### PR TITLE
Add asan-geode PR gate (doc 0030 M1.2)

### DIFF
--- a/.github/workflows/sanitizers-pr.yml
+++ b/.github/workflows/sanitizers-pr.yml
@@ -1,0 +1,49 @@
+name: Sanitizers PR
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "donner/svg/renderer/geode/**"
+      - "donner/svg/renderer/RendererDriver.*"
+      - "donner/svg/renderer/RendererGeode.*"
+
+jobs:
+  asan-geode:
+    name: asan-geode
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    # TODO(doc 0030 M1.2, add asan-geode PR gate): remove continue-on-error
+    # once main is green under `--config=asan --config=geode` again
+    # (issue #552's fix plus the current Geode ASan build breakage).
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install system dependencies
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y pkg-config libfontconfig1-dev libfreetype6-dev \
+              mesa-vulkan-drivers libvulkan1 libvulkan-dev \
+              libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
+              libgl1-mesa-dev
+
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-${{ runner.os }}
+          repository-cache: true
+          external-cache: true
+          cache-save: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Test (Geode ASan)
+        run: |
+          bazelisk test --config=asan --config=geode --test_output=errors \
+            //donner/svg/renderer/tests:resvg_test_suite_geode


### PR DESCRIPTION
🤖 Adds a Linux-only `asan-geode` PR workflow gated by tight Geode renderer path filters.

## What changed
- adds `.github/workflows/sanitizers-pr.yml`
- runs `bazelisk test --config=asan --config=geode --test_output=errors //donner/svg/renderer/tests:resvg_test_suite_geode`
- limits the workflow to PRs touching:
  - `donner/svg/renderer/geode/**`
  - `donner/svg/renderer/RendererDriver.*`
  - `donner/svg/renderer/RendererGeode.*`
- keeps the job name stable as `asan-geode` for branch-protection wiring

## Rollout status
This is intentionally **informational for now** via `continue-on-error: true`.

On current `main`, `//donner/svg/renderer/tests:resvg_test_suite_geode` exists, but `bazel test --config=asan --config=geode ...` is not green yet. In this checkout it fails during the Geode ASan build before test execution, so tightening this to a hard gate should wait until `main` is green under that config again (including the #552 fix landing).

## Notes
- I could not update `docs/design_docs/0030-ci_escape_refresh.md` because that file is not present on `main` in this repository state, so there was no Milestone 1.2 checkbox to flip in this PR.
