### PR TITLE
Fix structured editing stress artifact PNG stride

### DIFF
--- a/donner/editor/tests/StructuredEditingStress_tests.cc
+++ b/donner/editor/tests/StructuredEditingStress_tests.cc
@@ -108,9 +108,13 @@ void WriteBitmapArtifact(const std::filesystem::path& path, const svg::RendererB
     return;
   }
 
+  ASSERT_EQ(bitmap.rowBytes % 4u, 0u) << path;
+  ASSERT_EQ(bitmap.pixels.size(), bitmap.rowBytes * static_cast<std::size_t>(bitmap.dimensions.y))
+      << path;
+  const std::size_t strideInPixels = bitmap.rowBytes / 4u;
   svg::RendererImageIO::writeRgbaPixelsToPngFile(path.string().c_str(), bitmap.pixels,
                                                  bitmap.dimensions.x, bitmap.dimensions.y,
-                                                 bitmap.rowBytes);
+                                                 strideInPixels);
 }
 
 svg::RendererBitmap BuildDiffBitmap(const svg::RendererBitmap& actual,


### PR DESCRIPTION
## Summary

Fixes the main-branch CI failure in `//donner/editor/tests:structured_editing_stress_tests` from [run 26492436444 / job 78012983397](https://github.com/jwmcglynn/donner/actions/runs/26492436444/job/78012983397).

The stress-test artifact helper was passing `RendererBitmap::rowBytes` directly to `RendererImageIO::writeRgbaPixelsToPngFile`, whose parameter is stride in pixels. In sandboxed Bazel/CI runs this made stb encode PNG rows with a 4x stride and read past the bitmap buffer, causing a segfault while writing failure artifacts.

This converts `rowBytes` to pixels and adds layout assertions so future malformed bitmaps fail with a useful gtest message instead of crashing.

## Validation

- `tools/llm-bazel-wrap.sh test //donner/editor/tests:structured_editing_stress_tests --test_arg=--gtest_filter=StructuredEditingStressTest.FailureArtifactsIncludeReplayAndBitmapDiffFiles`
- `tools/llm-bazel-wrap.sh test //donner/editor/tests:structured_editing_stress_tests --nocache_test_results`