### PR TITLE
Land misc-include-cleaner (diff-only) + track historical debt (doc 0031 M1.1)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,7 @@ Checks: >
     -bugprone-easily-swappable-parameters,
     -bugprone-branch-clone,
     -bugprone-unchecked-optional-access,
+    misc-include-cleaner,
     cppcoreguidelines-*,
     -cppcoreguidelines-avoid-magic-numbers,
     -cppcoreguidelines-pro-type-union-access,

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches: ["*"]
   pull_request:
-    branches: [main]
+    branches: [main, feature/ci-hardening-2026q2]
 
 # Fast lint jobs covering checks that don't live inside `bazel test //...`:
 #
 # - clang-format (changed C++ files only — runs in <30s for typical PRs)
+# - misc-include-cleaner (changed C++ files only — avoids blocking on
+#   historical include debt while enforcing new diffs)
 # - gen_cmakelists.py unit tests + full --check validator (reentrant bazel
 #   prevents running --check from inside bazel test; see Phase 3 design doc)
 # - banned source patterns lint is NOT here: it runs automatically as a
@@ -54,6 +56,45 @@ jobs:
 
           echo "Checking ${MODIFIED}" | tr ' ' '\n'
           echo "${MODIFIED}" | xargs clang-format --dry-run -Werror
+
+  misc-include-cleaner:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 50
+
+      - name: Install clang-tidy
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y clang-tidy-19
+
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-${{ runner.os }}
+          repository-cache: true
+          external-cache: true
+          cache-save: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Check misc-include-cleaner on changed C++ files
+        run: |
+          if [[ -n "${{ github.base_ref }}" ]]; then
+            git fetch --depth=50 origin "${{ github.base_ref }}"
+            BASE="$(git merge-base "origin/${{ github.base_ref }}" HEAD)"
+          else
+            git fetch --depth=50 origin main 2>/dev/null || true
+            BASE="$(git merge-base origin/main HEAD 2>/dev/null || echo HEAD~1)"
+          fi
+
+          tools/run_misc_include_cleaner_diff.sh "${BASE}"
 
   cmake-validate:
     runs-on: ubuntu-24.04

--- a/docs/design_docs/0031-ci_hardening_2026q2.md
+++ b/docs/design_docs/0031-ci_hardening_2026q2.md
@@ -64,7 +64,7 @@ every variant is covered by the default test command.
 ## Implementation Plan
 
 - [ ] **Milestone 1 — Fast wins (S effort)**
-  - [x] M1.1: Land `misc-include-cleaner` in `.clang-tidy` + required `lint.yml` job. Fixes 0016 Category 2 (header-graph divergence); prevents the #520 `<ostream>` hotfix chain. _(Delegated, PR in flight.)_
+  - [x] M1.1: Land `misc-include-cleaner` in `.clang-tidy` + required `lint.yml` job. Fixes 0016 Category 2 (header-graph divergence); prevents the #520 `<ostream>` hotfix chain. _(Landed with diff-only enforcement; historical debt tracked in [#559](https://github.com/jwmcglynn/donner/issues/559).)_
   - [x] M1.2: Paths-scoped `asan-geode` PR gate for `donner/svg/renderer/geode/**` + `RendererDriver.*`. Catches issue #552 class. _(Delegated, PR in flight.)_
   - [x] M1.3: Add `tools/presubmit.sh --variants` running `tiny`/`text-full`/`geode` tiers. **Transitional** — M2.3 replaces this by making `bazel test //...` cover all variants by default. _(Delegated, PR in flight.)_
   - [x] M1.4: Add Category 8 (wall-clock perf) + Category 9 (sanitizer-only) to doc 0016. _(Landed as commit 0e51a695 on this feature branch.)_
@@ -220,6 +220,7 @@ Specific acceptance gates:
 
 ## Future Work
 
+- [ ] Historical `misc-include-cleaner` debt tracked in [#559](https://github.com/jwmcglynn/donner/issues/559); clear it in directory-scoped waves while the diff-only gate keeps new debt from growing.
 - [ ] ThreadSanitizer nightly once threaded code lands.
 - [ ] Per-backend pixel-diff threshold auto-calibration (0016 Category 4).
 - [ ] Convert `tools/presubmit.sh` death (post-M2.3) into a `tombstone`

--- a/tools/run_misc_include_cleaner_diff.sh
+++ b/tools/run_misc_include_cleaner_diff.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# Run clang-tidy's misc-include-cleaner only on changed C++ files.
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+BASE="${1:-}"
+if [[ -z "${BASE}" ]]; then
+  git fetch --depth=50 origin main >/dev/null 2>&1 || true
+  BASE="$(git merge-base origin/main HEAD 2>/dev/null || echo HEAD~1)"
+fi
+
+if command -v clang-tidy-19 >/dev/null 2>&1; then
+  CLANG_TIDY="clang-tidy-19"
+elif command -v clang-tidy >/dev/null 2>&1; then
+  CLANG_TIDY="clang-tidy"
+else
+  echo "clang-tidy not found in PATH" >&2
+  exit 1
+fi
+
+if command -v bazelisk >/dev/null 2>&1; then
+  BAZEL="bazelisk"
+elif command -v bazel >/dev/null 2>&1; then
+  BAZEL="bazel"
+else
+  echo "bazelisk/bazel not found in PATH" >&2
+  exit 1
+fi
+
+mapfile -t MODIFIED_FILES < <(
+  git diff --name-only --diff-filter=ACMR "${BASE}" HEAD \
+    | grep -E '\.(cc|h|hpp|cpp)$' \
+    | grep -v '^third_party/' || true
+)
+
+if [[ ${#MODIFIED_FILES[@]} -eq 0 ]]; then
+  echo "No modified C++ files; nothing to check."
+  exit 0
+fi
+
+echo "Refreshing compile_commands.json..."
+"${BAZEL}" run //tools:refresh_compile_commands
+
+echo "Running misc-include-cleaner on ${#MODIFIED_FILES[@]} changed file(s):"
+printf '  %s\n' "${MODIFIED_FILES[@]}"
+
+"${CLANG_TIDY}" \
+  -p . \
+  --quiet \
+  --checks=-*,misc-include-cleaner \
+  --warnings-as-errors=* \
+  "${MODIFIED_FILES[@]}"


### PR DESCRIPTION
🤖 This lands doc 0031 milestone M1.1 with **diff-only** `misc-include-cleaner` enforcement.

## Summary
- enable `misc-include-cleaner` in `.clang-tidy`
- add `tools/run_misc_include_cleaner_diff.sh` to refresh `compile_commands.json` and run clang-tidy only on changed C++ files
- add a required `misc-include-cleaner` job to `lint.yml` for PRs to `main` and `feature/ci-hardening-2026q2`
- track historical debt separately in #559 and mark M1.1 landed (diff-only enforcement) in doc 0031

## Why diff-only
The repo has a large pre-existing include-cleaner backlog, so gating the whole tree would block unrelated PRs and violate the always-green policy. This gate only fails when the PR touches a file with `misc-include-cleaner` findings, which keeps new debt from growing while historical debt is burned down in follow-up waves.

## Notes
- the debt tracker is #559 (`Historical misc-include-cleaner debt (2,875 findings)`)
- the top offender list in that issue came from the rollout scan used to seed the cleanup waves
