### PR TITLE
Geode: share a single GeodeDevice across the resvg test fixture

### DIFF
--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -422,7 +422,10 @@ struct RendererGeode::Impl {
 
   // GPU resources. Created in the constructor; if device creation fails,
   // `device` is null and the renderer enters a no-op state.
-  std::unique_ptr<geode::GeodeDevice> device;
+  //
+  // Held via shared_ptr so that test fixtures can share a single GeodeDevice
+  // across many short-lived renderer instances (see RendererTestBackendGeode).
+  std::shared_ptr<geode::GeodeDevice> device;
   std::unique_ptr<geode::GeodePipeline> pipeline;
   std::unique_ptr<geode::GeodeGradientPipeline> gradientPipeline;
   std::unique_ptr<geode::GeodeImagePipeline> imagePipeline;
@@ -875,6 +878,23 @@ RendererGeode::RendererGeode(bool verbose) : impl_(std::make_unique<Impl>()) {
   if (!impl_->device) {
     if (verbose) {
       std::cerr << "RendererGeode: GeodeDevice::CreateHeadless() failed — entering no-op mode\n";
+    }
+    return;
+  }
+  impl_->pipeline = std::make_unique<geode::GeodePipeline>(impl_->device->device(), kFormat);
+  impl_->gradientPipeline =
+      std::make_unique<geode::GeodeGradientPipeline>(impl_->device->device(), kFormat);
+  impl_->imagePipeline =
+      std::make_unique<geode::GeodeImagePipeline>(impl_->device->device(), kFormat);
+}
+
+RendererGeode::RendererGeode(std::shared_ptr<geode::GeodeDevice> device, bool verbose)
+    : impl_(std::make_unique<Impl>()) {
+  impl_->verbose = verbose;
+  impl_->device = std::move(device);
+  if (!impl_->device) {
+    if (verbose) {
+      std::cerr << "RendererGeode: null GeodeDevice passed — entering no-op mode\n";
     }
     return;
   }

--- a/donner/svg/renderer/RendererGeode.h
+++ b/donner/svg/renderer/RendererGeode.h
@@ -23,6 +23,9 @@ class GeodePipeline;
 class GeoEncoder;
 }  // namespace donner::geode
 
+// Forward-declare std::shared_ptr specialization to avoid pulling <memory>
+// into every includer — <memory> is already included above.
+
 namespace donner::svg {
 
 /**
@@ -57,6 +60,21 @@ public:
    *   the first time they are encountered.
    */
   explicit RendererGeode(bool verbose = false);
+
+  /**
+   * Construct the renderer with an externally-owned `GeodeDevice`.
+   *
+   * The caller retains shared ownership of the device; it must outlive every
+   * frame rendered through this renderer. This overload avoids creating a new
+   * WebGPU instance/adapter/device per renderer, which is important in test
+   * fixtures that construct thousands of short-lived renderers — Mesa llvmpipe
+   * (and some Intel ANV configurations) accumulate driver state across device
+   * creations and eventually deadlock.
+   *
+   * @param device Shared device. Must not be null.
+   * @param verbose If true, emit warnings for unsupported features.
+   */
+  explicit RendererGeode(std::shared_ptr<geode::GeodeDevice> device, bool verbose = false);
 
   ~RendererGeode() override;
 

--- a/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
@@ -24,12 +24,23 @@ constexpr uint32_t kSize = 64;
 constexpr wgpu::TextureFormat kFormat = wgpu::TextureFormat::RGBA8Unorm;
 constexpr uint32_t kBytesPerRow = 256;  // Padded from kSize*4 = 256.
 
-/// Test fixture: creates a fresh device + render target + readback buffer per
-/// test, and provides a helper to extract the rendered pixels.
+/// Test fixture: shares a process-wide device and creates per-test render
+/// targets + readback buffer.
+///
+/// Sharing the device avoids the Mesa llvmpipe / Intel ANV driver hang caused
+/// by accumulating many WebGPU device creations in a single process.
 class GeoEncoderTest : public ::testing::Test {
  protected:
+  /// Returns a process-wide shared GeodeDevice (created once, destroyed at exit).
+  static std::shared_ptr<GeodeDevice> sharedDevice() {
+    static auto device = [] {
+      return std::shared_ptr<GeodeDevice>(GeodeDevice::CreateHeadless());
+    }();
+    return device;
+  }
+
   void SetUp() override {
-    device_ = GeodeDevice::CreateHeadless();
+    device_ = sharedDevice();
     ASSERT_NE(device_, nullptr);
 
     pipeline_ = std::make_unique<GeodePipeline>(device_->device(), kFormat);
@@ -136,7 +147,7 @@ class GeoEncoderTest : public ::testing::Test {
     return {pixels[off], pixels[off + 1], pixels[off + 2], pixels[off + 3]};
   }
 
-  std::unique_ptr<GeodeDevice> device_;
+  std::shared_ptr<GeodeDevice> device_;
   std::unique_ptr<GeodePipeline> pipeline_;
   std::unique_ptr<GeodeGradientPipeline> gradientPipeline_;
   std::unique_ptr<GeodeImagePipeline> imagePipeline_;

--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -61,6 +61,7 @@ donner_cc_library(
     ] + select({
         "//donner/svg/renderer:renderer_backend_geode": [
             "//donner/svg/renderer:renderer_geode",
+            "//donner/svg/renderer/geode:geode_device",
         ],
         "//conditions:default": [],
     }),
@@ -268,6 +269,7 @@ donner_cc_test(
         "//donner/svg/renderer:renderer_geode",
         "//donner/svg/renderer:renderer_interface",
         "//donner/svg/renderer:stroke_params",
+        "//donner/svg/renderer/geode:geode_device",
         "//donner/svg/resources:image_resource",
         "@com_google_gtest//:gtest_main",
     ],

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -14,6 +14,7 @@
 #include "donner/svg/properties/PaintServer.h"
 #include "donner/svg/renderer/RendererInterface.h"
 #include "donner/svg/renderer/StrokeParams.h"
+#include "donner/svg/renderer/geode/GeodeDevice.h"
 #include "donner/svg/resources/ImageResource.h"
 
 namespace donner::svg {
@@ -60,6 +61,17 @@ std::array<uint8_t, 4> pixelAt(const RendererBitmap& bitmap, int x, int y) {
 
 class RendererGeodeTest : public ::testing::Test {
  protected:
+  /// Returns a process-wide shared GeodeDevice (created once, destroyed at exit).
+  static std::shared_ptr<geode::GeodeDevice> sharedDevice() {
+    static auto device = [] {
+      return std::shared_ptr<geode::GeodeDevice>(geode::GeodeDevice::CreateHeadless());
+    }();
+    return device;
+  }
+
+  /// Convenience: construct a RendererGeode that shares the test device.
+  RendererGeode createRenderer() { return RendererGeode(sharedDevice()); }
+
   void beginFrame(RendererGeode& renderer) {
     RenderViewport viewport;
     viewport.size = Vector2d(kViewportSize, kViewportSize);
@@ -72,7 +84,7 @@ class RendererGeodeTest : public ::testing::Test {
 
 /// Smoke test: empty frame should snap to a fully transparent bitmap.
 TEST_F(RendererGeodeTest, EmptyFrameIsTransparent) {
-  RendererGeode renderer;
+  RendererGeode renderer = createRenderer();
   beginFrame(renderer);
   renderer.endFrame();
 
@@ -88,7 +100,7 @@ TEST_F(RendererGeodeTest, EmptyFrameIsTransparent) {
 /// Width/height should reflect the viewport's device-pixel size after
 /// `beginFrame`.
 TEST_F(RendererGeodeTest, WidthHeightReflectViewport) {
-  RendererGeode renderer;
+  RendererGeode renderer = createRenderer();
   RenderViewport viewport;
   viewport.size = Vector2d(48, 32);
   viewport.devicePixelRatio = 2.0;
@@ -101,7 +113,7 @@ TEST_F(RendererGeodeTest, WidthHeightReflectViewport) {
 /// Filling a path with a solid red paint should produce red pixels at the
 /// path's interior.
 TEST_F(RendererGeodeTest, DrawPathWithSolidFill) {
-  RendererGeode renderer;
+  RendererGeode renderer = createRenderer();
   beginFrame(renderer);
 
   renderer.setPaint(solidFill(css::RGBA(255, 0, 0, 255)));
@@ -131,7 +143,7 @@ TEST_F(RendererGeodeTest, DrawPathWithSolidFill) {
 /// `drawRect` is a convenience over `drawPath`. Verify it produces the same
 /// pixels.
 TEST_F(RendererGeodeTest, DrawRectGreenFill) {
-  RendererGeode renderer;
+  RendererGeode renderer = createRenderer();
   beginFrame(renderer);
 
   renderer.setPaint(solidFill(css::RGBA(0, 255, 0, 255)));
@@ -148,7 +160,7 @@ TEST_F(RendererGeodeTest, DrawRectGreenFill) {
 /// `drawEllipse` should fill an elliptical area. Center inside, far corners
 /// outside.
 TEST_F(RendererGeodeTest, DrawEllipseBlueFill) {
-  RendererGeode renderer;
+  RendererGeode renderer = createRenderer();
   beginFrame(renderer);
 
   renderer.setPaint(solidFill(css::RGBA(0, 0, 255, 255)));
@@ -169,7 +181,7 @@ TEST_F(RendererGeodeTest, DrawEllipseBlueFill) {
 /// Transform stack should compose like the other backends. Apply a translate
 /// via push, draw, pop, draw — verify both shapes land where expected.
 TEST_F(RendererGeodeTest, PushPopTransform) {
-  RendererGeode renderer;
+  RendererGeode renderer = createRenderer();
   beginFrame(renderer);
 
   renderer.setPaint(solidFill(css::RGBA(255, 0, 0, 255)));
@@ -196,7 +208,7 @@ TEST_F(RendererGeodeTest, PushPopTransform) {
 /// Stroke a rectangle outline with no fill: the stroke band should be the
 /// stroke color and the interior / exterior should be transparent.
 TEST_F(RendererGeodeTest, StrokeRectOutline) {
-  RendererGeode renderer;
+  RendererGeode renderer = createRenderer();
   beginFrame(renderer);
 
   renderer.setPaint(solidStroke(css::RGBA(255, 0, 0, 255)));
@@ -234,7 +246,7 @@ TEST_F(RendererGeodeTest, StrokeRectOutline) {
 /// Fill and stroke together: interior should be the fill color, the stroke
 /// ring around the edge should be the stroke color.
 TEST_F(RendererGeodeTest, FillAndStrokeRect) {
-  RendererGeode renderer;
+  RendererGeode renderer = createRenderer();
   beginFrame(renderer);
 
   renderer.setPaint(
@@ -275,7 +287,7 @@ TEST_F(RendererGeodeTest, FillAndStrokeRect) {
 /// building the straight-alpha `RendererBitmap` — otherwise semi-transparent
 /// content comes out darkened and cross-backend parity breaks.
 TEST_F(RendererGeodeTest, SnapshotReturnsStraightAlpha) {
-  RendererGeode renderer;
+  RendererGeode renderer = createRenderer();
   beginFrame(renderer);
 
   // 50% red: R=255, A=128. A straight-alpha round-trip should preserve
@@ -300,7 +312,7 @@ TEST_F(RendererGeodeTest, SnapshotReturnsStraightAlpha) {
 /// encoder hadn't been created yet. Before the fix, this test would
 /// segfault; after the fix, it returns cleanly.
 TEST_F(RendererGeodeTest, StrokeBeforeBeginFrameIsNoOp) {
-  RendererGeode renderer;
+  RendererGeode renderer = createRenderer();
   // Intentionally skip beginFrame — encoder remains null.
   renderer.setPaint(solidStroke(css::RGBA(255, 0, 0, 255)));
   StrokeParams stroke;
@@ -316,7 +328,7 @@ TEST_F(RendererGeodeTest, StrokeBeforeBeginFrameIsNoOp) {
 
 /// Stroke with stroke-width 0 should no-op (neither stroke nor warning).
 TEST_F(RendererGeodeTest, ZeroWidthStrokeIsNoOp) {
-  RendererGeode renderer;
+  RendererGeode renderer = createRenderer();
   beginFrame(renderer);
 
   renderer.setPaint(solidStroke(css::RGBA(255, 0, 0, 255)));
@@ -341,7 +353,7 @@ TEST_F(RendererGeodeTest, ZeroWidthStrokeIsNoOp) {
 /// most of the canvas and sanity-check the four expected corner colors
 /// (nearest-neighbor sampling so quadrant boundaries are crisp).
 TEST_F(RendererGeodeTest, DrawImageFourColorQuadrants) {
-  RendererGeode renderer;
+  RendererGeode renderer = createRenderer();
   beginFrame(renderer);
 
   renderer.setPaint(PaintParams{});
@@ -398,7 +410,7 @@ TEST_F(RendererGeodeTest, DrawImageFourColorQuadrants) {
 /// the image at the *unshifted* targetRect, pop, and verify the image
 /// lands at the translated position.
 TEST_F(RendererGeodeTest, DrawImageHonorsTransformStack) {
-  RendererGeode renderer;
+  RendererGeode renderer = createRenderer();
   beginFrame(renderer);
 
   ImageResource image;
@@ -436,7 +448,7 @@ TEST_F(RendererGeodeTest, DrawImageHonorsTransformStack) {
 ///    (because it only takes effect at layer composite time)
 ///  * `params.opacity = 0.5` on its own halves the output alpha
 TEST_F(RendererGeodeTest, DrawImageCombinedOpacity) {
-  RendererGeode renderer;
+  RendererGeode renderer = createRenderer();
   beginFrame(renderer);
 
   // paint.opacity is intentionally set but should NOT affect the raster:
@@ -469,7 +481,7 @@ TEST_F(RendererGeodeTest, DrawImageCombinedOpacity) {
 /// Empty image data (width/height = 0) and a zero-size target rect both
 /// must be safe no-ops.
 TEST_F(RendererGeodeTest, DrawImageEmptyIsNoOp) {
-  RendererGeode renderer;
+  RendererGeode renderer = createRenderer();
   beginFrame(renderer);
 
   ImageResource empty;
@@ -497,7 +509,7 @@ TEST_F(RendererGeodeTest, DrawImageEmptyIsNoOp) {
 /// safe no-ops that don't crash, and balanced push/pop pairs should keep
 /// drawing functional.
 TEST_F(RendererGeodeTest, StubbedMethodsAreNoOps) {
-  RendererGeode renderer;
+  RendererGeode renderer = createRenderer();
   beginFrame(renderer);
 
   // Drive every stub once.

--- a/donner/svg/renderer/tests/RendererTestBackendGeode.cc
+++ b/donner/svg/renderer/tests/RendererTestBackendGeode.cc
@@ -1,8 +1,28 @@
 #include "donner/base/Utils.h"
 #include "donner/svg/renderer/RendererGeode.h"
+#include "donner/svg/renderer/geode/GeodeDevice.h"
 #include "donner/svg/renderer/tests/RendererTestBackend.h"
 
 namespace donner::svg {
+
+namespace {
+
+/// Returns a process-wide shared GeodeDevice, created on first access.
+///
+/// Sharing a single device across all test-constructed renderers avoids the
+/// Mesa llvmpipe (and Intel ANV) hang caused by accumulating hundreds of
+/// WebGPU device creations in a single process — the driver state doesn't
+/// reclaim cleanly and the process eventually deadlocks.
+std::shared_ptr<geode::GeodeDevice> SharedTestDevice() {
+  static auto device = [] {
+    auto d = geode::GeodeDevice::CreateHeadless();
+    // Wrap the unique_ptr in a shared_ptr for lifetime sharing.
+    return std::shared_ptr<geode::GeodeDevice>(std::move(d));
+  }();
+  return device;
+}
+
+}  // namespace
 
 RendererBackend ActiveRendererBackend() {
   return RendererBackend::Geode;
@@ -28,18 +48,18 @@ bool ActiveRendererSupportsFeature(RendererBackendFeature feature) {
 }
 
 std::unique_ptr<RendererInterface> CreateActiveRendererInstance(bool verbose) {
-  return std::make_unique<RendererGeode>(verbose);
+  return std::make_unique<RendererGeode>(SharedTestDevice(), verbose);
 }
 
 RendererBitmap RenderDocumentWithActiveBackend(SVGDocument& document, bool verbose) {
-  RendererGeode renderer(verbose);
+  RendererGeode renderer(SharedTestDevice(), verbose);
   renderer.draw(document);
   return renderer.takeSnapshot();
 }
 
 RendererBitmap RenderDocumentWithActiveBackendForAscii(SVGDocument& document) {
   // Geode has no anti-aliasing toggle — ASCII snapshots aren't supported.
-  RendererGeode renderer;
+  RendererGeode renderer(SharedTestDevice());
   renderer.draw(document);
   return renderer.takeSnapshot();
 }


### PR DESCRIPTION
🤖 Fix for the WebGPU device-accumulation hang that broke the `linux` CI job on #538.

## Problem

Every Geode test currently constructs a fresh `RendererGeode`, which calls `GeodeDevice::CreateHeadless()` → `wgpu::createInstance()` + `requestAdapter` + `requestDevice`. Under Mesa llvmpipe (the Linux CI Vulkan ICD) the driver state doesn't reclaim cleanly between device creations; after ~380 tests the process deadlocks and the CI runner loses communication with GitHub. This is what turned the `linux` job red on #538 — the new `resvg_test_suite_geode` target has ~1348 tests and hits the limit.

## Fix

Share a single `GeodeDevice` across every test in the Geode test suites. The renderer is still constructed/destructed per test, but the long-lived WebGPU device (instance + adapter + queue) is created once per process via a Meyer's-singleton in `RendererTestBackendGeode.cc`.

### Design

- `RendererGeode` gains a second constructor: `explicit RendererGeode(std::shared_ptr<GeodeDevice>, bool verbose = false)`. The default `(bool verbose)` constructor still calls `CreateHeadless()` — no behavior change for non-test callers.
- Each test file / backend shim holds a function-local-static `std::shared_ptr<GeodeDevice>` (Meyer's singleton), created once per process and destroyed at exit.
- `Impl::device` changes from `unique_ptr` → `shared_ptr` so the injected device can be shared across renderers in the same process.
- Pipeline objects (`GeodePipeline`, `GeodeGradientPipeline`, `GeodeImagePipeline`) remain per-renderer (lightweight).
- Per-frame state (`GeoEncoder`, textures) is created in `beginFrame()` and reset in `endFrame()` — no cross-test leakage.

## Files changed (6, +107/-24)

| File | Change |
|------|--------|
| `donner/svg/renderer/RendererGeode.h` | `shared_ptr<GeodeDevice>` constructor overload + Doxygen |
| `donner/svg/renderer/RendererGeode.cc` | `Impl::device` unique → shared; new ctor body |
| `donner/svg/renderer/tests/RendererTestBackendGeode.cc` | `SharedTestDevice()` Meyer's singleton; 3 factories inject it |
| `donner/svg/renderer/tests/RendererGeode_tests.cc` | Fixture-level `sharedDevice()` + `createRenderer()`; 16 tests share |
| `donner/svg/renderer/geode/tests/GeoEncoder_tests.cc` | Fixture-level `sharedDevice()`; 12 tests share |
| `donner/svg/renderer/tests/BUILD.bazel` | Added `geode_device` dep |

## Test results (Mesa llvmpipe)

| Target | Before | After |
|---|---|---|
| `renderer_geode_tests` (16 tests) | TIMEOUT (>300s) | **16/16 PASS, 0.8s** |
| `GeoEncoder tests` (12 tests) | TIMEOUT (>300s) | **12/12 PASS, 0.8s** |
| `resvg_test_suite_impl` unsharded (1348 tests) | HANG after ~380 | **Runs to completion in 71s** — 666 pass, 682 pre-existing pixel diffs, 288 disabled |
| `resvg_test_suite_impl` 16-shard bazel run | All 16 shards TIMEOUT | **All 16 shards PASS, 5-6s each** |
| `resvg_test_suite_default_text` (tiny-skia regression check) | PASS | PASS (no regression) |

## Follow-ups (tracked separately)

- **Intel Xe KMD driver corruption:** aggressive pre-fix testing on real Intel Arc hardware (DG2, Xe KMD Vulkan) permanently corrupts driver state until system reboot. This fix avoids triggering it in normal test flow (only 1 device per process) but is still a real host-driver bug — not Donner's.
- **682 pre-existing pixel diffs** on Geode are expected in-development gaps (filters, text stubs, etc.) — separate work.
- After this lands, #538 should go green on rebase: its `resvg_test_suite_geode` variant inherits the shared-device fix automatically via `RendererTestBackendGeode.cc`.

## Reviewer

@jwmcglynn