### PR TITLE
CI: skip-incompatible-explicit-targets in --config=ci

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -231,6 +231,15 @@ build:ci --local_test_jobs=HOST_CPUS
 build:ci --jobs=HOST_CPUS
 build:ci --verbose_failures
 build:ci --repository_cache=~/.cache/bazel-repo
+# Bazel-diff's `affected targets` list can include targets whose
+# `target_compatible_with` rules exclude the current host (the canonical
+# case: `//donner/editor/wasm:*` flagged on linux/macos hosts). Without
+# this flag bazel fails fast with "Target X is incompatible and cannot
+# be built, but was explicitly requested." With it, those targets are
+# silently skipped — which is the right behavior for a target-determinator-
+# generated list, since the host platform is the constraint, not the PR.
+# Avoids needing the `ci:full-test` PR label as a workaround.
+build:ci --skip_incompatible_explicit_targets
 
 # Allow `bazel run` on sharded test targets (sharding only applies to `bazel test`).
 run --test_sharding_strategy=disabled


### PR DESCRIPTION
## Summary

Adds `build:ci --skip_incompatible_explicit_targets` to `.bazelrc`.

When `main.yml`'s `determine-targets` step (bazel-diff) emits an affected-targets list that happens to include a target whose \`target_compatible_with\` excludes the runner platform — the canonical case is any \`//donner/editor/wasm:*\` target being flagged on a linux/macos host because compositor code transitively reaches it — bazel previously failed fast with:

\`\`\`
ERROR: Target //donner/editor/wasm:wasm is incompatible and cannot be built, but was explicitly requested.
\`\`\`

The current workaround (`ci:full-test` PR label → fallback to \`//...\`) gets the build green by switching to wildcard semantics where bazel silently skips incompatibles, but it pessimizes the whole PR to a full build for an infrastructure reason that has nothing to do with the diff. The flag is the canonical fix: skip incompatible explicit targets the same way bazel skips them under a wildcard, instead of failing the build.

After this lands the \`ci:full-test\` label is no longer needed for the wasm-incompatibility class of failure — PRs that touch the compositor stop needing the label workaround.

Scoped to \`build:ci\` deliberately: outside CI (developer workstation builds with explicitly-typed target paths) we keep the noisy failure so a typo or stale \`target_compatible_with\` rule is caught loudly. Only bazel-diff's machine-generated lists are the case where the caller didn't explicitly opt into the target.

## Test plan

- [x] Local verification — without the flag the build fails with \"incompatible and cannot be built\"; with the flag bazel logs \`Target //donner/editor/wasm:wasm was skipped\` and exits 0:

  \`\`\`
  $ bazel build --config=ci //donner/editor/wasm:wasm
  Target //donner/editor/wasm:wasm was skipped
  INFO: Build completed successfully, 1 total action
  \`\`\`

- [x] Normal target sanity (\`bazel test --config=ci //donner/svg/compositor:compositor_tests\`) still passes.
- [x] CI on this PR will exercise the same workflow path that previously needed the label. If it stays green without \`ci:full-test\`, the fix is good.

🤖 PR drafted by Claude (Opus 4.7) following operator feedback on PR #593 (\"we shouldn't need to add the full-test flag\").