### PR TITLE
Editor polish: Scale/rotate shape support and Geode/WASM compatibility

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -238,6 +238,7 @@ git_override(
         "//third_party/patches:imgui_bazel_build_files.patch",
         "//third_party/patches:imgui_wgpu_texture_cache.patch",
         "//third_party/patches:imgui_wgpu_premultiplied_textures.patch",
+        "//third_party/patches:imgui_wgpu_emscripten_dawn.patch",
     ],
     patch_strip = 1,
 )

--- a/donner/base/Path.cc
+++ b/donner/base/Path.cc
@@ -76,15 +76,51 @@ Box2d Path::bounds() const {
 }
 
 Box2d Path::transformedBounds(const Transform2d& transform) const {
-  // Transform all points and compute bounds on the transformed path.
-  // For curves, this is an approximation (transforms the control points, not the exact curve).
-  // For tight bounds, transform then recompute, but for most uses this is sufficient.
   if (points_.empty()) {
     return Box2d();
   }
 
-  // Simple approach: transform the bounding box.
-  return transform.transformBox(bounds());
+  const auto transformedPoint = [&transform](const Vector2d& point) {
+    return transform.transformPosition(point);
+  };
+
+  Box2d box = Box2d::CreateEmpty(transformedPoint(points_[0]));
+
+  for (const auto& cmd : commands_) {
+    switch (cmd.verb) {
+      case Verb::MoveTo:
+      case Verb::LineTo: box.addPoint(transformedPoint(points_[cmd.pointIndex])); break;
+
+      case Verb::QuadTo: {
+        const Vector2d start = transformedPoint(
+            (cmd.pointIndex >= 2)
+                ? points_[cmd.pointIndex - 1]
+                : (cmd.pointIndex >= 1 ? points_[cmd.pointIndex - 1] : points_[0]));
+        const Vector2d control = transformedPoint(points_[cmd.pointIndex]);
+        const Vector2d end = transformedPoint(points_[cmd.pointIndex + 1]);
+        const Box2d qBounds = QuadraticBounds(start, control, end);
+        box.addPoint(qBounds.topLeft);
+        box.addPoint(qBounds.bottomRight);
+        break;
+      }
+
+      case Verb::CurveTo: {
+        const Vector2d start =
+            transformedPoint((cmd.pointIndex >= 1) ? points_[cmd.pointIndex - 1] : points_[0]);
+        const Vector2d c1 = transformedPoint(points_[cmd.pointIndex]);
+        const Vector2d c2 = transformedPoint(points_[cmd.pointIndex + 1]);
+        const Vector2d end = transformedPoint(points_[cmd.pointIndex + 2]);
+        const Box2d cBounds = CubicBounds(start, c1, c2, end);
+        box.addPoint(cBounds.topLeft);
+        box.addPoint(cBounds.bottomRight);
+        break;
+      }
+
+      case Verb::ClosePath: break;
+    }
+  }
+
+  return box;
 }
 
 namespace {

--- a/donner/base/tests/Path_tests.cc
+++ b/donner/base/tests/Path_tests.cc
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
 #include <sstream>
 
 #include "donner/base/MathUtils.h"
@@ -417,6 +418,16 @@ TEST(Path, TransformedBoundsScale) {
   Box2d transformed = path.transformedBounds(Transform2d::Scale({2, 3}));
   ExpectNear(transformed.topLeft, Vector2d(0, 0));
   ExpectNear(transformed.bottomRight, Vector2d(20, 60));
+}
+
+TEST(Path, TransformedBoundsUsesTightTransformedPathNotTransformedLocalAabb) {
+  Path path = PathBuilder().moveTo({0, 0}).lineTo({100, 0}).lineTo({0, 10}).closePath().build();
+  const Box2d transformed =
+      path.transformedBounds(Transform2d::Rotate(MathConstants<double>::kPi / 4.0));
+
+  const double sqrtHalf = std::sqrt(0.5);
+  ExpectNear(transformed.topLeft, Vector2d(-10.0 * sqrtHalf, 0.0));
+  ExpectNear(transformed.bottomRight, Vector2d(100.0 * sqrtHalf, 100.0 * sqrtHalf));
 }
 
 // =============================================================================

--- a/donner/editor/AsyncRenderer.cc
+++ b/donner/editor/AsyncRenderer.cc
@@ -186,13 +186,11 @@ void AsyncRenderer::setWakeCallback(std::function<void()> callback) {
 }
 
 void AsyncRenderer::workerLoop() {
-  // Construct the Renderer on the worker thread so all its backend-owned
-  // resources (WebGPU device/queue/textures under Geode, etc.) are
-  // created and used from a single thread. Under
-  // Emscripten pthreads this is load-bearing: `WebGPU.Internals.jsObjects`
-  // is per-worker, and crossing thread boundaries triggers a
-  // `getJsObject` assert on the first `wgpuDeviceCreateTexture`.
-  svg::Renderer renderer;
+#ifdef __EMSCRIPTEN__
+  // Emscripten's WebGPU object table is per-worker. Construct and use the
+  // renderer on this pthread so wgpu handles never cross JS worker boundaries.
+  svg::Renderer workerRenderer;
+#endif
 
   while (true) {
     std::optional<RenderRequest> requestStorage;
@@ -204,8 +202,8 @@ void AsyncRenderer::workerLoop() {
                std::holds_alternative<ShutdownState>(workerState_);
       });
       if (std::holds_alternative<ShutdownState>(workerState_)) {
-        // `renderer` is destroyed here as the local unwinds, i.e. on
-        // the worker thread — mirroring its construction.
+        // `workerRenderer` is destroyed here in Emscripten builds, i.e. on
+        // the worker thread, mirroring its construction.
         return;
       }
       if (std::holds_alternative<CancellingState>(workerState_)) {
@@ -227,7 +225,13 @@ void AsyncRenderer::workerLoop() {
       rendering->pendingRequest.reset();
     }
     RenderRequest& request = *requestStorage;
+#ifdef __EMSCRIPTEN__
+    svg::Renderer& requestRenderer = workerRenderer;
+#else
+    // Native Geode editor builds intentionally use the request renderer so
+    // worker texture snapshots are created on the same WGPU device as ImGui.
     svg::Renderer& requestRenderer = request.lease.renderer();
+#endif
     svg::SVGDocument& requestDocument = request.lease.document();
 
     // §M4: every iteration starts with a fresh (non-cancelled) token.

--- a/donner/editor/AsyncRenderer.cc
+++ b/donner/editor/AsyncRenderer.cc
@@ -423,6 +423,11 @@ void AsyncRenderer::workerLoop() {
         return Vector2d(scaleX != 0.0 ? canvas.x / scaleX : 0.0,
                         scaleY != 0.0 ? canvas.y / scaleY : 0.0);
       };
+      const Transform2d canvasFromDocument = requestDocument.canvasFromDocumentTransform();
+      const Transform2d documentFromCanvas = canvasFromDocument.inverse();
+      const auto documentFromCachedDocument = [&](const Transform2d& canvasFromCachedCanvas) {
+        return canvasFromDocument * canvasFromCachedCanvas * documentFromCanvas;
+      };
       const auto publishedTextureMatches = [this](const std::string& tileId,
                                                   RenderResult::CompositedTile::Kind kind,
                                                   std::uint64_t generation,
@@ -498,7 +503,8 @@ void AsyncRenderer::workerLoop() {
         tile.bitmapDimsDoc = canvasToDoc(
             Vector2d(static_cast<double>(ct.bitmapDims.x), static_cast<double>(ct.bitmapDims.y)));
         if (ct.layerEntity != entt::null) {
-          tile.dragTranslationDoc = canvasToDoc(ct.canvasFromBitmap.translation());
+          tile.documentFromCachedDocument = documentFromCachedDocument(ct.canvasFromBitmap);
+          tile.dragTranslationDoc = tile.documentFromCachedDocument.translation();
         }
         tile.isDragTarget = ct.isDragTarget;
         if (!metadataOnly) {

--- a/donner/editor/AsyncRenderer.cc
+++ b/donner/editor/AsyncRenderer.cc
@@ -51,6 +51,19 @@ RenderResult::CompositedPreview BuildFullCanvasCompositedPreview(
 
 }  // namespace
 
+PresentationSnapshotPlan ChoosePresentationSnapshotPlan(bool hasCompositedPreview,
+                                                        bool requiresTextureSnapshotPresentation) {
+  if (requiresTextureSnapshotPresentation) {
+    return PresentationSnapshotPlan{
+        .captureTextureSnapshot = !hasCompositedPreview,
+    };
+  }
+
+  return PresentationSnapshotPlan{
+      .captureCpuSnapshot = true,
+  };
+}
+
 AsyncRenderer::AsyncRenderer() {
   thread_ = std::thread([this] { workerLoop(); });
 }
@@ -202,8 +215,10 @@ void AsyncRenderer::workerLoop() {
                std::holds_alternative<ShutdownState>(workerState_);
       });
       if (std::holds_alternative<ShutdownState>(workerState_)) {
+#ifdef __EMSCRIPTEN__
         // `workerRenderer` is destroyed here in Emscripten builds, i.e. on
         // the worker thread, mirroring its construction.
+#endif
         return;
       }
       if (std::holds_alternative<CancellingState>(workerState_)) {
@@ -228,8 +243,8 @@ void AsyncRenderer::workerLoop() {
 #ifdef __EMSCRIPTEN__
     svg::Renderer& requestRenderer = workerRenderer;
 #else
-    // Native Geode editor builds intentionally use the request renderer so
-    // worker texture snapshots are created on the same WGPU device as ImGui.
+    // Geode editor builds intentionally use the request renderer so worker texture snapshots are
+    // created on the same WGPU device as ImGui presentation.
     svg::Renderer& requestRenderer = request.lease.renderer();
 #endif
     svg::SVGDocument& requestDocument = request.lease.document();
@@ -243,6 +258,7 @@ void AsyncRenderer::workerLoop() {
     // Execute the render outside the lock so the UI thread can poll
     // `isBusy()` / `pollResult()` while we work.
     ZoneScopedN("AsyncRenderer::workerIteration");
+    const auto workerStart = std::chrono::steady_clock::now();
     std::optional<RenderResult::CompositedPreview> compositedPreview;
 
     // Compositor lifecycle is split into two independent decisions:
@@ -528,20 +544,14 @@ void AsyncRenderer::workerLoop() {
       };
     };
 
-    double workerMs = 0.0;
     bool renderCompleted = true;
-    const auto renderStart = std::chrono::steady_clock::now();
     {
       ZoneScopedN("Compositor::renderFrame");
-      // Wall-clock the core backend render so the editor can plot it
-      // on the frame graph next to the ImGui frame time. This measures
-      // the actual work the compositor performs per request, not the
-      // total worker iteration (which also pays for takeSnapshot and
-      // the result handoff). Scoped here so Tracy's zone cost isn't
-      // included either.
+      // The final worker timing below intentionally covers the whole
+      // presentation-gating iteration, including any readback or tile
+      // snapshot work after renderFrame. Keep this scoped timing in
+      // Tracy only for drilling into the compositor itself.
       renderCompleted = compositor_->renderFrame(viewport, cancelRender_);
-      const auto renderEnd = std::chrono::steady_clock::now();
-      workerMs = std::chrono::duration<double, std::milli>(renderEnd - renderStart).count();
     }
 
     // §M4: a cancelled render leaves compositor dirty flags ready for the next
@@ -576,16 +586,17 @@ void AsyncRenderer::workerLoop() {
     (void)request.selection;
     svg::RendererBitmap bitmap;
     std::shared_ptr<const svg::RendererTextureSnapshot> fullCanvasTexture;
-    if (requestRenderer.requiresTextureSnapshotPresentation()) {
-      if (!compositedPreview.has_value()) {
-        ZoneScopedN("Renderer::takeTextureSnapshot");
-        fullCanvasTexture = requestRenderer.takeTextureSnapshot();
-        UTILS_RELEASE_ASSERT_MSG(
-            fullCanvasTexture != nullptr,
-            "Geode full-canvas presentation did not produce a GPU texture. Refusing CPU "
-            "readback/upload fallback in Geode presentation mode.");
-      }
-    } else {
+    const PresentationSnapshotPlan snapshotPlan = ChoosePresentationSnapshotPlan(
+        compositedPreview.has_value(), requestRenderer.requiresTextureSnapshotPresentation());
+    if (snapshotPlan.captureTextureSnapshot) {
+      ZoneScopedN("Renderer::takeTextureSnapshot");
+      fullCanvasTexture = requestRenderer.takeTextureSnapshot();
+      UTILS_RELEASE_ASSERT_MSG(
+          fullCanvasTexture != nullptr,
+          "Geode full-canvas presentation did not produce a GPU texture. Refusing CPU "
+          "readback/upload fallback in Geode presentation mode.");
+    }
+    if (snapshotPlan.captureCpuSnapshot) {
       ZoneScopedN("Renderer::takeSnapshot");
       bitmap = requestRenderer.takeSnapshot();
     }
@@ -616,7 +627,6 @@ void AsyncRenderer::workerLoop() {
         done.result.bitmap = std::move(bitmap);
         done.result.compositedPreview = std::move(compositedPreview);
         done.result.version = request.version;
-        done.result.workerMs = workerMs;
         lastFastPathCounters_ = compositor_->fastPathCountersForTesting();
         lastLayerInspectorRows_ = compositor_->snapshotLayerInspectorRows();
         lastSegmentInspectorRows_ = compositor_->snapshotSegmentInspectorRows();
@@ -624,6 +634,10 @@ void AsyncRenderer::workerLoop() {
         lastStateSnapshot_ = compositor_->snapshotState();
         lastWorkerCompositorEntity_ = compositorEntity_;
         lastDocumentCanvasSize_ = canvasSize;
+        const auto workerEnd = std::chrono::steady_clock::now();
+        const double workerMs =
+            std::chrono::duration<double, std::milli>(workerEnd - workerStart).count();
+        done.result.workerMs = workerMs;
         workerState_ = std::move(done);
         // Snapshot the callback under the lock so a concurrent
         // `setWakeCallback` swap can't tear the invocation. Fire it

--- a/donner/editor/AsyncRenderer.h
+++ b/donner/editor/AsyncRenderer.h
@@ -44,6 +44,7 @@
 #include <vector>
 
 #include "donner/base/EcsRegistry.h"
+#include "donner/base/Transform.h"
 #include "donner/base/Vector2.h"
 #include "donner/svg/SVGDocument.h"
 #include "donner/svg/SVGElement.h"
@@ -99,6 +100,9 @@ struct RenderRequest {
     svg::compositor::InteractionHint interactionKind = svg::compositor::InteractionHint::ActiveDrag;
     /// Active drag translation represented by this request. Selection prewarms use zero.
     Vector2d translation = Vector2d::Zero();
+    /// Active affine transform represented by this request. Selection
+    /// prewarms use identity.
+    Transform2d documentFromCachedDocument = Transform2d();
     /// Monotonic id for the active drag gesture. Selection prewarms use zero.
     std::uint64_t dragGeneration = 0;
   };
@@ -188,6 +192,8 @@ struct RenderResult {
     /// adds this to `canvasOffsetDoc` so the dragged tile slides in
     /// real time without re-rasterizing.
     Vector2d dragTranslationDoc = Vector2d::Zero();
+    /// Affine transform from cached document placement to presented document placement.
+    Transform2d documentFromCachedDocument = Transform2d();
     /// True when this tile is the active drag target. Useful for
     /// pre-test inspection; the editor's blit math treats drag and
     /// non-drag tiles uniformly via `dragTranslationDoc`.

--- a/donner/editor/AsyncRenderer.h
+++ b/donner/editor/AsyncRenderer.h
@@ -99,6 +99,8 @@ struct RenderRequest {
     svg::compositor::InteractionHint interactionKind = svg::compositor::InteractionHint::ActiveDrag;
     /// Active drag translation represented by this request. Selection prewarms use zero.
     Vector2d translation = Vector2d::Zero();
+    /// Monotonic id for the active drag gesture. Selection prewarms use zero.
+    std::uint64_t dragGeneration = 0;
   };
 
   /**

--- a/donner/editor/AsyncRenderer.h
+++ b/donner/editor/AsyncRenderer.h
@@ -1,9 +1,9 @@
 #pragma once
 /// @file
 ///
-/// `AsyncRenderer` owns a `svg::Renderer` and runs its `draw()` +
-/// `takeSnapshot()` on a dedicated worker thread so heavy renders
-/// don't block the UI thread.
+/// `AsyncRenderer` owns a `svg::Renderer` and runs compositor rendering plus
+/// any final presentation snapshot handoff on a dedicated worker thread so
+/// heavy renders don't block the UI thread.
 ///
 /// ## Threading model
 ///
@@ -146,7 +146,25 @@ struct RenderRequest {
   std::optional<DragPreview> dragPreview;
 };
 
-/// Bitmap plus the document version it was rendered from.
+/// Final full-canvas snapshot work needed after compositor rendering.
+struct PresentationSnapshotPlan {
+  /// Capture a CPU bitmap with `Renderer::takeSnapshot()`.
+  bool captureCpuSnapshot = false;
+  /// Capture a GPU texture snapshot with `Renderer::takeTextureSnapshot()`.
+  bool captureTextureSnapshot = false;
+};
+
+/**
+ * Choose final full-canvas snapshot work for a render result.
+ *
+ * @param hasCompositedPreview True when compositor tiles already provide the presented pixels.
+ * @param requiresTextureSnapshotPresentation True when presentation must remain on GPU textures.
+ * @return The final snapshot plan for this worker iteration.
+ */
+[[nodiscard]] PresentationSnapshotPlan ChoosePresentationSnapshotPlan(
+    bool hasCompositedPreview, bool requiresTextureSnapshotPresentation);
+
+/// Presentation payload plus the document version it was rendered from.
 struct RenderResult {
   /// One composite tile from the worker's `CompositorController::
   /// snapshotCompositorTiles()` snapshot (design doc 0033 §M2C). The
@@ -220,10 +238,11 @@ struct RenderResult {
   svg::RendererBitmap bitmap;
   std::optional<CompositedPreview> compositedPreview;
   std::uint64_t version = 0;
-  /// Wall-clock milliseconds the worker spent inside
-  /// `CompositorController::renderFrame` for this iteration. Reported so
-  /// the editor can plot backend render time alongside ImGui frame time
-  /// on the frame graph. Zero means no backend work was recorded.
+  /// Wall-clock milliseconds spent in the worker iteration after a request is
+  /// dequeued, including `CompositorController::renderFrame`, final
+  /// snapshot/readback work, and diagnostic snapshots that gate presentation.
+  /// Reported so the editor can plot worker latency alongside ImGui frame time
+  /// on the frame graph. Zero means no worker timing was recorded.
   double workerMs = 0.0;
 };
 

--- a/donner/editor/BUILD.bazel
+++ b/donner/editor/BUILD.bazel
@@ -59,6 +59,15 @@ donner_cc_library(
 )
 
 donner_cc_library(
+    name = "selection_transform_handles",
+    srcs = ["SelectionTransformHandles.cc"],
+    hdrs = ["SelectionTransformHandles.h"],
+    deps = [
+        "//donner/base",
+    ],
+)
+
+donner_cc_library(
     name = "source_selection",
     srcs = ["SourceSelection.cc"],
     hdrs = ["SourceSelection.h"],
@@ -463,6 +472,7 @@ donner_cc_library(
         ":render_coordinator",
         ":render_pane_presenter",
         ":select_tool",
+        ":selection_transform_handles",
         ":sidebar_presenter",
         ":source_selection",
         ":text_editor",
@@ -546,6 +556,7 @@ donner_cc_library(
         ":editor_app",
         ":imgui_headers",
         ":selection_aabb",
+        ":selection_transform_handles",
         ":tool",
         ":undo_timeline",
         "//donner/base",
@@ -560,6 +571,7 @@ donner_cc_library(
     deps = [
         ":editor_app",
         ":selection_aabb",
+        ":selection_transform_handles",
         ":tracy_wrapper",
         "//donner/base",
         "//donner/css",

--- a/donner/editor/BUILD.bazel
+++ b/donner/editor/BUILD.bazel
@@ -22,6 +22,14 @@ load("//build_defs:rules.bzl", "donner_cc_binary", "donner_cc_library")
 # resolve outside dev builds.
 package(default_visibility = ["//visibility:public"])
 
+config_setting(
+    name = "wasm_geode_enabled",
+    flag_values = {
+        "//donner/editor/wasm:enable_wasm": "true",
+        "//donner/svg/renderer:renderer_backend": "geode",
+    },
+)
+
 exports_files(
     ["main.cc"],
     visibility = ["//donner/editor/wasm:__pkg__"],
@@ -203,6 +211,7 @@ donner_cc_library(
     srcs = ["GlTextureCache.cc"],
     hdrs = ["GlTextureCache.h"],
     defines = select({
+        ":wasm_geode_enabled": [],
         "//donner/svg/renderer:renderer_backend_geode": ["DONNER_EDITOR_WGPU"],
         "//conditions:default": [],
     }),
@@ -213,6 +222,9 @@ donner_cc_library(
         "//donner/base",
         "//donner/svg",
     ] + select({
+        ":wasm_geode_enabled": [
+            "//third_party/emscripten-glfw",
+        ],
         "//donner/editor/wasm:wasm_enabled": [
             "//third_party/emscripten-glfw",
         ],
@@ -375,6 +387,7 @@ donner_cc_library(
     srcs = ["LayerInspectorPanel.cc"],
     hdrs = ["LayerInspectorPanel.h"],
     defines = select({
+        ":wasm_geode_enabled": [],
         "//donner/svg/renderer:renderer_backend_geode": ["DONNER_EDITOR_WGPU"],
         "//conditions:default": [],
     }),
@@ -385,6 +398,9 @@ donner_cc_library(
         "//donner/svg/compositor",
         "@imgui",
     ] + select({
+        ":wasm_geode_enabled": [
+            "//third_party/emscripten-glfw",
+        ],
         "//donner/editor/wasm:wasm_enabled": [
             "//third_party/emscripten-glfw",
         ],

--- a/donner/editor/BUILD.bazel
+++ b/donner/editor/BUILD.bazel
@@ -68,6 +68,27 @@ donner_cc_library(
 )
 
 donner_cc_library(
+    name = "rotate_cursor_set",
+    srcs = ["RotateCursorSet.cc"],
+    hdrs = ["RotateCursorSet.h"],
+    deps = [
+        ":rotate_cursor_svg",
+        ":selection_transform_handles",
+        "//donner/base",
+        "//donner/svg",
+        "//donner/svg/parser",
+        "//donner/svg/renderer",
+    ] + select({
+        "//donner/editor/wasm:wasm_enabled": [
+            "//third_party/emscripten-glfw",
+        ],
+        "//conditions:default": [
+            "@glfw",
+        ],
+    }),
+)
+
+donner_cc_library(
     name = "source_selection",
     srcs = ["SourceSelection.cc"],
     hdrs = ["SourceSelection.h"],
@@ -471,6 +492,7 @@ donner_cc_library(
         ":menu_bar_presenter",
         ":render_coordinator",
         ":render_pane_presenter",
+        ":rotate_cursor_set",
         ":select_tool",
         ":selection_transform_handles",
         ":sidebar_presenter",
@@ -593,6 +615,14 @@ filegroup(
 # exposes `donner::embedded::kEditorNoticeText` as a
 # `std::span<const unsigned char>`. The editor's Help → About dialog
 # displays this.
+embed_resources(
+    name = "rotate_cursor_svg",
+    header_output = "donner/editor/RotateCursorSvg.h",
+    resources = {
+        "kRotateCursorSvg": "rotate_cursor.svg",
+    },
+)
+
 embed_resources(
     name = "notice",
     header_output = "donner/editor/Notice.h",

--- a/donner/editor/BUILD.bazel
+++ b/donner/editor/BUILD.bazel
@@ -30,6 +30,14 @@ config_setting(
     },
 )
 
+config_setting(
+    name = "wasm_tiny_skia_enabled",
+    flag_values = {
+        "//donner/editor/wasm:enable_wasm": "true",
+        "//donner/svg/renderer:renderer_backend": "tiny_skia",
+    },
+)
+
 exports_files(
     ["main.cc"],
     visibility = ["//donner/editor/wasm:__pkg__"],
@@ -87,7 +95,7 @@ donner_cc_library(
         "//donner/svg/parser",
         "//donner/svg/renderer",
     ] + select({
-        "//donner/editor/wasm:wasm_enabled": [
+        ":wasm_tiny_skia_enabled": [
             "//third_party/emscripten-glfw",
         ],
         "//conditions:default": [
@@ -211,7 +219,7 @@ donner_cc_library(
     srcs = ["GlTextureCache.cc"],
     hdrs = ["GlTextureCache.h"],
     defines = select({
-        ":wasm_geode_enabled": [],
+        ":wasm_geode_enabled": ["DONNER_EDITOR_WGPU"],
         "//donner/svg/renderer:renderer_backend_geode": ["DONNER_EDITOR_WGPU"],
         "//conditions:default": [],
     }),
@@ -223,9 +231,11 @@ donner_cc_library(
         "//donner/svg",
     ] + select({
         ":wasm_geode_enabled": [
+            "//donner/svg/renderer:renderer_geode",
             "//third_party/emscripten-glfw",
+            "@imgui//:imgui_wgpu_backend",
         ],
-        "//donner/editor/wasm:wasm_enabled": [
+        ":wasm_tiny_skia_enabled": [
             "//third_party/emscripten-glfw",
         ],
         "//donner/svg/renderer:renderer_backend_geode": [
@@ -247,7 +257,7 @@ donner_cc_library(
         ":render_pane_gesture",
         "//donner/editor/gui:editor_window",
     ] + select({
-        "//donner/editor/wasm:wasm_enabled": [
+        ":wasm_tiny_skia_enabled": [
             "//third_party/emscripten-glfw",
         ],
         "@platforms//os:macos": [
@@ -387,7 +397,7 @@ donner_cc_library(
     srcs = ["LayerInspectorPanel.cc"],
     hdrs = ["LayerInspectorPanel.h"],
     defines = select({
-        ":wasm_geode_enabled": [],
+        ":wasm_geode_enabled": ["DONNER_EDITOR_WGPU"],
         "//donner/svg/renderer:renderer_backend_geode": ["DONNER_EDITOR_WGPU"],
         "//conditions:default": [],
     }),
@@ -399,13 +409,15 @@ donner_cc_library(
         "@imgui",
     ] + select({
         ":wasm_geode_enabled": [
+            "//donner/svg/renderer:renderer_geode",
             "//third_party/emscripten-glfw",
+            "@imgui//:imgui_wgpu_backend",
         ],
-        "//donner/editor/wasm:wasm_enabled": [
+        ":wasm_tiny_skia_enabled": [
             "//third_party/emscripten-glfw",
         ],
         "//donner/svg/renderer:renderer_backend_geode": [
-            "//donner/svg/renderer",
+            "//donner/svg/renderer:renderer_geode",
             "@imgui//:imgui_wgpu_backend",
         ],
         "//conditions:default": [

--- a/donner/editor/CompositedPresentation.h
+++ b/donner/editor/CompositedPresentation.h
@@ -260,6 +260,7 @@ public:
       return SelectTool::ActiveDragPreview{
           .entity = cache->entity,
           .translation = Vector2d::Zero(),
+          .documentFromCachedDocument = Transform2d(),
       };
     }
     return std::nullopt;
@@ -308,6 +309,7 @@ private:
     return SelectTool::ActiveDragPreview{
         .entity = cache.entity,
         .translation = Vector2d::Zero(),
+        .documentFromCachedDocument = Transform2d(),
     };
   }
 
@@ -321,6 +323,7 @@ private:
     return SelectTool::ActiveDragPreview{
         .entity = cache.entity,
         .translation = Vector2d::Zero(),
+        .documentFromCachedDocument = Transform2d(),
         .dragGeneration = activePreview.dragGeneration,
     };
   }

--- a/donner/editor/CompositedPresentation.h
+++ b/donner/editor/CompositedPresentation.h
@@ -112,17 +112,41 @@ public:
     return std::holds_alternative<WaitingForChromeRefresh>(state_);
   }
 
+  /// Returns the active preview that should drive presenter-side tile transforms.
+  ///
+  /// During a live drag this is the tool's active preview. After mouse-up,
+  /// \ref SelectTool::activeDragPreview is empty, but the render pane must keep presenting the
+  /// released transform until a settled render replaces the cached tiles.
+  [[nodiscard]] std::optional<SelectTool::ActiveDragPreview> activePreviewForPresentation(
+      const std::optional<SelectTool::ActiveDragPreview>& activePreview) const {
+    if (activePreview.has_value()) {
+      return activePreview;
+    }
+
+    const auto* settling = std::get_if<SettlingForRender>(&state_);
+    if (settling != nullptr && settling->cache.has_value() &&
+        settling->cache->entity == settling->preview.entity) {
+      return settling->preview;
+    }
+
+    return std::nullopt;
+  }
+
   /// Returns true when an active drag needs a fresh composited capture.
   [[nodiscard]] bool needsCompositedLayerCapture(
       const std::optional<SelectTool::ActiveDragPreview>& activePreview,
-      std::uint64_t currentVersion, const Vector2i& currentCanvasSize) const {
+      std::uint64_t /*currentVersion*/, const Vector2i& currentCanvasSize) const {
     if (!activePreview.has_value()) {
       return false;
     }
 
     const std::optional<CachedTextures> cache = currentCache();
+    // Drag transform writes bump the document version every mouse move, but
+    // the active preview already carries that affine delta for presenter-side
+    // texture placement. Recapture only when the cache cannot represent the
+    // selected entity in the current canvas epoch.
     return !cache.has_value() || cache->entity != activePreview->entity ||
-           cache->version != currentVersion || cache->canvasSize != currentCanvasSize;
+           cache->canvasSize != currentCanvasSize;
   }
 
   /// Returns true when a released drag should request a settled composited refresh.

--- a/donner/editor/CompositedPresentation.h
+++ b/donner/editor/CompositedPresentation.h
@@ -245,7 +245,7 @@ public:
     // in flight, keep displaying the last cached document image without
     // applying the new entity's live drag offset to stale drag-target tiles.
     if (activePreview.has_value() && cache.has_value() && activePreview->entity == cache->entity) {
-      return representedPreviewForCache(*cache);
+      return representedPreviewForActiveCache(*cache, *activePreview);
     }
 
     if (const auto* settling = std::get_if<SettlingForRender>(&state_);
@@ -308,6 +308,20 @@ private:
     return SelectTool::ActiveDragPreview{
         .entity = cache.entity,
         .translation = Vector2d::Zero(),
+    };
+  }
+
+  static SelectTool::ActiveDragPreview representedPreviewForActiveCache(
+      const CachedTextures& cache, const SelectTool::ActiveDragPreview& activePreview) {
+    if (cache.representedPreview.has_value() && cache.representedPreview->entity == cache.entity &&
+        cache.representedPreview->dragGeneration == activePreview.dragGeneration) {
+      return *cache.representedPreview;
+    }
+
+    return SelectTool::ActiveDragPreview{
+        .entity = cache.entity,
+        .translation = Vector2d::Zero(),
+        .dragGeneration = activePreview.dragGeneration,
     };
   }
 

--- a/donner/editor/DocumentSyncController.cc
+++ b/donner/editor/DocumentSyncController.cc
@@ -224,8 +224,8 @@ void DocumentSyncController::applyPendingWritebacks(EditorApp& app, SelectTool& 
       });
     }
   }
-  if (auto completed = app.consumeTransformWriteback(); completed.has_value()) {
-    pendingTransformWritebacks_.push_back(std::move(*completed));
+  for (auto& completed : app.consumeTransformWritebacks()) {
+    pendingTransformWritebacks_.push_back(std::move(completed));
   }
 
   auto completedRemovals = app.consumeElementRemoveWritebacks();

--- a/donner/editor/EditorApp.cc
+++ b/donner/editor/EditorApp.cc
@@ -28,6 +28,55 @@ void ForEachGeometryElement(const svg::SVGElement& node, Visitor& visit) {
   }
 }
 
+svg::SVGElement ResolveSnapshotElement(AsyncSVGDocument& document, const UndoSnapshot& snapshot) {
+  svg::SVGElement liveElement = snapshot.element;
+  if (document.hasDocument() && snapshot.writebackTarget.has_value()) {
+    if (auto resolved =
+            resolveAttributeWritebackTarget(document.document(), *snapshot.writebackTarget);
+        resolved.has_value()) {
+      liveElement = *resolved;
+    }
+  }
+  return liveElement;
+}
+
+void ApplyTimelineSnapshot(EditorApp& app, AsyncSVGDocument& document,
+                           const UndoSnapshot& snapshot) {
+  svg::SVGElement liveElement = ResolveSnapshotElement(document, snapshot);
+
+  // Route the restored transform through the command queue so every
+  // DOM write — tool drags, text-pane re-parse, and undo — goes through
+  // the same mutation seam. The queue coalesces with any pending
+  // commands and applies on the next `flushFrame()`.
+  app.applyMutation(EditorCommand::SetTransformCommand(liveElement, snapshot.transform));
+
+  // Capture the source-text writeback target BEFORE the command drains
+  // so the path-based target resolves against the in-sync document.
+  // The writeback will be applied by `main.cc` after `flushFrame()`
+  // lands the undone transform on the element — at that point the
+  // transform the user sees on the canvas and the `transform=` value
+  // in the source must agree. Without this the DOM reverts but the
+  // source keeps the post-drag text, and the next edit lands on the
+  // wrong baseline.
+  if (snapshot.writebackTarget.has_value()) {
+    app.enqueueTransformWriteback(EditorApp::CompletedTransformWriteback{
+        .target = *snapshot.writebackTarget,
+        .transform = snapshot.transform,
+        .sourceTransformAttributeValue = snapshot.sourceTransformAttributeValue,
+        .restoreSourceTransformAttributeValue = snapshot.restoreSourceTransformAttributeValue});
+  } else if (auto target = captureAttributeWritebackTarget(liveElement); target.has_value()) {
+    app.enqueueTransformWriteback(EditorApp::CompletedTransformWriteback{
+        .target = std::move(*target),
+        .transform = snapshot.transform,
+        .sourceTransformAttributeValue = snapshot.sourceTransformAttributeValue,
+        .restoreSourceTransformAttributeValue = snapshot.restoreSourceTransformAttributeValue});
+  }
+
+  for (const UndoSnapshot& extra : snapshot.extras) {
+    ApplyTimelineSnapshot(app, document, extra);
+  }
+}
+
 }  // namespace
 
 EditorApp::EditorApp() = default;
@@ -37,7 +86,7 @@ bool EditorApp::loadFromString(std::string_view svgBytes) {
   refreshFirstSelectionCache();
   controller_.reset();
   undoTimeline_.clear();
-  pendingTransformWriteback_.reset();
+  pendingTransformWritebacks_.clear();
   pendingElementRemoveWritebacks_.clear();
   const bool result = document_.loadFromString(svgBytes);
   // A successful load resets the dirty state — the in-memory document
@@ -141,52 +190,16 @@ void EditorApp::undo() {
     return;
   }
 
-  svg::SVGElement liveElement = snapshot->element;
-  if (document_.hasDocument() && snapshot->writebackTarget.has_value()) {
-    if (auto resolved =
-            resolveAttributeWritebackTarget(document_.document(), *snapshot->writebackTarget);
-        resolved.has_value()) {
-      liveElement = *resolved;
-    }
-  }
-
-  // Route the restored transform through the command queue so every
-  // DOM write — tool drags, text-pane re-parse, and undo — goes through
-  // the same mutation seam. The queue coalesces with any pending
-  // commands and applies on the next `flushFrame()`.
-  applyMutation(EditorCommand::SetTransformCommand(liveElement, snapshot->transform));
-
-  // Capture the source-text writeback target BEFORE the command drains
-  // so the path-based target resolves against the in-sync document.
-  // The writeback will be applied by `main.cc` after `flushFrame()`
-  // lands the undone transform on the element — at that point the
-  // transform the user sees on the canvas and the `transform=` value
-  // in the source must agree. Without this the DOM reverts but the
-  // source keeps the post-drag text, and the next edit lands on the
-  // wrong baseline.
-  if (snapshot->writebackTarget.has_value()) {
-    enqueueTransformWriteback(CompletedTransformWriteback{
-        .target = *snapshot->writebackTarget,
-        .transform = snapshot->transform,
-        .sourceTransformAttributeValue = snapshot->sourceTransformAttributeValue,
-        .restoreSourceTransformAttributeValue = snapshot->restoreSourceTransformAttributeValue});
-  } else if (auto target = captureAttributeWritebackTarget(liveElement); target.has_value()) {
-    enqueueTransformWriteback(CompletedTransformWriteback{
-        .target = std::move(*target),
-        .transform = snapshot->transform,
-        .sourceTransformAttributeValue = snapshot->sourceTransformAttributeValue,
-        .restoreSourceTransformAttributeValue = snapshot->restoreSourceTransformAttributeValue});
-  }
+  ApplyTimelineSnapshot(*this, document_, *snapshot);
 }
 
 void EditorApp::redo() {
-  // "Redo" in the non-destructive timeline model is "break the active
-  // undo chain and undo again". Breaking the chain causes the next
-  // undo to start a fresh chain from the end of the timeline, which
-  // means the first entry it walks is the most recently-appended
-  // undo-entry — whose `before` state is the post-drag position.
-  undoTimeline_.breakUndoChain();
-  undo();
+  auto snapshot = undoTimeline_.redo();
+  if (!snapshot.has_value()) {
+    return;
+  }
+
+  ApplyTimelineSnapshot(*this, document_, *snapshot);
 }
 
 std::optional<svg::SVGGeometryElement> EditorApp::hitTest(const Vector2d& documentPoint) {

--- a/donner/editor/EditorApp.h
+++ b/donner/editor/EditorApp.h
@@ -197,6 +197,9 @@ public:
   /// Whether there is an entry to undo.
   [[nodiscard]] bool canUndo() const { return undoTimeline_.canUndo(); }
 
+  /// Whether the most recently undone entry can be redone.
+  [[nodiscard]] bool canRedo() const { return undoTimeline_.canRedo(); }
+
   /// Undo the most recent entry. Pops the timeline's next entry and
   /// pushes the restored transform onto the command queue as a
   /// `SetTransformCommand` — the actual DOM mutation happens on the
@@ -206,14 +209,9 @@ public:
 
   /// Redo the most recently undone entry.
   ///
-  /// In the non-destructive `UndoTimeline` model, "redo" is mechanically
-  /// identical to "undo the most recent undo-entry": breaking the
-  /// current undo chain and then calling `undo()` again pops the
-  /// undo-entry the previous `undo()` call appended, which restores
-  /// the post-drag state.
-  ///
-  /// Like `undo()`, the restored transform is routed through the
-  /// command queue so the mutation seam is preserved.
+  /// Like `undo()`, the restored transform is routed through the command
+  /// queue so the mutation seam is preserved. No-op unless the most recent
+  /// timeline action was an undo.
   void redo();
 
   // ---------------------------------------------------------------------------
@@ -254,20 +252,27 @@ public:
   /// source on its next `applyPendingTransformWriteback()` call. SelectTool
   /// calls this when a drag completes; `undo()` / `redo()` call it so
   /// undoing a canvas drag restores both the DOM transform *and* the
-  /// source text in lock-step. New entries overwrite any still-pending
-  /// writeback — coalescing is fine because the latest transform value
-  /// is always the one we want.
+  /// source text in lock-step. Multiple entries are preserved so grouped
+  /// multi-selection undo/redo updates every participant.
   void enqueueTransformWriteback(CompletedTransformWriteback writeback) {
-    pendingTransformWriteback_ = std::move(writeback);
+    pendingTransformWritebacks_.push_back(std::move(writeback));
   }
 
-  /// Drain the most recently queued transform writeback, if any. Called
-  /// once per frame by `main.cc`. The writeback payload is stable across
-  /// frames — callers latch it themselves if they need to retry on a
-  /// busy frame.
+  /// Drain the oldest queued transform writeback, if any.
   [[nodiscard]] std::optional<CompletedTransformWriteback> consumeTransformWriteback() {
-    auto result = std::move(pendingTransformWriteback_);
-    pendingTransformWriteback_.reset();
+    if (pendingTransformWritebacks_.empty()) {
+      return std::nullopt;
+    }
+    auto result = std::move(pendingTransformWritebacks_.front());
+    pendingTransformWritebacks_.erase(pendingTransformWritebacks_.begin());
+    return result;
+  }
+
+  /// Drain all queued transform writebacks. Called once per frame by
+  /// `DocumentSyncController`.
+  [[nodiscard]] std::vector<CompletedTransformWriteback> consumeTransformWritebacks() {
+    auto result = std::move(pendingTransformWritebacks_);
+    pendingTransformWritebacks_.clear();
     return result;
   }
 
@@ -305,7 +310,7 @@ private:
 
   bool structuredEditingEnabled_ = true;
 
-  std::optional<CompletedTransformWriteback> pendingTransformWriteback_;
+  std::vector<CompletedTransformWriteback> pendingTransformWritebacks_;
   std::vector<CompletedElementRemoveWriteback> pendingElementRemoveWritebacks_;
 
   std::optional<std::string> currentFilePath_;

--- a/donner/editor/EditorInputBridge.cc
+++ b/donner/editor/EditorInputBridge.cc
@@ -1,5 +1,9 @@
 #include "donner/editor/EditorInputBridge.h"
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
 #include <utility>
 
 #include "GLFW/glfw3.h"
@@ -9,11 +13,71 @@ namespace donner::editor {
 
 namespace {
 
+#ifdef __EMSCRIPTEN__
+// clang-format off
+EM_JS(void, InstallWasmWheelModifierCapture, (), {
+  const canvas = document.getElementById("canvas");
+  if (!canvas) {
+    return;
+  }
+
+  if (canvas.__donnerWheelModifierCapture) {
+    canvas.__donnerWheelModifierCapture.state.zoomModifierHeld = false;
+    return;
+  }
+
+  const state = {
+    zoomModifierHeld: false,
+  };
+  const handler = function(event) {
+    state.zoomModifierHeld = !!(event.ctrlKey || event.metaKey);
+  };
+
+  canvas.__donnerWheelModifierCapture = {
+    state: state,
+    handler: handler,
+  };
+  canvas.addEventListener("wheel", handler, {capture: true, passive: false});
+});
+
+EM_JS(void, RemoveWasmWheelModifierCapture, (), {
+  const canvas = document.getElementById("canvas");
+  const capture = canvas && canvas.__donnerWheelModifierCapture;
+  if (!capture) {
+    return;
+  }
+
+  canvas.removeEventListener("wheel", capture.handler, true);
+  delete canvas.__donnerWheelModifierCapture;
+});
+
+EM_JS(int, WasmWheelZoomModifierHeld, (), {
+  const canvas = document.getElementById("canvas");
+  const capture = canvas && canvas.__donnerWheelModifierCapture;
+  return capture && capture.state && capture.state.zoomModifierHeld ? 1 : 0;
+});
+
+EM_JS(void, RecordWasmScrollDebug, (int zoomModifierHeld, double xoffset, double yoffset), {
+  window.__donnerLastScrollEvent = {
+    zoomModifierHeld: !!zoomModifierHeld,
+    xoffset: xoffset,
+    yoffset: yoffset,
+    count: ((window.__donnerLastScrollEvent && window.__donnerLastScrollEvent.count) || 0) + 1,
+  };
+});
+// clang-format on
+#endif
+
 [[nodiscard]] bool IsZoomModifierHeld(GLFWwindow* window) {
-  return glfwGetKey(window, GLFW_KEY_LEFT_CONTROL) == GLFW_PRESS ||
-         glfwGetKey(window, GLFW_KEY_RIGHT_CONTROL) == GLFW_PRESS ||
-         glfwGetKey(window, GLFW_KEY_LEFT_SUPER) == GLFW_PRESS ||
-         glfwGetKey(window, GLFW_KEY_RIGHT_SUPER) == GLFW_PRESS;
+  const bool keyHeld = glfwGetKey(window, GLFW_KEY_LEFT_CONTROL) == GLFW_PRESS ||
+                       glfwGetKey(window, GLFW_KEY_RIGHT_CONTROL) == GLFW_PRESS ||
+                       glfwGetKey(window, GLFW_KEY_LEFT_SUPER) == GLFW_PRESS ||
+                       glfwGetKey(window, GLFW_KEY_RIGHT_SUPER) == GLFW_PRESS;
+#ifdef __EMSCRIPTEN__
+  return keyHeld || WasmWheelZoomModifierHeld() != 0;
+#else
+  return keyHeld;
+#endif
 }
 
 }  // namespace
@@ -23,10 +87,16 @@ EditorInputBridge::EditorInputBridge(gui::EditorWindow& window, double wheelZoom
   window_.setUserPointer(&pendingScrollEvents_);
   pendingScrollEvents_.previousCallback =
       window_.setScrollCallback(&EditorInputBridge::ScrollCallback);
+#ifdef __EMSCRIPTEN__
+  InstallWasmWheelModifierCapture();
+#endif
   (void)InstallPinchEventMonitor(window_.rawHandle(), &pendingScrollEvents_.events, wheelZoomStep);
 }
 
 EditorInputBridge::~EditorInputBridge() {
+#ifdef __EMSCRIPTEN__
+  RemoveWasmWheelModifierCapture();
+#endif
   if (window_.rawHandle() != nullptr) {
     std::ignore = window_.setScrollCallback(pendingScrollEvents_.previousCallback);
     window_.setUserPointer(nullptr);
@@ -50,10 +120,14 @@ void EditorInputBridge::ScrollCallback(GLFWwindow* window, double xoffset, doubl
   double cursorX = 0.0;
   double cursorY = 0.0;
   glfwGetCursorPos(window, &cursorX, &cursorY);
+  const bool zoomModifierHeld = IsZoomModifierHeld(window);
+#ifdef __EMSCRIPTEN__
+  RecordWasmScrollDebug(zoomModifierHeld ? 1 : 0, xoffset, yoffset);
+#endif
   state->events.push_back(RenderPaneScrollEvent{
       .scrollDelta = Vector2d(xoffset, yoffset),
       .cursorScreen = Vector2d(cursorX, cursorY),
-      .zoomModifierHeld = IsZoomModifierHeld(window),
+      .zoomModifierHeld = zoomModifierHeld,
   });
 }
 

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -15,6 +15,7 @@
 #include "donner/editor/DocumentSave.h"
 #include "donner/editor/DragCoalesce.h"
 #include "donner/editor/KeyboardShortcutPolicy.h"
+#include "donner/editor/SelectionTransformHandles.h"
 #include "donner/editor/SourceSelection.h"
 #include "donner/editor/SourceSync.h"
 #include "donner/editor/TracyWrapper.h"
@@ -41,6 +42,24 @@ constexpr float kMinLayerPanelHeight = 140.0f;
 constexpr double kTrackpadPanPixelsPerScrollUnit = 10.0;
 constexpr double kWheelZoomStep = 1.1;
 constexpr int kMaxSaveSyncFlushPasses = 4;
+
+ImGuiMouseCursor CursorForTransformHandleIntent(const SelectionTransformHandleIntent& intent) {
+  if (intent.kind == SelectionTransformHandleKind::Rotate) {
+    return ImGuiMouseCursor_ResizeAll;
+  }
+
+  if (intent.kind != SelectionTransformHandleKind::Resize) {
+    return ImGuiMouseCursor_Arrow;
+  }
+
+  switch (intent.corner) {
+    case SelectionTransformCorner::TopLeft:
+    case SelectionTransformCorner::BottomRight: return ImGuiMouseCursor_ResizeNWSE;
+    case SelectionTransformCorner::TopRight:
+    case SelectionTransformCorner::BottomLeft: return ImGuiMouseCursor_ResizeNESW;
+  }
+  return ImGuiMouseCursor_ResizeAll;
+}
 
 std::optional<std::string> LoadFile(const std::string& filename) {
   std::ifstream file(filename, std::ios::binary);
@@ -506,9 +525,26 @@ void EditorShell::renderRenderPane(const Vector2d& renderPaneOrigin, const Vecto
   };
 
   const bool toolEligible = paneHovered && !interactionController_.panning() && !spaceHeld;
+  const auto cachedHandleIntentAt = [&](const Vector2d& documentPoint) {
+    const auto& boundsCache = renderCoordinator_.selectionBoundsCache();
+    if (boundsCache.lastSelection != app_.selectedElements()) {
+      return SelectionTransformHandleIntent{};
+    }
+    return HitTestSelectionTransformHandles(boundsCache.displayedBoundsDoc, documentPoint,
+                                            interactionController_.viewport().pixelsPerDocUnit());
+  };
+  if (toolEligible && !ImGui::IsMouseDown(ImGuiMouseButton_Left)) {
+    const SelectionTransformHandleIntent hoverIntent =
+        cachedHandleIntentAt(screenToDocument(ImGui::GetMousePos()));
+    if (hoverIntent.kind != SelectionTransformHandleKind::None) {
+      ImGui::SetMouseCursor(CursorForTransformHandleIntent(hoverIntent));
+    }
+  }
   if (toolEligible && ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
     MouseModifiers modifiers;
     modifiers.shift = ImGui::GetIO().KeyShift;
+    modifiers.option = ImGui::GetIO().KeyAlt;
+    modifiers.pixelsPerDocUnit = interactionController_.viewport().pixelsPerDocUnit();
     interactionController_.bufferPendingClick(screenToDocument(ImGui::GetMousePos()), modifiers);
   }
 
@@ -534,8 +570,11 @@ void EditorShell::renderRenderPane(const Vector2d& renderPaneOrigin, const Vecto
     const auto& pendingClick = *interactionController_.pendingClick();
     const auto& boundsCache = renderCoordinator_.selectionBoundsCache();
     const bool cacheMatchesSelection = boundsCache.lastSelection == app_.selectedElements();
+    const SelectionTransformHandleIntent pendingHandleIntent =
+        cacheMatchesSelection ? cachedHandleIntentAt(pendingClick.documentPoint)
+                              : SelectionTransformHandleIntent{};
     const bool tookFastRedrag =
-        cacheMatchesSelection &&
+        cacheMatchesSelection && pendingHandleIntent.kind == SelectionTransformHandleKind::None &&
         selectTool_.tryStartRedragOnSelected(app_, pendingClick.documentPoint,
                                              pendingClick.modifiers, boundsCache.displayedBoundsDoc,
                                              boundsCache.displayedOccludingBoundsDoc);
@@ -554,7 +593,7 @@ void EditorShell::renderRenderPane(const Vector2d& renderPaneOrigin, const Vecto
       renderCoordinator_.rasterizeOverlayForCurrentSelection(
           app_, interactionController_.viewport(), textures_, selectTool_.marqueeRect(),
           RenderCoordinator::OverlayUploadMode::MatchDisplayedVersion,
-          selectTool_.activeDragPreview());
+          selectTool_.activeDragPreview(), selectTool_.activeTransformBoundsPreview());
       interactionController_.clearPendingClick();
     } else {
       // Worker is busy with a (likely-stale) prewarm render at the
@@ -583,29 +622,35 @@ void EditorShell::renderRenderPane(const Vector2d& renderPaneOrigin, const Vecto
       const ImVec2 currentScreen = ImGui::GetMousePos();
       if (ShouldPostDragMove<ImVec2>(currentScreen, lastPostedScreenPoint_,
                                      renderCoordinator_.asyncRenderer().isBusy())) {
-        selectTool_.onMouseMove(app_, screenToDocument(currentScreen), /*buttonHeld=*/true);
+        MouseModifiers modifiers;
+        modifiers.shift = ImGui::GetIO().KeyShift;
+        modifiers.option = ImGui::GetIO().KeyAlt;
+        modifiers.pixelsPerDocUnit = interactionController_.viewport().pixelsPerDocUnit();
+        selectTool_.onMouseMove(app_, screenToDocument(currentScreen), /*buttonHeld=*/true,
+                                modifiers);
         lastPostedScreenPoint_ = currentScreen;
         if (!renderCoordinator_.asyncRenderer().isBusy() && app_.flushFrame()) {
           renderCoordinator_.refreshSelectionBoundsCache(app_);
+          renderCoordinator_.rasterizeOverlayForCurrentSelection(
+              app_, interactionController_.viewport(), textures_, selectTool_.marqueeRect(),
+              RenderCoordinator::OverlayUploadMode::Immediate, selectTool_.activeDragPreview(),
+              selectTool_.activeTransformBoundsPreview());
         }
       }
     }
     if (ImGui::IsMouseReleased(ImGuiMouseButton_Left)) {
       const auto previewBeforeRelease = selectTool_.activeDragPreview();
+      const bool previewHadVisualChange =
+          previewBeforeRelease.has_value() &&
+          (!previewBeforeRelease->documentFromCachedDocument.isIdentity() ||
+           previewBeforeRelease->translation != Vector2d::Zero());
       selectTool_.onMouseUp(app_, screenToDocument(ImGui::GetMousePos()));
       lastPostedScreenPoint_.reset();
       if (previewBeforeRelease.has_value()) {
-        // The DOM was already updated every drag frame via
-        // `SelectTool::onMouseMove` → `applyMutation`, so drag release
-        // needs to do nothing beyond recording undo history (already done
-        // in `onMouseUp`). The compositor has the dragged entity's DOM
-        // position baked in; its cached bitmap is reused via an internal
-        // compose-offset delta for pure-translation drags (see
-        // `CompositorController::rasterizeLayer` + fast path), which
-        // means the display is byte-for-byte identical to a fresh render
-        // of the mutated DOM at identity composition. No "settling" hack
-        // needed — the compositor view IS the settled view.
-        if (!renderCoordinator_.asyncRenderer().isBusy() && app_.flushFrame()) {
+        if (!renderCoordinator_.asyncRenderer().isBusy() &&
+            (app_.flushFrame() || previewHadVisualChange)) {
+          renderCoordinator_.compositedPresentation().beginSettling(
+              previewBeforeRelease, app_.document().currentFrameVersion());
           renderCoordinator_.refreshSelectionBoundsCache(app_);
           renderCoordinator_.rasterizeOverlayForCurrentSelection(
               app_, interactionController_.viewport(), textures_, selectTool_.marqueeRect(),

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -515,10 +515,10 @@ void EditorShell::renderRenderPane(const Vector2d& renderPaneOrigin, const Vecto
   // Design doc 0033 §M8 — click→drag handoff doesn't wait for raster.
   //
   // Fast path: if the user clicks inside the bounds of the currently-
-  // selected element, we can start the re-drag IMMEDIATELY without
-  // gating on `!isBusy()`. The check uses `SelectionBoundsCache::
-  // displayedBoundsDoc` — populated on idle frames — so the call
-  // doesn't touch the registry the worker is mid-mutating. The
+  // selected element and outside cached later-painted bounds, we can
+  // start the re-drag IMMEDIATELY without gating on `!isBusy()`. The
+  // check uses `SelectionBoundsCache` — populated on idle frames — so
+  // the call doesn't touch the registry the worker is mid-mutating. The
   // previous M8 attempt failed because it called the live
   // `SnapshotSelectionWorldBounds` during the busy window; the
   // cache-based check fixes the race.
@@ -535,9 +535,10 @@ void EditorShell::renderRenderPane(const Vector2d& renderPaneOrigin, const Vecto
     const auto& boundsCache = renderCoordinator_.selectionBoundsCache();
     const bool cacheMatchesSelection = boundsCache.lastSelection == app_.selectedElements();
     const bool tookFastRedrag =
-        cacheMatchesSelection && selectTool_.tryStartRedragOnSelected(
-                                     app_, pendingClick.documentPoint, pendingClick.modifiers,
-                                     boundsCache.displayedBoundsDoc);
+        cacheMatchesSelection &&
+        selectTool_.tryStartRedragOnSelected(app_, pendingClick.documentPoint,
+                                             pendingClick.modifiers, boundsCache.displayedBoundsDoc,
+                                             boundsCache.displayedOccludingBoundsDoc);
     if (tookFastRedrag) {
       lastPostedScreenPoint_.reset();
       interactionController_.clearPendingClick();

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -91,12 +91,13 @@ EditorShell::EditorShell(gui::EditorWindow& window, EditorShellOptions options)
       app_(),
       selectTool_(),
       textEditor_(),
-      textures_(),
+      textures_(window.geodeDevice()),
       renderCoordinator_(window.geodeDevice()),
       rotateCursorSet_(),
       documentSyncController_(LoadFile(options_.svgPath).value_or("")),
       interactionController_(),
       inputBridge_(window_, kWheelZoomStep),
+      layerInspectorPanel_(window.geodeDevice()),
       dialogPresenter_(options_.editorNoticeText) {
   std::optional<std::string> initialSource = options_.initialSource;
   if (!initialSource.has_value() && !options_.svgPath.empty()) {
@@ -243,8 +244,11 @@ LayerInspectorStatusReadback EditorShell::layerInspectorStatusForReadback() cons
       .overlayDimsPx = Vector2i(textures_.overlayWidth(), textures_.overlayHeight()),
       .overlayTextureHandle = static_cast<std::uint64_t>(textures_.overlayTexture()),
   };
-  const std::optional<SelectTool::ActiveDragPreview> activeDragPreview =
+  const std::optional<SelectTool::ActiveDragPreview> liveActiveDragPreview =
       selectTool_.activeDragPreview();
+  const std::optional<SelectTool::ActiveDragPreview> activeDragPreview =
+      renderCoordinator_.compositedPresentation().activePreviewForPresentation(
+          liveActiveDragPreview);
   const std::optional<SelectTool::ActiveDragPreview> displayedDragPreview =
       renderCoordinator_.compositedPresentation().presentationPreview(activeDragPreview);
   readback.tiles.reserve(textures_.tiles().size());
@@ -661,6 +665,10 @@ void EditorShell::renderRenderPane(const Vector2d& renderPaneOrigin, const Vecto
       selectTool_.onMouseUp(app_, screenToDocument(ImGui::GetMousePos()));
       lastPostedScreenPoint_.reset();
       if (previewBeforeRelease.has_value()) {
+        if (previewHadVisualChange) {
+          renderCoordinator_.compositedPresentation().beginSettling(
+              previewBeforeRelease, app_.document().currentFrameVersion());
+        }
         if (!renderCoordinator_.asyncRenderer().isBusy() &&
             (app_.flushFrame() || previewHadVisualChange)) {
           renderCoordinator_.compositedPresentation().beginSettling(
@@ -683,7 +691,10 @@ void EditorShell::renderRenderPane(const Vector2d& renderPaneOrigin, const Vecto
                                           textures_);
   }
 
-  const auto activeDragPreview = selectTool_.activeDragPreview();
+  const auto liveActiveDragPreview = selectTool_.activeDragPreview();
+  const auto activeDragPreview =
+      renderCoordinator_.compositedPresentation().activePreviewForPresentation(
+          liveActiveDragPreview);
   const auto displayedDragPreview =
       renderCoordinator_.compositedPresentation().presentationPreview(activeDragPreview);
   RenderPanePresenterState paneState{

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -93,6 +93,7 @@ EditorShell::EditorShell(gui::EditorWindow& window, EditorShellOptions options)
       textEditor_(),
       textures_(),
       renderCoordinator_(window.geodeDevice()),
+      rotateCursorSet_(),
       documentSyncController_(LoadFile(options_.svgPath).value_or("")),
       interactionController_(),
       inputBridge_(window_, kWheelZoomStep),
@@ -161,6 +162,9 @@ EditorShell::EditorShell(gui::EditorWindow& window, EditorShellOptions options)
   app_.setCleanSourceText(textEditor_.getText());
   renderCoordinator_.refreshSelectionBoundsCache(app_);
   textures_.initialize();
+  if (!rotateCursorSet_.initialize(window_.rawHandle(), window_.geodeDevice())) {
+    std::fprintf(stderr, "[editor] custom rotate cursor unavailable; using fallback cursor\n");
+  }
 
   // On-demand render loop: the main thread sleeps in `window.waitEvents()`
   // between user inputs, so the worker thread has to nudge it when a
@@ -415,7 +419,7 @@ void EditorShell::handleGlobalShortcuts() {
       if (app_.canUndo()) {
         app_.undo();
       }
-    } else if (pressedZ && cmd && shift) {
+    } else if (pressedZ && cmd && shift && app_.canRedo()) {
       app_.redo();
     }
   }
@@ -537,8 +541,18 @@ void EditorShell::renderRenderPane(const Vector2d& renderPaneOrigin, const Vecto
     const SelectionTransformHandleIntent hoverIntent =
         cachedHandleIntentAt(screenToDocument(ImGui::GetMousePos()));
     if (hoverIntent.kind != SelectionTransformHandleKind::None) {
-      ImGui::SetMouseCursor(CursorForTransformHandleIntent(hoverIntent));
+      if (hoverIntent.kind == SelectionTransformHandleKind::Rotate &&
+          rotateCursorSet_.setRotateCursor(hoverIntent.corner)) {
+        ImGui::SetMouseCursor(ImGuiMouseCursor_Arrow);
+      } else {
+        rotateCursorSet_.clearIfActive();
+        ImGui::SetMouseCursor(CursorForTransformHandleIntent(hoverIntent));
+      }
+    } else {
+      rotateCursorSet_.clearIfActive();
     }
+  } else if (!toolEligible) {
+    rotateCursorSet_.clearIfActive();
   }
   if (toolEligible && ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
     MouseModifiers modifiers;
@@ -1005,7 +1019,7 @@ void EditorShell::runFrame() {
       .sourcePaneFocused = textEditor_.isFocused(),
       .canSave = app_.hasDocument(),
       .canUndo = app_.canUndo(),
-      .canRedo = app_.undoTimeline().entryCount() > 0,
+      .canRedo = app_.canRedo(),
   };
   const MenuBarActions menuActions = menuBarPresenter_.render(menuState, uiFontBold_);
   if (menuActions.openAbout) {
@@ -1026,7 +1040,7 @@ void EditorShell::runFrame() {
   if (menuActions.undo && app_.canUndo()) {
     app_.undo();
   }
-  if (menuActions.redo) {
+  if (menuActions.redo && app_.canRedo()) {
     app_.redo();
   }
   if (menuActions.cut) {

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -19,6 +19,7 @@
 #include "donner/editor/MenuBarPresenter.h"
 #include "donner/editor/RenderCoordinator.h"
 #include "donner/editor/RenderPanePresenter.h"
+#include "donner/editor/RotateCursorSet.h"
 #include "donner/editor/SelectTool.h"
 #include "donner/editor/SidebarPresenter.h"
 #include "donner/editor/TextEditor.h"
@@ -151,6 +152,7 @@ private:
   TextEditor textEditor_;
   GlTextureCache textures_;
   RenderCoordinator renderCoordinator_;
+  RotateCursorSet rotateCursorSet_;
   DocumentSyncController documentSyncController_;
   ViewportInteractionController interactionController_;
   std::optional<ViewportState> pendingViewportReplayOverride_;

--- a/donner/editor/GlTextureCache.cc
+++ b/donner/editor/GlTextureCache.cc
@@ -1,11 +1,15 @@
 #include "donner/editor/GlTextureCache.h"
 
+#include <cstring>
 #include <iterator>
+#include <utility>
 
 #include "donner/editor/TracyWrapper.h"
 #ifdef DONNER_EDITOR_WGPU
 #include "backends/imgui_impl_wgpu.h"
 #include "donner/svg/renderer/RendererGeode.h"
+#include "donner/svg/renderer/geode/GeodeDevice.h"
+#include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 #endif
 
 namespace donner::editor {
@@ -14,6 +18,16 @@ namespace {
 
 #ifdef DONNER_EDITOR_WGPU
 constexpr std::size_t kRetiredSnapshotFrameLimit = 3;
+constexpr uint32_t kWgpuBytesPerRowAlignment = 256u;
+
+uint32_t AlignWgpuBytesPerRow(uint32_t value) {
+  return (value + kWgpuBytesPerRowAlignment - 1u) & ~(kWgpuBytesPerRowAlignment - 1u);
+}
+
+ImTextureID TextureViewToImTextureId(const wgpu::TextureView& textureView) {
+  const WGPUTextureView rawTextureView = textureView;
+  return static_cast<ImTextureID>(reinterpret_cast<std::uintptr_t>(rawTextureView));
+}
 #endif
 
 Vector2i PayloadDimensionsForTile(const RenderResult::CompositedTile& tile) {
@@ -31,6 +45,23 @@ bool TileHasPayload(const RenderResult::CompositedTile& tile) {
 }
 
 }  // namespace
+
+#ifdef DONNER_EDITOR_WGPU
+struct GlTextureCache::WgpuUploadedTexture {
+  donner::geode::ScopedWgpuHandle<wgpu::Texture> texture;
+  donner::geode::ScopedWgpuHandle<wgpu::TextureView> view;
+};
+#endif
+
+GlTextureCache::GlTextureCache(std::shared_ptr<::donner::geode::GeodeDevice> geodeDevice)
+#ifdef DONNER_EDITOR_WGPU
+    : geodeDevice_(std::move(geodeDevice))
+#endif
+{
+#ifndef DONNER_EDITOR_WGPU
+  (void)geodeDevice;
+#endif
+}
 
 CompositedTileTextureIdentity TextureIdentityForCompositedTile(
     const RenderResult::CompositedTile& tile) {
@@ -85,8 +116,27 @@ void GlTextureCache::initialize() {
 void GlTextureCache::uploadOverlay(const svg::RendererBitmap& bitmap) {
   ZoneScopedN("GlTextureCache::uploadOverlay");
 #ifdef DONNER_EDITOR_WGPU
-  (void)bitmap;
-  clearOverlay();
+  RetiredSnapshotBatch retiredSnapshots;
+  if (overlayTexture_ != 0) {
+    retiredSnapshots.push_back(RetiredSnapshot{
+        .texture = overlayTexture_,
+        .snapshot = std::move(overlayTextureSnapshot_),
+        .uploadedTexture = std::move(overlayUploadedTexture_),
+    });
+  }
+  overlayTextureSnapshot_.reset();
+  overlayUploadedTexture_ = uploadBitmapToWgpu(bitmap);
+  overlayTexture_ = overlayUploadedTexture_ != nullptr
+                        ? TextureViewToImTextureId(overlayUploadedTexture_->view.get())
+                        : 0;
+  if (overlayTexture_ != 0) {
+    overlayWidth_ = bitmap.dimensions.x;
+    overlayHeight_ = bitmap.dimensions.y;
+  } else {
+    overlayWidth_ = 0;
+    overlayHeight_ = 0;
+  }
+  retireSnapshots(std::move(retiredSnapshots));
 #else
   UploadBitmap(overlayTexture_, bitmap, &overlayWidth_, &overlayHeight_);
 #endif
@@ -99,9 +149,15 @@ void GlTextureCache::uploadOverlayTexture(
   RetiredSnapshotBatch retiredSnapshots;
   const bool acquiredSnapshot =
       textureSnapshot != nullptr && overlayTextureSnapshot_ != textureSnapshot;
-  if (overlayTextureSnapshot_ != nullptr && overlayTextureSnapshot_ != textureSnapshot) {
-    retiredSnapshots.push_back(RetireSnapshot(overlayTexture_, std::move(overlayTextureSnapshot_)));
+  if (overlayTexture_ != 0 &&
+      (overlayTextureSnapshot_ != textureSnapshot || overlayUploadedTexture_ != nullptr)) {
+    retiredSnapshots.push_back(RetiredSnapshot{
+        .texture = overlayTexture_,
+        .snapshot = std::move(overlayTextureSnapshot_),
+        .uploadedTexture = std::move(overlayUploadedTexture_),
+    });
   }
+  overlayUploadedTexture_.reset();
   overlayTextureSnapshot_ = std::move(textureSnapshot);
   overlayTexture_ = ToImTextureId(overlayTextureSnapshot_.get());
   if (overlayTextureSnapshot_ != nullptr && overlayTexture_ != 0) {
@@ -112,10 +168,7 @@ void GlTextureCache::uploadOverlayTexture(
     overlayWidth_ = dims.x;
     overlayHeight_ = dims.y;
   } else {
-    if (overlayTextureSnapshot_ != nullptr) {
-      retiredSnapshots.push_back(
-          RetireSnapshot(overlayTexture_, std::move(overlayTextureSnapshot_)));
-    }
+    overlayTextureSnapshot_.reset();
     overlayTexture_ = 0;
     overlayWidth_ = 0;
     overlayHeight_ = 0;
@@ -175,29 +228,49 @@ void GlTextureCache::uploadComposited(const RenderResult::CompositedPreview& pre
     }
 
 #ifdef DONNER_EDITOR_WGPU
-    if (tile.textureSnapshot == nullptr) {
-      continue;
-    }
-    const ImTextureID textureId = ToImTextureId(tile.textureSnapshot.get());
-    if (textureId == 0) {
-      continue;
+    auto& entry = tileTextures_[tile.id];
+    const CompositedTileTextureIdentity tileIdentity = TextureIdentityForCompositedTile(tile);
+    if (entry.texture == 0 || entry.identity != tileIdentity) {
+      NativeTextureHandle textureId = 0;
+      Vector2i textureDims = Vector2i::Zero();
+      std::shared_ptr<const svg::RendererTextureSnapshot> textureSnapshot;
+      std::shared_ptr<WgpuUploadedTexture> uploadedTexture;
+
+      if (tile.textureSnapshot != nullptr) {
+        textureId = ToImTextureId(tile.textureSnapshot.get());
+        textureDims = tile.textureSnapshot->dimensions();
+        textureSnapshot = tile.textureSnapshot;
+      } else if (!tile.bitmap.empty()) {
+        uploadedTexture = uploadBitmapToWgpu(tile.bitmap);
+        if (uploadedTexture != nullptr) {
+          textureId = TextureViewToImTextureId(uploadedTexture->view.get());
+          textureDims = tile.bitmap.dimensions;
+        }
+      }
+
+      if (textureId == 0) {
+        continue;
+      }
+
+      if (entry.texture != 0) {
+        retiredSnapshots.push_back(RetiredSnapshot{
+            .texture = entry.texture,
+            .snapshot = std::move(entry.textureSnapshot),
+            .uploadedTexture = std::move(entry.uploadedTexture),
+        });
+      }
+      if (textureSnapshot != nullptr) {
+        ImGui_ImplWGPU_AddTexturePremultipliedAlphaRef(textureId);
+      }
+      entry.texture = textureId;
+      entry.textureSnapshot = std::move(textureSnapshot);
+      entry.uploadedTexture = std::move(uploadedTexture);
+      entry.identity = tileIdentity;
+      entry.uploadedGeneration = tile.generation;
+      entry.width = textureDims.x;
+      entry.height = textureDims.y;
     }
     liveIds.insert(tile.id);
-    auto& entry = tileTextures_[tile.id];
-    const Vector2i textureDims = tile.textureSnapshot->dimensions();
-    const bool acquiredSnapshot = entry.textureSnapshot != tile.textureSnapshot;
-    if (entry.textureSnapshot != nullptr && entry.textureSnapshot != tile.textureSnapshot) {
-      retiredSnapshots.push_back(RetireSnapshot(entry.texture, std::move(entry.textureSnapshot)));
-    }
-    if (acquiredSnapshot) {
-      ImGui_ImplWGPU_AddTexturePremultipliedAlphaRef(textureId);
-    }
-    entry.texture = textureId;
-    entry.textureSnapshot = tile.textureSnapshot;
-    entry.identity = TextureIdentityForCompositedTile(tile);
-    entry.uploadedGeneration = tile.generation;
-    entry.width = textureDims.x;
-    entry.height = textureDims.y;
 #else
     liveIds.insert(tile.id);
     auto& entry = tileTextures_[tile.id];
@@ -242,9 +315,12 @@ void GlTextureCache::uploadComposited(const RenderResult::CompositedPreview& pre
         glDeleteTextures(1, &it->second.texture);
       }
 #else
-      if (it->second.textureSnapshot != nullptr) {
-        retiredSnapshots.push_back(
-            RetireSnapshot(it->second.texture, std::move(it->second.textureSnapshot)));
+      if (it->second.texture != 0) {
+        retiredSnapshots.push_back(RetiredSnapshot{
+            .texture = it->second.texture,
+            .snapshot = std::move(it->second.textureSnapshot),
+            .uploadedTexture = std::move(it->second.uploadedTexture),
+        });
       }
 #endif
       it = tileTextures_.erase(it);
@@ -291,9 +367,15 @@ void GlTextureCache::advancePresentationFrame() {
 void GlTextureCache::clearOverlay() {
 #ifdef DONNER_EDITOR_WGPU
   RetiredSnapshotBatch retiredSnapshots;
-  if (overlayTextureSnapshot_ != nullptr) {
-    retiredSnapshots.push_back(RetireSnapshot(overlayTexture_, std::move(overlayTextureSnapshot_)));
+  if (overlayTexture_ != 0) {
+    retiredSnapshots.push_back(RetiredSnapshot{
+        .texture = overlayTexture_,
+        .snapshot = std::move(overlayTextureSnapshot_),
+        .uploadedTexture = std::move(overlayUploadedTexture_),
+    });
   }
+  overlayTextureSnapshot_.reset();
+  overlayUploadedTexture_.reset();
   retireSnapshots(std::move(retiredSnapshots));
 #else
   overlayTextureSnapshot_.reset();
@@ -308,8 +390,12 @@ void GlTextureCache::resetComposited() {
   RetiredSnapshotBatch retiredSnapshots;
   retiredSnapshots.reserve(tileTextures_.size());
   for (auto& [_, entry] : tileTextures_) {
-    if (entry.textureSnapshot != nullptr) {
-      retiredSnapshots.push_back(RetireSnapshot(entry.texture, std::move(entry.textureSnapshot)));
+    if (entry.texture != 0) {
+      retiredSnapshots.push_back(RetiredSnapshot{
+          .texture = entry.texture,
+          .snapshot = std::move(entry.textureSnapshot),
+          .uploadedTexture = std::move(entry.uploadedTexture),
+      });
     }
   }
   retireSnapshots(std::move(retiredSnapshots));
@@ -362,8 +448,74 @@ ImTextureID GlTextureCache::ToImTextureId(const svg::RendererTextureSnapshot* te
     return 0;
   }
   const auto* geodeTexture = static_cast<const svg::RendererGeodeTextureSnapshot*>(textureSnapshot);
-  const WGPUTextureView textureView = geodeTexture->textureView();
-  return static_cast<ImTextureID>(reinterpret_cast<std::uintptr_t>(textureView));
+  return TextureViewToImTextureId(geodeTexture->textureView());
+}
+
+std::shared_ptr<GlTextureCache::WgpuUploadedTexture> GlTextureCache::uploadBitmapToWgpu(
+    const svg::RendererBitmap& bitmap) {
+  if (geodeDevice_ == nullptr || bitmap.empty() || bitmap.rowBytes == 0u) {
+    return nullptr;
+  }
+
+  const uint32_t width = static_cast<uint32_t>(bitmap.dimensions.x);
+  const uint32_t height = static_cast<uint32_t>(bitmap.dimensions.y);
+  const uint32_t tightBytesPerRow = width * 4u;
+  const uint32_t paddedBytesPerRow = AlignWgpuBytesPerRow(tightBytesPerRow);
+
+  if (bitmap.rowBytes < tightBytesPerRow ||
+      bitmap.pixels.size() < bitmap.rowBytes * static_cast<std::size_t>(height)) {
+    return nullptr;
+  }
+
+  wgpu::TextureDescriptor textureDesc = {};
+  textureDesc.label = donner::geode::wgpuLabel("EditorUploadedBitmap");
+  textureDesc.size = {width, height, 1};
+  textureDesc.mipLevelCount = 1;
+  textureDesc.sampleCount = 1;
+  textureDesc.dimension = wgpu::TextureDimension::_2D;
+  textureDesc.format = wgpu::TextureFormat::RGBA8Unorm;
+  textureDesc.usage = wgpu::TextureUsage::TextureBinding | wgpu::TextureUsage::CopyDst;
+
+  auto uploaded = std::make_shared<WgpuUploadedTexture>();
+  uploaded->texture.reset(geodeDevice_->device().createTexture(textureDesc));
+  if (!uploaded->texture) {
+    return nullptr;
+  }
+  geodeDevice_->countTexture();
+
+  std::vector<uint8_t> uploadPixels;
+  const uint8_t* uploadData = bitmap.pixels.data();
+  std::size_t uploadSize = bitmap.rowBytes * static_cast<std::size_t>(height);
+  if (bitmap.rowBytes != tightBytesPerRow || tightBytesPerRow != paddedBytesPerRow) {
+    uploadPixels.assign(static_cast<std::size_t>(paddedBytesPerRow) * height, 0u);
+    for (uint32_t y = 0; y < height; ++y) {
+      const uint8_t* src = bitmap.pixels.data() + static_cast<std::size_t>(y) * bitmap.rowBytes;
+      uint8_t* dst = uploadPixels.data() + static_cast<std::size_t>(y) * paddedBytesPerRow;
+      std::memcpy(dst, src, tightBytesPerRow);
+    }
+    uploadData = uploadPixels.data();
+    uploadSize = uploadPixels.size();
+  }
+
+  wgpu::TexelCopyTextureInfo dst = {};
+  dst.texture = uploaded->texture.get();
+  dst.mipLevel = 0;
+  dst.origin = {0, 0, 0};
+  dst.aspect = wgpu::TextureAspect::All;
+
+  wgpu::TexelCopyBufferLayout layout = {};
+  layout.offset = 0;
+  layout.bytesPerRow = paddedBytesPerRow;
+  layout.rowsPerImage = height;
+
+  wgpu::Extent3D writeSize = {width, height, 1};
+  geodeDevice_->queue().writeTexture(dst, uploadData, uploadSize, layout, writeSize);
+
+  uploaded->view.reset(uploaded->texture.get().createView());
+  if (!uploaded->view) {
+    return nullptr;
+  }
+  return uploaded;
 }
 
 void GlTextureCache::retireSnapshots(RetiredSnapshotBatch snapshots) {

--- a/donner/editor/GlTextureCache.cc
+++ b/donner/editor/GlTextureCache.cc
@@ -167,6 +167,7 @@ void GlTextureCache::uploadComposited(const RenderResult::CompositedPreview& pre
       view.canvasOffsetDoc = tile.canvasOffsetDoc;
       view.bitmapDimsDoc = tile.bitmapDimsDoc;
       view.dragTranslationDoc = tile.dragTranslationDoc;
+      view.documentFromCachedDocument = tile.documentFromCachedDocument;
       view.metadataOnly = true;
       view.isDragTarget = tile.isDragTarget;
       tiles_.push_back(view);
@@ -228,6 +229,7 @@ void GlTextureCache::uploadComposited(const RenderResult::CompositedPreview& pre
     view.canvasOffsetDoc = tile.canvasOffsetDoc;
     view.bitmapDimsDoc = tile.bitmapDimsDoc;
     view.dragTranslationDoc = tile.dragTranslationDoc;
+    view.documentFromCachedDocument = tile.documentFromCachedDocument;
     view.isDragTarget = tile.isDragTarget;
     tiles_.push_back(view);
   }

--- a/donner/editor/GlTextureCache.h
+++ b/donner/editor/GlTextureCache.h
@@ -9,7 +9,7 @@
 #include <unordered_set>
 #include <vector>
 
-#if defined(__EMSCRIPTEN__)
+#if defined(__EMSCRIPTEN__) && !defined(DONNER_EDITOR_WGPU)
 #define GLFW_INCLUDE_ES3
 #include <GLES3/gl3.h>
 #elif !defined(DONNER_EDITOR_WGPU)
@@ -20,6 +20,10 @@
 #include "donner/base/Vector2.h"
 #include "donner/editor/AsyncRenderer.h"
 #include "donner/editor/ImGuiIncludes.h"
+
+namespace donner::geode {
+class GeodeDevice;
+}  // namespace donner::geode
 
 namespace donner::editor {
 
@@ -66,7 +70,7 @@ struct CompositedTileTextureIdentity {
  */
 class GlTextureCache {
 public:
-  GlTextureCache() = default;
+  explicit GlTextureCache(std::shared_ptr<::donner::geode::GeodeDevice> geodeDevice = nullptr);
   ~GlTextureCache();
 
   GlTextureCache(const GlTextureCache&) = delete;
@@ -126,6 +130,7 @@ public:
 private:
 #ifdef DONNER_EDITOR_WGPU
   using NativeTextureHandle = ImTextureID;
+  struct WgpuUploadedTexture;
 #else
   using NativeTextureHandle = GLuint;
 #endif
@@ -133,6 +138,7 @@ private:
   static ImTextureID ToImTextureId(NativeTextureHandle texture);
 #ifdef DONNER_EDITOR_WGPU
   static ImTextureID ToImTextureId(const svg::RendererTextureSnapshot* textureSnapshot);
+  std::shared_ptr<WgpuUploadedTexture> uploadBitmapToWgpu(const svg::RendererBitmap& bitmap);
 #endif
 #ifndef DONNER_EDITOR_WGPU
   static void UploadBitmap(GLuint texture, const svg::RendererBitmap& bitmap, int* outWidth,
@@ -143,6 +149,9 @@ private:
   struct CachedTextureEntry {
     NativeTextureHandle texture = 0;
     std::shared_ptr<const svg::RendererTextureSnapshot> textureSnapshot;
+#ifdef DONNER_EDITOR_WGPU
+    std::shared_ptr<WgpuUploadedTexture> uploadedTexture;
+#endif
     CompositedTileTextureIdentity identity;
     std::uint64_t uploadedGeneration = 0;
     int width = 0;
@@ -153,6 +162,7 @@ private:
   struct RetiredSnapshot {
     NativeTextureHandle texture = 0;
     std::shared_ptr<const svg::RendererTextureSnapshot> snapshot;
+    std::shared_ptr<WgpuUploadedTexture> uploadedTexture;
   };
 
   using RetiredSnapshotBatch = std::vector<RetiredSnapshot>;
@@ -162,10 +172,15 @@ private:
   static void releaseImGuiTexture(NativeTextureHandle texture);
 
   void retireSnapshots(RetiredSnapshotBatch snapshots);
+
+  std::shared_ptr<::donner::geode::GeodeDevice> geodeDevice_;
 #endif
 
   NativeTextureHandle overlayTexture_ = 0;
   std::shared_ptr<const svg::RendererTextureSnapshot> overlayTextureSnapshot_;
+#ifdef DONNER_EDITOR_WGPU
+  std::shared_ptr<WgpuUploadedTexture> overlayUploadedTexture_;
+#endif
 
   int overlayWidth_ = 0;
   int overlayHeight_ = 0;

--- a/donner/editor/GlTextureCache.h
+++ b/donner/editor/GlTextureCache.h
@@ -16,6 +16,7 @@
 #include "glad/glad.h"
 #endif
 
+#include "donner/base/Transform.h"
 #include "donner/base/Vector2.h"
 #include "donner/editor/AsyncRenderer.h"
 #include "donner/editor/ImGuiIncludes.h"
@@ -107,6 +108,7 @@ public:
     Vector2d canvasOffsetDoc = Vector2d::Zero();
     Vector2d bitmapDimsDoc = Vector2d::Zero();
     Vector2d dragTranslationDoc = Vector2d::Zero();
+    Transform2d documentFromCachedDocument = Transform2d();
     bool metadataOnly = false;
     bool isDragTarget = false;
   };

--- a/donner/editor/LayerInspectorPanel.cc
+++ b/donner/editor/LayerInspectorPanel.cc
@@ -2,14 +2,18 @@
 
 #include <cinttypes>
 #include <cstdint>
+#include <cstring>
 #include <iterator>
 #include <unordered_set>
+#include <utility>
 
 #include "donner/editor/ImGuiIncludes.h"
 #include "donner/editor/LayerInspectorDiagnostics.h"
 #ifdef DONNER_EDITOR_WGPU
 #include "backends/imgui_impl_wgpu.h"
 #include "donner/svg/renderer/RendererGeode.h"
+#include "donner/svg/renderer/geode/GeodeDevice.h"
+#include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 #endif
 
 namespace donner::editor {
@@ -19,6 +23,16 @@ namespace {
 constexpr float kThumbnailDisplayHeight = 48.0f;
 #ifdef DONNER_EDITOR_WGPU
 constexpr std::size_t kRetiredSnapshotFrameLimit = 3;
+constexpr uint32_t kWgpuBytesPerRowAlignment = 256u;
+
+uint32_t AlignWgpuBytesPerRow(uint32_t value) {
+  return (value + kWgpuBytesPerRowAlignment - 1u) & ~(kWgpuBytesPerRowAlignment - 1u);
+}
+
+ImTextureID TextureViewToImTextureId(const wgpu::TextureView& textureView) {
+  const WGPUTextureView rawTextureView = textureView;
+  return static_cast<ImTextureID>(reinterpret_cast<std::uintptr_t>(rawTextureView));
+}
 #endif
 
 const char* KindLabel(svg::compositor::CompositorController::CompositeTileSnapshot::Kind kind) {
@@ -46,6 +60,23 @@ const char* RefusalReasonLabel(svg::compositor::CompositorController::PromoteRef
 
 }  // namespace
 
+#ifdef DONNER_EDITOR_WGPU
+struct LayerInspectorPanel::WgpuUploadedTexture {
+  donner::geode::ScopedWgpuHandle<wgpu::Texture> texture;
+  donner::geode::ScopedWgpuHandle<wgpu::TextureView> view;
+};
+#endif
+
+LayerInspectorPanel::LayerInspectorPanel(std::shared_ptr<::donner::geode::GeodeDevice> geodeDevice)
+#ifdef DONNER_EDITOR_WGPU
+    : geodeDevice_(std::move(geodeDevice))
+#endif
+{
+#ifndef DONNER_EDITOR_WGPU
+  (void)geodeDevice;
+#endif
+}
+
 LayerInspectorPanel::~LayerInspectorPanel() {
 #ifdef DONNER_EDITOR_WGPU
   for (const auto& [_, entry] : textures_) {
@@ -71,28 +102,18 @@ LayerInspectorPanel::~LayerInspectorPanel() {
 LayerInspectorPanel::ThumbnailTextureHandle LayerInspectorPanel::uploadThumbnail(
     const svg::compositor::CompositorController::CompositeTileSnapshot& tile) {
 #ifdef DONNER_EDITOR_WGPU
-  if (tile.textureSnapshot == nullptr || tile.bitmapDims.x <= 0 || tile.bitmapDims.y <= 0) {
-    auto it = textures_.find(tile.id);
-    if (it != textures_.end()) {
-      RetiredSnapshotBatch retiredSnapshots;
-      if (it->second.textureSnapshot != nullptr) {
-        retiredSnapshots.push_back(
-            RetireSnapshot(it->second.texture, std::move(it->second.textureSnapshot)));
-      }
-      textures_.erase(it);
-      retireSnapshots(std::move(retiredSnapshots));
-    }
-    return 0;
-  }
+  const bool hasTextureSnapshot = tile.textureSnapshot != nullptr;
+  const bool hasCpuThumbnail =
+      !tile.thumbnailPixels.empty() && tile.thumbnailDims.x > 0 && tile.thumbnailDims.y > 0;
 
-  const ThumbnailTextureHandle texture = ToImTextureId(tile.textureSnapshot.get());
-  if (texture == 0) {
+  if (!hasTextureSnapshot && !hasCpuThumbnail) {
     auto it = textures_.find(tile.id);
     if (it != textures_.end()) {
       RetiredSnapshotBatch retiredSnapshots;
-      if (it->second.textureSnapshot != nullptr) {
-        retiredSnapshots.push_back(
-            RetireSnapshot(it->second.texture, std::move(it->second.textureSnapshot)));
+      if (it->second.texture != 0) {
+        retiredSnapshots.push_back(RetireSnapshot(it->second.texture,
+                                                  std::move(it->second.textureSnapshot),
+                                                  std::move(it->second.uploadedTexture)));
       }
       textures_.erase(it);
       retireSnapshots(std::move(retiredSnapshots));
@@ -102,19 +123,71 @@ LayerInspectorPanel::ThumbnailTextureHandle LayerInspectorPanel::uploadThumbnail
 
   auto& entry = textures_[tile.id];
   RetiredSnapshotBatch retiredSnapshots;
-  const bool acquiredSnapshot = entry.textureSnapshot != tile.textureSnapshot;
-  if (entry.textureSnapshot != nullptr && entry.textureSnapshot != tile.textureSnapshot) {
-    retiredSnapshots.push_back(RetireSnapshot(entry.texture, std::move(entry.textureSnapshot)));
-  }
-  if (acquiredSnapshot) {
-    ImGui_ImplWGPU_AddTexturePremultipliedAlphaRef(texture);
+
+  if (hasTextureSnapshot) {
+    const ThumbnailTextureHandle texture = ToImTextureId(tile.textureSnapshot.get());
+    if (texture == 0) {
+      if (entry.texture != 0) {
+        retiredSnapshots.push_back(RetireSnapshot(entry.texture, std::move(entry.textureSnapshot),
+                                                  std::move(entry.uploadedTexture)));
+      }
+      textures_.erase(tile.id);
+      retireSnapshots(std::move(retiredSnapshots));
+      return 0;
+    }
+
+    const bool acquiredSnapshot =
+        entry.textureSnapshot != tile.textureSnapshot || entry.uploadedTexture != nullptr;
+    if (acquiredSnapshot) {
+      if (entry.texture != 0) {
+        retiredSnapshots.push_back(RetireSnapshot(entry.texture, std::move(entry.textureSnapshot),
+                                                  std::move(entry.uploadedTexture)));
+      }
+      ImGui_ImplWGPU_AddTexturePremultipliedAlphaRef(texture);
+      entry.texture = texture;
+      entry.textureSnapshot = tile.textureSnapshot;
+      entry.uploadedTexture.reset();
+    }
+
+    entry.uploadedGeneration = tile.generation;
+    entry.width = tile.bitmapDims.x;
+    entry.height = tile.bitmapDims.y;
+    retireSnapshots(std::move(retiredSnapshots));
+    return entry.texture;
   }
 
+  const bool needsUpload = entry.texture == 0 || entry.uploadedTexture == nullptr ||
+                           entry.uploadedGeneration != tile.generation ||
+                           entry.width != tile.thumbnailDims.x ||
+                           entry.height != tile.thumbnailDims.y;
+  if (!needsUpload) {
+    return entry.texture;
+  }
+
+  std::shared_ptr<WgpuUploadedTexture> uploadedTexture =
+      uploadThumbnailPixelsToWgpu(tile.thumbnailPixels, tile.thumbnailDims);
+  const ThumbnailTextureHandle texture =
+      uploadedTexture != nullptr ? TextureViewToImTextureId(uploadedTexture->view.get()) : 0;
+  if (texture == 0) {
+    if (entry.texture != 0) {
+      retiredSnapshots.push_back(RetireSnapshot(entry.texture, std::move(entry.textureSnapshot),
+                                                std::move(entry.uploadedTexture)));
+    }
+    textures_.erase(tile.id);
+    retireSnapshots(std::move(retiredSnapshots));
+    return 0;
+  }
+
+  if (entry.texture != 0) {
+    retiredSnapshots.push_back(RetireSnapshot(entry.texture, std::move(entry.textureSnapshot),
+                                              std::move(entry.uploadedTexture)));
+  }
   entry.texture = texture;
-  entry.textureSnapshot = tile.textureSnapshot;
+  entry.textureSnapshot.reset();
+  entry.uploadedTexture = std::move(uploadedTexture);
   entry.uploadedGeneration = tile.generation;
-  entry.width = tile.bitmapDims.x;
-  entry.height = tile.bitmapDims.y;
+  entry.width = tile.thumbnailDims.x;
+  entry.height = tile.thumbnailDims.y;
   retireSnapshots(std::move(retiredSnapshots));
   return entry.texture;
 #else
@@ -169,9 +242,10 @@ void LayerInspectorPanel::evictAbsentTiles(
         glDeleteTextures(1, &it->second.texture);
       }
 #else
-      if (it->second.textureSnapshot != nullptr) {
-        retiredSnapshots.push_back(
-            RetireSnapshot(it->second.texture, std::move(it->second.textureSnapshot)));
+      if (it->second.texture != 0) {
+        retiredSnapshots.push_back(RetireSnapshot(it->second.texture,
+                                                  std::move(it->second.textureSnapshot),
+                                                  std::move(it->second.uploadedTexture)));
       }
 #endif
       it = textures_.erase(it);
@@ -359,11 +433,79 @@ LayerInspectorPanel::ThumbnailTextureHandle LayerInspectorPanel::ToImTextureId(
   return static_cast<ThumbnailTextureHandle>(reinterpret_cast<std::uintptr_t>(textureView));
 }
 
+std::shared_ptr<LayerInspectorPanel::WgpuUploadedTexture>
+LayerInspectorPanel::uploadThumbnailPixelsToWgpu(const std::vector<uint8_t>& pixels,
+                                                 const Vector2i& dimensions) {
+  if (geodeDevice_ == nullptr || pixels.empty() || dimensions.x <= 0 || dimensions.y <= 0) {
+    return nullptr;
+  }
+
+  const uint32_t width = static_cast<uint32_t>(dimensions.x);
+  const uint32_t height = static_cast<uint32_t>(dimensions.y);
+  const uint32_t tightBytesPerRow = width * 4u;
+  const uint32_t paddedBytesPerRow = AlignWgpuBytesPerRow(tightBytesPerRow);
+  if (pixels.size() < static_cast<std::size_t>(tightBytesPerRow) * height) {
+    return nullptr;
+  }
+
+  wgpu::TextureDescriptor textureDesc = {};
+  textureDesc.label = donner::geode::wgpuLabel("EditorLayerThumbnail");
+  textureDesc.size = {width, height, 1};
+  textureDesc.mipLevelCount = 1;
+  textureDesc.sampleCount = 1;
+  textureDesc.dimension = wgpu::TextureDimension::_2D;
+  textureDesc.format = wgpu::TextureFormat::RGBA8Unorm;
+  textureDesc.usage = wgpu::TextureUsage::TextureBinding | wgpu::TextureUsage::CopyDst;
+
+  auto uploaded = std::make_shared<WgpuUploadedTexture>();
+  uploaded->texture.reset(geodeDevice_->device().createTexture(textureDesc));
+  if (!uploaded->texture) {
+    return nullptr;
+  }
+  geodeDevice_->countTexture();
+
+  std::vector<uint8_t> uploadPixels;
+  const uint8_t* uploadData = pixels.data();
+  std::size_t uploadSize = pixels.size();
+  if (tightBytesPerRow != paddedBytesPerRow) {
+    uploadPixels.assign(static_cast<std::size_t>(paddedBytesPerRow) * height, 0u);
+    for (uint32_t y = 0; y < height; ++y) {
+      const uint8_t* src = pixels.data() + static_cast<std::size_t>(y) * tightBytesPerRow;
+      uint8_t* dst = uploadPixels.data() + static_cast<std::size_t>(y) * paddedBytesPerRow;
+      std::memcpy(dst, src, tightBytesPerRow);
+    }
+    uploadData = uploadPixels.data();
+    uploadSize = uploadPixels.size();
+  }
+
+  wgpu::TexelCopyTextureInfo dst = {};
+  dst.texture = uploaded->texture.get();
+  dst.mipLevel = 0;
+  dst.origin = {0, 0, 0};
+  dst.aspect = wgpu::TextureAspect::All;
+
+  wgpu::TexelCopyBufferLayout layout = {};
+  layout.offset = 0;
+  layout.bytesPerRow = paddedBytesPerRow;
+  layout.rowsPerImage = height;
+
+  wgpu::Extent3D writeSize = {width, height, 1};
+  geodeDevice_->queue().writeTexture(dst, uploadData, uploadSize, layout, writeSize);
+
+  uploaded->view.reset(uploaded->texture.get().createView());
+  if (!uploaded->view) {
+    return nullptr;
+  }
+  return uploaded;
+}
+
 LayerInspectorPanel::RetiredSnapshot LayerInspectorPanel::RetireSnapshot(
-    ThumbnailTextureHandle texture, std::shared_ptr<const svg::RendererTextureSnapshot> snapshot) {
+    ThumbnailTextureHandle texture, std::shared_ptr<const svg::RendererTextureSnapshot> snapshot,
+    std::shared_ptr<WgpuUploadedTexture> uploadedTexture) {
   return RetiredSnapshot{
       .texture = texture,
       .snapshot = std::move(snapshot),
+      .uploadedTexture = std::move(uploadedTexture),
   };
 }
 

--- a/donner/editor/LayerInspectorPanel.h
+++ b/donner/editor/LayerInspectorPanel.h
@@ -30,6 +30,10 @@
 
 #include "donner/svg/compositor/CompositorController.h"
 
+namespace donner::geode {
+class GeodeDevice;
+}  // namespace donner::geode
+
 namespace donner::editor {
 
 /// Stateful — owns one preview resource per active composite tile (keyed on
@@ -39,7 +43,7 @@ namespace donner::editor {
 /// Construct and destroy on the presentation thread.
 class LayerInspectorPanel {
 public:
-  LayerInspectorPanel() = default;
+  explicit LayerInspectorPanel(std::shared_ptr<::donner::geode::GeodeDevice> geodeDevice = nullptr);
   ~LayerInspectorPanel();
 
   LayerInspectorPanel(const LayerInspectorPanel&) = delete;
@@ -81,6 +85,7 @@ public:
 private:
 #ifdef DONNER_EDITOR_WGPU
   using ThumbnailTextureHandle = ImTextureID;
+  struct WgpuUploadedTexture;
 #else
   using ThumbnailTextureHandle = GLuint;
 #endif
@@ -88,6 +93,9 @@ private:
   struct ThumbnailTexture {
     ThumbnailTextureHandle texture = 0;
     std::shared_ptr<const svg::RendererTextureSnapshot> textureSnapshot;
+#ifdef DONNER_EDITOR_WGPU
+    std::shared_ptr<WgpuUploadedTexture> uploadedTexture;
+#endif
     std::uint64_t uploadedGeneration = 0;
     int width = 0;
     int height = 0;
@@ -106,16 +114,22 @@ private:
   struct RetiredSnapshot {
     ThumbnailTextureHandle texture = 0;
     std::shared_ptr<const svg::RendererTextureSnapshot> snapshot;
+    std::shared_ptr<WgpuUploadedTexture> uploadedTexture;
   };
 
   using RetiredSnapshotBatch = std::vector<RetiredSnapshot>;
 
   static ThumbnailTextureHandle ToImTextureId(const svg::RendererTextureSnapshot* textureSnapshot);
+  std::shared_ptr<WgpuUploadedTexture> uploadThumbnailPixelsToWgpu(
+      const std::vector<uint8_t>& pixels, const Vector2i& dimensions);
   static RetiredSnapshot RetireSnapshot(
-      ThumbnailTextureHandle texture, std::shared_ptr<const svg::RendererTextureSnapshot> snapshot);
+      ThumbnailTextureHandle texture, std::shared_ptr<const svg::RendererTextureSnapshot> snapshot,
+      std::shared_ptr<WgpuUploadedTexture> uploadedTexture);
   static void ReleaseImGuiTexture(ThumbnailTextureHandle texture);
 
   void retireSnapshots(RetiredSnapshotBatch snapshots);
+
+  std::shared_ptr<::donner::geode::GeodeDevice> geodeDevice_;
 #endif
 
   std::unordered_map<std::string, ThumbnailTexture> textures_;

--- a/donner/editor/OverlayRenderer.cc
+++ b/donner/editor/OverlayRenderer.cc
@@ -3,10 +3,12 @@
 #include <array>
 #include <vector>
 
+#include "donner/base/Path.h"
 #include "donner/base/Transform.h"
 #include "donner/css/Color.h"
 #include "donner/editor/EditorApp.h"
 #include "donner/editor/SelectionAabb.h"
+#include "donner/editor/SelectionTransformHandles.h"
 #include "donner/editor/TracyWrapper.h"
 #include "donner/svg/SVGDocument.h"
 #include "donner/svg/SVGGeometryElement.h"
@@ -34,6 +36,19 @@ svg::PaintParams MakeSelectionStrokePaint(double worldStrokeWidth) {
   // Bright cyan stroke, no fill.
   paint.stroke = svg::PaintServer::Solid(css::Color(css::RGBA(0x00, 0xc8, 0xff, 0xff)));
   paint.fill = svg::PaintServer::None{};
+  paint.strokeOpacity = 1.0;
+  paint.strokeParams.strokeWidth = worldStrokeWidth;
+  paint.strokeParams.lineCap = svg::StrokeLinecap::Butt;
+  paint.strokeParams.lineJoin = svg::StrokeLinejoin::Miter;
+  paint.strokeParams.miterLimit = 4.0;
+  return paint;
+}
+
+svg::PaintParams MakeHandlePaint(double worldStrokeWidth) {
+  svg::PaintParams paint;
+  paint.fill = svg::PaintServer::Solid(css::Color(css::RGBA(0xff, 0xff, 0xff, 0xff)));
+  paint.stroke = svg::PaintServer::Solid(css::Color(css::RGBA(0x00, 0xc8, 0xff, 0xff)));
+  paint.fillOpacity = 1.0;
   paint.strokeOpacity = 1.0;
   paint.strokeParams.strokeWidth = worldStrokeWidth;
   paint.strokeParams.lineCap = svg::StrokeLinecap::Butt;
@@ -72,6 +87,63 @@ svg::PaintParams MakeMarqueeStrokePaint(double worldStrokeWidth) {
 /// the only case the editor renders today.
 double LinearScale(const Transform2d& canvasFromDoc) {
   return canvasFromDoc.transformVector(Vector2d(1.0, 0.0)).length();
+}
+
+std::array<Vector2d, 4> TransformedBoxCorners(const Box2d& box,
+                                              const Transform2d& documentFromBoxDocument) {
+  const std::array<Vector2d, 4> corners{
+      box.topLeft,
+      Vector2d(box.bottomRight.x, box.topLeft.y),
+      box.bottomRight,
+      Vector2d(box.topLeft.x, box.bottomRight.y),
+  };
+
+  std::array<Vector2d, 4> transformed;
+  for (std::size_t i = 0; i < corners.size(); ++i) {
+    transformed[i] = documentFromBoxDocument.transformPosition(corners[i]);
+  }
+  return transformed;
+}
+
+Box2d HandleBoxForCorner(const Vector2d& cornerDoc, double scale) {
+  const SelectionTransformHandleBoxes handleBoxes =
+      SelectionTransformHandleBoxesForBounds(Box2d(cornerDoc, cornerDoc), scale);
+  return handleBoxes.boxes.front();
+}
+
+Path PathForCorners(const std::array<Vector2d, 4>& corners) {
+  PathBuilder builder;
+  builder.moveTo(corners[0]);
+  builder.lineTo(corners[1]);
+  builder.lineTo(corners[2]);
+  builder.lineTo(corners[3]);
+  builder.closePath();
+  return builder.build();
+}
+
+Path TransformPathToDocument(const Path& path, const Transform2d& documentFromElement) {
+  PathBuilder builder;
+  path.forEach([&](Path::Verb verb, std::span<const Vector2d> points) {
+    switch (verb) {
+      case Path::Verb::MoveTo:
+        builder.moveTo(documentFromElement.transformPosition(points[0]));
+        break;
+      case Path::Verb::LineTo:
+        builder.lineTo(documentFromElement.transformPosition(points[0]));
+        break;
+      case Path::Verb::QuadTo:
+        builder.quadTo(documentFromElement.transformPosition(points[0]),
+                       documentFromElement.transformPosition(points[1]));
+        break;
+      case Path::Verb::CurveTo:
+        builder.curveTo(documentFromElement.transformPosition(points[0]),
+                        documentFromElement.transformPosition(points[1]),
+                        documentFromElement.transformPosition(points[2]));
+        break;
+      case Path::Verb::ClosePath: builder.closePath(); break;
+    }
+  });
+  return builder.build();
 }
 
 }  // namespace
@@ -113,7 +185,8 @@ void OverlayRenderer::drawChromeWithTransform(svg::Renderer& renderer,
 
 SelectionChromeSnapshot OverlayRenderer::captureChromeSnapshot(
     std::span<const svg::SVGElement> selection, const std::optional<Box2d>& marqueeRectDoc,
-    const Transform2d& canvasFromDoc) {
+    const Transform2d& canvasFromDoc,
+    const std::optional<SelectionChromeBoundsPreview>& activeBoundsPreview) {
   SelectionChromeSnapshot snapshot;
   snapshot.canvasFromDoc = canvasFromDoc;
   snapshot.marqueeDoc = marqueeRectDoc;
@@ -136,8 +209,8 @@ SelectionChromeSnapshot OverlayRenderer::captureChromeSnapshot(
     for (const auto& geometry : CollectRenderableGeometry(element)) {
       if (const auto spline = geometry.computedSpline(); spline.has_value()) {
         SelectionChromeSnapshot::PathItem item;
-        item.spline = *spline;
-        item.canvasFromElement = geometry.elementFromWorld() * canvasFromDoc;
+        const Transform2d documentFromElement = geometry.elementFromWorld();
+        item.pathDoc = TransformPathToDocument(*spline, documentFromElement);
         snapshot.paths.push_back(std::move(item));
       }
     }
@@ -152,13 +225,29 @@ SelectionChromeSnapshot OverlayRenderer::captureChromeSnapshot(
   // DOM snapshot. The cache is still useful for main-loop selection-
   // changed detection; it's just no longer gating the overlay's bounds.
   snapshot.aabbsDoc = SnapshotSelectionWorldBounds(selection);
+  if (activeBoundsPreview.has_value() && !snapshot.aabbsDoc.empty()) {
+    const auto corners = TransformedBoxCorners(activeBoundsPreview->startBoundsDoc,
+                                               activeBoundsPreview->documentFromStartDocument);
+    snapshot.orientedBoundsDoc = SelectionChromeSnapshot::OrientedBox{.cornersDoc = corners};
+    snapshot.handleBoxesDoc.reserve(corners.size());
+    for (const Vector2d& corner : corners) {
+      snapshot.handleBoxesDoc.push_back(HandleBoxForCorner(corner, scale));
+    }
+  } else if (!snapshot.aabbsDoc.empty()) {
+    const Box2d combinedBounds = CombinedSelectionBounds(snapshot.aabbsDoc);
+    const SelectionTransformHandleBoxes handleBoxes =
+        SelectionTransformHandleBoxesForBounds(combinedBounds, scale);
+    snapshot.handleBoxesDoc.assign(handleBoxes.boxes.begin(), handleBoxes.boxes.end());
+  }
   return snapshot;
 }
 
 void OverlayRenderer::drawChromeFromSnapshot(svg::Renderer& renderer,
                                              const SelectionChromeSnapshot& snapshot) {
   ZoneScopedN("OverlayRenderer::drawChromeFromSnapshot");
-  if (snapshot.paths.empty() && snapshot.aabbsDoc.empty() && !snapshot.marqueeDoc.has_value()) {
+  if (snapshot.paths.empty() && snapshot.aabbsDoc.empty() &&
+      !snapshot.orientedBoundsDoc.has_value() && snapshot.handleBoxesDoc.empty() &&
+      !snapshot.marqueeDoc.has_value()) {
     return;
   }
 
@@ -171,10 +260,10 @@ void OverlayRenderer::drawChromeFromSnapshot(svg::Renderer& renderer,
   // reused across the loop.
   if (!snapshot.paths.empty()) {
     renderer.setPaint(selectionStrokePaint);
+    renderer.setTransform(snapshot.canvasFromDoc);
     for (const auto& item : snapshot.paths) {
-      renderer.setTransform(item.canvasFromElement);
       svg::PathShape shape;
-      shape.path = item.spline;
+      shape.path = item.pathDoc;
       shape.parentFromEntity = Transform2d();
       renderer.drawPath(shape, selectionStrokePaint.strokeParams);
     }
@@ -184,7 +273,14 @@ void OverlayRenderer::drawChromeFromSnapshot(svg::Renderer& renderer,
   // envelope when there are multiple elements. Drawn in document space
   // with `canvasFromDoc` applied so they line up with the content
   // bitmap the compositor produced for the same frame.
-  if (!snapshot.aabbsDoc.empty()) {
+  if (snapshot.orientedBoundsDoc.has_value()) {
+    renderer.setPaint(selectionStrokePaint);
+    renderer.setTransform(snapshot.canvasFromDoc);
+    svg::PathShape shape;
+    shape.path = PathForCorners(snapshot.orientedBoundsDoc->cornersDoc);
+    shape.parentFromEntity = Transform2d();
+    renderer.drawPath(shape, selectionStrokePaint.strokeParams);
+  } else if (!snapshot.aabbsDoc.empty()) {
     renderer.setPaint(selectionStrokePaint);
     renderer.setTransform(snapshot.canvasFromDoc);
     for (const Box2d& aabb : snapshot.aabbsDoc) {
@@ -196,6 +292,15 @@ void OverlayRenderer::drawChromeFromSnapshot(svg::Renderer& renderer,
         combined.addBox(snapshot.aabbsDoc[i]);
       }
       renderer.drawRect(combined, selectionStrokePaint.strokeParams);
+    }
+  }
+
+  if (!snapshot.handleBoxesDoc.empty()) {
+    renderer.setTransform(snapshot.canvasFromDoc);
+    const svg::PaintParams handlePaint = MakeHandlePaint(snapshot.selectionStrokeWidthWorld);
+    renderer.setPaint(handlePaint);
+    for (const Box2d& handleBox : snapshot.handleBoxesDoc) {
+      renderer.drawRect(handleBox, handlePaint.strokeParams);
     }
   }
 
@@ -214,17 +319,17 @@ void OverlayRenderer::drawChromeFromSnapshot(svg::Renderer& renderer,
   }
 }
 
-void OverlayRenderer::drawChromeWithTransform(svg::Renderer& renderer,
-                                              std::span<const svg::SVGElement> selection,
-                                              const std::optional<Box2d>& marqueeRectDoc,
-                                              const Transform2d& canvasFromDoc) {
+void OverlayRenderer::drawChromeWithTransform(
+    svg::Renderer& renderer, std::span<const svg::SVGElement> selection,
+    const std::optional<Box2d>& marqueeRectDoc, const Transform2d& canvasFromDoc,
+    const std::optional<SelectionChromeBoundsPreview>& activeBoundsPreview) {
   ZoneScopedN("OverlayRenderer::drawChrome");
   // Route the live path through capture + draw so M7's snapshot
   // implementation is the single source of truth. Same output, same
   // performance characteristics (the capture is straight-line registry
   // reads + a small allocation).
   const SelectionChromeSnapshot snapshot =
-      captureChromeSnapshot(selection, marqueeRectDoc, canvasFromDoc);
+      captureChromeSnapshot(selection, marqueeRectDoc, canvasFromDoc, activeBoundsPreview);
   drawChromeFromSnapshot(renderer, snapshot);
 }
 

--- a/donner/editor/OverlayRenderer.h
+++ b/donner/editor/OverlayRenderer.h
@@ -25,6 +25,7 @@
 /// `Renderer::takeSnapshot()`. The renderer's frame pixmap survives across
 /// `endFrame` so additional canvas commands compose onto it directly.
 
+#include <array>
 #include <optional>
 #include <span>
 #include <vector>
@@ -42,10 +43,19 @@ namespace donner::editor {
 
 class EditorApp;
 
+/// Active transform bounds chrome. Used while rotating to draw the
+/// gesture-start selection box transformed into the current document space.
+struct SelectionChromeBoundsPreview {
+  /// Selection AABB captured when the gesture started.
+  Box2d startBoundsDoc;
+  /// Current transform from gesture-start document space to active document space.
+  Transform2d documentFromStartDocument = Transform2d();
+};
+
 /// Frozen view of everything `OverlayRenderer::drawChromeWithTransform`
 /// would normally read off the live registry: per-element path splines
-/// (in local space) + their canvas transforms, per-element AABBs in doc
-/// space, and the optional marquee rect.
+/// transformed into document space, per-element AABBs in document space,
+/// and the optional marquee rect.
 ///
 /// Captured once via `OverlayRenderer::captureChromeSnapshot` while the
 /// registry is safe to read (worker is idle), then handed to
@@ -56,15 +66,19 @@ class EditorApp;
 /// is mid-render, so the editor can paint selection chrome in a frame
 /// that the worker hasn't returned a result for yet.
 struct SelectionChromeSnapshot {
+  /// Four document-space corners of an oriented selection box.
+  struct OrientedBox {
+    std::array<Vector2d, 4> cornersDoc;
+  };
+
   /// One entry per renderable geometry leaf in the selection (groups
   /// are expanded into their geometry descendants, same as the live
   /// path). Empty when nothing's selected.
   struct PathItem {
-    /// Element-local path data — does not change with drag transforms.
-    Path spline;
-    /// `canvasFromElement` at capture time. Composes the element's
-    /// `elementFromWorld` with the snapshot's `canvasFromDoc`.
-    Transform2d canvasFromElement;
+    /// Document-space path data sampled at capture time. Keeping the path
+    /// in document space lets chrome stroke width depend only on viewport
+    /// scale, not on the selected element's own scale/rotation transform.
+    Path pathDoc;
   };
   std::vector<PathItem> paths;
 
@@ -76,6 +90,14 @@ struct SelectionChromeSnapshot {
 
   /// Optional marquee rectangle in document space.
   std::optional<Box2d> marqueeDoc;
+
+  /// Optional oriented bounds drawn instead of axis-aligned AABBs while
+  /// a rotation gesture is active.
+  std::optional<OrientedBox> orientedBoundsDoc;
+
+  /// Corner resize handles in document space. Empty when there is no
+  /// selection AABB.
+  std::vector<Box2d> handleBoxesDoc;
 
   /// `canvasFromDoc` at capture time. The draw phase needs this for
   /// drawing AABBs and the marquee (both live in doc space).
@@ -132,10 +154,10 @@ public:
   ///   drawn as a filled + stroked rectangle matching the prior
   ///   ImGui chrome style.
   /// @param canvasFromDoc Maps document coordinates into canvas pixels.
-  static void drawChromeWithTransform(svg::Renderer& renderer,
-                                      std::span<const svg::SVGElement> selection,
-                                      const std::optional<Box2d>& marqueeRectDoc,
-                                      const Transform2d& canvasFromDoc);
+  static void drawChromeWithTransform(
+      svg::Renderer& renderer, std::span<const svg::SVGElement> selection,
+      const std::optional<Box2d>& marqueeRectDoc, const Transform2d& canvasFromDoc,
+      const std::optional<SelectionChromeBoundsPreview>& activeBoundsPreview = std::nullopt);
 
   /// Back-compat overload without marquee. Kept for existing callers
   /// that don't need a marquee rect (older tests, worker-thread
@@ -155,7 +177,8 @@ public:
   /// subsequent registry mutation.
   [[nodiscard]] static SelectionChromeSnapshot captureChromeSnapshot(
       std::span<const svg::SVGElement> selection, const std::optional<Box2d>& marqueeRectDoc,
-      const Transform2d& canvasFromDoc);
+      const Transform2d& canvasFromDoc,
+      const std::optional<SelectionChromeBoundsPreview>& activeBoundsPreview = std::nullopt);
 
   /// Race-free chrome rasterize: reads only the snapshot, never the
   /// registry. Safe to call while the async-renderer worker is

--- a/donner/editor/PresentationRenderScheduler.cc
+++ b/donner/editor/PresentationRenderScheduler.cc
@@ -35,6 +35,7 @@ PresentationRenderScheduleDecision PresentationRenderScheduler::evaluate(
         .entity = input.activeDragPreview->entity,
         .interactionKind = svg::compositor::InteractionHint::ActiveDrag,
         .translation = input.activeDragPreview->translation,
+        .dragGeneration = input.activeDragPreview->dragGeneration,
     };
   } else if (decision.needsCompositedPrewarm && input.selectedEntity != entt::null) {
     decision.dragPreview = RenderRequest::DragPreview{

--- a/donner/editor/PresentationRenderScheduler.cc
+++ b/donner/editor/PresentationRenderScheduler.cc
@@ -26,7 +26,7 @@ PresentationRenderScheduleDecision PresentationRenderScheduler::evaluate(
       needsSettledSelectionRefresh ||
       presentation.shouldPrewarm(input.selectedEntity, input.currentVersion,
                                  input.currentCanvasSize,
-                                 /*dragActive=*/false);
+                                 /*dragActive=*/input.activeDragPreview.has_value());
   decision.needsRegularRender = input.currentVersion != lastRenderedVersion_ ||
                                 input.currentCanvasSize != lastRenderedCanvasSize_;
 
@@ -43,6 +43,9 @@ PresentationRenderScheduleDecision PresentationRenderScheduler::evaluate(
         .entity = input.selectedEntity,
         .interactionKind = svg::compositor::InteractionHint::Selection,
     };
+  }
+  if (input.activeDragPreview.has_value() && !decision.needsCompositedLayerCapture) {
+    decision.needsRegularRender = false;
   }
 
   return decision;

--- a/donner/editor/PresentationRenderScheduler.cc
+++ b/donner/editor/PresentationRenderScheduler.cc
@@ -35,6 +35,7 @@ PresentationRenderScheduleDecision PresentationRenderScheduler::evaluate(
         .entity = input.activeDragPreview->entity,
         .interactionKind = svg::compositor::InteractionHint::ActiveDrag,
         .translation = input.activeDragPreview->translation,
+        .documentFromCachedDocument = input.activeDragPreview->documentFromCachedDocument,
         .dragGeneration = input.activeDragPreview->dragGeneration,
     };
   } else if (decision.needsCompositedPrewarm && input.selectedEntity != entt::null) {

--- a/donner/editor/PresentedFrameComposer.cc
+++ b/donner/editor/PresentedFrameComposer.cc
@@ -15,8 +15,8 @@ bool IsFinite(const Vector2d& value) {
   return IsFinite(value.x) && IsFinite(value.y);
 }
 
-bool IsFinite(const Transform2d& transform) {
-  for (double value : transform.data) {
+bool IsFinite(const Transform2d& candidateDocumentFromDocument) {
+  for (double value : candidateDocumentFromDocument.data) {
     if (!IsFinite(value)) {
       return false;
     }
@@ -27,6 +27,19 @@ bool IsFinite(const Transform2d& transform) {
 bool IsValidRect(const Vector2d& topLeft, const Vector2d& bottomRight) {
   return IsFinite(topLeft) && IsFinite(bottomRight) && bottomRight.x > topLeft.x &&
          bottomRight.y > topLeft.y;
+}
+
+bool IsValidQuad(const PresentedTileQuad& quad) {
+  return IsFinite(quad.topLeft) && IsFinite(quad.topRight) && IsFinite(quad.bottomRight) &&
+         IsFinite(quad.bottomLeft);
+}
+
+Transform2d DocumentFromCachedWithTranslationFallback(const Transform2d& documentFromCachedDocument,
+                                                      const Vector2d& translationDoc) {
+  if (documentFromCachedDocument.isIdentity() && translationDoc != Vector2d::Zero()) {
+    return Transform2d::Translate(translationDoc);
+  }
+  return documentFromCachedDocument;
 }
 
 }  // namespace
@@ -43,6 +56,25 @@ Vector2d ResolvePresentedTileDragTranslation(
   return tile.dragTranslationDoc;
 }
 
+Transform2d ResolvePresentedTileDocumentTransform(
+    const PresentedFrameTileGeometry& tile,
+    const std::optional<PresentedDragBaseline>& dragBaseline) {
+  const Transform2d tileDocumentFromCachedDocument = DocumentFromCachedWithTranslationFallback(
+      tile.documentFromCachedDocument, tile.dragTranslationDoc);
+  if (tile.isDragTarget && dragBaseline.has_value()) {
+    const Transform2d representedDocumentFromCachedDocument =
+        DocumentFromCachedWithTranslationFallback(
+            dragBaseline->representedDocumentFromCachedDocument,
+            dragBaseline->representedTranslationDoc);
+    const Transform2d activeDocumentFromCachedDocument = DocumentFromCachedWithTranslationFallback(
+        dragBaseline->activeDocumentFromCachedDocument, dragBaseline->activeTranslationDoc);
+    return tileDocumentFromCachedDocument * representedDocumentFromCachedDocument.inverse() *
+           activeDocumentFromCachedDocument;
+  }
+
+  return tileDocumentFromCachedDocument;
+}
+
 Vector2d ResolvePresentedOverlayDragTranslation(
     const std::optional<PresentedDragBaseline>& dragBaseline) {
   if (!dragBaseline.has_value()) {
@@ -52,24 +84,75 @@ Vector2d ResolvePresentedOverlayDragTranslation(
   return dragBaseline->activeTranslationDoc - dragBaseline->representedTranslationDoc;
 }
 
-std::optional<PresentedTileRect> ComputePresentedTileRect(
+Transform2d ResolvePresentedOverlayDocumentTransform(
+    const std::optional<PresentedDragBaseline>& dragBaseline) {
+  if (!dragBaseline.has_value()) {
+    return Transform2d();
+  }
+
+  const Transform2d representedDocumentFromCachedDocument =
+      DocumentFromCachedWithTranslationFallback(dragBaseline->representedDocumentFromCachedDocument,
+                                                dragBaseline->representedTranslationDoc);
+  const Transform2d activeDocumentFromCachedDocument = DocumentFromCachedWithTranslationFallback(
+      dragBaseline->activeDocumentFromCachedDocument, dragBaseline->activeTranslationDoc);
+  return representedDocumentFromCachedDocument.inverse() * activeDocumentFromCachedDocument;
+}
+
+std::optional<PresentedTileQuad> ComputePresentedTileQuad(
     const PresentedFrameTileGeometry& tile, const Transform2d& outputFromCanvasTransform,
     const std::optional<PresentedDragBaseline>& dragBaseline) {
   if (!IsFinite(outputFromCanvasTransform) || !IsFinite(tile.canvasOffsetDoc) ||
       !IsFinite(tile.bitmapDimsDoc) || !IsFinite(tile.dragTranslationDoc) ||
-      tile.bitmapDimsDoc.x <= 0.0 || tile.bitmapDimsDoc.y <= 0.0) {
+      !IsFinite(tile.documentFromCachedDocument) || tile.bitmapDimsDoc.x <= 0.0 ||
+      tile.bitmapDimsDoc.y <= 0.0) {
     return std::nullopt;
   }
 
   const Vector2d effectiveDragTranslationDoc =
       ResolvePresentedTileDragTranslation(tile, dragBaseline);
-  if (!IsFinite(effectiveDragTranslationDoc)) {
+  const Transform2d effectiveDocumentFromCachedDocument =
+      ResolvePresentedTileDocumentTransform(tile, dragBaseline);
+  if (!IsFinite(effectiveDragTranslationDoc) || !IsFinite(effectiveDocumentFromCachedDocument)) {
     return std::nullopt;
   }
 
-  const Vector2d originCanvas = tile.canvasOffsetDoc + effectiveDragTranslationDoc;
-  const Box2d canvasBox(originCanvas, originCanvas + tile.bitmapDimsDoc);
-  const Box2d outputBox = outputFromCanvasTransform.transformBox(canvasBox);
+  const Box2d canvasBox(tile.canvasOffsetDoc, tile.canvasOffsetDoc + tile.bitmapDimsDoc);
+  const Vector2d cachedTopLeft = canvasBox.topLeft;
+  const Vector2d cachedTopRight(canvasBox.bottomRight.x, canvasBox.topLeft.y);
+  const Vector2d cachedBottomRight = canvasBox.bottomRight;
+  const Vector2d cachedBottomLeft(canvasBox.topLeft.x, canvasBox.bottomRight.y);
+
+  const auto presentPoint = [&](const Vector2d& cachedPoint) {
+    return outputFromCanvasTransform.transformPosition(
+        effectiveDocumentFromCachedDocument.transformPosition(cachedPoint));
+  };
+  PresentedTileQuad quad{
+      .topLeft = presentPoint(cachedTopLeft),
+      .topRight = presentPoint(cachedTopRight),
+      .bottomRight = presentPoint(cachedBottomRight),
+      .bottomLeft = presentPoint(cachedBottomLeft),
+      .effectiveDocumentFromCachedDocument = effectiveDocumentFromCachedDocument,
+      .effectiveDragTranslationDoc = effectiveDragTranslationDoc,
+  };
+  if (!IsValidQuad(quad)) {
+    return std::nullopt;
+  }
+  return quad;
+}
+
+std::optional<PresentedTileRect> ComputePresentedTileRect(
+    const PresentedFrameTileGeometry& tile, const Transform2d& outputFromCanvasTransform,
+    const std::optional<PresentedDragBaseline>& dragBaseline) {
+  const std::optional<PresentedTileQuad> quad =
+      ComputePresentedTileQuad(tile, outputFromCanvasTransform, dragBaseline);
+  if (!quad.has_value()) {
+    return std::nullopt;
+  }
+
+  Box2d outputBox = Box2d::CreateEmpty(quad->topLeft);
+  outputBox.addPoint(quad->topRight);
+  outputBox.addPoint(quad->bottomRight);
+  outputBox.addPoint(quad->bottomLeft);
   if (!IsValidRect(outputBox.topLeft, outputBox.bottomRight)) {
     return std::nullopt;
   }
@@ -77,7 +160,7 @@ std::optional<PresentedTileRect> ComputePresentedTileRect(
   return PresentedTileRect{
       .topLeft = outputBox.topLeft,
       .bottomRight = outputBox.bottomRight,
-      .effectiveDragTranslationDoc = effectiveDragTranslationDoc,
+      .effectiveDragTranslationDoc = quad->effectiveDragTranslationDoc,
   };
 }
 

--- a/donner/editor/PresentedFrameComposer.h
+++ b/donner/editor/PresentedFrameComposer.h
@@ -17,6 +17,9 @@ struct PresentedFrameTileGeometry {
   Vector2d bitmapDimsDoc = Vector2d::Zero();
   /// Cached drag translation captured with the tile.
   Vector2d dragTranslationDoc = Vector2d::Zero();
+  /// Cached affine transform from the tile's rasterized document placement
+  /// to its presented document placement.
+  Transform2d documentFromCachedDocument = Transform2d();
   /// Whether this tile represents the current drag target.
   bool isDragTarget = false;
 };
@@ -29,6 +32,26 @@ struct PresentedDragBaseline {
   Vector2d representedTranslationDoc = Vector2d::Zero();
   /// Current active drag translation in document space.
   Vector2d activeTranslationDoc = Vector2d::Zero();
+  /// Document transform represented by the presented tiles.
+  Transform2d representedDocumentFromCachedDocument = Transform2d();
+  /// Current active document transform.
+  Transform2d activeDocumentFromCachedDocument = Transform2d();
+};
+
+/// Output-space quad for one presented tile.
+struct PresentedTileQuad {
+  /// Top-left corner in output coordinates.
+  Vector2d topLeft = Vector2d::Zero();
+  /// Top-right corner in output coordinates.
+  Vector2d topRight = Vector2d::Zero();
+  /// Bottom-right corner in output coordinates.
+  Vector2d bottomRight = Vector2d::Zero();
+  /// Bottom-left corner in output coordinates.
+  Vector2d bottomLeft = Vector2d::Zero();
+  /// Affine transform used to derive this quad.
+  Transform2d effectiveDocumentFromCachedDocument = Transform2d();
+  /// Drag translation used to derive this quad.
+  Vector2d effectiveDragTranslationDoc = Vector2d::Zero();
 };
 
 /// Output-space rectangle for one presented tile.
@@ -69,12 +92,44 @@ struct PresentedPixelRect {
     const std::optional<PresentedDragBaseline>& dragBaseline);
 
 /**
+ * Resolve the affine transform to apply while presenting a cached tile.
+ *
+ * @param tile Geometry for the tile being presented.
+ * @param dragBaseline Active drag baseline represented by the presented tiles.
+ * @return Transform from cached document placement to presented document placement.
+ */
+[[nodiscard]] Transform2d ResolvePresentedTileDocumentTransform(
+    const PresentedFrameTileGeometry& tile,
+    const std::optional<PresentedDragBaseline>& dragBaseline);
+
+/**
  * Resolve the screen-space-independent translation for a full-canvas overlay texture.
  *
  * @param dragBaseline Active drag baseline represented by the overlay texture.
  * @return Translation to add to the overlay texture's canvas-space placement.
  */
 [[nodiscard]] Vector2d ResolvePresentedOverlayDragTranslation(
+    const std::optional<PresentedDragBaseline>& dragBaseline);
+
+/**
+ * Resolve the affine transform from displayed overlay placement to active overlay placement.
+ *
+ * @param dragBaseline Active drag baseline represented by the overlay texture.
+ * @return Transform from displayed document placement to active document placement.
+ */
+[[nodiscard]] Transform2d ResolvePresentedOverlayDocumentTransform(
+    const std::optional<PresentedDragBaseline>& dragBaseline);
+
+/**
+ * Compute the output-space quad for a presented tile.
+ *
+ * @param tile Geometry for the tile being presented.
+ * @param outputFromCanvasTransform Transform from canvas/document coordinates to output space.
+ * @param dragBaseline Active drag baseline represented by the presented tiles.
+ * @return Output quad, or \c std::nullopt when tile or transform geometry is invalid.
+ */
+[[nodiscard]] std::optional<PresentedTileQuad> ComputePresentedTileQuad(
+    const PresentedFrameTileGeometry& tile, const Transform2d& outputFromCanvasTransform,
     const std::optional<PresentedDragBaseline>& dragBaseline);
 
 /**

--- a/donner/editor/RenderCoordinator.cc
+++ b/donner/editor/RenderCoordinator.cc
@@ -44,6 +44,7 @@ std::optional<SelectTool::ActiveDragPreview> DragPreviewFromRenderRequest(
   return SelectTool::ActiveDragPreview{
       .entity = preview->entity,
       .translation = preview->translation,
+      .dragGeneration = preview->dragGeneration,
   };
 }
 
@@ -70,6 +71,7 @@ bool CanReuseOverlayForActiveDrag(
     const GlTextureCache& textures) {
   return activeDragPreview.has_value() && presentedOverlayDragPreview.has_value() &&
          activeDragPreview->entity == presentedOverlayDragPreview->entity &&
+         activeDragPreview->dragGeneration == presentedOverlayDragPreview->dragGeneration &&
          textures.overlayWidth() > 0 && textures.overlayHeight() > 0;
 }
 

--- a/donner/editor/RenderCoordinator.cc
+++ b/donner/editor/RenderCoordinator.cc
@@ -66,18 +66,6 @@ std::optional<SelectTool::ActiveDragPreview> OverlayDragPreviewForSelection(
   };
 }
 
-bool CanReuseOverlayForActiveDrag(
-    const std::optional<SelectTool::ActiveDragPreview>& activeDragPreview,
-    const std::optional<SelectTool::ActiveDragPreview>& presentedOverlayDragPreview,
-    const GlTextureCache& textures) {
-  return activeDragPreview.has_value() && presentedOverlayDragPreview.has_value() &&
-         activeDragPreview->entity == presentedOverlayDragPreview->entity &&
-         activeDragPreview->dragGeneration == presentedOverlayDragPreview->dragGeneration &&
-         activeDragPreview->documentFromCachedDocument.isTranslation() &&
-         presentedOverlayDragPreview->documentFromCachedDocument.isTranslation() &&
-         textures.overlayWidth() > 0 && textures.overlayHeight() > 0;
-}
-
 bool SameTransform(const Transform2d& lhs, const Transform2d& rhs) {
   for (std::size_t i = 0; i < 6; ++i) {
     if (lhs.data[i] != rhs.data[i]) {
@@ -220,16 +208,16 @@ bool RenderCoordinator::rasterizeOverlayForCurrentSelection(
                                            std::span<const svg::SVGElement>(overlaySelection),
                                            marqueeRectDoc, canvasFromDoc, chromeBoundsPreview);
   overlayRenderer_.endFrame();
-  if (overlayRenderer_.requiresTextureSnapshotPresentation()) {
-    pendingOverlayTexture_ = overlayRenderer_.takeTextureSnapshot();
+  pendingOverlayTexture_ = overlayRenderer_.takeTextureSnapshot();
+  if (pendingOverlayTexture_ != nullptr) {
+    pendingOverlayBitmap_.reset();
+  } else if (overlayRenderer_.requiresTextureSnapshotPresentation()) {
     UTILS_RELEASE_ASSERT_MSG(
         pendingOverlayTexture_ != nullptr,
         "Geode overlay rasterization did not produce a GPU texture. Refusing CPU "
         "readback/upload fallback in Geode presentation mode.");
-    pendingOverlayBitmap_.reset();
   } else {
     pendingOverlayBitmap_ = overlayRenderer_.takeSnapshot();
-    pendingOverlayTexture_.reset();
   }
   pendingOverlayVersion_ = currentVersion;
   pendingOverlayDragPreview_ =
@@ -274,11 +262,11 @@ void RenderCoordinator::pollRenderResult(EditorApp& app, const ViewportState& vi
   }
 
   const auto& result = *resultOpt;
-  // Forward the worker-measured backend time to the frame history so
-  // `RenderFrameGraph` can overlay backend render time on the UI frame
-  // graph. The frame history's latest slot corresponds to the current
-  // UI frame (pushed at the top of `EditorShell::runFrame` before
-  // poll) — a landed result belongs to that frame.
+  // Forward the worker-measured presentation latency to the frame history so
+  // `RenderFrameGraph` can overlay async worker time on the UI frame graph.
+  // The frame history's latest slot corresponds to the current UI frame
+  // (pushed at the top of `EditorShell::runFrame` before poll) — a landed
+  // result belongs to that frame.
   if (frameHistory != nullptr) {
     frameHistory->setLatestBackendMs(static_cast<float>(result.workerMs));
   }
@@ -382,13 +370,10 @@ void RenderCoordinator::maybeRequestRender(EditorApp& app, SelectTool& selectToo
       !SameActiveBoundsPreview(activeBoundsPreview, lastOverlayActiveBoundsPreview_);
   const bool canvasDiffers = currentCanvasSize != lastOverlayCanvasSize_;
   const bool overlayVersionDiffers = currentVersion != lastOverlayVersion_;
-  const bool activeDragCanReuseOverlay =
-      !selectionDiffers && !marqueeDiffers && !canvasDiffers &&
-      CanReuseOverlayForActiveDrag(dragPreview, presentedOverlayDragPreview_, textures);
   if ((!compositedPresentation_.isWaitingForFullRender() || dragPreview.has_value() ||
        marqueeRectDoc.has_value() || activeBoundsPreviewDiffers) &&
       (selectionDiffers || marqueeDiffers || canvasDiffers || activeBoundsPreviewDiffers ||
-       (overlayVersionDiffers && !activeDragCanReuseOverlay))) {
+       overlayVersionDiffers)) {
     rasterizeOverlayForCurrentSelection(app, viewport, textures, marqueeRectDoc,
                                         dragPreview.has_value()
                                             ? OverlayUploadMode::Immediate

--- a/donner/editor/RenderCoordinator.cc
+++ b/donner/editor/RenderCoordinator.cc
@@ -44,6 +44,7 @@ std::optional<SelectTool::ActiveDragPreview> DragPreviewFromRenderRequest(
   return SelectTool::ActiveDragPreview{
       .entity = preview->entity,
       .translation = preview->translation,
+      .documentFromCachedDocument = preview->documentFromCachedDocument,
       .dragGeneration = preview->dragGeneration,
   };
 }
@@ -72,7 +73,31 @@ bool CanReuseOverlayForActiveDrag(
   return activeDragPreview.has_value() && presentedOverlayDragPreview.has_value() &&
          activeDragPreview->entity == presentedOverlayDragPreview->entity &&
          activeDragPreview->dragGeneration == presentedOverlayDragPreview->dragGeneration &&
+         activeDragPreview->documentFromCachedDocument.isTranslation() &&
+         presentedOverlayDragPreview->documentFromCachedDocument.isTranslation() &&
          textures.overlayWidth() > 0 && textures.overlayHeight() > 0;
+}
+
+bool SameTransform(const Transform2d& lhs, const Transform2d& rhs) {
+  for (std::size_t i = 0; i < 6; ++i) {
+    if (lhs.data[i] != rhs.data[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool SameActiveBoundsPreview(const std::optional<SelectTool::ActiveTransformBoundsPreview>& lhs,
+                             const std::optional<SelectTool::ActiveTransformBoundsPreview>& rhs) {
+  if (lhs.has_value() != rhs.has_value()) {
+    return false;
+  }
+  if (!lhs.has_value()) {
+    return true;
+  }
+
+  return lhs->startBoundsDoc == rhs->startBoundsDoc &&
+         SameTransform(lhs->documentFromStartDocument, rhs->documentFromStartDocument);
 }
 
 }  // namespace
@@ -141,6 +166,7 @@ void RenderCoordinator::resetForLoadedDocument() {
   lastOverlayCanvasSize_ = Vector2i::Zero();
   lastOverlayVersion_ = std::numeric_limits<std::uint64_t>::max();
   lastOverlayMarqueeRectDoc_.reset();
+  lastOverlayActiveBoundsPreview_.reset();
   renderScheduler_.reset();
 }
 
@@ -162,7 +188,8 @@ void RenderCoordinator::promoteSelectionBoundsIfReady() {
 bool RenderCoordinator::rasterizeOverlayForCurrentSelection(
     EditorApp& app, const ViewportState& viewport, GlTextureCache& textures,
     const std::optional<Box2d>& marqueeRectDoc, OverlayUploadMode uploadMode,
-    std::optional<SelectTool::ActiveDragPreview> representedDragPreview) {
+    std::optional<SelectTool::ActiveDragPreview> representedDragPreview,
+    std::optional<SelectTool::ActiveTransformBoundsPreview> activeBoundsPreview) {
   ZoneScopedN("RenderCoordinator::rasterizeOverlay");
   if (!app.hasDocument()) {
     return false;
@@ -179,12 +206,19 @@ bool RenderCoordinator::rasterizeOverlayForCurrentSelection(
   overlayRenderer_.beginFrame(overlayViewport);
   const Transform2d canvasFromDoc = app.document().document().canvasFromDocumentTransform();
   const auto& overlaySelection = app.selectedElements();
+  std::optional<SelectionChromeBoundsPreview> chromeBoundsPreview;
+  if (activeBoundsPreview.has_value()) {
+    chromeBoundsPreview = SelectionChromeBoundsPreview{
+        .startBoundsDoc = activeBoundsPreview->startBoundsDoc,
+        .documentFromStartDocument = activeBoundsPreview->documentFromStartDocument,
+    };
+  }
   // Overlay AABBs are computed from the same live DOM snapshot as the path
   // outlines. `selectionBoundsCache_` is maintained only for main-loop
   // selection-change detection and does not gate overlay geometry.
   OverlayRenderer::drawChromeWithTransform(overlayRenderer_,
                                            std::span<const svg::SVGElement>(overlaySelection),
-                                           marqueeRectDoc, canvasFromDoc);
+                                           marqueeRectDoc, canvasFromDoc, chromeBoundsPreview);
   overlayRenderer_.endFrame();
   if (overlayRenderer_.requiresTextureSnapshotPresentation()) {
     pendingOverlayTexture_ = overlayRenderer_.takeTextureSnapshot();
@@ -227,6 +261,7 @@ bool RenderCoordinator::rasterizeOverlayForCurrentSelection(
   lastOverlayCanvasSize_ = currentCanvasSize;
   lastOverlayVersion_ = currentVersion;
   lastOverlayMarqueeRectDoc_ = marqueeRectDoc;
+  lastOverlayActiveBoundsPreview_ = activeBoundsPreview;
   return true;
 }
 
@@ -337,25 +372,28 @@ void RenderCoordinator::maybeRequestRender(EditorApp& app, SelectTool& selectToo
   const auto& overlaySelection = app.selectedElements();
   const bool selectionDiffers = overlaySelection != lastOverlaySelectionVec_;
   const std::optional<Box2d> marqueeRectDoc = selectTool.marqueeRect();
+  const auto activeBoundsPreview = selectTool.activeTransformBoundsPreview();
   // The marquee rect updates every mouse-move during a marquee drag and
   // doesn't bump the document version (no DOM mutation), so it needs
   // its own invalidation check. Comparing via `!=` on the optional<Box2d>
   // covers "marquee appeared", "marquee moved", and "marquee ended".
   const bool marqueeDiffers = marqueeRectDoc != lastOverlayMarqueeRectDoc_;
+  const bool activeBoundsPreviewDiffers =
+      !SameActiveBoundsPreview(activeBoundsPreview, lastOverlayActiveBoundsPreview_);
   const bool canvasDiffers = currentCanvasSize != lastOverlayCanvasSize_;
   const bool overlayVersionDiffers = currentVersion != lastOverlayVersion_;
   const bool activeDragCanReuseOverlay =
       !selectionDiffers && !marqueeDiffers && !canvasDiffers &&
       CanReuseOverlayForActiveDrag(dragPreview, presentedOverlayDragPreview_, textures);
   if ((!compositedPresentation_.isWaitingForFullRender() || dragPreview.has_value() ||
-       marqueeRectDoc.has_value()) &&
-      (selectionDiffers || marqueeDiffers || canvasDiffers ||
+       marqueeRectDoc.has_value() || activeBoundsPreviewDiffers) &&
+      (selectionDiffers || marqueeDiffers || canvasDiffers || activeBoundsPreviewDiffers ||
        (overlayVersionDiffers && !activeDragCanReuseOverlay))) {
     rasterizeOverlayForCurrentSelection(app, viewport, textures, marqueeRectDoc,
                                         dragPreview.has_value()
                                             ? OverlayUploadMode::Immediate
                                             : OverlayUploadMode::MatchDisplayedVersion,
-                                        dragPreview);
+                                        dragPreview, activeBoundsPreview);
   }
 
   const PresentationRenderScheduleDecision schedule =

--- a/donner/editor/RenderCoordinator.h
+++ b/donner/editor/RenderCoordinator.h
@@ -99,7 +99,8 @@ public:
       EditorApp& app, const ViewportState& viewport, GlTextureCache& textures,
       const std::optional<Box2d>& marqueeRectDoc,
       OverlayUploadMode uploadMode = OverlayUploadMode::MatchDisplayedVersion,
-      std::optional<SelectTool::ActiveDragPreview> representedDragPreview = std::nullopt);
+      std::optional<SelectTool::ActiveDragPreview> representedDragPreview = std::nullopt,
+      std::optional<SelectTool::ActiveTransformBoundsPreview> activeBoundsPreview = std::nullopt);
   /// Drain the latest async-render result into the editor's UI state.
   /// If a `frameHistory` is supplied, its latest slot is stamped with
   /// the backend (worker) ms reported by `AsyncRenderer` so the frame
@@ -142,6 +143,9 @@ private:
   /// the last overlay rasterize didn't include one. Used to invalidate
   /// the cached overlay when the marquee geometry changes.
   std::optional<Box2d> lastOverlayMarqueeRectDoc_;
+  /// Active rotation bounds baked into the overlay texture, or nullopt
+  /// when the last overlay used normal axis-aligned selection bounds.
+  std::optional<SelectTool::ActiveTransformBoundsPreview> lastOverlayActiveBoundsPreview_;
 
   PresentationRenderScheduler renderScheduler_;
   /// Most recent desired canvas size requested by `maybeRequestRender`.

--- a/donner/editor/RenderPanePresenter.cc
+++ b/donner/editor/RenderPanePresenter.cc
@@ -160,7 +160,8 @@ std::optional<PresentedDragBaseline> PresentedBaselineFromSelectPreviews(
     const std::optional<SelectTool::ActiveDragPreview>& activePreview,
     const std::optional<SelectTool::ActiveDragPreview>& displayedPreview) {
   if (!activePreview.has_value() || !displayedPreview.has_value() ||
-      activePreview->entity != displayedPreview->entity) {
+      activePreview->entity != displayedPreview->entity ||
+      activePreview->dragGeneration != displayedPreview->dragGeneration) {
     return std::nullopt;
   }
 

--- a/donner/editor/RenderPanePresenter.cc
+++ b/donner/editor/RenderPanePresenter.cc
@@ -32,11 +32,11 @@ void RenderFrameGraph(const FrameHistory& history) {
   static float displayedBackendMs = 0.0f;
 
   msEma = msEma == 0.0f ? latestMs : 0.9f * msEma + 0.1f * latestMs;
-  // Feed the backend EMA only from non-zero samples — between drag
-  // bursts we go idle and stop emitting backend work; smoothing zero
-  // into the EMA would collapse the readout to near-zero even though
-  // the last actual render was 5-10 ms. Keep the EMA "sticky" at the
-  // most recent real measurement instead.
+  // Feed the worker EMA only from non-zero samples — between drag bursts we go
+  // idle and stop emitting worker results; smoothing zero into the EMA would
+  // collapse the readout to near-zero even though the last actual render was
+  // 5-10 ms. Keep the EMA "sticky" at the most recent real measurement
+  // instead.
   if (history.lastBackendMs > 0.0f) {
     backendMsEma = backendMsEma == 0.0f ? history.lastBackendMs
                                         : 0.9f * backendMsEma + 0.1f * history.lastBackendMs;
@@ -73,12 +73,11 @@ void RenderFrameGraph(const FrameHistory& history) {
                       ImVec2(x + barWidth, origin.y + kFrameGraphHeight), color);
   }
 
-  // Backend (async-renderer worker) time overlay. Only non-zero samples
-  // are plotted — zero means "no render result landed this frame" and
-  // we don't want a visible drop-to-zero between drag bursts. A thin
-  // cyan line segment connects consecutive non-zero samples; isolated
-  // points render as a single-pixel dot so a one-off render still
-  // shows up.
+  // Async worker/presentation time overlay. Only non-zero samples are plotted —
+  // zero means "no render result landed this frame" and we don't want a visible
+  // drop-to-zero between drag bursts. A thin cyan line segment connects
+  // consecutive non-zero samples; isolated points render as a single-pixel dot
+  // so a one-off render still shows up.
   constexpr ImU32 kBackendColor = IM_COL32(0, 220, 240, 220);
   const auto backendY = [&](float ms) {
     const float clamped = std::min(ms, scaleMs);
@@ -118,7 +117,7 @@ void RenderFrameGraph(const FrameHistory& history) {
   if (displayedBackendMs > 0.0f) {
     ImGui::SameLine();
     ImGui::PushStyleColor(ImGuiCol_Text, kBackendColor);
-    ImGui::Text("  backend %.2f ms", displayedBackendMs);
+    ImGui::Text("  worker %.2f ms", displayedBackendMs);
     ImGui::PopStyleColor();
   }
 }

--- a/donner/editor/RenderPanePresenter.cc
+++ b/donner/editor/RenderPanePresenter.cc
@@ -152,6 +152,7 @@ PresentedFrameTileGeometry PresentedGeometryFromTile(const GlTextureCache::TileV
       .canvasOffsetDoc = tile.canvasOffsetDoc,
       .bitmapDimsDoc = tile.bitmapDimsDoc,
       .dragTranslationDoc = tile.dragTranslationDoc,
+      .documentFromCachedDocument = tile.documentFromCachedDocument,
       .isDragTarget = tile.isDragTarget,
   };
 }
@@ -169,7 +170,24 @@ std::optional<PresentedDragBaseline> PresentedBaselineFromSelectPreviews(
       .entity = activePreview->entity,
       .representedTranslationDoc = displayedPreview->translation,
       .activeTranslationDoc = activePreview->translation,
+      .representedDocumentFromCachedDocument = displayedPreview->documentFromCachedDocument,
+      .activeDocumentFromCachedDocument = activePreview->documentFromCachedDocument,
   };
+}
+
+std::optional<PresentedDragBaseline> TranslationOverlayBaselineFromSelectPreviews(
+    const std::optional<SelectTool::ActiveDragPreview>& activePreview,
+    const std::optional<SelectTool::ActiveDragPreview>& displayedPreview) {
+  if (!activePreview.has_value() || !displayedPreview.has_value() ||
+      !activePreview->documentFromCachedDocument.isTranslation() ||
+      !displayedPreview->documentFromCachedDocument.isTranslation()) {
+    return std::nullopt;
+  }
+  return PresentedBaselineFromSelectPreviews(activePreview, displayedPreview);
+}
+
+ImVec2 ToImVec2(const Vector2d& value) {
+  return ImVec2(static_cast<float>(value.x), static_cast<float>(value.y));
 }
 
 }  // namespace
@@ -201,16 +219,14 @@ void RenderPanePresenter::render(const RenderPanePresenterState& state) const {
       continue;
     }
     hasDragTargetTile = hasDragTargetTile || tile.isDragTarget;
-    const std::optional<PresentedTileRect> tileRect = ComputePresentedTileRect(
+    const std::optional<PresentedTileQuad> tileQuad = ComputePresentedTileQuad(
         PresentedGeometryFromTile(tile), screenFromCanvasTransform, dragBaseline);
-    if (!tileRect.has_value()) {
+    if (!tileQuad.has_value()) {
       continue;
     }
-    const ImVec2 tileOrigin(static_cast<float>(tileRect->topLeft.x),
-                            static_cast<float>(tileRect->topLeft.y));
-    const ImVec2 tileBottomRight(static_cast<float>(tileRect->bottomRight.x),
-                                 static_cast<float>(tileRect->bottomRight.y));
-    paneDrawList->AddImage(tile.texture, tileOrigin, tileBottomRight);
+    paneDrawList->AddImageQuad(tile.texture, ToImVec2(tileQuad->topLeft),
+                               ToImVec2(tileQuad->topRight), ToImVec2(tileQuad->bottomRight),
+                               ToImVec2(tileQuad->bottomLeft));
   }
 
   // All editor chrome — path outlines, selection AABBs, and the
@@ -221,19 +237,27 @@ void RenderPanePresenter::render(const RenderPanePresenterState& state) const {
   // backend (Geode) can optimize end-to-end.
   if (state.textures.overlayWidth() > 0 && state.textures.overlayHeight() > 0) {
     const std::optional<PresentedDragBaseline> overlayBaseline =
-        hasDragTargetTile
-            ? PresentedBaselineFromSelectPreviews(state.activeDragPreview, state.overlayDragPreview)
-            : std::nullopt;
-    const Vector2d overlayTranslationDoc = ResolvePresentedOverlayDragTranslation(overlayBaseline);
-    const ImVec2 overlayTranslationScreen(static_cast<float>(overlayTranslationDoc.x * pxPerDoc),
-                                          static_cast<float>(overlayTranslationDoc.y * pxPerDoc));
+        hasDragTargetTile ? TranslationOverlayBaselineFromSelectPreviews(state.activeDragPreview,
+                                                                         state.overlayDragPreview)
+                          : std::nullopt;
+    const Transform2d documentFromOverlayDocument =
+        ResolvePresentedOverlayDocumentTransform(overlayBaseline);
+    const Vector2d docTopLeft = state.viewport.documentViewBox.topLeft;
+    const Vector2d docTopRight(state.viewport.documentViewBox.bottomRight.x,
+                               state.viewport.documentViewBox.topLeft.y);
+    const Vector2d docBottomRight = state.viewport.documentViewBox.bottomRight;
+    const Vector2d docBottomLeft(state.viewport.documentViewBox.topLeft.x,
+                                 state.viewport.documentViewBox.bottomRight.y);
+    const auto overlayPoint = [&](const Vector2d& documentPoint) {
+      return state.viewport.documentToScreen(
+          documentFromOverlayDocument.transformPosition(documentPoint));
+    };
     paneDrawList->PushClipRect(imageOrigin, imageBottomRight,
                                /*intersect_with_current_clip_rect=*/true);
-    paneDrawList->AddImage(state.textures.overlayTexture(),
-                           ImVec2(imageOrigin.x + overlayTranslationScreen.x,
-                                  imageOrigin.y + overlayTranslationScreen.y),
-                           ImVec2(imageBottomRight.x + overlayTranslationScreen.x,
-                                  imageBottomRight.y + overlayTranslationScreen.y));
+    paneDrawList->AddImageQuad(state.textures.overlayTexture(), ToImVec2(overlayPoint(docTopLeft)),
+                               ToImVec2(overlayPoint(docTopRight)),
+                               ToImVec2(overlayPoint(docBottomRight)),
+                               ToImVec2(overlayPoint(docBottomLeft)));
     paneDrawList->PopClipRect();
   }
 

--- a/donner/editor/RotateCursorSet.cc
+++ b/donner/editor/RotateCursorSet.cc
@@ -1,0 +1,245 @@
+#include "donner/editor/RotateCursorSet.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdio>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "GLFW/glfw3.h"
+#include "donner/base/ParseWarningSink.h"
+#include "donner/editor/RotateCursorSvg.h"
+#include "donner/svg/parser/SVGParser.h"
+#include "donner/svg/renderer/Renderer.h"
+
+namespace donner::editor {
+
+namespace {
+
+constexpr int kCursorSizePx = 32;
+constexpr int kCursorRasterScale = 4;
+constexpr int kCursorRasterSizePx = kCursorSizePx * kCursorRasterScale;
+constexpr int kCursorHotspotPx = 16;
+constexpr std::string_view kRotationPlaceholder = "rotate(0,16,16)";
+
+bool ReplaceFirst(std::string* text, std::string_view needle, std::string_view replacement) {
+  const std::size_t offset = text->find(needle);
+  if (offset == std::string::npos) {
+    return false;
+  }
+
+  text->replace(offset, needle.size(), replacement);
+  return true;
+}
+
+std::size_t CornerIndex(SelectionTransformCorner corner) {
+  switch (corner) {
+    case SelectionTransformCorner::TopLeft: return 0;
+    case SelectionTransformCorner::TopRight: return 1;
+    case SelectionTransformCorner::BottomRight: return 2;
+    case SelectionTransformCorner::BottomLeft: return 3;
+  }
+  return 0;
+}
+
+double RotationDegreesForCorner(SelectionTransformCorner corner) {
+  switch (corner) {
+    case SelectionTransformCorner::TopLeft: return 0.0;
+    case SelectionTransformCorner::TopRight: return 90.0;
+    case SelectionTransformCorner::BottomRight: return 180.0;
+    case SelectionTransformCorner::BottomLeft: return 270.0;
+  }
+  return 0.0;
+}
+
+std::string BuildRotateCursorSvg(SelectionTransformCorner corner) {
+  std::string svg(reinterpret_cast<const char*>(embedded::kRotateCursorSvg.data()),
+                  embedded::kRotateCursorSvg.size());
+  std::ostringstream replacement;
+  replacement << "rotate(" << RotationDegreesForCorner(corner) << ",16,16)";
+  ReplaceFirst(&svg, kRotationPlaceholder, replacement.str());
+
+  std::ostringstream rasterSize;
+  rasterSize << kCursorRasterSizePx;
+  const std::string rasterSizeText = rasterSize.str();
+  ReplaceFirst(&svg, R"svg(width="32")svg", std::string("width=\"") + rasterSizeText + "\"");
+  ReplaceFirst(&svg, R"svg(height="32")svg", std::string("height=\"") + rasterSizeText + "\"");
+  return svg;
+}
+
+std::optional<std::vector<unsigned char>> DownsampleToStraightAlphaTightRgba(
+    const svg::RendererBitmap& bitmap, int rasterScale) {
+  if (bitmap.empty() || rasterScale <= 0 || bitmap.dimensions.x != kCursorSizePx * rasterScale ||
+      bitmap.dimensions.y != kCursorSizePx * rasterScale ||
+      bitmap.rowBytes < static_cast<std::size_t>(bitmap.dimensions.x) * 4u) {
+    return std::nullopt;
+  }
+
+  std::vector<unsigned char> result(kCursorSizePx * kCursorSizePx * 4u);
+  const int sourcePixelsPerOutputPixel = rasterScale * rasterScale;
+  for (int y = 0; y < kCursorSizePx; ++y) {
+    for (int x = 0; x < kCursorSizePx; ++x) {
+      int premulR = 0;
+      int premulG = 0;
+      int premulB = 0;
+      int alphaSum = 0;
+      for (int dy = 0; dy < rasterScale; ++dy) {
+        const int srcY = y * rasterScale + dy;
+        const auto* srcRow =
+            bitmap.pixels.data() + static_cast<std::size_t>(srcY) * bitmap.rowBytes;
+        for (int dx = 0; dx < rasterScale; ++dx) {
+          const int srcX = x * rasterScale + dx;
+          const auto* src = srcRow + srcX * 4;
+          const int alpha = src[3];
+          alphaSum += alpha;
+          if (bitmap.alphaType == svg::AlphaType::Premultiplied) {
+            premulR += src[0];
+            premulG += src[1];
+            premulB += src[2];
+          } else {
+            premulR += (static_cast<int>(src[0]) * alpha + 127) / 255;
+            premulG += (static_cast<int>(src[1]) * alpha + 127) / 255;
+            premulB += (static_cast<int>(src[2]) * alpha + 127) / 255;
+          }
+        }
+      }
+
+      const int alpha = (alphaSum + sourcePixelsPerOutputPixel / 2) / sourcePixelsPerOutputPixel;
+      const std::size_t dstOffset = (static_cast<std::size_t>(y) * kCursorSizePx + x) * 4u;
+      if (alpha > 0) {
+        const int avgPremulR =
+            (premulR + sourcePixelsPerOutputPixel / 2) / sourcePixelsPerOutputPixel;
+        const int avgPremulG =
+            (premulG + sourcePixelsPerOutputPixel / 2) / sourcePixelsPerOutputPixel;
+        const int avgPremulB =
+            (premulB + sourcePixelsPerOutputPixel / 2) / sourcePixelsPerOutputPixel;
+        result[dstOffset + 0] =
+            static_cast<unsigned char>(std::clamp((avgPremulR * 255 + alpha / 2) / alpha, 0, 255));
+        result[dstOffset + 1] =
+            static_cast<unsigned char>(std::clamp((avgPremulG * 255 + alpha / 2) / alpha, 0, 255));
+        result[dstOffset + 2] =
+            static_cast<unsigned char>(std::clamp((avgPremulB * 255 + alpha / 2) / alpha, 0, 255));
+      }
+      result[dstOffset + 3] = static_cast<unsigned char>(std::clamp(alpha, 0, 255));
+    }
+  }
+
+  return result;
+}
+
+std::optional<RotateCursorImage> RenderImageFromSvg(
+    std::string_view svgSource, std::shared_ptr<geode::GeodeDevice> geodeDevice) {
+  ParseWarningSink warnings = ParseWarningSink::Disabled();
+  auto parseResult = svg::parser::SVGParser::ParseSVG(svgSource, warnings);
+  if (parseResult.hasError()) {
+    return std::nullopt;
+  }
+
+  svg::SVGDocument document = std::move(parseResult.result());
+  svg::Renderer renderer(std::move(geodeDevice));
+  renderer.draw(document);
+  svg::RendererBitmap bitmap = renderer.takeSnapshot();
+  std::optional<std::vector<unsigned char>> rgba =
+      DownsampleToStraightAlphaTightRgba(bitmap, kCursorRasterScale);
+  if (!rgba.has_value()) {
+    return std::nullopt;
+  }
+
+  return RotateCursorImage{
+      .width = kCursorSizePx,
+      .height = kCursorSizePx,
+      .rgba = std::move(*rgba),
+  };
+}
+
+}  // namespace
+
+std::optional<RotateCursorImage> RenderRotateCursorImage(
+    SelectionTransformCorner corner, std::shared_ptr<geode::GeodeDevice> geodeDevice) {
+  return RenderImageFromSvg(BuildRotateCursorSvg(corner), std::move(geodeDevice));
+}
+
+RotateCursorSet::~RotateCursorSet() {
+  destroy();
+}
+
+bool RotateCursorSet::initialize(GLFWwindow* window,
+                                 std::shared_ptr<geode::GeodeDevice> geodeDevice) {
+  destroy();
+  window_ = window;
+  if (window_ == nullptr) {
+    return false;
+  }
+
+  const std::array<SelectionTransformCorner, 4> corners = {
+      SelectionTransformCorner::TopLeft,
+      SelectionTransformCorner::TopRight,
+      SelectionTransformCorner::BottomRight,
+      SelectionTransformCorner::BottomLeft,
+  };
+
+  for (SelectionTransformCorner corner : corners) {
+    std::optional<RotateCursorImage> image = RenderRotateCursorImage(corner, geodeDevice);
+    if (!image.has_value()) {
+      destroy();
+      return false;
+    }
+
+    GLFWimage glfwImage{
+        .width = image->width,
+        .height = image->height,
+        .pixels = image->rgba.data(),
+    };
+    GLFWcursor* cursor = glfwCreateCursor(&glfwImage, kCursorHotspotPx, kCursorHotspotPx);
+    if (cursor == nullptr) {
+      destroy();
+      return false;
+    }
+    rotateCursors_[CornerIndex(corner)] = cursor;
+  }
+
+  valid_ = true;
+  return true;
+}
+
+bool RotateCursorSet::setRotateCursor(SelectionTransformCorner corner) {
+  if (!valid_ || window_ == nullptr) {
+    return false;
+  }
+
+  GLFWcursor* cursor = rotateCursors_[CornerIndex(corner)];
+  if (cursor == nullptr) {
+    return false;
+  }
+
+  glfwSetCursor(window_, cursor);
+  customCursorActive_ = true;
+  return true;
+}
+
+void RotateCursorSet::clearIfActive() {
+  if (!customCursorActive_ || window_ == nullptr) {
+    return;
+  }
+
+  glfwSetCursor(window_, nullptr);
+  customCursorActive_ = false;
+}
+
+void RotateCursorSet::destroy() {
+  clearIfActive();
+  for (GLFWcursor*& cursor : rotateCursors_) {
+    if (cursor != nullptr) {
+      glfwDestroyCursor(cursor);
+      cursor = nullptr;
+    }
+  }
+  window_ = nullptr;
+  valid_ = false;
+}
+
+}  // namespace donner::editor

--- a/donner/editor/RotateCursorSet.h
+++ b/donner/editor/RotateCursorSet.h
@@ -1,0 +1,76 @@
+#pragma once
+/// @file
+
+#include <array>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "donner/editor/SelectionTransformHandles.h"
+
+struct GLFWcursor;
+struct GLFWwindow;
+
+namespace donner::geode {
+class GeodeDevice;
+}
+
+namespace donner::editor {
+
+/// RGBA pixels for one custom editor cursor image.
+struct RotateCursorImage {
+  /// Cursor width in pixels.
+  int width = 0;
+
+  /// Cursor height in pixels.
+  int height = 0;
+
+  /// Straight-alpha RGBA pixels, tightly packed.
+  std::vector<unsigned char> rgba;
+};
+
+/// Render one oriented rotate-cursor SVG to straight-alpha RGBA pixels.
+[[nodiscard]] std::optional<RotateCursorImage> RenderRotateCursorImage(
+    SelectionTransformCorner corner, std::shared_ptr<geode::GeodeDevice> geodeDevice);
+
+/// RAII owner for the editor's custom rotate cursors.
+class RotateCursorSet {
+public:
+  RotateCursorSet() = default;
+  ~RotateCursorSet();
+
+  RotateCursorSet(const RotateCursorSet&) = delete;
+  RotateCursorSet& operator=(const RotateCursorSet&) = delete;
+  RotateCursorSet(RotateCursorSet&&) = delete;
+  RotateCursorSet& operator=(RotateCursorSet&&) = delete;
+
+  /// Create all rotate cursors for @p window.
+  ///
+  /// @param window GLFW window that will receive cursor changes.
+  /// @param geodeDevice Shared Geode device for Geode editor builds.
+  /// @return true if every cursor was created.
+  [[nodiscard]] bool initialize(GLFWwindow* window,
+                                std::shared_ptr<geode::GeodeDevice> geodeDevice);
+
+  /// Set the custom rotate cursor matching @p corner.
+  ///
+  /// @param corner Selection corner under the pointer.
+  /// @return true if a custom cursor was available and applied.
+  [[nodiscard]] bool setRotateCursor(SelectionTransformCorner corner);
+
+  /// Restore GLFW's default cursor if a custom rotate cursor is active.
+  void clearIfActive();
+
+  /// Whether all rotate cursors were created successfully.
+  [[nodiscard]] bool valid() const { return valid_; }
+
+private:
+  void destroy();
+
+  GLFWwindow* window_ = nullptr;
+  std::array<GLFWcursor*, 4> rotateCursors_ = {};
+  bool customCursorActive_ = false;
+  bool valid_ = false;
+};
+
+}  // namespace donner::editor

--- a/donner/editor/SelectTool.cc
+++ b/donner/editor/SelectTool.cc
@@ -1,6 +1,7 @@
 #include "donner/editor/SelectTool.h"
 
 #include <algorithm>
+#include <cmath>
 #include <vector>
 
 #include "donner/base/RcString.h"
@@ -9,6 +10,7 @@
 #include "donner/editor/EditorApp.h"
 #include "donner/editor/EditorCommand.h"
 #include "donner/editor/SelectionAabb.h"
+#include "donner/editor/SelectionTransformHandles.h"
 #include "donner/editor/UndoTimeline.h"
 #include "donner/svg/SVGDocument.h"
 #include "donner/svg/SVGGeometryElement.h"
@@ -18,6 +20,82 @@
 namespace donner::editor {
 
 namespace {
+
+constexpr double kDragThresholdDocUnits = 1.0;
+constexpr double kDragThresholdSq = kDragThresholdDocUnits * kDragThresholdDocUnits;
+constexpr double kMinScaleDenominator = 1e-9;
+
+bool IsFinite(double value) {
+  return std::isfinite(value);
+}
+
+bool IsFinite(const Transform2d& candidateDocumentFromDocument) {
+  for (double value : candidateDocumentFromDocument.data) {
+    if (!IsFinite(value)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+Vector2d CenterOf(const Box2d& box) {
+  return (box.topLeft + box.bottomRight) * 0.5;
+}
+
+Transform2d TransformDocumentAroundPoint(const Vector2d& fixedDocumentPoint,
+                                         const Transform2d& centeredDocumentFromDocument) {
+  return Transform2d::Translate(-fixedDocumentPoint) * centeredDocumentFromDocument *
+         Transform2d::Translate(fixedDocumentPoint);
+}
+
+double AngleFromCenter(const Vector2d& center, const Vector2d& point) {
+  const Vector2d delta = point - center;
+  return std::atan2(delta.y, delta.x);
+}
+
+std::optional<Transform2d> ResizeTransform(const Box2d& startBounds,
+                                           SelectionTransformCorner corner,
+                                           const Vector2d& documentPoint, bool preserveAspectRatio,
+                                           bool resizeFromCenter) {
+  const Vector2d center = CenterOf(startBounds);
+  const Vector2d startCorner = SelectionTransformCornerPoint(startBounds, corner);
+  const Vector2d anchor =
+      resizeFromCenter
+          ? center
+          : SelectionTransformCornerPoint(startBounds, OppositeSelectionTransformCorner(corner));
+  const Vector2d startVector = startCorner - anchor;
+  const Vector2d currentVector = documentPoint - anchor;
+  if (std::abs(startVector.x) < kMinScaleDenominator ||
+      std::abs(startVector.y) < kMinScaleDenominator) {
+    return std::nullopt;
+  }
+
+  double scaleX = currentVector.x / startVector.x;
+  double scaleY = currentVector.y / startVector.y;
+  if (preserveAspectRatio) {
+    const double uniformScale = std::abs(scaleX) >= std::abs(scaleY) ? scaleX : scaleY;
+    scaleX = uniformScale;
+    scaleY = uniformScale;
+  }
+
+  const Transform2d resizedDocumentFromStartDocument =
+      TransformDocumentAroundPoint(anchor, Transform2d::Scale(scaleX, scaleY));
+  if (!IsFinite(resizedDocumentFromStartDocument)) {
+    return std::nullopt;
+  }
+  return resizedDocumentFromStartDocument;
+}
+
+std::optional<Transform2d> RotateTransform(const Vector2d& center, double startAngleRadians,
+                                           const Vector2d& documentPoint) {
+  const double angleDelta = AngleFromCenter(center, documentPoint) - startAngleRadians;
+  const Transform2d rotatedDocumentFromStartDocument =
+      TransformDocumentAroundPoint(center, Transform2d::Rotate(angleDelta));
+  if (!IsFinite(rotatedDocumentFromStartDocument)) {
+    return std::nullopt;
+  }
+  return rotatedDocumentFromStartDocument;
+}
 
 /// Elements that don't contribute geometry to the rendered tree.
 /// `<defs>` / `<title>` / `<desc>` / `<metadata>` / `<style>` / `<script>`
@@ -181,6 +259,54 @@ void SelectTool::onMouseDown(EditorApp& editor, const Vector2d& documentPoint,
   dragState_.reset();
   marqueeState_.reset();
 
+  const auto selectedBoundsDoc =
+      SnapshotSelectionWorldBounds(std::span<const svg::SVGElement>(editor.selectedElements()));
+  if (!selectedBoundsDoc.empty() && !editor.selectedElements().empty()) {
+    const SelectionTransformHandleIntent handleIntent = HitTestSelectionTransformHandles(
+        selectedBoundsDoc, documentPoint, modifiers.pixelsPerDocUnit);
+    if (handleIntent.kind != SelectionTransformHandleKind::None) {
+      const auto& selection = editor.selectedElements();
+      const bool allGraphics = std::all_of(
+          selection.begin(), selection.end(),
+          [](const svg::SVGElement& element) { return element.isa<svg::SVGGraphicsElement>(); });
+      if (allGraphics) {
+        const auto makeDragParticipant = [](const svg::SVGElement& element) {
+          const Transform2d startTransform = element.cast<svg::SVGGraphicsElement>().transform();
+          return PerElementDrag{
+              .element = element,
+              .startTransform = startTransform,
+              .currentTransform = startTransform,
+              .writebackTarget = captureAttributeWritebackTarget(element),
+              .sourceTransformAttributeValue = element.getAttribute("transform"),
+          };
+        };
+
+        std::vector<PerElementDrag> extras;
+        extras.reserve(selection.size() - 1);
+        for (std::size_t i = 1; i < selection.size(); ++i) {
+          extras.push_back(makeDragParticipant(selection[i]));
+        }
+
+        const Box2d startBounds = CombinedSelectionBounds(selectedBoundsDoc);
+        const Vector2d center = CenterOf(startBounds);
+        dragState_ = DragState{
+            .primary = makeDragParticipant(selection.front()),
+            .extras = std::move(extras),
+            .gestureKind = handleIntent.kind == SelectionTransformHandleKind::Resize
+                               ? DragState::GestureKind::Resize
+                               : DragState::GestureKind::Rotate,
+            .corner = handleIntent.corner,
+            .startDocumentPoint = documentPoint,
+            .startBoundsDoc = startBounds,
+            .centerDocumentPoint = center,
+            .startAngleRadians = AngleFromCenter(center, documentPoint),
+            .generation = nextDragGeneration_++,
+        };
+        return;
+      }
+    }
+  }
+
   auto hit = editor.hitTest(documentPoint);
 
   // Snapshot-safe fallback for clicks inside the selected element's
@@ -313,6 +439,11 @@ void SelectTool::onMouseDown(EditorApp& editor, const Vector2d& documentPoint,
 }
 
 void SelectTool::onMouseMove(EditorApp& editor, const Vector2d& documentPoint, bool buttonHeld) {
+  onMouseMove(editor, documentPoint, buttonHeld, MouseModifiers{});
+}
+
+void SelectTool::onMouseMove(EditorApp& editor, const Vector2d& documentPoint, bool buttonHeld,
+                             MouseModifiers modifiers) {
   if (!buttonHeld) {
     return;
   }
@@ -336,23 +467,35 @@ void SelectTool::onMouseMove(EditorApp& editor, const Vector2d& documentPoint, b
   // checked against the squared delta magnitude in document units; once
   // the drag has actually moved past it the element tracks the cursor
   // exactly from that point on.
-  constexpr double kDragThresholdDocUnits = 1.0;
-  constexpr double kDragThresholdSq = kDragThresholdDocUnits * kDragThresholdDocUnits;
   if (!dragState_->hasMoved && deltaDoc.lengthSquared() < kDragThresholdSq) {
     return;
   }
 
-  // donner's Transform2 uses "row-major post-multiply" semantics: in
-  // `R * T * A`, A is applied first and R last. To translate the element
-  // in *parent* space (document space, since we assume top-level
-  // elements), the new local transform is the old local transform
-  // followed by a parent-space translation:
-  //
-  //   new_local = Translate(delta) * old_local
-  const Transform2d primaryNewTransform =
-      Transform2d::Translate(deltaDoc) * dragState_->primary.startTransform;
+  std::optional<Transform2d> documentFromStartDocument;
+  switch (dragState_->gestureKind) {
+    case DragState::GestureKind::Move:
+      // Donner's Transform2 uses row-vector post-multiply semantics, so
+      // `start * Translate(delta)` applies the element's existing transform
+      // first and then moves the resulting document-space geometry by delta.
+      documentFromStartDocument = Transform2d::Translate(deltaDoc);
+      break;
+    case DragState::GestureKind::Resize:
+      documentFromStartDocument = ResizeTransform(dragState_->startBoundsDoc, dragState_->corner,
+                                                  documentPoint, modifiers.shift, modifiers.option);
+      break;
+    case DragState::GestureKind::Rotate:
+      documentFromStartDocument = RotateTransform(dragState_->centerDocumentPoint,
+                                                  dragState_->startAngleRadians, documentPoint);
+      break;
+  }
+  if (!documentFromStartDocument.has_value()) {
+    return;
+  }
 
   dragState_->currentDocumentDelta = deltaDoc;
+  dragState_->currentDocumentFromStartDocument = *documentFromStartDocument;
+  const Transform2d primaryNewTransform =
+      dragState_->primary.startTransform * *documentFromStartDocument;
   dragState_->primary.currentTransform = primaryNewTransform;
   dragState_->hasMoved = true;
 
@@ -369,7 +512,7 @@ void SelectTool::onMouseMove(EditorApp& editor, const Vector2d& documentPoint, b
   editor.applyMutation(
       EditorCommand::SetTransformCommand(dragState_->primary.element, primaryNewTransform));
   for (auto& extra : dragState_->extras) {
-    extra.currentTransform = Transform2d::Translate(deltaDoc) * extra.startTransform;
+    extra.currentTransform = extra.startTransform * *documentFromStartDocument;
     editor.applyMutation(EditorCommand::SetTransformCommand(extra.element, extra.currentTransform));
   }
 }
@@ -418,6 +561,19 @@ void SelectTool::onMouseUp(EditorApp& editor, const Vector2d& /*documentPoint*/)
   // at the final position; we only need to record the undo snapshot
   // and latch the writeback target here.
   if (dragState_->hasMoved) {
+    const bool multiElement = !dragState_->extras.empty();
+    const char* undoLabel = multiElement ? "Move elements" : "Move element";
+    switch (dragState_->gestureKind) {
+      case DragState::GestureKind::Move:
+        undoLabel = multiElement ? "Move elements" : "Move element";
+        break;
+      case DragState::GestureKind::Resize:
+        undoLabel = multiElement ? "Resize elements" : "Resize element";
+        break;
+      case DragState::GestureKind::Rotate:
+        undoLabel = multiElement ? "Rotate elements" : "Rotate element";
+        break;
+    }
     UndoSnapshot before{
         .element = dragState_->primary.element,
         .transform = dragState_->primary.startTransform,
@@ -427,8 +583,7 @@ void SelectTool::onMouseUp(EditorApp& editor, const Vector2d& /*documentPoint*/)
     UndoSnapshot after{.element = dragState_->primary.element,
                        .transform = dragState_->primary.currentTransform,
                        .writebackTarget = dragState_->primary.writebackTarget};
-    editor.undoTimeline().record(dragState_->extras.empty() ? "Move element" : "Move elements",
-                                 std::move(before), std::move(after));
+    editor.undoTimeline().record(undoLabel, std::move(before), std::move(after));
 
     // Record undo for each extra element so a single Ctrl+Z reverts the
     // whole multi-element drag — one timeline entry per element keeps the
@@ -443,7 +598,7 @@ void SelectTool::onMouseUp(EditorApp& editor, const Vector2d& /*documentPoint*/)
       UndoSnapshot extraAfter{.element = extra.element,
                               .transform = extra.currentTransform,
                               .writebackTarget = extra.writebackTarget};
-      editor.undoTimeline().record("Move elements", std::move(extraBefore), std::move(extraAfter));
+      editor.undoTimeline().record(undoLabel, std::move(extraBefore), std::move(extraAfter));
     }
 
     if (dragState_->primary.writebackTarget.has_value()) {
@@ -479,9 +634,24 @@ std::optional<SelectTool::ActiveDragPreview> SelectTool::activeDragPreview() con
     return std::nullopt;
   }
 
-  return ActiveDragPreview{.entity = dragState_->primary.element.entityHandle().entity(),
-                           .translation = dragState_->currentDocumentDelta,
-                           .dragGeneration = dragState_->generation};
+  return ActiveDragPreview{
+      .entity = dragState_->primary.element.entityHandle().entity(),
+      .translation = dragState_->currentDocumentDelta,
+      .documentFromCachedDocument = dragState_->currentDocumentFromStartDocument,
+      .dragGeneration = dragState_->generation};
+}
+
+std::optional<SelectTool::ActiveTransformBoundsPreview> SelectTool::activeTransformBoundsPreview()
+    const {
+  if (!dragState_.has_value() || !dragState_->hasMoved ||
+      dragState_->gestureKind != DragState::GestureKind::Rotate) {
+    return std::nullopt;
+  }
+
+  return ActiveTransformBoundsPreview{
+      .startBoundsDoc = dragState_->startBoundsDoc,
+      .documentFromStartDocument = dragState_->currentDocumentFromStartDocument,
+  };
 }
 
 std::optional<Box2d> SelectTool::marqueeRect() const {

--- a/donner/editor/SelectTool.cc
+++ b/donner/editor/SelectTool.cc
@@ -121,7 +121,8 @@ svg::SVGElement TopLevelAncestor(svg::SVGElement hit, const svg::SVGElement& con
 
 bool SelectTool::tryStartRedragOnSelected(EditorApp& editor, const Vector2d& documentPoint,
                                           MouseModifiers modifiers,
-                                          std::span<const Box2d> selectionBoundsDoc) {
+                                          std::span<const Box2d> selectionBoundsDoc,
+                                          std::span<const Box2d> occludingBoundsDoc) {
   if (modifiers.shift) {
     return false;
   }
@@ -137,6 +138,11 @@ bool SelectTool::tryStartRedragOnSelected(EditorApp& editor, const Vector2d& doc
   if (selectionBoundsDoc.empty() || !selectionBoundsDoc.front().contains(documentPoint) ||
       !currentSelection.front().isa<svg::SVGGraphicsElement>()) {
     return false;
+  }
+  for (const Box2d& occludingBounds : occludingBoundsDoc) {
+    if (occludingBounds.contains(documentPoint)) {
+      return false;
+    }
   }
 
   // Reset any in-progress drag/marquee state before starting the new one

--- a/donner/editor/SelectTool.cc
+++ b/donner/editor/SelectTool.cc
@@ -583,23 +583,22 @@ void SelectTool::onMouseUp(EditorApp& editor, const Vector2d& /*documentPoint*/)
     UndoSnapshot after{.element = dragState_->primary.element,
                        .transform = dragState_->primary.currentTransform,
                        .writebackTarget = dragState_->primary.writebackTarget};
-    editor.undoTimeline().record(undoLabel, std::move(before), std::move(after));
-
-    // Record undo for each extra element so a single Ctrl+Z reverts the
-    // whole multi-element drag — one timeline entry per element keeps the
-    // existing timeline plumbing intact; the user sees them collapsed by
-    // the shared "Move elements" label if the timeline groups by label.
+    before.extras.reserve(dragState_->extras.size());
+    after.extras.reserve(dragState_->extras.size());
     for (const auto& extra : dragState_->extras) {
-      UndoSnapshot extraBefore{.element = extra.element,
-                               .transform = extra.startTransform,
-                               .writebackTarget = extra.writebackTarget,
-                               .sourceTransformAttributeValue = extra.sourceTransformAttributeValue,
-                               .restoreSourceTransformAttributeValue = true};
-      UndoSnapshot extraAfter{.element = extra.element,
-                              .transform = extra.currentTransform,
-                              .writebackTarget = extra.writebackTarget};
-      editor.undoTimeline().record(undoLabel, std::move(extraBefore), std::move(extraAfter));
+      before.extras.push_back(
+          UndoSnapshot{.element = extra.element,
+                       .transform = extra.startTransform,
+                       .writebackTarget = extra.writebackTarget,
+                       .sourceTransformAttributeValue = extra.sourceTransformAttributeValue,
+                       .restoreSourceTransformAttributeValue = true});
+      after.extras.push_back(UndoSnapshot{
+          .element = extra.element,
+          .transform = extra.currentTransform,
+          .writebackTarget = extra.writebackTarget,
+      });
     }
+    editor.undoTimeline().record(undoLabel, std::move(before), std::move(after));
 
     if (dragState_->primary.writebackTarget.has_value()) {
       std::vector<CompletedDragWriteback> extraWritebacks;

--- a/donner/editor/SelectTool.cc
+++ b/donner/editor/SelectTool.cc
@@ -161,6 +161,7 @@ bool SelectTool::tryStartRedragOnSelected(EditorApp& editor, const Vector2d& doc
           },
       .extras = {},
       .startDocumentPoint = documentPoint,
+      .generation = nextDragGeneration_++,
   };
   return true;
 }
@@ -301,6 +302,7 @@ void SelectTool::onMouseDown(EditorApp& editor, const Vector2d& documentPoint,
           },
       .extras = std::move(extras),
       .startDocumentPoint = documentPoint,
+      .generation = nextDragGeneration_++,
   };
 }
 
@@ -472,7 +474,8 @@ std::optional<SelectTool::ActiveDragPreview> SelectTool::activeDragPreview() con
   }
 
   return ActiveDragPreview{.entity = dragState_->primary.element.entityHandle().entity(),
-                           .translation = dragState_->currentDocumentDelta};
+                           .translation = dragState_->currentDocumentDelta,
+                           .dragGeneration = dragState_->generation};
 }
 
 std::optional<Box2d> SelectTool::marqueeRect() const {

--- a/donner/editor/SelectTool.h
+++ b/donner/editor/SelectTool.h
@@ -68,18 +68,18 @@ public:
   /// is mid-render (hitTest would race the worker's
   /// `prepareDocumentForRendering`).
   ///
-  /// `selectionBoundsDoc` is the **caller-supplied** AABB list for the
-  /// current selection (in document space). EditorShell passes the
-  /// pre-snapshotted bounds from `SelectionBoundsCache::displayedBoundsDoc`
-  /// — that cache is refreshed on idle frames, so reading it during a
-  /// busy render is race-free (no live `SnapshotSelectionWorldBounds`
-  /// call inside this function). `onMouseDown` passes a freshly-computed
-  /// live snapshot since its caller has already gated on `!isBusy()`.
+  /// `selectionBoundsDoc` and `occludingBoundsDoc` are **caller-supplied**
+  /// AABB lists in document space. EditorShell passes the pre-snapshotted
+  /// bounds from `SelectionBoundsCache` — that cache is refreshed on idle
+  /// frames, so reading it during a busy render is race-free (no live
+  /// `SnapshotSelectionWorldBounds` call inside this function). `onMouseDown`
+  /// passes freshly-computed live selection bounds and no occlusion hints since
+  /// its caller has already gated on `!isBusy()`.
   ///
   /// Returns true if a drag was started; false if the caller must fall
   /// back to the full `onMouseDown` path (multi-select, shift-click,
-  /// click outside the selection's snapshotted bounds, empty bounds
-  /// span, etc.).
+  /// click outside the selection's snapshotted bounds, click inside
+  /// later-painted cached bounds, empty bounds span, etc.).
   ///
   /// `onMouseDown` itself calls this first to avoid duplicating logic
   /// — so plain clicks on the selection always take the no-hit-test
@@ -87,7 +87,8 @@ public:
   /// can run it BEFORE checking `isBusy()` for the click handler.
   [[nodiscard]] bool tryStartRedragOnSelected(EditorApp& editor, const Vector2d& documentPoint,
                                               MouseModifiers modifiers,
-                                              std::span<const Box2d> selectionBoundsDoc);
+                                              std::span<const Box2d> selectionBoundsDoc,
+                                              std::span<const Box2d> occludingBoundsDoc = {});
 
   /// Whether a drag is currently in progress (button is held after a
   /// successful hit-test on mouse-down).

--- a/donner/editor/SelectTool.h
+++ b/donner/editor/SelectTool.h
@@ -26,6 +26,7 @@
 #include "donner/base/Transform.h"
 #include "donner/base/Vector2.h"
 #include "donner/editor/AttributeWriteback.h"
+#include "donner/editor/SelectionTransformHandles.h"
 #include "donner/editor/Tool.h"
 #include "donner/svg/SVGElement.h"
 
@@ -39,8 +40,20 @@ public:
     Entity entity = entt::null;
     /// Current drag translation in document coordinates.
     Vector2d translation = Vector2d::Zero();
+    /// Current affine transform from the cached document placement to
+    /// the active preview placement.
+    Transform2d documentFromCachedDocument = Transform2d();
     /// Monotonic id for one mouse-down/move/up drag gesture.
     std::uint64_t dragGeneration = 0;
+  };
+
+  /// Active transform chrome state for selection bounds presentation.
+  struct ActiveTransformBoundsPreview {
+    /// Selection AABB captured when the transform gesture started.
+    Box2d startBoundsDoc;
+    /// Current transform from gesture-start document space to active
+    /// document space.
+    Transform2d documentFromStartDocument = Transform2d();
   };
 
   /// Payload needed to write a completed drag back into the source pane.
@@ -59,6 +72,9 @@ public:
   void onMouseDown(EditorApp& editor, const Vector2d& documentPoint,
                    MouseModifiers modifiers) override;
   void onMouseMove(EditorApp& editor, const Vector2d& documentPoint, bool buttonHeld) override;
+  /// Mouse-move variant that samples live modifiers during resize gestures.
+  void onMouseMove(EditorApp& editor, const Vector2d& documentPoint, bool buttonHeld,
+                   MouseModifiers modifiers);
   void onMouseUp(EditorApp& editor, const Vector2d& documentPoint) override;
 
   /// Snapshot-safe re-drag start (design doc 0033 §M8). When the user
@@ -116,6 +132,9 @@ public:
   /// Returns the current drag preview, if a drag is in progress.
   [[nodiscard]] std::optional<ActiveDragPreview> activeDragPreview() const;
 
+  /// Returns active oriented-bounds chrome for in-progress rotation.
+  [[nodiscard]] std::optional<ActiveTransformBoundsPreview> activeTransformBoundsPreview() const;
+
 private:
   /// Per-element bookkeeping for one participant in a drag. Carries the
   /// start transform (for computing `startTransform * translate(delta)`
@@ -137,6 +156,12 @@ private:
   };
 
   struct DragState {
+    enum class GestureKind {
+      Move,
+      Resize,
+      Rotate,
+    };
+
     /// Primary drag participant — the element that was under the cursor on
     /// mouse-down. Always populated. The compositor-preview fast path
     /// (when a single-element drag is composited) runs against this one.
@@ -149,11 +174,19 @@ private:
     /// them all" design-tool behavior.
     std::vector<PerElementDrag> extras;
 
+    GestureKind gestureKind = GestureKind::Move;
+    SelectionTransformCorner corner = SelectionTransformCorner::TopLeft;
     Vector2d startDocumentPoint;
+    Box2d startBoundsDoc;
+    Vector2d centerDocumentPoint = Vector2d::Zero();
+    double startAngleRadians = 0.0;
     /// Generation copied into \ref ActiveDragPreview for this gesture.
     std::uint64_t generation = 0;
     /// Current drag delta in document coordinates, used for compositor preview.
     Vector2d currentDocumentDelta = Vector2d::Zero();
+    /// Current affine transform from the gesture-start document geometry
+    /// to the active preview geometry.
+    Transform2d currentDocumentFromStartDocument = Transform2d();
     /// Whether any `onMouseMove` has fired since `onMouseDown`. A
     /// click-without-drag shouldn't leave an undo entry behind.
     bool hasMoved = false;

--- a/donner/editor/SelectTool.h
+++ b/donner/editor/SelectTool.h
@@ -16,6 +16,7 @@
 /// All DOM mutations flow through `EditorApp::applyMutation()` as
 /// `EditorCommand::SetTransform` — never directly.
 
+#include <cstdint>
 #include <optional>
 #include <span>
 #include <vector>
@@ -34,8 +35,12 @@ class SelectTool final : public Tool {
 public:
   /// Preview state for an in-progress drag, consumed by the async renderer.
   struct ActiveDragPreview {
+    /// Entity being dragged.
     Entity entity = entt::null;
+    /// Current drag translation in document coordinates.
     Vector2d translation = Vector2d::Zero();
+    /// Monotonic id for one mouse-down/move/up drag gesture.
+    std::uint64_t dragGeneration = 0;
   };
 
   /// Payload needed to write a completed drag back into the source pane.
@@ -144,6 +149,8 @@ private:
     std::vector<PerElementDrag> extras;
 
     Vector2d startDocumentPoint;
+    /// Generation copied into \ref ActiveDragPreview for this gesture.
+    std::uint64_t generation = 0;
     /// Current drag delta in document coordinates, used for compositor preview.
     Vector2d currentDocumentDelta = Vector2d::Zero();
     /// Whether any `onMouseMove` has fired since `onMouseDown`. A
@@ -165,6 +172,7 @@ private:
   std::optional<DragState> dragState_;
   std::optional<MarqueeState> marqueeState_;
   std::optional<CompletedDragWriteback> completedDragWriteback_;
+  std::uint64_t nextDragGeneration_ = 1;
 };
 
 }  // namespace donner::editor

--- a/donner/editor/SelectionAabb.cc
+++ b/donner/editor/SelectionAabb.cc
@@ -3,6 +3,7 @@
 #include <optional>
 
 #include "donner/svg/ElementType.h"
+#include "donner/svg/SVGDocument.h"
 #include "donner/svg/SVGGeometryElement.h"
 
 namespace donner::editor {
@@ -45,6 +46,51 @@ void CollectRenderableGeometryImpl(const svg::SVGElement& root,
   }
 }
 
+void CollectLaterRenderableGeometryImpl(const svg::SVGElement& root,
+                                        const svg::SVGElement& selected, bool& afterSelected,
+                                        std::vector<svg::SVGGeometryElement>& out) {
+  if (IsNonRenderedContainer(root.type())) {
+    return;
+  }
+
+  if (root == selected) {
+    afterSelected = true;
+    return;
+  }
+
+  if (root.isa<svg::SVGGeometryElement>()) {
+    if (afterSelected) {
+      out.push_back(root.cast<svg::SVGGeometryElement>());
+    }
+    return;
+  }
+
+  for (auto child = root.firstChild(); child.has_value(); child = child->nextSibling()) {
+    CollectLaterRenderableGeometryImpl(*child, selected, afterSelected, out);
+  }
+}
+
+std::vector<svg::SVGGeometryElement> CollectLaterRenderableGeometry(
+    const svg::SVGElement& root, const svg::SVGElement& selected) {
+  std::vector<svg::SVGGeometryElement> out;
+  bool afterSelected = false;
+  CollectLaterRenderableGeometryImpl(root, selected, afterSelected, out);
+  return out;
+}
+
+std::vector<Box2d> SnapshotGeometryWorldBounds(
+    std::span<const svg::SVGGeometryElement> geometryElements) {
+  std::vector<Box2d> bounds;
+  bounds.reserve(geometryElements.size());
+  for (const auto& geometry : geometryElements) {
+    const auto wb = geometry.worldBounds();
+    if (wb.has_value()) {
+      bounds.push_back(*wb);
+    }
+  }
+  return bounds;
+}
+
 }  // namespace
 
 std::vector<svg::SVGGeometryElement> CollectRenderableGeometry(const svg::SVGElement& root) {
@@ -82,13 +128,28 @@ std::vector<Box2d> SnapshotSelectionWorldBounds(std::span<const svg::SVGElement>
   return bounds;
 }
 
+std::vector<Box2d> SnapshotSelectionOccludingWorldBounds(
+    std::span<const svg::SVGElement> selection) {
+  if (selection.size() != 1u) {
+    return {};
+  }
+
+  svg::SVGElement selected = selection.front();
+  const svg::SVGElement root = selected.ownerDocument().svgElement();
+  const std::vector<svg::SVGGeometryElement> laterGeometry =
+      CollectLaterRenderableGeometry(root, selected);
+  return SnapshotGeometryWorldBounds(laterGeometry);
+}
+
 void PromoteSelectionBoundsIfReady(SelectionBoundsCache& cache, std::uint64_t displayedDocVersion) {
   if (cache.pendingVersion != displayedDocVersion) {
     return;
   }
 
   cache.displayedBoundsDoc = cache.pendingBoundsDoc;
+  cache.displayedOccludingBoundsDoc = cache.pendingOccludingBoundsDoc;
   cache.pendingBoundsDoc.clear();
+  cache.pendingOccludingBoundsDoc.clear();
   cache.pendingVersion = 0;
 }
 
@@ -99,10 +160,12 @@ void RefreshSelectionBoundsCache(SelectionBoundsCache& cache,
   cache.lastSelection.assign(selection.begin(), selection.end());
   cache.lastRefreshVersion = currentDocVersion;
   cache.pendingBoundsDoc = SnapshotSelectionWorldBounds(selection);
+  cache.pendingOccludingBoundsDoc = SnapshotSelectionOccludingWorldBounds(selection);
   cache.pendingVersion = currentDocVersion;
 
   if (selection.empty()) {
     cache.displayedBoundsDoc.clear();
+    cache.displayedOccludingBoundsDoc.clear();
   }
 
   PromoteSelectionBoundsIfReady(cache, displayedDocVersion);

--- a/donner/editor/SelectionAabb.h
+++ b/donner/editor/SelectionAabb.h
@@ -36,12 +36,28 @@ namespace donner::editor {
 [[nodiscard]] std::vector<Box2d> SnapshotSelectionWorldBounds(
     std::span<const svg::SVGElement> selection);
 
+/// Snapshot world-space bounds for renderable geometry painted after a
+/// single selected element. This is a conservative occlusion hint for the
+/// async-safe re-drag path: if the click falls inside one of these bounds,
+/// the editor should wait for the normal hit-test path instead of assuming
+/// the selected element owns the click.
+///
+/// Multi-selection produces no occlusion hints because the fast re-drag
+/// path is single-selection only.
+///
+/// @param selection Current selection handles.
+/// @return Document-space AABBs for later-painted renderable geometry.
+[[nodiscard]] std::vector<Box2d> SnapshotSelectionOccludingWorldBounds(
+    std::span<const svg::SVGElement> selection);
+
 /// Pending/displayed selection AABBs tracked across document-version changes.
 struct SelectionBoundsCache {
   std::vector<svg::SVGElement> lastSelection;
   std::vector<Box2d> pendingBoundsDoc;
+  std::vector<Box2d> pendingOccludingBoundsDoc;
   std::uint64_t pendingVersion = 0;
   std::vector<Box2d> displayedBoundsDoc;
+  std::vector<Box2d> displayedOccludingBoundsDoc;
   std::uint64_t lastRefreshVersion = std::numeric_limits<std::uint64_t>::max();
 };
 

--- a/donner/editor/SelectionTransformHandles.cc
+++ b/donner/editor/SelectionTransformHandles.cc
@@ -1,0 +1,138 @@
+#include "donner/editor/SelectionTransformHandles.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+
+namespace donner::editor {
+
+namespace {
+
+constexpr double kHandleSizePixels = 9.0;
+constexpr double kRotateOuterRadiusPixels = 24.0;
+constexpr double kRotateInnerRadiusPixels = 10.0;
+constexpr double kMinPixelsPerDocUnit = 1e-9;
+
+std::array<SelectionTransformCorner, 4> AllCorners() {
+  return {SelectionTransformCorner::TopLeft, SelectionTransformCorner::TopRight,
+          SelectionTransformCorner::BottomRight, SelectionTransformCorner::BottomLeft};
+}
+
+bool IsFinite(double value) {
+  return std::isfinite(value);
+}
+
+bool IsFinite(const Vector2d& value) {
+  return IsFinite(value.x) && IsFinite(value.y);
+}
+
+bool ResizeBoxContains(const Vector2d& cornerDoc, const Vector2d& pointDoc, double halfHandleDoc) {
+  return std::abs(pointDoc.x - cornerDoc.x) <= halfHandleDoc &&
+         std::abs(pointDoc.y - cornerDoc.y) <= halfHandleDoc;
+}
+
+}  // namespace
+
+Box2d CombinedSelectionBounds(std::span<const Box2d> selectionBoundsDoc) {
+  if (selectionBoundsDoc.empty()) {
+    return Box2d();
+  }
+
+  Box2d combined = selectionBoundsDoc.front();
+  for (std::size_t i = 1; i < selectionBoundsDoc.size(); ++i) {
+    combined.addBox(selectionBoundsDoc[i]);
+  }
+  return combined;
+}
+
+Vector2d SelectionTransformCornerPoint(const Box2d& bounds, SelectionTransformCorner corner) {
+  switch (corner) {
+    case SelectionTransformCorner::TopLeft: return bounds.topLeft;
+    case SelectionTransformCorner::TopRight:
+      return Vector2d(bounds.bottomRight.x, bounds.topLeft.y);
+    case SelectionTransformCorner::BottomRight: return bounds.bottomRight;
+    case SelectionTransformCorner::BottomLeft:
+      return Vector2d(bounds.topLeft.x, bounds.bottomRight.y);
+  }
+  return bounds.topLeft;
+}
+
+SelectionTransformCorner OppositeSelectionTransformCorner(SelectionTransformCorner corner) {
+  switch (corner) {
+    case SelectionTransformCorner::TopLeft: return SelectionTransformCorner::BottomRight;
+    case SelectionTransformCorner::TopRight: return SelectionTransformCorner::BottomLeft;
+    case SelectionTransformCorner::BottomRight: return SelectionTransformCorner::TopLeft;
+    case SelectionTransformCorner::BottomLeft: return SelectionTransformCorner::TopRight;
+  }
+  return SelectionTransformCorner::TopLeft;
+}
+
+SelectionTransformHandleBoxes SelectionTransformHandleBoxesForBounds(const Box2d& boundsDoc,
+                                                                     double pixelsPerDocUnit) {
+  const double scale = std::max(std::abs(pixelsPerDocUnit), kMinPixelsPerDocUnit);
+  const double halfHandleDoc = (kHandleSizePixels * 0.5) / scale;
+
+  SelectionTransformHandleBoxes result;
+  const std::array<SelectionTransformCorner, 4> corners = AllCorners();
+  for (std::size_t i = 0; i < corners.size(); ++i) {
+    const Vector2d corner = SelectionTransformCornerPoint(boundsDoc, corners[i]);
+    result.boxes[i] = Box2d(corner - Vector2d(halfHandleDoc, halfHandleDoc),
+                            corner + Vector2d(halfHandleDoc, halfHandleDoc));
+  }
+  return result;
+}
+
+SelectionTransformHandleIntent HitTestSelectionTransformHandles(
+    std::span<const Box2d> selectionBoundsDoc, const Vector2d& documentPoint,
+    double pixelsPerDocUnit) {
+  if (selectionBoundsDoc.empty() || !IsFinite(documentPoint)) {
+    return {};
+  }
+
+  const double scale = std::abs(pixelsPerDocUnit);
+  if (scale < kMinPixelsPerDocUnit || !IsFinite(scale)) {
+    return {};
+  }
+
+  const Box2d bounds = CombinedSelectionBounds(selectionBoundsDoc);
+  if (bounds.isEmpty()) {
+    return {};
+  }
+
+  const double halfHandleDoc = (kHandleSizePixels * 0.5) / scale;
+  const std::array<SelectionTransformCorner, 4> corners = AllCorners();
+  for (SelectionTransformCorner corner : corners) {
+    const Vector2d cornerDoc = SelectionTransformCornerPoint(bounds, corner);
+    if (ResizeBoxContains(cornerDoc, documentPoint, halfHandleDoc)) {
+      return SelectionTransformHandleIntent{
+          .kind = SelectionTransformHandleKind::Resize,
+          .corner = corner,
+      };
+    }
+  }
+
+  const double innerRadiusDoc = kRotateInnerRadiusPixels / scale;
+  const double outerRadiusDoc = kRotateOuterRadiusPixels / scale;
+  if (bounds.contains(documentPoint)) {
+    return {};
+  }
+
+  for (SelectionTransformCorner corner : corners) {
+    const Vector2d cornerDoc = SelectionTransformCornerPoint(bounds, corner);
+    const double distance = (documentPoint - cornerDoc).length();
+    if (distance > innerRadiusDoc && distance <= outerRadiusDoc) {
+      return SelectionTransformHandleIntent{
+          .kind = SelectionTransformHandleKind::Rotate,
+          .corner = corner,
+      };
+    }
+  }
+
+  return {};
+}
+
+double PixelsPerDocUnitFromTransform(const Transform2d& canvasFromDoc) {
+  return canvasFromDoc.transformVector(Vector2d(1.0, 0.0)).length();
+}
+
+}  // namespace donner::editor

--- a/donner/editor/SelectionTransformHandles.h
+++ b/donner/editor/SelectionTransformHandles.h
@@ -1,0 +1,68 @@
+#pragma once
+/// @file
+
+#include <array>
+#include <span>
+
+#include "donner/base/Box.h"
+#include "donner/base/Transform.h"
+#include "donner/base/Vector2.h"
+
+namespace donner::editor {
+
+/// Corner handle identity for selection resize/rotate gestures.
+enum class SelectionTransformCorner {
+  TopLeft,
+  TopRight,
+  BottomRight,
+  BottomLeft,
+};
+
+/// Interaction kind under the pointer near selection transform handles.
+enum class SelectionTransformHandleKind {
+  None,
+  Resize,
+  Rotate,
+};
+
+/// Hit-test result for selection transform handles.
+struct SelectionTransformHandleIntent {
+  SelectionTransformHandleKind kind = SelectionTransformHandleKind::None;
+  SelectionTransformCorner corner = SelectionTransformCorner::TopLeft;
+
+  friend bool operator==(const SelectionTransformHandleIntent&,
+                         const SelectionTransformHandleIntent&) = default;
+};
+
+/// Visual handle boxes for one selection envelope, in document coordinates.
+struct SelectionTransformHandleBoxes {
+  std::array<Box2d, 4> boxes;
+};
+
+/// Return a combined AABB for a selection-bounds span.
+[[nodiscard]] Box2d CombinedSelectionBounds(std::span<const Box2d> selectionBoundsDoc);
+
+/// Return the point for a corner of @p bounds.
+[[nodiscard]] Vector2d SelectionTransformCornerPoint(const Box2d& bounds,
+                                                     SelectionTransformCorner corner);
+
+/// Return the opposite corner from @p corner.
+[[nodiscard]] SelectionTransformCorner OppositeSelectionTransformCorner(
+    SelectionTransformCorner corner);
+
+/// Build document-space handle boxes with screen-stable size under @p pixelsPerDocUnit.
+[[nodiscard]] SelectionTransformHandleBoxes SelectionTransformHandleBoxesForBounds(
+    const Box2d& boundsDoc, double pixelsPerDocUnit);
+
+/// Hit-test resize and rotate corner zones using document-space bounds and scale.
+///
+/// Resize wins over rotate when zones overlap. Rotate is intentionally outside
+/// the square handle, in a small ring around each corner.
+[[nodiscard]] SelectionTransformHandleIntent HitTestSelectionTransformHandles(
+    std::span<const Box2d> selectionBoundsDoc, const Vector2d& documentPoint,
+    double pixelsPerDocUnit);
+
+/// Return pixels per document unit from a document-to-canvas transform.
+[[nodiscard]] double PixelsPerDocUnitFromTransform(const Transform2d& canvasFromDoc);
+
+}  // namespace donner::editor

--- a/donner/editor/Tool.h
+++ b/donner/editor/Tool.h
@@ -26,6 +26,10 @@ struct MouseModifiers {
   /// Shift held — used by `SelectTool` to toggle/extend selection
   /// rather than replacing it.
   bool shift = false;
+  /// Option/Alt held — used by transform handles to resize from center.
+  bool option = false;
+  /// Current viewport scale used for screen-pixel-stable hit testing.
+  double pixelsPerDocUnit = 1.0;
 };
 
 /// Abstract editor pointer tool. Implementations are stateless across

--- a/donner/editor/UndoTimeline.cc
+++ b/donner/editor/UndoTimeline.cc
@@ -21,6 +21,9 @@ UndoSnapshot captureTransformSnapshot(const svg::SVGElement& element) {
 void applySnapshot(const UndoSnapshot& snapshot) {
   auto graphicsElement = snapshot.element.cast<svg::SVGGraphicsElement>();
   graphicsElement.setTransform(snapshot.transform);
+  for (const UndoSnapshot& extra : snapshot.extras) {
+    applySnapshot(extra);
+  }
 }
 
 void UndoTimeline::beginTransaction(std::string_view label, UndoSnapshot before) {
@@ -41,6 +44,7 @@ void UndoTimeline::commitTransaction(UndoSnapshot after) {
       .before = std::move(pendingTransaction_->before),
       .after = std::move(after),
   });
+  redoStack_.clear();
   pendingTransaction_ = std::nullopt;
 }
 
@@ -55,6 +59,7 @@ void UndoTimeline::record(std::string_view label, UndoSnapshot before, UndoSnaps
       .before = std::move(before),
       .after = std::move(after),
   });
+  redoStack_.clear();
 }
 
 std::optional<UndoSnapshot> UndoTimeline::undo() {
@@ -82,6 +87,7 @@ std::optional<UndoSnapshot> UndoTimeline::undo() {
       .after = targetCopy.before,
       .undoOf = cursorAtEntry,
   });
+  redoStack_.push_back(entries_.size() - 1);
 
   // Move cursor backward for the next undo in this chain.
   if (undoCursor_ == 0) {
@@ -93,12 +99,39 @@ std::optional<UndoSnapshot> UndoTimeline::undo() {
   return targetCopy.before;
 }
 
+std::optional<UndoSnapshot> UndoTimeline::redo() {
+  if (!canRedo()) {
+    return std::nullopt;
+  }
+
+  const size_t redoEntryIndex = redoStack_.back();
+  redoStack_.pop_back();
+  if (redoEntryIndex >= entries_.size()) {
+    return std::nullopt;
+  }
+
+  const UndoEntry targetCopy = entries_[redoEntryIndex];
+  entries_.push_back(UndoEntry{
+      .label = "Redo: " + targetCopy.label,
+      .before = targetCopy.after,
+      .after = targetCopy.before,
+      .undoOf = redoEntryIndex,
+  });
+
+  inUndoChain_ = false;
+  return targetCopy.before;
+}
+
 bool UndoTimeline::canUndo() const {
   if (inUndoChain_) {
     return undoCursor_ != kCursorExhausted;
   }
 
   return !entries_.empty();
+}
+
+bool UndoTimeline::canRedo() const {
+  return !redoStack_.empty();
 }
 
 std::optional<std::string_view> UndoTimeline::nextUndoLabel() const {
@@ -119,6 +152,7 @@ void UndoTimeline::clear() {
   inUndoChain_ = false;
   undoCursor_ = 0;
   chainStart_ = 0;
+  redoStack_.clear();
 }
 
 void UndoTimeline::breakUndoChain() {

--- a/donner/editor/UndoTimeline.h
+++ b/donner/editor/UndoTimeline.h
@@ -40,12 +40,18 @@ struct UndoSnapshot {
   /// When false, source writeback falls back to canonical serialization of
   /// `transform`.
   bool restoreSourceTransformAttributeValue = false;
+
+  /// Additional element snapshots that belong to the same user operation.
+  /// Multi-selection move/resize/rotate gestures use this so one UI undo
+  /// restores the whole manipulation instead of stepping through elements
+  /// one at a time.
+  std::vector<UndoSnapshot> extras;
 };
 
 /// Capture the current transform of an SVGElement as an undo snapshot.
 UndoSnapshot captureTransformSnapshot(const svg::SVGElement& element);
 
-/// Apply a previously captured snapshot back to its element.
+/// Apply a previously captured snapshot, including grouped extra element snapshots.
 void applySnapshot(const UndoSnapshot& snapshot);
 
 /// A single entry in the non-destructive undo timeline.
@@ -96,8 +102,15 @@ public:
   /// there is nothing to undo.
   std::optional<UndoSnapshot> undo();
 
+  /// Redo the most recently undone entry. Returns the snapshot the caller
+  /// should apply, or nullopt if there is nothing to redo.
+  std::optional<UndoSnapshot> redo();
+
   /// Whether there is an entry to undo (either in the current chain or by starting a new one).
   [[nodiscard]] bool canUndo() const;
+
+  /// Whether the most recent undo operation can be redone.
+  [[nodiscard]] bool canRedo() const;
 
   /// The label of the entry that would be undone next.
   [[nodiscard]] std::optional<std::string_view> nextUndoLabel() const;
@@ -126,6 +139,7 @@ private:
   bool inUndoChain_ = false;
   size_t undoCursor_ = 0;  ///< Entry index being reversed during the chain.
   size_t chainStart_ = 0;  ///< entries_.size() when the chain started.
+  std::vector<size_t> redoStack_;
 };
 
 }  // namespace donner::editor

--- a/donner/editor/ViewportInteractionController.cc
+++ b/donner/editor/ViewportInteractionController.cc
@@ -6,8 +6,8 @@ namespace donner::editor {
 
 void FrameHistory::push(float ms) {
   deltaMs[writeIndex] = ms;
-  // Reset the backend slot to zero — `setLatestBackendMs` will fill it
-  // in when a render result lands during the same UI frame.
+  // Reset the worker slot to zero — `setLatestBackendMs` will fill it in when
+  // a render result lands during the same UI frame.
   backendMs[writeIndex] = 0.0f;
   writeIndex = (writeIndex + 1) % kFrameHistoryCapacity;
   if (samples < kFrameHistoryCapacity) {

--- a/donner/editor/ViewportInteractionController.h
+++ b/donner/editor/ViewportInteractionController.h
@@ -18,28 +18,28 @@ struct FrameHistory {
   /// ImGui frame delta per UI-thread frame — populated from
   /// `ImGui::GetIO().DeltaTime` by `noteFrameDelta`.
   std::array<float, kFrameHistoryCapacity> deltaMs{};
-  /// Async-renderer worker time (ms) per UI frame, aligned 1:1 with the
-  /// matching `deltaMs[]` slot. Holds `0.0f` for frames where no render
-  /// result landed (the worker was still busy or nothing was requested);
-  /// consumers skip zero entries so the graph doesn't drop to zero
-  /// between drags.
+  /// Async-renderer worker/presentation latency (ms) per UI frame, aligned 1:1
+  /// with the matching `deltaMs[]` slot. Holds `0.0f` for frames where no
+  /// render result landed (the worker was still busy or nothing was requested);
+  /// consumers skip zero entries so the graph doesn't drop to zero between
+  /// drags.
   std::array<float, kFrameHistoryCapacity> backendMs{};
   std::size_t writeIndex = 0;
   std::size_t samples = 0;
-  /// Most recent non-zero backend sample, so latched-backend-latency
+  /// Most recent non-zero worker sample, so latched-worker-latency
   /// readers (the numeric readout, sticky-line rendering) have something
   /// to show between render-result landings.
   float lastBackendMs = 0.0f;
 
   /// Append a new frame sample. The matching `backendMs[]` slot is
-  /// reset to 0 ("no backend result this frame"); `setLatestBackendMs`
+  /// reset to 0 ("no worker result this frame"); `setLatestBackendMs`
   /// fills it in if a render result lands during the same UI frame.
   void push(float ms);
-  /// Record a backend (async-renderer worker) timing for the most
+  /// Record an async-renderer worker timing for the most
   /// recently pushed frame. Called by `RenderCoordinator::pollRenderResult`
   /// when a new `RenderResult` arrives. No-op if no frame has been pushed
-  /// yet. Also updates `lastBackendMs` so UI elements that want to show
-  /// the latest measured backend latency have a persistent value.
+  /// yet. Also updates `lastBackendMs` so UI elements that want to show the
+  /// latest measured worker latency have a persistent value.
   void setLatestBackendMs(float ms);
   [[nodiscard]] float latest() const;
   [[nodiscard]] float max() const;

--- a/donner/editor/gui/BUILD.bazel
+++ b/donner/editor/gui/BUILD.bazel
@@ -67,6 +67,7 @@ donner_cc_library(
     srcs = ["EditorWindow.cc"],
     hdrs = ["EditorWindow.h"],
     defines = select({
+        "//donner/editor:wasm_geode_enabled": [],
         "//donner/svg/renderer:renderer_backend_geode": ["DONNER_EDITOR_WGPU"],
         "//conditions:default": [],
     }),
@@ -77,6 +78,9 @@ donner_cc_library(
         "//donner/svg/renderer:renderer_interface",
         "@imgui",
     ] + select({
+        "//donner/editor:wasm_geode_enabled": [
+            "//third_party/emscripten-glfw",
+        ],
         "//donner/editor/wasm:wasm_enabled": [
             "//third_party/emscripten-glfw",
         ],

--- a/donner/editor/gui/BUILD.bazel
+++ b/donner/editor/gui/BUILD.bazel
@@ -67,7 +67,7 @@ donner_cc_library(
     srcs = ["EditorWindow.cc"],
     hdrs = ["EditorWindow.h"],
     defines = select({
-        "//donner/editor:wasm_geode_enabled": [],
+        "//donner/editor:wasm_geode_enabled": ["DONNER_EDITOR_WGPU"],
         "//donner/svg/renderer:renderer_backend_geode": ["DONNER_EDITOR_WGPU"],
         "//conditions:default": [],
     }),
@@ -79,9 +79,13 @@ donner_cc_library(
         "@imgui",
     ] + select({
         "//donner/editor:wasm_geode_enabled": [
+            "//donner/svg/renderer/geode:geode_device",
+            "//donner/svg/renderer/geode:geode_wgpu_util",
             "//third_party/emscripten-glfw",
+            "//third_party/webgpu-cpp:webgpu_cpp",
+            "@imgui//:imgui_wgpu_backend",
         ],
-        "//donner/editor/wasm:wasm_enabled": [
+        "//donner/editor:wasm_tiny_skia_enabled": [
             "//third_party/emscripten-glfw",
         ],
         "//donner/svg/renderer:renderer_backend_geode": [

--- a/donner/editor/gui/EditorWindow.cc
+++ b/donner/editor/gui/EditorWindow.cc
@@ -22,6 +22,7 @@ extern "C" {
 #include <GLFW/glfw3.h>
 #endif
 
+#include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
@@ -57,6 +58,34 @@ void GlfwErrorCallback(int error, const char* description) {
 }
 
 #ifdef DONNER_EDITOR_WGPU
+void OnEditorWgpuUncapturedError(WGPUDevice const* /*device*/, WGPUErrorType type,
+                                 WGPUStringView message, void* /*userdata1*/, void* /*userdata2*/) {
+  std::fprintf(stderr, "[Editor/WGPU] Uncaptured error (type=%d): %.*s\n", static_cast<int>(type),
+               static_cast<int>(message.length), message.data ? message.data : "");
+}
+
+class SurfacePresentGuard {
+public:
+  explicit SurfacePresentGuard(wgpu::Surface& surface) : surface_(surface) {}
+  ~SurfacePresentGuard() { present(); }
+
+  SurfacePresentGuard(const SurfacePresentGuard&) = delete;
+  SurfacePresentGuard& operator=(const SurfacePresentGuard&) = delete;
+
+  void present() {
+    if (!active_ || !surface_) {
+      return;
+    }
+
+    surface_.present();
+    active_ = false;
+  }
+
+private:
+  wgpu::Surface& surface_;
+  bool active_ = true;
+};
+
 wgpu::TextureFormat ChooseSurfaceFormat(const wgpu::SurfaceCapabilities& caps) {
   for (size_t i = 0; i < caps.formatCount; ++i) {
     const auto format = caps.formats[i];
@@ -367,6 +396,9 @@ EditorWindow::EditorWindow(EditorWindowOptions options) : options_(std::move(opt
   }
   wgpu::DeviceDescriptor deviceDesc = {};
   deviceDesc.label = wgpu::StringView{std::string_view{"DonnerEditorWGPUDevice"}};
+  deviceDesc.uncapturedErrorCallbackInfo.callback = OnEditorWgpuUncapturedError;
+  deviceDesc.uncapturedErrorCallbackInfo.userdata1 = nullptr;
+  deviceDesc.uncapturedErrorCallbackInfo.userdata2 = nullptr;
   wgpuState_->device = wgpuState_->adapter.requestDevice(deviceDesc);
   if (!wgpuState_->device) {
     std::fprintf(stderr, "EditorWindow: failed to create WebGPU device\n");
@@ -719,7 +751,16 @@ void EditorWindow::endFrameImpl(svg::RendererBitmap* readback) {
   }
 
   wgpu::SurfaceTexture surfaceTexture;
+  const auto acquireStart = std::chrono::steady_clock::now();
   wgpuState_->surface.getCurrentTexture(&surfaceTexture);
+  const auto acquireMs =
+      std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - acquireStart)
+          .count();
+  if (acquireMs > 250.0) {
+    std::fprintf(stderr,
+                 "[Editor/WGPU] surface.getCurrentTexture took %.1fms (status=%d, size=%dx%d)\n",
+                 acquireMs, static_cast<int>(surfaceTexture.status), displayW, displayH);
+  }
   if (surfaceTexture.status != WGPUSurfaceGetCurrentTextureStatus_SuccessOptimal &&
       surfaceTexture.status != WGPUSurfaceGetCurrentTextureStatus_SuccessSuboptimal) {
     donner::geode::ScopedWgpuHandle<wgpu::Texture> failedTexture(
@@ -728,6 +769,7 @@ void EditorWindow::endFrameImpl(svg::RendererBitmap* readback) {
   }
 
   donner::geode::ScopedWgpuHandle<wgpu::Texture> target(wgpu::Texture(surfaceTexture.texture));
+  SurfacePresentGuard presentGuard(wgpuState_->surface);
   const bool shouldReadback = readback != nullptr && options_.enableFramebufferReadback &&
                               SurfaceUsageSupportsReadback(wgpuState_->surfaceUsage);
   const uint32_t readbackWidth = static_cast<uint32_t>(displayW);
@@ -796,7 +838,7 @@ void EditorWindow::endFrameImpl(svg::RendererBitmap* readback) {
     }
     readbackBuffer.get().unmap();
   }
-  wgpuState_->surface.present();
+  presentGuard.present();
 #else
   glViewport(0, 0, displayW, displayH);
   glClearColor(options_.clearColor[0], options_.clearColor[1], options_.clearColor[2],

--- a/donner/editor/gui/EditorWindow.cc
+++ b/donner/editor/gui/EditorWindow.cc
@@ -4,8 +4,14 @@
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 
+#ifdef DONNER_EDITOR_WGPU
+#include <webgpu/webgpu.h>
+
+#include <webgpu/webgpu.hpp>
+#else
 #define GLFW_INCLUDE_ES3
 #include <GLES3/gl3.h>
+#endif
 
 #include "GLFW/emscripten_glfw3.h"
 #elif defined(DONNER_EDITOR_WGPU)
@@ -35,7 +41,9 @@ extern "C" {
 #include "donner/editor/ImGuiBackendIncludes.h"
 #include "donner/editor/TracyWrapper.h"
 #ifdef DONNER_EDITOR_WGPU
+#ifndef __EMSCRIPTEN__
 #include "donner/editor/gui/EditorWgpuSurface.h"
+#endif
 #include "donner/svg/renderer/geode/GeodeDevice.h"
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 #endif
@@ -77,7 +85,12 @@ public:
       return;
     }
 
+#ifdef __EMSCRIPTEN__
+    // Emscripten presents WebGPU canvas surfaces from the browser's rAF loop;
+    // calling wgpuSurfacePresent aborts in the JS glue.
+#else
     surface_.present();
+#endif
     active_ = false;
   }
 
@@ -85,6 +98,22 @@ private:
   wgpu::Surface& surface_;
   bool active_ = true;
 };
+
+wgpu::Surface CreateEditorWgpuSurface(const wgpu::Instance& instance, GLFWwindow* window) {
+#ifdef __EMSCRIPTEN__
+  (void)window;
+  WGPUEmscriptenSurfaceSourceCanvasHTMLSelector canvasSource =
+      WGPU_EMSCRIPTEN_SURFACE_SOURCE_CANVAS_HTML_SELECTOR_INIT;
+  canvasSource.selector.data = "#canvas";
+  canvasSource.selector.length = WGPU_STRLEN;
+
+  WGPUSurfaceDescriptor descriptor = WGPU_SURFACE_DESCRIPTOR_INIT;
+  descriptor.nextInChain = &canvasSource.chain;
+  return wgpu::Surface(wgpuInstanceCreateSurface(instance, &descriptor));
+#else
+  return CreateWgpuSurfaceFromGlfwWindow(instance, window);
+#endif
+}
 
 wgpu::TextureFormat ChooseSurfaceFormat(const wgpu::SurfaceCapabilities& caps) {
   for (size_t i = 0; i < caps.formatCount; ++i) {
@@ -105,9 +134,15 @@ constexpr uint32_t AlignTextureCopyBytesPerRow(uint32_t unpaddedBytesPerRow) {
 wgpu::TextureUsage SurfaceUsageForCapabilities(const wgpu::SurfaceCapabilities& caps,
                                                bool enableReadback) {
   WGPUTextureUsage usage = WGPUTextureUsage_RenderAttachment;
+#ifdef __EMSCRIPTEN__
+  if (enableReadback) {
+    usage |= WGPUTextureUsage_CopySrc;
+  }
+#else
   if (enableReadback && (caps.usages & WGPUTextureUsage_CopySrc) != 0) {
     usage |= WGPUTextureUsage_CopySrc;
   }
+#endif
   return wgpu::TextureUsage{usage};
 }
 
@@ -236,7 +271,31 @@ EM_JS(int, CanvasPixelHeight, (), {
 });
 
 EM_JS(int, CanvasCssWidth, (), { return Math.max(1, Math.floor(window.innerWidth)); });
+EM_JS(int, CanvasCssHeight, (), { return Math.max(1, Math.floor(window.innerHeight)); });
 EM_JS(double, BrowserDevicePixelRatio, (), { return window.devicePixelRatio || 1.0; });
+EM_JS(bool, WgpuReadbackStatsEnabled, (),
+      { return new URLSearchParams(window.location.search).has("wgpuReadbackStats"); });
+EM_JS(void, PublishWgpuReadbackStats,
+      (int renderSamples, int renderColored, int renderNonBlack, int renderMaxChannel,
+       int layerSamples, int layerColored, int layerNonBlack, int layerMaxChannel),
+      {
+        const previous = window.__donnerWgpuReadbackStats;
+        window.__donnerWgpuReadbackStats = {
+          frame : previous ? previous.frame + 1 : 1,
+          renderPane : {
+            samples : renderSamples,
+            coloredPixels : renderColored,
+            nonBlackPixels : renderNonBlack,
+            maxChannel : renderMaxChannel,
+          },
+          layerPreview : {
+            samples : layerSamples,
+            coloredPixels : layerColored,
+            nonBlackPixels : layerNonBlack,
+            maxChannel : layerMaxChannel,
+          },
+        };
+      });
 
 double CurrentDisplayScale() {
   const int logicalWidth = CanvasCssWidth();
@@ -246,6 +305,78 @@ double CurrentDisplayScale() {
   }
   return std::max(1.0, BrowserDevicePixelRatio());
 }
+
+#ifdef DONNER_EDITOR_WGPU
+struct WgpuReadbackStats {
+  int samples = 0;
+  int coloredPixels = 0;
+  int nonBlackPixels = 0;
+  int maxChannel = 0;
+};
+
+WgpuReadbackStats ComputeWgpuReadbackStatsForCssRegion(const svg::RendererBitmap& bitmap,
+                                                       double cssX, double cssY, double cssWidth,
+                                                       double cssHeight) {
+  if (bitmap.empty() || bitmap.rowBytes == 0u) {
+    return WgpuReadbackStats{};
+  }
+
+  const double displayScale = CurrentDisplayScale();
+  const int x0 = std::max(0, static_cast<int>(std::floor(cssX * displayScale)));
+  const int y0 = std::max(0, static_cast<int>(std::floor(cssY * displayScale)));
+  const int x1 =
+      std::min(bitmap.dimensions.x, static_cast<int>(std::ceil((cssX + cssWidth) * displayScale)));
+  const int y1 =
+      std::min(bitmap.dimensions.y, static_cast<int>(std::ceil((cssY + cssHeight) * displayScale)));
+  if (x1 <= x0 || y1 <= y0) {
+    return WgpuReadbackStats{};
+  }
+
+  WgpuReadbackStats stats;
+  for (int y = y0; y < y1; ++y) {
+    const uint8_t* row = bitmap.pixels.data() + static_cast<std::size_t>(y) * bitmap.rowBytes;
+    for (int x = x0; x < x1; ++x) {
+      const uint8_t* pixel = row + static_cast<std::size_t>(x) * 4u;
+      const int red = pixel[0];
+      const int green = pixel[1];
+      const int blue = pixel[2];
+      const int alpha = pixel[3];
+      const int maxRgb = std::max({red, green, blue});
+      const int minRgb = std::min({red, green, blue});
+      ++stats.samples;
+      stats.maxChannel = std::max(stats.maxChannel, maxRgb);
+      if (alpha > 0 && maxRgb > 12) {
+        ++stats.nonBlackPixels;
+      }
+      if (alpha > 0 && maxRgb > 50 && maxRgb - minRgb > 20) {
+        ++stats.coloredPixels;
+      }
+    }
+  }
+  return stats;
+}
+
+void PublishWgpuReadbackStatsForSmokeTests(const svg::RendererBitmap& bitmap) {
+  const double cssWidth = static_cast<double>(CanvasCssWidth());
+  const double cssHeight = static_cast<double>(CanvasCssHeight());
+
+  double renderPaneX = 560.0 + 20.0;
+  double renderPaneWidth = cssWidth - 560.0 - 420.0 - 40.0;
+  if (renderPaneWidth <= 0.0) {
+    renderPaneX = cssWidth * 0.35;
+    renderPaneWidth = cssWidth * 0.3;
+  }
+
+  const WgpuReadbackStats renderStats = ComputeWgpuReadbackStatsForCssRegion(
+      bitmap, renderPaneX, 80.0, renderPaneWidth, std::max(1.0, cssHeight - 220.0));
+  const WgpuReadbackStats layerStats = ComputeWgpuReadbackStatsForCssRegion(
+      bitmap, cssWidth - 420.0 + 8.0, cssHeight * 0.72, 90.0, cssHeight * 0.24);
+  PublishWgpuReadbackStats(renderStats.samples, renderStats.coloredPixels,
+                           renderStats.nonBlackPixels, renderStats.maxChannel, layerStats.samples,
+                           layerStats.coloredPixels, layerStats.nonBlackPixels,
+                           layerStats.maxChannel);
+}
+#endif
 #endif
 
 }  // namespace
@@ -316,6 +447,9 @@ EditorWindow::EditorWindow(EditorWindowOptions options) : options_(std::move(opt
   // produces "Hint ... not currently supported on this platform"
   // warnings at startup.
   glfwWindowHint(GLFW_SCALE_FRAMEBUFFER, GLFW_TRUE);
+#ifdef DONNER_EDITOR_WGPU
+  glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+#endif
   emscripten_glfw_set_next_window_canvas_selector("#canvas");
 #elif defined(DONNER_EDITOR_WGPU)
   glfwWindowHint(GLFW_VISIBLE, options_.visible ? GLFW_TRUE : GLFW_FALSE);
@@ -364,9 +498,13 @@ EditorWindow::EditorWindow(EditorWindowOptions options) : options_(std::move(opt
   }
 
 #ifdef __EMSCRIPTEN__
+#ifndef DONNER_EDITOR_WGPU
   glfwMakeContextCurrent(window_);
+#endif
   emscripten_glfw_make_canvas_resizable(window_, "window", nullptr);
-#elif defined(DONNER_EDITOR_WGPU)
+#endif
+
+#ifdef DONNER_EDITOR_WGPU
   wgpuState_ = std::make_unique<WgpuState>();
   wgpuState_->instance = wgpu::createInstance();
   if (!wgpuState_->instance) {
@@ -376,7 +514,7 @@ EditorWindow::EditorWindow(EditorWindowOptions options) : options_(std::move(opt
     glfwTerminate();
     return;
   }
-  wgpuState_->surface = CreateWgpuSurfaceFromGlfwWindow(wgpuState_->instance, window_);
+  wgpuState_->surface = CreateEditorWgpuSurface(wgpuState_->instance, window_);
   if (!wgpuState_->surface) {
     std::fprintf(stderr, "EditorWindow: failed to create WebGPU surface\n");
     glfwDestroyWindow(window_);
@@ -412,7 +550,11 @@ EditorWindow::EditorWindow(EditorWindowOptions options) : options_(std::move(opt
   wgpu::SurfaceCapabilities caps;
   wgpuState_->surface.getCapabilities(wgpuState_->adapter, &caps);
   wgpuState_->surfaceFormat = ChooseSurfaceFormat(caps);
-  wgpuState_->surfaceUsage = SurfaceUsageForCapabilities(caps, options_.enableFramebufferReadback);
+  bool enableSurfaceReadback = options_.enableFramebufferReadback;
+#if defined(__EMSCRIPTEN__) && defined(DONNER_EDITOR_WGPU)
+  enableSurfaceReadback = enableSurfaceReadback || WgpuReadbackStatsEnabled();
+#endif
+  wgpuState_->surfaceUsage = SurfaceUsageForCapabilities(caps, enableSurfaceReadback);
   if (caps.alphaModeCount > 0) {
     wgpuState_->alphaMode = wgpu::CompositeAlphaMode{caps.alphaModes[0]};
   } else {
@@ -422,7 +564,12 @@ EditorWindow::EditorWindow(EditorWindowOptions options) : options_(std::move(opt
 
   int surfaceWidth = 0;
   int surfaceHeight = 0;
+#ifdef __EMSCRIPTEN__
+  surfaceWidth = CanvasPixelWidth();
+  surfaceHeight = CanvasPixelHeight();
+#else
   glfwGetFramebufferSize(window_, &surfaceWidth, &surfaceHeight);
+#endif
   surfaceWidth = std::max(1, surfaceWidth);
   surfaceHeight = std::max(1, surfaceHeight);
   wgpu::SurfaceConfiguration surfaceConfig(wgpu::Default);
@@ -440,7 +587,9 @@ EditorWindow::EditorWindow(EditorWindowOptions options) : options_(std::move(opt
   geode::GeodeEmbedConfig embedConfig;
   embedConfig.device = wgpuState_->device;
   embedConfig.queue = wgpuState_->queue;
+#ifndef __EMSCRIPTEN__
   embedConfig.adapter = wgpuState_->adapter;
+#endif
   embedConfig.textureFormat = wgpuState_->surfaceFormat;
   wgpuState_->geodeDevice = geode::GeodeDevice::CreateFromExternal(embedConfig);
   if (wgpuState_->geodeDevice == nullptr) {
@@ -452,6 +601,7 @@ EditorWindow::EditorWindow(EditorWindowOptions options) : options_(std::move(opt
     return;
   }
 #else
+#ifndef __EMSCRIPTEN__
   glfwMakeContextCurrent(window_);
   glfwSwapInterval(1);  // vsync
 
@@ -485,6 +635,7 @@ EditorWindow::EditorWindow(EditorWindowOptions options) : options_(std::move(opt
     glfwSetWindowSize(window_, emulatedLogicalWidth, emulatedLogicalHeight);
   }
 #endif
+#endif
 
   // Dear ImGui setup. Matches the canonical example from the imgui docs.
   IMGUI_CHECKVERSION();
@@ -497,11 +648,10 @@ EditorWindow::EditorWindow(EditorWindowOptions options) : options_(std::move(opt
   int logicalWindowHeight = 0;
   glfwGetWindowSize(window_, &logicalWindowWidth, &logicalWindowHeight);
   int framebufferWidth = 0;
-  int framebufferHeight = 0;
 #ifdef __EMSCRIPTEN__
   framebufferWidth = CanvasPixelWidth();
-  framebufferHeight = CanvasPixelHeight();
 #else
+  int framebufferHeight = 0;
   glfwGetFramebufferSize(window_, &framebufferWidth, &framebufferHeight);
 #endif
   if (offscreenScale != 1.0) {
@@ -685,6 +835,16 @@ void EditorWindow::beginFrameImpl(const EditorWindowInputOverride* inputOverride
   ImGui_ImplOpenGL3_NewFrame();
 #endif
   ImGui_ImplGlfw_NewFrame();
+#if defined(__EMSCRIPTEN__) && defined(DONNER_EDITOR_WGPU)
+  {
+    ImGuiIO& io = ImGui::GetIO();
+    const double displayScale = CurrentDisplayScale();
+    io.DisplaySize =
+        ImVec2(static_cast<float>(CanvasCssWidth()), static_cast<float>(CanvasCssHeight()));
+    io.DisplayFramebufferScale =
+        ImVec2(static_cast<float>(displayScale), static_cast<float>(displayScale));
+  }
+#endif
   if (frameDisplayScaleOverride_ > 0.0) {
     // The null platform reports a 1:1 framebuffer/window ratio, so ImGui's GLFW
     // backend just reset DisplayFramebufferScale to 1. Restore the emulated
@@ -729,8 +889,16 @@ void EditorWindow::endFrameImpl(svg::RendererBitmap* readback) {
   glfwGetFramebufferSize(window_, &displayW, &displayH);
 #endif
 #ifdef DONNER_EDITOR_WGPU
-  if (readback != nullptr) {
-    *readback = svg::RendererBitmap{};
+  svg::RendererBitmap smokeTestReadback;
+  svg::RendererBitmap* targetReadback = readback;
+#if defined(__EMSCRIPTEN__) && defined(DONNER_EDITOR_WGPU)
+  const bool publishSmokeReadbackStats = WgpuReadbackStatsEnabled();
+  if (targetReadback == nullptr && publishSmokeReadbackStats) {
+    targetReadback = &smokeTestReadback;
+  }
+#endif
+  if (targetReadback != nullptr) {
+    *targetReadback = svg::RendererBitmap{};
   }
   if (wgpuState_ == nullptr || !wgpuState_->surface || !wgpuState_->device || displayW <= 0 ||
       displayH <= 0) {
@@ -770,8 +938,8 @@ void EditorWindow::endFrameImpl(svg::RendererBitmap* readback) {
 
   donner::geode::ScopedWgpuHandle<wgpu::Texture> target(wgpu::Texture(surfaceTexture.texture));
   SurfacePresentGuard presentGuard(wgpuState_->surface);
-  const bool shouldReadback = readback != nullptr && options_.enableFramebufferReadback &&
-                              SurfaceUsageSupportsReadback(wgpuState_->surfaceUsage);
+  const bool shouldReadback =
+      targetReadback != nullptr && SurfaceUsageSupportsReadback(wgpuState_->surfaceUsage);
   const uint32_t readbackWidth = static_cast<uint32_t>(displayW);
   const uint32_t readbackHeight = static_cast<uint32_t>(displayH);
   const uint32_t readbackBytesPerRow = AlignTextureCopyBytesPerRow(readbackWidth * 4u);
@@ -834,10 +1002,15 @@ void EditorWindow::endFrameImpl(svg::RendererBitmap* readback) {
         readbackBuffer.get().getConstMappedRange(0, readbackBufferSize));
     if (mapped != nullptr) {
       CopyMappedSurfaceToBitmap(mapped, readbackWidth, readbackHeight, readbackBytesPerRow,
-                                wgpuState_->surfaceFormat, readback);
+                                wgpuState_->surfaceFormat, targetReadback);
     }
     readbackBuffer.get().unmap();
   }
+#if defined(__EMSCRIPTEN__) && defined(DONNER_EDITOR_WGPU)
+  if (publishSmokeReadbackStats && targetReadback != nullptr && !targetReadback->empty()) {
+    PublishWgpuReadbackStatsForSmokeTests(*targetReadback);
+  }
+#endif
   presentGuard.present();
 #else
   glViewport(0, 0, displayW, displayH);

--- a/donner/editor/rotate_cursor.svg
+++ b/donner/editor/rotate_cursor.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <g id="rotate-cursor-glyph" transform="rotate(0,16,16)">
+    <g transform="translate(16,16) scale(0.75) translate(-16,-16)">
+      <path
+        d="M 11.5 20.5 C 11.5 15.5 15.5 11.5 20.5 11.5"
+        fill="none"
+        stroke="#ffffff"
+        stroke-width="4.4"
+        stroke-linecap="round"
+        stroke-linejoin="round" />
+      <path
+        d="M 10.7 24.85 Q 11.5 26.2 12.3 24.85 L 15.45 19.5 Q 16.35 18.0 14.6 18.0 H 8.4 Q 6.65 18.0 7.55 19.5 Z"
+        fill="#ffffff" />
+      <path
+        d="M 24.85 10.7 Q 26.2 11.5 24.85 12.3 L 19.5 15.45 Q 18.0 16.35 18.0 14.6 V 8.4 Q 18.0 6.65 19.5 7.55 Z"
+        fill="#ffffff" />
+      <path
+        d="M 11.5 20.5 C 11.5 15.5 15.5 11.5 20.5 11.5"
+        fill="none"
+        stroke="#111111"
+        stroke-width="2.36"
+        stroke-linecap="round"
+        stroke-linejoin="round" />
+      <path d="M 11.5 24.25 L 8.7 19.45 L 14.3 19.45 Z" fill="#111111" />
+      <path d="M 24.25 11.5 L 19.45 8.7 L 19.45 14.3 Z" fill="#111111" />
+    </g>
+  </g>
+</svg>

--- a/donner/editor/tests/AsyncRenderer_tests.cc
+++ b/donner/editor/tests/AsyncRenderer_tests.cc
@@ -40,6 +40,38 @@ bool HasPresentationPayload(const RenderResult::CompositedTile& tile) {
   return !tile.bitmap.empty() || tile.textureSnapshot != nullptr;
 }
 
+TEST(AsyncRendererPresentationPolicyTest, TexturePresentationSkipsFinalSnapshotWhenTilesExist) {
+  const PresentationSnapshotPlan plan = ChoosePresentationSnapshotPlan(
+      /*hasCompositedPreview=*/true, /*requiresTextureSnapshotPresentation=*/true);
+
+  EXPECT_FALSE(plan.captureCpuSnapshot);
+  EXPECT_FALSE(plan.captureTextureSnapshot);
+}
+
+TEST(AsyncRendererPresentationPolicyTest, TexturePresentationCapturesFallbackWhenTilesAreMissing) {
+  const PresentationSnapshotPlan plan = ChoosePresentationSnapshotPlan(
+      /*hasCompositedPreview=*/false, /*requiresTextureSnapshotPresentation=*/true);
+
+  EXPECT_FALSE(plan.captureCpuSnapshot);
+  EXPECT_TRUE(plan.captureTextureSnapshot);
+}
+
+TEST(AsyncRendererPresentationPolicyTest, CpuPresentationCanKeepDiagnosticSnapshotWithTiles) {
+  const PresentationSnapshotPlan plan = ChoosePresentationSnapshotPlan(
+      /*hasCompositedPreview=*/true, /*requiresTextureSnapshotPresentation=*/false);
+
+  EXPECT_TRUE(plan.captureCpuSnapshot);
+  EXPECT_FALSE(plan.captureTextureSnapshot);
+}
+
+TEST(AsyncRendererPresentationPolicyTest, CpuPresentationCapturesFallbackWhenTilesAreMissing) {
+  const PresentationSnapshotPlan plan = ChoosePresentationSnapshotPlan(
+      /*hasCompositedPreview=*/false, /*requiresTextureSnapshotPresentation=*/false);
+
+  EXPECT_TRUE(plan.captureCpuSnapshot);
+  EXPECT_FALSE(plan.captureTextureSnapshot);
+}
+
 constexpr bool kAsyncRendererWallclockTestsEnabled =
 #ifdef DONNER_ASYNC_RENDERER_WALLCLOCK_TESTS
     true;
@@ -626,8 +658,7 @@ TEST(AsyncRendererTest, CompositorResetOnDocumentVersionChange) {
     // After a version change, the compositor should still produce valid composited output.
     ASSERT_TRUE(result->compositedPreview.has_value());
     EXPECT_TRUE(result->compositedPreview->valid());
-    // The CPU snapshot is also always produced for diagnostics.
-    EXPECT_FALSE(result->bitmap.empty());
+    EXPECT_EQ(result->bitmap.empty(), renderer.requiresTextureSnapshotPresentation());
   }
 }
 
@@ -697,8 +728,15 @@ TEST(AsyncRendererTest, ColdRenderWithoutSelectionProducesFullCanvasCompositedTi
   const RenderResult::CompositedTile& tile = result->compositedPreview->tiles.front();
   EXPECT_EQ(tile.kind, RenderResult::CompositedTile::Kind::Segment);
   EXPECT_EQ(tile.id, "full-canvas");
-  EXPECT_FALSE(tile.bitmap.empty());
-  EXPECT_EQ(tile.bitmap.dimensions, Vector2i(64, 64));
+  EXPECT_TRUE(HasPresentationPayload(tile));
+  if (renderer.requiresTextureSnapshotPresentation()) {
+    ASSERT_NE(tile.textureSnapshot, nullptr);
+    EXPECT_TRUE(tile.bitmap.empty());
+    EXPECT_EQ(tile.textureSnapshot->dimensions(), Vector2i(64, 64));
+  } else {
+    EXPECT_FALSE(tile.bitmap.empty());
+    EXPECT_EQ(tile.bitmap.dimensions, Vector2i(64, 64));
+  }
   EXPECT_EQ(tile.bitmapDimsPx, Vector2i(64, 64));
   EXPECT_EQ(tile.rasterCanvasSize, Vector2i(64, 64));
   EXPECT_EQ(tile.canvasOffsetDoc, Vector2d::Zero());
@@ -3065,7 +3103,7 @@ TEST(RenderCoordinatorTest, ImmediateOverlayUploadBypassesDisplayedVersionGate) 
       << "active-drag overlay mode must publish current-frame chrome immediately";
 }
 
-TEST(RenderCoordinatorTest, ActiveDragReusesOverlayForPureTranslation) {
+TEST(RenderCoordinatorTest, ActiveDragRerasterizesOverlayForPureTranslation) {
   svg::Renderer rendererProbe;
   if (!rendererProbe.requiresTextureSnapshotPresentation()) {
     GTEST_SKIP() << "Overlay drag presentation is exercised by the Geode direct-texture path.";
@@ -3109,9 +3147,8 @@ TEST(RenderCoordinatorTest, ActiveDragReusesOverlayForPureTranslation) {
   coordinator.maybeRequestRender(app, selectTool, viewport, textures);
 
   ASSERT_TRUE(coordinator.presentedOverlayDragPreview().has_value());
-  EXPECT_EQ(coordinator.presentedOverlayDragPreview()->translation, Vector2d::Zero())
-      << "Pure translation drags should move the overlay texture at presentation time instead of "
-         "rerasterizing chrome every frame.";
+  EXPECT_EQ(coordinator.presentedOverlayDragPreview()->translation, Vector2d(8.0, 0.0))
+      << "Pure translation drags should rerasterize overlay chrome for the current frame.";
 }
 
 TEST(RenderCoordinatorTest, AffineActiveDragRerasterizesOverlayInsteadOfReusingTextureTransform) {

--- a/donner/editor/tests/AsyncRenderer_tests.cc
+++ b/donner/editor/tests/AsyncRenderer_tests.cc
@@ -1302,6 +1302,8 @@ TEST(AsyncRendererE2ETest, DragOThenSelectEDoesNotAdvanceExistingLayerGeneration
       request.dragPreview = RenderRequest::DragPreview{
           .entity = preview->entity,
           .interactionKind = svg::compositor::InteractionHint::ActiveDrag,
+          .translation = preview->translation,
+          .dragGeneration = preview->dragGeneration,
       };
     } else if (request.selectedEntity != entt::null) {
       request.dragPreview = RenderRequest::DragPreview{
@@ -1473,6 +1475,7 @@ TEST(AsyncRendererE2ETest, BackgroundStickerDragPresentsLiveDeltaFromStaleCache)
       .entity = backgroundEntity,
       .interactionKind = svg::compositor::InteractionHint::ActiveDrag,
       .translation = selectTool.activeDragPreview()->translation,
+      .dragGeneration = selectTool.activeDragPreview()->dragGeneration,
   };
   asyncRenderer.requestRender(request);
 
@@ -1494,6 +1497,7 @@ TEST(AsyncRendererE2ETest, BackgroundStickerDragPresentsLiveDeltaFromStaleCache)
       SelectTool::ActiveDragPreview{
           .entity = result->compositedPreview->representedDragPreview->entity,
           .translation = result->compositedPreview->representedDragPreview->translation,
+          .dragGeneration = result->compositedPreview->representedDragPreview->dragGeneration,
       });
 
   selectTool.onMouseMove(app, Vector2d(312.0, 204.0), /*buttonHeld=*/true);

--- a/donner/editor/tests/AsyncRenderer_tests.cc
+++ b/donner/editor/tests/AsyncRenderer_tests.cc
@@ -1303,6 +1303,7 @@ TEST(AsyncRendererE2ETest, DragOThenSelectEDoesNotAdvanceExistingLayerGeneration
           .entity = preview->entity,
           .interactionKind = svg::compositor::InteractionHint::ActiveDrag,
           .translation = preview->translation,
+          .documentFromCachedDocument = preview->documentFromCachedDocument,
           .dragGeneration = preview->dragGeneration,
       };
     } else if (request.selectedEntity != entt::null) {
@@ -1475,6 +1476,7 @@ TEST(AsyncRendererE2ETest, BackgroundStickerDragPresentsLiveDeltaFromStaleCache)
       .entity = backgroundEntity,
       .interactionKind = svg::compositor::InteractionHint::ActiveDrag,
       .translation = selectTool.activeDragPreview()->translation,
+      .documentFromCachedDocument = selectTool.activeDragPreview()->documentFromCachedDocument,
       .dragGeneration = selectTool.activeDragPreview()->dragGeneration,
   };
   asyncRenderer.requestRender(request);
@@ -3110,6 +3112,54 @@ TEST(RenderCoordinatorTest, ActiveDragReusesOverlayForPureTranslation) {
   EXPECT_EQ(coordinator.presentedOverlayDragPreview()->translation, Vector2d::Zero())
       << "Pure translation drags should move the overlay texture at presentation time instead of "
          "rerasterizing chrome every frame.";
+}
+
+TEST(RenderCoordinatorTest, AffineActiveDragRerasterizesOverlayInsteadOfReusingTextureTransform) {
+  svg::Renderer rendererProbe;
+  if (!rendererProbe.requiresTextureSnapshotPresentation()) {
+    GTEST_SKIP() << "Overlay drag presentation is exercised by the Geode direct-texture path.";
+  }
+
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+      <rect id="target" x="8" y="8" width="16" height="16" fill="red"/>
+    </svg>
+  )svg"));
+  app.document().document().setCanvasSize(64, 64);
+  auto target = app.document().document().querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  app.setSelection(*target);
+
+  ViewportState viewport;
+  viewport.paneSize = Vector2d(64.0, 64.0);
+  viewport.documentViewBox = Box2d::FromXYWH(0.0, 0.0, 64.0, 64.0);
+  viewport.devicePixelRatio = 1.0;
+
+  SelectTool selectTool;
+  selectTool.onMouseDown(app, Vector2d(24.0, 24.0), MouseModifiers{});
+  ASSERT_TRUE(selectTool.activeDragPreview().has_value());
+
+  GlTextureCache textures;
+  RenderCoordinator coordinator;
+  EXPECT_TRUE(coordinator.rasterizeOverlayForCurrentSelection(
+      app, viewport, textures, std::nullopt, RenderCoordinator::OverlayUploadMode::Immediate,
+      selectTool.activeDragPreview()));
+  ASSERT_TRUE(coordinator.presentedOverlayDragPreview().has_value());
+  EXPECT_TRUE(coordinator.presentedOverlayDragPreview()->documentFromCachedDocument.isIdentity());
+
+  selectTool.onMouseMove(app, Vector2d(32.0, 32.0), /*buttonHeld=*/true);
+  ASSERT_TRUE(app.flushFrame());
+  ASSERT_TRUE(selectTool.activeDragPreview().has_value());
+  ASSERT_FALSE(selectTool.activeDragPreview()->documentFromCachedDocument.isTranslation());
+
+  coordinator.maybeRequestRender(app, selectTool, viewport, textures);
+
+  ASSERT_TRUE(coordinator.presentedOverlayDragPreview().has_value());
+  EXPECT_FALSE(
+      coordinator.presentedOverlayDragPreview()->documentFromCachedDocument.isTranslation())
+      << "Affine resize/rotate drags should rerasterize chrome instead of stretching the previous "
+         "overlay texture at presentation time.";
 }
 
 TEST(RenderCoordinatorTest, ImmediateOverlayUploadAllowsEmptyOrFullCanvasContent) {

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -143,6 +143,15 @@ donner_cc_test(
 )
 
 donner_cc_test(
+    name = "rotate_cursor_set_tests",
+    srcs = ["RotateCursorSet_tests.cc"],
+    deps = [
+        "//donner/editor:rotate_cursor_set",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
     name = "source_selection_tests",
     srcs = ["SourceSelection_tests.cc"],
     data = ["//:donner_splash.svg"],

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -134,6 +134,15 @@ donner_cc_test(
 )
 
 donner_cc_test(
+    name = "selection_transform_handles_tests",
+    srcs = ["SelectionTransformHandles_tests.cc"],
+    deps = [
+        "//donner/editor:selection_transform_handles",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
     name = "source_selection_tests",
     srcs = ["SourceSelection_tests.cc"],
     data = ["//:donner_splash.svg"],

--- a/donner/editor/tests/CompositedPresentation_tests.cc
+++ b/donner/editor/tests/CompositedPresentation_tests.cc
@@ -90,7 +90,7 @@ TEST(CompositedPresentationTest, WaitingPhasesAreMutuallyExclusive) {
   EXPECT_FALSE(snapshot.waitingForChromeRefresh);
 }
 
-TEST(CompositedPresentationTest, NeedsCompositedLayerCaptureChecksCacheIdentity) {
+TEST(CompositedPresentationTest, NeedsCompositedLayerCaptureChecksCacheEntityAndCanvas) {
   CompositedPresentation state;
   const SelectTool::ActiveDragPreview active{
       .entity = Entity(7),
@@ -101,7 +101,8 @@ TEST(CompositedPresentationTest, NeedsCompositedLayerCaptureChecksCacheIdentity)
 
   state.noteCachedTextures(Entity(7), /*version=*/3, Vector2i(100, 100));
   EXPECT_FALSE(state.needsCompositedLayerCapture(active, /*currentVersion=*/3, Vector2i(100, 100)));
-  EXPECT_TRUE(state.needsCompositedLayerCapture(active, /*currentVersion=*/4, Vector2i(100, 100)));
+  EXPECT_FALSE(state.needsCompositedLayerCapture(active, /*currentVersion=*/4, Vector2i(100, 100)))
+      << "DOM version changes during drag are presented as affine texture placement.";
   EXPECT_TRUE(state.needsCompositedLayerCapture(active, /*currentVersion=*/3, Vector2i(120, 100)));
 }
 
@@ -251,6 +252,34 @@ TEST(CompositedPresentationTest, MouseUpKeepsSettlingPreviewUntilFullRenderLands
   EXPECT_EQ(state.presentationPreview(std::nullopt)->entity, Entity(7));
   EXPECT_DOUBLE_EQ(state.presentationPreview(std::nullopt)->translation.x, 0.0)
       << "Post-settle preview should fall to the zero-offset cached path.";
+}
+
+TEST(CompositedPresentationTest, MouseUpPreviewContinuesToDrivePresenterBaseline) {
+  CompositedPresentation state;
+  state.noteCachedTextures(Entity(7), /*version=*/3, Vector2i(100, 100));
+
+  SelectTool::ActiveDragPreview preview{
+      .entity = Entity(7),
+      .translation = Vector2d(12.0, 5.0),
+      .dragGeneration = 9,
+  };
+  state.beginSettling(preview, /*targetVersion=*/4);
+
+  const std::optional<SelectTool::ActiveDragPreview> presentationActivePreview =
+      state.activePreviewForPresentation(std::nullopt);
+  ASSERT_TRUE(presentationActivePreview.has_value());
+  EXPECT_EQ(presentationActivePreview->entity, Entity(7));
+  EXPECT_DOUBLE_EQ(presentationActivePreview->translation.x, 12.0);
+  EXPECT_EQ(presentationActivePreview->dragGeneration, 9u);
+
+  const std::optional<SelectTool::ActiveDragPreview> representedPreview =
+      state.presentationPreview(presentationActivePreview);
+  ASSERT_TRUE(representedPreview.has_value());
+  EXPECT_EQ(representedPreview->entity, Entity(7));
+  EXPECT_DOUBLE_EQ(representedPreview->translation.x, 0.0)
+      << "The presenter receives active=settling and represented=cached, so the final mouse-up "
+         "delta remains applied instead of popping back to the cached position.";
+  EXPECT_EQ(representedPreview->dragGeneration, presentationActivePreview->dragGeneration);
 }
 
 TEST(CompositedPresentationTest, SelectionChangeClearsSettlingState) {

--- a/donner/editor/tests/CompositedPresentation_tests.cc
+++ b/donner/editor/tests/CompositedPresentation_tests.cc
@@ -169,16 +169,42 @@ TEST(CompositedPresentationTest, ActiveDragUsesLandedRepresentedTranslation) {
                            SelectTool::ActiveDragPreview{
                                .entity = Entity(7),
                                .translation = Vector2d(3.0, 1.0),
+                               .dragGeneration = 4,
                            });
 
   SelectTool::ActiveDragPreview active{
       .entity = Entity(7),
       .translation = Vector2d(5.0, 2.0),
+      .dragGeneration = 4,
   };
   ASSERT_TRUE(state.presentationPreview(active).has_value());
   EXPECT_EQ(state.presentationPreview(active)->entity, Entity(7));
   EXPECT_DOUBLE_EQ(state.presentationPreview(active)->translation.x, 3.0);
   EXPECT_DOUBLE_EQ(state.presentationPreview(active)->translation.y, 1.0);
+  EXPECT_TRUE(Snapshot(state).hasCachedTextures);
+}
+
+TEST(CompositedPresentationTest, ActiveRedragIgnoresPreviousGestureRepresentedTranslation) {
+  CompositedPresentation state;
+  state.noteCachedTextures(Entity(7), /*version=*/4, Vector2i(100, 100),
+                           SelectTool::ActiveDragPreview{
+                               .entity = Entity(7),
+                               .translation = Vector2d(-122.0, -86.0),
+                               .dragGeneration = 4,
+                           });
+
+  SelectTool::ActiveDragPreview redrag{
+      .entity = Entity(7),
+      .translation = Vector2d::Zero(),
+      .dragGeneration = 5,
+  };
+  const std::optional<SelectTool::ActiveDragPreview> displayed = state.presentationPreview(redrag);
+
+  ASSERT_TRUE(displayed.has_value());
+  EXPECT_EQ(displayed->entity, Entity(7));
+  EXPECT_EQ(displayed->translation, Vector2d::Zero())
+      << "A new same-entity drag must not subtract the previous gesture's settled offset.";
+  EXPECT_EQ(displayed->dragGeneration, redrag.dragGeneration);
   EXPECT_TRUE(Snapshot(state).hasCachedTextures);
 }
 

--- a/donner/editor/tests/DocumentSyncController_tests.cc
+++ b/donner/editor/tests/DocumentSyncController_tests.cc
@@ -24,6 +24,12 @@ constexpr std::string_view kNonCanonicalTransformSvg =
          <rect id="r1" x="10" y="10" width="20" height="20" transform="translate(10, 0)" fill="red"/>
        </svg>)svg";
 
+constexpr std::string_view kTwoRectSvg =
+    R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+         <rect id="r1" x="0" y="0" width="10" height="10"/>
+         <rect id="r2" x="20" y="0" width="10" height="10"/>
+       </svg>)";
+
 class DocumentSyncControllerTest : public ::testing::Test {
 protected:
   void SetUp() override {
@@ -116,6 +122,44 @@ TEST_F(DocumentSyncControllerTest, SourceBackedDragWritebackMirrorsWithoutTextCh
   EXPECT_EQ(textEditor_.getText(), app_.document().document().source());
   EXPECT_FALSE(textEditor_.isTextChanged());
   EXPECT_TRUE(app_.document().queue().empty());
+}
+
+TEST_F(DocumentSyncControllerTest, AppTransformWritebacksDrainAllQueuedEntries) {
+  EditorApp app;
+  TextEditor textEditor;
+  SelectTool tool;
+  DocumentSyncController controller{std::string(kTwoRectSvg)};
+
+  ASSERT_TRUE(app.loadFromString(kTwoRectSvg));
+  app.setCurrentFilePath("test.svg");
+  app.setCleanSourceText(kTwoRectSvg);
+  textEditor.setText(kTwoRectSvg);
+  textEditor.resetTextChanged();
+
+  auto r1 = app.document().document().querySelector("#r1");
+  auto r2 = app.document().document().querySelector("#r2");
+  ASSERT_TRUE(r1.has_value());
+  ASSERT_TRUE(r2.has_value());
+  auto r1Target = captureAttributeWritebackTarget(*r1);
+  auto r2Target = captureAttributeWritebackTarget(*r2);
+  ASSERT_TRUE(r1Target.has_value());
+  ASSERT_TRUE(r2Target.has_value());
+
+  app.enqueueTransformWriteback(EditorApp::CompletedTransformWriteback{
+      .target = *r1Target, .transform = Transform2d::Translate(Vector2d(5.0, 0.0))});
+  app.enqueueTransformWriteback(EditorApp::CompletedTransformWriteback{
+      .target = *r2Target, .transform = Transform2d::Translate(Vector2d(11.0, 0.0))});
+
+  controller.applyPendingWritebacks(app, tool, textEditor);
+
+  EXPECT_EQ(textEditor.getText(), app.document().document().source());
+  EXPECT_FALSE(textEditor.isTextChanged());
+  r1 = app.document().document().querySelector("#r1");
+  r2 = app.document().document().querySelector("#r2");
+  ASSERT_TRUE(r1.has_value());
+  ASSERT_TRUE(r2.has_value());
+  EXPECT_EQ(r1->getAttribute("transform"), std::optional<RcString>(RcString("translate(5)")));
+  EXPECT_EQ(r2->getAttribute("transform"), std::optional<RcString>(RcString("translate(11)")));
 }
 
 TEST_F(DocumentSyncControllerTest, SourceBackedDeleteWritebackMirrorsFlushDeltaWithoutTextEcho) {

--- a/donner/editor/tests/DragReleasePopBack_tests.cc
+++ b/donner/editor/tests/DragReleasePopBack_tests.cc
@@ -414,7 +414,11 @@ TEST(DragReleasePopBackTest, CpuSnapshotShowsCorrectImageAfterSettling) {
   // the tile path.
   CompositedPresentation state;
   state.noteCachedTextures(entity, 1, Vector2i(200, 100));
-  state.beginSettling(SelectTool::ActiveDragPreview{entity, Vector2d(100, 0)}, 2);
+  state.beginSettling(
+      SelectTool::ActiveDragPreview{.entity = entity,
+                                    .translation = Vector2d(100, 0),
+                                    .documentFromCachedDocument = Transform2d::Translate(100, 0)},
+      2);
   state.noteFullRenderLanded(/*landedVersion=*/2);
 
   EXPECT_TRUE(Snapshot(state).hasCachedTextures);

--- a/donner/editor/tests/EditorLayerStress_tests.cc
+++ b/donner/editor/tests/EditorLayerStress_tests.cc
@@ -151,6 +151,8 @@ std::optional<RenderResult> RequestRenderAndWait(AsyncRenderer& asyncRenderer,
       request.dragPreview = RenderRequest::DragPreview{
           .entity = preview->entity,
           .interactionKind = svg::compositor::InteractionHint::ActiveDrag,
+          .translation = preview->translation,
+          .dragGeneration = preview->dragGeneration,
       };
     }
     return request;
@@ -281,6 +283,8 @@ protected:
       request.dragPreview = RenderRequest::DragPreview{
           .entity = preview->entity,
           .interactionKind = svg::compositor::InteractionHint::ActiveDrag,
+          .translation = preview->translation,
+          .dragGeneration = preview->dragGeneration,
       };
     }
     return request;

--- a/donner/editor/tests/EditorLayerStress_tests.cc
+++ b/donner/editor/tests/EditorLayerStress_tests.cc
@@ -152,6 +152,7 @@ std::optional<RenderResult> RequestRenderAndWait(AsyncRenderer& asyncRenderer,
           .entity = preview->entity,
           .interactionKind = svg::compositor::InteractionHint::ActiveDrag,
           .translation = preview->translation,
+          .documentFromCachedDocument = preview->documentFromCachedDocument,
           .dragGeneration = preview->dragGeneration,
       };
     }
@@ -284,6 +285,7 @@ protected:
           .entity = preview->entity,
           .interactionKind = svg::compositor::InteractionHint::ActiveDrag,
           .translation = preview->translation,
+          .documentFromCachedDocument = preview->documentFromCachedDocument,
           .dragGeneration = preview->dragGeneration,
       };
     }

--- a/donner/editor/tests/EditorWindow_tests.cc
+++ b/donner/editor/tests/EditorWindow_tests.cc
@@ -338,6 +338,51 @@ TEST(EditorWindowTest, WgpuPresentsGeodePremultipliedTextureWithoutDarkening) {
   ImGui_ImplWGPU_RemoveTexture(textureId);
 }
 
+TEST(EditorWindowTest, WgpuPresentsUploadedStraightAlphaBitmapWithStraightBlend) {
+  EditorWindow window(EditorWindowOptions{
+      .title = "Straight Alpha WGPU Bitmap Upload Test",
+      .initialWidth = 96,
+      .initialHeight = 96,
+      .visible = false,
+      .clearColor = {0.0f, 0.0f, 0.0f, 1.0f},
+      .enableFramebufferReadback = true,
+  });
+  if (!window.valid() || window.geodeDevice() == nullptr) {
+    GTEST_SKIP() << "WebGPU editor window is unavailable on this host";
+  }
+
+  svg::RendererBitmap bitmap;
+  bitmap.dimensions = Vector2i(32, 32);
+  bitmap.rowBytes = static_cast<std::size_t>(bitmap.dimensions.x) * 4u;
+  bitmap.alphaType = svg::AlphaType::Unpremultiplied;
+  bitmap.pixels.resize(bitmap.rowBytes * static_cast<std::size_t>(bitmap.dimensions.y));
+  for (std::size_t offset = 0; offset + 3 < bitmap.pixels.size(); offset += 4u) {
+    bitmap.pixels[offset + 0] = 255u;
+    bitmap.pixels[offset + 1] = 0u;
+    bitmap.pixels[offset + 2] = 0u;
+    bitmap.pixels[offset + 3] = 128u;
+  }
+
+  GlTextureCache textures(window.geodeDevice());
+  textures.initialize();
+  textures.uploadOverlay(bitmap);
+  ASSERT_NE(textures.overlayTexture(), 0);
+
+  window.beginFrame();
+  ImGui::GetBackgroundDrawList()->AddImage(textures.overlayTexture(), ImVec2(16.0f, 16.0f),
+                                           ImVec2(48.0f, 48.0f));
+  const svg::RendererBitmap actual = window.endFrameAndReadPixels();
+
+  ASSERT_FALSE(actual.empty());
+  const std::array<std::uint8_t, 4> center = PixelAt(actual, 32, 32);
+  EXPECT_NEAR(static_cast<int>(center[0]), 128, 3)
+      << "CPU bitmap uploads are straight-alpha RGBA; registering them as premultiplied makes "
+         "the WGPU presentation path skip the required source-alpha multiply.";
+  EXPECT_LE(center[1], 3);
+  EXPECT_LE(center[2], 3);
+  EXPECT_EQ(center[3], 255);
+}
+
 TEST(EditorWindowTest, WgpuPremultipliedTextureSurvivesOnePresentationOwnerRetiring) {
   EditorWindow window(EditorWindowOptions{
       .title = "Shared Premultiplied WGPU Texture Ownership Test",

--- a/donner/editor/tests/FilterDragReproTestUtils.cc
+++ b/donner/editor/tests/FilterDragReproTestUtils.cc
@@ -128,6 +128,7 @@ std::optional<double> DrainOneRender(AsyncRenderer& asyncRenderer, svg::Renderer
         .entity = preview->entity,
         .interactionKind = svg::compositor::InteractionHint::ActiveDrag,
         .translation = preview->translation,
+        .documentFromCachedDocument = preview->documentFromCachedDocument,
         .dragGeneration = preview->dragGeneration,
     };
   } else if (request.selectedEntity != entt::null) {

--- a/donner/editor/tests/FilterDragReproTestUtils.cc
+++ b/donner/editor/tests/FilterDragReproTestUtils.cc
@@ -127,6 +127,8 @@ std::optional<double> DrainOneRender(AsyncRenderer& asyncRenderer, svg::Renderer
     request.dragPreview = RenderRequest::DragPreview{
         .entity = preview->entity,
         .interactionKind = svg::compositor::InteractionHint::ActiveDrag,
+        .translation = preview->translation,
+        .dragGeneration = preview->dragGeneration,
     };
   } else if (request.selectedEntity != entt::null) {
     request.dragPreview = RenderRequest::DragPreview{

--- a/donner/editor/tests/GlRnrReplay_tests.cc
+++ b/donner/editor/tests/GlRnrReplay_tests.cc
@@ -266,7 +266,17 @@ TEST(GlRnrReplayTest, ClickAfterZoomBeforeRerasterSelectsNewTarget) {
       << "stale compositor status persisted through the bounded replay window";
 }
 
-TEST(GlRnrReplayTest, SecondDragActiveFrameMatchesMouseUpFrame) {
+// TODO(#601): Re-enable once the multi-thread determinism test framework lands.
+// This compares the active-drag frame against the mouse-up frame, but `pace=true`
+// lets the async render worker land between the two frames nondeterministically
+// (chronically flaky on CI across all branches). Making the replay deterministic
+// further showed the residual diff is the *selection chrome* (the active-drag
+// transform-preview bounding box vs the settled committed box), which changes
+// intentionally after the drag settles — so pixel-identity including chrome is
+// not a true invariant. The content "no-jump" invariant for this recording is
+// already covered deterministically by
+// `RnrReplayTest.FilterPostDragJumpReplayMatchesGroundTruth`.
+TEST(GlRnrReplayTest, DISABLED_SecondDragActiveFrameMatchesMouseUpFrame) {
   constexpr std::string_view kRnrPath = "donner/editor/tests/filter_post_drag_jump.rnr";
   const std::filesystem::path rnrPath = RunfilePath(kRnrPath);
   std::optional<repro::ReproFile> reproFile = repro::ReadReproFile(rnrPath);
@@ -305,7 +315,16 @@ TEST(GlRnrReplayTest, SecondDragActiveFrameMatchesMouseUpFrame) {
                                tests::PixelmatchIdentityParams());
 }
 
-TEST(GlRnrReplayTest, ZoomOutDragDoesNotPublishNewOverlayOverStaleSplitTiles) {
+// TODO(#601): Re-enable once the multi-thread determinism test framework lands.
+// The hard precondition `HasStaleSplitTiles(*guarded)` at frame 146 requires the
+// async render worker to still be several frames behind on the zoom re-raster — a
+// `pace=true` wall-clock race that is chronically flaky on CI (false ~50% of the
+// time, including on `main`). The guard invariant under test
+// (`ShouldUploadImmediateOverlayForPresentedTiles` rejecting stale split-tile
+// epochs) is already covered deterministically by `RenderCoordinatorTest`'s
+// `ImmediateOverlayUploadRequiresCurrentSplitCanvasEpoch` /
+// `SplitPreviewFromStaleCanvasEpochIsRejected` in AsyncRenderer_tests.cc.
+TEST(GlRnrReplayTest, DISABLED_ZoomOutDragDoesNotPublishNewOverlayOverStaleSplitTiles) {
   constexpr std::string_view kRnrPath = "zoom-out-drag-jump.rnr";
   constexpr std::uint64_t kBeforeFrame = 145;
   constexpr std::uint64_t kGuardedFrame = 146;

--- a/donner/editor/tests/OverlayRenderer_tests.cc
+++ b/donner/editor/tests/OverlayRenderer_tests.cc
@@ -11,6 +11,8 @@
 namespace donner::editor {
 namespace {
 
+constexpr double kPi = 3.14159265358979323846;
+
 constexpr std::string_view kTrivialSvg =
     R"(<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
          <rect id="r1" x="20" y="30" width="40" height="50" fill="red"/>
@@ -125,6 +127,95 @@ TEST(OverlayRendererTest, OverlayRendersIntoStandaloneRendererFrame) {
   }
   EXPECT_TRUE(foundOpaquePixel) << "Overlay bitmap is completely transparent — chrome was "
                                    "never drawn";
+}
+
+TEST(OverlayRendererTest, DrawsWhiteCornerHandlesWithSelectionStroke) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kTrivialSvg));
+  app.document().document().setCanvasSize(200, 200);
+
+  auto rect = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(rect.has_value());
+  app.setSelection(*rect);
+
+  svg::Renderer overlayRenderer;
+  svg::RenderViewport viewport;
+  viewport.size = Vector2d(200.0, 200.0);
+  viewport.devicePixelRatio = 1.0;
+  overlayRenderer.beginFrame(viewport);
+
+  const Transform2d canvasFromDoc = app.document().document().canvasFromDocumentTransform();
+  OverlayRenderer::drawChromeWithTransform(overlayRenderer, app.selectedElement(), canvasFromDoc);
+  overlayRenderer.endFrame();
+
+  const auto bitmap = overlayRenderer.takeSnapshot();
+  ASSERT_FALSE(bitmap.empty());
+
+  const auto pixelAt = [&](int x, int y, int channel) -> std::uint8_t {
+    const std::uint8_t* row = bitmap.pixels.data() + y * bitmap.rowBytes;
+    return row[x * 4 + channel];
+  };
+
+  // Top-left selection corner is also the center of the top-left handle.
+  EXPECT_GT(pixelAt(20, 30, 0), 220);
+  EXPECT_GT(pixelAt(20, 30, 1), 220);
+  EXPECT_GT(pixelAt(20, 30, 2), 220);
+  EXPECT_GT(pixelAt(20, 30, 3), 220);
+
+  // At least one pixel on the handle border should carry the cyan selection
+  // stroke color. Exact coverage varies slightly with rasterizer AA.
+  bool foundCyanBorderPixel = false;
+  for (int y = 24; y <= 36; ++y) {
+    for (int x = 14; x <= 26; ++x) {
+      const bool onBorder = x <= 16 || x >= 24 || y <= 26 || y >= 34;
+      if (!onBorder) {
+        continue;
+      }
+
+      if (pixelAt(x, y, 0) < 120 && pixelAt(x, y, 1) > 130 && pixelAt(x, y, 2) > 170 &&
+          pixelAt(x, y, 3) > 120) {
+        foundCyanBorderPixel = true;
+      }
+    }
+  }
+  EXPECT_TRUE(foundCyanBorderPixel);
+}
+
+TEST(OverlayRendererTest, ActiveRotationUsesOrientedBoundsUntilGestureEnds) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kTrivialSvg));
+  app.document().document().setCanvasSize(200, 200);
+
+  auto rect = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(rect.has_value());
+  app.setSelection(*rect);
+
+  const Transform2d canvasFromDoc = app.document().document().canvasFromDocumentTransform();
+  const Box2d startBounds = Box2d::FromXYWH(20.0, 30.0, 40.0, 50.0);
+  const Vector2d center(40.0, 55.0);
+  const Transform2d rotatedDocumentFromStartDocument = Transform2d::Translate(-center) *
+                                                       Transform2d::Rotate(kPi / 2.0) *
+                                                       Transform2d::Translate(center);
+
+  const SelectionChromeSnapshot activeSnapshot = OverlayRenderer::captureChromeSnapshot(
+      std::span<const svg::SVGElement>(app.selectedElements()), std::nullopt, canvasFromDoc,
+      SelectionChromeBoundsPreview{
+          .startBoundsDoc = startBounds,
+          .documentFromStartDocument = rotatedDocumentFromStartDocument,
+      });
+
+  ASSERT_TRUE(activeSnapshot.orientedBoundsDoc.has_value());
+  ASSERT_EQ(activeSnapshot.handleBoxesDoc.size(), 4u);
+  const Vector2d expectedTopLeft =
+      rotatedDocumentFromStartDocument.transformPosition(startBounds.topLeft);
+  EXPECT_NEAR(activeSnapshot.orientedBoundsDoc->cornersDoc[0].x, expectedTopLeft.x, 1e-6);
+  EXPECT_NEAR(activeSnapshot.orientedBoundsDoc->cornersDoc[0].y, expectedTopLeft.y, 1e-6);
+
+  const SelectionChromeSnapshot settledSnapshot = OverlayRenderer::captureChromeSnapshot(
+      std::span<const svg::SVGElement>(app.selectedElements()), std::nullopt, canvasFromDoc);
+  EXPECT_FALSE(settledSnapshot.orientedBoundsDoc.has_value());
+  ASSERT_EQ(settledSnapshot.aabbsDoc.size(), 1u);
+  EXPECT_EQ(settledSnapshot.aabbsDoc.front(), startBounds);
 }
 
 // Calling the overlay-only render path repeatedly (the click→reselect
@@ -331,6 +422,46 @@ TEST(OverlayRendererTest, PathOutlineDrawnAtTransformedLocationNotInverted) {
   EXPECT_EQ(alphaAt(0, 10), 0)
       << "Pixel at the inverted-translate location is non-empty — overlay is drawing "
          "the path at the sign-flipped transform location.";
+}
+
+TEST(OverlayRendererTest, PathOutlineStrokeDoesNotInheritElementScale) {
+  constexpr std::string_view kScaledInternalLineSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+              <path id="scaled" d="M 5 5 L 30 30 M 5 15 L 30 15"
+                    fill="none" stroke="red" stroke-width="1"
+                    transform="scale(6)"/>
+            </svg>)svg";
+
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kScaledInternalLineSvg));
+  app.document().document().setCanvasSize(200, 200);
+
+  auto scaledPath = app.document().document().querySelector("#scaled");
+  ASSERT_TRUE(scaledPath.has_value());
+  app.setSelection(*scaledPath);
+
+  svg::Renderer overlayRenderer;
+  svg::RenderViewport viewport;
+  viewport.size = Vector2d(200.0, 200.0);
+  viewport.devicePixelRatio = 1.0;
+  overlayRenderer.beginFrame(viewport);
+
+  const Transform2d canvasFromDoc = app.document().document().canvasFromDocumentTransform();
+  OverlayRenderer::drawChromeWithTransform(overlayRenderer, app.selectedElement(), canvasFromDoc);
+  overlayRenderer.endFrame();
+
+  const auto bitmap = overlayRenderer.takeSnapshot();
+  ASSERT_FALSE(bitmap.empty());
+
+  const auto alphaAt = [&](int x, int y) -> std::uint8_t {
+    const std::uint8_t* row = bitmap.pixels.data() + y * bitmap.rowBytes;
+    return row[x * 4 + 3];
+  };
+
+  EXPECT_GT(alphaAt(60, 90), 0) << "scaled horizontal path outline should be visible";
+  EXPECT_EQ(alphaAt(60, 92), 0)
+      << "selection path chrome stroke should remain one screen pixel wide; it must not "
+         "be scaled by the selected element's transform";
 }
 
 // ---------------------------------------------------------------------------

--- a/donner/editor/tests/PresentationRenderScheduler_tests.cc
+++ b/donner/editor/tests/PresentationRenderScheduler_tests.cc
@@ -77,6 +77,30 @@ TEST(PresentationRenderSchedulerTest, ActiveDragWithStaleCacheRequestsDragCaptur
   EXPECT_EQ(decision.dragPreview->dragGeneration, 9u);
 }
 
+TEST(PresentationRenderSchedulerTest, ActiveDragWithMatchingCacheDoesNotUploadAgain) {
+  PresentationRenderScheduler scheduler;
+  CompositedPresentation presentation;
+
+  const PresentationRenderScheduleDecision warm =
+      scheduler.evaluate(presentation, Input(Entity(7), /*version=*/1));
+  scheduler.noteRenderCompleted(warm.currentVersion, warm.currentCanvasSize);
+  presentation.noteCachedTextures(Entity(7), /*version=*/1, kCanvasSize);
+
+  const SelectTool::ActiveDragPreview activeDrag{
+      .entity = Entity(7),
+      .translation = Vector2d(9.0, 0.0),
+      .dragGeneration = 14,
+  };
+  const PresentationRenderScheduleDecision decision =
+      scheduler.evaluate(presentation, Input(Entity(7), /*version=*/8, activeDrag));
+
+  EXPECT_FALSE(decision.shouldRequestRender())
+      << "Active drag should transform cached promoted textures in the presenter; the DOM "
+         "version changes every mouse move and must not trigger a new bitmap upload.";
+  EXPECT_FALSE(decision.needsCompositedLayerCapture);
+  EXPECT_FALSE(decision.needsRegularRender);
+}
+
 TEST(PresentationRenderSchedulerTest, SettledSelectionRefreshRequestsSelectionHint) {
   PresentationRenderScheduler scheduler;
   CompositedPresentation presentation;

--- a/donner/editor/tests/PresentationRenderScheduler_tests.cc
+++ b/donner/editor/tests/PresentationRenderScheduler_tests.cc
@@ -62,6 +62,7 @@ TEST(PresentationRenderSchedulerTest, ActiveDragWithStaleCacheRequestsDragCaptur
   const SelectTool::ActiveDragPreview activeDrag{
       .entity = Entity(7),
       .translation = Vector2d(4.0, 0.0),
+      .dragGeneration = 9,
   };
   const PresentationRenderScheduleDecision decision =
       scheduler.evaluate(presentation, Input(Entity(7), /*version=*/1, activeDrag));
@@ -73,6 +74,7 @@ TEST(PresentationRenderSchedulerTest, ActiveDragWithStaleCacheRequestsDragCaptur
   EXPECT_EQ(decision.dragPreview->entity, Entity(7));
   EXPECT_EQ(decision.dragPreview->interactionKind, svg::compositor::InteractionHint::ActiveDrag);
   EXPECT_EQ(decision.dragPreview->translation, Vector2d(4.0, 0.0));
+  EXPECT_EQ(decision.dragPreview->dragGeneration, 9u);
 }
 
 TEST(PresentationRenderSchedulerTest, SettledSelectionRefreshRequestsSelectionHint) {

--- a/donner/editor/tests/PresentedFrameComposer_tests.cc
+++ b/donner/editor/tests/PresentedFrameComposer_tests.cc
@@ -110,6 +110,59 @@ TEST(PresentedFrameComposerTest, ComputesTileRectFromDocumentGeometry) {
   EXPECT_EQ(rect->effectiveDragTranslationDoc, Vector2d(2.0, 3.0));
 }
 
+TEST(PresentedFrameComposerTest, ComputesTileQuadFromAffineActivePreview) {
+  PresentedFrameTileGeometry tile;
+  tile.canvasOffsetDoc = Vector2d(0.0, 0.0);
+  tile.bitmapDimsDoc = Vector2d(10.0, 10.0);
+  tile.isDragTarget = true;
+
+  const std::optional<PresentedDragBaseline> baseline = PresentedDragBaseline{
+      .entity = Entity{123},
+      .representedDocumentFromCachedDocument = Transform2d(),
+      .activeDocumentFromCachedDocument = Transform2d::Scale(2.0),
+  };
+  const std::optional<PresentedTileQuad> quad =
+      ComputePresentedTileQuad(tile, Transform2d(), baseline);
+
+  ASSERT_TRUE(quad.has_value());
+  EXPECT_EQ(quad->topLeft, Vector2d(0.0, 0.0));
+  EXPECT_EQ(quad->topRight, Vector2d(20.0, 0.0));
+  EXPECT_EQ(quad->bottomRight, Vector2d(20.0, 20.0));
+  EXPECT_EQ(quad->bottomLeft, Vector2d(0.0, 20.0));
+}
+
+TEST(PresentedFrameComposerTest, RepresentedAffineTransformDoesNotDoubleApply) {
+  PresentedFrameTileGeometry tile;
+  tile.canvasOffsetDoc = Vector2d(0.0, 0.0);
+  tile.bitmapDimsDoc = Vector2d(10.0, 10.0);
+  tile.documentFromCachedDocument = Transform2d::Scale(2.0);
+  tile.isDragTarget = true;
+
+  const std::optional<PresentedDragBaseline> baseline = PresentedDragBaseline{
+      .entity = Entity{123},
+      .representedDocumentFromCachedDocument = Transform2d::Scale(2.0),
+      .activeDocumentFromCachedDocument = Transform2d::Scale(2.0),
+  };
+  const std::optional<PresentedTileQuad> quad =
+      ComputePresentedTileQuad(tile, Transform2d(), baseline);
+
+  ASSERT_TRUE(quad.has_value());
+  EXPECT_EQ(quad->bottomRight, Vector2d(20.0, 20.0));
+}
+
+TEST(PresentedFrameComposerTest, OverlayAffineTransformUsesRepresentedToActiveDelta) {
+  const std::optional<PresentedDragBaseline> baseline = PresentedDragBaseline{
+      .entity = Entity{123},
+      .representedDocumentFromCachedDocument = Transform2d::Scale(2.0),
+      .activeDocumentFromCachedDocument = Transform2d::Scale(3.0),
+  };
+
+  const Transform2d documentFromOverlayDocument =
+      ResolvePresentedOverlayDocumentTransform(baseline);
+
+  EXPECT_EQ(documentFromOverlayDocument.transformPosition(Vector2d(2.0, 2.0)), Vector2d(3.0, 3.0));
+}
+
 TEST(PresentedFrameComposerTest, ComputesTileRectFromNonZeroCanvasOrigin) {
   PresentedFrameTileGeometry tile;
   tile.canvasOffsetDoc = Vector2d(12.25, 24.75);

--- a/donner/editor/tests/RnrReplay_tests.cc
+++ b/donner/editor/tests/RnrReplay_tests.cc
@@ -209,6 +209,8 @@ std::optional<RenderResult> RequestRenderAndWait(AsyncRenderer& asyncRenderer,
     request.dragPreview = RenderRequest::DragPreview{
         .entity = preview->entity,
         .interactionKind = svg::compositor::InteractionHint::ActiveDrag,
+        .translation = preview->translation,
+        .dragGeneration = preview->dragGeneration,
     };
   }
 
@@ -594,6 +596,8 @@ protected:
         req.dragPreview = RenderRequest::DragPreview{
             .entity = dragPreview->entity,
             .interactionKind = svg::compositor::InteractionHint::ActiveDrag,
+            .translation = dragPreview->translation,
+            .dragGeneration = dragPreview->dragGeneration,
         };
       } else if (needsCompositedPrewarm && prewarmEntity != entt::null) {
         req.dragPreview = RenderRequest::DragPreview{

--- a/donner/editor/tests/RnrReplay_tests.cc
+++ b/donner/editor/tests/RnrReplay_tests.cc
@@ -103,9 +103,11 @@ void ApplyRecordedViewport(ViewportState& viewport, const repro::ReproViewport& 
                                              recordedViewport.viewBoxW, recordedViewport.viewBoxH);
 }
 
-MouseModifiers DecodeMouseModifiers(int modifierMask) {
+MouseModifiers DecodeMouseModifiers(int modifierMask, double pixelsPerDocUnit = 1.0) {
   MouseModifiers modifiers;
   modifiers.shift = (modifierMask & (1 << 1)) != 0;
+  modifiers.option = (modifierMask & (1 << 2)) != 0;
+  modifiers.pixelsPerDocUnit = pixelsPerDocUnit;
   return modifiers;
 }
 
@@ -210,6 +212,7 @@ std::optional<RenderResult> RequestRenderAndWait(AsyncRenderer& asyncRenderer,
         .entity = preview->entity,
         .interactionKind = svg::compositor::InteractionHint::ActiveDrag,
         .translation = preview->translation,
+        .documentFromCachedDocument = preview->documentFromCachedDocument,
         .dragGeneration = preview->dragGeneration,
     };
   }
@@ -389,7 +392,9 @@ protected:
         switch (event.kind) {
           case repro::ReproEvent::Kind::MouseDown:
             if (event.mouseButton == 0) {
-              selectTool.onMouseDown(app, mouseDoc, DecodeMouseModifiers(frame.modifiers));
+              selectTool.onMouseDown(
+                  app, mouseDoc,
+                  DecodeMouseModifiers(frame.modifiers, viewport.pixelsPerDocUnit()));
               frameNeedsRender = true;
             }
             break;
@@ -415,7 +420,8 @@ protected:
       }
 
       if (nowHeld && leftButtonHeld) {
-        selectTool.onMouseMove(app, mouseDoc, /*buttonHeld=*/true);
+        selectTool.onMouseMove(app, mouseDoc, /*buttonHeld=*/true,
+                               DecodeMouseModifiers(frame.modifiers, viewport.pixelsPerDocUnit()));
         frameNeedsRender = true;
       }
       leftButtonHeld = nowHeld;
@@ -597,6 +603,7 @@ protected:
             .entity = dragPreview->entity,
             .interactionKind = svg::compositor::InteractionHint::ActiveDrag,
             .translation = dragPreview->translation,
+            .documentFromCachedDocument = dragPreview->documentFromCachedDocument,
             .dragGeneration = dragPreview->dragGeneration,
         };
       } else if (needsCompositedPrewarm && prewarmEntity != entt::null) {
@@ -667,7 +674,7 @@ protected:
         if (event.kind == repro::ReproEvent::Kind::MouseDown && event.mouseButton == 0) {
           PendingClick click;
           click.documentPoint = mouseDoc;
-          click.modifiers = DecodeMouseModifiers(frame.modifiers);
+          click.modifiers = DecodeMouseModifiers(frame.modifiers, viewport.pixelsPerDocUnit());
           click.frameIndex = frame.index;
           click.queuedAt = std::chrono::steady_clock::now();
           pendingClick = click;
@@ -713,7 +720,8 @@ protected:
       }
 
       if (nowHeld && leftButtonHeld) {
-        selectTool.onMouseMove(app, mouseDoc, /*buttonHeld=*/true);
+        selectTool.onMouseMove(app, mouseDoc, /*buttonHeld=*/true,
+                               DecodeMouseModifiers(frame.modifiers, viewport.pixelsPerDocUnit()));
       }
       leftButtonHeld = nowHeld;
 

--- a/donner/editor/tests/RotateCursorSet_tests.cc
+++ b/donner/editor/tests/RotateCursorSet_tests.cc
@@ -1,0 +1,47 @@
+#include "donner/editor/RotateCursorSet.h"
+
+#include <cstddef>
+#include <optional>
+
+#include "gtest/gtest.h"
+
+namespace donner::editor {
+namespace {
+
+std::size_t CountNonTransparentPixels(const RotateCursorImage& image) {
+  std::size_t count = 0;
+  for (std::size_t i = 3; i < image.rgba.size(); i += 4) {
+    if (image.rgba[i] != 0) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+TEST(RotateCursorSetTest, RendersSvgCursorImagesForAllCorners) {
+  for (SelectionTransformCorner corner :
+       {SelectionTransformCorner::TopLeft, SelectionTransformCorner::TopRight,
+        SelectionTransformCorner::BottomRight, SelectionTransformCorner::BottomLeft}) {
+    std::optional<RotateCursorImage> image = RenderRotateCursorImage(corner, nullptr);
+    ASSERT_TRUE(image.has_value());
+    EXPECT_EQ(image->width, 32);
+    EXPECT_EQ(image->height, 32);
+    EXPECT_EQ(image->rgba.size(), 32u * 32u * 4u);
+    EXPECT_GT(CountNonTransparentPixels(*image), 80u);
+    EXPECT_LT(CountNonTransparentPixels(*image), 32u * 32u);
+  }
+}
+
+TEST(RotateCursorSetTest, RotatedCornersProduceDifferentBitmaps) {
+  std::optional<RotateCursorImage> topLeft =
+      RenderRotateCursorImage(SelectionTransformCorner::TopLeft, nullptr);
+  std::optional<RotateCursorImage> topRight =
+      RenderRotateCursorImage(SelectionTransformCorner::TopRight, nullptr);
+
+  ASSERT_TRUE(topLeft.has_value());
+  ASSERT_TRUE(topRight.has_value());
+  EXPECT_NE(topLeft->rgba, topRight->rgba);
+}
+
+}  // namespace
+}  // namespace donner::editor

--- a/donner/editor/tests/SelectTool_tests.cc
+++ b/donner/editor/tests/SelectTool_tests.cc
@@ -4,6 +4,7 @@
 
 #include "donner/editor/EditorApp.h"
 #include "donner/editor/SelectionAabb.h"
+#include "donner/svg/SVGGeometryElement.h"
 #include "donner/svg/SVGGraphicsElement.h"
 #include "gtest/gtest.h"
 
@@ -50,6 +51,11 @@ constexpr std::string_view kOverlappingRectsSvg =
          <rect id="front" x="40" y="40" width="50" height="50" fill="blue"/>
        </svg>)";
 
+constexpr std::string_view kResizeRectSvg =
+    R"(<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120">
+         <rect id="target" x="20" y="20" width="40" height="20" fill="red"/>
+       </svg>)";
+
 class SelectToolTest : public ::testing::Test {
 protected:
   void SetUp() override { ASSERT_TRUE(app.loadFromString(kTwoRectsSvg)); }
@@ -66,6 +72,14 @@ protected:
     auto element = app.document().document().querySelector(id);
     EXPECT_TRUE(element.has_value());
     return element->cast<svg::SVGGraphicsElement>().transform();
+  }
+
+  Box2d worldBoundsOf(std::string_view id) {
+    auto element = app.document().document().querySelector(id);
+    EXPECT_TRUE(element.has_value());
+    auto bounds = element->cast<svg::SVGGeometryElement>().worldBounds();
+    EXPECT_TRUE(bounds.has_value());
+    return *bounds;
   }
 
   bool selectionIs(std::string_view id) {
@@ -603,6 +617,25 @@ TEST_F(SelectToolTest, SingleSelectionStaysSingleWhenDragged) {
   EXPECT_NEAR(r2End.data[5] - r2Start.data[5], 0.0, 1e-6);
 }
 
+TEST_F(SelectToolTest, DragAfterScaleTranslatesInDocumentSpace) {
+  auto r1Handle = elementById("#r1").cast<svg::SVGGraphicsElement>();
+  r1Handle.setTransform(Transform2d::Scale(2.0));
+  app.setSelection(elementById("#r1"));
+
+  const Transform2d r1Start = transformOf("#r1");
+
+  tool.onMouseDown(app, Vector2d(40.0, 40.0), MouseModifiers{});
+  tool.onMouseMove(app, Vector2d(70.0, 55.0), /*buttonHeld=*/true);
+  tool.onMouseUp(app, Vector2d(70.0, 55.0));
+  ASSERT_TRUE(app.flushFrame());
+
+  const Transform2d r1End = transformOf("#r1");
+  EXPECT_NEAR(r1End.data[0], 2.0, 1e-6);
+  EXPECT_NEAR(r1End.data[3], 2.0, 1e-6);
+  EXPECT_NEAR(r1End.data[4] - r1Start.data[4], 30.0, 1e-6);
+  EXPECT_NEAR(r1End.data[5] - r1Start.data[5], 15.0, 1e-6);
+}
+
 TEST_F(SelectToolTest, MultiSelectDragPreservesExtraElementTransforms) {
   // Give r2 a prior transform so we can verify its start transform is
   // captured and delta is composed relative to the right starting point.
@@ -942,6 +975,207 @@ TEST_F(SelectToolTest, RedragFastPathDoesNotStealClickFromFrontOverlappingObject
 
   tool.onMouseDown(app, overlapPoint, MouseModifiers{});
   EXPECT_TRUE(selectionIs("#front"));
+}
+
+TEST_F(SelectToolTest, CornerHandleResizesSelectionFromOppositeCorner) {
+  loadSvg(kResizeRectSvg);
+  app.setSelection(elementById("#target"));
+
+  tool.onMouseDown(app, Vector2d(60.0, 40.0), MouseModifiers{});
+  tool.onMouseMove(app, Vector2d(80.0, 50.0), /*buttonHeld=*/true);
+  tool.onMouseUp(app, Vector2d(80.0, 50.0));
+  ASSERT_TRUE(app.flushFrame());
+
+  const Box2d bounds = worldBoundsOf("#target");
+  EXPECT_NEAR(bounds.topLeft.x, 20.0, 1e-6);
+  EXPECT_NEAR(bounds.topLeft.y, 20.0, 1e-6);
+  EXPECT_NEAR(bounds.width(), 60.0, 1e-6);
+  EXPECT_NEAR(bounds.height(), 30.0, 1e-6);
+  ASSERT_TRUE(app.undoTimeline().nextUndoLabel().has_value());
+  EXPECT_EQ(*app.undoTimeline().nextUndoLabel(), "Resize element");
+}
+
+TEST_F(SelectToolTest, ResizeGestureExposesAffinePreview) {
+  loadSvg(kResizeRectSvg);
+  app.setSelection(elementById("#target"));
+
+  tool.onMouseDown(app, Vector2d(60.0, 40.0), MouseModifiers{});
+  tool.onMouseMove(app, Vector2d(80.0, 50.0), /*buttonHeld=*/true);
+
+  const auto preview = tool.activeDragPreview();
+  ASSERT_TRUE(preview.has_value());
+  EXPECT_EQ(preview->entity, elementById("#target").entityHandle().entity());
+  EXPECT_FALSE(preview->documentFromCachedDocument.isTranslation())
+      << "resize preview must carry an affine scale, not just a drag offset";
+
+  const Vector2d anchoredCorner =
+      preview->documentFromCachedDocument.transformPosition(Vector2d(20.0, 20.0));
+  const Vector2d activeCorner =
+      preview->documentFromCachedDocument.transformPosition(Vector2d(60.0, 40.0));
+  EXPECT_NEAR(anchoredCorner.x, 20.0, 1e-6);
+  EXPECT_NEAR(anchoredCorner.y, 20.0, 1e-6);
+  EXPECT_NEAR(activeCorner.x, 80.0, 1e-6);
+  EXPECT_NEAR(activeCorner.y, 50.0, 1e-6);
+
+  tool.onMouseUp(app, Vector2d(80.0, 50.0));
+}
+
+TEST_F(SelectToolTest, ShiftCornerResizePreservesAspectRatio) {
+  loadSvg(kResizeRectSvg);
+  app.setSelection(elementById("#target"));
+
+  MouseModifiers modifiers;
+  modifiers.shift = true;
+  tool.onMouseDown(app, Vector2d(60.0, 40.0), modifiers);
+  tool.onMouseMove(app, Vector2d(80.0, 45.0), /*buttonHeld=*/true, modifiers);
+  tool.onMouseUp(app, Vector2d(80.0, 45.0));
+  ASSERT_TRUE(app.flushFrame());
+
+  const Box2d bounds = worldBoundsOf("#target");
+  EXPECT_NEAR(bounds.width(), 60.0, 1e-6);
+  EXPECT_NEAR(bounds.height(), 30.0, 1e-6);
+}
+
+TEST_F(SelectToolTest, OptionCornerResizeKeepsCenterFixed) {
+  loadSvg(kResizeRectSvg);
+  app.setSelection(elementById("#target"));
+
+  MouseModifiers modifiers;
+  modifiers.option = true;
+  tool.onMouseDown(app, Vector2d(60.0, 40.0), modifiers);
+  tool.onMouseMove(app, Vector2d(80.0, 50.0), /*buttonHeld=*/true, modifiers);
+  tool.onMouseUp(app, Vector2d(80.0, 50.0));
+  ASSERT_TRUE(app.flushFrame());
+
+  const Box2d bounds = worldBoundsOf("#target");
+  const Vector2d center = (bounds.topLeft + bounds.bottomRight) * 0.5;
+  EXPECT_NEAR(center.x, 40.0, 1e-6);
+  EXPECT_NEAR(center.y, 30.0, 1e-6);
+  EXPECT_NEAR(bounds.width(), 80.0, 1e-6);
+  EXPECT_NEAR(bounds.height(), 40.0, 1e-6);
+}
+
+TEST_F(SelectToolTest, ShiftCanToggleAspectConstraintDuringResize) {
+  loadSvg(kResizeRectSvg);
+  app.setSelection(elementById("#target"));
+
+  tool.onMouseDown(app, Vector2d(60.0, 40.0), MouseModifiers{});
+  tool.onMouseMove(app, Vector2d(80.0, 45.0), /*buttonHeld=*/true, MouseModifiers{});
+  ASSERT_TRUE(app.flushFrame());
+  EXPECT_NEAR(worldBoundsOf("#target").width(), 60.0, 1e-6);
+  EXPECT_NEAR(worldBoundsOf("#target").height(), 25.0, 1e-6);
+
+  MouseModifiers shift;
+  shift.shift = true;
+  tool.onMouseMove(app, Vector2d(80.0, 45.0), /*buttonHeld=*/true, shift);
+  tool.onMouseUp(app, Vector2d(80.0, 45.0));
+  ASSERT_TRUE(app.flushFrame());
+
+  const Box2d bounds = worldBoundsOf("#target");
+  EXPECT_NEAR(bounds.width(), 60.0, 1e-6);
+  EXPECT_NEAR(bounds.height(), 30.0, 1e-6);
+}
+
+TEST_F(SelectToolTest, OptionCanToggleCenterResizeDuringResize) {
+  loadSvg(kResizeRectSvg);
+  app.setSelection(elementById("#target"));
+
+  tool.onMouseDown(app, Vector2d(60.0, 40.0), MouseModifiers{});
+  tool.onMouseMove(app, Vector2d(80.0, 50.0), /*buttonHeld=*/true, MouseModifiers{});
+  ASSERT_TRUE(app.flushFrame());
+  Vector2d center = (worldBoundsOf("#target").topLeft + worldBoundsOf("#target").bottomRight) * 0.5;
+  EXPECT_NEAR(center.x, 50.0, 1e-6);
+  EXPECT_NEAR(center.y, 35.0, 1e-6);
+
+  MouseModifiers option;
+  option.option = true;
+  tool.onMouseMove(app, Vector2d(80.0, 50.0), /*buttonHeld=*/true, option);
+  tool.onMouseUp(app, Vector2d(80.0, 50.0));
+  ASSERT_TRUE(app.flushFrame());
+
+  const Box2d bounds = worldBoundsOf("#target");
+  center = (bounds.topLeft + bounds.bottomRight) * 0.5;
+  EXPECT_NEAR(center.x, 40.0, 1e-6);
+  EXPECT_NEAR(center.y, 30.0, 1e-6);
+  EXPECT_NEAR(bounds.width(), 80.0, 1e-6);
+  EXPECT_NEAR(bounds.height(), 40.0, 1e-6);
+}
+
+TEST_F(SelectToolTest, MultiSelectionCornerResizeUsesCombinedBounds) {
+  app.setSelection(std::vector<svg::SVGElement>{elementById("#r1"), elementById("#r2")});
+  ASSERT_EQ(app.selectedElements().size(), 2u);
+
+  tool.onMouseDown(app, Vector2d(140.0, 140.0), MouseModifiers{});
+  tool.onMouseMove(app, Vector2d(270.0, 270.0), /*buttonHeld=*/true);
+  tool.onMouseUp(app, Vector2d(270.0, 270.0));
+  ASSERT_TRUE(app.flushFrame());
+
+  const Box2d r1Bounds = worldBoundsOf("#r1");
+  const Box2d r2Bounds = worldBoundsOf("#r2");
+  EXPECT_NEAR(r1Bounds.topLeft.x, 10.0, 1e-6);
+  EXPECT_NEAR(r1Bounds.topLeft.y, 10.0, 1e-6);
+  EXPECT_NEAR(r1Bounds.width(), 40.0, 1e-6);
+  EXPECT_NEAR(r1Bounds.height(), 40.0, 1e-6);
+  EXPECT_NEAR(r2Bounds.topLeft.x, 190.0, 1e-6);
+  EXPECT_NEAR(r2Bounds.topLeft.y, 190.0, 1e-6);
+  EXPECT_NEAR(r2Bounds.width(), 80.0, 1e-6);
+  EXPECT_NEAR(r2Bounds.height(), 80.0, 1e-6);
+  ASSERT_TRUE(app.undoTimeline().nextUndoLabel().has_value());
+  EXPECT_EQ(*app.undoTimeline().nextUndoLabel(), "Resize elements");
+}
+
+TEST_F(SelectToolTest, RotateZoneRotatesAroundSelectionCenter) {
+  tool.onMouseDown(app, Vector2d(15.0, 15.0), MouseModifiers{});
+  tool.onMouseUp(app, Vector2d(15.0, 15.0));
+  ASSERT_TRUE(selectionIs("#r1"));
+
+  tool.onMouseDown(app, Vector2d(44.0, 20.0), MouseModifiers{});
+  tool.onMouseMove(app, Vector2d(20.0, 44.0), /*buttonHeld=*/true);
+  tool.onMouseUp(app, Vector2d(20.0, 44.0));
+  ASSERT_TRUE(app.flushFrame());
+
+  const Transform2d transform = transformOf("#r1");
+  EXPECT_NEAR(transform.data[0], 0.0, 1e-6);
+  EXPECT_NEAR(transform.data[1], 1.0, 1e-6);
+  EXPECT_NEAR(transform.data[2], -1.0, 1e-6);
+  EXPECT_NEAR(transform.data[3], 0.0, 1e-6);
+  EXPECT_NEAR(transform.data[4], 40.0, 1e-6);
+  EXPECT_NEAR(transform.data[5], 0.0, 1e-6);
+  ASSERT_TRUE(app.undoTimeline().nextUndoLabel().has_value());
+  EXPECT_EQ(*app.undoTimeline().nextUndoLabel(), "Rotate element");
+}
+
+TEST_F(SelectToolTest, ActiveRotationBoundsPreviewClearsOnMouseUp) {
+  tool.onMouseDown(app, Vector2d(15.0, 15.0), MouseModifiers{});
+  tool.onMouseUp(app, Vector2d(15.0, 15.0));
+  ASSERT_TRUE(selectionIs("#r1"));
+
+  tool.onMouseDown(app, Vector2d(44.0, 20.0), MouseModifiers{});
+  tool.onMouseMove(app, Vector2d(20.0, 44.0), /*buttonHeld=*/true);
+  EXPECT_TRUE(tool.activeTransformBoundsPreview().has_value());
+
+  tool.onMouseUp(app, Vector2d(20.0, 44.0));
+  EXPECT_FALSE(tool.activeTransformBoundsPreview().has_value())
+      << "rotation chrome must switch back to axis-aligned bounds immediately on release";
+}
+
+TEST_F(SelectToolTest, RotateAfterScaleUsesDocumentCenter) {
+  auto r1Handle = elementById("#r1").cast<svg::SVGGraphicsElement>();
+  r1Handle.setTransform(Transform2d::Scale(2.0));
+  app.setSelection(elementById("#r1"));
+
+  tool.onMouseDown(app, Vector2d(60.0, 6.0), MouseModifiers{});
+  tool.onMouseMove(app, Vector2d(74.0, 60.0), /*buttonHeld=*/true);
+  tool.onMouseUp(app, Vector2d(74.0, 60.0));
+  ASSERT_TRUE(app.flushFrame());
+
+  const Transform2d transform = transformOf("#r1");
+  const Vector2d localCenter = transform.transformPosition(Vector2d(20.0, 20.0));
+  const Vector2d localTopRight = transform.transformPosition(Vector2d(30.0, 10.0));
+  EXPECT_NEAR(localCenter.x, 40.0, 1e-6);
+  EXPECT_NEAR(localCenter.y, 40.0, 1e-6);
+  EXPECT_NEAR(localTopRight.x, 60.0, 1e-6);
+  EXPECT_NEAR(localTopRight.y, 60.0, 1e-6);
 }
 
 }  // namespace

--- a/donner/editor/tests/SelectTool_tests.cc
+++ b/donner/editor/tests/SelectTool_tests.cc
@@ -326,11 +326,13 @@ TEST_F(SelectToolTest, RedoAfterUndoRestoresPostDragState) {
   ASSERT_TRUE(app.flushFrame());
   EXPECT_DOUBLE_EQ(transformOf("#r1").data[4], 0.0);
   EXPECT_DOUBLE_EQ(transformOf("#r1").data[5], 0.0);
+  EXPECT_TRUE(app.canRedo());
 
   app.redo();
   ASSERT_TRUE(app.flushFrame());
   EXPECT_DOUBLE_EQ(transformOf("#r1").data[4], 25.0);
   EXPECT_DOUBLE_EQ(transformOf("#r1").data[5], 20.0);
+  EXPECT_FALSE(app.canRedo());
 }
 
 TEST_F(SelectToolTest, UndoRedoCyclesStayConsistent) {
@@ -357,6 +359,19 @@ TEST_F(SelectToolTest, RedoWithNothingToRedoIsNoOp) {
   // Nothing in the timeline → redo is a no-op.
   app.redo();
   EXPECT_FALSE(app.flushFrame());
+}
+
+TEST_F(SelectToolTest, RedoWithoutPriorUndoDoesNotUndoCompletedDrag) {
+  tool.onMouseDown(app, Vector2d(15.0, 15.0), MouseModifiers{});
+  tool.onMouseMove(app, Vector2d(40.0, 35.0), /*buttonHeld=*/true);
+  tool.onMouseUp(app, Vector2d(40.0, 35.0));
+  ASSERT_TRUE(app.flushFrame());
+  ASSERT_FALSE(app.canRedo());
+
+  app.redo();
+  EXPECT_FALSE(app.flushFrame());
+  EXPECT_DOUBLE_EQ(transformOf("#r1").data[4], 25.0);
+  EXPECT_DOUBLE_EQ(transformOf("#r1").data[5], 20.0);
 }
 
 TEST_F(SelectToolTest, TwoDifferentDragsBothUndoableInOrder) {
@@ -995,6 +1010,27 @@ TEST_F(SelectToolTest, CornerHandleResizesSelectionFromOppositeCorner) {
   EXPECT_EQ(*app.undoTimeline().nextUndoLabel(), "Resize element");
 }
 
+TEST_F(SelectToolTest, ResizeUndoRedoRestoresBounds) {
+  loadSvg(kResizeRectSvg);
+  app.setSelection(elementById("#target"));
+
+  const Box2d startBounds = worldBoundsOf("#target");
+  tool.onMouseDown(app, Vector2d(60.0, 40.0), MouseModifiers{});
+  tool.onMouseMove(app, Vector2d(80.0, 50.0), /*buttonHeld=*/true);
+  tool.onMouseUp(app, Vector2d(80.0, 50.0));
+  ASSERT_TRUE(app.flushFrame());
+  const Box2d resizedBounds = worldBoundsOf("#target");
+  ASSERT_NE(resizedBounds, startBounds);
+
+  app.undo();
+  ASSERT_TRUE(app.flushFrame());
+  EXPECT_EQ(worldBoundsOf("#target"), startBounds);
+
+  app.redo();
+  ASSERT_TRUE(app.flushFrame());
+  EXPECT_EQ(worldBoundsOf("#target"), resizedBounds);
+}
+
 TEST_F(SelectToolTest, ResizeGestureExposesAffinePreview) {
   loadSvg(kResizeRectSvg);
   app.setSelection(elementById("#target"));
@@ -1105,6 +1141,9 @@ TEST_F(SelectToolTest, MultiSelectionCornerResizeUsesCombinedBounds) {
   app.setSelection(std::vector<svg::SVGElement>{elementById("#r1"), elementById("#r2")});
   ASSERT_EQ(app.selectedElements().size(), 2u);
 
+  const Box2d r1StartBounds = worldBoundsOf("#r1");
+  const Box2d r2StartBounds = worldBoundsOf("#r2");
+
   tool.onMouseDown(app, Vector2d(140.0, 140.0), MouseModifiers{});
   tool.onMouseMove(app, Vector2d(270.0, 270.0), /*buttonHeld=*/true);
   tool.onMouseUp(app, Vector2d(270.0, 270.0));
@@ -1120,8 +1159,20 @@ TEST_F(SelectToolTest, MultiSelectionCornerResizeUsesCombinedBounds) {
   EXPECT_NEAR(r2Bounds.topLeft.y, 190.0, 1e-6);
   EXPECT_NEAR(r2Bounds.width(), 80.0, 1e-6);
   EXPECT_NEAR(r2Bounds.height(), 80.0, 1e-6);
+  EXPECT_EQ(app.undoTimeline().entryCount(), 1u)
+      << "one UI undo should revert the whole multi-selection resize";
   ASSERT_TRUE(app.undoTimeline().nextUndoLabel().has_value());
   EXPECT_EQ(*app.undoTimeline().nextUndoLabel(), "Resize elements");
+
+  app.undo();
+  ASSERT_TRUE(app.flushFrame());
+  EXPECT_EQ(worldBoundsOf("#r1"), r1StartBounds);
+  EXPECT_EQ(worldBoundsOf("#r2"), r2StartBounds);
+
+  app.redo();
+  ASSERT_TRUE(app.flushFrame());
+  EXPECT_EQ(worldBoundsOf("#r1"), r1Bounds);
+  EXPECT_EQ(worldBoundsOf("#r2"), r2Bounds);
 }
 
 TEST_F(SelectToolTest, RotateZoneRotatesAroundSelectionCenter) {
@@ -1157,6 +1208,34 @@ TEST_F(SelectToolTest, ActiveRotationBoundsPreviewClearsOnMouseUp) {
   tool.onMouseUp(app, Vector2d(20.0, 44.0));
   EXPECT_FALSE(tool.activeTransformBoundsPreview().has_value())
       << "rotation chrome must switch back to axis-aligned bounds immediately on release";
+}
+
+TEST_F(SelectToolTest, RotateUndoRedoRestoresTransform) {
+  tool.onMouseDown(app, Vector2d(15.0, 15.0), MouseModifiers{});
+  tool.onMouseUp(app, Vector2d(15.0, 15.0));
+  ASSERT_TRUE(selectionIs("#r1"));
+  const Transform2d startTransform = transformOf("#r1");
+
+  tool.onMouseDown(app, Vector2d(44.0, 20.0), MouseModifiers{});
+  tool.onMouseMove(app, Vector2d(20.0, 44.0), /*buttonHeld=*/true);
+  tool.onMouseUp(app, Vector2d(20.0, 44.0));
+  ASSERT_TRUE(app.flushFrame());
+  const Transform2d rotatedTransform = transformOf("#r1");
+  ASSERT_FALSE(rotatedTransform.isIdentity());
+
+  app.undo();
+  ASSERT_TRUE(app.flushFrame());
+  const Transform2d undoTransform = transformOf("#r1");
+  for (int i = 0; i < 6; ++i) {
+    EXPECT_NEAR(undoTransform.data[i], startTransform.data[i], 1e-6);
+  }
+
+  app.redo();
+  ASSERT_TRUE(app.flushFrame());
+  const Transform2d redoTransform = transformOf("#r1");
+  for (int i = 0; i < 6; ++i) {
+    EXPECT_NEAR(redoTransform.data[i], rotatedTransform.data[i], 1e-6);
+  }
 }
 
 TEST_F(SelectToolTest, RotateAfterScaleUsesDocumentCenter) {

--- a/donner/editor/tests/SelectTool_tests.cc
+++ b/donner/editor/tests/SelectTool_tests.cc
@@ -44,6 +44,12 @@ constexpr std::string_view kPlainGroupSiblingSvg =
          </g>
        </svg>)";
 
+constexpr std::string_view kOverlappingRectsSvg =
+    R"(<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120">
+         <rect id="back" x="10" y="10" width="90" height="90" fill="red"/>
+         <rect id="front" x="40" y="40" width="50" height="50" fill="blue"/>
+       </svg>)";
+
 class SelectToolTest : public ::testing::Test {
 protected:
   void SetUp() override { ASSERT_TRUE(app.loadFromString(kTwoRectsSvg)); }
@@ -902,6 +908,40 @@ TEST_F(SelectToolTest, TryRedragOnSelectedHitsTransparentInteriorOfFiltergroup) 
       tool.tryStartRedragOnSelected(app, Vector2d(15.0, 20.0), MouseModifiers{}, anchorBounds));
   EXPECT_TRUE(tool.isDragging());
   EXPECT_TRUE(selectionIs("#anchor"));
+}
+
+// Regression repro: EditorShell runs the re-drag fast path before the
+// idle-gated full hit-test. If the click is inside the selected element's
+// cached bounds but a later-painted object is on top at that point, the fast
+// path must not keep dragging the behind selection. It should fall through to
+// the normal hit-test path so the front object can become selected.
+TEST_F(SelectToolTest, RedragFastPathDoesNotStealClickFromFrontOverlappingObject) {
+  loadSvg(kOverlappingRectsSvg);
+  app.setSelection(elementById("#back"));
+  ASSERT_TRUE(selectionIs("#back"));
+
+  const Vector2d overlapPoint(50.0, 50.0);
+  auto hit = app.hitTest(overlapPoint);
+  ASSERT_TRUE(hit.has_value());
+  ASSERT_EQ(hit->id(), "front") << "test setup requires #front to paint above #back";
+
+  SelectionBoundsCache boundsCache;
+  const std::uint64_t version = app.document().currentFrameVersion();
+  RefreshSelectionBoundsCache(boundsCache, std::span<const svg::SVGElement>(app.selectedElements()),
+                              version, version);
+  ASSERT_FALSE(boundsCache.displayedBoundsDoc.empty());
+  ASSERT_TRUE(boundsCache.displayedBoundsDoc.front().contains(overlapPoint));
+  ASSERT_FALSE(boundsCache.displayedOccludingBoundsDoc.empty());
+  ASSERT_TRUE(boundsCache.displayedOccludingBoundsDoc.front().contains(overlapPoint));
+
+  EXPECT_FALSE(tool.tryStartRedragOnSelected(app, overlapPoint, MouseModifiers{},
+                                             boundsCache.displayedBoundsDoc,
+                                             boundsCache.displayedOccludingBoundsDoc))
+      << "a busy-frame re-drag fast path must not preempt a topmost hit-test candidate";
+  EXPECT_FALSE(tool.isDragging());
+
+  tool.onMouseDown(app, overlapPoint, MouseModifiers{});
+  EXPECT_TRUE(selectionIs("#front"));
 }
 
 }  // namespace

--- a/donner/editor/tests/SelectTool_tests.cc
+++ b/donner/editor/tests/SelectTool_tests.cc
@@ -1,5 +1,7 @@
 #include "donner/editor/SelectTool.h"
 
+#include <cstdint>
+
 #include "donner/editor/EditorApp.h"
 #include "donner/editor/SelectionAabb.h"
 #include "donner/svg/SVGGraphicsElement.h"
@@ -802,6 +804,23 @@ TEST_F(SelectToolTest, TryRedragOnSelectedStartsDragWhenClickIsInsideSelectedBou
   EXPECT_TRUE(tool.tryStartRedragOnSelected(app, Vector2d(20.0, 20.0), MouseModifiers{}, bounds));
   EXPECT_TRUE(tool.isDragging());
   EXPECT_TRUE(selectionIs("#r1"));
+}
+
+TEST_F(SelectToolTest, DragPreviewGenerationChangesForRedragOnSameSelection) {
+  tool.onMouseDown(app, Vector2d(15.0, 15.0), MouseModifiers{});
+  ASSERT_TRUE(selectionIs("#r1"));
+  ASSERT_TRUE(tool.activeDragPreview().has_value());
+  const std::uint64_t firstDragGeneration = tool.activeDragPreview()->dragGeneration;
+  tool.onMouseUp(app, Vector2d(15.0, 15.0));
+  ASSERT_FALSE(tool.isDragging());
+
+  const auto bounds =
+      SnapshotSelectionWorldBounds(std::span<const svg::SVGElement>(app.selectedElements()));
+  ASSERT_TRUE(tool.tryStartRedragOnSelected(app, Vector2d(20.0, 20.0), MouseModifiers{}, bounds));
+  ASSERT_TRUE(tool.activeDragPreview().has_value());
+
+  EXPECT_GT(tool.activeDragPreview()->dragGeneration, firstDragGeneration)
+      << "Presentation caches need to distinguish consecutive drags of the same entity.";
 }
 
 TEST_F(SelectToolTest, TryRedragOnSelectedReturnsFalseOnShiftClick) {

--- a/donner/editor/tests/SelectionAabb_tests.cc
+++ b/donner/editor/tests/SelectionAabb_tests.cc
@@ -114,5 +114,32 @@ TEST(SelectionAabbTest, SnapshotSkipsNonRenderedContainerDescendants) {
   EXPECT_EQ(bounds[0], Box2d::FromXYWH(80.0, 80.0, 40.0, 40.0));
 }
 
+TEST(SelectionAabbTest, SnapshotOccludingWorldBoundsIncludesOnlyLaterPaintedGeometry) {
+  constexpr std::string_view kSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+              <rect id="behind" x="1" y="1" width="2" height="3" fill="black"/>
+              <g id="selected">
+                <rect id="selected_child" x="20" y="20" width="40" height="40" fill="red"/>
+              </g>
+              <rect id="front_a" x="70" y="80" width="10" height="20" fill="blue"/>
+              <g id="front_group">
+                <rect id="front_b" x="100" y="110" width="30" height="40" fill="green"/>
+              </g>
+            </svg>)svg";
+
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kSvg));
+  auto selected = app.document().document().querySelector("#selected");
+  ASSERT_TRUE(selected.has_value());
+
+  const std::vector<svg::SVGElement> selection = {*selected};
+  const std::vector<Box2d> bounds =
+      SnapshotSelectionOccludingWorldBounds(std::span<const svg::SVGElement>(selection));
+
+  ASSERT_EQ(bounds.size(), 2u);
+  EXPECT_EQ(bounds[0], Box2d::FromXYWH(70.0, 80.0, 10.0, 20.0));
+  EXPECT_EQ(bounds[1], Box2d::FromXYWH(100.0, 110.0, 30.0, 40.0));
+}
+
 }  // namespace
 }  // namespace donner::editor

--- a/donner/editor/tests/SelectionAabb_tests.cc
+++ b/donner/editor/tests/SelectionAabb_tests.cc
@@ -2,8 +2,10 @@
 
 #include <gtest/gtest.h>
 
+#include "donner/base/MathUtils.h"
 #include "donner/editor/EditorApp.h"
 #include "donner/editor/SelectTool.h"
+#include "donner/svg/SVGGraphicsElement.h"
 
 namespace donner::editor {
 namespace {
@@ -112,6 +114,42 @@ TEST(SelectionAabbTest, SnapshotSkipsNonRenderedContainerDescendants) {
   // Hidden rect inside <defs><clipPath> must not contribute; the
   // bounds are just the visible child.
   EXPECT_EQ(bounds[0], Box2d::FromXYWH(80.0, 80.0, 40.0, 40.0));
+}
+
+TEST(SelectionAabbTest, SnapshotUsesTightTransformedPathBounds) {
+  constexpr std::string_view kTriangleSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" viewBox="-20 0 120 120">
+              <path id="triangle" d="M 0 0 L 100 0 L 0 10 Z" fill="red"/>
+            </svg>)svg";
+
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kTriangleSvg));
+  auto triangle = app.document().document().querySelector("#triangle");
+  ASSERT_TRUE(triangle.has_value());
+  triangle->cast<svg::SVGGraphicsElement>().setTransform(
+      Transform2d::Rotate(MathConstants<double>::kPi / 4.0));
+
+  const std::vector<svg::SVGElement> selection = {*triangle};
+  const std::vector<Box2d> bounds =
+      SnapshotSelectionWorldBounds(std::span<const svg::SVGElement>(selection));
+
+  ASSERT_EQ(bounds.size(), 1u);
+  const Transform2d documentFromElement =
+      triangle->cast<svg::SVGGraphicsElement>().elementFromWorld();
+  Box2d expected = Box2d::CreateEmpty(documentFromElement.transformPosition(Vector2d(0.0, 0.0)));
+  expected.addPoint(documentFromElement.transformPosition(Vector2d(100.0, 0.0)));
+  expected.addPoint(documentFromElement.transformPosition(Vector2d(0.0, 10.0)));
+
+  EXPECT_NEAR(bounds[0].topLeft.x, expected.topLeft.x, 1e-6);
+  EXPECT_NEAR(bounds[0].topLeft.y, expected.topLeft.y, 1e-6);
+  EXPECT_NEAR(bounds[0].bottomRight.x, expected.bottomRight.x, 1e-6);
+  EXPECT_NEAR(bounds[0].bottomRight.y, expected.bottomRight.y, 1e-6);
+
+  const Box2d looseBounds =
+      documentFromElement.transformBox(Box2d::FromXYWH(0.0, 0.0, 100.0, 10.0));
+  EXPECT_LT(bounds[0].height(), looseBounds.height())
+      << "settled selection bounds must be the tight transformed path, not the selected "
+         "path's transformed local AABB";
 }
 
 TEST(SelectionAabbTest, SnapshotOccludingWorldBoundsIncludesOnlyLaterPaintedGeometry) {

--- a/donner/editor/tests/SelectionTransformHandles_tests.cc
+++ b/donner/editor/tests/SelectionTransformHandles_tests.cc
@@ -1,0 +1,63 @@
+#include "donner/editor/SelectionTransformHandles.h"
+
+#include <array>
+
+#include "gtest/gtest.h"
+
+namespace donner::editor {
+namespace {
+
+TEST(SelectionTransformHandlesTest, HitTestFindsResizeCorner) {
+  const std::array<Box2d, 1> bounds{Box2d::FromXYWH(20.0, 30.0, 80.0, 40.0)};
+
+  const SelectionTransformHandleIntent intent =
+      HitTestSelectionTransformHandles(bounds, Vector2d(20.0, 30.0), /*pixelsPerDocUnit=*/1.0);
+
+  EXPECT_EQ(intent.kind, SelectionTransformHandleKind::Resize);
+  EXPECT_EQ(intent.corner, SelectionTransformCorner::TopLeft);
+}
+
+TEST(SelectionTransformHandlesTest, HitTestFindsRotateRingOutsideResizeHandle) {
+  const std::array<Box2d, 1> bounds{Box2d::FromXYWH(20.0, 30.0, 80.0, 40.0)};
+
+  const SelectionTransformHandleIntent intent =
+      HitTestSelectionTransformHandles(bounds, Vector2d(20.0, 16.0), /*pixelsPerDocUnit=*/1.0);
+
+  EXPECT_EQ(intent.kind, SelectionTransformHandleKind::Rotate);
+  EXPECT_EQ(intent.corner, SelectionTransformCorner::TopLeft);
+}
+
+TEST(SelectionTransformHandlesTest, ResizeTakesPriorityOverRotate) {
+  const std::array<Box2d, 1> bounds{Box2d::FromXYWH(20.0, 30.0, 80.0, 40.0)};
+
+  const SelectionTransformHandleIntent intent =
+      HitTestSelectionTransformHandles(bounds, Vector2d(22.0, 32.0), /*pixelsPerDocUnit=*/1.0);
+
+  EXPECT_EQ(intent.kind, SelectionTransformHandleKind::Resize);
+  EXPECT_EQ(intent.corner, SelectionTransformCorner::TopLeft);
+}
+
+TEST(SelectionTransformHandlesTest, HitSizeStaysStableAcrossZoom) {
+  const std::array<Box2d, 1> bounds{Box2d::FromXYWH(20.0, 30.0, 80.0, 40.0)};
+
+  EXPECT_EQ(HitTestSelectionTransformHandles(bounds, Vector2d(21.0, 31.0),
+                                             /*pixelsPerDocUnit=*/4.0)
+                .kind,
+            SelectionTransformHandleKind::Resize);
+  EXPECT_EQ(HitTestSelectionTransformHandles(bounds, Vector2d(27.0, 37.0),
+                                             /*pixelsPerDocUnit=*/4.0)
+                .kind,
+            SelectionTransformHandleKind::None);
+}
+
+TEST(SelectionTransformHandlesTest, CombinesMultiSelectionBounds) {
+  const std::array<Box2d, 2> bounds{Box2d::FromXYWH(20.0, 30.0, 20.0, 20.0),
+                                    Box2d::FromXYWH(100.0, 110.0, 30.0, 40.0)};
+
+  const Box2d combined = CombinedSelectionBounds(bounds);
+
+  EXPECT_EQ(combined, Box2d::FromXYWH(20.0, 30.0, 110.0, 120.0));
+}
+
+}  // namespace
+}  // namespace donner::editor

--- a/donner/editor/tests/StructuredEditingStress_tests.cc
+++ b/donner/editor/tests/StructuredEditingStress_tests.cc
@@ -670,6 +670,8 @@ protected:
       request.dragPreview = RenderRequest::DragPreview{
           .entity = preview->entity,
           .interactionKind = svg::compositor::InteractionHint::ActiveDrag,
+          .translation = preview->translation,
+          .dragGeneration = preview->dragGeneration,
       };
     }
     return request;

--- a/donner/editor/tests/StructuredEditingStress_tests.cc
+++ b/donner/editor/tests/StructuredEditingStress_tests.cc
@@ -671,6 +671,7 @@ protected:
           .entity = preview->entity,
           .interactionKind = svg::compositor::InteractionHint::ActiveDrag,
           .translation = preview->translation,
+          .documentFromCachedDocument = preview->documentFromCachedDocument,
           .dragGeneration = preview->dragGeneration,
       };
     }

--- a/donner/editor/tests/StructuredEditingStress_tests.cc
+++ b/donner/editor/tests/StructuredEditingStress_tests.cc
@@ -515,7 +515,7 @@ protected:
                           std::string_view expectedId) {
     RecordAction(phase);
     ASSERT_FALSE(asyncRenderer_.isBusy()) << phase << ": click while async renderer is busy";
-    selectTool_.onMouseDown(app_, documentPoint, MouseModifiers{});
+    selectTool_.onMouseDown(app_, documentPoint, ViewportMouseModifiers());
     ASSERT_TRUE(app_.selectedElement().has_value()) << phase;
     EXPECT_EQ(app_.selectedElement()->id(), expectedId) << phase;
     selectTool_.onMouseUp(app_, documentPoint);
@@ -526,11 +526,12 @@ protected:
                           const Vector2d& endDocumentPoint, std::string_view expectedId) {
     RecordAction(phase);
     ASSERT_FALSE(asyncRenderer_.isBusy()) << phase << ": drag while async renderer is busy";
-    selectTool_.onMouseDown(app_, startDocumentPoint, MouseModifiers{});
+    const MouseModifiers modifiers = ViewportMouseModifiers();
+    selectTool_.onMouseDown(app_, startDocumentPoint, modifiers);
     ASSERT_TRUE(app_.selectedElement().has_value()) << phase;
     EXPECT_EQ(app_.selectedElement()->id(), expectedId) << phase;
 
-    selectTool_.onMouseMove(app_, endDocumentPoint, /*buttonHeld=*/true);
+    selectTool_.onMouseMove(app_, endDocumentPoint, /*buttonHeld=*/true, modifiers);
     ASSERT_TRUE(app_.flushFrame()) << phase;
     selectTool_.onMouseUp(app_, endDocumentPoint);
     controller_->applyPendingWritebacks(app_, selectTool_, textEditor_);
@@ -541,6 +542,12 @@ protected:
                         const Vector2d& endScreenPoint, std::string_view expectedId) {
     DragDocumentPoints(phase, viewport_.screenToDocument(startScreenPoint),
                        viewport_.screenToDocument(endScreenPoint), expectedId);
+  }
+
+  MouseModifiers ViewportMouseModifiers() const {
+    MouseModifiers modifiers;
+    modifiers.pixelsPerDocUnit = viewport_.pixelsPerDocUnit();
+    return modifiers;
   }
 
   void ReplaceSourceText(std::string_view phase, std::string_view oldText,

--- a/donner/editor/tests/UndoTimeline_tests.cc
+++ b/donner/editor/tests/UndoTimeline_tests.cc
@@ -94,6 +94,35 @@ TEST(UndoTimelineTest, UndoRestoresBeforeStateAndAppendsUndoEntry) {
   EXPECT_DOUBLE_EQ(graphics.transform().data[4], startXform.data[4]);
   EXPECT_DOUBLE_EQ(graphics.transform().data[5], startXform.data[5]);
   EXPECT_EQ(timeline.entryCount(), 2u);
+  EXPECT_TRUE(timeline.canRedo());
+}
+
+TEST(UndoTimelineTest, RedoRestoresMostRecentUndo) {
+  auto doc = ParseOrDie();
+  auto rect = FirstRect(doc);
+  auto graphics = rect.cast<svg::SVGGraphicsElement>();
+
+  UndoTimeline timeline;
+
+  const Transform2d a = graphics.transform();
+  const Transform2d b = Transform2d::Translate(Vector2d(30, 50));
+
+  graphics.setTransform(b);
+  timeline.record("Move", UndoSnapshot{.element = rect, .transform = a},
+                  UndoSnapshot{.element = rect, .transform = b});
+  EXPECT_FALSE(timeline.canRedo());
+
+  auto undone = timeline.undo();
+  ASSERT_TRUE(undone.has_value());
+  applySnapshot(*undone);
+  ASSERT_TRUE(timeline.canRedo());
+
+  auto redone = timeline.redo();
+  ASSERT_TRUE(redone.has_value());
+  applySnapshot(*redone);
+  EXPECT_DOUBLE_EQ(graphics.transform().data[4], b.data[4]);
+  EXPECT_DOUBLE_EQ(graphics.transform().data[5], b.data[5]);
+  EXPECT_FALSE(timeline.canRedo());
 }
 
 TEST(UndoTimelineTest, UndoOfUndoReappliesTheOriginalMove) {

--- a/donner/editor/wasm/BUILD.bazel
+++ b/donner/editor/wasm/BUILD.bazel
@@ -34,6 +34,13 @@ _EMDAWNWEBGPU_JS_LIBS = [
     "//third_party/emdawnwebgpu:webgpu/src/library_webgpu.js",
 ]
 
+_EMDAWNWEBGPU_LINKOPTS = [
+    "--js-library=$(execpath //third_party/emdawnwebgpu:webgpu/src/library_webgpu_enum_tables.js)",
+    "--js-library=$(execpath //third_party/emdawnwebgpu:webgpu/src/library_webgpu_generated_struct_info.js)",
+    "--js-library=$(execpath //third_party/emdawnwebgpu:webgpu/src/library_webgpu_generated_sig_info.js)",
+    "--js-library=$(execpath //third_party/emdawnwebgpu:webgpu/src/library_webgpu.js)",
+]
+
 # Linker flags shared by both renderer backends.
 _COMMON_LINKOPTS = [
     "-pthread",
@@ -49,14 +56,14 @@ _COMMON_LINKOPTS = [
 
 cc_library(
     name = "notice_inputs",
-    deps = [
-        "//donner/editor:editor_icon",
-        "//donner/editor:editor_shell",
-    ],
     target_compatible_with = select({
         ":wasm_enabled": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
+    deps = [
+        "//donner/editor:editor_icon",
+        "//donner/editor:editor_shell",
+    ],
 )
 
 cc_binary(
@@ -80,7 +87,10 @@ cc_binary(
         "-sSTACK_SIZE=1048576",
         "-sUSE_PTHREADS=1",
         "-sENVIRONMENT=web,worker",
-    ],
+    ] + select({
+        "//donner/svg/renderer:renderer_backend_geode": _EMDAWNWEBGPU_LINKOPTS,
+        "//conditions:default": [],
+    }),
     tags = [
         "manual",
         "wasm",
@@ -112,9 +122,9 @@ wasm_cc_binary(
 web_package(
     name = "wasm_web_package",
     srcs = [
-        "//:donner_icon.svg",
         "enable-threads.js",
         "index.html",
+        "//:donner_icon.svg",
     ],
     tags = [
         "manual",

--- a/donner/editor/wasm/tests/package.json
+++ b/donner/editor/wasm/tests/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "donner-editor-wasm-tests",
+  "private": true,
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.59.1"
+  }
+}

--- a/donner/editor/wasm/tests/playwright.config.js
+++ b/donner/editor/wasm/tests/playwright.config.js
@@ -1,0 +1,16 @@
+const { defineConfig, devices } = require("@playwright/test");
+
+module.exports = defineConfig({
+  testDir: ".",
+  timeout: 30000,
+  use: {
+    ...devices["Desktop Chrome"],
+    ignoreHTTPSErrors: true,
+    launchOptions: {
+      args: [
+        "--enable-unsafe-webgpu",
+        "--ignore-certificate-errors",
+      ],
+    },
+  },
+});

--- a/donner/editor/wasm/tests/run_tests.sh
+++ b/donner/editor/wasm/tests/run_tests.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+export DONNER_WASM_BASE_URL="${DONNER_WASM_BASE_URL:-http://127.0.0.1:8000}"
+npx playwright test "$@"

--- a/donner/editor/wasm/tests/smoke.spec.ts
+++ b/donner/editor/wasm/tests/smoke.spec.ts
@@ -1,10 +1,16 @@
 import { expect, type Page, test } from "@playwright/test";
+import { inflateSync } from "node:zlib";
 
 declare global {
   interface Window {
     __donnerLastScrollEvent?: {
       zoomModifierHeld?: boolean;
       yoffset?: number;
+    };
+    __donnerWgpuReadbackStats?: {
+      frame: number;
+      renderPane: WgpuReadbackColorStats;
+      layerPreview: WgpuReadbackColorStats;
     };
   }
 }
@@ -24,73 +30,162 @@ interface CanvasColorStats {
   region: CssRegion;
 }
 
+type WgpuReadbackColorStats = Omit<CanvasColorStats, "region">;
+
+interface PngImage {
+  width: number;
+  height: number;
+  channels: number;
+  data: Uint8Array;
+}
+
 const kFatalRuntimePattern =
   /Aborted|Assertion failed|RuntimeError|Pthread .* sent an error|getJsObject/i;
 const kSourcePaneWidth = 560;
 const kRightPaneWidth = 420;
 
+function paethPredictor(left: number, up: number, upLeft: number): number {
+  const estimate = left + up - upLeft;
+  const leftDistance = Math.abs(estimate - left);
+  const upDistance = Math.abs(estimate - up);
+  const upLeftDistance = Math.abs(estimate - upLeft);
+  if (leftDistance <= upDistance && leftDistance <= upLeftDistance) {
+    return left;
+  }
+  return upDistance <= upLeftDistance ? up : upLeft;
+}
+
+function decodePng(buffer: Buffer): PngImage {
+  const signature = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  if (!buffer.subarray(0, signature.length).equals(signature)) {
+    throw new Error("screenshot is not a PNG");
+  }
+
+  let width = 0;
+  let height = 0;
+  let channels = 0;
+  const idatChunks: Buffer[] = [];
+  for (let offset = signature.length; offset < buffer.length;) {
+    const chunkLength = buffer.readUInt32BE(offset);
+    const type = buffer.toString("ascii", offset + 4, offset + 8);
+    const dataOffset = offset + 8;
+    const dataEnd = dataOffset + chunkLength;
+    const data = buffer.subarray(dataOffset, dataEnd);
+    offset = dataEnd + 4;
+
+    if (type === "IHDR") {
+      width = data.readUInt32BE(0);
+      height = data.readUInt32BE(4);
+      const bitDepth = data[8];
+      const colorType = data[9];
+      const compression = data[10];
+      const filter = data[11];
+      const interlace = data[12];
+      if (
+        bitDepth !== 8
+        || compression !== 0
+        || filter !== 0
+        || interlace !== 0
+        || (colorType !== 2 && colorType !== 6)
+      ) {
+        throw new Error(`unsupported PNG format: depth=${bitDepth} color=${colorType}`);
+      }
+      channels = colorType === 6 ? 4 : 3;
+    } else if (type === "IDAT") {
+      idatChunks.push(data);
+    } else if (type === "IEND") {
+      break;
+    }
+  }
+
+  if (width <= 0 || height <= 0 || channels <= 0 || idatChunks.length === 0) {
+    throw new Error("PNG is missing image data");
+  }
+
+  const bytesPerRow = width * channels;
+  const raw = inflateSync(Buffer.concat(idatChunks));
+  const output = new Uint8Array(height * bytesPerRow);
+  let sourceOffset = 0;
+  for (let y = 0; y < height; ++y) {
+    const filter = raw[sourceOffset++];
+    const rowOffset = y * bytesPerRow;
+    const previousRowOffset = rowOffset - bytesPerRow;
+    for (let x = 0; x < bytesPerRow; ++x) {
+      const value = raw[sourceOffset++];
+      const left = x >= channels ? output[rowOffset + x - channels] : 0;
+      const up = y > 0 ? output[previousRowOffset + x] : 0;
+      const upLeft = y > 0 && x >= channels ? output[previousRowOffset + x - channels] : 0;
+      let reconstructed = value;
+      if (filter === 1) {
+        reconstructed += left;
+      } else if (filter === 2) {
+        reconstructed += up;
+      } else if (filter === 3) {
+        reconstructed += Math.floor((left + up) / 2);
+      } else if (filter === 4) {
+        reconstructed += paethPredictor(left, up, upLeft);
+      } else if (filter !== 0) {
+        throw new Error(`unsupported PNG row filter ${filter}`);
+      }
+      output[rowOffset + x] = reconstructed & 0xff;
+    }
+  }
+
+  return { width, height, channels, data: output };
+}
+
 async function readCanvasColorStats(page: Page, region: CssRegion): Promise<CanvasColorStats> {
-  return page.evaluate((cssRegion) => {
-    const canvas = document.getElementById("canvas") as HTMLCanvasElement | null;
-    if (!canvas) {
-      throw new Error("canvas not found");
+  const canvasBox = await page.locator("canvas#canvas").boundingBox();
+  if (canvasBox === null) {
+    throw new Error("canvas not found");
+  }
+
+  const x = Math.max(0, region.x);
+  const y = Math.max(0, region.y);
+  const width = Math.max(1, Math.min(region.width, canvasBox.width - x));
+  const height = Math.max(1, Math.min(region.height, canvasBox.height - y));
+  const clip = {
+    x: canvasBox.x + x,
+    y: canvasBox.y + y,
+    width,
+    height,
+  };
+  const image = decodePng(await page.screenshot({ clip }));
+
+  let coloredPixels = 0;
+  let nonBlackPixels = 0;
+  let maxChannel = 0;
+  for (let offset = 0; offset < image.data.length; offset += image.channels) {
+    const red = image.data[offset];
+    const green = image.data[offset + 1];
+    const blue = image.data[offset + 2];
+    const alpha = image.channels === 4 ? image.data[offset + 3] : 255;
+    const maxRgb = Math.max(red, green, blue);
+    const minRgb = Math.min(red, green, blue);
+    maxChannel = Math.max(maxChannel, maxRgb);
+    if (alpha > 0 && maxRgb > 12) {
+      nonBlackPixels += 1;
     }
-
-    const gl = canvas.getContext("webgl2") ?? canvas.getContext("webgl");
-    if (!gl) {
-      throw new Error("WebGL context not available");
+    if (alpha > 0 && maxRgb > 50 && maxRgb - minRgb > 20) {
+      coloredPixels += 1;
     }
+  }
 
-    const cssWidth = canvas.clientWidth;
-    const cssHeight = canvas.clientHeight;
-    const scaleX = gl.drawingBufferWidth / cssWidth;
-    const scaleY = gl.drawingBufferHeight / cssHeight;
-    const x = Math.max(0, Math.floor(cssRegion.x * scaleX));
-    const y = Math.max(0, Math.floor((cssHeight - cssRegion.y - cssRegion.height) * scaleY));
-    const width = Math.max(
-      1,
-      Math.min(gl.drawingBufferWidth - x, Math.floor(cssRegion.width * scaleX)),
-    );
-    const height = Math.max(
-      1,
-      Math.min(gl.drawingBufferHeight - y, Math.floor(cssRegion.height * scaleY)),
-    );
-    const pixels = new Uint8Array(width * height * 4);
-    const framebufferBinding = gl.getParameter(gl.FRAMEBUFFER_BINDING) as WebGLFramebuffer | null;
-    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-    gl.readPixels(x, y, width, height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
-    gl.bindFramebuffer(gl.FRAMEBUFFER, framebufferBinding);
-
-    let coloredPixels = 0;
-    let nonBlackPixels = 0;
-    let maxChannel = 0;
-    for (let offset = 0; offset < pixels.length; offset += 4) {
-      const red = pixels[offset];
-      const green = pixels[offset + 1];
-      const blue = pixels[offset + 2];
-      const alpha = pixels[offset + 3];
-      const maxRgb = Math.max(red, green, blue);
-      const minRgb = Math.min(red, green, blue);
-      maxChannel = Math.max(maxChannel, maxRgb);
-      if (alpha > 0 && maxRgb > 12) {
-        nonBlackPixels += 1;
-      }
-      if (alpha > 0 && maxRgb > 50 && maxRgb - minRgb > 20) {
-        coloredPixels += 1;
-      }
-    }
-
-    return {
-      samples: width * height,
-      coloredPixels,
-      nonBlackPixels,
-      maxChannel,
-      region: { x, y, width, height },
-    };
-  }, region);
+  return {
+    samples: image.width * image.height,
+    coloredPixels,
+    nonBlackPixels,
+    maxChannel,
+    region: { x, y, width: image.width, height: image.height },
+  };
 }
 
 async function readRenderPaneColorStats(page: Page): Promise<CanvasColorStats> {
+  const wgpuStats = await page.evaluate(() => window.__donnerWgpuReadbackStats?.renderPane);
+  if (wgpuStats) {
+    return { ...wgpuStats, region: { x: 0, y: 0, width: 0, height: 0 } };
+  }
+
   const region = await page.evaluate(({ sourcePaneWidth, rightPaneWidth }) => {
     const canvas = document.getElementById("canvas") as HTMLCanvasElement | null;
     if (!canvas) {
@@ -116,6 +211,11 @@ async function readRenderPaneColorStats(page: Page): Promise<CanvasColorStats> {
 }
 
 async function readLayerPreviewColorStats(page: Page): Promise<CanvasColorStats> {
+  const wgpuStats = await page.evaluate(() => window.__donnerWgpuReadbackStats?.layerPreview);
+  if (wgpuStats) {
+    return { ...wgpuStats, region: { x: 0, y: 0, width: 0, height: 0 } };
+  }
+
   const region = await page.evaluate(({ rightPaneWidth }) => {
     const canvas = document.getElementById("canvas") as HTMLCanvasElement | null;
     if (!canvas) {
@@ -135,6 +235,8 @@ async function readLayerPreviewColorStats(page: Page): Promise<CanvasColorStats>
 
 async function openEditor(page: Page): Promise<string[]> {
   const baseUrl = process.env.DONNER_WASM_BASE_URL || "http://127.0.0.1:8000";
+  const url = new URL(baseUrl);
+  url.searchParams.set("wgpuReadbackStats", "1");
   const fatalMessages: string[] = [];
 
   page.on("console", (message) => {
@@ -147,7 +249,7 @@ async function openEditor(page: Page): Promise<string[]> {
     fatalMessages.push(`[pageerror] ${error.message}`);
   });
 
-  await page.goto(baseUrl, { waitUntil: "domcontentloaded" });
+  await page.goto(url.toString(), { waitUntil: "domcontentloaded" });
   const hasWebGpu = await page.evaluate(() => "gpu" in navigator);
   test.skip(!hasWebGpu, "Browser does not expose navigator.gpu");
 

--- a/donner/editor/wasm/tests/smoke.spec.ts
+++ b/donner/editor/wasm/tests/smoke.spec.ts
@@ -1,9 +1,139 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
+
+declare global {
+  interface Window {
+    __donnerLastScrollEvent?: {
+      zoomModifierHeld?: boolean;
+      yoffset?: number;
+    };
+  }
+}
+
+interface CssRegion {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface CanvasColorStats {
+  samples: number;
+  coloredPixels: number;
+  nonBlackPixels: number;
+  maxChannel: number;
+  region: CssRegion;
+}
 
 const kFatalRuntimePattern =
   /Aborted|Assertion failed|RuntimeError|Pthread .* sent an error|getJsObject/i;
+const kSourcePaneWidth = 560;
+const kRightPaneWidth = 420;
 
-test("wasm editor starts without runtime abort", async ({ page }) => {
+async function readCanvasColorStats(page: Page, region: CssRegion): Promise<CanvasColorStats> {
+  return page.evaluate((cssRegion) => {
+    const canvas = document.getElementById("canvas") as HTMLCanvasElement | null;
+    if (!canvas) {
+      throw new Error("canvas not found");
+    }
+
+    const gl = canvas.getContext("webgl2") ?? canvas.getContext("webgl");
+    if (!gl) {
+      throw new Error("WebGL context not available");
+    }
+
+    const cssWidth = canvas.clientWidth;
+    const cssHeight = canvas.clientHeight;
+    const scaleX = gl.drawingBufferWidth / cssWidth;
+    const scaleY = gl.drawingBufferHeight / cssHeight;
+    const x = Math.max(0, Math.floor(cssRegion.x * scaleX));
+    const y = Math.max(0, Math.floor((cssHeight - cssRegion.y - cssRegion.height) * scaleY));
+    const width = Math.max(
+      1,
+      Math.min(gl.drawingBufferWidth - x, Math.floor(cssRegion.width * scaleX)),
+    );
+    const height = Math.max(
+      1,
+      Math.min(gl.drawingBufferHeight - y, Math.floor(cssRegion.height * scaleY)),
+    );
+    const pixels = new Uint8Array(width * height * 4);
+    const framebufferBinding = gl.getParameter(gl.FRAMEBUFFER_BINDING) as WebGLFramebuffer | null;
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.readPixels(x, y, width, height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, framebufferBinding);
+
+    let coloredPixels = 0;
+    let nonBlackPixels = 0;
+    let maxChannel = 0;
+    for (let offset = 0; offset < pixels.length; offset += 4) {
+      const red = pixels[offset];
+      const green = pixels[offset + 1];
+      const blue = pixels[offset + 2];
+      const alpha = pixels[offset + 3];
+      const maxRgb = Math.max(red, green, blue);
+      const minRgb = Math.min(red, green, blue);
+      maxChannel = Math.max(maxChannel, maxRgb);
+      if (alpha > 0 && maxRgb > 12) {
+        nonBlackPixels += 1;
+      }
+      if (alpha > 0 && maxRgb > 50 && maxRgb - minRgb > 20) {
+        coloredPixels += 1;
+      }
+    }
+
+    return {
+      samples: width * height,
+      coloredPixels,
+      nonBlackPixels,
+      maxChannel,
+      region: { x, y, width, height },
+    };
+  }, region);
+}
+
+async function readRenderPaneColorStats(page: Page): Promise<CanvasColorStats> {
+  const region = await page.evaluate(({ sourcePaneWidth, rightPaneWidth }) => {
+    const canvas = document.getElementById("canvas") as HTMLCanvasElement | null;
+    if (!canvas) {
+      throw new Error("canvas not found");
+    }
+
+    let x = sourcePaneWidth + 20;
+    let width = canvas.clientWidth - sourcePaneWidth - rightPaneWidth - 40;
+    if (width <= 0) {
+      x = canvas.clientWidth * 0.35;
+      width = canvas.clientWidth * 0.3;
+    }
+
+    return {
+      x,
+      y: 80,
+      width,
+      height: Math.max(1, canvas.clientHeight - 220),
+    };
+  }, { sourcePaneWidth: kSourcePaneWidth, rightPaneWidth: kRightPaneWidth });
+
+  return readCanvasColorStats(page, region);
+}
+
+async function readLayerPreviewColorStats(page: Page): Promise<CanvasColorStats> {
+  const region = await page.evaluate(({ rightPaneWidth }) => {
+    const canvas = document.getElementById("canvas") as HTMLCanvasElement | null;
+    if (!canvas) {
+      throw new Error("canvas not found");
+    }
+
+    return {
+      x: canvas.clientWidth - rightPaneWidth + 8,
+      y: canvas.clientHeight * 0.72,
+      width: 90,
+      height: canvas.clientHeight * 0.24,
+    };
+  }, { rightPaneWidth: kRightPaneWidth });
+
+  return readCanvasColorStats(page, region);
+}
+
+async function openEditor(page: Page): Promise<string[]> {
   const baseUrl = process.env.DONNER_WASM_BASE_URL || "http://127.0.0.1:8000";
   const fatalMessages: string[] = [];
 
@@ -25,5 +155,87 @@ test("wasm editor starts without runtime abort", async ({ page }) => {
   await expect(page.locator("#status")).toBeHidden({ timeout: 20000 });
   await page.waitForTimeout(2000);
 
+  return fatalMessages;
+}
+
+test("wasm editor starts without runtime abort", async ({ page }) => {
+  const fatalMessages = await openEditor(page);
+
+  expect(fatalMessages).toEqual([]);
+});
+
+test("wasm editor renders colored document pixels", async ({ page }) => {
+  const fatalMessages = await openEditor(page);
+  await expect
+    .poll(async () => {
+      const stats = await readRenderPaneColorStats(page);
+      return stats.nonBlackPixels > 1000 && stats.coloredPixels > 500 && stats.maxChannel > 80;
+    }, {
+      message: "expected non-black, colored pixels in the render pane",
+      timeout: 20000,
+    })
+    .toBe(true);
+
+  expect(fatalMessages).toEqual([]);
+});
+
+test("wasm editor renders layer panel thumbnails", async ({ page }) => {
+  const fatalMessages = await openEditor(page);
+  await expect
+    .poll(async () => {
+      const stats = await readLayerPreviewColorStats(page);
+      return stats.coloredPixels > 100 && stats.maxChannel > 80;
+    }, {
+      message: "expected colored thumbnail pixels in the Layers panel preview column",
+      timeout: 20000,
+    })
+    .toBe(true);
+
+  expect(fatalMessages).toEqual([]);
+});
+
+test("WASM trackpad pinch wheel reaches editor as zoom gesture", async ({ page }) => {
+  const fatalMessages = await openEditor(page);
+  const canvas = page.locator("canvas#canvas");
+  const bounds = await canvas.boundingBox();
+  expect(bounds).not.toBeNull();
+  if (bounds === null) {
+    return;
+  }
+
+  const center = {
+    x: bounds.x + bounds.width * 0.5,
+    y: bounds.y + bounds.height * 0.5,
+  };
+  await page.mouse.move(center.x, center.y);
+  await page.evaluate(() => {
+    window.__donnerLastScrollEvent = undefined;
+  });
+
+  await page.evaluate(({ x, y }) => {
+    const target = document.getElementById("canvas");
+    if (!target) {
+      throw new Error("canvas not found");
+    }
+
+    target.dispatchEvent(
+      new WheelEvent("wheel", {
+        bubbles: true,
+        cancelable: true,
+        clientX: x,
+        clientY: y,
+        ctrlKey: true,
+        deltaMode: WheelEvent.DOM_DELTA_PIXEL,
+        deltaY: -100,
+      }),
+    );
+  }, center);
+
+  await expect
+    .poll(async () => page.evaluate(() => window.__donnerLastScrollEvent?.zoomModifierHeld))
+    .toBe(true);
+  await expect
+    .poll(async () => page.evaluate(() => window.__donnerLastScrollEvent?.yoffset))
+    .toBeGreaterThan(0);
   expect(fatalMessages).toEqual([]);
 });

--- a/donner/editor/wasm/tests/smoke.spec.ts
+++ b/donner/editor/wasm/tests/smoke.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/test";
+
+const kFatalRuntimePattern =
+  /Aborted|Assertion failed|RuntimeError|Pthread .* sent an error|getJsObject/i;
+
+test("wasm editor starts without runtime abort", async ({ page }) => {
+  const baseUrl = process.env.DONNER_WASM_BASE_URL || "http://127.0.0.1:8000";
+  const fatalMessages: string[] = [];
+
+  page.on("console", (message) => {
+    const text = message.text();
+    if (kFatalRuntimePattern.test(text)) {
+      fatalMessages.push(`[console:${message.type()}] ${text}`);
+    }
+  });
+  page.on("pageerror", (error) => {
+    fatalMessages.push(`[pageerror] ${error.message}`);
+  });
+
+  await page.goto(baseUrl, { waitUntil: "domcontentloaded" });
+  const hasWebGpu = await page.evaluate(() => "gpu" in navigator);
+  test.skip(!hasWebGpu, "Browser does not expose navigator.gpu");
+
+  await expect(page.locator("canvas#canvas")).toBeVisible();
+  await expect(page.locator("#status")).toBeHidden({ timeout: 20000 });
+  await page.waitForTimeout(2000);
+
+  expect(fatalMessages).toEqual([]);
+});

--- a/donner/svg/compositor/CompositorController.cc
+++ b/donner/svg/compositor/CompositorController.cc
@@ -1827,13 +1827,14 @@ void CompositorController::rasterizeLayer(CompositorLayer& layer, const RenderVi
     worldFromEntity = registry.get<components::RenderingInstanceComponent>(layer.entity())
                           .worldFromEntityTransform;
   }
-  if (std::shared_ptr<const RendererTextureSnapshot> texture = offscreen->takeTextureSnapshot()) {
-    layer.setTextureSnapshot(std::move(texture), worldFromEntity);
-  } else {
+  if (offscreen->requiresTextureSnapshotPresentation()) {
+    std::shared_ptr<const RendererTextureSnapshot> texture = offscreen->takeTextureSnapshot();
     UTILS_RELEASE_ASSERT_MSG(
-        !offscreen->requiresTextureSnapshotPresentation(),
+        texture != nullptr,
         "Geode compositor layer rasterization did not produce a GPU texture. Refusing CPU "
         "readback/upload fallback in Geode presentation mode.");
+    layer.setTextureSnapshot(std::move(texture), worldFromEntity);
+  } else {
     layer.setBitmap(offscreen->takeSnapshot(), worldFromEntity);
   }
   layer.setCanvasOffset(geometry.canvasOffset);
@@ -2014,15 +2015,15 @@ void CompositorController::rasterizeDirtyStaticSegments(const RenderViewport& vi
         RendererDriver driver(*offscreen);
         driver.drawEntityRange(registry, paintOrder[startIdx], paintOrder[endIdx], tightViewport,
                                Transform2d::Translate(-tightBoundsSnapped.topLeft));
-        if (std::shared_ptr<const RendererTextureSnapshot> texture =
-                offscreen->takeTextureSnapshot()) {
+        if (offscreen->requiresTextureSnapshotPresentation()) {
+          std::shared_ptr<const RendererTextureSnapshot> texture = offscreen->takeTextureSnapshot();
+          UTILS_RELEASE_ASSERT_MSG(
+              texture != nullptr,
+              "Geode compositor segment rasterization did not produce a GPU texture. Refusing CPU "
+              "readback/upload fallback in Geode presentation mode.");
           staticSegments_[i] = RendererBitmap{};
           staticSegmentTextures_[i] = std::move(texture);
         } else {
-          UTILS_RELEASE_ASSERT_MSG(
-              !offscreen->requiresTextureSnapshotPresentation(),
-              "Geode compositor segment rasterization did not produce a GPU texture. Refusing CPU "
-              "readback/upload fallback in Geode presentation mode.");
           staticSegments_[i] = offscreen->takeSnapshot();
           staticSegmentTextures_[i].reset();
         }
@@ -2032,15 +2033,15 @@ void CompositorController::rasterizeDirtyStaticSegments(const RenderViewport& vi
         RendererDriver driver(*offscreen);
         driver.drawEntityRange(registry, paintOrder[startIdx], paintOrder[endIdx], viewport,
                                Transform2d());
-        if (std::shared_ptr<const RendererTextureSnapshot> texture =
-                offscreen->takeTextureSnapshot()) {
+        if (offscreen->requiresTextureSnapshotPresentation()) {
+          std::shared_ptr<const RendererTextureSnapshot> texture = offscreen->takeTextureSnapshot();
+          UTILS_RELEASE_ASSERT_MSG(
+              texture != nullptr,
+              "Geode compositor segment rasterization did not produce a GPU texture. Refusing CPU "
+              "readback/upload fallback in Geode presentation mode.");
           staticSegments_[i] = RendererBitmap{};
           staticSegmentTextures_[i] = std::move(texture);
         } else {
-          UTILS_RELEASE_ASSERT_MSG(
-              !offscreen->requiresTextureSnapshotPresentation(),
-              "Geode compositor segment rasterization did not produce a GPU texture. Refusing CPU "
-              "readback/upload fallback in Geode presentation mode.");
           staticSegments_[i] = offscreen->takeSnapshot();
           staticSegmentTextures_[i].reset();
         }

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -617,8 +617,10 @@ struct RendererGeode::Impl {
     // The pattern tile being recorded.
     Box2d tileRect;                 // In pattern space (topLeft at origin).
     Transform2d targetFromPattern;  // Transform used when the tile is sampled.
-    wgpu::Texture tileTexture;      // Offscreen tile (1-sample resolve) being sampled later.
-    wgpu::Texture tileMsaaTexture;  // 4× MSAA companion used during tile recording.
+    geode::ScopedWgpuHandle<wgpu::Texture>
+        tileTexture;  // Offscreen tile (1-sample resolve) being sampled later.
+    geode::ScopedWgpuHandle<wgpu::Texture>
+        tileMsaaTexture;  // 4× MSAA companion used during tile recording.
     int tilePixelWidth = 0;
     int tilePixelHeight = 0;
     // Scale factor applied to all `setTransform` calls while this frame is
@@ -664,7 +666,7 @@ struct RendererGeode::Impl {
     }
   };
   struct TextureBucket {
-    std::vector<wgpu::Texture> free;
+    std::vector<geode::ScopedWgpuHandle<wgpu::Texture>> free;
     /// Monotonic frame index when this bucket was last touched by
     /// either `acquireTexture` or `releaseTexture`. Used by
     /// `evictStalePoolBuckets` to age out buckets whose size hasn't
@@ -696,7 +698,7 @@ struct RendererGeode::Impl {
     TextureBucket& bucket = texturePool[TextureKey::From(desc)];
     bucket.lastUsedFrame = currentFrameIndex;
     if (!bucket.free.empty()) {
-      wgpu::Texture texture = std::move(bucket.free.back());
+      wgpu::Texture texture = bucket.free.back().take();
       bucket.free.pop_back();
       return texture;
     }
@@ -725,9 +727,10 @@ struct RendererGeode::Impl {
     if (bucket.free.size() >= kMaxPoolEntriesPerKey) {
       // Bucket full — let the released texture go out of scope instead
       // of unbounded growth.
+      geode::ScopedWgpuHandle<wgpu::Texture> dropped(std::move(texture));
       return;
     }
-    bucket.free.push_back(std::move(texture));
+    bucket.free.push_back(geode::ScopedWgpuHandle<wgpu::Texture>(std::move(texture)));
   }
 
   /// Drop every bucket whose `lastUsedFrame` is older than
@@ -838,7 +841,7 @@ struct RendererGeode::Impl {
 
   /// A completed pattern tile ready to be sampled as fill or stroke paint.
   struct PatternPaintSlot {
-    wgpu::Texture tile;
+    geode::ScopedWgpuHandle<wgpu::Texture> tile;
     Vector2d tileSize;              // In pattern space.
     Transform2d targetFromPattern;  // destFromSource naming.
     // `deviceFromLocalTransform` snapshotted at the time the outer element kicked
@@ -1060,7 +1063,7 @@ struct RendererGeode::Impl {
     const Transform2d patternFromDevice = deviceFromPattern.inverse();
     const Transform2d patternFromPath = patternFromDevice * deviceFromLocalTransform;
     geode::GeoEncoder::PatternPaint p;
-    p.tile = slot.tile;
+    p.tile = slot.tile.get();
     p.tileSize = slot.tileSize;
     p.patternFromPath = patternFromPath;
     p.opacity = opacity;
@@ -1365,6 +1368,9 @@ struct RendererGeode::Impl {
       const double opacity = paint.fillOpacity;
       encoder->fillPathPattern(path, rule, buildPatternPaint(*patternFillPaint, opacity),
                                precomputedEncoded);
+      if (patternFillPaint->tile) {
+        device->deferDestroy(patternFillPaint->tile.take());
+      }
       patternFillPaint.reset();
       return;
     }
@@ -2462,22 +2468,28 @@ void RendererGeode::popFilterLayer() {
     vpDesc.mipLevelCount = 1;
     vpDesc.sampleCount = 1;
     vpDesc.dimension = wgpu::TextureDimension::_2D;
-    wgpu::Texture viewportTexture = impl_->device->device().createTexture(vpDesc);
+    geode::ScopedWgpuHandle<wgpu::Texture> viewportTexture(
+        impl_->device->device().createTexture(vpDesc));
+    if (viewportTexture) {
+      impl_->device->countTexture();
+    }
 
     if (viewportTexture) {
-      wgpu::CommandEncoder copyEncoder = impl_->device->device().createCommandEncoder();
+      geode::ScopedWgpuHandle<wgpu::CommandEncoder> copyEncoder(
+          impl_->device->device().createCommandEncoder());
       wgpu::TexelCopyTextureInfo src = {};
       src.texture = filteredTexture;
       src.origin = {static_cast<uint32_t>(frame.filterBufferOffsetX),
                     static_cast<uint32_t>(frame.filterBufferOffsetY), 0u};
       wgpu::TexelCopyTextureInfo dst = {};
-      dst.texture = viewportTexture;
+      dst.texture = viewportTexture.get();
       const wgpu::Extent3D extent = {vpW, vpH, 1u};
-      copyEncoder.copyTextureToTexture(src, dst, extent);
-      wgpu::CommandBuffer copyCmd = copyEncoder.finish();
-      impl_->device->queue().submit(1, &copyCmd);
+      copyEncoder.get().copyTextureToTexture(src, dst, extent);
+      geode::ScopedWgpuHandle<wgpu::CommandBuffer> copyCmd(copyEncoder.get().finish());
+      impl_->device->queue().submit(1, &copyCmd.get());
 
-      impl_->encoder->blitFullTarget(viewportTexture, 1.0);
+      impl_->encoder->blitFullTarget(viewportTexture.get(), 1.0);
+      impl_->device->deferDestroy(viewportTexture.take());
     }
   } else {
     // TODO(geode): Clip the composite to the filter region per SVG 2 §15.5.
@@ -2486,6 +2498,9 @@ void RendererGeode::popFilterLayer() {
     // CTM snapshot before using it as a scissor. Skipping for this PR —
     // all current feGaussianBlur resvg tests pass without the clip.
     impl_->encoder->blitFullTarget(filteredTexture, 1.0);
+  }
+  if (filteredTexture && filteredTexture != frame.layerTexture) {
+    impl_->device->deferDestroy(std::move(filteredTexture));
   }
   // Defer release to endFrame: `blitFullTarget` recorded a sample from
   // `filteredTexture` (which is `frame.layerTexture` when the filter
@@ -2696,7 +2711,7 @@ void RendererGeode::beginPatternTile(const Box2d& tileRect, const Transform2d& t
   td.mipLevelCount = 1;
   td.sampleCount = 1;
   td.dimension = wgpu::TextureDimension::_2D;
-  wgpu::Texture tileTexture = impl_->device->device().createTexture(td);
+  geode::ScopedWgpuHandle<wgpu::Texture> tileTexture(impl_->device->device().createTexture(td));
   impl_->device->countTexture();
   if (!tileTexture) {
     return;
@@ -2705,7 +2720,7 @@ void RendererGeode::beginPatternTile(const Box2d& tileRect, const Transform2d& t
   // 4× MSAA companion render target — shares the same encoder lifetime
   // as the tile; resolved into `tileTexture` at pass end. Skipped on
   // the alpha-coverage path (sampleCount == 1).
-  wgpu::Texture tileMsaaTexture;
+  geode::ScopedWgpuHandle<wgpu::Texture> tileMsaaTexture;
   if (impl_->device->sampleCount() > 1) {
     wgpu::TextureDescriptor tileMsaaDesc = {};
     tileMsaaDesc.label = wgpuLabel("RendererGeodePatternTileMSAA");
@@ -2715,12 +2730,14 @@ void RendererGeode::beginPatternTile(const Box2d& tileRect, const Transform2d& t
     tileMsaaDesc.mipLevelCount = 1;
     tileMsaaDesc.sampleCount = 4;
     tileMsaaDesc.dimension = wgpu::TextureDimension::_2D;
-    tileMsaaTexture = impl_->device->device().createTexture(tileMsaaDesc);
+    tileMsaaTexture.reset(impl_->device->device().createTexture(tileMsaaDesc));
     impl_->device->countTexture();
     if (!tileMsaaTexture) {
       return;
     }
   }
+  const wgpu::Texture tileTextureHandle = tileTexture.get();
+  const wgpu::Texture tileMsaaTextureHandle = tileMsaaTexture.get();
 
   // Stash the currently-active encoder/target/transform state. A nested
   // encoder can't share a render pass with the outer one, so we finish any
@@ -2747,8 +2764,8 @@ void RendererGeode::beginPatternTile(const Box2d& tileRect, const Transform2d& t
   frame.savedPixelHeight = impl_->pixelHeight;
   frame.tileRect = tileRect;
   frame.targetFromPattern = targetFromPattern;
-  frame.tileTexture = tileTexture;
-  frame.tileMsaaTexture = tileMsaaTexture;
+  frame.tileTexture = std::move(tileTexture);
+  frame.tileMsaaTexture = std::move(tileMsaaTexture);
   frame.tilePixelWidth = tilePixelWidth;
   frame.tilePixelHeight = tilePixelHeight;
   // Map pattern-tile units onto tile-texture pixels: this factor is applied
@@ -2773,8 +2790,8 @@ void RendererGeode::beginPatternTile(const Box2d& tileRect, const Transform2d& t
   // tile texture so the new encoder's MVP maps correctly.
   impl_->pixelWidth = tilePixelWidth;
   impl_->pixelHeight = tilePixelHeight;
-  impl_->target = tileTexture;
-  impl_->msaaTarget = tileMsaaTexture;
+  impl_->target = tileTextureHandle;
+  impl_->msaaTarget = tileMsaaTextureHandle;
   impl_->deviceFromLocalTransformStack.clear();
   // Initialise the current transform to the raster scale so direct draws
   // issued before the driver's next `setTransform` still land in the
@@ -2784,7 +2801,7 @@ void RendererGeode::beginPatternTile(const Box2d& tileRect, const Transform2d& t
 
   auto newEncoder = std::make_unique<geode::GeoEncoder>(
       *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
-      tileMsaaTexture, tileTexture, impl_->frameCommandEncoder.get());
+      tileMsaaTextureHandle, tileTextureHandle, impl_->frameCommandEncoder.get());
   // Transparent clear so unpainted tile pixels contribute nothing.
   newEncoder->clear(css::RGBA(0, 0, 0, 0));
   impl_->encoder = std::move(newEncoder);
@@ -2807,6 +2824,9 @@ void RendererGeode::endPatternTile(bool forStroke) {
   // for sampling by subsequent draws.
   if (impl_->encoder) {
     impl_->encoder->finish();
+  }
+  if (frame.tileMsaaTexture) {
+    impl_->device->deferDestroy(frame.tileMsaaTexture.take());
   }
 
   // Restore outer state.
@@ -2876,7 +2896,7 @@ void RendererGeode::endPatternTile(bool forStroke) {
   // through the existing 4x4 matrix multiply and compares against the
   // tile's native dimensions.
   Impl::PatternPaintSlot slot;
-  slot.tile = frame.tileTexture;
+  slot.tile = std::move(frame.tileTexture);
   slot.tileSize = frame.tileRect.size();
   slot.targetFromPattern = frame.targetFromPattern;
   // `frame.savedDeviceFromLocalTransform` is the path→device transform that was live at
@@ -3002,6 +3022,9 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
     impl_->encoder->fillPathPattern(strokedOutline, strokeDerived.fillRule,
                                     impl_->buildPatternPaint(*impl_->patternStrokePaint, opacity),
                                     strokeDerived.encoded);
+    if (impl_->patternStrokePaint->tile) {
+      impl_->device->deferDestroy(impl_->patternStrokePaint->tile.take());
+    }
     impl_->patternStrokePaint.reset();
     return;
   }

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -76,6 +76,10 @@ constexpr wgpu::TextureFormat kFilterIntermediateFormat = wgpu::TextureFormat::R
 /// matching the CPU-renderer helper.
 const Box2d kUnitPathBounds(Vector2d::Zero(), Vector2d(1, 1));
 
+bool IsBgraTextureFormat(wgpu::TextureFormat format) {
+  return static_cast<WGPUTextureFormat>(format) == WGPUTextureFormat_BGRA8Unorm;
+}
+
 /// Apply a `Transform2d` to every control point of a `Path`, returning a
 /// new `Path` whose commands mirror the input but whose coordinates are
 /// pre-transformed. Needed because `GeoEncoder::fillPath` draws in the
@@ -3242,12 +3246,6 @@ std::unique_ptr<RendererInterface> RendererGeode::createOffscreenInstance() cons
 }
 
 std::shared_ptr<const RendererTextureSnapshot> RendererGeode::takeTextureSnapshot() {
-#ifdef __EMSCRIPTEN__
-  // Emscripten's editor UI uses WebGL, not ImGui's WGPU backend, so a
-  // WebGPU texture snapshot cannot be presented directly by the UI. Return
-  // null to let compositor/editor callers use `takeSnapshot()` CPU pixels.
-  return nullptr;
-#else
   if (!impl_->device || !impl_->target || impl_->hostTarget || impl_->pixelWidth <= 0 ||
       impl_->pixelHeight <= 0) {
     return nullptr;
@@ -3261,7 +3259,6 @@ std::shared_ptr<const RendererTextureSnapshot> RendererGeode::takeTextureSnapsho
 
   return std::make_shared<RendererGeodeTextureSnapshot>(impl_->device, std::move(texture),
                                                         dimensions, impl_->textureFormat);
-#endif
 }
 
 RendererBitmap RendererGeode::takeSnapshot() const {
@@ -3352,14 +3349,16 @@ RendererBitmap RendererGeode::takeSnapshot() const {
   // break cross-backend parity.
   bitmap.dimensions = Vector2i(static_cast<int>(width), static_cast<int>(height));
   bitmap.rowBytes = static_cast<size_t>(width) * 4u;
+  bitmap.alphaType = AlphaType::Unpremultiplied;
   bitmap.pixels.resize(bitmap.rowBytes * height);
+  const bool sourceIsBgra = IsBgraTextureFormat(impl_->textureFormat);
   for (uint32_t y = 0; y < height; ++y) {
     const uint8_t* srcRow = mapped + static_cast<size_t>(y) * bytesPerRow;
     uint8_t* dstRow = bitmap.pixels.data() + static_cast<size_t>(y) * bitmap.rowBytes;
     for (uint32_t x = 0; x < width; ++x) {
-      const uint8_t srcR = srcRow[x * 4 + 0];
+      const uint8_t srcR = sourceIsBgra ? srcRow[x * 4 + 2] : srcRow[x * 4 + 0];
       const uint8_t srcG = srcRow[x * 4 + 1];
-      const uint8_t srcB = srcRow[x * 4 + 2];
+      const uint8_t srcB = sourceIsBgra ? srcRow[x * 4 + 0] : srcRow[x * 4 + 2];
       const uint8_t srcA = srcRow[x * 4 + 3];
       if (srcA == 0u) {
         dstRow[x * 4 + 0] = 0u;

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -3242,6 +3242,12 @@ std::unique_ptr<RendererInterface> RendererGeode::createOffscreenInstance() cons
 }
 
 std::shared_ptr<const RendererTextureSnapshot> RendererGeode::takeTextureSnapshot() {
+#ifdef __EMSCRIPTEN__
+  // Emscripten's editor UI uses WebGL, not ImGui's WGPU backend, so a
+  // WebGPU texture snapshot cannot be presented directly by the UI. Return
+  // null to let compositor/editor callers use `takeSnapshot()` CPU pixels.
+  return nullptr;
+#else
   if (!impl_->device || !impl_->target || impl_->hostTarget || impl_->pixelWidth <= 0 ||
       impl_->pixelHeight <= 0) {
     return nullptr;
@@ -3255,6 +3261,7 @@ std::shared_ptr<const RendererTextureSnapshot> RendererGeode::takeTextureSnapsho
 
   return std::make_shared<RendererGeodeTextureSnapshot>(impl_->device, std::move(texture),
                                                         dimensions, impl_->textureFormat);
+#endif
 }
 
 RendererBitmap RendererGeode::takeSnapshot() const {

--- a/donner/svg/renderer/RendererGeode.h
+++ b/donner/svg/renderer/RendererGeode.h
@@ -270,8 +270,16 @@ public:
    */
   [[nodiscard]] std::shared_ptr<const RendererTextureSnapshot> takeTextureSnapshot() override;
 
-  /// Geode presentation is GPU-native; editor handoff must not use CPU readback/upload.
-  [[nodiscard]] bool requiresTextureSnapshotPresentation() const override { return true; }
+  /// Geode presentation is GPU-native on native WGPU editor builds.
+  [[nodiscard]] bool requiresTextureSnapshotPresentation() const override {
+#ifdef __EMSCRIPTEN__
+    // The wasm editor presents through ImGui's WebGL backend, so WebGPU
+    // texture snapshots cannot be handed directly to the UI layer.
+    return false;
+#else
+    return true;
+#endif
+  }
 
 private:
   struct Impl;

--- a/donner/svg/renderer/RendererGeode.h
+++ b/donner/svg/renderer/RendererGeode.h
@@ -270,11 +270,13 @@ public:
    */
   [[nodiscard]] std::shared_ptr<const RendererTextureSnapshot> takeTextureSnapshot() override;
 
-  /// Geode presentation is GPU-native on native WGPU editor builds.
+  /// Geode presentation is GPU-native when callers can sample WebGPU textures directly.
   [[nodiscard]] bool requiresTextureSnapshotPresentation() const override {
 #ifdef __EMSCRIPTEN__
-    // The wasm editor presents through ImGui's WebGL backend, so WebGPU
-    // texture snapshots cannot be handed directly to the UI layer.
+    // Emscripten's WebGPU object table is per-worker. The editor's async
+    // renderer runs on a pthread, while ImGui presents on the main browser
+    // thread, so worker-created texture handles cannot be handed directly to
+    // ImGui. Use CPU snapshots for the worker handoff in wasm builds.
     return false;
 #else
     return true;

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -198,10 +198,10 @@ struct GeoEncoder::Impl {
   /// holds the handle until the `Arena` itself is destroyed (at
   /// encoder destruction, after `finish()` has submitted all work).
   struct Arena {
-    wgpu::Buffer buffer;
+    ScopedWgpuHandle<wgpu::Buffer> buffer;
     uint64_t capacity = 0;
     uint64_t offset = 0;  // Next unused byte within `buffer`.
-    std::vector<wgpu::Buffer> retired;
+    std::vector<ScopedWgpuHandle<wgpu::Buffer>> retired;
     wgpu::BufferUsage usage = wgpu::BufferUsage::CopyDst;
     const char* label = "GeodeArena";
   };
@@ -246,25 +246,25 @@ struct GeoEncoder::Impl {
       desc.label = wgpuLabel(arena.label);
       desc.size = newCap;
       desc.usage = arena.usage;
-      arena.buffer = device->device().createBuffer(desc);
+      arena.buffer.reset(device->device().createBuffer(desc));
       device->countBuffer();
       arena.capacity = newCap;
       arena.offset = 0;
       alignedOffset = 0;
     }
-    device->queue().writeBuffer(arena.buffer, alignedOffset, data, size);
+    device->queue().writeBuffer(arena.buffer.get(), alignedOffset, data, size);
     arena.offset = alignedOffset + size;
-    return {&arena.buffer, alignedOffset, size};
+    return {&arena.buffer.get(), alignedOffset, size};
   }
   // When sampleCount == 4: multisampled color attachment. All draws land
   // here and the hardware resolves into `target` at the end of each pass.
   // When sampleCount == 1: unused (null) — draws go directly to `target`.
   wgpu::Texture msaaTarget;
-  wgpu::TextureView msaaTargetView;
+  ScopedWgpuHandle<wgpu::TextureView> msaaTargetView;
   // 1-sample resolve / direct-render texture. External code (image blit,
   // readback) samples / copies from this texture, never the MSAA color.
   wgpu::Texture target;
-  wgpu::TextureView targetView;
+  ScopedWgpuHandle<wgpu::TextureView> targetView;
   ScopedWgpuHandle<wgpu::CommandEncoder> ownedCommandEncoder;
   wgpu::CommandEncoder commandEncoder;
   uint32_t targetWidth;
@@ -313,7 +313,7 @@ struct GeoEncoder::Impl {
   // so main-pass draw code picks back up exactly where it left off
   // when the mask pass ends.
   bool maskPassOpen = false;
-  wgpu::RenderPassEncoder maskPass;
+  ScopedWgpuHandle<wgpu::RenderPassEncoder> maskPass;
   // Transform active when the mask pass was opened, so mask draws use
   // the same device-pixel space as the parent content. The mask pass
   // always renders into the mask texture the caller passed in, which
@@ -323,7 +323,12 @@ struct GeoEncoder::Impl {
   // Pending draws are recorded into a render pass that's lazily opened.
   // The first clear/fill triggers `beginPass()`; finish() ends it.
   bool passOpen = false;
-  wgpu::RenderPassEncoder pass;
+  ScopedWgpuHandle<wgpu::RenderPassEncoder> pass;
+
+  // Per-encoder resources created while recording draw calls. They are
+  // released together when the encoder is destroyed, after `finish()` has
+  // ended the open pass and submitted the command buffer in owning mode.
+  ScopedWgpuResourceArena transientResources;
 
   // Default load op = clear-to-transparent until clear() is called explicitly.
   wgpu::Color clearColor = {0.0, 0.0, 0.0, 0.0};
@@ -395,9 +400,9 @@ struct GeoEncoder::Impl {
       uint32_t maxH = targetHeight - y;
       uint32_t w = std::min(scissorW, maxW);
       uint32_t h = std::min(scissorH, maxH);
-      pass.setScissorRect(x, y, w, h);
+      pass.get().setScissorRect(x, y, w, h);
     } else {
-      pass.setScissorRect(0, 0, targetWidth, targetHeight);
+      pass.get().setScissorRect(0, 0, targetWidth, targetHeight);
     }
   }
 
@@ -426,12 +431,12 @@ struct GeoEncoder::Impl {
       // state for a subsequent pass (see `setLoadPreserve()` — we may
       // reopen a pass to continue drawing on top of the previous MSAA
       // contents, e.g., after a nested-layer composite).
-      color.view = msaaTargetView;
-      color.resolveTarget = targetView;
+      color.view = msaaTargetView.get();
+      color.resolveTarget = targetView.get();
     } else {
       // 1-sample (alpha-coverage path): draw directly into the target
       // texture — no MSAA intermediate, no hardware resolve.
-      color.view = targetView;
+      color.view = targetView.get();
     }
     color.loadOp = loadPreserve ? wgpu::LoadOp::Load : wgpu::LoadOp::Clear;
     color.storeOp = wgpu::StoreOp::Store;
@@ -446,7 +451,7 @@ struct GeoEncoder::Impl {
     desc.colorAttachmentCount = 1;
     desc.colorAttachments = &color;
     desc.label = wgpuLabel("GeoEncoderPass");
-    pass = commandEncoder.beginRenderPass(desc);
+    pass.reset(commandEncoder.beginRenderPass(desc));
     // Pipelines are set per-draw — `fillPath` / `fillPathLinearGradient` /
     // `drawImage` each rebind their own pipeline before issuing a draw call.
     // Re-binding only happens when the bound pipeline differs from the next
@@ -470,7 +475,7 @@ struct GeoEncoder::Impl {
   bool currentPipelineIsGradient = false;
   void bindSolidPipeline() {
     if (currentPipeline != BoundPipeline::kSolid) {
-      pass.setPipeline(pipeline->pipeline());
+      pass.get().setPipeline(pipeline->pipeline());
       device->countPipelineSwitch();
       currentPipeline = BoundPipeline::kSolid;
       currentPipelineIsGradient = false;
@@ -478,7 +483,7 @@ struct GeoEncoder::Impl {
   }
   void bindGradientPipeline() {
     if (currentPipeline != BoundPipeline::kGradient) {
-      pass.setPipeline(gradientPipeline->pipeline());
+      pass.get().setPipeline(gradientPipeline->pipeline());
       device->countPipelineSwitch();
       currentPipeline = BoundPipeline::kGradient;
       currentPipelineIsGradient = true;
@@ -486,7 +491,7 @@ struct GeoEncoder::Impl {
   }
   void bindImagePipeline(const wgpu::RenderPipeline& imageRenderPipeline) {
     if (currentPipeline != BoundPipeline::kImage) {
-      pass.setPipeline(imageRenderPipeline);
+      pass.get().setPipeline(imageRenderPipeline);
       device->countPipelineSwitch();
       currentPipeline = BoundPipeline::kImage;
       currentPipelineIsGradient = false;
@@ -559,13 +564,13 @@ void GeoEncoder::initImpl(GeoEncoder::Impl& impl, GeodeDevice& device,
   impl.imagePipeline = &imagePipeline;
   impl.sampleCount = device.sampleCount();
   impl.target = resolveTarget;
-  impl.targetView = resolveTarget.createView();
+  impl.targetView.reset(resolveTarget.createView());
   impl.targetWidth = resolveTarget.getWidth();
   impl.targetHeight = resolveTarget.getHeight();
 
   if (impl.sampleCount > 1) {
     impl.msaaTarget = msaaTarget;
-    impl.msaaTargetView = msaaTarget.createView();
+    impl.msaaTargetView.reset(msaaTarget.createView());
   }
   // When sampleCount == 1 the msaaTarget / msaaTargetView stay null —
   // ensurePassOpen renders directly into targetView with no resolve.
@@ -746,7 +751,8 @@ void GeoEncoder::beginMaskPass(const wgpu::Texture& msaaMask, const wgpu::Textur
   // run on the next open.
   const bool mainPassWasOpen = impl_->passOpen;
   if (mainPassWasOpen) {
-    impl_->pass.end();
+    impl_->pass.get().end();
+    impl_->pass.reset();
     impl_->passOpen = false;
     impl_->loadPreserve = true;
   }
@@ -759,11 +765,11 @@ void GeoEncoder::beginMaskPass(const wgpu::Texture& msaaMask, const wgpu::Textur
 
   impl_->maskPassSavedTransform = impl_->transform;
 
-  wgpu::TextureView resolveView = resolveMask.createView();
+  wgpu::TextureView resolveView = impl_->transientResources.retain(resolveMask.createView());
 
   wgpu::RenderPassColorAttachment color = {};
   if (impl_->sampleCount > 1) {
-    wgpu::TextureView msaaView = msaaMask.createView();
+    wgpu::TextureView msaaView = impl_->transientResources.retain(msaaMask.createView());
     color.view = msaaView;
     color.resolveTarget = resolveView;
   } else {
@@ -780,12 +786,12 @@ void GeoEncoder::beginMaskPass(const wgpu::Texture& msaaMask, const wgpu::Textur
   desc.colorAttachmentCount = 1;
   desc.colorAttachments = &color;
   desc.label = wgpuLabel("GeoEncoderMaskPass");
-  impl_->maskPass = impl_->commandEncoder.beginRenderPass(desc);
-  impl_->maskPass.setPipeline(impl_->maskPipelineOwned->pipeline());
+  impl_->maskPass.reset(impl_->commandEncoder.beginRenderPass(desc));
+  impl_->maskPass.get().setPipeline(impl_->maskPipelineOwned->pipeline());
   impl_->device->countPipelineSwitch();
   // Full-target scissor so clip-path fills aren't clipped by any
   // outer scissor still cached in the encoder state.
-  impl_->maskPass.setScissorRect(0, 0, impl_->targetWidth, impl_->targetHeight);
+  impl_->maskPass.get().setScissorRect(0, 0, impl_->targetWidth, impl_->targetHeight);
   impl_->maskPassOpen = true;
 }
 
@@ -872,12 +878,12 @@ void GeoEncoder::fillPathIntoMask(const Path& path, FillRule rule,
   bgDesc.layout = impl_->maskPipelineOwned->bindGroupLayout();
   bgDesc.entryCount = 5;
   bgDesc.entries = entries;
-  wgpu::BindGroup bindGroup = dev.createBindGroup(bgDesc);
+  wgpu::BindGroup bindGroup = impl_->transientResources.retain(dev.createBindGroup(bgDesc));
   impl_->device->countBindGroup();
 
-  impl_->maskPass.setVertexBuffer(0, *vbAlloc.buffer, vbAlloc.offset, vbAlloc.size);
-  impl_->maskPass.setBindGroup(0, bindGroup, 0, nullptr);
-  impl_->maskPass.draw(static_cast<uint32_t>(encoded.vertices.size()), 1, 0, 0);
+  impl_->maskPass.get().setVertexBuffer(0, *vbAlloc.buffer, vbAlloc.offset, vbAlloc.size);
+  impl_->maskPass.get().setBindGroup(0, bindGroup, 0, nullptr);
+  impl_->maskPass.get().draw(static_cast<uint32_t>(encoded.vertices.size()), 1, 0, 0);
   impl_->device->countDraw();
 }
 
@@ -885,7 +891,8 @@ void GeoEncoder::endMaskPass() {
   if (!impl_->maskPassOpen) {
     return;
   }
-  impl_->maskPass.end();
+  impl_->maskPass.get().end();
+  impl_->maskPass.reset();
   impl_->maskPassOpen = false;
   // Rebind pipeline tracker — the main pass will need to re-select a
   // pipeline on its next draw.
@@ -1056,14 +1063,15 @@ void GeoEncoder::fillPathPattern(const Path& path, FillRule rule, const PatternP
   sd.minFilter = wgpu::FilterMode::Linear;
   sd.magFilter = wgpu::FilterMode::Linear;
   sd.maxAnisotropy = 1;
-  wgpu::Sampler sampler = impl_->device->device().createSampler(sd);
+  wgpu::Sampler sampler =
+      impl_->transientResources.retain(impl_->device->device().createSampler(sd));
 
   FillDrawArgs args = {};
   args.path = &path;
   args.rule = rule;
   args.precomputedEncoded = precomputedEncoded;
   args.paintMode = 1u;
-  args.patternView = paint.tile.createView();
+  args.patternView = impl_->transientResources.retain(paint.tile.createView());
   args.patternSampler = sampler;
   args.patternFromPath = paint.patternFromPath;
   args.tileSize = paint.tileSize;
@@ -1188,13 +1196,13 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args) {
   bgDesc.layout = impl_->pipeline->bindGroupLayout();
   bgDesc.entryCount = 8;
   bgDesc.entries = entries;
-  wgpu::BindGroup bindGroup = dev.createBindGroup(bgDesc);
+  wgpu::BindGroup bindGroup = impl_->transientResources.retain(dev.createBindGroup(bgDesc));
   impl_->device->countBindGroup();
 
   // 4. Record the draw call.
-  impl_->pass.setVertexBuffer(0, *vbAlloc.buffer, vbAlloc.offset, vbAlloc.size);
-  impl_->pass.setBindGroup(0, bindGroup, 0, nullptr);
-  impl_->pass.draw(static_cast<uint32_t>(encoded.vertices.size()), args.instanceCount, 0, 0);
+  impl_->pass.get().setVertexBuffer(0, *vbAlloc.buffer, vbAlloc.offset, vbAlloc.size);
+  impl_->pass.get().setBindGroup(0, bindGroup, 0, nullptr);
+  impl_->pass.get().draw(static_cast<uint32_t>(encoded.vertices.size()), args.instanceCount, 0, 0);
   impl_->device->countDraw();
 }
 
@@ -1336,12 +1344,12 @@ void GeoEncoder::fillPathLinearGradient(const Path& path, const LinearGradientPa
   bgDesc.layout = impl_->gradientPipeline->bindGroupLayout();
   bgDesc.entryCount = 5;
   bgDesc.entries = entries;
-  wgpu::BindGroup bindGroup = dev.createBindGroup(bgDesc);
+  wgpu::BindGroup bindGroup = impl_->transientResources.retain(dev.createBindGroup(bgDesc));
   impl_->device->countBindGroup();
 
-  impl_->pass.setVertexBuffer(0, *vbAlloc.buffer, vbAlloc.offset, vbAlloc.size);
-  impl_->pass.setBindGroup(0, bindGroup, 0, nullptr);
-  impl_->pass.draw(static_cast<uint32_t>(encoded.vertices.size()), 1, 0, 0);
+  impl_->pass.get().setVertexBuffer(0, *vbAlloc.buffer, vbAlloc.offset, vbAlloc.size);
+  impl_->pass.get().setBindGroup(0, bindGroup, 0, nullptr);
+  impl_->pass.get().draw(static_cast<uint32_t>(encoded.vertices.size()), 1, 0, 0);
   impl_->device->countDraw();
 }
 
@@ -1433,12 +1441,12 @@ void GeoEncoder::fillPathRadialGradient(const Path& path, const RadialGradientPa
   bgDesc.layout = impl_->gradientPipeline->bindGroupLayout();
   bgDesc.entryCount = 5;
   bgDesc.entries = entries;
-  wgpu::BindGroup bindGroup = dev.createBindGroup(bgDesc);
+  wgpu::BindGroup bindGroup = impl_->transientResources.retain(dev.createBindGroup(bgDesc));
   impl_->device->countBindGroup();
 
-  impl_->pass.setVertexBuffer(0, *vbAlloc.buffer, vbAlloc.offset, vbAlloc.size);
-  impl_->pass.setBindGroup(0, bindGroup, 0, nullptr);
-  impl_->pass.draw(static_cast<uint32_t>(encoded.vertices.size()), 1, 0, 0);
+  impl_->pass.get().setVertexBuffer(0, *vbAlloc.buffer, vbAlloc.offset, vbAlloc.size);
+  impl_->pass.get().setBindGroup(0, bindGroup, 0, nullptr);
+  impl_->pass.get().draw(static_cast<uint32_t>(encoded.vertices.size()), 1, 0, 0);
   impl_->device->countDraw();
 }
 
@@ -1478,8 +1486,9 @@ void GeoEncoder::blitFullTarget(const wgpu::Texture& src, double opacity) {
   qp.sourceIsPremultiplied = true;
   qp.clipMaskView = impl_->activeClipMaskView;
 
-  GeodeTextureEncoder::drawTexturedQuad(*impl_->device, *impl_->imagePipeline, impl_->pass, src,
-                                        mvp, impl_->targetWidth, impl_->targetHeight, qp);
+  GeodeTextureEncoder::drawTexturedQuad(*impl_->device, *impl_->imagePipeline, impl_->pass.get(),
+                                        src, mvp, impl_->targetWidth, impl_->targetHeight, qp,
+                                        impl_->transientResources);
 }
 
 void GeoEncoder::blitFullTargetMasked(const wgpu::Texture& content, const wgpu::Texture& mask,
@@ -1518,8 +1527,9 @@ void GeoEncoder::blitFullTargetMasked(const wgpu::Texture& content, const wgpu::
     qp.maskBounds = *maskBounds;
   }
 
-  GeodeTextureEncoder::drawTexturedQuad(*impl_->device, *impl_->imagePipeline, impl_->pass, content,
-                                        mvp, impl_->targetWidth, impl_->targetHeight, qp);
+  GeodeTextureEncoder::drawTexturedQuad(*impl_->device, *impl_->imagePipeline, impl_->pass.get(),
+                                        content, mvp, impl_->targetWidth, impl_->targetHeight, qp,
+                                        impl_->transientResources);
 }
 
 void GeoEncoder::blitFullTargetBlended(const wgpu::Texture& layer, const wgpu::Texture& dstSnapshot,
@@ -1560,8 +1570,9 @@ void GeoEncoder::blitFullTargetBlended(const wgpu::Texture& layer, const wgpu::T
   qp.dstSnapshotTexture = dstSnapshot;
   qp.clipMaskView = impl_->activeClipMaskView;
 
-  GeodeTextureEncoder::drawTexturedQuad(*impl_->device, *impl_->imagePipeline, impl_->pass, layer,
-                                        mvp, impl_->targetWidth, impl_->targetHeight, qp);
+  GeodeTextureEncoder::drawTexturedQuad(*impl_->device, *impl_->imagePipeline, impl_->pass.get(),
+                                        layer, mvp, impl_->targetWidth, impl_->targetHeight, qp,
+                                        impl_->transientResources);
 }
 
 void GeoEncoder::drawImage(const svg::ImageResource& image, const Box2d& destRect, double opacity,
@@ -1591,9 +1602,9 @@ void GeoEncoder::drawImage(const svg::ImageResource& image, const Box2d& destRec
   impl_->bindImagePipeline(impl_->imagePipeline->pipeline());
 
   // Upload the image to a sampled texture.
-  wgpu::Texture texture = GeodeTextureEncoder::uploadRgba8Texture(
+  wgpu::Texture texture = impl_->transientResources.retain(GeodeTextureEncoder::uploadRgba8Texture(
       *impl_->device, image.data.data(), static_cast<uint32_t>(image.width),
-      static_cast<uint32_t>(image.height));
+      static_cast<uint32_t>(image.height)));
   if (!texture) {
     return;
   }
@@ -1612,8 +1623,9 @@ void GeoEncoder::drawImage(const svg::ImageResource& image, const Box2d& destRec
       pixelated ? GeodeTextureEncoder::Filter::Nearest : GeodeTextureEncoder::Filter::Linear;
   qp.clipMaskView = impl_->activeClipMaskView;
 
-  GeodeTextureEncoder::drawTexturedQuad(*impl_->device, *impl_->imagePipeline, impl_->pass, texture,
-                                        mvp, impl_->targetWidth, impl_->targetHeight, qp);
+  GeodeTextureEncoder::drawTexturedQuad(*impl_->device, *impl_->imagePipeline, impl_->pass.get(),
+                                        texture, mvp, impl_->targetWidth, impl_->targetHeight, qp,
+                                        impl_->transientResources);
 }
 
 void GeoEncoder::drawTexture(const wgpu::Texture& texture, const Box2d& destRect, double opacity,
@@ -1640,19 +1652,22 @@ void GeoEncoder::drawTexture(const wgpu::Texture& texture, const Box2d& destRect
   qp.sourceIsPremultiplied = true;
   qp.clipMaskView = impl_->activeClipMaskView;
 
-  GeodeTextureEncoder::drawTexturedQuad(*impl_->device, *impl_->imagePipeline, impl_->pass, texture,
-                                        mvp, impl_->targetWidth, impl_->targetHeight, qp);
+  GeodeTextureEncoder::drawTexturedQuad(*impl_->device, *impl_->imagePipeline, impl_->pass.get(),
+                                        texture, mvp, impl_->targetWidth, impl_->targetHeight, qp,
+                                        impl_->transientResources);
 }
 
 void GeoEncoder::finish() {
   if (impl_->passOpen) {
-    impl_->pass.end();
+    impl_->pass.get().end();
+    impl_->pass.reset();
     impl_->passOpen = false;
   } else if (impl_->hasExplicitClear) {
     // No draws but a clear was requested — open and immediately close a pass
     // so the clear actually happens.
     impl_->ensurePassOpen();
-    impl_->pass.end();
+    impl_->pass.get().end();
+    impl_->pass.reset();
     impl_->passOpen = false;
   }
 

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -378,13 +378,13 @@ void GeodeDevice::initSharedPipelines() {
 
 void GeodeDevice::deferDestroy(wgpu::Buffer buffer) {
   if (buffer) {
-    pendingBuffers_.push_back(std::move(buffer));
+    pendingBuffers_.push_back(ScopedWgpuHandle<wgpu::Buffer>(std::move(buffer)));
   }
 }
 
 void GeodeDevice::deferDestroy(wgpu::Texture texture) {
   if (texture) {
-    pendingTextures_.push_back(std::move(texture));
+    pendingTextures_.push_back(ScopedWgpuHandle<wgpu::Texture>(std::move(texture)));
   }
 }
 

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -7,6 +7,7 @@
 #include <webgpu/webgpu.hpp>
 
 #include "donner/svg/renderer/geode/GeodeCounters.h"
+#include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 
 namespace donner::geode {
 
@@ -358,8 +359,8 @@ private:
 
   // Deferred-destroy queues: resources enqueued via deferDestroy() are held
   // alive until drainDeferredDestroys() drops them at the next frame boundary.
-  std::vector<wgpu::Buffer> pendingBuffers_;
-  std::vector<wgpu::Texture> pendingTextures_;
+  std::vector<ScopedWgpuHandle<wgpu::Buffer>> pendingBuffers_;
+  std::vector<ScopedWgpuHandle<wgpu::Texture>> pendingTextures_;
 };
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodeFilterEngine.cc
+++ b/donner/svg/renderer/geode/GeodeFilterEngine.cc
@@ -6,6 +6,7 @@
 #include <numbers>
 #include <unordered_map>
 #include <variant>
+#include <vector>
 
 #include "donner/svg/components/filter/FilterGraph.h"
 #include "donner/svg/renderer/geode/GeodeDevice.h"
@@ -13,6 +14,60 @@
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 
 namespace donner::geode {
+
+struct FilterResourceArena {
+  explicit FilterResourceArena(GeodeDevice& device) : device_(device) {}
+  ~FilterResourceArena() {
+    for (ScopedWgpuHandle<wgpu::Buffer>& buffer : buffers_) {
+      device_.deferDestroy(buffer.take());
+    }
+    for (ScopedWgpuHandle<wgpu::Texture>& texture : textures_) {
+      device_.deferDestroy(texture.take());
+    }
+  }
+
+  FilterResourceArena(const FilterResourceArena&) = delete;
+  FilterResourceArena& operator=(const FilterResourceArena&) = delete;
+
+  wgpu::Texture createTexture(const wgpu::Device& device, const wgpu::TextureDescriptor& desc) {
+    ScopedWgpuHandle<wgpu::Texture> texture(device.createTexture(desc));
+    if (!texture) {
+      return {};
+    }
+
+    device_.countTexture();
+    wgpu::Texture result = texture.get();
+    textures_.push_back(std::move(texture));
+    return result;
+  }
+
+  wgpu::Buffer createBuffer(const wgpu::Device& device, const wgpu::BufferDescriptor& desc) {
+    ScopedWgpuHandle<wgpu::Buffer> buffer(device.createBuffer(desc));
+    if (!buffer) {
+      return {};
+    }
+
+    device_.countBuffer();
+    wgpu::Buffer result = buffer.get();
+    buffers_.push_back(std::move(buffer));
+    return result;
+  }
+
+  wgpu::Texture takeTexture(wgpu::Texture texture) {
+    for (ScopedWgpuHandle<wgpu::Texture>& owned : textures_) {
+      if (owned.get() == texture) {
+        return owned.take();
+      }
+    }
+
+    return texture;
+  }
+
+private:
+  GeodeDevice& device_;
+  std::vector<ScopedWgpuHandle<wgpu::Texture>> textures_;
+  std::vector<ScopedWgpuHandle<wgpu::Buffer>> buffers_;
+};
 
 namespace {
 
@@ -371,8 +426,8 @@ uint32_t toShaderEdgeMode(svg::components::filter_primitive::GaussianBlur::EdgeM
 
 /// Create a texture usable as both a compute output (storage) and a
 /// subsequent compute / render input (texture binding).
-wgpu::Texture createIntermediateTexture(const wgpu::Device& device, uint32_t width, uint32_t height,
-                                        const char* label) {
+wgpu::Texture createIntermediateTexture(FilterResourceArena& arena, const wgpu::Device& device,
+                                        uint32_t width, uint32_t height, const char* label) {
   wgpu::TextureDescriptor td{};
   td.label = wgpuLabel(label);
   td.size = {width, height, 1};
@@ -382,7 +437,7 @@ wgpu::Texture createIntermediateTexture(const wgpu::Device& device, uint32_t wid
   td.mipLevelCount = 1;
   td.sampleCount = 1;
   td.dimension = wgpu::TextureDimension::_2D;
-  return device.createTexture(td);
+  return arena.createTexture(device, td);
 }
 
 /// Helper to create a pipeline with a standard (input, output, uniform) bind group layout.
@@ -516,17 +571,17 @@ void dispatchTwoInputUniform(GeodeDevice& device, const wgpu::BindGroupLayout& b
   const uint32_t width = output.getWidth();
   const uint32_t height = output.getHeight();
 
-  wgpu::TextureView in1View = in1.createView();
-  wgpu::TextureView in2View = in2.createView();
-  wgpu::TextureView outputView = output.createView();
+  ScopedWgpuHandle<wgpu::TextureView> in1View(in1.createView());
+  ScopedWgpuHandle<wgpu::TextureView> in2View(in2.createView());
+  ScopedWgpuHandle<wgpu::TextureView> outputView(output.createView());
 
   wgpu::BindGroupEntry bgEntries[4]{};
   bgEntries[0].binding = 0;
-  bgEntries[0].textureView = in1View;
+  bgEntries[0].textureView = in1View.get();
   bgEntries[1].binding = 1;
-  bgEntries[1].textureView = in2View;
+  bgEntries[1].textureView = in2View.get();
   bgEntries[2].binding = 2;
-  bgEntries[2].textureView = outputView;
+  bgEntries[2].textureView = outputView.get();
   bgEntries[3].binding = 3;
   bgEntries[3].buffer = uniformBuffer;
   bgEntries[3].offset = 0;
@@ -537,25 +592,27 @@ void dispatchTwoInputUniform(GeodeDevice& device, const wgpu::BindGroupLayout& b
   bgDesc.layout = bgl;
   bgDesc.entryCount = 4;
   bgDesc.entries = bgEntries;
-  wgpu::BindGroup bindGroup = dev.createBindGroup(bgDesc);
+  ScopedWgpuHandle<wgpu::BindGroup> bindGroup(dev.createBindGroup(bgDesc));
+  device.countBindGroup();
 
   wgpu::CommandEncoderDescriptor ceDesc{};
   ceDesc.label = wgpuLabel(label);
-  wgpu::CommandEncoder encoder = dev.createCommandEncoder(ceDesc);
+  ScopedWgpuHandle<wgpu::CommandEncoder> encoder(dev.createCommandEncoder(ceDesc));
 
   wgpu::ComputePassDescriptor passDesc{};
   passDesc.label = wgpuLabel(label);
-  wgpu::ComputePassEncoder pass = encoder.beginComputePass(passDesc);
-  pass.setPipeline(pipeline);
-  pass.setBindGroup(0, bindGroup, 0, nullptr);
+  ScopedWgpuHandle<wgpu::ComputePassEncoder> pass(encoder.get().beginComputePass(passDesc));
+  pass.get().setPipeline(pipeline);
+  pass.get().setBindGroup(0, bindGroup.get(), 0, nullptr);
 
   const uint32_t workgroupsX = (width + 7) / 8;
   const uint32_t workgroupsY = (height + 7) / 8;
-  pass.dispatchWorkgroups(workgroupsX, workgroupsY, 1);
-  pass.end();
+  pass.get().dispatchWorkgroups(workgroupsX, workgroupsY, 1);
+  pass.get().end();
+  pass.reset();
 
-  wgpu::CommandBuffer cmdBuf = encoder.finish();
-  device.queue().submit(1, &cmdBuf);
+  ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
+  device.queue().submit(1, &cmdBuf.get());
 }
 
 /// Dispatch a compute shader with a standard (input, output, uniform) bind group.
@@ -567,14 +624,14 @@ void dispatchInputOutputUniform(GeodeDevice& device, const wgpu::BindGroupLayout
   const uint32_t width = output.getWidth();
   const uint32_t height = output.getHeight();
 
-  wgpu::TextureView inputView = input.createView();
-  wgpu::TextureView outputView = output.createView();
+  ScopedWgpuHandle<wgpu::TextureView> inputView(input.createView());
+  ScopedWgpuHandle<wgpu::TextureView> outputView(output.createView());
 
   wgpu::BindGroupEntry bgEntries[3]{};
   bgEntries[0].binding = 0;
-  bgEntries[0].textureView = inputView;
+  bgEntries[0].textureView = inputView.get();
   bgEntries[1].binding = 1;
-  bgEntries[1].textureView = outputView;
+  bgEntries[1].textureView = outputView.get();
   bgEntries[2].binding = 2;
   bgEntries[2].buffer = uniformBuffer;
   bgEntries[2].offset = 0;
@@ -585,37 +642,39 @@ void dispatchInputOutputUniform(GeodeDevice& device, const wgpu::BindGroupLayout
   bgDesc.layout = bgl;
   bgDesc.entryCount = 3;
   bgDesc.entries = bgEntries;
-  wgpu::BindGroup bindGroup = dev.createBindGroup(bgDesc);
+  ScopedWgpuHandle<wgpu::BindGroup> bindGroup(dev.createBindGroup(bgDesc));
+  device.countBindGroup();
 
   wgpu::CommandEncoderDescriptor ceDesc{};
   ceDesc.label = wgpuLabel(label);
-  wgpu::CommandEncoder encoder = dev.createCommandEncoder(ceDesc);
+  ScopedWgpuHandle<wgpu::CommandEncoder> encoder(dev.createCommandEncoder(ceDesc));
 
   wgpu::ComputePassDescriptor passDesc{};
   passDesc.label = wgpuLabel(label);
-  wgpu::ComputePassEncoder pass = encoder.beginComputePass(passDesc);
-  pass.setPipeline(pipeline);
-  pass.setBindGroup(0, bindGroup, 0, nullptr);
+  ScopedWgpuHandle<wgpu::ComputePassEncoder> pass(encoder.get().beginComputePass(passDesc));
+  pass.get().setPipeline(pipeline);
+  pass.get().setBindGroup(0, bindGroup.get(), 0, nullptr);
 
   const uint32_t workgroupsX = (width + 7) / 8;
   const uint32_t workgroupsY = (height + 7) / 8;
-  pass.dispatchWorkgroups(workgroupsX, workgroupsY, 1);
-  pass.end();
+  pass.get().dispatchWorkgroups(workgroupsX, workgroupsY, 1);
+  pass.get().end();
+  pass.reset();
 
-  wgpu::CommandBuffer cmdBuf = encoder.finish();
-  device.queue().submit(1, &cmdBuf);
+  ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
+  device.queue().submit(1, &cmdBuf.get());
 }
 
 /// Create a uniform buffer and upload data to it.
-wgpu::Buffer createUniformBuffer(GeodeDevice& device, const void* data, size_t size,
-                                 const char* label) {
+wgpu::Buffer createUniformBuffer(FilterResourceArena& arena, GeodeDevice& device, const void* data,
+                                 size_t size, const char* label) {
   const wgpu::Device& dev = device.device();
   wgpu::BufferDescriptor bufDesc{};
   bufDesc.label = wgpuLabel(label);
   bufDesc.size = size;
   bufDesc.usage = wgpu::BufferUsage::Uniform | wgpu::BufferUsage::CopyDst;
   bufDesc.mappedAtCreation = false;
-  wgpu::Buffer buffer = dev.createBuffer(bufDesc);
+  wgpu::Buffer buffer = arena.createBuffer(dev, bufDesc);
   device.queue().writeBuffer(buffer, 0, data, size);
   return buffer;
 }
@@ -1218,11 +1277,12 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
                                          const Transform2d& deviceFromFilter) {
   using namespace svg::components;
 
+  FilterResourceArena arena(device_);
   std::unordered_map<std::string, wgpu::Texture> namedBuffers;
   wgpu::Texture currentBuffer = sourceGraphic;
   std::optional<wgpu::Texture> sourceAlpha;
   if (graphUsesStandardInput(graph, svg::components::FilterStandardInput::SourceAlpha)) {
-    sourceAlpha = applySourceAlpha(sourceGraphic);
+    sourceAlpha = applySourceAlpha(arena, sourceGraphic);
   }
 
   // Derive per-axis scale factors from the full CTM's basis vectors so
@@ -1352,11 +1412,12 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
           node.colorInterpolationFilters.value_or(graph.colorInterpolationFilters) !=
           svg::ColorInterpolationFilters::SRGB;
       if (nodeLinearRGB) {
-        wgpu::Texture linearInput = applyColorSpaceConversion(inputTex, /*srgbToLinear=*/true);
-        wgpu::Texture linearOutput = applyGaussianBlur(linearInput, sx, sy, em);
-        outputTex = applyColorSpaceConversion(linearOutput, /*srgbToLinear=*/false);
+        wgpu::Texture linearInput =
+            applyColorSpaceConversion(arena, inputTex, /*srgbToLinear=*/true);
+        wgpu::Texture linearOutput = applyGaussianBlur(arena, linearInput, sx, sy, em);
+        outputTex = applyColorSpaceConversion(arena, linearOutput, /*srgbToLinear=*/false);
       } else {
-        outputTex = applyGaussianBlur(inputTex, sx, sy, em);
+        outputTex = applyGaussianBlur(arena, inputTex, sx, sy, em);
       }
     } else if (const auto* offset = std::get_if<filter_primitive::Offset>(&node.primitive)) {
       // Project the offset vector through the full CTM so rotation/skew
@@ -1365,7 +1426,7 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
       filter_primitive::Offset scaled = *offset;
       scaled.dx = pixelOffset.x;
       scaled.dy = pixelOffset.y;
-      outputTex = applyOffset(inputTex, scaled);
+      outputTex = applyOffset(arena, inputTex, scaled);
     } else if (const auto* cm = std::get_if<filter_primitive::ColorMatrix>(&node.primitive)) {
       // Per SVG spec, feColorMatrix operates in linearRGB by default (the
       // `color-interpolation-filters` property). Match tiny-skia by
@@ -1379,17 +1440,18 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
             node.colorInterpolationFilters.value_or(graph.colorInterpolationFilters) !=
             svg::ColorInterpolationFilters::SRGB;
         if (nodeLinearRGB) {
-          wgpu::Texture linearInput = applyColorSpaceConversion(inputTex, /*srgbToLinear=*/true);
-          wgpu::Texture matrixOutput = applyColorMatrix(linearInput, *cm);
-          outputTex = applyColorSpaceConversion(matrixOutput, /*srgbToLinear=*/false);
+          wgpu::Texture linearInput =
+              applyColorSpaceConversion(arena, inputTex, /*srgbToLinear=*/true);
+          wgpu::Texture matrixOutput = applyColorMatrix(arena, linearInput, *cm);
+          outputTex = applyColorSpaceConversion(arena, matrixOutput, /*srgbToLinear=*/false);
         } else {
-          outputTex = applyColorMatrix(inputTex, *cm);
+          outputTex = applyColorMatrix(arena, inputTex, *cm);
         }
       }
     } else if (const auto* flood = std::get_if<filter_primitive::Flood>(&node.primitive)) {
-      outputTex = applyFlood(inputTex.getWidth(), inputTex.getHeight(), *flood);
+      outputTex = applyFlood(arena, inputTex.getWidth(), inputTex.getHeight(), *flood);
     } else if (std::holds_alternative<filter_primitive::Merge>(node.primitive)) {
-      outputTex = applyMerge(node, namedBuffers, currentBuffer, sourceGraphic,
+      outputTex = applyMerge(arena, node, namedBuffers, currentBuffer, sourceGraphic,
                              sourceAlpha ? &*sourceAlpha : nullptr);
     } else if (const auto* composite = std::get_if<filter_primitive::Composite>(&node.primitive)) {
       // Resolve second input (in2/backdrop).
@@ -1398,7 +1460,7 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
         in2Tex = resolveInput(node.inputs[1], namedBuffers, currentBuffer, sourceGraphic,
                               sourceAlpha ? &*sourceAlpha : nullptr);
       }
-      outputTex = applyComposite(inputTex, in2Tex, *composite);
+      outputTex = applyComposite(arena, inputTex, in2Tex, *composite);
     } else if (const auto* blend = std::get_if<filter_primitive::Blend>(&node.primitive)) {
       // Resolve second input (in2/backdrop).
       wgpu::Texture in2Tex = inputTex;
@@ -1413,24 +1475,24 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
           node.colorInterpolationFilters.value_or(graph.colorInterpolationFilters) !=
           svg::ColorInterpolationFilters::SRGB;
       if (nodeLinearRGB) {
-        wgpu::Texture linearIn1 = applyColorSpaceConversion(inputTex, /*srgbToLinear=*/true);
-        wgpu::Texture linearIn2 = applyColorSpaceConversion(in2Tex, /*srgbToLinear=*/true);
-        wgpu::Texture linearOutput = applyBlend(linearIn1, linearIn2, *blend);
-        outputTex = applyColorSpaceConversion(linearOutput, /*srgbToLinear=*/false);
+        wgpu::Texture linearIn1 = applyColorSpaceConversion(arena, inputTex, /*srgbToLinear=*/true);
+        wgpu::Texture linearIn2 = applyColorSpaceConversion(arena, in2Tex, /*srgbToLinear=*/true);
+        wgpu::Texture linearOutput = applyBlend(arena, linearIn1, linearIn2, *blend);
+        outputTex = applyColorSpaceConversion(arena, linearOutput, /*srgbToLinear=*/false);
       } else {
-        outputTex = applyBlend(inputTex, in2Tex, *blend);
+        outputTex = applyBlend(arena, inputTex, in2Tex, *blend);
       }
     } else if (const auto* morph = std::get_if<filter_primitive::Morphology>(&node.primitive)) {
       const int rx = static_cast<int>(std::round(toPixelX(morph->radiusX)));
       const int ry = static_cast<int>(std::round(toPixelY(morph->radiusY)));
-      outputTex = applyMorphology(inputTex, *morph, rx, ry);
+      outputTex = applyMorphology(arena, inputTex, *morph, rx, ry);
     } else if (const auto* ct = std::get_if<filter_primitive::ComponentTransfer>(&node.primitive)) {
-      outputTex = applyComponentTransfer(inputTex, *ct);
+      outputTex = applyComponentTransfer(arena, inputTex, *ct);
     } else if (const auto* conv = std::get_if<filter_primitive::ConvolveMatrix>(&node.primitive)) {
-      outputTex = applyConvolveMatrix(inputTex, *conv);
+      outputTex = applyConvolveMatrix(arena, inputTex, *conv);
     } else if (const auto* turb = std::get_if<filter_primitive::Turbulence>(&node.primitive)) {
-      outputTex =
-          applyTurbulence(inputTex.getWidth(), inputTex.getHeight(), *turb, deviceFromFilter);
+      outputTex = applyTurbulence(arena, inputTex.getWidth(), inputTex.getHeight(), *turb,
+                                  deviceFromFilter);
     } else if (const auto* disp = std::get_if<filter_primitive::DisplacementMap>(&node.primitive)) {
       wgpu::Texture in2Tex = inputTex;
       if (node.inputs.size() >= 2) {
@@ -1443,18 +1505,18 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
         pixelScale *= std::sqrt(bboxW * bboxH);
       }
       pixelScale *= std::sqrt(scaleX * scaleY);
-      outputTex = applyDisplacementMap(inputTex, in2Tex, *disp, pixelScale);
+      outputTex = applyDisplacementMap(arena, inputTex, in2Tex, *disp, pixelScale);
     } else if (const auto* diffuse =
                    std::get_if<filter_primitive::DiffuseLighting>(&node.primitive)) {
       const Box2d lightingInputSubregion =
           node.inputs.empty() ? filterRegionSubregion : resolveInputSubregion(node.inputs[0]);
-      outputTex =
-          applyDiffuseLighting(inputTex, *diffuse, graph, deviceFromFilter, lightingInputSubregion);
+      outputTex = applyDiffuseLighting(arena, inputTex, *diffuse, graph, deviceFromFilter,
+                                       lightingInputSubregion);
     } else if (const auto* specular =
                    std::get_if<filter_primitive::SpecularLighting>(&node.primitive)) {
       const Box2d lightingInputSubregion =
           node.inputs.empty() ? filterRegionSubregion : resolveInputSubregion(node.inputs[0]);
-      outputTex = applySpecularLighting(inputTex, *specular, graph, deviceFromFilter,
+      outputTex = applySpecularLighting(arena, inputTex, *specular, graph, deviceFromFilter,
                                         lightingInputSubregion);
     } else if (const auto* drop = std::get_if<filter_primitive::DropShadow>(&node.primitive)) {
       // stdDeviation is magnitude only; dx/dy are directional and need
@@ -1462,9 +1524,9 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
       double sx = drop->stdDeviationX >= 0 ? toPixelX(drop->stdDeviationX) : 0.0;
       double sy = drop->stdDeviationY >= 0 ? toPixelY(drop->stdDeviationY) : 0.0;
       const Vector2d pixelOffset = toPixelOffset(drop->dx, drop->dy);
-      outputTex = applyDropShadow(inputTex, *drop, sx, sy, pixelOffset.x, pixelOffset.y);
+      outputTex = applyDropShadow(arena, inputTex, *drop, sx, sy, pixelOffset.x, pixelOffset.y);
     } else if (const auto* image = std::get_if<filter_primitive::Image>(&node.primitive)) {
-      outputTex = applyImage(*image, inputTex.getWidth(), inputTex.getHeight(), graph, node,
+      outputTex = applyImage(arena, *image, inputTex.getWidth(), inputTex.getHeight(), graph, node,
                              deviceFromFilter);
     } else if (std::holds_alternative<filter_primitive::Tile>(node.primitive)) {
       // FE1 §9.20: feTile repeats the INPUT primitive's subregion to fill
@@ -1479,7 +1541,7 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
           static_cast<int32_t>(std::ceil(sourcePixels.bottomRight.x - sourcePixels.topLeft.x));
       int32_t srcH =
           static_cast<int32_t>(std::ceil(sourcePixels.bottomRight.y - sourcePixels.topLeft.y));
-      outputTex = applyTile(inputTex, srcX, srcY, srcW, srcH);
+      outputTex = applyTile(arena, inputTex, srcX, srcY, srcW, srcH);
     } else {
       // Unsupported primitive — pass through unchanged.
       if (verbose_ && !warnedUnsupported_) {
@@ -1590,7 +1652,7 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
         // Only needed when the node has explicit subregion attributes
         // and the CTM has rotation/skew, matching the CPU path's
         // per-pixel point-in-rect test.
-        outputTex = applySubregionClip(outputTex, filterFromDevice, nodeSubregion.topLeft.x,
+        outputTex = applySubregionClip(arena, outputTex, filterFromDevice, nodeSubregion.topLeft.x,
                                        nodeSubregion.topLeft.y, nodeSubregion.bottomRight.x,
                                        nodeSubregion.bottomRight.y);
       } else {
@@ -1602,9 +1664,10 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
         // pixels relative to the CPU reference.
         const Box2d pixelAABB = deviceFromFilter.transformBox(nodeSubregion);
         static const Transform2d kIdentity;
-        outputTex = applySubregionClip(
-            outputTex, kIdentity, std::floor(pixelAABB.topLeft.x), std::floor(pixelAABB.topLeft.y),
-            std::ceil(pixelAABB.bottomRight.x), std::ceil(pixelAABB.bottomRight.y));
+        outputTex =
+            applySubregionClip(arena, outputTex, kIdentity, std::floor(pixelAABB.topLeft.x),
+                               std::floor(pixelAABB.topLeft.y), std::ceil(pixelAABB.bottomRight.x),
+                               std::ceil(pixelAABB.bottomRight.y));
       }
 
       // Record the subregion for downstream nodes.
@@ -1636,17 +1699,17 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
       const Box2d pixelAABB = deviceFromFilter.transformBox(filterRegion);
       static const Transform2d kIdentity;
       currentBuffer =
-          applySubregionClip(currentBuffer, kIdentity, std::floor(pixelAABB.topLeft.x),
+          applySubregionClip(arena, currentBuffer, kIdentity, std::floor(pixelAABB.topLeft.x),
                              std::floor(pixelAABB.topLeft.y), std::ceil(pixelAABB.bottomRight.x),
                              std::ceil(pixelAABB.bottomRight.y));
     } else {
-      currentBuffer = applySubregionClip(currentBuffer, filterFromDevice, filterRegion.topLeft.x,
-                                         filterRegion.topLeft.y, filterRegion.bottomRight.x,
-                                         filterRegion.bottomRight.y);
+      currentBuffer = applySubregionClip(arena, currentBuffer, filterFromDevice,
+                                         filterRegion.topLeft.x, filterRegion.topLeft.y,
+                                         filterRegion.bottomRight.x, filterRegion.bottomRight.y);
     }
   }
 
-  return currentBuffer;
+  return arena.takeTexture(currentBuffer);
 }
 
 namespace {
@@ -1697,7 +1760,8 @@ BoxBlurPlan computeBoxPasses(double sigma) {
 
 }  // namespace
 
-wgpu::Texture GeodeFilterEngine::applyGaussianBlur(const wgpu::Texture& input, double stdDeviationX,
+wgpu::Texture GeodeFilterEngine::applyGaussianBlur(FilterResourceArena& arena,
+                                                   const wgpu::Texture& input, double stdDeviationX,
                                                    double stdDeviationY, uint32_t edgeMode) {
   const uint32_t width = input.getWidth();
   const uint32_t height = input.getHeight();
@@ -1717,11 +1781,11 @@ wgpu::Texture GeodeFilterEngine::applyGaussianBlur(const wgpu::Texture& input, d
     if (stdDeviationX >= kBoxBlurThreshold) {
       const BoxBlurPlan plan = computeBoxPasses(stdDeviationX);
       for (int i = 0; i < plan.numPasses; ++i) {
-        afterHorizontal = runBoxBlurPass(afterHorizontal, width, height, plan.passes[i].left,
+        afterHorizontal = runBoxBlurPass(arena, afterHorizontal, width, height, plan.passes[i].left,
                                          plan.passes[i].right, /*axis=*/0, edgeMode);
       }
     } else {
-      afterHorizontal = runBlurPass(input, width, height, static_cast<float>(stdDeviationX),
+      afterHorizontal = runBlurPass(arena, input, width, height, static_cast<float>(stdDeviationX),
                                     /*axis=*/0, edgeMode);
     }
   }
@@ -1731,24 +1795,25 @@ wgpu::Texture GeodeFilterEngine::applyGaussianBlur(const wgpu::Texture& input, d
     if (stdDeviationY >= kBoxBlurThreshold) {
       const BoxBlurPlan plan = computeBoxPasses(stdDeviationY);
       for (int i = 0; i < plan.numPasses; ++i) {
-        afterVertical = runBoxBlurPass(afterVertical, width, height, plan.passes[i].left,
+        afterVertical = runBoxBlurPass(arena, afterVertical, width, height, plan.passes[i].left,
                                        plan.passes[i].right, /*axis=*/1, edgeMode);
       }
     } else {
-      afterVertical = runBlurPass(afterHorizontal, width, height, static_cast<float>(stdDeviationY),
-                                  /*axis=*/1, edgeMode);
+      afterVertical =
+          runBlurPass(arena, afterHorizontal, width, height, static_cast<float>(stdDeviationY),
+                      /*axis=*/1, edgeMode);
     }
   }
 
   return afterVertical;
 }
 
-wgpu::Texture GeodeFilterEngine::runBlurPass(const wgpu::Texture& input, uint32_t width,
-                                             uint32_t height, float stdDeviation, uint32_t axis,
-                                             uint32_t edgeMode) {
+wgpu::Texture GeodeFilterEngine::runBlurPass(FilterResourceArena& arena, const wgpu::Texture& input,
+                                             uint32_t width, uint32_t height, float stdDeviation,
+                                             uint32_t axis, uint32_t edgeMode) {
   const wgpu::Device& dev = device_.device();
 
-  wgpu::Texture output = createIntermediateTexture(dev, width, height, "GaussianBlurPass");
+  wgpu::Texture output = createIntermediateTexture(arena, dev, width, height, "GaussianBlurPass");
 
   BlurParams params{};
   params.stdDeviation = stdDeviation;
@@ -1761,19 +1826,20 @@ wgpu::Texture GeodeFilterEngine::runBlurPass(const wgpu::Texture& input, uint32_
   params.pad1 = 0;
 
   wgpu::Buffer uniformBuffer =
-      createUniformBuffer(device_, &params, sizeof(params), "BlurParamsUniform");
+      createUniformBuffer(arena, device_, &params, sizeof(params), "BlurParamsUniform");
 
   dispatchInputOutputUniform(device_, blurBindGroupLayout_, gaussianBlurPipeline_, input, output,
                              uniformBuffer, sizeof(BlurParams), "GaussianBlurPass");
   return output;
 }
 
-wgpu::Texture GeodeFilterEngine::runBoxBlurPass(const wgpu::Texture& input, uint32_t width,
+wgpu::Texture GeodeFilterEngine::runBoxBlurPass(FilterResourceArena& arena,
+                                                const wgpu::Texture& input, uint32_t width,
                                                 uint32_t height, int32_t boxLeft, int32_t boxRight,
                                                 uint32_t axis, uint32_t edgeMode) {
   const wgpu::Device& dev = device_.device();
 
-  wgpu::Texture output = createIntermediateTexture(dev, width, height, "BoxBlurPass");
+  wgpu::Texture output = createIntermediateTexture(arena, dev, width, height, "BoxBlurPass");
 
   BlurParams params{};
   params.stdDeviation = 0.0f;
@@ -1786,7 +1852,7 @@ wgpu::Texture GeodeFilterEngine::runBoxBlurPass(const wgpu::Texture& input, uint
   params.pad1 = 0;
 
   wgpu::Buffer uniformBuffer =
-      createUniformBuffer(device_, &params, sizeof(params), "BlurParamsUniform");
+      createUniformBuffer(arena, device_, &params, sizeof(params), "BlurParamsUniform");
 
   dispatchInputOutputUniform(device_, blurBindGroupLayout_, gaussianBlurPipeline_, input, output,
                              uniformBuffer, sizeof(BlurParams), "BoxBlurPass");
@@ -1794,7 +1860,8 @@ wgpu::Texture GeodeFilterEngine::runBoxBlurPass(const wgpu::Texture& input, uint
 }
 
 wgpu::Texture GeodeFilterEngine::applyOffset(
-    const wgpu::Texture& input, const svg::components::filter_primitive::Offset& primitive) {
+    FilterResourceArena& arena, const wgpu::Texture& input,
+    const svg::components::filter_primitive::Offset& primitive) {
   const wgpu::Device& dev = device_.device();
   const uint32_t width = input.getWidth();
   const uint32_t height = input.getHeight();
@@ -1804,7 +1871,7 @@ wgpu::Texture GeodeFilterEngine::applyOffset(
     return input;
   }
 
-  wgpu::Texture output = createIntermediateTexture(dev, width, height, "FilterOffsetOutput");
+  wgpu::Texture output = createIntermediateTexture(arena, dev, width, height, "FilterOffsetOutput");
 
   OffsetParams params{};
   params.dx = static_cast<float>(primitive.dx);
@@ -1813,7 +1880,7 @@ wgpu::Texture GeodeFilterEngine::applyOffset(
   params.pad = 0;
 
   wgpu::Buffer uniformBuffer =
-      createUniformBuffer(device_, &params, sizeof(params), "OffsetParamsUniform");
+      createUniformBuffer(arena, device_, &params, sizeof(params), "OffsetParamsUniform");
 
   dispatchInputOutputUniform(device_, offsetBindGroupLayout_, offsetPipeline_, input, output,
                              uniformBuffer, sizeof(OffsetParams), "FilterOffsetPass");
@@ -1821,7 +1888,8 @@ wgpu::Texture GeodeFilterEngine::applyOffset(
 }
 
 wgpu::Texture GeodeFilterEngine::applyColorMatrix(
-    const wgpu::Texture& input, const svg::components::filter_primitive::ColorMatrix& primitive) {
+    FilterResourceArena& arena, const wgpu::Texture& input,
+    const svg::components::filter_primitive::ColorMatrix& primitive) {
   ColorMatrixParams params = buildColorMatrix(primitive);
 
   // Match tiny-skia's identity shortcut: skip the shader to avoid the
@@ -1835,10 +1903,11 @@ wgpu::Texture GeodeFilterEngine::applyColorMatrix(
   const uint32_t width = input.getWidth();
   const uint32_t height = input.getHeight();
 
-  wgpu::Texture output = createIntermediateTexture(dev, width, height, "FilterColorMatrixOutput");
+  wgpu::Texture output =
+      createIntermediateTexture(arena, dev, width, height, "FilterColorMatrixOutput");
 
   wgpu::Buffer uniformBuffer =
-      createUniformBuffer(device_, &params, sizeof(params), "ColorMatrixParamsUniform");
+      createUniformBuffer(arena, device_, &params, sizeof(params), "ColorMatrixParamsUniform");
 
   dispatchInputOutputUniform(device_, colorMatrixBindGroupLayout_, colorMatrixPipeline_, input,
                              output, uniformBuffer, sizeof(ColorMatrixParams),
@@ -1846,18 +1915,20 @@ wgpu::Texture GeodeFilterEngine::applyColorMatrix(
   return output;
 }
 
-wgpu::Texture GeodeFilterEngine::applySourceAlpha(const wgpu::Texture& input) {
+wgpu::Texture GeodeFilterEngine::applySourceAlpha(FilterResourceArena& arena,
+                                                  const wgpu::Texture& input) {
   const wgpu::Device& dev = device_.device();
   const uint32_t width = input.getWidth();
   const uint32_t height = input.getHeight();
 
-  wgpu::Texture output = createIntermediateTexture(dev, width, height, "FilterSourceAlphaOutput");
+  wgpu::Texture output =
+      createIntermediateTexture(arena, dev, width, height, "FilterSourceAlphaOutput");
 
   ColorMatrixParams params{};
   params.col3[3] = 1.0f;
 
   wgpu::Buffer uniformBuffer =
-      createUniformBuffer(device_, &params, sizeof(params), "SourceAlphaParamsUniform");
+      createUniformBuffer(arena, device_, &params, sizeof(params), "SourceAlphaParamsUniform");
 
   dispatchInputOutputUniform(device_, colorMatrixBindGroupLayout_, colorMatrixPipeline_, input,
                              output, uniformBuffer, sizeof(ColorMatrixParams),
@@ -1866,10 +1937,11 @@ wgpu::Texture GeodeFilterEngine::applySourceAlpha(const wgpu::Texture& input) {
 }
 
 wgpu::Texture GeodeFilterEngine::applyFlood(
-    uint32_t width, uint32_t height, const svg::components::filter_primitive::Flood& primitive) {
+    FilterResourceArena& arena, uint32_t width, uint32_t height,
+    const svg::components::filter_primitive::Flood& primitive) {
   const wgpu::Device& dev = device_.device();
 
-  wgpu::Texture output = createIntermediateTexture(dev, width, height, "FilterFloodOutput");
+  wgpu::Texture output = createIntermediateTexture(arena, dev, width, height, "FilterFloodOutput");
 
   // Resolve the flood color: CSS color → RGBA, then premultiply.  The filter
   // pipeline operates in premultiplied alpha (consistent with TinySkia and the
@@ -1885,14 +1957,14 @@ wgpu::Texture GeodeFilterEngine::applyFlood(
   params.color[3] = alpha;
 
   wgpu::Buffer uniformBuffer =
-      createUniformBuffer(device_, &params, sizeof(params), "FloodParamsUniform");
+      createUniformBuffer(arena, device_, &params, sizeof(params), "FloodParamsUniform");
 
   // Flood has no input texture — only output + uniform.
-  wgpu::TextureView outputView = output.createView();
+  ScopedWgpuHandle<wgpu::TextureView> outputView(output.createView());
 
   wgpu::BindGroupEntry bgEntries[2]{};
   bgEntries[0].binding = 0;
-  bgEntries[0].textureView = outputView;
+  bgEntries[0].textureView = outputView.get();
   bgEntries[1].binding = 1;
   bgEntries[1].buffer = uniformBuffer;
   bgEntries[1].offset = 0;
@@ -1903,31 +1975,33 @@ wgpu::Texture GeodeFilterEngine::applyFlood(
   bgDesc.layout = floodBindGroupLayout_;
   bgDesc.entryCount = 2;
   bgDesc.entries = bgEntries;
-  wgpu::BindGroup bindGroup = dev.createBindGroup(bgDesc);
+  ScopedWgpuHandle<wgpu::BindGroup> bindGroup(dev.createBindGroup(bgDesc));
+  device_.countBindGroup();
 
   wgpu::CommandEncoderDescriptor ceDesc{};
   ceDesc.label = wgpuLabel("FilterFloodEncoder");
-  wgpu::CommandEncoder encoder = dev.createCommandEncoder(ceDesc);
+  ScopedWgpuHandle<wgpu::CommandEncoder> encoder(dev.createCommandEncoder(ceDesc));
 
   wgpu::ComputePassDescriptor passDesc{};
   passDesc.label = wgpuLabel("FilterFloodPass");
-  wgpu::ComputePassEncoder pass = encoder.beginComputePass(passDesc);
-  pass.setPipeline(floodPipeline_);
-  pass.setBindGroup(0, bindGroup, 0, nullptr);
+  ScopedWgpuHandle<wgpu::ComputePassEncoder> pass(encoder.get().beginComputePass(passDesc));
+  pass.get().setPipeline(floodPipeline_);
+  pass.get().setBindGroup(0, bindGroup.get(), 0, nullptr);
 
   const uint32_t workgroupsX = (width + 7) / 8;
   const uint32_t workgroupsY = (height + 7) / 8;
-  pass.dispatchWorkgroups(workgroupsX, workgroupsY, 1);
-  pass.end();
+  pass.get().dispatchWorkgroups(workgroupsX, workgroupsY, 1);
+  pass.get().end();
+  pass.reset();
 
-  wgpu::CommandBuffer cmdBuf = encoder.finish();
-  device_.queue().submit(1, &cmdBuf);
+  ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
+  device_.queue().submit(1, &cmdBuf.get());
 
   return output;
 }
 
 wgpu::Texture GeodeFilterEngine::applyMerge(
-    const svg::components::FilterNode& node,
+    FilterResourceArena& arena, const svg::components::FilterNode& node,
     const std::unordered_map<std::string, wgpu::Texture>& namedBuffers,
     const wgpu::Texture& currentBuffer, const wgpu::Texture& sourceGraphic,
     const wgpu::Texture* sourceAlpha) {
@@ -1938,7 +2012,7 @@ wgpu::Texture GeodeFilterEngine::applyMerge(
     svg::components::filter_primitive::Flood transparent;
     transparent.floodColor = css::Color(css::RGBA(0, 0, 0, 0));
     transparent.floodOpacity = 0.0;
-    return applyFlood(width, height, transparent);
+    return applyFlood(arena, width, height, transparent);
   }
 
   // Resolve first input as the initial accumulator.
@@ -1949,66 +2023,70 @@ wgpu::Texture GeodeFilterEngine::applyMerge(
   for (size_t i = 1; i < node.inputs.size(); ++i) {
     wgpu::Texture src =
         resolveInput(node.inputs[i], namedBuffers, currentBuffer, sourceGraphic, sourceAlpha);
-    accumulator = runMergePass(src, accumulator, width, height);
+    accumulator = runMergePass(arena, src, accumulator, width, height);
   }
 
   return accumulator;
 }
 
-wgpu::Texture GeodeFilterEngine::runMergePass(const wgpu::Texture& src, const wgpu::Texture& dst,
-                                              uint32_t width, uint32_t height) {
+wgpu::Texture GeodeFilterEngine::runMergePass(FilterResourceArena& arena, const wgpu::Texture& src,
+                                              const wgpu::Texture& dst, uint32_t width,
+                                              uint32_t height) {
   const wgpu::Device& dev = device_.device();
 
-  wgpu::Texture output = createIntermediateTexture(dev, width, height, "FilterMergeOutput");
+  wgpu::Texture output = createIntermediateTexture(arena, dev, width, height, "FilterMergeOutput");
 
-  wgpu::TextureView srcView = src.createView();
-  wgpu::TextureView dstView = dst.createView();
-  wgpu::TextureView outputView = output.createView();
+  ScopedWgpuHandle<wgpu::TextureView> srcView(src.createView());
+  ScopedWgpuHandle<wgpu::TextureView> dstView(dst.createView());
+  ScopedWgpuHandle<wgpu::TextureView> outputView(output.createView());
 
   wgpu::BindGroupEntry bgEntries[3]{};
   bgEntries[0].binding = 0;
-  bgEntries[0].textureView = srcView;
+  bgEntries[0].textureView = srcView.get();
   bgEntries[1].binding = 1;
-  bgEntries[1].textureView = dstView;
+  bgEntries[1].textureView = dstView.get();
   bgEntries[2].binding = 2;
-  bgEntries[2].textureView = outputView;
+  bgEntries[2].textureView = outputView.get();
 
   wgpu::BindGroupDescriptor bgDesc{};
   bgDesc.label = wgpuLabel("FilterMergeBindGroup");
   bgDesc.layout = mergeBindGroupLayout_;
   bgDesc.entryCount = 3;
   bgDesc.entries = bgEntries;
-  wgpu::BindGroup bindGroup = dev.createBindGroup(bgDesc);
+  ScopedWgpuHandle<wgpu::BindGroup> bindGroup(dev.createBindGroup(bgDesc));
+  device_.countBindGroup();
 
   wgpu::CommandEncoderDescriptor ceDesc{};
   ceDesc.label = wgpuLabel("FilterMergeEncoder");
-  wgpu::CommandEncoder encoder = dev.createCommandEncoder(ceDesc);
+  ScopedWgpuHandle<wgpu::CommandEncoder> encoder(dev.createCommandEncoder(ceDesc));
 
   wgpu::ComputePassDescriptor passDesc{};
   passDesc.label = wgpuLabel("FilterMergePass");
-  wgpu::ComputePassEncoder pass = encoder.beginComputePass(passDesc);
-  pass.setPipeline(mergePipeline_);
-  pass.setBindGroup(0, bindGroup, 0, nullptr);
+  ScopedWgpuHandle<wgpu::ComputePassEncoder> pass(encoder.get().beginComputePass(passDesc));
+  pass.get().setPipeline(mergePipeline_);
+  pass.get().setBindGroup(0, bindGroup.get(), 0, nullptr);
 
   const uint32_t workgroupsX = (width + 7) / 8;
   const uint32_t workgroupsY = (height + 7) / 8;
-  pass.dispatchWorkgroups(workgroupsX, workgroupsY, 1);
-  pass.end();
+  pass.get().dispatchWorkgroups(workgroupsX, workgroupsY, 1);
+  pass.get().end();
+  pass.reset();
 
-  wgpu::CommandBuffer cmdBuf = encoder.finish();
-  device_.queue().submit(1, &cmdBuf);
+  ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
+  device_.queue().submit(1, &cmdBuf.get());
 
   return output;
 }
 
 wgpu::Texture GeodeFilterEngine::applyComposite(
-    const wgpu::Texture& in1, const wgpu::Texture& in2,
+    FilterResourceArena& arena, const wgpu::Texture& in1, const wgpu::Texture& in2,
     const svg::components::filter_primitive::Composite& primitive) {
   const wgpu::Device& dev = device_.device();
   const uint32_t width = in1.getWidth();
   const uint32_t height = in1.getHeight();
 
-  wgpu::Texture output = createIntermediateTexture(dev, width, height, "FilterCompositeOutput");
+  wgpu::Texture output =
+      createIntermediateTexture(arena, dev, width, height, "FilterCompositeOutput");
 
   // Map the Composite::Operator enum to the shader's uint index.
   using Op = svg::components::filter_primitive::Composite::Operator;
@@ -2034,7 +2112,7 @@ wgpu::Texture GeodeFilterEngine::applyComposite(
   params.k4 = static_cast<float>(primitive.k4);
 
   wgpu::Buffer uniformBuffer =
-      createUniformBuffer(device_, &params, sizeof(params), "CompositeParamsUniform");
+      createUniformBuffer(arena, device_, &params, sizeof(params), "CompositeParamsUniform");
 
   dispatchTwoInputUniform(device_, compositeBindGroupLayout_, compositePipeline_, in1, in2, output,
                           uniformBuffer, sizeof(CompositeParams), "FilterCompositePass");
@@ -2042,13 +2120,13 @@ wgpu::Texture GeodeFilterEngine::applyComposite(
 }
 
 wgpu::Texture GeodeFilterEngine::applyBlend(
-    const wgpu::Texture& in1, const wgpu::Texture& in2,
+    FilterResourceArena& arena, const wgpu::Texture& in1, const wgpu::Texture& in2,
     const svg::components::filter_primitive::Blend& primitive) {
   const wgpu::Device& dev = device_.device();
   const uint32_t width = in1.getWidth();
   const uint32_t height = in1.getHeight();
 
-  wgpu::Texture output = createIntermediateTexture(dev, width, height, "FilterBlendOutput");
+  wgpu::Texture output = createIntermediateTexture(arena, dev, width, height, "FilterBlendOutput");
 
   BlendParams params{};
   params.mode = static_cast<uint32_t>(primitive.mode);
@@ -2057,7 +2135,7 @@ wgpu::Texture GeodeFilterEngine::applyBlend(
   params.pad2 = 0;
 
   wgpu::Buffer uniformBuffer =
-      createUniformBuffer(device_, &params, sizeof(params), "BlendParamsUniform");
+      createUniformBuffer(arena, device_, &params, sizeof(params), "BlendParamsUniform");
 
   dispatchTwoInputUniform(device_, blendBindGroupLayout_, blendPipeline_, in1, in2, output,
                           uniformBuffer, sizeof(BlendParams), "FilterBlendPass");
@@ -2065,8 +2143,9 @@ wgpu::Texture GeodeFilterEngine::applyBlend(
 }
 
 wgpu::Texture GeodeFilterEngine::applyMorphology(
-    const wgpu::Texture& input, const svg::components::filter_primitive::Morphology& primitive,
-    int pixelRadiusX, int pixelRadiusY) {
+    FilterResourceArena& arena, const wgpu::Texture& input,
+    const svg::components::filter_primitive::Morphology& primitive, int pixelRadiusX,
+    int pixelRadiusY) {
   const wgpu::Device& dev = device_.device();
   const uint32_t width = input.getWidth();
   const uint32_t height = input.getHeight();
@@ -2088,7 +2167,8 @@ wgpu::Texture GeodeFilterEngine::applyMorphology(
   while (remainX > 0) {
     const int passX = std::min(remainX, kMaxRadius);
 
-    wgpu::Texture output = createIntermediateTexture(dev, width, height, "FilterMorphologyOutput");
+    wgpu::Texture output =
+        createIntermediateTexture(arena, dev, width, height, "FilterMorphologyOutput");
 
     using Op = svg::components::filter_primitive::Morphology::Operator;
     MorphologyParams params{};
@@ -2098,7 +2178,7 @@ wgpu::Texture GeodeFilterEngine::applyMorphology(
     params.pad = 0;
 
     wgpu::Buffer uniformBuffer =
-        createUniformBuffer(device_, &params, sizeof(params), "MorphologyParamsUniform");
+        createUniformBuffer(arena, device_, &params, sizeof(params), "MorphologyParamsUniform");
 
     dispatchInputOutputUniform(device_, morphologyBindGroupLayout_, morphologyPipeline_, current,
                                output, uniformBuffer, sizeof(MorphologyParams),
@@ -2112,7 +2192,8 @@ wgpu::Texture GeodeFilterEngine::applyMorphology(
   while (remainY > 0) {
     const int passY = std::min(remainY, kMaxRadius);
 
-    wgpu::Texture output = createIntermediateTexture(dev, width, height, "FilterMorphologyOutput");
+    wgpu::Texture output =
+        createIntermediateTexture(arena, dev, width, height, "FilterMorphologyOutput");
 
     using Op = svg::components::filter_primitive::Morphology::Operator;
     MorphologyParams params{};
@@ -2122,7 +2203,7 @@ wgpu::Texture GeodeFilterEngine::applyMorphology(
     params.pad = 0;
 
     wgpu::Buffer uniformBuffer =
-        createUniformBuffer(device_, &params, sizeof(params), "MorphologyParamsUniform");
+        createUniformBuffer(arena, device_, &params, sizeof(params), "MorphologyParamsUniform");
 
     dispatchInputOutputUniform(device_, morphologyBindGroupLayout_, morphologyPipeline_, current,
                                output, uniformBuffer, sizeof(MorphologyParams),
@@ -2135,14 +2216,14 @@ wgpu::Texture GeodeFilterEngine::applyMorphology(
 }
 
 wgpu::Texture GeodeFilterEngine::applyComponentTransfer(
-    const wgpu::Texture& input,
+    FilterResourceArena& arena, const wgpu::Texture& input,
     const svg::components::filter_primitive::ComponentTransfer& primitive) {
   const wgpu::Device& dev = device_.device();
   const uint32_t width = input.getWidth();
   const uint32_t height = input.getHeight();
 
   wgpu::Texture output =
-      createIntermediateTexture(dev, width, height, "FilterComponentTransferOutput");
+      createIntermediateTexture(arena, dev, width, height, "FilterComponentTransferOutput");
 
   // Build 4 × 256-entry LUTs (R, G, B, A) as uint32 array (1024 entries).
   std::array<uint32_t, 1024> lutData{};
@@ -2157,18 +2238,18 @@ wgpu::Texture GeodeFilterEngine::applyComponentTransfer(
   bufDesc.size = lutData.size() * sizeof(uint32_t);
   bufDesc.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
   bufDesc.mappedAtCreation = false;
-  wgpu::Buffer lutBuffer = dev.createBuffer(bufDesc);
+  wgpu::Buffer lutBuffer = arena.createBuffer(dev, bufDesc);
   device_.queue().writeBuffer(lutBuffer, 0, lutData.data(), bufDesc.size);
 
   // Build bind group.
-  wgpu::TextureView inputView = input.createView();
-  wgpu::TextureView outputView = output.createView();
+  ScopedWgpuHandle<wgpu::TextureView> inputView(input.createView());
+  ScopedWgpuHandle<wgpu::TextureView> outputView(output.createView());
 
   wgpu::BindGroupEntry bgEntries[3]{};
   bgEntries[0].binding = 0;
-  bgEntries[0].textureView = inputView;
+  bgEntries[0].textureView = inputView.get();
   bgEntries[1].binding = 1;
-  bgEntries[1].textureView = outputView;
+  bgEntries[1].textureView = outputView.get();
   bgEntries[2].binding = 2;
   bgEntries[2].buffer = lutBuffer;
   bgEntries[2].offset = 0;
@@ -2179,30 +2260,32 @@ wgpu::Texture GeodeFilterEngine::applyComponentTransfer(
   bgDesc.layout = componentTransferBindGroupLayout_;
   bgDesc.entryCount = 3;
   bgDesc.entries = bgEntries;
-  wgpu::BindGroup bindGroup = dev.createBindGroup(bgDesc);
+  ScopedWgpuHandle<wgpu::BindGroup> bindGroup(dev.createBindGroup(bgDesc));
+  device_.countBindGroup();
 
   wgpu::CommandEncoderDescriptor ceDesc{};
   ceDesc.label = wgpuLabel("FilterComponentTransferEncoder");
-  wgpu::CommandEncoder encoder = dev.createCommandEncoder(ceDesc);
+  ScopedWgpuHandle<wgpu::CommandEncoder> encoder(dev.createCommandEncoder(ceDesc));
 
   wgpu::ComputePassDescriptor passDesc{};
   passDesc.label = wgpuLabel("FilterComponentTransferPass");
-  wgpu::ComputePassEncoder pass = encoder.beginComputePass(passDesc);
-  pass.setPipeline(componentTransferPipeline_);
-  pass.setBindGroup(0, bindGroup, 0, nullptr);
+  ScopedWgpuHandle<wgpu::ComputePassEncoder> pass(encoder.get().beginComputePass(passDesc));
+  pass.get().setPipeline(componentTransferPipeline_);
+  pass.get().setBindGroup(0, bindGroup.get(), 0, nullptr);
 
   const uint32_t workgroupsX = (width + 7) / 8;
   const uint32_t workgroupsY = (height + 7) / 8;
-  pass.dispatchWorkgroups(workgroupsX, workgroupsY, 1);
-  pass.end();
+  pass.get().dispatchWorkgroups(workgroupsX, workgroupsY, 1);
+  pass.get().end();
+  pass.reset();
 
-  wgpu::CommandBuffer cmdBuf = encoder.finish();
-  device_.queue().submit(1, &cmdBuf);
+  ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
+  device_.queue().submit(1, &cmdBuf.get());
   return output;
 }
 
 wgpu::Texture GeodeFilterEngine::applyConvolveMatrix(
-    const wgpu::Texture& input,
+    FilterResourceArena& arena, const wgpu::Texture& input,
     const svg::components::filter_primitive::ConvolveMatrix& primitive) {
   const wgpu::Device& dev = device_.device();
   const uint32_t width = input.getWidth();
@@ -2240,11 +2323,11 @@ wgpu::Texture GeodeFilterEngine::applyConvolveMatrix(
                 << ", divisor=" << divisor << "); outputting transparent black\n";
     }
     // Return a transparent texture (matches CPU reference behavior).
-    return createIntermediateTexture(dev, width, height, "FilterConvolveMatrixTransparent");
+    return createIntermediateTexture(arena, dev, width, height, "FilterConvolveMatrixTransparent");
   }
 
   wgpu::Texture output =
-      createIntermediateTexture(dev, width, height, "FilterConvolveMatrixOutput");
+      createIntermediateTexture(arena, dev, width, height, "FilterConvolveMatrixOutput");
 
   ConvolveParams params{};
   params.orderX = primitive.orderX;
@@ -2270,18 +2353,18 @@ wgpu::Texture GeodeFilterEngine::applyConvolveMatrix(
   bufDesc.size = sizeof(ConvolveParams);
   bufDesc.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
   bufDesc.mappedAtCreation = false;
-  wgpu::Buffer paramsBuffer = dev.createBuffer(bufDesc);
+  wgpu::Buffer paramsBuffer = arena.createBuffer(dev, bufDesc);
   device_.queue().writeBuffer(paramsBuffer, 0, &params, sizeof(params));
 
   // Build bind group.
-  wgpu::TextureView inputView = input.createView();
-  wgpu::TextureView outputView = output.createView();
+  ScopedWgpuHandle<wgpu::TextureView> inputView(input.createView());
+  ScopedWgpuHandle<wgpu::TextureView> outputView(output.createView());
 
   wgpu::BindGroupEntry bgEntries[3]{};
   bgEntries[0].binding = 0;
-  bgEntries[0].textureView = inputView;
+  bgEntries[0].textureView = inputView.get();
   bgEntries[1].binding = 1;
-  bgEntries[1].textureView = outputView;
+  bgEntries[1].textureView = outputView.get();
   bgEntries[2].binding = 2;
   bgEntries[2].buffer = paramsBuffer;
   bgEntries[2].offset = 0;
@@ -2292,34 +2375,38 @@ wgpu::Texture GeodeFilterEngine::applyConvolveMatrix(
   bgDesc.layout = convolveMatrixBindGroupLayout_;
   bgDesc.entryCount = 3;
   bgDesc.entries = bgEntries;
-  wgpu::BindGroup bindGroup = dev.createBindGroup(bgDesc);
+  ScopedWgpuHandle<wgpu::BindGroup> bindGroup(dev.createBindGroup(bgDesc));
+  device_.countBindGroup();
 
   wgpu::CommandEncoderDescriptor ceDesc{};
   ceDesc.label = wgpuLabel("FilterConvolveMatrixEncoder");
-  wgpu::CommandEncoder encoder = dev.createCommandEncoder(ceDesc);
+  ScopedWgpuHandle<wgpu::CommandEncoder> encoder(dev.createCommandEncoder(ceDesc));
 
   wgpu::ComputePassDescriptor passDesc{};
   passDesc.label = wgpuLabel("FilterConvolveMatrixPass");
-  wgpu::ComputePassEncoder pass = encoder.beginComputePass(passDesc);
-  pass.setPipeline(convolveMatrixPipeline_);
-  pass.setBindGroup(0, bindGroup, 0, nullptr);
+  ScopedWgpuHandle<wgpu::ComputePassEncoder> pass(encoder.get().beginComputePass(passDesc));
+  pass.get().setPipeline(convolveMatrixPipeline_);
+  pass.get().setBindGroup(0, bindGroup.get(), 0, nullptr);
 
   const uint32_t workgroupsX = (width + 7) / 8;
   const uint32_t workgroupsY = (height + 7) / 8;
-  pass.dispatchWorkgroups(workgroupsX, workgroupsY, 1);
-  pass.end();
+  pass.get().dispatchWorkgroups(workgroupsX, workgroupsY, 1);
+  pass.get().end();
+  pass.reset();
 
-  wgpu::CommandBuffer cmdBuf = encoder.finish();
-  device_.queue().submit(1, &cmdBuf);
+  ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
+  device_.queue().submit(1, &cmdBuf.get());
   return output;
 }
 
 wgpu::Texture GeodeFilterEngine::applyTurbulence(
-    uint32_t width, uint32_t height, const svg::components::filter_primitive::Turbulence& primitive,
+    FilterResourceArena& arena, uint32_t width, uint32_t height,
+    const svg::components::filter_primitive::Turbulence& primitive,
     const Transform2d& deviceFromFilter) {
   const wgpu::Device& dev = device_.device();
 
-  wgpu::Texture output = createIntermediateTexture(dev, width, height, "FilterTurbulenceOutput");
+  wgpu::Texture output =
+      createIntermediateTexture(arena, dev, width, height, "FilterTurbulenceOutput");
 
   // Negative baseFrequency is invalid per SVG Filter Effects §15.20.3; produce transparent black
   // (matching resvg/tiny-skia behavior).
@@ -2363,7 +2450,7 @@ wgpu::Texture GeodeFilterEngine::applyTurbulence(
   bufDesc.size = sizeof(TurbulenceParams);
   bufDesc.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
   bufDesc.mappedAtCreation = false;
-  wgpu::Buffer paramsBuffer = dev.createBuffer(bufDesc);
+  wgpu::Buffer paramsBuffer = arena.createBuffer(dev, bufDesc);
   device_.queue().writeBuffer(paramsBuffer, 0, &params, sizeof(params));
 
   // Upload tables as storage buffer.
@@ -2372,14 +2459,14 @@ wgpu::Texture GeodeFilterEngine::applyTurbulence(
   tablesBufDesc.size = sizeof(TurbulenceTables);
   tablesBufDesc.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
   tablesBufDesc.mappedAtCreation = false;
-  wgpu::Buffer tablesBuffer = dev.createBuffer(tablesBufDesc);
+  wgpu::Buffer tablesBuffer = arena.createBuffer(dev, tablesBufDesc);
   device_.queue().writeBuffer(tablesBuffer, 0, &tables, sizeof(tables));
 
-  wgpu::TextureView outputView = output.createView();
+  ScopedWgpuHandle<wgpu::TextureView> outputView(output.createView());
 
   wgpu::BindGroupEntry bgEntries[3]{};
   bgEntries[0].binding = 0;
-  bgEntries[0].textureView = outputView;
+  bgEntries[0].textureView = outputView.get();
   bgEntries[1].binding = 1;
   bgEntries[1].buffer = paramsBuffer;
   bgEntries[1].offset = 0;
@@ -2394,37 +2481,39 @@ wgpu::Texture GeodeFilterEngine::applyTurbulence(
   bgDesc.layout = turbulenceBindGroupLayout_;
   bgDesc.entryCount = 3;
   bgDesc.entries = bgEntries;
-  wgpu::BindGroup bindGroup = dev.createBindGroup(bgDesc);
+  ScopedWgpuHandle<wgpu::BindGroup> bindGroup(dev.createBindGroup(bgDesc));
+  device_.countBindGroup();
 
   wgpu::CommandEncoderDescriptor ceDesc{};
   ceDesc.label = wgpuLabel("FilterTurbulenceEncoder");
-  wgpu::CommandEncoder encoder = dev.createCommandEncoder(ceDesc);
+  ScopedWgpuHandle<wgpu::CommandEncoder> encoder(dev.createCommandEncoder(ceDesc));
 
   wgpu::ComputePassDescriptor passDesc{};
   passDesc.label = wgpuLabel("FilterTurbulencePass");
-  wgpu::ComputePassEncoder pass = encoder.beginComputePass(passDesc);
-  pass.setPipeline(turbulencePipeline_);
-  pass.setBindGroup(0, bindGroup, 0, nullptr);
+  ScopedWgpuHandle<wgpu::ComputePassEncoder> pass(encoder.get().beginComputePass(passDesc));
+  pass.get().setPipeline(turbulencePipeline_);
+  pass.get().setBindGroup(0, bindGroup.get(), 0, nullptr);
 
   const uint32_t workgroupsX = (width + 7) / 8;
   const uint32_t workgroupsY = (height + 7) / 8;
-  pass.dispatchWorkgroups(workgroupsX, workgroupsY, 1);
-  pass.end();
+  pass.get().dispatchWorkgroups(workgroupsX, workgroupsY, 1);
+  pass.get().end();
+  pass.reset();
 
-  wgpu::CommandBuffer cmdBuf = encoder.finish();
-  device_.queue().submit(1, &cmdBuf);
+  ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
+  device_.queue().submit(1, &cmdBuf.get());
   return output;
 }
 
 wgpu::Texture GeodeFilterEngine::applyDisplacementMap(
-    const wgpu::Texture& in1, const wgpu::Texture& in2,
+    FilterResourceArena& arena, const wgpu::Texture& in1, const wgpu::Texture& in2,
     const svg::components::filter_primitive::DisplacementMap& primitive, double pixelScale) {
   const wgpu::Device& dev = device_.device();
   const uint32_t width = in1.getWidth();
   const uint32_t height = in1.getHeight();
 
   wgpu::Texture output =
-      createIntermediateTexture(dev, width, height, "FilterDisplacementMapOutput");
+      createIntermediateTexture(arena, dev, width, height, "FilterDisplacementMapOutput");
 
   using Channel = svg::components::filter_primitive::DisplacementMap::Channel;
   auto toIndex = [](Channel ch) -> uint32_t {
@@ -2444,7 +2533,7 @@ wgpu::Texture GeodeFilterEngine::applyDisplacementMap(
   params.pad = 0;
 
   wgpu::Buffer uniformBuffer =
-      createUniformBuffer(device_, &params, sizeof(params), "DisplacementMapParamsUniform");
+      createUniformBuffer(arena, device_, &params, sizeof(params), "DisplacementMapParamsUniform");
 
   dispatchTwoInputUniform(device_, displacementMapBindGroupLayout_, displacementMapPipeline_, in1,
                           in2, output, uniformBuffer, sizeof(DisplacementParams),
@@ -2548,7 +2637,8 @@ void fillLightParams(const svg::components::filter_primitive::LightSource& light
 }  // namespace
 
 wgpu::Texture GeodeFilterEngine::applyDiffuseLighting(
-    const wgpu::Texture& input, const svg::components::filter_primitive::DiffuseLighting& primitive,
+    FilterResourceArena& arena, const wgpu::Texture& input,
+    const svg::components::filter_primitive::DiffuseLighting& primitive,
     const svg::components::FilterGraph& graph, const Transform2d& deviceFromFilter,
     const Box2d& sampleSubregion) {
   const wgpu::Device& dev = device_.device();
@@ -2556,7 +2646,7 @@ wgpu::Texture GeodeFilterEngine::applyDiffuseLighting(
   const uint32_t height = input.getHeight();
 
   wgpu::Texture output =
-      createIntermediateTexture(dev, width, height, "FilterDiffuseLightingOutput");
+      createIntermediateTexture(arena, dev, width, height, "FilterDiffuseLightingOutput");
 
   DiffuseLightingParams params{};
   params.surfaceScale = static_cast<float>(primitive.surfaceScale);
@@ -2601,18 +2691,18 @@ wgpu::Texture GeodeFilterEngine::applyDiffuseLighting(
   bufDesc.size = sizeof(DiffuseLightingParams);
   bufDesc.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
   bufDesc.mappedAtCreation = false;
-  wgpu::Buffer paramsBuffer = dev.createBuffer(bufDesc);
+  wgpu::Buffer paramsBuffer = arena.createBuffer(dev, bufDesc);
   device_.queue().writeBuffer(paramsBuffer, 0, &params, sizeof(params));
 
   // Build bind group.
-  wgpu::TextureView inputView = input.createView();
-  wgpu::TextureView outputView = output.createView();
+  ScopedWgpuHandle<wgpu::TextureView> inputView(input.createView());
+  ScopedWgpuHandle<wgpu::TextureView> outputView(output.createView());
 
   wgpu::BindGroupEntry bgEntries[3]{};
   bgEntries[0].binding = 0;
-  bgEntries[0].textureView = inputView;
+  bgEntries[0].textureView = inputView.get();
   bgEntries[1].binding = 1;
-  bgEntries[1].textureView = outputView;
+  bgEntries[1].textureView = outputView.get();
   bgEntries[2].binding = 2;
   bgEntries[2].buffer = paramsBuffer;
   bgEntries[2].offset = 0;
@@ -2623,30 +2713,32 @@ wgpu::Texture GeodeFilterEngine::applyDiffuseLighting(
   bgDesc.layout = diffuseLightingBindGroupLayout_;
   bgDesc.entryCount = 3;
   bgDesc.entries = bgEntries;
-  wgpu::BindGroup bindGroup = dev.createBindGroup(bgDesc);
+  ScopedWgpuHandle<wgpu::BindGroup> bindGroup(dev.createBindGroup(bgDesc));
+  device_.countBindGroup();
 
   wgpu::CommandEncoderDescriptor ceDesc{};
   ceDesc.label = wgpuLabel("FilterDiffuseLightingEncoder");
-  wgpu::CommandEncoder encoder = dev.createCommandEncoder(ceDesc);
+  ScopedWgpuHandle<wgpu::CommandEncoder> encoder(dev.createCommandEncoder(ceDesc));
 
   wgpu::ComputePassDescriptor passDesc{};
   passDesc.label = wgpuLabel("FilterDiffuseLightingPass");
-  wgpu::ComputePassEncoder pass = encoder.beginComputePass(passDesc);
-  pass.setPipeline(diffuseLightingPipeline_);
-  pass.setBindGroup(0, bindGroup, 0, nullptr);
+  ScopedWgpuHandle<wgpu::ComputePassEncoder> pass(encoder.get().beginComputePass(passDesc));
+  pass.get().setPipeline(diffuseLightingPipeline_);
+  pass.get().setBindGroup(0, bindGroup.get(), 0, nullptr);
 
   const uint32_t workgroupsX = (width + 7) / 8;
   const uint32_t workgroupsY = (height + 7) / 8;
-  pass.dispatchWorkgroups(workgroupsX, workgroupsY, 1);
-  pass.end();
+  pass.get().dispatchWorkgroups(workgroupsX, workgroupsY, 1);
+  pass.get().end();
+  pass.reset();
 
-  wgpu::CommandBuffer cmdBuf = encoder.finish();
-  device_.queue().submit(1, &cmdBuf);
+  ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
+  device_.queue().submit(1, &cmdBuf.get());
   return output;
 }
 
 wgpu::Texture GeodeFilterEngine::applySpecularLighting(
-    const wgpu::Texture& input,
+    FilterResourceArena& arena, const wgpu::Texture& input,
     const svg::components::filter_primitive::SpecularLighting& primitive,
     const svg::components::FilterGraph& graph, const Transform2d& deviceFromFilter,
     const Box2d& sampleSubregion) {
@@ -2655,7 +2747,7 @@ wgpu::Texture GeodeFilterEngine::applySpecularLighting(
   const uint32_t height = input.getHeight();
 
   wgpu::Texture output =
-      createIntermediateTexture(dev, width, height, "FilterSpecularLightingOutput");
+      createIntermediateTexture(arena, dev, width, height, "FilterSpecularLightingOutput");
 
   SpecularLightingParams params{};
   params.surfaceScale = static_cast<float>(primitive.surfaceScale);
@@ -2699,18 +2791,18 @@ wgpu::Texture GeodeFilterEngine::applySpecularLighting(
   bufDesc.size = sizeof(SpecularLightingParams);
   bufDesc.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
   bufDesc.mappedAtCreation = false;
-  wgpu::Buffer paramsBuffer = dev.createBuffer(bufDesc);
+  wgpu::Buffer paramsBuffer = arena.createBuffer(dev, bufDesc);
   device_.queue().writeBuffer(paramsBuffer, 0, &params, sizeof(params));
 
   // Build bind group.
-  wgpu::TextureView inputView = input.createView();
-  wgpu::TextureView outputView = output.createView();
+  ScopedWgpuHandle<wgpu::TextureView> inputView(input.createView());
+  ScopedWgpuHandle<wgpu::TextureView> outputView(output.createView());
 
   wgpu::BindGroupEntry bgEntries[3]{};
   bgEntries[0].binding = 0;
-  bgEntries[0].textureView = inputView;
+  bgEntries[0].textureView = inputView.get();
   bgEntries[1].binding = 1;
-  bgEntries[1].textureView = outputView;
+  bgEntries[1].textureView = outputView.get();
   bgEntries[2].binding = 2;
   bgEntries[2].buffer = paramsBuffer;
   bgEntries[2].offset = 0;
@@ -2721,31 +2813,34 @@ wgpu::Texture GeodeFilterEngine::applySpecularLighting(
   bgDesc.layout = specularLightingBindGroupLayout_;
   bgDesc.entryCount = 3;
   bgDesc.entries = bgEntries;
-  wgpu::BindGroup bindGroup = dev.createBindGroup(bgDesc);
+  ScopedWgpuHandle<wgpu::BindGroup> bindGroup(dev.createBindGroup(bgDesc));
+  device_.countBindGroup();
 
   wgpu::CommandEncoderDescriptor ceDesc{};
   ceDesc.label = wgpuLabel("FilterSpecularLightingEncoder");
-  wgpu::CommandEncoder encoder = dev.createCommandEncoder(ceDesc);
+  ScopedWgpuHandle<wgpu::CommandEncoder> encoder(dev.createCommandEncoder(ceDesc));
 
   wgpu::ComputePassDescriptor passDesc{};
   passDesc.label = wgpuLabel("FilterSpecularLightingPass");
-  wgpu::ComputePassEncoder pass = encoder.beginComputePass(passDesc);
-  pass.setPipeline(specularLightingPipeline_);
-  pass.setBindGroup(0, bindGroup, 0, nullptr);
+  ScopedWgpuHandle<wgpu::ComputePassEncoder> pass(encoder.get().beginComputePass(passDesc));
+  pass.get().setPipeline(specularLightingPipeline_);
+  pass.get().setBindGroup(0, bindGroup.get(), 0, nullptr);
 
   const uint32_t workgroupsX = (width + 7) / 8;
   const uint32_t workgroupsY = (height + 7) / 8;
-  pass.dispatchWorkgroups(workgroupsX, workgroupsY, 1);
-  pass.end();
+  pass.get().dispatchWorkgroups(workgroupsX, workgroupsY, 1);
+  pass.get().end();
+  pass.reset();
 
-  wgpu::CommandBuffer cmdBuf = encoder.finish();
-  device_.queue().submit(1, &cmdBuf);
+  ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
+  device_.queue().submit(1, &cmdBuf.get());
   return output;
 }
 
 wgpu::Texture GeodeFilterEngine::applyDropShadow(
-    const wgpu::Texture& input, const svg::components::filter_primitive::DropShadow& primitive,
-    double pixelStdDevX, double pixelStdDevY, double pixelDx, double pixelDy) {
+    FilterResourceArena& arena, const wgpu::Texture& input,
+    const svg::components::filter_primitive::DropShadow& primitive, double pixelStdDevX,
+    double pixelStdDevY, double pixelDx, double pixelDy) {
   const wgpu::Device& dev = device_.device();
   const uint32_t width = input.getWidth();
   const uint32_t height = input.getHeight();
@@ -2753,9 +2848,11 @@ wgpu::Texture GeodeFilterEngine::applyDropShadow(
   // Blur the input first (if any deviation). The compose shader reads the
   // blurred texture's alpha at (coord - offset); blurring RGB at the same
   // time is free because we already have to walk the taps.
-  wgpu::Texture blurred = applyGaussianBlur(input, pixelStdDevX, pixelStdDevY, /*edgeMode=*/0);
+  wgpu::Texture blurred =
+      applyGaussianBlur(arena, input, pixelStdDevX, pixelStdDevY, /*edgeMode=*/0);
 
-  wgpu::Texture output = createIntermediateTexture(dev, width, height, "FilterDropShadowOutput");
+  wgpu::Texture output =
+      createIntermediateTexture(arena, dev, width, height, "FilterDropShadowOutput");
 
   const css::RGBA rgba = primitive.floodColor.asRGBA();
   const float floodA = (static_cast<float>(rgba.a) / 255.0f) *
@@ -2774,7 +2871,7 @@ wgpu::Texture GeodeFilterEngine::applyDropShadow(
   params.pad1 = 0;
 
   wgpu::Buffer uniformBuffer =
-      createUniformBuffer(device_, &params, sizeof(params), "DropShadowParamsUniform");
+      createUniformBuffer(arena, device_, &params, sizeof(params), "DropShadowParamsUniform");
 
   dispatchTwoInputUniform(device_, dropShadowBindGroupLayout_, dropShadowPipeline_, input, blurred,
                           output, uniformBuffer, sizeof(DropShadowParams), "FilterDropShadowPass");
@@ -2782,12 +2879,12 @@ wgpu::Texture GeodeFilterEngine::applyDropShadow(
 }
 
 wgpu::Texture GeodeFilterEngine::applyImage(
-    const svg::components::filter_primitive::Image& primitive, uint32_t width, uint32_t height,
-    const svg::components::FilterGraph& graph, const svg::components::FilterNode& node,
-    const Transform2d& deviceFromFilter) {
+    FilterResourceArena& arena, const svg::components::filter_primitive::Image& primitive,
+    uint32_t width, uint32_t height, const svg::components::FilterGraph& graph,
+    const svg::components::FilterNode& node, const Transform2d& deviceFromFilter) {
   const wgpu::Device& dev = device_.device();
 
-  wgpu::Texture output = createIntermediateTexture(dev, width, height, "FilterImageOutput");
+  wgpu::Texture output = createIntermediateTexture(arena, dev, width, height, "FilterImageOutput");
 
   // Empty / degenerate source: feed the shader a 1×1 transparent texture
   // with an out-of-bounds transform. The resulting output is transparent
@@ -2802,7 +2899,7 @@ wgpu::Texture GeodeFilterEngine::applyImage(
     imgDesc.mipLevelCount = 1;
     imgDesc.sampleCount = 1;
     imgDesc.dimension = wgpu::TextureDimension::_2D;
-    wgpu::Texture emptyTex = dev.createTexture(imgDesc);
+    wgpu::Texture emptyTex = arena.createTexture(dev, imgDesc);
     const uint8_t zero[4] = {0, 0, 0, 0};
     wgpu::TexelCopyTextureInfo dstInfo{};
     dstInfo.texture = emptyTex;
@@ -2815,7 +2912,8 @@ wgpu::Texture GeodeFilterEngine::applyImage(
     ImageParams params{};
     params.m02 = -1000.0f;
     params.m12 = -1000.0f;
-    wgpu::Buffer ub = createUniformBuffer(device_, &params, sizeof(params), "ImageParamsEmpty");
+    wgpu::Buffer ub =
+        createUniformBuffer(arena, device_, &params, sizeof(params), "ImageParamsEmpty");
     dispatchInputOutputUniform(device_, imageBindGroupLayout_, imagePipeline_, emptyTex, output, ub,
                                sizeof(ImageParams), "FilterImageEmptyPass");
     return output;
@@ -2846,7 +2944,7 @@ wgpu::Texture GeodeFilterEngine::applyImage(
   imgDesc.mipLevelCount = 1;
   imgDesc.sampleCount = 1;
   imgDesc.dimension = wgpu::TextureDimension::_2D;
-  wgpu::Texture imgTex = dev.createTexture(imgDesc);
+  wgpu::Texture imgTex = arena.createTexture(dev, imgDesc);
 
   wgpu::TexelCopyTextureInfo dstInfo{};
   dstInfo.texture = imgTex;
@@ -2888,7 +2986,7 @@ wgpu::Texture GeodeFilterEngine::applyImage(
     params.pad1 = 0;
 
     wgpu::Buffer uniformBuffer =
-        createUniformBuffer(device_, &params, sizeof(params), "ImageParamsFragRef");
+        createUniformBuffer(arena, device_, &params, sizeof(params), "ImageParamsFragRef");
     dispatchInputOutputUniform(device_, imageBindGroupLayout_, imagePipeline_, imgTex, output,
                                uniformBuffer, sizeof(ImageParams), "FilterImageFragRefPass");
     return output;
@@ -2913,7 +3011,7 @@ wgpu::Texture GeodeFilterEngine::applyImage(
     params.pad1 = 0;
 
     wgpu::Buffer uniformBuffer =
-        createUniformBuffer(device_, &params, sizeof(params), "ImageParamsFragRef");
+        createUniformBuffer(arena, device_, &params, sizeof(params), "ImageParamsFragRef");
     dispatchInputOutputUniform(device_, imageBindGroupLayout_, imagePipeline_, imgTex, output,
                                uniformBuffer, sizeof(ImageParams), "FilterImageFragRefPass");
     return output;
@@ -3050,20 +3148,20 @@ wgpu::Texture GeodeFilterEngine::applyImage(
   params.pad1 = 0;
 
   wgpu::Buffer uniformBuffer =
-      createUniformBuffer(device_, &params, sizeof(params), "ImageParamsUniform");
+      createUniformBuffer(arena, device_, &params, sizeof(params), "ImageParamsUniform");
 
   dispatchInputOutputUniform(device_, imageBindGroupLayout_, imagePipeline_, imgTex, output,
                              uniformBuffer, sizeof(ImageParams), "FilterImagePass");
   return output;
 }
 
-wgpu::Texture GeodeFilterEngine::applyTile(const wgpu::Texture& input, int32_t srcX, int32_t srcY,
-                                           int32_t srcW, int32_t srcH) {
+wgpu::Texture GeodeFilterEngine::applyTile(FilterResourceArena& arena, const wgpu::Texture& input,
+                                           int32_t srcX, int32_t srcY, int32_t srcW, int32_t srcH) {
   const wgpu::Device& dev = device_.device();
   const uint32_t width = input.getWidth();
   const uint32_t height = input.getHeight();
 
-  wgpu::Texture output = createIntermediateTexture(dev, width, height, "FilterTileOutput");
+  wgpu::Texture output = createIntermediateTexture(arena, dev, width, height, "FilterTileOutput");
 
   TileParams params{};
   params.srcX = srcX;
@@ -3072,14 +3170,15 @@ wgpu::Texture GeodeFilterEngine::applyTile(const wgpu::Texture& input, int32_t s
   params.srcH = srcH;
 
   wgpu::Buffer uniformBuffer =
-      createUniformBuffer(device_, &params, sizeof(params), "TileParamsUniform");
+      createUniformBuffer(arena, device_, &params, sizeof(params), "TileParamsUniform");
 
   dispatchInputOutputUniform(device_, tileBindGroupLayout_, tilePipeline_, input, output,
                              uniformBuffer, sizeof(TileParams), "FilterTilePass");
   return output;
 }
 
-wgpu::Texture GeodeFilterEngine::applySubregionClip(const wgpu::Texture& input,
+wgpu::Texture GeodeFilterEngine::applySubregionClip(FilterResourceArena& arena,
+                                                    const wgpu::Texture& input,
                                                     const Transform2d& filterFromDevice,
                                                     double usrX0, double usrY0, double usrX1,
                                                     double usrY1) {
@@ -3087,7 +3186,8 @@ wgpu::Texture GeodeFilterEngine::applySubregionClip(const wgpu::Texture& input,
   const uint32_t width = input.getWidth();
   const uint32_t height = input.getHeight();
 
-  wgpu::Texture output = createIntermediateTexture(dev, width, height, "FilterSubregionClipOutput");
+  wgpu::Texture output =
+      createIntermediateTexture(arena, dev, width, height, "FilterSubregionClipOutput");
 
   SubregionClipParams params{};
   params.invA = static_cast<float>(filterFromDevice.data[0]);
@@ -3104,7 +3204,7 @@ wgpu::Texture GeodeFilterEngine::applySubregionClip(const wgpu::Texture& input,
   params.pad1 = 0;
 
   wgpu::Buffer uniformBuffer =
-      createUniformBuffer(device_, &params, sizeof(params), "SubregionClipParamsUniform");
+      createUniformBuffer(arena, device_, &params, sizeof(params), "SubregionClipParamsUniform");
 
   dispatchInputOutputUniform(device_, subregionClipBindGroupLayout_, subregionClipPipeline_, input,
                              output, uniformBuffer, sizeof(SubregionClipParams),
@@ -3112,20 +3212,21 @@ wgpu::Texture GeodeFilterEngine::applySubregionClip(const wgpu::Texture& input,
   return output;
 }
 
-wgpu::Texture GeodeFilterEngine::applyColorSpaceConversion(const wgpu::Texture& input,
+wgpu::Texture GeodeFilterEngine::applyColorSpaceConversion(FilterResourceArena& arena,
+                                                           const wgpu::Texture& input,
                                                            bool srgbToLinear) {
   const wgpu::Device& dev = device_.device();
   const uint32_t width = input.getWidth();
   const uint32_t height = input.getHeight();
 
   wgpu::Texture output =
-      createIntermediateTexture(dev, width, height, "FilterColorSpaceConvertOutput");
+      createIntermediateTexture(arena, dev, width, height, "FilterColorSpaceConvertOutput");
 
   ColorSpaceConvertParams params{};
   params.direction = srgbToLinear ? 0u : 1u;
 
-  wgpu::Buffer uniformBuffer =
-      createUniformBuffer(device_, &params, sizeof(params), "ColorSpaceConvertParamsUniform");
+  wgpu::Buffer uniformBuffer = createUniformBuffer(arena, device_, &params, sizeof(params),
+                                                   "ColorSpaceConvertParamsUniform");
 
   dispatchInputOutputUniform(device_, colorSpaceConvertBindGroupLayout_, colorSpaceConvertPipeline_,
                              input, output, uniformBuffer, sizeof(ColorSpaceConvertParams),

--- a/donner/svg/renderer/geode/GeodeFilterEngine.h
+++ b/donner/svg/renderer/geode/GeodeFilterEngine.h
@@ -46,6 +46,7 @@ struct Tile;
 namespace donner::geode {
 
 class GeodeDevice;
+struct FilterResourceArena;
 
 /**
  * GPU filter-graph executor.
@@ -116,8 +117,8 @@ private:
   /// @param stdDeviationY Standard deviation in Y (pixels).
   /// @param edgeMode Edge handling mode (0=None, 1=Duplicate, 2=Wrap).
   /// @return The blurred texture.
-  wgpu::Texture applyGaussianBlur(const wgpu::Texture& input, double stdDeviationX,
-                                  double stdDeviationY, uint32_t edgeMode);
+  wgpu::Texture applyGaussianBlur(FilterResourceArena& arena, const wgpu::Texture& input,
+                                  double stdDeviationX, double stdDeviationY, uint32_t edgeMode);
 
   /// Run a single blur pass (horizontal or vertical).
   /// @param input Source texture for this pass.
@@ -127,8 +128,8 @@ private:
   /// @param axis 0 = horizontal, 1 = vertical.
   /// @param edgeMode Edge handling mode.
   /// @return Output texture for this pass.
-  wgpu::Texture runBlurPass(const wgpu::Texture& input, uint32_t width, uint32_t height,
-                            float stdDeviation, uint32_t axis, uint32_t edgeMode);
+  wgpu::Texture runBlurPass(FilterResourceArena& arena, const wgpu::Texture& input, uint32_t width,
+                            uint32_t height, float stdDeviation, uint32_t axis, uint32_t edgeMode);
 
   /// One pass of a 3-pass box blur (used to approximate a Gaussian for sigma
   /// >= 2.0, matching tiny-skia's behaviour).
@@ -140,34 +141,35 @@ private:
   /// @param axis 0 = horizontal, 1 = vertical.
   /// @param edgeMode Edge handling mode.
   /// @return Output texture for this pass.
-  wgpu::Texture runBoxBlurPass(const wgpu::Texture& input, uint32_t width, uint32_t height,
-                               int32_t boxLeft, int32_t boxRight, uint32_t axis, uint32_t edgeMode);
+  wgpu::Texture runBoxBlurPass(FilterResourceArena& arena, const wgpu::Texture& input,
+                               uint32_t width, uint32_t height, int32_t boxLeft, int32_t boxRight,
+                               uint32_t axis, uint32_t edgeMode);
 
   /// Shift pixels by (dx, dy) via compute shader.
   /// @param input The input texture.
   /// @param primitive The feOffset parameters.
   /// @return The offset texture.
-  wgpu::Texture applyOffset(const wgpu::Texture& input,
+  wgpu::Texture applyOffset(FilterResourceArena& arena, const wgpu::Texture& input,
                             const svg::components::filter_primitive::Offset& primitive);
 
   /// Apply a 4x5 color matrix to each pixel via compute shader.
   /// @param input The input texture.
   /// @param primitive The feColorMatrix parameters.
   /// @return The transformed texture.
-  wgpu::Texture applyColorMatrix(const wgpu::Texture& input,
+  wgpu::Texture applyColorMatrix(FilterResourceArena& arena, const wgpu::Texture& input,
                                  const svg::components::filter_primitive::ColorMatrix& primitive);
 
   /// Extract SourceAlpha (0,0,0,A) from a SourceGraphic texture.
   /// @param input The source-graphic texture.
   /// @return A texture whose RGB are zero and alpha matches the input alpha.
-  wgpu::Texture applySourceAlpha(const wgpu::Texture& input);
+  wgpu::Texture applySourceAlpha(FilterResourceArena& arena, const wgpu::Texture& input);
 
   /// Fill the output with a constant flood color via compute shader.
   /// @param width Output texture width.
   /// @param height Output texture height.
   /// @param primitive The feFlood parameters.
   /// @return The flood-filled texture.
-  wgpu::Texture applyFlood(uint32_t width, uint32_t height,
+  wgpu::Texture applyFlood(FilterResourceArena& arena, uint32_t width, uint32_t height,
                            const svg::components::filter_primitive::Flood& primitive);
 
   /// Alpha-over composite of N input textures via sequential compute dispatches.
@@ -176,7 +178,7 @@ private:
   /// @param currentBuffer The "previous" output buffer.
   /// @param sourceGraphic The original source-graphic texture.
   /// @return The composited texture.
-  wgpu::Texture applyMerge(const svg::components::FilterNode& node,
+  wgpu::Texture applyMerge(FilterResourceArena& arena, const svg::components::FilterNode& node,
                            const std::unordered_map<std::string, wgpu::Texture>& namedBuffers,
                            const wgpu::Texture& currentBuffer, const wgpu::Texture& sourceGraphic,
                            const wgpu::Texture* sourceAlpha);
@@ -187,15 +189,16 @@ private:
   /// @param width Output texture width.
   /// @param height Output texture height.
   /// @return The composited texture.
-  wgpu::Texture runMergePass(const wgpu::Texture& src, const wgpu::Texture& dst, uint32_t width,
-                             uint32_t height);
+  wgpu::Texture runMergePass(FilterResourceArena& arena, const wgpu::Texture& src,
+                             const wgpu::Texture& dst, uint32_t width, uint32_t height);
 
   /// Porter-Duff compositing of two inputs via compute shader.
   /// @param in1 First input texture (source).
   /// @param in2 Second input texture (destination/backdrop).
   /// @param primitive The feComposite parameters (operator + k1..k4).
   /// @return The composited texture.
-  wgpu::Texture applyComposite(const wgpu::Texture& in1, const wgpu::Texture& in2,
+  wgpu::Texture applyComposite(FilterResourceArena& arena, const wgpu::Texture& in1,
+                               const wgpu::Texture& in2,
                                const svg::components::filter_primitive::Composite& primitive);
 
   /// W3C Compositing 1 blend of two inputs via compute shader.
@@ -203,7 +206,8 @@ private:
   /// @param in2 Second input texture (backdrop).
   /// @param primitive The feBlend parameters (blend mode).
   /// @return The blended texture.
-  wgpu::Texture applyBlend(const wgpu::Texture& in1, const wgpu::Texture& in2,
+  wgpu::Texture applyBlend(FilterResourceArena& arena, const wgpu::Texture& in1,
+                           const wgpu::Texture& in2,
                            const svg::components::filter_primitive::Blend& primitive);
 
   /// Morphological erode / dilate via min / max rectangular kernel.
@@ -212,7 +216,7 @@ private:
   /// @param pixelRadiusX Horizontal radius in pixels.
   /// @param pixelRadiusY Vertical radius in pixels.
   /// @return The morphed texture.
-  wgpu::Texture applyMorphology(const wgpu::Texture& input,
+  wgpu::Texture applyMorphology(FilterResourceArena& arena, const wgpu::Texture& input,
                                 const svg::components::filter_primitive::Morphology& primitive,
                                 int pixelRadiusX, int pixelRadiusY);
 
@@ -221,7 +225,7 @@ private:
   /// @param primitive The feComponentTransfer parameters (4 channel functions).
   /// @return The transformed texture.
   wgpu::Texture applyComponentTransfer(
-      const wgpu::Texture& input,
+      FilterResourceArena& arena, const wgpu::Texture& input,
       const svg::components::filter_primitive::ComponentTransfer& primitive);
 
   /// NxM kernel convolution (feConvolveMatrix).
@@ -229,7 +233,7 @@ private:
   /// @param primitive The feConvolveMatrix parameters.
   /// @return The convolved texture.
   wgpu::Texture applyConvolveMatrix(
-      const wgpu::Texture& input,
+      FilterResourceArena& arena, const wgpu::Texture& input,
       const svg::components::filter_primitive::ConvolveMatrix& primitive);
 
   /// Perlin noise / fractal noise generator (feTurbulence).
@@ -238,7 +242,7 @@ private:
   /// @param primitive The feTurbulence parameters.
   /// @param deviceFromFilter Transform from filter/user space into device space.
   /// @return The noise texture.
-  wgpu::Texture applyTurbulence(uint32_t width, uint32_t height,
+  wgpu::Texture applyTurbulence(FilterResourceArena& arena, uint32_t width, uint32_t height,
                                 const svg::components::filter_primitive::Turbulence& primitive,
                                 const Transform2d& deviceFromFilter);
 
@@ -249,7 +253,7 @@ private:
   /// @param pixelScale Displacement scale in pixels.
   /// @return The displaced texture.
   wgpu::Texture applyDisplacementMap(
-      const wgpu::Texture& in1, const wgpu::Texture& in2,
+      FilterResourceArena& arena, const wgpu::Texture& in1, const wgpu::Texture& in2,
       const svg::components::filter_primitive::DisplacementMap& primitive, double pixelScale);
 
   /// Lambertian diffuse lighting (feDiffuseLighting).
@@ -259,7 +263,7 @@ private:
   /// @param scaleY User-to-pixel scale Y.
   /// @return The lit texture.
   wgpu::Texture applyDiffuseLighting(
-      const wgpu::Texture& input,
+      FilterResourceArena& arena, const wgpu::Texture& input,
       const svg::components::filter_primitive::DiffuseLighting& primitive,
       const svg::components::FilterGraph& graph, const Transform2d& deviceFromFilter,
       const Box2d& sampleSubregion);
@@ -271,7 +275,7 @@ private:
   /// @param scaleY User-to-pixel scale Y.
   /// @return The lit texture.
   wgpu::Texture applySpecularLighting(
-      const wgpu::Texture& input,
+      FilterResourceArena& arena, const wgpu::Texture& input,
       const svg::components::filter_primitive::SpecularLighting& primitive,
       const svg::components::FilterGraph& graph, const Transform2d& deviceFromFilter,
       const Box2d& sampleSubregion);
@@ -284,7 +288,7 @@ private:
   /// @param pixelDx Offset in pixel units (X).
   /// @param pixelDy Offset in pixel units (Y).
   /// @return The drop-shadowed texture.
-  wgpu::Texture applyDropShadow(const wgpu::Texture& input,
+  wgpu::Texture applyDropShadow(FilterResourceArena& arena, const wgpu::Texture& input,
                                 const svg::components::filter_primitive::DropShadow& primitive,
                                 double pixelStdDevX, double pixelStdDevY, double pixelDx,
                                 double pixelDy);
@@ -298,7 +302,8 @@ private:
   /// @param deviceFromFilter The combined CTM from filter/user-space to device pixels.
   ///   Used by fragment references to project through rotation/skew.
   /// @return The placed-image texture.
-  wgpu::Texture applyImage(const svg::components::filter_primitive::Image& primitive,
+  wgpu::Texture applyImage(FilterResourceArena& arena,
+                           const svg::components::filter_primitive::Image& primitive,
                            uint32_t width, uint32_t height,
                            const svg::components::FilterGraph& graph,
                            const svg::components::FilterNode& node,
@@ -311,8 +316,8 @@ private:
   /// @param srcW Source rectangle width in pixels.
   /// @param srcH Source rectangle height in pixels.
   /// @return The tiled texture.
-  wgpu::Texture applyTile(const wgpu::Texture& input, int32_t srcX, int32_t srcY, int32_t srcW,
-                          int32_t srcH);
+  wgpu::Texture applyTile(FilterResourceArena& arena, const wgpu::Texture& input, int32_t srcX,
+                          int32_t srcY, int32_t srcW, int32_t srcH);
 
   /// Clip a primitive's output to its user-space subregion via the inverse CTM.
   /// Pixels whose center maps outside the subregion are zeroed.
@@ -323,15 +328,17 @@ private:
   /// @param usrX1 User-space subregion right edge.
   /// @param usrY1 User-space subregion bottom edge.
   /// @return A new texture with out-of-subregion pixels cleared.
-  wgpu::Texture applySubregionClip(const wgpu::Texture& input, const Transform2d& filterFromDevice,
-                                   double usrX0, double usrY0, double usrX1, double usrY1);
+  wgpu::Texture applySubregionClip(FilterResourceArena& arena, const wgpu::Texture& input,
+                                   const Transform2d& filterFromDevice, double usrX0, double usrY0,
+                                   double usrX1, double usrY1);
 
   /// Convert a texture between sRGB and linearRGB color spaces.
   /// Used to implement `color-interpolation-filters: linearRGB` (the SVG default).
   /// @param input The input texture in premultiplied sRGB (or linear, for the reverse).
   /// @param srgbToLinear True to convert sRGB→linear, false for linear→sRGB.
   /// @return A new texture in the target color space.
-  wgpu::Texture applyColorSpaceConversion(const wgpu::Texture& input, bool srgbToLinear);
+  wgpu::Texture applyColorSpaceConversion(FilterResourceArena& arena, const wgpu::Texture& input,
+                                          bool srgbToLinear);
 
   GeodeDevice& device_;
 

--- a/donner/svg/renderer/geode/GeodeTextureEncoder.cc
+++ b/donner/svg/renderer/geode/GeodeTextureEncoder.cc
@@ -114,7 +114,8 @@ void GeodeTextureEncoder::drawTexturedQuad(GeodeDevice& device, const GeodeImage
                                            const wgpu::RenderPassEncoder& pass,
                                            const wgpu::Texture& texture, const float mvp[16],
                                            uint32_t targetWidth, uint32_t targetHeight,
-                                           const QuadParams& params) {
+                                           const QuadParams& params,
+                                           ScopedWgpuResourceArena& resourceArena) {
   if (!texture) {
     return;
   }
@@ -150,7 +151,7 @@ void GeodeTextureEncoder::drawTexturedQuad(GeodeDevice& device, const GeodeImage
   uniDesc.label = wgpuLabel("GeodeImageBlitUniforms");
   uniDesc.size = sizeof(Uniforms);
   uniDesc.usage = wgpu::BufferUsage::Uniform | wgpu::BufferUsage::CopyDst;
-  wgpu::Buffer uniBuf = dev.createBuffer(uniDesc);
+  wgpu::Buffer uniBuf = resourceArena.retain(dev.createBuffer(uniDesc));
   device.countBuffer();
   queue.writeBuffer(uniBuf, 0, &u, sizeof(Uniforms));
 
@@ -162,10 +163,12 @@ void GeodeTextureEncoder::drawTexturedQuad(GeodeDevice& device, const GeodeImage
   // view. When their owning feature flags are off, we bind the source
   // content texture view as a cheap dummy (the shader never samples it
   // because the corresponding mode guard is 0).
-  wgpu::TextureView view = texture.createView();
-  wgpu::TextureView maskView = params.maskTexture ? params.maskTexture.createView() : view;
-  wgpu::TextureView dstView =
-      params.dstSnapshotTexture ? params.dstSnapshotTexture.createView() : view;
+  wgpu::TextureView view = resourceArena.retain(texture.createView());
+  wgpu::TextureView maskView =
+      params.maskTexture ? resourceArena.retain(params.maskTexture.createView()) : view;
+  wgpu::TextureView dstView = params.dstSnapshotTexture
+                                  ? resourceArena.retain(params.dstSnapshotTexture.createView())
+                                  : view;
   wgpu::TextureView clipMaskView = params.clipMaskView ? params.clipMaskView : view;
   wgpu::BindGroupEntry entries[7] = {};
   entries[0].binding = 0;
@@ -189,7 +192,7 @@ void GeodeTextureEncoder::drawTexturedQuad(GeodeDevice& device, const GeodeImage
   bgDesc.layout = pipeline.bindGroupLayout();
   bgDesc.entryCount = 7;
   bgDesc.entries = entries;
-  wgpu::BindGroup bindGroup = dev.createBindGroup(bgDesc);
+  wgpu::BindGroup bindGroup = resourceArena.retain(dev.createBindGroup(bgDesc));
   device.countBindGroup();
 
   // The caller is expected to have invoked `GeoEncoder::bindImagePipeline`

--- a/donner/svg/renderer/geode/GeodeTextureEncoder.h
+++ b/donner/svg/renderer/geode/GeodeTextureEncoder.h
@@ -12,6 +12,7 @@ namespace donner::geode {
 
 class GeodeDevice;
 class GeodeImagePipeline;
+class ScopedWgpuResourceArena;
 
 /**
  * Reusable helpers for uploading pixel data to a `wgpu::Texture` and drawing
@@ -133,13 +134,16 @@ public:
    *   - Provide an MVP matrix built the same way as `GeoEncoder::Impl::buildMvp`
    *     (target-pixel → clip space, composed with the model-view transform).
    *
-   * Allocates fresh GPU resources (uniform buffer + bind group) per call —
-   * caching is a Phase 5 concern.
+   * Allocates fresh GPU resources (uniform buffer + bind group) per call and
+   * retains them in `resourceArena` until the caller finishes the enclosing
+   * command encoder.
+   *
+   * @param resourceArena Scoped owner for WebGPU handles created by the draw.
    */
   static void drawTexturedQuad(GeodeDevice& device, const GeodeImagePipeline& pipeline,
                                const wgpu::RenderPassEncoder& pass, const wgpu::Texture& texture,
                                const float mvp[16], uint32_t targetWidth, uint32_t targetHeight,
-                               const QuadParams& params);
+                               const QuadParams& params, ScopedWgpuResourceArena& resourceArena);
 };
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodeWgpuUtil.h
+++ b/donner/svg/renderer/geode/GeodeWgpuUtil.h
@@ -19,6 +19,7 @@
 
 #include <string_view>
 #include <utility>
+#include <vector>
 #include <webgpu/webgpu.hpp>
 
 namespace donner::geode {
@@ -105,6 +106,60 @@ public:
 
 private:
   Handle handle_;
+};
+
+/**
+ * Scoped owner for short-lived WebGPU resources used while recording a command
+ * encoder.
+ *
+ * The returned `wgpu::` values are borrowed aliases that remain valid while the
+ * arena is alive. This is useful for render-pass helpers that need handles to
+ * survive until the enclosing encoder is finished, but do not need bespoke
+ * ownership fields for every per-draw texture view / bind group / buffer.
+ */
+class ScopedWgpuResourceArena {
+public:
+  /// Retain a buffer handle and return a borrowed alias.
+  [[nodiscard]] wgpu::Buffer retain(wgpu::Buffer handle) {
+    return retainImpl(buffers_, std::move(handle));
+  }
+
+  /// Retain a texture handle and return a borrowed alias.
+  [[nodiscard]] wgpu::Texture retain(wgpu::Texture handle) {
+    return retainImpl(textures_, std::move(handle));
+  }
+
+  /// Retain a texture-view handle and return a borrowed alias.
+  [[nodiscard]] wgpu::TextureView retain(wgpu::TextureView handle) {
+    return retainImpl(textureViews_, std::move(handle));
+  }
+
+  /// Retain a sampler handle and return a borrowed alias.
+  [[nodiscard]] wgpu::Sampler retain(wgpu::Sampler handle) {
+    return retainImpl(samplers_, std::move(handle));
+  }
+
+  /// Retain a bind-group handle and return a borrowed alias.
+  [[nodiscard]] wgpu::BindGroup retain(wgpu::BindGroup handle) {
+    return retainImpl(bindGroups_, std::move(handle));
+  }
+
+private:
+  template <typename Handle>
+  static Handle retainImpl(std::vector<ScopedWgpuHandle<Handle>>& storage, Handle handle) {
+    if (!handle) {
+      return Handle();
+    }
+    Handle borrowed = handle;
+    storage.push_back(ScopedWgpuHandle<Handle>(std::move(handle)));
+    return borrowed;
+  }
+
+  std::vector<ScopedWgpuHandle<wgpu::Buffer>> buffers_;
+  std::vector<ScopedWgpuHandle<wgpu::Texture>> textures_;
+  std::vector<ScopedWgpuHandle<wgpu::TextureView>> textureViews_;
+  std::vector<ScopedWgpuHandle<wgpu::Sampler>> samplers_;
+  std::vector<ScopedWgpuHandle<wgpu::BindGroup>> bindGroups_;
 };
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -396,6 +396,36 @@ TEST_F(RendererGeodeTest, EmbeddedDeviceDrawPathExportsTextureSnapshot) {
             Vector2i(static_cast<int>(kViewportSize), static_cast<int>(kViewportSize)));
 }
 
+TEST_F(RendererGeodeTest, BgraTargetSnapshotReturnsStraightRgba) {
+  std::shared_ptr<geode::GeodeDevice> host = sharedDevice();
+  ASSERT_TRUE(host != nullptr);
+
+  geode::GeodeEmbedConfig config;
+  config.device = host->device();
+  config.queue = host->queue();
+  config.adapter = host->adapter();
+  config.textureFormat = wgpu::TextureFormat::BGRA8Unorm;
+  auto embeddedUnique = geode::GeodeDevice::CreateFromExternal(config);
+  ASSERT_NE(embeddedUnique, nullptr);
+
+  std::shared_ptr<geode::GeodeDevice> embedded(std::move(embeddedUnique));
+  RendererGeode renderer(embedded);
+  beginFrame(renderer);
+  renderer.setPaint(solidFill(css::RGBA(0, 200, 255, 255)));
+  renderer.drawRect(Box2d({16, 16}, {48, 48}), StrokeParams{});
+  renderer.endFrame();
+
+  const RendererBitmap actual = renderer.takeSnapshot();
+  ASSERT_FALSE(actual.empty());
+  EXPECT_EQ(actual.alphaType, AlphaType::Unpremultiplied);
+
+  const std::array<uint8_t, 4> center = pixelAt(actual, 32, 32);
+  EXPECT_LE(center[0], 2u) << "BGRA readback must be converted back to logical RGBA";
+  EXPECT_NEAR(static_cast<int>(center[1]), 200, 2);
+  EXPECT_NEAR(static_cast<int>(center[2]), 255, 2);
+  EXPECT_EQ(center[3], 255u);
+}
+
 /// Filling a path with a solid red paint should produce red pixels at the
 /// path's interior.
 TEST_F(RendererGeodeTest, DrawPathWithSolidFill) {

--- a/third_party/patches/imgui_wgpu_emscripten_dawn.patch
+++ b/third_party/patches/imgui_wgpu_emscripten_dawn.patch
@@ -1,0 +1,89 @@
+Subject: [PATCH] Allow Dawn-style WebGPU backend under Emscripten
+
+---
+ backends/imgui_impl_wgpu.cpp | 34 +++++++++++++++++++++++++---------
+ 1 file changed, 25 insertions(+), 9 deletions(-)
+
+diff --git a/backends/imgui_impl_wgpu.cpp b/backends/imgui_impl_wgpu.cpp
+index 23456789..3456789a 100644
+--- a/backends/imgui_impl_wgpu.cpp
++++ b/backends/imgui_impl_wgpu.cpp
+@@ -49,8 +49,8 @@
+     #error exactly one of IMGUI_IMPL_WEBGPU_BACKEND_DAWN or IMGUI_IMPL_WEBGPU_BACKEND_WGPU must be defined!
+     #endif
+ #else
+-    #if defined(IMGUI_IMPL_WEBGPU_BACKEND_DAWN) || defined(IMGUI_IMPL_WEBGPU_BACKEND_WGPU)
+-    #error neither IMGUI_IMPL_WEBGPU_BACKEND_DAWN nor IMGUI_IMPL_WEBGPU_BACKEND_WGPU may be defined if targeting emscripten!
++    #if defined(IMGUI_IMPL_WEBGPU_BACKEND_WGPU)
++    #error IMGUI_IMPL_WEBGPU_BACKEND_WGPU may not be defined if targeting emscripten!
+     #endif
+ #endif
+ 
+@@ -314,7 +314,19 @@ static void SafeRelease(FrameResources& res)
+     SafeRelease(res.VertexBufferHost);
+ }
+ 
+-static WGPUProgrammableStageDescriptor ImGui_ImplWGPU_CreateShaderModule(const char* wgsl_source)
++struct ImGui_ImplWGPU_ShaderStage
++{
++    WGPUShaderModule module = nullptr;
++#ifdef IMGUI_IMPL_WEBGPU_BACKEND_WGPU
++    const char* entryPoint = nullptr;
++#else
++    WGPUStringView entryPoint = {};
++#endif
++};
++
++static ImGui_ImplWGPU_ShaderStage ImGui_ImplWGPU_CreateShaderModule(const char* wgsl_source)
+ {
+     ImGui_ImplWGPU_Data* bd = ImGui_ImplWGPU_GetBackendData();
+ 
+@@ -331,7 +343,7 @@ static WGPUProgrammableStageDescriptor ImGui_ImplWGPU_CreateShaderModule(const c
+     WGPUShaderModuleDescriptor desc = {};
+     desc.nextInChain = reinterpret_cast<WGPUChainedStruct*>(&wgsl_desc);
+ 
+-    WGPUProgrammableStageDescriptor stage_desc = {};
++    ImGui_ImplWGPU_ShaderStage stage_desc = {};
+     stage_desc.module = wgpuDeviceCreateShaderModule(bd->wgpuDevice, &desc);
+ #ifdef IMGUI_IMPL_WEBGPU_BACKEND_DAWN
+     stage_desc.entryPoint = { "main", WGPU_STRLEN };
+@@ -833,17 +845,21 @@ static void ImGui_ImplWGPU_CreatePipelineState()
+     graphics_pipeline_desc.layout = wgpuDeviceCreatePipelineLayout(bd->wgpuDevice, &layout_desc);
+ 
+     // Create the vertex shader
+-    WGPUProgrammableStageDescriptor vertex_shader_desc = ImGui_ImplWGPU_CreateShaderModule(__shader_vert_wgsl);
++    ImGui_ImplWGPU_ShaderStage vertex_shader_desc = ImGui_ImplWGPU_CreateShaderModule(__shader_vert_wgsl);
+     graphics_pipeline_desc.vertex.module = vertex_shader_desc.module;
+     graphics_pipeline_desc.vertex.entryPoint = vertex_shader_desc.entryPoint;
+ 
+     // Vertex input configuration
+-    WGPUVertexAttribute attribute_desc[] =
+-    {
+-        { WGPUVertexFormat_Float32x2, (uint64_t)offsetof(ImDrawVert, pos), 0 },
+-        { WGPUVertexFormat_Float32x2, (uint64_t)offsetof(ImDrawVert, uv),  1 },
+-        { WGPUVertexFormat_Unorm8x4,  (uint64_t)offsetof(ImDrawVert, col), 2 },
+-    };
++    WGPUVertexAttribute attribute_desc[3] = {};
++    attribute_desc[0].format = WGPUVertexFormat_Float32x2;
++    attribute_desc[0].offset = (uint64_t)offsetof(ImDrawVert, pos);
++    attribute_desc[0].shaderLocation = 0;
++    attribute_desc[1].format = WGPUVertexFormat_Float32x2;
++    attribute_desc[1].offset = (uint64_t)offsetof(ImDrawVert, uv);
++    attribute_desc[1].shaderLocation = 1;
++    attribute_desc[2].format = WGPUVertexFormat_Unorm8x4;
++    attribute_desc[2].offset = (uint64_t)offsetof(ImDrawVert, col);
++    attribute_desc[2].shaderLocation = 2;
+ 
+     WGPUVertexBufferLayout buffer_layouts[1];
+     buffer_layouts[0].arrayStride = sizeof(ImDrawVert);
+@@ -855,8 +871,8 @@ static void ImGui_ImplWGPU_CreatePipelineState()
+     graphics_pipeline_desc.vertex.buffers = buffer_layouts;
+ 
+     // Create the pixel shader
+-    WGPUProgrammableStageDescriptor pixel_shader_desc = ImGui_ImplWGPU_CreateShaderModule(__shader_frag_wgsl);
+-    WGPUProgrammableStageDescriptor premultiplied_alpha_pixel_shader_desc = ImGui_ImplWGPU_CreateShaderModule(__shader_frag_premultiplied_alpha_wgsl);
++    ImGui_ImplWGPU_ShaderStage pixel_shader_desc = ImGui_ImplWGPU_CreateShaderModule(__shader_frag_wgsl);
++    ImGui_ImplWGPU_ShaderStage premultiplied_alpha_pixel_shader_desc = ImGui_ImplWGPU_CreateShaderModule(__shader_frag_premultiplied_alpha_wgsl);
+ 
+     // Create the blending setup
+     WGPUBlendState blend_state = ImGui_ImplWGPU_CreateStraightAlphaBlendState();


### PR DESCRIPTION
## Summary

Adds editor polish for shape transforms and renderer compatibility:

- Adds selection transform handles, rotate cursors, scale/rotate interactions, multi-element transform undo/writeback handling, and overlay coverage.
- Improves composited presentation and drag behavior for selected elements, including filtered/clipped content and hit priority.
- Fixes Geode/WebGPU resource and presentation paths used by the editor, including WASM startup/rendering compatibility and smoke-test coverage.
- Adds focused editor, renderer, Geode, and WASM tests for the updated behavior.

## Validation

- `clang-format -i` on modified C/C++ files
- `/usr/bin/python3 tools/cmake/gen_cmakelists.py --check`
- `bazel test //...`