### PR TITLE
tiny-skia: raise pixmap / filter allocation caps from 64 MiB to 1 GiB

### DIFF
--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -146,6 +146,19 @@ donner_cc_test(
 )
 
 donner_cc_test(
+    name = "zoom_filter_repro_tests",
+    srcs = ["ZoomFilterRepro_tests.cc"],
+    data = ["//:donner_splash.svg"],
+    deps = [
+        "//donner/svg",
+        "//donner/svg/parser",
+        "//donner/svg/renderer",
+        "//donner/svg/renderer:renderer_image_io",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
     name = "renderer_public_api_tests",
     srcs = [
         "RendererPublicApi_tests.cc",

--- a/donner/svg/renderer/tests/ZoomFilterRepro_tests.cc
+++ b/donner/svg/renderer/tests/ZoomFilterRepro_tests.cc
@@ -1,0 +1,201 @@
+/// @file
+/// Regression test for the "zoom-in-enough on splash → filters disappear"
+/// bug surfaced via the editor.
+///
+/// Two independent size caps in `third_party/tiny-skia-cpp` silently no-op'd
+/// renderer / filter work above 64 MiB:
+///
+///   - `Pixmap::fromSize` (and `Mask::fromSize`, `FloatPixmap::fromSize`,
+///     `FloatPixmap::fromPixmap`) rejected allocations > 64 MiB →
+///     viewport-sized main pixmaps above 4096×4096 RGBA failed and
+///     `takeSnapshot` returned empty.
+///   - `tiny_skia::filter::gaussianBlur(FloatPixmap&, …)` (and the uint8
+///     overload, and `Morphology`) returned early if the buffer exceeded
+///     64 MiB → the SourceGraphic flowed through unblurred, so the user
+///     saw lightning bolts rendered as hard paths instead of soft halos.
+///
+/// The user's editor repro: open the splash at default zoom, pinch-zoom
+/// in past ~9.18× (where the editor's `kMaxCanvasDim=8192` clamp kicks in
+/// on the 892×512 splash), and the blue glows around the bolts vanish.
+///
+/// These tests pin the regression at the renderer layer:
+///
+///   - Tiny pixmap (sanity)         — must always succeed.
+///   - 4096×4096 main pixmap        — at the prior 64 MiB cap boundary.
+///   - 8192×4708 main pixmap        — what the editor produces at
+///                                    `kMaxCanvasDim` on the splash; the
+///                                    snapshot must be non-empty.
+///   - Halo luma low vs high zoom   — the gaussian blur must apply at both
+///                                    canvas sizes. Without the fix, the
+///                                    high-zoom probe falls back to the
+///                                    raw deep-blue background and the
+///                                    luma delta jumps from ≤25 to ~37+.
+///
+/// All four tests dump PNGs to `$TEST_UNDECLARED_OUTPUTS_DIR` so a
+/// failing run gives the operator the actual pixels to look at.
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "donner/base/ParseWarningSink.h"
+#include "donner/svg/SVGDocument.h"
+#include "donner/svg/parser/SVGParser.h"
+#include "donner/svg/renderer/Renderer.h"
+#include "gtest/gtest.h"
+
+namespace donner::svg {
+namespace {
+
+std::string LoadSplash() {
+  std::ifstream stream("donner_splash.svg");
+  if (!stream.is_open()) {
+    return {};
+  }
+  std::ostringstream buf;
+  buf << stream.rdbuf();
+  return buf.str();
+}
+
+constexpr std::string_view kTinySvg =
+    R"(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+         <rect width="100" height="100" fill="red"/>
+       </svg>)";
+
+// Helper: parse `source`, set canvas, render, optionally save PNG, return
+// the snapshot.
+RendererBitmap RenderAt(std::string_view source, int width, int height, const char* outName) {
+  ParseWarningSink warningSink = ParseWarningSink::Disabled();
+  auto result = parser::SVGParser::ParseSVG(source, warningSink);
+  EXPECT_FALSE(result.hasError()) << "parse failed: " << result.error();
+  SVGDocument document = std::move(result.result());
+  document.setCanvasSize(width, height);
+  Renderer renderer;
+  renderer.draw(document);
+  if (outName != nullptr) {
+    if (const char* dir = std::getenv("TEST_UNDECLARED_OUTPUTS_DIR")) {
+      renderer.save((std::filesystem::path(dir) / outName).string().c_str());
+    }
+  }
+  return renderer.takeSnapshot();
+}
+
+// Sample an RGBA pixel from `bitmap` at the given device coords, returning
+// `{0, 0, 0, 0}` on out-of-bounds.
+std::array<uint8_t, 4> SamplePixel(const RendererBitmap& bitmap, int x, int y) {
+  if (x < 0 || y < 0 || x >= bitmap.dimensions.x || y >= bitmap.dimensions.y) {
+    return {0, 0, 0, 0};
+  }
+  const size_t stride =
+      bitmap.rowBytes ? bitmap.rowBytes : static_cast<size_t>(bitmap.dimensions.x) * 4;
+  const size_t offset = static_cast<size_t>(y) * stride + static_cast<size_t>(x) * 4;
+  return {bitmap.pixels[offset + 0], bitmap.pixels[offset + 1], bitmap.pixels[offset + 2],
+          bitmap.pixels[offset + 3]};
+}
+
+// Mean of `|luma(lo) - luma(hi)|` over a patch centered at `(lowX, lowY)`
+// in `lowZoom` and the proportionally-scaled point in `highZoom`. Used to
+// detect a filter going missing: with the blur on, the halo's luma matches
+// at both zoom levels; with the blur off, the high-zoom patch falls back
+// to the raw background and luma spikes.
+double MeanLumaDelta(const RendererBitmap& lowZoom, const RendererBitmap& highZoom, int lowX,
+                     int lowY, int patchRadius) {
+  const double scaleX =
+      static_cast<double>(highZoom.dimensions.x) / static_cast<double>(lowZoom.dimensions.x);
+  const double scaleY =
+      static_cast<double>(highZoom.dimensions.y) / static_cast<double>(lowZoom.dimensions.y);
+
+  double sumDelta = 0.0;
+  int count = 0;
+  for (int dy = -patchRadius; dy <= patchRadius; ++dy) {
+    for (int dx = -patchRadius; dx <= patchRadius; ++dx) {
+      const auto lo = SamplePixel(lowZoom, lowX + dx, lowY + dy);
+      const auto hi = SamplePixel(highZoom, static_cast<int>(std::round((lowX + dx) * scaleX)),
+                                  static_cast<int>(std::round((lowY + dy) * scaleY)));
+      // ITU-R BT.601 luma.
+      const double lumaLo = 0.299 * lo[0] + 0.587 * lo[1] + 0.114 * lo[2];
+      const double lumaHi = 0.299 * hi[0] + 0.587 * hi[1] + 0.114 * hi[2];
+      sumDelta += std::abs(lumaLo - lumaHi);
+      ++count;
+    }
+  }
+  return count > 0 ? sumDelta / count : 0.0;
+}
+
+TEST(ZoomFilterRepro, TinyCanvasRendersNonEmptySnapshot) {
+  // Sanity: a 100×100 canvas must render. If this fails, something is
+  // wrong with the test harness itself, not the cap.
+  const RendererBitmap snapshot = RenderAt(kTinySvg, 100, 100, /*outName=*/nullptr);
+  EXPECT_FALSE(snapshot.empty()) << "100×100 canvas produced an empty snapshot";
+}
+
+TEST(ZoomFilterRepro, SquareCanvasAtPriorCapBoundaryRenders) {
+  // 4096×4096 RGBA = exactly 64 MiB. The prior `Pixmap::fromSize` cap was
+  // `len.value() > kMaxAllocationBytes` (strict greater-than), so this size
+  // is on the boundary and was historically allowed.
+  const RendererBitmap snapshot = RenderAt(kTinySvg, 4096, 4096, /*outName=*/nullptr);
+  EXPECT_FALSE(snapshot.empty())
+      << "4096×4096 canvas (64 MiB exactly) failed to render — the cap may have moved.";
+}
+
+TEST(ZoomFilterRepro, SplashAtEditorClampBoundaryRenders) {
+  // The editor clamps `desiredCanvasSize` at `kMaxCanvasDim=8192` per axis,
+  // so at ~9.18× zoom on the 892×512 splash the canvas becomes 8192×4708
+  // (~154 MiB) — above the prior 64 MiB tiny-skia cap. Before the fix,
+  // `Pixmap::fromSize` returned `nullopt`, `frame_` was empty,
+  // `takeSnapshot` returned an empty bitmap, and the editor (which doesn't
+  // propagate the failure) ended up showing a stale or empty rendered
+  // image.
+  const std::string source = LoadSplash();
+  if (source.empty()) {
+    GTEST_SKIP() << "donner_splash.svg not in runfiles";
+  }
+  const RendererBitmap snapshot =
+      RenderAt(std::string_view{source}, 8192, 4708, "splash_at_editor_clamp_8192x4708.png");
+  EXPECT_FALSE(snapshot.empty())
+      << "Splash @ 8192×4708 produced an empty snapshot — main pixmap allocation failed. "
+         "Check `Pixmap::fromSize` cap in third_party/tiny-skia-cpp.";
+  // Renderer preserves the 892:512 viewBox aspect inside the requested canvas,
+  // so width matches exactly and height ends up at floor/round of
+  // `8192 * 512 / 892` ≈ 4703.79. Accept the aspect-preserved height range.
+  EXPECT_EQ(snapshot.dimensions.x, 8192);
+  EXPECT_GE(snapshot.dimensions.y, 4700);
+  EXPECT_LE(snapshot.dimensions.y, 4708);
+}
+
+TEST(ZoomFilterRepro, SplashHaloSurvivesHighZoom) {
+  // The gaussian blur halos around the splash's lightning bolts must
+  // survive a high-canvas render. Without the filter-primitive cap raises,
+  // `gaussianBlur(FloatPixmap&, …)` silently returns early on viewport-
+  // sized SourceGraphic float buffers above ~2048×2048 floats — the blur
+  // disappears while every other element renders normally. This produces a
+  // luma swing of ~37+ at the Lightning_glow_dark halo probe; with the
+  // blur intact, the delta is ≤25.
+  const std::string source = LoadSplash();
+  if (source.empty()) {
+    GTEST_SKIP() << "donner_splash.svg not in runfiles";
+  }
+  const RendererBitmap lo = RenderAt(std::string_view{source}, 892, 512, "splash_halo_lo.png");
+  ASSERT_FALSE(lo.empty());
+  const RendererBitmap hi = RenderAt(std::string_view{source}, 8192, 4708, "splash_halo_hi.png");
+  ASSERT_FALSE(hi.empty());
+
+  // Probe inside the Lightning_glow_dark halo on the small bottom bolt
+  // (low-zoom doc coords near (478, 440)) — the bright cyan glow that's
+  // visible in the low-zoom reference. When the gaussian blur no-ops at
+  // high zoom this region falls back to the deep-blue background.
+  const double delta = MeanLumaDelta(lo, hi, /*lowX=*/478, /*lowY=*/440, /*patchRadius=*/4);
+  EXPECT_LT(delta, 25.0) << "Halo luma at low vs high zoom differs by " << delta
+                         << " — a gaussian blur on the splash is no-op'ing at the high canvas. "
+                            "The blur primitive's defensive size cap is the likely cause: check "
+                            "third_party/tiny-skia-cpp/src/tiny_skia/filter/"
+                            "{GaussianBlur,Morphology,FloatPixmap}.{cpp,h}.";
+}
+
+}  // namespace
+}  // namespace donner::svg

--- a/third_party/tiny-skia-cpp/src/tiny_skia/Mask.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/Mask.cpp
@@ -14,7 +14,12 @@ std::optional<Mask> Mask::fromSize(std::uint32_t width, std::uint32_t height) {
   }
 
   const auto dataLen = static_cast<std::size_t>(width) * static_cast<std::size_t>(height);
-  constexpr std::size_t kMaxAllocationBytes = 64 * 1024 * 1024;
+  // Same defensive cap (1 GiB) as `Pixmap::fromSize`. Masks are 1 byte/pixel
+  // so this allows up to ~32768×32768 — comfortably above any reasonable
+  // editor / renderer use case while still rejecting maliciously-large input.
+  // See `Pixmap.cpp` for the rationale and the regression that drove raising
+  // the cap from the prior 64 MiB.
+  constexpr std::size_t kMaxAllocationBytes = 1024ULL * 1024ULL * 1024ULL;
   if (dataLen > kMaxAllocationBytes) {
     return std::nullopt;
   }

--- a/third_party/tiny-skia-cpp/src/tiny_skia/Pixmap.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/Pixmap.cpp
@@ -172,10 +172,19 @@ std::optional<Pixmap> Pixmap::fromSize(std::uint32_t width, std::uint32_t height
     return std::nullopt;
   }
 
-  // Defensive cap: reject large allocations to prevent OOM crashes on memory-constrained
-  // systems. With -fno-exceptions, std::vector's allocator calls std::terminate instead of
-  // throwing std::bad_alloc, so we must reject before allocating.
-  constexpr std::size_t kMaxAllocationBytes = 64 * 1024 * 1024;
+  // Defensive cap: reject malicious / accidental large allocations rather than
+  // crashing the process. With -fno-exceptions, std::vector's allocator calls
+  // std::terminate instead of throwing std::bad_alloc, so we must reject before
+  // allocating. The cap is set at 1 GiB — large enough for desktop renderer
+  // usage (donner's editor allows up to 8192×8192 RGBA = 256 MiB main canvas
+  // plus offscreen pixmaps for filter / mask / shadow-tree rasterization) and
+  // small enough to reject obviously-bad inputs (a viewBox claiming
+  // 100000×100000 would need ~40 GiB and is rejected outright).
+  //
+  // The previous 64 MiB value capped at 4096×4096 RGBA, which is below the
+  // editor's max canvas and silently broke filter rendering at moderate-to-
+  // high zoom — see `ZoomFilterRepro_tests.cc` for the regression.
+  constexpr std::size_t kMaxAllocationBytes = 1024ULL * 1024ULL * 1024ULL;
   if (len.value() > kMaxAllocationBytes) {
     return std::nullopt;
   }

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/FloatPixmap.h
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/FloatPixmap.h
@@ -33,9 +33,15 @@ class FloatPixmap {
       return std::nullopt;
     }
     const std::size_t count = static_cast<std::size_t>(width) * height * 4;
-    // Defensive cap: reject large allocations to prevent OOM crashes on memory-constrained
-    // systems. With -fno-exceptions, OOM calls std::terminate instead of throwing.
-    constexpr std::size_t kMaxAllocationBytes = 64 * 1024 * 1024;
+    // Defensive cap: reject malicious / accidental large allocations rather
+    // than crashing the process. With -fno-exceptions, OOM calls std::terminate
+    // instead of throwing. 1 GiB cap matches `Pixmap::fromSize` and the filter
+    // primitives' caps so a `FloatPixmap` can hold the float conversion of
+    // any `Pixmap` the allocator already accepted. The prior 64 MiB capped
+    // float pixmaps at ~2048×2048, which contributed to filters silently
+    // failing at high editor zoom — see `GaussianBlur.cpp` and
+    // `ZoomFilterRepro_tests.cc`.
+    constexpr std::size_t kMaxAllocationBytes = 1024ULL * 1024ULL * 1024ULL;
     if (count * sizeof(float) > kMaxAllocationBytes) {
       return std::nullopt;
     }

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/GaussianBlur.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/GaussianBlur.cpp
@@ -351,8 +351,10 @@ void gaussianBlur(Pixmap& pixmap, double sigmaX, double sigmaY, BlurEdgeMode edg
     return;
   }
 
-  // Guard against OOM: each buffer is width*height*4 bytes.
-  constexpr std::size_t kMaxAllocationBytes = 64 * 1024 * 1024;
+  // Guard against OOM: each buffer is width*height*4 bytes. 1 GiB cap to
+  // match the float variant below and `Pixmap::fromSize`. See the float
+  // overload's comment for the rationale.
+  constexpr std::size_t kMaxAllocationBytes = 1024ULL * 1024ULL * 1024ULL;
   const std::size_t bufferSize = static_cast<std::size_t>(width) * height * 4;
   if (bufferSize > kMaxAllocationBytes) {
     return;
@@ -411,8 +413,16 @@ void gaussianBlur(FloatPixmap& pixmap, double sigmaX, double sigmaY, BlurEdgeMod
     return;
   }
 
-  // Guard against OOM: each buffer is width*height*4 floats.
-  constexpr std::size_t kMaxAllocationBytes = 64 * 1024 * 1024;
+  // Guard against OOM: each buffer is width*height*4 floats. The cap
+  // matches `Pixmap::fromSize`'s 1 GiB defensive ceiling — large enough
+  // to handle a viewport-sized SourceGraphic (e.g. the editor's worst
+  // case at the `kMaxCanvasDim=8192` clamp boundary requires ~616 MiB
+  // of float buffer per blur scratch), small enough to reject inputs
+  // claiming pathological sizes. The prior 64 MiB cap silently no-op'd
+  // the blur whenever the SourceGraphic exceeded ~2048×2048 floats —
+  // which is the path the editor hits at high zoom, surfacing as
+  // "filters disappear when I zoom in." See `ZoomFilterRepro_tests.cc`.
+  constexpr std::size_t kMaxAllocationBytes = 1024ULL * 1024ULL * 1024ULL;
   const std::size_t bufferSize = static_cast<std::size_t>(width) * height * 4 * sizeof(float);
   if (bufferSize > kMaxAllocationBytes) {
     return;

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/Morphology.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/Morphology.cpp
@@ -240,8 +240,10 @@ void morphology(const Pixmap& src, Pixmap& dst, MorphologyOp op, int radiusX, in
   auto dstData = dst.data();
 
   const std::size_t totalBytes = static_cast<std::size_t>(w) * h * 4;
-  // Guard against OOM.
-  constexpr std::size_t kMaxAllocationBytes = 64 * 1024 * 1024;
+  // Guard against OOM. 1 GiB cap consistent with `GaussianBlur` and
+  // `Pixmap::fromSize`; see those for the rationale and the regression
+  // that surfaced from the prior 64 MiB value.
+  constexpr std::size_t kMaxAllocationBytes = 1024ULL * 1024ULL * 1024ULL;
   if (totalBytes > kMaxAllocationBytes) {
     return;
   }


### PR DESCRIPTION
## Summary

Filters silently disappeared in the editor when zooming in past the `kMaxCanvasDim=8192` clamp boundary on the splash (e.g. ~9.18× on `donner_splash.svg`). Two independent 64 MiB defensive caps in `third_party/tiny-skia-cpp` were rejecting the viewport-sized work without surfacing an error:

1. **`tiny_skia::Pixmap::fromSize`** rejects allocations > 64 MiB (= any pixmap > 4096×4096 RGBA). The editor's worst-case main canvas at the clamp boundary is 8192×4708 ≈ 154 MiB, so the renderer's `frame_` failed to allocate, `takeSnapshot` returned empty, and the editor reused a stale frame. `Mask::fromSize` and `FloatPixmap::fromSize` carry the same cap for the same reason.
2. **`tiny_skia::filter::gaussianBlur(FloatPixmap&, …)`** returns early without applying the blur when the buffer exceeds 64 MiB. The editor's filter graph operates on a viewport-sized SourceGraphic (`frame.pixmap` in the device-space fallback in `popFilterLayer`), so at high zoom the float conversion is ~616 MiB and the blur silently no-ops — the SourceGraphic flows through unchanged. The uint8 overload, `Morphology`, and `FloatPixmap` constructors carry the same cap for symmetry.

The user-visible bug is the second cap; the first cap was a separate latent failure mode that the regression test surfaced along the way. Both are fixed.

Raised all five caps to 1 GiB:

- Large enough for the editor's full zoom range — 8192×8192 RGBA = 256 MiB, viewport-sized float SourceGraphic at the clamp boundary = 616 MiB, comfortably below 1 GiB.
- Still rejecting malicious / accidental inputs — a viewBox claiming 100000×100000 needs ~40 GiB and is rejected outright.
- Consistent across the renderer pipeline so a follow-up investigator doesn't have to chase a different cap at each layer of the filter graph.

## Files

- `third_party/tiny-skia-cpp/src/tiny_skia/Pixmap.cpp`
- `third_party/tiny-skia-cpp/src/tiny_skia/Mask.cpp`
- `third_party/tiny-skia-cpp/src/tiny_skia/filter/GaussianBlur.cpp` (uint8 + float overloads)
- `third_party/tiny-skia-cpp/src/tiny_skia/filter/Morphology.cpp`
- `third_party/tiny-skia-cpp/src/tiny_skia/filter/FloatPixmap.h`
- `donner/svg/renderer/tests/ZoomFilterRepro_tests.cc` (new — regression pins for both failure modes)
- `donner/svg/renderer/tests/BUILD.bazel` (test target)

## Test plan

- [x] `bazel test //...` green (519 pass, 51 skipped).
- [x] **Red→green proven on the gaussian-blur path** — `SplashHaloSurvivesHighZoom` reports `delta=37.0` with the prior 64 MiB float cap and `delta<25` after the cap raise. Verified by toggling the cap back temporarily.
- [x] **Red→green proven on the snapshot path** — `SplashAtEditorClampBoundaryRenders` fails (empty snapshot) at the old 64 MiB Pixmap cap and passes at 1 GiB.
- [x] **End-to-end in the editor** — operator confirmed: open `donner_splash.svg`, pinch-zoom past the `kMaxCanvasDim` clamp threshold, the cyan glow halos around the lightning bolts now stay applied. Previously they vanished.
- [x] All four tests dump PNGs to `\$TEST_UNDECLARED_OUTPUTS_DIR` so a future failure gives the operator the pixels to look at.

🤖 PR drafted by Claude (Opus 4.7); root cause traced via debug print at the `gaussianBlur(FloatPixmap&)` cap and confirmed by toggling each cap independently to isolate which one drove the user-visible symptom.