### PR TITLE
Design: v0.5 retrospective + v1.0 release plan

### DIFF
--- a/docs/design_docs/0011-v0_5_release.md
+++ b/docs/design_docs/0011-v0_5_release.md
@@ -1,19 +1,20 @@
 # Design: v0.5 Release
 
-**Status:** In Progress
-**Updated:** 2026-04-16
+**Status:** Shipped (2026-04-16)
+**Updated:** 2026-04-17
 
 ## Summary
 
-Release checklist and implementation plan for shipping Donner v0.5. This release bundles all work
-since v0.1: renderer abstraction, tiny-skia software backend, text rendering (6 phases), and all 17
-SVG filter primitives with SIMD performance.
+Release checklist and implementation plan for Donner v0.5, tagged `v0.5.0` on 2026-04-16. This
+release bundled all work since v0.1: renderer abstraction, tiny-skia software backend, text
+rendering (6 phases), all 17 SVG filter primitives with SIMD performance, the in-tree editor, WASM
+editor, and `.svgz` support.
 
 Animation (9 phases), composited rendering, and interactivity (6 phases) are scoped out of v0.5 and
 deferred to v1.0.
 
-The release requires fixing test failures, verifying builds across configurations, updating
-documentation, creating examples for new features, running fuzzers, and ensuring CI is green.
+See the [v0.5 Retrospective](#v05-retrospective) below for follow-up work to carry into the next
+release.
 
 ## Goals
 
@@ -39,12 +40,11 @@ documentation, creating examples for new features, running fuzzers, and ensuring
 
 ## Next Steps
 
-Most release-hardening work is complete. Remaining work:
+v0.5.0 was tagged and published on 2026-04-16. Remaining post-release work is tracked in the
+[v0.5 Retrospective](#v05-retrospective) below and carried forward into v1.0.
 
-- **Phase 14: Release** — Final validation, build report, tag, release notes, and release
-  publication.
-- **Deferred:** Full per-entity recomputation beyond the current style-only dirty path, CSS
-  differential restyling, float feImage fragments (Phase 10), SubregionCropRect architecture,
+- **Deferred to v1.0:** Full per-entity recomputation beyond the current style-only dirty path,
+  CSS differential restyling, float feImage fragments (Phase 10), SubregionCropRect architecture,
   `ch` unit glyph measurement, bidirectional text, and all composited-rendering / spatial-index
   work.
 
@@ -346,14 +346,15 @@ the build report lands:
 - [x] **Update release notes with final highlights** — `RELEASE_NOTES.md` was refreshed on
   2026-04-16 during the final docs pass (including the final coverage figures). This commit must
   land **before** the build-report commit.
-- [ ] **Generate build report as the release commit** — After every other release-blocking change
-  is on `main`, regenerate `docs/build_report.md` with Skia/tiny-skia differentiation and commit
-  it as the tagged release commit (nothing else in that commit).
-- [ ] **Create release tag and publish** — Tag `v0.5.0` on the build-report commit and create the
-  GitHub release using the `RELEASE_NOTES.md` entry as the body.
-- [ ] **Verify release artifacts** — Confirm the GitHub release shows the correct tag, release
-  notes, and attached linux/macos binaries from `release.yml`.
-- [ ] **Post-release follow-up** — Update `ProjectRoadmap.md` and announce the release.
+- [x] **Generate build report as the release commit** — `b8bb66bf Release v0.5.0: regenerate build
+  report` regenerated `docs/build_report.md` on a clean tree with Skia/tiny-skia differentiation
+  and was the sole content of the tagged commit.
+- [x] **Create release tag and publish** — `v0.5.0` tagged on the build-report commit; GitHub
+  release published 2026-04-16T20:05:42Z using the `RELEASE_NOTES.md` entry as the body.
+- [x] **Verify release artifacts** — GitHub release shows `v0.5.0` with
+  `donner-svg_darwin_arm64`, `donner-svg_linux_x86_64`, and SLSA attestations attached.
+- [ ] **Post-release follow-up** — Update `ProjectRoadmap.md` to mark v0.5 as shipped and announce
+  the release. Retrospective items captured below.
 
 ---
 
@@ -413,23 +414,23 @@ commit, nothing else.
 - [x] **Generate build report** — Regenerate `docs/build_report.md` against a clean tree with
   Skia/tiny-skia backend differentiation. Commit it on `main` as the dedicated release commit
   (e.g. `Release v0.5.0: regenerate build report`). Nothing else goes in this commit.
-- [ ] **CI green on the build-report commit** — Final release-commit CI verification on the
-  commit that will be tagged.
+- [x] **CI green on the build-report commit** — Release-commit CI went green before tagging.
 
 ### Release
 
-- [ ] **Create release tag** — `git tag -a v0.5.0 -m "Donner SVG v0.5.0"` on the build-report
-  commit.
-- [ ] **Push tag** — `git push origin v0.5.0`.
-- [ ] **Create GitHub Release** — Use `gh release create` with the `RELEASE_NOTES.md` entry as the
-  body.
-- [ ] **Verify release artifacts** — Check the GitHub release page, rendered notes, and attached
-  binaries.
+- [x] **Create release tag** — `v0.5.0` tagged on the build-report commit (`b8bb66bf`).
+- [x] **Push tag** — Tag pushed to `origin`.
+- [x] **Create GitHub Release** — Published via `gh release create`
+  (<https://github.com/jwmcglynn/donner/releases/tag/v0.5.0>), body sourced from `RELEASE_NOTES.md`.
+- [x] **Verify release artifacts** — Release page renders, linux/macos binaries and SLSA
+  attestations are attached.
 
 ### Post-Release
 
 - [ ] **Update ProjectRoadmap.md** — Mark v0.5 as shipped and update the design-doc table.
 - [ ] **Announce** — Post the release to the relevant channels.
+- [ ] **BCR publish** — Publishing to the Bazel Central Registry failed on the v0.5.0 tag. See
+  [Retrospective → Release-process bugs](#release-process-bugs-carry-to-v06).
 
 ---
 
@@ -441,3 +442,64 @@ commit, nothing else.
 - **Build matrix**: Bazel (Linux/macOS) × CMake (Linux/macOS) × {Skia, tiny-skia}.
 - **CI**: All GitHub Actions workflows green on the release commit.
 - **Manual verification**: Animated splash SVG renders in browser and via `svg_to_png`.
+
+---
+
+## v0.5 Retrospective {#v05-retrospective}
+
+Captured on 2026-04-17 after the v0.5.0 release. These are the issues that surfaced during
+the cut that should be fixed before the next release.
+
+### Release-process bugs (carry to v0.6)
+
+1. **BCR publish failed.** Publishing Donner to the Bazel Central Registry on the `v0.5.0` tag
+   did not succeed. Needs debugging against the process captured in
+   [0018-bcr_release.md](0018-bcr_release.md) — identify the failure mode, fix the tooling, and
+   re-run on v0.5.x or v0.6.
+2. **Binary-size report in Doxygen is broken.** The Doxygen-rendered build report (binary-size
+   tables, feature matrix) is not displaying correctly — the treeview appears empty. Root-cause
+   the generation/integration step and ensure the report renders in the hosted Doxygen site
+   before the next tag.
+3. **Design docs pollute the Doxygen sidebar.** All 25+ design docs currently appear as
+   top-level sidebar entries. They should be grouped under a single "Design Docs" section so
+   the developer-facing sidebar stays navigable.
+4. **Doxygen lazy-lists filter/element pages.** The generated site enumerates every filter
+   primitive (and other element categories) as individual sidebar entries. Condense these into
+   a single "All Elements" / "Filter Primitives" index page so the sidebar isn't dominated by
+   element enumeration.
+5. **Too many public Bazel targets.** The public-target surface grew significantly in v0.5 —
+   especially inside `//donner/editor/...` — with many internal helpers visible to external
+   consumers. Audit `visibility` across the tree and tighten to `//donner/...`-private wherever
+   the target isn't a deliberate public API. The editor subtree is the priority; it leaked the
+   most targets.
+
+### vNext features to finish (not shipped in v0.5)
+
+These workstreams were **never part of v0.5's feature surface** — they were in-progress vNext
+work that sat alongside the v0.5 effort, with code landing on `main` but not enabled or
+exposed in the release. They should be the first feature work to finish before new v1.0
+scope is picked up:
+
+1. **Sandboxing** — Scaffolding landed on `main` during v0.5 development (wire-format fuzzer,
+   `sandbox_diff` CLI, hardened-child test fixes), but the broader editor sandbox story from
+   [0023-editor_sandbox.md](0023-editor_sandbox.md) was not enabled for v0.5 users. Finish the
+   remaining milestones.
+2. **Composited rendering** — [0025-composited_rendering.md](0025-composited_rendering.md) is
+   in draft and was not part of v0.5. Prerequisite for fluid editor dragging and the v1.0
+   interactivity story; needs to graduate from draft to shipped.
+3. **Geode renderer on a real GPU** — [0017-geode_renderer.md](0017-geode_renderer.md) has
+   Phase 0–2 complete and the resvg suite green on MSAA, but Geode is not enabled as a
+   user-facing backend in v0.5 and has not been validated on physical GPU hardware (only
+   CI / software adapters). Finish the real-GPU path before moving to new renderer work.
+
+### Next-release features (after the items above)
+
+Once the retrospective bugs and open-feature close-outs are done, the next tranche of feature
+work to pick up:
+
+1. **`<a>` element support** — Treat `<a>` as a grouping element for rendering (Issue S18 in
+   [0024-proposed_issues_2026q2.md](0024-proposed_issues_2026q2.md)). Small scope, 3 resvg
+   tests unblocked.
+2. **`<switch>` element + `systemLanguage`** — Conditional processing per
+   [SVG2 §5.9](https://www.w3.org/TR/SVG2/struct.html#ConditionalProcessing) (Issue S4 in
+   0024). Medium scope, ~15 resvg tests unblocked.

--- a/docs/design_docs/0026-svg_conformance_testing.md
+++ b/docs/design_docs/0026-svg_conformance_testing.md
@@ -1,0 +1,532 @@
+# Design: SVG Conformance Testing
+
+**Status:** Draft
+**Author:** GPT-5 Codex
+**Created:** 2026-04-16
+
+## Summary
+
+Donner already has strong renderer regression coverage: unit tests, fuzzers,
+hand-authored golden tests, and the upstream `resvg-test-suite`. What it does
+not yet have is a broader **spec-oriented conformance program** that combines
+multiple external suites and cleanly separates:
+
+- static rendering cases we can run today,
+- legacy SVG 1.1 cases we intentionally do **not** plan to pass under SVG 2,
+- and future DOM / animation / event / script cases that only make sense once
+  the `origin/scripting` branch lands.
+
+This design adds a manifest-driven conformance layer on top of the existing
+`ImageComparisonTestFixture` infrastructure. Phase 1 starts with the W3C SVG
+1.1 filter corpus because it is easy to wire into Donner's current
+golden-image runner and exercises the exact feature area the user asked about.
+Phase 2 adds curated SVG 2 era tests from web-platform-tests (WPT) that are
+still purely static. Phase 3, on top of the scripting design in
+`origin/scripting`, adds a separate harness for WPT-style scripted, DOM, and
+animation tests.
+
+The core design rule is:
+
+**Treat conformance suites as typed inputs, not as one giant bag of SVG
+files.** Each case records its oracle type (`png`, `svg-ref`, `script-harness`,
+`manual`), spec status (`current SVG 2`, `legacy-but-still-supported`,
+`removed-from-SVG-2`), and runtime requirements (`filters`, `text`, `script`,
+`animation`, `browser-host`). That keeps CI honest and prevents deprecated SVG
+1.1 features from quietly turning into misleading release blockers.
+
+## Goals
+
+- Add an external conformance lane beyond `resvg-test-suite`, starting with the
+  SVG 1.1 filter tests that are runnable with Donner's current renderer-only
+  harness.
+- Reuse Donner's existing golden-image test fixture and Bazel patterns instead
+  of inventing a second unrelated rendering test stack.
+- Model conformance cases explicitly enough that deprecated SVG 1.1 features
+  like `enable-background`, `BackgroundImage`, and `BackgroundAlpha` remain
+  visible but do not count as SVG 2 regressions.
+- Establish a practical answer to "what is the SVG 2 equivalent?":
+  WPT is the living SVG 2 era corpus, but only a subset is static and
+  renderer-only.
+- Define a future scripted-test lane that matches the architecture in
+  [0027-scripting.md](0027-scripting.md) without blocking the
+  immediate static test work on that branch landing first.
+- Produce conformance outputs that are meaningful per backend (`tiny-skia`,
+  `skia`, later `geode`) and per feature tier (`text`, `text-full`, `script`).
+
+## Non-Goals
+
+- Replacing `resvg-test-suite`. It remains Donner's primary upstream
+  cross-engine rendering regression suite.
+- Running the entire WPT repository inside Donner.
+- Claiming support for SVG 1.1 features that SVG 2 removed, such as
+  `enable-background`, just because an old suite contains them.
+- Building a browser engine on `main`. Script, DOM, event, and animation
+  conformance stays out of scope for the immediate work and depends on the
+  separate scripting design.
+- Making browser screenshot comparison a mandatory part of every PR gate.
+- Solving manual-test authoring or WPT upstream contribution workflow in the
+  first milestone.
+
+## Next Steps
+
+- Land a pilot suite for the static SVG 1.1 filter corpus using a new
+  manifest-driven conformance runner that reuses `ImageComparisonTestFixture`.
+- Add a curated WPT SVG snapshot plan for static reftests only; do not vendor
+  the whole WPT repo.
+- Keep the future script/animation lane explicitly gated on the milestones in
+  [0027-scripting.md](0027-scripting.md).
+
+## Implementation Plan
+
+- [ ] **M1** — Manifest format, Bazel overlays, and the SVG 1.1 filter pilot
+- [ ] **M2** — Static SVG 2 / WPT reftest lane
+- [ ] **M3** — CI policy, reporting, and documentation
+- [ ] **M4** — Scripted / DOM / animation conformance on top of `donner::script`
+
+## Background
+
+### Current Donner state
+
+Donner currently validates rendering through four main layers:
+
+- focused unit tests,
+- fuzzers for parser and hostile-input surfaces,
+- hand-authored renderer goldens under `donner/svg/renderer/testdata/`,
+- and the vendored upstream `resvg-test-suite`.
+
+That last suite is already valuable, but it is not the same thing as a spec
+conformance program:
+
+- it is authored around `resvg`'s corpus and naming,
+- it reflects `resvg`'s choices about what to test,
+- it includes intentional skips and golden overrides that are specific to
+  Donner's current implementation history,
+- and it does not cover future DOM / script behavior.
+
+### External suites relevant to Donner
+
+The [SVG 2 testing requirements](https://www.w3.org/Graphics/SVG/WG/wiki/Testing_Requirements)
+document explicitly calls out three test forms that matter here: SVG-vs-SVG
+references, SVG-vs-PNG references, and non-static tests for animation and the
+DOM driven by JavaScript. It also notes that filters and gradients are examples
+where PNG references are appropriate.
+
+WPT's
+[`svg/README.md`](https://github.com/web-platform-tests/wpt/blob/master/svg/README.md)
+says its `import/` directory contains tests imported from the SVG 1.1 Second
+Edition test suite, and that the old suite shipped reference PNGs which are
+especially useful for filters. The same README also explains that current SVG
+tests are organized into reftests and scripted tests under the SVG chapter
+directories.
+
+That gives Donner a clear split:
+
+1. **Immediate static opportunity**:
+   add the SVG 1.1 filter corpus, because it already fits Donner's
+   renderer-only model.
+2. **SVG 2 era static opportunity**:
+   add curated WPT SVG reftests whose reference side is still renderable by
+   Donner.
+3. **Future dynamic opportunity**:
+   add WPT scripted / animation / DOM tests only after Donner's scripting,
+   event, and virtual-time models exist.
+
+### Answer to "is there an equivalent for SVG 2?"
+
+Not as one tidy "34 SVG files + reference PNGs" package.
+
+The SVG 2 era equivalent is the **living WPT SVG corpus**, which mixes:
+
+- imported SVG 1.1 manual tests,
+- static reftests,
+- script-driven DOM tests,
+- animation timing tests,
+- and chapter-specific reference resources.
+
+So the right design is not "vendor one more monolithic suite". The right design
+is "vendor typed subsets with different runners".
+
+## Requirements and Constraints
+
+- **Deterministic and offline after fetch**: once the test repositories are
+  fetched by Bazel, all runs must be local-only. No network access during test
+  execution.
+- **No giant dependency blast radius**: avoid vendoring the entire WPT repo.
+  Prefer a curated snapshot containing only the SVG paths and resources Donner
+  actually consumes.
+- **Works with existing runner infrastructure**: the new static suites should
+  use `ImageComparisonTestFixture` and the same threshold / skip machinery used
+  by `resvg_test_suite`.
+- **Per-case metadata must be explicit**:
+  oracle type, SVG-version status, backend requirements, optional feature
+  requirements, and expected triage state all need to be declared in data, not
+  rediscovered ad hoc from filenames.
+- **SVG 2 positioning must stay honest**:
+  removed SVG 1.1 features remain documented and runnable as informational
+  legacy cases, but they must not silently become "Donner failing SVG 2".
+- **Presubmit cost must be controlled**:
+  the initial PR gate should be small enough to run on every change affecting
+  rendering, while the broader conformance matrix can shard or run in slower
+  lanes.
+- **Backend-aware**:
+  Geode, text tiers, and future script support should be modeled as feature
+  gates, not hard-coded special cases in each test file.
+
+## Proposed Architecture
+
+### High-level structure
+
+```mermaid
+flowchart TD
+    A[External corpora<br/>W3C SVG 1.1<br/>WPT SVG subset] --> B[Sync scripts + Bazel overlays]
+    B --> C[Typed manifest<br/>oracle + spec status + requirements]
+    C --> D1[PNG oracle runner]
+    C --> D2[SVG reftest runner]
+    C --> D3[Future script / DOM runner]
+    D1 --> E[ImageComparisonTestFixture]
+    D2 --> E
+    D3 --> F[Future donner::script host]
+    E --> G[Per-backend conformance report]
+    F --> G
+```
+
+### Data model
+
+Add a generated manifest-backed `ConformanceCase` table. The checked-in source
+of truth is JSON plus codegen to a C++ `.inc`, so the test binary has zero new
+runtime parsing dependencies.
+
+```cpp
+enum class ConformanceOracle {
+  PngReference,
+  SvgReference,
+  ScriptHarness,
+  Manual,
+};
+
+enum class ConformanceSpecStatus {
+  Svg2Current,
+  Svg11LegacySupported,
+  Svg11RemovedFromSvg2,
+};
+
+enum class ConformanceRequirement {
+  Filters,
+  Text,
+  TextFull,
+  Animation,
+  Script,
+  BrowserHost,
+  ExternalResources,
+};
+
+struct ConformanceCase {
+  std::string id;                  // stable ID: suite/category/name
+  std::string suite;               // svg11-w3c, wpt-svg, resvg-adjacent
+  std::string category;            // filters, text, struct, ...
+  std::string inputPath;           // primary SVG or HTML resource
+  ConformanceOracle oracle;
+  std::string referencePath;       // .png or ref.svg when applicable
+  std::vector<std::string> resources;
+  std::vector<ConformanceRequirement> requirements;
+  ConformanceSpecStatus specStatus;
+  ImageComparisonParams params;    // threshold / skip / feature gates
+  std::string note;                // reason string for legacy / skip / TODO
+};
+```
+
+### Why a typed manifest instead of another giant C++ map
+
+`resvg_test_suite.cc` can afford to keep overrides inline because it targets a
+single upstream repository with one runner shape. That does not scale to a
+multi-source conformance program where:
+
+- some cases compare SVG to PNG,
+- some compare SVG to reference SVG,
+- some are future script harness cases,
+- and some are intentionally legacy-only.
+
+The manifest makes the runner generic and pushes suite-specific policy into
+data instead of test-binary code.
+
+### Suite layout
+
+#### 1. `svg11_w3c_png_conformance`
+
+Purpose: immediate pilot for the SVG 1.1 filter corpus.
+
+- Input: SVG from the W3C SVG 1.1 suite (or the matching WPT import snapshot).
+- Oracle: reference PNG.
+- Runner: existing image-comparison fixture.
+- Initial scope: accepted filter cases first.
+- Expected legacy handling:
+  cases depending on `enable-background`, `BackgroundImage`, or
+  `BackgroundAlpha` are present in the manifest with
+  `Svg11RemovedFromSvg2` status and `Params::Skip(...)`.
+
+This lane answers the user's immediate question with the lowest engineering
+risk.
+
+#### 2. `svg2_wpt_static_reftests`
+
+Purpose: curated SVG 2 era coverage without requiring JS.
+
+- Input: selected WPT SVG tests whose reference side is another SVG Donner can
+  render.
+- Oracle: render test input and reference input through the same backend and
+  compare the resulting images.
+- Inclusion criteria:
+  - no JavaScript required,
+  - no HTML-only reference page,
+  - no manual pass criteria,
+  - deterministic under Donner's current virtual-document model.
+
+This becomes the actual SVG 2 era conformance lane for renderer-only behavior.
+
+#### 3. `svg2_wpt_scripted`
+
+Purpose: future DOM / event / animation / script conformance.
+
+- Input: selected WPT scripted tests, plus Donner-authored compatibility tests
+  for gaps where WPT assumes a full browser shell.
+- Oracle: pass/fail result from a scripted harness, optionally plus reference
+  rendering when the test is a script-driven reftest.
+- Dependencies:
+  [0027-scripting.md](0027-scripting.md), especially M1-M7 around
+  context limits, DOM exposure, event dispatch, and corpus testing.
+
+This runner is intentionally separate from the static image-comparison lane.
+
+### Repository and Bazel layout
+
+Add two new test-only external snapshots:
+
+- `@svg11-test-suite`
+- `@wpt-svg`
+
+Both are wired the same way `@resvg-test-suite` is wired today:
+
+- test-only overlay BUILD files in `third_party/`,
+- filegroups for test inputs and resources,
+- fetched only as non-BCR development dependencies.
+
+Do **not** point Bazel at the full WPT repository. Instead, keep a sync script
+under `tools/conformance/` that exports a minimal SVG-only snapshot:
+
+- selected `svg/` test directories,
+- required shared resources,
+- matching metadata files where needed.
+
+This keeps repository fetches and CI output manageable.
+
+### Runner behavior
+
+#### PNG oracle runner
+
+Uses `ImageComparisonTestFixture` directly:
+
+1. Load the input SVG.
+2. Render through the active backend.
+3. Compare against the reference PNG.
+4. Apply existing `ImageComparisonParams` semantics for thresholds, backend
+   gates, and explicit skips.
+
+This is nearly identical to today's `resvg_test_suite`.
+
+#### SVG reference runner
+
+Also uses `ImageComparisonTestFixture`, but renders **both** the test and the
+reference through Donner:
+
+1. Render the candidate file.
+2. Render the reference SVG.
+3. Compare the two outputs with the same pixel matcher.
+
+This matches WPT reftest semantics more closely than freezing browser
+screenshots, while staying deterministic and backend-local.
+
+The runner only accepts cases where the reference side is SVG (or another
+format Donner already renders, such as standalone image references resolved by
+the test loader). HTML reference pages remain out of scope for the static lane.
+
+#### Future scripted runner
+
+The scripted runner does **not** share the static runner's execution model.
+Instead it needs:
+
+- a deterministic document host with `donner::script::Context`,
+- resource serving for WPT-style local assets,
+- a virtual clock for animation and event timing,
+- pass/fail reporting compatible with testharness-style assertions,
+- and optional image comparison for script-driven reftests.
+
+That work belongs on top of the scripting branch, not ahead of it.
+
+## CI and Reporting
+
+### Presubmit policy
+
+Phase 1 should keep PR gating conservative:
+
+- run the SVG 1.1 filter pilot on the default backend in presubmit,
+- run the larger matrix (`tiny-skia`, `skia`, text tiers, later geode) in
+  slower or sharded lanes,
+- only promote new suites into `tools/presubmit.sh` once their failure modes
+  are stable and their skips are intentionally triaged.
+
+### Reporting
+
+Each suite should emit a machine-readable summary:
+
+- total cases,
+- passing cases,
+- skipped legacy cases,
+- skipped known feature gaps,
+- backend-specific failures,
+- and counts split by `ConformanceSpecStatus`.
+
+This keeps "we fail 12 SVG 2 tests" separate from
+"we intentionally skip 7 removed SVG 1.1 features".
+
+The roadmap and release checklist can then reference a concrete conformance
+report rather than an informal test run.
+
+## Security / Privacy
+
+These suites are untrusted inputs and must be treated like fuzz corpus inputs:
+
+- test execution is local-only after fetch,
+- external resource access stays under the existing sandboxed loader rules,
+- the static runners never execute JavaScript,
+- and the future scripted runner inherits the hard limits from the scripting
+  design (`memory`, `wall-clock`, `call depth`, no network, no filesystem).
+
+For the future browser-hosted / script-harness lane, the trust boundary is much
+sharper:
+
+- WPT resources must be served from a local test server only,
+- no live internet dependencies,
+- and Donner's script host must preserve the same "untrusted input never
+  crashes or escapes" invariant the scripting doc requires.
+
+## Testing and Validation
+
+### Immediate validation for M1
+
+- Unit-test the manifest codegen so a malformed case fails at generation time,
+  not halfway through a Bazel test.
+- Add runner self-tests covering:
+  - PNG oracle case loading,
+  - legacy skip classification,
+  - missing resource detection,
+  - and suite/category filtering.
+- Run the SVG 1.1 filter pilot on both `tiny-skia` and `skia`.
+- Verify legacy `enable-background` / `BackgroundImage` /
+  `BackgroundAlpha` cases are present and explicitly skipped with
+  `Svg11RemovedFromSvg2` status.
+
+### Validation for M2
+
+- Add a small curated WPT static subset first, not a large dump.
+- Include at least one test from each runner shape:
+  - pure SVG reftest,
+  - SVG + external resource reftest,
+  - and a case intentionally rejected because it requires HTML or JS.
+- Confirm the runner reports reftest-specific diagnostics cleanly:
+  input path, reference path, backend, pixel diff.
+
+### Validation for M4
+
+On the scripting branch:
+
+- reuse the corpus and release-gate model from
+  [0027-scripting.md](0027-scripting.md),
+- add a minimal WPT-scripted smoke subset first,
+- and only then grow into broader DOM/event/animation conformance.
+
+## Alternatives Considered
+
+### A1: Keep relying on `resvg-test-suite` only
+
+Pros:
+
+- zero new infrastructure,
+- already integrated,
+- already understood by contributors.
+
+Cons:
+
+- no independent external conformance lane,
+- no direct answer for the W3C filter corpus,
+- no structured path toward SVG 2 / WPT / scripted testing.
+
+Rejected because it does not solve the user's request or the roadmap's
+conformance goals.
+
+### A2: Vendor the full WPT repository
+
+Pros:
+
+- simplest story from a provenance perspective,
+- all SVG tests available immediately.
+
+Cons:
+
+- repository and fetch size explosion,
+- most tests irrelevant to Donner,
+- many cases unusable without a full browser environment.
+
+Rejected because the cost is too high for a renderer library.
+
+### A3: Use browser screenshots as the oracle for all SVG 2 tests
+
+Pros:
+
+- no need to interpret WPT reftest metadata locally,
+- easy to explain.
+
+Cons:
+
+- heavier and flakier,
+- makes renderer-only tests depend on a browser stack,
+- hides whether a failure is in Donner or in the screenshot-generation step.
+
+Rejected for the initial phases. Browser-driven or browser-adjacent oracles may
+still be useful later for scripted compatibility work.
+
+## Open Questions
+
+- Should the SVG 1.1 filter pilot use the original W3C archive directly, or a
+  curated WPT import snapshot that preserves the same files plus metadata?
+- Do we want the manifest source of truth to live entirely in JSON, or split
+  into generated "inventory JSON" plus a small hand-authored C++ override table
+  for thresholds and legacy classifications?
+- For WPT static reftests, what is the exact allowlist policy for HTML
+  reference files and CSS-heavy harness files that Donner cannot interpret as a
+  document?
+- When the scripting lane lands, do we want a Donner-native testharness
+  adapter, or a smaller compatibility layer that only supports the WPT SVG
+  subsets we actually plan to run?
+
+## Dependencies
+
+- Existing:
+  `ImageComparisonTestFixture`, `Runfiles`, `ImageComparisonParams`,
+  `@resvg-test-suite` patterns, sandboxed resource loading.
+- New test-only external data snapshots:
+  `@svg11-test-suite`, `@wpt-svg`.
+- Future scripted lane:
+  `donner::script` from [0027-scripting.md](0027-scripting.md).
+
+## Future Work
+
+- [ ] Expand beyond filters into other SVG 1.1 SVG-vs-PNG categories where the
+      references are still meaningful for SVG 2 behavior.
+- [ ] Add curated WPT SVG text, structure, masking, and painting reftests as
+      static coverage.
+- [ ] Add animation reftests driven by Donner's virtual clock once the
+      animation system lands.
+- [ ] Add WPT-style DOM and event tests once `donner::script` exposes the
+      required interfaces and event dispatch semantics.
+- [ ] Publish a backend-by-backend conformance dashboard and reference it from
+      `docs/ProjectRoadmap.md` and release criteria.

--- a/docs/design_docs/0027-scripting.md
+++ b/docs/design_docs/0027-scripting.md
@@ -1,0 +1,684 @@
+# Design: Donner Scripting (`donner::script`)
+
+**Status:** Draft
+**Author:** Claude Opus 4.6
+**Created:** 2026-04-12
+
+## Summary
+
+SVG2 defines inline `<script>`, DOM scripting, and event handlers. Every
+parallel SVG engine (resvg, librsvg, batik when used as a renderer) punts on
+these, creating the largest functional gap between Donner and a real browser
+for SVG. Adding scripting *well* is the single most differentiating feature
+Donner can ship — and Donner is uniquely positioned to do it, because the DOM
+in Donner is already an ECS.
+
+This doc proposes `donner::script`: an embedded QuickJS-NG runtime, a
+compile-time IDL codegen pipeline (built on C++26 static reflection) that
+projects the ECS as the DOM, and a hard sandbox that extends Donner's
+"never crash on untrusted input" invariant across the scripting boundary.
+
+The design invariant is that **the DOM is a projection of the ECS, not a
+parallel object graph**. Script handles are entity references with type
+information; `NodeList` liveness comes from entt views, not from
+hand-maintained mirrors; `element.style.foo` and CSS `--foo` share one storage
+representation; events dispatch along entt parent links.
+
+## Goals
+
+- Donner executes inline `<script>`, `on<Event>=` attribute handlers, and
+  SMIL-triggered scripts in a deterministic, sandboxed context — suitable for
+  rendering untrusted SVGs from the web with the same safety posture as the
+  parser.
+- A curated subset of DOM Core + SVG IDL, chosen to cover real-world SVG
+  interaction scripts (see §Non-Goals for what is explicitly out), is
+  reachable from JS.
+- Per-document CPU and memory budgets are **hard caps** enforced by the
+  runtime. Exceeding either surfaces a `ParseDiagnostic` and terminates the
+  script cleanly — no crash, no leak, no progress.
+- Every IDL-exposed interface ships with a fuzz target emitted by the same
+  codegen that emits the binding — new API surface and new coverage land
+  together.
+- ECS components become scriptable via one `donner::script::expose<C>()`
+  call. There is no hand-written marshalling layer.
+- CSS custom properties, SMIL attribute animations, and script property
+  writes share one backing representation so the style cascade resolves them
+  uniformly.
+- Integration with existing Donner systems:
+  - `StyleSystem` sees script mutations through the same invalidation path as
+    CSS changes (`incremental_invalidation.md`).
+  - `donner::css::PropertyRegistry` is the single source of truth for property
+    definitions; IDL codegen reads it.
+  - Parser errors, style errors, and script errors all flow through
+    `ParseDiagnostic`.
+  - The existing fuzzer harness pattern (`//donner/.../*_fuzzer`) extends to
+    the new binding surface.
+
+## Non-Goals
+
+- **No HTML**. Donner is an SVG engine. There is no HTML parser, no
+  `innerHTML` / `outerHTML`, no `contentEditable`, no `document.write`.
+- **No network or filesystem I/O**: `fetch`, `XMLHttpRequest`, `WebSocket`,
+  `FileReader`, `localStorage`, IndexedDB, `import()` of remote modules —
+  none of it. Script runs in a hermetic context.
+- **No Shadow DOM, Selection, Range**, or the CSSOM beyond `element.style` +
+  `getComputedStyle`.
+- **No `MutationObserver`/`MutationRecord`** in v1. The invalidation graph is
+  a C++-side concept; exposing it as a script-visible change feed is a
+  separate design.
+- **No JIT**. QuickJS-NG is interpreter-only, by choice — it removes a major
+  class of sandbox escapes and keeps binary size predictable.
+- **No long-running workers, no `SharedArrayBuffer`, no `Atomics`.** There is
+  exactly one JS context per document; it lives as long as the document.
+- **No cross-document scripting.** A script cannot reach outside its own
+  `Context`.
+- **No layout-box API** (`getBoundingClientRect`, `offsetWidth`, …). These
+  require a layout engine Donner does not have. `SVGGraphicsElement.getBBox()`
+  is in scope because it maps to Donner's existing bounding-box computations.
+- **No `requestAnimationFrame` tied to a real clock**. `rAF` callbacks fire
+  against Donner's SMIL/animation clock, which is explicitly virtual and
+  under host control. Deterministic rendering is a hard requirement for
+  golden-image tests and fuzzing.
+
+## Next Steps
+
+- Socialize this doc with DesignReviewBot, then freeze the goals + non-goals
+  before any C++ lands.
+- Spike **M1** (QuickJS-NG + sandbox + diagnostics + fuzz harness) in a
+  throwaway branch to validate the cost model before committing to the IDL
+  codegen work.
+- Draft the `.donner_idl` grammar end-to-end by piping one interface
+  (`SVGRectElement`) from IDL → C++ bindings → QuickJS object → fuzz target,
+  so the pipeline is proven on a single vertical slice before expanding.
+
+## Implementation Plan
+
+### High-level milestones
+
+- [ ] **M1** — Runtime spike: QuickJS-NG integration, sandbox, diagnostics,
+      fuzz harness.
+- [ ] **M2** — `.donner_idl` compiler and the first generated interface.
+- [ ] **M3** — `Node`, `Element`, `Document`, `getElementById`, `querySelector*`.
+- [ ] **M4** — Style object and CSS custom property unification.
+- [ ] **M5** — Event dispatch (capture/bubble, pointer + load + SMIL events).
+- [ ] **M6** — SVG geometry IDL types (`SVGLength`, `SVGPoint`, `SVGMatrix`,
+      `SVGNumber`, `SVGRect`).
+- [ ] **M7** — Real-world corpus + release gate.
+
+### M1 — Runtime spike (current focus)
+
+- [ ] Add `quickjs-ng` as a `non_bcr_deps` dependency alongside harfbuzz and
+      imgui. Pin to a specific release; keep a vendored `licenses/` entry.
+- [ ] Extend `build_defs/licenses.bzl` with a `quickjs-ng` overlay
+      (`MIT`, upstream URL, short name `quickjs`).
+- [ ] Extend `generate_build_report.py`'s `_DEPENDENCY_VARIANTS` to include a
+      variant that pulls scripting in, so binary-size tracking covers it from
+      day one.
+- [ ] New target `//donner/script:script` (enabled by a `--config=script`
+      config flag, `donner_script` feature gate).
+- [ ] `class donner::script::Context` — RAII wrapper over `JSContext*`, owns
+      exactly one document's JS state. Non-copyable, move-only.
+- [ ] `struct donner::script::ContextLimits` — hard caps:
+  - `memory_bytes` (default 16 MiB),
+  - `interrupt_tick_ms` (default 5 ms cooperative check),
+  - `wall_time_budget_ms` (default 2000 ms per top-level invocation),
+  - `call_depth_max` (default 256).
+- [ ] Wire `JS_SetMemoryLimit`, `JS_SetMaxStackSize`, and
+      `JS_SetInterruptHandler` in the `Context` constructor. The interrupt
+      handler reads an atomic clock set by a host-side deadline.
+- [ ] Route all `JSException` bubbling out of `Eval` into a
+      `ParseDiagnostic` (same struct the parser already uses). JS errors
+      thus appear in the existing diagnostic stream and fuzz triage tooling.
+- [ ] Module loader: intercepted and denied by default. A later milestone can
+      add a `ModuleResolver` callback for in-tree resources (e.g. resolving
+      `import 'donner:svg-constants'` to a pre-registered module), but no
+      filesystem lookup, ever.
+- [ ] Baseline bring-up tests:
+  - Eval `1 + 1` → 2.
+  - Eval `new Uint8Array(2_000_000_000)` → OOM, surfaced as diagnostic,
+    context remains usable for subsequent evals.
+  - Eval `while(true) {}` → wall-clock budget fires, diagnostic raised,
+    context torn down cleanly.
+  - Eval `throw new Error('boom')` → diagnostic carries the JS stack.
+- [ ] Fuzzer: `//donner/script:script_context_fuzzer` — libfuzzer-style entry
+      that feeds the input as JS source into an `Eval` under default limits.
+      Must not crash, leak, or exceed budgets. Added to the existing presubmit
+      fuzz panel.
+- [ ] Doc: `docs/building.md` gets a one-line note on `--config=script`.
+
+### M2 — `.donner_idl` compiler and first interface
+
+- [ ] Write the `.donner_idl` grammar. It is a **trimmed subset of WebIDL**,
+      not a reimplementation. Supported: `interface`, `attribute`,
+      `readonly attribute`, `getter`/`setter`, `const`, enumerated string
+      types, nullable types, sequence types. Unsupported: `partial interface`,
+      `mixin`, union types, typedefs across interfaces, async return types.
+- [ ] Grammar lives in `donner/script/idl/grammar.md` and has a bespoke
+      parser in `donner/script/idl/Parser.{h,cc}`. Parser is itself fuzzed
+      alongside other Donner parsers.
+- [ ] Each `interface` compiles to a C++26 reflected record whose members are
+      declared with attributes like
+      `[[= donner::script::idl::getter(&SVGRectElement::x)]]`. Reflection
+      walks these at compile time to emit a `static constexpr` binding table
+      consumed by the runtime at context creation.
+- [ ] Binding table entry shape:
+      `{ name, tag, getter, setter, arity, fuzz_hook }`. The `fuzz_hook` is
+      a stable ID used by the auto-emitted fuzz target to enumerate reachable
+      properties from any given entity.
+- [ ] First IDL file: `donner/script/idl/SVGRectElement.donner_idl`. End-to-end
+      test: an eval of
+      `document.getElementById('r').x.baseVal.value = 42`
+      moves the entity's rect x-coordinate, and the invalidation path triggers
+      a re-render.
+- [ ] Codegen emits **two** artifacts per IDL file:
+      `SVGRectElement_bindings.inc` (the static binding table) and
+      `SVGRectElement_fuzz.inc` (a libfuzzer harness covering every
+      getter/setter at least once per run). Both are `genrule`'d in Bazel
+      and visible in the generated-sources dir for audit.
+- [ ] **Invariant:** adding an IDL file is the *only* way to expose an
+      interface. Hand-written `JS_NewCFunction` binding calls are banned in
+      presubmit via `check_banned_patterns.py`.
+
+### M3 — Core DOM: `Node`, `Element`, `Document`, selectors
+
+- [ ] IDL for `Node`, `Element`, `Document`, `Attr`.
+- [ ] `getElementById(id)` — O(1) via a new `IdIndexComponent` component
+      stored on the document entity (built lazily, invalidated by `id`
+      attribute writes).
+- [ ] `querySelectorAll(selector)`:
+  - Parse once through `donner::css::parser::SelectorParser`.
+  - Materialize a `view<Matches<SelectorRule>>` entt view.
+  - Wrap the view in a JS Proxy that presents `NodeList` semantics
+    (`length`, indexed access, `item(i)`, iteration).
+  - Snapshot semantics: `querySelectorAll` returns a **static** NodeList; the
+    underlying view is consumed once into a `std::vector<Entity>` held by the
+    JS object. Live semantics are reserved for `getElementsByTagName` and
+    friends.
+- [ ] `getElementsByTagName(tag)` / `getElementsByClassName(cls)`:
+  - Backed by a permanently-live entt view keyed on tag component and class
+    component respectively.
+  - The JS Proxy queries the view on each indexed access, so the NodeList is
+    "live" in the DOM sense for free, with no additional bookkeeping.
+- [ ] `setAttribute(name, value)` / `getAttribute(name)` / `removeAttribute`:
+      write through `AttributeParser` → the element's presentation-attribute
+      component → style invalidation. This is the same code path the SVG
+      parser takes for inline attributes; reuse is mandatory.
+- [ ] `classList` — backed by a `ClassListComponent`; `add`/`remove`/`toggle`
+      are one-line entt mutations.
+- [ ] Tree mutation: `appendChild`, `insertBefore`, `removeChild`. These
+      touch the parent-link components. **This is the riskiest surface in
+      M3**; exhaustive randomized-tree tests and a mutation fuzzer are
+      required before sign-off.
+- [ ] **Invariant**: every tree mutation must go through one seam
+      (`donner::svg::components::TreeMutation`) so the editor, the parser,
+      and the script layer all feed into the same invalidation pipe.
+
+### M4 — Style object + CSS custom-property unification
+
+- [ ] `CSSStyleDeclaration` IDL as implemented by `element.style`. Only a
+      subset of properties is exposed — those that the `PropertyRegistry`
+      already knows about. Unknown names are silently stored as custom
+      properties (`--foo`).
+- [ ] `element.style.fill = 'red'` writes an `InlineStyleComponent` override
+      with author-level specificity. `getComputedStyle` reads
+      `ComputedStyleComponent` after the style system has resolved the
+      cascade. Both target the same storage, different mangling of the key.
+- [ ] **CSS customs unification**: `--foo` in CSS and `element.style['--foo']`
+      from JS land in the same `CustomPropertyStore` entt component. SMIL
+      `animate` targeting `--foo` also routes here. This means one update
+      path for three data sources.
+- [ ] `getComputedStyle(el).getPropertyValue(prop)` becomes a direct component
+      read; no recomputation is triggered by script reads (the style system
+      runs on the next tick / render call, same as a CSS mutation).
+- [ ] Golden tests: for each property in the registry, write a test that
+      verifies a script write behaves identically to a CSS rule write with
+      the same specificity. The test harness iterates `PropertyRegistry`
+      automatically, so new properties inherit coverage.
+
+### M5 — Event dispatch
+
+- [ ] `Event`, `EventTarget`, `EventListenerOptions` IDL.
+- [ ] `EventListenerComponent` stored per-element, keyed on `(eventType, phase)`.
+      Contains a `JSValue` (the handler), the `once` flag, the `passive`
+      flag, and a weak pointer back to the `Context` so a destroyed context
+      cleanly disarms its listeners.
+- [ ] Dispatcher walks the entt parent chain twice:
+      first capture (root → target), then bubble (target → root). This is a
+      single `TraverseUp()` utility pulled from the existing
+      `donner::svg::components` traversal helpers.
+- [ ] Events in scope for v1: `click`, `pointerdown`, `pointerup`,
+      `pointermove`, `load` (fired after parse), plus SMIL-driven `beginEvent`
+      / `endEvent` / `repeatEvent`. That list matches the 80/20 of
+      interaction-script usage.
+- [ ] Microtasks: QuickJS's job queue is drained after each top-level
+      dispatch. The interrupt handler guards both top-level eval and the
+      microtask drain loop — **a runaway `queueMicrotask` is indistinguishable
+      from a runaway `while(true)` and trips the same budget.**
+- [ ] `addEventListener` with `{ once: true }` removes the listener
+      automatically after firing (this is trivially an entt lifecycle hook).
+- [ ] **Design question:** what happens when a handler mutates the tree
+      mid-dispatch? See §Open Questions.
+
+### M6 — SVG geometry IDL types
+
+- [ ] `SVGLength`, `SVGLengthList`, `SVGPoint`, `SVGPointList`, `SVGMatrix`,
+      `SVGNumber`, `SVGRect`, `SVGAnimatedLength` (as a pass-through wrapper).
+- [ ] These are mostly "structured value holders" — no liveness issues. Each
+      maps to a small `struct` already present in `donner::svg::parser`.
+- [ ] The `baseVal` / `animVal` split is implemented. `baseVal` writes to the
+      base storage; `animVal` reads from the animated storage when SMIL is
+      driving the property. This replaces the "plain number" shortcut
+      everyone else cuts.
+
+### M7 — Corpus + release gate
+
+- [ ] Assemble a corpus of real-world SVGs with script:
+      demos, interactive infographics, and hand-authored test files. Target:
+      at least 25 unique SVGs covering click-to-reveal, pointer-drag,
+      SMIL-driven animation, and custom-property toggles.
+- [ ] For each corpus entry, verify:
+  - Parse succeeds.
+  - Script runs under default limits without raising a diagnostic.
+  - Golden render matches an expected PNG (pixel-diff against the Skia
+    backend as the reference).
+- [ ] Fuzzer corpus: add each script blob as a seed to the script fuzzer.
+- [ ] Release gate: `docs/release_checklist.md` gains a line
+      "Script corpus renders byte-identically on `--config=script`,
+      and the fuzzer has run ≥ 30 minutes without crashes" before the v0.6
+      cut.
+
+## Background and prior art
+
+Existing SVG engines that chose not to implement scripting:
+- **resvg** — explicit non-goal; focused on pure rendering.
+- **librsvg** — historically supported very limited scripting via libgjs,
+  removed as security risk.
+- **Inkscape** — has a separate scripting engine tied to its editor, not its
+  renderer.
+- **Batik** — uses Rhino; not suitable as a library because Rhino's footprint
+  is larger than all of Donner.
+
+Engines that do implement SVG scripting live inside full browsers (Blink,
+WebKit, Gecko) and pay the cost in binary size and attack surface. The
+opportunity here is to **ship a credible subset in a small package**, not to
+ship a browser.
+
+The ECS/DOM duality is the specific differentiator that makes this project
+finite instead of infinite. Every other engine that tried had to write
+thousands of binding functions by hand; Donner writes one reflection macro
+and lets the IDL compiler do the rest.
+
+## Proposed architecture
+
+### Component diagram
+
+```mermaid
+flowchart TD
+    subgraph Host[Host C++ / Donner]
+        Parser[donner::xml / svg::parser]
+        ECS[entt registry]
+        Style[StyleSystem]
+        Render[Renderers tiny-skia / Skia / Geode]
+        Events[Event system]
+    end
+
+    subgraph Script[donner::script]
+        Context[Context<br/>QuickJS-NG]
+        Sandbox[ContextLimits<br/>memory + interrupt + wall-time]
+        Bindings[Static binding table<br/>generated from .donner_idl]
+        Fuzz[Auto-generated fuzz harness]
+    end
+
+    IDL[.donner_idl files] -->|C++26 reflection codegen| Bindings
+    IDL -->|same codegen| Fuzz
+
+    Parser -->|inline &lt;script&gt;| Context
+    Events -->|addEventListener callbacks| Context
+    Context --> Sandbox
+    Context <-->|bind| Bindings
+    Bindings <-->|entity handles + property lenses| ECS
+    ECS --> Style --> Render
+    Bindings -.->|diagnostics| ParseDiag[ParseDiagnostic stream]
+    Sandbox -.->|budget violations| ParseDiag
+```
+
+### Data flow: a script write to `element.style.fill`
+
+1. JS: `rect.style.fill = 'red'`.
+2. QuickJS resolves `rect` to an opaque entity handle (a `u32` entity ID +
+   type discriminant).
+3. The `.style` proxy intercepts the `fill` set, consults the binding table
+   for the `CSSStyleDeclaration` interface's `fill` setter.
+4. The setter parses `'red'` through `donner::css::parser::ColorParser`
+   (exactly the code path the CSS parser uses), producing a
+   `donner::css::Color`.
+5. The entt component `InlineStyleComponent` on the target entity is written
+   with the new value, author-level specificity.
+6. The write dirties the style graph via `incremental_invalidation`.
+7. On the next render tick, `StyleSystem` re-resolves the cascade; the
+   renderer sees the new fill.
+
+At no point does the script runtime allocate outside the QuickJS arena, and
+at no point does control leave the sandbox. The parsing of `'red'` reuses
+battle-tested CSS code with its own fuzzer coverage.
+
+### Data flow: a `click` event
+
+1. Host delivers a pointer-down → pointer-up pair to `EventSystem`.
+2. Hit-testing walks the rendered scene, resolves a target entity.
+3. `EventSystem::dispatch(target, "click", …)` walks the entt parent chain:
+   - **Capture phase** (root → target), firing each `EventListenerComponent`
+     with `phase == capture`.
+   - **At-target** and **bubble phase** (target → root), firing listeners
+     with `phase == target / bubble`.
+4. For each listener, the `Context` is entered (pushing the deadline clock),
+   the `JSValue` handler is invoked with an `Event` object (itself a binding
+   over an entt-backed `EventRecord` component), and the `Context` is exited
+   on return.
+5. Microtasks drain; the interrupt handler guards the drain.
+6. Any thrown JS exception is captured as a `ParseDiagnostic` and dispatch
+   continues for remaining listeners (matches browser behaviour).
+
+## API / interfaces (sketch)
+
+```cpp
+namespace donner::script {
+
+struct ContextLimits {
+  size_t memory_bytes = 16 * 1024 * 1024;
+  std::chrono::milliseconds interrupt_tick{5};
+  std::chrono::milliseconds wall_time_budget{2000};
+  size_t call_depth_max = 256;
+};
+
+class Context {
+ public:
+  explicit Context(entt::registry& registry, ContextLimits limits = {});
+  ~Context();
+
+  // Non-copyable, move-only.
+  Context(const Context&) = delete;
+  Context(Context&&) noexcept;
+
+  // Evaluate a top-level script. Diagnostics on failure are appended to
+  // `diagnostics`. Never throws; never leaks context state.
+  bool Eval(std::string_view source,
+            std::string_view origin,
+            std::vector<ParseDiagnostic>& diagnostics);
+
+  // Expose an ECS component type through the script. Registers getters /
+  // setters via C++26 reflection over the component's public members.
+  template <typename Component>
+  void Expose(std::string_view interface_name);
+
+  // Dispatch an event along the target entity's parent chain.
+  void DispatchEvent(entt::entity target, const EventRecord& event);
+};
+
+}  // namespace donner::script
+```
+
+`Expose<Component>()` is one of ~20 call sites total, registered once per
+Donner component type in a central `RegisterBuiltinBindings()` function.
+**This function is the ONLY place hand-written binding registrations may
+appear** — everything else comes from `.donner_idl` files.
+
+## Data and state
+
+- **Lifetime**: A `Context` is owned by the `SVGDocument`. On document
+  teardown, QuickJS GC runs, the arena is freed, and the `entt::registry`
+  remains untouched — the script cannot outlive its document.
+- **Threading**: Donner is currently single-threaded per document. QuickJS is
+  not thread-safe, matching this model. Multi-document rendering runs one
+  context per document, never sharing state.
+- **Entity handles**: exposed to JS as opaque numeric IDs (entity generation
+  + index packed into an `f64` using `(generation << 32) | index`). The
+  binding layer re-unpacks and validates on every access; accessing a stale
+  handle throws a JS `TypeError`, not a C++ crash.
+
+## Error handling
+
+- Parser errors, style errors, and script errors all route through
+  `ParseDiagnostic` with a `source` discriminator (`parser`, `css`, `script`).
+- JS stack traces are captured via `JS_GetException` and attached to the
+  diagnostic's `context` field. The existing fuzz-triage tooling already
+  groups by diagnostic class, so script crashes surface in the same
+  dashboard as parser crashes.
+- **Budget violations** (memory, wall time, call depth) produce a
+  dedicated diagnostic class `ScriptBudgetExceeded` with the tripped budget
+  named in the diagnostic. Users can tune limits per document via
+  `ContextLimits`.
+
+## Performance
+
+- **Target**: A QuickJS context cold-start should add ≤ 1 ms per document
+  on the reference Linux runner. Measured under `PerfBot`'s existing
+  document-load benchmark, as part of M1 sign-off.
+- **Script eval**: JS is interpreted, so hot-loop performance is ~100× slower
+  than native. Real SVG scripts are not hot loops (one-off interaction
+  handlers, small animation tick functions), so this is accepted.
+- **Binding dispatch**: Because the binding table is `static constexpr`,
+  every getter/setter is a direct function pointer call with zero hashmap
+  lookup. QuickJS's property lookup is itself a hashmap but it's the
+  runtime's, not ours.
+- **ECS views for `getElementsByTagName`**: entt views are
+  compile-time-specialised and iterate in densely-packed storage. A "live
+  NodeList" access is a pointer-index step, not a tree walk.
+- **Allocation discipline**: No binding path may allocate a C++ heap object
+  per call. All transient state lives in the QuickJS arena or in the
+  existing per-document arena. `PerfBot` enforces this via allocation
+  counters in M7's release gate.
+
+## Security / privacy
+
+Donner's most important invariant is "untrusted input never crashes or
+escapes". The script layer is, by an enormous margin, the widest new attack
+surface Donner has taken on. Security is therefore **not a milestone** —
+it's a floor every milestone has to meet before merging.
+
+### Trust boundaries
+
+```mermaid
+flowchart LR
+    Untrusted[SVG + inline &lt;script&gt;<br/>untrusted] -->|parse + limits| SVGParser[donner::svg::parser]
+    SVGParser -->|script source string| Context[donner::script::Context<br/>sandboxed]
+    Context -->|via binding table| ECS[entt registry<br/>trusted, local-only]
+    Context -.->|cannot touch| FS[filesystem]
+    Context -.->|cannot touch| Net[network]
+    Context -.->|cannot reach| OtherDoc[other Context]
+    Context -->|diagnostics| ParseDiag[ParseDiagnostic]
+```
+
+Everything left of the `Context` box is untrusted. Everything right of the
+binding table is trusted, in-process state. **There is no trust boundary
+inside the binding table** — it is compile-time generated from audited IDL,
+with auto-generated fuzz coverage, and any hand-written C++ binding
+function is a presubmit failure.
+
+### Defensive measures
+
+- **Memory cap** via `JS_SetMemoryLimit`. Default 16 MiB; exceeding it causes
+  `Eval` to fail and the context to be safely torn down.
+- **Wall-clock budget** via `JS_SetInterruptHandler` reading a host-side
+  deadline. Default 2 s per top-level invocation. Applies to event handlers,
+  microtask drain, and module loading equally.
+- **Stack depth** via `JS_SetMaxStackSize`. Default 256 frames.
+- **No I/O surface**. No `fetch`, `XHR`, `WebSocket`, `localStorage`,
+  `FileReader`, `import()` of remote modules. `Context` intentionally does
+  not register these globals.
+- **Module loader denies by default**. A future callback may allow
+  pre-registered in-tree modules (e.g. `import 'donner:svg-constants'`), but
+  there is no filesystem resolution, ever.
+- **Entity handle validation** on every binding call. Stale handles raise
+  JS `TypeError`; they never dereference a freed entity.
+- **Tree mutation single seam**. `appendChild` / `removeChild` share the
+  editor's `TreeMutation` path, which is already fuzzed in `//donner/editor`.
+- **Fuzz harness per IDL**. Codegen emits a libfuzzer target alongside the
+  binding table; every getter/setter is touched on every run. Added to
+  presubmit fuzz panel.
+- **Randomised-tree stress**. M3 ships with a stress test that performs
+  millions of random mutation sequences against the tree and verifies no
+  invariant in the `donner::svg::components` world breaks.
+- **Continuous fuzzing**. The existing `continuous_fuzzing.md` infra picks up
+  the script corpus at zero additional cost.
+
+### Invariants to preserve
+
+- No path from `Context::Eval` to a C++ `abort()`, `std::terminate`, or
+  segfault under *any* input. Enforced by the fuzzer at presubmit.
+- No path from `Context::Eval` to host memory outside the QuickJS arena and
+  the per-document `entt::registry`. Enforced by ASan in nightly.
+- No path from one document's `Context` to another document's state.
+  Enforced by a cross-context access test in M1 bring-up.
+- No allocation of a C++-heap object per binding call, outside transient
+  `std::string` / `RcString` copies that go back to the arena by the end of
+  the call. Enforced by a `PerfBot` allocation-count assertion in M7.
+- Every IDL `interface` has a paired fuzz target. Enforced by a presubmit
+  grep: every `.donner_idl` file must have a corresponding `_fuzz.inc` in
+  its `genrule` outputs.
+
+## Testing and validation
+
+- **Unit tests** per IDL: getter returns expected value, setter writes
+  through to the entt component, validation errors raise JS exceptions not
+  C++ crashes.
+- **Golden tests** for each corpus SVG: parse → run script → render →
+  pixel-diff against reference. New corpus entries gate on pixel-diff parity
+  across `tiny-skia`, `skia`, and `geode` backends. The cross-backend
+  pixel-diff story already exists; scripting inherits it.
+- **Randomised tree mutation stress**: generate a random sequence of
+  appendChild/insertBefore/removeChild/setAttribute calls and assert tree
+  invariants after each step. Runs in the `bazel test //donner/script/...`
+  set as a parameterised test with 10 000 iterations at presubmit, 10 M
+  iterations nightly.
+- **Fuzzing**:
+  - Auto-generated IDL fuzz targets (one per interface).
+  - Free-form script eval fuzzer (`script_context_fuzzer`).
+  - Existing SVG fuzzer is extended to include scripts in the input corpus.
+  - All three plug into `continuous_fuzzing.md` infrastructure.
+- **Budget enforcement tests**: verify that each of the three budgets
+  (memory, wall time, call depth) produces the right diagnostic class and
+  that the context is usable afterwards.
+- **Regression test for cross-doc isolation**: two contexts, mutate state in
+  one, verify zero visibility from the other.
+
+## Dependencies
+
+- **QuickJS-NG** — `non_bcr_deps`, MIT. ~1 MB compiled, ES2023, no JIT, no
+  JavaScriptCore-style sandbox escapes. Upstream is actively maintained
+  (the primary Bellard QuickJS is less active). Only dependency new to
+  Donner.
+- **entt** — already in-tree.
+- **C++26 reflection** — compiler-gated. The IDL codegen requires it;
+  targets that need scripting are fenced behind a `--config=script` +
+  compiler-version check. Early builds may ship the IDL compiler as a
+  host-side tool that produces `.inc` files, which don't themselves require
+  C++26 at consumer sites.
+- `donner::css` (existing) for property parsing.
+- `donner::svg::parser::AttributeParser` (existing) for `setAttribute`
+  write-through.
+
+## Rollout plan
+
+- `--config=script` is **off by default** through M5.
+- M5 flips it on by default on Linux x86_64.
+- M7 extends the on-default list to macOS arm64.
+- BCR consumers are unaffected: QuickJS-NG is a `dev_dependency = True`
+  entry, not pulled by default.
+- A CMake-side opt-in flag (`DONNER_ENABLE_SCRIPT`) mirrors the Bazel config
+  for CMake consumers, gated on the same compiler-version check.
+- The editor (`//donner/editor`) explicitly does **not** execute scripts in
+  its canvas — author-time DOM mutation only. Scripts run in a preview pane
+  with the same `ContextLimits` as the embedder, to keep the editor safe
+  against its own content.
+
+## Alternatives considered
+
+### Duktape
+- **Pro**: ~250 KB, very small.
+- **Con**: ES5-only, slower, weaker exception story, and less active
+  upstream. The ES2023 feature set in QuickJS-NG matters because real-world
+  scripts use `let` / `const` / arrow functions / destructuring / async
+  handlers as a matter of course.
+- **Verdict**: rejected; the binary-size delta is not worth the JS-feature
+  delta.
+
+### JerryScript
+- **Pro**: IoT-targeted, very small, ES5.
+- **Con**: awkward C API for binding against a C++ ECS, and no clear story
+  for exception-based budget enforcement.
+- **Verdict**: rejected.
+
+### V8 or SpiderMonkey
+- **Pro**: brings a complete, well-fuzzed engine.
+- **Con**: binary size is an order of magnitude over Donner's entire current
+  binary. Build complexity is enormous. Both are JIT-first and "JITless
+  mode" is not a security guarantee. Sandbox escapes have been a regular
+  feature of both over the last decade.
+- **Verdict**: rejected on binary size alone.
+
+### WebAssembly instead of JS
+- **Pro**: sandboxing is simpler, GC integration via Wasm-GC may become
+  viable.
+- **Con**: authors do not write SVG scripts in Wasm. The compatibility
+  target is inline `<script>` with ECMAScript syntax. Wasm could live as a
+  **second** runtime behind the same `Context` interface for users who want
+  it, but it does not replace JS for SVG script compatibility.
+- **Verdict**: deferred; revisit if a user actually asks.
+
+### Implement WebIDL by hand
+- **Pro**: full control.
+- **Con**: every other engine that tried has either died or turned into a
+  browser. The IDL surface is large enough that hand-writing is a multi-year
+  commitment that is permanently out of sync with the spec.
+- **Verdict**: rejected. The `.donner_idl` + reflection approach is the
+  whole point of this design.
+
+### Parse the official WebIDL spec files directly
+- **Pro**: no bespoke grammar.
+- **Con**: WebIDL the full language is far larger than we need (union types,
+  partial interfaces, mixins, callback interfaces, promises, sequences of
+  sequences of unions of …). A trimmed subset grammar is genuinely simpler
+  than a WebIDL parser.
+- **Verdict**: rejected. `.donner_idl` owns its own grammar, deliberately
+  smaller.
+
+## Open questions
+
+- **Mid-dispatch tree mutation semantics.** If an event handler calls
+  `removeChild` on a node that's still pending a bubble-phase listener,
+  what is the expected behaviour? Browser behaviour is nuanced; the spec
+  prescribes some of it but not all. Needs a call with SpecBot before M5.
+- **`animVal` write path.** WebIDL says `animVal` is read-only but some
+  authors rely on reading it while SMIL is running. Does Donner's SMIL
+  engine keep a separate storage, or is `animVal` just a view over the
+  base storage plus the current animation sample? Revisit with
+  `incremental_invalidation` folks.
+- **Character encoding at the script boundary.** Script source is UTF-8;
+  QuickJS supports it. Attribute-handler source (`onclick="…"`) may go
+  through the XML entity decoder first. Are there cases where a script's
+  byte offsets in a diagnostic disagree with the XML parser's?
+- **C++26 reflection portability.** As of 2026-04, compilers' C++26
+  reflection support is partial. Which compiler version is the floor for
+  M2? Do we ship a host-side IDL compiler to decouple consumer-side
+  compiler requirements?
+- **Module loader policy for in-tree modules.** Should `import
+  'donner:svg-constants'` be allowed post-M5? What's the registration
+  story? Needs a follow-up design before any host-registered module ships.
+- **`requestAnimationFrame` clock source.** Confirmed: SMIL clock, virtual.
+  But what does `performance.now()` return? A monotonic clock frozen at
+  document-open time, or live? Golden tests want frozen.
+
+## Future work
+
+- [ ] `MutationObserver` backed by the existing invalidation graph.
+- [ ] Multi-document context sharing for `use`-referenced external SVGs
+      (carefully — needs a fresh security review).
+- [ ] A pre-registered "standard library" module exposing Donner-specific
+      helpers (`donner:constants`, `donner:math`) with a fuzz-audited API.
+- [ ] Script debugging: attach QuickJS's debugger protocol to the editor's
+      preview pane, so authors can step through SVG scripts in-place.
+- [ ] Wasm as a second runtime behind the same `Context` interface.
+- [ ] Speculative: `ScriptExecutionProfile` component — every script
+      exposes how much of its budget it used, visible in the editor for
+      hot-path discovery.

--- a/docs/design_docs/0028-v1_0_release.md
+++ b/docs/design_docs/0028-v1_0_release.md
@@ -1,0 +1,490 @@
+# Design: v1.0 Release
+
+**Status:** Draft
+**Author:** Jeff McGlynn (with Claude Opus 4.7)
+**Created:** 2026-04-17
+
+## Summary
+
+Release checklist and implementation plan for shipping Donner **v1.0** — the production release.
+This doc is the execution counterpart to the v1.0 section of
+[`docs/ProjectRoadmap.md`](../ProjectRoadmap.md#v10--production-release-in-progress), which
+remains the public-facing summary.
+
+v1.0 bundles every workstream that was deferred out of v0.5 plus the retrospective items captured
+in [0011-v0_5_release.md](0011-v0_5_release.md#v05-retrospective):
+
+- **Animation** — the 9 phases of SMIL (`<animate>`, `<animateTransform>`,
+  `<animateMotion>`, `<set>`, event-based timing).
+- **Interactivity** — `EventSystem`, `SpatialGrid` hit testing, the
+  `DonnerController` public API.
+- **Composited rendering** — the layer-based compositor from
+  [0025-composited_rendering.md](0025-composited_rendering.md), in-progress vNext work that
+  was never part of v0.5's feature surface. Prerequisite for fluid editor dragging.
+- **Interactive SVG editing API** — hybrid structured/freeform editing primitives from the
+  ProjectRoadmap: structured API, partial re-parsing, reverse serialization, invalid-region
+  tolerance.
+- **Editor v1 (the app)** — ship `//donner/editor` at first-release quality, building on the
+  in-progress MVP design in [0020-editor.md](0020-editor.md) and the render-pane UX design
+  in [0025-editor_ux.md](0025-editor_ux.md). Extend beyond the MVP to include shape and text
+  creation tools at minimum.
+- **Scripting** — `donner::script` (QuickJS-NG + IDL codegen) per
+  [0027-scripting.md](0027-scripting.md).
+- **Conformance** — the manifest-driven SVG 1.1 + WPT + scripted conformance program in
+  [0026-svg_conformance_testing.md](0026-svg_conformance_testing.md), plus contributing Donner
+  back to the upstream resvg test harness.
+- **Geode on real GPUs** — finishing [0017-geode_renderer.md](0017-geode_renderer.md) beyond
+  software adapters / CI validation.
+- **Parser hardening, DOM gaps, and entity lifecycle** — the items listed under each of those
+  headings in the ProjectRoadmap.
+- **Release-process + docs cleanup** — the retrospective items from 0011: BCR publish,
+  Doxygen sidebar grouping, condensed element/filter index, binary-size report rendering,
+  public-target visibility audit, Markdown element-list cleanup.
+- **Security, optimization, and ecosystem** — AI-assisted security pass, perf/size/memory/
+  compile-time audits, the "Donner Tiny" build profile, and the published comparison against
+  lunasvg/resvg.
+
+The user's top-of-mind list for v1.0 (in priority order) drives the first phases below:
+
+1. Doxygen sidebar / Markdown element-list cleanup.
+2. Composited rendering.
+3. Geode renderer on a real GPU.
+4. Sandboxing.
+5. Scripting.
+6. Animation.
+7. resvg test-suite cleanup.
+8. Conformance test suite.
+9. `<a>` and `<switch>` element support.
+10. Donner as a backend in the upstream resvg test harness.
+11. BCR publish (debug v0.5 failure + re-publish).
+12. Binary-size report in Doxygen rendering correctly.
+13. **Editor v1** — ship the editor at first-release quality, extending the MVP design in
+    [0020-editor.md](0020-editor.md) + [0025-editor_ux.md](0025-editor_ux.md) with shape and
+    text creation tools at minimum.
+
+Everything else from the ProjectRoadmap v1.0 section is included and sequenced into later phases —
+**option (b)**: keep the full scope rather than deferring items to a v1.1. Scope can be
+re-scoped down later if the schedule demands it.
+
+## Goals
+
+- Ship v1.0 with every item listed in the [v1.0 ProjectRoadmap
+  section](../ProjectRoadmap.md#v10--production-release-in-progress) closed or explicitly
+  deferred with a follow-up tracking issue.
+- Meet all **Release Criteria** from the ProjectRoadmap v1.0 section:
+  - Stable public API for rendering, editing, and authoring.
+  - ≥90% line coverage across production code.
+  - CSS3 gap analysis complete; every SVG2-referenced CSS property supported.
+  - Published SVG2 conformance report (from the new conformance suite) with known limitations
+    documented.
+  - Performance and binary-size profiles documented; the "Donner Tiny" tier is usable.
+  - Release documentation complete for embedders (embedding guide).
+- Close out every item from the [v0.5 retrospective](0011-v0_5_release.md#v05-retrospective).
+- Establish scripting and conformance as first-class Donner subsystems, so third-party parity
+  checks against browsers and resvg are a routine part of CI.
+
+## Non-Goals
+
+- Shipping scripting features rejected in the scripting design's Non-Goals (HTML, JIT, network
+  I/O, `MutationObserver`, etc. — see [0027-scripting.md](0027-scripting.md) §Non-Goals).
+- Shipping SVG 1.1-only deprecated features: `enable-background`, `BackgroundImage`/
+  `BackgroundAlpha`, `<tref>`, `kerning`, `glyph-orientation-*`. Those remain permanently
+  `Params::Skip()`.
+- Replacing the resvg test suite. It stays as Donner's primary cross-engine regression lane;
+  the new conformance suite supplements it.
+- A 100% resvg pass rate. Known architectural gaps (e.g. feImage float rendering path) stay
+  tracked in [0021-resvg_feature_gaps.md](0021-resvg_feature_gaps.md).
+- Running the full WPT repository in CI. The conformance design vendors a curated subset.
+- New rendering backends beyond Skia / tiny-skia / Geode.
+
+## Next Steps
+
+1. Review this doc (DesignReviewBot + user) and freeze the phase list before implementation
+   starts. Individual phases are already tracked by their own design docs — this is the
+   coordination layer.
+2. Socialize phase ordering. The default below is "retrospective bugs → close-out → animation →
+   interactivity → scripting → editing → conformance → optimization → release", but several
+   phases can run in parallel once phase 1 is done.
+3. Pick the first phase to start. The user's stated top priority is the Doxygen/Markdown docs
+   cleanup (Phase 1) because it unblocks every later "the sidebar is unusable" complaint.
+
+## Implementation Plan
+
+High-level milestones. Each phase points at the existing design doc that owns the detailed plan —
+this doc only tracks "is the v1.0-gating slice of that work done".
+
+- [ ] **Phase 1** — Release-process + docs cleanup (v0.5 retrospective carry-over).
+- [ ] **Phase 2** — Finish in-flight vNext workstreams (sandboxing, composited rendering,
+  Geode-on-GPU) — never shipped in v0.5, land them for v1.0.
+- [ ] **Phase 3** — SVG feature gaps: `<a>`, `<switch>`, and the P0/P1 items from
+  [0024-proposed_issues_2026q2.md](0024-proposed_issues_2026q2.md).
+- [ ] **Phase 4** — Animation (SMIL Phases 1–9) + animation test suite.
+- [ ] **Phase 5** — Interactivity (`EventSystem`, `SpatialGrid`, `DonnerController`).
+- [ ] **Phase 6** — Scripting (`donner::script`) per
+  [0027-scripting.md](0027-scripting.md).
+- [ ] **Phase 7** — Interactive SVG editing API (structured API, partial re-parsing, reverse
+  serialization, invalid-region tolerance). The library surface that Phase 8 consumes.
+- [ ] **Phase 8** — Editor v1 (the app): graduate `//donner/editor` from MVP to first-release
+  quality per [0020-editor.md](0020-editor.md) + [0025-editor_ux.md](0025-editor_ux.md),
+  adding shape and text creation tools at minimum.
+- [ ] **Phase 9** — Parser hardening + CSS3 gap closure.
+- [ ] **Phase 10** — Incremental invalidation completion + entity lifecycle + DOM gaps.
+- [ ] **Phase 11** — Conformance program per
+  [0026-svg_conformance_testing.md](0026-svg_conformance_testing.md), plus resvg suite cleanup
+  and upstream resvg harness contribution.
+- [ ] **Phase 12** — Security pass (AI-assisted audit + fuzzer expansion).
+- [ ] **Phase 13** — Performance, binary size, memory, compile time, "Donner Tiny" profile.
+- [ ] **Phase 14** — Ecosystem: comparison publication against lunasvg / resvg.
+- [ ] **Phase 15** — Documentation: design-docs-to-developer-docs conversion, embedding guide,
+  in-code docs audit.
+- [ ] **Phase 16** — Release: final validation, build report, tag, publish, BCR publish
+  verified on the v1.0 tag.
+
+---
+
+### Phase 1: Release-process + docs cleanup
+
+Carry over from the [v0.5 retrospective](0011-v0_5_release.md#v05-retrospective). These are
+small, high-visibility fixes that should land before v1.0 feature work to avoid re-surfacing at
+the next release cut.
+
+- [ ] **Doxygen sidebar grouping for design docs** — Group all `docs/design_docs/*.md` under a
+  single "Design Docs" section in the Doxygen tree instead of flattening them into top-level
+  sidebar entries.
+- [ ] **Condense filter/element enumeration in Doxygen** — Replace the per-primitive sidebar
+  explosion with a single "All Elements" / "Filter Primitives" index page.
+- [ ] **Binary-size report renders in Doxygen** — Fix the `docs/build_report.md` integration so
+  the hosted Doxygen site shows the binary-size tables and feature matrix instead of an empty
+  treeview.
+- [ ] **Markdown element-list cleanup** — Shorten the enumerated SVG element lists in README.md
+  and other Markdown docs. Collapse the 17 filter primitives and similar categories behind
+  named shortcuts with a link to the canonical list.
+- [ ] **BCR publish** — Root-cause the v0.5.0 BCR publish failure documented in
+  [0018-bcr_release.md](0018-bcr_release.md). Fix the tooling, verify end-to-end on a v0.5.x
+  (or v1.0-rc) tag, and re-run before the v1.0 tag.
+- [ ] **Public-target visibility audit** — Reduce Bazel `visibility` across the tree to
+  `//donner/...`-private by default. The `//donner/editor/...` subtree is the biggest
+  offender and should be fixed first. Anything deliberately public gets an explicit
+  `visibility = ["//visibility:public"]` and a comment explaining why.
+
+### Phase 2: Finish in-flight vNext workstreams
+
+Three vNext workstreams existed during v0.5 development but were **not** part of v0.5's
+feature surface — code landed on `main` but none was enabled/exposed for v0.5 users. They are
+the first feature work to finish for v1.0.
+
+- [ ] **Sandboxing** — Finish the remaining milestones in
+  [0023-editor_sandbox.md](0023-editor_sandbox.md). Scaffolding (wire-format fuzzer,
+  `sandbox_diff` CLI, hardened-child test fixes) already landed; the end-to-end hardened
+  editor path still needs to ship.
+- [ ] **Composited rendering** — [0025-composited_rendering.md](0025-composited_rendering.md)
+  graduates from Draft → Shipped. Layer-based caching that keeps editor dragging fluid.
+- [ ] **Geode renderer on a real GPU** — Finish [0017-geode_renderer.md](0017-geode_renderer.md).
+  Phase 0–2 and resvg MSAA are green on software adapters; Geode is not yet a user-facing
+  backend and has not been validated on physical GPU hardware.
+
+### Phase 3: SVG feature gaps
+
+Small, user-requested element additions plus the P0/P1 queue from 2026 Q2.
+
+- [ ] **`<a>` element support** — Render as a grouping element. Issue S18 in
+  [0024-proposed_issues_2026q2.md](0024-proposed_issues_2026q2.md). Small scope, 3 resvg tests.
+- [ ] **`<switch>` element + `systemLanguage`** — Conditional processing per
+  [SVG2 §5.9](https://www.w3.org/TR/SVG2/struct.html#ConditionalProcessing). Issue S4. Medium
+  scope, ~15 resvg tests.
+- [ ] **P0 quick wins** — S1 (CSS filter functions at render time, 30 tests) and S2
+  (`transform-origin` as a presentation attribute, 20 tests).
+- [ ] **P1 text baselines** — S5 (`dominant-baseline` full keyword set) + S7
+  (`alignment-baseline` full keyword set).
+- [ ] **P1 rendering** — S6 (`context-fill` / `context-stroke`), S8 (`paint-order`).
+- [ ] **P1 image / viewport** — S12 (intrinsic sizing), S3 (`<image>` sizing), S11 (`<use>` of
+  inline `<svg>`).
+- [ ] **`<symbol>` refX/refY units** ([#318](https://github.com/jwmcglynn/donner/issues/318))
+  and `<marker>` attribute units
+  ([#316](https://github.com/jwmcglynn/donner/issues/316)) — both listed under SVG Feature Gaps
+  in the ProjectRoadmap.
+
+### Phase 4: Animation
+
+9 phases of SMIL animation per the ProjectRoadmap. Needs its own design doc once the work
+starts (currently only the top-level ProjectRoadmap entry exists).
+
+- [ ] **Animation design doc** — Drop a dedicated `docs/design_docs/00NN-animation.md` before
+  implementation begins.
+- [ ] **Phases 1–9** — Timing model, interpolation engine, sandwich composition, attribute
+  targeting, `<animate>`, `<animateTransform>`, `<animateMotion>`, `<set>`, event-based timing.
+- [ ] **Animation test suite** — Comprehensive tests covering timing edge cases, interpolation
+  correctness, and event-based triggers.
+
+### Phase 5: Interactivity
+
+- [ ] **Phases 1–6** — `EventSystem`, `SpatialGrid`-accelerated hit testing, event dispatch
+  (mouse, pointer), CSS `cursor` property, `DonnerController` public API
+  (`addEventListener`, `elementFromPoint`, `findIntersectingRect`, `getWorldBounds`),
+  incremental spatial-index updates.
+
+### Phase 6: Scripting
+
+Owned by [0027-scripting.md](0027-scripting.md). This phase's v1.0 gate is completion of
+milestones **M1–M7** from that doc.
+
+- [ ] **M1** — QuickJS-NG runtime integration, sandbox, diagnostics, fuzz harness.
+- [ ] **M2** — `.donner_idl` compiler and first generated interface.
+- [ ] **M3** — Core DOM: `Node`, `Element`, `Document`, `getElementById`, selectors.
+- [ ] **M4** — Style object + CSS custom-property unification.
+- [ ] **M5** — Event dispatch (capture/bubble, pointer + load + SMIL events).
+- [ ] **M6** — SVG geometry IDL types (`SVGLength`, `SVGPoint`, `SVGMatrix`, `SVGNumber`,
+  `SVGRect`).
+- [ ] **M7** — Real-world corpus + release gate (the M7 gate in the scripting doc is itself
+  scoped as the scripting-subsystem release criterion).
+
+### Phase 7: Interactive SVG editing API
+
+The library-surface half of the flagship v1.0 editing feature from the ProjectRoadmap. This
+phase ships the Donner-side primitives; Phase 8 consumes them from the editor app.
+
+Builds on Phase 2 (composited rendering), Phase 5 (interactivity), and optionally Phase 6
+(scripting, where editor behavior is scriptable).
+
+- [ ] **Structured editing API** — Programmatic DOM mutations propagating through ECS with
+  incremental re-render.
+- [ ] **Partial re-parsing** — Parse only the changed region when source text is edited and
+  splice updates into the live document.
+- [ ] **Reverse serialization** — Splice editor-originated operations back into the source text
+  while preserving surrounding formatting. Enables source → DOM → visual edit → source
+  round-trips.
+- [ ] **Invalid-region tolerance** — Editing API does not crash or lose state on temporarily
+  invalid SVG during freeform text editing.
+
+### Phase 8: Editor v1 (the app)
+
+Graduate `//donner/editor` from its in-tree MVP (landed during v0.5 development) to a
+first-release-quality user-facing editor application. This is the visible half of the
+editing story — Phase 7 provides the underlying library surface.
+
+Owned by [0020-editor.md](0020-editor.md) (overall editor design, migration, command queue,
+mutation seam) and [0025-editor_ux.md](0025-editor_ux.md) (viewport, zoom, pan, click math,
+menu bar, multi-select, marquee, gestures).
+
+- [ ] **Finish the MVP design (0020)** — Close out the remaining milestones from 0020 beyond
+  what landed during v0.5 development.
+- [ ] **Ship the viewport / interaction rewrite (0025)** — Single-source-of-truth
+  `ViewportState`, exact click math at all zoom/pan/DPR combinations, no size-flicker on edit,
+  smooth drags, pinch/pan gestures, multi-select, marquee.
+- [ ] **Shape creation tools** — Minimum set: rectangle, ellipse/circle, line, polyline,
+  polygon, path. Each produces a well-formed DOM mutation via the Phase 7 structured API,
+  with preview + commit semantics.
+- [ ] **Text creation tools** — Click-to-place text insertion with live font selection,
+  size/weight/anchor controls, and editing of existing `<text>` / `<tspan>` nodes.
+  Integrates with the text pipeline from [0010-text_rendering.md](0010-text_rendering.md).
+- [ ] **Tool UX polish** — Selection tool as the rest state; tool picker in the menu bar and
+  keyboard-shortcutted; tool cursors; escape to cancel in-progress creation; undo integrates
+  with `UndoTimeline`.
+- [ ] **Editor release-gate** — User-facing editor passes a scripted acceptance pass
+  (create-edit-save-reload round-trip, at least one shape and one text insertion in every
+  supported tool), loads a corpus of real-world SVGs without visible glitches, and has
+  headless tests for every invariant pinned in 0025.
+- [ ] **Docs** — Editor quick-start + shape/text tool reference as part of the Phase 15
+  documentation pass.
+
+### Phase 9: Parser hardening + CSS3 gap closure
+
+- [ ] **`ParseWarning` type** — First-class warning type replacing the current
+  `vector<ParseError>` pattern; warnings vs errors distinct at the type level.
+- [ ] **Source location audit** — Verify every current parse error reports the correct source
+  location.
+- [ ] **Full source ranges** — Extend diagnostics to carry full start + end source ranges.
+- [ ] **Streaming CSS parser** — Consider making the CSS parser streaming (possibly via C++20
+  coroutines). Add source-range and incremental-update support parity with the XML parser.
+- [ ] **XML parser conformance** — Fix the known non-conforming `Name` token acceptance
+  ([#304](https://github.com/jwmcglynn/donner/issues/304)) and any related bugs.
+- [ ] **CSS3 gap closure** — Audit CSS3 property/selector support against every SVG2-referenced
+  property. Close gaps in selectors, cascading, specificity, shorthand expansion, value
+  parsing.
+
+### Phase 10: Incremental invalidation + entity lifecycle + DOM
+
+- [ ] **Selective per-entity recomputation** — Finish the partially-implemented v0.5 path from
+  [0005-incremental_invalidation.md](0005-incremental_invalidation.md). Layout/text/shape/
+  paint/filter passes should respect dirty flags and skip clean entities instead of full
+  teardown.
+- [ ] **CSS differential restyling** — When a stylesheet or class attribute changes, determine
+  which selector matches changed and re-resolve only affected elements.
+- [ ] **Node removal cleanup** — Destruction hooks tear down components, release resources, and
+  remove entities from spatial indices / caches. Currently removed entities leak in the ECS
+  registry.
+- [ ] **SVG2 DOM gap analysis** — Audit current DOM surface against the full SVG2 DOM spec.
+- [ ] **Close DOM gaps** — Implement missing interfaces/attributes/methods, prioritizing those
+  needed for Phase 6 (scripting), Phase 7 (editing API), and Phase 8 (editor app).
+
+### Phase 11: Conformance
+
+Owned by [0026-svg_conformance_testing.md](0026-svg_conformance_testing.md). This phase's v1.0
+gate is completion of M1–M4 from that doc, plus the two roadmap items on resvg.
+
+- [ ] **M1** — Manifest format + Bazel overlays + SVG 1.1 filter pilot.
+- [ ] **M2** — Static SVG 2 / WPT reftest lane.
+- [ ] **M3** — CI policy, reporting, and documentation.
+- [ ] **M4** — Scripted / DOM / animation conformance on top of `donner::script` (depends on
+  Phase 6).
+- [ ] **resvg test suite cleanup** — File, triage, and close out issues for current skipped /
+  thresholded tests. Tracked via
+  [0021-resvg_feature_gaps.md](0021-resvg_feature_gaps.md) and
+  [0009-resvg_test_suite_bugs.md](0009-resvg_test_suite_bugs.md).
+- [ ] **Add Donner to upstream resvg test harness** — External contribution: Donner as a
+  first-class backend in the `linebender/resvg-test-suite` repository.
+- [ ] **Publish SVG2 conformance report** — Required by the v1.0 Release Criteria in the
+  ProjectRoadmap. Drop output in `docs/` and link from the release notes.
+
+### Phase 12: Security pass
+
+- [ ] **AI-assisted security audit** — Comprehensive review of XML, CSS, SVG attribute, and
+  external-reference input paths.
+- [ ] **Fuzzer expansion** — Add fuzzers for under-covered surfaces: CSS, filter parameters,
+  animation timing, edit/patch paths, scripting IDL surface (codegen-emitted, per
+  0027-scripting.md).
+- [ ] **Integrate with [0012-continuous_fuzzing.md](0012-continuous_fuzzing.md)** — Make the
+  dockerized always-on fuzzing harness the default for the new fuzzers.
+
+### Phase 13: Performance, size, memory, compile time
+
+- [ ] **End-to-end profiling** — Profile parsing, style resolution, layout, rasterization.
+  Identify remaining hot paths beyond the filter-SIMD work already landed.
+- [ ] **Code / binary size audit** — Ensure text, filters, animation, and JS compile out
+  cleanly when disabled. Apply LTO + gc-sections per B9 in
+  [0024-proposed_issues_2026q2.md](0024-proposed_issues_2026q2.md).
+- [ ] **Memory audit** — ECS component sizes, pixmap allocations, filter intermediate buffers,
+  steady-state vs peak.
+- [ ] **Compile time** — Forward-declaration headers, modular EnTT (B4), split monolithic
+  `svg_core` / renderer files (B11, B14).
+- [ ] **"Donner Tiny" build profile** — Minimal-footprint tier stripping text/filters/
+  animation/JS. Document size impact per optional module. Pre-defined profiles: `tiny`,
+  `standard`, `full`.
+
+### Phase 14: Ecosystem comparison
+
+- [ ] **Lunasvg / resvg comparison** — Publish a detailed comparison covering feature support,
+  conformance, performance, API design, binary size, build complexity. Include reproducible
+  benchmarks and conformance results.
+
+### Phase 15: Documentation
+
+- [ ] **Design docs → developer docs** — Convert shipped design documents into developer-facing
+  architecture documentation. Remove planning/status artifacts, keep how-it-works content.
+- [ ] **In-code documentation cleanup** — Audit Doxygen annotations and comments on every
+  public header. Resolve the waived v0.5 Doxygen warning backlog.
+- [ ] **Embedding guide** — End-to-end guide for integrating Donner into applications: build
+  configuration, feature toggles, rendering setup, common workflows.
+
+### Phase 16: Release
+
+Mirrors [0011-v0_5_release.md](0011-v0_5_release.md) Phase 14. The build-report commit is the
+tagged commit.
+
+- [ ] **All release-blocking code on `main`** before the build-report commit.
+- [ ] **Update `RELEASE_NOTES.md`** with the final v1.0 highlights.
+- [ ] **Generate build report** as the dedicated release commit.
+- [ ] **CI green on the build-report commit.**
+- [ ] **Tag `v1.0.0`** on the build-report commit; push; `gh release create`.
+- [ ] **Verify release artifacts** — Linux/macOS binaries, SLSA attestations, BCR publish
+  (now expected to work end-to-end after Phase 1's BCR fix).
+- [ ] **Post-release** — ProjectRoadmap update, announcement.
+
+---
+
+## Release Criteria
+
+Copied verbatim from
+[ProjectRoadmap.md → v1.0 → Release Criteria](../ProjectRoadmap.md#release-criteria), so this
+doc is the single source of truth for execution:
+
+- All v1.0 issues closed.
+- SVG2 conformance report published with known limitations documented.
+- Stable API surface for rendering, editing, and authoring operations.
+- ≥90% code coverage across production code.
+- CSS3 gap analysis complete, all SVG2-referenced properties supported.
+- Performance and binary-size profiles documented.
+- Release documentation complete for embedders.
+
+Plus the v0.5 retrospective items (all addressed in Phase 1):
+
+- BCR publish working end-to-end on the v1.0 tag.
+- Doxygen sidebar organized; binary-size report rendering; element lists condensed.
+- Public-target visibility tightened, particularly under `//donner/editor/...`.
+
+## Proposed Architecture
+
+This is a coordination doc, not a feature design — the architectural changes live in the
+per-phase design docs:
+
+- Animation → a forthcoming `00NN-animation.md` (Phase 4).
+- Interactivity → ProjectRoadmap §Interactivity (Phase 5), to be promoted to a design doc.
+- Composited rendering → [0025-composited_rendering.md](0025-composited_rendering.md).
+- Scripting → [0027-scripting.md](0027-scripting.md).
+- Conformance → [0026-svg_conformance_testing.md](0026-svg_conformance_testing.md).
+- Editor sandbox → [0023-editor_sandbox.md](0023-editor_sandbox.md).
+- Geode → [0017-geode_renderer.md](0017-geode_renderer.md).
+- Incremental invalidation → [0005-incremental_invalidation.md](0005-incremental_invalidation.md).
+- BCR → [0018-bcr_release.md](0018-bcr_release.md).
+- Continuous fuzzing → [0012-continuous_fuzzing.md](0012-continuous_fuzzing.md).
+- Coverage → [0013-coverage_improvement.md](0013-coverage_improvement.md).
+
+Parallelism: Phases 1, 2, and 3 are mostly independent and can run in parallel. Phase 6
+(scripting) blocks Phase 11 M4 (scripted conformance) and parts of Phases 7/8 that need
+scripting hooks. Phase 2 (composited rendering) blocks the fluid-dragging parts of Phase 8
+(the editor app). Phase 7 (editing API) gates Phase 8 on the structured-mutation and
+reverse-serialization primitives — Phase 8 shape/text creation tools can start on the API as
+soon as the structured-mutation surface is usable, ahead of partial re-parsing / reverse
+serialization.
+
+## Security / Privacy
+
+v1.0 adds two major new trust boundaries beyond v0.5's parser / renderer surface:
+
+- **Scripting.** Untrusted JS running inside Donner. The threat model, sandbox, and fuzz
+  strategy are owned by [0027-scripting.md](0027-scripting.md) §Security / privacy.
+- **Editor sandbox.** Process isolation for editor parser/renderer. Owned by
+  [0023-editor_sandbox.md](0023-editor_sandbox.md).
+
+Donner's global invariant — "must safely handle untrusted input and must never crash" — extends
+unchanged across the scripting boundary. Phase 12 (Security pass) is the verification step.
+
+## Testing and Validation
+
+- **Existing lanes stay green**: unit tests, `renderer_tests`, `resvg_test_suite`, all 21+
+  fuzzers, CMake and Bazel builds across all backends.
+- **New conformance lane** (Phase 11) adds SVG 1.1 filter corpus, static SVG 2 / WPT reftests,
+  and — on top of scripting — scripted / DOM / animation conformance.
+- **Animation test suite** (Phase 4) covers timing, interpolation, event-based triggers.
+- **Scripting fuzz targets** (Phase 6) are emitted by IDL codegen so every new script-exposed
+  interface ships with fuzz coverage.
+- **Coverage target**: ≥90% line coverage across production code (v0.5 shipped at 81.7%).
+- **Binary-size, build-time, and perf profiles** (Phase 13) are captured in the build report
+  and become a release-gate artifact.
+
+## Dependencies
+
+- **QuickJS-NG** — new dep introduced by scripting (Phase 6). Licensed MIT; pinned via
+  `non_bcr_deps`. See [0027-scripting.md](0027-scripting.md) §Dependencies.
+- **WPT subset** — vendored curated snapshot added by the conformance program (Phase 11). See
+  [0026-svg_conformance_testing.md](0026-svg_conformance_testing.md) §Dependencies.
+- **Existing deps** unchanged.
+
+## Open Questions
+
+- **Phase ordering.** Animation (Phase 4) vs scripting (Phase 6) ordering is the biggest
+  open call. Scripting first unblocks scripted conformance (Phase 11 M4) sooner; animation
+  first is a cleaner user-facing story. Default here: animation first (matches user's stated
+  priority).
+- **Editor scope cut.** Phases 7 (API) and 8 (app) are both large. If schedule pressure
+  appears, Phase 7's "reverse serialization" and Phase 8's text creation tool are the most
+  deferrable items — the rest is load-bearing for the v1.0 interactive-editor story.
+- **Deprecate pre-option-(a) scope cut.** Keep revisiting whether v1.0 should be narrowed to
+  the user's top-12 list and everything else deferred to v1.1. Default today: full ProjectRoadmap
+  scope.
+
+## Future Work
+
+- **v1.1+ ideas** that were debated for v1.0 and intentionally left out today: MutationObserver
+  / script-visible change feed, cross-document scripting, HTML support, JIT, additional
+  rendering backends beyond Geode, full WPT integration.

--- a/docs/design_docs/README.md
+++ b/docs/design_docs/README.md
@@ -43,7 +43,7 @@ conventions automated agents should follow when editing design docs.
 | 0008 | [css_fonts](0008-css_fonts.md)                                                         | Partial                                                                    | CSS `@font-face` loading pipeline (TTF/OTF/WOFF/WOFF2). |
 | 0009 | [resvg_test_suite_bugs](0009-resvg_test_suite_bugs.md)                                 | Living catalog                                                             | Cases where resvg's golden images disagree with the SVG/CSS spec. |
 | 0010 | [text_rendering](0010-text_rendering.md)                                               | Implemented (Phases 1–6); backend refactor complete                        | `<text>`, `<tspan>`, `<textPath>`, the stb / FreeType / HarfBuzz backend tiers. |
-| 0011 | [v0_5_release](0011-v0_5_release.md)                                                   | In Progress                                                                | Release checklist and implementation plan for shipping v0.5. |
+| 0011 | [v0_5_release](0011-v0_5_release.md)                                                   | Shipped (v0.5.0, 2026-04-16)                                               | Release checklist and implementation plan for shipping v0.5, plus retrospective for the next release. |
 | 0012 | [continuous_fuzzing](0012-continuous_fuzzing.md)                                       | Design                                                                     | Dockerized always-on fuzzing harness for every parser surface. |
 | 0013 | [coverage_improvement](0013-coverage_improvement.md)                                   | In Progress (Round 1 complete, Round 2 in progress)                        | Ongoing per-round coverage work: what's still uncovered and why. |
 | 0014 | [filter_performance](0014-filter_performance.md)                                       | Complete (all filters within 1.5× of Skia)                                 | How the tiny-skia filter pipeline caught up with Skia on every primitive. |
@@ -58,6 +58,9 @@ conventions automated agents should follow when editing design docs.
 | 0023 | [editor_sandbox](0023-editor_sandbox.md)                                               | Design                                                                    | Browser-style process isolation for the editor's parser / renderer. |
 | 0024 | [proposed_issues_2026q2](0024-proposed_issues_2026q2.md)                               | Draft                                                                      | Q2 2026 wishlist: feature gaps and CI improvements. |
 | 0025 | [composited_rendering](0025-composited_rendering.md)                                   | Draft                                                                      | Layer-based compositor for fluid editor dragging without full re-render. |
+| 0026 | [svg_conformance_testing](0026-svg_conformance_testing.md)                             | Draft                                                                      | Manifest-driven SVG 1.1 filter + WPT + scripted conformance program. |
+| 0027 | [scripting](0027-scripting.md)                                                         | Draft                                                                      | `donner::script`: QuickJS-NG + IDL codegen that projects the ECS as the DOM. |
+| 0028 | [v1_0_release](0028-v1_0_release.md)                                                   | Draft                                                                      | Release checklist and implementation plan for shipping v1.0 (full ProjectRoadmap scope). |
 
 ## Cross-reference: developer docs
 


### PR DESCRIPTION
🤖 Authored by Claude Opus 4.7 via Claude Code on behalf of @jwmcglynn.

## Summary

- **0011-v0_5_release.md → Shipped (v0.5.0, 2026-04-16).** Phase 14 / release-publish items checked off. New **v0.5 Retrospective** section captures the bugs and follow-ups surfaced by the release: BCR publish failure, Doxygen sidebar grouping, Doxygen binary-size report rendering, condensed filter/element sidebar, Markdown element-list cleanup, and a public-target visibility audit (editor subtree is the worst offender). Separately lists the three in-flight vNext workstreams — **sandboxing**, **composited rendering**, **Geode-on-real-GPU** — that landed code on \`main\` during v0.5 development but were never part of v0.5's feature surface.

- **Pulls two draft design docs into \`main\`** so they can be referenced as in-tree:
  - \`0026-svg_conformance_testing.md\` from \`origin/conformance\` (authored by GPT-5 Codex).
  - \`0027-scripting.md\` from \`origin/scripting\` (authored by Claude Opus 4.6, renumbered from \`scripting.md\`).
  - Takes over both branches per user direction. Updates 0026's cross-refs to point at the local 0027.

- **New 0028-v1_0_release.md** — execution plan for v1.0, mirroring the structure of 0011 and anchoring the v1.0 section of \`docs/ProjectRoadmap.md\`. **Option (b):** keep the full ProjectRoadmap v1.0 scope rather than deferring items to a v1.1. Organized into 16 phases:
  1. Release-process + docs cleanup (v0.5 retrospective carry-over)
  2. Finish in-flight vNext workstreams (sandboxing, composited, Geode-on-GPU)
  3. SVG feature gaps (\`<a>\`, \`<switch>\`, P0/P1 from 0024)
  4. Animation (SMIL phases 1–9)
  5. Interactivity (\`EventSystem\`, \`SpatialGrid\`, \`DonnerController\`)
  6. Scripting (\`donner::script\` M1–M7)
  7. Interactive editing API (structured API, partial re-parsing, reverse serialization, invalid-region tolerance)
  8. **Editor v1 (the app)** — graduate \`//donner/editor\` from MVP to first-release quality, with shape and text creation tools at minimum
  9. Parser hardening + CSS3 gap closure
  10. Incremental invalidation + entity lifecycle + DOM gaps
  11. Conformance (0026 M1–M4, resvg suite cleanup, upstream resvg harness)
  12. Security pass
  13. Performance / binary size / memory / compile time / "Donner Tiny"
  14. Ecosystem comparison
  15. Documentation
  16. Release

- \`docs/design_docs/README.md\` index updated for 0011 status and the three new docs.

## Test plan

Docs-only change; no code or build files touched.

- [ ] Rendered Markdown reviewed on GitHub for 0011 retrospective + 0028 phase list
- [ ] Design-doc index in README.md links resolve
- [ ] Cross-references from 0028 to 0005 / 0010 / 0012 / 0013 / 0017 / 0018 / 0020 / 0023 / 0024 / 0025 / 0026 / 0027 all resolve
- [ ] 0026's rewritten refs to 0027 resolve (no lingering \`origin/scripting:…\` strings)