### PR TITLE
fix(sandbox): prevent SIGPIPE race in HardenedChildTest

### DIFF
--- a/donner/editor/sandbox/tests/SandboxHardening_tests.cc
+++ b/donner/editor/sandbox/tests/SandboxHardening_tests.cc
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include <fcntl.h>
+#include <signal.h>
 #include <spawn.h>
 #include <sys/resource.h>
 #include <sys/wait.h>
@@ -106,6 +107,16 @@ TEST(SandboxHardeningUnitTest, AppliesResourceLimitsWithSandboxEnv) {
 
 class HardenedChildTest : public ::testing::Test {
 protected:
+  void SetUp() override {
+    // The child can exit before the parent finishes writing stdin (e.g. when
+    // the hardening check rejects an empty envp in the "refuses" tests). Once
+    // the child closes its read end, the parent's ::write() would raise
+    // SIGPIPE and kill the gtest process mid-test, producing a bazel
+    // "Broken pipe" failure with no diagnostics. Ignore SIGPIPE so writes
+    // that race with a just-exited child return EPIPE instead.
+    ::signal(SIGPIPE, SIG_IGN);
+  }
+
   std::string ChildPath() {
     return Runfiles::instance().Rlocation("donner/editor/sandbox/donner_parser_child");
   }
@@ -170,9 +181,20 @@ protected:
     ::close(stderrFds[1]);
     ::close(devNull);
 
-    // Write stdin, close, drain stderr, reap.
+    // Write stdin, close, drain stderr, reap. The child may have already
+    // exited (and closed its stdin read end) by the time we get here — write
+    // failures with EPIPE are expected in that case and intentionally
+    // ignored. SIGPIPE is disabled in SetUp() so the signal does not kill
+    // the test process.
     if (!stdinBytes.empty()) {
-      ::write(stdinFds[1], stdinBytes.data(), stdinBytes.size());
+      const void* data = stdinBytes.data();
+      std::size_t remaining = stdinBytes.size();
+      while (remaining > 0) {
+        const ssize_t n = ::write(stdinFds[1], data, remaining);
+        if (n < 0) break;  // EPIPE, EINTR — child is gone or will be reaped below.
+        remaining -= static_cast<std::size_t>(n);
+        data = static_cast<const char*>(data) + n;
+      }
     }
     ::close(stdinFds[1]);
 


### PR DESCRIPTION
## Root cause

`HardenedChildTest` (in `donner/editor/sandbox/tests/SandboxHardening_tests.cc`) spawns `donner_parser_child` with a piped stdin, writes the SVG payload, then drains stderr and reaps. Two tests — `ChildRefusesWithoutSandboxEnvVar` and `ChildRefusesWhenSandboxEnvIsWrongValue` — intentionally pass an envp that fails the hardening env-var gate, so the child exits immediately before it reads any stdin bytes.

On fast runners the child exits and closes its stdin read end **before** the parent finishes writing. The parent's `::write()` then delivers SIGPIPE to the test process. Default SIGPIPE action is termination, so gtest dies mid-test and bazel reports:

```
FAIL: //donner/editor/sandbox/tests:sandbox_hardening_tests (Broken pipe)
```

The last line of captured gtest output is just the `[ RUN ] HardenedChildTest.ChildRefusesWithoutSandboxEnvVar` banner — no flush, because the process was killed by signal, not returning from `main`.

Failing run: https://github.com/jwmcglynn/donner/actions/runs/24363771263/job/71150029990

Dev1 and slower runners happened to win the race, so the bug was latent until the GitHub Actions Linux runner caught it.

## Fix

🤖 Two strictly-safer changes to `SandboxHardening_tests.cc`:

1. `HardenedChildTest::SetUp()` now calls `::signal(SIGPIPE, SIG_IGN)` so the signal cannot kill the test process.
2. The `::write()` loop in `Spawn()` is now a proper short-write loop that handles `-1` return (EPIPE, EINTR) as a benign early-child-exit. `waitpid()` below still surfaces the real exit code or signal.

Both changes are strict improvements over the original regardless of timing — unguarded `write()` into a pipe whose peer may have closed is unsound.

## Test plan

- [x] Cold-ish local run: `bazel test --config=ci --test_output=errors //donner/editor/sandbox/tests:sandbox_hardening_tests` — **PASSED** (1 out of 1).
- [ ] CI green across linux / macos / linux-geode.