### PR TITLE
Clarify implementation planning steps for design docs

### DIFF
--- a/docs/design_docs/AGENTS.md
+++ b/docs/design_docs/AGENTS.md
@@ -41,8 +41,10 @@ Quality expectations for this directory:
 - Use gMock for tests, and consider fuzzing strategies when working on parsers.
 - Use the design doc template at `docs/design_docs/template.md` to keep structure consistent.
 - When a feature ships, convert the design doc into a developer guide: drop TODOs, implementation
- plans, and prior-state notes. Rewrite in present tense to describe the shipped architecture and
+  plans, and prior-state notes. Rewrite in present tense to describe the shipped architecture and
   guarantees. Use `docs/design_docs/developer_template.md` as the reference structure.
 - When drafting implementation plans, start by outlining high-level milestones. When kicking off a
   milestone, expand it into indented Markdown checkboxes where each item is a single actionable
   step to complete when the user requests the next task.
+- Keep this guidance and the design doc templates in sync; update the template whenever these
+  instructions change so authors always start from the latest expectations.

--- a/docs/design_docs/design_template.md
+++ b/docs/design_docs/design_template.md
@@ -9,6 +9,9 @@
 # mermaid) are encouraged for trust boundaries and data flow.
 #
 # Start with Summary, Goals, Non-Goals, then Next Steps and Implementation Plan. Follow with the rest.
+# Build the Implementation Plan in two layers: list high-level milestones first, then when starting a
+# milestone, add indented Markdown checkboxes with single actionable steps to complete when the next
+# task is requested.
 # </instructions>
 
 ## Summary (Required)
@@ -24,8 +27,12 @@
 - Short summary of the immediate next step(s) to start execution (1–3 bullets).
 
 ## Implementation Plan (Required)
-- [ ] Phase breakdown with major steps (keep concise).
-- [ ] Item 2
+- High-level milestones for delivering the feature.
+  - [ ] Milestone 1: <concise milestone>
+    - [ ] Step 1: <single actionable task>
+    - [ ] Step 2: <single actionable task>
+  - [ ] Milestone 2: <concise milestone>
+    - [ ] Step 1: <single actionable task>
 
 ## User Stories (Optional)
 - As a <user>, I want <capability> so that <benefit>.


### PR DESCRIPTION
## Summary
- add guidance on structuring implementation plans in design docs, starting with milestones and expanding into actionable checklists

## Testing
- not run (doc-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b2c4e4d34832ab930a0a0caaa72a8)