### PR TITLE
fix(sandbox): EncodeColor CurrentColor fallback should be transparent, not opaque white

### DIFF
--- a/donner/editor/sandbox/SandboxCodecs.cc
+++ b/donner/editor/sandbox/SandboxCodecs.cc
@@ -126,14 +126,16 @@ void EncodeColor(WireWriter& w, const css::Color& color) {
   // S2: everything gets flattened to an RGBA variant on the wire. A `u8` tag
   // precedes the RGBA so future versions can reintroduce HSLA/CurrentColor
   // without breaking older readers.
-  css::RGBA rgba = css::RGBA();
+  // CurrentColor (and any unhandled variant) is not resolvable here — fall back to
+  // fully-transparent black, matching Donner's CSS-side "currentColor with no context"
+  // semantic. Note a default-constructed css::RGBA() is opaque *white* (r=g=b=a=0xFF), so the
+  // transparent fallback must be spelled out explicitly.
+  css::RGBA rgba = css::RGBA(0, 0, 0, 0);
   if (std::holds_alternative<css::RGBA>(color.value)) {
     rgba = std::get<css::RGBA>(color.value);
   } else if (std::holds_alternative<css::HSLA>(color.value)) {
     rgba = std::get<css::HSLA>(color.value).toRGBA();
   }
-  // CurrentColor is not resolvable here — fallback to fully-transparent, which
-  // matches Donner's CSS-side semantic of "currentColor with no context".
 
   w.writeU8(1);  // tag: RGBA
   EncodeRgba(w, rgba);

--- a/donner/editor/sandbox/tests/WireFormat_tests.cc
+++ b/donner/editor/sandbox/tests/WireFormat_tests.cc
@@ -1037,16 +1037,17 @@ TEST(CodecTest, ColorHslaFlattenedToRgba) {
   EXPECT_EQ(std::get<css::RGBA>(out.value), css::RGBA(255, 0, 0, 255));
 }
 
-TEST(CodecTest, ColorCurrentColorEncodesAsDefaultRgba) {
-  // CurrentColor is not resolvable at encode time, so the encoder writes a
-  // default-constructed css::RGBA() (opaque white) under the RGBA tag.
+TEST(CodecTest, ColorCurrentColorEncodesAsTransparent) {
+  // CurrentColor is not resolvable at encode time, so the encoder writes fully-transparent
+  // black under the RGBA tag (the "currentColor with no context" fallback) — not the opaque
+  // white of a default-constructed css::RGBA().
   WireWriter w;
   EncodeColor(w, css::Color(css::Color::CurrentColor()));
   WireReader r(w.data());
   css::Color out(css::RGBA(1, 2, 3, 4));
   ASSERT_TRUE(DecodeColor(r, out));
   ASSERT_TRUE(std::holds_alternative<css::RGBA>(out.value));
-  EXPECT_EQ(std::get<css::RGBA>(out.value), css::RGBA());
+  EXPECT_EQ(std::get<css::RGBA>(out.value), css::RGBA(0, 0, 0, 0));
 }
 
 TEST(CodecTest, ColorRejectsUnknownTag) {


### PR DESCRIPTION
Fixes the `EncodeColor` semantics bug surfaced by the #620 coverage tests.

`EncodeColor()` initialized its RGBA to a default-constructed `css::RGBA()` for the CurrentColor (and any unhandled) variant, intending the "fully-transparent / currentColor with no context" fallback its comment describes. But `css::RGBA()` defaults to `r=g=b=a=0xFF` — **opaque white** — so an unresolved currentColor serialized over the sandbox wire protocol painted as opaque white. Fixed to spell out transparent black `RGBA(0,0,0,0)`.

**Red→green:** `CodecTest.ColorCurrentColorEncodesAsTransparent` asserts `rgba(0,0,0,0)`; it produced `rgba(255,255,255,255)` at the parent commit, passes here. Full sandbox suite (incl. wire fuzzer) green.

**Stacked on #620** (the test it updates lives there). Base will retarget to `main` once #620 merges.