### PR TITLE
BCR prep: isolate non-BCR deps behind dev-only module extension

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -41,6 +41,13 @@ build --copt=-Wno-switch-default
 # Use registered clang toolchain.
 build --incompatible_enable_cc_toolchain_resolution
 
+# Enable the resvg-test-suite-dependent internal tests unconditionally for
+# local dev and CI. The flag defaults to False in the BUILD file so that
+# downstream consumers (who pull Donner via BCR and do NOT read this
+# .bazelrc) cleanly skip those tests instead of failing to resolve
+# @resvg-test-suite, which lives in the dev-only non_bcr_deps extension.
+common --//donner/svg/renderer:resvg_test_suite_available=true
+
 # Enable building with the latest llvm toolchain (downloaded on-demand, see MODULE.bazel)
 common:latest_llvm --extra_toolchains=@llvm_toolchain//:all
 common:latest_llvm --//build_defs:llvm_latest=1

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,7 +14,6 @@ use_repo(donner, "donner_config")
 local_repository = use_repo_rule("//third_party:bazel/local.bzl", "local_repository")
 new_local_repository = use_repo_rule("//third_party:bazel/local.bzl", "new_local_repository")
 git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-new_git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 
 # Build dependencies
 bazel_dep(name = "apple_support", version = "2.5.2", repo_name = "build_bazel_apple_support")  # Must be before rules_cc
@@ -25,6 +24,32 @@ bazel_dep(name = "platforms", version = "1.0.0")
 
 # rules_foreign_cc is used to wrap CMake-based third-party projects (Dawn/WebGPU).
 bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
+
+##
+## Non-BCR dependencies (dev-only extension)
+##
+# skia, harfbuzz, woff2, dawn, resvg-test-suite, and bazel_clang_tidy all live
+# behind `git_repository`/`new_git_repository` calls that are not permitted in
+# modules published to the Bazel Central Registry. We hide them behind a
+# module extension flagged `dev_dependency = True`, so downstream BCR consumers
+# never see them. When donner is the root module (local dev or CI), the
+# extension runs and fetches everything exactly as before.
+#
+# Every target in donner that references one of these repos MUST be behind a
+# `target_compatible_with` guard on the corresponding config_setting, so that
+# BCR consumers doing `bazel build @donner//...` simply skip those targets
+# rather than failing to resolve the missing repos. See
+# third_party/bazel/non_bcr_deps.bzl for the list.
+non_bcr_deps = use_extension("//third_party:bazel/non_bcr_deps.bzl", "non_bcr_deps", dev_dependency = True)
+use_repo(
+    non_bcr_deps,
+    "bazel_clang_tidy",
+    "dawn",
+    "harfbuzz",
+    "resvg-test-suite",
+    "skia",
+    "woff2",
+)
 
 ##
 ## Third-party dependencies
@@ -43,16 +68,6 @@ local_repository(
     name = "skia_user_config",
     path = "third_party/skia_user_config",
 )
-
-git_repository(
-    name = "skia",
-    commit = "d945cbcbbb5834245256e883803c2704f3a32e18",
-    remote = "https://github.com/google/skia",
-)
-
-bazel_deps = use_repo_rule("@skia//bazel:deps.bzl", "bazel_deps")
-c_plus_plus_deps = use_repo_rule("@skia//bazel:deps.bzl", "c_plus_plus_deps")
-header_based_configs = use_repo_rule("@skia//bazel:deps.bzl", "header_based_configs")
 
 bazel_dep(name = "freetype", version = "2.13.3.bcr.1")
 bazel_dep(name = "libpng", version = "1.6.54")
@@ -87,39 +102,8 @@ new_local_repository(
 
 bazel_dep(name = "zlib", version = "1.3.2")
 
-# WOFF2 text support (gated by text_full flag)
+# brotli is required by @woff2 (see non_bcr_deps.bzl); text-full only.
 bazel_dep(name = "brotli", version = "1.2.0")
-
-new_git_repository(
-    name = "woff2",
-    build_file = "//third_party:BUILD.woff2",
-    commit = "1f184d05566b3e25827a1f8e68eb82b9ccf54f3b",
-    remote = "https://github.com/google/woff2.git",
-)
-
-# HarfBuzz text shaping (gated by text_full flag)
-new_git_repository(
-    name = "harfbuzz",
-    build_file = "//third_party:BUILD.harfbuzz",
-    tag = "14.1.0",
-    remote = "https://github.com/harfbuzz/harfbuzz.git",
-    patch_cmds = [
-        # Create config-override.h to re-enable the draw API (disabled by HB_LEAN/HB_TINY).
-        # We need hb_font_draw_glyph() for glyph outline extraction.
-        """cat > src/config-override.h << 'HBEOF'
-// Re-enable the draw API for glyph outline extraction.
-// HB_TINY -> HB_LEAN -> HB_NO_DRAW -> HB_NO_OUTLINE, which strips these.
-#undef HB_NO_DRAW
-#undef HB_NO_OUTLINE
-// Re-enable CFF outlines (our fallback font Public Sans is OTF/CFF).
-#undef HB_NO_CFF
-#undef HB_NO_OT_FONT_CFF
-// Re-enable file I/O (hb_face_create_from_file_or_fail references
-// hb_blob_create_from_file_or_fail which is guarded by HB_NO_OPEN).
-#undef HB_NO_OPEN
-HBEOF""",
-    ],
-)
 
 ##
 ## Test dependencies
@@ -141,45 +125,8 @@ new_local_repository(
     path = "third_party/css-parsing-tests",
 )
 
-new_git_repository(
-    name = "resvg-test-suite",
-    build_file = "//third_party:BUILD.resvg-test-suite",
-    commit = "682a9c8da8c580ad59cba0ef8cb8a8fd5534022f",
-    remote = "https://github.com/RazrFalcon/resvg-test-suite.git",
-)
-
-# Dawn (WebGPU implementation) for the Geode GPU renderer.
-# Only fetched when --//donner/svg/renderer/geode:enable_dawn=true.
-# `patch_cmds` runs `fetch_dawn_dependencies.py` at repository fetch time
-# (which has network access) to populate third_party/ submodules, so the
-# downstream CMake build can run with DAWN_FETCH_DEPENDENCIES=OFF inside
-# Bazel's sandbox.
-new_git_repository(
-    name = "dawn",
-    build_file = "//third_party:BUILD.dawn",
-    # Pinned to a specific commit for reproducibility. Bump deliberately.
-    # From v20260403.135149 (2026-04-03).
-    commit = "fa93dacdf3931ec29ff8f42facf51db632c45308",
-    remote = "https://dawn.googlesource.com/dawn",
-    patch_cmds = [
-        "python3 tools/fetch_dawn_dependencies.py",
-        # Strip nested .git directories so Bazel's file tracking sees the
-        # submodule contents as regular source files.
-        "find third_party -name .git -type d -exec rm -rf {} + 2>/dev/null || true",
-        # Strip nested BUILD.bazel/BUILD/WORKSPACE files throughout the tree.
-        # Otherwise they create Bazel package boundaries and glob(['**']) stops
-        # recursing, leaving CMake unable to find many source subdirectories.
-        # Dawn has ~114 BUILD.bazel files under src/tint alone (Tint's upstream
-        # Bazel support for WGSL parsing), plus more in third_party submodules.
-        # The root BUILD file is provided by our overlay so the top-level one
-        # is not needed.
-        "find . -mindepth 2 \\( -name BUILD.bazel -o -name BUILD -o -name WORKSPACE -o -name WORKSPACE.bazel -o -name MODULE.bazel \\) -type f -delete 2>/dev/null || true",
-        # Remove the top-level WORKSPACE/MODULE files that Dawn ships with.
-        # (Keep our BUILD.bazel overlay which is placed at the root by Bazel's
-        # new_git_repository build_file attribute — don't remove that one.)
-        "rm -f WORKSPACE WORKSPACE.bazel MODULE.bazel",
-    ],
-)
+# resvg-test-suite and dawn are fetched via the non_bcr_deps module extension
+# declared above — they are not available when donner is consumed from BCR.
 
 bazel_dep(name = "rules_python", version = "1.9.0", dev_dependency = True)
 
@@ -220,12 +167,6 @@ git_override(
     module_name = "hedron_compile_commands",
     remote = "https://github.com/hedronvision/bazel-compile-commands-extractor",
     commit = "abb61a688167623088f8768cc9264798df6a9d10",
-)
-
-git_repository(
-    name = "bazel_clang_tidy",
-    commit = "c4d35e0d0b838309358e57a2efed831780f85cd0",
-    remote = "https://github.com/erenon/bazel_clang_tidy.git",
 )
 
 bazel_dep(name = "rules_proto", version = "7.1.0", dev_dependency = True)

--- a/donner/base/fonts/BUILD.bazel
+++ b/donner/base/fonts/BUILD.bazel
@@ -36,10 +36,19 @@ donner_cc_test(
     ],
 )
 
+# woff2_parser is only used from the text-full path
+# (donner/svg/resources/BUILD.bazel selects it under :text_full_enabled).
+# Gate the target itself so its @woff2 dep is only resolved when text_full is
+# enabled — this is a prerequisite for BCR consumers, where @woff2 is not
+# declared (it lives in the dev-only non_bcr_deps module extension).
 donner_cc_library(
     name = "woff2_parser",
     srcs = ["Woff2Parser.cc"],
     hdrs = ["Woff2Parser.h"],
+    target_compatible_with = select({
+        "//donner/svg/renderer:text_full_enabled": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     visibility = donner_internal_visibility(),
     deps = [
         "//donner/base",
@@ -51,6 +60,10 @@ donner_cc_test(
     name = "woff2_parser_tests",
     srcs = ["tests/Woff2Parser_tests.cc"],
     data = ["testdata/valid-001.woff2"],
+    target_compatible_with = select({
+        "//donner/svg/renderer:text_full_enabled": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     deps = [
         ":woff2_parser",
         "//donner/base:base_test_utils",

--- a/donner/svg/renderer/BUILD.bazel
+++ b/donner/svg/renderer/BUILD.bazel
@@ -43,6 +43,21 @@ bool_flag(
     visibility = ["//visibility:public"],
 )
 
+# Gate targets that read `@resvg-test-suite` at analysis/runtime.
+#
+# The upstream repo is fetched only for local development / CI (via the
+# non_bcr_deps dev module extension), and is not available when Donner is
+# consumed as a dep from BCR. Defaults to False so BCR consumers' broad
+# `bazel build @donner//...` cleanly skips those tests instead of failing
+# to resolve `@resvg-test-suite`. Donner's own `.bazelrc` sets this to
+# True unconditionally so local dev and CI continue to build/run the
+# tests exactly as before.
+bool_flag(
+    name = "resvg_test_suite_available",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
 config_setting(
     name = "renderer_backend_skia",
     flag_values = {":renderer_backend": "skia"},
@@ -89,6 +104,12 @@ config_setting(
 config_setting(
     name = "config_skia_debug",
     flag_values = {":skia_debug": "true"},
+)
+
+config_setting(
+    name = "resvg_test_suite_enabled",
+    flag_values = {":resvg_test_suite_available": "True"},
+    visibility = ["//visibility:public"],
 )
 
 donner_cc_library(

--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -175,6 +175,10 @@ donner_cc_test(
     data = [
         "@resvg-test-suite//:fonts",
     ],
+    target_compatible_with = select({
+        "//donner/svg/renderer:resvg_test_suite_enabled": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     deps = [
         "//donner/base:base_test_utils",
         "//donner/svg/text:text_backend_full",
@@ -204,6 +208,10 @@ donner_cc_test(
     data = [
         "@resvg-test-suite//:fonts",
     ],
+    target_compatible_with = select({
+        "//donner/svg/renderer:resvg_test_suite_enabled": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     deps = [
         "//donner/base:base_test_utils",
         "//donner/svg/text:text_backend",
@@ -241,6 +249,10 @@ donner_cc_test(
         "@resvg-test-suite//:svg",
     ],
     shard_count = 16,
+    target_compatible_with = select({
+        "//donner/svg/renderer:resvg_test_suite_enabled": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     deps = [
         ":image_comparison_test_fixture",
         "//donner/base:base_test_utils",

--- a/donner/svg/text/BUILD.bazel
+++ b/donner/svg/text/BUILD.bazel
@@ -77,10 +77,19 @@ donner_cc_library(
     }),
 )
 
+# text_backend_full is only pulled in from text_engine via a select() on
+# :text_full_enabled. Gate the target itself so its @harfbuzz dep is only
+# resolved when text_full is enabled — required for BCR consumers, where
+# @harfbuzz is not declared (it lives in the dev-only non_bcr_deps module
+# extension).
 donner_cc_library(
     name = "text_backend_full",
     srcs = ["TextBackendFull.cc"],
     hdrs = ["TextBackendFull.h"],
+    target_compatible_with = select({
+        "//donner/svg/renderer:text_full_enabled": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     visibility = ["//donner/svg:__subpackages__"],
     deps = [
         ":text_backend",

--- a/third_party/BUILD.bazel
+++ b/third_party/BUILD.bazel
@@ -6,6 +6,10 @@ exports_files(
         "BUILD.cmark-gfm",
         "BUILD.css-parsing-tests",
         "BUILD.stb",
+        # tools/cmake/gen_cmakelists.py reads this at runtime to discover the
+        # versions of deps that are hidden from BCR consumers behind a
+        # dev_dependency module extension.
+        "bazel/non_bcr_deps.bzl",
     ],
 )
 

--- a/third_party/bazel/non_bcr_deps.bzl
+++ b/third_party/bazel/non_bcr_deps.bzl
@@ -1,0 +1,129 @@
+"""Module extension for non-BCR dependencies.
+
+These repos are fetched only when donner is the root module (i.e. local
+development or CI), not when donner is consumed as a dependency from the
+Bazel Central Registry. The extension is imported from //MODULE.bazel with
+`dev_dependency = True`, so downstream BCR consumers never see these repos.
+
+Each dep listed here is load-bearing for a feature that is opt-in and NOT
+shipped over BCR:
+
+- skia            : Skia renderer backend       (--config=skia)
+- harfbuzz        : Text shaping                (--config=text-full)
+- woff2           : WOFF2 font format           (--config=text-full)
+- dawn            : WebGPU (Geode renderer)     (--//donner/svg/renderer/geode:enable_dawn=true)
+- resvg-test-suite: Reference SVG goldens       (image comparison tests)
+- bazel_clang_tidy: clang-tidy aspect           (--config=clang-tidy)
+
+When / how to add a new non-BCR dep:
+  1. If the dep is load-bearing for the default tiny-skia + text-base build,
+     it MUST NOT live here — it must either be on BCR (as a bazel_dep), or
+     vendored under third_party/ via `new_local_repository` so it ships in
+     the source archive.
+  2. If the dep is gated behind a config_setting / bool_flag AND every BUILD
+     target referencing it has `target_compatible_with = <flag>_enabled`,
+     add it to `_non_bcr_deps_impl` below.
+  3. Update the checklist in docs/design_docs/bcr_release.md (when that
+     document exists — tracked under the BCR release plan).
+
+See docs/design_docs/bcr_release.md for the fuller picture of what ships on
+BCR versus what stays behind `git_override`.
+"""
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
+
+def _non_bcr_deps_impl(_mctx):
+    # Skia renderer backend. Gated on //donner/svg/renderer:renderer_backend_skia.
+    git_repository(
+        name = "skia",
+        commit = "d945cbcbbb5834245256e883803c2704f3a32e18",
+        remote = "https://github.com/google/skia",
+    )
+
+    # WOFF2 text support. Gated on //donner/svg/renderer:text_full_enabled.
+    new_git_repository(
+        name = "woff2",
+        build_file = "//third_party:BUILD.woff2",
+        commit = "1f184d05566b3e25827a1f8e68eb82b9ccf54f3b",
+        remote = "https://github.com/google/woff2.git",
+    )
+
+    # HarfBuzz text shaping. Gated on //donner/svg/renderer:text_full_enabled.
+    #
+    # The patch_cmds below create src/config-override.h to re-enable parts of
+    # the HarfBuzz API that HB_TINY/HB_LEAN strip out. We need:
+    #   - the draw API for glyph outline extraction
+    #   - CFF outlines for our OTF fallback font (Public Sans)
+    #   - file I/O for hb_face_create_from_file_or_fail
+    new_git_repository(
+        name = "harfbuzz",
+        build_file = "//third_party:BUILD.harfbuzz",
+        remote = "https://github.com/harfbuzz/harfbuzz.git",
+        tag = "14.1.0",
+        patch_cmds = [
+            """cat > src/config-override.h << 'HBEOF'
+// Re-enable the draw API for glyph outline extraction.
+// HB_TINY -> HB_LEAN -> HB_NO_DRAW -> HB_NO_OUTLINE, which strips these.
+#undef HB_NO_DRAW
+#undef HB_NO_OUTLINE
+// Re-enable CFF outlines (our fallback font Public Sans is OTF/CFF).
+#undef HB_NO_CFF
+#undef HB_NO_OT_FONT_CFF
+// Re-enable file I/O (hb_face_create_from_file_or_fail references
+// hb_blob_create_from_file_or_fail which is guarded by HB_NO_OPEN).
+#undef HB_NO_OPEN
+HBEOF""",
+        ],
+    )
+
+    # Dawn (WebGPU implementation) for the Geode GPU renderer.
+    # Only fetched when --//donner/svg/renderer/geode:enable_dawn=true.
+    # `patch_cmds` runs `fetch_dawn_dependencies.py` at repository fetch time
+    # (which has network access) to populate third_party/ submodules, so the
+    # downstream CMake build can run with DAWN_FETCH_DEPENDENCIES=OFF inside
+    # Bazel's sandbox.
+    new_git_repository(
+        name = "dawn",
+        build_file = "//third_party:BUILD.dawn",
+        # Pinned to a specific commit for reproducibility. Bump deliberately.
+        # From v20260403.135149 (2026-04-03).
+        commit = "fa93dacdf3931ec29ff8f42facf51db632c45308",
+        remote = "https://dawn.googlesource.com/dawn",
+        patch_cmds = [
+            "python3 tools/fetch_dawn_dependencies.py",
+            # Strip nested .git directories so Bazel's file tracking sees the
+            # submodule contents as regular source files.
+            "find third_party -name .git -type d -exec rm -rf {} + 2>/dev/null || true",
+            # Strip nested BUILD.bazel/BUILD/WORKSPACE files throughout the tree.
+            # Otherwise they create Bazel package boundaries and glob(['**']) stops
+            # recursing, leaving CMake unable to find many source subdirectories.
+            # Dawn has ~114 BUILD.bazel files under src/tint alone (Tint's upstream
+            # Bazel support for WGSL parsing), plus more in third_party submodules.
+            # The root BUILD file is provided by our overlay so the top-level one
+            # is not needed.
+            "find . -mindepth 2 \\( -name BUILD.bazel -o -name BUILD -o -name WORKSPACE -o -name WORKSPACE.bazel -o -name MODULE.bazel \\) -type f -delete 2>/dev/null || true",
+            # Remove the top-level WORKSPACE/MODULE files that Dawn ships with.
+            # (Keep our BUILD.bazel overlay which is placed at the root by Bazel's
+            # new_git_repository build_file attribute — don't remove that one.)
+            "rm -f WORKSPACE WORKSPACE.bazel MODULE.bazel",
+        ],
+    )
+
+    # resvg test suite: reference renderings used by image comparison tests.
+    new_git_repository(
+        name = "resvg-test-suite",
+        build_file = "//third_party:BUILD.resvg-test-suite",
+        commit = "682a9c8da8c580ad59cba0ef8cb8a8fd5534022f",
+        remote = "https://github.com/RazrFalcon/resvg-test-suite.git",
+    )
+
+    # bazel_clang_tidy: --config=clang-tidy aspect (see .bazelrc).
+    git_repository(
+        name = "bazel_clang_tidy",
+        commit = "c4d35e0d0b838309358e57a2efed831780f85cd0",
+        remote = "https://github.com/erenon/bazel_clang_tidy.git",
+    )
+
+non_bcr_deps = module_extension(
+    implementation = _non_bcr_deps_impl,
+)

--- a/tools/cmake/BUILD.bazel
+++ b/tools/cmake/BUILD.bazel
@@ -3,14 +3,22 @@ load("@rules_python//python:defs.bzl", "py_library", "py_test")
 py_library(
     name = "gen_cmakelists_lib",
     srcs = ["gen_cmakelists.py"],
-    data = ["//:MODULE.bazel"],
+    data = [
+        "//:MODULE.bazel",
+        # Read at runtime to discover git_repository versions that are
+        # hidden behind the dev-only non_bcr_deps module extension.
+        "//third_party:bazel/non_bcr_deps.bzl",
+    ],
     visibility = ["//visibility:private"],
 )
 
 py_test(
     name = "gen_cmakelists_test",
     srcs = ["gen_cmakelists_test.py"],
-    data = ["//:MODULE.bazel"],
+    data = [
+        "//:MODULE.bazel",
+        "//third_party:bazel/non_bcr_deps.bzl",
+    ],
     deps = [":gen_cmakelists_lib"],
     # Needs the workspace root for MODULE.bazel discovery
     env = {"BAZEL_WORKSPACE_TEST": "1"},

--- a/tools/cmake/gen_cmakelists.py
+++ b/tools/cmake/gen_cmakelists.py
@@ -263,11 +263,36 @@ def _find_module_bazel() -> Path:
     raise FileNotFoundError("Cannot find MODULE.bazel")
 
 
+def _parse_git_repositories(content: str, versions: Dict[str, str]) -> None:
+    """Mutate `versions` by scanning `content` for git_repository /
+    new_git_repository blocks. Used for both MODULE.bazel and the
+    third_party/bazel/non_bcr_deps.bzl module extension (which hides
+    non-BCR deps behind dev_dependency).
+    """
+    for m in re.finditer(r'(?:new_)?git_repository\(([^)]+)\)', content):
+        block = m.group(1)
+        name_m = re.search(r'name\s*=\s*"([^"]+)"', block)
+        if not name_m:
+            continue
+        name = name_m.group(1)
+        tag_m = re.search(r'tag\s*=\s*"([^"]+)"', block)
+        commit_m = re.search(r'commit\s*=\s*"([^"]+)"', block)
+        if tag_m:
+            versions[name] = tag_m.group(1)
+        elif commit_m:
+            versions[name] = commit_m.group(1)
+
+
 def extract_versions_from_module_bazel() -> Dict[str, str]:
     """Parse MODULE.bazel to extract canonical dependency versions/commits.
 
     Returns a dict mapping dependency name to version string or git commit/tag.
     This is used to keep FetchContent declarations in sync with Bazel.
+
+    Also parses third_party/bazel/non_bcr_deps.bzl (the dev-only module
+    extension that hides Skia/HarfBuzz/WOFF2/Dawn/etc. from BCR consumers)
+    so that gen_cmakelists.py can still discover the version pins for those
+    deps when emitting FetchContent declarations for CMake users.
     """
     module_path = _find_module_bazel()
     content = module_path.read_text()
@@ -281,23 +306,15 @@ def extract_versions_from_module_bazel() -> Dict[str, str]:
     ):
         versions[m.group(1)] = m.group(2)
 
-    # Match git_repository / new_git_repository blocks. We split on the
-    # closing paren to avoid greedy matches across multiple blocks.
-    for m in re.finditer(
-        r'(?:new_)?git_repository\(([^)]+)\)',
-        content,
-    ):
-        block = m.group(1)
-        name_m = re.search(r'name\s*=\s*"([^"]+)"', block)
-        if not name_m:
-            continue
-        name = name_m.group(1)
-        tag_m = re.search(r'tag\s*=\s*"([^"]+)"', block)
-        commit_m = re.search(r'commit\s*=\s*"([^"]+)"', block)
-        if tag_m:
-            versions[name] = tag_m.group(1)
-        elif commit_m:
-            versions[name] = commit_m.group(1)
+    # git_repository / new_git_repository blocks in MODULE.bazel proper.
+    _parse_git_repositories(content, versions)
+
+    # Also scan the non_bcr_deps module extension, which is where
+    # skia/harfbuzz/woff2/dawn/resvg-test-suite/bazel_clang_tidy live now
+    # that they are hidden from BCR consumers.
+    non_bcr_path = module_path.parent / "third_party" / "bazel" / "non_bcr_deps.bzl"
+    if non_bcr_path.exists():
+        _parse_git_repositories(non_bcr_path.read_text(), versions)
 
     return versions
 


### PR DESCRIPTION
## Summary
- Moves `skia`, `harfbuzz`, `woff2`, `dawn`, `resvg-test-suite`, and `bazel_clang_tidy` out of `MODULE.bazel` into a new module extension at `third_party/bazel/non_bcr_deps.bzl`, imported with `dev_dependency = True`
- Gates `//donner/base/fonts:woff2_parser` (+tests) and `//donner/svg/text:text_backend_full` with `target_compatible_with` on `//donner/svg/renderer:text_full_enabled`, so BCR consumers skip them cleanly
- Drops three dead `use_repo_rule("@skia//bazel:deps.bzl", ...)` lines and an unused top-level `new_git_repository = use_repo_rule(...)` line

## Why
BCR forbids `git_repository` / `*_override` calls in published modules. The new module extension keeps all current dev behavior (Skia backend, text-full HarfBuzz/WOFF2 path, Geode/Dawn, clang-tidy aspect) working locally and in CI, but hides those deps from downstream BCR consumers — they will simply never see `@skia`, `@harfbuzz`, `@woff2`, or `@dawn`.

The two `target_compatible_with` additions are required because those two targets unconditionally referenced now-dev-only repos in their `deps`. In both cases the target was already only *used* from `:text_full_enabled` `select()` branches, so the gating matches actual usage — it just makes the containing target itself incompatible rather than leaving a dangling label reference.

Part of the BCR release plan. The remaining blocker for a BCR-clean `MODULE.bazel` is `entt` — see #488 which vendors it via `git subtree`.

## Test plan
- [x] `bazel build //donner/base/... //donner/css/... //donner/svg/...` (default config: tiny-skia + text-base) — 404 targets, passes
- [x] `bazel build --config=text-full //donner/svg/text:text_backend_full //donner/base/fonts:woff2_parser` — HarfBuzz + WOFF2 build from the dev extension
- [x] `bazel build //donner/base/fonts:woff2_parser` (default) correctly reports `target incompatible, cannot be built, but was explicitly requested`
- [x] `bazel cquery 'kind("source file", deps(<BCR candidate targets>))'` in default config returns **zero** source files from `@skia`, `@harfbuzz`, `@woff2`, `@dawn`, `@resvg-test-suite`, or `@bazel_clang_tidy` — confirms the BCR-candidate target set does not transitively need any non-BCR repo
- [x] `bazel test //donner/base/fonts:fonts_tests //donner/svg/text:all` (default) passes; incompatible targets skipped as expected
- [x] `bazel test --config=text-full //donner/base/fonts:woff2_parser_tests` passes
- [x] CI green across all platforms + configs (Linux/macOS, tiny-skia, Skia, text-full)