### PR TITLE
FilterDragRepro: split into donner_perf_cc_test (correctness + wallclock)

### DIFF
--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -121,14 +121,20 @@ donner_cc_test(
     ],
 )
 
-donner_cc_test(
+donner_perf_cc_test(
     name = "filter_drag_repro_tests",
-    srcs = ["FilterDragRepro_tests.cc"],
+    srcs = [
+        "FilterDragReproTestUtils.cc",
+        "FilterDragReproTestUtils.h",
+    ],
+    correctness_srcs = ["FilterDragReproCorrectness_tests.cc"],
+    wallclock_srcs = ["FilterDragReproWallclock_tests.cc"],
     data = [
         ":filter_drag_repro.rnr",
         "//:donner_splash.svg",
     ],
     deps = [
+        "//donner/base:base",
         "//donner/editor:async_renderer",
         "//donner/editor:async_svg_document",
         "//donner/editor:editor_app",

--- a/donner/editor/tests/FilterDragReproCorrectness_tests.cc
+++ b/donner/editor/tests/FilterDragReproCorrectness_tests.cc
@@ -1,0 +1,64 @@
+/// @file
+///
+/// CPU-invariant portion of the `filter_drag_repro` replay test.
+/// Runs on the default PR gate (`bazel test //...`) because every
+/// assertion here is independent of the host runner's wall-clock
+/// speed — fast-path counters, the selection-change invariant, and
+/// the "something was selected at all" invariant all derive from
+/// compositor and editor state, not from timing.
+///
+/// Paired with `FilterDragReproWallclock_tests.cc`, which runs the
+/// same scenario but asserts the runner-speed-dependent drag-frame
+/// wall-clock budgets and is tagged `manual` + `perf` so it only
+/// runs in the nightly `perf` lane.
+
+#include "donner/base/EcsRegistry_fwd.h"
+#include "donner/editor/tests/FilterDragReproTestUtils.h"
+#include "gtest/gtest.h"
+
+namespace donner::editor::filter_drag_repro {
+namespace {
+
+TEST(FilterDragReproCorrectnessTest, ReplayHitsFastPathAndReSelects) {
+  FilterDragReproResult r;
+  RunFilterDragReproScenario(&r);
+  if (r.skipped) {
+    GTEST_SKIP() << "Required data files not available in runfiles";
+  }
+
+  // Selection invariant: after the first mouse-up, ONE element must be
+  // selected (the first drag's target). The second mouse-down in the
+  // recording lands on a different location; it must hit-test, replace
+  // the selection, and produce a visible drag preview — the user's
+  // "I can't select any other elements" complaint is exactly the
+  // failure mode where the first drag's selection sticks because the
+  // new mouse-down was dropped (async renderer busy / first drag
+  // layer never demoted).
+  EXPECT_TRUE(r.firstSelection != donner::Entity{})
+      << "first drag ended without a latched selection — hit-test missed or gesture aborted";
+  EXPECT_TRUE(r.secondSelection != donner::Entity{})
+      << "second mouse-down never produced a selection — user's 'can't select anything else' "
+         "complaint exactly";
+  EXPECT_TRUE(r.firstSelection != r.secondSelection)
+      << "second drag's selection did not differ from the first — second mouse-down was ignored "
+         "(likely dropped because async renderer stayed busy through the entire repro window)";
+
+  // Fast-path counter regression gate. This is the CPU-speed-invariant
+  // signal that the compositor is riding the translation-only fast path
+  // during the drag rather than re-running the heavy
+  // `prepareDocumentForRendering` pipeline every frame. Catches the
+  // "really laggy" regression in the metric that isn't runner-
+  // dependent. The exact counts depend on frame count in the
+  // recording, so we assert the qualitative shape: at least some
+  // fast-path frames, at most one slow-path-with-dirty frame
+  // (the prewarm).
+  EXPECT_GT(r.fastPathFrames, 0u)
+      << "no frames took the translation-only fast path — compositor-group elevation / "
+         "skipMainComposeDuringSplit path is dead or mis-gated";
+  EXPECT_LE(r.slowPathFramesWithDirty, 1u)
+      << "more than the pre-warm frame slipped into the slow path — drag is spending wall-clock "
+         "re-preparing the document per frame";
+}
+
+}  // namespace
+}  // namespace donner::editor::filter_drag_repro

--- a/donner/editor/tests/FilterDragReproCorrectness_tests.cc
+++ b/donner/editor/tests/FilterDragReproCorrectness_tests.cc
@@ -12,7 +12,6 @@
 /// wall-clock budgets and is tagged `manual` + `perf` so it only
 /// runs in the nightly `perf` lane.
 
-#include "donner/base/EcsRegistry_fwd.h"
 #include "donner/editor/tests/FilterDragReproTestUtils.h"
 #include "gtest/gtest.h"
 
@@ -34,12 +33,12 @@ TEST(FilterDragReproCorrectnessTest, ReplayHitsFastPathAndReSelects) {
   // failure mode where the first drag's selection sticks because the
   // new mouse-down was dropped (async renderer busy / first drag
   // layer never demoted).
-  EXPECT_TRUE(r.firstSelection != donner::Entity{})
+  EXPECT_TRUE(r.firstSelectionExists)
       << "first drag ended without a latched selection — hit-test missed or gesture aborted";
-  EXPECT_TRUE(r.secondSelection != donner::Entity{})
+  EXPECT_TRUE(r.secondSelectionExists)
       << "second mouse-down never produced a selection — user's 'can't select anything else' "
          "complaint exactly";
-  EXPECT_TRUE(r.firstSelection != r.secondSelection)
+  EXPECT_TRUE(r.selectionChangedAcrossDrags)
       << "second drag's selection did not differ from the first — second mouse-down was ignored "
          "(likely dropped because async renderer stayed busy through the entire repro window)";
 

--- a/donner/editor/tests/FilterDragReproTestUtils.cc
+++ b/donner/editor/tests/FilterDragReproTestUtils.cc
@@ -33,6 +33,7 @@
 #include <utility>
 #include <vector>
 
+#include "donner/base/EcsRegistry_fwd.h"
 #include "donner/base/Transform.h"
 #include "donner/base/Vector2.h"
 #include "donner/base/xml/XMLQualifiedName.h"
@@ -309,7 +310,8 @@ DragStats ComputeDragStats(const ReplayResults& r, uint64_t fromFrame, uint64_t 
   return stats;
 }
 
-void DumpHistogram(const ReplayResults& r, uint64_t fromFrame, uint64_t toFrame, const char* label) {
+void DumpHistogram(const ReplayResults& r, uint64_t fromFrame, uint64_t toFrame,
+                   const char* label) {
   int buckets[6] = {0};  // <5, 5-15, 15-30, 30-60, 60-120, >=120
   for (const auto& f : r.frames) {
     if (f.reproFrameIndex <= fromFrame || f.reproFrameIndex >= toFrame || f.workerMs < 0.0) {
@@ -379,11 +381,11 @@ void RunFilterDragReproScenario(FilterDragReproResult* out) {
   ASSERT_GT(out->secondDrag.frameCount, 0);
 
   std::cerr << "[FilterDragRepro] first drag: frames=" << out->firstDrag.frameCount
-            << ", avg=" << out->firstDrag.avgWorkerMs
-            << " ms, max=" << out->firstDrag.maxWorkerMs << " ms\n";
+            << ", avg=" << out->firstDrag.avgWorkerMs << " ms, max=" << out->firstDrag.maxWorkerMs
+            << " ms\n";
   std::cerr << "[FilterDragRepro] second drag: frames=" << out->secondDrag.frameCount
-            << ", avg=" << out->secondDrag.avgWorkerMs
-            << " ms, max=" << out->secondDrag.maxWorkerMs << " ms\n";
+            << ", avg=" << out->secondDrag.avgWorkerMs << " ms, max=" << out->secondDrag.maxWorkerMs
+            << " ms\n";
 
   DumpHistogram(r, firstDown, firstUp, "first-drag");
   DumpHistogram(r, secondDown, secondUp, "second-drag");
@@ -399,8 +401,11 @@ void RunFilterDragReproScenario(FilterDragReproResult* out) {
             << " filterAncestor=" << r.selectionFilterAncestorIds[1] << "\n";
 
   ASSERT_EQ(r.selectionAfterMouseUp.size(), 2u);
-  out->firstSelection = r.selectionAfterMouseUp[0];
-  out->secondSelection = r.selectionAfterMouseUp[1];
+  const Entity firstSel = r.selectionAfterMouseUp[0];
+  const Entity secondSel = r.selectionAfterMouseUp[1];
+  out->firstSelectionExists = (firstSel != entt::null);
+  out->secondSelectionExists = (secondSel != entt::null);
+  out->selectionChangedAcrossDrags = (firstSel != secondSel);
   out->firstSelectionId = r.selectionElementIds[0];
   out->firstSelectionFilterAncestorId = r.selectionFilterAncestorIds[0];
   out->secondSelectionId = r.selectionElementIds[1];

--- a/donner/editor/tests/FilterDragReproTestUtils.cc
+++ b/donner/editor/tests/FilterDragReproTestUtils.cc
@@ -1,15 +1,7 @@
 /// @file
 ///
-/// Instrumented UI-layer test that replays the user-recorded
-/// `/tmp/filter_select.rnr` (checked in as `filter_drag_repro.rnr`)
-/// against the real editor stack — `EditorApp` + `SelectTool` +
-/// `RenderCoordinator` + `AsyncRenderer` — so we faithfully exercise
-/// the pipeline behind the user's report of:
-///
-///   - "drag an element with a `<feGaussianBlur>` filter, things get
-///     really laggy" — drag-frame wall-clock budget assertion,
-///   - "I can't select any other elements" after the first drag —
-///     second drag must actually start a new selection.
+/// Shared replay harness implementation for the `FilterDragRepro_*`
+/// tests. See `FilterDragReproTestUtils.h` for the contract.
 ///
 /// Replay is high-fidelity at the input boundary: we read mouse-down,
 /// mouse-move, and mouse-up events out of the `.donner-repro` file and
@@ -25,15 +17,20 @@
 /// replay player. When Stage 2 lands in full this harness collapses
 /// into `donner::editor::repro::ReplayPlayer`.
 
+#include "donner/editor/tests/FilterDragReproTestUtils.h"
+
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <optional>
 #include <sstream>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "donner/base/Transform.h"
@@ -54,8 +51,16 @@
 #include "donner/svg/renderer/RendererInterface.h"
 #include "gtest/gtest.h"
 
-namespace donner::editor {
+namespace donner::editor::filter_drag_repro {
 namespace {
+
+using ::donner::Entity;
+using ::donner::editor::AsyncRenderer;
+using ::donner::editor::EditorApp;
+using ::donner::editor::RenderCoordinator;
+using ::donner::editor::RenderRequest;
+using ::donner::editor::SelectTool;
+using ::donner::editor::ViewportState;
 
 // ---------------------------------------------------------------------------
 // Editor pane layout constants — mirrors `EditorShell.cc`.
@@ -71,11 +76,6 @@ constexpr double kInspectorPaneWidth = 320.0;
 // Typical ImGui menu-bar height under the project's style; matches the
 // live editor's top-of-pane offset within ~1px across platforms.
 constexpr double kMenuBarHeight = 20.0;
-
-struct ReplayConfig {
-  std::filesystem::path reproPath;
-  std::filesystem::path svgPath;
-};
 
 struct FrameTiming {
   uint64_t reproFrameIndex = 0;
@@ -155,25 +155,12 @@ struct ReplayState {
   bool leftButtonHeld = false;
 };
 
-// ---------------------------------------------------------------------------
-// Actually replay the recording through the full editor stack. Returns
-// per-frame timings so the caller can enforce budget assertions.
-// ---------------------------------------------------------------------------
-
 struct ReplayResults {
   std::vector<FrameTiming> frames;
   std::vector<uint64_t> mouseDownFrameIndices;
   std::vector<uint64_t> mouseUpFrameIndices;
-  /// `selectedEntityAtFrame[i]` is the selection at the end of
-  /// `frames[i]`'s runFrame. `entt::null` means "nothing selected".
   std::vector<Entity> selectedEntityAtFrame;
-  /// Elements selected per mouse-up — one entry per mouse-up. `entt::null`
-  /// if the gesture ended without selecting anything (e.g. empty-space
-  /// click with no marquee hits).
   std::vector<Entity> selectionAfterMouseUp;
-  /// `id` attribute of each selected element post-mouse-up (or "<none>"),
-  /// and its nearest filter-bearing ancestor's id (or "<none>") — so a
-  /// failing budget test can tell the reader what the user actually hit.
   std::vector<std::string> selectionElementIds;
   std::vector<std::string> selectionFilterAncestorIds;
   uint64_t fastPathFrames = 0;
@@ -215,10 +202,6 @@ ReplayResults ReplayRepro(const std::filesystem::path& reproPath,
   viewport.documentViewBox = *app.document().document().svgElement().viewBox();
   viewport.resetTo100Percent();
 
-  // Configure the document's canvas size to match the viewport's
-  // device-pixel target. The real shell does this in `EditorShell::
-  // runFrame` via `interactionController_.updatePaneLayout` -> the
-  // async-render request pipeline; here we do it directly.
   app.document().document().setCanvasSize(viewport.desiredCanvasSize().x,
                                           viewport.desiredCanvasSize().y);
 
@@ -231,20 +214,13 @@ ReplayResults ReplayRepro(const std::filesystem::path& reproPath,
 
     const auto frameStart = std::chrono::steady_clock::now();
 
-    // Compute document-space mouse position. Repro coords are logical
-    // window pixels; the pane is offset from the window origin.
     const Vector2d mouseScreen(frame.mouseX, frame.mouseY);
     const Vector2d mouseDoc = viewport.screenToDocument(mouseScreen);
     const bool wasHeld = state.leftButtonHeld;
     const bool nowHeld = (frame.mouseButtonMask & 1) != 0;
 
-    // Dispatch discrete events first (matches EditorInputBridge ordering).
     for (const auto& e : frame.events) {
       if (e.kind == repro::ReproEvent::Kind::MouseDown && e.mouseButton == 0) {
-        // Only fire onMouseDown when the renderer is idle — the live
-        // editor gates mouse-down on `!asyncRenderer.isBusy()` (see the
-        // gated dispatch in EditorShell/EditorInputBridge). If the user
-        // clicks during a long render they see the click dropped.
         if (!renderCoordinator.asyncRenderer().isBusy()) {
           selectTool.onMouseDown(app, mouseDoc, /*modifiers=*/{});
           results.mouseDownFrameIndices.push_back(frame.index);
@@ -260,10 +236,6 @@ ReplayResults ReplayRepro(const std::filesystem::path& reproPath,
           const svg::SVGElement sel = *app.selectedElement();
           postSelect = sel.entityHandle().entity();
           selId = std::string(sel.id());
-          // Walk ancestors looking for a filter="..." attribute. If found,
-          // the leaf click is hitting a descendant of a filter group — the
-          // exact scenario where `CompositorController::promoteEntity`
-          // refuses because of `HasCompositingBreakingAncestor`.
           svg::SVGElement cursor = sel;
           while (auto parent = cursor.parentElement()) {
             if (parent->hasAttribute(xml::XMLQualifiedNameRef("filter"))) {
@@ -280,10 +252,6 @@ ReplayResults ReplayRepro(const std::filesystem::path& reproPath,
       }
     }
 
-    // Between a mouse-down and the matching mouse-up, the live editor
-    // calls `SelectTool::onMouseMove` once per frame the button is held
-    // so the drag tracks the cursor. Replay has to mirror that so the
-    // DOM transform mutation stream matches reality.
     if (nowHeld && wasHeld) {
       selectTool.onMouseMove(app, mouseDoc, /*buttonHeld=*/true);
     } else if (!nowHeld && wasHeld) {
@@ -292,10 +260,6 @@ ReplayResults ReplayRepro(const std::filesystem::path& reproPath,
     }
     state.leftButtonHeld = nowHeld;
 
-    // `flushFrame` drains the command queue (applying any `SetTransform`
-    // commands dispatched this frame). Gated on `!isBusy()` in the real
-    // shell — we mirror that gate since a queued command must wait for
-    // the render to finish before it can mutate the DOM.
     const auto flushStart = std::chrono::steady_clock::now();
     timing.wasBusy = renderCoordinator.asyncRenderer().isBusy();
     if (!timing.wasBusy) {
@@ -305,12 +269,6 @@ ReplayResults ReplayRepro(const std::filesystem::path& reproPath,
         std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - flushStart)
             .count();
 
-    // Request a render each frame (matches `RenderCoordinator::
-    // maybeRequestRender`'s behavior during an active drag). If the
-    // renderer was busy, we still drive a render this frame — the real
-    // shell's gate is "request new render IF idle", but here we block
-    // on the current one and then immediately issue a new one to
-    // measure steady-state frame cost.
     auto workerMs = DrainOneRender(renderCoordinator.asyncRenderer(), renderCoordinator.renderer(),
                                    app.document().document(), app, selectTool, version);
     ++version;
@@ -335,20 +293,73 @@ ReplayResults ReplayRepro(const std::filesystem::path& reproPath,
   return results;
 }
 
-// ---------------------------------------------------------------------------
-// THE TEST. Faithfully replays the user's repro and asserts the two
-// user-reported invariants: drag frames stay under a reasonable budget,
-// and selection changes correctly across the release between drag #1
-// and drag #2.
-// ---------------------------------------------------------------------------
+DragStats ComputeDragStats(const ReplayResults& r, uint64_t fromFrame, uint64_t toFrame) {
+  DragStats stats;
+  double sum = 0.0;
+  for (const auto& f : r.frames) {
+    if (f.reproFrameIndex > fromFrame && f.reproFrameIndex < toFrame && f.workerMs >= 0.0) {
+      sum += f.workerMs;
+      stats.maxWorkerMs = std::max(stats.maxWorkerMs, f.workerMs);
+      ++stats.frameCount;
+    }
+  }
+  if (stats.frameCount > 0) {
+    stats.avgWorkerMs = sum / stats.frameCount;
+  }
+  return stats;
+}
 
-TEST(FilterDragReproTest, ReplayOfUserRecordingMeetsDragBudgetAndSecondSelect) {
+void DumpHistogram(const ReplayResults& r, uint64_t fromFrame, uint64_t toFrame, const char* label) {
+  int buckets[6] = {0};  // <5, 5-15, 15-30, 30-60, 60-120, >=120
+  for (const auto& f : r.frames) {
+    if (f.reproFrameIndex <= fromFrame || f.reproFrameIndex >= toFrame || f.workerMs < 0.0) {
+      continue;
+    }
+    if (f.workerMs < 5)
+      buckets[0]++;
+    else if (f.workerMs < 15)
+      buckets[1]++;
+    else if (f.workerMs < 30)
+      buckets[2]++;
+    else if (f.workerMs < 60)
+      buckets[3]++;
+    else if (f.workerMs < 120)
+      buckets[4]++;
+    else
+      buckets[5]++;
+  }
+  std::cerr << "[FilterDragRepro] " << label << " worker-ms histogram:";
+  std::cerr << " <5=" << buckets[0];
+  std::cerr << " 5-15=" << buckets[1];
+  std::cerr << " 15-30=" << buckets[2];
+  std::cerr << " 30-60=" << buckets[3];
+  std::cerr << " 60-120=" << buckets[4];
+  std::cerr << " >=120=" << buckets[5] << "\n";
+}
+
+void DumpFirstFiveFrames(const ReplayResults& r, uint64_t fromFrame, uint64_t toFrame,
+                         const char* label) {
+  std::cerr << "[FilterDragRepro] " << label << " first 5 frames: ";
+  int printed = 0;
+  for (const auto& f : r.frames) {
+    if (f.reproFrameIndex <= fromFrame || f.reproFrameIndex >= toFrame || f.workerMs < 0.0) {
+      continue;
+    }
+    if (printed++ >= 5) break;
+    std::cerr << f.workerMs << "ms ";
+  }
+  std::cerr << "\n";
+}
+
+}  // namespace
+
+void RunFilterDragReproScenario(FilterDragReproResult* out) {
   const std::filesystem::path reproPath = "donner/editor/tests/filter_drag_repro.rnr";
   const std::filesystem::path svgPath = "donner_splash.svg";
 
   if (!std::filesystem::exists(reproPath) || !std::filesystem::exists(svgPath)) {
-    GTEST_SKIP() << "Required data files not available in runfiles: " << reproPath << " or "
-                 << svgPath;
+    out->skipped = true;
+    return;
   }
 
   ReplayResults r = ReplayRepro(reproPath, svgPath);
@@ -357,88 +368,27 @@ TEST(FilterDragReproTest, ReplayOfUserRecordingMeetsDragBudgetAndSecondSelect) {
       << "expected exactly two mouse-down events in the repro (first drag, second drag)";
   ASSERT_EQ(r.mouseUpFrameIndices.size(), 2u) << "expected two mouse-up events in the repro";
 
-  // Partition the per-frame timings into phases so budget assertions can
-  // target the steady-state drag portion of each gesture separately.
   const uint64_t firstDown = r.mouseDownFrameIndices[0];
   const uint64_t firstUp = r.mouseUpFrameIndices[0];
   const uint64_t secondDown = r.mouseDownFrameIndices[1];
   const uint64_t secondUp = r.mouseUpFrameIndices[1];
 
-  double firstDragWorkerSum = 0.0;
-  double firstDragWorkerMax = 0.0;
-  int firstDragFrameCount = 0;
-  double secondDragWorkerSum = 0.0;
-  double secondDragWorkerMax = 0.0;
-  int secondDragFrameCount = 0;
-  for (const auto& f : r.frames) {
-    if (f.reproFrameIndex > firstDown && f.reproFrameIndex < firstUp && f.workerMs >= 0.0) {
-      firstDragWorkerSum += f.workerMs;
-      firstDragWorkerMax = std::max(firstDragWorkerMax, f.workerMs);
-      ++firstDragFrameCount;
-    }
-    if (f.reproFrameIndex > secondDown && f.reproFrameIndex < secondUp && f.workerMs >= 0.0) {
-      secondDragWorkerSum += f.workerMs;
-      secondDragWorkerMax = std::max(secondDragWorkerMax, f.workerMs);
-      ++secondDragFrameCount;
-    }
-  }
-  ASSERT_GT(firstDragFrameCount, 0);
-  ASSERT_GT(secondDragFrameCount, 0);
-  const double firstAvg = firstDragWorkerSum / firstDragFrameCount;
-  const double secondAvg = secondDragWorkerSum / secondDragFrameCount;
+  out->firstDrag = ComputeDragStats(r, firstDown, firstUp);
+  out->secondDrag = ComputeDragStats(r, secondDown, secondUp);
+  ASSERT_GT(out->firstDrag.frameCount, 0);
+  ASSERT_GT(out->secondDrag.frameCount, 0);
 
-  std::cerr << "[FilterDragRepro] first drag: frames=" << firstDragFrameCount
-            << ", avg=" << firstAvg << " ms, max=" << firstDragWorkerMax << " ms\n";
-  std::cerr << "[FilterDragRepro] second drag: frames=" << secondDragFrameCount
-            << ", avg=" << secondAvg << " ms, max=" << secondDragWorkerMax << " ms\n";
+  std::cerr << "[FilterDragRepro] first drag: frames=" << out->firstDrag.frameCount
+            << ", avg=" << out->firstDrag.avgWorkerMs
+            << " ms, max=" << out->firstDrag.maxWorkerMs << " ms\n";
+  std::cerr << "[FilterDragRepro] second drag: frames=" << out->secondDrag.frameCount
+            << ", avg=" << out->secondDrag.avgWorkerMs
+            << " ms, max=" << out->secondDrag.maxWorkerMs << " ms\n";
 
-  // Dump a histogram of per-frame worker-ms to understand the distribution.
-  const auto dumpHistogram = [&](uint64_t fromFrame, uint64_t toFrame, const char* label) {
-    int buckets[6] = {0};  // <5, 5-15, 15-30, 30-60, 60-120, >=120
-    for (const auto& f : r.frames) {
-      if (f.reproFrameIndex <= fromFrame || f.reproFrameIndex >= toFrame || f.workerMs < 0.0) {
-        continue;
-      }
-      if (f.workerMs < 5)
-        buckets[0]++;
-      else if (f.workerMs < 15)
-        buckets[1]++;
-      else if (f.workerMs < 30)
-        buckets[2]++;
-      else if (f.workerMs < 60)
-        buckets[3]++;
-      else if (f.workerMs < 120)
-        buckets[4]++;
-      else
-        buckets[5]++;
-    }
-    std::cerr << "[FilterDragRepro] " << label << " worker-ms histogram:";
-    std::cerr << " <5=" << buckets[0];
-    std::cerr << " 5-15=" << buckets[1];
-    std::cerr << " 15-30=" << buckets[2];
-    std::cerr << " 30-60=" << buckets[3];
-    std::cerr << " 60-120=" << buckets[4];
-    std::cerr << " >=120=" << buckets[5] << "\n";
-  };
-  dumpHistogram(firstDown, firstUp, "first-drag");
-  dumpHistogram(secondDown, secondUp, "second-drag");
-
-  // Print the first 5 frames of each drag (captures the cold-frame +
-  // steady-state transition).
-  const auto dumpFirstN = [&](uint64_t fromFrame, uint64_t toFrame, const char* label) {
-    std::cerr << "[FilterDragRepro] " << label << " first 5 frames: ";
-    int printed = 0;
-    for (const auto& f : r.frames) {
-      if (f.reproFrameIndex <= fromFrame || f.reproFrameIndex >= toFrame || f.workerMs < 0.0) {
-        continue;
-      }
-      if (printed++ >= 5) break;
-      std::cerr << f.workerMs << "ms ";
-    }
-    std::cerr << "\n";
-  };
-  dumpFirstN(firstDown, firstUp, "first-drag");
-  dumpFirstN(secondDown, secondUp, "second-drag");
+  DumpHistogram(r, firstDown, firstUp, "first-drag");
+  DumpHistogram(r, secondDown, secondUp, "second-drag");
+  DumpFirstFiveFrames(r, firstDown, firstUp, "first-drag");
+  DumpFirstFiveFrames(r, secondDown, secondUp, "second-drag");
   std::cerr << "[FilterDragRepro] fast-path counters at end: fast=" << r.fastPathFrames
             << " slowWithDirty=" << r.slowPathFramesWithDirty << " noDirty=" << r.noDirtyFrames
             << "\n";
@@ -448,56 +398,17 @@ TEST(FilterDragReproTest, ReplayOfUserRecordingMeetsDragBudgetAndSecondSelect) {
   std::cerr << "[FilterDragRepro] secondSel id=" << r.selectionElementIds[1]
             << " filterAncestor=" << r.selectionFilterAncestorIds[1] << "\n";
 
-  // Selection invariant: after the first mouse-up, ONE element must be
-  // selected (the first drag's target). The second mouse-down in the
-  // recording lands on a different location; it must hit-test, replace
-  // the selection, and produce a visible drag preview — the user's
-  // "I can't select any other elements" complaint is exactly the
-  // failure mode where the first drag's selection sticks because the
-  // new mouse-down was dropped (async renderer busy / first drag
-  // layer never demoted).
   ASSERT_EQ(r.selectionAfterMouseUp.size(), 2u);
-  const Entity firstSel = r.selectionAfterMouseUp[0];
-  const Entity secondSel = r.selectionAfterMouseUp[1];
-  EXPECT_TRUE(firstSel != entt::null)
-      << "first drag ended without a latched selection — hit-test missed or gesture aborted";
-  EXPECT_TRUE(secondSel != entt::null)
-      << "second mouse-down never produced a selection — user's 'can't select anything else' "
-         "complaint exactly";
-  EXPECT_TRUE(firstSel != secondSel)
-      << "second drag's selection did not differ from the first — second mouse-down was ignored "
-         "(likely dropped because async renderer stayed busy through the entire repro window)";
+  out->firstSelection = r.selectionAfterMouseUp[0];
+  out->secondSelection = r.selectionAfterMouseUp[1];
+  out->firstSelectionId = r.selectionElementIds[0];
+  out->firstSelectionFilterAncestorId = r.selectionFilterAncestorIds[0];
+  out->secondSelectionId = r.selectionElementIds[1];
+  out->secondSelectionFilterAncestorId = r.selectionFilterAncestorIds[1];
 
-  // Drag-budget invariants. The per-worker `workerMs` is the wall
-  // clock spent inside `CompositorController::renderFrame`. With the
-  // compositing-group elevation + `skipMainComposeDuringSplit` fast
-  // path both active, observed steady-state drag frames on this splash
-  // run at ~2 ms avg on dev hardware but ~40-50 ms avg on shared GitHub
-  // CI runners. Widened the wall-clock budgets to tolerate CI shape
-  // while still catching the "really laggy" regression (100+ ms frames)
-  // the user originally reported at ~250 ms / frame. Observed worst-
-  // frame spikes on shared GitHub CI Mac runners land ~165 ms typical,
-  // with single-outlier excursions past 200 ms (saw 218.8 ms on
-  // 2026-04-21, CI main #24742526232) — raised max to 300 ms so the
-  // gate tolerates cold-frame + runner-scheduling noise. The primary
-  // regression gates are the avg budget (80 ms — catches "every frame
-  // laggy") and the fast-path counter check below (CPU-speed-invariant).
-  // The max budget only has to catch pathological multi-frame stalls
-  // well above any observed CI noise. The proper structural fix here
-  // is to split this test via `donner_perf_cc_test` so the wall-clock
-  // assertions move to the nightly `perf` target; tracked for a
-  // follow-up PR.
-  constexpr double kDragWorkerAvgBudgetMs = 80.0;
-  constexpr double kDragWorkerMaxBudgetMs = 300.0;
-  EXPECT_LT(firstAvg, kDragWorkerAvgBudgetMs)
-      << "first drag (recorded as 'laggy'): avg worker ms exceeds budget — drag is re-running "
-         "the heavy full-document render pipeline every frame";
-  EXPECT_LT(firstDragWorkerMax, kDragWorkerMaxBudgetMs)
-      << "first drag: worst-frame worker ms exceeds budget";
-  EXPECT_LT(secondAvg, kDragWorkerAvgBudgetMs) << "second drag: avg worker ms exceeds budget";
-  EXPECT_LT(secondDragWorkerMax, kDragWorkerMaxBudgetMs)
-      << "second drag: worst-frame worker ms exceeds budget";
+  out->fastPathFrames = r.fastPathFrames;
+  out->slowPathFramesWithDirty = r.slowPathFramesWithDirty;
+  out->noDirtyFrames = r.noDirtyFrames;
 }
 
-}  // namespace
-}  // namespace donner::editor
+}  // namespace donner::editor::filter_drag_repro

--- a/donner/editor/tests/FilterDragReproTestUtils.h
+++ b/donner/editor/tests/FilterDragReproTestUtils.h
@@ -20,8 +20,6 @@
 #include <cstdint>
 #include <string>
 
-#include "donner/base/EcsRegistry_fwd.h"
-
 namespace donner::editor::filter_drag_repro {
 
 struct DragStats {
@@ -43,9 +41,13 @@ struct FilterDragReproResult {
   DragStats firstDrag;
   DragStats secondDrag;
 
-  // Selection invariants — the entity selected after each mouse-up.
-  donner::Entity firstSelection{};
-  donner::Entity secondSelection{};
+  // Selection invariants — did each mouse-up produce a selection, and
+  // did the second mouse-up end up on a different entity than the first?
+  // (The entity values themselves aren't useful to assert on by name;
+  // the invariant the user cares about is "new drag, new selection".)
+  bool firstSelectionExists = false;
+  bool secondSelectionExists = false;
+  bool selectionChangedAcrossDrags = false;
 
   // Diagnostic identifiers mirrored from the live editor, surfaced so
   // failing-test output tells the reader which element the user hit

--- a/donner/editor/tests/FilterDragReproTestUtils.h
+++ b/donner/editor/tests/FilterDragReproTestUtils.h
@@ -1,0 +1,76 @@
+#pragma once
+/// @file
+///
+/// Shared replay harness for the `FilterDragRepro_*` tests. The harness
+/// exercises the full editor stack (EditorApp + SelectTool +
+/// RenderCoordinator + AsyncRenderer) against the checked-in
+/// `filter_drag_repro.rnr` recording against `donner_splash.svg`, and
+/// returns aggregated per-gesture stats.
+///
+/// The scenario is split across two paired test targets produced by
+/// `donner_perf_cc_test`:
+///   - `filter_drag_repro_tests_correctness` — CPU-invariant
+///     assertions (fast-path counters, selection invariants). Runs on
+///     the default PR gate via `bazel test //...`.
+///   - `filter_drag_repro_tests_wallclock` — wall-clock budget
+///     assertions. Tagged `manual` + `perf` so it runs in the nightly
+///     `perf` lane, not on the PR gate where shared GitHub CI runners
+///     make per-frame wall-clock measurements flaky.
+
+#include <cstdint>
+#include <string>
+
+#include "donner/base/EcsRegistry_fwd.h"
+
+namespace donner::editor::filter_drag_repro {
+
+struct DragStats {
+  int frameCount = 0;
+  double avgWorkerMs = 0.0;
+  double maxWorkerMs = 0.0;
+};
+
+/// Aggregated result of replaying `filter_drag_repro.rnr` through the
+/// real editor stack. `skipped == true` means required data files were
+/// missing in runfiles and the caller should `GTEST_SKIP()` — the other
+/// fields are meaningless in that case.
+struct FilterDragReproResult {
+  bool skipped = false;
+
+  // Per-gesture drag stats, computed over the frames strictly between
+  // the mouse-down and mouse-up of each gesture (so cold mouse-down /
+  // mouse-up frames are excluded).
+  DragStats firstDrag;
+  DragStats secondDrag;
+
+  // Selection invariants — the entity selected after each mouse-up.
+  donner::Entity firstSelection{};
+  donner::Entity secondSelection{};
+
+  // Diagnostic identifiers mirrored from the live editor, surfaced so
+  // failing-test output tells the reader which element the user hit
+  // and which filter ancestor was in scope.
+  std::string firstSelectionId;
+  std::string firstSelectionFilterAncestorId;
+  std::string secondSelectionId;
+  std::string secondSelectionFilterAncestorId;
+
+  // CPU-speed-invariant compositor counters — the primary regression
+  // signal that the translation-only fast path is active.
+  uint64_t fastPathFrames = 0;
+  uint64_t slowPathFramesWithDirty = 0;
+  uint64_t noDirtyFrames = 0;
+};
+
+/// Replay the checked-in recording and populate `out`. Also streams the
+/// standard diagnostic log lines (per-gesture avg/max, histograms, first
+/// 5 frames, fast-path counters, selection ids) to `std::cerr` so both
+/// paired tests produce the same operator-facing log output.
+///
+/// Uses `ASSERT_*` internally; if an assertion trips, `out->skipped`
+/// stays false and the caller's test is halted by the assertion flow.
+/// On genuine "files missing in runfiles", sets `out->skipped = true`
+/// and returns without asserting — the caller issues `GTEST_SKIP()`.
+void RunFilterDragReproScenario(FilterDragReproResult* out);
+
+}  // namespace donner::editor::filter_drag_repro

--- a/donner/editor/tests/FilterDragReproWallclock_tests.cc
+++ b/donner/editor/tests/FilterDragReproWallclock_tests.cc
@@ -1,0 +1,54 @@
+/// @file
+///
+/// Wall-clock budget assertions for the `filter_drag_repro` replay.
+/// These numbers are runner-speed-dependent — the same scenario runs
+/// at ~2 ms/frame on dev hardware and 40-50 ms/frame avg (with
+/// single-outlier excursions past 200 ms) on shared GitHub CI
+/// runners. Put them in the `_wallclock` target (tagged `manual` +
+/// `perf`) so they run in the nightly `perf` lane instead of on every
+/// PR.
+///
+/// The CPU-invariant portion — fast-path counters and selection
+/// invariants — lives in `FilterDragReproCorrectness_tests.cc` and
+/// does run on the PR gate.
+
+#include "donner/editor/tests/FilterDragReproTestUtils.h"
+#include "gtest/gtest.h"
+
+namespace donner::editor::filter_drag_repro {
+namespace {
+
+TEST(FilterDragReproWallclockTest, DragFramesStayUnderNightlyWallclockBudget) {
+  FilterDragReproResult r;
+  RunFilterDragReproScenario(&r);
+  if (r.skipped) {
+    GTEST_SKIP() << "Required data files not available in runfiles";
+  }
+
+  // Budgets tuned for the nightly lane where we can assume roughly
+  // dev-machine-class runners. The numbers here are intentionally
+  // tighter than the transitional thresholds that the PR-gated test
+  // used — this is where we actually want to catch regressions.
+  //
+  // The original user report was ~250 ms / frame avg during a drag on
+  // a `<g filter>` subtree. The primary gate is `avg`, not `max`:
+  // sustained laggy behavior is what the user perceives. The `max`
+  // gate catches single catastrophic frames but has to leave headroom
+  // for cold-frame + runner-scheduling noise.
+  constexpr double kDragWorkerAvgBudgetMs = 80.0;
+  constexpr double kDragWorkerMaxBudgetMs = 250.0;
+
+  EXPECT_LT(r.firstDrag.avgWorkerMs, kDragWorkerAvgBudgetMs)
+      << "first drag (recorded as 'laggy'): avg worker ms exceeds budget — drag is re-running "
+         "the heavy full-document render pipeline every frame";
+  EXPECT_LT(r.firstDrag.maxWorkerMs, kDragWorkerMaxBudgetMs)
+      << "first drag: worst-frame worker ms exceeds budget — a single frame did full-prepare "
+         "work instead of riding the fast path";
+  EXPECT_LT(r.secondDrag.avgWorkerMs, kDragWorkerAvgBudgetMs)
+      << "second drag: avg worker ms exceeds budget";
+  EXPECT_LT(r.secondDrag.maxWorkerMs, kDragWorkerMaxBudgetMs)
+      << "second drag: worst-frame worker ms exceeds budget";
+}
+
+}  // namespace
+}  // namespace donner::editor::filter_drag_repro


### PR DESCRIPTION
## Summary

Structural follow-up to the 5ab777742 hotfix that widened `FilterDragRepro`'s max wall-clock budget to keep main green. The replay test bundled CPU-invariant invariants (fast-path counters, selection-change) with runner-sensitive wall-clock drag-frame budgets — so shared GitHub macOS runners flaked the whole test on a single outlier frame (#24742526232, 218.8 ms vs 200 ms budget).

This is the proper fix per CLAUDE.md:

> New perf tests should use `donner_perf_cc_test` so CPU-invariant correctness counters stay on the PR gate while runner-sensitive wall-clock budgets move to nightly `perf` targets.

## Changes

- **`FilterDragReproTestUtils.{h,cc}`** — shared replay harness. Owns the editor-stack plumbing, `ReplayRepro`, stat aggregation, and the `[FilterDragRepro]` diagnostic log lines both paired tests emit.
- **`FilterDragReproCorrectness_tests.cc`** — fast-path counter + selection-change assertions. Runs on the default PR gate (`bazel test //...`).
- **`FilterDragReproWallclock_tests.cc`** — avg + max drag-frame wall-clock budgets. Tagged `manual` + `perf` via `donner_perf_cc_test`; only runs in the nightly `perf` lane.
- **`BUILD.bazel`** — `donner_cc_test` → `donner_perf_cc_test`.

Wallclock max tightens back to 250 ms (from the 300 ms the hotfix set) now that it's in the nightly lane where runners are dev-class.

## Test plan

- [x] `bazel test //donner/editor/tests:filter_drag_repro_tests_correctness` passes locally
- [x] `bazel test //donner/editor/tests:filter_drag_repro_tests_wallclock` passes locally
- [x] `bazel test //donner/editor/tests/...` — 56/56 pass
- [x] `python3 tools/cmake/gen_cmakelists.py --check` — mirror in sync
- [x] `bazel query` confirms correctness target is on default PR gate, wallclock target is `manual`-tagged
- [ ] CI passes on the PR