### PR TITLE
Fix recursive marker rendering

### DIFF
--- a/donner/svg/renderer/RenderingContext.cc
+++ b/donner/svg/renderer/RenderingContext.cc
@@ -7,10 +7,11 @@
 #include "donner/svg/components/ComputedClipPathsComponent.h"
 #include "donner/svg/components/DirtyFlagsComponent.h"
 #include "donner/svg/components/ElementTypeComponent.h"
-#include "donner/svg/components/filter/FilterSystem.h"
 #include "donner/svg/components/RenderingBehaviorComponent.h"
 #include "donner/svg/components/RenderingInstanceComponent.h"
 #include "donner/svg/components/SVGDocumentContext.h"
+#include "donner/svg/components/filter/FilterComponent.h"
+#include "donner/svg/components/filter/FilterSystem.h"
 #include "donner/svg/components/layout/LayoutSystem.h"
 #include "donner/svg/components/layout/SizedElementComponent.h"
 #include "donner/svg/components/layout/SymbolComponent.h"
@@ -18,8 +19,6 @@
 #include "donner/svg/components/paint/GradientComponent.h"
 #include "donner/svg/components/paint/MarkerComponent.h"
 #include "donner/svg/components/paint/MaskComponent.h"
-#include "donner/svg/components/filter/FilterComponent.h"
-#include "donner/svg/components/filter/FilterSystem.h"
 #include "donner/svg/components/paint/PaintSystem.h"
 #include "donner/svg/components/paint/PatternComponent.h"
 #include "donner/svg/components/resources/ImageComponent.h"
@@ -573,8 +572,7 @@ public:
       // references an already-active mask element, applying this mask would create a cycle
       // one level deeper. Break the cycle now to match SVG spec behavior where all masks
       // in a mutual recursion cycle have their mask attributes treated as "none".
-      if (const auto* maskStyle =
-              resolvedRef->handle.try_get<ComputedStyleComponent>()) {
+      if (const auto* maskStyle = resolvedRef->handle.try_get<ComputedStyleComponent>()) {
         if (maskStyle->properties.has_value()) {
           if (auto nestedMask = maskStyle->properties->mask.get()) {
             if (auto nestedRef = nestedMask->resolve(*styleHandle.registry());
@@ -598,8 +596,7 @@ public:
           computedShadow &&
           computedShadow->findOffscreenShadow(ShadowBranchType::OffscreenMask).has_value()) {
         activeMaskElements_.insert(maskElement);
-        auto subtree =
-            instantiateOffscreenSubtree(shadowTreeHost, ShadowBranchType::OffscreenMask);
+        auto subtree = instantiateOffscreenSubtree(shadowTreeHost, ShadowBranchType::OffscreenMask);
         activeMaskElements_.erase(maskElement);
 
         return ResolvedMask{resolvedRef.value(), std::move(subtree),
@@ -614,10 +611,19 @@ public:
                                ShadowBranchType branchType) {
     if (auto resolvedRef = reference.resolve(*styleHandle.registry());
         resolvedRef && IsValidMarker(resolvedRef->handle)) {
+      const Entity markerElement = resolvedRef->handle.entity();
+      if (activeMarkerElements_.count(markerElement)) {
+        return ResolvedMarker{ResolvedReference{EntityHandle()}, std::nullopt,
+                              MarkerUnits::Default};
+      }
+
       if (const auto* computedShadow = styleHandle.try_get<ComputedShadowTreeComponent>();
           computedShadow && computedShadow->findOffscreenShadow(branchType).has_value()) {
-        return ResolvedMarker{resolvedRef.value(),
-                              instantiateOffscreenSubtree(styleHandle, branchType),
+        activeMarkerElements_.insert(markerElement);
+        auto subtree = instantiateOffscreenSubtree(styleHandle, branchType);
+        activeMarkerElements_.erase(markerElement);
+
+        return ResolvedMarker{resolvedRef.value(), std::move(subtree),
                               resolvedRef->handle.get<MarkerComponent>().markerUnits};
       }
     }
@@ -664,6 +670,10 @@ private:
   /// (e.g., mask1→mask2→mask1). When a mask reference resolves to an element already in this
   /// set, the cycle is broken by treating the mask attribute as "none".
   std::set<Entity> activeMaskElements_;
+
+  /// Tracks marker elements currently being instantiated so recursive marker references stop
+  /// after the first level instead of repeatedly expanding the same cycle.
+  std::set<Entity> activeMarkerElements_;
 };
 
 void InstantiatePaintShadowTree(Registry& registry, Entity entity, ShadowBranchType branchType,

--- a/donner/svg/renderer/tests/RendererPublicApi_tests.cc
+++ b/donner/svg/renderer/tests/RendererPublicApi_tests.cc
@@ -32,9 +32,9 @@ RendererBitmap NormalizeSnapshot(RendererBitmap snapshot) {
   normalized.pixels.resize(tightRowBytes * static_cast<std::size_t>(snapshot.dimensions.y));
 
   for (int y = 0; y < snapshot.dimensions.y; ++y) {
-    std::copy_n(
-        snapshot.pixels.begin() + static_cast<std::ptrdiff_t>(y * tightRowBytes), tightRowBytes,
-        normalized.pixels.begin() + static_cast<std::ptrdiff_t>(y * tightRowBytes));
+    std::copy_n(snapshot.pixels.begin() + static_cast<std::ptrdiff_t>(y * tightRowBytes),
+                tightRowBytes,
+                normalized.pixels.begin() + static_cast<std::ptrdiff_t>(y * tightRowBytes));
   }
 
   return normalized;
@@ -120,8 +120,7 @@ TEST(RendererPublicApiTest, IncrementalStyleInvalidationMatchesFullRender) {
   target->setAttribute("fill", "#0000ff");
 
   incrementalRenderer.draw(incrementalDocument);
-  const RendererBitmap incrementalSnapshot =
-      NormalizeSnapshot(incrementalRenderer.takeSnapshot());
+  const RendererBitmap incrementalSnapshot = NormalizeSnapshot(incrementalRenderer.takeSnapshot());
   ASSERT_FALSE(incrementalSnapshot.empty());
 
   SVGDocument fullDocument = ParseDocument(R"svg(
@@ -156,8 +155,7 @@ TEST(RendererPublicApiTest, TextUsesDocumentTransformForGlyphPlacement) {
   ASSERT_EQ(snapshot.dimensions, Vector2i(500, 500));
 
   const auto pixelAt = [&](int x, int y) -> std::array<uint8_t, 4> {
-    const size_t index =
-        (static_cast<size_t>(y) * snapshot.rowBytes) + static_cast<size_t>(x) * 4u;
+    const size_t index = (static_cast<size_t>(y) * snapshot.rowBytes) + static_cast<size_t>(x) * 4u;
     return {snapshot.pixels[index], snapshot.pixels[index + 1], snapshot.pixels[index + 2],
             snapshot.pixels[index + 3]};
   };
@@ -488,7 +486,6 @@ TEST(RendererPublicApiTest, StrokeRenderingOnRect) {
   // A point on the stroke (top edge at x=25, y=10) should be red.
   auto strokePx = PixelAt(snapshot, 25, 10);
   EXPECT_THAT(strokePx, IsRedish());
-  
 }
 
 // 2. Stroke-dasharray — verify dashed stroke renders differently from solid
@@ -537,9 +534,9 @@ TEST(RendererPublicApiTest, ShapeOpacity) {
 
   // The pixel should be semi-transparent red (~128 alpha).
   auto px = PixelAt(snapshot, 10, 10);
-  EXPECT_GT(px[0], 100);   // Red present
-  EXPECT_LT(px[3], 200);   // Not fully opaque
-  EXPECT_GT(px[3], 50);    // Not fully transparent
+  EXPECT_GT(px[0], 100);  // Red present
+  EXPECT_LT(px[3], 200);  // Not fully opaque
+  EXPECT_GT(px[3], 50);   // Not fully transparent
 }
 
 // 4. Fill-opacity + stroke-opacity
@@ -598,6 +595,30 @@ TEST(RendererPublicApiTest, MarkerRendering) {
   EXPECT_GT(markerPixel[3], 0);    // Not transparent — marker drawn here
 }
 
+TEST(RendererPublicApiTest, RecursiveMarkerStopsAtOneLevel) {
+  SVGDocument document = ParseDocument(R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="64" height="32" viewBox="0 0 64 32">
+        <defs>
+          <marker id="recursive" viewBox="0 0 10 10" refX="0" refY="0"
+                  markerWidth="10" markerHeight="10" orient="0" style="overflow:visible">
+            <rect x="0" y="0" width="4" height="4" fill="red" />
+            <polyline points="0,0 8,0" fill="none" stroke="black" stroke-opacity="0"
+                      marker-end="url(#recursive)" />
+          </marker>
+        </defs>
+        <polyline points="8,16 24,16" fill="none" stroke="black" marker-end="url(#recursive)" />
+      </svg>
+    )svg");
+
+  Renderer renderer;
+  renderer.draw(document);
+  const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
+  ASSERT_FALSE(snapshot.empty());
+
+  EXPECT_THAT(PixelAt(snapshot, 26, 18), IsRedish());
+  EXPECT_THAT(PixelAt(snapshot, 34, 18), IsTransparent());
+}
+
 // 6. Use element rendering
 TEST(RendererPublicApiTest, UseElementRendering) {
   SVGDocument document = ParseDocument(R"svg(
@@ -618,11 +639,9 @@ TEST(RendererPublicApiTest, UseElementRendering) {
   // Both use instances should produce blue pixels.
   auto first = PixelAt(snapshot, 10, 10);
   EXPECT_THAT(first, IsBlueish());
-  
 
   auto second = PixelAt(snapshot, 30, 10);
   EXPECT_THAT(second, IsBlueish());
-  
 }
 
 // 7. Nested group transforms
@@ -646,7 +665,6 @@ TEST(RendererPublicApiTest, NestedGroupTransforms) {
   // Inside the transformed rect (e.g., 20, 20) should be red.
   auto inside = PixelAt(snapshot, 20, 20);
   EXPECT_THAT(inside, IsOpaque());
-  
 
   // Outside the transformed rect (e.g., 5, 5) should be transparent.
   auto outside = PixelAt(snapshot, 5, 5);
@@ -677,11 +695,9 @@ TEST(RendererPublicApiTest, ViewBoxScaling) {
   // The green rect should fill the entire 50x50 canvas.
   auto corner = PixelAt(snapshot, 0, 0);
   EXPECT_THAT(corner, IsGreenish());
-  
 
   auto center = PixelAt(snapshot, 25, 25);
   EXPECT_THAT(center, IsGreenish());
-  
 }
 
 // 9. Symbol with use
@@ -729,9 +745,6 @@ TEST(RendererPublicApiTest, CssClassStyling) {
 
   auto px = PixelAt(snapshot, 10, 10);
   EXPECT_THAT(px, IsRedish());
-  
-  
-  
 }
 
 // 11. Inline style override
@@ -750,7 +763,7 @@ TEST(RendererPublicApiTest, InlineStyleOverridesAttribute) {
   // Style should override the fill attribute — result should be red, not blue.
   auto px = PixelAt(snapshot, 10, 10);
   EXPECT_THAT(px, IsRedish());
-  
+
   EXPECT_GT(px[3], 200);
 }
 
@@ -844,7 +857,6 @@ TEST(RendererPublicApiTest, ImageElementDataUri) {
   // to fill the 20x20 viewport, so center pixel should be red.
   auto px = PixelAt(snapshot, 10, 10);
   EXPECT_THAT(px, IsRedish());
-  
 }
 
 // 15. Empty document — render SVG with no visible content
@@ -884,7 +896,6 @@ TEST(RendererPublicApiTest, CircleElement) {
   // Center should be green.
   auto center = PixelAt(snapshot, 20, 20);
   EXPECT_THAT(center, IsGreenish());
-  
 
   // Corner should be transparent (outside circle).
   auto corner = PixelAt(snapshot, 0, 0);
@@ -907,7 +918,6 @@ TEST(RendererPublicApiTest, EllipseElement) {
   // Center should be blue.
   auto center = PixelAt(snapshot, 30, 15);
   EXPECT_GT(center[2], 200);
-  
 }
 
 // 18. Pattern fill
@@ -959,7 +969,6 @@ TEST(RendererPublicApiTest, ClipPathCropsContent) {
   // Inside clip region should be red.
   auto inside = PixelAt(snapshot, 20, 20);
   EXPECT_THAT(inside, IsOpaque());
-  
 
   // Outside clip region should be transparent.
   auto outside = PixelAt(snapshot, 2, 2);
@@ -1015,9 +1024,8 @@ TEST(RendererPublicApiTest, MixBlendModeIsolatedLayer) {
   // multiply(#ffff00, #00ffff) = #00ff00 (green)
   auto px = PixelAt(snapshot, 15, 15);
   EXPECT_LT(px[0], 30);   // Red channel ~0 (not cyan's 0 or yellow's 255)
-  EXPECT_GT(px[1], 200);   // Green channel ~255
+  EXPECT_GT(px[1], 200);  // Green channel ~255
   EXPECT_LT(px[2], 30);   // Blue channel ~0
-  
 }
 
 // 22. Visibility hidden — element should not appear
@@ -1081,8 +1089,8 @@ TEST(RendererPublicApiTest, GradientWithTransform) {
   auto top = PixelAt(snapshot, 20, 1);
   auto bottom = PixelAt(snapshot, 20, 38);
   // Top should be more red, bottom more blue.
-  EXPECT_GT(top[0], bottom[0]);   // More red at top
-  EXPECT_LT(top[2], bottom[2]);   // Less blue at top
+  EXPECT_GT(top[0], bottom[0]);  // More red at top
+  EXPECT_LT(top[2], bottom[2]);  // Less blue at top
 }
 
 // 25. Path element (exercises drawPath code path)
@@ -1102,7 +1110,6 @@ TEST(RendererPublicApiTest, PathElement) {
   auto inside = PixelAt(snapshot, 20, 20);
   EXPECT_GT(inside[0], 200);  // Red component of orange
   EXPECT_GT(inside[1], 100);  // Green component of orange
-  
 }
 
 // 26. Gradient userSpaceOnUse exercises non-objectBoundingBox branch
@@ -1127,9 +1134,9 @@ TEST(RendererPublicApiTest, GradientUserSpaceOnUse) {
 
   // Left edge should be cyan (R=0, G=255, B=255).
   auto left = PixelAt(snapshot, 1, 20);
-  EXPECT_LT(left[0], 50);    // Low red (cyan)
-  EXPECT_GT(left[1], 200);   // High green
-  EXPECT_GT(left[2], 200);   // High blue
+  EXPECT_LT(left[0], 50);   // Low red (cyan)
+  EXPECT_GT(left[1], 200);  // High green
+  EXPECT_GT(left[2], 200);  // High blue
 
   // Right edge should be magenta (R=255, G=0, B=255).
   auto right = PixelAt(snapshot, 38, 20);

--- a/donner/svg/renderer/tests/resvg_test_suite.cc
+++ b/donner/svg/renderer/tests/resvg_test_suite.cc
@@ -110,24 +110,21 @@ INSTANTIATE_TEST_SUITE_P(DominantBaseline, ImageComparisonTestFixture,
 
 // a-enable-background: Deprecated in SVG 2, not implemented. See docs/unsupported_svg1_features.md.
 
-INSTANTIATE_TEST_SUITE_P(
-    Fill, ImageComparisonTestFixture,
-    ValuesIn(getTestsWithPrefix("a-fill",  //
-                                {
-                                    {"a-fill-010.svg", Params::Skip()},  // UB: rgb(int int int)
-                                    {"a-fill-015.svg", Params::Skip()},  // UB: ICC color
-                                    {"a-fill-027.svg",
-                                     Params::Skip()},  // Not impl: Fallback with icc-color
-                                    // Text fill tests: Skia's native glyph rendering produces
-                                    // different outlines than stb_truetype, causing pixel diffs.
-                                    {"a-fill-031.svg",
-                                     Params::WithThreshold(kDefaultThreshold, 500)},
-                                    {"a-fill-032.svg",
-                                     Params::WithThreshold(kDefaultThreshold, 500)},
-                                    {"a-fill-033.svg",
-                                     Params::WithThreshold(kDefaultThreshold, 2100)},
-                                })),
-    TestNameFromFilename);
+INSTANTIATE_TEST_SUITE_P(Fill, ImageComparisonTestFixture,
+                         ValuesIn(getTestsWithPrefix(
+                             "a-fill",  //
+                             {
+                                 {"a-fill-010.svg", Params::Skip()},  // UB: rgb(int int int)
+                                 {"a-fill-015.svg", Params::Skip()},  // UB: ICC color
+                                 {"a-fill-027.svg",
+                                  Params::Skip()},  // Not impl: Fallback with icc-color
+                                 // Text fill tests: Skia's native glyph rendering produces
+                                 // different outlines than stb_truetype, causing pixel diffs.
+                                 {"a-fill-031.svg", Params::WithThreshold(kDefaultThreshold, 500)},
+                                 {"a-fill-032.svg", Params::WithThreshold(kDefaultThreshold, 500)},
+                                 {"a-fill-033.svg", Params::WithThreshold(kDefaultThreshold, 2100)},
+                             })),
+                         TestNameFromFilename);
 
 // TODO(filter): a-filter (CSS filter attribute)
 
@@ -715,12 +712,8 @@ INSTANTIATE_TEST_SUITE_P(
                                         "resvg-e-marker-019.png")},  // We (correctly)
                                                                      // apply opacity
                                                                      // on image
-            {"e-marker-022.svg", Params::Skip()},                    // Bug: Recursive marker rendering
-            {"e-marker-023.svg", Params::Skip()},                    // Bug: Recursive markers
-            {"e-marker-024.svg", Params::Skip()},                    // Bug: Recursive markers
             {"e-marker-032.svg", Params::Skip()},                    // UB: Target with subpaths
             {"e-marker-044.svg", Params::Skip()},                    // Bug: Multiple closepaths
-            {"e-marker-057.svg", Params::Skip()},                    // Bug: Recursive markers
             // Resvg bug? Direction to place markers at the beginning/end of closed shapes.
             {"e-marker-045.svg", Params::WithGoldenOverride(
                                      "donner/svg/renderer/testdata/golden/resvg-e-marker-045.png")},
@@ -756,10 +749,11 @@ INSTANTIATE_TEST_SUITE_P(
             {"e-pattern-008.svg",
              Params::WithThreshold(kDefaultThreshold, 250)},  // Skia pattern AA
             {"e-pattern-010.svg",
-             Params::WithThreshold(kDefaultThreshold, 150)},           // Skia pattern AA
-            {"e-pattern-018.svg", Params::WithThreshold(0.5f, 1150)},  // AA artifacts + quad glyph outlines
-            {"e-pattern-019.svg", Params::WithThreshold(0.2f)},        // Anti-aliasing artifacts
-            {"e-pattern-020.svg", Params::WithThreshold(0.6f, 800)},   // Nested pattern AA (768px)
+             Params::WithThreshold(kDefaultThreshold, 150)},  // Skia pattern AA
+            {"e-pattern-018.svg",
+             Params::WithThreshold(0.5f, 1150)},  // AA artifacts + quad glyph outlines
+            {"e-pattern-019.svg", Params::WithThreshold(0.2f)},       // Anti-aliasing artifacts
+            {"e-pattern-020.svg", Params::WithThreshold(0.6f, 800)},  // Nested pattern AA (768px)
             {"e-pattern-021.svg",
              Params::WithThreshold(0.2f)},  // Larger threshold due to recursive pattern seams.
             {"e-pattern-022.svg",


### PR DESCRIPTION
## Summary
- stop recursive marker resolution after the first active marker instance during rendering
- add a renderer regression test that exercises a self-recursive marker definition
- unskip the resvg marker cases that were failing because recursive markers expanded more than one level

## Root Cause
Marker references were resolved without tracking which marker elements were already active in the current offscreen marker expansion. That allowed recursive marker references to keep instantiating nested marker subtrees instead of terminating after one level.

## Impact
This fixes recursive marker rendering in the renderer and restores the affected resvg marker coverage.

## Validation
- `bazel test //...`
- `tools/presubmit.sh`
- targeted resvg marker verification during development for `e-marker-022`, `e-marker-023`, `e-marker-024`, and `e-marker-057`