### PR TITLE
Geode: Phase 3d mix-blend-mode (all 16 SVG blend modes)

### DIFF
--- a/docs/design_docs/geode_renderer.md
+++ b/docs/design_docs/geode_renderer.md
@@ -1289,10 +1289,28 @@ cleanup.
   clip rects), but is no longer on the critical path.
 - [x] Implement `pushIsolatedLayer`/`popIsolatedLayer`: offscreen
   render target allocation + opacity compositing. (Phase 2 landing.)
-  - [ ] Blend mode fragment shader (all 28 SVG/CSS blend modes).
-    Still pending — `popIsolatedLayer` does a plain premultiplied
-    source-over today. `painting/mix-blend-mode` + `painting/isolation`
-    remain category-gated.
+  - [x] **Phase 3d: blend mode fragment shader (all 16 SVG
+    `mix-blend-mode` values).** The existing `GeodeImagePipeline`
+    grew a third texture binding (`dstSnapshotTexture`) + a
+    `blendMode` uniform; `image_blit.wgsl` now carries the full
+    W3C Compositing Level 1 §9 suite (Normal → Luminosity,
+    including the HSL-space non-separable modes Hue / Saturation /
+    Color / Luminosity driven by the spec's `SetLum` / `SetSat` /
+    `ClipColor` helpers with the legacy 0.3/0.59/0.11 Lum
+    coefficients). `RendererGeode::popIsolatedLayer` takes the
+    blend-mode branch when the stored frame's mode is non-Normal:
+    it copies the parent's 1-sample resolve into a fresh snapshot
+    texture via `CommandEncoder::CopyTextureToTexture`, reopens the
+    parent with `LoadOp::Clear`, and dispatches
+    `GeoEncoder::blitFullTargetBlended(layer, snapshot, blendMode,
+    opacity)`. Group opacity is threaded through as the `opacity`
+    uniform so `opacity` + `mix-blend-mode` on the same element
+    composes correctly (source colour is scaled before the blend
+    formula, matching W3C Compositing 1 §7). Unlocks the full
+    `painting/mix-blend-mode` + `painting/isolation` categories —
+    21 of 22 mix-blend-mode/isolation tests pass at the default
+    threshold, no per-file overrides needed. Session delta: 666
+    → 688 passing on `resvg_test_suite_geode_text`.
 - [x] **Phase 3c: `<mask>` compositing via luminance blit.** The
   existing `GeodeImagePipeline` is extended with a second texture
   binding (luminance mask) + `maskMode` / `applyMaskBounds` /

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -488,6 +488,11 @@ struct RendererGeode::Impl {
     wgpu::Texture layerTexture;        // Inner layer 1-sample resolve.
     wgpu::Texture layerMsaaTexture;    // Inner layer 4× MSAA color attachment.
     double opacity = 1.0;
+    /// Phase 3d: SVG `mix-blend-mode`. `Normal` (default) keeps the
+    /// plain premultiplied source-over compositing path;
+    /// anything else drives `popIsolatedLayer` through the blend-blit
+    /// variant that snapshots the parent and uses the W3C formulas.
+    MixBlendMode blendMode = MixBlendMode::Normal;
   };
   std::vector<LayerStackFrame> layerStack;
 
@@ -654,7 +659,6 @@ struct RendererGeode::Impl {
   // only to keep stack semantics balanced and to drop the warning to stderr
   // exactly once per category in verbose mode.
   bool warnedClip = false;
-  bool warnedLayer = false;
   bool warnedFilter = false;
   bool warnedMask = false;
   bool warnedGradient = false;
@@ -1194,18 +1198,12 @@ void RendererGeode::popClip() {
 }
 
 void RendererGeode::pushIsolatedLayer(double opacity, MixBlendMode blendMode) {
-  // Blend modes other than Normal are a Phase 7 concern (they require the
-  // compute-based filter / compositor pipeline). For now we support
-  // Isolation + alpha — which handles group opacity, `<svg opacity=...>`,
-  // and nested-group `opacity` propagation, covering a-opacity-001/007/008
-  // and several adjacent tests. Anything-but-Normal blend is dropped with
-  // a one-shot warning.
-  if (blendMode != MixBlendMode::Normal) {
-    if (impl_->verbose && !impl_->warnedLayer) {
-      std::cerr << "RendererGeode: non-Normal blend modes not yet implemented (Phase 7)\n";
-      impl_->warnedLayer = true;
-    }
-  }
+  // Phase 3d implements all 16 `mix-blend-mode` values: the pushed
+  // layer renders normally, and `popIsolatedLayer` switches to a
+  // blend-blit compositor that reads a frozen snapshot of the parent
+  // target and runs the matching W3C Compositing 1 formula per
+  // pixel. `MixBlendMode::Normal` keeps the existing plain
+  // source-over composite path.
   if (!impl_->device || !impl_->pipeline || !impl_->gradientPipeline ||
       !impl_->imagePipeline || !impl_->encoder) {
     // Headless or degenerate state — drop silently but still push a
@@ -1261,6 +1259,7 @@ void RendererGeode::pushIsolatedLayer(double opacity, MixBlendMode blendMode) {
   frame.layerTexture = layerTexture;
   frame.layerMsaaTexture = layerMsaaTexture;
   frame.opacity = opacity;
+  frame.blendMode = blendMode;
 
   impl_->target = layerTexture;
   impl_->msaaTarget = layerMsaaTexture;
@@ -1291,13 +1290,72 @@ void RendererGeode::popIsolatedLayer() {
     impl_->encoder->finish();
   }
 
-  // Restore outer target + create a fresh encoder that preserves its
-  // existing contents (LoadOp::Load on the outer MSAA texture, whose
-  // state was retained via `StoreOp::Store`). Draw the layer's RESOLVED
-  // (1-sample) texture across the entire target with the stored opacity
-  // as the compositing alpha.
+  // Restore outer target references.
   impl_->target = frame.savedTarget;
   impl_->msaaTarget = frame.savedMsaaTarget;
+
+  if (frame.blendMode != MixBlendMode::Normal) {
+    // Phase 3d: SVG `mix-blend-mode`. The fragment shader needs the
+    // parent's current pixels as a backdrop, but WebGPU forbids
+    // reading from the render pass's own color attachment. Snapshot
+    // the parent's 1-sample resolve target into a separate texture
+    // via a CopyTextureToTexture command, then open a fresh parent
+    // encoder with `LoadOp::Clear` (NOT Load — the blend shader
+    // outputs the final pixel directly, incorporating the snapshot
+    // backdrop, so preserving the old contents would double-apply).
+    wgpu::TextureDescriptor snapDesc = {};
+    snapDesc.label = "RendererGeodeBlendDstSnapshot";
+    snapDesc.size = {static_cast<uint32_t>(impl_->pixelWidth),
+                     static_cast<uint32_t>(impl_->pixelHeight), 1u};
+    snapDesc.format = kFormat;
+    snapDesc.usage =
+        wgpu::TextureUsage::TextureBinding | wgpu::TextureUsage::CopyDst;
+    snapDesc.mipLevelCount = 1;
+    snapDesc.sampleCount = 1;
+    snapDesc.dimension = wgpu::TextureDimension::e2D;
+    wgpu::Texture snapshot = impl_->device->device().CreateTexture(&snapDesc);
+
+    if (snapshot) {
+      wgpu::CommandEncoderDescriptor copyDesc = {};
+      copyDesc.label = "RendererGeodeBlendCopy";
+      wgpu::CommandEncoder copyEncoder =
+          impl_->device->device().CreateCommandEncoder(&copyDesc);
+
+      wgpu::TexelCopyTextureInfo src = {};
+      src.texture = frame.savedTarget;
+      wgpu::TexelCopyTextureInfo dst = {};
+      dst.texture = snapshot;
+      const wgpu::Extent3D extent = {static_cast<uint32_t>(impl_->pixelWidth),
+                                     static_cast<uint32_t>(impl_->pixelHeight), 1u};
+      copyEncoder.CopyTextureToTexture(&src, &dst, &extent);
+      wgpu::CommandBuffer copyCmd = copyEncoder.Finish();
+      impl_->device->queue().Submit(1, &copyCmd);
+
+      // Open a fresh parent encoder that CLEARS the target — the
+      // blend blit covers every pixel so the clear has no visible
+      // effect, and skipping Load means a stale feedback loop can't
+      // sneak in.
+      auto newEncoder = std::make_unique<geode::GeoEncoder>(
+          *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
+          frame.savedMsaaTarget, frame.savedTarget);
+      newEncoder->clear(css::RGBA(0, 0, 0, 0));
+      impl_->encoder = std::move(newEncoder);
+      impl_->updateEncoderScissor();
+      impl_->encoder->blitFullTargetBlended(frame.layerTexture, snapshot,
+                                            static_cast<uint32_t>(frame.blendMode),
+                                            frame.opacity);
+      return;
+    }
+    // If snapshot allocation failed fall through to the Normal path —
+    // at least the layer content shows up even if unblended.
+  }
+
+  // Plain premultiplied source-over (the `Normal` case). Create a
+  // fresh encoder that preserves its existing contents (LoadOp::Load
+  // on the outer MSAA texture, whose state was retained via
+  // `StoreOp::Store`). Draw the layer's RESOLVED (1-sample) texture
+  // across the entire target with the stored opacity as the
+  // compositing alpha.
   auto newEncoder = std::make_unique<geode::GeoEncoder>(
       *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
       frame.savedMsaaTarget, frame.savedTarget);

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -1344,6 +1344,49 @@ void GeoEncoder::blitFullTargetMasked(const wgpu::Texture& content, const wgpu::
                                         mvp, impl_->targetWidth, impl_->targetHeight, qp);
 }
 
+void GeoEncoder::blitFullTargetBlended(const wgpu::Texture& layer,
+                                       const wgpu::Texture& dstSnapshot, uint32_t blendMode,
+                                       double opacity) {
+  if (!layer || !dstSnapshot || blendMode == 0u) {
+    return;
+  }
+  impl_->ensurePassOpen();
+  impl_->bindImagePipeline(impl_->imagePipeline->pipeline());
+
+  // Identity MVP for target-pixel → clip space, same as blitFullTarget.
+  const double sx = 2.0 / static_cast<double>(impl_->targetWidth);
+  const double sy = -2.0 / static_cast<double>(impl_->targetHeight);
+  float mvp[16] = {0};
+  mvp[0] = static_cast<float>(sx);
+  mvp[5] = static_cast<float>(sy);
+  mvp[10] = 1.0f;
+  mvp[12] = -1.0f;
+  mvp[13] = 1.0f;
+  mvp[15] = 1.0f;
+
+  GeodeTextureEncoder::QuadParams qp;
+  qp.destRect = Box2d(Vector2d(0.0, 0.0),
+                      Vector2d(static_cast<double>(impl_->targetWidth),
+                               static_cast<double>(impl_->targetHeight)));
+  qp.srcRect = Box2d({0.0, 0.0}, {1.0, 1.0});
+  // Per W3C Compositing 1, group opacity scales the SOURCE colour
+  // BEFORE the blend formula: `Cs_effective = Cs * groupOpacity` and
+  // `αs_effective = αs * groupOpacity`. The shader's leading
+  // multiply `color = sampled * uniforms.opacity` does exactly this
+  // to the premultiplied layer texel before calling
+  // `composite_with_blend`, so forwarding `opacity` here is enough.
+  qp.opacity = opacity;
+  qp.filter = GeodeTextureEncoder::Filter::Linear;
+  // Both layer and dst_snapshot are offscreen render targets already
+  // stored in premultiplied alpha.
+  qp.sourceIsPremultiplied = true;
+  qp.blendMode = blendMode;
+  qp.dstSnapshotTexture = dstSnapshot;
+
+  GeodeTextureEncoder::drawTexturedQuad(*impl_->device, *impl_->imagePipeline, impl_->pass, layer,
+                                        mvp, impl_->targetWidth, impl_->targetHeight, qp);
+}
+
 void GeoEncoder::drawImage(const svg::ImageResource& image, const Box2d& destRect, double opacity,
                            bool pixelated) {
   if (image.data.empty() || image.width <= 0 || image.height <= 0) {

--- a/donner/svg/renderer/geode/GeoEncoder.h
+++ b/donner/svg/renderer/geode/GeoEncoder.h
@@ -299,6 +299,33 @@ public:
                             const std::optional<Box2d>& maskBounds);
 
   /**
+   * Phase 3d `mix-blend-mode` compositing. Blits `layer` across the
+   * entire target using one of the 16 W3C Compositing Level 1 blend
+   * formulas, reading the backdrop from `dstSnapshot` (which the
+   * caller has already copied from the parent target because the
+   * shader cannot read the render pass's own color attachment).
+   *
+   * Both textures must be the SAME SIZE as this encoder's target
+   * and already stored in premultiplied alpha. The encoder's pass
+   * must be in a `LoadOp::Clear` state — the blend shader writes the
+   * final pixel directly and relies on the render target being
+   * zeroed before the draw.
+   *
+   * @param layer Offscreen RGBA8 layer texture (premultiplied).
+   * @param dstSnapshot Frozen copy of the parent target's current
+   *   state (premultiplied) — the blend's backdrop.
+   * @param blendMode Value in `1..=16` matching the
+   *   `donner::svg::MixBlendMode` enumeration. A value of `0`
+   *   silently falls through to no-op.
+   * @param opacity Group opacity in [0, 1]. Applied to the layer
+   *   BEFORE the blend formula so an `opacity` + `mix-blend-mode`
+   *   combo on the same element composes correctly — the source
+   *   colour that enters the blend is `layer * opacity`.
+   */
+  void blitFullTargetBlended(const wgpu::Texture& layer, const wgpu::Texture& dstSnapshot,
+                             uint32_t blendMode, double opacity);
+
+  /**
    * Draw a raster image into the given destination rectangle.
    *
    * The image's straight-alpha RGBA8 pixels are uploaded to a fresh

--- a/donner/svg/renderer/geode/GeodeImagePipeline.cc
+++ b/donner/svg/renderer/geode/GeodeImagePipeline.cc
@@ -8,11 +8,13 @@ GeodeImagePipeline::GeodeImagePipeline(const wgpu::Device& device,
                                        wgpu::TextureFormat colorFormat)
     : colorFormat_(colorFormat) {
   // ----- Bind group layout -----
-  // Four bindings: uniform buffer, sampler, sampled content texture,
-  // sampled luminance-mask texture. The mask texture is only read
-  // when `uniforms.maskMode != 0`; in normal blit mode a 1x1 dummy
-  // is bound so the layout stays stable.
-  wgpu::BindGroupLayoutEntry entries[4] = {};
+  // Five bindings: uniform buffer, sampler, sampled content texture,
+  // sampled luminance-mask texture (Phase 3c), sampled parent-
+  // snapshot texture (Phase 3d blend modes). The mask and snapshot
+  // textures are only read when their respective uniform flags are
+  // non-zero; in normal blit mode both bind to a 1x1 dummy so the
+  // bind group layout stays stable across every draw.
+  wgpu::BindGroupLayoutEntry entries[5] = {};
 
   entries[0].binding = 0;
   entries[0].visibility = wgpu::ShaderStage::Vertex | wgpu::ShaderStage::Fragment;
@@ -35,9 +37,15 @@ GeodeImagePipeline::GeodeImagePipeline(const wgpu::Device& device,
   entries[3].texture.viewDimension = wgpu::TextureViewDimension::e2D;
   entries[3].texture.multisampled = false;
 
+  entries[4].binding = 4;
+  entries[4].visibility = wgpu::ShaderStage::Fragment;
+  entries[4].texture.sampleType = wgpu::TextureSampleType::Float;
+  entries[4].texture.viewDimension = wgpu::TextureViewDimension::e2D;
+  entries[4].texture.multisampled = false;
+
   wgpu::BindGroupLayoutDescriptor bglDesc = {};
   bglDesc.label = "GeodeImageBlitBGL";
-  bglDesc.entryCount = 4;
+  bglDesc.entryCount = 5;
   bglDesc.entries = entries;
   bindGroupLayout_ = device.CreateBindGroupLayout(&bglDesc);
 

--- a/donner/svg/renderer/geode/GeodeTextureEncoder.cc
+++ b/donner/svg/renderer/geode/GeodeTextureEncoder.cc
@@ -34,8 +34,12 @@ struct alignas(16) Uniforms {
   uint32_t maskMode;        // 104 .. 108 — Phase 3c <mask> luminance blit
   uint32_t applyMaskBounds; // 108 .. 112 — clip output to `maskBounds`
   float maskBounds[4];      // 112 .. 128 — (x0, y0, x1, y1) in target-pixel space
+  uint32_t blendMode;       // 128 .. 132 — Phase 3d mix-blend-mode selector
+  uint32_t _blendPad0;      // 132 .. 136
+  uint32_t _blendPad1;      // 136 .. 140
+  uint32_t _blendPad2;      // 140 .. 144
 };
-static_assert(sizeof(Uniforms) == 128, "Image-blit Uniforms layout mismatch");
+static_assert(sizeof(Uniforms) == 144, "Image-blit Uniforms layout mismatch");
 
 }  // namespace
 
@@ -131,6 +135,7 @@ void GeodeTextureEncoder::drawTexturedQuad(GeodeDevice& device,
   u.maskBounds[1] = static_cast<float>(params.maskBounds.topLeft.y);
   u.maskBounds[2] = static_cast<float>(params.maskBounds.bottomRight.x);
   u.maskBounds[3] = static_cast<float>(params.maskBounds.bottomRight.y);
+  u.blendMode = params.blendMode;
 
   wgpu::BufferDescriptor uniDesc = {};
   uniDesc.label = "GeodeImageBlitUniforms";
@@ -143,14 +148,16 @@ void GeodeTextureEncoder::drawTexturedQuad(GeodeDevice& device,
   const wgpu::Sampler& sampler =
       (params.filter == Filter::Nearest) ? pipeline.nearestSampler() : pipeline.linearSampler();
 
-  // Bind group — the mask texture binding must always carry a valid
-  // view. When `params.maskTexture` is empty, we bind the source
-  // content texture view in its place as a cheap dummy (the shader
-  // ignores it because `maskMode == 0`).
+  // Bind group — the mask and dst-snapshot texture bindings must
+  // always carry a valid view. When their owning feature flags are
+  // off, we bind the source content texture view as a cheap dummy
+  // (the shader never samples it because the mode guard is 0).
   wgpu::TextureView view = texture.CreateView();
   wgpu::TextureView maskView =
       params.maskTexture ? params.maskTexture.CreateView() : view;
-  wgpu::BindGroupEntry entries[4] = {};
+  wgpu::TextureView dstView =
+      params.dstSnapshotTexture ? params.dstSnapshotTexture.CreateView() : view;
+  wgpu::BindGroupEntry entries[5] = {};
   entries[0].binding = 0;
   entries[0].buffer = uniBuf;
   entries[0].size = sizeof(Uniforms);
@@ -160,11 +167,13 @@ void GeodeTextureEncoder::drawTexturedQuad(GeodeDevice& device,
   entries[2].textureView = view;
   entries[3].binding = 3;
   entries[3].textureView = maskView;
+  entries[4].binding = 4;
+  entries[4].textureView = dstView;
 
   wgpu::BindGroupDescriptor bgDesc = {};
   bgDesc.label = "GeodeImageBlitBindGroup";
   bgDesc.layout = pipeline.bindGroupLayout();
-  bgDesc.entryCount = 4;
+  bgDesc.entryCount = 5;
   bgDesc.entries = entries;
   wgpu::BindGroup bindGroup = dev.CreateBindGroup(&bgDesc);
 

--- a/donner/svg/renderer/geode/GeodeTextureEncoder.h
+++ b/donner/svg/renderer/geode/GeodeTextureEncoder.h
@@ -106,6 +106,18 @@ public:
     /// Mask bounds in target-pixel space. Ignored unless
     /// `applyMaskBounds` is true.
     Box2d maskBounds;
+    /// Phase 3d SVG `mix-blend-mode` selector. `0` = plain
+    /// source-over; `1..=16` map to the enumeration in
+    /// `donner::svg::MixBlendMode` (Normal..Luminosity). When
+    /// non-zero, `dstSnapshotTexture` must hold the parent render
+    /// target's frozen content for the fragment shader to read as
+    /// the backdrop.
+    uint32_t blendMode = 0;
+    /// Frozen snapshot of the parent render target — see
+    /// `RendererGeode::popIsolatedLayer` which copies the prior
+    /// parent content into a separate texture before opening the
+    /// blend blit pass. Ignored unless `blendMode != 0`.
+    wgpu::Texture dstSnapshotTexture;
   };
 
   /**

--- a/donner/svg/renderer/geode/shaders/image_blit.wgsl
+++ b/donner/svg/renderer/geode/shaders/image_blit.wgsl
@@ -54,6 +54,17 @@ struct Uniforms {
   // only read when `applyMaskBounds != 0`. Sits at offset 112 so it
   // remains 16-byte (`vec4f`) aligned without explicit padding.
   maskBounds: vec4f,
+  // Phase 3d: SVG `mix-blend-mode` selector. `0` = plain source-over
+  // (or `maskMode` when set). `1..=16` map to the enumeration in
+  // `donner::svg::MixBlendMode` in the same order. When non-zero, the
+  // fragment shader samples the `dstSnapshotTexture` at binding 4 and
+  // composites the content through the matching W3C Compositing 1
+  // formula before writing. `maskMode` and `blendMode` are mutually
+  // exclusive; the host sets at most one per draw.
+  blendMode: u32,
+  _blendPad0: u32,
+  _blendPad1: u32,
+  _blendPad2: u32,
 };
 
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
@@ -63,6 +74,12 @@ struct Uniforms {
 // `maskMode == 0`. Sampled with the same `imageSampler` so texels are
 // interpolated between source pixels consistently with the content.
 @group(0) @binding(3) var maskTexture: texture_2d<f32>;
+// Phase 3d destination snapshot for `mix-blend-mode`. Bound to a
+// 1x1 dummy when `blendMode == 0`. When non-zero, this is a copy of
+// the parent render target captured before the blend blit pass, so
+// the blend formula can read the backdrop without the feedback loop
+// of sampling the pass's own color attachment.
+@group(0) @binding(4) var dstSnapshotTexture: texture_2d<f32>;
 
 // The vertex shader uses `@builtin(vertex_index)` to pick one of the six
 // corners of the quad — no vertex buffer is needed. Layout:
@@ -108,6 +125,263 @@ fn vs_main(@builtin(vertex_index) vid: u32) -> VertexOutput {
   return out;
 }
 
+// ============================================================================
+// W3C Compositing 1 — mix-blend-mode formulas
+// ============================================================================
+//
+// All blend functions `B(Cb, Cs)` operate on STRAIGHT-alpha RGB values.
+// The final W3C composite is applied by `composite_with_blend` below:
+//
+//   Cs' = (1 - αb) * Cs + αb * B(Cb, Cs)           // blended source
+//   Co  = αs * Cs' + (1 - αs) * αb * Cb            // premultiplied output
+//   αo  = αs + αb - αs * αb                        // Porter-Duff "over"
+//
+// which reduces to ordinary source-over when `B(Cb, Cs) == Cs` (the
+// Normal case). The host demultiplies both inputs inside
+// `composite_with_blend` before calling any of the helpers below so
+// these functions can use the straight-alpha formulas verbatim.
+//
+// Non-separable modes (hue, saturation, color, luminosity) get their
+// own dedicated `blend_*_non_separable` helpers because they operate
+// on the full RGB triple rather than per-channel.
+
+fn blend_multiply(cb: vec3f, cs: vec3f) -> vec3f {
+  return cb * cs;
+}
+
+fn blend_screen(cb: vec3f, cs: vec3f) -> vec3f {
+  return cb + cs - cb * cs;
+}
+
+fn blend_hard_light(cb: vec3f, cs: vec3f) -> vec3f {
+  // Overlay(cs, cb) = HardLight(cb, cs). Per W3C §9.1.7 the spec
+  // definition is: if cs <= 0.5 then 2*cb*cs else Screen(cb, 2*cs - 1).
+  let lo = 2.0 * cb * cs;
+  let hi = vec3f(1.0) - 2.0 * (vec3f(1.0) - cb) * (vec3f(1.0) - cs);
+  return select(hi, lo, cs <= vec3f(0.5));
+}
+
+fn blend_overlay(cb: vec3f, cs: vec3f) -> vec3f {
+  // Overlay(cb, cs) = HardLight(cs, cb) — roles swapped.
+  return blend_hard_light(cs, cb);
+}
+
+fn blend_darken(cb: vec3f, cs: vec3f) -> vec3f {
+  return min(cb, cs);
+}
+
+fn blend_lighten(cb: vec3f, cs: vec3f) -> vec3f {
+  return max(cb, cs);
+}
+
+fn blend_color_dodge_channel(cb: f32, cs: f32) -> f32 {
+  if (cb == 0.0) {
+    return 0.0;
+  }
+  if (cs >= 1.0) {
+    return 1.0;
+  }
+  return min(1.0, cb / (1.0 - cs));
+}
+
+fn blend_color_dodge(cb: vec3f, cs: vec3f) -> vec3f {
+  return vec3f(
+    blend_color_dodge_channel(cb.x, cs.x),
+    blend_color_dodge_channel(cb.y, cs.y),
+    blend_color_dodge_channel(cb.z, cs.z),
+  );
+}
+
+fn blend_color_burn_channel(cb: f32, cs: f32) -> f32 {
+  if (cb >= 1.0) {
+    return 1.0;
+  }
+  if (cs <= 0.0) {
+    return 0.0;
+  }
+  return 1.0 - min(1.0, (1.0 - cb) / cs);
+}
+
+fn blend_color_burn(cb: vec3f, cs: vec3f) -> vec3f {
+  return vec3f(
+    blend_color_burn_channel(cb.x, cs.x),
+    blend_color_burn_channel(cb.y, cs.y),
+    blend_color_burn_channel(cb.z, cs.z),
+  );
+}
+
+fn blend_soft_light_channel(cb: f32, cs: f32) -> f32 {
+  // W3C Compositing 1 §9.1.9 soft-light.
+  //
+  //   if (cs <= 0.5):
+  //     B = cb - (1 - 2*cs) * cb * (1 - cb)
+  //   else:
+  //     if (cb <= 0.25):
+  //       D = ((16*cb - 12) * cb + 4) * cb
+  //     else:
+  //       D = sqrt(cb)
+  //     B = cb + (2*cs - 1) * (D - cb)
+  if (cs <= 0.5) {
+    return cb - (1.0 - 2.0 * cs) * cb * (1.0 - cb);
+  }
+  var d: f32;
+  if (cb <= 0.25) {
+    d = ((16.0 * cb - 12.0) * cb + 4.0) * cb;
+  } else {
+    d = sqrt(cb);
+  }
+  return cb + (2.0 * cs - 1.0) * (d - cb);
+}
+
+fn blend_soft_light(cb: vec3f, cs: vec3f) -> vec3f {
+  return vec3f(
+    blend_soft_light_channel(cb.x, cs.x),
+    blend_soft_light_channel(cb.y, cs.y),
+    blend_soft_light_channel(cb.z, cs.z),
+  );
+}
+
+fn blend_difference(cb: vec3f, cs: vec3f) -> vec3f {
+  return abs(cb - cs);
+}
+
+fn blend_exclusion(cb: vec3f, cs: vec3f) -> vec3f {
+  return cb + cs - 2.0 * cb * cs;
+}
+
+// --- Non-separable modes (HSL) --------------------------------------------
+//
+// Lum, Sat, SetLum, SetSat, ClipColor follow W3C Compositing 1 §9.2.
+// The coefficients are the SVG / W3C spec values — NOT BT.709 — and are
+// applied to STRAIGHT RGB.
+
+fn lum_of(c: vec3f) -> f32 {
+  return 0.3 * c.x + 0.59 * c.y + 0.11 * c.z;
+}
+
+fn clip_color(c_in: vec3f) -> vec3f {
+  let l = lum_of(c_in);
+  let n = min(c_in.x, min(c_in.y, c_in.z));
+  let x = max(c_in.x, max(c_in.y, c_in.z));
+  var c = c_in;
+  if (n < 0.0) {
+    c = l + ((c - l) * l) / (l - n);
+  }
+  if (x > 1.0) {
+    c = l + ((c - l) * (1.0 - l)) / (x - l);
+  }
+  return c;
+}
+
+fn set_lum(c_in: vec3f, l: f32) -> vec3f {
+  let d = l - lum_of(c_in);
+  return clip_color(c_in + vec3f(d));
+}
+
+fn sat_of(c: vec3f) -> f32 {
+  return max(c.x, max(c.y, c.z)) - min(c.x, min(c.y, c.z));
+}
+
+fn set_sat(c_in: vec3f, s: f32) -> vec3f {
+  // Sort channels and rewrite mid/max relative to the new saturation.
+  // This is the `SetSat` algorithm from §9.2 expressed without
+  // pointer-chasing: identify min/mid/max indices by successive
+  // min/max operations, then build the output componentwise.
+  let r = c_in.x;
+  let g = c_in.y;
+  let b = c_in.z;
+  let cmax = max(r, max(g, b));
+  let cmin = min(r, min(g, b));
+  let cmid = r + g + b - cmax - cmin;
+
+  var new_min = 0.0;
+  var new_mid = 0.0;
+  var new_max = 0.0;
+  if (cmax > cmin) {
+    new_mid = ((cmid - cmin) * s) / (cmax - cmin);
+    new_max = s;
+  }
+
+  // Rebuild componentwise by comparing each input channel to the
+  // identified extremes. Exact-equality checks match the W3C
+  // reference — ties preserve the input ordering.
+  var out: vec3f;
+  out.x = select(new_min, select(new_max, new_mid, r == cmid), r == cmax);
+  out.y = select(new_min, select(new_max, new_mid, g == cmid), g == cmax);
+  out.z = select(new_min, select(new_max, new_mid, b == cmid), b == cmax);
+  // `set_sat` is followed by `set_lum` so tiny ordering ambiguities
+  // get absorbed by the luminosity restoration step.
+  return out;
+}
+
+fn blend_hue(cb: vec3f, cs: vec3f) -> vec3f {
+  return set_lum(set_sat(cs, sat_of(cb)), lum_of(cb));
+}
+
+fn blend_saturation(cb: vec3f, cs: vec3f) -> vec3f {
+  return set_lum(set_sat(cb, sat_of(cs)), lum_of(cb));
+}
+
+fn blend_color(cb: vec3f, cs: vec3f) -> vec3f {
+  return set_lum(cs, lum_of(cb));
+}
+
+fn blend_luminosity(cb: vec3f, cs: vec3f) -> vec3f {
+  return set_lum(cb, lum_of(cs));
+}
+
+// Dispatch. The caller passes demultiplied `cb` / `cs` and gets back
+// the blended straight-alpha RGB to plug into the Compositing-1
+// composite equation.
+fn apply_blend_fn(mode: u32, cb: vec3f, cs: vec3f) -> vec3f {
+  switch (mode) {
+    case 1u { return blend_multiply(cb, cs); }
+    case 2u { return blend_screen(cb, cs); }
+    case 3u { return blend_overlay(cb, cs); }
+    case 4u { return blend_darken(cb, cs); }
+    case 5u { return blend_lighten(cb, cs); }
+    case 6u { return blend_color_dodge(cb, cs); }
+    case 7u { return blend_color_burn(cb, cs); }
+    case 8u { return blend_hard_light(cb, cs); }
+    case 9u { return blend_soft_light(cb, cs); }
+    case 10u { return blend_difference(cb, cs); }
+    case 11u { return blend_exclusion(cb, cs); }
+    case 12u { return blend_hue(cb, cs); }
+    case 13u { return blend_saturation(cb, cs); }
+    case 14u { return blend_color(cb, cs); }
+    case 15u { return blend_luminosity(cb, cs); }
+    default { return cs; }
+  }
+}
+
+fn composite_with_blend(mode: u32, src_pm: vec4f, dst_pm: vec4f) -> vec4f {
+  // Demultiply both sides so the blend formulas see straight-alpha
+  // inputs. Skip the divide when alpha is zero so we don't emit NaN.
+  var cs = vec3f(0.0);
+  if (src_pm.a > 0.0) {
+    cs = src_pm.rgb / src_pm.a;
+  }
+  var cb = vec3f(0.0);
+  if (dst_pm.a > 0.0) {
+    cb = dst_pm.rgb / dst_pm.a;
+  }
+  let as_ = src_pm.a;
+  let ab = dst_pm.a;
+
+  let blended = apply_blend_fn(mode, cb, cs);
+
+  // Blended source colour per Compositing 1 §5.8.
+  let cs_prime = (1.0 - ab) * cs + ab * blended;
+
+  // Porter-Duff `over` with the blended source, emitting a
+  // premultiplied result:
+  //   co = αs * Cs' + (1 - αs) * αb * Cb
+  //   αo = αs + αb - αs * αb
+  let co = as_ * cs_prime + (1.0 - as_) * ab * cb;
+  let ao = as_ + ab - as_ * ab;
+  return vec4f(co, ao);
+}
+
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4f {
   let sampled = textureSample(imageTexture, imageSampler, in.uv);
@@ -125,6 +399,17 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
     // premultiplied-source-over blend state.
     let a = sampled.a * uniforms.opacity;
     color = vec4f(sampled.rgb * a, a);
+  }
+
+  if (uniforms.blendMode != 0u) {
+    // Phase 3d `mix-blend-mode`. `color` is the layer being composited
+    // (premultiplied), `dstSnapshotTexture` is the frozen parent
+    // target captured before the blend blit pass. The fragment
+    // output REPLACES the parent pixel — the pipeline is configured
+    // with `srcFactor=One, dstFactor=Zero` so this shader output
+    // lands verbatim in the render target.
+    let dstSample = textureSample(dstSnapshotTexture, imageSampler, in.uv);
+    return composite_with_blend(uniforms.blendMode, color, dstSample);
   }
 
   if (uniforms.maskMode != 0u) {

--- a/donner/svg/renderer/tests/resvg_test_suite.cc
+++ b/donner/svg/renderer/tests/resvg_test_suite.cc
@@ -90,12 +90,11 @@ geodeCategoryGate(std::string_view category) {
     };
   }
 
-  // Mix-blend-mode and isolation: Phase 9 (compositing).
-  if (category == "painting/mix-blend-mode" || category == "painting/isolation") {
-    return [](ImageComparisonParams& p) {
-      p.disableBackend(RendererBackend::Geode, "mix-blend-mode / isolation (Geode Phase 9)");
-    };
-  }
+  // Phase 3d implements all 16 W3C Compositing 1 blend modes through
+  // the image_blit pipeline's `blendMode` uniform + dst-snapshot
+  // binding, so `painting/mix-blend-mode` and `painting/isolation`
+  // are no longer wholesale gated here. Per-file overrides handle
+  // any remaining divergences.
 
   return std::nullopt;
 }


### PR DESCRIPTION
## Summary

Stacks on top of [#506](https://github.com/jwmcglynn/donner/pull/506). Extends the image-blit pipeline with the full W3C Compositing Level 1 suite for SVG `mix-blend-mode`, closing out the last correctness-bearing item in the Phase 3 checklist.

**Net delta on `resvg_test_suite_geode_text`: 666 → 688 passing / 0 failing (+22)**. The last remaining category gates in `painting/mix-blend-mode` and `painting/isolation` are gone.

### Shader (`shaders/image_blit.wgsl`)

- New `blendMode` uniform + `dstSnapshotTexture` binding at slot 4. When non-zero, the fragment samples the backdrop and runs the blended source-over composite.
- All 16 separable + non-separable blend functions inlined: **Multiply, Screen, Overlay, Darken, Lighten, ColorDodge, ColorBurn, HardLight, SoftLight, Difference, Exclusion, Hue, Saturation, Color, Luminosity**. The HSL-space modes use the W3C §9.2 `SetLum` / `SetSat` / `ClipColor` helpers with the legacy 0.3 / 0.59 / 0.11 `Lum` coefficients.
- `composite_with_blend` demultiplies both inputs, applies the blend function on straight RGB, then rebuilds the premultiplied Compositing-1 result:
  ```
  co = αs * [(1−αb)*cs + αb*B(cb,cs)] + (1−αs)*αb*cb
  αo = αs + αb − αs*αb
  ```
  which reduces to plain source-over when `B(cb,cs)=cs`.

### Pipeline / encoder

- `GeodeImagePipeline` bind group 4 → 5 entries (adds the dst-snapshot texture binding).
- CPU `Uniforms` struct 128 → 144 bytes (adds `blendMode` + pad; `maskBounds` stays at offset 112 for vec4 alignment).
- `QuadParams` gains `blendMode` + `dstSnapshotTexture`; when the snapshot is empty, the content view is rebound as a dummy so the bind group layout stays stable across every draw path.
- `GeoEncoder::blitFullTargetBlended(layer, dst, blendMode, opacity)` new public API. Reuses the existing fullscreen-quad infrastructure and threads group opacity through as the shader's `opacity` uniform so `opacity` + `mix-blend-mode` on the same element composes correctly (source colour is scaled BEFORE the blend formula, matching W3C Compositing 1 §7).

### Renderer (`RendererGeode::popIsolatedLayer`)

- `LayerStackFrame` now carries the stored `MixBlendMode`.
- Non-Normal branch: allocate a fresh 1-sample RGBA8 snapshot texture, drive a dedicated `CommandEncoder` to `CopyTextureToTexture` from the saved 1-sample resolve into it, submit, then open the restored parent encoder with `clear(RGBA(0,0,0,0))` (NOT `setLoadPreserve` — the blend shader writes the final pixel directly, so Load would double-apply the backdrop). Dispatch via `blitFullTargetBlended`.
- Normal branch keeps the existing `setLoadPreserve` + `blitFullTarget` path.

### Test gates

Drops `painting/mix-blend-mode` and `painting/isolation` from `geodeCategoryGate` — both categories now run end-to-end on Geode. The stale `warnedLayer` one-shot stderr flag is removed along the way.

## Stacked PR note

This targets `geode-phase3` (#506) as its base so the stacked diff only shows the blend-mode work. When #506 merges, GitHub will automatically retarget this PR to `main`.

## Test plan

- [ ] `bazelisk test --config=geode //donner/svg/renderer/geode/... //donner/svg/renderer/tests:renderer_geode_tests //donner/svg/renderer/tests:renderer_geode_golden_tests //donner/svg/renderer/tests:resvg_test_suite_geode_text //donner/svg/renderer/tests:resvg_test_suite_geode_text_full`
- [ ] `bazelisk test //donner/svg/renderer/tests:renderer_tests //donner/svg/renderer/tests:resvg_test_suite_tiny_skia_text` (no regression to shared code)
- [ ] CI: `linux-geode`, `linux`, `macos` all green