### PR TITLE
Add minimal font-face support

### DIFF
--- a/donner/svg/SVGDocument.cc
+++ b/donner/svg/SVGDocument.cc
@@ -7,6 +7,7 @@
 #include "donner/svg/components/SVGDocumentContext.h"
 #include "donner/svg/components/layout/LayoutSystem.h"
 #include "donner/svg/components/resources/ResourceManagerContext.h"
+#include "donner/svg/components/text/FontContext.h"
 #include "donner/svg/renderer/RenderingContext.h"
 
 namespace donner::svg {
@@ -25,6 +26,8 @@ SVGDocument::SVGDocument(std::shared_ptr<Registry> registry, Settings settings,
   components::ResourceManagerContext& resourceCtx =
       registry_->ctx().emplace<components::ResourceManagerContext>(*registry_);
   resourceCtx.setResourceLoader(std::move(settings.resourceLoader));
+
+  registry_->ctx().emplace<components::FontContext>(*registry_);
 
   registry_->ctx().emplace<xml::components::XMLNamespaceContext>(*registry_);
 }

--- a/donner/svg/SVGSVGElement.cc
+++ b/donner/svg/SVGSVGElement.cc
@@ -19,7 +19,11 @@ SVGSVGElement SVGSVGElement::CreateOn(EntityHandle handle) {
   stylesheetComponent.isUserAgentStylesheet = true;
 
   // From https://www.w3.org/TR/SVG2/styling.html#UAStyleSheet
-  stylesheetComponent.parseStylesheet(kUserAgentStylesheet);
+  components::FontContext* fontCtx = nullptr;
+  if (handle.registry()->ctx().contains<components::FontContext>()) {
+    fontCtx = &handle.registry()->ctx().get<components::FontContext>();
+  }
+  stylesheetComponent.parseStylesheet(kUserAgentStylesheet, fontCtx);
   return SVGSVGElement(handle);
 }
 

--- a/donner/svg/SVGStyleElement.cc
+++ b/donner/svg/SVGStyleElement.cc
@@ -18,7 +18,11 @@ void SVGStyleElement::setType(const RcStringOrRef& type) {
 void SVGStyleElement::setContents(std::string_view style) {
   if (isCssType()) {
     auto& stylesheetComponent = handle_.get_or_emplace<components::StylesheetComponent>();
-    stylesheetComponent.parseStylesheet(style);
+    components::FontContext* fontCtx = nullptr;
+    if (handle_.registry()->ctx().contains<components::FontContext>()) {
+      fontCtx = &handle_.registry()->ctx().get<components::FontContext>();
+    }
+    stylesheetComponent.parseStylesheet(style, fontCtx);
   }
 }
 

--- a/donner/svg/components/BUILD
+++ b/donner/svg/components/BUILD
@@ -67,5 +67,6 @@ cc_library(
         "//donner/svg/components/shadow:shadow_tree_system",
         "//donner/svg/components/shape:shape_system",
         "//donner/svg/components/text:text_system",
+        "//donner/svg/components/text:font_context",
     ],
 )

--- a/donner/svg/components/StylesheetComponent.cc
+++ b/donner/svg/components/StylesheetComponent.cc
@@ -1,13 +1,79 @@
 #include "donner/svg/components/StylesheetComponent.h"  // IWYU pragma: keep
 
 #include "donner/css/Stylesheet.h"
+#include "donner/css/parser/DeclarationListParser.h"
+#include "donner/css/parser/RuleParser.h"
 #include "donner/css/parser/StylesheetParser.h"
+#include "donner/css/parser/ValueParser.h"
+#include "donner/svg/components/resources/ResourceManagerContext.h"
+#include "donner/svg/components/text/FontContext.h"
 #include "donner/svg/properties/PresentationAttributeParsing.h"  // IWYU pragma: keep, for ParsePresentationAttribute
+#include "donner/svg/resources/FontLoader.h"
+#include "include/core/SkData.h"
 
 namespace donner::svg::components {
 
-void StylesheetComponent::parseStylesheet(const RcStringOrRef& str) {
+namespace {
+
+std::optional<std::string> TryGetSingleUrl(std::span<const css::ComponentValue> components) {
+  if (components.size() == 1) {
+    const css::ComponentValue& component = components.front();
+    if (const auto* url = component.tryGetToken<css::Token::Url>()) {
+      return std::string(url->value.str());
+    }
+    if (component.is<css::Function>()) {
+      const css::Function& func = component.get<css::Function>();
+      if (func.name.equalsLowercase("url") && func.values.size() == 1) {
+        if (const auto* strTok = func.values[0].tryGetToken<css::Token::String>()) {
+          return std::string(strTok->value.str());
+        }
+      }
+    }
+  }
+  return std::nullopt;
+}
+
+}  // namespace
+
+void StylesheetComponent::parseStylesheet(const RcStringOrRef& str,
+                                          components::FontContext* fontContext) {
   stylesheet = donner::css::parser::StylesheetParser::Parse(str);
+
+  if (!fontContext) {
+    return;
+  }
+
+  auto rules = donner::css::parser::RuleParser::ParseStylesheet(str);
+  Registry& registry = fontContext->registry();
+  auto* resMgr = registry.ctx().try_get<components::ResourceManagerContext>();
+  ResourceLoaderInterface* loader = resMgr ? resMgr->resourceLoader() : nullptr;
+
+  for (const auto& rule : rules) {
+    if (const css::AtRule* at = std::get_if<css::AtRule>(&rule.value)) {
+      if (at->name.equalsLowercase("font-face") && at->block) {
+        auto decls = css::parser::DeclarationListParser::ParseRuleDeclarations(at->block->values);
+        RcString family;
+        std::optional<std::string> src;
+        for (const auto& decl : decls) {
+          if (decl.name.equalsLowercase("font-family")) {
+            if (auto ident = parser::TryGetSingleIdent(decl.values)) {
+              family = *ident;
+            }
+          } else if (decl.name.equalsLowercase("src")) {
+            src = TryGetSingleUrl(decl.values);
+          }
+        }
+        if (!family.empty() && src && loader) {
+          FontLoader fontLoader(*loader);
+          auto dataOrErr = fontLoader.fromUri(*src);
+          if (std::holds_alternative<std::vector<uint8_t>>(dataOrErr)) {
+            const auto& data = std::get<std::vector<uint8_t>>(dataOrErr);
+            fontContext->addFont(family, SkData::MakeWithCopy(data.data(), data.size()));
+          }
+        }
+      }
+    }
+  }
 }
 
 }  // namespace donner::svg::components

--- a/donner/svg/components/StylesheetComponent.h
+++ b/donner/svg/components/StylesheetComponent.h
@@ -2,6 +2,7 @@
 /// @file
 
 #include "donner/css/Stylesheet.h"
+#include "donner/svg/components/text/FontContext.h"
 
 namespace donner::svg::components {
 
@@ -31,7 +32,7 @@ struct StylesheetComponent {
    *
    * @param str The contents of the \ref xml_style element.
    */
-  void parseStylesheet(const RcStringOrRef& str);
+  void parseStylesheet(const RcStringOrRef& str, components::FontContext* fontContext = nullptr);
 };
 
 }  // namespace donner::svg::components

--- a/donner/svg/components/resources/ResourceManagerContext.h
+++ b/donner/svg/components/resources/ResourceManagerContext.h
@@ -39,6 +39,9 @@ public:
     loader_ = std::move(loader);
   }
 
+  /// Get the resource loader if set.
+  ResourceLoaderInterface* resourceLoader() const { return loader_.get(); }
+
   /**
    * Get the size of an image resource for an entity, if it has one and successfully loaded.
    *

--- a/donner/svg/components/text/BUILD
+++ b/donner/svg/components/text/BUILD
@@ -17,6 +17,17 @@ cc_library(
 )
 
 cc_library(
+    name = "font_context",
+    srcs = ["FontContext.cc"],
+    hdrs = ["FontContext.h"],
+    visibility = ["//donner/svg/components:__subpackages__"],
+    deps = [
+        "//donner/base",
+        "@skia//:skia",
+    ],
+)
+
+cc_library(
     name = "text_system",
     srcs = [
         "TextSystem.cc",

--- a/donner/svg/components/text/FontContext.cc
+++ b/donner/svg/components/text/FontContext.cc
@@ -1,0 +1,24 @@
+#include "donner/svg/components/text/FontContext.h"
+
+#include "include/core/SkFontMgr.h"
+
+namespace donner::svg::components {
+
+FontContext::FontContext(Registry& registry) : registry_(registry) {}
+
+void FontContext::addFont(const RcString& family, sk_sp<SkData> data) {
+  if (!data) {
+    return;
+  }
+  sk_sp<SkTypeface> typeface = SkFontMgr::RefDefault()->makeFromData(std::move(data));
+  if (typeface) {
+    fonts_[family] = std::move(typeface);
+  }
+}
+
+sk_sp<SkTypeface> FontContext::getTypeface(const RcString& family) const {
+  auto it = fonts_.find(family);
+  return it != fonts_.end() ? it->second : nullptr;
+}
+
+}  // namespace donner::svg::components

--- a/donner/svg/components/text/FontContext.h
+++ b/donner/svg/components/text/FontContext.h
@@ -1,0 +1,26 @@
+#pragma once
+/// @file
+
+#include <unordered_map>
+
+#include "donner/base/EcsRegistry.h"
+#include "donner/base/RcString.h"
+#include "include/core/SkData.h"
+#include "include/core/SkTypeface.h"
+
+namespace donner::svg::components {
+
+class FontContext {
+public:
+  explicit FontContext(Registry& registry);
+
+  void addFont(const RcString& family, sk_sp<SkData> data);
+  sk_sp<SkTypeface> getTypeface(const RcString& family) const;
+  Registry& registry() const { return registry_; }
+
+private:
+  Registry& registry_;  // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+  std::unordered_map<RcString, sk_sp<SkTypeface>> fonts_;
+};
+
+}  // namespace donner::svg::components

--- a/donner/svg/renderer/BUILD
+++ b/donner/svg/renderer/BUILD
@@ -96,6 +96,7 @@ cc_library(
         "//donner/svg",
         "//donner/svg/core",
         "//donner/svg/renderer/common",
+        "//donner/svg/components/text:font_context",
         "//third_party/public-sans",
     ],
 )

--- a/donner/svg/renderer/RendererSkia.cc
+++ b/donner/svg/renderer/RendererSkia.cc
@@ -55,6 +55,7 @@
 #include "donner/svg/components/shape/ShapeSystem.h"
 #include "donner/svg/components/style/ComputedStyleComponent.h"
 #include "donner/svg/components/text/ComputedTextComponent.h"
+#include "donner/svg/components/text/FontContext.h"
 #include "donner/svg/graph/Reference.h"
 #include "donner/svg/renderer/RendererImageIO.h"
 #include "donner/svg/renderer/RendererUtils.h"
@@ -1039,7 +1040,14 @@ public:
 #endif
 
     const RcString& family = style.fontFamily.getRequired();
-    sk_sp<SkTypeface> typeface = fontMgr->matchFamilyStyle(family.str().c_str(), SkFontStyle());
+    Registry& registry = *dataHandle.registry();
+    sk_sp<SkTypeface> typeface = nullptr;
+    if (registry.ctx().contains<components::FontContext>()) {
+      typeface = registry.ctx().get<components::FontContext>().getTypeface(family);
+    }
+    if (!typeface) {
+      typeface = fontMgr->matchFamilyStyle(family.str().c_str(), SkFontStyle());
+    }
     if (!typeface) {
       typeface = fontMgr->makeFromData(SkData::MakeWithoutCopy(
           embedded::kPublicSansMediumOtf.data(), embedded::kPublicSansMediumOtf.size()));

--- a/donner/svg/resources/BUILD
+++ b/donner/svg/resources/BUILD
@@ -62,6 +62,17 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "font_loader",
+    srcs = ["FontLoader.cc"],
+    hdrs = ["FontLoader.h"],
+    visibility = ["//donner/svg:__subpackages__"],
+    deps = [
+        ":url_loader",
+        "//donner/base",
+    ],
+)
+
 cc_test(
     name = "url_loader_tests",
     srcs = [

--- a/donner/svg/resources/FontLoader.cc
+++ b/donner/svg/resources/FontLoader.cc
@@ -1,0 +1,13 @@
+#include "donner/svg/resources/FontLoader.h"
+
+namespace donner::svg {
+
+std::variant<std::vector<uint8_t>, UrlLoaderError> FontLoader::fromUri(std::string_view uri) {
+  auto result = urlLoader_.fromUri(uri);
+  if (std::holds_alternative<UrlLoaderError>(result)) {
+    return std::get<UrlLoaderError>(result);
+  }
+  return std::get<UrlLoader::Result>(result).data;
+}
+
+}  // namespace donner::svg

--- a/donner/svg/resources/FontLoader.h
+++ b/donner/svg/resources/FontLoader.h
@@ -1,0 +1,27 @@
+#pragma once
+/// @file
+
+#include <variant>
+#include <vector>
+
+#include "donner/svg/resources/UrlLoader.h"
+
+namespace donner::svg {
+
+class FontLoader {
+public:
+  explicit FontLoader(ResourceLoaderInterface& resourceLoader) : urlLoader_(resourceLoader) {}
+  ~FontLoader() = default;
+
+  FontLoader(const FontLoader&) = delete;
+  FontLoader(FontLoader&&) = delete;
+  FontLoader& operator=(const FontLoader&) = delete;
+  FontLoader& operator=(FontLoader&&) = delete;
+
+  std::variant<std::vector<uint8_t>, UrlLoaderError> fromUri(std::string_view uri);
+
+private:
+  UrlLoader urlLoader_;
+};
+
+}  // namespace donner::svg


### PR DESCRIPTION
## Summary
- introduce `FontContext` for custom fonts
- load fonts via new `FontLoader`
- parse `@font-face` rules inside stylesheets
- hook up Skia renderer to use fonts from context

## Testing
- `dprint fmt donner/svg/resources/FontLoader.h donner/svg/resources/FontLoader.cc donner/svg/components/text/FontContext.h donner/svg/components/text/FontContext.cc donner/svg/components/resources/ResourceManagerContext.h donner/svg/components/StylesheetComponent.h donner/svg/components/StylesheetComponent.cc donner/svg/SVGStyleElement.cc donner/svg/SVGSVGElement.cc donner/svg/SVGDocument.cc donner/svg/renderer/RendererSkia.cc`
- `clang-format -i donner/svg/resources/FontLoader.h donner/svg/resources/FontLoader.cc donner/svg/components/text/FontContext.h donner/svg/components/text/FontContext.cc donner/svg/components/resources/ResourceManagerContext.h donner/svg/components/StylesheetComponent.h donner/svg/components/StylesheetComponent.cc donner/svg/SVGStyleElement.cc donner/svg/SVGSVGElement.cc donner/svg/SVGDocument.cc donner/svg/renderer/RendererSkia.cc`