### PR TITLE
Geode: Phase 3 clipping and masking (polygon + path mask + <mask>)

### DIFF
--- a/docs/design_docs/geode_renderer.md
+++ b/docs/design_docs/geode_renderer.md
@@ -1231,12 +1231,88 @@ cleanup.
 
 ### Phase 3: Compositing and Clipping
 
-- [ ] Implement scissor-based clip rect.
-- [ ] Implement stencil-based clip path (render path to stencil, draw with stencil test).
-- [ ] Implement `pushIsolatedLayer`/`popIsolatedLayer`: offscreen render target allocation,
-  opacity/blend-mode compositing.
+- [x] Implement scissor-based clip rect.
+- [x] **Phase 3a: convex 4-vertex clip polygon.** For non-axis-aligned
+  ancestor transforms (e.g., a skewed or rotated `<symbol>` / `<svg>`
+  viewport), the rectangular scissor can only describe the AABB of the
+  transformed viewport, not the true parallelogram. `GeoEncoder` now
+  accepts `setClipPolygon(corners[4])` / `clearClipPolygon()`, uploads
+  4 inward half-planes through the `Uniforms` / `GradientUniforms`
+  blocks, and the fragment shader ANDs a per-sample half-plane test
+  into its `@builtin(sample_mask)` so the clip integrates with the 4×
+  MSAA coverage path. `RendererGeode::pushClip` detects non-axis-
+  aligned transforms via the 2×2 linear part and pushes the 4
+  transformed corners alongside the existing scissor AABB. Re-enables
+  `structure/symbol/with-transform-on-use{,-no-size}` on the Geode
+  resvg suite. Nested polygon clips (unusual) fall back to the
+  topmost polygon — no in-shader polygon-intersection pass yet.
+- [x] **Phase 3b: path clipping via R8 mask texture.** Arbitrary SVG
+  `clip-path` references are now honoured. `GeoEncoder` gains a
+  `beginMaskPass` / `fillPathIntoMask` / `endMaskPass` /
+  `setClipMask` / `clearClipMask` API. A new `GeodeMaskPipeline`
+  + `shaders/slug_mask.wgsl` renders clip paths into a 4× MSAA
+  R8Unorm target that resolves to a 1-sample R8Unorm texture; the
+  main fill + gradient pipelines gain an extra texture+sampler
+  binding and their fragment shaders sample `mask.r` at each pixel
+  center and multiply it into the output colour. A 1x1 dummy R8
+  (value 0xFF) is bound when no clip is active so the bind group
+  layout stays stable. `RendererGeode::pushClip` allocates mask
+  texture(s) per clip, walks `clip.clipPaths` applying the
+  `clipPathUnitsTransform × entityFromParent × currentTransform`
+  chain (matches `RendererTinySkia`), and stashes the outermost
+  resolve view on the clip stack entry so `updateEncoderScissor`
+  can bind the topmost mask. Multiple clip paths within a single
+  layer union via `BlendOperation::Max` on the R channel.
+
+  **Nested clip-path support (follow-up, also done):** The mask
+  pipeline itself accepts a clip mask input — `slug_mask.wgsl`
+  samples `clipMaskTexture.r` at the pixel center and multiplies it
+  into the shape's coverage output. `RendererGeode::pushClip`
+  partitions `clip.clipPaths` into contiguous layer runs, then
+  renders runs bottom-up (deepest first). Each outer layer binds
+  the previously-rendered deeper layer's mask as its input clip,
+  so every outer-layer shape is intersected with the deeper union
+  and `BlendOperation::Max` unions the outer shapes on top —
+  matching `RendererTinySkia::pushClip`'s recursive
+  `buildLayerMask`. Nested `<g>` clips (two separate `pushClip`
+  calls stacking) are handled by seeding the deepest layer's input
+  clip with the topmost existing clip stack entry's mask view,
+  intersecting the new clip with the active ancestor clip as it's
+  rendered. Unlocks the entire `masking/clipPath` +
+  `masking/clip` + `masking/clip-rule` category plus all
+  cross-category `*-on-clipPath` tests. Session delta: 596 → 636
+  passing on `resvg_test_suite_geode_text`.
+- [ ] Implement stencil-based clip path — superseded by Phase 3b
+  texture-mask clipping, which uses a resolved R8 mask sampled by the
+  main fill / gradient fragment shaders. Stencil would still be a
+  valid optimisation (skip the sample + the offscreen pass for simple
+  clip rects), but is no longer on the critical path.
+- [x] Implement `pushIsolatedLayer`/`popIsolatedLayer`: offscreen
+  render target allocation + opacity compositing. (Phase 2 landing.)
   - [ ] Blend mode fragment shader (all 28 SVG/CSS blend modes).
-- [ ] Implement mask compositing: render mask to offscreen, composite via alpha/luminance.
+    Still pending — `popIsolatedLayer` does a plain premultiplied
+    source-over today. `painting/mix-blend-mode` + `painting/isolation`
+    remain category-gated.
+- [x] **Phase 3c: `<mask>` compositing via luminance blit.** The
+  existing `GeodeImagePipeline` is extended with a second texture
+  binding (luminance mask) + `maskMode` / `applyMaskBounds` /
+  `maskBounds` uniforms; a 1x1 dummy mask is bound for normal
+  `drawImage` / `blitFullTarget` calls so layout stays stable. The
+  fragment shader computes `0.2126·R_pm + 0.7152·G_pm + 0.0722·B_pm`
+  (which equals `luminance(demult) · alpha` for premultiplied input)
+  and multiplies it into the output colour, matching tiny-skia's
+  `Mask::fromPixmap(Luminance)`. `RendererGeode::pushMask` allocates
+  two offscreen texture pairs (mask capture + masked content),
+  redirects the encoder into the first pair, and saves the outer
+  target + the `currentTransform` as the mask-bounds reference frame.
+  `transitionMaskToContent` swaps the encoder into the content pair.
+  `popMask` composites the pair back onto the restored parent via
+  `GeoEncoder::blitFullTargetMasked`, lifting the raw mask-bounds
+  rect into device-pixel space through the saved transform so
+  `maskUnits=userSpaceOnUse` and percent-sized bounds render
+  correctly. Unlocks the entire `masking/mask` category (31/31
+  tests passing). Session delta: 636 → 666 passing on
+  `resvg_test_suite_geode_text`.
 - [ ] Implement `GeodePatternCacheComponent` for ECS pattern caching.
 
 ### Phase 4: Text Rendering
@@ -1320,11 +1396,12 @@ pattern as the resvg suite's `getTestsWithPrefix` map.
       counting `MoveTo` verbs in the `strokeToFill` result).
     * Zero-length subpath stroke caps (SVG 2 §11.4 shapes emitted
       directly from `strokeSubpath`).
-  Four tests remain `disableBackend(Geode)` with per-file TODOs, three
-  of them blocked on Phase 3 path clipping for non-axis-aligned
-  transformed viewports (`structure/symbol/with-transform-on-use`,
-  `structure/image/preserveAspectRatio=xMaxYMax-slice-on-svg`) and one
-  on a bevel-fallback corner drift (`painting/stroke-linejoin/miter`).
+  Phase 3a polygon clipping unblocked
+  `structure/symbol/with-transform-on-use{,-no-size}` — the remaining
+  per-file TODOs are `structure/image/preserveAspectRatio=xMaxYMax-
+  slice-on-svg` (polygon clip edge AA fringes 4 pixels past the 100-px
+  max — a follow-up, not a functional gap) and
+  `painting/stroke-linejoin/miter` (bevel-fallback corner drift).
 - [x] **Track the pass-rate delta between Geode and RendererSkia.**
   After #504, `resvg_test_suite_geode_text` is **596 passing / 0
   failing / 765 skipped via feature gates** on top of the category

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -491,6 +491,38 @@ struct RendererGeode::Impl {
   };
   std::vector<LayerStackFrame> layerStack;
 
+  /// Phase 3c: state for an in-progress `<mask>` element. Two offscreen
+  /// texture pairs, one capturing the mask element's content and one
+  /// capturing the masked subtree. `popMask` composites them via
+  /// `GeoEncoder::blitFullTargetMasked` back onto the saved parent
+  /// target.
+  ///
+  /// Phase sequencing matches `RendererTinySkia`:
+  ///   * `pushMask` → allocate mask capture pair, redirect encoder.
+  ///   * `transitionMaskToContent` → switch to content pair.
+  ///   * `popMask` → blit (content * luminance(mask)) onto parent.
+  struct MaskStackFrame {
+    enum class Phase { Capturing, Content };
+    Phase phase = Phase::Capturing;
+    std::unique_ptr<geode::GeoEncoder> savedEncoder;
+    wgpu::Texture savedTarget;
+    wgpu::Texture savedMsaaTarget;
+    wgpu::Texture maskTexture;          // Mask element's content (RGBA).
+    wgpu::Texture maskMsaaTexture;
+    wgpu::Texture contentTexture;       // Masked element's content (RGBA).
+    wgpu::Texture contentMsaaTexture;
+    /// Raw mask-bounds rectangle from the driver, in the coordinate
+    /// space of `maskBoundsTransform` (userSpaceOnUse or the
+    /// objectBoundingBox-mapped user space — either way, NOT yet in
+    /// device pixels).
+    std::optional<Box2d> maskBounds;
+    /// `currentTransform` snapshotted at `pushMask` time so that
+    /// `popMask` can lift `maskBounds` into device-pixel space. This
+    /// mirrors `RendererTinySkia::SurfaceFrame::maskBoundsTransform`.
+    Transform2d maskBoundsTransform;
+  };
+  std::vector<MaskStackFrame> maskStack;
+
   /// A completed pattern tile ready to be sampled as fill or stroke paint.
   struct PatternPaintSlot {
     wgpu::Texture tile;
@@ -511,39 +543,97 @@ struct RendererGeode::Impl {
 
   /// Axis-aligned clip rectangles in target-pixel coords. Each entry
   /// corresponds to a `pushClip` with a non-empty `clipRect`. The active
-  /// scissor is the intersection of every entry on this stack.
+  /// scissor is the intersection of every entry's `pixelRect` on this
+  /// stack.
   /// Entries with `valid == false` represent pushClip calls that had no
   /// `clipRect` component (path- or mask-only clips) — they're tracked
   /// so `popClip` stays balanced with `pushClip`.
+  ///
+  /// For non-axis-aligned ancestor transforms (e.g., a rotated `<svg>`
+  /// or `<use>`), the scissor rect is the AABB of the transformed clip
+  /// rect — which over-reports coverage. In that case the entry also
+  /// carries the 4 polygon corners of the clip in device-pixel space,
+  /// and the fragment shader tests each sample against the polygon's
+  /// half-planes on top of the scissor rect. We only honour the TOPMOST
+  /// polygon-bearing entry (`setClipPolygon` has no in-shader
+  /// intersection with a previous polygon) — nested rotated clips are
+  /// rare enough that we accept the over-coverage fallback.
   struct ClipStackEntry {
     Box2d pixelRect;
     bool valid = false;
+    bool hasPolygon = false;
+    Vector2d polygonCorners[4];
+    /// Phase 3b path-clip mask. When non-null, `maskResolveView`
+    /// references a 1-sample R8Unorm texture sampled by the fill /
+    /// gradient pipelines through their clip-mask bindings. The
+    /// texture is allocated per `pushClip` call — the Impl owns the
+    /// wgpu::Texture to keep the resolve alive until `popClip`.
+    ///
+    /// For nested `<clipPath>` references, the pushClip code builds
+    /// one mask per clip-path layer (deepest first); each outer
+    /// layer's mask is rendered with the previous layer's mask as an
+    /// input clip mask so every outer shape is intersected with the
+    /// deeper union. The final (outermost) layer's resolve lives in
+    /// `maskResolveView`; the intermediate layer textures are parked
+    /// in `maskLayerTextures` so their wgpu::Texture ownership
+    /// persists until `popClip`.
+    wgpu::Texture maskMsaaTexture;
+    wgpu::Texture maskResolveTexture;
+    wgpu::TextureView maskResolveView;
+    std::vector<wgpu::Texture> maskLayerTextures;
   };
   std::vector<ClipStackEntry> clipStack;
 
   /// Recompute the intersection of every rectangular clip entry on
-  /// `clipStack` and apply it to the active encoder as a scissor. Called
-  /// whenever the clip stack changes.
+  /// `clipStack` and apply it to the active encoder as a scissor,
+  /// plus forward the topmost polygon clip (if any) through
+  /// `setClipPolygon`. Called whenever the clip stack changes.
   void updateEncoderScissor() {
     if (!encoder) {
       return;
     }
     std::optional<Box2d> active;
+    const ClipStackEntry* polygonEntry = nullptr;
+    const ClipStackEntry* maskEntry = nullptr;
     for (const ClipStackEntry& entry : clipStack) {
-      if (!entry.valid) {
-        continue;
+      if (entry.valid) {
+        if (!active.has_value()) {
+          active = entry.pixelRect;
+        } else {
+          // Intersect: take the overlap of the two rectangles.
+          const double x0 = std::max(active->topLeft.x, entry.pixelRect.topLeft.x);
+          const double y0 = std::max(active->topLeft.y, entry.pixelRect.topLeft.y);
+          const double x1 = std::min(active->bottomRight.x, entry.pixelRect.bottomRight.x);
+          const double y1 = std::min(active->bottomRight.y, entry.pixelRect.bottomRight.y);
+          active = Box2d(Vector2d(x0, y0), Vector2d(std::max(x0, x1), std::max(y0, y1)));
+        }
       }
-      if (!active.has_value()) {
-        active = entry.pixelRect;
-      } else {
-        // Intersect: take the overlap of the two rectangles.
-        const double x0 = std::max(active->topLeft.x, entry.pixelRect.topLeft.x);
-        const double y0 = std::max(active->topLeft.y, entry.pixelRect.topLeft.y);
-        const double x1 = std::min(active->bottomRight.x, entry.pixelRect.bottomRight.x);
-        const double y1 = std::min(active->bottomRight.y, entry.pixelRect.bottomRight.y);
-        active = Box2d(Vector2d(x0, y0), Vector2d(std::max(x0, x1), std::max(y0, y1)));
+      if (entry.hasPolygon) {
+        // Overwrite with the topmost polygon entry; no multi-polygon
+        // intersection in the shader (see ClipStackEntry docs).
+        polygonEntry = &entry;
+      }
+      if (entry.maskResolveView) {
+        // Same deal for the path-clip mask — we always bind the
+        // topmost one, and nested path-clip intersections are a
+        // TODO (would need multiple clip-mask bindings in the
+        // fragment shader or a per-clip compositing pass).
+        maskEntry = &entry;
       }
     }
+
+    if (polygonEntry != nullptr) {
+      encoder->setClipPolygon(polygonEntry->polygonCorners);
+    } else {
+      encoder->clearClipPolygon();
+    }
+
+    if (maskEntry != nullptr) {
+      encoder->setClipMask(maskEntry->maskResolveView);
+    } else {
+      encoder->clearClipMask();
+    }
+
     if (!active.has_value()) {
       encoder->clearScissorRect();
       return;
@@ -897,26 +987,202 @@ void RendererGeode::popTransform() {
 
 void RendererGeode::pushClip(const ResolvedClip& clip) {
   // Rectangular clip (the nested-`<svg>` viewport, `overflow: hidden`, and
-  // `<image>` dest-rect cases) is implemented via the WebGPU scissor rect.
-  // Path- and mask-based clipping are still stubbed — they require a
-  // stencil or mask-texture pass which is Phase 3 proper.
-  const bool hasPathOrMaskClip = !clip.clipPaths.empty() || clip.mask.has_value();
-  if (hasPathOrMaskClip && impl_->verbose && !impl_->warnedClip) {
-    std::cerr << "RendererGeode: path/mask clipping not yet implemented (Phase 3)\n";
-    impl_->warnedClip = true;
+  // `<image>` dest-rect cases) is implemented via the WebGPU scissor rect
+  // (plus the Phase 3a polygon clip for non-axis-aligned ancestors).
+  // Path-based clip-paths are implemented via the Phase 3b mask
+  // pipeline below. `<mask>` alpha masks are still stubbed (Phase 3c).
+  if (clip.mask.has_value() && impl_->verbose && !impl_->warnedMask) {
+    std::cerr << "RendererGeode: <mask> compositing not yet implemented (Phase 3c)\n";
+    impl_->warnedMask = true;
   }
 
   // Compose the incoming clip rect (in user-space) with the current
   // transform to get pixel-space coordinates, then push onto the stack.
   // The active scissor is the INTERSECTION of everything on the stack.
-  Box2d pixelRect;
-  bool valid = false;
+  Impl::ClipStackEntry entry;
   if (clip.clipRect.has_value()) {
     const Transform2d& t = impl_->currentTransform;
-    pixelRect = t.transformBox(*clip.clipRect);
-    valid = true;
+    entry.pixelRect = t.transformBox(*clip.clipRect);
+    entry.valid = true;
+
+    // Detect a non-axis-aligned ancestor transform — rotation or shear
+    // means the true clip shape is a parallelogram, not a rectangle,
+    // and a rectangular scissor can only describe its AABB. In that
+    // case we carry the 4 transformed corners through to the encoder
+    // as a polygon clip so the fragment shader can do a half-plane
+    // test per sample.
+    const double a = t.data[0];
+    const double b = t.data[1];
+    const double c = t.data[2];
+    const double d = t.data[3];
+    // Axis-aligned iff (no shear: b=c=0) OR (90°-rotation: a=d=0).
+    // Use a small tolerance to absorb floating-point noise in the
+    // composed transform chain.
+    constexpr double kAxisAlignedEps = 1e-9;
+    const bool axisAligned =
+        (std::abs(b) < kAxisAlignedEps && std::abs(c) < kAxisAlignedEps) ||
+        (std::abs(a) < kAxisAlignedEps && std::abs(d) < kAxisAlignedEps);
+    if (!axisAligned) {
+      const Box2d& local = *clip.clipRect;
+      const Vector2d tl(local.topLeft.x, local.topLeft.y);
+      const Vector2d tr(local.bottomRight.x, local.topLeft.y);
+      const Vector2d br(local.bottomRight.x, local.bottomRight.y);
+      const Vector2d bl(local.topLeft.x, local.bottomRight.y);
+      entry.polygonCorners[0] = t.transformPosition(tl);
+      entry.polygonCorners[1] = t.transformPosition(tr);
+      entry.polygonCorners[2] = t.transformPosition(br);
+      entry.polygonCorners[3] = t.transformPosition(bl);
+      entry.hasPolygon = true;
+    }
   }
-  impl_->clipStack.push_back({pixelRect, valid});
+
+  // Phase 3b: path-clip mask. When the clip has any `clipPaths`,
+  // render them into R8Unorm mask textures via the Slug mask
+  // pipeline and hand the resolved view of the outermost layer to
+  // the encoder so subsequent fill / gradient draws multiply clip
+  // coverage into their output.
+  //
+  // `clip.clipPaths` is a flat list in traversal order with a
+  // per-shape `layer` index. Paths at the same layer are UNIONED;
+  // when the layer decreases (we cross back from a nested clipPath
+  // reference to its parent), that whole nested layer is
+  // INTERSECTED with each path at the outer layer. This matches the
+  // recursive `buildLayerMask` in `RendererTinySkia::pushClip`.
+  //
+  // The union step lives in the hardware blend (`BlendOperation::Max`
+  // on the R channel). The intersection step lives in the slug_mask
+  // fragment shader: when a deeper layer's mask is bound as the
+  // `clipMaskTexture`, each outer-layer shape samples it at its
+  // pixel center and multiplies the coverage output, so
+  // `max(shape_i ∩ nested)` = `(union of shape_i) ∩ nested`.
+  //
+  // Bottom-up traversal order: we scan the clipPaths list and
+  // partition it into contiguous runs of equal layer. Deeper layers
+  // appear AFTER outer layers in the list (the driver emits them in
+  // the order they're encountered during DFS, and references push a
+  // higher layer for the nested clip's children). So the deepest
+  // layer is at the tail; we render each layer's mask in reverse,
+  // binding the previously-rendered deeper mask as the input clip.
+  if (!clip.clipPaths.empty() && impl_->device && impl_->encoder &&
+      impl_->pixelWidth > 0 && impl_->pixelHeight > 0) {
+    const wgpu::Device& dev = impl_->device->device();
+
+    const auto makeResolveTexture = [&](const char* label) {
+      wgpu::TextureDescriptor desc = {};
+      desc.label = label;
+      desc.size = {static_cast<uint32_t>(impl_->pixelWidth),
+                   static_cast<uint32_t>(impl_->pixelHeight), 1u};
+      desc.format = wgpu::TextureFormat::R8Unorm;
+      desc.usage =
+          wgpu::TextureUsage::RenderAttachment | wgpu::TextureUsage::TextureBinding;
+      desc.mipLevelCount = 1;
+      desc.sampleCount = 1;
+      desc.dimension = wgpu::TextureDimension::e2D;
+      return dev.CreateTexture(&desc);
+    };
+    const auto makeMsaaTexture = [&](const char* label) {
+      wgpu::TextureDescriptor desc = {};
+      desc.label = label;
+      desc.size = {static_cast<uint32_t>(impl_->pixelWidth),
+                   static_cast<uint32_t>(impl_->pixelHeight), 1u};
+      desc.format = wgpu::TextureFormat::R8Unorm;
+      desc.usage = wgpu::TextureUsage::RenderAttachment;
+      desc.mipLevelCount = 1;
+      desc.sampleCount = 4;
+      desc.dimension = wgpu::TextureDimension::e2D;
+      return dev.CreateTexture(&desc);
+    };
+
+    // Partition `clip.clipPaths` into contiguous [begin, end) ranges,
+    // one per layer, in the order they appear. Layers appear in
+    // traversal order — within a run the layer is constant, and
+    // boundaries correspond to clipPath-reference crossings. For
+    // each run we'll render one mask texture.
+    struct LayerRun {
+      size_t begin;
+      size_t end;
+      int layer;
+    };
+    std::vector<LayerRun> runs;
+    {
+      size_t i = 0;
+      while (i < clip.clipPaths.size()) {
+        const int layer = clip.clipPaths[i].layer;
+        size_t j = i + 1;
+        while (j < clip.clipPaths.size() && clip.clipPaths[j].layer == layer) {
+          ++j;
+        }
+        runs.push_back({i, j, layer});
+        i = j;
+      }
+    }
+
+    // Render runs bottom-up (deepest layer first). Each run's mask
+    // is rendered with the previously-rendered deeper mask bound as
+    // the input clip so shapes get intersected with the deeper
+    // union. Runs at the same layer don't intersect with each other
+    // — the Max blend on the R channel handles union within a run.
+    const Transform2d savedTransform = impl_->currentTransform;
+
+    // If any clip stack entry already carries a path mask (e.g., an
+    // ancestor `<g>` with its own `clip-path`), use the topmost one
+    // as the initial nested mask so this new clip gets intersected
+    // with it as it's being rendered. Without this seed the outer
+    // ancestor clip would be lost the moment the inner clip lands
+    // because `updateEncoderScissor` only binds the topmost entry.
+    wgpu::TextureView nestedMaskView;
+    for (auto rit = impl_->clipStack.rbegin(); rit != impl_->clipStack.rend(); ++rit) {
+      if (rit->maskResolveView) {
+        nestedMaskView = rit->maskResolveView;
+        break;
+      }
+    }
+
+    for (auto it = runs.rbegin(); it != runs.rend(); ++it) {
+      wgpu::Texture msaaTexture = makeMsaaTexture("RendererGeodeClipMaskMsaa");
+      wgpu::Texture resolveTexture = makeResolveTexture("RendererGeodeClipMaskResolve");
+      if (!msaaTexture || !resolveTexture) {
+        continue;
+      }
+
+      // Bind the previously-rendered nested mask (if any) so this
+      // layer's fragment shader samples it and intersects.
+      if (nestedMaskView) {
+        impl_->encoder->setClipMask(nestedMaskView);
+      } else {
+        impl_->encoder->clearClipMask();
+      }
+
+      impl_->encoder->beginMaskPass(msaaTexture, resolveTexture);
+      for (size_t s = it->begin; s < it->end; ++s) {
+        const PathShape& shape = clip.clipPaths[s];
+        const Transform2d composed =
+            clip.clipPathUnitsTransform * shape.entityFromParent * savedTransform;
+        impl_->encoder->setTransform(composed);
+        impl_->encoder->fillPathIntoMask(shape.path, shape.fillRule);
+      }
+      impl_->encoder->endMaskPass();
+
+      nestedMaskView = resolveTexture.CreateView();
+
+      // Keep the intermediate textures alive until popClip.
+      entry.maskLayerTextures.push_back(std::move(msaaTexture));
+      entry.maskLayerTextures.push_back(resolveTexture);
+
+      // The outermost layer (the LAST one processed by this loop,
+      // i.e. the FIRST run in `runs`) provides the resolve view the
+      // main draws sample as their clip.
+      entry.maskResolveTexture = resolveTexture;
+      entry.maskResolveView = nestedMaskView;
+    }
+
+    // Clear the encoder's internal clip-mask state — the next main
+    // pass will rebind via `updateEncoderScissor`.
+    impl_->encoder->clearClipMask();
+    impl_->encoder->setTransform(savedTransform);
+  }
+
+  impl_->clipStack.push_back(std::move(entry));
   impl_->updateEncoderScissor();
 }
 
@@ -1051,15 +1317,143 @@ void RendererGeode::pushFilterLayer(const components::FilterGraph& /*filterGraph
 
 void RendererGeode::popFilterLayer() {}
 
-void RendererGeode::pushMask(const std::optional<Box2d>& /*maskBounds*/) {
-  if (impl_->verbose && !impl_->warnedMask) {
-    std::cerr << "RendererGeode: masks not yet implemented (Phase 3)\n";
-    impl_->warnedMask = true;
+void RendererGeode::pushMask(const std::optional<Box2d>& maskBounds) {
+  if (!impl_->device || !impl_->pipeline || !impl_->gradientPipeline ||
+      !impl_->imagePipeline || !impl_->encoder || impl_->pixelWidth <= 0 ||
+      impl_->pixelHeight <= 0) {
+    // Headless / degenerate — push a placeholder so popMask stays balanced.
+    impl_->maskStack.push_back({});
+    return;
   }
+
+  const auto allocTexturePair = [&](const char* label, const char* msaaLabel,
+                                    wgpu::Texture& outResolve, wgpu::Texture& outMsaa) {
+    wgpu::TextureDescriptor td = {};
+    td.label = label;
+    td.size = {static_cast<uint32_t>(impl_->pixelWidth),
+               static_cast<uint32_t>(impl_->pixelHeight), 1u};
+    td.format = kFormat;
+    td.usage = wgpu::TextureUsage::RenderAttachment | wgpu::TextureUsage::TextureBinding |
+               wgpu::TextureUsage::CopySrc;
+    td.mipLevelCount = 1;
+    td.sampleCount = 1;
+    td.dimension = wgpu::TextureDimension::e2D;
+    outResolve = impl_->device->device().CreateTexture(&td);
+
+    wgpu::TextureDescriptor msaaDesc = {};
+    msaaDesc.label = msaaLabel;
+    msaaDesc.size = td.size;
+    msaaDesc.format = kFormat;
+    msaaDesc.usage = wgpu::TextureUsage::RenderAttachment;
+    msaaDesc.mipLevelCount = 1;
+    msaaDesc.sampleCount = 4;
+    msaaDesc.dimension = wgpu::TextureDimension::e2D;
+    outMsaa = impl_->device->device().CreateTexture(&msaaDesc);
+  };
+
+  Impl::MaskStackFrame frame;
+  allocTexturePair("RendererGeodeMaskCapture", "RendererGeodeMaskCaptureMSAA",
+                   frame.maskTexture, frame.maskMsaaTexture);
+  allocTexturePair("RendererGeodeMaskContent", "RendererGeodeMaskContentMSAA",
+                   frame.contentTexture, frame.contentMsaaTexture);
+  if (!frame.maskTexture || !frame.maskMsaaTexture || !frame.contentTexture ||
+      !frame.contentMsaaTexture) {
+    impl_->maskStack.push_back({});
+    return;
+  }
+  frame.maskBounds = maskBounds;
+  frame.maskBoundsTransform = impl_->currentTransform;
+
+  // Flush the outer encoder's pending draws so they land before we
+  // redirect subsequent commands into the mask capture.
+  impl_->encoder->finish();
+
+  frame.savedEncoder = std::move(impl_->encoder);
+  frame.savedTarget = impl_->target;
+  frame.savedMsaaTarget = impl_->msaaTarget;
+  frame.phase = Impl::MaskStackFrame::Phase::Capturing;
+
+  impl_->target = frame.maskTexture;
+  impl_->msaaTarget = frame.maskMsaaTexture;
+  auto captureEncoder = std::make_unique<geode::GeoEncoder>(
+      *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
+      frame.maskMsaaTexture, frame.maskTexture);
+  captureEncoder->clear(css::RGBA(0, 0, 0, 0));
+  impl_->encoder = std::move(captureEncoder);
+  impl_->maskStack.push_back(std::move(frame));
+  impl_->updateEncoderScissor();
 }
 
-void RendererGeode::transitionMaskToContent() {}
-void RendererGeode::popMask() {}
+void RendererGeode::transitionMaskToContent() {
+  if (impl_->maskStack.empty()) {
+    return;
+  }
+  Impl::MaskStackFrame& frame = impl_->maskStack.back();
+  if (frame.phase != Impl::MaskStackFrame::Phase::Capturing) {
+    return;
+  }
+  if (!frame.contentTexture || !frame.contentMsaaTexture || !impl_->encoder) {
+    frame.phase = Impl::MaskStackFrame::Phase::Content;
+    return;
+  }
+
+  // Flush the mask-capture encoder so the mask texture is ready to
+  // sample in popMask.
+  impl_->encoder->finish();
+
+  impl_->target = frame.contentTexture;
+  impl_->msaaTarget = frame.contentMsaaTexture;
+  auto contentEncoder = std::make_unique<geode::GeoEncoder>(
+      *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
+      frame.contentMsaaTexture, frame.contentTexture);
+  contentEncoder->clear(css::RGBA(0, 0, 0, 0));
+  impl_->encoder = std::move(contentEncoder);
+  frame.phase = Impl::MaskStackFrame::Phase::Content;
+  impl_->updateEncoderScissor();
+}
+
+void RendererGeode::popMask() {
+  if (impl_->maskStack.empty()) {
+    return;
+  }
+  Impl::MaskStackFrame frame = std::move(impl_->maskStack.back());
+  impl_->maskStack.pop_back();
+
+  if (!frame.savedEncoder) {
+    // Placeholder frame from the headless path — nothing to do.
+    return;
+  }
+
+  // Finish the content encoder so its resolve is ready to sample.
+  if (impl_->encoder) {
+    impl_->encoder->finish();
+  }
+
+  // Restore the outer target and reopen a new encoder with load-
+  // preserve on the saved MSAA state.
+  impl_->target = frame.savedTarget;
+  impl_->msaaTarget = frame.savedMsaaTarget;
+  auto newEncoder = std::make_unique<geode::GeoEncoder>(
+      *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
+      frame.savedMsaaTarget, frame.savedTarget);
+  newEncoder->setLoadPreserve();
+  impl_->encoder = std::move(newEncoder);
+  impl_->updateEncoderScissor();
+
+  // Lift the raw mask-bounds rect into device-pixel space using the
+  // transform captured at pushMask time. This handles `maskUnits ==
+  // userSpaceOnUse` (where bounds are in user space and need the
+  // element's world transform applied) and `objectBoundingBox`
+  // (where the driver has already folded the bbox mapping into the
+  // bounds, but the outer world transform still applies).
+  std::optional<Box2d> pixelMaskBounds;
+  if (frame.maskBounds.has_value()) {
+    pixelMaskBounds = frame.maskBoundsTransform.transformBox(*frame.maskBounds);
+  }
+
+  // Composite `content * luminance(mask)` onto the outer target.
+  impl_->encoder->blitFullTargetMasked(frame.contentTexture, frame.maskTexture, pixelMaskBounds);
+}
 
 void RendererGeode::beginPatternTile(const Box2d& tileRect,
                                      const Transform2d& targetFromPattern) {

--- a/donner/svg/renderer/geode/BUILD.bazel
+++ b/donner/svg/renderer/geode/BUILD.bazel
@@ -137,6 +137,18 @@ embed_resources(
     visibility = ["//donner/svg/renderer:__subpackages__"],
 )
 
+# Path-clip mask shader. Same band/curve encoding as slug_fill.wgsl but
+# outputs a single-channel coverage value into an R8Unorm target so the
+# main fill / gradient pipelines can sample it as a clip mask (Phase 3b).
+embed_resources(
+    name = "slug_mask_wgsl",
+    header_output = "embed_resources/SlugMaskWgsl.h",
+    resources = {
+        "kSlugMaskWgsl": "shaders/slug_mask.wgsl",
+    },
+    visibility = ["//donner/svg/renderer:__subpackages__"],
+)
+
 donner_cc_library(
     name = "geode_shaders",
     srcs = ["GeodeShaders.cc"],
@@ -147,6 +159,7 @@ donner_cc_library(
         ":image_blit_wgsl",
         ":slug_fill_wgsl",
         ":slug_gradient_wgsl",
+        ":slug_mask_wgsl",
         "@dawn//:webgpu_dawn",
     ],
 )

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -36,9 +36,31 @@ struct alignas(16) Uniforms {
   uint32_t fillRule;          // 160 .. 164
   uint32_t paintMode;         // 164 .. 168
   float patternOpacity;       // 168 .. 172
-  uint32_t _pad0;             // 172 .. 176 pad struct to 176 (mat4 alignment)
+  uint32_t hasClipPolygon;    // 172 .. 176 — 0 = no clip, 1 = clipPolygon active
+  // Phase 3b path-clip mask flag. When nonzero, the shader samples the
+  // clip mask texture at binding 5 (linear-filtered R8Unorm) and folds
+  // its red-channel coverage into the fragment colour. A 1x1 dummy
+  // texture is always bound so the `textureSample` is always legal.
+  uint32_t hasClipMask;       // 176 .. 180
+  uint32_t _clipPad0;         // 180 .. 184 — std140 alignment for next vec4 array
+  uint32_t _clipPad1;         // 184 .. 188
+  uint32_t _clipPad2;         // 188 .. 192
+  // Phase 3a polygon clipping: a 4-vertex convex clip polygon expressed
+  // as 4 edge half-planes, one per side, in VIEWPORT-PIXEL space. Each
+  // edge is `(a, b, c)` such that `a*x + b*y + c >= 0` marks the inside
+  // half-plane (the normal `(a, b)` points into the clipped region).
+  // The fragment shader AND's these half-plane tests into its
+  // `sample_mask` output so the clip integrates with the per-sample
+  // MSAA coverage path. Used by `RendererGeode::pushClip` for
+  // transformed rectangular viewports (`<symbol>` / `<use>` /
+  // `<svg>` viewports with a non-axis-aligned transform) where the
+  // true clip shape is a parallelogram that WebGPU's rectangular
+  // scissor rect cannot express. Stored as `vec4f[4]` (vec4 = xyz + pad)
+  // so the struct stays mat4x4-aligned and the WGSL side reads
+  // `array<vec4f, 4>` directly.
+  float clipPolygonPlanes[16];  // 192 .. 256 (4 edges × vec4)
 };
-static_assert(sizeof(Uniforms) == 176, "Uniforms struct layout mismatch");
+static_assert(sizeof(Uniforms) == 256, "Uniforms struct layout mismatch");
 
 /// Build a column-major 4x4 matrix from an affine `Transform2d` and write it
 /// into the first 16 floats of the output array. Used for the `mvp` and
@@ -115,8 +137,17 @@ struct alignas(16) GradientUniforms {
   uint32_t stopCount;         // 156 .. 160
   float stopColors[16 * 4];   // 160 .. 416
   float stopOffsets[4 * 4];   // 416 .. 480
+  // Phase 3a convex clip polygon + Phase 3b path-clip mask flag.
+  // Layout mirrors `slug_gradient.wgsl` — `hasClipPolygon` +
+  // `hasClipMask` + 2 pad u32 to reach vec4 alignment, then the 4
+  // half-plane rows.
+  uint32_t hasClipPolygon;    // 480 .. 484
+  uint32_t hasClipMask;       // 484 .. 488
+  uint32_t _clipPad1;         // 488 .. 492
+  uint32_t _clipPad2;         // 492 .. 496
+  float clipPolygonPlanes[16];// 496 .. 560
 };
-static_assert(sizeof(GradientUniforms) == 480,
+static_assert(sizeof(GradientUniforms) == 560,
               "GradientUniforms struct layout mismatch");
 
 /// Gradient kind values shared with `shaders/slug_gradient.wgsl`.
@@ -151,6 +182,40 @@ struct GeoEncoder::Impl {
   wgpu::TextureView dummyTextureView;
   wgpu::Sampler dummySampler;
 
+  // 1x1 R8Unorm dummy texture bound to the clip-mask slot when no
+  // clip is active. The single texel is `0xFF` so `textureSample(...).r`
+  // returns 1.0 — i.e., "this pixel is fully unclipped" — allowing
+  // the shader to sample unconditionally without branching on
+  // `hasClipMask` just to avoid an invalid texture read.
+  wgpu::Texture dummyClipMaskTexture;
+  wgpu::TextureView dummyClipMaskTextureView;
+
+  // Currently-bound clip mask state (Phase 3b). When
+  // `activeClipMaskView` is non-null, `hasClipMask == 1` in the
+  // uniforms and draws sample `activeClipMaskView` through the
+  // clip-mask binding. When null, the dummy is bound instead.
+  wgpu::TextureView activeClipMaskView;
+  wgpu::Sampler clipMaskSampler;
+
+  // Lazily-constructed mask-rendering pipeline. We build one when the
+  // first `beginMaskPass` call arrives so encoders that never touch
+  // clipping pay no construction cost. Shared across all mask passes
+  // within the lifetime of this encoder.
+  std::unique_ptr<GeodeMaskPipeline> maskPipelineOwned;
+
+  // While a mask pass is open (`maskPassOpen == true`), the main
+  // render pass is closed — draw calls that hit the mask pipeline go
+  // through `maskPass`. `beginMaskPass` saves the current `transform`
+  // so main-pass draw code picks back up exactly where it left off
+  // when the mask pass ends.
+  bool maskPassOpen = false;
+  wgpu::RenderPassEncoder maskPass;
+  // Transform active when the mask pass was opened, so mask draws use
+  // the same device-pixel space as the parent content. The mask pass
+  // always renders into the mask texture the caller passed in, which
+  // is the same size as the main target.
+  Transform2d maskPassSavedTransform = Transform2d();
+
   // Pending draws are recorded into a render pass that's lazily opened.
   // The first clear/fill triggers `beginPass()`; finish() ends it.
   bool passOpen = false;
@@ -181,6 +246,34 @@ struct GeoEncoder::Impl {
   uint32_t scissorW = 0;
   uint32_t scissorH = 0;
 
+  /// Phase 3a polygon clipping state. When `clipPolygonActive` is true,
+  /// the 4 planes in `clipPolygonPlanes` describe the inside half-plane
+  /// of each edge of a convex 4-vertex clip polygon in VIEWPORT-PIXEL
+  /// space. Each plane is `(a, b, c)` such that a fragment at
+  /// `@builtin(position).xy` is inside when `a*x + b*y + c >= 0`. The
+  /// fragment shader AND's these tests into its sample_mask so the
+  /// clip integrates with per-sample MSAA coverage.
+  ///
+  /// Set via `setClipPolygon` from `RendererGeode::pushClip` when the
+  /// current clip is a rectangular viewport with a non-axis-aligned
+  /// ancestor transform (where WebGPU's scissor rect can only describe
+  /// the AABB of the transformed rect, not the true parallelogram).
+  /// Cleared via `clearClipPolygon` when popClip restores a clip with
+  /// no active polygon.
+  bool clipPolygonActive = false;
+  float clipPolygonPlanes[16] = {0};  // 4 edges × vec4 (xyz + pad)
+
+  /// Populate the `hasClipPolygon` + `clipPolygonPlanes` fields on an
+  /// outgoing `Uniforms` / `GradientUniforms` struct. Keeps the
+  /// encoding of the clip state centralised so every draw helper that
+  /// writes a uniform picks up the same snapshot.
+  void writeClipPolygonUniforms(uint32_t& outFlag, float (&outPlanes)[16]) const {
+    outFlag = clipPolygonActive ? 1u : 0u;
+    for (size_t i = 0; i < 16; ++i) {
+      outPlanes[i] = clipPolygonPlanes[i];
+    }
+  }
+
   /// Apply the current scissor to the open render pass. No-op if the
   /// pass isn't open yet — `ensurePassOpen` will call this on first
   /// open. Safe to call whenever `scissorActive` / `scissor*` changes.
@@ -204,13 +297,15 @@ struct GeoEncoder::Impl {
     }
   }
 
-  /// Lazily create the dummy texture + sampler used by the solid-fill path.
+  /// Lazily create the dummy texture + sampler used by the solid-fill path
+  /// *and* the Phase 3b dummy clip mask texture + clip mask sampler.
   void ensureDummyResources() {
     if (dummyTextureView) {
       return;
     }
     const wgpu::Device& dev = device->device();
 
+    // --- Pattern dummy (RGBA8Unorm, 1x1, opaque black) ---
     wgpu::TextureDescriptor td = {};
     td.label = "GeoEncoderDummyPattern";
     td.size = {1u, 1u, 1u};
@@ -242,6 +337,50 @@ struct GeoEncoder::Impl {
     sd.minFilter = wgpu::FilterMode::Linear;
     sd.magFilter = wgpu::FilterMode::Linear;
     dummySampler = dev.CreateSampler(&sd);
+
+    // --- Clip-mask dummy (R8Unorm, 1x1, value 0xFF = 1.0) ---
+    wgpu::TextureDescriptor maskDummyDesc = {};
+    maskDummyDesc.label = "GeoEncoderDummyClipMask";
+    maskDummyDesc.size = {1u, 1u, 1u};
+    maskDummyDesc.format = wgpu::TextureFormat::R8Unorm;
+    maskDummyDesc.usage = wgpu::TextureUsage::TextureBinding | wgpu::TextureUsage::CopyDst;
+    maskDummyDesc.mipLevelCount = 1;
+    maskDummyDesc.sampleCount = 1;
+    maskDummyDesc.dimension = wgpu::TextureDimension::e2D;
+    dummyClipMaskTexture = dev.CreateTexture(&maskDummyDesc);
+
+    const uint8_t maskPixel[1] = {0xFF};
+    wgpu::TexelCopyTextureInfo maskDst = {};
+    maskDst.texture = dummyClipMaskTexture;
+    wgpu::TexelCopyBufferLayout maskLayout = {};
+    maskLayout.bytesPerRow = 1;
+    maskLayout.rowsPerImage = 1;
+    wgpu::Extent3D maskExtent = {1u, 1u, 1u};
+    device->queue().WriteTexture(&maskDst, maskPixel, sizeof(maskPixel), &maskLayout,
+                                 &maskExtent);
+
+    dummyClipMaskTextureView = dummyClipMaskTexture.CreateView();
+
+    // Clip mask sampler — Linear / ClampToEdge so edge coverage
+    // interpolates smoothly without wrapping back to the opposite
+    // side of the mask texture.
+    wgpu::SamplerDescriptor maskSd = {};
+    maskSd.label = "GeoEncoderClipMaskSampler";
+    maskSd.addressModeU = wgpu::AddressMode::ClampToEdge;
+    maskSd.addressModeV = wgpu::AddressMode::ClampToEdge;
+    maskSd.minFilter = wgpu::FilterMode::Linear;
+    maskSd.magFilter = wgpu::FilterMode::Linear;
+    clipMaskSampler = dev.CreateSampler(&maskSd);
+  }
+
+  /// Return the texture view that should be bound to the clip-mask
+  /// slot for the next draw — the active mask if set, or the dummy
+  /// otherwise. Always returns a valid view after `ensureDummyResources`.
+  const wgpu::TextureView& currentClipMaskView() {
+    if (activeClipMaskView) {
+      return activeClipMaskView;
+    }
+    return dummyClipMaskTextureView;
   }
 
   /// Open the render pass on demand.
@@ -433,6 +572,237 @@ void GeoEncoder::clearScissorRect() {
   impl_->applyScissorIfPassOpen();
 }
 
+void GeoEncoder::setClipPolygon(const Vector2d corners[4]) {
+  // Compute the inward-facing half-plane for each of the 4 edges of the
+  // convex polygon. Edge i runs from `corners[i]` to `corners[(i+1)%4]`,
+  // with direction `d = corners[(i+1)%4] - corners[i]`. The inward
+  // normal is `n = (-d.y, d.x)` when the winding is counter-clockwise
+  // in screen space (which in SVG's y-down coord system is "clockwise
+  // when viewed on-screen"). We DETECT the winding by computing the
+  // signed area of the polygon; if the area is negative we flip the
+  // normals so the half-plane equations always point *inside*.
+  //
+  // Each plane is stored as (a, b, c, pad) where `a*x + b*y + c >= 0`
+  // marks the inside half-plane. `c = -(a*corners[i].x + b*corners[i].y)`
+  // offsets the plane to pass through the edge start.
+
+  // Signed area (Shoelace formula / 2). Positive → CCW in standard math
+  // (y-up) but in SVG (y-down) that maps to a CW visual winding.
+  double signedArea = 0.0;
+  for (size_t i = 0; i < 4; ++i) {
+    const Vector2d& p0 = corners[i];
+    const Vector2d& p1 = corners[(i + 1) % 4];
+    signedArea += (p0.x * p1.y) - (p1.x * p0.y);
+  }
+  const double windingSign = signedArea >= 0.0 ? 1.0 : -1.0;
+
+  for (size_t i = 0; i < 4; ++i) {
+    const Vector2d& p0 = corners[i];
+    const Vector2d& p1 = corners[(i + 1) % 4];
+    const double dx = p1.x - p0.x;
+    const double dy = p1.y - p0.y;
+    // Inward normal: rotate (dx, dy) by +90° (= (-dy, dx)) and flip if
+    // the overall polygon winding is negative.
+    double nx = -dy * windingSign;
+    double ny = dx * windingSign;
+    // Normalise so the half-plane value is in viewport-pixel units
+    // (makes the per-sample test resolution-independent).
+    const double len = std::sqrt(nx * nx + ny * ny);
+    if (len > 1e-12) {
+      nx /= len;
+      ny /= len;
+    }
+    const double c = -(nx * p0.x + ny * p0.y);
+    impl_->clipPolygonPlanes[i * 4 + 0] = static_cast<float>(nx);
+    impl_->clipPolygonPlanes[i * 4 + 1] = static_cast<float>(ny);
+    impl_->clipPolygonPlanes[i * 4 + 2] = static_cast<float>(c);
+    impl_->clipPolygonPlanes[i * 4 + 3] = 0.0f;
+  }
+  impl_->clipPolygonActive = true;
+}
+
+void GeoEncoder::clearClipPolygon() {
+  impl_->clipPolygonActive = false;
+  for (size_t i = 0; i < 16; ++i) {
+    impl_->clipPolygonPlanes[i] = 0.0f;
+  }
+}
+
+// ============================================================================
+// Phase 3b: clip mask pass
+// ============================================================================
+
+void GeoEncoder::beginMaskPass(const wgpu::Texture& msaaMask,
+                               const wgpu::Texture& resolveMask) {
+  if (!msaaMask || !resolveMask) {
+    return;
+  }
+
+  // Close the current main render pass so the new mask pass can open
+  // against the mask texture. A subsequent main draw will lazily
+  // reopen the main pass with `LoadOp::Load` via `setLoadPreserve()`.
+  // Only flip `loadPreserve` when the main pass was *actually* open:
+  // if no main draw has landed yet the initial clear still needs to
+  // run on the next open.
+  const bool mainPassWasOpen = impl_->passOpen;
+  if (mainPassWasOpen) {
+    impl_->pass.End();
+    impl_->passOpen = false;
+    impl_->loadPreserve = true;
+  }
+
+  // Lazily build the mask pipeline on first use.
+  if (!impl_->maskPipelineOwned) {
+    impl_->maskPipelineOwned = std::make_unique<GeodeMaskPipeline>(impl_->device->device());
+  }
+
+  impl_->maskPassSavedTransform = impl_->transform;
+
+  wgpu::TextureView msaaView = msaaMask.CreateView();
+  wgpu::TextureView resolveView = resolveMask.CreateView();
+
+  wgpu::RenderPassColorAttachment color = {};
+  color.view = msaaView;
+  color.resolveTarget = resolveView;
+  color.loadOp = wgpu::LoadOp::Clear;
+  color.storeOp = wgpu::StoreOp::Store;
+  color.clearValue = {0.0, 0.0, 0.0, 0.0};
+
+  wgpu::RenderPassDescriptor desc = {};
+  desc.colorAttachmentCount = 1;
+  desc.colorAttachments = &color;
+  desc.label = "GeoEncoderMaskPass";
+  impl_->maskPass = impl_->commandEncoder.BeginRenderPass(&desc);
+  impl_->maskPass.SetPipeline(impl_->maskPipelineOwned->pipeline());
+  // Full-target scissor so clip-path fills aren't clipped by any
+  // outer scissor still cached in the encoder state.
+  impl_->maskPass.SetScissorRect(0, 0, impl_->targetWidth, impl_->targetHeight);
+  impl_->maskPassOpen = true;
+}
+
+void GeoEncoder::fillPathIntoMask(const Path& path, FillRule rule) {
+  if (!impl_->maskPassOpen) {
+    return;
+  }
+  // The mask pipeline now samples a nested clip mask via bindings
+  // 3/4, so it needs the dummy mask texture + sampler bound when
+  // no deeper layer is active. `ensureDummyResources` is idempotent
+  // and normally runs during the main draw path, but `beginMaskPass`
+  // can be called BEFORE any main draw on a fresh encoder.
+  impl_->ensureDummyResources();
+  EncodedPath encoded = GeodePathEncoder::encode(path, rule);
+  if (encoded.empty()) {
+    return;
+  }
+
+  const wgpu::Device& dev = impl_->device->device();
+  const wgpu::Queue& queue = impl_->device->queue();
+
+  const uint64_t vbSize = roundUp4(encoded.vertices.size() * sizeof(EncodedPath::Vertex));
+  wgpu::BufferDescriptor vbDesc = {};
+  vbDesc.label = "GeodeMaskVB";
+  vbDesc.size = vbSize;
+  vbDesc.usage = wgpu::BufferUsage::Vertex | wgpu::BufferUsage::CopyDst;
+  wgpu::Buffer vb = dev.CreateBuffer(&vbDesc);
+  queue.WriteBuffer(vb, 0, encoded.vertices.data(),
+                    encoded.vertices.size() * sizeof(EncodedPath::Vertex));
+
+  const uint64_t bandsSize = roundUp4(encoded.bands.size() * sizeof(EncodedPath::Band));
+  wgpu::BufferDescriptor bandsDesc = {};
+  bandsDesc.label = "GeodeMaskBandsSSBO";
+  bandsDesc.size = bandsSize;
+  bandsDesc.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
+  wgpu::Buffer bandsBuf = dev.CreateBuffer(&bandsDesc);
+  queue.WriteBuffer(bandsBuf, 0, encoded.bands.data(),
+                    encoded.bands.size() * sizeof(EncodedPath::Band));
+
+  const uint64_t curveFloats = encoded.curves.size() * 6u;
+  const uint64_t curvesSize = roundUp4(curveFloats * sizeof(float));
+  wgpu::BufferDescriptor curvesDesc = {};
+  curvesDesc.label = "GeodeMaskCurvesSSBO";
+  curvesDesc.size = curvesSize;
+  curvesDesc.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
+  wgpu::Buffer curvesBuf = dev.CreateBuffer(&curvesDesc);
+  queue.WriteBuffer(curvesBuf, 0, encoded.curves.data(),
+                    encoded.curves.size() * sizeof(EncodedPath::Curve));
+
+  // Mask uniforms — mvp, viewport, fillRule, hasClipMask. The last
+  // field gates whether the fragment shader samples the nested clip
+  // mask at binding 3 (used for nested `<clipPath>` references —
+  // each outer-layer shape is intersected with the deeper layer's
+  // already-rendered union).
+  struct alignas(16) MaskUniforms {
+    float mvp[16];        //  0 ..  64
+    float viewport[2];    // 64 ..  72
+    uint32_t fillRule;    // 72 ..  76
+    uint32_t hasClipMask; // 76 ..  80
+  };
+  static_assert(sizeof(MaskUniforms) == 80, "MaskUniforms layout mismatch");
+
+  MaskUniforms u = {};
+  impl_->buildMvp(u.mvp);
+  u.viewport[0] = static_cast<float>(impl_->targetWidth);
+  u.viewport[1] = static_cast<float>(impl_->targetHeight);
+  u.fillRule = (rule == FillRule::EvenOdd) ? 1u : 0u;
+  u.hasClipMask = impl_->activeClipMaskView ? 1u : 0u;
+
+  wgpu::BufferDescriptor uniDesc = {};
+  uniDesc.label = "GeodeMaskUniforms";
+  uniDesc.size = sizeof(MaskUniforms);
+  uniDesc.usage = wgpu::BufferUsage::Uniform | wgpu::BufferUsage::CopyDst;
+  wgpu::Buffer uniBuf = dev.CreateBuffer(&uniDesc);
+  queue.WriteBuffer(uniBuf, 0, &u, sizeof(MaskUniforms));
+
+  wgpu::BindGroupEntry entries[5] = {};
+  entries[0].binding = 0;
+  entries[0].buffer = uniBuf;
+  entries[0].size = sizeof(MaskUniforms);
+  entries[1].binding = 1;
+  entries[1].buffer = bandsBuf;
+  entries[1].size = bandsSize;
+  entries[2].binding = 2;
+  entries[2].buffer = curvesBuf;
+  entries[2].size = curvesSize;
+  entries[3].binding = 3;
+  entries[3].textureView = impl_->currentClipMaskView();
+  entries[4].binding = 4;
+  entries[4].sampler = impl_->clipMaskSampler;
+
+  wgpu::BindGroupDescriptor bgDesc = {};
+  bgDesc.label = "GeodeMaskBindGroup";
+  bgDesc.layout = impl_->maskPipelineOwned->bindGroupLayout();
+  bgDesc.entryCount = 5;
+  bgDesc.entries = entries;
+  wgpu::BindGroup bindGroup = dev.CreateBindGroup(&bgDesc);
+
+  impl_->maskPass.SetVertexBuffer(0, vb, 0, vbSize);
+  impl_->maskPass.SetBindGroup(0, bindGroup);
+  impl_->maskPass.Draw(static_cast<uint32_t>(encoded.vertices.size()), 1, 0, 0);
+}
+
+void GeoEncoder::endMaskPass() {
+  if (!impl_->maskPassOpen) {
+    return;
+  }
+  impl_->maskPass.End();
+  impl_->maskPassOpen = false;
+  // Rebind pipeline tracker — the main pass will need to re-select a
+  // pipeline on its next draw.
+  impl_->currentPipeline = Impl::BoundPipeline::kNone;
+  impl_->currentPipelineIsGradient = false;
+  // Restore encoder transform in case the caller trampled it with a
+  // mask-local transform.
+  impl_->transform = impl_->maskPassSavedTransform;
+}
+
+void GeoEncoder::setClipMask(const wgpu::TextureView& maskView) {
+  impl_->activeClipMaskView = maskView;
+}
+
+void GeoEncoder::clearClipMask() {
+  impl_->activeClipMaskView = wgpu::TextureView{};
+}
+
 void GeoEncoder::setLoadPreserve() {
   // No-op if a pass is already open — loadOp is a pass-construction
   // parameter and can't be changed mid-pass. The RendererGeode caller
@@ -521,6 +891,11 @@ void GeoEncoder::fillPathPattern(const Path& path, FillRule rule,
 }
 
 void GeoEncoder::submitFillDraw(const FillDrawArgs& args) {
+  // Always prepare the clip-mask dummy texture + sampler; the bind
+  // group layout requires a valid texture view at binding 5 and a
+  // valid sampler at binding 6 regardless of whether a clip is
+  // active.
+  impl_->ensureDummyResources();
   impl_->ensurePassOpen();
   impl_->bindSolidPipeline();
 
@@ -583,7 +958,8 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args) {
   u.fillRule = (args.rule == FillRule::EvenOdd) ? 1u : 0u;
   u.paintMode = args.paintMode;
   u.patternOpacity = args.patternOpacity;
-  u._pad0 = 0u;
+  impl_->writeClipPolygonUniforms(u.hasClipPolygon, u.clipPolygonPlanes);
+  u.hasClipMask = impl_->activeClipMaskView ? 1u : 0u;
 
   wgpu::BufferDescriptor uniDesc = {};
   uniDesc.label = "GeodeUniforms";
@@ -592,10 +968,12 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args) {
   wgpu::Buffer uniBuf = dev.CreateBuffer(&uniDesc);
   queue.WriteBuffer(uniBuf, 0, &u, sizeof(Uniforms));
 
-  // 3. Bind group — five entries: uniforms, bands SSBO, curves SSBO,
-  // pattern texture, pattern sampler. Solid-fill draws bind the dummy
-  // texture / sampler; the shader skips sampling when paintMode == 0.
-  wgpu::BindGroupEntry entries[5] = {};
+  // 3. Bind group — seven entries: uniforms, bands SSBO, curves SSBO,
+  // pattern texture, pattern sampler, clip-mask texture, clip-mask
+  // sampler. Solid-fill draws bind dummies for the pattern slot and
+  // the clip-mask slot binds either the dummy (hasClipMask == 0) or
+  // the active mask from `setClipMask`.
+  wgpu::BindGroupEntry entries[7] = {};
   entries[0].binding = 0;
   entries[0].buffer = uniBuf;
   entries[0].size = sizeof(Uniforms);
@@ -609,11 +987,15 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args) {
   entries[3].textureView = args.patternView;
   entries[4].binding = 4;
   entries[4].sampler = args.patternSampler;
+  entries[5].binding = 5;
+  entries[5].textureView = impl_->currentClipMaskView();
+  entries[6].binding = 6;
+  entries[6].sampler = impl_->clipMaskSampler;
 
   wgpu::BindGroupDescriptor bgDesc = {};
   bgDesc.label = "GeodeBindGroup";
   bgDesc.layout = impl_->pipeline->bindGroupLayout();
-  bgDesc.entryCount = 5;
+  bgDesc.entryCount = 7;
   bgDesc.entries = entries;
   wgpu::BindGroup bindGroup = dev.CreateBindGroup(&bgDesc);
 
@@ -680,6 +1062,9 @@ void GeoEncoder::fillPathLinearGradient(const Path& path, const LinearGradientPa
     return;
   }
 
+  // The gradient bind group now has a clip-mask texture binding (see
+  // Phase 3b); we need a dummy bound when no clip is active.
+  impl_->ensureDummyResources();
   impl_->ensurePassOpen();
   impl_->bindGradientPipeline();
 
@@ -730,6 +1115,8 @@ void GeoEncoder::fillPathLinearGradient(const Path& path, const LinearGradientPa
   populateSharedGradientUniforms<LinearGradientParams::Stop>(
       u, params.gradientFromPath, params.spreadMode, params.stops, rule);
   u.gradientKind = kGradientKindLinear;
+  impl_->writeClipPolygonUniforms(u.hasClipPolygon, u.clipPolygonPlanes);
+  u.hasClipMask = impl_->activeClipMaskView ? 1u : 0u;
 
   u.startGrad[0] = static_cast<float>(params.startGrad.x);
   u.startGrad[1] = static_cast<float>(params.startGrad.y);
@@ -743,8 +1130,9 @@ void GeoEncoder::fillPathLinearGradient(const Path& path, const LinearGradientPa
   wgpu::Buffer uniBuf = dev.CreateBuffer(&uniDesc);
   queue.WriteBuffer(uniBuf, 0, &u, sizeof(GradientUniforms));
 
-  // 4. Bind group (same shape as the solid pipeline: uniform + 2 SSBOs).
-  wgpu::BindGroupEntry entries[3] = {};
+  // 4. Bind group — five entries: uniforms, bands SSBO, curves SSBO,
+  // clip-mask texture, clip-mask sampler.
+  wgpu::BindGroupEntry entries[5] = {};
   entries[0].binding = 0;
   entries[0].buffer = uniBuf;
   entries[0].size = sizeof(GradientUniforms);
@@ -754,11 +1142,15 @@ void GeoEncoder::fillPathLinearGradient(const Path& path, const LinearGradientPa
   entries[2].binding = 2;
   entries[2].buffer = curvesBuf;
   entries[2].size = curvesSize;
+  entries[3].binding = 3;
+  entries[3].textureView = impl_->currentClipMaskView();
+  entries[4].binding = 4;
+  entries[4].sampler = impl_->clipMaskSampler;
 
   wgpu::BindGroupDescriptor bgDesc = {};
   bgDesc.label = "GeodeGradientBindGroup";
   bgDesc.layout = impl_->gradientPipeline->bindGroupLayout();
-  bgDesc.entryCount = 3;
+  bgDesc.entryCount = 5;
   bgDesc.entries = entries;
   wgpu::BindGroup bindGroup = dev.CreateBindGroup(&bgDesc);
 
@@ -779,6 +1171,8 @@ void GeoEncoder::fillPathRadialGradient(const Path& path, const RadialGradientPa
     return;
   }
 
+  // Dummy texture for the clip-mask slot, see fillPathLinearGradient.
+  impl_->ensureDummyResources();
   impl_->ensurePassOpen();
   impl_->bindGradientPipeline();
 
@@ -826,6 +1220,8 @@ void GeoEncoder::fillPathRadialGradient(const Path& path, const RadialGradientPa
   populateSharedGradientUniforms<RadialGradientParams::Stop>(
       u, params.gradientFromPath, params.spreadMode, params.stops, rule);
   u.gradientKind = kGradientKindRadial;
+  impl_->writeClipPolygonUniforms(u.hasClipPolygon, u.clipPolygonPlanes);
+  u.hasClipMask = impl_->activeClipMaskView ? 1u : 0u;
 
   u.radialCenter[0] = static_cast<float>(params.center.x);
   u.radialCenter[1] = static_cast<float>(params.center.y);
@@ -841,7 +1237,7 @@ void GeoEncoder::fillPathRadialGradient(const Path& path, const RadialGradientPa
   wgpu::Buffer uniBuf = dev.CreateBuffer(&uniDesc);
   queue.WriteBuffer(uniBuf, 0, &u, sizeof(GradientUniforms));
 
-  wgpu::BindGroupEntry entries[3] = {};
+  wgpu::BindGroupEntry entries[5] = {};
   entries[0].binding = 0;
   entries[0].buffer = uniBuf;
   entries[0].size = sizeof(GradientUniforms);
@@ -851,11 +1247,15 @@ void GeoEncoder::fillPathRadialGradient(const Path& path, const RadialGradientPa
   entries[2].binding = 2;
   entries[2].buffer = curvesBuf;
   entries[2].size = curvesSize;
+  entries[3].binding = 3;
+  entries[3].textureView = impl_->currentClipMaskView();
+  entries[4].binding = 4;
+  entries[4].sampler = impl_->clipMaskSampler;
 
   wgpu::BindGroupDescriptor bgDesc = {};
   bgDesc.label = "GeodeRadialGradientBindGroup";
   bgDesc.layout = impl_->gradientPipeline->bindGroupLayout();
-  bgDesc.entryCount = 3;
+  bgDesc.entryCount = 5;
   bgDesc.entries = entries;
   wgpu::BindGroup bindGroup = dev.CreateBindGroup(&bgDesc);
 
@@ -901,6 +1301,46 @@ void GeoEncoder::blitFullTarget(const wgpu::Texture& src, double opacity) {
   qp.sourceIsPremultiplied = true;
 
   GeodeTextureEncoder::drawTexturedQuad(*impl_->device, *impl_->imagePipeline, impl_->pass, src,
+                                        mvp, impl_->targetWidth, impl_->targetHeight, qp);
+}
+
+void GeoEncoder::blitFullTargetMasked(const wgpu::Texture& content, const wgpu::Texture& mask,
+                                      const std::optional<Box2d>& maskBounds) {
+  if (!content || !mask) {
+    return;
+  }
+  impl_->ensurePassOpen();
+  impl_->bindImagePipeline(impl_->imagePipeline->pipeline());
+
+  // Identity MVP for target-pixel → clip space, same as blitFullTarget.
+  const double sx = 2.0 / static_cast<double>(impl_->targetWidth);
+  const double sy = -2.0 / static_cast<double>(impl_->targetHeight);
+  float mvp[16] = {0};
+  mvp[0] = static_cast<float>(sx);
+  mvp[5] = static_cast<float>(sy);
+  mvp[10] = 1.0f;
+  mvp[12] = -1.0f;
+  mvp[13] = 1.0f;
+  mvp[15] = 1.0f;
+
+  GeodeTextureEncoder::QuadParams qp;
+  qp.destRect = Box2d(Vector2d(0.0, 0.0),
+                      Vector2d(static_cast<double>(impl_->targetWidth),
+                               static_cast<double>(impl_->targetHeight)));
+  qp.srcRect = Box2d({0.0, 0.0}, {1.0, 1.0});
+  qp.opacity = 1.0;
+  qp.filter = GeodeTextureEncoder::Filter::Linear;
+  // Both content and mask are offscreen render targets produced by
+  // Geode's premultiplied source-over pipeline, so they're already
+  // in premultiplied alpha.
+  qp.sourceIsPremultiplied = true;
+  qp.maskTexture = mask;
+  if (maskBounds.has_value()) {
+    qp.applyMaskBounds = true;
+    qp.maskBounds = *maskBounds;
+  }
+
+  GeodeTextureEncoder::drawTexturedQuad(*impl_->device, *impl_->imagePipeline, impl_->pass, content,
                                         mvp, impl_->targetWidth, impl_->targetHeight, qp);
 }
 

--- a/donner/svg/renderer/geode/GeoEncoder.h
+++ b/donner/svg/renderer/geode/GeoEncoder.h
@@ -204,6 +204,74 @@ public:
   void clearScissorRect();
 
   /**
+   * Activate a convex 4-vertex clip polygon (Phase 3a).
+   *
+   * Unlike `setScissorRect`, this clips to the exact parallelogram
+   * described by the 4 corners — used for `<symbol>` / `<svg>` /
+   * `<use>` viewports that have a non-axis-aligned ancestor transform
+   * where WebGPU's rectangular scissor can only express the AABB of
+   * the transformed rect, not the true polygon. The fragment shader
+   * tests each of 4 edge half-planes against its sub-pixel sample
+   * positions and AND's the result into `@builtin(sample_mask)` so
+   * clipping integrates with the 4× MSAA coverage path.
+   *
+   * @param corners 4 polygon vertices in target-pixel space, given in
+   *   consistent (clockwise OR counter-clockwise) winding order. The
+   *   encoder normalises edge normals so a fragment strictly INSIDE
+   *   the polygon satisfies every half-plane test.
+   */
+  void setClipPolygon(const Vector2d corners[4]);
+
+  /// Clear any active clip polygon, restoring unclipped rasterisation
+  /// (or falling back to just the scissor rect, if one is set).
+  void clearClipPolygon();
+
+  /**
+   * Phase 3b: open a new render pass that writes into the given mask
+   * texture pair. Used by `RendererGeode::pushClip` to materialise a
+   * path-based clip into an R8Unorm coverage texture that subsequent
+   * fill/gradient draws can sample.
+   *
+   * The main render pass, if open, is closed first. Subsequent
+   * `fillPathIntoMask` calls add paths to the mask via the Slug mask
+   * pipeline. `endMaskPass` closes the mask pass and re-opens the
+   * main pass (with `LoadOp::Load`) when the next draw lands.
+   *
+   * @param msaaMask 4× MSAA R8Unorm render target. Must be the same
+   *   size as this encoder's target. Cleared to 0 at the start of
+   *   the pass.
+   * @param resolveMask 1-sample R8Unorm resolve target. Sampled by
+   *   `setClipMask` after `endMaskPass`.
+   */
+  void beginMaskPass(const wgpu::Texture& msaaMask, const wgpu::Texture& resolveMask);
+
+  /**
+   * Fill `path` into the currently open mask pass using the Slug mask
+   * pipeline. Must be called between `beginMaskPass` and `endMaskPass`.
+   * The current encoder transform applies (so clip paths use the same
+   * device-pixel mapping as the content being clipped).
+   */
+  void fillPathIntoMask(const Path& path, FillRule rule);
+
+  /// Close the mask render pass opened by `beginMaskPass`.
+  void endMaskPass();
+
+  /**
+   * Bind `maskView` as the clip mask texture for subsequent fill /
+   * gradient draws. The view must reference a 1-sample R8Unorm
+   * texture the same size as the encoder's target — typically the
+   * resolve texture produced by `beginMaskPass` + `endMaskPass`.
+   *
+   * The shader samples `.r` at the pixel center and multiplies it
+   * into fragment coverage, so the mask represents a pre-rendered
+   * clip region in [0, 1].
+   */
+  void setClipMask(const wgpu::TextureView& maskView);
+
+  /// Remove any active clip mask, restoring unclipped rasterisation.
+  void clearClipMask();
+
+  /**
    * Blit an offscreen texture across the entire target with an alpha
    * multiplier. Used by `RendererGeode::popIsolatedLayer` to composite a
    * sub-layer's content back onto the outer target. The source texture
@@ -216,6 +284,24 @@ public:
    * @param opacity Overall alpha multiplier in [0, 1].
    */
   void blitFullTarget(const wgpu::Texture& src, double opacity);
+
+  /**
+   * Phase 3c `<mask>` compositing. Same as @ref blitFullTarget but
+   * additionally samples a luminance mask texture and multiplies the
+   * content by the mask's BT.709 luminance (× alpha, matching
+   * tiny-skia's `Mask::fromPixmap(Luminance)`). When `maskBounds` is
+   * provided, pixels outside the rect are discarded so the `<mask>`
+   * element's x/y/width/height are honoured.
+   *
+   * @param content Offscreen RGBA8 content texture, premultiplied,
+   *   same size as this encoder's target.
+   * @param mask Offscreen RGBA8 mask texture, premultiplied, same
+   *   size as `content`. The mask's luminance × alpha becomes a
+   *   per-pixel coverage multiplier on the content.
+   * @param maskBounds Optional clip rect in target-pixel space.
+   */
+  void blitFullTargetMasked(const wgpu::Texture& content, const wgpu::Texture& mask,
+                            const std::optional<Box2d>& maskBounds);
 
   /**
    * Draw a raster image into the given destination rectangle.

--- a/donner/svg/renderer/geode/GeodeImagePipeline.cc
+++ b/donner/svg/renderer/geode/GeodeImagePipeline.cc
@@ -8,8 +8,11 @@ GeodeImagePipeline::GeodeImagePipeline(const wgpu::Device& device,
                                        wgpu::TextureFormat colorFormat)
     : colorFormat_(colorFormat) {
   // ----- Bind group layout -----
-  // Three bindings: uniform buffer, sampler, sampled texture.
-  wgpu::BindGroupLayoutEntry entries[3] = {};
+  // Four bindings: uniform buffer, sampler, sampled content texture,
+  // sampled luminance-mask texture. The mask texture is only read
+  // when `uniforms.maskMode != 0`; in normal blit mode a 1x1 dummy
+  // is bound so the layout stays stable.
+  wgpu::BindGroupLayoutEntry entries[4] = {};
 
   entries[0].binding = 0;
   entries[0].visibility = wgpu::ShaderStage::Vertex | wgpu::ShaderStage::Fragment;
@@ -26,9 +29,15 @@ GeodeImagePipeline::GeodeImagePipeline(const wgpu::Device& device,
   entries[2].texture.viewDimension = wgpu::TextureViewDimension::e2D;
   entries[2].texture.multisampled = false;
 
+  entries[3].binding = 3;
+  entries[3].visibility = wgpu::ShaderStage::Fragment;
+  entries[3].texture.sampleType = wgpu::TextureSampleType::Float;
+  entries[3].texture.viewDimension = wgpu::TextureViewDimension::e2D;
+  entries[3].texture.multisampled = false;
+
   wgpu::BindGroupLayoutDescriptor bglDesc = {};
   bglDesc.label = "GeodeImageBlitBGL";
-  bglDesc.entryCount = 3;
+  bglDesc.entryCount = 4;
   bglDesc.entries = entries;
   bindGroupLayout_ = device.CreateBindGroupLayout(&bglDesc);
 

--- a/donner/svg/renderer/geode/GeodePipeline.cc
+++ b/donner/svg/renderer/geode/GeodePipeline.cc
@@ -7,12 +7,13 @@ namespace donner::geode {
 GeodePipeline::GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat colorFormat)
     : colorFormat_(colorFormat) {
   // ----- Bind group layout -----
-  // Five bindings: uniforms, bands SSBO, curves SSBO, pattern texture,
-  // pattern sampler. The texture + sampler are used only when the paintMode
-  // uniform is set to "pattern"; in solid-fill mode a 1x1 dummy texture is
-  // bound and the shader never samples it. A single layout keeps the
-  // pipeline stable across both fill modes.
-  wgpu::BindGroupLayoutEntry entries[5] = {};
+  // Seven bindings: uniforms, bands SSBO, curves SSBO, pattern texture,
+  // pattern sampler, clip-mask texture, clip-mask sampler. The pattern
+  // texture/sampler are only sampled when paintMode == "pattern" and
+  // the clip-mask texture/sampler only when `hasClipMask != 0`. A 1x1
+  // dummy texture is bound for both when the feature is inactive so
+  // the bind group layout is stable across draw calls.
+  wgpu::BindGroupLayoutEntry entries[7] = {};
 
   entries[0].binding = 0;
   entries[0].visibility = wgpu::ShaderStage::Vertex | wgpu::ShaderStage::Fragment;
@@ -39,9 +40,20 @@ GeodePipeline::GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat col
   entries[4].visibility = wgpu::ShaderStage::Fragment;
   entries[4].sampler.type = wgpu::SamplerBindingType::Filtering;
 
+  // Phase 3b clip mask texture + sampler.
+  entries[5].binding = 5;
+  entries[5].visibility = wgpu::ShaderStage::Fragment;
+  entries[5].texture.sampleType = wgpu::TextureSampleType::Float;
+  entries[5].texture.viewDimension = wgpu::TextureViewDimension::e2D;
+  entries[5].texture.multisampled = false;
+
+  entries[6].binding = 6;
+  entries[6].visibility = wgpu::ShaderStage::Fragment;
+  entries[6].sampler.type = wgpu::SamplerBindingType::Filtering;
+
   wgpu::BindGroupLayoutDescriptor bglDesc = {};
   bglDesc.label = "GeodeSlugFillBGL";
-  bglDesc.entryCount = 5;
+  bglDesc.entryCount = 7;
   bglDesc.entries = entries;
   bindGroupLayout_ = device.CreateBindGroupLayout(&bglDesc);
 
@@ -132,9 +144,11 @@ GeodePipeline::GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat col
 GeodeGradientPipeline::GeodeGradientPipeline(const wgpu::Device& device,
                                              wgpu::TextureFormat colorFormat)
     : colorFormat_(colorFormat) {
-  // Three bindings — same shape as the solid-fill pipeline, but the uniform
-  // buffer is larger (it carries gradient parameters).
-  wgpu::BindGroupLayoutEntry entries[3] = {};
+  // Five bindings — uniforms, bands SSBO, curves SSBO, clip-mask texture,
+  // clip-mask sampler. The clip-mask bindings always carry something
+  // valid; when `hasClipMask == 0` a 1x1 dummy texture is bound and
+  // the shader skips the sample work.
+  wgpu::BindGroupLayoutEntry entries[5] = {};
 
   entries[0].binding = 0;
   entries[0].visibility = wgpu::ShaderStage::Vertex | wgpu::ShaderStage::Fragment;
@@ -151,9 +165,20 @@ GeodeGradientPipeline::GeodeGradientPipeline(const wgpu::Device& device,
   entries[2].buffer.type = wgpu::BufferBindingType::ReadOnlyStorage;
   entries[2].buffer.minBindingSize = 0;
 
+  // Phase 3b clip mask texture + sampler.
+  entries[3].binding = 3;
+  entries[3].visibility = wgpu::ShaderStage::Fragment;
+  entries[3].texture.sampleType = wgpu::TextureSampleType::Float;
+  entries[3].texture.viewDimension = wgpu::TextureViewDimension::e2D;
+  entries[3].texture.multisampled = false;
+
+  entries[4].binding = 4;
+  entries[4].visibility = wgpu::ShaderStage::Fragment;
+  entries[4].sampler.type = wgpu::SamplerBindingType::Filtering;
+
   wgpu::BindGroupLayoutDescriptor bglDesc = {};
   bglDesc.label = "GeodeSlugGradientBGL";
-  bglDesc.entryCount = 3;
+  bglDesc.entryCount = 5;
   bglDesc.entries = entries;
   bindGroupLayout_ = device.CreateBindGroupLayout(&bglDesc);
 
@@ -219,6 +244,124 @@ GeodeGradientPipeline::GeodeGradientPipeline(const wgpu::Device& device,
 
   rpDesc.fragment = &fragmentState;
   // 4× MSAA to match the solid-fill pipeline — see its multisample comment.
+  rpDesc.multisample.count = 4;
+  rpDesc.multisample.mask = 0xFFFFFFFF;
+
+  pipeline_ = device.CreateRenderPipeline(&rpDesc);
+}
+
+// ============================================================================
+// GeodeMaskPipeline
+// ============================================================================
+
+GeodeMaskPipeline::GeodeMaskPipeline(const wgpu::Device& device) {
+  // Five bindings — uniforms, bands SSBO, curves SSBO, nested clip
+  // mask texture, nested clip mask sampler. The clip-mask slot is
+  // always bound; a 1x1 dummy is used when `uniforms.hasClipMask ==
+  // 0` so the draw stays valid without layout variants.
+  wgpu::BindGroupLayoutEntry entries[5] = {};
+
+  entries[0].binding = 0;
+  entries[0].visibility = wgpu::ShaderStage::Vertex | wgpu::ShaderStage::Fragment;
+  entries[0].buffer.type = wgpu::BufferBindingType::Uniform;
+  entries[0].buffer.minBindingSize = 0;
+
+  entries[1].binding = 1;
+  entries[1].visibility = wgpu::ShaderStage::Fragment;
+  entries[1].buffer.type = wgpu::BufferBindingType::ReadOnlyStorage;
+  entries[1].buffer.minBindingSize = 0;
+
+  entries[2].binding = 2;
+  entries[2].visibility = wgpu::ShaderStage::Fragment;
+  entries[2].buffer.type = wgpu::BufferBindingType::ReadOnlyStorage;
+  entries[2].buffer.minBindingSize = 0;
+
+  entries[3].binding = 3;
+  entries[3].visibility = wgpu::ShaderStage::Fragment;
+  entries[3].texture.sampleType = wgpu::TextureSampleType::Float;
+  entries[3].texture.viewDimension = wgpu::TextureViewDimension::e2D;
+  entries[3].texture.multisampled = false;
+
+  entries[4].binding = 4;
+  entries[4].visibility = wgpu::ShaderStage::Fragment;
+  entries[4].sampler.type = wgpu::SamplerBindingType::Filtering;
+
+  wgpu::BindGroupLayoutDescriptor bglDesc = {};
+  bglDesc.label = "GeodeSlugMaskBGL";
+  bglDesc.entryCount = 5;
+  bglDesc.entries = entries;
+  bindGroupLayout_ = device.CreateBindGroupLayout(&bglDesc);
+
+  wgpu::PipelineLayoutDescriptor plDesc = {};
+  plDesc.label = "GeodeSlugMaskPL";
+  plDesc.bindGroupLayoutCount = 1;
+  wgpu::BindGroupLayout layouts[1] = {bindGroupLayout_};
+  plDesc.bindGroupLayouts = layouts;
+  wgpu::PipelineLayout pipelineLayout = device.CreatePipelineLayout(&plDesc);
+
+  wgpu::ShaderModule shader = createSlugMaskShader(device);
+
+  // Same vertex buffer layout as the fill pipelines: pos (vec2f) +
+  // normal (vec2f) + bandIndex (u32) = 20 bytes per vertex.
+  wgpu::VertexAttribute vertexAttribs[3] = {};
+  vertexAttribs[0].format = wgpu::VertexFormat::Float32x2;
+  vertexAttribs[0].offset = 0;
+  vertexAttribs[0].shaderLocation = 0;
+
+  vertexAttribs[1].format = wgpu::VertexFormat::Float32x2;
+  vertexAttribs[1].offset = 8;
+  vertexAttribs[1].shaderLocation = 1;
+
+  vertexAttribs[2].format = wgpu::VertexFormat::Uint32;
+  vertexAttribs[2].offset = 16;
+  vertexAttribs[2].shaderLocation = 2;
+
+  wgpu::VertexBufferLayout vbLayout = {};
+  vbLayout.arrayStride = 20;
+  vbLayout.stepMode = wgpu::VertexStepMode::Vertex;
+  vbLayout.attributeCount = 3;
+  vbLayout.attributes = vertexAttribs;
+
+  // Max-blend so multiple clip paths rendered into the same mask layer
+  // UNION. Each shader writes `1.0` for covered samples, `0.0` would
+  // otherwise be the clear value, so `Max` over the red channel keeps
+  // the larger coverage — exactly the union.
+  wgpu::BlendState blend = {};
+  blend.color.srcFactor = wgpu::BlendFactor::One;
+  blend.color.dstFactor = wgpu::BlendFactor::One;
+  blend.color.operation = wgpu::BlendOperation::Max;
+  blend.alpha.srcFactor = wgpu::BlendFactor::One;
+  blend.alpha.dstFactor = wgpu::BlendFactor::One;
+  blend.alpha.operation = wgpu::BlendOperation::Max;
+
+  wgpu::ColorTargetState colorTarget = {};
+  colorTarget.format = wgpu::TextureFormat::R8Unorm;
+  colorTarget.blend = &blend;
+  colorTarget.writeMask = wgpu::ColorWriteMask::Red;
+
+  wgpu::FragmentState fragmentState = {};
+  fragmentState.module = shader;
+  fragmentState.entryPoint = "fs_main";
+  fragmentState.targetCount = 1;
+  fragmentState.targets = &colorTarget;
+
+  wgpu::RenderPipelineDescriptor rpDesc = {};
+  rpDesc.label = "GeodeSlugMask";
+  rpDesc.layout = pipelineLayout;
+
+  rpDesc.vertex.module = shader;
+  rpDesc.vertex.entryPoint = "vs_main";
+  rpDesc.vertex.bufferCount = 1;
+  rpDesc.vertex.buffers = &vbLayout;
+
+  rpDesc.primitive.topology = wgpu::PrimitiveTopology::TriangleList;
+  rpDesc.primitive.cullMode = wgpu::CullMode::None;
+
+  rpDesc.fragment = &fragmentState;
+  // 4× MSAA matching the colour pipelines. The mask texture is
+  // allocated MSAA-4 with a 1-sample R8 resolve target; the main fill
+  // pipelines sample the resolved texture to pick up fractional
+  // coverage at the clip edge.
   rpDesc.multisample.count = 4;
   rpDesc.multisample.mask = 0xFFFFFFFF;
 

--- a/donner/svg/renderer/geode/GeodePipeline.h
+++ b/donner/svg/renderer/geode/GeodePipeline.h
@@ -103,4 +103,48 @@ private:
   wgpu::RenderPipeline pipeline_;
 };
 
+/**
+ * Caches a compiled `wgpu::RenderPipeline` for the path-clip mask shader
+ * (`shaders/slug_mask.wgsl`) plus its bind-group layout.
+ *
+ * The mask pipeline is a stripped-down sibling of @ref GeodePipeline —
+ * it reuses the same vertex shader, the same band/curve storage SSBOs,
+ * and the same 4× MSAA coverage path, but the fragment stage writes a
+ * single-channel coverage value into an `R8Unorm` color attachment. The
+ * resulting mask texture is then sampled by @ref GeodePipeline and
+ * @ref GeodeGradientPipeline as a clip coverage multiplier.
+ *
+ * The bind group layout is:
+ * - binding 0: uniform buffer (mvp, viewport, fillRule).
+ * - binding 1: storage buffer (read-only) — Band[].
+ * - binding 2: storage buffer (read-only) — curve data (flat f32[]).
+ *
+ * No texture / sampler bindings — the mask pipeline doesn't read from
+ * any texture input. Multiple paths belonging to a single clip layer
+ * are unioned on the hardware side via `BlendOperation::Max`.
+ */
+class GeodeMaskPipeline {
+public:
+  /**
+   * Create a Slug mask pipeline for the given device. Renders into an
+   * R8Unorm MSAA texture (the mask target is allocated by the caller).
+   */
+  explicit GeodeMaskPipeline(const wgpu::Device& device);
+
+  ~GeodeMaskPipeline() = default;
+  GeodeMaskPipeline(const GeodeMaskPipeline&) = delete;
+  GeodeMaskPipeline& operator=(const GeodeMaskPipeline&) = delete;
+  GeodeMaskPipeline(GeodeMaskPipeline&&) noexcept = default;
+  GeodeMaskPipeline& operator=(GeodeMaskPipeline&&) noexcept = default;
+
+  const wgpu::RenderPipeline& pipeline() const { return pipeline_; }
+  const wgpu::BindGroupLayout& bindGroupLayout() const { return bindGroupLayout_; }
+  /// The color format the pipeline targets. Always `R8Unorm`.
+  wgpu::TextureFormat colorFormat() const { return wgpu::TextureFormat::R8Unorm; }
+
+private:
+  wgpu::BindGroupLayout bindGroupLayout_;
+  wgpu::RenderPipeline pipeline_;
+};
+
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodeShaders.cc
+++ b/donner/svg/renderer/geode/GeodeShaders.cc
@@ -3,6 +3,7 @@
 #include "embed_resources/ImageBlitWgsl.h"
 #include "embed_resources/SlugFillWgsl.h"
 #include "embed_resources/SlugGradientWgsl.h"
+#include "embed_resources/SlugMaskWgsl.h"
 
 namespace donner::geode {
 
@@ -32,6 +33,21 @@ wgpu::ShaderModule createSlugGradientShader(const wgpu::Device& device) {
 
   wgpu::ShaderModuleDescriptor desc = {};
   desc.label = "SlugGradient";
+  desc.nextInChain = &wgslSource;
+
+  return device.CreateShaderModule(&desc);
+}
+
+wgpu::ShaderModule createSlugMaskShader(const wgpu::Device& device) {
+  // Embedded at build time from shaders/slug_mask.wgsl via the
+  // :slug_mask_wgsl rule in BUILD.bazel.
+  wgpu::ShaderSourceWGSL wgslSource = {};
+  wgslSource.code.data =
+      reinterpret_cast<const char*>(donner::embedded::kSlugMaskWgsl.data());
+  wgslSource.code.length = donner::embedded::kSlugMaskWgsl.size();
+
+  wgpu::ShaderModuleDescriptor desc = {};
+  desc.label = "SlugMask";
   desc.nextInChain = &wgslSource;
 
   return device.CreateShaderModule(&desc);

--- a/donner/svg/renderer/geode/GeodeShaders.h
+++ b/donner/svg/renderer/geode/GeodeShaders.h
@@ -43,6 +43,19 @@ wgpu::ShaderModule createSlugFillShader(const wgpu::Device& device);
 wgpu::ShaderModule createSlugGradientShader(const wgpu::Device& device);
 
 /**
+ * Compile the path-clip mask shader for the given device.
+ *
+ * Same band/curve encoding as @ref createSlugFillShader but the fragment
+ * stage writes a single-channel coverage value into an R8Unorm target.
+ * The uniform layout is reduced to just the mvp matrix, viewport size,
+ * and fill rule — no paint mode, no pattern, no clip polygon. Used by
+ * the Phase 3b path-clipping pipeline to materialise a per-pixel clip
+ * mask texture that subsequent fill / gradient draws sample as a
+ * coverage multiplier.
+ */
+wgpu::ShaderModule createSlugMaskShader(const wgpu::Device& device);
+
+/**
  * Compile the image-blit shader for the given device.
  *
  * The WGSL source is embedded at build time from

--- a/donner/svg/renderer/geode/GeodeTextureEncoder.cc
+++ b/donner/svg/renderer/geode/GeodeTextureEncoder.cc
@@ -26,13 +26,14 @@ constexpr uint32_t alignUp(uint32_t value, uint32_t alignment) {
 /// explicitly padded so the size is a multiple of the largest member's
 /// alignment (mat4x4 = 16 bytes).
 struct alignas(16) Uniforms {
-  float mvp[16];          // 0  .. 64
-  float destRect[4];      // 64 .. 80
-  float srcRect[4];       // 80 .. 96
-  float opacity;          // 96  .. 100
-  uint32_t sourceIsPremult;// 100 .. 104
-  float _pad0[2];         // 104 .. 112
-  float _pad1[4];         // 112 .. 128
+  float mvp[16];            //   0 ..  64
+  float destRect[4];        //  64 ..  80
+  float srcRect[4];         //  80 ..  96
+  float opacity;            //  96 .. 100
+  uint32_t sourceIsPremult; // 100 .. 104
+  uint32_t maskMode;        // 104 .. 108 — Phase 3c <mask> luminance blit
+  uint32_t applyMaskBounds; // 108 .. 112 — clip output to `maskBounds`
+  float maskBounds[4];      // 112 .. 128 — (x0, y0, x1, y1) in target-pixel space
 };
 static_assert(sizeof(Uniforms) == 128, "Image-blit Uniforms layout mismatch");
 
@@ -124,6 +125,12 @@ void GeodeTextureEncoder::drawTexturedQuad(GeodeDevice& device,
   u.srcRect[3] = static_cast<float>(params.srcRect.bottomRight.y);
   u.opacity = static_cast<float>(params.opacity);
   u.sourceIsPremult = params.sourceIsPremultiplied ? 1u : 0u;
+  u.maskMode = params.maskTexture ? 1u : 0u;
+  u.applyMaskBounds = params.applyMaskBounds ? 1u : 0u;
+  u.maskBounds[0] = static_cast<float>(params.maskBounds.topLeft.x);
+  u.maskBounds[1] = static_cast<float>(params.maskBounds.topLeft.y);
+  u.maskBounds[2] = static_cast<float>(params.maskBounds.bottomRight.x);
+  u.maskBounds[3] = static_cast<float>(params.maskBounds.bottomRight.y);
 
   wgpu::BufferDescriptor uniDesc = {};
   uniDesc.label = "GeodeImageBlitUniforms";
@@ -136,9 +143,14 @@ void GeodeTextureEncoder::drawTexturedQuad(GeodeDevice& device,
   const wgpu::Sampler& sampler =
       (params.filter == Filter::Nearest) ? pipeline.nearestSampler() : pipeline.linearSampler();
 
-  // Bind group.
+  // Bind group — the mask texture binding must always carry a valid
+  // view. When `params.maskTexture` is empty, we bind the source
+  // content texture view in its place as a cheap dummy (the shader
+  // ignores it because `maskMode == 0`).
   wgpu::TextureView view = texture.CreateView();
-  wgpu::BindGroupEntry entries[3] = {};
+  wgpu::TextureView maskView =
+      params.maskTexture ? params.maskTexture.CreateView() : view;
+  wgpu::BindGroupEntry entries[4] = {};
   entries[0].binding = 0;
   entries[0].buffer = uniBuf;
   entries[0].size = sizeof(Uniforms);
@@ -146,11 +158,13 @@ void GeodeTextureEncoder::drawTexturedQuad(GeodeDevice& device,
   entries[1].sampler = sampler;
   entries[2].binding = 2;
   entries[2].textureView = view;
+  entries[3].binding = 3;
+  entries[3].textureView = maskView;
 
   wgpu::BindGroupDescriptor bgDesc = {};
   bgDesc.label = "GeodeImageBlitBindGroup";
   bgDesc.layout = pipeline.bindGroupLayout();
-  bgDesc.entryCount = 3;
+  bgDesc.entryCount = 4;
   bgDesc.entries = entries;
   wgpu::BindGroup bindGroup = dev.CreateBindGroup(&bgDesc);
 

--- a/donner/svg/renderer/geode/GeodeTextureEncoder.h
+++ b/donner/svg/renderer/geode/GeodeTextureEncoder.h
@@ -93,6 +93,19 @@ public:
     /// are premultiplied and must set this flag to avoid a double
     /// premultiplication that darkens the RGB channel.
     bool sourceIsPremultiplied = false;
+    /// Phase 3c `<mask>` luminance compositing. When non-null, this
+    /// texture is sampled alongside the source and its BT.709
+    /// luminance (multiplied by alpha, to match tiny-skia's
+    /// `Mask::fromPixmap(Luminance)`) is used as a coverage
+    /// multiplier on the output. Ignored unless
+    /// `RendererGeode::popMask` sets it.
+    wgpu::Texture maskTexture;
+    /// When true, output pixels outside `maskBounds` are discarded.
+    /// Used to honour the `<mask>` element's x/y/width/height.
+    bool applyMaskBounds = false;
+    /// Mask bounds in target-pixel space. Ignored unless
+    /// `applyMaskBounds` is true.
+    Box2d maskBounds;
   };
 
   /**

--- a/donner/svg/renderer/geode/shaders/image_blit.wgsl
+++ b/donner/svg/renderer/geode/shaders/image_blit.wgsl
@@ -39,13 +39,30 @@ struct Uniforms {
   // will multiply the entire texel by `opacity` and write the result
   // as-is.
   sourceIsPremult: u32,
-  _pad0: f32,
-  _pad1: f32,
+  // Nonzero when this blit should apply a luminance mask from the
+  // texture bound at binding 3. Used by `RendererGeode::popMask` to
+  // composite mask content through a `<mask>` element's luminance.
+  // When 0, the mask texture binding carries the 1x1 dummy and the
+  // shader skips the sampling entirely.
+  maskMode: u32,
+  // When `maskMode != 0`, pixels outside `maskBounds` (x0, y0, x1, y1)
+  // in target-pixel space are discarded. When zero, the field is
+  // unused. Used to honour the `<mask>` element's x/y/width/height
+  // attributes.
+  applyMaskBounds: u32,
+  // Mask bounds rectangle (x0, y0, x1, y1) in target-pixel space —
+  // only read when `applyMaskBounds != 0`. Sits at offset 112 so it
+  // remains 16-byte (`vec4f`) aligned without explicit padding.
+  maskBounds: vec4f,
 };
 
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
 @group(0) @binding(1) var imageSampler: sampler;
 @group(0) @binding(2) var imageTexture: texture_2d<f32>;
+// Phase 3c luminance mask input — bound to a 1x1 dummy when
+// `maskMode == 0`. Sampled with the same `imageSampler` so texels are
+// interpolated between source pixels consistently with the content.
+@group(0) @binding(3) var maskTexture: texture_2d<f32>;
 
 // The vertex shader uses `@builtin(vertex_index)` to pick one of the six
 // corners of the quad — no vertex buffer is needed. Layout:
@@ -94,15 +111,53 @@ fn vs_main(@builtin(vertex_index) vid: u32) -> VertexOutput {
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4f {
   let sampled = textureSample(imageTexture, imageSampler, in.uv);
+
+  // Base colour — premultiplied by the pipeline's blend expectations.
+  var color: vec4f;
   if (uniforms.sourceIsPremult != 0u) {
     // Source is already premultiplied. Just scale the whole texel by
     // the external opacity so the output stays premultiplied and
     // composites correctly through the pipeline's source-over blend.
-    return sampled * uniforms.opacity;
+    color = sampled * uniforms.opacity;
+  } else {
+    // The uploaded texture stores straight-alpha RGBA8. Premultiply by
+    // (alpha * opacity) so the fragment matches the pipeline's
+    // premultiplied-source-over blend state.
+    let a = sampled.a * uniforms.opacity;
+    color = vec4f(sampled.rgb * a, a);
   }
-  // The uploaded texture stores straight-alpha RGBA8. Premultiply by
-  // (alpha * opacity) so the fragment matches the pipeline's
-  // premultiplied-source-over blend state.
-  let a = sampled.a * uniforms.opacity;
-  return vec4f(sampled.rgb * a, a);
+
+  if (uniforms.maskMode != 0u) {
+    // SVG `<mask>` luminance. tiny-skia's mask.rs computes
+    //   luma = 0.2126*R + 0.7152*G + 0.0722*B   (BT.709, on STRAIGHT RGB)
+    //   mask_value = luma * alpha
+    // Working on premultiplied input, `r_premult = r_straight * a`, so:
+    //   0.2126*R_pm + 0.7152*G_pm + 0.0722*B_pm
+    //     = a * (0.2126*R + 0.7152*G + 0.0722*B)
+    //     = luma * a = mask_value
+    // exactly the tiny-skia formula — no division, no branching.
+    let maskSample = textureSample(maskTexture, imageSampler, in.uv);
+    let maskValue = maskSample.r * 0.2126
+                  + maskSample.g * 0.7152
+                  + maskSample.b * 0.0722;
+
+    // Honour the `<mask>` element's x/y/width/height attributes by
+    // discarding anything outside the bounds rectangle in target-
+    // pixel space (the pipeline's `@builtin(position)` is in
+    // framebuffer coords, matching how the host computes the rect).
+    if (uniforms.applyMaskBounds != 0u) {
+      let px = in.clip_pos.xy;
+      if (px.x < uniforms.maskBounds.x || px.x >= uniforms.maskBounds.z ||
+          px.y < uniforms.maskBounds.y || px.y >= uniforms.maskBounds.w) {
+        return vec4f(0.0);
+      }
+    }
+
+    // `color` is already premultiplied; multiplying the whole texel
+    // by a scalar mask value keeps that invariant and matches
+    // tinyskia's `applyMask` (which uses premultiplied blend-in).
+    return color * maskValue;
+  }
+
+  return color;
 }

--- a/donner/svg/renderer/geode/shaders/slug_fill.wgsl
+++ b/donner/svg/renderer/geode/shaders/slug_fill.wgsl
@@ -43,9 +43,20 @@ struct Uniforms {
   paintMode: u32,
   // Pattern alpha multiplier (e.g., fill-opacity). 1.0 for solid paint.
   patternOpacity: f32,
-  // Padding to 16-byte alignment. Total struct size MUST match the CPU-side
-  // Uniforms struct in GeoEncoder.cc.
+  // Nonzero when a convex 4-vertex clip polygon is active. When 0, the
+  // `clipPolygonPlanes` field is ignored.
+  hasClipPolygon: u32,
+  // Nonzero when a path-clip mask texture is bound at binding 5 and
+  // should be sampled for per-pixel clip coverage. When 0, the mask
+  // binding still holds a 1x1 dummy texture (value 1.0) so the shader
+  // can unconditionally sample without tripping WebGPU validation.
+  hasClipMask: u32,
   _pad0: u32,
+  _pad1: u32,
+  // Four inward-facing half-planes in viewport-pixel space, one per polygon
+  // edge. `plane.xyz = (nx, ny, c)` with `nx*x + ny*y + c >= 0` inside. The
+  // `w` component is padding for std140-style alignment.
+  clipPolygonPlanes: array<vec4f, 4>,
 };
 
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
@@ -81,6 +92,16 @@ struct Band {
 // 1x1 dummy texture is bound and the shader never samples it.
 @group(0) @binding(3) var patternTexture: texture_2d<f32>;
 @group(0) @binding(4) var patternSampler: sampler;
+
+// Path-clip mask texture (Phase 3b). R8Unorm, 1-sample (resolved from a
+// 4× MSAA render target before this draw). Always bound — when
+// `uniforms.hasClipMask == 0u` a 1x1 dummy texture with value 1.0 is
+// bound so the shader can unconditionally `textureSample` at the pixel
+// center without needing branchless paths or bind group layout
+// variants. The sampler uses linear filtering so the clip edge
+// interpolates smoothly across pixels.
+@group(0) @binding(5) var clipMaskTexture: texture_2d<f32>;
+@group(0) @binding(6) var clipMaskSampler: sampler;
 
 // ============================================================================
 // Vertex stage
@@ -237,6 +258,26 @@ fn curve_winding(curve: Quadratic, sample: vec2f) -> i32 {
 // Fragment stage
 // ============================================================================
 
+/// Test whether a sample position (in viewport-pixel space) lies inside
+/// the active convex clip polygon. Returns `true` when no polygon is
+/// active, so callers can unconditionally AND this into their coverage
+/// decision.
+fn sample_in_clip_polygon(pixel_pos: vec2f) -> bool {
+  if (uniforms.hasClipPolygon == 0u) {
+    return true;
+  }
+  for (var i = 0u; i < 4u; i = i + 1u) {
+    let plane = uniforms.clipPolygonPlanes[i];
+    // Small epsilon so samples exactly on the polygon boundary count as
+    // inside — matches the inclusive-at-boundary convention of the
+    // scissor rect fallback.
+    if (plane.x * pixel_pos.x + plane.y * pixel_pos.y + plane.z < -1e-4) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /// Test whether a single sub-pixel sample position is inside the fill,
 /// per the active fill rule. Shared between `fs_main` sample-mask loop
 /// and any future per-sample helpers.
@@ -268,6 +309,12 @@ struct FragOutput {
 @fragment
 fn fs_main(in: VertexOutput) -> FragOutput {
   let band = bands[in.bandIndex];
+
+  // Framebuffer-pixel center of this fragment. WGSL specifies that
+  // reading `@builtin(position)` in the fragment stage returns the pixel
+  // coordinates (x + 0.5, y + 0.5) — this is what the clip polygon's
+  // half-plane equations are expressed in.
+  let pixel_center = in.clip_pos.xy;
 
   // NO pixel-center band-Y clip. The previous single-sample path
   // discarded fragments whose pixel center fell outside the band's
@@ -319,6 +366,14 @@ fn fs_main(in: VertexOutput) -> FragOutput {
       continue;
     }
 
+    // Convex clip-polygon test, in viewport-pixel space. The polygon
+    // planes were uploaded by `GeoEncoder::setClipPolygon`; no-op when
+    // inactive.
+    let pixel_sample = pixel_center + offsets[s];
+    if (!sample_in_clip_polygon(pixel_sample)) {
+      continue;
+    }
+
     if (sample_is_inside(band, sp)) {
       mask = mask | (1u << s);
     }
@@ -328,6 +383,24 @@ fn fs_main(in: VertexOutput) -> FragOutput {
     discard;
   }
 
+  // Path-clip mask: sample the pre-rendered clip mask texture at the
+  // pixel center and fold its coverage into the fragment colour. The
+  // mask texture was resolved from a 4× MSAA render target so its
+  // alpha channel already carries fractional edge coverage; sampling
+  // with a linear filter interpolates that across pixel boundaries.
+  // When no mask is active, `hasClipMask == 0` and we skip the work
+  // entirely — the dummy texture's 1.0 value would also work but the
+  // branch shaves a texture fetch off the hot path.
+  var clipCoverage: f32 = 1.0;
+  if (uniforms.hasClipMask != 0u) {
+    let mask_uv = pixel_center / uniforms.viewport;
+    clipCoverage = clamp(textureSample(clipMaskTexture, clipMaskSampler, mask_uv).r,
+                         0.0, 1.0);
+    if (clipCoverage <= 0.0) {
+      discard;
+    }
+  }
+
   var out: FragOutput;
   out.mask = mask;
 
@@ -335,7 +408,7 @@ fn fs_main(in: VertexOutput) -> FragOutput {
     // `uniforms.color` is already premultiplied by the host encoder.
     // The hardware routes this one color to the selected samples and
     // resolves to fractional coverage after the pass.
-    out.color = uniforms.color;
+    out.color = uniforms.color * clipCoverage;
     return out;
   }
 
@@ -348,7 +421,7 @@ fn fs_main(in: VertexOutput) -> FragOutput {
   );
   let uv = wrapped / uniforms.tileSize;
   var sampled = textureSample(patternTexture, patternSampler, uv);
-  sampled = sampled * uniforms.patternOpacity;
+  sampled = sampled * uniforms.patternOpacity * clipCoverage;
   out.color = sampled;
   return out;
 }

--- a/donner/svg/renderer/geode/shaders/slug_gradient.wgsl
+++ b/donner/svg/renderer/geode/shaders/slug_gradient.wgsl
@@ -73,6 +73,19 @@ struct GradientUniforms {
   // Per-stop offset in [0, 1]. Packed 4 stops per vec4 to respect WGSL's
   // 16-byte array stride for uniform buffers.
   stopOffsets: array<vec4f, 4u>,
+
+  // Nonzero when a convex 4-vertex clip polygon is active. Same semantics
+  // as in `slug_fill.wgsl` — the planes are expressed in viewport-pixel
+  // space and tested against each sample's `@builtin(position)` offset.
+  hasClipPolygon: u32,
+  // Nonzero when a path-clip mask texture is bound at binding 3 (see
+  // `slug_fill.wgsl` for the motivation — the gradient pipeline
+  // carries its own copy of the flag so neither shader needs to reach
+  // into the other's uniform block).
+  hasClipMask: u32,
+  _clipPad1: u32,
+  _clipPad2: u32,
+  clipPolygonPlanes: array<vec4f, 4>,
 };
 
 @group(0) @binding(0) var<uniform> uniforms: GradientUniforms;
@@ -93,6 +106,13 @@ struct Band {
 
 // Flat float array of quadratic Bézier control points (6 floats per curve).
 @group(0) @binding(2) var<storage, read> curveData: array<f32>;
+
+// Path-clip mask texture + sampler (Phase 3b). Always bound; a 1x1
+// dummy with value 1.0 is bound when `uniforms.hasClipMask == 0` so
+// the sample call is always legal. See `slug_fill.wgsl` for the full
+// motivation.
+@group(0) @binding(3) var clipMaskTexture: texture_2d<f32>;
+@group(0) @binding(4) var clipMaskSampler: sampler;
 
 // ============================================================================
 // Vertex stage
@@ -392,6 +412,23 @@ fn gradient_t(path_pos: vec2f) -> f32 {
 // Fragment stage
 // ============================================================================
 
+/// Convex clip-polygon test in viewport-pixel space. Mirrors the
+/// identical helper in `slug_fill.wgsl`; the gradient uniform block
+/// keeps its own copy of `hasClipPolygon` / `clipPolygonPlanes` so no
+/// cross-shader binding is required.
+fn sample_in_clip_polygon(pixel_pos: vec2f) -> bool {
+  if (uniforms.hasClipPolygon == 0u) {
+    return true;
+  }
+  for (var i = 0u; i < 4u; i = i + 1u) {
+    let plane = uniforms.clipPolygonPlanes[i];
+    if (plane.x * pixel_pos.x + plane.y * pixel_pos.y + plane.z < -1e-4) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /// Same shape as `sample_is_inside` in slug_fill.wgsl. Duplicated
 /// because WGSL modules are per-shader and the gradient pipeline uses
 /// its own uniform buffer layout.
@@ -423,6 +460,10 @@ fn fs_main(in: VertexOutput) -> FragOutput {
   // explanation. Per-sample checks inside the loop own each sample to
   // exactly one band.
 
+  // Framebuffer-pixel center of this fragment, used for the clip
+  // polygon test (which is expressed in viewport-pixel space).
+  let pixel_center = in.clip_pos.xy;
+
   let dx = dpdx(in.sample_pos);
   let dy = dpdy(in.sample_pos);
 
@@ -440,6 +481,10 @@ fn fs_main(in: VertexOutput) -> FragOutput {
     if (sp.y < band.yMin || sp.y >= band.yMax) {
       continue;
     }
+    let pixel_sample = pixel_center + offsets[s];
+    if (!sample_in_clip_polygon(pixel_sample)) {
+      continue;
+    }
     if (sample_is_inside(band, sp)) {
       mask = mask | (1u << s);
     }
@@ -447,6 +492,18 @@ fn fs_main(in: VertexOutput) -> FragOutput {
 
   if (mask == 0u) {
     discard;
+  }
+
+  // Path-clip mask sampling — see the identical block in
+  // `slug_fill.wgsl` for the rationale.
+  var clipCoverage: f32 = 1.0;
+  if (uniforms.hasClipMask != 0u) {
+    let mask_uv = pixel_center / uniforms.viewport;
+    clipCoverage = clamp(textureSample(clipMaskTexture, clipMaskSampler, mask_uv).r,
+                         0.0, 1.0);
+    if (clipCoverage <= 0.0) {
+      discard;
+    }
   }
 
   // Evaluate the gradient stop color at the pixel center. Per-sample
@@ -461,7 +518,7 @@ fn fs_main(in: VertexOutput) -> FragOutput {
   let straight = sample_stops(t);
 
   var out: FragOutput;
-  out.color = vec4f(straight.rgb * straight.a, straight.a);
+  out.color = vec4f(straight.rgb * straight.a, straight.a) * clipCoverage;
   out.mask = mask;
   return out;
 }

--- a/donner/svg/renderer/geode/shaders/slug_mask.wgsl
+++ b/donner/svg/renderer/geode/shaders/slug_mask.wgsl
@@ -1,0 +1,268 @@
+// Slug mask pipeline: renders filled paths as coverage into an R8Unorm
+// mask texture, for use as a clip source by the main fill / gradient
+// pipelines (Phase 3b path clipping).
+//
+// This is a stripped-down copy of `slug_fill.wgsl`:
+//   * Same vertex shader + same band/curve encoding, so the CPU-side
+//     `GeodePathEncoder::encode` output can be fed directly in.
+//   * Fragment stage does the same 4-sample `sample_mask` coverage test
+//     as `slug_fill.wgsl`, but writes `vec4f(1.0, 0, 0, 0)` to an
+//     R8Unorm color attachment instead of a full RGBA fill colour.
+//   * 4× MSAA resolve averages the surviving samples into a single
+//     fractional-alpha coverage per mask pixel, so downstream shaders
+//     can do a straight `textureSample` to read clip coverage.
+//   * No paint mode, no pattern, no clip polygon — the mask is a pure
+//     CPU-uploaded path filled into empty space. If multiple clip paths
+//     share a single layer they are unioned via `BlendOperation::Max` on
+//     the host pipeline, not via shader logic.
+
+// ============================================================================
+// Uniforms
+// ============================================================================
+
+struct Uniforms {
+  // Model-view-projection matrix. Same mvp as the fill pipeline — the
+  // mask is rendered in path space and projected to mask-texture pixel
+  // space exactly the way `slug_fill.wgsl` does.
+  mvp: mat4x4f,
+  // Viewport dimensions in pixels (mask texture size).
+  viewport: vec2f,
+  // Fill rule: 0 = non-zero, 1 = even-odd.
+  fillRule: u32,
+  // Nonzero when a nested clip mask is bound at binding 3 and should
+  // be sampled during this draw. Used to support nested clip-path
+  // references (`<clipPath>` whose children carry their own
+  // `clip-path`). When the outer layer samples the inner layer's
+  // already-rendered mask, each outer-layer shape ends up intersected
+  // with the inner union — and Max blend unions the outer shapes on
+  // top. When zero, a 1x1 dummy with value 1.0 is bound and the
+  // shader effectively treats every pixel as fully unclipped.
+  hasClipMask: u32,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+
+// ============================================================================
+// Storage buffers
+// ============================================================================
+
+struct Band {
+  curveStart: u32,
+  curveCount: u32,
+  yMin: f32,
+  yMax: f32,
+  xMin: f32,
+  xMax: f32,
+  _pad0: f32,
+  _pad1: f32,
+};
+
+@group(0) @binding(1) var<storage, read> bands: array<Band>;
+
+// Flat float array of quadratic Bézier control points (6 floats per curve).
+@group(0) @binding(2) var<storage, read> curveData: array<f32>;
+
+// Nested clip-mask input — see `uniforms.hasClipMask` above.
+@group(0) @binding(3) var clipMaskTexture: texture_2d<f32>;
+@group(0) @binding(4) var clipMaskSampler: sampler;
+
+// ============================================================================
+// Vertex stage
+// ============================================================================
+
+struct VertexInput {
+  @location(0) pos: vec2f,
+  @location(1) normal: vec2f,
+  @location(2) bandIndex: u32,
+};
+
+struct VertexOutput {
+  @builtin(position) clip_pos: vec4f,
+  @location(0) sample_pos: vec2f,
+  @location(1) @interpolate(flat) bandIndex: u32,
+};
+
+@vertex
+fn vs_main(in: VertexInput) -> VertexOutput {
+  // Dynamic half-pixel dilation — identical to slug_fill.wgsl.
+  let world_normal = (uniforms.mvp * vec4f(in.normal, 0.0, 0.0)).xy;
+  let viewport_normal = world_normal * uniforms.viewport * 0.5;
+  let viewport_len = length(viewport_normal);
+  let d = 1.0 / max(viewport_len, 0.001);
+
+  let dilated = in.pos + in.normal * d;
+
+  var out: VertexOutput;
+  out.clip_pos = uniforms.mvp * vec4f(dilated, 0.0, 1.0);
+  out.sample_pos = dilated;
+  out.bandIndex = in.bandIndex;
+  return out;
+}
+
+// ============================================================================
+// Quadratic Bézier ray intersection (shared with slug_fill.wgsl)
+// ============================================================================
+
+struct Quadratic {
+  p0: vec2f,
+  p1: vec2f,
+  p2: vec2f,
+};
+
+fn load_curve(index: u32) -> Quadratic {
+  let base = index * 6u;
+  var q: Quadratic;
+  q.p0 = vec2f(curveData[base + 0u], curveData[base + 1u]);
+  q.p1 = vec2f(curveData[base + 2u], curveData[base + 3u]);
+  q.p2 = vec2f(curveData[base + 4u], curveData[base + 5u]);
+  return q;
+}
+
+fn solve_quadratic(a: f32, b: f32, c: f32) -> vec2f {
+  var roots = vec2f(-1.0, -1.0);
+
+  // Same `1e-4` degenerate-quadratic threshold as slug_fill.wgsl —
+  // LineTo-derived quadratics have theoretical `a = 0` but float32
+  // rounding leaves a tiny residual that, without the widened gate,
+  // trips the quadratic branch and amplifies into spurious roots.
+  if (abs(a) < 1e-4) {
+    if (abs(b) > 1e-6) {
+      let t = -c / b;
+      if (t >= 0.0 && t <= 1.0) {
+        roots.x = t;
+      }
+    }
+    return roots;
+  }
+
+  let disc = b * b - 4.0 * a * c;
+  if (disc < 0.0) {
+    return roots;
+  }
+
+  let sqrt_disc = sqrt(disc);
+  let inv_2a = 0.5 / a;
+  let t0 = (-b - sqrt_disc) * inv_2a;
+  let t1 = (-b + sqrt_disc) * inv_2a;
+
+  if (t0 >= 0.0 && t0 <= 1.0) {
+    roots.x = t0;
+  }
+  if (t1 >= 0.0 && t1 <= 1.0) {
+    roots.y = t1;
+  }
+  return roots;
+}
+
+fn curve_winding(curve: Quadratic, sample: vec2f) -> i32 {
+  let a = curve.p0.y - 2.0 * curve.p1.y + curve.p2.y;
+  let b = 2.0 * (curve.p1.y - curve.p0.y);
+  let c = curve.p0.y - sample.y;
+
+  let roots = solve_quadratic(a, b, c);
+
+  var winding: i32 = 0;
+  for (var i = 0; i < 2; i = i + 1) {
+    let t = select(roots.y, roots.x, i == 0);
+    if (t < 0.0) {
+      continue;
+    }
+    let omt = 1.0 - t;
+    let x = omt * omt * curve.p0.x + 2.0 * omt * t * curve.p1.x + t * t * curve.p2.x;
+    if (x < sample.x) {
+      continue;
+    }
+    let dy_dt = 2.0 * omt * (curve.p1.y - curve.p0.y) + 2.0 * t * (curve.p2.y - curve.p1.y);
+    if (dy_dt > 0.0) {
+      winding = winding + 1;
+    } else if (dy_dt < 0.0) {
+      winding = winding - 1;
+    }
+  }
+  return winding;
+}
+
+fn sample_is_inside(band: Band, sample_pos: vec2f) -> bool {
+  var winding: i32 = 0;
+  for (var i = 0u; i < band.curveCount; i = i + 1u) {
+    let curve = load_curve(band.curveStart + i);
+    winding = winding + curve_winding(curve, sample_pos);
+  }
+  if (uniforms.fillRule == 0u) {
+    return winding != 0;
+  }
+  return (winding & 1) != 0;
+}
+
+// ============================================================================
+// Fragment stage
+// ============================================================================
+
+/// One color attachment + one sample mask. Same scheme as `slug_fill.wgsl`:
+/// the fragment runs once per pixel, the per-sample coverage test populates
+/// `mask` bits, and the hardware resolves the MSAA color attachment into
+/// a fractional-alpha single-sample R8 texture — directly usable as a
+/// clip coverage source.
+struct FragOutput {
+  @location(0) color: vec4f,
+  @builtin(sample_mask) mask: u32,
+};
+
+@fragment
+fn fs_main(in: VertexOutput) -> FragOutput {
+  let band = bands[in.bandIndex];
+
+  let pixel_center = in.clip_pos.xy;
+
+  let dx = dpdx(in.sample_pos);
+  let dy = dpdy(in.sample_pos);
+
+  // Same rotated 4-sample pattern as `slug_fill.wgsl` so the mask's
+  // edge AA lands on the same sub-pixel offsets as the colour pass.
+  var offsets = array<vec2f, 4>(
+    vec2f(-0.125, -0.375),
+    vec2f( 0.375, -0.125),
+    vec2f(-0.375,  0.125),
+    vec2f( 0.125,  0.375),
+  );
+
+  var mask: u32 = 0u;
+  for (var s: u32 = 0u; s < 4u; s = s + 1u) {
+    let sp = in.sample_pos + offsets[s].x * dx + offsets[s].y * dy;
+    if (sp.y < band.yMin || sp.y >= band.yMax) {
+      continue;
+    }
+    if (sample_is_inside(band, sp)) {
+      mask = mask | (1u << s);
+    }
+  }
+
+  if (mask == 0u) {
+    discard;
+  }
+
+  // Nested clip-mask input: when a deeper layer's mask is bound, each
+  // outer-layer shape we render must be INTERSECTED with the deeper
+  // union. Sampling it as a multiplier on the coverage value turns the
+  // Max-blended layer into `max(shape_i ∩ nested)` = `(union of
+  // shape_i) ∩ nested`, which matches `RendererTinySkia`'s recursive
+  // intersection rule.
+  var clipCoverage: f32 = 1.0;
+  if (uniforms.hasClipMask != 0u) {
+    let mask_uv = pixel_center / uniforms.viewport;
+    clipCoverage = clamp(textureSample(clipMaskTexture, clipMaskSampler, mask_uv).r,
+                         0.0, 1.0);
+    if (clipCoverage <= 0.0) {
+      discard;
+    }
+  }
+
+  var out: FragOutput;
+  // Red-channel coverage. The alpha channel is ignored because the
+  // downstream fill pipeline samples `.r` as the clip value. Multiply
+  // by the nested clip coverage so shape edges land inside the deeper
+  // union.
+  out.color = vec4f(clipCoverage, 0.0, 0.0, 1.0);
+  out.mask = mask;
+  return out;
+}

--- a/donner/svg/renderer/geode/tests/GeodeShaders_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeShaders_tests.cc
@@ -22,4 +22,13 @@ TEST(GeodeShaders, SlugFillCompiles) {
   // uncaptured error callback before we get here.
 }
 
+/// Smoke test for the Phase 3b path-clip mask shader.
+TEST(GeodeShaders, SlugMaskCompiles) {
+  auto geodeDevice = GeodeDevice::CreateHeadless();
+  ASSERT_NE(geodeDevice, nullptr);
+
+  wgpu::ShaderModule module = createSlugMaskShader(geodeDevice->device());
+  ASSERT_TRUE(static_cast<bool>(module)) << "Slug mask shader failed to compile";
+}
+
 }  // namespace donner::geode

--- a/donner/svg/renderer/tests/resvg_test_suite.cc
+++ b/donner/svg/renderer/tests/resvg_test_suite.cc
@@ -77,15 +77,11 @@ geodeCategoryGate(std::string_view category) {
     };
   }
 
-  // Clipping / masking: arbitrary path clipping and alpha masks are
-  // Phase 3. `masking/clip-rule` is just the fill-rule attribute on
-  // clip paths — also path-clip territory.
-  if (category == "masking/clip" || category == "masking/clipPath" ||
-      category == "masking/mask" || category == "masking/clip-rule") {
-    return [](ImageComparisonParams& p) {
-      p.disableBackend(RendererBackend::Geode, "clipping/masking (Geode Phase 3)");
-    };
-  }
+  // Clip-paths (`masking/clip`, `masking/clipPath`, `masking/clip-rule`)
+  // run through the Phase 3b mask pipeline, and `<mask>` elements run
+  // through the Phase 3c mask-blit pipeline — no wholesale category
+  // gate here. Individual per-file overrides handle any remaining
+  // divergences.
 
   // Markers: Phase 6.
   if (category == "painting/marker") {
@@ -156,14 +152,27 @@ geodeFilenameGate(std::string_view category, std::string_view filename) {
     };
   }
 
-  // `structure/image/preserveAspectRatio=xMaxYMax-slice-on-svg` has a
-  // content-level bug (see the Phase 3 block below), handled earlier
-  // than the rest of the `preserveAspectRatio=*` widening.
+  // `structure/image/preserveAspectRatio=xMaxYMax-slice-on-svg` is
+  // currently 104 pixels past the default 100-px max even at the
+  // widened 0.3 per-pixel threshold. The failing pixels form a thin
+  // fringe along the curved green stroke inside the embedded data-URL
+  // SVG: 4× MSAA places the sub-pixel stroke edge on a different side
+  // of the pixel boundary than tiny-skia's 16× supersample on roughly
+  // 4% of the edge pixels, and those are 100% diffs (fully-coloured
+  // stroke vs background), not something a threshold bump can absorb.
+  // Historically this test was disabled under the mistaken "path
+  // clipping (Phase 3)" rationale; Phase 3a polygon clipping confirms
+  // no non-axis-aligned transform is in play (ancestor transform is
+  // `matrix(16 0 0 16 10 175)`), so polygon clipping isn't the lever
+  // to close this gap. Leaving disabled as an AA-quantisation TODO
+  // until Geode picks up a finer sample pattern or analytic stroke AA.
+  // TODO(geode): upgrade to 8× / 16× MSAA or analytic stroke AA to
+  // shed the thin-stroke fringe pixels on nested-image tests.
   if (category == "structure/image" &&
       filename == "preserveAspectRatio=xMaxYMax-slice-on-svg.svg") {
     return [](ImageComparisonParams& p) {
       p.disableBackend(RendererBackend::Geode,
-                       "non-axis-aligned viewport clip needs path clipping (Phase 3)");
+                       "4× MSAA thin-stroke fringe on nested image data URL");
     };
   }
 
@@ -187,39 +196,6 @@ geodeFilenameGate(std::string_view category, std::string_view filename) {
       filename == "control-points-clamping-1.svg" ||
       filename == "preserveAspectRatio=xMaxYMax-slice-on-svg.svg") {
     return [](ImageComparisonParams& p) { widenThresholdForGeode(p); };
-  }
-
-  // `structure/symbol/with-transform-on-use` applies a `skewX(20)`
-  // transform on a `<use>` element that references a `<symbol>` with a
-  // 100×100 viewport containing a 120×120 rect. The correct rendering
-  // clips the rect to the symbol viewport *in symbol-local space* and
-  // then skews the clipped shape, producing a parallelogram with both
-  // left and right edges slanted. Geode's rectangular scissor clips in
-  // canvas space with the AABB of the transformed viewport — that's
-  // wider than the true skewed viewport polygon along the bottom
-  // edge, leaving an untransformed rectangle with a vertical right
-  // edge visible. The correct fix is path clipping (Phase 3), which
-  // would let Geode clip to the actual transformed-viewport polygon
-  // instead of its AABB.
-  //
-  // The same root cause hits
-  // `structure/image/preserveAspectRatio=xMaxYMax-slice-on-svg`: the
-  // nested SVG data URL uses `xMaxYMax slice` which extends the
-  // content past the `<image>` viewport; Geode's AABB scissor leaves
-  // the blue rounded-rect background visible past the green stroke
-  // where tiny-skia correctly clips it. Both files share the
-  // transformed-viewport clipping gap.
-  // TODO(geode-phase3): use path clipping for non-axis-aligned
-  // transformed viewports (`<symbol>`, `<svg>` with transform,
-  // `<image>` with `slice`) so scissor-AABB clipping is no longer
-  // required.
-  if ((category == "structure/symbol" && filename == "with-transform-on-use.svg") ||
-      (category == "structure/image" &&
-       filename == "preserveAspectRatio=xMaxYMax-slice-on-svg.svg")) {
-    return [](ImageComparisonParams& p) {
-      p.disableBackend(RendererBackend::Geode,
-                       "non-axis-aligned viewport clip needs path clipping (Phase 3)");
-    };
   }
 
   // `painting/stroke-linejoin/miter` renders 6 stroked polylines with


### PR DESCRIPTION
## Summary

Stacks three feature landings on top of [#504](https://github.com/jwmcglynn/donner/pull/504) that together close out Phase 3 of the Geode renderer (clipping + masking). Net delta on `resvg_test_suite_geode_text` is **596 → 666 passing / 0 failing** (+70 tests).

### Phase 3a — convex 4-vertex clip polygon

Non-axis-aligned ancestor transforms (skewed/rotated `<symbol>` / `<svg>` viewports) produce parallelogram clips that WebGPU's rectangular scissor can only approximate as the AABB. `GeoEncoder` gains `setClipPolygon(corners[4])` / `clearClipPolygon()`; the fill and gradient shaders grow a `hasClipPolygon` + `clipPolygonPlanes` uniform block, test each of 4 sub-pixel samples against 4 inward half-planes, and AND the result into `@builtin(sample_mask)` so the clip integrates with 4× MSAA coverage. `RendererGeode::pushClip` detects non-axis-aligned transforms via the 2×2 linear part and carries the 4 transformed corners alongside the scissor AABB. Unlocks `structure/symbol/with-transform-on-use{,-no-size}`.

### Phase 3b — path clipping via R8 mask texture

A new `GeodeMaskPipeline` + `shaders/slug_mask.wgsl` renders clip paths into a 4× MSAA R8Unorm target that resolves to a 1-sample R8Unorm texture; the main fill / gradient pipelines grow a texture + sampler binding and their fragment shaders sample `mask.r` at each pixel center and multiply it into the output colour. A 1×1 dummy R8 (value `0xFF`) is bound when no clip is active so the bind group layout stays stable.

`RendererGeode::pushClip` walks `clip.clipPaths` with the correct `clipPathUnitsTransform × entityFromParent × currentTransform` composition (row-vector convention, matching `RendererTinySkia`).

**Nested clip-path support.** `slug_mask.wgsl` itself accepts an input clip mask, and `pushClip` processes contiguous layer runs in `clip.clipPaths` bottom-up, binding the previous (deeper) layer's resolved mask as each outer layer's clipMask input. Because `max(shape_i ∩ nested) = (union of shape_i) ∩ nested`, the `BlendOperation::Max` on the R channel composes cleanly with the per-shape intersection done in the shader — exactly the recursive `buildLayerMask` semantics of `RendererTinySkia::pushClip`. Nested `<g>` clips (two separate `pushClip` calls stacking) are handled by seeding the deepest layer's input clip with the topmost existing clip stack entry's mask view.

Unlocks `masking/clip`, `masking/clipPath`, `masking/clip-rule`, plus the cross-category `*-on-clipPath` tests.

### Phase 3c — `<mask>` compositing via luminance blit

The existing `GeodeImagePipeline` is extended with a second texture binding (luminance mask) + `maskMode` / `applyMaskBounds` / `maskBounds` uniforms; a 1×1 dummy mask is bound for normal `drawImage` / `blitFullTarget` calls. The fragment shader computes `0.2126·R_pm + 0.7152·G_pm + 0.0722·B_pm` (which equals `luminance(demult) · alpha` for premultiplied input, matching tiny-skia's `Mask::fromPixmap(Luminance)`) and multiplies it into the output colour. Bounds outside the `<mask>` x/y/width/height rect are discarded in the shader.

`RendererGeode::pushMask` allocates two offscreen texture pairs (mask capture + masked content), redirects the encoder into the first pair, and snapshots the current transform for later bounds mapping. `transitionMaskToContent` swaps the encoder into the content pair. `popMask` composites the pair back onto the restored parent via `GeoEncoder::blitFullTargetMasked`, lifting the raw mask-bounds rect into device-pixel space through the saved transform so `maskUnits=userSpaceOnUse` and percent-sized bounds render correctly.

Unlocks the entire `masking/mask` category (31/31 tests passing).

### Struct size bumps

- Fill `Uniforms` (240 → 256 B) — adds `hasClipMask` + pads
- Gradient `GradientUniforms` (480 → 560 B) — adds `hasClipMask` field
- Image-blit `Uniforms` stays at 128 B by reusing existing trailing padding for `maskMode` / `applyMaskBounds` / `maskBounds`

### Test delta

| Feature | Pass → Pass |
|---|---|
| Start (post-#504) | 596 |
| Phase 3a polygon clipping (+2 symbol-transform tests unblocked) | 596 |
| Phase 3b texture-mask path clipping (+33) | 629 |
| Phase 3b nested clipPath (+7) | 636 |
| Phase 3c `<mask>` compositing (+30) | **666** |

## Test plan

- [x] `bazelisk test --config=geode //donner/svg/renderer/geode/... //donner/svg/renderer/tests:renderer_geode_tests //donner/svg/renderer/tests:renderer_geode_golden_tests //donner/svg/renderer/tests:resvg_test_suite_geode_text //donner/svg/renderer/tests:resvg_test_suite_geode_text_full`
- [x] `bazelisk test //donner/svg/renderer/tests:renderer_tests //donner/svg/renderer/tests:resvg_test_suite_tiny_skia_text` (no regression to shared code)
- [x] CI: `linux-geode`, `linux`, `macos` all green