### PR TITLE
Bazel: hermetic Linux sysroot for remote execution

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -54,6 +54,17 @@ common:latest_llvm --extra_toolchains=@llvm_toolchain//:all
 common:latest_llvm --//build_defs:llvm_latest=1
 # Disable warning about not eliding copy on return (NRVO), which started triggering in skia on LLVM 21
 build:latest_llvm --copt=-Wno-nrvo
+# Use rules_python's hermetic Python launcher rather than the default
+# `#!/usr/bin/env python3` shebang. Without this, py_binary targets still rely
+# on a host python3 in PATH, which the Bazel remote-execution sandbox
+# (bazel-re1, NixOS) does not provide.
+common:latest_llvm --@rules_python//python/config_settings:bootstrap_impl=script
+# Disable V8's JIT in the emscripten Node runtime. bazel-re1's NativeLink
+# sandbox forbids creating executable memory pages (W+X), so V8 aborts with
+# SIGTRAP in `OS::SetPermissions` the moment it tries to baseline-compile
+# anything. `--jitless` keeps Node in the interpreter-only mode, which
+# emscripten's `compiler.mjs` is happy with.
+common:latest_llvm --action_env=NODE_OPTIONS=--jitless
 
 # Renderer backend selection
 common:skia --//donner/svg/renderer:renderer_backend=skia

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -50,6 +50,8 @@ use_repo(
     "harfbuzz",
     "resvg-test-suite",
     "skia",
+    "sysroot_linux_aarch64",
+    "sysroot_linux_x86_64",
     "tracy",
     "wgpu_native_linux_aarch64",
     "wgpu_native_linux_x86_64",
@@ -157,6 +159,20 @@ llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm", 
 llvm.toolchain(
     name = "llvm_toolchain",
     llvm_version = "21.1.6",
+)
+
+# Hermetic Linux sysroots: keep the toolchain self-contained on Bazel
+# remote-execution workers (bazel-re1, NixOS) that lack system glibc
+# headers. See third_party/bazel/non_bcr_deps.bzl for the tarballs.
+llvm.sysroot(
+    name = "llvm_toolchain",
+    targets = ["linux-aarch64"],
+    label = "@sysroot_linux_aarch64//:sysroot",
+)
+llvm.sysroot(
+    name = "llvm_toolchain",
+    targets = ["linux-x86_64"],
+    label = "@sysroot_linux_x86_64//:sysroot",
 )
 use_repo(llvm, "llvm_toolchain", "llvm_toolchain_llvm")
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -142,6 +142,21 @@ new_local_repository(
 
 bazel_dep(name = "rules_python", version = "1.9.0", dev_dependency = True)
 
+# Hermetic Python toolchain. Without this, rules_python's py_binary targets
+# fall back to `/usr/bin/env python3` on the host — which is fine for local
+# dev on dev1, but on the Bazel remote-execution sandbox (NixOS) no such
+# host interpreter is available. Registering `python.toolchain()` makes
+# rules_python ship a prebuilt CPython through the action cache so RE
+# workers execute the same interpreter as local builds.
+python = use_extension(
+    "@rules_python//python/extensions:python.bzl",
+    "python",
+    dev_dependency = True,
+)
+python.defaults(python_version = "3.12")
+python.toolchain(python_version = "3.12")
+use_repo(python, "python_3_12")
+
 #
 # Toolchain
 #

--- a/build_defs/BUILD.bazel
+++ b/build_defs/BUILD.bazel
@@ -73,3 +73,13 @@ config_setting(
         ":llvm_latest": "1",
     },
 )
+
+config_setting(
+    name = "llvm_latest_linux",
+    constraint_values = [
+        "@platforms//os:linux",
+    ],
+    flag_values = {
+        ":llvm_latest": "1",
+    },
+)

--- a/build_defs/rules.bzl
+++ b/build_defs/rules.bzl
@@ -69,6 +69,23 @@ def llvm21_macos_workaround_linkopts():
         "//conditions:default": [],
     })
 
+def libc_compat_deps():
+    """
+    Returns extra deps needed when linking against the hermetic LLVM toolchain
+    on Linux.
+
+    Chromium's Debian Bullseye sysroot (wired into `llvm_toolchain` via
+    `//third_party/bazel/non_bcr_deps.bzl`) exports `copy_file_range@GLIBC_2.27`
+    as a non-default-versioned symbol, so unversioned references from
+    `toolchains_llvm`'s prebuilt libc++.a don't auto-resolve. The tiny shim in
+    `//third_party/libc_compat` provides an unversioned `copy_file_range`
+    that forwards to the versioned glibc entry point.
+    """
+    return select({
+        "//build_defs:llvm_latest_linux": ["//third_party/libc_compat:libc_compat"],
+        "//conditions:default": [],
+    })
+
 def fuzzer_compatible_with():
     """
     Returns a list of labels that the fuzzer rules are compatible with.
@@ -307,7 +324,7 @@ def donner_variant_cc_test(name, dep, variants = None, named_variants = None, **
         testonly = 1,
     )
 
-def donner_cc_binary(name, srcs = [], linkopts = [], tags = [], **kwargs):
+def donner_cc_binary(name, srcs = [], linkopts = [], deps = [], tags = [], **kwargs):
     """
     Create a cc_binary with donner-specific defaults including LLVM 21 workaround.
 
@@ -315,6 +332,7 @@ def donner_cc_binary(name, srcs = [], linkopts = [], tags = [], **kwargs):
       name: Rule name.
       srcs: Source files.
       linkopts: List of linker options.
+      deps: List of dependencies.
       tags: Tags.
       **kwargs: Additional arguments, matching the implementation of cc_binary.
     """
@@ -322,6 +340,7 @@ def donner_cc_binary(name, srcs = [], linkopts = [], tags = [], **kwargs):
         name = name,
         srcs = srcs,
         linkopts = linkopts + llvm21_macos_workaround_linkopts(),
+        deps = deps + libc_compat_deps(),
         tags = tags,
         **kwargs
     )
@@ -333,7 +352,7 @@ def donner_cc_binary(name, srcs = [], linkopts = [], tags = [], **kwargs):
         tags = tags,
     )
 
-def donner_cc_test(name, srcs = [], linkopts = [], tags = [], **kwargs):
+def donner_cc_test(name, srcs = [], linkopts = [], deps = [], tags = [], **kwargs):
     """
     Create a cc_test with donner-specific defaults including LLVM 21 workaround.
 
@@ -341,6 +360,7 @@ def donner_cc_test(name, srcs = [], linkopts = [], tags = [], **kwargs):
       name: Rule name.
       srcs: Source files.
       linkopts: List of linker options.
+      deps: List of dependencies.
       tags: Tags.
       **kwargs: Additional arguments, matching the implementation of cc_test.
     """
@@ -348,6 +368,7 @@ def donner_cc_test(name, srcs = [], linkopts = [], tags = [], **kwargs):
         name = name,
         srcs = srcs,
         linkopts = linkopts + llvm21_macos_workaround_linkopts(),
+        deps = deps + libc_compat_deps(),
         tags = tags,
         **kwargs
     )
@@ -407,13 +428,14 @@ def donner_cc_library(name, srcs = [], hdrs = [], copts = [], tags = [], visibil
         tags = tags,
     )
 
-def donner_cc_fuzzer(name, corpus, **kwargs):
+def donner_cc_fuzzer(name, corpus, deps = [], **kwargs):
     """
     Create a libfuzzer-based fuzz target.
 
     Args:
       name: Rule name.
       corpus: Path to a corpus directory, or a filegroup rule for the corpus.
+      deps: List of dependencies.
       **kwargs: Additional arguments, matching the implementation of cc_test.
     """
     if not (corpus.startswith("//") or corpus.startswith(":")):
@@ -438,6 +460,7 @@ def donner_cc_fuzzer(name, corpus, **kwargs):
         name = name + "_bin",
         linkopts = fuzzer_linkopts,
         linkstatic = 1,
+        deps = deps + libc_compat_deps(),
         target_compatible_with = fuzzer_compatible_with(),
         tags = ["fuzz_target"],
         **kwargs
@@ -451,6 +474,7 @@ def donner_cc_fuzzer(name, corpus, **kwargs):
             "-timeout=2",
         ],
         linkstatic = 1,
+        deps = deps,
         target_compatible_with = fuzzer_compatible_with(),
         size = "large",
         data = select({
@@ -466,6 +490,7 @@ def donner_cc_fuzzer(name, corpus, **kwargs):
         linkopts = fuzzer_linkopts,
         args = ["$(locations %s)" % corpus_name],
         linkstatic = 1,
+        deps = deps,
         data = [corpus_name] + select({
             "@platforms//os:macos": ["@llvm_toolchain//:linker-components-aarch64-darwin"],
             "//conditions:default": [],

--- a/third_party/bazel/non_bcr_deps.bzl
+++ b/third_party/bazel/non_bcr_deps.bzl
@@ -15,6 +15,10 @@ shipped over BCR:
 - tracy           : In-process profiling client (//donner/editor only — see check_banned_patterns.py)
 - resvg-test-suite: Reference SVG goldens       (image comparison tests)
 - bazel_clang_tidy: clang-tidy aspect           (--config=clang-tidy)
+- sysroot_linux_*: Hermetic Debian Bullseye sysroots for Bazel remote execution
+                   (--config=re). Wired into the `llvm_toolchain` via its
+                   `sysroot` parameter so RE workers without glibc headers
+                   can still compile.
 
 When / how to add a new non-BCR dep:
   1. If the dep is load-bearing for the default tiny-skia + text-base build,
@@ -160,6 +164,60 @@ HBEOF""",
         name = "bazel_clang_tidy",
         commit = "c4d35e0d0b838309358e57a2efed831780f85cd0",
         remote = "https://github.com/erenon/bazel_clang_tidy.git",
+    )
+
+    # Hermetic Linux sysroots for Bazel remote execution via `--config=re`.
+    #
+    # The RE worker on bazel-re1 (NixOS) has no system glibc headers, so
+    # libc++'s <wchar.h> can't find `mbstate_t`. Chromium's prebuilt
+    # Debian Bullseye sysroots give the LLVM toolchain a complete set of
+    # C/C++ headers + runtime stubs to link against, keeping the build
+    # hermetic regardless of what the RE host does (or does not) install.
+    #
+    # Sourced from https://commondatastorage.googleapis.com/chrome-linux-sysroot
+    # (URL + "/" + Sha256Sum; see Chromium's build/linux/sysroot_scripts/
+    # install-sysroot.py). Bump by pulling the latest sysroots.json from
+    # chromium/src and updating both the sha256 + URL fragment.
+    # Exclude non-toolchain subtrees (docs, locale data, systemd units, etc.)
+    # so the filegroup is both smaller and skips files whose names contain
+    # characters Bazel rejects as target names — `lib/systemd/system/` ships
+    # escape-sequence filenames like `system-systemd\x2dcryptsetup.slice`
+    # that trip `glob()`.
+    _SYSROOT_BUILD_FILE = """\
+filegroup(
+    name = "sysroot",
+    srcs = glob(
+        include = ["**"],
+        exclude = [
+            "etc/**",
+            "lib/systemd/**",
+            "usr/lib/systemd/**",
+            "usr/share/doc/**",
+            "usr/share/info/**",
+            "usr/share/locale/**",
+            "usr/share/man/**",
+            "var/**",
+            "**/* *",
+        ],
+    ),
+    visibility = ["//visibility:public"],
+)
+"""
+    http_archive(
+        name = "sysroot_linux_x86_64",
+        build_file_content = _SYSROOT_BUILD_FILE,
+        sha256 = "52d61d4446ffebfaa3dda2cd02da4ab4876ff237853f46d273e7f9b666652e1d",
+        # GCS serves the archive at a bare sha256 path with no extension, so
+        # Bazel can't infer the format — pin `type` explicitly.
+        type = "tar.xz",
+        urls = ["https://commondatastorage.googleapis.com/chrome-linux-sysroot/52d61d4446ffebfaa3dda2cd02da4ab4876ff237853f46d273e7f9b666652e1d"],
+    )
+    http_archive(
+        name = "sysroot_linux_aarch64",
+        build_file_content = _SYSROOT_BUILD_FILE,
+        sha256 = "c7176a4c7aacbf46bda58a029f39f79a68008d3dee6518f154dcf5161a5486d8",
+        type = "tar.xz",
+        urls = ["https://commondatastorage.googleapis.com/chrome-linux-sysroot/c7176a4c7aacbf46bda58a029f39f79a68008d3dee6518f154dcf5161a5486d8"],
     )
 
 non_bcr_deps = module_extension(

--- a/third_party/libc_compat/BUILD.bazel
+++ b/third_party/libc_compat/BUILD.bazel
@@ -1,0 +1,22 @@
+"""Per-target glibc compatibility shims for the hermetic LLVM toolchain.
+
+See libc_compat.c for the full rationale. This target is injected as an
+implicit `deps` entry by `donner_cc_binary/test/fuzzer` whenever the build is
+using the latest LLVM toolchain on Linux (`--config=latest_llvm`, which
+`--config=re` pulls in transitively).
+"""
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "libc_compat",
+    srcs = ["libc_compat.c"],
+    # Must be linked into the final executable even when nothing visibly
+    # references it from our code — libc++.a is the consumer.
+    alwayslink = True,
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    visibility = ["//visibility:public"],
+)

--- a/third_party/libc_compat/libc_compat.c
+++ b/third_party/libc_compat/libc_compat.c
@@ -1,0 +1,31 @@
+// Compatibility shim for Chromium's Debian Bullseye sysroot + hermetic LLVM
+// toolchain (see //third_party/bazel/non_bcr_deps.bzl).
+//
+// The sysroot ships libc.so.6 with `copy_file_range@GLIBC_2.27` marked as a
+// non-default version (single `@`, not `@@`), so unversioned references from
+// toolchains_llvm's prebuilt libc++.a — specifically
+// std::__fs::filesystem::detail::copy_file_impl in operations.cpp — don't
+// auto-resolve at link time. Every other glibc symbol libc++ depends on is
+// already default-versioned, so this is a one-symbol fix rather than a
+// broader ABI mismatch.
+//
+// This shim defines `copy_file_range` as an ordinary symbol in our own code,
+// pointed at the versioned glibc entry point via `.symver`. The linker picks
+// up our definition, libc++ is happy, and the call forwards to glibc at
+// runtime.
+
+#if defined(__linux__) && !defined(__APPLE__)
+
+#include <sys/types.h>
+
+extern ssize_t donner_libc_compat_copy_file_range(int, off_t *, int, off_t *,
+                                                  size_t, unsigned int);
+__asm__(".symver donner_libc_compat_copy_file_range,copy_file_range@GLIBC_2.27");
+
+ssize_t copy_file_range(int fd_in, off_t *off_in, int fd_out, off_t *off_out,
+                        size_t len, unsigned int flags) {
+  return donner_libc_compat_copy_file_range(fd_in, off_in, fd_out, off_out,
+                                            len, flags);
+}
+
+#endif


### PR DESCRIPTION
## Summary

Unblock Bazel remote execution (`--config=re`) against bazel-re1 end-to-end. Four fixes land together because neither the sysroot nor the follow-ups are individually sufficient — RE was hitting a different wall at each layer (compile → link → py_binary → emcc).

1. **Hermetic Linux sysroot.** Wire Chromium's prebuilt Debian Bullseye x86_64/aarch64 sysroots into `llvm_toolchain` via `llvm.sysroot(...)` so libc++'s `<wchar.h>` can find glibc's `mbstate_t`. Extension keys the tarballs under `non_bcr_deps` (dev-only, BCR consumers never see them). `http_archive` uses `type = "tar.xz"` because the GCS URLs are bare-sha256 paths with no extension. Filegroup excludes `etc/`, `lib/systemd/`, `var/`, and a few `usr/share/*` subtrees — systemd units use escape-sequence filenames that Bazel can't represent as target names.
2. **libc++ `copy_file_range` shim.** Chromium's bullseye_arm64 sysroot exports `copy_file_range@GLIBC_2.27` as a *non*-default-versioned symbol (single `@`, not `@@`), so unversioned refs from `toolchains_llvm` 21.1.6's prebuilt libc++.a (in `std::__fs::filesystem::detail::copy_file_impl`) don't auto-resolve. Scanned libc++.a's 457 undefined refs against the sysroot's 70 non-default glibc symbols — `copy_file_range` is the only intersection, so a single-symbol shim suffices. `//third_party/libc_compat` provides an unversioned `copy_file_range` that forwards to the versioned glibc via `.symver`, injected as an implicit dep by `donner_cc_binary/test/fuzzer` via `libc_compat_deps()` selected on `//build_defs:llvm_latest_linux`. Keeps LLVM at 21.1.6.
3. **Hermetic Python toolchain.** Register a `rules_python` Python 3.12 toolchain in `MODULE.bazel` and set `bootstrap_impl=script` under `--config=latest_llvm` so py_binary's stage-1 launcher invokes the hermetic interpreter through the runfiles tree instead of falling through the `#!/usr/bin/env python3` shebang. Without this, `//tools:generate_embedded_test_resources` fails on the RE sandbox with `env: 'python3': Permission denied`.
4. **Emscripten/V8 jitless.** NativeLink's RE sandbox forbids W+X memory pages, so `emcc`'s bundled Node.js V8 crashes with SIGTRAP in `OS::SetPermissions` the moment it tries to baseline-compile `compiler.mjs`. `--action_env=NODE_OPTIONS=--jitless` keeps Node in interpreter-only mode; emscripten is happy with it.

## Sysroot provenance

| arch | sha256 | size |
| --- | --- | --- |
| `debian_bullseye_amd64_sysroot.tar.xz` | `52d61d4446ffebfaa3dda2cd02da4ab4876ff237853f46d273e7f9b666652e1d` | ~19.7 MB |
| `debian_bullseye_arm64_sysroot.tar.xz` | `c7176a4c7aacbf46bda58a029f39f79a68008d3dee6518f154dcf5161a5486d8` | ~18.4 MB |

URL = `https://commondatastorage.googleapis.com/chrome-linux-sysroot/<sha256>`, per Chromium's [`build/linux/sysroot_scripts/install-sysroot.py`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/build/linux/sysroot_scripts/install-sysroot.py).

## Test plan

- [x] `bazel build --config=latest_llvm //donner/base:base` — local hermetic LLVM build works with the new sysroot (~243 s cold).
- [x] `bazel test --config=latest_llvm //donner/base:base_tests` — local test binary (uses `std::filesystem`) links *and* passes at runtime, proving the libc++ shim forwards correctly.
- [x] `bazel build --config=re //donner/base:base` — RE leaf build, warm 14 s.
- [x] `bazel build --config=re //...` — **full validation, green**, against `grpcs://192.168.1.83:50051`:
      ```
      INFO: Elapsed time: 1923.516s, Critical Path: 327.92s
      INFO: 4798 processes: 6602 action cache hit, 2 disk cache hit,
        1 remote cache hit, 826 internal, 3969 remote.
      INFO: Build completed successfully, 4798 total actions
      ```
      ~32 min wall, 3,969 remote executions on bazel-re1.

🤖 Authored with Claude Code.