### PR TITLE
editor: drop AsyncRenderer threading-mode flip-back (#596 follow-up)

### DIFF
--- a/donner/editor/AsyncRenderer.cc
+++ b/donner/editor/AsyncRenderer.cc
@@ -49,23 +49,6 @@ RenderResult::CompositedPreview BuildFullCanvasCompositedPreview(
   };
 }
 
-/// Restores a document's threading mode to SingleThreaded when a worker iteration exits.
-///
-/// The async worker flips the (UI-owned, normally SingleThreaded) document into ConcurrentDom for
-/// the duration of a render so it can hold an explicit \ref donner::svg::DocumentWriteAccess guard.
-/// This restores the prior mode on every exit path. Declare it *before* the write-access optional
-/// so the write access is released first.
-struct ScopedThreadingModeRestore {
-  svg::SVGDocument* document = nullptr;
-  bool restore = false;
-
-  ~ScopedThreadingModeRestore() {
-    if (restore && document != nullptr) {
-      document->setThreadingMode(svg::ThreadingMode::SingleThreaded);
-    }
-  }
-};
-
 }  // namespace
 
 PresentationSnapshotPlan ChoosePresentationSnapshotPlan(bool hasCompositedPreview,
@@ -280,29 +263,18 @@ void AsyncRenderer::workerLoop() {
 
     // §concurrent-dom: serialize this worker render against UI-thread DOM reads. The lease shares
     // the live registry (it does not snapshot), and the worker cannot touch the document in
-    // SingleThreaded mode (owner-thread assert), so flip the normally-UI-owned document into
-    // ConcurrentDom and hold a write-access guard across the document-reading render work. The
-    // access is released via `releaseDocumentAccess()` *before* every `mutex_` section below to
-    // avoid a lock-order inversion against UI threads that read the DOM while holding `mutex_`.
-    // `restoreThreadingMode` is declared before `documentAccess` so the write access is released
-    // first, and restores the prior mode on any remaining exit path.
-    const bool restoreSingleThreadedMode =
-        requestDocument.threadingMode() == svg::ThreadingMode::SingleThreaded;
-    if (restoreSingleThreadedMode) {
+    // SingleThreaded mode (owner-thread assert). The document is flipped to ConcurrentDom on first
+    // render and stays there for the editor's lifetime — UI-thread reads are responsible for
+    // holding their own access guard (`withReadAccess` / a scoped `DocumentReadAccess`) where they
+    // touch the live document. The worker holds a write guard across the document-reading render
+    // work and releases it via `releaseDocumentAccess()` before every `mutex_` section below to
+    // avoid a lock-order inversion against UI threads holding `mutex_` while reading the DOM.
+    if (requestDocument.threadingMode() != svg::ThreadingMode::ConcurrentDom) {
       requestDocument.setThreadingMode(svg::ThreadingMode::ConcurrentDom);
     }
-    const ScopedThreadingModeRestore restoreThreadingMode{&requestDocument,
-                                                          restoreSingleThreadedMode};
     std::optional<svg::DocumentWriteAccess> documentAccess;
-    if (requestDocument.threadingMode() == svg::ThreadingMode::ConcurrentDom) {
-      documentAccess.emplace(requestDocument.writeAccess());
-    }
-    const auto releaseDocumentAccess = [&]() {
-      documentAccess.reset();
-      if (restoreSingleThreadedMode) {
-        requestDocument.setThreadingMode(svg::ThreadingMode::SingleThreaded);
-      }
-    };
+    documentAccess.emplace(requestDocument.writeAccess());
+    const auto releaseDocumentAccess = [&]() { documentAccess.reset(); };
 
     // Compositor lifecycle is split into two independent decisions:
     //

--- a/donner/editor/FocusView.cc
+++ b/donner/editor/FocusView.cc
@@ -497,7 +497,7 @@ bool AddFocusElement(const svg::SVGElement& element, FocusElementCollection* res
     return false;
   }
 
-  const Entity entity = element.entityHandle().entity();
+  const Entity entity = element.unsafeEntityHandle().entity();
   if (std::ranges::find(*visited, entity) != visited->end()) {
     return false;
   }
@@ -513,10 +513,10 @@ void AddElementReferenceLink(std::size_t fromOffset, const svg::SVGElement& refe
     return;
   }
 
-  const Entity referencedEntity = referenced.entityHandle().entity();
+  const Entity referencedEntity = referenced.unsafeEntityHandle().entity();
   const auto it = std::ranges::find_if(result->links, [&](const ElementReferenceLink& link) {
     return link.fromOffset == fromOffset &&
-           link.referenced.entityHandle().entity() == referencedEntity &&
+           link.referenced.unsafeEntityHandle().entity() == referencedEntity &&
            link.reverseReference == reverseReference;
   });
   if (it == result->links.end()) {
@@ -567,9 +567,9 @@ bool AddUniqueElement(const svg::SVGElement& element, std::vector<svg::SVGElemen
     return false;
   }
 
-  const Entity entity = element.entityHandle().entity();
+  const Entity entity = element.unsafeEntityHandle().entity();
   const auto it = std::ranges::find_if(*elements, [entity](const svg::SVGElement& existing) {
-    return existing.entityHandle().entity() == entity;
+    return existing.unsafeEntityHandle().entity() == entity;
   });
   if (it != elements->end()) {
     return false;
@@ -624,7 +624,7 @@ void MarkReverseExpandable(const svg::SVGElement& element,
     return;
   }
 
-  const Entity entity = element.entityHandle().entity();
+  const Entity entity = element.unsafeEntityHandle().entity();
   if (std::ranges::find(*reverseExpandableEntities, entity) == reverseExpandableEntities->end()) {
     reverseExpandableEntities->push_back(entity);
   }
@@ -639,7 +639,7 @@ void MarkReverseExpandableIfResource(const svg::SVGElement& element,
 
 bool CanReverseExpand(const svg::SVGElement& element,
                       const std::vector<Entity>& reverseExpandableEntities) {
-  const Entity entity = element.entityHandle().entity();
+  const Entity entity = element.unsafeEntityHandle().entity();
   return std::ranges::find(reverseExpandableEntities, entity) != reverseExpandableEntities.end();
 }
 
@@ -916,7 +916,7 @@ FocusElementCollection CollectFocusElements(const svg::SVGDocument& document,
   for (const svg::SVGElement& element : initialElements) {
     AddFocusElement(element, &result, &visited);
     if (IsGroupElement(element)) {
-      selectedGroupEntities.push_back(element.entityHandle().entity());
+      selectedGroupEntities.push_back(element.unsafeEntityHandle().entity());
     }
     MarkReverseExpandableIfResource(element, &reverseExpandableEntities);
   }
@@ -924,7 +924,7 @@ FocusElementCollection CollectFocusElements(const svg::SVGDocument& document,
   const svg::SVGElement root = document.svgElement();
   for (std::size_t i = 0; i < result.elements.size(); ++i) {
     const svg::SVGElement current = result.elements[i];
-    const Entity currentEntity = current.entityHandle().entity();
+    const Entity currentEntity = current.unsafeEntityHandle().entity();
     const bool currentIsSelectedGroup =
         std::ranges::find(selectedGroupEntities, currentEntity) != selectedGroupEntities.end();
     const FocusLinkSourceMode linkSourceMode =
@@ -1150,7 +1150,7 @@ FocusPartition ComputeFocusPartition(const svg::SVGDocument& document,
     }
 
     initialElements.push_back(selected);
-    selectedEntities.push_back(selected.entityHandle().entity());
+    selectedEntities.push_back(selected.unsafeEntityHandle().entity());
   }
 
   FocusPartition partition;
@@ -1160,7 +1160,7 @@ FocusPartition ComputeFocusPartition(const svg::SVGDocument& document,
   for (std::size_t i = 0; i < focusElements.elements.size(); ++i) {
     std::optional<ByteRange> elementRange = NodeRange(source, focusElements.elements[i]);
     const bool selectedElement =
-        std::ranges::find(selectedEntities, focusElements.elements[i].entityHandle().entity()) !=
+        std::ranges::find(selectedEntities, focusElements.elements[i].unsafeEntityHandle().entity()) !=
         selectedEntities.end();
     if (elementRange.has_value()) {
       (selectedElement ? partition.fullColor : partition.referenceColor)
@@ -1333,7 +1333,7 @@ ReferenceHighlightSummary ComputeReferenceHighlightSummary(
                                       &summary.referencingElements,
                                       std::numeric_limits<std::size_t>::max());
     std::erase_if(summary.referencingElements, [&](const svg::SVGElement& element) {
-      return element.entityHandle().entity() == selected.entityHandle().entity();
+      return element.unsafeEntityHandle().entity() == selected.unsafeEntityHandle().entity();
     });
   }
 

--- a/donner/editor/StyleSourceAnnotations.cc
+++ b/donner/editor/StyleSourceAnnotations.cc
@@ -500,7 +500,7 @@ void AddReferenceResourceContributions(
     AddContribution(std::move(contribution),
                     ContributionKey{
                         .kind = StyleContributionKind::ReferenceResourceElement,
-                        .elementEntity = element.entityHandle().entity(),
+                        .elementEntity = element.unsafeEntityHandle().entity(),
                         .propertyName = tagName,
                     },
                     annotations, contributionIndexByKey);
@@ -545,7 +545,7 @@ void AddElementLocalContributions(
     AddContribution(std::move(contribution),
                     ContributionKey{
                         .kind = StyleContributionKind::PresentationAttribute,
-                        .elementEntity = element.entityHandle().entity(),
+                        .elementEntity = element.unsafeEntityHandle().entity(),
                         .propertyName = propertyName,
                     },
                     annotations, contributionIndexByKey);
@@ -574,7 +574,7 @@ void AddElementLocalContributions(
     AddContribution(std::move(contribution),
                     ContributionKey{
                         .kind = StyleContributionKind::InlineStyleDeclaration,
-                        .elementEntity = element.entityHandle().entity(),
+                        .elementEntity = element.unsafeEntityHandle().entity(),
                         .declarationIndex = declarationIndex,
                         .propertyName = std::string(declaration.name),
                     },
@@ -656,7 +656,7 @@ void AddLocalCascadeEntries(const svg::SVGElement& element,
     std::optional<RcString> attrValue = xmlNode->getAttribute(attrName);
     auto contributionIter = contributionIndexByKey.find(ContributionKey{
         .kind = StyleContributionKind::PresentationAttribute,
-        .elementEntity = element.entityHandle().entity(),
+        .elementEntity = element.unsafeEntityHandle().entity(),
         .propertyName = propertyName,
     });
     if (!attrValue.has_value() || contributionIter == contributionIndexByKey.end()) {
@@ -681,7 +681,7 @@ void AddLocalCascadeEntries(const svg::SVGElement& element,
     const css::Declaration& declaration = declarations[declarationIndex];
     auto contributionIter = contributionIndexByKey.find(ContributionKey{
         .kind = StyleContributionKind::InlineStyleDeclaration,
-        .elementEntity = element.entityHandle().entity(),
+        .elementEntity = element.unsafeEntityHandle().entity(),
         .declarationIndex = declarationIndex,
         .propertyName = std::string(declaration.name),
     });

--- a/donner/editor/tests/AsyncRenderer_tests.cc
+++ b/donner/editor/tests/AsyncRenderer_tests.cc
@@ -270,8 +270,8 @@ TEST(AsyncRendererTest, PendingDemotePreviousDragTargetKeepsDragTranslationInTil
   auto elemB = document.querySelector("#b");
   ASSERT_TRUE(elemA.has_value());
   ASSERT_TRUE(elemB.has_value());
-  const Entity entityA = elemA->entityHandle().entity();
-  const Entity entityB = elemB->entityHandle().entity();
+  const Entity entityA = elemA->unsafeEntityHandle().entity();
+  const Entity entityB = elemB->unsafeEntityHandle().entity();
 
   svg::Renderer renderer;
   AsyncRenderer asyncRenderer;
@@ -372,7 +372,7 @@ TEST(AsyncRendererTest, DisplayNoneSelectionDropsStaleCompositedLayerImmediately
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity targetEntity = target->entityHandle().entity();
+  const Entity targetEntity = target->unsafeEntityHandle().entity();
 
   svg::Renderer renderer;
   AsyncRenderer asyncRenderer;
@@ -453,8 +453,8 @@ TEST(AsyncRendererTest, DisplayNoneSelectionDoesNotLeaveStaleBackgroundPixelsWhe
   auto next = document.querySelector("#next");
   ASSERT_TRUE(hiddenSoon.has_value());
   ASSERT_TRUE(next.has_value());
-  const Entity hiddenSoonEntity = hiddenSoon->entityHandle().entity();
-  const Entity nextEntity = next->entityHandle().entity();
+  const Entity hiddenSoonEntity = hiddenSoon->unsafeEntityHandle().entity();
+  const Entity nextEntity = next->unsafeEntityHandle().entity();
 
   svg::Renderer renderer;
   AsyncRenderer asyncRenderer;
@@ -611,15 +611,15 @@ TEST(AsyncRendererTest, RequestRenderDuringBusySignalsCancellationAndPicksUpNewR
   {
     RenderRequest request(renderer, document);
     request.version = 1;
-    request.selectedEntity = elemA->entityHandle().entity();
-    request.dragPreview = RenderRequest::DragPreview{.entity = elemA->entityHandle().entity()};
+    request.selectedEntity = elemA->unsafeEntityHandle().entity();
+    request.dragPreview = RenderRequest::DragPreview{.entity = elemA->unsafeEntityHandle().entity()};
     asyncRenderer.requestRender(request);
   }
   {
     RenderRequest request(renderer, document);
     request.version = 2;
-    request.selectedEntity = elemB->entityHandle().entity();
-    request.dragPreview = RenderRequest::DragPreview{.entity = elemB->entityHandle().entity()};
+    request.selectedEntity = elemB->unsafeEntityHandle().entity();
+    request.dragPreview = RenderRequest::DragPreview{.entity = elemB->unsafeEntityHandle().entity()};
     asyncRenderer.requestRender(request);
   }
 
@@ -638,7 +638,7 @@ TEST(AsyncRendererTest, RequestRenderDuringBusySignalsCancellationAndPicksUpNewR
   // committed.
   EXPECT_EQ(result->version, 2u);
   ASSERT_TRUE(result->compositedPreview.has_value());
-  EXPECT_EQ(result->compositedPreview->entity, elemB->entityHandle().entity());
+  EXPECT_EQ(result->compositedPreview->entity, elemB->unsafeEntityHandle().entity());
 
   // On a micro-document like this two-rect scene the first render
   // may complete before the second `requestRender` lands. The
@@ -676,7 +676,7 @@ TEST(AsyncRendererTest, CancelInFlightDropsResultAndReturnsWorkerToIdle) {
   RenderRequest request(renderer, document);
   request.version = 1;
   request.documentGeneration = 1;
-  request.selectedEntity = target->entityHandle().entity();
+  request.selectedEntity = target->unsafeEntityHandle().entity();
   asyncRenderer.requestRender(request);
   EXPECT_TRUE(asyncRenderer.isBusy());
 
@@ -716,7 +716,7 @@ TEST(AsyncRendererTest, CancelInFlightFollowedByRequestRenderRunsCleanly) {
   RenderRequest request(renderer, document);
   request.version = 1;
   request.documentGeneration = 1;
-  request.selectedEntity = target->entityHandle().entity();
+  request.selectedEntity = target->unsafeEntityHandle().entity();
 
   asyncRenderer.requestRender(request);
   asyncRenderer.cancelInFlight();
@@ -986,9 +986,9 @@ TEST(AsyncRendererTest, CompositedTilesCarryRasterCanvasSizeForCacheIdentity) {
 
   RenderRequest request(renderer, document);
   request.version = 1;
-  request.selectedEntity = target->entityHandle().entity();
+  request.selectedEntity = target->unsafeEntityHandle().entity();
   request.dragPreview = RenderRequest::DragPreview{
-      .entity = target->entityHandle().entity(),
+      .entity = target->unsafeEntityHandle().entity(),
       .interactionKind = svg::compositor::InteractionHint::Selection,
   };
   asyncRenderer.requestRender(request);
@@ -1044,9 +1044,9 @@ TEST(AsyncRendererTest, CompositingContextDescendantsProduceFullCanvasComposited
 
     RenderRequest request(renderer, document);
     request.version = 1;
-    request.selectedEntity = target->entityHandle().entity();
+    request.selectedEntity = target->unsafeEntityHandle().entity();
     request.dragPreview = RenderRequest::DragPreview{
-        .entity = target->entityHandle().entity(),
+        .entity = target->unsafeEntityHandle().entity(),
         .interactionKind = svg::compositor::InteractionHint::ActiveDrag,
         .translation = Vector2d(3.0, 2.0),
     };
@@ -1074,10 +1074,10 @@ TEST(AsyncRendererTest, CompositingContextDescendantsProduceFullCanvasComposited
     if (tile.textureSnapshot != nullptr) {
       EXPECT_EQ(tile.textureSnapshot->dimensions(), tile.bitmapDimsPx) << svgBody;
     }
-    EXPECT_EQ(result->compositedPreview->entity, target->entityHandle().entity()) << svgBody;
+    EXPECT_EQ(result->compositedPreview->entity, target->unsafeEntityHandle().entity()) << svgBody;
     ASSERT_TRUE(result->compositedPreview->representedDragPreview.has_value()) << svgBody;
     EXPECT_EQ(result->compositedPreview->representedDragPreview->entity,
-              target->entityHandle().entity())
+              target->unsafeEntityHandle().entity())
         << svgBody;
     EXPECT_EQ(result->compositedPreview->representedDragPreview->translation, Vector2d(3.0, 2.0))
         << svgBody;
@@ -1202,7 +1202,7 @@ TEST(AsyncRendererTest, ActiveDragCanvasResizePublishesFreshFinalOnly) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   svg::Renderer renderer;
   AsyncRenderer asyncRenderer;
@@ -1400,7 +1400,7 @@ TEST(AsyncRendererTest, ActiveDragStartDoesNotAdvanceUnchangedTileGenerations) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   svg::Renderer renderer;
   AsyncRenderer asyncRenderer;
@@ -1537,8 +1537,8 @@ TEST(AsyncRendererE2ETest, DragOThenSelectEDoesNotAdvanceExistingLayerGeneration
   auto ePolygon = app.document().document().querySelector("#Donner polygon.cls-85");
   ASSERT_TRUE(oPath.has_value());
   ASSERT_TRUE(ePolygon.has_value());
-  const Entity oEntity = oPath->entityHandle().entity();
-  const Entity eEntity = ePolygon->entityHandle().entity();
+  const Entity oEntity = oPath->unsafeEntityHandle().entity();
+  const Entity eEntity = ePolygon->unsafeEntityHandle().entity();
 
   SelectTool selectTool;
   svg::Renderer renderer;
@@ -1562,7 +1562,7 @@ TEST(AsyncRendererE2ETest, DragOThenSelectEDoesNotAdvanceExistingLayerGeneration
     request.structuralRemap = app.document().consumePendingStructuralRemap();
     if (app.selectedElement().has_value() &&
         app.selectedElement()->isa<svg::SVGGraphicsElement>()) {
-      request.selectedEntity = app.selectedElement()->entityHandle().entity();
+      request.selectedEntity = app.selectedElement()->unsafeEntityHandle().entity();
     }
     if (auto preview = selectTool.activeDragPreview(); preview.has_value()) {
       request.dragPreview = RenderRequest::DragPreview{
@@ -1654,7 +1654,7 @@ TEST(AsyncRendererE2ETest, DragOThenSelectEDoesNotAdvanceExistingLayerGeneration
   const Vector2d oDrag(354.0, 394.0);
   selectTool.onMouseDown(app, oStart, MouseModifiers{});
   ASSERT_TRUE(app.selectedElement().has_value());
-  ASSERT_EQ(app.selectedElement()->entityHandle().entity(), oEntity);
+  ASSERT_EQ(app.selectedElement()->unsafeEntityHandle().entity(), oEntity);
   ASSERT_TRUE(selectTool.activeDragPreview().has_value());
   ASSERT_TRUE(postRequest().has_value());
 
@@ -1681,12 +1681,12 @@ TEST(AsyncRendererE2ETest, DragOThenSelectEDoesNotAdvanceExistingLayerGeneration
   const Vector2d eClick(568.0, 315.0);
   selectTool.onMouseDown(app, eClick, MouseModifiers{});
   ASSERT_TRUE(app.selectedElement().has_value());
-  ASSERT_EQ(app.selectedElement()->entityHandle().entity(), eEntity);
+  ASSERT_EQ(app.selectedElement()->unsafeEntityHandle().entity(), eEntity);
   ASSERT_TRUE(selectTool.activeDragPreview().has_value());
 
   auto ePolygonAfterWriteback = app.document().document().querySelector("#Donner polygon.cls-85");
   ASSERT_TRUE(ePolygonAfterWriteback.has_value());
-  const Entity eEntityAfterWriteback = ePolygonAfterWriteback->entityHandle().entity();
+  const Entity eEntityAfterWriteback = ePolygonAfterWriteback->unsafeEntityHandle().entity();
   ASSERT_EQ(eEntityAfterWriteback, eEntity);
   ASSERT_TRUE(postRequest().has_value());
 
@@ -1723,7 +1723,7 @@ TEST(AsyncRendererE2ETest, BackgroundStickerDragPresentsLiveDeltaFromStaleCache)
     backgroundPath = app.document().document().querySelector("#Background_sticker path");
   }
   ASSERT_TRUE(backgroundPath.has_value());
-  const Entity backgroundEntity = backgroundPath->entityHandle().entity();
+  const Entity backgroundEntity = backgroundPath->unsafeEntityHandle().entity();
   app.setSelection(*backgroundPath);
 
   SelectTool selectTool;
@@ -2998,9 +2998,9 @@ TEST(AsyncRendererE2ETest, StructuralRemapSurvivesSupersededWritebackRequest) {
   RenderRequest initialRequest(renderer, asyncDoc.document());
   initialRequest.version = 1;
   initialRequest.documentGeneration = asyncDoc.documentGeneration();
-  initialRequest.selectedEntity = target->entityHandle().entity();
+  initialRequest.selectedEntity = target->unsafeEntityHandle().entity();
   initialRequest.dragPreview = RenderRequest::DragPreview{
-      .entity = target->entityHandle().entity(),
+      .entity = target->unsafeEntityHandle().entity(),
       .interactionKind = svg::compositor::InteractionHint::Selection,
   };
   asyncRenderer.requestRender(initialRequest);
@@ -3027,9 +3027,9 @@ TEST(AsyncRendererE2ETest, StructuralRemapSurvivesSupersededWritebackRequest) {
   RenderRequest followupRequest(renderer, asyncDoc.document());
   followupRequest.version = 3;
   followupRequest.documentGeneration = asyncDoc.documentGeneration();
-  followupRequest.selectedEntity = targetAfterWriteback->entityHandle().entity();
+  followupRequest.selectedEntity = targetAfterWriteback->unsafeEntityHandle().entity();
   followupRequest.dragPreview = RenderRequest::DragPreview{
-      .entity = targetAfterWriteback->entityHandle().entity(),
+      .entity = targetAfterWriteback->unsafeEntityHandle().entity(),
       .interactionKind = svg::compositor::InteractionHint::ActiveDrag,
   };
   ASSERT_TRUE(followupRequest.structuralRemap.empty());
@@ -3105,9 +3105,9 @@ TEST(AsyncRendererE2ETest, StructuralWritebackDoesNotResizeCanvasAndRerasterFilt
     return std::nullopt;
   };
 
-  postRequest(1, target->entityHandle().entity());
+  postRequest(1, target->unsafeEntityHandle().entity());
   ASSERT_TRUE(waitForResult().has_value());
-  const auto glowGenerationBefore = layerGeneration(glow->entityHandle().entity());
+  const auto glowGenerationBefore = layerGeneration(glow->unsafeEntityHandle().entity());
   ASSERT_TRUE(glowGenerationBefore.has_value()) << "#glow should be a mandatory filter layer";
 
   asyncDoc.applyMutation(
@@ -3126,11 +3126,11 @@ TEST(AsyncRendererE2ETest, StructuralWritebackDoesNotResizeCanvasAndRerasterFilt
   ASSERT_TRUE(targetAfterWriteback.has_value());
   ASSERT_TRUE(glowAfterWriteback.has_value());
 
-  postRequest(2, targetAfterWriteback->entityHandle().entity());
+  postRequest(2, targetAfterWriteback->unsafeEntityHandle().entity());
   ASSERT_TRUE(waitForResult().has_value());
 
   EXPECT_EQ(asyncRenderer.compositorResetCountForTesting(), 0u);
-  const auto glowGenerationAfter = layerGeneration(glowAfterWriteback->entityHandle().entity());
+  const auto glowGenerationAfter = layerGeneration(glowAfterWriteback->unsafeEntityHandle().entity());
   ASSERT_TRUE(glowGenerationAfter.has_value());
   EXPECT_EQ(*glowGenerationAfter, *glowGenerationBefore)
       << "Unchanged mandatory filter layer rerasterized across structural writeback; "
@@ -3314,7 +3314,7 @@ TEST(RenderCoordinatorTest, DisplayNoneSelectionSuppressesPromotedTilePresentati
 
   target->setStyle("display:none");
 
-  EXPECT_EQ(coordinator.suppressedCompositedLayerEntity(app), target->entityHandle().entity())
+  EXPECT_EQ(coordinator.suppressedCompositedLayerEntity(app), target->unsafeEntityHandle().entity())
       << "The live DOM has hidden the selected element, so stale promoted-layer pixels should not "
          "be drawn even while selection chrome remains visible.";
 }
@@ -3329,7 +3329,7 @@ TEST(RenderCoordinatorTest, DisplayNoneSelectionSuppressesPreReparseCachedLayer)
 
   auto target = app.document().document().querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity oldTargetEntity = target->entityHandle().entity();
+  const Entity oldTargetEntity = target->unsafeEntityHandle().entity();
   app.setSelection(*target);
 
   RenderCoordinator coordinator;
@@ -3346,7 +3346,7 @@ TEST(RenderCoordinatorTest, DisplayNoneSelectionSuppressesPreReparseCachedLayer)
   ASSERT_TRUE(app.flushFrame());
 
   ASSERT_TRUE(app.selectedElement().has_value());
-  const Entity newTargetEntity = app.selectedElement()->entityHandle().entity();
+  const Entity newTargetEntity = app.selectedElement()->unsafeEntityHandle().entity();
   ASSERT_NE(oldTargetEntity, newTargetEntity)
       << "This regression covers source-reparse selection remap, where the stale texture still "
          "belongs to the pre-reparse entity.";
@@ -3367,7 +3367,7 @@ TEST(RenderCoordinatorTest, DisplayNoneSelectionKeepsPreReparseSuppressionAfterC
 
   auto target = app.document().document().querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity oldTargetEntity = target->entityHandle().entity();
+  const Entity oldTargetEntity = target->unsafeEntityHandle().entity();
   app.setSelection(*target);
 
   RenderCoordinator coordinator;
@@ -3405,7 +3405,7 @@ TEST(RenderCoordinatorTest, DisplayNoneSuppressionSurvivesSelectingDifferentVisi
   auto next = app.document().document().querySelector("#next");
   ASSERT_TRUE(hiddenSoon.has_value());
   ASSERT_TRUE(next.has_value());
-  const Entity hiddenSoonEntity = hiddenSoon->entityHandle().entity();
+  const Entity hiddenSoonEntity = hiddenSoon->unsafeEntityHandle().entity();
   app.setSelection(*hiddenSoon);
 
   RenderCoordinator coordinator;
@@ -3434,7 +3434,7 @@ TEST(RenderCoordinatorTest, DisplayNoneSuppressionClearsWhenSameElementBecomesVi
 
   auto target = app.document().document().querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity targetEntity = target->entityHandle().entity();
+  const Entity targetEntity = target->unsafeEntityHandle().entity();
   app.setSelection(*target);
 
   RenderCoordinator coordinator;

--- a/donner/editor/tests/EditorLayerStress_tests.cc
+++ b/donner/editor/tests/EditorLayerStress_tests.cc
@@ -145,7 +145,7 @@ std::optional<RenderResult> RequestRenderAndWait(AsyncRenderer& asyncRenderer,
     request.structuralRemap = app.document().consumePendingStructuralRemap();
     if (app.selectedElement().has_value() &&
         app.selectedElement()->isa<svg::SVGGraphicsElement>()) {
-      request.selectedEntity = app.selectedElement()->entityHandle().entity();
+      request.selectedEntity = app.selectedElement()->unsafeEntityHandle().entity();
     }
     if (auto preview = selectTool.activeDragPreview(); preview.has_value()) {
       request.dragPreview = RenderRequest::DragPreview{
@@ -278,7 +278,7 @@ protected:
     request.structuralRemap = app_.document().consumePendingStructuralRemap();
     if (app_.selectedElement().has_value() &&
         app_.selectedElement()->isa<svg::SVGGraphicsElement>()) {
-      request.selectedEntity = app_.selectedElement()->entityHandle().entity();
+      request.selectedEntity = app_.selectedElement()->unsafeEntityHandle().entity();
     }
     if (auto preview = selectTool_.activeDragPreview(); preview.has_value()) {
       request.dragPreview = RenderRequest::DragPreview{

--- a/donner/editor/tests/EditorWindow_tests.cc
+++ b/donner/editor/tests/EditorWindow_tests.cc
@@ -238,7 +238,7 @@ std::optional<RenderResult::CompositedPreview> RenderBlurredGlowCompositedPrevie
     return std::nullopt;
   }
 
-  return RenderCompositedPreview(device, document, glow->entityHandle().entity());
+  return RenderCompositedPreview(device, document, glow->unsafeEntityHandle().entity());
 }
 
 void DrawCompositedTiles(const GlTextureCache& textures, const ImVec2& origin, double zoom) {
@@ -556,7 +556,7 @@ TEST(EditorWindowTest, WgpuPresentsZoomedDonnerSplashFilteredLayerWithoutDarkeni
   std::optional<svg::SVGElement> target = document->querySelector("#Big_lightning_glow");
   ASSERT_TRUE(target.has_value());
   std::optional<RenderResult::CompositedPreview> preview =
-      RenderCompositedPreview(window.geodeDevice(), *document, target->entityHandle().entity());
+      RenderCompositedPreview(window.geodeDevice(), *document, target->unsafeEntityHandle().entity());
   ASSERT_TRUE(preview.has_value());
   ASSERT_GE(preview->tiles.size(), 2u) << "Expected splash background plus selected filter layer";
 

--- a/donner/editor/tests/RnrReplay_tests.cc
+++ b/donner/editor/tests/RnrReplay_tests.cc
@@ -236,7 +236,7 @@ std::optional<RenderResult> RequestRenderAndWait(AsyncRenderer& asyncRenderer,
   request.documentGeneration = app.document().documentGeneration();
   request.structuralRemap = app.document().consumePendingStructuralRemap();
   if (app.selectedElement().has_value() && app.selectedElement()->isa<svg::SVGGraphicsElement>()) {
-    request.selectedEntity = app.selectedElement()->entityHandle().entity();
+    request.selectedEntity = app.selectedElement()->unsafeEntityHandle().entity();
   }
   if (auto preview = selectTool.activeDragPreview(); preview.has_value()) {
     request.dragPreview = RenderRequest::DragPreview{
@@ -601,7 +601,7 @@ protected:
       const auto dragPreview = selectTool.activeDragPreview();
       const Entity prewarmEntity =
           app.selectedElement().has_value() && app.selectedElement()->isa<svg::SVGGraphicsElement>()
-              ? app.selectedElement()->entityHandle().entity()
+              ? app.selectedElement()->unsafeEntityHandle().entity()
               : entt::null;
 
       // Drop stale settling state on selection change. (Lighter than

--- a/donner/editor/tests/SelectTool_tests.cc
+++ b/donner/editor/tests/SelectTool_tests.cc
@@ -1049,7 +1049,7 @@ TEST_F(SelectToolTest, ResizeGestureExposesAffinePreview) {
 
   const auto preview = tool.activeDragPreview();
   ASSERT_TRUE(preview.has_value());
-  EXPECT_EQ(preview->entity, elementById("#target").entityHandle().entity());
+  EXPECT_EQ(preview->entity, elementById("#target").unsafeEntityHandle().entity());
   EXPECT_FALSE(preview->documentFromCachedDocument.isTranslation())
       << "resize preview must carry an affine scale, not just a drag offset";
   const auto resizeGesture = tool.activeGesturePreview();

--- a/donner/editor/tests/StructuredEditingStress_tests.cc
+++ b/donner/editor/tests/StructuredEditingStress_tests.cc
@@ -465,6 +465,10 @@ protected:
     }
 
     const std::string source(app_.document().document().source());
+    // §concurrent-dom: hold a scoped read access for the XML/source inspection below — the call
+    // chain (XMLNode::TryCast → entity resolution → getNodeLocation) hits guarded EntityHandle
+    // accessors that assert under ConcurrentDom without a scoped access guard.
+    [[maybe_unused]] svg::DocumentReadAccess access = app_.document().document().readAccess();
     std::optional<xml::XMLNode> xmlNode = xml::XMLNode::TryCast(element->entityHandle());
     ASSERT_TRUE(xmlNode.has_value()) << phase << ": " << id << " is not backed by XML";
 
@@ -670,7 +674,7 @@ protected:
     request.selection = app_.selectedElement();
     if (app_.selectedElement().has_value() &&
         app_.selectedElement()->isa<svg::SVGGraphicsElement>()) {
-      request.selectedEntity = app_.selectedElement()->entityHandle().entity();
+      request.selectedEntity = app_.selectedElement()->unsafeEntityHandle().entity();
     }
     if (std::optional<SelectTool::ActiveDragPreview> preview = selectTool_.activeDragPreview();
         preview.has_value()) {

--- a/donner/svg/SVGDocument.cc
+++ b/donner/svg/SVGDocument.cc
@@ -456,9 +456,9 @@ SVGDocument::SVGDocument(SVGDocumentHandle documentState, Settings settings,
   auto& ctx = registry.ctx().emplace<components::SVGDocumentContext>(
       components::SVGDocumentContext::InternalCtorTag{}, documentState_);
   if (ontoEntityHandle) {
-    ctx.rootEntity = SVGSVGElement::CreateOn(ontoEntityHandle).entityHandle().entity();
+    ctx.rootEntity = SVGSVGElement::CreateOn(ontoEntityHandle).unsafeEntityHandle().entity();
   } else {
-    ctx.rootEntity = SVGSVGElement::Create(*this).entityHandle().entity();
+    ctx.rootEntity = SVGSVGElement::Create(*this).unsafeEntityHandle().entity();
   }
   registry.get_or_emplace<components::NodeLifetimeComponent>(ctx.rootEntity).markAttached();
 
@@ -599,6 +599,11 @@ xml::ApplySourceEditResult SVGDocument::applySourceEdit(const xml::XMLEditIntent
     return result;
   }
 
+  // §concurrent-dom: applySourceEdit drives a tree-shaped mutation (insertions, removes, attribute
+  // changes) through `xmlDocument().applySourceEdit` and `applyXMLMutation`; acquire write access
+  // up front so all of that runs under one guard under ThreadingMode::ConcurrentDom.
+  [[maybe_unused]] DocumentWriteAccess access = writeAccess();
+
   xml::ApplySourceEditResult result;
   {
     // Defer detached-node collection across the reparse. ReplaceChildrenFromParsedNode removes
@@ -626,6 +631,10 @@ xml::ApplySourceEditResult SVGDocument::applySourceEdit(const xml::XMLEditIntent
 xml::ApplySourceEditResult SVGDocument::setElementAttribute(const SVGElement& element,
                                                             const xml::XMLQualifiedNameRef& name,
                                                             std::string_view value) {
+  // §concurrent-dom: this is a mutation entry point. Acquire write access up front so the implicit
+  // `EntityHandle` conversions of `element.handle_` below (resolve() through the guarded path)
+  // don't fire the scoped-access assert under ThreadingMode::ConcurrentDom.
+  [[maybe_unused]] DocumentWriteAccess access = writeAccess();
   if (hasSourceStore()) {
     std::optional<xml::XMLNode> xmlNode = xml::XMLNode::TryCast(element.handle_);
     if (xmlNode.has_value()) {
@@ -651,6 +660,10 @@ xml::ApplySourceEditResult SVGDocument::setElementAttribute(const SVGElement& el
 
 xml::ApplySourceEditResult SVGDocument::removeElementAttribute(
     const SVGElement& element, const xml::XMLQualifiedNameRef& name) {
+  // §concurrent-dom: this is a mutation entry point. Acquire write access up front so the implicit
+  // `EntityHandle` conversions of `element.handle_` below don't fire the scoped-access assert under
+  // ThreadingMode::ConcurrentDom.
+  [[maybe_unused]] DocumentWriteAccess access = writeAccess();
   if (hasSourceStore()) {
     std::optional<xml::XMLNode> xmlNode = xml::XMLNode::TryCast(element.handle_);
     if (xmlNode.has_value()) {
@@ -673,6 +686,11 @@ xml::ApplySourceEditResult SVGDocument::removeElementAttribute(
 xml::ApplySourceEditResult SVGDocument::insertElement(const SVGElement& parent,
                                                       const SVGElement& element,
                                                       std::optional<SVGElement> referenceElement) {
+  // §concurrent-dom: this is a mutation entry point. Acquire write access up front so the implicit
+  // `EntityHandle` conversions of `parent.handle_`, `element.handle_`, and
+  // `referenceElement->handle_` below don't fire the scoped-access assert under
+  // ThreadingMode::ConcurrentDom.
+  [[maybe_unused]] DocumentWriteAccess access = writeAccess();
   if (hasSourceStore()) {
     std::optional<xml::XMLNode> parentNode = xml::XMLNode::TryCast(parent.handle_);
     if (parentNode.has_value()) {
@@ -715,6 +733,10 @@ xml::ApplySourceEditResult SVGDocument::insertElement(const SVGElement& parent,
 }
 
 xml::ApplySourceEditResult SVGDocument::removeElement(const SVGElement& element) {
+  // §concurrent-dom: this is a mutation entry point. Acquire write access up front so the implicit
+  // `EntityHandle` conversions of `element.handle_` and `parent.entityHandle()` below don't fire
+  // the scoped-access assert under ThreadingMode::ConcurrentDom.
+  [[maybe_unused]] DocumentWriteAccess access = writeAccess();
   const std::optional<SVGElement> parent = element.parentElement();
 
   if (hasSourceStore()) {

--- a/donner/svg/components/layout/tests/LayoutSystem_tests.cc
+++ b/donner/svg/components/layout/tests/LayoutSystem_tests.cc
@@ -799,7 +799,7 @@ TEST_F(LayoutSystemTest, CreateShadowSizedElementComponent) {
   ParseWarningSink warningSink;
 
   auto useHandle = document.querySelector("#u")->entityHandle();
-  auto symbolEntity = document.querySelector("#sym")->entityHandle().entity();
+  auto symbolEntity = document.querySelector("#sym")->unsafeEntityHandle().entity();
 
   EXPECT_TRUE(layoutSystem.createShadowSizedElementComponent(
       registry, shadowEntity, useHandle, symbolEntity, ShadowBranchType::Main, warningSink));
@@ -824,7 +824,7 @@ TEST_F(LayoutSystemTest, CreateShadowSizedElementComponentReturnsFalseWhenNotMai
 
   EXPECT_FALSE(layoutSystem.createShadowSizedElementComponent(
       registry, shadowEntity, document.querySelector("#u")->entityHandle(),
-      document.querySelector("#sym")->entityHandle().entity(), ShadowBranchType::OffscreenFill,
+      document.querySelector("#sym")->unsafeEntityHandle().entity(), ShadowBranchType::OffscreenFill,
       warningSink));
 }
 

--- a/donner/svg/components/paint/tests/PaintSystem_tests.cc
+++ b/donner/svg/components/paint/tests/PaintSystem_tests.cc
@@ -115,7 +115,7 @@ TEST_F(PaintSystemTest, CreateComputedStopReturnsExistingComponent) {
   SVGDocument document;
   SVGStopElement stopElement = SVGStopElement::Create(document);
   auto& registry = document.registry();
-  auto entity = stopElement.entityHandle().entity();
+  auto entity = stopElement.unsafeEntityHandle().entity();
   auto& stop = registry.emplace<StopComponent>(entity);
   auto& style = registry.emplace<ComputedStyleComponent>(entity);
   style.properties.emplace();
@@ -237,7 +237,7 @@ TEST_F(PaintSystemTest, GradientInitializationStopsOnRecursiveShadowRoot) {
   ASSERT_TRUE(element.has_value());
   auto& shadow = element->entityHandle().emplace<ComputedShadowTreeComponent>();
   shadow.mainBranch = ComputedShadowTreeComponent::BranchStorage{
-      ShadowBranchType::Main, element->entityHandle().entity(), {}};
+      ShadowBranchType::Main, element->unsafeEntityHandle().entity(), {}};
 
   ParseWarningSink warningSink;
   StyleSystem().computeAllStyles(document.registry(), warningSink);

--- a/donner/svg/components/shadow/tests/ShadowTreeSystem_tests.cc
+++ b/donner/svg/components/shadow/tests/ShadowTreeSystem_tests.cc
@@ -64,7 +64,7 @@ TEST_F(ShadowTreeSystemTest, UseElementReferencesRect) {
 
   // Verify the use element has a ShadowTreeComponent
   auto& registry = document.registry();
-  auto entity = useElement->entityHandle().entity();
+  auto entity = useElement->unsafeEntityHandle().entity();
   EXPECT_TRUE(registry.all_of<ShadowTreeComponent>(entity));
 
   auto& shadowTree = registry.get<ShadowTreeComponent>(entity);
@@ -171,7 +171,7 @@ TEST_F(ShadowTreeSystemTest, TeardownCleansShadowEntities) {
   )");
 
   auto& registry = document.registry();
-  auto useEntity = document.querySelector("#u")->entityHandle().entity();
+  auto useEntity = document.querySelector("#u")->unsafeEntityHandle().entity();
 
   // If a ComputedShadowTreeComponent exists, tear it down.
   auto* computed = registry.try_get<ComputedShadowTreeComponent>(useEntity);
@@ -196,7 +196,7 @@ TEST_F(ShadowTreeSystemTest, PopulateInstanceMainBranch) {
   )");
 
   auto hostEntity = document.querySelector("#host")->entityHandle();
-  auto targetEntity = document.querySelector("#target")->entityHandle().entity();
+  auto targetEntity = document.querySelector("#target")->unsafeEntityHandle().entity();
 
   ComputedShadowTreeComponent shadow;
   ShadowTreeSystem system;
@@ -267,7 +267,7 @@ TEST_F(ShadowTreeSystemTest, PopulateInstanceParentRecursionWarns) {
   )");
 
   auto childEntity = document.querySelector("#child")->entityHandle();
-  auto parentEntity = document.querySelector("#parent")->entityHandle().entity();
+  auto parentEntity = document.querySelector("#parent")->unsafeEntityHandle().entity();
 
   ComputedShadowTreeComponent shadow;
   ShadowTreeSystem system;
@@ -293,7 +293,7 @@ TEST_F(ShadowTreeSystemTest, PopulateInstanceOffscreenBranchReturnsIndex) {
   )");
 
   auto hostEntity = document.querySelector("#host")->entityHandle();
-  auto targetEntity = document.querySelector("#target")->entityHandle().entity();
+  auto targetEntity = document.querySelector("#target")->unsafeEntityHandle().entity();
 
   ComputedShadowTreeComponent shadow;
   ShadowTreeSystem system;
@@ -369,7 +369,7 @@ TEST_F(ShadowTreeSystemTest, PopulateInstanceNestedShadowTreeInvokesHandlerAndCo
   auto hostEntity = document.querySelector("#host")->entityHandle();
   auto nestedEntity = document.querySelector("#nested")->entityHandle();
   registry.emplace<DoNotInheritFillOrStrokeTag>(
-      document.querySelector("#target")->entityHandle().entity());
+      document.querySelector("#target")->unsafeEntityHandle().entity());
 
   bool handlerCalled = false;
   ShadowTreeSystem system([&handlerCalled](Registry&, Entity, EntityHandle, Entity,
@@ -459,7 +459,7 @@ TEST_F(ShadowTreeSystemTest, PopulateInstanceMirrorsChildrenInNonNestedBranch) {
   )");
 
   auto hostEntity = document.querySelector("#host")->entityHandle();
-  auto targetEntity = document.querySelector("#target")->entityHandle().entity();
+  auto targetEntity = document.querySelector("#target")->unsafeEntityHandle().entity();
 
   ShadowTreeSystem system;
   ComputedShadowTreeComponent shadow;

--- a/donner/svg/components/style/tests/StyleSystem_tests.cc
+++ b/donner/svg/components/style/tests/StyleSystem_tests.cc
@@ -144,7 +144,7 @@ TEST_F(StyleSystemTest, StylesheetSourceMapMapsRuleBackToSvgSource) {
   auto styleElement = document.querySelector("style");
   ASSERT_TRUE(styleElement.has_value());
   const auto& stylesheet =
-      document.registry().get<StylesheetComponent>(styleElement->entityHandle().entity());
+      document.registry().get<StylesheetComponent>(styleElement->unsafeEntityHandle().entity());
   ASSERT_EQ(stylesheet.stylesheet.rules().size(), 1u);
 
   const css::SelectorRule& rule = stylesheet.stylesheet.rules()[0];
@@ -431,7 +431,7 @@ TEST_F(StyleSystemTest, ComputeAllStylesFullRecomputeClearsAndRebuildsStyles) {
   auto element = document.querySelector("#r");
   ASSERT_TRUE(element.has_value());
 
-  auto styleEntity = document.querySelector("style")->entityHandle().entity();
+  auto styleEntity = document.querySelector("style")->unsafeEntityHandle().entity();
   auto& stylesheet = document.registry().get<StylesheetComponent>(styleEntity);
   stylesheet.parseStylesheet("rect { fill: blue; }");
   SetRenderTreeState(document.registry(), RenderTreeState{.needsFullRebuild = false,
@@ -442,7 +442,7 @@ TEST_F(StyleSystemTest, ComputeAllStylesFullRecomputeClearsAndRebuildsStyles) {
   styleSystem.computeAllStyles(document.registry(), warningSink);
 
   EXPECT_EQ(document.registry()
-                .get<ComputedStyleComponent>(element->entityHandle().entity())
+                .get<ComputedStyleComponent>(element->unsafeEntityHandle().entity())
                 .properties->fill.getRequired(),
             PaintServer(PaintServer::Solid(css::Color(css::RGBA(0, 0, 0xFF, 0xFF)))));
 }
@@ -482,8 +482,8 @@ TEST_F(StyleSystemTest, ComputeStylesForSubsetOnlyComputesRequestedEntities) {
     </svg>
   )");
 
-  const Entity a = document.querySelector("#a")->entityHandle().entity();
-  const Entity b = document.querySelector("#b")->entityHandle().entity();
+  const Entity a = document.querySelector("#a")->unsafeEntityHandle().entity();
+  const Entity b = document.querySelector("#b")->unsafeEntityHandle().entity();
 
   ParseWarningSink warningSink;
   styleSystem.computeStylesFor(document.registry(), std::array<Entity, 1>{a}, warningSink);
@@ -514,9 +514,9 @@ TEST_F(StyleSystemTest, ShadowTreeSelectorsMatchSiblingAndAttributeState) {
   auto useElement = document.querySelector("#u");
   ASSERT_TRUE(useElement.has_value());
   auto& shadowTree = document.registry().get_or_emplace<ComputedShadowTreeComponent>(
-      useElement->entityHandle().entity());
+      useElement->unsafeEntityHandle().entity());
   auto target = document.registry()
-                    .get<ShadowTreeComponent>(useElement->entityHandle().entity())
+                    .get<ShadowTreeComponent>(useElement->unsafeEntityHandle().entity())
                     .mainTargetEntity(document.registry());
   ASSERT_TRUE(target.has_value());
 

--- a/donner/svg/components/text/tests/TextSystem_tests.cc
+++ b/donner/svg/components/text/tests/TextSystem_tests.cc
@@ -55,7 +55,7 @@ TEST_F(TextSystemTest, BasicTextElement) {
   )");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
 
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
@@ -73,7 +73,7 @@ TEST_F(TextSystemTest, TextWithTspan) {
   )");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
 
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
@@ -94,7 +94,7 @@ TEST_F(TextSystemTest, PositioningInheritedFromRoot) {
   )");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
 
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
@@ -120,7 +120,7 @@ TEST_F(TextSystemTest, PerCharacterPositioning) {
   )");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
 
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
@@ -147,7 +147,7 @@ TEST_F(TextSystemTest, DxDyPositioning) {
   )");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
 
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
@@ -175,7 +175,7 @@ TEST_F(TextSystemTest, RootDxDyBecomesScalarStartPosition) {
   )");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
 
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
@@ -201,7 +201,7 @@ TEST_F(TextSystemTest, RotateAttribute) {
   )");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
 
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
@@ -224,7 +224,7 @@ TEST_F(TextSystemTest, EmptyTextElement) {
   )");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
 
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
@@ -243,7 +243,7 @@ TEST_F(TextSystemTest, MultipleTspanWithPositioning) {
   )");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
 
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
@@ -277,7 +277,7 @@ TEST_F(TextSystemTest, TextPathReference) {
   )");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
 
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
@@ -301,7 +301,7 @@ TEST_F(TextSystemTest, TextPathWithStartOffset) {
   )");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
 
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
@@ -330,7 +330,7 @@ TEST_F(TextSystemTest, TextPathWithAbsoluteStartOffsetAndTransform) {
   auto document = std::move(maybeResult).result();
 
   Registry& registry = document.registry();
-  auto pathEntity = document.querySelector("#p")->entityHandle().entity();
+  auto pathEntity = document.querySelector("#p")->unsafeEntityHandle().entity();
   registry.emplace_or_replace<ComputedLocalTransformComponent>(
       pathEntity, Transform2d::Translate({5, 7}), CssTransform(Transform2d::Translate({5, 7})),
       Vector2d::Zero());
@@ -338,7 +338,7 @@ TEST_F(TextSystemTest, TextPathWithAbsoluteStartOffsetAndTransform) {
   StyleSystem().computeAllStyles(registry, warningSink);
   TextSystem().instantiateAllComputedComponents(registry, warningSink);
 
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
   ASSERT_THAT(computed->spans, SizeIs(2));
@@ -364,7 +364,7 @@ TEST_F(TextSystemTest, TextPathUsesSplineOverrideWhenComputedPathMissing) {
   ASSERT_THAT(maybeResult, NoParseError());
   auto document = std::move(maybeResult).result();
 
-  auto pathEntity = document.querySelector("#p")->entityHandle().entity();
+  auto pathEntity = document.querySelector("#p")->unsafeEntityHandle().entity();
   Registry& registry = document.registry();
   Path spline = PathBuilder().moveTo(Vector2d(1, 2)).lineTo(Vector2d(3, 4)).build();
   registry.get<PathComponent>(pathEntity).splineOverride = spline;
@@ -373,7 +373,7 @@ TEST_F(TextSystemTest, TextPathUsesSplineOverrideWhenComputedPathMissing) {
   StyleSystem().computeAllStyles(registry, warningSink);
   TextSystem().instantiateAllComputedComponents(registry, warningSink);
 
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
   ASSERT_THAT(computed->spans, SizeIs(2));
@@ -390,7 +390,7 @@ TEST_F(TextSystemTest, TextPathWithInvalidReferenceMarksFailure) {
   )svg");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
   ASSERT_THAT(computed->spans, SizeIs(2));
@@ -407,7 +407,7 @@ TEST_F(TextSystemTest, TextPathWithEmptyReferencedPathMarksFailure) {
   )svg");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
   ASSERT_THAT(computed->spans, SizeIs(2));
@@ -434,7 +434,7 @@ TEST_F(TextSystemTest, MixedTextPathChildrenProduceSeparateSpans) {
   )");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
 
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
@@ -469,7 +469,7 @@ TEST_F(TextSystemTest, NestedTextRootIsIgnored) {
   )svg");
 
   auto& registry = document.registry();
-  auto outerEntity = document.querySelector("#outer")->entityHandle().entity();
+  auto outerEntity = document.querySelector("#outer")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(outerEntity);
   ASSERT_NE(computed, nullptr);
 
@@ -491,7 +491,7 @@ TEST_F(TextSystemTest, NonTextChildrenAreIgnoredDuringSpanCollection) {
   )svg");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
 
@@ -523,7 +523,7 @@ TEST_F(TextSystemTest, NestedTextPathContentIsHidden) {
   )");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
 
@@ -566,7 +566,7 @@ TEST_F(TextSystemTest, TextPathTspanChildrenProduceSeparatePathSpans) {
   )");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
 
@@ -609,7 +609,7 @@ TEST_F(TextSystemTest, TextPathWhitespaceAroundTspansIsPreservedInSpans) {
   )");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
 
@@ -637,7 +637,7 @@ TEST_F(TextSystemTest, Utf8MultibyteCounting) {
   )");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
 
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
@@ -655,7 +655,7 @@ TEST_F(TextSystemTest, Utf16CountingTreatsEmojiAsTwoCodeUnits) {
   )svg");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
   ASSERT_THAT(computed->spans, SizeIs(1));
@@ -670,7 +670,7 @@ TEST_F(TextSystemTest, RotateListStopsWhenGlobalIndicesRunOut) {
   )svg");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
   ASSERT_THAT(computed->spans, SizeIs(1));
@@ -686,7 +686,7 @@ TEST_F(TextSystemTest, InheritedRotateListStopsAcrossChildSpans) {
   )svg");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
   ASSERT_THAT(computed->spans, SizeIs(3));
@@ -705,7 +705,7 @@ TEST_F(TextSystemTest, XmlSpacePreserveKeepsWhitespaceAndInheritance) {
   )svg");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
   ASSERT_THAT(computed->spans, SizeIs(3));
@@ -722,7 +722,7 @@ TEST_F(TextSystemTest, TextPathWithoutHrefIsHidden) {
   )svg");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
   ASSERT_THAT(computed->spans, SizeIs(2));
@@ -739,7 +739,7 @@ TEST_F(TextSystemTest, TextPathNestedUnderTspanMarksFailure) {
   )svg");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
 
@@ -774,8 +774,8 @@ TEST_F(TextSystemTest, TextPathTransformAppliesQuadAndCurveCommands) {
   auto document = std::move(maybeResult).result();
 
   Registry& registry = document.registry();
-  auto quadEntity = document.querySelector("#quad")->entityHandle().entity();
-  auto curveEntity = document.querySelector("#curve")->entityHandle().entity();
+  auto quadEntity = document.querySelector("#quad")->unsafeEntityHandle().entity();
+  auto curveEntity = document.querySelector("#curve")->unsafeEntityHandle().entity();
   registry.emplace_or_replace<ComputedLocalTransformComponent>(
       quadEntity, Transform2d::Translate({1, 2}), CssTransform(Transform2d::Translate({1, 2})),
       Vector2d::Zero());
@@ -787,7 +787,7 @@ TEST_F(TextSystemTest, TextPathTransformAppliesQuadAndCurveCommands) {
   StyleSystem().computeAllStyles(registry, warningSink);
   TextSystem().instantiateAllComputedComponents(registry, warningSink);
 
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
   std::vector<const ComputedTextComponent::TextSpan*> pathSpans;
@@ -830,7 +830,7 @@ TEST_F(TextSystemTest, TextPathTransformAppliesClosePath) {
   auto document = std::move(maybeResult).result();
 
   Registry& registry = document.registry();
-  auto closedEntity = document.querySelector("#closed")->entityHandle().entity();
+  auto closedEntity = document.querySelector("#closed")->unsafeEntityHandle().entity();
   registry.emplace_or_replace<ComputedLocalTransformComponent>(
       closedEntity, Transform2d::Translate({2, 3}), CssTransform(Transform2d::Translate({2, 3})),
       Vector2d::Zero());
@@ -839,7 +839,7 @@ TEST_F(TextSystemTest, TextPathTransformAppliesClosePath) {
   StyleSystem().computeAllStyles(registry, warningSink);
   TextSystem().instantiateAllComputedComponents(registry, warningSink);
 
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
 
@@ -885,7 +885,7 @@ TEST_F(TextSystemTest, ListOnlyPositioning) {
   )");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
 
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
@@ -910,7 +910,7 @@ TEST_F(TextSystemTest, NoDoubleApplication) {
   )");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
 
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
@@ -933,7 +933,7 @@ TEST_F(TextSystemTest, ChildTspanPreservesListZero) {
   )");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
 
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
@@ -957,7 +957,7 @@ TEST_F(TextSystemTest, StartsNewChunk) {
   )");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
 
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
@@ -984,7 +984,7 @@ TEST_F(TextSystemTest, DisplayNoneConsumesRotateIndices) {
   )");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
 
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
@@ -1028,7 +1028,7 @@ TEST_F(TextSystemTest, WhitespaceTspanBoundarySpace) {
       "</svg>");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
 
   auto& textComp = registry.get<TextComponent>(textEntity);
   EXPECT_EQ(textComp.textChunks.size(), 2u);
@@ -1059,7 +1059,7 @@ TEST_F(TextSystemTest, WhitespaceInterTspanSpacing) {
   )");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
   std::string concatenated;
@@ -1080,7 +1080,7 @@ TEST_F(TextSystemTest, WhitespacePreserveLeadingSpaces) {
   )");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
   std::string concatenated;
@@ -1102,7 +1102,7 @@ TEST_F(TextSystemTest, WhitespaceDefaultRootPreserveTspan) {
   )");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
   std::string concatenated;
@@ -1121,7 +1121,7 @@ TEST_F(TextSystemTest, WhitespacePreserveRootDefaultTspan) {
   )");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
   std::string concatenated;
@@ -1146,7 +1146,7 @@ TEST_F(TextSystemTest, WhitespaceGradientTspan) {
   )svg");
 
   auto& registry = document.registry();
-  auto textEntity = document.querySelector("#t")->entityHandle().entity();
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
   std::string concatenated;

--- a/donner/svg/compositor/CompositorController.cc
+++ b/donner/svg/compositor/CompositorController.cc
@@ -417,7 +417,7 @@ void CompositorController::demoteEntity(Entity entity) {
   // Detached entities must leave `activeHints_` immediately so stale
   // paint-order ranges cannot survive deletion.
   Registry& registry = document().registry();
-  const Entity rootEntity = document().svgElement().entityHandle().entity();
+  const Entity rootEntity = document().svgElement().unsafeEntityHandle().entity();
   if (!IsEntityInLiveTree(registry, entity, rootEntity)) {
     activeHints_.erase(entity);
     pendingDemotions_.erase(entity);

--- a/donner/svg/compositor/CompositorController_tests.cc
+++ b/donner/svg/compositor/CompositorController_tests.cc
@@ -95,7 +95,7 @@ TEST_F(CompositorControllerTest, PromoteEntitySucceeds) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   EXPECT_TRUE(compositor.promoteEntity(entity));
@@ -110,7 +110,7 @@ TEST_F(CompositorControllerTest, PromoteSameEntityTwiceSucceeds) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   EXPECT_TRUE(compositor.promoteEntity(entity));
@@ -135,7 +135,7 @@ TEST_F(CompositorControllerTest, DemoteRemovesLayer) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   EXPECT_TRUE(compositor.promoteEntity(entity));
@@ -162,7 +162,7 @@ TEST_F(CompositorControllerTest, M9DemoteIsLazyWithinHysteresisWindow) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   ASSERT_TRUE(compositor.promoteEntity(entity));
@@ -183,7 +183,7 @@ TEST_F(CompositorControllerTest, M9RepromoteSameEntityCancelsPendingDemote) {
   configureMockForCaching();
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   ASSERT_TRUE(compositor.promoteEntity(entity, InteractionHint::Selection));
@@ -216,7 +216,7 @@ TEST_F(CompositorControllerTest, M9DemoteFiresAfterHysteresisExpires) {
   configureMockForCaching();
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   ASSERT_TRUE(compositor.promoteEntity(entity));
@@ -254,8 +254,8 @@ TEST_F(CompositorControllerTest, M9PendingDemoteKeepsHasSplitStaticLayersTrue) {
   auto b = document.querySelector("#b");
   ASSERT_TRUE(a.has_value());
   ASSERT_TRUE(b.has_value());
-  const Entity entityA = a->entityHandle().entity();
-  const Entity entityB = b->entityHandle().entity();
+  const Entity entityA = a->unsafeEntityHandle().entity();
+  const Entity entityB = b->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   ASSERT_TRUE(compositor.promoteEntity(entityA));
@@ -297,8 +297,8 @@ TEST_F(CompositorControllerTest, M9PendingDemoteDoesNotMaskLiveDragTarget) {
   auto b = document.querySelector("#b");
   ASSERT_TRUE(a.has_value());
   ASSERT_TRUE(b.has_value());
-  const Entity entityA = a->entityHandle().entity();
-  const Entity entityB = b->entityHandle().entity();
+  const Entity entityA = a->unsafeEntityHandle().entity();
+  const Entity entityB = b->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   ASSERT_TRUE(compositor.promoteEntity(entityA));
@@ -336,7 +336,7 @@ TEST_F(CompositorControllerTest, M9FlushPendingDemotionsForTestingFiresImmediate
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   ASSERT_TRUE(compositor.promoteEntity(entity));
@@ -355,7 +355,7 @@ TEST_F(CompositorControllerTest, DemoteNonPromotedEntityIsNoOp) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   compositor.demoteEntity(entity);  // No-op, should not crash.
@@ -369,7 +369,7 @@ TEST_F(CompositorControllerTest, ComputedLayerAssignmentAttachedOnPromote) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
   Registry& registry = document.registry();
 
   CompositorController compositor(document, renderer_);
@@ -402,7 +402,7 @@ TEST_F(CompositorControllerTest, LayerLimitEnforced) {
   for (int i = 0; i < kMaxCompositorLayers; ++i) {
     auto elem = document.querySelector("#r" + std::to_string(i));
     ASSERT_TRUE(elem.has_value()) << "Element r" << i << " not found";
-    EXPECT_TRUE(compositor.promoteEntity(elem->entityHandle().entity()))
+    EXPECT_TRUE(compositor.promoteEntity(elem->unsafeEntityHandle().entity()))
         << "Failed to promote element " << i;
   }
 
@@ -411,7 +411,7 @@ TEST_F(CompositorControllerTest, LayerLimitEnforced) {
   // Next promotion should fail.
   auto extra = document.querySelector("#r" + std::to_string(kMaxCompositorLayers));
   ASSERT_TRUE(extra.has_value());
-  EXPECT_FALSE(compositor.promoteEntity(extra->entityHandle().entity()));
+  EXPECT_FALSE(compositor.promoteEntity(extra->unsafeEntityHandle().entity()));
 }
 
 TEST_F(CompositorControllerTest, PromoteMultipleEntities) {
@@ -426,12 +426,12 @@ TEST_F(CompositorControllerTest, PromoteMultipleEntities) {
   ASSERT_TRUE(b.has_value());
 
   CompositorController compositor(document, renderer_);
-  EXPECT_TRUE(compositor.promoteEntity(a->entityHandle().entity()));
-  EXPECT_TRUE(compositor.promoteEntity(b->entityHandle().entity()));
+  EXPECT_TRUE(compositor.promoteEntity(a->unsafeEntityHandle().entity()));
+  EXPECT_TRUE(compositor.promoteEntity(b->unsafeEntityHandle().entity()));
   EXPECT_EQ(compositor.layerCount(), 2u);
 
-  EXPECT_TRUE(compositor.isPromoted(a->entityHandle().entity()));
-  EXPECT_TRUE(compositor.isPromoted(b->entityHandle().entity()));
+  EXPECT_TRUE(compositor.isPromoted(a->unsafeEntityHandle().entity()));
+  EXPECT_TRUE(compositor.isPromoted(b->unsafeEntityHandle().entity()));
 }
 
 TEST_F(CompositorControllerTest, LayerComposeOffsetTracksDomTranslationDelta) {
@@ -441,7 +441,7 @@ TEST_F(CompositorControllerTest, LayerComposeOffsetTracksDomTranslationDelta) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   configureMockForCaching();
   CompositorController compositor(document, renderer_);
@@ -473,7 +473,7 @@ TEST_F(CompositorControllerTest, LayerComposeOffsetOfNonPromotedReturnsIdentity)
   ASSERT_TRUE(target.has_value());
 
   CompositorController compositor(document, renderer_);
-  const Transform2d result = compositor.layerComposeOffset(target->entityHandle().entity());
+  const Transform2d result = compositor.layerComposeOffset(target->unsafeEntityHandle().entity());
   EXPECT_TRUE(result.isIdentity());
 }
 
@@ -505,7 +505,7 @@ TEST_F(CompositorControllerTest, SinglePromotedLayerBuildsSplitStaticLayers) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   ASSERT_TRUE(compositor.promoteEntity(entity));
@@ -538,8 +538,8 @@ TEST_F(CompositorControllerTest, MultiplePromotedLayersDoNotBuildSplitStaticLaye
   ASSERT_TRUE(b.has_value());
 
   CompositorController compositor(document, renderer_);
-  ASSERT_TRUE(compositor.promoteEntity(a->entityHandle().entity()));
-  ASSERT_TRUE(compositor.promoteEntity(b->entityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(a->unsafeEntityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(b->unsafeEntityHandle().entity()));
 
   RenderViewport viewport;
   viewport.size = Vector2d(64, 64);
@@ -556,7 +556,7 @@ TEST_F(CompositorControllerTest, MoveConstructor) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   compositor.promoteEntity(entity);
@@ -578,7 +578,7 @@ TEST_F(CompositorControllerTest, SimpleFillNoFallback) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   compositor.promoteEntity(entity);
@@ -598,7 +598,7 @@ TEST_F(CompositorControllerTest, FilterTriggersFallback) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   compositor.promoteEntity(entity);
@@ -618,7 +618,7 @@ TEST_F(CompositorControllerTest, ClipPathTriggersFallback) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   compositor.promoteEntity(entity);
@@ -638,7 +638,7 @@ TEST_F(CompositorControllerTest, MaskTriggersFallback) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   compositor.promoteEntity(entity);
@@ -655,7 +655,7 @@ TEST_F(CompositorControllerTest, OpacityTriggersFallback) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   compositor.promoteEntity(entity);
@@ -679,7 +679,7 @@ TEST_F(CompositorControllerTest, GradientFillTriggersFallback) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   compositor.promoteEntity(entity);
@@ -694,7 +694,7 @@ TEST_F(CompositorControllerTest, FallbackReasonsOfUnpromotedEntity) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   EXPECT_EQ(compositor.fallbackReasonsOf(entity), FallbackReason::None);
@@ -709,7 +709,7 @@ TEST_F(CompositorControllerTest, ResetAllLayersClearsPromotedEntities) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   configureMockForCaching();
@@ -736,7 +736,7 @@ TEST_F(CompositorControllerTest, ResetAllLayersClearsComputedLayerAssignment) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   EXPECT_TRUE(compositor.promoteEntity(entity));
@@ -771,8 +771,8 @@ TEST_F(CompositorControllerTest, SnapshotLayerInspectorRowsEmitsRowPerLayerWithB
   auto b = document.querySelector("#b");
   ASSERT_TRUE(a.has_value());
   ASSERT_TRUE(b.has_value());
-  const Entity entityA = a->entityHandle().entity();
-  const Entity entityB = b->entityHandle().entity();
+  const Entity entityA = a->unsafeEntityHandle().entity();
+  const Entity entityB = b->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   ASSERT_TRUE(compositor.promoteEntity(entityA));
@@ -804,7 +804,7 @@ TEST_F(CompositorControllerTest, SnapshotLayerInspectorRowsTracksRasterizeCountA
   configureMockForCaching();
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   ASSERT_TRUE(compositor.promoteEntity(entity));
@@ -833,7 +833,7 @@ TEST_F(CompositorControllerTest, TextureOnlyDragReusesPayloadWithoutRasterize) {
   configureMockForTextureCaching();
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   ASSERT_TRUE(compositor.promoteEntity(entity, InteractionHint::ActiveDrag));
@@ -884,7 +884,7 @@ TEST_F(CompositorControllerTest, SnapshotLayerInspectorRowsEmitsThumbnailWithMax
   configureMockForCaching();
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   ASSERT_TRUE(compositor.promoteEntity(entity));
@@ -920,7 +920,7 @@ TEST_F(CompositorControllerTest, SnapshotSegmentInspectorRowsEmitsOneRowPerSlot)
   ASSERT_TRUE(a.has_value());
 
   CompositorController compositor(document, renderer_);
-  ASSERT_TRUE(compositor.promoteEntity(a->entityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(a->unsafeEntityHandle().entity()));
   compositor.renderFrame(RenderViewport{kTestSvgDefaultSize});
 
   const auto rows = compositor.snapshotSegmentInspectorRows();
@@ -962,7 +962,7 @@ TEST_F(CompositorControllerTest, IntrinsicSizeMandatoryFilterLayerHasNonZeroCanv
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const auto* layer = compositor.findLayerForTest(target->entityHandle().entity());
+  const auto* layer = compositor.findLayerForTest(target->unsafeEntityHandle().entity());
   ASSERT_NE(layer, nullptr);
   ASSERT_TRUE(layer->hasValidBitmap());
 
@@ -989,7 +989,7 @@ TEST_F(CompositorControllerTest, EditorPromotedLayerAlsoUsesIntrinsicSize) {
   configureMockForCaching();
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   ASSERT_TRUE(compositor.promoteEntity(entity));
@@ -1035,7 +1035,7 @@ TEST_F(CompositorControllerTest, IntrinsicSizeLayerFastPathTranslationStillWorks
 
   // Rasterize-time: canvasFromBitmap is identity, canvasOffset is the
   // bitmap's intrinsic position.
-  const auto* layerBefore = compositor.findLayerForTest(target->entityHandle().entity());
+  const auto* layerBefore = compositor.findLayerForTest(target->unsafeEntityHandle().entity());
   ASSERT_NE(layerBefore, nullptr);
   const Vector2d offsetAtRasterize = layerBefore->canvasOffset();
 
@@ -1043,7 +1043,7 @@ TEST_F(CompositorControllerTest, IntrinsicSizeLayerFastPathTranslationStillWorks
   target->cast<SVGGraphicsElement>().setTransform(Transform2d::Translate(5.0, 10.0));
   compositor.renderFrame(RenderViewport{Vector2d(200, 100)});
 
-  const auto* layerAfter = compositor.findLayerForTest(target->entityHandle().entity());
+  const auto* layerAfter = compositor.findLayerForTest(target->unsafeEntityHandle().entity());
   ASSERT_NE(layerAfter, nullptr);
   EXPECT_EQ(layerAfter->canvasOffset(), offsetAtRasterize)
       << "canvasOffset stays put — only canvasFromBitmap encodes the drag delta.";
@@ -1143,7 +1143,7 @@ TEST_F(CompositorControllerTest, ResetAllLayersAllowsRepromotion) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   configureMockForCaching();

--- a/donner/svg/compositor/CompositorGolden_tests.cc
+++ b/donner/svg/compositor/CompositorGolden_tests.cc
@@ -112,7 +112,7 @@ TEST_F(CompositorGoldenTest, PromotedEntityMatchesFullRender) {
   ASSERT_TRUE(target.has_value());
 
   CompositorController compositor(document, renderer_);
-  ASSERT_TRUE(compositor.promoteEntity(target->entityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(target->unsafeEntityHandle().entity()));
 
   DualPathVerifier verifier(compositor, renderer_);
   const auto result = verifier.renderAndVerify(viewport_);
@@ -133,7 +133,7 @@ TEST_F(CompositorGoldenTest, TranslationOnlyDragProducesCorrectPixels) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   ASSERT_TRUE(compositor.promoteEntity(entity));
@@ -184,7 +184,7 @@ TEST_F(CompositorGoldenTest, DraggingFilterGroupSubtreeEngagesFastPath) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   // Promote with ActiveDrag so the drag target sets up the single-
@@ -251,7 +251,7 @@ TEST_F(CompositorGoldenTest, TranslationDragEngagesFastPathAtMultipleCanvasScale
 
     auto target = document.querySelector("#target");
     ASSERT_TRUE(target.has_value());
-    const Entity entity = target->entityHandle().entity();
+    const Entity entity = target->unsafeEntityHandle().entity();
 
     CompositorController compositor(document, renderer_);
     ASSERT_TRUE(compositor.promoteEntity(entity, InteractionHint::ActiveDrag));
@@ -328,7 +328,7 @@ TEST_F(CompositorGoldenTest, ScaledCanvasTranslationOnlyDragProducesCorrectPixel
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   ASSERT_TRUE(compositor.promoteEntity(entity));
@@ -399,7 +399,7 @@ TEST_F(CompositorGoldenTest, BucketedStandaloneRectRasterizesCorrectly) {
 
   // Explicit promote to set up the drag scenario. With `complexityBucketing`
   // on and aggressive threshold, the white-background rect also gets a bucket.
-  ASSERT_TRUE(compositor.promoteEntity(target->entityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(target->unsafeEntityHandle().entity()));
   target->cast<SVGGraphicsElement>().setTransform(Transform2d::Translate(Vector2d(100.0, 0.0)));
   compositor.renderFrame(viewport_);
 
@@ -431,12 +431,12 @@ TEST_F(CompositorGoldenTest, BucketedStandaloneAfterResetRasterizesCorrectly) {
   CompositorController compositor(document, renderer_, config);
 
   // Phase 1: initial promote + render (warm the bucketer state).
-  ASSERT_TRUE(compositor.promoteEntity(target->entityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(target->unsafeEntityHandle().entity()));
   compositor.renderFrame(viewport_);
 
   // Phase 2: resetAllLayers, then promote + render again.
   compositor.resetAllLayers();
-  ASSERT_TRUE(compositor.promoteEntity(target->entityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(target->unsafeEntityHandle().entity()));
   compositor.renderFrame(viewport_);
 
   const RendererBitmap flat = renderer_.takeSnapshot();
@@ -458,7 +458,7 @@ TEST_F(CompositorGoldenTest, DragReleaseResetSequenceWithAggressiveBucketing) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorConfig config;
   config.complexityBucketing = true;
@@ -542,7 +542,7 @@ TEST_F(CompositorGoldenTest, FilterGroupAutoPromotesOnFirstRender) {
 
   auto glow = document.querySelector("#glow");
   ASSERT_TRUE(glow.has_value());
-  const Entity glowEntity = glow->entityHandle().entity();
+  const Entity glowEntity = glow->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   EXPECT_EQ(compositor.layerCount(), 0u) << "no render yet — detectors haven't run";
@@ -583,7 +583,7 @@ TEST_F(CompositorGoldenTest, FilteredLayerBoundsStopAtLayerSubtree) {
 
   auto glow = document.querySelector("#glow");
   ASSERT_TRUE(glow.has_value());
-  const Entity glowEntity = glow->entityHandle().entity();
+  const Entity glowEntity = glow->unsafeEntityHandle().entity();
 
   RenderViewport largeViewport;
   largeViewport.size = Vector2d(1000, 1000);
@@ -617,7 +617,7 @@ TEST_F(CompositorGoldenTest, RealSplashLightningBlurLayerUsesFilterBounds) {
   SVGDocument document = parseDocument(splashSource);
   auto glow = document.querySelector("#Lightning_glow_dark");
   ASSERT_TRUE(glow.has_value());
-  const Entity glowEntity = glow->entityHandle().entity();
+  const Entity glowEntity = glow->unsafeEntityHandle().entity();
 
   RenderViewport splashViewport;
   splashViewport.size = Vector2d(892, 512);
@@ -649,8 +649,8 @@ TEST_F(CompositorGoldenTest, EmptyStaticSegmentsArePrunedFromPublicTileSnapshots
   ASSERT_TRUE(b.has_value());
 
   CompositorController compositor(document, renderer_);
-  ASSERT_TRUE(compositor.promoteEntity(a->entityHandle().entity()));
-  ASSERT_TRUE(compositor.promoteEntity(b->entityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(a->unsafeEntityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(b->unsafeEntityHandle().entity()));
   compositor.renderFrame(viewport_);
 
   const auto uploadTiles = compositor.snapshotTilesForUpload();
@@ -717,7 +717,7 @@ TEST_F(CompositorGoldenTest, DualPathGate_ExplicitPromoteAtIdentity) {
   CompositorConfig config;
   config.verifyPixelIdentity = true;
   CompositorController compositor(document, renderer_, config);
-  ASSERT_TRUE(compositor.promoteEntity(target->entityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(target->unsafeEntityHandle().entity()));
 
   compositor.renderFrame(viewport_);
   compositor.renderFrame(viewport_);
@@ -740,7 +740,7 @@ TEST_F(CompositorGoldenTest, VerifyPixelIdentityGateCatchesNoDriftOnValidScene) 
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorConfig config;
   config.verifyPixelIdentity = true;  // Enable the in-tree dual-path assertion.
@@ -779,7 +779,7 @@ TEST_F(CompositorGoldenTest, GaussianBlurredShapeMatchesFullRenderAfterPromotion
   ASSERT_TRUE(target.has_value());
 
   CompositorController compositor(document, renderer_);
-  ASSERT_TRUE(compositor.promoteEntity(target->entityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(target->unsafeEntityHandle().entity()));
 
   DualPathVerifier verifier(compositor, renderer_);
   const auto result = verifier.renderAndVerify(viewport_);
@@ -810,7 +810,7 @@ TEST_F(CompositorGoldenTest, GaussianBlurredShapeRemainsVisibleDuringDrag) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   ASSERT_TRUE(compositor.promoteEntity(entity));
@@ -949,7 +949,7 @@ TEST_F(CompositorGoldenTest, ReducedSplashDraggingLetterPreservesGlow) {
   const Pixel glowBaseline = getPixel(baseline, kSampleX, kSampleY);
 
   // User clicks on letter A to start the drag.
-  ASSERT_TRUE(compositor.promoteEntity(letterA->entityHandle().entity()))
+  ASSERT_TRUE(compositor.promoteEntity(letterA->unsafeEntityHandle().entity()))
       << "letter A has no compositing ancestor, should promote";
 
   // Series of drag frames (editor drags at ~60fps). The user moves the DOM
@@ -1041,7 +1041,7 @@ TEST_F(CompositorGoldenTest, SplashDragWithBucketingAndMultipleFilterGroups) {
   auto letter2 = document.querySelector("#letter_2");
   ASSERT_TRUE(letter2.has_value());
 
-  ASSERT_TRUE(compositor.promoteEntity(letter2->entityHandle().entity()))
+  ASSERT_TRUE(compositor.promoteEntity(letter2->unsafeEntityHandle().entity()))
       << "letter_2 has no compositing ancestor, should promote";
 
   Pixel dragGlowA{}, dragGlowB{}, dragGlowC{};
@@ -1088,7 +1088,7 @@ TEST_F(CompositorGoldenTest, SplitBitmapsStableAcrossTranslationOnlyDragFrames) 
   CompositorController compositor(document, renderer_);
   compositor.renderFrame(viewport_);
 
-  ASSERT_TRUE(compositor.promoteEntity(target->entityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(target->unsafeEntityHandle().entity()));
   target->cast<SVGGraphicsElement>().setTransform(Transform2d::Translate(Vector2d(1.0, 0.0)));
   compositor.renderFrame(viewport_);
 
@@ -1141,7 +1141,7 @@ TEST_F(CompositorGoldenTest, DragTargetOnlySnapshotKeepsNonDragTileMetadata) {
   CompositorController compositor(document, renderer_);
   compositor.renderFrame(viewport_);
 
-  ASSERT_TRUE(compositor.promoteEntity(target->entityHandle().entity()).promotedLayer());
+  ASSERT_TRUE(compositor.promoteEntity(target->unsafeEntityHandle().entity()).promotedLayer());
   target->cast<SVGGraphicsElement>().setTransform(Transform2d::Translate(Vector2d(4.0, 0.0)));
   compositor.renderFrame(viewport_);
 
@@ -1190,7 +1190,7 @@ TEST_F(CompositorGoldenTest, SelectionToActiveDragDoesNotAdvanceUnchangedTileGen
   )svg");
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity targetEntity = target->entityHandle().entity();
+  const Entity targetEntity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   compositor.setSkipMainComposeDuringSplit(true);
@@ -1261,10 +1261,10 @@ TEST_F(CompositorGoldenTest, TransformMutationOnPromotedEntitySkipsFullPrepare) 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(bystander.has_value());
   ASSERT_TRUE(target.has_value());
-  const Entity bystanderEntity = bystander->entityHandle().entity();
+  const Entity bystanderEntity = bystander->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
-  ASSERT_TRUE(compositor.promoteEntity(target->entityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(target->unsafeEntityHandle().entity()));
 
   compositor.renderFrame(viewport_);
 
@@ -1309,7 +1309,7 @@ TEST_F(CompositorGoldenTest, DragEntityMutationKeepsMandatoryFilterLayerCached) 
   ASSERT_TRUE(target.has_value());
 
   CompositorController compositor(document, renderer_);
-  ASSERT_TRUE(compositor.promoteEntity(target->entityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(target->unsafeEntityHandle().entity()));
 
   // Initial render populates every layer bitmap and bg/fg.
   compositor.renderFrame(viewport_);
@@ -1317,7 +1317,7 @@ TEST_F(CompositorGoldenTest, DragEntityMutationKeepsMandatoryFilterLayerCached) 
   // Capture the pre-mutation filter-layer bitmap pointer. An intervening
   // rasterizeLayer call would reallocate the vector and change `.data()`.
   const uint8_t* glowDataBefore =
-      compositor.layerBitmapOf(glow->entityHandle().entity()).pixels.data();
+      compositor.layerBitmapOf(glow->unsafeEntityHandle().entity()).pixels.data();
   ASSERT_NE(glowDataBefore, nullptr);
 
   // Simulate the mutation the editor applies on drag release: bake the drag
@@ -1328,7 +1328,7 @@ TEST_F(CompositorGoldenTest, DragEntityMutationKeepsMandatoryFilterLayerCached) 
   compositor.renderFrame(viewport_);
 
   const uint8_t* glowDataAfter =
-      compositor.layerBitmapOf(glow->entityHandle().entity()).pixels.data();
+      compositor.layerBitmapOf(glow->unsafeEntityHandle().entity()).pixels.data();
   EXPECT_EQ(glowDataBefore, glowDataAfter)
       << "glow filter layer must be reused across the drag-release mutation — re-rasterizing it "
          "is what the user felt as a ~2s hang on every new drag";
@@ -1398,10 +1398,10 @@ TEST_F(CompositorGoldenTest, SplashDragMultipleFilterLayersStableAcrossManyFrame
   ASSERT_TRUE(glowB.has_value());
   ASSERT_TRUE(glowC.has_value());
 
-  const Entity letter2Entity = letter2->entityHandle().entity();
-  const Entity glowAEntity = glowA->entityHandle().entity();
-  const Entity glowBEntity = glowB->entityHandle().entity();
-  const Entity glowCEntity = glowC->entityHandle().entity();
+  const Entity letter2Entity = letter2->unsafeEntityHandle().entity();
+  const Entity glowAEntity = glowA->unsafeEntityHandle().entity();
+  const Entity glowBEntity = glowB->unsafeEntityHandle().entity();
+  const Entity glowCEntity = glowC->unsafeEntityHandle().entity();
 
   // Editor default config: all auto-promotion sources on.
   CompositorConfig config;
@@ -1491,7 +1491,7 @@ TEST_F(CompositorGoldenTest, SplashDragOnGroupReExercisesRasterizePath) {
 
   auto donner = document.querySelector("#Donner_target");
   ASSERT_TRUE(donner.has_value());
-  const Entity donnerEntity = donner->entityHandle().entity();
+  const Entity donnerEntity = donner->unsafeEntityHandle().entity();
 
   CompositorConfig config;
   CompositorController compositor(document, renderer_, config);
@@ -1531,7 +1531,7 @@ TEST_F(CompositorGoldenTest, NonPromotedMutationInvalidatesOnlyContainingSegment
   ASSERT_TRUE(after.has_value());
 
   CompositorController compositor(document, renderer_);
-  ASSERT_TRUE(compositor.promoteEntity(target->entityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(target->unsafeEntityHandle().entity()));
 
   // First render populates both segments.
   compositor.renderFrame(viewport_);
@@ -1648,7 +1648,7 @@ TEST_F(CompositorGoldenTest, SplitBitmapsInvalidateOnViewportResize) {
 
   CompositorController compositor(document, renderer_);
 
-  ASSERT_TRUE(compositor.promoteEntity(target->entityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(target->unsafeEntityHandle().entity()));
   target->cast<SVGGraphicsElement>().setTransform(Transform2d::Translate(Vector2d(1.0, 0.0)));
 
   document.setCanvasSize(200, 100);
@@ -1793,7 +1793,7 @@ TEST_F(CompositorGoldenTest, TightBoundedSegmentsSurviveExplicitDragTargetPromot
   // framebuffer back. With the flag on, the main renderer would be
   // untouched (the editor path) and the comparison would land on
   // whatever stale pixels were there before.
-  ASSERT_TRUE(compositor.promoteEntity(target->entityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(target->unsafeEntityHandle().entity()));
   DualPathVerifier verifier(compositor, renderer_);
 
   // DOM is at identity (no drag motion). Composition transform is
@@ -1849,7 +1849,7 @@ TEST_F(CompositorGoldenTest, TightBoundedSegmentsPixelIdentityOnRealSplashWithDr
 
   // Promote as a drag target and apply a small DOM transform to
   // simulate the first drag frame.
-  ASSERT_TRUE(compositor.promoteEntity(target->entityHandle().entity()))
+  ASSERT_TRUE(compositor.promoteEntity(target->unsafeEntityHandle().entity()))
       << "letter failed to promote — check compositing-breaking-ancestor";
   target->cast<SVGGraphicsElement>().setTransform(Transform2d::Translate(Vector2d(8.0, 0.0)));
 
@@ -1969,14 +1969,14 @@ TEST_F(CompositorGoldenTest, DragGroupWithRadialGradientChild_NoArtifact) {
 
   CompositorController compositor(document, renderer_);
   // Two-phase drag flow (mirrors editor).
-  compositor.promoteEntity(group->entityHandle().entity(), InteractionHint::Selection);
+  compositor.promoteEntity(group->unsafeEntityHandle().entity(), InteractionHint::Selection);
   compositor.renderFrame(viewport);
-  compositor.demoteEntity(group->entityHandle().entity());
+  compositor.demoteEntity(group->unsafeEntityHandle().entity());
   // §M9: flush so the demote-then-promote-different-kind sequence
   // rebuilds the layer (the path under test) rather than reusing
   // the hysteresis-preserved one.
   compositor.flushPendingDemotionsForTesting();
-  compositor.promoteEntity(group->entityHandle().entity(), InteractionHint::ActiveDrag);
+  compositor.promoteEntity(group->unsafeEntityHandle().entity(), InteractionHint::ActiveDrag);
   group->cast<SVGGraphicsElement>().setTransform(Transform2d::Translate(Vector2d(40.0, 0.0)));
   compositor.renderFrame(viewport);
   const RendererBitmap composited = renderer_.takeSnapshot();
@@ -2068,7 +2068,7 @@ TEST_F(CompositorGoldenTest, TightBoundsRotatedEllipseNoClip) {
     CompositorConfig config;
     config.tightBoundedSegments = tight;
     CompositorController compositor(document, renderer_, config);
-    compositor.promoteEntity(trigger->entityHandle().entity(), InteractionHint::Selection);
+    compositor.promoteEntity(trigger->unsafeEntityHandle().entity(), InteractionHint::Selection);
     compositor.renderFrame(vp);
     return renderer_.takeSnapshot();
   };
@@ -2133,7 +2133,7 @@ TEST_F(CompositorGoldenTest, TightBoundsGradientWithClipPathSublayer) {
     CompositorConfig config;
     config.tightBoundedSegments = tightBounds;
     CompositorController compositor(document, renderer_, config);
-    compositor.promoteEntity(left->entityHandle().entity(), InteractionHint::Selection);
+    compositor.promoteEntity(left->unsafeEntityHandle().entity(), InteractionHint::Selection);
     compositor.renderFrame(vp);
     return renderer_.takeSnapshot();
   };
@@ -2214,7 +2214,7 @@ TEST_F(CompositorGoldenTest, TightBoundsWithRotatingGradientNoDrift) {
     CompositorConfig config;
     config.tightBoundedSegments = tightBounds;
     CompositorController compositor(document, renderer_, config);
-    compositor.promoteEntity(left->entityHandle().entity(), InteractionHint::Selection);
+    compositor.promoteEntity(left->unsafeEntityHandle().entity(), InteractionHint::Selection);
     compositor.renderFrame(vp);
     return renderer_.takeSnapshot();
   };
@@ -2292,7 +2292,7 @@ TEST_F(CompositorGoldenTest, TightBoundsRotatedEllipseWithRotatingGradient) {
     CompositorConfig config;
     config.tightBoundedSegments = tight;
     CompositorController compositor(document, renderer_, config);
-    compositor.promoteEntity(trigger->entityHandle().entity(), InteractionHint::Selection);
+    compositor.promoteEntity(trigger->unsafeEntityHandle().entity(), InteractionHint::Selection);
     compositor.renderFrame(vp);
     return renderer_.takeSnapshot();
   };
@@ -2360,10 +2360,10 @@ TEST_F(CompositorGoldenTest, SplashLetterThenCloudOrbSelection) {
     CompositorConfig config;
     config.tightBoundedSegments = tightBounds;
     CompositorController compositor(doc, renderer_, config);
-    compositor.promoteEntity(letter->entityHandle().entity(), InteractionHint::Selection);
+    compositor.promoteEntity(letter->unsafeEntityHandle().entity(), InteractionHint::Selection);
     compositor.renderFrame(vp);
-    compositor.demoteEntity(letter->entityHandle().entity());
-    compositor.promoteEntity(orb->entityHandle().entity(), InteractionHint::Selection);
+    compositor.demoteEntity(letter->unsafeEntityHandle().entity());
+    compositor.promoteEntity(orb->unsafeEntityHandle().entity(), InteractionHint::Selection);
     compositor.renderFrame(vp);
     return renderer_.takeSnapshot();
   };
@@ -2508,16 +2508,16 @@ TEST_F(CompositorGoldenTest, SplashCloudsDragMatchesReference) {
     auto target = doc.querySelector("#Clouds_with_gradients");
     EXPECT_TRUE(target.has_value());
     CompositorController compositor(doc, renderer_);
-    compositor.promoteEntity(target->entityHandle().entity(), InteractionHint::Selection);
+    compositor.promoteEntity(target->unsafeEntityHandle().entity(), InteractionHint::Selection);
     compositor.renderFrame(vp);
-    compositor.demoteEntity(target->entityHandle().entity());
+    compositor.demoteEntity(target->unsafeEntityHandle().entity());
     // §M9: flush the hysteresis window so the demote actually fires
     // before the kind-change re-promote — this test specifically
     // probes the demote+promote layer-rebuild path (vs. the
     // hysteresis-preserved layer reuse), so the hysteresis would
     // otherwise mask the very transition under test.
     compositor.flushPendingDemotionsForTesting();
-    compositor.promoteEntity(target->entityHandle().entity(), InteractionHint::ActiveDrag);
+    compositor.promoteEntity(target->unsafeEntityHandle().entity(), InteractionHint::ActiveDrag);
     target->cast<SVGGraphicsElement>().setTransform(Transform2d::Translate(Vector2d(8.0, 0.0)));
     compositor.renderFrame(vp);
     return renderer_.takeSnapshot();
@@ -2593,15 +2593,15 @@ TEST_F(CompositorGoldenTest, DragGroupWithClipPathSiblingAndGradient) {
   viewport.devicePixelRatio = 1.0;
 
   CompositorController compositor(document, renderer_);
-  compositor.promoteEntity(group->entityHandle().entity(), InteractionHint::Selection);
+  compositor.promoteEntity(group->unsafeEntityHandle().entity(), InteractionHint::Selection);
   compositor.renderFrame(viewport);
-  compositor.demoteEntity(group->entityHandle().entity());
+  compositor.demoteEntity(group->unsafeEntityHandle().entity());
   // §M9: flush the hysteresis window so the demote actually fires
   // before the kind-change re-promote — this test probes the
   // demote+promote layer-rebuild path, which the M9 hysteresis would
   // otherwise short-circuit.
   compositor.flushPendingDemotionsForTesting();
-  compositor.promoteEntity(group->entityHandle().entity(), InteractionHint::ActiveDrag);
+  compositor.promoteEntity(group->unsafeEntityHandle().entity(), InteractionHint::ActiveDrag);
   group->cast<SVGGraphicsElement>().setTransform(Transform2d::Translate(Vector2d(40.0, 0.0)));
   compositor.renderFrame(viewport);
   const RendererBitmap composited = renderer_.takeSnapshot();
@@ -2701,15 +2701,15 @@ TEST_F(CompositorGoldenTest, TwoPhaseDragOfPlainGroupMovesChildren) {
   // phase-1 snapshot.
 
   // Two-phase: Selection prewarm → demote → ActiveDrag re-promote.
-  ASSERT_TRUE(compositor.promoteEntity(group->entityHandle().entity(), InteractionHint::Selection));
+  ASSERT_TRUE(compositor.promoteEntity(group->unsafeEntityHandle().entity(), InteractionHint::Selection));
   compositor.renderFrame(viewport);
-  compositor.demoteEntity(group->entityHandle().entity());
+  compositor.demoteEntity(group->unsafeEntityHandle().entity());
   // §M9: flush the hysteresis so the demote+re-promote cycle this
   // test specifically probes still rebuilds the layer rather than
   // taking the hysteresis fast path.
   compositor.flushPendingDemotionsForTesting();
   ASSERT_TRUE(
-      compositor.promoteEntity(group->entityHandle().entity(), InteractionHint::ActiveDrag));
+      compositor.promoteEntity(group->unsafeEntityHandle().entity(), InteractionHint::ActiveDrag));
   group->cast<SVGGraphicsElement>().setTransform(Transform2d::Translate(Vector2d(40.0, 0.0)));
   compositor.renderFrame(viewport);
 
@@ -2749,7 +2749,7 @@ TEST_F(CompositorGoldenTest, SetTightBoundedSegmentsEnabledTogglesAtRuntime) {
   ASSERT_TRUE(target.has_value());
   CompositorController compositorTight(documentTight, renderer_);
   ASSERT_TRUE(compositorTight.tightBoundedSegmentsEnabled());
-  ASSERT_TRUE(compositorTight.promoteEntity(target->entityHandle().entity()));
+  ASSERT_TRUE(compositorTight.promoteEntity(target->unsafeEntityHandle().entity()));
   compositorTight.renderFrame(viewport_);
   // Flip the toggle off — all cached segments are marked dirty and
   // re-rasterize on the next frame at full canvas size.
@@ -2772,7 +2772,7 @@ TEST_F(CompositorGoldenTest, SetTightBoundedSegmentsEnabledTogglesAtRuntime) {
   CompositorConfig refConfig;
   refConfig.tightBoundedSegments = false;
   CompositorController compositorRef(documentRef, renderer_, refConfig);
-  ASSERT_TRUE(compositorRef.promoteEntity(targetRef->entityHandle().entity()));
+  ASSERT_TRUE(compositorRef.promoteEntity(targetRef->unsafeEntityHandle().entity()));
   compositorRef.renderFrame(viewport_);
   const RendererBitmap reference = renderer_.takeSnapshot();
 
@@ -2818,7 +2818,7 @@ TEST_F(CompositorGoldenTest, GradientInsideFilteredGroup_SingleFrame) {
   auto glow = document.querySelector("#glow");
   ASSERT_TRUE(glow.has_value());
   CompositorController compositor(document, renderer_);
-  ASSERT_TRUE(compositor.promoteEntity(glow->entityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(glow->unsafeEntityHandle().entity()));
   compositor.renderFrame(viewport_);
   const RendererBitmap flat = renderer_.takeSnapshot();
   const Pixel halo = getPixel(flat, 70, 50);
@@ -2852,7 +2852,7 @@ TEST_F(CompositorGoldenTest, FlatColorInsideFilteredGroup_RepeatedFrames) {
   auto letter = document.querySelector("#letter");
   ASSERT_TRUE(letter.has_value());
   CompositorController compositor(document, renderer_);
-  ASSERT_TRUE(compositor.promoteEntity(letter->entityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(letter->unsafeEntityHandle().entity()));
   for (int i = 0; i < 5; ++i) {
     letter->cast<SVGGraphicsElement>().setTransform(Transform2d::Translate(Vector2d(i * 5.0, 0.0)));
     compositor.renderFrame(viewport_);
@@ -2888,7 +2888,7 @@ TEST_F(CompositorGoldenTest, DraggingLetterPreservesGradientFilteredGlowAcrossFr
 
   auto letterD = document.querySelector("#letter_D");
   ASSERT_TRUE(letterD.has_value());
-  const Entity entity = letterD->entityHandle().entity();
+  const Entity entity = letterD->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   ASSERT_TRUE(compositor.promoteEntity(entity));
@@ -2935,7 +2935,7 @@ TEST_F(CompositorGoldenTest, DraggingLetterInsideWrapperPreservesNestedGlow) {
   ASSERT_TRUE(letterD.has_value());
 
   CompositorController compositor(document, renderer_);
-  ASSERT_TRUE(compositor.promoteEntity(letterD->entityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(letterD->unsafeEntityHandle().entity()));
 
   compositor.renderFrame(viewport_);
 
@@ -2975,7 +2975,7 @@ TEST_F(CompositorGoldenTest, DraggingLetterPreservesBackgroundGlow) {
 
   CompositorController compositor(document, renderer_);
   // User clicks on letter D to start a drag.
-  ASSERT_TRUE(compositor.promoteEntity(letterD->entityHandle().entity()))
+  ASSERT_TRUE(compositor.promoteEntity(letterD->unsafeEntityHandle().entity()))
       << "letter is not a descendant of any filtered/masked/clipped group, should promote";
 
   // Frame 1: initial render.
@@ -3023,7 +3023,7 @@ TEST_F(CompositorGoldenTest, FilteredGroupWithChildrenRasterizesIncludingChildre
   // drawEntityRange(glow, glow.lastRenderedEntity) should render the circle
   // inside the filter context.
   CompositorController compositor(document, renderer_);
-  ASSERT_TRUE(compositor.promoteEntity(glow->entityHandle().entity()))
+  ASSERT_TRUE(compositor.promoteEntity(glow->unsafeEntityHandle().entity()))
       << "the filter-bearing group itself should promote (it IS the compositing root)";
 
   DualPathVerifier verifier(compositor, renderer_);
@@ -3053,9 +3053,9 @@ TEST_F(CompositorGoldenTest, ChildOfFilteredGroupRequiresFullCanvasPreview) {
   ASSERT_TRUE(target.has_value());
 
   CompositorController compositor(document, renderer_);
-  EXPECT_EQ(compositor.promoteEntity(target->entityHandle().entity()),
+  EXPECT_EQ(compositor.promoteEntity(target->unsafeEntityHandle().entity()),
             CompositorController::PromoteResult::FullCanvasPreviewRequired);
-  EXPECT_FALSE(compositor.isPromoted(target->entityHandle().entity()));
+  EXPECT_FALSE(compositor.isPromoted(target->unsafeEntityHandle().entity()));
   EXPECT_EQ(compositor.layerCount(), 0u);
 }
 
@@ -3078,7 +3078,7 @@ TEST_F(CompositorGoldenTest, ChildOfClippedGroupRequiresFullCanvasPreview) {
   ASSERT_TRUE(target.has_value());
 
   CompositorController compositor(document, renderer_);
-  EXPECT_EQ(compositor.promoteEntity(target->entityHandle().entity()),
+  EXPECT_EQ(compositor.promoteEntity(target->unsafeEntityHandle().entity()),
             CompositorController::PromoteResult::FullCanvasPreviewRequired);
 }
 
@@ -3101,7 +3101,7 @@ TEST_F(CompositorGoldenTest, ChildOfMaskedGroupRequiresFullCanvasPreview) {
   ASSERT_TRUE(target.has_value());
 
   CompositorController compositor(document, renderer_);
-  EXPECT_EQ(compositor.promoteEntity(target->entityHandle().entity()),
+  EXPECT_EQ(compositor.promoteEntity(target->unsafeEntityHandle().entity()),
             CompositorController::PromoteResult::FullCanvasPreviewRequired);
 }
 
@@ -3121,9 +3121,9 @@ TEST_F(CompositorGoldenTest, PlainDescendantStillPromotes) {
   ASSERT_TRUE(target.has_value());
 
   CompositorController compositor(document, renderer_);
-  EXPECT_TRUE(compositor.promoteEntity(target->entityHandle().entity()))
+  EXPECT_TRUE(compositor.promoteEntity(target->unsafeEntityHandle().entity()))
       << "plain `<g>` ancestor without compositing features doesn't block promotion";
-  EXPECT_TRUE(compositor.isPromoted(target->entityHandle().entity()));
+  EXPECT_TRUE(compositor.isPromoted(target->unsafeEntityHandle().entity()));
 }
 
 // Regression: a radially-gradient-filled shape, auto-promoted, renders
@@ -3147,7 +3147,7 @@ TEST_F(CompositorGoldenTest, RadialGradientShapeMatchesFullRenderAfterPromotion)
   ASSERT_TRUE(target.has_value());
 
   CompositorController compositor(document, renderer_);
-  ASSERT_TRUE(compositor.promoteEntity(target->entityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(target->unsafeEntityHandle().entity()));
 
   DualPathVerifier verifier(compositor, renderer_);
   const auto result = verifier.renderAndVerify(viewport_);
@@ -3271,7 +3271,7 @@ TEST_F(CompositorGoldenTest, SplashDragLatencyBudgetsOnRealRenderer) {
 
   auto letter2 = document.querySelector("#letter_2");
   ASSERT_TRUE(letter2.has_value());
-  const Entity letter2Entity = letter2->entityHandle().entity();
+  const Entity letter2Entity = letter2->unsafeEntityHandle().entity();
 
   // Phase 2 — first drag frame. Promotes the drag target for the first
   // time, triggers first-time rasterization of N+1 segments + all promoted
@@ -3378,7 +3378,7 @@ TEST_F(CompositorGoldenTest, SplashPrewarmMakesFirstDragFree) {
 
   auto letter2 = document.querySelector("#letter_2");
   ASSERT_TRUE(letter2.has_value());
-  const Entity letter2Entity = letter2->entityHandle().entity();
+  const Entity letter2Entity = letter2->unsafeEntityHandle().entity();
 
   using Clock = std::chrono::steady_clock;
   const auto elapsedMs = [](Clock::time_point start) {
@@ -3460,7 +3460,7 @@ TEST_F(CompositorGoldenTest, RealSplashDragLatencyOnTinySkia) {
   auto firstLetter = document.querySelector("#Donner path");
   ASSERT_TRUE(firstLetter.has_value())
       << "splash has no `#Donner path` — has the file structure changed?";
-  const Entity letterEntity = firstLetter->entityHandle().entity();
+  const Entity letterEntity = firstLetter->unsafeEntityHandle().entity();
 
   // Phase 2 — first drag frame. Promotes + rasterizes everything.
   ASSERT_TRUE(compositor.promoteEntity(letterEntity))
@@ -3560,7 +3560,7 @@ TEST_F(CompositorGoldenTest, SplashDragEndReplaceDocumentReplayLatency) {
 
   auto letter2 = document.querySelector("#letter_2");
   ASSERT_TRUE(letter2.has_value());
-  const Entity letter2Entity = letter2->entityHandle().entity();
+  const Entity letter2Entity = letter2->unsafeEntityHandle().entity();
 
   // Prewarm + drag a few frames to match the steady-state compositor state.
   ASSERT_TRUE(compositor.promoteEntity(letter2Entity));
@@ -3629,7 +3629,7 @@ TEST_F(CompositorGoldenTest, ResetAllLayersAfterPromoteDoesNotCrash) {
   // Promote + render — populates activeHints_ with a ScopedCompositorHint
   // pinned to the current registry. This is the state that used to crash
   // when `resetAllLayers` ran after the document was replaced.
-  ASSERT_TRUE(compositor.promoteEntity(target->entityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(target->unsafeEntityHandle().entity()));
   compositor.renderFrame(viewport_);
 
   // Drive a few drag frames so mandatoryDetector_ / complexityBucketer_
@@ -3647,13 +3647,13 @@ TEST_F(CompositorGoldenTest, ResetAllLayersAfterPromoteDoesNotCrash) {
   compositor.resetAllLayers();
 
   // Rebuild from scratch after the reset. Must complete without crashing.
-  ASSERT_TRUE(compositor.promoteEntity(target->entityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(target->unsafeEntityHandle().entity()));
   compositor.renderFrame(viewport_);
 
   // A second reset-then-render cycle — the editor's source-writeback path
   // can fire this more than once if the user drags repeatedly.
   compositor.resetAllLayers();
-  ASSERT_TRUE(compositor.promoteEntity(target->entityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(target->unsafeEntityHandle().entity()));
   compositor.renderFrame(viewport_);
 }
 
@@ -3681,7 +3681,7 @@ TEST_F(CompositorGoldenTest, RemapAfterStructuralReplaceIdentityPreservesCaches)
   CompositorController compositor(document, renderer_);
   compositor.setSkipMainComposeDuringSplit(true);
 
-  ASSERT_TRUE(compositor.promoteEntity(target->entityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(target->unsafeEntityHandle().entity()));
   compositor.renderFrame(viewport_);
   // Drive a few drag frames so every cache is warm.
   for (int i = 1; i <= 3; ++i) {
@@ -3691,9 +3691,9 @@ TEST_F(CompositorGoldenTest, RemapAfterStructuralReplaceIdentityPreservesCaches)
   }
 
   const uint8_t* glowBitmapBefore =
-      compositor.layerBitmapOf(glow->entityHandle().entity()).pixels.data();
+      compositor.layerBitmapOf(glow->unsafeEntityHandle().entity()).pixels.data();
   const uint8_t* targetBitmapBefore =
-      compositor.layerBitmapOf(target->entityHandle().entity()).pixels.data();
+      compositor.layerBitmapOf(target->unsafeEntityHandle().entity()).pixels.data();
 
   // Build an identity remap: every entity in the registry maps to itself.
   // Walk the whole registry so we don't miss ancillary entities.
@@ -3707,9 +3707,9 @@ TEST_F(CompositorGoldenTest, RemapAfterStructuralReplaceIdentityPreservesCaches)
       << "identity remap must succeed — every required entity is present";
 
   // Cached bitmaps should be preserved (same `.pixels.data()` pointer).
-  EXPECT_EQ(compositor.layerBitmapOf(glow->entityHandle().entity()).pixels.data(), glowBitmapBefore)
+  EXPECT_EQ(compositor.layerBitmapOf(glow->unsafeEntityHandle().entity()).pixels.data(), glowBitmapBefore)
       << "glow filter-layer bitmap was reallocated during identity remap — cache lost";
-  EXPECT_EQ(compositor.layerBitmapOf(target->entityHandle().entity()).pixels.data(),
+  EXPECT_EQ(compositor.layerBitmapOf(target->unsafeEntityHandle().entity()).pixels.data(),
             targetBitmapBefore)
       << "drag-target bitmap was reallocated during identity remap — cache lost";
 
@@ -3717,7 +3717,7 @@ TEST_F(CompositorGoldenTest, RemapAfterStructuralReplaceIdentityPreservesCaches)
   target->cast<SVGGraphicsElement>().setTransform(Transform2d::Translate(Vector2d(10.0, 0.0)));
   compositor.renderFrame(viewport_);
 
-  EXPECT_EQ(compositor.layerBitmapOf(glow->entityHandle().entity()).pixels.data(), glowBitmapBefore)
+  EXPECT_EQ(compositor.layerBitmapOf(glow->unsafeEntityHandle().entity()).pixels.data(), glowBitmapBefore)
       << "glow bitmap was reallocated on the post-remap drag frame — fast path broke";
 }
 
@@ -3746,9 +3746,9 @@ TEST_F(CompositorGoldenTest, BuildStructuralEntityRemapIdenticalTrees) {
   auto targetInB = docB.querySelector("#target");
   ASSERT_TRUE(targetInA.has_value());
   ASSERT_TRUE(targetInB.has_value());
-  const Entity oldTarget = targetInA->entityHandle().entity();
+  const Entity oldTarget = targetInA->unsafeEntityHandle().entity();
   ASSERT_TRUE(remap.contains(oldTarget)) << "#target is missing from remap";
-  EXPECT_EQ(remap.at(oldTarget), targetInB->entityHandle().entity())
+  EXPECT_EQ(remap.at(oldTarget), targetInB->unsafeEntityHandle().entity())
       << "#target in docA doesn't map to #target in docB";
 }
 
@@ -3809,7 +3809,7 @@ TEST_F(CompositorGoldenTest, BuildStructuralEntityRemapIgnoresAttributeValueChan
   auto dragA = docA.querySelector("#drag");
   auto dragB = docB.querySelector("#drag");
   ASSERT_TRUE(dragA.has_value() && dragB.has_value());
-  EXPECT_EQ(remap.at(dragA->entityHandle().entity()), dragB->entityHandle().entity());
+  EXPECT_EQ(remap.at(dragA->unsafeEntityHandle().entity()), dragB->unsafeEntityHandle().entity());
 }
 
 // Incremental GL-upload discipline: on the first click-to-drag after
@@ -3867,7 +3867,7 @@ TEST_F(CompositorGoldenTest, ClickToDragAdvancesAtMostThreeTileGenerations) {
   // Phase 1 — click + drag in one frame: the editor sets the drag
   // target's transform and posts a render with the letter as the
   // drag entity.
-  ASSERT_TRUE(compositor.promoteEntity(target->entityHandle().entity()));
+  ASSERT_TRUE(compositor.promoteEntity(target->unsafeEntityHandle().entity()));
   target->cast<SVGGraphicsElement>().setTransform(Transform2d::Translate(Vector2d(10.0, 0.0)));
   compositor.renderFrame(vp);
 

--- a/donner/svg/compositor/CompositorPerf_tests.cc
+++ b/donner/svg/compositor/CompositorPerf_tests.cc
@@ -97,7 +97,7 @@ TEST_F(CompositorPerfTest, DragFrameOverhead_1kNodes) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   auto drag = DragSession::begin(compositor, entity);
   ASSERT_TRUE(drag.has_value());
@@ -145,7 +145,7 @@ TEST_F(CompositorPerfTest, PromoteDemoteCycle_1kNodes) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   constexpr int kCycles = 1000;
   auto start = Clock::now();
@@ -174,7 +174,7 @@ TEST_F(CompositorPerfTest, DragFrameOverhead_10kNodes) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   auto drag = DragSession::begin(compositor, entity);
   ASSERT_TRUE(drag.has_value());
@@ -236,7 +236,7 @@ TEST_F(CompositorPerfTest, ClickToFirstDragUpdate_10kNodes) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   RenderViewport viewport;
   viewport.size = Vector2d(1000, 1000);
@@ -296,7 +296,7 @@ TEST_F(CompositorPerfTest, ClickToFirstDragUpdate_1kNodes) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   RenderViewport viewport;
   viewport.size = Vector2d(1000, 1000);

--- a/donner/svg/compositor/DragSession_tests.cc
+++ b/donner/svg/compositor/DragSession_tests.cc
@@ -36,7 +36,7 @@ TEST_F(DragSessionTest, BeginPromotesEntity) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   auto session = DragSession::begin(compositor, entity);
@@ -53,7 +53,7 @@ TEST_F(DragSessionTest, EndDemotesEntity) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   auto session = DragSession::begin(compositor, entity);
@@ -75,7 +75,7 @@ TEST_F(DragSessionTest, DestructorDemotes) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   {
@@ -106,7 +106,7 @@ TEST_F(DragSessionTest, MoveConstructor) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   auto session = DragSession::begin(compositor, entity);
@@ -134,8 +134,8 @@ TEST_F(DragSessionTest, MoveAssignment) {
   auto b = document.querySelector("#b");
   ASSERT_TRUE(a.has_value());
   ASSERT_TRUE(b.has_value());
-  const Entity entityA = a->entityHandle().entity();
-  const Entity entityB = b->entityHandle().entity();
+  const Entity entityA = a->unsafeEntityHandle().entity();
+  const Entity entityB = b->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   auto sessionA = DragSession::begin(compositor, entityA);

--- a/donner/svg/compositor/InteractionHintNoAllocation_tests.cc
+++ b/donner/svg/compositor/InteractionHintNoAllocation_tests.cc
@@ -52,7 +52,7 @@ TEST_F(InteractionHintNoAllocationTest, SteadyStateDragDoesNotChurnECSState) {
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   ASSERT_TRUE(compositor.promoteEntity(entity));
@@ -93,7 +93,7 @@ TEST_F(InteractionHintNoAllocationTest, MandatoryDetectorIsIdleDuringSteadyState
 
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
-  const Entity entity = target->entityHandle().entity();
+  const Entity entity = target->unsafeEntityHandle().entity();
 
   CompositorController compositor(document, renderer_);
   ASSERT_TRUE(compositor.promoteEntity(entity));

--- a/donner/svg/renderer/tests/RenderingContext_tests.cc
+++ b/donner/svg/renderer/tests/RenderingContext_tests.cc
@@ -141,7 +141,7 @@ TEST_F(RenderingContextTest, GetWorldBoundsRect) {
 
   auto element = document.querySelector("#r");
   ASSERT_TRUE(element.has_value());
-  auto bounds = ctx.getWorldBounds(element->entityHandle().entity());
+  auto bounds = ctx.getWorldBounds(element->unsafeEntityHandle().entity());
   ASSERT_TRUE(bounds.has_value());
   EXPECT_NEAR(bounds->topLeft.x, 10.0, 1.0);
   EXPECT_NEAR(bounds->topLeft.y, 20.0, 1.0);
@@ -208,7 +208,7 @@ TEST_F(RenderingContextTest, GroupedElements) {
   RenderingContext ctx(document.registry());
   ctx.instantiateRenderTree(false, warningSink_);
 
-  auto bounds = ctx.getWorldBounds(document.querySelector("#r")->entityHandle().entity());
+  auto bounds = ctx.getWorldBounds(document.querySelector("#r")->unsafeEntityHandle().entity());
   ASSERT_TRUE(bounds.has_value());
   EXPECT_NEAR(bounds->topLeft.x, 50.0, 1.0);
   EXPECT_NEAR(bounds->topLeft.y, 50.0, 1.0);
@@ -346,7 +346,7 @@ TEST_F(RenderingContextTest, PointerEventsBoundingBoxHitsWithoutPaint) {
   )");
 
   RenderingContext ctx(document.registry());
-  const Entity rectEntity = document.querySelector("#r")->entityHandle().entity();
+  const Entity rectEntity = document.querySelector("#r")->unsafeEntityHandle().entity();
   EXPECT_EQ(ctx.findIntersecting(Vector2d(50, 50)), rectEntity);
 }
 
@@ -359,7 +359,7 @@ TEST_F(RenderingContextTest, PointerEventsVisibleFillHitsTransparentFill) {
   )");
 
   RenderingContext ctx(document.registry());
-  const Entity rectEntity = document.querySelector("#r")->entityHandle().entity();
+  const Entity rectEntity = document.querySelector("#r")->unsafeEntityHandle().entity();
   EXPECT_EQ(ctx.findIntersecting(Vector2d(50, 50)), rectEntity);
 }
 
@@ -398,7 +398,7 @@ TEST_F(RenderingContextTest, PointerEventsStrokeHitsHiddenStrokeGeometry) {
   )");
 
   RenderingContext ctx(document.registry());
-  const Entity rectEntity = document.querySelector("#r")->entityHandle().entity();
+  const Entity rectEntity = document.querySelector("#r")->unsafeEntityHandle().entity();
   EXPECT_EQ(ctx.findIntersecting(Vector2d(15, 50)), rectEntity);
   EXPECT_TRUE(ctx.findIntersecting(Vector2d(50, 50)) == entt::null);
 }
@@ -413,8 +413,8 @@ TEST_F(RenderingContextTest, FindIntersectingRectReturnsFrontToBackOrder) {
   )");
 
   RenderingContext ctx(document.registry());
-  const Entity backEntity = document.querySelector("#back")->entityHandle().entity();
-  const Entity frontEntity = document.querySelector("#front")->entityHandle().entity();
+  const Entity backEntity = document.querySelector("#back")->unsafeEntityHandle().entity();
+  const Entity frontEntity = document.querySelector("#front")->unsafeEntityHandle().entity();
 
   const std::vector<Entity> hits = ctx.findIntersectingRect(Box2d::FromXYWH(30, 30, 10, 10));
   ASSERT_THAT(hits.size(), Gt(1u));

--- a/donner/svg/tests/SVGElementLifetime_tests.cc
+++ b/donner/svg/tests/SVGElementLifetime_tests.cc
@@ -105,7 +105,7 @@ TEST(SVGElementLifetimeTests, DetachedElementCollectedAfterLastHandleIsReleased)
   SVGSVGElement root = document.svgElement();
   std::optional<SVGRectElement> rect;
   rect.emplace(SVGRectElement::Create(document));
-  const Entity rectEntity = rect->entityHandle().entity();
+  const Entity rectEntity = rect->unsafeEntityHandle().entity();
   root.appendChild(*rect);
 
   root.removeChild(*rect);
@@ -122,7 +122,7 @@ TEST(SVGElementLifetimeTests, DetachedRootsAreQueuedInDocumentState) {
   SVGSVGElement root = document.svgElement();
   std::optional<SVGRectElement> rect;
   rect.emplace(SVGRectElement::Create(document));
-  const Entity rectEntity = rect->entityHandle().entity();
+  const Entity rectEntity = rect->unsafeEntityHandle().entity();
   root.appendChild(*rect);
 
   root.removeChild(*rect);
@@ -142,7 +142,7 @@ TEST(SVGElementLifetimeTests, DetachedNodeDiagnosticsTrackRetainedAndCollectedRo
   rect.emplace(SVGRectElement::Create(document));
   std::optional<SVGElement> rectCopy;
   rectCopy.emplace(*rect);
-  const Entity rectEntity = rect->entityHandle().entity();
+  const Entity rectEntity = rect->unsafeEntityHandle().entity();
   root.appendChild(*rect);
 
   root.removeChild(*rect);
@@ -186,7 +186,7 @@ TEST(SVGElementLifetimeTests, CollectionDeferralRetainsDetachedRootsUntilGuardEx
   SVGSVGElement root = document.svgElement();
   std::optional<SVGRectElement> rect;
   rect.emplace(SVGRectElement::Create(document));
-  const Entity rectEntity = rect->entityHandle().entity();
+  const Entity rectEntity = rect->unsafeEntityHandle().entity();
   root.appendChild(*rect);
 
   {
@@ -224,7 +224,7 @@ TEST(SVGElementLifetimeTests, RepeatedCreateRemoveReinsertCyclesCollectDetachedN
   for (int cycle = 0; cycle < 64; ++cycle) {
     std::optional<SVGRectElement> rect;
     rect.emplace(SVGRectElement::Create(document));
-    const Entity rectEntity = rect->entityHandle().entity();
+    const Entity rectEntity = rect->unsafeEntityHandle().entity();
 
     root.appendChild(*rect);
     root.removeChild(*rect);
@@ -254,8 +254,8 @@ TEST(SVGElementLifetimeTests, DescendantHandleKeepsDetachedSubtreeAlive) {
   std::optional<SVGRectElement> rect;
   group.emplace(SVGGElement::Create(document));
   rect.emplace(SVGRectElement::Create(document));
-  const Entity groupEntity = group->entityHandle().entity();
-  const Entity rectEntity = rect->entityHandle().entity();
+  const Entity groupEntity = group->unsafeEntityHandle().entity();
+  const Entity rectEntity = rect->unsafeEntityHandle().entity();
   root.appendChild(*group);
   group->appendChild(*rect);
 
@@ -288,7 +288,7 @@ TEST(SVGElementLifetimeTests, ReattachedElementIsNotCollectedWhenHandleIsRelease
   SVGSVGElement root = document.svgElement();
   std::optional<SVGRectElement> rect;
   rect.emplace(SVGRectElement::Create(document));
-  const Entity rectEntity = rect->entityHandle().entity();
+  const Entity rectEntity = rect->unsafeEntityHandle().entity();
   root.appendChild(*rect);
   root.removeChild(*rect);
 
@@ -334,7 +334,7 @@ TEST(SVGElementLifetimeTests, DetachedDuplicateIdDoesNotMaskAttachedReference) {
   const std::optional<ResolvedReference> resolved =
       Reference("#target").resolve(document.registry());
   ASSERT_TRUE(resolved.has_value());
-  EXPECT_EQ(resolved->handle.entity(), attached.entityHandle().entity());
+  EXPECT_EQ(resolved->handle.entity(), attached.unsafeEntityHandle().entity());
 }
 
 TEST(SVGElementLifetimeTests, XmlNodeRemoveUsesLifetimeAwareSvgMutation) {
@@ -346,7 +346,7 @@ TEST(SVGElementLifetimeTests, XmlNodeRemoveUsesLifetimeAwareSvgMutation) {
   SVGDocument document = std::move(maybeDocument.result());
   std::optional<SVGElement> retained = document.querySelector("#target");
   ASSERT_TRUE(retained.has_value());
-  const Entity rectEntity = retained->entityHandle().entity();
+  const Entity rectEntity = retained->unsafeEntityHandle().entity();
   std::optional<xml::XMLNode> retainedNode = xml::XMLNode::TryCast(retained->entityHandle());
   ASSERT_TRUE(retainedNode.has_value());
 

--- a/donner/svg/tests/SVGElement_tests.cc
+++ b/donner/svg/tests/SVGElement_tests.cc
@@ -122,7 +122,7 @@ TEST_F(SVGElementTests, ScopedAccessExposesResolvedHandle) {
 
   const std::uint64_t initialRevision = document_.handle()->revision();
   rect.withWriteAccess([rect](DocumentWriteAccess&, EntityHandle handle) mutable {
-    EXPECT_EQ(handle.entity(), rect.entityHandle().entity());
+    EXPECT_EQ(handle.entity(), rect.unsafeEntityHandle().entity());
     rect.setX(Lengthd(10));
     rect.setY(Lengthd(20));
   });
@@ -1023,9 +1023,9 @@ TEST_F(SVGElementTests, ShadowTreesDoNotEnumerateChildren) {
   Entity child = registry.create();
   registry.emplace<::donner::components::TreeComponent>(child, xml::XMLQualifiedNameRef("rect"));
   registry.emplace<components::ElementTypeComponent>(child, ElementType::Rect);
-  registry.get<::donner::components::TreeComponent>(element.entityHandle().entity())
+  registry.get<::donner::components::TreeComponent>(element.unsafeEntityHandle().entity())
       .appendChild(registry, child);
-  registry.emplace<components::ShadowTreeComponent>(element.entityHandle().entity());
+  registry.emplace<components::ShadowTreeComponent>(element.unsafeEntityHandle().entity());
 
   EXPECT_EQ(element.firstChild(), std::nullopt);
   EXPECT_EQ(element.lastChild(), std::nullopt);

--- a/donner/svg/tests/SVGTreeMutation_tests.cc
+++ b/donner/svg/tests/SVGTreeMutation_tests.cc
@@ -32,7 +32,7 @@ TEST(SVGTreeMutationTests, RootStartsAttachedAndNewElementsStartDetached) {
 
   const SVGRectElement rect = SVGRectElement::Create(document);
   EXPECT_FALSE(LifetimeOf(rect).isAttached());
-  EXPECT_EQ(LifetimeOf(rect).detachedRoot, rect.entityHandle().entity());
+  EXPECT_EQ(LifetimeOf(rect).detachedRoot, rect.unsafeEntityHandle().entity());
 }
 
 TEST(SVGTreeMutationTests, AppendToDetachedParentKeepsInsertedSubtreeDetached) {
@@ -43,9 +43,9 @@ TEST(SVGTreeMutationTests, AppendToDetachedParentKeepsInsertedSubtreeDetached) {
   group.appendChild(rect);
 
   EXPECT_FALSE(LifetimeOf(group).isAttached());
-  EXPECT_EQ(LifetimeOf(group).detachedRoot, group.entityHandle().entity());
+  EXPECT_EQ(LifetimeOf(group).detachedRoot, group.unsafeEntityHandle().entity());
   EXPECT_FALSE(LifetimeOf(rect).isAttached());
-  EXPECT_EQ(LifetimeOf(rect).detachedRoot, group.entityHandle().entity());
+  EXPECT_EQ(LifetimeOf(rect).detachedRoot, group.unsafeEntityHandle().entity());
 }
 
 TEST(SVGTreeMutationTests, AppendDetachedSubtreeToRootMarksWholeSubtreeAttached) {
@@ -102,9 +102,9 @@ TEST(SVGTreeMutationTests, RemoveChildMarksWholeSubtreeDetached) {
   EXPECT_FALSE(group.parentElement().has_value());
   EXPECT_EQ(rect.parentElement(), group);
   EXPECT_FALSE(LifetimeOf(group).isAttached());
-  EXPECT_EQ(LifetimeOf(group).detachedRoot, group.entityHandle().entity());
+  EXPECT_EQ(LifetimeOf(group).detachedRoot, group.unsafeEntityHandle().entity());
   EXPECT_FALSE(LifetimeOf(rect).isAttached());
-  EXPECT_EQ(LifetimeOf(rect).detachedRoot, group.entityHandle().entity());
+  EXPECT_EQ(LifetimeOf(rect).detachedRoot, group.unsafeEntityHandle().entity());
 }
 
 TEST(SVGTreeMutationTests, ReappendDetachedSubtreeMarksWholeSubtreeAttachedAgain) {

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -37,6 +37,14 @@ fi
 
 echo "Analyzing coverage for: ${TARGETS[*]}"
 
+function file_mtime() {
+  if [[ "$(uname)" == "Darwin" ]]; then
+    stat -f %m "$1"
+  else
+    stat -c %Y "$1"
+  fi
+}
+
 # Error if genhtml is not found (only required when HTML output is enabled).
 if [ "$NO_HTML" = false ] && ! which genhtml > /dev/null; then
     echo "ERROR: genhtml not found, please install lcov"
@@ -88,7 +96,7 @@ fi
   # early exit).
   BEFORE_TS=0
   if [ -f "$COVERAGE_REPORT" ]; then
-    BEFORE_TS=$(stat -f %m "$COVERAGE_REPORT" 2>/dev/null || stat -c %Y "$COVERAGE_REPORT" 2>/dev/null || echo 0)
+    BEFORE_TS=$(file_mtime "$COVERAGE_REPORT")
   fi
 
   if [ "$QUIET" = true ]; then
@@ -105,7 +113,7 @@ fi
     exit 1
   fi
 
-  AFTER_TS=$(stat -f %m "$COVERAGE_REPORT" 2>/dev/null || stat -c %Y "$COVERAGE_REPORT" 2>/dev/null || echo 0)
+  AFTER_TS=$(file_mtime "$COVERAGE_REPORT")
   if [ "$AFTER_TS" -le "$BEFORE_TS" ]; then
     echo "ERROR: Coverage report was not updated (stale data from a previous run)"
     exit 1

--- a/tools/mcp-servers/editor-control/EditorControlSession.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSession.cc
@@ -696,7 +696,7 @@ int AttachPngFile(ToolCallResult* out, const std::string& label, const std::file
 
 json ElementJson(const svg::SVGElement& element) {
   return json{
-      {"entity", EntityToJsonValue(element.entityHandle().entity())},
+      {"entity", EntityToJsonValue(element.unsafeEntityHandle().entity())},
       {"tag", element.tagName().toString()},
       {"id", std::string(element.id())},
       {"class", std::string(element.className())},
@@ -2255,7 +2255,7 @@ ToolCallResult EditorControlSession::replayRnr(const json& arguments) {
       Entity selectedEntity = entt::null;
       if (app_.selectedElement().has_value() &&
           app_.selectedElement()->isa<svg::SVGGraphicsElement>()) {
-        selectedEntity = app_.selectedElement()->entityHandle().entity();
+        selectedEntity = app_.selectedElement()->unsafeEntityHandle().entity();
       }
       const PresentationRenderScheduleDecision schedule =
           renderScheduler.evaluate(displayPresentation_, PresentationRenderScheduleInput{
@@ -2670,7 +2670,7 @@ bool EditorControlSession::renderCurrentFrame(std::vector<CapturedRenderResult>*
   Entity selectedEntity = entt::null;
   if (app_.selectedElement().has_value() &&
       app_.selectedElement()->isa<svg::SVGGraphicsElement>()) {
-    selectedEntity = app_.selectedElement()->entityHandle().entity();
+    selectedEntity = app_.selectedElement()->unsafeEntityHandle().entity();
   }
   displayPresentation_.clearSettlingIfSelectionChanged(selectedEntity, activePreview.has_value());
 


### PR DESCRIPTION
Follow-up to PR #596, addressing the AsyncRenderer threading-mode flip-back review feedback and keeping the public DOM API within the existing ECS escape-hatch boundary.

## What this PR does

**AsyncRenderer simplification.** The worker no longer flips the document between `SingleThreaded` and `ConcurrentDom` on every render iteration. On first render it transitions the editor document into `ThreadingMode::ConcurrentDom` and leaves it there for the editor lifetime. UI-thread reads are responsible for explicit guards (`withReadAccess` / scoped `DocumentReadAccess`) where they touch the live document.

**Existing ECS escape hatch only.** The proposed public `SVGElement::entity()` accessor was removed. Call sites that only need the entity id now use the existing documented advanced escape hatch: `unsafeEntityHandle().entity()`.

**Guarded mutation entry points.** All `SVGDocument` mutation entry points that resolve `SVGElement` handles now acquire `writeAccess()` up front: `applySourceEdit`, `setElementAttribute`, `removeElementAttribute`, `insertElement`, and `removeElement`.

**Coverage CI robustness.** `tools/coverage.sh` now uses an OS-aware file mtime helper so Linux does not accidentally parse GNU `stat -f` filesystem metadata as an integer timestamp when checking for stale coverage reports.

## Still Deferred

Comments 4 / 8 / 3 from PR #596's review remain separate follow-ups: removing the per-getter `DocumentReadAccess` lines in SVG element classes, and adding an implicit invalidate-on-scope-exit hook.

## Validation

Local checks for this follow-up:

```
bash -n tools/coverage.sh
git diff --check
```

Prior branch validation before the coverage-script follow-up:

```
bazel test //donner/editor/... //donner/svg/... //donner/base/... //tools/...
```

PR CI is running on the latest push.