### PR TITLE
ci: self-hosted Linux GitHub Actions runner for jwmcglynn

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,10 +14,20 @@ on:
     branches: [main]
   workflow_dispatch:  # Re-run on demand (e.g. before final merge)
 
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
+#
+# Self-hosted coverage uses the same operator-only gate as CI's Linux lane:
+# SELFHOSTED_LINUX_RUNNER must be "true", and both actor identities must be
+# jwmcglynn. That prevents collaborator reruns from executing on the homelab
+# runner or seeing the Codecov secret there. Everyone else stays on hosted
+# Ubuntu.
 jobs:
   build:
     runs-on: ubuntu-24.04
+    if: ${{ vars.SELFHOSTED_LINUX_RUNNER != 'true' || github.actor != 'jwmcglynn' || github.triggering_actor != 'jwmcglynn' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -40,26 +50,103 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libncurses-dev pkg-config libfontconfig1-dev libfreetype6-dev
+          sudo apt-get install -y libncurses-dev pkg-config libfontconfig1-dev libfreetype6-dev \
+            mesa-vulkan-drivers libvulkan1 libvulkan-dev \
+            libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
+            libgl1-mesa-dev libosmesa6-dev
 
       - name: Generate coverage
         run: |
-          # Exclude //donner/editor/gui/... and //donner/editor:* — they
-          # depend on GLFW + imgui, which need X11/GL headers that the
-          # hermetic LLVM sysroot (used via --config=latest_llvm in
-          # coverage.sh) does not carry. //donner/editor/sandbox/... is
-          # GLFW-free and stays in scope.
           tools/coverage.sh --quiet --no-html \
             //donner/base/... \
             //donner/css/... \
             //donner/svg/... \
-            //donner/editor/sandbox/...
+            //donner/editor/...
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage-report/filtered_report.dat
+          flags: unittests
+          fail_ci_if_error: true
+          verbose: true
+
+  coverage-self-hosted:
+    runs-on: [self-hosted, linux, arm64, event-horizon]
+    if: ${{ vars.SELFHOSTED_LINUX_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Sync Bazel toolchain
+        run: |
+          find /var/cache/bazel/user-root -maxdepth 5 \
+            \( -name "*+local_config_cc" \
+            -o -name "local_config_cc" \
+            -o -name "*+local_config_cc_toolchains" \
+            -o -name "local_config_cc_toolchains" \
+            -o -name "*+local_config_cc.marker" \
+            -o -name "local_config_cc.marker" \
+            -o -name "*+local_config_cc_toolchains.marker" \
+            -o -name "local_config_cc_toolchains.marker" \) \
+            -exec rm -rf {} + 2>/dev/null || true
+
+      - name: Prepare Bazel LLVM linker
+        shell: bash
+        run: |
+          set -euo pipefail
+          bazelisk fetch --config=latest_llvm \
+            //donner/base/... \
+            //donner/css/... \
+            //donner/svg/... \
+            //donner/editor/...
+          patch-bazel-llvm-tools /var/cache/bazel/user-root
+          # `fetch` starts a Bazel server before we patch the downloaded
+          # linker. Restart it so coverage action inputs are digested from the
+          # patched ELF instead of stale server state.
+          bazelisk shutdown
+
+      - name: Generate coverage
+        run: |
+          tools/coverage.sh --quiet --no-html \
+            //donner/base/... \
+            //donner/css/... \
+            //donner/svg/... \
+            //donner/editor/...
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: self-hosted-coverage-report
+          path: coverage-report/filtered_report.dat
+          if-no-files-found: error
+          retention-days: 1
+
+  upload-self-hosted-coverage:
+    needs: coverage-self-hosted
+    runs-on: ubuntu-24.04
+    if: ${{ vars.SELFHOSTED_LINUX_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: self-hosted-coverage-report
+          path: coverage-report
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage-report/filtered_report.dat
+          disable_search: true
           flags: unittests
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,13 +17,11 @@ on:
 # Variables:
 #
 #   - SELFHOSTED_LINUX_RUNNER: "true" when the linux self-hosted runner
-#     (event-horizon) is online. Adds an ADDITIONAL `linux-self-hosted`
-#     job (ARM64) on top of the GitHub-hosted x86_64 `linux` job, but
-#     only for operator runs (`github.actor == 'jwmcglynn'`). The
-#     baseline x86_64 `linux` job runs for everyone all the time —
-#     this is purely augmentation, not replacement. That way x86
-#     coverage never regresses, and the operator gets extra ARM64
-#     coverage + homelab speed on top.
+#     (event-horizon) is online. Switches the Linux lane over entirely:
+#     operator runs go to `linux-self-hosted` (ARM64), everyone else
+#     stays on the GitHub-hosted `linux` (x86_64) job. Mutually
+#     exclusive — exactly one Linux job runs per workflow invocation
+#     for the operator. Non-operator runs always use GitHub-hosted.
 #
 #   - SELFHOSTED_MACOS_RUNNER: "true" when the macOS self-hosted runner
 #     (deep-thought) is online. Switches the macOS lane over entirely:
@@ -44,10 +42,11 @@ on:
 
 jobs:
   linux:
-    # Runs for everyone, always — this is the x86_64 baseline that
-    # must never regress. When the operator also has the self-hosted
-    # ARM64 runner available, the `linux-self-hosted` job below runs
-    # in addition to (not instead of) this one.
+    # GitHub-hosted x86_64 baseline. Suppressed for operator runs when
+    # the self-hosted ARM64 runner is active (mirrors the macOS pattern);
+    # the `linux-self-hosted` job below runs instead. Non-operator runs
+    # (fork PRs, collaborators) always use this job.
+    if: ${{ vars.SELFHOSTED_LINUX_RUNNER != 'true' || github.actor != 'jwmcglynn' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -100,15 +99,13 @@ jobs:
           bazelisk test --config=ci --test_output=errors \
             //donner/svg/renderer/tests:resvg_test_suite_skia_ref
 
-  # ARM64 augmentation of the `linux` job above, running on the
-  # event-horizon self-hosted runner. Selected by the gate explained at
-  # the top of this file:
+  # ARM64 Linux job on the event-horizon self-hosted runner. Selected by
+  # the gate explained at the top of this file:
   #
   #   - Runs only when SELFHOSTED_LINUX_RUNNER == 'true' AND the
   #     triggering actor is jwmcglynn.
-  #   - Runs IN ADDITION TO the GitHub-hosted `linux` job, not instead
-  #     of it. Baseline x86_64 coverage is never lost; this is pure
-  #     ARM64 augmentation for operator runs.
+  #   - The `linux` job is suppressed in the same condition, so operator
+  #     runs go here exclusively (mirrors the macOS mutual-exclusion model).
   #
   # Differences from the GitHub-hosted Linux job:
   #

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,17 +129,15 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Build
-        # Also excludes fuzz_target: NixOS clang doesn't ship
-        # <fuzzer/FuzzedDataProvider.h> on its default include path
-        # the way Ubuntu's clang-18 does, so fuzz targets fail
-        # compilation with "file not found" under `bazelisk build //...`
-        # without any fuzzer sanitizer flag. Consistent with the
-        # main-only Skia reference pattern: fuzz targets build+test
-        # only on main merges (where the GitHub-hosted linux job
-        # runs them).
+        # Same -skia_ref filter as the GitHub-hosted linux job above.
+        # fuzz targets ARE built here: the donner-runner NixOS guest
+        # now -isystem's compiler-rt-libc's include dir into every
+        # bazel cc action via /etc/bazel.bazelrc, so
+        # <fuzzer/FuzzedDataProvider.h> resolves the same way it does
+        # on Ubuntu's apt clang-18.
         run: |
           bazelisk build --config=ci \
-            --build_tag_filters=-skia_ref,-fuzz_target \
+            --build_tag_filters=-skia_ref \
             //...
 
       - name: Build (Skia reference)
@@ -149,12 +147,12 @@ jobs:
             //donner/svg/renderer/tests:resvg_test_suite_skia_ref
 
       - name: Test
-        # Match the build filter above — fuzz targets aren't built so
-        # they can't be tested on self-hosted; they run on the
-        # GitHub-hosted `linux` job instead.
+        # Matches the build filter above; fuzz targets are exercised
+        # on self-hosted now that the runner guest provides the
+        # libFuzzer headers via bazelrc -isystem.
         run: |
           bazelisk test --config=ci --test_output=errors \
-            --test_tag_filters=-skia_ref,-fuzz_target \
+            --test_tag_filters=-skia_ref \
             //...
 
       - name: Test (Skia reference)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,7 +137,7 @@ jobs:
         # and Bazel's hermetic include scanner allows absolute /nix/store paths.
         # This step is idempotent; on a cold cache it's a no-op.
         run: |
-          find /var/cache/bazel/user-root -maxdepth 2 -type d \
+          find /var/cache/bazel/user-root -maxdepth 4 -type d \
             -name "local_config_cc" -exec rm -rf {} + 2>/dev/null || true
 
       - name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,9 +174,7 @@ jobs:
             //donner/svg/renderer/tests:renderer_geode_tests
 
   macos:
-    if: >
-      (github.ref == 'refs/heads/main' || github.event_name == 'pull_request')
-      && (vars.SELFHOSTED_MACOS_RUNNER != 'true' || github.actor != 'jwmcglynn')
+    if: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && (vars.SELFHOSTED_MACOS_RUNNER != 'true' || github.actor != 'jwmcglynn') }}
     runs-on: macos-15
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,11 +125,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Sync Bazel toolchain
+        # Force cc_autoconf to re-run by removing the cached toolchain config.
+        # On NixOS, cc_configure detects include paths by running `clang -v`;
+        # the nixpkgs cc-wrapper adds NIX_CFLAGS_COMPILE (-isystem paths for
+        # compiler-rt, X11, Vulkan, etc.) to that invocation.  But Bazel does
+        # NOT track NIX_CFLAGS_COMPILE as part of cc_configure's cache key —
+        # the rule doesn't access it via repository_ctx.os.environ, only via
+        # a subprocess.  Deleting local_config_cc forces fresh toolchain
+        # detection so the -isystem paths land in cxx_builtin_include_directories
+        # and Bazel's hermetic include scanner allows absolute /nix/store paths.
+        # This step is idempotent; on a cold cache it's a no-op.
+        run: |
+          find /var/cache/bazel/user-root -maxdepth 2 -type d \
+            -name "local_config_cc" -exec rm -rf {} + 2>/dev/null || true
+
       - name: Build
         # Same -skia_ref filter as the GitHub-hosted linux job above.
         # fuzz targets ARE built here: the donner-runner NixOS guest
-        # now -isystem's compiler-rt-libc's include dir into every
-        # bazel cc action via /etc/bazel.bazelrc, so
+        # injects compiler-rt-libc's include dir (and X11, Vulkan, etc.)
+        # via NIX_CFLAGS_COMPILE in /etc/bazel.bazelrc, so
         # <fuzzer/FuzzedDataProvider.h> resolves the same way it does
         # on Ubuntu's apt clang-18.
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,11 +138,14 @@ jobs:
         # This step is idempotent; on a cold cache it's a no-op.
         #
         # Pattern note: In Bazel 8 Bzlmod mode the repository uses the canonical
-        # name "+cc_configure+local_config_cc" (not the bare "local_config_cc"
-        # from WORKSPACE mode). The wildcard "*local_config_cc*" matches both.
+        # name "rules_cc++cc_configure_extension+local_config_cc" (not bare
+        # "local_config_cc" from WORKSPACE mode). The pattern "*local_config_cc"
+        # (trailing anchor, no *) matches both while NOT matching the sibling
+        # "rules_cc++cc_configure_extension+local_config_cc_toolchains" repo —
+        # deleting that one causes "BUILD file not found" errors.
         run: |
           find /var/cache/bazel/user-root -maxdepth 5 -type d \
-            -name "*local_config_cc*" -exec rm -rf {} + 2>/dev/null || true
+            -name "*local_config_cc" -exec rm -rf {} + 2>/dev/null || true
 
       - name: Build
         # Same -skia_ref filter as the GitHub-hosted linux job above.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,9 +129,17 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Build
+        # Also excludes fuzz_target: NixOS clang doesn't ship
+        # <fuzzer/FuzzedDataProvider.h> on its default include path
+        # the way Ubuntu's clang-18 does, so fuzz targets fail
+        # compilation with "file not found" under `bazelisk build //...`
+        # without any fuzzer sanitizer flag. Consistent with the
+        # main-only Skia reference pattern: fuzz targets build+test
+        # only on main merges (where the GitHub-hosted linux job
+        # runs them).
         run: |
           bazelisk build --config=ci \
-            --build_tag_filters=-skia_ref \
+            --build_tag_filters=-skia_ref,-fuzz_target \
             //...
 
       - name: Build (Skia reference)
@@ -141,9 +149,12 @@ jobs:
             //donner/svg/renderer/tests:resvg_test_suite_skia_ref
 
       - name: Test
+        # Match the build filter above — fuzz targets aren't built so
+        # they can't be tested on self-hosted; they run on the
+        # GitHub-hosted `linux` job instead.
         run: |
           bazelisk test --config=ci --test_output=errors \
-            --test_tag_filters=-skia_ref \
+            --test_tag_filters=-skia_ref,-fuzz_target \
             //...
 
       - name: Test (Skia reference)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,23 +12,34 @@ on:
 # are retried to survive transient GitHub/registry outages. Build/test steps
 # are NOT retried -- a real test failure should surface immediately.
 #
-# Self-hosted runner gate: when the repository variable
-# SELFHOSTED_LINUX_RUNNER is set to "true" (configured under repo Settings →
-# Secrets and variables → Actions → Variables), trusted commits — direct
-# pushes and pull requests opened from a branch in this same repo — route to
-# the `linux-self-hosted` job on the event-horizon donner-runner microvm
-# (4 GiB / 2 vCPU NixOS guest with bazel-cache1 wired in). Forks and any run
-# while the variable is unset stay on `ubuntu-24.04`. Only one of `linux` and
-# `linux-self-hosted` runs per workflow invocation; they are mirrors of each
-# other modulo the runner.
+# Self-hosted runner gate: when the repository variables
+# SELFHOSTED_LINUX_RUNNER / SELFHOSTED_MACOS_RUNNER are set to "true"
+# (configured under repo Settings → Secrets and variables → Actions →
+# Variables), runs where `github.actor == 'jwmcglynn'` route to the
+# `linux-self-hosted` and `macos-self-hosted` jobs running on the
+# mcglynn homelab self-hosted fleet (donner-runner microvm on
+# event-horizon + native launchd runner on deep-thought), both of which
+# have bazel-cache1 wired in.
 #
-# The `vars.SELFHOSTED_LINUX_RUNNER == 'true'` guard means this PR is safe
-# to land before the self-hosted runner is registered. Flip the variable
-# once the runner is online and the next push uses it.
+# Anyone else — fork PRs, same-repo PRs from collaborators, runs
+# re-triggered by a non-operator, any workflow dispatch by anyone other
+# than jwmcglynn — stays on the corresponding GitHub-hosted
+# `ubuntu-24.04` / `macos-15` job. The mirrors are mutually exclusive:
+# exactly one of `linux` / `linux-self-hosted` runs per workflow, and
+# exactly one of `macos` / `macos-self-hosted`.
+#
+# `github.actor == 'jwmcglynn'` is the strictest practical gate: it
+# pins the self-hosted lane to the single operator account that owns
+# the homelab runners, so no other committer can cause a job to execute
+# on (and potentially pollute the cache of) the self-hosted fleet.
+#
+# The gate is safe to land before the runners are registered: with both
+# variables unset, behavior is unchanged from the pre-gate workflow.
+# Flip a variable once its runner is online and the next push uses it.
 
 jobs:
   linux:
-    if: ${{ vars.SELFHOSTED_LINUX_RUNNER != 'true' || !(github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ vars.SELFHOSTED_LINUX_RUNNER != 'true' || github.actor != 'jwmcglynn' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -74,22 +85,22 @@ jobs:
   # Mirror of the `linux` job above, but on the event-horizon self-hosted
   # runner. Selected by the gate explained at the top of this file:
   #
-  #   - Runs only when SELFHOSTED_LINUX_RUNNER == 'true' AND the trigger is a
-  #     direct push or a same-repo PR (forks never reach this job).
-  #   - The `linux` job is suppressed in the same condition, so trusted
-  #     commits run here exclusively.
+  #   - Runs only when SELFHOSTED_LINUX_RUNNER == 'true' AND the triggering
+  #     actor is jwmcglynn.
+  #   - The `linux` job is suppressed in the same condition, so operator
+  #     runs go here exclusively.
   #
   # Differences from the GitHub-hosted Linux job:
   #
   #   - No setup-bazel step. The microvm guest already has bazelisk on PATH
   #     and writes through to bazel-cache1 (gRPC at 192.168.1.63:9092) via
-  #     /etc/bazel.bazelrc baked into the NixOS guest config; trusted commits
+  #     /etc/bazel.bazelrc baked into the NixOS guest config; operator runs
   #     get full read+write cache access.
   #   - No apt-get step. The donner-runner NixOS guest config installs
   #     fontconfig, freetype, mesa-vulkan-drivers, libvulkan via
   #     environment.systemPackages.
   linux-self-hosted:
-    if: ${{ vars.SELFHOSTED_LINUX_RUNNER == 'true' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ vars.SELFHOSTED_LINUX_RUNNER == 'true' && github.actor == 'jwmcglynn' }}
     runs-on: [self-hosted, linux, arm64, event-horizon]
     steps:
       - name: Checkout
@@ -163,8 +174,10 @@ jobs:
             //donner/svg/renderer/tests:renderer_geode_tests
 
   macos:
+    if: >
+      (github.ref == 'refs/heads/main' || github.event_name == 'pull_request')
+      && (vars.SELFHOSTED_MACOS_RUNNER != 'true' || github.actor != 'jwmcglynn')
     runs-on: macos-15
-    if: github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -200,3 +213,41 @@ jobs:
         # Marked informational for now: fuzzer tests were previously macOS-disabled
         # so we don't want to break macOS CI during the rollout. Remove `|| true`
         # and the comment once the fuzzer corpus passes cleanly on macOS.
+
+  # Mirror of the `macos` job above, but on the deep-thought self-hosted
+  # runner. Selected by the gate explained at the top of this file:
+  #
+  #   - Runs only when SELFHOSTED_MACOS_RUNNER == 'true' AND the
+  #     triggering actor is jwmcglynn.
+  #   - The `macos` job is suppressed in the same condition, so operator
+  #     runs go here exclusively.
+  #
+  # Differences from the GitHub-hosted macOS job:
+  #
+  #   - No setup-bazel step. The host has ~/bin/bazelisk on PATH and a
+  #     pre-configured ~/.bazelrc pointing at bazel-cache1 (gRPC, LAN) and
+  #     persistent ~/Library/Caches/bazel-{repo,disk}-cache.
+  #   - Same gate on `github.ref == 'refs/heads/main'` for the main-only
+  #     fuzzer test suite; that only triggers on merges.
+  macos-self-hosted:
+    if: ${{ vars.SELFHOSTED_MACOS_RUNNER == 'true' && github.actor == 'jwmcglynn' }}
+    runs-on: [self-hosted, macOS, arm64, deep-thought]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build
+        run: bazelisk build --config=ci //...
+
+      - name: Test
+        run: bazelisk test --config=ci --test_output=errors //...
+
+      - name: Test fuzzers (libFuzzer via LLVM 21 toolchain)
+        if: github.ref == 'refs/heads/main'
+        run: |
+          bazelisk test \
+            --config=asan-fuzzer \
+            --test_output=errors \
+            --test_tag_filters=fuzz_target \
+            --build_tag_filters=fuzz_target \
+            //... || true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,34 +12,42 @@ on:
 # are retried to survive transient GitHub/registry outages. Build/test steps
 # are NOT retried -- a real test failure should surface immediately.
 #
-# Self-hosted runner gate: when the repository variables
-# SELFHOSTED_LINUX_RUNNER / SELFHOSTED_MACOS_RUNNER are set to "true"
-# (configured under repo Settings → Secrets and variables → Actions →
-# Variables), runs where `github.actor == 'jwmcglynn'` route to the
-# `linux-self-hosted` and `macos-self-hosted` jobs running on the
-# mcglynn homelab self-hosted fleet (donner-runner microvm on
-# event-horizon + native launchd runner on deep-thought), both of which
-# have bazel-cache1 wired in.
+# Self-hosted runner gates. Two repository variables, one per OS, each
+# configured at repo Settings → Secrets and variables → Actions →
+# Variables:
 #
-# Anyone else — fork PRs, same-repo PRs from collaborators, runs
-# re-triggered by a non-operator, any workflow dispatch by anyone other
-# than jwmcglynn — stays on the corresponding GitHub-hosted
-# `ubuntu-24.04` / `macos-15` job. The mirrors are mutually exclusive:
-# exactly one of `linux` / `linux-self-hosted` runs per workflow, and
-# exactly one of `macos` / `macos-self-hosted`.
+#   - SELFHOSTED_LINUX_RUNNER: "true" when the linux self-hosted runner
+#     (event-horizon) is online. Adds an ADDITIONAL `linux-self-hosted`
+#     job (ARM64) on top of the GitHub-hosted x86_64 `linux` job, but
+#     only for operator runs (`github.actor == 'jwmcglynn'`). The
+#     baseline x86_64 `linux` job runs for everyone all the time —
+#     this is purely augmentation, not replacement. That way x86
+#     coverage never regresses, and the operator gets extra ARM64
+#     coverage + homelab speed on top.
+#
+#   - SELFHOSTED_MACOS_RUNNER: "true" when the macOS self-hosted runner
+#     (deep-thought) is online. Switches the macOS lane over entirely:
+#     operator runs go to `macos-self-hosted`, everyone else stays on
+#     the GitHub-hosted `macos-15` job. Mutually exclusive — exactly
+#     one macOS job runs per workflow invocation.
 #
 # `github.actor == 'jwmcglynn'` is the strictest practical gate: it
-# pins the self-hosted lane to the single operator account that owns
-# the homelab runners, so no other committer can cause a job to execute
-# on (and potentially pollute the cache of) the self-hosted fleet.
+# pins the self-hosted lane to the operator account that owns the
+# homelab runners, so no other committer — fork PRs, same-repo PRs
+# from collaborators, reruns by non-operators — can execute on or
+# pollute the cache of the self-hosted fleet.
 #
-# The gate is safe to land before the runners are registered: with both
-# variables unset, behavior is unchanged from the pre-gate workflow.
-# Flip a variable once its runner is online and the next push uses it.
+# Both gates are safe to land before the runners are registered: with
+# the variables unset, behavior is unchanged from the pre-gate
+# workflow. Flip a variable once its runner is online and the next
+# push uses it.
 
 jobs:
   linux:
-    if: ${{ vars.SELFHOSTED_LINUX_RUNNER != 'true' || github.actor != 'jwmcglynn' }}
+    # Runs for everyone, always — this is the x86_64 baseline that
+    # must never regress. When the operator also has the self-hosted
+    # ARM64 runner available, the `linux-self-hosted` job below runs
+    # in addition to (not instead of) this one.
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -82,23 +90,27 @@ jobs:
           bazelisk test --config=ci --test_output=errors \
             //donner/svg/renderer/tests:resvg_test_suite_skia_ref
 
-  # Mirror of the `linux` job above, but on the event-horizon self-hosted
-  # runner. Selected by the gate explained at the top of this file:
+  # ARM64 augmentation of the `linux` job above, running on the
+  # event-horizon self-hosted runner. Selected by the gate explained at
+  # the top of this file:
   #
-  #   - Runs only when SELFHOSTED_LINUX_RUNNER == 'true' AND the triggering
-  #     actor is jwmcglynn.
-  #   - The `linux` job is suppressed in the same condition, so operator
-  #     runs go here exclusively.
+  #   - Runs only when SELFHOSTED_LINUX_RUNNER == 'true' AND the
+  #     triggering actor is jwmcglynn.
+  #   - Runs IN ADDITION TO the GitHub-hosted `linux` job, not instead
+  #     of it. Baseline x86_64 coverage is never lost; this is pure
+  #     ARM64 augmentation for operator runs.
   #
   # Differences from the GitHub-hosted Linux job:
   #
-  #   - No setup-bazel step. The microvm guest already has bazelisk on PATH
-  #     and writes through to bazel-cache1 (gRPC at 192.168.1.63:9092) via
-  #     /etc/bazel.bazelrc baked into the NixOS guest config; operator runs
-  #     get full read+write cache access.
-  #   - No apt-get step. The donner-runner NixOS guest config installs
-  #     fontconfig, freetype, mesa-vulkan-drivers, libvulkan via
-  #     environment.systemPackages.
+  #   - Different architecture: this runs aarch64, the GitHub-hosted
+  #     `linux` job runs x86_64. Catching a regression in only one
+  #     architecture is the primary value of running both.
+  #   - No setup-bazel step. The runner host already has bazelisk on
+  #     PATH and writes through to bazel-cache1 (gRPC at LAN address)
+  #     via /etc/bazel.bazelrc; operator runs get full read+write
+  #     cache access.
+  #   - No apt-get step. The runner's base config installs fontconfig,
+  #     freetype, mesa-vulkan-drivers, libvulkan.
   linux-self-hosted:
     if: ${{ vars.SELFHOSTED_LINUX_RUNNER == 'true' && github.actor == 'jwmcglynn' }}
     runs-on: [self-hosted, linux, arm64, event-horizon]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,15 +137,21 @@ jobs:
         # and Bazel's hermetic include scanner allows absolute /nix/store paths.
         # This step is idempotent; on a cold cache it's a no-op.
         #
-        # Pattern note: In Bazel 8 Bzlmod mode the repository uses the canonical
-        # name "rules_cc++cc_configure_extension+local_config_cc" (not bare
-        # "local_config_cc" from WORKSPACE mode). The pattern "*local_config_cc"
-        # (trailing anchor, no *) matches both while NOT matching the sibling
-        # "rules_cc++cc_configure_extension+local_config_cc_toolchains" repo —
-        # deleting that one causes "BUILD file not found" errors.
+        # Pattern note: In Bazel 8 Bzlmod mode the cc_configure module extension
+        # produces two repos: "rules_cc++cc_configure_extension+local_config_cc"
+        # (compiler detection) and "rules_cc++cc_configure_extension+local_config_cc_toolchains"
+        # (toolchain registration). Both must be cleared together — deleting only
+        # the directory is not enough because Bazel checks the marker file for
+        # cache validity; if the marker exists but the directory content is broken
+        # (no BUILD file), Bazel reuses the broken state without regenerating.
+        # Deleting both the directories and their @*.marker siblings forces a
+        # clean cc_configure_extension evaluation that regenerates both correctly.
+        # The "*cc_configure*" pattern covers all markers and the "*local_config_cc*"
+        # pattern covers both repo directories and any WORKSPACE-mode remnants.
         run: |
-          find /var/cache/bazel/user-root -maxdepth 5 -type d \
-            -name "*local_config_cc" -exec rm -rf {} + 2>/dev/null || true
+          find /var/cache/bazel/user-root -maxdepth 5 \
+            \( -name "*cc_configure*" -o -name "*local_config_cc*" \) \
+            -exec rm -rf {} + 2>/dev/null || true
 
       - name: Build
         # Same -skia_ref filter as the GitHub-hosted linux job above.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -146,11 +146,24 @@ jobs:
         # (no BUILD file), Bazel reuses the broken state without regenerating.
         # Deleting both the directories and their @*.marker siblings forces a
         # clean cc_configure_extension evaluation that regenerates both correctly.
-        # The "*cc_configure*" pattern covers all markers and the "*local_config_cc*"
-        # pattern covers both repo directories and any WORKSPACE-mode remnants.
+        #
+        # Safety: use suffix-anchored patterns ("*+local_config_cc" and
+        # "*+local_config_cc_toolchains") rather than substring patterns like
+        # "*cc_configure*".  The substring form reaches into unrelated repos —
+        # e.g. apple_support+/crosstool/osx_cc_configure.bzl lives at exactly
+        # maxdepth 5 and would be deleted, breaking the apple_support module.
+        # The canonical Bzlmod names end with "+local_config_cc[_toolchains]",
+        # which no other CC-configure repo in this graph shares.
         run: |
           find /var/cache/bazel/user-root -maxdepth 5 \
-            \( -name "*cc_configure*" -o -name "*local_config_cc*" \) \
+            \( -name "*+local_config_cc" \
+            -o -name "local_config_cc" \
+            -o -name "*+local_config_cc_toolchains" \
+            -o -name "local_config_cc_toolchains" \
+            -o -name "*+local_config_cc.marker" \
+            -o -name "local_config_cc.marker" \
+            -o -name "*+local_config_cc_toolchains.marker" \
+            -o -name "local_config_cc_toolchains.marker" \) \
             -exec rm -rf {} + 2>/dev/null || true
 
       - name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,9 +136,13 @@ jobs:
         # detection so the -isystem paths land in cxx_builtin_include_directories
         # and Bazel's hermetic include scanner allows absolute /nix/store paths.
         # This step is idempotent; on a cold cache it's a no-op.
+        #
+        # Pattern note: In Bazel 8 Bzlmod mode the repository uses the canonical
+        # name "+cc_configure+local_config_cc" (not the bare "local_config_cc"
+        # from WORKSPACE mode). The wildcard "*local_config_cc*" matches both.
         run: |
-          find /var/cache/bazel/user-root -maxdepth 4 -type d \
-            -name "local_config_cc" -exec rm -rf {} + 2>/dev/null || true
+          find /var/cache/bazel/user-root -maxdepth 5 -type d \
+            -name "*local_config_cc*" -exec rm -rf {} + 2>/dev/null || true
 
       - name: Build
         # Same -skia_ref filter as the GitHub-hosted linux job above.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,11 +74,21 @@ jobs:
           cache-save: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build
-        run: bazelisk build --config=ci //...
+        # Exclude skia_ref-tagged targets (pulls in the full Skia library)
+        # to avoid the multi-minute Skia compile on every PR. Main merges
+        # still exercise it in the `Build (Skia reference)` step below.
+        run: |
+          bazelisk build --config=ci \
+            --build_tag_filters=-skia_ref \
+            //...
+
+      - name: Build (Skia reference)
+        if: github.ref == 'refs/heads/main'
+        run: |
+          bazelisk build --config=ci \
+            //donner/svg/renderer/tests:resvg_test_suite_skia_ref
 
       - name: Test
-        # Exclude the Skia reference variant on PRs (only run on main merges)
-        # to avoid compiling the full Skia library on every PR.
         run: |
           bazelisk test --config=ci --test_output=errors \
             --test_tag_filters=-skia_ref \
@@ -119,10 +129,18 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Build
-        run: bazelisk build --config=ci //...
+        run: |
+          bazelisk build --config=ci \
+            --build_tag_filters=-skia_ref \
+            //...
+
+      - name: Build (Skia reference)
+        if: github.ref == 'refs/heads/main'
+        run: |
+          bazelisk build --config=ci \
+            //donner/svg/renderer/tests:resvg_test_suite_skia_ref
 
       - name: Test
-        # Match the github-hosted job: skip skia_ref on PRs (only run on main).
         run: |
           bazelisk test --config=ci --test_output=errors \
             --test_tag_filters=-skia_ref \
@@ -202,10 +220,28 @@ jobs:
           cache-save: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build
-        run: bazelisk build --config=ci //...
+        run: |
+          bazelisk build --config=ci \
+            --build_tag_filters=-skia_ref \
+            //...
+
+      - name: Build (Skia reference)
+        if: github.ref == 'refs/heads/main'
+        run: |
+          bazelisk build --config=ci \
+            //donner/svg/renderer/tests:resvg_test_suite_skia_ref
 
       - name: Test
-        run: bazelisk test --config=ci --test_output=errors //...
+        run: |
+          bazelisk test --config=ci --test_output=errors \
+            --test_tag_filters=-skia_ref \
+            //...
+
+      - name: Test (Skia reference)
+        if: github.ref == 'refs/heads/main'
+        run: |
+          bazelisk test --config=ci --test_output=errors \
+            //donner/svg/renderer/tests:resvg_test_suite_skia_ref
 
       # Run fuzzers on macOS via the LLVM 21 toolchain (Apple Clang lacks
       # libclang_rt.fuzzer_osx.a, but --config=asan-fuzzer activates
@@ -247,10 +283,28 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Build
-        run: bazelisk build --config=ci //...
+        run: |
+          bazelisk build --config=ci \
+            --build_tag_filters=-skia_ref \
+            //...
+
+      - name: Build (Skia reference)
+        if: github.ref == 'refs/heads/main'
+        run: |
+          bazelisk build --config=ci \
+            //donner/svg/renderer/tests:resvg_test_suite_skia_ref
 
       - name: Test
-        run: bazelisk test --config=ci --test_output=errors //...
+        run: |
+          bazelisk test --config=ci --test_output=errors \
+            --test_tag_filters=-skia_ref \
+            //...
+
+      - name: Test (Skia reference)
+        if: github.ref == 'refs/heads/main'
+        run: |
+          bazelisk test --config=ci --test_output=errors \
+            //donner/svg/renderer/tests:resvg_test_suite_skia_ref
 
       - name: Test fuzzers (libFuzzer via LLVM 21 toolchain)
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,24 @@ on:
 # Retry policy: network-sensitive steps (checkout, apt install, bazel fetch)
 # are retried to survive transient GitHub/registry outages. Build/test steps
 # are NOT retried -- a real test failure should surface immediately.
+#
+# Self-hosted runner gate: when the repository variable
+# SELFHOSTED_LINUX_RUNNER is set to "true" (configured under repo Settings →
+# Secrets and variables → Actions → Variables), trusted commits — direct
+# pushes and pull requests opened from a branch in this same repo — route to
+# the `linux-self-hosted` job on the event-horizon donner-runner microvm
+# (4 GiB / 2 vCPU NixOS guest with bazel-cache1 wired in). Forks and any run
+# while the variable is unset stay on `ubuntu-24.04`. Only one of `linux` and
+# `linux-self-hosted` runs per workflow invocation; they are mirrors of each
+# other modulo the runner.
+#
+# The `vars.SELFHOSTED_LINUX_RUNNER == 'true'` guard means this PR is safe
+# to land before the self-hosted runner is registered. Flip the variable
+# once the runner is online and the next push uses it.
 
 jobs:
   linux:
+    if: ${{ vars.SELFHOSTED_LINUX_RUNNER != 'true' || !(github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -45,6 +60,46 @@ jobs:
       - name: Test
         # Exclude the Skia reference variant on PRs (only run on main merges)
         # to avoid compiling the full Skia library on every PR.
+        run: |
+          bazelisk test --config=ci --test_output=errors \
+            --test_tag_filters=-skia_ref \
+            //...
+
+      - name: Test (Skia reference)
+        if: github.ref == 'refs/heads/main'
+        run: |
+          bazelisk test --config=ci --test_output=errors \
+            //donner/svg/renderer/tests:resvg_test_suite_skia_ref
+
+  # Mirror of the `linux` job above, but on the event-horizon self-hosted
+  # runner. Selected by the gate explained at the top of this file:
+  #
+  #   - Runs only when SELFHOSTED_LINUX_RUNNER == 'true' AND the trigger is a
+  #     direct push or a same-repo PR (forks never reach this job).
+  #   - The `linux` job is suppressed in the same condition, so trusted
+  #     commits run here exclusively.
+  #
+  # Differences from the GitHub-hosted Linux job:
+  #
+  #   - No setup-bazel step. The microvm guest already has bazelisk on PATH
+  #     and writes through to bazel-cache1 (gRPC at 192.168.1.63:9092) via
+  #     /etc/bazel.bazelrc baked into the NixOS guest config; trusted commits
+  #     get full read+write cache access.
+  #   - No apt-get step. The donner-runner NixOS guest config installs
+  #     fontconfig, freetype, mesa-vulkan-drivers, libvulkan via
+  #     environment.systemPackages.
+  linux-self-hosted:
+    if: ${{ vars.SELFHOSTED_LINUX_RUNNER == 'true' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    runs-on: [self-hosted, linux, arm64, event-horizon]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build
+        run: bazelisk build --config=ci //...
+
+      - name: Test
+        # Match the github-hosted job: skip skia_ref on PRs (only run on main).
         run: |
           bazelisk test --config=ci --test_output=errors \
             --test_tag_filters=-skia_ref \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,9 +12,22 @@ concurrency:
   group: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.workflow, github.event.pull_request.number) || format('push-{0}-{1}', github.workflow, github.run_id) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+  pull-requests: read
+
 # Retry policy: network-sensitive steps (checkout, apt install, bazel fetch)
 # are retried to survive transient GitHub/registry outages. Build/test steps
 # are NOT retried -- a real test failure should surface immediately.
+
+# Self-hosted Linux runner gate (repo Settings -> Variables). Setting
+# SELFHOSTED_LINUX_RUNNER to "true" routes the operator's own Linux runs onto
+# the homelab ARM64 runner on event-horizon and skips the matching
+# GitHub-hosted lane; everyone else stays GitHub-hosted. Gated on BOTH
+# github.actor and github.triggering_actor == jwmcglynn so that no collaborator
+# push -- and no rerun of the operator's run by someone else -- can execute on
+# the runner or poison the shared LAN Bazel cache. Unset is a no-op: behavior
+# is identical to the GitHub-hosted-only workflow.
 
 jobs:
   gatekeeper:
@@ -240,9 +253,11 @@ jobs:
           echo "affected=$affected" >> "$GITHUB_OUTPUT"
 
   linux:
+    # GitHub-hosted x86_64 baseline. Suppressed for operator runs when the
+    # self-hosted ARM64 lane is active (see gate comment above).
     runs-on: ubuntu-24.04
     needs: [gatekeeper, determine-targets]
-    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') }}
+    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') && (vars.SELFHOSTED_LINUX_RUNNER != 'true' || github.actor != 'jwmcglynn' || github.triggering_actor != 'jwmcglynn') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -268,6 +283,87 @@ jobs:
           repository-cache: true
           external-cache: true
           cache-save: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build
+        shell: bash
+        run: |
+          set -euo pipefail
+          TARGETS=$(if [[ "${{ needs.determine-targets.outputs.fallback }}" == "true" ]]; then
+            echo "//..."
+          else
+            echo "${{ needs.determine-targets.outputs.affected }}"
+          fi)
+          bazelisk build --config=ci $TARGETS
+
+      - name: Test
+        shell: bash
+        run: |
+          set -euo pipefail
+          TARGETS=$(if [[ "${{ needs.determine-targets.outputs.fallback }}" == "true" ]]; then
+            echo "//..."
+          else
+            echo "${{ needs.determine-targets.outputs.affected }}"
+          fi)
+          bazelisk test --config=ci --test_output=errors \
+            $TARGETS
+
+
+  # Operator's ARM64 Linux runs on the event-horizon self-hosted runner.
+  # Replaces `linux` for operator runs (extra arch coverage + homelab cache).
+  # The NixOS host pre-provisions the toolchain (fontconfig, freetype, mesa,
+  # vulkan, X11, clang-tidy) and writes bazel-cache1 over LAN gRPC, so there
+  # is no apt/setup-bazel step. The runner intentionally has no host GPU
+  # device passthrough; Mesa llvmpipe/lavapipe provide the same software
+  # rendering path used by GitHub-hosted Linux so this lane runs the same test
+  # surface instead of excluding graphics targets.
+  linux-self-hosted:
+    runs-on: [self-hosted, linux, arm64, event-horizon]
+    needs: [gatekeeper, determine-targets]
+    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') && vars.SELFHOSTED_LINUX_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Sync Bazel toolchain
+        # NixOS injects include paths via NIX_CFLAGS_COMPILE, which Bazel does
+        # not track in cc_configure's cache key; a stale local_config_cc then
+        # omits them and the hermetic include scanner rejects /nix/store
+        # headers. Delete both Bzlmod repos and their markers to force fresh
+        # detection. Suffix-anchored patterns avoid clobbering apple_support's
+        # osx_cc_configure. Idempotent; a no-op on a cold cache.
+        run: |
+          find /var/cache/bazel/user-root -maxdepth 5 \
+            \( -name "*+local_config_cc" \
+            -o -name "local_config_cc" \
+            -o -name "*+local_config_cc_toolchains" \
+            -o -name "local_config_cc_toolchains" \
+            -o -name "*+local_config_cc.marker" \
+            -o -name "local_config_cc.marker" \
+            -o -name "*+local_config_cc_toolchains.marker" \
+            -o -name "local_config_cc_toolchains.marker" \) \
+            -exec rm -rf {} + 2>/dev/null || true
+
+      - name: Prepare Bazel LLVM linker
+        # Bazel downloads the upstream LLVM toolchain into the persistent
+        # output_user_root. On NixOS the downloaded ld.lld needs an explicit
+        # RPATH for libxml2/zlib, but we still want to use Donner's Bazel
+        # toolchain rather than replacing the linker with nixpkgs' lld.
+        shell: bash
+        run: |
+          set -euo pipefail
+          TARGETS=$(if [[ "${{ needs.determine-targets.outputs.fallback }}" == "true" ]]; then
+            echo "//..."
+          else
+            echo "${{ needs.determine-targets.outputs.affected }}"
+          fi)
+          bazelisk fetch --config=ci $TARGETS
+          patch-bazel-llvm-tools /var/cache/bazel/user-root
+          # `fetch` starts a Bazel server before we patch the downloaded
+          # linker. Restart it so build/test action inputs are digested from
+          # the patched ELF instead of stale server state.
+          bazelisk shutdown
 
       - name: Build
         shell: bash

--- a/donner/editor/gui/EditorWindow.cc
+++ b/donner/editor/gui/EditorWindow.cc
@@ -441,9 +441,9 @@ EditorWindow::EditorWindow(EditorWindowOptions options) : options_(std::move(opt
   glfwInitHint(GLFW_PLATFORM, GLFW_PLATFORM_EMSCRIPTEN);
 #else
 #if defined(__linux__)
-  // Use GLFW's windowless "null" platform (OSMesa software GL) for offscreen
-  // framebuffer-readback replay on Linux. We also fall back to it automatically
-  // when there is no X11/Wayland display, so headless runs degrade gracefully.
+  // Use GLFW's windowless "null" platform for offscreen Linux replay. We also
+  // fall back to it automatically when there is no X11/Wayland display, so
+  // headless runs degrade gracefully.
   useNullPlatform = options_.offscreen;
   const bool hasDisplay =
       std::getenv("DISPLAY") != nullptr || std::getenv("WAYLAND_DISPLAY") != nullptr;
@@ -472,6 +472,12 @@ EditorWindow::EditorWindow(EditorWindowOptions options) : options_(std::move(opt
   glfwWindowHint(GLFW_VISIBLE, options_.visible ? GLFW_TRUE : GLFW_FALSE);
   glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
 #else
+  if (useNullPlatform) {
+    // GLFW's native context on the null platform is OSMesa. Use EGL instead so
+    // Linux CI exercises Mesa's surfaceless llvmpipe path on both Ubuntu and
+    // NixOS, without requiring a physical GPU or libOSMesa.
+    glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
+  }
   // OpenGL 3.3 core is plenty — matches what imgui_impl_opengl3 targets
   // by default and what glad was generated for.
   glfwWindowHint(GLFW_VISIBLE, options_.visible ? GLFW_TRUE : GLFW_FALSE);

--- a/donner/editor/repro/GlRnrReplay.cc
+++ b/donner/editor/repro/GlRnrReplay.cc
@@ -342,9 +342,9 @@ bool RunGlRnrReplay(const GlRnrReplayOptions& options, GlRnrReplayResult* result
       .initialHeight = initialHeight,
       .visible = options.visible,
       // Capture replays hide their window by default. Linux uses GLFW's null
-      // platform + OSMesa for framebuffer readback; macOS keeps the native
-      // GPU-backed Cocoa context. An interactive (visible) replay keeps the
-      // native windowed platform.
+      // platform with Mesa's EGL/llvmpipe path for framebuffer readback; macOS
+      // keeps the native GPU-backed Cocoa context. An interactive (visible)
+      // replay keeps the native windowed platform.
       .offscreen = !options.visible,
       // Reproduce the recorded HiDPI scale during hidden replay so framebuffer
       // crops line up with captures taken on the recording host.


### PR DESCRIPTION
## Summary
Adds the Linux half of the self-hosted CI runner rollout:
- **`linux-self-hosted`** - ARM64 Linux on `event-horizon`
- **`coverage-self-hosted`** - matching coverage job on the same runner

For operator-owned runs, `linux-self-hosted` replaces the GitHub-hosted `linux` lane when `SELFHOSTED_LINUX_RUNNER == 'true'`. Everyone else stays on the GitHub-hosted `ubuntu-24.04` lane. macOS self-hosting is intentionally deferred to a follow-up so P0 can focus on getting Linux operational first.

The self-hosted Linux lane now runs the same build/test surface as the GitHub-hosted Linux lane. It does **not** filter out Geode/WebGPU, GLFW, X11, or GL targets. The runner image has been fixed instead: the NixOS guest preinstalls the Linux system libraries and pins headless GL/EGL to Mesa llvmpipe plus Vulkan/WebGPU to Mesa lavapipe, with no host GPU passthrough.

Coverage now has a self-hosted counterpart with the same operator gate. The hosted coverage job remains the fallback for everyone else.

## Gate
The self-hosted Linux jobs run only when:
- `vars.SELFHOSTED_LINUX_RUNNER == 'true'`
- `github.actor == 'jwmcglynn'`
- `github.triggering_actor == 'jwmcglynn'`
- the existing duplicate-push/docs-only skips do not apply, for CI

The GitHub-hosted `linux` and hosted coverage jobs carry the De Morgan complement of that self-hosted gate, so exactly one Linux/coverage lane runs for a non-skipped workflow.

| `SELFHOSTED_LINUX_RUNNER` | actor & triggering_actor | Linux job that runs |
|---|---|---|
| unset/false | any | `linux` / hosted coverage |
| `true` | both `jwmcglynn` | `linux-self-hosted` / `coverage-self-hosted` |
| `true` | anyone else | `linux` / hosted coverage |

## Security notes
- Requires both `github.actor` and `github.triggering_actor`, closing the rerun-escalation gap where a collaborator could rerun an operator-authored run onto the self-hosted runner.
- Adds least-privilege `GITHUB_TOKEN` permissions to CI: `contents: read`, `pull-requests: read`.
- Sets `persist-credentials: false` on self-hosted checkouts so build/test code cannot read a persisted checkout token from git config.
- Keeps the runner in an ephemeral NixOS microvm; the long-lived GitHub PAT remains on `gha-host1`, and only a short-lived runner registration token is mounted into the guest.
- Does not pass host GPU devices through to PR code. Graphics tests use Mesa software renderers.
- Leaves macOS on GitHub-hosted CI in this PR to keep the first operational milestone narrow.

## Integration with current `main`
Rebased onto current `main` (`7bde695d`). The self-hosted Linux job depends on `gatekeeper` and `determine-targets`, and inherits the docs-only / duplicate-push skips plus bazel-diff affected-target selection from the GitHub-hosted lane.

## Test plan
- [x] Workflow YAML parses locally.
- [x] `git diff --check` passes for Donner PR changes.
- [x] Local targeted Bazel CI test passes: `//donner/editor/tests:editor_window_tests`.
- [x] Rebuilt `gha-host1` runner config with Java, LLVM coverage tools, Bazel wrapper, X11/GL/Vulkan libraries, and Mesa llvmpipe/lavapipe environment.
- [x] Verified `donner-runner-01` re-registered and is listening/running jobs.
- [ ] Current PR head (`1b08b7c9`): CI, Coverage, Lint, CodeQL, and CMake Build all passed.
- [ ] Same commit re-run by a non-operator: `linux` runs, `linux-self-hosted` skipped.
- [ ] Fork/collaborator PR: GitHub-hosted `linux` runs, `linux-self-hosted` skipped.