### PR TITLE
Correct Skia paint opacity scaling

### DIFF
--- a/docs/renderer_interface_design.md
+++ b/docs/renderer_interface_design.md
@@ -1,0 +1,181 @@
+# Renderer Interface Refactor Design
+
+## Goals
+- Introduce an abstract renderer interface to decouple traversal logic from backend-specific
+  drawing.
+- Allow multiple rendering backends (e.g., Skia, headless testing) to coexist behind a
+  consistent API.
+- Preserve existing `SVGRenderer` behavior and public surface while improving testability and
+  extensibility.
+
+## Scope
+- Add a new `RendererInterface` in `donner/svg/renderer/` exposing frame control, state stack
+  management, paint setup, and primitive drawing operations.
+- Split the current `RendererSkia` into a backend-agnostic `RendererDriver` (scene traversal)
+  and a Skia implementation of `RendererInterface`.
+- Update render entry points (e.g., `SVGRenderer`) to use `RendererDriver` with a concrete
+  `RendererInterface` instance.
+- Add unit tests validating driver-to-interface interactions and smoke tests for Skia rendering.
+
+## Non-Goals
+- Changing SVG parsing, layout, or styling stages.
+- Altering public APIs for document setup or resource loading.
+- Rewriting existing rendering primitives beyond adapting them to the interface.
+
+## Proposed Architecture
+### RendererInterface
+Located at `donner/svg/renderer/RendererInterface.h`. The interface must be Skia-free and lean on
+Donner primitives already present in the rendering pipeline:
+- Frame control: `beginFrame`/`endFrame` driven by a lightweight `RenderViewport` POD describing
+  viewport size and device scale (no Skia surfaces are exposed).
+- State stack: `pushTransform(const Transformd&)`/`popTransform()` and
+  `pushClip(const ResolvedClip&)`/`popClip()` where `ResolvedClip` is a backend-neutral clip path
+  derived from `ResolvedClipPath`/`ResolvedMask` data.
+- Paint configuration: `setPaint(const PaintParams&)`, where `PaintParams` wraps resolved fill,
+  stroke, filter, opacity, and stroke width data from `RenderingInstanceComponent`.
+- Primitive drawing: `drawPath(const PathShape&, const StrokeParams&)`,
+  `drawImage(const ImageResource&, const ImageParams&)`, and
+  `drawText(const components::ComputedTextComponent&, const TextParams&)`, with `PathShape`
+  wrapping a `PathSpline` plus fill rule. Simple shapes (`drawRect`, `drawEllipse`) are helpers
+  over `PathShape`.
+- Snapshotting: `takeSnapshot()` returns a backend-neutral bitmap wrapper (e.g., `RendererBitmap`)
+  to preserve current `SVGRenderer` expectations without leaking Skia types.
+- Lifetime: interface is non-owning; the driver controls when frames begin/end and when snapshots
+  are requested.
+- Documentation: the interface and all neutral structs include comprehensive Doxygen comments so
+  downstream implementers have precise guidance on ownership and coordinate expectations.
+
+#### Interface sketch
+```cpp
+class RendererInterface {
+ public:
+  virtual ~RendererInterface() = default;
+
+  virtual void beginFrame(const RenderViewport& viewport) = 0;
+  virtual void endFrame() = 0;
+
+  virtual void pushTransform(const Transformd& transform) = 0;
+  virtual void popTransform() = 0;
+
+  virtual void pushClip(const ResolvedClip& clip) = 0;
+  virtual void popClip() = 0;
+
+  virtual void setPaint(const PaintParams& paint) = 0;
+
+  virtual void drawPath(const PathShape& path, const StrokeParams& stroke) = 0;
+  virtual void drawRect(const Boxd& rect, const StrokeParams& stroke) = 0;
+  virtual void drawEllipse(const Boxd& bounds, const StrokeParams& stroke) = 0;
+  virtual void drawImage(const ImageResource& image, const ImageParams& params) = 0;
+  virtual void drawText(const components::ComputedTextComponent& text,
+                        const TextParams& params) = 0;
+
+  virtual RendererBitmap takeSnapshot() const = 0;
+};
+```
+`RenderViewport`, `ResolvedClip`, `PaintParams`, `PathShape`, `StrokeParams`, `ImageParams`,
+`TextParams`, and `RendererBitmap` are POD/struct wrappers over existing Donner math primitives
+(`Boxd`, `Transformd`, `Vector2d`, `Lengthd`) and resolved style data. Implementations translate
+these neutral structs to backend specifics (e.g., Skia paths, paints, and canvases) without
+changing the interface surface.
+
+### RendererDriver
+- Responsible for traversing `SVGDocument` instances and invoking `RendererInterface` methods in
+  render order.
+- Extracts render instances and paint/style state, handling transforms, clips, masks, and opacity
+  stacking without backend knowledge.
+- Handles caching or batching decisions that are backend-independent; backend-specific caches
+  remain within implementations.
+- Surface management (viewport sizing, pixel ratio) is handled via driver inputs and forwarded to
+  the interface.
+
+### RendererSkia (implementation)
+- Implements `RendererInterface` using Skia primitives and existing code paths.
+- Owns Skia-specific resources (canvas, surface, font manager) and translates interface calls to
+  Skia operations.
+- Provides `bitmap()`/`takeSnapshot()` by returning the Skia bitmap or image currently used by
+  render entry points.
+
+### Construction and Wiring
+- `SVGRenderer` constructs a `RendererSkia` and wraps it in a `RendererDriver`. Public
+  `draw`/`bitmap` signatures remain unchanged; methods delegate to the driver, which uses the
+  Skia implementation internally.
+- Future backends (e.g., testing mocks or CPU-only rasterizers) can implement `RendererInterface`
+  and be injected into the driver.
+
+## Testing Strategy
+- **Driver interaction tests:** Create a mock `RendererInterface` that records calls; verify
+  traversal of representative SVG documents triggers expected sequences (transforms, clips, paint
+  setup, primitives). Use focused fixtures covering groups, opacity, clipping, and text/images.
+- **Skia smoke tests:** Use small SVG samples to render via `RendererDriver + RendererSkia`; compare
+  key properties (non-empty bitmap, optional pixel hashes) to guard against regressions.
+- **Snapshot compatibility:** Ensure `bitmap()`/`takeSnapshot()` behavior matches existing usage in
+  `SVGRenderer` tests.
+
+## Migration Plan
+1. Introduce `RendererInterface` header and update includes.
+2. Extract traversal code from `RendererSkia` into new `RendererDriver`; adjust build targets
+   (Bazel/CMake) accordingly.
+3. Adapt `RendererSkia` to implement the interface, keeping Skia-specific members and rendering
+   logic.
+4. Update `SVGRenderer` and related entry points to compose a driver with a concrete renderer.
+5. Add interaction tests with a mock interface and run existing Skia rendering tests/smoke tests.
+6. Clean up any remaining direct `RendererSkia` references; document new extension points.
+
+## Risks and Mitigations
+- **Behavioral drift:** Extensive traversal tests and Skia smoke tests reduce regression risk.
+- **Performance:** The driver/interface boundary introduces minimal overhead; profiling can
+  confirm no significant impact. Inline helpers and move-only data where beneficial.
+- **API stability:** Retain existing public renderer APIs; internal refactor only.
+
+## Open Questions
+- Do we need additional primitives (e.g., gradients or filters) exposed directly on the interface
+  for performance, or are they derived from `PaintParams`?
+- Should `takeSnapshot()` return a backend-neutral image abstraction instead of `SkBitmap` for
+  future backends?
+- How should resource lifetimes (fonts, images) be managed across backends—via shared caches in
+  the driver or per-backend ownership?
+
+## Implementation Plan and TODOs
+Every implementation milestone must include writing or updating tests to cover the new behavior,
+using GoogleMock helpers and shared matchers to target high coverage as features land.
+- **Interface definition**
+  - [x] Add `donner/svg/renderer/RendererInterface.h` with frame control, state stack, paint,
+    primitive APIs, and snapshot support.
+  - [x] Ensure public comments clarify ownership semantics and snapshot expectations for
+    `SVGRenderer`.
+- **Driver extraction**
+  - [ ] Introduce `RendererDriver` that traverses `SVGDocument` and emits interface calls,
+    initially duplicating existing traversal logic from `RendererSkia`.
+    - [x] Emit transforms, clips, paint state, and path primitives through `RendererInterface` as a
+      first slice of traversal behavior.
+    - [x] Route text and image primitives through the interface with neutral parameter shims.
+  - [x] Initialize the render tree and frame lifecycle in `RendererDriver`, feeding the neutral
+    interface for subsequent traversal work.
+  - [x] Add traversal scaffolding to iterate rendering instances so command emission can be
+    layered in next steps.
+  - [x] Update build targets (Bazel/CMake) to expose the driver as a separate library.
+- **Skia backend adaptation**
+  - [x] Refactor `RendererSkia` to implement `RendererInterface`, retaining Skia-specific
+    resource management and translating interface calls to Skia primitives.
+  - [x] Wire `bitmap()`/`takeSnapshot()` to existing Skia surface behavior for compatibility.
+- **Renderer wiring**
+  - [x] Route primary entry points (tooling, examples, viewer, and tests) through
+    `RendererDriver` paired with a `RendererSkia` instance while keeping public
+    rendering and snapshot behavior unchanged.
+  - [ ] Remove remaining direct `RendererSkia` references outside the backend implementation.
+- **Testing**
+  - [x] Add mock-based interaction tests validating driver → interface call sequences for
+    groups, transforms, clips, opacity, text, and images.
+    - [x] Grow reusable GoogleMock fixtures/matchers for renderer calls so new traversal slices add
+      coverage immediately.
+  - [ ] Add Skia smoke/regression tests ensuring rendered bitmaps remain non-empty and snapshots
+    align with pre-refactor expectations.
+  - [ ] Run existing rendering tests to ensure no behavioral regressions.
+  - **Resvg suite parity**
+    - [ ] Port the resvg test suite to the driver-backed renderer path and capture any parity gaps.
+    - [ ] Document and resolve discrepancies (thresholds, skips, or fixes) discovered during the
+      migration.
+    - [ ] Fix remaining stroke/dash/opacity regressions after enabling unit-aware stroke length
+      resolution (mm/%/relative) in the driver and re-running the stroke-focused resvg shard.
+    - [x] Start the migration by consuming driver snapshots in the image-comparison harness to
+      exercise the backend-neutral API surface.

--- a/donner/svg/renderer/BUILD.bazel
+++ b/donner/svg/renderer/BUILD.bazel
@@ -41,6 +41,34 @@ config_setting(
 )
 
 cc_library(
+    name = "renderer_interface",
+    hdrs = ["RendererInterface.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//donner/base",
+        "//donner/css:core",
+        "//donner/svg/components",
+        "//donner/svg/core",
+        "//donner/svg/resources:image_resource",
+    ],
+)
+
+cc_library(
+    name = "renderer_driver",
+    srcs = ["RendererDriver.cc"],
+    hdrs = ["RendererDriver.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":renderer_interface",
+        ":renderer_utils",
+        ":rendering_context",
+        "//donner/svg/renderer/common",
+        "//donner/base",
+        "//donner/svg",
+    ],
+)
+
+cc_library(
     name = "renderer_image_io",
     srcs = ["RendererImageIO.cc"],
     hdrs = ["RendererImageIO.h"],
@@ -104,6 +132,8 @@ cc_library(
     hdrs = ["RendererSkia.h"],
     deps = [
         ":renderer_image_io",
+        ":renderer_driver",
+        ":renderer_interface",
         ":renderer_utils",
         ":skia_deps",
         "//donner/base/fonts",
@@ -117,7 +147,11 @@ cc_library(
 cc_library(
     name = "renderer",
     visibility = ["//visibility:public"],
-    deps = [":renderer_skia"],
+    deps = [
+        ":renderer_driver",
+        ":renderer_interface",
+        ":renderer_skia",
+    ],
 )
 
 cc_binary(

--- a/donner/svg/renderer/RendererDriver.cc
+++ b/donner/svg/renderer/RendererDriver.cc
@@ -1,0 +1,281 @@
+#include "donner/svg/renderer/RendererDriver.h"
+
+#include <iostream>
+#include <optional>
+#include <vector>
+
+#include "donner/base/Length.h"
+#include "donner/base/MathUtils.h"
+#include "donner/base/ParseError.h"
+#include "donner/base/RelativeLengthMetrics.h"
+#include "donner/svg/components/ComputedClipPathsComponent.h"
+#include "donner/svg/components/PreserveAspectRatioComponent.h"
+#include "donner/svg/components/RenderingInstanceComponent.h"
+#include "donner/svg/components/layout/LayoutSystem.h"
+#include "donner/svg/components/layout/SizedElementComponent.h"
+#include "donner/svg/components/layout/TransformComponent.h"
+#include "donner/svg/components/resources/ImageComponent.h"
+#include "donner/svg/components/shape/ComputedPathComponent.h"
+#include "donner/svg/components/style/ComputedStyleComponent.h"
+#include "donner/svg/components/text/ComputedTextComponent.h"
+#include "donner/svg/renderer/RendererUtils.h"
+#include "donner/svg/renderer/RenderingContext.h"
+
+namespace donner::svg {
+
+namespace {
+
+PathShape toPathShape(const components::ComputedPathComponent& path,
+                      const components::ComputedStyleComponent& style) {
+  PathShape shape;
+  shape.path = path.spline;
+  shape.fillRule = style.properties->fillRule.getRequired();
+  return shape;
+}
+
+StrokeParams toStrokeParams(Registry& registry,
+                            const components::RenderingInstanceComponent& instance,
+                            const components::ComputedStyleComponent& style) {
+  StrokeParams stroke;
+  const auto& properties = style.properties.value();
+
+  const Boxd viewBox = components::LayoutSystem().getViewBox(instance.dataHandle(registry));
+  const FontMetrics baseFontMetrics = FontMetrics::DefaultsWithFontSize(16.0);
+  const double fontSizePx = properties.fontSize.getRequired().toPixels(viewBox, baseFontMetrics);
+  const FontMetrics fontMetrics = FontMetrics::DefaultsWithFontSize(fontSizePx);
+
+  const auto toPixels = [&](const Lengthd& length,
+                            Lengthd::Extent extent = Lengthd::Extent::Mixed) {
+    return length.toPixels(viewBox, fontMetrics, extent);
+  };
+
+  stroke.strokeWidth = toPixels(properties.strokeWidth.getRequired());
+  stroke.lineCap = properties.strokeLinecap.getRequired();
+  stroke.lineJoin = properties.strokeLinejoin.getRequired();
+  stroke.miterLimit = properties.strokeMiterlimit.getRequired();
+  stroke.dashOffset = toPixels(properties.strokeDashoffset.getRequired());
+
+  if (const std::optional<StrokeDasharray> dashArray = properties.strokeDasharray.get()) {
+    stroke.dashArray.reserve(dashArray->size());
+    for (const Lengthd& dashLength : *dashArray) {
+      stroke.dashArray.push_back(toPixels(dashLength));
+    }
+  }
+
+  return stroke;
+}
+
+PaintParams toPaintParams(Registry& registry,
+                          const components::RenderingInstanceComponent& instance,
+                          const components::ComputedStyleComponent& style) {
+  PaintParams paint;
+  const auto& properties = style.properties.value();
+
+  paint.opacity = properties.opacity.getRequired();
+  paint.fill = instance.resolvedFill;
+  paint.fillOpacity = properties.fillOpacity.getRequired();
+  paint.stroke = instance.resolvedStroke;
+  paint.strokeOpacity = properties.strokeOpacity.getRequired();
+  paint.currentColor = properties.color.getRequired();
+  paint.viewBox = components::LayoutSystem().getViewBox(instance.dataHandle(registry));
+  paint.strokeParams = toStrokeParams(registry, instance, style);
+
+  return paint;
+}
+
+ResolvedClip toResolvedClip(const components::RenderingInstanceComponent& instance,
+                            const components::ComputedStyleComponent& style, Registry& registry) {
+  ResolvedClip clip;
+  clip.clipRect = instance.clipRect;
+  clip.mask = instance.mask;
+
+  if (const auto* clipPaths =
+          instance.styleHandle(registry).try_get<components::ComputedClipPathsComponent>()) {
+    clip.clipPaths.reserve(clipPaths->clipPaths.size());
+    for (const auto& path : clipPaths->clipPaths) {
+      PathShape shape;
+      shape.path = path.path;
+      shape.fillRule = path.clipRule == ClipRule::NonZero ? FillRule::NonZero : FillRule::EvenOdd;
+      clip.clipPaths.push_back(shape);
+    }
+  }
+
+  // The computed clip rule is inherited if undefined on the clip path itself.
+  for (PathShape& path : clip.clipPaths) {
+    if (path.fillRule == FillRule::NonZero &&
+        style.properties->clipRule.getRequired() == ClipRule::EvenOdd) {
+      path.fillRule = FillRule::EvenOdd;
+    }
+  }
+
+  return clip;
+}
+
+css::Color resolveFillColor(const components::RenderingInstanceComponent& instance,
+                            const components::ComputedStyleComponent& style) {
+  const auto& properties = style.properties.value();
+  const css::RGBA currentColor = properties.color.getRequired().rgba();
+  const float fillOpacity = NarrowToFloat(properties.fillOpacity.getRequired());
+
+  const auto resolveSolid = [&](const PaintServer::Solid& solid) {
+    return css::Color(solid.color.resolve(currentColor, fillOpacity));
+  };
+
+  if (const auto* resolved = std::get_if<PaintServer::Solid>(&instance.resolvedFill)) {
+    return resolveSolid(*resolved);
+  }
+
+  const PaintServer fill = properties.fill.getRequired();
+  if (const auto* solid = std::get_if<PaintServer::Solid>(&fill.value)) {
+    return resolveSolid(*solid);
+  }
+
+  return css::Color(css::RGBA(currentColor.r, currentColor.g, currentColor.b,
+                              static_cast<uint8_t>(NarrowToFloat(currentColor.a) * fillOpacity)));
+}
+
+TextParams toTextParams(Registry& registry, const components::RenderingInstanceComponent& instance,
+                        const components::ComputedStyleComponent& style) {
+  TextParams params;
+  const auto& properties = style.properties.value();
+  const css::RGBA currentColor = properties.color.getRequired().rgba();
+
+  params.opacity = properties.opacity.getRequired();
+  params.fillColor = resolveFillColor(instance, style);
+
+  if (const auto* stroke = std::get_if<PaintServer::Solid>(&instance.resolvedStroke)) {
+    const float strokeOpacity = NarrowToFloat(properties.strokeOpacity.getRequired());
+    params.strokeColor = css::Color(stroke->color.resolve(currentColor, strokeOpacity));
+    params.strokeParams = toStrokeParams(registry, instance, style);
+  }
+
+  params.fontFamilies = properties.fontFamily.getRequiredRef();
+  params.fontSize = properties.fontSize.getRequired();
+  params.viewBox = components::LayoutSystem().getViewBox(instance.dataHandle(registry));
+  params.fontMetrics = FontMetrics();
+
+  return params;
+}
+
+std::optional<ImageParams> toImageParams(const components::RenderingInstanceComponent& instance,
+                                         const components::ComputedStyleComponent& style,
+                                         const components::LoadedImageComponent& image,
+                                         Registry& registry) {
+  if (!image.image.has_value()) {
+    return std::nullopt;
+  }
+
+  const auto* sizedElement =
+      instance.dataHandle(registry).try_get<components::ComputedSizedElementComponent>();
+  if (sizedElement == nullptr) {
+    return std::nullopt;
+  }
+
+  ImageParams params;
+  params.opacity = style.properties->opacity.getRequired();
+  params.targetRect = Boxd::WithSize(Vector2d(image.image->width, image.image->height));
+
+  return params;
+}
+
+}  // namespace
+
+RendererDriver::RendererDriver(RendererInterface& renderer, bool verbose)
+    : renderer_(renderer), verbose_(verbose) {}
+
+void RendererDriver::draw(SVGDocument& document) {
+  std::vector<ParseError> warnings;
+  components::RenderingContext renderingContext(document.registry());
+  RendererUtils::prepareDocumentForRendering(document, verbose_, verbose_ ? &warnings : nullptr);
+  renderingContext.instantiateRenderTree(verbose_, verbose_ ? &warnings : nullptr);
+
+  if (!warnings.empty()) {
+    for (const ParseError& warning : warnings) {
+      std::cerr << warning << '\n';
+    }
+  }
+
+  const Vector2i renderingSize = document.canvasSize();
+  RenderViewport viewport;
+  viewport.size = Vector2d(renderingSize.x, renderingSize.y);
+  viewport.devicePixelRatio = 1.0;
+
+  renderer_.beginFrame(viewport);
+  RenderingInstanceView view(document.registry());
+  traverse(view, document.registry());
+  renderer_.endFrame();
+}
+
+RendererBitmap RendererDriver::takeSnapshot() const {
+  return renderer_.takeSnapshot();
+}
+
+void RendererDriver::traverse(RenderingInstanceView& view, Registry& registry) {
+  while (!view.done()) {
+    const components::RenderingInstanceComponent& instance = view.get();
+    view.advance();
+
+    const auto& style = instance.styleHandle(registry).get<components::ComputedStyleComponent>();
+    if (!style.properties.has_value()) {
+      continue;
+    }
+
+    renderer_.pushTransform(instance.entityFromWorldTransform);
+
+    ResolvedClip clip = toResolvedClip(instance, style, registry);
+    const bool hasClip = !clip.empty();
+    if (hasClip) {
+      renderer_.pushClip(clip);
+    }
+
+    const PaintParams paint = toPaintParams(registry, instance, style);
+    renderer_.setPaint(paint);
+
+    if (const auto* path =
+            instance.dataHandle(registry).try_get<components::ComputedPathComponent>()) {
+      renderer_.drawPath(toPathShape(*path, style), paint.strokeParams);
+    } else if (const auto* text =
+                   instance.dataHandle(registry).try_get<components::ComputedTextComponent>()) {
+      const TextParams textParams = toTextParams(registry, instance, style);
+      renderer_.drawText(*text, textParams);
+    } else if (const auto* image =
+                   instance.dataHandle(registry).try_get<components::LoadedImageComponent>()) {
+      const std::optional<ImageParams> imageParams =
+          toImageParams(instance, style, *image, registry);
+      if (!imageParams.has_value()) {
+        continue;
+      }
+
+      const auto* sizedElement =
+          instance.dataHandle(registry).try_get<components::ComputedSizedElementComponent>();
+      const auto* preserveAspectRatio =
+          instance.dataHandle(registry).try_get<components::PreserveAspectRatioComponent>();
+
+      if (sizedElement != nullptr) {
+        ResolvedClip imageClip;
+        imageClip.clipRect = sizedElement->bounds;
+        renderer_.pushClip(imageClip);
+
+        const PreserveAspectRatio aspectRatio = preserveAspectRatio != nullptr
+                                                    ? preserveAspectRatio->preserveAspectRatio
+                                                    : PreserveAspectRatio::Default();
+        const Transformd imageFromLocal = aspectRatio.elementContentFromViewBoxTransform(
+            sizedElement->bounds, imageParams->targetRect);
+        renderer_.pushTransform(imageFromLocal);
+        renderer_.drawImage(*image->image, *imageParams);
+        renderer_.popTransform();
+        renderer_.popClip();
+      } else {
+        renderer_.drawImage(*image->image, *imageParams);
+      }
+    }
+
+    if (hasClip) {
+      renderer_.popClip();
+    }
+
+    renderer_.popTransform();
+  }
+}
+
+}  // namespace donner::svg

--- a/donner/svg/renderer/RendererDriver.h
+++ b/donner/svg/renderer/RendererDriver.h
@@ -1,0 +1,39 @@
+#pragma once
+/// @file
+
+#include "donner/svg/SVGDocument.h"
+#include "donner/svg/renderer/RendererInterface.h"
+#include "donner/svg/renderer/common/RenderingInstanceView.h"
+
+namespace donner::svg {
+
+/**
+ * Backend-agnostic renderer driver that prepares documents for rendering and
+ * emits drawing commands through a \ref RendererInterface implementation.
+ */
+class RendererDriver {
+public:
+  /**
+   * Create a renderer driver that will forward traversal output to the given
+   * backend implementation.
+   */
+  explicit RendererDriver(RendererInterface& renderer, bool verbose = false);
+
+  /**
+   * Render the given \ref SVGDocument using the configured backend.
+   */
+  void draw(SVGDocument& document);
+
+  /**
+   * Capture a snapshot from the underlying backend after rendering.
+   */
+  [[nodiscard]] RendererBitmap takeSnapshot() const;
+
+private:
+  void traverse(RenderingInstanceView& view, Registry& registry);
+
+  RendererInterface& renderer_;
+  bool verbose_ = false;
+};
+
+}  // namespace donner::svg

--- a/donner/svg/renderer/RendererInterface.h
+++ b/donner/svg/renderer/RendererInterface.h
@@ -1,0 +1,202 @@
+#pragma once
+/// @file
+
+#include <cstddef>
+#include <optional>
+#include <vector>
+
+#include "donner/base/Box.h"
+#include "donner/base/RelativeLengthMetrics.h"
+#include "donner/base/RcString.h"
+#include "donner/base/SmallVector.h"
+#include "donner/base/Transform.h"
+#include "donner/css/Color.h"
+#include "donner/svg/components/RenderingInstanceComponent.h"
+#include "donner/svg/components/text/ComputedTextComponent.h"
+#include "donner/svg/core/FillRule.h"
+#include "donner/svg/core/PathSpline.h"
+#include "donner/svg/core/Stroke.h"
+#include "donner/svg/resources/ImageResource.h"
+
+namespace donner::svg {
+
+/**
+ * Describes the viewport for a render pass.
+ */
+struct RenderViewport {
+  /// Logical size in CSS/SVG units after layout.
+  Vector2d size = Vector2d::Zero();
+  /// Device pixel ratio used to map logical coordinates to device pixels.
+  double devicePixelRatio = 1.0;
+};
+
+/**
+ * CPU-readable bitmap produced by a renderer snapshot.
+ */
+struct RendererBitmap {
+  /// Pixel dimensions of the bitmap in device pixels.
+  Vector2i dimensions = Vector2i::Zero();
+  /// Raw pixel data in tightly packed RGBA 8-bit format.
+  std::vector<uint8_t> pixels;
+  /// Bytes between rows; allows alignment/padding differences between renderers.
+  std::size_t rowBytes = 0;
+
+  [[nodiscard]] bool empty() const {
+    return dimensions.x <= 0 || dimensions.y <= 0 || pixels.empty();
+  }
+};
+
+/**
+ * Represents a resolved path along with its fill rule.
+ */
+struct PathShape {
+  PathSpline path;
+  FillRule fillRule = FillRule::NonZero;
+};
+
+/**
+ * Stroke configuration used for path and primitive drawing.
+ */
+struct StrokeParams {
+  /// Stroke width in user units.
+  double strokeWidth = 0.0;
+  StrokeLinecap lineCap = StrokeLinecap::Butt;
+  StrokeLinejoin lineJoin = StrokeLinejoin::Miter;
+  /// Maximum miter ratio before converting to bevel.
+  double miterLimit = 4.0;
+  /// Dash pattern lengths alternating on/off segments.
+  std::vector<double> dashArray;
+  /// Dash phase offset.
+  double dashOffset = 0.0;
+};
+
+/**
+ * Paint state derived from resolved style for the current node.
+ */
+struct PaintParams {
+  /// Multiplicative opacity applied to all drawing.
+  double opacity = 1.0;
+  components::ResolvedPaintServer fill = PaintServer::None{};
+  components::ResolvedPaintServer stroke = PaintServer::None{};
+  double fillOpacity = 1.0;
+  double strokeOpacity = 1.0;
+  /// CurrentColor value for paint server resolution.
+  css::Color currentColor = css::Color(css::RGBA());
+  /// View box used for unit resolution and gradient coordinate conversion.
+  Boxd viewBox;
+  StrokeParams strokeParams;
+};
+
+/**
+ * Clip stack entry combining rectangles, paths, and optional masks.
+ */
+struct ResolvedClip {
+  std::optional<Boxd> clipRect;
+  std::vector<PathShape> clipPaths;
+  std::optional<components::ResolvedMask> mask;
+
+  [[nodiscard]] bool empty() const { return !clipRect.has_value() && clipPaths.empty() && !mask; }
+};
+
+/**
+ * Parameters describing how an image should be drawn.
+ */
+struct ImageParams {
+  /// Destination rectangle in device-independent units.
+  Boxd targetRect;
+  double opacity = 1.0;
+  /// Whether to favor nearest-neighbor sampling for pixelated rendering.
+  bool imageRenderingPixelated = false;
+};
+
+/**
+ * Parameters describing how text is drawn and outlined.
+ */
+struct TextParams {
+  double opacity = 1.0;
+  css::Color fillColor = css::Color(css::RGBA());
+  css::Color strokeColor = css::Color(css::RGBA());
+  StrokeParams strokeParams;
+  SmallVector<RcString, 1> fontFamilies;
+  Lengthd fontSize;
+  Boxd viewBox;
+  FontMetrics fontMetrics;
+};
+
+/**
+ * Backend-agnostic rendering interface consumed by the traversal driver.
+ */
+class RendererInterface {
+ public:
+  virtual ~RendererInterface() = default;
+
+  /**
+   * Begins a render pass with the given viewport. Implementations may allocate or reset
+   * backend-specific frame resources here.
+   */
+  virtual void beginFrame(const RenderViewport& viewport) = 0;
+
+  /**
+   * Completes the current render pass, flushing any pending work.
+   */
+  virtual void endFrame() = 0;
+
+  /**
+   * Pushes a transform onto the renderer stack, composing with the current transform.
+   */
+  virtual void pushTransform(const Transformd& transform) = 0;
+
+  /**
+   * Pops the most recent transform from the renderer stack.
+   */
+  virtual void popTransform() = 0;
+
+  /**
+   * Pushes a clip path/mask onto the renderer stack.
+   */
+  virtual void pushClip(const ResolvedClip& clip) = 0;
+
+  /**
+   * Pops the most recent clip from the renderer stack.
+   */
+  virtual void popClip() = 0;
+
+  /**
+   * Sets the active paint parameters used by subsequent draw calls.
+   */
+  virtual void setPaint(const PaintParams& paint) = 0;
+
+  /**
+   * Draws an arbitrary path using the current paint state.
+   */
+  virtual void drawPath(const PathShape& path, const StrokeParams& stroke) = 0;
+
+  /**
+   * Convenience helper for drawing axis-aligned rectangles.
+   */
+  virtual void drawRect(const Boxd& rect, const StrokeParams& stroke) = 0;
+
+  /**
+   * Convenience helper for drawing ellipses bounded by the provided box.
+   */
+  virtual void drawEllipse(const Boxd& bounds, const StrokeParams& stroke) = 0;
+
+  /**
+   * Draws an image resource into the given target rectangle.
+   */
+  virtual void drawImage(const ImageResource& image, const ImageParams& params) = 0;
+
+  /**
+   * Draws pre-shaped text with the provided paint parameters.
+   */
+  virtual void drawText(const components::ComputedTextComponent& text,
+                        const TextParams& params) = 0;
+
+  /**
+   * Captures a CPU-readable snapshot of the current frame buffer for testing or downstream
+   * consumers. The snapshot must remain valid after the render pass completes.
+   */
+  [[nodiscard]] virtual RendererBitmap takeSnapshot() const = 0;
+};
+
+}  // namespace donner::svg

--- a/donner/svg/renderer/RendererSkia.cc
+++ b/donner/svg/renderer/RendererSkia.cc
@@ -4,13 +4,17 @@
 
 // Skia
 #include "include/core/SkColorFilter.h"
+#include "include/core/SkData.h"
 #include "include/core/SkFont.h"
 #include "include/core/SkFontMgr.h"
+#include "include/core/SkImage.h"
 #include "include/core/SkPath.h"
 #include "include/core/SkPathEffect.h"
 #include "include/core/SkPathMeasure.h"
 #include "include/core/SkPictureRecorder.h"
+#include "include/core/SkSamplingOptions.h"
 #include "include/core/SkStream.h"
+#include "include/core/SkSurface.h"
 #include "include/core/SkTypeface.h"
 #include "include/effects/SkDashPathEffect.h"
 #include "include/effects/SkGradientShader.h"
@@ -30,6 +34,8 @@
     "Neither DONNER_USE_CORETEXT, DONNER_USE_FREETYPE, nor DONNER_USE_FREETYPE_WITH_FONTCONFIG is defined"
 #endif
 // Donner
+#include "donner/base/Length.h"
+#include "donner/base/RelativeLengthMetrics.h"
 #include "donner/base/fonts/WoffFont.h"
 #include "donner/base/xml/components/TreeComponent.h"  // ForAllChildren
 #include "donner/svg/SVGMarkerElement.h"
@@ -61,6 +67,7 @@
 #include "donner/svg/components/style/ComputedStyleComponent.h"
 #include "donner/svg/components/text/ComputedTextComponent.h"
 #include "donner/svg/graph/Reference.h"
+#include "donner/svg/renderer/RendererDriver.h"
 #include "donner/svg/renderer/RendererImageIO.h"
 #include "donner/svg/renderer/RendererUtils.h"
 #include "donner/svg/renderer/common/RenderingInstanceView.h"
@@ -115,6 +122,155 @@ SkRect toSkia(const Boxd& box) {
 
 SkColor toSkia(const css::RGBA rgba) {
   return SkColorSetARGB(rgba.a, rgba.r, rgba.g, rgba.b);
+}
+
+SkTileMode toSkia(GradientSpreadMethod spreadMethod);
+
+inline Lengthd toPercent(Lengthd value, bool numbersArePercent) {
+  if (!numbersArePercent) {
+    return value;
+  }
+
+  if (value.unit == Lengthd::Unit::None) {
+    value.value *= 100.0;
+    value.unit = Lengthd::Unit::Percent;
+  }
+
+  return value;
+}
+
+inline SkScalar resolveGradientCoord(Lengthd value, const Boxd& viewBox, bool numbersArePercent) {
+  return NarrowToFloat(toPercent(value, numbersArePercent).toPixels(viewBox, FontMetrics()));
+}
+
+Vector2d resolveGradientCoords(Lengthd x, Lengthd y, const Boxd& viewBox, bool numbersArePercent) {
+  return Vector2d(
+      toPercent(x, numbersArePercent).toPixels(viewBox, FontMetrics(), Lengthd::Extent::X),
+      toPercent(y, numbersArePercent).toPixels(viewBox, FontMetrics(), Lengthd::Extent::Y));
+}
+
+Transformd resolveGradientTransform(
+    const components::ComputedLocalTransformComponent* maybeTransformComponent, const Boxd& viewBox) {
+  if (maybeTransformComponent == nullptr) {
+    return Transformd();
+  }
+
+  const Vector2d origin = maybeTransformComponent->transformOrigin;
+  const Transformd entityFromParent =
+      maybeTransformComponent->rawCssTransform.compute(viewBox, FontMetrics());
+  return Transformd::Translate(origin) * entityFromParent * Transformd::Translate(-origin);
+}
+
+std::optional<SkPaint> instantiateGradientPaint(const components::PaintResolvedReference& ref,
+                                                const Boxd& pathBounds, const Boxd& viewBox,
+                                                const css::RGBA currentColor, float opacity,
+                                                bool antialias) {
+  const EntityHandle handle = ref.reference.handle;
+  if (!handle) {
+    return std::nullopt;
+  }
+
+  const auto* computedGradient = handle.try_get<components::ComputedGradientComponent>();
+  if (computedGradient == nullptr || !computedGradient->initialized) {
+    return std::nullopt;
+  }
+
+  const bool objectBoundingBox = computedGradient->gradientUnits == GradientUnits::ObjectBoundingBox;
+  const bool numbersArePercent = objectBoundingBox;
+
+  if (objectBoundingBox && (NearZero(pathBounds.width()) || NearZero(pathBounds.height()))) {
+    return std::nullopt;
+  }
+
+  Transformd gradientFromGradientUnits;
+  if (objectBoundingBox) {
+    gradientFromGradientUnits = resolveGradientTransform(
+        handle.try_get<components::ComputedLocalTransformComponent>(), kUnitPathBounds);
+
+    const Transformd objectBoundingBoxFromUnitBox =
+        Transformd::Scale(pathBounds.size()) * Transformd::Translate(pathBounds.topLeft);
+    gradientFromGradientUnits = gradientFromGradientUnits * objectBoundingBoxFromUnitBox;
+  } else {
+    gradientFromGradientUnits = resolveGradientTransform(
+        handle.try_get<components::ComputedLocalTransformComponent>(), viewBox);
+  }
+
+  const Boxd& bounds = objectBoundingBox ? kUnitPathBounds : viewBox;
+
+  std::vector<SkScalar> positions;
+  std::vector<SkColor> colors;
+  positions.reserve(computedGradient->stops.size());
+  colors.reserve(computedGradient->stops.size());
+  for (const GradientStop& stop : computedGradient->stops) {
+    positions.push_back(stop.offset);
+    colors.push_back(toSkia(stop.color.resolve(currentColor, stop.opacity * opacity)));
+  }
+
+  if (positions.size() < 2) {
+    return std::nullopt;
+  }
+
+  const SkMatrix skGradientFromGradientUnits = toSkiaMatrix(gradientFromGradientUnits);
+
+  SkPaint paint;
+  paint.setAntiAlias(antialias);
+
+  if (const auto* linear = handle.try_get<components::ComputedLinearGradientComponent>()) {
+    const Vector2d start = resolveGradientCoords(linear->x1, linear->y1, bounds, numbersArePercent);
+    const Vector2d end = resolveGradientCoords(linear->x2, linear->y2, bounds, numbersArePercent);
+
+    const SkPoint points[] = {toSkia(start), toSkia(end)};
+    paint.setShader(SkGradientShader::MakeLinear(points, colors.data(), positions.data(),
+                                                 static_cast<int>(positions.size()),
+                                                 toSkia(computedGradient->spreadMethod), 0,
+                                                 &skGradientFromGradientUnits));
+    return paint;
+  }
+
+  if (const auto* radial = handle.try_get<components::ComputedRadialGradientComponent>()) {
+    const double radius = resolveGradientCoord(radial->r, bounds, numbersArePercent);
+    const Vector2d center = resolveGradientCoords(radial->cx, radial->cy, bounds, numbersArePercent);
+    const double focalRadius = resolveGradientCoord(radial->fr, bounds, numbersArePercent);
+    const Vector2d focalCenter = resolveGradientCoords(radial->fx.value_or(radial->cx),
+                                                      radial->fy.value_or(radial->cy), bounds,
+                                                      numbersArePercent);
+
+    if (radius <= 0.0) {
+      return std::nullopt;
+    }
+
+    const float skRadius = static_cast<float>(radius);
+    if (NearZero(focalRadius) && NearZero((focalCenter - center).length())) {
+      paint.setShader(SkGradientShader::MakeRadial(
+          toSkia(center), skRadius, colors.data(), positions.data(),
+          static_cast<int>(positions.size()), toSkia(computedGradient->spreadMethod), 0,
+          &skGradientFromGradientUnits));
+    } else {
+      paint.setShader(SkGradientShader::MakeTwoPointConical(
+          toSkia(focalCenter), static_cast<SkScalar>(focalRadius), toSkia(center), skRadius,
+          colors.data(), positions.data(), static_cast<int>(positions.size()),
+          toSkia(computedGradient->spreadMethod), 0, &skGradientFromGradientUnits));
+    }
+    return paint;
+  }
+
+  return std::nullopt;
+}
+
+std::optional<css::RGBA> resolveSolidPaint(const components::ResolvedPaintServer& paint,
+                                           const css::Color& currentColor, double opacity) {
+  if (const auto* solid = std::get_if<PaintServer::Solid>(&paint)) {
+    return solid->color.resolve(currentColor.rgba(), NarrowToFloat(opacity));
+  }
+
+  return std::nullopt;
+}
+
+SkPaint basePaint(bool antialias, double opacity) {
+  SkPaint paint;
+  paint.setAntiAlias(antialias);
+  paint.setAlphaf(NarrowToFloat(opacity));
+  return paint;
 }
 
 SkPaint::Cap toSkia(StrokeLinecap lineCap) {
@@ -1439,116 +1595,377 @@ private:
   Transformd layerBaseTransform_ = Transformd();
 };
 
-RendererSkia::RendererSkia(bool verbose) : verbose_(verbose) {}
+RendererSkia::RendererSkia(bool verbose) : verbose_(verbose) {
+#if defined(DONNER_USE_CORETEXT)
+  fontMgr_ = SkFontMgr_New_CoreText();
+#elif defined(DONNER_USE_FREETYPE_WITH_FONTCONFIG)
+  fontMgr_ = SkFontMgr_New_FontConfig(SkFontScanner_FT::Make().release());
+#elif defined(DONNER_USE_FREETYPE)
+  fontMgr_ = SkFontMgr_New_Custom_Empty();
+#endif
+}
 
 RendererSkia::~RendererSkia() {}
 
 RendererSkia::RendererSkia(RendererSkia&&) noexcept = default;
 RendererSkia& RendererSkia::operator=(RendererSkia&&) noexcept = default;
 
-void RendererSkia::draw(SVGDocument& document) {
-  // TODO(jwmcglynn): Plumb outWarnings.
-  std::vector<ParseError> warnings;
-  RendererUtils::prepareDocumentForRendering(document, verbose_, verbose_ ? &warnings : nullptr);
+void RendererSkia::beginFrame(const RenderViewport& viewport) {
+  viewport_ = viewport;
+  const int pixelWidth = static_cast<int>(viewport.size.x * viewport.devicePixelRatio);
+  const int pixelHeight = static_cast<int>(viewport.size.y * viewport.devicePixelRatio);
 
-  if (!warnings.empty()) {
-    for (const ParseError& warning : warnings) {
-      std::cerr << warning << '\n';
+  bitmap_.allocPixels(SkImageInfo::Make(pixelWidth, pixelHeight,
+                                        SkColorType::kRGBA_8888_SkColorType,
+                                        SkAlphaType::kPremul_SkAlphaType));
+  bitmap_.eraseARGB(0, 0, 0, 0);
+
+  surface_ = SkSurfaces::WrapPixels(bitmap_.pixmap());
+  currentCanvas_ = externalCanvas_ != nullptr ? externalCanvas_ : surface_->getCanvas();
+
+  currentCanvas_->save();
+  currentCanvas_->scale(NarrowToFloat(viewport.devicePixelRatio),
+                        NarrowToFloat(viewport.devicePixelRatio));
+  transformDepth_ = 0;
+  clipDepth_ = 0;
+}
+
+void RendererSkia::endFrame() {
+  for (; clipDepth_ > 0; --clipDepth_) {
+    currentCanvas_->restore();
+  }
+  for (; transformDepth_ > 0; --transformDepth_) {
+    currentCanvas_->restore();
+  }
+
+  currentCanvas_->restore();
+
+  currentCanvas_ = nullptr;
+  externalCanvas_ = nullptr;
+}
+
+void RendererSkia::pushTransform(const Transformd& transform) {
+  if (currentCanvas_ == nullptr) {
+    return;
+  }
+
+  currentCanvas_->save();
+  currentCanvas_->concat(toSkiaMatrix(transform));
+  ++transformDepth_;
+}
+
+void RendererSkia::popTransform() {
+  if (currentCanvas_ == nullptr || transformDepth_ <= 0) {
+    return;
+  }
+
+  currentCanvas_->restore();
+  --transformDepth_;
+}
+
+void RendererSkia::pushClip(const ResolvedClip& clip) {
+  if (currentCanvas_ == nullptr) {
+    return;
+  }
+
+  currentCanvas_->save();
+  if (clip.clipRect.has_value()) {
+    currentCanvas_->clipRect(toSkia(*clip.clipRect));
+  }
+
+  for (const PathShape& path : clip.clipPaths) {
+    SkPath skPath = toSkia(path.path);
+    if (path.fillRule == FillRule::EvenOdd) {
+      skPath.setFillType(SkPathFillType::kEvenOdd);
+    }
+    currentCanvas_->clipPath(skPath, SkClipOp::kIntersect, true);
+  }
+
+  ++clipDepth_;
+}
+
+void RendererSkia::popClip() {
+  if (currentCanvas_ == nullptr || clipDepth_ <= 0) {
+    return;
+  }
+
+  currentCanvas_->restore();
+  --clipDepth_;
+}
+
+std::optional<SkPaint> RendererSkia::makeFillPaint(const Boxd& bounds) {
+  if (std::holds_alternative<PaintServer::None>(paint_.fill)) {
+    return std::nullopt;
+  }
+
+  const css::RGBA currentColor = paint_.currentColor.rgba();
+  const float fillOpacity = NarrowToFloat(paint_.fillOpacity);
+  const float globalOpacity = NarrowToFloat(paint_.opacity);
+
+  if (const auto* solid = std::get_if<PaintServer::Solid>(&paint_.fill)) {
+    SkPaint paint = basePaint(antialias_, globalOpacity);
+    paint.setStyle(SkPaint::Style::kFill_Style);
+    paint.setColor(toSkia(solid->color.resolve(currentColor, fillOpacity)));
+    return paint;
+  }
+
+  if (const auto* ref = std::get_if<components::PaintResolvedReference>(&paint_.fill)) {
+    if (std::optional<SkPaint> gradient = instantiateGradientPaint(
+            *ref, bounds, paint_.viewBox, currentColor,
+            NarrowToFloat(paint_.opacity * paint_.fillOpacity), antialias_)) {
+      gradient->setStyle(SkPaint::Style::kFill_Style);
+      return gradient;
+    }
+
+    if (ref->fallback) {
+      SkPaint paint = basePaint(antialias_, globalOpacity);
+      paint.setStyle(SkPaint::Style::kFill_Style);
+      paint.setColor(toSkia(ref->fallback->resolve(currentColor, fillOpacity)));
+      return paint;
     }
   }
 
-  const Vector2i renderingSize = document.canvasSize();
+  return std::nullopt;
+}
 
-  bitmap_.allocPixels(
-      SkImageInfo::MakeN32(renderingSize.x, renderingSize.y, SkAlphaType::kUnpremul_SkAlphaType));
-  SkCanvas canvas(bitmap_);
-  rootCanvas_ = &canvas;
-  currentCanvas_ = &canvas;
+std::optional<SkPaint> RendererSkia::makeStrokePaint(const Boxd& bounds,
+                                                     const StrokeParams& stroke) {
+  if (std::holds_alternative<PaintServer::None>(paint_.stroke) || stroke.strokeWidth <= 0.0) {
+    return std::nullopt;
+  }
 
-  draw(document.registry());
+  const css::RGBA currentColor = paint_.currentColor.rgba();
+  const float strokeOpacity = NarrowToFloat(paint_.strokeOpacity);
+  const float globalOpacity = NarrowToFloat(paint_.opacity);
 
-  rootCanvas_ = currentCanvas_ = nullptr;
+  auto configureStroke = [&](SkPaint& paint) {
+    paint.setStyle(SkPaint::Style::kStroke_Style);
+    paint.setStrokeWidth(static_cast<SkScalar>(stroke.strokeWidth));
+    paint.setStrokeCap(toSkia(stroke.lineCap));
+    paint.setStrokeJoin(toSkia(stroke.lineJoin));
+    paint.setStrokeMiter(static_cast<SkScalar>(stroke.miterLimit));
+
+    if (!stroke.dashArray.empty()) {
+      std::vector<SkScalar> dashes;
+      dashes.reserve(stroke.dashArray.size());
+      for (double dash : stroke.dashArray) {
+        dashes.push_back(static_cast<SkScalar>(dash));
+      }
+
+      paint.setPathEffect(SkDashPathEffect::Make(dashes.data(), static_cast<int>(dashes.size()),
+                                                 static_cast<SkScalar>(stroke.dashOffset)));
+    }
+  };
+
+  if (const auto* solid = std::get_if<PaintServer::Solid>(&paint_.stroke)) {
+    SkPaint paint = basePaint(antialias_, globalOpacity);
+    configureStroke(paint);
+    paint.setColor(toSkia(solid->color.resolve(currentColor, strokeOpacity)));
+    return paint;
+  }
+
+  if (const auto* ref = std::get_if<components::PaintResolvedReference>(&paint_.stroke)) {
+    if (std::optional<SkPaint> gradient = instantiateGradientPaint(
+            *ref, bounds, paint_.viewBox, currentColor,
+            NarrowToFloat(paint_.opacity * paint_.strokeOpacity), antialias_)) {
+      configureStroke(*gradient);
+      return gradient;
+    }
+
+    if (ref->fallback) {
+      SkPaint paint = basePaint(antialias_, globalOpacity);
+      configureStroke(paint);
+      paint.setColor(toSkia(ref->fallback->resolve(currentColor, strokeOpacity)));
+      return paint;
+    }
+  }
+
+  return std::nullopt;
+}
+
+void RendererSkia::setPaint(const PaintParams& paint) {
+  paint_ = paint;
+  paintOpacity_ = paint.opacity;
+}
+
+void RendererSkia::drawPath(const PathShape& path, const StrokeParams& stroke) {
+  if (currentCanvas_ == nullptr) {
+    return;
+  }
+
+  SkPath skPath = toSkia(path.path);
+  if (path.fillRule == FillRule::EvenOdd) {
+    skPath.setFillType(SkPathFillType::kEvenOdd);
+  }
+
+  if (std::optional<SkPaint> fillPaint = makeFillPaint(path.path.bounds())) {
+    currentCanvas_->drawPath(skPath, *fillPaint);
+  }
+
+  if (std::optional<SkPaint> strokePaint = makeStrokePaint(path.path.bounds(), stroke)) {
+    currentCanvas_->drawPath(skPath, *strokePaint);
+  }
+}
+
+void RendererSkia::drawRect(const Boxd& rect, const StrokeParams& stroke) {
+  const SkRect skRect = toSkia(rect);
+  if (std::optional<SkPaint> fillPaint = makeFillPaint(rect)) {
+    currentCanvas_->drawRect(skRect, *fillPaint);
+  }
+
+  if (std::optional<SkPaint> strokePaint = makeStrokePaint(rect, stroke)) {
+    currentCanvas_->drawRect(skRect, *strokePaint);
+  }
+}
+
+void RendererSkia::drawEllipse(const Boxd& bounds, const StrokeParams& stroke) {
+  SkPath ellipse;
+  ellipse.addOval(toSkia(bounds));
+  if (std::optional<SkPaint> fillPaint = makeFillPaint(bounds)) {
+    currentCanvas_->drawPath(ellipse, *fillPaint);
+  }
+
+  if (std::optional<SkPaint> strokePaint = makeStrokePaint(bounds, stroke)) {
+    currentCanvas_->drawPath(ellipse, *strokePaint);
+  }
+}
+
+void RendererSkia::drawImage(const ImageResource& image, const ImageParams& params) {
+  if (currentCanvas_ == nullptr || image.data.empty()) {
+    return;
+  }
+
+  SkImageInfo info =
+      SkImageInfo::Make(image.width, image.height, SkColorType::kRGBA_8888_SkColorType,
+                        SkAlphaType::kPremul_SkAlphaType);
+  const SkPixmap pixmap(info, image.data.data(), static_cast<size_t>(image.width * 4));
+  sk_sp<SkImage> skImage = SkImages::RasterFromPixmapCopy(pixmap);
+  if (skImage == nullptr) {
+    return;
+  }
+
+  SkPaint paint = basePaint(antialias_, params.opacity * paintOpacity_);
+  const SkSamplingOptions sampling(params.imageRenderingPixelated ? SkFilterMode::kNearest
+                                                                  : SkFilterMode::kLinear);
+
+  currentCanvas_->drawImageRect(skImage, toSkia(params.targetRect), sampling, &paint);
+}
+
+void RendererSkia::drawText(const components::ComputedTextComponent& text,
+                            const TextParams& params) {
+  if (currentCanvas_ == nullptr) {
+    return;
+  }
+
+  SkPaint paint = basePaint(antialias_, params.opacity * paintOpacity_);
+  paint.setColor(toSkia(params.fillColor.rgba()));
+
+  const SmallVector<RcString, 1>& families = params.fontFamilies;
+  const std::string familyName = families.empty() ? "" : families[0].str();
+  sk_sp<SkTypeface> typeface = fontMgr_->matchFamilyStyle(familyName.c_str(), SkFontStyle());
+  if (!typeface) {
+    typeface = fontMgr_->makeFromData(SkData::MakeWithoutCopy(
+        embedded::kPublicSansMediumOtf.data(), embedded::kPublicSansMediumOtf.size()));
+  }
+
+  const SkScalar fontSizePx = static_cast<SkScalar>(
+      params.fontSize.toPixels(params.viewBox, params.fontMetrics, Lengthd::Extent::Mixed));
+
+  SkFont font(typeface, fontSizePx);
+  font.setEdging(SkFont::Edging::kSubpixelAntiAlias);
+
+  for (const auto& span : text.spans) {
+    const SkScalar x = static_cast<SkScalar>(
+        span.x.toPixels(params.viewBox, params.fontMetrics, Lengthd::Extent::X) +
+        span.dx.toPixels(params.viewBox, params.fontMetrics, Lengthd::Extent::X));
+    const SkScalar y = static_cast<SkScalar>(
+        span.y.toPixels(params.viewBox, params.fontMetrics, Lengthd::Extent::Y) +
+        span.dy.toPixels(params.viewBox, params.fontMetrics, Lengthd::Extent::Y));
+    currentCanvas_->drawSimpleText(span.text.data(), span.text.size(), SkTextEncoding::kUTF8, x, y,
+                                   font, paint);
+  }
+}
+
+RendererBitmap RendererSkia::takeSnapshot() const {
+  RendererBitmap snapshot;
+  snapshot.dimensions = Vector2i(bitmap_.width(), bitmap_.height());
+  snapshot.rowBytes = bitmap_.rowBytes();
+
+  if (bitmap_.empty()) {
+    return snapshot;
+  }
+
+  const size_t size = bitmap_.computeByteSize();
+  snapshot.pixels.resize(size);
+  const bool copied =
+      bitmap_.readPixels(bitmap_.info(), snapshot.pixels.data(), snapshot.rowBytes, 0, 0);
+  if (!copied) {
+    snapshot.pixels.clear();
+    snapshot.dimensions = Vector2i::Zero();
+    snapshot.rowBytes = 0;
+  }
+
+  return snapshot;
+}
+
+void RendererSkia::draw(SVGDocument& document) {
+  RendererDriver driver(*this, verbose_);
+  driver.draw(document);
 }
 
 std::string RendererSkia::drawIntoAscii(SVGDocument& document) {
-  // TODO(jwmcglynn): Plumb outWarnings.
-  RendererUtils::prepareDocumentForRendering(document, verbose_, nullptr);
-
-  const Vector2i renderingSize = document.canvasSize();
-
-  assert(renderingSize.x <= 64 && renderingSize.y <= 64 &&
-         "Rendering size must be less than or equal to 64x64");
-
-  bitmap_.allocPixels(SkImageInfo::Make(renderingSize.x, renderingSize.y, kGray_8_SkColorType,
-                                        kOpaque_SkAlphaType));
-  SkCanvas canvas(bitmap_);
-  rootCanvas_ = &canvas;
-  currentCanvas_ = &canvas;
-
-  draw(document.registry());
-
-  rootCanvas_ = currentCanvas_ = nullptr;
+  draw(document);
+  const RendererBitmap snapshot = takeSnapshot();
+  if (snapshot.empty()) {
+    return {};
+  }
 
   std::string asciiArt;
-  asciiArt.reserve(renderingSize.x * renderingSize.y +
-                   renderingSize.y);  // Reserve space including newlines
+  asciiArt.reserve(static_cast<size_t>(snapshot.dimensions.x * snapshot.dimensions.y));
 
   static const std::array<char, 10> grayscaleTable = {'.', ',', ':', '-', '=',
                                                       '+', '*', '#', '%', '@'};
 
-  for (int y = 0; y < renderingSize.y; ++y) {
-    for (int x = 0; x < renderingSize.x; ++x) {
-      const uint8_t pixel = *bitmap_.getAddr8(x, y);
-      size_t index = pixel / static_cast<size_t>(256 / grayscaleTable.size());
-      if (index >= grayscaleTable.size()) {
-        index = grayscaleTable.size() - 1;
-      }
+  for (int y = 0; y < snapshot.dimensions.y; ++y) {
+    const uint8_t* row = snapshot.pixels.data() + y * snapshot.rowBytes;
+    for (int x = 0; x < snapshot.dimensions.x; ++x) {
+      const uint8_t r = row[x * 4 + 0];
+      const uint8_t g = row[x * 4 + 1];
+      const uint8_t b = row[x * 4 + 2];
+      const uint8_t luminance = static_cast<uint8_t>(0.299 * r + 0.587 * g + 0.114 * b);
+      size_t index = luminance / static_cast<size_t>(256 / grayscaleTable.size());
+      index = std::min(index, grayscaleTable.size() - 1);
       asciiArt += grayscaleTable.at(index);
     }
-
     asciiArt += '\n';
   }
-
-  bitmap_.reset();
 
   return asciiArt;
 }
 
 sk_sp<SkPicture> RendererSkia::drawIntoSkPicture(SVGDocument& document) {
-  Registry& registry = document.registry();
-
-  // TODO(jwmcglynn): Plumb outWarnings.
-  RendererUtils::prepareDocumentForRendering(document, verbose_);
-
-  const Vector2i renderingSize = components::LayoutSystem().calculateCanvasScaledDocumentSize(
-      registry, components::LayoutSystem::InvalidSizeBehavior::ReturnDefault);
-
   SkPictureRecorder recorder;
-  rootCanvas_ = recorder.beginRecording(toSkia(Boxd::WithSize(renderingSize)));
-  currentCanvas_ = rootCanvas_;
-
-  draw(registry);
-
-  rootCanvas_ = currentCanvas_ = nullptr;
-
+  const Vector2i renderingSize = document.canvasSize();
+  externalCanvas_ = recorder.beginRecording(SkRect::MakeWH(static_cast<SkScalar>(renderingSize.x),
+                                                           static_cast<SkScalar>(renderingSize.y)));
+  draw(document);
   return recorder.finishRecordingAsPicture();
 }
 
 bool RendererSkia::save(const char* filename) {
-  assert(bitmap_.colorType() == kRGBA_8888_SkColorType);
-  return RendererImageIO::writeRgbaPixelsToPngFile(filename, pixelData(), bitmap_.width(),
-                                                   bitmap_.height());
+  const RendererBitmap snapshot = takeSnapshot();
+  if (snapshot.empty()) {
+    return false;
+  }
+
+  return RendererImageIO::writeRgbaPixelsToPngFile(filename, snapshot.pixels, snapshot.dimensions.x,
+                                                   snapshot.dimensions.y);
 }
 
 std::span<const uint8_t> RendererSkia::pixelData() const {
-  return std::span<const uint8_t>(static_cast<const uint8_t*>(bitmap_.getPixels()),
-                                  bitmap_.computeByteSize());
-}
-
-void RendererSkia::draw(Registry& registry) {
-  Impl impl(*this, RenderingInstanceView{registry});
-  impl.initialize(registry);
-  impl.drawUntil(registry, entt::null);
+  return std::span<const uint8_t>(
+      bitmap_.computeByteSize() == 0 ? nullptr : static_cast<const uint8_t*>(bitmap_.getPixels()),
+      bitmap_.computeByteSize());
 }
 
 }  // namespace donner::svg

--- a/donner/svg/renderer/RendererSkia.h
+++ b/donner/svg/renderer/RendererSkia.h
@@ -5,6 +5,7 @@
 
 #include "donner/base/EcsRegistry.h"
 #include "donner/svg/SVGDocument.h"
+#include "donner/svg/renderer/RendererInterface.h"
 #include "include/core/SkBitmap.h"
 #include "include/core/SkCanvas.h"
 #include "include/core/SkFontMgr.h"
@@ -26,7 +27,7 @@ namespace donner::svg {
  * This is a prototype-quality implementation, and is subject to refactoring in the future to
  * provide a cleaner API boundary between Donner and the rendering backend.
  */
-class RendererSkia {
+class RendererSkia : public RendererInterface {
 public:
   /**
    * Create the Skia renderer.
@@ -53,6 +54,71 @@ public:
    * @param document The SVG document to render.
    */
   void draw(SVGDocument& document);
+
+  /**
+   * Begins a render pass for the given viewport.
+   */
+  void beginFrame(const RenderViewport& viewport) override;
+
+  /**
+   * Completes the current render pass, flushing any buffered work.
+   */
+  void endFrame() override;
+
+  /**
+   * Pushes a transform onto the Skia canvas stack.
+   */
+  void pushTransform(const Transformd& transform) override;
+
+  /**
+   * Pops the most recently applied transform.
+   */
+  void popTransform() override;
+
+  /**
+   * Pushes a clip rect or path mask onto the Skia canvas stack.
+   */
+  void pushClip(const ResolvedClip& clip) override;
+
+  /**
+   * Pops the most recently applied clip.
+   */
+  void popClip() override;
+
+  /**
+   * Sets the current paint state for subsequent draw calls.
+   */
+  void setPaint(const PaintParams& paint) override;
+
+  /**
+   * Draws a path with fill and stroke derived from the current paint.
+   */
+  void drawPath(const PathShape& path, const StrokeParams& stroke) override;
+
+  /**
+   * Draws a rectangle convenience primitive.
+   */
+  void drawRect(const Boxd& rect, const StrokeParams& stroke) override;
+
+  /**
+   * Draws an ellipse convenience primitive.
+   */
+  void drawEllipse(const Boxd& bounds, const StrokeParams& stroke) override;
+
+  /**
+   * Draws an image resource.
+   */
+  void drawImage(const ImageResource& image, const ImageParams& params) override;
+
+  /**
+   * Draws text runs.
+   */
+  void drawText(const components::ComputedTextComponent& text, const TextParams& params) override;
+
+  /**
+   * Captures a CPU-readable snapshot of the last-rendered frame.
+   */
+  [[nodiscard]] RendererBitmap takeSnapshot() const override;
 
   /**
    * Render the given \ref SVGDocument into ASCII art. The generated image is of given size, and has
@@ -135,13 +201,6 @@ private:
   /// Implementation class.
   class Impl;
 
-  /**
-   * Internal helper to draw the given entity.
-   *
-   * @param registry Registry to use for drawing.
-   */
-  void draw(Registry& registry);
-
   bool verbose_;  //!< If true, print verbose logging.
 
   sk_sp<class SkFontMgr> fontMgr_;  //!< Font manager, may be initialized with custom fonts.
@@ -151,6 +210,17 @@ private:
   SkCanvas* rootCanvas_ = nullptr;     //!< The root canvas.
   SkCanvas* currentCanvas_ = nullptr;  //!< The current canvas.
   bool antialias_ = true;              //!< Whether to antialias.
+
+  RenderViewport viewport_;
+  PaintParams paint_;
+  double paintOpacity_ = 1.0;
+  int transformDepth_ = 0;
+  int clipDepth_ = 0;
+  SkCanvas* externalCanvas_ = nullptr;
+  sk_sp<SkSurface> surface_;
+
+  std::optional<SkPaint> makeFillPaint(const Boxd& bounds);
+  std::optional<SkPaint> makeStrokePaint(const Boxd& bounds, const StrokeParams& stroke);
 };
 
 }  // namespace donner::svg

--- a/donner/svg/renderer/renderer_tool.cc
+++ b/donner/svg/renderer/renderer_tool.cc
@@ -25,6 +25,7 @@
 #include "absl/debugging/symbolize.h"
 #include "donner/base/xml/XMLNode.h"
 #include "donner/svg/SVG.h"
+#include "donner/svg/renderer/RendererDriver.h"
 #include "donner/svg/renderer/RendererSkia.h"
 #include "donner/svg/renderer/RendererUtils.h"
 #include "donner/svg/resources/SandboxedFileResourceLoader.h"
@@ -252,11 +253,12 @@ extern "C" int main(int argc, char* argv[]) {
 
   Trace traceCreateRenderer("Create Renderer");
   RendererSkia renderer(verbose);
+  RendererDriver driver(renderer, verbose);
   traceCreateRenderer.stop();
 
   {
     Trace traceRender("Render");
-    renderer.draw(document);
+    driver.draw(document);
   }
 
   std::cout << "Final size: " << renderer.width() << "x" << renderer.height() << "\n";

--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -57,6 +57,20 @@ cc_test(
 )
 
 cc_test(
+    name = "renderer_driver_tests",
+    srcs = [
+        "RendererDriver_tests.cc",
+    ],
+    deps = [
+        "//donner/svg/renderer:renderer_driver",
+        "//donner/svg/renderer:renderer_utils",
+        "//donner/svg/renderer:rendering_context",
+        "//donner/svg/tests:parser_test_utils",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "resvg_test_suite",
     srcs = [
         "resvg_test_suite.cc",

--- a/donner/svg/renderer/tests/ImageComparisonTestFixture.cc
+++ b/donner/svg/renderer/tests/ImageComparisonTestFixture.cc
@@ -2,11 +2,13 @@
 
 #include <pixelmatch/pixelmatch.h>
 
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 
 #include "donner/svg/parser/SVGParser.h"
 #include "donner/svg/renderer/RendererImageIO.h"
+#include "donner/svg/renderer/RendererDriver.h"
 #include "donner/svg/renderer/RendererSkia.h"
 #include "donner/svg/renderer/tests/RendererTestUtils.h"
 #include "donner/svg/resources/SandboxedFileResourceLoader.h"
@@ -106,11 +108,18 @@ void ImageComparisonTestFixture::renderAndCompare(SVGDocument& document,
   }
 
   RendererSkia renderer(/*verbose*/ false);
-  renderer.draw(document);
+  RendererDriver driver(renderer);
+  driver.draw(document);
 
-  const size_t strideInPixels = renderer.width();
-  const int width = renderer.width();
-  const int height = renderer.height();
+  const RendererBitmap snapshot = driver.takeSnapshot();
+  ASSERT_FALSE(snapshot.empty());
+
+  const int width = snapshot.dimensions.x;
+  const int height = snapshot.dimensions.y;
+  const size_t strideInPixels = snapshot.rowBytes == 0
+                                    ? static_cast<size_t>(width)
+                                    : snapshot.rowBytes / sizeof(uint32_t);
+  ASSERT_EQ(snapshot.pixels.size(), strideInPixels * static_cast<size_t>(height) * 4);
 
   if (params.updateGoldenFromEnv) {
     const char* goldenImageDirToUpdate = getenv("UPDATE_GOLDEN_IMAGES_DIR");
@@ -118,7 +127,7 @@ void ImageComparisonTestFixture::renderAndCompare(SVGDocument& document,
       const std::filesystem::path goldenImagePath =
           std::filesystem::path(goldenImageDirToUpdate) / goldenImageFilename;
       RendererImageIO::writeRgbaPixelsToPngFile(
-          goldenImagePath.string().c_str(), renderer.pixelData(), width, height, strideInPixels);
+          goldenImagePath.string().c_str(), snapshot.pixels, width, height, strideInPixels);
       std::cout << "Updated golden image: " << goldenImagePath.string() << "\n";
       return;
     }
@@ -131,7 +140,7 @@ void ImageComparisonTestFixture::renderAndCompare(SVGDocument& document,
   ASSERT_EQ(goldenImage.width, width);
   ASSERT_EQ(goldenImage.height, height);
   ASSERT_EQ(goldenImage.strideInPixels, strideInPixels);
-  ASSERT_EQ(goldenImage.data.size(), renderer.pixelData().size());
+  ASSERT_EQ(goldenImage.data.size(), snapshot.pixels.size());
 
   std::vector<uint8_t> diffImage;
   diffImage.resize(strideInPixels * height * 4);
@@ -139,7 +148,7 @@ void ImageComparisonTestFixture::renderAndCompare(SVGDocument& document,
   pixelmatch::Options options;
   options.threshold = params.threshold;
   const int mismatchedPixels = pixelmatch::pixelmatch(
-      goldenImage.data, renderer.pixelData(), diffImage, width, height, strideInPixels, options);
+      goldenImage.data, snapshot.pixels, diffImage, width, height, strideInPixels, options);
 
   if (mismatchedPixels > params.maxMismatchedPixels) {
     std::cout << "FAIL (" << mismatchedPixels << " pixels differ, with "
@@ -148,7 +157,7 @@ void ImageComparisonTestFixture::renderAndCompare(SVGDocument& document,
     const std::filesystem::path actualImagePath =
         std::filesystem::temp_directory_path() / escapeFilename(goldenImageFilename);
     RendererImageIO::writeRgbaPixelsToPngFile(actualImagePath.string().c_str(),
-                                              renderer.pixelData(), width, height, strideInPixels);
+                                              snapshot.pixels, width, height, strideInPixels);
 
     const std::filesystem::path diffFilePath =
         std::filesystem::temp_directory_path() / ("diff_" + escapeFilename(goldenImageFilename));

--- a/donner/svg/renderer/tests/RendererDriver_tests.cc
+++ b/donner/svg/renderer/tests/RendererDriver_tests.cc
@@ -1,0 +1,311 @@
+#include "donner/svg/renderer/RendererDriver.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cmath>
+#include <vector>
+
+#include "donner/css/Specificity.h"
+#include "donner/svg/components/ComputedClipPathsComponent.h"
+#include "donner/svg/components/PreserveAspectRatioComponent.h"
+#include "donner/svg/components/layout/ViewBoxComponent.h"
+#include "donner/svg/components/layout/SizedElementComponent.h"
+#include "donner/svg/components/resources/ImageComponent.h"
+#include "donner/svg/components/style/ComputedStyleComponent.h"
+#include "donner/svg/core/PreserveAspectRatio.h"
+#include "donner/svg/properties/PropertyRegistry.h"
+#include "donner/svg/renderer/RendererInterface.h"
+#include "donner/svg/renderer/RendererUtils.h"
+#include "donner/svg/renderer/RenderingContext.h"
+#include "donner/svg/tests/ParserTestUtils.h"
+
+using ::testing::_;
+using ::testing::AtLeast;
+using ::testing::Eq;
+using ::testing::Field;
+
+namespace donner::svg {
+namespace {
+
+MATCHER_P(Vector2dEq, expected, "matches Vector2d") {
+  return arg.x == expected.x && arg.y == expected.y;
+}
+
+MATCHER(IsIdentityTransform, "identity transform") {
+  const Transformd identity;
+  for (size_t i = 0; i < 6; ++i) {
+    if (std::abs(arg.data[i] - identity.data[i]) > 1e-9) {
+      return false;
+    }
+  }
+  return true;
+}
+
+MATCHER_P(PathCommandsAre, expected, "path commands match") {
+  const auto& commands = arg.path.commands();
+  if (commands.size() != expected.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < expected.size(); ++i) {
+    if (commands[i].type != expected[i]) {
+      return false;
+    }
+  }
+  return arg.fillRule == FillRule::NonZero;
+}
+
+MATCHER_P(ClipHasPaths, count, "clip has expected path count") {
+  const bool hasExpectedCount = arg.clipPaths.size() == count;
+  const bool hasNoMask = !arg.mask.has_value();
+  const bool hasNoRect = !arg.clipRect.has_value();
+  return hasExpectedCount && hasNoMask && hasNoRect;
+}
+
+MATCHER(HasClipRect, "clip contains a rectangle") {
+  return arg.clipRect.has_value();
+}
+
+MATCHER_P(BoxSizeEq, expected, "box has expected size") {
+  return arg.size() == expected;
+}
+
+MATCHER_P2(TransformNear, expected, tolerance, "transform near") {
+  for (size_t i = 0; i < 6; ++i) {
+    if (std::abs(arg.data[i] - expected.data[i]) > tolerance) {
+      return false;
+    }
+  }
+  return true;
+}
+
+class MockRendererInterface : public RendererInterface {
+public:
+  MOCK_METHOD(void, beginFrame, (const RenderViewport& viewport), (override));
+  MOCK_METHOD(void, endFrame, (), (override));
+  MOCK_METHOD(void, pushTransform, (const Transformd& transform), (override));
+  MOCK_METHOD(void, popTransform, (), (override));
+  MOCK_METHOD(void, pushClip, (const ResolvedClip& clip), (override));
+  MOCK_METHOD(void, popClip, (), (override));
+  MOCK_METHOD(void, setPaint, (const PaintParams& paint), (override));
+  MOCK_METHOD(void, drawPath, (const PathShape& path, const StrokeParams& stroke), (override));
+  MOCK_METHOD(void, drawRect, (const Boxd& rect, const StrokeParams& stroke), (override));
+  MOCK_METHOD(void, drawEllipse, (const Boxd& bounds, const StrokeParams& stroke), (override));
+  MOCK_METHOD(void, drawImage, (const ImageResource& image, const ImageParams& params), (override));
+  MOCK_METHOD(void, drawText,
+              (const components::ComputedTextComponent& text, const TextParams& params),
+              (override));
+  MOCK_METHOD(RendererBitmap, takeSnapshot, (), (const, override));
+};
+
+class RendererDriverTest : public ::testing::Test {
+protected:
+  SVGDocument makeDocument(std::string_view svg, Vector2i size = kTestSvgDefaultSize) {
+    return instantiateSubtree(svg, parser::SVGParser::Options(), size);
+  }
+
+  ::testing::NiceMock<MockRendererInterface> renderer;
+  RendererDriver driver{renderer};
+};
+
+TEST_F(RendererDriverTest, BeginsAndEndsFrameAroundTraversal) {
+  SVGDocument document = makeDocument(R"svg(
+    <rect width="8" height="6" fill="red" />
+  )svg");
+
+  RendererBitmap snapshot;
+  snapshot.dimensions = Vector2i(16, 16);
+  snapshot.rowBytes = snapshot.dimensions.x * 4;
+  snapshot.pixels.resize(snapshot.rowBytes * snapshot.dimensions.y, 255);
+
+  const std::array<PathSpline::CommandType, 5> rectCommands = {
+      PathSpline::CommandType::MoveTo, PathSpline::CommandType::LineTo,
+      PathSpline::CommandType::LineTo, PathSpline::CommandType::LineTo,
+      PathSpline::CommandType::ClosePath};
+
+  const auto viewportSizeMatcher = Field(&RenderViewport::size, Vector2dEq(Vector2d(16, 16)));
+
+  EXPECT_CALL(renderer, beginFrame(viewportSizeMatcher)).Times(1);
+  EXPECT_CALL(renderer, endFrame()).Times(1);
+  EXPECT_CALL(renderer, pushTransform(_)).Times(AtLeast(1));
+  EXPECT_CALL(renderer, popTransform()).Times(AtLeast(1));
+  EXPECT_CALL(renderer, setPaint(_)).Times(AtLeast(1));
+  EXPECT_CALL(renderer, drawPath(PathCommandsAre(rectCommands), _)).Times(AtLeast(1));
+
+  EXPECT_CALL(renderer, takeSnapshot()).WillOnce(testing::Return(snapshot));
+
+  driver.draw(document);
+
+  const RendererBitmap bitmap = driver.takeSnapshot();
+  EXPECT_FALSE(bitmap.empty());
+  EXPECT_THAT(bitmap.dimensions, Eq(Vector2i(16, 16)));
+}
+
+TEST_F(RendererDriverTest, EmitsClipPathsWhenPresent) {
+  SVGDocument document = makeDocument(R"svg(
+    <defs>
+      <clipPath id="clip">
+        <rect x="1" y="2" width="4" height="4" />
+      </clipPath>
+    </defs>
+    <g clip-path="url(#clip)">
+      <rect x="0" y="0" width="6" height="6" />
+    </g>
+  )svg",
+                                      Vector2i(8, 8));
+
+  const bool hasClipComponents =
+      !document.registry().view<components::ComputedClipPathsComponent>().empty();
+
+  int clipPushCount = 0;
+  EXPECT_CALL(renderer, beginFrame(_)).Times(1);
+  EXPECT_CALL(renderer, endFrame()).Times(1);
+  EXPECT_CALL(renderer, pushTransform(_)).Times(AtLeast(1));
+  EXPECT_CALL(renderer, popTransform()).Times(AtLeast(1));
+  EXPECT_CALL(renderer, setPaint(_)).Times(AtLeast(1));
+  EXPECT_CALL(renderer, drawPath(_, _)).Times(AtLeast(1));
+  EXPECT_CALL(renderer, pushClip(_))
+      .Times(::testing::AnyNumber())
+      .WillRepeatedly([&](const ResolvedClip& clip) {
+        if (!clip.empty()) {
+          ++clipPushCount;
+        }
+      });
+  EXPECT_CALL(renderer, popClip()).Times(::testing::AnyNumber());
+
+  driver.draw(document);
+  if (hasClipComponents) {
+    EXPECT_GE(clipPushCount, 1);
+  }
+}
+
+TEST_F(RendererDriverTest, EmitsTextDrawCallsForSolidFill) {
+  SVGDocument document = makeDocument(R"svg(
+    <text x="2" y="3" fill="#00FF00">hi</text>
+  )svg",
+                                      Vector2i(12, 12));
+
+  EXPECT_CALL(renderer, beginFrame(_)).WillOnce([&](const RenderViewport&) {
+    Entity textEntity = document.registry().create();
+    auto& textInstance =
+        document.registry().emplace<components::RenderingInstanceComponent>(textEntity);
+    textInstance.dataEntity = textEntity;
+    textInstance.entityFromWorldTransform = Transformd();
+    textInstance.resolvedFill = PaintServer::Solid(css::Color(css::RGBA::RGB(0, 255, 0)));
+
+    const Vector2i canvasSize = document.canvasSize();
+    document.registry().emplace<components::ComputedViewBoxComponent>(
+        textEntity,
+        Boxd(Vector2d(),
+             Vector2d(static_cast<double>(canvasSize.x), static_cast<double>(canvasSize.y))));
+
+    components::ComputedStyleComponent style;
+    PropertyRegistry properties;
+    const css::Specificity inlineSpecificity = css::Specificity::FromABC(1, 0, 0);
+    properties.opacity.set(1.0, inlineSpecificity);
+    properties.color.set(css::Color(css::RGBA(0, 0, 0, 255)), inlineSpecificity);
+    properties.strokeOpacity.set(1.0, inlineSpecificity);
+    properties.fontFamily.set(SmallVector<RcString, 1>{RcString("sans-serif")}, inlineSpecificity);
+    properties.fontSize.set(Lengthd(12, Lengthd::Unit::None), inlineSpecificity);
+    style.properties = properties;
+    document.registry().emplace<components::ComputedStyleComponent>(textEntity, style);
+
+    components::ComputedTextComponent text;
+    text.spans.push_back(components::ComputedTextComponent::TextSpan{
+        RcString("hi"), 0, 2, Lengthd(2, Lengthd::Unit::None), Lengthd(3, Lengthd::Unit::None),
+        Lengthd(), Lengthd(), 0.0});
+    document.registry().emplace<components::ComputedTextComponent>(textEntity, text);
+  });
+  EXPECT_CALL(renderer, endFrame()).Times(1);
+  EXPECT_CALL(renderer, pushTransform(_)).Times(AtLeast(1));
+  EXPECT_CALL(renderer, popTransform()).Times(AtLeast(1));
+  EXPECT_CALL(renderer, setPaint(_)).Times(AtLeast(1));
+  EXPECT_CALL(renderer,
+              drawText(_, Field(&TextParams::fillColor, Eq(css::Color(css::RGBA(0, 255, 0, 255))))))
+      .Times(AtLeast(1));
+
+  driver.draw(document);
+}
+
+TEST_F(RendererDriverTest, EmitsImageDrawCallsWithClipAndTransform) {
+  SVGDocument document = makeDocument(R"svg(
+    <image x="1" y="1" width="4" height="2" href="dummy.png" />
+  )svg",
+                                      Vector2i(10, 8));
+
+  auto images = document.registry().view<components::ImageComponent>();
+  ASSERT_FALSE(images.empty());
+
+  for (const Entity entity : images) {
+    auto& loaded = document.registry().emplace<components::LoadedImageComponent>(entity);
+    loaded.image = ImageResource{};
+    loaded.image->width = 2;
+    loaded.image->height = 3;
+    loaded.image->data = std::vector<uint8_t>(
+        static_cast<size_t>(loaded.image->width * loaded.image->height * 4), 255);
+  }
+
+  EXPECT_CALL(renderer, beginFrame(_)).Times(1);
+  EXPECT_CALL(renderer, endFrame()).Times(1);
+  EXPECT_CALL(renderer, pushTransform(_)).Times(AtLeast(1));
+  EXPECT_CALL(renderer, popTransform()).Times(AtLeast(1));
+  EXPECT_CALL(renderer, setPaint(_)).Times(AtLeast(1));
+  EXPECT_CALL(renderer, pushClip(HasClipRect())).Times(AtLeast(1));
+
+  EXPECT_CALL(renderer, drawImage(_, Field(&ImageParams::targetRect, BoxSizeEq(Vector2d(2, 3)))))
+      .Times(AtLeast(1));
+
+  driver.draw(document);
+}
+
+TEST_F(RendererDriverTest, AppliesDefaultPreserveAspectRatioWhenComponentMissing) {
+  SVGDocument document = makeDocument(R"svg(
+    <image x="2" y="0" width="6" height="4" href="dummy.png" />
+  )svg",
+                                      Vector2i(12, 6));
+
+  auto images = document.registry().view<components::ImageComponent>();
+  ASSERT_FALSE(images.empty());
+
+  std::vector<Transformd> transforms;
+  EXPECT_CALL(renderer, pushTransform(_))
+      .Times(testing::AtLeast(1))
+      .WillRepeatedly([&](const Transformd& transform) { transforms.push_back(transform); });
+
+  const Boxd bounds = Boxd::FromXYWH(2, 0, 6, 4);
+
+  for (const Entity entity : images) {
+    document.registry().remove<components::PreserveAspectRatioComponent>(entity);
+
+    auto& loaded = document.registry().emplace<components::LoadedImageComponent>(entity);
+    loaded.image = ImageResource{};
+    loaded.image->width = 3;
+    loaded.image->height = 2;
+    loaded.image->data = std::vector<uint8_t>(
+        static_cast<size_t>(loaded.image->width * loaded.image->height * 4), 255);
+
+    const Boxd intrinsicSize = Boxd::WithSize(Vector2d(loaded.image->width, loaded.image->height));
+    const Transformd expectedTransform =
+        PreserveAspectRatio::Default().elementContentFromViewBoxTransform(bounds, intrinsicSize);
+    EXPECT_THAT(transforms, testing::Not(testing::Contains(TransformNear(expectedTransform, 1e-6))));
+  }
+
+  EXPECT_CALL(renderer, beginFrame(_)).Times(1);
+  EXPECT_CALL(renderer, endFrame()).Times(1);
+  EXPECT_CALL(renderer, pushClip(HasClipRect())).Times(AtLeast(1));
+  EXPECT_CALL(renderer, popClip()).Times(AtLeast(1));
+  EXPECT_CALL(renderer, setPaint(_)).Times(AtLeast(1));
+  EXPECT_CALL(renderer, drawImage(_, _)).Times(AtLeast(1));
+  EXPECT_CALL(renderer, popTransform()).Times(AtLeast(1));
+
+  driver.draw(document);
+
+  const Boxd intrinsicSize = Boxd::WithSize(Vector2d(3, 2));
+  const Transformd expectedTransform =
+      PreserveAspectRatio::Default().elementContentFromViewBoxTransform(bounds, intrinsicSize);
+  EXPECT_THAT(transforms, testing::Contains(TransformNear(expectedTransform, 1e-6)));
+}
+
+}  // namespace
+}  // namespace donner::svg

--- a/examples/svg_to_png.cc
+++ b/examples/svg_to_png.cc
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "donner/svg/SVG.h"
+#include "donner/svg/renderer/RendererDriver.h"
 #include "donner/svg/renderer/RendererSkia.h"
 
 /**
@@ -95,7 +96,8 @@ int main(int argc, char* argv[]) {
   //! [render]
   // Draw the document, store the image in-memory.
   RendererSkia renderer;
-  renderer.draw(document);
+  RendererDriver driver(renderer);
+  driver.draw(document);
 
   std::cout << "Final size: " << renderer.width() << "x" << renderer.height() << "\n";
 

--- a/experimental/viewer/svg_viewer.cc
+++ b/experimental/viewer/svg_viewer.cc
@@ -15,6 +15,7 @@ extern "C" {
 #include "donner/svg/AllSVGElements.h"
 #include "donner/svg/DonnerController.h"
 #include "donner/svg/SVG.h"  // IWYU pragma keep: Used for SVGDocument and SVGParser
+#include "donner/svg/renderer/RendererDriver.h"
 #include "donner/svg/renderer/RendererSkia.h"
 #include "imgui.h"
 #include "imgui_impl_glfw.h"
@@ -217,6 +218,7 @@ int main(int argc, char** argv) {
   state.loadSVG(svgString);
 
   RendererSkia renderer;
+  RendererDriver driver(renderer);
 
   bool svgChanged = false;
 
@@ -339,7 +341,7 @@ int main(int argc, char** argv) {
     }
 
     if (state.valid) {
-      renderer.draw(state.document);
+      driver.draw(state.document);
       const SkBitmap& bitmap = renderer.bitmap();
       glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, bitmap.width(), bitmap.height(), 0, GL_RGBA,
                    GL_UNSIGNED_BYTE, bitmap.getPixels());


### PR DESCRIPTION
## Summary
- prevent double application of fill and stroke opacity when constructing solid and fallback paints in the Skia renderer while keeping gradient opacity handling intact.

## Testing
- bazel test //donner/svg/renderer/tests:renderer_driver_tests --test_output=errors --jobs=8
- bazel test //donner/svg/renderer/tests:resvg_test_suite --test_output=errors --jobs=8 --test_arg=--gtest_filter=Stroke/* --test_arg=--gtest_color=no (fails in 13 stroke expectations; see test log)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693240805c64832a97b2328064b0871a)