### PR TITLE
Make self-hosted CI tolerate remote cache outages

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -75,6 +75,11 @@ jobs:
   coverage-self-hosted:
     runs-on: [self-hosted, linux, arm64, event-horizon]
     if: ${{ vars.SELFHOSTED_LINUX_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
+    env:
+      # The runner host may add the LAN Bazel cache from its home rc. Keep
+      # coverage resilient when the private gRPC endpoint is down.
+      BAZEL_SELF_HOSTED_REMOTE_FALLBACK_FLAGS: "--remote_local_fallback=true --incompatible_remote_local_fallback_for_remote_cache=true --remote_timeout=5s"
+      DONNER_COVERAGE_BAZEL_FLAGS: "--remote_local_fallback=true --incompatible_remote_local_fallback_for_remote_cache=true --remote_timeout=5s"
 
     steps:
       - uses: actions/checkout@v6
@@ -98,7 +103,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          bazelisk fetch --config=latest_llvm \
+          bazelisk fetch --config=latest_llvm $BAZEL_SELF_HOSTED_REMOTE_FALLBACK_FLAGS \
             //donner/base/... \
             //donner/css/... \
             //donner/svg/... \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -320,6 +320,11 @@ jobs:
     runs-on: [self-hosted, linux, arm64, event-horizon]
     needs: [gatekeeper, determine-targets]
     if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') && vars.SELFHOSTED_LINUX_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
+    env:
+      # The runner host may add the LAN Bazel cache from its home rc. Keep
+      # that acceleration when it is healthy, but fall back to local execution
+      # if the private gRPC endpoint is down.
+      BAZEL_SELF_HOSTED_REMOTE_FALLBACK_FLAGS: "--remote_local_fallback=true --incompatible_remote_local_fallback_for_remote_cache=true --remote_timeout=5s"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -358,7 +363,7 @@ jobs:
           else
             echo "${{ needs.determine-targets.outputs.affected }}"
           fi)
-          bazelisk fetch --config=ci $TARGETS
+          bazelisk fetch --config=ci $BAZEL_SELF_HOSTED_REMOTE_FALLBACK_FLAGS $TARGETS
           patch-bazel-llvm-tools /var/cache/bazel/user-root
           # `fetch` starts a Bazel server before we patch the downloaded
           # linker. Restart it so build/test action inputs are digested from
@@ -374,7 +379,7 @@ jobs:
           else
             echo "${{ needs.determine-targets.outputs.affected }}"
           fi)
-          bazelisk build --config=ci $TARGETS
+          bazelisk build --config=ci $BAZEL_SELF_HOSTED_REMOTE_FALLBACK_FLAGS $TARGETS
 
       - name: Test
         shell: bash
@@ -386,7 +391,7 @@ jobs:
             echo "${{ needs.determine-targets.outputs.affected }}"
           fi)
           bazelisk test --config=ci --test_output=errors \
-            $TARGETS
+            $BAZEL_SELF_HOSTED_REMOTE_FALLBACK_FLAGS $TARGETS
 
 
   macos:
@@ -461,8 +466,9 @@ jobs:
     env:
       # The runner host has an operator ~/.bazelrc for interactive RE/cache work.
       # The invocations below use --nohome_rc so CI matches GitHub-hosted macOS
-      # and only picks up cache settings declared in this workflow.
-      BAZEL_MACOS_BUILD_FLAGS: "--macos_minimum_os=13.3 --remote_cache=grpc://192.168.1.63:9092 --remote_upload_local_results=true"
+      # and only picks up cache settings declared in this workflow. Cache/RE
+      # outages degrade to local execution instead of failing the CI gate.
+      BAZEL_MACOS_BUILD_FLAGS: "--macos_minimum_os=13.3 --remote_cache=grpc://192.168.1.63:9092 --remote_upload_local_results=true --remote_local_fallback=true --incompatible_remote_local_fallback_for_remote_cache=true --remote_timeout=5s"
       BAZEL_MACOS_TEST_FLAGS: "--test_env=HOME"
     steps:
       - name: Checkout

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -29,6 +29,11 @@ function file_mtime() {
 }
 
 TARGETS=()
+BAZEL_COVERAGE_FLAGS=()
+
+if [[ -n "${DONNER_COVERAGE_BAZEL_FLAGS:-}" ]]; then
+  read -r -a BAZEL_COVERAGE_FLAGS <<< "$DONNER_COVERAGE_BAZEL_FLAGS"
+fi
 
 # Check for --quiet option
 QUIET=false
@@ -117,10 +122,12 @@ fi
 
   if [ "$QUIET" = true ]; then
     bazel coverage --config=latest_llvm --ui_event_filters=-info,-stdout,-stderr --noshow_progress \
+      "${BAZEL_COVERAGE_FLAGS[@]}" \
       --action_env=BAZEL_LLVM_COV=$LLVM_COV_PATH --action_env=GCOV=$LLVM_PROFDATA_PATH \
       $BAZEL_TEST_ENV "${TARGETS[@]}" || true
   else
-    bazel coverage --config=latest_llvm --action_env=BAZEL_LLVM_COV=$LLVM_COV_PATH \
+    bazel coverage --config=latest_llvm "${BAZEL_COVERAGE_FLAGS[@]}" \
+      --action_env=BAZEL_LLVM_COV=$LLVM_COV_PATH \
       --action_env=GCOV=$LLVM_PROFDATA_PATH $BAZEL_TEST_ENV "${TARGETS[@]}" || true
   fi
 


### PR DESCRIPTION

## Summary

- add Bazel remote-cache fallback flags to self-hosted Linux CI and coverage lanes
- add the same fallback behavior to the self-hosted macOS cache flags
- let tools/coverage.sh receive extra Bazel flags through DONNER_COVERAGE_BAZEL_FLAGS

## Root Cause

The main branch CI failure was caused by Bazel timing out while querying grpc://192.168.1.63:9092. The GitHub Actions runners were alive, but the private Bazel cache/RE endpoint was unreachable, so builds failed before any test failures were observed.

## Validation

- ruby -e "require \"yaml\"; YAML.load_file(\".github/workflows/main.yml\"); YAML.load_file(\".github/workflows/coverage.yml\")"
- bash -n tools/coverage.sh
- git diff --check HEAD~1 HEAD
- bazel --batch --output_user_root=/private/tmp/bazel-help help build | rg "remote_local_fallback|incompatible_remote_local_fallback_for_remote_cache|remote_timeout"
- env LLM=1 bazel test //... attempted; local macOS build failed before tests because this invocation lacks the workflow macOS deployment target and libc++ marks std::filesystem unavailable below macOS 10.15
