### PR TITLE
Geode perf: M2 path-encode cache + M4.2 transient-texture pool

### DIFF
--- a/docs/design_docs/0030-geode_performance.md
+++ b/docs/design_docs/0030-geode_performance.md
@@ -170,8 +170,13 @@ algorithm.
   - [x] Tightened Milestone 0 counter ceilings in `GeodePerf_tests.cc`:
     Lion `bufferCreates` ceiling now 10 (down from 800); Lion
     `bindgroupCreates` ceiling stays 200 pending M1.f.2.
-- [ ] Milestone 2: `GeodePathCacheComponent` — cache the CPU encode
-  (Tier 3 findings, maps to 0017 Phase 5 bullet 1).
+- [x] Milestone 2: `GeodePathCacheComponent` — cache the CPU encode
+  (Tier 3 findings, maps to 0017 Phase 5 bullet 1). _Landed
+  2026-04-20._ Observed frame-2 `pathEncodes` deltas:
+  SimpleShapes 3→0, Moderate 2→0, Lion 132→0,
+  Ghostscript_Tiger 305→0. GPU-arena-handle retention (original
+  bullet 3) deferred to a follow-up PR; `<use>` instancing
+  stays on Milestone 6.
   - Cache only the final `EncodedPath`, not the intermediate
     `quadPath` / `monotonicPath`. The intermediate stages are fused
     inside `GeodePathEncoder::encode` and retaining them buys

--- a/docs/design_docs/0030-geode_performance.md
+++ b/docs/design_docs/0030-geode_performance.md
@@ -305,20 +305,34 @@ algorithm.
   - [x] Counter delta: Moderate (1 `<g opacity>` layer) drops from
     `submits=4` → `submits=2` (frame + readback). Ceiling tightened
     in `GeodePerf_tests.cc`.
-- [ ] Milestone 4: Transient render-target pool (Tier 2 findings).
+- [x] Milestone 4: Transient render-target pool (Tier 2 findings).
+  _Landed 2026-04-20 (M4.2)._
   - [x] M4.1: Reuse `impl_->target` and `impl_->msaaTarget` across frames
     when `pixelWidth`/`pixelHeight` are unchanged. _Landed 2026-04-19._
     Tracks `impl_->targetWidth`/`impl_->targetHeight` in Impl; beginFrame
     only recreates when the new viewport size differs. The
     `CountersResetBetweenFrames` test gates this with
     `EXPECT_LT(secondCounters.textureCreates, firstCounters.textureCreates)`.
-  - [ ] Size-bucketed free list for layer/filter/mask scratch textures:
-    round (w,h) up to the next power of two per axis, key on
-    `(bucket_w, bucket_h, format, sampleCount)`, recycle on pop/endFrame.
-    Covers `pushIsolatedLayer` (`:1328`), `pushFilterLayer` (`:1506`),
-    `pushMask` (`:1611`), `pushClip` mask layers (`:1255`).
-  - [ ] Counter ceiling: `texture_creates == 0` on a repeat-render of the
-    same document at the same size.
+  - [x] M4.2: exact-size `(width, height, format, sampleCount, usage)`
+    pool on `RendererGeode::Impl` covering `pushIsolatedLayer` /
+    `popIsolatedLayer` (including the mix-blend-mode `dstSnapshot`),
+    `pushFilterLayer` / `popFilterLayer`, `pushMask` / `popMask`, and
+    the clip-mask layers allocated by `pushClip`. Release is deferred
+    to `endFrame` (after `queue.submit`) so recorded GPU work
+    completes before a subsequent acquire hands the texture back out.
+    Observed frame-2 `textureCreates` deltas:
+    SimpleShapes 2→0, Moderate (with isolated layer) 8→0,
+    Lion 2→0, Ghostscript_Tiger 2→0. Power-of-two size bucketing
+    (for viewport-resize scenarios) remains a follow-up.
+  - [x] Prerequisite to M4.2: share the two GeoEncoder bind-group
+    dummy resources (1×1 RGBA8 pattern + 1×1 R8Unorm clip mask, plus
+    views and samplers) on `GeodeDevice`. Prior to this, every
+    push/pop encoder allocated its own pair; this alone dropped
+    per-frame `textureCreates` by 2 on simple fixtures and by 6+ on
+    layered ones.
+  - [x] Counter ceiling: `texture_creates == 0` on a repeat-render of
+    the same document at the same size. Asserted by
+    `{SimpleShapes,Moderate,Lion,GhostscriptTiger}_NoDirtyPath_ZeroTextures`.
 - [ ] Milestone 5: Filter engine caching (Tier 5 findings).
   - [ ] Swap `std::unordered_map<std::string, wgpu::Texture> namedBuffers`
     in `GeodeFilterEngine::execute` (`GeodeFilterEngine.cc:964`) for an

--- a/docs/design_docs/0030-geode_performance.md
+++ b/docs/design_docs/0030-geode_performance.md
@@ -172,21 +172,114 @@ algorithm.
     `bindgroupCreates` ceiling stays 200 pending M1.f.2.
 - [ ] Milestone 2: `GeodePathCacheComponent` — cache the CPU encode
   (Tier 3 findings, maps to 0017 Phase 5 bullet 1).
-  - [ ] Define `GeodePathCacheComponent` carrying `EncodedPath` +
-    `quadPath` + `monotonicPath` (or just the final encode; decide based on
-    whether stroke/dash parameters change more than geometry).
-  - [ ] Install on path entities at `RenderingContext`-instantiation time;
-    invalidate from `IncrementalInvalidationSystem` dirty flags (see
-    `docs/design_docs/0005-incremental_invalidation.md`) — fall back to
-    re-encode when the dirty bit is set.
-  - [ ] Extend the cache to also own the GPU-resident handles into the
-    vertex/band/curve arenas from Milestone 1 so cached paths re-use
-    their upload, not just the CPU bytes.
-  - [ ] Cache `strokeToFill` output on stroked paths (keyed by stroke
-    parameters) — the call at `RendererGeode.cc:2028` is as expensive
-    as encode and currently runs every frame.
-  - [ ] Counter ceiling: `path_encodes == 0` on a frame where no path
-    dirty flag is set, for `lion.svg` and `Ghostscript_Tiger.svg`.
+  - Cache only the final `EncodedPath`, not the intermediate
+    `quadPath` / `monotonicPath`. The intermediate stages are fused
+    inside `GeodePathEncoder::encode` and retaining them buys
+    nothing on a pure re-render (geometry didn't change) while
+    costing extra memory per path. The stroke slot caches the
+    `strokeToFill` output path alongside its encode, since both are
+    derived from the same stroke-key inputs.
+  - **Entity plumbing.** Widen `RendererInterface::drawPath` to
+    carry an `EntityHandle` so the encode sites can look up the
+    cache component on the source entity. Touches three
+    implementations (`RendererGeode`, `RendererTinySkia`,
+    `MockRendererInterface`) and the three `renderer_.drawPath()`
+    call sites in `RendererDriver::traverseRange()` (lines 928,
+    1373, 1667). Entity is already in scope at those call sites
+    (`view.currentEntity()` at `RendererDriver.cc:818`). Non-Geode
+    implementations ignore the new parameter.
+  - **ShapeSystem content-equality gate (prerequisite).**
+    Today, `ShapeSystem::instantiateAllComputedPaths`
+    (`ShapeSystem.cc:191-204`) iterates every shape in the
+    registry and calls `emplace_or_replace<ComputedPathComponent>`
+    unconditionally — it does not per-entity-gate on the
+    `DirtyFlags::Shape` bit. That means if any single entity is
+    dirty, every shape's `ComputedPathComponent` is rewritten,
+    which would invalidate every cached encode. Fix before M2
+    caches anything: at each of the 8 write sites under
+    `createComputedShapeWithStyle(...)` overloads
+    (`ShapeSystem.cc:294,317,334,355,365,391,423,429`), compare
+    the newly built `Path` to the existing `ComputedPathComponent::spline`
+    (via `try_get`). If equal, return the existing component
+    without calling `emplace_or_replace`. Requires a new
+    `Path::operator==` in `donner/base/Path.h` (members:
+    `commands_`, `points_`). This is a standalone CPU-side perf
+    win (skips downstream work keyed on the write) and — most
+    importantly — makes entt's `on_update<ComputedPathComponent>`
+    signal a precise "geometry actually changed" edge.
+  - **Invalidation via entt `on_update` signal.** In
+    `RendererGeode::Impl`, connect listeners on
+    `registry.on_update<ComputedPathComponent>()` and
+    `on_destroy<ComputedPathComponent>()`. Listener:
+    `registry.remove<GeodePathCacheComponent>(entity)`. entt
+    signals are synchronous, so the wipe happens in-band with the
+    write. No polling, no dirty-flag cascade reasoning. Ctor
+    connects; dtor disconnects via stored
+    `entt::scoped_connection`s.
+  - **Component layout.** Under
+    `donner/svg/renderer/geode/GeodePathCacheComponent.h`:
+
+    ```cpp
+    struct GeodePathCacheComponent {
+      std::optional<EncodedPath> fillEncode;
+      struct StrokeSlot {
+        StrokeStyle strokeKey;               // equality-keyed on stroke inputs
+        Path strokedPath;                    // strokeToFill output
+        EncodedPath strokedEncode;
+      };
+      std::optional<StrokeSlot> strokeSlot;
+    };
+    ```
+
+    Installed lazily via `registry.get_or_emplace` at the Geode
+    encode call sites — keeps the component Geode-local, so
+    `RendererTinySkia` pays no storage cost.
+  - **Cache hit path.** At each encode site
+    (`GeoEncoder::submitFillDraw`, `fillPathLinearGradient`,
+    `fillPathRadialGradient`, `fillPathIntoMask`) the encoder
+    receives the entity handle and takes the fast path:
+
+    ```
+    if (auto* cache = registry.try_get<GeodePathCacheComponent>(entity);
+        cache && cache->fillEncode.has_value()) {
+      // hit — reuse cached EncodedPath, skip encode + countPathEncode.
+    } else {
+      encode(); store into cache->fillEncode;
+    }
+    ```
+
+    `countPathEncode()` is *only* called on miss, so the counter
+    gates the test assertion directly.
+  - **Stroke slot.** Keyed by `StrokeStyle ==`. Geometry changes
+    wipe the whole `GeodePathCacheComponent` via the entt signal
+    above, so the stroke slot is implicitly invalidated too.
+    Stroke-only changes (stroke width/dash/cap/join via CSS)
+    don't fire the signal — but they do change `StrokeStyle`, so
+    the equality check on the existing stroke slot misses and
+    causes a regenerate. Decoupled storage means fill changes
+    don't pay for re-strokeToFill and vice versa.
+  - **Deferred to a follow-up PR:**
+    - GPU-resident arena handle retention (original M2 bullet 3):
+      caching the vertex/band/curve offsets from M1's persistent
+      arenas so cached paths also skip re-upload. Requires arena
+      generation-stamping so cached offsets invalidate when the
+      arena grows or recycles. Separate PR.
+    - Batching duplicate `<use>` instances onto a single cached
+      encode via instanced draws — tracked in M6.
+  - **Test plan (repro-first per `CLAUDE.md` debugging discipline).**
+    Added to `donner/svg/renderer/geode/tests/GeodePerf_tests.cc`:
+    - `Lion_NoDirtyPath_ZeroEncodes` — render twice, assert
+      `counters.pathEncodes == 0` on frame 2.
+    - `GhostscriptTiger_NoDirtyPath_ZeroEncodes` — same shape on
+      Ghostscript_Tiger.svg.
+    - `Lion_OneGeometryChange_OneEncode` — mutate one path's `d`,
+      assert exactly one re-encode (stretch: only the changed
+      path's encode fires).
+    Tests land red (pathEncodes > 0 on frame 2) before any
+    implementation.
+  - **Counter ceiling after M2:** `pathEncodes == 0` on a no-change
+    frame for `lion.svg` and `Ghostscript_Tiger.svg`, tightened
+    from the M0 observed baselines (Lion frame-1 pathEncodes=132).
 - [x] Milestone 3: Single-encoder-per-frame (Tier 2 findings).
   _Landed 2026-04-19._
   - [x] `GeoEncoder` gained a shared-CommandEncoder constructor

--- a/docs/design_docs/0030-geode_performance.md
+++ b/docs/design_docs/0030-geode_performance.md
@@ -126,11 +126,26 @@ algorithm.
     M1.f.2 for the follow-up that collapses `bindgroupCreates` too.
   - [ ] M1.f.2: `hasDynamicOffset = true` bind-group layouts +
     cached-per-pipeline bind group. Drops `bindgroupCreates` to O(1)
-    per pipeline per frame. Requires coordinated changes to
-    `GeodePipeline`, `GeodeGradientPipeline`, `GeodeMaskPipeline`
-    layout definitions and arena-invalidation tracking so the cached
-    bind group rebuilds on arena growth. Deferred — big-enough change
-    to warrant its own PR.
+    per pipeline per frame.
+    - **Investigation 2026-04-19 (abandoned, not shipped):** an
+      initial implementation with `hasDynamicOffset = true` on the
+      uniform / bands / curves bindings + a signature-tracked
+      per-pipeline bind-group cache reached `bindgroupCreates`
+      132 → 5 on Lion. However, multi-draw fixtures (`Rect2`,
+      `Ellipse1`, `QuadBezier`, `Polyline`) rendered with
+      300-2000-pixel differences against goldens — even with the
+      cache bypassed. The corruption is in the dynamic-offset
+      plumbing itself, not the caching logic. Reverted.
+    - Hypotheses to investigate on the next attempt: (a) the
+      bind-group entry `size` field interacts with WGSL uniform-block
+      layout differently than expected when `size != sizeof(struct)`;
+      (b) `queue.writeBuffer` followed by a dynamic-offset bind in
+      the same frame may have an ordering/visibility issue on
+      wgpu-native Metal; (c) storage-buffer dynamic offsets may
+      require a per-slot synchronization barrier we're not emitting.
+      Next attempt should enable wgpu-native validation trace mode
+      and capture a frame with Metal GPU Capture (Xcode) to confirm
+      the actual reads.
   - [x] Delete the redundant `pass.setPipeline` at `GeoEncoder.cc:942`.
     _Landed 2026-04-19._ `submitFillDraw` now relies on
     `bindSolidPipeline` for state tracking — previously the explicit

--- a/donner/base/Path.h
+++ b/donner/base/Path.h
@@ -383,6 +383,15 @@ public:
   /// Ostream output operator.
   friend std::ostream& operator<<(std::ostream& os, const Path& path);
 
+  /// Value equality. Two paths compare equal iff their command verb /
+  /// point-index sequences and point arrays are bitwise-equal. Used as an
+  /// invalidation edge by `ShapeSystem` to suppress redundant
+  /// `ComputedPathComponent` rewrites when shape attributes recompute to
+  /// the same geometry (design doc 0030 Milestone 2).
+  bool operator==(const Path& other) const {
+    return commands_ == other.commands_ && points_ == other.points_;
+  }
+
 private:
   friend class PathBuilder;
 

--- a/donner/base/Path.h
+++ b/donner/base/Path.h
@@ -50,10 +50,10 @@ inline std::ostream& operator<<(std::ostream& os, LineJoin join) {
 
 /// Parameters for converting a stroked path to a filled outline.
 struct StrokeStyle {
-  double width = 1.0;          ///< Stroke width.
-  LineCap cap = LineCap::Butt;     ///< Line cap style for open subpath endpoints.
+  double width = 1.0;               ///< Stroke width.
+  LineCap cap = LineCap::Butt;      ///< Line cap style for open subpath endpoints.
   LineJoin join = LineJoin::Miter;  ///< Line join style for corners between segments.
-  double miterLimit = 4.0;     ///< Maximum miter length ratio (as per SVG stroke-miterlimit).
+  double miterLimit = 4.0;          ///< Maximum miter length ratio (as per SVG stroke-miterlimit).
 
   /// Dash pattern lengths alternating on/off segments (SVG `stroke-dasharray`).
   /// Empty vector means solid stroke. If the vector has an odd number of
@@ -70,6 +70,12 @@ struct StrokeStyle {
   /// length, so all dash distances are scaled by `actualLength / pathLength`.
   /// Zero (the default) means use the actual path length unchanged.
   double pathLength = 0.0;
+
+  /// Defaulted memberwise equality. Used as a cache key by the Geode
+  /// stroke-encode cache (design doc 0030 Milestone 2): a cached
+  /// `Path::strokeToFill` result is reused only when the source
+  /// `StrokeStyle` still compares equal.
+  bool operator==(const StrokeStyle& other) const = default;
 };
 
 class PathBuilder;
@@ -98,10 +104,10 @@ public:
 
   /// A command in the path, pairing a verb with the index of its first point.
   struct Command {
-    Verb verb;              ///< The verb type.
-    uint32_t pointIndex;    ///< Index of the first point for this command in the points array.
-    bool isInternal = false; ///< True for intermediate segments of arc decomposition. These are
-                             ///< skipped when computing vertices for marker placement.
+    Verb verb;                ///< The verb type.
+    uint32_t pointIndex;      ///< Index of the first point for this command in the points array.
+    bool isInternal = false;  ///< True for intermediate segments of arc decomposition. These are
+                              ///< skipped when computing vertices for marker placement.
 
     /// Equality operator.
     bool operator==(const Command& other) const {

--- a/donner/svg/components/shape/ShapeSystem.cc
+++ b/donner/svg/components/shape/ShapeSystem.cc
@@ -90,7 +90,7 @@ ParseResult<RcString> ParseD(std::span<const css::ComponentValue> components) {
 }
 
 std::optional<ParseDiagnostic> ParseDFromAttributes(PathComponent& properties,
-                                               const parser::PropertyParseFnParams& params) {
+                                                    const parser::PropertyParseFnParams& params) {
   if (const std::string_view* str = std::get_if<std::string_view>(&params.valueOrComponents)) {
     properties.d.set(RcString(*str), params.specificity);
   } else {
@@ -104,6 +104,22 @@ std::optional<ParseDiagnostic> ParseDFromAttributes(PathComponent& properties,
   }
 
   return std::nullopt;
+}
+
+/// Emplace or replace ComputedPathComponent only if the newly computed
+/// path differs from any existing one. Suppressing the write when the
+/// geometry is unchanged keeps entt's on_update<ComputedPathComponent>
+/// signal a precise "geometry actually changed" edge — downstream
+/// caches (e.g. the Geode encode cache from design doc 0030
+/// Milestone 2) listen on that signal and rely on it not firing for
+/// no-op regenerations.
+ComputedPathComponent& emplaceComputedPathIfChanged(EntityHandle handle, Path newPath) {
+  if (auto* existing = handle.try_get<ComputedPathComponent>()) {
+    if (existing->spline == newPath) {
+      return *existing;
+    }
+  }
+  return handle.emplace_or_replace<ComputedPathComponent>(std::move(newPath));
 }
 
 /**
@@ -162,8 +178,9 @@ constexpr bool ForEachShape(const F& f) {
 
 }  // namespace
 
-ComputedPathComponent* ShapeSystem::createComputedPathIfShape(
-    EntityHandle handle, const FontMetrics& fontMetrics, ParseWarningSink& warningSink) {
+ComputedPathComponent* ShapeSystem::createComputedPathIfShape(EntityHandle handle,
+                                                              const FontMetrics& fontMetrics,
+                                                              ParseWarningSink& warningSink) {
   ComputedPathComponent* computedPath = handle.try_get<ComputedPathComponent>();
   if (computedPath) {
     return computedPath;
@@ -188,8 +205,7 @@ ComputedPathComponent* ShapeSystem::createComputedPathIfShape(
   return computedPath;
 }
 
-void ShapeSystem::instantiateAllComputedPaths(Registry& registry,
-                                              ParseWarningSink& warningSink) {
+void ShapeSystem::instantiateAllComputedPaths(Registry& registry, ParseWarningSink& warningSink) {
   ForEachShape<AllShapes>([&]<typename ShapeType>() {
     for (auto view = registry.view<ShapeType, ComputedStyleComponent>(); auto entity : view) {
       auto [shape, style] = view.get(entity);
@@ -237,7 +253,7 @@ bool ShapeSystem::pathStrokeIntersects(EntityHandle handle, const Vector2d& poin
 }
 
 std::optional<Box2d> ShapeSystem::getTransformedShapeBounds(EntityHandle handle,
-                                                           const Transform2d& worldFromTarget) {
+                                                            const Transform2d& worldFromTarget) {
   std::optional<Box2d> overallBounds;
 
   if (const ComputedStyleComponent* style = handle.try_get<ComputedStyleComponent>()) {
@@ -291,7 +307,7 @@ ComputedPathComponent* ShapeSystem::createComputedShapeWithStyle(
   if (radius > 0.0) {
     Path path = PathBuilder().addCircle(center, radius).build();
 
-    return &handle.emplace_or_replace<ComputedPathComponent>(std::move(path));
+    return &emplaceComputedPathIfChanged(handle, std::move(path));
   } else {
     return nullptr;
   }
@@ -314,7 +330,7 @@ ComputedPathComponent* ShapeSystem::createComputedShapeWithStyle(
   if (radius.x > 0.0 && radius.y > 0.0) {
     Path path = PathBuilder().addEllipse(Box2d(center - radius, center + radius)).build();
 
-    return &handle.emplace_or_replace<ComputedPathComponent>(std::move(path));
+    return &emplaceComputedPathIfChanged(handle, std::move(path));
   } else {
     return nullptr;
   }
@@ -331,7 +347,7 @@ ComputedPathComponent* ShapeSystem::createComputedShapeWithStyle(
                      line.y2.toPixels(viewport, fontMetrics));
 
   Path path = PathBuilder().moveTo(start).lineTo(end).build();
-  return &handle.emplace_or_replace<ComputedPathComponent>(std::move(path));
+  return &emplaceComputedPathIfChanged(handle, std::move(path));
 }
 
 ComputedPathComponent* ShapeSystem::createComputedShapeWithStyle(
@@ -352,7 +368,7 @@ ComputedPathComponent* ShapeSystem::createComputedShapeWithStyle(
   }
 
   if (path.splineOverride) {
-    return &handle.emplace_or_replace<ComputedPathComponent>(path.splineOverride.value());
+    return &emplaceComputedPathIfChanged(handle, path.splineOverride.value());
   } else if (actualD.hasValue()) {
     auto maybePath = parser::PathParser::Parse(actualD.get().value());
     if (maybePath.hasError()) {
@@ -362,7 +378,7 @@ ComputedPathComponent* ShapeSystem::createComputedShapeWithStyle(
 
     if (maybePath.hasResult() && !maybePath.result().empty()) {
       // Success: Return path
-      return &handle.emplace_or_replace<ComputedPathComponent>(std::move(maybePath.result()));
+      return &emplaceComputedPathIfChanged(handle, std::move(maybePath.result()));
     }
   }
 
@@ -388,7 +404,7 @@ ComputedPathComponent* ShapeSystem::createComputedShapeWithStyle(
     builder.closePath();
   }
 
-  return &handle.emplace_or_replace<ComputedPathComponent>(builder.build());
+  return &emplaceComputedPathIfChanged(handle, builder.build());
 }
 
 ComputedPathComponent* ShapeSystem::createComputedShapeWithStyle(
@@ -416,17 +432,15 @@ ComputedPathComponent* ShapeSystem::createComputedShapeWithStyle(
                 size.y * 0.5));
 
       // Success: Draw a rect with rounded corners.
-      Path path = PathBuilder()
-                      .addRoundedRect(Box2d(pos, pos + size), radius.x, radius.y)
-                      .build();
+      Path path = PathBuilder().addRoundedRect(Box2d(pos, pos + size), radius.x, radius.y).build();
 
-      return &handle.emplace_or_replace<ComputedPathComponent>(std::move(path));
+      return &emplaceComputedPathIfChanged(handle, std::move(path));
 
     } else {
       // Success: Draw a rect with sharp corners
       Path path = PathBuilder().addRect(Box2d(pos, pos + size)).build();
 
-      return &handle.emplace_or_replace<ComputedPathComponent>(std::move(path));
+      return &emplaceComputedPathIfChanged(handle, std::move(path));
     }
   }
 

--- a/donner/svg/renderer/BUILD.bazel
+++ b/donner/svg/renderer/BUILD.bazel
@@ -301,6 +301,8 @@ donner_cc_library(
         "//donner/svg/renderer/geode:geode_device",
         "//donner/svg/renderer/geode:geode_filter_engine",
         "//donner/svg/renderer/geode:geode_image_pipeline",
+        "//donner/svg/renderer/geode:geode_path_cache_component",
+        "//donner/svg/renderer/geode:geode_path_encoder",
         "//donner/svg/renderer/geode:geode_pipeline",
         "//donner/svg/renderer/geode:geode_wgpu_util",
         "//donner/svg/resources:image_resource",

--- a/donner/svg/renderer/RendererDriver.cc
+++ b/donner/svg/renderer/RendererDriver.cc
@@ -13,12 +13,12 @@
 #include "donner/base/RelativeLengthMetrics.h"
 #include "donner/base/xml/components/TreeComponent.h"
 #include "donner/svg/components/ComputedClipPathsComponent.h"
-#include "donner/svg/components/filter/FilterComponent.h"
 #include "donner/svg/components/PathLengthComponent.h"
 #include "donner/svg/components/PreserveAspectRatioComponent.h"
 #include "donner/svg/components/RenderingBehaviorComponent.h"
 #include "donner/svg/components/RenderingInstanceComponent.h"
 #include "donner/svg/components/SVGDocumentContext.h"
+#include "donner/svg/components/filter/FilterComponent.h"
 #include "donner/svg/components/layout/LayoutSystem.h"
 #include "donner/svg/components/layout/SizedElementComponent.h"
 #include "donner/svg/components/layout/TransformComponent.h"
@@ -28,7 +28,6 @@
 #include "donner/svg/components/resources/ImageComponent.h"
 #include "donner/svg/components/resources/ResourceManagerContext.h"
 #include "donner/svg/components/shape/ComputedPathComponent.h"
-#include "donner/svg/components/text/ComputedTextComponent.h"
 #include "donner/svg/components/shape/ShapeSystem.h"
 #include "donner/svg/components/style/ComputedStyleComponent.h"
 #include "donner/svg/components/text/ComputedTextComponent.h"
@@ -113,8 +112,7 @@ bool ShouldCullDeviceBox(const Box2d& deviceBox, const Vector2i& renderingSize) 
 
   // Viewport culling: entire box is beyond one of the four edges, with a
   // one-device-pixel slack to tolerate floating-point drift at the boundary.
-  if (maxX < -kViewportCullSlackDevicePx ||
-      maxY < -kViewportCullSlackDevicePx ||
+  if (maxX < -kViewportCullSlackDevicePx || maxY < -kViewportCullSlackDevicePx ||
       minX > renderingSize.x + kViewportCullSlackDevicePx ||
       minY > renderingSize.y + kViewportCullSlackDevicePx) {
     return true;
@@ -270,8 +268,7 @@ void resolvePerSpanStyles(Registry& registry, components::ComputedTextComponent&
   }
 }
 
-PathShape toPathShape(EntityHandle sourceEntity,
-                      const components::ComputedPathComponent& path,
+PathShape toPathShape(EntityHandle sourceEntity, const components::ComputedPathComponent& path,
                       const components::ComputedStyleComponent& style) {
   PathShape shape;
   shape.path = path.spline;
@@ -592,8 +589,8 @@ std::optional<components::FilterGraph> resolveFilterGraph(
 
 /// Compute the filter region bounds in entity-local coordinates from a resolved filter reference.
 std::optional<Box2d> computeFilterRegion(Registry& registry,
-                                        const components::ResolvedFilterEffect& filter,
-                                        const components::RenderingInstanceComponent& instance) {
+                                         const components::ResolvedFilterEffect& filter,
+                                         const components::RenderingInstanceComponent& instance) {
   const auto* reference = std::get_if<ResolvedReference>(&filter);
   if (!reference) {
     // For CSS filter function lists, check if any entry is a url() reference.
@@ -852,7 +849,8 @@ void RendererDriver::drawEntityRange(Registry& registry, Entity firstEntity, Ent
       renderer_.pushIsolatedLayer(opacity, blendMode);
     }
 
-    const Box2d filterViewBox = components::LayoutSystem().getViewBox(instance.dataHandle(registry));
+    const Box2d filterViewBox =
+        components::LayoutSystem().getViewBox(instance.dataHandle(registry));
     const FontMetrics filterBaseFontMetrics = FontMetrics::DefaultsWithFontSize(16.0);
     const double filterFontSizePx =
         style.properties->fontSize.getRequired().toPixels(filterViewBox, filterBaseFontMetrics);
@@ -1023,8 +1021,8 @@ void RendererDriver::drawEntityRange(Registry& registry, Entity firstEntity, Ent
 }
 
 std::optional<Box2d> RendererDriver::computeEntityRangeBounds(
-    Registry& registry, Entity firstEntity, Entity lastEntity,
-    const RenderViewport& viewport, const Transform2d& surfaceFromCanvas) {
+    Registry& registry, Entity firstEntity, Entity lastEntity, const RenderViewport& viewport,
+    const Transform2d& surfaceFromCanvas) {
   const Vector2d canvasSize = viewport.size;
   if (canvasSize.x <= 0.0 || canvasSize.y <= 0.0) {
     return std::nullopt;
@@ -1053,10 +1051,9 @@ std::optional<Box2d> RendererDriver::computeEntityRangeBounds(
   };
   const auto traceEntity = [&](Entity e, const char* kind, const Box2d& box) {
     if (kTrace) {
-      std::fprintf(stderr,
-                   "[bounds] entity=%u %s box=(%.1f,%.1f → %.1f,%.1f)\n",
-                   static_cast<unsigned>(e), kind, box.topLeft.x, box.topLeft.y,
-                   box.bottomRight.x, box.bottomRight.y);
+      std::fprintf(stderr, "[bounds] entity=%u %s box=(%.1f,%.1f → %.1f,%.1f)\n",
+                   static_cast<unsigned>(e), kind, box.topLeft.x, box.topLeft.y, box.bottomRight.x,
+                   box.bottomRight.y);
     }
   };
 
@@ -1157,8 +1154,7 @@ std::optional<Box2d> RendererDriver::computeEntityRangeBounds(
       // further — use `miterLimit * strokeWidth / 2` as the worst-case
       // bound per spec.
       const PaintParams paint = toPaintParams(registry, instance, style);
-      const bool hasStroke =
-          !std::holds_alternative<PaintServer::None>(paint.stroke);
+      const bool hasStroke = !std::holds_alternative<PaintServer::None>(paint.stroke);
       if (hasStroke && paint.strokeParams.strokeWidth > 0.0) {
         double padding = paint.strokeParams.strokeWidth / 2.0;
         if (paint.strokeParams.lineJoin == StrokeLinejoin::Miter) {
@@ -1202,18 +1198,16 @@ std::optional<Box2d> RendererDriver::computeEntityRangeBounds(
   // Clamp to canvas — content partially off-canvas shouldn't
   // over-allocate the offscreen.
   const Box2d canvasRect(Vector2d::Zero(), canvasSize);
-  const Vector2d clampedTL(
-      std::max(accumulated->topLeft.x, canvasRect.topLeft.x),
-      std::max(accumulated->topLeft.y, canvasRect.topLeft.y));
-  const Vector2d clampedBR(
-      std::min(accumulated->bottomRight.x, canvasRect.bottomRight.x),
-      std::min(accumulated->bottomRight.y, canvasRect.bottomRight.y));
+  const Vector2d clampedTL(std::max(accumulated->topLeft.x, canvasRect.topLeft.x),
+                           std::max(accumulated->topLeft.y, canvasRect.topLeft.y));
+  const Vector2d clampedBR(std::min(accumulated->bottomRight.x, canvasRect.bottomRight.x),
+                           std::min(accumulated->bottomRight.y, canvasRect.bottomRight.y));
   if (clampedTL.x >= clampedBR.x || clampedTL.y >= clampedBR.y) {
     return std::nullopt;  // Fully off-canvas.
   }
   if (kTrace) {
-    std::fprintf(stderr, "[bounds] ---> final: (%.1f,%.1f → %.1f,%.1f)\n", clampedTL.x,
-                 clampedTL.y, clampedBR.x, clampedBR.y);
+    std::fprintf(stderr, "[bounds] ---> final: (%.1f,%.1f → %.1f,%.1f)\n", clampedTL.x, clampedTL.y,
+                 clampedBR.x, clampedBR.y);
   }
   return Box2d(clampedTL, clampedBR);
 }
@@ -1265,7 +1259,8 @@ void RendererDriver::traverse(RenderingInstanceView& view, Registry& registry) {
       renderer_.pushIsolatedLayer(opacity, blendMode);
     }
 
-    const Box2d filterViewBox = components::LayoutSystem().getViewBox(instance.dataHandle(registry));
+    const Box2d filterViewBox =
+        components::LayoutSystem().getViewBox(instance.dataHandle(registry));
     const FontMetrics filterBaseFontMetrics = FontMetrics::DefaultsWithFontSize(16.0);
     const double filterFontSizePx =
         style.properties->fontSize.getRequired().toPixels(filterViewBox, filterBaseFontMetrics);
@@ -1459,8 +1454,7 @@ void RendererDriver::traverse(RenderingInstanceView& view, Registry& registry) {
           }
         }
       } else if (auto* text =
-                     instance.dataHandle(registry)
-                         .try_get<components::ComputedTextComponent>()) {
+                     instance.dataHandle(registry).try_get<components::ComputedTextComponent>()) {
         const auto* textComp = instance.dataHandle(registry).try_get<components::TextComponent>();
         const TextParams textParams = toTextParams(registry, instance, style, textComp);
         resolvePerSpanStyles(registry, *text, instance.dataHandle(registry));
@@ -1558,7 +1552,8 @@ void RendererDriver::traverseRange(RenderingInstanceView& view, Registry& regist
     if (verbose_) {
       const Transform2d combined = instance.worldFromEntityTransform * surfaceFromCanvasTransform_;
       std::cout << "[traverseRange] entity=" << entt::to_integral(entity)
-                << " visible=" << instance.visible << "\n  surfaceFromCanvas=" << surfaceFromCanvasTransform_
+                << " visible=" << instance.visible
+                << "\n  surfaceFromCanvas=" << surfaceFromCanvasTransform_
                 << "\n  worldFromEntity=" << instance.worldFromEntityTransform
                 << "\n  combined=" << combined << "\n";
     }
@@ -1573,7 +1568,8 @@ void RendererDriver::traverseRange(RenderingInstanceView& view, Registry& regist
       renderer_.pushIsolatedLayer(opacity, blendMode);
     }
 
-    const Box2d filterViewBox = components::LayoutSystem().getViewBox(instance.dataHandle(registry));
+    const Box2d filterViewBox =
+        components::LayoutSystem().getViewBox(instance.dataHandle(registry));
     const FontMetrics filterBaseFontMetrics = FontMetrics::DefaultsWithFontSize(16.0);
     const double filterFontSizePx =
         style.properties->fontSize.getRequired().toPixels(filterViewBox, filterBaseFontMetrics);
@@ -1724,8 +1720,7 @@ void RendererDriver::traverseRange(RenderingInstanceView& view, Registry& regist
           }
         }
       } else if (auto* text =
-                     instance.dataHandle(registry)
-                         .try_get<components::ComputedTextComponent>()) {
+                     instance.dataHandle(registry).try_get<components::ComputedTextComponent>()) {
         const auto* textComp = instance.dataHandle(registry).try_get<components::TextComponent>();
         const TextParams textParams = toTextParams(registry, instance, style, textComp);
         resolvePerSpanStyles(registry, *text, instance.dataHandle(registry));
@@ -1858,7 +1853,7 @@ int RendererDriver::renderMask(RenderingInstanceView& view, Registry& registry,
 
     if (mc->maskContentUnits == MaskContentUnits::ObjectBoundingBox) {
       const Transform2d userSpaceFromMaskContent = Transform2d::Scale(shapeLocalBounds.size()) *
-                                                  Transform2d::Translate(shapeLocalBounds.topLeft);
+                                                   Transform2d::Translate(shapeLocalBounds.topLeft);
       surfaceFromCanvasTransform_ = userSpaceFromMaskContent * surfaceFromCanvasTransform_;
     }
 
@@ -2051,11 +2046,11 @@ void RendererDriver::drawMarker(RenderingInstanceView& view, Registry& registry,
 
   const Transform2d markerOffsetFromVertex =
       Transform2d::Translate(-markerComponent->refX * markerUnitsFromViewBox.data[0],
-                            -markerComponent->refY * markerUnitsFromViewBox.data[3]);
+                             -markerComponent->refY * markerUnitsFromViewBox.data[3]);
 
   const Transform2d vertexFromEntity = Transform2d::Scale(markerScale) *
-                                      Transform2d::Rotate(angleRadians) *
-                                      Transform2d::Translate(vertexPosition);
+                                       Transform2d::Rotate(angleRadians) *
+                                       Transform2d::Translate(vertexPosition);
 
   const Transform2d vertexFromWorld =
       vertexFromEntity * surfaceFromCanvasTransform_ * instance.worldFromEntityTransform;
@@ -2358,9 +2353,8 @@ void RendererDriver::preRenderFeImageFragments(components::FilterGraph& filterGr
       lastEntity = shadowResult->lastEntity;
     } else if (targetInstance) {
       firstEntity = targetEntity;
-      lastEntity = targetInstance->subtreeInfo
-                       ? targetInstance->subtreeInfo->lastRenderedEntity
-                       : targetEntity;
+      lastEntity = targetInstance->subtreeInfo ? targetInstance->subtreeInfo->lastRenderedEntity
+                                               : targetEntity;
     } else {
       feImageFragmentGuard_->erase(entityId);
       imageNode->fragmentId = RcString();
@@ -2379,13 +2373,12 @@ void RendererDriver::preRenderFeImageFragments(components::FilterGraph& filterGr
     subDriver.feImageFragmentGuard_ = feImageFragmentGuard_;
 
     // The fragment is rendered at its natural position in the document coordinate system
-    // (no surfaceFromCanvasTransform_ offset). The filter pipeline applies a device-space post-translation
-    // via SkImageFilters::Offset to position the content at the filter region origin. This is
-    // correct for all transforms (skew, rotation, etc.) because the offset doesn't interact with
-    // the element's transform — it's applied after the element is fully rendered.
+    // (no surfaceFromCanvasTransform_ offset). The filter pipeline applies a device-space
+    // post-translation via SkImageFilters::Offset to position the content at the filter region
+    // origin. This is correct for all transforms (skew, rotation, etc.) because the offset doesn't
+    // interact with the element's transform — it's applied after the element is fully rendered.
     if (filterRegion.has_value()) {
-      imageNode->fragmentRegionTopLeft =
-          Vector2d(filterRegion->topLeft.x, filterRegion->topLeft.y);
+      imageNode->fragmentRegionTopLeft = Vector2d(filterRegion->topLeft.x, filterRegion->topLeft.y);
     }
 
     {

--- a/donner/svg/renderer/RendererDriver.cc
+++ b/donner/svg/renderer/RendererDriver.cc
@@ -270,11 +270,13 @@ void resolvePerSpanStyles(Registry& registry, components::ComputedTextComponent&
   }
 }
 
-PathShape toPathShape(const components::ComputedPathComponent& path,
+PathShape toPathShape(EntityHandle sourceEntity,
+                      const components::ComputedPathComponent& path,
                       const components::ComputedStyleComponent& style) {
   PathShape shape;
   shape.path = path.spline;
   shape.fillRule = style.properties->fillRule.getRequired();
+  shape.sourceEntity = sourceEntity;
   return shape;
 }
 
@@ -925,7 +927,8 @@ void RendererDriver::drawEntityRange(Registry& registry, Entity firstEntity, Ent
     if (instance.visible && !filterHidesElement) {
       if (const auto* path =
               instance.dataHandle(registry).try_get<components::ComputedPathComponent>()) {
-        renderer_.drawPath(toPathShape(*path, style), paint.strokeParams);
+        renderer_.drawPath(toPathShape(instance.dataHandle(registry), *path, style),
+                           paint.strokeParams);
         drawMarkers(view, registry, instance, *path, style);
       } else if (auto* text =
                      instance.dataHandle(registry).try_get<components::ComputedTextComponent>()) {
@@ -1370,7 +1373,8 @@ void RendererDriver::traverse(RenderingInstanceView& view, Registry& registry) {
     if (instance.visible && !filterHidesElement && !cullDraw) {
       if (const auto* path =
               instance.dataHandle(registry).try_get<components::ComputedPathComponent>()) {
-        renderer_.drawPath(toPathShape(*path, style), paint.strokeParams);
+        renderer_.drawPath(toPathShape(instance.dataHandle(registry), *path, style),
+                           paint.strokeParams);
         drawMarkers(view, registry, instance, *path, style);
       } else if (auto* text =
                      instance.dataHandle(registry).try_get<components::ComputedTextComponent>()) {
@@ -1664,7 +1668,8 @@ void RendererDriver::traverseRange(RenderingInstanceView& view, Registry& regist
     if (instance.visible && !filterHidesElement && !cullDraw) {
       if (const auto* path =
               instance.dataHandle(registry).try_get<components::ComputedPathComponent>()) {
-        renderer_.drawPath(toPathShape(*path, style), paint.strokeParams);
+        renderer_.drawPath(toPathShape(instance.dataHandle(registry), *path, style),
+                           paint.strokeParams);
         drawMarkers(view, registry, instance, *path, style);
       } else if (auto* text =
                      instance.dataHandle(registry).try_get<components::ComputedTextComponent>()) {

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1070,11 +1070,15 @@ struct RendererGeode::Impl {
         const FillRule fillRule = strokeFillRuleFor(stroked);
         device->countPathEncode();
         geode::EncodedPath encoded = geode::GeodePathEncoder::encode(stroked, fillRule);
-        cache.strokeSlot.emplace();
-        cache.strokeSlot->strokeKey = strokeStyle;
-        cache.strokeSlot->strokedPath = std::move(stroked);
-        cache.strokeSlot->strokedEncode = std::move(encoded);
-        cache.strokeSlot->strokeFillRule = fillRule;
+        // GCC 14 libstdc++ rejects `.emplace()` here with "is_constructible_v<StrokeSlot> was not
+        // satisfied"; clang + libc++ accepts it. Build the value explicitly and assign to sidestep
+        // the toolchain disagreement.
+        cache.strokeSlot = geode::GeodePathCacheComponent::StrokeSlot{
+            .strokeKey = strokeStyle,
+            .strokedPath = std::move(stroked),
+            .strokedEncode = std::move(encoded),
+            .strokeFillRule = fillRule,
+        };
       }
       result.strokedPath = &cache.strokeSlot->strokedPath;
       result.encoded = &cache.strokeSlot->strokedEncode;

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1115,39 +1115,33 @@ struct RendererGeode::Impl {
     }
   }
 
-  ~Impl() {
-    // Disconnect the M2 cache-invalidation listener before the Impl is
-    // gone. Connection + disconnection are both no-ops when no registry
-    // was ever seen (e.g., a headless renderer that never drew anything).
-    //
-    // We rely on the normal lifecycle — SVGDocument outlives the
-    // renderer that drew it. In the reverse case (registry destroyed
-    // first) this disconnect would UB on a freed registry; tests that
-    // invert the lifetime don't exist today and would need to handle
-    // their own cleanup.
-    if (cacheInvalidationRegistry) {
-      cacheInvalidationRegistry->on_update<components::ComputedPathComponent>()
-          .disconnect<&Impl::onComputedPathChanged>();
-      cacheInvalidationRegistry->on_destroy<components::ComputedPathComponent>()
-          .disconnect<&Impl::onComputedPathChanged>();
-      cacheInvalidationRegistry = nullptr;
-    }
-  }
+  // No custom destructor: the M2 cache-invalidation listener is a
+  // free function with no dependency on `this`, so the natural entt
+  // lifecycle is correct — connections die with the `Registry` they
+  // live on. Calling `.disconnect<&fn>()` from a dtor would UB when
+  // the registry is destroyed BEFORE the renderer (common in tests
+  // where an `SVGDocument` is declared after its `Renderer` in the
+  // same scope, so the document destructs first). Leaving the
+  // connection attached is harmless: either the registry is alive
+  // and a subsequent geometry change fires `remove<GeodePathCacheComponent>`
+  // (which is a no-op if the component isn't present), or the
+  // registry is gone and no signal will ever fire again.
 };
 
 void RendererGeode::Impl::ensureCacheInvalidationWired(Registry& registry) {
   if (&registry == cacheInvalidationRegistry) {
     return;
   }
-  if (cacheInvalidationRegistry) {
-    cacheInvalidationRegistry->on_update<components::ComputedPathComponent>()
-        .disconnect<&Impl::onComputedPathChanged>();
-    cacheInvalidationRegistry->on_destroy<components::ComputedPathComponent>()
-        .disconnect<&Impl::onComputedPathChanged>();
-    // Reconnecting to a fresh registry: leave the old one's cache
-    // components in place (they die with the old registry) and start
-    // fresh on the new one.
-  }
+  // When the renderer switches documents (rare — test fixtures reusing
+  // one renderer across parses), we do NOT disconnect from the old
+  // registry. There's no safe way to know whether the old registry is
+  // still alive at this point, and `disconnect<>()` on a freed
+  // registry is UB. Leaving the old connection attached is harmless:
+  // our free-function listener is fine to outlive the renderer
+  // (see the `~Impl` comment above). Worst case: the old document
+  // keeps paying one signal dispatch on geometry changes; the removal
+  // call is a cheap no-op because the old `GeodePathCacheComponent`
+  // entries aren't being re-installed.
   registry.on_update<components::ComputedPathComponent>().connect<&Impl::onComputedPathChanged>();
   registry.on_destroy<components::ComputedPathComponent>().connect<&Impl::onComputedPathChanged>();
   cacheInvalidationRegistry = &registry;

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <iostream>
+#include <map>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -580,6 +581,100 @@ struct RendererGeode::Impl {
   };
   std::vector<PatternStackFrame> patternStack;
 
+  // --------------------------------------------------------------------
+  // M4.2 transient-texture pool (design doc 0030 §M4.2).
+  //
+  // Every push/pop of isolated-layer / filter-layer / mask / clip-mask
+  // scratch allocates a resolve + MSAA-companion pair — prior to this
+  // pool those allocations fired on every frame even when the same
+  // document was re-rendered at the same viewport. The pool holds
+  // released textures keyed by `(width, height, format, sampleCount,
+  // usage)`; same-dim / same-format acquisition on a later frame pops
+  // from the bucket instead of calling `createTexture`.
+  //
+  // Exact-size pooling (no power-of-two bucketing). Works for the
+  // repeat-render case this PR targets because layer sizes are
+  // derived from `pixelWidth`/`pixelHeight`, which don't change
+  // between idle re-renders. A size-bucketing extension is a future
+  // follow-up for viewport-resize scenarios.
+  // --------------------------------------------------------------------
+
+  /// Key used for texture-pool bucket lookup. Two textures are
+  /// interchangeable iff every field matches — same size, same
+  /// format, same MSAA sample count, same usage flags.
+  struct TextureKey {
+    uint32_t width = 0;
+    uint32_t height = 0;
+    wgpu::TextureFormat format = wgpu::TextureFormat::Undefined;
+    uint32_t sampleCount = 1;
+    wgpu::TextureUsage usage = wgpu::TextureUsage::None;
+
+    auto operator<=>(const TextureKey& other) const = default;
+
+    static TextureKey From(const wgpu::TextureDescriptor& desc) {
+      return TextureKey{desc.size.width, desc.size.height, desc.format, desc.sampleCount,
+                        desc.usage};
+    }
+  };
+  std::map<TextureKey, std::vector<wgpu::Texture>> texturePool;
+
+  /// Acquire a pooled texture matching `desc`, or create a fresh one
+  /// on miss. Always increments the `textureCreates` counter on miss;
+  /// never on hit. Returns a null texture on device failure.
+  wgpu::Texture acquireTexture(const wgpu::TextureDescriptor& desc) {
+    auto& bucket = texturePool[TextureKey::From(desc)];
+    if (!bucket.empty()) {
+      wgpu::Texture texture = std::move(bucket.back());
+      bucket.pop_back();
+      return texture;
+    }
+    wgpu::Texture texture = device->device().createTexture(desc);
+    if (texture) {
+      device->countTexture();
+    }
+    return texture;
+  }
+
+  /// Return a texture to its pool bucket IMMEDIATELY. Caller must
+  /// pass the same descriptor used to acquire, otherwise the next
+  /// acquire with the original descriptor will miss the bucket.
+  ///
+  /// Prefer `releaseTextureAtFrameEnd` for textures whose GPU work was
+  /// recorded into the shared `frameCommandEncoder`: releasing those
+  /// mid-frame would let a subsequent `acquireTexture` on the same
+  /// bucket hand the texture back out before the GPU has finished
+  /// writing it.
+  void releaseTexture(wgpu::Texture texture, const wgpu::TextureDescriptor& desc) {
+    if (!texture) {
+      return;
+    }
+    texturePool[TextureKey::From(desc)].push_back(std::move(texture));
+  }
+
+  /// Defer a release until after the frame's command buffer has been
+  /// submitted. Used by `popIsolatedLayer` / `popFilterLayer` / etc.,
+  /// where the layer texture is still referenced by commands recorded
+  /// into the frame encoder and must not be recycled mid-frame.
+  struct PendingRelease {
+    wgpu::Texture texture;
+    wgpu::TextureDescriptor desc;
+  };
+  std::vector<PendingRelease> framePendingReleases;
+
+  void releaseTextureAtFrameEnd(wgpu::Texture texture, const wgpu::TextureDescriptor& desc) {
+    if (!texture) {
+      return;
+    }
+    framePendingReleases.push_back({std::move(texture), desc});
+  }
+
+  void drainPendingReleases() {
+    for (auto& pending : framePendingReleases) {
+      releaseTexture(std::move(pending.texture), pending.desc);
+    }
+    framePendingReleases.clear();
+  }
+
   /// A saved encoder + target state for an in-progress isolated layer
   /// (`pushIsolatedLayer` / `popIsolatedLayer`). When the driver begins a
   /// group with non-identity opacity or a non-Normal blend mode, we
@@ -592,6 +687,11 @@ struct RendererGeode::Impl {
     wgpu::Texture savedMsaaTarget;   // Outer 4× MSAA color attachment.
     wgpu::Texture layerTexture;      // Inner layer 1-sample resolve.
     wgpu::Texture layerMsaaTexture;  // Inner layer 4× MSAA color attachment.
+    /// Descriptors captured at push time so `popIsolatedLayer` can
+    /// release the textures back to the correct pool bucket via
+    /// `releaseTexture`.
+    wgpu::TextureDescriptor layerDesc = {};
+    wgpu::TextureDescriptor layerMsaaDesc = {};
     double opacity = 1.0;
     /// Phase 3d: SVG `mix-blend-mode`. `Normal` (default) keeps the
     /// plain premultiplied source-over compositing path;
@@ -611,6 +711,9 @@ struct RendererGeode::Impl {
     wgpu::Texture savedMsaaTarget;   // Outer 4× MSAA color attachment.
     wgpu::Texture layerTexture;      // Inner layer 1-sample resolve.
     wgpu::Texture layerMsaaTexture;  // Inner layer 4× MSAA color attachment.
+    /// Descriptors captured at push for M4.2 pool release.
+    wgpu::TextureDescriptor layerDesc = {};
+    wgpu::TextureDescriptor layerMsaaDesc = {};
     components::FilterGraph filterGraph;
     Box2d filterRegion;
   };
@@ -639,6 +742,11 @@ struct RendererGeode::Impl {
     wgpu::Texture maskMsaaTexture;
     wgpu::Texture contentTexture;  // Masked element's content (RGBA).
     wgpu::Texture contentMsaaTexture;
+    /// Descriptors captured at push for M4.2 pool release.
+    wgpu::TextureDescriptor maskDesc = {};
+    wgpu::TextureDescriptor maskMsaaDesc = {};
+    wgpu::TextureDescriptor contentDesc = {};
+    wgpu::TextureDescriptor contentMsaaDesc = {};
     /// Raw mask-bounds rectangle from the driver, in the coordinate
     /// space of `maskBoundsTransform` (userSpaceOnUse or the
     /// objectBoundingBox-mapped user space — either way, NOT yet in
@@ -708,7 +816,10 @@ struct RendererGeode::Impl {
     wgpu::Texture maskMsaaTexture;
     wgpu::Texture maskResolveTexture;
     wgpu::TextureView maskResolveView;
-    std::vector<wgpu::Texture> maskLayerTextures;
+    /// Paired (texture, descriptor) entries. Every clip-mask texture
+    /// allocated by `pushClip` (across all nested layers) lives here
+    /// until `popClip` hands them back to the M4.2 texture pool.
+    std::vector<PendingRelease> maskLayerTextures;
   };
   std::vector<ClipStackEntry> clipStack;
 
@@ -1338,6 +1449,13 @@ void RendererGeode::endFrame() {
     impl_->frameCommandEncoder = wgpu::CommandEncoder();
   }
 
+  // Now that the command buffer is submitted, it's safe to return the
+  // frame's transient layer / filter / mask / snapshot textures to
+  // the pool. WebGPU's driver tracks texture dependencies across
+  // submits, so acquiring these on the next frame will schedule the
+  // new writes after the previous submit's GPU work completes.
+  impl_->drainPendingReleases();
+
   impl_->currentTransform = Transform2d();
   impl_->transformStack.clear();
 }
@@ -1456,37 +1574,34 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
       impl_->pixelHeight > 0) {
     const wgpu::Device& dev = impl_->device->device();
 
-    const auto makeResolveTexture = [&](const char* label) {
-      wgpu::TextureDescriptor desc = {};
-      desc.label = wgpuLabel(label);
-      desc.size = {static_cast<uint32_t>(impl_->pixelWidth),
-                   static_cast<uint32_t>(impl_->pixelHeight), 1u};
-      desc.format = wgpu::TextureFormat::R8Unorm;
-      desc.usage = wgpu::TextureUsage::RenderAttachment | wgpu::TextureUsage::TextureBinding;
-      desc.mipLevelCount = 1;
-      desc.sampleCount = 1;
-      desc.dimension = wgpu::TextureDimension::_2D;
-      auto t = dev.createTexture(desc);
-      impl_->device->countTexture();
-      return t;
+    const auto makeResolveTexture = [&](const char* label, wgpu::TextureDescriptor& outDesc) {
+      outDesc = wgpu::TextureDescriptor{};
+      outDesc.label = wgpuLabel(label);
+      outDesc.size = {static_cast<uint32_t>(impl_->pixelWidth),
+                      static_cast<uint32_t>(impl_->pixelHeight), 1u};
+      outDesc.format = wgpu::TextureFormat::R8Unorm;
+      outDesc.usage = wgpu::TextureUsage::RenderAttachment | wgpu::TextureUsage::TextureBinding;
+      outDesc.mipLevelCount = 1;
+      outDesc.sampleCount = 1;
+      outDesc.dimension = wgpu::TextureDimension::_2D;
+      return impl_->acquireTexture(outDesc);
     };
-    const auto makeMsaaTexture = [&](const char* label) -> wgpu::Texture {
+    const auto makeMsaaTexture = [&](const char* label,
+                                     wgpu::TextureDescriptor& outDesc) -> wgpu::Texture {
       if (impl_->device->sampleCount() == 1) {
         // Alpha-coverage path: no separate MSAA texture needed.
         return {};
       }
-      wgpu::TextureDescriptor desc = {};
-      desc.label = wgpuLabel(label);
-      desc.size = {static_cast<uint32_t>(impl_->pixelWidth),
-                   static_cast<uint32_t>(impl_->pixelHeight), 1u};
-      desc.format = wgpu::TextureFormat::R8Unorm;
-      desc.usage = wgpu::TextureUsage::RenderAttachment;
-      desc.mipLevelCount = 1;
-      desc.sampleCount = 4;
-      desc.dimension = wgpu::TextureDimension::_2D;
-      auto t = dev.createTexture(desc);
-      impl_->device->countTexture();
-      return t;
+      outDesc = wgpu::TextureDescriptor{};
+      outDesc.label = wgpuLabel(label);
+      outDesc.size = {static_cast<uint32_t>(impl_->pixelWidth),
+                      static_cast<uint32_t>(impl_->pixelHeight), 1u};
+      outDesc.format = wgpu::TextureFormat::R8Unorm;
+      outDesc.usage = wgpu::TextureUsage::RenderAttachment;
+      outDesc.mipLevelCount = 1;
+      outDesc.sampleCount = 4;
+      outDesc.dimension = wgpu::TextureDimension::_2D;
+      return impl_->acquireTexture(outDesc);
     };
 
     // Partition `clip.clipPaths` into contiguous [begin, end) ranges,
@@ -1534,10 +1649,18 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
       }
     }
 
+    (void)dev;  // Kept for potential future use; texture allocation
+                // routes through `impl_->acquireTexture` now.
     for (auto it = runs.rbegin(); it != runs.rend(); ++it) {
-      wgpu::Texture msaaTexture = makeMsaaTexture("RendererGeodeClipMaskMsaa");
-      wgpu::Texture resolveTexture = makeResolveTexture("RendererGeodeClipMaskResolve");
+      wgpu::TextureDescriptor msaaDesc = {};
+      wgpu::TextureDescriptor resolveDesc = {};
+      wgpu::Texture msaaTexture = makeMsaaTexture("RendererGeodeClipMaskMsaa", msaaDesc);
+      wgpu::Texture resolveTexture =
+          makeResolveTexture("RendererGeodeClipMaskResolve", resolveDesc);
       if (!resolveTexture || (impl_->device->sampleCount() > 1 && !msaaTexture)) {
+        // Release anything we managed to acquire before giving up.
+        if (msaaTexture) impl_->releaseTexture(std::move(msaaTexture), msaaDesc);
+        if (resolveTexture) impl_->releaseTexture(std::move(resolveTexture), resolveDesc);
         continue;
       }
 
@@ -1561,9 +1684,12 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
 
       nestedMaskView = resolveTexture.createView();
 
-      // Keep the intermediate textures alive until popClip.
-      entry.maskLayerTextures.push_back(std::move(msaaTexture));
-      entry.maskLayerTextures.push_back(resolveTexture);
+      // Keep the intermediate textures alive until popClip, paired
+      // with their descs for M4.2 pool release.
+      if (msaaTexture) {
+        entry.maskLayerTextures.push_back({std::move(msaaTexture), msaaDesc});
+      }
+      entry.maskLayerTextures.push_back({resolveTexture, resolveDesc});
 
       // The outermost layer (the LAST one processed by this loop,
       // i.e. the FIRST run in `runs`) provides the resolve view the
@@ -1584,6 +1710,16 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
 
 void RendererGeode::popClip() {
   if (!impl_->clipStack.empty()) {
+    // Defer release of the mask textures to endFrame — the main
+    // encoder that was just drawing under this clip may have recorded
+    // samples from `maskResolveTexture` into the frame encoder, and
+    // recycling mid-frame could hand the texture to a later acquire
+    // before the submit.
+    Impl::ClipStackEntry& entry = impl_->clipStack.back();
+    for (auto& release : entry.maskLayerTextures) {
+      impl_->releaseTextureAtFrameEnd(std::move(release.texture), release.desc);
+    }
+    entry.maskLayerTextures.clear();
     impl_->clipStack.pop_back();
   }
   impl_->updateEncoderScissor();
@@ -1618,16 +1754,15 @@ void RendererGeode::pushIsolatedLayer(double opacity, MixBlendMode blendMode) {
   td.mipLevelCount = 1;
   td.sampleCount = 1;
   td.dimension = wgpu::TextureDimension::_2D;
-  wgpu::Texture layerTexture = impl_->device->device().createTexture(td);
-  impl_->device->countTexture();
+  wgpu::Texture layerTexture = impl_->acquireTexture(td);
   if (!layerTexture) {
     impl_->layerStack.push_back({});
     return;
   }
 
+  wgpu::TextureDescriptor msaaDesc = {};
   wgpu::Texture layerMsaaTexture;
   if (impl_->device->sampleCount() > 1) {
-    wgpu::TextureDescriptor msaaDesc = {};
     msaaDesc.label = wgpuLabel("RendererGeodeIsolatedLayerMSAA");
     msaaDesc.size = td.size;
     msaaDesc.format = kFormat;
@@ -1635,9 +1770,9 @@ void RendererGeode::pushIsolatedLayer(double opacity, MixBlendMode blendMode) {
     msaaDesc.mipLevelCount = 1;
     msaaDesc.sampleCount = 4;
     msaaDesc.dimension = wgpu::TextureDimension::_2D;
-    layerMsaaTexture = impl_->device->device().createTexture(msaaDesc);
-    impl_->device->countTexture();
+    layerMsaaTexture = impl_->acquireTexture(msaaDesc);
     if (!layerMsaaTexture) {
+      impl_->releaseTexture(std::move(layerTexture), td);
       impl_->layerStack.push_back({});
       return;
     }
@@ -1655,6 +1790,8 @@ void RendererGeode::pushIsolatedLayer(double opacity, MixBlendMode blendMode) {
   frame.savedMsaaTarget = impl_->msaaTarget;
   frame.layerTexture = layerTexture;
   frame.layerMsaaTexture = layerMsaaTexture;
+  frame.layerDesc = td;
+  frame.layerMsaaDesc = msaaDesc;
   frame.opacity = opacity;
   frame.blendMode = blendMode;
 
@@ -1709,8 +1846,7 @@ void RendererGeode::popIsolatedLayer() {
     snapDesc.mipLevelCount = 1;
     snapDesc.sampleCount = 1;
     snapDesc.dimension = wgpu::TextureDimension::_2D;
-    wgpu::Texture snapshot = impl_->device->device().createTexture(snapDesc);
-    impl_->device->countTexture();
+    wgpu::Texture snapshot = impl_->acquireTexture(snapDesc);
 
     if (snapshot) {
       // Record the snapshot copy into the shared frame CommandEncoder
@@ -1748,6 +1884,13 @@ void RendererGeode::popIsolatedLayer() {
       impl_->updateEncoderScissor();
       impl_->encoder->blitFullTargetBlended(frame.layerTexture, snapshot,
                                             static_cast<uint32_t>(frame.blendMode), frame.opacity);
+      // Defer release: `blitFullTargetBlended` recorded samples from
+      // both `frame.layerTexture` and `snapshot` into the shared
+      // frameCommandEncoder; they must stay alive until that buffer
+      // is submitted at `endFrame`.
+      impl_->releaseTextureAtFrameEnd(std::move(frame.layerTexture), frame.layerDesc);
+      impl_->releaseTextureAtFrameEnd(std::move(frame.layerMsaaTexture), frame.layerMsaaDesc);
+      impl_->releaseTextureAtFrameEnd(std::move(snapshot), snapDesc);
       return;
     }
     // If snapshot allocation failed fall through to the Normal path —
@@ -1767,6 +1910,9 @@ void RendererGeode::popIsolatedLayer() {
   impl_->encoder = std::move(newEncoder);
   impl_->updateEncoderScissor();
   impl_->encoder->blitFullTarget(frame.layerTexture, frame.opacity);
+  // Same deferred-release rationale as the blend-mode branch above.
+  impl_->releaseTextureAtFrameEnd(std::move(frame.layerTexture), frame.layerDesc);
+  impl_->releaseTextureAtFrameEnd(std::move(frame.layerMsaaTexture), frame.layerMsaaDesc);
 }
 
 void RendererGeode::pushFilterLayer(const components::FilterGraph& filterGraph,
@@ -1797,8 +1943,7 @@ void RendererGeode::pushFilterLayer(const components::FilterGraph& filterGraph,
   td.mipLevelCount = 1;
   td.sampleCount = 1;
   td.dimension = wgpu::TextureDimension::_2D;
-  wgpu::Texture layerTexture = impl_->device->device().createTexture(td);
-  impl_->device->countTexture();
+  wgpu::Texture layerTexture = impl_->acquireTexture(td);
   if (!layerTexture) {
     impl_->filterStack.push_back({});
     return;
@@ -1812,9 +1957,9 @@ void RendererGeode::pushFilterLayer(const components::FilterGraph& filterGraph,
   msaaDesc.mipLevelCount = 1;
   msaaDesc.sampleCount = 4;
   msaaDesc.dimension = wgpu::TextureDimension::_2D;
-  wgpu::Texture layerMsaaTexture = impl_->device->device().createTexture(msaaDesc);
-  impl_->device->countTexture();
+  wgpu::Texture layerMsaaTexture = impl_->acquireTexture(msaaDesc);
   if (!layerMsaaTexture) {
+    impl_->releaseTexture(std::move(layerTexture), td);
     impl_->filterStack.push_back({});
     return;
   }
@@ -1829,6 +1974,8 @@ void RendererGeode::pushFilterLayer(const components::FilterGraph& filterGraph,
   frame.savedMsaaTarget = impl_->msaaTarget;
   frame.layerTexture = layerTexture;
   frame.layerMsaaTexture = layerMsaaTexture;
+  frame.layerDesc = td;
+  frame.layerMsaaDesc = msaaDesc;
   frame.filterGraph = filterGraph;
   frame.filterRegion = region;
 
@@ -1891,6 +2038,13 @@ void RendererGeode::popFilterLayer() {
   // CTM snapshot before using it as a scissor. Skipping for this PR —
   // all current feGaussianBlur resvg tests pass without the clip.
   impl_->encoder->blitFullTarget(filteredTexture, 1.0);
+  // Defer release to endFrame: `blitFullTarget` recorded a sample from
+  // `filteredTexture` (which is `frame.layerTexture` when the filter
+  // graph is empty) into the frame encoder. Filter-engine-owned
+  // intermediates are tracked separately by `GeodeFilterEngine` and
+  // covered by M5; we only recycle the layer capture pair here.
+  impl_->releaseTextureAtFrameEnd(std::move(frame.layerTexture), frame.layerDesc);
+  impl_->releaseTextureAtFrameEnd(std::move(frame.layerMsaaTexture), frame.layerMsaaDesc);
 }
 
 void RendererGeode::pushMask(const std::optional<Box2d>& maskBounds) {
@@ -1902,39 +2056,38 @@ void RendererGeode::pushMask(const std::optional<Box2d>& maskBounds) {
   }
 
   const auto allocTexturePair = [&](const char* label, const char* msaaLabel,
-                                    wgpu::Texture& outResolve, wgpu::Texture& outMsaa) {
-    wgpu::TextureDescriptor td = {};
-    td.label = wgpuLabel(label);
-    td.size = {static_cast<uint32_t>(impl_->pixelWidth), static_cast<uint32_t>(impl_->pixelHeight),
-               1u};
-    td.format = kFormat;
-    td.usage = wgpu::TextureUsage::RenderAttachment | wgpu::TextureUsage::TextureBinding |
-               wgpu::TextureUsage::CopySrc;
-    td.mipLevelCount = 1;
-    td.sampleCount = 1;
-    td.dimension = wgpu::TextureDimension::_2D;
-    outResolve = impl_->device->device().createTexture(td);
-    impl_->device->countTexture();
+                                    wgpu::Texture& outResolve, wgpu::TextureDescriptor& outDesc,
+                                    wgpu::Texture& outMsaa, wgpu::TextureDescriptor& outMsaaDesc) {
+    outDesc = wgpu::TextureDescriptor{};
+    outDesc.label = wgpuLabel(label);
+    outDesc.size = {static_cast<uint32_t>(impl_->pixelWidth),
+                    static_cast<uint32_t>(impl_->pixelHeight), 1u};
+    outDesc.format = kFormat;
+    outDesc.usage = wgpu::TextureUsage::RenderAttachment | wgpu::TextureUsage::TextureBinding |
+                    wgpu::TextureUsage::CopySrc;
+    outDesc.mipLevelCount = 1;
+    outDesc.sampleCount = 1;
+    outDesc.dimension = wgpu::TextureDimension::_2D;
+    outResolve = impl_->acquireTexture(outDesc);
 
     if (impl_->device->sampleCount() > 1) {
-      wgpu::TextureDescriptor msaaDesc = {};
-      msaaDesc.label = wgpuLabel(msaaLabel);
-      msaaDesc.size = td.size;
-      msaaDesc.format = kFormat;
-      msaaDesc.usage = wgpu::TextureUsage::RenderAttachment;
-      msaaDesc.mipLevelCount = 1;
-      msaaDesc.sampleCount = 4;
-      msaaDesc.dimension = wgpu::TextureDimension::_2D;
-      outMsaa = impl_->device->device().createTexture(msaaDesc);
-      impl_->device->countTexture();
+      outMsaaDesc = wgpu::TextureDescriptor{};
+      outMsaaDesc.label = wgpuLabel(msaaLabel);
+      outMsaaDesc.size = outDesc.size;
+      outMsaaDesc.format = kFormat;
+      outMsaaDesc.usage = wgpu::TextureUsage::RenderAttachment;
+      outMsaaDesc.mipLevelCount = 1;
+      outMsaaDesc.sampleCount = 4;
+      outMsaaDesc.dimension = wgpu::TextureDimension::_2D;
+      outMsaa = impl_->acquireTexture(outMsaaDesc);
     }
   };
 
   Impl::MaskStackFrame frame;
   allocTexturePair("RendererGeodeMaskCapture", "RendererGeodeMaskCaptureMSAA", frame.maskTexture,
-                   frame.maskMsaaTexture);
+                   frame.maskDesc, frame.maskMsaaTexture, frame.maskMsaaDesc);
   allocTexturePair("RendererGeodeMaskContent", "RendererGeodeMaskContentMSAA", frame.contentTexture,
-                   frame.contentMsaaTexture);
+                   frame.contentDesc, frame.contentMsaaTexture, frame.contentMsaaDesc);
   const bool needsMsaa = impl_->device->sampleCount() > 1;
   if (!frame.maskTexture || (needsMsaa && !frame.maskMsaaTexture) || !frame.contentTexture ||
       (needsMsaa && !frame.contentMsaaTexture)) {
@@ -2034,6 +2187,15 @@ void RendererGeode::popMask() {
 
   // Composite `content * luminance(mask)` onto the outer target.
   impl_->encoder->blitFullTargetMasked(frame.contentTexture, frame.maskTexture, pixelMaskBounds);
+
+  // Defer release to endFrame — `blitFullTargetMasked` recorded
+  // samples from both `contentTexture` and `maskTexture` into the
+  // frame encoder. MSAA companions had no post-render samples but
+  // are bucketed alongside their resolve for symmetry.
+  impl_->releaseTextureAtFrameEnd(std::move(frame.maskTexture), frame.maskDesc);
+  impl_->releaseTextureAtFrameEnd(std::move(frame.maskMsaaTexture), frame.maskMsaaDesc);
+  impl_->releaseTextureAtFrameEnd(std::move(frame.contentTexture), frame.contentDesc);
+  impl_->releaseTextureAtFrameEnd(std::move(frame.contentMsaaTexture), frame.contentMsaaDesc);
 }
 
 void RendererGeode::beginPatternTile(const Box2d& tileRect, const Transform2d& targetFromPattern) {

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -616,16 +616,41 @@ struct RendererGeode::Impl {
                         desc.usage};
     }
   };
-  std::map<TextureKey, std::vector<wgpu::Texture>> texturePool;
+  struct TextureBucket {
+    std::vector<wgpu::Texture> free;
+    /// Monotonic frame index when this bucket was last touched by
+    /// either `acquireTexture` or `releaseTexture`. Used by
+    /// `evictStalePoolBuckets` to age out buckets whose size hasn't
+    /// been seen in a while (viewport-resize scenarios).
+    uint64_t lastUsedFrame = 0;
+  };
+  std::map<TextureKey, TextureBucket> texturePool;
+
+  /// Per-bucket hard cap. Prevents a single size from accumulating
+  /// unbounded textures even if a pathological frame pushes and pops
+  /// dozens of layers at that size without ever reacquiring.
+  static constexpr std::size_t kMaxPoolEntriesPerKey = 8;
+
+  /// Drop a bucket entirely if it hasn't been touched in this many
+  /// consecutive frames. At 60 fps this is ~2 seconds of idleness;
+  /// long enough to survive transient dips (e.g. an editor dragging
+  /// slightly then stopping) while still releasing memory on real
+  /// viewport-size changes.
+  static constexpr uint64_t kBucketEvictAfterFrames = 120;
+
+  /// Monotonic frame counter. Incremented in `beginFrame`; used to
+  /// stamp `TextureBucket::lastUsedFrame`.
+  uint64_t currentFrameIndex = 0;
 
   /// Acquire a pooled texture matching `desc`, or create a fresh one
   /// on miss. Always increments the `textureCreates` counter on miss;
   /// never on hit. Returns a null texture on device failure.
   wgpu::Texture acquireTexture(const wgpu::TextureDescriptor& desc) {
-    auto& bucket = texturePool[TextureKey::From(desc)];
-    if (!bucket.empty()) {
-      wgpu::Texture texture = std::move(bucket.back());
-      bucket.pop_back();
+    TextureBucket& bucket = texturePool[TextureKey::From(desc)];
+    bucket.lastUsedFrame = currentFrameIndex;
+    if (!bucket.free.empty()) {
+      wgpu::Texture texture = std::move(bucket.free.back());
+      bucket.free.pop_back();
       return texture;
     }
     wgpu::Texture texture = device->device().createTexture(desc);
@@ -648,7 +673,29 @@ struct RendererGeode::Impl {
     if (!texture) {
       return;
     }
-    texturePool[TextureKey::From(desc)].push_back(std::move(texture));
+    TextureBucket& bucket = texturePool[TextureKey::From(desc)];
+    bucket.lastUsedFrame = currentFrameIndex;
+    if (bucket.free.size() >= kMaxPoolEntriesPerKey) {
+      // Bucket full — let the released texture go out of scope instead
+      // of unbounded growth.
+      return;
+    }
+    bucket.free.push_back(std::move(texture));
+  }
+
+  /// Drop every bucket whose `lastUsedFrame` is older than
+  /// `kBucketEvictAfterFrames` frames. Called at `beginFrame`. On
+  /// steady-state workloads this is a no-op (all buckets refresh
+  /// their stamps each frame); under viewport-resize churn it caps
+  /// pool memory at whatever sizes have been seen recently.
+  void evictStalePoolBuckets() {
+    for (auto it = texturePool.begin(); it != texturePool.end();) {
+      if (currentFrameIndex - it->second.lastUsedFrame > kBucketEvictAfterFrames) {
+        it = texturePool.erase(it);
+      } else {
+        ++it;
+      }
+    }
   }
 
   /// Defer a release until after the frame's command buffer has been
@@ -973,14 +1020,20 @@ struct RendererGeode::Impl {
   // --------------------------------------------------------------------
   // M2 path-encode cache (design doc 0030 §Milestone 2).
   //
-  // `cacheInvalidationRegistry` tracks the registry our entt
-  // `on_update<ComputedPathComponent>` / `on_destroy<ComputedPathComponent>`
-  // listener is connected to. When `draw()` comes in with a different
-  // registry (e.g. a test fixture reusing one renderer across documents),
-  // we disconnect from the old and reconnect to the new.
+  // Our entt `on_update<ComputedPathComponent>` / `on_destroy<ComputedPathComponent>`
+  // listener is connected lazily at `draw()` entry. Presence is tracked
+  // via a sentinel context component on the registry itself
+  // (`ListenerInstalled`) — pointer-identity on `&registry` would be
+  // unsafe across document lifetimes (a destroyed document's registry
+  // memory can be reused, giving us the same pointer value for an
+  // entirely different `entt::basic_registry` with no listener).
   // --------------------------------------------------------------------
 
-  Registry* cacheInvalidationRegistry = nullptr;
+  /// Sentinel context component, emplaced on a registry the first
+  /// time it's seen by `ensureCacheInvalidationWired`. Lifetime ties
+  /// to the registry — dies with it, so a re-allocated registry at
+  /// the same address doesn't carry the tag.
+  struct ListenerInstalled {};
 
   /// Connect (or rewire) our `on_update<ComputedPathComponent>` /
   /// `on_destroy<ComputedPathComponent>` listener onto `registry`.
@@ -1244,22 +1297,22 @@ struct RendererGeode::Impl {
 };
 
 void RendererGeode::Impl::ensureCacheInvalidationWired(Registry& registry) {
-  if (&registry == cacheInvalidationRegistry) {
+  // Sentinel lives on the registry's context store, so its presence
+  // implies "this registry has already had our listener connected".
+  // When the registry is destroyed the sentinel goes with it — a
+  // later registry allocated at the same address will (correctly)
+  // miss the sentinel and get its own listener. Pointer-identity on
+  // `&registry` alone can't distinguish those cases.
+  if (registry.ctx().contains<ListenerInstalled>()) {
     return;
   }
-  // When the renderer switches documents (rare — test fixtures reusing
-  // one renderer across parses), we do NOT disconnect from the old
-  // registry. There's no safe way to know whether the old registry is
-  // still alive at this point, and `disconnect<>()` on a freed
-  // registry is UB. Leaving the old connection attached is harmless:
-  // our free-function listener is fine to outlive the renderer
-  // (see the `~Impl` comment above). Worst case: the old document
-  // keeps paying one signal dispatch on geometry changes; the removal
-  // call is a cheap no-op because the old `GeodePathCacheComponent`
-  // entries aren't being re-installed.
+  registry.ctx().emplace<ListenerInstalled>();
   registry.on_update<components::ComputedPathComponent>().connect<&Impl::onComputedPathChanged>();
   registry.on_destroy<components::ComputedPathComponent>().connect<&Impl::onComputedPathChanged>();
-  cacheInvalidationRegistry = &registry;
+  // Leaving the connection attached across renderer destruction is
+  // intentional: our free-function listener has no `this`-capture,
+  // so it's safe to outlive the renderer. Connections die with the
+  // registry.
 }
 
 void RendererGeode::Impl::onComputedPathChanged(Registry& registry, Entity entity) {
@@ -1355,6 +1408,13 @@ void RendererGeode::beginFrame(const RenderViewport& viewport) {
   impl_->transformStack.clear();
   impl_->paint = PaintParams();
   impl_->encoder.reset();
+
+  // M4.2: stamp each frame with a monotonic index and age out pool
+  // buckets that haven't been touched in the last
+  // `kBucketEvictAfterFrames` frames. Caps memory under viewport
+  // resize.
+  ++impl_->currentFrameIndex;
+  impl_->evictStalePoolBuckets();
 
   // Reset counters regardless of device state.
   impl_->counters.reset();

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -9,16 +9,19 @@
 #include <webgpu/webgpu.hpp>
 
 #include "donner/base/Box.h"
+#include "donner/base/EcsRegistry.h"
 #include "donner/base/Path.h"
 #include "donner/base/RelativeLengthMetrics.h"
 #include "donner/base/Transform.h"
 #include "donner/base/Vector2.h"
+#include "donner/svg/SVGDocument.h"
 #include "donner/svg/components/RenderingInstanceComponent.h"
 #include "donner/svg/components/filter/FilterGraph.h"
 #include "donner/svg/components/layout/TransformComponent.h"
 #include "donner/svg/components/paint/GradientComponent.h"
 #include "donner/svg/components/paint/LinearGradientComponent.h"
 #include "donner/svg/components/paint/RadialGradientComponent.h"
+#include "donner/svg/components/shape/ComputedPathComponent.h"
 #include "donner/svg/core/Gradient.h"
 #include "donner/svg/core/Stroke.h"
 #include "donner/svg/properties/PaintServer.h"
@@ -27,6 +30,8 @@
 #include "donner/svg/renderer/geode/GeodeDevice.h"
 #include "donner/svg/renderer/geode/GeodeFilterEngine.h"
 #include "donner/svg/renderer/geode/GeodeImagePipeline.h"
+#include "donner/svg/renderer/geode/GeodePathCacheComponent.h"
+#include "donner/svg/renderer/geode/GeodePathEncoder.h"
 #include "donner/svg/renderer/geode/GeodePipeline.h"
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 #include "donner/svg/resources/ImageResource.h"
@@ -854,10 +859,138 @@ struct RendererGeode::Impl {
     }
   }
 
+  // --------------------------------------------------------------------
+  // M2 path-encode cache (design doc 0030 §Milestone 2).
+  //
+  // `cacheInvalidationRegistry` tracks the registry our entt
+  // `on_update<ComputedPathComponent>` / `on_destroy<ComputedPathComponent>`
+  // listener is connected to. When `draw()` comes in with a different
+  // registry (e.g. a test fixture reusing one renderer across documents),
+  // we disconnect from the old and reconnect to the new.
+  // --------------------------------------------------------------------
+
+  Registry* cacheInvalidationRegistry = nullptr;
+
+  /// Connect (or rewire) our `on_update<ComputedPathComponent>` /
+  /// `on_destroy<ComputedPathComponent>` listener onto `registry`.
+  /// Called at the start of each `draw()`. Idempotent for the same
+  /// registry. When switching registries (test fixtures reusing one
+  /// renderer), disconnects from the old first.
+  void ensureCacheInvalidationWired(Registry& registry);
+
+  /// Wipe the cache component from an entity when its source
+  /// `ComputedPathComponent` is rewritten by `ShapeSystem` or destroyed.
+  /// Connected to entt's `on_update` / `on_destroy` signals.
+  /// File-scope free function with this signature is the only shape
+  /// entt's `.connect<&fn>()` accepts that doesn't couple lifetime to
+  /// `this` — see M2 notes in design doc 0030.
+  static void onComputedPathChanged(Registry& registry, Entity entity);
+
+  /// Scratch buffer for the no-source-entity stroke path. `getStrokeDerived`
+  /// uses this as stable storage when there's no `GeodePathCacheComponent`
+  /// to live on (e.g. `drawRect` / `drawEllipse` convenience draws). Only
+  /// one active draw at a time, so a single slot is safe.
+  Path strokeScratchPath;
+
+  /// Value returned by `getFillEncode` / `getStrokeDerived` describing
+  /// which encode the caller should pass down to `GeoEncoder`.
+  struct StrokeDerived {
+    /// Path to draw. Null means "no stroke geometry — skip the draw".
+    /// Points into the entity's cache slot on hit, or into
+    /// `strokeScratchPath` on the no-entity fallback.
+    const Path* strokedPath = nullptr;
+    /// Precomputed encode pointer for `GeoEncoder`. Non-null only when
+    /// the stroke came from a cache slot — the no-entity fallback
+    /// leaves this null and lets `GeoEncoder` encode inline.
+    const geode::EncodedPath* encoded = nullptr;
+    /// Fill rule to use. For open-path strokes, `strokeToFill` emits one
+    /// subpath → NonZero; for closed-path strokes, two → EvenOdd.
+    FillRule fillRule = FillRule::NonZero;
+  };
+
+  /// Encode-side of the cache. If `source` holds a valid entity handle,
+  /// installs / reuses a `GeodePathCacheComponent::fillEncode` on it and
+  /// returns a stable pointer into that component. If `source` is null
+  /// (non-driver callers), returns null and `GeoEncoder` will encode
+  /// inline — the old pre-M2 code path.
+  const geode::EncodedPath* getFillEncode(EntityHandle source, const Path& path, FillRule rule) {
+    if (!source) {
+      return nullptr;
+    }
+    auto& cache = source.get_or_emplace<geode::GeodePathCacheComponent>();
+    if (!cache.fillEncode) {
+      device->countPathEncode();
+      cache.fillEncode = geode::GeodePathEncoder::encode(path, rule);
+    }
+    return &*cache.fillEncode;
+  }
+
+  /// Determine the fill rule for a stroked outline per the subpath-count
+  /// rule documented in `RendererGeode::drawPath`. Open-path strokes
+  /// produce one subpath (NonZero); closed-path strokes produce two
+  /// same-winding subpaths (EvenOdd hollow-ring semantics).
+  static FillRule strokeFillRuleFor(const Path& strokedOutline) {
+    size_t subpathCount = 0;
+    for (const auto& cmd : strokedOutline.commands()) {
+      if (cmd.verb == Path::Verb::MoveTo) {
+        ++subpathCount;
+      }
+    }
+    return (subpathCount <= 1) ? FillRule::NonZero : FillRule::EvenOdd;
+  }
+
+  /// Stroke-side of the cache. Builds (or reuses) the `strokeToFill`
+  /// output and its encode on `source`'s `GeodePathCacheComponent`.
+  /// Returns a `StrokeDerived` pointing into the cache (entity path) or
+  /// into `strokeScratchPath` (no-entity fallback). The caller must
+  /// check `strokedPath == nullptr` for the "zero-stroke" case.
+  StrokeDerived getStrokeDerived(EntityHandle source, const Path& geometry,
+                                 const StrokeStyle& strokeStyle) {
+    StrokeDerived result;
+    if (source) {
+      auto& cache = source.get_or_emplace<geode::GeodePathCacheComponent>();
+      if (!cache.strokeSlot || cache.strokeSlot->strokeKey != strokeStyle) {
+        // Miss (or stroke-params changed) — rebuild.
+        Path stroked = geometry.strokeToFill(strokeStyle);
+        if (stroked.empty()) {
+          cache.strokeSlot.reset();
+          return result;  // strokedPath stays null.
+        }
+        const FillRule fillRule = strokeFillRuleFor(stroked);
+        device->countPathEncode();
+        geode::EncodedPath encoded = geode::GeodePathEncoder::encode(stroked, fillRule);
+        cache.strokeSlot.emplace();
+        cache.strokeSlot->strokeKey = strokeStyle;
+        cache.strokeSlot->strokedPath = std::move(stroked);
+        cache.strokeSlot->strokedEncode = std::move(encoded);
+        cache.strokeSlot->strokeFillRule = fillRule;
+      }
+      result.strokedPath = &cache.strokeSlot->strokedPath;
+      result.encoded = &cache.strokeSlot->strokedEncode;
+      result.fillRule = cache.strokeSlot->strokeFillRule;
+      return result;
+    }
+    // No-entity fallback: compute into the Impl-local scratch buffer.
+    // GeoEncoder will encode inline when `encoded` is left null.
+    strokeScratchPath = geometry.strokeToFill(strokeStyle);
+    if (strokeScratchPath.empty()) {
+      return result;
+    }
+    result.strokedPath = &strokeScratchPath;
+    result.fillRule = strokeFillRuleFor(strokeScratchPath);
+    return result;
+  }
+
   /// Issue a fill of the given path using the current `paint.fill`. Handles
   /// solid colors, linear and radial gradients, and pattern tiles. None and
   /// unsupported types are ignored or fall back to their fallback color.
-  void fillResolved(const Path& path, FillRule rule) {
+  ///
+  /// `precomputedEncoded` is the M2 cache-hit payload (see
+  /// `getFillEncode`). When non-null, the encoder skips the
+  /// `GeodePathEncoder::encode` + `countPathEncode()` pair; otherwise
+  /// `GeoEncoder` runs the inline encode path.
+  void fillResolved(const Path& path, FillRule rule,
+                    const geode::EncodedPath* precomputedEncoded = nullptr) {
     if (!encoder) {
       return;
     }
@@ -867,19 +1000,21 @@ struct RendererGeode::Impl {
     if (patternFillPaint.has_value()) {
       syncTransform();
       const double opacity = paint.fillOpacity;
-      encoder->fillPathPattern(path, rule, buildPatternPaint(*patternFillPaint, opacity));
+      encoder->fillPathPattern(path, rule, buildPatternPaint(*patternFillPaint, opacity),
+                               precomputedEncoded);
       patternFillPaint.reset();
       return;
     }
     const double effectiveOpacity = paint.fillOpacity;
-    drawPaintedPath(path, paint.fill, effectiveOpacity, rule);
+    drawPaintedPath(path, paint.fill, effectiveOpacity, rule, precomputedEncoded);
   }
 
   /// Core dispatch: given a path and a resolved paint server, emit the
   /// appropriate fill call (solid color or gradient).
   void drawPaintedPath(const Path& path, const components::ResolvedPaintServer& server,
-                       double effectiveOpacity, FillRule rule) {
-    drawPaintedPathAgainst(path, path, server, effectiveOpacity, rule);
+                       double effectiveOpacity, FillRule rule,
+                       const geode::EncodedPath* precomputedEncoded = nullptr) {
+    drawPaintedPathAgainst(path, path, server, effectiveOpacity, rule, precomputedEncoded);
   }
 
   /// Same as `drawPaintedPath`, but the gradient's objectBoundingBox is
@@ -890,7 +1025,8 @@ struct RendererGeode::Impl {
   /// would warp the gradient direction relative to the underlying shape.
   void drawPaintedPathAgainst(const Path& geometryPath, const Path& drawPath,
                               const components::ResolvedPaintServer& server,
-                              double effectiveOpacity, FillRule rule) {
+                              double effectiveOpacity, FillRule rule,
+                              const geode::EncodedPath* precomputedEncoded = nullptr) {
     if (!encoder || drawPath.empty()) {
       return;
     }
@@ -904,7 +1040,8 @@ struct RendererGeode::Impl {
     // Solid color: straight through the flat fill pipeline.
     if (const auto* solid = std::get_if<PaintServer::Solid>(&server)) {
       syncTransform();
-      encoder->fillPath(drawPath, solid->color.resolve(currentColor, opacity), rule);
+      encoder->fillPath(drawPath, solid->color.resolve(currentColor, opacity), rule,
+                        precomputedEncoded);
       return;
     }
 
@@ -923,7 +1060,7 @@ struct RendererGeode::Impl {
           warnedGradient = true;
         }
         syncTransform();
-        encoder->fillPathLinearGradient(drawPath, *linear, rule);
+        encoder->fillPathLinearGradient(drawPath, *linear, rule, precomputedEncoded);
         return;
       }
 
@@ -937,14 +1074,14 @@ struct RendererGeode::Impl {
         }
         if (radial->gradient.has_value()) {
           syncTransform();
-          encoder->fillPathRadialGradient(drawPath, *radial->gradient, rule);
+          encoder->fillPathRadialGradient(drawPath, *radial->gradient, rule, precomputedEncoded);
           return;
         }
         if (radial->solidFallback.has_value()) {
           // SVG2 degenerate radial (r=0): paint the last stop color as a
           // solid fill so the element remains visible.
           syncTransform();
-          encoder->fillPath(drawPath, *radial->solidFallback, rule);
+          encoder->fillPath(drawPath, *radial->solidFallback, rule, precomputedEncoded);
           return;
         }
         // Recognized as radial but otherwise unusable (empty stops, focal
@@ -963,7 +1100,8 @@ struct RendererGeode::Impl {
       // solid fallback color if one was declared, otherwise drop the draw.
       if (ref->fallback.has_value()) {
         syncTransform();
-        encoder->fillPath(drawPath, ref->fallback->resolve(currentColor, opacity), rule);
+        encoder->fillPath(drawPath, ref->fallback->resolve(currentColor, opacity), rule,
+                          precomputedEncoded);
         return;
       }
 
@@ -976,7 +1114,50 @@ struct RendererGeode::Impl {
       }
     }
   }
+
+  ~Impl() {
+    // Disconnect the M2 cache-invalidation listener before the Impl is
+    // gone. Connection + disconnection are both no-ops when no registry
+    // was ever seen (e.g., a headless renderer that never drew anything).
+    //
+    // We rely on the normal lifecycle — SVGDocument outlives the
+    // renderer that drew it. In the reverse case (registry destroyed
+    // first) this disconnect would UB on a freed registry; tests that
+    // invert the lifetime don't exist today and would need to handle
+    // their own cleanup.
+    if (cacheInvalidationRegistry) {
+      cacheInvalidationRegistry->on_update<components::ComputedPathComponent>()
+          .disconnect<&Impl::onComputedPathChanged>();
+      cacheInvalidationRegistry->on_destroy<components::ComputedPathComponent>()
+          .disconnect<&Impl::onComputedPathChanged>();
+      cacheInvalidationRegistry = nullptr;
+    }
+  }
 };
+
+void RendererGeode::Impl::ensureCacheInvalidationWired(Registry& registry) {
+  if (&registry == cacheInvalidationRegistry) {
+    return;
+  }
+  if (cacheInvalidationRegistry) {
+    cacheInvalidationRegistry->on_update<components::ComputedPathComponent>()
+        .disconnect<&Impl::onComputedPathChanged>();
+    cacheInvalidationRegistry->on_destroy<components::ComputedPathComponent>()
+        .disconnect<&Impl::onComputedPathChanged>();
+    // Reconnecting to a fresh registry: leave the old one's cache
+    // components in place (they die with the old registry) and start
+    // fresh on the new one.
+  }
+  registry.on_update<components::ComputedPathComponent>().connect<&Impl::onComputedPathChanged>();
+  registry.on_destroy<components::ComputedPathComponent>().connect<&Impl::onComputedPathChanged>();
+  cacheInvalidationRegistry = &registry;
+}
+
+void RendererGeode::Impl::onComputedPathChanged(Registry& registry, Entity entity) {
+  // entt allows `remove` on a component the entity doesn't hold — it's a
+  // cheap no-op in that case. We don't need an `all_of` guard.
+  registry.remove<geode::GeodePathCacheComponent>(entity);
+}
 
 RendererGeode::RendererGeode(bool verbose) : impl_(std::make_unique<Impl>()) {
   impl_->verbose = verbose;
@@ -1038,6 +1219,14 @@ RendererGeode::RendererGeode(RendererGeode&&) noexcept = default;
 RendererGeode& RendererGeode::operator=(RendererGeode&&) noexcept = default;
 
 void RendererGeode::draw(SVGDocument& document) {
+  // Wire the M2 cache-invalidation listener onto this document's
+  // registry BEFORE the driver runs `RenderingContext::instantiateRenderTree`.
+  // The listener must be connected when `ShapeSystem` fires its
+  // `on_update<ComputedPathComponent>` signals; otherwise a geometry
+  // change between draws would silently leave a stale encode in
+  // `GeodePathCacheComponent`.
+  impl_->ensureCacheInvalidationWired(document.registry());
+
   RendererDriver driver(*this, impl_->verbose);
   driver.draw(document);
 }
@@ -2099,7 +2288,12 @@ void RendererGeode::setPaint(const PaintParams& paint) {
 }
 
 void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) {
-  impl_->fillResolved(path.path, path.fillRule);
+  // M2 cache lookup for the fill encode. Null `sourceEntity` (editor
+  // overlay, test-harness direct draws) returns nullptr and `GeoEncoder`
+  // falls back to the inline encode path.
+  const geode::EncodedPath* fillEncoded =
+      impl_->getFillEncode(path.sourceEntity, path.path, path.fillRule);
+  impl_->fillResolved(path.path, path.fillRule, fillEncoded);
 
   // Mirror fillResolved's no-op safety: if there's no encoder (headless
   // device init failed, zero-pixel viewport, or draw-before-beginFrame),
@@ -2135,29 +2329,25 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   // segment rectangle drops out). NonZero handles that case correctly
   // because the overlapping winding still sums to non-zero.
   //
-  // Pick per-source: count the subpaths produced by `strokeToFill`.
-  // A 1-subpath result means the source was open, use NonZero. A
-  // 2-subpath result means the source was closed and we need EvenOdd.
-  const Path strokedOutline = path.path.strokeToFill(toStrokeStyle(stroke));
-  if (strokedOutline.empty()) {
+  // The M2 cache (`GeodePathCacheComponent::strokeSlot`) memoizes the
+  // `strokeToFill` output + its encode + the derived fill rule, keyed
+  // by `StrokeStyle` equality. A cache hit skips all three computations.
+  const StrokeStyle strokeStyle = toStrokeStyle(stroke);
+  const Impl::StrokeDerived strokeDerived =
+      impl_->getStrokeDerived(path.sourceEntity, path.path, strokeStyle);
+  if (!strokeDerived.strokedPath) {
     return;
   }
-
-  size_t subpathCount = 0;
-  for (const auto& cmd : strokedOutline.commands()) {
-    if (cmd.verb == Path::Verb::MoveTo) {
-      ++subpathCount;
-    }
-  }
-  const FillRule strokeFillRule = (subpathCount <= 1) ? FillRule::NonZero : FillRule::EvenOdd;
+  const Path& strokedOutline = *strokeDerived.strokedPath;
 
   // Pattern dispatch comes first: a stroke pattern slot was populated by the
   // driver via `endPatternTile(forStroke=true)` and consumed here.
   if (impl_->patternStrokePaint.has_value()) {
     impl_->syncTransform();
     const double opacity = impl_->paint.strokeOpacity;
-    impl_->encoder->fillPathPattern(strokedOutline, strokeFillRule,
-                                    impl_->buildPatternPaint(*impl_->patternStrokePaint, opacity));
+    impl_->encoder->fillPathPattern(strokedOutline, strokeDerived.fillRule,
+                                    impl_->buildPatternPaint(*impl_->patternStrokePaint, opacity),
+                                    strokeDerived.encoded);
     impl_->patternStrokePaint.reset();
     return;
   }
@@ -2170,7 +2360,7 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   const double effectiveOpacity = impl_->paint.strokeOpacity;
   auto strokeServer = impl_->paint.stroke;
   impl_->drawPaintedPathAgainst(path.path, strokedOutline, strokeServer, effectiveOpacity,
-                                strokeFillRule);
+                                strokeDerived.fillRule, strokeDerived.encoded);
 }
 
 void RendererGeode::drawRect(const Box2d& rect, const StrokeParams& stroke) {

--- a/donner/svg/renderer/RendererInterface.h
+++ b/donner/svg/renderer/RendererInterface.h
@@ -8,6 +8,8 @@
 
 #include "donner/base/Box.h"
 #include "donner/base/EcsRegistry_fwd.h"
+#include "donner/base/FillRule.h"
+#include "donner/base/Path.h"
 #include "donner/base/RcString.h"
 #include "donner/base/RelativeLengthMetrics.h"
 #include "donner/base/SmallVector.h"
@@ -19,10 +21,8 @@
 #include "donner/svg/components/filter/FilterGraph.h"
 #include "donner/svg/components/text/ComputedTextComponent.h"
 #include "donner/svg/core/DominantBaseline.h"
-#include "donner/base/FillRule.h"
 #include "donner/svg/core/LengthAdjust.h"
 #include "donner/svg/core/MixBlendMode.h"
-#include "donner/base/Path.h"
 #include "donner/svg/core/TextAnchor.h"
 #include "donner/svg/core/TextDecoration.h"
 #include "donner/svg/core/WritingMode.h"
@@ -110,7 +110,7 @@ struct PaintParams {
  * Clip stack entry combining rectangles, paths, and optional masks.
  */
 struct ResolvedClip {
-  std::optional<Box2d> clipRect;  ///< Optional axis-aligned clip rectangle.
+  std::optional<Box2d> clipRect;     ///< Optional axis-aligned clip rectangle.
   std::vector<PathShape> clipPaths;  ///< Ordered list of clip path shapes to intersect.
   /// Transform applied to all clip paths (e.g., objectBoundingBox unit mapping).
   Transform2d clipPathUnitsTransform;  ///< Transform applied to the clip path coordinate system.

--- a/donner/svg/renderer/RendererInterface.h
+++ b/donner/svg/renderer/RendererInterface.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "donner/base/Box.h"
+#include "donner/base/EcsRegistry_fwd.h"
 #include "donner/base/RcString.h"
 #include "donner/base/RelativeLengthMetrics.h"
 #include "donner/base/SmallVector.h"
@@ -80,6 +81,12 @@ struct PathShape {
   /// Layer index for boolean combination: paths on the same layer are unioned, layers are
   /// intersected.
   int layer = 0;
+  /// Source entity this path was derived from. Set by the driver at the `drawPath` call
+  /// site (`RendererDriver::traverseRange`). Backends that cache per-entity state key
+  /// off this (see `GeodePathCacheComponent`). A null `EntityHandle` (the default) means
+  /// "no associated entity" — non-driver callers (overlay drawing, test harnesses) leave
+  /// it null and backends fall back to the un-cached path.
+  EntityHandle sourceEntity;
 };
 
 /**

--- a/donner/svg/renderer/geode/BUILD.bazel
+++ b/donner/svg/renderer/geode/BUILD.bazel
@@ -49,6 +49,18 @@ donner_cc_library(
     ],
 )
 
+# Header-only ECS component for the M2 Geode path-encode cache. See
+# design doc 0030 §Milestone 2.
+donner_cc_library(
+    name = "geode_path_cache_component",
+    hdrs = ["GeodePathCacheComponent.h"],
+    visibility = ["//donner/svg/renderer:__subpackages__"],
+    deps = [
+        ":geode_path_encoder",
+        "//donner/base",
+    ],
+)
+
 # Header-only perf-counters struct. See design doc 0030.
 donner_cc_library(
     name = "geode_counters",

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -851,7 +851,8 @@ void GeoEncoder::beginMaskPass(const wgpu::Texture& msaaMask, const wgpu::Textur
   impl_->maskPassOpen = true;
 }
 
-void GeoEncoder::fillPathIntoMask(const Path& path, FillRule rule) {
+void GeoEncoder::fillPathIntoMask(const Path& path, FillRule rule,
+                                  const EncodedPath* precomputedEncoded) {
   if (!impl_->maskPassOpen) {
     return;
   }
@@ -859,8 +860,14 @@ void GeoEncoder::fillPathIntoMask(const Path& path, FillRule rule) {
   // Dummy resources are pre-created in the encoder constructor so
   // the bind group is always complete, even if `beginMaskPass` fires
   // before any main draw.
-  impl_->device->countPathEncode();
-  EncodedPath encoded = GeodePathEncoder::encode(path, rule);
+  EncodedPath ownedEncoded;
+  const EncodedPath* encodedPtr = precomputedEncoded;
+  if (!encodedPtr) {
+    impl_->device->countPathEncode();
+    ownedEncoded = GeodePathEncoder::encode(path, rule);
+    encodedPtr = &ownedEncoded;
+  }
+  const EncodedPath& encoded = *encodedPtr;
   if (encoded.empty()) {
     return;
   }
@@ -976,6 +983,13 @@ struct GeoEncoder::FillDrawArgs {
   const Path* path;
   FillRule rule;
 
+  /// Optional precomputed encode. When non-null, `submitFillDraw`
+  /// uses this directly and skips `GeodePathEncoder::encode` +
+  /// `countPathEncode`. Used by the M2 `GeodePathCacheComponent`
+  /// cache-hit path (design doc 0030). When null, the encode runs
+  /// inline (legacy behavior).
+  const EncodedPath* precomputedEncoded = nullptr;
+
   // Paint mode selector. 0 = solid, 1 = pattern.
   uint32_t paintMode;
 
@@ -990,10 +1004,12 @@ struct GeoEncoder::FillDrawArgs {
   float patternOpacity;
 };
 
-void GeoEncoder::fillPath(const Path& path, const css::RGBA& color, FillRule rule) {
+void GeoEncoder::fillPath(const Path& path, const css::RGBA& color, FillRule rule,
+                          const EncodedPath* precomputedEncoded) {
   FillDrawArgs args = {};
   args.path = &path;
   args.rule = rule;
+  args.precomputedEncoded = precomputedEncoded;
   args.paintMode = 0u;
   const float alpha = color.a / 255.0f;
   args.solidColor[0] = (color.r / 255.0f) * alpha;
@@ -1013,7 +1029,8 @@ void GeoEncoder::fillPath(const Path& path, const css::RGBA& color, FillRule rul
   submitFillDraw(args);
 }
 
-void GeoEncoder::fillPathPattern(const Path& path, FillRule rule, const PatternPaint& paint) {
+void GeoEncoder::fillPathPattern(const Path& path, FillRule rule, const PatternPaint& paint,
+                                 const EncodedPath* precomputedEncoded) {
   if (!paint.tile || paint.tileSize.x <= 0.0 || paint.tileSize.y <= 0.0) {
     return;
   }
@@ -1035,6 +1052,7 @@ void GeoEncoder::fillPathPattern(const Path& path, FillRule rule, const PatternP
   FillDrawArgs args = {};
   args.path = &path;
   args.rule = rule;
+  args.precomputedEncoded = precomputedEncoded;
   args.paintMode = 1u;
   args.patternView = paint.tile.createView();
   args.patternSampler = sampler;
@@ -1056,9 +1074,18 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args) {
   // draw; see design doc 0030, Tier 4.
   impl_->bindSolidPipeline();
 
-  // 1. CPU encode the path into Slug band data.
-  impl_->device->countPathEncode();
-  EncodedPath encoded = GeodePathEncoder::encode(*args.path, args.rule);
+  // 1. CPU encode the path into Slug band data — unless the caller
+  // already supplied a precomputed encode via the M2 cache
+  // (`GeodePathCacheComponent`). Cache hits skip both the encode
+  // work and the `pathEncodes` counter bump.
+  EncodedPath ownedEncoded;
+  const EncodedPath* encodedPtr = args.precomputedEncoded;
+  if (!encodedPtr) {
+    impl_->device->countPathEncode();
+    ownedEncoded = GeodePathEncoder::encode(*args.path, args.rule);
+    encodedPtr = &ownedEncoded;
+  }
+  const EncodedPath& encoded = *encodedPtr;
   if (encoded.empty()) {
     return;  // Nothing to draw.
   }
@@ -1198,7 +1225,7 @@ void populateSharedGradientUniforms(GradientUniforms& u, const Transform2d& grad
 }  // namespace
 
 void GeoEncoder::fillPathLinearGradient(const Path& path, const LinearGradientParams& params,
-                                        FillRule rule) {
+                                        FillRule rule, const EncodedPath* precomputedEncoded) {
   if (params.stops.empty()) {
     return;
   }
@@ -1209,9 +1236,16 @@ void GeoEncoder::fillPathLinearGradient(const Path& path, const LinearGradientPa
   impl_->ensurePassOpen();
   impl_->bindGradientPipeline();
 
-  // 1. CPU encode the path into Slug band data (same as fillPath).
-  impl_->device->countPathEncode();
-  EncodedPath encoded = GeodePathEncoder::encode(path, rule);
+  // 1. CPU encode the path into Slug band data (same as fillPath) —
+  // unless the M2 cache already has a precomputed encode.
+  EncodedPath ownedEncoded;
+  const EncodedPath* encodedPtr = precomputedEncoded;
+  if (!encodedPtr) {
+    impl_->device->countPathEncode();
+    ownedEncoded = GeodePathEncoder::encode(path, rule);
+    encodedPtr = &ownedEncoded;
+  }
+  const EncodedPath& encoded = *encodedPtr;
   if (encoded.empty()) {
     return;
   }
@@ -1286,7 +1320,7 @@ void GeoEncoder::fillPathLinearGradient(const Path& path, const LinearGradientPa
 }
 
 void GeoEncoder::fillPathRadialGradient(const Path& path, const RadialGradientParams& params,
-                                        FillRule rule) {
+                                        FillRule rule, const EncodedPath* precomputedEncoded) {
   if (params.stops.empty()) {
     return;
   }
@@ -1302,8 +1336,14 @@ void GeoEncoder::fillPathRadialGradient(const Path& path, const RadialGradientPa
   impl_->ensurePassOpen();
   impl_->bindGradientPipeline();
 
-  impl_->device->countPathEncode();
-  EncodedPath encoded = GeodePathEncoder::encode(path, rule);
+  EncodedPath ownedEncoded;
+  const EncodedPath* encodedPtr = precomputedEncoded;
+  if (!encodedPtr) {
+    impl_->device->countPathEncode();
+    ownedEncoded = GeodePathEncoder::encode(path, rule);
+    encodedPtr = &ownedEncoded;
+  }
+  const EncodedPath& encoded = *encodedPtr;
   if (encoded.empty()) {
     return;
   }

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -266,29 +266,19 @@ struct GeoEncoder::Impl {
   // MSAA sample count from GeodeDevice. 1 = no MSAA (alpha-coverage path).
   uint32_t sampleCount = 4;
 
-  // Dummy 1x1 texture + sampler bound when `paintMode == 0` (solid fill).
-  // The bind group layout always requires texture/sampler entries so the
-  // pipeline can be shared between solid and pattern fills, but in solid
-  // mode the shader never reads from them. Lazily initialised on first use
-  // because the device may create the encoder before any draw is issued.
-  wgpu::Texture dummyTexture;
-  wgpu::TextureView dummyTextureView;
-  wgpu::Sampler dummySampler;
-
-  // 1x1 R8Unorm dummy texture bound to the clip-mask slot when no
-  // clip is active. The single texel is `0xFF` so `textureSample(...).r`
-  // returns 1.0 — i.e., "this pixel is fully unclipped" — allowing
-  // the shader to sample unconditionally without branching on
-  // `hasClipMask` just to avoid an invalid texture read.
-  wgpu::Texture dummyClipMaskTexture;
-  wgpu::TextureView dummyClipMaskTextureView;
+  // Dummy texture / sampler resources are now owned by `GeodeDevice`
+  // and shared across every GeoEncoder — see `GeodeDevice::dummyPatternTexture()`
+  // and the M4.2 notes in design doc 0030. Access them via
+  // `device->dummyPatternTextureView()`, etc. The bind-group layout
+  // always includes the pattern + clip-mask slots so the pipeline can
+  // be shared between solid/pattern/gradient/masked draws; the device
+  // dummies fill the unused slots.
 
   // Currently-bound clip mask state (Phase 3b). When
   // `activeClipMaskView` is non-null, `hasClipMask == 1` in the
   // uniforms and draws sample `activeClipMaskView` through the
-  // clip-mask binding. When null, the dummy is bound instead.
+  // clip-mask binding. When null, the device's shared dummy is bound.
   wgpu::TextureView activeClipMaskView;
-  wgpu::Sampler clipMaskSampler;
 
   // Lazily-constructed mask-rendering pipeline. We build one when the
   // first `beginMaskPass` call arrives so encoders that never touch
@@ -390,95 +380,15 @@ struct GeoEncoder::Impl {
     }
   }
 
-  /// Lazily create the dummy texture + sampler used by the solid-fill path
-  /// *and* the Phase 3b dummy clip mask texture + clip mask sampler.
-  void ensureDummyResources() {
-    if (dummyTextureView) {
-      return;
-    }
-    const wgpu::Device& dev = device->device();
-
-    // --- Pattern dummy (RGBA8Unorm, 1x1, opaque black) ---
-    wgpu::TextureDescriptor td = {};
-    td.label = wgpuLabel("GeoEncoderDummyPattern");
-    td.size = {1u, 1u, 1u};
-    td.format = wgpu::TextureFormat::RGBA8Unorm;
-    td.usage = wgpu::TextureUsage::TextureBinding | wgpu::TextureUsage::CopyDst;
-    td.mipLevelCount = 1;
-    td.sampleCount = 1;
-    td.dimension = wgpu::TextureDimension::_2D;
-    dummyTexture = dev.createTexture(td);
-    device->countTexture();
-
-    // Write a single opaque-black pixel so sampling returns a defined value
-    // even though the shader never reads it in solid mode. WriteTexture
-    // allows unpadded rows when the transfer fits in a single row.
-    const uint8_t pixel[4] = {0, 0, 0, 255};
-    wgpu::TexelCopyTextureInfo dst = {};
-    dst.texture = dummyTexture;
-    wgpu::TexelCopyBufferLayout layout = {};
-    layout.bytesPerRow = 4;
-    layout.rowsPerImage = 1;
-    wgpu::Extent3D extent = {1u, 1u, 1u};
-    device->queue().writeTexture(dst, pixel, sizeof(pixel), layout, extent);
-
-    dummyTextureView = dummyTexture.createView();
-
-    // `{wgpu::Default}` initializes with `maxAnisotropy = 1`; plain `= {}`
-    // leaves it at 0 which wgpu-native rejects as a validation error.
-    wgpu::SamplerDescriptor sd{wgpu::Default};
-    sd.label = wgpuLabel("GeoEncoderDummySampler");
-    sd.addressModeU = wgpu::AddressMode::Repeat;
-    sd.addressModeV = wgpu::AddressMode::Repeat;
-    sd.minFilter = wgpu::FilterMode::Linear;
-    sd.magFilter = wgpu::FilterMode::Linear;
-    sd.maxAnisotropy = 1;
-    dummySampler = dev.createSampler(sd);
-
-    // --- Clip-mask dummy (R8Unorm, 1x1, value 0xFF = 1.0) ---
-    wgpu::TextureDescriptor maskDummyDesc = {};
-    maskDummyDesc.label = wgpuLabel("GeoEncoderDummyClipMask");
-    maskDummyDesc.size = {1u, 1u, 1u};
-    maskDummyDesc.format = wgpu::TextureFormat::R8Unorm;
-    maskDummyDesc.usage = wgpu::TextureUsage::TextureBinding | wgpu::TextureUsage::CopyDst;
-    maskDummyDesc.mipLevelCount = 1;
-    maskDummyDesc.sampleCount = 1;
-    maskDummyDesc.dimension = wgpu::TextureDimension::_2D;
-    dummyClipMaskTexture = dev.createTexture(maskDummyDesc);
-    device->countTexture();
-
-    const uint8_t maskPixel[1] = {0xFF};
-    wgpu::TexelCopyTextureInfo maskDst = {};
-    maskDst.texture = dummyClipMaskTexture;
-    wgpu::TexelCopyBufferLayout maskLayout = {};
-    maskLayout.bytesPerRow = 1;
-    maskLayout.rowsPerImage = 1;
-    wgpu::Extent3D maskExtent = {1u, 1u, 1u};
-    device->queue().writeTexture(maskDst, maskPixel, sizeof(maskPixel), maskLayout, maskExtent);
-
-    dummyClipMaskTextureView = dummyClipMaskTexture.createView();
-
-    // Clip mask sampler — Linear / ClampToEdge so edge coverage
-    // interpolates smoothly without wrapping back to the opposite
-    // side of the mask texture.
-    wgpu::SamplerDescriptor maskSd{wgpu::Default};
-    maskSd.label = wgpuLabel("GeoEncoderClipMaskSampler");
-    maskSd.addressModeU = wgpu::AddressMode::ClampToEdge;
-    maskSd.addressModeV = wgpu::AddressMode::ClampToEdge;
-    maskSd.minFilter = wgpu::FilterMode::Linear;
-    maskSd.magFilter = wgpu::FilterMode::Linear;
-    maskSd.maxAnisotropy = 1;
-    clipMaskSampler = dev.createSampler(maskSd);
-  }
-
   /// Return the texture view that should be bound to the clip-mask
-  /// slot for the next draw — the active mask if set, or the dummy
-  /// otherwise. Always returns a valid view after `ensureDummyResources`.
+  /// slot for the next draw — the active mask if set, or the device's
+  /// shared identity-mask dummy otherwise (see
+  /// `GeodeDevice::dummyClipMaskTextureView()`).
   const wgpu::TextureView& currentClipMaskView() {
     if (activeClipMaskView) {
       return activeClipMaskView;
     }
-    return dummyClipMaskTextureView;
+    return device->dummyClipMaskTextureView();
   }
 
   /// Open the render pass on demand.
@@ -637,12 +547,12 @@ void GeoEncoder::initImpl(GeoEncoder::Impl& impl, GeodeDevice& device,
   // ensurePassOpen renders directly into targetView with no resolve.
 }
 
-// Post-init: pre-create dummies + configure per-draw arenas. Runs once
-// `commandEncoder` has been installed. Called by both constructors.
+// Post-init: configure per-draw arenas. Runs once `commandEncoder`
+// has been installed. Called by both constructors.
 void GeoEncoder::finalizeImpl(GeoEncoder::Impl& impl) {
-  // Pre-create the solid-fill / clip-mask dummy texture + sampler + view
-  // resources once per encoder; avoids a per-draw ensure call.
-  impl.ensureDummyResources();
+  // Dummy pattern / clip-mask textures + samplers are now owned by
+  // `GeodeDevice` (see design doc 0030 §M4.2) and shared across
+  // encoders — no per-encoder create needed.
 
   // Configure per-draw arenas (bump-allocated GPU buffers, design
   // doc 0030 Milestone 1). They stay empty here; the first draw
@@ -927,7 +837,7 @@ void GeoEncoder::fillPathIntoMask(const Path& path, FillRule rule,
   entries[3].binding = 3;
   entries[3].textureView = impl_->currentClipMaskView();
   entries[4].binding = 4;
-  entries[4].sampler = impl_->clipMaskSampler;
+  entries[4].sampler = impl_->device->dummyClipMaskSampler();
 
   wgpu::BindGroupDescriptor bgDesc = {};
   bgDesc.label = wgpuLabel("GeodeMaskBindGroup");
@@ -1021,8 +931,8 @@ void GeoEncoder::fillPath(const Path& path, const css::RGBA& color, FillRule rul
   // Solid-mode binds the pre-created dummy texture + sampler so the
   // bind group layout (which always includes pattern bindings) is
   // complete. Both are built once in the encoder constructor.
-  args.patternView = impl_->dummyTextureView;
-  args.patternSampler = impl_->dummySampler;
+  args.patternView = impl_->device->dummyPatternTextureView();
+  args.patternSampler = impl_->device->dummyPatternSampler();
   args.tileSize = Vector2d(1.0, 1.0);
   args.patternFromPath = Transform2d();
 
@@ -1157,7 +1067,7 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args) {
   entries[5].binding = 5;
   entries[5].textureView = impl_->currentClipMaskView();
   entries[6].binding = 6;
-  entries[6].sampler = impl_->clipMaskSampler;
+  entries[6].sampler = impl_->device->dummyClipMaskSampler();
 
   wgpu::BindGroupDescriptor bgDesc = {};
   bgDesc.label = wgpuLabel("GeodeBindGroup");
@@ -1304,7 +1214,7 @@ void GeoEncoder::fillPathLinearGradient(const Path& path, const LinearGradientPa
   entries[3].binding = 3;
   entries[3].textureView = impl_->currentClipMaskView();
   entries[4].binding = 4;
-  entries[4].sampler = impl_->clipMaskSampler;
+  entries[4].sampler = impl_->device->dummyClipMaskSampler();
 
   wgpu::BindGroupDescriptor bgDesc = {};
   bgDesc.label = wgpuLabel("GeodeGradientBindGroup");
@@ -1400,7 +1310,7 @@ void GeoEncoder::fillPathRadialGradient(const Path& path, const RadialGradientPa
   entries[3].binding = 3;
   entries[3].textureView = impl_->currentClipMaskView();
   entries[4].binding = 4;
-  entries[4].sampler = impl_->clipMaskSampler;
+  entries[4].sampler = impl_->device->dummyClipMaskSampler();
 
   wgpu::BindGroupDescriptor bgDesc = {};
   bgDesc.label = wgpuLabel("GeodeRadialGradientBindGroup");

--- a/donner/svg/renderer/geode/GeoEncoder.h
+++ b/donner/svg/renderer/geode/GeoEncoder.h
@@ -23,6 +23,8 @@ struct ImageResource;
 
 namespace donner::geode {
 
+struct EncodedPath;
+
 class GeodeDevice;
 class GeodeImagePipeline;
 class GeodePipeline;
@@ -268,7 +270,12 @@ public:
    * The current encoder transform applies (so clip paths use the same
    * device-pixel mapping as the content being clipped).
    */
-  void fillPathIntoMask(const Path& path, FillRule rule);
+  /// @param precomputedEncoded Optional M2 cache-hit payload. When
+  ///   non-null, the encoder skips `GeodePathEncoder::encode` and the
+  ///   `pathEncodes` counter bump. Used by `RendererGeode` to plumb a
+  ///   cached `GeodePathCacheComponent::strokeSlot` result.
+  void fillPathIntoMask(const Path& path, FillRule rule,
+                        const EncodedPath* precomputedEncoded = nullptr);
 
   /// Close the mask render pass opened by `beginMaskPass`.
   void endMaskPass();
@@ -379,7 +386,11 @@ public:
    *   premultiplication for the blend pipeline).
    * @param rule Fill rule (NonZero or EvenOdd).
    */
-  void fillPath(const Path& path, const css::RGBA& color, FillRule rule);
+  /// @param precomputedEncoded Optional M2 cache-hit payload — see
+  ///   `GeodePathCacheComponent`. When non-null, skips encode +
+  ///   counter bump.
+  void fillPath(const Path& path, const css::RGBA& color, FillRule rule,
+                const EncodedPath* precomputedEncoded = nullptr);
 
   /**
    * Fill a path with a linear gradient.
@@ -400,7 +411,8 @@ public:
    *   verbose warning at the call site in `RendererGeode`.
    * @param rule Fill rule (NonZero or EvenOdd).
    */
-  void fillPathLinearGradient(const Path& path, const LinearGradientParams& params, FillRule rule);
+  void fillPathLinearGradient(const Path& path, const LinearGradientParams& params, FillRule rule,
+                              const EncodedPath* precomputedEncoded = nullptr);
 
   /**
    * Fill a path with a radial gradient.
@@ -418,7 +430,8 @@ public:
    *   focal point + radius, shared transform and stops).
    * @param rule Fill rule (NonZero or EvenOdd).
    */
-  void fillPathRadialGradient(const Path& path, const RadialGradientParams& params, FillRule rule);
+  void fillPathRadialGradient(const Path& path, const RadialGradientParams& params, FillRule rule,
+                              const EncodedPath* precomputedEncoded = nullptr);
 
   /**
    * Describes a pattern tile used as a paint source for `fillPathPattern`.
@@ -451,7 +464,8 @@ public:
    * test identically to `fillPath`, and samples the tile for pixels inside
    * the path.
    */
-  void fillPathPattern(const Path& path, FillRule rule, const PatternPaint& paint);
+  void fillPathPattern(const Path& path, FillRule rule, const PatternPaint& paint,
+                       const EncodedPath* precomputedEncoded = nullptr);
 
   /**
    * Submit all encoded commands to the GPU queue.

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -21,9 +21,8 @@ namespace {
 /// The WebGPU C API passes the message as a `WGPUStringView` (pointer +
 /// length) rather than a NUL-terminated string, so we use the
 /// precision-length form of `printf` to avoid reading past `length`.
-void OnUncapturedError(WGPUDevice const* /*device*/, WGPUErrorType type,
-                       WGPUStringView message, void* /*userdata1*/,
-                       void* /*userdata2*/) {
+void OnUncapturedError(WGPUDevice const* /*device*/, WGPUErrorType type, WGPUStringView message,
+                       void* /*userdata1*/, void* /*userdata2*/) {
   std::fprintf(stderr, "[Geode/wgpu-native] Uncaptured error (type=%d): %.*s\n",
                static_cast<int>(type), static_cast<int>(message.length),
                message.data ? message.data : "");
@@ -36,6 +35,17 @@ void OnUncapturedError(WGPUDevice const* /*device*/, WGPUErrorType type,
 /// directly on the outer class.
 struct GeodeDevice::Impl {
   wgpu::Instance instance;
+
+  // Shared dummies used by every GeoEncoder's bind groups — see
+  // comment block on `GeodeDevice::dummyPatternTexture()`. Created
+  // once at `CreateHeadless` time so they never count against
+  // per-frame `textureCreates` ceilings.
+  wgpu::Texture dummyPatternTexture;
+  wgpu::TextureView dummyPatternTextureView;
+  wgpu::Sampler dummyPatternSampler;
+  wgpu::Texture dummyClipMaskTexture;
+  wgpu::TextureView dummyClipMaskTextureView;
+  wgpu::Sampler dummyClipMaskSampler;
 };
 
 GeodeDevice::GeodeDevice() : impl_(std::make_unique<Impl>()) {}
@@ -109,9 +119,8 @@ std::unique_ptr<GeodeDevice> GeodeDevice::CreateHeadless() {
       std::fprintf(stderr,
                    "[Geode/wgpu-native] Adapter: %.*s %.*s (%.*s) "
                    "backend=%s type=%s vendorID=0x%04x deviceID=0x%04x\n",
-                   static_cast<int>(vendor.size()), vendor.data(),
-                   static_cast<int>(device.size()), device.data(),
-                   static_cast<int>(arch.size()), arch.data(), backend, type,
+                   static_cast<int>(vendor.size()), vendor.data(), static_cast<int>(device.size()),
+                   device.data(), static_cast<int>(arch.size()), arch.data(), backend, type,
                    info.vendorID, info.deviceID);
 
       // Intel + Vulkan: writing @builtin(sample_mask) from overlapping band
@@ -161,7 +170,99 @@ std::unique_ptr<GeodeDevice> GeodeDevice::CreateHeadless() {
     return nullptr;
   }
 
+  // 5. Create the shared dummy textures / samplers used by every
+  // GeoEncoder. These are 1×1 "identity" fills for the pattern and
+  // clip-mask bind slots when the current draw doesn't actually use
+  // them. Previously each GeoEncoder allocated its own pair, which
+  // showed up as 2+ `textureCreates` per frame for every
+  // push/pop layer/filter/mask encoder. See design doc 0030 §M4.2.
+  //
+  // Created here (before any `setCounters()` call) so the allocations
+  // never count against per-frame ceilings.
+  {
+    // Pattern dummy: 1×1 RGBA8 opaque black.
+    wgpu::TextureDescriptor td = {};
+    td.label = wgpu::StringView{std::string_view{"GeodeDeviceDummyPattern"}};
+    td.size = {1u, 1u, 1u};
+    td.format = wgpu::TextureFormat::RGBA8Unorm;
+    td.usage = wgpu::TextureUsage::TextureBinding | wgpu::TextureUsage::CopyDst;
+    td.mipLevelCount = 1;
+    td.sampleCount = 1;
+    td.dimension = wgpu::TextureDimension::_2D;
+    result->impl_->dummyPatternTexture = result->device_.createTexture(td);
+
+    const uint8_t pixel[4] = {0, 0, 0, 255};
+    wgpu::TexelCopyTextureInfo dst = {};
+    dst.texture = result->impl_->dummyPatternTexture;
+    wgpu::TexelCopyBufferLayout layout = {};
+    layout.bytesPerRow = 4;
+    layout.rowsPerImage = 1;
+    wgpu::Extent3D extent = {1u, 1u, 1u};
+    result->queue_.writeTexture(dst, pixel, sizeof(pixel), layout, extent);
+    result->impl_->dummyPatternTextureView = result->impl_->dummyPatternTexture.createView();
+
+    wgpu::SamplerDescriptor sd{wgpu::Default};
+    sd.label = wgpu::StringView{std::string_view{"GeodeDeviceDummyPatternSampler"}};
+    sd.addressModeU = wgpu::AddressMode::Repeat;
+    sd.addressModeV = wgpu::AddressMode::Repeat;
+    sd.minFilter = wgpu::FilterMode::Linear;
+    sd.magFilter = wgpu::FilterMode::Linear;
+    sd.maxAnisotropy = 1;
+    result->impl_->dummyPatternSampler = result->device_.createSampler(sd);
+  }
+
+  {
+    // Clip-mask dummy: 1×1 R8Unorm with value 0xFF (= 1.0 coverage).
+    wgpu::TextureDescriptor md = {};
+    md.label = wgpu::StringView{std::string_view{"GeodeDeviceDummyClipMask"}};
+    md.size = {1u, 1u, 1u};
+    md.format = wgpu::TextureFormat::R8Unorm;
+    md.usage = wgpu::TextureUsage::TextureBinding | wgpu::TextureUsage::CopyDst;
+    md.mipLevelCount = 1;
+    md.sampleCount = 1;
+    md.dimension = wgpu::TextureDimension::_2D;
+    result->impl_->dummyClipMaskTexture = result->device_.createTexture(md);
+
+    const uint8_t mpixel[1] = {0xFF};
+    wgpu::TexelCopyTextureInfo mdst = {};
+    mdst.texture = result->impl_->dummyClipMaskTexture;
+    wgpu::TexelCopyBufferLayout mlayout = {};
+    mlayout.bytesPerRow = 1;
+    mlayout.rowsPerImage = 1;
+    wgpu::Extent3D mextent = {1u, 1u, 1u};
+    result->queue_.writeTexture(mdst, mpixel, sizeof(mpixel), mlayout, mextent);
+    result->impl_->dummyClipMaskTextureView = result->impl_->dummyClipMaskTexture.createView();
+
+    wgpu::SamplerDescriptor msd{wgpu::Default};
+    msd.label = wgpu::StringView{std::string_view{"GeodeDeviceDummyClipMaskSampler"}};
+    msd.addressModeU = wgpu::AddressMode::ClampToEdge;
+    msd.addressModeV = wgpu::AddressMode::ClampToEdge;
+    msd.minFilter = wgpu::FilterMode::Linear;
+    msd.magFilter = wgpu::FilterMode::Linear;
+    msd.maxAnisotropy = 1;
+    result->impl_->dummyClipMaskSampler = result->device_.createSampler(msd);
+  }
+
   return result;
+}
+
+const wgpu::Texture& GeodeDevice::dummyPatternTexture() const {
+  return impl_->dummyPatternTexture;
+}
+const wgpu::TextureView& GeodeDevice::dummyPatternTextureView() const {
+  return impl_->dummyPatternTextureView;
+}
+const wgpu::Sampler& GeodeDevice::dummyPatternSampler() const {
+  return impl_->dummyPatternSampler;
+}
+const wgpu::Texture& GeodeDevice::dummyClipMaskTexture() const {
+  return impl_->dummyClipMaskTexture;
+}
+const wgpu::TextureView& GeodeDevice::dummyClipMaskTextureView() const {
+  return impl_->dummyClipMaskTextureView;
+}
+const wgpu::Sampler& GeodeDevice::dummyClipMaskSampler() const {
+  return impl_->dummyClipMaskSampler;
 }
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -116,6 +116,38 @@ public:
    */
   bool supportsTimestamps() const { return false; }
 
+  /// @name Shared dummy resources (design doc 0030 Milestone 4.2)
+  /// @{
+  ///
+  /// GeoEncoder's bind groups always include pattern + clip-mask
+  /// texture/sampler slots, even when the current draw doesn't
+  /// actually use them. Each slot is filled with a 1×1 "identity"
+  /// texture when the feature is inactive. Prior to M4.2 every
+  /// GeoEncoder instance created its own dummies (two textures per
+  /// encoder), which showed up as 2+ `textureCreates` per frame per
+  /// push/pop. Caching the dummies on the device — one instance per
+  /// GeodeDevice — drops that to zero steady-state.
+
+  /// 1×1 opaque-black RGBA8 dummy. Bound into the pattern slot when
+  /// the current draw is solid / gradient (not a pattern). The shader
+  /// does not sample from it, but the bind group layout still requires
+  /// a valid binding.
+  const wgpu::Texture& dummyPatternTexture() const;
+  /// View of `dummyPatternTexture()`.
+  const wgpu::TextureView& dummyPatternTextureView() const;
+  /// Linear-Repeat sampler used for both the dummy and real pattern tiles.
+  const wgpu::Sampler& dummyPatternSampler() const;
+
+  /// 1×1 R8Unorm with value `0xFF` (= 1.0 coverage). Bound into the
+  /// clip-mask slot when no clip mask is active — the shader
+  /// multiplies coverage by this value, so `1.0` is a no-op.
+  const wgpu::Texture& dummyClipMaskTexture() const;
+  /// View of `dummyClipMaskTexture()`.
+  const wgpu::TextureView& dummyClipMaskTextureView() const;
+  /// Linear-ClampToEdge sampler used for both the dummy and real clip masks.
+  const wgpu::Sampler& dummyClipMaskSampler() const;
+  /// @}
+
 private:
   GeodeDevice();
 

--- a/donner/svg/renderer/geode/GeodePathCacheComponent.h
+++ b/donner/svg/renderer/geode/GeodePathCacheComponent.h
@@ -1,0 +1,68 @@
+#pragma once
+/// @file
+/// Per-entity cache of Geode's CPU encode pipeline output.
+///
+/// Design doc: docs/design_docs/0030-geode_performance.md §Milestone 2.
+///
+/// `GeodePathEncoder::encode` (cubicToQuadratic → toMonotonic → band
+/// decomposition) is the Tier-3 hot path identified in 0030. Without a
+/// cache it runs every frame for every draw — 132 times per frame for
+/// `lion.svg`. This component holds the encode result across frames so
+/// re-rendering an unchanged document skips the CPU work entirely.
+///
+/// Invalidation is owned by `RendererGeode`, which listens on entt's
+/// `on_update<ComputedPathComponent>` + `on_destroy<ComputedPathComponent>`
+/// signals and removes this component whenever the underlying geometry
+/// changes. `ShapeSystem`'s content-equality gate (see
+/// `emplaceComputedPathIfChanged`) ensures those signals only fire when
+/// the path actually changed, so idle re-renders leave the cache intact.
+
+#include <optional>
+
+#include "donner/base/Path.h"
+#include "donner/svg/renderer/geode/GeodePathEncoder.h"
+
+namespace donner::geode {
+
+/// Per-entity cache of Geode's encoded-path output (and strokeToFill
+/// result). Installed lazily by `RendererGeode` at the encode call
+/// sites via `get_or_emplace`; removed automatically when the source
+/// `ComputedPathComponent` updates or is destroyed.
+///
+/// Lives in `donner::geode` (not `donner::svg::geode`) to match the
+/// other Geode types (`EncodedPath`, `LinearGradientParams`, …) that
+/// `RendererGeode.cc` references unqualified via `geode::` inside the
+/// `donner::svg` namespace.
+struct GeodePathCacheComponent {
+  /// Fill-slot encode. Populated on first encode; reused on hit.
+  /// Reset by the entt signal listener when geometry changes.
+  std::optional<EncodedPath> fillEncode;
+
+  /// Stroke-slot cache. Holds both the `Path::strokeToFill` output
+  /// path and its encoded form, keyed by the source `StrokeStyle`.
+  /// Invalidated whenever the fill slot is (geometry change, via the
+  /// entt signal), or on stroke-key mismatch (stroke width/dash/cap/
+  /// join change via CSS — the old key no longer matches the new one,
+  /// so the next access regenerates).
+  struct StrokeSlot {
+    /// Equality key. Compared against the caller's `StrokeStyle` to
+    /// detect stroke-parameter changes.
+    StrokeStyle strokeKey;
+
+    /// Cached `Path::strokeToFill` output. Reused across draws of
+    /// the same entity + stroke-key combination.
+    Path strokedPath;
+
+    /// Cached encode of `strokedPath`. Produced by
+    /// `GeodePathEncoder::encode(strokedPath, strokeFillRule)`.
+    EncodedPath strokedEncode;
+
+    /// Fill rule the stroke was encoded with. `strokeToFill` picks
+    /// NonZero vs EvenOdd based on subpath topology, so this is
+    /// derived and cached alongside the encode.
+    FillRule strokeFillRule = FillRule::NonZero;
+  };
+  std::optional<StrokeSlot> strokeSlot;
+};
+
+}  // namespace donner::geode

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -277,5 +277,116 @@ TEST_F(GeodePerfTest, CountersResetBetweenFrames) {
       << "because render targets are reused at the same size.";
 }
 
+// ---------------------------------------------------------------------------
+// Milestone 2: GeodePathCacheComponent — no-geometry-change ⇒ zero encodes.
+//
+// The promise: once a document has been rendered once, rendering it again
+// with no geometry or style mutation must perform zero CPU-side path
+// encodes. `GeodePathCacheComponent` holds the `EncodedPath` across frames;
+// `ComputedPathComponent` equality gating in `ShapeSystem` means its entt
+// `on_update` signal only fires when geometry actually changes, so the
+// cache survives idle re-renders.
+//
+// These tests use one `RendererGeode` across two `draw()` calls so the
+// cache component on the document's registry is live on frame 2.
+// ---------------------------------------------------------------------------
+
+/// Helper: two consecutive renders of the same document, returning only
+/// the SECOND frame's counters. Used by the M2 zero-encode assertions.
+geode::GeodeCounters countersForSecondRender(std::string_view svgSource,
+                                             const std::shared_ptr<geode::GeodeDevice>& device) {
+  ParseWarningSink sink = ParseWarningSink::Disabled();
+  auto parsed = parser::SVGParser::ParseSVG(svgSource, sink);
+  if (parsed.hasError()) {
+    ADD_FAILURE() << "ParseSVG failed: " << parsed.error().reason;
+    return {};
+  }
+  SVGDocument document = std::move(parsed.result());
+
+  RendererGeode renderer(device);
+  renderer.draw(document);
+  (void)renderer.takeSnapshot();
+  // First-frame counters intentionally discarded — we only care about the
+  // steady-state second frame.
+
+  renderer.draw(document);
+  (void)renderer.takeSnapshot();
+  return renderer.lastFrameTimings().counters;
+}
+
+TEST_F(GeodePerfTest, SimpleShapes_NoDirtyPath_ZeroEncodes) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  const geode::GeodeCounters c = countersForSecondRender(kSimpleShapesSvg, device);
+  printCounters("SimpleShapes_NoDirtyPath_ZeroEncodes (frame2)", c);
+
+  // M2 target: second frame does zero path encodes — three shapes hit the
+  // cache. countPathEncode() is only called on cache miss.
+  EXPECT_EQ(c.pathEncodes, 0u)
+      << "Cache miss on an unchanged second render: one or more paths "
+         "re-encoded despite zero geometry changes.";
+}
+
+TEST_F(GeodePerfTest, Moderate_NoDirtyPath_ZeroEncodes) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  const geode::GeodeCounters c = countersForSecondRender(kModerateSvg, device);
+  printCounters("Moderate_NoDirtyPath_ZeroEncodes (frame2)", c);
+
+  // M2 target: zero encodes across both fill paths — confirms the cache
+  // covers both `submitFillDraw` (opacity-layer path) and
+  // `fillPathLinearGradient` (rounded-rect path).
+  EXPECT_EQ(c.pathEncodes, 0u)
+      << "Cache miss on unchanged second render: fill or gradient path "
+         "re-encoded despite zero geometry changes.";
+}
+
+TEST_F(GeodePerfTest, Lion_NoDirtyPath_ZeroEncodes) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  const std::string svg = readFile("donner/svg/renderer/testdata/lion.svg");
+  if (svg.empty()) {
+    GTEST_SKIP() << "testdata/lion.svg not readable — ensure the test target "
+                 << "has testdata as a data dep.";
+    return;
+  }
+
+  const geode::GeodeCounters c = countersForSecondRender(svg, device);
+  printCounters("Lion_NoDirtyPath_ZeroEncodes (frame2)", c);
+
+  // M2 target: 132 cached paths → zero re-encodes. This is the headline
+  // assertion: the lion is our standard "many paths" stress fixture and
+  // the M0 baseline showed 132 pathEncodes per frame. Driving that to 0
+  // is the whole point of the cache.
+  EXPECT_EQ(c.pathEncodes, 0u)
+      << "Cache miss on unchanged second render of lion.svg: "
+         "re-encoded paths despite zero geometry changes.";
+}
+
+TEST_F(GeodePerfTest, GhostscriptTiger_NoDirtyPath_ZeroEncodes) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  const std::string svg = readFile("donner/svg/renderer/testdata/Ghostscript_Tiger.svg");
+  if (svg.empty()) {
+    GTEST_SKIP() << "testdata/Ghostscript_Tiger.svg not readable — ensure the "
+                 << "test target has testdata as a data dep.";
+    return;
+  }
+
+  const geode::GeodeCounters c = countersForSecondRender(svg, device);
+  printCounters("GhostscriptTiger_NoDirtyPath_ZeroEncodes (frame2)", c);
+
+  // M2 target: Tiger has strokes too, so this test also exercises the
+  // stroke slot of `GeodePathCacheComponent` — a second render must not
+  // re-run `Path::strokeToFill` nor re-encode the stroked outline.
+  EXPECT_EQ(c.pathEncodes, 0u)
+      << "Cache miss on unchanged second render of Ghostscript_Tiger.svg: "
+         "fill- or stroke-slot cache missed despite zero geometry changes.";
+}
+
 }  // namespace
 }  // namespace donner::svg

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -153,10 +153,13 @@ TEST_F(GeodePerfTest, SimpleShapes_BaselineCeilings) {
   //   M1.f.1 (uniforms):  bufferCreates=5 (4 arenas + 1 readback,
   //                       arenas lazily grown — some frames only
   //                       touch 3 arenas)
+  //   M4.2 (device dummies + pool): textureCreates=2 (target + MSAA
+  //                       pair, fresh on first frame; repeat-render
+  //                       is 0, see `*_ZeroTextures` tests below).
   EXPECT_LE(c.pathEncodes, 5u);       // M2: target = 0 on unchanged-geometry frames.
   EXPECT_LE(c.bufferCreates, 8u);     // M1.f.2: target = 1 (readback only).
   EXPECT_LE(c.bindgroupCreates, 6u);  // M1.f.2: target <= #pipelines (3 today).
-  EXPECT_LE(c.textureCreates, 6u);    // M4: target = 0 on unchanged-size repeat.
+  EXPECT_LE(c.textureCreates, 3u);    // Target + MSAA pair on frame 1; 0 on repeat.
   EXPECT_LE(c.submits, 3u);           // M3: target = 1.
 }
 
@@ -184,10 +187,12 @@ TEST_F(GeodePerfTest, Moderate_BaselineCeilings) {
   //                   their own arenas — 3×3 + 1 readback.)
   //   M3 (shared CE): bufferCreates=10 submits=2 textureCreates=10
   //                   (push/pop no longer forces a queue submit)
+  //   M4.2 (device dummies + pool): textureCreates=4 on frame 1
+  //                   (target+MSAA + layer+MSAA), 0 on repeat.
   EXPECT_LE(c.pathEncodes, 4u);       // M2: target = 0.
   EXPECT_LE(c.bufferCreates, 12u);    // M1.f.2 + future arena-share: target ~= 5.
   EXPECT_LE(c.bindgroupCreates, 6u);  // M1.f.2: target <= #pipelines.
-  EXPECT_LE(c.textureCreates, 12u);   // M4: target = 0 on repeat same-size.
+  EXPECT_LE(c.textureCreates, 6u);    // Target+MSAA + layer+MSAA on first render; 0 on repeat.
   EXPECT_LE(c.submits, 3u);           // M3: target = 2 steady-state (frame + readback).
 }
 
@@ -224,10 +229,12 @@ TEST_F(GeodePerfTest, Lion_BaselineCeilings) {
   //   M1.f.1 (uniforms):  bufferCreates=6 (4 arenas + 2 dummies +
   //                       readback; 98.9% total drop from M0)
   //   bindgroupCreates=132 (one per draw; M1.f.2 collapses to ~1).
+  //   M4.2 (device dummies + pool): textureCreates=2 on frame 1
+  //                       (target + MSAA); 0 on repeat.
   EXPECT_LE(c.pathEncodes, 200u);       // M2: target = 0.
   EXPECT_LE(c.bufferCreates, 10u);      // M1.f.2: target ~= 5 steady-state.
   EXPECT_LE(c.bindgroupCreates, 200u);  // M1.f.2: target <= #pipelines.
-  EXPECT_LE(c.textureCreates, 6u);      // M4: target = 0.
+  EXPECT_LE(c.textureCreates, 3u);      // Target + MSAA on first render; 0 on repeat.
   EXPECT_LE(c.submits, 3u);             // M3: target = 1.
 }
 

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -387,5 +387,79 @@ TEST_F(GeodePerfTest, GhostscriptTiger_NoDirtyPath_ZeroEncodes) {
          "fill- or stroke-slot cache missed despite zero geometry changes.";
 }
 
+// ---------------------------------------------------------------------------
+// Milestone 4.2: Transient render-target pool — zero-alloc repeat render.
+//
+// Per design doc 0030 §M4.2: a size-keyed free list for layer / filter /
+// mask / clip-mask scratch textures. Combined with M4.1 (target + MSAA
+// reuse) and the per-encoder persistent dummy texture (M1), a repeat
+// render of the same document at the same size should allocate zero
+// textures on frame 2.
+// ---------------------------------------------------------------------------
+
+TEST_F(GeodePerfTest, SimpleShapes_NoDirtyPath_ZeroTextures) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  const geode::GeodeCounters c = countersForSecondRender(kSimpleShapesSvg, device);
+  printCounters("SimpleShapes_NoDirtyPath_ZeroTextures (frame2)", c);
+
+  // Exercises only the main target / MSAA pair; no isolated layers.
+  // Any texture allocation here means M4.1 regressed or a dummy is
+  // leaking per-frame.
+  EXPECT_EQ(c.textureCreates, 0u)
+      << "Texture allocation on unchanged second render: main target or "
+         "dummy texture leaking across frames.";
+}
+
+TEST_F(GeodePerfTest, Moderate_NoDirtyPath_ZeroTextures) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  const geode::GeodeCounters c = countersForSecondRender(kModerateSvg, device);
+  printCounters("Moderate_NoDirtyPath_ZeroTextures (frame2)", c);
+
+  // Moderate fixture has `<path opacity="0.8">` which triggers a
+  // `pushIsolatedLayer` / `popIsolatedLayer` round-trip per frame. The
+  // layer allocates an RGBA8 resolve + 4× MSAA companion — M4.2 must
+  // pool and reuse both.
+  EXPECT_EQ(c.textureCreates, 0u)
+      << "Isolated-layer texture leak on unchanged second render. "
+         "Layer push/pop should draw from the M4.2 texture pool.";
+}
+
+TEST_F(GeodePerfTest, Lion_NoDirtyPath_ZeroTextures) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  const std::string svg = readFile("donner/svg/renderer/testdata/lion.svg");
+  if (svg.empty()) {
+    GTEST_SKIP() << "testdata/lion.svg not readable.";
+    return;
+  }
+
+  const geode::GeodeCounters c = countersForSecondRender(svg, device);
+  printCounters("Lion_NoDirtyPath_ZeroTextures (frame2)", c);
+
+  EXPECT_EQ(c.textureCreates, 0u) << "Texture allocation on unchanged second render of lion.svg.";
+}
+
+TEST_F(GeodePerfTest, GhostscriptTiger_NoDirtyPath_ZeroTextures) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  const std::string svg = readFile("donner/svg/renderer/testdata/Ghostscript_Tiger.svg");
+  if (svg.empty()) {
+    GTEST_SKIP() << "testdata/Ghostscript_Tiger.svg not readable.";
+    return;
+  }
+
+  const geode::GeodeCounters c = countersForSecondRender(svg, device);
+  printCounters("GhostscriptTiger_NoDirtyPath_ZeroTextures (frame2)", c);
+
+  EXPECT_EQ(c.textureCreates, 0u)
+      << "Texture allocation on unchanged second render of Ghostscript_Tiger.svg.";
+}
+
 }  // namespace
 }  // namespace donner::svg

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -430,9 +430,8 @@ TEST_F(GeodePerfTest, Moderate_NoDirtyPath_ZeroTextures) {
   // `pushIsolatedLayer` / `popIsolatedLayer` round-trip per frame. The
   // layer allocates an RGBA8 resolve + 4× MSAA companion — M4.2 must
   // pool and reuse both.
-  EXPECT_EQ(c.textureCreates, 0u)
-      << "Isolated-layer texture leak on unchanged second render. "
-         "Layer push/pop should draw from the M4.2 texture pool.";
+  EXPECT_EQ(c.textureCreates, 0u) << "Isolated-layer texture leak on unchanged second render. "
+                                     "Layer push/pop should draw from the M4.2 texture pool.";
 }
 
 TEST_F(GeodePerfTest, Lion_NoDirtyPath_ZeroTextures) {

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -267,10 +267,12 @@ TEST_F(GeodePerfTest, CountersResetBetweenFrames) {
   const auto secondCounters = renderer.lastFrameTimings().counters;
 
   // Second-frame counters are strictly this-frame only (beginFrame
-  // resets). They should be no greater than the first frame's — same
-  // work, and render targets are reused across same-size frames
-  // (design doc 0030 Milestone 4.1).
-  EXPECT_GT(secondCounters.pathEncodes, 0u);
+  // resets). Since M2 (`GeodePathCacheComponent`) landed, an unchanged
+  // second render does zero path encodes — the explicit assertion on
+  // that invariant lives in `SimpleShapes_NoDirtyPath_ZeroEncodes`;
+  // here we just confirm the reset path preserves the invariant across
+  // counters and that render targets get reused (Milestone 4.1).
+  EXPECT_EQ(secondCounters.pathEncodes, 0u);
   EXPECT_LE(secondCounters.pathEncodes, firstCounters.pathEncodes);
   EXPECT_LT(secondCounters.textureCreates, firstCounters.textureCreates)
       << "Second frame should create STRICTLY FEWER textures than the first "
@@ -323,9 +325,8 @@ TEST_F(GeodePerfTest, SimpleShapes_NoDirtyPath_ZeroEncodes) {
 
   // M2 target: second frame does zero path encodes — three shapes hit the
   // cache. countPathEncode() is only called on cache miss.
-  EXPECT_EQ(c.pathEncodes, 0u)
-      << "Cache miss on an unchanged second render: one or more paths "
-         "re-encoded despite zero geometry changes.";
+  EXPECT_EQ(c.pathEncodes, 0u) << "Cache miss on an unchanged second render: one or more paths "
+                                  "re-encoded despite zero geometry changes.";
 }
 
 TEST_F(GeodePerfTest, Moderate_NoDirtyPath_ZeroEncodes) {
@@ -338,9 +339,8 @@ TEST_F(GeodePerfTest, Moderate_NoDirtyPath_ZeroEncodes) {
   // M2 target: zero encodes across both fill paths — confirms the cache
   // covers both `submitFillDraw` (opacity-layer path) and
   // `fillPathLinearGradient` (rounded-rect path).
-  EXPECT_EQ(c.pathEncodes, 0u)
-      << "Cache miss on unchanged second render: fill or gradient path "
-         "re-encoded despite zero geometry changes.";
+  EXPECT_EQ(c.pathEncodes, 0u) << "Cache miss on unchanged second render: fill or gradient path "
+                                  "re-encoded despite zero geometry changes.";
 }
 
 TEST_F(GeodePerfTest, Lion_NoDirtyPath_ZeroEncodes) {
@@ -361,9 +361,8 @@ TEST_F(GeodePerfTest, Lion_NoDirtyPath_ZeroEncodes) {
   // assertion: the lion is our standard "many paths" stress fixture and
   // the M0 baseline showed 132 pathEncodes per frame. Driving that to 0
   // is the whole point of the cache.
-  EXPECT_EQ(c.pathEncodes, 0u)
-      << "Cache miss on unchanged second render of lion.svg: "
-         "re-encoded paths despite zero geometry changes.";
+  EXPECT_EQ(c.pathEncodes, 0u) << "Cache miss on unchanged second render of lion.svg: "
+                                  "re-encoded paths despite zero geometry changes.";
 }
 
 TEST_F(GeodePerfTest, GhostscriptTiger_NoDirtyPath_ZeroEncodes) {

--- a/tools/cmake/gen_cmakelists.py
+++ b/tools/cmake/gen_cmakelists.py
@@ -237,6 +237,7 @@ SKIPPED_CMAKE_TARGET_DEPS: Set[str] = {
     "donner_svg_renderer_geode_geode_device",
     "donner_svg_renderer_geode_geode_filter_engine",
     "donner_svg_renderer_geode_geode_image_pipeline",
+    "donner_svg_renderer_geode_geode_path_cache_component",
     "donner_svg_renderer_geode_geode_pipeline",
     "donner_svg_renderer_geode_geode_path_encoder",
     "donner_svg_renderer_geode_geode_shaders",


### PR DESCRIPTION
## Summary

Implements two cross-cutting Geode performance milestones from design doc
0030 so idle re-renders of the same document allocate zero CPU-side
encodes *and* zero transient textures:

- **M2: `GeodePathCacheComponent`** — caches `GeodePathEncoder::encode`
  (cubic→quadratic, monotonic split, band decomposition) and
  `Path::strokeToFill` on a per-entity ECS component, keyed by entt
  `on_update<ComputedPathComponent>` invalidation.
- **M4.2: transient-texture pool** — exact-size
  `(width, height, format, sampleCount, usage)` free list covering
  isolated-layer / filter-layer / mask / clip-mask scratch textures
  plus the mix-blend-mode `dstSnapshot`. Releases are deferred to
  after `queue.submit` so GPU work finishes before the same texture
  is handed back out.

## Headline counter deltas (frame 2, same document)

| Fixture               | pathEncodes | textureCreates |
|-----------------------|-------------|----------------|
| SimpleShapes          | 3 → 0       | 2 → 0          |
| Moderate (w/ layer)   | 2 → 0       | 8 → 0          |
| lion.svg              | 132 → 0     | 2 → 0          |
| Ghostscript_Tiger.svg | 305 → 0     | 2 → 0          |

Both invariants are asserted by
`{SimpleShapes,Moderate,Lion,GhostscriptTiger}_NoDirtyPath_{ZeroEncodes,ZeroTextures}`
in `GeodePerf_tests.cc`.

## What's in the stack

Commits (in order):

1. `design: retain M1.f.2 investigation notes from abandoned attempt`
2. `design + tests: M2 GeodePathCacheComponent — red repro tests first`
3. `ShapeSystem: gate ComputedPathComponent writes on content change`
4. `RendererInterface: add sourceEntity field to PathShape`
5. `Geode M2: GeodePathCacheComponent — zero-encode steady state`
6. `Geode M2: don't disconnect entt listener at renderer teardown`
7. `M4.2: red repro tests — textureCreates == 0 on repeat render`
8. `M4.2 step 1: share dummy textures across GeoEncoders via GeodeDevice`
9. `M4.2 step 2: TexturePool for layer/filter/mask/clip-mask scratch`
10. `M4.2 step 3: tighten baseline ceilings + mark design doc landed`
11. `CMake mirror: skip geode_path_cache_component in non-geode targets`

## Design notes worth flagging at review

- **Entity plumbing.** `PathShape` gained a `sourceEntity` field instead of
  widening `RendererInterface::drawPath`. Non-driver callers (overlay,
  tests) leave it null; Geode keys its cache on it.
- **ShapeSystem content-equality gate.** New `Path::operator==` +
  `emplaceComputedPathIfChanged` helper. This is the invalidation
  edge M2 relies on: `on_update<ComputedPathComponent>` only fires
  when the spline actually changed. Without this, the cache would
  be wiped on every frame where any entity was dirty.
- **Listener teardown is intentionally not disconnecting.** Fixed a
  UB crash (`RendererPublicApiTest.StrokeDasharrayDiffersFromSolid`)
  where `SVGDocument` destructs before `Renderer` in the same scope
  and the Impl's `~` called `disconnect<>()` on a freed registry.
  Listeners are free functions with no `this`-capture, so leaving
  them attached is safe — they die with the registry.
- **M4.2 uses exact-size keying, not power-of-two bucketing.** Simpler
  and sufficient for the repeat-same-size target; viewport-resize
  scenarios will miss all buckets on the new size. Bucketing is
  listed as a follow-up in design doc 0030.

## Deferred to follow-up PRs

- GPU-resident vertex/band/curve arena handle retention on
  `GeodePathCacheComponent` (cache the upload, not just the CPU
  bytes).
- `<use>` instancing via the cache (M6).
- Power-of-two size bucketing for viewport-resize scenarios (M4.2
  extension).
- `GeodeFilterEngine`-internal texture pool + command encoder
  sharing (M5).

## Test plan

- [x] `//donner/svg/renderer/geode:geode_perf_tests` — all 13 perf
      assertions green (4 M2 zero-encode + 4 M4.2 zero-textures + 4
      tightened baselines + counters-reset).
- [x] `//donner/svg/renderer/tests:renderer_geode_golden_tests`.
- [x] `//donner/svg/renderer/tests:renderer_public_api_tests` (catches
      the pre-fix StrokeDasharray crash).
- [x] `//donner/svg/renderer/tests:renderer_tests` (tiny-skia default backend).
- [x] `//donner/svg/renderer/tests:resvg_test_suite_geode` — 0 regressions.
- [x] `//donner/svg/renderer/...` — 69 pass / 3 skipped.
- [x] `//donner/base:base_tests`, `//donner/svg/components/shape:shape_system_tests`.
- [x] `tools/presubmit.sh --fast` (CMake mirror validation + clang-format).
- [ ] Let CI run the full `bazel test //...` + fuzzers + Linux build.