### PR TITLE
CI: replace actions/cache with bazel-contrib/setup-bazel

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,14 +22,14 @@ jobs:
           java-version: 11
           distribution: "microsoft"
 
-      - name: Cache Bazel
-        uses: actions/cache@v5
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
-          path: |
-            ~/.cache/bazel
-          key: ${{ runner.os }}-bazelcov-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE', 'WORKSPACE.bazel', 'WORKSPACE.bzlmod', 'MODULE.bazel') }}
-          restore-keys: |
-            ${{ runner.os }}-bazelcov-
+          bazelisk-cache: true
+          disk-cache: coverage-${{ runner.os }}
+          repository-cache: true
+          external-cache: true
+          cache-save: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,25 +44,14 @@ jobs:
             # a prebuilt `libwgpu_native.so`, so no cross-stdlib compile
             # happens during fetch.
 
-      - name: Cache Bazel
-        uses: actions/cache@v5
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
-          path: |
-            ~/.cache/bazel
-          key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel') }}
-          restore-keys: |
-            ${{ runner.os }}-bazel-
-
-      # bazelisk fetch downloads the toolchain and module dependencies. We retry
-      # this step specifically to tolerate GitHub / BCR / Chromium rate limits,
-      # without masking actual compilation errors in the subsequent build step.
-      - name: Fetch Bazel dependencies
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 15
-          max_attempts: 3
-          retry_wait_seconds: 30
-          command: bazelisk fetch //...
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-${{ runner.os }}
+          repository-cache: true
+          external-cache: true
+          cache-save: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build
         run: bazelisk build //...
@@ -116,15 +105,14 @@ jobs:
           sudo apt-get install -y pkg-config libfontconfig1-dev libfreetype6-dev \
             mesa-vulkan-drivers libvulkan1 libvulkan-dev
 
-      - name: Cache Bazel
-        uses: actions/cache@v5
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
-          path: |
-            ~/.cache/bazel
-          key: ${{ runner.os }}-bazel-geode-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel') }}
-          restore-keys: |
-            ${{ runner.os }}-bazel-geode-
-            ${{ runner.os }}-bazel-
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-geode-${{ runner.os }}
+          repository-cache: true
+          external-cache: true
+          cache-save: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build Geode targets
         run: |
@@ -151,22 +139,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Cache Bazel
-        uses: actions/cache@v5
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
-          path: |
-            /private/var/tmp/_bazel_runner/
-          key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel') }}
-          restore-keys: |
-            ${{ runner.os }}-bazel-
-
-      - name: Fetch Bazel dependencies
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 15
-          max_attempts: 3
-          retry_wait_seconds: 30
-          command: bazelisk fetch //...
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-${{ runner.os }}
+          repository-cache: true
+          external-cache: true
+          cache-save: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build
         run: bazelisk build //...


### PR DESCRIPTION
## Summary

Replace monolithic `actions/cache@v5` tarball caching with `bazel-contrib/setup-bazel@0.19.0` granular cache layers. Each layer invalidates independently:

- **disk-cache**: compiled outputs (invalidates on BUILD file changes)
- **repository-cache**: module deps (invalidates on MODULE.bazel changes)
- **external-cache**: individual external repos >10MB cached separately
- **bazelisk-cache**: bazelisk binary itself

PRs read from main's cache but don't write back (`cache-save` gating), preventing cache pollution.

Also removes manual `bazelisk fetch` steps — setup-bazel handles dependency fetching through its cache layers.

## Impact

- Fewer full cache misses: a source-only change no longer invalidates the repository cache
- Faster cache restore/save: smaller per-layer blobs instead of one multi-GB tarball
- PR isolation: PRs can't pollute main's cache

## Test plan

- [ ] CI passes on all jobs (linux, macOS, linux-geode, coverage)
- [ ] Verify cache layers appear in GitHub Actions cache list after a main merge
- [ ] Verify PR builds can read from main's cache