### PR TITLE
Fix stale design-doc refs in text/ subdirectory after numbering

### DIFF
--- a/docs/design_docs/text/architecture.md
+++ b/docs/design_docs/text/architecture.md
@@ -1,10 +1,10 @@
 # Text Rendering: Architecture
 
-[Back to hub](../text_rendering.md)
+[Back to hub](../0010-text_rendering.md)
 
 > Historical note: this document captures the original dependency evaluation and phased design
 > before the `TextEngine` / `TextBackend` refactor landed. The current shipped architecture is
-> summarized in [the hub](../text_rendering.md) and documented in
+> summarized in [the hub](../0010-text_rendering.md) and documented in
 > [text_backend_refactor.md](text_backend_refactor.md).
 
 ## Dependency Evaluation

--- a/docs/design_docs/text/overview.md
+++ b/docs/design_docs/text/overview.md
@@ -1,6 +1,6 @@
 # Text Rendering: Overview
 
-[Back to hub](../text_rendering.md)
+[Back to hub](../0010-text_rendering.md)
 
 **Status:** Implemented (base + text_full tiers)
 **Author:** Claude Opus 4.6

--- a/docs/design_docs/text/rtl_and_complex_scripts.md
+++ b/docs/design_docs/text/rtl_and_complex_scripts.md
@@ -1,6 +1,6 @@
 # Text Rendering: RTL Text and Complex Scripts
 
-[Back to hub](../text_rendering.md)
+[Back to hub](../0010-text_rendering.md)
 
 ## RTL Text and Complex Scripts (Phase 7) {#rtl}
 
@@ -77,7 +77,7 @@ glyphs in visual (LTR) order, but the y values should be applied in DOM order pe
 ## Color Emoji (Phase 8) {#color-emoji}
 
 **Status:** Implemented (text-full only)
-**See also:** [color_emoji.md](../color_emoji.md)
+**See also:** [0006-color_emoji.md](../0006-color_emoji.md)
 
 CBDT/CBLC color bitmap emoji support via FreeType. Enabled by adding libpng to the FreeType build
 via `single_version_override` patches. Key components:

--- a/docs/design_docs/text/testing.md
+++ b/docs/design_docs/text/testing.md
@@ -1,6 +1,6 @@
 # Text Rendering: Testing and Validation
 
-[Back to hub](../text_rendering.md)
+[Back to hub](../0010-text_rendering.md)
 
 ## Testing and Validation
 

--- a/docs/design_docs/text/text_backend_refactor.md
+++ b/docs/design_docs/text/text_backend_refactor.md
@@ -1,6 +1,6 @@
 # Text Backend Refactor: TextBackend Abstraction
 
-[Back to hub](../text_rendering.md)
+[Back to hub](../0010-text_rendering.md)
 
 **Status:** Implemented
 **Author:** Claude Opus 4.6
@@ -592,7 +592,7 @@ on the text root entity. Font property changes (family, size, weight, style, str
 cascade through the style system and are handled by the full render tree rebuild path.
 
 This integrates with the existing incremental invalidation system (see
-[incremental_invalidation.md](../incremental_invalidation.md)).
+[0005-incremental_invalidation.md](../0005-incremental_invalidation.md)).
 
 ### Renderer integration
 

--- a/docs/design_docs/text/text_v1_release.md
+++ b/docs/design_docs/text/text_v1_release.md
@@ -1,6 +1,6 @@
 # Text v1 Release
 
-[Back to hub](../text_rendering.md)
+[Back to hub](../0010-text_rendering.md)
 
 **Status:** Shipped
 

--- a/docs/design_docs/text/textpath.md
+++ b/docs/design_docs/text/textpath.md
@@ -1,6 +1,6 @@
 # Text Rendering: textPath
 
-[Back to hub](../text_rendering.md)
+[Back to hub](../0010-text_rendering.md)
 
 **Status:** Shipped for Text v1
 


### PR DESCRIPTION
## Summary

Cleanup from #523. The ADR-style renumbering of `docs/design_docs/*.md` updated every `./` and bare reference, but missed 10 `../` references from the nested `docs/design_docs/text/*.md` files pointing back at sibling docs in the parent directory.

Caught by a local Doxygen run against main:

```
warning: unable to resolve reference to '../text_rendering.md' for \ref command
warning: unable to resolve reference to '../color_emoji.md' for \ref command
warning: unable to resolve reference to '../incremental_invalidation.md' for \ref command
```

## Fix

| Old | New |
|---|---|
| `../text_rendering.md` (×8) | `../0010-text_rendering.md` |
| `../color_emoji.md` | `../0006-color_emoji.md` |
| `../incremental_invalidation.md` | `../0005-incremental_invalidation.md` |

## Impact

Local `doxygen Doxyfile` scan before/after:
- Before: **1686** warnings
- After: **1676** warnings
- Delta: **−10** (exactly the references fixed here)

The remaining 1676 are pre-existing and unrelated to the v0.5 numbering work.

## Test plan

- [x] `doxygen Doxyfile` — confirmed −10 warnings
- [ ] CI green
- [ ] Codex review resolved