### PR TITLE
Geode perf M6: draw-call instrumentation + `<use>` instancing

### DIFF
--- a/docs/design_docs/0030-geode_performance.md
+++ b/docs/design_docs/0030-geode_performance.md
@@ -367,7 +367,7 @@ algorithm.
     reordering across paint order, which SVG forbids. Unlikely
     to ship without M1.f.2 (dynamic-offset bind groups) first
     exposing a different bind-group amortization regime.
-  - [ ] Bullet 2 (instanced `<use>` draws): **next milestone.**
+  - [ ] Bullet 2 (instanced `<use>` draws): **partially landed.**
     Motivating fixture: `docs/img/arch_container.svg` with 1028
     `<use>` elements — today that's 1028 `drawCalls`; target is
     O(distinct-source-entity × distinct-paint) per render pass.
@@ -375,13 +375,42 @@ algorithm.
     share the same `dataEntity` AND same resolved solid paint
     AND no stroke/mask/filter/clip → one instanced GPU draw with
     per-instance transforms via a new storage-buffer binding.
-    Shader changes in `slug_fill.wgsl` + alpha-coverage variant;
-    new `GeoEncoder::fillPathInstanced` entry point. One attempt
-    via a delegated agent stalled without committing code; the
-    next attempt should pin the agent to a driver-side
-    detection-only commit first (counter: `instancedGroupsDetected`)
-    so the instrumentation + fixture land before the shader
-    rewrite risk.
+
+    - [x] **M6-B step 1 — detection counter.** Added
+      `sameSourceDrawPairs` to `GeodeCounters`. `RendererGeode::Impl`
+      tracks `lastDrawSourceEntity`; `drawPath` bumps the counter
+      on consecutive same-source calls. Zero on fixtures without
+      `<use>`; reports `N − 1` on a run of `N` consecutive
+      batchable `<use>` instances (verified by
+      `UseHeavy_BaselineCeilings` with 8 `<use>` → 7). Lands
+      separately from any actual batching so the signal is
+      observable even before the shader/driver pass ships.
+    - [x] **M6-B step 2 — shader + bind-group plumbing.** Added
+      binding 7 on the Slug-fill pipeline: a per-instance affine
+      transforms SSBO (`slug_fill.wgsl` + alpha-coverage variant).
+      `vs_main` now takes `@builtin(instance_index)`, fetches the
+      instance transform, and composes `effective_mvp = mvp *
+      instance_mat`. For non-instanced draws `GeodeDevice` owns
+      a 1-element identity buffer — existing draws are no-op
+      identity composes, goldens and the resvg suite unchanged.
+      Unlocks `fillPathInstanced`, next.
+    - [ ] **M6-B step 3 — batching.** Still to write:
+      - `GeoEncoder::fillPathInstanced(path, color, rule,
+        std::span<Transform2d>, precomputedEncoded)` — uploads
+        transforms into an arena slice, sets up the bind group
+        with binding 7 pointing at the slice, issues
+        `pass.draw(vertexCount, instanceCount=N, 0, 0)`.
+      - `RendererInterface::drawPathInstanced(...)` — virtual
+        with a default loop fallback for non-Geode backends.
+      - Driver lookahead in `RendererDriver::traverseRange`:
+        peek ahead from the current entity, accumulate
+        consecutive entities with same `dataEntity` / same
+        solid paint / no subtree / compatible clip. On the
+        accumulator, emit one `drawPathInstanced`; advance
+        the view past the group.
+      - Update `UseHeavy_BaselineCeilings` to assert
+        `drawCalls == 1` + `sameSourceDrawPairs == 0` (the
+        batcher eliminates the consecutive same-source runs).
 - [ ] Milestone 7: Opportunistic cleanups.
   - [ ] GPU-side `takeSnapshot` unpremultiply (`RendererGeode.cc:2322-2353`)
     via a one-dispatch compute kernel writing into a CopySrc buffer;

--- a/docs/design_docs/0030-geode_performance.md
+++ b/docs/design_docs/0030-geode_performance.md
@@ -394,23 +394,35 @@ algorithm.
       a 1-element identity buffer — existing draws are no-op
       identity composes, goldens and the resvg suite unchanged.
       Unlocks `fillPathInstanced`, next.
-    - [ ] **M6-B step 3 — batching.** Still to write:
-      - `GeoEncoder::fillPathInstanced(path, color, rule,
-        std::span<Transform2d>, precomputedEncoded)` — uploads
-        transforms into an arena slice, sets up the bind group
-        with binding 7 pointing at the slice, issues
-        `pass.draw(vertexCount, instanceCount=N, 0, 0)`.
-      - `RendererInterface::drawPathInstanced(...)` — virtual
-        with a default loop fallback for non-Geode backends.
-      - Driver lookahead in `RendererDriver::traverseRange`:
-        peek ahead from the current entity, accumulate
-        consecutive entities with same `dataEntity` / same
-        solid paint / no subtree / compatible clip. On the
-        accumulator, emit one `drawPathInstanced`; advance
-        the view past the group.
-      - Update `UseHeavy_BaselineCeilings` to assert
-        `drawCalls == 1` + `sameSourceDrawPairs == 0` (the
-        batcher eliminates the consecutive same-source runs).
+    - [x] **M6-B step 3 — batching.** _Landed 2026-04-20._
+      - `GeoEncoder::fillPathInstanced(encoded, color, rule,
+        std::span<const float>)`: packs transforms into the new
+        `instanceTransformArena`, sets up `FillDrawArgs` with the
+        instance-buffer slice + `instanceCount = N`, issues one
+        `pass.draw(vertexCount, N, 0, 0)`.
+      - Batching is **backend-internal** on `RendererGeode::Impl`
+        — no driver changes, no new
+        `RendererInterface::drawPathInstanced` virtual. `drawPath`
+        attempts to append to a pending batch keyed on
+        `(sourceEntity, color, rule)`; state-change APIs
+        (`pushClip` / `popClip`, the three layer types,
+        `drawImage` / `drawText`, `endFrame`, …) flush the
+        pending batch. Paint-key mismatches flush via the
+        `tryAppendOrStartBatch` key check.
+      - Flush machinery saves + restores `currentTransform`
+        around the emit so a mid-`drawPath` flush (between fill
+        and stroke siblings) doesn't leak the batched transform
+        back into the caller's state. Without the save/restore
+        this broke `rect2.svg` (10k px diff) and
+        `stroking_pathlength.svg` (1.7k px diff) — caught by the
+        regression sweep.
+      - `UseHeavy_BaselineCeilings` tightened to
+        `drawCalls == 1`, `bindgroupCreates == 1`,
+        `sameSourceDrawPairs == 7`. The detection counter stays
+        at `N − 1` because it fires at `drawPath` entry (before
+        the batcher's emit decision) — kept distinct from
+        `drawCalls` so regressions in detection vs. batching can
+        be triaged independently.
 - [ ] Milestone 7: Opportunistic cleanups.
   - [ ] GPU-side `takeSnapshot` unpremultiply (`RendererGeode.cc:2322-2353`)
     via a one-dispatch compute kernel writing into a CopySrc buffer;

--- a/docs/design_docs/0030-geode_performance.md
+++ b/docs/design_docs/0030-geode_performance.md
@@ -346,11 +346,42 @@ algorithm.
     `:1664`, `:1735`, `:1890`, `:1973`) into the outer frame encoder.
 - [ ] Milestone 6: Batch draws sharing pipeline state (0017 Phase 5
   bullet 6).
-  - [ ] Sort the per-frame draw list by `(pipeline, bind-group prefix,
-    scissor/clip)` and collapse contiguous same-pipeline draws into a
-    single `RenderPass` segment.
-  - [ ] Instanced path draws for repeated `<use>` of the same encoded
-    path (leverages Milestone 2 cache identity).
+  - [x] **M6-A: instrumentation.** `drawCalls` + `pipelineSwitches`
+    counters added to `GeodeCounters`, wired into every
+    `pass.draw(...)` and pipeline-tracker switch site in
+    `GeoEncoder` / `GeodeTextureEncoder`. Baseline ceilings
+    asserted in `GeodePerf_tests.cc`. _Landed 2026-04-20._
+
+    Key finding: Lion (132 paths) fires `drawCalls=132` /
+    `pipelineSwitches=1`. The state tracker already collapses
+    contiguous same-pipeline draws onto a single `setPipeline` —
+    M6's Bullet 1 ("sort + collapse contiguous same-pipeline
+    draws") has zero headroom on solid-fill fixtures, and
+    reordering across paint order would break SVG semantics
+    anyway. The only lever that moves `drawCalls` on unchanged
+    input is Bullet 2 (`<use>` instancing).
+
+  - [ ] Bullet 1 (sort / collapse contiguous same-pipeline draws):
+    **deprioritised.** The state tracker already delivers this
+    within a single render pass; the only residual win requires
+    reordering across paint order, which SVG forbids. Unlikely
+    to ship without M1.f.2 (dynamic-offset bind groups) first
+    exposing a different bind-group amortization regime.
+  - [ ] Bullet 2 (instanced `<use>` draws): **next milestone.**
+    Motivating fixture: `docs/img/arch_container.svg` with 1028
+    `<use>` elements — today that's 1028 `drawCalls`; target is
+    O(distinct-source-entity × distinct-paint) per render pass.
+    Scope for the first cut: consecutive `<use>` siblings that
+    share the same `dataEntity` AND same resolved solid paint
+    AND no stroke/mask/filter/clip → one instanced GPU draw with
+    per-instance transforms via a new storage-buffer binding.
+    Shader changes in `slug_fill.wgsl` + alpha-coverage variant;
+    new `GeoEncoder::fillPathInstanced` entry point. One attempt
+    via a delegated agent stalled without committing code; the
+    next attempt should pin the agent to a driver-side
+    detection-only commit first (counter: `instancedGroupsDetected`)
+    so the instrumentation + fixture land before the shader
+    rewrite risk.
 - [ ] Milestone 7: Opportunistic cleanups.
   - [ ] GPU-side `takeSnapshot` unpremultiply (`RendererGeode.cc:2322-2353`)
     via a one-dispatch compute kernel writing into a CopySrc buffer;

--- a/donner/editor/tests/FilterDragRepro_tests.cc
+++ b/donner/editor/tests/FilterDragRepro_tests.cc
@@ -475,10 +475,14 @@ TEST(FilterDragReproTest, ReplayOfUserRecordingMeetsDragBudgetAndSecondSelect) {
   // run at ~2 ms avg on dev hardware but ~40 ms avg on shared GitHub CI
   // runners. Widened the wall-clock budgets to tolerate CI shape while
   // still catching the "really laggy" regression (100+ ms frames) the
-  // user originally reported at ~250 ms / frame. The fast-path counter
-  // check below is the CPU-speed-invariant regression gate.
+  // user originally reported at ~250 ms / frame. Observed worst-frame
+  // spikes on shared GitHub CI Mac runners reach ~165 ms (single
+  // outlier in a 141-frame recording); raised max to 200 ms to keep
+  // the test non-flaky while still well below the 250 ms regression
+  // this gate exists to catch. The fast-path counter check below is
+  // the CPU-speed-invariant regression gate.
   constexpr double kDragWorkerAvgBudgetMs = 80.0;
-  constexpr double kDragWorkerMaxBudgetMs = 150.0;
+  constexpr double kDragWorkerMaxBudgetMs = 200.0;
   EXPECT_LT(firstAvg, kDragWorkerAvgBudgetMs)
       << "first drag (recorded as 'laggy'): avg worker ms exceeds budget — drag is re-running "
          "the heavy full-document render pipeline every frame";

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1044,6 +1044,35 @@ struct RendererGeode::Impl {
   /// registries are never considered "consecutive same-source").
   Entity lastDrawSourceEntity = entt::null;
 
+  /// M6-B step 3 (design doc 0030 §M6 Bullet 2): deferred batch for
+  /// consecutive `drawPath` calls that share a source entity + resolved
+  /// solid paint + no stroke + no subtree complication. Each matching
+  /// call appends its `currentTransform` into `transforms`; the batch
+  /// is flushed by `flushPendingBatch()` whenever state changes in a
+  /// way that invalidates the batch (paint-key mismatch on the next
+  /// drawPath, any push/pop, end of frame, …). A flush of size >= 2
+  /// routes through `GeoEncoder::fillPathInstanced` — one GPU draw
+  /// with `instanceCount == N`. Size-1 flushes degrade to the regular
+  /// single-draw path so we don't pay the per-instance-buffer cost for
+  /// unbatched draws.
+  struct PendingBatch {
+    Entity sourceEntity = entt::null;
+    css::RGBA color;
+    FillRule rule = FillRule::NonZero;
+    const geode::EncodedPath* encoded = nullptr;
+    /// Reference to the source Path. Caller guarantees lifetime —
+    /// the Path is stored on `ComputedPathComponent` (pinned by
+    /// `GeodePathCacheComponent`'s cache invariant for the frame's
+    /// lifetime).
+    const Path* path = nullptr;
+    /// `currentTransform` captured at each `drawPath`. On flush, the
+    /// outer encoder transform is set to identity and these are
+    /// uploaded as per-instance transforms (see
+    /// `flushPendingBatch` for the math).
+    std::vector<Transform2d> transforms;
+  };
+  std::optional<PendingBatch> pendingBatch;
+
   /// Connect (or rewire) our `on_update<ComputedPathComponent>` /
   /// `on_destroy<ComputedPathComponent>` listener onto `registry`.
   /// Called at the start of each `draw()`. Idempotent for the same
@@ -1096,6 +1125,107 @@ struct RendererGeode::Impl {
       cache.fillEncode = geode::GeodePathEncoder::encode(path, rule);
     }
     return &*cache.fillEncode;
+  }
+
+  /// Pack a 2D affine into the 8-float wire format the shader expects
+  /// (two `vec4f` rows, `(a, c, e, 0)` / `(b, d, f, 0)` — see
+  /// `struct InstanceTransform` in `shaders/slug_fill.wgsl`).
+  /// `Transform2d::data` is column-major `[a, b, c, d, e, f]`.
+  static void packTransform(const Transform2d& xf, float out[8]) {
+    out[0] = static_cast<float>(xf.data[0]);  // a
+    out[1] = static_cast<float>(xf.data[2]);  // c
+    out[2] = static_cast<float>(xf.data[4]);  // e
+    out[3] = 0.0f;
+    out[4] = static_cast<float>(xf.data[1]);  // b
+    out[5] = static_cast<float>(xf.data[3]);  // d
+    out[6] = static_cast<float>(xf.data[5]);  // f
+    out[7] = 0.0f;
+  }
+
+  /// Emit any pending M6-B batch. No-op if there's nothing pending.
+  /// On size == 1 the batch degrades to a single `fillPath` call so we
+  /// don't pay the per-instance-buffer cost when we accumulated
+  /// exactly one draw. Size >= 2 is one instanced GPU draw.
+  ///
+  /// Flushing mutates `currentTransform` to push the batch's
+  /// transform(s) down to the encoder, then RESTORES it to the
+  /// caller's current value. Without the restore, a flush in the
+  /// middle of `drawPath` (between fill and stroke, for example)
+  /// would leave the transform stuck at the flushed batch's value
+  /// for the subsequent stroke emit — breaks any fixture that
+  /// mixes batchable fills with stroked siblings.
+  void flushPendingBatch() {
+    if (!pendingBatch.has_value() || pendingBatch->transforms.empty()) {
+      pendingBatch.reset();
+      return;
+    }
+    if (!encoder) {
+      pendingBatch.reset();
+      return;
+    }
+    const Transform2d savedTransform = currentTransform;
+    PendingBatch batch = std::move(*pendingBatch);
+    pendingBatch.reset();
+
+    if (batch.transforms.size() == 1) {
+      // Single draw — restore the captured transform + use the
+      // non-instanced path.
+      currentTransform = batch.transforms.front();
+      syncTransform();
+      encoder->fillPath(*batch.path, batch.color, batch.rule, batch.encoded);
+    } else {
+      // Instanced: set encoder transform to identity so the shader's
+      // `uniforms.mvp` carries only the orthographic screen-pixel mapping.
+      // Each instance transform already encodes the full
+      // `worldFromEntity * surfaceFromCanvas` composition that a
+      // non-batched draw would fold into currentTransform; compose with
+      // identity `uniforms.mvp` is equivalent to composing with the
+      // original currentTransform per-draw.
+      currentTransform = Transform2d();
+      syncTransform();
+
+      // Pack transforms into the wire format the shader expects.
+      std::vector<float> packed(batch.transforms.size() * 8u);
+      for (size_t i = 0; i < batch.transforms.size(); ++i) {
+        packTransform(batch.transforms[i], packed.data() + i * 8u);
+      }
+      encoder->fillPathInstanced(*batch.encoded, batch.color, batch.rule, packed);
+    }
+
+    // Restore so subsequent draw/state ops see the driver-set
+    // transform intact. Draw-emitting helpers (`syncTransform` +
+    // `encoder->fillPath*`) read `currentTransform` when re-entered,
+    // so we don't need to re-sync the encoder right now.
+    currentTransform = savedTransform;
+  }
+
+  /// Predicate: would a batchable draw with this key extend the
+  /// currently pending batch, or does it start a new one? Returns
+  /// true when the current `drawPath` call should NOT emit (because
+  /// it's been absorbed into a batch). Always returns true on a
+  /// non-empty batch state — either appends or flushes + starts new.
+  /// The caller is expected to have already verified the draw is
+  /// "batch-compatible" (solid paint, no stroke, has source entity,
+  /// has cached fill encode, no in-flight pattern).
+  bool tryAppendOrStartBatch(Entity sourceEntity, const Path& path, const css::RGBA& color,
+                             FillRule rule, const geode::EncodedPath* encoded) {
+    const bool matches = pendingBatch.has_value() &&
+                        pendingBatch->sourceEntity == sourceEntity &&
+                        pendingBatch->color == color && pendingBatch->rule == rule;
+    if (matches) {
+      pendingBatch->transforms.push_back(currentTransform);
+      return true;
+    }
+    // Key doesn't match — flush whatever's pending, then start fresh.
+    flushPendingBatch();
+    pendingBatch.emplace();
+    pendingBatch->sourceEntity = sourceEntity;
+    pendingBatch->color = color;
+    pendingBatch->rule = rule;
+    pendingBatch->encoded = encoded;
+    pendingBatch->path = &path;
+    pendingBatch->transforms.push_back(currentTransform);
+    return true;
   }
 
   /// Determine the fill rule for a stroked outline per the subpath-count
@@ -1510,6 +1640,11 @@ void RendererGeode::beginFrame(const RenderViewport& viewport) {
 }
 
 void RendererGeode::endFrame() {
+  // M6-B step 3: flush any pending `<use>`-batch before closing out
+  // the frame. Without this, the last run of batchable draws in the
+  // frame would never emit.
+  impl_->flushPendingBatch();
+
   if (impl_->encoder) {
     // Ends the open render pass without submitting — shared-mode.
     impl_->encoder->finish();
@@ -1572,6 +1707,11 @@ void RendererGeode::popTransform() {
 }
 
 void RendererGeode::pushClip(const ResolvedClip& clip) {
+  // M6-B step 3: flush batch before a state change — a subsequent
+  // drawPath inside the new clip is no longer "batch-compatible"
+  // with the pending run from the outer clip region.
+  impl_->flushPendingBatch();
+
   // Rectangular clip (the nested-`<svg>` viewport, `overflow: hidden`, and
   // `<image>` dest-rect cases) is implemented via the WebGPU scissor rect
   // (plus the Phase 3a polygon clip for non-axis-aligned ancestors).
@@ -1786,6 +1926,10 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
 }
 
 void RendererGeode::popClip() {
+  // M6-B step 3: flush before popping so the batched draws stay
+  // inside the clip region they were accumulated under.
+  impl_->flushPendingBatch();
+
   if (!impl_->clipStack.empty()) {
     // Defer release of the mask textures to endFrame — the main
     // encoder that was just drawing under this clip may have recorded
@@ -1803,6 +1947,8 @@ void RendererGeode::popClip() {
 }
 
 void RendererGeode::pushIsolatedLayer(double opacity, MixBlendMode blendMode) {
+  impl_->flushPendingBatch();  // M6-B step 3
+
   // Phase 3d implements all 16 `mix-blend-mode` values: the pushed
   // layer renders normally, and `popIsolatedLayer` switches to a
   // blend-blit compositor that reads a frozen snapshot of the parent
@@ -1886,6 +2032,7 @@ void RendererGeode::pushIsolatedLayer(double opacity, MixBlendMode blendMode) {
 }
 
 void RendererGeode::popIsolatedLayer() {
+  impl_->flushPendingBatch();  // M6-B step 3
   if (impl_->layerStack.empty()) {
     return;
   }
@@ -1994,6 +2141,7 @@ void RendererGeode::popIsolatedLayer() {
 
 void RendererGeode::pushFilterLayer(const components::FilterGraph& filterGraph,
                                     const std::optional<Box2d>& filterRegion) {
+  impl_->flushPendingBatch();  // M6-B step 3
   if (!impl_->device || !impl_->pipeline || !impl_->gradientPipeline || !impl_->imagePipeline ||
       !impl_->encoder || !impl_->filterEngine) {
     // Headless or degenerate state — push a placeholder frame so
@@ -2069,6 +2217,7 @@ void RendererGeode::pushFilterLayer(const components::FilterGraph& filterGraph,
 }
 
 void RendererGeode::popFilterLayer() {
+  impl_->flushPendingBatch();  // M6-B step 3
   if (impl_->filterStack.empty()) {
     return;
   }
@@ -2125,6 +2274,7 @@ void RendererGeode::popFilterLayer() {
 }
 
 void RendererGeode::pushMask(const std::optional<Box2d>& maskBounds) {
+  impl_->flushPendingBatch();  // M6-B step 3
   if (!impl_->device || !impl_->pipeline || !impl_->gradientPipeline || !impl_->imagePipeline ||
       !impl_->encoder || impl_->pixelWidth <= 0 || impl_->pixelHeight <= 0) {
     // Headless / degenerate — push a placeholder so popMask stays balanced.
@@ -2195,6 +2345,7 @@ void RendererGeode::pushMask(const std::optional<Box2d>& maskBounds) {
 }
 
 void RendererGeode::transitionMaskToContent() {
+  impl_->flushPendingBatch();  // M6-B step 3
   if (impl_->maskStack.empty()) {
     return;
   }
@@ -2224,6 +2375,7 @@ void RendererGeode::transitionMaskToContent() {
 }
 
 void RendererGeode::popMask() {
+  impl_->flushPendingBatch();  // M6-B step 3
   if (impl_->maskStack.empty()) {
     return;
   }
@@ -2276,6 +2428,7 @@ void RendererGeode::popMask() {
 }
 
 void RendererGeode::beginPatternTile(const Box2d& tileRect, const Transform2d& targetFromPattern) {
+  impl_->flushPendingBatch();  // M6-B step 3
   if (!impl_->device || !impl_->pipeline) {
     return;
   }
@@ -2419,6 +2572,7 @@ void RendererGeode::beginPatternTile(const Box2d& tileRect, const Transform2d& t
 }
 
 void RendererGeode::endPatternTile(bool forStroke) {
+  impl_->flushPendingBatch();  // M6-B step 3
   if (impl_->patternStack.empty()) {
     return;
   }
@@ -2540,6 +2694,38 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   // falls back to the inline encode path.
   const geode::EncodedPath* fillEncoded =
       impl_->getFillEncode(path.sourceEntity, path.path, path.fillRule);
+
+  // M6-B step 3: try to append to a pending `<use>`-batch. Preconditions:
+  //  - Source entity valid (non-null handle).
+  //  - Fill encode cache hit (shared across all instances).
+  //  - Solid paint (gradient / pattern need per-draw uniforms today).
+  //  - No active pattern-fill handoff from the driver.
+  //  - No stroke (we can't defer a fill while the stroke runs on top).
+  //
+  // When all hold: append this draw's `currentTransform` into the pending
+  // batch (flushing + restarting if the paint/source key differs) and
+  // return early. A later state change (pushClip, popLayer, endFrame,
+  // setPaint-different-key, non-batchable draw) flushes as one instanced
+  // draw.
+  const bool hasStroke =
+      !(stroke.strokeWidth <= 0.0 ||
+        std::holds_alternative<PaintServer::None>(impl_->paint.stroke));
+  const bool batchable =
+      !hasStroke && fillEncoded != nullptr &&
+      path.sourceEntity.entity() != entt::null &&
+      std::holds_alternative<PaintServer::Solid>(impl_->paint.fill) &&
+      !impl_->patternFillPaint.has_value() && impl_->encoder != nullptr;
+  if (batchable) {
+    const auto& solid = std::get<PaintServer::Solid>(impl_->paint.fill);
+    const css::RGBA color = solid.color.resolve(
+        impl_->paint.currentColor.rgba(), static_cast<float>(impl_->paint.fillOpacity));
+    impl_->tryAppendOrStartBatch(path.sourceEntity.entity(), path.path, color, path.fillRule,
+                                 fillEncoded);
+    return;
+  }
+
+  // Non-batchable: flush whatever's pending, then emit normally.
+  impl_->flushPendingBatch();
   impl_->fillResolved(path.path, path.fillRule, fillEncoded);
 
   // Mirror fillResolved's no-op safety: if there's no encoder (headless
@@ -2623,6 +2809,7 @@ void RendererGeode::drawEllipse(const Box2d& bounds, const StrokeParams& stroke)
 }
 
 void RendererGeode::drawImage(const ImageResource& image, const ImageParams& params) {
+  impl_->flushPendingBatch();  // M6-B step 3
   if (!impl_->encoder) {
     return;
   }
@@ -2643,6 +2830,7 @@ void RendererGeode::drawImage(const ImageResource& image, const ImageParams& par
 
 void RendererGeode::drawText(Registry& registry, const components::ComputedTextComponent& text,
                              const TextParams& params) {
+  impl_->flushPendingBatch();  // M6-B step 3
 #ifdef DONNER_TEXT_ENABLED
   if (!impl_->device || !impl_->encoder || impl_->pixelWidth <= 0 || impl_->pixelHeight <= 0) {
     return;

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1209,9 +1209,8 @@ struct RendererGeode::Impl {
   /// has cached fill encode, no in-flight pattern).
   bool tryAppendOrStartBatch(Entity sourceEntity, const Path& path, const css::RGBA& color,
                              FillRule rule, const geode::EncodedPath* encoded) {
-    const bool matches = pendingBatch.has_value() &&
-                        pendingBatch->sourceEntity == sourceEntity &&
-                        pendingBatch->color == color && pendingBatch->rule == rule;
+    const bool matches = pendingBatch.has_value() && pendingBatch->sourceEntity == sourceEntity &&
+                         pendingBatch->color == color && pendingBatch->rule == rule;
     if (matches) {
       pendingBatch->deviceFromLocalTransforms.push_back(deviceFromLocalTransform);
       return true;
@@ -2707,18 +2706,16 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   // return early. A later state change (pushClip, popLayer, endFrame,
   // setPaint-different-key, non-batchable draw) flushes as one instanced
   // draw.
-  const bool hasStroke =
-      !(stroke.strokeWidth <= 0.0 ||
-        std::holds_alternative<PaintServer::None>(impl_->paint.stroke));
-  const bool batchable =
-      !hasStroke && fillEncoded != nullptr &&
-      path.sourceEntity.entity() != entt::null &&
-      std::holds_alternative<PaintServer::Solid>(impl_->paint.fill) &&
-      !impl_->patternFillPaint.has_value() && impl_->encoder != nullptr;
+  const bool hasStroke = !(stroke.strokeWidth <= 0.0 ||
+                           std::holds_alternative<PaintServer::None>(impl_->paint.stroke));
+  const bool batchable = !hasStroke && fillEncoded != nullptr &&
+                         path.sourceEntity.entity() != entt::null &&
+                         std::holds_alternative<PaintServer::Solid>(impl_->paint.fill) &&
+                         !impl_->patternFillPaint.has_value() && impl_->encoder != nullptr;
   if (batchable) {
     const auto& solid = std::get<PaintServer::Solid>(impl_->paint.fill);
-    const css::RGBA color = solid.color.resolve(
-        impl_->paint.currentColor.rgba(), static_cast<float>(impl_->paint.fillOpacity));
+    const css::RGBA color = solid.color.resolve(impl_->paint.currentColor.rgba(),
+                                                static_cast<float>(impl_->paint.fillOpacity));
     impl_->tryAppendOrStartBatch(path.sourceEntity.entity(), path.path, color, path.fillRule,
                                  fillEncoded);
     return;

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1035,6 +1035,15 @@ struct RendererGeode::Impl {
   /// the same address doesn't carry the tag.
   struct ListenerInstalled {};
 
+  /// M6-B detection (design doc 0030 §M6 Bullet 2): track the source
+  /// entity of the most recent `drawPath` call so `drawPath` can bump
+  /// `sameSourceDrawPairs` whenever it sees two consecutive
+  /// entity-matched calls. Reset to `entt::null` at `beginFrame`.
+  /// Value is the `PathShape::sourceEntity`'s entity (not its
+  /// registry-qualified handle — two drawPath calls from different
+  /// registries are never considered "consecutive same-source").
+  Entity lastDrawSourceEntity = entt::null;
+
   /// Connect (or rewire) our `on_update<ComputedPathComponent>` /
   /// `on_destroy<ComputedPathComponent>` listener onto `registry`.
   /// Called at the start of each `draw()`. Idempotent for the same
@@ -1415,6 +1424,10 @@ void RendererGeode::beginFrame(const RenderViewport& viewport) {
   // resize.
   ++impl_->currentFrameIndex;
   impl_->evictStalePoolBuckets();
+
+  // M6-B detection: drop the previous-draw source-entity memo so
+  // cross-frame draws don't show up as "same-source runs".
+  impl_->lastDrawSourceEntity = entt::null;
 
   // Reset counters regardless of device state.
   impl_->counters.reset();
@@ -2508,6 +2521,20 @@ void RendererGeode::setPaint(const PaintParams& paint) {
 }
 
 void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) {
+  // M6-B detection (design doc 0030 §M6 Bullet 2): when a `<use>`
+  // draws a path that was also just drawn by the previous call —
+  // same source entity, same paint — this is exactly the case an
+  // instancing pass would collapse into one GPU draw. Count it here
+  // so the benefit of a future batcher is measurable before the
+  // batcher ships. Null source (non-driver callers) never matches,
+  // so editor overlay / convenience `drawRect` calls don't skew the
+  // counter.
+  if (path.sourceEntity.entity() != entt::null &&
+      path.sourceEntity.entity() == impl_->lastDrawSourceEntity) {
+    ++impl_->counters.sameSourceDrawPairs;
+  }
+  impl_->lastDrawSourceEntity = path.sourceEntity.entity();
+
   // M2 cache lookup for the fill encode. Null `sourceEntity` (editor
   // overlay, test-harness direct draws) returns nullptr and `GeoEncoder`
   // falls back to the inline encode path.

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -542,8 +542,8 @@ struct RendererGeode::Impl {
 
   // CPU-side state.
   PaintParams paint;
-  Transform2d currentTransform;
-  std::vector<Transform2d> transformStack;
+  Transform2d deviceFromLocalTransform;
+  std::vector<Transform2d> deviceFromLocalTransformStack;
 
   // --- Pattern tile state (Phase 2H) ---
   //
@@ -562,8 +562,8 @@ struct RendererGeode::Impl {
     std::unique_ptr<geode::GeoEncoder> savedEncoder;
     wgpu::Texture savedTarget;
     wgpu::Texture savedMsaaTarget;
-    Transform2d savedTransform;
-    std::vector<Transform2d> savedTransformStack;
+    Transform2d savedDeviceFromLocalTransform;
+    std::vector<Transform2d> savedDeviceFromLocalTransformStack;
     int savedPixelWidth = 0;
     int savedPixelHeight = 0;
 
@@ -799,7 +799,7 @@ struct RendererGeode::Impl {
     /// objectBoundingBox-mapped user space — either way, NOT yet in
     /// device pixels).
     std::optional<Box2d> maskBounds;
-    /// `currentTransform` snapshotted at `pushMask` time so that
+    /// `deviceFromLocalTransform` snapshotted at `pushMask` time so that
     /// `popMask` can lift `maskBounds` into device-pixel space. This
     /// mirrors `RendererTinySkia::SurfaceFrame::maskBoundsTransform`.
     Transform2d maskBoundsTransform;
@@ -811,11 +811,11 @@ struct RendererGeode::Impl {
     wgpu::Texture tile;
     Vector2d tileSize;              // In pattern space.
     Transform2d targetFromPattern;  // destFromSource naming.
-    // `currentTransform` snapshotted at the time the outer element kicked
+    // `deviceFromLocalTransform` snapshotted at the time the outer element kicked
     // off `beginPatternTile`. This is the path→device transform that the
     // SAME outer element will use when its fill draw happens. Used at
     // pattern-paint build time to strip the canvas-scale / parent-transform
-    // chain back out of the live `currentTransform`, so the resulting
+    // chain back out of the live `deviceFromLocalTransform`, so the resulting
     // `patternFromPath` matrix compares path-space positions against the
     // pattern tile's user-space coordinate system instead of accidentally
     // multiplying them by the viewBox→canvas scale.
@@ -973,24 +973,24 @@ struct RendererGeode::Impl {
   /// current transform so the shader samples in the correct space.
   ///
   /// Math: during the fill draw, the Geode vertex shader emits `sample_pos`
-  /// in PATH space (pre-MVP, pre-`currentTransform`). The pattern fragment
+  /// in PATH space (pre-MVP, pre-`deviceFromLocalTransform`). The pattern fragment
   /// shader needs pattern-tile-space coordinates. The driver gave us
   /// `targetFromPattern` in USER space (i.e., the viewBox frame the outer
   /// element was drawn in) — *not* device space — which is a semantic
-  /// mismatch with the renderer, where `currentTransform` goes all the way
+  /// mismatch with the renderer, where `deviceFromLocalTransform` goes all the way
   /// from path space to device pixels (i.e., it bakes in the
   /// viewBox→canvas scale on top of the entity's own transform).
   ///
-  /// To bridge the mismatch we capture `deviceFromPathAtCapture = currentTransform`
+  /// To bridge the mismatch we capture `deviceFromPathAtCapture = deviceFromLocalTransform`
   /// at `beginPatternTile` time. Both the pattern's content subtree and the
   /// eventual fill draw use the same referencing element, so that transform
   /// is the path→device mapping we'd want for BOTH the tile raster and
   /// the final sample. The chain is:
   ///
   ///   pattern_pos  =  inverse(deviceFromPath_at_capture * targetFromPattern)
-  ///                 · currentTransform · path_pos
+  ///                 · deviceFromLocalTransform · path_pos
   ///
-  /// Expanding: the two `currentTransform`/`deviceFromPath_at_capture` matrices
+  /// Expanding: the two `deviceFromLocalTransform`/`deviceFromPath_at_capture` matrices
   /// cancel (they're the same transform when the outer element is drawing
   /// its own fill immediately after the pattern subtree returns), leaving
   /// `inverse(targetFromPattern) · path_pos` — which sits in the user-space
@@ -1001,7 +1001,7 @@ struct RendererGeode::Impl {
                                                     double opacity) const {
     const Transform2d deviceFromPattern = slot.deviceFromPathAtCapture * slot.targetFromPattern;
     const Transform2d patternFromDevice = deviceFromPattern.inverse();
-    const Transform2d patternFromPath = patternFromDevice * currentTransform;
+    const Transform2d patternFromPath = patternFromDevice * deviceFromLocalTransform;
     geode::GeoEncoder::PatternPaint p;
     p.tile = slot.tile;
     p.tileSize = slot.tileSize;
@@ -1010,10 +1010,10 @@ struct RendererGeode::Impl {
     return p;
   }
 
-  /// Push the renderer's currentTransform onto the encoder before drawing.
+  /// Push the renderer's deviceFromLocalTransform onto the encoder before drawing.
   void syncTransform() {
     if (encoder) {
-      encoder->setTransform(currentTransform);
+      encoder->setTransform(deviceFromLocalTransform);
     }
   }
 
@@ -1047,7 +1047,7 @@ struct RendererGeode::Impl {
   /// M6-B step 3 (design doc 0030 §M6 Bullet 2): deferred batch for
   /// consecutive `drawPath` calls that share a source entity + resolved
   /// solid paint + no stroke + no subtree complication. Each matching
-  /// call appends its `currentTransform` into `transforms`; the batch
+  /// call appends its `deviceFromLocalTransform` into `transforms`; the batch
   /// is flushed by `flushPendingBatch()` whenever state changes in a
   /// way that invalidates the batch (paint-key mismatch on the next
   /// drawPath, any push/pop, end of frame, …). A flush of size >= 2
@@ -1065,11 +1065,11 @@ struct RendererGeode::Impl {
     /// `GeodePathCacheComponent`'s cache invariant for the frame's
     /// lifetime).
     const Path* path = nullptr;
-    /// `currentTransform` captured at each `drawPath`. On flush, the
+    /// `deviceFromLocalTransform` captured at each `drawPath`. On flush, the
     /// outer encoder transform is set to identity and these are
     /// uploaded as per-instance transforms (see
     /// `flushPendingBatch` for the math).
-    std::vector<Transform2d> transforms;
+    std::vector<Transform2d> deviceFromLocalTransforms;
   };
   std::optional<PendingBatch> pendingBatch;
 
@@ -1147,7 +1147,7 @@ struct RendererGeode::Impl {
   /// don't pay the per-instance-buffer cost when we accumulated
   /// exactly one draw. Size >= 2 is one instanced GPU draw.
   ///
-  /// Flushing mutates `currentTransform` to push the batch's
+  /// Flushing mutates `deviceFromLocalTransform` to push the batch's
   /// transform(s) down to the encoder, then RESTORES it to the
   /// caller's current value. Without the restore, a flush in the
   /// middle of `drawPath` (between fill and stroke, for example)
@@ -1155,7 +1155,7 @@ struct RendererGeode::Impl {
   /// for the subsequent stroke emit — breaks any fixture that
   /// mixes batchable fills with stroked siblings.
   void flushPendingBatch() {
-    if (!pendingBatch.has_value() || pendingBatch->transforms.empty()) {
+    if (!pendingBatch.has_value() || pendingBatch->deviceFromLocalTransforms.empty()) {
       pendingBatch.reset();
       return;
     }
@@ -1163,14 +1163,14 @@ struct RendererGeode::Impl {
       pendingBatch.reset();
       return;
     }
-    const Transform2d savedTransform = currentTransform;
+    const Transform2d savedDeviceFromLocalTransform = deviceFromLocalTransform;
     PendingBatch batch = std::move(*pendingBatch);
     pendingBatch.reset();
 
-    if (batch.transforms.size() == 1) {
+    if (batch.deviceFromLocalTransforms.size() == 1) {
       // Single draw — restore the captured transform + use the
       // non-instanced path.
-      currentTransform = batch.transforms.front();
+      deviceFromLocalTransform = batch.deviceFromLocalTransforms.front();
       syncTransform();
       encoder->fillPath(*batch.path, batch.color, batch.rule, batch.encoded);
     } else {
@@ -1178,25 +1178,25 @@ struct RendererGeode::Impl {
       // `uniforms.mvp` carries only the orthographic screen-pixel mapping.
       // Each instance transform already encodes the full
       // `worldFromEntity * surfaceFromCanvas` composition that a
-      // non-batched draw would fold into currentTransform; compose with
+      // non-batched draw would fold into deviceFromLocalTransform; compose with
       // identity `uniforms.mvp` is equivalent to composing with the
-      // original currentTransform per-draw.
-      currentTransform = Transform2d();
+      // original deviceFromLocalTransform per-draw.
+      deviceFromLocalTransform = Transform2d();
       syncTransform();
 
       // Pack transforms into the wire format the shader expects.
-      std::vector<float> packed(batch.transforms.size() * 8u);
-      for (size_t i = 0; i < batch.transforms.size(); ++i) {
-        packTransform(batch.transforms[i], packed.data() + i * 8u);
+      std::vector<float> packed(batch.deviceFromLocalTransforms.size() * 8u);
+      for (size_t i = 0; i < batch.deviceFromLocalTransforms.size(); ++i) {
+        packTransform(batch.deviceFromLocalTransforms[i], packed.data() + i * 8u);
       }
       encoder->fillPathInstanced(*batch.encoded, batch.color, batch.rule, packed);
     }
 
     // Restore so subsequent draw/state ops see the driver-set
     // transform intact. Draw-emitting helpers (`syncTransform` +
-    // `encoder->fillPath*`) read `currentTransform` when re-entered,
+    // `encoder->fillPath*`) read `deviceFromLocalTransform` when re-entered,
     // so we don't need to re-sync the encoder right now.
-    currentTransform = savedTransform;
+    deviceFromLocalTransform = savedDeviceFromLocalTransform;
   }
 
   /// Predicate: would a batchable draw with this key extend the
@@ -1213,7 +1213,7 @@ struct RendererGeode::Impl {
                         pendingBatch->sourceEntity == sourceEntity &&
                         pendingBatch->color == color && pendingBatch->rule == rule;
     if (matches) {
-      pendingBatch->transforms.push_back(currentTransform);
+      pendingBatch->deviceFromLocalTransforms.push_back(deviceFromLocalTransform);
       return true;
     }
     // Key doesn't match — flush whatever's pending, then start fresh.
@@ -1224,7 +1224,7 @@ struct RendererGeode::Impl {
     pendingBatch->rule = rule;
     pendingBatch->encoded = encoded;
     pendingBatch->path = &path;
-    pendingBatch->transforms.push_back(currentTransform);
+    pendingBatch->deviceFromLocalTransforms.push_back(deviceFromLocalTransform);
     return true;
   }
 
@@ -1543,8 +1543,8 @@ void RendererGeode::beginFrame(const RenderViewport& viewport) {
   impl_->viewport = viewport;
   impl_->pixelWidth = static_cast<int>(viewport.size.x * viewport.devicePixelRatio);
   impl_->pixelHeight = static_cast<int>(viewport.size.y * viewport.devicePixelRatio);
-  impl_->currentTransform = Transform2d();
-  impl_->transformStack.clear();
+  impl_->deviceFromLocalTransform = Transform2d();
+  impl_->deviceFromLocalTransformStack.clear();
   impl_->paint = PaintParams();
   impl_->encoder.reset();
 
@@ -1668,8 +1668,8 @@ void RendererGeode::endFrame() {
   // new writes after the previous submit's GPU work completes.
   impl_->drainPendingReleases();
 
-  impl_->currentTransform = Transform2d();
-  impl_->transformStack.clear();
+  impl_->deviceFromLocalTransform = Transform2d();
+  impl_->deviceFromLocalTransformStack.clear();
 }
 
 void RendererGeode::setTransform(const Transform2d& transform) {
@@ -1687,23 +1687,23 @@ void RendererGeode::setTransform(const Transform2d& transform) {
     scaled.data[1] *= scale.y;
     scaled.data[3] *= scale.y;
     scaled.data[5] *= scale.y;
-    impl_->currentTransform = scaled;
+    impl_->deviceFromLocalTransform = scaled;
     return;
   }
-  impl_->currentTransform = transform;
+  impl_->deviceFromLocalTransform = transform;
 }
 
 void RendererGeode::pushTransform(const Transform2d& transform) {
-  impl_->transformStack.push_back(impl_->currentTransform);
-  impl_->currentTransform = transform * impl_->currentTransform;
+  impl_->deviceFromLocalTransformStack.push_back(impl_->deviceFromLocalTransform);
+  impl_->deviceFromLocalTransform = transform * impl_->deviceFromLocalTransform;
 }
 
 void RendererGeode::popTransform() {
-  if (impl_->transformStack.empty()) {
+  if (impl_->deviceFromLocalTransformStack.empty()) {
     return;
   }
-  impl_->currentTransform = impl_->transformStack.back();
-  impl_->transformStack.pop_back();
+  impl_->deviceFromLocalTransform = impl_->deviceFromLocalTransformStack.back();
+  impl_->deviceFromLocalTransformStack.pop_back();
 }
 
 void RendererGeode::pushClip(const ResolvedClip& clip) {
@@ -1726,7 +1726,7 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
   // The active scissor is the INTERSECTION of everything on the stack.
   Impl::ClipStackEntry entry;
   if (clip.clipRect.has_value()) {
-    const Transform2d& t = impl_->currentTransform;
+    const Transform2d& t = impl_->deviceFromLocalTransform;
     entry.pixelRect = t.transformBox(*clip.clipRect);
     entry.valid = true;
 
@@ -1850,7 +1850,7 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
     // the input clip so shapes get intersected with the deeper
     // union. Runs at the same layer don't intersect with each other
     // — the Max blend on the R channel handles union within a run.
-    const Transform2d savedTransform = impl_->currentTransform;
+    const Transform2d savedDeviceFromLocalTransform = impl_->deviceFromLocalTransform;
 
     // If any clip stack entry already carries a path mask (e.g., an
     // ancestor `<g>` with its own `clip-path`), use the topmost one
@@ -1893,7 +1893,7 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
       for (size_t s = it->begin; s < it->end; ++s) {
         const PathShape& shape = clip.clipPaths[s];
         const Transform2d composed =
-            clip.clipPathUnitsTransform * shape.parentFromEntity * savedTransform;
+            clip.clipPathUnitsTransform * shape.parentFromEntity * savedDeviceFromLocalTransform;
         impl_->encoder->setTransform(composed);
         impl_->encoder->fillPathIntoMask(shape.path, shape.fillRule);
       }
@@ -1918,7 +1918,7 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
     // Clear the encoder's internal clip-mask state — the next main
     // pass will rebind via `updateEncoderScissor`.
     impl_->encoder->clearClipMask();
-    impl_->encoder->setTransform(savedTransform);
+    impl_->encoder->setTransform(savedDeviceFromLocalTransform);
   }
 
   impl_->clipStack.push_back(std::move(entry));
@@ -2322,7 +2322,7 @@ void RendererGeode::pushMask(const std::optional<Box2d>& maskBounds) {
     return;
   }
   frame.maskBounds = maskBounds;
-  frame.maskBoundsTransform = impl_->currentTransform;
+  frame.maskBoundsTransform = impl_->deviceFromLocalTransform;
 
   // Flush the outer encoder's pending draws so they land before we
   // redirect subsequent commands into the mask capture.
@@ -2447,7 +2447,7 @@ void RendererGeode::beginPatternTile(const Box2d& tileRect, const Transform2d& t
   // that was rendered at 40×40 texels. The extra resolution lets the
   // MSAA-resolved tile capture finer edge transitions, closing the gap.
   constexpr double kPatternSupersampleScale = 2.0;
-  const Transform2d deviceFromPattern = impl_->currentTransform * targetFromPattern;
+  const Transform2d deviceFromPattern = impl_->deviceFromLocalTransform * targetFromPattern;
   const double scaleX = std::hypot(deviceFromPattern.data[0], deviceFromPattern.data[1]);
   const double scaleY = std::hypot(deviceFromPattern.data[2], deviceFromPattern.data[3]);
   auto boundedPx = [](double v) {
@@ -2518,8 +2518,8 @@ void RendererGeode::beginPatternTile(const Box2d& tileRect, const Transform2d& t
   frame.savedEncoder = std::move(impl_->encoder);
   frame.savedTarget = impl_->target;
   frame.savedMsaaTarget = impl_->msaaTarget;
-  frame.savedTransform = impl_->currentTransform;
-  frame.savedTransformStack = std::move(impl_->transformStack);
+  frame.savedDeviceFromLocalTransform = impl_->deviceFromLocalTransform;
+  frame.savedDeviceFromLocalTransformStack = std::move(impl_->deviceFromLocalTransformStack);
   frame.savedPixelWidth = impl_->pixelWidth;
   frame.savedPixelHeight = impl_->pixelHeight;
   frame.tileRect = tileRect;
@@ -2552,12 +2552,12 @@ void RendererGeode::beginPatternTile(const Box2d& tileRect, const Transform2d& t
   impl_->pixelHeight = tilePixelHeight;
   impl_->target = tileTexture;
   impl_->msaaTarget = tileMsaaTexture;
-  impl_->transformStack.clear();
+  impl_->deviceFromLocalTransformStack.clear();
   // Initialise the current transform to the raster scale so direct draws
   // issued before the driver's next `setTransform` still land in the
   // correct place on the tile texture.
   const Vector2d& rasterScale = impl_->patternStack.back().rasterScale;
-  impl_->currentTransform = Transform2d::Scale(rasterScale.x, rasterScale.y);
+  impl_->deviceFromLocalTransform = Transform2d::Scale(rasterScale.x, rasterScale.y);
 
   auto newEncoder = std::make_unique<geode::GeoEncoder>(
       *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
@@ -2591,8 +2591,8 @@ void RendererGeode::endPatternTile(bool forStroke) {
   impl_->msaaTarget = frame.savedMsaaTarget;
   impl_->pixelWidth = frame.savedPixelWidth;
   impl_->pixelHeight = frame.savedPixelHeight;
-  impl_->currentTransform = frame.savedTransform;
-  impl_->transformStack = std::move(frame.savedTransformStack);
+  impl_->deviceFromLocalTransform = frame.savedDeviceFromLocalTransform;
+  impl_->deviceFromLocalTransformStack = std::move(frame.savedDeviceFromLocalTransformStack);
 
   // Create a fresh encoder for the outer target. The old outer encoder was
   // finished in `beginPatternTile`; the new one loads the current contents
@@ -2656,13 +2656,13 @@ void RendererGeode::endPatternTile(bool forStroke) {
   slot.tile = frame.tileTexture;
   slot.tileSize = frame.tileRect.size();
   slot.targetFromPattern = frame.targetFromPattern;
-  // `frame.savedTransform` is the path→device transform that was live at
-  // `beginPatternTile` time — i.e., the outer element's currentTransform
+  // `frame.savedDeviceFromLocalTransform` is the path→device transform that was live at
+  // `beginPatternTile` time — i.e., the outer element's deviceFromLocalTransform
   // including the viewBox→canvas scale. We stash it on the slot so
-  // `buildPatternPaint` can cancel it out of the live `currentTransform`
+  // `buildPatternPaint` can cancel it out of the live `deviceFromLocalTransform`
   // at the upcoming fill draw, leaving the pattern sample in the pattern's
   // user-space frame (where `tileSize` is expressed).
-  slot.deviceFromPathAtCapture = frame.savedTransform;
+  slot.deviceFromPathAtCapture = frame.savedDeviceFromLocalTransform;
   if (forStroke) {
     impl_->patternStrokePaint = std::move(slot);
   } else {
@@ -2702,7 +2702,7 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   //  - No active pattern-fill handoff from the driver.
   //  - No stroke (we can't defer a fill while the stroke runs on top).
   //
-  // When all hold: append this draw's `currentTransform` into the pending
+  // When all hold: append this draw's `deviceFromLocalTransform` into the pending
   // batch (flushing + restarting if the paint/source key differs) and
   // return early. A later state change (pushClip, popLayer, endFrame,
   // setPaint-different-key, non-batchable draw) flushes as one instanced
@@ -2896,11 +2896,11 @@ void RendererGeode::drawText(Registry& registry, const components::ComputedTextC
 
   // Snapshot the encoder's current transform so we can restore it if
   // per-glyph rotations mess with it. `fillPath` honours
-  // `impl_->currentTransform` via `setTransform`, and the glyph
+  // `impl_->deviceFromLocalTransform` via `setTransform`, and the glyph
   // outline coordinates are already mapped into the text element's
   // local space by the transformPath call below -- so we want the
-  // encoder to use the element's currentTransform unchanged.
-  impl_->encoder->setTransform(impl_->currentTransform);
+  // encoder to use the element's deviceFromLocalTransform unchanged.
+  impl_->encoder->setTransform(impl_->deviceFromLocalTransform);
 
   for (size_t runIndex = 0; runIndex < runs.size(); ++runIndex) {
     const auto& run = runs[runIndex];

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1218,7 +1218,7 @@ struct RendererGeode::Impl {
     }
     // Key doesn't match — flush whatever's pending, then start fresh.
     flushPendingBatch();
-    pendingBatch.emplace();
+    pendingBatch = PendingBatch{};
     pendingBatch->sourceEntity = sourceEntity;
     pendingBatch->color = color;
     pendingBatch->rule = rule;

--- a/donner/svg/renderer/RendererTinySkia.cc
+++ b/donner/svg/renderer/RendererTinySkia.cc
@@ -806,13 +806,14 @@ void RendererTinySkia::pushFilterLayer(const components::FilterGraph& filterGrap
   surfaceStack_.push_back(std::move(frame));
 
   // Apply the buffer offset to the current transform. setTransform (called by RendererDriver)
-  // ran BEFORE this filter layer was pushed, so deviceFromLocalTransform_ doesn't include the offset yet.
-  // Subsequent setTransform calls will pick up the offset from surfaceStack_.back(), but we
-  // need to fix the already-set transform for the element being filtered.
+  // ran BEFORE this filter layer was pushed, so deviceFromLocalTransform_ doesn't include the
+  // offset yet. Subsequent setTransform calls will pick up the offset from surfaceStack_.back(),
+  // but we need to fix the already-set transform for the element being filtered.
   const auto& pushedFrame = surfaceStack_.back();
   if (pushedFrame.filterBufferOffsetX != 0 || pushedFrame.filterBufferOffsetY != 0) {
-    deviceFromLocalTransform_ = deviceFromLocalTransform_ * Transform2d::Translate(pushedFrame.filterBufferOffsetX,
-                                                                  pushedFrame.filterBufferOffsetY);
+    deviceFromLocalTransform_ =
+        deviceFromLocalTransform_ *
+        Transform2d::Translate(pushedFrame.filterBufferOffsetX, pushedFrame.filterBufferOffsetY);
   }
 #else
   (void)filterGraph;
@@ -863,7 +864,7 @@ void RendererTinySkia::popFilterLayer() {
 
     const double blurPadding = computeBlurPadding(frame.filterGraph);
     const Box2d paddedRegion(filterRegion.topLeft - Vector2d(blurPadding, blurPadding),
-                            filterRegion.bottomRight + Vector2d(blurPadding, blurPadding));
+                             filterRegion.bottomRight + Vector2d(blurPadding, blurPadding));
 
     const int localWidth = std::max(1, static_cast<int>(std::ceil(paddedRegion.width() * scaleX)));
     const int localHeight =
@@ -1073,7 +1074,8 @@ void RendererTinySkia::popMask() {
   }
 }
 
-void RendererTinySkia::beginPatternTile(const Box2d& tileRect, const Transform2d& targetFromPattern) {
+void RendererTinySkia::beginPatternTile(const Box2d& tileRect,
+                                        const Transform2d& targetFromPattern) {
   SurfaceFrame frame;
   frame.kind = SurfaceKind::PatternTile;
   frame.savedTransform = deviceFromLocalTransform_;
@@ -1348,8 +1350,8 @@ void RendererTinySkia::drawImage(const ImageResource& image, const ImageParams& 
   const double scaleX = params.targetRect.width() / static_cast<double>(image.width);
   const double scaleY = params.targetRect.height() / static_cast<double>(image.height);
   const Transform2d imageFromLocal = Transform2d::Scale(scaleX, scaleY) *
-                                    Transform2d::Translate(params.targetRect.topLeft) *
-                                    deviceFromLocalTransform_;
+                                     Transform2d::Translate(params.targetRect.topLeft) *
+                                     deviceFromLocalTransform_;
 
   tiny_skia::PixmapPaint paint;
   paint.opacity = NarrowToFloat(params.opacity * paintOpacity_);
@@ -1515,11 +1517,11 @@ void RendererTinySkia::drawText(Registry& registry, const components::ComputedTe
         } else if (patternFillPaint_.has_value()) {
           tiny_skia::Paint paint = makeBasePaint(antialias_);
           paint.unpremulStore = surfaceStack_.empty();
-          paint.shader = tiny_skia::Pattern(
-              patternFillPaint_->pixmap.view(), tiny_skia::SpreadMode::Repeat,
-              tiny_skia::FilterQuality::Bilinear,
-              NarrowToFloat(spanFillOpacity * static_cast<float>(span.opacity)),
-              toTinyTransform(patternFillPaint_->targetFromPattern));
+          paint.shader =
+              tiny_skia::Pattern(patternFillPaint_->pixmap.view(), tiny_skia::SpreadMode::Repeat,
+                                 tiny_skia::FilterQuality::Bilinear,
+                                 NarrowToFloat(spanFillOpacity * static_cast<float>(span.opacity)),
+                                 toTinyTransform(patternFillPaint_->targetFromPattern));
           spanFillPaint = paint;
         } else if (ref->fallback.has_value()) {
           spanFillPaint = makeSolidPaint(
@@ -1584,8 +1586,8 @@ void RendererTinySkia::drawText(Registry& registry, const components::ComputedTe
         glyphPath =
             textEngine.glyphOutline(run.font, glyph.glyphIndex, scale * glyph.fontSizeScale);
         if (glyph.stretchScaleX != 1.0f || glyph.stretchScaleY != 1.0f) {
-          glyphPath = transformPath(
-              glyphPath, Transform2d::Scale(glyph.stretchScaleX, glyph.stretchScaleY));
+          glyphPath = transformPath(glyphPath,
+                                    Transform2d::Scale(glyph.stretchScaleX, glyph.stretchScaleY));
         }
       }
 
@@ -1611,12 +1613,13 @@ void RendererTinySkia::drawText(Registry& registry, const components::ComputedTe
           const double targetH =
               static_cast<double>(bitmap->height) * bitmap->scale * glyph.stretchScaleY;
 
-          // Use the same transform pattern as drawImage: Scale * Translate * deviceFromLocalTransform_.
+          // Use the same transform pattern as drawImage: Scale * Translate *
+          // deviceFromLocalTransform_.
           const double imgScaleX = targetW / static_cast<double>(bitmap->width);
           const double imgScaleY = targetH / static_cast<double>(bitmap->height);
           const Transform2d imageFromLocal = Transform2d::Scale(imgScaleX, imgScaleY) *
-                                            Transform2d::Translate(Vector2d(targetX, targetY)) *
-                                            deviceFromLocalTransform_;
+                                             Transform2d::Translate(Vector2d(targetX, targetY)) *
+                                             deviceFromLocalTransform_;
 
           tiny_skia::PixmapPaint paint;
           paint.opacity = NarrowToFloat(paintOpacity_);
@@ -1827,12 +1830,12 @@ void RendererTinySkia::drawText(Registry& registry, const components::ComputedTe
             }
 
             Path segPath = PathBuilder()
-                .moveTo(Vector2d(0.0, decoTopY))
-                .lineTo(Vector2d(segmentWidth, decoTopY))
-                .lineTo(Vector2d(segmentWidth, decoTopY + decoThickness))
-                .lineTo(Vector2d(0.0, decoTopY + decoThickness))
-                .closePath()
-                .build();
+                               .moveTo(Vector2d(0.0, decoTopY))
+                               .lineTo(Vector2d(segmentWidth, decoTopY))
+                               .lineTo(Vector2d(segmentWidth, decoTopY + decoThickness))
+                               .lineTo(Vector2d(0.0, decoTopY + decoThickness))
+                               .closePath()
+                               .build();
 
             Transform2d segTransform = Transform2d::Translate(glyph.xPosition, glyph.yPosition);
             if (glyph.rotateDegrees != 0.0) {
@@ -1867,12 +1870,12 @@ void RendererTinySkia::drawText(Registry& registry, const components::ComputedTe
             const double x1 = lastGlyph->xPosition + lastGlyph->xAdvance;
             const double y = baselineY + decoTopY;
             Path decoPath = PathBuilder()
-                .moveTo(Vector2d(x0, y))
-                .lineTo(Vector2d(x1, y))
-                .lineTo(Vector2d(x1, y + decoThickness))
-                .lineTo(Vector2d(x0, y + decoThickness))
-                .closePath()
-                .build();
+                                .moveTo(Vector2d(x0, y))
+                                .lineTo(Vector2d(x1, y))
+                                .lineTo(Vector2d(x1, y + decoThickness))
+                                .lineTo(Vector2d(x0, y + decoThickness))
+                                .closePath()
+                                .build();
             drawDecoPath(toTinyPath(decoPath));
           } else {
             PathBuilder decoBuilder;

--- a/donner/svg/renderer/RendererTinySkia.cc
+++ b/donner/svg/renderer/RendererTinySkia.cc
@@ -610,8 +610,8 @@ void RendererTinySkia::beginFrame(const RenderViewport& viewport) {
   const int pixelHeight = static_cast<int>(viewport.size.y * viewport.devicePixelRatio);
 
   frame_ = createTransparentPixmap(pixelWidth, pixelHeight);
-  currentTransform_ = Transform2d();
-  transformStack_.clear();
+  deviceFromLocalTransform_ = Transform2d();
+  deviceFromLocalTransformStack_.clear();
   currentClipMask_.reset();
   clipStack_.clear();
   surfaceStack_.clear();
@@ -625,8 +625,8 @@ void RendererTinySkia::endFrame() {
   }
 
   surfaceStack_.clear();
-  currentTransform_ = Transform2d();
-  transformStack_.clear();
+  deviceFromLocalTransform_ = Transform2d();
+  deviceFromLocalTransformStack_.clear();
   currentClipMask_.reset();
   clipStack_.clear();
 }
@@ -634,35 +634,35 @@ void RendererTinySkia::endFrame() {
 void RendererTinySkia::setTransform(const Transform2d& transform) {
   if (!surfaceStack_.empty() && surfaceStack_.back().kind == SurfaceKind::PatternTile) {
     const Transform2d& rasterFromTile = surfaceStack_.back().patternRasterFromTile;
-    currentTransform_ =
+    deviceFromLocalTransform_ =
         scaleTransformOutput(transform, Vector2d(rasterFromTile.data[0], rasterFromTile.data[3]));
   } else if (!surfaceStack_.empty() && surfaceStack_.back().kind == SurfaceKind::FilterLayer) {
     const auto& frame = surfaceStack_.back();
     if (frame.filterBufferOffsetX != 0 || frame.filterBufferOffsetY != 0) {
       // Offset the transform so content at negative device coordinates renders into the
       // expanded filter buffer. Same pattern as PatternTile's rasterFromTile adjustment.
-      currentTransform_ =
+      deviceFromLocalTransform_ =
           transform * Transform2d::Translate(frame.filterBufferOffsetX, frame.filterBufferOffsetY);
     } else {
-      currentTransform_ = transform;
+      deviceFromLocalTransform_ = transform;
     }
   } else {
-    currentTransform_ = transform;
+    deviceFromLocalTransform_ = transform;
   }
 }
 
 void RendererTinySkia::pushTransform(const Transform2d& transform) {
-  transformStack_.push_back(currentTransform_);
-  currentTransform_ = transform * currentTransform_;
+  deviceFromLocalTransformStack_.push_back(deviceFromLocalTransform_);
+  deviceFromLocalTransform_ = transform * deviceFromLocalTransform_;
 }
 
 void RendererTinySkia::popTransform() {
-  if (transformStack_.empty()) {
+  if (deviceFromLocalTransformStack_.empty()) {
     return;
   }
 
-  currentTransform_ = transformStack_.back();
-  transformStack_.pop_back();
+  deviceFromLocalTransform_ = deviceFromLocalTransformStack_.back();
+  deviceFromLocalTransformStack_.pop_back();
 }
 
 void RendererTinySkia::pushClip(const ResolvedClip& clip) {
@@ -736,7 +736,7 @@ void RendererTinySkia::pushFilterLayer(const components::FilterGraph& filterGrap
   frame.kind = SurfaceKind::FilterLayer;
   frame.filterGraph = filterGraph;
   frame.filterRegion = filterRegion;
-  frame.deviceFromFilter = currentTransform_;
+  frame.deviceFromFilter = deviceFromLocalTransform_;
 
   const int viewportWidth = static_cast<int>(currentPixmap().width());
   const int viewportHeight = static_cast<int>(currentPixmap().height());
@@ -751,7 +751,7 @@ void RendererTinySkia::pushFilterLayer(const components::FilterGraph& filterGrap
   int height = viewportHeight;
 
   if (filterRegion.has_value()) {
-    const Box2d deviceRegion = currentTransform_.transformBox(*filterRegion);
+    const Box2d deviceRegion = deviceFromLocalTransform_.transformBox(*filterRegion);
     const int regionX0 = static_cast<int>(std::floor(deviceRegion.topLeft.x));
     const int regionY0 = static_cast<int>(std::floor(deviceRegion.topLeft.y));
     const int regionX1 = static_cast<int>(std::ceil(deviceRegion.bottomRight.x));
@@ -806,12 +806,12 @@ void RendererTinySkia::pushFilterLayer(const components::FilterGraph& filterGrap
   surfaceStack_.push_back(std::move(frame));
 
   // Apply the buffer offset to the current transform. setTransform (called by RendererDriver)
-  // ran BEFORE this filter layer was pushed, so currentTransform_ doesn't include the offset yet.
+  // ran BEFORE this filter layer was pushed, so deviceFromLocalTransform_ doesn't include the offset yet.
   // Subsequent setTransform calls will pick up the offset from surfaceStack_.back(), but we
   // need to fix the already-set transform for the element being filtered.
   const auto& pushedFrame = surfaceStack_.back();
   if (pushedFrame.filterBufferOffsetX != 0 || pushedFrame.filterBufferOffsetY != 0) {
-    currentTransform_ = currentTransform_ * Transform2d::Translate(pushedFrame.filterBufferOffsetX,
+    deviceFromLocalTransform_ = deviceFromLocalTransform_ * Transform2d::Translate(pushedFrame.filterBufferOffsetX,
                                                                   pushedFrame.filterBufferOffsetY);
   }
 #else
@@ -881,7 +881,7 @@ void RendererTinySkia::popFilterLayer() {
       // (translate) → local raster pixels (scale).
       // Operator* convention: (A * B)(p) = B(A(p)), so A is applied first.
       const Transform2d filterFromDevice = deviceFromFilter.inverse();
-      const Transform2d deviceToLocal =
+      const Transform2d localFromDevice =
           filterFromDevice *
           Transform2d::Translate(-paddedRegion.topLeft.x, -paddedRegion.topLeft.y) *
           Transform2d::Scale(scaleX, scaleY);
@@ -894,7 +894,7 @@ void RendererTinySkia::popFilterLayer() {
 
         auto localView = localPixmap.mutableView();
         tiny_skia::Painter::drawPixmap(localView, 0, 0, frame.pixmap.view(), resamplePaint,
-                                       toTinyTransform(deviceToLocal));
+                                       toTinyTransform(localFromDevice));
       }
 
       // Execute the filter graph in local raster space.
@@ -1001,7 +1001,7 @@ void RendererTinySkia::pushMask(const std::optional<Box2d>& maskBounds) {
   SurfaceFrame frame;
   frame.kind = SurfaceKind::MaskCapture;
   frame.maskBounds = maskBounds;
-  frame.maskBoundsTransform = currentTransform_;
+  frame.maskBoundsTransform = deviceFromLocalTransform_;
   frame.pixmap = createTransparentPixmap(static_cast<int>(currentPixmap().width()),
                                          static_cast<int>(currentPixmap().height()));
   surfaceStack_.push_back(std::move(frame));
@@ -1076,8 +1076,8 @@ void RendererTinySkia::popMask() {
 void RendererTinySkia::beginPatternTile(const Box2d& tileRect, const Transform2d& targetFromPattern) {
   SurfaceFrame frame;
   frame.kind = SurfaceKind::PatternTile;
-  frame.savedTransform = currentTransform_;
-  frame.savedTransformStack = transformStack_;
+  frame.savedTransform = deviceFromLocalTransform_;
+  frame.savedTransformStack = deviceFromLocalTransformStack_;
   frame.savedClipMask = currentClipMask_;
   frame.savedClipStack = clipStack_;
   const Transform2d deviceFromPattern = frame.savedTransform * targetFromPattern;
@@ -1098,8 +1098,8 @@ void RendererTinySkia::beginPatternTile(const Box2d& tileRect, const Transform2d
 
   surfaceStack_.push_back(std::move(frame));
 
-  currentTransform_ = surfaceStack_.back().patternRasterFromTile;
-  transformStack_.clear();
+  deviceFromLocalTransform_ = surfaceStack_.back().patternRasterFromTile;
+  deviceFromLocalTransformStack_.clear();
   currentClipMask_.reset();
   clipStack_.clear();
 }
@@ -1112,8 +1112,8 @@ void RendererTinySkia::endPatternTile(bool forStroke) {
   SurfaceFrame frame = std::move(surfaceStack_.back());
   surfaceStack_.pop_back();
 
-  currentTransform_ = frame.savedTransform;
-  transformStack_ = std::move(frame.savedTransformStack);
+  deviceFromLocalTransform_ = frame.savedTransform;
+  deviceFromLocalTransformStack_ = std::move(frame.savedTransformStack);
   currentClipMask_ = std::move(frame.savedClipMask);
   clipStack_ = std::move(frame.savedClipStack);
   PatternPaintState state{std::move(frame.pixmap), frame.targetFromPattern};
@@ -1149,12 +1149,12 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
   if (std::optional<tiny_skia::Paint> fillPaint = makeFillPaint(path.path.bounds())) {
     auto pixmapView = currentPixmapView();
     tiny_skia::Painter::fillPath(pixmapView, tinyPath, *fillPaint, toTinyFillRule(path.fillRule),
-                                 toTinyTransform(currentTransform_), mask);
+                                 toTinyTransform(deviceFromLocalTransform_), mask);
     if (fillPaintPixmap != nullptr) {
       auto fillPaintView = fillPaintPixmap->mutableView();
       tiny_skia::Painter::fillPath(fillPaintView, tinyPath, *fillPaint,
                                    toTinyFillRule(path.fillRule),
-                                   toTinyTransform(currentTransform_), mask);
+                                   toTinyTransform(deviceFromLocalTransform_), mask);
     }
     if (usedPatternFill) {
       patternFillPaint_.reset();
@@ -1197,11 +1197,11 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
 
     auto pixmapView = currentPixmapView();
     tiny_skia::Painter::strokePath(pixmapView, tinyPath, *strokePaint, tinyStroke,
-                                   toTinyTransform(currentTransform_), mask);
+                                   toTinyTransform(deviceFromLocalTransform_), mask);
     if (strokePaintPixmap != nullptr) {
       auto strokePaintView = strokePaintPixmap->mutableView();
       tiny_skia::Painter::strokePath(strokePaintView, tinyPath, *strokePaint, tinyStroke,
-                                     toTinyTransform(currentTransform_), mask);
+                                     toTinyTransform(deviceFromLocalTransform_), mask);
     }
     if (usedPatternStroke) {
       patternStrokePaint_.reset();
@@ -1233,11 +1233,11 @@ void RendererTinySkia::drawRect(const Box2d& rect, const StrokeParams& stroke) {
   if (std::optional<tiny_skia::Paint> fillPaint = makeFillPaint(rect)) {
     auto pixmapView = currentPixmapView();
     tiny_skia::Painter::fillRect(pixmapView, *tinyRect, *fillPaint,
-                                 toTinyTransform(currentTransform_), mask);
+                                 toTinyTransform(deviceFromLocalTransform_), mask);
     if (fillPaintPixmap != nullptr) {
       auto fillPaintView = fillPaintPixmap->mutableView();
       tiny_skia::Painter::fillRect(fillPaintView, *tinyRect, *fillPaint,
-                                   toTinyTransform(currentTransform_), mask);
+                                   toTinyTransform(deviceFromLocalTransform_), mask);
     }
     if (usedPatternFill) {
       patternFillPaint_.reset();
@@ -1255,11 +1255,11 @@ void RendererTinySkia::drawRect(const Box2d& rect, const StrokeParams& stroke) {
 
     auto pixmapView = currentPixmapView();
     tiny_skia::Painter::strokePath(pixmapView, path, *strokePaint, tinyStroke,
-                                   toTinyTransform(currentTransform_), mask);
+                                   toTinyTransform(deviceFromLocalTransform_), mask);
     if (strokePaintPixmap != nullptr) {
       auto strokePaintView = strokePaintPixmap->mutableView();
       tiny_skia::Painter::strokePath(strokePaintView, path, *strokePaint, tinyStroke,
-                                     toTinyTransform(currentTransform_), mask);
+                                     toTinyTransform(deviceFromLocalTransform_), mask);
     }
     if (usedPatternStroke) {
       patternStrokePaint_.reset();
@@ -1294,11 +1294,11 @@ void RendererTinySkia::drawEllipse(const Box2d& bounds, const StrokeParams& stro
   if (std::optional<tiny_skia::Paint> fillPaint = makeFillPaint(bounds)) {
     auto pixmapView = currentPixmapView();
     tiny_skia::Painter::fillPath(pixmapView, path, *fillPaint, tiny_skia::FillRule::Winding,
-                                 toTinyTransform(currentTransform_), mask);
+                                 toTinyTransform(deviceFromLocalTransform_), mask);
     if (fillPaintPixmap != nullptr) {
       auto fillPaintView = fillPaintPixmap->mutableView();
       tiny_skia::Painter::fillPath(fillPaintView, path, *fillPaint, tiny_skia::FillRule::Winding,
-                                   toTinyTransform(currentTransform_), mask);
+                                   toTinyTransform(deviceFromLocalTransform_), mask);
     }
     if (usedPatternFill) {
       patternFillPaint_.reset();
@@ -1315,11 +1315,11 @@ void RendererTinySkia::drawEllipse(const Box2d& bounds, const StrokeParams& stro
 
     auto pixmapView = currentPixmapView();
     tiny_skia::Painter::strokePath(pixmapView, path, *strokePaint, tinyStroke,
-                                   toTinyTransform(currentTransform_), mask);
+                                   toTinyTransform(deviceFromLocalTransform_), mask);
     if (strokePaintPixmap != nullptr) {
       auto strokePaintView = strokePaintPixmap->mutableView();
       tiny_skia::Painter::strokePath(strokePaintView, path, *strokePaint, tinyStroke,
-                                     toTinyTransform(currentTransform_), mask);
+                                     toTinyTransform(deviceFromLocalTransform_), mask);
     }
     if (usedPatternStroke) {
       patternStrokePaint_.reset();
@@ -1349,7 +1349,7 @@ void RendererTinySkia::drawImage(const ImageResource& image, const ImageParams& 
   const double scaleY = params.targetRect.height() / static_cast<double>(image.height);
   const Transform2d imageFromLocal = Transform2d::Scale(scaleX, scaleY) *
                                     Transform2d::Translate(params.targetRect.topLeft) *
-                                    currentTransform_;
+                                    deviceFromLocalTransform_;
 
   tiny_skia::PixmapPaint paint;
   paint.opacity = NarrowToFloat(params.opacity * paintOpacity_);
@@ -1611,12 +1611,12 @@ void RendererTinySkia::drawText(Registry& registry, const components::ComputedTe
           const double targetH =
               static_cast<double>(bitmap->height) * bitmap->scale * glyph.stretchScaleY;
 
-          // Use the same transform pattern as drawImage: Scale * Translate * currentTransform_.
+          // Use the same transform pattern as drawImage: Scale * Translate * deviceFromLocalTransform_.
           const double imgScaleX = targetW / static_cast<double>(bitmap->width);
           const double imgScaleY = targetH / static_cast<double>(bitmap->height);
           const Transform2d imageFromLocal = Transform2d::Scale(imgScaleX, imgScaleY) *
                                             Transform2d::Translate(Vector2d(targetX, targetY)) *
-                                            currentTransform_;
+                                            deviceFromLocalTransform_;
 
           tiny_skia::PixmapPaint paint;
           paint.opacity = NarrowToFloat(paintOpacity_);
@@ -1653,13 +1653,13 @@ void RendererTinySkia::drawText(Registry& registry, const components::ComputedTe
       if (spanFillPaint) {
         tiny_skia::Painter::fillPath(pixmapView, tinyPath, *spanFillPaint,
                                      tiny_skia::FillRule::Winding,
-                                     toTinyTransform(currentTransform_), mask);
+                                     toTinyTransform(deviceFromLocalTransform_), mask);
       }
 
       // Stroke.
       if (spanStrokePaint) {
         tiny_skia::Painter::strokePath(pixmapView, tinyPath, *spanStrokePaint, spanTinyStroke,
-                                       toTinyTransform(currentTransform_), mask);
+                                       toTinyTransform(deviceFromLocalTransform_), mask);
       }
     }
 
@@ -1790,13 +1790,13 @@ void RendererTinySkia::drawText(Registry& registry, const components::ComputedTe
           if (decoFillPaint) {
             tiny_skia::Painter::fillPath(pixmapView, tinyPath, *decoFillPaint,
                                          tiny_skia::FillRule::Winding,
-                                         toTinyTransform(currentTransform_), mask);
+                                         toTinyTransform(deviceFromLocalTransform_), mask);
           }
           if (decoStrokePaint && span.decorationStrokeWidth > 0.0) {
             tiny_skia::Stroke stroke;
             stroke.width = NarrowToFloat(span.decorationStrokeWidth);
             tiny_skia::Painter::strokePath(pixmapView, tinyPath, *decoStrokePaint, stroke,
-                                           toTinyTransform(currentTransform_), mask);
+                                           toTinyTransform(deviceFromLocalTransform_), mask);
           }
         };
 
@@ -2004,7 +2004,7 @@ std::optional<tiny_skia::Mask> RendererTinySkia::buildClipMask(const ResolvedCli
       std::cout << "none";
     }
     std::cout << " clipPaths=" << clip.clipPaths.size()
-              << "\n  currentTransform=" << currentTransform_
+              << "\n  currentTransform=" << deviceFromLocalTransform_
               << "  clipPathUnitsTransform=" << clip.clipPathUnitsTransform;
   }
 
@@ -2021,7 +2021,7 @@ std::optional<tiny_skia::Mask> RendererTinySkia::buildClipMask(const ResolvedCli
   if (clip.clipRect.has_value()) {
     rectMask = createMask();
     if (rectMask.has_value()) {
-      drawRectIntoMask(*rectMask, *clip.clipRect, currentTransform_, antialias_);
+      drawRectIntoMask(*rectMask, *clip.clipRect, deviceFromLocalTransform_, antialias_);
     }
   }
 
@@ -2040,7 +2040,7 @@ std::optional<tiny_skia::Mask> RendererTinySkia::buildClipMask(const ResolvedCli
     }
 
     const Transform2d clipPathTransform =
-        clip.clipPathUnitsTransform * shape.parentFromEntity * currentTransform_;
+        clip.clipPathUnitsTransform * shape.parentFromEntity * deviceFromLocalTransform_;
     if (verbose_) {
       const Box2d pathBounds = shape.path.bounds();
       std::cout << "\n  shape layer=" << shape.layer << " bounds=" << pathBounds

--- a/donner/svg/renderer/RendererTinySkia.h
+++ b/donner/svg/renderer/RendererTinySkia.h
@@ -270,8 +270,8 @@ private:
   double paintOpacity_ = 1.0;
 
   tiny_skia::Pixmap frame_;
-  Transform2d currentTransform_;
-  std::vector<Transform2d> transformStack_;
+  Transform2d deviceFromLocalTransform_;
+  std::vector<Transform2d> deviceFromLocalTransformStack_;
   std::optional<tiny_skia::Mask> currentClipMask_;
   std::vector<std::optional<tiny_skia::Mask>> clipStack_;
   std::vector<SurfaceFrame> surfaceStack_;

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -209,6 +209,11 @@ struct GeoEncoder::Impl {
   Arena bandArena;
   Arena curveArena;
   Arena uniformArena;
+  /// M6-B step 3: per-instance affine transforms for `fillPathInstanced`.
+  /// Packed as two vec4f rows per instance (32 bytes), matching the WGSL
+  /// `InstanceTransform` struct. Alignment uses `kStorageOffsetAlignment`
+  /// since the binding is storage read-only.
+  Arena instanceTransformArena;
 
   // When true, this encoder owns its `commandEncoder` and `finish()`
   // calls `commandEncoder.finish()` + `queue().submit()`. When false
@@ -568,6 +573,8 @@ void GeoEncoder::finalizeImpl(GeoEncoder::Impl& impl) {
   impl.curveArena.label = "GeodeCurveArena";
   impl.uniformArena.usage = wgpu::BufferUsage::Uniform | wgpu::BufferUsage::CopyDst;
   impl.uniformArena.label = "GeodeUniformArena";
+  impl.instanceTransformArena.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
+  impl.instanceTransformArena.label = "GeodeInstanceTransformArena";
 }
 
 GeoEncoder::GeoEncoder(GeodeDevice& device, const GeodePipeline& fillPipeline,
@@ -951,6 +958,53 @@ void GeoEncoder::fillPath(const Path& path, const css::RGBA& color, FillRule rul
   args.patternSampler = impl_->device->dummyPatternSampler();
   args.tileSize = Vector2d(1.0, 1.0);
   args.patternFromPath = Transform2d();
+
+  submitFillDraw(args);
+}
+
+void GeoEncoder::fillPathInstanced(const EncodedPath& encoded, const css::RGBA& color, FillRule rule,
+                                   std::span<const float> instanceTransforms) {
+  if (encoded.empty() || instanceTransforms.empty()) {
+    return;
+  }
+  // Caller packs 8 floats per instance — two vec4f rows of a row-major
+  // affine. Malformed inputs drop silently rather than tripping a
+  // validation error mid-frame.
+  const size_t totalFloats = instanceTransforms.size();
+  const uint32_t instanceCount = static_cast<uint32_t>(totalFloats / 8u);
+  if (instanceCount == 0u || totalFloats != static_cast<size_t>(instanceCount) * 8u) {
+    return;
+  }
+
+  // Upload packed transforms into the dedicated instance arena.
+  const uint64_t itSize = roundUp4(totalFloats * sizeof(float));
+  const auto itAlloc =
+      impl_->allocInArena(impl_->instanceTransformArena, instanceTransforms.data(), itSize,
+                          kStorageOffsetAlignment);
+
+  FillDrawArgs args = {};
+  // `args.path` stays null — with a precomputed encode the submit path
+  // never re-encodes, so the raw Path isn't needed. Gradient/pattern
+  // variants aren't batchable in this PR; pure solid only.
+  args.path = nullptr;
+  args.rule = rule;
+  args.precomputedEncoded = &encoded;
+  args.paintMode = 0u;
+  const float alpha = color.a / 255.0f;
+  args.solidColor[0] = (color.r / 255.0f) * alpha;
+  args.solidColor[1] = (color.g / 255.0f) * alpha;
+  args.solidColor[2] = (color.b / 255.0f) * alpha;
+  args.solidColor[3] = alpha;
+  args.patternOpacity = 1.0f;
+  args.patternView = impl_->device->dummyPatternTextureView();
+  args.patternSampler = impl_->device->dummyPatternSampler();
+  args.tileSize = Vector2d(1.0, 1.0);
+  args.patternFromPath = Transform2d();
+
+  args.instanceTransformsBuffer = itAlloc.buffer;
+  args.instanceTransformsOffset = itAlloc.offset;
+  args.instanceTransformsSize = itAlloc.size;
+  args.instanceCount = instanceCount;
 
   submitFillDraw(args);
 }

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -962,8 +962,8 @@ void GeoEncoder::fillPath(const Path& path, const css::RGBA& color, FillRule rul
   submitFillDraw(args);
 }
 
-void GeoEncoder::fillPathInstanced(const EncodedPath& encoded, const css::RGBA& color, FillRule rule,
-                                   std::span<const float> instanceTransforms) {
+void GeoEncoder::fillPathInstanced(const EncodedPath& encoded, const css::RGBA& color,
+                                   FillRule rule, std::span<const float> instanceTransforms) {
   if (encoded.empty() || instanceTransforms.empty()) {
     return;
   }
@@ -978,9 +978,8 @@ void GeoEncoder::fillPathInstanced(const EncodedPath& encoded, const css::RGBA& 
 
   // Upload packed transforms into the dedicated instance arena.
   const uint64_t itSize = roundUp4(totalFloats * sizeof(float));
-  const auto itAlloc =
-      impl_->allocInArena(impl_->instanceTransformArena, instanceTransforms.data(), itSize,
-                          kStorageOffsetAlignment);
+  const auto itAlloc = impl_->allocInArena(impl_->instanceTransformArena, instanceTransforms.data(),
+                                           itSize, kStorageOffsetAlignment);
 
   FillDrawArgs args = {};
   // `args.path` stays null — with a precomputed encode the submit path

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -450,6 +450,7 @@ struct GeoEncoder::Impl {
   void bindSolidPipeline() {
     if (currentPipeline != BoundPipeline::kSolid) {
       pass.setPipeline(pipeline->pipeline());
+      device->countPipelineSwitch();
       currentPipeline = BoundPipeline::kSolid;
       currentPipelineIsGradient = false;
     }
@@ -457,6 +458,7 @@ struct GeoEncoder::Impl {
   void bindGradientPipeline() {
     if (currentPipeline != BoundPipeline::kGradient) {
       pass.setPipeline(gradientPipeline->pipeline());
+      device->countPipelineSwitch();
       currentPipeline = BoundPipeline::kGradient;
       currentPipelineIsGradient = true;
     }
@@ -464,6 +466,7 @@ struct GeoEncoder::Impl {
   void bindImagePipeline(const wgpu::RenderPipeline& imageRenderPipeline) {
     if (currentPipeline != BoundPipeline::kImage) {
       pass.setPipeline(imageRenderPipeline);
+      device->countPipelineSwitch();
       currentPipeline = BoundPipeline::kImage;
       currentPipelineIsGradient = false;
     }
@@ -755,6 +758,7 @@ void GeoEncoder::beginMaskPass(const wgpu::Texture& msaaMask, const wgpu::Textur
   desc.label = wgpuLabel("GeoEncoderMaskPass");
   impl_->maskPass = impl_->commandEncoder.beginRenderPass(desc);
   impl_->maskPass.setPipeline(impl_->maskPipelineOwned->pipeline());
+  impl_->device->countPipelineSwitch();
   // Full-target scissor so clip-path fills aren't clipped by any
   // outer scissor still cached in the encoder state.
   impl_->maskPass.setScissorRect(0, 0, impl_->targetWidth, impl_->targetHeight);
@@ -850,6 +854,7 @@ void GeoEncoder::fillPathIntoMask(const Path& path, FillRule rule,
   impl_->maskPass.setVertexBuffer(0, *vbAlloc.buffer, vbAlloc.offset, vbAlloc.size);
   impl_->maskPass.setBindGroup(0, bindGroup, 0, nullptr);
   impl_->maskPass.draw(static_cast<uint32_t>(encoded.vertices.size()), 1, 0, 0);
+  impl_->device->countDraw();
 }
 
 void GeoEncoder::endMaskPass() {
@@ -1081,6 +1086,7 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args) {
   impl_->pass.setVertexBuffer(0, *vbAlloc.buffer, vbAlloc.offset, vbAlloc.size);
   impl_->pass.setBindGroup(0, bindGroup, 0, nullptr);
   impl_->pass.draw(static_cast<uint32_t>(encoded.vertices.size()), 1, 0, 0);
+  impl_->device->countDraw();
 }
 
 namespace {
@@ -1227,6 +1233,7 @@ void GeoEncoder::fillPathLinearGradient(const Path& path, const LinearGradientPa
   impl_->pass.setVertexBuffer(0, *vbAlloc.buffer, vbAlloc.offset, vbAlloc.size);
   impl_->pass.setBindGroup(0, bindGroup, 0, nullptr);
   impl_->pass.draw(static_cast<uint32_t>(encoded.vertices.size()), 1, 0, 0);
+  impl_->device->countDraw();
 }
 
 void GeoEncoder::fillPathRadialGradient(const Path& path, const RadialGradientParams& params,
@@ -1323,6 +1330,7 @@ void GeoEncoder::fillPathRadialGradient(const Path& path, const RadialGradientPa
   impl_->pass.setVertexBuffer(0, *vbAlloc.buffer, vbAlloc.offset, vbAlloc.size);
   impl_->pass.setBindGroup(0, bindGroup, 0, nullptr);
   impl_->pass.draw(static_cast<uint32_t>(encoded.vertices.size()), 1, 0, 0);
+  impl_->device->countDraw();
 }
 
 void GeoEncoder::blitFullTarget(const wgpu::Texture& src, double opacity) {

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -917,6 +917,17 @@ struct GeoEncoder::FillDrawArgs {
   Transform2d patternFromPath;
   Vector2d tileSize;
   float patternOpacity;
+
+  /// M6 Bullet 2: optional per-instance transform buffer. When null,
+  /// `submitFillDraw` binds `GeodeDevice::identityInstanceTransformBuffer`
+  /// (single-instance draws). When set, the caller has uploaded N
+  /// copies of the 2-vec4f `InstanceTransform` struct at
+  /// `instanceTransformsOffset`, and `submitFillDraw` issues a draw
+  /// with `instanceCount == N`.
+  const wgpu::Buffer* instanceTransformsBuffer = nullptr;
+  uint64_t instanceTransformsOffset = 0;
+  uint64_t instanceTransformsSize = 0;
+  uint32_t instanceCount = 1;
 };
 
 void GeoEncoder::fillPath(const Path& path, const css::RGBA& color, FillRule rule,
@@ -1047,12 +1058,14 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args) {
   const auto uniAlloc =
       impl_->allocInArena(impl_->uniformArena, &u, sizeof(Uniforms), kUniformOffsetAlignment);
 
-  // 3. Bind group — seven entries: uniforms, bands SSBO, curves SSBO,
+  // 3. Bind group — eight entries: uniforms, bands SSBO, curves SSBO,
   // pattern texture, pattern sampler, clip-mask texture, clip-mask
-  // sampler. SSBO + uniform entries reference the arena buffers at
-  // per-draw offsets; the draws are unpacked from shared buffers by
-  // the bind group's `offset` + `size` fields.
-  wgpu::BindGroupEntry entries[7] = {};
+  // sampler, and (M6 Bullet 2) per-instance transforms SSBO. SSBO +
+  // uniform entries reference the arena buffers at per-draw offsets;
+  // the instance-transforms entry is either a caller-supplied arena
+  // slice (`fillPathInstanced`) or the device's 1-element identity
+  // buffer (single-instance fills).
+  wgpu::BindGroupEntry entries[8] = {};
   entries[0].binding = 0;
   entries[0].buffer = *uniAlloc.buffer;
   entries[0].offset = uniAlloc.offset;
@@ -1073,11 +1086,24 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args) {
   entries[5].textureView = impl_->currentClipMaskView();
   entries[6].binding = 6;
   entries[6].sampler = impl_->device->dummyClipMaskSampler();
+  entries[7].binding = 7;
+  if (args.instanceTransformsBuffer != nullptr) {
+    entries[7].buffer = *args.instanceTransformsBuffer;
+    entries[7].offset = args.instanceTransformsOffset;
+    entries[7].size = args.instanceTransformsSize;
+  } else {
+    // One-element identity buffer owned by GeodeDevice. Layout is two
+    // vec4f rows = 32 bytes; kept in sync with the WGSL
+    // `InstanceTransform` struct in `shaders/slug_fill.wgsl`.
+    entries[7].buffer = impl_->device->identityInstanceTransformBuffer();
+    entries[7].offset = 0;
+    entries[7].size = 32u;
+  }
 
   wgpu::BindGroupDescriptor bgDesc = {};
   bgDesc.label = wgpuLabel("GeodeBindGroup");
   bgDesc.layout = impl_->pipeline->bindGroupLayout();
-  bgDesc.entryCount = 7;
+  bgDesc.entryCount = 8;
   bgDesc.entries = entries;
   wgpu::BindGroup bindGroup = dev.createBindGroup(bgDesc);
   impl_->device->countBindGroup();
@@ -1085,7 +1111,7 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args) {
   // 4. Record the draw call.
   impl_->pass.setVertexBuffer(0, *vbAlloc.buffer, vbAlloc.offset, vbAlloc.size);
   impl_->pass.setBindGroup(0, bindGroup, 0, nullptr);
-  impl_->pass.draw(static_cast<uint32_t>(encoded.vertices.size()), 1, 0, 0);
+  impl_->pass.draw(static_cast<uint32_t>(encoded.vertices.size()), args.instanceCount, 0, 0);
   impl_->device->countDraw();
 }
 

--- a/donner/svg/renderer/geode/GeoEncoder.h
+++ b/donner/svg/renderer/geode/GeoEncoder.h
@@ -393,6 +393,41 @@ public:
                 const EncodedPath* precomputedEncoded = nullptr);
 
   /**
+   * Fill N copies of the same encoded path at N different affine
+   * transforms, in one GPU draw call (Milestone 6 Bullet 2).
+   *
+   * The caller has already packed each transform into the wire format
+   * the shader expects: two `vec4f` rows per instance (row-major affine,
+   * 32 bytes per entry). See `donner/svg/renderer/geode/shaders/slug_fill.wgsl`
+   * `struct InstanceTransform` for the exact layout.
+   *
+   * The vertex shader composes each instance's transform with the
+   * currently-bound `uniforms.mvp`, so `encoder.setTransform(...)`
+   * still applies an outer world transform; per-instance data is the
+   * *delta* relative to that. Pass `Transform2d::Identity` to
+   * `setTransform` if instance transforms already encode the full
+   * path→clip-space mapping (the common case for `<use>` batching,
+   * where each instance's transform is the full `worldFromEntity`).
+   *
+   * If `instanceTransforms` is empty the call is a no-op. If
+   * `instanceTransforms.size() == 1` this is equivalent to a single
+   * `fillPath` with the given transform folded in — the caller can
+   * still prefer it when bouncing through the batcher.
+   *
+   * @param encoded Precomputed `EncodedPath` shared across all
+   *   instances. Required (non-null) — there's no "encode inline"
+   *   path here; the whole point is to amortize one encode across
+   *   many draws.
+   * @param color Solid fill color (NOT premultiplied).
+   * @param rule Fill rule.
+   * @param instanceTransforms Span of `{row0, row1}` vec4f pairs,
+   *   two consecutive `vec4f` per instance (32 bytes each). The span
+   *   must contain exactly `8 * instanceCount` floats.
+   */
+  void fillPathInstanced(const EncodedPath& encoded, const css::RGBA& color, FillRule rule,
+                         std::span<const float> instanceTransforms);
+
+  /**
    * Fill a path with a linear gradient.
    *
    * Same CPU-side Slug band encoding as @ref fillPath, but the shading stage

--- a/donner/svg/renderer/geode/GeodeCounters.h
+++ b/donner/svg/renderer/geode/GeodeCounters.h
@@ -66,6 +66,18 @@ struct GeodeCounters {
   /// style many-solid-fill input).
   uint64_t pipelineSwitches = 0;
 
+  /// Number of consecutive `drawPath` calls whose source entity
+  /// matches the immediately previous call's source entity — i.e.
+  /// the draw-call savings that would be unlocked by M6 Bullet 2
+  /// (`<use>` instancing). A run of N consecutive same-source draws
+  /// contributes `N - 1` here.
+  ///
+  /// Zero on fixtures without `<use>` (Lion, Tiger). Non-zero on
+  /// fixtures where `<use>` elements reference the same source in
+  /// adjacent draw order, which is what the future instancing pass
+  /// will collapse into one GPU draw call per group.
+  uint64_t sameSourceDrawPairs = 0;
+
   /// Reset all counters to zero. Called at `RendererGeode::beginFrame`.
   void reset() { *this = {}; }
 };

--- a/donner/svg/renderer/geode/GeodeCounters.h
+++ b/donner/svg/renderer/geode/GeodeCounters.h
@@ -50,6 +50,22 @@ struct GeodeCounters {
   /// frame (the `GeodePathCacheComponent` serves all paths).
   uint64_t pathEncodes = 0;
 
+  /// `wgpu::RenderPassEncoder::draw` / `drawIndexed` calls. One per
+  /// submitted draw call, regardless of instance count. Used to gate
+  /// Milestone 6: same-source-entity `<use>` draws collapse to a
+  /// single instanced call, so heavy `<use>` fixtures should drop
+  /// proportionally.
+  uint64_t drawCalls = 0;
+
+  /// `wgpu::RenderPassEncoder::setPipeline` calls that actually
+  /// switched the bound pipeline (the GeoEncoder state tracker
+  /// deduplicates no-op binds). Gates M6's "sort / collapse
+  /// contiguous same-pipeline draws" bullet: on a pure-solid fixture
+  /// the steady-state value should converge toward the number of
+  /// distinct pipelines the frame touches (typically 1 for Lion-
+  /// style many-solid-fill input).
+  uint64_t pipelineSwitches = 0;
+
   /// Reset all counters to zero. Called at `RendererGeode::beginFrame`.
   void reset() { *this = {}; }
 };

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -46,6 +46,13 @@ struct GeodeDevice::Impl {
   wgpu::Texture dummyClipMaskTexture;
   wgpu::TextureView dummyClipMaskTextureView;
   wgpu::Sampler dummyClipMaskSampler;
+
+  // M6 Bullet 2: 1-element instance-transform buffer bound by every
+  // non-instanced solid fill. Uploaded once at CreateHeadless time,
+  // never modified. Layout matches the WGSL `InstanceTransform`
+  // struct: two vec4f rows carrying the identity affine
+  // `{(1,0,0,0), (0,1,0,0)}`.
+  wgpu::Buffer identityInstanceTransformBuffer;
 };
 
 GeodeDevice::GeodeDevice() : impl_(std::make_unique<Impl>()) {}
@@ -243,6 +250,22 @@ std::unique_ptr<GeodeDevice> GeodeDevice::CreateHeadless() {
     result->impl_->dummyClipMaskSampler = result->device_.createSampler(msd);
   }
 
+  // M6 Bullet 2: identity instance-transform buffer for non-instanced
+  // solid fills. Two vec4f rows = 32 bytes, uploaded once.
+  {
+    const float identity[8] = {
+        1.0f, 0.0f, 0.0f, 0.0f,  // row0 = (a, c, e, _pad) = identity X
+        0.0f, 1.0f, 0.0f, 0.0f,  // row1 = (b, d, f, _pad) = identity Y
+    };
+    wgpu::BufferDescriptor bd = {};
+    bd.label = wgpu::StringView{std::string_view{"GeodeDeviceIdentityInstanceTransform"}};
+    bd.size = sizeof(identity);
+    bd.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
+    result->impl_->identityInstanceTransformBuffer = result->device_.createBuffer(bd);
+    result->queue_.writeBuffer(result->impl_->identityInstanceTransformBuffer, 0, identity,
+                               sizeof(identity));
+  }
+
   return result;
 }
 
@@ -263,6 +286,9 @@ const wgpu::TextureView& GeodeDevice::dummyClipMaskTextureView() const {
 }
 const wgpu::Sampler& GeodeDevice::dummyClipMaskSampler() const {
   return impl_->dummyClipMaskSampler;
+}
+const wgpu::Buffer& GeodeDevice::identityInstanceTransformBuffer() const {
+  return impl_->identityInstanceTransformBuffer;
 }
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -109,6 +109,12 @@ public:
   void countPathEncode() const {
     if (counters_) ++counters_->pathEncodes;
   }
+  void countDraw() const {
+    if (counters_) ++counters_->drawCalls;
+  }
+  void countPipelineSwitch() const {
+    if (counters_) ++counters_->pipelineSwitches;
+  }
 
   /**
    * Whether the driver supports GPU timestamp queries. Always false

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -152,6 +152,18 @@ public:
   const wgpu::TextureView& dummyClipMaskTextureView() const;
   /// Linear-ClampToEdge sampler used for both the dummy and real clip masks.
   const wgpu::Sampler& dummyClipMaskSampler() const;
+
+  /// One-element instance-transform storage buffer carrying the identity
+  /// affine. Bound at binding 7 of the Slug fill bind-group layout by
+  /// every non-instanced solid fill so the bind-group layout stays
+  /// stable across draw calls regardless of whether `fillPathInstanced`
+  /// is in play. See design doc 0030 §M6 Bullet 2.
+  ///
+  /// Layout mirrors the WGSL `InstanceTransform` struct in
+  /// `shaders/slug_fill.wgsl`: two `vec4f` per entry, row-major affine,
+  /// so the identity is `{(1, 0, 0, 0), (0, 1, 0, 0)}`. The `.z`
+  /// components carry the translation (0 for identity).
+  const wgpu::Buffer& identityInstanceTransformBuffer() const;
   /// @}
 
 private:

--- a/donner/svg/renderer/geode/GeodePipeline.cc
+++ b/donner/svg/renderer/geode/GeodePipeline.cc
@@ -9,13 +9,18 @@ GeodePipeline::GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat col
                              bool useAlphaCoverageShader, uint32_t sampleCount)
     : colorFormat_(colorFormat) {
   // ----- Bind group layout -----
-  // Seven bindings: uniforms, bands SSBO, curves SSBO, pattern texture,
-  // pattern sampler, clip-mask texture, clip-mask sampler. The pattern
+  // Eight bindings: uniforms, bands SSBO, curves SSBO, pattern texture,
+  // pattern sampler, clip-mask texture, clip-mask sampler, and
+  // (Milestone 6 Bullet 2) per-instance transforms SSBO. The pattern
   // texture/sampler are only sampled when paintMode == "pattern" and
   // the clip-mask texture/sampler only when `hasClipMask != 0`. A 1x1
   // dummy texture is bound for both when the feature is inactive so
-  // the bind group layout is stable across draw calls.
-  wgpu::BindGroupLayoutEntry entries[7] = {};
+  // the bind group layout is stable across draw calls. The
+  // instance-transforms buffer is always bound too — a 1-element
+  // identity buffer (`GeodeDevice::identityInstanceTransformBuffer`)
+  // for single-draw fills, a full per-instance array for
+  // `fillPathInstanced`.
+  wgpu::BindGroupLayoutEntry entries[8] = {};
 
   entries[0].binding = 0;
   entries[0].visibility = wgpu::ShaderStage::Vertex | wgpu::ShaderStage::Fragment;
@@ -53,9 +58,15 @@ GeodePipeline::GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat col
   entries[6].visibility = wgpu::ShaderStage::Fragment;
   entries[6].sampler.type = wgpu::SamplerBindingType::Filtering;
 
+  // M6 Bullet 2: per-instance affine transforms (vertex-visible only).
+  entries[7].binding = 7;
+  entries[7].visibility = wgpu::ShaderStage::Vertex;
+  entries[7].buffer.type = wgpu::BufferBindingType::ReadOnlyStorage;
+  entries[7].buffer.minBindingSize = 0;
+
   wgpu::BindGroupLayoutDescriptor bglDesc = {};
   bglDesc.label = wgpuLabel("GeodeSlugFillBGL");
-  bglDesc.entryCount = 7;
+  bglDesc.entryCount = 8;
   bglDesc.entries = entries;
   bindGroupLayout_ = device.createBindGroupLayout(bglDesc);
 
@@ -68,9 +79,8 @@ GeodePipeline::GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat col
   wgpu::PipelineLayout pipelineLayout = device.createPipelineLayout(plDesc);
 
   // ----- Shader module -----
-  wgpu::ShaderModule shader =
-      useAlphaCoverageShader ? createSlugFillAlphaCoverageShader(device)
-                             : createSlugFillShader(device);
+  wgpu::ShaderModule shader = useAlphaCoverageShader ? createSlugFillAlphaCoverageShader(device)
+                                                     : createSlugFillShader(device);
 
   // ----- Vertex buffer layout -----
   // Matches EncodedPath::Vertex: pos (vec2f) + normal (vec2f) + bandIndex (u32)
@@ -144,8 +154,7 @@ GeodePipeline::GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat col
 
 GeodeGradientPipeline::GeodeGradientPipeline(const wgpu::Device& device,
                                              wgpu::TextureFormat colorFormat,
-                                             bool useAlphaCoverageShader,
-                                             uint32_t sampleCount)
+                                             bool useAlphaCoverageShader, uint32_t sampleCount)
     : colorFormat_(colorFormat) {
   // Five bindings — uniforms, bands SSBO, curves SSBO, clip-mask texture,
   // clip-mask sampler. The clip-mask bindings always carry something
@@ -192,9 +201,8 @@ GeodeGradientPipeline::GeodeGradientPipeline(const wgpu::Device& device,
   plDesc.bindGroupLayouts = layouts;
   wgpu::PipelineLayout pipelineLayout = device.createPipelineLayout(plDesc);
 
-  wgpu::ShaderModule shader =
-      useAlphaCoverageShader ? createSlugGradientAlphaCoverageShader(device)
-                             : createSlugGradientShader(device);
+  wgpu::ShaderModule shader = useAlphaCoverageShader ? createSlugGradientAlphaCoverageShader(device)
+                                                     : createSlugGradientShader(device);
 
   // Same vertex buffer layout as the solid-fill pipeline.
   wgpu::VertexAttribute vertexAttribs[3] = {};
@@ -305,9 +313,8 @@ GeodeMaskPipeline::GeodeMaskPipeline(const wgpu::Device& device, bool useAlphaCo
   plDesc.bindGroupLayouts = layouts;
   wgpu::PipelineLayout pipelineLayout = device.createPipelineLayout(plDesc);
 
-  wgpu::ShaderModule shader =
-      useAlphaCoverageShader ? createSlugMaskAlphaCoverageShader(device)
-                             : createSlugMaskShader(device);
+  wgpu::ShaderModule shader = useAlphaCoverageShader ? createSlugMaskAlphaCoverageShader(device)
+                                                     : createSlugMaskShader(device);
 
   // Same vertex buffer layout as the fill pipelines: pos (vec2f) +
   // normal (vec2f) + bandIndex (u32) = 20 bytes per vertex.

--- a/donner/svg/renderer/geode/GeodeTextureEncoder.cc
+++ b/donner/svg/renderer/geode/GeodeTextureEncoder.cc
@@ -178,14 +178,12 @@ void GeodeTextureEncoder::drawTexturedQuad(GeodeDevice& device, const GeodeImage
   wgpu::BindGroup bindGroup = dev.createBindGroup(bgDesc);
   device.countBindGroup();
 
-  // Switch to the image pipeline and record the draw call.
-  // The caller is expected to restore the Slug-fill pipeline if it needs
-  // to, but since `fillPath` sets the pipeline at the top of the pass via
-  // `ensurePassOpen`, switching mid-pass requires `SetPipeline` before the
-  // next fill call. `GeoEncoder` handles that by always calling
-  // `SetPipeline` at the start of each draw helper.
+  // The caller is expected to have invoked `GeoEncoder::bindImagePipeline`
+  // already, which is the sole place the image pipeline is bound + counted.
+  // Set the pipeline here too as a defensive no-op (Dawn collapses the
+  // rebind on GPU); skip counting so `pipelineSwitches` reflects actual
+  // pipeline transitions.
   pass.setPipeline(pipeline.pipeline());
-  device.countPipelineSwitch();
   pass.setBindGroup(0, bindGroup, 0, nullptr);
   pass.draw(6, 1, 0, 0);
   device.countDraw();

--- a/donner/svg/renderer/geode/GeodeTextureEncoder.cc
+++ b/donner/svg/renderer/geode/GeodeTextureEncoder.cc
@@ -185,8 +185,10 @@ void GeodeTextureEncoder::drawTexturedQuad(GeodeDevice& device, const GeodeImage
   // next fill call. `GeoEncoder` handles that by always calling
   // `SetPipeline` at the start of each draw helper.
   pass.setPipeline(pipeline.pipeline());
+  device.countPipelineSwitch();
   pass.setBindGroup(0, bindGroup, 0, nullptr);
   pass.draw(6, 1, 0, 0);
+  device.countDraw();
 }
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/shaders/slug_fill.wgsl
+++ b/donner/svg/renderer/geode/shaders/slug_fill.wgsl
@@ -24,42 +24,46 @@
 struct Uniforms {
   // Model-view-projection matrix. 4x4 to support future 3D / perspective;
   // 2D content uses an orthographic matrix that's effectively 2x2 + translate.
-  mvp: mat4x4f,
-  // Pattern sampling transform: maps path-space sample positions to
-  // pattern-tile-space. Only used when paintMode == 1 (pattern fill). Stored
-  // as mat4x4 for alignment simplicity; only the upper-left 2x3 affine is
-  // meaningful for 2D content.
-  patternFromPath: mat4x4f,
-  // Viewport dimensions in pixels.
-  viewport: vec2f,
-  // Pattern tile size in pattern-tile space (width, height). Ignored when
-  // paintMode == 0.
-  tileSize: vec2f,
-  // Fill color (premultiplied alpha). Only used when paintMode == 0.
-  color: vec4f,
-  // Fill rule: 0 = non-zero, 1 = even-odd.
-  fillRule: u32,
-  // Paint mode: 0 = solid color, 1 = pattern texture (repeat-tiled).
-  paintMode: u32,
-  // Pattern alpha multiplier (e.g., fill-opacity). 1.0 for solid paint.
-  patternOpacity: f32,
-  // Nonzero when a convex 4-vertex clip polygon is active. When 0, the
-  // `clipPolygonPlanes` field is ignored.
-  hasClipPolygon: u32,
-  // Nonzero when a path-clip mask texture is bound at binding 5 and
-  // should be sampled for per-pixel clip coverage. When 0, the mask
-  // binding still holds a 1x1 dummy texture (value 1.0) so the shader
-  // can unconditionally sample without tripping WebGPU validation.
-  hasClipMask: u32,
-  _pad0: u32,
-  _pad1: u32,
-  // Four inward-facing half-planes in viewport-pixel space, one per polygon
-  // edge. `plane.xyz = (nx, ny, c)` with `nx*x + ny*y + c >= 0` inside. The
-  // `w` component is padding for std140-style alignment.
-  clipPolygonPlanes: array<vec4f, 4>,
+  mvp : mat4x4f,
+        // Pattern sampling transform: maps path-space sample positions to
+        // pattern-tile-space. Only used when paintMode == 1 (pattern fill). Stored
+        // as mat4x4 for alignment simplicity; only the upper-left 2x3 affine is
+        // meaningful for 2D content.
+        patternFromPath : mat4x4f,
+                          // Viewport dimensions in pixels.
+                          viewport : vec2f,
+                                     // Pattern tile size in pattern-tile space (width, height).
+                                     // Ignored when paintMode == 0.
+                                     tileSize
+      : vec2f,
+        // Fill color (premultiplied alpha). Only used when paintMode == 0.
+        color : vec4f,
+                // Fill rule: 0 = non-zero, 1 = even-odd.
+                fillRule : u32,
+                           // Paint mode: 0 = solid color, 1 = pattern texture (repeat-tiled).
+                           paintMode
+      : u32,
+        // Pattern alpha multiplier (e.g., fill-opacity). 1.0 for solid paint.
+        patternOpacity : f32,
+                         // Nonzero when a convex 4-vertex clip polygon is active. When 0, the
+                         // `clipPolygonPlanes` field is ignored.
+                         hasClipPolygon
+      : u32,
+        // Nonzero when a path-clip mask texture is bound at binding 5 and
+        // should be sampled for per-pixel clip coverage. When 0, the mask
+        // binding still holds a 1x1 dummy texture (value 1.0) so the shader
+        // can unconditionally sample without tripping WebGPU validation.
+        hasClipMask : u32,
+                      _pad0 : u32,
+                              _pad1
+      : u32,
+        // Four inward-facing half-planes in viewport-pixel space, one per polygon
+        // edge. `plane.xyz = (nx, ny, c)` with `nx*x + ny*y + c >= 0` inside. The
+        // `w` component is padding for std140-style alignment.
+        clipPolygonPlanes : array<vec4f, 4>,
 };
 
-@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(0) var<uniform> uniforms : Uniforms;
 
 // ============================================================================
 // Storage buffers
@@ -68,30 +72,30 @@ struct Uniforms {
 // Per-band metadata. Parallel to the draw instance — the vertex shader reads
 // the band for its instance via gl_InstanceIndex / @builtin(instance_index).
 struct Band {
-  curveStart: u32,
-  curveCount: u32,
-  yMin: f32,
-  yMax: f32,
-  xMin: f32,
-  xMax: f32,
-  _pad0: f32,
-  _pad1: f32,
+  curveStart : u32,
+               curveCount : u32,
+                            yMin : f32,
+                                   yMax : f32,
+                                          xMin : f32,
+                                                 xMax : f32,
+                                                        _pad0 : f32,
+                                                                _pad1 : f32,
 };
 
-@group(0) @binding(1) var<storage, read> bands: array<Band>;
+@group(0) @binding(1) var<storage, read> bands : array<Band>;
 
 // Quadratic Bézier control points: (p0, p1, p2). Stored as packed floats,
 // 6 floats per curve.
 //
 // Using vec2f stride would waste memory due to alignment padding; the
 // flat f32 array packs tighter at the cost of slightly more arithmetic.
-@group(0) @binding(2) var<storage, read> curveData: array<f32>;
+@group(0) @binding(2) var<storage, read> curveData : array<f32>;
 
 // Pattern tile texture + sampler. These bindings exist even when paintMode == 0
 // so the bind group layout is stable across draw calls; in solid-paint mode a
 // 1x1 dummy texture is bound and the shader never samples it.
-@group(0) @binding(3) var patternTexture: texture_2d<f32>;
-@group(0) @binding(4) var patternSampler: sampler;
+@group(0) @binding(3) var patternTexture : texture_2d<f32>;
+@group(0) @binding(4) var patternSampler : sampler;
 
 // Path-clip mask texture (Phase 3b). R8Unorm, 1-sample (resolved from a
 // 4× MSAA render target before this draw). Always bound — when
@@ -100,8 +104,26 @@ struct Band {
 // center without needing branchless paths or bind group layout
 // variants. The sampler uses linear filtering so the clip edge
 // interpolates smoothly across pixels.
-@group(0) @binding(5) var clipMaskTexture: texture_2d<f32>;
-@group(0) @binding(6) var clipMaskSampler: sampler;
+@group(0) @binding(5) var clipMaskTexture : texture_2d<f32>;
+@group(0) @binding(6) var clipMaskSampler : sampler;
+
+// Per-instance affine transform (Milestone 6 Bullet 2: `<use>` instancing).
+//
+// Each `array` element is a 2×3 affine packed as two vec4f:
+//   row0 = (a, c, e, _pad)  →  x' = a*x + c*y + e
+//   row1 = (b, d, f, _pad)  →  y' = b*x + d*y + f
+//
+// The vertex shader composes this transform into `uniforms.mvp` before
+// applying it to `pos`/`normal`, so a single instanced draw can paint N
+// copies of the same encoded path at N different transforms.
+//
+// For non-instanced draws (instanceCount == 1) a device-owned 1-element
+// buffer with identity transform is bound here so the bind-group layout
+// stays stable across draw calls.
+struct InstanceTransform {
+  row0 : vec4f, row1 : vec4f,
+};
+@group(0) @binding(7) var<storage, read> instanceTransforms : array<InstanceTransform>;
 
 // ============================================================================
 // Vertex stage
@@ -109,39 +131,59 @@ struct Band {
 
 struct VertexInput {
   // Position in path space.
-  @location(0) pos: vec2f,
-  // Outward normal for dilation (quad corner sign, -1 or +1 per axis).
-  @location(1) normal: vec2f,
-  // Band index — which band this vertex belongs to.
-  @location(2) bandIndex: u32,
+  @location(0) pos : vec2f,
+                     // Outward normal for dilation (quad corner sign, -1 or +1 per axis).
+                     @location(1) normal : vec2f,
+                                           // Band index — which band this vertex belongs to.
+                                           @location(2) bandIndex : u32,
 };
 
 struct VertexOutput {
-  @builtin(position) clip_pos: vec4f,
-  // Path-space sample position. Fragment shader casts a ray from here.
-  @location(0) sample_pos: vec2f,
-  // Band index passed through so the fragment shader can look up the band
-  // (WGSL doesn't have per-primitive builtins on all backends).
-  @location(1) @interpolate(flat) bandIndex: u32,
+  @builtin(position) clip_pos
+      : vec4f,
+        // Path-space sample position. Fragment shader casts a ray from here.
+        @location(0) sample_pos
+      : vec2f,
+        // Band index passed through so the fragment shader can look up the band
+        // (WGSL doesn't have per-primitive builtins on all backends).
+        @location(1) @interpolate(flat) bandIndex : u32,
 };
 
-@vertex
-fn vs_main(in: VertexInput) -> VertexOutput {
+@vertex fn vs_main(@builtin(instance_index) instance_index : u32, in : VertexInput)
+    -> VertexOutput {
+  // Compose the per-instance affine transform into the MVP. For
+  // non-instanced draws `instance_index == 0` and the identity
+  // transform bound by the encoder makes this a no-op. For a
+  // `fillPathInstanced` draw each invocation picks up its own
+  // transform, so N copies of the same encoded path land at N
+  // different screen positions with a single draw call.
+  let xf = instanceTransforms[instance_index];
+  // WGSL matrices are column-major: mat4x4f(col0, col1, col2, col3).
+  //   col 0: (a, b, 0, 0)   col 1: (c, d, 0, 0)
+  //   col 2: (0, 0, 1, 0)   col 3: (e, f, 0, 1)
+  let instance_mat =
+      mat4x4f(vec4f(xf.row0.x, xf.row1.x, 0.0, 0.0), vec4f(xf.row0.y, xf.row1.y, 0.0, 0.0),
+              vec4f(0.0, 0.0, 1.0, 0.0), vec4f(xf.row0.z, xf.row1.z, 0.0, 1.0), );
+  let effective_mvp = uniforms.mvp * instance_mat;
+
   // Dynamic half-pixel dilation: expand the quad by exactly half a pixel
   // in viewport space along the outward normal.
   //
   // For the orthographic 2D case the math simplifies significantly from the
   // full quadratic solution — d = 1 / |viewport-space normal projection|.
-  let world_normal = (uniforms.mvp * vec4f(in.normal, 0.0, 0.0)).xy;
+  let world_normal = (effective_mvp * vec4f(in.normal, 0.0, 0.0)).xy;
   let viewport_normal = world_normal * uniforms.viewport * 0.5;
   let viewport_len = length(viewport_normal);
   let d = 1.0 / max(viewport_len, 0.001);
 
   // Dilate in path space so the fragment shader still samples in path space.
+  // (Sample space is the path's own coordinate system — the fragment ray-cast
+  // against `curveData` must stay pre-transform; `effective_mvp` only drives
+  // clip-space positioning.)
   let dilated = in.pos + in.normal * d;
 
-  var out: VertexOutput;
-  out.clip_pos = uniforms.mvp * vec4f(dilated, 0.0, 1.0);
+  var out : VertexOutput;
+  out.clip_pos = effective_mvp * vec4f(dilated, 0.0, 1.0);
   out.sample_pos = dilated;
   out.bandIndex = in.bandIndex;
   return out;
@@ -154,14 +196,12 @@ fn vs_main(in: VertexInput) -> VertexOutput {
 // Unpack a quadratic from the curve buffer. Each curve is 6 floats:
 // [p0x, p0y, p1x, p1y, p2x, p2y].
 struct Quadratic {
-  p0: vec2f,
-  p1: vec2f,
-  p2: vec2f,
+  p0 : vec2f, p1 : vec2f, p2 : vec2f,
 };
 
-fn load_curve(index: u32) -> Quadratic {
+fn load_curve(index : u32) -> Quadratic {
   let base = index * 6u;
-  var q: Quadratic;
+  var q : Quadratic;
   q.p0 = vec2f(curveData[base + 0u], curveData[base + 1u]);
   q.p1 = vec2f(curveData[base + 2u], curveData[base + 3u]);
   q.p2 = vec2f(curveData[base + 4u], curveData[base + 5u]);
@@ -170,7 +210,7 @@ fn load_curve(index: u32) -> Quadratic {
 
 // Solve the quadratic equation at² + bt + c = 0 for roots in (0, 1].
 // Returns two t values; invalid roots are set to -1.
-fn solve_quadratic(a: f32, b: f32, c: f32) -> vec2f {
+fn solve_quadratic(a : f32, b : f32, c : f32) -> vec2f {
   var roots = vec2f(-1.0, -1.0);
 
   // Threshold raised from 1e-6 to 1e-4 to robustly route degenerate
@@ -221,14 +261,14 @@ fn solve_quadratic(a: f32, b: f32, c: f32) -> vec2f {
 // Rearranging: t² (p0y - 2 p1y + p2y) + 2t (p1y - p0y) + (p0y - sample_y) = 0
 // i.e., a t² + b t + c = 0 with a = p0y - 2 p1y + p2y, b = 2(p1y - p0y),
 // c = p0y - sample_y.
-fn curve_winding(curve: Quadratic, sample: vec2f) -> i32 {
+fn curve_winding(curve : Quadratic, sample : vec2f) -> i32 {
   let a = curve.p0.y - 2.0 * curve.p1.y + curve.p2.y;
   let b = 2.0 * (curve.p1.y - curve.p0.y);
   let c = curve.p0.y - sample.y;
 
   let roots = solve_quadratic(a, b, c);
 
-  var winding: i32 = 0;
+  var winding : i32 = 0;
   for (var i = 0; i < 2; i = i + 1) {
     let t = select(roots.y, roots.x, i == 0);
     if (t < 0.0) {
@@ -262,7 +302,7 @@ fn curve_winding(curve: Quadratic, sample: vec2f) -> i32 {
 /// the active convex clip polygon. Returns `true` when no polygon is
 /// active, so callers can unconditionally AND this into their coverage
 /// decision.
-fn sample_in_clip_polygon(pixel_pos: vec2f) -> bool {
+fn sample_in_clip_polygon(pixel_pos : vec2f) -> bool {
   if (uniforms.hasClipPolygon == 0u) {
     return true;
   }
@@ -281,8 +321,8 @@ fn sample_in_clip_polygon(pixel_pos: vec2f) -> bool {
 /// Test whether a single sub-pixel sample position is inside the fill,
 /// per the active fill rule. Shared between `fs_main` sample-mask loop
 /// and any future per-sample helpers.
-fn sample_is_inside(band: Band, sample_pos: vec2f) -> bool {
-  var winding: i32 = 0;
+fn sample_is_inside(band : Band, sample_pos : vec2f) -> bool {
+  var winding : i32 = 0;
   for (var i = 0u; i < band.curveCount; i = i + 1u) {
     let curve = load_curve(band.curveStart + i);
     winding = winding + curve_winding(curve, sample_pos);
@@ -302,12 +342,10 @@ fn sample_is_inside(band: Band, sample_pos: vec2f) -> bool {
 /// 0/4, 1/4, 2/4, 3/4, or 4/4 coverage per pixel, closely matching
 /// tiny-skia's 4× supersampling scan-converter.
 struct FragOutput {
-  @location(0) color: vec4f,
-  @builtin(sample_mask) mask: u32,
+  @location(0) color : vec4f, @builtin(sample_mask) mask : u32,
 };
 
-@fragment
-fn fs_main(in: VertexOutput) -> FragOutput {
+@fragment fn fs_main(in : VertexOutput) -> FragOutput {
   let band = bands[in.bandIndex];
 
   // Framebuffer-pixel center of this fragment. WGSL specifies that
@@ -345,15 +383,11 @@ fn fs_main(in: VertexOutput) -> FragOutput {
   // positions, so any 4 distinct in-pixel offsets give a correct 4×
   // coverage estimate. Use D3D-style rotated positions to avoid
   // axis-aligned Moiré on near-horizontal / near-vertical edges.
-  var offsets = array<vec2f, 4>(
-    vec2f(-0.125, -0.375),
-    vec2f( 0.375, -0.125),
-    vec2f(-0.375,  0.125),
-    vec2f( 0.125,  0.375),
-  );
+  var offsets = array<vec2f, 4>(vec2f(-0.125, -0.375), vec2f(0.375, -0.125), vec2f(-0.375, 0.125),
+                                vec2f(0.125, 0.375), );
 
-  var mask: u32 = 0u;
-  for (var s: u32 = 0u; s < 4u; s = s + 1u) {
+  var mask : u32 = 0u;
+  for (var s : u32 = 0u; s < 4u; s = s + 1u) {
     // Convert the viewport-pixel offset into a path-space delta.
     let sp = in.sample_pos + offsets[s].x * dx + offsets[s].y * dy;
 
@@ -391,17 +425,16 @@ fn fs_main(in: VertexOutput) -> FragOutput {
   // When no mask is active, `hasClipMask == 0` and we skip the work
   // entirely — the dummy texture's 1.0 value would also work but the
   // branch shaves a texture fetch off the hot path.
-  var clipCoverage: f32 = 1.0;
+  var clipCoverage : f32 = 1.0;
   if (uniforms.hasClipMask != 0u) {
     let mask_uv = pixel_center / uniforms.viewport;
-    clipCoverage = clamp(textureSample(clipMaskTexture, clipMaskSampler, mask_uv).r,
-                         0.0, 1.0);
+    clipCoverage = clamp(textureSample(clipMaskTexture, clipMaskSampler, mask_uv).r, 0.0, 1.0);
     if (clipCoverage <= 0.0) {
       discard;
     }
   }
 
-  var out: FragOutput;
+  var out : FragOutput;
   out.mask = mask;
 
   if (uniforms.paintMode == 0u) {
@@ -415,10 +448,8 @@ fn fs_main(in: VertexOutput) -> FragOutput {
   // Pattern mode: sample the tile at the pixel center. The
   // sample_mask still controls edge coverage.
   let patternPos = (uniforms.patternFromPath * vec4f(in.sample_pos, 0.0, 1.0)).xy;
-  let wrapped = vec2f(
-    fract(patternPos.x / uniforms.tileSize.x) * uniforms.tileSize.x,
-    fract(patternPos.y / uniforms.tileSize.y) * uniforms.tileSize.y,
-  );
+  let wrapped = vec2f(fract(patternPos.x / uniforms.tileSize.x) * uniforms.tileSize.x,
+                      fract(patternPos.y / uniforms.tileSize.y) * uniforms.tileSize.y, );
   let uv = wrapped / uniforms.tileSize;
   var sampled = textureSample(patternTexture, patternSampler, uv);
   sampled = sampled * uniforms.patternOpacity * clipCoverage;

--- a/donner/svg/renderer/geode/shaders/slug_fill.wgsl
+++ b/donner/svg/renderer/geode/shaders/slug_fill.wgsl
@@ -24,46 +24,42 @@
 struct Uniforms {
   // Model-view-projection matrix. 4x4 to support future 3D / perspective;
   // 2D content uses an orthographic matrix that's effectively 2x2 + translate.
-  mvp : mat4x4f,
-        // Pattern sampling transform: maps path-space sample positions to
-        // pattern-tile-space. Only used when paintMode == 1 (pattern fill). Stored
-        // as mat4x4 for alignment simplicity; only the upper-left 2x3 affine is
-        // meaningful for 2D content.
-        patternFromPath : mat4x4f,
-                          // Viewport dimensions in pixels.
-                          viewport : vec2f,
-                                     // Pattern tile size in pattern-tile space (width, height).
-                                     // Ignored when paintMode == 0.
-                                     tileSize
-      : vec2f,
-        // Fill color (premultiplied alpha). Only used when paintMode == 0.
-        color : vec4f,
-                // Fill rule: 0 = non-zero, 1 = even-odd.
-                fillRule : u32,
-                           // Paint mode: 0 = solid color, 1 = pattern texture (repeat-tiled).
-                           paintMode
-      : u32,
-        // Pattern alpha multiplier (e.g., fill-opacity). 1.0 for solid paint.
-        patternOpacity : f32,
-                         // Nonzero when a convex 4-vertex clip polygon is active. When 0, the
-                         // `clipPolygonPlanes` field is ignored.
-                         hasClipPolygon
-      : u32,
-        // Nonzero when a path-clip mask texture is bound at binding 5 and
-        // should be sampled for per-pixel clip coverage. When 0, the mask
-        // binding still holds a 1x1 dummy texture (value 1.0) so the shader
-        // can unconditionally sample without tripping WebGPU validation.
-        hasClipMask : u32,
-                      _pad0 : u32,
-                              _pad1
-      : u32,
-        // Four inward-facing half-planes in viewport-pixel space, one per polygon
-        // edge. `plane.xyz = (nx, ny, c)` with `nx*x + ny*y + c >= 0` inside. The
-        // `w` component is padding for std140-style alignment.
-        clipPolygonPlanes : array<vec4f, 4>,
+  mvp: mat4x4f,
+  // Pattern sampling transform: maps path-space sample positions to
+  // pattern-tile-space. Only used when paintMode == 1 (pattern fill). Stored
+  // as mat4x4 for alignment simplicity; only the upper-left 2x3 affine is
+  // meaningful for 2D content.
+  patternFromPath: mat4x4f,
+  // Viewport dimensions in pixels.
+  viewport: vec2f,
+  // Pattern tile size in pattern-tile space (width, height). Ignored when
+  // paintMode == 0.
+  tileSize: vec2f,
+  // Fill color (premultiplied alpha). Only used when paintMode == 0.
+  color: vec4f,
+  // Fill rule: 0 = non-zero, 1 = even-odd.
+  fillRule: u32,
+  // Paint mode: 0 = solid color, 1 = pattern texture (repeat-tiled).
+  paintMode: u32,
+  // Pattern alpha multiplier (e.g., fill-opacity). 1.0 for solid paint.
+  patternOpacity: f32,
+  // Nonzero when a convex 4-vertex clip polygon is active. When 0, the
+  // `clipPolygonPlanes` field is ignored.
+  hasClipPolygon: u32,
+  // Nonzero when a path-clip mask texture is bound at binding 5 and
+  // should be sampled for per-pixel clip coverage. When 0, the mask
+  // binding still holds a 1x1 dummy texture (value 1.0) so the shader
+  // can unconditionally sample without tripping WebGPU validation.
+  hasClipMask: u32,
+  _pad0: u32,
+  _pad1: u32,
+  // Four inward-facing half-planes in viewport-pixel space, one per polygon
+  // edge. `plane.xyz = (nx, ny, c)` with `nx*x + ny*y + c >= 0` inside. The
+  // `w` component is padding for std140-style alignment.
+  clipPolygonPlanes: array<vec4f, 4>,
 };
 
-@group(0) @binding(0) var<uniform> uniforms : Uniforms;
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
 
 // ============================================================================
 // Storage buffers
@@ -72,30 +68,30 @@ struct Uniforms {
 // Per-band metadata. Parallel to the draw instance — the vertex shader reads
 // the band for its instance via gl_InstanceIndex / @builtin(instance_index).
 struct Band {
-  curveStart : u32,
-               curveCount : u32,
-                            yMin : f32,
-                                   yMax : f32,
-                                          xMin : f32,
-                                                 xMax : f32,
-                                                        _pad0 : f32,
-                                                                _pad1 : f32,
+  curveStart: u32,
+  curveCount: u32,
+  yMin: f32,
+  yMax: f32,
+  xMin: f32,
+  xMax: f32,
+  _pad0: f32,
+  _pad1: f32,
 };
 
-@group(0) @binding(1) var<storage, read> bands : array<Band>;
+@group(0) @binding(1) var<storage, read> bands: array<Band>;
 
 // Quadratic Bézier control points: (p0, p1, p2). Stored as packed floats,
 // 6 floats per curve.
 //
 // Using vec2f stride would waste memory due to alignment padding; the
 // flat f32 array packs tighter at the cost of slightly more arithmetic.
-@group(0) @binding(2) var<storage, read> curveData : array<f32>;
+@group(0) @binding(2) var<storage, read> curveData: array<f32>;
 
 // Pattern tile texture + sampler. These bindings exist even when paintMode == 0
 // so the bind group layout is stable across draw calls; in solid-paint mode a
 // 1x1 dummy texture is bound and the shader never samples it.
-@group(0) @binding(3) var patternTexture : texture_2d<f32>;
-@group(0) @binding(4) var patternSampler : sampler;
+@group(0) @binding(3) var patternTexture: texture_2d<f32>;
+@group(0) @binding(4) var patternSampler: sampler;
 
 // Path-clip mask texture (Phase 3b). R8Unorm, 1-sample (resolved from a
 // 4× MSAA render target before this draw). Always bound — when
@@ -104,8 +100,8 @@ struct Band {
 // center without needing branchless paths or bind group layout
 // variants. The sampler uses linear filtering so the clip edge
 // interpolates smoothly across pixels.
-@group(0) @binding(5) var clipMaskTexture : texture_2d<f32>;
-@group(0) @binding(6) var clipMaskSampler : sampler;
+@group(0) @binding(5) var clipMaskTexture: texture_2d<f32>;
+@group(0) @binding(6) var clipMaskSampler: sampler;
 
 // Per-instance affine transform (Milestone 6 Bullet 2: `<use>` instancing).
 //
@@ -121,9 +117,10 @@ struct Band {
 // buffer with identity transform is bound here so the bind-group layout
 // stays stable across draw calls.
 struct InstanceTransform {
-  row0 : vec4f, row1 : vec4f,
+  row0: vec4f,
+  row1: vec4f,
 };
-@group(0) @binding(7) var<storage, read> instanceTransforms : array<InstanceTransform>;
+@group(0) @binding(7) var<storage, read> instanceTransforms: array<InstanceTransform>;
 
 // ============================================================================
 // Vertex stage
@@ -131,26 +128,24 @@ struct InstanceTransform {
 
 struct VertexInput {
   // Position in path space.
-  @location(0) pos : vec2f,
-                     // Outward normal for dilation (quad corner sign, -1 or +1 per axis).
-                     @location(1) normal : vec2f,
-                                           // Band index — which band this vertex belongs to.
-                                           @location(2) bandIndex : u32,
+  @location(0) pos: vec2f,
+  // Outward normal for dilation (quad corner sign, -1 or +1 per axis).
+  @location(1) normal: vec2f,
+  // Band index — which band this vertex belongs to.
+  @location(2) bandIndex: u32,
 };
 
 struct VertexOutput {
-  @builtin(position) clip_pos
-      : vec4f,
-        // Path-space sample position. Fragment shader casts a ray from here.
-        @location(0) sample_pos
-      : vec2f,
-        // Band index passed through so the fragment shader can look up the band
-        // (WGSL doesn't have per-primitive builtins on all backends).
-        @location(1) @interpolate(flat) bandIndex : u32,
+  @builtin(position) clip_pos: vec4f,
+  // Path-space sample position. Fragment shader casts a ray from here.
+  @location(0) sample_pos: vec2f,
+  // Band index passed through so the fragment shader can look up the band
+  // (WGSL doesn't have per-primitive builtins on all backends).
+  @location(1) @interpolate(flat) bandIndex: u32,
 };
 
-@vertex fn vs_main(@builtin(instance_index) instance_index : u32, in : VertexInput)
-    -> VertexOutput {
+@vertex
+fn vs_main(@builtin(instance_index) instance_index: u32, in: VertexInput) -> VertexOutput {
   // Compose the per-instance affine transform into the MVP. For
   // non-instanced draws `instance_index == 0` and the identity
   // transform bound by the encoder makes this a no-op. For a
@@ -161,9 +156,12 @@ struct VertexOutput {
   // WGSL matrices are column-major: mat4x4f(col0, col1, col2, col3).
   //   col 0: (a, b, 0, 0)   col 1: (c, d, 0, 0)
   //   col 2: (0, 0, 1, 0)   col 3: (e, f, 0, 1)
-  let instance_mat =
-      mat4x4f(vec4f(xf.row0.x, xf.row1.x, 0.0, 0.0), vec4f(xf.row0.y, xf.row1.y, 0.0, 0.0),
-              vec4f(0.0, 0.0, 1.0, 0.0), vec4f(xf.row0.z, xf.row1.z, 0.0, 1.0), );
+  let instance_mat = mat4x4f(
+    vec4f(xf.row0.x, xf.row1.x, 0.0, 0.0),
+    vec4f(xf.row0.y, xf.row1.y, 0.0, 0.0),
+    vec4f(0.0,       0.0,       1.0, 0.0),
+    vec4f(xf.row0.z, xf.row1.z, 0.0, 1.0),
+  );
   let effective_mvp = uniforms.mvp * instance_mat;
 
   // Dynamic half-pixel dilation: expand the quad by exactly half a pixel
@@ -182,7 +180,7 @@ struct VertexOutput {
   // clip-space positioning.)
   let dilated = in.pos + in.normal * d;
 
-  var out : VertexOutput;
+  var out: VertexOutput;
   out.clip_pos = effective_mvp * vec4f(dilated, 0.0, 1.0);
   out.sample_pos = dilated;
   out.bandIndex = in.bandIndex;
@@ -196,12 +194,14 @@ struct VertexOutput {
 // Unpack a quadratic from the curve buffer. Each curve is 6 floats:
 // [p0x, p0y, p1x, p1y, p2x, p2y].
 struct Quadratic {
-  p0 : vec2f, p1 : vec2f, p2 : vec2f,
+  p0: vec2f,
+  p1: vec2f,
+  p2: vec2f,
 };
 
-fn load_curve(index : u32) -> Quadratic {
+fn load_curve(index: u32) -> Quadratic {
   let base = index * 6u;
-  var q : Quadratic;
+  var q: Quadratic;
   q.p0 = vec2f(curveData[base + 0u], curveData[base + 1u]);
   q.p1 = vec2f(curveData[base + 2u], curveData[base + 3u]);
   q.p2 = vec2f(curveData[base + 4u], curveData[base + 5u]);
@@ -210,7 +210,7 @@ fn load_curve(index : u32) -> Quadratic {
 
 // Solve the quadratic equation at² + bt + c = 0 for roots in (0, 1].
 // Returns two t values; invalid roots are set to -1.
-fn solve_quadratic(a : f32, b : f32, c : f32) -> vec2f {
+fn solve_quadratic(a: f32, b: f32, c: f32) -> vec2f {
   var roots = vec2f(-1.0, -1.0);
 
   // Threshold raised from 1e-6 to 1e-4 to robustly route degenerate
@@ -261,14 +261,14 @@ fn solve_quadratic(a : f32, b : f32, c : f32) -> vec2f {
 // Rearranging: t² (p0y - 2 p1y + p2y) + 2t (p1y - p0y) + (p0y - sample_y) = 0
 // i.e., a t² + b t + c = 0 with a = p0y - 2 p1y + p2y, b = 2(p1y - p0y),
 // c = p0y - sample_y.
-fn curve_winding(curve : Quadratic, sample : vec2f) -> i32 {
+fn curve_winding(curve: Quadratic, sample: vec2f) -> i32 {
   let a = curve.p0.y - 2.0 * curve.p1.y + curve.p2.y;
   let b = 2.0 * (curve.p1.y - curve.p0.y);
   let c = curve.p0.y - sample.y;
 
   let roots = solve_quadratic(a, b, c);
 
-  var winding : i32 = 0;
+  var winding: i32 = 0;
   for (var i = 0; i < 2; i = i + 1) {
     let t = select(roots.y, roots.x, i == 0);
     if (t < 0.0) {
@@ -302,7 +302,7 @@ fn curve_winding(curve : Quadratic, sample : vec2f) -> i32 {
 /// the active convex clip polygon. Returns `true` when no polygon is
 /// active, so callers can unconditionally AND this into their coverage
 /// decision.
-fn sample_in_clip_polygon(pixel_pos : vec2f) -> bool {
+fn sample_in_clip_polygon(pixel_pos: vec2f) -> bool {
   if (uniforms.hasClipPolygon == 0u) {
     return true;
   }
@@ -321,8 +321,8 @@ fn sample_in_clip_polygon(pixel_pos : vec2f) -> bool {
 /// Test whether a single sub-pixel sample position is inside the fill,
 /// per the active fill rule. Shared between `fs_main` sample-mask loop
 /// and any future per-sample helpers.
-fn sample_is_inside(band : Band, sample_pos : vec2f) -> bool {
-  var winding : i32 = 0;
+fn sample_is_inside(band: Band, sample_pos: vec2f) -> bool {
+  var winding: i32 = 0;
   for (var i = 0u; i < band.curveCount; i = i + 1u) {
     let curve = load_curve(band.curveStart + i);
     winding = winding + curve_winding(curve, sample_pos);
@@ -342,10 +342,12 @@ fn sample_is_inside(band : Band, sample_pos : vec2f) -> bool {
 /// 0/4, 1/4, 2/4, 3/4, or 4/4 coverage per pixel, closely matching
 /// tiny-skia's 4× supersampling scan-converter.
 struct FragOutput {
-  @location(0) color : vec4f, @builtin(sample_mask) mask : u32,
+  @location(0) color: vec4f,
+  @builtin(sample_mask) mask: u32,
 };
 
-@fragment fn fs_main(in : VertexOutput) -> FragOutput {
+@fragment
+fn fs_main(in: VertexOutput) -> FragOutput {
   let band = bands[in.bandIndex];
 
   // Framebuffer-pixel center of this fragment. WGSL specifies that
@@ -383,11 +385,15 @@ struct FragOutput {
   // positions, so any 4 distinct in-pixel offsets give a correct 4×
   // coverage estimate. Use D3D-style rotated positions to avoid
   // axis-aligned Moiré on near-horizontal / near-vertical edges.
-  var offsets = array<vec2f, 4>(vec2f(-0.125, -0.375), vec2f(0.375, -0.125), vec2f(-0.375, 0.125),
-                                vec2f(0.125, 0.375), );
+  var offsets = array<vec2f, 4>(
+    vec2f(-0.125, -0.375),
+    vec2f( 0.375, -0.125),
+    vec2f(-0.375,  0.125),
+    vec2f( 0.125,  0.375),
+  );
 
-  var mask : u32 = 0u;
-  for (var s : u32 = 0u; s < 4u; s = s + 1u) {
+  var mask: u32 = 0u;
+  for (var s: u32 = 0u; s < 4u; s = s + 1u) {
     // Convert the viewport-pixel offset into a path-space delta.
     let sp = in.sample_pos + offsets[s].x * dx + offsets[s].y * dy;
 
@@ -425,16 +431,17 @@ struct FragOutput {
   // When no mask is active, `hasClipMask == 0` and we skip the work
   // entirely — the dummy texture's 1.0 value would also work but the
   // branch shaves a texture fetch off the hot path.
-  var clipCoverage : f32 = 1.0;
+  var clipCoverage: f32 = 1.0;
   if (uniforms.hasClipMask != 0u) {
     let mask_uv = pixel_center / uniforms.viewport;
-    clipCoverage = clamp(textureSample(clipMaskTexture, clipMaskSampler, mask_uv).r, 0.0, 1.0);
+    clipCoverage = clamp(textureSample(clipMaskTexture, clipMaskSampler, mask_uv).r,
+                         0.0, 1.0);
     if (clipCoverage <= 0.0) {
       discard;
     }
   }
 
-  var out : FragOutput;
+  var out: FragOutput;
   out.mask = mask;
 
   if (uniforms.paintMode == 0u) {
@@ -448,8 +455,10 @@ struct FragOutput {
   // Pattern mode: sample the tile at the pixel center. The
   // sample_mask still controls edge coverage.
   let patternPos = (uniforms.patternFromPath * vec4f(in.sample_pos, 0.0, 1.0)).xy;
-  let wrapped = vec2f(fract(patternPos.x / uniforms.tileSize.x) * uniforms.tileSize.x,
-                      fract(patternPos.y / uniforms.tileSize.y) * uniforms.tileSize.y, );
+  let wrapped = vec2f(
+    fract(patternPos.x / uniforms.tileSize.x) * uniforms.tileSize.x,
+    fract(patternPos.y / uniforms.tileSize.y) * uniforms.tileSize.y,
+  );
   let uv = wrapped / uniforms.tileSize;
   var sampled = textureSample(patternTexture, patternSampler, uv);
   sampled = sampled * uniforms.patternOpacity * clipCoverage;

--- a/donner/svg/renderer/geode/shaders/slug_fill_alpha_coverage.wgsl
+++ b/donner/svg/renderer/geode/shaders/slug_fill_alpha_coverage.wgsl
@@ -16,72 +16,85 @@
 // ============================================================================
 
 struct Uniforms {
-  mvp: mat4x4f,
-  patternFromPath: mat4x4f,
-  viewport: vec2f,
-  tileSize: vec2f,
-  color: vec4f,
-  fillRule: u32,
-  paintMode: u32,
-  patternOpacity: f32,
-  hasClipPolygon: u32,
-  hasClipMask: u32,
-  _pad0: u32,
-  _pad1: u32,
-  clipPolygonPlanes: array<vec4f, 4>,
+  mvp : mat4x4f,
+        patternFromPath : mat4x4f,
+                          viewport : vec2f,
+                                     tileSize : vec2f,
+                                                color : vec4f,
+                                                        fillRule : u32,
+                                                                   paintMode : u32,
+                                                                               patternOpacity
+      : f32,
+        hasClipPolygon : u32,
+                         hasClipMask : u32,
+                                       _pad0 : u32,
+                                               _pad1 : u32,
+                                                       clipPolygonPlanes : array<vec4f, 4>,
 };
 
-@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(0) var<uniform> uniforms : Uniforms;
 
 // ============================================================================
 // Storage buffers
 // ============================================================================
 
 struct Band {
-  curveStart: u32,
-  curveCount: u32,
-  yMin: f32,
-  yMax: f32,
-  xMin: f32,
-  xMax: f32,
-  _pad0: f32,
-  _pad1: f32,
+  curveStart : u32,
+               curveCount : u32,
+                            yMin : f32,
+                                   yMax : f32,
+                                          xMin : f32,
+                                                 xMax : f32,
+                                                        _pad0 : f32,
+                                                                _pad1 : f32,
 };
 
-@group(0) @binding(1) var<storage, read> bands: array<Band>;
-@group(0) @binding(2) var<storage, read> curveData: array<f32>;
-@group(0) @binding(3) var patternTexture: texture_2d<f32>;
-@group(0) @binding(4) var patternSampler: sampler;
-@group(0) @binding(5) var clipMaskTexture: texture_2d<f32>;
-@group(0) @binding(6) var clipMaskSampler: sampler;
+@group(0) @binding(1) var<storage, read> bands : array<Band>;
+@group(0) @binding(2) var<storage, read> curveData : array<f32>;
+@group(0) @binding(3) var patternTexture : texture_2d<f32>;
+@group(0) @binding(4) var patternSampler : sampler;
+@group(0) @binding(5) var clipMaskTexture : texture_2d<f32>;
+@group(0) @binding(6) var clipMaskSampler : sampler;
+
+// Per-instance affine transform (Milestone 6 Bullet 2). See slug_fill.wgsl
+// for the full comment — this binding/struct mirror that shader.
+struct InstanceTransform {
+  row0 : vec4f, row1 : vec4f,
+};
+@group(0) @binding(7) var<storage, read> instanceTransforms : array<InstanceTransform>;
 
 // ============================================================================
 // Vertex stage (identical to slug_fill.wgsl)
 // ============================================================================
 
 struct VertexInput {
-  @location(0) pos: vec2f,
-  @location(1) normal: vec2f,
-  @location(2) bandIndex: u32,
+  @location(0) pos : vec2f, @location(1) normal : vec2f, @location(2) bandIndex : u32,
 };
 
 struct VertexOutput {
-  @builtin(position) clip_pos: vec4f,
-  @location(0) sample_pos: vec2f,
-  @location(1) @interpolate(flat) bandIndex: u32,
+  @builtin(position) clip_pos : vec4f,
+                                @location(0) sample_pos : vec2f,
+                                                          @location(1) @interpolate(flat) bandIndex
+      : u32,
 };
 
-@vertex
-fn vs_main(in: VertexInput) -> VertexOutput {
-  let world_normal = (uniforms.mvp * vec4f(in.normal, 0.0, 0.0)).xy;
+@vertex fn vs_main(@builtin(instance_index) instance_index : u32, in : VertexInput)
+    -> VertexOutput {
+  let xf = instanceTransforms[instance_index];
+  let instance_mat =
+      mat4x4f(vec4f(xf.row0.x, xf.row1.x, 0.0, 0.0), vec4f(xf.row0.y, xf.row1.y, 0.0, 0.0),
+              vec4f(0.0, 0.0, 1.0, 0.0), vec4f(xf.row0.z, xf.row1.z, 0.0, 1.0), );
+  let effective_mvp = uniforms.mvp * instance_mat;
+
+  let world_normal = (effective_mvp * vec4f(in.normal, 0.0, 0.0)).xy;
   let viewport_normal = world_normal * uniforms.viewport * 0.5;
   let viewport_len = length(viewport_normal);
   let d = 1.0 / max(viewport_len, 0.001);
 
   let dilated = in.pos + in.normal * d;
 
-  var out: VertexOutput;
-  out.clip_pos = uniforms.mvp * vec4f(dilated, 0.0, 1.0);
+  var out : VertexOutput;
+  out.clip_pos = effective_mvp * vec4f(dilated, 0.0, 1.0);
   out.sample_pos = dilated;
   out.bandIndex = in.bandIndex;
   return out;
@@ -92,21 +105,19 @@ fn vs_main(in: VertexInput) -> VertexOutput {
 // ============================================================================
 
 struct Quadratic {
-  p0: vec2f,
-  p1: vec2f,
-  p2: vec2f,
+  p0 : vec2f, p1 : vec2f, p2 : vec2f,
 };
 
-fn load_curve(index: u32) -> Quadratic {
+fn load_curve(index : u32) -> Quadratic {
   let base = index * 6u;
-  var q: Quadratic;
+  var q : Quadratic;
   q.p0 = vec2f(curveData[base + 0u], curveData[base + 1u]);
   q.p1 = vec2f(curveData[base + 2u], curveData[base + 3u]);
   q.p2 = vec2f(curveData[base + 4u], curveData[base + 5u]);
   return q;
 }
 
-fn solve_quadratic(a: f32, b: f32, c: f32) -> vec2f {
+fn solve_quadratic(a : f32, b : f32, c : f32) -> vec2f {
   var roots = vec2f(-1.0, -1.0);
 
   if (abs(a) < 1e-4) {
@@ -138,14 +149,14 @@ fn solve_quadratic(a: f32, b: f32, c: f32) -> vec2f {
   return roots;
 }
 
-fn curve_winding(curve: Quadratic, sample: vec2f) -> i32 {
+fn curve_winding(curve : Quadratic, sample : vec2f) -> i32 {
   let a = curve.p0.y - 2.0 * curve.p1.y + curve.p2.y;
   let b = 2.0 * (curve.p1.y - curve.p0.y);
   let c = curve.p0.y - sample.y;
 
   let roots = solve_quadratic(a, b, c);
 
-  var winding: i32 = 0;
+  var winding : i32 = 0;
   for (var i = 0; i < 2; i = i + 1) {
     let t = select(roots.y, roots.x, i == 0);
     if (t < 0.0) {
@@ -172,7 +183,7 @@ fn curve_winding(curve: Quadratic, sample: vec2f) -> i32 {
 // Fragment stage
 // ============================================================================
 
-fn sample_in_clip_polygon(pixel_pos: vec2f) -> bool {
+fn sample_in_clip_polygon(pixel_pos : vec2f) -> bool {
   if (uniforms.hasClipPolygon == 0u) {
     return true;
   }
@@ -185,8 +196,8 @@ fn sample_in_clip_polygon(pixel_pos: vec2f) -> bool {
   return true;
 }
 
-fn sample_is_inside(band: Band, sample_pos: vec2f) -> bool {
-  var winding: i32 = 0;
+fn sample_is_inside(band : Band, sample_pos : vec2f) -> bool {
+  var winding : i32 = 0;
   for (var i = 0u; i < band.curveCount; i = i + 1u) {
     let curve = load_curve(band.curveStart + i);
     winding = winding + curve_winding(curve, sample_pos);
@@ -200,26 +211,21 @@ fn sample_is_inside(band: Band, sample_pos: vec2f) -> bool {
 /// Alpha-coverage fragment output: no @builtin(sample_mask).
 /// Coverage is folded into color.a instead.
 struct FragOutput {
-  @location(0) color: vec4f,
+  @location(0) color : vec4f,
 };
 
-@fragment
-fn fs_main(in: VertexOutput) -> FragOutput {
+@fragment fn fs_main(in : VertexOutput) -> FragOutput {
   let band = bands[in.bandIndex];
   let pixel_center = in.clip_pos.xy;
 
   let dx = dpdx(in.sample_pos);
   let dy = dpdy(in.sample_pos);
 
-  var offsets = array<vec2f, 4>(
-    vec2f(-0.125, -0.375),
-    vec2f( 0.375, -0.125),
-    vec2f(-0.375,  0.125),
-    vec2f( 0.125,  0.375),
-  );
+  var offsets = array<vec2f, 4>(vec2f(-0.125, -0.375), vec2f(0.375, -0.125), vec2f(-0.375, 0.125),
+                                vec2f(0.125, 0.375), );
 
-  var mask: u32 = 0u;
-  for (var s: u32 = 0u; s < 4u; s = s + 1u) {
+  var mask : u32 = 0u;
+  for (var s : u32 = 0u; s < 4u; s = s + 1u) {
     let sp = in.sample_pos + offsets[s].x * dx + offsets[s].y * dy;
     if (sp.y < band.yMin || sp.y >= band.yMax) {
       continue;
@@ -240,17 +246,16 @@ fn fs_main(in: VertexOutput) -> FragOutput {
   // Convert the 4-bit sample mask into a fractional coverage value.
   let coverage = f32(countOneBits(mask)) / 4.0;
 
-  var clipCoverage: f32 = 1.0;
+  var clipCoverage : f32 = 1.0;
   if (uniforms.hasClipMask != 0u) {
     let mask_uv = pixel_center / uniforms.viewport;
-    clipCoverage = clamp(textureSample(clipMaskTexture, clipMaskSampler, mask_uv).r,
-                         0.0, 1.0);
+    clipCoverage = clamp(textureSample(clipMaskTexture, clipMaskSampler, mask_uv).r, 0.0, 1.0);
     if (clipCoverage <= 0.0) {
       discard;
     }
   }
 
-  var out: FragOutput;
+  var out : FragOutput;
 
   if (uniforms.paintMode == 0u) {
     // Scale premultiplied color by coverage (all 4 channels since premultiplied).
@@ -260,10 +265,8 @@ fn fs_main(in: VertexOutput) -> FragOutput {
 
   // Pattern mode: sample the tile and scale by coverage.
   let patternPos = (uniforms.patternFromPath * vec4f(in.sample_pos, 0.0, 1.0)).xy;
-  let wrapped = vec2f(
-    fract(patternPos.x / uniforms.tileSize.x) * uniforms.tileSize.x,
-    fract(patternPos.y / uniforms.tileSize.y) * uniforms.tileSize.y,
-  );
+  let wrapped = vec2f(fract(patternPos.x / uniforms.tileSize.x) * uniforms.tileSize.x,
+                      fract(patternPos.y / uniforms.tileSize.y) * uniforms.tileSize.y, );
   let uv = wrapped / uniforms.tileSize;
   var sampled = textureSample(patternTexture, patternSampler, uv);
   sampled = sampled * uniforms.patternOpacity * clipCoverage * coverage;

--- a/donner/svg/renderer/geode/shaders/slug_fill_alpha_coverage.wgsl
+++ b/donner/svg/renderer/geode/shaders/slug_fill_alpha_coverage.wgsl
@@ -16,74 +16,78 @@
 // ============================================================================
 
 struct Uniforms {
-  mvp : mat4x4f,
-        patternFromPath : mat4x4f,
-                          viewport : vec2f,
-                                     tileSize : vec2f,
-                                                color : vec4f,
-                                                        fillRule : u32,
-                                                                   paintMode : u32,
-                                                                               patternOpacity
-      : f32,
-        hasClipPolygon : u32,
-                         hasClipMask : u32,
-                                       _pad0 : u32,
-                                               _pad1 : u32,
-                                                       clipPolygonPlanes : array<vec4f, 4>,
+  mvp: mat4x4f,
+  patternFromPath: mat4x4f,
+  viewport: vec2f,
+  tileSize: vec2f,
+  color: vec4f,
+  fillRule: u32,
+  paintMode: u32,
+  patternOpacity: f32,
+  hasClipPolygon: u32,
+  hasClipMask: u32,
+  _pad0: u32,
+  _pad1: u32,
+  clipPolygonPlanes: array<vec4f, 4>,
 };
 
-@group(0) @binding(0) var<uniform> uniforms : Uniforms;
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
 
 // ============================================================================
 // Storage buffers
 // ============================================================================
 
 struct Band {
-  curveStart : u32,
-               curveCount : u32,
-                            yMin : f32,
-                                   yMax : f32,
-                                          xMin : f32,
-                                                 xMax : f32,
-                                                        _pad0 : f32,
-                                                                _pad1 : f32,
+  curveStart: u32,
+  curveCount: u32,
+  yMin: f32,
+  yMax: f32,
+  xMin: f32,
+  xMax: f32,
+  _pad0: f32,
+  _pad1: f32,
 };
 
-@group(0) @binding(1) var<storage, read> bands : array<Band>;
-@group(0) @binding(2) var<storage, read> curveData : array<f32>;
-@group(0) @binding(3) var patternTexture : texture_2d<f32>;
-@group(0) @binding(4) var patternSampler : sampler;
-@group(0) @binding(5) var clipMaskTexture : texture_2d<f32>;
-@group(0) @binding(6) var clipMaskSampler : sampler;
+@group(0) @binding(1) var<storage, read> bands: array<Band>;
+@group(0) @binding(2) var<storage, read> curveData: array<f32>;
+@group(0) @binding(3) var patternTexture: texture_2d<f32>;
+@group(0) @binding(4) var patternSampler: sampler;
+@group(0) @binding(5) var clipMaskTexture: texture_2d<f32>;
+@group(0) @binding(6) var clipMaskSampler: sampler;
 
 // Per-instance affine transform (Milestone 6 Bullet 2). See slug_fill.wgsl
 // for the full comment — this binding/struct mirror that shader.
 struct InstanceTransform {
-  row0 : vec4f, row1 : vec4f,
+  row0: vec4f,
+  row1: vec4f,
 };
-@group(0) @binding(7) var<storage, read> instanceTransforms : array<InstanceTransform>;
+@group(0) @binding(7) var<storage, read> instanceTransforms: array<InstanceTransform>;
 
 // ============================================================================
 // Vertex stage (identical to slug_fill.wgsl)
 // ============================================================================
 
 struct VertexInput {
-  @location(0) pos : vec2f, @location(1) normal : vec2f, @location(2) bandIndex : u32,
+  @location(0) pos: vec2f,
+  @location(1) normal: vec2f,
+  @location(2) bandIndex: u32,
 };
 
 struct VertexOutput {
-  @builtin(position) clip_pos : vec4f,
-                                @location(0) sample_pos : vec2f,
-                                                          @location(1) @interpolate(flat) bandIndex
-      : u32,
+  @builtin(position) clip_pos: vec4f,
+  @location(0) sample_pos: vec2f,
+  @location(1) @interpolate(flat) bandIndex: u32,
 };
 
-@vertex fn vs_main(@builtin(instance_index) instance_index : u32, in : VertexInput)
-    -> VertexOutput {
+@vertex
+fn vs_main(@builtin(instance_index) instance_index: u32, in: VertexInput) -> VertexOutput {
   let xf = instanceTransforms[instance_index];
-  let instance_mat =
-      mat4x4f(vec4f(xf.row0.x, xf.row1.x, 0.0, 0.0), vec4f(xf.row0.y, xf.row1.y, 0.0, 0.0),
-              vec4f(0.0, 0.0, 1.0, 0.0), vec4f(xf.row0.z, xf.row1.z, 0.0, 1.0), );
+  let instance_mat = mat4x4f(
+    vec4f(xf.row0.x, xf.row1.x, 0.0, 0.0),
+    vec4f(xf.row0.y, xf.row1.y, 0.0, 0.0),
+    vec4f(0.0,       0.0,       1.0, 0.0),
+    vec4f(xf.row0.z, xf.row1.z, 0.0, 1.0),
+  );
   let effective_mvp = uniforms.mvp * instance_mat;
 
   let world_normal = (effective_mvp * vec4f(in.normal, 0.0, 0.0)).xy;
@@ -93,7 +97,7 @@ struct VertexOutput {
 
   let dilated = in.pos + in.normal * d;
 
-  var out : VertexOutput;
+  var out: VertexOutput;
   out.clip_pos = effective_mvp * vec4f(dilated, 0.0, 1.0);
   out.sample_pos = dilated;
   out.bandIndex = in.bandIndex;
@@ -105,19 +109,21 @@ struct VertexOutput {
 // ============================================================================
 
 struct Quadratic {
-  p0 : vec2f, p1 : vec2f, p2 : vec2f,
+  p0: vec2f,
+  p1: vec2f,
+  p2: vec2f,
 };
 
-fn load_curve(index : u32) -> Quadratic {
+fn load_curve(index: u32) -> Quadratic {
   let base = index * 6u;
-  var q : Quadratic;
+  var q: Quadratic;
   q.p0 = vec2f(curveData[base + 0u], curveData[base + 1u]);
   q.p1 = vec2f(curveData[base + 2u], curveData[base + 3u]);
   q.p2 = vec2f(curveData[base + 4u], curveData[base + 5u]);
   return q;
 }
 
-fn solve_quadratic(a : f32, b : f32, c : f32) -> vec2f {
+fn solve_quadratic(a: f32, b: f32, c: f32) -> vec2f {
   var roots = vec2f(-1.0, -1.0);
 
   if (abs(a) < 1e-4) {
@@ -149,14 +155,14 @@ fn solve_quadratic(a : f32, b : f32, c : f32) -> vec2f {
   return roots;
 }
 
-fn curve_winding(curve : Quadratic, sample : vec2f) -> i32 {
+fn curve_winding(curve: Quadratic, sample: vec2f) -> i32 {
   let a = curve.p0.y - 2.0 * curve.p1.y + curve.p2.y;
   let b = 2.0 * (curve.p1.y - curve.p0.y);
   let c = curve.p0.y - sample.y;
 
   let roots = solve_quadratic(a, b, c);
 
-  var winding : i32 = 0;
+  var winding: i32 = 0;
   for (var i = 0; i < 2; i = i + 1) {
     let t = select(roots.y, roots.x, i == 0);
     if (t < 0.0) {
@@ -183,7 +189,7 @@ fn curve_winding(curve : Quadratic, sample : vec2f) -> i32 {
 // Fragment stage
 // ============================================================================
 
-fn sample_in_clip_polygon(pixel_pos : vec2f) -> bool {
+fn sample_in_clip_polygon(pixel_pos: vec2f) -> bool {
   if (uniforms.hasClipPolygon == 0u) {
     return true;
   }
@@ -196,8 +202,8 @@ fn sample_in_clip_polygon(pixel_pos : vec2f) -> bool {
   return true;
 }
 
-fn sample_is_inside(band : Band, sample_pos : vec2f) -> bool {
-  var winding : i32 = 0;
+fn sample_is_inside(band: Band, sample_pos: vec2f) -> bool {
+  var winding: i32 = 0;
   for (var i = 0u; i < band.curveCount; i = i + 1u) {
     let curve = load_curve(band.curveStart + i);
     winding = winding + curve_winding(curve, sample_pos);
@@ -211,21 +217,26 @@ fn sample_is_inside(band : Band, sample_pos : vec2f) -> bool {
 /// Alpha-coverage fragment output: no @builtin(sample_mask).
 /// Coverage is folded into color.a instead.
 struct FragOutput {
-  @location(0) color : vec4f,
+  @location(0) color: vec4f,
 };
 
-@fragment fn fs_main(in : VertexOutput) -> FragOutput {
+@fragment
+fn fs_main(in: VertexOutput) -> FragOutput {
   let band = bands[in.bandIndex];
   let pixel_center = in.clip_pos.xy;
 
   let dx = dpdx(in.sample_pos);
   let dy = dpdy(in.sample_pos);
 
-  var offsets = array<vec2f, 4>(vec2f(-0.125, -0.375), vec2f(0.375, -0.125), vec2f(-0.375, 0.125),
-                                vec2f(0.125, 0.375), );
+  var offsets = array<vec2f, 4>(
+    vec2f(-0.125, -0.375),
+    vec2f( 0.375, -0.125),
+    vec2f(-0.375,  0.125),
+    vec2f( 0.125,  0.375),
+  );
 
-  var mask : u32 = 0u;
-  for (var s : u32 = 0u; s < 4u; s = s + 1u) {
+  var mask: u32 = 0u;
+  for (var s: u32 = 0u; s < 4u; s = s + 1u) {
     let sp = in.sample_pos + offsets[s].x * dx + offsets[s].y * dy;
     if (sp.y < band.yMin || sp.y >= band.yMax) {
       continue;
@@ -246,16 +257,17 @@ struct FragOutput {
   // Convert the 4-bit sample mask into a fractional coverage value.
   let coverage = f32(countOneBits(mask)) / 4.0;
 
-  var clipCoverage : f32 = 1.0;
+  var clipCoverage: f32 = 1.0;
   if (uniforms.hasClipMask != 0u) {
     let mask_uv = pixel_center / uniforms.viewport;
-    clipCoverage = clamp(textureSample(clipMaskTexture, clipMaskSampler, mask_uv).r, 0.0, 1.0);
+    clipCoverage = clamp(textureSample(clipMaskTexture, clipMaskSampler, mask_uv).r,
+                         0.0, 1.0);
     if (clipCoverage <= 0.0) {
       discard;
     }
   }
 
-  var out : FragOutput;
+  var out: FragOutput;
 
   if (uniforms.paintMode == 0u) {
     // Scale premultiplied color by coverage (all 4 channels since premultiplied).
@@ -265,8 +277,10 @@ struct FragOutput {
 
   // Pattern mode: sample the tile and scale by coverage.
   let patternPos = (uniforms.patternFromPath * vec4f(in.sample_pos, 0.0, 1.0)).xy;
-  let wrapped = vec2f(fract(patternPos.x / uniforms.tileSize.x) * uniforms.tileSize.x,
-                      fract(patternPos.y / uniforms.tileSize.y) * uniforms.tileSize.y, );
+  let wrapped = vec2f(
+    fract(patternPos.x / uniforms.tileSize.x) * uniforms.tileSize.x,
+    fract(patternPos.y / uniforms.tileSize.y) * uniforms.tileSize.y,
+  );
   let uv = wrapped / uniforms.tileSize;
   var sampled = textureSample(patternTexture, patternSampler, uv);
   sampled = sampled * uniforms.patternOpacity * clipCoverage * coverage;

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -47,6 +47,30 @@ constexpr std::string_view kSimpleShapesSvg = R"SVG(
 </svg>
 )SVG";
 
+/// Inline fixture: a single defined shape referenced by eight `<use>`
+/// instances at distinct positions. The whole document resolves to
+/// eight draws of the same source entity — exactly the shape
+/// Milestone 6 Bullet 2 targets for instancing. Today these draw as
+/// eight separate GPU calls; `sameSourceDrawPairs` should report
+/// seven (= 8 − 1) adjacent-same-source pairs, which is the draw-call
+/// savings an instancing pass would unlock.
+constexpr std::string_view kUseHeavySvg = R"SVG(
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+     viewBox="0 0 400 100">
+  <defs>
+    <rect id="r" width="20" height="20" fill="red"/>
+  </defs>
+  <use xlink:href="#r" x="0"   y="0"/>
+  <use xlink:href="#r" x="40"  y="0"/>
+  <use xlink:href="#r" x="80"  y="0"/>
+  <use xlink:href="#r" x="120" y="0"/>
+  <use xlink:href="#r" x="160" y="0"/>
+  <use xlink:href="#r" x="200" y="0"/>
+  <use xlink:href="#r" x="240" y="0"/>
+  <use xlink:href="#r" x="280" y="0"/>
+</svg>
+)SVG";
+
 /// Inline fixture: a handful of cubic Bezier paths plus one linear
 /// gradient. Hits the `fillPathLinearGradient` Tier-1 site and exercises
 /// stroke outline encoding on the open-path `path` elements.
@@ -69,11 +93,12 @@ constexpr std::string_view kModerateSvg = R"SVG(
 /// counter on its own column for easy diffing across milestones.
 void printCounters(const char* label, const geode::GeodeCounters& c) {
   std::fprintf(stderr,
-               "[GeodePerf] %-32s  pathEncodes=%4" PRIu64 "  bufferCreates=%5" PRIu64
+               "[GeodePerf] %-40s  pathEncodes=%4" PRIu64 "  bufferCreates=%5" PRIu64
                "  bindgroupCreates=%5" PRIu64 "  textureCreates=%3" PRIu64 "  submits=%3" PRIu64
-               "  drawCalls=%4" PRIu64 "  pipelineSwitches=%3" PRIu64 "\n",
+               "  drawCalls=%4" PRIu64 "  pipelineSwitches=%3" PRIu64
+               "  sameSourceDrawPairs=%3" PRIu64 "\n",
                label, c.pathEncodes, c.bufferCreates, c.bindgroupCreates, c.textureCreates,
-               c.submits, c.drawCalls, c.pipelineSwitches);
+               c.submits, c.drawCalls, c.pipelineSwitches, c.sameSourceDrawPairs);
 }
 
 /// Read a file from disk. Returns the empty string on any I/O error —
@@ -253,13 +278,53 @@ TEST_F(GeodePerfTest, Lion_BaselineCeilings) {
   //                       (`<use>` instancing) is the knob that moves
   //                       drawCalls for `<use>`-heavy fixtures; Lion
   //                       has no `<use>` so this ceiling stays at 132.
-  EXPECT_LE(c.pathEncodes, 200u);       // M2: target = 0.
-  EXPECT_LE(c.bufferCreates, 10u);      // M1.f.2: target ~= 5 steady-state.
-  EXPECT_LE(c.bindgroupCreates, 200u);  // M1.f.2: target <= #pipelines.
-  EXPECT_LE(c.textureCreates, 3u);      // Target + MSAA on first render; 0 on repeat.
-  EXPECT_LE(c.submits, 3u);             // M3: target = 1.
-  EXPECT_LE(c.drawCalls, 200u);         // 132 paths, one draw each (no <use>).
-  EXPECT_LE(c.pipelineSwitches, 2u);    // All-solid fixture: tracker binds solid once.
+  EXPECT_LE(c.pathEncodes, 200u);        // M2: target = 0.
+  EXPECT_LE(c.bufferCreates, 10u);       // M1.f.2: target ~= 5 steady-state.
+  EXPECT_LE(c.bindgroupCreates, 200u);   // M1.f.2: target <= #pipelines.
+  EXPECT_LE(c.textureCreates, 3u);       // Target + MSAA on first render; 0 on repeat.
+  EXPECT_LE(c.submits, 3u);              // M3: target = 1.
+  EXPECT_LE(c.drawCalls, 200u);          // 132 paths, one draw each (no <use>).
+  EXPECT_LE(c.pipelineSwitches, 2u);     // All-solid fixture: tracker binds solid once.
+  EXPECT_EQ(c.sameSourceDrawPairs, 0u);  // No `<use>` in Lion — every draw has a unique source.
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: eight `<use>` instances of one source `<rect>`. Motivates
+// M6 Bullet 2 (`<use>` instancing): today these render as eight
+// separate GPU draws; the future batcher collapses them into one
+// instanced draw. The detection counter `sameSourceDrawPairs` reports
+// seven adjacent-same-source pairs = the draw-call savings an
+// instancing pass would unlock.
+// ---------------------------------------------------------------------------
+
+TEST_F(GeodePerfTest, UseHeavy_BaselineCeilings) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  geode::GeodeCounters c = renderAndGetCounters(kUseHeavySvg, device);
+
+  RecordProperty("bufferCreates", std::to_string(c.bufferCreates));
+  RecordProperty("bindgroupCreates", std::to_string(c.bindgroupCreates));
+  RecordProperty("textureCreates", std::to_string(c.textureCreates));
+  RecordProperty("submits", std::to_string(c.submits));
+  RecordProperty("pathEncodes", std::to_string(c.pathEncodes));
+  RecordProperty("drawCalls", std::to_string(c.drawCalls));
+  RecordProperty("pipelineSwitches", std::to_string(c.pipelineSwitches));
+  RecordProperty("sameSourceDrawPairs", std::to_string(c.sameSourceDrawPairs));
+  printCounters(::testing::UnitTest::GetInstance()->current_test_info()->name(), c);
+
+  // M2: the `<use>` instances share one source `<rect>` entity, so
+  // its encoded path is cached once and reused for all eight draws
+  // on frame 1 (first draw encodes, next seven hit the cache).
+  EXPECT_LE(c.pathEncodes, 2u);
+  // Current state: eight separate GPU draws, one per `<use>`.
+  // Target after M6 Bullet 2: `drawCalls == 1` (single instanced).
+  EXPECT_LE(c.drawCalls, 10u);
+  // Seven adjacent-same-source pairs = the exact count an instancing
+  // pass would collapse. Pinning this value so a regression in the
+  // detection path (e.g. `<use>` stops resolving to a shared
+  // `dataEntity`) trips immediately.
+  EXPECT_EQ(c.sameSourceDrawPairs, 7u);
 }
 
 // ---------------------------------------------------------------------------

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -68,11 +68,12 @@ constexpr std::string_view kModerateSvg = R"SVG(
 /// test output (RecordProperty only surfaces in XML). Format keeps each
 /// counter on its own column for easy diffing across milestones.
 void printCounters(const char* label, const geode::GeodeCounters& c) {
-  std::fprintf(
-      stderr,
-      "[GeodePerf] %-32s  pathEncodes=%4" PRIu64 "  bufferCreates=%5" PRIu64
-      "  bindgroupCreates=%5" PRIu64 "  textureCreates=%3" PRIu64 "  submits=%3" PRIu64 "\n",
-      label, c.pathEncodes, c.bufferCreates, c.bindgroupCreates, c.textureCreates, c.submits);
+  std::fprintf(stderr,
+               "[GeodePerf] %-32s  pathEncodes=%4" PRIu64 "  bufferCreates=%5" PRIu64
+               "  bindgroupCreates=%5" PRIu64 "  textureCreates=%3" PRIu64 "  submits=%3" PRIu64
+               "  drawCalls=%4" PRIu64 "  pipelineSwitches=%3" PRIu64 "\n",
+               label, c.pathEncodes, c.bufferCreates, c.bindgroupCreates, c.textureCreates,
+               c.submits, c.drawCalls, c.pipelineSwitches);
 }
 
 /// Read a file from disk. Returns the empty string on any I/O error —
@@ -145,6 +146,8 @@ TEST_F(GeodePerfTest, SimpleShapes_BaselineCeilings) {
   RecordProperty("textureCreates", std::to_string(c.textureCreates));
   RecordProperty("submits", std::to_string(c.submits));
   RecordProperty("pathEncodes", std::to_string(c.pathEncodes));
+  RecordProperty("drawCalls", std::to_string(c.drawCalls));
+  RecordProperty("pipelineSwitches", std::to_string(c.pipelineSwitches));
   printCounters(::testing::UnitTest::GetInstance()->current_test_info()->name(), c);
 
   // Observed 2026-04-19 on macOS/Metal, M4 Pro:
@@ -156,11 +159,15 @@ TEST_F(GeodePerfTest, SimpleShapes_BaselineCeilings) {
   //   M4.2 (device dummies + pool): textureCreates=2 (target + MSAA
   //                       pair, fresh on first frame; repeat-render
   //                       is 0, see `*_ZeroTextures` tests below).
+  //   M6 instrumentation: drawCalls=3 (one per solid fill),
+  //                       pipelineSwitches=1 (solid pipeline only).
   EXPECT_LE(c.pathEncodes, 5u);       // M2: target = 0 on unchanged-geometry frames.
   EXPECT_LE(c.bufferCreates, 8u);     // M1.f.2: target = 1 (readback only).
   EXPECT_LE(c.bindgroupCreates, 6u);  // M1.f.2: target <= #pipelines (3 today).
   EXPECT_LE(c.textureCreates, 3u);    // Target + MSAA pair on frame 1; 0 on repeat.
   EXPECT_LE(c.submits, 3u);           // M3: target = 1.
+  EXPECT_LE(c.drawCalls, 4u);         // 3 shapes, one draw each.
+  EXPECT_LE(c.pipelineSwitches, 2u);  // Solid pipeline bound once.
 }
 
 // ---------------------------------------------------------------------------
@@ -178,6 +185,8 @@ TEST_F(GeodePerfTest, Moderate_BaselineCeilings) {
   RecordProperty("textureCreates", std::to_string(c.textureCreates));
   RecordProperty("submits", std::to_string(c.submits));
   RecordProperty("pathEncodes", std::to_string(c.pathEncodes));
+  RecordProperty("drawCalls", std::to_string(c.drawCalls));
+  RecordProperty("pipelineSwitches", std::to_string(c.pipelineSwitches));
   printCounters(::testing::UnitTest::GetInstance()->current_test_info()->name(), c);
 
   // Observed 2026-04-19:
@@ -189,11 +198,16 @@ TEST_F(GeodePerfTest, Moderate_BaselineCeilings) {
   //                   (push/pop no longer forces a queue submit)
   //   M4.2 (device dummies + pool): textureCreates=4 on frame 1
   //                   (target+MSAA + layer+MSAA), 0 on repeat.
+  //   M6 instrumentation: drawCalls=2 (solid fill + gradient fill),
+  //                   pipelineSwitches=~3 (solid for layer, image
+  //                   blit on layer composite, gradient for rect).
   EXPECT_LE(c.pathEncodes, 4u);       // M2: target = 0.
   EXPECT_LE(c.bufferCreates, 12u);    // M1.f.2 + future arena-share: target ~= 5.
   EXPECT_LE(c.bindgroupCreates, 6u);  // M1.f.2: target <= #pipelines.
   EXPECT_LE(c.textureCreates, 6u);    // Target+MSAA + layer+MSAA on first render; 0 on repeat.
   EXPECT_LE(c.submits, 3u);           // M3: target = 2 steady-state (frame + readback).
+  EXPECT_LE(c.drawCalls, 6u);         // 2 fills + blit composites.
+  EXPECT_LE(c.pipelineSwitches, 6u);  // Solid / gradient / image pipelines + mask if any.
 }
 
 // ---------------------------------------------------------------------------
@@ -220,6 +234,8 @@ TEST_F(GeodePerfTest, Lion_BaselineCeilings) {
   RecordProperty("textureCreates", std::to_string(c.textureCreates));
   RecordProperty("submits", std::to_string(c.submits));
   RecordProperty("pathEncodes", std::to_string(c.pathEncodes));
+  RecordProperty("drawCalls", std::to_string(c.drawCalls));
+  RecordProperty("pipelineSwitches", std::to_string(c.pipelineSwitches));
   printCounters(::testing::UnitTest::GetInstance()->current_test_info()->name(), c);
 
   // Observed 2026-04-19:
@@ -231,11 +247,19 @@ TEST_F(GeodePerfTest, Lion_BaselineCeilings) {
   //   bindgroupCreates=132 (one per draw; M1.f.2 collapses to ~1).
   //   M4.2 (device dummies + pool): textureCreates=2 on frame 1
   //                       (target + MSAA); 0 on repeat.
+  //   M6 instrumentation: drawCalls=132 (one per path),
+  //                       pipelineSwitches=1 (solid pipeline only —
+  //                       all of Lion is solid-fill). M6 Bullet 2
+  //                       (`<use>` instancing) is the knob that moves
+  //                       drawCalls for `<use>`-heavy fixtures; Lion
+  //                       has no `<use>` so this ceiling stays at 132.
   EXPECT_LE(c.pathEncodes, 200u);       // M2: target = 0.
   EXPECT_LE(c.bufferCreates, 10u);      // M1.f.2: target ~= 5 steady-state.
   EXPECT_LE(c.bindgroupCreates, 200u);  // M1.f.2: target <= #pipelines.
   EXPECT_LE(c.textureCreates, 3u);      // Target + MSAA on first render; 0 on repeat.
   EXPECT_LE(c.submits, 3u);             // M3: target = 1.
+  EXPECT_LE(c.drawCalls, 200u);         // 132 paths, one draw each (no <use>).
+  EXPECT_LE(c.pipelineSwitches, 2u);    // All-solid fixture: tracker binds solid once.
 }
 
 // ---------------------------------------------------------------------------

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -317,13 +317,19 @@ TEST_F(GeodePerfTest, UseHeavy_BaselineCeilings) {
   // its encoded path is cached once and reused for all eight draws
   // on frame 1 (first draw encodes, next seven hit the cache).
   EXPECT_LE(c.pathEncodes, 2u);
-  // Current state: eight separate GPU draws, one per `<use>`.
-  // Target after M6 Bullet 2: `drawCalls == 1` (single instanced).
-  EXPECT_LE(c.drawCalls, 10u);
-  // Seven adjacent-same-source pairs = the exact count an instancing
-  // pass would collapse. Pinning this value so a regression in the
-  // detection path (e.g. `<use>` stops resolving to a shared
-  // `dataEntity`) trips immediately.
+  // M6-B step 3: the batcher collapses all eight consecutive
+  // same-source `<use>` draws into a single instanced GPU call.
+  EXPECT_EQ(c.drawCalls, 1u);
+  // And a single bind group covers all eight — per-instance
+  // transforms ride in a storage-buffer binding (binding 7), while
+  // the other seven entries are stable across the batch.
+  EXPECT_EQ(c.bindgroupCreates, 1u);
+  // Seven adjacent-same-source pairs detected at `drawPath` entry
+  // (BEFORE batching collapses them). This is the "opportunity"
+  // counter — kept as a separate signal from `drawCalls` (the
+  // "realized" counter) so a regression in the detection path
+  // (e.g. `<use>` stops resolving to a shared `dataEntity`) or
+  // in the batcher trips independently.
   EXPECT_EQ(c.sameSourceDrawPairs, 7u);
 }
 

--- a/donner/svg/renderer/tests/FilterGraphExecutor_tests.cc
+++ b/donner/svg/renderer/tests/FilterGraphExecutor_tests.cc
@@ -28,7 +28,7 @@ Pixel GetPixel(const tiny_skia::Pixmap& pixmap, int x, int y) {
   return Pixel{data[index + 0], data[index + 1], data[index + 2], data[index + 3]};
 }
 
-tiny_skia::Pixmap CreateBlurredDotPixmap(const Transform2d& filterTransform) {
+tiny_skia::Pixmap CreateBlurredDotPixmap(const Transform2d& deviceFromFilterTransform) {
   auto maybePixmap = tiny_skia::Pixmap::fromSize(32, 32);
   EXPECT_TRUE(maybePixmap.has_value());
   tiny_skia::Pixmap pixmap = std::move(*maybePixmap);
@@ -44,7 +44,7 @@ tiny_skia::Pixmap CreateBlurredDotPixmap(const Transform2d& filterTransform) {
   };
   graph.nodes.push_back(std::move(node));
 
-  ApplyFilterGraphToPixmap(pixmap, graph, filterTransform, std::nullopt);
+  ApplyFilterGraphToPixmap(pixmap, graph, deviceFromFilterTransform, std::nullopt);
   return pixmap;
 }
 


### PR DESCRIPTION
## Summary

Stacks on #554 (already merged). Implements Milestone 6 from `docs/design_docs/0030-geode_performance.md`:

### M6-A — instrumentation (landed first, informed M6-B design)
- Added `drawCalls` and `pipelineSwitches` counters to `GeodeCounters`.
- Observed on `lion.svg` (132 paths): `drawCalls=132`, `pipelineSwitches=1`. The state tracker was already collapsing pipeline rebinds, so **M6 Bullet 1 ("pipeline cache") was deprioritised** — counters proved it's already optimal. Documented in the design doc.

### M6-B — `<use>` instancing (three incremental steps)
1. **Detection**: `sameSourceDrawPairs` counter + new `UseHeavy` fixture (8× `<use>` of one rect).
2. **Plumbing**: new storage-buffer binding (group0 binding 7) carries per-instance affine transforms; shader composes `uniforms.mvp * instance_mat` via `@builtin(instance_index)`. Identity-only in this step — no behaviour change, just wiring.
3. **Batching**: `RendererGeode::Impl::PendingBatch` collects N consecutive `drawPath`s with the same `sourceEntity` + paint + state, then emits a single instanced GPU draw with packed per-instance transforms.

All pushes, pops, filters, masks, and clips flush the pending batch first.

### Counter deltas on the `UseHeavy` fixture (8 uses of 1 rect)
|                      | before | after |
|----------------------|--------|-------|
| `drawCalls`          | 8      | 1     |
| `bindgroupCreates`   | 8      | 1     |
| `sameSourceDrawPairs`| 7      | 7     |

### Naming audit
Renamed to follow the project's `destFromSource` convention:
- `currentTransform` → `deviceFromLocalTransform` (Geode + TinySkia)
- `transformStack` → `deviceFromLocalTransformStack`
- `filterTransform` → `deviceFromFilterTransform` (filter-graph test)
- `deviceToLocal` → `localFromDevice` (TinySkia)
- In `PendingBatch`: `transforms` → `deviceFromLocalTransforms`, `savedTransform` → `savedDeviceFromLocalTransform`

### Key bug fixed during step 3
Early `flushPendingBatch` implementation mutated `deviceFromLocalTransform` without restore, so the *caller's* next stroke draw used the flushed transform. Caught by `rect2.svg` (12k pixel diff) and `stroking_pathlength.svg` (1.7k). Fix: save + restore `deviceFromLocalTransform` around the emit.

## Test plan
- [x] `bazel test --config=geode //donner/svg/renderer/geode/...`
- [x] `bazel test //donner/svg/renderer/...` (full renderer suite, including resvg)
- [x] `GeodePerf_tests.UseHeavy_BaselineCeilings` passes with tightened ceilings
- [x] `GeodePerf_tests.NoDirtyPath_ZeroEncodes`, `NoDirtyPath_ZeroTextures` (from #554) still green