### PR TITLE
CMake: add --build validation to gen_cmakelists.py --check (doc 0031 M2.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@
 
 - **`main` is always green.** There is no such thing as a "preexisting test failure" — any red test blocks merge, full stop. If something on `main` breaks, the next PR is fixing it, not routing around it.
 - **Run `bazel test //...` before pushing any PR.** This is the single source of truth for local validation. Our goal is that `bazel test //...` catches every regression that CI would — if CI catches something local didn't, that's a gap to fix in the test surface, not a reason to skip the local check.
+- **When touching the CMake mirror or `gen_cmakelists.py`, also run `python3 tools/cmake/gen_cmakelists.py --check --build`.** Plain `--check` is intentionally fast and static; `--build` is the opt-in local compile gate that catches real CMake drift before CI does.
 - `tools/presubmit.sh` is a transitional wrapper and will be retired once `bazel test //...` covers every variant (`--config=tiny`, `--config=text-full`, `--config=geode`) by default. Prefer `bazel test //...` today; do not add new logic to `presubmit.sh` that couldn't live in Bazel directly.
 
 ## Debugging Discipline

--- a/docs/design_docs/0031-ci_hardening_2026q2.md
+++ b/docs/design_docs/0031-ci_hardening_2026q2.md
@@ -75,7 +75,7 @@ every variant is covered by the default test command.
 
 - [ ] **Milestone 2 — Cache and nightly infrastructure (M effort)**
   - [ ] M2.1: Per-config cache slots. Extend `disk-cache` key with a config tag (`-default`, `-asan`, `-geode`). Prevents the asan-fuzzer-evicts-main collision observed pre-Skia-removal. (Subsumes 0029 M1.)
-  - [ ] M2.2: Extend `tools/cmake/gen_cmakelists.py --check` to actually `cmake --build` the generated CMake on Linux + macOS tiers. Catches drift that the static validator missed in commits 19d41df8, 398d312b, 89448ad7, a7d682fe.
+  - [x] M2.2: Extend `tools/cmake/gen_cmakelists.py --check` to optionally `cmake --build` the generated CMake via `--build`, while keeping plain `--check` fast and static. Catches drift that the static validator missed in commits 19d41df8, 398d312b, 89448ad7, a7d682fe.
   - [ ] M2.3: Make `bazel test //...` cover every variant by default. Audit `donner_variant_cc_test` usage; ensure `tiny`, `text-full`, `geode` variants auto-emit under the default test command. Once green, delete `tools/presubmit.sh`.
   - [ ] M2.4: Introduce `donner_perf_cc_test` macro splitting correctness counters (PR-gate) from wall-clock thresholds (nightly, tagged `perf`). Retires 5 recent threshold-widening hotfixes (8043ad7b, 1f147f2f, 43f42cf7, ab68092b, 8cd89ef7). Absorbs doc 0016 Category 8.
   - [ ] M2.5: Nightly `sanitizers.yml` running ASan+UBSan across `//donner/...`. **Skip-idle**: first job compares `origin/main` HEAD against the last successful `workflow_run` SHA; if unchanged, exit 0 and short-circuit. Required for `main` merges (not PR-blocking).

--- a/tools/cmake/gen_cmakelists.py
+++ b/tools/cmake/gen_cmakelists.py
@@ -1393,6 +1393,73 @@ def _validate_generated_output(gen_root: Path, workspace: Path, generated_files:
     return errors
 
 
+def _format_command_error(prefix: str, command: List[str], output: str) -> str:
+    """Format a subprocess failure for human-readable diagnostics."""
+    rendered_output = output.strip() if output.strip() else "(no output captured)"
+    return f"{prefix}\n  {' '.join(command)}\n\n{rendered_output}"
+
+
+def _run_cmake_build_validation(
+    source_dir: Path,
+    build_dir: Path,
+    *,
+    jobs: Optional[int] = None,
+) -> Optional[str]:
+    """Configure and build a generated CMake tree.
+
+    Returns ``None`` on success, or a human-readable error string on failure.
+    """
+    parallel_jobs = max(1, jobs or os.cpu_count() or 1)
+
+    configure_cmd = ["cmake", "-S", ".", "-B", str(build_dir)]
+    try:
+        configure_result = subprocess.run(
+            configure_cmd,
+            cwd=source_dir,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+    except FileNotFoundError:
+        return (
+            "CMake configure failed:\n"
+            f"  {' '.join(configure_cmd)}\n\n"
+            "cmake command not found. Install cmake to use --build validation."
+        )
+    if configure_result.returncode != 0:
+        return _format_command_error(
+            "CMake configure failed:",
+            configure_cmd,
+            configure_result.stdout,
+        )
+
+    build_cmd = ["cmake", "--build", str(build_dir), "--parallel", str(parallel_jobs)]
+    try:
+        build_result = subprocess.run(
+            build_cmd,
+            cwd=source_dir,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+    except FileNotFoundError:
+        return (
+            "CMake build failed:\n"
+            f"  {' '.join(build_cmd)}\n\n"
+            "cmake command not found. Install cmake to use --build validation."
+        )
+    if build_result.returncode != 0:
+        return _format_command_error(
+            "CMake build failed:",
+            build_cmd,
+            build_result.stdout,
+        )
+
+    return None
+
+
 def main() -> None:
     """Main entry point to generate all CMakeLists.txt files."""
     global _check_mode
@@ -1408,12 +1475,21 @@ def main() -> None:
               "or any external dep is unmapped. Does not modify the workspace."),
     )
     parser.add_argument(
+        "--build",
+        action="store_true",
+        help=("With --check, also run 'cmake -S . -B <temp build dir>' followed by "
+              "'cmake --build' on the generated tree. This is slower than the "
+              "default static validation and is intended as an opt-in deep check."),
+    )
+    parser.add_argument(
         "--output-dir",
         type=Path,
         default=None,
         help="Write generated files to this directory instead of the workspace.",
     )
     args = parser.parse_args()
+    if args.build and not args.check:
+        parser.error("--build requires --check")
     _check_mode = args.check
 
     if args.check:
@@ -1452,6 +1528,7 @@ def main() -> None:
 
         print("Generating and validating CMakeLists.txt files...")
         errors: List[str] = []
+        build_error: Optional[str] = None
         try:
             generate_root()
             generate_all_packages()
@@ -1466,6 +1543,13 @@ def main() -> None:
 
             # Statically validate the generated output
             errors = _validate_generated_output(workspace, workspace, generated_set)
+            if args.build and not errors and not _unmapped_deps:
+                print("Static validation passed; configuring and building generated tree...")
+                with tempfile.TemporaryDirectory(prefix="donner-cmake-check-") as temp_dir:
+                    build_error = _run_cmake_build_validation(
+                        workspace,
+                        Path(temp_dir) / "build",
+                    )
         finally:
             # Remove anything newly created then restore originals
             for p in list(workspace.rglob("CMakeLists.txt")):
@@ -1476,13 +1560,18 @@ def main() -> None:
                 p = workspace / rel
                 p.write_bytes(content)
 
-        had_errors = bool(errors) or bool(_unmapped_deps)
+        had_errors = bool(errors) or bool(_unmapped_deps) or build_error is not None
         if errors:
             print(f"\n{'='*60}")
             print(f"CMakeLists.txt VALIDATION FAILED ({len(errors)} error(s))")
             print(f"{'='*60}")
             for e in errors:
                 print(f"  {e}")
+        if build_error:
+            print(f"\n{'='*60}")
+            print("CMakeLists.txt BUILD VALIDATION FAILED")
+            print(f"{'='*60}")
+            print(build_error)
         if _unmapped_deps:
             print(f"\nUnmapped external dependencies ({len(_unmapped_deps)}):")
             for msg in _unmapped_deps:
@@ -1494,7 +1583,10 @@ def main() -> None:
 
         if had_errors:
             sys.exit(1)
-        print("CMakeLists.txt validation passed.")
+        if args.build:
+            print("CMakeLists.txt validation and build passed.")
+        else:
+            print("CMakeLists.txt validation passed.")
         sys.exit(0)
     else:
         output_dir = args.output_dir

--- a/tools/cmake/gen_cmakelists_test.py
+++ b/tools/cmake/gen_cmakelists_test.py
@@ -1,13 +1,17 @@
 """Unit tests for gen_cmakelists.py.
 
-These tests cover the offline/pure-Python helpers that don't require
-running bazel query. The full generation + validation flow is exercised
-by the --check mode (run from CI and presubmit.sh), not from here.
+These tests cover the offline helpers that don't require running bazel
+query. That includes the parser/validator helpers plus the opt-in CMake
+build-validation helper exercised against synthetic source trees.
 """
 
 import os
+import shutil
 import sys
+import tempfile
+import textwrap
 import unittest
+from unittest import mock
 from pathlib import Path
 
 # Allow running as either a standalone script or a bazel py_test
@@ -200,6 +204,63 @@ class ExtractTargetsAndRefsTest(unittest.TestCase):
             defined, _, _ = g._extract_cmake_targets_and_refs(root)
             self.assertIn("real", defined)
             self.assertNotIn("fake", defined)
+
+
+@unittest.skipUnless(shutil.which("cmake"), "cmake is required for build validation tests")
+class CmakeBuildValidationTest(unittest.TestCase):
+    def test_reports_missing_cmake_command(self):
+        with tempfile.TemporaryDirectory() as source_dir_str:
+            source_dir = Path(source_dir_str)
+            build_dir = source_dir / "build"
+
+            with mock.patch.object(g.subprocess, "run", side_effect=FileNotFoundError):
+                error = g._run_cmake_build_validation(source_dir, build_dir, jobs=1)
+
+            self.assertIsNotNone(error)
+            self.assertIn("cmake command not found", error)
+
+    def test_build_succeeds_for_valid_tree(self):
+        with tempfile.TemporaryDirectory() as source_dir_str:
+            source_dir = Path(source_dir_str)
+            build_dir = source_dir / "build"
+            (source_dir / "CMakeLists.txt").write_text(
+                textwrap.dedent(
+                    """\
+                    cmake_minimum_required(VERSION 3.20)
+                    project(cmake_build_validation_ok LANGUAGES C)
+                    add_library(smoke STATIC smoke.c)
+                    """
+                )
+            )
+            (source_dir / "smoke.c").write_text("int Smoke(void) { return 42; }\n")
+
+            error = g._run_cmake_build_validation(source_dir, build_dir, jobs=1)
+
+            self.assertIsNone(error)
+
+    def test_build_reports_compile_failure(self):
+        with tempfile.TemporaryDirectory() as source_dir_str:
+            source_dir = Path(source_dir_str)
+            build_dir = source_dir / "build"
+            (source_dir / "CMakeLists.txt").write_text(
+                textwrap.dedent(
+                    """\
+                    cmake_minimum_required(VERSION 3.20)
+                    project(cmake_build_validation_fail LANGUAGES C)
+                    add_library(smoke STATIC smoke.c)
+                    """
+                )
+            )
+            (source_dir / "smoke.c").write_text(
+                '#include "missing_header_for_build_validation.h"\n'
+                "int Smoke(void) { return 42; }\n"
+            )
+
+            error = g._run_cmake_build_validation(source_dir, build_dir, jobs=1)
+
+            self.assertIsNotNone(error)
+            self.assertIn("CMake build failed:", error)
+            self.assertIn("missing_header_for_build_validation.h", error)
 
 
 if __name__ == "__main__":

--- a/tools/presubmit.sh
+++ b/tools/presubmit.sh
@@ -7,7 +7,8 @@
 # `bazel test //...` catches banned source patterns automatically. This
 # script adds the two checks that can't live inside bazel test today:
 #
-#   - `gen_cmakelists.py --check` (can't run bazel query inside bazel test)
+#   - `gen_cmakelists.py --check` (can't run bazel query inside bazel test;
+#     use `--check --build` separately when touching the CMake mirror)
 #   - clang-format on modified files (needs the local `clang-format` binary)
 #
 # Run before opening a PR. Designed to be fast (<2 min for lints) and


### PR DESCRIPTION
🤖 Summary:
- add an opt-in `--build` mode to `tools/cmake/gen_cmakelists.py --check` that configures and builds the generated CMake tree in a temporary build dir after the existing static validation passes
- cover the new helper with synthetic CMake unit tests, including a missing-include compile failure and missing-`cmake` reporting
- document the local deep-check command and mark doc 0031 M2.2 complete

Validation:
- `PATH=/tmp/cmake-venv/bin:$PATH python3 -m unittest tools/cmake/gen_cmakelists_test.py`
- `PATH=/tmp/cmake-venv/bin:$PATH bazel test --test_env=PATH=/tmp/cmake-venv/bin:$PATH //tools/cmake:gen_cmakelists_test`
- `python3 tools/cmake/gen_cmakelists.py --check`
- `python3 tools/cmake/gen_cmakelists.py --check --build` now fails cleanly when `cmake` is absent instead of tracebacking
- `PATH=/tmp/cmake-venv/bin:$PATH python3 tools/cmake/gen_cmakelists.py --check --build` reaches a real repo build failure in `third_party/tiny-skia-cpp` on this arm64 host, which is the existing local blocker to a green full-tree CMake build here
- attempted `PATH=/tmp/cmake-venv/bin:$PATH bazel test --test_env=PATH=/tmp/cmake-venv/bin:$PATH //...`, but it hung during external fetch on this host before producing a suite result