### PR TITLE
ci: route macOS lane to self-hosted runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,10 +20,10 @@ permissions:
 # are retried to survive transient GitHub/registry outages. Build/test steps
 # are NOT retried -- a real test failure should surface immediately.
 
-# Self-hosted Linux runner gate (repo Settings -> Variables). Setting
-# SELFHOSTED_LINUX_RUNNER to "true" routes the operator's own Linux runs onto
-# the homelab ARM64 runner on event-horizon and skips the matching
-# GitHub-hosted lane; everyone else stays GitHub-hosted. Gated on BOTH
+# Self-hosted runner gates (repo Settings -> Variables). Setting
+# SELFHOSTED_LINUX_RUNNER / SELFHOSTED_MACOS_RUNNER to "true" routes the
+# operator's own matching OS lane onto the homelab ARM64 runner and skips the
+# matching GitHub-hosted lane; everyone else stays GitHub-hosted. Gated on BOTH
 # github.actor and github.triggering_actor == jwmcglynn so that no collaborator
 # push -- and no rerun of the operator's run by someone else -- can execute on
 # the runner or poison the shared LAN Bazel cache. Unset is a no-op: behavior
@@ -392,7 +392,7 @@ jobs:
   macos:
     runs-on: macos-15
     needs: [gatekeeper, determine-targets]
-    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') }}
+    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') && (vars.SELFHOSTED_MACOS_RUNNER != 'true' || github.actor != 'jwmcglynn' || github.triggering_actor != 'jwmcglynn') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -437,6 +437,58 @@ jobs:
             echo "${{ needs.determine-targets.outputs.affected }}"
           fi)
           bazelisk test --config=ci --test_output=errors $TARGETS
+        # Fuzzer regression suite runs in `.github/workflows/fuzz.yml` on a
+        # nightly cron so it doesn't gate every main push. PRs touching
+        # fuzzer code re-trigger that workflow via path filter.
+
+
+  # Operator's ARM64 macOS runs on the deep-thought self-hosted runner.
+  # Replaces `macos` for operator runs. The host pre-provisions Bazelisk,
+  # Homebrew llvm@19, and Xcode Command Line Tools.
+  macos-self-hosted:
+    runs-on: [self-hosted, macOS, ARM64, deep-thought]
+    needs: [gatekeeper, determine-targets]
+    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') && vars.SELFHOSTED_MACOS_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
+    env:
+      BAZEL_MACOS_CACHE_FLAGS: "--remote_cache=grpc://192.168.1.63:9092 --remote_upload_local_results=true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Prepare self-hosted macOS toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "/Users/jwm/bin" >> "$GITHUB_PATH"
+          echo "/opt/homebrew/opt/llvm@19/bin" >> "$GITHUB_PATH"
+          test -x /Users/jwm/bin/bazelisk
+          test -x /Users/jwm/bin/bazel
+          test -x /opt/homebrew/opt/llvm@19/bin/clang-tidy
+
+      - name: Build
+        shell: bash
+        run: |
+          set -euo pipefail
+          TARGETS=$(if [[ "${{ needs.determine-targets.outputs.fallback }}" == "true" ]]; then
+            echo "//..."
+          else
+            echo "${{ needs.determine-targets.outputs.affected }}"
+          fi)
+          bazelisk build --config=ci $BAZEL_MACOS_CACHE_FLAGS $TARGETS
+
+      - name: Test
+        shell: bash
+        run: |
+          set -euo pipefail
+          TARGETS=$(if [[ "${{ needs.determine-targets.outputs.fallback }}" == "true" ]]; then
+            echo "//..."
+          else
+            echo "${{ needs.determine-targets.outputs.affected }}"
+          fi)
+          bazelisk test --config=ci --test_output=errors \
+            $BAZEL_MACOS_CACHE_FLAGS $TARGETS
         # Fuzzer regression suite runs in `.github/workflows/fuzz.yml` on a
         # nightly cron so it doesn't gate every main push. PRs touching
         # fuzzer code re-trigger that workflow via path filter.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -470,10 +470,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "/Users/jwm/bin" >> "$GITHUB_PATH"
+          echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
           echo "/opt/homebrew/opt/llvm@19/bin" >> "$GITHUB_PATH"
-          test -x /Users/jwm/bin/bazelisk
-          test -x /Users/jwm/bin/bazel
+          test -x /opt/homebrew/bin/bazelisk
+          test -x /opt/homebrew/bin/bazel
           test -x /opt/homebrew/opt/llvm@19/bin/clang-tidy
 
       - name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -393,6 +393,11 @@ jobs:
     runs-on: macos-15
     needs: [gatekeeper, determine-targets]
     if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') && (vars.SELFHOSTED_MACOS_RUNNER != 'true' || github.actor != 'jwmcglynn' || github.triggering_actor != 'jwmcglynn') }}
+    env:
+      # Xcode's libc++ marks std::format floating-point support as macOS 13.3+.
+      # Set the CI deployment target explicitly so hosted and self-hosted macOS
+      # compile the same target instead of inheriting host defaults.
+      BAZEL_MACOS_BUILD_FLAGS: "--macos_minimum_os=13.3"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -425,7 +430,7 @@ jobs:
           else
             echo "${{ needs.determine-targets.outputs.affected }}"
           fi)
-          bazelisk build --config=ci $TARGETS
+          bazelisk build --config=ci $BAZEL_MACOS_BUILD_FLAGS $TARGETS
 
       - name: Test
         shell: bash
@@ -436,7 +441,8 @@ jobs:
           else
             echo "${{ needs.determine-targets.outputs.affected }}"
           fi)
-          bazelisk test --config=ci --test_output=errors $TARGETS
+          bazelisk test --config=ci --test_output=errors \
+            $BAZEL_MACOS_BUILD_FLAGS $TARGETS
         # Fuzzer regression suite runs in `.github/workflows/fuzz.yml` on a
         # nightly cron so it doesn't gate every main push. PRs touching
         # fuzzer code re-trigger that workflow via path filter.
@@ -450,7 +456,10 @@ jobs:
     needs: [gatekeeper, determine-targets]
     if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') && vars.SELFHOSTED_MACOS_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
     env:
-      BAZEL_MACOS_CACHE_FLAGS: "--remote_cache=grpc://192.168.1.63:9092 --remote_upload_local_results=true"
+      # The runner host has an operator ~/.bazelrc for interactive RE/cache work.
+      # The invocations below use --nohome_rc so CI matches GitHub-hosted macOS
+      # and only picks up cache settings declared in this workflow.
+      BAZEL_MACOS_BUILD_FLAGS: "--macos_minimum_os=13.3 --remote_cache=grpc://192.168.1.63:9092 --remote_upload_local_results=true"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -476,7 +485,7 @@ jobs:
           else
             echo "${{ needs.determine-targets.outputs.affected }}"
           fi)
-          bazelisk build --config=ci $BAZEL_MACOS_CACHE_FLAGS $TARGETS
+          bazelisk --nohome_rc build --config=ci $BAZEL_MACOS_BUILD_FLAGS $TARGETS
 
       - name: Test
         shell: bash
@@ -487,8 +496,8 @@ jobs:
           else
             echo "${{ needs.determine-targets.outputs.affected }}"
           fi)
-          bazelisk test --config=ci --test_output=errors \
-            $BAZEL_MACOS_CACHE_FLAGS $TARGETS
+          bazelisk --nohome_rc test --config=ci --test_output=errors \
+            $BAZEL_MACOS_BUILD_FLAGS $TARGETS
         # Fuzzer regression suite runs in `.github/workflows/fuzz.yml` on a
         # nightly cron so it doesn't gate every main push. PRs touching
         # fuzzer code re-trigger that workflow via path filter.

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -12,6 +12,22 @@ function print_help() {
   exit 0
 }
 
+function file_mtime() {
+  local file="$1"
+
+  if stat -c %Y "$file" >/dev/null 2>&1; then
+    stat -c %Y "$file"
+    return
+  fi
+
+  if stat -f %m "$file" >/dev/null 2>&1; then
+    stat -f %m "$file"
+    return
+  fi
+
+  echo 0
+}
+
 TARGETS=()
 
 # Check for --quiet option
@@ -88,7 +104,7 @@ fi
   # early exit).
   BEFORE_TS=0
   if [ -f "$COVERAGE_REPORT" ]; then
-    BEFORE_TS=$(stat -f %m "$COVERAGE_REPORT" 2>/dev/null || stat -c %Y "$COVERAGE_REPORT" 2>/dev/null || echo 0)
+    BEFORE_TS=$(file_mtime "$COVERAGE_REPORT")
   fi
 
   if [ "$QUIET" = true ]; then
@@ -105,7 +121,7 @@ fi
     exit 1
   fi
 
-  AFTER_TS=$(stat -f %m "$COVERAGE_REPORT" 2>/dev/null || stat -c %Y "$COVERAGE_REPORT" 2>/dev/null || echo 0)
+  AFTER_TS=$(file_mtime "$COVERAGE_REPORT")
   if [ "$AFTER_TS" -le "$BEFORE_TS" ]; then
     echo "ERROR: Coverage report was not updated (stale data from a previous run)"
     exit 1


### PR DESCRIPTION
## Summary
Adds the macOS half of the self-hosted CI rollout:
- keeps GitHub-hosted `macos` as the fallback for everyone else
- adds `macos-self-hosted` on `donner-runner-macos-01` / `deep-thought`
- gates self-hosted execution on `SELFHOSTED_MACOS_RUNNER == 'true'` plus both `github.actor` and `github.triggering_actor` being `jwmcglynn`

The self-hosted job runs the same Bazel build/test target surface as hosted macOS. The host pre-provisions Bazelisk, Xcode, and Homebrew `llvm@19`; the workflow verifies Homebrew paths (`/opt/homebrew/bin`, `/opt/homebrew/opt/llvm@19/bin`) so it is not coupled to the operator home directory.

Both hosted and self-hosted macOS now pass `--macos_minimum_os=13.3` explicitly, which matches Donner's C++20 `std::format`/libc++ requirements under the current Xcode SDK. The self-hosted job also runs Bazel with `--nohome_rc` so it does not inherit `deep-thought`'s interactive RE/cache `.bazelrc`; CI only uses the flags declared in this workflow.

The self-hosted macOS job uses the same stable `bazel-cache1` gRPC endpoint used by the Linux runners. During bring-up, `bazel-cache1` was raised to 4 GiB, and the Linux runner microVMs were raised to 16 GiB each under a 48 GiB `gha-host1` cap so Linux build and coverage can run concurrently without the coverage OOM seen on 8 GiB guests.

Also fixes `tools/coverage.sh` timestamp detection so GNU `stat -f` output is not treated as an integer on Linux. This was harmless in the successful path but noisy and brittle after interrupted coverage runs.

## Security notes
- Self-hosted checkout uses `persist-credentials: false`.
- Hosted and self-hosted macOS jobs use complementary gates so only one macOS lane runs for a non-skipped workflow.
- The self-hosted runner still only receives operator-authored/operator-triggered runs; everyone else stays GitHub-hosted.
- `--nohome_rc` prevents accidental use of operator-local Bazel credentials or RE config in CI.
- The workflow no longer references `/Users/jwm/bin`, so the runner can move to a dedicated non-admin macOS user.

## Test plan
- [x] Workflow YAML parses locally.
- [x] `git diff --check` passes.
- [x] GitHub reports `donner-runner-macos-01` online and idle.
- [x] `deep-thought` has Homebrew Bazelisk and `llvm@19` clang-tidy present.
- [x] `deep-thought` can reach `bazel-cache1` at `192.168.1.63:9092`.
- [x] Manual macOS smoke: `//donner/base:base` builds with `--nohome_rc --macos_minimum_os=13.3` and the remote cache.
- [x] PR CI: `macos-self-hosted` ran on `donner-runner-macos-01`; hosted `macos` skipped.
- [x] PR CI: Linux/Lint/CodeQL/CMake/Coverage are green at `763a31a80706a8b23648d2a1f4bc8524c2666727`.