### PR TITLE
fix(layout): correct transform-origin pivot sandwich order (F2)

### DIFF
--- a/donner/svg/components/layout/LayoutSystem.cc
+++ b/donner/svg/components/layout/LayoutSystem.cc
@@ -306,9 +306,13 @@ Transform2d LayoutSystem::getEntityFromParentTransform(EntityHandle entity) {
   const ComputedLocalTransformComponent& computedTransform =
       createComputedLocalTransformComponentWithStyle(entity, style, FontMetrics(), disabledSink);
 
-  return Transform2d::Translate(computedTransform.transformOrigin) *
+  // Apply the transform-origin pivot: translate the origin to (0,0), apply the element transform,
+  // then translate back. Donner's `operator*` is left-first (`A * B` applies A, then B), so the
+  // pivot-out translation `Translate(-origin)` must come first in the product and the pivot-back
+  // `Translate(origin)` last — equivalent to the column-matrix product T(origin)·M·T(-origin).
+  return Transform2d::Translate(-computedTransform.transformOrigin) *
          computedTransform.parentFromEntity *
-         Transform2d::Translate(-computedTransform.transformOrigin);
+         Transform2d::Translate(computedTransform.transformOrigin);
 }
 
 Transform2d LayoutSystem::getCanvasFromDocumentTransform(Registry& registry) {

--- a/donner/svg/components/layout/tests/LayoutSystem_tests.cc
+++ b/donner/svg/components/layout/tests/LayoutSystem_tests.cc
@@ -227,9 +227,12 @@ TEST_F(LayoutSystemTest, TransformOriginSupport) {
   auto rectA = document.querySelector("#a")->entityHandle();
   auto rectB = document.querySelector("#b")->entityHandle();
 
-  const Transform2d expectedOrigin50Percent = Transform2d::Translate({50.0, 50.0}) *
+  // transform-origin pivot in destFromSource / left-first `operator*` convention: translate the
+  // origin to (0,0) first, rotate, then translate back. Equivalent to the column-matrix product
+  // T(origin)·R·T(-origin).
+  const Transform2d expectedOrigin50Percent = Transform2d::Translate({-50.0, -50.0}) *
                                               Transform2d::Rotate(MathConstants<double>::kHalfPi) *
-                                              Transform2d::Translate({-50.0, -50.0});
+                                              Transform2d::Translate({50.0, 50.0});
 
   EXPECT_THAT(layoutSystem.getEntityFromParentTransform(rectA),
               TransformEq(expectedOrigin50Percent));
@@ -250,9 +253,9 @@ TEST_F(LayoutSystemTest, TransformOriginBottomRight) {
 
   auto rectC = document.querySelector("#c")->entityHandle();
 
-  const Transform2d expected = Transform2d::Translate({100.0, 100.0}) *
+  const Transform2d expected = Transform2d::Translate({-100.0, -100.0}) *
                                Transform2d::Rotate(MathConstants<double>::kHalfPi) *
-                               Transform2d::Translate({-100.0, -100.0});
+                               Transform2d::Translate({100.0, 100.0});
 
   EXPECT_THAT(layoutSystem.getEntityFromParentTransform(rectC), TransformEq(expected));
 }
@@ -270,9 +273,9 @@ TEST_F(LayoutSystemTest, TransformOriginQuarterThreeQuarter) {
 
   auto rectD = document.querySelector("#d")->entityHandle();
 
-  const Transform2d expected = Transform2d::Translate({25.0, 75.0}) *
+  const Transform2d expected = Transform2d::Translate({-25.0, -75.0}) *
                                Transform2d::Rotate(MathConstants<double>::kHalfPi) *
-                               Transform2d::Translate({-25.0, -75.0});
+                               Transform2d::Translate({25.0, 75.0});
 
   EXPECT_THAT(layoutSystem.getEntityFromParentTransform(rectD), TransformEq(expected));
 }
@@ -290,9 +293,9 @@ TEST_F(LayoutSystemTest, TransformOriginPixels) {
 
   auto rectE = document.querySelector("#e")->entityHandle();
 
-  const Transform2d expected = Transform2d::Translate({10.0, 20.0}) *
+  const Transform2d expected = Transform2d::Translate({-10.0, -20.0}) *
                                Transform2d::Rotate(MathConstants<double>::kHalfPi) *
-                               Transform2d::Translate({-10.0, -20.0});
+                               Transform2d::Translate({10.0, 20.0});
 
   EXPECT_THAT(layoutSystem.getEntityFromParentTransform(rectE), TransformEq(expected));
 }
@@ -810,9 +813,6 @@ TEST_F(LayoutSystemTest, CreateShadowSizedElementComponentReturnsFalseWhenNotMai
 /**
  * transform-origin: center center should resolve to 50% 50%.
  * For non-sized elements like <rect>, percentages are resolved against the inherited viewBox.
- *
- * Note: single-keyword "center" currently fails to parse (known issue in the CSS transform-origin
- * parser), so we use the two-keyword form "center center" here.
  */
 TEST_F(LayoutSystemTest, TransformOriginCenterKeyword) {
   auto document = ParseSVG(R"-(
@@ -825,10 +825,11 @@ TEST_F(LayoutSystemTest, TransformOriginCenterKeyword) {
   auto rectHandle = document.querySelector("#r")->entityHandle();
 
   // "center center" maps to 50% 50%, resolved against the viewBox (120x80).
-  // Origin offset = (60, 40).
-  const Transform2d expected = Transform2d::Translate({60.0, 40.0}) *
+  // Origin offset = (60, 40). Pivot sandwich in left-first `operator*` order: translate the origin
+  // to (0,0) first, rotate, then translate back (column-matrix product T(origin)·R·T(-origin)).
+  const Transform2d expected = Transform2d::Translate({-60.0, -40.0}) *
                                Transform2d::Rotate(MathConstants<double>::kHalfPi) *
-                               Transform2d::Translate({-60.0, -40.0});
+                               Transform2d::Translate({60.0, 40.0});
 
   EXPECT_THAT(layoutSystem.getEntityFromParentTransform(rectHandle), TransformEq(expected));
 }
@@ -848,9 +849,10 @@ TEST_F(LayoutSystemTest, TransformOriginRightBottom) {
   auto rectHandle = document.querySelector("#r")->entityHandle();
 
   // "right" = 100% of viewBox width (200), "bottom" = 100% of viewBox height (140).
-  const Transform2d expected = Transform2d::Translate({200.0, 140.0}) *
+  // Pivot sandwich in left-first `operator*` order: T(origin)·R·T(-origin) (column-matrix).
+  const Transform2d expected = Transform2d::Translate({-200.0, -140.0}) *
                                Transform2d::Rotate(MathConstants<double>::kHalfPi) *
-                               Transform2d::Translate({-200.0, -140.0});
+                               Transform2d::Translate({200.0, 140.0});
 
   EXPECT_THAT(layoutSystem.getEntityFromParentTransform(rectHandle), TransformEq(expected));
 }

--- a/donner/svg/renderer/tests/resvg_test_suite.cc
+++ b/donner/svg/renderer/tests/resvg_test_suite.cc
@@ -94,6 +94,14 @@ std::optional<std::function<void(ImageComparisonParams&)>> geodeCategoryGate(
     };
   }
 
+  // transform-origin: the shapes here are rotated 45/90 degrees about their pivot, so every shape
+  // edge is a diagonal MSAA boundary. Geode matches tiny-skia exactly (GeodeTinyParity passes), but
+  // the GeodeGolden mode picks up the usual 4x-MSAA edge-sampling drift vs the resvg reference
+  // (~140-280px), handled the same way as the filter categories above.
+  if (category == "structure/transform-origin") {
+    return [](ImageComparisonParams& p) { widenThresholdForGeode(p); };
+  }
+
   // Clip-paths (`masking/clip`, `masking/clipPath`, `masking/clip-rule`)
   // run through the Phase 3b mask pipeline, and `<mask>` elements run
   // through the Phase 3c mask-blit pipeline — no wholesale category
@@ -2227,40 +2235,41 @@ INSTANTIATE_TEST_SUITE_P(
 
 INSTANTIATE_TEST_SUITE_P(
     StructureTransformOrigin, ImageComparisonTestFixture,
-    Combine(ValuesIn(getTestsInCategory(
-                "structure/transform-origin",
-                {
-                    // TODO(#514): transform-origin rendering is broken after #514's
-                    // single-keyword parsing changes — 10K-150K pixel diffs indicate
-                    // the rendering is completely wrong, not just slightly off. Disabled
-                    // until the root cause is investigated and fixed properly.
-                    {"bottom.svg", Params::Skip("transform-origin broken after #514")},
-                    {"center.svg", Params::Skip("transform-origin broken after #514")},
-                    {"keyword-length.svg", Params::Skip("transform-origin broken after #514")},
-                    {"left.svg", Params::Skip("transform-origin broken after #514")},
-                    {"length-percent.svg", Params::Skip("transform-origin broken after #514")},
-                    {"length-px.svg", Params::Skip("transform-origin broken after #514")},
-                    {"on-clippath-objectBoundingBox.svg",
-                     Params::Skip("transform-origin broken after #514")},
-                    {"on-clippath.svg", Params::Skip("transform-origin broken after #514")},
-                    {"on-gradient-object-bounding-box.svg",
-                     Params::Skip("transform-origin broken after #514")},
-                    {"on-gradient-user-space-on-use.svg",
-                     Params::Skip("transform-origin broken after #514")},
-                    {"on-group.svg", Params::Skip("transform-origin broken after #514")},
-                    {"on-image.svg", Params::Skip("transform-origin broken after #514")},
-                    {"on-pattern-object-bounding-box.svg",
-                     Params::Skip("transform-origin broken after #514")},
-                    {"on-pattern-user-space-on-use.svg",
-                     Params::Skip("transform-origin broken after #514")},
-                    {"on-shape.svg", Params::Skip("transform-origin broken after #514")},
-                    {"on-text-path.svg", Params::Skip("transform-origin broken after #514")},
-                    {"on-text.svg", Params::Skip("transform-origin broken after #514")},
-                    {"right-bottom.svg", Params::Skip("transform-origin broken after #514")},
-                    {"right.svg", Params::Skip("transform-origin broken after #514")},
-                    {"top.svg", Params::Skip("transform-origin broken after #514")},
-                })),
-            ValuesIn(ActiveComparisonModes())),
+    Combine(
+        ValuesIn(getTestsInCategory(
+            "structure/transform-origin",
+            {
+                // The remaining skips are not the #514 regression (that was an inverted
+                // transform-origin pivot-sandwich order, fixed in LayoutSystem). They are
+                // pre-existing feature gaps: transform-origin is not yet applied to element
+                // classes that carry their own transform machinery.
+                //
+                // Gradients/patterns route their transform through
+                // `getRawEntityFromParentTransform` (gradientTransform / patternTransform),
+                // which intentionally drops the transform-origin pivot — so the property has
+                // never been honored on these paint servers.
+                {"on-gradient-object-bounding-box.svg",
+                 Params::Skip("transform-origin not applied to gradientTransform (feature gap)")},
+                {"on-gradient-user-space-on-use.svg",
+                 Params::Skip("transform-origin not applied to gradientTransform (feature gap)")},
+                {"on-pattern-object-bounding-box.svg",
+                 Params::Skip("transform-origin not applied to patternTransform (feature gap)")},
+                {"on-pattern-user-space-on-use.svg",
+                 Params::Skip("transform-origin not applied to patternTransform (feature gap)")},
+                // <image>/<text>/<textPath> compute the correct origin in LayoutSystem, but the
+                // pivot does not yet compose correctly with their content-placement transforms,
+                // so the element renders off-screen. Pre-existing gap, separate from #514.
+                {"on-image.svg",
+                 Params::Skip("transform-origin pivot not composed with image content placement "
+                              "(feature gap)")},
+                {"on-text.svg",
+                 Params::Skip("transform-origin pivot not composed with text layout (feature "
+                              "gap)")},
+                {"on-text-path.svg",
+                 Params::Skip("transform-origin pivot not composed with textPath layout "
+                              "(feature gap)")},
+            })),
+        ValuesIn(ActiveComparisonModes())),
     TestNameFromFilename);
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
🤖 Fixes **F2** in [0021](docs/design_docs/0021-resvg_feature_gaps.md): the `transform-origin` rendering regression introduced by #514.

## Root cause
`LayoutSystem::getEntityFromParentTransform` wrote the pivot sandwich in intuitive math order `Translate(O) * raw * Translate(-O)`, but Donner's `Transform2d::operator*` is **left-first** (`A * B` = apply A then B, column-vector points). So the pivot-out translate applied **last** instead of first — the pivot point was not a fixed point of the transform, and every rotated/scaled element with a non-zero `transform-origin` (CSS default `50% 50%`) pivoted around the wrong center.

Verified by hand: for `center.svg` the pivot (100,100) must stay fixed. Old order → (-100, 182.8); corrected order `Translate(-O) * raw * Translate(O)` → (100,100), matching the SVG's reference `translate(100 100) rotate(45) translate(-100 -100)`. (#531's `entityFromParent`→`parentFromEntity` rename didn't invert anything, so the bug stood from #514 onward; the tests were skipped at birth, never green.)

## Fix
- `LayoutSystem.cc` — swap the two translates to `Translate(-origin) * parentFromEntity * Translate(origin)`.
- `LayoutSystem_tests.cc` — six `TransformOrigin*` unit tests had been written to assert the **broken** order; corrected their expected values (red→green at the unit level too).

## Red→green (13 tests un-skipped)
`resvg_test_suite_default_text` TinyGolden at HEAD: `bottom` 9736px, `center` 9660px, `left` 9736px, `on-clippath` 52126px, `on-clippath-obb` **151110px**, … → all pass at default threshold after the fix. `_default_text` / `_max` / `_geode` suites green; layout unit tests (all variants) + `renderer_tests` green.

Un-skipped: bottom, center, keyword-length, left, length-percent, length-px, on-clippath, on-clippath-objectBoundingBox, on-group, on-shape, right, right-bottom, top.

## Geode
GeodeTinyParity passes clean (geode matches tiny-skia at the flat-100/0.02 gate). The rotated shapes are all-diagonal MSAA edges, so the **GeodeGolden** mode (vs the resvg reference) picks up the usual 4× MSAA edge drift (~140–280px) — widened via `widenThresholdForGeode`, identical to the filter categories; this does **not** touch the parity comparison (which hardcodes 0.02/100).

## Not this regression (7 kept skipped, re-tagged accurately)
`on-gradient` ×2, `on-pattern` ×2, `on-image`, `on-text`, `on-text-path` were **never green**: gradients/patterns route through `getRawEntityFromParentTransform` which intentionally drops the origin pivot, and image/text don't compose the pivot with content placement. These are a **separate pre-existing feature gap** (transform-origin not honored on paint servers / images / text), not the #514 regression — worth a new 0021 entry. The F2 entry can be deleted when #607 lands.