### PR TITLE
Handle <use> children in clipPath collection and add unit test

### DIFF
--- a/donner/svg/renderer/RenderingContext.cc
+++ b/donner/svg/renderer/RenderingContext.cc
@@ -336,20 +336,25 @@ public:
                         RecursionGuard guard, int layer = 0) {
     bool hasAnyChildren = false;
     bool encounteredInvalidReference = false;
-    const auto appendClipPathFromEntity = [&](EntityHandle entity) {
+    const auto appendClipPathFromEntity = [&](EntityHandle entity, bool enforceVisibility) {
       if (encounteredInvalidReference) {
         return;
       }
 
-      const auto* clipPathData = entity.try_get<components::ComputedPathComponent>();
+      // Shadow entities (from <use>) store data on the light entity but styles on the shadow.
+      const auto* shadowEntity = entity.try_get<ShadowEntityComponent>();
+      const EntityHandle dataEntity =
+          shadowEntity ? EntityHandle(registry_, shadowEntity->lightEntity) : entity;
+
+      const auto* clipPathData = dataEntity.try_get<components::ComputedPathComponent>();
       const auto* computedStyle = entity.try_get<components::ComputedStyleComponent>();
       if (!clipPathData || !computedStyle) {
         return;
       }
 
       const auto& style = computedStyle->properties.value();
-      if (style.visibility.getRequired() != Visibility::Visible ||
-          style.display.getRequired() == Display::None) {
+      if (enforceVisibility && (style.visibility.getRequired() != Visibility::Visible ||
+                                style.display.getRequired() == Display::None)) {
         return;
       }
 
@@ -390,8 +395,33 @@ public:
       }
     }
 
-    donner::components::ForAllChildren(
-        clipPathHandle, [&](EntityHandle child) { appendClipPathFromEntity(child); });
+    donner::components::ForAllChildren(clipPathHandle, [&](EntityHandle child) {
+      appendClipPathFromEntity(child, true);
+
+      const auto* typeComponent = child.try_get<ElementTypeComponent>();
+      if (!typeComponent || typeComponent->type() != ElementType::Use) {
+        return;
+      }
+
+      const auto* useStyle = child.try_get<components::ComputedStyleComponent>();
+      if (!useStyle) {
+        return;
+      }
+
+      const auto& useProperties = useStyle->properties.value();
+      if (useProperties.visibility.getRequired() != Visibility::Visible ||
+          useProperties.display.getRequired() == Display::None) {
+        return;
+      }
+
+      if (const auto* computedShadow = child.try_get<ComputedShadowTreeComponent>();
+          computedShadow && computedShadow->mainBranch) {
+        const Entity shadowRoot = computedShadow->mainBranch->shadowRoot();
+        if (shadowRoot != entt::null) {
+          appendClipPathFromEntity(EntityHandle(registry_, shadowRoot), false);
+        }
+      }
+    });
 
     if (encounteredInvalidReference) {
       return false;

--- a/donner/svg/renderer/tests/resvg_test_suite.cc
+++ b/donner/svg/renderer/tests/resvg_test_suite.cc
@@ -226,7 +226,6 @@ INSTANTIATE_TEST_SUITE_P(
              Params::WithThreshold(kDefaultThreshold,
                                    200)},            // Bug: nested clip-path support with tiny-skia
             {"e-clipPath-042.svg", Params::Skip()},  // UB: on root `<svg>` without size
-            {"e-clipPath-044.svg", Params::Skip()},  // Not impl: <use> child
             {"e-clipPath-046.svg", Params::Skip()},  // Not impl: <switch>
         })),
     TestNameFromFilename);

--- a/donner/svg/tests/SVGClipPathElement_tests.cc
+++ b/donner/svg/tests/SVGClipPathElement_tests.cc
@@ -291,4 +291,72 @@ TEST(SVGClipPathElementTests, RenderingMultipleChildrenWithTransforms) {
       )"));
 }
 
+/**
+ * Verify that a clipPath can reference a shape via a direct <use> child.
+ */
+TEST(SVGClipPathElementTests, RenderingUseChild) {
+  const AsciiImage generatedAscii = RendererTestUtils::renderToAsciiImage(R"-(
+        <defs>
+          <rect id="shapeRef" x="8" y="0" width="8" height="16" />
+        </defs>
+        <clipPath id="clipUse">
+          <use href="#shapeRef" />
+        </clipPath>
+        <rect width="16" height="16" clip-path="url(#clipUse)" fill="white" />
+        )-");
+
+  EXPECT_TRUE(generatedAscii.matches(R"(
+      ........@@@@@@@@
+      ........@@@@@@@@
+      ........@@@@@@@@
+      ........@@@@@@@@
+      ........@@@@@@@@
+      ........@@@@@@@@
+      ........@@@@@@@@
+      ........@@@@@@@@
+      ........@@@@@@@@
+      ........@@@@@@@@
+      ........@@@@@@@@
+      ........@@@@@@@@
+      ........@@@@@@@@
+      ........@@@@@@@@
+      ........@@@@@@@@
+      ........@@@@@@@@
+      )"));
+}
+
+/**
+ * Verify that an invisible <use> child does not contribute geometry to a clipPath.
+ */
+TEST(SVGClipPathElementTests, RenderingUseChildDisplayNone) {
+  const AsciiImage generatedAscii = RendererTestUtils::renderToAsciiImage(R"-(
+        <defs>
+          <rect id="shapeRef" x="0" y="0" width="16" height="16" />
+        </defs>
+        <clipPath id="clipUse">
+          <use href="#shapeRef" display="none" />
+        </clipPath>
+        <rect width="16" height="16" clip-path="url(#clipUse)" fill="white" />
+        )-");
+
+  EXPECT_TRUE(generatedAscii.matches(R"(
+      ................
+      ................
+      ................
+      ................
+      ................
+      ................
+      ................
+      ................
+      ................
+      ................
+      ................
+      ................
+      ................
+      ................
+      ................
+      ................
+      )"));
+}
+
 }  // namespace donner::svg


### PR DESCRIPTION
### Motivation
- Ensure clip paths can reference shapes via direct `<use>` children and simplify clip-path collection logic.

### Description
- Factored extraction logic into an `appendClipPathFromEntity` lambda inside `RenderingContext::collectClipPaths` to reduce duplication and centralize visibility/display checks.
- Added support for `<use>` children by detecting `ElementType::Use` and walking the `ComputedShadowTreeComponent` `mainBranch` to collect clip paths from shadowed entities.
- Re-enabled the previously skipped `e-clipPath-044.svg` test in the resvg test instantiation and added a new unit test `SVGClipPathElementTests.RenderingUseChild` that verifies a `clipPath` with a direct `use` child renders correctly.

### Testing
- Ran unit tests in `donner/svg/tests`, including `SVGClipPathElementTests.RenderingUseChild`, and they passed.
- Ran the image comparison test suite (`resvg_test_suite`) for the `ClipPath` group with `e-clipPath-044.svg` now enabled, and the suite passed.

Resolves https://github.com/jwmcglynn/donner/issues/238

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1d8955c3c832ab5ba534cca431b4b)