### PR TITLE
Update libclang builds to use a bazel transition to switch to libstdc++

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,8 +6,6 @@ build --incompatible_enable_cc_toolchain_resolution
 # Clang with libc++
 build:libc++ --action_env=CXXFLAGS=-stdlib=libc++
 build:libc++ --action_env=LDFLAGS=-stdlib=libc++
-build:libc++ --action_env=BAZEL_CXXOPTS=-stdlib=libc++
-build:libc++ --action_env=BAZEL_LINKLIBS=-lc++abi:-lc++
 build:libc++ --define force_libcpp=enabled
 
 # C++20

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,7 +16,7 @@ RUN case "${TARGETPLATFORM}" in \
 #
 RUN apt-get update \
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends software-properties-common libncurses5
+    && apt-get -y install --no-install-recommends software-properties-common libncurses-dev
 
 #
 # Install java

--- a/third_party/BUILD.hdoc
+++ b/third_party/BUILD.hdoc
@@ -1,5 +1,18 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_setting")
+load("@donner//third_party:hdoc.bzl", "asset_to_cpp", "bundle_assets", "libclang_cc_binary", "libclang_cc_test", "require_libclang")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
-load("@donner//third_party:hdoc.bzl", "LIBCLANG_COPTS", "LIBCLANG_LINKOPTS", "asset_to_cpp", "bundle_assets")
+
+bool_setting(
+    name = "setting_libclang_build",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "libclang_build",
+    flag_values = {
+        ":setting_libclang_build": "true",
+    },
+)
 
 asset_to_cpp(
     name = "hdoc-payload-schema",
@@ -42,10 +55,9 @@ cc_library(
         "src/version.hpp",
         "tests/TestUtils.hpp",
     ],
-    copts = LIBCLANG_COPTS,
     includes = ["src"],
-    linkopts = LIBCLANG_LINKOPTS,
     linkstatic = 1,
+    target_compatible_with = require_libclang(),
     deps = [
         "@argparse",
         "@llvm_toolchain_llvm//:lib_clangAST",
@@ -99,9 +111,8 @@ cc_library(
         "src/serde/HTMLWriter.hpp",
         "src/support/MarkdownConverter.hpp",
     ],
-    copts = LIBCLANG_COPTS,
     includes = ["src"],
-    linkopts = LIBCLANG_LINKOPTS,
+    target_compatible_with = require_libclang(),
     deps = [
         ":ctml",
         ":hdoc_lib",
@@ -116,35 +127,43 @@ cc_library(
 )
 
 cc_binary(
-    name = "hdoc",
+    name = "hdoc-bin",
     srcs = [
         "src/main.cpp",
     ],
-    copts = LIBCLANG_COPTS,
-    linkopts = LIBCLANG_LINKOPTS,
-    visibility = ["//visibility:public"],
+    target_compatible_with = require_libclang(),
     deps = [
         ":hdoc_lib",
         ":html_output",
     ],
+)
+
+libclang_cc_binary(
+    name = "hdoc",
+    actual_binary = ":hdoc-bin",
+    visibility = ["//visibility:public"],
 )
 
 cc_binary(
-    name = "hdoc-exporter",
+    name = "hdoc-exporter-bin",
     srcs = [
         "src/exporter-main.cpp",
     ],
-    copts = LIBCLANG_COPTS,
-    linkopts = LIBCLANG_LINKOPTS,
-    visibility = ["//visibility:public"],
+    target_compatible_with = require_libclang(),
     deps = [
         ":hdoc_lib",
         ":html_output",
     ],
 )
 
+libclang_cc_binary(
+    name = "hdoc-exporter",
+    actual_binary = ":hdoc-exporter-bin",
+    visibility = ["//visibility:public"],
+)
+
 cc_test(
-    name = "hdoc-tests",
+    name = "hdoc-tests-bin",
     srcs = [
         "tests/TestUtils.cpp",
         "tests/TestUtils.hpp",
@@ -171,13 +190,17 @@ cc_test(
         "tests/json-tests/json-tests-schema-validation.cpp",
         "tests/unit-tests/test.cpp",
     ],
-    copts = LIBCLANG_COPTS,
-    linkopts = LIBCLANG_LINKOPTS,
     linkstatic = 1,
+    target_compatible_with = require_libclang(),
     deps = [
         ":hdoc_lib",
         ":html_output",
         "@doctest//doctest",
         "@llvm_toolchain_llvm//:lib_clangFormat",
     ],
+)
+
+libclang_cc_test(
+    name = "hdoc-tests",
+    actual_test = ":hdoc-tests-bin",
 )

--- a/tools/clang-plugin/BUILD
+++ b/tools/clang-plugin/BUILD
@@ -1,27 +1,26 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_setting")
 load("@rules_cc//cc:defs.bzl", "cc_binary")
+load(":libclang_cc_binary.bzl", "libclang_cc_binary", "require_libclang")
+
+bool_setting(
+    name = "setting_libclang_build",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "libclang_build",
+    flag_values = {
+        ":setting_libclang_build": "true",
+    },
+)
 
 cc_binary(
-    name = "clang-plugin",
+    name = "clang-plugin-bin",
     srcs = [
         "main.cc",
     ],
-    copts = select({
-        "@platforms//os:macos": [],
-        "//conditions:default": [
-            "-stdlib=libstdc++",
-            "-D_GLIBCXX_USE_CXX11_ABI=1",
-        ],
-    }) + [
-        "-fno-rtti",
-    ],
     includes = ["src"],
-    linkopts = select({
-        "@platforms//os:macos": [],
-        "//conditions:default": [
-            "-stdlib=libstdc++",
-            "-lstdc++",
-        ],
-    }),
+    target_compatible_with = require_libclang(),
     deps = [
         "@llvm_toolchain_llvm//:lib_clangAST",
         "@llvm_toolchain_llvm//:lib_clangBasic",
@@ -32,4 +31,10 @@ cc_binary(
         "@llvm_toolchain_llvm//:lib_clangToolingInclusions",
         "@llvm_toolchain_llvm//:libclang_include",
     ],
+)
+
+libclang_cc_binary(
+    name = "clang-plugin",
+    actual_binary = ":clang-plugin-bin",
+    visibility = ["//visibility:public"],
 )

--- a/tools/clang-plugin/libclang_cc_binary.bzl
+++ b/tools/clang-plugin/libclang_cc_binary.bzl
@@ -1,0 +1,89 @@
+"""
+Defines the libclang_cc_binary rule, which allows building binaries that depend on libclang and
+libstdc++ from within a build system that uses libc++ by default.
+
+To use, first create a cc_binary and then a libclang_cc_binary rule that wraps it:
+```
+load(":libclang_cc_binary.bzl", "libclang_cc_binary", "require_libclang")
+
+cc_binary(
+    name = "example_bin",
+    srcs = ["main.cpp"],
+    target_compatible_with = require_libclang(),
+)
+
+libclang_cc_binary(
+    name = "example",
+    actual_binary = ":example_bin",
+    visibility = ["//visibility:public"],
+)
+```
+
+To avoid compilation errors when doing a wildcard build (`bazel build //...`), add the
+target_compatible_with attribute to any rule that directly links against libclang:
+```
+    target_compatible_with = require_libclang(),
+```
+"""
+
+def require_libclang():
+    return select({
+        "//tools/clang-plugin:libclang_build": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    })
+
+def _libclang_transition_impl(settings, _attr):
+    cpu = settings["//command_line_option:cpu"]
+    is_apple = cpu.startswith("darwin_")
+
+    return {
+        "//command_line_option:cxxopt": ([] if is_apple else [
+            "-stdlib=libstdc++",
+            "-D_GLIBCXX_USE_CXX11_ABI=1",
+        ]) + [
+            "-fno-rtti",
+        ],
+        "//command_line_option:linkopt": [] if is_apple else [
+            "-stdlib=libstdc++",
+            "-lstdc++",
+        ],
+        "//tools/clang-plugin:setting_libclang_build": True,
+    }
+
+_libclang_transition = transition(
+    implementation = _libclang_transition_impl,
+    inputs = ["//command_line_option:cpu"],
+    outputs = [
+        "//command_line_option:cxxopt",
+        "//command_line_option:linkopt",
+        "//tools/clang-plugin:setting_libclang_build",
+    ],
+)
+
+def _libclang_cc_binary_impl(ctx):
+    actual_binary = ctx.attr.actual_binary[0]
+    outfile = ctx.actions.declare_file(ctx.label.name)
+    cc_binary_outfile = actual_binary[DefaultInfo].files.to_list()[0]
+
+    ctx.actions.run_shell(
+        inputs = [cc_binary_outfile],
+        outputs = [outfile],
+        command = "cp %s %s" % (cc_binary_outfile.path, outfile.path),
+    )
+    return [
+        DefaultInfo(
+            executable = outfile,
+            data_runfiles = actual_binary[DefaultInfo].data_runfiles,
+        ),
+    ]
+
+libclang_cc_binary = rule(
+    implementation = _libclang_cc_binary_impl,
+    attrs = {
+        "actual_binary": attr.label(cfg = _libclang_transition),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+    executable = True,
+)


### PR DESCRIPTION
libclang libraries use libstdc++, so it conflicts with the default libc++ build.  Introduce a bazel build transition, and use it to build hdoc and the example clang plugin.

Fixes #35 
