### PR TITLE
Dynamic rope reference connectors

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -3,6 +3,9 @@ When running Bazel in this repository, use `tools/llm-bazel-wrap.sh` instead of
 invoking `bazel` directly. The wrapper removes Codex-injected PATH entries that
 would otherwise perturb Bazel's effective client environment and action cache
 keys. When writing commands in docs and to the user, use `bazel` instead.
+
+When creating pull requests, do not prefix PR titles with `[codex]`, agent names,
+or other tool branding. Use plain project-style titles that describe the change.
 """
 
 [shell_environment_policy]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,9 +74,10 @@ When creating a pull request:
    - `python3 tools/cmake/gen_cmakelists.py --check` (CMake generator + output validator; runs outside bazel because it uses `bazel query`).
    - **`clang-format -i` on every modified C/C++ file** before committing — `git clang-format` covers staged changes. The project `.clang-format` is tuned so clang-format 18 and 19 produce identical output, so any locally-installed clang-format works.
 3. **For fuzzer-sensitive changes**, run `bazel test --config=asan-fuzzer <fuzzer target>`. macOS needs this config because Apple Clang lacks `libclang_rt.fuzzer_osx.a`; `--config=asan-fuzzer` activates the LLVM 21 toolchain which provides it.
-4. **Monitor CI and code review** — after opening, check CI status, merge conflicts, and review comments every ~7 minutes until the PR is green and reviewed. Use `gh pr checks <number>` and `gh api repos/jwmcglynn/donner/pulls/<number>/comments`.
-5. **Expect a Codex code review** within the first few minutes — address feedback promptly by pushing follow-up commits. If Codex finds no issues it will approve the PR (👍 / APPROVED state). A Codex approval alone is not sufficient to merge — a `jwmcglynn` review is always required.
-6. **Transient CI failures** (apt/bazel fetch/chromium rate-limits) are retried automatically. Test, compile, linker, and pixel-diff failures are never transient — investigate the root cause, don't re-run blindly.
+4. **Monitor CI and code review by default for every created PR** — whenever you create or open a PR, automatically keep monitoring CI status, merge conflicts, and review comments every ~7 minutes until the PR is green and reviewed; do not wait for a separate user prompt. Use `gh pr checks <number>` and `gh api repos/jwmcglynn/donner/pulls/<number>/comments` when `gh` is authenticated, or the GitHub connector equivalents when `gh` is unavailable.
+5. **No agent branding in PR titles** — do not prefix pull request titles with `[codex]`, agent names, or other tool branding. Use a plain project-style title that describes the change.
+6. **Expect a Codex code review** within the first few minutes — address feedback promptly by pushing follow-up commits. If Codex finds no issues it will approve the PR (👍 / APPROVED state). A Codex approval alone is not sufficient to merge — a `jwmcglynn` review is always required.
+7. **Transient CI failures** (apt/bazel fetch/chromium rate-limits) are retried automatically. Test, compile, linker, and pixel-diff failures are never transient — investigate the root cause, don't re-run blindly.
 
 See `docs/design_docs/0016-ci_escape_prevention.md` for the full rationale behind these checks and the taxonomy of CI escapes they prevent.
 

--- a/docs/design_docs/0041-2-path_authoring_and_boolean_operations.md
+++ b/docs/design_docs/0041-2-path_authoring_and_boolean_operations.md
@@ -1,0 +1,704 @@
+# Design: Path Authoring and Boolean Operations
+
+**Status:** Prototype
+**Author:** Codex GPT-5
+**Created:** 2026-05-25
+
+## Summary
+
+Donner's editor should support designer-grade path authoring: a centered top toolbar with Select,
+Pen, and Path Edit tools; an Illustrator-like Pen flow for drawing paths; and a Path Edit tool for
+editing anchors, handles, and open-path continuation. The same workstream should add unified
+multi-selection across the canvas and source pane, plus right-side pane controls for boolean shape
+operations such as Union, Intersect, Subtract Front, Subtract Back, and Exclude, and arrange controls
+such as Bring Forward and Send to Back.
+
+The editor UX should feel familiar to users of vector design tools without forcing Donner's core
+geometry model into editor-only code. Path editing lives in `//donner/editor`; path boolean math
+lives at the Donner geometry/SVG layer so rendering, scripting, tests, and future command surfaces
+can use the same operation engine.
+
+## Goals
+
+- Add a centered horizontal tool palette at the top of the render pane with three icon buttons:
+  Select, Pen, and Path Edit.
+- Let the Pen tool create new `<path>` elements with straight and cubic segments.
+- Let the Pen tool append to a selected pre-existing unclosed path.
+- Let users close a path by clicking near its start point.
+- Keep Pen tool interaction responsive and low latency. Drafting, handle drags, and pointer previews
+  must not require whole-document reparses on each frame; the UI should update immediately from local
+  editor state and commit through structured DOM/source deltas.
+- Let Path Edit mode select, move, delete, and modify anchors and cubic control handles on existing
+  paths.
+- Visualize anchors, control points, and handle lines while editing. In Path Edit mode, anchors are
+  small solid rectangles in document space.
+- Support three handle coupling modes: Symmetric, Aligned, and Independent.
+- Support key modifiers for standard path-tool behavior without creating a modal maze.
+- Add unified multi-select support for canvas and source-pane element selection.
+- Add a right-side pane Path Operations section over selected path-convertible SVG elements, rendered
+  as icon-only operation buttons with tooltips.
+- Add a right-side pane Arrange section for moving selected elements forward/backward in paint order,
+  also rendered as icon-only operation buttons with tooltips.
+- Add keyboard shortcuts for tool switching, path operations, and arrange operations.
+- Introduce a Donner-level boolean path operation API with deterministic results and editor-facing
+  source writeback.
+- Pin interaction guarantees in editor tests and geometry guarantees in base/SVG tests.
+
+## Non-Goals
+
+- This does not replace the existing Select tool's drag/resize/rotate behavior.
+- This does not implement freehand pencil drawing, brush strokes, calligraphy, or pressure input.
+- This does not implement smart snapping, grids, guides, or magnetic alignment.
+- This does not add text-to-path, image tracing, or outline-font conversion.
+- This does not initially preserve editable cubic curves through boolean operations. The boolean MVP
+  may output flattened line segments; curve reconstruction is future work.
+- This does not implement non-destructive live Pathfinder stacks. Boolean operations are destructive
+  document edits with undo support in the first version.
+- This does not make boolean operations available for arbitrary SVG nodes such as `<text>`,
+  `<image>`, or unresolved `<use>` references in the first version.
+- This does not add a top-level Path menu in the first version; path operations live in the
+  right-side pane with keyboard shortcuts.
+
+## Next Steps
+
+- Replace the prototype bounds-based Union / Intersect path operations with a Donner-level boolean
+  path backend.
+- Design and test the editable path model that maps SVG `d` commands to anchors and handles.
+- Add arrange controls next to the Path Operations panel.
+
+## Implementation Plan
+
+- [ ] Milestone 1: Tool palette and tool dispatch.
+  - [ ] Add `EditorToolId` with `Select`, `Pen`, and `PathEdit`.
+  - [ ] Add a centered render-pane toolbar presenter with icon buttons and selected/hover states.
+  - [ ] Route render-pane pointer events through the active tool while preserving `SelectTool`.
+  - [ ] Define unified multi-selection semantics for canvas clicks, marquee selection, and source
+        pane element clicks.
+  - [ ] Draw source-pane multi-selection as semantic element decorations instead of native text
+        selection ranges.
+  - [ ] Add tests for tool switching, keyboard shortcuts, and source-pane focus interactions.
+- [ ] Milestone 2: Editable path model.
+  - [ ] Add `EditablePath`/`EditableAnchor` types that round-trip SVG path data.
+  - [ ] Convert `M/L/C/Q/Z` commands into anchors, incoming handles, outgoing handles, and close
+        state.
+  - [ ] Preserve unsupported commands by normalizing them through existing path parsing and
+        serialization rules.
+  - [ ] Add unit tests for parse, edit, serialize, and undo snapshots.
+- [ ] Milestone 3: Pen tool.
+  - [ ] Create a new `<path>` on first click using the active style defaults.
+  - [ ] Append line anchors on click and cubic anchors on click-drag.
+  - [ ] Close the active path when clicking within a screen-stable tolerance of the start anchor.
+  - [ ] Append to a selected open path by clicking either endpoint.
+  - [ ] Add modifier behavior for constrained angles, handle breaking, and temporary Path Edit.
+- [ ] Milestone 4: Path Edit tool.
+  - [ ] Hit-test anchors, control handles, handle lines, and segments in screen-pixel-stable
+        tolerances.
+  - [ ] Draw solid rectangle anchors, circular control handles, and thin handle lines in overlay
+        chrome.
+  - [ ] Support moving anchors, moving handles, deleting anchors, and clearing handles by clicking
+        the active last point.
+  - [ ] Add contextual handle mode controls for Symmetric, Aligned, and Independent.
+- [ ] Milestone 5: Right-side path operations, arrange controls, and command plumbing.
+  - [x] Add right-side pane Path Operations actions and enabled-state checks for selected
+        path-convertible elements.
+  - [ ] Add right-side pane Arrange actions for Bring Forward, Send Backward, Bring to Front, and
+        Send to Back.
+  - [ ] Add keyboard shortcuts for tool selection, path operations, and arrange commands.
+  - [x] Add initial editor command plumbing for destructive path operations with source writeback.
+  - [ ] Add undo snapshots for destructive path operations.
+  - [ ] Add editor commands for paint-order moves with undo and source writeback.
+  - [ ] Preserve selection on the result path and scroll its source range into view.
+- [ ] Milestone 6: Donner-level boolean path operations.
+  - [ ] Add a path boolean API over `donner::Path`, transforms, fill rules, and tolerance options.
+  - [ ] Implement or wrap a robust polygon clipping backend behind the API.
+  - [ ] Add SVG conversion helpers that turn selected geometry elements into document-space paths.
+  - [ ] Add base/SVG/editor tests and visual regressions for each operation.
+
+## User Stories
+
+- As a designer, I can select the Pen tool, click to place points, drag to create smooth curves, and
+  close a shape by clicking back on the start point.
+- As a designer, I can select an open path, choose Pen, click one endpoint, and continue drawing from
+  that path instead of creating a new one.
+- As a designer, I can choose Path Edit, see the anchors as solid rectangles, drag handles to refine
+  curves, and change a selected point from symmetric handles to aligned or independent handles.
+- As a designer, I can Shift-click shapes on canvas or source ranges in the text view to build the
+  multi-selection needed for path operations.
+- As a designer, I can select overlapping shapes and click Union, Intersect, Subtract Front, or
+  Exclude in the right pane to create a new editable SVG path.
+- As a designer, I can select one or more elements and bring them forward, send them backward, or
+  move them to the front/back of their local paint-order scope.
+
+## Requirements and Constraints
+
+- Tool hit-testing is screen-pixel-stable. Anchor and handle hit boxes stay usable at every zoom and
+  device pixel ratio by using `MouseModifiers::pixelsPerDocUnit` / `ViewportState`.
+- Path edits are document mutations. They must flow through `EditorApp::applyMutation()` and
+  `UndoTimeline`, not direct DOM writes from a tool.
+- Pen drafting is latency-sensitive. Pointer-move feedback should render from an editor-owned
+  preview/elevated path model; the live DOM and source pane are updated at semantic commit points
+  using `InsertElementCommand` / `SetAttributeCommand` source deltas, not by `ReplaceDocument` or
+  repeated full-document reparses.
+- Canvas edits update the source pane through the existing source writeback path where a source range
+  exists. If a path cannot be patched locally, the document sync layer may replace the whole element
+  source range.
+- Canvas and source-pane element selection share one ordered selection model. There must not be
+  separate canvas-only and source-only selection sets.
+- Path authoring should not require a full async raster before chrome updates. Overlay chrome uses
+  the same snapshot/chrome priority lane described in `0033-editor_design_tool_responsiveness.md`.
+- Boolean operations must be deterministic for the same input paths, transforms, fill rules, and
+  tolerance options. `//donner/base:path_boolean_tests` should fail if operation output changes
+  unexpectedly.
+- Boolean operations must be bounded. Segment counts, recursion depth, and result complexity must
+  have explicit caps tested by `//donner/base:path_boolean_tests` and negative editor tests.
+
+## Proposed Architecture
+
+```mermaid
+flowchart LR
+  Toolbar["ToolPalettePresenter"] --> ActiveTool["EditorToolController"]
+  Select["SelectTool"] --> ActiveTool
+  Pen["PenTool"] --> ActiveTool
+  PathEdit["PathEditTool"] --> ActiveTool
+  ActiveTool --> Commands["EditorCommand"]
+  Commands --> App["EditorApp::applyMutation"]
+  App --> SourceSync["DocumentSyncController"]
+  Pen --> Editable["EditablePath"]
+  PathEdit --> Editable
+  CanvasHit["Canvas hit-test"] --> Selection["EditorSelectionModel"]
+  SourceHit["Source element hit-test"] --> Selection
+  Selection --> ActiveTool
+  Selection --> RightPane
+  Selection --> SourceSync
+  RightPane["RightPanePresenter"] --> PathPanel["PathOperationsPanel"]
+  RightPane --> ArrangePanel["ArrangePanel"]
+  PathPanel --> BoolCmd["PathOperationCommand"]
+  ArrangePanel --> ArrangeCmd["ArrangeOrderCommand"]
+  ArrangeCmd --> App
+  BoolCmd --> SvgOps["SVGPathOperationSystem"]
+  SvgOps --> BaseBool["donner::PathBoolean"]
+  BaseBool --> Result["Result <path>"]
+```
+
+## Prototype Status
+
+The first in-editor path operation slice is intentionally conservative:
+
+- The right-side Inspector pane now renders an icon-only Path Operations row for Union, Intersect,
+  Subtract Front, Subtract Back, and Exclude.
+- Union and Intersect are enabled for multi-selections made entirely of bounded SVG geometry.
+- The initial operation result is a replacement `<path>` generated from document-space AABBs:
+  Union emits the selected bounds' enclosing rectangle; Intersect emits the overlapping rectangle.
+- Subtract Front, Subtract Back, and Exclude are present but disabled until the Donner-level boolean
+  path backend exists.
+- The operation queues `InsertElementCommand` for the result path followed by `DeleteElementCommand`
+  for the original selection, so DOM mutation and source mirroring stay on the existing editor
+  command path.
+
+This deliberately trades geometric completeness for a working UI and source-sync path. The
+production boolean backend should replace only the result-geometry computation, not the editor
+selection, command, or panel plumbing.
+
+### Multi-Selection Model
+
+Path operations need a first-class selection set, not a single active element with ad hoc extras.
+`EditorApp` should remain the owner of selection state, but the contract should be explicit:
+
+- The selection is an ordered list of SVG elements with no duplicates.
+- The first selected element remains the primary element for existing single-selection callers and
+  style-source fallback.
+- Plain canvas click replaces the selection with the hit element.
+- Shift-click on an unselected canvas element adds it to the current selection.
+- Shift-click on an already selected canvas element removes it, unless it is the only selected
+  element; the last element stays selected to avoid accidental empty selections.
+- Plain click on empty canvas clears the selection.
+- Shift-click on empty canvas keeps the existing selection unchanged.
+- Plain marquee replaces the selection with the marquee hits.
+- Shift-marquee adds marquee hits to the existing selection, preserving existing order and appending
+  new elements in document order.
+
+Dragging a selected element moves the whole selection. Transform handles operate on the combined
+selection bounds when multiple selected elements are transformable. Operations that require a single
+element, such as direct XML attribute inspection, should disable themselves or show a compact
+multi-selection summary rather than guessing.
+
+Source-pane selection uses the same selection model. This should be semantic element selection, not
+multiple native text selections:
+
+- Plain click on an element source range selects that element and leaves the caret at the clicked
+  text position.
+- Shift-click on an element source range adds/removes that element using the same toggle rules as
+  canvas Shift-click.
+- Shift-drag still performs normal text range selection; the semantic toggle happens only for
+  click-like source gestures.
+- Selected source ranges render as decorations behind the text. The primary selected element uses
+  the brightest selected style, and additional selected elements use the same selected style with a
+  less prominent primary marker.
+- Source focus mode treats all selected elements as brightest, referenced elements as medium
+  brightness, and unrelated source as the existing gray out-of-focus text.
+- Typing inside any selected element's source range should preserve the current selection unless the
+  edit deletes that element or moves the caret outside all selected/focused ranges.
+
+This keeps text editing fluid: users can build a geometry selection from source without turning the
+text editor into a discontiguous text-selection widget.
+
+### Tool Palette
+
+The toolbar is a small horizontal button bar centered at the top of the render pane, slightly below
+the main menu bar and above document content. It is part of the editor chrome, not document content.
+It should use the same UI font and icon scale as the rest of the editor.
+
+The initial buttons are:
+
+| Tool      | Icon intent                         | Behavior                                    |
+| --------- | ----------------------------------- | ------------------------------------------- |
+| Select    | Current arrow/select icon           | Existing select, drag, resize, rotate tool  |
+| Pen       | Pen nib                             | Create new paths and append to open paths   |
+| Path Edit | Open triangle/direct-selection icon | Edit anchors, handles, segments, open paths |
+
+The toolbar owns only active-tool state and presentation. Pointer behavior stays in tool classes.
+This keeps `EditorShell` from becoming a large gesture switch statement.
+
+### Editable Path Model
+
+`EditablePath` is the editor's manipulation model for one SVG path. It is not a replacement for
+`donner::Path`; it is a source-preserving editing view that can serialize back to `d`.
+
+```cpp
+enum class HandleMode {
+  Symmetric,
+  Aligned,
+  Independent,
+};
+
+struct EditableAnchor {
+  Vector2d point;
+  std::optional<Vector2d> inHandle;
+  std::optional<Vector2d> outHandle;
+  HandleMode handleMode = HandleMode::Independent;
+};
+
+struct EditablePath {
+  std::vector<EditableAnchor> anchors;
+  bool closed = false;
+};
+```
+
+The model should treat a cubic segment as:
+
+- previous anchor `outHandle`
+- current anchor `inHandle`
+- current anchor `point`
+
+Straight segments have no handles on the endpoint pair. Quadratic segments can be represented as
+derived cubic handles when first edited; serialization may normalize edited quadratic segments to
+cubic commands. The editor should preserve unedited path data where possible, but editing a segment
+is allowed to normalize that local segment.
+
+### Pen Tool Behavior
+
+The Pen tool has one active drafting path. A click without drag adds a corner anchor. A click-drag
+adds a smooth anchor with a visible outgoing handle; the incoming handle for the next segment is
+determined by the selected handle mode.
+
+Core behaviors:
+
+- Click empty document: create a new `<path>` and place the first anchor.
+- Click while drafting: add the next anchor and segment.
+- Click-drag while drafting: add a cubic anchor and set its outgoing control handle.
+- Click near the first anchor: close the path by adding `Z`.
+- Press Escape/Enter: finish the active path without closing it.
+- Press Backspace/Delete while drafting: remove the last anchor.
+- Click an endpoint of a selected unclosed path: enter append mode from that endpoint.
+- Click the last anchor of the active path: clear that anchor's control handles and convert it to a
+  corner point.
+
+Append mode should support both open endpoints. If the user starts from the first point, the editor
+prepends anchors and reverses segment orientation only as needed to keep serialization simple. The
+selected path remains selected during append mode, and the active endpoint is highlighted.
+
+### Path Edit Behavior
+
+Path Edit mode exposes the editable skeleton for selected paths:
+
+- Anchors render as small solid rectangles.
+- Control points render as small circles or diamonds.
+- Handle lines render as thin lines from anchor to control point.
+- Selected anchors/handles use the active selection color; unselected editable points use the
+  secondary chrome color.
+- Hovered points expand hit tolerance but do not resize the visual rect.
+
+Actions:
+
+- Click anchor: select that anchor.
+- Shift-click anchor: add/remove anchor from the anchor selection.
+- Drag anchor: move selected anchors.
+- Drag control point: update that handle according to the anchor's handle mode.
+- Click segment: insert a new anchor at the nearest curve parameter.
+- Delete: delete selected anchors and reconnect adjacent segments when possible.
+- Click the last anchor of an open path: clear both handles on that anchor.
+
+Handle modes:
+
+- **Symmetric:** opposite handles stay collinear and equal length.
+- **Aligned:** opposite handles stay collinear but can have different lengths.
+- **Independent:** handles move independently.
+
+The UI exposes these modes through a compact contextual segmented control near the selected anchor
+or in the toolbar when one or more anchors are selected. Modifier keys can temporarily override the
+mode during a drag, but the persistent mode is explicit and visible.
+
+### Modifier Keys
+
+Modifier behavior should match common vector design tools while staying learnable:
+
+| Input            | Pen tool behavior                                      | Path Edit behavior                                     |
+| ---------------- | ------------------------------------------------------ | ------------------------------------------------------ |
+| Shift            | Constrain segment/handle angle to 45-degree increments | Constrain anchor/handle drag angle                     |
+| Option/Alt       | Temporarily break handle coupling                      | Temporarily use Independent handles                    |
+| Cmd/Ctrl         | Temporarily switch to Path Edit                        | Temporarily switch to Select for whole-object movement |
+| Space            | Temporarily pan using the existing hand cursor mode    | Temporarily pan                                        |
+| Escape           | Finish current path without closing                    | Clear anchor/handle selection                          |
+| Backspace/Delete | Remove last drafted point                              | Delete selected anchors                                |
+| Enter/Return     | Finish current path                                    | Commit current edit and keep path selected             |
+
+The exact Cmd/Ctrl mapping can be platform-adjusted, but the behavior should be expressed in tests
+as semantic modifiers rather than raw key codes.
+
+### Keyboard Shortcuts
+
+Tool shortcuts should be active when the render pane or right-side pane has focus. Source-pane text
+editing wins while the source pane has keyboard focus, so typing `p` in source never switches tools.
+
+| Shortcut | Command   |
+| -------- | --------- |
+| `V`      | Select    |
+| `P`      | Pen       |
+| `A`      | Path Edit |
+
+Path operation shortcuts use `Cmd+Option` on macOS and `Ctrl+Alt` on Windows/Linux:
+
+| Shortcut             | Command         |
+| -------------------- | --------------- |
+| `Cmd+Option+U`       | Union           |
+| `Cmd+Option+I`       | Intersect       |
+| `Cmd+Option+-`       | Subtract Front  |
+| `Cmd+Option+Shift+-` | Subtract Back   |
+| `Cmd+Option+X`       | Exclude Overlap |
+| `Cmd+Option+D`       | Divide          |
+| `Cmd+Option+O`       | Outline Stroke  |
+
+Arrange shortcuts should match common vector/design tools:
+
+| Shortcut      | Command        |
+| ------------- | -------------- |
+| `Cmd+]`       | Bring Forward  |
+| `Cmd+[`       | Send Backward  |
+| `Cmd+Shift+]` | Bring to Front |
+| `Cmd+Shift+[` | Send to Back   |
+
+## Right-Side Path Operations and Arrange Pane
+
+Path and arrange commands live in the right-hand inspector pane. The pane may use text section
+headings, but each command control is an icon-only button: no visible text inside the button. Buttons
+should be square, visually align with other inspector controls, expose accessible names, and show
+tooltips with the command name, keyboard shortcut, and disabled reason when unavailable.
+
+The initial Path Operations section is a compact icon-button list:
+
+| Operation      | Icon intent                    | Operation enum  | Selection requirement                         |
+| -------------- | ------------------------------ | --------------- | --------------------------------------------- |
+| Union          | Merged overlapping shapes      | `Union`         | Two or more closed path-convertible elements  |
+| Intersect      | Overlap lens                   | `Intersect`     | Two or more closed path-convertible elements  |
+| Subtract Front | Back shape with front cut away | `SubtractFront` | Two or more closed path-convertible elements  |
+| Subtract Back  | Front shape with back cut away | `SubtractBack`  | Two or more closed path-convertible elements  |
+| Exclude        | Alternating overlap            | `Xor`           | Two or more closed path-convertible elements  |
+| Divide         | Split regions                  | `Divide`        | Two or more closed path-convertible elements  |
+| Outline Stroke | Stroke converted to fill       | `OutlineStroke` | One or more stroked path-convertible elements |
+
+`Outline Stroke` can land after the main boolean set because `Path::strokeToFill` already exists
+but style/writeback semantics need care. `Divide` can also be delayed if the boolean backend returns
+multiple output contours later than single-path operations.
+
+Operation semantics:
+
+- **Union:** result fill is the union of all selected fill regions.
+- **Intersect:** result fill is the area common to every selected fill region.
+- **Subtract Front:** base is the backmost selected element in SVG paint order; subtract the union of
+  every selected element painted above it.
+- **Subtract Back:** base is the frontmost selected element; subtract the union of every selected
+  element painted below it.
+- **Exclude Overlap:** result fill toggles each selected fill region; areas covered by an odd number
+  of inputs remain.
+- **Divide:** split the selected shapes at all intersections and emit separate path pieces.
+
+The result element should be inserted at the paint-order position of the operation's base element.
+For Union, Intersect, and Exclude, the active selection's primary element is the style source; if the
+selection has no primary, use the frontmost selected element. For Subtract Front/Back, the base
+element provides paint style and insertion position. The original selected elements are removed by
+the command, not hidden.
+
+The Arrange section sits near Path Operations because both affect selected geometry. It is also a
+compact icon-button list with tooltips, not text buttons:
+
+| Operation      | Icon intent                | Command enum   | Behavior                           |
+| -------------- | -------------------------- | -------------- | ---------------------------------- |
+| Bring Forward  | Layer moving up one slot   | `BringForward` | Move selection one paint step up   |
+| Send Backward  | Layer moving down one slot | `SendBackward` | Move selection one paint step down |
+| Bring to Front | Layer at top               | `BringToFront` | Move selection to front            |
+| Send to Back   | Layer at bottom            | `SendToBack`   | Move selection to back             |
+
+SVG paint order is document order within the same parent: later siblings paint above earlier
+siblings. The MVP should enable arrange commands only when every selected movable element shares the
+same parent and is not inside a resource-only container such as `<defs>`, `<clipPath>`, `<mask>`,
+`<marker>`, or gradient content. Multi-selection moves as one stable block and preserves relative
+order. Bring Forward/Send Backward skip selected neighbors, so repeated shortcut presses move the
+selected block one unselected sibling at a time.
+
+Proposed arrange command surface:
+
+```cpp
+enum class ArrangeOrderOp {
+  BringForward,
+  SendBackward,
+  BringToFront,
+  SendToBack,
+};
+```
+
+`ArrangeOrderCommand` stores stable DOM/source locators, the original sibling order, and the target
+sibling order. Undo restores the original order. Source writeback should move whole XML node ranges
+when source locations are available; if the document sync layer cannot patch the affected ranges, the
+command should either fall back to whole-document serialization or refuse with a status message. It
+must not silently desynchronize canvas order from source order.
+
+## Donner-Level Boolean Path Operations
+
+Boolean operations should be available below the editor so they can be tested independently and used
+later by scripting or command-line tools.
+
+Proposed base API:
+
+```cpp
+namespace donner {
+
+enum class PathBooleanOp {
+  Union,
+  Intersect,
+  Difference,
+  Xor,
+  Divide,
+};
+
+struct PathBooleanInput {
+  Path path;
+  FillRule fillRule = FillRule::NonZero;
+  Transform2d outputFromPath = Transform2d();
+};
+
+struct PathBooleanOptions {
+  double flattenTolerance = 0.01;
+  std::size_t maxInputSegments = 100000;
+  std::size_t maxOutputSegments = 200000;
+};
+
+struct PathBooleanResult {
+  std::vector<Path> paths;
+  std::vector<ParseDiagnostic> warnings;
+};
+
+PathBooleanResult ApplyPathBoolean(PathBooleanOp op, std::span<const PathBooleanInput> inputs,
+                                   const PathBooleanOptions& options);
+
+}  // namespace donner
+```
+
+The editor-facing SVG layer then provides:
+
+```cpp
+namespace donner::svg {
+
+struct SVGPathOperationOptions {
+  PathBooleanOptions booleanOptions;
+  bool removeOriginals = true;
+};
+
+std::optional<SVGElement> ApplySVGPathOperation(SVGDocument& document,
+                                                std::span<const SVGElement> elements,
+                                                PathBooleanOp op,
+                                                const SVGPathOperationOptions& options);
+
+}  // namespace donner::svg
+```
+
+### Geometry Backend Strategy
+
+The first implementation should not hand-roll a full Bezier arrangement algorithm. The pragmatic
+MVP is:
+
+1. Convert every input shape to a document-space `Path`.
+2. Flatten curves to polylines using `PathBooleanOptions::flattenTolerance`.
+3. Run polygon clipping through a robust backend hidden behind `ApplyPathBoolean`.
+4. Convert output contours back to `Path` using `MoveTo`, `LineTo`, and `ClosePath`.
+
+This produces deterministic SVG paths and gets the editor workflow online. It does not preserve
+original cubic handles through boolean results; that is explicitly future work. A later backend can
+replace the polygon clipping layer with exact Bezier intersections or curve fitting without
+changing editor command semantics or right-pane UI.
+
+The backend should be selected behind a small adapter. Candidate dependencies can be evaluated for
+license, determinism, integer scaling behavior, and robustness on self-intersections. If no
+dependency fits, implement a limited in-tree polygon clipping engine only after base tests cover
+degenerate intersections, coincident edges, holes, winding, and near-zero areas.
+
+### SVG Conversion Rules
+
+Supported in the first version:
+
+- `<path>` with closed subpaths.
+- `<rect>`, `<circle>`, `<ellipse>`, `<line>`, `<polyline>`, and `<polygon>` after conversion through
+  `ShapeSystem` computed paths, when the fill region is well-defined.
+- Groups whose descendants are all supported path-convertible shapes.
+- Per-element transforms, including ancestor transforms, baked into document-space input paths.
+
+Deferred:
+
+- Text, images, unresolved `<use>`, filters, masks, and clip paths.
+- Boolean operations over live strokes unless the user first chooses Outline Stroke.
+- Non-destructive compound path objects.
+
+Fill rules must be respected per input. The result should serialize with an explicit `fill-rule`
+when the operation requires `evenodd` semantics or when preserving `nonzero` would change the
+rendered region.
+
+## Data and State
+
+`PenTool` and `PathEditTool` keep only gesture-local state: active path entity, selected anchors,
+active handle, and draft preview. Durable document state remains SVG source/DOM.
+
+Multi-selection state remains in `EditorApp` as SVG elements, with source and canvas views acting as
+different input surfaces for the same state. Source decorations should store byte ranges derived
+from the current source map and be recomputed after document remaps; they should not become durable
+selection identifiers.
+
+Path edit previews should be value snapshots:
+
+```cpp
+struct PathEditChromeSnapshot {
+  std::vector<Vector2d> anchorsDoc;
+  std::vector<Vector2d> handlesDoc;
+  std::vector<std::pair<Vector2d, Vector2d>> handleLinesDoc;
+  std::optional<std::size_t> hoveredAnchor;
+  std::vector<std::size_t> selectedAnchors;
+};
+```
+
+The overlay renderer can draw this snapshot without reading the registry, matching the race-free
+selection chrome model from design doc 0033.
+
+## Error Handling
+
+Path tool edits should fail closed: if a selected element cannot be represented as `EditablePath`,
+Path Edit mode shows no anchors for that element and logs a compact diagnostic in the editor status
+surface. Path operation buttons should be disabled unless the current selection is path-convertible.
+Arrange buttons should be disabled unless the selected elements share a supported paint-order scope.
+
+If a boolean operation exceeds segment caps or produces an empty result, the command should leave
+the document unchanged and surface a user-visible status message. It should not partially remove
+input elements before the result is ready.
+
+## Performance
+
+Path editing is interactive and must not wait on full document rasterization. Anchor/handle chrome
+updates should be cheap value snapshots. The path's `d` update can be applied on mouse-up for large
+paths, with a live overlay preview during drag; small paths may update live if tests show no stutter.
+
+Boolean operations are command-style, not per-frame. They may take longer than a pointer move, but
+they should still be cancellable or bounded. The MVP target is sub-100 ms for typical icon/logo
+operations under 2,000 flattened segments and graceful refusal for pathological inputs.
+
+## Security / Privacy
+
+Inputs are local SVG documents and local pointer/key events. No network access or external file
+access is introduced.
+
+The risk is denial-of-service from adversarial path data: huge coordinate values, dense curves,
+self-intersections, coincident edges, or flattening that explodes segment count. The boolean layer
+must validate finite coordinates, enforce input/output segment caps, clamp recursion depth, and
+return diagnostics rather than hanging. These limits are enforced by `//donner/base:path_boolean_tests`
+and malformed SVG integration tests in `//donner/svg/tests:svg_tests`.
+
+## Testing and Validation
+
+- `//donner/editor/tests:path_tool_tests`: Pen create/append/close behavior, modifier semantics,
+  handle mode transitions, clearing handles by clicking the active last point, and path edit anchor
+  movement.
+- `//donner/editor/tests:select_tool_tests`: canvas Shift-click add/remove behavior, Shift-marquee
+  additive behavior, empty-canvas behavior, group drag, and combined transform handles.
+- `//donner/editor/tests:source_selection_tests`: source plain click replacement, source Shift-click
+  add/remove behavior, selected source range decoration generation, and remapping after source edits.
+- `//donner/editor/tests:render_pane_presenter_tests`: toolbar layout, centered placement, icon
+  hit-testing, hover/active states, and no overlap with render content at small pane sizes.
+- `//donner/editor/tests:sidebar_presenter_tests`: Path Operations and Arrange section visibility,
+  icon-only buttons, tooltip labels, disabled reasons, and shortcut hints.
+- `//donner/editor/tests:editor_app_tests`: path operation command routing, arrange command routing,
+  multi-selection order preservation, primary-element preservation, unsupported arrange scopes, undo,
+  and source writeback.
+- `//donner/editor/tests:overlay_renderer_tests`: anchor rectangles, control handles, handle lines,
+  close-point hover state, and stable screen-pixel sizes across zoom.
+- `//donner/editor/tests:document_sync_controller_tests`: canvas path edits update source without
+  losing selection, undo history, or source scroll.
+- `//donner/base:path_boolean_tests`: union/intersect/difference/xor/divide on rectangles, curves
+  after flattening, holes, coincident edges, self-intersections, empty results, and segment caps.
+- `//donner/svg/tests:svg_tests`: SVG element conversion to boolean inputs and result serialization.
+- `.rnr` replay coverage: draw a path, close it, reopen Path Edit mode, move anchors, append to an
+  open path, Shift-click two shapes from canvas and source, run a right-pane boolean command, and
+  move the result backward/forward in paint order.
+
+## Dependencies
+
+No dependency should be added for the editor UI itself. Boolean operations may justify a small,
+well-tested geometry backend, but it must be hidden behind `ApplyPathBoolean` and evaluated for
+license compatibility, deterministic output, integer scaling behavior, and maintenance cost.
+
+## Alternatives Considered
+
+- **Editor-only boolean operations.** Rejected because scripting, tests, and future CLI tooling
+  would need the same math, and editor-only geometry would be harder to validate.
+- **Exact Bezier boolean operations first.** Attractive long term, but too much algorithmic risk for
+  the first UI milestone. Flattened polygon clipping gives predictable behavior and isolates the
+  backend behind an API that can improve later.
+- **Use SVG `<clipPath>`/`mask>` instead of destructive path results.** This is non-destructive but
+  does not produce the editable geometry users expect from a path operation.
+- **Top-level Path menu for operations.** Deferred because the current editor puts object-specific
+  actions in the right-hand pane, and icon-only operation buttons make the available operations more
+  discoverable while still allowing shortcuts.
+- **Use native multi-range text selection for source multi-select.** Rejected because it conflicts
+  with normal caret editing, Shift-drag text selection, clipboard behavior, and IME expectations.
+  Semantic element decorations give the source pane structural multi-select without compromising
+  text editing.
+- **Path Edit as part of Select.** Rejected because selection and direct anchor editing have
+  different hit targets, modifier behavior, and chrome density.
+
+## Open Questions
+
+- Should the default new-path style inherit from the current selection, use a global active style,
+  or use fixed editor defaults?
+- Should Path Edit mode support editing multiple selected paths at once in the first milestone, or
+  start with one path plus multi-path visualization?
+- Should source multi-select also support Cmd/Ctrl-click as a platform-native toggle alias, or keep
+  Shift-click as the only additive selection gesture?
+- What exact tolerance should close-point hit-testing use: fixed screen pixels only, or fixed screen
+  pixels with a document-space maximum?
+- Should boolean results use the active selection order or pure SVG paint order when those differ?
+- Which polygon clipping backend, if any, is acceptable for Donner's dependency policy?
+- Should the Pen tool live-update `d` during drag for small paths, or always preview until mouse-up?
+
+## Future Work
+
+- [ ] Curve reconstruction after boolean operations.
+- [ ] Compound paths and non-destructive Pathfinder stacks.
+- [ ] Smart snapping to anchors, tangents, grid, and nearby geometry.
+- [ ] Shape Builder tool for painting union/subtract regions directly.
+- [ ] Convert text and strokes to editable paths.
+- [ ] Keyboard-accessible anchor navigation and editing.

--- a/docs/design_docs/README.md
+++ b/docs/design_docs/README.md
@@ -90,6 +90,7 @@ conventions automated agents should follow when editing design docs.
 | 0039 | [text_editor_focus_and_flash](0039-text_editor_focus_and_flash.md)                         | Implemented; see [Editor Source Focus](../editor_source_focus.md) | Source-pane focus view, changed-character flash highlight, and context-aware soft wrap without horizontal scrolling.         |
 | 0040 | [semantic_text_completion](0040-semantic_text_completion.md)                               | Design                                                            | Parser-backed text completion and source block movement that preserve cursor flow and document structure.                    |
 | 0041 | [geode_analytical_aa](0041-geode_analytical_aa.md) | Developer reference | Geode anti-aliasing & coverage: 4× MSAA `sample_mask`; the accepted sub-pixel floor vs tiny's Skia-AAA; appendix of rejected AA approaches. |
+| 0041-2 | [path_authoring_and_boolean_operations](0041-2-path_authoring_and_boolean_operations.md) | Prototype | Illustrator-like path authoring, direct path editing, and Donner-level boolean path operations for the editor. |
 | 0042 | [geode_slug_conformance](0042-geode_slug_conformance.md) | Developer reference | Geode Slug implementation reference: encoder + shader pipeline, invariants, and known limitations. |
 
 ## Cross-reference: developer docs

--- a/donner/base/xml/XMLDocument.cc
+++ b/donner/base/xml/XMLDocument.cc
@@ -741,6 +741,57 @@ bool IsXmlSpace(char ch) {
   return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r';
 }
 
+std::string ClosingTagFor(const XMLNode& node) {
+  std::string closingTag;
+  closingTag.append("</");
+  AppendQualifiedName(closingTag, node.tagName());
+  closingTag.push_back('>');
+  return closingTag;
+}
+
+bool SourceHasClosingTagAt(std::string_view source, std::size_t offset,
+                           std::string_view closingTag) {
+  return offset <= source.size() && closingTag.size() <= source.size() - offset &&
+         source.substr(offset, closingTag.size()) == closingTag;
+}
+
+std::optional<std::size_t> FindParentClosingTagInsertionOffset(const XMLDocument& document,
+                                                               const XMLNode& parent) {
+  const std::string closingTag = ClosingTagFor(parent);
+  if (std::optional<SourceRange> closingTagLocation = parent.getClosingTagLocation();
+      closingTagLocation.has_value() && closingTagLocation->start.offset.has_value()) {
+    const std::size_t offset = *closingTagLocation->start.offset;
+    if (SourceHasClosingTagAt(document.source(), offset, closingTag)) {
+      return offset;
+    }
+  }
+
+  std::optional<SourceRange> nodeLocation = parent.getNodeLocation();
+  if (!nodeLocation.has_value() || !nodeLocation->start.offset.has_value() ||
+      !nodeLocation->end.offset.has_value() ||
+      *nodeLocation->end.offset > document.source().size()) {
+    return std::nullopt;
+  }
+
+  const std::size_t searchStart = *nodeLocation->start.offset;
+  const std::size_t searchEnd = *nodeLocation->end.offset;
+  if (searchEnd < closingTag.size()) {
+    return std::nullopt;
+  }
+
+  const std::size_t lastPossibleOffset = searchEnd - closingTag.size();
+  for (std::size_t offset = lastPossibleOffset;; --offset) {
+    if (SourceHasClosingTagAt(document.source(), offset, closingTag)) {
+      return offset;
+    }
+    if (offset == searchStart) {
+      break;
+    }
+  }
+
+  return std::nullopt;
+}
+
 void ApplyParentInsertionPlan(XMLNode& parent, const NodeInsertionPlan& plan) {
   if (plan.parentOpeningTagLocation.has_value() && plan.parentClosingTagLocation.has_value() &&
       plan.parentEndOffset.has_value()) {
@@ -773,13 +824,10 @@ std::optional<NodeInsertionPlan> GetNodeInsertionPlan(const XMLDocument& documen
     };
   }
 
-  std::optional<SourceRange> closingTagLocation = parent.getClosingTagLocation();
-  if (closingTagLocation.has_value() && closingTagLocation->start.offset.has_value()) {
-    if (*closingTagLocation->start.offset > document.source().size()) {
-      return std::nullopt;
-    }
-
-    const std::size_t offset = *closingTagLocation->start.offset;
+  if (std::optional<std::size_t> closingTagOffset =
+          FindParentClosingTagInsertionOffset(document, parent);
+      closingTagOffset.has_value()) {
+    const std::size_t offset = *closingTagOffset;
     return NodeInsertionPlan{
         .replacementOffset = offset,
         .replacementLength = 0,
@@ -805,10 +853,7 @@ std::optional<NodeInsertionPlan> GetNodeInsertionPlan(const XMLDocument& documen
     --replacementStart;
   }
 
-  std::string closingTag;
-  closingTag.append("</");
-  AppendQualifiedName(closingTag, parent.tagName());
-  closingTag.push_back('>');
+  const std::string closingTag = ClosingTagFor(parent);
 
   const std::size_t insertedOffset = replacementStart + 1;
   const std::size_t closingTagStart = insertedOffset + serializedNode.size();

--- a/donner/base/xml/tests/XMLParser_tests.cc
+++ b/donner/base/xml/tests/XMLParser_tests.cc
@@ -984,6 +984,34 @@ TEST_F(XMLParserTests, InsertNodeBeforeReferenceUpdatesSourceThroughDocument) {
   EXPECT_EQ(*rect.nextSibling(), sibling);
 }
 
+TEST_F(XMLParserTests, InsertNodeRecoversStaleClosingTagLocation) {
+  constexpr std::string_view kXml = R"(<svg><g id="parent"></g></svg>)";
+  constexpr std::string_view kInserted = R"(<rect id="inserted"/>)";
+
+  ParseResult<XMLDocument> maybeDocument = XMLParser::Parse(kXml);
+  ASSERT_THAT(maybeDocument, NoParseError());
+
+  XMLDocument document = std::move(maybeDocument.result());
+  XMLNode svg = document.root().firstChild().value();
+  XMLNode rect = XMLNode::CreateElementNode(document, "rect");
+  rect.setAttribute("id", "inserted");
+
+  svg.setClosingTagLocation(
+      SourceRange{FileOffset::Offset(kXml.size()), FileOffset::Offset(kXml.size())});
+
+  ApplySourceEditResult result = document.insertNode(svg, rect);
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_THAT(result.sourceDeltas, ElementsAre(XMLSourceDelta{
+                                       .offset = kXml.find("</svg>"),
+                                       .removedLength = 0,
+                                       .insertedLength = kInserted.size(),
+                                       .sourceVersion = 1,
+                                   }));
+  EXPECT_EQ(document.source(), R"(<svg><g id="parent"></g><rect id="inserted"/></svg>)");
+  EXPECT_LT(document.source().find(R"(<rect id="inserted"/>)"), document.source().find("</svg>"));
+}
+
 TEST_F(XMLParserTests, InsertNodeExpandsSelfClosingParentThroughDocument) {
   constexpr std::string_view kXml = R"(<svg><g id="parent"/><circle/></svg>)";
 

--- a/donner/editor/AsyncSVGDocument.cc
+++ b/donner/editor/AsyncSVGDocument.cc
@@ -197,6 +197,20 @@ void AsyncSVGDocument::applyOne(const EditorCommand& command) {
       break;
     }
 
+    case EditorCommand::Kind::InsertElement: {
+      if (!command.parentElement.has_value() || !command.element.has_value()) {
+        return;
+      }
+      xml::ApplySourceEditResult result = document_->insertElement(
+          *command.parentElement, *command.element, command.referenceElement);
+      lastFlushResult_.sourceDeltas.insert(lastFlushResult_.sourceDeltas.end(),
+                                           result.sourceDeltas.begin(), result.sourceDeltas.end());
+      if (result.diagnostic.has_value()) {
+        lastParseError_ = std::move(result.diagnostic);
+      }
+      break;
+    }
+
     case EditorCommand::Kind::DeleteElement: {
       if (!command.element.has_value()) {
         return;

--- a/donner/editor/BUILD.bazel
+++ b/donner/editor/BUILD.bazel
@@ -167,6 +167,15 @@ donner_cc_library(
 )
 
 donner_cc_library(
+    name = "rope_simulation",
+    srcs = ["RopeSimulation.cc"],
+    hdrs = ["RopeSimulation.h"],
+    deps = [
+        "//donner/base",
+    ],
+)
+
+donner_cc_library(
     name = "render_pane_gesture",
     srcs = ["RenderPaneGesture.cc"],
     hdrs = ["RenderPaneGesture.h"],
@@ -876,6 +885,7 @@ donner_cc_library(
         ":flash_decorations",
         ":focus_view",
         ":imgui_headers",
+        ":rope_simulation",
         ":soft_wrap",
         ":source_edit_intent",
         ":text_buffer",

--- a/donner/editor/BUILD.bazel
+++ b/donner/editor/BUILD.bazel
@@ -90,6 +90,7 @@ donner_cc_library(
     deps = [
         ":pan_closed_cursor_svg",
         ":pan_cursor_svg",
+        ":pen_cursor_svg",
         ":rotate_cursor_svg",
         ":selection_transform_handles",
         "//donner/base",
@@ -119,13 +120,35 @@ donner_cc_library(
 )
 
 donner_cc_library(
+    name = "reference_fanout",
+    hdrs = ["ReferenceFanout.h"],
+    deps = [],
+)
+
+donner_cc_library(
     name = "focus_view",
     srcs = ["FocusView.cc"],
     hdrs = ["FocusView.h"],
     deps = [
+        ":reference_fanout",
         "//donner/base",
         "//donner/base/xml",
         "//donner/svg",
+    ],
+)
+
+donner_cc_library(
+    name = "style_source_annotations",
+    srcs = ["StyleSourceAnnotations.cc"],
+    hdrs = ["StyleSourceAnnotations.h"],
+    deps = [
+        ":flash_decorations",
+        ":reference_fanout",
+        "//donner/base",
+        "//donner/base/xml",
+        "//donner/css",
+        "//donner/svg",
+        "//donner/svg/components/style:style_system",
     ],
 )
 
@@ -546,6 +569,7 @@ donner_cc_library(
         ":layer_inspector_diagnostics",
         ":layer_inspector_panel",
         ":menu_bar_presenter",
+        ":pen_tool",
         ":render_coordinator",
         ":render_pane_presenter",
         ":rotate_cursor_set",
@@ -553,6 +577,7 @@ donner_cc_library(
         ":selection_transform_handles",
         ":sidebar_presenter",
         ":source_selection",
+        ":style_source_annotations",
         ":text_editor",
         ":tracy_wrapper",
         ":viewport_interaction_controller",
@@ -643,6 +668,20 @@ donner_cc_library(
 )
 
 donner_cc_library(
+    name = "pen_tool",
+    srcs = ["PenTool.cc"],
+    hdrs = ["PenTool.h"],
+    deps = [
+        ":command_queue",
+        ":editor_app",
+        ":tool",
+        "//donner/base",
+        "//donner/svg",
+        "//donner/svg/parser",
+    ],
+)
+
+donner_cc_library(
     name = "overlay_renderer",
     srcs = ["OverlayRenderer.cc"],
     hdrs = ["OverlayRenderer.h"],
@@ -684,6 +723,14 @@ embed_resources(
     header_output = "donner/editor/PanCursorSvg.h",
     resources = {
         "kPanCursorSvg": "pan_cursor.svg",
+    },
+)
+
+embed_resources(
+    name = "pen_cursor_svg",
+    header_output = "donner/editor/PenCursorSvg.h",
+    resources = {
+        "kPenCursorSvg": "pen_cursor.svg",
     },
 )
 
@@ -737,7 +784,7 @@ donner_cc_library(
 # pane and a click-and-drag render pane. The minimal viewer demo lives
 # at `//examples:svg_viewer`.
 #
-#     bazel run //donner/editor -- donner_splash.svg
+# bazel run //donner/editor -- donner_splash.svg
 donner_cc_binary(
     name = "editor",
     srcs = ["main.cc"],

--- a/donner/editor/BUILD.bazel
+++ b/donner/editor/BUILD.bazel
@@ -148,7 +148,6 @@ donner_cc_library(
         "//donner/base/xml",
         "//donner/css",
         "//donner/svg",
-        "//donner/svg/components/style:style_system",
     ],
 )
 

--- a/donner/editor/CommandQueue.cc
+++ b/donner/editor/CommandQueue.cc
@@ -68,7 +68,7 @@ CommandQueue::FlushResult CommandQueue::flush() {
         result.effectiveCommands[it->second] = std::move(cmd);
       }
     } else {
-      // ReplaceDocument or DeleteElement: just emit. (At most one
+      // ReplaceDocument, InsertElement, or DeleteElement: just emit. (At most one
       // ReplaceDocument survives the startIndex walk above.)
       result.effectiveCommands.push_back(std::move(cmd));
     }

--- a/donner/editor/CommandQueue.h
+++ b/donner/editor/CommandQueue.h
@@ -17,7 +17,9 @@
 ///    most recent transform. A drag that produces 60 mouse-move
 ///    `SetTransform` commands per second flushes as a single
 ///    `setTransform()` call.
-/// 3. No reordering across commands targeting different entities.
+/// 3. `InsertElement` and `DeleteElement` are structural and are never
+///    coalesced.
+/// 4. No reordering across commands targeting different entities.
 ///    Coalescing only collapses redundant writes.
 ///
 /// The queue is **single-threaded** — it must only be touched from the UI

--- a/donner/editor/DocumentSyncController.cc
+++ b/donner/editor/DocumentSyncController.cc
@@ -23,6 +23,11 @@ struct SourceMirrorEdit {
   std::string_view replacement;
 };
 
+enum class OffsetMappingBias {
+  BeforeReplacement,
+  AfterReplacement,
+};
+
 std::optional<SourceMirrorEdit> BuildSingleSourceMirrorEdit(std::string_view oldSource,
                                                             std::string_view newSource) {
   if (oldSource == newSource) {
@@ -48,6 +53,72 @@ std::optional<SourceMirrorEdit> BuildSingleSourceMirrorEdit(std::string_view old
       .removedLength = oldSource.size() - prefixLength - suffixLength,
       .replacement = newSource.substr(prefixLength, newSource.size() - prefixLength - suffixLength),
   };
+}
+
+std::optional<std::size_t> MapOffsetThroughSourceMirrorEdit(std::size_t offset,
+                                                            const SourceMirrorEdit& edit,
+                                                            OffsetMappingBias bias) {
+  const std::size_t editEnd = edit.offset + edit.removedLength;
+  if (editEnd < edit.offset) {
+    return std::nullopt;
+  }
+
+  if (offset < edit.offset) {
+    return offset;
+  }
+
+  if (offset > editEnd) {
+    return offset - edit.removedLength + edit.replacement.size();
+  }
+
+  if (offset == edit.offset && bias == OffsetMappingBias::BeforeReplacement) {
+    return edit.offset;
+  }
+
+  return edit.offset + edit.replacement.size();
+}
+
+bool SourceRangeConflictsWithMirrorEdit(std::size_t offset, std::size_t length,
+                                        const SourceMirrorEdit& edit) {
+  const std::size_t end = offset + length;
+  const std::size_t editEnd = edit.offset + edit.removedLength;
+  if (end < offset || editEnd < edit.offset) {
+    return true;
+  }
+
+  if (length == 0) {
+    return offset > edit.offset && offset < editEnd;
+  }
+
+  if (edit.removedLength == 0) {
+    return offset <= edit.offset && edit.offset < end;
+  }
+
+  return offset < editEnd && edit.offset < end;
+}
+
+std::optional<std::size_t> MapOffsetByFollowingContext(std::string_view oldSource,
+                                                       std::string_view newSource,
+                                                       std::size_t offset) {
+  if (offset >= oldSource.size()) {
+    return std::nullopt;
+  }
+
+  constexpr std::size_t kMaxContextLength = 64;
+  const std::size_t maxContextLength = std::min(kMaxContextLength, oldSource.size() - offset);
+  for (std::size_t contextLength = 1; contextLength <= maxContextLength; ++contextLength) {
+    const std::string_view context = oldSource.substr(offset, contextLength);
+    const std::size_t firstMatch = newSource.find(context);
+    if (firstMatch == std::string_view::npos) {
+      continue;
+    }
+
+    if (newSource.find(context, firstMatch + 1) == std::string_view::npos) {
+      return firstMatch;
+    }
+  }
+
+  return std::nullopt;
 }
 
 std::string CanonicalizeForTextEditor(std::string_view source) {
@@ -98,23 +169,73 @@ bool ApplyXMLSourceDeltasIntoTextEditor(EditorApp& app, TextEditor& textEditor,
   }
 
   const std::string source = CanonicalizeForTextEditor(app.document().document().source());
+  std::string baselineSource = *previousSourceText;
+  std::string workingText = textEditor.getText();
   for (const xml::XMLSourceDelta& delta : sourceDeltas) {
-    const std::string currentText = textEditor.getText();
-    if (delta.offset > currentText.size() ||
-        delta.removedLength > currentText.size() - delta.offset || delta.offset > source.size() ||
-        delta.insertedLength > source.size() - delta.offset) {
+    if (delta.offset > baselineSource.size() ||
+        delta.removedLength > baselineSource.size() - delta.offset ||
+        delta.offset > source.size() || delta.insertedLength > source.size() - delta.offset) {
       return MirrorDocumentSourceIntoTextEditor(app, textEditor, previousSourceText,
                                                 lastWritebackSourceText);
     }
 
-    textEditor.applyExternalSourceEdit(
-        delta.offset, delta.removedLength,
-        std::string_view(source).substr(delta.offset, delta.insertedLength));
+    std::size_t mappedOffset = delta.offset;
+    std::size_t mappedRemovedLength = delta.removedLength;
+    if (std::optional<SourceMirrorEdit> edit =
+            BuildSingleSourceMirrorEdit(baselineSource, workingText);
+        edit.has_value()) {
+      if (SourceRangeConflictsWithMirrorEdit(delta.offset, delta.removedLength, *edit)) {
+        if (delta.removedLength != 0) {
+          return MirrorDocumentSourceIntoTextEditor(app, textEditor, previousSourceText,
+                                                    lastWritebackSourceText);
+        }
+
+        std::optional<std::size_t> contextOffset =
+            MapOffsetByFollowingContext(baselineSource, workingText, delta.offset);
+        if (!contextOffset.has_value()) {
+          return MirrorDocumentSourceIntoTextEditor(app, textEditor, previousSourceText,
+                                                    lastWritebackSourceText);
+        }
+
+        mappedOffset = *contextOffset;
+        mappedRemovedLength = 0;
+      } else {
+        std::optional<std::size_t> mappedStart = MapOffsetThroughSourceMirrorEdit(
+            delta.offset, *edit, OffsetMappingBias::AfterReplacement);
+        std::optional<std::size_t> mappedEnd = MapOffsetThroughSourceMirrorEdit(
+            delta.offset + delta.removedLength, *edit, OffsetMappingBias::AfterReplacement);
+        if (!mappedStart.has_value() || !mappedEnd.has_value() || *mappedEnd < *mappedStart) {
+          return MirrorDocumentSourceIntoTextEditor(app, textEditor, previousSourceText,
+                                                    lastWritebackSourceText);
+        }
+
+        mappedOffset = *mappedStart;
+        mappedRemovedLength = *mappedEnd - *mappedStart;
+      }
+    }
+
+    if (mappedOffset > workingText.size() ||
+        mappedRemovedLength > workingText.size() - mappedOffset) {
+      return MirrorDocumentSourceIntoTextEditor(app, textEditor, previousSourceText,
+                                                lastWritebackSourceText);
+    }
+
+    const std::string_view replacement =
+        std::string_view(source).substr(delta.offset, delta.insertedLength);
+    textEditor.applyExternalSourceEdit(mappedOffset, mappedRemovedLength, replacement);
+    workingText.replace(mappedOffset, mappedRemovedLength, replacement.data(), replacement.size());
+    baselineSource.replace(delta.offset, delta.removedLength, replacement.data(),
+                           replacement.size());
   }
 
-  if (textEditor.getText() != source) {
+  if (baselineSource != source) {
     return MirrorDocumentSourceIntoTextEditor(app, textEditor, previousSourceText,
                                               lastWritebackSourceText);
+  }
+
+  if (workingText != source) {
+    QueueSourceWritebackReparse(app, workingText, previousSourceText, lastWritebackSourceText);
+    return true;
   }
 
   MarkMirroredDocumentSource(app, source, previousSourceText, lastWritebackSourceText);

--- a/donner/editor/DocumentSyncController.cc
+++ b/donner/editor/DocumentSyncController.cc
@@ -221,6 +221,7 @@ std::optional<float> DocumentSyncController::nextTextSyncWakeSeconds() const {
 void DocumentSyncController::applyPendingWritebacks(EditorApp& app, SelectTool& selectTool,
                                                     TextEditor& textEditor) {
   const AsyncSVGDocument::FlushResult& lastFlush = app.document().lastFlushResult();
+  bool handledLastFlushSourceDeltas = false;
   if (lastFlush.replacedDocument && lastFlush.preserveUndoOnReparse && app.hasDocument() &&
       !app.document().lastParseError().has_value()) {
     (void)MirrorDocumentSourceIntoTextEditor(app, textEditor, &previousSourceText_,
@@ -249,6 +250,7 @@ void DocumentSyncController::applyPendingWritebacks(EditorApp& app, SelectTool& 
   }
 
   if (!pendingElementRemoveWritebacks_.empty()) {
+    handledLastFlushSourceDeltas = true;
     if (mirrorSourceDeltas(app, textEditor, app.document().lastFlushResult().sourceDeltas) ||
         MirrorDocumentSourceIntoTextEditor(app, textEditor, &previousSourceText_,
                                            &lastWritebackSourceText_)) {
@@ -271,6 +273,13 @@ void DocumentSyncController::applyPendingWritebacks(EditorApp& app, SelectTool& 
         textEditor.setText(source, /*preserveScroll=*/true);
         QueueSourceWritebackReparse(app, source, &previousSourceText_, &lastWritebackSourceText_);
       }
+    }
+  }
+
+  if (!handledLastFlushSourceDeltas && !lastFlush.sourceDeltas.empty()) {
+    if (!mirrorSourceDeltas(app, textEditor, lastFlush.sourceDeltas)) {
+      (void)MirrorDocumentSourceIntoTextEditor(app, textEditor, &previousSourceText_,
+                                               &lastWritebackSourceText_);
     }
   }
 

--- a/donner/editor/EditorApp.cc
+++ b/donner/editor/EditorApp.cc
@@ -1,7 +1,19 @@
 #include "donner/editor/EditorApp.h"
 
+#include <algorithm>
+#include <array>
+#include <optional>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "donner/base/FormatNumber.h"
+#include "donner/css/CSS.h"
+#include "donner/css/Declaration.h"
 #include "donner/editor/AttributeWriteback.h"
 #include "donner/editor/TextPatch.h"
+#include "donner/svg/SVGDocument.h"
+#include "donner/svg/SVGPathElement.h"
 
 namespace donner::editor {
 
@@ -26,6 +38,111 @@ void ForEachGeometryElement(const svg::SVGElement& node, Visitor& visit) {
   }
   for (auto child = node.firstChild(); child.has_value(); child = child->nextSibling()) {
     ForEachGeometryElement(*child, visit);
+  }
+}
+
+std::optional<std::string> MergeStyleProperty(std::string_view existingStyle,
+                                              std::string_view propertyName,
+                                              std::string_view propertyValue) {
+  const std::string update = std::string(propertyName) + ": " + std::string(propertyValue);
+  std::vector<css::Declaration> updateDeclarations = css::CSS::ParseStyleAttribute(update);
+  if (updateDeclarations.empty()) {
+    return std::nullopt;
+  }
+
+  const std::vector<css::Declaration> existingDeclarations =
+      css::CSS::ParseStyleAttribute(existingStyle);
+  return css::mergeStyleDeclarations(existingDeclarations, updateDeclarations);
+}
+
+struct PathOperationSelection {
+  std::vector<Box2d> bounds;
+};
+
+bool PathOperationPrototypeSupports(PathOperationKind operation) {
+  return operation == PathOperationKind::Union || operation == PathOperationKind::Intersect;
+}
+
+std::optional<Box2d> IntersectBoxes(const std::vector<Box2d>& bounds) {
+  if (bounds.empty()) {
+    return std::nullopt;
+  }
+
+  Box2d result = bounds.front();
+  for (std::size_t i = 1; i < bounds.size(); ++i) {
+    result.topLeft.x = std::max(result.topLeft.x, bounds[i].topLeft.x);
+    result.topLeft.y = std::max(result.topLeft.y, bounds[i].topLeft.y);
+    result.bottomRight.x = std::min(result.bottomRight.x, bounds[i].bottomRight.x);
+    result.bottomRight.y = std::min(result.bottomRight.y, bounds[i].bottomRight.y);
+  }
+
+  if (result.width() <= 0.0 || result.height() <= 0.0) {
+    return std::nullopt;
+  }
+
+  return result;
+}
+
+Box2d UnionBoxes(const std::vector<Box2d>& bounds) {
+  Box2d result = bounds.front();
+  for (std::size_t i = 1; i < bounds.size(); ++i) {
+    result.addBox(bounds[i]);
+  }
+  return result;
+}
+
+std::string FormatPathPoint(const Vector2d& point) {
+  return donner::detail::FormatNumberForSVG(point.x) + " " +
+         donner::detail::FormatNumberForSVG(point.y);
+}
+
+std::string RectanglePathData(const Box2d& box) {
+  const Vector2d topRight(box.bottomRight.x, box.topLeft.y);
+  const Vector2d bottomLeft(box.topLeft.x, box.bottomRight.y);
+
+  std::string result = "M ";
+  result += FormatPathPoint(box.topLeft);
+  result += " L ";
+  result += FormatPathPoint(topRight);
+  result += " L ";
+  result += FormatPathPoint(box.bottomRight);
+  result += " L ";
+  result += FormatPathPoint(bottomLeft);
+  result += " Z";
+  return result;
+}
+
+PathOperationSelection CollectPathOperationSelection(std::span<const svg::SVGElement> selection) {
+  PathOperationSelection result;
+  result.bounds.reserve(selection.size());
+
+  for (const svg::SVGElement& element : selection) {
+    if (!element.isa<svg::SVGGeometryElement>()) {
+      continue;
+    }
+
+    const svg::SVGGeometryElement geometry = element.cast<svg::SVGGeometryElement>();
+    std::optional<Box2d> bounds = geometry.worldBounds();
+    if (!bounds.has_value() || bounds->isEmpty()) {
+      continue;
+    }
+
+    result.bounds.push_back(*bounds);
+  }
+
+  return result;
+}
+
+void CopyPathOperationStyle(const svg::SVGElement& source, svg::SVGPathElement& target) {
+  constexpr std::array<const char*, 8> kCopiedAttributes = {
+      "class",        "fill",           "fill-opacity", "stroke",
+      "stroke-width", "stroke-opacity", "opacity",      "fill-rule",
+  };
+
+  for (const char* name : kCopiedAttributes) {
+    if (std::optional<RcString> value = source.getAttribute(name); value.has_value()) {
+      target.setAttribute(name, std::string_view(*value));
+    }
   }
 }
 
@@ -239,6 +356,118 @@ void EditorApp::addToSelection(const svg::SVGElement& element) {
   }
   selection_.push_back(element);
   refreshFirstSelectionCache();
+}
+
+bool EditorApp::setAttributeOnSelection(std::string_view attrName, std::string_view attrValue) {
+  if (selection_.empty()) {
+    return false;
+  }
+
+  for (const svg::SVGElement& element : selection_) {
+    applyMutation(
+        EditorCommand::SetAttributeCommand(element, std::string(attrName), std::string(attrValue)));
+  }
+  return true;
+}
+
+bool EditorApp::setStylePropertyOnSelection(std::string_view propertyName,
+                                            std::string_view propertyValue) {
+  if (selection_.empty()) {
+    return false;
+  }
+
+  bool queuedMutation = false;
+  for (const svg::SVGElement& element : selection_) {
+    const std::optional<RcString> styleAttribute = element.getAttribute("style");
+    const std::string_view existingStyle =
+        styleAttribute.has_value() ? std::string_view(*styleAttribute) : std::string_view();
+    const std::optional<std::string> mergedStyle =
+        MergeStyleProperty(existingStyle, propertyName, propertyValue);
+    if (!mergedStyle.has_value()) {
+      continue;
+    }
+
+    applyMutation(EditorCommand::SetAttributeCommand(element, "style", *mergedStyle));
+    queuedMutation = true;
+  }
+  return queuedMutation;
+}
+
+bool EditorApp::setStrokeWidthOnSelection(double strokeWidth) {
+  const double clampedStrokeWidth = std::max(0.0, strokeWidth);
+  return setStylePropertyOnSelection("stroke-width",
+                                     donner::detail::FormatNumberForSVG(clampedStrokeWidth));
+}
+
+void EditorApp::setActiveStrokeWidth(double strokeWidth) {
+  activePaintStyle_.strokeWidth = std::max(0.0, strokeWidth);
+}
+
+PathOperationAvailability EditorApp::pathOperationAvailability(PathOperationKind operation) const {
+  if (!document_.hasDocument()) {
+    return {.canApply = false, .reason = "No SVG document is loaded"};
+  }
+
+  if (!PathOperationPrototypeSupports(operation)) {
+    return {.canApply = false, .reason = "Prototype supports Union and Intersect first"};
+  }
+
+  if (selection_.size() < 2u) {
+    return {.canApply = false, .reason = "Select at least two bounded geometry elements"};
+  }
+
+  const PathOperationSelection pathSelection = CollectPathOperationSelection(selection_);
+  if (pathSelection.bounds.size() != selection_.size()) {
+    return {.canApply = false, .reason = "Selection includes unsupported or empty geometry"};
+  }
+
+  if (operation == PathOperationKind::Intersect &&
+      !IntersectBoxes(pathSelection.bounds).has_value()) {
+    return {.canApply = false, .reason = "Selected bounds do not overlap"};
+  }
+
+  return {.canApply = true};
+}
+
+bool EditorApp::applyPathOperation(PathOperationKind operation) {
+  const PathOperationAvailability availability = pathOperationAvailability(operation);
+  if (!availability.canApply) {
+    return false;
+  }
+
+  const std::vector<svg::SVGElement> selected = selection_;
+  const PathOperationSelection pathSelection = CollectPathOperationSelection(selected);
+  std::optional<Box2d> resultBox;
+  switch (operation) {
+    case PathOperationKind::Union: resultBox = UnionBoxes(pathSelection.bounds); break;
+    case PathOperationKind::Intersect: resultBox = IntersectBoxes(pathSelection.bounds); break;
+    case PathOperationKind::SubtractFront:
+    case PathOperationKind::SubtractBack:
+    case PathOperationKind::Exclude: return false;
+  }
+
+  if (!resultBox.has_value()) {
+    return false;
+  }
+
+  svg::SVGDocument& document = document_.document();
+  svg::SVGPathElement resultPath = svg::SVGPathElement::Create(document);
+  resultPath.setAttribute("d", RectanglePathData(*resultBox));
+  CopyPathOperationStyle(selected.front(), resultPath);
+
+  svg::SVGElement parent = selected.front().parentElement().value_or(document.svgElement());
+  std::optional<svg::SVGElement> referenceElement;
+  if (const std::optional<svg::SVGElement> selectedParent = selected.front().parentElement();
+      selectedParent.has_value() && *selectedParent == parent) {
+    referenceElement = selected.front();
+  }
+
+  applyMutation(EditorCommand::InsertElementCommand(parent, resultPath, referenceElement));
+  for (const svg::SVGElement& element : selected) {
+    applyMutation(EditorCommand::DeleteElementCommand(element));
+  }
+  setSelection(resultPath);
+  return true;
 }
 
 void EditorApp::refreshFirstSelectionCache() {

--- a/donner/editor/EditorApp.h
+++ b/donner/editor/EditorApp.h
@@ -15,6 +15,7 @@
 /// canvas pan/zoom state (that lives at the main-loop layer where it
 /// belongs). It is just enough surface for `SelectTool` to do its job.
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -32,6 +33,28 @@
 #include "donner/svg/SVGGeometryElement.h"
 
 namespace donner::editor {
+
+/// Boolean-style path operation exposed by the editor path operations panel.
+enum class PathOperationKind : std::uint8_t {
+  Union,
+  Intersect,
+  SubtractFront,
+  SubtractBack,
+  Exclude,
+};
+
+/// Whether a path operation can currently be applied to the editor selection.
+struct PathOperationAvailability {
+  bool canApply = false;  ///< True when the operation button should be enabled.
+  std::string reason;     ///< Short disabled-state reason for tooltips and tests.
+};
+
+/// Active paint settings used by authoring tools when creating new geometry.
+struct ActivePaintStyle {
+  std::string fill = "none";     ///< SVG fill attribute for new geometry.
+  std::string stroke = "black";  ///< SVG stroke attribute for new geometry.
+  double strokeWidth = 1.0;      ///< SVG stroke-width attribute for new geometry.
+};
 
 /// Top-level editor shell.
 ///
@@ -177,9 +200,81 @@ public:
   /// existing entries. No-op if `element` is already selected.
   void addToSelection(const svg::SVGElement& element);
 
+  /**
+   * Queue an attribute write for every selected element.
+   *
+   * @param attrName Attribute name to set, e.g. `"fill"`.
+   * @param attrValue Attribute value to write.
+   * @return true if commands were queued.
+   */
+  bool setAttributeOnSelection(std::string_view attrName, std::string_view attrValue);
+
+  /**
+   * Merge a single CSS declaration into each selected element's `style` attribute.
+   *
+   * @param propertyName CSS property name, e.g. `"fill"`.
+   * @param propertyValue CSS property value, e.g. `"#112233"`.
+   * @return true if commands were queued.
+   */
+  bool setStylePropertyOnSelection(std::string_view propertyName, std::string_view propertyValue);
+
+  /**
+   * Queue a `stroke-width` style-property write for every selected element.
+   *
+   * @param strokeWidth Stroke width in user units. Negative values clamp to zero.
+   * @return true if commands were queued.
+   */
+  bool setStrokeWidthOnSelection(double strokeWidth);
+
+  /// Active paint settings used by path-authoring tools for newly-created elements.
+  [[nodiscard]] const ActivePaintStyle& activePaintStyle() const { return activePaintStyle_; }
+
+  /**
+   * Set the active fill attribute for newly-created elements.
+   *
+   * @param fill SVG fill attribute value.
+   */
+  void setActiveFill(std::string_view fill) { activePaintStyle_.fill = std::string(fill); }
+
+  /**
+   * Set the active stroke attribute for newly-created elements.
+   *
+   * @param stroke SVG stroke attribute value.
+   */
+  void setActiveStroke(std::string_view stroke) { activePaintStyle_.stroke = std::string(stroke); }
+
+  /**
+   * Set the active stroke width for newly-created elements.
+   *
+   * @param strokeWidth Stroke width in user units. Negative values clamp to zero.
+   */
+  void setActiveStrokeWidth(double strokeWidth);
+
   /// Drop every entry from the selection. Equivalent to
   /// `setSelection(std::nullopt)` but reads better at clear sites.
   void clearSelection() { setSelection(std::nullopt); }
+
+  /**
+   * Return whether a path operation is available for the current selection.
+   *
+   * @param operation Operation to test.
+   * @return Availability and a user-facing disabled reason.
+   */
+  [[nodiscard]] PathOperationAvailability pathOperationAvailability(
+      PathOperationKind operation) const;
+
+  /**
+   * Queue a destructive path operation over the current selection.
+   *
+   * The current prototype supports Union and Intersect by replacing the
+   * selected geometry with a source-backed rectangle path derived from the
+   * selected elements' document-space bounds. Full curve/path boolean math is
+   * scoped in `0041-path_authoring_and_boolean_operations.md`.
+   *
+   * @param operation Operation to apply.
+   * @return true if commands were queued.
+   */
+  bool applyPathOperation(PathOperationKind operation);
 
   // ---------------------------------------------------------------------------
   // Hit testing
@@ -329,6 +424,7 @@ private:
   std::optional<std::string> currentFilePath_;
   std::string cleanSourceText_;
   bool isDirty_ = false;
+  ActivePaintStyle activePaintStyle_;
 };
 
 }  // namespace donner::editor

--- a/donner/editor/EditorCommand.h
+++ b/donner/editor/EditorCommand.h
@@ -51,6 +51,11 @@ struct EditorCommand {
     /// to the most-recently-queued value.
     SetAttribute,
 
+    /// Insert `element` as a child of `parentElement`, optionally before
+    /// `referenceElement`. Used by authoring tools that create new DOM
+    /// nodes. Not coalesced.
+    InsertElement,
+
     /// Detach the element from its parent, making it invisible to the
     /// renderer. The ECS entity itself is NOT destroyed — it stays in
     /// the registry, just orphaned. This is a "soft delete" so any
@@ -64,6 +69,13 @@ struct EditorCommand {
   /// Target element for SetTransform and DeleteElement. `std::nullopt`
   /// for ReplaceDocument.
   std::optional<svg::SVGElement> element;
+
+  /// Parent element for InsertElement.
+  std::optional<svg::SVGElement> parentElement;
+
+  /// Optional sibling for InsertElement; inserted before this element
+  /// when present, otherwise appended to the parent.
+  std::optional<svg::SVGElement> referenceElement;
 
   /// SetTransform payload. Default-constructed for ReplaceDocument /
   /// DeleteElement.
@@ -114,6 +126,18 @@ struct EditorCommand {
     cmd.element = std::move(element);
     cmd.attributeName = std::move(name);
     cmd.attributeValue = std::move(value);
+    return cmd;
+  }
+
+  /// Builds an InsertElement command.
+  static EditorCommand InsertElementCommand(
+      svg::SVGElement parent, svg::SVGElement element,
+      std::optional<svg::SVGElement> reference = std::nullopt) {
+    EditorCommand cmd;
+    cmd.kind = Kind::InsertElement;
+    cmd.parentElement = std::move(parent);
+    cmd.element = std::move(element);
+    cmd.referenceElement = std::move(reference);
     return cmd;
   }
 

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -78,11 +78,13 @@ constexpr std::string_view kRenderPaneContextMenuName = "Render Context Menu";
 constexpr ImWchar kEditorGlyphRanges[] = {
     0x0020, 0x00ff,  // Basic Latin + Latin Supplement.
     0x2217, 0x2217,  // Asterisk operator.
+    0x2726, 0x2726,  // Black four pointed star.
     0x2731, 0x2731,  // Heavy asterisk.
     0,
 };
 constexpr ImWchar kEditorSymbolGlyphRanges[] = {
     0x2217, 0x2217,  // Asterisk operator.
+    0x2726, 0x2726,  // Black four pointed star.
     0x2731, 0x2731,  // Heavy asterisk.
     0,
 };
@@ -2552,6 +2554,9 @@ void EditorShell::updateSourceStyleDecorations() {
         .showChip = contribution.showChip,
         .chipCount = contribution.matchedElementCount,
         .showOverflowMarker = contribution.showOverflowMarker,
+        .chipKind = contribution.kind == StyleContributionKind::ReferenceResourceElement
+                        ? TextEditor::SourceStyleChipKind::ReferenceCount
+                        : TextEditor::SourceStyleChipKind::SelectorMatchCount,
         .tooltip = contribution.tooltip,
         .chipTooltip = contribution.chipTooltip,
         .overflowTooltip = contribution.overflowTooltip,

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -288,12 +288,15 @@ std::optional<SourceByteRange> ResolveReferenceSourceRange(svg::SVGDocument& doc
     return std::nullopt;
   }
 
-  const std::optional<svg::ResolvedReference> resolved = reference.resolve(document.registry());
-  if (!resolved.has_value() || !resolved->valid()) {
-    return std::nullopt;
-  }
+  return document.withReadAccess(
+      [source, &reference](svg::DocumentReadAccess& access) -> std::optional<SourceByteRange> {
+        const std::optional<svg::ResolvedReference> resolved = reference.resolve(access.registry());
+        if (!resolved.has_value() || !resolved->valid()) {
+          return std::nullopt;
+        }
 
-  return EntitySourceByteRange(resolved->handle, source);
+        return EntitySourceByteRange(resolved->handle, source);
+      });
 }
 
 ToolbarPaintReferenceState ToolbarPaintReferenceStateFor(svg::SVGDocument* document,
@@ -514,11 +517,7 @@ ImVec2 ReferenceHighlightChipTextSize(std::string_view label) {
 void AddUniqueElements(std::vector<svg::SVGElement>* target,
                        std::span<const svg::SVGElement> elements) {
   for (const svg::SVGElement& element : elements) {
-    const Entity entity = element.entityHandle().entity();
-    const auto it = std::ranges::find_if(*target, [entity](const svg::SVGElement& existing) {
-      return existing.entityHandle().entity() == entity;
-    });
-    if (it == target->end()) {
+    if (std::ranges::find(*target, element) == target->end()) {
       target->push_back(element);
     }
   }

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -75,6 +75,17 @@ constexpr float kToolPalettePadding = 5.0f;
 constexpr float kToolPalettePaintWidgetWidth = 118.0f;
 constexpr float kToolPaletteTopInset = 8.0f;
 constexpr std::string_view kRenderPaneContextMenuName = "Render Context Menu";
+constexpr ImWchar kEditorGlyphRanges[] = {
+    0x0020, 0x00ff,  // Basic Latin + Latin Supplement.
+    0x2217, 0x2217,  // Asterisk operator.
+    0x2731, 0x2731,  // Heavy asterisk.
+    0,
+};
+constexpr ImWchar kEditorSymbolGlyphRanges[] = {
+    0x2217, 0x2217,  // Asterisk operator.
+    0x2731, 0x2731,  // Heavy asterisk.
+    0,
+};
 
 ImGuiMouseCursor CursorForTransformHandleIntent(const SelectionTransformHandleIntent& intent) {
   if (intent.kind == SelectionTransformHandleKind::Rotate) {
@@ -622,18 +633,24 @@ EditorShell::EditorShell(gui::EditorWindow& window, EditorShellOptions options)
   ImFontConfig fontCfg;
   fontCfg.FontDataOwnedByAtlas = false;
   const double displayScale = window_.displayScale();
-  std::ignore =
-      io.Fonts->AddFontFromMemoryTTF(const_cast<unsigned char*>(embedded::kRobotoRegularTtf.data()),
-                                     static_cast<int>(embedded::kRobotoRegularTtf.size()),
-                                     static_cast<float>(15.0 * displayScale), &fontCfg);
-  uiFontBold_ =
-      io.Fonts->AddFontFromMemoryTTF(const_cast<unsigned char*>(embedded::kRobotoBoldTtf.data()),
-                                     static_cast<int>(embedded::kRobotoBoldTtf.size()),
-                                     static_cast<float>(15.0 * displayScale), &fontCfg);
+  std::ignore = io.Fonts->AddFontFromMemoryTTF(
+      const_cast<unsigned char*>(embedded::kRobotoRegularTtf.data()),
+      static_cast<int>(embedded::kRobotoRegularTtf.size()), static_cast<float>(15.0 * displayScale),
+      &fontCfg, kEditorGlyphRanges);
+  uiFontBold_ = io.Fonts->AddFontFromMemoryTTF(
+      const_cast<unsigned char*>(embedded::kRobotoBoldTtf.data()),
+      static_cast<int>(embedded::kRobotoBoldTtf.size()), static_cast<float>(15.0 * displayScale),
+      &fontCfg, kEditorGlyphRanges);
   codeFont_ = io.Fonts->AddFontFromMemoryTTF(
       const_cast<unsigned char*>(embedded::kFiraCodeRegularTtf.data()),
       static_cast<int>(embedded::kFiraCodeRegularTtf.size()),
-      static_cast<float>(14.0 * displayScale), &fontCfg);
+      static_cast<float>(14.0 * displayScale), &fontCfg, kEditorGlyphRanges);
+  ImFontConfig codeSymbolFontCfg = fontCfg;
+  codeSymbolFontCfg.MergeMode = true;
+  std::ignore = io.Fonts->AddFontFromMemoryTTF(
+      const_cast<unsigned char*>(embedded::kRobotoRegularTtf.data()),
+      static_cast<int>(embedded::kRobotoRegularTtf.size()), static_cast<float>(14.0 * displayScale),
+      &codeSymbolFontCfg, kEditorSymbolGlyphRanges);
 
   if (!app_.loadFromString(*initialSource)) {
     // Keep the shell alive so the user can still edit/fix the file from the source pane.
@@ -676,6 +693,23 @@ EditorShell::EditorShell(gui::EditorWindow& window, EditorShellOptions options)
   }
 
   valid_ = true;
+}
+
+std::optional<float> EditorShell::nextIdleWakeSeconds() const {
+  std::optional<float> result;
+  const auto includeWake = [&result](std::optional<float> wakeSeconds) {
+    if (!wakeSeconds.has_value()) {
+      return;
+    }
+
+    const float clampedWakeSeconds = std::max(0.0f, *wakeSeconds);
+    result = result.has_value() ? std::min(*result, clampedWakeSeconds) : clampedWakeSeconds;
+  };
+
+  includeWake(documentSyncController_.nextTextSyncWakeSeconds());
+  includeWake(textEditor_.nextFlashWakeSeconds());
+  includeWake(textEditor_.nextRopeAnimationWakeSeconds());
+  return result;
 }
 
 EditorShell::~EditorShell() {
@@ -2786,10 +2820,6 @@ void EditorShell::runFrame() {
     renderLayerPanelSplitter(rightPaneX, rightPaneWidth_, rightSidebarLayout);
   }
   renderFloatingLayerPanel();
-  if (documentSyncController_.nextTextSyncWakeSeconds().has_value() ||
-      textEditor_.nextFlashWakeSeconds().has_value()) {
-    window_.wakeEventLoop();
-  }
 }
 
 }  // namespace donner::editor

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -5,6 +5,7 @@
 #include <array>
 #include <cfloat>
 #include <cmath>
+#include <cstdint>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
@@ -17,6 +18,7 @@
 #include <vector>
 
 #include "GLFW/glfw3.h"
+#include "donner/css/parser/ColorParser.h"
 #include "donner/editor/DocumentSave.h"
 #include "donner/editor/DragCoalesce.h"
 #include "donner/editor/FocusView.h"
@@ -24,10 +26,13 @@
 #include "donner/editor/SelectionTransformHandles.h"
 #include "donner/editor/SourceSelection.h"
 #include "donner/editor/SourceSync.h"
+#include "donner/editor/StyleSourceAnnotations.h"
 #include "donner/editor/TracyWrapper.h"
 #include "donner/editor/XmlAutocomplete.h"
 #include "donner/editor/gui/EditorWindow.h"
 #include "donner/editor/repro/ReproRecorder.h"
+#include "donner/svg/SVGDocument.h"
+#include "donner/svg/properties/PaintServer.h"
 #include "embed_resources/FiraCodeFont.h"
 #include "embed_resources/RobotoFont.h"
 
@@ -64,6 +69,11 @@ constexpr float kReferenceChipPaddingY = 5.0f;
 constexpr float kReferenceChipRadius = 6.0f;
 constexpr float kReferenceChipGapFromAabb = 30.0f;
 constexpr float kReferenceChipMinFontSize = 15.0f;
+constexpr float kToolPaletteButtonSize = 30.0f;
+constexpr float kToolPaletteGap = 4.0f;
+constexpr float kToolPalettePadding = 5.0f;
+constexpr float kToolPalettePaintWidgetWidth = 118.0f;
+constexpr float kToolPaletteTopInset = 8.0f;
 constexpr std::string_view kRenderPaneContextMenuName = "Render Context Menu";
 
 ImGuiMouseCursor CursorForTransformHandleIntent(const SelectionTransformHandleIntent& intent) {
@@ -96,6 +106,306 @@ void SetImGuiOsCursorManagementEnabled(bool enabled) {
 bool ContainsScreenPoint(const Box2d& rect, const ImVec2& point) {
   return point.x >= rect.topLeft.x && point.x <= rect.bottomRight.x && point.y >= rect.topLeft.y &&
          point.y <= rect.bottomRight.y;
+}
+
+ImVec2 ToImVec2(const Vector2d& point) {
+  return ImVec2(static_cast<float>(point.x), static_cast<float>(point.y));
+}
+
+Vector2d CubicPoint(const Vector2d& p0, const Vector2d& p1, const Vector2d& p2, const Vector2d& p3,
+                    double t) {
+  const double oneMinusT = 1.0 - t;
+  return p0 * (oneMinusT * oneMinusT * oneMinusT) + p1 * (3.0 * oneMinusT * oneMinusT * t) +
+         p2 * (3.0 * oneMinusT * t * t) + p3 * (t * t * t);
+}
+
+ImVec2 PenToolIconPoint(const ImVec2& origin, float scale, float x, float y) {
+  return ImVec2(origin.x + x * scale, origin.y + y * scale);
+}
+
+void StrokePenToolButtonIcon(ImDrawList* drawList, const ImVec2& min, const ImVec2& max,
+                             ImU32 color, float strokeWidth) {
+  const float buttonSize = std::min(max.x - min.x, max.y - min.y);
+  const float iconSize = buttonSize - 9.0f;
+  const float scale = iconSize / 24.0f;
+  const ImVec2 origin(min.x + (max.x - min.x - iconSize) * 0.5f,
+                      min.y + (max.y - min.y - iconSize) * 0.5f);
+  const auto point = [&](float x, float y) { return PenToolIconPoint(origin, scale, x, y); };
+
+  drawList->PathClear();
+  drawList->PathLineTo(point(14.4153f, 18.6964f));
+  drawList->PathLineTo(point(7.88293f, 19.2352f));
+  drawList->PathLineTo(point(3.80865f, 3.84719f));
+  drawList->PathLineTo(point(19.1966f, 7.92147f));
+  drawList->PathLineTo(point(18.3043f, 14.8073f));
+  drawList->PathStroke(color, ImDrawFlags_None, strokeWidth);
+
+  constexpr float kCosMinus45 = 0.70710678f;
+  constexpr float kSinMinus45 = -0.70710678f;
+  constexpr float kRectX = 13.7081f;
+  constexpr float kRectY = 19.4036f;
+  const auto rectPoint = [&](float dx, float dy) {
+    return point(kRectX + dx * kCosMinus45 - dy * kSinMinus45,
+                 kRectY + dx * kSinMinus45 + dy * kCosMinus45);
+  };
+  drawList->PathClear();
+  drawList->PathLineTo(rectPoint(0.0f, 0.0f));
+  drawList->PathLineTo(rectPoint(7.22447f, 0.0f));
+  drawList->PathLineTo(rectPoint(7.22447f, 3.0f));
+  drawList->PathLineTo(rectPoint(0.0f, 3.0f));
+  drawList->PathStroke(color, ImDrawFlags_Closed, strokeWidth);
+
+  drawList->AddLine(point(5.92996f, 5.96852f), point(10.8797f, 10.9183f), color, strokeWidth);
+  drawList->AddCircle(point(12.2939f, 12.3325f), 2.0f * scale, color, 0, strokeWidth);
+}
+
+void DrawPenToolButtonIcon(ImDrawList* drawList, const ImVec2& min, const ImVec2& max) {
+  StrokePenToolButtonIcon(drawList, min, max, IM_COL32(255, 255, 255, 255), 3.0f);
+  StrokePenToolButtonIcon(drawList, min, max, IM_COL32(0, 0, 0, 255), 1.75f);
+}
+
+void DrawSelectToolButtonIcon(ImDrawList* drawList, const ImVec2& min, const ImVec2& max) {
+  const float buttonSize = std::min(max.x - min.x, max.y - min.y);
+  const float iconSize = buttonSize - 8.0f;
+  const float scale = iconSize / 24.0f;
+  const ImVec2 origin(min.x + (max.x - min.x - iconSize) * 0.5f,
+                      min.y + (max.y - min.y - iconSize) * 0.5f);
+  const auto point = [&](float x, float y) {
+    return ImVec2(origin.x + x * scale, origin.y + y * scale);
+  };
+  const std::array<ImVec2, 7> points = {
+      point(5.5f, 3.5f),   point(5.5f, 21.0f),  point(10.2f, 16.4f), point(12.9f, 22.0f),
+      point(15.8f, 20.6f), point(13.0f, 15.1f), point(19.5f, 15.1f),
+  };
+
+  drawList->AddTriangleFilled(points[0], points[1], points[2], IM_COL32(0, 0, 0, 255));
+  drawList->AddTriangleFilled(points[0], points[2], points[6], IM_COL32(0, 0, 0, 255));
+  drawList->AddTriangleFilled(points[2], points[3], points[5], IM_COL32(0, 0, 0, 255));
+  drawList->AddTriangleFilled(points[3], points[4], points[5], IM_COL32(0, 0, 0, 255));
+
+  drawList->AddPolyline(points.data(), static_cast<int>(points.size()),
+                        IM_COL32(255, 255, 255, 255), ImDrawFlags_Closed, 3.2f);
+  drawList->AddPolyline(points.data(), static_cast<int>(points.size()), IM_COL32(0, 0, 0, 255),
+                        ImDrawFlags_Closed, 1.7f);
+}
+
+float ColorChannelToFloat(std::uint8_t value) {
+  return static_cast<float>(value) / 255.0f;
+}
+
+ImVec4 ColorToImVec4(const css::RGBA& color) {
+  return ImVec4(ColorChannelToFloat(color.r), ColorChannelToFloat(color.g),
+                ColorChannelToFloat(color.b), ColorChannelToFloat(color.a));
+}
+
+css::RGBA ColorFromPicker(const float color[4]) {
+  const auto channel = [](float value) {
+    return static_cast<std::uint8_t>(
+        std::clamp(static_cast<int>(std::lround(value * 255.0f)), 0, 255));
+  };
+  return css::RGBA(channel(color[0]), channel(color[1]), channel(color[2]), channel(color[3]));
+}
+
+std::string ColorToSvgAttribute(const css::RGBA& color) {
+  return color.toHexString();
+}
+
+std::optional<css::RGBA> ParseColorAttribute(std::string_view value) {
+  auto parsed = css::parser::ColorParser::ParseString(value);
+  if (parsed.hasError() || !parsed.hasResult()) {
+    return std::nullopt;
+  }
+
+  const css::Color color = parsed.result();
+  if (color.isCurrentColor()) {
+    return css::RGBA::RGB(0, 0, 0);
+  }
+
+  return color.asRGBA();
+}
+
+css::RGBA CurrentColorForElement(const svg::SVGElement& element) {
+  const css::Color color = element.getComputedStyle().color.getRequired();
+  return color.isCurrentColor() ? css::RGBA::RGB(0, 0, 0) : color.asRGBA();
+}
+
+struct ToolbarPaintReferenceState {
+  std::string href;
+  bool external = false;
+  std::optional<SourceByteRange> sourceRange;
+};
+
+struct ToolbarPaintSlotState {
+  css::RGBA color = css::RGBA::RGB(0, 0, 0);
+  bool isNone = true;
+  bool isCustom = false;
+  std::optional<ToolbarPaintReferenceState> reference;
+  std::string customLabel;
+};
+
+struct ToolbarPaintState {
+  ToolbarPaintSlotState fill;
+  ToolbarPaintSlotState stroke;
+};
+
+css::RGBA PaintServerFallbackColor() {
+  return css::RGBA::RGB(74, 89, 112);
+}
+
+ToolbarPaintSlotState ToolbarPaintSlotStateForActiveAttribute(std::string_view value) {
+  ToolbarPaintSlotState state;
+  if (value == "none") {
+    return state;
+  }
+
+  state.isNone = false;
+  const std::optional<css::RGBA> parsedColor = ParseColorAttribute(value);
+  state.color = parsedColor.value_or(PaintServerFallbackColor());
+  state.isCustom = !parsedColor.has_value();
+  if (state.isCustom) {
+    state.customLabel = std::string(value);
+  }
+  return state;
+}
+
+std::optional<SourceByteRange> ResolveReferenceSourceRange(svg::SVGDocument& document,
+                                                           std::string_view source,
+                                                           const svg::Reference& reference) {
+  if (reference.isExternal()) {
+    return std::nullopt;
+  }
+
+  const std::optional<svg::ResolvedReference> resolved = reference.resolve(document.registry());
+  if (!resolved.has_value() || !resolved->valid()) {
+    return std::nullopt;
+  }
+
+  return EntitySourceByteRange(resolved->handle, source);
+}
+
+ToolbarPaintReferenceState ToolbarPaintReferenceStateFor(svg::SVGDocument* document,
+                                                         std::optional<std::string_view> source,
+                                                         const svg::Reference& reference) {
+  ToolbarPaintReferenceState state;
+  state.href = std::string(std::string_view(reference.href));
+  state.external = reference.isExternal();
+
+  if (document != nullptr && source.has_value() && !state.external) {
+    state.sourceRange = ResolveReferenceSourceRange(*document, *source, reference);
+  }
+
+  return state;
+}
+
+ToolbarPaintSlotState ToolbarPaintSlotStateForPaintServer(const svg::PaintServer& paint,
+                                                          const css::RGBA& currentColor,
+                                                          svg::SVGDocument* document,
+                                                          std::optional<std::string_view> source) {
+  ToolbarPaintSlotState state;
+  state.color = PaintServerFallbackColor();
+
+  if (paint.is<svg::PaintServer::None>()) {
+    state.isNone = true;
+    return state;
+  }
+
+  if (paint.is<svg::PaintServer::Solid>()) {
+    state.isNone = false;
+    state.color = paint.get<svg::PaintServer::Solid>().color.resolve(currentColor, 1.0f);
+    return state;
+  }
+
+  if (paint.is<svg::PaintServer::ElementReference>()) {
+    const auto& ref = paint.get<svg::PaintServer::ElementReference>();
+    state.isNone = false;
+    state.isCustom = true;
+    state.reference = ToolbarPaintReferenceStateFor(document, source, ref.reference);
+    if (ref.fallback.has_value()) {
+      state.color = ref.fallback->resolve(currentColor, 1.0f);
+    }
+    return state;
+  }
+
+  state.isNone = false;
+  state.isCustom = true;
+  state.customLabel = paint.is<svg::PaintServer::ContextFill>() ? "context-fill" : "context-stroke";
+  return state;
+}
+
+ToolbarPaintSlotState ToolbarPaintSlotStateForElement(const svg::SVGElement& element,
+                                                      std::string_view attrName,
+                                                      svg::SVGDocument* document,
+                                                      std::optional<std::string_view> source) {
+  const auto& style = element.getComputedStyle();
+  const svg::PaintServer paint =
+      attrName == "fill" ? style.fill.getRequired() : style.stroke.getRequired();
+  ToolbarPaintSlotState state =
+      ToolbarPaintSlotStateForPaintServer(paint, CurrentColorForElement(element), document, source);
+
+  if (state.isCustom || !state.isNone) {
+    return state;
+  }
+
+  if (std::optional<RcString> attribute = element.getAttribute(attrName);
+      attribute.has_value() && std::string_view(*attribute) != "none") {
+    state = ToolbarPaintSlotStateForActiveAttribute(std::string_view(*attribute));
+  }
+  return state;
+}
+
+ToolbarPaintState ToolbarPaintStateForActivePaint(const ActivePaintStyle& paintStyle) {
+  ToolbarPaintState state;
+  state.fill = ToolbarPaintSlotStateForActiveAttribute(paintStyle.fill);
+  state.stroke = ToolbarPaintSlotStateForActiveAttribute(paintStyle.stroke);
+  return state;
+}
+
+void OverridePaintStateFromElement(ToolbarPaintState* state, const svg::SVGElement& element,
+                                   svg::SVGDocument* document,
+                                   std::optional<std::string_view> source) {
+  state->fill = ToolbarPaintSlotStateForElement(element, "fill", document, source);
+  state->stroke = ToolbarPaintSlotStateForElement(element, "stroke", document, source);
+}
+
+ToolbarPaintState ToolbarPaintStateForApp(EditorApp& app, std::optional<std::string_view> source) {
+  ToolbarPaintState state = ToolbarPaintStateForActivePaint(app.activePaintStyle());
+  if (app.hasSelection()) {
+    OverridePaintStateFromElement(&state, app.selectedElements().front(),
+                                  app.hasDocument() ? &app.document().document() : nullptr, source);
+  }
+  return state;
+}
+
+void DrawPaintSwatch(ImDrawList* drawList, const ImVec2& min, const ImVec2& max,
+                     const ToolbarPaintSlotState& state) {
+  drawList->AddRectFilled(min, max, ImGui::GetColorU32(ColorToImVec4(state.color)), 2.0f);
+  if (state.isCustom) {
+    drawList->PushClipRect(min, max, true);
+    for (float x = min.x - (max.y - min.y); x < max.x; x += 5.0f) {
+      drawList->AddLine(ImVec2(x, max.y), ImVec2(x + (max.y - min.y), min.y),
+                        IM_COL32(255, 255, 255, 95), 1.0f);
+    }
+    drawList->PopClipRect();
+  }
+  drawList->AddRect(min, max, IM_COL32(255, 255, 255, 230), 2.0f, 0, 1.0f);
+  drawList->AddRect(min, max, state.isCustom ? IM_COL32(91, 189, 255, 255) : IM_COL32(0, 0, 0, 210),
+                    2.0f, 0, 2.0f);
+  if (state.isNone) {
+    drawList->AddLine(ImVec2(min.x + 2.0f, max.y - 2.0f), ImVec2(max.x - 2.0f, min.y + 2.0f),
+                      IM_COL32(230, 40, 40, 255), 2.2f);
+  }
+}
+
+std::string PaintChipLabel(std::string_view prefix, const ToolbarPaintSlotState& state) {
+  std::string value = state.reference.has_value() ? state.reference->href : state.customLabel;
+  if (value.empty()) {
+    value = "custom";
+  }
+  constexpr std::size_t kMaxValueLength = 12;
+  if (value.size() > kMaxValueLength) {
+    value = value.substr(0, kMaxValueLength - 3) + "...";
+  }
+  return std::string(prefix) + " " + value;
 }
 
 std::string SelectionSizeChipLabel(const Box2d& screenBounds) {
@@ -266,6 +576,7 @@ EditorShell::EditorShell(gui::EditorWindow& window, EditorShellOptions options)
       options_(std::move(options)),
       app_(),
       selectTool_(),
+      penTool_(),
       textEditor_(),
       textures_(window.geodeDevice()),
       renderCoordinator_(window.geodeDevice()),
@@ -662,6 +973,23 @@ void EditorShell::handleGlobalShortcuts() {
     toggleSourceFocusMode();
   }
 
+  if (!sourcePaneFocused && !anyPopupOpen && !cmd &&
+      ImGui::IsKeyPressed(ImGuiKey_V, /*repeat=*/false)) {
+    activeTool_ = ActiveTool::Select;
+    penTool_.cancel();
+  }
+
+  if (!sourcePaneFocused && !anyPopupOpen && !cmd &&
+      ImGui::IsKeyPressed(ImGuiKey_P, /*repeat=*/false)) {
+    activeTool_ = ActiveTool::Pen;
+  }
+
+  if (!anyPopupOpen && ImGui::IsKeyPressed(ImGuiKey_Escape, /*repeat=*/false) &&
+      penTool_.isDrafting()) {
+    penTool_.cancel();
+    return;
+  }
+
   if (!anyPopupOpen && ImGui::IsKeyPressed(ImGuiKey_Escape, /*repeat=*/false) &&
       app_.hasSelection()) {
     app_.setSelection(std::nullopt);
@@ -684,7 +1012,9 @@ void EditorShell::renderSourcePane(float paneOriginY, float paneHeight, float pa
   ImGui::Begin("Source", nullptr, kPaneFlags);
   ImGui::PushFont(codeFont);
   textEditor_.setSourceFocusModeContextMenu(sourceFocusMode_);
+  updateSourceStyleDecorations();
   textEditor_.render("##source");
+  applySourceStyleDecorationChipClick();
   updateSourceHoverPreview();
   if (textEditor_.takeSourceFocusModeContextMenuToggleRequest()) {
     toggleSourceFocusMode();
@@ -703,6 +1033,245 @@ void EditorShell::renderSourcePane(float paneOriginY, float paneHeight, float pa
   }
   updateSourceHoverPreview();
   ImGui::End();
+}
+
+Box2d EditorShell::toolPaletteScreenRect(const ImVec2& paneOrigin,
+                                         const ImVec2& contentRegion) const {
+  constexpr float kButtonCount = 3.0f;
+  const float width = kToolPalettePadding * 2.0f + kToolPaletteButtonSize * kButtonCount +
+                      kToolPalettePaintWidgetWidth + kToolPaletteGap * kButtonCount;
+  const float height = kToolPalettePadding * 2.0f + kToolPaletteButtonSize;
+  const float x = paneOrigin.x + std::max(0.0f, (contentRegion.x - width) * 0.5f);
+  const float y = paneOrigin.y + kToolPaletteTopInset;
+  return Box2d::FromXYWH(x, y, width, height);
+}
+
+void EditorShell::renderFillStrokeToolbarWidget() {
+  const bool rendererBusy = renderCoordinator_.asyncRenderer().isBusy();
+  const bool canEditPaint = app_.hasDocument() && !rendererBusy;
+  std::string editorSource;
+  std::string documentSource;
+  std::optional<std::string_view> sourceForRanges;
+  if (canEditPaint) {
+    editorSource = textEditor_.getText();
+    documentSource = CanonicalizeForTextEditor(app_.document().document().source());
+    if (editorSource == documentSource) {
+      sourceForRanges = std::string_view(editorSource);
+    }
+  }
+  const ToolbarPaintState paintState =
+      rendererBusy ? ToolbarPaintState{} : ToolbarPaintStateForApp(app_, sourceForRanges);
+  ImGui::BeginDisabled(!canEditPaint);
+  ImGui::InvisibleButton("##fill_stroke_widget",
+                         ImVec2(kToolPalettePaintWidgetWidth, kToolPaletteButtonSize));
+  const ImVec2 min = ImGui::GetItemRectMin();
+  const ImVec2 max = ImGui::GetItemRectMax();
+  const ImVec2 mouse = ImGui::GetMousePos();
+  const ImVec2 strokeMin(min.x + 15.0f, min.y + 3.0f);
+  const ImVec2 strokeMax(strokeMin.x + 19.0f, strokeMin.y + 19.0f);
+  const ImVec2 fillMin(min.x + 5.0f, min.y + 10.0f);
+  const ImVec2 fillMax(fillMin.x + 19.0f, fillMin.y + 19.0f);
+  const ImVec2 chipMin(min.x + 42.0f, min.y + 1.0f);
+  const ImVec2 chipMax(max.x - 3.0f, min.y + 14.0f);
+  const ImVec2 fillChipMin(chipMin.x, min.y + 16.0f);
+  const ImVec2 fillChipMax(chipMax.x, min.y + 29.0f);
+  const ImVec2 strokeChipMin(chipMin.x, chipMin.y);
+  const ImVec2 strokeChipMax(chipMax.x, chipMax.y);
+  ImDrawList* drawList = ImGui::GetWindowDrawList();
+  DrawPaintSwatch(drawList, strokeMin, strokeMax, paintState.stroke);
+  DrawPaintSwatch(drawList, fillMin, fillMax, paintState.fill);
+
+  const auto contains = [](const ImVec2& rectMin, const ImVec2& rectMax, const ImVec2& point) {
+    return point.x >= rectMin.x && point.x <= rectMax.x && point.y >= rectMin.y &&
+           point.y <= rectMax.y;
+  };
+  const auto fitChipLabel = [](std::string label, float maxWidth) {
+    if (ImGui::CalcTextSize(label.c_str()).x <= maxWidth) {
+      return label;
+    }
+
+    std::string base = std::move(label);
+    while (base.size() > 1u) {
+      base.pop_back();
+      const std::string candidate = base + "...";
+      if (ImGui::CalcTextSize(candidate.c_str()).x <= maxWidth) {
+        return candidate;
+      }
+    }
+    return std::string("...");
+  };
+  const auto renderChip = [&](std::string_view prefix, const ToolbarPaintSlotState& slot,
+                              const ImVec2& rectMin, const ImVec2& rectMax) {
+    if (!slot.isCustom) {
+      return;
+    }
+
+    const bool actionable = slot.reference.has_value() && slot.reference->sourceRange.has_value();
+    const ImU32 fillColor = actionable ? IM_COL32(37, 112, 172, 245) : IM_COL32(61, 72, 86, 225);
+    const ImU32 borderColor =
+        actionable ? IM_COL32(127, 203, 255, 255) : IM_COL32(119, 132, 150, 235);
+    drawList->AddRectFilled(rectMin, rectMax, fillColor, 4.0f);
+    drawList->AddRect(rectMin, rectMax, borderColor, 4.0f, 0, 1.0f);
+
+    const std::string label =
+        fitChipLabel(PaintChipLabel(prefix, slot), rectMax.x - rectMin.x - 8.0f);
+    const ImVec2 textSize = ImGui::CalcTextSize(label.c_str());
+    drawList->AddText(
+        ImVec2(rectMin.x + 4.0f, rectMin.y + (rectMax.y - rectMin.y - textSize.y) * 0.5f - 0.5f),
+        IM_COL32(255, 255, 255, 245), label.c_str());
+  };
+  renderChip("S", paintState.stroke, strokeChipMin, strokeChipMax);
+  renderChip("F", paintState.fill, fillChipMin, fillChipMax);
+
+  if (canEditPaint && ImGui::IsItemClicked()) {
+    const bool clickedFillChip =
+        paintState.fill.isCustom && contains(fillChipMin, fillChipMax, mouse);
+    const bool clickedStrokeChip =
+        paintState.stroke.isCustom && contains(strokeChipMin, strokeChipMax, mouse);
+    bool handledPaintClick = false;
+    if (clickedFillChip || clickedStrokeChip) {
+      const ToolbarPaintSlotState& slot = clickedFillChip ? paintState.fill : paintState.stroke;
+      if (slot.reference.has_value() && slot.reference->sourceRange.has_value()) {
+        revealSourceRange(*slot.reference->sourceRange);
+      }
+      handledPaintClick = true;
+    }
+
+    if (!handledPaintClick) {
+      const bool clickedFill = mouse.x >= fillMin.x && mouse.x <= fillMax.x &&
+                               mouse.y >= fillMin.y && mouse.y <= fillMax.y;
+      const bool clickedStroke = mouse.x >= strokeMin.x && mouse.x <= strokeMax.x &&
+                                 mouse.y >= strokeMin.y && mouse.y <= strokeMax.y;
+      if (clickedFill || !clickedStroke) {
+        ImGui::OpenPopup("##fill_color_picker");
+      } else {
+        ImGui::OpenPopup("##stroke_color_picker");
+      }
+    }
+  }
+  if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+    const bool hoveredFillChip =
+        paintState.fill.isCustom && contains(fillChipMin, fillChipMax, mouse);
+    const bool hoveredStrokeChip =
+        paintState.stroke.isCustom && contains(strokeChipMin, strokeChipMax, mouse);
+    if (hoveredFillChip || hoveredStrokeChip) {
+      const char* name = hoveredFillChip ? "Fill" : "Stroke";
+      const ToolbarPaintSlotState& slot = hoveredFillChip ? paintState.fill : paintState.stroke;
+      if (slot.reference.has_value() && slot.reference->sourceRange.has_value()) {
+        ImGui::SetTooltip("%s paint server %s. Click to show source.", name,
+                          slot.reference->href.c_str());
+      } else if (slot.reference.has_value() && slot.reference->external) {
+        ImGui::SetTooltip("%s uses external paint server %s.", name, slot.reference->href.c_str());
+      } else if (slot.reference.has_value()) {
+        ImGui::SetTooltip("%s uses unresolved paint server %s.", name,
+                          slot.reference->href.c_str());
+      } else {
+        ImGui::SetTooltip("%s uses custom paint %s.", name, slot.customLabel.c_str());
+      }
+    } else {
+      ImGui::SetTooltip("%s", canEditPaint ? "Fill / stroke" : "Open an SVG document");
+    }
+  }
+  ImGui::EndDisabled();
+
+  auto renderColorPopup = [&](const char* popupId, const char* pickerId, std::string_view attrName,
+                              const ToolbarPaintSlotState& slot) {
+    if (!ImGui::BeginPopup(popupId)) {
+      return;
+    }
+
+    float pickerColor[4] = {
+        ColorChannelToFloat(slot.color.r),
+        ColorChannelToFloat(slot.color.g),
+        ColorChannelToFloat(slot.color.b),
+        ColorChannelToFloat(slot.color.a),
+    };
+    constexpr ImGuiColorEditFlags kFlags = ImGuiColorEditFlags_AlphaBar |
+                                           ImGuiColorEditFlags_AlphaPreviewHalf |
+                                           ImGuiColorEditFlags_NoSidePreview;
+    if (ImGui::ColorPicker4(pickerId, pickerColor, kFlags)) {
+      const css::RGBA chosen = ColorFromPicker(pickerColor);
+      const std::string svgColor = ColorToSvgAttribute(chosen);
+      if (attrName == "fill") {
+        app_.setActiveFill(svgColor);
+      } else {
+        app_.setActiveStroke(svgColor);
+      }
+      std::ignore = app_.setStylePropertyOnSelection(attrName, svgColor);
+      window_.wakeEventLoop();
+    }
+    ImGui::EndPopup();
+  };
+
+  renderColorPopup("##fill_color_picker", "##fill_picker", "fill", paintState.fill);
+  renderColorPopup("##stroke_color_picker", "##stroke_picker", "stroke", paintState.stroke);
+}
+
+void EditorShell::renderToolPalette(const ImVec2& paneOrigin, const ImVec2& contentRegion) {
+  const Box2d rect = toolPaletteScreenRect(paneOrigin, contentRegion);
+  ImDrawList* drawList = ImGui::GetWindowDrawList();
+  drawList->AddRectFilled(
+      ImVec2(static_cast<float>(rect.topLeft.x), static_cast<float>(rect.topLeft.y)),
+      ImVec2(static_cast<float>(rect.bottomRight.x), static_cast<float>(rect.bottomRight.y)),
+      ImGui::GetColorU32(ImVec4(0.11f, 0.12f, 0.14f, 0.92f)), 7.0f);
+  drawList->AddRect(
+      ImVec2(static_cast<float>(rect.topLeft.x), static_cast<float>(rect.topLeft.y)),
+      ImVec2(static_cast<float>(rect.bottomRight.x), static_cast<float>(rect.bottomRight.y)),
+      ImGui::GetColorU32(ImVec4(1.0f, 1.0f, 1.0f, 0.14f)), 7.0f);
+
+  ImGui::SetCursorScreenPos(ImVec2(static_cast<float>(rect.topLeft.x) + kToolPalettePadding,
+                                   static_cast<float>(rect.topLeft.y) + kToolPalettePadding));
+  ImGui::PushID("tool_palette");
+  ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 5.0f);
+  ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0.0f, 0.0f));
+
+  enum class ToolButtonIcon {
+    None,
+    SelectPointer,
+    PenTool,
+  };
+  const auto renderButton = [&](ActiveTool tool, const char* label, ToolButtonIcon icon,
+                                const char* tooltip) {
+    const bool selected = activeTool_ == tool;
+    if (selected) {
+      ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.18f, 0.43f, 0.90f, 1.0f));
+      ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.22f, 0.50f, 1.0f, 1.0f));
+      ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.14f, 0.35f, 0.78f, 1.0f));
+    }
+    if (ImGui::Button(label, ImVec2(kToolPaletteButtonSize, kToolPaletteButtonSize))) {
+      activeTool_ = tool;
+      if (tool == ActiveTool::Select) {
+        penTool_.cancel();
+      }
+    }
+    if (icon == ToolButtonIcon::SelectPointer) {
+      DrawSelectToolButtonIcon(drawList, ImGui::GetItemRectMin(), ImGui::GetItemRectMax());
+    } else if (icon == ToolButtonIcon::PenTool) {
+      DrawPenToolButtonIcon(drawList, ImGui::GetItemRectMin(), ImGui::GetItemRectMax());
+    }
+    if (ImGui::IsItemHovered()) {
+      ImGui::SetTooltip("%s", tooltip);
+    }
+    if (selected) {
+      ImGui::PopStyleColor(3);
+    }
+  };
+
+  renderButton(ActiveTool::Select, "##select_tool", ToolButtonIcon::SelectPointer, "Select");
+  ImGui::SameLine(0.0f, kToolPaletteGap);
+  renderButton(ActiveTool::Pen, "##pen_tool", ToolButtonIcon::PenTool, "Pen");
+  ImGui::SameLine(0.0f, kToolPaletteGap);
+  ImGui::BeginDisabled(true);
+  (void)ImGui::Button("△", ImVec2(kToolPaletteButtonSize, kToolPaletteButtonSize));
+  ImGui::EndDisabled();
+  if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+    ImGui::SetTooltip("%s", "Path edit");
+  }
+  ImGui::SameLine(0.0f, kToolPaletteGap);
+  renderFillStrokeToolbarWidget();
+
+  ImGui::PopStyleVar(2);
+  ImGui::PopID();
 }
 
 void EditorShell::renderRenderPane(const Vector2d& renderPaneOrigin, const Vector2d& renderPaneSize,
@@ -740,13 +1309,16 @@ void EditorShell::renderRenderPane(const Vector2d& renderPaneOrigin, const Vecto
   const bool hideReferenceChip = selectTool_.activeTransformBoundsPreview().has_value();
   const std::optional<Box2d> referenceChipRect =
       hideReferenceChip ? std::nullopt : referenceHighlightChipScreenRect(referenceChipLabel);
+  const Box2d toolPaletteRect = toolPaletteScreenRect(paneOriginImGui, contentRegion);
+  const bool toolPaletteHovered = ContainsScreenPoint(toolPaletteRect, ImGui::GetMousePos());
   const bool referenceChipHovered = referenceChipRect.has_value() &&
                                     ContainsScreenPoint(*referenceChipRect, ImGui::GetMousePos());
 
+  ImGui::SetNextItemAllowOverlap();
   ImGui::InvisibleButton("##render_canvas", contentRegion,
                          ImGuiButtonFlags_MouseButtonLeft | ImGuiButtonFlags_MouseButtonMiddle);
   const bool paneHovered = ImGui::IsItemHovered();
-  const bool canvasHovered = paneHovered && !referenceChipHovered;
+  const bool canvasHovered = paneHovered && !referenceChipHovered && !toolPaletteHovered;
   const Box2d paneRect = Box2d::FromXYWH(interactionController_.viewport().paneOrigin.x,
                                          interactionController_.viewport().paneOrigin.y,
                                          interactionController_.viewport().paneSize.x,
@@ -789,8 +1361,8 @@ void EditorShell::renderRenderPane(const Vector2d& renderPaneOrigin, const Vecto
     }
   }
 
-  const bool modalCapturingInput =
-      referenceChipHovered || ImGui::IsPopupOpen(nullptr, ImGuiPopupFlags_AnyPopup);
+  const bool modalCapturingInput = referenceChipHovered || toolPaletteHovered ||
+                                   ImGui::IsPopupOpen(nullptr, ImGuiPopupFlags_AnyPopup);
   interactionController_.consumeScrollEvents(inputBridge_.events(), paneRect, modalCapturingInput,
                                              kWheelZoomStep, kTrackpadPanPixelsPerScrollUnit);
 
@@ -804,6 +1376,8 @@ void EditorShell::renderRenderPane(const Vector2d& renderPaneOrigin, const Vecto
   }
 
   const bool toolEligible = canvasHovered && !interactionController_.panning() && !spaceHeld;
+  const bool selectToolActive = activeTool_ == ActiveTool::Select;
+  const bool penToolActive = activeTool_ == ActiveTool::Pen;
   const auto cachedHandleIntentAt = [&](const Vector2d& documentPoint) {
     const auto& boundsCache = renderCoordinator_.selectionBoundsCache();
     if (boundsCache.lastSelection != app_.selectedElements()) {
@@ -813,7 +1387,16 @@ void EditorShell::renderRenderPane(const Vector2d& renderPaneOrigin, const Vecto
                                             interactionController_.viewport().pixelsPerDocUnit());
   };
   SelectionTransformHandleIntent hoverTransformIntent;
-  if (!rotateCursorLocked && toolEligible && !ImGui::IsMouseDown(ImGuiMouseButton_Left)) {
+  if (penToolActive && !rotateCursorLocked && toolEligible) {
+    if (rotateCursorSet_.setPenCursor()) {
+      SetImGuiOsCursorManagementEnabled(false);
+    } else {
+      rotateCursorSet_.clearIfActive();
+      SetImGuiOsCursorManagementEnabled(true);
+      ImGui::SetMouseCursor(ImGuiMouseCursor_Arrow);
+    }
+  } else if (selectToolActive && !rotateCursorLocked && toolEligible &&
+             !ImGui::IsMouseDown(ImGuiMouseButton_Left)) {
     hoverTransformIntent = cachedHandleIntentAt(screenToDocument(ImGui::GetMousePos()));
     if (hoverTransformIntent.kind != SelectionTransformHandleKind::None) {
       if (hoverTransformIntent.kind == SelectionTransformHandleKind::Rotate &&
@@ -867,7 +1450,8 @@ void EditorShell::renderRenderPane(const Vector2d& renderPaneOrigin, const Vecto
         cacheMatchesSelection ? cachedHandleIntentAt(pendingClick.documentPoint)
                               : SelectionTransformHandleIntent{};
     const bool tookFastRedrag =
-        cacheMatchesSelection && pendingHandleIntent.kind == SelectionTransformHandleKind::None &&
+        selectToolActive && cacheMatchesSelection &&
+        pendingHandleIntent.kind == SelectionTransformHandleKind::None &&
         selectTool_.tryStartRedragOnSelected(app_, pendingClick.documentPoint,
                                              pendingClick.modifiers, boundsCache.displayedBoundsDoc,
                                              boundsCache.displayedOccludingBoundsDoc);
@@ -879,14 +1463,27 @@ void EditorShell::renderRenderPane(const Vector2d& renderPaneOrigin, const Vecto
       // Slow path: full `onMouseDown` (hitTest + selection change +
       // possible drag start). Race-safe only when the worker is idle.
       lastPostedScreenPoint_.reset();
-      selectTool_.onMouseDown(app_, pendingClick.documentPoint, pendingClick.modifiers);
-      renderCoordinator_.refreshSelectionBoundsCache(app_);
-      renderCoordinator_.maybeRequestRender(app_, selectTool_, interactionController_.viewport(),
-                                            textures_);
-      renderCoordinator_.rasterizeOverlayForCurrentSelection(
-          app_, interactionController_.viewport(), textures_, selectTool_.marqueeRect(),
-          RenderCoordinator::OverlayUploadMode::MatchDisplayedVersion,
-          selectTool_.activeDragPreview(), selectTool_.activeTransformBoundsPreview());
+      bool queuedMutationForNextFrame = false;
+      if (selectToolActive) {
+        selectTool_.onMouseDown(app_, pendingClick.documentPoint, pendingClick.modifiers);
+      } else if (penToolActive) {
+        penTool_.onMouseDown(app_, pendingClick.documentPoint, pendingClick.modifiers);
+        if (!ImGui::IsMouseDown(ImGuiMouseButton_Left) && penTool_.isDraggingAnchor()) {
+          penTool_.onMouseUp(app_, pendingClick.documentPoint);
+        }
+        queuedMutationForNextFrame = true;
+      }
+      if (queuedMutationForNextFrame) {
+        window_.wakeEventLoop();
+      } else {
+        renderCoordinator_.refreshSelectionBoundsCache(app_);
+        renderCoordinator_.maybeRequestRender(app_, selectTool_, interactionController_.viewport(),
+                                              textures_);
+        renderCoordinator_.rasterizeOverlayForCurrentSelection(
+            app_, interactionController_.viewport(), textures_, selectTool_.marqueeRect(),
+            RenderCoordinator::OverlayUploadMode::MatchDisplayedVersion,
+            selectTool_.activeDragPreview(), selectTool_.activeTransformBoundsPreview());
+      }
       interactionController_.clearPendingClick();
     } else {
       // Worker is busy with a (likely-stale) prewarm render at the
@@ -961,6 +1558,16 @@ void EditorShell::renderRenderPane(const Vector2d& renderPaneOrigin, const Vecto
     }
   }
 
+  if (penToolActive && penTool_.isDraggingAnchor()) {
+    if (ImGui::IsMouseDown(ImGuiMouseButton_Left) && !spaceHeld) {
+      penTool_.onMouseMove(app_, screenToDocument(ImGui::GetMousePos()), /*buttonHeld=*/true);
+    }
+    if (ImGui::IsMouseReleased(ImGuiMouseButton_Left)) {
+      penTool_.onMouseUp(app_, screenToDocument(ImGui::GetMousePos()));
+      window_.wakeEventLoop();
+    }
+  }
+
   if (!renderCoordinator_.asyncRenderer().isBusy() && app_.hasDocument()) {
     renderCoordinator_.maybeRequestRender(app_, selectTool_, interactionController_.viewport(),
                                           textures_);
@@ -989,8 +1596,10 @@ void EditorShell::renderRenderPane(const Vector2d& renderPaneOrigin, const Vecto
       .suppressDragTargetTiles = renderCoordinator_.selectedElementIsDisplayNone(app_),
   };
   renderPanePresenter_.render(paneState);
+  renderPenToolPreview();
   renderSelectionSizeChip(hoverTransformIntent, activeGesturePreview);
   renderReferenceHighlightChip();
+  renderToolPalette(paneOriginImGui, contentRegion);
   renderRenderPaneContextMenu();
 
   ImGui::End();
@@ -1035,8 +1644,12 @@ void EditorShell::renderSidebars(float rightPaneX, float rightPaneWidth, float p
   ImGui::SetNextWindowPos(ImVec2(rightPaneX, layout.inspectorPaneY), ImGuiCond_Always);
   ImGui::SetNextWindowSize(ImVec2(rightPaneWidth, layout.inspectorPaneHeight), ImGuiCond_Always);
   ImGui::Begin("Inspector", nullptr, paneFlags);
-  sidebarPresenter_.renderInspector(interactionController_.viewport());
+  const bool inspectorQueuedMutation =
+      sidebarPresenter_.renderInspector(liveAppForClicks, interactionController_.viewport());
   ImGui::End();
+  if (inspectorQueuedMutation) {
+    window_.wakeEventLoop();
+  }
 
   if (layerPanelDetached_) {
     return;
@@ -1332,8 +1945,10 @@ std::vector<svg::SVGElement> EditorShell::sourceHoverElements() const {
 
   const std::size_t hoverOffset = textEditor_.getByteOffsetAtCoordinates(*hoverPosition);
   if (std::optional<StyleFocus> styleFocus = styleFocusAtSourceOffset(hoverOffset)) {
-    return ExcludeSelectedSourceHoverElements(std::move(styleFocus->impactedElements),
-                                              app_.selectedElements());
+    return ExcludeDocumentRootSourceHoverElement(
+        ExcludeSelectedSourceHoverElements(std::move(styleFocus->impactedElements),
+                                           app_.selectedElements()),
+        app_.document().document());
   }
 
   std::optional<svg::SVGElement> element =
@@ -1342,7 +1957,9 @@ std::vector<svg::SVGElement> EditorShell::sourceHoverElements() const {
     return {};
   }
 
-  return ExcludeSelectedSourceHoverElements({*element}, app_.selectedElements());
+  return ExcludeDocumentRootSourceHoverElement(
+      ExcludeSelectedSourceHoverElements({*element}, app_.selectedElements()),
+      app_.document().document());
 }
 
 std::vector<SourceByteRange> EditorShell::sourceHoverRangesForElements(
@@ -1621,6 +2238,52 @@ void EditorShell::renderReferenceHighlightChip() {
                     IM_COL32(255, 255, 255, 255), label.c_str(), label.c_str() + label.size());
 }
 
+void EditorShell::renderPenToolPreview() {
+  if (activeTool_ != ActiveTool::Pen || !penTool_.isDrafting()) {
+    return;
+  }
+
+  ImDrawList* drawList = ImGui::GetWindowDrawList();
+  const ViewportState& viewport = interactionController_.viewport();
+  const ImU32 pathColor = ImGui::GetColorU32(ImVec4(0.10f, 0.43f, 1.0f, 1.0f));
+  const ImU32 handleColor = ImGui::GetColorU32(ImVec4(0.10f, 0.43f, 1.0f, 0.42f));
+  const ImU32 anchorFill = ImGui::GetColorU32(ImVec4(1.0f, 1.0f, 1.0f, 1.0f));
+  const ImU32 anchorStroke = ImGui::GetColorU32(ImVec4(0.06f, 0.20f, 0.48f, 1.0f));
+
+  for (const PenTool::PreviewHandleLine& handle : penTool_.previewHandleLines()) {
+    drawList->AddLine(ToImVec2(viewport.documentToScreen(handle.start)),
+                      ToImVec2(viewport.documentToScreen(handle.end)), handleColor, 1.2f);
+    drawList->AddCircleFilled(ToImVec2(viewport.documentToScreen(handle.end)), 3.0f, handleColor);
+  }
+
+  for (const PenTool::PreviewSegment& segment : penTool_.previewSegments()) {
+    if (!segment.cubic) {
+      drawList->AddLine(ToImVec2(viewport.documentToScreen(segment.start)),
+                        ToImVec2(viewport.documentToScreen(segment.end)), pathColor, 2.0f);
+      continue;
+    }
+
+    constexpr int kCubicSteps = 24;
+    Vector2d previous = segment.start;
+    for (int i = 1; i <= kCubicSteps; ++i) {
+      const double t = static_cast<double>(i) / static_cast<double>(kCubicSteps);
+      const Vector2d current =
+          CubicPoint(segment.start, segment.control1, segment.control2, segment.end, t);
+      drawList->AddLine(ToImVec2(viewport.documentToScreen(previous)),
+                        ToImVec2(viewport.documentToScreen(current)), pathColor, 2.0f);
+      previous = current;
+    }
+  }
+
+  for (const Vector2d& anchor : penTool_.previewAnchors()) {
+    const ImVec2 center = ToImVec2(viewport.documentToScreen(anchor));
+    const ImVec2 min(center.x - 4.0f, center.y - 4.0f);
+    const ImVec2 max(center.x + 4.0f, center.y + 4.0f);
+    drawList->AddRectFilled(min, max, anchorFill, 1.0f);
+    drawList->AddRect(min, max, anchorStroke, 1.0f, 0, 1.4f);
+  }
+}
+
 void EditorShell::openRenderPaneContextMenu(const Vector2d& documentPoint) {
   renderContextMenuDocumentPoint_ = documentPoint;
   renderContextMenuHitElement_.reset();
@@ -1736,6 +2399,9 @@ void EditorShell::applyStyleFocus(StyleFocus styleFocus) {
   applySourcePartition(std::move(styleFocus.partition));
   sourceFocusOriginatedInStyle_ = true;
   sourceSelectionOriginatedInText_ = false;
+  if (styleFocus.reverseReferenceExpansionSuppressed) {
+    return;
+  }
   if (app_.selectedElements() != styleFocus.impactedElements) {
     app_.setSelection(std::move(styleFocus.impactedElements));
     sourceSelectionOriginatedInText_ = app_.selectedElements() != lastHighlightedSelection_;
@@ -1811,6 +2477,97 @@ void EditorShell::updateSourceFocusView(bool scrollToSelection) {
   }
 }
 
+void EditorShell::updateSourceStyleDecorations() {
+  const auto clearDecorations = [this]() {
+    styleSourceContributions_.clear();
+    styleSourceDecorationsValid_ = false;
+    styleSourceDecorationSourceVersion_ = 0;
+    styleSourceDecorationText_.clear();
+    std::ignore = textEditor_.clearSourceStyleDecorations();
+  };
+
+  if (!app_.hasDocument() || textEditor_.isTextChanged() || app_.document().hasPendingMutations()) {
+    clearDecorations();
+    return;
+  }
+
+  const std::string documentSource = CanonicalizeForTextEditor(app_.document().document().source());
+  if (documentSource.empty() || textEditor_.getText() != documentSource) {
+    clearDecorations();
+    return;
+  }
+
+  const std::uint64_t sourceVersion = app_.document().document().sourceVersion();
+  if (styleSourceDecorationsValid_ && styleSourceDecorationSourceVersion_ == sourceVersion &&
+      styleSourceDecorationText_ == documentSource) {
+    return;
+  }
+
+  StyleSourceAnnotations annotations =
+      ComputeStyleSourceAnnotations(app_.document().document(), documentSource);
+  styleSourceContributions_ = std::move(annotations.contributions);
+
+  std::vector<TextEditor::SourceStyleDecoration> decorations;
+  decorations.reserve(styleSourceContributions_.size());
+  for (const StyleSourceContribution& contribution : styleSourceContributions_) {
+    decorations.push_back(TextEditor::SourceStyleDecoration{
+        .id = contribution.id,
+        .range = contribution.sourceRange,
+        .chipRange = contribution.chipRange,
+        .ineffective = !contribution.effective,
+        .showChip = contribution.showChip,
+        .chipCount = contribution.matchedElementCount,
+        .showOverflowMarker = contribution.showOverflowMarker,
+        .tooltip = contribution.tooltip,
+        .chipTooltip = contribution.chipTooltip,
+        .overflowTooltip = contribution.overflowTooltip,
+    });
+  }
+
+  std::ignore = textEditor_.setSourceStyleDecorations(std::move(decorations));
+  styleSourceDecorationsValid_ = true;
+  styleSourceDecorationSourceVersion_ = sourceVersion;
+  styleSourceDecorationText_ = documentSource;
+}
+
+void EditorShell::applySourceStyleDecorationChipClick() {
+  const std::optional<std::size_t> clickedId = textEditor_.takeClickedSourceStyleChipId();
+  if (!clickedId.has_value()) {
+    return;
+  }
+
+  auto contributionIter =
+      std::find_if(styleSourceContributions_.begin(), styleSourceContributions_.end(),
+                   [clickedId](const StyleSourceContribution& contribution) {
+                     return contribution.id == *clickedId;
+                   });
+  if (contributionIter == styleSourceContributions_.end()) {
+    return;
+  }
+  if (contributionIter->showOverflowMarker) {
+    return;
+  }
+
+  app_.setSelection(contributionIter->matchedElements);
+  sourceSelectionOriginatedInText_ = true;
+  sourceFocusOriginatedInStyle_ = false;
+  referenceHighlightActive_ = false;
+  referenceHighlightChipHovered_ = false;
+  referenceHighlightSummary_ = ReferenceHighlightSummary{};
+  lastReferenceHighlightSelection_.clear();
+  updateSourceFocusView(/*scrollToSelection=*/false);
+
+  if (!renderCoordinator_.asyncRenderer().isBusy()) {
+    renderCoordinator_.refreshSelectionBoundsCache(app_);
+    renderCoordinator_.rasterizeOverlayForCurrentSelection(
+        app_, interactionController_.viewport(), textures_, selectTool_.marqueeRect(),
+        RenderCoordinator::OverlayUploadMode::Immediate, selectTool_.activeDragPreview(),
+        selectTool_.activeTransformBoundsPreview());
+  }
+
+  window_.wakeEventLoop();
+}
+
 void EditorShell::setSourceFocusMode(bool enabled) {
   sourceFocusMode_ = enabled;
   if (sourceFocusOriginatedInStyle_) {
@@ -1843,6 +2600,14 @@ void EditorShell::setSourcePaneVisible(bool visible) {
           RenderCoordinator::OverlayUploadMode::Immediate, selectTool_.activeDragPreview(),
           selectTool_.activeTransformBoundsPreview());
     }
+  }
+  window_.wakeEventLoop();
+}
+
+void EditorShell::revealSourceRange(SourceByteRange byteRange) {
+  setSourcePaneVisible(true);
+  if (HighlightSourceByteRange(textEditor_, byteRange)) {
+    textEditor_.flashSourceRange(byteRange);
   }
   window_.wakeEventLoop();
 }

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -111,6 +111,8 @@ public:
 
   [[nodiscard]] bool valid() const { return valid_; }
   void runFrame();
+  /// Return the next idle-loop wake interval needed for throttled UI work.
+  [[nodiscard]] std::optional<float> nextIdleWakeSeconds() const;
 
   /// Current render-pane viewport. Exposed for replay/readback harnesses
   /// that need to crop the presented framebuffer to the canvas region.

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -19,11 +19,13 @@
 #include "donner/editor/LayerInspectorDiagnostics.h"
 #include "donner/editor/LayerInspectorPanel.h"
 #include "donner/editor/MenuBarPresenter.h"
+#include "donner/editor/PenTool.h"
 #include "donner/editor/RenderCoordinator.h"
 #include "donner/editor/RenderPanePresenter.h"
 #include "donner/editor/RotateCursorSet.h"
 #include "donner/editor/SelectTool.h"
 #include "donner/editor/SidebarPresenter.h"
+#include "donner/editor/StyleSourceAnnotations.h"
 #include "donner/editor/TextEditor.h"
 #include "donner/editor/ViewportInteractionController.h"
 
@@ -137,6 +139,10 @@ private:
   void renderSourcePane(float paneOriginY, float paneHeight, float paneWidth, ImFont* codeFont);
   void renderRenderPane(const Vector2d& renderPaneOrigin, const Vector2d& renderPaneSize,
                         ImGuiWindowFlags paneFlags);
+  [[nodiscard]] Box2d toolPaletteScreenRect(const ImVec2& paneOrigin,
+                                            const ImVec2& contentRegion) const;
+  void renderToolPalette(const ImVec2& paneOrigin, const ImVec2& contentRegion);
+  void renderFillStrokeToolbarWidget();
   void renderSidebars(float rightPaneX, float rightPaneWidth, float paneOriginY,
                       const RightSidebarLayout& layout, ImGuiWindowFlags paneFlags);
   void renderSourcePaneSplitter(float windowWidth, float paneOriginY, float paneHeight,
@@ -171,6 +177,7 @@ private:
       const SelectionTransformHandleIntent& hoverTransformIntent,
       const std::optional<SelectTool::ActiveGesturePreview>& activeGesturePreview);
   void renderReferenceHighlightChip();
+  void renderPenToolPreview();
   void openRenderPaneContextMenu(const Vector2d& documentPoint);
   void renderRenderPaneContextMenu();
   [[nodiscard]] std::optional<StyleFocus> styleFocusAtSourceOffset(std::size_t sourceOffset) const;
@@ -179,9 +186,12 @@ private:
   void syncSelectionFromSourceCursorIfNeeded();
   void applySourcePartition(FocusPartition partition);
   void updateSourceFocusView(bool scrollToSelection = false);
+  void updateSourceStyleDecorations();
+  void applySourceStyleDecorationChipClick();
   void setSourceFocusMode(bool enabled);
   void toggleSourceFocusMode();
   void setSourcePaneVisible(bool visible);
+  void revealSourceRange(SourceByteRange byteRange);
 
   gui::EditorWindow& window_;
   EditorShellOptions options_;
@@ -189,6 +199,12 @@ private:
 
   EditorApp app_;
   SelectTool selectTool_;
+  PenTool penTool_;
+  enum class ActiveTool : std::uint8_t {
+    Select,
+    Pen,
+  };
+  ActiveTool activeTool_ = ActiveTool::Select;
   TextEditor textEditor_;
   GlTextureCache textures_;
   RenderCoordinator renderCoordinator_;
@@ -236,6 +252,10 @@ private:
   std::vector<svg::SVGElement> lastReferenceHighlightSelection_;
   bool referenceHighlightActive_ = false;
   bool referenceHighlightChipHovered_ = false;
+  std::vector<StyleSourceContribution> styleSourceContributions_;
+  bool styleSourceDecorationsValid_ = false;
+  std::uint64_t styleSourceDecorationSourceVersion_ = 0;
+  std::string styleSourceDecorationText_;
   std::optional<Vector2d> renderContextMenuDocumentPoint_;
   std::optional<svg::SVGElement> renderContextMenuHitElement_;
   bool renderContextMenuOpenRequested_ = false;

--- a/donner/editor/FocusView.cc
+++ b/donner/editor/FocusView.cc
@@ -1306,6 +1306,7 @@ std::optional<FocusPartition> ComputeStyleFocusPartitionAtSourceOffset(
 ReferenceHighlightSummary ComputeReferenceHighlightSummary(
     const svg::SVGDocument& document, std::span<const svg::SVGElement> selectedElements) {
   ReferenceHighlightSummary summary;
+  [[maybe_unused]] const svg::DocumentReadAccess focusReadAccess = document.readAccess();
   if (!document.hasSourceStore() || selectedElements.empty()) {
     return summary;
   }

--- a/donner/editor/FocusView.cc
+++ b/donner/editor/FocusView.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <limits>
 #include <optional>
 #include <span>
 #include <string>
@@ -12,6 +13,7 @@
 
 #include "donner/base/FileOffset.h"
 #include "donner/base/xml/XMLNode.h"
+#include "donner/editor/ReferenceFanout.h"
 #include "donner/svg/ElementType.h"
 #include "donner/svg/SVGStyleQuery.h"
 
@@ -33,9 +35,15 @@ struct FocusCssRule {
   std::optional<ByteRange> stylesheetNodeRange;
 };
 
+struct ElementReferenceLink {
+  std::size_t fromOffset = 0;
+  svg::SVGElement referenced;
+  bool reverseReference = false;
+};
+
 struct FocusElementCollection {
   std::vector<svg::SVGElement> elements;
-  std::vector<std::pair<std::size_t, svg::SVGElement>> links;
+  std::vector<ElementReferenceLink> links;
   std::vector<FocusCssRule> cssRules;
   std::vector<FocusReferenceLink> cssLinks;
 };
@@ -109,6 +117,20 @@ std::optional<ByteRange> NodeRange(std::string_view source, const svg::SVGElemen
   return NodeRange(source, *xmlNode);
 }
 
+std::optional<ByteRange> OpeningTagRange(std::string_view source, const svg::SVGElement& element) {
+  std::optional<xml::XMLNode> xmlNode = xml::XMLNode::TryCast(element.entityHandle());
+  if (!xmlNode.has_value()) {
+    return std::nullopt;
+  }
+
+  std::optional<SourceRange> sourceRange = xmlNode->getOpeningTagLocation();
+  if (!sourceRange.has_value()) {
+    return std::nullopt;
+  }
+
+  return ResolveSourceRange(source, *sourceRange);
+}
+
 std::optional<ByteRange> NodeRangeForEntity(std::string_view source, Registry& registry,
                                             Entity entity) {
   std::optional<xml::XMLNode> xmlNode = xml::XMLNode::TryCast(EntityHandle(registry, entity));
@@ -117,16 +139,6 @@ std::optional<ByteRange> NodeRangeForEntity(std::string_view source, Registry& r
   }
 
   return NodeRange(source, *xmlNode);
-}
-
-std::optional<std::size_t> NodeStartOffset(std::string_view source,
-                                           const svg::SVGElement& element) {
-  std::optional<ByteRange> range = NodeRange(source, element);
-  if (!range.has_value()) {
-    return std::nullopt;
-  }
-
-  return range->start;
 }
 
 bool HasTreeComponent(const svg::SVGElement& element) {
@@ -449,11 +461,19 @@ bool IsRenderedStyleTarget(const svg::SVGElement& element) {
 
 void AppendImpactedElementsForStyleRule(const svg::SVGElement& root,
                                         const svg::SVGStyleRuleAtSourceOffset& sourceRule,
-                                        std::vector<svg::SVGElement>* impactedElements) {
+                                        std::vector<svg::SVGElement>* impactedElements,
+                                        std::size_t maxElements) {
+  if (impactedElements->size() > maxElements) {
+    return;
+  }
+
   if (IsRenderedStyleTarget(root)) {
     for (const svg::SVGMatchedStyleRule& match : svg::CollectMatchedStyleRules(root)) {
       if (MatchesStyleSourceRule(match, sourceRule)) {
         impactedElements->push_back(root);
+        if (impactedElements->size() > maxElements) {
+          return;
+        }
         break;
       }
     }
@@ -462,7 +482,10 @@ void AppendImpactedElementsForStyleRule(const svg::SVGElement& root,
   for (auto child = SafeFirstChild(root); child.has_value();) {
     svg::SVGElement current = *child;
     child = SafeNextSibling(current);
-    AppendImpactedElementsForStyleRule(current, sourceRule, impactedElements);
+    AppendImpactedElementsForStyleRule(current, sourceRule, impactedElements, maxElements);
+    if (impactedElements->size() > maxElements) {
+      return;
+    }
   }
 }
 
@@ -483,23 +506,57 @@ bool AddFocusElement(const svg::SVGElement& element, FocusElementCollection* res
 }
 
 void AddElementReferenceLink(std::size_t fromOffset, const svg::SVGElement& referenced,
-                             FocusElementCollection* result) {
+                             bool reverseReference, FocusElementCollection* result) {
   if (!HasLiveSvgTreeComponents(referenced)) {
     return;
   }
 
   const Entity referencedEntity = referenced.entityHandle().entity();
-  const auto it = std::ranges::find_if(result->links, [&](const auto& link) {
-    return link.first == fromOffset && link.second.entityHandle().entity() == referencedEntity;
+  const auto it = std::ranges::find_if(result->links, [&](const ElementReferenceLink& link) {
+    return link.fromOffset == fromOffset &&
+           link.referenced.entityHandle().entity() == referencedEntity &&
+           link.reverseReference == reverseReference;
   });
   if (it == result->links.end()) {
-    result->links.emplace_back(fromOffset, referenced);
+    result->links.push_back(ElementReferenceLink{
+        .fromOffset = fromOffset,
+        .referenced = referenced,
+        .reverseReference = reverseReference,
+    });
   }
 }
 
 void AddSourceReferenceLink(FocusReferenceLink link, std::vector<FocusReferenceLink>* links) {
   if (std::ranges::find(*links, link) == links->end()) {
     links->push_back(link);
+  }
+}
+
+std::optional<std::size_t> ReferenceLinkTargetOffset(std::string_view source,
+                                                     const svg::SVGElement& referenced);
+
+void AppendElementReferenceLinks(std::string_view source,
+                                 const std::vector<std::size_t>& lineStarts,
+                                 const std::vector<ElementReferenceLink>& links,
+                                 FocusPartition* partition) {
+  const std::size_t reverseLinkCount = std::ranges::count_if(
+      links, [](const ElementReferenceLink& link) { return link.reverseReference; });
+  const bool drawReverseLinks = !IsLargeReverseReferenceFanout(reverseLinkCount);
+
+  for (const ElementReferenceLink& link : links) {
+    if (link.reverseReference && !drawReverseLinks) {
+      continue;
+    }
+
+    std::optional<std::size_t> targetOffset = ReferenceLinkTargetOffset(source, link.referenced);
+    if (!targetOffset.has_value() || link.fromOffset > source.size()) {
+      continue;
+    }
+
+    partition->referenceLinks.push_back(FocusReferenceLink{
+        .from = PointForOffset(lineStarts, link.fromOffset),
+        .to = PointForOffset(lineStarts, *targetOffset),
+    });
   }
 }
 
@@ -542,6 +599,21 @@ bool IsReferenceResourceElement(const svg::SVGElement& element) {
   return tagName == "clipPath" || tagName == "filter" || tagName == "linearGradient" ||
          tagName == "marker" || tagName == "mask" || tagName == "pattern" ||
          tagName == "radialGradient" || tagName == "symbol" || HasAncestorNamed(element, "defs");
+}
+
+std::optional<std::size_t> ReferenceLinkTargetOffset(std::string_view source,
+                                                     const svg::SVGElement& referenced) {
+  if (IsReferenceResourceElement(referenced)) {
+    if (std::optional<ByteRange> openingTagRange = OpeningTagRange(source, referenced)) {
+      return openingTagRange->end;
+    }
+  }
+
+  if (std::optional<ByteRange> targetRange = NodeRange(source, referenced)) {
+    return targetRange->start;
+  }
+
+  return std::nullopt;
 }
 
 void MarkReverseExpandable(const svg::SVGElement& element,
@@ -669,7 +741,8 @@ void AppendReverseAttributeReferences(std::string_view source, const svg::SVGEle
     }
 
     if (reference.sourceOffset.has_value()) {
-      AddElementReferenceLink(*reference.sourceOffset, targetElement, result);
+      AddElementReferenceLink(*reference.sourceOffset, targetElement, /*reverseReference=*/true,
+                              result);
     }
     AddFocusElement(root, result, visited);
     MarkReverseExpandableIfResource(root, reverseExpandableEntities);
@@ -716,7 +789,8 @@ void AppendReverseCssReferences(std::string_view source, const std::vector<std::
 
         referencesTarget = true;
         if (reference.sourceOffset.has_value()) {
-          AddElementReferenceLink(*reference.sourceOffset, targetElement, result);
+          AddElementReferenceLink(*reference.sourceOffset, targetElement,
+                                  /*reverseReference=*/true, result);
         }
       }
 
@@ -754,14 +828,18 @@ void AppendReverseCssReferences(std::string_view source, const std::vector<std::
 
 void AppendReverseAttributeReferenceElements(std::string_view source, const svg::SVGElement& root,
                                              std::string_view targetId,
-                                             std::vector<svg::SVGElement>* elements) {
-  if (!HasLiveSvgTreeComponents(root)) {
+                                             std::vector<svg::SVGElement>* elements,
+                                             std::size_t maxElements) {
+  if (!HasLiveSvgTreeComponents(root) || elements->size() > maxElements) {
     return;
   }
 
   for (const FragmentReference& reference : ReferencedFragments(source, root)) {
     if (reference.fragmentId == targetId) {
       AddUniqueElement(root, elements);
+      if (elements->size() > maxElements) {
+        return;
+      }
       break;
     }
   }
@@ -769,14 +847,18 @@ void AppendReverseAttributeReferenceElements(std::string_view source, const svg:
   for (auto child = SafeFirstChild(root); child.has_value();) {
     svg::SVGElement current = *child;
     child = SafeNextSibling(current);
-    AppendReverseAttributeReferenceElements(source, current, targetId, elements);
+    AppendReverseAttributeReferenceElements(source, current, targetId, elements, maxElements);
+    if (elements->size() > maxElements) {
+      return;
+    }
   }
 }
 
 void AppendReverseCssReferenceElements(std::string_view source, const svg::SVGElement& root,
                                        std::string_view targetId,
-                                       std::vector<svg::SVGElement>* elements) {
-  if (!HasLiveSvgTreeComponents(root)) {
+                                       std::vector<svg::SVGElement>* elements,
+                                       std::size_t maxElements) {
+  if (!HasLiveSvgTreeComponents(root) || elements->size() > maxElements) {
     return;
   }
 
@@ -797,6 +879,9 @@ void AppendReverseCssReferenceElements(std::string_view source, const svg::SVGEl
             return reference.fragmentId == targetId;
           })) {
         AddUniqueElement(root, elements);
+        if (elements->size() > maxElements) {
+          return;
+        }
         break;
       }
     }
@@ -805,7 +890,10 @@ void AppendReverseCssReferenceElements(std::string_view source, const svg::SVGEl
   for (auto child = SafeFirstChild(root); child.has_value();) {
     svg::SVGElement current = *child;
     child = SafeNextSibling(current);
-    AppendReverseCssReferenceElements(source, current, targetId, elements);
+    AppendReverseCssReferenceElements(source, current, targetId, elements, maxElements);
+    if (elements->size() > maxElements) {
+      return;
+    }
   }
 }
 
@@ -842,7 +930,10 @@ FocusElementCollection CollectFocusElements(const svg::SVGDocument& document,
       }
 
       if (reference.sourceOffset.has_value()) {
-        AddElementReferenceLink(*reference.sourceOffset, *referenced, &result);
+        const bool reverseReference =
+            std::ranges::find(reverseProcessedIds, reference.fragmentId) !=
+            reverseProcessedIds.end();
+        AddElementReferenceLink(*reference.sourceOffset, *referenced, reverseReference, &result);
       }
 
       AddFocusElement(*referenced, &result, &visited);
@@ -852,6 +943,16 @@ FocusElementCollection CollectFocusElements(const svg::SVGDocument& document,
     if (currentId.empty() || !CanReverseExpand(current, reverseExpandableEntities) ||
         std::ranges::find(reverseProcessedIds, std::string_view(currentId)) !=
             reverseProcessedIds.end()) {
+      continue;
+    }
+
+    std::vector<svg::SVGElement> reverseReferenceElements;
+    AppendReverseAttributeReferenceElements(document.source(), root, std::string_view(currentId),
+                                            &reverseReferenceElements,
+                                            kMaxExpandedReverseReferences);
+    AppendReverseCssReferenceElements(document.source(), root, std::string_view(currentId),
+                                      &reverseReferenceElements, kMaxExpandedReverseReferences);
+    if (IsLargeReverseReferenceFanout(reverseReferenceElements.size())) {
       continue;
     }
 
@@ -1055,17 +1156,7 @@ FocusPartition ComputeFocusPartition(const svg::SVGDocument& document,
   partition.referenceLinks.insert(partition.referenceLinks.end(), focusElements.cssLinks.begin(),
                                   focusElements.cssLinks.end());
 
-  for (const auto& [fromOffset, referenced] : focusElements.links) {
-    std::optional<ByteRange> targetRange = NodeRange(source, referenced);
-    if (!targetRange.has_value() || fromOffset > source.size()) {
-      continue;
-    }
-
-    partition.referenceLinks.push_back(FocusReferenceLink{
-        .from = PointForOffset(lineStarts, fromOffset),
-        .to = PointForOffset(lineStarts, targetRange->start),
-    });
-  }
+  AppendElementReferenceLinks(source, lineStarts, focusElements.links, &partition);
 
   Normalize(&partition.fullColor);
   Normalize(&partition.referenceColor);
@@ -1111,12 +1202,17 @@ std::optional<StyleFocus> ComputeStyleFocusAtSourceOffset(const svg::SVGDocument
   const svg::SVGElement root = document.svgElement();
   Registry& registry = *root.entityHandle().registry();
   std::vector<svg::SVGElement> impactedElements;
-  AppendImpactedElementsForStyleRule(root, *sourceRule, &impactedElements);
+  AppendImpactedElementsForStyleRule(root, *sourceRule, &impactedElements,
+                                     kMaxExpandedReverseReferences);
+  const bool suppressReverseReferenceExpansion =
+      IsLargeReverseReferenceFanout(impactedElements.size());
 
   std::vector<FragmentReference> cssReferences;
   AppendCssFragmentReferences(source, *ruleRange, &cssReferences);
-  const FocusElementCollection focusElements =
-      CollectFocusElements(document, impactedElements, cssReferences, lineStarts);
+  FocusElementCollection focusElements;
+  if (!suppressReverseReferenceExpansion) {
+    focusElements = CollectFocusElements(document, impactedElements, cssReferences, lineStarts);
+  }
 
   FocusPartition partition;
   partition.fullColor.push_back(RangeToLines(lineStarts, *ruleRange));
@@ -1126,43 +1222,35 @@ std::optional<StyleFocus> ComputeStyleFocusAtSourceOffset(const svg::SVGDocument
     AddNodeTagLineRanges(source, lineStarts, *stylesheetNodeRange, &partition);
   }
 
-  for (const svg::SVGElement& element : focusElements.elements) {
-    if (std::optional<ByteRange> elementRange = NodeRange(source, element)) {
-      partition.referenceColor.push_back(RangeToLines(lineStarts, *elementRange));
+  if (!suppressReverseReferenceExpansion) {
+    for (const svg::SVGElement& element : focusElements.elements) {
+      if (std::optional<ByteRange> elementRange = NodeRange(source, element)) {
+        partition.referenceColor.push_back(RangeToLines(lineStarts, *elementRange));
+      }
+
+      std::ignore = AddAncestorTagLineRanges(source, lineStarts, element, &partition,
+                                             /*required=*/false);
     }
 
-    std::ignore = AddAncestorTagLineRanges(source, lineStarts, element, &partition,
-                                           /*required=*/false);
-  }
-
-  for (const FocusCssRule& cssRule : focusElements.cssRules) {
-    partition.referenceColor.push_back(RangeToLines(lineStarts, cssRule.ruleRange));
-    if (cssRule.stylesheetNodeRange.has_value()) {
-      AddNodeTagLineRanges(source, lineStarts, *cssRule.stylesheetNodeRange, &partition);
+    for (const FocusCssRule& cssRule : focusElements.cssRules) {
+      partition.referenceColor.push_back(RangeToLines(lineStarts, cssRule.ruleRange));
+      if (cssRule.stylesheetNodeRange.has_value()) {
+        AddNodeTagLineRanges(source, lineStarts, *cssRule.stylesheetNodeRange, &partition);
+      }
     }
-  }
-  partition.referenceLinks.insert(partition.referenceLinks.end(), focusElements.cssLinks.begin(),
-                                  focusElements.cssLinks.end());
+    partition.referenceLinks.insert(partition.referenceLinks.end(), focusElements.cssLinks.begin(),
+                                    focusElements.cssLinks.end());
 
-  for (const svg::SVGElement& element : focusElements.elements) {
-    if (std::optional<std::size_t> elementStart = NodeStartOffset(source, element)) {
-      partition.referenceLinks.push_back(FocusReferenceLink{
-          .from = PointForOffset(lineStarts, selectorRange->start),
-          .to = PointForOffset(lineStarts, *elementStart),
-      });
-    }
-  }
-
-  for (const auto& [fromOffset, referenced] : focusElements.links) {
-    std::optional<ByteRange> targetRange = NodeRange(source, referenced);
-    if (!targetRange.has_value() || fromOffset > source.size()) {
-      continue;
+    for (const svg::SVGElement& element : focusElements.elements) {
+      if (std::optional<std::size_t> elementStart = ReferenceLinkTargetOffset(source, element)) {
+        partition.referenceLinks.push_back(FocusReferenceLink{
+            .from = PointForOffset(lineStarts, selectorRange->start),
+            .to = PointForOffset(lineStarts, *elementStart),
+        });
+      }
     }
 
-    partition.referenceLinks.push_back(FocusReferenceLink{
-        .from = PointForOffset(lineStarts, fromOffset),
-        .to = PointForOffset(lineStarts, targetRange->start),
-    });
+    AppendElementReferenceLinks(source, lineStarts, focusElements.links, &partition);
   }
 
   Normalize(&partition.fullColor);
@@ -1177,7 +1265,9 @@ std::optional<StyleFocus> ComputeStyleFocusAtSourceOffset(const svg::SVGDocument
   partition.hidden = HiddenLineRanges(static_cast<int>(lineStarts.size()), visible);
   return StyleFocus{
       .partition = std::move(partition),
-      .impactedElements = std::move(impactedElements),
+      .impactedElements = suppressReverseReferenceExpansion ? std::vector<svg::SVGElement>{}
+                                                            : std::move(impactedElements),
+      .reverseReferenceExpansionSuppressed = suppressReverseReferenceExpansion,
   };
 }
 
@@ -1214,9 +1304,11 @@ ReferenceHighlightSummary ComputeReferenceHighlightSummary(
     }
 
     AppendReverseAttributeReferenceElements(source, root, std::string_view(id),
-                                            &summary.referencingElements);
+                                            &summary.referencingElements,
+                                            std::numeric_limits<std::size_t>::max());
     AppendReverseCssReferenceElements(source, root, std::string_view(id),
-                                      &summary.referencingElements);
+                                      &summary.referencingElements,
+                                      std::numeric_limits<std::size_t>::max());
     std::erase_if(summary.referencingElements, [&](const svg::SVGElement& element) {
       return element.entityHandle().entity() == selected.entityHandle().entity();
     });

--- a/donner/editor/FocusView.cc
+++ b/donner/editor/FocusView.cc
@@ -55,6 +55,12 @@ struct CssRuleKey {
   bool operator==(const CssRuleKey& other) const = default;
 };
 
+enum class FocusLinkSourceMode {
+  All,       ///< Links may originate from this element and descendants.
+  RootOnly,  ///< Links may originate from this element, but not descendants.
+  None,      ///< This subtree contributes context only, with no links.
+};
+
 std::optional<ByteRange> ResolveSourceRange(std::string_view source, const SourceRange& range) {
   const FileOffset start = range.start.resolveOffset(source);
   const FileOffset end = range.end.resolveOffset(source);
@@ -315,34 +321,10 @@ std::vector<FragmentReference> ReferencedFragments(std::string_view source,
   return result;
 }
 
-std::optional<std::size_t> AttributeValueStartOffset(std::string_view source,
-                                                     const xml::XMLNode& xmlNode,
-                                                     std::string_view attrName) {
-  if (std::optional<xml::XMLAttributeSourceLocation> location =
-          xmlNode.getAttributeSourceLocation(xml::XMLQualifiedNameRef(attrName))) {
-    if (std::optional<ByteRange> valueRange = ResolveSourceRange(source, location->valueRange)) {
-      return valueRange->start;
-    }
-  }
-
-  return std::nullopt;
-}
-
 std::optional<std::size_t> SelectorLinkSourceOffset(std::string_view source,
                                                     const svg::SVGElement& selected) {
-  std::optional<xml::XMLNode> xmlNode = xml::XMLNode::TryCast(selected.entityHandle());
-  if (!xmlNode.has_value()) {
-    return std::nullopt;
-  }
-
-  for (std::string_view attrName : {std::string_view("class"), std::string_view("id")}) {
-    if (std::optional<std::size_t> offset = AttributeValueStartOffset(source, *xmlNode, attrName)) {
-      return offset;
-    }
-  }
-
-  if (std::optional<ByteRange> nodeRange = NodeRange(source, selected)) {
-    return nodeRange->start;
+  if (std::optional<ByteRange> openingTagRange = OpeningTagRange(source, selected)) {
+    return openingTagRange->end;
   }
 
   return std::nullopt;
@@ -358,16 +340,31 @@ void AppendCssFragmentReferences(std::string_view source, ByteRange range,
                               references);
 }
 
-void AppendReferencedFragmentsInSubtree(std::string_view source, const svg::SVGElement& root,
-                                        std::vector<FragmentReference>* references) {
-  for (const FragmentReference& reference : ReferencedFragments(source, root)) {
-    references->push_back(reference);
+FocusLinkSourceMode ChildLinkSourceMode(FocusLinkSourceMode mode) {
+  return mode == FocusLinkSourceMode::All ? FocusLinkSourceMode::All : FocusLinkSourceMode::None;
+}
+
+void AppendFragmentReferences(std::vector<FragmentReference> input, FocusLinkSourceMode mode,
+                              std::vector<FragmentReference>* references) {
+  if (mode == FocusLinkSourceMode::None) {
+    for (FragmentReference& reference : input) {
+      reference.sourceOffset = std::nullopt;
+    }
   }
+
+  references->insert(references->end(), input.begin(), input.end());
+}
+
+void AppendReferencedFragmentsInSubtree(std::string_view source, const svg::SVGElement& root,
+                                        FocusLinkSourceMode linkSourceMode,
+                                        std::vector<FragmentReference>* references) {
+  AppendFragmentReferences(ReferencedFragments(source, root), linkSourceMode, references);
 
   for (auto child = SafeFirstChild(root); child.has_value();) {
     svg::SVGElement current = *child;
     child = SafeNextSibling(current);
-    AppendReferencedFragmentsInSubtree(source, current, references);
+    AppendReferencedFragmentsInSubtree(source, current, ChildLinkSourceMode(linkSourceMode),
+                                       references);
   }
 }
 
@@ -457,6 +454,11 @@ bool IsRenderedStyleTarget(const svg::SVGElement& element) {
     case svg::ElementType::Use: return true;
     default: return false;
   }
+}
+
+bool IsGroupElement(const svg::SVGElement& element) {
+  const std::optional<svg::ElementType> type = SafeElementType(element);
+  return type.has_value() && *type == svg::ElementType::G;
 }
 
 void AppendImpactedElementsForStyleRule(const svg::SVGElement& root,
@@ -682,12 +684,14 @@ void AppendMatchedCssRulesInSubtree(std::string_view source,
                                     const std::vector<std::size_t>& lineStarts,
                                     const svg::SVGElement& root, FocusElementCollection* result,
                                     std::vector<CssRuleKey>* visitedCssRules,
+                                    FocusLinkSourceMode linkSourceMode,
                                     std::vector<FragmentReference>* references) {
   if (!HasLiveSvgTreeComponents(root)) {
     return;
   }
 
   Registry& registry = *root.entityHandle().registry();
+  const bool emitLinks = linkSourceMode != FocusLinkSourceMode::None;
   const std::optional<std::size_t> selectorLinkSource = SelectorLinkSourceOffset(source, root);
   if (IsRenderedStyleTarget(root)) {
     for (const svg::SVGMatchedStyleRule& matchedRule : svg::CollectMatchedStyleRules(root)) {
@@ -705,7 +709,7 @@ void AppendMatchedCssRulesInSubtree(std::string_view source,
 
       AddMatchedCssRule(source, registry, matchedRule, result, visitedCssRules);
 
-      if (selectorLinkSource.has_value() && *selectorLinkSource <= source.size()) {
+      if (emitLinks && selectorLinkSource.has_value() && *selectorLinkSource <= source.size()) {
         AddSourceReferenceLink(
             FocusReferenceLink{
                 .from = PointForOffset(lineStarts, *selectorLinkSource),
@@ -714,7 +718,9 @@ void AppendMatchedCssRulesInSubtree(std::string_view source,
             &result->cssLinks);
       }
 
-      AppendCssFragmentReferences(source, *ruleRange, references);
+      std::vector<FragmentReference> ruleReferences;
+      AppendCssFragmentReferences(source, *ruleRange, &ruleReferences);
+      AppendFragmentReferences(std::move(ruleReferences), linkSourceMode, references);
     }
   }
 
@@ -722,7 +728,7 @@ void AppendMatchedCssRulesInSubtree(std::string_view source,
     svg::SVGElement current = *child;
     child = SafeNextSibling(current);
     AppendMatchedCssRulesInSubtree(source, lineStarts, current, result, visitedCssRules,
-                                   references);
+                                   ChildLinkSourceMode(linkSourceMode), references);
   }
 }
 
@@ -903,25 +909,34 @@ FocusElementCollection CollectFocusElements(const svg::SVGDocument& document,
                                             const std::vector<std::size_t>& lineStarts) {
   FocusElementCollection result;
   std::vector<Entity> visited;
+  std::vector<Entity> selectedGroupEntities;
   std::vector<Entity> reverseExpandableEntities;
   std::vector<std::string> reverseProcessedIds;
   std::vector<CssRuleKey> visitedCssRules;
   for (const svg::SVGElement& element : initialElements) {
     AddFocusElement(element, &result, &visited);
+    if (IsGroupElement(element)) {
+      selectedGroupEntities.push_back(element.entityHandle().entity());
+    }
     MarkReverseExpandableIfResource(element, &reverseExpandableEntities);
   }
 
   const svg::SVGElement root = document.svgElement();
   for (std::size_t i = 0; i < result.elements.size(); ++i) {
     const svg::SVGElement current = result.elements[i];
+    const Entity currentEntity = current.entityHandle().entity();
+    const bool currentIsSelectedGroup =
+        std::ranges::find(selectedGroupEntities, currentEntity) != selectedGroupEntities.end();
+    const FocusLinkSourceMode linkSourceMode =
+        currentIsSelectedGroup ? FocusLinkSourceMode::RootOnly : FocusLinkSourceMode::All;
     std::vector<FragmentReference> references;
     if (i == 0) {
       references.insert(references.end(), initialReferences.begin(), initialReferences.end());
     }
 
     AppendMatchedCssRulesInSubtree(document.source(), lineStarts, current, &result,
-                                   &visitedCssRules, &references);
-    AppendReferencedFragmentsInSubtree(document.source(), current, &references);
+                                   &visitedCssRules, linkSourceMode, &references);
+    AppendReferencedFragmentsInSubtree(document.source(), current, linkSourceMode, &references);
 
     for (const FragmentReference& reference : references) {
       std::optional<svg::SVGElement> referenced = FindElementById(root, reference.fragmentId);
@@ -979,8 +994,9 @@ void AppendForwardReferenceElements(const svg::SVGDocument& document,
   std::vector<CssRuleKey> ignoredCssRules;
   std::vector<FragmentReference> references;
   AppendMatchedCssRulesInSubtree(document.source(), lineStarts, element, &ignoredCollection,
-                                 &ignoredCssRules, &references);
-  AppendReferencedFragmentsInSubtree(document.source(), element, &references);
+                                 &ignoredCssRules, FocusLinkSourceMode::All, &references);
+  AppendReferencedFragmentsInSubtree(document.source(), element, FocusLinkSourceMode::All,
+                                     &references);
 
   const svg::SVGElement root = document.svgElement();
   for (const FragmentReference& reference : references) {
@@ -1019,6 +1035,17 @@ void AddNodeTagLineRanges(std::string_view source, const std::vector<std::size_t
                           ByteRange nodeRange, FocusPartition* partition) {
   for (ByteRange tagRange : AncestorTagRanges(source, nodeRange)) {
     partition->dimmed.push_back(RangeToLines(lineStarts, tagRange));
+  }
+}
+
+void AddXmlAncestorTagLineRanges(std::string_view source,
+                                 const std::vector<std::size_t>& lineStarts,
+                                 const xml::XMLNode& node, FocusPartition* partition) {
+  for (std::optional<xml::XMLNode> ancestor = node.parentElement(); ancestor.has_value();
+       ancestor = ancestor->parentElement()) {
+    if (std::optional<ByteRange> ancestorRange = NodeRange(source, *ancestor)) {
+      AddNodeTagLineRanges(source, lineStarts, *ancestorRange, partition);
+    }
   }
 }
 
@@ -1221,6 +1248,10 @@ std::optional<StyleFocus> ComputeStyleFocusAtSourceOffset(const svg::SVGDocument
           NodeRangeForEntity(source, registry, sourceRule->stylesheetEntity)) {
     AddNodeTagLineRanges(source, lineStarts, *stylesheetNodeRange, &partition);
   }
+  if (std::optional<xml::XMLNode> stylesheetNode =
+          xml::XMLNode::TryCast(EntityHandle(registry, sourceRule->stylesheetEntity))) {
+    AddXmlAncestorTagLineRanges(source, lineStarts, *stylesheetNode, &partition);
+  }
 
   if (!suppressReverseReferenceExpansion) {
     for (const svg::SVGElement& element : focusElements.elements) {
@@ -1240,15 +1271,6 @@ std::optional<StyleFocus> ComputeStyleFocusAtSourceOffset(const svg::SVGDocument
     }
     partition.referenceLinks.insert(partition.referenceLinks.end(), focusElements.cssLinks.begin(),
                                     focusElements.cssLinks.end());
-
-    for (const svg::SVGElement& element : focusElements.elements) {
-      if (std::optional<std::size_t> elementStart = ReferenceLinkTargetOffset(source, element)) {
-        partition.referenceLinks.push_back(FocusReferenceLink{
-            .from = PointForOffset(lineStarts, selectorRange->start),
-            .to = PointForOffset(lineStarts, *elementStart),
-        });
-      }
-    }
 
     AppendElementReferenceLinks(source, lineStarts, focusElements.links, &partition);
   }

--- a/donner/editor/FocusView.h
+++ b/donner/editor/FocusView.h
@@ -56,6 +56,7 @@ struct FocusPartition {
 struct StyleFocus {
   FocusPartition partition;                       ///< Source-pane partition for the matched rule.
   std::vector<svg::SVGElement> impactedElements;  ///< Elements matched by the selected rule.
+  bool reverseReferenceExpansionSuppressed = false;  ///< True when too many matches fan out.
 };
 
 /// Distinct same-document references related to the active selection.

--- a/donner/editor/OverlayRenderer.cc
+++ b/donner/editor/OverlayRenderer.cc
@@ -206,15 +206,17 @@ bool HasDisplayNoneInAncestorChain(const svg::SVGElement& element) {
 void AppendPathItems(std::span<const svg::SVGElement> elements,
                      std::vector<SelectionChromeSnapshot::PathItem>* out) {
   for (const auto& element : elements) {
-    for (const auto& geometry : CollectRenderableGeometry(element)) {
-      if (const auto spline = geometry.computedSpline(); spline.has_value()) {
-        SelectionChromeSnapshot::PathItem item;
-        const Transform2d documentFromElement = geometry.elementFromWorld();
-        item.pathDoc = TransformPathToDocument(*spline, documentFromElement);
-        item.displayNone = HasDisplayNoneInAncestorChain(geometry);
-        out->push_back(std::move(item));
+    element.withWriteAccess([&element, out](svg::DocumentWriteAccess&, EntityHandle) {
+      for (const auto& geometry : CollectRenderableGeometry(element)) {
+        if (const auto spline = geometry.computedSpline(); spline.has_value()) {
+          SelectionChromeSnapshot::PathItem item;
+          const Transform2d documentFromElement = geometry.elementFromWorld();
+          item.pathDoc = TransformPathToDocument(*spline, documentFromElement);
+          item.displayNone = HasDisplayNoneInAncestorChain(geometry);
+          out->push_back(std::move(item));
+        }
       }
-    }
+    });
   }
 }
 

--- a/donner/editor/PenTool.cc
+++ b/donner/editor/PenTool.cc
@@ -1,0 +1,370 @@
+#include "donner/editor/PenTool.h"
+
+#include <algorithm>
+#include <cmath>
+#include <string_view>
+#include <vector>
+
+#include "donner/base/FormatNumber.h"
+#include "donner/base/Path.h"
+#include "donner/editor/EditorApp.h"
+#include "donner/editor/EditorCommand.h"
+#include "donner/svg/SVGDocument.h"
+#include "donner/svg/SVGElement.h"
+#include "donner/svg/SVGSVGElement.h"
+#include "donner/svg/parser/PathParser.h"
+
+namespace donner::editor {
+
+namespace {
+
+constexpr double kClosePointScreenTolerance = 10.0;
+
+std::string FormatPoint(const Vector2d& point) {
+  return donner::detail::FormatNumberForSVG(point.x) + " " +
+         donner::detail::FormatNumberForSVG(point.y);
+}
+
+std::string MoveToPathData(const Vector2d& point) {
+  return "M " + FormatPoint(point);
+}
+
+bool HasMeaningfulHandle(const Vector2d& anchor, const std::optional<Vector2d>& handle) {
+  return handle.has_value() && std::hypot(handle->x - anchor.x, handle->y - anchor.y) > 1e-9;
+}
+
+}  // namespace
+
+void PenTool::onMouseDown(EditorApp& editor, const Vector2d& documentPoint,
+                          MouseModifiers modifiers) {
+  if (!editor.document().hasDocument()) {
+    cancel();
+    return;
+  }
+
+  if (!activePath_.has_value()) {
+    if (std::optional<OpenPathState> state = openStateForSelectedPath(editor); state.has_value()) {
+      continueSelectedPath(editor, editor.selectedElements().front().cast<svg::SVGPathElement>(),
+                           *state, documentPoint, modifiers);
+      return;
+    }
+
+    startNewPath(editor, documentPoint);
+    return;
+  }
+
+  if (shouldCloseAt(documentPoint, modifiers)) {
+    closePath(editor);
+    return;
+  }
+
+  appendLine(editor, constrainedPoint(documentPoint, modifiers));
+}
+
+void PenTool::onMouseMove(EditorApp& editor, const Vector2d& documentPoint, bool buttonHeld) {
+  (void)editor;
+  if (!buttonHeld || !draggingAnchor_) {
+    return;
+  }
+
+  updateDraggedAnchor(documentPoint);
+}
+
+void PenTool::onMouseUp(EditorApp& editor, const Vector2d& documentPoint) {
+  if (!draggingAnchor_) {
+    return;
+  }
+
+  updateDraggedAnchor(documentPoint);
+  draggingAnchor_ = false;
+  if (draggedAnchorChanged_) {
+    commitActivePathData(editor);
+  }
+  draggedAnchorChanged_ = false;
+}
+
+void PenTool::cancel() {
+  activePath_.reset();
+  anchors_.clear();
+  startPoint_ = Vector2d::Zero();
+  currentPoint_ = Vector2d::Zero();
+  activePathData_.clear();
+  closed_ = false;
+  draggingAnchor_ = false;
+  draggedAnchorChanged_ = false;
+  draggingAnchorIndex_ = 0;
+}
+
+std::optional<PenTool::OpenPathState> PenTool::openStateForSelectedPath(
+    const EditorApp& editor) const {
+  const std::vector<svg::SVGElement>& selected = editor.selectedElements();
+  if (selected.size() != 1u || !selected.front().isa<svg::SVGPathElement>()) {
+    return std::nullopt;
+  }
+
+  const svg::SVGPathElement pathElement = selected.front().cast<svg::SVGPathElement>();
+  const std::string pathData(std::string_view(pathElement.d()));
+  auto parsed = svg::parser::PathParser::Parse(pathData);
+  if (parsed.hasError() || !parsed.hasResult()) {
+    return std::nullopt;
+  }
+
+  const Path& path = parsed.result();
+  if (path.empty()) {
+    return std::nullopt;
+  }
+
+  std::vector<Anchor> anchors;
+  bool subpathOpen = false;
+  for (const Path::Command& command : path.commands()) {
+    switch (command.verb) {
+      case Path::Verb::MoveTo:
+        anchors.clear();
+        anchors.push_back(Anchor{.point = path.points()[command.pointIndex]});
+        subpathOpen = true;
+        break;
+      case Path::Verb::LineTo:
+        if (anchors.empty()) {
+          return std::nullopt;
+        }
+        anchors.push_back(Anchor{.point = path.points()[command.pointIndex]});
+        break;
+      case Path::Verb::QuadTo: {
+        if (anchors.empty()) {
+          return std::nullopt;
+        }
+        const Vector2d start = anchors.back().point;
+        const Vector2d control = path.points()[command.pointIndex];
+        const Vector2d end = path.points()[command.pointIndex + 1u];
+        anchors.back().outHandle = start + (control - start) * (2.0 / 3.0);
+        anchors.push_back(Anchor{
+            .point = end,
+            .inHandle = end + (control - end) * (2.0 / 3.0),
+        });
+        break;
+      }
+      case Path::Verb::CurveTo:
+        if (anchors.empty()) {
+          return std::nullopt;
+        }
+        anchors.back().outHandle = path.points()[command.pointIndex];
+        anchors.push_back(Anchor{
+            .point = path.points()[command.pointIndex + 2u],
+            .inHandle = path.points()[command.pointIndex + 1u],
+        });
+        break;
+      case Path::Verb::ClosePath: subpathOpen = false; break;
+    }
+  }
+
+  if (!subpathOpen || anchors.empty()) {
+    return std::nullopt;
+  }
+
+  return OpenPathState{.anchors = std::move(anchors)};
+}
+
+Vector2d PenTool::constrainedPoint(const Vector2d& documentPoint,
+                                   const MouseModifiers& modifiers) const {
+  if (!modifiers.shift || anchors_.empty()) {
+    return documentPoint;
+  }
+
+  const double dx = documentPoint.x - currentPoint_.x;
+  const double dy = documentPoint.y - currentPoint_.y;
+  if (std::abs(dx) >= std::abs(dy)) {
+    return Vector2d(documentPoint.x, currentPoint_.y);
+  }
+  return Vector2d(currentPoint_.x, documentPoint.y);
+}
+
+bool PenTool::shouldCloseAt(const Vector2d& documentPoint, const MouseModifiers& modifiers) const {
+  if (anchors_.size() < 3u) {
+    return false;
+  }
+
+  const double pixelsPerDocUnit = std::max(modifiers.pixelsPerDocUnit, 0.000001);
+  const double toleranceDoc = kClosePointScreenTolerance / pixelsPerDocUnit;
+  const double distance =
+      std::hypot(documentPoint.x - startPoint_.x, documentPoint.y - startPoint_.y);
+  return distance <= toleranceDoc;
+}
+
+std::string PenTool::serializePathData() const {
+  if (anchors_.empty()) {
+    return "";
+  }
+
+  std::string result = MoveToPathData(anchors_.front().point);
+  for (std::size_t i = 1; i < anchors_.size(); ++i) {
+    const Anchor& previous = anchors_[i - 1u];
+    const Anchor& current = anchors_[i];
+    const bool cubic = HasMeaningfulHandle(previous.point, previous.outHandle) ||
+                       HasMeaningfulHandle(current.point, current.inHandle);
+    result += " ";
+    if (cubic) {
+      result += "C ";
+      result += FormatPoint(previous.outHandle.value_or(previous.point));
+      result += " ";
+      result += FormatPoint(current.inHandle.value_or(current.point));
+      result += " ";
+      result += FormatPoint(current.point);
+    } else {
+      result += "L ";
+      result += FormatPoint(current.point);
+    }
+  }
+
+  if (closed_) {
+    result += " Z";
+  }
+  return result;
+}
+
+std::vector<PenTool::PreviewSegment> PenTool::previewSegments() const {
+  std::vector<PreviewSegment> result;
+  if (anchors_.size() < 2u) {
+    return result;
+  }
+
+  result.reserve(anchors_.size() - 1u);
+  for (std::size_t i = 1; i < anchors_.size(); ++i) {
+    const Anchor& previous = anchors_[i - 1u];
+    const Anchor& current = anchors_[i];
+    const bool cubic = HasMeaningfulHandle(previous.point, previous.outHandle) ||
+                       HasMeaningfulHandle(current.point, current.inHandle);
+    result.push_back(PreviewSegment{
+        .start = previous.point,
+        .control1 = previous.outHandle.value_or(previous.point),
+        .control2 = current.inHandle.value_or(current.point),
+        .end = current.point,
+        .cubic = cubic,
+    });
+  }
+  return result;
+}
+
+std::vector<Vector2d> PenTool::previewAnchors() const {
+  std::vector<Vector2d> result;
+  result.reserve(anchors_.size());
+  for (const Anchor& anchor : anchors_) {
+    result.push_back(anchor.point);
+  }
+  return result;
+}
+
+std::vector<PenTool::PreviewHandleLine> PenTool::previewHandleLines() const {
+  std::vector<PreviewHandleLine> result;
+  for (const Anchor& anchor : anchors_) {
+    if (HasMeaningfulHandle(anchor.point, anchor.inHandle)) {
+      result.push_back(PreviewHandleLine{.start = anchor.point, .end = *anchor.inHandle});
+    }
+    if (HasMeaningfulHandle(anchor.point, anchor.outHandle)) {
+      result.push_back(PreviewHandleLine{.start = anchor.point, .end = *anchor.outHandle});
+    }
+  }
+  return result;
+}
+
+void PenTool::startNewPath(EditorApp& editor, const Vector2d& documentPoint) {
+  svg::SVGDocument& document = editor.document().document();
+  svg::SVGPathElement path = svg::SVGPathElement::Create(document);
+  anchors_.clear();
+  anchors_.push_back(Anchor{.point = documentPoint});
+  closed_ = false;
+  rebuildActivePathData();
+  path.setAttribute("d", activePathData_);
+  const ActivePaintStyle& paintStyle = editor.activePaintStyle();
+  path.setAttribute("fill", paintStyle.fill);
+  path.setAttribute("stroke", paintStyle.stroke);
+  path.setAttribute("stroke-width", donner::detail::FormatNumberForSVG(paintStyle.strokeWidth));
+
+  startPoint_ = documentPoint;
+  currentPoint_ = documentPoint;
+  activePath_ = path;
+  beginDragLastAnchor();
+
+  svg::SVGElement parent = document.svgElement();
+  editor.applyMutation(EditorCommand::InsertElementCommand(parent, path));
+  editor.setSelection(path);
+}
+
+void PenTool::continueSelectedPath(EditorApp& editor, const svg::SVGPathElement& path,
+                                   const OpenPathState& state, const Vector2d& documentPoint,
+                                   const MouseModifiers& modifiers) {
+  activePath_ = path;
+  anchors_ = state.anchors;
+  closed_ = false;
+  startPoint_ = anchors_.front().point;
+  currentPoint_ = anchors_.back().point;
+  rebuildActivePathData();
+  if (shouldCloseAt(documentPoint, modifiers)) {
+    closePath(editor);
+    return;
+  }
+
+  appendLine(editor, constrainedPoint(documentPoint, modifiers));
+}
+
+void PenTool::rebuildActivePathData() {
+  activePathData_ = serializePathData();
+}
+
+void PenTool::beginDragLastAnchor() {
+  draggingAnchor_ = !anchors_.empty();
+  draggedAnchorChanged_ = false;
+  draggingAnchorIndex_ = anchors_.empty() ? 0u : anchors_.size() - 1u;
+}
+
+void PenTool::updateDraggedAnchor(const Vector2d& documentPoint) {
+  if (!draggingAnchor_ || draggingAnchorIndex_ >= anchors_.size()) {
+    return;
+  }
+
+  Anchor& anchor = anchors_[draggingAnchorIndex_];
+  const Vector2d delta = documentPoint - anchor.point;
+  if (std::hypot(delta.x, delta.y) <= 1e-9) {
+    return;
+  }
+
+  if (draggingAnchorIndex_ > 0u) {
+    anchor.inHandle = anchor.point - delta;
+  }
+  anchor.outHandle = anchor.point + delta;
+  draggedAnchorChanged_ = true;
+  rebuildActivePathData();
+}
+
+void PenTool::commitActivePathData(EditorApp& editor) {
+  if (!activePath_.has_value()) {
+    return;
+  }
+
+  editor.applyMutation(EditorCommand::SetAttributeCommand(*activePath_, "d", activePathData_));
+  editor.setSelection(*activePath_);
+}
+
+void PenTool::appendLine(EditorApp& editor, const Vector2d& documentPoint) {
+  if (!activePath_.has_value()) {
+    return;
+  }
+
+  anchors_.push_back(Anchor{.point = documentPoint});
+  currentPoint_ = documentPoint;
+  rebuildActivePathData();
+  commitActivePathData(editor);
+  beginDragLastAnchor();
+}
+
+void PenTool::closePath(EditorApp& editor) {
+  if (!activePath_.has_value()) {
+    return;
+  }
+
+  closed_ = true;
+  rebuildActivePathData();
+  commitActivePathData(editor);
+  cancel();
+}
+
+}  // namespace donner::editor

--- a/donner/editor/PenTool.h
+++ b/donner/editor/PenTool.h
@@ -1,0 +1,122 @@
+#pragma once
+/// @file
+///
+/// Prototype path authoring tool. `PenTool` creates source-backed `<path>`
+/// elements and appends straight line segments from document-space clicks.
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "donner/base/Vector2.h"
+#include "donner/editor/Tool.h"
+#include "donner/svg/SVGPathElement.h"
+
+namespace donner::editor {
+
+/// Click-to-place path authoring tool.
+///
+/// The prototype supports polyline creation, shift-constrained points,
+/// continuing a selected open `<path>`, and closing an active path by
+/// clicking near its first point.
+class PenTool final : public Tool {
+public:
+  /// Preview segment for immediate pen-tool chrome.
+  struct PreviewSegment {
+    Vector2d start = Vector2d::Zero();
+    Vector2d control1 = Vector2d::Zero();
+    Vector2d control2 = Vector2d::Zero();
+    Vector2d end = Vector2d::Zero();
+    bool cubic = false;
+  };
+
+  /// Preview line connecting an anchor to one of its control handles.
+  struct PreviewHandleLine {
+    Vector2d start = Vector2d::Zero();
+    Vector2d end = Vector2d::Zero();
+  };
+
+  /// Handle a click in document space.
+  ///
+  /// @param editor Editor state and mutation queue.
+  /// @param documentPoint Click location in SVG document coordinates.
+  /// @param modifiers Modifier-key state for the click.
+  void onMouseDown(EditorApp& editor, const Vector2d& documentPoint,
+                   MouseModifiers modifiers) override;
+
+  /// Handle pointer movement; currently unused by the prototype.
+  ///
+  /// @param editor Editor state and mutation queue.
+  /// @param documentPoint Pointer location in SVG document coordinates.
+  /// @param buttonHeld Whether the left mouse button is down.
+  void onMouseMove(EditorApp& editor, const Vector2d& documentPoint, bool buttonHeld) override;
+
+  /// Handle mouse release; currently unused by the prototype.
+  ///
+  /// @param editor Editor state and mutation queue.
+  /// @param documentPoint Release location in SVG document coordinates.
+  void onMouseUp(EditorApp& editor, const Vector2d& documentPoint) override;
+
+  /// Cancel the in-progress path without modifying the current document.
+  void cancel();
+
+  /// Whether the tool is currently appending to a path.
+  [[nodiscard]] bool isDrafting() const { return activePath_.has_value(); }
+
+  /// Whether the current mouse drag is shaping the most recently placed anchor.
+  [[nodiscard]] bool isDraggingAnchor() const { return draggingAnchor_; }
+
+  /// Current path data for tests and UI diagnostics.
+  [[nodiscard]] const std::string& activePathData() const { return activePathData_; }
+
+  /// Path preview segments for immediate render-pane chrome.
+  [[nodiscard]] std::vector<PreviewSegment> previewSegments() const;
+
+  /// Anchor positions for immediate render-pane chrome.
+  [[nodiscard]] std::vector<Vector2d> previewAnchors() const;
+
+  /// Handle guide lines for immediate render-pane chrome.
+  [[nodiscard]] std::vector<PreviewHandleLine> previewHandleLines() const;
+
+private:
+  struct Anchor {
+    Vector2d point = Vector2d::Zero();
+    std::optional<Vector2d> inHandle;
+    std::optional<Vector2d> outHandle;
+  };
+
+  struct OpenPathState {
+    std::vector<Anchor> anchors;
+  };
+
+  [[nodiscard]] std::optional<OpenPathState> openStateForSelectedPath(
+      const EditorApp& editor) const;
+  [[nodiscard]] Vector2d constrainedPoint(const Vector2d& documentPoint,
+                                          const MouseModifiers& modifiers) const;
+  [[nodiscard]] bool shouldCloseAt(const Vector2d& documentPoint,
+                                   const MouseModifiers& modifiers) const;
+  [[nodiscard]] std::string serializePathData() const;
+  void startNewPath(EditorApp& editor, const Vector2d& documentPoint);
+  void continueSelectedPath(EditorApp& editor, const svg::SVGPathElement& path,
+                            const OpenPathState& state, const Vector2d& documentPoint,
+                            const MouseModifiers& modifiers);
+  void rebuildActivePathData();
+  void beginDragLastAnchor();
+  void updateDraggedAnchor(const Vector2d& documentPoint);
+  void commitActivePathData(EditorApp& editor);
+  void appendLine(EditorApp& editor, const Vector2d& documentPoint);
+  void closePath(EditorApp& editor);
+
+  std::optional<svg::SVGPathElement> activePath_;
+  std::vector<Anchor> anchors_;
+  Vector2d startPoint_ = Vector2d::Zero();
+  Vector2d currentPoint_ = Vector2d::Zero();
+  std::string activePathData_;
+  bool closed_ = false;
+  bool draggingAnchor_ = false;
+  bool draggedAnchorChanged_ = false;
+  std::size_t draggingAnchorIndex_ = 0;
+};
+
+}  // namespace donner::editor

--- a/donner/editor/ReferenceFanout.h
+++ b/donner/editor/ReferenceFanout.h
@@ -1,0 +1,26 @@
+#pragma once
+/// @file
+
+#include <cstddef>
+#include <string_view>
+
+namespace donner::editor {
+
+/// Maximum number of reverse references that source focus expands directly.
+inline constexpr std::size_t kMaxExpandedReverseReferences = 5;
+
+/// Tooltip shown when a reverse-reference fanout is too large to expand.
+inline constexpr std::string_view kReverseReferenceOverflowTooltip =
+    "Too many reverse refs to draw lines";
+
+/**
+ * Return true when a reverse-reference fanout should stay summarized.
+ *
+ * @param count Number of reverse references or selector-matched elements.
+ * @return True when expanding the fanout would be too noisy or expensive.
+ */
+[[nodiscard]] constexpr bool IsLargeReverseReferenceFanout(std::size_t count) {
+  return count > kMaxExpandedReverseReferences;
+}
+
+}  // namespace donner::editor

--- a/donner/editor/RenderCoordinator.cc
+++ b/donner/editor/RenderCoordinator.cc
@@ -62,7 +62,7 @@ std::optional<SelectTool::ActiveDragPreview> OverlayDragPreviewForSelection(
   }
 
   return SelectTool::ActiveDragPreview{
-      .entity = app.selectedElement()->entityHandle().entity(),
+      .entity = app.selectedElement()->unsafeEntityHandle().entity(),
       .translation = Vector2d::Zero(),
   };
 }

--- a/donner/editor/RopeSimulation.cc
+++ b/donner/editor/RopeSimulation.cc
@@ -1,0 +1,564 @@
+#include "donner/editor/RopeSimulation.h"
+
+#include <algorithm>
+#include <cmath>
+#include <numbers>
+#include <vector>
+
+namespace donner::editor {
+
+namespace {
+
+constexpr double kMinDistance = 1e-6;
+constexpr double kMaxCoshArgument = 24.0;
+constexpr double kNominalStepSeconds = 1.0 / 60.0;
+constexpr double kMaxCatchUpSeconds = 0.25;
+
+double UnitFromSeed(std::uint32_t seed) {
+  seed ^= seed >> 16u;
+  seed *= 0x7feb352du;
+  seed ^= seed >> 15u;
+  seed *= 0x846ca68bu;
+  seed ^= seed >> 16u;
+  return static_cast<double>(seed & 0xffffu) / static_cast<double>(0xffffu);
+}
+
+double PolylineLength(std::span<const Vector2d> route) {
+  double result = 0.0;
+  for (std::size_t i = 1; i < route.size(); ++i) {
+    result += route[i - 1].distance(route[i]);
+  }
+  return result;
+}
+
+Vector2d SamplePolyline(std::span<const Vector2d> route, double distance) {
+  if (route.empty()) {
+    return Vector2d();
+  }
+
+  double consumed = 0.0;
+  for (std::size_t i = 1; i < route.size(); ++i) {
+    const Vector2d segment = route[i] - route[i - 1];
+    const double segmentLength = segment.length();
+    if (segmentLength <= kMinDistance) {
+      continue;
+    }
+
+    if (consumed + segmentLength >= distance) {
+      const double t = std::clamp((distance - consumed) / segmentLength, 0.0, 1.0);
+      return route[i - 1] + segment * t;
+    }
+
+    consumed += segmentLength;
+  }
+
+  return route.back();
+}
+
+double AverageSpeed(std::span<const Vector2d> positions, std::span<const Vector2d> previous) {
+  if (positions.size() <= 2 || positions.size() != previous.size()) {
+    return 0.0;
+  }
+
+  double total = 0.0;
+  for (std::size_t i = 1; i + 1 < positions.size(); ++i) {
+    total += positions[i].distance(previous[i]);
+  }
+  return total / static_cast<double>(positions.size() - 2u);
+}
+
+double MaxDistance(std::span<const Vector2d> positions, std::span<const Vector2d> reference) {
+  if (positions.size() != reference.size()) {
+    return 0.0;
+  }
+
+  double result = 0.0;
+  for (std::size_t i = 0; i < positions.size(); ++i) {
+    result = std::max(result, positions[i].distance(reference[i]));
+  }
+  return result;
+}
+
+Vector2d ClampLength(const Vector2d& value, double maxLength) {
+  if (maxLength <= 0.0) {
+    return Vector2d();
+  }
+
+  const double length = value.length();
+  return length > maxLength ? value * (maxLength / length) : value;
+}
+
+double EffectiveDampingRetention(double activeTimeSeconds, const RopeSimulationOptions& options) {
+  const double baseRetention = std::clamp(options.damping, 0.0, 1.0);
+  const double targetSeconds = std::max(0.0, options.settleTimeSeconds);
+  if (activeTimeSeconds <= targetSeconds) {
+    return baseRetention;
+  }
+
+  const double overdueRetention = std::clamp(options.overdueDamping, 0.0, 1.0);
+  const double rampSeconds = std::max(0.0, options.overdueDampingRampSeconds);
+  const double ramp = rampSeconds <= kMinDistance
+                          ? 1.0
+                          : std::clamp((activeTimeSeconds - targetSeconds) / rampSeconds, 0.0, 1.0);
+  return baseRetention + (overdueRetention - baseRetention) * ramp;
+}
+
+double SafeCosh(double value) {
+  return std::cosh(std::clamp(value, -kMaxCoshArgument, kMaxCoshArgument));
+}
+
+std::vector<Vector2d> BuildFallbackCatenaryRoute(const Vector2d& start, const Vector2d& end,
+                                                 int particleCount, double sag) {
+  std::vector<Vector2d> route;
+  route.reserve(static_cast<std::size_t>(particleCount));
+  for (int i = 0; i < particleCount; ++i) {
+    const double t =
+        particleCount <= 1 ? 0.0 : static_cast<double>(i) / static_cast<double>(particleCount - 1);
+    const Vector2d chord = start + (end - start) * t;
+    route.push_back(Vector2d(chord.x, chord.y + sag * std::sin(std::numbers::pi * t)));
+  }
+  return route;
+}
+
+std::vector<Vector2d> BuildCatenaryRoute(const Vector2d& start, const Vector2d& end,
+                                         const RopeSimulationOptions& options) {
+  const int segmentCount = std::max(1, options.segmentCount);
+  const int particleCount = segmentCount + 1;
+  const double chordLength = start.distance(end);
+  const double slack =
+      std::clamp(std::max(options.catenaryMinSlackPx, chordLength * options.catenarySlackRatio),
+                 0.0, std::max(0.0, options.catenaryMaxSlackPx));
+  const double sag = std::max(slack * 0.65, 4.0);
+
+  if (std::abs(end.x - start.x) <= kMinDistance || chordLength <= kMinDistance) {
+    return BuildFallbackCatenaryRoute(start, end, particleCount, sag);
+  }
+
+  const bool reversed = end.x < start.x;
+  const Vector2d left = reversed ? end : start;
+  const Vector2d right = reversed ? start : end;
+  const double horizontalDistance = right.x - left.x;
+  const double verticalDistance = right.y - left.y;
+  const double arcLength = std::max(chordLength + slack, chordLength + kMinDistance);
+  const double horizontalCatenaryDistance = std::sqrt(
+      std::max(kMinDistance, arcLength * arcLength - verticalDistance * verticalDistance));
+  if (horizontalCatenaryDistance <= horizontalDistance + kMinDistance) {
+    return BuildFallbackCatenaryRoute(start, end, particleCount, sag);
+  }
+
+  double lo = horizontalDistance / 1000.0;
+  double hi = std::max(horizontalDistance, 1.0);
+  const auto catenaryDistanceForA = [horizontalDistance](double a) {
+    return 2.0 * a * std::sinh(std::clamp(horizontalDistance / (2.0 * a), 0.0, kMaxCoshArgument));
+  };
+
+  while (catenaryDistanceForA(hi) > horizontalCatenaryDistance) {
+    hi *= 2.0;
+  }
+
+  for (int i = 0; i < 64; ++i) {
+    const double mid = (lo + hi) * 0.5;
+    if (catenaryDistanceForA(mid) > horizontalCatenaryDistance) {
+      lo = mid;
+    } else {
+      hi = mid;
+    }
+  }
+
+  const double a = (lo + hi) * 0.5;
+  const double midX = (left.x + right.x) * 0.5;
+  const double x0 = midX + a * std::asinh(verticalDistance / horizontalCatenaryDistance);
+  const double c = left.y + a * SafeCosh((left.x - x0) / a);
+
+  std::vector<Vector2d> route;
+  route.reserve(static_cast<std::size_t>(particleCount));
+  for (int i = 0; i < particleCount; ++i) {
+    const double t =
+        particleCount <= 1 ? 0.0 : static_cast<double>(i) / static_cast<double>(particleCount - 1);
+    const double x = left.x + horizontalDistance * t;
+    const double y = c - a * SafeCosh((x - x0) / a);
+    route.push_back(Vector2d(x, y));
+  }
+
+  if (reversed) {
+    std::reverse(route.begin(), route.end());
+  }
+
+  return route;
+}
+
+}  // namespace
+
+void RopeSimulation::reset(std::span<const Vector2d> route, const RopeSimulationOptions& options) {
+  if (route.size() < 2) {
+    positions_.clear();
+    previousPositions_.clear();
+    restPositions_.clear();
+    restLengths_.clear();
+    catenaryRest_ = false;
+    sleep();
+    return;
+  }
+
+  const int segmentCount = std::max(1, options.segmentCount);
+  const int particleCount = segmentCount + 1;
+  positions_.assign(static_cast<std::size_t>(particleCount), route.front());
+
+  const double totalLength = PolylineLength(route);
+  if (totalLength <= kMinDistance) {
+    std::fill(positions_.begin(), positions_.end(), route.front());
+  } else {
+    for (int i = 0; i < particleCount; ++i) {
+      const double distance =
+          totalLength * static_cast<double>(i) / static_cast<double>(segmentCount);
+      positions_[static_cast<std::size_t>(i)] = SamplePolyline(route, distance);
+    }
+  }
+
+  previousPositions_ = positions_;
+  restPositions_ = positions_;
+  hasAnchors_ = true;
+  lastStart_ = positions_.front();
+  lastEnd_ = positions_.back();
+  restLengths_.assign(static_cast<std::size_t>(segmentCount), 0.0);
+  for (int i = 0; i < segmentCount; ++i) {
+    restLengths_[static_cast<std::size_t>(i)] = positions_[static_cast<std::size_t>(i)].distance(
+        positions_[static_cast<std::size_t>(i + 1)]);
+  }
+  previousStepSeconds_ = std::max(kMinDistance, options.maxDeltaTime);
+  catenaryRest_ = false;
+  wake();
+}
+
+void RopeSimulation::resetCatenary(const Vector2d& start, const Vector2d& end,
+                                   const RopeSimulationOptions& options) {
+  const std::vector<Vector2d> route = BuildCatenaryRoute(start, end, options);
+  reset(route, options);
+  positions_.front() = start;
+  positions_.back() = end;
+  previousPositions_ = positions_;
+  restPositions_ = positions_;
+  lastStart_ = start;
+  lastEnd_ = end;
+  hasAnchors_ = true;
+  catenaryRest_ = true;
+  sleep();
+}
+
+void RopeSimulation::applyImpulse(const Vector2d& impulse) {
+  if (positions_.size() < 3 || previousPositions_.size() != positions_.size()) {
+    return;
+  }
+  if (impulse.lengthSquared() <= kMinDistance * kMinDistance) {
+    return;
+  }
+
+  for (std::size_t i = 1; i + 1 < positions_.size(); ++i) {
+    const double normalized = static_cast<double>(i) / static_cast<double>(positions_.size() - 1u);
+    const double envelope = std::sin(std::numbers::pi * normalized);
+    previousPositions_[i] -= impulse * envelope;
+  }
+  previousStepSeconds_ = kNominalStepSeconds;
+  wake();
+}
+
+void RopeSimulation::applyBottomImpulse(const Vector2d& impulse, double normalizedWidth) {
+  if (positions_.size() < 3 || previousPositions_.size() != positions_.size()) {
+    return;
+  }
+  if (impulse.lengthSquared() <= kMinDistance * kMinDistance) {
+    return;
+  }
+
+  std::size_t bottomIndex = 1;
+  for (std::size_t i = 2; i + 1 < positions_.size(); ++i) {
+    if (positions_[i].y > positions_[bottomIndex].y) {
+      bottomIndex = i;
+    }
+  }
+
+  const double center =
+      static_cast<double>(bottomIndex) / static_cast<double>(positions_.size() - 1u);
+  const double width = std::clamp(normalizedWidth, 0.02, 1.0);
+  for (std::size_t i = 1; i + 1 < positions_.size(); ++i) {
+    const double normalized = static_cast<double>(i) / static_cast<double>(positions_.size() - 1u);
+    const double distance = (normalized - center) / width;
+    const double envelope = std::exp(-0.5 * distance * distance);
+    previousPositions_[i] -= impulse * envelope;
+  }
+  previousStepSeconds_ = kNominalStepSeconds;
+  wake();
+}
+
+void RopeSimulation::update(const Vector2d& start, const Vector2d& end, double deltaTimeSeconds,
+                            double scrollDeltaY, double timeSeconds, std::uint32_t phaseSeed,
+                            bool frozen, const RopeSimulationOptions& options) {
+  if (positions_.size() < 2 || previousPositions_.size() != positions_.size() ||
+      restLengths_.size() + 1u != positions_.size()) {
+    resetCatenary(start, end, options);
+  }
+
+  const bool endpointMoved = applyEndpointMotion(start, end, options, frozen);
+  positions_.front() = start;
+  positions_.back() = end;
+  lastStart_ = start;
+  lastEnd_ = end;
+  hasAnchors_ = true;
+  if (frozen) {
+    previousPositions_ = positions_;
+    return;
+  }
+
+  const bool scrolled = std::abs(scrollDeltaY) > 0.001;
+  if (endpointMoved || scrolled) {
+    wake();
+  }
+  if (settled_) {
+    previousPositions_ = positions_;
+    return;
+  }
+
+  const double maxStep = std::max(kMinDistance, options.maxDeltaTime);
+  double remaining = std::clamp(deltaTimeSeconds, 0.0, std::max(kMaxCatchUpSeconds, maxStep));
+  const double frameStartTime = timeSeconds - remaining;
+  double elapsedThisFrame = 0.0;
+  bool applyScrollImpulse = scrolled;
+  if (remaining <= kMinDistance) {
+    solveConstraints(start, end, options);
+    return;
+  }
+
+  while (remaining > kMinDistance && !settled_) {
+    const double deltaTime = std::min(remaining, maxStep);
+    const double averageStepMotion = AverageSpeed(positions_, previousPositions_);
+    const bool applyIdleSway = !catenaryRest_ &&
+                               activeTimeSeconds_ < std::max(0.0, options.settleTimeSeconds) &&
+                               averageStepMotion <= options.idleSwayMaxSpeed;
+    const double phase = UnitFromSeed(phaseSeed) * 2.0 * std::numbers::pi;
+    const double angularFrequency = 2.0 * std::numbers::pi * options.idleSwayFrequencyHz;
+    const double stepTimeSeconds = frameStartTime + elapsedThisFrame + deltaTime;
+    const double damping = std::pow(EffectiveDampingRetention(activeTimeSeconds_, options),
+                                    deltaTime / kNominalStepSeconds);
+    const double velocityScale =
+        previousStepSeconds_ > kMinDistance ? deltaTime / previousStepSeconds_ : 1.0;
+
+    for (std::size_t i = 1; i + 1 < positions_.size(); ++i) {
+      if (applyScrollImpulse) {
+        const double scrollImpulse =
+            std::clamp(scrollDeltaY * options.scrollResponse, -options.maxScrollImpulsePx,
+                       options.maxScrollImpulsePx);
+        previousPositions_[i].y -= scrollImpulse;
+      }
+
+      Vector2d velocity = (positions_[i] - previousPositions_[i]) * (velocityScale * damping);
+      previousPositions_[i] = positions_[i];
+
+      Vector2d acceleration(0.0, catenaryRest_ ? 0.0 : options.gravityPxPerSec2);
+      if (catenaryRest_ && restPositions_.size() == positions_.size()) {
+        acceleration += (restPositions_[i] - positions_[i]) *
+                        std::max(0.0, options.catenaryRestoringForcePerSec2);
+      }
+      if (applyIdleSway) {
+        const double normalized =
+            static_cast<double>(i) / static_cast<double>(positions_.size() - 1u);
+        const double envelope = std::sin(std::numbers::pi * normalized);
+        acceleration.x += options.idleSwayPxPerSec2 * envelope *
+                          std::sin(angularFrequency * stepTimeSeconds + phase + normalized * 1.7);
+      }
+
+      positions_[i] += velocity + acceleration * (deltaTime * deltaTime);
+    }
+
+    const std::vector<Vector2d> beforeConstraints = positions_;
+    solveConstraints(start, end, options);
+    for (std::size_t i = 1; i + 1 < positions_.size(); ++i) {
+      previousPositions_[i] += positions_[i] - beforeConstraints[i];
+    }
+    previousPositions_.front() = positions_.front();
+    previousPositions_.back() = positions_.back();
+    const double solvedStepMotion = AverageSpeed(positions_, previousPositions_);
+    const double restDistance = catenaryRest_ ? MaxDistance(positions_, restPositions_) : 0.0;
+    const bool closeToRest =
+        !catenaryRest_ || restDistance <= std::max(0.0, options.settleRestDistanceThresholdPx);
+    previousStepSeconds_ = deltaTime;
+    activeTimeSeconds_ += deltaTime;
+    if (solvedStepMotion <= std::max(0.0, options.settleMotionThresholdPx) && closeToRest) {
+      stillTimeSeconds_ += deltaTime;
+    } else {
+      stillTimeSeconds_ = 0.0;
+    }
+    elapsedThisFrame += deltaTime;
+    remaining -= deltaTime;
+    applyScrollImpulse = false;
+
+    if (stillTimeSeconds_ >= std::max(0.0, options.settleStillnessSeconds)) {
+      if (catenaryRest_ && restPositions_.size() == positions_.size()) {
+        positions_ = restPositions_;
+        positions_.front() = start;
+        positions_.back() = end;
+      }
+      sleep();
+    }
+  }
+}
+
+Path RopeSimulation::toPath(const RopeSimulationOptions& options) const {
+  PathBuilder builder;
+  if (positions_.empty()) {
+    return builder.build();
+  }
+
+  builder.moveTo(positions_.front());
+  if (positions_.size() == 1u) {
+    return builder.build();
+  }
+
+  if (positions_.size() == 2u) {
+    builder.lineTo(positions_.back());
+    return builder.build();
+  }
+
+  const double tension = std::clamp(options.bezierTension, 0.0, 1.0);
+  for (std::size_t i = 1; i + 1 < positions_.size(); ++i) {
+    const Vector2d midpoint = (positions_[i] + positions_[i + 1u]) * 0.5;
+    const Vector2d relaxedControl = (builder.currentPoint() + midpoint) * 0.5;
+    const Vector2d control = relaxedControl + (positions_[i] - relaxedControl) * tension;
+    builder.quadTo(control, midpoint);
+  }
+  builder.quadTo(positions_[positions_.size() - 2u], positions_.back());
+
+  return builder.build();
+}
+
+Vector2d RopeSimulation::endTangent() const {
+  if (positions_.size() < 2) {
+    return Vector2d::XAxis();
+  }
+
+  for (std::size_t i = positions_.size() - 1u; i > 0; --i) {
+    const Vector2d tangent = positions_[i] - positions_[i - 1u];
+    if (tangent.lengthSquared() > kMinDistance * kMinDistance) {
+      return tangent;
+    }
+  }
+
+  return Vector2d::XAxis();
+}
+
+void RopeSimulation::retargetCatenaryRest(const Vector2d& start, const Vector2d& end,
+                                          const RopeSimulationOptions& options) {
+  if (positions_.size() < 2) {
+    return;
+  }
+
+  const std::vector<Vector2d> route = BuildCatenaryRoute(start, end, options);
+  restPositions_.assign(positions_.size(), start);
+  const double totalLength = PolylineLength(route);
+  if (totalLength <= kMinDistance) {
+    std::fill(restPositions_.begin(), restPositions_.end(), start);
+  } else {
+    for (std::size_t i = 0; i < restPositions_.size(); ++i) {
+      const double distance =
+          totalLength * static_cast<double>(i) / static_cast<double>(restPositions_.size() - 1u);
+      restPositions_[i] = SamplePolyline(route, distance);
+    }
+  }
+
+  restPositions_.front() = start;
+  restPositions_.back() = end;
+  restLengths_.assign(positions_.size() - 1u, 0.0);
+  for (std::size_t i = 0; i + 1 < restPositions_.size(); ++i) {
+    restLengths_[i] = restPositions_[i].distance(restPositions_[i + 1u]);
+  }
+  catenaryRest_ = true;
+}
+
+void RopeSimulation::solveConstraints(const Vector2d& start, const Vector2d& end,
+                                      const RopeSimulationOptions& options) {
+  if (positions_.size() < 2 || restLengths_.size() + 1u != positions_.size()) {
+    return;
+  }
+
+  const int iterationCount = std::max(0, options.constraintIterations);
+  for (int iteration = 0; iteration < iterationCount; ++iteration) {
+    positions_.front() = start;
+    positions_.back() = end;
+
+    for (std::size_t i = 0; i + 1 < positions_.size(); ++i) {
+      const Vector2d delta = positions_[i + 1u] - positions_[i];
+      const double distance = delta.length();
+      if (distance <= kMinDistance) {
+        continue;
+      }
+
+      const double correction = (distance - restLengths_[i]) / distance;
+      const Vector2d offset = delta * (0.5 * correction);
+      if (i == 0) {
+        positions_[i + 1u] -= offset * 2.0;
+      } else if (i + 2u == positions_.size()) {
+        positions_[i] += offset * 2.0;
+      } else {
+        positions_[i] += offset;
+        positions_[i + 1u] -= offset;
+      }
+    }
+  }
+
+  positions_.front() = start;
+  positions_.back() = end;
+}
+
+bool RopeSimulation::applyEndpointMotion(const Vector2d& start, const Vector2d& end,
+                                         const RopeSimulationOptions& options, bool frozen) {
+  if (!hasAnchors_ || positions_.size() < 3 || previousPositions_.size() != positions_.size()) {
+    return false;
+  }
+
+  const Vector2d startDelta = start - lastStart_;
+  const Vector2d endDelta = end - lastEnd_;
+  if (startDelta.lengthSquared() + endDelta.lengthSquared() <= kMinDistance * kMinDistance) {
+    return false;
+  }
+
+  const double follow = frozen ? 1.0 : std::clamp(options.endpointFollow, 0.0, 1.0);
+  const double impulseScale = frozen ? 0.0 : std::max(0.0, options.endpointImpulse);
+  retargetCatenaryRest(start, end, options);
+  const double velocityRetention =
+      frozen ? 0.0 : std::clamp(options.endpointMotionVelocityRetention, 0.0, 1.0);
+  const double catenaryBlend = frozen ? 0.0 : std::clamp(options.endpointCatenaryBlend, 0.0, 1.0);
+  for (std::size_t i = 1; i + 1 < positions_.size(); ++i) {
+    const double normalized = static_cast<double>(i) / static_cast<double>(positions_.size() - 1u);
+    const Vector2d anchorDelta = startDelta * (1.0 - normalized) + endDelta * normalized;
+    const Vector2d carriedDelta = anchorDelta * follow;
+    positions_[i] += carriedDelta;
+    previousPositions_[i] += carriedDelta;
+    if (restPositions_.size() == positions_.size() && catenaryBlend > 0.0) {
+      const Vector2d velocity = positions_[i] - previousPositions_[i];
+      positions_[i] += (restPositions_[i] - positions_[i]) * catenaryBlend;
+      previousPositions_[i] = positions_[i] - velocity * velocityRetention;
+    } else {
+      const Vector2d velocity = positions_[i] - previousPositions_[i];
+      previousPositions_[i] = positions_[i] - velocity * velocityRetention;
+    }
+
+    const double envelope = std::sin(std::numbers::pi * normalized);
+    const Vector2d impulse =
+        ClampLength(anchorDelta * impulseScale, std::max(0.0, options.maxEndpointImpulsePx));
+    previousPositions_[i] -= impulse * envelope;
+  }
+  return !frozen;
+}
+
+void RopeSimulation::wake() {
+  activeTimeSeconds_ = 0.0;
+  stillTimeSeconds_ = 0.0;
+  settled_ = false;
+}
+
+void RopeSimulation::sleep() {
+  previousPositions_ = positions_;
+  stillTimeSeconds_ = 0.0;
+  settled_ = true;
+}
+
+}  // namespace donner::editor

--- a/donner/editor/RopeSimulation.h
+++ b/donner/editor/RopeSimulation.h
@@ -1,0 +1,143 @@
+#pragma once
+/// @file
+
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "donner/base/Path.h"
+#include "donner/base/Vector2.h"
+
+namespace donner::editor {
+
+/// Tunable parameters for text-view reference rope simulation.
+struct RopeSimulationOptions {
+  int segmentCount = 18;              ///< Number of simulated rope segments.
+  int constraintIterations = 7;       ///< Distance-constraint solve iterations per frame.
+  double gravityPxPerSec2 = 55.0;     ///< Downward acceleration in screen pixels per second.
+  double damping = 0.985;             ///< Verlet velocity retained per 60 Hz simulation step.
+  double scrollResponse = 0.35;       ///< Extra inertia impulse from source-pane scrolling.
+  double maxScrollImpulsePx = 4.0;    ///< Maximum per-frame scroll impulse in screen pixels.
+  double idleSwayPxPerSec2 = 18.0;    ///< Low-speed horizontal idle sway acceleration.
+  double idleSwayFrequencyHz = 0.45;  ///< Idle sway frequency.
+  double idleSwayMaxSpeed = 6.0;      ///< Average substep particle motion under which sway applies.
+  double maxDeltaTime = 1.0 / 60.0;   ///< Largest fixed simulation substep.
+  double settleTimeSeconds = 5.0;     ///< Target damping window after a disturbance.
+  double settleMotionThresholdPx = 0.01;         ///< Average substep motion treated as still.
+  double settleStillnessSeconds = 0.25;          ///< Stillness duration required before sleeping.
+  double settleRestDistanceThresholdPx = 0.5;    ///< Max distance from rest shape before sleep.
+  double overdueDamping = 0.45;                  ///< Velocity retained after missed settle target.
+  double overdueDampingRampSeconds = 1.5;        ///< Seconds to ramp into overdue damping.
+  double catenaryRestoringForcePerSec2 = 540.0;  ///< Restoring force toward catenary rest shape.
+  double bezierTension = 1.0;                    ///< Quadratic Bézier smoothing tension in [0, 1].
+  double catenarySlackRatio = 0.10;   ///< Extra catenary length as a ratio of endpoint distance.
+  double catenaryMinSlackPx = 18.0;   ///< Minimum extra catenary length in screen pixels.
+  double catenaryMaxSlackPx = 70.0;   ///< Maximum extra catenary length in screen pixels.
+  double initialImpulsePx = 0.2;      ///< Subtle initial velocity displacement in screen pixels.
+  double endpointFollow = 0.82;       ///< Fraction of endpoint movement carried into the body.
+  double endpointImpulse = 0.02;      ///< Extra body velocity from endpoint movement.
+  double maxEndpointImpulsePx = 1.0;  ///< Clamp for per-frame endpoint-movement impulse.
+  double endpointMotionVelocityRetention = 0.35;  ///< Velocity retained after endpoints move.
+  double endpointCatenaryBlend = 0.10;            ///< Body blend toward new catenary rest shape.
+};
+
+/// Small fixed-endpoint Verlet rope simulation used by source reference connectors.
+class RopeSimulation {
+public:
+  /// Construct an empty rope simulation.
+  RopeSimulation() = default;
+
+  /**
+   * Reset this rope by sampling \p route into evenly spaced simulated particles.
+   *
+   * @param route Polyline route from fixed start to fixed end.
+   * @param options Simulation options controlling segment count and smoothing.
+   */
+  void reset(std::span<const Vector2d> route, const RopeSimulationOptions& options);
+
+  /**
+   * Reset this rope to a catenary between fixed endpoints.
+   *
+   * The resulting rest lengths come from the sampled catenary, so gravity and
+   * distance constraints settle toward the same hanging-curve family instead
+   * of a pre-routed polyline. The rope starts asleep with zero velocity;
+   * callers may wake it with \ref applyBottomImpulse or endpoint motion.
+   *
+   * @param start Fixed rope start point in screen coordinates.
+   * @param end Fixed rope end point in screen coordinates.
+   * @param options Simulation options controlling slack and segment count.
+   */
+  void resetCatenary(const Vector2d& start, const Vector2d& end,
+                     const RopeSimulationOptions& options);
+
+  /**
+   * Add an instantaneous velocity impulse to interior rope particles.
+   *
+   * @param impulse Screen-space velocity displacement applied with a sine envelope.
+   */
+  void applyImpulse(const Vector2d& impulse);
+
+  /**
+   * Add a localized velocity impulse centered on the lowest interior particle.
+   *
+   * @param impulse Screen-space velocity displacement at the catenary bottom.
+   * @param normalizedWidth Sine-normalized falloff width in [0, 1].
+   */
+  void applyBottomImpulse(const Vector2d& impulse, double normalizedWidth);
+
+  /**
+   * Advance the rope by one frame.
+   *
+   * @param start Fixed rope start point in screen coordinates.
+   * @param end Fixed rope end point in screen coordinates.
+   * @param deltaTimeSeconds Frame delta time in seconds.
+   * @param scrollDeltaY Source-pane vertical scroll delta since the previous frame.
+   * @param timeSeconds Monotonic UI time in seconds, used for idle sway phase.
+   * @param phaseSeed Stable per-rope seed used to desynchronize idle sway.
+   * @param frozen If true, skip integration and keep the rope body stable for interaction.
+   * @param options Simulation options.
+   */
+  void update(const Vector2d& start, const Vector2d& end, double deltaTimeSeconds,
+              double scrollDeltaY, double timeSeconds, std::uint32_t phaseSeed, bool frozen,
+              const RopeSimulationOptions& options);
+
+  /// Return the simulated particle positions.
+  [[nodiscard]] std::span<const Vector2d> points() const { return positions_; }
+
+  /// Return true when this rope has no particles.
+  [[nodiscard]] bool empty() const { return positions_.empty(); }
+
+  /// Return true when this rope still needs timed animation frames.
+  [[nodiscard]] bool needsAnimation() const { return !settled_ && positions_.size() >= 2u; }
+
+  /// Convert the current rope body into a Bézier path.
+  [[nodiscard]] Path toPath(const RopeSimulationOptions& options) const;
+
+  /// Return the final segment tangent for orienting an arrowhead.
+  [[nodiscard]] Vector2d endTangent() const;
+
+private:
+  void retargetCatenaryRest(const Vector2d& start, const Vector2d& end,
+                            const RopeSimulationOptions& options);
+  void solveConstraints(const Vector2d& start, const Vector2d& end,
+                        const RopeSimulationOptions& options);
+  [[nodiscard]] bool applyEndpointMotion(const Vector2d& start, const Vector2d& end,
+                                         const RopeSimulationOptions& options, bool frozen);
+  void wake();
+  void sleep();
+
+  std::vector<Vector2d> positions_;
+  std::vector<Vector2d> previousPositions_;
+  std::vector<Vector2d> restPositions_;
+  std::vector<double> restLengths_;
+  Vector2d lastStart_;
+  Vector2d lastEnd_;
+  double activeTimeSeconds_ = 0.0;
+  double stillTimeSeconds_ = 0.0;
+  double previousStepSeconds_ = 1.0 / 60.0;
+  bool hasAnchors_ = false;
+  bool catenaryRest_ = false;
+  bool settled_ = true;
+};
+
+}  // namespace donner::editor

--- a/donner/editor/RotateCursorSet.cc
+++ b/donner/editor/RotateCursorSet.cc
@@ -14,6 +14,7 @@
 #include "donner/base/ParseWarningSink.h"
 #include "donner/editor/PanClosedCursorSvg.h"
 #include "donner/editor/PanCursorSvg.h"
+#include "donner/editor/PenCursorSvg.h"
 #include "donner/editor/RotateCursorSvg.h"
 #include "donner/svg/parser/SVGParser.h"
 #include "donner/svg/renderer/Renderer.h"
@@ -27,6 +28,8 @@ constexpr int kCursorRasterScale = 4;
 constexpr int kCursorRasterSizePx = kCursorSizePx * kCursorRasterScale;
 constexpr int kCursorHotspotPx = 16;
 constexpr int kPanCursorHotspotPx = 15;
+constexpr int kPenCursorHotspotXPx = 4;
+constexpr int kPenCursorHotspotYPx = 4;
 constexpr std::string_view kRotationPlaceholder = "rotate(0,16,16)";
 
 bool ReplaceFirst(std::string* text, std::string_view needle, std::string_view replacement) {
@@ -94,6 +97,18 @@ std::string BuildPanCursorSvg(PanCursorKind kind) {
                  embedded::kPanClosedCursorSvg.size());
       break;
   }
+
+  std::ostringstream rasterSize;
+  rasterSize << kCursorRasterSizePx;
+  const std::string rasterSizeText = rasterSize.str();
+  ReplaceFirst(&svg, R"svg(width="32")svg", std::string("width=\"") + rasterSizeText + "\"");
+  ReplaceFirst(&svg, R"svg(height="32")svg", std::string("height=\"") + rasterSizeText + "\"");
+  return svg;
+}
+
+std::string BuildPenCursorSvg() {
+  std::string svg(reinterpret_cast<const char*>(embedded::kPenCursorSvg.data()),
+                  embedded::kPenCursorSvg.size());
 
   std::ostringstream rasterSize;
   rasterSize << kCursorRasterSizePx;
@@ -200,6 +215,11 @@ std::optional<RotateCursorImage> RenderPanCursorImage(
   return RenderImageFromSvg(BuildPanCursorSvg(kind), std::move(geodeDevice));
 }
 
+std::optional<RotateCursorImage> RenderPenCursorImage(
+    std::shared_ptr<geode::GeodeDevice> geodeDevice) {
+  return RenderImageFromSvg(BuildPenCursorSvg(), std::move(geodeDevice));
+}
+
 RotateCursorSet::~RotateCursorSet() {
   destroy();
 }
@@ -259,6 +279,23 @@ bool RotateCursorSet::initialize(GLFWwindow* window,
     panCursors_[PanCursorIndex(kind)] = cursor;
   }
 
+  std::optional<RotateCursorImage> penImage = RenderPenCursorImage(geodeDevice);
+  if (!penImage.has_value()) {
+    destroy();
+    return false;
+  }
+
+  GLFWimage glfwImage{
+      .width = penImage->width,
+      .height = penImage->height,
+      .pixels = penImage->rgba.data(),
+  };
+  penCursor_ = glfwCreateCursor(&glfwImage, kPenCursorHotspotXPx, kPenCursorHotspotYPx);
+  if (penCursor_ == nullptr) {
+    destroy();
+    return false;
+  }
+
   valid_ = true;
   return true;
 }
@@ -293,6 +330,16 @@ bool RotateCursorSet::setPanCursor(PanCursorKind kind) {
   return true;
 }
 
+bool RotateCursorSet::setPenCursor() {
+  if (!valid_ || window_ == nullptr || penCursor_ == nullptr) {
+    return false;
+  }
+
+  glfwSetCursor(window_, penCursor_);
+  customCursorActive_ = true;
+  return true;
+}
+
 void RotateCursorSet::clearIfActive() {
   if (!customCursorActive_ || window_ == nullptr) {
     return;
@@ -315,6 +362,10 @@ void RotateCursorSet::destroy() {
       glfwDestroyCursor(cursor);
       cursor = nullptr;
     }
+  }
+  if (penCursor_ != nullptr) {
+    glfwDestroyCursor(penCursor_);
+    penCursor_ = nullptr;
   }
   window_ = nullptr;
   valid_ = false;

--- a/donner/editor/RotateCursorSet.h
+++ b/donner/editor/RotateCursorSet.h
@@ -48,6 +48,12 @@ enum class PanCursorKind {
 [[nodiscard]] std::optional<RotateCursorImage> RenderPanCursorImage(
     PanCursorKind kind, std::shared_ptr<geode::GeodeDevice> geodeDevice);
 
+/// Render the pen-tool cursor SVG to straight-alpha RGBA pixels.
+///
+/// @param geodeDevice Shared Geode device for Geode editor builds.
+[[nodiscard]] std::optional<RotateCursorImage> RenderPenCursorImage(
+    std::shared_ptr<geode::GeodeDevice> geodeDevice);
+
 /// RAII owner for the editor's custom cursors.
 class RotateCursorSet {
 public:
@@ -79,6 +85,11 @@ public:
   /// @return true if a custom cursor was available and applied.
   [[nodiscard]] bool setPanCursor(PanCursorKind kind);
 
+  /// Set the custom pen-tool cursor.
+  ///
+  /// @return true if a custom cursor was available and applied.
+  [[nodiscard]] bool setPenCursor();
+
   /// Restore GLFW's default cursor if a custom cursor is active.
   void clearIfActive();
 
@@ -91,6 +102,7 @@ private:
   GLFWwindow* window_ = nullptr;
   std::array<GLFWcursor*, 4> rotateCursors_ = {};
   std::array<GLFWcursor*, 2> panCursors_ = {};
+  GLFWcursor* penCursor_ = nullptr;
   bool customCursorActive_ = false;
   bool valid_ = false;
 };

--- a/donner/editor/SelectionAabb.cc
+++ b/donner/editor/SelectionAabb.cc
@@ -128,7 +128,9 @@ std::vector<Box2d> SnapshotGeometryWorldBounds(
 
 std::vector<svg::SVGGeometryElement> CollectRenderableGeometry(const svg::SVGElement& root) {
   std::vector<svg::SVGGeometryElement> out;
-  CollectRenderableGeometryImpl(root, out);
+  root.withReadAccess([&out, &root](svg::DocumentReadAccess&, EntityHandle) {
+    CollectRenderableGeometryImpl(root, out);
+  });
   return out;
 }
 
@@ -142,17 +144,21 @@ std::vector<Box2d> SnapshotSelectionWorldBounds(std::span<const svg::SVGElement>
     // `<g filter>` it unions every descendant shape so the AABB
     // envelopes the visible group.
     std::optional<Box2d> merged;
-    for (const auto& geometry : CollectRenderableGeometry(element)) {
-      const auto wb = geometry.worldBounds();
-      if (!wb.has_value()) {
-        continue;
+    element.withWriteAccess([&element, &merged](svg::DocumentWriteAccess&, EntityHandle) {
+      std::vector<svg::SVGGeometryElement> geometryElements;
+      CollectRenderableGeometryImpl(element, geometryElements);
+      for (const auto& geometry : geometryElements) {
+        const auto wb = geometry.worldBounds();
+        if (!wb.has_value()) {
+          continue;
+        }
+        if (merged.has_value()) {
+          merged->addBox(*wb);
+        } else {
+          merged = *wb;
+        }
       }
-      if (merged.has_value()) {
-        merged->addBox(*wb);
-      } else {
-        merged = *wb;
-      }
-    }
+    });
     if (merged.has_value()) {
       bounds.push_back(*merged);
     }
@@ -168,14 +174,17 @@ std::vector<Box2d> SnapshotSelectionOccludingWorldBounds(
   }
 
   svg::SVGElement selected = selection.front();
-  if (!HasLiveSvgTreeComponents(selected)) {
-    return {};
-  }
+  return selected.withWriteAccess(
+      [&selected](svg::DocumentWriteAccess&, EntityHandle) -> std::vector<Box2d> {
+        if (!HasLiveSvgTreeComponents(selected)) {
+          return {};
+        }
 
-  const svg::SVGElement root = selected.ownerDocument().svgElement();
-  const std::vector<svg::SVGGeometryElement> laterGeometry =
-      CollectLaterRenderableGeometry(root, selected);
-  return SnapshotGeometryWorldBounds(laterGeometry);
+        const svg::SVGElement root = selected.ownerDocument().svgElement();
+        const std::vector<svg::SVGGeometryElement> laterGeometry =
+            CollectLaterRenderableGeometry(root, selected);
+        return SnapshotGeometryWorldBounds(laterGeometry);
+      });
 }
 
 void PromoteSelectionBoundsIfReady(SelectionBoundsCache& cache, std::uint64_t displayedDocVersion) {

--- a/donner/editor/SidebarPresenter.cc
+++ b/donner/editor/SidebarPresenter.cc
@@ -1,6 +1,7 @@
 #include "donner/editor/SidebarPresenter.h"
 
 #include <algorithm>
+#include <array>
 #include <limits>
 #include <sstream>
 #include <string>
@@ -111,6 +112,156 @@ void RenderInspectorSection(const char* heading, const char* tableId,
     }
     ImGui::EndTable();
   }
+}
+
+struct PathOperationButton {
+  PathOperationKind operation;
+  const char* id;
+  const char* tooltip;
+};
+
+constexpr std::array<PathOperationButton, 5> kPathOperationButtons = {{
+    {.operation = PathOperationKind::Union, .id = "##path_operation_union", .tooltip = "Union"},
+    {.operation = PathOperationKind::Intersect,
+     .id = "##path_operation_intersect",
+     .tooltip = "Intersect"},
+    {.operation = PathOperationKind::SubtractFront,
+     .id = "##path_operation_subtract_front",
+     .tooltip = "Subtract Front"},
+    {.operation = PathOperationKind::SubtractBack,
+     .id = "##path_operation_subtract_back",
+     .tooltip = "Subtract Back"},
+    {.operation = PathOperationKind::Exclude,
+     .id = "##path_operation_exclude",
+     .tooltip = "Exclude"},
+}};
+
+void RenderPathOperationIcon(PathOperationKind operation, ImVec2 min, ImVec2 max, ImU32 iconColor) {
+  ImDrawList* drawList = ImGui::GetWindowDrawList();
+  const float w = max.x - min.x;
+  const float h = max.y - min.y;
+  const float left = min.x + w * 0.28f;
+  const float top = min.y + h * 0.28f;
+  const float right = min.x + w * 0.60f;
+  const float bottom = min.y + h * 0.60f;
+  const ImVec2 a0(left, top);
+  const ImVec2 a1(right, bottom);
+  const ImVec2 b0(min.x + w * 0.42f, min.y + h * 0.42f);
+  const ImVec2 b1(min.x + w * 0.74f, min.y + h * 0.74f);
+  const ImVec2 overlap0(b0.x, b0.y);
+  const ImVec2 overlap1(a1.x, a1.y);
+  const float strokeWidth = 1.6f;
+
+  switch (operation) {
+    case PathOperationKind::Union:
+      drawList->AddRect(a0, a1, iconColor, 2.0f, 0, strokeWidth);
+      drawList->AddRect(b0, b1, iconColor, 2.0f, 0, strokeWidth);
+      drawList->AddLine(ImVec2(a0.x, b0.y), ImVec2(b0.x, b0.y), iconColor, strokeWidth);
+      drawList->AddLine(ImVec2(b0.x, a0.y), ImVec2(b0.x, b0.y), iconColor, strokeWidth);
+      break;
+    case PathOperationKind::Intersect:
+      drawList->AddRect(a0, a1, iconColor, 2.0f, 0, strokeWidth);
+      drawList->AddRect(b0, b1, iconColor, 2.0f, 0, strokeWidth);
+      drawList->AddRectFilled(overlap0, overlap1, iconColor, 1.0f);
+      break;
+    case PathOperationKind::SubtractFront:
+      drawList->AddRect(a0, a1, iconColor, 2.0f, 0, strokeWidth);
+      drawList->AddRect(b0, b1, iconColor, 2.0f, 0, strokeWidth);
+      drawList->AddLine(ImVec2(b0.x + 1.0f, b0.y), ImVec2(b1.x - 1.0f, b1.y), iconColor,
+                        strokeWidth);
+      break;
+    case PathOperationKind::SubtractBack:
+      drawList->AddRect(a0, a1, iconColor, 2.0f, 0, strokeWidth);
+      drawList->AddRect(b0, b1, iconColor, 2.0f, 0, strokeWidth);
+      drawList->AddLine(ImVec2(a0.x + 1.0f, a0.y), ImVec2(a1.x - 1.0f, a1.y), iconColor,
+                        strokeWidth);
+      break;
+    case PathOperationKind::Exclude:
+      drawList->AddRect(a0, a1, iconColor, 2.0f, 0, strokeWidth);
+      drawList->AddRect(b0, b1, iconColor, 2.0f, 0, strokeWidth);
+      drawList->AddLine(overlap0, overlap1, iconColor, strokeWidth);
+      drawList->AddLine(ImVec2(overlap1.x, overlap0.y), ImVec2(overlap0.x, overlap1.y), iconColor,
+                        strokeWidth);
+      break;
+  }
+}
+
+bool RenderPathOperationsPanel(EditorApp* liveApp) {
+  ImGui::Separator();
+  ImGui::TextUnformatted("Path Operations");
+
+  bool queuedMutation = false;
+  const ImVec2 buttonSize(30.0f, 26.0f);
+  for (std::size_t i = 0; i < kPathOperationButtons.size(); ++i) {
+    const PathOperationButton& button = kPathOperationButtons[i];
+    const PathOperationAvailability availability =
+        liveApp != nullptr
+            ? liveApp->pathOperationAvailability(button.operation)
+            : PathOperationAvailability{.canApply = false, .reason = "Rendering in progress"};
+
+    if (i > 0) {
+      ImGui::SameLine();
+    }
+
+    if (!availability.canApply) {
+      ImGui::BeginDisabled();
+    }
+    if (ImGui::Button(button.id, buttonSize) && liveApp != nullptr &&
+        liveApp->applyPathOperation(button.operation)) {
+      queuedMutation = true;
+    }
+    if (!availability.canApply) {
+      ImGui::EndDisabled();
+    }
+
+    if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+      if (availability.canApply) {
+        ImGui::SetTooltip("%s", button.tooltip);
+      } else {
+        ImGui::SetTooltip("%s: %s", button.tooltip, availability.reason.c_str());
+      }
+    }
+
+    const ImU32 iconColor = availability.canApply ? ImGui::GetColorU32(ImGuiCol_Text)
+                                                  : ImGui::GetColorU32(ImGuiCol_TextDisabled);
+    RenderPathOperationIcon(button.operation, ImGui::GetItemRectMin(), ImGui::GetItemRectMax(),
+                            iconColor);
+  }
+
+  return queuedMutation;
+}
+
+double FirstSelectedStrokeWidth(const EditorApp& app) {
+  const std::vector<svg::SVGElement>& selection = app.selectedElements();
+  if (selection.empty()) {
+    return 1.0;
+  }
+
+  return selection.front().getComputedStyle().strokeWidth.getRequired().value;
+}
+
+bool RenderStrokeControlsPanel(EditorApp* liveApp) {
+  ImGui::Separator();
+  ImGui::TextUnformatted("Stroke");
+
+  const bool canEdit = liveApp != nullptr && liveApp->hasSelection();
+  float strokeWidth = canEdit ? static_cast<float>(FirstSelectedStrokeWidth(*liveApp)) : 1.0f;
+
+  if (!canEdit) {
+    ImGui::BeginDisabled();
+  }
+  ImGui::SetNextItemWidth(96.0f);
+  const bool changed = ImGui::DragFloat("Width", &strokeWidth, 0.1f, 0.0f, 200.0f, "%.2f");
+  if (!canEdit) {
+    ImGui::EndDisabled();
+  }
+
+  if (changed && liveApp != nullptr) {
+    liveApp->setActiveStrokeWidth(strokeWidth);
+    return liveApp->setStrokeWidthOnSelection(strokeWidth);
+  }
+
+  return false;
 }
 
 }  // namespace
@@ -259,9 +410,18 @@ void SidebarPresenter::renderTreeView(EditorApp* liveApp, TreeViewState& state) 
   renderTreeNode(liveApp, *treeSnapshot_, state);
 }
 
-void SidebarPresenter::renderInspector(const ViewportState& viewport) const {
+bool SidebarPresenter::renderInspector(EditorApp* liveApp, const ViewportState& viewport) const {
+  bool queuedMutation = false;
   if (!inspectorSnapshot_.hasSelection) {
-    ImGui::TextDisabled("Select a single element to inspect attributes.");
+    if (liveApp != nullptr && liveApp->selectedElements().size() > 1u) {
+      ImGui::Text("%zu elements selected", liveApp->selectedElements().size());
+      queuedMutation = RenderStrokeControlsPanel(liveApp);
+      queuedMutation = RenderPathOperationsPanel(liveApp) || queuedMutation;
+    } else {
+      ImGui::TextDisabled("Select a single element to inspect attributes.");
+      queuedMutation = RenderStrokeControlsPanel(liveApp);
+      queuedMutation = RenderPathOperationsPanel(liveApp) || queuedMutation;
+    }
   } else {
     ImGui::TextUnformatted(inspectorSnapshot_.titleText.c_str());
     if (inspectorSnapshot_.bounds.has_value()) {
@@ -274,10 +434,12 @@ void SidebarPresenter::renderInspector(const ViewportState& viewport) const {
       ImGui::Text("Transform: [%.3f %.3f %.3f %.3f  %.2f %.2f]", xform.data[0], xform.data[1],
                   xform.data[2], xform.data[3], xform.data[4], xform.data[5]);
     }
+    queuedMutation = RenderStrokeControlsPanel(liveApp);
     RenderInspectorSection("XML attributes", "##inspector_xml_attributes",
                            inspectorSnapshot_.xmlAttributes);
     RenderInspectorSection("Computed style", "##inspector_computed_style",
                            inspectorSnapshot_.computedStyle);
+    queuedMutation = RenderPathOperationsPanel(liveApp) || queuedMutation;
   }
   ImGui::Separator();
   ImGui::Text("Zoom: %.0f%%", viewport.zoom * 100.0);
@@ -288,6 +450,7 @@ void SidebarPresenter::renderInspector(const ViewportState& viewport) const {
   ImGui::TextDisabled("Cmd+scroll = zoom");
   ImGui::TextDisabled("space+drag = pan");
   ImGui::TextDisabled("Cmd+0 = 100%%");
+  return queuedMutation;
 }
 
 }  // namespace donner::editor

--- a/donner/editor/SidebarPresenter.cc
+++ b/donner/editor/SidebarPresenter.cc
@@ -286,6 +286,8 @@ void SidebarPresenter::refreshSnapshot(const EditorApp& app) {
     return;
   }
 
+  [[maybe_unused]] const donner::svg::DocumentWriteAccess snapshotWriteAccess =
+      app.document().document().writeAccess();
   const auto& selectionList = app.selectedElements();
   TreeNodeSnapshot root;
   captureTreeNode(app.document().document().svgElement(), selectionList, root);

--- a/donner/editor/SidebarPresenter.h
+++ b/donner/editor/SidebarPresenter.h
@@ -43,8 +43,15 @@ public:
   /// thread owns the document).
   void renderTreeView(EditorApp* liveApp, TreeViewState& state) const;
 
-  /// Render the inspector pane from the current snapshot.
-  void renderInspector(const ViewportState& viewport) const;
+  /**
+   * Render the inspector pane from the current snapshot.
+   *
+   * @param liveApp Live editor app for button actions, or null while the
+   *   renderer owns the document.
+   * @param viewport Viewport state diagnostics.
+   * @return true if an inspector action queued a document mutation.
+   */
+  bool renderInspector(EditorApp* liveApp, const ViewportState& viewport) const;
 
   [[nodiscard]] bool inspectorHasSelectionForTesting() const {
     return inspectorSnapshot_.hasSelection;

--- a/donner/editor/SourceEditIntent.h
+++ b/donner/editor/SourceEditIntent.h
@@ -17,6 +17,14 @@ enum class SourceEditIntentKind {
   Redo,     ///< The edit came from text-editor redo.
 };
 
+/// Line/column coordinate attached to a source edit boundary.
+struct SourceEditPoint {
+  int line = 0;    ///< Zero-based source line.
+  int column = 0;  ///< Zero-based source column.
+
+  bool operator==(const SourceEditPoint& other) const = default;
+};
+
 /// One source-buffer edit expressed in byte offsets against the buffer version
 /// visible when the edit occurred.
 struct SourceEditIntent {
@@ -25,6 +33,9 @@ struct SourceEditIntent {
   std::string replacement;        ///< Bytes inserted at \ref offset.
   SourceEditIntentKind kind = SourceEditIntentKind::Unknown;
   std::uint64_t bufferVersion = 0;  ///< Monotonic text-buffer edit version.
+  SourceEditPoint start;            ///< Edit start in the pre-edit source buffer.
+  SourceEditPoint removedEnd;       ///< End of the removed range in the pre-edit buffer.
+  SourceEditPoint replacementEnd;   ///< End of the inserted text in the post-edit buffer.
 
   bool operator==(const SourceEditIntent& other) const = default;
 };

--- a/donner/editor/SourceSelection.cc
+++ b/donner/editor/SourceSelection.cc
@@ -157,32 +157,40 @@ std::vector<svg::SVGElement> ExcludeDocumentRootSourceHoverElement(
 std::optional<svg::SVGElement> FindElementAtSourceOffset(const svg::SVGDocument& document,
                                                          std::string_view source,
                                                          std::size_t offset) {
-  if (offset >= source.size()) {
-    return std::nullopt;
-  }
+  return document.withReadAccess(
+      [&document, source, offset](svg::DocumentReadAccess&) -> std::optional<svg::SVGElement> {
+        if (offset >= source.size()) {
+          return std::nullopt;
+        }
 
-  return FindElementAtSourceOffsetImpl(document.svgElement(), source, offset);
+        return FindElementAtSourceOffsetImpl(document.svgElement(), source, offset);
+      });
 }
 
 std::optional<svg::SVGElement> FindElementNearSourceOffset(const svg::SVGDocument& document,
                                                            std::string_view source,
                                                            std::size_t offset) {
-  std::optional<svg::SVGElement> current =
-      offset < source.size() ? FindElementAtSourceOffset(document, source, offset) : std::nullopt;
-  if (offset == 0) {
+  return document.withReadAccess([&document, source, offset](
+                                     svg::DocumentReadAccess&) -> std::optional<svg::SVGElement> {
+    const svg::SVGElement root = document.svgElement();
+    std::optional<svg::SVGElement> current =
+        offset < source.size() ? FindElementAtSourceOffsetImpl(root, source, offset) : std::nullopt;
+    if (offset == 0) {
+      return current;
+    }
+
+    std::optional<svg::SVGElement> previous =
+        FindElementAtSourceOffsetImpl(root, source, offset - 1);
+    if (previous.has_value() && ElementTagEndsAt(*previous, source, offset)) {
+      return previous;
+    }
+
+    if (previous.has_value() && (!current.has_value() || IsAncestorOrSelf(*current, *previous))) {
+      return previous;
+    }
+
     return current;
-  }
-
-  std::optional<svg::SVGElement> previous = FindElementAtSourceOffset(document, source, offset - 1);
-  if (previous.has_value() && ElementTagEndsAt(*previous, source, offset)) {
-    return previous;
-  }
-
-  if (previous.has_value() && (!current.has_value() || IsAncestorOrSelf(*current, *previous))) {
-    return previous;
-  }
-
-  return current;
+  });
 }
 
 std::optional<svg::SVGElement> FindElementAtSourceCursor(const svg::SVGDocument& document,

--- a/donner/editor/SourceSelection.cc
+++ b/donner/editor/SourceSelection.cc
@@ -14,19 +14,6 @@ namespace donner::editor {
 
 namespace {
 
-Coordinates FileOffsetToEditorCoordinates(const TextEditor& textEditor, const FileOffset& offset) {
-  if (offset.offset.has_value()) {
-    return textEditor.getCoordinatesAtByteOffset(*offset.offset);
-  }
-
-  if (offset.lineInfo.has_value()) {
-    return Coordinates(static_cast<int>(offset.lineInfo->line) - 1,
-                       static_cast<int>(offset.lineInfo->offsetOnLine));
-  }
-
-  return Coordinates(0, 0);
-}
-
 std::optional<std::size_t> ResolveFileOffset(std::string_view source, const FileOffset& offset) {
   const FileOffset resolved = offset.resolveOffset(source);
   if (!resolved.offset.has_value()) {
@@ -97,25 +84,23 @@ bool ElementTagEndsAt(const svg::SVGElement& element, std::string_view source, s
 }  // namespace
 
 bool HighlightElementSource(TextEditor& textEditor, const svg::SVGElement& element) {
-  auto xmlNode = element.withReadAccess(
-      [](svg::DocumentReadAccess&, EntityHandle handle) { return xml::XMLNode::TryCast(handle); });
-  if (!xmlNode.has_value()) {
+  const std::string source = textEditor.getText();
+  const std::optional<SourceByteRange> byteRange = ElementSourceByteRange(element, source);
+  return byteRange.has_value() && HighlightSourceByteRange(textEditor, *byteRange);
+}
+
+bool HighlightSourceByteRange(TextEditor& textEditor, SourceByteRange byteRange) {
+  if (byteRange.end <= byteRange.start || byteRange.end > textEditor.getText().size()) {
     return false;
   }
 
-  auto range = xmlNode->getNodeLocation();
-  if (!range.has_value()) {
-    return false;
-  }
-
-  textEditor.selectAndFocus(FileOffsetToEditorCoordinates(textEditor, range->start),
-                            FileOffsetToEditorCoordinates(textEditor, range->end));
+  textEditor.selectAndFocus(textEditor.getCoordinatesAtByteOffset(byteRange.start),
+                            textEditor.getCoordinatesAtByteOffset(byteRange.end));
   return true;
 }
 
-std::optional<SourceByteRange> ElementSourceByteRange(const svg::SVGElement& element,
-                                                      std::string_view source) {
-  auto xmlNode = xml::XMLNode::TryCast(element.entityHandle());
+std::optional<SourceByteRange> EntitySourceByteRange(EntityHandle handle, std::string_view source) {
+  auto xmlNode = xml::XMLNode::TryCast(handle);
   if (!xmlNode.has_value()) {
     return std::nullopt;
   }
@@ -134,6 +119,13 @@ std::optional<SourceByteRange> ElementSourceByteRange(const svg::SVGElement& ele
   return SourceByteRange{.start = *start, .end = *end};
 }
 
+std::optional<SourceByteRange> ElementSourceByteRange(const svg::SVGElement& element,
+                                                      std::string_view source) {
+  return element.withReadAccess([source](svg::DocumentReadAccess&, EntityHandle handle) {
+    return EntitySourceByteRange(handle, source);
+  });
+}
+
 std::vector<svg::SVGElement> ExcludeSelectedSourceHoverElements(
     std::vector<svg::SVGElement> hoverElements, std::span<const svg::SVGElement> selectedElements) {
   if (hoverElements.empty() || selectedElements.empty()) {
@@ -146,6 +138,18 @@ std::vector<svg::SVGElement> ExcludeSelectedSourceHoverElements(
                                                         selectedElements.end(),
                                                         element) != selectedElements.end();
                                      }),
+                      hoverElements.end());
+  return hoverElements;
+}
+
+std::vector<svg::SVGElement> ExcludeDocumentRootSourceHoverElement(
+    std::vector<svg::SVGElement> hoverElements, const svg::SVGDocument& document) {
+  if (hoverElements.empty()) {
+    return hoverElements;
+  }
+
+  const svg::SVGElement root = document.svgElement();
+  hoverElements.erase(std::remove(hoverElements.begin(), hoverElements.end(), root),
                       hoverElements.end());
   return hoverElements;
 }

--- a/donner/editor/SourceSelection.h
+++ b/donner/editor/SourceSelection.h
@@ -7,6 +7,7 @@
 #include <string_view>
 #include <vector>
 
+#include "donner/base/EcsRegistry.h"
 #include "donner/editor/TextEditor.h"
 #include "donner/svg/SVGDocument.h"
 #include "donner/svg/SVGElement.h"
@@ -21,6 +22,27 @@ namespace donner::editor {
  * @return true if a source range was found and selected.
  */
 bool HighlightElementSource(TextEditor& textEditor, const svg::SVGElement& element);
+
+/**
+ * Selects a raw source byte range in the text editor.
+ *
+ * @param textEditor Source editor to update.
+ * @param byteRange Half-open byte range to select.
+ * @return true if the range was valid for the current text buffer.
+ */
+bool HighlightSourceByteRange(TextEditor& textEditor, SourceByteRange byteRange);
+
+/**
+ * Return the serialized XML node byte range for an ECS entity.
+ *
+ * This is useful for resolved references where the caller has an \ref EntityHandle but not a
+ * public \ref svg::SVGElement wrapper.
+ *
+ * @param handle Entity whose XML node source should be resolved.
+ * @param source Source text corresponding to the entity's document.
+ * @return Half-open byte range for the node, or \c std::nullopt if no source range exists.
+ */
+std::optional<SourceByteRange> EntitySourceByteRange(EntityHandle handle, std::string_view source);
 
 /**
  * Return the serialized XML node byte range for an SVG element.
@@ -41,6 +63,19 @@ std::optional<SourceByteRange> ElementSourceByteRange(const svg::SVGElement& ele
  */
 std::vector<svg::SVGElement> ExcludeSelectedSourceHoverElements(
     std::vector<svg::SVGElement> hoverElements, std::span<const svg::SVGElement> selectedElements);
+
+/**
+ * Removes the document root from automatic source-hover candidates.
+ *
+ * The root `<svg>` source range covers the entire document, so automatic source hover should not
+ * turn that into a whole-canvas overlay preview.
+ *
+ * @param hoverElements Candidate elements resolved from the source hover position.
+ * @param document Document whose root should be excluded.
+ * @return Hover candidates that are not the document root element.
+ */
+std::vector<svg::SVGElement> ExcludeDocumentRootSourceHoverElement(
+    std::vector<svg::SVGElement> hoverElements, const svg::SVGDocument& document);
 
 /**
  * Finds the deepest SVG element whose source range contains \p offset.

--- a/donner/editor/StyleSourceAnnotations.cc
+++ b/donner/editor/StyleSourceAnnotations.cc
@@ -819,29 +819,31 @@ void MarkEffectiveContributionsForElement(
 
 StyleSourceAnnotations ComputeStyleSourceAnnotations(svg::SVGDocument& document,
                                                      std::string_view source) {
-  StyleSourceAnnotations annotations;
   if (source.empty()) {
+    return {};
+  }
+
+  return document.withWriteAccess([&document, source](svg::DocumentWriteAccess& access) {
+    StyleSourceAnnotations annotations;
+    std::unordered_map<ContributionKey, std::size_t, ContributionKeyHash> contributionIndexByKey;
+    Registry& registry = access.registry();
+    AddStylesheetContributions(registry, source, &annotations, &contributionIndexByKey);
+
+    std::vector<svg::SVGElement> elements;
+    CollectElements(document.svgElement(), &elements);
+    AddReferenceResourceContributions(registry, source, elements, &annotations,
+                                      &contributionIndexByKey);
+    for (const svg::SVGElement& element : elements) {
+      AddElementLocalContributions(element, source, &annotations, &contributionIndexByKey);
+    }
+
+    AddStylesheetMatches(elements, &annotations, contributionIndexByKey);
+    for (const svg::SVGElement& element : elements) {
+      MarkEffectiveContributionsForElement(element, &annotations, contributionIndexByKey);
+    }
+
     return annotations;
-  }
-
-  std::unordered_map<ContributionKey, std::size_t, ContributionKeyHash> contributionIndexByKey;
-  Registry& registry = document.registry();
-  AddStylesheetContributions(registry, source, &annotations, &contributionIndexByKey);
-
-  std::vector<svg::SVGElement> elements;
-  CollectElements(document.svgElement(), &elements);
-  AddReferenceResourceContributions(registry, source, elements, &annotations,
-                                    &contributionIndexByKey);
-  for (const svg::SVGElement& element : elements) {
-    AddElementLocalContributions(element, source, &annotations, &contributionIndexByKey);
-  }
-
-  AddStylesheetMatches(elements, &annotations, contributionIndexByKey);
-  for (const svg::SVGElement& element : elements) {
-    MarkEffectiveContributionsForElement(element, &annotations, contributionIndexByKey);
-  }
-
-  return annotations;
+  });
 }
 
 }  // namespace donner::editor

--- a/donner/editor/StyleSourceAnnotations.cc
+++ b/donner/editor/StyleSourceAnnotations.cc
@@ -1,0 +1,847 @@
+#include "donner/editor/StyleSourceAnnotations.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "donner/base/EcsRegistry.h"
+#include "donner/base/FileOffset.h"
+#include "donner/base/xml/XMLNode.h"
+#include "donner/base/xml/XMLQualifiedName.h"
+#include "donner/css/CSS.h"
+#include "donner/css/Declaration.h"
+#include "donner/css/Specificity.h"
+#include "donner/editor/ReferenceFanout.h"
+#include "donner/svg/ElementType.h"
+#include "donner/svg/components/StylesheetComponent.h"
+#include "donner/svg/components/style/StyleSystem.h"
+#include "donner/svg/properties/PropertyRegistry.h"
+
+namespace donner::editor {
+namespace {
+
+using donner::svg::components::MatchedStyleRule;
+using donner::svg::components::StylesheetComponent;
+using donner::svg::components::StyleSystem;
+
+constexpr css::Specificity kPresentationSpecificity = css::Specificity::FromABC(0, 0, 0);
+struct ContributionKey {
+  StyleContributionKind kind = StyleContributionKind::StylesheetDeclaration;
+  Entity elementEntity = entt::null;
+  Entity stylesheetEntity = entt::null;
+  std::size_t ruleIndex = 0;
+  std::size_t declarationIndex = 0;
+  std::string propertyName;
+
+  bool operator==(const ContributionKey& other) const = default;
+};
+
+struct ContributionKeyHash {
+  std::size_t operator()(const ContributionKey& key) const {
+    std::size_t hash = std::hash<int>()(static_cast<int>(key.kind));
+    hash ^= std::hash<std::uint32_t>()(static_cast<std::uint32_t>(key.elementEntity)) +
+            0x9e3779b9u + (hash << 6u) + (hash >> 2u);
+    hash ^= std::hash<std::uint32_t>()(static_cast<std::uint32_t>(key.stylesheetEntity)) +
+            0x9e3779b9u + (hash << 6u) + (hash >> 2u);
+    hash ^= std::hash<std::size_t>()(key.ruleIndex) + 0x9e3779b9u + (hash << 6u) + (hash >> 2u);
+    hash ^=
+        std::hash<std::size_t>()(key.declarationIndex) + 0x9e3779b9u + (hash << 6u) + (hash >> 2u);
+    hash ^= std::hash<std::string>()(key.propertyName) + 0x9e3779b9u + (hash << 6u) + (hash >> 2u);
+    return hash;
+  }
+};
+
+struct CascadeEntry {
+  std::size_t contributionIndex = 0;
+  css::Specificity specificity;
+  std::optional<css::Declaration> declaration;
+  std::string presentationValue;
+};
+
+struct Winner {
+  css::Specificity specificity;
+  std::size_t order = 0;
+  std::size_t contributionIndex = 0;
+};
+
+struct FragmentReference {
+  std::string fragmentId;
+  std::optional<svg::SVGElement> referencingElement;
+};
+
+[[nodiscard]] std::optional<SourceByteRange> ToByteRange(const SourceRange& range,
+                                                         std::size_t sourceSize) {
+  if (!range.start.offset.has_value() || !range.end.offset.has_value()) {
+    return std::nullopt;
+  }
+
+  const std::size_t start = *range.start.offset;
+  const std::size_t end = *range.end.offset;
+  if (start > end || start > sourceSize) {
+    return std::nullopt;
+  }
+
+  return SourceByteRange{start, std::min(end, sourceSize)};
+}
+
+[[nodiscard]] bool IsAsciiSpace(char ch) {
+  return std::isspace(static_cast<unsigned char>(ch)) != 0;
+}
+
+[[nodiscard]] std::string TagNameForElement(const svg::SVGElement& element) {
+  if (std::optional<xml::XMLQualifiedNameRef> tagName = element.tryTagName()) {
+    return std::string(tagName->name);
+  }
+
+  return "element";
+}
+
+[[nodiscard]] bool HasAncestorNamed(const svg::SVGElement& element, std::string_view tagName) {
+  for (std::optional<svg::SVGElement> ancestor = element.parentElement(); ancestor.has_value();
+       ancestor = ancestor->parentElement()) {
+    if (std::optional<xml::XMLQualifiedNameRef> ancestorTagName = ancestor->tryTagName();
+        ancestorTagName.has_value() && std::string_view(ancestorTagName->name) == tagName) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+[[nodiscard]] bool IsReferenceResourceElement(const svg::SVGElement& element) {
+  const std::optional<svg::ElementType> type = element.tryType();
+  if (!type.has_value() || !xml::XMLNode::TryCast(element.entityHandle()).has_value()) {
+    return false;
+  }
+
+  switch (*type) {
+    case svg::ElementType::ClipPath:
+    case svg::ElementType::Filter:
+    case svg::ElementType::LinearGradient:
+    case svg::ElementType::Marker:
+    case svg::ElementType::Mask:
+    case svg::ElementType::Pattern:
+    case svg::ElementType::RadialGradient:
+    case svg::ElementType::Symbol: return true;
+    case svg::ElementType::Defs:
+    case svg::ElementType::Stop:
+    case svg::ElementType::Style: return false;
+    default: break;
+  }
+
+  return HasAncestorNamed(element, "defs");
+}
+
+void AppendFragmentReference(std::vector<FragmentReference>* references,
+                             std::string_view fragmentId,
+                             std::optional<svg::SVGElement> referencingElement) {
+  if (fragmentId.empty()) {
+    return;
+  }
+
+  references->push_back(FragmentReference{
+      .fragmentId = std::string(fragmentId),
+      .referencingElement = referencingElement,
+  });
+}
+
+void AppendUrlFragmentReferences(std::string_view value,
+                                 std::optional<svg::SVGElement> referencingElement,
+                                 std::vector<FragmentReference>* references) {
+  std::size_t searchPos = 0;
+  while (searchPos < value.size()) {
+    const std::size_t urlPos = value.find("url(", searchPos);
+    if (urlPos == std::string_view::npos) {
+      return;
+    }
+
+    std::size_t index = urlPos + 4;
+    while (index < value.size() && IsAsciiSpace(value[index])) {
+      ++index;
+    }
+
+    char quote = '\0';
+    if (index < value.size() && (value[index] == '\'' || value[index] == '"')) {
+      quote = value[index];
+      ++index;
+      while (index < value.size() && IsAsciiSpace(value[index])) {
+        ++index;
+      }
+    }
+
+    if (index >= value.size() || value[index] != '#') {
+      searchPos = index;
+      continue;
+    }
+
+    const std::size_t fragmentStart = index + 1;
+    std::size_t fragmentEnd = fragmentStart;
+    while (fragmentEnd < value.size()) {
+      const char ch = value[fragmentEnd];
+      if ((quote != '\0' && ch == quote) || (quote == '\0' && (ch == ')' || IsAsciiSpace(ch)))) {
+        break;
+      }
+      ++fragmentEnd;
+    }
+
+    AppendFragmentReference(references, value.substr(fragmentStart, fragmentEnd - fragmentStart),
+                            referencingElement);
+    searchPos = fragmentEnd;
+  }
+}
+
+void AppendHrefFragmentReference(std::string_view value,
+                                 std::optional<svg::SVGElement> referencingElement,
+                                 std::vector<FragmentReference>* references) {
+  std::size_t start = 0;
+  while (start < value.size() && IsAsciiSpace(value[start])) {
+    ++start;
+  }
+
+  if (start >= value.size() || value[start] != '#') {
+    return;
+  }
+
+  std::size_t end = value.size();
+  while (end > start + 1 && IsAsciiSpace(value[end - 1])) {
+    --end;
+  }
+
+  AppendFragmentReference(references, value.substr(start + 1, end - start - 1), referencingElement);
+}
+
+[[nodiscard]] SourceByteRange ExpandCssDeclarationRange(std::string_view source,
+                                                        SourceByteRange range,
+                                                        std::optional<std::size_t> hardEnd) {
+  const std::size_t limit = std::min(hardEnd.value_or(source.size()), source.size());
+  range.start = std::min(range.start, limit);
+  range.end = std::min(range.end, limit);
+
+  std::size_t end = range.end;
+  while (end < limit && source[end] != ';' && source[end] != '}') {
+    ++end;
+  }
+  if (end < limit && source[end] == ';') {
+    ++end;
+  }
+
+  range.end = end;
+  while (range.end > range.start &&
+         std::isspace(static_cast<unsigned char>(source[range.end - 1])) != 0) {
+    --range.end;
+  }
+  return range;
+}
+
+[[nodiscard]] std::optional<SourceByteRange> DeclarationDocumentRange(
+    const StylesheetComponent& stylesheet, const css::Declaration& declaration,
+    std::string_view source) {
+  std::optional<SourceRange> documentRange =
+      stylesheet.sourceMap.mapToDocumentSource(declaration.sourceRange);
+  if (!documentRange.has_value()) {
+    return std::nullopt;
+  }
+
+  std::optional<SourceByteRange> byteRange = ToByteRange(*documentRange, source.size());
+  if (!byteRange.has_value()) {
+    return std::nullopt;
+  }
+
+  return ExpandCssDeclarationRange(source, *byteRange, std::nullopt);
+}
+
+[[nodiscard]] std::optional<SourceByteRange> SelectorDocumentRange(
+    const StylesheetComponent& stylesheet, const css::SelectorRule& rule, std::string_view source) {
+  std::optional<SourceRange> documentRange =
+      stylesheet.sourceMap.mapToDocumentSource(rule.selectorSourceRange);
+  if (!documentRange.has_value()) {
+    return std::nullopt;
+  }
+
+  return ToByteRange(*documentRange, source.size());
+}
+
+[[nodiscard]] SourceByteRange InlineDeclarationDocumentRange(
+    const css::Declaration& declaration, const xml::XMLAttributeSourceLocation& styleLocation,
+    std::string_view source) {
+  const std::size_t valueStart = styleLocation.valueRange.start.offset.value_or(0);
+  const std::size_t valueEnd = styleLocation.valueRange.end.offset.value_or(valueStart);
+  const std::size_t localStart = declaration.sourceRange.start.offset.value_or(0);
+  const std::size_t localEnd = declaration.sourceRange.end.offset.value_or(localStart);
+  SourceByteRange range{
+      std::min(valueStart + localStart, valueEnd),
+      std::min(valueStart + localEnd, valueEnd),
+  };
+  return ExpandCssDeclarationRange(source, range, valueEnd);
+}
+
+[[nodiscard]] css::Specificity SpecificityForDeclaration(const css::Declaration& declaration,
+                                                         css::Specificity baseSpecificity) {
+  return declaration.important ? css::Specificity::Important() : baseSpecificity;
+}
+
+[[nodiscard]] bool IsPropertyDeclarationValid(const css::Declaration& declaration,
+                                              css::Specificity specificity) {
+  svg::PropertyRegistry registry;
+  return !registry.parseProperty(declaration, specificity).has_value();
+}
+
+[[nodiscard]] bool IsPresentationAttributeProperty(std::string_view name) {
+  if (!svg::PropertyRegistry::isPresentationAttributeName(name)) {
+    return false;
+  }
+
+  const std::span<const std::string_view> propertyNames = svg::PropertyRegistry::propertyNames();
+  return std::find(propertyNames.begin(), propertyNames.end(), name) != propertyNames.end();
+}
+
+[[nodiscard]] bool IsPresentationAttributeValid(std::string_view name, std::string_view value,
+                                                EntityHandle handle) {
+  svg::PropertyRegistry registry;
+  ParseResult<bool> result = registry.parsePresentationAttribute(name, value, handle);
+  return result.hasResult() && result.result();
+}
+
+void CollectElements(svg::SVGElement root, std::vector<svg::SVGElement>* elements) {
+  elements->push_back(root);
+  for (std::optional<svg::SVGElement> child = root.firstChild(); child.has_value();
+       child = child->nextSibling()) {
+    CollectElements(*child, elements);
+  }
+}
+
+void AddUniqueMatchedElement(StyleSourceContribution* contribution,
+                             const svg::SVGElement& element) {
+  if (std::find(contribution->matchedElements.begin(), contribution->matchedElements.end(),
+                element) == contribution->matchedElements.end()) {
+    contribution->matchedElements.push_back(element);
+  }
+}
+
+void AddMatchedElement(StyleSourceContribution* contribution, const svg::SVGElement& element) {
+  AddUniqueMatchedElement(contribution, element);
+  contribution->matchedElementCount = static_cast<int>(contribution->matchedElements.size());
+}
+
+void ApplyReverseReferenceFanoutMarker(StyleSourceContribution* contribution) {
+  if (!contribution->showChip ||
+      !IsLargeReverseReferenceFanout(static_cast<std::size_t>(contribution->matchedElementCount))) {
+    return;
+  }
+
+  contribution->showOverflowMarker = true;
+  contribution->overflowTooltip = std::string(kReverseReferenceOverflowTooltip);
+}
+
+void AddContribution(
+    StyleSourceContribution contribution, const ContributionKey& key,
+    StyleSourceAnnotations* annotations,
+    std::unordered_map<ContributionKey, std::size_t, ContributionKeyHash>* contributionIndexByKey) {
+  contribution.id = annotations->contributions.size() + 1u;
+  const std::size_t index = annotations->contributions.size();
+  annotations->contributions.push_back(std::move(contribution));
+  contributionIndexByKey->emplace(key, index);
+}
+
+void AddStylesheetContributions(
+    Registry& registry, std::string_view source, StyleSourceAnnotations* annotations,
+    std::unordered_map<ContributionKey, std::size_t, ContributionKeyHash>* contributionIndexByKey) {
+  for (auto view = registry.view<StylesheetComponent>(); auto stylesheetEntity : view) {
+    const StylesheetComponent& stylesheet = view.get<StylesheetComponent>(stylesheetEntity);
+    if (stylesheet.isUserAgentStylesheet || stylesheet.sourceMap.empty()) {
+      continue;
+    }
+
+    const std::span<const css::SelectorRule> rules = stylesheet.stylesheet.rules();
+    for (std::size_t ruleIndex = 0; ruleIndex < rules.size(); ++ruleIndex) {
+      const css::SelectorRule& rule = rules[ruleIndex];
+      const std::optional<SourceByteRange> selectorRange =
+          SelectorDocumentRange(stylesheet, rule, source);
+      bool chipAssignedForRule = false;
+      for (std::size_t declarationIndex = 0; declarationIndex < rule.declarations.size();
+           ++declarationIndex) {
+        const css::Declaration& declaration = rule.declarations[declarationIndex];
+        std::optional<SourceByteRange> sourceRange =
+            DeclarationDocumentRange(stylesheet, declaration, source);
+        if (!sourceRange.has_value()) {
+          continue;
+        }
+
+        StyleSourceContribution contribution;
+        contribution.sourceRange = *sourceRange;
+        contribution.chipRange = selectorRange.value_or(*sourceRange);
+        contribution.propertyName = std::string(declaration.name);
+        contribution.kind = StyleContributionKind::StylesheetDeclaration;
+        contribution.showChip = !chipAssignedForRule;
+        contribution.tooltip = std::string(declaration.name) +
+                               " is overridden by a later or higher-specificity CSS declaration";
+        contribution.chipTooltip = "Selector matches 0 elements";
+        chipAssignedForRule = true;
+
+        AddContribution(std::move(contribution),
+                        ContributionKey{
+                            .kind = StyleContributionKind::StylesheetDeclaration,
+                            .stylesheetEntity = stylesheetEntity,
+                            .ruleIndex = ruleIndex,
+                            .declarationIndex = declarationIndex,
+                            .propertyName = std::string(declaration.name),
+                        },
+                        annotations, contributionIndexByKey);
+      }
+    }
+  }
+}
+
+void AppendAttributeFragmentReferences(const svg::SVGElement& element,
+                                       std::vector<FragmentReference>* references) {
+  std::optional<xml::XMLNode> xmlNode = xml::XMLNode::TryCast(element.entityHandle());
+  if (!xmlNode.has_value()) {
+    return;
+  }
+
+  for (const xml::XMLQualifiedNameRef& attrName : xmlNode->attributes()) {
+    std::optional<RcString> attrValue = xmlNode->getAttribute(attrName);
+    if (!attrValue.has_value()) {
+      continue;
+    }
+
+    const std::string_view value = *attrValue;
+    AppendUrlFragmentReferences(value, element, references);
+    if (attrName.name == "href") {
+      AppendHrefFragmentReference(value, element, references);
+    }
+  }
+}
+
+void AppendStylesheetFragmentReferences(Registry& registry, std::string_view source,
+                                        std::vector<FragmentReference>* references) {
+  for (auto view = registry.view<StylesheetComponent>(); auto stylesheetEntity : view) {
+    const StylesheetComponent& stylesheet = view.get<StylesheetComponent>(stylesheetEntity);
+    if (stylesheet.isUserAgentStylesheet || stylesheet.sourceMap.empty()) {
+      continue;
+    }
+
+    for (const css::SelectorRule& rule : stylesheet.stylesheet.rules()) {
+      std::optional<SourceRange> documentRange =
+          stylesheet.sourceMap.mapToDocumentSource(rule.ruleSourceRange);
+      if (!documentRange.has_value()) {
+        continue;
+      }
+
+      std::optional<SourceByteRange> ruleRange = ToByteRange(*documentRange, source.size());
+      if (!ruleRange.has_value()) {
+        continue;
+      }
+
+      AppendUrlFragmentReferences(
+          source.substr(ruleRange->start, ruleRange->end - ruleRange->start), std::nullopt,
+          references);
+    }
+  }
+}
+
+void AddReferenceResourceContributions(
+    Registry& registry, std::string_view source, const std::vector<svg::SVGElement>& elements,
+    StyleSourceAnnotations* annotations,
+    std::unordered_map<ContributionKey, std::size_t, ContributionKeyHash>* contributionIndexByKey) {
+  std::vector<FragmentReference> references;
+  for (const svg::SVGElement& element : elements) {
+    AppendAttributeFragmentReferences(element, &references);
+  }
+  AppendStylesheetFragmentReferences(registry, source, &references);
+
+  std::unordered_map<std::string, std::size_t> referenceCountById;
+  std::unordered_map<std::string, std::vector<svg::SVGElement>> referencingElementsById;
+  for (const FragmentReference& reference : references) {
+    ++referenceCountById[reference.fragmentId];
+    if (reference.referencingElement.has_value()) {
+      std::vector<svg::SVGElement>& referencingElements =
+          referencingElementsById[reference.fragmentId];
+      if (std::find(referencingElements.begin(), referencingElements.end(),
+                    *reference.referencingElement) == referencingElements.end()) {
+        referencingElements.push_back(*reference.referencingElement);
+      }
+    }
+  }
+
+  for (const svg::SVGElement& element : elements) {
+    if (!IsReferenceResourceElement(element)) {
+      continue;
+    }
+
+    const RcString id = element.id();
+    if (id.empty()) {
+      continue;
+    }
+
+    std::optional<xml::XMLNode> xmlNode = xml::XMLNode::TryCast(element.entityHandle());
+    if (!xmlNode.has_value()) {
+      continue;
+    }
+
+    std::optional<SourceRange> nodeLocation = xmlNode->getNodeLocation();
+    if (!nodeLocation.has_value()) {
+      continue;
+    }
+
+    std::optional<SourceByteRange> sourceRange = ToByteRange(*nodeLocation, source.size());
+    if (!sourceRange.has_value()) {
+      continue;
+    }
+
+    std::optional<SourceByteRange> chipRange;
+    if (std::optional<SourceRange> openingTagRange = xmlNode->getOpeningTagLocation()) {
+      chipRange = ToByteRange(*openingTagRange, source.size());
+    }
+
+    const std::string idString{std::string_view(id)};
+    const auto referenceCountIter = referenceCountById.find(idString);
+    const int referenceCount = referenceCountIter == referenceCountById.end()
+                                   ? 0
+                                   : static_cast<int>(referenceCountIter->second);
+    const std::string tagName = TagNameForElement(element);
+
+    StyleSourceContribution contribution;
+    contribution.sourceRange = *sourceRange;
+    contribution.chipRange = chipRange.value_or(*sourceRange);
+    contribution.propertyName = tagName;
+    contribution.kind = StyleContributionKind::ReferenceResourceElement;
+    contribution.effective = referenceCount > 0;
+    contribution.showChip = true;
+    contribution.matchedElementCount = referenceCount;
+    ApplyReverseReferenceFanoutMarker(&contribution);
+    if (auto referencingElementsIter = referencingElementsById.find(idString);
+        referencingElementsIter != referencingElementsById.end()) {
+      contribution.matchedElements = referencingElementsIter->second;
+    }
+    contribution.tooltip = tagName + " #" + idString + " is not referenced";
+    contribution.chipTooltip =
+        "Referenced " + std::to_string(referenceCount) + " time" + (referenceCount == 1 ? "" : "s");
+
+    AddContribution(std::move(contribution),
+                    ContributionKey{
+                        .kind = StyleContributionKind::ReferenceResourceElement,
+                        .elementEntity = element.entityHandle().entity(),
+                        .propertyName = tagName,
+                    },
+                    annotations, contributionIndexByKey);
+  }
+}
+
+void AddElementLocalContributions(
+    const svg::SVGElement& element, std::string_view source, StyleSourceAnnotations* annotations,
+    std::unordered_map<ContributionKey, std::size_t, ContributionKeyHash>* contributionIndexByKey) {
+  std::optional<xml::XMLNode> xmlNode = xml::XMLNode::TryCast(element.entityHandle());
+  if (!xmlNode.has_value()) {
+    return;
+  }
+
+  for (const xml::XMLQualifiedNameRef& attrName : xmlNode->attributes()) {
+    const std::string propertyName = attrName.toString();
+    if (!IsPresentationAttributeProperty(propertyName)) {
+      continue;
+    }
+
+    std::optional<RcString> attrValue = xmlNode->getAttribute(attrName);
+    std::optional<xml::XMLAttributeSourceLocation> location =
+        xmlNode->getAttributeSourceLocation(attrName);
+    if (!attrValue.has_value() || !location.has_value()) {
+      continue;
+    }
+
+    std::optional<SourceByteRange> sourceRange = ToByteRange(location->fullRange, source.size());
+    if (!sourceRange.has_value()) {
+      continue;
+    }
+
+    StyleSourceContribution contribution;
+    contribution.sourceRange = *sourceRange;
+    contribution.chipRange = *sourceRange;
+    contribution.propertyName = propertyName;
+    contribution.kind = StyleContributionKind::PresentationAttribute;
+    contribution.matchedElementCount = 1;
+    contribution.matchedElements.push_back(element);
+    contribution.tooltip = propertyName + " is overridden by higher-specificity CSS";
+
+    AddContribution(std::move(contribution),
+                    ContributionKey{
+                        .kind = StyleContributionKind::PresentationAttribute,
+                        .elementEntity = element.entityHandle().entity(),
+                        .propertyName = propertyName,
+                    },
+                    annotations, contributionIndexByKey);
+  }
+
+  std::optional<RcString> styleValue = xmlNode->getAttribute(xml::XMLQualifiedNameRef("style"));
+  std::optional<xml::XMLAttributeSourceLocation> styleLocation =
+      xmlNode->getAttributeSourceLocation(xml::XMLQualifiedNameRef("style"));
+  if (!styleValue.has_value() || !styleLocation.has_value()) {
+    return;
+  }
+
+  const std::vector<css::Declaration> declarations = css::CSS::ParseStyleAttribute(*styleValue);
+  for (std::size_t declarationIndex = 0; declarationIndex < declarations.size();
+       ++declarationIndex) {
+    const css::Declaration& declaration = declarations[declarationIndex];
+    StyleSourceContribution contribution;
+    contribution.sourceRange = InlineDeclarationDocumentRange(declaration, *styleLocation, source);
+    contribution.chipRange = contribution.sourceRange;
+    contribution.propertyName = std::string(declaration.name);
+    contribution.kind = StyleContributionKind::InlineStyleDeclaration;
+    contribution.matchedElementCount = 1;
+    contribution.matchedElements.push_back(element);
+    contribution.tooltip = std::string(declaration.name) + " is overridden by !important CSS";
+
+    AddContribution(std::move(contribution),
+                    ContributionKey{
+                        .kind = StyleContributionKind::InlineStyleDeclaration,
+                        .elementEntity = element.entityHandle().entity(),
+                        .declarationIndex = declarationIndex,
+                        .propertyName = std::string(declaration.name),
+                    },
+                    annotations, contributionIndexByKey);
+  }
+}
+
+void AddStylesheetMatches(const std::vector<svg::SVGElement>& elements,
+                          StyleSourceAnnotations* annotations,
+                          const std::unordered_map<ContributionKey, std::size_t,
+                                                   ContributionKeyHash>& contributionIndexByKey) {
+  const StyleSystem styleSystem;
+  for (const svg::SVGElement& element : elements) {
+    const std::vector<MatchedStyleRule> matches =
+        styleSystem.collectMatchedStyleRules(element.entityHandle());
+    for (const MatchedStyleRule& match : matches) {
+      if (match.isUserAgentStylesheet) {
+        continue;
+      }
+
+      const auto* stylesheet =
+          element.entityHandle().registry()->try_get<StylesheetComponent>(match.stylesheetEntity);
+      if (stylesheet == nullptr) {
+        continue;
+      }
+
+      const std::span<const css::SelectorRule> rules = stylesheet->stylesheet.rules();
+      if (match.ruleIndex >= rules.size()) {
+        continue;
+      }
+
+      const css::SelectorRule& rule = rules[match.ruleIndex];
+      for (std::size_t declarationIndex = 0; declarationIndex < rule.declarations.size();
+           ++declarationIndex) {
+        const css::Declaration& declaration = rule.declarations[declarationIndex];
+        auto contributionIter = contributionIndexByKey.find(ContributionKey{
+            .kind = StyleContributionKind::StylesheetDeclaration,
+            .stylesheetEntity = match.stylesheetEntity,
+            .ruleIndex = match.ruleIndex,
+            .declarationIndex = declarationIndex,
+            .propertyName = std::string(declaration.name),
+        });
+        if (contributionIter == contributionIndexByKey.end()) {
+          continue;
+        }
+
+        AddMatchedElement(&annotations->contributions[contributionIter->second], element);
+      }
+    }
+  }
+
+  for (StyleSourceContribution& contribution : annotations->contributions) {
+    if (contribution.kind == StyleContributionKind::StylesheetDeclaration) {
+      contribution.chipTooltip = "Selector matches " +
+                                 std::to_string(contribution.matchedElementCount) + " element" +
+                                 (contribution.matchedElementCount == 1 ? "" : "s");
+      ApplyReverseReferenceFanoutMarker(&contribution);
+    }
+  }
+}
+
+void AddLocalCascadeEntries(const svg::SVGElement& element,
+                            const std::unordered_map<ContributionKey, std::size_t,
+                                                     ContributionKeyHash>& contributionIndexByKey,
+                            std::vector<CascadeEntry>* entries) {
+  std::optional<xml::XMLNode> xmlNode = xml::XMLNode::TryCast(element.entityHandle());
+  if (!xmlNode.has_value()) {
+    return;
+  }
+
+  for (const xml::XMLQualifiedNameRef& attrName : xmlNode->attributes()) {
+    const std::string propertyName = attrName.toString();
+    if (!IsPresentationAttributeProperty(propertyName)) {
+      continue;
+    }
+
+    std::optional<RcString> attrValue = xmlNode->getAttribute(attrName);
+    auto contributionIter = contributionIndexByKey.find(ContributionKey{
+        .kind = StyleContributionKind::PresentationAttribute,
+        .elementEntity = element.entityHandle().entity(),
+        .propertyName = propertyName,
+    });
+    if (!attrValue.has_value() || contributionIter == contributionIndexByKey.end()) {
+      continue;
+    }
+
+    entries->push_back(CascadeEntry{
+        .contributionIndex = contributionIter->second,
+        .specificity = kPresentationSpecificity,
+        .presentationValue = std::string(*attrValue),
+    });
+  }
+
+  std::optional<RcString> styleValue = xmlNode->getAttribute(xml::XMLQualifiedNameRef("style"));
+  if (!styleValue.has_value()) {
+    return;
+  }
+
+  const std::vector<css::Declaration> declarations = css::CSS::ParseStyleAttribute(*styleValue);
+  for (std::size_t declarationIndex = 0; declarationIndex < declarations.size();
+       ++declarationIndex) {
+    const css::Declaration& declaration = declarations[declarationIndex];
+    auto contributionIter = contributionIndexByKey.find(ContributionKey{
+        .kind = StyleContributionKind::InlineStyleDeclaration,
+        .elementEntity = element.entityHandle().entity(),
+        .declarationIndex = declarationIndex,
+        .propertyName = std::string(declaration.name),
+    });
+    if (contributionIter == contributionIndexByKey.end()) {
+      continue;
+    }
+
+    entries->push_back(CascadeEntry{
+        .contributionIndex = contributionIter->second,
+        .specificity = SpecificityForDeclaration(declaration, css::Specificity::StyleAttribute()),
+        .declaration = declaration,
+    });
+  }
+}
+
+void AddStylesheetCascadeEntries(
+    const svg::SVGElement& element,
+    const std::unordered_map<ContributionKey, std::size_t, ContributionKeyHash>&
+        contributionIndexByKey,
+    std::vector<CascadeEntry>* entries) {
+  const StyleSystem styleSystem;
+  const std::vector<MatchedStyleRule> matches =
+      styleSystem.collectMatchedStyleRules(element.entityHandle());
+  for (const MatchedStyleRule& match : matches) {
+    if (match.isUserAgentStylesheet) {
+      continue;
+    }
+
+    const auto* stylesheet =
+        element.entityHandle().registry()->try_get<StylesheetComponent>(match.stylesheetEntity);
+    if (stylesheet == nullptr) {
+      continue;
+    }
+
+    const std::span<const css::SelectorRule> rules = stylesheet->stylesheet.rules();
+    if (match.ruleIndex >= rules.size()) {
+      continue;
+    }
+
+    const css::SelectorRule& rule = rules[match.ruleIndex];
+    for (std::size_t declarationIndex = 0; declarationIndex < rule.declarations.size();
+         ++declarationIndex) {
+      const css::Declaration& declaration = rule.declarations[declarationIndex];
+      auto contributionIter = contributionIndexByKey.find(ContributionKey{
+          .kind = StyleContributionKind::StylesheetDeclaration,
+          .stylesheetEntity = match.stylesheetEntity,
+          .ruleIndex = match.ruleIndex,
+          .declarationIndex = declarationIndex,
+          .propertyName = std::string(declaration.name),
+      });
+      if (contributionIter == contributionIndexByKey.end()) {
+        continue;
+      }
+
+      entries->push_back(CascadeEntry{
+          .contributionIndex = contributionIter->second,
+          .specificity = SpecificityForDeclaration(declaration, match.specificity),
+          .declaration = declaration,
+      });
+    }
+  }
+}
+
+void MarkEffectiveContributionsForElement(
+    const svg::SVGElement& element, StyleSourceAnnotations* annotations,
+    const std::unordered_map<ContributionKey, std::size_t, ContributionKeyHash>&
+        contributionIndexByKey) {
+  std::vector<CascadeEntry> entries;
+  AddLocalCascadeEntries(element, contributionIndexByKey, &entries);
+  AddStylesheetCascadeEntries(element, contributionIndexByKey, &entries);
+
+  std::unordered_map<std::string, Winner> winnersByProperty;
+  std::size_t order = 0;
+  for (const CascadeEntry& entry : entries) {
+    ++order;
+    const StyleSourceContribution& contribution =
+        annotations->contributions[entry.contributionIndex];
+
+    bool valid = false;
+    if (contribution.kind == StyleContributionKind::PresentationAttribute) {
+      valid = IsPresentationAttributeValid(contribution.propertyName, entry.presentationValue,
+                                           element.entityHandle());
+    } else if (entry.declaration.has_value()) {
+      valid = IsPropertyDeclarationValid(*entry.declaration, entry.specificity);
+    }
+
+    if (!valid) {
+      continue;
+    }
+
+    auto winnerIter = winnersByProperty.find(contribution.propertyName);
+    if (winnerIter == winnersByProperty.end() ||
+        entry.specificity > winnerIter->second.specificity ||
+        (entry.specificity == winnerIter->second.specificity && order > winnerIter->second.order)) {
+      winnersByProperty[contribution.propertyName] = Winner{
+          .specificity = entry.specificity,
+          .order = order,
+          .contributionIndex = entry.contributionIndex,
+      };
+    }
+  }
+
+  for (const auto& [propertyName, winner] : winnersByProperty) {
+    annotations->contributions[winner.contributionIndex].effective = true;
+  }
+}
+
+}  // namespace
+
+StyleSourceAnnotations ComputeStyleSourceAnnotations(svg::SVGDocument& document,
+                                                     std::string_view source) {
+  StyleSourceAnnotations annotations;
+  if (source.empty()) {
+    return annotations;
+  }
+
+  std::unordered_map<ContributionKey, std::size_t, ContributionKeyHash> contributionIndexByKey;
+  Registry& registry = document.registry();
+  AddStylesheetContributions(registry, source, &annotations, &contributionIndexByKey);
+
+  std::vector<svg::SVGElement> elements;
+  CollectElements(document.svgElement(), &elements);
+  AddReferenceResourceContributions(registry, source, elements, &annotations,
+                                    &contributionIndexByKey);
+  for (const svg::SVGElement& element : elements) {
+    AddElementLocalContributions(element, source, &annotations, &contributionIndexByKey);
+  }
+
+  AddStylesheetMatches(elements, &annotations, contributionIndexByKey);
+  for (const svg::SVGElement& element : elements) {
+    MarkEffectiveContributionsForElement(element, &annotations, contributionIndexByKey);
+  }
+
+  return annotations;
+}
+
+}  // namespace donner::editor

--- a/donner/editor/StyleSourceAnnotations.cc
+++ b/donner/editor/StyleSourceAnnotations.cc
@@ -20,16 +20,11 @@
 #include "donner/css/Specificity.h"
 #include "donner/editor/ReferenceFanout.h"
 #include "donner/svg/ElementType.h"
-#include "donner/svg/components/StylesheetComponent.h"
-#include "donner/svg/components/style/StyleSystem.h"
+#include "donner/svg/SVGStyleQuery.h"
 #include "donner/svg/properties/PropertyRegistry.h"
 
 namespace donner::editor {
 namespace {
-
-using donner::svg::components::MatchedStyleRule;
-using donner::svg::components::StylesheetComponent;
-using donner::svg::components::StyleSystem;
 
 constexpr css::Specificity kPresentationSpecificity = css::Specificity::FromABC(0, 0, 0);
 struct ContributionKey {
@@ -241,15 +236,13 @@ void AppendHrefFragmentReference(std::string_view value,
 }
 
 [[nodiscard]] std::optional<SourceByteRange> DeclarationDocumentRange(
-    const StylesheetComponent& stylesheet, const css::Declaration& declaration,
-    std::string_view source) {
-  std::optional<SourceRange> documentRange =
-      stylesheet.sourceMap.mapToDocumentSource(declaration.sourceRange);
-  if (!documentRange.has_value()) {
+    const svg::SVGStylesheetDeclaration& declaration, std::string_view source) {
+  if (!declaration.declarationSourceRange.has_value()) {
     return std::nullopt;
   }
 
-  std::optional<SourceByteRange> byteRange = ToByteRange(*documentRange, source.size());
+  std::optional<SourceByteRange> byteRange =
+      ToByteRange(*declaration.declarationSourceRange, source.size());
   if (!byteRange.has_value()) {
     return std::nullopt;
   }
@@ -258,14 +251,12 @@ void AppendHrefFragmentReference(std::string_view value,
 }
 
 [[nodiscard]] std::optional<SourceByteRange> SelectorDocumentRange(
-    const StylesheetComponent& stylesheet, const css::SelectorRule& rule, std::string_view source) {
-  std::optional<SourceRange> documentRange =
-      stylesheet.sourceMap.mapToDocumentSource(rule.selectorSourceRange);
-  if (!documentRange.has_value()) {
+    const svg::SVGStylesheetRule& rule, std::string_view source) {
+  if (!rule.selectorSourceRange.has_value()) {
     return std::nullopt;
   }
 
-  return ToByteRange(*documentRange, source.size());
+  return ToByteRange(*rule.selectorSourceRange, source.size());
 }
 
 [[nodiscard]] SourceByteRange InlineDeclarationDocumentRange(
@@ -351,50 +342,40 @@ void AddContribution(
 }
 
 void AddStylesheetContributions(
-    Registry& registry, std::string_view source, StyleSourceAnnotations* annotations,
+    std::span<const svg::SVGStylesheetRule> styleRules, std::string_view source,
+    StyleSourceAnnotations* annotations,
     std::unordered_map<ContributionKey, std::size_t, ContributionKeyHash>* contributionIndexByKey) {
-  for (auto view = registry.view<StylesheetComponent>(); auto stylesheetEntity : view) {
-    const StylesheetComponent& stylesheet = view.get<StylesheetComponent>(stylesheetEntity);
-    if (stylesheet.isUserAgentStylesheet || stylesheet.sourceMap.empty()) {
-      continue;
-    }
-
-    const std::span<const css::SelectorRule> rules = stylesheet.stylesheet.rules();
-    for (std::size_t ruleIndex = 0; ruleIndex < rules.size(); ++ruleIndex) {
-      const css::SelectorRule& rule = rules[ruleIndex];
-      const std::optional<SourceByteRange> selectorRange =
-          SelectorDocumentRange(stylesheet, rule, source);
-      bool chipAssignedForRule = false;
-      for (std::size_t declarationIndex = 0; declarationIndex < rule.declarations.size();
-           ++declarationIndex) {
-        const css::Declaration& declaration = rule.declarations[declarationIndex];
-        std::optional<SourceByteRange> sourceRange =
-            DeclarationDocumentRange(stylesheet, declaration, source);
-        if (!sourceRange.has_value()) {
-          continue;
-        }
-
-        StyleSourceContribution contribution;
-        contribution.sourceRange = *sourceRange;
-        contribution.chipRange = selectorRange.value_or(*sourceRange);
-        contribution.propertyName = std::string(declaration.name);
-        contribution.kind = StyleContributionKind::StylesheetDeclaration;
-        contribution.showChip = !chipAssignedForRule;
-        contribution.tooltip = std::string(declaration.name) +
-                               " is overridden by a later or higher-specificity CSS declaration";
-        contribution.chipTooltip = "Selector matches 0 elements";
-        chipAssignedForRule = true;
-
-        AddContribution(std::move(contribution),
-                        ContributionKey{
-                            .kind = StyleContributionKind::StylesheetDeclaration,
-                            .stylesheetEntity = stylesheetEntity,
-                            .ruleIndex = ruleIndex,
-                            .declarationIndex = declarationIndex,
-                            .propertyName = std::string(declaration.name),
-                        },
-                        annotations, contributionIndexByKey);
+  for (const svg::SVGStylesheetRule& rule : styleRules) {
+    const std::optional<SourceByteRange> selectorRange = SelectorDocumentRange(rule, source);
+    bool chipAssignedForRule = false;
+    for (const svg::SVGStylesheetDeclaration& stylesheetDeclaration : rule.declarations) {
+      const css::Declaration& declaration = stylesheetDeclaration.declaration;
+      std::optional<SourceByteRange> sourceRange =
+          DeclarationDocumentRange(stylesheetDeclaration, source);
+      if (!sourceRange.has_value()) {
+        continue;
       }
+
+      StyleSourceContribution contribution;
+      contribution.sourceRange = *sourceRange;
+      contribution.chipRange = selectorRange.value_or(*sourceRange);
+      contribution.propertyName = std::string(declaration.name);
+      contribution.kind = StyleContributionKind::StylesheetDeclaration;
+      contribution.showChip = !chipAssignedForRule;
+      contribution.tooltip = std::string(declaration.name) +
+                             " is overridden by a later or higher-specificity CSS declaration";
+      contribution.chipTooltip = "Selector matches 0 elements";
+      chipAssignedForRule = true;
+
+      AddContribution(std::move(contribution),
+                      ContributionKey{
+                          .kind = StyleContributionKind::StylesheetDeclaration,
+                          .stylesheetEntity = rule.stylesheetEntity,
+                          .ruleIndex = rule.ruleIndex,
+                          .declarationIndex = stylesheetDeclaration.declarationIndex,
+                          .propertyName = std::string(declaration.name),
+                      },
+                      annotations, contributionIndexByKey);
     }
   }
 }
@@ -420,42 +401,33 @@ void AppendAttributeFragmentReferences(const svg::SVGElement& element,
   }
 }
 
-void AppendStylesheetFragmentReferences(Registry& registry, std::string_view source,
+void AppendStylesheetFragmentReferences(std::span<const svg::SVGStylesheetRule> styleRules,
+                                        std::string_view source,
                                         std::vector<FragmentReference>* references) {
-  for (auto view = registry.view<StylesheetComponent>(); auto stylesheetEntity : view) {
-    const StylesheetComponent& stylesheet = view.get<StylesheetComponent>(stylesheetEntity);
-    if (stylesheet.isUserAgentStylesheet || stylesheet.sourceMap.empty()) {
+  for (const svg::SVGStylesheetRule& rule : styleRules) {
+    if (!rule.ruleSourceRange.has_value()) {
       continue;
     }
 
-    for (const css::SelectorRule& rule : stylesheet.stylesheet.rules()) {
-      std::optional<SourceRange> documentRange =
-          stylesheet.sourceMap.mapToDocumentSource(rule.ruleSourceRange);
-      if (!documentRange.has_value()) {
-        continue;
-      }
-
-      std::optional<SourceByteRange> ruleRange = ToByteRange(*documentRange, source.size());
-      if (!ruleRange.has_value()) {
-        continue;
-      }
-
-      AppendUrlFragmentReferences(
-          source.substr(ruleRange->start, ruleRange->end - ruleRange->start), std::nullopt,
-          references);
+    std::optional<SourceByteRange> ruleRange = ToByteRange(*rule.ruleSourceRange, source.size());
+    if (!ruleRange.has_value()) {
+      continue;
     }
+
+    AppendUrlFragmentReferences(source.substr(ruleRange->start, ruleRange->end - ruleRange->start),
+                                std::nullopt, references);
   }
 }
 
 void AddReferenceResourceContributions(
-    Registry& registry, std::string_view source, const std::vector<svg::SVGElement>& elements,
-    StyleSourceAnnotations* annotations,
+    std::string_view source, std::span<const svg::SVGStylesheetRule> styleRules,
+    const std::vector<svg::SVGElement>& elements, StyleSourceAnnotations* annotations,
     std::unordered_map<ContributionKey, std::size_t, ContributionKeyHash>* contributionIndexByKey) {
   std::vector<FragmentReference> references;
   for (const svg::SVGElement& element : elements) {
     AppendAttributeFragmentReferences(element, &references);
   }
-  AppendStylesheetFragmentReferences(registry, source, &references);
+  AppendStylesheetFragmentReferences(styleRules, source, &references);
 
   std::unordered_map<std::string, std::size_t> referenceCountById;
   std::unordered_map<std::string, std::vector<svg::SVGElement>> referencingElementsById;
@@ -610,39 +582,41 @@ void AddElementLocalContributions(
   }
 }
 
+[[nodiscard]] const svg::SVGStylesheetRule* FindStylesheetRule(
+    std::span<const svg::SVGStylesheetRule> styleRules, Entity stylesheetEntity,
+    std::size_t ruleIndex) {
+  auto iter = std::find_if(
+      styleRules.begin(), styleRules.end(), [stylesheetEntity, ruleIndex](const auto& rule) {
+        return rule.stylesheetEntity == stylesheetEntity && rule.ruleIndex == ruleIndex;
+      });
+  return iter == styleRules.end() ? nullptr : &*iter;
+}
+
 void AddStylesheetMatches(const std::vector<svg::SVGElement>& elements,
+                          std::span<const svg::SVGStylesheetRule> styleRules,
                           StyleSourceAnnotations* annotations,
                           const std::unordered_map<ContributionKey, std::size_t,
                                                    ContributionKeyHash>& contributionIndexByKey) {
-  const StyleSystem styleSystem;
   for (const svg::SVGElement& element : elements) {
-    const std::vector<MatchedStyleRule> matches =
-        styleSystem.collectMatchedStyleRules(element.entityHandle());
-    for (const MatchedStyleRule& match : matches) {
+    const std::vector<svg::SVGMatchedStyleRule> matches = svg::CollectMatchedStyleRules(element);
+    for (const svg::SVGMatchedStyleRule& match : matches) {
       if (match.isUserAgentStylesheet) {
         continue;
       }
 
-      const auto* stylesheet =
-          element.entityHandle().registry()->try_get<StylesheetComponent>(match.stylesheetEntity);
-      if (stylesheet == nullptr) {
+      const svg::SVGStylesheetRule* rule =
+          FindStylesheetRule(styleRules, match.stylesheetEntity, match.ruleIndex);
+      if (rule == nullptr) {
         continue;
       }
 
-      const std::span<const css::SelectorRule> rules = stylesheet->stylesheet.rules();
-      if (match.ruleIndex >= rules.size()) {
-        continue;
-      }
-
-      const css::SelectorRule& rule = rules[match.ruleIndex];
-      for (std::size_t declarationIndex = 0; declarationIndex < rule.declarations.size();
-           ++declarationIndex) {
-        const css::Declaration& declaration = rule.declarations[declarationIndex];
+      for (const svg::SVGStylesheetDeclaration& stylesheetDeclaration : rule->declarations) {
+        const css::Declaration& declaration = stylesheetDeclaration.declaration;
         auto contributionIter = contributionIndexByKey.find(ContributionKey{
             .kind = StyleContributionKind::StylesheetDeclaration,
             .stylesheetEntity = match.stylesheetEntity,
             .ruleIndex = match.ruleIndex,
-            .declarationIndex = declarationIndex,
+            .declarationIndex = stylesheetDeclaration.declarationIndex,
             .propertyName = std::string(declaration.name),
         });
         if (contributionIter == contributionIndexByKey.end()) {
@@ -724,38 +698,29 @@ void AddLocalCascadeEntries(const svg::SVGElement& element,
 }
 
 void AddStylesheetCascadeEntries(
-    const svg::SVGElement& element,
+    const svg::SVGElement& element, std::span<const svg::SVGStylesheetRule> styleRules,
     const std::unordered_map<ContributionKey, std::size_t, ContributionKeyHash>&
         contributionIndexByKey,
     std::vector<CascadeEntry>* entries) {
-  const StyleSystem styleSystem;
-  const std::vector<MatchedStyleRule> matches =
-      styleSystem.collectMatchedStyleRules(element.entityHandle());
-  for (const MatchedStyleRule& match : matches) {
+  const std::vector<svg::SVGMatchedStyleRule> matches = svg::CollectMatchedStyleRules(element);
+  for (const svg::SVGMatchedStyleRule& match : matches) {
     if (match.isUserAgentStylesheet) {
       continue;
     }
 
-    const auto* stylesheet =
-        element.entityHandle().registry()->try_get<StylesheetComponent>(match.stylesheetEntity);
-    if (stylesheet == nullptr) {
+    const svg::SVGStylesheetRule* rule =
+        FindStylesheetRule(styleRules, match.stylesheetEntity, match.ruleIndex);
+    if (rule == nullptr) {
       continue;
     }
 
-    const std::span<const css::SelectorRule> rules = stylesheet->stylesheet.rules();
-    if (match.ruleIndex >= rules.size()) {
-      continue;
-    }
-
-    const css::SelectorRule& rule = rules[match.ruleIndex];
-    for (std::size_t declarationIndex = 0; declarationIndex < rule.declarations.size();
-         ++declarationIndex) {
-      const css::Declaration& declaration = rule.declarations[declarationIndex];
+    for (const svg::SVGStylesheetDeclaration& stylesheetDeclaration : rule->declarations) {
+      const css::Declaration& declaration = stylesheetDeclaration.declaration;
       auto contributionIter = contributionIndexByKey.find(ContributionKey{
           .kind = StyleContributionKind::StylesheetDeclaration,
           .stylesheetEntity = match.stylesheetEntity,
           .ruleIndex = match.ruleIndex,
-          .declarationIndex = declarationIndex,
+          .declarationIndex = stylesheetDeclaration.declarationIndex,
           .propertyName = std::string(declaration.name),
       });
       if (contributionIter == contributionIndexByKey.end()) {
@@ -772,12 +737,13 @@ void AddStylesheetCascadeEntries(
 }
 
 void MarkEffectiveContributionsForElement(
-    const svg::SVGElement& element, StyleSourceAnnotations* annotations,
+    const svg::SVGElement& element, std::span<const svg::SVGStylesheetRule> styleRules,
+    StyleSourceAnnotations* annotations,
     const std::unordered_map<ContributionKey, std::size_t, ContributionKeyHash>&
         contributionIndexByKey) {
   std::vector<CascadeEntry> entries;
   AddLocalCascadeEntries(element, contributionIndexByKey, &entries);
-  AddStylesheetCascadeEntries(element, contributionIndexByKey, &entries);
+  AddStylesheetCascadeEntries(element, styleRules, contributionIndexByKey, &entries);
 
   std::unordered_map<std::string, Winner> winnersByProperty;
   std::size_t order = 0;
@@ -823,23 +789,24 @@ StyleSourceAnnotations ComputeStyleSourceAnnotations(svg::SVGDocument& document,
     return {};
   }
 
-  return document.withWriteAccess([&document, source](svg::DocumentWriteAccess& access) {
+  return document.withWriteAccess([&document, source](svg::DocumentWriteAccess&) {
     StyleSourceAnnotations annotations;
     std::unordered_map<ContributionKey, std::size_t, ContributionKeyHash> contributionIndexByKey;
-    Registry& registry = access.registry();
-    AddStylesheetContributions(registry, source, &annotations, &contributionIndexByKey);
+    const std::vector<svg::SVGStylesheetRule> styleRules = svg::CollectStylesheetRules(document);
+    AddStylesheetContributions(styleRules, source, &annotations, &contributionIndexByKey);
 
     std::vector<svg::SVGElement> elements;
     CollectElements(document.svgElement(), &elements);
-    AddReferenceResourceContributions(registry, source, elements, &annotations,
+    AddReferenceResourceContributions(source, styleRules, elements, &annotations,
                                       &contributionIndexByKey);
     for (const svg::SVGElement& element : elements) {
       AddElementLocalContributions(element, source, &annotations, &contributionIndexByKey);
     }
 
-    AddStylesheetMatches(elements, &annotations, contributionIndexByKey);
+    AddStylesheetMatches(elements, styleRules, &annotations, contributionIndexByKey);
     for (const svg::SVGElement& element : elements) {
-      MarkEffectiveContributionsForElement(element, &annotations, contributionIndexByKey);
+      MarkEffectiveContributionsForElement(element, styleRules, &annotations,
+                                           contributionIndexByKey);
     }
 
     return annotations;

--- a/donner/editor/StyleSourceAnnotations.h
+++ b/donner/editor/StyleSourceAnnotations.h
@@ -1,0 +1,58 @@
+#pragma once
+/// @file
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "donner/editor/FlashDecorations.h"
+#include "donner/svg/SVGDocument.h"
+#include "donner/svg/SVGElement.h"
+
+namespace donner::editor {
+
+/// Source contribution kind for editor-side cascade annotations.
+enum class StyleContributionKind {
+  StylesheetDeclaration,     ///< Declaration inside an authored `<style>` rule.
+  InlineStyleDeclaration,    ///< Declaration inside an element `style=""` attribute.
+  PresentationAttribute,     ///< SVG presentation attribute on an element.
+  ReferenceResourceElement,  ///< Non-rendered resource element such as a gradient or filter.
+};
+
+/// One source-backed style contribution and its source-editor annotation metadata.
+struct StyleSourceContribution {
+  std::size_t id = 0;  ///< Stable id within a single annotation computation.
+  SourceByteRange sourceRange;
+  SourceByteRange chipRange;  ///< Source range whose end anchors the selector chip.
+  std::string propertyName;
+  StyleContributionKind kind = StyleContributionKind::StylesheetDeclaration;
+  bool effective = false;  ///< True when this contribution wins for at least one element.
+  bool showChip = false;   ///< True when a selector match-count chip should be shown.
+  int matchedElementCount = 0;
+  bool showOverflowMarker = false;  ///< True when a chip should show an overflow marker.
+  std::vector<svg::SVGElement> matchedElements;
+  std::string tooltip;          ///< Tooltip for the source range.
+  std::string chipTooltip;      ///< Tooltip for the selector match-count chip.
+  std::string overflowTooltip;  ///< Tooltip for the overflow marker.
+};
+
+/// Source annotations derived from CSS cascade analysis.
+struct StyleSourceAnnotations {
+  std::vector<StyleSourceContribution> contributions;
+};
+
+/**
+ * Compute source-editor style annotations for \p document.
+ *
+ * This is intentionally read-only: it describes which source style contributions are selected by
+ * the cascade but does not modify rendering, CSS state, or DOM state.
+ *
+ * @param document Source-backed SVG document to inspect.
+ * @param source Source text currently synchronized with \p document.
+ * @return Style contribution annotations for the text editor.
+ */
+[[nodiscard]] StyleSourceAnnotations ComputeStyleSourceAnnotations(svg::SVGDocument& document,
+                                                                   std::string_view source);
+
+}  // namespace donner::editor

--- a/donner/editor/TextEditor.cc
+++ b/donner/editor/TextEditor.cc
@@ -1119,6 +1119,9 @@ void TextEditor::renderInternal(std::string_view title) {
   }
 
   renderFocusReferenceLinks(drawList);
+  renderSourceStyleDecorationChips(drawList);
+  hitTestSourceStyleDecorationChips();
+  renderSourceStyleDecorationTooltip();
   renderExtraUI(drawList, cursorScreenPos, scrollX, scrollY, longestLine, contentSize);
   handleScrolling();
 }
@@ -1306,6 +1309,7 @@ void TextEditor::renderLine(int lineNo, const ImVec2& lineStart, const ImVec2& t
 
   // Render text
   renderText(line, textStart, drawList);
+  renderSourceStyleDecorationStrikethroughs(lineNo, 0, text_.getLineMaxColumn(lineNo), drawList);
 
   // Render cursor if this is the cursor line
   if (state_.cursorPosition.line == lineNo) {
@@ -1342,6 +1346,8 @@ void TextEditor::renderVisualLine(const VisualLine& visualLine, int visualLineIn
   }
 
   renderText(visualLine, line, textStart, drawList);
+  renderSourceStyleDecorationStrikethroughs(visualLine.lineNo, visualLine.startColumn,
+                                            visualLine.endColumn, drawList);
 
   if (state_.cursorPosition.line == visualLine.lineNo &&
       visualLineIndex == visualLineIndexForCoordinates(state_.cursorPosition)) {
@@ -1586,6 +1592,22 @@ float TextBaselineOffsetY() {
   return font->Ascent * (ImGui::GetFontSize() / font->FontSize);
 }
 
+ImU32 SourceStyleChipFillColor() {
+  return ImGui::ColorConvertFloat4ToU32(ImVec4(0.13f, 0.39f, 0.64f, 0.96f));
+}
+
+ImU32 SourceStyleChipBorderColor() {
+  return ImGui::ColorConvertFloat4ToU32(ImVec4(0.58f, 0.78f, 0.95f, 0.76f));
+}
+
+ImU32 SourceStyleChipTextColor() {
+  return ImGui::ColorConvertFloat4ToU32(ImVec4(0.96f, 0.99f, 1.0f, 1.0f));
+}
+
+ImU32 SourceStyleStrikethroughColor() {
+  return ImGui::ColorConvertFloat4ToU32(ImVec4(1.0f, 1.0f, 1.0f, 0.92f));
+}
+
 }  // namespace
 
 std::optional<TextEditor::FocusReferenceConnectorLayout> TextEditor::focusReferenceConnectorLayout(
@@ -1600,9 +1622,14 @@ std::optional<TextEditor::FocusReferenceConnectorLayout> TextEditor::focusRefere
   layout.start.x += charAdvance_.x * 0.5f;
   layout.start.y += baselineY;
 
-  layout.tip = coordinatesToScreenPos(Coordinates(link.to.line, link.to.column));
-  layout.tip.x -= 2.0f * uiScale_;
-  layout.tip.y += baselineY;
+  if (std::optional<SourceStyleChipBounds> targetChip = sourceStyleChipBoundsForAnchor(link.to)) {
+    layout.tip = ImVec2(targetChip->max.x,
+                        targetChip->min.y + (targetChip->max.y - targetChip->min.y) * 0.5f);
+  } else {
+    layout.tip = coordinatesToScreenPos(Coordinates(link.to.line, link.to.column));
+    layout.tip.x -= 2.0f * uiScale_;
+    layout.tip.y += baselineY;
+  }
 
   constexpr int kLaneCount = 5;
   const int laneIndex = ((linkIndex % kLaneCount) + kLaneCount) % kLaneCount;
@@ -1623,6 +1650,53 @@ std::optional<TextEditor::FocusReferenceConnectorLayout> TextEditor::focusRefere
       ImGui::ColorConvertU32ToFloat4(palette_[static_cast<int>(ColorIndex::Selection)]).w;
   layout.color = PastelReferenceColor(link, linkIndex, selectionAlpha);
   return layout;
+}
+
+std::optional<TextEditor::SourceStyleChipBounds> TextEditor::sourceStyleChipBoundsForDecoration(
+    const SourceStyleDecoration& decoration) const {
+  if (!decoration.showChip) {
+    return std::nullopt;
+  }
+
+  const SourceByteRange anchorRange = decoration.chipRange.end > decoration.chipRange.start
+                                          ? decoration.chipRange
+                                          : decoration.range;
+  const Coordinates anchor = getCoordinatesAtByteOffset(anchorRange.end);
+  if (isLineHiddenByFocus(anchor.line)) {
+    return std::nullopt;
+  }
+
+  const float paddingX = std::max(3.0f * uiScale_, 3.0f);
+  const float paddingY = std::max(1.0f * uiScale_, 1.0f);
+  const float gap = std::max(4.0f * uiScale_, 4.0f);
+  const std::string label = std::to_string(decoration.chipCount);
+  const ImVec2 textSize =
+      ImGui::GetFont()->CalcTextSizeA(ImGui::GetFontSize(), FLT_MAX, -1.0f, label.c_str());
+  const ImVec2 chipSize(textSize.x + paddingX * 2.0f, textSize.y + paddingY * 2.0f);
+  ImVec2 min = coordinatesToScreenPos(anchor);
+  min.x += gap;
+  min.y += std::max(0.0f, (charAdvance_.y - chipSize.y) * 0.5f);
+  return SourceStyleChipBounds{
+      .min = min,
+      .max = ImVec2(min.x + chipSize.x, min.y + chipSize.y),
+  };
+}
+
+std::optional<TextEditor::SourceStyleChipBounds> TextEditor::sourceStyleChipBoundsForAnchor(
+    const SourcePoint& anchor) const {
+  for (const SourceStyleDecoration& decoration : sourceStyleDecorations_) {
+    const SourceByteRange anchorRange = decoration.chipRange.end > decoration.chipRange.start
+                                            ? decoration.chipRange
+                                            : decoration.range;
+    const Coordinates chipAnchor = getCoordinatesAtByteOffset(anchorRange.end);
+    if (chipAnchor.line != anchor.line || chipAnchor.column != anchor.column) {
+      continue;
+    }
+
+    return sourceStyleChipBoundsForDecoration(decoration);
+  }
+
+  return std::nullopt;
 }
 
 void TextEditor::renderFocusReferenceLinks(ImDrawList* drawList) {
@@ -1651,6 +1725,165 @@ void TextEditor::renderFocusReferenceLinks(ImDrawList* drawList) {
     DrawArrowhead(drawList, layout->tip, SubVec(layout->tip, layout->laneEnd), layout->color,
                   arrowLength, arrowHalfWidth);
     ++visibleLinkIndex;
+  }
+}
+
+const TextEditor::SourceStyleDecoration* TextEditor::sourceStyleDecorationAtByteOffset(
+    std::size_t byteOffset, bool ineffectiveOnly) const {
+  for (const SourceStyleDecoration& decoration : sourceStyleDecorations_) {
+    if (ineffectiveOnly && !decoration.ineffective) {
+      continue;
+    }
+    if (byteOffset >= decoration.range.start && byteOffset < decoration.range.end) {
+      return &decoration;
+    }
+  }
+
+  return nullptr;
+}
+
+bool TextEditor::isByteOffsetInIneffectiveStyleDecoration(std::size_t byteOffset) const {
+  return sourceStyleDecorationAtByteOffset(byteOffset, /*ineffectiveOnly=*/true) != nullptr;
+}
+
+void TextEditor::renderSourceStyleDecorationStrikethroughs(int lineNo, int startColumn,
+                                                           int endColumn, ImDrawList* drawList) {
+  if (sourceStyleDecorations_.empty() || drawList == nullptr || endColumn <= startColumn) {
+    return;
+  }
+
+  const ImU32 color = SourceStyleStrikethroughColor();
+  const float thickness = std::max(1.0f, uiScale_);
+  constexpr float kStrikeHeightFraction = 0.5f;
+  constexpr float kStrikeOffsetY = -2.0f;
+
+  for (const SourceStyleDecoration& decoration : sourceStyleDecorations_) {
+    if (!decoration.ineffective) {
+      continue;
+    }
+
+    const Coordinates rangeStart = getCoordinatesAtByteOffset(decoration.range.start);
+    const Coordinates rangeEnd = getCoordinatesAtByteOffset(decoration.range.end);
+    if (rangeEnd.line < lineNo || rangeStart.line > lineNo) {
+      continue;
+    }
+
+    int strikeStartColumn = startColumn;
+    int strikeEndColumn = endColumn;
+    if (rangeStart.line == lineNo) {
+      strikeStartColumn = std::max(strikeStartColumn, rangeStart.column);
+    }
+    if (rangeEnd.line == lineNo) {
+      strikeEndColumn = std::min(strikeEndColumn, rangeEnd.column);
+    }
+    if (strikeEndColumn <= strikeStartColumn) {
+      continue;
+    }
+
+    const ImVec2 start = coordinatesToScreenPos(Coordinates(lineNo, strikeStartColumn));
+    const ImVec2 end = coordinatesToScreenPos(Coordinates(lineNo, strikeEndColumn));
+    const float y =
+        std::floor(start.y + ImGui::GetFontSize() * kStrikeHeightFraction + kStrikeOffsetY) + 0.5f;
+    drawList->AddLine(ImVec2(start.x, y), ImVec2(end.x, y), color, thickness);
+  }
+}
+
+void TextEditor::renderSourceStyleDecorationChips(ImDrawList* drawList) {
+  sourceStyleChipHitRects_.clear();
+  if (sourceStyleDecorations_.empty()) {
+    return;
+  }
+
+  const float paddingX = std::max(3.0f * uiScale_, 3.0f);
+  const float paddingY = std::max(1.0f * uiScale_, 1.0f);
+  const float rounding = 4.0f * uiScale_;
+  const float markerGap = std::max(2.0f * uiScale_, 2.0f);
+  const float markerFontSize = ImGui::GetFontSize() * 1.45f;
+  const float markerHitPadding = std::max(2.0f * uiScale_, 2.0f);
+  constexpr const char* kOverflowMarker = "∗";
+
+  for (const SourceStyleDecoration& decoration : sourceStyleDecorations_) {
+    if (!decoration.showChip) {
+      continue;
+    }
+
+    std::optional<SourceStyleChipBounds> bounds = sourceStyleChipBoundsForDecoration(decoration);
+    if (!bounds.has_value()) {
+      continue;
+    }
+
+    const std::string label = std::to_string(decoration.chipCount);
+    const ImVec2 min = bounds->min;
+    const ImVec2 max = bounds->max;
+    const ImVec2 chipSize(max.x - min.x, max.y - min.y);
+
+    drawList->AddRectFilled(min, max, SourceStyleChipFillColor(), rounding);
+    drawList->AddRect(min, max, SourceStyleChipBorderColor(), rounding, ImDrawFlags_None,
+                      std::max(1.0f, uiScale_));
+    drawList->AddText(ImVec2(min.x + paddingX, min.y + paddingY), SourceStyleChipTextColor(),
+                      label.c_str());
+
+    sourceStyleChipHitRects_.push_back(SourceStyleChipHitRect{
+        .id = decoration.id,
+        .min = min,
+        .max = max,
+        .tooltip = decoration.chipTooltip.empty() ? decoration.tooltip : decoration.chipTooltip,
+    });
+
+    if (decoration.showOverflowMarker) {
+      const ImVec2 markerSize =
+          ImGui::GetFont()->CalcTextSizeA(markerFontSize, FLT_MAX, -1.0f, kOverflowMarker);
+      const ImVec2 markerMin(max.x + markerGap, min.y + (chipSize.y - markerSize.y) * 0.5f);
+      const ImVec2 markerMax(markerMin.x + markerSize.x, markerMin.y + markerSize.y);
+      drawList->AddText(ImGui::GetFont(), markerFontSize, markerMin, SourceStyleChipFillColor(),
+                        kOverflowMarker);
+
+      sourceStyleChipHitRects_.push_back(SourceStyleChipHitRect{
+          .id = decoration.id,
+          .min = ImVec2(markerMin.x - markerHitPadding, markerMin.y - markerHitPadding),
+          .max = ImVec2(markerMax.x + markerHitPadding, markerMax.y + markerHitPadding),
+          .tooltip = decoration.overflowTooltip,
+          .clickEnabled = false,
+      });
+    }
+  }
+}
+
+void TextEditor::hitTestSourceStyleDecorationChips() {
+  if (sourceStyleChipHitRects_.empty()) {
+    return;
+  }
+
+  for (const SourceStyleChipHitRect& hitRect : sourceStyleChipHitRects_) {
+    if (!ImGui::IsMouseHoveringRect(hitRect.min, hitRect.max)) {
+      continue;
+    }
+
+    if (!hitRect.tooltip.empty()) {
+      ImGui::SetTooltip("%s", hitRect.tooltip.c_str());
+    }
+    if (hitRect.clickEnabled && ImGui::IsMouseClicked(0)) {
+      clickedSourceStyleChipId_ = hitRect.id;
+    }
+    return;
+  }
+}
+
+void TextEditor::renderSourceStyleDecorationTooltip() {
+  if (!hoveredTextPosition_.has_value()) {
+    return;
+  }
+  for (const SourceStyleChipHitRect& hitRect : sourceStyleChipHitRects_) {
+    if (ImGui::IsMouseHoveringRect(hitRect.min, hitRect.max)) {
+      return;
+    }
+  }
+
+  const std::size_t byteOffset = getByteOffsetAtCoordinates(*hoveredTextPosition_);
+  const SourceStyleDecoration* decoration =
+      sourceStyleDecorationAtByteOffset(byteOffset, /*ineffectiveOnly=*/true);
+  if (decoration != nullptr && !decoration->tooltip.empty()) {
+    ImGui::SetTooltip("%s", decoration->tooltip.c_str());
   }
 }
 
@@ -1762,6 +1995,50 @@ bool TextEditor::setHoverSourceRanges(std::vector<SourceByteRange> ranges) {
 
   hoverSourceRanges_ = std::move(ranges);
   return true;
+}
+
+bool TextEditor::setSourceStyleDecorations(std::vector<SourceStyleDecoration> decorations) {
+  const std::size_t bufferSize = getText().size();
+  for (SourceStyleDecoration& decoration : decorations) {
+    decoration.range.start = std::min(decoration.range.start, bufferSize);
+    decoration.range.end = std::min(decoration.range.end, bufferSize);
+    decoration.chipRange.start = std::min(decoration.chipRange.start, bufferSize);
+    decoration.chipRange.end = std::min(decoration.chipRange.end, bufferSize);
+    if (decoration.chipRange.end <= decoration.chipRange.start) {
+      decoration.chipRange = decoration.range;
+    }
+    decoration.chipCount = std::max(0, decoration.chipCount);
+  }
+
+  std::erase_if(decorations, [](const SourceStyleDecoration& decoration) {
+    return decoration.range.end <= decoration.range.start;
+  });
+  std::sort(decorations.begin(), decorations.end(),
+            [](const SourceStyleDecoration& lhs, const SourceStyleDecoration& rhs) {
+              if (lhs.range.start != rhs.range.start) {
+                return lhs.range.start < rhs.range.start;
+              }
+              if (lhs.range.end != rhs.range.end) {
+                return lhs.range.end < rhs.range.end;
+              }
+              return lhs.id < rhs.id;
+            });
+  decorations.erase(std::unique(decorations.begin(), decorations.end()), decorations.end());
+
+  if (sourceStyleDecorations_ == decorations) {
+    return false;
+  }
+
+  sourceStyleDecorations_ = std::move(decorations);
+  sourceStyleChipHitRects_.clear();
+  clickedSourceStyleChipId_.reset();
+  return true;
+}
+
+std::optional<std::size_t> TextEditor::takeClickedSourceStyleChipId() {
+  std::optional<std::size_t> clicked = clickedSourceStyleChipId_;
+  clickedSourceStyleChipId_.reset();
+  return clicked;
 }
 
 bool TextEditor::isPositionInsideFocusRange(const Coordinates& position) const {
@@ -1919,7 +2196,8 @@ void TextEditor::renderText(const VisualLine& visualLine, const Line& line, cons
     ImU32 color = getGlyphColor(glyph);
     if (referenceColored) {
       color = referenceTextColor(color);
-    } else if (dimmed) {
+    }
+    if (dimmed) {
       color = dimmedTextColor(color);
     }
 
@@ -1940,7 +2218,8 @@ void TextEditor::renderText(const VisualLine& visualLine, const Line& line, cons
       ImU32 arrowColor = 0x99906060;
       if (referenceColored) {
         arrowColor = referenceTextColor(arrowColor);
-      } else if (dimmed) {
+      }
+      if (dimmed) {
         arrowColor = dimmedTextColor(arrowColor);
       }
       drawList->AddText(ImGui::GetFont(), ImGui::GetFontSize(), ImVec2(arrowX, arrowY), arrowColor,
@@ -1952,7 +2231,8 @@ void TextEditor::renderText(const VisualLine& visualLine, const Line& line, cons
       ImU32 dotColor = 0x99805050;
       if (referenceColored) {
         dotColor = referenceTextColor(dotColor);
-      } else if (dimmed) {
+      }
+      if (dimmed) {
         dotColor = dimmedTextColor(dotColor);
       }
       drawList->AddCircleFilled(ImVec2(centerX, centerY), 1.0f, dotColor, 4);

--- a/donner/editor/TextEditor.cc
+++ b/donner/editor/TextEditor.cc
@@ -1,13 +1,16 @@
 #include "donner/editor/TextEditor.h"
 
 #include <algorithm>
+#include <cctype>
 #include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <functional>
 #include <regex>
+#include <span>
 #include <stack>
 #include <string>
+#include <vector>
 
 #include "donner/base/Utf8.h"
 #include "donner/base/Utils.h"
@@ -17,6 +20,8 @@
 namespace donner::editor {
 
 namespace {
+
+constexpr float kFocusReferenceRopeWakeSeconds = 1.0f / 60.0f;
 
 /**
  * Compare two ranges for equality using a binary predicate.
@@ -85,6 +90,9 @@ TextEditor::TextEditor()
     if (onContentUpdate) {
       onContentUpdate(this);
     }
+  };
+  core_.sourceEditIntentHook = [this](const SourceEditIntent& intent) {
+    remapFocusMetadataForSourceEdit(intent);
   };
 }
 
@@ -679,6 +687,13 @@ void TextEditor::handleMouseInputs() {
     functionDeclarationTooltip_ = false;
   }
 
+  if (click && tryNavigateToFocusReferenceRopeAt(ImGui::GetMousePos())) {
+    autocompleteOpened_ = false;
+    autocompleteObject_.clear();
+    lastClick_ = -1.0f;
+    return;
+  }
+
   if (click && tryExpandFocusHiddenPlaceholderAt(ImGui::GetMousePos())) {
     lastClick_ = -1.0f;
     return;
@@ -765,14 +780,6 @@ void TextEditor::handleMouseInputs() {
 
     // Create selection from start to current point
     core_.setInteractiveSelection(interactiveStart_, interactiveEnd_, selectionMode_);
-
-    // Handle autoscroll during selection
-    const float mouseX = ImGui::GetMousePos().x;
-    if (mouseX > findOrigin_.x + windowWidth_ - 50 && mouseX < findOrigin_.x + windowWidth_) {
-      ImGui::SetScrollX(ImGui::GetScrollX() + 1.0f);
-    } else if (mouseX > findOrigin_.x && mouseX < findOrigin_.x + textStart_ + 50) {
-      ImGui::SetScrollX(ImGui::GetScrollX() - 1.0f);
-    }
 
     // Handle vertical autoscroll
     const float mouseY = ImGui::GetMousePos().y;
@@ -1079,7 +1086,10 @@ void TextEditor::renderInternal(std::string_view title) {
   }
 
   const ImVec2 cursorScreenPos = uiCursorPos_ = ImGui::GetCursorScreenPos();
-  const float scrollX = lastScrollX_ = ImGui::GetScrollX();
+  if (!horizontalScroll_) {
+    ImGui::SetScrollX(0.0f);
+  }
+  const float scrollX = lastScrollX_ = horizontalScroll_ ? ImGui::GetScrollX() : 0.0f;
   const float scrollY = lastScroll_ = ImGui::GetScrollY();
 
   // Calculate visible lines
@@ -1143,13 +1153,10 @@ void TextEditor::handleScrolling() {
     return;
   }
 
-  const float scrollX = ImGui::GetScrollX();
   const float scrollY = ImGui::GetScrollY();
   const float height = visibleTextRegionHeight();
-  const float width = windowWidth_;
 
   const auto pos = getActualCursorCoordinates();
-  const auto len = getTextDistanceToLineStart(pos);
 
   if ((wordWrapEnabled_ || focusPartitionActive_) && !visualLines_.empty()) {
     const int visualIndex = visualLineIndexForCoordinates(pos);
@@ -1168,20 +1175,12 @@ void TextEditor::handleScrolling() {
   const auto top = static_cast<int>(std::floor(scrollY / charAdvance_.y));
   const auto bottom =
       static_cast<int>(std::floor((scrollY + height - charAdvance_.y) / charAdvance_.y));
-  const auto left = static_cast<int>(std::ceil(scrollX / charAdvance_.x));
-  const auto right = static_cast<int>(std::ceil((scrollX + width) / charAdvance_.x));
 
   if (pos.line < top) {
     ImGui::SetScrollY(std::max(0.0f, pos.line * charAdvance_.y));
   }
   if (pos.line > bottom) {
     ImGui::SetScrollY(std::max(0.0f, (pos.line + 1) * charAdvance_.y - height));
-  }
-  if (pos.column < left) {
-    ImGui::SetScrollX(std::max(0.0f, len + textStart_ - 11 * charAdvance_.x));
-  }
-  if (len + textStart_ > (right - 4) * charAdvance_.x) {
-    ImGui::SetScrollX(std::max(0.0f, len + textStart_ + 4 * charAdvance_.x - width));
   }
 
   scrollToCursor_ = false;
@@ -1500,6 +1499,14 @@ ImVec2 MulVec(const ImVec2& value, float scale) {
   return ImVec2(value.x * scale, value.y * scale);
 }
 
+Vector2d ToVector2d(const ImVec2& value) {
+  return Vector2d(value.x, value.y);
+}
+
+ImVec2 ToImVec2(const Vector2d& value) {
+  return ImVec2(static_cast<float>(value.x), static_cast<float>(value.y));
+}
+
 float VecLength(const ImVec2& value) {
   return std::sqrt(value.x * value.x + value.y * value.y);
 }
@@ -1509,31 +1516,124 @@ ImVec2 NormalizeVec(const ImVec2& value) {
   return length > 0.001f ? MulVec(value, 1.0f / length) : ImVec2(0.0f, 0.0f);
 }
 
-void PathRoundedCorner(ImDrawList* drawList, const ImVec2& previous, const ImVec2& corner,
-                       const ImVec2& next, float radius) {
-  const float previousLength = VecLength(SubVec(previous, corner));
-  const float nextLength = VecLength(SubVec(next, corner));
-  const float cornerRadius = std::min({radius, previousLength * 0.5f, nextLength * 0.5f});
-  if (cornerRadius <= 0.5f) {
-    drawList->PathLineTo(corner);
-    return;
-  }
-
-  const ImVec2 before =
-      AddVec(corner, MulVec(NormalizeVec(SubVec(previous, corner)), cornerRadius));
-  const ImVec2 after = AddVec(corner, MulVec(NormalizeVec(SubVec(next, corner)), cornerRadius));
-  drawList->PathLineTo(before);
-  drawList->PathBezierQuadraticCurveTo(corner, after, 8);
+bool IsReferenceSourceChar(char value) {
+  const unsigned char ch = static_cast<unsigned char>(value);
+  return std::isalnum(ch) != 0 || value == '_' || value == '-' || value == '#' || value == '.' ||
+         value == ':' || value == '%';
 }
 
-void StrokeRoundedConnector(ImDrawList* drawList, const ImVec2& start, const ImVec2& bendA,
-                            const ImVec2& bendB, const ImVec2& end, ImU32 color, float thickness,
-                            float radius) {
-  drawList->PathLineTo(start);
-  PathRoundedCorner(drawList, start, bendA, bendB, radius);
-  PathRoundedCorner(drawList, bendA, bendB, end, radius);
-  drawList->PathLineTo(end);
-  drawList->PathStroke(color, ImDrawFlags_None, thickness);
+enum class EditBoundaryBias {
+  Before,
+  After,
+};
+
+SourcePoint ToSourcePoint(const SourceEditPoint& point) {
+  return SourcePoint{.line = point.line, .column = point.column};
+}
+
+int CompareSourcePoints(const SourcePoint& lhs, const SourcePoint& rhs) {
+  if (lhs.line != rhs.line) {
+    return lhs.line < rhs.line ? -1 : 1;
+  }
+  if (lhs.column != rhs.column) {
+    return lhs.column < rhs.column ? -1 : 1;
+  }
+  return 0;
+}
+
+SourcePoint ShiftPointAfterEdit(const SourcePoint& point, const SourcePoint& oldEnd,
+                                const SourcePoint& newEnd) {
+  if (point.line == oldEnd.line) {
+    return SourcePoint{
+        .line = newEnd.line,
+        .column = std::max(0, newEnd.column + point.column - oldEnd.column),
+    };
+  }
+
+  return SourcePoint{
+      .line = std::max(0, point.line + newEnd.line - oldEnd.line),
+      .column = point.column,
+  };
+}
+
+SourcePoint MapSourcePointForEdit(const SourcePoint& point, const SourceEditIntent& intent,
+                                  EditBoundaryBias bias) {
+  const SourcePoint start = ToSourcePoint(intent.start);
+  const SourcePoint oldEnd = ToSourcePoint(intent.removedEnd);
+  const SourcePoint newEnd = ToSourcePoint(intent.replacementEnd);
+  const int startComparison = CompareSourcePoints(point, start);
+  if (startComparison < 0) {
+    return point;
+  }
+
+  if (CompareSourcePoints(oldEnd, start) == 0) {
+    if (startComparison == 0) {
+      return bias == EditBoundaryBias::After ? newEnd : start;
+    }
+    return ShiftPointAfterEdit(point, oldEnd, newEnd);
+  }
+
+  const int endComparison = CompareSourcePoints(point, oldEnd);
+  if (endComparison > 0) {
+    return ShiftPointAfterEdit(point, oldEnd, newEnd);
+  }
+  if (startComparison == 0 && bias == EditBoundaryBias::Before) {
+    return start;
+  }
+
+  return bias == EditBoundaryBias::After ? newEnd : start;
+}
+
+std::size_t MapSourceOffsetForEdit(std::size_t point, const SourceEditIntent& intent,
+                                   EditBoundaryBias bias) {
+  const std::size_t editStart = intent.offset;
+  const std::size_t removedLength = intent.removedLength;
+  const std::size_t insertedLength = intent.replacement.size();
+  const std::size_t editEnd = editStart + removedLength;
+  if (point < editStart) {
+    return point;
+  }
+
+  if (removedLength == 0u && point == editStart) {
+    return bias == EditBoundaryBias::After ? editStart + insertedLength : editStart;
+  }
+
+  if (point > editEnd) {
+    if (insertedLength >= removedLength) {
+      return point + (insertedLength - removedLength);
+    }
+    return point - (removedLength - insertedLength);
+  }
+
+  if (point == editStart && bias == EditBoundaryBias::Before) {
+    return editStart;
+  }
+  return editStart + insertedLength;
+}
+
+SourceByteRange MapSourceByteRangeForEdit(SourceByteRange range, const SourceEditIntent& intent,
+                                          std::size_t newBufferSize) {
+  range.start =
+      std::min(MapSourceOffsetForEdit(range.start, intent, EditBoundaryBias::After), newBufferSize);
+  range.end =
+      std::min(MapSourceOffsetForEdit(range.end, intent, EditBoundaryBias::After), newBufferSize);
+  if (range.end < range.start) {
+    range.end = range.start;
+  }
+  return range;
+}
+
+LineRange MapLineRangeForEdit(LineRange range, const SourceEditIntent& intent, int totalLines) {
+  const SourcePoint start = MapSourcePointForEdit(SourcePoint{.line = range.startLine, .column = 0},
+                                                  intent, EditBoundaryBias::Before);
+  const SourcePoint end = MapSourcePointForEdit(SourcePoint{.line = range.endLine, .column = 0},
+                                                intent, EditBoundaryBias::After);
+  range.startLine = std::clamp(start.line, 0, totalLines);
+  range.endLine = std::clamp(end.line, 0, totalLines);
+  if (range.endLine < range.startLine) {
+    range.endLine = range.startLine;
+  }
+  return range;
 }
 
 void DrawArrowhead(ImDrawList* drawList, const ImVec2& tip, const ImVec2& direction, ImU32 color,
@@ -1583,6 +1683,38 @@ ImU32 PastelReferenceColor(const FocusReferenceLink& link, int linkIndex, float 
   return ImGui::ColorConvertFloat4ToU32(ImVec4(red, green, blue, std::clamp(alpha, 0.0f, 1.0f)));
 }
 
+ImU32 BrightenReferenceColor(ImU32 color) {
+  ImVec4 value = ImGui::ColorConvertU32ToFloat4(color);
+  value.x = std::min(1.0f, value.x * 1.16f + 0.06f);
+  value.y = std::min(1.0f, value.y * 1.16f + 0.06f);
+  value.z = std::min(1.0f, value.z * 1.16f + 0.06f);
+  value.w = std::min(1.0f, value.w + 0.20f);
+  return ImGui::ColorConvertFloat4ToU32(value);
+}
+
+void StrokeDonnerPath(ImDrawList* drawList, const Path& path, ImU32 color, float thickness) {
+  if (path.empty()) {
+    return;
+  }
+
+  drawList->PathClear();
+  path.forEach([drawList](Path::Verb verb, std::span<const Vector2d> points) {
+    switch (verb) {
+      case Path::Verb::MoveTo:
+      case Path::Verb::LineTo: drawList->PathLineTo(ToImVec2(points[0])); break;
+      case Path::Verb::QuadTo:
+        drawList->PathBezierQuadraticCurveTo(ToImVec2(points[0]), ToImVec2(points[1]), 8);
+        break;
+      case Path::Verb::CurveTo:
+        drawList->PathBezierCubicCurveTo(ToImVec2(points[0]), ToImVec2(points[1]),
+                                         ToImVec2(points[2]), 8);
+        break;
+      case Path::Verb::ClosePath: break;
+    }
+  });
+  drawList->PathStroke(color, ImDrawFlags_None, thickness);
+}
+
 float TextBaselineOffsetY() {
   const ImFont* font = ImGui::GetFont();
   if (font == nullptr || font->FontSize <= 0.0f) {
@@ -1618,38 +1750,208 @@ std::optional<TextEditor::FocusReferenceConnectorLayout> TextEditor::focusRefere
 
   FocusReferenceConnectorLayout layout;
   const float baselineY = TextBaselineOffsetY();
-  layout.start = coordinatesToScreenPos(Coordinates(link.from.line, link.from.column));
-  layout.start.x += charAdvance_.x * 0.5f;
-  layout.start.y += baselineY;
+  if (std::optional<FocusReferenceSourceUnderline> sourceUnderline =
+          focusReferenceSourceUnderline(link.from)) {
+    layout.sourceUnderline = *sourceUnderline;
+    layout.hasSourceUnderline = true;
+    layout.start = ImVec2((sourceUnderline->start.x + sourceUnderline->end.x) * 0.5f,
+                          sourceUnderline->start.y);
+  } else {
+    layout.start = coordinatesToScreenPos(Coordinates(link.from.line, link.from.column));
+    layout.start.x += charAdvance_.x * 0.5f;
+    layout.start.y += baselineY;
+  }
 
-  if (std::optional<SourceStyleChipBounds> targetChip = sourceStyleChipBoundsForAnchor(link.to)) {
-    layout.tip = ImVec2(targetChip->max.x,
-                        targetChip->min.y + (targetChip->max.y - targetChip->min.y) * 0.5f);
+  if (std::optional<SourceStyleChipBounds> targetChip =
+          sourceStyleChipBoundsForReferenceTarget(link.to)) {
+    const ImVec2 chipCenter((targetChip->min.x + targetChip->max.x) * 0.5f,
+                            (targetChip->min.y + targetChip->max.y) * 0.5f);
+    if (targetChip->max.y + uiScale_ < layout.start.y) {
+      layout.tip = ImVec2(chipCenter.x, targetChip->max.y);
+    } else {
+      const float leftDistance = std::abs(layout.start.x - targetChip->min.x);
+      const float rightDistance = std::abs(layout.start.x - targetChip->max.x);
+      const float sideX = leftDistance <= rightDistance ? targetChip->min.x : targetChip->max.x;
+      layout.tip = ImVec2(sideX, chipCenter.y);
+    }
   } else {
     layout.tip = coordinatesToScreenPos(Coordinates(link.to.line, link.to.column));
     layout.tip.x -= 2.0f * uiScale_;
     layout.tip.y += baselineY;
   }
 
-  constexpr int kLaneCount = 5;
-  const int laneIndex = ((linkIndex % kLaneCount) + kLaneCount) % kLaneCount;
-  const float laneSpacing = std::max(2.0f * uiScale_, 0.35f * charAdvance_.x);
-  const float scrollbarReserve = std::max(ImGui::GetStyle().ScrollbarSize, 12.0f * uiScale_);
-  const float contentRightX =
-      uiCursorPos_.x +
-      (contentRegionMax_.x > 0.0f ? contentRegionMax_.x : std::max(windowWidth_, textStart_)) -
-      scrollbarReserve - 0.8f * charAdvance_.x;
-  const float endpointRightX = std::max(layout.start.x, layout.tip.x) + 1.5f * charAdvance_.x;
-  const float laneX =
-      std::max(contentRightX - static_cast<float>(laneIndex) * laneSpacing, endpointRightX);
-
-  layout.laneStart = ImVec2(laneX, layout.start.y);
-  layout.laneEnd = ImVec2(laneX, layout.tip.y);
-
   const float selectionAlpha =
       ImGui::ColorConvertU32ToFloat4(palette_[static_cast<int>(ColorIndex::Selection)]).w;
   layout.color = PastelReferenceColor(link, linkIndex, selectionAlpha);
   return layout;
+}
+
+std::optional<TextEditor::FocusReferenceSourceUnderline> TextEditor::focusReferenceSourceUnderline(
+    const SourcePoint& source) const {
+  const Coordinates position = sanitizeCoordinates(Coordinates(source.line, source.column));
+  if (position.line < 0 || position.line >= text_.getTotalLines()) {
+    return std::nullopt;
+  }
+
+  const Line& line = text_.getLineGlyphs(position.line);
+  if (line.empty()) {
+    return std::nullopt;
+  }
+
+  int focusIndex = text_.getCharacterIndex(position);
+  if (focusIndex >= static_cast<int>(line.size())) {
+    focusIndex = static_cast<int>(line.size()) - 1;
+  }
+  if (focusIndex < 0) {
+    return std::nullopt;
+  }
+
+  if (!IsReferenceSourceChar(line[focusIndex].character) && focusIndex > 0 &&
+      IsReferenceSourceChar(line[focusIndex - 1].character)) {
+    --focusIndex;
+  }
+
+  int underlineStartIndex = focusIndex;
+  int underlineEndIndex = std::min(focusIndex + 1, static_cast<int>(line.size()));
+  if (IsReferenceSourceChar(line[focusIndex].character)) {
+    while (underlineStartIndex > 0 &&
+           IsReferenceSourceChar(line[underlineStartIndex - 1].character)) {
+      --underlineStartIndex;
+    }
+    while (underlineEndIndex < static_cast<int>(line.size()) &&
+           IsReferenceSourceChar(line[underlineEndIndex].character)) {
+      ++underlineEndIndex;
+    }
+  }
+
+  const int startColumn = text_.getCharacterColumn(position.line, underlineStartIndex);
+  int endColumn = text_.getCharacterColumn(position.line, underlineEndIndex);
+  if (endColumn <= startColumn) {
+    endColumn = startColumn + 1;
+  }
+
+  const ImVec2 startPos = coordinatesToScreenPos(Coordinates(position.line, startColumn));
+  const ImVec2 endPos = coordinatesToScreenPos(Coordinates(position.line, endColumn));
+  const float underlineY = startPos.y + TextBaselineOffsetY() + std::max(1.5f * uiScale_, 1.5f);
+  return FocusReferenceSourceUnderline{
+      .start = ImVec2(startPos.x, underlineY),
+      .end = ImVec2(endPos.x, underlineY),
+  };
+}
+
+RopeSimulationOptions TextEditor::focusReferenceRopeOptions() const {
+  RopeSimulationOptions options;
+  options.segmentCount = 28;
+  options.constraintIterations = 10;
+  options.gravityPxPerSec2 = 180.0 * uiScale_;
+  options.damping = 0.985;
+  options.scrollResponse = 0.008;
+  options.maxScrollImpulsePx = 0.8 * uiScale_;
+  options.idleSwayPxPerSec2 = 18.0 * uiScale_;
+  options.idleSwayFrequencyHz = 0.45;
+  options.idleSwayMaxSpeed = 6.0 * uiScale_;
+  options.maxDeltaTime = 1.0 / 60.0;
+  options.settleTimeSeconds = 5.0;
+  options.settleMotionThresholdPx = 0.012 * uiScale_;
+  options.settleStillnessSeconds = 0.20;
+  options.settleRestDistanceThresholdPx = 0.45 * uiScale_;
+  options.overdueDamping = 0.42;
+  options.overdueDampingRampSeconds = 1.25;
+  options.catenaryRestoringForcePerSec2 = 640.0;
+  options.bezierTension = 1.0;
+  options.catenarySlackRatio = 0.18;
+  options.catenaryMinSlackPx = 30.0 * uiScale_;
+  options.catenaryMaxSlackPx = 120.0 * uiScale_;
+  options.initialImpulsePx = 0.2 * uiScale_;
+  options.endpointFollow = 0.84;
+  options.endpointImpulse = 0.0;
+  options.maxEndpointImpulsePx = 0.0;
+  options.endpointMotionVelocityRetention = 0.22;
+  options.endpointCatenaryBlend = 0.18;
+  return options;
+}
+
+bool TextEditor::isFocusReferenceRopeHit(const Path& path, const ImVec2& mousePos,
+                                         float hitWidth) const {
+  return !path.empty() && path.isOnPath(ToVector2d(mousePos), static_cast<double>(hitWidth));
+}
+
+void TextEditor::navigateToFocusReferenceLink(const FocusReferenceLink& link) {
+  const Coordinates target(link.to.line, link.to.column);
+  setSelection(target, target);
+  setCursorPosition(target);
+  cursorPositionChanged_ = true;
+  cursorPositionChangedByMouse_ = true;
+  scrollToCursor_ = true;
+}
+
+void TextEditor::remapFocusMetadataForSourceEdit(const SourceEditIntent& intent) {
+  if (intent.removedLength == 0u && intent.replacement.empty()) {
+    return;
+  }
+
+  const std::size_t bufferSize = getText().size();
+  for (SourceByteRange& range : hoverSourceRanges_) {
+    range = MapSourceByteRangeForEdit(range, intent, bufferSize);
+  }
+  std::erase_if(hoverSourceRanges_,
+                [](const SourceByteRange& range) { return range.end <= range.start; });
+
+  for (SourceStyleDecoration& decoration : sourceStyleDecorations_) {
+    decoration.range = MapSourceByteRangeForEdit(decoration.range, intent, bufferSize);
+    decoration.chipRange = MapSourceByteRangeForEdit(decoration.chipRange, intent, bufferSize);
+  }
+  sourceStyleChipHitRects_.clear();
+
+  if (!focusPartitionActive_) {
+    return;
+  }
+
+  const int totalLines = text_.getTotalLines();
+  const auto remapRanges = [&intent, totalLines](std::vector<LineRange>* ranges) {
+    for (LineRange& range : *ranges) {
+      range = MapLineRangeForEdit(range, intent, totalLines);
+    }
+    std::erase_if(*ranges, [](const LineRange& range) { return range.endLine <= range.startLine; });
+  };
+
+  remapRanges(&focusPartition_.fullColor);
+  remapRanges(&focusPartition_.referenceColor);
+  remapRanges(&focusPartition_.dimmed);
+  remapRanges(&focusPartition_.hidden);
+  remapRanges(&expandedFocusHiddenRanges_);
+
+  std::map<FocusReferenceLink, FocusReferenceRopeState, FocusReferenceLinkLess> remappedRopes;
+  for (FocusReferenceLink& link : focusPartition_.referenceLinks) {
+    const FocusReferenceLink oldLink = link;
+    link.from = MapSourcePointForEdit(link.from, intent, EditBoundaryBias::After);
+    link.to = MapSourcePointForEdit(link.to, intent, EditBoundaryBias::After);
+
+    auto node = focusReferenceRopes_.extract(oldLink);
+    if (!node.empty()) {
+      node.key() = link;
+      remappedRopes.insert(std::move(node));
+    }
+  }
+  focusReferenceRopes_ = std::move(remappedRopes);
+  focusPartitionActive_ = !focusPartition_.empty();
+  visualLayoutMaxColumns_ = 0;
+}
+
+bool TextEditor::tryNavigateToFocusReferenceRopeAt(const ImVec2& mousePos) {
+  if (!focusPartitionActive_ || focusReferenceRopes_.empty()) {
+    return false;
+  }
+
+  const float hitWidth = std::max(7.0f * uiScale_, 5.0f);
+  for (const auto& [link, state] : focusReferenceRopes_) {
+    if (isFocusReferenceRopeHit(state.path, mousePos, hitWidth)) {
+      navigateToFocusReferenceLink(link);
+      return true;
+    }
+  }
+
+  return false;
 }
 
 std::optional<TextEditor::SourceStyleChipBounds> TextEditor::sourceStyleChipBoundsForDecoration(
@@ -1682,14 +1984,22 @@ std::optional<TextEditor::SourceStyleChipBounds> TextEditor::sourceStyleChipBoun
   };
 }
 
-std::optional<TextEditor::SourceStyleChipBounds> TextEditor::sourceStyleChipBoundsForAnchor(
-    const SourcePoint& anchor) const {
+std::optional<TextEditor::SourceStyleChipBounds>
+TextEditor::sourceStyleChipBoundsForReferenceTarget(const SourcePoint& target) const {
+  const Coordinates targetCoordinates(target.line, target.column);
+  const std::size_t targetOffset = getByteOffsetAtCoordinates(targetCoordinates);
   for (const SourceStyleDecoration& decoration : sourceStyleDecorations_) {
+    if (!decoration.showChip) {
+      continue;
+    }
+
     const SourceByteRange anchorRange = decoration.chipRange.end > decoration.chipRange.start
                                             ? decoration.chipRange
                                             : decoration.range;
     const Coordinates chipAnchor = getCoordinatesAtByteOffset(anchorRange.end);
-    if (chipAnchor.line != anchor.line || chipAnchor.column != anchor.column) {
+    const bool exactAnchor = chipAnchor.line == target.line && chipAnchor.column == target.column;
+    const bool inChipRange = targetOffset >= anchorRange.start && targetOffset <= anchorRange.end;
+    if (!exactAnchor && !inChipRange) {
       continue;
     }
 
@@ -1701,15 +2011,33 @@ std::optional<TextEditor::SourceStyleChipBounds> TextEditor::sourceStyleChipBoun
 
 void TextEditor::renderFocusReferenceLinks(ImDrawList* drawList) {
   if (!focusPartitionActive_ || focusPartition_.referenceLinks.empty()) {
+    focusReferenceRopes_.clear();
+    lastFocusReferenceRopeScrollY_ = lastScroll_;
     return;
   }
 
   const float thickness = 1.75f * uiScale_;
-  const float cornerRadius = 8.0f * uiScale_;
+  const float hoverThickness = 2.45f * uiScale_;
   const float arrowLength = 8.0f * uiScale_;
   const float arrowHalfWidth = 4.5f * uiScale_;
+  const float hitWidth = std::max(7.0f * uiScale_, hoverThickness + 4.0f * uiScale_);
+  const RopeSimulationOptions ropeOptions = focusReferenceRopeOptions();
+  const double deltaTime = static_cast<double>(ImGui::GetIO().DeltaTime);
+  const bool hadRopes = !focusReferenceRopes_.empty();
+  const bool sourceWindowHovered = ImGui::IsWindowHovered();
+  const double scrollDeltaY =
+      hadRopes && sourceWindowHovered
+          ? static_cast<double>(lastScroll_ - lastFocusReferenceRopeScrollY_)
+          : 0.0;
+  lastFocusReferenceRopeScrollY_ = lastScroll_;
+
+  ++focusReferenceRopeFrame_;
 
   int visibleLinkIndex = 0;
+  bool hoveredAny = false;
+  const bool canHover = sourceWindowHovered && !ImGui::IsMouseDown(ImGuiMouseButton_Left) &&
+                        !ImGui::IsMouseDown(ImGuiMouseButton_Right);
+  const ImVec2 mousePos = ImGui::GetMousePos();
   for (const FocusReferenceLink& link : focusPartition_.referenceLinks) {
     std::optional<FocusReferenceConnectorLayout> layout =
         focusReferenceConnectorLayout(link, visibleLinkIndex);
@@ -1717,14 +2045,54 @@ void TextEditor::renderFocusReferenceLinks(ImDrawList* drawList) {
       continue;
     }
 
-    const ImVec2 endDirection = NormalizeVec(SubVec(layout->tip, layout->laneEnd));
-    const ImVec2 pathEnd = SubVec(layout->tip, MulVec(endDirection, arrowLength * 0.7f));
+    const Vector2d start = ToVector2d(layout->start);
+    const Vector2d tip = ToVector2d(layout->tip);
+    const double chordLength = start.distance(tip);
+    const std::uint32_t ropeSeed = MixReferenceSeed(link, visibleLinkIndex);
+    FocusReferenceRopeState& ropeState = focusReferenceRopes_[link];
+    const bool lengthChanged =
+        ropeState.initialized && std::abs(ropeState.chordLength - chordLength) >
+                                     static_cast<double>(std::max(28.0f * uiScale_, 8.0f));
+    if (!ropeState.initialized || ropeState.rope.empty() || lengthChanged) {
+      ropeState.rope.resetCatenary(start, tip, ropeOptions);
+      const double side = UnitFromSeed(ropeSeed ^ 0x7c15f3a9u) < 0.5f ? -1.0 : 1.0;
+      ropeState.rope.applyBottomImpulse(Vector2d(side * ropeOptions.initialImpulsePx, 0.0), 0.12);
+      ropeState.path = ropeState.rope.toPath(ropeOptions);
+      ropeState.initialized = true;
+    }
 
-    StrokeRoundedConnector(drawList, layout->start, layout->laneStart, layout->laneEnd, pathEnd,
-                           layout->color, thickness, cornerRadius);
-    DrawArrowhead(drawList, layout->tip, SubVec(layout->tip, layout->laneEnd), layout->color,
-                  arrowLength, arrowHalfWidth);
+    const bool hoveredBeforeUpdate = canHover && ropeState.initialized &&
+                                     isFocusReferenceRopeHit(ropeState.path, mousePos, hitWidth);
+    ropeState.rope.update(start, tip, deltaTime, scrollDeltaY, ImGui::GetTime(), ropeSeed,
+                          hoveredBeforeUpdate, ropeOptions);
+    ropeState.path = ropeState.rope.toPath(ropeOptions);
+    ropeState.hovered = canHover && isFocusReferenceRopeHit(ropeState.path, mousePos, hitWidth);
+    ropeState.chordLength = chordLength;
+    ropeState.lastFrameSeen = focusReferenceRopeFrame_;
+
+    const ImU32 color = ropeState.hovered ? BrightenReferenceColor(layout->color) : layout->color;
+    if (layout->hasSourceUnderline) {
+      drawList->AddLine(layout->sourceUnderline.start, layout->sourceUnderline.end, color,
+                        std::max(1.0f, uiScale_));
+    }
+    StrokeDonnerPath(drawList, ropeState.path, color,
+                     ropeState.hovered ? hoverThickness : thickness);
+    ropeState.arrowDirection = ropeState.rope.endTangent();
+    DrawArrowhead(drawList, layout->tip, ToImVec2(ropeState.arrowDirection), color, arrowLength,
+                  arrowHalfWidth);
+    if (ropeState.hovered && !hoveredAny) {
+      hoveredAny = true;
+      ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
+    }
     ++visibleLinkIndex;
+  }
+
+  for (auto it = focusReferenceRopes_.begin(); it != focusReferenceRopes_.end();) {
+    if (it->second.lastFrameSeen != focusReferenceRopeFrame_) {
+      it = focusReferenceRopes_.erase(it);
+    } else {
+      ++it;
+    }
   }
 }
 
@@ -1800,7 +2168,7 @@ void TextEditor::renderSourceStyleDecorationChips(ImDrawList* drawList) {
   const float markerGap = std::max(2.0f * uiScale_, 2.0f);
   const float markerFontSize = ImGui::GetFontSize() * 1.45f;
   const float markerHitPadding = std::max(2.0f * uiScale_, 2.0f);
-  constexpr const char* kOverflowMarker = "∗";
+  constexpr const char* kOverflowMarker = "✱";
 
   for (const SourceStyleDecoration& decoration : sourceStyleDecorations_) {
     if (!decoration.showChip) {
@@ -1970,6 +2338,7 @@ void TextEditor::setSelection(const Coordinates& start, const Coordinates& end,
 void TextEditor::setFocusPartition(const FocusPartition& partition) {
   if (!FocusPartitionsEqual(focusPartition_, partition)) {
     expandedFocusHiddenRanges_.clear();
+    focusReferenceRopes_.clear();
   }
 
   focusPartition_ = partition;
@@ -2056,6 +2425,7 @@ void TextEditor::clearFocusPartition() {
   focusPartition_ = FocusPartition{};
   focusPartitionActive_ = false;
   expandedFocusHiddenRanges_.clear();
+  focusReferenceRopes_.clear();
 }
 
 void TextEditor::flashSourceRange(SourceByteRange byteRange) {
@@ -2064,6 +2434,21 @@ void TextEditor::flashSourceRange(SourceByteRange byteRange) {
 
 std::optional<float> TextEditor::nextFlashWakeSeconds() const {
   return flashDecorations_.nextWakeSeconds(FlashDecorations::Clock::now());
+}
+
+std::optional<float> TextEditor::nextRopeAnimationWakeSeconds() const {
+  if (!focusPartitionActive_) {
+    return std::nullopt;
+  }
+
+  for (const auto& ropeEntry : focusReferenceRopes_) {
+    const FocusReferenceRopeState& state = ropeEntry.second;
+    if (!state.hovered && state.rope.needsAnimation()) {
+      return kFocusReferenceRopeWakeSeconds;
+    }
+  }
+
+  return std::nullopt;
 }
 
 void TextEditor::tickSourceFlashes() {
@@ -2568,7 +2953,8 @@ void TextEditor::renderExtraUI(ImDrawList* drawList, const ImVec2& basePos, floa
   const int visualLineCount = (wordWrapEnabled_ || focusPartitionActive_)
                                   ? static_cast<int>(visualLines_.size())
                                   : text_.getTotalLines() - foldedLines_;
-  ImGui::Dummy(ImVec2(longest + 100.0f * uiScale_, visualLineCount * charAdvance_.y));
+  const float dummyWidth = horizontalScroll_ ? longest + 100.0f * uiScale_ : 0.0f;
+  ImGui::Dummy(ImVec2(dummyWidth, visualLineCount * charAdvance_.y));
 
   // Handle cursor visibility
   if (scrollToCursor_) {
@@ -3585,13 +3971,10 @@ void TextEditor::ensureCursorVisible() {
     return;
   }
 
-  const float scrollX = ImGui::GetScrollX();
   const float scrollY = ImGui::GetScrollY();
   const float height = visibleTextRegionHeight();
-  const float width = windowWidth_;
 
   const auto pos = getActualCursorCoordinates();
-  const auto len = getTextDistanceToLineStart(pos);
 
   if ((wordWrapEnabled_ || focusPartitionActive_) && !visualLines_.empty()) {
     const int visualIndex = visualLineIndexForCoordinates(pos);
@@ -3609,20 +3992,12 @@ void TextEditor::ensureCursorVisible() {
   const auto top = static_cast<int>(std::floor(scrollY / charAdvance_.y));
   const auto bottom =
       static_cast<int>(std::floor((scrollY + height - charAdvance_.y) / charAdvance_.y));
-  const auto left = static_cast<int>(std::ceil(scrollX / charAdvance_.x));
-  const auto right = static_cast<int>(std::ceil((scrollX + width) / charAdvance_.x));
 
   if (pos.line < top) {
     ImGui::SetScrollY(std::max(0.0f, pos.line * charAdvance_.y));
   }
   if (pos.line > bottom) {
     ImGui::SetScrollY(std::max(0.0f, (pos.line + 1) * charAdvance_.y - height));
-  }
-  if (pos.column < left) {
-    ImGui::SetScrollX(std::max(0.0f, len + textStart_ - 11 * charAdvance_.x));
-  }
-  if (len + textStart_ > (right - 4) * charAdvance_.x) {
-    ImGui::SetScrollX(std::max(0.0f, len + textStart_ + 4 * charAdvance_.x - width));
   }
 }
 

--- a/donner/editor/TextEditor.cc
+++ b/donner/editor/TextEditor.cc
@@ -1740,6 +1740,13 @@ ImU32 SourceStyleStrikethroughColor() {
   return ImGui::ColorConvertFloat4ToU32(ImVec4(1.0f, 1.0f, 1.0f, 0.92f));
 }
 
+constexpr const char* kStyleSourceChipIcon = "✦";
+
+ImVec2 StyleSourceChipTextSize() {
+  return ImGui::GetFont()->CalcTextSizeA(ImGui::GetFontSize(), FLT_MAX, -1.0f,
+                                         kStyleSourceChipIcon);
+}
+
 }  // namespace
 
 std::optional<TextEditor::FocusReferenceConnectorLayout> TextEditor::focusReferenceConnectorLayout(
@@ -1750,18 +1757,9 @@ std::optional<TextEditor::FocusReferenceConnectorLayout> TextEditor::focusRefere
 
   FocusReferenceConnectorLayout layout;
   const float baselineY = TextBaselineOffsetY();
-  if (std::optional<FocusReferenceSourceUnderline> sourceUnderline =
-          focusReferenceSourceUnderline(link.from)) {
-    layout.sourceUnderline = *sourceUnderline;
-    layout.hasSourceUnderline = true;
-    layout.start = ImVec2((sourceUnderline->start.x + sourceUnderline->end.x) * 0.5f,
-                          sourceUnderline->start.y);
-  } else {
-    layout.start = coordinatesToScreenPos(Coordinates(link.from.line, link.from.column));
-    layout.start.x += charAdvance_.x * 0.5f;
-    layout.start.y += baselineY;
-  }
-
+  layout.start = coordinatesToScreenPos(Coordinates(link.from.line, link.from.column));
+  layout.start.x += charAdvance_.x * 0.5f;
+  layout.start.y += baselineY;
   if (std::optional<SourceStyleChipBounds> targetChip =
           sourceStyleChipBoundsForReferenceTarget(link.to)) {
     const ImVec2 chipCenter((targetChip->min.x + targetChip->max.x) * 0.5f,
@@ -1774,10 +1772,44 @@ std::optional<TextEditor::FocusReferenceConnectorLayout> TextEditor::focusRefere
       const float sideX = leftDistance <= rightDistance ? targetChip->min.x : targetChip->max.x;
       layout.tip = ImVec2(sideX, chipCenter.y);
     }
+
+    if (targetChip->kind == SourceStyleChipKind::SelectorMatchCount) {
+      if (std::optional<SourceStyleChipBounds> sourceChip =
+              focusReferenceStyleSourceChipBounds(link.from)) {
+        layout.sourceStyleChip = *sourceChip;
+        layout.hasSourceStyleChip = true;
+        const ImVec2 sourceChipCenter((sourceChip->min.x + sourceChip->max.x) * 0.5f,
+                                      (sourceChip->min.y + sourceChip->max.y) * 0.5f);
+        if (layout.tip.y + uiScale_ < sourceChip->min.y) {
+          layout.start = ImVec2(sourceChipCenter.x, sourceChip->min.y);
+        } else if (layout.tip.y > sourceChip->max.y + uiScale_) {
+          layout.start = ImVec2(sourceChipCenter.x, sourceChip->max.y);
+        } else {
+          const float leftDistance = std::abs(layout.tip.x - sourceChip->min.x);
+          const float rightDistance = std::abs(layout.tip.x - sourceChip->max.x);
+          const float sideX = leftDistance <= rightDistance ? sourceChip->min.x : sourceChip->max.x;
+          layout.start = ImVec2(sideX, sourceChipCenter.y);
+        }
+      }
+    }
   } else {
     layout.tip = coordinatesToScreenPos(Coordinates(link.to.line, link.to.column));
     layout.tip.x -= 2.0f * uiScale_;
     layout.tip.y += baselineY;
+  }
+
+  if (!layout.hasSourceStyleChip) {
+    if (std::optional<FocusReferenceSourceUnderline> sourceUnderline =
+            focusReferenceSourceUnderline(link.from)) {
+      layout.sourceUnderline = *sourceUnderline;
+      layout.hasSourceUnderline = true;
+      layout.start = ImVec2((sourceUnderline->start.x + sourceUnderline->end.x) * 0.5f,
+                            sourceUnderline->start.y);
+    } else {
+      layout.start = coordinatesToScreenPos(Coordinates(link.from.line, link.from.column));
+      layout.start.x += charAdvance_.x * 0.5f;
+      layout.start.y += baselineY;
+    }
   }
 
   const float selectionAlpha =
@@ -1981,6 +2013,7 @@ std::optional<TextEditor::SourceStyleChipBounds> TextEditor::sourceStyleChipBoun
   return SourceStyleChipBounds{
       .min = min,
       .max = ImVec2(min.x + chipSize.x, min.y + chipSize.y),
+      .kind = decoration.chipKind,
   };
 }
 
@@ -2007,6 +2040,30 @@ TextEditor::sourceStyleChipBoundsForReferenceTarget(const SourcePoint& target) c
   }
 
   return std::nullopt;
+}
+
+std::optional<TextEditor::SourceStyleChipBounds> TextEditor::focusReferenceStyleSourceChipBounds(
+    const SourcePoint& source) const {
+  const Coordinates position = sanitizeCoordinates(Coordinates(source.line, source.column));
+  if (position.line < 0 || position.line >= text_.getTotalLines() ||
+      isLineHiddenByFocus(position.line)) {
+    return std::nullopt;
+  }
+
+  const Coordinates lineEnd(position.line, text_.getLineMaxColumn(position.line));
+  const float paddingX = std::max(4.0f * uiScale_, 4.0f);
+  const float paddingY = std::max(1.0f * uiScale_, 1.0f);
+  const float gap = std::max(5.0f * uiScale_, 5.0f);
+  const ImVec2 iconSize = StyleSourceChipTextSize();
+  const ImVec2 chipSize(iconSize.x + paddingX * 2.0f, iconSize.y + paddingY * 2.0f);
+  ImVec2 min = coordinatesToScreenPos(lineEnd);
+  min.x += gap;
+  min.y += std::max(0.0f, (charAdvance_.y - chipSize.y) * 0.5f);
+  return SourceStyleChipBounds{
+      .min = min,
+      .max = ImVec2(min.x + chipSize.x, min.y + chipSize.y),
+      .kind = SourceStyleChipKind::SelectorMatchCount,
+  };
 }
 
 void TextEditor::renderFocusReferenceLinks(ImDrawList* drawList) {
@@ -2074,6 +2131,9 @@ void TextEditor::renderFocusReferenceLinks(ImDrawList* drawList) {
     if (layout->hasSourceUnderline) {
       drawList->AddLine(layout->sourceUnderline.start, layout->sourceUnderline.end, color,
                         std::max(1.0f, uiScale_));
+    }
+    if (layout->hasSourceStyleChip) {
+      renderFocusReferenceStyleSourceChip(drawList, layout->sourceStyleChip, color);
     }
     StrokeDonnerPath(drawList, ropeState.path, color,
                      ropeState.hovered ? hoverThickness : thickness);
@@ -2154,6 +2214,29 @@ void TextEditor::renderSourceStyleDecorationStrikethroughs(int lineNo, int start
         std::floor(start.y + ImGui::GetFontSize() * kStrikeHeightFraction + kStrikeOffsetY) + 0.5f;
     drawList->AddLine(ImVec2(start.x, y), ImVec2(end.x, y), color, thickness);
   }
+}
+
+void TextEditor::renderFocusReferenceStyleSourceChip(ImDrawList* drawList,
+                                                     const SourceStyleChipBounds& bounds,
+                                                     ImU32 color) const {
+  if (drawList == nullptr) {
+    return;
+  }
+
+  const float paddingX = std::max(4.0f * uiScale_, 4.0f);
+  const float paddingY = std::max(1.0f * uiScale_, 1.0f);
+  const float rounding = 4.0f * uiScale_;
+  const ImVec4 colorVec = ImGui::ColorConvertU32ToFloat4(color);
+  const ImU32 fillColor =
+      ImGui::ColorConvertFloat4ToU32(ImVec4(colorVec.x, colorVec.y, colorVec.z, 0.18f));
+  const ImU32 borderColor =
+      ImGui::ColorConvertFloat4ToU32(ImVec4(colorVec.x, colorVec.y, colorVec.z, 0.72f));
+
+  drawList->AddRectFilled(bounds.min, bounds.max, fillColor, rounding);
+  drawList->AddRect(bounds.min, bounds.max, borderColor, rounding, ImDrawFlags_None,
+                    std::max(1.0f, uiScale_));
+  drawList->AddText(ImVec2(bounds.min.x + paddingX, bounds.min.y + paddingY), borderColor,
+                    kStyleSourceChipIcon);
 }
 
 void TextEditor::renderSourceStyleDecorationChips(ImDrawList* drawList) {

--- a/donner/editor/TextEditor.cc
+++ b/donner/editor/TextEditor.cc
@@ -1747,6 +1747,19 @@ ImVec2 StyleSourceChipTextSize() {
                                          kStyleSourceChipIcon);
 }
 
+ImVec2 ChipConnectorPoint(const ImVec2& min, const ImVec2& max, const ImVec2& otherEndpoint,
+                          float verticalTolerance) {
+  const ImVec2 center((min.x + max.x) * 0.5f, (min.y + max.y) * 0.5f);
+  if (max.y + verticalTolerance < otherEndpoint.y) {
+    return ImVec2(center.x, max.y);
+  }
+
+  const float leftDistance = std::abs(otherEndpoint.x - min.x);
+  const float rightDistance = std::abs(otherEndpoint.x - max.x);
+  const float sideX = leftDistance <= rightDistance ? min.x : max.x;
+  return ImVec2(sideX, center.y);
+}
+
 }  // namespace
 
 std::optional<TextEditor::FocusReferenceConnectorLayout> TextEditor::focusReferenceConnectorLayout(
@@ -1762,34 +1775,14 @@ std::optional<TextEditor::FocusReferenceConnectorLayout> TextEditor::focusRefere
   layout.start.y += baselineY;
   if (std::optional<SourceStyleChipBounds> targetChip =
           sourceStyleChipBoundsForReferenceTarget(link.to)) {
-    const ImVec2 chipCenter((targetChip->min.x + targetChip->max.x) * 0.5f,
-                            (targetChip->min.y + targetChip->max.y) * 0.5f);
-    if (targetChip->max.y + uiScale_ < layout.start.y) {
-      layout.tip = ImVec2(chipCenter.x, targetChip->max.y);
-    } else {
-      const float leftDistance = std::abs(layout.start.x - targetChip->min.x);
-      const float rightDistance = std::abs(layout.start.x - targetChip->max.x);
-      const float sideX = leftDistance <= rightDistance ? targetChip->min.x : targetChip->max.x;
-      layout.tip = ImVec2(sideX, chipCenter.y);
-    }
+    layout.tip = ChipConnectorPoint(targetChip->min, targetChip->max, layout.start, uiScale_);
 
     if (targetChip->kind == SourceStyleChipKind::SelectorMatchCount) {
       if (std::optional<SourceStyleChipBounds> sourceChip =
               focusReferenceStyleSourceChipBounds(link.from)) {
         layout.sourceStyleChip = *sourceChip;
         layout.hasSourceStyleChip = true;
-        const ImVec2 sourceChipCenter((sourceChip->min.x + sourceChip->max.x) * 0.5f,
-                                      (sourceChip->min.y + sourceChip->max.y) * 0.5f);
-        if (layout.tip.y + uiScale_ < sourceChip->min.y) {
-          layout.start = ImVec2(sourceChipCenter.x, sourceChip->min.y);
-        } else if (layout.tip.y > sourceChip->max.y + uiScale_) {
-          layout.start = ImVec2(sourceChipCenter.x, sourceChip->max.y);
-        } else {
-          const float leftDistance = std::abs(layout.tip.x - sourceChip->min.x);
-          const float rightDistance = std::abs(layout.tip.x - sourceChip->max.x);
-          const float sideX = leftDistance <= rightDistance ? sourceChip->min.x : sourceChip->max.x;
-          layout.start = ImVec2(sideX, sourceChipCenter.y);
-        }
+        layout.start = ChipConnectorPoint(sourceChip->min, sourceChip->max, layout.tip, uiScale_);
       }
     }
   } else {

--- a/donner/editor/TextEditor.h
+++ b/donner/editor/TextEditor.h
@@ -197,6 +197,23 @@ public:
   using LanguageDefinition = ::donner::editor::LanguageDefinition;
   using String = RcString;
 
+  /// Source decoration for style/cascade annotations in the editor.
+  struct SourceStyleDecoration {
+    std::size_t id = 0;         ///< Stable decoration id returned on chip clicks.
+    SourceByteRange range;      ///< Source byte range covered by the decoration.
+    SourceByteRange chipRange;  ///< Source range whose end anchors the chip.
+    bool ineffective = false;   ///< Strike through the source range when the style is inactive.
+    bool showChip = false;      ///< Render a selector-match count chip.
+    int chipCount = 0;          ///< Count rendered inside the chip.
+    bool showOverflowMarker = false;  ///< Render a chip-adjacent overflow marker.
+    std::string tooltip;              ///< Tooltip shown for the inactive source range.
+    std::string chipTooltip;          ///< Tooltip shown for the chip.
+    std::string overflowTooltip;      ///< Tooltip shown for the overflow marker.
+
+    /// Equality operator.
+    bool operator==(const SourceStyleDecoration& other) const = default;
+  };
+
   // Constants
   static constexpr int kLineNumberSpace = 20;  //!< Width of line number margin in pixels
 
@@ -573,6 +590,16 @@ public:
   [[nodiscard]] const std::vector<SourceByteRange>& hoverSourceRanges() const {
     return hoverSourceRanges_;
   }
+  /// Set source style/cascade decorations.
+  bool setSourceStyleDecorations(std::vector<SourceStyleDecoration> decorations);
+  /// Clear source style/cascade decorations.
+  bool clearSourceStyleDecorations() { return setSourceStyleDecorations({}); }
+  /// Active source style/cascade decorations.
+  [[nodiscard]] const std::vector<SourceStyleDecoration>& sourceStyleDecorations() const {
+    return sourceStyleDecorations_;
+  }
+  /// Return and clear the last clicked source style decoration chip id.
+  [[nodiscard]] std::optional<std::size_t> takeClickedSourceStyleChipId();
 
   /// Install a source-focus partition. Hidden lines are folded from the view only.
   void setFocusPartition(const FocusPartition& partition);
@@ -1042,10 +1069,21 @@ private:
   std::vector<int>& changedLines_;
   std::vector<int> highlightedLines_;               //!< Lines to highlight
   std::vector<SourceByteRange> hoverSourceRanges_;  //!< Source ranges highlighted on hover
+  std::vector<SourceStyleDecoration> sourceStyleDecorations_;  //!< Style source decorations.
   FocusPartition focusPartition_;
   bool focusPartitionActive_ = false;
   FlashDecorations flashDecorations_;
   std::vector<LineRange> expandedFocusHiddenRanges_;
+
+  struct SourceStyleChipHitRect {
+    std::size_t id = 0;
+    ImVec2 min;
+    ImVec2 max;
+    std::string tooltip;
+    bool clickEnabled = true;
+  };
+  std::vector<SourceStyleChipHitRect> sourceStyleChipHitRects_;
+  std::optional<std::size_t> clickedSourceStyleChipId_;
 
   struct VisualLine {
     int lineNo = 0;
@@ -1068,6 +1106,22 @@ private:
   };
   [[nodiscard]] std::optional<FocusReferenceConnectorLayout> focusReferenceConnectorLayout(
       const FocusReferenceLink& link, int linkIndex) const;
+  struct SourceStyleChipBounds {
+    ImVec2 min;
+    ImVec2 max;
+  };
+  [[nodiscard]] std::optional<SourceStyleChipBounds> sourceStyleChipBoundsForDecoration(
+      const SourceStyleDecoration& decoration) const;
+  [[nodiscard]] std::optional<SourceStyleChipBounds> sourceStyleChipBoundsForAnchor(
+      const SourcePoint& anchor) const;
+  [[nodiscard]] const SourceStyleDecoration* sourceStyleDecorationAtByteOffset(
+      std::size_t byteOffset, bool ineffectiveOnly) const;
+  [[nodiscard]] bool isByteOffsetInIneffectiveStyleDecoration(std::size_t byteOffset) const;
+  void renderSourceStyleDecorationStrikethroughs(int lineNo, int startColumn, int endColumn,
+                                                 ImDrawList* drawList);
+  void renderSourceStyleDecorationChips(ImDrawList* drawList);
+  void hitTestSourceStyleDecorationChips();
+  void renderSourceStyleDecorationTooltip();
 
   // Editor settings. `insertSpaces_`, `smartIndent_`, `tabSize_`,
   // `scrollToCursor_`, `scrollToTop_`, `textChanged_`, `colorizerEnabled_`,

--- a/donner/editor/TextEditor.h
+++ b/donner/editor/TextEditor.h
@@ -198,6 +198,12 @@ public:
   using LanguageDefinition = ::donner::editor::LanguageDefinition;
   using String = RcString;
 
+  /// Visual role for a rendered source style chip.
+  enum class SourceStyleChipKind {
+    SelectorMatchCount,  ///< Chip summarizes elements matched by a CSS selector.
+    ReferenceCount,      ///< Chip summarizes same-document references to a resource.
+  };
+
   /// Source decoration for style/cascade annotations in the editor.
   struct SourceStyleDecoration {
     std::size_t id = 0;         ///< Stable decoration id returned on chip clicks.
@@ -207,9 +213,11 @@ public:
     bool showChip = false;      ///< Render a selector-match count chip.
     int chipCount = 0;          ///< Count rendered inside the chip.
     bool showOverflowMarker = false;  ///< Render a chip-adjacent overflow marker.
-    std::string tooltip;              ///< Tooltip shown for the inactive source range.
-    std::string chipTooltip;          ///< Tooltip shown for the chip.
-    std::string overflowTooltip;      ///< Tooltip shown for the overflow marker.
+    SourceStyleChipKind chipKind =
+        SourceStyleChipKind::SelectorMatchCount;  ///< Semantic kind of the chip.
+    std::string tooltip;                          ///< Tooltip shown for the inactive source range.
+    std::string chipTooltip;                      ///< Tooltip shown for the chip.
+    std::string overflowTooltip;                  ///< Tooltip shown for the overflow marker.
 
     /// Equality operator.
     bool operator==(const SourceStyleDecoration& other) const = default;
@@ -1124,12 +1132,20 @@ private:
     ImVec2 end;
   };
 
+  struct SourceStyleChipBounds {
+    ImVec2 min;
+    ImVec2 max;
+    SourceStyleChipKind kind = SourceStyleChipKind::SelectorMatchCount;
+  };
+
   struct FocusReferenceConnectorLayout {
     ImVec2 start;
     ImVec2 tip;
     FocusReferenceSourceUnderline sourceUnderline;
+    SourceStyleChipBounds sourceStyleChip;
     ImU32 color = 0;
     bool hasSourceUnderline = false;
+    bool hasSourceStyleChip = false;
   };
   std::map<FocusReferenceLink, FocusReferenceRopeState, FocusReferenceLinkLess>
       focusReferenceRopes_;
@@ -1145,19 +1161,19 @@ private:
   bool tryNavigateToFocusReferenceRopeAt(const ImVec2& mousePos);
   void navigateToFocusReferenceLink(const FocusReferenceLink& link);
   void remapFocusMetadataForSourceEdit(const SourceEditIntent& intent);
-  struct SourceStyleChipBounds {
-    ImVec2 min;
-    ImVec2 max;
-  };
   [[nodiscard]] std::optional<SourceStyleChipBounds> sourceStyleChipBoundsForDecoration(
       const SourceStyleDecoration& decoration) const;
   [[nodiscard]] std::optional<SourceStyleChipBounds> sourceStyleChipBoundsForReferenceTarget(
       const SourcePoint& target) const;
+  [[nodiscard]] std::optional<SourceStyleChipBounds> focusReferenceStyleSourceChipBounds(
+      const SourcePoint& source) const;
   [[nodiscard]] const SourceStyleDecoration* sourceStyleDecorationAtByteOffset(
       std::size_t byteOffset, bool ineffectiveOnly) const;
   [[nodiscard]] bool isByteOffsetInIneffectiveStyleDecoration(std::size_t byteOffset) const;
   void renderSourceStyleDecorationStrikethroughs(int lineNo, int startColumn, int endColumn,
                                                  ImDrawList* drawList);
+  void renderFocusReferenceStyleSourceChip(ImDrawList* drawList,
+                                           const SourceStyleChipBounds& bounds, ImU32 color) const;
   void renderSourceStyleDecorationChips(ImDrawList* drawList);
   void hitTestSourceStyleDecorationChips();
   void renderSourceStyleDecorationTooltip();

--- a/donner/editor/TextEditor.h
+++ b/donner/editor/TextEditor.h
@@ -16,6 +16,7 @@
 #include "donner/base/RcString.h"
 #include "donner/editor/FlashDecorations.h"
 #include "donner/editor/FocusView.h"
+#include "donner/editor/RopeSimulation.h"
 #include "donner/editor/SoftWrap.h"
 #include "donner/editor/TextBuffer.h"
 #include "donner/editor/TextEditorCore.h"
@@ -622,6 +623,8 @@ public:
   void flashSourceRange(SourceByteRange byteRange);
   /// Return the next flash wake interval, or nullopt if no flash is active.
   [[nodiscard]] std::optional<float> nextFlashWakeSeconds() const;
+  /// Return the next rope-animation wake interval, or nullopt if every rope is idle.
+  [[nodiscard]] std::optional<float> nextRopeAnimationWakeSeconds() const;
   /// Remove expired flashes using the current steady-clock time.
   void tickSourceFlashes();
 
@@ -636,7 +639,7 @@ public:
   void setAutoIndentOnPaste(bool value) { core_.setAutoIndentOnPaste(value); }
   void setHighlightLine(bool value) { highlightLine_ = value; }
   void setCompleteBraces(bool value) { core_.setCompleteBraces(value); }
-  void setHorizontalScroll(bool value) { horizontalScroll_ = value; }
+  void setHorizontalScroll(bool /*value*/) { horizontalScroll_ = false; }
   void setSmartPredictions(bool value) { autocomplete_ = value; }
   void setFunctionDeclarationTooltip(bool value) { functionDeclarationTooltipEnabled_ = value; }
   void setFunctionTooltips(bool value) { funcTooltips_ = value; }
@@ -1097,23 +1100,59 @@ private:
   std::vector<VisualLine> visualLines_;
   int visualLayoutMaxColumns_ = 0;
 
+  struct FocusReferenceLinkLess {
+    bool operator()(const FocusReferenceLink& lhs, const FocusReferenceLink& rhs) const {
+      if (lhs.from.line != rhs.from.line) return lhs.from.line < rhs.from.line;
+      if (lhs.from.column != rhs.from.column) return lhs.from.column < rhs.from.column;
+      if (lhs.to.line != rhs.to.line) return lhs.to.line < rhs.to.line;
+      return lhs.to.column < rhs.to.column;
+    }
+  };
+
+  struct FocusReferenceRopeState {
+    RopeSimulation rope;
+    Path path;
+    Vector2d arrowDirection = Vector2d::XAxis();
+    double chordLength = 0.0;
+    bool hovered = false;
+    bool initialized = false;
+    uint64_t lastFrameSeen = 0;
+  };
+
+  struct FocusReferenceSourceUnderline {
+    ImVec2 start;
+    ImVec2 end;
+  };
+
   struct FocusReferenceConnectorLayout {
     ImVec2 start;
-    ImVec2 laneStart;
-    ImVec2 laneEnd;
     ImVec2 tip;
+    FocusReferenceSourceUnderline sourceUnderline;
     ImU32 color = 0;
+    bool hasSourceUnderline = false;
   };
+  std::map<FocusReferenceLink, FocusReferenceRopeState, FocusReferenceLinkLess>
+      focusReferenceRopes_;
+  uint64_t focusReferenceRopeFrame_ = 0;
+  float lastFocusReferenceRopeScrollY_ = 0.0f;
   [[nodiscard]] std::optional<FocusReferenceConnectorLayout> focusReferenceConnectorLayout(
       const FocusReferenceLink& link, int linkIndex) const;
+  [[nodiscard]] std::optional<FocusReferenceSourceUnderline> focusReferenceSourceUnderline(
+      const SourcePoint& source) const;
+  [[nodiscard]] RopeSimulationOptions focusReferenceRopeOptions() const;
+  [[nodiscard]] bool isFocusReferenceRopeHit(const Path& path, const ImVec2& mousePos,
+                                             float hitWidth) const;
+  bool tryNavigateToFocusReferenceRopeAt(const ImVec2& mousePos);
+  void navigateToFocusReferenceLink(const FocusReferenceLink& link);
+  void remapFocusMetadataForSourceEdit(const SourceEditIntent& intent);
   struct SourceStyleChipBounds {
     ImVec2 min;
     ImVec2 max;
   };
   [[nodiscard]] std::optional<SourceStyleChipBounds> sourceStyleChipBoundsForDecoration(
       const SourceStyleDecoration& decoration) const;
-  [[nodiscard]] std::optional<SourceStyleChipBounds> sourceStyleChipBoundsForAnchor(
-      const SourcePoint& anchor) const;
+  [[nodiscard]] std::optional<SourceStyleChipBounds> sourceStyleChipBoundsForReferenceTarget(
+      const SourcePoint& target) const;
   [[nodiscard]] const SourceStyleDecoration* sourceStyleDecorationAtByteOffset(
       std::size_t byteOffset, bool ineffectiveOnly) const;
   [[nodiscard]] bool isByteOffsetInIneffectiveStyleDecoration(std::size_t byteOffset) const;

--- a/donner/editor/TextEditorCore.cc
+++ b/donner/editor/TextEditorCore.cc
@@ -182,17 +182,24 @@ void TextEditorCore::appendSourceEditIntent(SourceEditIntent intent) {
 
   intent.bufferVersion = ++sourceEditIntentVersion_;
   pendingSourceEditIntents_.push_back(std::move(intent));
+  if (sourceEditIntentHook) {
+    sourceEditIntentHook(pendingSourceEditIntents_.back());
+  }
 }
 
 void TextEditorCore::recordSourceEditIntent(const UndoRecord& record, SourceEditIntentKind kind) {
   std::string_view removed = record.removed;
   std::string_view replacement = record.added;
   Coordinates start = !record.removed.empty() ? record.removedStart : record.addedStart;
+  Coordinates removedEnd = !record.removed.empty() ? record.removedEnd : start;
+  Coordinates replacementEnd = !record.added.empty() ? record.addedEnd : start;
 
   if (kind == SourceEditIntentKind::Undo) {
     removed = record.added;
     replacement = record.removed;
     start = !record.added.empty() ? record.addedStart : record.removedStart;
+    removedEnd = !record.added.empty() ? record.addedEnd : start;
+    replacementEnd = !record.removed.empty() ? record.removedEnd : start;
   }
 
   SourceEditIntentKind classifiedKind = kind;
@@ -211,6 +218,10 @@ void TextEditorCore::recordSourceEditIntent(const UndoRecord& record, SourceEdit
       .removedLength = removed.size(),
       .replacement = std::string(replacement),
       .kind = classifiedKind,
+      .start = SourceEditPoint{.line = start.line, .column = start.column},
+      .removedEnd = SourceEditPoint{.line = removedEnd.line, .column = removedEnd.column},
+      .replacementEnd =
+          SourceEditPoint{.line = replacementEnd.line, .column = replacementEnd.column},
   });
 }
 

--- a/donner/editor/TextEditorCore.h
+++ b/donner/editor/TextEditorCore.h
@@ -450,6 +450,7 @@ public:
   std::function<void()> requestAutocompleteHook;
   std::function<void(char32_t, const Coordinates&)> functionTooltipHook;
   std::function<void()> onContentUpdateInternal;
+  std::function<void(const SourceEditIntent&)> sourceEditIntentHook;
 
 private:
   using RegexList = std::vector<std::pair<std::regex, ColorIndex>>;

--- a/donner/editor/gui/EditorWindow.cc
+++ b/donner/editor/gui/EditorWindow.cc
@@ -828,6 +828,15 @@ void EditorWindow::waitEvents() {
 #endif
 }
 
+void EditorWindow::waitEventsTimeout(double timeoutSeconds) {
+#ifdef __EMSCRIPTEN__
+  // The browser already clocks frames through requestAnimationFrame.
+  glfwPollEvents();
+#else
+  glfwWaitEventsTimeout(std::max(0.0, timeoutSeconds));
+#endif
+}
+
 void EditorWindow::wakeEventLoop() {
 #ifdef __EMSCRIPTEN__
   // No-op — the browser's rAF cadence handles wake-ups implicitly.

--- a/donner/editor/gui/EditorWindow.h
+++ b/donner/editor/gui/EditorWindow.h
@@ -10,7 +10,7 @@
 /// The class is intentionally narrow — it exposes only what the main
 /// binary needs:
 ///   - construct/destruct (RAII handles cleanup)
-///   - `shouldClose()` / `pollEvents()` — event loop hooks
+///   - `shouldClose()` / `pollEvents()` / `waitEvents()` / `waitEventsTimeout()` — event loop hooks
 ///   - `beginFrame()` / `endFrame()` — ImGui frame bracketing + swap
 ///   - `uploadBitmap()` — moves a CPU-side RGBA buffer into a GL texture
 ///     (reuses the same texture ID across frames to avoid churn)
@@ -137,6 +137,12 @@ public:
   /// drives the main loop instead (`glfwWaitEvents` is unimplemented
   /// upstream).
   void waitEvents();
+
+  /// Blocks until an event arrives or \p timeoutSeconds elapses, then
+  /// pumps the event queue once.
+  ///
+  /// @param timeoutSeconds Maximum wait duration in seconds.
+  void waitEventsTimeout(double timeoutSeconds);
 
   /// Post an empty event into the window's queue, waking a concurrent
   /// `waitEvents()` call. Safe to call from any thread. Used by the

--- a/donner/editor/main.cc
+++ b/donner/editor/main.cc
@@ -117,15 +117,18 @@ int main(int argc, char** argv) {
   while (!window.shouldClose()) {
     {
       ZoneScopedN("waitEvents");
-      // On native this blocks until a user input, window event, or a
-      // `wakeEventLoop()` post from the render worker. The editor is
-      // event-driven — no frames are produced between user inputs and
-      // worker results. Matches the original viewer prototype (commit
-      // 8e78aa49).
+      // On native this blocks until a user input, window event, timed
+      // UI wake, or a `wakeEventLoop()` post from the render worker.
+      // The editor is event-driven: no frames are produced between user
+      // inputs, worker results, and active timed UI work.
       //
       // On Emscripten `waitEvents` falls through to `glfwPollEvents`
       // since the browser drives the loop via `requestAnimationFrame`.
-      window.waitEvents();
+      if (const std::optional<float> wakeSeconds = shell.nextIdleWakeSeconds()) {
+        window.waitEventsTimeout(*wakeSeconds);
+      } else {
+        window.waitEvents();
+      }
     }
     {
       ZoneScopedN("beginFrame");

--- a/donner/editor/pen_cursor.svg
+++ b/donner/editor/pen_cursor.svg
@@ -1,0 +1,39 @@
+<!-- Visual reference: https://www.svgrepo.com/svg/437972/pen-tool -->
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <g id="pen-cursor-glyph" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <g stroke="#ffffff" stroke-width="3.35">
+      <path
+        d="
+          M 14.4153 18.6964
+          L 7.88293 19.2352
+          L 3.80865 3.84719
+          L 19.1966 7.92147
+          L 18.3043 14.8073" />
+      <rect
+        x="13.7081"
+        y="19.4036"
+        width="7.22447"
+        height="3"
+        transform="rotate(-45 13.7081 19.4036)" />
+      <line x1="5.92996" y1="5.96852" x2="10.8797" y2="10.9183" />
+      <circle cx="12.2939" cy="12.3325" r="2" transform="rotate(-45 12.2939 12.3325)" />
+    </g>
+    <g stroke="#000000" stroke-width="2">
+      <path
+        d="
+          M 14.4153 18.6964
+          L 7.88293 19.2352
+          L 3.80865 3.84719
+          L 19.1966 7.92147
+          L 18.3043 14.8073" />
+      <rect
+        x="13.7081"
+        y="19.4036"
+        width="7.22447"
+        height="3"
+        transform="rotate(-45 13.7081 19.4036)" />
+      <line x1="5.92996" y1="5.96852" x2="10.8797" y2="10.9183" />
+      <circle cx="12.2939" cy="12.3325" r="2" transform="rotate(-45 12.2939 12.3325)" />
+    </g>
+  </g>
+</svg>

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -182,6 +182,16 @@ donner_cc_test(
 )
 
 donner_cc_test(
+    name = "style_source_annotations_tests",
+    srcs = ["StyleSourceAnnotations_tests.cc"],
+    deps = [
+        "//donner/editor:style_source_annotations",
+        "//donner/svg/parser",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
     name = "flash_decorations_tests",
     srcs = ["FlashDecorations_tests.cc"],
     deps = [
@@ -521,6 +531,21 @@ donner_cc_test(
     deps = [
         "//donner/editor:editor_app",
         "//donner/editor:select_tool",
+        "//donner/svg",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
+    name = "pen_tool_tests",
+    srcs = ["PenTool_tests.cc"],
+    data = ["//:donner_splash.svg"],
+    deps = [
+        "//donner/editor:document_sync_controller",
+        "//donner/editor:editor_app",
+        "//donner/editor:pen_tool",
+        "//donner/editor:select_tool",
+        "//donner/editor:text_editor",
         "//donner/svg",
         "@com_google_gtest//:gtest_main",
     ],

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -210,6 +210,15 @@ donner_cc_test(
 )
 
 donner_cc_test(
+    name = "rope_simulation_tests",
+    srcs = ["RopeSimulation_tests.cc"],
+    deps = [
+        "//donner/editor:rope_simulation",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
     name = "render_pane_viewport_tests",
     srcs = ["RenderPaneViewport_tests.cc"],
     deps = [

--- a/donner/editor/tests/CommandQueue_tests.cc
+++ b/donner/editor/tests/CommandQueue_tests.cc
@@ -207,5 +207,21 @@ TEST_F(CommandQueueTest, DeleteElementCommandNotCoalesced) {
   EXPECT_EQ(effective[2].kind, EditorCommand::Kind::DeleteElement);
 }
 
+TEST_F(CommandQueueTest, InsertElementCommandNotCoalesced) {
+  CommandQueue queue;
+  queue.push(EditorCommand::InsertElementCommand(*a, *b));
+  queue.push(EditorCommand::InsertElementCommand(*a, *c));
+
+  const auto flushResult = queue.flush();
+  const auto& effective = flushResult.effectiveCommands;
+  ASSERT_EQ(effective.size(), 2u);
+  EXPECT_EQ(effective[0].kind, EditorCommand::Kind::InsertElement);
+  EXPECT_EQ(effective[1].kind, EditorCommand::Kind::InsertElement);
+  EXPECT_TRUE(effective[0].parentElement == a);
+  EXPECT_TRUE(effective[0].element == b);
+  EXPECT_TRUE(effective[1].parentElement == a);
+  EXPECT_TRUE(effective[1].element == c);
+}
+
 }  // namespace
 }  // namespace donner::editor

--- a/donner/editor/tests/DocumentSyncController_tests.cc
+++ b/donner/editor/tests/DocumentSyncController_tests.cc
@@ -349,6 +349,44 @@ TEST_F(DocumentSyncControllerTest, SourceBackedDeleteWritebackMirrorsFlushDeltaW
   EXPECT_FALSE(app_.document().document().querySelector("#r1").has_value());
 }
 
+TEST_F(DocumentSyncControllerTest, PathOperationMirrorsInsertAndDeletesWithoutTextEcho) {
+  constexpr std::string_view kTwoOverlappingRects =
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+         <rect id="r1" x="10" y="10" width="40" height="40" fill="red"/>
+         <rect id="r2" x="30" y="25" width="40" height="20" fill="blue"/>
+       </svg>)";
+
+  EditorApp app;
+  TextEditor textEditor;
+  SelectTool tool;
+  DocumentSyncController controller{std::string(kTwoOverlappingRects)};
+
+  ASSERT_TRUE(app.loadFromString(kTwoOverlappingRects));
+  app.setCurrentFilePath("test.svg");
+  app.setCleanSourceText(kTwoOverlappingRects);
+  textEditor.setText(kTwoOverlappingRects);
+  textEditor.resetTextChanged();
+
+  auto r1 = app.document().document().querySelector("#r1");
+  auto r2 = app.document().document().querySelector("#r2");
+  ASSERT_TRUE(r1.has_value());
+  ASSERT_TRUE(r2.has_value());
+  app.setSelection(std::vector<svg::SVGElement>{*r1, *r2});
+
+  ASSERT_TRUE(app.applyPathOperation(PathOperationKind::Intersect));
+  ASSERT_TRUE(app.flushFrame());
+  EXPECT_FALSE(app.document().lastFlushResult().replacedDocument);
+  EXPECT_GE(app.document().lastFlushResult().sourceDeltas.size(), 3u);
+
+  controller.applyPendingWritebacks(app, tool, textEditor);
+
+  EXPECT_EQ(textEditor.getText(), app.document().document().source());
+  EXPECT_FALSE(textEditor.isTextChanged());
+  EXPECT_TRUE(app.document().document().querySelector("path").has_value());
+  EXPECT_FALSE(app.document().document().querySelector("#r1").has_value());
+  EXPECT_FALSE(app.document().document().querySelector("#r2").has_value());
+}
+
 TEST_F(DocumentSyncControllerTest, UiDeleteUndoRestoresDeletedElementAndSourceText) {
   EditorApp app;
   TextEditor textEditor;

--- a/donner/editor/tests/EditorApp_tests.cc
+++ b/donner/editor/tests/EditorApp_tests.cc
@@ -1,6 +1,7 @@
 #include "donner/editor/EditorApp.h"
 
 #include "donner/editor/ViewportGeometry.h"
+#include "donner/svg/SVGPathElement.h"
 #include "gtest/gtest.h"
 
 namespace donner::editor {
@@ -178,6 +179,215 @@ TEST(EditorAppTest, AddToSelectionIsIdempotent) {
   app.addToSelection(*r1);
   app.addToSelection(*r1);
   EXPECT_EQ(app.selectedElements().size(), 1u);
+}
+
+TEST(EditorAppTest, SetAttributeOnSelectionQueuesEverySelectedElement) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kTrivialSvg));
+
+  auto r1 = app.document().document().querySelector("#r1");
+  auto r2 = app.document().document().querySelector("#r2");
+  ASSERT_TRUE(r1.has_value());
+  ASSERT_TRUE(r2.has_value());
+  app.setSelection(std::vector<svg::SVGElement>{*r1, *r2});
+
+  ASSERT_TRUE(app.setAttributeOnSelection("fill", "#112233"));
+  EXPECT_EQ(app.document().queue().size(), 2u);
+  ASSERT_TRUE(app.flushFrame());
+
+  auto updatedR1 = app.document().document().querySelector("#r1");
+  auto updatedR2 = app.document().document().querySelector("#r2");
+  ASSERT_TRUE(updatedR1.has_value());
+  ASSERT_TRUE(updatedR2.has_value());
+  EXPECT_EQ(updatedR1->getAttribute("fill"), "#112233");
+  EXPECT_EQ(updatedR2->getAttribute("fill"), "#112233");
+}
+
+TEST(EditorAppTest, SetStylePropertyOnSelectionMergesIntoStyleAttribute) {
+  constexpr std::string_view kStyledSvg =
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+         <rect id="r1" x="10" y="10" width="20" height="20" fill="red"
+               style="stroke: blue; opacity: 0.5"/>
+       </svg>)";
+
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kStyledSvg));
+
+  auto r1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(r1.has_value());
+  app.setSelection(*r1);
+
+  ASSERT_TRUE(app.setStylePropertyOnSelection("fill", "#112233"));
+  EXPECT_EQ(app.document().queue().size(), 1u);
+  ASSERT_TRUE(app.flushFrame());
+
+  auto updatedR1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(updatedR1.has_value());
+  EXPECT_EQ(updatedR1->getAttribute("fill"), "red");
+  EXPECT_EQ(updatedR1->getAttribute("style"), "stroke: blue; opacity: 0.5; fill: #112233");
+}
+
+TEST(EditorAppTest, SetStylePropertyOnSelectionOverridesExistingStyleProperty) {
+  constexpr std::string_view kStyledSvg =
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+         <rect id="r1" x="10" y="10" width="20" height="20" fill="red"
+               style="fill: blue; stroke: black"/>
+       </svg>)";
+
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kStyledSvg));
+
+  auto r1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(r1.has_value());
+  app.setSelection(*r1);
+
+  ASSERT_TRUE(app.setStylePropertyOnSelection("fill", "#112233"));
+  ASSERT_TRUE(app.flushFrame());
+
+  auto updatedR1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(updatedR1.has_value());
+  EXPECT_EQ(updatedR1->getAttribute("style"), "stroke: black; fill: #112233");
+}
+
+TEST(EditorAppTest, SetStrokeWidthOnSelectionClampsNegativeValues) {
+  constexpr std::string_view kStyledSvg =
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+         <rect id="r1" x="10" y="10" width="20" height="20" stroke-width="4"
+               style="stroke: black; opacity: 0.5"/>
+       </svg>)";
+
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kStyledSvg));
+
+  auto r1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(r1.has_value());
+  app.setSelection(*r1);
+
+  ASSERT_TRUE(app.setStrokeWidthOnSelection(-4.0));
+  ASSERT_TRUE(app.flushFrame());
+
+  auto updatedR1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(updatedR1.has_value());
+  EXPECT_EQ(updatedR1->getAttribute("stroke-width"), "4");
+  EXPECT_EQ(updatedR1->getAttribute("style"), "stroke: black; opacity: 0.5; stroke-width: 0");
+}
+
+TEST(EditorAppTest, SetStrokeWidthOnSelectionOverridesExistingStyleProperty) {
+  constexpr std::string_view kStyledSvg =
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+         <rect id="r1" x="10" y="10" width="20" height="20" stroke-width="4"
+               style="stroke-width: 9; stroke: black"/>
+       </svg>)";
+
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kStyledSvg));
+
+  auto r1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(r1.has_value());
+  app.setSelection(*r1);
+
+  ASSERT_TRUE(app.setStrokeWidthOnSelection(2.5));
+  ASSERT_TRUE(app.flushFrame());
+
+  auto updatedR1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(updatedR1.has_value());
+  EXPECT_EQ(updatedR1->getAttribute("stroke-width"), "4");
+  EXPECT_EQ(updatedR1->getAttribute("style"), "stroke: black; stroke-width: 2.5");
+}
+
+TEST(EditorAppTest, SetActiveStrokeWidthClampsNegativeValues) {
+  EditorApp app;
+
+  app.setActiveStrokeWidth(-4.0);
+
+  EXPECT_EQ(app.activePaintStyle().strokeWidth, 0.0);
+}
+
+TEST(EditorAppTest, PathOperationAvailabilityRequiresMultipleGeometryElements) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kTrivialSvg));
+
+  EXPECT_FALSE(app.pathOperationAvailability(PathOperationKind::Union).canApply);
+
+  auto r1 = app.document().document().querySelector("#r1");
+  auto r2 = app.document().document().querySelector("#r2");
+  ASSERT_TRUE(r1.has_value());
+  ASSERT_TRUE(r2.has_value());
+
+  app.setSelection(*r1);
+  EXPECT_FALSE(app.pathOperationAvailability(PathOperationKind::Union).canApply);
+
+  app.setSelection(std::vector<svg::SVGElement>{*r1, *r2});
+  EXPECT_TRUE(app.pathOperationAvailability(PathOperationKind::Union).canApply);
+  EXPECT_FALSE(app.pathOperationAvailability(PathOperationKind::SubtractFront).canApply);
+}
+
+TEST(EditorAppTest, PathUnionReplacesSelectionWithBoundsPath) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kTrivialSvg));
+
+  auto r1 = app.document().document().querySelector("#r1");
+  auto r2 = app.document().document().querySelector("#r2");
+  ASSERT_TRUE(r1.has_value());
+  ASSERT_TRUE(r2.has_value());
+  app.setSelection(std::vector<svg::SVGElement>{*r1, *r2});
+
+  ASSERT_TRUE(app.applyPathOperation(PathOperationKind::Union));
+  ASSERT_EQ(app.selectedElements().size(), 1u);
+  ASSERT_TRUE(app.selectedElements().front().isa<svg::SVGPathElement>());
+  EXPECT_EQ(std::string_view(app.selectedElements().front().cast<svg::SVGPathElement>().d()),
+            "M 10 10 L 70 10 L 70 70 L 10 70 Z");
+
+  ASSERT_TRUE(app.flushFrame());
+  EXPECT_FALSE(app.document().document().querySelector("#r1").has_value());
+  EXPECT_FALSE(app.document().document().querySelector("#r2").has_value());
+  auto result = app.document().document().querySelector("path");
+  ASSERT_TRUE(result.has_value());
+  ASSERT_TRUE(result->isa<svg::SVGPathElement>());
+  EXPECT_EQ(std::string_view(result->cast<svg::SVGPathElement>().d()),
+            "M 10 10 L 70 10 L 70 70 L 10 70 Z");
+  EXPECT_NE(app.document().document().source().find(R"(<path d="M 10 10 L 70 10)"),
+            std::string_view::npos);
+}
+
+TEST(EditorAppTest, PathIntersectReplacesSelectionWithOverlapPath) {
+  constexpr std::string_view kOverlappingSvg =
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+         <rect id="r1" x="10" y="10" width="40" height="40" fill="red"/>
+         <rect id="r2" x="30" y="25" width="40" height="20" fill="blue"/>
+       </svg>)";
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kOverlappingSvg));
+
+  auto r1 = app.document().document().querySelector("#r1");
+  auto r2 = app.document().document().querySelector("#r2");
+  ASSERT_TRUE(r1.has_value());
+  ASSERT_TRUE(r2.has_value());
+  app.setSelection(std::vector<svg::SVGElement>{*r1, *r2});
+
+  ASSERT_TRUE(app.applyPathOperation(PathOperationKind::Intersect));
+  ASSERT_TRUE(app.flushFrame());
+
+  auto result = app.document().document().querySelector("path");
+  ASSERT_TRUE(result.has_value());
+  ASSERT_TRUE(result->isa<svg::SVGPathElement>());
+  EXPECT_EQ(std::string_view(result->cast<svg::SVGPathElement>().d()),
+            "M 30 25 L 50 25 L 50 45 L 30 45 Z");
+}
+
+TEST(EditorAppTest, PathIntersectDisabledWhenBoundsDoNotOverlap) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kTrivialSvg));
+
+  auto r1 = app.document().document().querySelector("#r1");
+  auto r2 = app.document().document().querySelector("#r2");
+  ASSERT_TRUE(r1.has_value());
+  ASSERT_TRUE(r2.has_value());
+  app.setSelection(std::vector<svg::SVGElement>{*r1, *r2});
+
+  EXPECT_FALSE(app.pathOperationAvailability(PathOperationKind::Intersect).canApply);
+  EXPECT_FALSE(app.applyPathOperation(PathOperationKind::Intersect));
+  EXPECT_EQ(app.document().queue().size(), 0u);
 }
 
 TEST(EditorAppTest, HitTestRectFindsAllIntersectingElements) {

--- a/donner/editor/tests/FocusView_tests.cc
+++ b/donner/editor/tests/FocusView_tests.cc
@@ -76,6 +76,16 @@ constexpr std::string_view kSelectorListSvg =
   <rect id="miss" class="miss"/>
 </svg>)svg";
 
+constexpr std::string_view kStyleInDefsSvg =
+    R"svg(<svg xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>
+      .hit { fill: red; }
+    </style>
+  </defs>
+  <rect id="hit" class="hit"/>
+</svg>)svg";
+
 constexpr std::string_view kStyleSourceMutationSvg =
     R"svg(<svg xmlns="http://www.w3.org/2000/svg">
   <style>
@@ -180,6 +190,17 @@ constexpr std::string_view kGroupedCssChildrenSvg =
     <path id="boltB" class="bright"/>
   </g>
   <path id="sibling" class="unused"/>
+</svg>)svg";
+
+constexpr std::string_view kGroupOwnAndChildCssSvg =
+    R"svg(<svg xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .outer { opacity: 0.8; }
+    .inner { fill: white; }
+  </style>
+  <g id="group" class="outer">
+    <path id="child" class="inner"/>
+  </g>
 </svg>)svg";
 
 std::size_t OffsetForNeedle(std::string_view source, std::string_view needle) {
@@ -339,7 +360,7 @@ TEST(FocusViewTest, ReferenceHighlightSummaryCountsForwardReferences) {
   EXPECT_EQ(summary.totalCount(), 3u);
 }
 
-TEST(FocusViewTest, IncludesReferencesFromStyleAndDescendantHrefAttributes) {
+TEST(FocusViewTest, GroupSelectionDrawsOnlyOwnReferenceArrows) {
   EditorApp app;
   ASSERT_TRUE(app.loadFromString(kSubtreeReferencedSvg));
   std::optional<svg::SVGElement> target = app.document().document().querySelector("#target");
@@ -355,10 +376,6 @@ TEST(FocusViewTest, IncludesReferencesFromStyleAndDescendantHrefAttributes) {
                 {
                     .from = PointForNeedle(kSubtreeReferencedSvg, "#arrow"),
                     .to = PointForOpeningTagEnd(kSubtreeReferencedSvg, R"(<marker id="arrow")"),
-                },
-                {
-                    .from = PointForNeedle(kSubtreeReferencedSvg, "#pathRef"),
-                    .to = PointForOpeningTagEnd(kSubtreeReferencedSvg, R"(<path id="pathRef")"),
                 },
             }));
 }
@@ -387,12 +404,12 @@ TEST(FocusViewTest, IncludesMatchedCssRulesAndCssDeclarationReferences) {
   EXPECT_TRUE(ContainsLine(partition.hidden,
                            PointForNeedle(kCssReferencedSvg, R"(<rect id="sibling")").line));
 
-  EXPECT_TRUE(ContainsLink(
-      partition.referenceLinks,
-      FocusReferenceLink{
-          .from = PointForNeedleAfter(kCssReferencedSvg, "cls-92", R"(<rect id="target")"),
-          .to = PointForNeedle(kCssReferencedSvg, ".cls-92"),
-      }));
+  EXPECT_TRUE(
+      ContainsLink(partition.referenceLinks,
+                   FocusReferenceLink{
+                       .from = PointForOpeningTagEnd(kCssReferencedSvg, R"(<rect id="target")"),
+                       .to = PointForNeedle(kCssReferencedSvg, ".cls-92"),
+                   }));
   EXPECT_TRUE(ContainsLink(
       partition.referenceLinks,
       FocusReferenceLink{
@@ -423,11 +440,17 @@ TEST(FocusViewTest, StyleOffsetFocusIncludesImpactedElementsAndCssDeclarationRef
   EXPECT_TRUE(ContainsLine(partition->hidden,
                            PointForNeedle(kCssReferencedSvg, R"(<rect id="sibling")").line));
 
-  EXPECT_TRUE(ContainsLink(partition->referenceLinks,
-                           FocusReferenceLink{
-                               .from = PointForNeedle(kCssReferencedSvg, ".cls-92"),
-                               .to = PointForNeedle(kCssReferencedSvg, R"(<rect id="target")"),
-                           }));
+  EXPECT_TRUE(
+      ContainsLink(partition->referenceLinks,
+                   FocusReferenceLink{
+                       .from = PointForOpeningTagEnd(kCssReferencedSvg, R"(<rect id="target")"),
+                       .to = PointForNeedle(kCssReferencedSvg, ".cls-92"),
+                   }));
+  EXPECT_FALSE(ContainsLink(partition->referenceLinks,
+                            FocusReferenceLink{
+                                .from = PointForNeedle(kCssReferencedSvg, ".cls-92"),
+                                .to = PointForNeedle(kCssReferencedSvg, R"(<rect id="target")"),
+                            }));
   EXPECT_TRUE(ContainsLink(
       partition->referenceLinks,
       FocusReferenceLink{
@@ -455,6 +478,24 @@ TEST(FocusViewTest, StyleOffsetFocusUsesSelectorListBranchUnderCursor) {
                            PointForNeedle(kSelectorListSvg, R"(<rect id="hit")").line));
   EXPECT_TRUE(ContainsLine(blockPartition->referenceColor,
                            PointForNeedle(kSelectorListSvg, R"(<rect id="miss")").line));
+}
+
+TEST(FocusViewTest, StyleOffsetFocusShowsStyleElementAncestors) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kStyleInDefsSvg));
+
+  const std::optional<FocusPartition> partition = ComputeStyleFocusPartitionAtSourceOffset(
+      app.document().document(), OffsetForNeedle(kStyleInDefsSvg, ".hit"));
+  ASSERT_TRUE(partition.has_value());
+
+  EXPECT_TRUE(ContainsLine(partition->dimmed, PointForNeedle(kStyleInDefsSvg, "<svg").line));
+  EXPECT_TRUE(ContainsLine(partition->dimmed, PointForNeedle(kStyleInDefsSvg, "<defs>").line));
+  EXPECT_TRUE(ContainsLine(partition->dimmed, PointForNeedle(kStyleInDefsSvg, "<style>").line));
+  EXPECT_TRUE(ContainsLine(partition->dimmed, PointForNeedle(kStyleInDefsSvg, "</style>").line));
+  EXPECT_TRUE(ContainsLine(partition->dimmed, PointForNeedle(kStyleInDefsSvg, "</defs>").line));
+  EXPECT_TRUE(ContainsLine(partition->dimmed, PointForNeedle(kStyleInDefsSvg, "</svg>").line));
+  EXPECT_FALSE(ContainsLine(partition->hidden, PointForNeedle(kStyleInDefsSvg, "<defs>").line));
+  EXPECT_FALSE(ContainsLine(partition->hidden, PointForNeedle(kStyleInDefsSvg, "</defs>").line));
 }
 
 TEST(FocusViewTest, StyleFocusReportsImpactedElementsForCanvasSelection) {
@@ -545,7 +586,7 @@ TEST(FocusViewTest, StyleOffsetFocusSurvivesStructuredSourceTypingMutations) {
   }
 }
 
-TEST(FocusViewTest, SelectingGroupIncludesCssRuleLinksForDescendantElements) {
+TEST(FocusViewTest, SelectingGroupShowsDescendantCssRulesWithoutDescendantLinks) {
   EditorApp app;
   ASSERT_TRUE(app.loadFromString(kGroupedCssChildrenSvg));
   std::optional<svg::SVGElement> group =
@@ -565,18 +606,28 @@ TEST(FocusViewTest, SelectingGroupIncludesCssRuleLinksForDescendantElements) {
   EXPECT_TRUE(ContainsLine(partition.hidden,
                            PointForNeedle(kGroupedCssChildrenSvg, R"(<path id="sibling")").line));
 
-  EXPECT_TRUE(ContainsLink(
-      partition.referenceLinks,
-      FocusReferenceLink{
-          .from = PointForNeedleAfter(kGroupedCssChildrenSvg, "glow", R"(<path id="boltA")"),
-          .to = PointForNeedle(kGroupedCssChildrenSvg, ".glow"),
-      }));
-  EXPECT_TRUE(ContainsLink(
-      partition.referenceLinks,
-      FocusReferenceLink{
-          .from = PointForNeedleAfter(kGroupedCssChildrenSvg, "bright", R"(<path id="boltB")"),
-          .to = PointForNeedle(kGroupedCssChildrenSvg, ".bright"),
-      }));
+  EXPECT_TRUE(partition.referenceLinks.empty());
+}
+
+TEST(FocusViewTest, SelectingGroupStillDrawsOwnCssRuleLink) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kGroupOwnAndChildCssSvg));
+  std::optional<svg::SVGElement> group = app.document().document().querySelector("#group");
+  ASSERT_TRUE(group.has_value());
+
+  const FocusPartition partition = ComputeFocusPartition(app.document().document(), *group);
+
+  EXPECT_TRUE(ContainsLine(partition.referenceColor,
+                           PointForNeedle(kGroupOwnAndChildCssSvg, ".outer").line));
+  EXPECT_TRUE(ContainsLine(partition.referenceColor,
+                           PointForNeedle(kGroupOwnAndChildCssSvg, ".inner").line));
+  EXPECT_EQ(SortLinks(partition.referenceLinks),
+            SortLinks(std::vector<FocusReferenceLink>{
+                {
+                    .from = PointForOpeningTagEnd(kGroupOwnAndChildCssSvg, R"(<g id="group")"),
+                    .to = PointForNeedle(kGroupOwnAndChildCssSvg, ".outer"),
+                },
+            }));
 }
 
 TEST(FocusViewTest, SelectingMultipleElementsIncludesCssRuleLinksForEachSelection) {
@@ -598,18 +649,18 @@ TEST(FocusViewTest, SelectingMultipleElementsIncludesCssRuleLinksForEachSelectio
       ContainsLine(partition.referenceColor, PointForNeedle(kGroupedCssChildrenSvg, ".glow").line));
   EXPECT_TRUE(ContainsLine(partition.referenceColor,
                            PointForNeedle(kGroupedCssChildrenSvg, ".bright").line));
-  EXPECT_TRUE(ContainsLink(
-      partition.referenceLinks,
-      FocusReferenceLink{
-          .from = PointForNeedleAfter(kGroupedCssChildrenSvg, "glow", R"(<path id="boltA")"),
-          .to = PointForNeedle(kGroupedCssChildrenSvg, ".glow"),
-      }));
-  EXPECT_TRUE(ContainsLink(
-      partition.referenceLinks,
-      FocusReferenceLink{
-          .from = PointForNeedleAfter(kGroupedCssChildrenSvg, "bright", R"(<path id="boltB")"),
-          .to = PointForNeedle(kGroupedCssChildrenSvg, ".bright"),
-      }));
+  EXPECT_TRUE(
+      ContainsLink(partition.referenceLinks,
+                   FocusReferenceLink{
+                       .from = PointForOpeningTagEnd(kGroupedCssChildrenSvg, R"(<path id="boltA")"),
+                       .to = PointForNeedle(kGroupedCssChildrenSvg, ".glow"),
+                   }));
+  EXPECT_TRUE(
+      ContainsLink(partition.referenceLinks,
+                   FocusReferenceLink{
+                       .from = PointForOpeningTagEnd(kGroupedCssChildrenSvg, R"(<path id="boltB")"),
+                       .to = PointForNeedle(kGroupedCssChildrenSvg, ".bright"),
+                   }));
 }
 
 TEST(FocusViewTest, SelectingReferencedResourceIncludesReferringElementsAndCssRules) {

--- a/donner/editor/tests/FocusView_tests.cc
+++ b/donner/editor/tests/FocusView_tests.cc
@@ -116,6 +116,19 @@ constexpr std::string_view kFilterFanoutSvg =
   <path id="otherUser" class="uses-other"/>
 </svg>)svg";
 
+constexpr std::string_view kDenseResourceReferrersSvg =
+    R"svg(<svg xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="paint"><stop offset="1"/></linearGradient>
+  </defs>
+  <rect id="r1" fill="url(#paint)"/>
+  <rect id="r2" fill="url(#paint)"/>
+  <rect id="r3" fill="url(#paint)"/>
+  <rect id="r4" fill="url(#paint)"/>
+  <rect id="r5" fill="url(#paint)"/>
+  <rect id="r6" fill="url(#paint)"/>
+</svg>)svg";
+
 constexpr std::string_view kNonRenderedStopStyleSvg =
     R"svg(<svg xmlns="http://www.w3.org/2000/svg">
   <style>
@@ -142,6 +155,19 @@ constexpr std::string_view kUniversalStopStyleSvg =
   </defs>
 </svg>)svg";
 
+constexpr std::string_view kDenseUniversalStyleSvg =
+    R"svg(<svg xmlns="http://www.w3.org/2000/svg">
+  <style>
+    * { stroke-width: 0; }
+  </style>
+  <rect id="r1"/>
+  <rect id="r2"/>
+  <rect id="r3"/>
+  <rect id="r4"/>
+  <rect id="r5"/>
+  <rect id="r6"/>
+</svg>)svg";
+
 constexpr std::string_view kGroupedCssChildrenSvg =
     R"svg(<svg xmlns="http://www.w3.org/2000/svg">
   <style>
@@ -164,6 +190,24 @@ std::size_t OffsetForNeedle(std::string_view source, std::string_view needle) {
 
 SourcePoint PointForNeedle(std::string_view source, std::string_view needle) {
   const std::size_t offset = OffsetForNeedle(source, needle);
+
+  int line = 0;
+  std::size_t lineStart = 0;
+  for (std::size_t i = 0; i < offset; ++i) {
+    if (source[i] == '\n') {
+      ++line;
+      lineStart = i + 1;
+    }
+  }
+
+  return SourcePoint{.line = line, .column = static_cast<int>(offset - lineStart)};
+}
+
+SourcePoint PointForOpeningTagEnd(std::string_view source, std::string_view openingTagStart) {
+  const std::size_t startOffset = OffsetForNeedle(source, openingTagStart);
+  const std::size_t closeOffset = source.find('>', startOffset);
+  EXPECT_NE(closeOffset, std::string_view::npos) << openingTagStart;
+  const std::size_t offset = closeOffset == std::string_view::npos ? startOffset : closeOffset + 1;
 
   int line = 0;
   std::size_t lineStart = 0;
@@ -258,19 +302,19 @@ TEST(FocusViewTest, IncludesReferencedPaintAndCompositingElements) {
             SortLinks(std::vector<FocusReferenceLink>{
                 {
                     .from = PointForNeedle(kReferencedSvg, "#paint"),
-                    .to = PointForNeedle(kReferencedSvg, R"(<linearGradient id="paint")"),
+                    .to = PointForOpeningTagEnd(kReferencedSvg, R"(<linearGradient id="paint")"),
                 },
                 {
                     .from = PointForNeedle(kReferencedSvg, "#clip"),
-                    .to = PointForNeedle(kReferencedSvg, R"(<clipPath id="clip")"),
+                    .to = PointForOpeningTagEnd(kReferencedSvg, R"(<clipPath id="clip")"),
                 },
                 {
                     .from = PointForNeedle(kReferencedSvg, "#shadow"),
-                    .to = PointForNeedle(kReferencedSvg, R"(<filter id="shadow")"),
+                    .to = PointForOpeningTagEnd(kReferencedSvg, R"(<filter id="shadow")"),
                 },
                 {
                     .from = PointForNeedle(kReferencedSvg, "#base"),
-                    .to = PointForNeedle(kReferencedSvg, R"(<linearGradient id="base")"),
+                    .to = PointForOpeningTagEnd(kReferencedSvg, R"(<linearGradient id="base")"),
                 },
             }));
 }
@@ -310,11 +354,11 @@ TEST(FocusViewTest, IncludesReferencesFromStyleAndDescendantHrefAttributes) {
             SortLinks(std::vector<FocusReferenceLink>{
                 {
                     .from = PointForNeedle(kSubtreeReferencedSvg, "#arrow"),
-                    .to = PointForNeedle(kSubtreeReferencedSvg, R"(<marker id="arrow")"),
+                    .to = PointForOpeningTagEnd(kSubtreeReferencedSvg, R"(<marker id="arrow")"),
                 },
                 {
                     .from = PointForNeedle(kSubtreeReferencedSvg, "#pathRef"),
-                    .to = PointForNeedle(kSubtreeReferencedSvg, R"(<path id="pathRef")"),
+                    .to = PointForOpeningTagEnd(kSubtreeReferencedSvg, R"(<path id="pathRef")"),
                 },
             }));
 }
@@ -349,12 +393,12 @@ TEST(FocusViewTest, IncludesMatchedCssRulesAndCssDeclarationReferences) {
           .from = PointForNeedleAfter(kCssReferencedSvg, "cls-92", R"(<rect id="target")"),
           .to = PointForNeedle(kCssReferencedSvg, ".cls-92"),
       }));
-  EXPECT_TRUE(
-      ContainsLink(partition.referenceLinks,
-                   FocusReferenceLink{
-                       .from = PointForNeedle(kCssReferencedSvg, "#paint"),
-                       .to = PointForNeedle(kCssReferencedSvg, R"(<linearGradient id="paint")"),
-                   }));
+  EXPECT_TRUE(ContainsLink(
+      partition.referenceLinks,
+      FocusReferenceLink{
+          .from = PointForNeedle(kCssReferencedSvg, "#paint"),
+          .to = PointForOpeningTagEnd(kCssReferencedSvg, R"(<linearGradient id="paint")"),
+      }));
 }
 
 TEST(FocusViewTest, StyleOffsetFocusIncludesImpactedElementsAndCssDeclarationReferences) {
@@ -384,12 +428,12 @@ TEST(FocusViewTest, StyleOffsetFocusIncludesImpactedElementsAndCssDeclarationRef
                                .from = PointForNeedle(kCssReferencedSvg, ".cls-92"),
                                .to = PointForNeedle(kCssReferencedSvg, R"(<rect id="target")"),
                            }));
-  EXPECT_TRUE(
-      ContainsLink(partition->referenceLinks,
-                   FocusReferenceLink{
-                       .from = PointForNeedle(kCssReferencedSvg, "#paint"),
-                       .to = PointForNeedle(kCssReferencedSvg, R"(<linearGradient id="paint")"),
-                   }));
+  EXPECT_TRUE(ContainsLink(
+      partition->referenceLinks,
+      FocusReferenceLink{
+          .from = PointForNeedle(kCssReferencedSvg, "#paint"),
+          .to = PointForOpeningTagEnd(kCssReferencedSvg, R"(<linearGradient id="paint")"),
+      }));
 }
 
 TEST(FocusViewTest, StyleOffsetFocusUsesSelectorListBranchUnderCursor) {
@@ -597,31 +641,31 @@ TEST(FocusViewTest, SelectingReferencedResourceIncludesReferringElementsAndCssRu
   EXPECT_TRUE(ContainsLine(partition.hidden,
                            PointForNeedle(kResourceReferrersSvg, R"(<rect id="sibling")").line));
 
-  EXPECT_TRUE(
-      ContainsLink(partition.referenceLinks,
-                   FocusReferenceLink{
-                       .from = PointForNeedle(kResourceReferrersSvg, "#paint"),
-                       .to = PointForNeedle(kResourceReferrersSvg, R"(<radialGradient id="paint")"),
-                   }));
-  EXPECT_TRUE(
-      ContainsLink(partition.referenceLinks,
-                   FocusReferenceLink{
-                       .from = PointForNeedleAfter(kResourceReferrersSvg, "#paint",
-                                                   R"(<linearGradient id="chained")"),
-                       .to = PointForNeedle(kResourceReferrersSvg, R"(<radialGradient id="paint")"),
-                   }));
+  EXPECT_TRUE(ContainsLink(
+      partition.referenceLinks,
+      FocusReferenceLink{
+          .from = PointForNeedle(kResourceReferrersSvg, "#paint"),
+          .to = PointForOpeningTagEnd(kResourceReferrersSvg, R"(<radialGradient id="paint")"),
+      }));
+  EXPECT_TRUE(ContainsLink(
+      partition.referenceLinks,
+      FocusReferenceLink{
+          .from = PointForNeedleAfter(kResourceReferrersSvg, "#paint",
+                                      R"(<linearGradient id="chained")"),
+          .to = PointForOpeningTagEnd(kResourceReferrersSvg, R"(<radialGradient id="paint")"),
+      }));
   EXPECT_TRUE(ContainsLink(
       partition.referenceLinks,
       FocusReferenceLink{
           .from =
               PointForNeedleAfter(kResourceReferrersSvg, "#paint", R"(<circle id="attrTarget")"),
-          .to = PointForNeedle(kResourceReferrersSvg, R"(<radialGradient id="paint")"),
+          .to = PointForOpeningTagEnd(kResourceReferrersSvg, R"(<radialGradient id="paint")"),
       }));
   EXPECT_TRUE(ContainsLink(
       partition.referenceLinks,
       FocusReferenceLink{
           .from = PointForNeedle(kResourceReferrersSvg, "#chained"),
-          .to = PointForNeedle(kResourceReferrersSvg, R"(<linearGradient id="chained")"),
+          .to = PointForOpeningTagEnd(kResourceReferrersSvg, R"(<linearGradient id="chained")"),
       }));
 }
 
@@ -643,6 +687,45 @@ TEST(FocusViewTest, ReferenceHighlightSummaryCountsReverseReferences) {
   EXPECT_TRUE(ContainsElement(summary.referencingElements,
                               app.document().document().querySelector("#chained")));
   EXPECT_EQ(summary.totalCount(), 3u);
+}
+
+TEST(FocusViewTest, SuppressesReverseReferenceExpansionAfterFiveRefs) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kDenseResourceReferrersSvg));
+  std::optional<svg::SVGElement> paint = app.document().document().querySelector("#paint");
+  ASSERT_TRUE(paint.has_value());
+
+  const FocusPartition partition = ComputeFocusPartition(app.document().document(), *paint);
+
+  EXPECT_TRUE(ContainsLine(
+      partition.fullColor,
+      PointForNeedle(kDenseResourceReferrersSvg, R"(<linearGradient id="paint")").line));
+  EXPECT_FALSE(ContainsLine(partition.referenceColor,
+                            PointForNeedle(kDenseResourceReferrersSvg, R"(<rect id="r1")").line));
+  EXPECT_FALSE(ContainsLine(partition.referenceColor,
+                            PointForNeedle(kDenseResourceReferrersSvg, R"(<rect id="r6")").line));
+  EXPECT_TRUE(ContainsLine(partition.hidden,
+                           PointForNeedle(kDenseResourceReferrersSvg, R"(<rect id="r1")").line));
+  EXPECT_TRUE(partition.referenceLinks.empty());
+}
+
+TEST(FocusViewTest, StyleFocusSuppressesUniversalSelectorExpansionAfterFiveRefs) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kDenseUniversalStyleSvg));
+
+  const std::optional<StyleFocus> focus = ComputeStyleFocusAtSourceOffset(
+      app.document().document(), OffsetForNeedle(kDenseUniversalStyleSvg, "stroke-width"));
+  ASSERT_TRUE(focus.has_value());
+
+  EXPECT_TRUE(focus->reverseReferenceExpansionSuppressed);
+  EXPECT_TRUE(focus->impactedElements.empty());
+  EXPECT_TRUE(ContainsLine(focus->partition.fullColor,
+                           PointForNeedle(kDenseUniversalStyleSvg, "* {").line));
+  EXPECT_FALSE(ContainsLine(focus->partition.referenceColor,
+                            PointForNeedle(kDenseUniversalStyleSvg, R"(<rect id="r1")").line));
+  EXPECT_FALSE(ContainsLine(focus->partition.referenceColor,
+                            PointForNeedle(kDenseUniversalStyleSvg, R"(<rect id="r6")").line));
+  EXPECT_TRUE(focus->partition.referenceLinks.empty());
 }
 
 TEST(FocusViewTest, ForwardFilterDependencyDoesNotReverseExpandOtherFilterReferrers) {
@@ -674,7 +757,7 @@ TEST(FocusViewTest, ForwardFilterDependencyDoesNotReverseExpandOtherFilterReferr
       partition.referenceLinks,
       FocusReferenceLink{
           .from = PointForNeedleAfter(kFilterFanoutSvg, "#glow", R"(<path id="letterD")"),
-          .to = PointForNeedle(kFilterFanoutSvg, R"(<filter id="glow")"),
+          .to = PointForOpeningTagEnd(kFilterFanoutSvg, R"(<filter id="glow")"),
       }));
 }
 
@@ -699,13 +782,14 @@ TEST(FocusViewTest, SelectingFilterResourceStillIncludesTransitiveReferrers) {
       partition.referenceLinks,
       FocusReferenceLink{
           .from = PointForNeedleAfter(kFilterFanoutSvg, "#glow", R"(<filter id="other")"),
-          .to = PointForNeedle(kFilterFanoutSvg, R"(<filter id="glow")"),
+          .to = PointForOpeningTagEnd(kFilterFanoutSvg, R"(<filter id="glow")"),
       }));
-  EXPECT_TRUE(ContainsLink(partition.referenceLinks,
-                           FocusReferenceLink{
-                               .from = PointForNeedle(kFilterFanoutSvg, "#other"),
-                               .to = PointForNeedle(kFilterFanoutSvg, R"(<filter id="other")"),
-                           }));
+  EXPECT_TRUE(
+      ContainsLink(partition.referenceLinks,
+                   FocusReferenceLink{
+                       .from = PointForNeedle(kFilterFanoutSvg, "#other"),
+                       .to = PointForOpeningTagEnd(kFilterFanoutSvg, R"(<filter id="other")"),
+                   }));
 }
 
 TEST(FocusViewTest, ReferencedGradientOmitsCssRulesMatchedOnlyByStopDescendants) {

--- a/donner/editor/tests/FocusView_tests.cc
+++ b/donner/editor/tests/FocusView_tests.cc
@@ -10,6 +10,7 @@
 #include "donner/editor/DocumentSyncController.h"
 #include "donner/editor/EditorApp.h"
 #include "donner/editor/TextEditor.h"
+#include "donner/svg/DocumentState.h"
 #include "donner/svg/SVGUnknownElement.h"
 
 namespace donner::editor {
@@ -358,6 +359,20 @@ TEST(FocusViewTest, ReferenceHighlightSummaryCountsForwardReferences) {
                               app.document().document().querySelector("#shadow")));
   EXPECT_TRUE(summary.referencingElements.empty());
   EXPECT_EQ(summary.totalCount(), 3u);
+}
+
+TEST(FocusViewTest, ReferenceHighlightSummaryAllowsConcurrentDom) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kReferencedSvg));
+  app.document().document().setThreadingMode(svg::ThreadingMode::ConcurrentDom);
+  std::optional<svg::SVGElement> target = app.document().document().querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+
+  const ReferenceHighlightSummary summary = ComputeReferenceHighlightSummary(
+      app.document().document(), std::span<const svg::SVGElement>(&*target, 1));
+
+  EXPECT_EQ(summary.referencedElements.size(), 3u);
+  EXPECT_TRUE(summary.referencingElements.empty());
 }
 
 TEST(FocusViewTest, GroupSelectionDrawsOnlyOwnReferenceArrows) {

--- a/donner/editor/tests/OverlayRenderer_tests.cc
+++ b/donner/editor/tests/OverlayRenderer_tests.cc
@@ -5,6 +5,7 @@
 
 #include "donner/base/Transform.h"
 #include "donner/editor/EditorApp.h"
+#include "donner/svg/DocumentState.h"
 #include "donner/svg/SVGGeometryElement.h"
 #include "donner/svg/SVGGraphicsElement.h"
 #include "donner/svg/renderer/Renderer.h"
@@ -90,6 +91,26 @@ TEST(OverlayRendererTest, CaptureSnapshotIncludesSourceHoverChromeWithoutSelecti
   EXPECT_TRUE(snapshot.paths.empty());
   EXPECT_TRUE(snapshot.aabbsDoc.empty());
   EXPECT_TRUE(snapshot.handleBoxesDoc.empty());
+  EXPECT_FALSE(snapshot.hoverPaths.empty());
+  EXPECT_FALSE(snapshot.hoverAabbsDoc.empty());
+}
+
+TEST(OverlayRendererTest, CaptureSnapshotAllowsConcurrentDomSelectionAndHover) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kTrivialSvg));
+  app.document().document().setThreadingMode(svg::ThreadingMode::ConcurrentDom);
+
+  auto rect = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(rect.has_value());
+  app.setSelection(*rect);
+
+  const std::array<svg::SVGElement, 1> hoverElements{*rect};
+  const SelectionChromeSnapshot snapshot = OverlayRenderer::captureChromeSnapshot(
+      std::span<const svg::SVGElement>(app.selectedElements()), std::nullopt, Transform2d(),
+      std::nullopt, std::span<const svg::SVGElement>(hoverElements));
+
+  EXPECT_FALSE(snapshot.paths.empty());
+  EXPECT_FALSE(snapshot.aabbsDoc.empty());
   EXPECT_FALSE(snapshot.hoverPaths.empty());
   EXPECT_FALSE(snapshot.hoverAabbsDoc.empty());
 }

--- a/donner/editor/tests/PenTool_tests.cc
+++ b/donner/editor/tests/PenTool_tests.cc
@@ -1,0 +1,247 @@
+#include "donner/editor/PenTool.h"
+
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <string_view>
+
+#include "donner/editor/DocumentSyncController.h"
+#include "donner/editor/EditorApp.h"
+#include "donner/editor/SelectTool.h"
+#include "donner/editor/TextEditor.h"
+#include "donner/svg/SVGElement.h"
+#include "donner/svg/SVGPathElement.h"
+#include "gtest/gtest.h"
+
+namespace donner::editor {
+namespace {
+
+constexpr std::string_view kEmptySvg =
+    R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"></svg>)";
+
+constexpr std::string_view kSelfClosingEmptySvg =
+    R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"/>)";
+
+constexpr std::string_view kXmlDeclarationSvg =
+    R"(<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <g id="layer"></g>
+</svg>)";
+
+constexpr std::string_view kOpenPathSvg =
+    R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+         <path id="p" d="M 0 0 L 10 0" fill="none" stroke="black"/>
+       </svg>)";
+
+class PenToolTest : public ::testing::Test {
+protected:
+  void SetUp() override { ASSERT_TRUE(app.loadFromString(kEmptySvg)); }
+
+  svg::SVGPathElement path() {
+    auto element = app.document().document().querySelector("path");
+    EXPECT_TRUE(element.has_value());
+    return element->cast<svg::SVGPathElement>();
+  }
+
+  EditorApp app;
+  PenTool tool;
+};
+
+TEST_F(PenToolTest, FirstClickInsertsSelectedPath) {
+  tool.onMouseDown(app, Vector2d(10.0, 20.0), MouseModifiers{});
+  ASSERT_TRUE(app.flushFrame());
+
+  svg::SVGPathElement inserted = path();
+  EXPECT_EQ(inserted.d(), "M 10 20");
+  ASSERT_EQ(app.selectedElements().size(), 1u);
+  EXPECT_EQ(app.selectedElements().front(), inserted);
+  const std::string source(app.document().document().source());
+  const std::size_t pathOffset = source.find(R"(<path d="M 10 20")");
+  const std::size_t svgCloseOffset = source.find("</svg>");
+  ASSERT_NE(pathOffset, std::string::npos);
+  ASSERT_NE(svgCloseOffset, std::string::npos);
+  EXPECT_LT(pathOffset, svgCloseOffset);
+}
+
+TEST_F(PenToolTest, FirstClickUsesActivePaintStyle) {
+  app.setActiveFill("#112233");
+  app.setActiveStroke("#445566");
+  app.setActiveStrokeWidth(2.5);
+
+  tool.onMouseDown(app, Vector2d(10.0, 20.0), MouseModifiers{});
+  ASSERT_TRUE(app.flushFrame());
+
+  svg::SVGPathElement inserted = path();
+  EXPECT_EQ(inserted.getAttribute("fill"), "#112233");
+  EXPECT_EQ(inserted.getAttribute("stroke"), "#445566");
+  EXPECT_EQ(inserted.getAttribute("stroke-width"), "2.5");
+}
+
+TEST_F(PenToolTest, FirstClickExpandsSelfClosingSvgRoot) {
+  ASSERT_TRUE(app.loadFromString(kSelfClosingEmptySvg));
+
+  tool.onMouseDown(app, Vector2d(10.0, 20.0), MouseModifiers{});
+  ASSERT_TRUE(app.flushFrame());
+
+  const std::string source(app.document().document().source());
+  const std::size_t pathOffset = source.find(R"(<path d="M 10 20")");
+  const std::size_t svgCloseOffset = source.find("</svg>");
+  ASSERT_NE(pathOffset, std::string::npos);
+  ASSERT_NE(svgCloseOffset, std::string::npos);
+  EXPECT_LT(pathOffset, svgCloseOffset);
+  EXPECT_NE(source.find(R"(height="100"><path)"), std::string::npos);
+}
+
+TEST_F(PenToolTest, FirstClickInsertsInsideSvgWithXmlDeclaration) {
+  ASSERT_TRUE(app.loadFromString(kXmlDeclarationSvg));
+
+  tool.onMouseDown(app, Vector2d(10.0, 20.0), MouseModifiers{});
+  ASSERT_TRUE(app.flushFrame());
+
+  const std::string source(app.document().document().source());
+  const std::size_t pathOffset = source.find(R"(<path d="M 10 20")");
+  const std::size_t svgCloseOffset = source.find("</svg>");
+  ASSERT_NE(pathOffset, std::string::npos);
+  ASSERT_NE(svgCloseOffset, std::string::npos);
+  EXPECT_LT(pathOffset, svgCloseOffset);
+}
+
+TEST_F(PenToolTest, FirstClickInsertsInsideDonnerSplashRoot) {
+  std::ifstream splashStream("donner_splash.svg");
+  ASSERT_TRUE(splashStream.is_open());
+  std::ostringstream splashBuffer;
+  splashBuffer << splashStream.rdbuf();
+  const std::string splashSource = splashBuffer.str();
+  ASSERT_TRUE(app.loadFromString(splashSource));
+
+  tool.onMouseDown(app, Vector2d(10.0, 20.0), MouseModifiers{});
+  ASSERT_TRUE(app.flushFrame());
+
+  const std::string source(app.document().document().source());
+  const std::size_t pathOffset = source.find(R"(<path d="M 10 20")");
+  const std::size_t svgCloseOffset = source.rfind("</svg>");
+  ASSERT_NE(pathOffset, std::string::npos);
+  ASSERT_NE(svgCloseOffset, std::string::npos);
+  EXPECT_LT(pathOffset, svgCloseOffset);
+}
+
+TEST_F(PenToolTest, SubsequentClicksAppendLineSegments) {
+  tool.onMouseDown(app, Vector2d(10.0, 20.0), MouseModifiers{});
+  ASSERT_TRUE(app.flushFrame());
+
+  tool.onMouseDown(app, Vector2d(30.0, 40.0), MouseModifiers{});
+  ASSERT_TRUE(app.flushFrame());
+
+  EXPECT_EQ(path().d(), "M 10 20 L 30 40");
+  EXPECT_TRUE(tool.isDrafting());
+}
+
+TEST_F(PenToolTest, ConsecutiveClicksBeforeFlushStayInsideSvgRoot) {
+  TextEditor textEditor;
+  textEditor.setText(kEmptySvg);
+  textEditor.resetTextChanged();
+  DocumentSyncController controller{std::string(kEmptySvg)};
+  SelectTool selectTool;
+
+  tool.onMouseDown(app, Vector2d(10.0, 20.0), MouseModifiers{});
+  tool.onMouseDown(app, Vector2d(30.0, 40.0), MouseModifiers{});
+  ASSERT_TRUE(app.flushFrame());
+  controller.applyPendingWritebacks(app, selectTool, textEditor);
+
+  EXPECT_EQ(textEditor.getText(), app.document().document().source());
+  const std::size_t pathOffset = textEditor.getText().find(R"(d="M 10 20 L 30 40")");
+  const std::size_t svgCloseOffset = textEditor.getText().find("</svg>");
+  ASSERT_NE(pathOffset, std::string::npos);
+  ASSERT_NE(svgCloseOffset, std::string::npos);
+  EXPECT_LT(pathOffset, svgCloseOffset);
+}
+
+TEST_F(PenToolTest, DraggingPlacedPointCreatesCubicHandles) {
+  tool.onMouseDown(app, Vector2d(10.0, 10.0), MouseModifiers{});
+  tool.onMouseMove(app, Vector2d(20.0, 10.0), /*buttonHeld=*/true);
+  tool.onMouseUp(app, Vector2d(20.0, 10.0));
+  ASSERT_TRUE(app.flushFrame());
+
+  tool.onMouseDown(app, Vector2d(40.0, 10.0), MouseModifiers{});
+  tool.onMouseMove(app, Vector2d(40.0, 30.0), /*buttonHeld=*/true);
+
+  ASSERT_EQ(tool.previewSegments().size(), 1u);
+  EXPECT_TRUE(tool.previewSegments().front().cubic);
+  EXPECT_EQ(tool.activePathData(), "M 10 10 C 20 10 40 -10 40 10");
+
+  tool.onMouseUp(app, Vector2d(40.0, 30.0));
+  ASSERT_TRUE(app.flushFrame());
+
+  EXPECT_EQ(path().d(), "M 10 10 C 20 10 40 -10 40 10");
+}
+
+TEST_F(PenToolTest, ClickNearStartClosesPath) {
+  tool.onMouseDown(app, Vector2d(10.0, 10.0), MouseModifiers{});
+  ASSERT_TRUE(app.flushFrame());
+  tool.onMouseDown(app, Vector2d(40.0, 10.0), MouseModifiers{});
+  ASSERT_TRUE(app.flushFrame());
+  tool.onMouseDown(app, Vector2d(40.0, 40.0), MouseModifiers{});
+  ASSERT_TRUE(app.flushFrame());
+
+  MouseModifiers modifiers;
+  modifiers.pixelsPerDocUnit = 1.0;
+  tool.onMouseDown(app, Vector2d(11.0, 10.0), modifiers);
+  ASSERT_TRUE(app.flushFrame());
+
+  EXPECT_EQ(path().d(), "M 10 10 L 40 10 L 40 40 Z");
+  EXPECT_FALSE(tool.isDrafting());
+}
+
+TEST_F(PenToolTest, ShiftConstrainsNextSegment) {
+  tool.onMouseDown(app, Vector2d(10.0, 10.0), MouseModifiers{});
+  ASSERT_TRUE(app.flushFrame());
+
+  MouseModifiers modifiers;
+  modifiers.shift = true;
+  tool.onMouseDown(app, Vector2d(40.0, 18.0), modifiers);
+  ASSERT_TRUE(app.flushFrame());
+
+  EXPECT_EQ(path().d(), "M 10 10 L 40 10");
+}
+
+TEST_F(PenToolTest, SelectedOpenPathCanBeContinued) {
+  ASSERT_TRUE(app.loadFromString(kOpenPathSvg));
+  auto selected = app.document().document().querySelector("#p");
+  ASSERT_TRUE(selected.has_value());
+  app.setSelection(*selected);
+
+  tool.onMouseDown(app, Vector2d(10.0, 10.0), MouseModifiers{});
+  ASSERT_TRUE(app.flushFrame());
+
+  EXPECT_EQ(selected->cast<svg::SVGPathElement>().d(), "M 0 0 L 10 0 L 10 10");
+  EXPECT_TRUE(tool.isDrafting());
+}
+
+TEST_F(PenToolTest, GenericSourceDeltasMirrorPenChangesIntoTextPane) {
+  TextEditor textEditor;
+  textEditor.setText(kEmptySvg);
+  textEditor.resetTextChanged();
+  DocumentSyncController controller{std::string(kEmptySvg)};
+  SelectTool selectTool;
+
+  tool.onMouseDown(app, Vector2d(10.0, 20.0), MouseModifiers{});
+  ASSERT_TRUE(app.flushFrame());
+  controller.applyPendingWritebacks(app, selectTool, textEditor);
+
+  EXPECT_EQ(textEditor.getText(), app.document().document().source());
+  const std::size_t pathOffset = textEditor.getText().find(R"(<path d="M 10 20")");
+  const std::size_t svgCloseOffset = textEditor.getText().find("</svg>");
+  ASSERT_NE(pathOffset, std::string::npos);
+  ASSERT_NE(svgCloseOffset, std::string::npos);
+  EXPECT_LT(pathOffset, svgCloseOffset);
+
+  tool.onMouseDown(app, Vector2d(30.0, 40.0), MouseModifiers{});
+  ASSERT_TRUE(app.flushFrame());
+  controller.applyPendingWritebacks(app, selectTool, textEditor);
+
+  EXPECT_EQ(textEditor.getText(), app.document().document().source());
+  EXPECT_NE(textEditor.getText().find(R"(d="M 10 20 L 30 40")"), std::string::npos);
+}
+
+}  // namespace
+}  // namespace donner::editor

--- a/donner/editor/tests/PenTool_tests.cc
+++ b/donner/editor/tests/PenTool_tests.cc
@@ -243,5 +243,39 @@ TEST_F(PenToolTest, GenericSourceDeltasMirrorPenChangesIntoTextPane) {
   EXPECT_NE(textEditor.getText().find(R"(d="M 10 20 L 30 40")"), std::string::npos);
 }
 
+TEST_F(PenToolTest, FirstClickInDirtyTextPaneStaysInsideCurrentSvgRoot) {
+  constexpr std::string_view kSvgWithRect =
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect id="old"/></svg>)";
+  constexpr std::string_view kDirtySvg =
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"></svg>)";
+
+  ASSERT_TRUE(app.loadFromString(kSvgWithRect));
+  TextEditor textEditor;
+  textEditor.setText(kDirtySvg);
+  textEditor.resetTextChanged();
+  ASSERT_EQ(textEditor.getText(), kDirtySvg);
+  DocumentSyncController controller{std::string(kSvgWithRect)};
+  SelectTool selectTool;
+
+  tool.onMouseDown(app, Vector2d(10.0, 20.0), MouseModifiers{});
+  ASSERT_TRUE(app.flushFrame());
+  controller.applyPendingWritebacks(app, selectTool, textEditor);
+
+  const std::string sourceText = textEditor.getText();
+  const std::size_t pathOffset = sourceText.find(R"(<path d="M 10 20")");
+  const std::size_t svgCloseOffset = sourceText.find("</svg>");
+  ASSERT_NE(pathOffset, std::string::npos);
+  ASSERT_NE(svgCloseOffset, std::string::npos);
+  EXPECT_LT(pathOffset, svgCloseOffset) << sourceText;
+  EXPECT_EQ(sourceText.find(R"(id="old")"), std::string::npos) << sourceText;
+
+  ASSERT_TRUE(app.flushFrame());
+  controller.applyPendingWritebacks(app, selectTool, textEditor);
+
+  EXPECT_EQ(textEditor.getText(), app.document().document().source());
+  EXPECT_FALSE(app.document().document().querySelector("#old").has_value());
+  EXPECT_TRUE(app.document().document().querySelector("path").has_value());
+}
+
 }  // namespace
 }  // namespace donner::editor

--- a/donner/editor/tests/RopeSimulation_tests.cc
+++ b/donner/editor/tests/RopeSimulation_tests.cc
@@ -1,0 +1,471 @@
+#include "donner/editor/RopeSimulation.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace donner::editor {
+namespace {
+
+RopeSimulationOptions TestOptions() {
+  RopeSimulationOptions options;
+  options.segmentCount = 8;
+  options.constraintIterations = 10;
+  options.idleSwayPxPerSec2 = 0.0;
+  options.gravityPxPerSec2 = 80.0;
+  return options;
+}
+
+RopeSimulation MakeStraightRope(const RopeSimulationOptions& options) {
+  const std::vector<Vector2d> route = {
+      Vector2d(0.0, 0.0),
+      Vector2d(100.0, 0.0),
+  };
+  RopeSimulation rope;
+  rope.reset(route, options);
+  return rope;
+}
+
+double MaxDeviationFrom(std::span<const Vector2d> points, std::span<const Vector2d> reference) {
+  double result = 0.0;
+  const std::size_t count = std::min(points.size(), reference.size());
+  for (std::size_t i = 0; i < count; ++i) {
+    result = std::max(result, points[i].distance(reference[i]));
+  }
+  return result;
+}
+
+}  // namespace
+
+TEST(RopeSimulationTest, KeepsEndpointsPinnedAfterUpdates) {
+  const RopeSimulationOptions options = TestOptions();
+  RopeSimulation rope = MakeStraightRope(options);
+
+  for (int i = 0; i < 30; ++i) {
+    rope.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 60.0, 0.0,
+                static_cast<double>(i) / 60.0, 123u, false, options);
+  }
+
+  ASSERT_GE(rope.points().size(), 2u);
+  EXPECT_EQ(rope.points().front(), Vector2d(0.0, 0.0));
+  EXPECT_EQ(rope.points().back(), Vector2d(100.0, 0.0));
+}
+
+TEST(RopeSimulationTest, GravityMovesInteriorParticlesDown) {
+  const RopeSimulationOptions options = TestOptions();
+  RopeSimulation rope = MakeStraightRope(options);
+  const double beforeY = rope.points()[rope.points().size() / 2u].y;
+
+  for (int i = 0; i < 8; ++i) {
+    rope.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 60.0, 0.0,
+                static_cast<double>(i) / 60.0, 456u, false, options);
+  }
+
+  EXPECT_GT(rope.points()[rope.points().size() / 2u].y, beforeY);
+  EXPECT_EQ(rope.points().front(), Vector2d(0.0, 0.0));
+  EXPECT_EQ(rope.points().back(), Vector2d(100.0, 0.0));
+}
+
+TEST(RopeSimulationTest, ResetCatenaryHangsBetweenEndpoints) {
+  RopeSimulationOptions options = TestOptions();
+  options.gravityPxPerSec2 = 0.0;
+  options.catenaryMinSlackPx = 24.0;
+  RopeSimulation rope;
+
+  rope.resetCatenary(Vector2d(0.0, 20.0), Vector2d(120.0, 20.0), options);
+
+  ASSERT_GE(rope.points().size(), 3u);
+  EXPECT_NEAR(rope.points().front().x, 0.0, 1e-9);
+  EXPECT_NEAR(rope.points().front().y, 20.0, 1e-9);
+  EXPECT_NEAR(rope.points().back().x, 120.0, 1e-9);
+  EXPECT_NEAR(rope.points().back().y, 20.0, 1e-9);
+  const Vector2d middle = rope.points()[rope.points().size() / 2u];
+  EXPECT_NEAR(middle.x, 60.0, 1.0);
+  EXPECT_GT(middle.y, 20.0);
+}
+
+TEST(RopeSimulationTest, ResetCatenaryStartsSettledWithZeroVelocity) {
+  RopeSimulationOptions options = TestOptions();
+  RopeSimulation rope;
+  rope.resetCatenary(Vector2d(0.0, 0.0), Vector2d(120.0, 0.0), options);
+  const std::vector<Vector2d> before(rope.points().begin(), rope.points().end());
+
+  EXPECT_FALSE(rope.needsAnimation());
+  rope.update(Vector2d(0.0, 0.0), Vector2d(120.0, 0.0), 1.0 / 60.0, 0.0, 1.0 / 60.0, 123u, false,
+              options);
+
+  EXPECT_EQ(std::vector<Vector2d>(rope.points().begin(), rope.points().end()), before);
+  EXPECT_FALSE(rope.needsAnimation());
+}
+
+TEST(RopeSimulationTest, ScrollImpulseAffectsInteriorOnly) {
+  RopeSimulationOptions options = TestOptions();
+  options.gravityPxPerSec2 = 0.0;
+  RopeSimulation withoutScroll = MakeStraightRope(options);
+  RopeSimulation withScroll = MakeStraightRope(options);
+
+  withoutScroll.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 60.0, 0.0, 0.0, 789u, false,
+                       options);
+  withScroll.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 60.0, 12.0, 0.0, 789u, false,
+                    options);
+
+  ASSERT_EQ(withoutScroll.points().size(), withScroll.points().size());
+  EXPECT_EQ(withScroll.points().front(), Vector2d(0.0, 0.0));
+  EXPECT_EQ(withScroll.points().back(), Vector2d(100.0, 0.0));
+  EXPECT_NE(withScroll.points()[withScroll.points().size() / 2u].y,
+            withoutScroll.points()[withoutScroll.points().size() / 2u].y);
+}
+
+TEST(RopeSimulationTest, ScrollImpulseIsCappedForFastScrolls) {
+  RopeSimulationOptions options = TestOptions();
+  options.constraintIterations = 0;
+  options.gravityPxPerSec2 = 0.0;
+  options.scrollResponse = 1.0;
+  options.maxScrollImpulsePx = 0.5;
+  RopeSimulation rope = MakeStraightRope(options);
+
+  rope.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 60.0, 1000.0, 1.0 / 60.0, 789u, false,
+              options);
+
+  ASSERT_GE(rope.points().size(), 3u);
+  EXPECT_LE(std::abs(rope.points()[rope.points().size() / 2u].y), 0.5 + 1e-9);
+  EXPECT_EQ(rope.points().front(), Vector2d(0.0, 0.0));
+  EXPECT_EQ(rope.points().back(), Vector2d(100.0, 0.0));
+}
+
+TEST(RopeSimulationTest, ApplyImpulseCreatesMotionOnNextUpdate) {
+  RopeSimulationOptions options = TestOptions();
+  options.gravityPxPerSec2 = 0.0;
+  RopeSimulation rope;
+  rope.resetCatenary(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), options);
+  const Vector2d before = rope.points()[rope.points().size() / 2u];
+
+  rope.applyImpulse(Vector2d(4.0, 0.0));
+  rope.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 60.0, 0.0, 0.0, 123u, false, options);
+
+  EXPECT_GT(rope.points()[rope.points().size() / 2u].x, before.x);
+  EXPECT_EQ(rope.points().front(), Vector2d(0.0, 0.0));
+  EXPECT_EQ(rope.points().back(), Vector2d(100.0, 0.0));
+}
+
+TEST(RopeSimulationTest, BottomImpulseIsLocalizedNearCatenaryBottom) {
+  RopeSimulationOptions options = TestOptions();
+  options.constraintIterations = 0;
+  options.gravityPxPerSec2 = 0.0;
+  RopeSimulation rope;
+  rope.resetCatenary(Vector2d(0.0, 0.0), Vector2d(120.0, 0.0), options);
+  std::size_t bottomIndex = 1;
+  for (std::size_t i = 2; i + 1 < rope.points().size(); ++i) {
+    if (rope.points()[i].y > rope.points()[bottomIndex].y) {
+      bottomIndex = i;
+    }
+  }
+  const std::vector<Vector2d> before(rope.points().begin(), rope.points().end());
+
+  rope.applyBottomImpulse(Vector2d(0.25, 0.0), 0.12);
+  rope.update(Vector2d(0.0, 0.0), Vector2d(120.0, 0.0), 1.0 / 60.0, 0.0, 1.0 / 60.0, 123u, false,
+              options);
+
+  const std::size_t shoulderIndex = 1;
+  const Vector2d bottomDelta = rope.points()[bottomIndex] - before[bottomIndex];
+  const Vector2d shoulderDelta = rope.points()[shoulderIndex] - before[shoulderIndex];
+  EXPECT_GT(std::abs(bottomDelta.x), std::abs(shoulderDelta.x) * 4.0);
+  EXPECT_GT(std::abs(bottomDelta.x), std::abs(bottomDelta.y) * 20.0);
+  EXPECT_EQ(rope.points().front(), Vector2d(0.0, 0.0));
+  EXPECT_EQ(rope.points().back(), Vector2d(120.0, 0.0));
+}
+
+TEST(RopeSimulationTest, CatenaryBottomImpulseDecaysWithoutEnergyGain) {
+  RopeSimulationOptions options = TestOptions();
+  options.damping = 0.86;
+  options.gravityPxPerSec2 = 500.0;
+  options.idleSwayPxPerSec2 = 500.0;
+  options.settleMotionThresholdPx = 0.0;
+  options.settleStillnessSeconds = 100.0;
+  options.settleTimeSeconds = 100.0;
+  RopeSimulation rope;
+  rope.resetCatenary(Vector2d(0.0, 0.0), Vector2d(120.0, 0.0), options);
+  const std::vector<Vector2d> rest(rope.points().begin(), rope.points().end());
+
+  rope.applyBottomImpulse(Vector2d(0.25, 0.0), 0.12);
+
+  double earlyPeak = 0.0;
+  double latePeak = 0.0;
+  for (int frame = 0; frame < 120; ++frame) {
+    rope.update(Vector2d(0.0, 0.0), Vector2d(120.0, 0.0), 1.0 / 60.0, 0.0,
+                static_cast<double>(frame + 1) / 60.0, 123u, false, options);
+
+    double maxDeviation = 0.0;
+    for (std::size_t i = 0; i < rope.points().size(); ++i) {
+      maxDeviation = std::max(maxDeviation, rope.points()[i].distance(rest[i]));
+    }
+
+    if (frame < 20) {
+      earlyPeak = std::max(earlyPeak, maxDeviation);
+    } else if (frame >= 90) {
+      latePeak = std::max(latePeak, maxDeviation);
+    }
+  }
+
+  EXPECT_GT(earlyPeak, 0.0);
+  EXPECT_LT(latePeak, earlyPeak * 0.35);
+  EXPECT_TRUE(rope.needsAnimation());
+}
+
+TEST(RopeSimulationTest, CatenaryBottomImpulseIsStableAcrossFrameCadences) {
+  RopeSimulationOptions options = TestOptions();
+  options.damping = 0.86;
+  options.gravityPxPerSec2 = 500.0;
+  options.idleSwayPxPerSec2 = 500.0;
+  options.settleMotionThresholdPx = 0.0;
+  options.settleStillnessSeconds = 100.0;
+  options.settleTimeSeconds = 100.0;
+  RopeSimulation sixtyHz;
+  RopeSimulation fastInputCadence;
+  RopeSimulation coarseCadence;
+  sixtyHz.resetCatenary(Vector2d(0.0, 0.0), Vector2d(120.0, 0.0), options);
+  fastInputCadence.resetCatenary(Vector2d(0.0, 0.0), Vector2d(120.0, 0.0), options);
+  coarseCadence.resetCatenary(Vector2d(0.0, 0.0), Vector2d(120.0, 0.0), options);
+  sixtyHz.applyBottomImpulse(Vector2d(0.25, 0.0), 0.12);
+  fastInputCadence.applyBottomImpulse(Vector2d(0.25, 0.0), 0.12);
+  coarseCadence.applyBottomImpulse(Vector2d(0.25, 0.0), 0.12);
+
+  for (int frame = 0; frame < 60; ++frame) {
+    sixtyHz.update(Vector2d(0.0, 0.0), Vector2d(120.0, 0.0), 1.0 / 60.0, 0.0,
+                   static_cast<double>(frame + 1) / 60.0, 123u, false, options);
+  }
+  for (int frame = 0; frame < 120; ++frame) {
+    fastInputCadence.update(Vector2d(0.0, 0.0), Vector2d(120.0, 0.0), 1.0 / 120.0, 0.0,
+                            static_cast<double>(frame + 1) / 120.0, 123u, false, options);
+  }
+  for (int frame = 0; frame < 15; ++frame) {
+    coarseCadence.update(Vector2d(0.0, 0.0), Vector2d(120.0, 0.0), 1.0 / 15.0, 0.0,
+                         static_cast<double>(frame + 1) / 15.0, 123u, false, options);
+  }
+
+  ASSERT_EQ(sixtyHz.points().size(), fastInputCadence.points().size());
+  ASSERT_EQ(sixtyHz.points().size(), coarseCadence.points().size());
+  for (std::size_t i = 0; i < sixtyHz.points().size(); ++i) {
+    EXPECT_LT(sixtyHz.points()[i].distance(fastInputCadence.points()[i]), 0.02);
+    EXPECT_LT(sixtyHz.points()[i].distance(coarseCadence.points()[i]), 0.02);
+  }
+}
+
+TEST(RopeSimulationTest, LargeFrameDeltaAdvancesThroughFixedRealtimeSubsteps) {
+  RopeSimulationOptions options = TestOptions();
+  options.constraintIterations = 0;
+  options.gravityPxPerSec2 = 0.0;
+  options.damping = 1.0;
+  options.maxDeltaTime = 1.0 / 60.0;
+  options.settleTimeSeconds = 1.0;
+
+  RopeSimulation singleFrame = MakeStraightRope(options);
+  RopeSimulation fourFrames = MakeStraightRope(options);
+  singleFrame.applyImpulse(Vector2d(4.0, 0.0));
+  fourFrames.applyImpulse(Vector2d(4.0, 0.0));
+
+  singleFrame.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 4.0 / 60.0, 0.0, 4.0 / 60.0, 123u,
+                     false, options);
+  for (int i = 0; i < 4; ++i) {
+    fourFrames.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 60.0, 0.0,
+                      static_cast<double>(i + 1) / 60.0, 123u, false, options);
+  }
+
+  ASSERT_EQ(singleFrame.points().size(), fourFrames.points().size());
+  const std::size_t middle = singleFrame.points().size() / 2u;
+  EXPECT_NEAR(singleFrame.points()[middle].x, fourFrames.points()[middle].x, 1e-9);
+  EXPECT_NEAR(singleFrame.points()[middle].y, fourFrames.points()[middle].y, 1e-9);
+}
+
+TEST(RopeSimulationTest, ShortFrameDeltasPreserveRealtimeVelocityScale) {
+  RopeSimulationOptions options = TestOptions();
+  options.constraintIterations = 0;
+  options.gravityPxPerSec2 = 0.0;
+  options.damping = 1.0;
+  options.maxDeltaTime = 1.0 / 60.0;
+  options.settleTimeSeconds = 1.0;
+
+  RopeSimulation singleFrame = MakeStraightRope(options);
+  RopeSimulation twoFrames = MakeStraightRope(options);
+  singleFrame.applyImpulse(Vector2d(4.0, 0.0));
+  twoFrames.applyImpulse(Vector2d(4.0, 0.0));
+
+  singleFrame.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 60.0, 0.0, 1.0 / 60.0, 123u,
+                     false, options);
+  twoFrames.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 120.0, 0.0, 1.0 / 120.0, 123u,
+                   false, options);
+  twoFrames.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 120.0, 0.0, 1.0 / 60.0, 123u,
+                   false, options);
+
+  ASSERT_EQ(singleFrame.points().size(), twoFrames.points().size());
+  const std::size_t middle = singleFrame.points().size() / 2u;
+  EXPECT_NEAR(singleFrame.points()[middle].x, twoFrames.points()[middle].x, 1e-9);
+  EXPECT_NEAR(singleFrame.points()[middle].y, twoFrames.points()[middle].y, 1e-9);
+}
+
+TEST(RopeSimulationTest, SleepsAfterStillnessAndWakesOnImpulse) {
+  RopeSimulationOptions options = TestOptions();
+  options.constraintIterations = 0;
+  options.gravityPxPerSec2 = 0.0;
+  options.damping = 0.0;
+  options.maxDeltaTime = 1.0 / 60.0;
+  options.settleMotionThresholdPx = 0.001;
+  options.settleStillnessSeconds = 0.02;
+  options.settleTimeSeconds = 100.0;
+  RopeSimulation rope = MakeStraightRope(options);
+  rope.applyImpulse(Vector2d(3.0, 0.0));
+
+  ASSERT_TRUE(rope.needsAnimation());
+  rope.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 60.0, 0.0, 1.0 / 60.0, 123u, false,
+              options);
+  EXPECT_TRUE(rope.needsAnimation());
+  rope.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 60.0, 0.0, 2.0 / 60.0, 123u, false,
+              options);
+  EXPECT_FALSE(rope.needsAnimation());
+
+  const std::vector<Vector2d> asleep(rope.points().begin(), rope.points().end());
+  rope.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 60.0, 0.0, 3.0 / 60.0, 123u, false,
+              options);
+  EXPECT_EQ(std::vector<Vector2d>(rope.points().begin(), rope.points().end()), asleep);
+
+  rope.applyImpulse(Vector2d(1.0, 0.0));
+  EXPECT_TRUE(rope.needsAnimation());
+}
+
+TEST(RopeSimulationTest, OverdueDampingSleepsOnlyAfterStillnessAndResetsOnWake) {
+  RopeSimulationOptions options = TestOptions();
+  options.constraintIterations = 0;
+  options.gravityPxPerSec2 = 0.0;
+  options.damping = 1.0;
+  options.overdueDamping = 0.0;
+  options.overdueDampingRampSeconds = 0.0;
+  options.maxDeltaTime = 1.0 / 60.0;
+  options.settleMotionThresholdPx = 0.001;
+  options.settleStillnessSeconds = 0.02;
+  options.settleTimeSeconds = 0.0;
+  RopeSimulation rope = MakeStraightRope(options);
+  rope.applyImpulse(Vector2d(0.75, 0.0));
+
+  rope.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 60.0, 0.0, 1.0 / 60.0, 123u, false,
+              options);
+  EXPECT_TRUE(rope.needsAnimation());
+  rope.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 60.0, 0.0, 2.0 / 60.0, 123u, false,
+              options);
+  EXPECT_TRUE(rope.needsAnimation());
+  rope.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 60.0, 0.0, 3.0 / 60.0, 123u, false,
+              options);
+  ASSERT_FALSE(rope.needsAnimation());
+
+  const Vector2d beforeWake = rope.points()[rope.points().size() / 2u];
+  rope.applyImpulse(Vector2d(0.75, 0.0));
+  rope.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 60.0, 0.0, 4.0 / 60.0, 123u, false,
+              options);
+
+  EXPECT_TRUE(rope.needsAnimation());
+  EXPECT_NE(rope.points()[rope.points().size() / 2u].x, beforeWake.x);
+}
+
+TEST(RopeSimulationTest, EndpointMotionCarriesBodyAndAddsVelocity) {
+  RopeSimulationOptions options = TestOptions();
+  options.gravityPxPerSec2 = 0.0;
+  options.endpointFollow = 0.8;
+  options.endpointImpulse = 0.2;
+  RopeSimulation rope;
+  rope.resetCatenary(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), options);
+  const Vector2d before = rope.points()[rope.points().size() / 2u];
+
+  rope.update(Vector2d(0.0, 12.0), Vector2d(100.0, 12.0), 1.0 / 60.0, 0.0, 0.0, 123u, false,
+              options);
+
+  EXPECT_EQ(rope.points().front(), Vector2d(0.0, 12.0));
+  EXPECT_EQ(rope.points().back(), Vector2d(100.0, 12.0));
+  EXPECT_GT(rope.points()[rope.points().size() / 2u].y, before.y + 8.0);
+}
+
+TEST(RopeSimulationTest, EndpointMotionRetargetsAndDampsBackToCatenary) {
+  RopeSimulationOptions options = TestOptions();
+  options.segmentCount = 16;
+  options.constraintIterations = 12;
+  options.gravityPxPerSec2 = 0.0;
+  options.damping = 0.84;
+  options.overdueDamping = 0.2;
+  options.overdueDampingRampSeconds = 0.0;
+  options.settleTimeSeconds = 0.7;
+  options.settleMotionThresholdPx = 0.015;
+  options.settleStillnessSeconds = 0.12;
+  options.settleRestDistanceThresholdPx = 0.3;
+  options.catenaryRestoringForcePerSec2 = 900.0;
+  options.endpointFollow = 0.82;
+  options.endpointImpulse = 0.0;
+  options.endpointMotionVelocityRetention = 0.20;
+  options.endpointCatenaryBlend = 0.20;
+
+  RopeSimulation target;
+  target.resetCatenary(Vector2d(0.0, 0.0), Vector2d(112.0, 0.0), options);
+  const std::vector<Vector2d> targetPoints(target.points().begin(), target.points().end());
+
+  RopeSimulation rope;
+  rope.resetCatenary(Vector2d(0.0, 0.0), Vector2d(120.0, 0.0), options);
+  rope.applyBottomImpulse(Vector2d(0.2, 0.0), 0.12);
+  rope.update(Vector2d(0.0, 0.0), Vector2d(112.0, 0.0), 1.0 / 60.0, 0.0, 1.0 / 60.0, 123u, false,
+              options);
+  const double initialDeviation = MaxDeviationFrom(rope.points(), targetPoints);
+
+  for (int frame = 1; frame < 240 && rope.needsAnimation(); ++frame) {
+    rope.update(Vector2d(0.0, 0.0), Vector2d(112.0, 0.0), 1.0 / 60.0, 0.0,
+                static_cast<double>(frame + 1) / 60.0, 123u, false, options);
+  }
+
+  const double settledDeviation = MaxDeviationFrom(rope.points(), targetPoints);
+  EXPECT_GT(initialDeviation, 0.05);
+  EXPECT_LT(settledDeviation, 0.01);
+  EXPECT_FALSE(rope.needsAnimation());
+}
+
+TEST(RopeSimulationTest, IdleSwayIsDeterministicAndSubtle) {
+  RopeSimulationOptions options = TestOptions();
+  options.gravityPxPerSec2 = 0.0;
+  options.idleSwayPxPerSec2 = 18.0;
+
+  RopeSimulation first = MakeStraightRope(options);
+  RopeSimulation second = MakeStraightRope(options);
+  first.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 60.0, 0.0, 1.25, 42u, false,
+               options);
+  second.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 60.0, 0.0, 1.25, 42u, false,
+                options);
+
+  ASSERT_EQ(first.points().size(), second.points().size());
+  const std::size_t middle = first.points().size() / 2u;
+  EXPECT_EQ(first.points()[middle], second.points()[middle]);
+  EXPECT_LT(std::abs(first.points()[middle].x - 50.0), 0.1);
+}
+
+TEST(RopeSimulationTest, HoverFreezePreservesBodyWhenAnchorsDoNotMove) {
+  const RopeSimulationOptions options = TestOptions();
+  RopeSimulation rope = MakeStraightRope(options);
+  rope.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 60.0, 0.0, 0.0, 12u, false, options);
+  const std::vector<Vector2d> before(rope.points().begin(), rope.points().end());
+
+  rope.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 60.0, 30.0, 1.0, 12u, true, options);
+
+  EXPECT_EQ(std::vector<Vector2d>(rope.points().begin(), rope.points().end()), before);
+}
+
+TEST(RopeSimulationTest, ConvertsToBezierPathEndingAtTarget) {
+  const RopeSimulationOptions options = TestOptions();
+  RopeSimulation rope = MakeStraightRope(options);
+  rope.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 60.0, 0.0, 0.0, 12u, false, options);
+
+  const Path path = rope.toPath(options);
+  ASSERT_FALSE(path.empty());
+  ASSERT_GE(path.commands().size(), 2u);
+  EXPECT_EQ(path.commands().front().verb, Path::Verb::MoveTo);
+  EXPECT_EQ(path.commands().back().verb, Path::Verb::QuadTo);
+  ASSERT_FALSE(path.points().empty());
+  EXPECT_EQ(path.points().back(), Vector2d(100.0, 0.0));
+}
+
+}  // namespace donner::editor

--- a/donner/editor/tests/RotateCursorSet_tests.cc
+++ b/donner/editor/tests/RotateCursorSet_tests.cc
@@ -75,6 +75,19 @@ TEST(RotateCursorSetTest, RendersPanCursorImage) {
   }
 }
 
+TEST(RotateCursorSetTest, PenCursorUsesBlackGlyphWithWhiteOutline) {
+  std::optional<RotateCursorImage> image = RenderPenCursorImage(nullptr);
+
+  ASSERT_TRUE(image.has_value());
+  EXPECT_EQ(image->width, 32);
+  EXPECT_EQ(image->height, 32);
+  EXPECT_EQ(image->rgba.size(), 32u * 32u * 4u);
+  EXPECT_GT(CountNonTransparentPixels(*image), 90u);
+  EXPECT_LT(CountNonTransparentPixels(*image), 32u * 32u);
+  EXPECT_GT(CountOpaqueBlackPixels(*image), 25u);
+  EXPECT_GT(CountOpaqueWhitePixels(*image), 8u);
+}
+
 TEST(RotateCursorSetTest, OpenAndClosedPanCursorsProduceDifferentBitmaps) {
   std::optional<RotateCursorImage> openHand =
       RenderPanCursorImage(PanCursorKind::OpenHand, nullptr);

--- a/donner/editor/tests/SelectionAabb_tests.cc
+++ b/donner/editor/tests/SelectionAabb_tests.cc
@@ -5,6 +5,7 @@
 #include "donner/base/MathUtils.h"
 #include "donner/editor/EditorApp.h"
 #include "donner/editor/SelectTool.h"
+#include "donner/svg/DocumentState.h"
 #include "donner/svg/SVGGraphicsElement.h"
 
 namespace donner::editor {
@@ -36,6 +37,22 @@ TEST(SelectionAabbTest, SnapshotSelectionWorldBoundsSkipsNonGeometryWithoutBound
 
   ASSERT_EQ(bounds.size(), 1u);
   EXPECT_EQ(bounds[0], Box2d::FromXYWH(10.0, 15.0, 20.0, 25.0));
+}
+
+TEST(SelectionAabbTest, SnapshotBoundsAllowConcurrentDom) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kTwoRectSvg));
+  app.document().document().setThreadingMode(svg::ThreadingMode::ConcurrentDom);
+
+  auto rect = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(rect.has_value());
+  const std::vector<svg::SVGElement> selection = {*rect};
+
+  const std::vector<Box2d> bounds =
+      SnapshotSelectionWorldBounds(std::span<const svg::SVGElement>(selection));
+
+  ASSERT_EQ(bounds.size(), 1u);
+  EXPECT_EQ(bounds[0], Box2d::FromXYWH(20.0, 20.0, 40.0, 40.0));
 }
 
 TEST(SelectionAabbTest, SnapshotSelectionWorldBoundsMovesWithDrag) {
@@ -177,6 +194,27 @@ TEST(SelectionAabbTest, SnapshotOccludingWorldBoundsIncludesOnlyLaterPaintedGeom
   ASSERT_EQ(bounds.size(), 2u);
   EXPECT_EQ(bounds[0], Box2d::FromXYWH(70.0, 80.0, 10.0, 20.0));
   EXPECT_EQ(bounds[1], Box2d::FromXYWH(100.0, 110.0, 30.0, 40.0));
+}
+
+TEST(SelectionAabbTest, SnapshotOccludingBoundsAllowConcurrentDom) {
+  constexpr std::string_view kSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+              <rect id="selected" x="20" y="20" width="40" height="40" fill="red"/>
+              <rect id="front" x="70" y="80" width="10" height="20" fill="blue"/>
+            </svg>)svg";
+
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kSvg));
+  app.document().document().setThreadingMode(svg::ThreadingMode::ConcurrentDom);
+  auto selected = app.document().document().querySelector("#selected");
+  ASSERT_TRUE(selected.has_value());
+
+  const std::vector<svg::SVGElement> selection = {*selected};
+  const std::vector<Box2d> bounds =
+      SnapshotSelectionOccludingWorldBounds(std::span<const svg::SVGElement>(selection));
+
+  ASSERT_EQ(bounds.size(), 1u);
+  EXPECT_EQ(bounds[0], Box2d::FromXYWH(70.0, 80.0, 10.0, 20.0));
 }
 
 }  // namespace

--- a/donner/editor/tests/SidebarPresenter_tests.cc
+++ b/donner/editor/tests/SidebarPresenter_tests.cc
@@ -3,6 +3,7 @@
 #include <span>
 #include <string_view>
 
+#include "donner/svg/DocumentState.h"
 #include "gtest/gtest.h"
 
 namespace donner::editor {
@@ -82,6 +83,24 @@ TEST(SidebarPresenterTest, RefreshSnapshotCapturesXmlAttributesAndComputedStyle)
   const std::string* colorValue = FindInspectorValue(computedStyle, "color");
   ASSERT_NE(colorValue, nullptr);
   EXPECT_EQ(*colorValue, "rgba(0, 0, 0, 255) (default)");
+}
+
+TEST(SidebarPresenterTest, RefreshSnapshotAllowsConcurrentDom) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kInspectorSvg));
+  app.setCleanSourceText(kInspectorSvg);
+  app.document().document().setThreadingMode(svg::ThreadingMode::ConcurrentDom);
+
+  auto target = app.document().document().querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  app.setSelection(*target);
+
+  SidebarPresenter presenter;
+  presenter.refreshSnapshot(app);
+
+  EXPECT_TRUE(presenter.inspectorHasSelectionForTesting());
+  EXPECT_FALSE(presenter.inspectorXmlAttributesForTesting().empty());
+  EXPECT_FALSE(presenter.inspectorComputedStyleForTesting().empty());
 }
 
 TEST(SidebarPresenterTest, RefreshSnapshotOmitsInspectorDetailsForMultiSelection) {

--- a/donner/editor/tests/SourceSelection_tests.cc
+++ b/donner/editor/tests/SourceSelection_tests.cc
@@ -13,6 +13,7 @@
 #include "donner/base/xml/XMLNode.h"
 #include "donner/editor/EditorApp.h"
 #include "donner/editor/TextEditor.h"
+#include "donner/svg/DocumentState.h"
 
 namespace donner::editor {
 namespace {
@@ -76,6 +77,25 @@ TEST(SourceSelectionTest, FindsDeepestElementAtSourceOffset) {
       FindElementAtSourceOffset(app.document().document(), source, groupBodyOffset + 1);
   ASSERT_TRUE(group.has_value());
   EXPECT_EQ(group->id(), "layer");
+}
+
+TEST(SourceSelectionTest, FindsElementAtSourceOffsetAllowsConcurrentDom) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kSvg));
+  app.document().document().setThreadingMode(svg::ThreadingMode::ConcurrentDom);
+  const std::string source(app.document().document().source());
+
+  const std::size_t rectOffset = source.find("id=\"target\"");
+  ASSERT_NE(rectOffset, std::string::npos);
+  std::optional<svg::SVGElement> rect =
+      FindElementAtSourceOffset(app.document().document(), source, rectOffset);
+  ASSERT_TRUE(rect.has_value());
+  EXPECT_EQ(rect->id(), "target");
+
+  std::optional<svg::SVGElement> near =
+      FindElementNearSourceOffset(app.document().document(), source, rectOffset);
+  ASSERT_TRUE(near.has_value());
+  EXPECT_EQ(near->id(), "target");
 }
 
 TEST(SourceSelectionTest, ReturnsElementSourceByteRange) {

--- a/donner/editor/tests/SourceSelection_tests.cc
+++ b/donner/editor/tests/SourceSelection_tests.cc
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <fstream>
+#include <optional>
 #include <span>
 #include <sstream>
 #include <string>
@@ -92,6 +93,45 @@ TEST(SourceSelectionTest, ReturnsElementSourceByteRange) {
   EXPECT_NE(selected.find("id=\"target\""), std::string::npos);
 }
 
+TEST(SourceSelectionTest, ReturnsEntitySourceByteRangeForReferencedPaintServer) {
+  constexpr std::string_view source =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <defs>
+    <linearGradient id="paint">
+      <stop offset="0" stop-color="red"/>
+    </linearGradient>
+  </defs>
+  <rect id="target" fill="url(#paint)" width="20" height="20"/>
+</svg>)svg";
+
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(source));
+
+  auto paint = app.document().document().querySelector("#paint");
+  ASSERT_TRUE(paint.has_value());
+
+  const std::string currentSource(app.document().document().source());
+  const std::optional<SourceByteRange> range =
+      EntitySourceByteRange(paint->entityHandle(), currentSource);
+  ASSERT_TRUE(range.has_value());
+  const std::string selected = currentSource.substr(range->start, range->end - range->start);
+  EXPECT_NE(selected.find("<linearGradient"), std::string::npos);
+  EXPECT_NE(selected.find("id=\"paint\""), std::string::npos);
+
+  TextEditor textEditor;
+  textEditor.setText(currentSource);
+  ASSERT_TRUE(HighlightSourceByteRange(textEditor, *range));
+  EXPECT_EQ(textEditor.getSelectedText(), selected);
+}
+
+TEST(SourceSelectionTest, RejectsInvalidRawSourceByteRange) {
+  TextEditor textEditor;
+  textEditor.setText("abc");
+
+  EXPECT_FALSE(HighlightSourceByteRange(textEditor, SourceByteRange{.start = 1, .end = 1}));
+  EXPECT_FALSE(HighlightSourceByteRange(textEditor, SourceByteRange{.start = 1, .end = 4}));
+}
+
 TEST(SourceSelectionTest, ExcludesSelectedElementsFromSourceHoverCandidates) {
   EditorApp app;
   ASSERT_TRUE(app.loadFromString(kSvg));
@@ -106,6 +146,36 @@ TEST(SourceSelectionTest, ExcludesSelectedElementsFromSourceHoverCandidates) {
 
   ASSERT_EQ(filtered.size(), 1u);
   EXPECT_EQ(filtered.front().id(), "layer");
+}
+
+TEST(SourceSelectionTest, ExcludesDocumentRootFromSourceHoverCandidates) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kSvg));
+  svg::SVGDocument& document = app.document().document();
+  const svg::SVGElement root = document.svgElement();
+  std::optional<svg::SVGElement> rect = document.querySelector("#target");
+  ASSERT_TRUE(rect.has_value());
+
+  std::vector<svg::SVGElement> filtered =
+      ExcludeDocumentRootSourceHoverElement({root, *rect}, document);
+  ASSERT_EQ(filtered.size(), 1u);
+  EXPECT_EQ(filtered.front().id(), "target");
+
+  filtered = ExcludeDocumentRootSourceHoverElement({root}, document);
+  EXPECT_TRUE(filtered.empty());
+}
+
+TEST(SourceSelectionTest, RootSvgStillResolvesAtSourceOffsetForExplicitSelection) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kSvg));
+  const std::string source(app.document().document().source());
+
+  const std::size_t rootOffset = source.find("<svg");
+  ASSERT_NE(rootOffset, std::string::npos);
+  std::optional<svg::SVGElement> root =
+      FindElementNearSourceOffset(app.document().document(), source, rootOffset + 1);
+  ASSERT_TRUE(root.has_value());
+  EXPECT_EQ(*root, app.document().document().svgElement());
 }
 
 TEST(SourceSelectionTest, FindsElementAtTextEditorCursor) {

--- a/donner/editor/tests/StyleSourceAnnotations_tests.cc
+++ b/donner/editor/tests/StyleSourceAnnotations_tests.cc
@@ -5,6 +5,7 @@
 #include <string_view>
 
 #include "donner/base/ParseWarningSink.h"
+#include "donner/svg/DocumentState.h"
 #include "donner/svg/parser/SVGParser.h"
 
 namespace donner::editor {
@@ -59,6 +60,22 @@ TEST(StyleSourceAnnotations, StylesheetRuleReportsSelectorMatchedElementChipCoun
   EXPECT_TRUE(fill->showChip);
   EXPECT_EQ(fill->matchedElementCount, 2);
   EXPECT_TRUE(fill->effective);
+}
+
+TEST(StyleSourceAnnotations, ComputeAllowsConcurrentDom) {
+  constexpr std::string_view kSource = R"svg(<svg xmlns="http://www.w3.org/2000/svg">
+  <style>.hit { fill: red; }</style>
+  <rect class="hit"/>
+</svg>)svg";
+  svg::SVGDocument document = ParseSvg(kSource);
+  document.setThreadingMode(svg::ThreadingMode::ConcurrentDom);
+
+  const StyleSourceAnnotations annotations = ComputeStyleSourceAnnotations(document, kSource);
+
+  const StyleSourceContribution* fill = FindContribution(
+      annotations, StyleContributionKind::StylesheetDeclaration, "fill", "fill: red", kSource);
+  ASSERT_NE(fill, nullptr);
+  EXPECT_EQ(fill->matchedElementCount, 1);
 }
 
 TEST(StyleSourceAnnotations, StylesheetChipAnchorsToSelectorRange) {

--- a/donner/editor/tests/StyleSourceAnnotations_tests.cc
+++ b/donner/editor/tests/StyleSourceAnnotations_tests.cc
@@ -1,0 +1,297 @@
+#include "donner/editor/StyleSourceAnnotations.h"
+
+#include <gtest/gtest.h>
+
+#include <string_view>
+
+#include "donner/base/ParseWarningSink.h"
+#include "donner/svg/parser/SVGParser.h"
+
+namespace donner::editor {
+namespace {
+
+svg::SVGDocument ParseSvg(std::string_view source) {
+  ParseWarningSink sink;
+  auto result = svg::parser::SVGParser::ParseSVG(source, sink);
+  EXPECT_FALSE(result.hasError());
+  return std::move(result).result();
+}
+
+std::string_view SourceForContribution(std::string_view source,
+                                       const StyleSourceContribution& contribution) {
+  return source.substr(contribution.sourceRange.start,
+                       contribution.sourceRange.end - contribution.sourceRange.start);
+}
+
+std::string_view SourceForRange(std::string_view source, SourceByteRange range) {
+  return source.substr(range.start, range.end - range.start);
+}
+
+const StyleSourceContribution* FindContribution(const StyleSourceAnnotations& annotations,
+                                                StyleContributionKind kind,
+                                                std::string_view propertyName,
+                                                std::string_view sourceNeedle,
+                                                std::string_view source) {
+  for (const StyleSourceContribution& contribution : annotations.contributions) {
+    if (contribution.kind == kind && contribution.propertyName == propertyName &&
+        SourceForContribution(source, contribution).find(sourceNeedle) != std::string_view::npos) {
+      return &contribution;
+    }
+  }
+
+  return nullptr;
+}
+
+TEST(StyleSourceAnnotations, StylesheetRuleReportsSelectorMatchedElementChipCount) {
+  constexpr std::string_view kSource = R"svg(<svg xmlns="http://www.w3.org/2000/svg">
+  <style>.hit { fill: red; }</style>
+  <rect class="hit"/>
+  <circle class="hit"/>
+  <path/>
+</svg>)svg";
+  svg::SVGDocument document = ParseSvg(kSource);
+
+  const StyleSourceAnnotations annotations = ComputeStyleSourceAnnotations(document, kSource);
+
+  const StyleSourceContribution* fill = FindContribution(
+      annotations, StyleContributionKind::StylesheetDeclaration, "fill", "fill: red", kSource);
+  ASSERT_NE(fill, nullptr);
+  EXPECT_TRUE(fill->showChip);
+  EXPECT_EQ(fill->matchedElementCount, 2);
+  EXPECT_TRUE(fill->effective);
+}
+
+TEST(StyleSourceAnnotations, StylesheetChipAnchorsToSelectorRange) {
+  constexpr std::string_view kSource = R"svg(<svg xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .hit {
+      fill: red;
+      stroke: blue;
+    }
+  </style>
+  <rect class="hit"/>
+</svg>)svg";
+  svg::SVGDocument document = ParseSvg(kSource);
+
+  const StyleSourceAnnotations annotations = ComputeStyleSourceAnnotations(document, kSource);
+
+  const StyleSourceContribution* fill = FindContribution(
+      annotations, StyleContributionKind::StylesheetDeclaration, "fill", "fill: red", kSource);
+  ASSERT_NE(fill, nullptr);
+  EXPECT_TRUE(fill->showChip);
+  EXPECT_EQ(SourceForRange(kSource, fill->chipRange), ".hit");
+
+  const StyleSourceContribution* stroke = FindContribution(
+      annotations, StyleContributionKind::StylesheetDeclaration, "stroke", "stroke: blue", kSource);
+  ASSERT_NE(stroke, nullptr);
+  EXPECT_FALSE(stroke->showChip);
+  EXPECT_EQ(SourceForRange(kSource, stroke->chipRange), ".hit");
+}
+
+TEST(StyleSourceAnnotations, OverriddenStylesheetDeclarationKeepsOverrideTooltip) {
+  constexpr std::string_view kSource = R"svg(<svg xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .hit { fill: url(#paint); }
+    .hit { fill: red; }
+  </style>
+  <rect class="hit"/>
+</svg>)svg";
+  svg::SVGDocument document = ParseSvg(kSource);
+
+  const StyleSourceAnnotations annotations = ComputeStyleSourceAnnotations(document, kSource);
+
+  const StyleSourceContribution* fillUrl =
+      FindContribution(annotations, StyleContributionKind::StylesheetDeclaration, "fill",
+                       "fill: url(#paint)", kSource);
+  ASSERT_NE(fillUrl, nullptr);
+  EXPECT_FALSE(fillUrl->effective);
+  EXPECT_EQ(fillUrl->matchedElementCount, 1);
+  EXPECT_EQ(fillUrl->chipTooltip, "Selector matches 1 element");
+  EXPECT_EQ(fillUrl->tooltip,
+            "fill is overridden by a later or higher-specificity CSS declaration");
+}
+
+TEST(StyleSourceAnnotations, StylesheetChipMarksOverflowWhenSelectorMatchesTooManyElements) {
+  constexpr std::string_view kSource = R"svg(<svg xmlns="http://www.w3.org/2000/svg">
+  <style>* { stroke-width: 0; }</style>
+  <rect/>
+  <rect/>
+  <rect/>
+  <rect/>
+  <rect/>
+  <rect/>
+</svg>)svg";
+  svg::SVGDocument document = ParseSvg(kSource);
+
+  const StyleSourceAnnotations annotations = ComputeStyleSourceAnnotations(document, kSource);
+
+  const StyleSourceContribution* strokeWidth =
+      FindContribution(annotations, StyleContributionKind::StylesheetDeclaration, "stroke-width",
+                       "stroke-width: 0", kSource);
+  ASSERT_NE(strokeWidth, nullptr);
+  EXPECT_TRUE(strokeWidth->showChip);
+  EXPECT_GT(strokeWidth->matchedElementCount, 5);
+  EXPECT_TRUE(strokeWidth->showOverflowMarker);
+  EXPECT_EQ(strokeWidth->overflowTooltip, "Too many reverse refs to draw lines");
+}
+
+TEST(StyleSourceAnnotations, ReferenceResourceElementsShowReferenceCountAndUnusedStrike) {
+  constexpr std::string_view kSource = R"svg(<svg xmlns="http://www.w3.org/2000/svg">
+  <style>.hit { fill: url(#paint); }</style>
+  <defs>
+    <linearGradient id="paint"><stop offset="1"/></linearGradient>
+    <linearGradient id="unused"><stop offset="1"/></linearGradient>
+    <path id="shape"/>
+  </defs>
+  <use href="#shape"/>
+  <rect class="hit"/>
+</svg>)svg";
+  svg::SVGDocument document = ParseSvg(kSource);
+
+  const StyleSourceAnnotations annotations = ComputeStyleSourceAnnotations(document, kSource);
+
+  const StyleSourceContribution* paint =
+      FindContribution(annotations, StyleContributionKind::ReferenceResourceElement,
+                       "linearGradient", R"(id="paint")", kSource);
+  ASSERT_NE(paint, nullptr);
+  EXPECT_TRUE(paint->showChip);
+  EXPECT_TRUE(paint->effective);
+  EXPECT_EQ(paint->matchedElementCount, 1);
+  EXPECT_EQ(paint->chipTooltip, "Referenced 1 time");
+  EXPECT_EQ(SourceForRange(kSource, paint->chipRange), R"(<linearGradient id="paint">)");
+
+  const StyleSourceContribution* unused =
+      FindContribution(annotations, StyleContributionKind::ReferenceResourceElement,
+                       "linearGradient", R"(id="unused")", kSource);
+  ASSERT_NE(unused, nullptr);
+  EXPECT_TRUE(unused->showChip);
+  EXPECT_FALSE(unused->effective);
+  EXPECT_EQ(unused->matchedElementCount, 0);
+  EXPECT_EQ(unused->tooltip, "linearGradient #unused is not referenced");
+  EXPECT_EQ(unused->chipTooltip, "Referenced 0 times");
+
+  const StyleSourceContribution* shape =
+      FindContribution(annotations, StyleContributionKind::ReferenceResourceElement, "path",
+                       R"(id="shape")", kSource);
+  ASSERT_NE(shape, nullptr);
+  EXPECT_TRUE(shape->effective);
+  EXPECT_EQ(shape->matchedElementCount, 1);
+}
+
+TEST(StyleSourceAnnotations, ReferenceResourceElementMarksOverflowWhenTooManyReverseRefs) {
+  constexpr std::string_view kSource = R"svg(<svg xmlns="http://www.w3.org/2000/svg">
+  <defs><linearGradient id="paint"><stop offset="1"/></linearGradient></defs>
+  <rect fill="url(#paint)"/>
+  <rect fill="url(#paint)"/>
+  <rect fill="url(#paint)"/>
+  <rect fill="url(#paint)"/>
+  <rect fill="url(#paint)"/>
+  <rect fill="url(#paint)"/>
+</svg>)svg";
+  svg::SVGDocument document = ParseSvg(kSource);
+
+  const StyleSourceAnnotations annotations = ComputeStyleSourceAnnotations(document, kSource);
+
+  const StyleSourceContribution* paint =
+      FindContribution(annotations, StyleContributionKind::ReferenceResourceElement,
+                       "linearGradient", R"(id="paint")", kSource);
+  ASSERT_NE(paint, nullptr);
+  EXPECT_TRUE(paint->showChip);
+  EXPECT_EQ(paint->matchedElementCount, 6);
+  EXPECT_TRUE(paint->showOverflowMarker);
+  EXPECT_EQ(paint->overflowTooltip, "Too many reverse refs to draw lines");
+}
+
+TEST(StyleSourceAnnotations, InlineStyleDeclarationDoesNotShowSelectorChip) {
+  constexpr std::string_view kSource = R"svg(<svg xmlns="http://www.w3.org/2000/svg">
+  <rect style="fill: red; stroke: blue"/>
+</svg>)svg";
+  svg::SVGDocument document = ParseSvg(kSource);
+
+  const StyleSourceAnnotations annotations = ComputeStyleSourceAnnotations(document, kSource);
+
+  const StyleSourceContribution* fill = FindContribution(
+      annotations, StyleContributionKind::InlineStyleDeclaration, "fill", "fill: red", kSource);
+  ASSERT_NE(fill, nullptr);
+  EXPECT_FALSE(fill->showChip);
+  EXPECT_EQ(fill->matchedElementCount, 1);
+  EXPECT_TRUE(fill->effective);
+}
+
+TEST(StyleSourceAnnotations, PresentationAttributeDimsWhenOverriddenByInlineStyle) {
+  constexpr std::string_view kSource = R"svg(<svg xmlns="http://www.w3.org/2000/svg">
+  <rect fill="red" style="fill: blue"/>
+</svg>)svg";
+  svg::SVGDocument document = ParseSvg(kSource);
+
+  const StyleSourceAnnotations annotations = ComputeStyleSourceAnnotations(document, kSource);
+
+  const StyleSourceContribution* presentationFill = FindContribution(
+      annotations, StyleContributionKind::PresentationAttribute, "fill", "fill=\"red\"", kSource);
+  ASSERT_NE(presentationFill, nullptr);
+  EXPECT_FALSE(presentationFill->showChip);
+  EXPECT_FALSE(presentationFill->effective);
+
+  const StyleSourceContribution* inlineFill = FindContribution(
+      annotations, StyleContributionKind::InlineStyleDeclaration, "fill", "fill: blue", kSource);
+  ASSERT_NE(inlineFill, nullptr);
+  EXPECT_TRUE(inlineFill->effective);
+}
+
+TEST(StyleSourceAnnotations, PresentationStrokeWidthDimsWhenOverriddenByStylesheet) {
+  constexpr std::string_view kSource = R"svg(<svg xmlns="http://www.w3.org/2000/svg">
+  <style>.wide { stroke-width: 3; }</style>
+  <rect class="wide" stroke-width="1"/>
+</svg>)svg";
+  svg::SVGDocument document = ParseSvg(kSource);
+
+  const StyleSourceAnnotations annotations = ComputeStyleSourceAnnotations(document, kSource);
+
+  const StyleSourceContribution* presentationStrokeWidth =
+      FindContribution(annotations, StyleContributionKind::PresentationAttribute, "stroke-width",
+                       "stroke-width=\"1\"", kSource);
+  ASSERT_NE(presentationStrokeWidth, nullptr);
+  EXPECT_FALSE(presentationStrokeWidth->effective);
+
+  const StyleSourceContribution* stylesheetStrokeWidth =
+      FindContribution(annotations, StyleContributionKind::StylesheetDeclaration, "stroke-width",
+                       "stroke-width: 3", kSource);
+  ASSERT_NE(stylesheetStrokeWidth, nullptr);
+  EXPECT_TRUE(stylesheetStrokeWidth->showChip);
+  EXPECT_EQ(stylesheetStrokeWidth->matchedElementCount, 1);
+  EXPECT_TRUE(stylesheetStrokeWidth->effective);
+}
+
+TEST(StyleSourceAnnotations, PresentationAttributeStaysActiveWithoutOverride) {
+  constexpr std::string_view kSource = R"svg(<svg xmlns="http://www.w3.org/2000/svg">
+  <rect fill="red"/>
+</svg>)svg";
+  svg::SVGDocument document = ParseSvg(kSource);
+
+  const StyleSourceAnnotations annotations = ComputeStyleSourceAnnotations(document, kSource);
+
+  const StyleSourceContribution* presentationFill = FindContribution(
+      annotations, StyleContributionKind::PresentationAttribute, "fill", "fill=\"red\"", kSource);
+  ASSERT_NE(presentationFill, nullptr);
+  EXPECT_TRUE(presentationFill->effective);
+}
+
+TEST(StyleSourceAnnotations, StylesheetDeclarationStaysActiveIfItWinsForAnyMatchedElement) {
+  constexpr std::string_view kSource = R"svg(<svg xmlns="http://www.w3.org/2000/svg">
+  <style>.hit { fill: red; }</style>
+  <rect class="hit" style="fill: blue"/>
+  <circle class="hit"/>
+</svg>)svg";
+  svg::SVGDocument document = ParseSvg(kSource);
+
+  const StyleSourceAnnotations annotations = ComputeStyleSourceAnnotations(document, kSource);
+
+  const StyleSourceContribution* stylesheetFill = FindContribution(
+      annotations, StyleContributionKind::StylesheetDeclaration, "fill", "fill: red", kSource);
+  ASSERT_NE(stylesheetFill, nullptr);
+  EXPECT_EQ(stylesheetFill->matchedElementCount, 2);
+  EXPECT_TRUE(stylesheetFill->effective);
+}
+
+}  // namespace
+}  // namespace donner::editor

--- a/donner/editor/tests/TextEditor_tests.cc
+++ b/donner/editor/tests/TextEditor_tests.cc
@@ -221,6 +221,8 @@ protected:
     };
   }
 
+  [[nodiscard]] int LineMaxColumn(int line) const { return editor.text_.getLineMaxColumn(line); }
+
   [[nodiscard]] bool HasActiveSourceFlash() const {
     return editor.nextFlashWakeSeconds().has_value() &&
            !editor.flashDecorations_.activeBackgrounds(FlashDecorations::Clock::now()).empty();
@@ -1278,6 +1280,7 @@ TEST_F(TextEditorTests, FocusReferenceConnectorTerminatesOnClosestSourceStyleChi
           .chipRange = SourceByteRange{.start = 0, .end = 27},
           .showChip = true,
           .chipCount = 1,
+          .chipKind = TextEditor::SourceStyleChipKind::ReferenceCount,
           .chipTooltip = "Referenced 1 time",
       },
   }));
@@ -1300,6 +1303,8 @@ TEST_F(TextEditorTests, FocusReferenceConnectorTerminatesOnClosestSourceStyleChi
 
   const auto layout = FocusReferenceLayout(link, 0);
   ASSERT_TRUE(layout.has_value());
+  EXPECT_FALSE(layout->hasSourceStyleChip);
+  EXPECT_TRUE(layout->hasSourceUnderline);
 
   const ImVec2 chipMin = SourceStyleChipHitRectMin(0);
   const ImVec2 chipMax = SourceStyleChipHitRectMax(0);
@@ -1348,6 +1353,13 @@ TEST_F(TextEditorTests, FocusReferenceConnectorTargetsSelectorChipByRangeStart) 
   const ImVec2 chipMax = SourceStyleChipHitRectMax(0);
   EXPECT_FLOAT_EQ(layout->tip.x, (chipMin.x + chipMax.x) * 0.5f);
   EXPECT_FLOAT_EQ(layout->tip.y, chipMax.y);
+  EXPECT_TRUE(layout->hasSourceStyleChip);
+  EXPECT_FALSE(layout->hasSourceUnderline);
+  EXPECT_GT(layout->sourceStyleChip.min.x,
+            ScreenPointAtCoordinates(Coordinates(1, LineMaxColumn(1))).x);
+  EXPECT_FLOAT_EQ(layout->start.x, layout->sourceStyleChip.min.x);
+  EXPECT_FLOAT_EQ(layout->start.y,
+                  (layout->sourceStyleChip.min.y + layout->sourceStyleChip.max.y) * 0.5f);
   ExpectFocusReferenceArrowMatchesTangent(link);
 }
 

--- a/donner/editor/tests/TextEditor_tests.cc
+++ b/donner/editor/tests/TextEditor_tests.cc
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cmath>
 #include <optional>
 #include <sstream>
@@ -141,6 +142,7 @@ protected:
   }
 
   [[nodiscard]] float LastScrollY() const { return editor.lastScroll_; }
+  [[nodiscard]] float LastScrollX() const { return editor.lastScrollX_; }
   [[nodiscard]] float LastScrollViewportHeight() const { return editor.scrollViewportHeight_; }
   [[nodiscard]] float CharacterAdvanceY() const { return editor.charAdvance_.y; }
   void EnterCharacter(ImWchar character) { editor.enterCharacter(character, /*shift=*/false); }
@@ -227,6 +229,94 @@ protected:
   [[nodiscard]] std::optional<TextEditor::FocusReferenceConnectorLayout> FocusReferenceLayout(
       const FocusReferenceLink& link, int linkIndex) const {
     return editor.focusReferenceConnectorLayout(link, linkIndex);
+  }
+
+  [[nodiscard]] std::vector<FocusReferenceLink> FocusReferenceLinks() const {
+    return editor.focusPartition_.referenceLinks;
+  }
+
+  [[nodiscard]] RopeSimulationOptions FocusReferenceRopeOptions() const {
+    return editor.focusReferenceRopeOptions();
+  }
+
+  [[nodiscard]] const TextEditor::FocusReferenceRopeState* FocusReferenceRope(
+      const FocusReferenceLink& link) const {
+    const auto it = editor.focusReferenceRopes_.find(link);
+    return it == editor.focusReferenceRopes_.end() ? nullptr : &it->second;
+  }
+
+  [[nodiscard]] bool FocusReferenceRopeHit(const FocusReferenceLink& link,
+                                           const ImVec2& point) const {
+    const TextEditor::FocusReferenceRopeState* rope = FocusReferenceRope(link);
+    return rope != nullptr && editor.isFocusReferenceRopeHit(
+                                  rope->path, point, std::max(7.0f * editor.uiScale_, 5.0f));
+  }
+
+  [[nodiscard]] bool FocusReferenceRopeHovered(const FocusReferenceLink& link) const {
+    const TextEditor::FocusReferenceRopeState* rope = FocusReferenceRope(link);
+    return rope != nullptr && rope->hovered;
+  }
+
+  void ExpectFocusReferenceArrowMatchesTangent(const FocusReferenceLink& link) const {
+    const TextEditor::FocusReferenceRopeState* rope = FocusReferenceRope(link);
+    ASSERT_NE(rope, nullptr);
+    EXPECT_EQ(rope->arrowDirection, rope->rope.endTangent());
+  }
+
+  [[nodiscard]] bool FocusReferenceRopePathIsBezier(const FocusReferenceLink& link) const {
+    const TextEditor::FocusReferenceRopeState* rope = FocusReferenceRope(link);
+    return rope != nullptr && !rope->path.empty() && !rope->path.commands().empty() &&
+           rope->path.commands().back().verb == Path::Verb::QuadTo;
+  }
+
+  [[nodiscard]] std::optional<Box2d> FocusReferenceRopeBounds(
+      const FocusReferenceLink& link) const {
+    const TextEditor::FocusReferenceRopeState* rope = FocusReferenceRope(link);
+    if (rope == nullptr || rope->path.empty()) {
+      return std::nullopt;
+    }
+
+    return rope->path.bounds();
+  }
+
+  [[nodiscard]] std::vector<Vector2d> FocusReferenceRopePoints(
+      const FocusReferenceLink& link) const {
+    const TextEditor::FocusReferenceRopeState* rope = FocusReferenceRope(link);
+    if (rope == nullptr) {
+      return {};
+    }
+
+    return std::vector<Vector2d>(rope->rope.points().begin(), rope->rope.points().end());
+  }
+
+  void ResetFocusReferenceRopeToSettledCatenary(const FocusReferenceLink& link, int linkIndex,
+                                                float previousScrollY) {
+    const std::optional<TextEditor::FocusReferenceConnectorLayout> layout =
+        FocusReferenceLayout(link, linkIndex);
+    ASSERT_TRUE(layout.has_value());
+
+    TextEditor::FocusReferenceRopeState& rope = editor.focusReferenceRopes_[link];
+    const RopeSimulationOptions options = editor.focusReferenceRopeOptions();
+    const Vector2d start(layout->start.x, layout->start.y);
+    const Vector2d tip(layout->tip.x, layout->tip.y);
+    rope.rope.resetCatenary(start, tip, options);
+    rope.path = rope.rope.toPath(options);
+    rope.chordLength = start.distance(tip);
+    rope.hovered = false;
+    rope.initialized = true;
+    rope.lastFrameSeen = editor.focusReferenceRopeFrame_;
+    editor.lastFocusReferenceRopeScrollY_ = previousScrollY;
+  }
+
+  [[nodiscard]] std::optional<ImVec2> FocusReferenceRopeMidpoint(
+      const FocusReferenceLink& link) const {
+    const TextEditor::FocusReferenceRopeState* rope = FocusReferenceRope(link);
+    if (rope == nullptr || rope->path.empty()) {
+      return std::nullopt;
+    }
+
+    const Path::PointOnPath point = rope->path.pointAtArcLength(rope->path.pathLength() * 0.5);
+    return ImVec2(static_cast<float>(point.point.x), static_cast<float>(point.point.y));
   }
 
   [[nodiscard]] ImVec2 ScreenPointAtCoordinates(const Coordinates& position) const {
@@ -926,6 +1016,17 @@ TEST_F(TextEditorTests, RenderBuildsWrappedVisualRowsForLongXmlLine) {
   EXPECT_FALSE(editor.isImGuiChildIgnored());
   EXPECT_TRUE(editor.wordWrapEnabled());
   EXPECT_FALSE(HorizontalScrollEnabled());
+  EXPECT_FLOAT_EQ(LastScrollX(), 0.0f);
+}
+
+TEST_F(TextEditorTests, HorizontalScrollSetterDoesNotEnableTextViewHorizontalScroll) {
+  editor.setText(R"(  <rect id="target" x="10" y="20" width="30" height="40" fill="red"/>)");
+  editor.setHorizontalScroll(true);
+
+  RenderEditorFrame(ImVec2(180.0f, 180.0f));
+
+  EXPECT_FALSE(HorizontalScrollEnabled());
+  EXPECT_FLOAT_EQ(LastScrollX(), 0.0f);
 }
 
 TEST_F(TextEditorTests, WrappedHitTestingMapsContinuationRowToLogicalColumn) {
@@ -1088,7 +1189,7 @@ TEST_F(TextEditorTests, SourceFocusModeContextMenuStateAndToggleRequestAreConsum
   EXPECT_FALSE(SourceFocusModeContextMenuVisible());
 }
 
-TEST_F(TextEditorTests, FocusReferenceConnectorsRouteThroughDistinctRightSideLanes) {
+TEST_F(TextEditorTests, FocusReferenceConnectorsUseCatenaryRopesBetweenEndpoints) {
   editor.setText(
       "  <defs>\n"
       "    <linearGradient id=\"grad\"/>\n"
@@ -1115,30 +1216,149 @@ TEST_F(TextEditorTests, FocusReferenceConnectorsRouteThroughDistinctRightSideLan
   ASSERT_TRUE(rectLayout.has_value());
   ASSERT_TRUE(circleLayout.has_value());
 
-  EXPECT_GT(rectLayout->laneStart.x, rectLayout->start.x);
-  EXPECT_FLOAT_EQ(rectLayout->laneStart.x, rectLayout->laneEnd.x);
-  EXPECT_GT(rectLayout->laneEnd.x, rectLayout->tip.x);
-  EXPECT_NE(rectLayout->laneStart.x, circleLayout->laneStart.x);
-
   const float baselineY = TextBaselineOffsetY();
   const ImVec2 rectSourceTop = ScreenPointAtCoordinates(Coordinates(3, 19));
   const ImVec2 gradientTargetTop = ScreenPointAtCoordinates(Coordinates(1, 4));
-  EXPECT_FLOAT_EQ(rectLayout->start.y, rectSourceTop.y + baselineY);
+  const ImVec2 rectReferenceStart = ScreenPointAtCoordinates(Coordinates(3, 18));
+  const ImVec2 rectReferenceEnd = ScreenPointAtCoordinates(Coordinates(3, 23));
+  EXPECT_TRUE(rectLayout->hasSourceUnderline);
+  EXPECT_FLOAT_EQ(rectLayout->sourceUnderline.start.x, rectReferenceStart.x);
+  EXPECT_FLOAT_EQ(rectLayout->sourceUnderline.end.x, rectReferenceEnd.x);
+  EXPECT_FLOAT_EQ(rectLayout->start.x,
+                  (rectLayout->sourceUnderline.start.x + rectLayout->sourceUnderline.end.x) * 0.5f);
+  EXPECT_FLOAT_EQ(rectLayout->start.y, rectLayout->sourceUnderline.start.y);
+  EXPECT_GT(rectLayout->start.y, rectSourceTop.y + baselineY);
   EXPECT_FLOAT_EQ(rectLayout->tip.y, gradientTargetTop.y + baselineY);
 
   EXPECT_NE(rectLayout->color, circleLayout->color);
   const float alpha = ImGui::ColorConvertU32ToFloat4(rectLayout->color).w;
   EXPECT_GE(alpha, 0.45f);
   EXPECT_LE(alpha, 0.55f);
+
+  EXPECT_TRUE(FocusReferenceRopePathIsBezier(rectLink));
+  const std::optional<Box2d> rectBounds = FocusReferenceRopeBounds(rectLink);
+  ASSERT_TRUE(rectBounds.has_value());
+  EXPECT_LE(rectBounds->bottomRight.x, std::max(rectLayout->start.x, rectLayout->tip.x) + 3.0f)
+      << "Catenary rope should hang between endpoints instead of routing through a right lane";
+  EXPECT_GT(rectBounds->bottomRight.y, std::max(rectLayout->start.y, rectLayout->tip.y));
+  ASSERT_TRUE(editor.nextRopeAnimationWakeSeconds().has_value());
+  EXPECT_FLOAT_EQ(*editor.nextRopeAnimationWakeSeconds(), 1.0f / 60.0f);
 }
 
-TEST_F(TextEditorTests, FocusReferenceConnectorTerminatesOnRightSideOfSourceStyleChip) {
+TEST_F(TextEditorTests, FocusReferenceRopeOptionsUseDenseFastRopeTuning) {
+  const RopeSimulationOptions options = FocusReferenceRopeOptions();
+
+  EXPECT_GE(options.segmentCount, 28);
+  EXPECT_GE(options.constraintIterations, 10);
+  EXPECT_GE(options.gravityPxPerSec2, 180.0);
+  EXPECT_LE(options.scrollResponse, 0.01);
+  EXPECT_LE(options.maxScrollImpulsePx, 0.8);
+  EXPECT_GE(options.catenarySlackRatio, 0.18);
+  EXPECT_GE(options.catenaryMinSlackPx, 30.0);
+  EXPECT_GE(options.catenaryMaxSlackPx, 120.0);
+  EXPECT_LE(options.initialImpulsePx, 0.25);
+  EXPECT_LE(options.settleRestDistanceThresholdPx, 0.45);
+  EXPECT_LT(options.overdueDamping, options.damping);
+  EXPECT_LE(options.overdueDampingRampSeconds, 1.5);
+  EXPECT_GE(options.catenaryRestoringForcePerSec2, 600.0);
+  EXPECT_EQ(options.endpointImpulse, 0.0);
+  EXPECT_EQ(options.maxEndpointImpulsePx, 0.0);
+  EXPECT_LE(options.endpointMotionVelocityRetention, 0.25);
+  EXPECT_GE(options.endpointCatenaryBlend, 0.15);
+}
+
+TEST_F(TextEditorTests, FocusReferenceConnectorTerminatesOnClosestSourceStyleChipEdge) {
   editor.setText(
-      "<linearGradient id=\"paint\">\n"
+      "<linearGradient id=\"paint\"> padding padding padding\n"
       "<rect fill=\"url(#paint)\"/>\n");
   ASSERT_TRUE(editor.setSourceStyleDecorations({
       TextEditor::SourceStyleDecoration{
           .id = 94,
+          .range = SourceByteRange{.start = 0, .end = 27},
+          .chipRange = SourceByteRange{.start = 0, .end = 27},
+          .showChip = true,
+          .chipCount = 1,
+          .chipTooltip = "Referenced 1 time",
+      },
+  }));
+
+  const FocusReferenceLink link{
+      .from = SourcePoint{.line = 1, .column = 17},
+      .to = SourcePoint{.line = 0, .column = 27},
+  };
+  const FocusReferenceLink rightLink{
+      .from = SourcePoint{.line = 0, .column = 45},
+      .to = SourcePoint{.line = 0, .column = 27},
+  };
+  editor.setFocusPartition(FocusPartition{
+      .fullColor = {LineRange{.startLine = 0, .endLine = 2}},
+      .referenceLinks = {link, rightLink},
+  });
+
+  RenderEditorFrame(ImVec2(520.0f, 140.0f));
+  ASSERT_EQ(SourceStyleChipHitRectCount(), 1u);
+
+  const auto layout = FocusReferenceLayout(link, 0);
+  ASSERT_TRUE(layout.has_value());
+
+  const ImVec2 chipMin = SourceStyleChipHitRectMin(0);
+  const ImVec2 chipMax = SourceStyleChipHitRectMax(0);
+  EXPECT_FLOAT_EQ(layout->tip.x, (chipMin.x + chipMax.x) * 0.5f);
+  EXPECT_FLOAT_EQ(layout->tip.y, chipMax.y);
+  ExpectFocusReferenceArrowMatchesTangent(link);
+
+  const auto rightLayout = FocusReferenceLayout(rightLink, 1);
+  ASSERT_TRUE(rightLayout.has_value());
+  EXPECT_FLOAT_EQ(rightLayout->tip.x, chipMax.x);
+  EXPECT_FLOAT_EQ(rightLayout->tip.y, (chipMin.y + chipMax.y) * 0.5f);
+  ExpectFocusReferenceArrowMatchesTangent(rightLink);
+}
+
+TEST_F(TextEditorTests, FocusReferenceConnectorTargetsSelectorChipByRangeStart) {
+  editor.setText(
+      ".hit { fill: red; }\n"
+      "<rect class=\"hit\"/>\n");
+  ASSERT_TRUE(editor.setSourceStyleDecorations({
+      TextEditor::SourceStyleDecoration{
+          .id = 95,
+          .range = SourceByteRange{.start = 7, .end = 16},
+          .chipRange = SourceByteRange{.start = 0, .end = 4},
+          .showChip = true,
+          .chipCount = 1,
+          .chipTooltip = "Selector matches 1 element",
+      },
+  }));
+
+  const FocusReferenceLink link{
+      .from = SourcePoint{.line = 1, .column = 13},
+      .to = SourcePoint{.line = 0, .column = 0},
+  };
+  editor.setFocusPartition(FocusPartition{
+      .fullColor = {LineRange{.startLine = 0, .endLine = 2}},
+      .referenceLinks = {link},
+  });
+
+  RenderEditorFrame(ImVec2(360.0f, 120.0f));
+  ASSERT_EQ(SourceStyleChipHitRectCount(), 1u);
+
+  const auto layout = FocusReferenceLayout(link, 0);
+  ASSERT_TRUE(layout.has_value());
+
+  const ImVec2 chipMin = SourceStyleChipHitRectMin(0);
+  const ImVec2 chipMax = SourceStyleChipHitRectMax(0);
+  EXPECT_FLOAT_EQ(layout->tip.x, (chipMin.x + chipMax.x) * 0.5f);
+  EXPECT_FLOAT_EQ(layout->tip.y, chipMax.y);
+  ExpectFocusReferenceArrowMatchesTangent(link);
+}
+
+TEST_F(TextEditorTests, TypingRemapsFocusReferenceRopeEndpointsImmediately) {
+  const std::string source =
+      "<linearGradient id=\"grad\"/>\n"
+      "<rect fill=\"url(#grad)\"/>\n";
+  editor.setText(source);
+  ASSERT_TRUE(editor.setSourceStyleDecorations({
+      TextEditor::SourceStyleDecoration{
+          .id = 96,
           .range = SourceByteRange{.start = 0, .end = 27},
           .chipRange = SourceByteRange{.start = 0, .end = 27},
           .showChip = true,
@@ -1156,16 +1376,36 @@ TEST_F(TextEditorTests, FocusReferenceConnectorTerminatesOnRightSideOfSourceStyl
       .referenceLinks = {link},
   });
 
-  RenderEditorFrame(ImVec2(520.0f, 140.0f));
-  ASSERT_EQ(SourceStyleChipHitRectCount(), 1u);
+  RenderEditorFrame(ImVec2(420.0f, 140.0f));
+  const auto beforeLayout = FocusReferenceLayout(link, 0);
+  ASSERT_TRUE(beforeLayout.has_value());
+  const std::vector<Vector2d> beforePoints = FocusReferenceRopePoints(link);
+  ASSERT_FALSE(beforePoints.empty());
 
-  const auto layout = FocusReferenceLayout(link, 0);
-  ASSERT_TRUE(layout.has_value());
+  constexpr std::string_view kInsertedLine = "<!-- live -->\n";
+  editor.setCursorPosition(Coordinates(0, 0));
+  editor.insertText(kInsertedLine);
 
-  const ImVec2 chipMin = SourceStyleChipHitRectMin(0);
-  const ImVec2 chipMax = SourceStyleChipHitRectMax(0);
-  EXPECT_FLOAT_EQ(layout->tip.x, chipMax.x);
-  EXPECT_FLOAT_EQ(layout->tip.y, chipMin.y + (chipMax.y - chipMin.y) * 0.5f);
+  const FocusReferenceLink remappedLink{
+      .from = SourcePoint{.line = 2, .column = 17},
+      .to = SourcePoint{.line = 1, .column = 27},
+  };
+  EXPECT_EQ(FocusReferenceLinks(), (std::vector<FocusReferenceLink>{remappedLink}));
+  ASSERT_EQ(editor.sourceStyleDecorations().size(), 1u);
+  EXPECT_EQ(editor.sourceStyleDecorations()[0].chipRange,
+            (SourceByteRange{.start = kInsertedLine.size(), .end = kInsertedLine.size() + 27u}));
+  EXPECT_EQ(FocusReferenceRope(link), nullptr);
+  EXPECT_NE(FocusReferenceRope(remappedLink), nullptr);
+
+  RenderEditorFrame(ImVec2(420.0f, 160.0f));
+  const auto afterLayout = FocusReferenceLayout(remappedLink, 0);
+  ASSERT_TRUE(afterLayout.has_value());
+  EXPECT_GT(afterLayout->start.y, beforeLayout->start.y);
+  EXPECT_GT(afterLayout->tip.y, beforeLayout->tip.y);
+
+  const std::vector<Vector2d> afterPoints = FocusReferenceRopePoints(remappedLink);
+  ASSERT_EQ(afterPoints.size(), beforePoints.size());
+  EXPECT_GT(afterPoints[afterPoints.size() / 2u].y, beforePoints[beforePoints.size() / 2u].y);
 }
 
 TEST_F(TextEditorTests, ReferenceOnlyFocusPartitionLeavesAllLinesVisible) {
@@ -1186,6 +1426,107 @@ TEST_F(TextEditorTests, ReferenceOnlyFocusPartitionLeavesAllLinesVisible) {
 
   EXPECT_EQ(VisualLineLogicalLines(), (std::vector<int>{0, 1, 2, 3}));
   EXPECT_TRUE(FocusReferenceLayout(link, 0).has_value());
+}
+
+TEST_F(TextEditorTests, FocusReferenceRopeHitTestDetectsMouseNearConnector) {
+  editor.setText(
+      "  <defs>\n"
+      "    <linearGradient id=\"grad\"/>\n"
+      "  </defs>\n"
+      "  <rect fill=\"url(#grad)\"/>\n");
+  const FocusReferenceLink link{
+      .from = SourcePoint{.line = 3, .column = 19},
+      .to = SourcePoint{.line = 1, .column = 4},
+  };
+  editor.setFocusPartition(FocusPartition{
+      .fullColor = {LineRange{.startLine = 1, .endLine = 4}},
+      .referenceLinks = {link},
+  });
+
+  RenderEditorFrame(ImVec2(520.0f, 180.0f));
+
+  const std::optional<ImVec2> midpoint = FocusReferenceRopeMidpoint(link);
+  ASSERT_TRUE(midpoint.has_value());
+  EXPECT_TRUE(FocusReferenceRopeHit(link, *midpoint));
+}
+
+TEST_F(TextEditorTests, CanvasScrollFrameDoesNotApplyFocusReferenceRopeScrollImpulse) {
+  editor.setText(
+      "  <defs>\n"
+      "    <linearGradient id=\"grad\"/>\n"
+      "  </defs>\n"
+      "  <rect fill=\"url(#grad)\"/>\n");
+  const FocusReferenceLink link{
+      .from = SourcePoint{.line = 3, .column = 19},
+      .to = SourcePoint{.line = 1, .column = 4},
+  };
+  editor.setFocusPartition(FocusPartition{
+      .fullColor = {LineRange{.startLine = 1, .endLine = 4}},
+      .referenceLinks = {link},
+  });
+
+  RenderEditorFrame(ImVec2(520.0f, 180.0f));
+  ResetFocusReferenceRopeToSettledCatenary(link, 0, /*previousScrollY=*/-40.0f);
+  const std::vector<Vector2d> before = FocusReferenceRopePoints(link);
+
+  RenderEditorFrameWithMouse(ImVec2(760.0f, 560.0f), /*mouseDown=*/false, ImVec2(520.0f, 180.0f));
+
+  EXPECT_EQ(FocusReferenceRopePoints(link), before);
+}
+
+TEST_F(TextEditorTests, HoveredFocusReferenceRopeGetsInteractiveStateAndFreezes) {
+  editor.setText(
+      "  <defs>\n"
+      "    <linearGradient id=\"grad\"/>\n"
+      "  </defs>\n"
+      "  <rect fill=\"url(#grad)\"/>\n");
+  const FocusReferenceLink link{
+      .from = SourcePoint{.line = 3, .column = 19},
+      .to = SourcePoint{.line = 1, .column = 4},
+  };
+  editor.setFocusPartition(FocusPartition{
+      .fullColor = {LineRange{.startLine = 1, .endLine = 4}},
+      .referenceLinks = {link},
+  });
+
+  RenderEditorFrame(ImVec2(520.0f, 180.0f));
+  const std::optional<ImVec2> midpoint = FocusReferenceRopeMidpoint(link);
+  ASSERT_TRUE(midpoint.has_value());
+  const std::vector<Vector2d> beforeHover = FocusReferenceRopePoints(link);
+
+  RenderEditorFrameWithMouse(*midpoint, /*mouseDown=*/false, ImVec2(520.0f, 180.0f));
+
+  EXPECT_TRUE(FocusReferenceRopeHovered(link));
+  EXPECT_EQ(FocusReferenceRopePoints(link), beforeHover);
+  EXPECT_FALSE(editor.nextRopeAnimationWakeSeconds().has_value());
+}
+
+TEST_F(TextEditorTests, ClickingFocusReferenceRopeMovesCursorToDefinition) {
+  editor.setText(
+      "  <defs>\n"
+      "    <linearGradient id=\"grad\"/>\n"
+      "  </defs>\n"
+      "  <rect fill=\"url(#grad)\"/>\n");
+  const FocusReferenceLink link{
+      .from = SourcePoint{.line = 3, .column = 19},
+      .to = SourcePoint{.line = 1, .column = 4},
+  };
+  editor.setFocusPartition(FocusPartition{
+      .fullColor = {LineRange{.startLine = 1, .endLine = 4}},
+      .referenceLinks = {link},
+  });
+  editor.setCursorPosition(Coordinates(0, 0));
+  RenderEditorFrame(ImVec2(520.0f, 180.0f));
+  const std::optional<ImVec2> midpoint = FocusReferenceRopeMidpoint(link);
+  ASSERT_TRUE(midpoint.has_value());
+
+  RenderEditorFrameWithMouse(*midpoint, /*mouseDown=*/false, ImVec2(520.0f, 180.0f));
+  RenderEditorFrameWithMouse(*midpoint, /*mouseDown=*/true, ImVec2(520.0f, 180.0f));
+
+  EXPECT_EQ(editor.getCursorPosition(), Coordinates(link.to.line, link.to.column));
+  EXPECT_FALSE(editor.hasSelection());
+  EXPECT_TRUE(editor.isCursorPositionChanged());
+  EXPECT_TRUE(editor.didMouseChangeCursorPosition());
 }
 
 TEST_F(TextEditorTests, SelectAndFocusScrollsToWrappedVisualCursorLine) {

--- a/donner/editor/tests/TextEditor_tests.cc
+++ b/donner/editor/tests/TextEditor_tests.cc
@@ -1322,6 +1322,8 @@ TEST_F(TextEditorTests, FocusReferenceConnectorTerminatesOnClosestSourceStyleChi
 TEST_F(TextEditorTests, FocusReferenceConnectorTargetsSelectorChipByRangeStart) {
   editor.setText(
       ".hit { fill: red; }\n"
+      "\n"
+      "\n"
       "<rect class=\"hit\"/>\n");
   ASSERT_TRUE(editor.setSourceStyleDecorations({
       TextEditor::SourceStyleDecoration{
@@ -1335,11 +1337,11 @@ TEST_F(TextEditorTests, FocusReferenceConnectorTargetsSelectorChipByRangeStart) 
   }));
 
   const FocusReferenceLink link{
-      .from = SourcePoint{.line = 1, .column = 13},
+      .from = SourcePoint{.line = 3, .column = 13},
       .to = SourcePoint{.line = 0, .column = 0},
   };
   editor.setFocusPartition(FocusPartition{
-      .fullColor = {LineRange{.startLine = 0, .endLine = 2}},
+      .fullColor = {LineRange{.startLine = 0, .endLine = 4}},
       .referenceLinks = {link},
   });
 
@@ -1356,7 +1358,8 @@ TEST_F(TextEditorTests, FocusReferenceConnectorTargetsSelectorChipByRangeStart) 
   EXPECT_TRUE(layout->hasSourceStyleChip);
   EXPECT_FALSE(layout->hasSourceUnderline);
   EXPECT_GT(layout->sourceStyleChip.min.x,
-            ScreenPointAtCoordinates(Coordinates(1, LineMaxColumn(1))).x);
+            ScreenPointAtCoordinates(Coordinates(3, LineMaxColumn(3))).x);
+  EXPECT_GT(layout->sourceStyleChip.min.y, layout->tip.y);
   EXPECT_FLOAT_EQ(layout->start.x, layout->sourceStyleChip.min.x);
   EXPECT_FLOAT_EQ(layout->start.y,
                   (layout->sourceStyleChip.min.y + layout->sourceStyleChip.max.y) * 0.5f);

--- a/donner/editor/tests/TextEditor_tests.cc
+++ b/donner/editor/tests/TextEditor_tests.cc
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -245,6 +246,31 @@ protected:
     return editor.flashDecorations_.activeBackgrounds(FlashDecorations::Clock::now());
   }
 
+  [[nodiscard]] bool IsByteOffsetInIneffectiveStyleDecoration(std::size_t byteOffset) const {
+    return editor.isByteOffsetInIneffectiveStyleDecoration(byteOffset);
+  }
+
+  [[nodiscard]] std::size_t SourceStyleChipHitRectCount() const {
+    return editor.sourceStyleChipHitRects_.size();
+  }
+
+  [[nodiscard]] ImVec2 SourceStyleChipHitRectCenter(std::size_t index) const {
+    const auto& hitRect = editor.sourceStyleChipHitRects_[index];
+    return ImVec2((hitRect.min.x + hitRect.max.x) * 0.5f, (hitRect.min.y + hitRect.max.y) * 0.5f);
+  }
+
+  [[nodiscard]] ImVec2 SourceStyleChipHitRectMin(std::size_t index) const {
+    return editor.sourceStyleChipHitRects_[index].min;
+  }
+
+  [[nodiscard]] ImVec2 SourceStyleChipHitRectMax(std::size_t index) const {
+    return editor.sourceStyleChipHitRects_[index].max;
+  }
+
+  [[nodiscard]] std::string SourceStyleChipHitRectTooltip(std::size_t index) const {
+    return editor.sourceStyleChipHitRects_[index].tooltip;
+  }
+
   ImGuiContext* imguiContext_ = nullptr;
   TextEditor editor;
 };
@@ -323,6 +349,138 @@ TEST_F(TextEditorTests, HoverSourceRangesAreClampedAndDeduplicated) {
   EXPECT_FALSE(editor.setHoverSourceRanges(editor.hoverSourceRanges()));
   EXPECT_TRUE(editor.clearHoverSourceRanges());
   EXPECT_TRUE(editor.hoverSourceRanges().empty());
+}
+
+TEST_F(TextEditorTests, SourceStyleDecorationsAreClampedAndCleared) {
+  editor.setText("abcdef");
+
+  EXPECT_TRUE(editor.setSourceStyleDecorations({
+      TextEditor::SourceStyleDecoration{
+          .id = 7,
+          .range = SourceByteRange{.start = 4, .end = 4},
+          .ineffective = true,
+      },
+      TextEditor::SourceStyleDecoration{
+          .id = 2,
+          .range = SourceByteRange{.start = 5, .end = 100},
+          .showChip = true,
+          .chipCount = -4,
+          .tooltip = "unused selector",
+      },
+      TextEditor::SourceStyleDecoration{
+          .id = 1,
+          .range = SourceByteRange{.start = 2, .end = 5},
+          .ineffective = true,
+          .tooltip = "fill is overridden",
+      },
+  }));
+
+  ASSERT_EQ(editor.sourceStyleDecorations().size(), 2u);
+  EXPECT_EQ(editor.sourceStyleDecorations()[0].id, 1u);
+  EXPECT_EQ(editor.sourceStyleDecorations()[0].range, (SourceByteRange{.start = 2, .end = 5}));
+  EXPECT_TRUE(editor.sourceStyleDecorations()[0].ineffective);
+  EXPECT_EQ(editor.sourceStyleDecorations()[1].id, 2u);
+  EXPECT_EQ(editor.sourceStyleDecorations()[1].range, (SourceByteRange{.start = 5, .end = 6}));
+  EXPECT_EQ(editor.sourceStyleDecorations()[1].chipCount, 0);
+
+  EXPECT_FALSE(editor.setSourceStyleDecorations(editor.sourceStyleDecorations()));
+  EXPECT_TRUE(editor.clearSourceStyleDecorations());
+  EXPECT_TRUE(editor.sourceStyleDecorations().empty());
+}
+
+TEST_F(TextEditorTests, SourceStyleDecorationsStrikeRangesWithoutRenderingHiddenChips) {
+  editor.setText("fill: red;");
+  ASSERT_TRUE(editor.setSourceStyleDecorations({
+      TextEditor::SourceStyleDecoration{
+          .id = 11,
+          .range = SourceByteRange{.start = 0, .end = 4},
+          .ineffective = true,
+          .showChip = false,
+          .chipCount = 5,
+          .tooltip = "fill is overridden",
+      },
+  }));
+
+  EXPECT_TRUE(IsByteOffsetInIneffectiveStyleDecoration(0));
+  EXPECT_TRUE(IsByteOffsetInIneffectiveStyleDecoration(3));
+  EXPECT_FALSE(IsByteOffsetInIneffectiveStyleDecoration(4));
+
+  RenderEditorFrame(ImVec2(360.0f, 120.0f));
+  EXPECT_EQ(SourceStyleChipHitRectCount(), 0u);
+}
+
+TEST_F(TextEditorTests, SourceStyleDecorationChipClickIsConsumable) {
+  editor.setText(".cls { fill: red; }\n");
+  ASSERT_TRUE(editor.setSourceStyleDecorations({
+      TextEditor::SourceStyleDecoration{
+          .id = 42,
+          .range = SourceByteRange{.start = 7, .end = 16},
+          .showChip = true,
+          .chipCount = 3,
+          .tooltip = "3 matched elements",
+      },
+  }));
+
+  RenderEditorFrame(ImVec2(420.0f, 120.0f));
+  ASSERT_EQ(SourceStyleChipHitRectCount(), 1u);
+  const ImVec2 chipCenter = SourceStyleChipHitRectCenter(0);
+
+  RenderEditorFrameWithMouse(chipCenter, true, ImVec2(420.0f, 120.0f));
+
+  EXPECT_EQ(editor.takeClickedSourceStyleChipId(), std::optional<std::size_t>(42));
+  EXPECT_EQ(editor.takeClickedSourceStyleChipId(), std::nullopt);
+}
+
+TEST_F(TextEditorTests, SourceStyleDecorationChipUsesChipRangeAnchor) {
+  editor.setText(".hit {\n  fill: red;\n}\n");
+  ASSERT_TRUE(editor.setSourceStyleDecorations({
+      TextEditor::SourceStyleDecoration{
+          .id = 84,
+          .range = SourceByteRange{.start = 9, .end = 19},
+          .chipRange = SourceByteRange{.start = 0, .end = 4},
+          .showChip = true,
+          .chipCount = 2,
+          .tooltip = "fill is overridden",
+          .chipTooltip = "Selector matches 2 elements",
+      },
+  }));
+
+  RenderEditorFrame(ImVec2(420.0f, 120.0f));
+  ASSERT_EQ(SourceStyleChipHitRectCount(), 1u);
+
+  const float selectorLineCenterY =
+      ScreenPointAtVisualTextOffset(/*visualIndex=*/0, /*visualColumnOffset=*/4).y;
+  const float propertyLineCenterY =
+      ScreenPointAtVisualTextOffset(/*visualIndex=*/1, /*visualColumnOffset=*/12).y;
+  const float chipCenterY = SourceStyleChipHitRectCenter(0).y;
+  EXPECT_LT(std::abs(chipCenterY - selectorLineCenterY),
+            std::abs(chipCenterY - propertyLineCenterY));
+  EXPECT_EQ(SourceStyleChipHitRectTooltip(0), "Selector matches 2 elements");
+}
+
+TEST_F(TextEditorTests, SourceStyleDecorationOverflowMarkerHasTooltipAndIsNotClickable) {
+  editor.setText("<linearGradient id=\"paint\">\n");
+  ASSERT_TRUE(editor.setSourceStyleDecorations({
+      TextEditor::SourceStyleDecoration{
+          .id = 85,
+          .range = SourceByteRange{.start = 0, .end = 27},
+          .chipRange = SourceByteRange{.start = 0, .end = 27},
+          .showChip = true,
+          .chipCount = 6,
+          .showOverflowMarker = true,
+          .chipTooltip = "Referenced 6 times",
+          .overflowTooltip = "Too many reverse refs to draw lines",
+      },
+  }));
+
+  RenderEditorFrame(ImVec2(520.0f, 120.0f));
+  ASSERT_EQ(SourceStyleChipHitRectCount(), 2u);
+  EXPECT_LT(SourceStyleChipHitRectCenter(0).x, SourceStyleChipHitRectCenter(1).x);
+  EXPECT_EQ(SourceStyleChipHitRectTooltip(0), "Referenced 6 times");
+  EXPECT_EQ(SourceStyleChipHitRectTooltip(1), "Too many reverse refs to draw lines");
+
+  RenderEditorFrameWithMouse(SourceStyleChipHitRectCenter(1), true, ImVec2(520.0f, 120.0f));
+  EXPECT_EQ(editor.takeClickedSourceStyleChipId(), std::nullopt);
 }
 
 TEST_F(TextEditorTests, MoveLeftRetractsCursor) {
@@ -972,6 +1130,42 @@ TEST_F(TextEditorTests, FocusReferenceConnectorsRouteThroughDistinctRightSideLan
   const float alpha = ImGui::ColorConvertU32ToFloat4(rectLayout->color).w;
   EXPECT_GE(alpha, 0.45f);
   EXPECT_LE(alpha, 0.55f);
+}
+
+TEST_F(TextEditorTests, FocusReferenceConnectorTerminatesOnRightSideOfSourceStyleChip) {
+  editor.setText(
+      "<linearGradient id=\"paint\">\n"
+      "<rect fill=\"url(#paint)\"/>\n");
+  ASSERT_TRUE(editor.setSourceStyleDecorations({
+      TextEditor::SourceStyleDecoration{
+          .id = 94,
+          .range = SourceByteRange{.start = 0, .end = 27},
+          .chipRange = SourceByteRange{.start = 0, .end = 27},
+          .showChip = true,
+          .chipCount = 1,
+          .chipTooltip = "Referenced 1 time",
+      },
+  }));
+
+  const FocusReferenceLink link{
+      .from = SourcePoint{.line = 1, .column = 17},
+      .to = SourcePoint{.line = 0, .column = 27},
+  };
+  editor.setFocusPartition(FocusPartition{
+      .fullColor = {LineRange{.startLine = 0, .endLine = 2}},
+      .referenceLinks = {link},
+  });
+
+  RenderEditorFrame(ImVec2(520.0f, 140.0f));
+  ASSERT_EQ(SourceStyleChipHitRectCount(), 1u);
+
+  const auto layout = FocusReferenceLayout(link, 0);
+  ASSERT_TRUE(layout.has_value());
+
+  const ImVec2 chipMin = SourceStyleChipHitRectMin(0);
+  const ImVec2 chipMax = SourceStyleChipHitRectMax(0);
+  EXPECT_FLOAT_EQ(layout->tip.x, chipMax.x);
+  EXPECT_FLOAT_EQ(layout->tip.y, chipMin.y + (chipMax.y - chipMin.y) * 0.5f);
 }
 
 TEST_F(TextEditorTests, ReferenceOnlyFocusPartitionLeavesAllLinesVisible) {

--- a/donner/svg/SVGStyleQuery.cc
+++ b/donner/svg/SVGStyleQuery.cc
@@ -1,22 +1,50 @@
 #include "donner/svg/SVGStyleQuery.h"
 
+#include <span>
+
 #include "donner/svg/SVGDocument.h"
 #include "donner/svg/SVGElement.h"
+#include "donner/svg/components/StylesheetComponent.h"
 #include "donner/svg/components/style/StyleSystem.h"
 
 namespace donner::svg {
 namespace {
+
+using components::StylesheetComponent;
 
 SVGMatchedStyleRule ToPublicMatchedRule(const components::MatchedStyleRule& rule) {
   return SVGMatchedStyleRule{
       .stylesheetEntity = rule.stylesheetEntity,
       .ruleIndex = rule.ruleIndex,
       .selectorEntryIndex = rule.selectorEntryIndex,
+      .specificity = rule.specificity,
       .isUserAgentStylesheet = rule.isUserAgentStylesheet,
       .ruleSourceRange = rule.ruleSourceRange,
       .selectorSourceRange = rule.selectorSourceRange,
       .declarationSourceRanges = rule.declarationSourceRanges,
   };
+}
+
+SVGStylesheetRule ToPublicStylesheetRule(Entity stylesheetEntity, std::size_t ruleIndex,
+                                         const StylesheetComponent& stylesheet,
+                                         const css::SelectorRule& rule) {
+  SVGStylesheetRule result{
+      .stylesheetEntity = stylesheetEntity,
+      .ruleIndex = ruleIndex,
+      .ruleSourceRange = stylesheet.sourceMap.mapToDocumentSource(rule.ruleSourceRange),
+      .selectorSourceRange = stylesheet.sourceMap.mapToDocumentSource(rule.selectorSourceRange),
+  };
+  result.declarations.reserve(rule.declarations.size());
+  for (std::size_t declarationIndex = 0; declarationIndex < rule.declarations.size();
+       ++declarationIndex) {
+    const css::Declaration& declaration = rule.declarations[declarationIndex];
+    result.declarations.push_back(SVGStylesheetDeclaration{
+        .declarationIndex = declarationIndex,
+        .declaration = declaration,
+        .declarationSourceRange = stylesheet.sourceMap.mapToDocumentSource(declaration.sourceRange),
+    });
+  }
+  return result;
 }
 
 SVGStyleRuleAtSourceOffset ToPublicSourceRule(const components::StyleRuleAtSourceOffset& rule) {
@@ -32,35 +60,59 @@ SVGStyleRuleAtSourceOffset ToPublicSourceRule(const components::StyleRuleAtSourc
 }  // namespace
 
 std::vector<SVGMatchedStyleRule> CollectMatchedStyleRules(const SVGElement& element) {
-  if (!element.entityHandle()) {
-    return {};
-  }
+  return element.withReadAccess([](DocumentReadAccess&, EntityHandle handle) {
+    if (!handle) {
+      return std::vector<SVGMatchedStyleRule>();
+    }
 
-  std::vector<components::MatchedStyleRule> internalRules =
-      components::StyleSystem().collectMatchedStyleRules(element.entityHandle());
-  std::vector<SVGMatchedStyleRule> rules;
-  rules.reserve(internalRules.size());
-  for (const components::MatchedStyleRule& rule : internalRules) {
-    rules.push_back(ToPublicMatchedRule(rule));
-  }
-  return rules;
+    std::vector<components::MatchedStyleRule> internalRules =
+        components::StyleSystem().collectMatchedStyleRules(handle);
+    std::vector<SVGMatchedStyleRule> rules;
+    rules.reserve(internalRules.size());
+    for (const components::MatchedStyleRule& rule : internalRules) {
+      rules.push_back(ToPublicMatchedRule(rule));
+    }
+    return rules;
+  });
+}
+
+std::vector<SVGStylesheetRule> CollectStylesheetRules(const SVGDocument& document) {
+  return document.withReadAccess([](DocumentReadAccess& access) {
+    std::vector<SVGStylesheetRule> result;
+    Registry& registry = access.registry();
+    for (auto view = registry.view<StylesheetComponent>(); auto stylesheetEntity : view) {
+      const StylesheetComponent& stylesheet = view.get<StylesheetComponent>(stylesheetEntity);
+      if (stylesheet.isUserAgentStylesheet || stylesheet.sourceMap.empty()) {
+        continue;
+      }
+
+      const std::span<const css::SelectorRule> rules = stylesheet.stylesheet.rules();
+      for (std::size_t ruleIndex = 0; ruleIndex < rules.size(); ++ruleIndex) {
+        result.push_back(
+            ToPublicStylesheetRule(stylesheetEntity, ruleIndex, stylesheet, rules[ruleIndex]));
+      }
+    }
+    return result;
+  });
 }
 
 std::optional<SVGStyleRuleAtSourceOffset> FindStyleRuleAtSourceOffset(
     const SVGDocument& document, std::size_t documentSourceOffset) {
-  EntityHandle rootHandle = document.svgElement().entityHandle();
-  if (!rootHandle) {
-    return std::nullopt;
-  }
+  return document.withReadAccess([&document, documentSourceOffset](DocumentReadAccess&) {
+    EntityHandle rootHandle = document.svgElement().entityHandle();
+    if (!rootHandle) {
+      return std::optional<SVGStyleRuleAtSourceOffset>();
+    }
 
-  std::optional<components::StyleRuleAtSourceOffset> rule =
-      components::StyleSystem().findStyleRuleAtSourceOffset(*rootHandle.registry(),
-                                                            documentSourceOffset);
-  if (!rule.has_value()) {
-    return std::nullopt;
-  }
+    std::optional<components::StyleRuleAtSourceOffset> rule =
+        components::StyleSystem().findStyleRuleAtSourceOffset(*rootHandle.registry(),
+                                                              documentSourceOffset);
+    if (!rule.has_value()) {
+      return std::optional<SVGStyleRuleAtSourceOffset>();
+    }
 
-  return ToPublicSourceRule(*rule);
+    return std::optional<SVGStyleRuleAtSourceOffset>(ToPublicSourceRule(*rule));
+  });
 }
 
 }  // namespace donner::svg

--- a/donner/svg/SVGStyleQuery.h
+++ b/donner/svg/SVGStyleQuery.h
@@ -7,6 +7,8 @@
 
 #include "donner/base/EcsRegistry.h"
 #include "donner/base/FileOffset.h"
+#include "donner/css/Declaration.h"
+#include "donner/css/Specificity.h"
 
 namespace donner::svg {
 
@@ -18,6 +20,7 @@ struct SVGMatchedStyleRule {
   Entity stylesheetEntity = entt::null;  ///< Entity carrying the matched stylesheet.
   std::size_t ruleIndex = 0;             ///< Index of the matched rule within the stylesheet.
   std::size_t selectorEntryIndex = 0;    ///< Index of the matched selector-list entry.
+  css::Specificity specificity;          ///< Selector specificity for this match.
   bool isUserAgentStylesheet = false;    ///< True when this came from the built-in UA stylesheet.
   std::optional<SourceRange> ruleSourceRange;        ///< Matched rule range in SVG source.
   std::optional<SourceRange> selectorSourceRange;    ///< Matched selector branch in SVG source.
@@ -25,6 +28,22 @@ struct SVGMatchedStyleRule {
 
   /// Equality operator.
   bool operator==(const SVGMatchedStyleRule& other) const = default;
+};
+
+/// Source-backed declaration within a stylesheet rule.
+struct SVGStylesheetDeclaration {
+  std::size_t declarationIndex = 0;                   ///< Index within the rule.
+  css::Declaration declaration;                       ///< Parsed CSS declaration.
+  std::optional<SourceRange> declarationSourceRange;  ///< Declaration range in SVG source.
+};
+
+/// Source-backed author stylesheet rule in a document.
+struct SVGStylesheetRule {
+  Entity stylesheetEntity = entt::null;                ///< Entity carrying the stylesheet.
+  std::size_t ruleIndex = 0;                           ///< Index within the stylesheet.
+  std::optional<SourceRange> ruleSourceRange;          ///< Rule range in SVG source.
+  std::optional<SourceRange> selectorSourceRange;      ///< Selector range in SVG source.
+  std::vector<SVGStylesheetDeclaration> declarations;  ///< Rule declarations.
 };
 
 /// Stylesheet rule found at a document source offset.
@@ -46,6 +65,12 @@ struct SVGStyleRuleAtSourceOffset {
 /// @param element Element to inspect.
 /// @return Matched stylesheet rules in cascade scan order.
 std::vector<SVGMatchedStyleRule> CollectMatchedStyleRules(const SVGElement& element);
+
+/// Collect source-backed author stylesheet rules in \p document.
+///
+/// @param document SVG document to inspect.
+/// @return Source-backed stylesheet rules in document scan order.
+std::vector<SVGStylesheetRule> CollectStylesheetRules(const SVGDocument& document);
 
 /// Find the author stylesheet rule at \p documentSourceOffset.
 ///


### PR DESCRIPTION
## Summary

- Adds dynamic rope-based reference connectors in the text editor, including hover/click behavior and physics tuning.
- Updates source focus, style chips, selector/reference routing, and pen-tool insertion behavior.
- Rebases the work on latest `origin/main` and guards audited editor DOM access paths for `ConcurrentDom`.

## Root Cause / Notes

The latest crash came from editor overlay and selection helpers reading raw SVG/ECS state while the document was in `ThreadingMode::ConcurrentDom`. The fix wraps overlay geometry capture, selection bounds snapshots, source selection scans, style annotation scans, focus reference summaries, and sidebar snapshots in the appropriate scoped document access guards.

I pushed this to a fresh branch, `codex/dynamic-rope-reference-connectors`, instead of overwriting the divergent remote `design-0039-text-editor-focus-flash` branch.

## Validation

- `bazel test //donner/editor/tests:focus_view_tests //donner/editor/tests:overlay_renderer_tests //donner/editor/tests:selection_aabb_tests //donner/editor/tests:source_selection_tests //donner/editor/tests:style_source_annotations_tests //donner/editor/tests:sidebar_presenter_tests`
- `bazel build //donner/editor:editor`
- `git diff --check`