### PR TITLE
Refactor renderer tests to use shared fixture

### DIFF
--- a/donner/svg/renderer/tests/BUILD
+++ b/donner/svg/renderer/tests/BUILD
@@ -47,13 +47,12 @@ cc_test(
         "//donner/svg/renderer/testdata",
     ],
     deps = [
+        ":image_comparison_test_fixture",
         ":renderer_test_utils",
         "//donner/svg/parser",
         "//donner/svg/renderer",
-        "//donner/svg/renderer:renderer_image_io",
         "//donner/svg/tests:parser_test_utils",
         "@com_google_gtest//:gtest_main",
-        "@pixelmatch-cpp17",
     ],
 )
 

--- a/donner/svg/renderer/tests/ImageComparisonTestFixture.h
+++ b/donner/svg/renderer/tests/ImageComparisonTestFixture.h
@@ -1,3 +1,4 @@
+/// @file
 #pragma once
 
 #include <gtest/gtest.h>
@@ -8,29 +9,63 @@
 
 namespace donner::svg {
 
-// Circle rendering is slightly different since Donner uses four custom curves instead of arcTo.
-// Allow a small number of mismatched pixels to accomodate.
+/**
+ * @brief Default maximum number of mismatched pixels allowed in image comparisons.
+ *
+ * Circle rendering is slightly different since Donner uses four custom curves instead of arcTo.
+ * This constant allows a small number of mismatched pixels to accommodate these differences.
+ */
 static constexpr int kDefaultMismatchedPixels = 100;
 
-// For most tests, a threshold of 0.01 is sufficient, but some specific tests have slightly
-// different anti-aliasing artifacts, so a larger threshold is required:
-// - a_transform_007 - 0.05 to pass
-// - e_line_001 - 0.02 to pass
+/**
+ * @brief Default threshold for pixel differences in image comparisons.
+ *
+ * For most tests, a threshold of 0.01 (1%) is sufficient. Some specific tests might require a
+ * larger threshold due to subtle anti-aliasing differences. For example:
+ * - `a_transform_007` might need up to 0.05.
+ * - `e_line_001` might need up to 0.02.
+ */
 static constexpr float kDefaultThreshold = 0.01f;
 
+/**
+ * @brief Parameters for controlling image comparison tests.
+ *
+ * This struct allows customization of various aspects of the image comparison process,
+ * such as error thresholds, skipping tests, and overriding golden image filenames.
+ */
 struct ImageComparisonParams {
+  /// Maximum allowed difference per pixel (0.0 to 1.0).
   float threshold = kDefaultThreshold;
+  /// Maximum number of pixels that can exceed the threshold.
   int maxMismatchedPixels = kDefaultMismatchedPixels;
+  /// If true, skip this test case.
   bool skip = false;
+  /// If true, save a .skp file for debugging when a test fails.
   bool saveDebugSkpOnFailure = true;
+  /// If true, allow updating golden images via an environment variable.
+  bool updateGoldenFromEnv = false;
+  /// Optional canvas size override, which determines the size of the rendered image.
+  std::optional<Vector2i> canvasSize;
+  /// Optional filename to use for the golden image, overriding the default.
   std::string_view overrideGoldenFilename;
 
+  /**
+   * @brief Creates parameters to skip a test.
+   * @return ImageComparisonParams configured to skip.
+   */
   static ImageComparisonParams Skip() {
     ImageComparisonParams result;
     result.skip = true;
     return result;
   }
 
+  /**
+   * @brief Creates parameters with a specific threshold and maximum mismatched pixels.
+   *
+   * @param threshold The per-pixel difference threshold.
+   * @param maxMismatchedPixels The maximum number of pixels allowed to mismatch.
+   * @return ImageComparisonParams configured with the specified thresholds.
+   */
   static ImageComparisonParams WithThreshold(float threshold,
                                              int maxMismatchedPixels = kDefaultMismatchedPixels) {
     ImageComparisonParams result;
@@ -39,40 +74,126 @@ struct ImageComparisonParams {
     return result;
   }
 
+  /**
+   * @brief Creates parameters with an overridden golden image filename.
+   *
+   * @param filename The filename to use for the golden image.
+   * @return ImageComparisonParams configured with the golden override.
+   */
   static ImageComparisonParams WithGoldenOverride(std::string_view filename) {
     ImageComparisonParams result;
     result.overrideGoldenFilename = filename;
     return result;
   }
 
+  /**
+   * @brief Disables saving of .skp files on test failure.
+   * @return Reference to this ImageComparisonParams object.
+   */
   ImageComparisonParams& disableDebugSkpOnFailure() {
     saveDebugSkpOnFailure = false;
     return *this;
   }
+
+  /**
+   * @brief Enables updating golden images based on an environment variable.
+   * @return Reference to this ImageComparisonParams object.
+   */
+  ImageComparisonParams& enableGoldenUpdateFromEnv() {
+    updateGoldenFromEnv = true;
+    return *this;
+  }
+
+  /**
+   * @brief Sets a custom canvas size for rendering.
+   *
+   * @param width The width of the canvas.
+   * @param height The height of the canvas.
+   * @return Reference to this ImageComparisonParams object.
+   */
+  ImageComparisonParams& setCanvasSize(int width, int height) {
+    canvasSize = Vector2i(width, height);
+    return *this;
+  }
 };
 
+/**
+ * @brief Represents a single test case for image comparison.
+ *
+ * Contains the path to the SVG file to be tested and the parameters for the comparison.
+ */
 struct ImageComparisonTestcase {
-  std::filesystem::path svgFilename;
-  ImageComparisonParams params;
+  std::filesystem::path svgFilename;  //!< Path to the SVG file for this test case.
+  ImageComparisonParams params;       //!< Parameters for this specific test case.
 
+  /**
+   * @brief Comparison operator for sorting test cases by filename.
+   */
   friend bool operator<(const ImageComparisonTestcase& lhs, const ImageComparisonTestcase& rhs) {
     return lhs.svgFilename < rhs.svgFilename;
   }
 
+  /**
+   * @brief Stream insertion operator for printing the test case (prints the SVG filename).
+   */
   friend std::ostream& operator<<(std::ostream& os, const ImageComparisonTestcase& rhs) {
     return os << rhs.svgFilename.string();
   }
 };
 
+/**
+ * @brief Generates a test name from the SVG filename in the test parameter info.
+ *
+ * This is used by GTest to create human-readable test names for parameterized tests.
+ *
+ * @param info Test parameter information containing the \ref ImageComparisonTestcase.
+ * @return A string suitable for use as a test name.
+ */
 std::string TestNameFromFilename(const testing::TestParamInfo<ImageComparisonTestcase>& info);
 
+/**
+ * @brief A Google Test fixture for tests that compare rendered SVG output against golden images.
+ *
+ * This fixture is parameterized with \ref ImageComparisonTestcase, allowing multiple SVG files
+ * to be tested with different comparison parameters. It provides helper methods for loading
+ * SVG documents and performing the rendering and comparison.
+ */
 class ImageComparisonTestFixture : public testing::TestWithParam<ImageComparisonTestcase> {
 protected:
+  /**
+   * @brief Loads an SVG document from the given filename.
+   *
+   * @param filename The path to the SVG file.
+   * @param resourceDir Optional path to a directory containing resources (e.g., external images)
+   *                    referenced by the SVG.
+   * @return The loaded \ref SVGDocument.
+   */
   SVGDocument loadSVG(const char* filename,
                       const std::optional<std::filesystem::path>& resourceDir = std::nullopt);
 
+  /**
+   * @brief Renders the given SVG document and compares it against a golden image.
+   *
+   * Uses default comparison parameters.
+   *
+   * @param document The \ref SVGDocument to render.
+   * @param svgFilename The original path of the SVG file (used for naming output files).
+   * @param goldenImageFilename The path to the golden image file.
+   */
   void renderAndCompare(SVGDocument& document, const std::filesystem::path& svgFilename,
                         const char* goldenImageFilename);
+
+  /**
+   * @brief Renders the given SVG document and compares it against a golden image using specified
+   * parameters.
+   *
+   * @param document The \ref SVGDocument to render.
+   * @param svgFilename The original path of the SVG file (used for naming output files).
+   * @param goldenImageFilename The path to the golden image file.
+   * @param params The \ref ImageComparisonParams to use for the comparison.
+   */
+  void renderAndCompare(SVGDocument& document, const std::filesystem::path& svgFilename,
+                        const char* goldenImageFilename, const ImageComparisonParams& params);
 };
 
 }  // namespace donner::svg

--- a/donner/svg/renderer/tests/Renderer_tests.cc
+++ b/donner/svg/renderer/tests/Renderer_tests.cc
@@ -1,12 +1,10 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <pixelmatch/pixelmatch.h>
 
 #include <fstream>
 
 #include "donner/svg/parser/SVGParser.h"
-#include "donner/svg/renderer/RendererImageIO.h"
-#include "donner/svg/renderer/RendererSkia.h"
+#include "donner/svg/renderer/tests/ImageComparisonTestFixture.h"
 #include "donner/svg/renderer/tests/RendererTestUtils.h"
 
 // clang-format off
@@ -26,22 +24,7 @@
 
 namespace donner::svg {
 
-namespace {
-
-std::string escapeFilename(std::string filename) {
-  std::transform(filename.begin(), filename.end(), filename.begin(), [](char c) {
-    if (c == '\\' || c == '/') {
-      return '_';
-    } else {
-      return c;
-    }
-  });
-  return filename;
-}
-
-}  // namespace
-
-class RendererTests : public testing::Test {
+class RendererTests : public ImageComparisonTestFixture {
 protected:
   parser::SVGParser::Options optionsExperimental() {
     parser::SVGParser::Options options;
@@ -73,222 +56,170 @@ protected:
     return std::move(maybeResult.result());
   }
 
-  void renderAndCompare(SVGDocument& document, const char* goldenImageFilename) {
-    RendererSkia renderer;
-    renderer.draw(document);
+  void compareWithGolden(const char* svgFilename, const char* goldenFilename,
+                         parser::SVGParser::Options options = {}) {
+    SVGDocument document = loadSVG(svgFilename, options);
 
-    const size_t strideInPixels = renderer.width();
-    const int width = renderer.width();
-    const int height = renderer.height();
-
-    const char* goldenImageDirToUpdate = getenv("UPDATE_GOLDEN_IMAGES_DIR");
-    if (goldenImageDirToUpdate) {
-      const std::filesystem::path goldenImagePath =
-          std::filesystem::path(goldenImageDirToUpdate) / goldenImageFilename;
-
-      RendererImageIO::writeRgbaPixelsToPngFile(
-          goldenImagePath.string().c_str(), renderer.pixelData(), width, height, strideInPixels);
-
-      std::cout << "Updated golden image: " << goldenImagePath.string() << "\n";
-      return;
-    }
-
-    auto maybeGoldenImage = RendererTestUtils::readRgbaImageFromPngFile(goldenImageFilename);
-    ASSERT_TRUE(maybeGoldenImage.has_value());
-
-    Image goldenImage = std::move(maybeGoldenImage.value());
-    ASSERT_EQ(goldenImage.width, width);
-    ASSERT_EQ(goldenImage.height, height);
-    ASSERT_EQ(goldenImage.strideInPixels, strideInPixels);
-    ASSERT_EQ(goldenImage.data.size(), renderer.pixelData().size());
-
-    std::vector<uint8_t> diffImage;
-    diffImage.resize(strideInPixels * height * 4);
-
-    pixelmatch::Options options;
-    options.threshold = 0.1f;  // Apply a non-zero threshold to account for anti-aliasing
-                               // differences between platforms. Without this, macOS/Linux would be
-                               // unable to use each other's goldens.
-    const int mismatchedPixels = pixelmatch::pixelmatch(
-        goldenImage.data, renderer.pixelData(), diffImage, width, height, strideInPixels, options);
-
-    if (mismatchedPixels != 0) {
-      const std::filesystem::path actualImagePath =
-          std::filesystem::temp_directory_path() / escapeFilename(goldenImageFilename);
-      std::cout << "Actual rendering: " << actualImagePath.string() << "\n";
-      RendererImageIO::writeRgbaPixelsToPngFile(
-          actualImagePath.string().c_str(), renderer.pixelData(), width, height, strideInPixels);
-
-      const std::filesystem::path diffFilePath =
-          std::filesystem::temp_directory_path() / ("diff_" + escapeFilename(goldenImageFilename));
-      std::cerr << "Diff: " << diffFilePath.string() << "\n";
-
-      RendererImageIO::writeRgbaPixelsToPngFile(diffFilePath.string().c_str(), diffImage, width,
-                                                height, strideInPixels);
-
-      FAIL() << "Computed image diff and expected version in " << goldenImageFilename
-             << " do not match, " << mismatchedPixels << " pixels different.\n\n"
-             << "To update the golden image, run the following command:\n\n"
-             << "  UPDATE_GOLDEN_IMAGES_DIR=$(bazel info workspace) bazel run "
-                "//donner/svg/renderer/tests:renderer_tests\n";
-    }
+    // Apply a non-zero threshold to account for anti-aliasing differences between platforms.
+    // Without this, macOS/Linux would be unable to use each other's goldens.
+    ImageComparisonParams params =
+        ImageComparisonParams::WithThreshold(0.1).enableGoldenUpdateFromEnv();
+    renderAndCompare(document, svgFilename, goldenFilename, params);
   }
 };
 
 TEST_F(RendererTests, Ellipse1) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/ellipse1.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/ellipse1.png");
+  compareWithGolden("donner/svg/renderer/testdata/ellipse1.svg",
+                    "donner/svg/renderer/testdata/golden/ellipse1.png");
 }
 
 TEST_F(RendererTests, Rect2) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/rect2.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/rect2.png");
+  compareWithGolden("donner/svg/renderer/testdata/rect2.svg",
+                    "donner/svg/renderer/testdata/golden/rect2.png");
 }
 
 TEST_F(RendererTests, Skew1) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/skew1.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/skew1.png");
+  compareWithGolden("donner/svg/renderer/testdata/skew1.svg",
+                    "donner/svg/renderer/testdata/golden/skew1.png");
 }
 
 TEST_F(RendererTests, SizeTooLarge) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/size-too-large.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/size-too-large.png");
+  compareWithGolden("donner/svg/renderer/testdata/size-too-large.svg",
+                    "donner/svg/renderer/testdata/golden/size-too-large.png");
 }
 
 TEST_F(RendererTests, NestedSvgAspectRatio) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/nested-svg-aspectratio.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/nested-svg-aspectratio.png");
+  compareWithGolden("donner/svg/renderer/testdata/nested-svg-aspectratio.svg",
+                    "donner/svg/renderer/testdata/golden/nested-svg-aspectratio.png");
 }
 
 TEST_F(RendererTests, RadialFr1) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/radial-fr-1.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/radial-fr-1.png");
+  compareWithGolden("donner/svg/renderer/testdata/radial-fr-1.svg",
+                    "donner/svg/renderer/testdata/golden/radial-fr-1.png");
 }
 
 TEST_F(RendererTests, RadialFr2) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/radial-fr-2.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/radial-fr-2.png");
+  compareWithGolden("donner/svg/renderer/testdata/radial-fr-2.svg",
+                    "donner/svg/renderer/testdata/golden/radial-fr-2.png");
 }
 
 TEST_F(RendererTests, RadialConical1) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/radial-conical-1.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/radial-conical-1.png");
+  compareWithGolden("donner/svg/renderer/testdata/radial-conical-1.svg",
+                    "donner/svg/renderer/testdata/golden/radial-conical-1.png");
 }
 
 TEST_F(RendererTests, RadialConical2) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/radial-conical-2.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/radial-conical-2.png");
+  compareWithGolden("donner/svg/renderer/testdata/radial-conical-2.svg",
+                    "donner/svg/renderer/testdata/golden/radial-conical-2.png");
 }
 
 TEST_F(RendererTests, GhostscriptTiger) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/Ghostscript_Tiger.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/Ghostscript_Tiger.png");
+  compareWithGolden("donner/svg/renderer/testdata/Ghostscript_Tiger.svg",
+                    "donner/svg/renderer/testdata/golden/Ghostscript_Tiger.png");
 }
 
 TEST_F(RendererTests, Polygon) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/polygon.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/polygon.png");
+  compareWithGolden("donner/svg/renderer/testdata/polygon.svg",
+                    "donner/svg/renderer/testdata/golden/polygon.png");
 }
 
 TEST_F(RendererTests, Polyline) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/polyline.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/polyline.png");
+  compareWithGolden("donner/svg/renderer/testdata/polyline.svg",
+                    "donner/svg/renderer/testdata/golden/polyline.png");
 }
 
 TEST_F(RendererTests, Lion) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/lion.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/lion.png");
+  compareWithGolden("donner/svg/renderer/testdata/lion.svg",
+                    "donner/svg/renderer/testdata/golden/lion.png");
 }
 
 TEST_F(RendererTests, StrokingComplex) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/stroking_complex.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/stroking_complex.png");
+  compareWithGolden("donner/svg/renderer/testdata/stroking_complex.svg",
+                    "donner/svg/renderer/testdata/golden/stroking_complex.png");
 }
 
 TEST_F(RendererTests, StrokingDasharray) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/stroking_dasharray.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/stroking_dasharray.png");
+  compareWithGolden("donner/svg/renderer/testdata/stroking_dasharray.svg",
+                    "donner/svg/renderer/testdata/golden/stroking_dasharray.png");
 }
 
 TEST_F(RendererTests, StrokingDashoffset) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/stroking_dashoffset.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/stroking_dashoffset.png");
+  compareWithGolden("donner/svg/renderer/testdata/stroking_dashoffset.svg",
+                    "donner/svg/renderer/testdata/golden/stroking_dashoffset.png");
 }
 
 TEST_F(RendererTests, StrokingLinecap) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/stroking_linecap.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/stroking_linecap.png");
+  compareWithGolden("donner/svg/renderer/testdata/stroking_linecap.svg",
+                    "donner/svg/renderer/testdata/golden/stroking_linecap.png");
 }
 
 TEST_F(RendererTests, StrokingLinejoin) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/stroking_linejoin.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/stroking_linejoin.png");
+  compareWithGolden("donner/svg/renderer/testdata/stroking_linejoin.svg",
+                    "donner/svg/renderer/testdata/golden/stroking_linejoin.png");
 }
 
 TEST_F(RendererTests, StrokingMiterlimit) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/stroking_miterlimit.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/stroking_miterlimit.png");
+  compareWithGolden("donner/svg/renderer/testdata/stroking_miterlimit.svg",
+                    "donner/svg/renderer/testdata/golden/stroking_miterlimit.png");
 }
 
 TEST_F(RendererTests, StrokingStrokewidth) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/stroking_strokewidth.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/stroking_strokewidth.png");
+  compareWithGolden("donner/svg/renderer/testdata/stroking_strokewidth.svg",
+                    "donner/svg/renderer/testdata/golden/stroking_strokewidth.png");
 }
 
 TEST_F(RendererTests, StrokingPathLength) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/stroking_pathlength.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/stroking_pathlength.png");
+  compareWithGolden("donner/svg/renderer/testdata/stroking_pathlength.svg",
+                    "donner/svg/renderer/testdata/golden/stroking_pathlength.png");
 }
 
 TEST_F(RendererTests, PokerChips) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/poker_chips.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/poker_chips.png");
+  compareWithGolden("donner/svg/renderer/testdata/poker_chips.svg",
+                    "donner/svg/renderer/testdata/golden/poker_chips.png");
 }
 
 TEST_F(RendererTests, QuadBezier) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/quadbezier1.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/quadbezier1.png");
+  compareWithGolden("donner/svg/renderer/testdata/quadbezier1.svg",
+                    "donner/svg/renderer/testdata/golden/quadbezier1.png");
 }
 
 TEST_F(RendererTests, DonnerIcon) {
-  SVGDocument document = loadSVG("donner_icon.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/donner_icon.png");
+  compareWithGolden("donner_icon.svg", "donner/svg/renderer/testdata/golden/donner_icon.png");
 }
 
 TEST_F(RendererTests, DonnerSplash) {
-  SVGDocument document = loadSVG("donner_splash.svg", optionsExperimental());
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/donner_splash.png");
+  compareWithGolden("donner_splash.svg", "donner/svg/renderer/testdata/golden/donner_splash.png",
+                    optionsExperimental());
 }
 
 TEST_F(RendererTests, DonnerSplashNoExperimental) {
-  SVGDocument document = loadSVG("donner_splash.svg");
-  renderAndCompare(document,
-                   "donner/svg/renderer/testdata/golden/donner_splash_no_experimental.png");
+  compareWithGolden("donner_splash.svg",
+                    "donner/svg/renderer/testdata/golden/donner_splash_no_experimental.png");
 }
 
 TEST_F(RendererTests, SVG2_e_use_001) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/svg2-e-use-001.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/svg2-e-use-001.png");
+  compareWithGolden("donner/svg/renderer/testdata/svg2-e-use-001.svg",
+                    "donner/svg/renderer/testdata/golden/svg2-e-use-001.png");
 }
 
 TEST_F(RendererTests, SVG2_e_use_002) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/svg2-e-use-002.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/svg2-e-use-002.png");
+  compareWithGolden("donner/svg/renderer/testdata/svg2-e-use-002.svg",
+                    "donner/svg/renderer/testdata/golden/svg2-e-use-002.png");
 }
 
 TEST_F(RendererTests, SVG2_e_use_003) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/svg2-e-use-003.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/svg2-e-use-003.png");
+  compareWithGolden("donner/svg/renderer/testdata/svg2-e-use-003.svg",
+                    "donner/svg/renderer/testdata/golden/svg2-e-use-003.png");
 }
 
 TEST_F(RendererTests, SVG2_e_use_004) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/svg2-e-use-004.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/svg2-e-use-004.png");
+  compareWithGolden("donner/svg/renderer/testdata/svg2-e-use-004.svg",
+                    "donner/svg/renderer/testdata/golden/svg2-e-use-004.png");
 }
 
 TEST_F(RendererTests, SVG2_e_use_005) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/svg2-e-use-005.svg");
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/svg2-e-use-005.png");
+  compareWithGolden("donner/svg/renderer/testdata/svg2-e-use-005.svg",
+                    "donner/svg/renderer/testdata/golden/svg2-e-use-005.png");
 }
 
 TEST_F(RendererTests, RectAscii) {
@@ -317,8 +248,9 @@ TEST_F(RendererTests, RectAscii) {
 }
 
 TEST_F(RendererTests, Edzample) {
-  SVGDocument document = loadSVG("donner/svg/renderer/testdata/Edzample_Anim3.svg", optionsExperimental());
-  renderAndCompare(document, "donner/svg/renderer/testdata/golden/Edzample_Anim3.png");
+  compareWithGolden("donner/svg/renderer/testdata/Edzample_Anim3.svg",
+                    "donner/svg/renderer/testdata/golden/Edzample_Anim3.png",
+                    optionsExperimental());
 }
 
 }  // namespace donner::svg

--- a/donner/svg/renderer/tests/resvg_test_suite.cc
+++ b/donner/svg/renderer/tests/resvg_test_suite.cc
@@ -30,6 +30,9 @@ std::vector<ImageComparisonTestcase> getTestsWithPrefix(
         test.params = it->second;
       }
 
+      // Always set the canvas size to 500x500 for these tests.
+      test.params.setCanvasSize(500, 500);
+
       testPlan.emplace_back(std::move(test));
     }
   }


### PR DESCRIPTION
## Summary
- Support golden image updates in ImageComparisonTestFixture
- Rewrite renderer tests to use ImageComparisonTestFixture
- Restructure the output ordering to make it easier to debug failures

## Testing

```
bazel test //...
```

Resolves #167 