### PR TITLE
Add CLAUDE.md with squash-and-merge PR convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# Donner Project Instructions
+
+## Pull Requests
+
+- **Always squash-and-merge** when merging PRs. Use `gh pr merge --squash`.
+- Never use merge commits or rebase-and-merge on this repository.


### PR DESCRIPTION
## Summary

- Adds a `CLAUDE.md` project instruction file establishing that all PRs must be squash-and-merged via `gh pr merge --squash`.

## Test plan

- [x] No code changes — instruction-only file