### PR TITLE
CI: dedupe duplicate push + pull_request runs

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main, feature/ci-hardening-2026q2]
 
+concurrency:
+  # See main.yml for rationale; same shared push/PR dedupe pattern.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   gatekeeper:
     runs-on: ubuntu-24.04

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,20 +6,41 @@ on:
   pull_request:
     branches: [main, feature/ci-hardening-2026q2]
 
-concurrency:
-  # See main.yml for rationale; same shared push/PR dedupe pattern.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}
-  cancel-in-progress: true
-
 jobs:
   gatekeeper:
     runs-on: ubuntu-24.04
     outputs:
       docs_only: ${{ steps.docs_only.outputs.docs_only }}
+      is_duplicate_push: ${{ steps.dup_push.outputs.is_duplicate_push }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - id: dup_push
+        name: Detect duplicate push (PR already open for this branch)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          # See main.yml for rationale; same dup-push detection.
+          if [[ "${{ github.event_name }}" != "push" ]]; then
+            echo "is_duplicate_push=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "is_duplicate_push=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          open_prs="$(gh pr list --repo "${{ github.repository }}" \
+            --state open --head "${{ github.ref_name }}" \
+            --json number -q 'length')"
+          if [[ "${open_prs}" -gt 0 ]]; then
+            echo "Skipping push CI: open PR already covers branch '${{ github.ref_name }}'"
+            echo "is_duplicate_push=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_duplicate_push=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - id: docs_only
         name: Detect docs-only PR
@@ -72,7 +93,7 @@ jobs:
   linux:
     runs-on: ubuntu-24.04
     needs: gatekeeper
-    if: ${{ github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true' }}
+    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') }}
     strategy:
       fail-fast: false
       matrix:
@@ -113,7 +134,7 @@ jobs:
   macos:
     runs-on: macos-15
     needs: gatekeeper
-    if: ${{ github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true' }}
+    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,8 +7,9 @@ on:
     branches: [main, feature/ci-hardening-2026q2]
 
 concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.workflow, github.event.pull_request.number) || format('push-{0}-{1}', github.workflow, github.run_id) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # See main.yml for rationale; same shared push/PR dedupe pattern.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
 
 # Fast lint jobs covering checks that don't live inside `bazel test //...`:
 #

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,9 +7,8 @@ on:
     branches: [main, feature/ci-hardening-2026q2]
 
 concurrency:
-  # See main.yml for rationale; same shared push/PR dedupe pattern.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}
-  cancel-in-progress: true
+  group: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.workflow, github.event.pull_request.number) || format('push-{0}-{1}', github.workflow, github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Fast lint jobs covering checks that don't live inside `bazel test //...`:
 #
@@ -18,9 +17,41 @@ concurrency:
 # - gen_cmakelists.py unit tests + full --check validator (reentrant bazel
 #   prevents running --check from inside bazel test; see design doc 0016)
 jobs:
+  gatekeeper:
+    runs-on: ubuntu-24.04
+    outputs:
+      is_duplicate_push: ${{ steps.dup_push.outputs.is_duplicate_push }}
+    steps:
+      - id: dup_push
+        name: Detect duplicate push (PR already open for this branch)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          # See main.yml for rationale; same dup-push detection.
+          if [[ "${{ github.event_name }}" != "push" ]]; then
+            echo "is_duplicate_push=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "is_duplicate_push=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          open_prs="$(gh pr list --repo "${{ github.repository }}" \
+            --state open --head "${{ github.ref_name }}" \
+            --json number -q 'length')"
+          if [[ "${open_prs}" -gt 0 ]]; then
+            echo "Skipping push CI: open PR already covers branch '${{ github.ref_name }}'"
+            echo "is_duplicate_push=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_duplicate_push=false" >> "$GITHUB_OUTPUT"
+          fi
+
   lint:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
+    needs: gatekeeper
+    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -52,6 +83,8 @@ jobs:
   cmake-validate:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    needs: gatekeeper
+    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' }}
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,14 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.workflow, github.event.pull_request.number) || format('push-{0}-{1}', github.workflow, github.run_id) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Shared group between push and pull_request events on the same branch:
+  # `github.event.pull_request.head.ref` (PR) and `github.ref_name` (push) both
+  # resolve to the bare branch name, so a `git push` to a branch with an open PR
+  # races into the same group as the PR's synchronize event and one cancels the
+  # other. Push to a branch without an open PR still gets a fresh group, so
+  # feature branches keep CI coverage before the PR is opened.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
 
 # Retry policy: network-sensitive steps (checkout, apt install, bazel fetch)
 # are retried to survive transient GitHub/registry outages. Build/test steps

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,14 +9,8 @@ on:
     branches: [main]
 
 concurrency:
-  # Shared group between push and pull_request events on the same branch:
-  # `github.event.pull_request.head.ref` (PR) and `github.ref_name` (push) both
-  # resolve to the bare branch name, so a `git push` to a branch with an open PR
-  # races into the same group as the PR's synchronize event and one cancels the
-  # other. Push to a branch without an open PR still gets a fresh group, so
-  # feature branches keep CI coverage before the PR is opened.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}
-  cancel-in-progress: true
+  group: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.workflow, github.event.pull_request.number) || format('push-{0}-{1}', github.workflow, github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Retry policy: network-sensitive steps (checkout, apt install, bazel fetch)
 # are retried to survive transient GitHub/registry outages. Build/test steps
@@ -27,10 +21,41 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       docs_only: ${{ steps.docs_only.outputs.docs_only }}
+      is_duplicate_push: ${{ steps.dup_push.outputs.is_duplicate_push }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - id: dup_push
+        name: Detect duplicate push (PR already open for this branch)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          # When a `git push` lands on a branch that already has an open PR,
+          # GitHub fires both a `push` and a `pull_request` (synchronize) event,
+          # creating two parallel CI runs at the same SHA. We let the PR run do
+          # the work and skip the push run cleanly so it shows green-skipped
+          # instead of red-cancelled. Pushes to main, or to feature branches
+          # without an open PR, are NOT skipped.
+          if [[ "${{ github.event_name }}" != "push" ]]; then
+            echo "is_duplicate_push=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "is_duplicate_push=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          open_prs="$(gh pr list --repo "${{ github.repository }}" \
+            --state open --head "${{ github.ref_name }}" \
+            --json number -q 'length')"
+          if [[ "${open_prs}" -gt 0 ]]; then
+            echo "Skipping push CI: open PR already covers branch '${{ github.ref_name }}'"
+            echo "is_duplicate_push=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_duplicate_push=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - id: docs_only
         name: Detect docs-only PR
@@ -83,7 +108,7 @@ jobs:
   determine-targets:
     runs-on: ubuntu-24.04
     needs: gatekeeper
-    if: ${{ github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true' }}
+    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') }}
     env:
       BAZEL_DIFF_TAG: "v18.1.0"
     outputs:
@@ -217,7 +242,7 @@ jobs:
   linux:
     runs-on: ubuntu-24.04
     needs: [gatekeeper, determine-targets]
-    if: ${{ github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true' }}
+    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -271,7 +296,7 @@ jobs:
   macos:
     runs-on: macos-15
     needs: [gatekeeper, determine-targets]
-    if: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') }}
+    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Every PR currently triggers two parallel workflow runs per workflow file (main.yml, lint.yml, cmake.yml): one from the `push` event on the source branch and one from the `pull_request` event. The existing concurrency keys (`push-{run_id}` vs `pr-{number}`) put them in different groups, so neither cancelled the other — doubling CI compute on every PR push. You can see this clearly on PR #580: two `linux`, two `macos (tiny_skia)`, two `cmake-validate`, etc.

## Approach

Detect at the start of each workflow whether this is a `push` event whose branch already has an open PR. If so, skip the downstream jobs cleanly. Skipped jobs render green-skipped (rather than red-cancelled), so this avoids the misleading "Canceling since a higher priority waiting request ... exists" annotations that a concurrency-based approach produces.

- Add an `is_duplicate_push` output to the existing `gatekeeper` job in `main.yml` and `cmake.yml`; add a new `gatekeeper` to `lint.yml`.
- All downstream jobs gate on `needs.gatekeeper.outputs.is_duplicate_push != 'true'`.
- Pushes to `main` and to feature branches with no open PR are unaffected.

## Trade-off

There's still a one-time race when someone pushes a brand-new branch and then opens a PR — the original push run finishes (no PR existed at the time the gatekeeper ran), then the PR-open event triggers a fresh run. This is a single duplicate per PR creation and is acceptable.

## Test plan

- [ ] Push a follow-up commit to this PR and confirm the push-event workflow runs show "Skipping push CI: open PR already covers branch ..." and skipped downstream jobs (green status).
- [ ] Verify only the `pull_request`-event runs do real work.
- [ ] After merge: push to `main` still runs full CI.
- [ ] After merge: push a brand-new feature branch (no PR yet) still runs full CI.