### PR TITLE
Switch Linux to build with system clang by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -20,6 +20,13 @@ build --enable_platform_specific_config
 ## Build config
 ##
 
+# Force clang to be the default compiler for all Bazel C/C++ actions.
+# Propagates CC/CXX so every action (including host tools) uses clang/clang++.
+build --action_env=CC=clang
+build --action_env=CXX=clang++
+build --host_action_env=CC=clang
+build --host_action_env=CXX=clang++
+
 # Disable layering check since toolchains_llvm has issues with it.
 build --features=-layering_check
 
@@ -37,16 +44,13 @@ build --incompatible_enable_cc_toolchain_resolution
 common:latest_llvm --extra_toolchains=@llvm_toolchain//:all
 common:latest_llvm --//build_defs:llvm_latest=1
 
-# Build with clang on Linux
-build:linux --config=latest_llvm
-
 # Clang with libc++
 build:libc++ --action_env=CXXFLAGS=-stdlib=libc++
 build:libc++ --action_env=LDFLAGS=-stdlib=libc++
 build:libc++ --define force_libcpp=enabled
 
 # C++20
-build:c++20 --cxxopt=-std=c++20 --cxxopt=-fexperimental-library
+build:c++20 --cxxopt=-std=c++20
 
 # Host toolchain using libstdc++ instead of libc++, for libclang support
 build:host_libstdc++ --host_cxxopt=-std=c++20 --host_cxxopt=-stdlib=libstdc++ --host_linkopt=-lstdc++

--- a/donner/base/RcStringOrRef.h
+++ b/donner/base/RcStringOrRef.h
@@ -1,6 +1,8 @@
 #pragma once
 /// @file
 
+#include <variant>
+
 #include "donner/base/RcString.h"
 
 namespace donner {

--- a/donner/base/StringUtils.h
+++ b/donner/base/StringUtils.h
@@ -1,10 +1,12 @@
 #pragma once
 /// @file
 
+#include <cstdint>
 #include <iterator>
 #include <ranges>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace donner {
 

--- a/donner/base/Utf8.h
+++ b/donner/base/Utf8.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cassert>
+#include <cstdint>
 #include <string_view>
 #include <tuple>
 

--- a/donner/base/parser/tests/NumberParser_fuzzer.cc
+++ b/donner/base/parser/tests/NumberParser_fuzzer.cc
@@ -1,3 +1,5 @@
+#include <cmath>  // for std::isnan
+
 #include "donner/base/parser/NumberParser.h"
 
 namespace donner::parser {

--- a/donner/css/Color.cc
+++ b/donner/css/Color.cc
@@ -3,6 +3,8 @@
 #include <frozen/string.h>
 #include <frozen/unordered_map.h>
 
+#include <cmath>
+
 #include "donner/base/MathUtils.h"
 
 namespace donner::css {
@@ -187,14 +189,14 @@ uint8_t numberToChannel(double number) {
  * @param lightness  Lightness in reference range [0,1]
  */
 RGBA hslToRgb(float hueDegrees, float saturation, float lightness) {
-  hueDegrees = fmodf(hueDegrees, 360.0f);
+  hueDegrees = std::fmod(hueDegrees, 360.0f);
 
   if (hueDegrees < 0.0f) {
     hueDegrees += 360.0f;
   }
 
   auto f = [&](float n) {
-    const float k = std::fmodf(n + hueDegrees / 30.0f, 12.0f);
+    const float k = std::fmod(n + hueDegrees / 30.0f, 12.0f);
     const float a = saturation * Min(lightness, 1.0f - lightness);
     return lightness - a * Max(-1.0f, Min(k - 3.0f, 9.0f - k, 1.0f));
   };

--- a/donner/css/Color.h
+++ b/donner/css/Color.h
@@ -1,6 +1,7 @@
 #pragma once
 /// @file
 
+#include <cstdint>
 #include <optional>
 #include <ostream>
 #include <string_view>

--- a/donner/css/selectors/ComplexSelector.h
+++ b/donner/css/selectors/ComplexSelector.h
@@ -1,6 +1,7 @@
 #pragma once
 /// @file
 
+#include <functional>
 #include <vector>
 
 #include "donner/base/Utils.h"

--- a/donner/svg/ElementType.h
+++ b/donner/svg/ElementType.h
@@ -1,6 +1,7 @@
 #pragma once
 /// @file
 
+#include <cstdint>
 #include <ostream>
 
 namespace donner::svg {

--- a/donner/svg/components/filter/BUILD
+++ b/donner/svg/components/filter/BUILD
@@ -17,6 +17,7 @@ cc_library(
     deps = [
         "//donner/svg/properties",
     ],
+    alwayslink = 1,
 )
 
 cc_library(

--- a/donner/svg/components/paint/BUILD
+++ b/donner/svg/components/paint/BUILD
@@ -33,6 +33,7 @@ cc_library(
         "//donner/svg/components/shape:components",
         "//donner/svg/properties",
     ],
+    alwayslink = 1,
 )
 
 cc_library(

--- a/donner/svg/core/ClipPathUnits.h
+++ b/donner/svg/core/ClipPathUnits.h
@@ -1,6 +1,7 @@
 #pragma once
 /// @file
 
+#include <cstdint>
 #include <ostream>
 
 #include "donner/base/Utils.h"

--- a/donner/svg/core/ClipRule.h
+++ b/donner/svg/core/ClipRule.h
@@ -4,6 +4,7 @@
  * Defines the ClipRule enum used for determining how paths are clipped with \ref xml_clipPath.
  */
 
+#include <cstdint>
 #include <ostream>
 
 #include "donner/base/Utils.h"

--- a/donner/svg/core/Display.h
+++ b/donner/svg/core/Display.h
@@ -7,6 +7,7 @@
  */
 
 #include <ostream>
+#include <cstdint>
 
 #include "donner/base/Utils.h"
 

--- a/donner/svg/core/FillRule.h
+++ b/donner/svg/core/FillRule.h
@@ -4,6 +4,7 @@
  * Defines the \ref donner::svg::FillRule enum used for determining how fills are painted on shapes.
  */
 
+#include <cstdint>
 #include <ostream>
 
 #include "donner/base/Utils.h"

--- a/donner/svg/core/Gradient.h
+++ b/donner/svg/core/Gradient.h
@@ -1,6 +1,8 @@
 #pragma once
 /// @file
 
+#include <cstdint>
+
 #include "donner/css/Color.h"
 
 namespace donner::svg {

--- a/donner/svg/core/LengthAdjust.h
+++ b/donner/svg/core/LengthAdjust.h
@@ -1,6 +1,7 @@
 #pragma once
 /// @file
 
+#include <cstdint>
 #include <ostream>
 
 #include "donner/base/Utils.h"
@@ -14,7 +15,7 @@ namespace donner::svg {
  * This is used on the \ref xml_text and \ref xml_tspan elements, and controls how the text is
  * stretched, either by adding spacing between glyphs or also by stretching the glyphs themselves.
  */
-enum class LengthAdjust {
+enum class LengthAdjust : uint8_t {
   /**
    * The text is stretched by adding spacing between glyphs, but the glyphs themselves are not
    * scaled.

--- a/donner/svg/core/MarkerOrient.h
+++ b/donner/svg/core/MarkerOrient.h
@@ -1,6 +1,8 @@
 #pragma once
 /// @file
 
+#include <cstdint>
+
 #include "donner/base/MathUtils.h"
 #include "donner/base/Vector2.h"
 

--- a/donner/svg/core/MarkerUnits.h
+++ b/donner/svg/core/MarkerUnits.h
@@ -1,6 +1,7 @@
 #pragma once
 /// @file
 
+#include <cstdint>
 #include <ostream>
 
 #include "donner/base/Utils.h"

--- a/donner/svg/core/MaskUnits.h
+++ b/donner/svg/core/MaskUnits.h
@@ -1,6 +1,7 @@
 #pragma once
 /// @file
 
+#include <cstdint>
 #include <ostream>
 
 #include "donner/base/Utils.h"

--- a/donner/svg/core/Overflow.h
+++ b/donner/svg/core/Overflow.h
@@ -6,6 +6,7 @@
  * content that is too large for its container.
  */
 
+#include <cstdint>
 #include <ostream>
 
 #include "donner/base/Utils.h"

--- a/donner/svg/core/PathSpline.h
+++ b/donner/svg/core/PathSpline.h
@@ -1,6 +1,7 @@
 #pragma once
 /// @file
 
+#include <cstdint>
 #include <vector>
 
 #include "donner/base/Box.h"

--- a/donner/svg/core/PointerEvents.h
+++ b/donner/svg/core/PointerEvents.h
@@ -3,6 +3,7 @@
 #pragma once
 /// @file
 
+#include <cstdint>
 #include <ostream>
 
 #include "donner/base/Utils.h"

--- a/donner/svg/core/PreserveAspectRatio.h
+++ b/donner/svg/core/PreserveAspectRatio.h
@@ -2,6 +2,7 @@
 /// @file
 /// Defines PreserveAspectRatio for SVG aspect ratio preservation.
 
+#include <cstdint>
 #include <optional>
 #include <ostream>
 
@@ -44,7 +45,9 @@ public:
    *
    * @see https://www.w3.org/TR/SVG2/coords.html#PreserveAspectRatioAttribute
    */
-  static PreserveAspectRatio Default() { return PreserveAspectRatio{Align::XMidYMid, MeetOrSlice::Meet}; }
+  static PreserveAspectRatio Default() {
+    return PreserveAspectRatio{Align::XMidYMid, MeetOrSlice::Meet};
+  }
 
   /**
    * Creates a PreserveAspectRatio with 'none' alignment.

--- a/donner/svg/core/Stroke.h
+++ b/donner/svg/core/Stroke.h
@@ -6,6 +6,7 @@
  * donner::svg::StrokeLinejoin, and \ref donner::svg::StrokeDasharray.
  */
 
+#include <cstdint>
 #include <ostream>
 #include <vector>
 

--- a/donner/svg/core/Visibility.h
+++ b/donner/svg/core/Visibility.h
@@ -6,6 +6,7 @@
  * visible or hidden.
  */
 
+#include <cstdint>
 #include <ostream>
 
 #include "donner/base/Utils.h"

--- a/donner/svg/renderer/RendererImageIO.cc
+++ b/donner/svg/renderer/RendererImageIO.cc
@@ -4,6 +4,7 @@
 
 #include <cassert>
 #include <fstream>
+#include <limits>
 
 namespace donner::svg {
 

--- a/donner/svg/renderer/RendererImageIO.h
+++ b/donner/svg/renderer/RendererImageIO.h
@@ -1,6 +1,7 @@
 #pragma once
 /// @file
 
+#include <cstdint>
 #include <span>
 
 namespace donner::svg {

--- a/donner/svg/resources/ImageResource.h
+++ b/donner/svg/resources/ImageResource.h
@@ -1,6 +1,7 @@
 #pragma once
 /// @file
 
+#include <cstdint>
 #include <vector>
 
 namespace donner::svg {

--- a/donner/svg/resources/UrlDecode.h
+++ b/donner/svg/resources/UrlDecode.h
@@ -1,6 +1,7 @@
 #pragma once
 /// @file
 
+#include <cstdint>
 #include <string_view>
 #include <vector>
 


### PR DESCRIPTION
Previously we were downloading LLVM, which was very slow on the first build.  Use system clang as we don't need as much of a cutting-edge compiler as when the project was started.