### PR TITLE
Fix devcontainer JSONC trailing commas for template prebuild

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,8 +32,8 @@
         "matepek.vscode-catch2-test-adapter",
         "ms-vscode.cpptools",
         "vadimcn.vscode-lldb"
-      ],
-    },
+      ]
+    }
   },
   // Connect as non-root user.
   "remoteUser": "vscode",


### PR DESCRIPTION
### Motivation
- The `.devcontainer/devcontainer.json` template creation step in the `.devcontainer/devcontainer.json` workflow failed during CI because trailing commas in the JSONC made the template parsing strict check fail.

### Description
- Remove trailing commas in `.devcontainer/devcontainer.json` (after the `extensions` array and the `vscode` object) while preserving comments so the file remains JSONC but is parseable by stricter template tooling.

### Testing
- Ran a lightweight validation pipeline consisting of a JSON parse (comments stripped) using `python3` and a trailing-comma search with `rg -n ',\s*[}\]]' .devcontainer/devcontainer.json`, both of which succeeded (no parse errors and no trailing-comma matches).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d15a4b0894832aa5c1fd705d91c8c9)