### PR TITLE
Geode: fix multi-band hang on Intel Arc Vulkan via alpha-coverage AA gate

### DIFF
--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -878,9 +878,10 @@ RendererGeode::RendererGeode(bool verbose) : impl_(std::make_unique<Impl>()) {
     }
     return;
   }
-  impl_->pipeline = std::make_unique<geode::GeodePipeline>(impl_->device->device(), kFormat);
-  impl_->gradientPipeline =
-      std::make_unique<geode::GeodeGradientPipeline>(impl_->device->device(), kFormat);
+  impl_->pipeline = std::make_unique<geode::GeodePipeline>(
+      impl_->device->device(), kFormat, impl_->device->useAlphaCoverageAA());
+  impl_->gradientPipeline = std::make_unique<geode::GeodeGradientPipeline>(
+      impl_->device->device(), kFormat, impl_->device->useAlphaCoverageAA());
   impl_->imagePipeline =
       std::make_unique<geode::GeodeImagePipeline>(impl_->device->device(), kFormat);
 }

--- a/donner/svg/renderer/geode/BUILD.bazel
+++ b/donner/svg/renderer/geode/BUILD.bazel
@@ -157,6 +157,36 @@ embed_resources(
     visibility = ["//donner/svg/renderer:__subpackages__"],
 )
 
+# Alpha-coverage shader variants. These differ from their MSAA counterparts
+# only in the fragment output: no @builtin(sample_mask), coverage folded into
+# the fragment color. Used on Intel + Vulkan to avoid a Mesa ANV hang.
+embed_resources(
+    name = "slug_fill_alpha_coverage_wgsl",
+    header_output = "embed_resources/SlugFillAlphaCoverageWgsl.h",
+    resources = {
+        "kSlugFillAlphaCoverageWgsl": "shaders/slug_fill_alpha_coverage.wgsl",
+    },
+    visibility = ["//donner/svg/renderer:__subpackages__"],
+)
+
+embed_resources(
+    name = "slug_gradient_alpha_coverage_wgsl",
+    header_output = "embed_resources/SlugGradientAlphaCoverageWgsl.h",
+    resources = {
+        "kSlugGradientAlphaCoverageWgsl": "shaders/slug_gradient_alpha_coverage.wgsl",
+    },
+    visibility = ["//donner/svg/renderer:__subpackages__"],
+)
+
+embed_resources(
+    name = "slug_mask_alpha_coverage_wgsl",
+    header_output = "embed_resources/SlugMaskAlphaCoverageWgsl.h",
+    resources = {
+        "kSlugMaskAlphaCoverageWgsl": "shaders/slug_mask_alpha_coverage.wgsl",
+    },
+    visibility = ["//donner/svg/renderer:__subpackages__"],
+)
+
 donner_cc_library(
     name = "geode_shaders",
     srcs = ["GeodeShaders.cc"],
@@ -167,8 +197,11 @@ donner_cc_library(
         ":geode_wgpu_util",
         ":image_blit_wgsl",
         ":slug_fill_wgsl",
+        ":slug_fill_alpha_coverage_wgsl",
         ":slug_gradient_wgsl",
+        ":slug_gradient_alpha_coverage_wgsl",
         ":slug_mask_wgsl",
+        ":slug_mask_alpha_coverage_wgsl",
         "//third_party/webgpu-cpp:webgpu_cpp",
     ],
 )

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -393,13 +393,14 @@ struct GeoEncoder::Impl {
     if (passOpen) {
       return;
     }
+    wgpu::RenderPassColorAttachment color = {};
+
     // 4× MSAA color attachment with per-pass resolve. The MSAA view is
     // the draw target; WebGPU implicitly resolves into `targetView` at
     // pass end. `storeOp = Store` on the MSAA attachment preserves its
     // state for a subsequent pass (see `setLoadPreserve()` — we may
     // reopen a pass to continue drawing on top of the previous MSAA
     // contents, e.g., after a nested-layer composite).
-    wgpu::RenderPassColorAttachment color = {};
     color.view = msaaTargetView;
     color.resolveTarget = targetView;
     color.loadOp = loadPreserve ? wgpu::LoadOp::Load : wgpu::LoadOp::Clear;
@@ -658,7 +659,9 @@ void GeoEncoder::beginMaskPass(const wgpu::Texture& msaaMask,
 
   // Lazily build the mask pipeline on first use.
   if (!impl_->maskPipelineOwned) {
-    impl_->maskPipelineOwned = std::make_unique<GeodeMaskPipeline>(impl_->device->device());
+    impl_->maskPipelineOwned =
+        std::make_unique<GeodeMaskPipeline>(impl_->device->device(),
+                                            impl_->device->useAlphaCoverageAA());
   }
 
   impl_->maskPassSavedTransform = impl_->transform;

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -68,6 +68,49 @@ std::unique_ptr<GeodeDevice> GeodeDevice::CreateHeadless() {
     return nullptr;
   }
 
+  // Log adapter selection so it is obvious at a glance whether we landed
+  // on a discrete GPU / integrated GPU / software rasterizer, and which
+  // native backend (Vulkan / Metal / D3D12 / …) is driving it.
+  {
+    WGPUAdapterInfo info = {};
+    if (wgpuAdapterGetInfo(result->adapter_, &info) == WGPUStatus_Success) {
+      auto sv = [](const WGPUStringView& s) {
+        return std::string_view{s.data ? s.data : "", s.data ? s.length : 0};
+      };
+      const char* backend = "?";
+      switch (info.backendType) {
+        case WGPUBackendType_Vulkan: backend = "Vulkan"; break;
+        case WGPUBackendType_Metal: backend = "Metal"; break;
+        case WGPUBackendType_D3D12: backend = "D3D12"; break;
+        case WGPUBackendType_D3D11: backend = "D3D11"; break;
+        case WGPUBackendType_OpenGL: backend = "OpenGL"; break;
+        case WGPUBackendType_OpenGLES: backend = "OpenGLES"; break;
+        case WGPUBackendType_WebGPU: backend = "WebGPU"; break;
+        case WGPUBackendType_Null: backend = "Null"; break;
+        default: break;
+      }
+      const char* type = "?";
+      switch (info.adapterType) {
+        case WGPUAdapterType_DiscreteGPU: type = "DiscreteGPU"; break;
+        case WGPUAdapterType_IntegratedGPU: type = "IntegratedGPU"; break;
+        case WGPUAdapterType_CPU: type = "CPU"; break;
+        case WGPUAdapterType_Unknown: type = "Unknown"; break;
+        default: break;
+      }
+      const auto vendor = sv(info.vendor);
+      const auto device = sv(info.device);
+      const auto arch = sv(info.architecture);
+      std::fprintf(stderr,
+                   "[Geode/wgpu-native] Adapter: %.*s %.*s (%.*s) "
+                   "backend=%s type=%s vendorID=0x%04x deviceID=0x%04x\n",
+                   static_cast<int>(vendor.size()), vendor.data(),
+                   static_cast<int>(device.size()), device.data(),
+                   static_cast<int>(arch.size()), arch.data(), backend, type,
+                   info.vendorID, info.deviceID);
+      wgpuAdapterInfoFreeMembers(info);
+    }
+  }
+
   // 3. Create the device. Error diagnostics are wired via
   //    `uncapturedErrorCallbackInfo` on the descriptor — the callback
   //    stays valid for the device's lifetime.

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -107,6 +107,19 @@ std::unique_ptr<GeodeDevice> GeodeDevice::CreateHeadless() {
                    static_cast<int>(device.size()), device.data(),
                    static_cast<int>(arch.size()), arch.data(), backend, type,
                    info.vendorID, info.deviceID);
+
+      // Intel + Vulkan: writing @builtin(sample_mask) from overlapping band
+      // quads hangs Mesa ANV / Xe KMD when bandCount >= 2 (observed on Arc
+      // A380, Mesa 25.2.8). Fall back to alpha-coverage AA which folds the
+      // 4-sample mask into the fragment color on a 1-sample render target.
+      if (info.vendorID == 0x8086 && info.backendType == WGPUBackendType_Vulkan) {
+        result->useAlphaCoverageAA_ = true;
+        std::fprintf(stderr,
+                     "[Geode] Intel Arc + Vulkan detected; using alpha-coverage AA "
+                     "(sample_mask output hangs on Mesa 25.2.8 Xe-KMD; "
+                     "upstream fix in Mesa 25.3)\n");
+      }
+
       wgpuAdapterInfoFreeMembers(info);
     }
   }

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -55,6 +55,19 @@ public:
   /// Returns the adapter backing this device.
   const wgpu::Adapter& adapter() const { return adapter_; }
 
+  /**
+   * Whether to use alpha-coverage AA instead of hardware 4× MSAA with
+   * `@builtin(sample_mask)`.
+   *
+   * Returns true on Intel + Vulkan, where writing `@builtin(sample_mask)`
+   * from overlapping band quads hangs Mesa ANV / Xe KMD (observed on
+   * Arc A380, Mesa 25.2.8). The alpha-coverage path folds 4-sample
+   * coverage into the fragment color instead of relying on the hardware
+   * sample mask. The pipeline still uses `multisample.count = 4` so
+   * MSAA render targets and resolve steps are unchanged.
+   */
+  bool useAlphaCoverageAA() const { return useAlphaCoverageAA_; }
+
 private:
   GeodeDevice();
 
@@ -66,6 +79,8 @@ private:
   wgpu::Adapter adapter_;
   wgpu::Device device_;
   wgpu::Queue queue_;
+
+  bool useAlphaCoverageAA_ = false;
 };
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodePipeline.cc
+++ b/donner/svg/renderer/geode/GeodePipeline.cc
@@ -5,7 +5,8 @@
 
 namespace donner::geode {
 
-GeodePipeline::GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat colorFormat)
+GeodePipeline::GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat colorFormat,
+                             bool useAlphaCoverageShader)
     : colorFormat_(colorFormat) {
   // ----- Bind group layout -----
   // Seven bindings: uniforms, bands SSBO, curves SSBO, pattern texture,
@@ -67,7 +68,9 @@ GeodePipeline::GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat col
   wgpu::PipelineLayout pipelineLayout = device.createPipelineLayout(plDesc);
 
   // ----- Shader module -----
-  wgpu::ShaderModule shader = createSlugFillShader(device);
+  wgpu::ShaderModule shader =
+      useAlphaCoverageShader ? createSlugFillAlphaCoverageShader(device)
+                             : createSlugFillShader(device);
 
   // ----- Vertex buffer layout -----
   // Matches EncodedPath::Vertex: pos (vec2f) + normal (vec2f) + bandIndex (u32)
@@ -143,7 +146,8 @@ GeodePipeline::GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat col
 // ============================================================================
 
 GeodeGradientPipeline::GeodeGradientPipeline(const wgpu::Device& device,
-                                             wgpu::TextureFormat colorFormat)
+                                             wgpu::TextureFormat colorFormat,
+                                             bool useAlphaCoverageShader)
     : colorFormat_(colorFormat) {
   // Five bindings — uniforms, bands SSBO, curves SSBO, clip-mask texture,
   // clip-mask sampler. The clip-mask bindings always carry something
@@ -190,7 +194,9 @@ GeodeGradientPipeline::GeodeGradientPipeline(const wgpu::Device& device,
   plDesc.bindGroupLayouts = layouts;
   wgpu::PipelineLayout pipelineLayout = device.createPipelineLayout(plDesc);
 
-  wgpu::ShaderModule shader = createSlugGradientShader(device);
+  wgpu::ShaderModule shader =
+      useAlphaCoverageShader ? createSlugGradientAlphaCoverageShader(device)
+                             : createSlugGradientShader(device);
 
   // Same vertex buffer layout as the solid-fill pipeline.
   wgpu::VertexAttribute vertexAttribs[3] = {};
@@ -244,7 +250,7 @@ GeodeGradientPipeline::GeodeGradientPipeline(const wgpu::Device& device,
   rpDesc.primitive.cullMode = wgpu::CullMode::None;
 
   rpDesc.fragment = &fragmentState;
-  // 4× MSAA to match the solid-fill pipeline — see its multisample comment.
+  // Match the solid-fill pipeline's sample count.
   rpDesc.multisample.count = 4;
   rpDesc.multisample.mask = 0xFFFFFFFF;
 
@@ -255,7 +261,7 @@ GeodeGradientPipeline::GeodeGradientPipeline(const wgpu::Device& device,
 // GeodeMaskPipeline
 // ============================================================================
 
-GeodeMaskPipeline::GeodeMaskPipeline(const wgpu::Device& device) {
+GeodeMaskPipeline::GeodeMaskPipeline(const wgpu::Device& device, bool useAlphaCoverageShader) {
   // Five bindings — uniforms, bands SSBO, curves SSBO, nested clip
   // mask texture, nested clip mask sampler. The clip-mask slot is
   // always bound; a 1x1 dummy is used when `uniforms.hasClipMask ==
@@ -300,7 +306,9 @@ GeodeMaskPipeline::GeodeMaskPipeline(const wgpu::Device& device) {
   plDesc.bindGroupLayouts = layouts;
   wgpu::PipelineLayout pipelineLayout = device.createPipelineLayout(plDesc);
 
-  wgpu::ShaderModule shader = createSlugMaskShader(device);
+  wgpu::ShaderModule shader =
+      useAlphaCoverageShader ? createSlugMaskAlphaCoverageShader(device)
+                             : createSlugMaskShader(device);
 
   // Same vertex buffer layout as the fill pipelines: pos (vec2f) +
   // normal (vec2f) + bandIndex (u32) = 20 bytes per vertex.

--- a/donner/svg/renderer/geode/GeodePipeline.h
+++ b/donner/svg/renderer/geode/GeodePipeline.h
@@ -37,8 +37,13 @@ public:
    * @param device The WebGPU device.
    * @param colorFormat The pixel format of the render target this pipeline
    *   will draw into. Must match the target texture's format at draw time.
+   * @param useAlphaCoverageShader When true, selects the alpha-coverage
+   *   variant of the fill shader (no `@builtin(sample_mask)` output).
+   *   The pipeline still uses 4× MSAA; coverage is folded into the
+   *   fragment color instead of relying on the hardware sample mask.
    */
-  GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat colorFormat);
+  GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat colorFormat,
+                bool useAlphaCoverageShader = false);
 
   ~GeodePipeline() = default;
   GeodePipeline(const GeodePipeline&) = delete;
@@ -80,7 +85,9 @@ private:
 class GeodeGradientPipeline {
 public:
   /// Construct a gradient pipeline for the given device and color target format.
-  GeodeGradientPipeline(const wgpu::Device& device, wgpu::TextureFormat colorFormat);
+  /// @param useAlphaCoverageShader When true, selects the alpha-coverage shader variant.
+  GeodeGradientPipeline(const wgpu::Device& device, wgpu::TextureFormat colorFormat,
+                        bool useAlphaCoverageShader = false);
 
   ~GeodeGradientPipeline() = default;
   GeodeGradientPipeline(const GeodeGradientPipeline&) = delete;
@@ -127,9 +134,11 @@ class GeodeMaskPipeline {
 public:
   /**
    * Create a Slug mask pipeline for the given device. Renders into an
-   * R8Unorm MSAA texture (the mask target is allocated by the caller).
+   * R8Unorm texture with 4× MSAA.
+   *
+   * @param useAlphaCoverageShader When true, selects the alpha-coverage shader variant.
    */
-  explicit GeodeMaskPipeline(const wgpu::Device& device);
+  explicit GeodeMaskPipeline(const wgpu::Device& device, bool useAlphaCoverageShader = false);
 
   ~GeodeMaskPipeline() = default;
   GeodeMaskPipeline(const GeodeMaskPipeline&) = delete;

--- a/donner/svg/renderer/geode/GeodeShaders.cc
+++ b/donner/svg/renderer/geode/GeodeShaders.cc
@@ -3,8 +3,11 @@
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 #include "embed_resources/ImageBlitWgsl.h"
 #include "embed_resources/SlugFillWgsl.h"
+#include "embed_resources/SlugFillAlphaCoverageWgsl.h"
 #include "embed_resources/SlugGradientWgsl.h"
+#include "embed_resources/SlugGradientAlphaCoverageWgsl.h"
 #include "embed_resources/SlugMaskWgsl.h"
+#include "embed_resources/SlugMaskAlphaCoverageWgsl.h"
 
 namespace donner::geode {
 
@@ -60,6 +63,24 @@ wgpu::ShaderModule createImageBlitShader(const wgpu::Device& device) {
   return createShaderFromWgsl(device, "ImageBlit",
                               donner::embedded::kImageBlitWgsl.data(),
                               donner::embedded::kImageBlitWgsl.size());
+}
+
+wgpu::ShaderModule createSlugFillAlphaCoverageShader(const wgpu::Device& device) {
+  return createShaderFromWgsl(device, "SlugFillAlphaCoverage",
+                              donner::embedded::kSlugFillAlphaCoverageWgsl.data(),
+                              donner::embedded::kSlugFillAlphaCoverageWgsl.size());
+}
+
+wgpu::ShaderModule createSlugGradientAlphaCoverageShader(const wgpu::Device& device) {
+  return createShaderFromWgsl(device, "SlugGradientAlphaCoverage",
+                              donner::embedded::kSlugGradientAlphaCoverageWgsl.data(),
+                              donner::embedded::kSlugGradientAlphaCoverageWgsl.size());
+}
+
+wgpu::ShaderModule createSlugMaskAlphaCoverageShader(const wgpu::Device& device) {
+  return createShaderFromWgsl(device, "SlugMaskAlphaCoverage",
+                              donner::embedded::kSlugMaskAlphaCoverageWgsl.data(),
+                              donner::embedded::kSlugMaskAlphaCoverageWgsl.size());
 }
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodeShaders.h
+++ b/donner/svg/renderer/geode/GeodeShaders.h
@@ -56,6 +56,22 @@ wgpu::ShaderModule createSlugGradientShader(const wgpu::Device& device);
 wgpu::ShaderModule createSlugMaskShader(const wgpu::Device& device);
 
 /**
+ * Compile the alpha-coverage variant of the Slug fill shader.
+ *
+ * Identical to `createSlugFillShader` except the fragment stage has no
+ * `@builtin(sample_mask)` output — coverage is folded into the fragment
+ * color as `popcount(mask) / 4.0`. Used on Intel + Vulkan where writing
+ * `sample_mask` from overlapping band quads hangs Mesa ANV / Xe KMD.
+ */
+wgpu::ShaderModule createSlugFillAlphaCoverageShader(const wgpu::Device& device);
+
+/// Alpha-coverage variant of `createSlugGradientShader`.
+wgpu::ShaderModule createSlugGradientAlphaCoverageShader(const wgpu::Device& device);
+
+/// Alpha-coverage variant of `createSlugMaskShader`.
+wgpu::ShaderModule createSlugMaskAlphaCoverageShader(const wgpu::Device& device);
+
+/**
  * Compile the image-blit shader for the given device.
  *
  * The WGSL source is embedded at build time from

--- a/donner/svg/renderer/geode/shaders/slug_fill_alpha_coverage.wgsl
+++ b/donner/svg/renderer/geode/shaders/slug_fill_alpha_coverage.wgsl
@@ -1,0 +1,272 @@
+// Alpha-coverage variant of the Slug fill shader.
+//
+// Identical to slug_fill.wgsl except:
+//   * FragOutput has no @builtin(sample_mask) — avoids a hang on Intel Arc
+//     (Mesa ANV / Xe KMD) when multiple band quads overlap at a pixel.
+//   * Coverage is instead folded into the output color as
+//     `color *= popcount(mask) / 4.0`, producing equivalent AA via alpha
+//     blending on a single-sample render target.
+//
+// This shader is selected at pipeline creation time when
+// `GeodeDevice::useAlphaCoverageAA()` returns true (Intel + Vulkan).
+// See slug_fill.wgsl for the full algorithm commentary.
+
+// ============================================================================
+// Uniforms
+// ============================================================================
+
+struct Uniforms {
+  mvp: mat4x4f,
+  patternFromPath: mat4x4f,
+  viewport: vec2f,
+  tileSize: vec2f,
+  color: vec4f,
+  fillRule: u32,
+  paintMode: u32,
+  patternOpacity: f32,
+  hasClipPolygon: u32,
+  hasClipMask: u32,
+  _pad0: u32,
+  _pad1: u32,
+  clipPolygonPlanes: array<vec4f, 4>,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+
+// ============================================================================
+// Storage buffers
+// ============================================================================
+
+struct Band {
+  curveStart: u32,
+  curveCount: u32,
+  yMin: f32,
+  yMax: f32,
+  xMin: f32,
+  xMax: f32,
+  _pad0: f32,
+  _pad1: f32,
+};
+
+@group(0) @binding(1) var<storage, read> bands: array<Band>;
+@group(0) @binding(2) var<storage, read> curveData: array<f32>;
+@group(0) @binding(3) var patternTexture: texture_2d<f32>;
+@group(0) @binding(4) var patternSampler: sampler;
+@group(0) @binding(5) var clipMaskTexture: texture_2d<f32>;
+@group(0) @binding(6) var clipMaskSampler: sampler;
+
+// ============================================================================
+// Vertex stage (identical to slug_fill.wgsl)
+// ============================================================================
+
+struct VertexInput {
+  @location(0) pos: vec2f,
+  @location(1) normal: vec2f,
+  @location(2) bandIndex: u32,
+};
+
+struct VertexOutput {
+  @builtin(position) clip_pos: vec4f,
+  @location(0) sample_pos: vec2f,
+  @location(1) @interpolate(flat) bandIndex: u32,
+};
+
+@vertex
+fn vs_main(in: VertexInput) -> VertexOutput {
+  let world_normal = (uniforms.mvp * vec4f(in.normal, 0.0, 0.0)).xy;
+  let viewport_normal = world_normal * uniforms.viewport * 0.5;
+  let viewport_len = length(viewport_normal);
+  let d = 1.0 / max(viewport_len, 0.001);
+
+  let dilated = in.pos + in.normal * d;
+
+  var out: VertexOutput;
+  out.clip_pos = uniforms.mvp * vec4f(dilated, 0.0, 1.0);
+  out.sample_pos = dilated;
+  out.bandIndex = in.bandIndex;
+  return out;
+}
+
+// ============================================================================
+// Quadratic Bézier ray intersection (identical to slug_fill.wgsl)
+// ============================================================================
+
+struct Quadratic {
+  p0: vec2f,
+  p1: vec2f,
+  p2: vec2f,
+};
+
+fn load_curve(index: u32) -> Quadratic {
+  let base = index * 6u;
+  var q: Quadratic;
+  q.p0 = vec2f(curveData[base + 0u], curveData[base + 1u]);
+  q.p1 = vec2f(curveData[base + 2u], curveData[base + 3u]);
+  q.p2 = vec2f(curveData[base + 4u], curveData[base + 5u]);
+  return q;
+}
+
+fn solve_quadratic(a: f32, b: f32, c: f32) -> vec2f {
+  var roots = vec2f(-1.0, -1.0);
+
+  if (abs(a) < 1e-4) {
+    if (abs(b) > 1e-6) {
+      let t = -c / b;
+      if (t >= 0.0 && t <= 1.0) {
+        roots.x = t;
+      }
+    }
+    return roots;
+  }
+
+  let disc = b * b - 4.0 * a * c;
+  if (disc < 0.0) {
+    return roots;
+  }
+
+  let sqrt_disc = sqrt(disc);
+  let inv_2a = 0.5 / a;
+  let t0 = (-b - sqrt_disc) * inv_2a;
+  let t1 = (-b + sqrt_disc) * inv_2a;
+
+  if (t0 >= 0.0 && t0 <= 1.0) {
+    roots.x = t0;
+  }
+  if (t1 >= 0.0 && t1 <= 1.0) {
+    roots.y = t1;
+  }
+  return roots;
+}
+
+fn curve_winding(curve: Quadratic, sample: vec2f) -> i32 {
+  let a = curve.p0.y - 2.0 * curve.p1.y + curve.p2.y;
+  let b = 2.0 * (curve.p1.y - curve.p0.y);
+  let c = curve.p0.y - sample.y;
+
+  let roots = solve_quadratic(a, b, c);
+
+  var winding: i32 = 0;
+  for (var i = 0; i < 2; i = i + 1) {
+    let t = select(roots.y, roots.x, i == 0);
+    if (t < 0.0) {
+      continue;
+    }
+
+    let omt = 1.0 - t;
+    let x = omt * omt * curve.p0.x + 2.0 * omt * t * curve.p1.x + t * t * curve.p2.x;
+    if (x < sample.x) {
+      continue;
+    }
+
+    let dy_dt = 2.0 * omt * (curve.p1.y - curve.p0.y) + 2.0 * t * (curve.p2.y - curve.p1.y);
+    if (dy_dt > 0.0) {
+      winding = winding + 1;
+    } else if (dy_dt < 0.0) {
+      winding = winding - 1;
+    }
+  }
+  return winding;
+}
+
+// ============================================================================
+// Fragment stage
+// ============================================================================
+
+fn sample_in_clip_polygon(pixel_pos: vec2f) -> bool {
+  if (uniforms.hasClipPolygon == 0u) {
+    return true;
+  }
+  for (var i = 0u; i < 4u; i = i + 1u) {
+    let plane = uniforms.clipPolygonPlanes[i];
+    if (plane.x * pixel_pos.x + plane.y * pixel_pos.y + plane.z < -1e-4) {
+      return false;
+    }
+  }
+  return true;
+}
+
+fn sample_is_inside(band: Band, sample_pos: vec2f) -> bool {
+  var winding: i32 = 0;
+  for (var i = 0u; i < band.curveCount; i = i + 1u) {
+    let curve = load_curve(band.curveStart + i);
+    winding = winding + curve_winding(curve, sample_pos);
+  }
+  if (uniforms.fillRule == 0u) {
+    return winding != 0;
+  }
+  return (winding & 1) != 0;
+}
+
+/// Alpha-coverage fragment output: no @builtin(sample_mask).
+/// Coverage is folded into color.a instead.
+struct FragOutput {
+  @location(0) color: vec4f,
+};
+
+@fragment
+fn fs_main(in: VertexOutput) -> FragOutput {
+  let band = bands[in.bandIndex];
+  let pixel_center = in.clip_pos.xy;
+
+  let dx = dpdx(in.sample_pos);
+  let dy = dpdy(in.sample_pos);
+
+  var offsets = array<vec2f, 4>(
+    vec2f(-0.125, -0.375),
+    vec2f( 0.375, -0.125),
+    vec2f(-0.375,  0.125),
+    vec2f( 0.125,  0.375),
+  );
+
+  var mask: u32 = 0u;
+  for (var s: u32 = 0u; s < 4u; s = s + 1u) {
+    let sp = in.sample_pos + offsets[s].x * dx + offsets[s].y * dy;
+    if (sp.y < band.yMin || sp.y >= band.yMax) {
+      continue;
+    }
+    let pixel_sample = pixel_center + offsets[s];
+    if (!sample_in_clip_polygon(pixel_sample)) {
+      continue;
+    }
+    if (sample_is_inside(band, sp)) {
+      mask = mask | (1u << s);
+    }
+  }
+
+  if (mask == 0u) {
+    discard;
+  }
+
+  // Convert the 4-bit sample mask into a fractional coverage value.
+  let coverage = f32(countOneBits(mask)) / 4.0;
+
+  var clipCoverage: f32 = 1.0;
+  if (uniforms.hasClipMask != 0u) {
+    let mask_uv = pixel_center / uniforms.viewport;
+    clipCoverage = clamp(textureSample(clipMaskTexture, clipMaskSampler, mask_uv).r,
+                         0.0, 1.0);
+    if (clipCoverage <= 0.0) {
+      discard;
+    }
+  }
+
+  var out: FragOutput;
+
+  if (uniforms.paintMode == 0u) {
+    // Scale premultiplied color by coverage (all 4 channels since premultiplied).
+    out.color = uniforms.color * coverage * clipCoverage;
+    return out;
+  }
+
+  // Pattern mode: sample the tile and scale by coverage.
+  let patternPos = (uniforms.patternFromPath * vec4f(in.sample_pos, 0.0, 1.0)).xy;
+  let wrapped = vec2f(
+    fract(patternPos.x / uniforms.tileSize.x) * uniforms.tileSize.x,
+    fract(patternPos.y / uniforms.tileSize.y) * uniforms.tileSize.y,
+  );
+  let uv = wrapped / uniforms.tileSize;
+  var sampled = textureSample(patternTexture, patternSampler, uv);
+  sampled = sampled * uniforms.patternOpacity * clipCoverage * coverage;
+  out.color = sampled;
+  return out;
+}

--- a/donner/svg/renderer/geode/shaders/slug_gradient_alpha_coverage.wgsl
+++ b/donner/svg/renderer/geode/shaders/slug_gradient_alpha_coverage.wgsl
@@ -1,0 +1,382 @@
+// Alpha-coverage variant of the Slug gradient-fill shader.
+//
+// Identical to slug_gradient.wgsl except:
+//   * FragOutput has no @builtin(sample_mask) — avoids a hang on Intel Arc
+//     (Mesa ANV / Xe KMD) when multiple band quads overlap at a pixel.
+//   * Coverage is instead folded into the output color as
+//     `color *= popcount(mask) / 4.0`, producing equivalent AA via alpha
+//     blending on a single-sample render target.
+//
+// This shader is selected at pipeline creation time when
+// `GeodeDevice::useAlphaCoverageAA()` returns true (Intel + Vulkan).
+// See slug_gradient.wgsl for the full algorithm commentary.
+
+// ============================================================================
+// Uniforms
+// ============================================================================
+
+const kMaxStops: u32 = 16u;
+const kGradientLinear: u32 = 0u;
+const kGradientRadial: u32 = 1u;
+
+struct GradientUniforms {
+  mvp: mat4x4f,
+  viewport: vec2f,
+  fillRule: u32,
+  spreadMode: u32,
+  row0: vec4f,
+  row1: vec4f,
+  startGrad: vec2f,
+  endGrad: vec2f,
+  radialCenter: vec2f,
+  radialFocal: vec2f,
+  radialRadius: f32,
+  radialFocalRadius: f32,
+  gradientKind: u32,
+  stopCount: u32,
+  stopColors: array<vec4f, kMaxStops>,
+  stopOffsets: array<vec4f, 4u>,
+  hasClipPolygon: u32,
+  hasClipMask: u32,
+  _clipPad1: u32,
+  _clipPad2: u32,
+  clipPolygonPlanes: array<vec4f, 4>,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: GradientUniforms;
+
+struct Band {
+  curveStart: u32,
+  curveCount: u32,
+  yMin: f32,
+  yMax: f32,
+  xMin: f32,
+  xMax: f32,
+  _pad0: f32,
+  _pad1: f32,
+};
+
+@group(0) @binding(1) var<storage, read> bands: array<Band>;
+@group(0) @binding(2) var<storage, read> curveData: array<f32>;
+@group(0) @binding(3) var clipMaskTexture: texture_2d<f32>;
+@group(0) @binding(4) var clipMaskSampler: sampler;
+
+// ============================================================================
+// Vertex stage (identical to slug_gradient.wgsl)
+// ============================================================================
+
+struct VertexInput {
+  @location(0) pos: vec2f,
+  @location(1) normal: vec2f,
+  @location(2) bandIndex: u32,
+};
+
+struct VertexOutput {
+  @builtin(position) clip_pos: vec4f,
+  @location(0) sample_pos: vec2f,
+  @location(1) @interpolate(flat) bandIndex: u32,
+};
+
+@vertex
+fn vs_main(in: VertexInput) -> VertexOutput {
+  let world_normal = (uniforms.mvp * vec4f(in.normal, 0.0, 0.0)).xy;
+  let viewport_normal = world_normal * uniforms.viewport * 0.5;
+  let viewport_len = length(viewport_normal);
+  let d = 1.0 / max(viewport_len, 0.001);
+
+  let dilated = in.pos + in.normal * d;
+
+  var out: VertexOutput;
+  out.clip_pos = uniforms.mvp * vec4f(dilated, 0.0, 1.0);
+  out.sample_pos = dilated;
+  out.bandIndex = in.bandIndex;
+  return out;
+}
+
+// ============================================================================
+// Quadratic Bézier ray intersection (shared with slug_gradient.wgsl)
+// ============================================================================
+
+struct Quadratic {
+  p0: vec2f,
+  p1: vec2f,
+  p2: vec2f,
+};
+
+fn load_curve(index: u32) -> Quadratic {
+  let base = index * 6u;
+  var q: Quadratic;
+  q.p0 = vec2f(curveData[base + 0u], curveData[base + 1u]);
+  q.p1 = vec2f(curveData[base + 2u], curveData[base + 3u]);
+  q.p2 = vec2f(curveData[base + 4u], curveData[base + 5u]);
+  return q;
+}
+
+fn solve_quadratic(a: f32, b: f32, c: f32) -> vec2f {
+  var roots = vec2f(-1.0, -1.0);
+
+  if (abs(a) < 1e-4) {
+    if (abs(b) > 1e-6) {
+      let t = -c / b;
+      if (t >= 0.0 && t <= 1.0) {
+        roots.x = t;
+      }
+    }
+    return roots;
+  }
+
+  let disc = b * b - 4.0 * a * c;
+  if (disc < 0.0) {
+    return roots;
+  }
+
+  let sqrt_disc = sqrt(disc);
+  let inv_2a = 0.5 / a;
+  let t0 = (-b - sqrt_disc) * inv_2a;
+  let t1 = (-b + sqrt_disc) * inv_2a;
+
+  if (t0 >= 0.0 && t0 <= 1.0) {
+    roots.x = t0;
+  }
+  if (t1 >= 0.0 && t1 <= 1.0) {
+    roots.y = t1;
+  }
+  return roots;
+}
+
+fn curve_winding(curve: Quadratic, sample: vec2f) -> i32 {
+  let a = curve.p0.y - 2.0 * curve.p1.y + curve.p2.y;
+  let b = 2.0 * (curve.p1.y - curve.p0.y);
+  let c = curve.p0.y - sample.y;
+
+  let roots = solve_quadratic(a, b, c);
+
+  var winding: i32 = 0;
+  for (var i = 0; i < 2; i = i + 1) {
+    let t = select(roots.y, roots.x, i == 0);
+    if (t < 0.0) {
+      continue;
+    }
+    let omt = 1.0 - t;
+    let x = omt * omt * curve.p0.x + 2.0 * omt * t * curve.p1.x + t * t * curve.p2.x;
+    if (x < sample.x) {
+      continue;
+    }
+    let dy_dt = 2.0 * omt * (curve.p1.y - curve.p0.y) + 2.0 * t * (curve.p2.y - curve.p1.y);
+    if (dy_dt > 0.0) {
+      winding = winding + 1;
+    } else if (dy_dt < 0.0) {
+      winding = winding - 1;
+    }
+  }
+  return winding;
+}
+
+// ============================================================================
+// Gradient evaluation (identical to slug_gradient.wgsl)
+// ============================================================================
+
+fn load_stop_offset(i: u32) -> f32 {
+  let vec_index = i / 4u;
+  let comp = i % 4u;
+  let v = uniforms.stopOffsets[vec_index];
+  if (comp == 0u) { return v.x; }
+  if (comp == 1u) { return v.y; }
+  if (comp == 2u) { return v.z; }
+  return v.w;
+}
+
+fn apply_spread(t: f32, mode: u32) -> f32 {
+  if (mode == 1u) {
+    var r = t - 2.0 * floor(t * 0.5);
+    if (r > 1.0) {
+      r = 2.0 - r;
+    }
+    return r;
+  }
+  if (mode == 2u) {
+    return t - floor(t);
+  }
+  return clamp(t, 0.0, 1.0);
+}
+
+fn sample_stops(t: f32) -> vec4f {
+  let count = uniforms.stopCount;
+  if (count == 0u) {
+    return vec4f(0.0, 0.0, 0.0, 0.0);
+  }
+  let firstOffset = load_stop_offset(0u);
+  if (t <= firstOffset) {
+    return uniforms.stopColors[0];
+  }
+  let lastOffset = load_stop_offset(count - 1u);
+  if (t >= lastOffset) {
+    return uniforms.stopColors[count - 1u];
+  }
+
+  for (var i: u32 = 1u; i < count; i = i + 1u) {
+    let o0 = load_stop_offset(i - 1u);
+    let o1 = load_stop_offset(i);
+    if (t <= o1) {
+      let span = max(o1 - o0, 1e-6);
+      let f = (t - o0) / span;
+      return mix(uniforms.stopColors[i - 1u], uniforms.stopColors[i], f);
+    }
+  }
+  return uniforms.stopColors[count - 1u];
+}
+
+fn gradient_space(path_pos: vec2f) -> vec2f {
+  let gx = uniforms.row0.x * path_pos.x + uniforms.row0.y * path_pos.y + uniforms.row0.z;
+  let gy = uniforms.row1.x * path_pos.x + uniforms.row1.y * path_pos.y + uniforms.row1.z;
+  return vec2f(gx, gy);
+}
+
+fn linear_t(gpos: vec2f) -> f32 {
+  let axis = uniforms.endGrad - uniforms.startGrad;
+  let axisLenSq = max(dot(axis, axis), 1e-12);
+  return dot(gpos - uniforms.startGrad, axis) / axisLenSq;
+}
+
+fn radial_t(gpos: vec2f) -> f32 {
+  let F = uniforms.radialFocal;
+  let C = uniforms.radialCenter;
+  let Fr = uniforms.radialFocalRadius;
+  let R = uniforms.radialRadius;
+
+  let e = gpos - F;
+  let d = C - F;
+  let Dr = R - Fr;
+
+  let A = dot(d, d) - Dr * Dr;
+  let B = dot(e, d) + Fr * Dr;
+  let Ce = dot(e, e) - Fr * Fr;
+
+  if (abs(A) < 1e-8) {
+    if (abs(B) < 1e-8) {
+      return 1.0;
+    }
+    return Ce / (2.0 * B);
+  }
+
+  let disc = B * B - A * Ce;
+  if (disc < 0.0) {
+    return 1e6;
+  }
+
+  let sqrtDisc = sqrt(disc);
+  let invA = 1.0 / A;
+  let t0 = (B - sqrtDisc) * invA;
+  let t1 = (B + sqrtDisc) * invA;
+
+  let r1 = Fr + t1 * Dr;
+  if (r1 >= 0.0) {
+    return t1;
+  }
+  let r0 = Fr + t0 * Dr;
+  if (r0 >= 0.0) {
+    return t0;
+  }
+  return 1e6;
+}
+
+fn gradient_t(path_pos: vec2f) -> f32 {
+  let gpos = gradient_space(path_pos);
+  if (uniforms.gradientKind == kGradientRadial) {
+    return radial_t(gpos);
+  }
+  return linear_t(gpos);
+}
+
+// ============================================================================
+// Fragment stage
+// ============================================================================
+
+fn sample_in_clip_polygon(pixel_pos: vec2f) -> bool {
+  if (uniforms.hasClipPolygon == 0u) {
+    return true;
+  }
+  for (var i = 0u; i < 4u; i = i + 1u) {
+    let plane = uniforms.clipPolygonPlanes[i];
+    if (plane.x * pixel_pos.x + plane.y * pixel_pos.y + plane.z < -1e-4) {
+      return false;
+    }
+  }
+  return true;
+}
+
+fn sample_is_inside(band: Band, sample_pos: vec2f) -> bool {
+  var winding: i32 = 0;
+  for (var i = 0u; i < band.curveCount; i = i + 1u) {
+    let curve = load_curve(band.curveStart + i);
+    winding = winding + curve_winding(curve, sample_pos);
+  }
+  if (uniforms.fillRule == 0u) {
+    return winding != 0;
+  }
+  return (winding & 1) != 0;
+}
+
+/// Alpha-coverage fragment output: no @builtin(sample_mask).
+/// Coverage is folded into color.a instead.
+struct FragOutput {
+  @location(0) color: vec4f,
+};
+
+@fragment
+fn fs_main(in: VertexOutput) -> FragOutput {
+  let band = bands[in.bandIndex];
+
+  let pixel_center = in.clip_pos.xy;
+
+  let dx = dpdx(in.sample_pos);
+  let dy = dpdy(in.sample_pos);
+
+  var offsets = array<vec2f, 4>(
+    vec2f(-0.125, -0.375),
+    vec2f( 0.375, -0.125),
+    vec2f(-0.375,  0.125),
+    vec2f( 0.125,  0.375),
+  );
+
+  var mask: u32 = 0u;
+  for (var s: u32 = 0u; s < 4u; s = s + 1u) {
+    let sp = in.sample_pos + offsets[s].x * dx + offsets[s].y * dy;
+    if (sp.y < band.yMin || sp.y >= band.yMax) {
+      continue;
+    }
+    let pixel_sample = pixel_center + offsets[s];
+    if (!sample_in_clip_polygon(pixel_sample)) {
+      continue;
+    }
+    if (sample_is_inside(band, sp)) {
+      mask = mask | (1u << s);
+    }
+  }
+
+  if (mask == 0u) {
+    discard;
+  }
+
+  // Convert the 4-bit sample mask into a fractional coverage value.
+  let coverage = f32(countOneBits(mask)) / 4.0;
+
+  var clipCoverage: f32 = 1.0;
+  if (uniforms.hasClipMask != 0u) {
+    let mask_uv = pixel_center / uniforms.viewport;
+    clipCoverage = clamp(textureSample(clipMaskTexture, clipMaskSampler, mask_uv).r,
+                         0.0, 1.0);
+    if (clipCoverage <= 0.0) {
+      discard;
+    }
+  }
+
+  let raw_t = gradient_t(in.sample_pos);
+  let t = apply_spread(raw_t, uniforms.spreadMode);
+  let straight = sample_stops(t);
+
+  var out: FragOutput;
+  // Premultiply straight-alpha gradient color, then scale by coverage.
+  out.color = vec4f(straight.rgb * straight.a, straight.a) * clipCoverage * coverage;
+  return out;
+}

--- a/donner/svg/renderer/geode/shaders/slug_mask_alpha_coverage.wgsl
+++ b/donner/svg/renderer/geode/shaders/slug_mask_alpha_coverage.wgsl
@@ -1,0 +1,228 @@
+// Alpha-coverage variant of the Slug mask shader.
+//
+// Identical to slug_mask.wgsl except:
+//   * FragOutput has no @builtin(sample_mask) — avoids a hang on Intel Arc
+//     (Mesa ANV / Xe KMD) when multiple band quads overlap at a pixel.
+//   * Coverage is instead folded into the R channel as
+//     `popcount(mask) / 4.0`, producing equivalent fractional-alpha mask
+//     values on a single-sample R8Unorm render target.
+//
+// This shader is selected at pipeline creation time when
+// `GeodeDevice::useAlphaCoverageAA()` returns true (Intel + Vulkan).
+// See slug_mask.wgsl for the full algorithm commentary.
+
+// ============================================================================
+// Uniforms
+// ============================================================================
+
+struct Uniforms {
+  mvp: mat4x4f,
+  viewport: vec2f,
+  fillRule: u32,
+  hasClipMask: u32,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+
+// ============================================================================
+// Storage buffers
+// ============================================================================
+
+struct Band {
+  curveStart: u32,
+  curveCount: u32,
+  yMin: f32,
+  yMax: f32,
+  xMin: f32,
+  xMax: f32,
+  _pad0: f32,
+  _pad1: f32,
+};
+
+@group(0) @binding(1) var<storage, read> bands: array<Band>;
+@group(0) @binding(2) var<storage, read> curveData: array<f32>;
+@group(0) @binding(3) var clipMaskTexture: texture_2d<f32>;
+@group(0) @binding(4) var clipMaskSampler: sampler;
+
+// ============================================================================
+// Vertex stage (identical to slug_mask.wgsl)
+// ============================================================================
+
+struct VertexInput {
+  @location(0) pos: vec2f,
+  @location(1) normal: vec2f,
+  @location(2) bandIndex: u32,
+};
+
+struct VertexOutput {
+  @builtin(position) clip_pos: vec4f,
+  @location(0) sample_pos: vec2f,
+  @location(1) @interpolate(flat) bandIndex: u32,
+};
+
+@vertex
+fn vs_main(in: VertexInput) -> VertexOutput {
+  let world_normal = (uniforms.mvp * vec4f(in.normal, 0.0, 0.0)).xy;
+  let viewport_normal = world_normal * uniforms.viewport * 0.5;
+  let viewport_len = length(viewport_normal);
+  let d = 1.0 / max(viewport_len, 0.001);
+
+  let dilated = in.pos + in.normal * d;
+
+  var out: VertexOutput;
+  out.clip_pos = uniforms.mvp * vec4f(dilated, 0.0, 1.0);
+  out.sample_pos = dilated;
+  out.bandIndex = in.bandIndex;
+  return out;
+}
+
+// ============================================================================
+// Quadratic Bézier ray intersection (shared with slug_mask.wgsl)
+// ============================================================================
+
+struct Quadratic {
+  p0: vec2f,
+  p1: vec2f,
+  p2: vec2f,
+};
+
+fn load_curve(index: u32) -> Quadratic {
+  let base = index * 6u;
+  var q: Quadratic;
+  q.p0 = vec2f(curveData[base + 0u], curveData[base + 1u]);
+  q.p1 = vec2f(curveData[base + 2u], curveData[base + 3u]);
+  q.p2 = vec2f(curveData[base + 4u], curveData[base + 5u]);
+  return q;
+}
+
+fn solve_quadratic(a: f32, b: f32, c: f32) -> vec2f {
+  var roots = vec2f(-1.0, -1.0);
+
+  if (abs(a) < 1e-4) {
+    if (abs(b) > 1e-6) {
+      let t = -c / b;
+      if (t >= 0.0 && t <= 1.0) {
+        roots.x = t;
+      }
+    }
+    return roots;
+  }
+
+  let disc = b * b - 4.0 * a * c;
+  if (disc < 0.0) {
+    return roots;
+  }
+
+  let sqrt_disc = sqrt(disc);
+  let inv_2a = 0.5 / a;
+  let t0 = (-b - sqrt_disc) * inv_2a;
+  let t1 = (-b + sqrt_disc) * inv_2a;
+
+  if (t0 >= 0.0 && t0 <= 1.0) {
+    roots.x = t0;
+  }
+  if (t1 >= 0.0 && t1 <= 1.0) {
+    roots.y = t1;
+  }
+  return roots;
+}
+
+fn curve_winding(curve: Quadratic, sample: vec2f) -> i32 {
+  let a = curve.p0.y - 2.0 * curve.p1.y + curve.p2.y;
+  let b = 2.0 * (curve.p1.y - curve.p0.y);
+  let c = curve.p0.y - sample.y;
+
+  let roots = solve_quadratic(a, b, c);
+
+  var winding: i32 = 0;
+  for (var i = 0; i < 2; i = i + 1) {
+    let t = select(roots.y, roots.x, i == 0);
+    if (t < 0.0) {
+      continue;
+    }
+    let omt = 1.0 - t;
+    let x = omt * omt * curve.p0.x + 2.0 * omt * t * curve.p1.x + t * t * curve.p2.x;
+    if (x < sample.x) {
+      continue;
+    }
+    let dy_dt = 2.0 * omt * (curve.p1.y - curve.p0.y) + 2.0 * t * (curve.p2.y - curve.p1.y);
+    if (dy_dt > 0.0) {
+      winding = winding + 1;
+    } else if (dy_dt < 0.0) {
+      winding = winding - 1;
+    }
+  }
+  return winding;
+}
+
+fn sample_is_inside(band: Band, sample_pos: vec2f) -> bool {
+  var winding: i32 = 0;
+  for (var i = 0u; i < band.curveCount; i = i + 1u) {
+    let curve = load_curve(band.curveStart + i);
+    winding = winding + curve_winding(curve, sample_pos);
+  }
+  if (uniforms.fillRule == 0u) {
+    return winding != 0;
+  }
+  return (winding & 1) != 0;
+}
+
+// ============================================================================
+// Fragment stage
+// ============================================================================
+
+/// Alpha-coverage fragment output: no @builtin(sample_mask).
+/// Coverage is folded into the R channel instead.
+struct FragOutput {
+  @location(0) color: vec4f,
+};
+
+@fragment
+fn fs_main(in: VertexOutput) -> FragOutput {
+  let band = bands[in.bandIndex];
+
+  let pixel_center = in.clip_pos.xy;
+
+  let dx = dpdx(in.sample_pos);
+  let dy = dpdy(in.sample_pos);
+
+  var offsets = array<vec2f, 4>(
+    vec2f(-0.125, -0.375),
+    vec2f( 0.375, -0.125),
+    vec2f(-0.375,  0.125),
+    vec2f( 0.125,  0.375),
+  );
+
+  var mask: u32 = 0u;
+  for (var s: u32 = 0u; s < 4u; s = s + 1u) {
+    let sp = in.sample_pos + offsets[s].x * dx + offsets[s].y * dy;
+    if (sp.y < band.yMin || sp.y >= band.yMax) {
+      continue;
+    }
+    if (sample_is_inside(band, sp)) {
+      mask = mask | (1u << s);
+    }
+  }
+
+  if (mask == 0u) {
+    discard;
+  }
+
+  // Convert the 4-bit sample mask into a fractional coverage value.
+  let coverage = f32(countOneBits(mask)) / 4.0;
+
+  var clipCoverage: f32 = 1.0;
+  if (uniforms.hasClipMask != 0u) {
+    let mask_uv = pixel_center / uniforms.viewport;
+    clipCoverage = clamp(textureSample(clipMaskTexture, clipMaskSampler, mask_uv).r,
+                         0.0, 1.0);
+    if (clipCoverage <= 0.0) {
+      discard;
+    }
+  }
+
+  var out: FragOutput;
+  // Red-channel coverage, scaled by nested clip mask and sample coverage.
+  out.color = vec4f(clipCoverage * coverage, 0.0, 0.0, 1.0);
+  return out;
+}

--- a/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
@@ -32,9 +32,10 @@ class GeoEncoderTest : public ::testing::Test {
     device_ = GeodeDevice::CreateHeadless();
     ASSERT_NE(device_, nullptr);
 
-    pipeline_ = std::make_unique<GeodePipeline>(device_->device(), kFormat);
-    gradientPipeline_ =
-        std::make_unique<GeodeGradientPipeline>(device_->device(), kFormat);
+    pipeline_ = std::make_unique<GeodePipeline>(device_->device(), kFormat,
+                                                device_->useAlphaCoverageAA());
+    gradientPipeline_ = std::make_unique<GeodeGradientPipeline>(
+        device_->device(), kFormat, device_->useAlphaCoverageAA());
     imagePipeline_ = std::make_unique<GeodeImagePipeline>(device_->device(), kFormat);
 
     wgpu::TextureDescriptor td = {};


### PR DESCRIPTION
## Bug

On Intel Arc A380 (DG2) + Mesa 25.2.8 Xe-KMD Vulkan, Geode tests producing paths with `bandCount >= 2` hang forever. Single-band paths pass fine. The hang occurs regardless of MSAA sample count.

**Repro:** `DrawRectGreenFill` (rect 8,8→56,56 = 48px tall = 2 bands) hangs; `DrawPathWithSolidFill` (rect 16,16→48,48 = 32px tall = 1 band) passes.

## Phase 1: MSAA falsified

Prior investigation confirmed the hang correlates with `ceil(pathHeight/32) >= 2` (multi-band), NOT with MSAA on/off. Disabling MSAA entirely (`multisample.count = 1`) caused a **different** hang on all draws — another Intel driver issue.

## Phase 2: Experiment 1 localized the cause

Removing `@builtin(sample_mask)` output from the fragment shaders resolved the hang. The root cause: when overlapping band quads (from half-pixel dilation) produce two fragment invocations at the same pixel, both writing `sample_mask` deadlocks Mesa ANV / Xe KMD on Intel Arc.

## Phase 3: Fix — alpha-coverage AA gate

**Vendor gate:** `vendorID == 0x8086 && backendType == WGPUBackendType_Vulkan` → `GeodeDevice::useAlphaCoverageAA() == true`.

**Shader change:** Three new alpha-coverage WGSL shader variants (`slug_fill_alpha_coverage.wgsl`, `slug_gradient_alpha_coverage.wgsl`, `slug_mask_alpha_coverage.wgsl`) that differ from the originals only in:
- No `@builtin(sample_mask)` in `FragOutput`
- Coverage computed as `f32(countOneBits(mask)) / 4.0`
- Fragment color scaled by coverage (premultiplied, all 4 channels)
- `mask == 0u → discard` check preserved

**Pipeline:** `multisample.count` stays at 4 (changing to 1 triggers a separate Intel driver hang). All 4 MSAA samples receive the same coverage-scaled color → MSAA resolve averages identical values → correct result with slight VRAM overhead from unused per-sample storage.

**Selection:** Pipeline constructors accept `bool useAlphaCoverageShader`; the flag propagates from `GeodeDevice::useAlphaCoverageAA()` through `RendererGeode`, `GeoEncoder`, and test fixtures.

## Validation on real Arc A380 hardware

| Test | Bands | Before | After |
|------|-------|--------|-------|
| `GeoEncoderTest.FillTriangle` | 2 | HANG | PASS (56ms) |
| `RendererGeodeTest.DrawRectGreenFill` | 2 | HANG | PASS (228ms) |
| `RendererGeodeTest.DrawPathWithSolidFill` | 1 | PASS | PASS (232ms) |
| `GeoEncoderTest.FillRect` | 1 | PASS | PASS (55ms) |
| All GeoEncoder gradient tests | 2 | HANG | PASS (~55ms each) |
| Default-config (TinySkia) tests | — | PASS | PASS |

## Known issues (separate from this PR)

1. **Sequential device creation hang:** Intel Arc hangs after creating 3+ WebGPU devices in one process. This is a driver resource leak unrelated to `sample_mask` — affects test suite runs with >2 tests. Individual tests are reliable.
2. **Image pipeline hang:** `DrawImageHonorsOpacity` hangs — the image blit shader never used `sample_mask`, so this is a separate Intel driver issue.

## Mesa upstream context

The `@builtin(sample_mask)` hang is expected to be fixed in Mesa 25.3. The vendor gate can be removed once CI Mesa crosses that version.

## Follow-ups

- [ ] Golden images may need regeneration once CI gets Arc hardware (alpha-coverage AA produces slightly different edge pixels)
- [ ] Remove vendor gate once Mesa 25.3+ is validated
- [ ] Investigate sequential device creation hang (separate Intel driver issue)
- [ ] Investigate image pipeline hang on Intel Arc (separate issue)