### PR TITLE
Editor Sandbox M2: RendererInterface wire format, process isolation, GUI editor

### DIFF
--- a/docs/design_docs/editor_sandbox.md
+++ b/docs/design_docs/editor_sandbox.md
@@ -1,0 +1,983 @@
+# Design: Editor Sandbox, Renderer-IPC, and Record/Replay
+
+**Status:** Design
+**Author:** Claude Opus 4.6
+**Created:** 2026-04-11
+
+## Summary
+
+Donner's editor today parses and renders untrusted SVG in-process. As the editor
+grows a user-facing **address bar** that loads arbitrary `https://` URLs and local
+`file://` paths, the parser — Donner's largest fuzzer-exposed surface — becomes
+the single most attractive target in the binary. A parser crash or memory
+corruption would take the editor (and the user's unsaved work) with it.
+
+This design puts the parser, DOM, and `RendererDriver` in a **separate
+sandboxed child process**, mirroring the browser process model. The clever
+part: we already have `RendererInterface` — a pure-virtual, value-typed,
+stateful-but-LIFO command surface with 28 methods — and `RendererRecorder` is
+already planned as a tee wrapper. **Those two facts together mean the
+`RendererInterface` is already an RPC protocol in disguise.** We make it
+literal:
+
+1. Sandbox process runs parser + `RendererDriver` + a `SerializingRenderer`
+   that encodes each virtual call as a wire message.
+2. Editor host runs `ReplayingRenderer` that decodes the wire stream and
+   invokes the **real** backend (Skia, TinySkia, Geode).
+3. The on-wire format is the same format `RendererRecorder` writes, so
+   **record/replay is free** — it's just "tee the IPC socket into a file."
+4. Because every render command is addressable by index in the stream, the
+   editor gets a **frame inspector**: pause the IPC pump, show the recorded
+   command list in an ImGui panel, scrub a slider, replay commands `[0..N)`
+   to a headless backend, blit the result.
+
+The C++26-reflection angle is specifically about the marshalling layer: with
+reflection, we can derive the serializer for each method's parameter struct
+mechanically instead of writing 28 hand-rolled `Encode*`/`Decode*` pairs. Today
+that's aspirational (tree is on C++20); we land the hand-rolled version first
+and plan the reflection migration as a follow-up that deletes boilerplate
+rather than changes behavior.
+
+Address bar is the motivating UX: "type a URL, see it render, crash the child
+process if it's malicious, recover transparently." It is the forcing function
+for the sandbox; the sandbox is the forcing function for the IPC layer; the IPC
+layer is the forcing function for record/replay and the frame inspector. The
+whole stack falls out of one decision.
+
+## Goals
+
+- **Isolate parsing**: `SVGParser::ParseSVG` runs in a child process with no
+  filesystem, network, or IPC access beyond its stdin/stdout pipes. A crash or
+  memory corruption in the parser never takes the editor down.
+- **Address bar**: editor gains a URL bar that accepts `https://`, `http://`,
+  and `file://` URIs. Loads are always routed through the sandbox.
+- **RendererInterface as IPC**: the 28-method `RendererInterface` becomes the
+  wire protocol between sandbox and host. No other IPC surface exists between
+  the two processes.
+- **RendererRecorder → file format**: promote the planned in-memory
+  `RendererRecorder` into a serializable format (`.rnr`, "Renderer Recording")
+  that round-trips across the IPC boundary and to disk.
+- **Frame inspector**: ImGui panel inside the editor that shows the command
+  stream for the current frame, allows pausing before `endFrame()`, scrubbing
+  to command index `N`, and inspecting individual command arguments.
+- **Determinism**: replaying a `.rnr` file against the same backend at the
+  same viewport must be pixel-identical to the original render.
+- **No C++26 dependency on day one**: hand-rolled marshallers ship first;
+  reflection is a follow-up that preserves the wire format.
+
+## Non-Goals
+
+- **Not a full browser sandbox.** We're not using `seccomp-bpf`, AppArmor, or
+  SELinux policies in the initial milestone — just OS process separation,
+  closed file descriptors, and a dropped working directory. Hardening is
+  staged.
+- **Not cross-origin CSS/font/image fetches.** The sandbox child parses SVG
+  *bytes*; it never initiates network requests. The host fetches the bytes
+  over HTTPS and hands them to the sandbox. Sub-resource URL fetching (e.g.
+  `<image href="https://...">`) is Future Work.
+- **Not WASM-compatible.** The sandbox uses Unix pipes and `posix_spawn`; the
+  editor's WASM build (M6) continues to run the parser in-process, with the
+  browser's own sandbox as the trust boundary. The IPC abstraction exists,
+  but `SandboxedParseSVG` is a direct call in WASM builds.
+- **Not Windows in milestone 1.** Editor M3 targets macOS + Linux; the
+  sandbox follows the same platform cut. Windows is Future Work.
+- **Not a replacement for the fuzzer.** `SVGParser_fuzzer` continues to find
+  bugs at the parser level. The sandbox is defense-in-depth, not defense-in-first.
+- **Not a general-purpose IPC framework.** This is one protocol
+  (`RendererInterface`), not a reusable RPC system. No service discovery, no
+  versioning handshake beyond a magic-number header, no bidirectional method
+  calls (the sandbox is strictly a producer of commands).
+
+## Next Steps
+
+- [ ] Land Editor M2 (mutation seam, `AsyncSVGDocument` command queue) —
+  sandbox depends on the host-side command queue as the insertion point.
+- [ ] Land `RendererRecorder` as specified in
+  [renderer_interface_design.md:242](./renderer_interface_design.md) — the
+  in-memory variant is the foundation for the wire format.
+- [ ] Prototype **Milestone S1** (byte-level sandbox loopback, no IPC yet):
+  parse in a child process, return rendered PNG bytes over stdout. This
+  proves the process model before committing to the RendererInterface wire
+  protocol.
+
+## Implementation Plan
+
+- [ ] **Milestone S1: Byte-in, PNG-out child process (proof of model)**
+  - [ ] New binary `//donner/editor/sandbox:donner_parser_child`, no ImGui,
+        no GL, no renderer backend. Reads SVG bytes from stdin, parses,
+        renders to an in-memory bitmap via `RendererTinySkia::createOffscreenInstance()`,
+        writes PNG bytes to stdout, exits.
+  - [ ] Host-side `SandboxHost` class in `//donner/editor:sandbox_host` that
+        `posix_spawn`s the child with `stdin`/`stdout` piped, writes SVG
+        bytes, reads PNG bytes, returns them. Synchronous API.
+  - [ ] Crash test: feed `SVGParser_fuzzer` corpus through `SandboxHost`;
+        host must never crash, only observe non-zero exit codes.
+  - [ ] **Decision gate**: if S1 frame time is dominated by process spawn,
+        switch to a long-lived child with a framed-message protocol before
+        S2. Measure `posix_spawn` + first-render on a p50 corpus entry.
+
+- [ ] **Milestone S2: RendererInterface wire format**
+  - [ ] Define `donner::editor::sandbox::Wire` — a framed message format.
+        Header: 4-byte magic `DRNR`, 4-byte version, 4-byte length, 4-byte
+        opcode, payload. Payload is POD-only; variable-length fields
+        (`std::vector<PathShape>`, `SmallVector<RcString>`) are length-prefixed.
+  - [ ] Enumerate opcodes, one per `RendererInterface` virtual method. 28
+        total + `kEndOfFrame` sentinel + `kError`.
+  - [ ] Implement `SerializingRenderer : RendererInterface` that writes the
+        corresponding opcode + marshalled payload to a `BufferedWriter`
+        (abstracted so it can target a pipe, a file, or an in-memory vector).
+  - [ ] Implement `ReplayingRenderer` that reads from a `BufferedReader`,
+        decodes, and forwards to a wrapped `RendererInterface&`.
+  - [ ] **Round-trip test** in `//donner/svg/renderer/tests`: for every golden
+        SVG in the existing resvg test suite, assert that
+        `RendererTinySkia → serialize → deserialize → RendererTinySkia`
+        produces a pixel-identical snapshot to `RendererTinySkia` alone.
+        This is the single test that proves the wire format is lossless.
+  - [ ] Hand-write marshallers for `PathShape`, `PaintParams`, `ResolvedClip`,
+        `ImageParams`, `TextParams`, `FilterGraph`, `StrokeParams`,
+        `ResolvedPaintServer` variant, `ResolvedMask`. Track total LOC; this
+        is the number C++26 reflection will delete in Milestone S5.
+  - [ ] Fuzz the deserializer. New target `sandbox_wire_fuzzer` that feeds
+        random bytes into `ReplayingRenderer` and asserts it never crashes
+        — only returns `kError`. This is non-negotiable: the deserializer is
+        the trust boundary.
+
+- [ ] **Milestone S3: Long-lived child + address bar**
+  - [ ] Replace S1's one-shot child with a long-lived `donner_parser_child`
+        that reads a `ParseRequest` (SVG bytes + viewport + backend choice)
+        and streams a `SerializingRenderer` command sequence over stdout
+        until `kEndOfFrame`, then loops. Exits on EOF.
+  - [ ] Host-side `SandboxHost::render(bytes, viewport) -> CommandStream`
+        where `CommandStream` is a movable handle that pumps commands into
+        the host's real renderer via `ReplayingRenderer`.
+  - [ ] **Address bar UI** in `EditorApp`:
+        - ImGui `InputText` at the top of the viewport.
+        - Accepts `https://`, `http://`, `file://`, and bare paths.
+        - Dispatch: HTTPS fetch happens on the **host** (uses `curl` vendored
+          as a dev-only `bazel_dep` — see Dependencies), then hands bytes to
+          `SandboxHost`. `file://` / bare paths are read on the host
+          (filesystem access is a host privilege, not a sandbox privilege),
+          then handed off identically. The sandbox only ever sees raw bytes.
+        - Status chip: `Loading…`, `Rendered`, `Crashed (sandbox)`,
+          `Parse error`, `Fetch failed (HTTP 404)`, etc.
+  - [ ] **Crash recovery**: if the sandbox child exits non-zero, show the
+        error chip, keep the previously-rendered document on screen, and
+        respawn the child on the next navigation. No editor state is lost.
+  - [ ] Wire the address bar into `fuzz_replay_cli` from editor M5: every
+        fuzzer corpus entry gets fed through the address bar code path,
+        asserting host-process liveness.
+
+- [ ] **Milestone S4: Record/replay + frame inspector**
+  - [ ] Define `.rnr` file format = Wire framing + a single header block
+        (viewport, backend hint, timestamp, originating URL). A file is
+        literally the stdout of a sandboxed render session, captured verbatim.
+  - [ ] `DrnrRecorder` is a `BufferedWriter` adapter that tees the IPC stream
+        to disk while it's flowing into `ReplayingRenderer`. Zero-copy;
+        recording is a ~0% overhead passthrough.
+  - [ ] `donner_editor replay <file.rnr>` CLI mode: loads a file, replays
+        into the editor's current backend, shows the result in the viewport.
+        Also usable from `fuzz_replay_cli`.
+  - [ ] **Frame inspector pane**: new ImGui dockable window.
+        - Toggle "Pause next frame" button. When pressed, `SandboxHost`
+          buffers the whole command stream for frame `N+1` into a
+          `std::vector<WireMessage>` before handing it to `ReplayingRenderer`.
+        - Command list: virtual-scrolled ImGui table, one row per command,
+          showing opcode, nesting depth (tracked by push/pop balance),
+          and a one-line summary (`setPaint(fill=#FF0000, stroke=none)`).
+        - Scrub slider: `[0..N]` where `N = commands.size()`. Dragging
+          replays commands `[0..i)` into an off-screen
+          `RendererInterface::createOffscreenInstance()` at the viewport
+          resolution, blits the result into the main viewport. This gives a
+          "draw order visualization" for free.
+        - Inspector sub-pane: click a command row, see its full decoded
+          arguments (path ops, paint servers, transform matrix) in a
+          ImGui property tree.
+        - "Export .rnr" button dumps the paused frame to disk.
+  - [ ] Structural-diff mode: load two `.rnr` files, show a diff of their
+        command streams side-by-side. Useful for regression triage.
+
+- [ ] **Milestone S5: C++26 reflection migration (aspirational, gated)**
+  - [ ] Bump `.bazelrc` `--config=c++26` (new config, not default). Verify
+        with the current `latest_llvm` toolchain. If not yet available,
+        park this milestone.
+  - [ ] Replace hand-rolled `Encode<PathShape>` / `Decode<PathShape>` etc.
+        with a single `Encode<T>` / `Decode<T>` template that iterates
+        `std::meta::nonstatic_data_members_of(^^T)`.
+  - [ ] **Wire format must not change.** This milestone is a code reduction,
+        not a protocol change. Gate on the round-trip test from S2 continuing
+        to pass byte-for-byte.
+  - [ ] Measure LOC delta. Target: delete at least 60% of the hand-rolled
+        marshaller code from S2.
+
+- [ ] **Milestone S6: Sandbox hardening (defense in depth)**
+  - [ ] Linux: `seccomp-bpf` filter applied inside the child after
+        initialization — allow only `read`, `write`, `brk`, `mmap`,
+        `munmap`, `exit`, `exit_group`, `rt_sigreturn`, `futex`. Any other
+        syscall kills the child.
+  - [ ] macOS: `sandbox_init` with a deny-all profile allowing only
+        stdin/stdout pipes. (macOS sandboxing is deprecated-but-extant; good
+        enough for editor-local protection.)
+  - [ ] Close all inherited file descriptors except the IPC pipes before
+        `execve`. Set `RLIMIT_AS` (address space), `RLIMIT_CPU`, `RLIMIT_FSIZE`.
+  - [ ] Run child under its own UID if the editor is launched with
+        sufficient privilege (optional, off by default).
+  - [ ] No `/proc` access, no filesystem access, no network.
+
+## User Stories
+
+- **As a security-conscious user**, I want to paste a URL from a random
+  Discord channel into the editor without worrying that a malformed SVG
+  will corrupt my in-progress document.
+- **As a developer**, I want to debug "why does this SVG render wrong in
+  Donner but right in Chrome" by pausing at the exact draw call where the
+  visual diverges, and inspecting the paint parameters.
+- **As a fuzzer operator**, I want `fuzz_replay_cli` to exercise the same
+  code path real users hit (sandbox + IPC + replay), so crashes found in
+  fuzzing are crashes users would see.
+- **As a bug reporter**, I want to attach a `.rnr` file to an issue that
+  reproduces the visual glitch without shipping the possibly-proprietary
+  source SVG.
+- **As a Donner maintainer**, I want the record/replay format to be
+  version-controlled regression fixtures so I can assert that
+  "issue #NNN renders this command sequence" forever.
+
+## Background
+
+Donner's parser is the highest-surface attack target in the codebase. It
+accepts arbitrary XML + CSS + path data + filter graphs, and fuzzer corpus
+already exists (`SVGParser_fuzzer`, `SVGParser_structured_fuzzer`). Every
+editor launch that loads an SVG today is trusting the parser with the
+host process lifecycle.
+
+Chromium, Firefox, Safari, and Edge all moved HTML/CSS/image parsing out of
+the browser UI process a decade ago for exactly this reason. Browsers treat
+the renderer as a separate process that receives display-list-ish commands
+and rasterizes them. Donner's `RendererInterface` is already shaped like a
+display list; it's 28 pure virtual methods over value types. The only thing
+stopping it from being a wire protocol is that we haven't written a
+serializer.
+
+Prior art in tree:
+
+- `RendererRecorder` (planned, not shipped) — the tee pattern, in-memory
+  only. See [renderer_interface_design.md:242-256](./renderer_interface_design.md).
+- `RendererInterface` — [donner/svg/renderer/RendererInterface.h:190-353](../../donner/svg/renderer/RendererInterface.h).
+- Editor design doc — [docs/design_docs/editor.md](./editor.md). The editor
+  currently has no sandbox story.
+- Parser entry point — [donner/svg/parser/SVGParser.h:93](../../donner/svg/parser/SVGParser.h).
+  Already `noexcept`; already produces a `ParseResult`. Already the right
+  seam.
+
+No existing IPC, process separation, shared memory, or sandboxing code in
+the tree (grep confirmed). This is greenfield.
+
+## Requirements and Constraints
+
+**Functional:**
+- Every SVG load through the address bar, file dialog, or programmatic
+  `EditorApp::loadSvgString()` is routed through the sandbox.
+- The host process never executes `SVGParser::ParseSVG` directly (except in
+  WASM builds, where the browser is the sandbox).
+- Wire format is stable within a milestone; breaking changes bump the
+  4-byte version header.
+- Record/replay files are portable across Skia/TinySkia/Geode backends with
+  pixel identity on the same backend, best-effort parity across backends.
+
+**Quality:**
+- Sandbox roundtrip (parse + render + IPC + replay) adds no more than
+  **2× the in-process render time** at p50 for the existing test corpus.
+  The goal is "you don't notice"; a 2× budget leaves room to optimize.
+- Child process spawn + first-render latency ≤ 80 ms at p95 on the M1 target
+  machines (Linux dev laptop, macOS dev laptop). If it's higher, we switch
+  to a warm-pool model.
+- Frame inspector pause → unpause → next render ≤ 16 ms (one frame) so the
+  inspector doesn't drop frames when engaged.
+
+**Constraints:**
+- No raising the minimum C++ standard for non-sandbox code until S5. S5 is
+  opt-in under a separate build config.
+- No new mandatory dependencies in the BCR consumer graph. All sandbox
+  deps (`curl`, any IPC helpers) are `dev_dependency = True` in
+  `MODULE.bazel`, same pattern as imgui/glfw/tracy.
+- No `fork()` without `exec()` — we don't want to inherit the host's entt
+  registry, GL context, or malloc arena into the child.
+
+## Proposed Architecture
+
+### Trust boundary
+
+```
+┌────────────────────────────────────────┐     ┌───────────────────────────────┐
+│  Editor Host Process (TRUSTED)         │     │  Sandbox Child (UNTRUSTED)    │
+│                                        │     │                               │
+│  ┌──────────────────────────────────┐  │     │  ┌─────────────────────────┐  │
+│  │  ImGui UI + Address Bar          │  │     │  │  stdin: ParseRequest    │  │
+│  │   │                              │  │     │  │     │                   │  │
+│  │   ▼                              │  │     │  │     ▼                   │  │
+│  │  HTTP(S) fetch (curl) / fs read  │  │     │  │  SVGParser::ParseSVG    │  │
+│  │   │                              │  │     │  │     │                   │  │
+│  │   ▼ (raw bytes)                  │  │     │  │     ▼                   │  │
+│  │  SandboxHost::render()           │──┼─────┼──│  SVGDocument            │  │
+│  │   │                              │  │ IPC │  │     │                   │  │
+│  │   │  ┌───────────────────────┐   │  │ pipe│  │     ▼                   │  │
+│  │   │  │ ReplayingRenderer     │   │  │     │  │  RendererDriver         │  │
+│  │   │  │   decodes wire msgs   │◄──┼──┼─────┼──│     │                   │  │
+│  │   │  │   forwards to:        │   │  │     │  │     ▼                   │  │
+│  │   │  └───────────────────────┘   │  │     │  │  SerializingRenderer    │  │
+│  │   ▼                              │  │     │  │  (writes wire to stdout)│  │
+│  │  RendererSkia / TinySkia / Geode │  │     │  └─────────────────────────┘  │
+│  │   │                              │  │     │                               │
+│  │   ▼                              │  │     │  seccomp-bpf / sandbox_init   │
+│  │  GL framebuffer, on screen       │  │     │  no fs, no net, pipes only    │
+│  └──────────────────────────────────┘  │     └───────────────────────────────┘
+└────────────────────────────────────────┘
+```
+
+**Key invariant**: `RendererInterface` is the *only* data flow from sandbox
+to host. The host never sees `SVGDocument`, never sees parsed XML, never
+sees the sandbox's entt registry. It sees a stream of rendering commands,
+decodes them with a fuzzed deserializer, and forwards them to its real
+backend. The attack surface shrinks from "a full SVG parser" to "a
+protobuf-shaped deserializer for 28 message types."
+
+### Why RendererInterface is the right wire protocol
+
+Three properties of the existing interface make this work:
+
+1. **Pure virtual, no state bleed.** Every method is `virtual`, with no
+   default implementation or inherited state. Calls are self-contained
+   modulo the explicit LIFO stacks (`pushTransform`/`popTransform`,
+   `pushClip`/`popClip`, `pushIsolatedLayer`/`popIsolatedLayer`). Those
+   stacks are already serialized as "push these, pop them in this order" —
+   there's no hidden state.
+2. **Value-typed arguments.** Every argument is either a POD, a value type
+   with well-defined copy semantics (`PathShape`, `ResolvedClip`,
+   `PaintParams`), or an explicit `span<const T>`. No raw pointers, no
+   back-references into the document. `ResolvedClip` even implements a
+   deep-copy constructor explicitly
+   ([RendererInterface.h:109-127](../../donner/svg/renderer/RendererInterface.h))
+   because the driver already needs it. That deep copy is the serializer.
+3. **Driver is already separated from backend.** `RendererDriver` consumes
+   an `SVGDocument` and emits calls into a `RendererInterface&`. It doesn't
+   know what backend is on the other side. Swapping a real backend for a
+   `SerializingRenderer` is a one-line change at the driver call site.
+
+This is the "we already have the interface, we just need the protocol"
+observation. We're not designing IPC; we're designing *a serializer for an
+interface that already exists*.
+
+### Sandbox child lifecycle
+
+- **Launch**: host `posix_spawn`s `donner_parser_child` with stdin/stdout
+  piped, stderr inherited (for debug logging), working directory `/`, no
+  environment except `LANG`, `LC_*`, `PATH` (for dyld/ld.so), and a
+  `DONNER_SANDBOX=1` marker the child checks in `main()` to refuse to run
+  without it. All other FDs closed via `posix_spawn_file_actions_addclosefrom_np`
+  on Linux / `CLOEXEC` sweep on macOS.
+- **Handshake**: child writes a 16-byte `{magic, version, pid, pad}` frame
+  to stdout within 500 ms of launch. Host reads it, asserts version match,
+  considers the child "ready." No complex handshake beyond this.
+- **Request**: host writes `{opcode=kParseRequest, len, svg_bytes,
+  viewport, backend_hint}` to child stdin.
+- **Response**: child parses, drives renderer, writes
+  `{opcode=kBeginFrame, ...}` … `{opcode=kEndFrame}` sequence. Each frame
+  ends with `kEndFrame`. The child then waits for the next request.
+- **Crash**: child exits non-zero (SIGSEGV, SIGABRT, parse OOM, etc.).
+  Host's next `read()` on stdout returns 0 or errors. `SandboxHost`
+  observes this, raises `SandboxCrashed{exit_code, signal}`, and respawns
+  on the next request. Inflight frame is discarded.
+- **Shutdown**: host writes `{opcode=kShutdown}`; child exits cleanly.
+  Host joins the reader thread. On editor exit, host sends `kShutdown`
+  with a 100 ms grace before `SIGKILL`.
+
+### Wire format
+
+Framed message stream, little-endian (matches every platform Donner
+targets). No self-describing metadata beyond the opcode — the host and
+child are built from the same source, so field layouts agree by
+construction.
+
+```
+Message:
+  u32 magic     = 'DRNR'                (only on first frame per connection)
+  u32 opcode    // one per RendererInterface method + control opcodes
+  u32 length    // payload bytes
+  u8  payload[length]
+
+Payload encoding:
+  - Fixed-size fields: packed struct (alignment 4).
+  - std::string / std::string_view: u32 length + bytes.
+  - std::vector<T>: u32 count + T repeated.
+  - std::optional<T>: u8 present + T if present.
+  - std::variant<Ts...>: u8 tag + Ts[tag] body.
+  - span<const T>: identical to vector<T>.
+```
+
+Control opcodes (not mapped to `RendererInterface` methods):
+
+| Opcode | Direction | Purpose |
+|---|---|---|
+| `kHandshake` | child→host | First frame after spawn. |
+| `kParseRequest` | host→child | SVG bytes + viewport + backend hint. |
+| `kBeginFrame` … `kEndFrame` | child→host | Wraps a command sequence. |
+| `kParseError` | child→host | Parser returned an error; no commands follow. |
+| `kShutdown` | host→child | Exit cleanly. |
+| `kDiagnostic` | child→host | Warning sink passthrough (non-fatal parse warnings surface in host UI). |
+
+### Address bar flow
+
+```
+1. User types https://example.com/foo.svg into address bar.
+2. EditorApp::navigate(uri):
+   a. Classify scheme: https / http / file / relative.
+   b. Host-side fetch:
+      - https/http: curl → bytes (with a hard 10 MB cap + 10 s timeout).
+      - file://  : fopen → bytes (cap 100 MB; this is the user's own disk).
+   c. Show "Loading…" chip in UI.
+3. SandboxHost::render(bytes, viewport, backend_hint).
+4. Child parses, drives renderer, streams commands. ReplayingRenderer on the
+   host feeds them into the real backend for the active frame.
+5. Success: "Rendered" chip, viewport shows result, undo timeline resets
+   (navigating is not an undoable operation; it's a document replacement).
+6. Failure modes:
+   - Fetch error  → "Fetch failed (HTTP 404)" chip, keep previous document.
+   - Parse error  → "Parse error: <message>" chip, keep previous document.
+   - Sandbox crash → "Sandbox crashed (SIGSEGV)" chip, keep previous doc,
+                     respawn child asynchronously.
+```
+
+**The host never parses.** Even for local files that the user "trusts," we
+route through the sandbox — defense in depth and consistency of code path
+both matter. Files the user trusts can still be attacker-controlled (email
+attachments, downloads folder, `~/Downloads/untrusted.svg`).
+
+### Record/replay format (`.rnr`)
+
+The `.rnr` file is *literally the sandbox's stdout stream for one render*,
+written to disk verbatim. No reordering, no compression (initially). This
+means:
+
+- `DrnrRecorder` is a tee: `stdout → (real consumer, file)`. Zero
+  serialization overhead — the bytes are already in wire format.
+- A file-on-disk replay is indistinguishable from a live sandbox render.
+  The `ReplayingRenderer` doesn't know or care whether its `BufferedReader`
+  is a pipe or a file.
+- Format version = wire version. A `.rnr` from version 1 fails to load
+  against a version 2 editor with a clear error; we're not going to write
+  version-migration code in the initial milestones.
+
+File header (prepended at recorder construction, not passed through the
+pipe):
+
+```
+u32 magic    = 'DRNF'  (note: F for file, distinguishes from pipe magic)
+u32 version
+u64 timestamp_unix_ns
+u32 viewport_w
+u32 viewport_h
+u32 backend_hint
+u32 uri_length
+u8  uri[uri_length]   // originating URL, for provenance
+```
+
+### Frame inspector
+
+The frame inspector is "pause the IPC pump and show the ring buffer."
+Concretely:
+
+- `SandboxHost` has two modes: `kStreaming` (commands flow straight to
+  `ReplayingRenderer` as they arrive) and `kBuffered` (commands accumulate
+  in a `std::vector<WireMessage>` until the user explicitly drains them).
+- Pressing "Pause next frame" flips the mode to `kBuffered` on the next
+  `kBeginFrame` boundary. The entire next frame's commands buffer without
+  touching the real backend.
+- ImGui pane renders the buffered commands as a scrollable table:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  Frame Inspector           [▶ Resume]  [⏏ Export .rnr]  [🔄 Clear]  │
+├──────────────────────────────────────────────────────────────────────┤
+│  #  │ Depth │ Opcode             │ Summary                           │
+├─────┼───────┼────────────────────┼───────────────────────────────────┤
+│  0  │   0   │ beginFrame         │ viewport=800×600                  │
+│  1  │   0   │ pushTransform      │ scale(2,2) translate(50,50)       │
+│  2  │   1   │ pushClip           │ rect(0,0,400,400) + 1 path        │
+│  3  │   1   │ setPaint           │ fill=#FF0000 stroke=none          │
+│  4  │   1   │ drawRect           │ (10,10,90,90) opacity=1.0         │
+│  5  │   1   │ setPaint           │ fill=url(#grad) stroke=#000       │
+│  6  │   1   │ drawPath           │ 47 ops, fill=NonZero              │
+│  …  │       │                    │                                   │
+│ 184 │   0   │ endFrame           │                                   │
+├──────────────────────────────────────────────────────────────────────┤
+│  Scrub: [0 ━━━━━━━━━━━●━━━━━━━━ 184]   Replay through command #93  │
+├──────────────────────────────────────────────────────────────────────┤
+│  Selected: #6 drawPath                                               │
+│    path:   M10,10 L90,10 C... (47 ops)                               │
+│    fill:   LinearGradient(#grad) [3 stops]                           │
+│    stroke: #000 width=2.0 linecap=round                              │
+│    bbox:   (10, 10) → (90, 90)                                       │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+The scrub slider replays commands `[0..i)` into an off-screen renderer via
+`RendererInterface::createOffscreenInstance()`. The off-screen result blits
+into the main viewport, replacing the paused frame. Scrubbing is
+interactive (60 fps target) because replay is a pointer walk through an
+already-decoded `std::vector`.
+
+Export writes the buffered messages + header to a `.rnr` file.
+
+Depth tracking: the inspector counts `pushTransform`/`popTransform`,
+`pushClip`/`popClip`, `pushIsolatedLayer`/`popIsolatedLayer`,
+`pushFilterLayer`/`popFilterLayer`, `pushMask`/`popMask`. Mismatched push/pop
+is flagged red.
+
+### Insertion point into the editor
+
+The editor's M2 milestone introduces `AsyncSVGDocument` — a single-threaded
+command queue flushed at frame boundaries
+([editor.md:226-238](./editor.md)). That's the seam.
+
+Today's M2 plan:
+```
+main thread:  DOM mutations → command queue → render thread → RendererInterface
+```
+
+Post-sandbox:
+```
+main thread:  fetch bytes → SandboxHost::render(bytes)
+              │
+              ▼
+              child process ──── IPC wire ────┐
+                                              ▼
+              render thread: ReplayingRenderer → real RendererInterface
+```
+
+The `AsyncSVGDocument` mutation seam does not move — it still operates on
+a host-side `SVGDocument` mirror for selection, hit-testing, and the text
+editor pane. **But that mirror is built from the same `kParseRequest` bytes
+the sandbox consumes, parsed a second time on the host** for non-rendering
+purposes.
+
+Wait — that reintroduces the parser in the host. Alternatives considered:
+
+1. **Host re-parses for DOM mirror** (simplest): two parses per load, but
+   the host parse is only for selection/editing structure, not rendering.
+   The bug blast radius is "host crashes while building the mirror" — same
+   as today. No regression, no improvement.
+2. **Sandbox ships DOM structure back** (cleanest): extend the wire format
+   with a `kDomStructure` message containing a flat tree of element IDs,
+   tag names, bounding boxes, and source-range spans. The host never parses.
+   Downside: a second protocol surface and another fuzzed deserializer.
+3. **Read-only view mode initially** (punt): the address bar loads *only*
+   render; the document is not mutable until the user issues an explicit
+   "Edit this" command which re-parses on the host. First milestones pay
+   this cost.
+
+**Decision**: start with (3) for S3, migrate to (2) in a follow-up milestone
+once the command-stream wire format is stable. (1) is the fallback if (2)
+proves too expensive. Decision rationale: (3) lets the sandbox milestone
+ship without touching the editor's edit path; (2) is the principled
+end-state but requires designing a second wire protocol, which should not
+block S3.
+
+## API / Interfaces
+
+```cpp
+namespace donner::editor::sandbox {
+
+class SandboxHost {
+ public:
+  explicit SandboxHost(SandboxOptions opts);
+  ~SandboxHost();  // sends kShutdown, joins, SIGKILLs on timeout
+
+  // Spawns the child if not already running, sends kParseRequest, returns a
+  // handle that streams commands into `target` and completes at kEndFrame.
+  // Throws SandboxCrashed on child exit before kEndFrame.
+  void render(std::span<const uint8_t> svg_bytes,
+              const RenderViewport& viewport,
+              BackendHint backend,
+              RendererInterface& target);
+
+  // For the frame inspector: buffers the next frame's commands instead of
+  // forwarding them, then returns the buffer. Caller owns the buffer.
+  std::vector<WireMessage> captureNextFrame(
+      std::span<const uint8_t> svg_bytes,
+      const RenderViewport& viewport,
+      BackendHint backend);
+
+  [[nodiscard]] bool childAlive() const;
+  [[nodiscard]] std::optional<ExitInfo> lastExit() const;
+};
+
+// Tee adapter for record/replay.
+class DrnrRecorder {
+ public:
+  DrnrRecorder(std::filesystem::path out,
+               const RecordingHeader& header);
+  void feed(const WireMessage& msg);  // writes to disk and passes through
+  // use via: SandboxHost::render(bytes, vp, backend, TeeRenderer{recorder, realRenderer})
+};
+
+// Replay a .rnr file into any RendererInterface.
+ReplayResult ReplayDrnrFile(std::filesystem::path in, RendererInterface& target);
+
+}  // namespace donner::editor::sandbox
+```
+
+Host-side `RendererInterface` wrappers:
+
+```cpp
+namespace donner::svg {
+
+// Forwards calls into a wire stream. Owned by the sandbox child.
+class SerializingRenderer : public RendererInterface {
+ public:
+  explicit SerializingRenderer(BufferedWriter& out);
+  // ... 28 method overrides, each encoding opcode + payload.
+};
+
+// Reads a wire stream and forwards to a real backend.
+class ReplayingRenderer {
+ public:
+  ReplayingRenderer(BufferedReader& in, RendererInterface& target);
+  // Drives commands until kEndFrame or error. Returns ReplayStatus.
+  ReplayStatus pumpFrame();
+};
+
+}  // namespace donner::svg
+```
+
+## Data and State
+
+**Threading model**:
+- Host main thread: ImGui, event loop, address bar, `SandboxHost::render()`
+  (synchronous).
+- Host IPC reader thread (one, owned by `SandboxHost`): blocks on child
+  stdout `read()`, decodes frames, pushes `WireMessage` into a lock-free
+  SPSC queue. Exists only to keep the main thread from blocking on
+  per-command `read()` syscalls.
+- Host render thread (inherited from editor M2): drains the SPSC queue via
+  `ReplayingRenderer`, issues calls into the real backend. Same thread as
+  the existing GL context.
+- Child main thread: blocks on stdin `read()` for `kParseRequest`, parses,
+  drives renderer, writes to stdout, loops.
+- Child has no other threads. Parser and renderer driver are single-threaded.
+
+**Memory ownership**:
+- Wire messages are owned by the IPC reader thread's decode buffer until
+  consumed by `ReplayingRenderer`. No reference-sharing with the real
+  backend — `ReplayingRenderer` calls `drawPath(PathShape{...})` by value,
+  same as the driver would.
+- `PathShape::path` is the biggest allocation per draw call. It's
+  reconstructed from wire bytes into a fresh `std::vector<PathOp>` in the
+  host's arena. We accept the allocation cost; the Skia backend was already
+  going to copy this into an `SkPath`.
+- Frame inspector's buffered `std::vector<WireMessage>` is host-thread-owned
+  and lives until the user drains it or clears the pane.
+
+## Error Handling
+
+| Class | Detection | Response |
+|---|---|---|
+| HTTPS fetch failure | curl return code | Address bar chip, no sandbox round-trip. |
+| File read failure | `errno` | Address bar chip, no sandbox round-trip. |
+| Parse error (valid wire, malformed SVG) | `kParseError` opcode | Address bar chip with parser message, previous document preserved. |
+| Parse warnings | `kDiagnostic` opcodes | Logged to editor console pane; non-blocking. |
+| Sandbox crash (SIGSEGV, SIGABRT, OOM) | Child exit non-zero, `read()` returns 0 | `SandboxCrashed` raised, address bar chip, child respawned on next request. Crashing corpus entry logged for fuzzer ingestion. |
+| Sandbox hang | Host-side 30 s deadline on `kEndFrame` arrival | Host sends SIGKILL, treats as crash. Deadline is generous; real renders should complete in <1 s. |
+| Wire format error (host sees an opcode it doesn't recognize, length overrun, invalid variant tag) | Deserializer check | Host raises `WireProtocolError`, kills child, respawns. **This path is fuzzed.** |
+| Backend reports an error during replay | `ReplayingRenderer` catches | Logged, frame completes on best-effort basis. Host never crashes on a replay error. |
+
+**Non-negotiable invariant**: *the host process never crashes due to any
+input from the sandbox child, including maliciously-crafted wire messages
+targeting the host's deserializer*. The `sandbox_wire_fuzzer` target in S2
+exists specifically to hold this line.
+
+## Performance
+
+**Targets** (p95, on M1-class Linux + macOS dev machines):
+
+- `posix_spawn` + child ready handshake: ≤ 40 ms.
+- Small SVG (resvg test suite average): end-to-end parse + render + replay
+  ≤ 15 ms additional over in-process baseline.
+- Large SVG (Ghostscript tiger, 200+ paths): ≤ 50 ms additional.
+- Address bar navigation p50 for a 50 KB `.svg` over HTTPS: ≤ 200 ms
+  (dominated by network, not IPC).
+- Frame inspector scrub: 60 fps on a 1000-command frame.
+
+**Budget decomposition**:
+1. Serialization (child side): one memcpy per primitive-typed field,
+   allocations only for `std::vector` payloads. Target <10% CPU overhead
+   vs. a real backend call.
+2. Pipe I/O: the kernel pipe buffer is 64 KB on Linux default; typical frames
+   are 10–200 KB. We accept that large frames will block the child momentarily
+   when the host falls behind — this is desired backpressure.
+3. Deserialization (host side): mirror of serialization, one memcpy per
+   primitive, one allocation per variable-length field.
+4. Replay (host side): identical to in-process rendering — the forwarded
+   calls are exactly what the driver would have emitted.
+
+**Watch list** (things that could blow the budget):
+- `drawText` has the largest payload (`span<FontFace>` with TTF tables).
+  Mitigation: if the font is resolvable via a system font family name, send
+  only the name; fall back to shipping bytes only for embedded `@font-face`.
+- `pushFilterLayer(FilterGraph)` has a deeply nested structure. Measure
+  first, optimize if needed.
+- `ImageResource` for raster images. Measure; may need shared memory fast
+  path for very large images (Future Work).
+
+**Measurement plan**:
+- Benchmark target `//donner/editor/sandbox:ipc_benchmark` that runs the
+  resvg test suite through sandbox-on and sandbox-off paths, reports
+  per-test deltas.
+- Tracy zones around every major boundary: parse start/end, wire
+  write/read, replay start/end. Editor's Tracy toggle (M3) surfaces these.
+
+## Security / Privacy
+
+### Threat model
+
+**Adversary**: attacker who controls the SVG bytes being parsed. Can craft
+malformed XML, oversized paths, pathological filters, font data with
+malicious OpenType tables, CSS expressions that trigger parser or style-
+system bugs. Delivery vectors: user pastes URL, user opens downloaded file,
+user receives `.svg` attachment and opens in Donner.
+
+**Attacker capability**: arbitrary code execution *inside the sandbox
+child* is considered "game won" from the parser's perspective. The child
+must not be able to:
+
+- Read or write the user's filesystem (other than the SVG bytes piped in).
+- Open network connections.
+- Send IPC to the editor host beyond the `RendererInterface` wire stream.
+- Escalate to persist beyond its process lifetime.
+- Trigger host-side crashes via malformed wire messages.
+
+**Non-goals for the threat model**:
+
+- Side-channel attacks (timing, cache) — out of scope; we're not rendering
+  secrets.
+- Protection against attackers who already have code execution on the host.
+- Protection of the sandbox child from itself (e.g., DoS via slow renders
+  is handled by the 30 s host deadline, not by fine-grained limits in the
+  child).
+
+### Trust boundaries
+
+1. **User input (address bar) → host fetch**: host validates scheme allowlist
+   (`https`, `http`, `file`, bare path = `file` resolved relative to CWD),
+   enforces 10 MB size cap on HTTPS, 100 MB cap on local files, 10 s HTTPS
+   timeout. No URL redirection following beyond 5 hops. No cookies, no
+   user-agent customization.
+2. **Host fetch → sandbox child**: raw bytes only. No filenames, no URLs,
+   no host metadata crosses the pipe.
+3. **Sandbox child → host (wire messages)**: deserializer is the trust
+   boundary. Every length field is bounds-checked against the remaining
+   payload before allocation; every variant tag is range-checked; every
+   `std::vector` count is capped at a sensible maximum (e.g., 10M path ops
+   per `PathShape`, 1024 clip paths per `ResolvedClip`). **The deserializer
+   is fuzzed (`sandbox_wire_fuzzer`).**
+4. **Sandbox child → OS**: seccomp-bpf (Linux) or `sandbox_init` (macOS)
+   deny-by-default, allowing only the syscalls required to read stdin,
+   write stdout, allocate memory, and exit. Enforced after child
+   initialization completes (the parser allocator may warm up before the
+   filter activates).
+
+### Defensive measures
+
+- **Resource caps**:
+  - `RLIMIT_AS` (address space) = 1 GB. A parser OOM kills only the child.
+  - `RLIMIT_CPU` = 30 seconds. A pathological SVG can't pin a core forever.
+  - `RLIMIT_FSIZE` = 0. No file writes, belt-and-braces.
+  - `RLIMIT_NOFILE` = 16. Enough for stdin/stdout/stderr and a handful of
+    internal FDs; no extra file descriptors possible.
+- **Wire message caps** (enforced in `ReplayingRenderer`):
+  - Max frame size: 256 MB. Larger frames are treated as a protocol violation.
+  - Max path ops per `PathShape`: 10M.
+  - Max clip paths per `ResolvedClip`: 1024.
+  - Max filter graph depth: 256.
+  - Max command count per frame: 10M.
+- **No ambient authority**: child inherits no environment variables beyond
+  locale + `PATH`, no file descriptors beyond pipes, no working directory
+  beyond `/`, no signal handlers, no `LD_PRELOAD` (wiped from environment),
+  no privilege.
+- **Opaque forwarding**: if the deserializer cannot fully understand a
+  message (unknown opcode from a future child version), it treats the
+  connection as corrupt and kills the child. No graceful degradation.
+
+### Fuzzing plan
+
+Three new fuzzers:
+
+1. **`sandbox_wire_fuzzer`**: feeds random bytes into `ReplayingRenderer`
+   operating against a `MockRendererInterface` (planned in the renderer
+   interface design). Asserts the host never crashes. **The single most
+   important fuzzer in this design.** Corpus seeded with real recorded
+   frames from the resvg test suite.
+2. **`drnr_replay_fuzzer`**: same deserializer, but file-shaped inputs
+   with a header. Catches header-specific bugs.
+3. **Reuse `SVGParser_fuzzer` end-to-end**: every corpus entry is fed
+   through `SandboxHost::render` as part of CI. Any host crash is a
+   test failure. This is the `fuzz_replay_cli` path from editor M5, with
+   sandbox enabled.
+
+### Sensitive data handling
+
+- The editor does not log wire messages by default. A `--debug-wire`
+  flag enables a hex dump to stderr for debugging, gated off in release
+  builds.
+- `.rnr` files can contain text content from the source SVG (via
+  `drawText`'s `TextParams`). Users exporting a `.rnr` for bug reporting
+  should be aware of this; the export dialog mentions it.
+- No telemetry, no phone-home, no anonymous crash reporting in the initial
+  milestones.
+
+### Invariants enforced post-launch
+
+1. **Host never crashes on sandbox input.** Enforced by `sandbox_wire_fuzzer`
+   in CI.
+2. **Parser never executes in the host process (non-WASM builds).**
+   Enforced by `check_banned_patterns.py` extension: forbid
+   `SVGParser::ParseSVG` imports outside `donner/editor/sandbox/child/**`
+   and existing non-editor callers. The editor host code is not allowed
+   to reach the parser directly.
+3. **Wire format is versioned.** Breaking changes bump the version field;
+   a version mismatch between host and child is a fatal error on handshake.
+
+## Testing and Validation
+
+- **Unit**: `SerializingRenderer` / `ReplayingRenderer` round-trips for
+  every `RendererInterface` method. One test per opcode, table-driven.
+  Asserts encoded bytes + decoded state match.
+- **Integration**: the resvg test suite, run once in-process and once
+  through the sandbox; pixel-identical assertion on same backend. This is
+  the single most important test — it proves end-to-end correctness.
+- **Golden**: record `.rnr` files for a curated subset of the resvg suite,
+  check them in under `donner/editor/sandbox/tests/goldens/*.rnr`. On CI,
+  replay them and assert pixel equality. Regenerate via the standard
+  `UPDATE_GOLDEN_IMAGES_DIR` workflow.
+- **Fuzzing**:
+  - `sandbox_wire_fuzzer` runs on every PR via existing fuzzer CI plumbing.
+  - `SVGParser_fuzzer` corpus replays through `fuzz_replay_cli` with
+    `--sandbox` enabled as a release gate.
+- **Crash recovery**: deliberately-crashing corpus entries (SIGSEGV, SIGABRT,
+  infinite loops) fed through `SandboxHost`; assertions on host liveness
+  and child respawn count.
+- **Frame inspector**: headless test that enters buffered mode, captures a
+  frame, scrubs from 0 to N, asserts the off-screen replay matches the
+  in-stream replay at each index.
+- **Address bar**: integration test with a local HTTP server serving curated
+  payloads (valid SVG, malformed SVG, 404, slow response, oversized body).
+  Asserts the UI chip transitions and the previous document survives every
+  failure mode.
+
+## Dependencies
+
+- **New dev dependency**: `curl` (or `libcurl`) for HTTPS fetching in the
+  address bar. Added as `dev_dependency = True` in `MODULE.bazel`, same
+  pattern as imgui/glfw. Not added to the BCR consumer graph. Alternative:
+  hand-rolled HTTP client — rejected as out of scope for an editor
+  milestone.
+- **No new runtime dependencies** for the parser child binary — it's just
+  `//donner/svg:parser` + `//donner/svg/renderer:renderer_tiny_skia` +
+  the new `:sandbox_wire_lib`.
+- **Bazel `banned-patterns`**: new rule preventing `SVGParser::ParseSVG`
+  calls from `//donner/editor:core` and its transitive deps. Editor core
+  uses `SandboxHost::render` exclusively.
+
+## Rollout Plan
+
+- **Milestone S1** ships behind nothing — it's a new binary and a new test,
+  no user-visible behavior change.
+- **Milestone S3** (address bar + sandbox) ships with the address bar
+  enabled by default. Users get the sandbox transparently.
+- **`--in-process-parser`** debug flag remains for the entire S1–S5 period:
+  routes parsing back through the host for performance comparison and
+  debugging of sandbox issues. Default off. Removed after S6.
+- **WASM build (editor M6)**: the sandbox code compiles out; `SandboxHost`
+  becomes a direct call into `SVGParser::ParseSVG`. The browser is the
+  sandbox.
+- **`.rnr` format**: version 1 in S4. No migration path for version bumps
+  in the S4–S6 window; a format change invalidates existing files. This
+  is acceptable because `.rnr` files are not user-authored assets, only
+  debug artifacts.
+
+## Alternatives Considered
+
+1. **seccomp-bpf only, no separate process**: run the parser in a thread
+   with a restricted syscall filter. Rejected: seccomp-bpf can't protect
+   the host process's memory from a parser bug; a corrupted heap in one
+   thread corrupts the whole process. Process boundary is the only robust
+   memory firewall.
+
+2. **WASM parser embedded in the host**: compile `SVGParser` to WASM, run
+   it in an in-process WASM runtime (e.g., Wasmtime). Memory isolation
+   comes free. Rejected for now: adds ~5 MB of runtime dependency,
+   complicates the build, parser-WASM boundary has its own IPC cost, and
+   we'd still need to design a wire protocol. Revisit if sandbox process
+   overhead proves unacceptable.
+
+3. **Protobuf / FlatBuffers as the wire format**: rejected because the
+   format is not versioned across runs (host and child always share source),
+   and because a hand-rolled format is smaller, faster, and lets us
+   integrate C++26 reflection directly with our own types. Protobuf is
+   already in the tree as a dev dep (for other tooling) but adding it to
+   the hot rendering path is a regression in both compile time and runtime.
+
+4. **Shared memory for path / image payloads**: rejected in initial
+   milestones because it complicates the trust boundary (the child gets a
+   handle into host address space) and because pipe throughput is adequate
+   for typical frames. Revisit if `drawImage` with large bitmaps blows the
+   latency budget.
+
+5. **Run the driver in the host, stream events from the sandbox**: the
+   sandbox would ship a parsed `SVGDocument` subtree over the wire and the
+   host would run `RendererDriver`. Rejected: `SVGDocument` is a much
+   larger and more complex surface than `RendererInterface`. The wire
+   format would need to encode entt registries, style trees, and resolved
+   components. `RendererInterface` is the smallest possible seam.
+
+6. **C++26 reflection on day one**: rejected because the tree is on C++20
+   and the toolchain may not support P2996 yet. Shipping the hand-rolled
+   version first lets us validate the wire format and ship the feature;
+   reflection migration is a code-reduction follow-up.
+
+## Open Questions
+
+- **Long-lived child vs. per-render spawn**: S1 decides. If `posix_spawn`
+  dominates small-render latency, S3 must use a warm child pool. Suspected
+  answer: one persistent child, spawned at editor startup, respawned on
+  crash.
+- **HTTPS client**: `libcurl` (battle-tested, big) vs. hand-rolled
+  (`<TcpSocket>` + OpenSSL, small). Libcurl is the default recommendation;
+  lean on it to avoid becoming a TLS implementation.
+- **Sub-resource fetching** (`<image href="https://...">` inside an SVG):
+  currently out of scope. Most interesting path forward: route through the
+  host via a request-from-sandbox protocol. Delayed until after S6.
+- **Shared memory for `ImageResource`**: measure first.
+- **Windows sandboxing**: requires a separate story (Job Objects +
+  AppContainer). Not blocking M1; Windows editor support is itself Future
+  Work in [editor.md](./editor.md).
+- **DOM mirror strategy**: S3 ships read-only (option 3 from Proposed
+  Architecture). Decision on option 1 vs. option 2 happens when S3 closes.
+
+# Future Work
+
+- [ ] Sub-resource fetching protocol (sandbox requests, host fetches,
+      returns bytes). Allows `<image href>`, `<use href>` cross-document,
+      `@font-face src=url()`.
+- [ ] Shared-memory fast path for `drawImage` payloads larger than 1 MB.
+- [ ] Windows sandbox via Job Object + AppContainer.
+- [ ] `kDomStructure` wire message for structured editor DOM mirror
+      (replaces the "re-parse on host" path).
+- [ ] C++26 reflection migration (S5) assuming toolchain support lands.
+- [ ] Compressed `.rnr` files (zstd framing) for fixtures that take up
+      too much git space.
+- [ ] Multi-frame `.rnr` files for animation capture.
+- [ ] Cross-backend replay comparisons: replay the same `.rnr` against
+      Skia, TinySkia, and Geode and pixel-diff the results. First-class
+      integration of the existing renderer parity story.
+- [ ] Profile-guided optimization of the wire format (variable-length
+      integers, dictionary compression for repeated paints).
+- [ ] Per-session sandbox telemetry (opt-in) for crash reporting.

--- a/donner/editor/app/BUILD.bazel
+++ b/donner/editor/app/BUILD.bazel
@@ -1,0 +1,61 @@
+"""Donner Editor MVP — the headless core, REPL shell, and binary.
+
+The `app` package is the first concrete `donner/editor/` code outside
+`sandbox/`. It builds on top of every sandbox primitive:
+
+  - `SvgSource` for URI → bytes
+  - `PipelinedRenderer` for multi-threaded wire-based rasterization
+  - `FrameInspector` + `RnrFile` for "inspect" / "record" commands
+  - `TerminalImageViewer` for the `show` command
+
+The `:editor_app` library is fully UI-free and exhaustively testable; the
+binary target layers a stdin/stdout REPL on top.
+"""
+
+load("//build_defs:rules.bzl", "donner_cc_binary", "donner_cc_library", "renderer_backend_compatible_with")
+
+package(default_visibility = ["//donner/editor:__subpackages__"])
+
+donner_cc_library(
+    name = "editor_app",
+    srcs = ["EditorApp.cc"],
+    hdrs = ["EditorApp.h"],
+    target_compatible_with = renderer_backend_compatible_with(["tiny_skia"]),
+    visibility = ["//donner/editor:__subpackages__"],
+    deps = [
+        "//donner/base",
+        "//donner/editor/sandbox:pipelined_renderer",
+        "//donner/editor/sandbox:serializing_renderer",
+        "//donner/editor/sandbox:svg_source",
+        "//donner/svg",
+        "//donner/svg/parser",
+        "//donner/svg/renderer:renderer_interface",
+    ],
+)
+
+donner_cc_library(
+    name = "editor_repl",
+    srcs = ["EditorRepl.cc"],
+    hdrs = ["EditorRepl.h"],
+    target_compatible_with = renderer_backend_compatible_with(["tiny_skia"]),
+    visibility = ["//donner/editor:__subpackages__"],
+    deps = [
+        ":editor_app",
+        "//donner/editor/sandbox:frame_inspector",
+        "//donner/editor/sandbox:rnr_file",
+        "//donner/svg/renderer:renderer_image_io",
+        "//donner/svg/renderer:renderer_interface",
+        "//donner/svg/renderer:terminal_image_viewer",
+    ],
+)
+
+donner_cc_binary(
+    name = "donner_editor",
+    srcs = ["donner_editor_main.cc"],
+    target_compatible_with = renderer_backend_compatible_with(["tiny_skia"]),
+    visibility = ["//donner/editor:__subpackages__"],
+    deps = [
+        ":editor_app",
+        ":editor_repl",
+    ],
+)

--- a/donner/editor/app/EditorApp.cc
+++ b/donner/editor/app/EditorApp.cc
@@ -1,0 +1,184 @@
+#include "donner/editor/app/EditorApp.h"
+
+#include <limits>
+#include <sstream>
+#include <utility>
+
+#include "donner/base/ParseWarningSink.h"
+#include "donner/editor/sandbox/PipelinedRenderer.h"
+#include "donner/editor/sandbox/SerializingRenderer.h"
+#include "donner/svg/SVG.h"
+
+namespace donner::editor::app {
+
+namespace {
+
+std::string_view StatusLabel(EditorStatus status) {
+  switch (status) {
+    case EditorStatus::kEmpty:         return "empty";
+    case EditorStatus::kLoading:       return "loading";
+    case EditorStatus::kRendered:      return "rendered";
+    case EditorStatus::kRenderedLossy: return "rendered (lossy)";
+    case EditorStatus::kFetchError:    return "fetch error";
+    case EditorStatus::kParseError:    return "parse error";
+    case EditorStatus::kRenderError:   return "render error";
+  }
+  return "?";
+}
+
+EditorStatus FetchStatusToEditorStatus(sandbox::SvgFetchStatus status) {
+  if (status == sandbox::SvgFetchStatus::kOk) return EditorStatus::kRendered;
+  return EditorStatus::kFetchError;
+}
+
+}  // namespace
+
+EditorApp::EditorApp(EditorAppOptions options)
+    : options_(std::move(options)),
+      source_(options_.sourceOptions),
+      width_(options_.defaultWidth),
+      height_(options_.defaultHeight) {
+  // The MVP only wires the in-process threaded pipeline today. The
+  // `kSandboxedProcess` path is reserved for a follow-up so `EditorApp`'s
+  // API stays stable across the transition.
+  pipeline_ = std::make_unique<sandbox::PipelinedRenderer>();
+  current_.message = "no document loaded";
+}
+
+EditorApp::~EditorApp() = default;
+
+const EditorSnapshot& EditorApp::navigate(std::string_view uri) {
+  current_ = EditorSnapshot{};
+  current_.uri = std::string(uri);
+  current_.status = EditorStatus::kLoading;
+
+  const auto fetch = source_.fetch(uri);
+  if (fetch.status != sandbox::SvgFetchStatus::kOk) {
+    current_.status = FetchStatusToEditorStatus(fetch.status);
+    std::ostringstream msg;
+    msg << StatusLabel(current_.status) << ": " << fetch.diagnostics;
+    current_.message = std::move(msg).str();
+    return current_;
+  }
+
+  rawBytes_ = std::move(fetch.bytes);
+
+  // Store the resolved path and its mtime so pollForChanges() can detect
+  // on-disk edits without re-fetching every poll cycle.
+  loadedPath_ = fetch.resolvedPath;
+  if (!loadedPath_.empty()) {
+    std::error_code ec;
+    lastModTime_ = std::filesystem::last_write_time(loadedPath_, ec);
+    // If stat fails, leave lastModTime_ at its default so polling stays
+    // inert rather than spinning on reload.
+  }
+
+  return renderCachedBytes(uri);
+}
+
+const EditorSnapshot& EditorApp::reload() {
+  if (current_.uri.empty() && rawBytes_.empty()) {
+    current_.message = "reload: no document loaded";
+    return current_;
+  }
+  // Re-fetch from the source so file-on-disk edits are picked up.
+  const auto uri = current_.uri;
+  return navigate(uri);
+}
+
+const EditorSnapshot& EditorApp::resize(int width, int height) {
+  if (width <= 0 || height <= 0) {
+    current_.message = "resize: width/height must be positive";
+    return current_;
+  }
+  width_ = width;
+  height_ = height;
+  if (rawBytes_.empty()) {
+    current_.message = "resize: no document loaded";
+    return current_;
+  }
+  return renderCachedBytes(current_.uri);
+}
+
+const EditorSnapshot& EditorApp::renderCachedBytes(std::string_view uri) {
+  // Parse on the main thread. We need to pass a real `SVGDocument` to the
+  // pipelined renderer — serialization happens inside `submit()`, which
+  // runs on the caller (main) thread too.
+  ParseWarningSink warnings;
+  const std::string_view svgView(reinterpret_cast<const char*>(rawBytes_.data()),
+                                 rawBytes_.size());
+  auto parseResult = svg::parser::SVGParser::ParseSVG(svgView, warnings);
+  if (parseResult.hasError()) {
+    current_.uri = std::string(uri);
+    current_.status = EditorStatus::kParseError;
+    std::ostringstream msg;
+    msg << parseResult.error();
+    current_.message = "parse error: " + std::move(msg).str();
+    return current_;
+  }
+
+  svg::SVGDocument document = std::move(parseResult.result());
+
+  const uint64_t frameId = pipeline_->submit(document, width_, height_);
+  auto frame = pipeline_->waitForFrame(frameId);
+  if (!frame.has_value() || !frame->ok) {
+    current_.uri = std::string(uri);
+    current_.status = EditorStatus::kRenderError;
+    current_.message = "render error: worker returned no frame";
+    return current_;
+  }
+
+  current_.uri = std::string(uri);
+  current_.bitmap = std::move(frame->bitmap);
+  current_.unsupportedCount = frame->unsupportedCount;
+  current_.status = frame->unsupportedCount == 0 ? EditorStatus::kRendered
+                                                  : EditorStatus::kRenderedLossy;
+
+  // The pipelined renderer currently doesn't surface the wire bytes it
+  // handed to the worker — the wire buffer is consumed inside the worker
+  // as soon as replay completes. The MVP re-runs the serializer on the
+  // main thread to populate `current_.wire` so that "inspect" / "record"
+  // REPL commands can operate on the same frame the user just rendered.
+  // This double-work is intentional for the MVP — a later revision can
+  // extend `PipelinedFrame` to retain the wire bytes and eliminate the
+  // second serialization pass entirely.
+  {
+    sandbox::SerializingRenderer tee;
+    auto docAgain = svg::parser::SVGParser::ParseSVG(svgView, warnings).result();
+    docAgain.setCanvasSize(width_, height_);
+    tee.draw(docAgain);
+    current_.wire = std::move(tee).takeBuffer();
+  }
+
+  std::ostringstream msg;
+  msg << StatusLabel(current_.status) << " " << current_.bitmap.dimensions.x << "x"
+      << current_.bitmap.dimensions.y;
+  if (current_.unsupportedCount > 0) {
+    msg << " (" << current_.unsupportedCount << " unsupported)";
+  }
+  current_.message = std::move(msg).str();
+
+  lastGoodBitmap_ = current_.bitmap;
+  lastGoodWire_ = current_.wire;
+  return current_;
+}
+
+bool EditorApp::pollForChanges() {
+  if (!watchEnabled_ || loadedPath_.empty()) {
+    return false;
+  }
+
+  std::error_code ec;
+  const auto currentMtime = std::filesystem::last_write_time(loadedPath_, ec);
+  if (ec) {
+    return false;  // File may have been deleted; don't reload.
+  }
+
+  if (currentMtime != lastModTime_) {
+    reload();
+    return true;
+  }
+  return false;
+}
+
+}  // namespace donner::editor::app

--- a/donner/editor/app/EditorApp.h
+++ b/donner/editor/app/EditorApp.h
@@ -1,0 +1,168 @@
+#pragma once
+/// @file
+///
+/// **EditorApp** — the headless core of the Donner Editor MVP. Owns the
+/// current document state (URI, raw bytes, rendered bitmap, wire stream)
+/// and exposes a narrow state-transition API that higher layers (a REPL, a
+/// GLFW/ImGui shell, a wasm frontend) call into.
+///
+/// This is deliberately UI-free: no ImGui, no GLFW, no GL, no stdin/stdout.
+/// The UI layer takes an `EditorApp&` and drives it — tests can do the
+/// same. That mirrors the editor design doc's mutation-seam principle for
+/// M2 (`EditorApp::applyMutation`) at the coarsest possible granularity:
+/// right now the only mutation the MVP supports is "navigate to a new URI
+/// and re-render."
+///
+/// Rendering is delegated to a `PipelinedRenderer` by default — the same
+/// multi-threaded wire-based pipeline that S3.6 landed — so the main
+/// thread never blocks on rasterization. The backing renderer is
+/// pluggable via `EditorAppOptions` for tests that want deterministic
+/// synchronous execution or sandbox isolation.
+
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "donner/editor/sandbox/PipelinedRenderer.h"
+#include "donner/editor/sandbox/SvgSource.h"
+#include "donner/svg/renderer/RendererInterface.h"
+
+namespace donner::editor::app {
+
+/// High-level state the editor can be in. The REPL uses this to decide
+/// what status chip / prompt decoration to show the user.
+enum class EditorStatus {
+  kEmpty,         ///< No document loaded yet.
+  kLoading,       ///< Navigation in flight (rare — our pipeline is synchronous today).
+  kRendered,      ///< A bitmap is available and was rendered cleanly.
+  kRenderedLossy, ///< Rendered, but the wire stream contained `kUnsupported` messages.
+  kFetchError,    ///< `SvgSource::fetch` failed. Previous bitmap is retained.
+  kParseError,    ///< Parser returned an error. Previous bitmap is retained.
+  kRenderError,   ///< Rasterization failed post-parse. Previous bitmap is retained.
+};
+
+/// Render mode — which sandbox variant powers the pipeline. The MVP only
+/// wires `kInProcessThread` today; the `kSandboxedProcess` variant is
+/// reserved so the option struct is forward-compatible when the
+/// `SandboxHost`-backed renderer lands.
+enum class EditorRenderMode {
+  /// Default. Main thread parses + drives, worker thread rasterizes. Zero
+  /// process overhead, fully deterministic when `waitForFrame` is used.
+  kInProcessThread,
+  /// Reserved. When implemented, routes through `SandboxHost` with a
+  /// separate child process. Surfaces the same API.
+  kSandboxedProcess,
+};
+
+struct EditorAppOptions {
+  /// Which pipeline to use. `kInProcessThread` is the only mode MVP
+  /// implements today.
+  EditorRenderMode renderMode = EditorRenderMode::kInProcessThread;
+
+  /// Default viewport used for navigations that don't carry an explicit
+  /// width/height. Matches typical desktop editor previews.
+  int defaultWidth = 512;
+  int defaultHeight = 384;
+
+  /// Options forwarded to the internal `SvgSource`. Most tests override
+  /// `baseDirectory` to isolate fixture files from the developer's CWD.
+  donner::editor::sandbox::SvgSourceOptions sourceOptions;
+};
+
+/// Snapshot of the most recent navigation result. All fields are read-only
+/// after `EditorApp::navigate` returns — subsequent navigations produce a
+/// new snapshot.
+struct EditorSnapshot {
+  EditorStatus status = EditorStatus::kEmpty;
+  /// Resolved URI the snapshot corresponds to, or empty for `kEmpty`.
+  std::string uri;
+  /// RGBA snapshot of the rendered frame. Empty if no render has succeeded.
+  svg::RendererBitmap bitmap;
+  /// Raw sandbox wire bytes from the most recent successful render. Useful
+  /// for "record" / "inspect" REPL commands. Empty for unsuccessful states.
+  std::vector<uint8_t> wire;
+  /// Number of `kUnsupported` messages observed during replay (0 means
+  /// fully faithful).
+  uint32_t unsupportedCount = 0;
+  /// Human-readable status line suitable for display in a UI chip or a
+  /// terminal prompt.
+  std::string message;
+};
+
+class EditorApp {
+public:
+  explicit EditorApp(EditorAppOptions options = {});
+  ~EditorApp();
+
+  EditorApp(const EditorApp&) = delete;
+  EditorApp& operator=(const EditorApp&) = delete;
+
+  /// Fetches `uri`, drives the renderer at the configured viewport, and
+  /// blocks until a new frame is available on the worker. Returns the
+  /// updated snapshot. On any error, the previous successful frame's
+  /// bitmap is retained (accessible via `lastGoodBitmap()`) and the new
+  /// snapshot's status reflects the failure.
+  const EditorSnapshot& navigate(std::string_view uri);
+
+  /// Fetches the current URI again with the same viewport, useful for
+  /// "reload the file after editing it in an external editor" workflows.
+  /// No-op when no URI is loaded yet.
+  const EditorSnapshot& reload();
+
+  /// Re-renders the currently-loaded document at a new viewport. Cheaper
+  /// than a full navigate because no fetch happens.
+  const EditorSnapshot& resize(int width, int height);
+
+  [[nodiscard]] const EditorSnapshot& current() const { return current_; }
+  [[nodiscard]] int width() const { return width_; }
+  [[nodiscard]] int height() const { return height_; }
+
+  /// The most recent successful bitmap, regardless of the current status.
+  /// Allows UIs to keep showing the last good render while an error chip
+  /// covers the new failure — matches the address bar's "keep previous
+  /// document on screen" behavior from the design doc.
+  [[nodiscard]] const svg::RendererBitmap& lastGoodBitmap() const { return lastGoodBitmap_; }
+  /// The wire bytes matching `lastGoodBitmap()`. Same retention semantics.
+  [[nodiscard]] const std::vector<uint8_t>& lastGoodWire() const { return lastGoodWire_; }
+
+  /// Enable or disable filesystem watch mode. When enabled,
+  /// `pollForChanges()` checks whether the loaded file's mtime has changed
+  /// and auto-reloads if so.
+  void setWatchEnabled(bool v) { watchEnabled_ = v; }
+  [[nodiscard]] bool watchEnabled() const { return watchEnabled_; }
+
+  /// Checks if the currently-loaded file's modification time has changed
+  /// since the last fetch. If yes (and watch is enabled), calls `reload()`
+  /// internally and returns true. Returns false when watch is disabled, no
+  /// file is loaded, or the file hasn't changed.
+  bool pollForChanges();
+
+private:
+  /// Runs the cached raw SVG bytes through the pipeline and updates
+  /// `current_` + `lastGood*_` according to the outcome. Common helper for
+  /// navigate/reload/resize.
+  const EditorSnapshot& renderCachedBytes(std::string_view uri);
+
+  EditorAppOptions options_;
+  donner::editor::sandbox::SvgSource source_;
+  std::unique_ptr<donner::editor::sandbox::PipelinedRenderer> pipeline_;
+
+  int width_;
+  int height_;
+
+  EditorSnapshot current_;
+  std::vector<uint8_t> rawBytes_;  ///< Last successfully-fetched bytes, for reload/resize.
+  svg::RendererBitmap lastGoodBitmap_;
+  std::vector<uint8_t> lastGoodWire_;
+
+  bool watchEnabled_ = false;
+  /// Path of the currently-loaded file, used for mtime polling.
+  std::filesystem::path loadedPath_;
+  /// The file's mtime at the time of the last successful fetch.
+  std::filesystem::file_time_type lastModTime_{};
+};
+
+}  // namespace donner::editor::app

--- a/donner/editor/app/EditorRepl.cc
+++ b/donner/editor/app/EditorRepl.cc
@@ -1,0 +1,303 @@
+#include "donner/editor/app/EditorRepl.h"
+
+#include <charconv>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#ifdef __linux__
+#include <poll.h>
+#include <unistd.h>
+#endif
+
+#include "donner/editor/app/EditorApp.h"
+#include "donner/editor/sandbox/FrameInspector.h"
+#include "donner/editor/sandbox/RnrFile.h"
+#include "donner/svg/renderer/RendererImageIO.h"
+#include "donner/svg/renderer/TerminalImageViewer.h"
+
+namespace donner::editor::app {
+
+namespace {
+
+std::vector<std::string> Tokenize(const std::string& line) {
+  std::vector<std::string> tokens;
+  std::istringstream iss(line);
+  std::string tok;
+  while (iss >> tok) {
+    tokens.push_back(std::move(tok));
+  }
+  return tokens;
+}
+
+}  // namespace
+
+EditorRepl::EditorRepl(EditorApp& app, std::istream& in, std::ostream& out,
+                       EditorReplOptions options)
+    : app_(app), in_(in), out_(out), options_(std::move(options)) {}
+
+int EditorRepl::run() {
+  if (options_.printBanner) {
+    out_ << "Donner Editor MVP — type 'help' for commands, 'quit' to exit.\n";
+  }
+
+  int count = 0;
+  std::string line;
+  while (!quit_) {
+    if (!options_.prompt.empty()) {
+      out_ << options_.prompt;
+      out_.flush();
+    }
+
+#ifdef __linux__
+    // When watch mode is enabled and we're reading from a real fd (stdin),
+    // use poll() with a 500ms timeout so we can periodically check for
+    // file changes without blocking indefinitely on user input.
+    if (app_.watchEnabled() && &in_ == &std::cin) {
+      bool gotLine = false;
+      while (!quit_ && !gotLine) {
+        struct pollfd pfd = {STDIN_FILENO, POLLIN, 0};
+        int ready = ::poll(&pfd, 1, 500);
+        if (ready > 0) {
+          if (!std::getline(in_, line)) {
+            return count;  // EOF
+          }
+          gotLine = true;
+        } else {
+          if (app_.pollForChanges()) {
+            out_ << "[auto-reloaded] " << app_.current().message << "\n";
+            out_.flush();
+          }
+        }
+      }
+    } else
+#endif
+    {
+      // Standard blocking path: stringstream input (tests) or watch disabled.
+      if (!std::getline(in_, line)) break;
+    }
+
+    // Poll once even on the non-poll path (for stringstream-based tests).
+    if (app_.watchEnabled()) {
+      if (app_.pollForChanges()) {
+        out_ << "[auto-reloaded] " << app_.current().message << "\n";
+      }
+    }
+
+    if (dispatch(line)) ++count;
+  }
+  return count;
+}
+
+bool EditorRepl::dispatch(const std::string& line) {
+  const auto tokens = Tokenize(line);
+  if (tokens.empty()) return false;
+  const auto& cmd = tokens.front();
+
+  if (cmd == "help" || cmd == "?") {
+    printHelp();
+    return true;
+  }
+  if (cmd == "quit" || cmd == "exit") {
+    quit_ = true;
+    return true;
+  }
+  if (cmd == "status") {
+    printStatus();
+    return true;
+  }
+  if (cmd == "load") {
+    if (tokens.size() != 2) {
+      out_ << "usage: load <uri>\n";
+      return false;
+    }
+    cmdLoad(tokens[1]);
+    return true;
+  }
+  if (cmd == "reload") {
+    cmdReload();
+    return true;
+  }
+  if (cmd == "resize") {
+    if (tokens.size() != 3) {
+      out_ << "usage: resize <width> <height>\n";
+      return false;
+    }
+    auto parseDim = [&](const std::string& s, int& out) -> bool {
+      int v = 0;
+      const auto [ptr, ec] = std::from_chars(s.data(), s.data() + s.size(), v);
+      if (ec != std::errc() || ptr != s.data() + s.size() || v <= 0) {
+        out_ << "resize: invalid dimension '" << s << "'\n";
+        return false;
+      }
+      out = v;
+      return true;
+    };
+    int w = 0, h = 0;
+    if (!parseDim(tokens[1], w) || !parseDim(tokens[2], h)) return false;
+    cmdResize(w, h);
+    return true;
+  }
+  if (cmd == "show") {
+    cmdShow();
+    return true;
+  }
+  if (cmd == "save") {
+    if (tokens.size() != 2) {
+      out_ << "usage: save <out.png>\n";
+      return false;
+    }
+    cmdSave(tokens[1]);
+    return true;
+  }
+  if (cmd == "inspect") {
+    cmdInspect();
+    return true;
+  }
+  if (cmd == "record") {
+    if (tokens.size() != 2) {
+      out_ << "usage: record <out.rnr>\n";
+      return false;
+    }
+    cmdRecord(tokens[1]);
+    return true;
+  }
+  if (cmd == "watch") {
+    if (tokens.size() != 2) {
+      out_ << "usage: watch on|off\n";
+      return false;
+    }
+    cmdWatch(tokens[1]);
+    return true;
+  }
+
+  out_ << "unknown command '" << cmd << "' — type 'help' for the list\n";
+  return false;
+}
+
+void EditorRepl::printHelp() {
+  out_ << "Commands:\n"
+       << "  help                    show this help\n"
+       << "  load <uri>              fetch + render a new SVG (file:// or path)\n"
+       << "  reload                  re-fetch the current URI\n"
+       << "  resize <w> <h>          re-render at a new viewport\n"
+       << "  status                  print the latest status line\n"
+       << "  show                    render current frame to the terminal\n"
+       << "  save <out.png>          write current bitmap as PNG\n"
+       << "  inspect                 dump decoded wire stream\n"
+       << "  record <out.rnr>        save current frame as a .rnr recording\n"
+       << "  watch on|off            toggle filesystem watch for auto-reload\n"
+       << "  quit | exit             leave the editor\n";
+}
+
+void EditorRepl::printStatus() {
+  const auto& snap = app_.current();
+  out_ << "[" << snap.message << "]";
+  if (!snap.uri.empty()) {
+    out_ << " uri=" << snap.uri;
+  }
+  out_ << "\n";
+}
+
+void EditorRepl::cmdLoad(const std::string& uri) {
+  app_.navigate(uri);
+  printStatus();
+}
+
+void EditorRepl::cmdReload() {
+  app_.reload();
+  printStatus();
+}
+
+void EditorRepl::cmdResize(int width, int height) {
+  app_.resize(width, height);
+  printStatus();
+}
+
+void EditorRepl::cmdShow() {
+  const auto& bitmap = app_.lastGoodBitmap();
+  if (bitmap.pixels.empty()) {
+    out_ << "show: no frame available (try 'load <uri>' first)\n";
+    return;
+  }
+  if (!options_.showEnabled) {
+    out_ << "show: disabled in this repl session\n";
+    return;
+  }
+
+  svg::TerminalImageView view{
+      .data = std::span<const uint8_t>(bitmap.pixels),
+      .width = bitmap.dimensions.x,
+      .height = bitmap.dimensions.y,
+      .strideInPixels = bitmap.rowBytes / 4,
+  };
+  auto config = svg::TerminalImageViewer::DetectConfigFromEnvironment();
+  config.autoScale = true;
+  svg::TerminalImageViewer{}.render(view, out_, config);
+}
+
+void EditorRepl::cmdSave(const std::string& path) {
+  const auto& bitmap = app_.lastGoodBitmap();
+  if (bitmap.pixels.empty() || bitmap.dimensions.x <= 0) {
+    out_ << "save: no frame available\n";
+    return;
+  }
+  const auto png = svg::RendererImageIO::writeRgbaPixelsToPngMemory(
+      bitmap.pixels, bitmap.dimensions.x, bitmap.dimensions.y,
+      bitmap.rowBytes / 4);
+  std::ofstream out(path, std::ios::binary);
+  if (!out) {
+    out_ << "save: cannot open " << path << "\n";
+    return;
+  }
+  out.write(reinterpret_cast<const char*>(png.data()),
+            static_cast<std::streamsize>(png.size()));
+  out_ << "save: wrote " << path << " (" << png.size() << " bytes)\n";
+}
+
+void EditorRepl::cmdInspect() {
+  const auto& wire = app_.lastGoodWire();
+  if (wire.empty()) {
+    out_ << "inspect: no frame available\n";
+    return;
+  }
+  out_ << sandbox::FrameInspector::Dump(wire);
+}
+
+void EditorRepl::cmdRecord(const std::string& path) {
+  const auto& wire = app_.lastGoodWire();
+  if (wire.empty()) {
+    out_ << "record: no frame available\n";
+    return;
+  }
+  sandbox::RnrHeader header;
+  header.width = static_cast<uint32_t>(app_.width());
+  header.height = static_cast<uint32_t>(app_.height());
+  header.backend = sandbox::BackendHint::kTinySkia;
+  header.uri = app_.current().uri;
+  const auto status = sandbox::SaveRnrFile(path, header, wire);
+  if (status != sandbox::RnrIoStatus::kOk) {
+    out_ << "record: save failed\n";
+    return;
+  }
+  out_ << "record: wrote " << path << " (" << wire.size() << " wire bytes)\n";
+}
+
+void EditorRepl::cmdWatch(const std::string& arg) {
+  if (arg == "on") {
+    app_.setWatchEnabled(true);
+    out_ << "watch: enabled\n";
+  } else if (arg == "off") {
+    app_.setWatchEnabled(false);
+    out_ << "watch: disabled\n";
+  } else {
+    out_ << "usage: watch on|off\n";
+  }
+}
+
+}  // namespace donner::editor::app

--- a/donner/editor/app/EditorRepl.h
+++ b/donner/editor/app/EditorRepl.h
@@ -1,0 +1,82 @@
+#pragma once
+/// @file
+///
+/// `EditorRepl` is the stdin/stdout-driven command loop that sits on top
+/// of `EditorApp`. It exists so that the MVP can be driven (and tested)
+/// without an ImGui window — the shell layer is a thin parser that maps
+/// line-based text commands to `EditorApp` methods and writes
+/// human-readable output.
+///
+/// The REPL is parameterized by `std::istream&` + `std::ostream&` instead
+/// of hard-coding `std::cin`/`std::cout`, so headless tests can feed a
+/// scripted input stream and assert against the captured output without
+/// touching the real terminal.
+///
+/// Supported commands (one per line, whitespace-separated):
+///
+///   `help`                 — list commands
+///   `load <uri>`           — fetch + render
+///   `reload`               — re-fetch the current URI
+///   `resize <w> <h>`       — re-render at a new viewport
+///   `status`               — print the latest status line
+///   `show`                 — render the current frame to the terminal (ANSI)
+///   `save <out.png>`       — write the current bitmap as a PNG
+///   `inspect`              — dump the frame's decoded command stream
+///   `record <out.rnr>`     — save the current frame as a `.rnr` recording
+///   `watch on|off`          — toggle filesystem mtime polling for auto-reload
+///   `quit` / `exit`        — leave the loop
+
+#include <iosfwd>
+#include <string>
+
+namespace donner::editor::app {
+
+class EditorApp;
+
+/// Runtime options for the REPL. Defaults match the interactive binary.
+struct EditorReplOptions {
+  /// Prompt string printed before each command line. Tests pass an empty
+  /// string so captured output doesn't include decoration.
+  std::string prompt = "donner> ";
+  /// If true, `show` attempts to render the frame to the output stream
+  /// using `TerminalImageViewer`. Tests disable this because the sampled
+  /// ANSI output is noisy to match against.
+  bool showEnabled = true;
+  /// If true, the REPL prints a one-line welcome banner before accepting
+  /// commands. Tests disable this.
+  bool printBanner = true;
+};
+
+class EditorRepl {
+public:
+  EditorRepl(EditorApp& app, std::istream& in, std::ostream& out,
+             EditorReplOptions options = {});
+
+  /// Runs the command loop until EOF or a `quit`/`exit` command. Returns
+  /// the number of commands successfully dispatched.
+  int run();
+
+  /// Dispatches a single pre-tokenized command line. Exposed for tests
+  /// that want to skip the input stream entirely.
+  bool dispatch(const std::string& line);
+
+private:
+  void printHelp();
+  void printStatus();
+  void cmdLoad(const std::string& uri);
+  void cmdReload();
+  void cmdResize(int width, int height);
+  void cmdShow();
+  void cmdSave(const std::string& path);
+  void cmdInspect();
+  void cmdRecord(const std::string& path);
+  void cmdWatch(const std::string& arg);
+
+  EditorApp& app_;
+  std::istream& in_;
+  std::ostream& out_;
+  EditorReplOptions options_;
+  bool quit_ = false;
+};
+
+}  // namespace donner::editor::app

--- a/donner/editor/app/donner_editor_main.cc
+++ b/donner/editor/app/donner_editor_main.cc
@@ -1,0 +1,47 @@
+/// @file
+///
+/// `donner_editor` — the MVP editor binary. Spins up an `EditorApp` and an
+/// `EditorRepl` driven by stdin/stdout, so you can:
+///
+///     $ bazel run //donner/editor/app:donner_editor
+///     donner> load donner_splash.svg
+///     [rendered 512x384] uri=donner_splash.svg
+///     donner> show       # prints an ANSI approximation to the terminal
+///     donner> save out.png
+///     donner> inspect    # dumps the decoded wire stream
+///     donner> quit
+///
+/// This is deliberately the smallest possible "editor" binary: no window,
+/// no GL, no ImGui. Every piece of the sandbox infrastructure that landed
+/// in S1-S6.1 is exercised end-to-end via the REPL commands.
+
+#include <cstdlib>
+#include <iostream>
+
+#include "donner/editor/app/EditorApp.h"
+#include "donner/editor/app/EditorRepl.h"
+
+int main(int argc, char* argv[]) {
+  // Respect bazel's BUILD_WORKING_DIRECTORY so `bazel run` resolves
+  // user-supplied paths against their original cwd, matching the pattern
+  // used by //examples:svg_to_png.
+  if (const char* bwd = std::getenv("BUILD_WORKING_DIRECTORY")) {
+    std::error_code ec;
+    std::filesystem::current_path(bwd, ec);
+  }
+
+  donner::editor::app::EditorAppOptions options;
+  // Fetch paths relative to the invoking user's cwd.
+  options.sourceOptions.baseDirectory = std::filesystem::current_path();
+
+  // Accept a one-shot initial URL as argv[1] so the binary is scriptable:
+  //   donner_editor mini.svg
+  donner::editor::app::EditorApp app(std::move(options));
+  if (argc > 1) {
+    app.navigate(argv[1]);
+  }
+
+  donner::editor::app::EditorRepl repl(app, std::cin, std::cout);
+  repl.run();
+  return 0;
+}

--- a/donner/editor/app/tests/BUILD.bazel
+++ b/donner/editor/app/tests/BUILD.bazel
@@ -1,0 +1,15 @@
+"""Tests for the editor MVP — headless drivers for EditorApp + EditorRepl."""
+
+load("//build_defs:rules.bzl", "donner_cc_test", "renderer_backend_compatible_with")
+
+donner_cc_test(
+    name = "editor_app_tests",
+    srcs = ["EditorApp_tests.cc"],
+    target_compatible_with = renderer_backend_compatible_with(["tiny_skia"]),
+    deps = [
+        "//donner/editor/app:editor_app",
+        "//donner/editor/app:editor_repl",
+        "//donner/editor/sandbox:rnr_file",
+        "@com_google_gtest//:gtest_main",
+    ],
+)

--- a/donner/editor/app/tests/EditorApp_tests.cc
+++ b/donner/editor/app/tests/EditorApp_tests.cc
@@ -1,0 +1,382 @@
+/// @file
+///
+/// MVP editor tests covering `EditorApp` state transitions and `EditorRepl`
+/// command dispatch. These are fully headless — the REPL is driven by an
+/// in-memory `std::stringstream` instead of a TTY, and the status chips
+/// and `.rnr` files are asserted without touching the terminal image
+/// viewer path (which is noisy to match against).
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <string_view>
+
+#include "donner/editor/app/EditorApp.h"
+#include "donner/editor/app/EditorRepl.h"
+#include "donner/editor/sandbox/RnrFile.h"
+
+namespace donner::editor::app {
+namespace {
+
+class EditorAppTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    tmpDir_ = std::filesystem::path(::testing::TempDir()) /
+              ("editor_app_test_" + std::to_string(::rand()));
+    std::filesystem::create_directories(tmpDir_);
+  }
+
+  void TearDown() override {
+    std::error_code ec;
+    std::filesystem::remove_all(tmpDir_, ec);
+  }
+
+  std::filesystem::path WriteSvg(const std::string& name, std::string_view contents) {
+    const auto path = tmpDir_ / name;
+    std::ofstream out(path, std::ios::binary);
+    out.write(contents.data(), static_cast<std::streamsize>(contents.size()));
+    return path;
+  }
+
+  EditorAppOptions Options() {
+    EditorAppOptions opts;
+    opts.defaultWidth = 64;
+    opts.defaultHeight = 48;
+    opts.sourceOptions.baseDirectory = tmpDir_;
+    return opts;
+  }
+
+  std::filesystem::path tmpDir_;
+};
+
+constexpr std::string_view kSimpleSvg =
+    R"(<svg xmlns="http://www.w3.org/2000/svg" width="64" height="48">
+       <rect width="64" height="48" fill="red"/>
+     </svg>)";
+
+// -----------------------------------------------------------------------------
+// EditorApp core
+// -----------------------------------------------------------------------------
+
+TEST_F(EditorAppTest, EmptyStateBeforeNavigate) {
+  EditorApp app(Options());
+  EXPECT_EQ(app.current().status, EditorStatus::kEmpty);
+  EXPECT_TRUE(app.current().uri.empty());
+  EXPECT_TRUE(app.lastGoodBitmap().pixels.empty());
+}
+
+TEST_F(EditorAppTest, NavigateSucceedsOnValidFile) {
+  WriteSvg("red.svg", kSimpleSvg);
+  EditorApp app(Options());
+
+  const auto& snap = app.navigate("red.svg");
+  ASSERT_EQ(snap.status, EditorStatus::kRendered) << snap.message;
+  EXPECT_EQ(snap.uri, "red.svg");
+  EXPECT_EQ(snap.bitmap.dimensions.x, 64);
+  EXPECT_EQ(snap.bitmap.dimensions.y, 48);
+  EXPECT_FALSE(snap.wire.empty());
+  EXPECT_EQ(snap.unsupportedCount, 0u);
+
+  // lastGoodBitmap mirrors the current bitmap on success.
+  EXPECT_EQ(app.lastGoodBitmap().pixels, snap.bitmap.pixels);
+}
+
+TEST_F(EditorAppTest, FetchErrorKeepsPreviousBitmap) {
+  WriteSvg("red.svg", kSimpleSvg);
+  EditorApp app(Options());
+  app.navigate("red.svg");
+  const auto goodBytes = app.lastGoodBitmap().pixels;
+  ASSERT_FALSE(goodBytes.empty());
+
+  // Second navigation fails at the fetch step.
+  const auto& bad = app.navigate("does_not_exist.svg");
+  EXPECT_EQ(bad.status, EditorStatus::kFetchError);
+  EXPECT_TRUE(bad.bitmap.pixels.empty());
+  EXPECT_FALSE(bad.message.empty());
+
+  // But lastGoodBitmap still holds the previous successful frame — this
+  // is the "keep previous document on screen" contract from the design doc.
+  EXPECT_EQ(app.lastGoodBitmap().pixels, goodBytes);
+}
+
+TEST_F(EditorAppTest, ParseErrorSurfacesDistinctStatus) {
+  WriteSvg("garbage.svg", "this is not svg at all");
+  EditorApp app(Options());
+  const auto& snap = app.navigate("garbage.svg");
+  EXPECT_EQ(snap.status, EditorStatus::kParseError);
+  EXPECT_FALSE(snap.message.empty());
+  EXPECT_NE(snap.message.find("parse"), std::string::npos);
+}
+
+TEST_F(EditorAppTest, ResizeReRendersAtNewViewport) {
+  WriteSvg("red.svg", kSimpleSvg);
+  EditorApp app(Options());
+  app.navigate("red.svg");
+
+  // kSimpleSvg is 64x48 (4:3) — request a 128x96 canvas to match the
+  // source aspect ratio so Donner's preserveAspectRatio doesn't letterbox
+  // the result into an unexpected height.
+  const auto& resized = app.resize(128, 96);
+  EXPECT_EQ(resized.status, EditorStatus::kRendered) << resized.message;
+  EXPECT_EQ(resized.bitmap.dimensions.x, 128);
+  EXPECT_EQ(resized.bitmap.dimensions.y, 96);
+}
+
+TEST_F(EditorAppTest, ReloadPicksUpFileChanges) {
+  const auto path = WriteSvg("live.svg",
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+         <rect width="32" height="32" fill="red"/>
+       </svg>)");
+  EditorApp app(Options());
+  const auto& first = app.navigate("live.svg");
+  ASSERT_EQ(first.status, EditorStatus::kRendered);
+  const auto firstPixels = first.bitmap.pixels;
+
+  // Replace the file contents with a differently-colored rect.
+  {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    constexpr std::string_view kUpdated =
+        R"(<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+           <rect width="32" height="32" fill="blue"/>
+         </svg>)";
+    out.write(kUpdated.data(), static_cast<std::streamsize>(kUpdated.size()));
+  }
+
+  const auto& reloaded = app.reload();
+  ASSERT_EQ(reloaded.status, EditorStatus::kRendered);
+  EXPECT_NE(reloaded.bitmap.pixels, firstPixels)
+      << "reload should have picked up the file edit";
+}
+
+// -----------------------------------------------------------------------------
+// EditorApp watch / pollForChanges
+// -----------------------------------------------------------------------------
+
+TEST_F(EditorAppTest, PollForChangesReturnsFalseWhenWatchDisabled) {
+  WriteSvg("red.svg", kSimpleSvg);
+  EditorApp app(Options());
+  app.navigate("red.svg");
+  // Watch is disabled by default.
+  EXPECT_FALSE(app.watchEnabled());
+  EXPECT_FALSE(app.pollForChanges());
+}
+
+TEST_F(EditorAppTest, PollForChangesReturnsFalseWhenNoFileLoaded) {
+  EditorApp app(Options());
+  app.setWatchEnabled(true);
+  EXPECT_FALSE(app.pollForChanges());
+}
+
+TEST_F(EditorAppTest, PollForChangesDetectsFileModification) {
+  const auto path = WriteSvg("watch.svg",
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+         <rect width="32" height="32" fill="red"/>
+       </svg>)");
+  EditorApp app(Options());
+  app.navigate("watch.svg");
+  app.setWatchEnabled(true);
+  const auto firstPixels = app.lastGoodBitmap().pixels;
+  ASSERT_FALSE(firstPixels.empty());
+
+  // No change yet — poll should return false.
+  EXPECT_FALSE(app.pollForChanges());
+
+  // Overwrite the file with different content.
+  {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    constexpr std::string_view kUpdated =
+        R"(<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+           <rect width="32" height="32" fill="blue"/>
+         </svg>)";
+    out.write(kUpdated.data(), static_cast<std::streamsize>(kUpdated.size()));
+  }
+
+  // Touch the file to ensure the mtime differs — some filesystems have
+  // coarse timestamps (1s resolution).
+  std::filesystem::last_write_time(
+      path, std::filesystem::file_time_type::clock::now());
+
+  EXPECT_TRUE(app.pollForChanges());
+  EXPECT_NE(app.lastGoodBitmap().pixels, firstPixels)
+      << "pollForChanges should have reloaded with new content";
+
+  // A second poll without further edits should return false.
+  EXPECT_FALSE(app.pollForChanges());
+}
+
+// -----------------------------------------------------------------------------
+// EditorRepl command dispatch
+// -----------------------------------------------------------------------------
+
+class EditorReplTest : public EditorAppTest {
+protected:
+  EditorReplOptions ReplOptions() {
+    EditorReplOptions opts;
+    opts.printBanner = false;
+    opts.prompt = "";
+    opts.showEnabled = false;  // don't touch terminal image viewer in tests
+    return opts;
+  }
+};
+
+TEST_F(EditorReplTest, HelpListsAllCommands) {
+  EditorApp app(Options());
+  std::stringstream in("help\nquit\n");
+  std::stringstream out;
+  EditorRepl repl(app, in, out, ReplOptions());
+  repl.run();
+
+  const auto text = out.str();
+  for (const auto* cmd : {"load ", "reload", "resize", "show", "save ", "inspect",
+                          "record", "quit"}) {
+    EXPECT_NE(text.find(cmd), std::string::npos) << "help missing: " << cmd;
+  }
+}
+
+TEST_F(EditorReplTest, LoadStatusSaveCycle) {
+  WriteSvg("red.svg", kSimpleSvg);
+  const auto pngPath = tmpDir_ / "out.png";
+
+  std::stringstream in;
+  in << "load red.svg\n"
+     << "status\n"
+     << "save " << pngPath.string() << "\n"
+     << "quit\n";
+  std::stringstream out;
+
+  EditorApp app(Options());
+  EditorRepl repl(app, in, out, ReplOptions());
+  const int dispatched = repl.run();
+  EXPECT_EQ(dispatched, 4);
+
+  const auto text = out.str();
+  EXPECT_NE(text.find("rendered 64x48"), std::string::npos) << text;
+  EXPECT_NE(text.find("uri=red.svg"), std::string::npos);
+  EXPECT_NE(text.find("save: wrote"), std::string::npos);
+
+  // PNG file exists and starts with the PNG magic.
+  ASSERT_TRUE(std::filesystem::exists(pngPath));
+  std::ifstream png(pngPath, std::ios::binary);
+  char magic[8] = {};
+  png.read(magic, 8);
+  const unsigned char expected[] = {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
+  for (int i = 0; i < 8; ++i) {
+    EXPECT_EQ(static_cast<unsigned char>(magic[i]), expected[i]) << "byte " << i;
+  }
+}
+
+TEST_F(EditorReplTest, RecordWritesValidRnrFile) {
+  WriteSvg("red.svg", kSimpleSvg);
+  const auto rnrPath = tmpDir_ / "demo.rnr";
+
+  std::stringstream in;
+  in << "load red.svg\n"
+     << "record " << rnrPath.string() << "\n"
+     << "quit\n";
+  std::stringstream out;
+
+  EditorApp app(Options());
+  EditorRepl repl(app, in, out, ReplOptions());
+  repl.run();
+
+  EXPECT_NE(out.str().find("record: wrote"), std::string::npos);
+  ASSERT_TRUE(std::filesystem::exists(rnrPath));
+
+  // Load the .rnr back and verify its contents look reasonable.
+  sandbox::RnrHeader header;
+  std::vector<uint8_t> wire;
+  ASSERT_EQ(sandbox::LoadRnrFile(rnrPath, header, wire), sandbox::RnrIoStatus::kOk);
+  EXPECT_EQ(header.width, 64u);
+  EXPECT_EQ(header.height, 48u);
+  EXPECT_FALSE(wire.empty());
+}
+
+TEST_F(EditorReplTest, InspectProducesCommandDump) {
+  WriteSvg("red.svg", kSimpleSvg);
+
+  std::stringstream in("load red.svg\ninspect\nquit\n");
+  std::stringstream out;
+
+  EditorApp app(Options());
+  EditorRepl repl(app, in, out, ReplOptions());
+  repl.run();
+
+  const auto text = out.str();
+  EXPECT_NE(text.find("beginFrame"), std::string::npos);
+  EXPECT_NE(text.find("endFrame"), std::string::npos);
+  EXPECT_NE(text.find("drawPath"), std::string::npos);
+}
+
+TEST_F(EditorReplTest, UnknownCommandDoesNotCrash) {
+  EditorApp app(Options());
+  std::stringstream in("frobnicate\nquit\n");
+  std::stringstream out;
+  EditorRepl repl(app, in, out, ReplOptions());
+  repl.run();
+  EXPECT_NE(out.str().find("unknown command"), std::string::npos);
+}
+
+TEST_F(EditorReplTest, InspectWithNoFrameReportsError) {
+  EditorApp app(Options());
+  std::stringstream in("inspect\nquit\n");
+  std::stringstream out;
+  EditorRepl repl(app, in, out, ReplOptions());
+  repl.run();
+  EXPECT_NE(out.str().find("no frame available"), std::string::npos);
+}
+
+TEST_F(EditorReplTest, ResizeCommandParsesDimensions) {
+  WriteSvg("red.svg", kSimpleSvg);
+  // Match the SVG's 4:3 aspect so preserveAspectRatio doesn't letterbox.
+  std::stringstream in("load red.svg\nresize 128 96\nstatus\nquit\n");
+  std::stringstream out;
+
+  EditorApp app(Options());
+  EditorRepl repl(app, in, out, ReplOptions());
+  repl.run();
+
+  const auto text = out.str();
+  EXPECT_NE(text.find("rendered 128x96"), std::string::npos) << text;
+}
+
+TEST_F(EditorReplTest, WatchOnOffCommand) {
+  EditorApp app(Options());
+  std::stringstream in("watch on\nwatch off\nquit\n");
+  std::stringstream out;
+  EditorRepl repl(app, in, out, ReplOptions());
+  repl.run();
+
+  const auto text = out.str();
+  EXPECT_NE(text.find("watch: enabled"), std::string::npos) << text;
+  EXPECT_NE(text.find("watch: disabled"), std::string::npos) << text;
+  // After "watch off", the app's watch should be disabled.
+  EXPECT_FALSE(app.watchEnabled());
+}
+
+TEST_F(EditorReplTest, WatchInvalidArgPrintsUsage) {
+  EditorApp app(Options());
+  std::stringstream in("watch maybe\nquit\n");
+  std::stringstream out;
+  EditorRepl repl(app, in, out, ReplOptions());
+  repl.run();
+
+  const auto text = out.str();
+  EXPECT_NE(text.find("usage: watch on|off"), std::string::npos) << text;
+}
+
+TEST_F(EditorReplTest, HelpListsWatchCommand) {
+  EditorApp app(Options());
+  std::stringstream in("help\nquit\n");
+  std::stringstream out;
+  EditorRepl repl(app, in, out, ReplOptions());
+  repl.run();
+
+  const auto text = out.str();
+  EXPECT_NE(text.find("watch"), std::string::npos) << text;
+}
+
+}  // namespace
+}  // namespace donner::editor::app

--- a/donner/editor/gui/BUILD.bazel
+++ b/donner/editor/gui/BUILD.bazel
@@ -1,0 +1,44 @@
+"""GLFW + ImGui + OpenGL frontend for the Donner Editor MVP.
+
+Builds the `donner_editor_gui` binary — a real window that exercises the
+entire S1-S6 sandbox stack plus the M1 editor infrastructure. The window
+layer is tagged `manual` so it doesn't run under headless CI; the binary
+still builds as part of `bazel test //...`, though.
+"""
+
+load("//build_defs:rules.bzl", "donner_cc_binary", "donner_cc_library", "renderer_backend_compatible_with")
+
+package(default_visibility = ["//donner/editor:__subpackages__"])
+
+donner_cc_library(
+    name = "editor_window",
+    srcs = ["EditorWindow.cc"],
+    hdrs = ["EditorWindow.h"],
+    target_compatible_with = renderer_backend_compatible_with(["tiny_skia"]),
+    visibility = ["//donner/editor:__subpackages__"],
+    deps = [
+        "//donner/svg/renderer:renderer_interface",
+        "//third_party/glad",
+        "@imgui",
+    ],
+)
+
+donner_cc_binary(
+    name = "donner_editor_gui",
+    srcs = ["donner_editor_gui_main.cc"],
+    # The binary requires a display to actually run, so we tag it manual
+    # to keep it out of `bazel test //...` wildcards. It still builds.
+    tags = ["manual"],
+    target_compatible_with = renderer_backend_compatible_with(["tiny_skia"]),
+    visibility = ["//donner/editor:__subpackages__"],
+    deps = [
+        ":editor_window",
+        "//donner/editor/app:editor_app",
+        "//donner/editor/sandbox:frame_inspector",
+        "//donner/editor/sandbox:rnr_file",
+        "//donner/svg/renderer:renderer_image_io",
+        "//donner/svg/renderer:renderer_tiny_skia",
+        "//third_party/glad",
+        "@imgui",
+    ],
+)

--- a/donner/editor/gui/BUILD.bazel
+++ b/donner/editor/gui/BUILD.bazel
@@ -14,6 +14,10 @@ donner_cc_library(
     name = "editor_window",
     srcs = ["EditorWindow.cc"],
     hdrs = ["EditorWindow.h"],
+    # The GUI requires a display server (X11/Wayland/Cocoa) at both compile
+    # and run time. Tagged manual so `bazel build //...` on headless CI
+    # doesn't pull in GLFW (which fails without X11 dev headers).
+    tags = ["manual"],
     target_compatible_with = renderer_backend_compatible_with(["tiny_skia"]),
     visibility = ["//donner/editor:__subpackages__"],
     deps = [

--- a/donner/editor/gui/EditorWindow.cc
+++ b/donner/editor/gui/EditorWindow.cc
@@ -1,0 +1,150 @@
+#include "donner/editor/gui/EditorWindow.h"
+
+#include <glad/glad.h>
+// glad must be included before GLFW so it takes precedence.
+#include <GLFW/glfw3.h>
+
+#include "backends/imgui_impl_glfw.h"
+#include "backends/imgui_impl_opengl3.h"
+#include "imgui.h"
+
+#include <cstdio>
+
+namespace donner::editor::gui {
+
+namespace {
+
+void GlfwErrorCallback(int error, const char* description) {
+  std::fprintf(stderr, "GLFW error %d: %s\n", error, description);
+}
+
+}  // namespace
+
+EditorWindow::EditorWindow(EditorWindowOptions options) : options_(std::move(options)) {
+  glfwSetErrorCallback(&GlfwErrorCallback);
+
+  if (glfwInit() == GLFW_FALSE) {
+    std::fprintf(stderr, "EditorWindow: glfwInit() failed\n");
+    return;
+  }
+
+  // OpenGL 3.3 core is plenty — matches what imgui_impl_opengl3 targets
+  // by default and what glad was generated for.
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+  glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+#ifdef __APPLE__
+  glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
+#endif
+
+  window_ = glfwCreateWindow(options_.initialWidth, options_.initialHeight,
+                             options_.title.c_str(), /*monitor=*/nullptr,
+                             /*share=*/nullptr);
+  if (window_ == nullptr) {
+    std::fprintf(stderr, "EditorWindow: glfwCreateWindow() failed\n");
+    glfwTerminate();
+    return;
+  }
+
+  glfwMakeContextCurrent(window_);
+  glfwSwapInterval(1);  // vsync
+
+  if (gladLoadGLLoader(reinterpret_cast<GLADloadproc>(glfwGetProcAddress)) == 0) {
+    std::fprintf(stderr, "EditorWindow: glad failed to load GL symbols\n");
+    glfwDestroyWindow(window_);
+    window_ = nullptr;
+    glfwTerminate();
+    return;
+  }
+
+  // Dear ImGui setup. Matches the canonical example from the imgui docs.
+  IMGUI_CHECKVERSION();
+  ImGui::CreateContext();
+  ImGuiIO& io = ImGui::GetIO();
+  io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+  io.IniFilename = nullptr;  // no persistent layout file on disk
+
+  ImGui::StyleColorsDark();
+  if (!ImGui_ImplGlfw_InitForOpenGL(window_, /*install_callbacks=*/true)) {
+    std::fprintf(stderr, "EditorWindow: ImGui_ImplGlfw_InitForOpenGL failed\n");
+    return;
+  }
+  if (!ImGui_ImplOpenGL3_Init("#version 330 core")) {
+    std::fprintf(stderr, "EditorWindow: ImGui_ImplOpenGL3_Init failed\n");
+    return;
+  }
+  imguiInitialized_ = true;
+  valid_ = true;
+}
+
+EditorWindow::~EditorWindow() {
+  if (imguiInitialized_) {
+    ImGui_ImplOpenGL3_Shutdown();
+    ImGui_ImplGlfw_Shutdown();
+    ImGui::DestroyContext();
+  }
+  if (textureId_ != 0) {
+    glDeleteTextures(1, &textureId_);
+    textureId_ = 0;
+  }
+  if (window_ != nullptr) {
+    glfwDestroyWindow(window_);
+    window_ = nullptr;
+  }
+  glfwTerminate();
+}
+
+bool EditorWindow::shouldClose() const {
+  return window_ == nullptr || glfwWindowShouldClose(window_) != 0;
+}
+
+void EditorWindow::pollEvents() {
+  glfwPollEvents();
+}
+
+void EditorWindow::beginFrame() {
+  ImGui_ImplOpenGL3_NewFrame();
+  ImGui_ImplGlfw_NewFrame();
+  ImGui::NewFrame();
+}
+
+void EditorWindow::endFrame() {
+  ImGui::Render();
+  int displayW = 0;
+  int displayH = 0;
+  glfwGetFramebufferSize(window_, &displayW, &displayH);
+  glViewport(0, 0, displayW, displayH);
+  glClearColor(options_.clearColor[0], options_.clearColor[1],
+               options_.clearColor[2], options_.clearColor[3]);
+  glClear(GL_COLOR_BUFFER_BIT);
+  ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+  glfwSwapBuffers(window_);
+}
+
+void EditorWindow::uploadBitmap(const svg::RendererBitmap& bitmap) {
+  if (bitmap.pixels.empty() || bitmap.dimensions.x <= 0 || bitmap.dimensions.y <= 0) {
+    return;
+  }
+
+  if (textureId_ == 0) {
+    glGenTextures(1, &textureId_);
+  }
+  glBindTexture(GL_TEXTURE_2D, textureId_);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+  const int strideInPixels =
+      bitmap.rowBytes > 0 ? static_cast<int>(bitmap.rowBytes / 4) : bitmap.dimensions.x;
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, strideInPixels);
+  glTexImage2D(GL_TEXTURE_2D, /*level=*/0, GL_RGBA, bitmap.dimensions.x,
+               bitmap.dimensions.y, /*border=*/0, GL_RGBA, GL_UNSIGNED_BYTE,
+               bitmap.pixels.data());
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+
+  textureWidth_ = bitmap.dimensions.x;
+  textureHeight_ = bitmap.dimensions.y;
+}
+
+}  // namespace donner::editor::gui

--- a/donner/editor/gui/EditorWindow.h
+++ b/donner/editor/gui/EditorWindow.h
@@ -1,0 +1,100 @@
+#pragma once
+/// @file
+///
+/// `EditorWindow` — RAII wrapper around GLFW + OpenGL + Dear ImGui. Keeps
+/// the main binary thin by encapsulating everything that would otherwise
+/// be boilerplate: GLFW init, window creation, context current, glad
+/// loader, ImGui context, imgui_impl_glfw + imgui_impl_opengl3 setup,
+/// plus texture upload from a `RendererBitmap`.
+///
+/// The class is intentionally narrow — it exposes only what the main
+/// binary needs:
+///   - construct/destruct (RAII handles cleanup)
+///   - `shouldClose()` / `pollEvents()` — event loop hooks
+///   - `beginFrame()` / `endFrame()` — ImGui frame bracketing + swap
+///   - `uploadBitmap()` — moves a CPU-side RGBA buffer into a GL texture
+///     (reuses the same texture ID across frames to avoid churn)
+///   - `textureId()` — exposes the current texture for `ImGui::Image`
+///
+/// Any code that wants to draw ImGui widgets happens *between*
+/// `beginFrame()` and `endFrame()` on the caller's side — this class
+/// doesn't own the widget tree, just the hosting surface.
+
+#include <cstdint>
+#include <string>
+
+#include "donner/svg/renderer/RendererInterface.h"
+
+struct GLFWwindow;
+
+namespace donner::editor::gui {
+
+struct EditorWindowOptions {
+  std::string title = "Donner Editor";
+  int initialWidth = 1280;
+  int initialHeight = 720;
+  /// Background clear color (RGBA, 0..1). Matches the viewport surround
+  /// when the document doesn't fill the whole window.
+  float clearColor[4] = {0.11f, 0.11f, 0.13f, 1.0f};
+};
+
+/// Initializes GLFW + GL + ImGui when constructed, tears everything down
+/// in the destructor. One instance per process — ImGui's global state
+/// means we can't easily have two at once.
+class EditorWindow {
+public:
+  explicit EditorWindow(EditorWindowOptions options = {});
+  ~EditorWindow();
+
+  EditorWindow(const EditorWindow&) = delete;
+  EditorWindow& operator=(const EditorWindow&) = delete;
+
+  /// True iff GLFW + GL + ImGui initialized successfully. Callers should
+  /// bail out if this is false instead of trying to render.
+  [[nodiscard]] bool valid() const { return valid_; }
+
+  /// True when the user has clicked the window close button or pressed
+  /// the OS's "close" shortcut.
+  [[nodiscard]] bool shouldClose() const;
+
+  /// Pumps the OS event queue. Must be called once per frame.
+  void pollEvents();
+
+  /// Starts a new ImGui frame. Caller issues `ImGui::*` widget calls
+  /// after this returns.
+  void beginFrame();
+
+  /// Flushes the current ImGui frame to the backbuffer, clears with the
+  /// configured color, and swaps. Must be called once per `beginFrame()`.
+  void endFrame();
+
+  /// Uploads `bitmap` to the GL texture owned by this window. The
+  /// texture is reused across calls — later calls replace the contents.
+  /// No-op on empty bitmaps. After upload, `textureId()` returns a handle
+  /// suitable for `ImGui::Image((void*)(intptr_t)textureId(), ...)`.
+  void uploadBitmap(const svg::RendererBitmap& bitmap);
+
+  /// Raw GL texture name for the most recent bitmap upload. Zero when no
+  /// upload has happened yet.
+  [[nodiscard]] uint32_t textureId() const { return textureId_; }
+
+  /// Dimensions of the most recently uploaded bitmap. (0, 0) before the
+  /// first upload.
+  [[nodiscard]] int textureWidth() const { return textureWidth_; }
+  [[nodiscard]] int textureHeight() const { return textureHeight_; }
+
+  /// Raw GLFW window handle. Exposed for advanced use cases (custom key
+  /// bindings, drag-and-drop setup). The main MVP binary doesn't need it.
+  [[nodiscard]] GLFWwindow* rawHandle() const { return window_; }
+
+private:
+  EditorWindowOptions options_;
+  GLFWwindow* window_ = nullptr;
+  uint32_t textureId_ = 0;
+  int textureWidth_ = 0;
+  int textureHeight_ = 0;
+  bool valid_ = false;
+  bool imguiInitialized_ = false;
+};
+
+}  // namespace donner::editor::gui

--- a/donner/editor/gui/donner_editor_gui_main.cc
+++ b/donner/editor/gui/donner_editor_gui_main.cc
@@ -1,0 +1,383 @@
+/// @file
+///
+/// `donner_editor_gui` — the full-window MVP editor. Pairs the headless
+/// `EditorApp` + `PipelinedRenderer` stack with a GLFW/ImGui/OpenGL shell
+/// that a user can actually interact with.
+///
+/// The UI is intentionally minimal — just the pieces that prove the
+/// sandbox architecture works end-to-end in a real window:
+///
+///   - **Address bar** at the top — accepts `file://` URIs and bare paths,
+///     same as the `SvgSource` classifier. Press Enter to fetch + render.
+///   - **Status line** — colored chip showing the current editor state
+///     (rendered / lossy / parse error / fetch error).
+///   - **Viewport** — the last-good bitmap displayed via `ImGui::Image`
+///     from a GL texture uploaded on every navigation.
+///   - **Save / Inspect / Record buttons** — parity with the REPL.
+///
+/// There is deliberately no document tree, no selection, no text editor
+/// pane — those come later. This binary exists to prove that the exact
+/// same stack the terminal REPL exercises also drives a window.
+
+#include <array>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <utility>
+
+#include "imgui.h"
+
+#include "donner/editor/app/EditorApp.h"
+#include "donner/editor/gui/EditorWindow.h"
+#include "donner/editor/sandbox/FrameInspector.h"
+#include "donner/editor/sandbox/RnrFile.h"
+#include "donner/svg/renderer/RendererImageIO.h"
+#include "donner/svg/renderer/RendererTinySkia.h"
+
+#include <glad/glad.h>
+
+namespace {
+
+using donner::editor::app::EditorApp;
+using donner::editor::app::EditorAppOptions;
+using donner::editor::app::EditorStatus;
+using donner::editor::gui::EditorWindow;
+using donner::editor::gui::EditorWindowOptions;
+namespace sandbox = donner::editor::sandbox;
+namespace svg = donner::svg;
+
+/// Maps an editor status to a chip color the user can grok at a glance.
+ImVec4 StatusColor(EditorStatus status) {
+  switch (status) {
+    case EditorStatus::kRendered:      return ImVec4(0.30f, 0.85f, 0.45f, 1.0f);  // green
+    case EditorStatus::kRenderedLossy: return ImVec4(0.95f, 0.78f, 0.22f, 1.0f);  // amber
+    case EditorStatus::kLoading:       return ImVec4(0.60f, 0.70f, 0.90f, 1.0f);  // blue
+    case EditorStatus::kFetchError:
+    case EditorStatus::kParseError:
+    case EditorStatus::kRenderError:   return ImVec4(0.92f, 0.42f, 0.38f, 1.0f);  // red
+    case EditorStatus::kEmpty:         return ImVec4(0.60f, 0.60f, 0.60f, 1.0f);  // grey
+  }
+  return ImVec4(0.60f, 0.60f, 0.60f, 1.0f);
+}
+
+bool WritePngFile(const std::filesystem::path& path, const std::vector<uint8_t>& bytes) {
+  std::ofstream out(path, std::ios::binary);
+  if (!out) return false;
+  out.write(reinterpret_cast<const char*>(bytes.data()),
+            static_cast<std::streamsize>(bytes.size()));
+  return out.good();
+}
+
+void DrawAddressBar(EditorApp& app, EditorWindow& window, char* urlBuffer,
+                    std::size_t urlBufferSize, std::string& statusNote) {
+  ImGui::PushItemWidth(-160.0f);
+  const bool submit = ImGui::InputText("##url", urlBuffer, urlBufferSize,
+                                       ImGuiInputTextFlags_EnterReturnsTrue);
+  ImGui::PopItemWidth();
+
+  ImGui::SameLine();
+  const bool loadClicked = ImGui::Button("Load", ImVec2(60, 0));
+  ImGui::SameLine();
+  const bool reloadClicked = ImGui::Button("Reload", ImVec2(70, 0));
+
+  if (submit || loadClicked) {
+    app.navigate(urlBuffer);
+    if (app.current().status == EditorStatus::kRendered ||
+        app.current().status == EditorStatus::kRenderedLossy) {
+      window.uploadBitmap(app.lastGoodBitmap());
+    }
+    statusNote.clear();
+  }
+  if (reloadClicked) {
+    app.reload();
+    if (app.current().status == EditorStatus::kRendered ||
+        app.current().status == EditorStatus::kRenderedLossy) {
+      window.uploadBitmap(app.lastGoodBitmap());
+    }
+    statusNote.clear();
+  }
+}
+
+void DrawStatusChip(const EditorApp& app, const std::string& statusNote) {
+  const auto& snap = app.current();
+  ImGui::TextColored(StatusColor(snap.status), "[%s]", snap.message.c_str());
+  if (!snap.uri.empty()) {
+    ImGui::SameLine();
+    ImGui::TextDisabled("%s", snap.uri.c_str());
+  }
+  if (!statusNote.empty()) {
+    ImGui::TextUnformatted(statusNote.c_str());
+  }
+}
+
+void DrawActionButtons(EditorApp& app, std::string& statusNote) {
+  const bool hasFrame = !app.lastGoodBitmap().pixels.empty();
+  if (ImGui::Button("Save PNG…")) {
+    if (!hasFrame) {
+      statusNote = "save: no frame available";
+    } else {
+      const auto path = std::filesystem::current_path() / "donner_editor_frame.png";
+      const auto& bitmap = app.lastGoodBitmap();
+      const auto png = svg::RendererImageIO::writeRgbaPixelsToPngMemory(
+          bitmap.pixels, bitmap.dimensions.x, bitmap.dimensions.y,
+          bitmap.rowBytes / 4);
+      if (!png.empty() && WritePngFile(path, png)) {
+        statusNote = "wrote " + path.string();
+      } else {
+        statusNote = "save: failed to write " + path.string();
+      }
+    }
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Record .rnr")) {
+    if (!hasFrame) {
+      statusNote = "record: no frame available";
+    } else {
+      const auto path = std::filesystem::current_path() / "donner_editor_frame.rnr";
+      sandbox::RnrHeader header;
+      header.width = static_cast<uint32_t>(app.width());
+      header.height = static_cast<uint32_t>(app.height());
+      header.backend = sandbox::BackendHint::kTinySkia;
+      header.uri = app.current().uri;
+      if (sandbox::SaveRnrFile(path, header, app.lastGoodWire()) ==
+          sandbox::RnrIoStatus::kOk) {
+        statusNote = "wrote " + path.string();
+      } else {
+        statusNote = "record: failed to write " + path.string();
+      }
+    }
+  }
+}
+
+/// Uploads a RendererBitmap into a GL texture using the same pattern as
+/// EditorWindow::uploadBitmap. Creates the texture lazily on first call.
+void UploadBitmapToTexture(const svg::RendererBitmap& bitmap, GLuint& textureId) {
+  if (bitmap.pixels.empty() || bitmap.dimensions.x <= 0 || bitmap.dimensions.y <= 0) {
+    return;
+  }
+  if (textureId == 0) {
+    glGenTextures(1, &textureId);
+  }
+  glBindTexture(GL_TEXTURE_2D, textureId);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+  const int strideInPixels =
+      bitmap.rowBytes > 0 ? static_cast<int>(bitmap.rowBytes / 4) : bitmap.dimensions.x;
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, strideInPixels);
+  glTexImage2D(GL_TEXTURE_2D, /*level=*/0, GL_RGBA, bitmap.dimensions.x,
+               bitmap.dimensions.y, /*border=*/0, GL_RGBA, GL_UNSIGNED_BYTE,
+               bitmap.pixels.data());
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+}
+
+/// Persistent state for the scrub slider, shared between DrawInspectorPane
+/// (which drives the slider) and DrawViewport (which shows the result).
+struct ScrubState {
+  int scrubIndex = 0;
+  bool scrubActive = false;
+  GLuint scrubTextureId = 0;
+  int scrubTextureWidth = 0;
+  int scrubTextureHeight = 0;
+  int lastReplayedIndex = -1;
+};
+
+void DrawInspectorPane(const EditorApp& app, bool& inspectorOpen,
+                       ScrubState& scrub) {
+  if (!inspectorOpen) return;
+  ImGui::Begin("Frame Inspector", &inspectorOpen);
+  const auto& wire = app.lastGoodWire();
+  if (wire.empty()) {
+    ImGui::TextDisabled("no frame recorded yet");
+    ImGui::End();
+    return;
+  }
+  const auto result = sandbox::FrameInspector::Decode(wire);
+  ImGui::Text("%zu command(s), finalDepth=%d",
+              static_cast<size_t>(result.commands.size()), result.finalDepth);
+  if (!result.streamValid) {
+    ImGui::TextColored(ImVec4(0.92f, 0.42f, 0.38f, 1.0f),
+                       "decode stopped: %s", result.error.c_str());
+  }
+  if (ImGui::BeginTable("commands", 3,
+                        ImGuiTableFlags_RowBg | ImGuiTableFlags_Borders |
+                            ImGuiTableFlags_ScrollY)) {
+    ImGui::TableSetupColumn("#");
+    ImGui::TableSetupColumn("depth");
+    ImGui::TableSetupColumn("summary");
+    ImGui::TableHeadersRow();
+    for (const auto& cmd : result.commands) {
+      ImGui::TableNextRow();
+      ImGui::TableNextColumn();
+      ImGui::Text("%u", cmd.index);
+      ImGui::TableNextColumn();
+      ImGui::Text("%d", cmd.depth);
+      ImGui::TableNextColumn();
+      ImGui::TextUnformatted(cmd.summary.c_str());
+    }
+    ImGui::EndTable();
+  }
+
+  // --- Scrub slider for draw-order visualization ---
+  ImGui::Separator();
+  const int maxIndex = static_cast<int>(result.commands.size());
+  // Clamp in case the command count changed between frames.
+  if (scrub.scrubIndex > maxIndex) {
+    scrub.scrubIndex = maxIndex;
+  }
+
+  const bool wasActive = scrub.scrubActive;
+  ImGui::Checkbox("Scrub", &scrub.scrubActive);
+  ImGui::SameLine();
+  if (scrub.scrubActive) {
+    ImGui::PushItemWidth(-1);
+    ImGui::SliderInt("##scrub_slider", &scrub.scrubIndex, 0, maxIndex);
+    ImGui::PopItemWidth();
+
+    // Replay into the offscreen backend when scrub is first activated or
+    // the slider value changes.
+    const bool justActivated = scrub.scrubActive && !wasActive;
+    if (justActivated || scrub.scrubIndex != scrub.lastReplayedIndex) {
+      static svg::RendererTinySkia offscreenBackend;
+      sandbox::FrameInspector::ReplayPrefix(
+          wire, static_cast<std::size_t>(scrub.scrubIndex), offscreenBackend);
+      auto bitmap = offscreenBackend.takeSnapshot();
+      UploadBitmapToTexture(bitmap, scrub.scrubTextureId);
+      scrub.scrubTextureWidth = bitmap.dimensions.x;
+      scrub.scrubTextureHeight = bitmap.dimensions.y;
+      scrub.lastReplayedIndex = scrub.scrubIndex;
+    }
+
+    if (ImGui::Button("Resume")) {
+      scrub.scrubActive = false;
+    }
+  } else {
+    ImGui::TextDisabled("enable to step through draw commands");
+    scrub.lastReplayedIndex = -1;
+  }
+
+  ImGui::End();
+}
+
+void DrawViewport(const EditorWindow& window, const EditorApp& app,
+                  const ScrubState& scrub) {
+  const float availWidth = ImGui::GetContentRegionAvail().x;
+  const float availHeight = ImGui::GetContentRegionAvail().y;
+
+  // Choose between the scrub texture and the main texture.
+  const bool useScrub = scrub.scrubActive && scrub.scrubTextureId != 0;
+  const GLuint texId = useScrub ? scrub.scrubTextureId : window.textureId();
+  const int texW = useScrub ? scrub.scrubTextureWidth : window.textureWidth();
+  const int texH = useScrub ? scrub.scrubTextureHeight : window.textureHeight();
+
+  if (texId == 0) {
+    ImGui::TextDisabled("viewport: no frame — load an SVG to begin");
+    return;
+  }
+  // Fit the texture into the remaining area while preserving aspect.
+  const float srcW = static_cast<float>(texW);
+  const float srcH = static_cast<float>(texH);
+  const float scale = std::min(availWidth / srcW, availHeight / srcH);
+  const ImVec2 dst(srcW * scale, srcH * scale);
+  // Centre the image within the available space.
+  const ImVec2 cursor = ImGui::GetCursorPos();
+  ImGui::SetCursorPos(ImVec2(cursor.x + (availWidth - dst.x) * 0.5f,
+                             cursor.y + (availHeight - dst.y) * 0.5f));
+  ImGui::Image(static_cast<ImTextureID>(static_cast<intptr_t>(texId)), dst);
+  (void)app;
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+  // Respect bazel's BUILD_WORKING_DIRECTORY so `bazel run` resolves
+  // user-supplied paths against the invoking user's cwd.
+  if (const char* bwd = std::getenv("BUILD_WORKING_DIRECTORY")) {
+    std::error_code ec;
+    std::filesystem::current_path(bwd, ec);
+  }
+
+  EditorAppOptions appOptions;
+  appOptions.defaultWidth = 800;
+  appOptions.defaultHeight = 600;
+  appOptions.sourceOptions.baseDirectory = std::filesystem::current_path();
+  EditorApp app(std::move(appOptions));
+
+  EditorWindow window({.title = "Donner Editor", .initialWidth = 1280, .initialHeight = 800});
+  if (!window.valid()) {
+    std::fprintf(stderr, "donner_editor_gui: failed to initialize window\n");
+    return 1;
+  }
+
+  // Pre-populate the address bar with argv[1] if supplied, and trigger a
+  // navigation so the first frame already has content.
+  std::array<char, 1024> urlBuffer{};
+  if (argc > 1) {
+    std::strncpy(urlBuffer.data(), argv[1], urlBuffer.size() - 1);
+    app.navigate(argv[1]);
+    if (app.current().status == EditorStatus::kRendered ||
+        app.current().status == EditorStatus::kRenderedLossy) {
+      window.uploadBitmap(app.lastGoodBitmap());
+    }
+  }
+
+  std::string statusNote;
+  bool inspectorOpen = false;
+  bool watchEnabled = false;
+  int frameCounter = 0;
+  ScrubState scrub;
+
+  while (!window.shouldClose()) {
+    window.pollEvents();
+    window.beginFrame();
+
+    // Throttled filesystem poll: check every ~30 frames (~500ms at 60fps).
+    ++frameCounter;
+    if (watchEnabled && frameCounter >= 30) {
+      frameCounter = 0;
+      if (app.pollForChanges()) {
+        window.uploadBitmap(app.lastGoodBitmap());
+        statusNote = "[auto-reloaded]";
+      }
+    }
+
+    const ImGuiViewport* viewport = ImGui::GetMainViewport();
+    ImGui::SetNextWindowPos(viewport->WorkPos);
+    ImGui::SetNextWindowSize(viewport->WorkSize);
+    ImGui::Begin("Donner Editor", nullptr,
+                 ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove |
+                     ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoBringToFrontOnFocus);
+
+    DrawAddressBar(app, window, urlBuffer.data(), urlBuffer.size(), statusNote);
+    DrawStatusChip(app, statusNote);
+    DrawActionButtons(app, statusNote);
+
+    ImGui::SameLine();
+    if (ImGui::Checkbox("Watch", &watchEnabled)) {
+      app.setWatchEnabled(watchEnabled);
+    }
+    ImGui::SameLine();
+    ImGui::Checkbox("Inspector", &inspectorOpen);
+
+    ImGui::Separator();
+    DrawViewport(window, app, scrub);
+    ImGui::End();
+
+    DrawInspectorPane(app, inspectorOpen, scrub);
+
+    window.endFrame();
+  }
+
+  // Clean up the scrub texture if it was created.
+  if (scrub.scrubTextureId != 0) {
+    glDeleteTextures(1, &scrub.scrubTextureId);
+  }
+  return 0;
+}

--- a/donner/editor/sandbox/BUILD.bazel
+++ b/donner/editor/sandbox/BUILD.bazel
@@ -1,0 +1,203 @@
+"""Donner Editor sandbox: isolated parser/renderer child process.
+
+Milestone S1 of the editor sandbox design (docs/design_docs/editor_sandbox.md):
+a byte-in, PNG-out child process that parses untrusted SVG in isolation, plus a
+`SandboxHost` host-side driver that spawns the child and classifies its exit.
+
+These targets are gated on the tiny_skia renderer backend — the child
+deliberately links only the lightweight backend, since pulling Skia into a
+throwaway parser child would bloat every render by tens of megabytes.
+"""
+
+load("//build_defs:rules.bzl", "donner_cc_binary", "donner_cc_library", "renderer_backend_compatible_with")
+
+package(default_visibility = ["//donner/editor:__subpackages__"])
+
+donner_cc_library(
+    name = "sandbox_protocol",
+    hdrs = ["SandboxProtocol.h"],
+    visibility = ["//donner/editor:__subpackages__"],
+)
+
+donner_cc_library(
+    name = "sandbox_hardening",
+    srcs = ["SandboxHardening.cc"],
+    hdrs = ["SandboxHardening.h"],
+    visibility = ["//donner/editor:__subpackages__"],
+)
+
+donner_cc_library(
+    name = "svg_source",
+    srcs = ["SvgSource.cc"],
+    hdrs = ["SvgSource.h"],
+    visibility = ["//donner/editor:__subpackages__"],
+)
+
+donner_cc_library(
+    name = "rnr_file",
+    srcs = ["RnrFile.cc"],
+    hdrs = ["RnrFile.h"],
+    visibility = ["//donner/editor:__subpackages__"],
+)
+
+donner_cc_library(
+    name = "frame_inspector",
+    srcs = ["FrameInspector.cc"],
+    hdrs = ["FrameInspector.h"],
+    target_compatible_with = renderer_backend_compatible_with(["tiny_skia"]),
+    visibility = ["//donner/editor:__subpackages__"],
+    deps = [
+        ":replaying_renderer",
+        ":sandbox_codecs",
+        ":wire",
+        "//donner/base",
+        "//donner/svg",
+        "//donner/svg/renderer:renderer_interface",
+    ],
+)
+
+donner_cc_library(
+    name = "wire",
+    hdrs = ["Wire.h"],
+    visibility = ["//donner/editor:__subpackages__"],
+)
+
+donner_cc_library(
+    name = "sandbox_codecs",
+    srcs = ["SandboxCodecs.cc"],
+    hdrs = ["SandboxCodecs.h"],
+    target_compatible_with = renderer_backend_compatible_with(["tiny_skia"]),
+    visibility = ["//donner/editor:__subpackages__"],
+    deps = [
+        ":wire",
+        "//donner/base",
+        "//donner/svg",
+        "//donner/svg/renderer:renderer_interface",
+        "//donner/svg/resources:image_resource",
+    ],
+)
+
+donner_cc_library(
+    name = "serializing_renderer",
+    srcs = ["SerializingRenderer.cc"],
+    hdrs = ["SerializingRenderer.h"],
+    target_compatible_with = renderer_backend_compatible_with(["tiny_skia"]),
+    visibility = ["//donner/editor:__subpackages__"],
+    deps = [
+        ":sandbox_codecs",
+        ":wire",
+        "//donner/base",
+        "//donner/svg",
+        "//donner/svg/renderer:renderer_driver",
+        "//donner/svg/renderer:renderer_interface",
+    ],
+)
+
+donner_cc_library(
+    name = "replaying_renderer",
+    srcs = ["ReplayingRenderer.cc"],
+    hdrs = ["ReplayingRenderer.h"],
+    defines = select({
+        "//donner/svg/renderer:text_enabled": ["DONNER_TEXT_ENABLED"],
+        "//conditions:default": [],
+    }),
+    target_compatible_with = renderer_backend_compatible_with(["tiny_skia"]),
+    visibility = ["//donner/editor:__subpackages__"],
+    deps = [
+        ":sandbox_codecs",
+        ":wire",
+        "//donner/base",
+        "//donner/svg/renderer:renderer_interface",
+    ] + select({
+        "//donner/svg/renderer:text_enabled": [
+            "//donner/svg/resources:font_manager",
+            "//donner/svg/text:text_engine",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+donner_cc_library(
+    name = "pipelined_renderer",
+    srcs = ["PipelinedRenderer.cc"],
+    hdrs = ["PipelinedRenderer.h"],
+    target_compatible_with = renderer_backend_compatible_with(["tiny_skia"]),
+    visibility = ["//donner/editor:__subpackages__"],
+    deps = [
+        ":replaying_renderer",
+        ":serializing_renderer",
+        "//donner/svg",
+        "//donner/svg/renderer:renderer_interface",
+        "//donner/svg/renderer:renderer_tiny_skia",
+    ],
+)
+
+donner_cc_library(
+    name = "sandbox_host",
+    srcs = ["SandboxHost.cc"],
+    hdrs = ["SandboxHost.h"],
+    target_compatible_with = renderer_backend_compatible_with(["tiny_skia"]),
+    visibility = ["//donner/editor:__subpackages__"],
+    deps = [
+        ":replaying_renderer",
+        ":sandbox_protocol",
+        "//donner/svg/renderer:renderer_image_io",
+        "//donner/svg/renderer:renderer_interface",
+        "//donner/svg/renderer:renderer_tiny_skia",
+    ],
+)
+
+donner_cc_binary(
+    name = "donner_parser_child",
+    srcs = ["parser_child_main.cc"],
+    target_compatible_with = renderer_backend_compatible_with(["tiny_skia"]),
+    visibility = ["//donner/editor:__subpackages__"],
+    deps = [
+        ":sandbox_hardening",
+        ":sandbox_protocol",
+        ":serializing_renderer",
+        "//donner/base",
+        "//donner/svg",
+        "//donner/svg/parser",
+        "//donner/svg/renderer:renderer_interface",
+    ],
+)
+
+donner_cc_binary(
+    name = "sandbox_render",
+    srcs = ["sandbox_render_main.cc"],
+    data = [":donner_parser_child"],
+    target_compatible_with = renderer_backend_compatible_with(["tiny_skia"]),
+    visibility = ["//donner/editor:__subpackages__"],
+    deps = [
+        ":sandbox_host",
+        ":svg_source",
+        "//donner/svg/renderer:renderer_image_io",
+        "//donner/svg/renderer:renderer_tiny_skia",
+    ],
+)
+
+donner_cc_binary(
+    name = "sandbox_replay",
+    srcs = ["sandbox_replay_main.cc"],
+    target_compatible_with = renderer_backend_compatible_with(["tiny_skia"]),
+    visibility = ["//donner/editor:__subpackages__"],
+    deps = [
+        ":frame_inspector",
+        ":replaying_renderer",
+        ":rnr_file",
+        "//donner/svg/renderer:renderer_image_io",
+        "//donner/svg/renderer:renderer_tiny_skia",
+    ],
+)
+
+donner_cc_binary(
+    name = "sandbox_inspect",
+    srcs = ["sandbox_inspect_main.cc"],
+    target_compatible_with = renderer_backend_compatible_with(["tiny_skia"]),
+    visibility = ["//donner/editor:__subpackages__"],
+    deps = [
+        ":frame_inspector",
+        ":rnr_file",
+    ],
+)

--- a/donner/editor/sandbox/FrameInspector.cc
+++ b/donner/editor/sandbox/FrameInspector.cc
@@ -1,0 +1,416 @@
+#include "donner/editor/sandbox/FrameInspector.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdio>
+#include <cstring>
+#include <sstream>
+#include <string_view>
+
+#include "donner/editor/sandbox/SandboxCodecs.h"
+
+namespace donner::editor::sandbox {
+
+namespace {
+
+/// True if `op` opens a LIFO scope (push*, begin*).
+bool IsPush(Opcode op) {
+  switch (op) {
+    case Opcode::kPushTransform:
+    case Opcode::kPushClip:
+    case Opcode::kPushIsolatedLayer:
+      return true;
+    default:
+      return false;
+  }
+}
+
+/// True if `op` closes a LIFO scope (pop*, end*).
+bool IsPop(Opcode op) {
+  switch (op) {
+    case Opcode::kPopTransform:
+    case Opcode::kPopClip:
+    case Opcode::kPopIsolatedLayer:
+      return true;
+    default:
+      return false;
+  }
+}
+
+/// Peeks at the u32 opcode + u32 payload_length at the current cursor
+/// without advancing it. Used by the decode pass, which needs to record
+/// the absolute byte offset *before* reading the header.
+bool PeekMessageHeader(std::span<const uint8_t> bytes, std::size_t pos,
+                       Opcode& outOp, uint32_t& outLen) {
+  if (pos + 8 > bytes.size()) return false;
+  uint32_t op = 0;
+  uint32_t len = 0;
+  std::memcpy(&op, bytes.data() + pos, sizeof(uint32_t));
+  std::memcpy(&len, bytes.data() + pos + sizeof(uint32_t), sizeof(uint32_t));
+  outOp = static_cast<Opcode>(op);
+  outLen = len;
+  return true;
+}
+
+/// Builds a terse summary for the supported opcodes. Unknown or complex
+/// payloads return the plain opcode name.
+std::string SummarizeCommand(Opcode op, std::span<const uint8_t> payload) {
+  WireReader r(payload);
+
+  auto formatDouble = [](double v) {
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "%g", v);
+    return std::string(buf);
+  };
+
+  auto formatBox = [&](const Box2d& b) {
+    std::ostringstream os;
+    os << "(" << formatDouble(b.topLeft.x) << "," << formatDouble(b.topLeft.y) << ","
+       << formatDouble(b.bottomRight.x) << "," << formatDouble(b.bottomRight.y) << ")";
+    return os.str();
+  };
+
+  switch (op) {
+    case Opcode::kStreamHeader: {
+      uint32_t magic = 0;
+      uint32_t version = 0;
+      if (r.readU32(magic) && r.readU32(version)) {
+        std::ostringstream os;
+        os << "streamHeader magic=0x" << std::hex << magic << std::dec
+           << " version=" << version;
+        return os.str();
+      }
+      return "streamHeader";
+    }
+
+    case Opcode::kBeginFrame: {
+      svg::RenderViewport vp;
+      if (DecodeRenderViewport(r, vp)) {
+        std::ostringstream os;
+        os << "beginFrame viewport=" << formatDouble(vp.size.x) << "x"
+           << formatDouble(vp.size.y) << " dpr=" << formatDouble(vp.devicePixelRatio);
+        return os.str();
+      }
+      return "beginFrame";
+    }
+
+    case Opcode::kEndFrame:
+      return "endFrame";
+
+    case Opcode::kSetTransform: {
+      Transform2d t;
+      if (DecodeTransform2d(r, t)) {
+        std::ostringstream os;
+        os << "setTransform tx=" << formatDouble(t.data[4])
+           << " ty=" << formatDouble(t.data[5]);
+        return os.str();
+      }
+      return "setTransform";
+    }
+
+    case Opcode::kPushTransform: {
+      Transform2d t;
+      if (DecodeTransform2d(r, t)) {
+        std::ostringstream os;
+        os << "pushTransform tx=" << formatDouble(t.data[4])
+           << " ty=" << formatDouble(t.data[5]);
+        return os.str();
+      }
+      return "pushTransform";
+    }
+    case Opcode::kPopTransform:
+      return "popTransform";
+
+    case Opcode::kPushClip: {
+      svg::ResolvedClip clip;
+      if (DecodeResolvedClip(r, clip)) {
+        std::ostringstream os;
+        os << "pushClip";
+        if (clip.clipRect) os << " rect=" << formatBox(*clip.clipRect);
+        if (!clip.clipPaths.empty()) os << " paths=" << clip.clipPaths.size();
+        return os.str();
+      }
+      return "pushClip";
+    }
+    case Opcode::kPopClip:
+      return "popClip";
+
+    case Opcode::kPushIsolatedLayer: {
+      double opacity = 0;
+      svg::MixBlendMode mode = svg::MixBlendMode::Normal;
+      if (r.readF64(opacity) && DecodeMixBlendMode(r, mode)) {
+        std::ostringstream os;
+        os << "pushIsolatedLayer opacity=" << formatDouble(opacity)
+           << " mode=" << static_cast<int>(mode);
+        return os.str();
+      }
+      return "pushIsolatedLayer";
+    }
+    case Opcode::kPopIsolatedLayer:
+      return "popIsolatedLayer";
+
+    case Opcode::kSetPaint: {
+      svg::PaintParams paint;
+      std::optional<WireGradient> fillGradient;
+      std::optional<WireGradient> strokeGradient;
+      if (DecodePaintParams(r, paint, &fillGradient, &strokeGradient)) {
+        std::ostringstream os;
+        os << "setPaint opacity=" << formatDouble(paint.opacity);
+        // Fill summary — recognize solid + gradient variants.
+        if (fillGradient) {
+          os << " fill="
+             << (fillGradient->kind == WireGradient::Kind::kLinear
+                     ? "linearGradient"
+                     : "radialGradient")
+             << "(" << fillGradient->stops.size() << " stops)";
+        } else if (std::holds_alternative<svg::PaintServer::Solid>(paint.fill)) {
+          const auto& solid = std::get<svg::PaintServer::Solid>(paint.fill);
+          if (std::holds_alternative<css::RGBA>(solid.color.value)) {
+            const auto c = std::get<css::RGBA>(solid.color.value);
+            char hex[16];
+            std::snprintf(hex, sizeof(hex), " fill=#%02X%02X%02X", c.r, c.g, c.b);
+            os << hex;
+          }
+        } else {
+          os << " fill=none";
+        }
+        return os.str();
+      }
+      return "setPaint";
+    }
+
+    case Opcode::kDrawPath: {
+      svg::PathShape shape;
+      if (DecodePathShape(r, shape)) {
+        std::ostringstream os;
+        os << "drawPath verbs=" << shape.path.commands().size();
+        return os.str();
+      }
+      return "drawPath";
+    }
+
+    case Opcode::kDrawRect: {
+      Box2d rect;
+      if (DecodeBox2d(r, rect)) {
+        return "drawRect " + formatBox(rect);
+      }
+      return "drawRect";
+    }
+
+    case Opcode::kDrawEllipse: {
+      Box2d bounds;
+      if (DecodeBox2d(r, bounds)) {
+        return "drawEllipse " + formatBox(bounds);
+      }
+      return "drawEllipse";
+    }
+
+    case Opcode::kPushMask:               return "pushMask";
+    case Opcode::kTransitionMaskToContent: return "transitionMaskToContent";
+    case Opcode::kPopMask:                return "popMask";
+    case Opcode::kBeginPatternTile:       return "beginPatternTile";
+    case Opcode::kEndPatternTile:         return "endPatternTile";
+    case Opcode::kPushFilterLayer:        return "pushFilterLayer";
+    case Opcode::kPopFilterLayer:         return "popFilterLayer";
+    case Opcode::kDrawImage:              return "drawImage";
+
+    case Opcode::kUnsupported: {
+      uint32_t kindRaw = 0;
+      if (r.readU32(kindRaw)) {
+        std::ostringstream os;
+        os << "unsupported ("
+           << FrameInspector::UnsupportedKindName(static_cast<UnsupportedKind>(kindRaw))
+           << ")";
+        return os.str();
+      }
+      return "unsupported";
+    }
+
+    case Opcode::kInvalid:
+      return "<invalid>";
+  }
+  return std::string(FrameInspector::OpcodeName(op));
+}
+
+}  // namespace
+
+std::string_view FrameInspector::OpcodeName(Opcode op) {
+  switch (op) {
+    case Opcode::kInvalid:                return "invalid";
+    case Opcode::kStreamHeader:           return "streamHeader";
+    case Opcode::kBeginFrame:             return "beginFrame";
+    case Opcode::kEndFrame:               return "endFrame";
+    case Opcode::kSetTransform:           return "setTransform";
+    case Opcode::kPushTransform:          return "pushTransform";
+    case Opcode::kPopTransform:           return "popTransform";
+    case Opcode::kPushClip:               return "pushClip";
+    case Opcode::kPopClip:                return "popClip";
+    case Opcode::kPushIsolatedLayer:      return "pushIsolatedLayer";
+    case Opcode::kPopIsolatedLayer:       return "popIsolatedLayer";
+    case Opcode::kPushMask:               return "pushMask";
+    case Opcode::kTransitionMaskToContent: return "transitionMaskToContent";
+    case Opcode::kPopMask:                return "popMask";
+    case Opcode::kBeginPatternTile:       return "beginPatternTile";
+    case Opcode::kEndPatternTile:         return "endPatternTile";
+    case Opcode::kSetPaint:               return "setPaint";
+    case Opcode::kDrawPath:               return "drawPath";
+    case Opcode::kDrawRect:               return "drawRect";
+    case Opcode::kDrawEllipse:            return "drawEllipse";
+    case Opcode::kDrawImage:              return "drawImage";
+    case Opcode::kUnsupported:            return "unsupported";
+  }
+  return "unknown";
+}
+
+std::string_view FrameInspector::UnsupportedKindName(UnsupportedKind kind) {
+  switch (kind) {
+    case UnsupportedKind::kPushFilterLayer:            return "pushFilterLayer";
+    case UnsupportedKind::kPopFilterLayer:             return "popFilterLayer";
+    case UnsupportedKind::kPushMask:                   return "pushMask";
+    case UnsupportedKind::kTransitionMaskToContent:    return "transitionMaskToContent";
+    case UnsupportedKind::kPopMask:                    return "popMask";
+    case UnsupportedKind::kBeginPatternTile:           return "beginPatternTile";
+    case UnsupportedKind::kEndPatternTile:             return "endPatternTile";
+    case UnsupportedKind::kDrawImage:                  return "drawImage";
+    case UnsupportedKind::kDrawText:                   return "drawText";
+    case UnsupportedKind::kPaintServerGradient:        return "paintServerGradient";
+    case UnsupportedKind::kPaintServerPattern:         return "paintServerPattern";
+    case UnsupportedKind::kPaintServerResolvedReference:
+      return "paintServerResolvedReference";
+    case UnsupportedKind::kClipMaskChain:              return "clipMaskChain";
+    case UnsupportedKind::kColorNonRgba:               return "colorNonRgba";
+  }
+  return "unknownUnsupportedKind";
+}
+
+InspectionResult FrameInspector::Decode(std::span<const uint8_t> wire) {
+  InspectionResult out;
+  std::size_t pos = 0;
+  uint32_t index = 0;
+  int32_t depth = 0;
+
+  while (pos < wire.size()) {
+    Opcode op = Opcode::kInvalid;
+    uint32_t payloadLen = 0;
+    if (!PeekMessageHeader(wire, pos, op, payloadLen)) {
+      out.error = "truncated message header at offset " + std::to_string(pos);
+      out.finalDepth = depth;
+      return out;
+    }
+    if (payloadLen > kMaxPayloadBytes || pos + 8 + payloadLen > wire.size()) {
+      out.error = "payload length " + std::to_string(payloadLen) +
+                  " overruns buffer at offset " + std::to_string(pos);
+      out.finalDepth = depth;
+      return out;
+    }
+
+    DecodedCommand cmd;
+    cmd.index = index++;
+    cmd.opcode = op;
+    cmd.depth = std::max<int32_t>(0, depth);
+    cmd.byteOffset = pos;
+    cmd.byteLength = 8 + payloadLen;
+
+    const auto payload = wire.subspan(pos + 8, payloadLen);
+    cmd.summary = SummarizeCommand(op, payload);
+    out.commands.push_back(std::move(cmd));
+
+    // Depth tracking happens *after* recording the row so the push/pop
+    // commands themselves appear at the parent's depth — matching how most
+    // tree UIs render the handles for an expandable node.
+    if (IsPush(op)) ++depth;
+    if (IsPop(op)) --depth;
+
+    pos += 8 + payloadLen;
+  }
+
+  out.streamValid = true;
+  out.finalDepth = depth;
+  return out;
+}
+
+ReplayStatus FrameInspector::ReplayPrefix(std::span<const uint8_t> wire,
+                                          std::size_t commandCount,
+                                          svg::RendererInterface& target) {
+  // Full-replay fast path: the caller asked for everything. Just forward.
+  if (commandCount == std::numeric_limits<std::size_t>::max()) {
+    ReplayingRenderer replay(target);
+    ReplayReport report;
+    return replay.pumpFrame(wire, report);
+  }
+
+  // Walk the stream looking for the byte offset just past the Nth command
+  // (where command 0 is `kBeginFrame` — the stream header is always
+  // consumed but not counted, matching the `Decode()` convention minus the
+  // header row).
+  std::size_t pos = 0;
+  std::size_t cmdsSeen = 0;
+  bool sawHeader = false;
+  bool sawEndFrame = false;
+
+  while (pos < wire.size()) {
+    Opcode op = Opcode::kInvalid;
+    uint32_t payloadLen = 0;
+    if (!PeekMessageHeader(wire, pos, op, payloadLen)) break;
+    if (pos + 8 + payloadLen > wire.size()) break;
+
+    const std::size_t nextPos = pos + 8 + payloadLen;
+
+    if (!sawHeader) {
+      if (op != Opcode::kStreamHeader) return ReplayStatus::kHeaderMismatch;
+      sawHeader = true;
+      pos = nextPos;
+      continue;
+    }
+
+    if (cmdsSeen >= commandCount) break;
+    ++cmdsSeen;
+    pos = nextPos;
+    if (op == Opcode::kEndFrame) {
+      sawEndFrame = true;
+      break;
+    }
+  }
+
+  if (!sawHeader) return ReplayStatus::kHeaderMismatch;
+
+  // Replay the prefix we just located. ReplayingRenderer re-validates the
+  // header and payload cross-checks on its own, so this is the only place
+  // that needs to know about prefix boundaries.
+  const auto prefix = wire.subspan(0, pos);
+  ReplayingRenderer replay(target);
+  ReplayReport report;
+  const ReplayStatus status = replay.pumpFrame(prefix, report);
+
+  if (sawEndFrame) {
+    // Whole (possibly lossy) frame — passthrough.
+    return status;
+  }
+
+  // We cut the stream short. `kEndOfStream` is expected here; synthesize
+  // the missing endFrame so the target has a valid frame to snapshot.
+  if (status == ReplayStatus::kEndOfStream || status == ReplayStatus::kOk ||
+      status == ReplayStatus::kEncounteredUnsupported) {
+    target.endFrame();
+    return ReplayStatus::kOk;
+  }
+  return status;
+}
+
+std::string FrameInspector::Dump(std::span<const uint8_t> wire) {
+  const auto result = Decode(wire);
+  std::ostringstream os;
+  os << "# " << result.commands.size() << " command(s), finalDepth="
+     << result.finalDepth << "\n";
+  for (const auto& cmd : result.commands) {
+    os << "[" << cmd.index << "] ";
+    for (int i = 0; i < cmd.depth; ++i) os << "  ";
+    os << cmd.summary << "\n";
+  }
+  if (!result.streamValid) {
+    os << "! decode stopped: " << result.error << "\n";
+  }
+  return os.str();
+}
+
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/FrameInspector.h
+++ b/donner/editor/sandbox/FrameInspector.h
@@ -1,0 +1,105 @@
+#pragma once
+/// @file
+///
+/// Headless frame inspection: decode a sandbox wire stream into an indexed
+/// list of commands with human-readable summaries, and replay any prefix of
+/// those commands into a real backend. This is the **engine** that S4's
+/// eventual ImGui frame inspector panel will sit on top of; keeping it
+/// UI-free means we can test it now and reuse it from non-editor contexts
+/// (bug reports, `.rnr` replay CLIs, structural diffs).
+///
+/// The inspector never rasterizes on its own — rasterization is always
+/// delegated to a caller-provided `RendererInterface`. Decoding, on the
+/// other hand, is fully self-contained and deterministic.
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "donner/editor/sandbox/ReplayingRenderer.h"
+#include "donner/editor/sandbox/Wire.h"
+#include "donner/svg/renderer/RendererInterface.h"
+
+namespace donner::editor::sandbox {
+
+/// One message in the decoded stream. The summary is meant for UI display
+/// (ImGui command-list rows, text dumps, structural diffs) — it is
+/// intentionally terse and not round-trippable.
+struct DecodedCommand {
+  /// Zero-based message index inside the wire stream. Index 0 is always
+  /// the `kStreamHeader` message.
+  uint32_t index = 0;
+  /// Opcode raw value. Use `Opcode` cast for type-safe comparisons.
+  Opcode opcode = Opcode::kInvalid;
+  /// LIFO nesting depth at the point this command was emitted. Incremented
+  /// by every `push*` and decremented by every `pop*`. Unbalanced streams
+  /// can go negative briefly; the inspector clamps at zero for display.
+  int32_t depth = 0;
+  /// Byte offset of this message's header inside the wire buffer.
+  std::size_t byteOffset = 0;
+  /// Total bytes this message occupies (8-byte header + payload).
+  std::size_t byteLength = 0;
+  /// Human-readable one-liner (e.g. `drawRect (10,10,30,30)`,
+  /// `setPaint fill=#FF0000 stroke=none`). May be empty for opcodes the
+  /// summarizer doesn't understand yet.
+  std::string summary;
+};
+
+/// Outcome of `FrameInspector::Decode`. `streamValid` is true iff the entire
+/// wire stream parsed without error — a false value means `commands`
+/// contains whatever the inspector was able to decode before the first
+/// failure, and `error` describes why it stopped.
+struct InspectionResult {
+  std::vector<DecodedCommand> commands;
+  bool streamValid = false;
+  std::string error;
+  /// Final nesting depth after the last successfully decoded command.
+  /// Should be 0 for a well-formed frame; any non-zero value means the
+  /// push/pop pairs are unbalanced.
+  int32_t finalDepth = 0;
+};
+
+/// All static helpers — inspector instances are stateless beyond the
+/// inputs each call is given.
+class FrameInspector {
+public:
+  /// Parses `wire` into a command list without invoking any renderer.
+  /// Always produces a result (even on partial parses); callers inspect
+  /// `InspectionResult::streamValid` to distinguish "fully decoded" from
+  /// "stopped at an error".
+  static InspectionResult Decode(std::span<const uint8_t> wire);
+
+  /// Replays exactly the first `commandCount` commands into `target`. The
+  /// counting starts at the `kBeginFrame` message — the `kStreamHeader`
+  /// is always consumed but not counted as a "command". After the prefix
+  /// is dispatched, `target.endFrame()` is synthesized if the prefix
+  /// didn't already include a real `kEndFrame`, so the target has a valid
+  /// frame to snapshot.
+  ///
+  /// Passing `commandCount = SIZE_MAX` replays the entire stream verbatim.
+  /// `commandCount = 0` begins a frame and immediately ends it — useful as
+  /// a "clear to the start of the frame" baseline in the UI.
+  ///
+  /// @returns `ReplayStatus::kOk` on success, `kMalformed` if the stream
+  ///   is corrupt, `kHeaderMismatch` on a missing/wrong header.
+  static ReplayStatus ReplayPrefix(std::span<const uint8_t> wire,
+                                   std::size_t commandCount,
+                                   svg::RendererInterface& target);
+
+  /// Builds a single-line textual summary of the wire stream: one row per
+  /// command, with indentation tracking nesting depth. Intended for
+  /// `sandbox_inspect` output and crash-report attachments.
+  static std::string Dump(std::span<const uint8_t> wire);
+
+  /// Returns a short, human-readable name for an opcode (e.g. "drawRect",
+  /// "pushTransform"). Stable — safe to embed in logs and bug reports.
+  static std::string_view OpcodeName(Opcode op);
+
+  /// Returns a short, human-readable name for an unsupported-kind tag.
+  static std::string_view UnsupportedKindName(UnsupportedKind kind);
+};
+
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/PipelinedRenderer.cc
+++ b/donner/editor/sandbox/PipelinedRenderer.cc
@@ -1,0 +1,138 @@
+#include "donner/editor/sandbox/PipelinedRenderer.h"
+
+#include <chrono>
+#include <utility>
+
+#include "donner/editor/sandbox/ReplayingRenderer.h"
+#include "donner/editor/sandbox/SerializingRenderer.h"
+#include "donner/svg/SVGDocument.h"
+#include "donner/svg/renderer/RendererTinySkia.h"
+
+namespace donner::editor::sandbox {
+
+std::unique_ptr<svg::RendererInterface> MakeDefaultRendererTinySkia() {
+  return std::make_unique<svg::RendererTinySkia>();
+}
+
+PipelinedRenderer::PipelinedRenderer(RendererFactory factory) : factory_(factory) {
+  worker_ = std::thread([this] { workerMain(); });
+}
+
+PipelinedRenderer::~PipelinedRenderer() {
+  {
+    std::lock_guard<std::mutex> lock(inboxMutex_);
+    shutdown_.store(true, std::memory_order_release);
+  }
+  inboxCv_.notify_all();
+  outboxCv_.notify_all();
+  if (worker_.joinable()) {
+    worker_.join();
+  }
+}
+
+uint64_t PipelinedRenderer::submit(svg::SVGDocument& document, int width, int height) {
+  const uint64_t frameId = nextFrameId_.fetch_add(1, std::memory_order_relaxed);
+
+  // Serialize on the calling thread. This is intentional: the document is
+  // thread-owned and the driver mutates its caches during traversal, so the
+  // safest place to encode is exactly where the document lives.
+  document.setCanvasSize(width, height);
+  SerializingRenderer serializer;
+  serializer.draw(document);
+
+  PendingFrame frame;
+  frame.frameId = frameId;
+  frame.wire = std::move(serializer).takeBuffer();
+  frame.width = width;
+  frame.height = height;
+
+  {
+    std::lock_guard<std::mutex> lock(inboxMutex_);
+    // Newest wins: overwrite any previously-queued frame that the worker
+    // hasn't picked up yet.
+    pending_ = std::move(frame);
+  }
+  inboxCv_.notify_one();
+  return frameId;
+}
+
+std::optional<PipelinedFrame> PipelinedRenderer::acquireLatestFrame() {
+  std::lock_guard<std::mutex> lock(outboxMutex_);
+  if (!latest_.has_value()) {
+    return std::nullopt;
+  }
+  std::optional<PipelinedFrame> out = std::move(latest_);
+  latest_.reset();
+  return out;
+}
+
+std::optional<PipelinedFrame> PipelinedRenderer::waitForFrame(uint64_t target) {
+  std::unique_lock<std::mutex> lock(outboxMutex_);
+  outboxCv_.wait(lock, [&] {
+    if (shutdown_.load(std::memory_order_acquire)) return true;
+    return latest_.has_value() && latest_->frameId >= target;
+  });
+  if (!latest_.has_value() || latest_->frameId < target) {
+    return std::nullopt;
+  }
+  std::optional<PipelinedFrame> out = std::move(latest_);
+  latest_.reset();
+  return out;
+}
+
+void PipelinedRenderer::workerMain() {
+  std::unique_ptr<svg::RendererInterface> backend;
+
+  while (true) {
+    PendingFrame pending;
+    {
+      std::unique_lock<std::mutex> lock(inboxMutex_);
+      inboxCv_.wait(lock, [&] {
+        return pending_.has_value() || shutdown_.load(std::memory_order_acquire);
+      });
+      if (shutdown_.load(std::memory_order_acquire) && !pending_.has_value()) {
+        return;
+      }
+      pending = std::move(*pending_);
+      pending_.reset();
+    }
+
+    if (!backend) {
+      backend = factory_();
+    }
+    if (!backend) {
+      // Factory returned nullptr — publish a failed frame and keep running
+      // so the caller can observe the failure deterministically.
+      PipelinedFrame failed;
+      failed.frameId = pending.frameId;
+      failed.ok = false;
+      {
+        std::lock_guard<std::mutex> lock(outboxMutex_);
+        latest_ = std::move(failed);
+      }
+      outboxCv_.notify_all();
+      continue;
+    }
+
+    ReplayingRenderer replay(*backend);
+    ReplayReport report;
+    const ReplayStatus status = replay.pumpFrame(pending.wire, report);
+
+    PipelinedFrame out;
+    out.frameId = pending.frameId;
+    out.unsupportedCount = report.unsupportedCount;
+    out.ok = (status == ReplayStatus::kOk) ||
+             (status == ReplayStatus::kEncounteredUnsupported);
+    if (out.ok) {
+      out.bitmap = backend->takeSnapshot();
+    }
+
+    {
+      std::lock_guard<std::mutex> lock(outboxMutex_);
+      latest_ = std::move(out);
+    }
+    outboxCv_.notify_all();
+  }
+}
+
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/PipelinedRenderer.h
+++ b/donner/editor/sandbox/PipelinedRenderer.h
@@ -1,0 +1,162 @@
+#pragma once
+/// @file
+///
+/// **PipelinedRenderer** — a multi-threaded, in-process renderer that reuses
+/// the sandbox wire format as a producer/consumer boundary between the main
+/// thread (parser + driver + serializer) and a worker thread (deserializer +
+/// real backend).
+///
+/// Motivation: the same observation that drives the sandbox design —
+/// `RendererInterface` is a self-contained command stream — means the same
+/// serialize/replay pipeline works across any boundary:
+///
+/// | Boundary           | Producer → Consumer         | Transport         |
+/// |--------------------|----------------------------|-------------------|
+/// | Process (sandbox)  | child → host               | pipe              |
+/// | Thread (this file) | main → render worker       | `std::vector` buf |
+/// | Time (frame inspect)| last frame → inspector pane| in-memory replay  |
+/// | File (record/replay)| now → later                 | `.rnr` file       |
+///
+/// `PipelinedRenderer` targets the threading case. The main thread calls
+/// `submit(document)`, which runs the parser/driver inline (fast, mostly
+/// cache-local) and serializes the `RendererInterface` calls into a byte
+/// buffer. The buffer is handed off to a worker thread that decodes it and
+/// invokes a real backend (`RendererTinySkia`, typically). The main thread
+/// returns as soon as serialization completes, freeing it to mutate the
+/// document for frame N+1 while frame N rasterizes in parallel.
+///
+/// This is "newest wins": if `submit()` is called while a previous frame is
+/// still rasterizing, the old frame is abandoned on the worker side. We're
+/// building an interactive editor — the user cares about the current frame,
+/// not the complete history.
+///
+/// **Why not just pass `SVGDocument` across threads?** Two reasons:
+/// 1. The ECS registry inside `SVGDocument` has mutable caches (layout,
+///    computed style) that the driver writes during traversal. Passing the
+///    same document to a worker while the main thread is mutating it races.
+///    Serializing freezes the snapshot.
+/// 2. The wire buffer is a natural sync point. Once `submit()` returns, the
+///    caller can mutate the document freely — the worker is operating on
+///    bytes, not references.
+
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <span>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "donner/svg/renderer/RendererInterface.h"
+
+namespace donner::svg {
+class SVGDocument;
+}  // namespace donner::svg
+
+namespace donner::editor::sandbox {
+
+/// One frame's worth of rendered pixels and metadata handed back to the main
+/// thread after `PipelinedRenderer` completes a submission.
+struct PipelinedFrame {
+  /// Monotonically increasing frame sequence number. Frame N == submission N.
+  uint64_t frameId = 0;
+  /// RGBA8 snapshot at viewport resolution. Empty on failure.
+  svg::RendererBitmap bitmap;
+  /// Number of `kUnsupported` messages the replayer saw on this frame.
+  uint32_t unsupportedCount = 0;
+  /// True iff the wire stream decoded and rasterized cleanly.
+  bool ok = false;
+};
+
+/// Factory for the real backend the worker thread should rasterize into.
+/// Called exactly once, on the worker thread, before the first replay. The
+/// worker owns the returned renderer for its whole lifetime.
+using RendererFactory = std::unique_ptr<svg::RendererInterface> (*)();
+
+/// Default factory that returns a `RendererTinySkia` — the one backend
+/// guaranteed to be available in every Donner build.
+std::unique_ptr<svg::RendererInterface> MakeDefaultRendererTinySkia();
+
+/// A pipelined renderer that moves rasterization off the caller's thread.
+///
+/// Thread-safety: `submit()` and `acquireLatestFrame()` are main-thread-only.
+/// The worker thread is internal and never exposed.
+class PipelinedRenderer {
+public:
+  /// Construct the renderer and spawn the worker thread.
+  ///
+  /// @param factory Called on the worker thread to build the real backend
+  ///   the first time a frame is rasterized. Defaults to
+  ///   `MakeDefaultRendererTinySkia`.
+  explicit PipelinedRenderer(RendererFactory factory = &MakeDefaultRendererTinySkia);
+
+  /// Stop the worker thread and tear down state. Blocks until the worker
+  /// observes the shutdown flag and exits.
+  ~PipelinedRenderer();
+
+  PipelinedRenderer(const PipelinedRenderer&) = delete;
+  PipelinedRenderer& operator=(const PipelinedRenderer&) = delete;
+
+  /// Serializes `document` on the calling thread and hands the resulting
+  /// byte stream to the worker. Returns as soon as serialization completes —
+  /// typically a handful of milliseconds.
+  ///
+  /// Overwrites any previously-queued frame that the worker hasn't started
+  /// yet. If the worker is already rasterizing, its in-flight frame
+  /// continues; the *next* frame it picks up is this one. This is the
+  /// "newest wins" policy — see the file comment for rationale.
+  ///
+  /// @param document The document to render. The caller may mutate or free
+  ///   it immediately after this call returns.
+  /// @param width Viewport width in CSS pixels.
+  /// @param height Viewport height in CSS pixels.
+  /// @returns Frame id assigned to this submission. Pair with the id on the
+  ///   returned `PipelinedFrame` to detect whether a call to
+  ///   `acquireLatestFrame()` has produced the frame you care about yet.
+  uint64_t submit(svg::SVGDocument& document, int width, int height);
+
+  /// Returns the most recently completed frame, if any. The frame is moved
+  /// out of the renderer; subsequent calls return `std::nullopt` until the
+  /// worker completes another frame.
+  [[nodiscard]] std::optional<PipelinedFrame> acquireLatestFrame();
+
+  /// Blocks until a frame with `frameId >= target` is available and
+  /// returns it. Intended for tests and synchronous callers that don't want
+  /// to spin. Returns `std::nullopt` on shutdown.
+  [[nodiscard]] std::optional<PipelinedFrame> waitForFrame(uint64_t target);
+
+private:
+  struct PendingFrame {
+    uint64_t frameId = 0;
+    std::vector<uint8_t> wire;
+    int width = 0;
+    int height = 0;
+  };
+
+  void workerMain();
+
+  RendererFactory factory_;
+  std::thread worker_;
+
+  // Signals the worker that a new frame is queued. Guards `pending_` and
+  // `shutdown_`.
+  mutable std::mutex inboxMutex_;
+  std::condition_variable inboxCv_;
+  std::optional<PendingFrame> pending_;
+  std::atomic<bool> shutdown_{false};
+
+  // Guards `latest_` and wakes `waitForFrame()` callers. Distinct mutex so
+  // the worker can publish a completed frame without blocking the main
+  // thread that may be concurrently submitting the next one.
+  mutable std::mutex outboxMutex_;
+  std::condition_variable outboxCv_;
+  std::optional<PipelinedFrame> latest_;
+
+  std::atomic<uint64_t> nextFrameId_{1};
+};
+
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/ReplayingRenderer.cc
+++ b/donner/editor/sandbox/ReplayingRenderer.cc
@@ -1,0 +1,377 @@
+#include "donner/editor/sandbox/ReplayingRenderer.h"
+
+#include <optional>
+#include <utility>
+
+#include "donner/base/EcsRegistry.h"
+#include "donner/css/FontFace.h"
+#include "donner/editor/sandbox/SandboxCodecs.h"
+#include "donner/svg/components/RenderingInstanceComponent.h"
+#include "donner/svg/components/paint/GradientComponent.h"
+#include "donner/svg/components/paint/LinearGradientComponent.h"
+#include "donner/svg/components/paint/RadialGradientComponent.h"
+#include "donner/svg/graph/Reference.h"
+#include "donner/svg/resources/ImageResource.h"
+
+#ifdef DONNER_TEXT_ENABLED
+#include "donner/svg/resources/FontManager.h"
+#include "donner/svg/text/TextEngine.h"
+#endif
+
+namespace donner::editor::sandbox {
+
+// Holds the replay-side ECS state needed to materialize gradient references
+// from wire messages. One instance per ReplayingRenderer; fresh entities are
+// created on demand inside `DecodePaintParams`, and the registry is cleared
+// between frames via `resetFrame()`.
+struct ReplayingRenderer::Impl {
+  Registry registry;
+
+  /// Backing storage for decoded font faces. Kept alive so that
+  /// `TextParams::fontFaces` (a span) remains valid through the
+  /// `drawText` call.
+  std::vector<css::FontFace> lastFontFaces;
+
+  void resetFrame() { registry.clear(); }
+
+  /// Converts a decoded `WireGradient` into a real `PaintResolvedReference`
+  /// suitable for handing to `RendererInterface::setPaint`. The returned
+  /// variant references a fresh entity in `registry` that carries exactly
+  /// the components `RendererTinySkia::makeFillPaint` / `makeStrokePaint`
+  /// look up during paint resolution.
+  svg::components::ResolvedPaintServer MaterializeGradient(const WireGradient& g) {
+    const Entity entity = registry.create();
+    auto& computed =
+        registry.emplace<svg::components::ComputedGradientComponent>(entity);
+    computed.initialized = true;
+    computed.gradientUnits = g.units;
+    computed.spreadMethod = g.spreadMethod;
+    computed.stops = g.stops;
+
+    if (g.kind == WireGradient::Kind::kLinear) {
+      auto& lin =
+          registry.emplace<svg::components::ComputedLinearGradientComponent>(entity);
+      lin.x1 = g.x1;
+      lin.y1 = g.y1;
+      lin.x2 = g.x2;
+      lin.y2 = g.y2;
+    } else {
+      auto& rad =
+          registry.emplace<svg::components::ComputedRadialGradientComponent>(entity);
+      rad.cx = g.cx;
+      rad.cy = g.cy;
+      rad.r = g.r;
+      rad.fx = g.fx;
+      rad.fy = g.fy;
+      rad.fr = g.fr;
+    }
+
+    svg::components::PaintResolvedReference out;
+    out.reference = svg::ResolvedReference{EntityHandle(registry, entity)};
+    out.fallback = g.fallback;
+    return out;
+  }
+};
+
+ReplayingRenderer::ReplayingRenderer(svg::RendererInterface& target)
+    : impl_(std::make_unique<Impl>()), target_(target) {}
+
+ReplayingRenderer::~ReplayingRenderer() = default;
+
+namespace {
+
+bool ReadHeader(WireReader& r) {
+  Opcode opcode = Opcode::kInvalid;
+  uint32_t payloadLength = 0;
+  if (!r.readMessageHeader(opcode, payloadLength)) return false;
+  if (opcode != Opcode::kStreamHeader || payloadLength != 8) return false;
+
+  uint32_t magic = 0;
+  uint32_t version = 0;
+  if (!r.readU32(magic) || !r.readU32(version)) return false;
+  if (magic != kWireMagic || version != kWireVersion) return false;
+  return true;
+}
+
+}  // namespace
+
+ReplayStatus ReplayingRenderer::pumpFrame(std::span<const uint8_t> wire,
+                                          ReplayReport& report) {
+  report = ReplayReport{};
+  WireReader r(wire);
+
+  if (!ReadHeader(r)) {
+    return ReplayStatus::kHeaderMismatch;
+  }
+
+  bool sawEndFrame = false;
+
+  while (r.remaining() > 0 && !sawEndFrame) {
+    Opcode opcode = Opcode::kInvalid;
+    uint32_t payloadLength = 0;
+    if (!r.readMessageHeader(opcode, payloadLength)) {
+      return ReplayStatus::kMalformed;
+    }
+
+    const std::size_t payloadStart = r.position();
+    if (payloadLength > r.remaining()) {
+      return ReplayStatus::kMalformed;
+    }
+
+    report.lastOpcode = opcode;
+    ++report.messagesProcessed;
+
+    const DispatchOutcome outcome = handleMessage(r, opcode);
+
+    switch (outcome) {
+      case DispatchOutcome::kHandled:
+        break;
+      case DispatchOutcome::kUnsupported:
+        ++report.unsupportedCount;
+        break;
+      case DispatchOutcome::kDecodeError:
+        return ReplayStatus::kMalformed;
+      case DispatchOutcome::kUnknownOpcode: {
+        // Skip the remaining payload and report the unknown opcode.
+        const std::size_t consumed = r.position() - payloadStart;
+        if (consumed > payloadLength) return ReplayStatus::kMalformed;
+        if (!r.skip(payloadLength - consumed)) return ReplayStatus::kMalformed;
+        return ReplayStatus::kUnknownOpcode;
+      }
+    }
+
+    // Verify the handler consumed exactly `payloadLength` bytes. A mismatch
+    // means encoder and decoder disagree on field layout — fail hard rather
+    // than silently render the wrong thing.
+    const std::size_t consumed = r.position() - payloadStart;
+    if (consumed != payloadLength) {
+      return ReplayStatus::kMalformed;
+    }
+
+    if (opcode == Opcode::kEndFrame) {
+      sawEndFrame = true;
+    }
+  }
+
+  if (!sawEndFrame) {
+    return ReplayStatus::kEndOfStream;
+  }
+  return report.unsupportedCount == 0 ? ReplayStatus::kOk
+                                       : ReplayStatus::kEncounteredUnsupported;
+}
+
+ReplayingRenderer::DispatchOutcome ReplayingRenderer::handleMessage(
+    WireReader& r, Opcode opcode) {
+  switch (opcode) {
+    case Opcode::kBeginFrame: {
+      svg::RenderViewport viewport;
+      if (!DecodeRenderViewport(r, viewport)) return DispatchOutcome::kDecodeError;
+      // Fresh registry per frame so gradient entities don't pile up over a
+      // long editor session. Materialization happens on each kSetPaint.
+      impl_->resetFrame();
+      target_.beginFrame(viewport);
+      return DispatchOutcome::kHandled;
+    }
+
+    case Opcode::kEndFrame:
+      target_.endFrame();
+      return DispatchOutcome::kHandled;
+
+    case Opcode::kSetTransform: {
+      Transform2d t;
+      if (!DecodeTransform2d(r, t)) return DispatchOutcome::kDecodeError;
+      target_.setTransform(t);
+      return DispatchOutcome::kHandled;
+    }
+
+    case Opcode::kPushTransform: {
+      Transform2d t;
+      if (!DecodeTransform2d(r, t)) return DispatchOutcome::kDecodeError;
+      target_.pushTransform(t);
+      return DispatchOutcome::kHandled;
+    }
+
+    case Opcode::kPopTransform:
+      target_.popTransform();
+      return DispatchOutcome::kHandled;
+
+    case Opcode::kPushClip: {
+      svg::ResolvedClip clip;
+      if (!DecodeResolvedClip(r, clip)) return DispatchOutcome::kDecodeError;
+      target_.pushClip(clip);
+      return DispatchOutcome::kHandled;
+    }
+
+    case Opcode::kPopClip:
+      target_.popClip();
+      return DispatchOutcome::kHandled;
+
+    case Opcode::kPushIsolatedLayer: {
+      double opacity = 0;
+      svg::MixBlendMode blendMode = svg::MixBlendMode::Normal;
+      if (!r.readF64(opacity)) return DispatchOutcome::kDecodeError;
+      if (!DecodeMixBlendMode(r, blendMode)) return DispatchOutcome::kDecodeError;
+      target_.pushIsolatedLayer(opacity, blendMode);
+      return DispatchOutcome::kHandled;
+    }
+
+    case Opcode::kPopIsolatedLayer:
+      target_.popIsolatedLayer();
+      return DispatchOutcome::kHandled;
+
+    case Opcode::kSetPaint: {
+      svg::PaintParams paint;
+      std::optional<WireGradient> fillGradient;
+      std::optional<WireGradient> strokeGradient;
+      if (!DecodePaintParams(r, paint, &fillGradient, &strokeGradient)) {
+        return DispatchOutcome::kDecodeError;
+      }
+      // Materialize any gradient paint servers into the replayer's private
+      // registry, then patch the PaintParams before forwarding. The backend
+      // sees a normal PaintResolvedReference — it doesn't know or care that
+      // the referenced entity only exists for the duration of this frame.
+      if (fillGradient) {
+        paint.fill = impl_->MaterializeGradient(*fillGradient);
+      }
+      if (strokeGradient) {
+        paint.stroke = impl_->MaterializeGradient(*strokeGradient);
+      }
+      target_.setPaint(paint);
+      return DispatchOutcome::kHandled;
+    }
+
+    case Opcode::kDrawPath: {
+      svg::PathShape shape;
+      svg::StrokeParams stroke;
+      if (!DecodePathShape(r, shape)) return DispatchOutcome::kDecodeError;
+      if (!DecodeStrokeParams(r, stroke)) return DispatchOutcome::kDecodeError;
+      target_.drawPath(shape, stroke);
+      return DispatchOutcome::kHandled;
+    }
+
+    case Opcode::kDrawRect: {
+      Box2d rect;
+      svg::StrokeParams stroke;
+      if (!DecodeBox2d(r, rect)) return DispatchOutcome::kDecodeError;
+      if (!DecodeStrokeParams(r, stroke)) return DispatchOutcome::kDecodeError;
+      target_.drawRect(rect, stroke);
+      return DispatchOutcome::kHandled;
+    }
+
+    case Opcode::kDrawEllipse: {
+      Box2d bounds;
+      svg::StrokeParams stroke;
+      if (!DecodeBox2d(r, bounds)) return DispatchOutcome::kDecodeError;
+      if (!DecodeStrokeParams(r, stroke)) return DispatchOutcome::kDecodeError;
+      target_.drawEllipse(bounds, stroke);
+      return DispatchOutcome::kHandled;
+    }
+
+    case Opcode::kPushMask: {
+      bool hasBounds = false;
+      if (!r.readBool(hasBounds)) return DispatchOutcome::kDecodeError;
+      std::optional<Box2d> bounds;
+      if (hasBounds) {
+        Box2d b;
+        if (!DecodeBox2d(r, b)) return DispatchOutcome::kDecodeError;
+        bounds = b;
+      }
+      target_.pushMask(bounds);
+      return DispatchOutcome::kHandled;
+    }
+
+    case Opcode::kTransitionMaskToContent:
+      target_.transitionMaskToContent();
+      return DispatchOutcome::kHandled;
+
+    case Opcode::kPopMask:
+      target_.popMask();
+      return DispatchOutcome::kHandled;
+
+    case Opcode::kBeginPatternTile: {
+      Box2d tileRect;
+      Transform2d targetFromPattern;
+      if (!DecodeBox2d(r, tileRect)) return DispatchOutcome::kDecodeError;
+      if (!DecodeTransform2d(r, targetFromPattern)) {
+        return DispatchOutcome::kDecodeError;
+      }
+      target_.beginPatternTile(tileRect, targetFromPattern);
+      return DispatchOutcome::kHandled;
+    }
+
+    case Opcode::kEndPatternTile: {
+      bool forStroke = false;
+      if (!r.readBool(forStroke)) return DispatchOutcome::kDecodeError;
+      target_.endPatternTile(forStroke);
+      return DispatchOutcome::kHandled;
+    }
+
+    case Opcode::kPushFilterLayer: {
+      svg::components::FilterGraph filterGraph;
+      if (!DecodeFilterGraph(r, filterGraph)) return DispatchOutcome::kDecodeError;
+      bool hasRegion = false;
+      std::optional<Box2d> filterRegion;
+      if (!r.readBool(hasRegion)) return DispatchOutcome::kDecodeError;
+      if (hasRegion) {
+        Box2d box;
+        if (!DecodeBox2d(r, box)) return DispatchOutcome::kDecodeError;
+        filterRegion = box;
+      }
+      target_.pushFilterLayer(filterGraph, filterRegion);
+      return DispatchOutcome::kHandled;
+    }
+
+    case Opcode::kPopFilterLayer:
+      target_.popFilterLayer();
+      return DispatchOutcome::kHandled;
+
+    case Opcode::kDrawImage: {
+      svg::ImageResource image;
+      svg::ImageParams params;
+      if (!DecodeImageResource(r, image)) return DispatchOutcome::kDecodeError;
+      if (!DecodeImageParams(r, params)) return DispatchOutcome::kDecodeError;
+      target_.drawImage(image, params);
+      return DispatchOutcome::kHandled;
+    }
+
+    case Opcode::kDrawText: {
+      svg::components::ComputedTextComponent textComp;
+      svg::TextParams params;
+      if (!DecodeComputedTextComponent(r, textComp)) return DispatchOutcome::kDecodeError;
+      if (!DecodeTextParams(r, params, &impl_->lastFontFaces))
+        return DispatchOutcome::kDecodeError;
+      // Point the span at stable storage that outlives the drawText call.
+      params.fontFaces = impl_->lastFontFaces;
+#ifdef DONNER_TEXT_ENABLED
+      // Lazily initialize FontManager + TextEngine on the replayer's private
+      // registry so the backend's drawText can resolve fonts and lay out
+      // glyphs. FontManager must be created first — TextEngine depends on it.
+      if (!impl_->registry.ctx().contains<svg::TextEngine>()) {
+        auto& fontManager =
+            impl_->registry.ctx().emplace<svg::FontManager>(impl_->registry);
+        impl_->registry.ctx().emplace<svg::TextEngine>(fontManager,
+                                                       impl_->registry);
+      }
+#endif
+      target_.drawText(impl_->registry, textComp, params);
+      return DispatchOutcome::kHandled;
+    }
+
+    case Opcode::kUnsupported: {
+      uint32_t kind = 0;
+      if (!r.readU32(kind)) return DispatchOutcome::kDecodeError;
+      (void)kind;  // Diagnostic only; replay silently skips the draw call.
+      return DispatchOutcome::kUnsupported;
+    }
+
+    case Opcode::kStreamHeader:
+      // A second header mid-stream is a protocol error.
+      return DispatchOutcome::kDecodeError;
+
+    case Opcode::kInvalid:
+    default:
+      return DispatchOutcome::kUnknownOpcode;
+  }
+}
+
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/ReplayingRenderer.h
+++ b/donner/editor/sandbox/ReplayingRenderer.h
@@ -1,0 +1,84 @@
+#pragma once
+/// @file
+///
+/// Decodes a `SerializingRenderer` wire stream and dispatches its messages
+/// onto a wrapped, real `RendererInterface`. The replay is host-side: the
+/// target can be `RendererTinySkia`, `RendererSkia`, `RendererGeode`, or a
+/// test mock.
+///
+/// `ReplayingRenderer::pumpFrame()` is the single entry point. It reads
+/// messages from the wire until it encounters `kEndFrame`, an unknown opcode,
+/// a malformed payload, or end-of-stream. It never crashes on adversarial
+/// input; every failure is reported via a `ReplayStatus` return code.
+
+#include <cstdint>
+#include <memory>
+#include <span>
+
+#include "donner/base/EcsRegistry.h"
+#include "donner/editor/sandbox/Wire.h"
+#include "donner/svg/renderer/RendererInterface.h"
+
+namespace donner::editor::sandbox {
+
+/// Outcome of replaying a single frame onto the wrapped backend.
+enum class ReplayStatus {
+  kOk,                ///< Frame ended cleanly with `kEndFrame`.
+  kEndOfStream,       ///< Reader ran out of bytes without seeing `kEndFrame`.
+  kMalformed,         ///< A payload failed to decode (length, tag, range).
+  kUnknownOpcode,     ///< Reader saw an opcode it doesn't know.
+  kHeaderMismatch,    ///< Magic or version mismatch on the stream header.
+  kEncounteredUnsupported,  ///< Replay succeeded but hit a `kUnsupported` message.
+};
+
+/// Statistics and diagnostic info from a replay. Always valid regardless of status.
+struct ReplayReport {
+  uint32_t messagesProcessed = 0;
+  uint32_t unsupportedCount = 0;
+  Opcode lastOpcode = Opcode::kInvalid;
+};
+
+class ReplayingRenderer {
+public:
+  /// Constructs a replayer that will dispatch to `target`. The target's
+  /// lifetime must exceed every call to `pumpFrame()`.
+  explicit ReplayingRenderer(svg::RendererInterface& target);
+  ~ReplayingRenderer();
+
+  ReplayingRenderer(const ReplayingRenderer&) = delete;
+  ReplayingRenderer& operator=(const ReplayingRenderer&) = delete;
+
+  /// Replays the given wire-format bytes onto the target backend. The bytes
+  /// are expected to begin with a `kStreamHeader` and end with `kEndFrame`.
+  ///
+  /// @param wire Byte span containing the full frame (may be a view into
+  ///   stdout bytes, a mapped file, or a test buffer).
+  /// @param[out] report Populated with per-message statistics regardless of
+  ///   status.
+  /// @returns `kOk` on full success, or an error discriminant describing
+  ///   where replay stopped.
+  ReplayStatus pumpFrame(std::span<const uint8_t> wire, ReplayReport& report);
+
+private:
+  enum class DispatchOutcome {
+    kHandled,       ///< Message was fully consumed and dispatched.
+    kUnsupported,   ///< `kUnsupported` message — replay skips but remains valid.
+    kDecodeError,   ///< Payload failed to decode; reader is marked failed.
+    kUnknownOpcode, ///< Opcode not recognized; payload must be skipped.
+  };
+
+  DispatchOutcome handleMessage(WireReader& r, Opcode opcode);
+
+  // WIRE.5: the replayer owns a private ECS registry used to materialize
+  // gradient paint-server references. Each frame gets a fresh entity per
+  // gradient; the registry is cleared on `kBeginFrame` so stale entities
+  // don't pile up across long runs. The registry is intentionally
+  // heap-allocated behind an opaque `impl_` pointer to keep the public
+  // header free of the entt include.
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+
+  svg::RendererInterface& target_;
+};
+
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/RnrFile.cc
+++ b/donner/editor/sandbox/RnrFile.cc
@@ -1,0 +1,110 @@
+#include "donner/editor/sandbox/RnrFile.h"
+
+#include <cstring>
+#include <fstream>
+
+namespace donner::editor::sandbox {
+
+namespace {
+
+template <typename T>
+void AppendPod(std::vector<uint8_t>& dst, const T& value) {
+  static_assert(std::is_trivially_copyable_v<T>);
+  const std::size_t offset = dst.size();
+  dst.resize(offset + sizeof(T));
+  std::memcpy(dst.data() + offset, &value, sizeof(T));
+}
+
+template <typename T>
+bool ReadPod(std::span<const uint8_t>& cursor, T& out) {
+  static_assert(std::is_trivially_copyable_v<T>);
+  if (cursor.size() < sizeof(T)) return false;
+  std::memcpy(&out, cursor.data(), sizeof(T));
+  cursor = cursor.subspan(sizeof(T));
+  return true;
+}
+
+}  // namespace
+
+std::vector<uint8_t> EncodeRnrBuffer(const RnrHeader& header,
+                                     std::span<const uint8_t> wireBytes) {
+  std::vector<uint8_t> buf;
+  buf.reserve(28 + header.uri.size() + wireBytes.size());
+
+  AppendPod<uint32_t>(buf, kRnrFileMagic);
+  AppendPod<uint32_t>(buf, header.fileVersion);
+  AppendPod<uint64_t>(buf, header.timestampNanos);
+  AppendPod<uint32_t>(buf, header.width);
+  AppendPod<uint32_t>(buf, header.height);
+  AppendPod<uint32_t>(buf, static_cast<uint32_t>(header.backend));
+  AppendPod<uint32_t>(buf, static_cast<uint32_t>(header.uri.size()));
+  buf.insert(buf.end(), header.uri.begin(), header.uri.end());
+  buf.insert(buf.end(), wireBytes.begin(), wireBytes.end());
+  return buf;
+}
+
+RnrIoStatus ParseRnrBuffer(std::span<const uint8_t> buffer, RnrHeader& outHeader,
+                           std::vector<uint8_t>& outWireBytes) {
+  outHeader = RnrHeader{};
+  outWireBytes.clear();
+
+  std::span<const uint8_t> cursor = buffer;
+  uint32_t magic = 0;
+  if (!ReadPod(cursor, magic)) return RnrIoStatus::kTruncated;
+  if (magic != kRnrFileMagic) return RnrIoStatus::kMagicMismatch;
+
+  uint32_t fileVersion = 0;
+  if (!ReadPod(cursor, fileVersion)) return RnrIoStatus::kTruncated;
+  if (fileVersion != kRnrFileVersion) return RnrIoStatus::kVersionMismatch;
+  outHeader.fileVersion = fileVersion;
+
+  if (!ReadPod(cursor, outHeader.timestampNanos)) return RnrIoStatus::kTruncated;
+  if (!ReadPod(cursor, outHeader.width)) return RnrIoStatus::kTruncated;
+  if (!ReadPod(cursor, outHeader.height)) return RnrIoStatus::kTruncated;
+
+  uint32_t rawBackend = 0;
+  if (!ReadPod(cursor, rawBackend)) return RnrIoStatus::kTruncated;
+  outHeader.backend = static_cast<BackendHint>(rawBackend);
+
+  uint32_t uriLength = 0;
+  if (!ReadPod(cursor, uriLength)) return RnrIoStatus::kTruncated;
+  if (uriLength > kRnrMaxUriBytes) return RnrIoStatus::kUriTooLong;
+  if (cursor.size() < uriLength) return RnrIoStatus::kTruncated;
+  outHeader.uri.assign(reinterpret_cast<const char*>(cursor.data()), uriLength);
+  cursor = cursor.subspan(uriLength);
+
+  outWireBytes.assign(cursor.begin(), cursor.end());
+  return RnrIoStatus::kOk;
+}
+
+RnrIoStatus SaveRnrFile(const std::filesystem::path& path, const RnrHeader& header,
+                        std::span<const uint8_t> wireBytes) {
+  if (header.uri.size() > kRnrMaxUriBytes) return RnrIoStatus::kUriTooLong;
+
+  const auto buffer = EncodeRnrBuffer(header, wireBytes);
+  std::ofstream out(path, std::ios::binary | std::ios::trunc);
+  if (!out) return RnrIoStatus::kWriteFailed;
+  out.write(reinterpret_cast<const char*>(buffer.data()),
+            static_cast<std::streamsize>(buffer.size()));
+  if (!out) return RnrIoStatus::kWriteFailed;
+  return RnrIoStatus::kOk;
+}
+
+RnrIoStatus LoadRnrFile(const std::filesystem::path& path, RnrHeader& outHeader,
+                        std::vector<uint8_t>& outWireBytes) {
+  std::ifstream in(path, std::ios::binary | std::ios::ate);
+  if (!in) return RnrIoStatus::kReadFailed;
+  const auto size = static_cast<std::streamoff>(in.tellg());
+  if (size < 0) return RnrIoStatus::kReadFailed;
+  in.seekg(0);
+
+  std::vector<uint8_t> buffer(static_cast<std::size_t>(size));
+  if (size > 0) {
+    in.read(reinterpret_cast<char*>(buffer.data()), size);
+    if (!in || in.gcount() != size) return RnrIoStatus::kReadFailed;
+  }
+
+  return ParseRnrBuffer(buffer, outHeader, outWireBytes);
+}
+
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/RnrFile.h
+++ b/donner/editor/sandbox/RnrFile.h
@@ -1,0 +1,108 @@
+#pragma once
+/// @file
+///
+/// `.rnr` — **Donner Renderer Recording** — is a compact on-disk container
+/// for a single sandbox wire stream plus enough metadata to reproduce the
+/// original render. The file body is the raw wire bytes from
+/// `SandboxHost::renderToBackend` (or `SerializingRenderer::takeBuffer`)
+/// appended verbatim — no re-encoding, no compression.
+///
+/// Layout:
+///
+/// ```
+///   u32   fileMagic      = 'DRNF' (0x464E5244 little-endian)
+///   u32   fileVersion    = 1
+///   u64   timestampNanos (unix epoch, best-effort)
+///   u32   widthPixels
+///   u32   heightPixels
+///   u32   backendHint    (see BackendHint enum)
+///   u32   uriLength
+///   u8[]  uri            (UTF-8, no terminator, may be empty)
+///   u8[]  wireStream     (rest of file — kStreamHeader..kEndFrame)
+/// ```
+///
+/// The `fileVersion` is distinct from `kWireVersion` in `Wire.h`. A file
+/// format bump doesn't necessarily imply a wire protocol change, and vice
+/// versa — the file header wraps the wire stream, not the other way around.
+
+#include <cstdint>
+#include <filesystem>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace donner::editor::sandbox {
+
+/// Magic identifier for an `.rnr` file (`DRNF` in ASCII, little-endian u32).
+inline constexpr uint32_t kRnrFileMagic = 0x464E5244u;
+
+/// Bumped on any breaking change to the header layout. Does not need to
+/// match `Wire.h`'s `kWireVersion`.
+inline constexpr uint32_t kRnrFileVersion = 1;
+
+/// Upper bound on a URI stored in a recording header. 64 KiB is plenty for
+/// any real path or URL, and cheap to validate on read.
+inline constexpr uint32_t kRnrMaxUriBytes = 64u * 1024u;
+
+/// Backend that recorded the stream, for diagnostic round-tripping. The
+/// replayer never acts on this — the host picks whatever backend it wants
+/// to replay into — but it's useful for bug reports ("this .rnr was
+/// captured with backend=tiny_skia").
+enum class BackendHint : uint32_t {
+  kUnspecified = 0,
+  kTinySkia = 1,
+  kSkia = 2,
+  kGeode = 3,
+};
+
+/// Per-file metadata. All fields are POD or trivially serializable. `uri`
+/// may be empty when the recording originated from an in-memory string.
+struct RnrHeader {
+  uint32_t fileVersion = kRnrFileVersion;
+  uint64_t timestampNanos = 0;
+  uint32_t width = 0;
+  uint32_t height = 0;
+  BackendHint backend = BackendHint::kUnspecified;
+  std::string uri;
+};
+
+/// Outcome of an I/O call.
+enum class RnrIoStatus {
+  kOk,
+  kWriteFailed,
+  kReadFailed,
+  kTruncated,        ///< Stream ended inside the header.
+  kMagicMismatch,    ///< First four bytes aren't `DRNF`.
+  kVersionMismatch,  ///< Header version newer/older than we understand.
+  kUriTooLong,       ///< `uriLength` exceeds `kRnrMaxUriBytes`.
+};
+
+/// Writes `header` + `wireBytes` to the given path, creating or replacing
+/// the file. `wireBytes` is copied verbatim after the header — callers
+/// should pass the exact bytes returned by the sandbox or serializing
+/// renderer, including the `kStreamHeader` and `kEndFrame` messages.
+[[nodiscard]] RnrIoStatus SaveRnrFile(const std::filesystem::path& path,
+                                      const RnrHeader& header,
+                                      std::span<const uint8_t> wireBytes);
+
+/// Reads a `.rnr` file into memory. On success, `outHeader` is populated
+/// and `outWireBytes` contains the raw wire stream suitable for
+/// `ReplayingRenderer::pumpFrame`.
+[[nodiscard]] RnrIoStatus LoadRnrFile(const std::filesystem::path& path,
+                                      RnrHeader& outHeader,
+                                      std::vector<uint8_t>& outWireBytes);
+
+/// Parses a recording from an in-memory buffer instead of disk. Same
+/// semantics as `LoadRnrFile`, but without any I/O — useful for unit tests
+/// and for round-tripping a recording through a memfd without hitting the
+/// filesystem.
+[[nodiscard]] RnrIoStatus ParseRnrBuffer(std::span<const uint8_t> buffer,
+                                         RnrHeader& outHeader,
+                                         std::vector<uint8_t>& outWireBytes);
+
+/// Serializes `header` + `wireBytes` into a contiguous byte vector without
+/// touching the filesystem. Always succeeds (just allocates and memcpys).
+std::vector<uint8_t> EncodeRnrBuffer(const RnrHeader& header,
+                                     std::span<const uint8_t> wireBytes);
+
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/SandboxCodecs.cc
+++ b/donner/editor/sandbox/SandboxCodecs.cc
@@ -1,0 +1,2040 @@
+#include "donner/editor/sandbox/SandboxCodecs.h"
+
+#include <cstdint>
+#include <variant>
+#include <vector>
+
+#include "donner/svg/components/paint/GradientComponent.h"
+#include "donner/svg/components/paint/LinearGradientComponent.h"
+#include "donner/svg/components/paint/RadialGradientComponent.h"
+#include "donner/svg/components/text/ComputedTextComponent.h"
+
+namespace donner::editor::sandbox {
+
+namespace {
+
+// Upper bound on how many Command/points pairs we'll accept in a single Path.
+// Matches the per-frame cap guidance in docs/design_docs/editor_sandbox.md.
+constexpr uint32_t kMaxPathCommands = 10'000'000;
+constexpr uint32_t kMaxPathPoints = 20'000'000;
+constexpr uint32_t kMaxDashArrayLen = 4096;
+constexpr uint32_t kMaxClipPaths = 1024;
+
+// Reconstructs a Path from a decoded verb stream via PathBuilder. Points are
+// consumed from a cursor to keep verb/point counts cross-checked.
+bool BuildPathFromVerbs(const std::vector<Path::Verb>& verbs,
+                       const std::vector<Vector2d>& points, Path& out) {
+  PathBuilder builder;
+  std::size_t cursor = 0;
+  const auto take = [&](std::size_t n, std::span<const Vector2d>& dst) -> bool {
+    if (points.size() - cursor < n) return false;
+    dst = std::span<const Vector2d>(points.data() + cursor, n);
+    cursor += n;
+    return true;
+  };
+
+  for (const Path::Verb verb : verbs) {
+    std::span<const Vector2d> pts;
+    switch (verb) {
+      case Path::Verb::MoveTo:
+        if (!take(1, pts)) return false;
+        builder.moveTo(pts[0]);
+        break;
+      case Path::Verb::LineTo:
+        if (!take(1, pts)) return false;
+        builder.lineTo(pts[0]);
+        break;
+      case Path::Verb::QuadTo:
+        if (!take(2, pts)) return false;
+        builder.quadTo(pts[0], pts[1]);
+        break;
+      case Path::Verb::CurveTo:
+        if (!take(3, pts)) return false;
+        builder.curveTo(pts[0], pts[1], pts[2]);
+        break;
+      case Path::Verb::ClosePath:
+        builder.closePath();
+        break;
+    }
+  }
+
+  if (cursor != points.size()) {
+    // Trailing point data with no verb to consume it — treat as corruption.
+    return false;
+  }
+  out = builder.build();
+  return true;
+}
+
+std::size_t PointsPerVerb(Path::Verb verb) {
+  switch (verb) {
+    case Path::Verb::MoveTo:
+    case Path::Verb::LineTo:
+      return 1;
+    case Path::Verb::QuadTo:
+      return 2;
+    case Path::Verb::CurveTo:
+      return 3;
+    case Path::Verb::ClosePath:
+      return 0;
+  }
+  return 0;
+}
+
+}  // namespace
+
+// -----------------------------------------------------------------------------
+// Primitive Donner types
+// -----------------------------------------------------------------------------
+
+void EncodeVector2d(WireWriter& w, const Vector2d& v) {
+  w.writeF64(v.x);
+  w.writeF64(v.y);
+}
+bool DecodeVector2d(WireReader& r, Vector2d& out) {
+  return r.readF64(out.x) && r.readF64(out.y);
+}
+
+void EncodeVector2i(WireWriter& w, const Vector2i& v) {
+  w.writeI32(v.x);
+  w.writeI32(v.y);
+}
+bool DecodeVector2i(WireReader& r, Vector2i& out) {
+  return r.readI32(out.x) && r.readI32(out.y);
+}
+
+void EncodeTransform2d(WireWriter& w, const Transform2d& t) {
+  for (int i = 0; i < 6; ++i) {
+    w.writeF64(t.data[i]);
+  }
+}
+bool DecodeTransform2d(WireReader& r, Transform2d& out) {
+  for (int i = 0; i < 6; ++i) {
+    if (!r.readF64(out.data[i])) return false;
+  }
+  return true;
+}
+
+void EncodeBox2d(WireWriter& w, const Box2d& b) {
+  EncodeVector2d(w, b.topLeft);
+  EncodeVector2d(w, b.bottomRight);
+}
+bool DecodeBox2d(WireReader& r, Box2d& out) {
+  return DecodeVector2d(r, out.topLeft) && DecodeVector2d(r, out.bottomRight);
+}
+
+void EncodeRgba(WireWriter& w, const css::RGBA& rgba) {
+  w.writeU8(rgba.r);
+  w.writeU8(rgba.g);
+  w.writeU8(rgba.b);
+  w.writeU8(rgba.a);
+}
+bool DecodeRgba(WireReader& r, css::RGBA& out) {
+  return r.readU8(out.r) && r.readU8(out.g) && r.readU8(out.b) && r.readU8(out.a);
+}
+
+void EncodeColor(WireWriter& w, const css::Color& color) {
+  // S2: everything gets flattened to an RGBA variant on the wire. A `u8` tag
+  // precedes the RGBA so future versions can reintroduce HSLA/CurrentColor
+  // without breaking older readers.
+  css::RGBA rgba = css::RGBA();
+  if (std::holds_alternative<css::RGBA>(color.value)) {
+    rgba = std::get<css::RGBA>(color.value);
+  } else if (std::holds_alternative<css::HSLA>(color.value)) {
+    rgba = std::get<css::HSLA>(color.value).toRGBA();
+  }
+  // CurrentColor is not resolvable here — fallback to fully-transparent, which
+  // matches Donner's CSS-side semantic of "currentColor with no context".
+
+  w.writeU8(1);  // tag: RGBA
+  EncodeRgba(w, rgba);
+}
+bool DecodeColor(WireReader& r, css::Color& out) {
+  uint8_t tag = 0;
+  if (!r.readU8(tag)) return false;
+  if (tag != 1) {
+    r.fail();
+    return false;
+  }
+  css::RGBA rgba;
+  if (!DecodeRgba(r, rgba)) return false;
+  out = css::Color(rgba);
+  return true;
+}
+
+// -----------------------------------------------------------------------------
+// Enums
+// -----------------------------------------------------------------------------
+
+void EncodeFillRule(WireWriter& w, FillRule v) { w.writeU8(static_cast<uint8_t>(v)); }
+bool DecodeFillRule(WireReader& r, FillRule& out) {
+  uint8_t v = 0;
+  if (!r.readU8(v)) return false;
+  if (v > static_cast<uint8_t>(FillRule::EvenOdd)) {
+    r.fail();
+    return false;
+  }
+  out = static_cast<FillRule>(v);
+  return true;
+}
+
+void EncodeMixBlendMode(WireWriter& w, svg::MixBlendMode v) {
+  w.writeU8(static_cast<uint8_t>(v));
+}
+bool DecodeMixBlendMode(WireReader& r, svg::MixBlendMode& out) {
+  uint8_t v = 0;
+  if (!r.readU8(v)) return false;
+  if (v > static_cast<uint8_t>(svg::MixBlendMode::Luminosity)) {
+    r.fail();
+    return false;
+  }
+  out = static_cast<svg::MixBlendMode>(v);
+  return true;
+}
+
+void EncodeStrokeLinecap(WireWriter& w, svg::StrokeLinecap v) {
+  w.writeU8(static_cast<uint8_t>(v));
+}
+bool DecodeStrokeLinecap(WireReader& r, svg::StrokeLinecap& out) {
+  uint8_t v = 0;
+  if (!r.readU8(v)) return false;
+  if (v > static_cast<uint8_t>(svg::StrokeLinecap::Square)) {
+    r.fail();
+    return false;
+  }
+  out = static_cast<svg::StrokeLinecap>(v);
+  return true;
+}
+
+void EncodeStrokeLinejoin(WireWriter& w, svg::StrokeLinejoin v) {
+  w.writeU8(static_cast<uint8_t>(v));
+}
+bool DecodeStrokeLinejoin(WireReader& r, svg::StrokeLinejoin& out) {
+  uint8_t v = 0;
+  if (!r.readU8(v)) return false;
+  if (v > static_cast<uint8_t>(svg::StrokeLinejoin::Arcs)) {
+    r.fail();
+    return false;
+  }
+  out = static_cast<svg::StrokeLinejoin>(v);
+  return true;
+}
+
+// -----------------------------------------------------------------------------
+// Path and stroke
+// -----------------------------------------------------------------------------
+
+void EncodePath(WireWriter& w, const Path& path) {
+  const auto commands = path.commands();
+  const auto points = path.points();
+
+  w.writeU32(static_cast<uint32_t>(commands.size()));
+  for (const auto& cmd : commands) {
+    w.writeU8(static_cast<uint8_t>(cmd.verb));
+  }
+
+  w.writeU32(static_cast<uint32_t>(points.size()));
+  for (const auto& p : points) {
+    EncodeVector2d(w, p);
+  }
+}
+
+bool DecodePath(WireReader& r, Path& out) {
+  uint32_t commandCount = 0;
+  if (!r.readCount(commandCount, kMaxPathCommands)) return false;
+
+  std::vector<Path::Verb> verbs;
+  verbs.reserve(commandCount);
+  std::size_t expectedPoints = 0;
+  for (uint32_t i = 0; i < commandCount; ++i) {
+    uint8_t v = 0;
+    if (!r.readU8(v)) return false;
+    if (v > static_cast<uint8_t>(Path::Verb::ClosePath)) {
+      r.fail();
+      return false;
+    }
+    const auto verb = static_cast<Path::Verb>(v);
+    verbs.push_back(verb);
+    expectedPoints += PointsPerVerb(verb);
+  }
+
+  uint32_t pointCount = 0;
+  if (!r.readCount(pointCount, kMaxPathPoints)) return false;
+  if (pointCount != expectedPoints) {
+    r.fail();
+    return false;
+  }
+
+  std::vector<Vector2d> points;
+  points.reserve(pointCount);
+  for (uint32_t i = 0; i < pointCount; ++i) {
+    Vector2d p;
+    if (!DecodeVector2d(r, p)) return false;
+    points.push_back(p);
+  }
+
+  if (!BuildPathFromVerbs(verbs, points, out)) {
+    r.fail();
+    return false;
+  }
+  return true;
+}
+
+void EncodeStrokeParams(WireWriter& w, const svg::StrokeParams& s) {
+  w.writeF64(s.strokeWidth);
+  EncodeStrokeLinecap(w, s.lineCap);
+  EncodeStrokeLinejoin(w, s.lineJoin);
+  w.writeF64(s.miterLimit);
+
+  w.writeU32(static_cast<uint32_t>(s.dashArray.size()));
+  for (const double d : s.dashArray) {
+    w.writeF64(d);
+  }
+  w.writeF64(s.dashOffset);
+  w.writeF64(s.pathLength);
+}
+
+bool DecodeStrokeParams(WireReader& r, svg::StrokeParams& out) {
+  if (!r.readF64(out.strokeWidth)) return false;
+  if (!DecodeStrokeLinecap(r, out.lineCap)) return false;
+  if (!DecodeStrokeLinejoin(r, out.lineJoin)) return false;
+  if (!r.readF64(out.miterLimit)) return false;
+
+  uint32_t count = 0;
+  if (!r.readCount(count, kMaxDashArrayLen)) return false;
+  out.dashArray.clear();
+  out.dashArray.reserve(count);
+  for (uint32_t i = 0; i < count; ++i) {
+    double v = 0;
+    if (!r.readF64(v)) return false;
+    out.dashArray.push_back(v);
+  }
+  if (!r.readF64(out.dashOffset)) return false;
+  if (!r.readF64(out.pathLength)) return false;
+  return true;
+}
+
+void EncodePathShape(WireWriter& w, const svg::PathShape& p) {
+  EncodePath(w, p.path);
+  EncodeFillRule(w, p.fillRule);
+  EncodeTransform2d(w, p.entityFromParent);
+  w.writeI32(p.layer);
+}
+
+bool DecodePathShape(WireReader& r, svg::PathShape& out) {
+  if (!DecodePath(r, out.path)) return false;
+  if (!DecodeFillRule(r, out.fillRule)) return false;
+  if (!DecodeTransform2d(r, out.entityFromParent)) return false;
+  if (!r.readI32(out.layer)) return false;
+  return true;
+}
+
+// -----------------------------------------------------------------------------
+// Paint and clip
+// -----------------------------------------------------------------------------
+
+namespace {
+// Tags for the ResolvedPaintServer variant on the wire.
+constexpr uint8_t kPaintTagNone = 0;
+constexpr uint8_t kPaintTagSolid = 1;
+constexpr uint8_t kPaintTagStub = 2;      // unsupported alternative — decode as None
+constexpr uint8_t kPaintTagGradient = 3;  // WIRE.5: linear/radial gradient
+
+constexpr uint32_t kMaxGradientStops = 4096;
+}  // namespace
+
+void EncodeLengthd(WireWriter& w, const Lengthd& v) {
+  w.writeF64(v.value);
+  w.writeU8(static_cast<uint8_t>(v.unit));
+}
+bool DecodeLengthd(WireReader& r, Lengthd& out) {
+  double value = 0;
+  uint8_t unit = 0;
+  if (!r.readF64(value)) return false;
+  if (!r.readU8(unit)) return false;
+  if (unit > static_cast<uint8_t>(LengthUnit::Vmax)) {
+    r.fail();
+    return false;
+  }
+  out = Lengthd(value, static_cast<LengthUnit>(unit));
+  return true;
+}
+
+void EncodeWireGradient(WireWriter& w, const WireGradient& g) {
+  w.writeU8(static_cast<uint8_t>(g.kind));
+  w.writeU8(static_cast<uint8_t>(g.units));
+  w.writeU8(static_cast<uint8_t>(g.spreadMethod));
+
+  // Stops: count + each stop as (f32 offset, u32 rgba, f32 opacity).
+  w.writeU32(static_cast<uint32_t>(g.stops.size()));
+  for (const auto& stop : g.stops) {
+    // GradientStop.offset is float, not double.
+    const double offset64 = static_cast<double>(stop.offset);
+    w.writeF64(offset64);
+    css::RGBA rgba;
+    if (std::holds_alternative<css::RGBA>(stop.color.value)) {
+      rgba = std::get<css::RGBA>(stop.color.value);
+    } else if (std::holds_alternative<css::HSLA>(stop.color.value)) {
+      rgba = std::get<css::HSLA>(stop.color.value).toRGBA();
+    }
+    EncodeRgba(w, rgba);
+    w.writeF64(static_cast<double>(stop.opacity));
+  }
+
+  // Geometry — both linear and radial fields are always present. Wasting a
+  // few bytes is cheaper than branching the wire layout and makes the decoder
+  // trivially bounds-checkable.
+  EncodeLengthd(w, g.x1);
+  EncodeLengthd(w, g.y1);
+  EncodeLengthd(w, g.x2);
+  EncodeLengthd(w, g.y2);
+
+  EncodeLengthd(w, g.cx);
+  EncodeLengthd(w, g.cy);
+  EncodeLengthd(w, g.r);
+  w.writeBool(g.fx.has_value());
+  if (g.fx) EncodeLengthd(w, *g.fx);
+  w.writeBool(g.fy.has_value());
+  if (g.fy) EncodeLengthd(w, *g.fy);
+  EncodeLengthd(w, g.fr);
+
+  // Fallback color — matches the PaintResolvedReference structure.
+  w.writeBool(g.fallback.has_value());
+  if (g.fallback) EncodeColor(w, *g.fallback);
+}
+
+bool DecodeWireGradient(WireReader& r, WireGradient& out) {
+  uint8_t kind = 0;
+  if (!r.readU8(kind)) return false;
+  if (kind > static_cast<uint8_t>(WireGradient::Kind::kRadial)) {
+    r.fail();
+    return false;
+  }
+  out.kind = static_cast<WireGradient::Kind>(kind);
+
+  uint8_t units = 0;
+  if (!r.readU8(units)) return false;
+  if (units > static_cast<uint8_t>(svg::GradientUnits::ObjectBoundingBox)) {
+    r.fail();
+    return false;
+  }
+  out.units = static_cast<svg::GradientUnits>(units);
+
+  uint8_t spread = 0;
+  if (!r.readU8(spread)) return false;
+  if (spread > static_cast<uint8_t>(svg::GradientSpreadMethod::Repeat)) {
+    r.fail();
+    return false;
+  }
+  out.spreadMethod = static_cast<svg::GradientSpreadMethod>(spread);
+
+  uint32_t stopCount = 0;
+  if (!r.readCount(stopCount, kMaxGradientStops)) return false;
+  out.stops.clear();
+  out.stops.reserve(stopCount);
+  for (uint32_t i = 0; i < stopCount; ++i) {
+    svg::GradientStop stop;
+    double offset = 0;
+    if (!r.readF64(offset)) return false;
+    stop.offset = static_cast<float>(offset);
+    css::RGBA rgba;
+    if (!DecodeRgba(r, rgba)) return false;
+    stop.color = css::Color(rgba);
+    double opacity = 0;
+    if (!r.readF64(opacity)) return false;
+    stop.opacity = static_cast<float>(opacity);
+    out.stops.push_back(std::move(stop));
+  }
+
+  if (!DecodeLengthd(r, out.x1)) return false;
+  if (!DecodeLengthd(r, out.y1)) return false;
+  if (!DecodeLengthd(r, out.x2)) return false;
+  if (!DecodeLengthd(r, out.y2)) return false;
+
+  if (!DecodeLengthd(r, out.cx)) return false;
+  if (!DecodeLengthd(r, out.cy)) return false;
+  if (!DecodeLengthd(r, out.r)) return false;
+  bool hasFx = false;
+  if (!r.readBool(hasFx)) return false;
+  if (hasFx) {
+    Lengthd fx;
+    if (!DecodeLengthd(r, fx)) return false;
+    out.fx = fx;
+  } else {
+    out.fx.reset();
+  }
+  bool hasFy = false;
+  if (!r.readBool(hasFy)) return false;
+  if (hasFy) {
+    Lengthd fy;
+    if (!DecodeLengthd(r, fy)) return false;
+    out.fy = fy;
+  } else {
+    out.fy.reset();
+  }
+  if (!DecodeLengthd(r, out.fr)) return false;
+
+  bool hasFallback = false;
+  if (!r.readBool(hasFallback)) return false;
+  if (hasFallback) {
+    css::Color color(css::RGBA{});
+    if (!DecodeColor(r, color)) return false;
+    out.fallback = color;
+  } else {
+    out.fallback.reset();
+  }
+  return true;
+}
+
+namespace {
+
+/// Attempts to flatten a PaintResolvedReference's gradient components into a
+/// self-contained `WireGradient`. Returns `std::nullopt` if the reference
+/// doesn't resolve to a gradient (e.g., it's a pattern). The caller is the
+/// serializer side, which has live access to the sandbox-side registry, so
+/// `handle.try_get<...>()` is safe.
+std::optional<WireGradient> FlattenGradientReference(
+    const svg::components::PaintResolvedReference& ref) {
+  const auto& handle = ref.reference.handle;
+  const auto* gradient =
+      handle.try_get<svg::components::ComputedGradientComponent>();
+  if (gradient == nullptr || !gradient->initialized) {
+    return std::nullopt;
+  }
+
+  WireGradient out;
+  out.units = gradient->gradientUnits;
+  out.spreadMethod = gradient->spreadMethod;
+  out.stops = gradient->stops;
+  out.fallback = ref.fallback;
+
+  if (const auto* linear =
+          handle.try_get<svg::components::ComputedLinearGradientComponent>()) {
+    out.kind = WireGradient::Kind::kLinear;
+    out.x1 = linear->x1;
+    out.y1 = linear->y1;
+    out.x2 = linear->x2;
+    out.y2 = linear->y2;
+    return out;
+  }
+  if (const auto* radial =
+          handle.try_get<svg::components::ComputedRadialGradientComponent>()) {
+    out.kind = WireGradient::Kind::kRadial;
+    out.cx = radial->cx;
+    out.cy = radial->cy;
+    out.r = radial->r;
+    out.fx = radial->fx;
+    out.fy = radial->fy;
+    out.fr = radial->fr;
+    return out;
+  }
+  return std::nullopt;
+}
+
+}  // namespace
+
+void EncodeResolvedPaintServer(WireWriter& w,
+                               const svg::components::ResolvedPaintServer& p) {
+  if (std::holds_alternative<svg::PaintServer::None>(p)) {
+    w.writeU8(kPaintTagNone);
+    return;
+  }
+  if (std::holds_alternative<svg::PaintServer::Solid>(p)) {
+    const auto& solid = std::get<svg::PaintServer::Solid>(p);
+    w.writeU8(kPaintTagSolid);
+    EncodeColor(w, solid.color);
+    return;
+  }
+  if (std::holds_alternative<svg::components::PaintResolvedReference>(p)) {
+    const auto& ref = std::get<svg::components::PaintResolvedReference>(p);
+    if (auto gradient = FlattenGradientReference(ref)) {
+      w.writeU8(kPaintTagGradient);
+      EncodeWireGradient(w, *gradient);
+      return;
+    }
+    // Fall through: unresolvable or pattern — emit a stub. The downstream
+    // setPaint will decode to None; pattern rendering continues to work via
+    // RendererTinySkia's patternFillPaint_ side channel.
+  }
+  w.writeU8(kPaintTagStub);
+}
+
+bool DecodeResolvedPaintServer(WireReader& r,
+                               svg::components::ResolvedPaintServer& out,
+                               std::optional<WireGradient>* outPendingGradient) {
+  uint8_t tag = 0;
+  if (!r.readU8(tag)) return false;
+  switch (tag) {
+    case kPaintTagNone:
+      out = svg::PaintServer::None{};
+      return true;
+    case kPaintTagSolid: {
+      css::Color color(css::RGBA{});
+      if (!DecodeColor(r, color)) return false;
+      out = svg::PaintServer::Solid(color);
+      return true;
+    }
+    case kPaintTagStub:
+      // Decode as transparent-solid rather than None. This matters for
+      // patterns: RendererTinySkia::makeFillPaint() returns early on None
+      // (line 2105) before checking patternFillPaint_ (line 2112). A
+      // transparent-solid passes the None check, letting the pattern side
+      // channel take effect. For non-pattern stubs, transparent-solid is
+      // visually identical to None on a transparent-initialized canvas.
+      out = svg::PaintServer::Solid(css::Color(css::RGBA(0, 0, 0, 0)));
+      return true;
+    case kPaintTagGradient: {
+      WireGradient gradient;
+      if (!DecodeWireGradient(r, gradient)) return false;
+      if (outPendingGradient != nullptr) {
+        *outPendingGradient = std::move(gradient);
+      }
+      // The actual `PaintResolvedReference` is materialized by the replayer
+      // before the decoded PaintParams is forwarded to the backend. Until
+      // then, we hold a placeholder `None` so the variant stays valid.
+      out = svg::PaintServer::None{};
+      return true;
+    }
+    default:
+      r.fail();
+      return false;
+  }
+}
+
+void EncodePaintParams(WireWriter& w, const svg::PaintParams& p) {
+  w.writeF64(p.opacity);
+  EncodeResolvedPaintServer(w, p.fill);
+  EncodeResolvedPaintServer(w, p.stroke);
+  w.writeF64(p.fillOpacity);
+  w.writeF64(p.strokeOpacity);
+  EncodeColor(w, p.currentColor);
+  EncodeBox2d(w, p.viewBox);
+  EncodeStrokeParams(w, p.strokeParams);
+}
+
+bool DecodePaintParams(WireReader& r, svg::PaintParams& out,
+                       std::optional<WireGradient>* outFillGradient,
+                       std::optional<WireGradient>* outStrokeGradient) {
+  if (!r.readF64(out.opacity)) return false;
+  if (!DecodeResolvedPaintServer(r, out.fill, outFillGradient)) return false;
+  if (!DecodeResolvedPaintServer(r, out.stroke, outStrokeGradient)) return false;
+  if (!r.readF64(out.fillOpacity)) return false;
+  if (!r.readF64(out.strokeOpacity)) return false;
+  if (!DecodeColor(r, out.currentColor)) return false;
+  if (!DecodeBox2d(r, out.viewBox)) return false;
+  if (!DecodeStrokeParams(r, out.strokeParams)) return false;
+  return true;
+}
+
+void EncodeResolvedClip(WireWriter& w, const svg::ResolvedClip& c) {
+  w.writeBool(c.clipRect.has_value());
+  if (c.clipRect) {
+    EncodeBox2d(w, *c.clipRect);
+  }
+
+  w.writeU32(static_cast<uint32_t>(c.clipPaths.size()));
+  for (const auto& shape : c.clipPaths) {
+    EncodePathShape(w, shape);
+  }
+
+  EncodeTransform2d(w, c.clipPathUnitsTransform);
+  // ResolvedMask: always encoded as absent. Masks hit the unsupported path
+  // before ever reaching this encoder in the SerializingRenderer; if one
+  // slips through we deliberately drop it instead of corrupting the stream.
+  w.writeBool(false);
+}
+
+bool DecodeResolvedClip(WireReader& r, svg::ResolvedClip& out) {
+  bool hasRect = false;
+  if (!r.readBool(hasRect)) return false;
+  if (hasRect) {
+    Box2d rect;
+    if (!DecodeBox2d(r, rect)) return false;
+    out.clipRect = rect;
+  } else {
+    out.clipRect.reset();
+  }
+
+  uint32_t pathCount = 0;
+  if (!r.readCount(pathCount, kMaxClipPaths)) return false;
+  out.clipPaths.clear();
+  out.clipPaths.reserve(pathCount);
+  for (uint32_t i = 0; i < pathCount; ++i) {
+    svg::PathShape shape;
+    if (!DecodePathShape(r, shape)) return false;
+    out.clipPaths.push_back(std::move(shape));
+  }
+
+  if (!DecodeTransform2d(r, out.clipPathUnitsTransform)) return false;
+
+  bool hasMask = false;
+  if (!r.readBool(hasMask)) return false;
+  // Mask payload is never written, so hasMask==true on the wire is a bug.
+  if (hasMask) {
+    r.fail();
+    return false;
+  }
+  out.mask.reset();
+  return true;
+}
+
+// -----------------------------------------------------------------------------
+// Misc
+// -----------------------------------------------------------------------------
+
+void EncodeRenderViewport(WireWriter& w, const svg::RenderViewport& v) {
+  EncodeVector2d(w, v.size);
+  w.writeF64(v.devicePixelRatio);
+}
+bool DecodeRenderViewport(WireReader& r, svg::RenderViewport& out) {
+  if (!DecodeVector2d(r, out.size)) return false;
+  if (!r.readF64(out.devicePixelRatio)) return false;
+  return true;
+}
+
+void EncodeImageParams(WireWriter& w, const svg::ImageParams& p) {
+  EncodeBox2d(w, p.targetRect);
+  w.writeF64(p.opacity);
+  w.writeBool(p.imageRenderingPixelated);
+}
+bool DecodeImageParams(WireReader& r, svg::ImageParams& out) {
+  if (!DecodeBox2d(r, out.targetRect)) return false;
+  if (!r.readF64(out.opacity)) return false;
+  if (!r.readBool(out.imageRenderingPixelated)) return false;
+  return true;
+}
+
+namespace {
+// 512 MB hard cap on inline image data — any real SVG image is tiny
+// compared to this. Anything larger is a protocol violation.
+constexpr uint32_t kMaxImageBytes = 512u * 1024u * 1024u;
+}  // namespace
+
+void EncodeImageResource(WireWriter& w, const svg::ImageResource& img) {
+  w.writeI32(img.width);
+  w.writeI32(img.height);
+  w.writeU32(static_cast<uint32_t>(img.data.size()));
+  w.writeBytes(std::span<const uint8_t>(img.data));
+}
+
+bool DecodeImageResource(WireReader& r, svg::ImageResource& out) {
+  if (!r.readI32(out.width)) return false;
+  if (!r.readI32(out.height)) return false;
+  if (out.width < 0 || out.height < 0) {
+    r.fail();
+    return false;
+  }
+  uint32_t byteLen = 0;
+  if (!r.readCount(byteLen, kMaxImageBytes)) return false;
+  out.data.resize(byteLen);
+  if (byteLen > 0 && !r.readBytes(std::span<uint8_t>(out.data))) return false;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Text: TextParams + ComputedTextComponent
+// ---------------------------------------------------------------------------
+
+namespace {
+constexpr uint32_t kMaxTextSpans = 10'000;
+constexpr uint32_t kMaxPositionList = 100'000;
+constexpr uint32_t kMaxFontFamilies = 64;
+constexpr uint32_t kMaxBaselineShifts = 256;
+constexpr uint32_t kMaxFontFaces = 256;
+constexpr uint32_t kMaxFontFaceSources = 16;
+constexpr uint32_t kMaxFontDataBytes = 50u * 1024u * 1024u;  // 50 MB
+constexpr uint32_t kMaxTechHints = 32;
+
+void EncodeOptionalLengthd(WireWriter& w, const std::optional<Lengthd>& v) {
+  w.writeBool(v.has_value());
+  if (v) EncodeLengthd(w, *v);
+}
+bool DecodeOptionalLengthd(WireReader& r, std::optional<Lengthd>& out) {
+  bool present = false;
+  if (!r.readBool(present)) return false;
+  if (present) {
+    Lengthd v;
+    if (!DecodeLengthd(r, v)) return false;
+    out = v;
+  } else {
+    out.reset();
+  }
+  return true;
+}
+
+template <typename T>
+void EncodeSmallVecOptLengthd(WireWriter& w, const T& vec) {
+  w.writeU32(static_cast<uint32_t>(vec.size()));
+  for (const auto& v : vec) {
+    EncodeOptionalLengthd(w, v);
+  }
+}
+template <typename T>
+bool DecodeSmallVecOptLengthd(WireReader& r, T& out, uint32_t maxCount) {
+  uint32_t count = 0;
+  if (!r.readCount(count, maxCount)) return false;
+  out.clear();
+  for (uint32_t i = 0; i < count; ++i) {
+    std::optional<Lengthd> v;
+    if (!DecodeOptionalLengthd(r, v)) return false;
+    out.push_back(std::move(v));
+  }
+  return true;
+}
+
+void EncodeTextSpan(WireWriter& w, const svg::components::ComputedTextComponent::TextSpan& s) {
+  // Text content
+  w.writeString(std::string_view(s.text));
+  w.writeU32(static_cast<uint32_t>(s.start));
+  w.writeU32(static_cast<uint32_t>(s.end));
+
+  // Positioning lists
+  EncodeSmallVecOptLengthd(w, s.xList);
+  EncodeSmallVecOptLengthd(w, s.yList);
+  EncodeSmallVecOptLengthd(w, s.dxList);
+  EncodeSmallVecOptLengthd(w, s.dyList);
+
+  w.writeU32(static_cast<uint32_t>(s.rotateList.size()));
+  for (const double v : s.rotateList) {
+    w.writeF64(v);
+  }
+
+  // Paint servers (reuse existing codec)
+  EncodeResolvedPaintServer(w, s.resolvedFill);
+  EncodeResolvedPaintServer(w, s.resolvedStroke);
+
+  // Scalar style fields
+  w.writeF64(s.opacity);
+  w.writeF64(s.fillOpacity);
+  w.writeF64(s.strokeOpacity);
+  EncodeLengthd(w, s.fontSize);
+  w.writeI32(s.fontWeight);
+  w.writeU8(static_cast<uint8_t>(s.fontStyle));
+  w.writeU8(static_cast<uint8_t>(s.fontStretch));
+  w.writeU8(static_cast<uint8_t>(s.fontVariant));
+  w.writeF64(s.strokeWidth);
+  w.writeF64(s.strokeMiterLimit);
+  EncodeStrokeLinecap(w, s.strokeLinecap);
+  EncodeStrokeLinejoin(w, s.strokeLinejoin);
+
+  // Path (optional)
+  w.writeBool(s.pathSpline.has_value());
+  if (s.pathSpline) EncodePath(w, *s.pathSpline);
+
+  // Baseline shifts
+  w.writeU32(static_cast<uint32_t>(s.ancestorBaselineShifts.size()));
+  for (const auto& shift : s.ancestorBaselineShifts) {
+    using K = svg::components::ComputedTextComponent::TextSpan::BaselineShiftKeyword;
+    w.writeU8(static_cast<uint8_t>(shift.keyword));
+    EncodeLengthd(w, shift.shift);
+    w.writeF64(shift.fontSizePx);
+  }
+  w.writeU8(static_cast<uint8_t>(s.baselineShiftKeyword));
+  EncodeLengthd(w, s.baselineShift);
+
+  // Enum fields
+  w.writeU8(static_cast<uint8_t>(s.textAnchor));
+  w.writeU8(static_cast<uint8_t>(s.visibility));
+  w.writeU8(static_cast<uint8_t>(s.textDecoration));
+  w.writeU8(static_cast<uint8_t>(s.alignmentBaseline));
+
+  // Spacing
+  w.writeF64(s.letterSpacingPx);
+  w.writeF64(s.wordSpacingPx);
+  EncodeOptionalLengthd(w, s.textLength);
+  w.writeU8(static_cast<uint8_t>(s.lengthAdjust));
+
+  // Booleans
+  w.writeBool(s.startsNewChunk);
+  w.writeBool(s.hidden);
+  w.writeBool(s.textPathFailed);
+
+  w.writeF64(s.pathStartOffset);
+
+  // Decoration paint/styling
+  EncodeResolvedPaintServer(w, s.resolvedDecorationFill);
+  EncodeResolvedPaintServer(w, s.resolvedDecorationStroke);
+  w.writeF64(s.decorationFillOpacity);
+  w.writeF64(s.decorationStrokeOpacity);
+  w.writeF64(s.decorationStrokeWidth);
+  w.writeF64(static_cast<double>(s.decorationFontSizePx));
+  w.writeI32(s.decorationDeclarationCount);
+}
+
+bool DecodeTextSpan(WireReader& r,
+                    svg::components::ComputedTextComponent::TextSpan& s) {
+  std::string text;
+  if (!r.readString(text)) return false;
+  s.text = RcString(text);
+  uint32_t start = 0, end = 0;
+  if (!r.readU32(start) || !r.readU32(end)) return false;
+  s.start = start;
+  s.end = end;
+
+  if (!DecodeSmallVecOptLengthd(r, s.xList, kMaxPositionList)) return false;
+  if (!DecodeSmallVecOptLengthd(r, s.yList, kMaxPositionList)) return false;
+  if (!DecodeSmallVecOptLengthd(r, s.dxList, kMaxPositionList)) return false;
+  if (!DecodeSmallVecOptLengthd(r, s.dyList, kMaxPositionList)) return false;
+
+  uint32_t rotCount = 0;
+  if (!r.readCount(rotCount, kMaxPositionList)) return false;
+  s.rotateList.clear();
+  for (uint32_t i = 0; i < rotCount; ++i) {
+    double v = 0;
+    if (!r.readF64(v)) return false;
+    s.rotateList.push_back(v);
+  }
+
+  if (!DecodeResolvedPaintServer(r, s.resolvedFill)) return false;
+  if (!DecodeResolvedPaintServer(r, s.resolvedStroke)) return false;
+
+  if (!r.readF64(s.opacity)) return false;
+  if (!r.readF64(s.fillOpacity)) return false;
+  if (!r.readF64(s.strokeOpacity)) return false;
+  if (!DecodeLengthd(r, s.fontSize)) return false;
+  if (!r.readI32(s.fontWeight)) return false;
+  uint8_t u = 0;
+  if (!r.readU8(u)) return false; s.fontStyle = static_cast<svg::FontStyle>(u);
+  if (!r.readU8(u)) return false; s.fontStretch = static_cast<svg::FontStretch>(u);
+  if (!r.readU8(u)) return false; s.fontVariant = static_cast<svg::FontVariant>(u);
+  if (!r.readF64(s.strokeWidth)) return false;
+  if (!r.readF64(s.strokeMiterLimit)) return false;
+  if (!DecodeStrokeLinecap(r, s.strokeLinecap)) return false;
+  if (!DecodeStrokeLinejoin(r, s.strokeLinejoin)) return false;
+
+  bool hasPath = false;
+  if (!r.readBool(hasPath)) return false;
+  if (hasPath) {
+    Path p;
+    if (!DecodePath(r, p)) return false;
+    s.pathSpline = std::move(p);
+  } else {
+    s.pathSpline.reset();
+  }
+
+  uint32_t shiftCount = 0;
+  if (!r.readCount(shiftCount, kMaxBaselineShifts)) return false;
+  s.ancestorBaselineShifts.clear();
+  using AncestorShift = svg::components::ComputedTextComponent::TextSpan::AncestorShift;
+  using K = svg::components::ComputedTextComponent::TextSpan::BaselineShiftKeyword;
+  for (uint32_t i = 0; i < shiftCount; ++i) {
+    AncestorShift shift;
+    if (!r.readU8(u)) return false;
+    shift.keyword = static_cast<K>(u);
+    if (!DecodeLengthd(r, shift.shift)) return false;
+    if (!r.readF64(shift.fontSizePx)) return false;
+    s.ancestorBaselineShifts.push_back(shift);
+  }
+  if (!r.readU8(u)) return false; s.baselineShiftKeyword = static_cast<K>(u);
+  if (!DecodeLengthd(r, s.baselineShift)) return false;
+
+  if (!r.readU8(u)) return false; s.textAnchor = static_cast<svg::TextAnchor>(u);
+  if (!r.readU8(u)) return false; s.visibility = static_cast<svg::Visibility>(u);
+  if (!r.readU8(u)) return false; s.textDecoration = static_cast<svg::TextDecoration>(u);
+  if (!r.readU8(u)) return false; s.alignmentBaseline = static_cast<svg::DominantBaseline>(u);
+
+  if (!r.readF64(s.letterSpacingPx)) return false;
+  if (!r.readF64(s.wordSpacingPx)) return false;
+  if (!DecodeOptionalLengthd(r, s.textLength)) return false;
+  if (!r.readU8(u)) return false; s.lengthAdjust = static_cast<svg::LengthAdjust>(u);
+
+  if (!r.readBool(s.startsNewChunk)) return false;
+  if (!r.readBool(s.hidden)) return false;
+  if (!r.readBool(s.textPathFailed)) return false;
+
+  if (!r.readF64(s.pathStartOffset)) return false;
+
+  if (!DecodeResolvedPaintServer(r, s.resolvedDecorationFill)) return false;
+  if (!DecodeResolvedPaintServer(r, s.resolvedDecorationStroke)) return false;
+  if (!r.readF64(s.decorationFillOpacity)) return false;
+  if (!r.readF64(s.decorationStrokeOpacity)) return false;
+  if (!r.readF64(s.decorationStrokeWidth)) return false;
+  double decFontSize = 0;
+  if (!r.readF64(decFontSize)) return false;
+  s.decorationFontSizePx = static_cast<float>(decFontSize);
+  if (!r.readI32(s.decorationDeclarationCount)) return false;
+
+  // Entities are not transferred across the wire boundary. The replayer
+  // doesn't have the original document's registry, so entity handles are
+  // meaningless. Set to null — the renderer will re-derive as needed.
+  s.sourceEntity = entt::null;
+  s.textPathSourceEntity = entt::null;
+  return true;
+}
+
+void EncodeFontFaceSource(WireWriter& w, const css::FontFaceSource& src) {
+  w.writeU8(static_cast<uint8_t>(src.kind));
+  if (src.kind == css::FontFaceSource::Kind::Data) {
+    // Data payload: write the byte vector inline.
+    const auto* dataPtr =
+        std::get_if<std::shared_ptr<const std::vector<uint8_t>>>(&src.payload);
+    if (dataPtr && *dataPtr) {
+      const auto& bytes = **dataPtr;
+      w.writeU32(static_cast<uint32_t>(bytes.size()));
+      w.writeBytes(std::span<const uint8_t>(bytes));
+    } else {
+      w.writeU32(0);
+    }
+  } else {
+    // Local or Url: write the string payload.
+    const auto* strPtr = std::get_if<RcString>(&src.payload);
+    if (strPtr) {
+      w.writeString(std::string_view(*strPtr));
+    } else {
+      w.writeString(std::string_view{});
+    }
+  }
+  w.writeString(std::string_view(src.formatHint));
+  w.writeU32(static_cast<uint32_t>(src.techHints.size()));
+  for (const auto& hint : src.techHints) {
+    w.writeString(std::string_view(hint));
+  }
+}
+
+bool DecodeFontFaceSource(WireReader& r, css::FontFaceSource& out) {
+  uint8_t kindU8 = 0;
+  if (!r.readU8(kindU8)) return false;
+  if (kindU8 > static_cast<uint8_t>(css::FontFaceSource::Kind::Data)) {
+    return false;
+  }
+  out.kind = static_cast<css::FontFaceSource::Kind>(kindU8);
+
+  if (out.kind == css::FontFaceSource::Kind::Data) {
+    uint32_t dataLen = 0;
+    if (!r.readCount(dataLen, kMaxFontDataBytes)) return false;
+    auto dataVec = std::make_shared<std::vector<uint8_t>>(dataLen);
+    if (dataLen > 0) {
+      if (!r.readBytes(std::span<uint8_t>(dataVec->data(), dataLen))) return false;
+    }
+    out.payload = std::move(dataVec);
+  } else {
+    std::string str;
+    if (!r.readString(str)) return false;
+    out.payload = RcString(str);
+  }
+
+  std::string formatHint;
+  if (!r.readString(formatHint)) return false;
+  out.formatHint = RcString(formatHint);
+
+  uint32_t techCount = 0;
+  if (!r.readCount(techCount, kMaxTechHints)) return false;
+  out.techHints.clear();
+  out.techHints.reserve(techCount);
+  for (uint32_t i = 0; i < techCount; ++i) {
+    std::string hint;
+    if (!r.readString(hint)) return false;
+    out.techHints.push_back(RcString(hint));
+  }
+  return true;
+}
+
+}  // namespace
+
+void EncodeFontFace(WireWriter& w, const css::FontFace& face) {
+  w.writeString(std::string_view(face.familyName));
+  w.writeI32(face.fontWeight);
+  w.writeI32(face.fontStyle);
+  w.writeI32(face.fontStretch);
+  w.writeU32(static_cast<uint32_t>(face.sources.size()));
+  for (const auto& src : face.sources) {
+    EncodeFontFaceSource(w, src);
+  }
+}
+
+bool DecodeFontFace(WireReader& r, css::FontFace& out) {
+  std::string familyName;
+  if (!r.readString(familyName)) return false;
+  out.familyName = RcString(familyName);
+  if (!r.readI32(out.fontWeight)) return false;
+  if (!r.readI32(out.fontStyle)) return false;
+  if (!r.readI32(out.fontStretch)) return false;
+  uint32_t srcCount = 0;
+  if (!r.readCount(srcCount, kMaxFontFaceSources)) return false;
+  out.sources.clear();
+  out.sources.reserve(srcCount);
+  for (uint32_t i = 0; i < srcCount; ++i) {
+    css::FontFaceSource src;
+    if (!DecodeFontFaceSource(r, src)) return false;
+    out.sources.push_back(std::move(src));
+  }
+  return true;
+}
+
+void EncodeTextParams(WireWriter& w, const svg::TextParams& p) {
+  w.writeF64(p.opacity);
+  EncodeColor(w, p.fillColor);
+  EncodeColor(w, p.strokeColor);
+  EncodeStrokeParams(w, p.strokeParams);
+
+  w.writeU32(static_cast<uint32_t>(p.fontFamilies.size()));
+  for (const auto& fam : p.fontFamilies) {
+    w.writeString(std::string_view(fam));
+  }
+
+  EncodeLengthd(w, p.fontSize);
+  EncodeBox2d(w, p.viewBox);
+
+  // FontMetrics
+  w.writeF64(p.fontMetrics.fontSize);
+  w.writeF64(p.fontMetrics.rootFontSize);
+  w.writeF64(p.fontMetrics.exUnitInEm);
+  w.writeF64(p.fontMetrics.chUnitInEm);
+  w.writeBool(p.fontMetrics.viewportSize.has_value());
+  if (p.fontMetrics.viewportSize) EncodeVector2d(w, *p.fontMetrics.viewportSize);
+
+  w.writeU8(static_cast<uint8_t>(p.textAnchor));
+  w.writeU8(static_cast<uint8_t>(p.textDecoration));
+  w.writeU8(static_cast<uint8_t>(p.dominantBaseline));
+  w.writeU8(static_cast<uint8_t>(p.writingMode));
+  w.writeF64(p.letterSpacingPx);
+  w.writeF64(p.wordSpacingPx);
+  EncodeOptionalLengthd(w, p.textLength);
+  w.writeU8(static_cast<uint8_t>(p.lengthAdjust));
+
+  // Encode fontFaces with full inline font data.
+  w.writeU32(static_cast<uint32_t>(p.fontFaces.size()));
+  for (const auto& face : p.fontFaces) {
+    EncodeFontFace(w, face);
+  }
+  // textRootEntity is a local entity handle — meaningless on the replay side.
+}
+
+bool DecodeTextParams(WireReader& r, svg::TextParams& out,
+                      std::vector<css::FontFace>* outFontFaces) {
+  if (!r.readF64(out.opacity)) return false;
+  if (!DecodeColor(r, out.fillColor)) return false;
+  if (!DecodeColor(r, out.strokeColor)) return false;
+  if (!DecodeStrokeParams(r, out.strokeParams)) return false;
+
+  uint32_t famCount = 0;
+  if (!r.readCount(famCount, kMaxFontFamilies)) return false;
+  out.fontFamilies.clear();
+  for (uint32_t i = 0; i < famCount; ++i) {
+    std::string fam;
+    if (!r.readString(fam)) return false;
+    out.fontFamilies.push_back(RcString(fam));
+  }
+
+  if (!DecodeLengthd(r, out.fontSize)) return false;
+  if (!DecodeBox2d(r, out.viewBox)) return false;
+
+  if (!r.readF64(out.fontMetrics.fontSize)) return false;
+  if (!r.readF64(out.fontMetrics.rootFontSize)) return false;
+  if (!r.readF64(out.fontMetrics.exUnitInEm)) return false;
+  if (!r.readF64(out.fontMetrics.chUnitInEm)) return false;
+  bool hasViewport = false;
+  if (!r.readBool(hasViewport)) return false;
+  if (hasViewport) {
+    Vector2d vp;
+    if (!DecodeVector2d(r, vp)) return false;
+    out.fontMetrics.viewportSize = vp;
+  } else {
+    out.fontMetrics.viewportSize.reset();
+  }
+
+  uint8_t u = 0;
+  if (!r.readU8(u)) return false; out.textAnchor = static_cast<svg::TextAnchor>(u);
+  if (!r.readU8(u)) return false; out.textDecoration = static_cast<svg::TextDecoration>(u);
+  if (!r.readU8(u)) return false; out.dominantBaseline = static_cast<svg::DominantBaseline>(u);
+  if (!r.readU8(u)) return false; out.writingMode = static_cast<svg::WritingMode>(u);
+  if (!r.readF64(out.letterSpacingPx)) return false;
+  if (!r.readF64(out.wordSpacingPx)) return false;
+  if (!DecodeOptionalLengthd(r, out.textLength)) return false;
+  if (!r.readU8(u)) return false; out.lengthAdjust = static_cast<svg::LengthAdjust>(u);
+
+  uint32_t fontFaceCount = 0;
+  if (!r.readCount(fontFaceCount, kMaxFontFaces)) return false;
+  if (outFontFaces) {
+    outFontFaces->clear();
+    outFontFaces->reserve(fontFaceCount);
+    for (uint32_t i = 0; i < fontFaceCount; ++i) {
+      css::FontFace face;
+      if (!DecodeFontFace(r, face)) return false;
+      outFontFaces->push_back(std::move(face));
+    }
+    out.fontFaces = *outFontFaces;
+  } else {
+    // Caller doesn't need font faces — still must consume the bytes.
+    for (uint32_t i = 0; i < fontFaceCount; ++i) {
+      css::FontFace face;
+      if (!DecodeFontFace(r, face)) return false;
+    }
+    out.fontFaces = {};
+  }
+  out.textRootEntity = entt::null;
+  return true;
+}
+
+void EncodeComputedTextComponent(
+    WireWriter& w, const svg::components::ComputedTextComponent& text) {
+  w.writeU32(static_cast<uint32_t>(text.spans.size()));
+  for (const auto& span : text.spans) {
+    EncodeTextSpan(w, span);
+  }
+}
+
+bool DecodeComputedTextComponent(
+    WireReader& r, svg::components::ComputedTextComponent& out) {
+  uint32_t count = 0;
+  if (!r.readCount(count, kMaxTextSpans)) return false;
+  out.spans.clear();
+  for (uint32_t i = 0; i < count; ++i) {
+    svg::components::ComputedTextComponent::TextSpan span;
+    if (!DecodeTextSpan(r, span)) return false;
+    out.spans.push_back(std::move(span));
+  }
+  return true;
+}
+
+// -----------------------------------------------------------------------------
+// Filter primitive encoding helpers
+// -----------------------------------------------------------------------------
+
+namespace {
+
+// Primitive variant tag — stable across versions.
+enum class FilterPrimitiveTag : uint8_t {
+  kGaussianBlur = 0,
+  kFlood = 1,
+  kOffset = 2,
+  kMerge = 3,
+  kBlend = 4,
+  kComposite = 5,
+  kColorMatrix = 6,
+  kDropShadow = 7,
+  kComponentTransfer = 8,
+  kConvolveMatrix = 9,
+  kMorphology = 10,
+  kTile = 11,
+  kTurbulence = 12,
+  kImage = 13,
+  kDisplacementMap = 14,
+  kDiffuseLighting = 15,
+  kSpecularLighting = 16,
+};
+
+// Per-field caps for filter-related variable-length fields.
+constexpr uint32_t kMaxFilterNodes = 1024;
+constexpr uint32_t kMaxFilterInputs = 256;
+constexpr uint32_t kMaxColorMatrixValues = 256;
+constexpr uint32_t kMaxTransferTableValues = 4096;
+constexpr uint32_t kMaxConvolveKernelValues = 10000;
+constexpr uint32_t kMaxImageDataBytes = 64u * 1024u * 1024u;
+
+// FilterInput tags
+constexpr uint8_t kFilterInputPrevious = 0;
+constexpr uint8_t kFilterInputStandard = 1;
+constexpr uint8_t kFilterInputNamed = 2;
+
+void EncodeFilterInput(WireWriter& w,
+                       const svg::components::FilterInput& input) {
+  std::visit(
+      [&](auto&& arg) {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<T, svg::components::FilterInput::Previous>) {
+          w.writeU8(kFilterInputPrevious);
+        } else if constexpr (std::is_same_v<T, svg::components::FilterStandardInput>) {
+          w.writeU8(kFilterInputStandard);
+          w.writeU8(static_cast<uint8_t>(arg));
+        } else if constexpr (std::is_same_v<T, svg::components::FilterInput::Named>) {
+          w.writeU8(kFilterInputNamed);
+          w.writeString(std::string_view(arg.name));
+        }
+      },
+      input.value);
+}
+
+bool DecodeFilterInput(WireReader& r, svg::components::FilterInput& out) {
+  uint8_t tag = 0;
+  if (!r.readU8(tag)) return false;
+  switch (tag) {
+    case kFilterInputPrevious:
+      out.value = svg::components::FilterInput::Previous{};
+      return true;
+    case kFilterInputStandard: {
+      uint8_t v = 0;
+      if (!r.readU8(v)) return false;
+      if (v > static_cast<uint8_t>(svg::components::FilterStandardInput::StrokePaint)) {
+        r.fail();
+        return false;
+      }
+      out.value = static_cast<svg::components::FilterStandardInput>(v);
+      return true;
+    }
+    case kFilterInputNamed: {
+      std::string name;
+      if (!r.readString(name)) return false;
+      out.value = svg::components::FilterInput::Named{RcString(name)};
+      return true;
+    }
+    default:
+      r.fail();
+      return false;
+  }
+}
+
+void EncodeOptionalLenghdFilter(WireWriter& w, const std::optional<Lengthd>& v) {
+  w.writeBool(v.has_value());
+  if (v) EncodeLengthd(w, *v);
+}
+
+bool DecodeOptionalLenghdFilter(WireReader& r, std::optional<Lengthd>& out) {
+  bool has = false;
+  if (!r.readBool(has)) return false;
+  if (has) {
+    Lengthd v;
+    if (!DecodeLengthd(r, v)) return false;
+    out = v;
+  } else {
+    out.reset();
+  }
+  return true;
+}
+
+void EncodeLightSource(WireWriter& w,
+                       const svg::components::filter_primitive::LightSource& ls) {
+  w.writeU8(static_cast<uint8_t>(ls.type));
+  w.writeF64(ls.azimuth);
+  w.writeF64(ls.elevation);
+  w.writeF64(ls.x);
+  w.writeF64(ls.y);
+  w.writeF64(ls.z);
+  w.writeF64(ls.pointsAtX);
+  w.writeF64(ls.pointsAtY);
+  w.writeF64(ls.pointsAtZ);
+  w.writeF64(ls.spotExponent);
+  w.writeBool(ls.limitingConeAngle.has_value());
+  if (ls.limitingConeAngle) w.writeF64(*ls.limitingConeAngle);
+}
+
+bool DecodeLightSource(WireReader& r,
+                       svg::components::filter_primitive::LightSource& out) {
+  uint8_t type = 0;
+  if (!r.readU8(type)) return false;
+  if (type > static_cast<uint8_t>(
+                 svg::components::filter_primitive::LightSource::Type::Spot)) {
+    r.fail();
+    return false;
+  }
+  out.type = static_cast<svg::components::filter_primitive::LightSource::Type>(type);
+  if (!r.readF64(out.azimuth)) return false;
+  if (!r.readF64(out.elevation)) return false;
+  if (!r.readF64(out.x)) return false;
+  if (!r.readF64(out.y)) return false;
+  if (!r.readF64(out.z)) return false;
+  if (!r.readF64(out.pointsAtX)) return false;
+  if (!r.readF64(out.pointsAtY)) return false;
+  if (!r.readF64(out.pointsAtZ)) return false;
+  if (!r.readF64(out.spotExponent)) return false;
+  bool hasCone = false;
+  if (!r.readBool(hasCone)) return false;
+  if (hasCone) {
+    double v = 0;
+    if (!r.readF64(v)) return false;
+    out.limitingConeAngle = v;
+  } else {
+    out.limitingConeAngle.reset();
+  }
+  return true;
+}
+
+void EncodeTransferFunc(
+    WireWriter& w,
+    const svg::components::filter_primitive::ComponentTransfer::Func& f) {
+  w.writeU8(static_cast<uint8_t>(f.type));
+  w.writeU32(static_cast<uint32_t>(f.tableValues.size()));
+  for (double v : f.tableValues) w.writeF64(v);
+  w.writeF64(f.slope);
+  w.writeF64(f.intercept);
+  w.writeF64(f.amplitude);
+  w.writeF64(f.exponent);
+  w.writeF64(f.offset);
+}
+
+bool DecodeTransferFunc(
+    WireReader& r,
+    svg::components::filter_primitive::ComponentTransfer::Func& out) {
+  uint8_t type = 0;
+  if (!r.readU8(type)) return false;
+  if (type > static_cast<uint8_t>(
+                 svg::components::filter_primitive::ComponentTransfer::FuncType::Gamma)) {
+    r.fail();
+    return false;
+  }
+  out.type =
+      static_cast<svg::components::filter_primitive::ComponentTransfer::FuncType>(type);
+  uint32_t count = 0;
+  if (!r.readCount(count, kMaxTransferTableValues)) return false;
+  out.tableValues.clear();
+  out.tableValues.reserve(count);
+  for (uint32_t i = 0; i < count; ++i) {
+    double v = 0;
+    if (!r.readF64(v)) return false;
+    out.tableValues.push_back(v);
+  }
+  if (!r.readF64(out.slope)) return false;
+  if (!r.readF64(out.intercept)) return false;
+  if (!r.readF64(out.amplitude)) return false;
+  if (!r.readF64(out.exponent)) return false;
+  if (!r.readF64(out.offset)) return false;
+  return true;
+}
+
+// ---- Per-primitive encoders ----
+
+void EncodeFilterPrimitive(
+    WireWriter& w,
+    const svg::components::filter_primitive::GaussianBlur& p) {
+  w.writeU8(static_cast<uint8_t>(FilterPrimitiveTag::kGaussianBlur));
+  w.writeF64(p.stdDeviationX);
+  w.writeF64(p.stdDeviationY);
+  w.writeU8(static_cast<uint8_t>(p.edgeMode));
+}
+
+void EncodeFilterPrimitive(
+    WireWriter& w, const svg::components::filter_primitive::Flood& p) {
+  w.writeU8(static_cast<uint8_t>(FilterPrimitiveTag::kFlood));
+  EncodeColor(w, p.floodColor);
+  w.writeF64(p.floodOpacity);
+}
+
+void EncodeFilterPrimitive(
+    WireWriter& w, const svg::components::filter_primitive::Offset& p) {
+  w.writeU8(static_cast<uint8_t>(FilterPrimitiveTag::kOffset));
+  w.writeF64(p.dx);
+  w.writeF64(p.dy);
+}
+
+void EncodeFilterPrimitive(
+    WireWriter& w, const svg::components::filter_primitive::Merge&) {
+  w.writeU8(static_cast<uint8_t>(FilterPrimitiveTag::kMerge));
+  // Merge has no fields beyond its inputs (encoded in the FilterNode).
+}
+
+void EncodeFilterPrimitive(
+    WireWriter& w, const svg::components::filter_primitive::Blend& p) {
+  w.writeU8(static_cast<uint8_t>(FilterPrimitiveTag::kBlend));
+  w.writeU8(static_cast<uint8_t>(p.mode));
+}
+
+void EncodeFilterPrimitive(
+    WireWriter& w, const svg::components::filter_primitive::Composite& p) {
+  w.writeU8(static_cast<uint8_t>(FilterPrimitiveTag::kComposite));
+  w.writeU8(static_cast<uint8_t>(p.op));
+  w.writeF64(p.k1);
+  w.writeF64(p.k2);
+  w.writeF64(p.k3);
+  w.writeF64(p.k4);
+}
+
+void EncodeFilterPrimitive(
+    WireWriter& w, const svg::components::filter_primitive::ColorMatrix& p) {
+  w.writeU8(static_cast<uint8_t>(FilterPrimitiveTag::kColorMatrix));
+  w.writeU8(static_cast<uint8_t>(p.type));
+  w.writeU32(static_cast<uint32_t>(p.values.size()));
+  for (double v : p.values) w.writeF64(v);
+}
+
+void EncodeFilterPrimitive(
+    WireWriter& w, const svg::components::filter_primitive::DropShadow& p) {
+  w.writeU8(static_cast<uint8_t>(FilterPrimitiveTag::kDropShadow));
+  w.writeF64(p.dx);
+  w.writeF64(p.dy);
+  w.writeF64(p.stdDeviationX);
+  w.writeF64(p.stdDeviationY);
+  EncodeColor(w, p.floodColor);
+  w.writeF64(p.floodOpacity);
+}
+
+void EncodeFilterPrimitive(
+    WireWriter& w,
+    const svg::components::filter_primitive::ComponentTransfer& p) {
+  w.writeU8(static_cast<uint8_t>(FilterPrimitiveTag::kComponentTransfer));
+  EncodeTransferFunc(w, p.funcR);
+  EncodeTransferFunc(w, p.funcG);
+  EncodeTransferFunc(w, p.funcB);
+  EncodeTransferFunc(w, p.funcA);
+}
+
+void EncodeFilterPrimitive(
+    WireWriter& w,
+    const svg::components::filter_primitive::ConvolveMatrix& p) {
+  w.writeU8(static_cast<uint8_t>(FilterPrimitiveTag::kConvolveMatrix));
+  w.writeI32(p.orderX);
+  w.writeI32(p.orderY);
+  w.writeU32(static_cast<uint32_t>(p.kernelMatrix.size()));
+  for (double v : p.kernelMatrix) w.writeF64(v);
+  w.writeBool(p.divisor.has_value());
+  if (p.divisor) w.writeF64(*p.divisor);
+  w.writeF64(p.bias);
+  w.writeBool(p.targetX.has_value());
+  if (p.targetX) w.writeI32(*p.targetX);
+  w.writeBool(p.targetY.has_value());
+  if (p.targetY) w.writeI32(*p.targetY);
+  w.writeU8(static_cast<uint8_t>(p.edgeMode));
+  w.writeBool(p.preserveAlpha);
+}
+
+void EncodeFilterPrimitive(
+    WireWriter& w, const svg::components::filter_primitive::Morphology& p) {
+  w.writeU8(static_cast<uint8_t>(FilterPrimitiveTag::kMorphology));
+  w.writeU8(static_cast<uint8_t>(p.op));
+  w.writeF64(p.radiusX);
+  w.writeF64(p.radiusY);
+}
+
+void EncodeFilterPrimitive(
+    WireWriter& w, const svg::components::filter_primitive::Tile&) {
+  w.writeU8(static_cast<uint8_t>(FilterPrimitiveTag::kTile));
+}
+
+void EncodeFilterPrimitive(
+    WireWriter& w, const svg::components::filter_primitive::Turbulence& p) {
+  w.writeU8(static_cast<uint8_t>(FilterPrimitiveTag::kTurbulence));
+  w.writeU8(static_cast<uint8_t>(p.type));
+  w.writeF64(p.baseFrequencyX);
+  w.writeF64(p.baseFrequencyY);
+  w.writeI32(p.numOctaves);
+  w.writeF64(p.seed);
+  w.writeBool(p.stitchTiles);
+}
+
+void EncodeFilterPrimitive(
+    WireWriter& w, const svg::components::filter_primitive::Image& p) {
+  w.writeU8(static_cast<uint8_t>(FilterPrimitiveTag::kImage));
+  w.writeString(std::string_view(p.href));
+  w.writeU8(static_cast<uint8_t>(p.preserveAspectRatio.align));
+  w.writeU8(static_cast<uint8_t>(p.preserveAspectRatio.meetOrSlice));
+  w.writeU32(static_cast<uint32_t>(p.imageData.size()));
+  w.writeBytes(p.imageData);
+  w.writeI32(p.imageWidth);
+  w.writeI32(p.imageHeight);
+  w.writeString(std::string_view(p.fragmentId));
+  w.writeBool(p.isFragmentReference);
+  EncodeVector2d(w, p.fragmentRegionTopLeft);
+}
+
+void EncodeFilterPrimitive(
+    WireWriter& w,
+    const svg::components::filter_primitive::DisplacementMap& p) {
+  w.writeU8(static_cast<uint8_t>(FilterPrimitiveTag::kDisplacementMap));
+  w.writeF64(p.scale);
+  w.writeU8(static_cast<uint8_t>(p.xChannelSelector));
+  w.writeU8(static_cast<uint8_t>(p.yChannelSelector));
+}
+
+void EncodeFilterPrimitive(
+    WireWriter& w,
+    const svg::components::filter_primitive::DiffuseLighting& p) {
+  w.writeU8(static_cast<uint8_t>(FilterPrimitiveTag::kDiffuseLighting));
+  w.writeF64(p.surfaceScale);
+  w.writeF64(p.diffuseConstant);
+  EncodeColor(w, p.lightingColor);
+  w.writeBool(p.light.has_value());
+  if (p.light) EncodeLightSource(w, *p.light);
+}
+
+void EncodeFilterPrimitive(
+    WireWriter& w,
+    const svg::components::filter_primitive::SpecularLighting& p) {
+  w.writeU8(static_cast<uint8_t>(FilterPrimitiveTag::kSpecularLighting));
+  w.writeF64(p.surfaceScale);
+  w.writeF64(p.specularConstant);
+  w.writeF64(p.specularExponent);
+  EncodeColor(w, p.lightingColor);
+  w.writeBool(p.light.has_value());
+  if (p.light) EncodeLightSource(w, *p.light);
+}
+
+// ---- Per-primitive decoders (dispatched by tag) ----
+
+bool DecodeFilterPrimitiveGaussianBlur(
+    WireReader& r, svg::components::FilterPrimitive& out) {
+  svg::components::filter_primitive::GaussianBlur p;
+  if (!r.readF64(p.stdDeviationX)) return false;
+  if (!r.readF64(p.stdDeviationY)) return false;
+  uint8_t em = 0;
+  if (!r.readU8(em)) return false;
+  if (em > static_cast<uint8_t>(
+               svg::components::filter_primitive::GaussianBlur::EdgeMode::Wrap)) {
+    r.fail();
+    return false;
+  }
+  p.edgeMode =
+      static_cast<svg::components::filter_primitive::GaussianBlur::EdgeMode>(em);
+  out = p;
+  return true;
+}
+
+bool DecodeFilterPrimitiveFlood(WireReader& r,
+                                svg::components::FilterPrimitive& out) {
+  svg::components::filter_primitive::Flood p;
+  if (!DecodeColor(r, p.floodColor)) return false;
+  if (!r.readF64(p.floodOpacity)) return false;
+  out = p;
+  return true;
+}
+
+bool DecodeFilterPrimitiveOffset(WireReader& r,
+                                 svg::components::FilterPrimitive& out) {
+  svg::components::filter_primitive::Offset p;
+  if (!r.readF64(p.dx)) return false;
+  if (!r.readF64(p.dy)) return false;
+  out = p;
+  return true;
+}
+
+bool DecodeFilterPrimitiveMerge(WireReader& r,
+                                svg::components::FilterPrimitive& out) {
+  out = svg::components::filter_primitive::Merge{};
+  return true;
+}
+
+bool DecodeFilterPrimitiveBlend(WireReader& r,
+                                svg::components::FilterPrimitive& out) {
+  uint8_t mode = 0;
+  if (!r.readU8(mode)) return false;
+  if (mode > static_cast<uint8_t>(
+                 svg::components::filter_primitive::Blend::Mode::Luminosity)) {
+    r.fail();
+    return false;
+  }
+  svg::components::filter_primitive::Blend p;
+  p.mode = static_cast<svg::components::filter_primitive::Blend::Mode>(mode);
+  out = p;
+  return true;
+}
+
+bool DecodeFilterPrimitiveComposite(WireReader& r,
+                                    svg::components::FilterPrimitive& out) {
+  uint8_t op = 0;
+  if (!r.readU8(op)) return false;
+  if (op > static_cast<uint8_t>(
+               svg::components::filter_primitive::Composite::Operator::Arithmetic)) {
+    r.fail();
+    return false;
+  }
+  svg::components::filter_primitive::Composite p;
+  p.op = static_cast<svg::components::filter_primitive::Composite::Operator>(op);
+  if (!r.readF64(p.k1)) return false;
+  if (!r.readF64(p.k2)) return false;
+  if (!r.readF64(p.k3)) return false;
+  if (!r.readF64(p.k4)) return false;
+  out = p;
+  return true;
+}
+
+bool DecodeFilterPrimitiveColorMatrix(WireReader& r,
+                                      svg::components::FilterPrimitive& out) {
+  uint8_t type = 0;
+  if (!r.readU8(type)) return false;
+  if (type > static_cast<uint8_t>(
+                 svg::components::filter_primitive::ColorMatrix::Type::LuminanceToAlpha)) {
+    r.fail();
+    return false;
+  }
+  svg::components::filter_primitive::ColorMatrix p;
+  p.type = static_cast<svg::components::filter_primitive::ColorMatrix::Type>(type);
+  uint32_t count = 0;
+  if (!r.readCount(count, kMaxColorMatrixValues)) return false;
+  p.values.reserve(count);
+  for (uint32_t i = 0; i < count; ++i) {
+    double v = 0;
+    if (!r.readF64(v)) return false;
+    p.values.push_back(v);
+  }
+  out = p;
+  return true;
+}
+
+bool DecodeFilterPrimitiveDropShadow(WireReader& r,
+                                     svg::components::FilterPrimitive& out) {
+  svg::components::filter_primitive::DropShadow p;
+  if (!r.readF64(p.dx)) return false;
+  if (!r.readF64(p.dy)) return false;
+  if (!r.readF64(p.stdDeviationX)) return false;
+  if (!r.readF64(p.stdDeviationY)) return false;
+  if (!DecodeColor(r, p.floodColor)) return false;
+  if (!r.readF64(p.floodOpacity)) return false;
+  out = p;
+  return true;
+}
+
+bool DecodeFilterPrimitiveComponentTransfer(
+    WireReader& r, svg::components::FilterPrimitive& out) {
+  svg::components::filter_primitive::ComponentTransfer p;
+  if (!DecodeTransferFunc(r, p.funcR)) return false;
+  if (!DecodeTransferFunc(r, p.funcG)) return false;
+  if (!DecodeTransferFunc(r, p.funcB)) return false;
+  if (!DecodeTransferFunc(r, p.funcA)) return false;
+  out = p;
+  return true;
+}
+
+bool DecodeFilterPrimitiveConvolveMatrix(
+    WireReader& r, svg::components::FilterPrimitive& out) {
+  svg::components::filter_primitive::ConvolveMatrix p;
+  if (!r.readI32(p.orderX)) return false;
+  if (!r.readI32(p.orderY)) return false;
+  uint32_t kernelCount = 0;
+  if (!r.readCount(kernelCount, kMaxConvolveKernelValues)) return false;
+  p.kernelMatrix.reserve(kernelCount);
+  for (uint32_t i = 0; i < kernelCount; ++i) {
+    double v = 0;
+    if (!r.readF64(v)) return false;
+    p.kernelMatrix.push_back(v);
+  }
+  bool hasDivisor = false;
+  if (!r.readBool(hasDivisor)) return false;
+  if (hasDivisor) {
+    double v = 0;
+    if (!r.readF64(v)) return false;
+    p.divisor = v;
+  }
+  if (!r.readF64(p.bias)) return false;
+  bool hasTargetX = false;
+  if (!r.readBool(hasTargetX)) return false;
+  if (hasTargetX) {
+    int32_t v = 0;
+    if (!r.readI32(v)) return false;
+    p.targetX = v;
+  }
+  bool hasTargetY = false;
+  if (!r.readBool(hasTargetY)) return false;
+  if (hasTargetY) {
+    int32_t v = 0;
+    if (!r.readI32(v)) return false;
+    p.targetY = v;
+  }
+  uint8_t em = 0;
+  if (!r.readU8(em)) return false;
+  if (em > static_cast<uint8_t>(
+               svg::components::filter_primitive::ConvolveMatrix::EdgeMode::None)) {
+    r.fail();
+    return false;
+  }
+  p.edgeMode =
+      static_cast<svg::components::filter_primitive::ConvolveMatrix::EdgeMode>(em);
+  if (!r.readBool(p.preserveAlpha)) return false;
+  out = p;
+  return true;
+}
+
+bool DecodeFilterPrimitiveMorphology(WireReader& r,
+                                     svg::components::FilterPrimitive& out) {
+  uint8_t op = 0;
+  if (!r.readU8(op)) return false;
+  if (op > static_cast<uint8_t>(
+               svg::components::filter_primitive::Morphology::Operator::Dilate)) {
+    r.fail();
+    return false;
+  }
+  svg::components::filter_primitive::Morphology p;
+  p.op = static_cast<svg::components::filter_primitive::Morphology::Operator>(op);
+  if (!r.readF64(p.radiusX)) return false;
+  if (!r.readF64(p.radiusY)) return false;
+  out = p;
+  return true;
+}
+
+bool DecodeFilterPrimitiveTile(WireReader& r,
+                               svg::components::FilterPrimitive& out) {
+  out = svg::components::filter_primitive::Tile{};
+  return true;
+}
+
+bool DecodeFilterPrimitiveTurbulence(WireReader& r,
+                                     svg::components::FilterPrimitive& out) {
+  uint8_t type = 0;
+  if (!r.readU8(type)) return false;
+  if (type > static_cast<uint8_t>(
+                 svg::components::filter_primitive::Turbulence::Type::Turbulence)) {
+    r.fail();
+    return false;
+  }
+  svg::components::filter_primitive::Turbulence p;
+  p.type = static_cast<svg::components::filter_primitive::Turbulence::Type>(type);
+  if (!r.readF64(p.baseFrequencyX)) return false;
+  if (!r.readF64(p.baseFrequencyY)) return false;
+  if (!r.readI32(p.numOctaves)) return false;
+  if (!r.readF64(p.seed)) return false;
+  if (!r.readBool(p.stitchTiles)) return false;
+  out = p;
+  return true;
+}
+
+bool DecodeFilterPrimitiveImage(WireReader& r,
+                                svg::components::FilterPrimitive& out) {
+  svg::components::filter_primitive::Image p;
+  std::string href;
+  if (!r.readString(href)) return false;
+  p.href = RcString(href);
+  uint8_t align = 0, mos = 0;
+  if (!r.readU8(align)) return false;
+  if (align > static_cast<uint8_t>(svg::PreserveAspectRatio::Align::XMaxYMax)) {
+    r.fail();
+    return false;
+  }
+  if (!r.readU8(mos)) return false;
+  if (mos > static_cast<uint8_t>(svg::PreserveAspectRatio::MeetOrSlice::Slice)) {
+    r.fail();
+    return false;
+  }
+  p.preserveAspectRatio.align =
+      static_cast<svg::PreserveAspectRatio::Align>(align);
+  p.preserveAspectRatio.meetOrSlice =
+      static_cast<svg::PreserveAspectRatio::MeetOrSlice>(mos);
+  uint32_t dataLen = 0;
+  if (!r.readCount(dataLen, kMaxImageDataBytes)) return false;
+  p.imageData.resize(dataLen);
+  if (dataLen > 0 && !r.readBytes(p.imageData)) return false;
+  if (!r.readI32(p.imageWidth)) return false;
+  if (!r.readI32(p.imageHeight)) return false;
+  std::string fragmentId;
+  if (!r.readString(fragmentId)) return false;
+  p.fragmentId = RcString(fragmentId);
+  if (!r.readBool(p.isFragmentReference)) return false;
+  if (!DecodeVector2d(r, p.fragmentRegionTopLeft)) return false;
+  out = p;
+  return true;
+}
+
+bool DecodeFilterPrimitiveDisplacementMap(
+    WireReader& r, svg::components::FilterPrimitive& out) {
+  svg::components::filter_primitive::DisplacementMap p;
+  if (!r.readF64(p.scale)) return false;
+  uint8_t xCh = 0, yCh = 0;
+  if (!r.readU8(xCh)) return false;
+  if (xCh > static_cast<uint8_t>(
+                svg::components::filter_primitive::DisplacementMap::Channel::A)) {
+    r.fail();
+    return false;
+  }
+  if (!r.readU8(yCh)) return false;
+  if (yCh > static_cast<uint8_t>(
+                svg::components::filter_primitive::DisplacementMap::Channel::A)) {
+    r.fail();
+    return false;
+  }
+  p.xChannelSelector =
+      static_cast<svg::components::filter_primitive::DisplacementMap::Channel>(xCh);
+  p.yChannelSelector =
+      static_cast<svg::components::filter_primitive::DisplacementMap::Channel>(yCh);
+  out = p;
+  return true;
+}
+
+bool DecodeFilterPrimitiveDiffuseLighting(
+    WireReader& r, svg::components::FilterPrimitive& out) {
+  svg::components::filter_primitive::DiffuseLighting p;
+  if (!r.readF64(p.surfaceScale)) return false;
+  if (!r.readF64(p.diffuseConstant)) return false;
+  if (!DecodeColor(r, p.lightingColor)) return false;
+  bool hasLight = false;
+  if (!r.readBool(hasLight)) return false;
+  if (hasLight) {
+    svg::components::filter_primitive::LightSource ls;
+    if (!DecodeLightSource(r, ls)) return false;
+    p.light = ls;
+  }
+  out = p;
+  return true;
+}
+
+bool DecodeFilterPrimitiveSpecularLighting(
+    WireReader& r, svg::components::FilterPrimitive& out) {
+  svg::components::filter_primitive::SpecularLighting p;
+  if (!r.readF64(p.surfaceScale)) return false;
+  if (!r.readF64(p.specularConstant)) return false;
+  if (!r.readF64(p.specularExponent)) return false;
+  if (!DecodeColor(r, p.lightingColor)) return false;
+  bool hasLight = false;
+  if (!r.readBool(hasLight)) return false;
+  if (hasLight) {
+    svg::components::filter_primitive::LightSource ls;
+    if (!DecodeLightSource(r, ls)) return false;
+    p.light = ls;
+  }
+  out = p;
+  return true;
+}
+
+bool DecodeFilterPrimitiveByTag(WireReader& r, uint8_t tag,
+                                svg::components::FilterPrimitive& out) {
+  switch (static_cast<FilterPrimitiveTag>(tag)) {
+    case FilterPrimitiveTag::kGaussianBlur:
+      return DecodeFilterPrimitiveGaussianBlur(r, out);
+    case FilterPrimitiveTag::kFlood:
+      return DecodeFilterPrimitiveFlood(r, out);
+    case FilterPrimitiveTag::kOffset:
+      return DecodeFilterPrimitiveOffset(r, out);
+    case FilterPrimitiveTag::kMerge:
+      return DecodeFilterPrimitiveMerge(r, out);
+    case FilterPrimitiveTag::kBlend:
+      return DecodeFilterPrimitiveBlend(r, out);
+    case FilterPrimitiveTag::kComposite:
+      return DecodeFilterPrimitiveComposite(r, out);
+    case FilterPrimitiveTag::kColorMatrix:
+      return DecodeFilterPrimitiveColorMatrix(r, out);
+    case FilterPrimitiveTag::kDropShadow:
+      return DecodeFilterPrimitiveDropShadow(r, out);
+    case FilterPrimitiveTag::kComponentTransfer:
+      return DecodeFilterPrimitiveComponentTransfer(r, out);
+    case FilterPrimitiveTag::kConvolveMatrix:
+      return DecodeFilterPrimitiveConvolveMatrix(r, out);
+    case FilterPrimitiveTag::kMorphology:
+      return DecodeFilterPrimitiveMorphology(r, out);
+    case FilterPrimitiveTag::kTile:
+      return DecodeFilterPrimitiveTile(r, out);
+    case FilterPrimitiveTag::kTurbulence:
+      return DecodeFilterPrimitiveTurbulence(r, out);
+    case FilterPrimitiveTag::kImage:
+      return DecodeFilterPrimitiveImage(r, out);
+    case FilterPrimitiveTag::kDisplacementMap:
+      return DecodeFilterPrimitiveDisplacementMap(r, out);
+    case FilterPrimitiveTag::kDiffuseLighting:
+      return DecodeFilterPrimitiveDiffuseLighting(r, out);
+    case FilterPrimitiveTag::kSpecularLighting:
+      return DecodeFilterPrimitiveSpecularLighting(r, out);
+    default:
+      r.fail();
+      return false;
+  }
+}
+
+void EncodeFilterNode(WireWriter& w,
+                      const svg::components::FilterNode& node) {
+  // Primitive (tag + fields).
+  std::visit([&](const auto& p) { EncodeFilterPrimitive(w, p); },
+             node.primitive);
+
+  // Inputs.
+  w.writeU32(static_cast<uint32_t>(node.inputs.size()));
+  for (const auto& input : node.inputs) {
+    EncodeFilterInput(w, input);
+  }
+
+  // Named result.
+  w.writeBool(node.result.has_value());
+  if (node.result) w.writeString(std::string_view(*node.result));
+
+  // Subregion bounds.
+  EncodeOptionalLenghdFilter(w, node.x);
+  EncodeOptionalLenghdFilter(w, node.y);
+  EncodeOptionalLenghdFilter(w, node.width);
+  EncodeOptionalLenghdFilter(w, node.height);
+
+  // Per-primitive color-interpolation-filters override.
+  w.writeBool(node.colorInterpolationFilters.has_value());
+  if (node.colorInterpolationFilters) {
+    w.writeU8(static_cast<uint8_t>(*node.colorInterpolationFilters));
+  }
+}
+
+bool DecodeFilterNode(WireReader& r, svg::components::FilterNode& out) {
+  // Primitive tag + fields.
+  uint8_t tag = 0;
+  if (!r.readU8(tag)) return false;
+  if (!DecodeFilterPrimitiveByTag(r, tag, out.primitive)) return false;
+
+  // Inputs.
+  uint32_t inputCount = 0;
+  if (!r.readCount(inputCount, kMaxFilterInputs)) return false;
+  out.inputs.clear();
+  out.inputs.reserve(inputCount);
+  for (uint32_t i = 0; i < inputCount; ++i) {
+    svg::components::FilterInput input;
+    if (!DecodeFilterInput(r, input)) return false;
+    out.inputs.push_back(std::move(input));
+  }
+
+  // Named result.
+  bool hasResult = false;
+  if (!r.readBool(hasResult)) return false;
+  if (hasResult) {
+    std::string result;
+    if (!r.readString(result)) return false;
+    out.result = RcString(result);
+  } else {
+    out.result.reset();
+  }
+
+  // Subregion bounds.
+  if (!DecodeOptionalLenghdFilter(r, out.x)) return false;
+  if (!DecodeOptionalLenghdFilter(r, out.y)) return false;
+  if (!DecodeOptionalLenghdFilter(r, out.width)) return false;
+  if (!DecodeOptionalLenghdFilter(r, out.height)) return false;
+
+  // Per-primitive color-interpolation-filters override.
+  bool hasCif = false;
+  if (!r.readBool(hasCif)) return false;
+  if (hasCif) {
+    uint8_t cif = 0;
+    if (!r.readU8(cif)) return false;
+    out.colorInterpolationFilters =
+        static_cast<svg::ColorInterpolationFilters>(cif);
+  } else {
+    out.colorInterpolationFilters.reset();
+  }
+  return true;
+}
+
+}  // namespace
+
+void EncodeFilterGraph(WireWriter& w, const svg::components::FilterGraph& g) {
+  // Encode the full primitive chain.
+  w.writeU32(static_cast<uint32_t>(g.nodes.size()));
+  for (const auto& node : g.nodes) {
+    EncodeFilterNode(w, node);
+  }
+  w.writeU8(static_cast<uint8_t>(g.colorInterpolationFilters));
+  w.writeU8(static_cast<uint8_t>(g.primitiveUnits));
+  w.writeBool(g.elementBoundingBox.has_value());
+  if (g.elementBoundingBox) EncodeBox2d(w, *g.elementBoundingBox);
+  w.writeBool(g.filterRegion.has_value());
+  if (g.filterRegion) EncodeBox2d(w, *g.filterRegion);
+  EncodeVector2d(w, g.userToPixelScale);
+}
+
+bool DecodeFilterGraph(WireReader& r, svg::components::FilterGraph& out) {
+  uint32_t nodeCount = 0;
+  if (!r.readCount(nodeCount, kMaxFilterNodes)) return false;
+  out.nodes.clear();
+  out.nodes.reserve(nodeCount);
+  for (uint32_t i = 0; i < nodeCount; ++i) {
+    svg::components::FilterNode node;
+    node.primitive = svg::components::filter_primitive::GaussianBlur{};
+    if (!DecodeFilterNode(r, node)) return false;
+    out.nodes.push_back(std::move(node));
+  }
+  uint8_t cif = 0;
+  if (!r.readU8(cif)) return false;
+  out.colorInterpolationFilters =
+      static_cast<svg::ColorInterpolationFilters>(cif);
+  uint8_t pu = 0;
+  if (!r.readU8(pu)) return false;
+  out.primitiveUnits = static_cast<svg::PrimitiveUnits>(pu);
+  bool hasEbb = false;
+  if (!r.readBool(hasEbb)) return false;
+  if (hasEbb) {
+    Box2d box;
+    if (!DecodeBox2d(r, box)) return false;
+    out.elementBoundingBox = box;
+  } else {
+    out.elementBoundingBox.reset();
+  }
+  bool hasFr = false;
+  if (!r.readBool(hasFr)) return false;
+  if (hasFr) {
+    Box2d box;
+    if (!DecodeBox2d(r, box)) return false;
+    out.filterRegion = box;
+  } else {
+    out.filterRegion.reset();
+  }
+  if (!DecodeVector2d(r, out.userToPixelScale)) return false;
+  return true;
+}
+
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/SandboxCodecs.h
+++ b/donner/editor/sandbox/SandboxCodecs.h
@@ -1,0 +1,227 @@
+#pragma once
+/// @file
+///
+/// Encoders and decoders for Donner value types that cross the sandbox wire
+/// boundary. Every `Encode*` writes its type into a `WireWriter`; every
+/// `Decode*` reads from a `WireReader` and sets the reader's failure flag on
+/// any problem (truncation, invalid variant tag, out-of-range enum, length
+/// cap). Decoders never throw and never crash on adversarial input.
+///
+/// Scope for S2: paths, transforms, boxes, colors, stroke params, solid paint
+/// servers, simple clips. Gradients, patterns, filters, masks, text, and
+/// images are out of scope and the `SerializingRenderer` emits a
+/// `kUnsupported` message instead of attempting to encode them.
+
+#include <optional>
+#include <vector>
+
+#include "donner/base/Box.h"
+#include "donner/base/FillRule.h"
+#include "donner/base/Length.h"
+#include "donner/base/Path.h"
+#include "donner/base/Transform.h"
+#include "donner/base/Vector2.h"
+#include "donner/css/Color.h"
+#include "donner/css/FontFace.h"
+#include "donner/editor/sandbox/Wire.h"
+#include "donner/svg/components/RenderingInstanceComponent.h"
+#include "donner/svg/components/text/ComputedTextComponent.h"
+#include "donner/svg/core/Gradient.h"
+#include "donner/svg/core/MixBlendMode.h"
+#include "donner/svg/core/Stroke.h"
+#include "donner/svg/properties/PaintServer.h"
+#include "donner/svg/renderer/RendererInterface.h"
+#include "donner/svg/renderer/StrokeParams.h"
+#include "donner/svg/resources/ImageResource.h"
+
+namespace donner::editor::sandbox {
+
+/// @name Primitive Donner types
+/// @{
+void EncodeVector2d(WireWriter& w, const Vector2d& v);
+[[nodiscard]] bool DecodeVector2d(WireReader& r, Vector2d& out);
+
+void EncodeVector2i(WireWriter& w, const Vector2i& v);
+[[nodiscard]] bool DecodeVector2i(WireReader& r, Vector2i& out);
+
+void EncodeTransform2d(WireWriter& w, const Transform2d& t);
+[[nodiscard]] bool DecodeTransform2d(WireReader& r, Transform2d& out);
+
+void EncodeBox2d(WireWriter& w, const Box2d& b);
+[[nodiscard]] bool DecodeBox2d(WireReader& r, Box2d& out);
+
+void EncodeRgba(WireWriter& w, const css::RGBA& rgba);
+[[nodiscard]] bool DecodeRgba(WireReader& r, css::RGBA& out);
+
+/// Encodes a `css::Color`. HSLA and CurrentColor are not fully faithful in
+/// S2 — HSLA is converted to RGBA, and CurrentColor is encoded with a
+/// fallback RGBA so the replayed paint doesn't resolve to a surprise value.
+void EncodeColor(WireWriter& w, const css::Color& color);
+[[nodiscard]] bool DecodeColor(WireReader& r, css::Color& out);
+/// @}
+
+/// @name Enums (encoded as a single `u8` byte each)
+/// @{
+void EncodeFillRule(WireWriter& w, FillRule v);
+[[nodiscard]] bool DecodeFillRule(WireReader& r, FillRule& out);
+
+void EncodeMixBlendMode(WireWriter& w, svg::MixBlendMode v);
+[[nodiscard]] bool DecodeMixBlendMode(WireReader& r, svg::MixBlendMode& out);
+
+void EncodeStrokeLinecap(WireWriter& w, svg::StrokeLinecap v);
+[[nodiscard]] bool DecodeStrokeLinecap(WireReader& r, svg::StrokeLinecap& out);
+
+void EncodeStrokeLinejoin(WireWriter& w, svg::StrokeLinejoin v);
+[[nodiscard]] bool DecodeStrokeLinejoin(WireReader& r, svg::StrokeLinejoin& out);
+/// @}
+
+/// @name Path and stroke state
+/// @{
+
+/// Encodes a `Path` as: `u32 commandCount`, then each command as
+/// `u8 verb, u32 pointIndex`, then `u32 pointCount`, then `pointCount *
+/// Vector2d`. `isInternal` is not preserved — S2 paths come straight from the
+/// driver and the flag is only used for marker placement, which happens
+/// before this encoder sees the path.
+void EncodePath(WireWriter& w, const Path& path);
+[[nodiscard]] bool DecodePath(WireReader& r, Path& out);
+
+void EncodeStrokeParams(WireWriter& w, const svg::StrokeParams& s);
+[[nodiscard]] bool DecodeStrokeParams(WireReader& r, svg::StrokeParams& out);
+
+void EncodePathShape(WireWriter& w, const svg::PathShape& p);
+[[nodiscard]] bool DecodePathShape(WireReader& r, svg::PathShape& out);
+/// @}
+
+/// @name Paint and clip
+/// @{
+
+/// Self-contained gradient payload — everything needed to reconstruct a
+/// linear or radial gradient on the replay side without registry lookups.
+/// This is the serializer's side of WIRE.5: it flattens a
+/// `PaintResolvedReference` to a gradient entity into plain values that
+/// cross the wire, then the replayer materializes them onto a fresh ECS
+/// entity via `GradientReplayRegistry`.
+struct WireGradient {
+  enum class Kind : uint8_t { kLinear = 0, kRadial = 1 };
+  Kind kind = Kind::kLinear;
+
+  // Common fields (apply to both linear and radial).
+  svg::GradientUnits units = svg::GradientUnits::Default;
+  svg::GradientSpreadMethod spreadMethod = svg::GradientSpreadMethod::Default;
+  std::vector<svg::GradientStop> stops;
+
+  // Linear fields — used when kind == kLinear.
+  Lengthd x1;
+  Lengthd y1;
+  Lengthd x2;
+  Lengthd y2;
+
+  // Radial fields — used when kind == kRadial.
+  Lengthd cx;
+  Lengthd cy;
+  Lengthd r;
+  std::optional<Lengthd> fx;
+  std::optional<Lengthd> fy;
+  Lengthd fr;
+
+  // Fallback color carried from the original PaintResolvedReference.
+  std::optional<css::Color> fallback;
+};
+
+/// Encodes a `Lengthd` as `f64 value, u8 unit`.
+void EncodeLengthd(WireWriter& w, const Lengthd& v);
+[[nodiscard]] bool DecodeLengthd(WireReader& r, Lengthd& out);
+
+/// Encodes a `WireGradient` in full. The gradient kind tag is written first
+/// so a truncated stream can still be recognized as malformed early.
+void EncodeWireGradient(WireWriter& w, const WireGradient& g);
+[[nodiscard]] bool DecodeWireGradient(WireReader& r, WireGradient& out);
+
+/// Encodes a `ResolvedPaintServer` variant. Supports:
+///   - `PaintServer::None`
+///   - `PaintServer::Solid`
+///   - `PaintResolvedReference` carrying a **linear or radial gradient**
+///     (flattened to a `WireGradient`).
+/// Pattern paint servers and other unresolved references still fall through
+/// as stubs that decode to `None`. That's a separate milestone — see
+/// `docs/design_docs/editor_sandbox.md`.
+void EncodeResolvedPaintServer(WireWriter& w, const svg::components::ResolvedPaintServer& p);
+
+/// Decodes a `ResolvedPaintServer`. When the wire carries a gradient tag
+/// the fully-decoded `WireGradient` is stashed in `*outPendingGradient`
+/// (if non-null) and `out` is set to `PaintServer::None`. The caller is
+/// expected to materialize the gradient via a replay-side ECS registry
+/// before forwarding `out` to the backend. If `outPendingGradient` is null,
+/// gradients silently decode as `None`.
+[[nodiscard]] bool DecodeResolvedPaintServer(
+    WireReader& r, svg::components::ResolvedPaintServer& out,
+    std::optional<WireGradient>* outPendingGradient = nullptr);
+
+void EncodePaintParams(WireWriter& w, const svg::PaintParams& p);
+
+/// Decodes a `PaintParams`. Fill and stroke gradients (if any) are stashed
+/// in the corresponding out-parameters rather than being flattened into the
+/// result's `ResolvedPaintServer` variants — see `DecodeResolvedPaintServer`.
+[[nodiscard]] bool DecodePaintParams(
+    WireReader& r, svg::PaintParams& out,
+    std::optional<WireGradient>* outFillGradient = nullptr,
+    std::optional<WireGradient>* outStrokeGradient = nullptr);
+
+/// Encodes the subset of `ResolvedClip` we support in S2: rect + paths +
+/// unit-transform. The optional mask is always encoded as "absent" — masks
+/// cross the wire as `kUnsupported` from higher up in the caller chain.
+void EncodeResolvedClip(WireWriter& w, const svg::ResolvedClip& c);
+[[nodiscard]] bool DecodeResolvedClip(WireReader& r, svg::ResolvedClip& out);
+/// @}
+
+/// @name Misc
+/// @{
+void EncodeRenderViewport(WireWriter& w, const svg::RenderViewport& v);
+[[nodiscard]] bool DecodeRenderViewport(WireReader& r, svg::RenderViewport& out);
+
+void EncodeImageParams(WireWriter& w, const svg::ImageParams& p);
+[[nodiscard]] bool DecodeImageParams(WireReader& r, svg::ImageParams& out);
+
+/// Encodes an `ImageResource` as: `u32 width, u32 height, u32 byteLength,
+/// u8[byteLength]`. Bytes are stored RGBA-straight (the same format
+/// `RendererInterface::drawImage` expects).
+void EncodeImageResource(WireWriter& w, const svg::ImageResource& img);
+[[nodiscard]] bool DecodeImageResource(WireReader& r, svg::ImageResource& out);
+
+/// Encodes a single `css::FontFace` (family name, weight/style/stretch,
+/// and the source list including inline font data blobs).
+void EncodeFontFace(WireWriter& w, const css::FontFace& face);
+
+/// Decodes a single `css::FontFace`. Returns false on any parse failure.
+[[nodiscard]] bool DecodeFontFace(WireReader& r, css::FontFace& out);
+
+/// Encodes a `TextParams` struct including `fontFaces` with full inline
+/// font data. Up to 256 font faces are supported.
+void EncodeTextParams(WireWriter& w, const svg::TextParams& p);
+
+/// Decodes a `TextParams`. The decoded font faces are stored into
+/// `outFontFaces` (if non-null) so the caller can keep the backing
+/// storage alive for the `fontFaces` span. When `outFontFaces` is
+/// provided and non-empty after decode, `out.fontFaces` is set to
+/// reference it.
+[[nodiscard]] bool DecodeTextParams(WireReader& r, svg::TextParams& out,
+                                    std::vector<css::FontFace>* outFontFaces = nullptr);
+
+/// Encodes a `ComputedTextComponent` (vector of TextSpan, each carrying
+/// text content, positioning lists, paint servers, font style, etc.).
+void EncodeComputedTextComponent(WireWriter& w,
+                                 const svg::components::ComputedTextComponent& text);
+[[nodiscard]] bool DecodeComputedTextComponent(
+    WireReader& r, svg::components::ComputedTextComponent& out);
+
+/// Encodes a `FilterGraph` as metadata only: 0 nodes (transparent
+/// pass-through), colorInterpolationFilters, primitiveUnits,
+/// elementBoundingBox, filterRegion, userToPixelScale. The full primitive
+/// chain is deferred to a follow-up milestone — the pass-through stub
+/// preserves layout without producing visual effects.
+void EncodeFilterGraph(WireWriter& w, const svg::components::FilterGraph& g);
+[[nodiscard]] bool DecodeFilterGraph(WireReader& r, svg::components::FilterGraph& out);
+/// @}
+
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/SandboxHardening.cc
+++ b/donner/editor/sandbox/SandboxHardening.cc
@@ -1,0 +1,310 @@
+#include "donner/editor/sandbox/SandboxHardening.h"
+
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <sys/resource.h>
+#include <unistd.h>
+
+#if defined(__linux__)
+#include <linux/audit.h>
+#include <linux/filter.h>
+#include <linux/seccomp.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+
+#include <array>
+#include <cstddef>
+#endif
+
+namespace donner::editor::sandbox {
+
+namespace {
+
+bool SetRlimit(int resource, rlim_t value, std::string& err) {
+  rlimit r;
+  r.rlim_cur = value;
+  r.rlim_max = value;
+  if (::setrlimit(resource, &r) != 0) {
+    err = std::strerror(errno);
+    return false;
+  }
+  return true;
+}
+
+/// Close all file descriptors strictly greater than FD 2 (stderr). Uses
+/// the Linux-specific `close_range` syscall when available; falls back to
+/// an explicit loop that uses `sysconf(_SC_OPEN_MAX)` as an upper bound.
+/// Either path is best-effort — an already-closed FD is fine.
+bool CloseFdsAboveStderr() {
+#if defined(__linux__) && defined(SYS_close_range)
+  // Close FDs [3, uint32_max) in one syscall. Returns 0 on success.
+  const long rc = ::syscall(SYS_close_range, 3u, ~0u, 0u);
+  if (rc == 0) return true;
+  if (errno != ENOSYS) {
+    // close_range is present but failed for some reason — fall through to
+    // the manual sweep rather than reporting an error, since individual
+    // close() calls are more forgiving.
+  }
+#endif
+
+  long maxFd = ::sysconf(_SC_OPEN_MAX);
+  if (maxFd <= 0) maxFd = 1024;
+  for (long fd = 3; fd < maxFd; ++fd) {
+    // Ignore EBADF — "not open" is the outcome we want anyway.
+    (void)::close(static_cast<int>(fd));
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// seccomp-bpf syscall allowlist (Linux only)
+// ---------------------------------------------------------------------------
+#if defined(__linux__)
+
+// Determine the expected audit architecture at compile time.
+#if defined(__aarch64__)
+#define DONNER_SECCOMP_ARCH AUDIT_ARCH_AARCH64
+#elif defined(__x86_64__)
+#define DONNER_SECCOMP_ARCH AUDIT_ARCH_X86_64
+#else
+// Unsupported architecture — InstallSeccompFilter will be a no-op.
+#define DONNER_SECCOMP_ARCH 0
+#endif
+
+/// Installs a seccomp-bpf filter that allows only the syscalls the parser
+/// child needs. Disallowed syscalls return -EACCES (fail-open mode for
+/// initial deployment; to be tightened to SECCOMP_RET_KILL_PROCESS once the
+/// allowlist is proven stable).
+///
+/// Returns true on success, false if prctl/seccomp setup failed.
+bool InstallSeccompFilter() {
+#if DONNER_SECCOMP_ARCH == 0
+  // Architecture not supported — silently skip.
+  return true;
+#else
+  // PR_SET_NO_NEW_PRIVS is required before installing a seccomp filter
+  // without CAP_SYS_ADMIN.
+  if (::prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0) {
+    return false;
+  }
+
+  // The syscall allowlist. Each entry is a __NR_* constant. The BPF program
+  // is generated from this table: for each entry, emit a JEQ that jumps to
+  // ALLOW if the syscall number matches, otherwise falls through to the
+  // next check. After all checks, the default action is SECCOMP_RET_ERRNO.
+  //
+  // Architecture-specific notes:
+  //   - aarch64 has no __NR_fstat; glibc uses __NR_newfstatat instead.
+  //   - x86_64 has both __NR_fstat and __NR_newfstatat.
+  static constexpr int kAllowedSyscalls[] = {
+      // I/O
+      __NR_read,
+      __NR_write,
+      __NR_close,
+#if defined(__NR_fstat)
+      __NR_fstat,
+#endif
+#if defined(__NR_newfstatat)
+      __NR_newfstatat,
+#endif
+      __NR_lseek,
+
+      // Memory management
+      __NR_brk,
+      __NR_mmap,
+      __NR_munmap,
+      __NR_mremap,
+      __NR_mprotect,
+      __NR_madvise,
+
+      // Threading / signals
+      __NR_futex,
+      __NR_rt_sigaction,
+      __NR_rt_sigprocmask,
+      __NR_rt_sigreturn,
+
+      // Process exit
+      __NR_exit,
+      __NR_exit_group,
+
+      // Information
+      __NR_getpid,
+      __NR_gettid,
+      __NR_clock_gettime,
+      __NR_getrandom,
+
+      // Resource limits (needed for prlimit64 self-query)
+      __NR_prlimit64,
+
+      // glibc startup / TLS
+      __NR_set_tid_address,
+      __NR_set_robust_list,
+      __NR_rseq,
+  };
+
+  static constexpr size_t kNumAllowed =
+      sizeof(kAllowedSyscalls) / sizeof(kAllowedSyscalls[0]);
+
+  // BPF program layout:
+  //   [0]   Load arch from seccomp_data
+  //   [1]   JEQ arch -> [3], else [2]
+  //   [2]   KILL_PROCESS (wrong architecture)
+  //   [3]   Load syscall number from seccomp_data
+  //   [4..4+2*N-1]  For each allowed syscall:
+  //           JEQ __NR_xxx -> ALLOW (next instruction)
+  //           RET ALLOW
+  //         (the JEQ skips 0 instructions on match to hit the RET ALLOW
+  //          immediately following, or skips 1 to fall through to the next
+  //          JEQ pair)
+  //   [4+2*N]  Default: RET ERRNO(EACCES)
+  //
+  // Total instructions: 4 + 2*N + 1 = 5 + 2*N
+
+  static constexpr size_t kFilterLen = 5 + 2 * kNumAllowed;
+
+  // Build the filter program. We use a std::array so the size is known at
+  // compile time and we avoid VLA or dynamic allocation.
+  std::array<struct sock_filter, kFilterLen> filter{};
+  size_t idx = 0;
+
+  // [0] Load architecture field from seccomp_data.
+  filter[idx++] = BPF_STMT(BPF_LD | BPF_W | BPF_ABS,
+                            offsetof(struct seccomp_data, arch));
+
+  // [1] Check architecture matches expected. Skip next instruction if match.
+  filter[idx++] = BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, DONNER_SECCOMP_ARCH,
+                            1, 0);
+
+  // [2] Architecture mismatch: kill the process.
+  filter[idx++] = BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_KILL_PROCESS);
+
+  // [3] Load syscall number from seccomp_data.
+  filter[idx++] = BPF_STMT(BPF_LD | BPF_W | BPF_ABS,
+                            offsetof(struct seccomp_data, nr));
+
+  // [4..4+2*N-1] For each allowed syscall, emit a JEQ + RET ALLOW pair.
+  for (size_t i = 0; i < kNumAllowed; ++i) {
+    // JEQ: if syscall == kAllowedSyscalls[i], jump to next instruction
+    // (jt=0 means skip 0, landing on the RET ALLOW); otherwise skip 1
+    // to jump over the RET ALLOW to the next JEQ pair.
+    filter[idx++] = BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K,
+                              static_cast<__u32>(kAllowedSyscalls[i]), 0, 1);
+    filter[idx++] = BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW);
+  }
+
+  // [4+2*N] Default deny: return -EACCES instead of killing, so we can
+  // detect false positives during initial deployment.
+  filter[idx++] = BPF_STMT(BPF_RET | BPF_K,
+                            SECCOMP_RET_ERRNO | (EACCES & SECCOMP_RET_DATA));
+
+  struct sock_fprog prog {};
+  prog.len = static_cast<unsigned short>(idx);
+  prog.filter = filter.data();
+
+  return ::prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &prog) == 0;
+#endif  // DONNER_SECCOMP_ARCH != 0
+}
+
+#endif  // defined(__linux__)
+
+void LogSummary(const HardeningOptions& options) {
+  // Keep this single-line and stable — tests grep for the "sandbox
+  // hardening:" prefix. Anything on stderr is captured by the host as
+  // diagnostics and surfaced through `RenderResult::diagnostics`.
+  std::fprintf(
+      stderr,
+      "sandbox hardening: as=%zu cpu=%u fsize=%zu nofile=%u chdir=%d fdsweep=%d seccomp=%d\n",
+      options.addressSpaceBytes, options.cpuSeconds, options.maxFileBytes,
+      options.maxOpenFiles, options.chdirRoot ? 1 : 0,
+      options.closeExtraFds ? 1 : 0, options.installSeccompFilter ? 1 : 0);
+}
+
+}  // namespace
+
+HardeningResult ApplyHardening(const HardeningOptions& options) {
+  HardeningResult result;
+
+  if (options.requireSandboxEnv) {
+    const char* marker = std::getenv("DONNER_SANDBOX");
+    if (marker == nullptr || std::strcmp(marker, "1") != 0) {
+      result.status = HardeningStatus::kMissingSandboxEnv;
+      result.message =
+          "refusing to run without DONNER_SANDBOX=1 — this binary must be "
+          "launched via SandboxHost, not executed directly";
+      return result;
+    }
+  }
+
+  if (options.chdirRoot) {
+    if (::chdir("/") != 0) {
+      result.status = HardeningStatus::kChdirFailed;
+      result.message = std::string("chdir(\"/\"): ") + std::strerror(errno);
+      return result;
+    }
+  }
+
+  // Close inherited FDs BEFORE installing RLIMIT_NOFILE — the NOFILE cap
+  // lowers the ceiling on future opens but doesn't retroactively close
+  // already-open descriptors.
+  if (options.closeExtraFds) {
+    if (!CloseFdsAboveStderr()) {
+      result.status = HardeningStatus::kCloseFdsFailed;
+      result.message = "FD sweep failed";
+      return result;
+    }
+  }
+
+  std::string errMessage;
+  if (options.addressSpaceBytes > 0) {
+    if (!SetRlimit(RLIMIT_AS,
+                   static_cast<rlim_t>(options.addressSpaceBytes), errMessage)) {
+      result.status = HardeningStatus::kResourceLimitFailed;
+      result.message = "RLIMIT_AS: " + errMessage;
+      return result;
+    }
+  }
+  if (options.cpuSeconds > 0) {
+    if (!SetRlimit(RLIMIT_CPU, static_cast<rlim_t>(options.cpuSeconds), errMessage)) {
+      result.status = HardeningStatus::kResourceLimitFailed;
+      result.message = "RLIMIT_CPU: " + errMessage;
+      return result;
+    }
+  }
+  if (!SetRlimit(RLIMIT_FSIZE, static_cast<rlim_t>(options.maxFileBytes),
+                 errMessage)) {
+    result.status = HardeningStatus::kResourceLimitFailed;
+    result.message = "RLIMIT_FSIZE: " + errMessage;
+    return result;
+  }
+  if (options.maxOpenFiles > 0) {
+    if (!SetRlimit(RLIMIT_NOFILE, static_cast<rlim_t>(options.maxOpenFiles),
+                   errMessage)) {
+      result.status = HardeningStatus::kResourceLimitFailed;
+      result.message = "RLIMIT_NOFILE: " + errMessage;
+      return result;
+    }
+  }
+
+  // Install the seccomp-bpf filter LAST. All preceding setup steps
+  // (chdir, FD sweep, rlimits) may need syscalls that the filter would
+  // deny, so the filter must not be active until setup is complete.
+#if defined(__linux__)
+  if (options.installSeccompFilter) {
+    if (!InstallSeccompFilter()) {
+      result.status = HardeningStatus::kSeccompFailed;
+      result.message = std::string("seccomp-bpf installation failed: ") + std::strerror(errno);
+      return result;
+    }
+  }
+#endif
+
+  if (options.logSummaryToStderr) {
+    LogSummary(options);
+  }
+
+  return result;
+}
+
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/SandboxHardening.cc
+++ b/donner/editor/sandbox/SandboxHardening.cc
@@ -142,6 +142,39 @@ bool InstallSeccompFilter() {
       __NR_set_tid_address,
       __NR_set_robust_list,
       __NR_rseq,
+
+      // x86_64-specific: arch_prctl is used by glibc for TLS/FS base setup.
+      // Not present on aarch64.
+#if defined(__NR_arch_prctl)
+      __NR_arch_prctl,
+#endif
+      // x86_64 glibc may use access/openat/stat during CRT init (locale,
+      // NSS) even after our FD sweep. Allow them so the child doesn't get
+      // stuck during early init on CI runners.
+#if defined(__NR_access)
+      __NR_access,
+#endif
+#if defined(__NR_openat)
+      __NR_openat,
+#endif
+#if defined(__NR_stat)
+      __NR_stat,
+#endif
+      // poll/ppoll needed by some glibc I/O paths (e.g. stdio locking).
+#if defined(__NR_poll)
+      __NR_poll,
+#endif
+#if defined(__NR_ppoll)
+      __NR_ppoll,
+#endif
+      // ioctl(TIOCGWINSZ) may be called by glibc on stderr.
+#if defined(__NR_ioctl)
+      __NR_ioctl,
+#endif
+      // sched_getaffinity used by some allocators for arena sizing.
+#if defined(__NR_sched_getaffinity)
+      __NR_sched_getaffinity,
+#endif
   };
 
   static constexpr size_t kNumAllowed =

--- a/donner/editor/sandbox/SandboxHardening.h
+++ b/donner/editor/sandbox/SandboxHardening.h
@@ -1,0 +1,109 @@
+#pragma once
+/// @file
+///
+/// Defense-in-depth hardening applied inside the sandbox child process
+/// immediately after startup, before it reads any untrusted input. See
+/// docs/design_docs/editor_sandbox.md §"Milestone S6".
+///
+/// S6.1 (this file) ships the portable hardening that works on Linux and
+/// macOS without extra dependencies:
+///
+///   - **Environment gate**: the child refuses to run unless
+///     `DONNER_SANDBOX=1` is set, so accidental direct execution (e.g., a
+///     developer running the binary by hand to reproduce a crash) fails
+///     loudly rather than silently behaving like a sandboxed child.
+///   - **`chdir("/")`**: strips the child's relative-path authority so a
+///     bug that tries to open "foo.txt" can't hit a file the host was in
+///     the middle of editing.
+///   - **FD sweep**: closes every inherited file descriptor above stderr.
+///     Prevents the child from accidentally holding a writable FD to the
+///     host's terminal, log file, or runfiles tree.
+///   - **`setrlimit` caps**: `RLIMIT_AS` (address space), `RLIMIT_CPU`
+///     (wall CPU seconds), `RLIMIT_FSIZE` (regular-file writes), and
+///     `RLIMIT_NOFILE` (max open files). A parser OOM or infinite-loop
+///     pathological SVG is bounded at the kernel level, not relying on
+///     host-side watchdogs.
+///
+/// S6.2 (follow-up): `seccomp-bpf` syscall allowlist on Linux,
+/// `sandbox_init` deny-all profile on macOS, and optional per-UID
+/// isolation. Those are intentionally out of scope for this milestone —
+/// they carry real risk of breaking the child in architecture-specific
+/// ways, and landing them behind unit tests needs more than a session's
+/// worth of iteration.
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace donner::editor::sandbox {
+
+/// Knobs for which hardening measures to apply. Defaults match the "strict
+/// production sandbox child" profile the design doc calls out. Tests and
+/// developer tools can relax individual measures — e.g., setting
+/// `requireSandboxEnv = false` makes the child runnable by hand under a
+/// debugger.
+struct HardeningOptions {
+  /// Verify that `DONNER_SANDBOX=1` is set in the environment. The child
+  /// refuses to run otherwise. Set to `false` only for ad-hoc developer
+  /// debugging — the `SandboxHost` always sets this in production.
+  bool requireSandboxEnv = true;
+
+  /// `RLIMIT_AS` cap in bytes. 0 means "leave unset". Default 1 GiB —
+  /// large enough for any real SVG the parser might touch, small enough
+  /// that a runaway allocation is caught at the kernel boundary.
+  std::size_t addressSpaceBytes = 1024uLL * 1024uLL * 1024uLL;
+
+  /// `RLIMIT_CPU` cap in wall seconds. 0 = unset. Default 30 s.
+  unsigned int cpuSeconds = 30;
+
+  /// `RLIMIT_FSIZE` cap in bytes. 0 means "no file writes allowed" — pipe
+  /// writes (stdout) are unaffected because pipes are not regular files.
+  std::size_t maxFileBytes = 0;
+
+  /// `RLIMIT_NOFILE` cap. Default 16 (stdin/stdout/stderr plus headroom
+  /// for any internal FDs glibc may open transiently).
+  unsigned int maxOpenFiles = 16;
+
+  /// Change working directory to `/` so relative paths can't escape.
+  bool chdirRoot = true;
+
+  /// Close all inherited file descriptors above stderr (FD 2) before
+  /// reading any untrusted input.
+  bool closeExtraFds = true;
+
+  /// Emit a single-line summary of the applied profile to stderr. Useful
+  /// for tests (which grep for the marker) and for debugging.
+  bool logSummaryToStderr = true;
+
+  /// Install a seccomp-bpf syscall allowlist (Linux only). Denied syscalls
+  /// return -EACCES in the current "fail-open" mode; future hardening will
+  /// switch to SECCOMP_RET_KILL_PROCESS. On non-Linux platforms this field
+  /// is silently ignored.
+  bool installSeccompFilter = true;
+};
+
+/// Classifies the outcome of `ApplyHardening`. On any non-kOk status the
+/// child should exit with a usage error — hardening is all-or-nothing.
+enum class HardeningStatus {
+  kOk,                    ///< Every requested measure took effect.
+  kMissingSandboxEnv,     ///< DONNER_SANDBOX was not set to 1.
+  kChdirFailed,           ///< chdir("/") returned non-zero.
+  kCloseFdsFailed,        ///< FD sweep failed in a way we can't recover from.
+  kResourceLimitFailed,   ///< One of the setrlimit calls failed.
+  kSeccompFailed,         ///< seccomp-bpf filter installation failed.
+};
+
+struct HardeningResult {
+  HardeningStatus status = HardeningStatus::kOk;
+  /// Single-line diagnostic, suitable for stderr. Empty on success.
+  std::string message;
+};
+
+/// Applies the requested hardening measures in order. Intended to be
+/// called exactly once at the start of the child's `main()`, after argv
+/// parsing but before reading stdin. Safe to call from multi-threaded
+/// code in theory, but the child is single-threaded by design and the
+/// caller is expected to run this before spawning any workers.
+HardeningResult ApplyHardening(const HardeningOptions& options = {});
+
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/SandboxHost.cc
+++ b/donner/editor/sandbox/SandboxHost.cc
@@ -1,0 +1,339 @@
+#include "donner/editor/sandbox/SandboxHost.h"
+
+#include <fcntl.h>
+#include <poll.h>
+#include <signal.h>
+#include <spawn.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <array>
+#include <atomic>
+#include <cerrno>
+#include <csignal>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "donner/editor/sandbox/ReplayingRenderer.h"
+#include "donner/editor/sandbox/SandboxProtocol.h"
+#include "donner/svg/renderer/RendererImageIO.h"
+#include "donner/svg/renderer/RendererTinySkia.h"
+
+extern "C" char** environ;  // POSIX, not declared in <unistd.h> on glibc.
+
+namespace donner::editor::sandbox {
+
+namespace {
+
+/// Ensures SIGPIPE doesn't terminate the host if the child exits before
+/// draining stdin. We want `write()` to return `EPIPE` instead. Installed
+/// once per process; the static guard makes repeated construction cheap.
+void IgnoreSigpipeOnce() {
+  static const bool kInstalled = [] {
+    struct sigaction sa{};
+    sa.sa_handler = SIG_IGN;
+    sigemptyset(&sa.sa_mask);
+    (void)::sigaction(SIGPIPE, &sa, nullptr);
+    return true;
+  }();
+  (void)kInstalled;
+}
+
+SandboxStatus ClassifyExit(int rawStatus, int& outExit) {
+  if (WIFEXITED(rawStatus)) {
+    const int code = WEXITSTATUS(rawStatus);
+    outExit = code;
+    switch (code) {
+      case kExitOk:
+        return SandboxStatus::kOk;
+      case kExitUsageError:
+        return SandboxStatus::kUsageError;
+      case kExitParseError:
+        return SandboxStatus::kParseError;
+      case kExitRenderError:
+        return SandboxStatus::kRenderError;
+      default:
+        return SandboxStatus::kUnknownExit;
+    }
+  }
+  if (WIFSIGNALED(rawStatus)) {
+    outExit = -WTERMSIG(rawStatus);
+    return SandboxStatus::kCrashed;
+  }
+  outExit = rawStatus;
+  return SandboxStatus::kUnknownExit;
+}
+
+bool WriteAll(int fd, std::string_view data) {
+  const char* p = data.data();
+  std::size_t remaining = data.size();
+  while (remaining > 0) {
+    const ssize_t n = ::write(fd, p, remaining);
+    if (n > 0) {
+      p += n;
+      remaining -= static_cast<std::size_t>(n);
+      continue;
+    }
+    if (n < 0 && errno == EINTR) {
+      continue;
+    }
+    return false;  // EPIPE, ENOSPC, or unexpected short write.
+  }
+  return true;
+}
+
+struct Pipe {
+  int readFd = -1;
+  int writeFd = -1;
+
+  [[nodiscard]] bool valid() const { return readFd >= 0 && writeFd >= 0; }
+
+  void closeRead() {
+    if (readFd >= 0) {
+      ::close(readFd);
+      readFd = -1;
+    }
+  }
+  void closeWrite() {
+    if (writeFd >= 0) {
+      ::close(writeFd);
+      writeFd = -1;
+    }
+  }
+  void closeBoth() {
+    closeRead();
+    closeWrite();
+  }
+};
+
+Pipe MakePipe() {
+  int fds[2] = {-1, -1};
+  if (::pipe(fds) != 0) {
+    return Pipe{};
+  }
+  return Pipe{fds[0], fds[1]};
+}
+
+}  // namespace
+
+SandboxHost::SandboxHost(std::string childBinaryPath)
+    : childBinaryPath_(std::move(childBinaryPath)) {}
+
+SandboxHost::RawExitInfo SandboxHost::spawnAndCollect(
+    std::string_view svgBytes, int width, int height,
+    std::vector<uint8_t>& outStdout) {
+  IgnoreSigpipeOnce();
+
+  RawExitInfo info;
+  outStdout.clear();
+
+  Pipe stdinPipe = MakePipe();
+  Pipe stdoutPipe = MakePipe();
+  Pipe stderrPipe = MakePipe();
+  if (!stdinPipe.valid() || !stdoutPipe.valid() || !stderrPipe.valid()) {
+    stdinPipe.closeBoth();
+    stdoutPipe.closeBoth();
+    stderrPipe.closeBoth();
+    info.status = SandboxStatus::kSpawnFailed;
+    info.diagnostics = "pipe() failed: ";
+    info.diagnostics += std::strerror(errno);
+    return info;
+  }
+
+  posix_spawn_file_actions_t actions;
+  posix_spawn_file_actions_init(&actions);
+  posix_spawn_file_actions_adddup2(&actions, stdinPipe.readFd, STDIN_FILENO);
+  posix_spawn_file_actions_adddup2(&actions, stdoutPipe.writeFd, STDOUT_FILENO);
+  posix_spawn_file_actions_adddup2(&actions, stderrPipe.writeFd, STDERR_FILENO);
+  posix_spawn_file_actions_addclose(&actions, stdinPipe.readFd);
+  posix_spawn_file_actions_addclose(&actions, stdinPipe.writeFd);
+  posix_spawn_file_actions_addclose(&actions, stdoutPipe.readFd);
+  posix_spawn_file_actions_addclose(&actions, stdoutPipe.writeFd);
+  posix_spawn_file_actions_addclose(&actions, stderrPipe.readFd);
+  posix_spawn_file_actions_addclose(&actions, stderrPipe.writeFd);
+
+  const std::string widthStr = std::to_string(width);
+  const std::string heightStr = std::to_string(height);
+  std::array<char*, 4> argv = {
+      const_cast<char*>(childBinaryPath_.c_str()),
+      const_cast<char*>(widthStr.c_str()),
+      const_cast<char*>(heightStr.c_str()),
+      nullptr,
+  };
+
+  // Curated environment: the child gets ONLY the sandbox marker plus a few
+  // pre-allocated slots for debugging overrides. We deliberately drop
+  // LD_PRELOAD, LD_LIBRARY_PATH, HOME, PWD, and anything else the host may
+  // have accumulated. The child's `ApplyHardening()` verifies the marker
+  // before reading any untrusted input.
+  std::string sandboxVar = "DONNER_SANDBOX=1";
+  std::array<char*, 2> childEnv = {
+      sandboxVar.data(),
+      nullptr,
+  };
+
+  pid_t childPid = -1;
+  const int spawnErr = ::posix_spawn(&childPid, childBinaryPath_.c_str(),
+                                     &actions, /*attrp=*/nullptr, argv.data(),
+                                     childEnv.data());
+  posix_spawn_file_actions_destroy(&actions);
+
+  stdinPipe.closeRead();
+  stdoutPipe.closeWrite();
+  stderrPipe.closeWrite();
+
+  if (spawnErr != 0) {
+    stdinPipe.closeBoth();
+    stdoutPipe.closeBoth();
+    stderrPipe.closeBoth();
+    info.status = SandboxStatus::kSpawnFailed;
+    info.diagnostics = std::string("posix_spawn failed: ") + std::strerror(spawnErr);
+    return info;
+  }
+
+  std::atomic<bool> writeOk{true};
+  std::thread writer([&writeOk, inFd = stdinPipe.writeFd,
+                      payload = std::string(svgBytes)]() mutable {
+    if (!WriteAll(inFd, payload)) {
+      writeOk.store(false, std::memory_order_relaxed);
+    }
+    ::close(inFd);
+  });
+  stdinPipe.writeFd = -1;
+
+  std::string errBuf;
+  std::array<pollfd, 2> fds = {
+      pollfd{stdoutPipe.readFd, POLLIN, 0},
+      pollfd{stderrPipe.readFd, POLLIN, 0},
+  };
+  bool outOpen = true;
+  bool errOpen = true;
+  bool readFailed = false;
+
+  while (outOpen || errOpen) {
+    fds[0].revents = 0;
+    fds[1].revents = 0;
+    fds[0].events = outOpen ? POLLIN : 0;
+    fds[1].events = errOpen ? POLLIN : 0;
+
+    const int n = ::poll(fds.data(), fds.size(), /*timeout=*/-1);
+    if (n < 0) {
+      if (errno == EINTR) continue;
+      readFailed = true;
+      break;
+    }
+
+    auto drainTo = [](int fd, auto appender) -> bool {
+      std::array<uint8_t, 4096> buf;
+      const ssize_t r = ::read(fd, buf.data(), buf.size());
+      if (r > 0) {
+        appender(buf.data(), static_cast<std::size_t>(r));
+        return true;
+      }
+      if (r < 0 && errno == EINTR) return true;
+      return false;
+    };
+
+    if (outOpen && (fds[0].revents & (POLLIN | POLLHUP | POLLERR))) {
+      const bool stillOpen = drainTo(stdoutPipe.readFd, [&](const uint8_t* p, std::size_t len) {
+        outStdout.insert(outStdout.end(), p, p + len);
+      });
+      if (!stillOpen) outOpen = false;
+    }
+    if (errOpen && (fds[1].revents & (POLLIN | POLLHUP | POLLERR))) {
+      const bool stillOpen = drainTo(stderrPipe.readFd, [&](const uint8_t* p, std::size_t len) {
+        errBuf.append(reinterpret_cast<const char*>(p), len);
+      });
+      if (!stillOpen) errOpen = false;
+    }
+  }
+
+  writer.join();
+  stdoutPipe.closeRead();
+  stderrPipe.closeRead();
+
+  int rawStatus = 0;
+  while (::waitpid(childPid, &rawStatus, 0) < 0) {
+    if (errno == EINTR) continue;
+    info.status = SandboxStatus::kReadFailed;
+    info.diagnostics = std::string("waitpid failed: ") + std::strerror(errno);
+    return info;
+  }
+
+  info.status = ClassifyExit(rawStatus, info.exitCode);
+  info.diagnostics = std::move(errBuf);
+
+  if (readFailed) {
+    info.status = SandboxStatus::kReadFailed;
+  } else if (!writeOk.load(std::memory_order_relaxed) &&
+             info.status == SandboxStatus::kOk) {
+    info.status = SandboxStatus::kWriteFailed;
+  }
+  return info;
+}
+
+RenderResult SandboxHost::renderToBackend(std::string_view svgBytes, int width,
+                                          int height, svg::RendererInterface& target) {
+  RenderResult result;
+
+  RawExitInfo info = spawnAndCollect(svgBytes, width, height, result.wire);
+  result.status = info.status;
+  result.exitCode = info.exitCode;
+  result.diagnostics = std::move(info.diagnostics);
+
+  if (result.status != SandboxStatus::kOk) {
+    return result;
+  }
+
+  ReplayingRenderer replay(target);
+  ReplayReport report;
+  const ReplayStatus replayStatus = replay.pumpFrame(result.wire, report);
+  result.unsupportedCount = report.unsupportedCount;
+
+  switch (replayStatus) {
+    case ReplayStatus::kOk:
+      result.status = SandboxStatus::kOk;
+      break;
+    case ReplayStatus::kEncounteredUnsupported:
+      // Still a successful render, just lossy. Keep kOk; callers inspect
+      // `unsupportedCount` to decide whether to show a warning.
+      result.status = SandboxStatus::kOk;
+      break;
+    case ReplayStatus::kHeaderMismatch:
+    case ReplayStatus::kMalformed:
+    case ReplayStatus::kEndOfStream:
+    case ReplayStatus::kUnknownOpcode:
+      result.status = SandboxStatus::kWireMalformed;
+      break;
+  }
+  return result;
+}
+
+RenderResult SandboxHost::render(std::string_view svgBytes, int width, int height) {
+  svg::RendererTinySkia backend;
+  RenderResult result = renderToBackend(svgBytes, width, height, backend);
+  if (result.status != SandboxStatus::kOk) {
+    return result;
+  }
+
+  const svg::RendererBitmap bitmap = backend.takeSnapshot();
+  if (bitmap.dimensions.x <= 0 || bitmap.dimensions.y <= 0 || bitmap.pixels.empty()) {
+    result.status = SandboxStatus::kRenderError;
+    result.diagnostics += "\nhost-side RendererTinySkia produced an empty snapshot";
+    return result;
+  }
+
+  result.png = svg::RendererImageIO::writeRgbaPixelsToPngMemory(
+      bitmap.pixels, bitmap.dimensions.x, bitmap.dimensions.y,
+      bitmap.rowBytes / 4);
+  if (result.png.empty()) {
+    result.status = SandboxStatus::kRenderError;
+    result.diagnostics += "\nhost-side PNG encode failed";
+  }
+  return result;
+}
+
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/SandboxHost.h
+++ b/donner/editor/sandbox/SandboxHost.h
@@ -1,0 +1,104 @@
+#pragma once
+/// @file
+///
+/// Host-side driver for the sandbox child process. See
+/// docs/design_docs/editor_sandbox.md (S1 for the process model, S2 for the
+/// wire format, S3 for the host-side replay path).
+///
+/// `SandboxHost` spawns `donner_parser_child` as a subprocess, pipes SVG bytes
+/// to its stdin, reads a `RendererInterface` wire stream from its stdout, and
+/// either replays the stream into a caller-provided backend
+/// (`renderToBackend`) or runs the full host-side rasterizer + PNG encode
+/// (`render`) as a convenience wrapper.
+///
+/// The host process never crashes on adversarial SVG input — the worst failure
+/// mode is a `SandboxStatus::kCrashed` result with the previous document left
+/// intact on the caller side.
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "donner/svg/renderer/RendererInterface.h"
+
+namespace donner::editor::sandbox {
+
+/// Outcome of a single render invocation on `SandboxHost`.
+enum class SandboxStatus {
+  kOk,            ///< Child exited 0 and the replay consumed the stream cleanly.
+  kSpawnFailed,   ///< `posix_spawn` or pipe setup failed before the child ran.
+  kWriteFailed,   ///< Host could not deliver the full SVG payload to the child.
+  kReadFailed,    ///< Host could not read stdout/stderr from the child.
+  kParseError,    ///< Child returned `kExitParseError` — malformed SVG.
+  kUsageError,    ///< Child returned `kExitUsageError` — bad argv/dimensions.
+  kRenderError,   ///< Child returned `kExitRenderError` — encoder bailed out.
+  kCrashed,       ///< Child died via signal (SIGSEGV, SIGABRT, ...).
+  kUnknownExit,   ///< Child exited with an unrecognized non-zero code.
+  kWireMalformed, ///< Child exited 0 but its wire stream failed to decode.
+};
+
+/// Result payload for a render call. Fields are populated according to
+/// `status` — see each field comment for when it's valid.
+struct RenderResult {
+  SandboxStatus status = SandboxStatus::kOk;
+  /// Raw exit code (0 on success), or `-signal` when the child died on a signal.
+  int exitCode = 0;
+  /// Child's stderr captured verbatim. Always available regardless of status.
+  std::string diagnostics;
+  /// PNG-encoded image bytes. Populated only by `render()` on `kOk`.
+  std::vector<uint8_t> png;
+  /// Raw wire-format bytes read from the child's stdout. Always populated
+  /// when the child reached `kEndFrame`, regardless of whether the host-side
+  /// replay succeeded. Useful for debugging and for piping into a file
+  /// recorder (see S4 in the design doc).
+  std::vector<uint8_t> wire;
+  /// Count of `kUnsupported` messages the replayer observed, if any. A
+  /// non-zero value means the output is lossy compared to an in-process
+  /// render (gradients, filters, masks, etc.).
+  uint32_t unsupportedCount = 0;
+};
+
+/// Spawns and communicates with the sandbox child binary. Not thread-safe:
+/// construct one instance per thread that needs to render.
+class SandboxHost {
+public:
+  /// @param childBinaryPath Absolute path to the `donner_parser_child` executable.
+  ///   Callers in tests should resolve this via `donner::Runfiles`.
+  explicit SandboxHost(std::string childBinaryPath);
+
+  /// Renders `svgBytes` into a caller-provided `RendererInterface` via the
+  /// sandbox child + host-side `ReplayingRenderer`. The child's wire stream
+  /// is decoded into `target` — after this call returns with `kOk`, the
+  /// target has received `beginFrame()`, a sequence of drawing calls, and
+  /// `endFrame()`, same as if the driver had run in-process.
+  ///
+  /// @param svgBytes Raw SVG source (may contain any bytes; not NUL-terminated).
+  /// @param width Canvas width in CSS pixels.
+  /// @param height Canvas height in CSS pixels.
+  /// @param target Destination renderer. Must outlive this call.
+  RenderResult renderToBackend(std::string_view svgBytes, int width, int height,
+                               svg::RendererInterface& target);
+
+  /// Convenience wrapper: renders via `renderToBackend` into a host-side
+  /// `RendererTinySkia` and encodes the snapshot to PNG. Preserves the S1
+  /// public contract so existing callers (tests, CLIs) don't have to change.
+  RenderResult render(std::string_view svgBytes, int width, int height);
+
+private:
+  struct RawExitInfo {
+    std::string diagnostics;
+    int exitCode = 0;
+    SandboxStatus status = SandboxStatus::kOk;
+  };
+
+  /// Spawns the child, pipes `svgBytes` into it, collects stdout + stderr,
+  /// and classifies the exit. Does no decoding — callers decide whether to
+  /// replay the stdout bytes into a `RendererInterface`.
+  RawExitInfo spawnAndCollect(std::string_view svgBytes, int width, int height,
+                              std::vector<uint8_t>& outStdout);
+
+  std::string childBinaryPath_;
+};
+
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/SandboxProtocol.h
+++ b/donner/editor/sandbox/SandboxProtocol.h
@@ -1,0 +1,17 @@
+#pragma once
+/// @file
+///
+/// Shared protocol constants between the editor host and the `donner_parser_child`
+/// sandbox binary. See docs/design_docs/editor_sandbox.md Milestone S1 for the
+/// one-shot byte-in / PNG-out contract these exit codes implement.
+
+namespace donner::editor::sandbox {
+
+/// Child exit codes. The host classifies these into `SandboxStatus` values.
+/// Values follow BSD `sysexits.h` convention where plausible.
+inline constexpr int kExitOk = 0;
+inline constexpr int kExitUsageError = 64;
+inline constexpr int kExitParseError = 65;
+inline constexpr int kExitRenderError = 66;
+
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/SerializingRenderer.cc
+++ b/donner/editor/sandbox/SerializingRenderer.cc
@@ -1,0 +1,201 @@
+#include "donner/editor/sandbox/SerializingRenderer.h"
+
+#include <utility>
+
+#include "donner/editor/sandbox/SandboxCodecs.h"
+#include "donner/svg/SVGDocument.h"
+#include "donner/svg/renderer/RendererDriver.h"
+#include "donner/svg/resources/ImageResource.h"
+
+namespace donner::editor::sandbox {
+
+SerializingRenderer::SerializingRenderer() = default;
+SerializingRenderer::~SerializingRenderer() = default;
+
+void SerializingRenderer::writeStreamHeader() {
+  if (headerWritten_) return;
+  auto token = writer_.beginMessage(Opcode::kStreamHeader);
+  writer_.writeU32(kWireMagic);
+  writer_.writeU32(kWireVersion);
+  writer_.finishMessage(token);
+  headerWritten_ = true;
+}
+
+void SerializingRenderer::writeUnsupported(UnsupportedKind kind) {
+  writeStreamHeader();
+  auto token = writer_.beginMessage(Opcode::kUnsupported);
+  writer_.writeU32(static_cast<uint32_t>(kind));
+  writer_.finishMessage(token);
+  ++unsupportedCount_;
+}
+
+void SerializingRenderer::draw(svg::SVGDocument& document) {
+  svg::RendererDriver driver(*this, /*verbose=*/false);
+  driver.draw(document);
+}
+
+void SerializingRenderer::beginFrame(const svg::RenderViewport& viewport) {
+  writeStreamHeader();
+  width_ = static_cast<int>(viewport.size.x * viewport.devicePixelRatio);
+  height_ = static_cast<int>(viewport.size.y * viewport.devicePixelRatio);
+
+  auto token = writer_.beginMessage(Opcode::kBeginFrame);
+  EncodeRenderViewport(writer_, viewport);
+  writer_.finishMessage(token);
+}
+
+void SerializingRenderer::endFrame() {
+  auto token = writer_.beginMessage(Opcode::kEndFrame);
+  writer_.finishMessage(token);
+}
+
+void SerializingRenderer::setTransform(const Transform2d& transform) {
+  auto token = writer_.beginMessage(Opcode::kSetTransform);
+  EncodeTransform2d(writer_, transform);
+  writer_.finishMessage(token);
+}
+
+void SerializingRenderer::pushTransform(const Transform2d& transform) {
+  auto token = writer_.beginMessage(Opcode::kPushTransform);
+  EncodeTransform2d(writer_, transform);
+  writer_.finishMessage(token);
+}
+
+void SerializingRenderer::popTransform() {
+  auto token = writer_.beginMessage(Opcode::kPopTransform);
+  writer_.finishMessage(token);
+}
+
+void SerializingRenderer::pushClip(const svg::ResolvedClip& clip) {
+  if (clip.mask.has_value()) {
+    writeUnsupported(UnsupportedKind::kClipMaskChain);
+    return;
+  }
+  auto token = writer_.beginMessage(Opcode::kPushClip);
+  EncodeResolvedClip(writer_, clip);
+  writer_.finishMessage(token);
+}
+
+void SerializingRenderer::popClip() {
+  auto token = writer_.beginMessage(Opcode::kPopClip);
+  writer_.finishMessage(token);
+}
+
+void SerializingRenderer::pushIsolatedLayer(double opacity, svg::MixBlendMode blendMode) {
+  auto token = writer_.beginMessage(Opcode::kPushIsolatedLayer);
+  writer_.writeF64(opacity);
+  EncodeMixBlendMode(writer_, blendMode);
+  writer_.finishMessage(token);
+}
+
+void SerializingRenderer::popIsolatedLayer() {
+  auto token = writer_.beginMessage(Opcode::kPopIsolatedLayer);
+  writer_.finishMessage(token);
+}
+
+void SerializingRenderer::pushFilterLayer(const svg::components::FilterGraph& filterGraph,
+                                          const std::optional<Box2d>& filterRegion) {
+  auto token = writer_.beginMessage(Opcode::kPushFilterLayer);
+  EncodeFilterGraph(writer_, filterGraph);
+  writer_.writeBool(filterRegion.has_value());
+  if (filterRegion) {
+    EncodeBox2d(writer_, *filterRegion);
+  }
+  writer_.finishMessage(token);
+}
+
+void SerializingRenderer::popFilterLayer() {
+  auto token = writer_.beginMessage(Opcode::kPopFilterLayer);
+  writer_.finishMessage(token);
+}
+
+void SerializingRenderer::pushMask(const std::optional<Box2d>& maskBounds) {
+  auto token = writer_.beginMessage(Opcode::kPushMask);
+  writer_.writeBool(maskBounds.has_value());
+  if (maskBounds) {
+    EncodeBox2d(writer_, *maskBounds);
+  }
+  writer_.finishMessage(token);
+}
+
+void SerializingRenderer::transitionMaskToContent() {
+  auto token = writer_.beginMessage(Opcode::kTransitionMaskToContent);
+  writer_.finishMessage(token);
+}
+
+void SerializingRenderer::popMask() {
+  auto token = writer_.beginMessage(Opcode::kPopMask);
+  writer_.finishMessage(token);
+}
+
+void SerializingRenderer::beginPatternTile(const Box2d& tileRect,
+                                           const Transform2d& targetFromPattern) {
+  auto token = writer_.beginMessage(Opcode::kBeginPatternTile);
+  EncodeBox2d(writer_, tileRect);
+  EncodeTransform2d(writer_, targetFromPattern);
+  writer_.finishMessage(token);
+}
+
+void SerializingRenderer::endPatternTile(bool forStroke) {
+  auto token = writer_.beginMessage(Opcode::kEndPatternTile);
+  writer_.writeBool(forStroke);
+  writer_.finishMessage(token);
+}
+
+void SerializingRenderer::setPaint(const svg::PaintParams& paint) {
+  auto token = writer_.beginMessage(Opcode::kSetPaint);
+  EncodePaintParams(writer_, paint);
+  writer_.finishMessage(token);
+}
+
+void SerializingRenderer::drawPath(const svg::PathShape& path, const svg::StrokeParams& stroke) {
+  auto token = writer_.beginMessage(Opcode::kDrawPath);
+  EncodePathShape(writer_, path);
+  EncodeStrokeParams(writer_, stroke);
+  writer_.finishMessage(token);
+}
+
+void SerializingRenderer::drawRect(const Box2d& rect, const svg::StrokeParams& stroke) {
+  auto token = writer_.beginMessage(Opcode::kDrawRect);
+  EncodeBox2d(writer_, rect);
+  EncodeStrokeParams(writer_, stroke);
+  writer_.finishMessage(token);
+}
+
+void SerializingRenderer::drawEllipse(const Box2d& bounds, const svg::StrokeParams& stroke) {
+  auto token = writer_.beginMessage(Opcode::kDrawEllipse);
+  EncodeBox2d(writer_, bounds);
+  EncodeStrokeParams(writer_, stroke);
+  writer_.finishMessage(token);
+}
+
+void SerializingRenderer::drawImage(const svg::ImageResource& image,
+                                     const svg::ImageParams& params) {
+  auto token = writer_.beginMessage(Opcode::kDrawImage);
+  EncodeImageResource(writer_, image);
+  EncodeImageParams(writer_, params);
+  writer_.finishMessage(token);
+}
+
+void SerializingRenderer::drawText(Registry&,
+                                   const svg::components::ComputedTextComponent& text,
+                                   const svg::TextParams& params) {
+  auto token = writer_.beginMessage(Opcode::kDrawText);
+  EncodeComputedTextComponent(writer_, text);
+  EncodeTextParams(writer_, params);
+  writer_.finishMessage(token);
+}
+
+svg::RendererBitmap SerializingRenderer::takeSnapshot() const {
+  // A SerializingRenderer has no backing pixels — snapshots are a host
+  // concern (performed by the real replay backend). Return an empty bitmap
+  // to satisfy the override; callers in the sandbox pipeline should never
+  // request a snapshot from here.
+  return svg::RendererBitmap{};
+}
+
+std::unique_ptr<svg::RendererInterface> SerializingRenderer::createOffscreenInstance() const {
+  return nullptr;
+}
+
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/SerializingRenderer.h
+++ b/donner/editor/sandbox/SerializingRenderer.h
@@ -1,0 +1,109 @@
+#pragma once
+/// @file
+///
+/// `SerializingRenderer` is a `RendererInterface` implementation that encodes
+/// each virtual method call to a `WireWriter` instead of rasterizing. It runs
+/// the normal `RendererDriver` inside its `draw()` entry point, so every
+/// call the driver would have made into a real backend (transform stack, paint
+/// state, draw primitives) ends up as a wire message.
+///
+/// Supported opcodes (S2 scope):
+///  - frame lifecycle, transforms, isolated layers
+///  - solid-color paint (`PaintServer::None` / `PaintServer::Solid` only)
+///  - clip state (rect + path shapes, no masks)
+///  - drawPath, drawRect, drawEllipse
+///
+/// Anything else emits a `kUnsupported` message and increments
+/// `unsupportedCount()` — the driver keeps making calls against us but the
+/// resulting stream is flagged lossy.
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+#include "donner/editor/sandbox/Wire.h"
+#include "donner/svg/renderer/RendererInterface.h"
+
+namespace donner::editor::sandbox {
+
+class SerializingRenderer final : public svg::RendererInterface {
+public:
+  SerializingRenderer();
+  ~SerializingRenderer() override;
+
+  SerializingRenderer(const SerializingRenderer&) = delete;
+  SerializingRenderer& operator=(const SerializingRenderer&) = delete;
+
+  /// @name RendererInterface
+  /// @{
+  void draw(svg::SVGDocument& document) override;
+  [[nodiscard]] int width() const override { return width_; }
+  [[nodiscard]] int height() const override { return height_; }
+
+  void beginFrame(const svg::RenderViewport& viewport) override;
+  void endFrame() override;
+
+  void setTransform(const Transform2d& transform) override;
+  void pushTransform(const Transform2d& transform) override;
+  void popTransform() override;
+
+  void pushClip(const svg::ResolvedClip& clip) override;
+  void popClip() override;
+
+  void pushIsolatedLayer(double opacity, svg::MixBlendMode blendMode) override;
+  void popIsolatedLayer() override;
+
+  void pushFilterLayer(const svg::components::FilterGraph& filterGraph,
+                       const std::optional<Box2d>& filterRegion) override;
+  void popFilterLayer() override;
+
+  void pushMask(const std::optional<Box2d>& maskBounds) override;
+  void transitionMaskToContent() override;
+  void popMask() override;
+
+  void beginPatternTile(const Box2d& tileRect, const Transform2d& targetFromPattern) override;
+  void endPatternTile(bool forStroke) override;
+
+  void setPaint(const svg::PaintParams& paint) override;
+
+  void drawPath(const svg::PathShape& path, const svg::StrokeParams& stroke) override;
+  void drawRect(const Box2d& rect, const svg::StrokeParams& stroke) override;
+  void drawEllipse(const Box2d& bounds, const svg::StrokeParams& stroke) override;
+
+  void drawImage(const svg::ImageResource& image, const svg::ImageParams& params) override;
+  void drawText(Registry& registry, const svg::components::ComputedTextComponent& text,
+                const svg::TextParams& params) override;
+
+  [[nodiscard]] svg::RendererBitmap takeSnapshot() const override;
+  [[nodiscard]] std::unique_ptr<svg::RendererInterface> createOffscreenInstance() const override;
+  /// @}
+
+  /// Number of `kUnsupported` messages emitted so far. A value of 0 means the
+  /// stream is faithful to the original call sequence; any other value means
+  /// the replay renderer will miss at least one draw call.
+  [[nodiscard]] std::size_t unsupportedCount() const { return unsupportedCount_; }
+
+  /// True iff `unsupportedCount() > 0`.
+  [[nodiscard]] bool hasUnsupported() const { return unsupportedCount_ > 0; }
+
+  /// Move the accumulated wire bytes out of the writer. Invalidates the
+  /// renderer; call exactly once, after `draw()` returns.
+  [[nodiscard]] std::vector<uint8_t> takeBuffer() && {
+    return std::move(writer_).take();
+  }
+
+  /// View of the accumulated wire bytes without transferring ownership.
+  [[nodiscard]] std::span<const uint8_t> data() const { return writer_.data(); }
+
+private:
+  void writeStreamHeader();
+  void writeUnsupported(UnsupportedKind kind);
+
+  WireWriter writer_;
+  int width_ = 0;
+  int height_ = 0;
+  std::size_t unsupportedCount_ = 0;
+  bool headerWritten_ = false;
+};
+
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/SvgSource.cc
+++ b/donner/editor/sandbox/SvgSource.cc
@@ -1,0 +1,247 @@
+#include "donner/editor/sandbox/SvgSource.h"
+
+#include <array>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <system_error>
+#include <utility>
+
+namespace donner::editor::sandbox {
+
+namespace {
+
+constexpr std::string_view kFileScheme = "file://";
+constexpr std::string_view kHttpsScheme = "https://";
+constexpr std::string_view kHttpScheme = "http://";
+
+// Returns true if `uri` begins with a scheme like "xxxx://".
+bool HasExplicitScheme(std::string_view uri) {
+  const auto colon = uri.find(':');
+  if (colon == std::string_view::npos || colon == 0) return false;
+  if (uri.size() < colon + 3) return false;
+  return uri.substr(colon, 3) == "://";
+}
+
+// Strips a leading "file://" prefix and returns the remaining path. Handles
+// the common malformed "file://relative" shape by treating it as relative.
+std::string StripFileScheme(std::string_view uri) {
+  return std::string(uri.substr(kFileScheme.size()));
+}
+
+std::string Diagnose(const std::filesystem::path& path, std::string_view verb,
+                     const std::error_code& ec) {
+  std::string out = std::string(verb);
+  out += " '";
+  out += path.string();
+  out += "': ";
+  out += ec.message();
+  return out;
+}
+
+}  // namespace
+
+SvgSource::SvgSource(SvgSourceOptions options) : options_(std::move(options)) {}
+
+SvgFetchResult SvgSource::fetch(std::string_view uri) const {
+  SvgFetchResult result;
+
+  if (uri.empty()) {
+    result.status = SvgFetchStatus::kInvalidUri;
+    result.diagnostics = "empty uri";
+    return result;
+  }
+
+  if (HasExplicitScheme(uri)) {
+    if (uri.size() >= kFileScheme.size() &&
+        uri.substr(0, kFileScheme.size()) == kFileScheme) {
+      return fetchFromPath(std::filesystem::path(StripFileScheme(uri)));
+    }
+    if ((uri.size() >= kHttpsScheme.size() &&
+         uri.substr(0, kHttpsScheme.size()) == kHttpsScheme) ||
+        (uri.size() >= kHttpScheme.size() &&
+         uri.substr(0, kHttpScheme.size()) == kHttpScheme)) {
+      return fetchFromUrl(uri);
+    }
+    result.status = SvgFetchStatus::kSchemeNotSupported;
+    result.diagnostics = "unsupported scheme in: ";
+    result.diagnostics.append(uri);
+    return result;
+  }
+
+  // Bare path — absolute or relative.
+  std::filesystem::path path(std::string{uri});
+  if (path.is_relative()) {
+    path = options_.baseDirectory / path;
+  }
+  return fetchFromPath(path);
+}
+
+SvgFetchResult SvgSource::fetchFromPath(const std::filesystem::path& path) const {
+  SvgFetchResult result;
+  result.resolvedPath = path;
+
+  std::error_code ec;
+  const auto canonical = std::filesystem::weakly_canonical(path, ec);
+  if (!ec) {
+    result.resolvedPath = canonical;
+  }
+
+  // Check existence up-front so we can differentiate "missing" from
+  // "exists-but-unreadable".
+  std::error_code existsEc;
+  const bool exists = std::filesystem::exists(result.resolvedPath, existsEc);
+  if (existsEc || !exists) {
+    result.status = SvgFetchStatus::kNotFound;
+    result.diagnostics = Diagnose(result.resolvedPath, "stat",
+                                  existsEc ? existsEc : std::make_error_code(std::errc::no_such_file_or_directory));
+    return result;
+  }
+
+  std::error_code typeEc;
+  const auto status = std::filesystem::status(result.resolvedPath, typeEc);
+  if (typeEc) {
+    result.status = SvgFetchStatus::kReadFailed;
+    result.diagnostics = Diagnose(result.resolvedPath, "status", typeEc);
+    return result;
+  }
+  if (!std::filesystem::is_regular_file(status)) {
+    result.status = SvgFetchStatus::kNotRegularFile;
+    result.diagnostics = "not a regular file: " + result.resolvedPath.string();
+    return result;
+  }
+
+  std::error_code sizeEc;
+  const auto byteCount = std::filesystem::file_size(result.resolvedPath, sizeEc);
+  if (sizeEc) {
+    result.status = SvgFetchStatus::kReadFailed;
+    result.diagnostics = Diagnose(result.resolvedPath, "file_size", sizeEc);
+    return result;
+  }
+  if (byteCount > options_.maxFileBytes) {
+    result.status = SvgFetchStatus::kTooLarge;
+    result.diagnostics = "file exceeds maxFileBytes (" + std::to_string(byteCount) +
+                         " > " + std::to_string(options_.maxFileBytes) + "): " +
+                         result.resolvedPath.string();
+    return result;
+  }
+
+  std::ifstream in(result.resolvedPath, std::ios::binary);
+  if (!in.is_open()) {
+    // Distinguish permission-denied from generic read failure when we can.
+    if (errno == EACCES) {
+      result.status = SvgFetchStatus::kPermissionDenied;
+    } else {
+      result.status = SvgFetchStatus::kReadFailed;
+    }
+    result.diagnostics = "failed to open: " + result.resolvedPath.string() +
+                         " (" + std::strerror(errno) + ")";
+    return result;
+  }
+
+  result.bytes.resize(static_cast<std::size_t>(byteCount));
+  if (byteCount > 0) {
+    in.read(reinterpret_cast<char*>(result.bytes.data()),
+            static_cast<std::streamsize>(byteCount));
+    if (!in || static_cast<std::size_t>(in.gcount()) != byteCount) {
+      result.status = SvgFetchStatus::kReadFailed;
+      result.bytes.clear();
+      result.diagnostics = "short read on: " + result.resolvedPath.string();
+      return result;
+    }
+  }
+
+  result.status = SvgFetchStatus::kOk;
+  return result;
+}
+
+SvgFetchResult SvgSource::fetchFromUrl(std::string_view url) const {
+  SvgFetchResult result;
+  // resolvedPath is left empty for network fetches — there is no filesystem path.
+
+  // Validate the URL contains no shell metacharacters. We allow a restricted
+  // character set to prevent shell injection: alphanumeric, ':', '/', '.', '-',
+  // '_', '~', '?', '&', '=', '%', '#', '+', '@', ',', ';', '!', '(', ')'.
+  for (const char c : url) {
+    if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+          (c >= '0' && c <= '9') ||
+          c == ':' || c == '/' || c == '.' || c == '-' || c == '_' ||
+          c == '~' || c == '?' || c == '&' || c == '=' || c == '%' ||
+          c == '#' || c == '+' || c == '@' || c == ',' || c == ';' ||
+          c == '!' || c == '(' || c == ')' || c == '[' || c == ']')) {
+      result.status = SvgFetchStatus::kInvalidUri;
+      result.diagnostics = "URL contains disallowed character for shell safety: '";
+      result.diagnostics += c;
+      result.diagnostics += "'";
+      return result;
+    }
+  }
+
+  // Build the curl command. Flags:
+  //   -sS          — silent but show errors
+  //   -L           — follow redirects
+  //   --max-time   — total timeout
+  //   --max-redirs — redirect limit
+  //   --max-filesize — abort if Content-Length exceeds the cap
+  //   -f           — fail on HTTP errors (4xx/5xx)
+  std::string cmd = "curl -sS -L -f";
+  cmd += " --max-time " + std::to_string(options_.httpTimeoutSeconds);
+  cmd += " --max-redirs " + std::to_string(options_.maxRedirects);
+  cmd += " --max-filesize " + std::to_string(options_.maxHttpBytes);
+  cmd += " -- '";
+  cmd += url;
+  cmd += "' 2>&1";
+
+  // NOLINTNEXTLINE(cert-env33-c) — popen is acceptable for the trusted host side.
+  FILE* pipe = ::popen(cmd.c_str(), "r");
+  if (!pipe) {
+    result.status = SvgFetchStatus::kNetworkError;
+    result.diagnostics = "failed to launch curl subprocess";
+    return result;
+  }
+
+  // Read the response in chunks, enforcing the byte cap on the host side even
+  // if the server doesn't send Content-Length (--max-filesize only works when
+  // the server advertises it).
+  constexpr std::size_t kChunkSize = 65536;
+  std::array<char, kChunkSize> buf{};
+  while (true) {
+    const std::size_t n = std::fread(buf.data(), 1, buf.size(), pipe);
+    if (n == 0) break;
+    if (result.bytes.size() + n > options_.maxHttpBytes) {
+      ::pclose(pipe);
+      result.status = SvgFetchStatus::kTooLarge;
+      result.bytes.clear();
+      result.diagnostics = "HTTP response exceeded maxHttpBytes (" +
+                           std::to_string(options_.maxHttpBytes) + ")";
+      return result;
+    }
+    result.bytes.insert(result.bytes.end(), buf.data(), buf.data() + n);
+  }
+
+  const int exitCode = ::pclose(pipe);
+  if (exitCode != 0) {
+    // If we got no data at all, it's a pure network error. If we got some
+    // data, it's likely the error message from curl (because of 2>&1).
+    std::string curlOutput(result.bytes.begin(), result.bytes.end());
+    result.bytes.clear();
+    result.status = SvgFetchStatus::kNetworkError;
+    result.diagnostics = "curl exited with code " + std::to_string(exitCode);
+    if (!curlOutput.empty()) {
+      result.diagnostics += ": " + curlOutput;
+    }
+    return result;
+  }
+
+  if (result.bytes.empty()) {
+    result.status = SvgFetchStatus::kNetworkError;
+    result.diagnostics = "curl returned empty response";
+    return result;
+  }
+
+  result.status = SvgFetchStatus::kOk;
+  return result;
+}
+
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/SvgSource.h
+++ b/donner/editor/sandbox/SvgSource.h
@@ -1,0 +1,91 @@
+#pragma once
+/// @file
+///
+/// `SvgSource` resolves a user-supplied URI into a raw byte buffer that the
+/// sandbox child can parse. This is the host-side half of the address bar
+/// design: the host has filesystem (and eventually network) privilege, and
+/// hands the sandbox child only the resulting bytes — never the filename,
+/// never the URL.
+///
+/// Supported schemes in this milestone:
+///  - `file://<absolute-path>` — spec-style file URIs.
+///  - bare absolute paths (`/foo/bar.svg`).
+///  - bare relative paths (`./icon.svg`, `icon.svg`) — resolved against the
+///    caller-specified base directory.
+///
+/// `https://` / `http://` — fetched via the system `curl` CLI on the host
+/// side. The host enforces a 10 MB cap, 10-second timeout, and max 5
+/// redirects. The sandbox child never sees the URL or touches the network.
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace donner::editor::sandbox {
+
+/// Outcome of a fetch attempt. `kOk` means `bytes` is populated and the
+/// caller can pass it straight to `SandboxHost::renderToBackend`.
+enum class SvgFetchStatus {
+  kOk,                  ///< Bytes retrieved successfully.
+  kSchemeNotSupported,  ///< URI used a scheme this build doesn't implement.
+  kInvalidUri,          ///< URI could not be parsed.
+  kNotFound,            ///< Resolved path does not exist.
+  kNotRegularFile,      ///< Path exists but isn't a regular file.
+  kPermissionDenied,    ///< Resolved path isn't readable.
+  kTooLarge,            ///< File exceeds the configured size cap.
+  kReadFailed,          ///< I/O error mid-read.
+  kNetworkError,        ///< HTTP(S) fetch failed (timeout, DNS, etc.).
+};
+
+/// Result payload. `bytes` is only populated on `kOk`; all other statuses
+/// leave it empty and set `diagnostics` to a human-readable reason.
+struct SvgFetchResult {
+  SvgFetchStatus status = SvgFetchStatus::kOk;
+  std::vector<uint8_t> bytes;
+  /// Absolute filesystem path the loader resolved to, for diagnostics and
+  /// provenance tracking (e.g., baking into `.rnr` headers in S4). Empty
+  /// when the URI didn't map to a filesystem path.
+  std::filesystem::path resolvedPath;
+  std::string diagnostics;
+};
+
+/// Configuration knobs for a `SvgSource`. Defaults match the design doc's
+/// address-bar section: 100 MB cap on local files.
+struct SvgSourceOptions {
+  /// Directory used to resolve relative paths. Defaults to the current
+  /// working directory at `SvgSource` construction time.
+  std::filesystem::path baseDirectory = std::filesystem::current_path();
+  /// Maximum number of bytes the loader will read from a single file. The
+  /// cap exists to keep a malicious or runaway path from exhausting memory
+  /// before the sandbox even sees the bytes.
+  std::size_t maxFileBytes = 100u * 1024u * 1024u;
+  /// Maximum number of bytes to accept from an HTTP(S) response.
+  std::size_t maxHttpBytes = 10u * 1024u * 1024u;
+  /// Timeout in seconds for HTTP(S) fetches.
+  int httpTimeoutSeconds = 10;
+  /// Maximum number of redirects to follow for HTTP(S) fetches.
+  int maxRedirects = 5;
+};
+
+/// Stateless-from-the-outside URI resolver. `SvgSource` holds the config
+/// knobs, but every `fetch()` call is independent and thread-safe.
+class SvgSource {
+public:
+  explicit SvgSource(SvgSourceOptions options = {});
+
+  /// Resolves `uri` to raw bytes. The URI is classified into a scheme (or
+  /// falls through to "bare path"), the path is canonicalized and
+  /// size-checked, and the file is read into memory. Never throws.
+  [[nodiscard]] SvgFetchResult fetch(std::string_view uri) const;
+
+private:
+  SvgFetchResult fetchFromPath(const std::filesystem::path& path) const;
+  SvgFetchResult fetchFromUrl(std::string_view url) const;
+
+  SvgSourceOptions options_;
+};
+
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/Wire.h
+++ b/donner/editor/sandbox/Wire.h
@@ -1,0 +1,313 @@
+#pragma once
+/// @file
+///
+/// Milestone S2 wire format for the editor sandbox. See
+/// docs/design_docs/editor_sandbox.md §"Wire format".
+///
+/// A wire stream is a sequence of messages: `u32 opcode`, `u32 payload_length`,
+/// `u8 payload[payload_length]`. Everything is little-endian, which matches
+/// every platform Donner targets today. The first message per stream is a
+/// `kStreamHeader` carrying the magic + version so a reader can detect mixed
+/// versions up-front.
+///
+/// **Every** primitive read in `WireReader` is bounds-checked against the
+/// remaining buffer; every length field is capped by `kMax*` constants to
+/// bound untrusted input. The reader must never crash on adversarial bytes —
+/// this is the single most important invariant in the whole sandbox design.
+
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace donner::editor::sandbox {
+
+/// Magic identifier ("DRNR" as a little-endian u32).
+inline constexpr uint32_t kWireMagic = 0x524E5244u;
+
+/// Wire format version. Bumped on any payload layout change.
+inline constexpr uint32_t kWireVersion = 1;
+
+/// Hard caps the reader enforces on variable-length fields. Bounding these
+/// turns "parser allocates 18 exabytes" into a graceful `kReadFailed`.
+inline constexpr uint32_t kMaxVectorCount = 10'000'000;
+inline constexpr uint32_t kMaxStringBytes = 10u * 1024u * 1024u;
+inline constexpr uint32_t kMaxFrameBytes = 256u * 1024u * 1024u;
+inline constexpr uint32_t kMaxPayloadBytes = kMaxFrameBytes;
+
+/// Opcodes. One per supported `RendererInterface` method, plus control ops.
+///
+/// Values are stable across patch releases; new opcodes append at the end. Do
+/// not renumber existing opcodes without bumping `kWireVersion`.
+enum class Opcode : uint32_t {
+  kInvalid = 0,
+
+  /// Stream metadata. Always the first message.
+  kStreamHeader = 1,
+
+  /// Frame lifecycle.
+  kBeginFrame = 10,
+  kEndFrame = 11,
+
+  /// Transform stack.
+  kSetTransform = 20,
+  kPushTransform = 21,
+  kPopTransform = 22,
+
+  /// Clip stack. S2 encodes rect + path shapes; masks fall through as `kUnsupported`.
+  kPushClip = 30,
+  kPopClip = 31,
+
+  /// Isolated compositing layer (opacity + blend mode only).
+  kPushIsolatedLayer = 40,
+  kPopIsolatedLayer = 41,
+
+  /// Paint state. S2 encodes `PaintServer::None` and `PaintServer::Solid`; any
+  /// other paint-server variant (gradient, pattern, resolved reference) emits
+  /// `kUnsupported` and the frame is considered lossy.
+  kSetPaint = 50,
+
+  /// Mask sub-scope. Between `kPushMask` and `kTransitionMaskToContent`
+  /// the stream carries the mask's own drawing commands (what will be
+  /// used to derive the alpha mask). Between `kTransitionMaskToContent`
+  /// and `kPopMask` the stream carries the masked content itself.
+  kPushMask = 42,
+  kTransitionMaskToContent = 43,
+  kPopMask = 44,
+
+  /// Pattern tile sub-scope. Draw calls between `kBeginPatternTile` and
+  /// `kEndPatternTile` are recorded into an offscreen pattern surface
+  /// instead of the main framebuffer, then used as the paint source for
+  /// the next draw call.
+  kBeginPatternTile = 45,
+  kEndPatternTile = 46,
+
+  /// Drawing primitives.
+  kDrawPath = 60,
+  kDrawRect = 61,
+  kDrawEllipse = 62,
+  kDrawImage = 63,
+  kDrawText = 64,
+
+  /// Filter layer sub-scope (transparent pass-through in S2 — the primitive
+  /// chain is not yet serialized, so the filter has no visual effect but
+  /// preserves the compositing stack).
+  kPushFilterLayer = 47,
+  kPopFilterLayer = 48,
+
+  /// Placeholder for any method `SerializingRenderer` can't faithfully encode
+  /// (text — see `UnsupportedKind`). Payload is a single u32 identifying
+  /// which kind was hit, for diagnostics.
+  kUnsupported = 1000,
+};
+
+/// Tag identifying which unsupported `RendererInterface` method was skipped.
+enum class UnsupportedKind : uint32_t {
+  kPushFilterLayer = 1,
+  kPopFilterLayer = 2,
+  kPushMask = 3,
+  kTransitionMaskToContent = 4,
+  kPopMask = 5,
+  kBeginPatternTile = 6,
+  kEndPatternTile = 7,
+  kDrawImage = 8,
+  kDrawText = 9,
+  kPaintServerGradient = 10,
+  kPaintServerPattern = 11,
+  kPaintServerResolvedReference = 12,
+  kClipMaskChain = 13,
+  kColorNonRgba = 14,
+};
+
+/// Append-only byte buffer writer. Cheap by design — a `std::vector<uint8_t>`
+/// owner with a few typed helpers. No growth policy beyond the vector's.
+class WireWriter {
+public:
+  /// Total bytes written so far.
+  [[nodiscard]] std::size_t size() const { return buffer_.size(); }
+
+  /// Returns a view of the accumulated bytes.
+  [[nodiscard]] std::span<const uint8_t> data() const { return buffer_; }
+
+  /// Releases ownership of the accumulated bytes.
+  [[nodiscard]] std::vector<uint8_t> take() && { return std::move(buffer_); }
+
+  /// @name Primitives
+  /// All writes are little-endian.
+  /// @{
+  void writeU8(uint8_t v) { buffer_.push_back(v); }
+  void writeU32(uint32_t v) { writePod(v); }
+  void writeI32(int32_t v) { writePod(v); }
+  void writeU64(uint64_t v) { writePod(v); }
+  void writeF64(double v) { writePod(v); }
+  void writeBool(bool v) { writeU8(v ? 1 : 0); }
+
+  void writeBytes(std::span<const uint8_t> bytes) {
+    buffer_.insert(buffer_.end(), bytes.begin(), bytes.end());
+  }
+
+  void writeString(std::string_view s) {
+    writeU32(static_cast<uint32_t>(s.size()));
+    buffer_.insert(buffer_.end(), s.begin(), s.end());
+  }
+  /// @}
+
+  /// Writes a raw message header: `u32 opcode, u32 payload_length`. The caller
+  /// is responsible for appending `payload_length` bytes immediately after.
+  void writeMessageHeader(Opcode opcode, uint32_t payloadLength) {
+    writeU32(static_cast<uint32_t>(opcode));
+    writeU32(payloadLength);
+  }
+
+  /// Reserves a payload-length slot before the payload is encoded, returning a
+  /// token the caller hands back to `finishMessage()` once the payload is
+  /// complete. This avoids having to buffer the payload twice.
+  struct MessageToken {
+    std::size_t lengthOffset;
+    std::size_t payloadStart;
+  };
+
+  [[nodiscard]] MessageToken beginMessage(Opcode opcode) {
+    writeU32(static_cast<uint32_t>(opcode));
+    const std::size_t lengthOffset = buffer_.size();
+    writeU32(0);  // placeholder
+    return MessageToken{lengthOffset, buffer_.size()};
+  }
+
+  void finishMessage(MessageToken token) {
+    const std::size_t payloadBytes = buffer_.size() - token.payloadStart;
+    const auto len = static_cast<uint32_t>(payloadBytes);
+    std::memcpy(buffer_.data() + token.lengthOffset, &len, sizeof(len));
+  }
+
+private:
+  template <typename T>
+  void writePod(T value) {
+    static_assert(std::is_trivially_copyable_v<T>);
+    const auto offset = buffer_.size();
+    buffer_.resize(offset + sizeof(T));
+    std::memcpy(buffer_.data() + offset, &value, sizeof(T));
+  }
+
+  std::vector<uint8_t> buffer_;
+};
+
+/// Read cursor into an immutable byte span. Every read that could overflow the
+/// buffer returns `false` and leaves `failed_` set, so callers can do their
+/// work without interleaved error checking and verify success at the end.
+class WireReader {
+public:
+  explicit WireReader(std::span<const uint8_t> bytes) : bytes_(bytes) {}
+
+  [[nodiscard]] bool failed() const { return failed_; }
+  [[nodiscard]] std::size_t remaining() const {
+    return failed_ ? 0 : (bytes_.size() - pos_);
+  }
+  [[nodiscard]] std::size_t position() const { return pos_; }
+
+  /// Manually mark the reader failed (e.g., when a higher-level invariant is
+  /// violated like an unknown variant tag).
+  void fail() { failed_ = true; }
+
+  /// Seeks forward by `n` bytes, e.g. to skip over a payload the caller doesn't
+  /// understand. Fails on overflow.
+  [[nodiscard]] bool skip(std::size_t n) {
+    if (!check(n)) return false;
+    pos_ += n;
+    return true;
+  }
+
+  /// @name Primitive reads
+  /// @{
+  [[nodiscard]] bool readU8(uint8_t& out) {
+    if (!check(1)) return false;
+    out = bytes_[pos_++];
+    return true;
+  }
+
+  [[nodiscard]] bool readU32(uint32_t& out) { return readPod(out); }
+  [[nodiscard]] bool readI32(int32_t& out) { return readPod(out); }
+  [[nodiscard]] bool readU64(uint64_t& out) { return readPod(out); }
+  [[nodiscard]] bool readF64(double& out) { return readPod(out); }
+
+  [[nodiscard]] bool readBool(bool& out) {
+    uint8_t v = 0;
+    if (!readU8(v)) return false;
+    if (v > 1) {
+      failed_ = true;
+      return false;
+    }
+    out = (v != 0);
+    return true;
+  }
+
+  [[nodiscard]] bool readString(std::string& out, uint32_t maxBytes = kMaxStringBytes) {
+    uint32_t len = 0;
+    if (!readU32(len)) return false;
+    if (len > maxBytes || !check(len)) {
+      failed_ = true;
+      return false;
+    }
+    out.assign(reinterpret_cast<const char*>(bytes_.data() + pos_), len);
+    pos_ += len;
+    return true;
+  }
+
+  [[nodiscard]] bool readBytes(std::span<uint8_t> out) {
+    if (!check(out.size())) return false;
+    std::memcpy(out.data(), bytes_.data() + pos_, out.size());
+    pos_ += out.size();
+    return true;
+  }
+
+  /// Reads a `u32` length field and validates it against a per-field cap
+  /// before the caller allocates anything. Returns the length on success.
+  [[nodiscard]] bool readCount(uint32_t& out, uint32_t maxCount) {
+    if (!readU32(out)) return false;
+    if (out > maxCount) {
+      failed_ = true;
+      return false;
+    }
+    return true;
+  }
+  /// @}
+
+  /// Reads `u32 opcode, u32 payload_length` from the head of the buffer.
+  [[nodiscard]] bool readMessageHeader(Opcode& outOpcode, uint32_t& outPayloadLength) {
+    uint32_t rawOp = 0;
+    if (!readU32(rawOp) || !readU32(outPayloadLength)) return false;
+    if (outPayloadLength > kMaxPayloadBytes) {
+      failed_ = true;
+      return false;
+    }
+    outOpcode = static_cast<Opcode>(rawOp);
+    return true;
+  }
+
+private:
+  template <typename T>
+  bool readPod(T& out) {
+    static_assert(std::is_trivially_copyable_v<T>);
+    if (!check(sizeof(T))) return false;
+    std::memcpy(&out, bytes_.data() + pos_, sizeof(T));
+    pos_ += sizeof(T);
+    return true;
+  }
+
+  [[nodiscard]] bool check(std::size_t n) {
+    if (failed_) return false;
+    if (n > bytes_.size() - pos_) {
+      failed_ = true;
+      return false;
+    }
+    return true;
+  }
+
+  std::span<const uint8_t> bytes_;
+  std::size_t pos_ = 0;
+  bool failed_ = false;
+};
+
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/parser_child_main.cc
+++ b/donner/editor/sandbox/parser_child_main.cc
@@ -1,0 +1,111 @@
+/// @file
+///
+/// Sandbox child binary: reads SVG bytes from stdin, parses, drives the
+/// renderer via `SerializingRenderer`, and streams wire-format bytes to
+/// stdout. Exits non-zero on any failure.
+///
+/// S3 protocol (one-shot):
+/// - `argv`:   `donner_parser_child <width> <height>`
+/// - `stdin`:  raw SVG bytes (read to EOF)
+/// - `stdout`: wire-format message stream (see `donner/editor/sandbox/Wire.h`)
+/// - `stderr`: human-readable diagnostics on any failure path
+/// - exit:     see `SandboxProtocol.h` for exit-code classification
+///
+/// The child deliberately does **not** link a rasterizer. Pixel generation is
+/// a host concern — the sandbox just converts an SVG bytestring into an
+/// equivalent stream of `RendererInterface` calls that any host backend can
+/// replay.
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "donner/base/ParseWarningSink.h"
+#include "donner/editor/sandbox/SandboxHardening.h"
+#include "donner/editor/sandbox/SandboxProtocol.h"
+#include "donner/editor/sandbox/SerializingRenderer.h"
+#include "donner/svg/SVG.h"
+#include "donner/svg/renderer/RendererInterface.h"
+
+namespace {
+
+constexpr int kMaxDimension = 16384;
+
+std::string ReadAllStdin() {
+  std::ostringstream oss;
+  oss << std::cin.rdbuf();
+  return std::move(oss).str();
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+  using namespace donner;                  // NOLINT(google-build-using-namespace)
+  using namespace donner::editor::sandbox;  // NOLINT(google-build-using-namespace)
+  using namespace donner::svg;              // NOLINT(google-build-using-namespace)
+  using namespace donner::svg::parser;      // NOLINT(google-build-using-namespace)
+
+  if (argc != 3) {
+    std::fprintf(stderr, "usage: donner_parser_child <width> <height>\n");
+    return kExitUsageError;
+  }
+
+  const int width = std::atoi(argv[1]);
+  const int height = std::atoi(argv[2]);
+  if (width <= 0 || height <= 0 || width > kMaxDimension || height > kMaxDimension) {
+    std::fprintf(stderr, "invalid dimensions: %dx%d\n", width, height);
+    return kExitUsageError;
+  }
+
+  // Apply the S6 hardening profile BEFORE touching any untrusted input. This
+  // covers RLIMIT caps, FD sweep, chdir(/), and the DONNER_SANDBOX env gate.
+  // A non-kOk status here is fatal — the sandbox contract is all-or-nothing.
+  const auto hardening = ApplyHardening();
+  if (hardening.status != HardeningStatus::kOk) {
+    std::fprintf(stderr, "sandbox hardening failed: %s\n", hardening.message.c_str());
+    return kExitUsageError;
+  }
+
+  const std::string svg = ReadAllStdin();
+
+  ParseWarningSink warnings;
+  ParseResult<SVGDocument> maybeDocument = SVGParser::ParseSVG(svg, warnings);
+  if (maybeDocument.hasError()) {
+    std::ostringstream errStream;
+    errStream << maybeDocument.error();
+    std::fprintf(stderr, "parse error: %s\n", errStream.str().c_str());
+    return kExitParseError;
+  }
+
+  SVGDocument document = std::move(maybeDocument.result());
+  document.setCanvasSize(width, height);
+
+  SerializingRenderer renderer;
+  renderer.draw(document);
+
+  const auto wire = renderer.data();
+  if (wire.empty()) {
+    std::fprintf(stderr, "empty wire stream from SerializingRenderer\n");
+    return kExitRenderError;
+  }
+
+  if (std::fwrite(wire.data(), 1, wire.size(), stdout) != wire.size()) {
+    std::fprintf(stderr, "stdout write truncated\n");
+    return kExitRenderError;
+  }
+  std::fflush(stdout);
+
+  if (renderer.hasUnsupported()) {
+    // Non-fatal: the host will see `kEncounteredUnsupported` from the replayer
+    // and surface it to the user. We still exit 0 because the frame was
+    // emitted successfully — callers can inspect the stderr channel for the
+    // specific count.
+    std::fprintf(stderr, "warning: %zu unsupported call(s) encoded as kUnsupported\n",
+                 renderer.unsupportedCount());
+  }
+  return kExitOk;
+}

--- a/donner/editor/sandbox/sandbox_inspect_main.cc
+++ b/donner/editor/sandbox/sandbox_inspect_main.cc
@@ -1,0 +1,47 @@
+/// @file
+///
+/// `sandbox_inspect` — loads a `.rnr` recording and prints the decoded
+/// command stream as an indented text table. It's the text-mode version of
+/// the eventual ImGui frame inspector panel described in
+/// `docs/design_docs/editor_sandbox.md` S4, and usable today for debugging
+/// and bug reports even before the editor UI lands.
+///
+/// Usage:
+///     sandbox_inspect <input.rnr>
+
+#include <cstdio>
+#include <filesystem>
+#include <vector>
+
+#include "donner/editor/sandbox/FrameInspector.h"
+#include "donner/editor/sandbox/RnrFile.h"
+
+int main(int argc, char* argv[]) {
+  using namespace donner::editor::sandbox;  // NOLINT(google-build-using-namespace)
+
+  if (argc != 2) {
+    std::fprintf(stderr, "usage: sandbox_inspect <input.rnr>\n");
+    return 64;
+  }
+
+  const std::filesystem::path inputPath = argv[1];
+  RnrHeader header;
+  std::vector<uint8_t> wire;
+  const auto loadStatus = LoadRnrFile(inputPath, header, wire);
+  if (loadStatus != RnrIoStatus::kOk) {
+    std::fprintf(stderr, "sandbox_inspect: load failed (status=%d)\n",
+                 static_cast<int>(loadStatus));
+    return 66;
+  }
+
+  std::fprintf(stdout, "# rnr file: %s\n", inputPath.string().c_str());
+  std::fprintf(stdout, "# viewport: %ux%u\n", header.width, header.height);
+  std::fprintf(stdout, "# backend:  %u\n", static_cast<uint32_t>(header.backend));
+  std::fprintf(stdout, "# uri:      %s\n", header.uri.c_str());
+  std::fprintf(stdout, "# wire bytes: %zu\n", wire.size());
+  std::fprintf(stdout, "\n");
+
+  const std::string dump = FrameInspector::Dump(wire);
+  std::fwrite(dump.data(), 1, dump.size(), stdout);
+  return 0;
+}

--- a/donner/editor/sandbox/sandbox_render_main.cc
+++ b/donner/editor/sandbox/sandbox_render_main.cc
@@ -1,0 +1,133 @@
+/// @file
+///
+/// `sandbox_render` — command-line tool that exercises the full editor
+/// sandbox pipeline end-to-end:
+///
+///     SvgSource -> SandboxHost -> donner_parser_child -> wire format
+///                -> ReplayingRenderer -> RendererTinySkia -> PNG
+///
+/// It's the address bar's code path with the UI replaced by argv. When the
+/// editor's M2 actually lands, `EditorApp::navigate(uri)` will call the same
+/// sequence of functions — this CLI is how we prove the sequence works
+/// before there's a UI to drive it.
+///
+/// Usage:
+///     sandbox_render <uri> <width> <height> <output.png>
+///
+/// The child binary path is expected to sit next to this binary in the same
+/// runfiles tree (`donner/editor/sandbox/donner_parser_child`). Override
+/// with `DONNER_PARSER_CHILD=/abs/path` if you're running outside Bazel's
+/// runfiles layout.
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "donner/editor/sandbox/SandboxHost.h"
+#include "donner/editor/sandbox/SvgSource.h"
+#include "donner/svg/renderer/RendererImageIO.h"
+#include "donner/svg/renderer/RendererTinySkia.h"
+
+namespace {
+
+int Usage() {
+  std::fprintf(stderr, "usage: sandbox_render <uri> <width> <height> <output.png>\n");
+  return 64;  // EX_USAGE
+}
+
+std::string ResolveChildPath(const char* argv0) {
+  if (const char* override = std::getenv("DONNER_PARSER_CHILD"); override && *override) {
+    return override;
+  }
+  // Fall back to a sibling binary in the same runfiles directory as argv[0].
+  // Works under `bazel run` and for installed builds alike.
+  namespace fs = std::filesystem;
+  std::error_code ec;
+  const fs::path self(argv0);
+  const fs::path parent = self.parent_path();
+  const fs::path sibling = parent / "donner_parser_child";
+  if (fs::exists(sibling, ec)) {
+    return sibling.string();
+  }
+  // Last resort: let posix_spawn search PATH.
+  return "donner_parser_child";
+}
+
+bool WritePngFile(const std::filesystem::path& path,
+                  const std::vector<uint8_t>& bytes) {
+  std::ofstream out(path, std::ios::binary);
+  if (!out) return false;
+  out.write(reinterpret_cast<const char*>(bytes.data()),
+            static_cast<std::streamsize>(bytes.size()));
+  return out.good();
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+  using namespace donner::editor::sandbox;  // NOLINT(google-build-using-namespace)
+
+  if (argc != 5) return Usage();
+
+  const char* uri = argv[1];
+  const int width = std::atoi(argv[2]);
+  const int height = std::atoi(argv[3]);
+  const std::filesystem::path outputPath = argv[4];
+
+  if (width <= 0 || height <= 0) {
+    std::fprintf(stderr, "sandbox_render: width and height must be positive integers\n");
+    return Usage();
+  }
+
+  // Step 1: fetch the SVG bytes (host-side privilege).
+  SvgSource source;
+  const auto fetch = source.fetch(uri);
+  if (fetch.status != SvgFetchStatus::kOk) {
+    std::fprintf(stderr, "sandbox_render: fetch failed: %s\n", fetch.diagnostics.c_str());
+    return 66;  // EX_NOINPUT
+  }
+
+  // Step 2: hand the bytes to the sandbox child, replay its wire stream into
+  // a local RendererTinySkia backend.
+  SandboxHost host(ResolveChildPath(argv[0]));
+  const std::string_view svgView(reinterpret_cast<const char*>(fetch.bytes.data()),
+                                 fetch.bytes.size());
+
+  donner::svg::RendererTinySkia backend;
+  const auto result = host.renderToBackend(svgView, width, height, backend);
+  if (result.status != SandboxStatus::kOk) {
+    std::fprintf(stderr, "sandbox_render: sandbox render failed (status=%d, exit=%d): %s\n",
+                 static_cast<int>(result.status), result.exitCode, result.diagnostics.c_str());
+    return 70;  // EX_SOFTWARE
+  }
+  if (result.unsupportedCount > 0) {
+    std::fprintf(stderr, "sandbox_render: warning: %u unsupported call(s) skipped\n",
+                 result.unsupportedCount);
+  }
+
+  // Step 3: encode the backend's snapshot to PNG and write it out.
+  const donner::svg::RendererBitmap bitmap = backend.takeSnapshot();
+  if (bitmap.dimensions.x <= 0 || bitmap.dimensions.y <= 0 || bitmap.pixels.empty()) {
+    std::fprintf(stderr, "sandbox_render: empty snapshot after replay\n");
+    return 70;
+  }
+
+  const auto png = donner::svg::RendererImageIO::writeRgbaPixelsToPngMemory(
+      bitmap.pixels, bitmap.dimensions.x, bitmap.dimensions.y,
+      bitmap.rowBytes / 4);
+  if (png.empty() || !WritePngFile(outputPath, png)) {
+    std::fprintf(stderr, "sandbox_render: failed to write PNG to %s\n",
+                 outputPath.string().c_str());
+    return 73;  // EX_CANTCREAT
+  }
+
+  std::printf("sandbox_render: wrote %s (%dx%d)\n", outputPath.string().c_str(),
+              bitmap.dimensions.x, bitmap.dimensions.y);
+  return 0;
+}

--- a/donner/editor/sandbox/sandbox_replay_main.cc
+++ b/donner/editor/sandbox/sandbox_replay_main.cc
@@ -1,0 +1,105 @@
+/// @file
+///
+/// `sandbox_replay` — loads a `.rnr` recording and rasterizes it via
+/// `RendererTinySkia` to a PNG. Purely host-side: no sandbox child, no
+/// parser, no network. This is the end-to-end proof that `.rnr` files are
+/// self-contained and deterministic — the only inputs are the bytes on
+/// disk.
+///
+/// Usage:
+///     sandbox_replay <input.rnr> <output.png>
+
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "donner/editor/sandbox/FrameInspector.h"
+#include "donner/editor/sandbox/ReplayingRenderer.h"
+#include "donner/editor/sandbox/RnrFile.h"
+#include "donner/svg/renderer/RendererImageIO.h"
+#include "donner/svg/renderer/RendererTinySkia.h"
+
+namespace {
+
+int Usage() {
+  std::fprintf(stderr, "usage: sandbox_replay <input.rnr> <output.png>\n");
+  return 64;
+}
+
+bool WritePngFile(const std::filesystem::path& path,
+                  const std::vector<uint8_t>& bytes) {
+  std::ofstream out(path, std::ios::binary);
+  if (!out) return false;
+  out.write(reinterpret_cast<const char*>(bytes.data()),
+            static_cast<std::streamsize>(bytes.size()));
+  return out.good();
+}
+
+const char* RnrStatusString(donner::editor::sandbox::RnrIoStatus status) {
+  using donner::editor::sandbox::RnrIoStatus;
+  switch (status) {
+    case RnrIoStatus::kOk:               return "ok";
+    case RnrIoStatus::kWriteFailed:      return "write failed";
+    case RnrIoStatus::kReadFailed:       return "read failed";
+    case RnrIoStatus::kTruncated:        return "truncated header";
+    case RnrIoStatus::kMagicMismatch:    return "magic mismatch";
+    case RnrIoStatus::kVersionMismatch:  return "version mismatch";
+    case RnrIoStatus::kUriTooLong:       return "uri too long";
+  }
+  return "unknown";
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+  using namespace donner::editor::sandbox;  // NOLINT(google-build-using-namespace)
+
+  if (argc != 3) return Usage();
+
+  const std::filesystem::path inputPath = argv[1];
+  const std::filesystem::path outputPath = argv[2];
+
+  RnrHeader header;
+  std::vector<uint8_t> wire;
+  const auto loadStatus = LoadRnrFile(inputPath, header, wire);
+  if (loadStatus != RnrIoStatus::kOk) {
+    std::fprintf(stderr, "sandbox_replay: load failed: %s\n", RnrStatusString(loadStatus));
+    return 66;
+  }
+
+  std::fprintf(stdout, "sandbox_replay: loaded %s (%ux%u, backend hint=%u, uri='%s')\n",
+               inputPath.string().c_str(), header.width, header.height,
+               static_cast<uint32_t>(header.backend), header.uri.c_str());
+
+  donner::svg::RendererTinySkia backend;
+  const auto status = FrameInspector::ReplayPrefix(
+      wire, std::numeric_limits<std::size_t>::max(), backend);
+  if (status != ReplayStatus::kOk && status != ReplayStatus::kEncounteredUnsupported) {
+    std::fprintf(stderr, "sandbox_replay: replay failed (status=%d)\n",
+                 static_cast<int>(status));
+    return 70;
+  }
+  if (status == ReplayStatus::kEncounteredUnsupported) {
+    std::fprintf(stderr, "sandbox_replay: warning: stream contained unsupported messages\n");
+  }
+
+  const auto bitmap = backend.takeSnapshot();
+  if (bitmap.dimensions.x <= 0 || bitmap.dimensions.y <= 0 || bitmap.pixels.empty()) {
+    std::fprintf(stderr, "sandbox_replay: empty snapshot after replay\n");
+    return 70;
+  }
+  const auto png = donner::svg::RendererImageIO::writeRgbaPixelsToPngMemory(
+      bitmap.pixels, bitmap.dimensions.x, bitmap.dimensions.y,
+      bitmap.rowBytes / 4);
+  if (png.empty() || !WritePngFile(outputPath, png)) {
+    std::fprintf(stderr, "sandbox_replay: failed to write PNG to %s\n",
+                 outputPath.string().c_str());
+    return 73;
+  }
+  std::fprintf(stdout, "sandbox_replay: wrote %s (%dx%d)\n", outputPath.string().c_str(),
+               bitmap.dimensions.x, bitmap.dimensions.y);
+  return 0;
+}

--- a/donner/editor/sandbox/tests/BUILD.bazel
+++ b/donner/editor/sandbox/tests/BUILD.bazel
@@ -1,0 +1,120 @@
+"""Tests for the Milestone S1 editor sandbox.
+
+These tests spawn `donner_parser_child` as a subprocess via `SandboxHost`,
+verify that well-formed SVG round-trips to a PNG, and — critically — verify
+the host survives adversarial input that crashes the child.
+"""
+
+load("//build_defs:rules.bzl", "donner_cc_test", "renderer_backend_compatible_with")
+
+donner_cc_test(
+    name = "sandbox_host_tests",
+    srcs = ["SandboxHost_tests.cc"],
+    data = [
+        "//donner/editor/sandbox:donner_parser_child",
+    ],
+    target_compatible_with = renderer_backend_compatible_with(["tiny_skia"]),
+    deps = [
+        "//donner/base",
+        "//donner/base:base_test_utils",
+        "//donner/editor/sandbox:sandbox_host",
+        "//donner/editor/sandbox:sandbox_protocol",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
+    name = "sandbox_pipeline_tests",
+    srcs = ["SandboxPipeline_tests.cc"],
+    data = [
+        "//donner/editor/sandbox:donner_parser_child",
+    ],
+    target_compatible_with = renderer_backend_compatible_with(["tiny_skia"]),
+    deps = [
+        "//donner/base",
+        "//donner/base:base_test_utils",
+        "//donner/editor/sandbox:sandbox_host",
+        "//donner/svg",
+        "//donner/svg/parser",
+        "//donner/svg/renderer:renderer_interface",
+        "//donner/svg/renderer:renderer_tiny_skia",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
+    name = "record_replay_tests",
+    srcs = ["RecordReplay_tests.cc"],
+    target_compatible_with = renderer_backend_compatible_with(["tiny_skia"]),
+    deps = [
+        "//donner/base",
+        "//donner/editor/sandbox:frame_inspector",
+        "//donner/editor/sandbox:replaying_renderer",
+        "//donner/editor/sandbox:rnr_file",
+        "//donner/editor/sandbox:serializing_renderer",
+        "//donner/editor/sandbox:wire",
+        "//donner/svg",
+        "//donner/svg/parser",
+        "//donner/svg/renderer:renderer_interface",
+        "//donner/svg/renderer:renderer_tiny_skia",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
+    name = "sandbox_hardening_tests",
+    srcs = ["SandboxHardening_tests.cc"],
+    data = [
+        "//donner/editor/sandbox:donner_parser_child",
+    ],
+    target_compatible_with = renderer_backend_compatible_with(["tiny_skia"]),
+    deps = [
+        "//donner/base",
+        "//donner/base:base_test_utils",
+        "//donner/editor/sandbox:sandbox_hardening",
+        "//donner/editor/sandbox:sandbox_protocol",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
+    name = "svg_source_tests",
+    srcs = ["SvgSource_tests.cc"],
+    deps = [
+        "//donner/editor/sandbox:svg_source",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
+    name = "pipelined_renderer_tests",
+    srcs = ["PipelinedRenderer_tests.cc"],
+    target_compatible_with = renderer_backend_compatible_with(["tiny_skia"]),
+    deps = [
+        "//donner/base",
+        "//donner/editor/sandbox:pipelined_renderer",
+        "//donner/svg",
+        "//donner/svg/parser",
+        "//donner/svg/renderer:renderer_interface",
+        "//donner/svg/renderer:renderer_tiny_skia",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
+    name = "wire_format_tests",
+    srcs = ["WireFormat_tests.cc"],
+    target_compatible_with = renderer_backend_compatible_with(["tiny_skia"]),
+    deps = [
+        "//donner/base",
+        "//donner/editor/sandbox:replaying_renderer",
+        "//donner/editor/sandbox:sandbox_codecs",
+        "//donner/editor/sandbox:serializing_renderer",
+        "//donner/editor/sandbox:wire",
+        "//donner/svg",
+        "//donner/svg/parser",
+        "//donner/svg/renderer:renderer_interface",
+        "//donner/svg/renderer:renderer_tiny_skia",
+        "@com_google_gtest//:gtest_main",
+    ],
+)

--- a/donner/editor/sandbox/tests/PipelinedRenderer_tests.cc
+++ b/donner/editor/sandbox/tests/PipelinedRenderer_tests.cc
@@ -1,0 +1,146 @@
+/// @file
+///
+/// Tests for `PipelinedRenderer` — the in-process, multi-threaded variant of
+/// the sandbox wire pipeline. Verifies:
+///  1. `submit()` → `waitForFrame()` produces a bitmap equal to an in-process
+///     render for the same SVG (lossless across the thread boundary).
+///  2. Multiple submissions each produce a distinct `frameId` and return the
+///     newest rasterized frame.
+///  3. "Newest wins" — queueing several frames without draining only requires
+///     the last one to survive.
+///  4. The worker thread shuts down cleanly when the renderer is destroyed,
+///     even if a frame is still in-flight.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <string_view>
+#include <thread>
+#include <utility>
+
+#include "donner/base/ParseWarningSink.h"
+#include "donner/editor/sandbox/PipelinedRenderer.h"
+#include "donner/svg/SVG.h"
+#include "donner/svg/renderer/RendererInterface.h"
+#include "donner/svg/renderer/RendererTinySkia.h"
+
+namespace donner::editor::sandbox {
+namespace {
+
+svg::SVGDocument ParseOrDie(std::string_view svg) {
+  ParseWarningSink warnings;
+  auto result = svg::parser::SVGParser::ParseSVG(svg, warnings);
+  EXPECT_FALSE(result.hasError()) << result.error();
+  return std::move(result.result());
+}
+
+svg::RendererBitmap RenderInProcess(std::string_view svg, int w, int h) {
+  auto doc = ParseOrDie(svg);
+  doc.setCanvasSize(w, h);
+  svg::RendererTinySkia renderer;
+  renderer.draw(doc);
+  return renderer.takeSnapshot();
+}
+
+constexpr std::string_view kSimpleSvg =
+    R"(<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+       <rect width="32" height="32" fill="red"/>
+     </svg>)";
+
+TEST(PipelinedRendererTest, SingleFrameMatchesInProcess) {
+  PipelinedRenderer pipeline;
+  auto doc = ParseOrDie(kSimpleSvg);
+
+  const uint64_t id = pipeline.submit(doc, 32, 32);
+  const auto frame = pipeline.waitForFrame(id);
+  ASSERT_TRUE(frame.has_value());
+  EXPECT_EQ(frame->frameId, id);
+  EXPECT_TRUE(frame->ok);
+  EXPECT_EQ(frame->unsupportedCount, 0u);
+
+  const auto direct = RenderInProcess(kSimpleSvg, 32, 32);
+  ASSERT_EQ(frame->bitmap.dimensions, direct.dimensions);
+  EXPECT_EQ(frame->bitmap.pixels, direct.pixels)
+      << "pipeline rasterization must be pixel-identical to in-process";
+}
+
+TEST(PipelinedRendererTest, FrameIdsMonotonicallyIncrease) {
+  PipelinedRenderer pipeline;
+  auto doc1 = ParseOrDie(kSimpleSvg);
+  auto doc2 = ParseOrDie(kSimpleSvg);
+  auto doc3 = ParseOrDie(kSimpleSvg);
+
+  const uint64_t id1 = pipeline.submit(doc1, 32, 32);
+  const uint64_t id2 = pipeline.submit(doc2, 32, 32);
+  const uint64_t id3 = pipeline.submit(doc3, 32, 32);
+  EXPECT_LT(id1, id2);
+  EXPECT_LT(id2, id3);
+
+  // Wait for the highest frame id — the worker will eventually complete
+  // something ≥ id3, possibly after skipping id1/id2 under the newest-wins
+  // policy.
+  const auto frame = pipeline.waitForFrame(id3);
+  ASSERT_TRUE(frame.has_value());
+  EXPECT_GE(frame->frameId, id3);
+}
+
+TEST(PipelinedRendererTest, NewestWinsWhenQueuingSeveralFrames) {
+  PipelinedRenderer pipeline;
+
+  // Fire several submits rapidly; only the last one is guaranteed to
+  // eventually land. The worker may happen to rasterize earlier ones, but
+  // nothing in the API promises that.
+  uint64_t lastId = 0;
+  for (int i = 0; i < 5; ++i) {
+    auto doc = ParseOrDie(kSimpleSvg);
+    lastId = pipeline.submit(doc, 32, 32);
+  }
+
+  const auto frame = pipeline.waitForFrame(lastId);
+  ASSERT_TRUE(frame.has_value());
+  EXPECT_GE(frame->frameId, lastId);
+  EXPECT_TRUE(frame->ok);
+}
+
+TEST(PipelinedRendererTest, ShutdownIsClean) {
+  // Smoke test: constructing and destructing a pipeline without any frames
+  // must not deadlock. Also: destructing mid-submission must not crash.
+  {
+    PipelinedRenderer idle;
+  }
+  {
+    PipelinedRenderer inFlight;
+    auto doc = ParseOrDie(kSimpleSvg);
+    inFlight.submit(doc, 32, 32);
+    // Do not wait — the destructor should join the worker regardless.
+  }
+}
+
+TEST(PipelinedRendererTest, AcquireLatestReturnsNulloptBeforeFirstFrame) {
+  PipelinedRenderer pipeline;
+  EXPECT_FALSE(pipeline.acquireLatestFrame().has_value());
+}
+
+TEST(PipelinedRendererTest, PipelineMatchesComplexRender) {
+  constexpr std::string_view kComplex =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+         <g transform="translate(10 10)">
+           <rect width="30" height="30" fill="green"/>
+           <circle cx="60" cy="60" r="20" fill="orange"/>
+         </g>
+       </svg>)svg";
+
+  PipelinedRenderer pipeline;
+  auto doc = ParseOrDie(kComplex);
+  const uint64_t id = pipeline.submit(doc, 100, 100);
+  const auto frame = pipeline.waitForFrame(id);
+  ASSERT_TRUE(frame.has_value());
+  ASSERT_TRUE(frame->ok);
+
+  const auto direct = RenderInProcess(kComplex, 100, 100);
+  ASSERT_EQ(frame->bitmap.dimensions, direct.dimensions);
+  EXPECT_EQ(frame->bitmap.pixels, direct.pixels);
+}
+
+}  // namespace
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/tests/RecordReplay_tests.cc
+++ b/donner/editor/sandbox/tests/RecordReplay_tests.cc
@@ -1,0 +1,300 @@
+/// @file
+///
+/// Tests for S4 record/replay and the headless frame inspector. These
+/// cover three things:
+///
+/// 1. **`.rnr` file round-trip** — encode + decode header, handle truncation,
+///    bad magic, and version mismatches.
+/// 2. **`FrameInspector::Decode`** — parses a serialized frame and produces a
+///    sensible command list (indices, depth tracking, summaries that aren't
+///    empty for supported opcodes).
+/// 3. **Pixel round-trip through a `.rnr` file** — serialize → save → load →
+///    replay → compare against an in-process RendererTinySkia render, and
+///    verify the result is byte-identical.
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "donner/base/ParseWarningSink.h"
+#include "donner/editor/sandbox/FrameInspector.h"
+#include "donner/editor/sandbox/ReplayingRenderer.h"
+#include "donner/editor/sandbox/RnrFile.h"
+#include "donner/editor/sandbox/SerializingRenderer.h"
+#include "donner/editor/sandbox/Wire.h"
+#include "donner/svg/SVG.h"
+#include "donner/svg/renderer/RendererInterface.h"
+#include "donner/svg/renderer/RendererTinySkia.h"
+
+namespace donner::editor::sandbox {
+namespace {
+
+constexpr std::string_view kSvg =
+    R"(<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+       <g>
+         <rect width="64" height="64" fill="red"/>
+         <rect x="16" y="16" width="32" height="32" fill="blue"/>
+       </g>
+     </svg>)";
+
+svg::SVGDocument ParseOrDie(std::string_view svg) {
+  ParseWarningSink warnings;
+  auto result = svg::parser::SVGParser::ParseSVG(svg, warnings);
+  EXPECT_FALSE(result.hasError()) << result.error();
+  return std::move(result.result());
+}
+
+std::vector<uint8_t> SerializeSimpleFrame(std::string_view svg, int w, int h) {
+  auto doc = ParseOrDie(svg);
+  doc.setCanvasSize(w, h);
+  SerializingRenderer serializer;
+  serializer.draw(doc);
+  return std::move(serializer).takeBuffer();
+}
+
+svg::RendererBitmap RenderInProcess(std::string_view svg, int w, int h) {
+  auto doc = ParseOrDie(svg);
+  doc.setCanvasSize(w, h);
+  svg::RendererTinySkia renderer;
+  renderer.draw(doc);
+  return renderer.takeSnapshot();
+}
+
+// -----------------------------------------------------------------------------
+// RnrFile round-trip
+// -----------------------------------------------------------------------------
+
+TEST(RnrFileTest, EncodeDecodeMemoryBufferRoundTrips) {
+  RnrHeader header;
+  header.timestampNanos = 1744487136ull * 1'000'000'000ull;
+  header.width = 640;
+  header.height = 480;
+  header.backend = BackendHint::kTinySkia;
+  header.uri = "file:///tmp/test.svg";
+
+  const std::vector<uint8_t> wire = {0x01, 0x02, 0x03, 0x04, 0xDE, 0xAD, 0xBE, 0xEF};
+
+  const auto encoded = EncodeRnrBuffer(header, wire);
+
+  RnrHeader decodedHeader;
+  std::vector<uint8_t> decodedWire;
+  ASSERT_EQ(ParseRnrBuffer(encoded, decodedHeader, decodedWire), RnrIoStatus::kOk);
+  EXPECT_EQ(decodedHeader.fileVersion, kRnrFileVersion);
+  EXPECT_EQ(decodedHeader.timestampNanos, header.timestampNanos);
+  EXPECT_EQ(decodedHeader.width, header.width);
+  EXPECT_EQ(decodedHeader.height, header.height);
+  EXPECT_EQ(decodedHeader.backend, BackendHint::kTinySkia);
+  EXPECT_EQ(decodedHeader.uri, header.uri);
+  EXPECT_EQ(decodedWire, wire);
+}
+
+TEST(RnrFileTest, TruncatedHeaderReturnsTruncated) {
+  std::vector<uint8_t> buf = {0x44, 0x52, 0x4E, 0x46};  // only magic
+  RnrHeader header;
+  std::vector<uint8_t> wire;
+  EXPECT_EQ(ParseRnrBuffer(buf, header, wire), RnrIoStatus::kTruncated);
+}
+
+TEST(RnrFileTest, WrongMagicRejected) {
+  std::vector<uint8_t> buf(32, 0);
+  RnrHeader header;
+  std::vector<uint8_t> wire;
+  EXPECT_EQ(ParseRnrBuffer(buf, header, wire), RnrIoStatus::kMagicMismatch);
+}
+
+TEST(RnrFileTest, VersionMismatchRejected) {
+  RnrHeader header;
+  header.fileVersion = kRnrFileVersion + 1;
+  const std::vector<uint8_t> wire;
+  const auto encoded = EncodeRnrBuffer(header, wire);
+
+  RnrHeader out;
+  std::vector<uint8_t> outWire;
+  EXPECT_EQ(ParseRnrBuffer(encoded, out, outWire), RnrIoStatus::kVersionMismatch);
+}
+
+TEST(RnrFileTest, SaveLoadDiskRoundTrips) {
+  const std::filesystem::path path =
+      std::filesystem::path(::testing::TempDir()) / "round_trip.rnr";
+
+  RnrHeader header;
+  header.width = 32;
+  header.height = 32;
+  header.backend = BackendHint::kTinySkia;
+  header.uri = "memory://trivial";
+  const std::vector<uint8_t> wire = {0xAA, 0xBB, 0xCC};
+
+  ASSERT_EQ(SaveRnrFile(path, header, wire), RnrIoStatus::kOk);
+  RnrHeader loaded;
+  std::vector<uint8_t> loadedWire;
+  ASSERT_EQ(LoadRnrFile(path, loaded, loadedWire), RnrIoStatus::kOk);
+  EXPECT_EQ(loaded.width, 32u);
+  EXPECT_EQ(loaded.height, 32u);
+  EXPECT_EQ(loaded.uri, "memory://trivial");
+  EXPECT_EQ(loadedWire, wire);
+}
+
+// -----------------------------------------------------------------------------
+// FrameInspector decoding
+// -----------------------------------------------------------------------------
+
+TEST(FrameInspectorTest, DecodesKnownSerializedFrame) {
+  const auto wire = SerializeSimpleFrame(kSvg, 64, 64);
+  const auto result = FrameInspector::Decode(wire);
+
+  ASSERT_TRUE(result.streamValid) << result.error;
+  ASSERT_FALSE(result.commands.empty());
+
+  // First command is always the stream header.
+  EXPECT_EQ(result.commands.front().opcode, Opcode::kStreamHeader);
+
+  // Somewhere in there we must see a beginFrame and an endFrame, and at
+  // least two draw primitives (the SVG has two nested rects — the driver
+  // may encode them as drawRect or drawPath depending on how it resolves
+  // the shape geometry; either is fine for this test).
+  bool sawBegin = false;
+  bool sawEnd = false;
+  int drawCount = 0;
+  for (const auto& cmd : result.commands) {
+    if (cmd.opcode == Opcode::kBeginFrame) sawBegin = true;
+    if (cmd.opcode == Opcode::kEndFrame) sawEnd = true;
+    if (cmd.opcode == Opcode::kDrawRect || cmd.opcode == Opcode::kDrawPath ||
+        cmd.opcode == Opcode::kDrawEllipse) {
+      ++drawCount;
+    }
+    EXPECT_GE(cmd.depth, 0);
+    EXPECT_FALSE(cmd.summary.empty()) << "opcode "
+                                       << static_cast<int>(cmd.opcode)
+                                       << " should have a summary";
+  }
+  EXPECT_TRUE(sawBegin);
+  EXPECT_TRUE(sawEnd);
+  EXPECT_GE(drawCount, 2);
+  EXPECT_EQ(result.finalDepth, 0) << "push/pop must balance for a clean frame";
+}
+
+TEST(FrameInspectorTest, DumpProducesTextOutput) {
+  const auto wire = SerializeSimpleFrame(kSvg, 32, 32);
+  const std::string dump = FrameInspector::Dump(wire);
+  EXPECT_FALSE(dump.empty());
+  EXPECT_NE(dump.find("beginFrame"), std::string::npos);
+  EXPECT_NE(dump.find("endFrame"), std::string::npos);
+}
+
+TEST(FrameInspectorTest, DecodeStopsAtTruncation) {
+  auto wire = SerializeSimpleFrame(kSvg, 32, 32);
+  // Cut off the middle of a message to force a truncation error.
+  wire.resize(wire.size() / 2);
+  const auto result = FrameInspector::Decode(wire);
+  // Valid prefix was decoded but stream is not valid overall.
+  EXPECT_FALSE(result.commands.empty());
+  EXPECT_FALSE(result.streamValid);
+  EXPECT_FALSE(result.error.empty());
+}
+
+TEST(FrameInspectorTest, OpcodeNamesAreStable) {
+  // Every listed opcode should have a short name.
+  const std::array<Opcode, 14> opcodes = {
+      Opcode::kStreamHeader, Opcode::kBeginFrame, Opcode::kEndFrame,
+      Opcode::kSetTransform, Opcode::kPushTransform, Opcode::kPopTransform,
+      Opcode::kPushClip, Opcode::kPopClip, Opcode::kPushIsolatedLayer,
+      Opcode::kPopIsolatedLayer, Opcode::kSetPaint, Opcode::kDrawPath,
+      Opcode::kDrawRect, Opcode::kDrawEllipse};
+  for (Opcode op : opcodes) {
+    const auto name = FrameInspector::OpcodeName(op);
+    EXPECT_FALSE(name.empty()) << "opcode " << static_cast<int>(op);
+    EXPECT_NE(name, "unknown");
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Partial replay — scrub slider simulation
+// -----------------------------------------------------------------------------
+
+TEST(FrameInspectorTest, ReplayPrefixFullStreamMatchesDirect) {
+  const auto wire = SerializeSimpleFrame(kSvg, 64, 64);
+
+  svg::RendererTinySkia target;
+  const auto status = FrameInspector::ReplayPrefix(
+      wire, std::numeric_limits<std::size_t>::max(), target);
+  ASSERT_EQ(status, ReplayStatus::kOk);
+
+  const auto direct = RenderInProcess(kSvg, 64, 64);
+  const auto viaInspector = target.takeSnapshot();
+  ASSERT_EQ(direct.dimensions, viaInspector.dimensions);
+  EXPECT_EQ(direct.pixels, viaInspector.pixels);
+}
+
+TEST(FrameInspectorTest, ReplayPrefixZeroProducesBlankFrame) {
+  const auto wire = SerializeSimpleFrame(kSvg, 32, 32);
+
+  svg::RendererTinySkia target;
+  const auto status = FrameInspector::ReplayPrefix(wire, 0, target);
+  EXPECT_EQ(status, ReplayStatus::kOk);
+
+  const auto snap = target.takeSnapshot();
+  // No beginFrame happened, so the backend never allocated a framebuffer.
+  // Its dimensions should be zero.
+  EXPECT_EQ(snap.dimensions.x, 0);
+  EXPECT_EQ(snap.dimensions.y, 0);
+}
+
+TEST(FrameInspectorTest, ReplayPrefixPartialIsRenderable) {
+  const auto wire = SerializeSimpleFrame(kSvg, 32, 32);
+  const auto decoded = FrameInspector::Decode(wire);
+  ASSERT_TRUE(decoded.streamValid);
+
+  // Replay the first 3 commands (beginFrame + a push + a setPaint, most
+  // likely). The exact sequence depends on the driver, but the target must
+  // end up with a valid framebuffer of the right size thanks to the
+  // synthesized endFrame.
+  svg::RendererTinySkia target;
+  const auto status = FrameInspector::ReplayPrefix(wire, 3, target);
+  EXPECT_EQ(status, ReplayStatus::kOk);
+  const auto snap = target.takeSnapshot();
+  EXPECT_GT(snap.dimensions.x, 0);
+  EXPECT_GT(snap.dimensions.y, 0);
+}
+
+// -----------------------------------------------------------------------------
+// End-to-end: record → save → load → replay → pixel-identical
+// -----------------------------------------------------------------------------
+
+TEST(RecordReplayEndToEndTest, RoundTripPreservesPixels) {
+  const auto wire = SerializeSimpleFrame(kSvg, 100, 100);
+
+  RnrHeader header;
+  header.width = 100;
+  header.height = 100;
+  header.backend = BackendHint::kTinySkia;
+  header.uri = "memory://record_replay_test";
+
+  const std::filesystem::path path =
+      std::filesystem::path(::testing::TempDir()) / "round_trip_full.rnr";
+  ASSERT_EQ(SaveRnrFile(path, header, wire), RnrIoStatus::kOk);
+
+  RnrHeader loadedHeader;
+  std::vector<uint8_t> loadedWire;
+  ASSERT_EQ(LoadRnrFile(path, loadedHeader, loadedWire), RnrIoStatus::kOk);
+  EXPECT_EQ(loadedWire, wire);
+
+  svg::RendererTinySkia target;
+  const auto status = FrameInspector::ReplayPrefix(
+      loadedWire, std::numeric_limits<std::size_t>::max(), target);
+  ASSERT_EQ(status, ReplayStatus::kOk);
+
+  const auto direct = RenderInProcess(kSvg, 100, 100);
+  const auto replayed = target.takeSnapshot();
+  ASSERT_EQ(direct.dimensions, replayed.dimensions);
+  EXPECT_EQ(direct.pixels, replayed.pixels)
+      << "round-tripping through a .rnr file on disk must be lossless";
+}
+
+}  // namespace
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/tests/SandboxHardening_tests.cc
+++ b/donner/editor/sandbox/tests/SandboxHardening_tests.cc
@@ -1,0 +1,260 @@
+/// @file
+///
+/// Tests for S6.1 sandbox hardening. These exercise two distinct layers:
+///
+/// 1. **In-process unit tests** — call `ApplyHardening()` directly to
+///    verify the environment gate classifies correctly, and to confirm
+///    setrlimit caps are actually installed (via `getrlimit` inspection).
+/// 2. **Subprocess integration tests** — spawn the real child binary via
+///    `fork` + `execve` with explicit environment control, to confirm the
+///    gate fails closed when DONNER_SANDBOX is missing and works normally
+///    when the host's curated envp is passed through. This is the only
+///    layer where we can observe the child's exit code directly without
+///    going through the `SandboxHost` pipe plumbing.
+
+#include "donner/editor/sandbox/SandboxHardening.h"
+
+#include <gtest/gtest.h>
+
+#include <fcntl.h>
+#include <spawn.h>
+#include <sys/resource.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <array>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#include "donner/base/tests/Runfiles.h"
+#include "donner/editor/sandbox/SandboxProtocol.h"
+
+extern "C" char** environ;
+
+namespace donner::editor::sandbox {
+namespace {
+
+// -----------------------------------------------------------------------------
+// In-process unit tests — call ApplyHardening() directly and check state.
+// -----------------------------------------------------------------------------
+
+TEST(SandboxHardeningUnitTest, MissingSandboxEnvFailsClosed) {
+  // The test harness's environment may legitimately have DONNER_SANDBOX
+  // set (or not). Strip it before calling ApplyHardening so the test is
+  // deterministic regardless of how the suite was invoked.
+  ::unsetenv("DONNER_SANDBOX");
+
+  HardeningOptions opts;
+  // Don't actually modify the test process's FDs or chdir — we only care
+  // about the env gate classification here.
+  opts.chdirRoot = false;
+  opts.closeExtraFds = false;
+  opts.addressSpaceBytes = 0;
+  opts.cpuSeconds = 0;
+  opts.maxFileBytes = 0;  // leave RLIMIT_FSIZE alone... oh wait, 0 means "block"
+  opts.maxOpenFiles = 0;  // 0 means "leave RLIMIT_NOFILE alone"
+  opts.logSummaryToStderr = false;
+  opts.installSeccompFilter = false;  // don't jail the test process
+
+  // maxFileBytes default is 0 which means "block all file writes" — we
+  // can't actually call that inside a gtest process without breaking
+  // stderr. For the unit test, set it to something large enough to be a
+  // no-op but nonzero so the setrlimit path is still exercised, then
+  // leave FD sweep and chdir off.
+  opts.maxFileBytes = 1u << 30;  // 1 GiB cap, effectively unlimited for the test process
+
+  const auto result = ApplyHardening(opts);
+  EXPECT_EQ(result.status, HardeningStatus::kMissingSandboxEnv);
+  EXPECT_FALSE(result.message.empty());
+}
+
+TEST(SandboxHardeningUnitTest, AppliesResourceLimitsWithSandboxEnv) {
+  ::setenv("DONNER_SANDBOX", "1", /*overwrite=*/1);
+
+  HardeningOptions opts;
+  // Exercise the RLIMIT paths without actually hobbling the test process:
+  // keep chdir and FD sweep off; set each cap high enough that real gtest
+  // machinery is unaffected.
+  opts.chdirRoot = false;
+  opts.closeExtraFds = false;
+  opts.addressSpaceBytes = 0;            // skip RLIMIT_AS
+  opts.cpuSeconds = 0;                   // skip RLIMIT_CPU
+  opts.maxFileBytes = 1u << 30;          // 1 GiB cap — far above any test output
+  opts.maxOpenFiles = 4096;              // generous
+  opts.logSummaryToStderr = false;
+  opts.installSeccompFilter = false;     // don't jail the test process
+
+  const auto result = ApplyHardening(opts);
+  EXPECT_EQ(result.status, HardeningStatus::kOk) << result.message;
+
+  // Confirm at least one of the caps actually took effect by reading it
+  // back via getrlimit.
+  rlimit fsize{};
+  ASSERT_EQ(::getrlimit(RLIMIT_FSIZE, &fsize), 0);
+  EXPECT_LE(fsize.rlim_cur, static_cast<rlim_t>(1u << 30));
+
+  rlimit nofile{};
+  ASSERT_EQ(::getrlimit(RLIMIT_NOFILE, &nofile), 0);
+  EXPECT_LE(nofile.rlim_cur, static_cast<rlim_t>(4096));
+}
+
+// -----------------------------------------------------------------------------
+// Subprocess integration tests — spawn the real donner_parser_child with
+// controlled envp and observe its exit code.
+// -----------------------------------------------------------------------------
+
+class HardenedChildTest : public ::testing::Test {
+protected:
+  std::string ChildPath() {
+    return Runfiles::instance().Rlocation("donner/editor/sandbox/donner_parser_child");
+  }
+
+  struct SpawnResult {
+    int exitCode = 0;
+    int termSignal = 0;
+    std::string stderrCaptured;
+  };
+
+  // Spawns the child with the given envp, pipes `stdinBytes` to its stdin,
+  // drains its stderr, reaps the child, and returns the exit info. stdout
+  // is redirected to /dev/null so we don't have to decode the wire bytes
+  // for tests that only care about the exit code.
+  SpawnResult Spawn(std::string_view stdinBytes,
+                    const std::vector<std::string>& env) {
+    SpawnResult out;
+
+    int stdinFds[2] = {-1, -1};
+    int stderrFds[2] = {-1, -1};
+    ::pipe(stdinFds);
+    ::pipe(stderrFds);
+
+    const int devNull = ::open("/dev/null", O_WRONLY);
+    EXPECT_GE(devNull, 0);
+
+    posix_spawn_file_actions_t actions;
+    posix_spawn_file_actions_init(&actions);
+    posix_spawn_file_actions_adddup2(&actions, stdinFds[0], STDIN_FILENO);
+    posix_spawn_file_actions_adddup2(&actions, devNull, STDOUT_FILENO);
+    posix_spawn_file_actions_adddup2(&actions, stderrFds[1], STDERR_FILENO);
+    posix_spawn_file_actions_addclose(&actions, stdinFds[0]);
+    posix_spawn_file_actions_addclose(&actions, stdinFds[1]);
+    posix_spawn_file_actions_addclose(&actions, stderrFds[0]);
+    posix_spawn_file_actions_addclose(&actions, stderrFds[1]);
+    posix_spawn_file_actions_addclose(&actions, devNull);
+
+    const std::string childPath = ChildPath();
+    std::string arg1 = "10";
+    std::string arg2 = "10";
+    std::array<char*, 4> argv = {
+        const_cast<char*>(childPath.c_str()),
+        arg1.data(),
+        arg2.data(),
+        nullptr,
+    };
+
+    // Build a mutable envp from the supplied strings.
+    std::vector<std::string> envBacking = env;
+    std::vector<char*> envp;
+    envp.reserve(envBacking.size() + 1);
+    for (auto& s : envBacking) envp.push_back(s.data());
+    envp.push_back(nullptr);
+
+    pid_t child = -1;
+    const int rc = ::posix_spawn(&child, childPath.c_str(), &actions,
+                                 /*attrp=*/nullptr, argv.data(), envp.data());
+    posix_spawn_file_actions_destroy(&actions);
+    EXPECT_EQ(rc, 0);
+
+    ::close(stdinFds[0]);
+    ::close(stderrFds[1]);
+    ::close(devNull);
+
+    // Write stdin, close, drain stderr, reap.
+    if (!stdinBytes.empty()) {
+      ::write(stdinFds[1], stdinBytes.data(), stdinBytes.size());
+    }
+    ::close(stdinFds[1]);
+
+    std::array<char, 4096> buf;
+    while (true) {
+      const ssize_t n = ::read(stderrFds[0], buf.data(), buf.size());
+      if (n <= 0) break;
+      out.stderrCaptured.append(buf.data(), static_cast<std::size_t>(n));
+    }
+    ::close(stderrFds[0]);
+
+    int raw = 0;
+    ::waitpid(child, &raw, 0);
+    if (WIFEXITED(raw)) out.exitCode = WEXITSTATUS(raw);
+    if (WIFSIGNALED(raw)) out.termSignal = WTERMSIG(raw);
+    return out;
+  }
+};
+
+TEST_F(HardenedChildTest, ChildRefusesWithoutSandboxEnvVar) {
+  // Intentionally pass NO env vars. The child's first action is the
+  // hardening check, which should exit 64 with a diagnostic.
+  const auto result = Spawn("<svg/>", {});
+  EXPECT_EQ(result.exitCode, kExitUsageError);
+  EXPECT_EQ(result.termSignal, 0);
+  EXPECT_NE(result.stderrCaptured.find("DONNER_SANDBOX=1"),
+            std::string::npos)
+      << "stderr was: " << result.stderrCaptured;
+}
+
+TEST_F(HardenedChildTest, ChildRefusesWhenSandboxEnvIsWrongValue) {
+  const auto result = Spawn("<svg/>", {"DONNER_SANDBOX=0"});
+  EXPECT_EQ(result.exitCode, kExitUsageError);
+  EXPECT_NE(result.stderrCaptured.find("DONNER_SANDBOX=1"),
+            std::string::npos);
+}
+
+TEST_F(HardenedChildTest, ChildRunsWithCuratedEnvpAndLogsProfile) {
+  constexpr std::string_view kSvg =
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+         <rect width="10" height="10" fill="red"/>
+       </svg>)";
+  const auto result = Spawn(kSvg, {"DONNER_SANDBOX=1"});
+  // Successful render exits 0.
+  EXPECT_EQ(result.exitCode, kExitOk) << "stderr: " << result.stderrCaptured;
+  EXPECT_EQ(result.termSignal, 0);
+  // Hardening logs its profile — grep for the stable prefix.
+  EXPECT_NE(result.stderrCaptured.find("sandbox hardening:"),
+            std::string::npos)
+      << "expected hardening summary on stderr, got: "
+      << result.stderrCaptured;
+}
+
+// ---------------------------------------------------------------------------
+// Seccomp integration test: the child installs a seccomp-bpf filter by
+// default. Verify that a normal SVG parse+render succeeds under the filter
+// and that the log output confirms seccomp was enabled.
+// ---------------------------------------------------------------------------
+
+TEST_F(HardenedChildTest, ChildRendersSuccessfullyUnderSeccomp) {
+  constexpr std::string_view kSvg =
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20">
+         <circle cx="10" cy="10" r="8" fill="blue" stroke="green" stroke-width="2"/>
+       </svg>)";
+  const auto result = Spawn(kSvg, {"DONNER_SANDBOX=1"});
+  // The child must exit 0 — the seccomp filter must not block any syscall
+  // that the normal parse+render path needs.
+  EXPECT_EQ(result.exitCode, kExitOk)
+      << "Child failed under seccomp filter. stderr: "
+      << result.stderrCaptured;
+  EXPECT_EQ(result.termSignal, 0)
+      << "Child was killed by signal " << result.termSignal
+      << " — possible seccomp KILL_PROCESS or missing allowlist entry. "
+      << "stderr: " << result.stderrCaptured;
+
+#if defined(__linux__)
+  // On Linux, confirm the hardening summary includes seccomp=1.
+  EXPECT_NE(result.stderrCaptured.find("seccomp=1"), std::string::npos)
+      << "expected seccomp=1 in hardening summary, got: "
+      << result.stderrCaptured;
+#endif
+}
+
+}  // namespace
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/tests/SandboxHost_tests.cc
+++ b/donner/editor/sandbox/tests/SandboxHost_tests.cc
@@ -1,0 +1,131 @@
+/// @file
+///
+/// End-to-end tests for Milestone S1 of the editor sandbox: spawn the child
+/// binary, render a few representative SVGs (valid, malformed, crashy), assert
+/// host liveness and exit classification.
+///
+/// The core invariant these tests defend is simple: **no adversarial input can
+/// crash the host process**. Every failure mode reported by `SandboxHost`
+/// should be a normal `RenderResult`, never an abort or signal propagated to
+/// the test runner.
+
+#include "donner/editor/sandbox/SandboxHost.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#include "donner/base/tests/Runfiles.h"
+
+namespace donner::editor::sandbox {
+namespace {
+
+using ::testing::Test;
+
+class SandboxHostTest : public Test {
+ protected:
+  SandboxHost MakeHost() {
+    const std::string childPath =
+        Runfiles::instance().Rlocation("donner/editor/sandbox/donner_parser_child");
+    return SandboxHost(childPath);
+  }
+};
+
+constexpr std::string_view kTrivialSvg =
+    R"(<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50">)"
+    R"(<rect width="50" height="50" fill="red"/>)"
+    R"(</svg>)";
+
+constexpr std::array<uint8_t, 8> kPngMagic = {0x89, 0x50, 0x4E, 0x47,
+                                              0x0D, 0x0A, 0x1A, 0x0A};
+
+bool StartsWithPngMagic(const std::vector<uint8_t>& bytes) {
+  if (bytes.size() < kPngMagic.size()) return false;
+  return std::equal(kPngMagic.begin(), kPngMagic.end(), bytes.begin());
+}
+
+TEST_F(SandboxHostTest, RendersTrivialSvgToPng) {
+  SandboxHost host = MakeHost();
+  RenderResult result = host.render(kTrivialSvg, 50, 50);
+
+  EXPECT_EQ(result.status, SandboxStatus::kOk) << "diagnostics: " << result.diagnostics;
+  EXPECT_EQ(result.exitCode, 0);
+  EXPECT_TRUE(StartsWithPngMagic(result.png)) << "png size=" << result.png.size();
+  EXPECT_GT(result.png.size(), kPngMagic.size());
+}
+
+TEST_F(SandboxHostTest, ClassifiesParseErrorWithoutCrashingHost) {
+  SandboxHost host = MakeHost();
+  RenderResult result = host.render("this is not svg at all", 50, 50);
+
+  EXPECT_EQ(result.status, SandboxStatus::kParseError);
+  EXPECT_TRUE(result.png.empty());
+  EXPECT_FALSE(result.diagnostics.empty())
+      << "expected a stderr diagnostic from the child";
+}
+
+TEST_F(SandboxHostTest, EmptyInputIsParseError) {
+  SandboxHost host = MakeHost();
+  RenderResult result = host.render("", 50, 50);
+
+  EXPECT_EQ(result.status, SandboxStatus::kParseError);
+  EXPECT_TRUE(result.png.empty());
+}
+
+TEST_F(SandboxHostTest, LargeSvgDoesNotDeadlockPipes) {
+  // Build an SVG larger than the default 64 KiB pipe buffer so that the host's
+  // background-writer thread actually has to overlap with the child's reads.
+  // If the SandboxHost pipe plumbing is wrong this test wedges forever.
+  std::string svg =
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">)";
+  svg.reserve(200 * 1024);
+  for (int i = 0; i < 2000; ++i) {
+    svg += R"(<rect x="1" y="1" width="2" height="2" fill="#010101"/>)";
+  }
+  svg += "</svg>";
+  ASSERT_GT(svg.size(), 64u * 1024) << "test SVG should exceed a single pipe buffer";
+
+  SandboxHost host = MakeHost();
+  RenderResult result = host.render(svg, 100, 100);
+
+  EXPECT_EQ(result.status, SandboxStatus::kOk) << "diagnostics: " << result.diagnostics;
+  EXPECT_TRUE(StartsWithPngMagic(result.png));
+}
+
+TEST_F(SandboxHostTest, RejectsInvalidDimensions) {
+  SandboxHost host = MakeHost();
+  RenderResult result = host.render(kTrivialSvg, /*width=*/0, /*height=*/50);
+
+  EXPECT_EQ(result.status, SandboxStatus::kUsageError);
+  EXPECT_TRUE(result.png.empty());
+}
+
+// Regression guard for the primary threat model: the host must survive an
+// arbitrary byte-stream that would otherwise crash the parser. We can't
+// easily fabricate a parser crash on demand (SVGParser is fuzzed and
+// noexcept), so this test checks the next-best thing: whatever the worst case
+// is, `RenderResult` comes back cleanly rather than aborting the test runner.
+TEST_F(SandboxHostTest, AdversarialBytesNeverCrashTheHost) {
+  SandboxHost host = MakeHost();
+
+  // A mix of partial tags, enormous attribute values, and binary garbage.
+  std::string payload = "<svg xmlns='http://www.w3.org/2000/svg'><";
+  payload.append(100, '\xff');
+  payload += "path d='";
+  payload.append(50'000, 'M');
+  payload += "'/></svg>";
+
+  RenderResult result = host.render(payload, 100, 100);
+  // We don't care whether this is kOk or kParseError — we care that we got a
+  // RenderResult at all. Failing this test means the host crashed.
+  EXPECT_TRUE(result.status == SandboxStatus::kOk ||
+              result.status == SandboxStatus::kParseError ||
+              result.status == SandboxStatus::kRenderError ||
+              result.status == SandboxStatus::kCrashed)
+      << "unexpected status " << static_cast<int>(result.status);
+}
+
+}  // namespace
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/tests/SandboxPipeline_tests.cc
+++ b/donner/editor/sandbox/tests/SandboxPipeline_tests.cc
@@ -1,0 +1,134 @@
+/// @file
+///
+/// End-to-end pipeline tests for the editor sandbox: spawn the child binary,
+/// stream the wire format through a pipe, replay into a host-side
+/// `RendererTinySkia`, and assert the resulting bitmap is pixel-identical to
+/// an in-process render.
+///
+/// These tests close the loop on S1 + S2 + S3: process isolation (S1), wire
+/// format (S2), and the host-side `renderToBackend` API (S3). A failure here
+/// means something in that chain is lossy.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#include "donner/base/ParseWarningSink.h"
+#include "donner/base/tests/Runfiles.h"
+#include "donner/editor/sandbox/SandboxHost.h"
+#include "donner/svg/SVG.h"
+#include "donner/svg/renderer/RendererInterface.h"
+#include "donner/svg/renderer/RendererTinySkia.h"
+
+namespace donner::editor::sandbox {
+namespace {
+
+class SandboxPipelineTest : public ::testing::Test {
+protected:
+  SandboxHost MakeHost() {
+    const std::string childPath =
+        Runfiles::instance().Rlocation("donner/editor/sandbox/donner_parser_child");
+    return SandboxHost(childPath);
+  }
+
+  static svg::RendererBitmap RenderInProcess(std::string_view svg, int w, int h) {
+    ParseWarningSink warnings;
+    auto parseResult = svg::parser::SVGParser::ParseSVG(svg, warnings);
+    EXPECT_FALSE(parseResult.hasError()) << parseResult.error();
+    svg::SVGDocument document = std::move(parseResult.result());
+    document.setCanvasSize(w, h);
+    svg::RendererTinySkia renderer;
+    renderer.draw(document);
+    return renderer.takeSnapshot();
+  }
+};
+
+TEST_F(SandboxPipelineTest, SolidRectPixelIdenticalThroughSandbox) {
+  constexpr std::string_view kSvg =
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+         <rect width="32" height="32" fill="red"/>
+       </svg>)";
+
+  const auto direct = RenderInProcess(kSvg, 32, 32);
+
+  svg::RendererTinySkia viaBackend;
+  auto host = MakeHost();
+  const auto result = host.renderToBackend(kSvg, 32, 32, viaBackend);
+  ASSERT_EQ(result.status, SandboxStatus::kOk) << "diagnostics: " << result.diagnostics;
+  EXPECT_EQ(result.unsupportedCount, 0u);
+
+  const auto viaWire = viaBackend.takeSnapshot();
+  ASSERT_EQ(direct.dimensions, viaWire.dimensions);
+  EXPECT_EQ(direct.pixels, viaWire.pixels)
+      << "the sandbox child + wire pipeline must be pixel-identical to in-process";
+}
+
+TEST_F(SandboxPipelineTest, PathFillPixelIdenticalThroughSandbox) {
+  constexpr std::string_view kSvg =
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+         <path d="M8 8 L56 8 L32 56 Z" fill="blue"/>
+       </svg>)";
+
+  const auto direct = RenderInProcess(kSvg, 64, 64);
+
+  svg::RendererTinySkia viaBackend;
+  auto host = MakeHost();
+  const auto result = host.renderToBackend(kSvg, 64, 64, viaBackend);
+  ASSERT_EQ(result.status, SandboxStatus::kOk) << result.diagnostics;
+  EXPECT_EQ(result.unsupportedCount, 0u);
+
+  const auto viaWire = viaBackend.takeSnapshot();
+  ASSERT_EQ(direct.dimensions, viaWire.dimensions);
+  EXPECT_EQ(direct.pixels, viaWire.pixels);
+}
+
+TEST_F(SandboxPipelineTest, TransformedGroupPixelIdenticalThroughSandbox) {
+  constexpr std::string_view kSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+         <g transform="translate(10 10)">
+           <rect width="30" height="30" fill="green"/>
+           <circle cx="60" cy="60" r="20" fill="orange"/>
+         </g>
+       </svg>)svg";
+
+  const auto direct = RenderInProcess(kSvg, 100, 100);
+
+  svg::RendererTinySkia viaBackend;
+  auto host = MakeHost();
+  const auto result = host.renderToBackend(kSvg, 100, 100, viaBackend);
+  ASSERT_EQ(result.status, SandboxStatus::kOk) << result.diagnostics;
+  EXPECT_EQ(result.unsupportedCount, 0u);
+
+  const auto viaWire = viaBackend.takeSnapshot();
+  ASSERT_EQ(direct.dimensions, viaWire.dimensions);
+  EXPECT_EQ(direct.pixels, viaWire.pixels);
+}
+
+TEST_F(SandboxPipelineTest, WireBytesAreCapturedOnSuccess) {
+  constexpr std::string_view kSvg =
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+         <rect width="10" height="10" fill="black"/>
+       </svg>)";
+
+  svg::RendererTinySkia viaBackend;
+  auto host = MakeHost();
+  const auto result = host.renderToBackend(kSvg, 10, 10, viaBackend);
+  ASSERT_EQ(result.status, SandboxStatus::kOk) << result.diagnostics;
+  // The wire field must contain at least a stream header (8-byte payload +
+  // 8-byte message header = 16 bytes) plus a begin/end frame pair.
+  EXPECT_GE(result.wire.size(), 24u);
+}
+
+TEST_F(SandboxPipelineTest, MalformedSvgSurfacesAsParseError) {
+  svg::RendererTinySkia viaBackend;
+  auto host = MakeHost();
+  const auto result = host.renderToBackend("definitely not svg", 10, 10, viaBackend);
+  EXPECT_EQ(result.status, SandboxStatus::kParseError);
+  EXPECT_TRUE(result.wire.empty());
+  EXPECT_FALSE(result.diagnostics.empty());
+}
+
+}  // namespace
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/tests/SvgSource_tests.cc
+++ b/donner/editor/sandbox/tests/SvgSource_tests.cc
@@ -1,0 +1,172 @@
+/// @file
+///
+/// Tests for `SvgSource` — the URI/path resolver that feeds the sandbox.
+/// Covers the scheme classifier, absolute/relative path resolution, the size
+/// cap, and the error surface for missing files, wrong file types, and
+/// unsupported schemes.
+
+#include "donner/editor/sandbox/SvgSource.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <system_error>
+
+namespace donner::editor::sandbox {
+namespace {
+
+class SvgSourceTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    const std::string tmpRoot = ::testing::TempDir();
+    // testing::TempDir() may be shared across tests — make a per-test subdir.
+    tmpDir_ = std::filesystem::path(tmpRoot) /
+              ("svg_source_test_" + std::to_string(::rand()));
+    std::filesystem::create_directories(tmpDir_);
+  }
+
+  void TearDown() override {
+    std::error_code ec;
+    std::filesystem::remove_all(tmpDir_, ec);
+  }
+
+  std::filesystem::path WriteFile(const std::string& name, std::string_view contents) {
+    const auto path = tmpDir_ / name;
+    std::ofstream out(path, std::ios::binary);
+    out.write(contents.data(), static_cast<std::streamsize>(contents.size()));
+    return path;
+  }
+
+  std::filesystem::path tmpDir_;
+};
+
+constexpr std::string_view kMiniSvg =
+    R"(<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"/>)";
+
+TEST_F(SvgSourceTest, FetchesAbsolutePath) {
+  const auto path = WriteFile("mini.svg", kMiniSvg);
+  SvgSource source;
+  const auto result = source.fetch(path.string());
+  ASSERT_EQ(result.status, SvgFetchStatus::kOk) << result.diagnostics;
+  EXPECT_EQ(result.bytes.size(), kMiniSvg.size());
+}
+
+TEST_F(SvgSourceTest, FetchesFileScheme) {
+  const auto path = WriteFile("mini.svg", kMiniSvg);
+  SvgSource source;
+  const auto result = source.fetch("file://" + path.string());
+  ASSERT_EQ(result.status, SvgFetchStatus::kOk) << result.diagnostics;
+  EXPECT_EQ(result.bytes.size(), kMiniSvg.size());
+}
+
+TEST_F(SvgSourceTest, FetchesRelativePathAgainstBaseDirectory) {
+  WriteFile("icon.svg", kMiniSvg);
+
+  SvgSourceOptions opts;
+  opts.baseDirectory = tmpDir_;
+  SvgSource source(opts);
+
+  const auto result = source.fetch("icon.svg");
+  ASSERT_EQ(result.status, SvgFetchStatus::kOk) << result.diagnostics;
+  EXPECT_EQ(result.bytes.size(), kMiniSvg.size());
+}
+
+// ---------- HTTP(S) scheme routing ----------
+
+TEST_F(SvgSourceTest, HttpsSchemeAttemptsNetworkFetch) {
+  // A fetch to a known-bad host should produce kNetworkError, *not*
+  // kSchemeNotSupported — proving the scheme classifier routes to the
+  // network path.
+  SvgSourceOptions opts;
+  opts.httpTimeoutSeconds = 2;  // Keep the test fast.
+  SvgSource source(opts);
+  const auto result = source.fetch("https://localhost:1/does_not_exist.svg");
+  EXPECT_EQ(result.status, SvgFetchStatus::kNetworkError);
+  EXPECT_TRUE(result.bytes.empty());
+  EXPECT_FALSE(result.diagnostics.empty());
+}
+
+TEST_F(SvgSourceTest, HttpSchemeAttemptsNetworkFetch) {
+  SvgSourceOptions opts;
+  opts.httpTimeoutSeconds = 2;
+  SvgSource source(opts);
+  const auto result = source.fetch("http://localhost:1/does_not_exist.svg");
+  EXPECT_EQ(result.status, SvgFetchStatus::kNetworkError);
+  EXPECT_TRUE(result.bytes.empty());
+  EXPECT_FALSE(result.diagnostics.empty());
+}
+
+TEST_F(SvgSourceTest, FtpSchemeStillNotSupported) {
+  SvgSource source;
+  const auto result = source.fetch("ftp://example.com/icon.svg");
+  EXPECT_EQ(result.status, SvgFetchStatus::kSchemeNotSupported);
+  EXPECT_TRUE(result.bytes.empty());
+  EXPECT_FALSE(result.diagnostics.empty());
+}
+
+TEST_F(SvgSourceTest, HttpsResolvedPathIsEmpty) {
+  // Network fetches should leave resolvedPath empty — there's no filesystem
+  // path to report.
+  SvgSourceOptions opts;
+  opts.httpTimeoutSeconds = 2;
+  SvgSource source(opts);
+  const auto result = source.fetch("https://localhost:1/icon.svg");
+  EXPECT_TRUE(result.resolvedPath.empty());
+}
+
+TEST_F(SvgSourceTest, HttpsRejectsShellMetacharacters) {
+  SvgSource source;
+  const auto result = source.fetch("https://example.com/icon.svg; rm -rf /");
+  // The space and semicolon should be rejected.
+  EXPECT_EQ(result.status, SvgFetchStatus::kInvalidUri);
+}
+
+TEST_F(SvgSourceTest, MissingFileIsNotFound) {
+  SvgSource source;
+  const auto result = source.fetch((tmpDir_ / "does_not_exist.svg").string());
+  EXPECT_EQ(result.status, SvgFetchStatus::kNotFound);
+  EXPECT_TRUE(result.bytes.empty());
+}
+
+TEST_F(SvgSourceTest, DirectoryIsNotRegularFile) {
+  SvgSource source;
+  const auto result = source.fetch(tmpDir_.string());
+  EXPECT_EQ(result.status, SvgFetchStatus::kNotRegularFile);
+  EXPECT_TRUE(result.bytes.empty());
+}
+
+TEST_F(SvgSourceTest, RejectsOversizedFile) {
+  const auto path = WriteFile("big.svg", std::string(1024, 'x'));
+
+  SvgSourceOptions opts;
+  opts.maxFileBytes = 512;
+  SvgSource source(opts);
+
+  const auto result = source.fetch(path.string());
+  EXPECT_EQ(result.status, SvgFetchStatus::kTooLarge);
+  EXPECT_TRUE(result.bytes.empty());
+}
+
+TEST_F(SvgSourceTest, EmptyUriIsInvalid) {
+  SvgSource source;
+  const auto result = source.fetch("");
+  EXPECT_EQ(result.status, SvgFetchStatus::kInvalidUri);
+}
+
+TEST_F(SvgSourceTest, ResolvedPathIsCanonicalizedForRelative) {
+  WriteFile("indirect.svg", kMiniSvg);
+  SvgSourceOptions opts;
+  opts.baseDirectory = tmpDir_;
+  SvgSource source(opts);
+
+  const auto result = source.fetch("./indirect.svg");
+  ASSERT_EQ(result.status, SvgFetchStatus::kOk);
+  EXPECT_TRUE(result.resolvedPath.is_absolute());
+  EXPECT_EQ(result.resolvedPath.filename(), "indirect.svg");
+}
+
+}  // namespace
+}  // namespace donner::editor::sandbox

--- a/donner/editor/sandbox/tests/WireFormat_tests.cc
+++ b/donner/editor/sandbox/tests/WireFormat_tests.cc
@@ -1,0 +1,959 @@
+/// @file
+///
+/// Milestone S2 unit + integration tests for the editor sandbox wire format.
+///
+/// Layered coverage:
+/// 1. Primitive `Wire.h` round-trips — every `write*` pairs with a `read*`.
+/// 2. Type codec round-trips — encode → decode → equality across every
+///    supported Donner value type (Vector2d, Transform2d, Box2d, RGBA, Color,
+///    StrokeParams, Path, PathShape, PaintParams with Solid/None, ResolvedClip).
+/// 3. `SerializingRenderer` → `ReplayingRenderer` end-to-end dispatch against
+///    a capturing mock backend, verifying the wire preserves call sequence
+///    and arguments.
+/// 4. Adversarial input: the reader never crashes on truncated or garbage
+///    bytes, regardless of the message stream prefix.
+///
+/// The pixel-exact "parse SVG → render twice → compare PNG" round-trip is
+/// intentionally out of scope for this test file; that lives in the renderer
+/// test suite once S3 wires the child process up.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "donner/base/FillRule.h"
+#include "donner/base/ParseWarningSink.h"
+#include "donner/base/Path.h"
+#include "donner/css/Color.h"
+#include "donner/css/FontFace.h"
+#include "donner/editor/sandbox/ReplayingRenderer.h"
+#include "donner/editor/sandbox/SandboxCodecs.h"
+#include "donner/editor/sandbox/SerializingRenderer.h"
+#include "donner/editor/sandbox/Wire.h"
+#include "donner/svg/SVG.h"
+#include "donner/svg/core/MixBlendMode.h"
+#include "donner/svg/properties/PaintServer.h"
+#include "donner/svg/renderer/RendererInterface.h"
+#include "donner/svg/renderer/RendererTinySkia.h"
+#include "donner/svg/renderer/StrokeParams.h"
+
+namespace donner::editor::sandbox {
+namespace {
+
+using ::donner::svg::MixBlendMode;
+using ::donner::svg::PaintParams;
+using ::donner::svg::PaintServer;
+using ::donner::svg::PathShape;
+using ::donner::svg::RenderViewport;
+using ::donner::svg::ResolvedClip;
+using ::donner::svg::StrokeLinecap;
+using ::donner::svg::StrokeLinejoin;
+using ::donner::svg::StrokeParams;
+
+// -----------------------------------------------------------------------------
+// WireReader/WireWriter primitives
+// -----------------------------------------------------------------------------
+
+TEST(WireTest, RoundTripPrimitives) {
+  WireWriter w;
+  w.writeU8(0x42);
+  w.writeU32(0xDEADBEEFu);
+  w.writeU64(0x0123456789ABCDEFull);
+  w.writeF64(3.14159265358979);
+  w.writeBool(true);
+  w.writeBool(false);
+  w.writeString("hello sandbox");
+
+  WireReader r(w.data());
+  uint8_t b = 0;
+  uint32_t i32 = 0;
+  uint64_t i64 = 0;
+  double f = 0;
+  bool bTrue = false;
+  bool bFalse = true;
+  std::string s;
+
+  ASSERT_TRUE(r.readU8(b));
+  ASSERT_TRUE(r.readU32(i32));
+  ASSERT_TRUE(r.readU64(i64));
+  ASSERT_TRUE(r.readF64(f));
+  ASSERT_TRUE(r.readBool(bTrue));
+  ASSERT_TRUE(r.readBool(bFalse));
+  ASSERT_TRUE(r.readString(s));
+
+  EXPECT_EQ(b, 0x42);
+  EXPECT_EQ(i32, 0xDEADBEEFu);
+  EXPECT_EQ(i64, 0x0123456789ABCDEFull);
+  EXPECT_DOUBLE_EQ(f, 3.14159265358979);
+  EXPECT_TRUE(bTrue);
+  EXPECT_FALSE(bFalse);
+  EXPECT_EQ(s, "hello sandbox");
+  EXPECT_EQ(r.remaining(), 0u);
+  EXPECT_FALSE(r.failed());
+}
+
+TEST(WireTest, TruncatedReadFailsGracefully) {
+  WireWriter w;
+  w.writeU8(0x01);  // only one byte available
+  WireReader r(w.data());
+  uint32_t i = 0;
+  EXPECT_FALSE(r.readU32(i));
+  EXPECT_TRUE(r.failed());
+}
+
+TEST(WireTest, OversizedStringRejected) {
+  WireWriter w;
+  w.writeU32(0xFFFFFFFFu);  // claim 4 GB of string data
+  WireReader r(w.data());
+  std::string s;
+  EXPECT_FALSE(r.readString(s));
+  EXPECT_TRUE(r.failed());
+}
+
+TEST(WireTest, CountRespectsCap) {
+  WireWriter w;
+  w.writeU32(kMaxVectorCount + 1);
+  WireReader r(w.data());
+  uint32_t count = 0;
+  EXPECT_FALSE(r.readCount(count, kMaxVectorCount));
+  EXPECT_TRUE(r.failed());
+}
+
+TEST(WireTest, MessageHeaderLengthRejectedWhenTooLarge) {
+  WireWriter w;
+  w.writeU32(static_cast<uint32_t>(Opcode::kBeginFrame));
+  w.writeU32(kMaxPayloadBytes + 1);  // payload length out of bounds
+  WireReader r(w.data());
+  Opcode op = Opcode::kInvalid;
+  uint32_t len = 0;
+  EXPECT_FALSE(r.readMessageHeader(op, len));
+  EXPECT_TRUE(r.failed());
+}
+
+// -----------------------------------------------------------------------------
+// Type codec round-trips
+// -----------------------------------------------------------------------------
+
+TEST(CodecTest, Vector2dRoundTrip) {
+  WireWriter w;
+  EncodeVector2d(w, Vector2d(1.5, -2.25));
+  WireReader r(w.data());
+  Vector2d v;
+  ASSERT_TRUE(DecodeVector2d(r, v));
+  EXPECT_DOUBLE_EQ(v.x, 1.5);
+  EXPECT_DOUBLE_EQ(v.y, -2.25);
+}
+
+TEST(CodecTest, Transform2dRoundTrip) {
+  WireWriter w;
+  Transform2d t;
+  t.data[0] = 1.1;
+  t.data[1] = 2.2;
+  t.data[2] = 3.3;
+  t.data[3] = 4.4;
+  t.data[4] = 5.5;
+  t.data[5] = 6.6;
+  EncodeTransform2d(w, t);
+
+  WireReader r(w.data());
+  Transform2d out;
+  ASSERT_TRUE(DecodeTransform2d(r, out));
+  for (int i = 0; i < 6; ++i) {
+    EXPECT_DOUBLE_EQ(out.data[i], t.data[i]) << "index " << i;
+  }
+}
+
+TEST(CodecTest, Box2dRoundTrip) {
+  WireWriter w;
+  Box2d b(Vector2d(1, 2), Vector2d(10, 20));
+  EncodeBox2d(w, b);
+  WireReader r(w.data());
+  Box2d out;
+  ASSERT_TRUE(DecodeBox2d(r, out));
+  EXPECT_DOUBLE_EQ(out.topLeft.x, 1);
+  EXPECT_DOUBLE_EQ(out.topLeft.y, 2);
+  EXPECT_DOUBLE_EQ(out.bottomRight.x, 10);
+  EXPECT_DOUBLE_EQ(out.bottomRight.y, 20);
+}
+
+TEST(CodecTest, RgbaRoundTrip) {
+  WireWriter w;
+  const css::RGBA rgba(0x12, 0x34, 0x56, 0x78);
+  EncodeRgba(w, rgba);
+  WireReader r(w.data());
+  css::RGBA out;
+  ASSERT_TRUE(DecodeRgba(r, out));
+  EXPECT_EQ(out, rgba);
+}
+
+TEST(CodecTest, ColorRoundTrip) {
+  WireWriter w;
+  const css::Color color(css::RGBA(0xFF, 0x80, 0x00, 0xAA));
+  EncodeColor(w, color);
+  WireReader r(w.data());
+  css::Color out(css::RGBA{});
+  ASSERT_TRUE(DecodeColor(r, out));
+  ASSERT_TRUE(std::holds_alternative<css::RGBA>(out.value));
+  EXPECT_EQ(std::get<css::RGBA>(out.value), css::RGBA(0xFF, 0x80, 0x00, 0xAA));
+}
+
+TEST(CodecTest, StrokeParamsRoundTrip) {
+  WireWriter w;
+  StrokeParams s;
+  s.strokeWidth = 2.5;
+  s.lineCap = StrokeLinecap::Round;
+  s.lineJoin = StrokeLinejoin::Bevel;
+  s.miterLimit = 5.0;
+  s.dashArray = {2.0, 3.5, 1.0};
+  s.dashOffset = 0.25;
+  s.pathLength = 100.0;
+  EncodeStrokeParams(w, s);
+
+  WireReader r(w.data());
+  StrokeParams out;
+  ASSERT_TRUE(DecodeStrokeParams(r, out));
+  EXPECT_DOUBLE_EQ(out.strokeWidth, 2.5);
+  EXPECT_EQ(out.lineCap, StrokeLinecap::Round);
+  EXPECT_EQ(out.lineJoin, StrokeLinejoin::Bevel);
+  EXPECT_DOUBLE_EQ(out.miterLimit, 5.0);
+  EXPECT_EQ(out.dashArray, (std::vector<double>{2.0, 3.5, 1.0}));
+  EXPECT_DOUBLE_EQ(out.dashOffset, 0.25);
+  EXPECT_DOUBLE_EQ(out.pathLength, 100.0);
+}
+
+TEST(CodecTest, PathRoundTripPreservesVerbsAndPoints) {
+  PathBuilder pb;
+  pb.moveTo(Vector2d(1, 2))
+      .lineTo(Vector2d(3, 4))
+      .quadTo(Vector2d(5, 6), Vector2d(7, 8))
+      .curveTo(Vector2d(9, 10), Vector2d(11, 12), Vector2d(13, 14))
+      .closePath();
+  Path original = pb.build();
+
+  WireWriter w;
+  EncodePath(w, original);
+  WireReader r(w.data());
+  Path out;
+  ASSERT_TRUE(DecodePath(r, out));
+
+  ASSERT_EQ(out.commands().size(), original.commands().size());
+  for (std::size_t i = 0; i < out.commands().size(); ++i) {
+    EXPECT_EQ(out.commands()[i].verb, original.commands()[i].verb) << "index " << i;
+  }
+  ASSERT_EQ(out.points().size(), original.points().size());
+  for (std::size_t i = 0; i < out.points().size(); ++i) {
+    EXPECT_EQ(out.points()[i], original.points()[i]) << "index " << i;
+  }
+}
+
+TEST(CodecTest, PaintParamsRoundTripSolidFill) {
+  PaintParams p;
+  p.opacity = 0.75;
+  p.fill = PaintServer::Solid(css::Color(css::RGBA(255, 0, 0, 255)));
+  p.stroke = PaintServer::None{};
+  p.fillOpacity = 0.9;
+  p.strokeOpacity = 1.0;
+  p.currentColor = css::Color(css::RGBA(128, 128, 128, 255));
+  p.viewBox = Box2d(Vector2d(0, 0), Vector2d(100, 100));
+  p.strokeParams.strokeWidth = 1.25;
+
+  WireWriter w;
+  EncodePaintParams(w, p);
+  WireReader r(w.data());
+  PaintParams out;
+  ASSERT_TRUE(DecodePaintParams(r, out));
+  EXPECT_DOUBLE_EQ(out.opacity, 0.75);
+  ASSERT_TRUE(std::holds_alternative<PaintServer::Solid>(out.fill));
+  EXPECT_EQ(std::get<PaintServer::Solid>(out.fill).color.value,
+            css::Color::Type(css::RGBA(255, 0, 0, 255)));
+  EXPECT_TRUE(std::holds_alternative<PaintServer::None>(out.stroke));
+  EXPECT_DOUBLE_EQ(out.fillOpacity, 0.9);
+  EXPECT_DOUBLE_EQ(out.strokeOpacity, 1.0);
+  EXPECT_DOUBLE_EQ(out.strokeParams.strokeWidth, 1.25);
+}
+
+TEST(CodecTest, ResolvedClipRoundTripRectOnly) {
+  ResolvedClip c;
+  c.clipRect = Box2d(Vector2d(0, 0), Vector2d(50, 50));
+  c.clipPathUnitsTransform = Transform2d();
+  // No paths, no mask.
+
+  WireWriter w;
+  EncodeResolvedClip(w, c);
+  WireReader r(w.data());
+  ResolvedClip out;
+  ASSERT_TRUE(DecodeResolvedClip(r, out));
+  ASSERT_TRUE(out.clipRect.has_value());
+  EXPECT_DOUBLE_EQ(out.clipRect->topLeft.x, 0);
+  EXPECT_DOUBLE_EQ(out.clipRect->bottomRight.x, 50);
+  EXPECT_TRUE(out.clipPaths.empty());
+  EXPECT_FALSE(out.mask.has_value());
+}
+
+// -----------------------------------------------------------------------------
+// SerializingRenderer → ReplayingRenderer integration
+// -----------------------------------------------------------------------------
+
+namespace capture {
+
+// Minimal RendererInterface that records the calls it receives. The round-trip
+// test drives a SerializingRenderer manually, decodes via ReplayingRenderer,
+// and asserts the captured sequence matches what was dispatched.
+class CapturingRenderer final : public svg::RendererInterface {
+public:
+  struct Call {
+    std::string kind;
+    double x = 0, y = 0, w = 0, h = 0;
+    double opacity = 1.0;
+    uint8_t r = 0, g = 0, b = 0, a = 0;
+  };
+
+  std::vector<Call> calls;
+  int w_ = 0;
+  int h_ = 0;
+
+  void draw(svg::SVGDocument&) override { calls.push_back({"draw"}); }
+  int width() const override { return w_; }
+  int height() const override { return h_; }
+
+  void beginFrame(const svg::RenderViewport& vp) override {
+    w_ = static_cast<int>(vp.size.x);
+    h_ = static_cast<int>(vp.size.y);
+    Call c{"beginFrame"};
+    c.x = vp.size.x;
+    c.y = vp.size.y;
+    c.opacity = vp.devicePixelRatio;
+    calls.push_back(c);
+  }
+  void endFrame() override { calls.push_back({"endFrame"}); }
+
+  void setTransform(const Transform2d& t) override {
+    Call c{"setTransform"};
+    c.x = t.data[4];
+    c.y = t.data[5];
+    calls.push_back(c);
+  }
+  void pushTransform(const Transform2d& t) override {
+    Call c{"pushTransform"};
+    c.x = t.data[4];
+    c.y = t.data[5];
+    calls.push_back(c);
+  }
+  void popTransform() override { calls.push_back({"popTransform"}); }
+
+  void pushClip(const svg::ResolvedClip& clip) override {
+    Call c{"pushClip"};
+    if (clip.clipRect) {
+      c.x = clip.clipRect->topLeft.x;
+      c.y = clip.clipRect->topLeft.y;
+      c.w = clip.clipRect->bottomRight.x;
+      c.h = clip.clipRect->bottomRight.y;
+    }
+    calls.push_back(c);
+  }
+  void popClip() override { calls.push_back({"popClip"}); }
+
+  void pushIsolatedLayer(double opacity, svg::MixBlendMode) override {
+    Call c{"pushIsolatedLayer"};
+    c.opacity = opacity;
+    calls.push_back(c);
+  }
+  void popIsolatedLayer() override { calls.push_back({"popIsolatedLayer"}); }
+
+  void pushFilterLayer(const svg::components::FilterGraph&, const std::optional<Box2d>&) override {
+  }
+  void popFilterLayer() override {}
+
+  void pushMask(const std::optional<Box2d>&) override {}
+  void transitionMaskToContent() override {}
+  void popMask() override {}
+
+  void beginPatternTile(const Box2d&, const Transform2d&) override {}
+  void endPatternTile(bool) override {}
+
+  void setPaint(const svg::PaintParams& paint) override {
+    Call c{"setPaint"};
+    c.opacity = paint.opacity;
+    if (std::holds_alternative<svg::PaintServer::Solid>(paint.fill)) {
+      const auto& solid = std::get<svg::PaintServer::Solid>(paint.fill);
+      if (std::holds_alternative<css::RGBA>(solid.color.value)) {
+        const auto rgba = std::get<css::RGBA>(solid.color.value);
+        c.r = rgba.r;
+        c.g = rgba.g;
+        c.b = rgba.b;
+        c.a = rgba.a;
+      }
+    }
+    calls.push_back(c);
+  }
+
+  void drawPath(const svg::PathShape& shape, const svg::StrokeParams&) override {
+    Call c{"drawPath"};
+    c.opacity = static_cast<double>(shape.path.commands().size());
+    calls.push_back(c);
+  }
+  void drawRect(const Box2d& rect, const svg::StrokeParams&) override {
+    Call c{"drawRect"};
+    c.x = rect.topLeft.x;
+    c.y = rect.topLeft.y;
+    c.w = rect.bottomRight.x;
+    c.h = rect.bottomRight.y;
+    calls.push_back(c);
+  }
+  void drawEllipse(const Box2d& bounds, const svg::StrokeParams&) override {
+    Call c{"drawEllipse"};
+    c.x = bounds.topLeft.x;
+    c.y = bounds.topLeft.y;
+    c.w = bounds.bottomRight.x;
+    c.h = bounds.bottomRight.y;
+    calls.push_back(c);
+  }
+  void drawImage(const svg::ImageResource&, const svg::ImageParams&) override {}
+  void drawText(Registry&, const svg::components::ComputedTextComponent&,
+                const svg::TextParams&) override {}
+
+  svg::RendererBitmap takeSnapshot() const override { return {}; }
+  std::unique_ptr<svg::RendererInterface> createOffscreenInstance() const override {
+    return nullptr;
+  }
+};
+
+}  // namespace capture
+
+TEST(IntegrationTest, SerializeReplayRoundTripDispatchesCallsInOrder) {
+  SerializingRenderer ser;
+  // Simulate a minimal driver-driven sequence by calling the supported methods
+  // in the same order the driver would.
+  ser.beginFrame({Vector2d(100, 80), 1.0});
+  ser.pushTransform(Transform2d());
+  PaintParams paint;
+  paint.opacity = 0.5;
+  paint.fill = PaintServer::Solid(css::Color(css::RGBA(1, 2, 3, 4)));
+  ser.setPaint(paint);
+  ser.drawRect(Box2d(Vector2d(10, 20), Vector2d(30, 40)), StrokeParams{});
+  ser.popTransform();
+  ser.endFrame();
+
+  ASSERT_FALSE(ser.hasUnsupported());
+
+  capture::CapturingRenderer target;
+  ReplayingRenderer replay(target);
+  ReplayReport report;
+  const auto status = replay.pumpFrame(ser.data(), report);
+  EXPECT_EQ(status, ReplayStatus::kOk);
+  EXPECT_EQ(report.unsupportedCount, 0u);
+
+  ASSERT_EQ(target.calls.size(), 6u);
+  EXPECT_EQ(target.calls[0].kind, "beginFrame");
+  EXPECT_DOUBLE_EQ(target.calls[0].x, 100);
+  EXPECT_DOUBLE_EQ(target.calls[0].y, 80);
+  EXPECT_EQ(target.calls[1].kind, "pushTransform");
+  EXPECT_EQ(target.calls[2].kind, "setPaint");
+  EXPECT_DOUBLE_EQ(target.calls[2].opacity, 0.5);
+  EXPECT_EQ(target.calls[2].r, 1);
+  EXPECT_EQ(target.calls[2].g, 2);
+  EXPECT_EQ(target.calls[2].b, 3);
+  EXPECT_EQ(target.calls[2].a, 4);
+  EXPECT_EQ(target.calls[3].kind, "drawRect");
+  EXPECT_DOUBLE_EQ(target.calls[3].x, 10);
+  EXPECT_DOUBLE_EQ(target.calls[3].y, 20);
+  EXPECT_DOUBLE_EQ(target.calls[3].w, 30);
+  EXPECT_DOUBLE_EQ(target.calls[3].h, 40);
+  EXPECT_EQ(target.calls[4].kind, "popTransform");
+  EXPECT_EQ(target.calls[5].kind, "endFrame");
+}
+
+TEST(IntegrationTest, AllMethodsNowSupportedNoUnsupported) {
+  // Every RendererInterface method now has a real opcode. This test
+  // verifies there are zero kUnsupported emissions for a frame that
+  // exercises drawText (the last method to get a real opcode).
+  SerializingRenderer ser;
+  ser.beginFrame({Vector2d(10, 10), 1.0});
+  Registry dummyRegistry;
+  svg::components::ComputedTextComponent dummyText;
+  ser.drawText(dummyRegistry, dummyText, svg::TextParams{});
+  ser.endFrame();
+  EXPECT_FALSE(ser.hasUnsupported())
+      << "drawText should now encode as a real opcode, not kUnsupported";
+  EXPECT_EQ(ser.unsupportedCount(), 0u);
+
+  capture::CapturingRenderer target;
+  ReplayingRenderer replay(target);
+  ReplayReport report;
+  const auto status = replay.pumpFrame(ser.data(), report);
+  EXPECT_EQ(status, ReplayStatus::kOk)
+      << "replay should complete cleanly with zero unsupported";
+  EXPECT_EQ(report.unsupportedCount, 0u);
+}
+
+// -----------------------------------------------------------------------------
+// Adversarial inputs — the deserializer must never crash
+// -----------------------------------------------------------------------------
+
+TEST(AdversarialTest, RandomBytesDoNotCrashReplay) {
+  // 256 bytes of "random-ish" input across a few characteristic patterns.
+  const std::vector<std::vector<uint8_t>> corpora = {
+      {},                                                      // empty
+      {0x00},                                                  // too short for header
+      {0xDE, 0xAD, 0xBE, 0xEF},                                // wrong magic
+      {0x44, 0x52, 0x4E, 0x52},                                // correct magic alone
+      std::vector<uint8_t>(32, 0xFF),                          // all ones
+      std::vector<uint8_t>(256, 0x00),                         // all zeros
+  };
+
+  capture::CapturingRenderer target;
+  ReplayingRenderer replay(target);
+  for (const auto& bytes : corpora) {
+    ReplayReport report;
+    const auto status = replay.pumpFrame(bytes, report);
+    (void)status;  // any status is fine — all that matters is "no crash".
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Pixel-exact RendererTinySkia round-trip — the canonical S2 lossless check.
+// -----------------------------------------------------------------------------
+
+namespace {
+
+svg::SVGDocument ParseOrDie(std::string_view svg) {
+  ParseWarningSink warnings;
+  auto result = svg::parser::SVGParser::ParseSVG(svg, warnings);
+  EXPECT_FALSE(result.hasError()) << result.error();
+  return std::move(result.result());
+}
+
+svg::RendererBitmap RenderDirect(std::string_view svg, int width, int height) {
+  auto document = ParseOrDie(svg);
+  document.setCanvasSize(width, height);
+  svg::RendererTinySkia renderer;
+  renderer.draw(document);
+  return renderer.takeSnapshot();
+}
+
+svg::RendererBitmap RenderViaWire(std::string_view svg, int width, int height,
+                                  bool& outHasUnsupported) {
+  auto serDocument = ParseOrDie(svg);
+  serDocument.setCanvasSize(width, height);
+
+  SerializingRenderer ser;
+  ser.draw(serDocument);
+  outHasUnsupported = ser.hasUnsupported();
+
+  svg::RendererTinySkia replayBackend;
+  ReplayingRenderer replay(replayBackend);
+  ReplayReport report;
+  const auto status = replay.pumpFrame(ser.data(), report);
+  EXPECT_TRUE(status == ReplayStatus::kOk || status == ReplayStatus::kEncounteredUnsupported)
+      << "replay status = " << static_cast<int>(status);
+  return replayBackend.takeSnapshot();
+}
+
+}  // namespace
+
+TEST(PixelRoundTripTest, SolidRectMatchesDirectRender) {
+  constexpr std::string_view kSvg =
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+         <rect width="32" height="32" fill="red"/>
+       </svg>)";
+
+  const auto direct = RenderDirect(kSvg, 32, 32);
+  bool hasUnsupported = false;
+  const auto viaWire = RenderViaWire(kSvg, 32, 32, hasUnsupported);
+
+  ASSERT_EQ(direct.dimensions, viaWire.dimensions);
+  ASSERT_EQ(direct.pixels.size(), viaWire.pixels.size());
+  EXPECT_FALSE(hasUnsupported);
+  EXPECT_EQ(direct.pixels, viaWire.pixels)
+      << "serializing/replaying through the wire format must be pixel-identical";
+}
+
+TEST(PixelRoundTripTest, PathFillMatchesDirectRender) {
+  constexpr std::string_view kSvg =
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+         <path d="M8 8 L56 8 L32 56 Z" fill="blue"/>
+       </svg>)";
+
+  const auto direct = RenderDirect(kSvg, 64, 64);
+  bool hasUnsupported = false;
+  const auto viaWire = RenderViaWire(kSvg, 64, 64, hasUnsupported);
+
+  ASSERT_EQ(direct.dimensions, viaWire.dimensions);
+  ASSERT_EQ(direct.pixels.size(), viaWire.pixels.size());
+  EXPECT_FALSE(hasUnsupported);
+  EXPECT_EQ(direct.pixels, viaWire.pixels);
+}
+
+TEST(PixelRoundTripTest, LinearGradientMatchesDirectRender) {
+  // WIRE.5 exercise: a linear gradient filled rect. The serializer
+  // flattens the PaintResolvedReference into a WireGradient; the replayer
+  // materializes a fresh entity in its private registry and hands the
+  // backend a real PaintResolvedReference that points at it.
+  constexpr std::string_view kSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80">
+         <defs>
+           <linearGradient id="g" x1="0" y1="0" x2="80" y2="0"
+                           gradientUnits="userSpaceOnUse">
+             <stop offset="0" stop-color="#ff0000"/>
+             <stop offset="1" stop-color="#0000ff"/>
+           </linearGradient>
+         </defs>
+         <rect width="80" height="80" fill="url(#g)"/>
+       </svg>)svg";
+
+  const auto direct = RenderDirect(kSvg, 80, 80);
+  bool hasUnsupported = false;
+  const auto viaWire = RenderViaWire(kSvg, 80, 80, hasUnsupported);
+
+  ASSERT_EQ(direct.dimensions, viaWire.dimensions);
+  ASSERT_EQ(direct.pixels.size(), viaWire.pixels.size());
+  EXPECT_FALSE(hasUnsupported)
+      << "linear gradients should no longer trigger kUnsupported";
+  EXPECT_EQ(direct.pixels, viaWire.pixels)
+      << "linear gradient rendering must be byte-identical across the wire";
+}
+
+TEST(PixelRoundTripTest, RadialGradientMatchesDirectRender) {
+  constexpr std::string_view kSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80">
+         <defs>
+           <radialGradient id="g" cx="40" cy="40" r="40"
+                           gradientUnits="userSpaceOnUse">
+             <stop offset="0" stop-color="#ffff00"/>
+             <stop offset="1" stop-color="#ff00ff"/>
+           </radialGradient>
+         </defs>
+         <circle cx="40" cy="40" r="40" fill="url(#g)"/>
+       </svg>)svg";
+
+  const auto direct = RenderDirect(kSvg, 80, 80);
+  bool hasUnsupported = false;
+  const auto viaWire = RenderViaWire(kSvg, 80, 80, hasUnsupported);
+
+  ASSERT_EQ(direct.dimensions, viaWire.dimensions);
+  EXPECT_FALSE(hasUnsupported);
+  EXPECT_EQ(direct.pixels, viaWire.pixels)
+      << "radial gradient rendering must be byte-identical across the wire";
+}
+
+TEST(PixelRoundTripTest, MaskedContentMatchesDirectRender) {
+  // Exercise kPushMask/kTransitionMaskToContent/kPopMask — a solid rect
+  // under a circular mask. If the wire drops any of these, the result
+  // comes out as an unmasked full rect.
+  constexpr std::string_view kSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80">
+         <defs>
+           <mask id="m">
+             <circle cx="40" cy="40" r="25" fill="white"/>
+           </mask>
+         </defs>
+         <rect width="80" height="80" fill="red" mask="url(#m)"/>
+       </svg>)svg";
+
+  const auto direct = RenderDirect(kSvg, 80, 80);
+  bool hasUnsupported = false;
+  const auto viaWire = RenderViaWire(kSvg, 80, 80, hasUnsupported);
+  EXPECT_FALSE(hasUnsupported)
+      << "mask opcodes should no longer emit kUnsupported";
+  ASSERT_EQ(direct.dimensions, viaWire.dimensions);
+  EXPECT_EQ(direct.pixels, viaWire.pixels);
+}
+
+TEST(PixelRoundTripTest, PatternTileMatchesDirectRender) {
+  // Pattern paint servers use a backend-side channel: beginPatternTile →
+  // sub-stream → endPatternTile stores the recorded pixmap in
+  // `patternFillPaint_`, and the next makeFillPaint call picks it up
+  // regardless of what the wire says in setPaint (which still encodes the
+  // PaintResolvedReference as kPaintTagStub → None). The critical
+  // correctness guarantee is that the recorded tile pixmap and the backend's
+  // state management survive the serialize/replay roundtrip.
+  constexpr std::string_view kSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80">
+         <defs>
+           <pattern id="p" x="0" y="0" width="16" height="16"
+                    patternUnits="userSpaceOnUse">
+             <rect width="8" height="8" fill="blue"/>
+             <rect x="8" y="8" width="8" height="8" fill="blue"/>
+           </pattern>
+         </defs>
+         <rect width="80" height="80" fill="url(#p)"/>
+       </svg>)svg";
+
+  const auto direct = RenderDirect(kSvg, 80, 80);
+  bool hasUnsupported = false;
+  const auto viaWire = RenderViaWire(kSvg, 80, 80, hasUnsupported);
+  EXPECT_FALSE(hasUnsupported)
+      << "pattern opcodes should not emit kUnsupported";
+  ASSERT_EQ(direct.dimensions, viaWire.dimensions);
+
+  // Count differing pixels and diagnose.
+  int diffPixels = 0;
+  int nonBlankDirect = 0;
+  int nonBlankWire = 0;
+  for (std::size_t i = 0; i + 3 < direct.pixels.size(); i += 4) {
+    if (direct.pixels[i + 3] != 0) ++nonBlankDirect;
+    if (viaWire.pixels[i + 3] != 0) ++nonBlankWire;
+    if (direct.pixels[i] != viaWire.pixels[i] ||
+        direct.pixels[i + 1] != viaWire.pixels[i + 1] ||
+        direct.pixels[i + 2] != viaWire.pixels[i + 2] ||
+        direct.pixels[i + 3] != viaWire.pixels[i + 3]) {
+      ++diffPixels;
+    }
+  }
+  const int totalPixels = direct.dimensions.x * direct.dimensions.y;
+  // Also verify deterministic serialization: two separate serialize passes
+  // on independently-parsed documents must produce identical wire bytes.
+  auto wireDoc1 = ParseOrDie(kSvg);
+  wireDoc1.setCanvasSize(80, 80);
+  SerializingRenderer ser1;
+  ser1.draw(wireDoc1);
+  auto wireDoc2 = ParseOrDie(kSvg);
+  wireDoc2.setCanvasSize(80, 80);
+  SerializingRenderer ser2;
+  ser2.draw(wireDoc2);
+  const bool wiresDeterministic = (ser1.data().size() == ser2.data().size()) &&
+      std::equal(ser1.data().begin(), ser1.data().end(), ser2.data().begin());
+  EXPECT_TRUE(wiresDeterministic)
+      << "two serialize passes produced different wire bytes (sizes: "
+      << ser1.data().size() << " vs " << ser2.data().size() << ")";
+  EXPECT_EQ(direct.pixels, viaWire.pixels)
+      << "pattern: " << diffPixels << " / " << totalPixels << " pixels differ. "
+      << "direct non-blank=" << nonBlankDirect
+      << " wire non-blank=" << nonBlankWire;
+}
+
+TEST(PixelRoundTripTest, TransformedShapesMatchDirectRender) {
+  // Use a custom raw-string delimiter so the `translate(10 10)` sequence
+  // doesn't prematurely terminate the string literal.
+  constexpr std::string_view kSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+         <g transform="translate(10 10)">
+           <rect width="30" height="30" fill="green"/>
+           <circle cx="60" cy="60" r="20" fill="orange"/>
+         </g>
+       </svg>)svg";
+
+  const auto direct = RenderDirect(kSvg, 100, 100);
+  bool hasUnsupported = false;
+  const auto viaWire = RenderViaWire(kSvg, 100, 100, hasUnsupported);
+
+  ASSERT_EQ(direct.dimensions, viaWire.dimensions);
+  ASSERT_EQ(direct.pixels.size(), viaWire.pixels.size());
+  EXPECT_FALSE(hasUnsupported);
+  EXPECT_EQ(direct.pixels, viaWire.pixels);
+}
+
+TEST(PixelRoundTripTest, GaussianBlurFilterMatchesDirectRender) {
+  // Exercise the full FilterGraph encoding: a single feGaussianBlur
+  // primitive applied to a solid red rectangle. The wire must carry the
+  // node count, the primitive tag + stdDeviation fields, the input list,
+  // and the graph metadata so the replay backend produces the same blur.
+  constexpr std::string_view kSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80">
+         <defs>
+           <filter id="f">
+             <feGaussianBlur in="SourceGraphic" stdDeviation="3"/>
+           </filter>
+         </defs>
+         <rect width="80" height="80" fill="red" filter="url(#f)"/>
+       </svg>)svg";
+
+  const auto direct = RenderDirect(kSvg, 80, 80);
+  bool hasUnsupported = false;
+  const auto viaWire = RenderViaWire(kSvg, 80, 80, hasUnsupported);
+  EXPECT_FALSE(hasUnsupported)
+      << "filter opcodes should not emit kUnsupported";
+  ASSERT_EQ(direct.dimensions, viaWire.dimensions);
+  EXPECT_EQ(direct.pixels, viaWire.pixels)
+      << "feGaussianBlur rendering must be byte-identical across the wire";
+}
+
+TEST(PixelRoundTripTest, ColorMatrixFilterMatchesDirectRender) {
+  // Exercise feColorMatrix (saturate type). A green rect desaturated to
+  // grayscale verifies that the matrix type + values vector survive the
+  // wire round-trip.
+  constexpr std::string_view kSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+         <defs>
+           <filter id="f">
+             <feColorMatrix type="saturate" values="0"/>
+           </filter>
+         </defs>
+         <rect width="64" height="64" fill="green" filter="url(#f)"/>
+       </svg>)svg";
+
+  const auto direct = RenderDirect(kSvg, 64, 64);
+  bool hasUnsupported = false;
+  const auto viaWire = RenderViaWire(kSvg, 64, 64, hasUnsupported);
+  EXPECT_FALSE(hasUnsupported)
+      << "feColorMatrix should not emit kUnsupported";
+  ASSERT_EQ(direct.dimensions, viaWire.dimensions);
+  EXPECT_EQ(direct.pixels, viaWire.pixels)
+      << "feColorMatrix rendering must be byte-identical across the wire";
+}
+
+TEST(AdversarialTest, ClaimedLengthBeyondBufferFails) {
+  // Handcraft a stream that says "here's 1 GB of payload" but gives only 4 bytes.
+  WireWriter w;
+  w.writeU32(static_cast<uint32_t>(Opcode::kStreamHeader));
+  w.writeU32(8);
+  w.writeU32(kWireMagic);
+  w.writeU32(kWireVersion);
+
+  w.writeU32(static_cast<uint32_t>(Opcode::kBeginFrame));
+  w.writeU32(1u << 30);  // 1 GiB
+  // ... no payload follows.
+
+  capture::CapturingRenderer target;
+  ReplayingRenderer replay(target);
+  ReplayReport report;
+  EXPECT_EQ(replay.pumpFrame(w.data(), report), ReplayStatus::kMalformed);
+}
+
+// -----------------------------------------------------------------------------
+// FontFace round-trip
+// -----------------------------------------------------------------------------
+
+TEST(CodecTest, FontFaceRoundTrip) {
+  css::FontFace face;
+  face.familyName = RcString("TestFont");
+  face.fontWeight = 700;
+  face.fontStyle = 1;
+  face.fontStretch = 3;
+
+  // Source 0: Kind::Data with dummy TTF bytes.
+  {
+    css::FontFaceSource src;
+    src.kind = css::FontFaceSource::Kind::Data;
+    auto data = std::make_shared<std::vector<uint8_t>>(
+        std::vector<uint8_t>{0x00, 0x01, 0x00, 0x00, 0xDE, 0xAD, 0xBE, 0xEF});
+    src.payload = std::move(data);
+    src.formatHint = RcString("opentype");
+    src.techHints = {RcString("variations"), RcString("color-COLRv1")};
+    face.sources.push_back(std::move(src));
+  }
+
+  // Source 1: Kind::Local with a family name.
+  {
+    css::FontFaceSource src;
+    src.kind = css::FontFaceSource::Kind::Local;
+    src.payload = RcString("Arial");
+    src.formatHint = RcString("");
+    face.sources.push_back(std::move(src));
+  }
+
+  // Source 2: Kind::Url with a URL string.
+  {
+    css::FontFaceSource src;
+    src.kind = css::FontFaceSource::Kind::Url;
+    src.payload = RcString("https://example.com/font.woff2");
+    src.formatHint = RcString("woff2");
+    face.sources.push_back(std::move(src));
+  }
+
+  WireWriter w;
+  EncodeFontFace(w, face);
+  WireReader r(w.data());
+  css::FontFace decoded;
+  ASSERT_TRUE(DecodeFontFace(r, decoded));
+
+  EXPECT_EQ(std::string_view(decoded.familyName), "TestFont");
+  EXPECT_EQ(decoded.fontWeight, 700);
+  EXPECT_EQ(decoded.fontStyle, 1);
+  EXPECT_EQ(decoded.fontStretch, 3);
+  ASSERT_EQ(decoded.sources.size(), 3u);
+
+  // Verify Data source round-trips.
+  {
+    const auto& s = decoded.sources[0];
+    EXPECT_EQ(s.kind, css::FontFaceSource::Kind::Data);
+    const auto* dataPtr =
+        std::get_if<std::shared_ptr<const std::vector<uint8_t>>>(&s.payload);
+    ASSERT_NE(dataPtr, nullptr);
+    ASSERT_NE(*dataPtr, nullptr);
+    EXPECT_EQ((*dataPtr)->size(), 8u);
+    EXPECT_EQ((**dataPtr)[4], 0xDE);
+    EXPECT_EQ((**dataPtr)[7], 0xEF);
+    EXPECT_EQ(std::string_view(s.formatHint), "opentype");
+    ASSERT_EQ(s.techHints.size(), 2u);
+    EXPECT_EQ(std::string_view(s.techHints[0]), "variations");
+    EXPECT_EQ(std::string_view(s.techHints[1]), "color-COLRv1");
+  }
+
+  // Verify Local source round-trips.
+  {
+    const auto& s = decoded.sources[1];
+    EXPECT_EQ(s.kind, css::FontFaceSource::Kind::Local);
+    const auto* strPtr = std::get_if<RcString>(&s.payload);
+    ASSERT_NE(strPtr, nullptr);
+    EXPECT_EQ(std::string_view(*strPtr), "Arial");
+  }
+
+  // Verify Url source round-trips.
+  {
+    const auto& s = decoded.sources[2];
+    EXPECT_EQ(s.kind, css::FontFaceSource::Kind::Url);
+    const auto* strPtr = std::get_if<RcString>(&s.payload);
+    ASSERT_NE(strPtr, nullptr);
+    EXPECT_EQ(std::string_view(*strPtr), "https://example.com/font.woff2");
+    EXPECT_EQ(std::string_view(s.formatHint), "woff2");
+  }
+}
+
+TEST(CodecTest, TextParamsWithFontFacesRoundTrip) {
+  // Build a TextParams with a non-empty fontFaces vector.
+  css::FontFace face;
+  face.familyName = RcString("CustomFont");
+  face.fontWeight = 400;
+  face.fontStyle = 0;
+  face.fontStretch = 5;
+
+  css::FontFaceSource src;
+  src.kind = css::FontFaceSource::Kind::Data;
+  auto data = std::make_shared<std::vector<uint8_t>>(
+      std::vector<uint8_t>{0xCA, 0xFE, 0xBA, 0xBE, 0x01, 0x02, 0x03});
+  src.payload = std::move(data);
+  src.formatHint = RcString("truetype");
+  face.sources.push_back(std::move(src));
+
+  std::vector<css::FontFace> faces = {face};
+
+  svg::TextParams params;
+  params.opacity = 0.8;
+  params.fontFamilies.push_back(RcString("CustomFont"));
+  params.fontFaces = faces;
+
+  WireWriter w;
+  EncodeTextParams(w, params);
+  WireReader r(w.data());
+
+  svg::TextParams decoded;
+  std::vector<css::FontFace> decodedFaces;
+  ASSERT_TRUE(DecodeTextParams(r, decoded, &decodedFaces));
+
+  // Verify the font faces survived the round-trip.
+  ASSERT_EQ(decodedFaces.size(), 1u);
+  EXPECT_EQ(std::string_view(decodedFaces[0].familyName), "CustomFont");
+  ASSERT_EQ(decodedFaces[0].sources.size(), 1u);
+  const auto& ds = decodedFaces[0].sources[0];
+  EXPECT_EQ(ds.kind, css::FontFaceSource::Kind::Data);
+  const auto* dp =
+      std::get_if<std::shared_ptr<const std::vector<uint8_t>>>(&ds.payload);
+  ASSERT_NE(dp, nullptr);
+  ASSERT_NE(*dp, nullptr);
+  EXPECT_EQ((*dp)->size(), 7u);
+  EXPECT_EQ((**dp)[0], 0xCA);
+  EXPECT_EQ((**dp)[3], 0xBE);
+  EXPECT_EQ(std::string_view(ds.formatHint), "truetype");
+
+  // Verify the span was set.
+  EXPECT_EQ(decoded.fontFaces.size(), 1u);
+  EXPECT_DOUBLE_EQ(decoded.opacity, 0.8);
+}
+
+}  // namespace
+}  // namespace donner::editor::sandbox

--- a/donner/svg/renderer/BUILD.bazel
+++ b/donner/svg/renderer/BUILD.bazel
@@ -152,6 +152,10 @@ donner_cc_library(
     name = "renderer_driver",
     srcs = ["RendererDriver.cc"],
     hdrs = ["RendererDriver.h"],
+    defines = select({
+        ":text_enabled": ["DONNER_TEXT_ENABLED"],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
     deps = [
         ":renderer_interface",
@@ -160,7 +164,10 @@ donner_cc_library(
         "//donner/base",
         "//donner/svg",
         "//donner/svg/renderer/common",
-    ],
+    ] + select({
+        ":text_enabled": ["//donner/svg/text:text_engine"],
+        "//conditions:default": [],
+    }),
 )
 
 donner_cc_library(

--- a/donner/svg/renderer/BUILD.bazel
+++ b/donner/svg/renderer/BUILD.bazel
@@ -181,7 +181,10 @@ donner_cc_library(
     name = "renderer_image_io",
     srcs = ["RendererImageIO.cc"],
     hdrs = ["RendererImageIO.h"],
-    visibility = ["//donner/svg/renderer:__subpackages__"],
+    visibility = [
+        "//donner/editor:__subpackages__",
+        "//donner/svg/renderer:__subpackages__",
+    ],
     deps = [
         "@stb//:image_write",
     ],
@@ -201,7 +204,10 @@ donner_cc_library(
     name = "terminal_image_viewer",
     srcs = ["TerminalImageViewer.cc"],
     hdrs = ["TerminalImageViewer.h"],
-    visibility = ["//donner/svg:__subpackages__"],
+    visibility = [
+        "//donner/editor:__subpackages__",
+        "//donner/svg:__subpackages__",
+    ],
     deps = [
         ":renderer_image_io",
         "//donner/base/encoding:base64",

--- a/donner/svg/resources/BUILD.bazel
+++ b/donner/svg/resources/BUILD.bazel
@@ -14,7 +14,10 @@ donner_cc_library(
 donner_cc_library(
     name = "image_resource",
     hdrs = ["ImageResource.h"],
-    visibility = ["//donner/svg:__subpackages__"],
+    visibility = [
+        "//donner/editor:__subpackages__",
+        "//donner/svg:__subpackages__",
+    ],
 )
 
 donner_cc_library(
@@ -87,7 +90,10 @@ donner_cc_library(
         "//donner/svg/renderer:text_full_enabled": ["DONNER_TEXT_WOFF2_ENABLED"],
         "//conditions:default": [],
     }),
-    visibility = ["//donner/svg:__subpackages__"],
+    visibility = [
+        "//donner/editor:__subpackages__",
+        "//donner/svg:__subpackages__",
+    ],
     deps = [
         "//donner/base",
         "//donner/base/fonts",

--- a/donner/svg/text/BUILD.bazel
+++ b/donner/svg/text/BUILD.bazel
@@ -57,7 +57,10 @@ donner_cc_library(
         "//donner/svg/renderer:text_full_enabled": ["DONNER_TEXT_FULL"],
         "//conditions:default": [],
     }),
-    visibility = ["//donner/svg:__subpackages__"],
+    visibility = [
+        "//donner/editor:__subpackages__",
+        "//donner/svg:__subpackages__",
+    ],
     deps = [
         ":text_backend",
         ":text_backend_simple",

--- a/third_party/patches/glfw_bazel_build_files.patch
+++ b/third_party/patches/glfw_bazel_build_files.patch
@@ -13,7 +13,7 @@ new file mode 100644
 index 00000000..952ce1c3
 --- /dev/null
 +++ b/BUILD.bazel
-@@ -0,0 +1,145 @@
+@@ -0,0 +1,146 @@
 +load("@rules_cc//cc:defs.bzl", "cc_library")
 +load("@bazel_skylib//lib:selects.bzl", "selects")
 +
@@ -77,6 +77,7 @@ index 00000000..952ce1c3
 +        "//conditions:default": [
 +            "src/glx_context.c",
 +            "src/linux_joystick.c",
++            "src/posix_poll.c",
 +            "src/posix_thread.c",
 +            "src/posix_time.c",
 +            "src/x11_init.c",

--- a/tools/cmake/gen_cmakelists.py
+++ b/tools/cmake/gen_cmakelists.py
@@ -99,7 +99,12 @@ SKIPPED_PACKAGES = {
     "donner/benchmarks",  # requires Google Benchmark (Bazel-only)
     "donner/svg/renderer/geode",  # Geode (WebGPU) — Bazel-only, gated behind --enable_dawn flag
     "donner/editor",  # Donner Editor — Bazel-only, depends on imgui/glfw/tracy
+    "donner/editor/app",
+    "donner/editor/app/tests",
+    "donner/editor/gui",
     "donner/editor/resources",
+    "donner/editor/sandbox",
+    "donner/editor/sandbox/tests",
     "donner/editor/tests",
     "donner/editor/wasm",
     "third_party/stb",


### PR DESCRIPTION
## Summary

Implements the full editor sandbox design (`docs/design_docs/editor_sandbox.md`): a browser-style process model where SVG parsing runs in an isolated child process and rendering commands stream back to the host via a serialized `RendererInterface` wire protocol.

**50 files, +11,352 lines, 35 bazel targets, 90+ test cases — all passing.**

### Architecture

The key insight: `RendererInterface` is already a self-contained command stream. Making it literal gives us sandbox IPC, multi-threaded rendering, record/replay, and frame inspection from one design decision.

- **SerializingRenderer** encodes every `RendererInterface` call into a compact binary stream (22 opcodes covering all 28 virtual methods, zero `kUnsupported` emissions)
- **ReplayingRenderer** decodes the stream and dispatches to any backend (TinySkia, Skia, Geode)
- The same wire format works across **four transport boundaries**:
  - **Process pipes** (`SandboxHost`) — parser runs in an isolated child
  - **Threads** (`PipelinedRenderer`) — main thread serializes, worker rasterizes
  - **Files** (`.rnr` recording) — capture and replay render sessions
  - **Partial replay** (`FrameInspector`) — scrub slider for draw-order visualization

### Wire format coverage (pixel-identical round-trip tests)

| Feature | Status |
|---|---|
| Solid fills, paths, rects, ellipses, transforms, clips | Pixel-identical |
| Linear + radial gradients | Pixel-identical (replay-side mini-registry) |
| Masks (push/transition/pop) | Pixel-identical |
| Pattern tiles | Pixel-identical (backend side-channel) |
| Filter layers | 17-variant primitive codec (transparent pass-through) |
| Images | Inline RGBA pixels |
| Text | Full ComputedTextComponent + TextParams + FontFace bytes |

### Sandbox hardening

- `RLIMIT_AS`/`CPU`/`FSIZE`/`NOFILE` caps, FD sweep, `chdir("/")`, env gate
- **seccomp-bpf** syscall allowlist (aarch64 + x86_64, fail-open mode)
- Curated 2-entry envp (`DONNER_SANDBOX=1` only — drops `LD_PRELOAD`, auth tokens, etc.)

### Editor MVP

- **EditorApp**: headless core with `navigate`/`reload`/`resize`/`pollForChanges`
- **EditorRepl**: stdin/stdout command loop (`load`, `show`, `save`, `inspect`, `record`, `watch on/off`)
- **donner_editor_gui**: GLFW+ImGui+GL window with address bar, status chip, viewport, frame inspector pane with scrub slider
- **SvgSource**: `file://` + local paths + `https://`/`http://` (via system curl, shell-injection protected)
- **Live file watching** via mtime polling (REPL + GUI)

### CLI tools

- `sandbox_render` — end-to-end: URI → sandbox child → wire → replay → PNG
- `sandbox_replay` — loads `.rnr` → replays → PNG (no parser needed)
- `sandbox_inspect` — decoded command stream as indented text table

## Test plan

- [x] 35 bazel targets pass (`bazel test //donner/editor/...`)
- [x] Pixel-identical round-trip tests for: solid rect, path, transforms, linear gradient, radial gradient, mask, pattern tile
- [x] Filter primitive round-trips: feGaussianBlur, feColorMatrix
- [x] Font face data round-trip (Kind::Data with inline bytes)
- [x] Process isolation: malformed/adversarial SVG never crashes the host
- [x] Sandbox hardening: child refuses without DONNER_SANDBOX=1, seccomp filter active
- [x] SvgSource: file://, relative paths, size caps, HTTPS routing, shell-metachar rejection
- [x] EditorApp state: navigate, reload, fetch error retains previous bitmap, watch polling
- [x] EditorRepl: load/status/save/inspect/record/resize/watch/help command dispatch
- [x] Wire adversarial inputs: random bytes, truncated streams, oversized length claims