### PR TITLE
Enhance top-level agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,17 @@ The `.roo/rules` directory provides condensed guidelines on coding style, archit
 - The rendering pipeline ultimately creates `RenderingInstanceComponent` objects
   consumed by a backend like Skia.
 
+## General Practices
+
+- Prefer existing Donner utilities (e.g., `Transformd`, `RcString`,
+  `StringUtils`) before introducing new dependencies. Keep external libraries
+  to a minimum and justify any additions.
+- Optimize for readability and testability. Extract helpers rather than adding
+  large inline logic blocks.
+- Tests:
+  - Use gMock with gTest for C++ tests.
+  - Add fuzzers for parser-style code paths when practical.
+
 ## Building
 
 - Both bazel and CMake are supported, but Bazel is the primary build system. CMake is experimental and may not support all features.
@@ -61,6 +72,8 @@ The `.roo/rules` directory provides condensed guidelines on coding style, archit
   (`dprint.json` sets line width to 100 and indent width to 2).
 - Use `buildifier` to format Bazel build files (e.g. `.bzl`, `BUILD.bazel`).
   or `external/`.
+- Design docs have dedicated guidance under `docs/design_docs/AGENTS.md`.
+  Refer to those instructions when authoring or updating design documentation.
 - For doc-only changes, don't run `clang-format` or `dprint`, or build.
 - Doc files under docs/ are used to generate Doxygen documentation.
   - Use `tools/doxygen.sh` to generate the docs.

--- a/docs/design_docs/AGENTS.md
+++ b/docs/design_docs/AGENTS.md
@@ -1,0 +1,30 @@
+# Agent Instructions for Design Docs
+
+This directory holds guidance for writing design documents for new features.
+Follow these steps when collaborating on a feature:
+
+1. **Start with goals.** Begin every feature by writing a design doc driven by
+   the goals provided by the user or requester. Capture scope, constraints, and
+   any open questions.
+2. **Design readiness gate.** Iterate on the design doc until the user confirms
+   it is ready. Only then move on to planning implementation work.
+3. **Implementation plan.** Once the design is approved, write a detailed
+   implementation plan plus a Markdown TODO list with the concrete steps needed
+   to deliver the feature.
+4. **Iterative implementation.** Enter the implementation phase and complete
+   the TODO steps one at a time, gathering user feedback after each step and
+   updating the plan accordingly.
+5. **Keep design docs current.** During implementation and code review, keep the
+   design doc in sync with the latest decisions and feedback.
+6. **Finalization.** After all TODO items are complete, finish any remaining
+   work to ship the feature. Convert the design doc into developer-facing
+   documentation by removing prior-state notes and step-by-step plans. Document
+   the current architecture and the resulting feature set.
+
+Quality expectations for this directory:
+
+- Maximize readability, testability, and documentation so the feature is
+  production quality.
+- Prefer project utilities (e.g., Transformd, RcString, StringUtils) and avoid
+  unnecessary external dependencies.
+- Use gMock for tests, and consider fuzzing strategies when working on parsers.


### PR DESCRIPTION
## Summary
- add general practices to the root AGENTS instructions to steer dependency choices and utility usage
- document readability-focused development habits along with testing expectations like gMock and fuzzing for parsers

## Testing
- not run (doc-only change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935bbb94198832abc58d40c59853246)