### PR TITLE
ci(coverage): exclude editor GLFW targets from coverage scope

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,7 +40,16 @@ jobs:
 
       - name: Generate coverage
         run: |
-          tools/coverage.sh --quiet --no-html
+          # Exclude //donner/editor/gui/... and //donner/editor:* — they
+          # depend on GLFW + imgui, which need X11/GL headers that the
+          # hermetic LLVM sysroot (used via --config=latest_llvm in
+          # coverage.sh) does not carry. //donner/editor/sandbox/... is
+          # GLFW-free and stays in scope.
+          tools/coverage.sh --quiet --no-html \
+            //donner/base/... \
+            //donner/css/... \
+            //donner/svg/... \
+            //donner/editor/sandbox/...
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6


### PR DESCRIPTION
## Root cause

PR #518 (Editor M2) added targets under \`//donner/editor/\` and \`//donner/editor/gui/\` that depend on \`@glfw\` and \`@imgui\`. These need \`X11/Xlib.h\` and \`GL/gl.h\`.

The coverage job runs under \`--config=latest_llvm\` (hermetic LLVM toolchain). Its sysroot does not carry X11/GL headers, so any transitive GLFW compile fails with:

\`\`\`
fatal error: 'X11/Xlib.h' file not found
fatal error: 'GL/gl.h' file not found
\`\`\`

\`main.yml\`'s \`--config=ci\` uses host clang which finds \`/usr/include/X11/\` from the apt-installed system, which is why main builds pass but coverage does not. This is the first PR coverage run since #518 landed because \`coverage.yml\` only triggers on \`pull_request\` types \`opened\`/\`reopened\`.

Failing run: https://github.com/jwmcglynn/donner/actions/runs/24377209174/job/71193098931

## Fix

🤖 Scope the coverage run to the parts of \`//donner/...\` that are unit-testable and GLFW-free:

\`\`\`
//donner/base/...
//donner/css/...
//donner/svg/...
//donner/editor/sandbox/...
\`\`\`

\`//donner/editor/sandbox/\` is process-isolated from the GUI layer and does not transitively depend on \`glfw\`/\`imgui\`, so it stays in scope. The dropped targets (\`//donner/editor/gui/...\` and the editor top-level package) are integration glue (window management, event dispatch, imgui bootstrap) with minimal unit-test coverage value.

## Test plan

- [ ] Coverage CI green after merge
- [ ] Downstream PRs (#531 composited impl, #532 sandbox test fix) unblock automatically