### PR TITLE
xml: make TreeMutationContext unconditional + drop nullptr/empty-function gates (#596 follow-up)

### DIFF
--- a/donner/base/xml/XMLDocument.cc
+++ b/donner/base/xml/XMLDocument.cc
@@ -8,6 +8,7 @@
 
 #include "donner/base/xml/XMLEscape.h"
 #include "donner/base/xml/XMLIncrementalParser.h"
+#include "donner/base/xml/components/TreeMutationContext.h"
 #include "donner/base/xml/components/XMLDocumentContext.h"
 #include "donner/base/xml/components/XMLNamespaceContext.h"
 #include "donner/base/xml/components/XMLValueComponent.h"
@@ -1201,13 +1202,25 @@ std::ostream& operator<<(std::ostream& os, ReparseScope scope) {
 }
 
 XMLDocument::XMLDocument() : registry_(std::make_shared<Registry>()) {
+  // Tree mutations always go through TreeMutationContext; install the basic XML defaults so
+  // higher-level models (SVGDocument) can just override individual callbacks. Done before
+  // XMLDocumentContext / XMLNamespaceContext so `XMLNode::CreateDocumentNode` below sees a
+  // fully-installed mutation context.
+  registry_->ctx().emplace<donner::components::TreeMutationContext>();
+
   auto& ctx = registry_->ctx().emplace<XMLDocumentContext>(XMLDocumentContext::InternalCtorTag{});
   ctx.rootEntity = XMLNode::CreateDocumentNode(*this).entityHandle().entity();
 
   registry_->ctx().emplace<XMLNamespaceContext>(*registry_);
 }
 
-XMLDocument::XMLDocument(std::shared_ptr<Registry> registry) : registry_(std::move(registry)) {}
+XMLDocument::XMLDocument(std::shared_ptr<Registry> registry) : registry_(std::move(registry)) {
+  // A shared registry may already have a TreeMutationContext installed (e.g. by a higher-level
+  // document model that owns the registry); install the basic XML defaults only if not.
+  if (!registry_->ctx().contains<donner::components::TreeMutationContext>()) {
+    registry_->ctx().emplace<donner::components::TreeMutationContext>();
+  }
+}
 
 XMLDocument XMLDocument::CreateFromRegistry(std::shared_ptr<Registry> registry) {
   UTILS_RELEASE_ASSERT_MSG(registry != nullptr, "Cannot create XMLDocument from null registry");

--- a/donner/base/xml/XMLNode.cc
+++ b/donner/base/xml/XMLNode.cc
@@ -543,58 +543,34 @@ std::optional<XMLNode> XMLNode::nextSibling() const {
              : std::nullopt;
 }
 
+// `TreeMutationContext` is an invariant of any registry created through the document facades
+// (XMLDocument's ctor installs the basic XML defaults; SVGDocument overrides them with the
+// SVG-specific callbacks). We can therefore call through the context unconditionally instead of
+// gating on `find<TreeMutationContext>()` + falling back to a direct TreeComponent path.
 void XMLNode::insertBefore(const XMLNode& newNode, std::optional<XMLNode> referenceNode) {
-  if (auto* mutations = handle_.registry()->ctx().find<donner::components::TreeMutationContext>();
-      mutations != nullptr && mutations->insertBefore) {
-    mutations->insertBefore(handle_, newNode.handle_,
-                            referenceNode ? referenceNode->handle_ : EntityHandle());
-    return;
-  }
-
-  handle_.get<TreeComponent>().insertBefore(
-      registry(), newNode.handle_.entity(),
-      referenceNode ? referenceNode->handle_.entity() : entt::null);
+  auto& mutations = handle_.registry()->ctx().get<donner::components::TreeMutationContext>();
+  mutations.insertBefore(handle_, newNode.handle_,
+                         referenceNode ? referenceNode->handle_ : EntityHandle());
 }
 
 void XMLNode::appendChild(const XMLNode& child) {
-  if (auto* mutations = handle_.registry()->ctx().find<donner::components::TreeMutationContext>();
-      mutations != nullptr && mutations->appendChild) {
-    mutations->appendChild(handle_, child.handle_);
-    return;
-  }
-
-  handle_.get<TreeComponent>().appendChild(registry(), child.handle_.entity());
+  auto& mutations = handle_.registry()->ctx().get<donner::components::TreeMutationContext>();
+  mutations.appendChild(handle_, child.handle_);
 }
 
 void XMLNode::replaceChild(const XMLNode& newChild, const XMLNode& oldChild) {
-  if (auto* mutations = handle_.registry()->ctx().find<donner::components::TreeMutationContext>();
-      mutations != nullptr && mutations->replaceChild) {
-    mutations->replaceChild(handle_, newChild.handle_, oldChild.handle_);
-    return;
-  }
-
-  handle_.get<TreeComponent>().replaceChild(registry(), newChild.handle_.entity(),
-                                            oldChild.handle_.entity());
+  auto& mutations = handle_.registry()->ctx().get<donner::components::TreeMutationContext>();
+  mutations.replaceChild(handle_, newChild.handle_, oldChild.handle_);
 }
 
 void XMLNode::removeChild(const XMLNode& child) {
-  if (auto* mutations = handle_.registry()->ctx().find<donner::components::TreeMutationContext>();
-      mutations != nullptr && mutations->removeChild) {
-    mutations->removeChild(handle_, child.handle_);
-    return;
-  }
-
-  handle_.get<TreeComponent>().removeChild(registry(), child.entityHandle().entity());
+  auto& mutations = handle_.registry()->ctx().get<donner::components::TreeMutationContext>();
+  mutations.removeChild(handle_, child.handle_);
 }
 
 void XMLNode::remove() {
-  if (auto* mutations = handle_.registry()->ctx().find<donner::components::TreeMutationContext>();
-      mutations != nullptr && mutations->remove) {
-    mutations->remove(handle_);
-    return;
-  }
-
-  handle_.get<TreeComponent>().remove(registry());
+  auto& mutations = handle_.registry()->ctx().get<donner::components::TreeMutationContext>();
+  mutations.remove(handle_);
 }
 
 std::optional<FileOffset> XMLNode::sourceStartOffset() const {

--- a/donner/base/xml/components/TreeMutationContext.h
+++ b/donner/base/xml/components/TreeMutationContext.h
@@ -4,18 +4,31 @@
 #include <functional>
 
 #include "donner/base/EcsRegistry.h"
+#include "donner/base/xml/components/TreeComponent.h"
 
 namespace donner::components {
 
 /**
- * Optional document-local hooks for tree mutations.
+ * Document-local hooks for tree mutations.
  *
- * \ref XMLNode uses these callbacks when a document installs them in `Registry::ctx()`. Plain XML
- * documents leave the hooks absent and mutate \ref TreeComponent directly. Higher-level document
- * models, such as SVG, use the hooks to layer invalidation and lifetime tracking over the shared
- * XML tree API without making the base XML library depend on SVG.
+ * Always installed in `Registry::ctx()` by the owning document model: \ref XMLDocument installs
+ * the `Default*` callbacks below (which operate on \ref TreeComponent directly), and higher-level
+ * models such as SVGDocument overwrite the individual callbacks after construction to layer
+ * invalidation and lifetime tracking on top. \ref XMLNode mutation methods always go through the
+ * context, so the lookup never needs to fall back to a direct \ref TreeComponent path —
+ * `Registry::ctx().contains<TreeMutationContext>()` is an invariant of any registry exposed
+ * through one of the document facades.
  */
 struct TreeMutationContext {
+  /// Default ctor installs the basic XML callbacks. Higher-level models (SVGDocument) overwrite
+  /// the individual function fields after construction.
+  TreeMutationContext()
+      : insertBefore(DefaultInsertBefore),
+        appendChild(DefaultAppendChild),
+        replaceChild(DefaultReplaceChild),
+        removeChild(DefaultRemoveChild),
+        remove(DefaultRemove) {}
+
   /// Callback for `insertBefore(parent, newNode, referenceNode)`.
   std::function<void(EntityHandle parent, EntityHandle newNode, EntityHandle referenceNode)>
       insertBefore;
@@ -32,6 +45,31 @@ struct TreeMutationContext {
 
   /// Callback for `remove(entity)`.
   std::function<void(EntityHandle entity)> remove;
+
+  /// Basic XML defaults — operate on \ref TreeComponent directly.
+  static void DefaultInsertBefore(EntityHandle parent, EntityHandle newNode,
+                                  EntityHandle referenceNode) {
+    parent.get<TreeComponent>().insertBefore(*parent.registry(), newNode.entity(),
+                                             referenceNode ? referenceNode.entity() : entt::null);
+  }
+
+  static void DefaultAppendChild(EntityHandle parent, EntityHandle child) {
+    parent.get<TreeComponent>().appendChild(*parent.registry(), child.entity());
+  }
+
+  static void DefaultReplaceChild(EntityHandle parent, EntityHandle newChild,
+                                  EntityHandle oldChild) {
+    parent.get<TreeComponent>().replaceChild(*parent.registry(), newChild.entity(),
+                                             oldChild.entity());
+  }
+
+  static void DefaultRemoveChild(EntityHandle parent, EntityHandle child) {
+    parent.get<TreeComponent>().removeChild(*parent.registry(), child.entity());
+  }
+
+  static void DefaultRemove(EntityHandle entity) {
+    entity.get<TreeComponent>().remove(*entity.registry());
+  }
 };
 
 }  // namespace donner::components

--- a/donner/svg/SVGDocument.cc
+++ b/donner/svg/SVGDocument.cc
@@ -439,7 +439,14 @@ SVGDocument::SVGDocument(SVGDocumentHandle documentState, Settings settings,
                          EntityHandle ontoEntityHandle)
     : documentState_(std::move(documentState)) {
   Registry& registry = documentState_->registry();
-  auto& treeMutations = registry.ctx().emplace<donner::components::TreeMutationContext>();
+  // TreeMutationContext is now always installed (XMLDocument's ctor installs the basic-XML
+  // defaults when the registry is created via the XML path); on a fresh SVG-only registry we
+  // install it here, then override the individual callbacks with the SVG-specific implementations
+  // that layer invalidation and lifetime tracking on top of the tree mutations.
+  if (!registry.ctx().contains<donner::components::TreeMutationContext>()) {
+    registry.ctx().emplace<donner::components::TreeMutationContext>();
+  }
+  auto& treeMutations = registry.ctx().get<donner::components::TreeMutationContext>();
   treeMutations.insertBefore = components::TreeMutation::InsertBefore;
   treeMutations.appendChild = components::TreeMutation::AppendChild;
   treeMutations.replaceChild = components::TreeMutation::ReplaceChild;


### PR DESCRIPTION
Follow-up to PR #596 — addresses comment 5 (mutation context unconditional) in full, and confirms the status of the other CR items.

## Status of each CR comment

| # | Comment | Status |
|---|---|---|
| 1 | `developer_docs.md:32` — Move to own file / rename / split | ✅ Already done by branch commit `6ca78e12` (the existing `docs/multithreading.md` + `docs/dom_element_lifetime.md`, plus the user-facing `docs/svg_dom_threading_and_lifetime.md` referenced from `introduction.md`/`api.md`/`getting_started.md`, are wired up via `\subpage Multithreading` / `\subpage DomElementLifetime`) |
| 6 | `0033-dom_lifetime_and_concurrency.md:3` — Convert to a developer doc | ✅ Already done by `6ca78e12` (design doc deleted, dev docs added) |
| 7 | `SVGElement.h:142` — Const-only read access; non-const requires DocumentWriteAccess | ✅ Already in place — `ElementAnchor` has `get<T>() const` / `get<T>(DocumentWriteAccess&) const` (same for `try_get`); `emplace`/`get_or_emplace`/`emplace_or_replace`/`remove` are write-access-only |
| **5** | `SVGDocument.cc:23` — Make mutation context unconditional, avoid nullptr + std::function checks | ✅ **Done in this PR** — `TreeMutationContext` now has a default ctor installing five static `Default*` callbacks (basic XML behavior); `XMLDocument` always emplaces; `SVGDocument` overrides the five callbacks; `XMLNode`'s five mutation methods drop both the nullptr gate and the per-callback emptiness gate and call through unconditionally |
| 2 | `AsyncRenderer.cc:83` — Drop `ScopedThreadingModeRestore`; use ConcurrentDom unconditionally | ⏸ **Deferred** — see below |
| 3 | `SVGCircleElement.cc:24` — Implicit invalidate on scope exit | ⏸ **Deferred** — see below |
| 4, 8 | `SVGCircleElement.cc:46` — What's read access for? / Only hot paths should pre-acquire | ⏸ **Deferred** — see below |

## What's in this PR

```
 donner/base/xml/XMLDocument.cc                   | 15 ++++++-
 donner/base/xml/XMLNode.cc                       | 54 +++++++-----------------
 donner/base/xml/components/TreeMutationContext.h | 48 ++++++++++++++++++---
 donner/svg/SVGDocument.cc                        |  9 +++-
 4 files changed, 80 insertions(+), 46 deletions(-)
```

- `TreeMutationContext` gains a default ctor that installs five static `Default*` callbacks (`DefaultInsertBefore`, `DefaultAppendChild`, `DefaultReplaceChild`, `DefaultRemoveChild`, `DefaultRemove`) operating on `TreeComponent` directly. The header is upgraded to include `TreeComponent.h` so the defaults can live inline.
- `XMLDocument::XMLDocument()` and `XMLDocument(std::shared_ptr<Registry>)` both install the context (the shared-registry ctor uses `contains` first so it does not clobber a context already installed by a higher-level model).
- `SVGDocument::SVGDocument` uses `contains` + `emplace` + `get` to override the five callbacks with the SVG-specific implementations that layer invalidation and lifetime tracking on top.
- `XMLNode`'s five mutation methods (`insertBefore`, `appendChild`, `replaceChild`, `removeChild`, `remove`) drop both the `mutations != nullptr` gate and the per-callback emptiness gate and call through the context unconditionally. The inline `TreeComponent` fallback path is removed — its semantics live on `TreeMutationContext::Default*` instead.

Plain-XML users get identical observable behavior (the basic XML defaults do exactly what the inline fallback did), but the call sites read as a single direct dispatch.

## Why 2 / 3 / 4 / 8 still need a deliberate session

I tried the AsyncRenderer simplification (comment 2) in isolation — drop `ScopedThreadingModeRestore`, keep the document in `ConcurrentDom` for the editor's lifetime. The build was clean but `async_renderer_tests` and `structured_editing_stress_tests` immediately Class-B-asserted on `SVGElement.cc:253` because tests' post-render DOM reads and assertions are not wrapped in `withReadAccess`. Reverted that change in this PR.

The full refactor requires:
- `EditorShell::runFrame` and the sandbox/replay/test harnesses to either (a) hold coarse-grained `DocumentReadAccess` over read-only sections, or (b) wrap each post-render DOM read in `withReadAccess`. Coarse-grained read across the whole frame doesn't work because the editor frame interleaves user-input *writes* with reads, and `DocumentWriteAccess` does not support read→write upgrade (write would deadlock on the calling thread's own held read — exactly the codex P1 from PR #596).
- Once unguarded reads are eliminated, the ~147 per-getter `DocumentReadAccess` lines (comments 4/8) can be reverted: the underlying `try_get` assertions stay correct because callers hold access.
- The implicit-invalidate hook (comment 3) is independent but needs a polymorphic invalidate or a per-class scoped-mutation wrapper, since each element class's `invalidate()` removes its own `Computed*` components.

This is a multi-session refactor with a non-trivial design surface, and ramming through it half-way leaves a broken intermediate state. Happy to take it as its own scoped PR.

## Validation

```
bazel test //donner/base/... //donner/svg/... //donner/editor/...
→ 595 pass, 7 fail (all environmental Geode #542), 11 skipped — zero non-Geode failures.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
