### PR TITLE
CI: per-config Bazel disk-cache slots (doc 0031 M2.1)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
         uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
-          disk-cache: coverage-${{ runner.os }}
+          disk-cache: coverage-${{ runner.os }}-coverage
           repository-cache: true
           external-cache: true
           cache-save: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -230,7 +230,7 @@ jobs:
         uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
-          disk-cache: ${{ github.workflow }}-${{ runner.os }}
+          disk-cache: ${{ github.workflow }}-${{ runner.os }}-default
           repository-cache: true
           external-cache: true
           cache-save: ${{ github.ref == 'refs/heads/main' }}
@@ -271,7 +271,7 @@ jobs:
         uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
-          disk-cache: ${{ github.workflow }}-${{ runner.os }}
+          disk-cache: ${{ github.workflow }}-${{ runner.os }}-default
           repository-cache: true
           external-cache: true
           cache-save: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/sanitizers-pr.yml
+++ b/.github/workflows/sanitizers-pr.yml
@@ -38,7 +38,7 @@ jobs:
         uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
-          disk-cache: ${{ github.workflow }}-${{ runner.os }}
+          disk-cache: ${{ github.workflow }}-${{ runner.os }}-asan-geode
           repository-cache: true
           external-cache: true
           cache-save: ${{ github.ref == 'refs/heads/main' }}

--- a/docs/design_docs/0031-ci_hardening_2026q2.md
+++ b/docs/design_docs/0031-ci_hardening_2026q2.md
@@ -75,7 +75,7 @@ every variant is covered by the default test command.
   - [ ] M1.8b: Branch-protection update — make the new `lint`, `asan-geode`, and core test jobs required on `main`. User action (requires admin).
 
 - [ ] **Milestone 2 — Cache and nightly infrastructure (M effort)**
-  - [ ] M2.1: Per-config cache slots. Extend `disk-cache` key with a config tag (`-default`, `-asan`, `-geode`). Prevents the asan-fuzzer-evicts-main collision observed pre-Skia-removal. (Subsumes 0029 M1.)
+  - [x] M2.1: Per-config cache slots. Extend `disk-cache` key with a config tag (`-default`, `-asan`, `-geode`). Prevents the asan-fuzzer-evicts-main collision observed pre-Skia-removal. (Subsumes 0029 M1.)
   - [x] M2.2: Extend `tools/cmake/gen_cmakelists.py --check` to optionally `cmake --build` the generated CMake via `--build`, while keeping plain `--check` fast and static. Catches drift that the static validator missed in commits 19d41df8, 398d312b, 89448ad7, a7d682fe.
   - [ ] M2.3: Make `bazel test //...` cover every variant by default. Audit `donner_variant_cc_test` usage; ensure `tiny`, `text-full`, `geode` variants auto-emit under the default test command. Once green, delete `tools/presubmit.sh`.
   - [ ] M2.4: Introduce `donner_perf_cc_test` macro splitting correctness counters (PR-gate) from wall-clock thresholds (nightly, tagged `perf`). Retires 5 recent threshold-widening hotfixes (8043ad7b, 1f147f2f, 43f42cf7, ab68092b, 8cd89ef7). Absorbs doc 0016 Category 8.


### PR DESCRIPTION
🤖 ## Summary
- add explicit per-config Bazel disk-cache suffixes for `main.yml` default jobs, `sanitizers-pr.yml`'s `asan-geode` job, and `coverage.yml`
- leave `cache-save: \\${{ github.ref == 'refs/heads/main' }}` unchanged
- check off doc 0031 M2.1

## Cache footprint
- GHA repo cache quota is 10 GB, LRU-evicted per repo
- current populated default disk-cache slots are about 0.48 GB (Linux) + 0.73 GB (macOS) = about 1.21 GB total, based on `actions/caches`
- with six named slots (`default` linux + macOS, `asan`, `ubsan`, `asan-geode`, `coverage`), the practical footprint still fits the quota; even a conservative ~1.5 GB/slot budget is about 9 GB

## Notes
- `sanitizers.yml` already had per-config `-asan` / `-ubsan` keys on this branch, so this PR leaves it unchanged
- `main.yml` on `feature/ci-hardening-2026q2` currently has only the default-config Bazel jobs; there is no separate tiny-skia Bazel cache key in that workflow to retag in this branch state