### PR TITLE
Compositor: fix #582 fast-path drag + dragged-shape tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,9 @@ See `docs/design_docs/0016-ci_escape_prevention.md` for the full rationale behin
 - Docs: follow `docs/AGENTS.md`, use templates under `docs/design_docs/`. Run `tools/doxygen.sh` to regenerate.
 - **All code changes should include tests.** Use gMock/gTest. Add fuzzers for parser paths when practical.
 - Fix root causes, not symptoms; include necessary error handling without asking. Mainline must stay green — investigate failures rather than dismissing them as pre-existing.
+- **No dead code, refactor in-place.** Modify existing types/functions/modules step by step — do NOT build a parallel new implementation alongside the old one with the intent to "switch over later." Orphaned `.cc`/`.h` whose only consumers are their own tests are dead code and must be deleted in the same commit that severs their last live caller. See `CLAUDE.md` §"No Dead Code, Refactor In-Place" for the policy that drives this.
+- **Pixel-diff tests use `donner/editor/tests:bitmap_golden_compare` (`CompareBitmapToBitmap` / `CompareBitmapToGolden`) + pixelmatch.** No private `composeOver` helpers; no percentage-divergence thresholds — either identity or inspectable `actual_*`/`expected_*`/`diff_*.png` under `$TEST_UNDECLARED_OUTPUTS_DIR`. See `CLAUDE.md` §"Pixel-Diff Tests".
+- **Regression tests must fail at HEAD before the fix lands.** Commit the failing test on its own commit first so CI records a red→green transition. See `CLAUDE.md` §"Debugging Discipline" and §"Bug-Fix Commit Discipline".
 
 ## Building
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,14 @@ cmake -S . -B build -DDONNER_BUILD_TESTS=ON && cmake --build build -j$(nproc) &&
 
 ## Transform Naming Convention
 
-Use **destFromSource** naming: `entityFromWorldTransform`, `deviceFromPattern`, `canvasFromDocumentWorldTransform_`. Always `destFromSource` form (e.g., `localFromDevice`, not `deviceToLocal`).
+Use **destFromSource** naming for every `Transform2d` — locals, fields, parameters, struct members, return values, everything. The destFromSource name *is* the documentation; a value whose direction lives only in a comment will eventually be composed wrong.
+
+- ✅ `entityFromWorldTransform`, `deviceFromPattern`, `canvasFromDocumentWorldTransform_`, `bitmapEntityFromEntity`, `worldFromPreviousWorld`.
+- ❌ `delta`, `xform`, `transform`, `mat`, `t`, `temp` — and `deviceToLocal` / `worldToEntity` (wrong direction word).
+
+Composition reads right-to-left under donner's post-multiply convention: `A_from_B * B_from_C` produces `A_from_C` (rightmost applied first). If your composition doesn't spell out a valid `dest_from_source` chain when you read the names, the math is wrong.
+
+Inverses get the swapped name: `bitmapEntityFromWorld.inverse()` is `worldFromBitmapEntity`. Don't keep the original name on a local that holds the inverse.
 
 ## Feature Flags & Build Configurations
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,9 +26,28 @@
 
 When debugging bugs — **especially performance or UI bugs** — write an automated test that reproduces the bug BEFORE attempting a fix. No fixes without repros.
 
+- **A regression test is only valid if it FAILED on the broken code.** Run the test at HEAD *before* applying the fix, capture the failure output (diff PNG, pixel count, error) and verify it matches the user-reported symptom. Commit the test on its own commit first so CI records a red→green transition. If you can't get the test to fail at HEAD, the test is wrong — not the bug. "Plausible-sounding fix without a red→green transition" is an attempt, not a fix — title the commit `attempt:` / `hypothesis:` and do not mark the issue closed.
+- **User pushback is automatic evidence the test was wrong.** When the user reports a bug is still present after a claimed fix, the default response is "the test that verifies my fix is wrong or missing — writing a new one." Never reply with "I don't see why it would still be broken" or ask the user to re-confirm steps. The user's repro *is* the signal; your test is what needs debugging.
 - **Perf bugs**: the repro must measure the exact latency the user observes (e.g. click-to-first-pixel wall-clock, per-frame time). Put explicit budget assertions in the test (`EXPECT_LT(measured_ms, budget_ms)`) so regressions trip loudly. New perf tests should use `donner_perf_cc_test` so CPU-invariant correctness counters stay on the PR gate while runner-sensitive wall-clock budgets move to nightly `perf` targets. Don't settle for "works on my laptop" — the test itself is the verification.
-- **UI bugs**: if the bug only manifests through the full editor event loop (mouse events, ImGui state, worker-thread ping-pong), write an instrumented UI-layer test that drives `AsyncRenderer`/`AsyncSVGDocument`/`RenderCoordinator` with the exact request-posting sequence the editor uses. Faithfully mirror the event flow — do not fabricate a prewarm phase that the real editor doesn't fire.
+- **UI bugs**: if the bug only manifests through the full editor event loop (mouse events, ImGui state, worker-thread ping-pong), write an instrumented UI-layer test that drives the live backend path (`EditorBackendCore` + `CompositorController`) with the exact request-posting sequence the editor uses. Faithfully mirror the event flow — do not fabricate a prewarm phase that the real editor doesn't fire.
 - **Iterating without a repro** wastes everyone's time. A bug you can't reproduce automatically is a bug you can't fix; a fix you can't verify automatically is a fix you can't ship. Manual "please run it and tell me what you see" cycles are a last resort, not a primary workflow.
 - Reference tests:
-  - `donner/editor/tests/AsyncRenderer_tests.cc`'s `AsyncRendererE2ETest` suite — examples of the full editor-flow harness (cold render → click-then-drag → steady-state drag frames, with wall-clock budgets).
-  - `donner/svg/compositor/CompositorGolden_tests.cc`'s `SplashDrag*` tests — examples of compositor-level perf gates on the real `donner_splash.svg` via the `data` dep.
+  - `donner/editor/sandbox/tests/EditorBackendGoldenImage_tests.cc`'s `FilterDisappearRepro7*` suite — full thin-client flow (`.rnr` → `EditorBackendCore` → pixelmatch diff vs `svg::Renderer::draw`) with inspectable diff PNGs.
+  - `donner/svg/compositor/CompositorGolden_tests.cc`'s `SplashDrag*` tests — compositor-level perf gates on the real `donner_splash.svg` via the `data` dep.
+
+## Pixel-Diff Tests
+
+- **Use `donner/editor/tests:bitmap_golden_compare`** (`CompareBitmapToBitmap` / `CompareBitmapToGolden`) + pixelmatch for every bitmap comparison. Do NOT roll a private `composeOver` / `CompositeOver` / `CountDifferingPixelsInRect` helper in the test file — those "boutique" comparators hid bug #582 behind a 5% threshold for weeks.
+- **Do NOT use percentage thresholds.** They mask regressions smaller than the threshold and scale with scene size. Either the diff is zero (identity) or the test writes `actual_*.png` / `expected_*.png` / `diff_*.png` to `$TEST_UNDECLARED_OUTPUTS_DIR` for operator inspection.
+- If a new pixel-diff test needs composition the helper library doesn't provide, extend `bitmap_golden_compare` — do not inline a private variant in the test.
+
+## Bug-Fix Commit Discipline
+
+- **Commits claiming `Fixes #NNN` / `closes #NNN` must name a test file + test name that failed at the parent commit and passes at this commit.** If the test was introduced in the same PR, an earlier commit in the series must show it failing (red→green sequence on the branch).
+- **"Plausible-sounding fix without a documented red→green transition" is an attempt, not a fix.** Use `attempt:` or `hypothesis:` in the commit subject and do NOT close the issue — a human reviewer decides when the evidence is sufficient.
+
+## No Dead Code, Refactor In-Place
+
+- **Never leave dark or dead code.** Orphaned `.cc`/`.h` files whose only callers are their own tests are dead code per the always-green-main rule. They pass CI (their tests still work), but they actively harm debugging — investigators grep for symbols that no live binary executes and burn hours chasing ghosts. The `EditorShell` / `GlTextureCache` / `RenderPanePresenter` / `ExperimentalDragPresentation` cluster that soaked up weeks of the #582 investigation is the worst-case example.
+- **Refactoring must be incremental and in-place.** Modify the existing type/function/module step by step, landing each step on `main`. Do NOT build a parallel new implementation alongside the old one with the intent to "switch over later" — the old path inevitably persists, accumulates "we'll delete this in the migration" TODOs, diverges, and becomes the dark-code trap above. If the change really is too large for an in-place sequence, write a design doc describing the migration strategy and the deletion milestones, and hold each deletion as a blocking gate.
+- **A rebase/merge commit that enumerates "deleted files" must actually delete them.** The `Category A (deleted files kept deleted)` pattern (60052563) is banned — either land the deletions in the same commit, or open a tracking issue for each orphaned path and link it so the omission is visible.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,10 @@
 - **When touching the CMake mirror or `gen_cmakelists.py`, also run `python3 tools/cmake/gen_cmakelists.py --check --build`.** Plain `--check` is intentionally fast and static; `--build` is the opt-in local compile gate that catches real CMake drift before CI does.
 - The `tiny`, `text-full`, and `geode` variant lanes now run as `*_tiny` / `*_text_full` / `*_geode` wrappers under default `bazel test //...` (see `donner_cc_test(variants=…)` in `build_defs/rules.bzl`). The transitional `tools/presubmit.sh` wrapper has been retired — `bazel test //...` is the single command that gates a PR.
 
+## Transform Naming
+
+- **Every `Transform2d` local, field, parameter, and struct member must be named in `destFromSource` form** — e.g., `bitmapEntityFromEntity`, `worldFromPreviousWorld`, `canvasFromDocument`. Names like `delta`, `xform`, `t`, `transform`, `mat` are banned: the destFromSource name *is* the documentation, and a value whose direction is encoded only in a comment will be composed wrong the first time it's reused. See `AGENTS.md` §"Transform Naming Convention" for the full rule and rationale.
+
 ## Formatting
 
 - **Run `clang-format -i` on every modified C/C++ file before committing.** `git clang-format` covers staged changes. The project `.clang-format` (Google + 100-col, see `.clang-format`) is tuned so clang-format 18 and 19 produce identical output — use whichever is on your `$PATH`.

--- a/docs/design_docs/0025-composited_rendering.md
+++ b/docs/design_docs/0025-composited_rendering.md
@@ -2137,3 +2137,273 @@ the root cause is found — no rebuild required.
    `takeSnapshot()` → `drawImage()` paths** — this is a pre-existing
    correctness bug independent of the compositor. Fix alongside the
    tier-1 `AlphaType` adapter work.
+
+## Postmortem — #582: Fast-path subtree propagation accumulated deltas across drag frames
+
+### Summary
+
+A subtle correctness bug in `CompositorController`'s translation-only
+fast path drifted the rendered position of subtree-promoted layers
+(the canonical case: `<g filter>` groups) away from the DOM-truth
+position over consecutive drag frames. A 50-frame drag of splash's
+`#Big_lightning_glow` produced a backend bitmap that diverged from
+a direct re-render by ~16,000 pixels — a visually obvious
+"mispositioned filter" at the end of the drag.
+
+The bug was user-visible, consistently reproducible by hand, and
+survived **four rounds of speculative "fixes"** (commits
+`8e7ec375`, `5fb1acc8`, plus two reverted attempts) spanning
+multiple weeks before the actual root cause was isolated. Each
+of those speculative fixes was merged in good faith and claimed
+to close the issue in its commit message. None of them did.
+
+The final fix is three lines at `CompositorController.cc:738-740`
+(`53780152`): compute a per-frame delta separately from the
+stamp-relative delta, and pass the per-frame delta to the subtree
+propagation.
+
+### Root cause
+
+The fast path for subtree-promoted layers called
+`propagateFastPathTranslationToSubtree(registry, res.entity, res.delta)`
+at `CompositorController.cc:735` (pre-fix), where `res.delta` is
+`newWorldFromEntity * bitmapEntityFromWorldTransform^-1` — the
+cumulative delta **since the bitmap was stamped**. That's the right
+value for `setCanvasFromBitmap`: the layer's compose offset is
+relative to its stamp, so the full cumulative translation lands
+the bitmap at the current DOM position.
+
+But it is the **wrong** value for subtree propagation.
+`propagateFastPathTranslationToSubtree` left-composes its argument
+onto each descendant's *current*
+`RenderingInstanceComponent::worldFromEntityTransform`:
+
+```cpp
+instance->worldFromEntityTransform =
+    delta * instance->worldFromEntityTransform;
+```
+
+The descendant's `worldFromEntityTransform` had already been
+translated on previous drag frames. Left-composing the
+cumulative-since-stamp delta on top re-applied every prior frame's
+drag on top of itself. After N frames of drag with per-frame
+deltas `d_1, d_2, …, d_N`:
+
+- Expected descendant transform: `C * (I + d_N)` (scale + one
+  copy of the cumulative translation).
+- Actual descendant transform: `C * (I + d_N + d_{N-1} + … + d_1)`
+  — up to N-fold over-translation in the worst case.
+
+The layer ROOT was fine because `res.layer->setCanvasFromBitmap(res.delta)`
+overwrote its compose offset every frame (no accumulation on
+that path). Only descendants — which the fast path mutates to
+keep their RICs in sync so the slow-path / rasterize paths still
+work — accumulated the drift.
+
+### Why "dual-path debug assertion" didn't catch this
+
+The design doc's **§"Verification Strategy"** guarantees
+pixel-identical correctness via a runtime debug assertion
+(`CompositorConfig::verifyPixelIdentity`) that captures the
+composited output, runs a full-document reference render, and
+diffs pixel-by-pixel. The doc's §Reversibility promises: "the
+compositor can never silently produce wrong pixels — any
+regression is caught immediately."
+
+That guarantee did not hold for this bug. Three reasons:
+
+1. **The assertion is off by default.** `verifyPixelIdentity`
+   defaults to `false` (see `CompositorConfig`) and costs 2×
+   frame time when on. No CI target turns it on for interactive
+   drag sequences; the compositor's dedicated tests turn it on
+   for synthetic scenes, but none of those exercise the
+   "subtree-promoted layer + many consecutive drag frames on a
+   real splash-scale document" case.
+
+2. **The assertion runs inside `renderFrame`.** It compares
+   compositor output against a `RendererDriver::draw(document)`
+   reference on the same frame. But the bug manifests only after
+   the subtree propagation has been applied N times — and the
+   reference path reads the **same already-drifted
+   `worldFromEntityTransform` values** that the compositor
+   just wrote. Both paths converge on the same wrong answer.
+   The assertion would only catch this bug if the reference
+   path recomputed `worldFromEntityTransform` from scratch via
+   `LayoutSystem`, bypassing the RICs. It doesn't.
+
+3. **No test exercised the exact trigger.** The bug requires:
+   (a) a subtree-promoted layer (triggers
+   `propagateFastPathTranslationToSubtree`), (b) multiple
+   consecutive drag frames on the same entity (triggers the
+   accumulation), and (c) a comparison against an authoritative
+   post-drag DOM state (triggers the visible divergence). The
+   existing golden tests had (a) and (b) but compared against
+   **committed PNG goldens generated from the compositor's own
+   output** — so any drift that was consistent across runs would
+   lock into the golden on first generation.
+
+### Why the bug survived four speculative fixes
+
+Each attempted fix was plausible because it matched *a* detail
+of the user's symptom (filter disappearing / shifting /
+appearing clipped). None of them were verified against the
+actual bug because **no automated test existed that could fail
+on the bug**. Fixes were merged, I asserted the bug was closed,
+the user pushed back within a day or two, and the cycle
+repeated.
+
+The specific anti-patterns that made each iteration feel like
+progress but weren't:
+
+- **Boutique CPU-composition helpers in tests.** The initial
+  regression tests re-implemented alpha-over composition with a
+  private `CompositeOver` helper in the test file itself, then
+  diffed the result against a re-raster ground truth with a
+  **percentage-divergence threshold** (e.g. "< 5% of the filter's
+  bounding region"). A bug that visually moved the whole filter
+  by a few pixels stayed within 5% because the filter's opaque
+  area is only a fraction of its bounding box — the test
+  reported "PASS" at 1.8% diff on a scenario that was actually
+  showing the exact bug.
+
+- **Investigation chasing the wrong architecture.** For several
+  sessions, investigation focused on `GlTextureCache` /
+  `RenderPanePresenter` / `ExperimentalDragPresentation` —
+  classes whose file paths still existed in the tree but which
+  had been orphaned from the live binary by the thin-client
+  migration (`60052563`). Hypotheses about
+  `GlTextureCache::promotedTranslationDoc_` entity desync,
+  `PromotedTextureScreenOffset` rounding, and drag-target-swap
+  state machine transitions all looked plausible given the
+  symptom — and were **investigated against code that no live
+  binary ever executes**. The bug was in a completely different
+  file from any of the hypotheses.
+
+- **Fixes motivated by a single crash-adjacent detail.**
+  Commit `8e7ec375` ("reset `canvasFromBitmap_` inside
+  `setBitmap`") and `5fb1acc8` ("size compositor viewport to
+  `doc.canvasSize()`") each fixed a real issue — a real
+  double-offset on re-rasterize, a real canvas-size mismatch —
+  but neither was the dominant contributor to #582. They were
+  found by reasoning about the compositor's data flow, not by
+  running a failing test. The subsequent claim that each "fixed
+  #582" was based on "I don't see an obvious reason it would
+  still be broken," not on a reproducer that went green.
+
+### What finally worked
+
+Four things, in order:
+
+1. **Deleted the dead code.** `0783e821` removed ~10k LOC of the
+   old `EditorShell` / `RenderPanePresenter` / `GlTextureCache`
+   path that was orphaned in the 60052563 rebase but still had
+   test suites passing. This eliminated the entire class of
+   "investigate the wrong architecture" failures and forced
+   subsequent investigation onto the live thin-client path.
+
+2. **Wrote a test that actually reproduced the bug.** `a7788beb`
+   added `FilterDisappearRepro7BackendBitmapMatchesDirectRender`:
+   replay `filter_elm_disappear-7.rnr` through the live
+   `EditorBackendCore::handlePointerEvent`, capture
+   `FramePayload.finalBitmapPixels` at each mup, diff against a
+   fresh `svg::Renderer::draw(doc)` of the backend's current
+   DOM via pixelmatch, dump inspectable `actual_` / `expected_` /
+   `diff_` PNGs on failure. No boutique composition math, no
+   percentage thresholds. The first time the test ran it
+   failed with 15,000-19,000 pixels of divergence at every
+   post-interaction checkpoint — exactly matching the user's
+   report.
+
+3. **Bisected with a test-only kill-switch.** `923f63db` added
+   `EditorBackendCore::setCpuComposeEnabledForTesting(bool)` and
+   paired it with a second test that forces the main-renderer
+   compose path. Both variants diverged by the same pixel count —
+   ruling out the CPU compose path (which had been my previous
+   top suspect) in one test run.
+
+4. **Frame-by-frame bisection pinpointed the first bad frame.**
+   `b8c3c251` added `SplashFilterDragPerFrameDivergence`, which
+   counted divergent pixels after every single event in a
+   synthesized drag. The log showed divergence flat at the
+   chrome baseline (~2,940 px) through mv#1-6, then jumping
+   to 10,475 px at mv#7 — the exact frame where SelectTool's
+   drag-activation threshold first mutated filter-g's transform
+   and the fast-path first fired. From there it grew
+   monotonically as the accumulation compounded. That single
+   log line localized the bug to ±5 lines of code in the
+   fast-path loop.
+
+### Lessons
+
+1. **A runtime debug assertion is not a substitute for a test
+   that fails on the bug.** `verifyPixelIdentity`'s design guarantee
+   assumed the reference path would be authoritative — but it
+   shares RIC storage with the compositor. The dual-path assertion
+   should either recompute RIC state from `LayoutSystem` before
+   each reference render, OR be supplemented by a test that reads
+   the DOM from outside the compositor's run (i.e. an external
+   process, which is what the new `FilterDisappearRepro7Backend*`
+   tests effectively are).
+
+2. **Test-private alpha-over is a trap.** Any future compositor
+   regression test that needs to diff bitmaps must go through
+   `BitmapGoldenCompare::CompareBitmapToBitmap` (or the existing
+   golden-PNG path), not a private `CompositeOver` helper. The
+   `BitmapGoldenCompare` path produces operator-inspectable
+   `actual_` / `expected_` / `diff_` PNGs on mismatch; a private
+   helper with a percentage threshold produces an uninspectable
+   number.
+
+3. **"Plausible fix" is not a merge criterion.** When a user
+   reports a bug still reproduces after a fix, the default
+   response must be "the test that allegedly verifies my fix is
+   wrong or missing" — not "I don't see why it would still be
+   broken." The test that landed with `a7788beb` should have
+   been written **before** `8e7ec375` or `5fb1acc8`; both would
+   have been exposed as non-fixes the moment the test ran.
+
+4. **Dead code is actively harmful during debugging.** The
+   orphaned frontend classes (EditorShell, GlTextureCache,
+   RenderPanePresenter, ExperimentalDragPresentation) survived
+   in the tree because their tests still passed. They soaked
+   up weeks of investigation because they matched the symptom
+   lexically ("drag-target swap stale textures", "promoted-layer
+   compose offset") without being in the live execution path.
+   The rebase commit (60052563) listed these for deletion and
+   called them "kept deleted" — but the deletion itself didn't
+   land. That alone should have been a process gate: a rebase
+   commit claiming to delete code must include the deletion, or
+   the architecture migration isn't actually complete.
+
+5. **Fast-path delta semantics need to be named explicitly.** The
+   `res.delta` variable meant "cumulative-since-stamp", but the
+   name gave no hint, and the code used it in two places that
+   wanted different things. A follow-up refactor should rename
+   `res.delta` to `res.stampDelta` and the computed
+   `perFrameDelta` to `res.perFrameDelta`, and document at the
+   `FastPathResolution` struct definition which consumers need
+   which delta. The cost of the bug was dominated by the two
+   names that didn't exist — if the code had said `stampDelta`
+   at line 671 and `perFrameDelta` somewhere, a reviewer would
+   have noticed both being used interchangeably downstream.
+
+### Action items
+
+- [x] Land the fix (`53780152`).
+- [x] Land the bug-reproducing test (`a7788beb`) as a permanent
+      regression guard.
+- [x] Delete the orphaned frontend code (`0783e821`).
+- [x] Replace boutique `CompositeOver` in tests with
+      `BitmapGoldenCompare::CompareBitmapToBitmap` + pixelmatch
+      (done in the test cluster around `a7788beb`).
+- [ ] Extend `verifyPixelIdentity` to recompute RIC state from
+      `LayoutSystem` before the reference render, so the dual-
+      path assertion doesn't share drifted state with the
+      compositor path. Tracked as follow-up.
+- [ ] Rename `FastPathResolution::delta` → `stampDelta` and make
+      the per-frame delta a separate named field. Tracked as
+      follow-up.
+- [ ] Enable `verifyPixelIdentity` by default in a dedicated CI
+      target (e.g. `compositor_pixel_identity_tests`) running
+      against a representative subset of the existing `.rnr`
+      fixtures. Tracked as follow-up.

--- a/docs/design_docs/0032-sandbox_branch_split.md
+++ b/docs/design_docs/0032-sandbox_branch_split.md
@@ -1,0 +1,466 @@
+# Design: Sandbox Branch Split
+
+**Status:** Design
+**Author:** Claude Opus 4.7 (1M context)
+**Created:** 2026-05-10
+
+## Summary
+
+The `origin/sandbox` branch is 97 commits ahead of `origin/main` and entangles
+three logically separate threads: (1) a major editor architectural rewrite
+into a thin client + out-of-process backend, (2) the address-bar feature plus
+URL fetch / SSRF hardening built on that backend, and (3) a long tail of
+general-purpose improvements (compositor `#582` fix, drag coalesce, filter
+group elevation, tree-view pane, element inspector, `.rnr` v2, WASM Playwright
+tests, Geode staging-buffer reuse).
+
+Threads (1) and (2) are sandbox-specific and stay on the draft. Thread (3) is
+the subject of this doc: extract every piece that can stand on `main` without
+the new architecture, land it as one or more reviewable PRs, then keep the
+sandbox draft as a thinner-but-still-sandbox-shaped branch.
+
+Each candidate falls into one of four extraction tiers, from "clean
+cherry-pick" to "feature exists on main but the sandbox version touches the
+new architecture and needs a re-port." This doc names the tier per feature so
+that effort estimates are honest up front — one of the original asks
+(on-demand render loop) turned out to already be on `main`, and SelectionAabb
+already exists on `main` too, so the actual extractable surface is smaller
+than the raw commit count suggests.
+
+**PR shape: exactly four PRs total, one per tier.** Tier 3 bundles all seven
+re-ports into a single large PR per operator direction.
+
+## Goals
+
+1. **Land every general-purpose improvement on `main` ahead of the sandbox
+   merge.** This de-risks the sandbox PR (smaller diff, fewer concerns mixed
+   in) and gets the wins to users without waiting for the sandbox to clear
+   review.
+2. **Preserve the sandbox draft as a still-coherent branch.** After
+   extraction, `sandbox` rebases onto the freshened `main` and stays a draft
+   centered on the architecture refactor + address bar + sandboxing
+   primitives.
+3. **No silent regressions.** Each extracted PR runs `bazel test //...`
+   green; no perf-test budgets relax; no compositor goldens drift.
+4. **Per-feature tier visibility.** Each item in the extraction list is
+   tagged with its tier (1–4) so reviewers and the operator can see at a
+   glance which extractions are 30-minute cherry-picks and which are
+   day-shaped re-ports.
+
+## Non-Goals
+
+- **Not extracting the thin-client / out-of-process backend architecture.**
+  `EditorBackendClient*`, `donner/editor/backend_lib/`, and
+  `donner/editor/sandbox/` were created *for* the sandbox and stay on the
+  draft.
+- **Not extracting the address bar.** Per operator direction, `AddressBar*`,
+  `AddressBarDispatcher*`, `ContentSniffer`, `CurlAvailability`,
+  `ResourcePolicy`, `SvgFetcher*`, the curl SSRF hardening, parse-error
+  chips, the implicit-consent UX, and the load progress bar all stay on the
+  draft.
+- **Not extracting sandboxing primitives.** Linux seccomp fail-closed, macOS
+  `sandbox_init`, `RLIMIT_FSIZE`, FD sweep, `--backend-smoke-test`,
+  `installSandboxProfile`, libc_compat injection, live-protocol fuzzers, the
+  persistent-child plumbing, and the sandbox-only design doc 0023 stay on the
+  draft.
+- **Not extracting sandbox-driven CI hygiene as part of this split.** The
+  misc-include-cleaner pre-build scoping, clang-tidy GCC-13 stdlib pinning,
+  `*_macOS.*` exclusions, the 256-finding include-cleaner sweep, and the
+  branch-wide clang-format 18 reformat are their own initiative and are
+  out of scope for this doc. (See "Future Work" — they may justify a
+  separate extraction track later, but they're not gating the sandbox merge.)
+- **Not back-porting features that genuinely require the new architecture.**
+  If a sandbox feature only works because there's an out-of-process backend
+  to talk to (e.g., the live-protocol fuzzers, persistent-child flake fix),
+  it does not get a re-port — it ships when sandbox ships.
+- **Not refactoring `main`'s editor architecture as part of this work.**
+  `main` keeps `EditorShell` / `RenderCoordinator` / `EditorWindow` for now;
+  this split is purely additive on `main`. The architecture refactor lands
+  via the eventual sandbox PR, not via these extractions.
+
+## Next Steps
+
+- Operator sign-off received (2026-05-10): execute the maximalist split —
+  Tiers 1, 2, 3, and 4 all in scope. Sandbox proper is deferred "for a
+  while," so Tier 3 re-ports are unambiguously worth the cost.
+- **Stack-then-split workflow.** Branch `editor-dev` off `origin/main` and
+  port *all four tiers* onto it as a stack — Tier 1 commits at the
+  bottom, Tier 4 commits at the top — **before opening any PRs**. The
+  operator tests `editor-dev` locally as a single integrated branch first.
+  Only after local validation does the branch get split into four PRs
+  (one per tier) targeting `main`.
+- **Exactly four PRs total: one PR per tier.** Tier 3 is one large bundled
+  PR covering all seven re-ports, not seven small PRs. This is an explicit
+  operator constraint.
+- Implementation order on `editor-dev`: Tier 1 → Tier 2 → Tier 3 → Tier 4,
+  with each tier as a contiguous range of commits so the eventual PR
+  split is a clean `git range-diff` / `git rebase --onto` operation.
+
+## Implementation Plan
+
+- [x] **Milestone 0: Branch setup.** Created `editor-dev` off
+      `origin/main`. All subsequent milestones landed on this branch as a
+      stack.
+  - [x] `git checkout -b editor-dev origin/main` (and detach from upstream).
+  - [x] Tier boundaries marked in commit messages with `[tier1]` /
+        `[tier2]` / `[tier3]` / `[tier4]` prefixes.
+
+- [x] **Milestone 1: Tier 1 extractions (clean cherry-pick).** Cleanly
+      applies onto `main`; small surface; high confidence. Landed on
+      `editor-dev` as the bottom of the stack.
+  - [x] Cherry-picked the four compositor `#582` commits in chronological
+        order: `c020578b`, `8e7ec375`, `d032df3e`, `53780152`. Sandbox-only
+        test hunks dropped. Required two fixups: (a) duplicate
+        `propagateFastPathTranslationToSubtree` declaration removed,
+        (b) `findLayerForTest` accessor added to expose layer state to
+        the new tests. Also renamed `compositionTransform` → `canvasFromBitmap`
+        in test code per destFromSource convention.
+  - [x] ~~Cherry-pick `879e3340` (Geode staging-buffer reuse)~~ — **deferred**;
+        regresses `BlendedLayerPopPreservesBackdropOutsideClip` on aarch64.
+        Investigate as a follow-up.
+  - [x] Cherry-picked the `CompositorGolden_tests.cc` additions (subset
+        driving `CompositorController` directly).
+  - [x] Cherry-picked design-doc `0025-composited_rendering.md` postmortem
+        (`d11da687`) and policy updates (`b5189d8b`).
+  - [x] Compositor tests pass; Geode renderer tests fail with environmental
+        per-case timeouts on this aarch64 dev box (same on `origin/main`,
+        not Tier 1 regressions).
+  - [x] `clang-format -i` run; commits stay un-PR'd on `editor-dev`.
+
+- [x] **Milestone 2: Tier 2 extractions (`.rnr` v2 format upgrade only).**
+      Format-only slice landed via codex delegation (commit
+      `[tier2] editor: .rnr v2 file format (format-only slice)`).
+  - [x] `ReproFile.{cc,h}` extended with `ReproViewport`, `ReproHit`,
+        per-frame `mouseDocX/mouseDocY`, per-frame `viewport`, per-event
+        `hit`. Version bumped to v2. Reader handles both v1 and v2.
+  - [x] `ReproRecorder.{cc,h}` gained `FrameContext` parameter on
+        `snapshotFrame()` (default-empty) so existing zero-arg callsites
+        compile unchanged.
+  - [x] `ReproFile_tests.cc` extended with v2 round-trip + v1-readable-
+        under-v2 tests; `bazel test //donner/editor/repro/...` green.
+        Filter-disappear corpus seeds + replay harness shipped in
+        Milestone 3.7.
+
+- [ ] **Milestone 3: Tier 3 extractions (re-port against `main`'s
+      `EditorShell`).** Implementation surfaced an important finding:
+      **three of the seven items were already on `main`** from prior PRs
+      (`#529`, `#531`, `#550` era), so only four required actual porting.
+  - [x] **3a — Drag-coalesce extraction.** Codex-delegated
+        (`[tier3] editor: drag-coalesce primitive (header + EditorShell
+        wiring)`). `DragCoalesce.h` ported verbatim, `DragCoalesce_tests.cc`
+        with high-rate stream coverage, and wired into `EditorShell.cc`
+        with `ShouldPostDragMove` gating against `asyncRenderer().isBusy()`.
+        Last-posted-screen-point reset on mouse-up.
+  - [x] **3b — Filter-group sibling expansion.** Codex-delegated
+        (`[tier3] editor: drag elevated <g filter> with visual-composite
+        siblings`). After the existing elevation logic on main selects a
+        `<g filter>` / `<g mask>` / `<g clip-path>`, the new code walks the
+        group's direct siblings and adds those whose renderable geometry
+        is ≥70 % contained in the group's subtree bbox to the drag set.
+        Reuses `CollectRenderableGeometry`. Tests in `SelectTool_tests.cc`.
+  - [~] **3c — Group-selection AABB expansion.** **Already on `main`**
+        from PR `#550` (Editor: fix exit crash, filter-drag perf, and
+        group-selection chrome). `CollectRenderableGeometry` and
+        `SnapshotSelectionWorldBounds` are already on `main`. Sandbox-only
+        residual (`ComputeSelectionAabbScreenRects` test utility) deferred
+        as a follow-up — it has no production callsite even on sandbox.
+  - [~] **3e — Tree-view pane.** **Already on `main`**: `SidebarPresenter`
+        already has `renderTreeView`/`renderTreeNode` with click-to-select,
+        Ctrl/Shift modifiers, and scroll-to-selected. The sandbox commit
+        `8866deb2` adds the *protocol* (FrameTreeSummary, kSelectElement);
+        the UX itself shipped earlier. No port needed.
+  - [ ] **3d — Selection identity diagnostics.** **Deferred** as
+        follow-up. Most of `13099271` is sandbox-protocol-tied
+        (`FramePayload.tree`, `FrameSelectionEntry`); the portable bits
+        (BitmapGoldenCompare helper, attempt-tagged PNG dumps) are test
+        infrastructure that doesn't unblock the operator's testing.
+        Revisit when the sandbox merge gets closer.
+  - [in-flight] **3f — Element inspector G4.** Codex-delegated; adds
+        XML attributes + computed style sections to `renderInspector`
+        in `SidebarPresenter`. Single-element invariant.
+  - [in-flight] **3g — `.rnr` replay harness + filter-disappear corpus.**
+        Codex-delegated; new `RnrReplay_tests.cc` drives `AsyncRenderer` +
+        `AsyncSVGDocument` with replayed events from .rnr v2 files,
+        pixelmatch-compares against committed PNG goldens. Corpus seeds
+        (`filter_elm_disappear-{2..7}.rnr`) and goldens move from sandbox
+        to `donner/editor/tests/testdata/`.
+
+- [x] **Milestone 4: Tier 4 — WASM Playwright smoke harness (re-scoped).**
+      Codex-delegated. Codex correctly identified that the original-scope
+      Playwright suite depended on browser-side test hooks (`__donner_ready`,
+      `__donner_metrics`, `__donner_simulate`, `OnBrowserFileReadyPath`)
+      that are sandbox-only additions to `donner/editor/main.cc` and the
+      WASM `BUILD.bazel`. **Re-scoped** to a smoke-only port that doesn't
+      require those hooks; `drag_perf.spec.ts` deferred until the hooks land.
+  - [x] Added `donner/editor/wasm/tests/` (BUILD, package.json,
+        playwright.config.ts, run_tests.sh, smoke.spec.ts, NOTES.md
+        documenting the deferral). Bazel target tagged `manual` and
+        `playwright`. `bazel build //donner/editor/wasm/tests:all`
+        completes (target is manual, so `:all` is empty; explicit target
+        builds successfully).
+  - [x] Startup-stderr matcher in `smoke.spec.ts` is permissive
+        (`/^(\[startup\]|\[Geode\/emscripten\]|GLFW error 0:|warning:)/`
+        or empty). Tighten when the operator captures the actual tags
+        from main's WASM build.
+
+- [ ] **Milestone 5: Local validation gate (operator).** Before any PRs
+      open, the operator builds `editor-dev` locally and exercises the
+      editor — golden-path UX, drag perf, address-bar-free flows,
+      compositor `#582` repros, tree-view + element inspector. Any
+      regressions surface here, not in CI.
+  - [ ] Operator: `bazel build //donner/editor:editor` and run.
+  - [ ] Operator: spot-check Tier-3 features (drag coalesce, filter
+        elevation, AABB expansion, tree view, element inspector,
+        diagnostics, replay harness).
+  - [ ] Operator: optionally exercise WASM build + Playwright suite via
+        the tag-gated target.
+  - [ ] Operator signal: "ship it" → proceed to Milestone 6.
+
+- [ ] **Milestone 6: Stack split into four PRs.** Mechanical operation —
+      use the `[tierN]` commit-message tags from Milestone 0 to delineate
+      tier boundaries. One PR per tier, in numerical order. Each PR
+      targets `origin/main` and stacks on the previous PR until merged.
+  - [ ] Find the boundary commits via `git log --grep='\[tier'`.
+  - [ ] Branch `tier1-compositor-fixes` from the last Tier-1 commit, push,
+        open PR.
+  - [ ] After Tier 1 lands on `main`, rebase `editor-dev` onto refreshed
+        `main`; branch `tier2-rnr-v2` from the last Tier-2 commit, push,
+        open PR.
+  - [ ] Repeat for Tier 3 (`tier3-editor-improvements`) and Tier 4
+        (`tier4-wasm-playwright`).
+  - [ ] After all four tiers are merged, delete `editor-dev`.
+
+- [ ] **Milestone 7: Sandbox draft cleanup.** After Tiers 1–4 land,
+      rebase `sandbox` onto refreshed `main`. Resolve the inevitable
+      conflicts (the architecture refactor still touches the same
+      compositor / repro files we extracted). Confirm `bazel test //...`
+      still passes on the rebased draft. The draft stays draft; the eventual
+      sandbox merge is a separate decision.
+
+## Background
+
+`origin/sandbox` is the working branch for the editor sandboxing initiative
+(design doc 0023). Across ~5 weeks of work, three threads converged:
+
+1. **The architecture refactor.** To put untrusted SVG parsing behind a
+   sandboxed boundary, the editor was rewritten from a single-process
+   `EditorShell` + `RenderCoordinator` + `EditorWindow` into a thin
+   front-end (ImGui host) that talks to a `donner/editor/backend_lib/`
+   backend over `donner/editor/sandbox/` IPC. Files removed: `EditorShell`,
+   `RenderCoordinator`, `EditorWindow`, `RenderPanePresenter`,
+   `ViewportInteractionController`, `MenuBarPresenter`,
+   `SidebarPresenter`, `EditorInputBridge`, `DialogPresenter`,
+   `ImGuiClipboard`, `GlTextureCache`, etc. Files added: `EditorBackendClient.h`
+   + `_InProcess.cc` + `_Session.cc`, `backend_lib/`, `sandbox/`.
+2. **The address-bar feature.** Loading remote URLs requires a fetch path,
+   which means an SSRF hardening surface, which means content-type sniffing
+   and a resource policy. New files: `AddressBar*`, `AddressBarDispatcher*`,
+   `ContentSniffer*`, `CurlAvailability.cc`, `LocalPathDisplay*`,
+   `ResourcePolicy*`, `SvgFetcher*`. Stays on the draft per direction.
+3. **General-purpose improvements.** Wherever sandbox work uncovered a
+   pre-existing bug (compositor `#582`), perf nit (Geode staging buffer),
+   missing test infra (`.rnr` v2 with hit-testing), or new editor capability
+   (tree view, element inspector, drag-coalesce), commits accumulated on
+   `sandbox` that have nothing intrinsically to do with the sandbox.
+
+This doc covers thread (3).
+
+## Proposed Architecture
+
+This is process design, not software architecture. Two phases:
+
+**Phase A — stack on `editor-dev`** (no PRs):
+
+```
+   origin/main
+       │
+       └──► editor-dev
+              │
+              ├── [tier1] compositor #582 + Geode + design doc 0025
+              ├── [tier2] .rnr v2 format upgrade
+              ├── [tier3] drag-coalesce, filter elevation, AABB,
+              │           diagnostics, tree view, element inspector,
+              │           replay harness  (one tier, seven features,
+              │           contiguous range of commits)
+              └── [tier4] WASM Playwright (tag-gated)
+              │
+              ▼
+       Operator local test
+              │
+              ▼
+       "ship it"
+```
+
+**Phase B — split into four PRs** (mechanical, one per tier, in order):
+
+```
+   origin/main
+       │
+       ├── PR 1 ───── tier1-compositor-fixes
+       ├── PR 2 ───── tier2-rnr-v2-format         (after PR 1 lands)
+       ├── PR 3 ───── tier3-editor-improvements   (after PR 2 lands)
+       └── PR 4 ───── tier4-wasm-playwright       (after PR 3 lands)
+                              │
+                              ▼
+                  sandbox rebase onto main
+                 (deferred; still draft post-split)
+```
+
+Exactly four PRs, one per tier. Sandbox stays a draft for "a while" — the
+rebase happens on the operator's schedule, not on this work's critical path.
+
+The tiering itself is the architecture: it forces explicit acknowledgement
+of *which* extractions are cheap and *which* are day-shaped, before any
+porting work starts.
+
+### Tier definitions
+
+- **Tier 1 — Pure cherry-pick.** Files exist on `main`; the diff applies
+  cleanly (modulo dropping sandbox-only test hunks). Confidence: high.
+  PR shape: one bundled PR. Effort: ~half-day total.
+- **Tier 2 — Cherry-pick + wiring.** Files exist on `main`; diff applies
+  but needs small callsite adjustments because `EditorShell` (`main`)
+  differs from `EditorBackendClient` (`sandbox`). Confidence: medium-high.
+  PR shape: one PR. Effort: ~half-day.
+- **Tier 3 — Re-port.** Feature concept is portable; sandbox implementation
+  is not. Re-author against `main`'s `EditorShell` + `RenderCoordinator`.
+  Confidence: medium. PR shape: **one bundled PR covering seven re-ports**
+  (operator constraint). Effort: 7–12 days total.
+- **Tier 4 — Standalone subsystem.** Lives outside the editor proper (the
+  WASM Playwright harness is the only one). Confidence: medium-high.
+  PR shape: one PR, tag-gated. Effort: ~half-day.
+
+## Per-feature extraction map
+
+| Feature | Tier | Sandbox commit(s) | Notes |
+|---|---|---|---|
+| Compositor `#582` fast-path subtree fix | 1 | `c020578b`, `8e7ec375`, `d032df3e`, `53780152` | Drop sandbox-test hunks during pick. |
+| Geode staging-buffer reuse | **deferred** | `879e3340` | Originally planned for Tier 1. Dropped during impl: `RendererGeodeTest.BlendedLayerPopPreservesBackdropOutsideClip` regresses on aarch64 with the patch applied — the thread-local buffer reuse interacts with WebGPU `writeTexture` validation in a way the sandbox commit's "padding bytes are ignored" rationale doesn't cover. Investigate separately. |
+| Compositor `#582` postmortem + design doc 0025 | 1 | `d11da687`, `b5189d8b`, design-doc add | Doc-only. |
+| `.rnr` v2 format | 2 | `7167fb8e` (format-only slice) | Recorder wiring against `main`'s `EditorShell` is small. |
+| `.rnr` replay harness + filter-disappear corpus | 3 | `ce8b181a`, `cd3492b7`, `3c236629`, `7075e632`, `5ea9b77c`, `e7541836`, plus `7167fb8e` corpus | Re-authored against `AsyncRenderer` on main; sandbox version uses `EditorBackendClient`. |
+| Drag-coalesce (`DragCoalesce.h`) | 3 | `1fde7905`, `2b4b34c4` | Header is portable; caller integration re-authored. |
+| `<g filter>` top-level elevation | 3 | `8274778c`, `cf4231d1` | Re-port into `main`'s `SelectTool.cc`. |
+| Group-selection AABB expansion | 3 | `ecf0bb3f` | `SelectionAabb` exists on main; descendant-walk is the new logic. |
+| Tree-view pane | 3 | `8866deb2` | Re-author as in-process ECS reader. |
+| Element inspector G4 | 3 | `08372da4` | Re-author as in-process ECS reader. |
+| Selection identity diagnostics + pixelmatch goldens | 3 | `13099271`, `2a3bf761` | Pixelmatch goldens portable; protocol-tied diagnostics aren't. |
+| WASM Playwright harness | 4 | `2f40d0b7` | Adjust startup-log matcher; decide CI tag policy. |
+| `emscripten_fetch` wiring (S10) | — | `75cab44c` | **Stays on sandbox.** Only useful with `SvgFetcherWasm`, which is the address-bar's WASM fetch path. Not extractable without dragging in the address bar. |
+| On-demand render loop (`0b9c0281`) | n/a | already on `main` | Sandbox dropped it during refactor and re-added it. `main` already has the equivalent in `EditorWindow::waitEvents()`. **No extraction.** |
+| `SelectionAabb.{cc,h}` add | n/a | already on `main` | Listed previously but already exists on `main`. **No extraction.** |
+
+## Testing and Validation
+
+- **Per-PR gate.** `bazel test //...` is the source of truth (per
+  `CLAUDE.md`'s always-green-`main` rule). Each extraction PR must run that
+  green locally before push.
+- **Compositor Tier 1.** New goldens land in
+  `donner/svg/compositor/CompositorGolden_tests.cc` for the `#582` repros;
+  the perf budgets in `CompositorGolden_tests.cc`'s `SplashDrag*` family
+  must not regress.
+- **Drag-coalesce Tier 3.** Port the unit tests verbatim
+  (`DragCoalesce_tests.cc`); add an integration assertion in
+  `EditorShell`-level tests on `main` that a synthetic mouse stream
+  produces at most one post per round-trip.
+- **`.rnr` v2 Tier 2.** `ReproFile_tests.cc` already covers v1; add v2
+  round-trip tests; verify a v1 file reads correctly under v2-aware code.
+- **Tier 3 re-ports.** Each feature ships with its own targeted tests
+  against `main`'s code paths. The sandbox tests don't carry over because
+  they exercise the protocol; that's why Tier 3 is more expensive than
+  Tier 1/2.
+- **Tier 4 WASM Playwright.** Decide whether to gate behind a
+  `--test_tag_filters=playwright` opt-in or include in default
+  `bazel test //...`. Recommend opt-in for now until headless Chromium
+  reliability is established in CI.
+
+No security/privacy section: the extracted features don't introduce new
+trust boundaries. The trust boundaries this branch *does* introduce
+(URL fetch, IPC, sandbox primitives) all stay on the sandbox draft.
+
+## Risks
+
+- **R1 — Tier 3 effort underestimated, single-PR bundling amplifies the
+  blast radius.** "Re-port" is a polite word for "re-author against a
+  different architecture." If tree-view, element inspector, or the replay
+  harness turns out to need ECS-traversal helpers or test infrastructure
+  that doesn't yet exist on `main`, day estimates balloon — and because
+  Tier 3 is a single PR (operator constraint), a blocker on one re-port
+  delays the whole tier. Mitigation: implement in dependency order
+  (drag-coalesce → filter elevation → AABB → diagnostics → tree-view →
+  element inspector → replay harness) so partial progress is always in a
+  shippable state; if a late item hits a blocker, drop it from the bundle
+  and ship the rest, deferring the blocker to a Tier-3.5 follow-up. (The
+  follow-up would then be a *fifth* PR — a deviation from the four-PR
+  constraint that should be flagged to the operator before splitting.)
+- **R2 — Sandbox rebase friction grows.** Every PR that lands on `main`
+  while sandbox is still draft is a rebase that the sandbox owner has to
+  resolve. Mitigation: bundle Tier 1 into one PR rather than spreading it
+  across four; rebase sandbox once after each tier lands, not after each PR.
+  This risk is reduced because sandbox proper is deferred "for a while" —
+  the rebase cost is borne later, in a single concentrated session, not
+  amortized across a tight merge window.
+- **R3 — Replay harness re-port collides with main's `AsyncRenderer`
+  surface.** The sandbox version drives `EditorBackendClient`; on `main`
+  the replay harness must drive `AsyncRenderer` + `AsyncSVGDocument`.
+  `AsyncRenderer_tests.cc` was deleted on sandbox, so we don't have a
+  reference for what the v2-`.rnr`-aware AsyncRenderer harness should look
+  like — we're re-authoring it. Mitigation: do this re-port last in
+  Tier 3, after the smaller ports have validated the general re-port
+  pattern; expect 1–2 days for the harness alone.
+- **R4 — Compositor goldens drift between sandbox and `main`.** If we
+  extract Tier 1 goldens but the sandbox branch later modifies the same
+  goldens, the rebase produces a conflict where the sandbox version "wins"
+  and quietly reverts the extracted change. Mitigation: pin extracted
+  golden files in `CODEOWNERS` for the sandbox rebase to force the owner to
+  read each conflict.
+- **R5 — Tier 4 startup-log contract drift.** The Playwright matcher is
+  pinned to `[startup] …` prefixes that the sandbox build emits. `main`'s
+  WASM build may emit different prefixes. Mitigation: capture the actual
+  `main` startup log before writing the matcher; keep the matcher
+  permissive (regex over `^\[(startup|GLFW error 0)\]`).
+
+## Decisions
+
+Sign-off captured 2026-05-10:
+
+- **D1 — Maximalist split.** Tiers 1–4 are all in scope. Sandbox proper is
+  deferred "for a while," so Tier 3 re-ports are unambiguously worth the
+  cost — they ship value to `main` users now rather than sitting behind a
+  multi-month sandbox review.
+- **D2 — Replay harness ships, not just format.** The `.rnr` v2 format
+  upgrade lands in Tier 2; the replay harness + corpus seeds land as a
+  Tier 3 PR (re-authored against `AsyncRenderer`, since sandbox deleted
+  the AsyncRenderer test surface).
+- **D3 — Tier 1 is one bundled PR.** Compositor `#582` fix + Geode
+  staging-buffer reuse + design doc 0025 + postmortem all in a single PR
+  off `compositor-fixes`.
+- **D4 — Tier 4 is tag-gated.** WASM Playwright suite is opt-in
+  (`--test_tag_filters=playwright` or explicit target), not default
+  `bazel test //...`. Promote to default only after CI track record exists.
+- **D5 — Tree-view + element inspector are in scope.** Worth the Tier 3
+  cost given the deferred sandbox merge.
+- **D6 — Exactly four PRs total, one per tier.** Tier 3 bundles all seven
+  re-ports into a single large PR. Splitting the tier across multiple PRs
+  is not authorized without re-checking with the operator — see R1 for
+  the contingency if a Tier-3 item hits a blocker.
+- **D7 — Stack-then-split workflow.** All four tiers port onto a single
+  `editor-dev` branch as a stack of commits before any PR opens. The
+  operator validates `editor-dev` locally (Milestone 5). Only after
+  "ship it" does the branch get split into four PRs (Milestone 6). This
+  catches integration regressions across tiers before they hit reviewers.
+
+## Future Work
+
+- [ ] **Sandbox-driven CI hygiene extraction.** misc-include-cleaner pre-build
+      scoping, clang-tidy GCC-13 stdlib pinning, the 256-finding sweep, and
+      the branch-wide clang-format 18 reformat are valuable on `main` but
+      orthogonal to feature extraction. Justify a separate doc and split.
+- [ ] **Live-protocol fuzzers extraction.** If the wire format ends up
+      stable enough across `EditorBackendClient` versions, the fuzzers may
+      be valuable as a permanent test surface — but only after the protocol
+      itself stabilizes.
+- [ ] **`.rnr` replay harness on `main`.** If sandbox merge slips past
+      Q2 2026, port the replay harness so the existing repro corpus has
+      a consumer and `main` gets regression coverage of the filter-disappear
+      class of bugs.

--- a/docs/design_docs/AGENTS.md
+++ b/docs/design_docs/AGENTS.md
@@ -24,6 +24,18 @@ All design documents live under `docs/design_docs/`.
 - In-flight designs: `design_template.md` (Summary, Goals, Non-Goals, Next Steps, Implementation Plan, Security/Privacy, Testing/Validation).
 - Shipped features: `developer_template.md` (present tense, no TODOs, include guarantees/testing/security).
 
+## Invariants Must Point At CI Targets
+
+Every claimed invariant in a design doc ("cannot happen", "always holds", "the X can never silently produce wrong Y") must name a CI target that fails when the invariant breaks. If the enforcement mechanism is an off-by-default runtime assertion (`DCHECK`, a `--verify_*` flag, a test-only knob), describe it as *diagnostic tooling*, not as a guarantee — its existence does not make the invariant enforced.
+
+During design review, trace each "cannot happen" / "always holds" claim back to a named test target. If there isn't one, the options are:
+
+1. Add a CI target (test, lint, or fuzzer) that fails on violation.
+2. Rewrite the claim to describe what is actually enforced.
+3. List the gap under §"Open Questions" or §"Verification Strategy" with a follow-up action item.
+
+The #582 postmortem in [0025-composited_rendering.md](0025-composited_rendering.md) is the canonical example of what happens when this rule is skipped: the `verifyPixelIdentity` assertion was the only enforcement for the "compositor cannot silently produce wrong pixels" invariant, it was off by default, no CI target ever turned it on, and the invariant quietly broke for weeks.
+
 ## Resvg Test Integration
 
 When writing design docs for renderer features, reference relevant resvg tests that validate the feature, include a test plan listing which should pass after implementation, update test status as work progresses, and document skip removals with references to the fixing implementation.

--- a/docs/design_docs/README.md
+++ b/docs/design_docs/README.md
@@ -75,6 +75,7 @@ conventions automated agents should follow when editing design docs.
 | 0029 | [ci_runtime](0029-ci_runtime.md)                                                       | Superseded by [0031](0031-ci_hardening_2026q2.md)                          | CI runtime reduction plan (post-Skia baseline, per-config cache slots, runner sizing). Scope folded into 0031. |
 | 0030 | [geode_performance](0030-geode_performance.md)                                         | In Progress                                                                | Geode GPU-backend performance milestones (counters, arenas, shared command encoder, target reuse). |
 | 0031 | [ci_hardening_2026q2](0031-ci_hardening_2026q2.md)                                     | Design                                                                     | Consolidated CI work for 2026-Q2: escape prevention (issue #552 class) + runtime reduction (subsumes 0029). |
+| 0032 | [sandbox_branch_split](0032-sandbox_branch_split.md)                                   | Design                                                                     | Plan for extracting general-purpose improvements off the `sandbox` branch into `main`-targeted PRs (tiered by porting cost). |
 
 ## Cross-reference: developer docs
 

--- a/donner/svg/compositor/CompositorController.cc
+++ b/donner/svg/compositor/CompositorController.cc
@@ -742,6 +742,26 @@ void CompositorController::renderFrame(const RenderViewport& viewport) {
       unhandledDirtyEntities.reserve(resolutions.size());
       for (const auto& res : resolutions) {
         auto& instance = registry.get<components::RenderingInstanceComponent>(res.entity);
+        // Compute the per-frame delta BEFORE we overwrite the RIC:
+        // `instance.worldFromEntityTransform` at this moment is the
+        // PREVIOUS frame's value (set either by a prior fast-path
+        // iteration, by `prepareDocumentForRendering`, or by the
+        // initial tree instantiation). `res.delta` below, in contrast,
+        // is the cumulative delta since the bitmap was STAMPED —
+        // the right value for `setCanvasFromBitmap` (which operates
+        // against the stamped bitmap) but the WRONG value for
+        // `propagateFastPathTranslationToSubtree`, which left-composes
+        // it onto each descendant's already-translated
+        // `worldFromEntityTransform`. Using the stamp-delta there
+        // re-applies every prior frame's translation on top of
+        // itself, producing canvas pixels that drift further from
+        // the DOM's true position with every drag frame — the #582
+        // "filter element mispositioned after many drag frames"
+        // symptom. Per-frame delta is what the descendants actually
+        // need: layered over their current (already-post-previous-frame)
+        // transforms, it advances them exactly one drag step.
+        const Transform2d perFrameDelta =
+            res.newWorldFromEntity * instance.worldFromEntityTransform.inverse();
         instance.worldFromEntityTransform = res.newWorldFromEntity;
 
         if (res.delta.isTranslation()) {
@@ -754,7 +774,7 @@ void CompositorController::renderFrame(const RenderViewport& viewport) {
           // rather than going back to the renderer.
           res.layer->setCanvasFromBitmap(res.delta);
           if (res.isSubtree) {
-            propagateFastPathTranslationToSubtree(registry, res.entity, res.delta);
+            propagateFastPathTranslationToSubtree(registry, res.entity, perFrameDelta);
           }
         } else {
           // Single-entity layer with non-translation delta (scale,

--- a/donner/svg/compositor/CompositorController.cc
+++ b/donner/svg/compositor/CompositorController.cc
@@ -623,7 +623,11 @@ void CompositorController::renderFrame(const RenderViewport& viewport) {
       Entity entity = entt::null;
       CompositorLayer* layer = nullptr;
       Transform2d newWorldFromEntity;
-      Transform2d delta;
+      /// `bitmapEntity_from_entity` — the canvas-from-canvas mapping from
+      /// the bitmap's stamped entity frame to the entity's CURRENT frame.
+      /// Used as the layer's `canvasFromBitmap` compose offset on the
+      /// bitmap-reuse fast path. **Stamp-relative**, NOT per-frame.
+      Transform2d bitmapEntityFromEntity;
       bool isSubtree = false;
     };
     std::vector<FastPathResolution> resolutions;
@@ -671,27 +675,27 @@ void CompositorController::renderFrame(const RenderViewport& viewport) {
           components::LayoutSystem().getCanvasFromDocumentTransform(registry);
       const Transform2d newWorldFromEntity =
           abs.worldFromEntity * (abs.worldIsCanvas ? canvasFromDocument : Transform2d());
-      // The delta is the canvas-from-canvas transform that maps
-      // bitmap-canvas-pixels (rasterized at the OLD `worldFromEntity`) to
-      // their CURRENT canvas position (under the NEW `worldFromEntity`).
+      // `bitmapEntityFromEntity`: takes a point in the entity's CURRENT
+      // frame and returns it in the bitmap's stamp-time entity frame.
+      // The compositor uses this as `canvasFromBitmap` on the layer's
+      // bitmap-reuse fast path: rendering the cached bitmap (which was
+      // rasterized in stamp-frame coords) through this transform places
+      // its pixels at the entity's current world position.
       //
-      // For a bitmap pixel at canvas position c_old, its corresponding
-      // entity-local point is `oldEntityFromWorld(c_old)`; its current
-      // canvas position is `newWorldFromEntity(<that local p>)`. Reading
-      // donner's left-to-right composition (`A * B` applied to v means
-      // "first A, then B"), the canvas-to-canvas mapping is therefore
-      // `oldEntityFromWorld * newWorldFromEntity`.
-      //
-      // The reverse order (`newWFE * oldEFW`) is an entity-local mapping,
-      // which collapses to the right answer ONLY when the old transform's
-      // linear part is identity. For a previously-resized element it
-      // misreports the canvas delta as `oldScale.inverse() * delta_doc`,
-      // so the cached bitmap moves at `delta_doc / scale` pixels per
-      // drag step while the overlay (driven by worldBounds) moves at
-      // `delta_doc`. See `LayerComposeOffsetReflectsDocumentDeltaForResized
-      // Element` for the regression pin.
-      const Transform2d delta = matchedLayer->bitmapEntityFromWorldTransform()->inverse() *
-                                newWorldFromEntity;
+      // Under donner's post-multiply convention (`A * B` applied to v
+      // means "first B, then A"), `bitmapEntityFromWorld_at_stamp *
+      // newWorldFromEntity_now` walks v from current entity → world →
+      // stamp entity. The reverse order (`newWFE * oldEFW`) reads as a
+      // direct entity-local mapping and collapses to the right answer
+      // ONLY when the stamped transform's linear part is identity. For a
+      // previously-resized element the reverse misreports the canvas
+      // delta as `oldScale.inverse() * delta_doc`, so the cached bitmap
+      // moves at `delta_doc / scale` pixels per drag step while the
+      // overlay (driven by worldBounds) moves at `delta_doc`. See
+      // `LayerComposeOffsetReflectsDocumentDeltaForResizedElement` for
+      // the regression pin.
+      const Transform2d bitmapEntityFromEntity =
+          matchedLayer->bitmapEntityFromWorldTransform()->inverse() * newWorldFromEntity;
 
       const bool isSubtree = matchedLayer->firstEntity() != e || matchedLayer->lastEntity() != e;
       // Subtree layers require a pure-translation delta: only then can we
@@ -700,7 +704,7 @@ void CompositorController::renderFrame(const RenderViewport& viewport) {
       // (scale, rotate, transform-list change) stay on the slow path.
       // Single-entity layers can tolerate non-translation deltas via a
       // targeted re-rasterize later in `renderFrame`.
-      if (isSubtree && !delta.isTranslation()) {
+      if (isSubtree && !bitmapEntityFromEntity.isTranslation()) {
         eligible = false;
         break;
       }
@@ -732,7 +736,7 @@ void CompositorController::renderFrame(const RenderViewport& viewport) {
           .entity = e,
           .layer = matchedLayer,
           .newWorldFromEntity = newWorldFromEntity,
-          .delta = delta,
+          .bitmapEntityFromEntity = bitmapEntityFromEntity,
           .isSubtree = isSubtree,
       });
     }
@@ -742,29 +746,31 @@ void CompositorController::renderFrame(const RenderViewport& viewport) {
       unhandledDirtyEntities.reserve(resolutions.size());
       for (const auto& res : resolutions) {
         auto& instance = registry.get<components::RenderingInstanceComponent>(res.entity);
-        // Compute the per-frame delta BEFORE we overwrite the RIC:
-        // `instance.worldFromEntityTransform` at this moment is the
-        // PREVIOUS frame's value (set either by a prior fast-path
-        // iteration, by `prepareDocumentForRendering`, or by the
-        // initial tree instantiation). `res.delta` below, in contrast,
-        // is the cumulative delta since the bitmap was STAMPED —
-        // the right value for `setCanvasFromBitmap` (which operates
-        // against the stamped bitmap) but the WRONG value for
+        // `worldFromPreviousWorld`: takes a point in the previous frame's
+        // world-space and returns its position in the current frame's
+        // world-space. Computed BEFORE we overwrite the RIC, because
+        // `instance.worldFromEntityTransform` at this moment still holds
+        // the PREVIOUS frame's value (set by a prior fast-path iteration,
+        // by `prepareDocumentForRendering`, or by initial tree
+        // instantiation). `res.bitmapEntityFromEntity` below is
+        // *stamp-relative* (cumulative since the bitmap was rasterized) —
+        // the right value for `setCanvasFromBitmap`, which operates
+        // against the stamped bitmap, but the WRONG value for
         // `propagateFastPathTranslationToSubtree`, which left-composes
         // it onto each descendant's already-translated
-        // `worldFromEntityTransform`. Using the stamp-delta there
-        // re-applies every prior frame's translation on top of
-        // itself, producing canvas pixels that drift further from
-        // the DOM's true position with every drag frame — the #582
-        // "filter element mispositioned after many drag frames"
-        // symptom. Per-frame delta is what the descendants actually
-        // need: layered over their current (already-post-previous-frame)
-        // transforms, it advances them exactly one drag step.
-        const Transform2d perFrameDelta =
+        // `worldFromEntityTransform`. Passing the stamp-relative delta
+        // there re-applies every prior frame's translation on top of
+        // itself, drifting descendants forward by `n * frame_delta`
+        // after `n` drag frames — the #582 "filter element
+        // mispositioned" symptom. The per-frame
+        // `worldFromPreviousWorld`, layered over the descendants'
+        // post-previous-frame transforms, advances them exactly one
+        // drag step.
+        const Transform2d worldFromPreviousWorld =
             res.newWorldFromEntity * instance.worldFromEntityTransform.inverse();
         instance.worldFromEntityTransform = res.newWorldFromEntity;
 
-        if (res.delta.isTranslation()) {
+        if (res.bitmapEntityFromEntity.isTranslation()) {
           // Bitmap-reuse fast path: the delta between the current DOM
           // transform and the bitmap's rasterize-time transform is a
           // pure translation, so reuse the bitmap by updating
@@ -772,9 +778,9 @@ void CompositorController::renderFrame(const RenderViewport& viewport) {
           // mouse-move flips the entity's transform attribute, but the
           // compositor just writes a ~single-matrix compose offset
           // rather than going back to the renderer.
-          res.layer->setCanvasFromBitmap(res.delta);
+          res.layer->setCanvasFromBitmap(res.bitmapEntityFromEntity);
           if (res.isSubtree) {
-            propagateFastPathTranslationToSubtree(registry, res.entity, perFrameDelta);
+            propagateFastPathTranslationToSubtree(registry, res.entity, worldFromPreviousWorld);
           }
         } else {
           // Single-entity layer with non-translation delta (scale,
@@ -2239,8 +2245,8 @@ std::pair<Entity, Entity> CompositorController::computeEntityRange(Registry& reg
   return {entity, lastPainting != entt::null ? lastPainting : entity};
 }
 
-void CompositorController::propagateFastPathTranslationToSubtree(Registry& registry, Entity root,
-                                                                 const Transform2d& delta) {
+void CompositorController::propagateFastPathTranslationToSubtree(
+    Registry& registry, Entity root, const Transform2d& worldFromPreviousWorld) {
   using TreeComponent = donner::components::TreeComponent;
   std::vector<Entity> stack;
   if (const auto* tree = registry.try_get<TreeComponent>(root)) {
@@ -2259,7 +2265,8 @@ void CompositorController::propagateFastPathTranslationToSubtree(Registry& regis
       // translation — every descendant's world transform pre-multiplies
       // by that same delta (root-from-descendant is unchanged, world-
       // from-root shifts by delta, so world-from-descendant shifts too).
-      instance->worldFromEntityTransform = delta * instance->worldFromEntityTransform;
+      instance->worldFromEntityTransform =
+          worldFromPreviousWorld * instance->worldFromEntityTransform;
       // Invalidate the cached absolute-transform so any later
       // `LayoutSystem::getAbsoluteTransformComponent` query recomputes
       // from the authoritative DOM instead of returning the pre-drag

--- a/donner/svg/compositor/CompositorController.cc
+++ b/donner/svg/compositor/CompositorController.cc
@@ -671,8 +671,27 @@ void CompositorController::renderFrame(const RenderViewport& viewport) {
           components::LayoutSystem().getCanvasFromDocumentTransform(registry);
       const Transform2d newWorldFromEntity =
           abs.worldFromEntity * (abs.worldIsCanvas ? canvasFromDocument : Transform2d());
-      const Transform2d delta =
-          newWorldFromEntity * matchedLayer->bitmapEntityFromWorldTransform()->inverse();
+      // The delta is the canvas-from-canvas transform that maps
+      // bitmap-canvas-pixels (rasterized at the OLD `worldFromEntity`) to
+      // their CURRENT canvas position (under the NEW `worldFromEntity`).
+      //
+      // For a bitmap pixel at canvas position c_old, its corresponding
+      // entity-local point is `oldEntityFromWorld(c_old)`; its current
+      // canvas position is `newWorldFromEntity(<that local p>)`. Reading
+      // donner's left-to-right composition (`A * B` applied to v means
+      // "first A, then B"), the canvas-to-canvas mapping is therefore
+      // `oldEntityFromWorld * newWorldFromEntity`.
+      //
+      // The reverse order (`newWFE * oldEFW`) is an entity-local mapping,
+      // which collapses to the right answer ONLY when the old transform's
+      // linear part is identity. For a previously-resized element it
+      // misreports the canvas delta as `oldScale.inverse() * delta_doc`,
+      // so the cached bitmap moves at `delta_doc / scale` pixels per
+      // drag step while the overlay (driven by worldBounds) moves at
+      // `delta_doc`. See `LayerComposeOffsetReflectsDocumentDeltaForResized
+      // Element` for the regression pin.
+      const Transform2d delta = matchedLayer->bitmapEntityFromWorldTransform()->inverse() *
+                                newWorldFromEntity;
 
       const bool isSubtree = matchedLayer->firstEntity() != e || matchedLayer->lastEntity() != e;
       // Subtree layers require a pure-translation delta: only then can we
@@ -970,6 +989,15 @@ void CompositorController::renderFrame(const RenderViewport& viewport) {
   // rasterize at the post-drag position, producing misalignment
   // crescents at the sub-layers' rendered edges (the
   // `#Clouds_with_gradients` splash artifact).
+  // `worldFromEntityTransform` is stamped by `RenderingContext` as
+  // `absoluteTransform × canvasFromDocument` (for worldIsCanvas
+  // entities). With the canvas-from-canvas delta formula below
+  // (`oldEFW * newWFE`), the result is already in canvas-pixel space
+  // and feeds straight into the `setTransform` + `drawImage` compose
+  // pipeline. `ScaledCanvasTranslationOnlyDragProducesCorrectPixels`
+  // pins the 2× canvas (retina/zoomed) drag delta and
+  // `LayerComposeOffsetReflectsDocumentDeltaForResizedElement` pins
+  // the previously-resized-element drag delta.
   for (auto& layer : layers_) {
     if (!layer.hasValidBitmap() || !layer.bitmapEntityFromWorldTransform().has_value()) {
       continue;
@@ -980,7 +1008,29 @@ void CompositorController::renderFrame(const RenderViewport& viewport) {
     }
     const auto& instance = registry.get<components::RenderingInstanceComponent>(layer.entity());
     const Transform2d& bitmapStamp = *layer.bitmapEntityFromWorldTransform();
-    const Transform2d delta = instance.worldFromEntityTransform * bitmapStamp.inverse();
+    // Canvas-to-canvas delta for the cached bitmap. Applied to a canvas
+    // pixel `c_old` (where the bitmap content currently appears under
+    // the OLD `worldFromEntity`), the composition first walks back to
+    // entity-local via `oldEFW = oldWFE.inverse()`, then forward through
+    // the NEW `worldFromEntity`. With donner's left-to-right convention
+    // (`A * B`(v) = B(A(v))`), that's `oldEFW * newWFE`.
+    //
+    // The previous formula was `newWFE * oldEFW` followed by a
+    // `docFromCanvas * ... * canvasFromDoc` conjugation. Algebraically
+    // that produced the correct canvas-space delta ONLY when the old
+    // transform's linear part was identity — `newWFE * oldEFW` then
+    // collapses to `T_new * T_old.inverse()` (doc-space) and the
+    // conjugation lifts it to canvas-space. For a previously-resized
+    // element the cancellation fails: the old scale's inverse leaks
+    // into the result, the conjugation re-applies canvasFromDoc on top
+    // of an already canvas-space value, and the cached bitmap moves at
+    // `delta_doc / oldScale` canvas pixels per drag step — visibly
+    // behind the cursor while the overlay tracks correctly. See
+    // `LayerComposeOffsetReflectsDocumentDeltaForResizedElement`.
+    //
+    // The new composition produces canvas-from-canvas directly, so the
+    // conjugation has nothing to do and is gone.
+    const Transform2d delta = bitmapStamp.inverse() * instance.worldFromEntityTransform;
     if (delta.isTranslation()) {
       layer.setCanvasFromBitmap(delta);
     }

--- a/donner/svg/compositor/CompositorController.h
+++ b/donner/svg/compositor/CompositorController.h
@@ -514,12 +514,14 @@ private:
   /// Fast-path helper: a promoted subtree layer's root just shifted by a pure
   /// world-space translation. Descendants' local transforms are unchanged, so
   /// their world transforms shift by the same delta. Pre-multiply every
-  /// descendant RIC's `worldFromEntityTransform` by @p delta so subsequent
+  /// descendant RIC's `worldFromEntityTransform` by @p worldFromPreviousWorld
+  /// — the per-frame world-from-world delta that maps a point at its previous
+  /// frame's world position to its current world position — so subsequent
   /// reads (e.g. a forced re-rasterize later in the session, or the next
   /// frame's fast-path delta computation against a descendant-rooted layer)
   /// see up-to-date world positions.
   static void propagateFastPathTranslationToSubtree(Registry& registry, Entity root,
-                                                    const Transform2d& delta);
+                                                    const Transform2d& worldFromPreviousWorld);
 
   SVGDocument* document_ = nullptr;
   RendererInterface* renderer_ = nullptr;

--- a/donner/svg/compositor/CompositorController.h
+++ b/donner/svg/compositor/CompositorController.h
@@ -419,17 +419,6 @@ private:
   CompositorLayer* findLayer(Entity entity);
   const CompositorLayer* findLayer(Entity entity) const;
 
-  /// Lift @p delta into every descendant of @p root by pre-multiplying
-  /// their cached `worldFromEntityTransform` and invalidating the
-  /// `ComputedAbsoluteTransformComponent`. Called from the subtree fast
-  /// path when a promoted group root moves by a pure translation — the
-  /// layer's bitmap is reused, but descendants still need their world
-  /// transforms refreshed so a subsequent fast-path frame rooted
-  /// deeper in the subtree computes its delta against the current DOM
-  /// instead of a pre-drag cache.
-  static void propagateFastPathTranslationToSubtree(Registry& registry, Entity root,
-                                                    const Transform2d& delta);
-
   /// Rasterize a single promoted layer into its bitmap cache.
   void rasterizeLayer(CompositorLayer& layer, const RenderViewport& viewport);
 

--- a/donner/svg/compositor/CompositorController.h
+++ b/donner/svg/compositor/CompositorController.h
@@ -404,10 +404,31 @@ public:
   /// bucket layers keep their generation and their GL texture binding.
   [[nodiscard]] std::vector<CompositorTile> snapshotTilesForUpload() const;
 
+  /// Read-only accessor for the layer bound to @p entity. Test-only —
+  /// lets regression tests inspect `canvasFromBitmap` /
+  /// `bitmapEntityFromWorldTransform` after a drag frame to verify the
+  /// translation-only fast path engaged (bitmap stamp unchanged,
+  /// composition transform carries the delta). Production callers
+  /// should go through `isPromoted` / `promoteEntity` instead.
+  [[nodiscard]] const CompositorLayer* findLayerForTest(Entity entity) const {
+    return findLayer(entity);
+  }
+
 private:
   /// Find the layer for a given entity, or nullptr if not promoted.
   CompositorLayer* findLayer(Entity entity);
   const CompositorLayer* findLayer(Entity entity) const;
+
+  /// Lift @p delta into every descendant of @p root by pre-multiplying
+  /// their cached `worldFromEntityTransform` and invalidating the
+  /// `ComputedAbsoluteTransformComponent`. Called from the subtree fast
+  /// path when a promoted group root moves by a pure translation — the
+  /// layer's bitmap is reused, but descendants still need their world
+  /// transforms refreshed so a subsequent fast-path frame rooted
+  /// deeper in the subtree computes its delta against the current DOM
+  /// instead of a pre-drag cache.
+  static void propagateFastPathTranslationToSubtree(Registry& registry, Entity root,
+                                                    const Transform2d& delta);
 
   /// Rasterize a single promoted layer into its bitmap cache.
   void rasterizeLayer(CompositorLayer& layer, const RenderViewport& viewport);

--- a/donner/svg/compositor/CompositorGolden_tests.cc
+++ b/donner/svg/compositor/CompositorGolden_tests.cc
@@ -145,6 +145,238 @@ TEST_F(CompositorGoldenTest, TranslationOnlyDragProducesCorrectPixels) {
   EXPECT_THAT(getPixel(flat, 35, 35), IsWhite()) << "Original position now vacated";
 }
 
+// Editor-reported regression: when the compositor has a promoted layer
+// and the DOM transform changes by a pure translation, the fast path
+// should update `canvasFromBitmap` (cheap, ~50 µs) and NOT re-
+// rasterize the layer bitmap (~10-100 ms on real content). The spike
+// shows up as visible jank on the fps graph during drag. This guards
+// the fast path by checking that after a translation-only drag frame
+// the layer's `canvasFromBitmap` carries the delta AND the
+// bitmap's rasterize-time stamp is unchanged (which means the cached
+// bitmap was reused). Fires on regressions to:
+//   - `isTranslation()` returning false (e.g. `canvasFromDoc`
+//      conjugation introducing float drift that trips `NearEquals`);
+//   - `bitmapEntityFromWorldTransform` getting updated every frame
+//     (which would incorrectly make every delta `Identity`);
+//   - the dirty-flag consumer marking the drag target for re-raster
+//     even when the delta is pure translation.
+// Editor-reported regression: dragging a `<g filter>` group should
+// reuse the filter's cached bitmap via the compositor's translation-
+// only fast path, not re-rasterize the entire scene. Before the fix,
+// the fast-path eligibility check required `firstEntity == lastEntity
+// == e`, which is only true for single-entity layers. Subtree layers
+// (filter groups, clip-path groups, `<g>` with children) failed the
+// gate, forcing every drag frame through `prepareDocumentForRendering`
+// at ~25 ms/frame on real splash content.
+TEST_F(CompositorGoldenTest, DraggingFilterGroupSubtreeEngagesFastPath) {
+  SVGDocument document = parseDocument(R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+      <defs>
+        <filter id="blur"><feGaussianBlur stdDeviation="4"/></filter>
+      </defs>
+      <rect width="200" height="200" fill="white"/>
+      <g id="target" filter="url(#blur)">
+        <rect x="60" y="60" width="40" height="20" fill="red"/>
+        <rect x="60" y="100" width="40" height="20" fill="blue"/>
+      </g>
+    </svg>
+  )svg");
+
+  auto target = document.querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  const Entity entity = target->entityHandle().entity();
+
+  CompositorController compositor(document, renderer_);
+  // Promote with ActiveDrag so the drag target sets up the single-
+  // promoted-layer split path. The filter group itself is also auto-
+  // promoted by `MandatoryHintDetector`; the explicit promote here
+  // matches what `SelectTool::onMouseDown` does when the user clicks
+  // a filter group after the editor's `elevateToCompositingRoot`
+  // hoist.
+  ASSERT_TRUE(compositor.promoteEntity(entity, InteractionHint::ActiveDrag));
+
+  RenderViewport viewport;
+  viewport.size = Vector2d(200, 200);
+  viewport.devicePixelRatio = 1.0;
+  compositor.renderFrame(viewport);
+
+  const CompositorLayer* layer = compositor.findLayerForTest(entity);
+  ASSERT_NE(layer, nullptr) << "filter group must be a layer root";
+  ASSERT_TRUE(layer->hasValidBitmap());
+  const std::optional<Transform2d> stampAfterWarm = layer->bitmapEntityFromWorldTransform();
+  ASSERT_TRUE(stampAfterWarm.has_value());
+
+  // Drag. The filter group contains children, so `layer.firstEntity()
+  // != layer.lastEntity()` — the single-entity fast-path gate would
+  // have rejected this, forcing a full `prepareDocumentForRendering`
+  // re-run every frame.
+  target->cast<SVGGraphicsElement>().setTransform(Transform2d::Translate(Vector2d(10.0, 0.0)));
+  compositor.renderFrame(viewport);
+
+  const CompositorLayer* layerAfterDrag = compositor.findLayerForTest(entity);
+  ASSERT_NE(layerAfterDrag, nullptr);
+  ASSERT_TRUE(layerAfterDrag->hasValidBitmap());
+
+  // Fast-path signal #1: the layer's rasterize-time stamp hasn't
+  // moved. If it changed, `setBitmap` ran — slow path.
+  const std::optional<Transform2d> stampAfterDrag =
+      layerAfterDrag->bitmapEntityFromWorldTransform();
+  ASSERT_TRUE(stampAfterDrag.has_value());
+  EXPECT_NEAR(stampAfterDrag->data[4], stampAfterWarm->data[4], 1e-9)
+      << "filter-group layer was re-rasterized during drag instead of reusing "
+         "the cached bitmap — the `firstEntity == lastEntity == e` gate "
+         "rejected the subtree layer from the fast path";
+  EXPECT_NEAR(stampAfterDrag->data[5], stampAfterWarm->data[5], 1e-9);
+
+  // Fast-path signal #2: `canvasFromBitmap` carries the 10-px
+  // delta in canvas-pixel space.
+  const Transform2d canvasFromBitmap = layerAfterDrag->canvasFromBitmap();
+  ASSERT_TRUE(canvasFromBitmap.isTranslation());
+  EXPECT_NEAR(canvasFromBitmap.translation().x, 10.0, 1e-6);
+  EXPECT_NEAR(canvasFromBitmap.translation().y, 0.0, 1e-6);
+}
+
+TEST_F(CompositorGoldenTest, TranslationDragEngagesFastPathAtMultipleCanvasScales) {
+  for (double canvasScale : {1.0, 2.0, 1.5}) {
+    SCOPED_TRACE("canvasScale=" + std::to_string(canvasScale));
+    const int canvasDim = static_cast<int>(200.0 * canvasScale);
+    const std::string svgSource =
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"" + std::to_string(canvasDim) +
+        "\" height=\"" + std::to_string(canvasDim) +
+        "\" viewBox=\"0 0 200 200\">"
+        "<rect width=\"200\" height=\"200\" fill=\"white\"/>"
+        "<rect id=\"target\" x=\"20\" y=\"20\" width=\"40\" height=\"40\" fill=\"red\"/>"
+        "</svg>";
+    SVGDocument document = parseDocument(svgSource);
+
+    auto target = document.querySelector("#target");
+    ASSERT_TRUE(target.has_value());
+    const Entity entity = target->entityHandle().entity();
+
+    CompositorController compositor(document, renderer_);
+    ASSERT_TRUE(compositor.promoteEntity(entity, InteractionHint::ActiveDrag));
+
+    RenderViewport viewport;
+    viewport.size = Vector2d(canvasDim, canvasDim);
+    viewport.devicePixelRatio = 1.0;
+
+    // Warm the bitmap cache. At this point `bitmapEntityFromWorldTransform`
+    // is stamped against the current (identity-translation) DOM state.
+    compositor.renderFrame(viewport);
+
+    const CompositorLayer* layer = compositor.findLayerForTest(entity);
+    ASSERT_NE(layer, nullptr);
+    ASSERT_TRUE(layer->hasValidBitmap())
+        << "post-warm layer bitmap should be valid";
+    const std::optional<Transform2d> stampAfterWarm = layer->bitmapEntityFromWorldTransform();
+    ASSERT_TRUE(stampAfterWarm.has_value());
+
+    // Drag. SelectTool pre-multiplies the delta in parent (doc) space.
+    target->cast<SVGGraphicsElement>().setTransform(Transform2d::Translate(Vector2d(25.0, 0.0)));
+    compositor.renderFrame(viewport);
+
+    const CompositorLayer* layerAfterDrag = compositor.findLayerForTest(entity);
+    ASSERT_NE(layerAfterDrag, nullptr);
+    ASSERT_TRUE(layerAfterDrag->hasValidBitmap());
+
+    // The fast-path signal: the layer's `bitmapEntityFromWorldTransform`
+    // MUST be identical to the warmed stamp (no re-rasterize). If it
+    // was bumped to the new DOM transform, `setBitmap` ran, which
+    // means the slow path kicked in.
+    const std::optional<Transform2d> stampAfterDrag =
+        layerAfterDrag->bitmapEntityFromWorldTransform();
+    ASSERT_TRUE(stampAfterDrag.has_value());
+    EXPECT_NEAR(stampAfterDrag->data[0], stampAfterWarm->data[0], 1e-9)
+        << "bitmap stamp regressed: layer was re-rasterized instead of using "
+           "the translation-only fast path";
+    EXPECT_NEAR(stampAfterDrag->data[4], stampAfterWarm->data[4], 1e-9)
+        << "bitmap stamp regressed: layer was re-rasterized instead of using "
+           "the translation-only fast path";
+    EXPECT_NEAR(stampAfterDrag->data[5], stampAfterWarm->data[5], 1e-9)
+        << "bitmap stamp regressed: layer was re-rasterized instead of using "
+           "the translation-only fast path";
+
+    // And the canvasFromBitmap MUST carry the delta — 25 doc units
+    // at `canvasScale` → `25 * canvasScale` canvas pixels.
+    const Transform2d canvasFromBitmap = layerAfterDrag->canvasFromBitmap();
+    ASSERT_TRUE(canvasFromBitmap.isTranslation())
+        << "canvasFromBitmap should be a pure translation after a "
+           "translation-only drag; non-translation means the conjugation "
+           "produced an affine with scale/shear drift and would have marked "
+           "the layer dirty for re-rasterize";
+    const Vector2d delta = canvasFromBitmap.translation();
+    EXPECT_NEAR(delta.x, 25.0 * canvasScale, 1e-6)
+        << "delta should be in canvas-pixel space";
+    EXPECT_NEAR(delta.y, 0.0, 1e-6);
+  }
+}
+
+// Editor-reported bug repro: when the canvas is bigger than the viewBox —
+// e.g. HiDPI rendering at 2x, or zoomed-in interactive mode — a drag that
+// translates an element by N document units should produce a visible move
+// of N * canvasScale pixels. On Geode's split-bitmap path this was moving
+// the bitmap by N pixels (document units applied raw) while the rest of
+// the frame (and the selection chrome) correctly moved N * canvasScale.
+// Guarded here with a plain `CompositorController.renderFrame` so a
+// regression fires an assert even without an editor-level harness.
+TEST_F(CompositorGoldenTest, ScaledCanvasTranslationOnlyDragProducesCorrectPixels) {
+  // viewBox 100×100 rendered into a 200×200 canvas → 2× scale.
+  SVGDocument document = parseDocument(R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 100 100">
+      <rect width="100" height="100" fill="white"/>
+      <rect id="target" x="5" y="5" width="20" height="20" fill="red"/>
+    </svg>
+  )svg");
+
+  auto target = document.querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  const Entity entity = target->entityHandle().entity();
+
+  CompositorController compositor(document, renderer_);
+  ASSERT_TRUE(compositor.promoteEntity(entity));
+
+  RenderViewport scaledViewport;
+  scaledViewport.size = Vector2d(200, 200);
+  scaledViewport.devicePixelRatio = 1.0;
+
+  // Frame 1: initial render, stamps the layer bitmap at identity
+  // transform. This is the "pre-drag" frame the editor sends on
+  // select-before-drag to warm the cache.
+  compositor.renderFrame(scaledViewport);
+
+  // Now the user drags: DOM moves by 25 doc units → canvas 50 pixels
+  // (at 2× scale). Mirror SelectTool::onMouseMove's `Translate(deltaDoc)
+  // * startTransform` shape.
+  target->cast<SVGGraphicsElement>().setTransform(Transform2d::Translate(Vector2d(25.0, 0.0)));
+
+  // Frame 2: drag frame. Compositor picks up the delta against the
+  // stamped bitmap and applies a translation-only canvasFromBitmap
+  // instead of re-rasterizing. This is the path the user exercises
+  // during drag — if the delta is computed in doc space but applied
+  // in canvas-pixel space, the bitmap moves HALF the intended
+  // distance, producing a visible gap between the chrome AABB (which
+  // re-reads DOM canvas-space) and the rendered shape.
+  compositor.renderFrame(scaledViewport);
+
+  const RendererBitmap flat = renderer_.takeSnapshot();
+  // Original target center: doc (15, 15) → canvas (30, 30).
+  // After Translate(25, 0) in doc space: doc (40, 15) → canvas (80, 30).
+  EXPECT_THAT(getPixel(flat, 80, 30), IsRed())
+      << "after a fast-path drag the bitmap should be stamped at canvas "
+         "pixel (80, 30); any other offset means the compositor applied "
+         "the doc-space delta in pixel space and missed the canvasFromDoc "
+         "scale — this is the user-reported `shape moves half the distance "
+         "of the overlay` regression";
+  EXPECT_THAT(getPixel(flat, 30, 30), IsWhite())
+      << "original position now vacated — a stale bitmap here means the "
+         "compositor left the old stamp around AND overlaid a shifted copy";
+  // Probe the "moved half the distance" regression specifically: canvas
+  // pixel (55, 30) is where the bitmap lands if delta is applied raw.
+  EXPECT_THAT(getPixel(flat, 55, 30), IsWhite())
+      << "no bitmap residue at half-delta position — if this fails, the "
+         "split-bitmap path is treating doc-space translation as pixel-space";
+}
+
 // Targeted probe: when a top-level `<rect>` is bucketed in isolation, does
 // `rasterizeLayer` (via `RendererDriver::drawEntityRange`) produce the
 // correct pixels? Calls the same code path the bucketer triggers at

--- a/donner/svg/compositor/CompositorLayer.h
+++ b/donner/svg/compositor/CompositorLayer.h
@@ -149,6 +149,23 @@ public:
   void setBitmap(RendererBitmap bitmap, const Transform2d& worldFromEntityTransform) {
     bitmap_ = std::move(bitmap);
     bitmapEntityFromWorldTransform_ = worldFromEntityTransform;
+    // Reset the compose offset: the new bitmap captures the entity at
+    // `worldFromEntityTransform` (its CURRENT world position), so no
+    // additional offset is needed to display it at that position.
+    //
+    // Any `canvasFromBitmap_` value that was computed against the
+    // PREVIOUS (stale) bitmap stamp — e.g. the update loop in
+    // `renderFrame` that sets `delta = current_RIC - old_stamp`
+    // before `rasterizeDirtyLayersLoop` fires — is wrong for the new
+    // bitmap: displaying at `new_stamp + old_delta` double-offsets the
+    // element by (current - old). Resetting here brings the post-
+    // rasterize compose math back to "draw bitmap at stamped pos."
+    //
+    // Callers that want a specific compose offset on top of the
+    // freshly-rasterized bitmap (e.g. a drag hand-off that wants to
+    // preserve the in-flight screen position across the rasterize)
+    // must call `setCanvasFromBitmap` explicitly AFTER this.
+    canvasFromBitmap_ = Transform2d();
     dirty_ = false;
     ++generation_;
   }


### PR DESCRIPTION
## Summary

First of four Tier-1..4 PRs splitting general-purpose improvements out of the sandbox branch onto `main` (per [design 0032](docs/design_docs/0032-sandbox_branch_split.md)). This PR is the **compositor `#582` bundle** — four cherry-picks from sandbox that restore the `<g filter>` drag fast path and fix three positioning bugs that flowed from the same area.

- **`<g filter>` subtree fast path** (`4048a090`): relax the per-frame eligibility gate so subtree-rooted promoted layers qualify. Drags on `donner_splash.svg` go from ~25 ms/frame back to sub-frame.
- **#582 fix — fast-path subtree translation accumulates across frames** (`f32be87c`): pass the per-frame delta (not cumulative-since-stamp) into `propagateFastPathTranslationToSubtree`; descendants no longer drift forward by `n * frame_delta` after `n` frames.
- **Compose-offset order for resized elements** (`fd60ed9d`): compute canvas-from-canvas directly as `bitmapStamp.inverse() * worldFromEntity` so a resized-then-dragged shape tracks the cursor 1:1 instead of lagging by `oldScale`.
- **`setBitmap` resets `canvasFromBitmap_`** (`48ec5927`): clear the layer's compose offset when the bitmap is restamped, eliminating first-frame jitter after a re-rasterize.

Plus the design-doc work that's part of this bundle:

- `docs/design_docs/0025-composited_rendering.md` gets a ~200-line postmortem of the #582 investigation (root cause, why the dual-path `verifyPixelIdentity` assertion missed it, the four rounds of speculative fixes, what finally worked, follow-up action items).
- `CLAUDE.md` + `AGENTS.md` policy updates distilled from that postmortem: red→green transition required for fix commits, no boutique pixel-diff helpers, no dead/parallel reimplementations, etc.
- `docs/design_docs/0032-sandbox_branch_split.md` is the four-tier split plan itself; lives at the bottom of the editor-dev stack.

Automated coverage in `donner/svg/compositor/CompositorGolden_tests.cc` (`SplashDrag*`, `DraggingFilterGroupSubtreeEngagesFastPath`, `LayerComposeOffsetReflectsDocumentDeltaForResizedElement`, `ScaledCanvasTranslationOnlyDragProducesCorrectPixels`) pins each fix; `bazel test //...` green locally.

## Test plan

- [x] `bazel test //...` green locally.
- [x] Manual smoke on `donner_splash.svg`:
  - [x] Drag `Big_lightning_glow` — smooth, no frame stalls.
  - [x] Long circular drag on a `<g filter>` — cursor and shape stay coincident; no drift.
  - [x] Zoom canvas to non-100%, drag a filter group — shape tracks 1:1, no scale lag.
  - [x] Drag-release-drag — no first-frame jitter on the second drag.
  - [x] Non-filter drags (DONNER text, cloud paths) unaffected.

🤖 PR drafted by Claude (Opus 4.7) per the design 0032 split plan; review and edit as needed.