### PR TITLE
docs(0021): refresh resvg feature-gaps backlog — CPU-led after geode parity

### DIFF
--- a/docs/design_docs/0021-resvg_feature_gaps.md
+++ b/docs/design_docs/0021-resvg_feature_gaps.md
@@ -43,28 +43,56 @@ nearly closed — see [Geode parity — resolved](#geode-parity--resolved-606).
 
 | | Count |
 |---|---:|
-| `Params::Skip(...)` | 288 |
+| `Params::Skip(...)` | 288 (→ ~260 once #608–#611 land — 28 un-skipped) |
 | `Params::RenderOnly(...)` | 51 (UB — render-must-not-crash, no pixel compare) |
-| CPU `WithThreshold` overrides (tiny-skia) | 87 (of which ~22 exceed 1000 px → masked-bug candidates) |
+| CPU `WithThreshold` overrides (tiny-skia) | 87 (→ ~78 after #610 drops the feImage caps; ~15 still over 1000 px → masked-bug candidates) |
 | Commented-out category blocks | 1 (`filters/filter-functions`) |
 | Geode binary parity gate (`geodeParityGate`) | 173 (172 edge-floor + 1 `feColorMatrix/hueRotate`); 0 text, 0 other genuine |
 
 ---
+
+## Recently fixed (PRs #608–#611)
+
+Landed 2026-05-25 from a parallel CPU-backend debugging sweep. IDs are burned (not reused).
+
+- **F2 — `transform-origin` regression (#514)** → [#609](https://github.com/jwmcglynn/donner/pull/609).
+  The pivot sandwich was written `Translate(O) * raw * Translate(-O)`, but
+  `Transform2d::operator*` is left-first, so the pivot-out translate applied *last* —
+  the pivot wasn't a fixed point. Swapped to `Translate(-O) * raw * Translate(O)`.
+  13 tests un-skipped (9.7k–151k px → pass). The 7 paint-server/`<image>`/text cases
+  were a *separate* never-implemented gap → re-filed as **F12** below.
+- **B1 — intrinsic sizing + percent on non-square viewBox** → [#611](https://github.com/jwmcglynn/donner/pull/611).
+  Three coupled causes: `calculateRawDocumentSize` used `transformPosition` (folded
+  the letterbox translation into the size); percent resolution used the viewBox
+  *diagonal* extent instead of per-axis X/Y; `<marker>` length attrs were parsed with
+  a no-suffix parser that rejected `%`. 10 tests un-skipped.
+- **B5 — `feMorphology` degenerate radius** → [#608](https://github.com/jwmcglynn/donner/pull/608).
+  Negative/zero/empty/absent radius blanked the shape to transparent black; per
+  Filter Effects §15.4 a disabled morphology passes the input through. 5 tests un-skipped.
+- **B6 — `feImage` resampling** → [#610](https://github.com/jwmcglynn/donner/pull/610).
+  The suspected fragment-ref-transform bug was a red herring — those 3 tests were
+  never broken (their 22k–34k px thresholds were pure over-inflation, now removed).
+  The real bug: tiny-skia upscaled feImage with **bilinear**; resvg uses
+  **Mitchell-Netravali bicubic**. 4 subregion tests 2.6k–8.7k px → 0. `svg.svg`'s
+  custom golden refreshed to bicubic; geode gated pending a WGSL bicubic port (see
+  the geode follow-up in [Geode parity](#geode-parity--resolved-606)).
 
 ## Priority 0: CPU-backend backlog (the active front)
 
 Highest-value first. "Out of scope" rows are correct-as-skipped and listed at the
 bottom for completeness.
 
+> **Recently fixed (PRs #608–#611, in review) — see [Recently fixed](#recently-fixed-prs-608611).**
+> F2 (transform-origin regression), B1 (intrinsic sizing), B5 (feMorphology), B6
+> (feImage resampling) are resolved; their IDs are burned. The rows below are
+> what's left.
+
 | ID | Gap | Impact | Kind |
 |---|---|---:|---|
-| **F2** | `transform-origin` rendering **regression** (#514) | 20 | **Regression — single PR, known-good prior state. Top payoff.** |
-| **B6** | `feImage` fragment-ref + transform broken (masked by fat thresholds) | 7 | **Bug — 22k–34k px diffs hidden at `maxPx`; not AA.** |
 | B2 | `filters/filter-functions` disabled (CI "Data corrupted") | ~30 | CI gap — whole category dark |
 | B3 | `<image>` embedded/data-URL sizing | 18 | Bug — one investigation |
-| B1 | intrinsic sizing + percent on non-square viewBox | ~10 | Bug — one root cause, many categories |
-| B5 | `feMorphology` edge cases | 5 | Bug |
 | B4 | `<use>` → inline `<svg>` sizing | 5 | Bug (shares machinery with B3) |
+| F12 | `transform-origin` on paint-servers / `<image>` / text | 7 | Feature (split out of the F2 regression) |
 | F3 | `context-fill` / `context-stroke` | 13 | Feature |
 | F5 | full `dominant-baseline` keyword set | 14 | Feature |
 | F4 | `<switch>` conditional processing | 12 (+systemLanguage 3) | Feature |
@@ -83,30 +111,6 @@ bottom for completeness.
 ---
 
 ## Tracked regressions & disabled blocks
-
-### F2: `transform-origin` rendering broken after #514
-
-**Impact:** 20 tests — all of `structure/transform-origin/` (category
-`StructureTransformOrigin`, [`resvg_test_suite.cc:2229`](../../donner/svg/renderer/tests/resvg_test_suite.cc)).
-
-**Symptom:** 10K–150K-pixel diffs — rendering is completely wrong, not slightly
-off. Every test tagged `Skip("transform-origin broken after #514")`.
-
-**Root cause:** PR #514 added single-keyword `transform-origin` parsing (e.g.
-`transform-origin: center`) and regressed the rendering path in the process.
-Before #514 the two-token forms applied correctly; after #514 the transform
-pivots around the wrong origin.
-
-**Next step:** bisect #514's diff. The parser change and the apply-at-render change
-are separable — verify `ParseTransformOrigin` output, then check
-`LayoutSystem::createComputedLocalTransformComponentWithStyle` consumes the
-resolved origin. Land the fix and un-skip all 20 in one PR. **Highest single-PR
-payoff in the backlog** (it's a regression, so there's a known-good prior state).
-
-> Note: this entry previously described `transform-origin` as a never-implemented
-> *presentation attribute*. That gap was closed; the current failure is the #514
-> *regression* above. The presentation-attribute form should be re-verified once
-> the regression is fixed.
 
 ### B2: `filters/filter-functions` category disabled on CI
 
@@ -140,38 +144,10 @@ the suite default (100). pixelmatch already excludes anti-aliased pixels, so a
 multi-thousand-px diff on the CPU backend is a *real* rendering difference. Per
 [CLAUDE.md §"Anti-Aliasing Is Never the Root Cause"](../../CLAUDE.md), "AA drift"
 is not a valid reason for these magnitudes. The full audit list lives in the test
-file; the two structural clusters are promoted to tracked bugs below.
-
-### B6: `feImage` fragment-ref + transform broken (CPU)
-
-**Impact:** 7 tests in `filters/feImage/`, all "passing" at inflated caps:
-
-| Test | `maxPx` | Comment in file |
-|---|---:|---|
-| `link-to-an-element-with-transform.svg` | 34200 | "Fragment ref with skewX transform on element" |
-| `link-on-an-element-with-complex-transform.svg` | 26200 | "Fragment ref with complex transform" |
-| `chained-feImage.svg` | 22000 | "Chained feImage fragment refs" |
-| `with-subregion-4.svg` | 15000 | "Absolute subregion coords" |
-| `with-subregion-3.svg` | 14500 | "Percentage width subregion" |
-| `with-subregion-1.svg` / `with-subregion-2.svg` | 5100 | "OBB subregion bilinear / percentage" |
-
-**Symptom:** a 34K-px diff on a single image means the **transform applied to a
-`feImage` fragment reference is wrong** (placement/scale/skew), and subregion
-placement disagrees with the golden. This is the same family as the Geode feImage
-divergence that #606 chased (resolved there with the shared-`RendererDriver`
-re-draw fix + driver-independent placement) — the CPU path was never audited, just
-thresholded.
-
-**Root cause:** needs investigation. Start at the `feImage` primitive's handling of
-(a) a fragment reference to a transformed element, and (b) the
-`x`/`y`/`width`/`height` subregion → device mapping. Cross-check against the Geode
-feImage fixes in [0017](0017-geode_renderer.md) / the #606 filter work — the
-correct placement math may already exist there.
-
-**Next step:** drop the thresholds to the default 100, capture
-`actual/expected/diff` PNGs for `link-to-an-element-with-transform`, and root-cause
-the transform composition. Overlaps [B3](#b3-image-embedded--data-url-sizing)
-(image placement) and [F8](#f8-primitive-subregion-clipping) (subregion).
+file. **B6 (feImage resampling) is now fixed** — see [Recently fixed](#recently-fixed-prs-608611);
+the real cause was a bilinear-vs-bicubic kernel, not the suspected transform bug, and
+the 3 "transform" tests were never broken (their fat thresholds were over-inflation,
+now removed). The remaining structural cluster is below.
 
 ### B7: font substitution — missing bundled families
 
@@ -202,33 +178,10 @@ likely map to already-bundled Noto faces (real diff to chase), while
 
 ## High-leverage bugs (one root cause, many tests)
 
-### B1: Intrinsic sizing + percent resolution on non-square viewBox
-
-**Impact:** ~10 tests across 7 categories (all carry the reason string
-`"… intrinsic sizing + percent resolution with non-square viewBox; see
-ShapesEllipse"`).
-
-**Symptom:** For SVGs with a non-square `viewBox` (e.g. `0 0 200 100`) and no
-explicit `width`/`height`, the intrinsic document size is wrong. Under the
-fixture's `setCanvasSize(500, 500)`, Donner produces 500×375 instead of 500×250,
-so percent-valued geometry (`cx="50%"`, `rx="40%"`, …) resolves against the wrong
-viewport and renders oversized / off-center.
-
-**Root cause:** `LayoutSystem::calculateRawDocumentSize`
-([LayoutSystem.cc:806](../../donner/svg/components/layout/LayoutSystem.cc)) uses
-`transformPosition()` on the viewBox→content transform, which folds in the
-letterbox translation. `transformVector()` (no translation) is the correct call.
-The percent-resolution pipeline is coupled to this, so fix both together.
-
-**Next step:** swap `transformPosition`→`transformVector`, audit percent
-resolution in `ComputedShapeComponent`/`LayoutSystem`, land as one PR.
-
-**Affected tests:** `shapes/ellipse/percent-values{,-missing-ry}`,
-`shapes/line/percent-units`, `shapes/rect/percentage-values-{1,2}`,
-`paint-servers/linearGradient/gradientUnits=userSpaceOnUse-with-percent`,
-`paint-servers/radialGradient/gradientUnits=objectBoundingBox-with-percent`,
-`painting/marker/percent-values`,
-`text/text/percent-value-on-{x-and-y,dx-and-dy}`.
+**B1 (intrinsic sizing + percent on non-square viewBox) is now fixed** — see
+[Recently fixed](#recently-fixed-prs-608611). It was three coupled causes, not just
+the suspected `transformPosition`→`transformVector` (also per-axis percent extent +
+`<marker>` `%` parsing).
 
 ### B3: `<image>` embedded / data-URL sizing
 
@@ -245,7 +198,7 @@ cases disagree with the golden.
 
 **Next step:** start with `embedded-png` + `preserveAspectRatio=none` (the
 simplest), then walk the no-width/no-height/auto matrix. Shares
-`preserveAspectRatio` math with [B6](#b6-feimage-fragment-ref--transform-broken-cpu)
+`preserveAspectRatio` math with [B6 (fixed)](#recently-fixed-prs-608611)
 and [B4](#b4-use-referencing-inline-svg-elements).
 
 ### B4: `<use>` referencing inline `<svg>` elements
@@ -258,15 +211,8 @@ combinations sizes the instance wrong.
 **Next step:** likely shares machinery with B3's viewport sizing; investigate
 together if convenient.
 
-### B5: `feMorphology` edge cases
-
-**Impact:** 5 tests in `filters/feMorphology/` (`empty-radius`, `negative-radius`,
-`no-radius`, `radius-with-too-many-values`, `zero-radius`).
-
-**Symptom:** degenerate/invalid radius values aren't handled to spec.
-
-**Next step:** add radius validation/clamping in the feMorphology primitive per
-Filter Effects §15.
+**B5 (feMorphology degenerate radius) is now fixed** — see
+[Recently fixed](#recently-fixed-prs-608611).
 
 ---
 
@@ -302,7 +248,7 @@ render order (fill/stroke/markers) is not reordered. On shapes, text, and tspan.
 
 **Impact:** 5 tests (`filters/feBlend` 2, `filters/feComposite` 3 incl. feFlood
 subregion). Filter primitives don't clip output to their `x`/`y`/`width`/`height`
-subregion. Overlaps [B6](#b6-feimage-fragment-ref--transform-broken-cpu)'s subregion cases.
+subregion. Overlaps [B6 (fixed)](#recently-fixed-prs-608611)'s subregion cases.
 
 ### F9: `textLength` + `lengthAdjust`
 
@@ -322,6 +268,21 @@ deferred vertical/`writing-mode=tb` cases.
 `text/text/bidi-reordering`, `text/tspan/bidi-reordering`,
 `text/letter-spacing/mixed-scripts`, `text/textLength` Arabic. Needs the BiDi
 algorithm + RTL shaping (`text-full`). Group as one workstream.
+
+### F12: `transform-origin` on paint-servers / `<image>` / text
+
+**Impact:** 7 tests in `structure/transform-origin/` (`on-gradient` ×2, `on-pattern`
+×2, `on-image`, `on-text`, `on-text-path`), kept skipped after the F2 regression fix.
+
+**Symptom:** these were *never* green — they are a separate never-implemented gap, not
+the #514 regression. Gradients/patterns route their transform through
+`getRawEntityFromParentTransform` (`SVGGradientElement.cc`, `SVGPatternElement.cc`),
+which intentionally drops the `transform-origin` pivot; for `<image>`/text the layout
+computes the correct origin (verified) but it doesn't compose with the content-placement
+transform, so they render off-screen.
+
+**Next step:** thread the resolved origin pivot through the paint-server and
+image/text content transforms (the shape path is now correct after #609 — mirror it).
 
 ### Smaller feature gaps
 
@@ -419,6 +380,11 @@ accepted AA floor.
   filter output path; one fix likely clears most. Repro: run `GeodeTinyParity` at
   threshold 0 and diff a solid-fill test (`painting/fill/rgb-0-127-0-0.5`). AA
   background + the accepted 4× MSAA edge floor: [0041 §2](0041-geode_analytical_aa.md).
+- **G6 — feImage bicubic shader (new, from #610).** tiny-skia now upscales feImage
+  with Mitchell-Netravali bicubic to match resvg; geode's WGSL image sampler
+  (`filter_image.wgsl`) is still bilinear, so `filters/feImage/svg.svg` is gated on
+  geode (`disableBackend(Geode)`). Port the bicubic kernel into the shader to match,
+  then un-gate.
 
 > The 172 `kEdgeFloor` entries are the **accepted-by-design** 4× MSAA edge-coverage
 > quantization (content matches tiny-skia; the sub-pixel edge differs). Geode stays

--- a/docs/design_docs/0021-resvg_feature_gaps.md
+++ b/docs/design_docs/0021-resvg_feature_gaps.md
@@ -1,286 +1,81 @@
 # resvg-test-suite: Feature Gaps & Open Bugs
 
-**Status:** Living catalog (current as of 2026-05-15)
+**Status:** Living catalog (current as of 2026-05-25). **Geode parity closed in
+[#606](https://github.com/jwmcglynn/donner/pull/606)** — the GPU backend is now at
+content parity with the CPU rasterizer (residual items are the accepted 4× MSAA
+edge floor + a short G3/G4/G5 tail). **The CPU-backend (RendererTinySkia) feature
+gaps and bugs are now the active front, and lead this backlog.**
 
 The triage backlog for [0022](0022-resvg_test_suite_upgrade.md)'s Milestone 2 —
 working through the tests the suite upgrade pulled in and either fixing the
 underlying gap or recording why a `Params::Skip(...)` is the correct state. Each
-entry corresponds to one or more skips in
+entry corresponds to one or more skips/threshold-overrides in
 [`resvg_test_suite.cc`](../../donner/svg/renderer/tests/resvg_test_suite.cc).
-
-**[Geode (GPU backend) parity leads this backlog](#geode-parity--priority-0)** —
-reaching pixel parity with the CPU rasterizer is Priority 0; the CPU-backend
-feature gaps follow.
 
 When a gap is fixed, delete its entry here and un-skip the tests **in the same
 PR**. Golden overrides (where Donner is right and resvg's golden is wrong) live in
 [0009](0009-resvg_test_suite_bugs.md), not here.
 
 **Conventions:**
-- **Impact** = number of currently-skipped tests the entry covers.
+- **Impact** = number of currently-skipped (or fat-thresholded) tests the entry covers.
 - **Root cause** = best-known localized explanation, or "needs investigation".
 - **Next step** = what a fix PR touches first.
 - Prefix `B` = bug (Donner is wrong), `F` = feature gap (standard feature not
   implemented). Numbers are stable IDs other docs/PRs can reference; retired
   entries leave their number burned.
 
+## How a test can be "not passing"
+
+There are **four** ways the suite hides a gap — not just `Skip`. The fourth is the
+one most likely to mask a real bug, and was under-tracked before this revision:
+
+| State | Count | Meaning |
+|---|---:|---|
+| `Params::Skip("reason")` | 288 | Not run. Feature gap or known bug. The bulk of this doc. |
+| `Params::RenderOnly("UB: …")` | 51 | Rendered, **not** compared. Implementation-defined / UB input; we only assert no-crash. Correctly classified — [out of scope](#out-of-scope-correctly-skipped--do-not-fix). |
+| Commented-out `INSTANTIATE_TEST_SUITE_P` | 1 block | `filters/filter-functions` — whole category dark on CI. See [B2](#b2-filtersfilter-functions-category-disabled-on-ci). |
+| `Params::WithThreshold(…, maxPx)` with **large `maxPx`** | ~22 over 1000 px | **Passes, but only because the diff cap is inflated.** Per [CLAUDE.md](../../CLAUDE.md) (>1000 px non-text = broken feature), several of these are **masked bugs**, not "AA". New section: [Masked bugs behind inflated CPU thresholds](#masked-bugs-behind-inflated-cpu-thresholds). |
+
+Geode's separate binary parity gate (`geodeParityGate`) is a fifth axis, now
+nearly closed — see [Geode parity — resolved](#geode-parity--resolved-606).
+
 ## Current totals
 
 | | Count |
 |---|---:|
 | `Params::Skip(...)` | 288 |
-| `Params::RenderOnly(...)` | 51 (mostly UB cases — render-must-not-crash, no pixel compare) |
+| `Params::RenderOnly(...)` | 51 (UB — render-must-not-crash, no pixel compare) |
+| CPU `WithThreshold` overrides (tiny-skia) | 87 (of which ~22 exceed 1000 px → masked-bug candidates) |
 | Commented-out category blocks | 1 (`filters/filter-functions`) |
-
-## Geode parity — Priority 0
-
-The GPU backend ([Geode](0017-geode_renderer.md)) must reach pixel parity with the
-CPU rasterizer (RendererTinySkia) across the resvg suite. As of 2026-05-15 the
-Geode variant (`:resvg_test_suite_geode`, wired at
-[`BUILD.bazel:447`](../../donner/svg/renderer/tests/BUILD.bazel)) runs **1,345
-pass / 0 fail / 291 skipped** of 1,636 cases. The 291 skips are **268 text** (the
-whole text suite gated off) + **23 per-test pixel divergences**. Closing those is
-the parity goal, and it leads this backlog.
-
-The structural stubs are gone — `drawText`, `pushFilterLayer`, clip, mask, blend
-modes, markers, patterns, gradients, and images are all implemented. Of 252 text
-tests, 162 fail on Geode; that splits into **4× MSAA edge-coverage quantization**
-(the bulk — accepted, Geode stays at 4× for perf) and **real structural bugs**
-(G1-struct — `drawText` renders no text stroke/decoration, plus CJK/vertical/
-rotate+pattern cases), alongside a **handful of filter-primitive bugs** (G2).
-
-> Source of truth for the per-test divergences: the 8 `disableBackend(Geode, …)`
-> gates in [`resvg_test_suite.cc`](../../donner/svg/renderer/tests/resvg_test_suite.cc)
-> (`geodeCategoryGate` / `geodeFilenameGate`). Narrative + phase plan:
-> [0017 Phase 5b/7](0017-geode_renderer.md). This section is the prioritization,
-> not a duplicate list — don't fork the gate list here.
-
-> ⚠️ **The "0 failing" number is softer than it looks.** Many Geode tests pass only
-> because their pixel threshold was widened with an "AA drift" / "MSAA vs
-> supersample" justification (~40 such sites across the Geode test code). Per
-> [CLAUDE.md §"Anti-Aliasing Is Never the Root Cause"](../../CLAUDE.md), that
-> reasoning is invalid: pixelmatch already excludes anti-aliased pixels, so a
-> nonzero diff is a real difference, not AA. Each AA-justified Geode threshold is a
-> **candidate masked bug** and needs re-auditing — passing-with-a-fat-threshold is
-> not parity. This audit is part of the parity work (G2/G5 below), not separate.
-
-### G1: Geode text parity — split into edge-sampling (accepted) + structural bugs
-
-**Status:** investigated 2026-05-15 to ground truth (full geode text run, pixel
-analysis, code read). Repro committed —
-`GeodeTextDecorationRepro.UnderlineNotRenderedOnGeode` in
-[`resvg_test_suite.cc`](../../donner/svg/renderer/tests/resvg_test_suite.cc)
-(red on Geode, authored + green on both CPU text tiers).
-
-**Methodology (corrected):** measure parity as geode-vs-**tiny-skia**, not
-geode-vs-resvg-golden. tiny-skia passes **all 252** text tests with the suite's
-per-test thresholds; geode fails **162** of the same tests with the same params —
-so all 162 are **geode-specific**. (My earlier "most text passes" was a sampling
-artifact; the full run is 88 pass / 162 fail.)
-
-The 162 split into two very different buckets:
-
-#### G1-edge: 4× MSAA edge-coverage quantization (the bulk) — accepted, not fixed
-
-The majority of failures (median ~697 px) are **edge-coverage quantization**.
-Proven on `text-anchor/end-on-text`: the text bbox is **pixel-identical** to the
-reference (`x[21..246] y[164..250]`, same size, ink within 1%), and geode's edge
-alpha is **quantized to 64-steps (0/64/128/191/255)** = exactly 4 MSAA samples,
-vs the reference's smooth coverage. This is the one place "edge sampling" is the
-*proven* cause (per [CLAUDE.md §"Anti-Aliasing Is Never the Root Cause"](../../CLAUDE.md),
-proven by a 1px edge band + quantified — not assumed).
-
-**Decision: Geode stays at 4× MSAA for performance.** So G1-edge is *not* a bug to
-fix — when un-gating, these tests get a documented per-test threshold widening
-attributable to the 4× sample count (a proven, deliberate tradeoff, not AA
-hand-waving). Glyphs at integer positions already pass (`font-weight/650` → 3 px);
-only fractional-position edges diverge.
-
-#### G1-struct: real structural bugs (the tail) — these get fixed
-
-Genuinely missing/broken rendering, far too large for edge coverage:
-
-- **`drawText` decoration** — `drawText` rendered no text-decoration
-  (underline/overline/line-through), while `RendererTinySkia::drawText` does.
-  ✅ **Fixed** (decoration *fill*) — ported metrics → rect → `fillPath`; the repro
-  is green and the existing geode golden suite is unaffected.
-- **`drawText` text + decoration stroke** — `drawText` drew no `stroke="…"` on
-  text. ✅ **Fixed** — re-enabled glyph + decoration stroke via
-  `placed.strokeToFill(...)`. (Two wrong hypotheses on the way, both ruled out by
-  measurement: it is *not* a "~2.5× too thick" width bug — element `strokeWidth=0`,
-  the stroke is span-driven and 2.5px is the correct device scale. The real bug was
-  the **fill rule**: closed contours expand to same-winding outer+inner subpaths,
-  so the ring needs `EvenOdd` (`Impl::strokeFillRuleFor`), not `NonZero` which
-  filled glyph interiors solid. Verified hollow ring; decoration tests 0 → 3.)
-- ~~**Default-fill resolution for stroked text**~~ — recorded as a "missing black
-  fill" bug (default-fill `<text stroke="…">` resolving `spanFill` alpha=0, glyphs
-  rendering as the stroke ring only). **Investigated 2026-05-24: not a bug at HEAD**
-  (`aab9665f6`). Instrumented `drawText` measures `spanFill=(0,0,0,255)`, `hasFill=1`
-  across plain / nested (`all-types-nested.svg`) / tspan-child / inherited-from-group
-  variants; a tiny-skia-authored golden diffs at ~201 px (the accepted G1-edge 4×
-  MSAA floor) with black-filled glyphs + a hollow stroke ring confirmed visually. The
-  original note was an in-flight artifact of the stroke fill-rule fix (same commit),
-  recorded as a hypothesis without a committed red repro — there is no fix to make.
-> ⚠️ **Metric caveat (added 2026-05-24):** the px figures below were measured
-> **geode-vs-resvg-golden** — the wrong oracle (parity is geode-vs-**tiny-skia**, per
-> the methodology note above). They are inflated by the shared ~1313 px
-> tiny-skia-vs-resvg baseline offset (the documented ~2 px vertical-baseline
-> reference gap, already covered by the suite's `withMaxPixelsDifferent(1500)` on the
-> tb tests) plus the ~950 px sub-pixel crosshair/frame floor common to the whole
-> writing-mode category. **Re-measure geode-vs-tiny-skia before treating any of these
-> as a bug** — two of the three originally listed (default-fill, vertical) evaporated
-> under the correct metric.
-
-- ~~`text/writing-mode=tb` (vertical) → ~2.3k px~~ — **not a bug** (investigated
-  2026-05-24). Geode-vs-tiny-skia is **9 px** (G1-edge floor) across all six vertical
-  tests (`tb`, `tb-rl`, `tb-with-alignment`, `inheritance`, `vertical-lr`,
-  `vertical-rl`); a bare vertical repro is 0 px. The 2.3k was geode-vs-resvg (~1313
-  baseline + ~950 crosshair/frame). The vertical rotate-only transform is identical
-  in both `drawText` paths.
-- `text/text/xml_lang_ja` (CJK) → ~19k px **geode-vs-resvg — re-measure**. Likely
-  real + structural anyway: bitmap-only/CBDT glyphs are skipped in `drawText`
-  (`RendererGeode.cc:3162`) — overlaps [G4](#g4-color-emoji--bitmap-fonts-structural).
-- `text/text/rotate…underline…pattern` → ~105k px **geode-vs-resvg — re-measure**.
-  Magnitude is large enough to be a real pattern-on-rotated-text bug regardless.
-
-**Latent (no failing test yet):** the two `drawText` paths compose the per-glyph
-transform differently — tiny-skia does stretch-on-outline then `Rotate*Translate`
-(`RendererTinySkia.cc:1588-1650`); Geode does `Scale*Rotate*Translate`
-(`RendererGeode.cc:3216-3224`). These diverge only when `stretchScale≠1` **and**
-`rotateDegrees≠0` at once — i.e. vertical text + `textLength`/`lengthAdjust=spacingAndGlyphs`.
-No current test hits that combo (0 px contribution here); file a properly-scoped repro
-before fixing.
-
-**Plan:**
-1. ✅ Repro committed (text-decoration underline, red on Geode).
-2. ✅ **Decoration fill** rendered in `drawText` — repro green, no golden-suite
-   regression.
-3. ✅ **Text + decoration stroke** rendered with the correct fill rule.
-4. ✅ **Default-fill resolution for stroked text** — investigated, *not a bug* at
-   HEAD (see struck bullet above); the recorded symptom doesn't reproduce. No change.
-5. Work the remaining G1-struct tail — **re-measure geode-vs-tiny-skia FIRST** (the
-   doc's px figures are geode-vs-resvg; two of three "bugs" evaporated under the
-   correct metric). Live candidates: CJK (`xml_lang_ja`, bitmap-glyph skip / G4) and
-   rotate+pattern (~105k). Vertical is resolved (9 px floor). **← active.**
-6. **Un-gate** via an **additive in-process backend matrix** — full plan in
-   [0017 §Phase 4b](0017-geode_renderer.md#phase-4b-in-process-backend-matrix--geode-vs-tiny-skia-parity-comparison).
-   One geode-enabled binary runs three comparison modes per test (`TinyGolden`,
-   `GeodeGolden`, and `GeodeTinyParity` which ignores the golden). **Landed green
-   (2026-05-24)** at the final policy: parity = pixelmatch `includeAA=false`, per-pixel
-   `kDefaultThreshold` (0.02), **flat 100-px max-count, no per-test thresholds** (not the
-   rejected `widenThresholdForGeode` 0.3 bump, which masks solid-region bugs — the
-   [G5](#g5-audit-the-aa-justified-geode-thresholds) pattern). Tests >100 px are **binary-
-   gated** via `geodeParityGate`, organized as an inventory: **172 edge-floor** (4× MSAA
-   edge quantization, 101–763 px — one shared reason, ratchet out together with finer AA) +
-   **56 genuine** (**38 filter** → reference [G2](#g2-filter-primitive-correctness-16-of-23-disabled-tests);
-   **18 text/text-on-shape** → reference [0038](0038-geode_tinyskia_text_parity.md)).
-   Whole-suite parity: **1035 pass / 228 gated** (text 86/159, non-text 949/69). The ~137
-   sub-visual premultiply fills pass at 0.02 → [G5](#g5-audit-the-aa-justified-geode-thresholds).
-
-   **Progress since landing (2026-05-24, see [0038](0038-geode_tinyskia_text_parity.md)):** the
-   text hoist resolved **all structural text divergences** (`kGenuineText` empty — gradient/
-   pattern-on-text + a shared-layout baseline-shift idempotency bug fixed, rest render-correct
-   edge-floor), and G2 fixes: a **linearRGB color-interpolation-filters** sweep for feComposite,
-   feComponentTransfer + feTurbulence + feMerge + feConvolveMatrix + feDiffuse/SpecularLighting
-   (geode was applying it to some primitives but not others), an **feImage shared-`RendererDriver`
-   re-draw idempotency fix** (8 tests), a **feDisplacementMap** correctness fix (un-premult +
-   bilinear + linearRGB), and a **feSpecularLighting spec fix** (specularExponent [1,128] clamp +
-   `<1`→transparent), and **`feGaussianBlur/complex-transform`** (anisotropic-blur-under-rotation —
-   ported tiny's transformed-blur path into geode's `popFilterLayer`: resample device→local, blur
-   in local space, composite back; 35151→140px). All 37 original filter divergences resolved; a
-   38th, **`feColorMatrix/type=hueRotate`**, surfaced on CI's Mesa **llvmpipe** (>100px geode-vs-tiny
-   there, ≤100px on macOS Metal — the Metal-calibrated un-gate missed it; gated as a driver-divergent
-   G2 color-math case). **Gate ledger now: 0 text + 1 G2 (hueRotate, llvmpipe-divergent) + 192
-   edge-floor = 193 gated** (down from 228); the rest are the **accepted-by-design** geode-vs-tiny
-   AAA-coverage / crosshair sub-pixel floor (content matches, unfixable in-renderer — [0041 §2](0041-geode_analytical_aa.md)). Two real
-   production idempotency bugs (baseline-shift, feImage) surfaced by the parity harness's
-   double-draw, plus a systematic geode filter linearRGB gap + spec-conformance bugs + the
-   transformed-blur path — all fixed in shared/geode code, not backend quirks. **Text + filter
-   parity complete.**
-
-### G2: Filter-primitive correctness (16 of 23 disabled tests)
-
-Concentrated, well-scoped shader/kernel bugs (file:line into
-[`resvg_test_suite.cc`](../../donner/svg/renderer/tests/resvg_test_suite.cc)):
-
-- **feConvolveMatrix** edge-mode / targetX / preserveAlpha / order=4 — 9 tests (`:206`)
-- **feImage** subregion / `preserveAspectRatio` placement, diverges between Mesa
-  llvmpipe and lavapipe (needs driver-independent placement) — 5 tests (`:364`)
-- **genuine pixel regressions**: feMorphology w/ opacity, feSpecularLighting
-  exponent=0, feTile empty-region, filter transform-on-shape — 4 tests (`:228`)
-- **feComponentTransfer** gradient + mixed per-channel types — 1 (`:332`)
-- **feDiffuseLighting** no-light-source draws black instead of no-op pass-through — 1 (`:346`)
-
-### G3: Driver / perf one-offs (low priority)
-
-- **feMorphology huge-radius** > 30 s on Mesa llvmpipe trips the per-testcase
-  watchdog — 1 test (`:406`); kernel tuning, ties into
-  [0030](0030-geode_performance.md).
-- **marker `orient=auto`** tangent disagrees at curve cusps — 1 test (`:251`); real
-  geometry bug.
-
-### G4: Color-emoji / bitmap fonts (structural)
-
-CBDT/CBLC bitmap glyphs are skipped inside `drawText`
-([`RendererGeode.cc:3162`](../../donner/svg/renderer/RendererGeode.cc)) — they need
-the `GeodeTextureEncoder` path wired up. Smaller scope; sequence after G1 lands the
-outline-text suite.
-
-### G5: Audit the AA-justified Geode thresholds
-
-**Impact:** ~40 widened-threshold sites across the Geode test code (grep
-`resvg_test_suite.cc`, `Renderer_tests.cc`, `RendererGeodeGolden_tests.cc`,
-`RendererTestBackendGeode.cc` for `MSAA` / `supersample` / `AA drift`).
-
-**Symptom:** these tests "pass" only with an inflated per-pixel threshold whose
-comment blames anti-aliasing. pixelmatch already excludes AA pixels, so the
-absorbed diff is real — each is a possible Geode rendering bug hiding behind the
-threshold (the #582 pattern).
-
-**Next step:** for each, drop the threshold to default, capture the real diff
-(`actual/expected/diff` PNGs), and root-cause it. Replace the AA comment with the
-true cause or a tracking link. Don't reword the comments without doing the
-investigation — that just relabels the masking.
-
-**G5-premultiply (quantified 2026-05-24, the Phase 4b parity run):** ~137 non-text
-tests show a **uniform, sub-perceptual color/alpha offset across solid fills** — the
-*whole* fill region differs from tiny-skia at strict-0, but the diff collapses to
-<100 px at the suite's default 0.02 threshold (and is invisible to the eye). The
-likely single root cause is **premultiplied-alpha / color-space rounding** in Geode's
-solid + filter output path (e.g. unpremultiply-on-store rounding vs tiny-skia). These
-**pass** the Phase 4b parity gate at 0.02 (not gated), but they are exactly the G5
-"sub-threshold real diff" pattern at scale: a 1–2 level offset on a 400×400 fill =
-160000 px at threshold 0. **One premultiply/rounding fix likely clears most of them.**
-Repro: run the `GeodeTinyParity` mode at threshold 0 (vs 0.02) and diff a solid-fill
-test such as `filters/feBlend/mode=multiply` or `painting/fill/rgb-0-127-0-0.5` — the
-diff is the entire solid interior, uniformly. Tracked as the durable color-output item.
+| Geode binary parity gate (`geodeParityGate`) | 173 (172 edge-floor + 1 `feColorMatrix/hueRotate`); 0 text, 0 other genuine |
 
 ---
 
-## Backlog ranked by leverage (CPU backends)
+## Priority 0: CPU-backend backlog (the active front)
 
-Geode parity (above) is Priority 0. The rest of this doc is the CPU-backend
-(RendererTinySkia / Skia) feature gaps. Highest-value first; "out of scope" rows
-are correct-as-skipped and listed at the bottom for completeness.
+Highest-value first. "Out of scope" rows are correct-as-skipped and listed at the
+bottom for completeness.
 
 | ID | Gap | Impact | Kind |
 |---|---|---:|---|
-| F2 | `transform-origin` rendering regression (#514) | 21 | Regression — single PR |
+| **F2** | `transform-origin` rendering **regression** (#514) | 20 | **Regression — single PR, known-good prior state. Top payoff.** |
+| **B6** | `feImage` fragment-ref + transform broken (masked by fat thresholds) | 7 | **Bug — 22k–34k px diffs hidden at `maxPx`; not AA.** |
 | B2 | `filters/filter-functions` disabled (CI "Data corrupted") | ~30 | CI gap — whole category dark |
 | B3 | `<image>` embedded/data-URL sizing | 18 | Bug — one investigation |
-| F3 | `context-fill` / `context-stroke` | 13 | Feature |
-| F4 | `<switch>` conditional processing | 12 | Feature |
-| F5 | full `dominant-baseline` keyword set | 14 | Feature |
-| F6 | full `alignment-baseline` keyword set | 10 | Feature |
 | B1 | intrinsic sizing + percent on non-square viewBox | ~10 | Bug — one root cause, many categories |
-| F7 | `paint-order` rendering | 9 | Feature (parsed, not rendered) |
-| B4 | `<use>` → inline `<svg>` sizing | 5 | Bug |
 | B5 | `feMorphology` edge cases | 5 | Bug |
-| F8 | primitive subregion clipping (feBlend/feComposite/feFlood) | 5 | Feature |
+| B4 | `<use>` → inline `<svg>` sizing | 5 | Bug (shares machinery with B3) |
+| F3 | `context-fill` / `context-stroke` | 13 | Feature |
+| F5 | full `dominant-baseline` keyword set | 14 | Feature |
+| F4 | `<switch>` conditional processing | 12 (+systemLanguage 3) | Feature |
+| F6 | full `alignment-baseline` keyword set | 10 | Feature |
+| F7 | `paint-order` rendering | 8 | Feature (parsed, not rendered) |
 | F9 | `textLength` + `lengthAdjust` stretch/compress | 8 | Feature |
 | F10 | `textPath` SVG2 attributes (`path`/`side`/`method`/`spacing`) | 8 | Feature |
-| F11 | BiDi / RTL text shaping | ~8 | Feature |
-| — | masking edge cases (mask 8, clipPath 11) | ~19 | Mixed |
+| F11 | BiDi / RTL text shaping | ~8 | Feature (needs `text-full`) |
+| F8 | primitive subregion clipping (feBlend/feComposite/feFlood) | 5 | Feature |
+| B7 | font substitution — missing bundled families (masked by fat thresholds) | ~9 | Triage: bundle fonts vs. document as known gap |
+| — | masking edge cases (mask 8, clipPath 6) | ~14 | Mixed |
 | — | uncertain `Bug?` entries (need triage) | ~12 | Needs investigation |
 | F1 | `enable-background` + `in=Background*` | 23 | **Out of scope** (deprecated) |
 | — | other deprecated/UB skips | ~30 | **Out of scope** |
@@ -291,11 +86,11 @@ are correct-as-skipped and listed at the bottom for completeness.
 
 ### F2: `transform-origin` rendering broken after #514
 
-**Impact:** 21 tests — all of `structure/transform-origin/`.
+**Impact:** 20 tests — all of `structure/transform-origin/` (category
+`StructureTransformOrigin`, [`resvg_test_suite.cc:2229`](../../donner/svg/renderer/tests/resvg_test_suite.cc)).
 
 **Symptom:** 10K–150K-pixel diffs — rendering is completely wrong, not slightly
-off. Tagged `Skip("transform-origin broken after #514")` with `TODO(#514)` at
-[`resvg_test_suite.cc:1593`](../../donner/svg/renderer/tests/resvg_test_suite.cc).
+off. Every test tagged `Skip("transform-origin broken after #514")`.
 
 **Root cause:** PR #514 added single-keyword `transform-origin` parsing (e.g.
 `transform-origin: center`) and regressed the rendering path in the process.
@@ -305,7 +100,7 @@ pivots around the wrong origin.
 **Next step:** bisect #514's diff. The parser change and the apply-at-render change
 are separable — verify `ParseTransformOrigin` output, then check
 `LayoutSystem::createComputedLocalTransformComponentWithStyle` consumes the
-resolved origin. Land the fix and un-skip all 21 in one PR. **Highest single-PR
+resolved origin. Land the fix and un-skip all 20 in one PR. **Highest single-PR
 payoff in the backlog** (it's a regression, so there's a known-good prior state).
 
 > Note: this entry previously described `transform-origin` as a never-implemented
@@ -315,12 +110,14 @@ payoff in the backlog** (it's a regression, so there's a known-good prior state)
 
 ### B2: `filters/filter-functions` category disabled on CI
 
-**Impact:** ~30 tests — the entire `filters/filter-functions/` block.
+**Impact:** ~30 tests — the entire `filters/filter-functions/` block, commented out
+at [`resvg_test_suite.cc:1410`](../../donner/svg/renderer/tests/resvg_test_suite.cc).
 
 **Symptom:** The `INSTANTIATE_TEST_SUITE_P(FiltersFilterFunctions, …)` block is
-commented out ([`resvg_test_suite.cc:872`](../../donner/svg/renderer/tests/resvg_test_suite.cc)).
-The category produces `"Data corrupted"` parse errors on CI x86_64 runners but
-passes locally on aarch64.
+commented out. The category produces `"Data corrupted"` parse errors on CI x86_64
+runners but passes locally on aarch64. (Note: the harmless per-test `"Data
+corrupted"` log lines from `UrlLoader` font fallback are *unrelated* — this is a
+parse failure that fails the comparison.)
 
 **Root cause:** unknown. Candidates: a resvg-test-suite data-integrity issue on
 CI, an x86_64-specific parser bug, or a runfiles/encoding difference between the
@@ -333,6 +130,73 @@ that triggers `"Data corrupted"` and minimize it. These tests were enabled once 
 rendering path works — this is an input/parse problem on one arch. Two custom
 goldens (`drop-shadow-function-{mm,em}-values`) are parked for re-enable; see
 [0009](0009-resvg_test_suite_bugs.md).
+
+---
+
+## Masked bugs behind inflated CPU thresholds
+
+These tests **pass**, but only because `maxMismatchedPixels` was raised far above
+the suite default (100). pixelmatch already excludes anti-aliased pixels, so a
+multi-thousand-px diff on the CPU backend is a *real* rendering difference. Per
+[CLAUDE.md §"Anti-Aliasing Is Never the Root Cause"](../../CLAUDE.md), "AA drift"
+is not a valid reason for these magnitudes. The full audit list lives in the test
+file; the two structural clusters are promoted to tracked bugs below.
+
+### B6: `feImage` fragment-ref + transform broken (CPU)
+
+**Impact:** 7 tests in `filters/feImage/`, all "passing" at inflated caps:
+
+| Test | `maxPx` | Comment in file |
+|---|---:|---|
+| `link-to-an-element-with-transform.svg` | 34200 | "Fragment ref with skewX transform on element" |
+| `link-on-an-element-with-complex-transform.svg` | 26200 | "Fragment ref with complex transform" |
+| `chained-feImage.svg` | 22000 | "Chained feImage fragment refs" |
+| `with-subregion-4.svg` | 15000 | "Absolute subregion coords" |
+| `with-subregion-3.svg` | 14500 | "Percentage width subregion" |
+| `with-subregion-1.svg` / `with-subregion-2.svg` | 5100 | "OBB subregion bilinear / percentage" |
+
+**Symptom:** a 34K-px diff on a single image means the **transform applied to a
+`feImage` fragment reference is wrong** (placement/scale/skew), and subregion
+placement disagrees with the golden. This is the same family as the Geode feImage
+divergence that #606 chased (resolved there with the shared-`RendererDriver`
+re-draw fix + driver-independent placement) — the CPU path was never audited, just
+thresholded.
+
+**Root cause:** needs investigation. Start at the `feImage` primitive's handling of
+(a) a fragment reference to a transformed element, and (b) the
+`x`/`y`/`width`/`height` subregion → device mapping. Cross-check against the Geode
+feImage fixes in [0017](0017-geode_renderer.md) / the #606 filter work — the
+correct placement math may already exist there.
+
+**Next step:** drop the thresholds to the default 100, capture
+`actual/expected/diff` PNGs for `link-to-an-element-with-transform`, and root-cause
+the transform composition. Overlaps [B3](#b3-image-embedded--data-url-sizing)
+(image placement) and [F8](#f8-primitive-subregion-clipping) (subregion).
+
+### B7: font substitution — missing bundled families
+
+**Impact:** ~9 `text/font-family/` tests at `maxPx` 600–5200 (`serif` 4200,
+`sans-serif` 1900, `monospace` 600, `cursive` 5000, `fantasy` 5200,
+`bold-sans-serif` 5200, `source-sans-pro` 1300, `font-list` 1300, `fallback-2`
+1000), plus `text/text/xml-lang=ja` (19100, CJK) and `structure/defs/
+style-inheritance-on-text` (6500).
+
+**Symptom:** the diffs are whole-glyph — Donner substitutes a *different font* than
+the golden was rendered with (the suite's `cursive`/`fantasy`/CJK families aren't
+bundled), so every glyph outline differs. This is not a renderer bug; it's a
+font-availability gap currently *silently* absorbed by a fat threshold.
+
+**Next step (triage decision):** either (a) bundle the missing families and tighten
+the thresholds to default, or (b) reclassify these as explicit `Skip("font not
+bundled: <family>")` so the gap is visible instead of hidden. Do **not** leave them
+as unexplained fat thresholds. Decide per-family; `serif`/`sans-serif`/`monospace`
+likely map to already-bundled Noto faces (real diff to chase), while
+`cursive`/`fantasy` are genuinely missing.
+
+> The remaining sub-1000-px CPU thresholds (feColorMatrix matrix/saturate variants,
+> feDropShadow, text-decoration rotate-lists, pattern AA) are small enough to be
+> plausible coverage-geometry differences; audit opportunistically but they are not
+> promoted bugs.
 
 ---
 
@@ -380,7 +244,9 @@ cases disagree with the golden.
 `preserveAspectRatio` resolution for raster + nested-SVG content.
 
 **Next step:** start with `embedded-png` + `preserveAspectRatio=none` (the
-simplest), then walk the no-width/no-height/auto matrix.
+simplest), then walk the no-width/no-height/auto matrix. Shares
+`preserveAspectRatio` math with [B6](#b6-feimage-fragment-ref--transform-broken-cpu)
+and [B4](#b4-use-referencing-inline-svg-elements).
 
 ### B4: `<use>` referencing inline `<svg>` elements
 
@@ -429,14 +295,14 @@ baseline alignment.
 
 ### F7: `paint-order` rendering
 
-**Impact:** 9 tests in `painting/paint-order/`. The property name parses but
+**Impact:** 8 tests in `painting/paint-order/`. The property name parses but
 render order (fill/stroke/markers) is not reordered. On shapes, text, and tspan.
 
 ### F8: primitive subregion clipping
 
 **Impact:** 5 tests (`filters/feBlend` 2, `filters/feComposite` 3 incl. feFlood
 subregion). Filter primitives don't clip output to their `x`/`y`/`width`/`height`
-subregion.
+subregion. Overlaps [B6](#b6-feimage-fragment-ref--transform-broken-cpu)'s subregion cases.
 
 ### F9: `textLength` + `lengthAdjust`
 
@@ -484,11 +350,14 @@ bug vs. out-of-scope:
 - `structure/svg`: XML Entity references (3), mixed namespaces, non-UTF-8 encoding,
   rect-inside-non-SVG-element, xmlns validation
 - `paint-servers/stop`: `stop-color` inherit edge case
-- `text/letter-spacing/non-ASCII-character`: different CJK glyph (wrong font?)
+- `text/letter-spacing/non-ASCII-character`: different CJK glyph (wrong font? →
+  overlaps [B7](#b7-font-substitution--missing-bundled-families))
 - `text/textLength/on-text-and-tspan`: we compress more than the golden
 - `text/font-family/fallback-1`: fallback from invalid family
 - `masking/clip/simple-case`: empty `Skip()` with no reason — must get a reason or
   be fixed
+- `filters/feImage/empty.svg`: `Skip("Linux CI: std::bad_alloc in test setup")` —
+  a CI-only allocation failure that should be root-caused, not left skipped
 
 ---
 
@@ -505,6 +374,56 @@ bug vs. out-of-scope:
 | painting/opacity/50percent | 1 | css-color-4 allows percentage; test predates it. |
 | structure/style-attribute | 1 | `<svg version="1.1">` disables geometry-in-style (SVG 1.1 behavior). |
 | RenderOnly UB cases | 51 | Implementation-defined output; we verify no-crash only (per project policy, kept RenderOnly not Skip). |
+
+---
+
+## Geode parity — resolved (#606)
+
+The GPU backend ([Geode](0017-geode_renderer.md)) reached **content parity** with
+RendererTinySkia across the resvg suite in
+[#606](https://github.com/jwmcglynn/donner/pull/606). Parity is measured
+geode-vs-**tiny-skia** (not geode-vs-resvg-golden, which carries a baseline/crosshair
+offset that fakes bugs), via the in-process backend matrix
+([0017 §Phase 4b](0017-geode_renderer.md)): one geode binary runs `TinyGolden`,
+`GeodeGolden`, and `GeodeTinyParity` modes. The parity gate is pixelmatch
+`includeAA=false`, per-pixel `kDefaultThreshold` (0.02), **flat 100-px max-count, no
+per-test thresholds**; tests over 100 px are binary-gated in `geodeParityGate`.
+
+**Gate ledger (current): 173 gated = 172 edge-floor + 1 G2 + 0 text.** The
+structural work is done; what remains is one driver-divergent color case and the
+accepted AA floor.
+
+- **G1 — text parity ✅ complete.** All structural text divergences resolved
+  (text/decoration fill + stroke with the correct fill rule, gradient/pattern on
+  text incl. span-override precedence, per-char dy/rotate, a shared-layout
+  baseline-shift idempotency bug). `kGenuineText` is empty. Developer reference:
+  [0038](0038-geode_tinyskia_text_parity.md).
+- **G2 — filter primitives ✅ complete (1 residual).** All 37 original filter
+  divergences fixed (a systematic linearRGB `color-interpolation-filters` sweep, an
+  feImage shared-`RendererDriver` re-draw idempotency fix, feDisplacementMap
+  correctness, feSpecularLighting spec clamp, anisotropic transformed-blur). **One
+  residual:** `filters/feColorMatrix/type=hueRotate` diverges >100 px on CI's Mesa
+  **llvmpipe** (≤100 px on macOS Metal) — gated as `kGenuineG2`, a driver-divergent
+  color-math case.
+- **G3 — driver / perf one-offs (residual).** `feMorphology/huge-radius` >30 s on
+  llvmpipe (watchdog; ties into [0030](0030-geode_performance.md)); `marker
+  orient=auto` tangent at curve cusps (real geometry bug). Low priority.
+- **G4 — color-emoji / bitmap fonts (residual, structural).** CBDT/CBLC bitmap
+  glyphs are skipped inside `drawText` ([RendererGeode.cc](../../donner/svg/renderer/RendererGeode.cc)) —
+  they need the `GeodeTextureEncoder` path. Overlaps the CPU CJK gap in
+  [B7](#b7-font-substitution--missing-bundled-families).
+- **G5 — premultiply / color-output audit (open).** ~137 non-text tests show a
+  uniform, sub-perceptual color/alpha offset across solid fills — they **pass** the
+  0.02 parity gate but the whole fill region differs at strict-0. Likely one
+  premultiplied-alpha / unpremult-on-store rounding root cause in Geode's solid +
+  filter output path; one fix likely clears most. Repro: run `GeodeTinyParity` at
+  threshold 0 and diff a solid-fill test (`painting/fill/rgb-0-127-0-0.5`). AA
+  background + the accepted 4× MSAA edge floor: [0041 §2](0041-geode_analytical_aa.md).
+
+> The 172 `kEdgeFloor` entries are the **accepted-by-design** 4× MSAA edge-coverage
+> quantization (content matches tiny-skia; the sub-pixel edge differs). Geode stays
+> at 4× MSAA for performance — these ratchet out together if/when finer AA lands,
+> not one-by-one. Do **not** widen per-test thresholds to "fix" them.
 
 ---
 


### PR DESCRIPTION
🤖 Refreshes the resvg feature-gaps living catalog now that Geode parity closed in #606.

**What changed**
- **Geode parity demoted to "resolved (#606)"** — gate ledger 228→173 (172 accepted 4× MSAA edge-floor + 1 `feColorMatrix/hueRotate` llvmpipe-divergent; 0 text, 0 other genuine). G1/G2 complete (→ 0038/0041/0042); G3/G4/G5 are the short residual tail.
- **CPU/tiny-skia backlog promoted to Priority 0**, re-ranked with the **F2 `transform-origin` regression (#514, 20 tests)** at the top (known-good prior state → highest single-PR payoff).
- **New classification axis:** a test can fail to pass four ways, not one. Added `WithThreshold` overrides with inflated `maxPx` — ~22 CPU tests "pass" only behind 1000px+ caps. Per [CLAUDE.md](../blob/main/CLAUDE.md) these are masked bugs, not AA:
  - **B6** — `feImage` fragment-ref + transform broken on CPU (`link-to-an-element-with-transform` **34,200px**, `link-on-...-complex-transform` 26,200, `chained-feImage` 22,000, subregion 5,100–15,000). A 34k-px diff means the fragment-ref transform is wrong.
  - **B7** — font substitution (missing bundled families, 600–5,200px) — bundle or `Skip`, don't hide.
- Refreshed counts/dates (288 Skip, 51 RenderOnly/UB, 87 CPU thresholds, F2=20).

Docs-only; no code or test changes. Parallel fix PRs for F2/B6/B1/B5 to follow.