### PR TITLE
refactor: footgun-free Property access pattern (remove getRequired/hasValue)

### DIFF
--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -238,7 +238,7 @@ std::optional<css::RGBA> ParseColorAttribute(std::string_view value) {
 }
 
 css::RGBA CurrentColorForElement(const svg::SVGElement& element) {
-  const css::Color color = element.getComputedStyle().color.getRequired();
+  const css::Color color = element.getComputedStyle().color.get().value();
   return color.isCurrentColor() ? css::RGBA::RGB(0, 0, 0) : color.asRGBA();
 }
 
@@ -354,7 +354,7 @@ ToolbarPaintSlotState ToolbarPaintSlotStateForElement(const svg::SVGElement& ele
                                                       std::optional<std::string_view> source) {
   const auto& style = element.getComputedStyle();
   const svg::PaintServer paint =
-      attrName == "fill" ? style.fill.getRequired() : style.stroke.getRequired();
+      attrName == "fill" ? style.fill.get().value() : style.stroke.get().value();
   ToolbarPaintSlotState state =
       ToolbarPaintSlotStateForPaintServer(paint, CurrentColorForElement(element), document, source);
 

--- a/donner/editor/OverlayRenderer.cc
+++ b/donner/editor/OverlayRenderer.cc
@@ -185,7 +185,7 @@ Path TransformPathToDocument(const Path& path, const Transform2d& documentFromEl
 }
 
 bool ElementDisplayNone(const svg::SVGElement& element) {
-  return element.getComputedStyle().display.getRequired() == svg::Display::None;
+  return element.getComputedStyle().display.get().value() == svg::Display::None;
 }
 
 bool HasDisplayNoneInAncestorChain(const svg::SVGElement& element) {

--- a/donner/editor/RenderCoordinator.cc
+++ b/donner/editor/RenderCoordinator.cc
@@ -109,7 +109,7 @@ std::optional<svg::SVGElement> SelectedGraphicsElement(EditorApp& app) {
 }
 
 bool IsDisplayNone(const svg::SVGElement& element) {
-  return element.getComputedStyle().display.getRequired() == svg::Display::None;
+  return element.getComputedStyle().display.get().value() == svg::Display::None;
 }
 
 }  // namespace

--- a/donner/editor/SidebarPresenter.cc
+++ b/donner/editor/SidebarPresenter.cc
@@ -237,7 +237,7 @@ double FirstSelectedStrokeWidth(const EditorApp& app) {
     return 1.0;
   }
 
-  return selection.front().getComputedStyle().strokeWidth.getRequired().value;
+  return selection.front().getComputedStyle().strokeWidth.get().value().value;
 }
 
 bool RenderStrokeControlsPanel(EditorApp* liveApp) {

--- a/donner/editor/tests/DocumentSyncController_tests.cc
+++ b/donner/editor/tests/DocumentSyncController_tests.cc
@@ -125,7 +125,7 @@ TEST_F(DocumentSyncControllerTest, ThrottledCompletedStyleEditReportsWakeAndAppl
   rect = app_.document().document().querySelector("#r1");
   ASSERT_TRUE(rect.has_value());
   EXPECT_EQ(rect->getAttribute("style"), std::optional<RcString>(RcString("display:none")));
-  EXPECT_EQ(rect->getComputedStyle().display.getRequired(), svg::Display::None);
+  EXPECT_EQ(rect->getComputedStyle().display.get().value(), svg::Display::None);
 }
 
 TEST_F(DocumentSyncControllerTest, PartialOpeningTagEditPreservesSelectionWhileInvalid) {
@@ -194,7 +194,7 @@ TEST_F(DocumentSyncControllerTest, TypingDisplayNoneBeforePathClassKeepsSelectio
   }
 
   ASSERT_TRUE(app_.selectedElement().has_value());
-  EXPECT_EQ(app_.selectedElement()->getComputedStyle().display.getRequired(), svg::Display::None);
+  EXPECT_EQ(app_.selectedElement()->getComputedStyle().display.get().value(), svg::Display::None);
 }
 
 TEST_F(DocumentSyncControllerTest, RevertingTextToCleanBaselineClearsDirtyFlag) {

--- a/donner/svg/SVGCircleElement.cc
+++ b/donner/svg/SVGCircleElement.cc
@@ -38,32 +38,32 @@ void SVGCircleElement::setR(Lengthd value) {
 
 Lengthd SVGCircleElement::cx() const {
   const auto* component = handle_.try_get<components::CircleComponent>();
-  return component ? component->properties.cx.getRequired() : Lengthd();
+  return component ? component->properties.cx.get().value() : Lengthd();
 }
 
 Lengthd SVGCircleElement::cy() const {
   const auto* component = handle_.try_get<components::CircleComponent>();
-  return component ? component->properties.cy.getRequired() : Lengthd();
+  return component ? component->properties.cy.get().value() : Lengthd();
 }
 
 Lengthd SVGCircleElement::r() const {
   const auto* component = handle_.try_get<components::CircleComponent>();
-  return component ? component->properties.r.getRequired() : Lengthd();
+  return component ? component->properties.r.get().value() : Lengthd();
 }
 
 Lengthd SVGCircleElement::computedCx() const {
   compute();
-  return handle_.get<components::ComputedCircleComponent>().properties.cx.getRequired();
+  return handle_.get<components::ComputedCircleComponent>().properties.cx.get().value();
 }
 
 Lengthd SVGCircleElement::computedCy() const {
   compute();
-  return handle_.get<components::ComputedCircleComponent>().properties.cy.getRequired();
+  return handle_.get<components::ComputedCircleComponent>().properties.cy.get().value();
 }
 
 Lengthd SVGCircleElement::computedR() const {
   compute();
-  return handle_.get<components::ComputedCircleComponent>().properties.r.getRequired();
+  return handle_.get<components::ComputedCircleComponent>().properties.r.get().value();
 }
 
 void SVGCircleElement::invalidate() const {

--- a/donner/svg/SVGEllipseElement.cc
+++ b/donner/svg/SVGEllipseElement.cc
@@ -46,12 +46,12 @@ void SVGEllipseElement::setRy(std::optional<Lengthd> value) {
 
 Lengthd SVGEllipseElement::cx() const {
   const auto* component = handle_.try_get<components::EllipseComponent>();
-  return component ? component->properties.cx.getRequired() : Lengthd();
+  return component ? component->properties.cx.get().value() : Lengthd();
 }
 
 Lengthd SVGEllipseElement::cy() const {
   const auto* component = handle_.try_get<components::EllipseComponent>();
-  return component ? component->properties.cy.getRequired() : Lengthd();
+  return component ? component->properties.cy.get().value() : Lengthd();
 }
 
 std::optional<Lengthd> SVGEllipseElement::rx() const {
@@ -66,12 +66,12 @@ std::optional<Lengthd> SVGEllipseElement::ry() const {
 
 Lengthd SVGEllipseElement::computedCx() const {
   compute();
-  return handle_.get<components::ComputedEllipseComponent>().properties.cx.getRequired();
+  return handle_.get<components::ComputedEllipseComponent>().properties.cx.get().value();
 }
 
 Lengthd SVGEllipseElement::computedCy() const {
   compute();
-  return handle_.get<components::ComputedEllipseComponent>().properties.cy.getRequired();
+  return handle_.get<components::ComputedEllipseComponent>().properties.cy.get().value();
 }
 
 Lengthd SVGEllipseElement::computedRx() const {

--- a/donner/svg/SVGImageElement.cc
+++ b/donner/svg/SVGImageElement.cc
@@ -87,14 +87,14 @@ void SVGImageElement::setHeight(std::optional<Lengthd> value) {
 
 Lengthd SVGImageElement::x() const {
   const auto* component = handle_.try_get<components::SizedElementComponent>();
-  return component ? component->properties.x.getRequired()
-                   : components::SizedElementComponent().properties.x.getRequired();
+  return component ? component->properties.x.get().value()
+                   : components::SizedElementComponent().properties.x.get().value();
 }
 
 Lengthd SVGImageElement::y() const {
   const auto* component = handle_.try_get<components::SizedElementComponent>();
-  return component ? component->properties.y.getRequired()
-                   : components::SizedElementComponent().properties.y.getRequired();
+  return component ? component->properties.y.get().value()
+                   : components::SizedElementComponent().properties.y.get().value();
 }
 
 std::optional<Lengthd> SVGImageElement::width() const {

--- a/donner/svg/SVGPatternElement.cc
+++ b/donner/svg/SVGPatternElement.cc
@@ -50,14 +50,14 @@ PreserveAspectRatio SVGPatternElement::preserveAspectRatio() const {
 
 Lengthd SVGPatternElement::x() const {
   const auto* component = handle_.try_get<components::PatternComponent>();
-  return component ? component->sizeProperties.x.getRequired()
-                   : components::PatternComponent().sizeProperties.x.getRequired();
+  return component ? component->sizeProperties.x.get().value()
+                   : components::PatternComponent().sizeProperties.x.get().value();
 }
 
 Lengthd SVGPatternElement::y() const {
   const auto* component = handle_.try_get<components::PatternComponent>();
-  return component ? component->sizeProperties.y.getRequired()
-                   : components::PatternComponent().sizeProperties.y.getRequired();
+  return component ? component->sizeProperties.y.get().value()
+                   : components::PatternComponent().sizeProperties.y.get().value();
 }
 
 std::optional<Lengthd> SVGPatternElement::width() const {

--- a/donner/svg/SVGRectElement.cc
+++ b/donner/svg/SVGRectElement.cc
@@ -61,22 +61,22 @@ void SVGRectElement::setRy(std::optional<Lengthd> value) {
 
 Lengthd SVGRectElement::x() const {
   const auto* component = handle_.try_get<components::RectComponent>();
-  return component ? component->properties.x.getRequired() : Lengthd();
+  return component ? component->properties.x.get().value() : Lengthd();
 }
 
 Lengthd SVGRectElement::y() const {
   const auto* component = handle_.try_get<components::RectComponent>();
-  return component ? component->properties.y.getRequired() : Lengthd();
+  return component ? component->properties.y.get().value() : Lengthd();
 }
 
 Lengthd SVGRectElement::width() const {
   const auto* component = handle_.try_get<components::RectComponent>();
-  return component ? component->properties.width.getRequired() : Lengthd();
+  return component ? component->properties.width.get().value() : Lengthd();
 }
 
 Lengthd SVGRectElement::height() const {
   const auto* component = handle_.try_get<components::RectComponent>();
-  return component ? component->properties.height.getRequired() : Lengthd();
+  return component ? component->properties.height.get().value() : Lengthd();
 }
 
 std::optional<Lengthd> SVGRectElement::rx() const {
@@ -91,22 +91,22 @@ std::optional<Lengthd> SVGRectElement::ry() const {
 
 Lengthd SVGRectElement::computedX() const {
   compute();
-  return handle_.get<components::ComputedRectComponent>().properties.x.getRequired();
+  return handle_.get<components::ComputedRectComponent>().properties.x.get().value();
 }
 
 Lengthd SVGRectElement::computedY() const {
   compute();
-  return handle_.get<components::ComputedRectComponent>().properties.y.getRequired();
+  return handle_.get<components::ComputedRectComponent>().properties.y.get().value();
 }
 
 Lengthd SVGRectElement::computedWidth() const {
   compute();
-  return handle_.get<components::ComputedRectComponent>().properties.width.getRequired();
+  return handle_.get<components::ComputedRectComponent>().properties.width.get().value();
 }
 
 Lengthd SVGRectElement::computedHeight() const {
   compute();
-  return handle_.get<components::ComputedRectComponent>().properties.height.getRequired();
+  return handle_.get<components::ComputedRectComponent>().properties.height.get().value();
 }
 
 Lengthd SVGRectElement::computedRx() const {

--- a/donner/svg/SVGSVGElement.cc
+++ b/donner/svg/SVGSVGElement.cc
@@ -32,19 +32,19 @@ PreserveAspectRatio SVGSVGElement::preserveAspectRatio() const {
 }
 
 Lengthd SVGSVGElement::x() const {
-  return handle_.get<components::SizedElementComponent>().properties.x.getRequired();
+  return handle_.get<components::SizedElementComponent>().properties.x.get().value();
 }
 
 Lengthd SVGSVGElement::y() const {
-  return handle_.get<components::SizedElementComponent>().properties.y.getRequired();
+  return handle_.get<components::SizedElementComponent>().properties.y.get().value();
 }
 
 std::optional<Lengthd> SVGSVGElement::width() const {
-  return handle_.get<components::SizedElementComponent>().properties.width.getRequired();
+  return handle_.get<components::SizedElementComponent>().properties.width.get().value();
 }
 
 std::optional<Lengthd> SVGSVGElement::height() const {
-  return handle_.get<components::SizedElementComponent>().properties.height.getRequired();
+  return handle_.get<components::SizedElementComponent>().properties.height.get().value();
 }
 
 void SVGSVGElement::setViewBox(std::optional<Box2d> viewBox) {

--- a/donner/svg/SVGStopElement.cc
+++ b/donner/svg/SVGStopElement.cc
@@ -47,14 +47,14 @@ float SVGStopElement::offset() const {
 
 css::Color SVGStopElement::stopColor() const {
   const auto* component = handle_.try_get<components::StopComponent>();
-  return component ? component->properties.stopColor.getRequired()
-                   : components::StopProperties().stopColor.getRequired();
+  return component ? component->properties.stopColor.get().value()
+                   : components::StopProperties().stopColor.get().value();
 }
 
 double SVGStopElement::stopOpacity() const {
   const auto* component = handle_.try_get<components::StopComponent>();
-  return component ? component->properties.stopOpacity.getRequired()
-                   : components::StopProperties().stopOpacity.getRequired();
+  return component ? component->properties.stopOpacity.get().value()
+                   : components::StopProperties().stopOpacity.get().value();
 }
 
 css::Color SVGStopElement::computedStopColor() const {
@@ -62,7 +62,7 @@ css::Color SVGStopElement::computedStopColor() const {
   ParseWarningSink disabledSink = ParseWarningSink::Disabled();
   const components::ComputedStopComponent& computed = components::PaintSystem().createComputedStop(
       handle_, handle_.get_or_emplace<components::StopComponent>(access), disabledSink);
-  return computed.properties.stopColor.getRequired();
+  return computed.properties.stopColor.get().value();
 }
 
 double SVGStopElement::computedStopOpacity() const {
@@ -70,7 +70,7 @@ double SVGStopElement::computedStopOpacity() const {
   ParseWarningSink disabledSink = ParseWarningSink::Disabled();
   const components::ComputedStopComponent& computed = components::PaintSystem().createComputedStop(
       handle_, handle_.get_or_emplace<components::StopComponent>(access), disabledSink);
-  return computed.properties.stopOpacity.getRequired();
+  return computed.properties.stopOpacity.get().value();
 }
 
 void SVGStopElement::invalidate() const {

--- a/donner/svg/SVGSymbolElement.cc
+++ b/donner/svg/SVGSymbolElement.cc
@@ -69,8 +69,8 @@ void SVGSymbolElement::setX(Lengthd value) {
 
 Lengthd SVGSymbolElement::x() const {
   const auto* component = handle_.try_get<components::SizedElementComponent>();
-  return component ? component->properties.x.getRequired()
-                   : components::SizedElementComponent().properties.x.getRequired();
+  return component ? component->properties.x.get().value()
+                   : components::SizedElementComponent().properties.x.get().value();
 }
 
 void SVGSymbolElement::setY(Lengthd value) {
@@ -83,8 +83,8 @@ void SVGSymbolElement::setY(Lengthd value) {
 
 Lengthd SVGSymbolElement::y() const {
   const auto* component = handle_.try_get<components::SizedElementComponent>();
-  return component ? component->properties.y.getRequired()
-                   : components::SizedElementComponent().properties.y.getRequired();
+  return component ? component->properties.y.get().value()
+                   : components::SizedElementComponent().properties.y.get().value();
 }
 
 void SVGSymbolElement::setWidth(std::optional<Lengthd> value) {

--- a/donner/svg/SVGUseElement.cc
+++ b/donner/svg/SVGUseElement.cc
@@ -79,14 +79,14 @@ void SVGUseElement::setHeight(std::optional<Lengthd> value) {
 
 Lengthd SVGUseElement::x() const {
   const auto* component = handle_.try_get<components::SizedElementComponent>();
-  return component ? component->properties.x.getRequired()
-                   : components::SizedElementComponent().properties.x.getRequired();
+  return component ? component->properties.x.get().value()
+                   : components::SizedElementComponent().properties.x.get().value();
 }
 
 Lengthd SVGUseElement::y() const {
   const auto* component = handle_.try_get<components::SizedElementComponent>();
-  return component ? component->properties.y.getRequired()
-                   : components::SizedElementComponent().properties.y.getRequired();
+  return component ? component->properties.y.get().value()
+                   : components::SizedElementComponent().properties.y.get().value();
 }
 
 std::optional<Lengthd> SVGUseElement::width() const {

--- a/donner/svg/components/filter/FilterSystem.cc
+++ b/donner/svg/components/filter/FilterSystem.cc
@@ -103,17 +103,17 @@ filter_primitive::Flood resolveFloodProperties(const Registry& registry, entt::e
     }
 
     // Resolve currentColor.
-    if (props.floodColor.hasValue() && props.floodColor.getRequired().isCurrentColor()) {
+    if (props.floodColor.isSpecified() && props.floodColor.get().value().isCurrentColor()) {
       const auto& currentColor = style->properties->color;
-      props.floodColor.set(currentColor.getRequired(), currentColor.specificity);
+      props.floodColor.set(currentColor.get().value(), currentColor.specificity);
     }
   }
 
-  if (props.floodColor.hasValue()) {
-    flood.floodColor = props.floodColor.getRequired();
+  if (props.floodColor.isSpecified()) {
+    flood.floodColor = props.floodColor.get().value();
   }
-  if (props.floodOpacity.hasValue()) {
-    flood.floodOpacity = props.floodOpacity.getRequired();
+  if (props.floodOpacity.isSpecified()) {
+    flood.floodOpacity = props.floodOpacity.get().value();
   }
 
   return flood;
@@ -154,13 +154,13 @@ css::Color resolveLightingColor(const Registry& registry, entt::entity cur,
     }
 
     // Resolve currentColor.
-    if (lightingColor.hasValue() && lightingColor.getRequired().isCurrentColor()) {
+    if (lightingColor.isSpecified() && lightingColor.get().value().isCurrentColor()) {
       const auto& currentColor = style->properties->color;
-      lightingColor.set(currentColor.getRequired(), currentColor.specificity);
+      lightingColor.set(currentColor.get().value(), currentColor.specificity);
     }
   }
 
-  return lightingColor.getRequired();
+  return lightingColor.get().value();
 }
 
 /// Resolve color-interpolation-filters on an individual filter primitive entity.
@@ -169,8 +169,9 @@ css::Color resolveLightingColor(const Registry& registry, entt::entity cur,
 std::optional<ColorInterpolationFilters> resolveColorInterpolationFilters(const Registry& registry,
                                                                           entt::entity cur) {
   if (const auto* style = registry.try_get<ComputedStyleComponent>(cur)) {
-    if (style->properties.has_value() && style->properties->colorInterpolationFilters.hasValue()) {
-      return style->properties->colorInterpolationFilters.getRequired();
+    if (style->properties.has_value() &&
+        style->properties->colorInterpolationFilters.isSpecified()) {
+      return style->properties->colorInterpolationFilters.get().value();
     }
   }
   return std::nullopt;
@@ -448,17 +449,17 @@ void FilterSystem::createComputedFilter(EntityHandle handle, const FilterCompone
         }
 
         // Resolve currentColor.
-        if (props.floodColor.hasValue() && props.floodColor.getRequired().isCurrentColor()) {
+        if (props.floodColor.isSpecified() && props.floodColor.get().value().isCurrentColor()) {
           const auto& currentColor = style->properties->color;
-          props.floodColor.set(currentColor.getRequired(), currentColor.specificity);
+          props.floodColor.set(currentColor.get().value(), currentColor.specificity);
         }
       }
 
-      if (props.floodColor.hasValue()) {
-        prim.floodColor = props.floodColor.getRequired();
+      if (props.floodColor.isSpecified()) {
+        prim.floodColor = props.floodColor.get().value();
       }
-      if (props.floodOpacity.hasValue()) {
-        prim.floodOpacity = props.floodOpacity.getRequired();
+      if (props.floodOpacity.isSpecified()) {
+        prim.floodOpacity = props.floodOpacity.get().value();
       }
 
       filterGraph.nodes.push_back(makeFilterNode(prim, *primitive, primitiveCIF));

--- a/donner/svg/components/layout/LayoutSystem.cc
+++ b/donner/svg/components/layout/LayoutSystem.cc
@@ -115,7 +115,13 @@ void ApplyUnparsedProperties(SizedElementProperties& properties,
 
 template <typename T, PropertyCascade kCascade>
 bool IsAbsolute(const Property<T, kCascade>& property) {
-  return property.hasValue() && property.getRequired().isAbsoluteSize();
+  // Guard on the *resolved value*, not isSpecified(): a property specified as
+  // inherit/initial/unset is isSpecified()==true but resolves to no value, so
+  // pairing isSpecified() with a value access would abort (e.g. a root
+  // <svg width="inherit">). A property is a definite absolute size only when it
+  // resolves to an absolute Length.
+  const std::optional<T> value = property.get();
+  return value.has_value() && value->isAbsoluteSize();
 }
 
 template <typename T, PropertyCascade kCascade>
@@ -123,7 +129,7 @@ double GetDefiniteSize(const Property<T, kCascade>& property) {
   assert(IsAbsolute(property) && "Property must be absolute to get definite size");
 
   // Since we know the size is absolute, we don't need to specify a real viewBox or FontMetrics.
-  return property.getRequired().toPixels(Box2d::CreateEmpty(Vector2d()), FontMetrics());
+  return property.get().value().toPixels(Box2d::CreateEmpty(Vector2d()), FontMetrics());
 }
 
 Box2d GetViewBoxInternal(Registry& registry, Entity rootEntity, std::optional<Box2d> parentViewBox,
@@ -664,7 +670,7 @@ const ComputedLocalTransformComponent& LayoutSystem::createComputedLocalTransfor
   auto& computedTransform = handle.get_or_emplace<ComputedLocalTransformComponent>();
   if (transform.transform.get()) {
     computedTransform.rawCssTransform = transform.transform.get().value();
-    const TransformOrigin originValue = style.properties->transformOrigin.getRequired();
+    const TransformOrigin originValue = style.properties->transformOrigin.get().value();
 
     // The transform-origin is relative to the element's bounding box.
     Box2d bounds;
@@ -725,7 +731,7 @@ Box2d LayoutSystem::calculateSizedElementBounds(EntityHandle entity,
 
   Vector2d size = inheritedViewBox.size();
   if (const auto* viewBox = entity.try_get<ViewBoxComponent>()) {
-    if (!properties.width.hasValue() && !properties.height.hasValue() && viewBox->viewBox) {
+    if (!properties.width.isSpecified() && !properties.height.isSpecified() && viewBox->viewBox) {
       size = viewBox->viewBox->size();
     }
 
@@ -745,20 +751,20 @@ Box2d LayoutSystem::calculateSizedElementBounds(EntityHandle entity,
   // > viewport (i.e., if it is a 'svg' or 'symbol')
   if (!shadowTree || (shadowTree && shadowTree->mainLightRoot() != entt::null &&
                       entity.registry()->all_of<ViewBoxComponent>(shadowTree->mainLightRoot()))) {
-    if (properties.width.hasValue()) {
-      size.x = properties.width.getRequired().toPixels(inheritedViewBox, fontMetrics,
+    if (properties.width.isSpecified()) {
+      size.x = properties.width.get().value().toPixels(inheritedViewBox, fontMetrics,
                                                        Lengthd::Extent::X);
     }
 
-    if (properties.height.hasValue()) {
-      size.y = properties.height.getRequired().toPixels(inheritedViewBox, fontMetrics,
+    if (properties.height.isSpecified()) {
+      size.y = properties.height.get().value().toPixels(inheritedViewBox, fontMetrics,
                                                         Lengthd::Extent::Y);
     }
   }
 
   const Vector2d origin(
-      properties.x.getRequired().toPixels(inheritedViewBox, fontMetrics, Lengthd::Extent::X),
-      properties.y.getRequired().toPixels(inheritedViewBox, fontMetrics, Lengthd::Extent::Y));
+      properties.x.get().value().toPixels(inheritedViewBox, fontMetrics, Lengthd::Extent::X),
+      properties.y.get().value().toPixels(inheritedViewBox, fontMetrics, Lengthd::Extent::Y));
 
   if (registry.all_of<ImageComponent>(entity)) {
     if (auto maybeImageSize = registry.ctx().get<ResourceManagerContext>().getImageSize(entity)) {
@@ -766,19 +772,19 @@ Box2d LayoutSystem::calculateSizedElementBounds(EntityHandle entity,
 
       // Use the default sizing algorithm to detect the size if any parameters are missing.
       // See https://www.w3.org/TR/css-images-3/#default-sizing
-      if (properties.width.hasValue() && properties.height.hasValue()) {
+      if (properties.width.isSpecified() && properties.height.isSpecified()) {
         return Box2d(origin, origin + size);
-      } else if (!properties.width.hasValue() && !properties.height.hasValue()) {
+      } else if (!properties.width.isSpecified() && !properties.height.isSpecified()) {
         size = Vector2d(imageSize);
       } else {
         const float aspectRatio = static_cast<float>(imageSize.x) / static_cast<float>(imageSize.y);
 
-        if (!properties.width.hasValue()) {
-          size.x = properties.height.getRequired().toPixels(inheritedViewBox, fontMetrics,
+        if (!properties.width.isSpecified()) {
+          size.x = properties.height.get().value().toPixels(inheritedViewBox, fontMetrics,
                                                             Lengthd::Extent::X) *
                    aspectRatio;
-        } else if (!properties.height.hasValue()) {
-          size.y = properties.width.getRequired().toPixels(inheritedViewBox, fontMetrics,
+        } else if (!properties.height.isSpecified()) {
+          size.y = properties.width.get().value().toPixels(inheritedViewBox, fontMetrics,
                                                            Lengthd::Extent::Y) /
                    aspectRatio;
         }
@@ -902,27 +908,27 @@ bool LayoutSystem::createShadowSizedElementComponent(Registry& registry, Entity 
   // Override the width/height if the parent element specifies them
   SizedElementProperties properties = targetSizedElement->properties;
 
-  if (parentSizedElement->properties.width.hasValue()) {
+  if (parentSizedElement->properties.width.isSpecified()) {
     properties.width = parentSizedElement->properties.width;
   }
-  if (parentSizedElement->properties.height.hasValue()) {
+  if (parentSizedElement->properties.height.isSpecified()) {
     properties.height = parentSizedElement->properties.height;
   }
 
   Vector2d size = parentViewBox.size();
 
-  if (properties.width.hasValue()) {
+  if (properties.width.isSpecified()) {
     size.x =
-        properties.width.getRequired().toPixels(parentViewBox, fontMetrics, Lengthd::Extent::X);
+        properties.width.get().value().toPixels(parentViewBox, fontMetrics, Lengthd::Extent::X);
   }
-  if (properties.height.hasValue()) {
+  if (properties.height.isSpecified()) {
     size.y =
-        properties.height.getRequired().toPixels(parentViewBox, fontMetrics, Lengthd::Extent::Y);
+        properties.height.get().value().toPixels(parentViewBox, fontMetrics, Lengthd::Extent::Y);
   }
 
   const Vector2d origin(
-      properties.x.getRequired().toPixels(parentViewBox, fontMetrics, Lengthd::Extent::X),
-      properties.y.getRequired().toPixels(parentViewBox, fontMetrics, Lengthd::Extent::Y));
+      properties.x.get().value().toPixels(parentViewBox, fontMetrics, Lengthd::Extent::X),
+      properties.y.get().value().toPixels(parentViewBox, fontMetrics, Lengthd::Extent::Y));
 
   // Create the shadow component
   auto& shadowSized =

--- a/donner/svg/components/layout/tests/LayoutSystem_tests.cc
+++ b/donner/svg/components/layout/tests/LayoutSystem_tests.cc
@@ -33,6 +33,31 @@ protected:
   LayoutSystem layoutSystem;
 };
 
+// Regression: a root <svg> whose width/height is a CSS-wide keyword
+// (inherit/initial/unset) leaves those Properties in a non-Set state, where
+// isSpecified() is true but get() resolves to no value (width/height have no
+// initial). IsAbsolute() guarded on the cascade predicate and then accessed the
+// value, aborting ("Required property not set") during document-size
+// computation. Donner must not abort on such (valid CSS, untrusted) input.
+// Found by editor_state_machine_fuzzer; see Property::isSpecified() vs get().
+TEST_F(LayoutSystemTest, RootSizeCssWideKeywordDoesNotCrash) {
+  for (const std::string_view keyword : {"inherit", "initial", "unset"}) {
+    SCOPED_TRACE(testing::Message() << "width/height keyword: " << keyword);
+    auto document = ParseSVG(std::string("<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"") +
+                             std::string(keyword) + "\" height=\"" + std::string(keyword) +
+                             "\" viewBox=\"0 0 200 200\"></svg>");
+
+    ParseWarningSink disabledSink = ParseWarningSink::Disabled();
+    layoutSystem.instantiateAllComputedComponents(document.registry(), disabledSink);
+
+    // Neither of these must abort; with no definite absolute size the viewBox
+    // falls back to the declared viewBox extents.
+    (void)layoutSystem.calculateDocumentSize(document.registry());
+    EXPECT_THAT(layoutSystem.getViewBox(document.rootEntityHandle()),
+                BoxEq(Vector2i(0, 0), Vector2i(200, 200)));
+  }
+}
+
 TEST_F(LayoutSystemTest, ViewportRoot) {
   auto document = ParseSVG(R"(
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
@@ -824,8 +849,8 @@ TEST_F(LayoutSystemTest, CreateShadowSizedElementComponentReturnsFalseWhenNotMai
 
   EXPECT_FALSE(layoutSystem.createShadowSizedElementComponent(
       registry, shadowEntity, document.querySelector("#u")->entityHandle(),
-      document.querySelector("#sym")->unsafeEntityHandle().entity(), ShadowBranchType::OffscreenFill,
-      warningSink));
+      document.querySelector("#sym")->unsafeEntityHandle().entity(),
+      ShadowBranchType::OffscreenFill, warningSink));
 }
 
 // --- transform-origin with keywords ---

--- a/donner/svg/components/paint/PaintSystem.cc
+++ b/donner/svg/components/paint/PaintSystem.cc
@@ -160,8 +160,8 @@ void PaintSystem::initializeComputedGradient(EntityHandle handle,
        cur = registry.get<donner::components::TreeComponent>(cur).nextSibling()) {
     if (const auto* stop = registry.try_get<ComputedStopComponent>(cur)) {
       computedGradient.stops.emplace_back(
-          GradientStop{stop->properties.offset, stop->properties.stopColor.getRequired(),
-                       NarrowToFloat(stop->properties.stopOpacity.getRequired())});
+          GradientStop{stop->properties.offset, stop->properties.stopColor.get().value(),
+                       NarrowToFloat(stop->properties.stopOpacity.get().value())});
     }
   }
 }

--- a/donner/svg/components/paint/PatternComponent.cc
+++ b/donner/svg/components/paint/PatternComponent.cc
@@ -25,16 +25,16 @@ void ComputedPatternComponent::inheritAttributesFrom(EntityHandle handle, Entity
   if (pattern.patternContentUnits) {
     patternContentUnits = pattern.patternContentUnits.value();
   }
-  if (pattern.sizeProperties.x.hasValue()) {
+  if (pattern.sizeProperties.x.isSpecified()) {
     sizeProperties.x = pattern.sizeProperties.x;
   }
-  if (pattern.sizeProperties.y.hasValue()) {
+  if (pattern.sizeProperties.y.isSpecified()) {
     sizeProperties.y = pattern.sizeProperties.y;
   }
-  if (pattern.sizeProperties.width.hasValue()) {
+  if (pattern.sizeProperties.width.isSpecified()) {
     sizeProperties.width = pattern.sizeProperties.width;
   }
-  if (pattern.sizeProperties.height.hasValue()) {
+  if (pattern.sizeProperties.height.isSpecified()) {
     sizeProperties.height = pattern.sizeProperties.height;
   }
 }

--- a/donner/svg/components/paint/StopComponent.cc
+++ b/donner/svg/components/paint/StopComponent.cc
@@ -75,9 +75,9 @@ ComputedStopComponent::ComputedStopComponent(
   }
 
   // Evaluate stopColor if it is currentColor.
-  if (properties.stopColor.hasValue() && properties.stopColor.getRequired().isCurrentColor()) {
+  if (properties.stopColor.isSpecified() && properties.stopColor.get().value().isCurrentColor()) {
     const auto& currentColor = style.properties->color;
-    properties.stopColor.set(currentColor.getRequired(), currentColor.specificity);
+    properties.stopColor.set(currentColor.get().value(), currentColor.specificity);
   }
 }
 

--- a/donner/svg/components/shape/ShapeSystem.cc
+++ b/donner/svg/components/shape/ShapeSystem.cc
@@ -37,7 +37,7 @@ FontMetrics fontMetricsForElement(Registry& registry, const ComputedStyleCompone
       if (const auto* rootStyle = registry.try_get<ComputedStyleComponent>(ctx->rootEntity)) {
         if (rootStyle->properties) {
           // Use default FontMetrics for resolving root font-size (avoids circular dependency).
-          metrics.rootFontSize = rootStyle->properties->fontSize.getRequired().toPixels(
+          metrics.rootFontSize = rootStyle->properties->fontSize.get().value().toPixels(
               Box2d(), FontMetrics(), Lengthd::Extent::Mixed);
         }
       }
@@ -47,7 +47,7 @@ FontMetrics fontMetricsForElement(Registry& registry, const ComputedStyleCompone
   // Element's computed font-size for em/ex/ch units.
   if (style.properties) {
     // Resolve font-size using default metrics (font-size itself can't be em-relative to itself).
-    metrics.fontSize = style.properties->fontSize.getRequired().toPixels(Box2d(), FontMetrics(),
+    metrics.fontSize = style.properties->fontSize.get().value().toPixels(Box2d(), FontMetrics(),
                                                                          Lengthd::Extent::Mixed);
   }
 
@@ -55,7 +55,7 @@ FontMetrics fontMetricsForElement(Registry& registry, const ComputedStyleCompone
   if (auto* textEngine = registry.ctx().find<TextEngine>()) {
     if (style.properties) {
       if (const auto chUnit =
-              textEngine->measureChUnitInEm(style.properties->fontFamily.getRequired())) {
+              textEngine->measureChUnitInEm(style.properties->fontFamily.get().value())) {
         metrics.chUnitInEm = *chUnit;
       }
     }
@@ -183,7 +183,7 @@ constexpr bool ForEachShape(const F& f) {
 
 bool IsDisplayNone(EntityHandle handle, ParseWarningSink& warningSink) {
   const ComputedStyleComponent& style = StyleSystem().computeStyle(handle, warningSink);
-  return style.properties && style.properties->display.getRequired() == Display::None;
+  return style.properties && style.properties->display.get().value() == Display::None;
 }
 
 }  // namespace
@@ -303,11 +303,11 @@ ComputedPathComponent* ShapeSystem::createComputedShapeWithStyle(
 
   const Box2d viewport = LayoutSystem().getViewBox(handle);
 
-  const Vector2d center(computedCircle.properties.cx.getRequired().toPixels(viewport, fontMetrics,
+  const Vector2d center(computedCircle.properties.cx.get().value().toPixels(viewport, fontMetrics,
                                                                             Lengthd::Extent::X),
-                        computedCircle.properties.cy.getRequired().toPixels(viewport, fontMetrics,
+                        computedCircle.properties.cy.get().value().toPixels(viewport, fontMetrics,
                                                                             Lengthd::Extent::Y));
-  const double radius = computedCircle.properties.r.getRequired().toPixels(viewport, fontMetrics);
+  const double radius = computedCircle.properties.r.get().value().toPixels(viewport, fontMetrics);
 
   if (radius > 0.0) {
     Path path = PathBuilder().addCircle(center, radius).build();
@@ -326,9 +326,9 @@ ComputedPathComponent* ShapeSystem::createComputedShapeWithStyle(
 
   const Box2d viewport = LayoutSystem().getViewBox(handle);
 
-  const Vector2d center(computedEllipse.properties.cx.getRequired().toPixels(viewport, fontMetrics,
+  const Vector2d center(computedEllipse.properties.cx.get().value().toPixels(viewport, fontMetrics,
                                                                              Lengthd::Extent::X),
-                        computedEllipse.properties.cy.getRequired().toPixels(viewport, fontMetrics,
+                        computedEllipse.properties.cy.get().value().toPixels(viewport, fontMetrics,
                                                                              Lengthd::Extent::Y));
   const Vector2d radius(std::get<1>(computedEllipse.properties.calculateRx(viewport, fontMetrics)),
                         std::get<1>(computedEllipse.properties.calculateRy(viewport, fontMetrics)));
@@ -375,7 +375,7 @@ ComputedPathComponent* ShapeSystem::createComputedShapeWithStyle(
 
   if (path.splineOverride) {
     return &emplaceComputedPathIfChanged(handle, path.splineOverride.value());
-  } else if (actualD.hasValue()) {
+  } else if (actualD.isSpecified()) {
     auto maybePath = parser::PathParser::Parse(actualD.get().value());
     if (maybePath.hasError()) {
       // Propagate warnings, which may be set on success too.
@@ -422,15 +422,15 @@ ComputedPathComponent* ShapeSystem::createComputedShapeWithStyle(
   const Box2d viewport = LayoutSystem().getViewBox(handle);
 
   const Vector2d pos(
-      computedRect.properties.x.getRequired().toPixels(viewport, fontMetrics, Lengthd::Extent::X),
-      computedRect.properties.y.getRequired().toPixels(viewport, fontMetrics, Lengthd::Extent::Y));
-  const Vector2d size(computedRect.properties.width.getRequired().toPixels(viewport, fontMetrics,
+      computedRect.properties.x.get().value().toPixels(viewport, fontMetrics, Lengthd::Extent::X),
+      computedRect.properties.y.get().value().toPixels(viewport, fontMetrics, Lengthd::Extent::Y));
+  const Vector2d size(computedRect.properties.width.get().value().toPixels(viewport, fontMetrics,
                                                                            Lengthd::Extent::X),
-                      computedRect.properties.height.getRequired().toPixels(viewport, fontMetrics,
+                      computedRect.properties.height.get().value().toPixels(viewport, fontMetrics,
                                                                             Lengthd::Extent::Y));
 
   if (size.x > 0.0 && size.y > 0.0) {
-    if (computedRect.properties.rx.hasValue() || computedRect.properties.ry.hasValue()) {
+    if (computedRect.properties.rx.isSpecified() || computedRect.properties.ry.isSpecified()) {
       const Vector2d radius(
           Clamp(std::get<1>(computedRect.properties.calculateRx(viewport, fontMetrics)), 0.0,
                 size.x * 0.5),

--- a/donner/svg/components/shape/tests/CircleEllipseComponent_tests.cc
+++ b/donner/svg/components/shape/tests/CircleEllipseComponent_tests.cc
@@ -96,7 +96,7 @@ TEST(EllipseComponent, ComputedEllipseComponentAppliesUnparsedProperties) {
 
   EXPECT_FALSE(warningSink.hasWarnings());
   EXPECT_THAT(computed.properties.cx.get(), Optional(Lengthd(15, Lengthd::Unit::None)));
-  EXPECT_TRUE(computed.properties.ry.hasValue());
+  EXPECT_TRUE(computed.properties.ry.isSpecified());
   EXPECT_THAT(computed.properties.ry.get(), Eq(std::nullopt));
 }
 
@@ -109,7 +109,7 @@ TEST(EllipseComponent, ComputedEllipseComponentReportsInvalidUnparsedProperty) {
   ASSERT_TRUE(warningSink.hasWarnings());
   ASSERT_EQ(warningSink.warnings().size(), 1u);
   EXPECT_THAT(warningSink.warnings().front(), ParseErrorIs("Invalid length or percentage"));
-  EXPECT_FALSE(computed.properties.rx.hasValue());
+  EXPECT_FALSE(computed.properties.rx.isSpecified());
 }
 
 TEST(EllipseComponent, ParseEllipsePresentationAttributeParsesKnownAttribute) {
@@ -135,7 +135,7 @@ TEST(EllipseComponent, ParseEllipsePresentationAttributeReturnsErrorForInvalidVa
       ParseErrorIs("Invalid length or percentage"));
 
   const EllipseProperties& properties = ellipse.entityHandle().get<EllipseComponent>().properties;
-  EXPECT_FALSE(properties.ry.hasValue());
+  EXPECT_FALSE(properties.ry.isSpecified());
 }
 
 TEST(EllipseComponent, ParseEllipsePresentationAttributeReturnsFalseForUnknownAttribute) {

--- a/donner/svg/components/shape/tests/RectComponent_tests.cc
+++ b/donner/svg/components/shape/tests/RectComponent_tests.cc
@@ -38,7 +38,7 @@ TEST(RectComponent, ComputedRectComponentAppliesUnparsedProperties) {
 
   EXPECT_FALSE(warningSink.hasWarnings());
   EXPECT_THAT(computed.properties.x.get(), Optional(Lengthd(15, Lengthd::Unit::None)));
-  EXPECT_TRUE(computed.properties.ry.hasValue());
+  EXPECT_TRUE(computed.properties.ry.isSpecified());
   EXPECT_THAT(computed.properties.ry.get(), Eq(std::nullopt));
 }
 
@@ -77,7 +77,7 @@ TEST(RectComponent, ParseRectPresentationAttributeReturnsErrorForInvalidAttribut
       ParseErrorIs("Invalid length or percentage"));
 
   const RectProperties& properties = rect.entityHandle().get<RectComponent>().properties;
-  EXPECT_FALSE(properties.rx.hasValue());
+  EXPECT_FALSE(properties.rx.isSpecified());
 }
 
 TEST(RectComponent, ParseRectPresentationAttributeReturnsFalseForUnknownAttribute) {

--- a/donner/svg/components/style/StyleSystem.cc
+++ b/donner/svg/components/style/StyleSystem.cc
@@ -261,7 +261,7 @@ void StyleSystem::computePropertiesInto(EntityHandle handle, ComputedStyleCompon
     if (parent != entt::null) {
       const auto& parentStyle = registry.get<ComputedStyleComponent>(parent);
       if (parentStyle.properties) {
-        parentFontSizePx = parentStyle.properties->fontSize.getRequired().value;
+        parentFontSizePx = parentStyle.properties->fontSize.get().value().value;
       }
     }
     computedStyle.properties->resolveFontSize(parentFontSizePx);
@@ -271,7 +271,7 @@ void StyleSystem::computePropertiesInto(EntityHandle handle, ComputedStyleCompon
     if (parent != entt::null) {
       const auto& parentStyle = registry.get<ComputedStyleComponent>(parent);
       if (parentStyle.properties) {
-        parentFontWeight = parentStyle.properties->fontWeight.getRequired();
+        parentFontWeight = parentStyle.properties->fontWeight.get().value();
       }
     }
     computedStyle.properties->resolveFontWeight(parentFontWeight);
@@ -281,7 +281,7 @@ void StyleSystem::computePropertiesInto(EntityHandle handle, ComputedStyleCompon
     if (parent != entt::null) {
       const auto& parentStyle = registry.get<ComputedStyleComponent>(parent);
       if (parentStyle.properties) {
-        parentFontStretch = parentStyle.properties->fontStretch.getRequired();
+        parentFontStretch = parentStyle.properties->fontStretch.get().value();
       }
     }
     computedStyle.properties->resolveFontStretch(parentFontStretch);

--- a/donner/svg/components/style/tests/StyleSystem_tests.cc
+++ b/donner/svg/components/style/tests/StyleSystem_tests.cc
@@ -261,7 +261,7 @@ TEST_F(StyleSystemTest, DisplayNoneComputed) {
   auto* computed = element->entityHandle().try_get<ComputedStyleComponent>();
   ASSERT_THAT(computed, NotNull());
   EXPECT_TRUE(computed->properties.has_value());
-  EXPECT_EQ(computed->properties->display.getRequired(), Display::None);
+  EXPECT_EQ(computed->properties->display.get().value(), Display::None);
 }
 
 TEST_F(StyleSystemTest, VisibilityHiddenComputed) {
@@ -276,7 +276,7 @@ TEST_F(StyleSystemTest, VisibilityHiddenComputed) {
   auto* computed = element->entityHandle().try_get<ComputedStyleComponent>();
   ASSERT_THAT(computed, NotNull());
   EXPECT_TRUE(computed->properties.has_value());
-  EXPECT_EQ(computed->properties->visibility.getRequired(), Visibility::Hidden);
+  EXPECT_EQ(computed->properties->visibility.get().value(), Visibility::Hidden);
 }
 
 // --- Individual style computation ---
@@ -376,9 +376,9 @@ TEST_F(StyleSystemTest, UpdateStyleMergesAndInvalidatesComputedStyle) {
 
   ParseWarningSink warningSink;
   const auto& computed = styleSystem.computeStyle(element->entityHandle(), warningSink);
-  EXPECT_EQ(computed.properties->fill.getRequired(),
+  EXPECT_EQ(computed.properties->fill.get().value(),
             PaintServer(PaintServer::Solid(css::Color(css::RGBA(0, 128, 0, 0xFF)))));
-  EXPECT_EQ(computed.properties->stroke.getRequired(),
+  EXPECT_EQ(computed.properties->stroke.get().value(),
             PaintServer(PaintServer::Solid(css::Color(css::RGBA(0, 0, 0xFF, 0xFF)))));
 }
 
@@ -412,11 +412,13 @@ TEST_F(StyleSystemTest, ComputeAllStylesDirtyOnlyRecomputesStyleDirtyEntities) {
 
   EXPECT_EQ(document.registry()
                 .get<ComputedStyleComponent>(dirty.entity())
-                .properties->fill.getRequired(),
+                .properties->fill.get()
+                .value(),
             PaintServer(PaintServer::Solid(css::Color(css::RGBA(0, 0, 0xFF, 0xFF)))));
   EXPECT_EQ(document.registry()
                 .get<ComputedStyleComponent>(clean.entity())
-                .properties->fill.getRequired(),
+                .properties->fill.get()
+                .value(),
             PaintServer(PaintServer::Solid(css::Color(css::RGBA(0, 0, 0, 0xFF)))));
 }
 
@@ -443,7 +445,8 @@ TEST_F(StyleSystemTest, ComputeAllStylesFullRecomputeClearsAndRebuildsStyles) {
 
   EXPECT_EQ(document.registry()
                 .get<ComputedStyleComponent>(element->unsafeEntityHandle().entity())
-                .properties->fill.getRequired(),
+                .properties->fill.get()
+                .value(),
             PaintServer(PaintServer::Solid(css::Color(css::RGBA(0, 0, 0xFF, 0xFF)))));
 }
 
@@ -535,12 +538,12 @@ TEST_F(StyleSystemTest, ShadowTreeSelectorsMatchSiblingAndAttributeState) {
   const auto& rectStyle = document.registry().get<ComputedStyleComponent>(shadowRect);
   const auto& circleStyle = document.registry().get<ComputedStyleComponent>(shadowCircle);
 
-  EXPECT_EQ(rectStyle.properties->fill.getRequired(),
+  EXPECT_EQ(rectStyle.properties->fill.get().value(),
             PaintServer(PaintServer::Solid(css::Color(css::RGBA(0, 0, 0xFF, 0xFF)))));
-  EXPECT_EQ(rectStyle.properties->visibility.getRequired(), Visibility::Hidden);
-  EXPECT_EQ(circleStyle.properties->stroke.getRequired(),
+  EXPECT_EQ(rectStyle.properties->visibility.get().value(), Visibility::Hidden);
+  EXPECT_EQ(circleStyle.properties->stroke.get().value(),
             PaintServer(PaintServer::Solid(css::Color(css::RGBA(0, 128, 0, 0xFF)))));
-  EXPECT_DOUBLE_EQ(circleStyle.properties->opacity.getRequired(), 0.5);
+  EXPECT_DOUBLE_EQ(circleStyle.properties->opacity.get().value(), 0.5);
 }
 
 }  // namespace donner::svg::components

--- a/donner/svg/components/text/TextSystem.cc
+++ b/donner/svg/components/text/TextSystem.cc
@@ -365,7 +365,7 @@ void TextSystem::instantiateComputedComponent(EntityHandle rootHandle,
     bool isHidden = parentHidden;
     if (!isHidden) {
       auto* style = handle.try_get<ComputedStyleComponent>();
-      if (style && style->properties && style->properties->display.getRequired() == Display::None) {
+      if (style && style->properties && style->properties->display.get().value() == Display::None) {
         isHidden = true;
       }
     }

--- a/donner/svg/properties/Property.h
+++ b/donner/svg/properties/Property.h
@@ -86,25 +86,32 @@ struct Property {
   std::optional<T> get() const { return state == PropertyState::Set ? value : getInitialFn(); }
 
   /**
-   * Gets the value of the property, requiring that the value is not std::nullopt.
+   * Gets the resolved value, or \p fallback if the property does not resolve to a concrete value
+   * (e.g. it is unset with no initial, or its keyword is `inherit`/`initial`/`unset` with no
+   * resolved value). Never aborts.
    *
-   * @return The value.
+   * This is the footgun-free replacement for the former `getRequired()`: prefer it, or `get()`
+   * and handle `std::nullopt`, rather than asserting a value is present. For the rare case where an
+   * invariant genuinely guarantees presence, `get().value()` makes the abort explicit and local.
+   *
+   * @param fallback Value to return when the property does not resolve to a value.
+   * @return The resolved value, or \p fallback.
    */
-  T getRequired() const {
-    auto result = get();
-    UTILS_RELEASE_ASSERT_MSG(result.has_value(), "Required property not set");
-    return std::move(result.value());
-  }
+  T getOr(const T& fallback) const { return get().value_or(fallback); }
 
   /**
-   * Gets a const-ref to the value, for accessing complex types without copying. Requires that \ref
-   * hasValue() is true.
+   * Returns a non-owning pointer to the *stored* value when the property is explicitly \ref
+   * PropertyState::Set, for no-copy access to complex values; returns `nullptr` otherwise
+   * (including the `inherit`/`initial`/`unset` states, which carry no stored value).
    *
-   * @return const T& Reference to the value.
+   * Footgun-free replacement for the former `getRequiredRef()`: callers null-check the result
+   * instead of relying on an assert. Note this never returns the *initial* value — use \ref get()
+   * if you need initial-value resolution.
+   *
+   * @return Pointer to the stored value, or `nullptr`.
    */
-  const T& getRequiredRef() const {
-    UTILS_RELEASE_ASSERT_MSG(hasValue(), "Required property not set");
-    return value.value();
+  const T* getStoredValue() const {
+    return (state == PropertyState::Set && value.has_value()) ? &*value : nullptr;
   }
 
   /**
@@ -177,7 +184,7 @@ struct Property {
       const bool canInherit = options == PropertyInheritOptions::All ||
                               (options == PropertyInheritOptions::NoPaint && !isPaint);
 
-      if (parent.hasValue() && canInherit) {
+      if (parent.isSpecified() && canInherit) {
         if (state == PropertyState::NotSet || state == PropertyState::Inherit ||
             state == PropertyState::ExplicitUnset) {
           // Inherit from parent.
@@ -204,9 +211,17 @@ struct Property {
   }
 
   /**
-   * @return true if the property has any value set, including CSS built-in values.
+   * Whether the cascade assigned this property any state other than \ref PropertyState::NotSet —
+   * i.e. a concrete value OR a CSS-wide keyword (`inherit`/`initial`/`unset`) was specified.
+   *
+   * This is a *cascade* predicate, NOT a guarantee that \ref get() returns a value: for
+   * `inherit`/`initial`/`unset` (and `Set` to `none`) this is true while `get()` may be
+   * `std::nullopt`. Do not use it as a guard before reading the value — use \ref get(), \ref
+   * getOr(), or \ref getStoredValue() for that.
+   *
+   * @return true if any cascade state other than NotSet was specified.
    */
-  bool hasValue() const { return state != PropertyState::NotSet; }
+  bool isSpecified() const { return state != PropertyState::NotSet; }
 
   std::string_view name;                        ///< Property name, such as "color".
   std::optional<T> value;                       ///< Property value, or `std::nullopt` if not set.

--- a/donner/svg/properties/PropertyParsing.h
+++ b/donner/svg/properties/PropertyParsing.h
@@ -97,7 +97,7 @@ template <typename T, PropertyCascade kCascade, typename ParseCallbackFn>
 std::optional<ParseDiagnostic> Parse(const PropertyParseFnParams& params,
                                      ParseCallbackFn callbackFn,
                                      Property<T, kCascade>* destination) {
-  if (destination->hasValue() && params.specificity < destination->specificity) {
+  if (destination->isSpecified() && params.specificity < destination->specificity) {
     // Existing specificity is higher than the new one, so we don't need to parse.
     return std::nullopt;
   }

--- a/donner/svg/properties/PropertyRegistry.cc
+++ b/donner/svg/properties/PropertyRegistry.cc
@@ -1347,7 +1347,8 @@ DONNER_CONSTEXPR_MAP auto kProperties =
                    // From https://www.w3.org/TR/css-color-3/#currentcolor:
                    // If the 'currentColor' keyword is set on the 'color' property itself, it is
                    // treated as `color: inherit`.
-                   if (registry.color.hasValue() && registry.color.getRequired().isCurrentColor()) {
+                   if (registry.color.isSpecified() &&
+                       registry.color.get().value().isCurrentColor()) {
                      registry.color.set(PropertyState::Inherit, registry.color.specificity);
                    }
 
@@ -1989,7 +1990,7 @@ size_t PropertyRegistry::numPropertiesSet() const {
 
   size_t result = 0;
   forEachProperty<0, numProperties()>([&selfProperties, &result](auto i) {
-    if (std::get<i.value>(selfProperties).hasValue()) {
+    if (std::get<i.value>(selfProperties).isSpecified()) {
       ++result;
     }
   });
@@ -2142,7 +2143,7 @@ bool PropertyRegistry::isPresentationAttributeInherited(std::string_view name) {
 }
 
 void PropertyRegistry::resolveFontSize(double parentFontSizePx) {
-  const Lengthd fs = fontSize.getRequired();
+  const Lengthd fs = fontSize.get().value();
   double resolvedPx;
   switch (fs.unit) {
     case Lengthd::Unit::Percent:
@@ -2167,7 +2168,7 @@ void PropertyRegistry::resolveFontSize(double parentFontSizePx) {
 }
 
 void PropertyRegistry::resolveFontWeight(int parentFontWeight) {
-  const int fw = fontWeight.getRequired();
+  const int fw = fontWeight.get().value();
   if (fw == kFontWeightBolder) {
     // CSS Fonts Level 4 §2.5: bolder relative to inherited weight.
     int resolved;
@@ -2194,7 +2195,7 @@ void PropertyRegistry::resolveFontWeight(int parentFontWeight) {
 }
 
 void PropertyRegistry::resolveFontStretch(int parentFontStretch) {
-  const int fs = fontStretch.getRequired();
+  const int fs = fontStretch.get().value();
   if (fs == kFontStretchNarrower) {
     // Move one step narrower, clamped to UltraCondensed.
     int resolved = parentFontStretch - 1;
@@ -2221,7 +2222,7 @@ std::ostream& operator<<(std::ostream& os, const PropertyRegistry& registry) {
   PropertyRegistry::forEachProperty<0, PropertyRegistry::numProperties()>(
       [&os, &resultProperties](auto i) {
         const auto& property = std::get<i.value>(resultProperties);
-        if (property.hasValue()) {
+        if (property.isSpecified()) {
           os << "  " << property << std::endl;
         }
       });

--- a/donner/svg/properties/RxRyProperties.cc
+++ b/donner/svg/properties/RxRyProperties.cc
@@ -8,8 +8,8 @@ std::tuple<Lengthd, double> CalculateRadiusMaybeAuto(const Property<Lengthd>& pr
                                                      const FontMetrics& fontMetrics,
                                                      Lengthd::Extent propertyExtent,
                                                      Lengthd::Extent fallbackExtent) {
-  if (property.hasValue()) {
-    const Lengthd value = property.getRequired();
+  if (property.isSpecified()) {
+    const Lengthd value = property.get().value();
     const double pixels = value.toPixels(viewBox, fontMetrics, propertyExtent);
 
     if (pixels >= 0.0) {
@@ -19,8 +19,8 @@ std::tuple<Lengthd, double> CalculateRadiusMaybeAuto(const Property<Lengthd>& pr
 
   // If there's no property, the field is set to "auto", so try using the other dimension
   // (fallbackProperty).
-  if (fallbackProperty.hasValue()) {
-    const Lengthd fallbackValue = fallbackProperty.getRequired();
+  if (fallbackProperty.isSpecified()) {
+    const Lengthd fallbackValue = fallbackProperty.get().value();
     const double fallbackPixels = fallbackValue.toPixels(viewBox, fontMetrics, fallbackExtent);
     if (fallbackPixels >= 0.0) {
       return std::make_tuple(fallbackValue, fallbackPixels);

--- a/donner/svg/properties/tests/PropertyRegistry_tests.cc
+++ b/donner/svg/properties/tests/PropertyRegistry_tests.cc
@@ -118,24 +118,24 @@ TEST(PropertyRegistry, BuiltinKeywords) {
     PropertyRegistry registry;
     registry.parseStyle("color: initial");
     EXPECT_EQ(registry.color.state, PropertyState::ExplicitInitial);
-    EXPECT_TRUE(registry.color.hasValue());
+    EXPECT_TRUE(registry.color.isSpecified());
     EXPECT_THAT(registry.color.get(), Eq(Color(RGBA(0, 0, 0, 0xFF))));
 
     registry.parseStyle("color: inherit");
     EXPECT_EQ(registry.color.state, PropertyState::Inherit);
-    EXPECT_TRUE(registry.color.hasValue());
+    EXPECT_TRUE(registry.color.isSpecified());
     EXPECT_THAT(registry.color.get(), Eq(Color(RGBA(0, 0, 0, 0xFF))));
 
     registry.parseStyle("color: unset");
     EXPECT_EQ(registry.color.state, PropertyState::ExplicitUnset);
-    EXPECT_TRUE(registry.color.hasValue());
+    EXPECT_TRUE(registry.color.isSpecified());
     EXPECT_THAT(registry.color.get(), Eq(Color(RGBA(0, 0, 0, 0xFF))));
   }
 
   {
     PropertyRegistry registry;
     registry.parseStyle("color: inherit invalid");
-    EXPECT_FALSE(registry.color.hasValue());
+    EXPECT_FALSE(registry.color.isSpecified());
     EXPECT_THAT(registry.color.get(), Eq(Color(RGBA(0, 0, 0, 0xFF))));
   }
 }
@@ -143,7 +143,7 @@ TEST(PropertyRegistry, BuiltinKeywords) {
 TEST(PropertyRegistry, ParseColor) {
   PropertyRegistry registry;
   registry.parseStyle("color: red");
-  EXPECT_TRUE(registry.color.hasValue());
+  EXPECT_TRUE(registry.color.isSpecified());
   EXPECT_THAT(registry.color.get(), Optional(Color(RGBA(0xFF, 0, 0, 0xFF))));
 }
 
@@ -171,7 +171,7 @@ TEST(PropertyRegistry, ParsePresentationAttribute) {
   {
     PropertyRegistry registry;
     EXPECT_THAT(registry.parsePresentationAttribute("color", ""), ParseErrorIs("No color found"));
-    EXPECT_FALSE(registry.color.hasValue());
+    EXPECT_FALSE(registry.color.isSpecified());
     EXPECT_THAT(registry.color.get(), Eq(Color(RGBA(0, 0, 0, 0xFF))));
   }
 
@@ -179,7 +179,7 @@ TEST(PropertyRegistry, ParsePresentationAttribute) {
     PropertyRegistry registry;
     EXPECT_THAT(registry.parsePresentationAttribute("color", "invalid"),
                 ParseErrorIs("Invalid color 'invalid'"));
-    EXPECT_FALSE(registry.color.hasValue());
+    EXPECT_FALSE(registry.color.isSpecified());
     EXPECT_THAT(registry.color.get(), Eq(Color(RGBA(0, 0, 0, 0xFF))));
   }
 
@@ -187,7 +187,7 @@ TEST(PropertyRegistry, ParsePresentationAttribute) {
     PropertyRegistry registry;
     EXPECT_THAT(registry.parsePresentationAttribute("color", "red !important"),
                 ParseErrorIs("Expected a single color"));
-    EXPECT_FALSE(registry.color.hasValue()) << "!important is not supported";
+    EXPECT_FALSE(registry.color.isSpecified()) << "!important is not supported";
     EXPECT_THAT(registry.color.get(), Eq(Color(RGBA(0, 0, 0, 0xFF))));
   }
 
@@ -195,7 +195,7 @@ TEST(PropertyRegistry, ParsePresentationAttribute) {
     PropertyRegistry registry;
     EXPECT_THAT(registry.parsePresentationAttribute("color", " /*comment*/ red "),
                 ParseResultIs(true));
-    EXPECT_TRUE(registry.color.hasValue()) << "Comments and whitespace should be ignored";
+    EXPECT_TRUE(registry.color.isSpecified()) << "Comments and whitespace should be ignored";
     EXPECT_THAT(registry.color.get(), Optional(Color(RGBA(0xFF, 0, 0, 0xFF))));
   }
 }
@@ -206,11 +206,11 @@ TEST(PropertyRegistry, Fill) {
 
   {
     PropertyRegistry registry;
-    EXPECT_FALSE(registry.fill.hasValue());
+    EXPECT_FALSE(registry.fill.isSpecified());
     EXPECT_THAT(registry.fill.get(), Optional(kInitialFill));
 
     registry.parseStyle("fill: none");
-    EXPECT_TRUE(registry.fill.hasValue());
+    EXPECT_TRUE(registry.fill.isSpecified());
     EXPECT_THAT(registry.fill.get(), Optional(PaintServer(PaintServer::None())));
 
     registry.parseStyle("fill: red  ");
@@ -222,18 +222,18 @@ TEST(PropertyRegistry, Fill) {
     PropertyRegistry registry;
     EXPECT_THAT(registry.parsePresentationAttribute("fill", ""),
                 ParseErrorIs("Invalid paint server value"));
-    EXPECT_FALSE(registry.fill.hasValue());
+    EXPECT_FALSE(registry.fill.isSpecified());
     EXPECT_THAT(registry.fill.get(), Optional(kInitialFill));
   }
 
   {
     PropertyRegistry registry;
     registry.parseStyle("fill: red asdf");
-    EXPECT_FALSE(registry.fill.hasValue());
+    EXPECT_FALSE(registry.fill.isSpecified());
     EXPECT_THAT(registry.fill.get(), Optional(kInitialFill));
 
     registry.parseStyle("fill: asdf");
-    EXPECT_FALSE(registry.fill.hasValue());
+    EXPECT_FALSE(registry.fill.isSpecified());
     EXPECT_THAT(registry.fill.get(), Optional(kInitialFill));
   }
 
@@ -248,7 +248,7 @@ TEST(PropertyRegistry, Fill) {
   {
     PropertyRegistry registry;
     registry.parseStyle("fill: context-stroke invalid");
-    EXPECT_FALSE(registry.fill.hasValue());
+    EXPECT_FALSE(registry.fill.isSpecified());
     EXPECT_THAT(registry.fill.get(), Optional(kInitialFill));
   }
 
@@ -272,7 +272,7 @@ TEST(PropertyRegistry, Fill) {
   {
     PropertyRegistry registry;
     registry.parseStyle("fill: url(#test) invalid");
-    EXPECT_FALSE(registry.fill.hasValue());
+    EXPECT_FALSE(registry.fill.isSpecified());
     EXPECT_THAT(registry.fill.get(), Optional(kInitialFill));
   }
 }
@@ -283,11 +283,11 @@ TEST(PropertyRegistry, Stroke) {
 
   {
     PropertyRegistry registry;
-    EXPECT_FALSE(registry.stroke.hasValue());
+    EXPECT_FALSE(registry.stroke.isSpecified());
     EXPECT_THAT(registry.stroke.get(), Optional(kInitialFill));
 
     registry.parseStyle("stroke: none");
-    EXPECT_TRUE(registry.stroke.hasValue());
+    EXPECT_TRUE(registry.stroke.isSpecified());
     EXPECT_THAT(registry.stroke.get(), Optional(PaintServer(PaintServer::None())));
 
     registry.parseStyle("stroke: red  ");
@@ -298,11 +298,11 @@ TEST(PropertyRegistry, Stroke) {
   {
     PropertyRegistry registry;
     registry.parseStyle("stroke: red asdf");
-    EXPECT_FALSE(registry.stroke.hasValue());
+    EXPECT_FALSE(registry.stroke.isSpecified());
     EXPECT_THAT(registry.stroke.get(), Optional(kInitialFill));
 
     registry.parseStyle("stroke: asdf");
-    EXPECT_FALSE(registry.stroke.hasValue());
+    EXPECT_FALSE(registry.stroke.isSpecified());
     EXPECT_THAT(registry.stroke.get(), Optional(kInitialFill));
   }
 
@@ -317,7 +317,7 @@ TEST(PropertyRegistry, Stroke) {
   {
     PropertyRegistry registry;
     registry.parseStyle("stroke: context-stroke invalid");
-    EXPECT_FALSE(registry.stroke.hasValue());
+    EXPECT_FALSE(registry.stroke.isSpecified());
     EXPECT_THAT(registry.stroke.get(), Optional(kInitialFill));
   }
 
@@ -344,7 +344,7 @@ TEST(PropertyRegistry, Stroke) {
 TEST(PropertyRegistry, FontStyle) {
   {
     PropertyRegistry registry;
-    EXPECT_FALSE(registry.fontStyle.hasValue());
+    EXPECT_FALSE(registry.fontStyle.isSpecified());
     EXPECT_THAT(registry.fontStyle.get(), Optional(FontStyle::Normal));
   }
 
@@ -369,7 +369,7 @@ TEST(PropertyRegistry, FontStyle) {
   {
     PropertyRegistry registry;
     registry.parseStyle("font-style: invalid");
-    EXPECT_FALSE(registry.fontStyle.hasValue());
+    EXPECT_FALSE(registry.fontStyle.isSpecified());
   }
 
   // Presentation attribute.
@@ -383,7 +383,7 @@ TEST(PropertyRegistry, FontStyle) {
 TEST(PropertyRegistry, FontStretch) {
   {
     PropertyRegistry registry;
-    EXPECT_FALSE(registry.fontStretch.hasValue());
+    EXPECT_FALSE(registry.fontStretch.isSpecified());
     EXPECT_THAT(registry.fontStretch.get(), Optional(static_cast<int>(FontStretch::Normal)));
   }
 
@@ -459,7 +459,7 @@ TEST(PropertyRegistry, FontStretch) {
   {
     PropertyRegistry registry;
     registry.parseStyle("font-stretch: invalid");
-    EXPECT_FALSE(registry.fontStretch.hasValue());
+    EXPECT_FALSE(registry.fontStretch.isSpecified());
   }
 
   // Presentation attribute.
@@ -474,7 +474,7 @@ TEST(PropertyRegistry, FontStretch) {
 TEST(PropertyRegistry, FontVariant) {
   {
     PropertyRegistry registry;
-    EXPECT_FALSE(registry.fontVariant.hasValue());
+    EXPECT_FALSE(registry.fontVariant.isSpecified());
     EXPECT_THAT(registry.fontVariant.get(), Optional(FontVariant::Normal));
   }
 
@@ -493,7 +493,7 @@ TEST(PropertyRegistry, FontVariant) {
   {
     PropertyRegistry registry;
     registry.parseStyle("font-variant: invalid");
-    EXPECT_FALSE(registry.fontVariant.hasValue());
+    EXPECT_FALSE(registry.fontVariant.isSpecified());
   }
 
   // Presentation attribute.
@@ -651,7 +651,7 @@ TEST(PropertyRegistry, FontWeight) {
   {
     PropertyRegistry registry;
     registry.parseStyle("font-weight: invalid");
-    EXPECT_FALSE(registry.fontWeight.hasValue());
+    EXPECT_FALSE(registry.fontWeight.isSpecified());
   }
 
   {
@@ -669,7 +669,7 @@ TEST(PropertyRegistry, InheritFromNoPaintSkipsPaintServers) {
   const PropertyRegistry inherited = child.inheritFrom(parent, PropertyInheritOptions::NoPaint);
 
   EXPECT_THAT(inherited.color.get(), Optional(Color(RGBA(0xFF, 0, 0, 0xFF))));
-  EXPECT_FALSE(inherited.fill.hasValue());
+  EXPECT_FALSE(inherited.fill.isSpecified());
   EXPECT_THAT(inherited.fill.get(),
               Optional(PaintServer(PaintServer::Solid(Color(RGBA(0, 0, 0, 0xFF))))));
 }
@@ -1033,7 +1033,7 @@ TEST(PropertyRegistry, PaintReferenceTransformOriginAndFilterFunctionEdges) {
   {
     PropertyRegistry registry;
     registry.parseStyle("fill: url(#paint)");
-    ASSERT_TRUE(registry.fill.hasValue());
+    ASSERT_TRUE(registry.fill.isSpecified());
     EXPECT_THAT(registry.fill.get(),
                 Optional(PaintServer(PaintServer::ElementReference("#paint"))));
   }
@@ -1041,7 +1041,7 @@ TEST(PropertyRegistry, PaintReferenceTransformOriginAndFilterFunctionEdges) {
   {
     PropertyRegistry registry;
     registry.parseStyle("fill: url(#paint) none");
-    ASSERT_TRUE(registry.fill.hasValue());
+    ASSERT_TRUE(registry.fill.isSpecified());
     EXPECT_THAT(registry.fill.get(),
                 Optional(PaintServer(PaintServer::ElementReference("#paint"))));
   }
@@ -1049,7 +1049,7 @@ TEST(PropertyRegistry, PaintReferenceTransformOriginAndFilterFunctionEdges) {
   {
     PropertyRegistry registry;
     registry.parseStyle("fill: url(#paint) red");
-    ASSERT_TRUE(registry.fill.hasValue());
+    ASSERT_TRUE(registry.fill.isSpecified());
     EXPECT_THAT(registry.fill.get(), Optional(PaintServer(PaintServer::ElementReference(
                                          "#paint", Color(RGBA(0xFF, 0x00, 0x00, 0xFF))))));
   }
@@ -1071,7 +1071,7 @@ TEST(PropertyRegistry, PaintReferenceTransformOriginAndFilterFunctionEdges) {
   {
     PropertyRegistry registry;
     registry.parseStyle("clip-path: url(#clip)");
-    ASSERT_TRUE(registry.clipPath.hasValue());
+    ASSERT_TRUE(registry.clipPath.isSpecified());
     EXPECT_THAT(registry.clipPath.get(), Optional(Reference("#clip")));
   }
 
@@ -1102,7 +1102,7 @@ TEST(PropertyRegistry, PaintReferenceTransformOriginAndFilterFunctionEdges) {
     // and "top" is a separate (ignored) token. This is correct per CSS spec.
     PropertyRegistry registry;
     registry.parseStyle("transform-origin: left,top");
-    ASSERT_TRUE(registry.transformOrigin.hasValue());
+    ASSERT_TRUE(registry.transformOrigin.isSpecified());
   }
 
   {
@@ -1124,21 +1124,21 @@ TEST(PropertyRegistry, PaintReferenceTransformOriginAndFilterFunctionEdges) {
   {
     PropertyRegistry registry;
     registry.parseStyle("filter: blur()");
-    const auto& blur = registry.filter.getRequiredRef().front().get<FilterEffect::Blur>();
+    const auto& blur = (*registry.filter.getStoredValue()).front().get<FilterEffect::Blur>();
     EXPECT_EQ(blur.stdDeviationX, Lengthd(0, Lengthd::Unit::Px));
   }
 
   {
     PropertyRegistry registry;
     registry.parseStyle("filter: blur( )");
-    const auto& blur = registry.filter.getRequiredRef().front().get<FilterEffect::Blur>();
+    const auto& blur = (*registry.filter.getStoredValue()).front().get<FilterEffect::Blur>();
     EXPECT_EQ(blur.stdDeviationX, Lengthd(0, Lengthd::Unit::Px));
   }
 
   {
     PropertyRegistry registry;
     registry.parseStyle("filter: blur(0)");
-    const auto& blur = registry.filter.getRequiredRef().front().get<FilterEffect::Blur>();
+    const auto& blur = (*registry.filter.getStoredValue()).front().get<FilterEffect::Blur>();
     EXPECT_EQ(blur.stdDeviationX, Lengthd(0, Lengthd::Unit::Px));
   }
 
@@ -1146,21 +1146,24 @@ TEST(PropertyRegistry, PaintReferenceTransformOriginAndFilterFunctionEdges) {
     PropertyRegistry registry;
     registry.parseStyle("filter: hue-rotate()");
     EXPECT_DOUBLE_EQ(
-        registry.filter.getRequiredRef().front().get<FilterEffect::HueRotate>().angleDegrees, 0.0);
+        (*registry.filter.getStoredValue()).front().get<FilterEffect::HueRotate>().angleDegrees,
+        0.0);
   }
 
   {
     PropertyRegistry registry;
     registry.parseStyle("filter: hue-rotate( )");
     EXPECT_DOUBLE_EQ(
-        registry.filter.getRequiredRef().front().get<FilterEffect::HueRotate>().angleDegrees, 0.0);
+        (*registry.filter.getStoredValue()).front().get<FilterEffect::HueRotate>().angleDegrees,
+        0.0);
   }
 
   {
     PropertyRegistry registry;
     registry.parseStyle("filter: hue-rotate(45deg)");
     EXPECT_DOUBLE_EQ(
-        registry.filter.getRequiredRef().front().get<FilterEffect::HueRotate>().angleDegrees, 45.0);
+        (*registry.filter.getStoredValue()).front().get<FilterEffect::HueRotate>().angleDegrees,
+        45.0);
   }
 
   {
@@ -1182,7 +1185,7 @@ TEST(PropertyRegistry, PaintReferenceTransformOriginAndFilterFunctionEdges) {
     PropertyRegistry registry;
     registry.parseStyle("filter: brightness( )");
     EXPECT_DOUBLE_EQ(
-        registry.filter.getRequiredRef().front().get<FilterEffect::Brightness>().amount, 1.0);
+        (*registry.filter.getStoredValue()).front().get<FilterEffect::Brightness>().amount, 1.0);
   }
 
   {
@@ -1201,7 +1204,8 @@ TEST(PropertyRegistry, PaintReferenceTransformOriginAndFilterFunctionEdges) {
   {
     PropertyRegistry registry;
     registry.parseStyle("filter: drop-shadow(1 2)");
-    const auto& shadow = registry.filter.getRequiredRef().front().get<FilterEffect::DropShadow>();
+    const auto& shadow =
+        (*registry.filter.getStoredValue()).front().get<FilterEffect::DropShadow>();
     EXPECT_EQ(shadow.offsetX, Lengthd(1, Lengthd::Unit::None));
     EXPECT_EQ(shadow.offsetY, Lengthd(2, Lengthd::Unit::None));
   }
@@ -1251,7 +1255,7 @@ TEST(PropertyRegistry, PaintReferenceTransformOriginAndFilterFunctionEdges) {
   {
     PropertyRegistry registry;
     registry.parseStyle("filter: url(#a), url(#b)");
-    const auto& effects = registry.filter.getRequiredRef();
+    const auto& effects = (*registry.filter.getStoredValue());
     ASSERT_EQ(effects.size(), 2u);
     EXPECT_EQ(effects[0].get<FilterEffect::ElementReference>().reference, Reference("#a"));
     EXPECT_EQ(effects[1].get<FilterEffect::ElementReference>().reference, Reference("#b"));
@@ -1260,7 +1264,7 @@ TEST(PropertyRegistry, PaintReferenceTransformOriginAndFilterFunctionEdges) {
   {
     PropertyRegistry registry;
     registry.parseStyle("filter: url(#a) ");
-    ASSERT_EQ(registry.filter.getRequiredRef().size(), 1u);
+    ASSERT_EQ((*registry.filter.getStoredValue()).size(), 1u);
   }
 }
 
@@ -1299,8 +1303,8 @@ TEST(PropertyRegistry, BaselineShiftSpacingAndDasharray) {
   {
     PropertyRegistry registry;
     registry.parseStyle("stroke-dasharray: 1 2, 3%");
-    ASSERT_TRUE(registry.strokeDasharray.hasValue());
-    const auto& dasharray = registry.strokeDasharray.getRequiredRef();
+    ASSERT_TRUE(registry.strokeDasharray.isSpecified());
+    const auto& dasharray = (*registry.strokeDasharray.getStoredValue());
     EXPECT_EQ(dasharray.size(), 3u);
     EXPECT_EQ(dasharray[0], Lengthd(1, Lengthd::Unit::None));
     EXPECT_EQ(dasharray[1], Lengthd(2, Lengthd::Unit::None));
@@ -1319,8 +1323,8 @@ TEST(PropertyRegistry, FilterParsing) {
   {
     PropertyRegistry registry;
     registry.parseStyle("filter: none");
-    ASSERT_TRUE(registry.filter.hasValue());
-    EXPECT_TRUE(registry.filter.getRequiredRef().empty());
+    ASSERT_TRUE(registry.filter.isSpecified());
+    EXPECT_TRUE((*registry.filter.getStoredValue()).empty());
   }
 
   {
@@ -1328,8 +1332,8 @@ TEST(PropertyRegistry, FilterParsing) {
     registry.parseStyle(
         "filter: blur(2px) hue-rotate(0.5turn) brightness(50%) contrast(2) grayscale() "
         "invert(25%) opacity(0.4) saturate(3) sepia() url(#f)");
-    ASSERT_TRUE(registry.filter.hasValue());
-    const auto& effects = registry.filter.getRequiredRef();
+    ASSERT_TRUE(registry.filter.isSpecified());
+    const auto& effects = (*registry.filter.getStoredValue());
     ASSERT_EQ(effects.size(), 10u);
     EXPECT_TRUE(effects[0].is<FilterEffect::Blur>());
     EXPECT_EQ(effects[0].get<FilterEffect::Blur>().stdDeviationX, Lengthd(2, Lengthd::Unit::Px));
@@ -1355,8 +1359,8 @@ TEST(PropertyRegistry, FilterParsing) {
   {
     PropertyRegistry registry;
     registry.parseStyle("filter: drop-shadow(red 1px 2px 3px)");
-    ASSERT_TRUE(registry.filter.hasValue());
-    const auto& effects = registry.filter.getRequiredRef();
+    ASSERT_TRUE(registry.filter.isSpecified());
+    const auto& effects = (*registry.filter.getStoredValue());
     ASSERT_EQ(effects.size(), 1u);
     const auto& shadow = effects.front().get<FilterEffect::DropShadow>();
     EXPECT_EQ(shadow.offsetX, Lengthd(1, Lengthd::Unit::Px));
@@ -1396,14 +1400,14 @@ TEST(PropertyRegistry, TransformPresentationAttribute) {
       registry.parsePresentationAttribute("transform", "translate(10 20)", rect.entityHandle()),
       ParseResultIs(true));
   ASSERT_TRUE(rect.entityHandle().all_of<components::TransformComponent>());
-  EXPECT_TRUE(rect.entityHandle().get<components::TransformComponent>().transform.hasValue());
+  EXPECT_TRUE(rect.entityHandle().get<components::TransformComponent>().transform.isSpecified());
 }
 
 TEST(PropertyRegistry, TransformOriginStrokeMiterlimitAndFilterEdgeCases) {
   {
     PropertyRegistry registry;
     registry.parseStyle("transform-origin: left top");
-    const TransformOrigin origin = registry.transformOrigin.getRequired();
+    const TransformOrigin origin = registry.transformOrigin.get().value();
     EXPECT_EQ(origin.x, Lengthd(0, Lengthd::Unit::Percent));
     EXPECT_EQ(origin.y, Lengthd(0, Lengthd::Unit::Percent));
   }
@@ -1411,7 +1415,7 @@ TEST(PropertyRegistry, TransformOriginStrokeMiterlimitAndFilterEdgeCases) {
   {
     PropertyRegistry registry;
     registry.parseStyle("transform-origin: right bottom");
-    const TransformOrigin origin = registry.transformOrigin.getRequired();
+    const TransformOrigin origin = registry.transformOrigin.get().value();
     EXPECT_EQ(origin.x, Lengthd(100, Lengthd::Unit::Percent));
     EXPECT_EQ(origin.y, Lengthd(100, Lengthd::Unit::Percent));
   }
@@ -1419,7 +1423,7 @@ TEST(PropertyRegistry, TransformOriginStrokeMiterlimitAndFilterEdgeCases) {
   {
     PropertyRegistry registry;
     registry.parseStyle("transform-origin: center center");
-    const TransformOrigin origin = registry.transformOrigin.getRequired();
+    const TransformOrigin origin = registry.transformOrigin.get().value();
     EXPECT_EQ(origin.x, Lengthd(50, Lengthd::Unit::Percent));
     EXPECT_EQ(origin.y, Lengthd(50, Lengthd::Unit::Percent));
   }
@@ -1440,7 +1444,7 @@ TEST(PropertyRegistry, TransformOriginStrokeMiterlimitAndFilterEdgeCases) {
   {
     PropertyRegistry registry;
     registry.parseStyle("filter: hue-rotate(200grad) hue-rotate(3.141592653589793rad)");
-    const auto& effects = registry.filter.getRequiredRef();
+    const auto& effects = (*registry.filter.getStoredValue());
     ASSERT_EQ(effects.size(), 2u);
     EXPECT_DOUBLE_EQ(effects[0].get<FilterEffect::HueRotate>().angleDegrees, 180.0);
     EXPECT_NEAR(effects[1].get<FilterEffect::HueRotate>().angleDegrees, 180.0, 1e-9);
@@ -1449,7 +1453,7 @@ TEST(PropertyRegistry, TransformOriginStrokeMiterlimitAndFilterEdgeCases) {
   {
     PropertyRegistry registry;
     registry.parseStyle("filter: hue-rotate(0)");
-    const auto& effects = registry.filter.getRequiredRef();
+    const auto& effects = (*registry.filter.getStoredValue());
     ASSERT_EQ(effects.size(), 1u);
     EXPECT_DOUBLE_EQ(effects[0].get<FilterEffect::HueRotate>().angleDegrees, 0.0);
   }
@@ -1457,7 +1461,7 @@ TEST(PropertyRegistry, TransformOriginStrokeMiterlimitAndFilterEdgeCases) {
   {
     PropertyRegistry registry;
     registry.parseStyle("filter: url(\"#quoted\")");
-    const auto& effects = registry.filter.getRequiredRef();
+    const auto& effects = (*registry.filter.getStoredValue());
     ASSERT_EQ(effects.size(), 1u);
     EXPECT_TRUE(effects[0].is<FilterEffect::ElementReference>());
     EXPECT_EQ(effects[0].get<FilterEffect::ElementReference>().reference, Reference("#quoted"));
@@ -1466,7 +1470,8 @@ TEST(PropertyRegistry, TransformOriginStrokeMiterlimitAndFilterEdgeCases) {
   {
     PropertyRegistry registry;
     registry.parseStyle("filter: drop-shadow(1px 2px red)");
-    const auto& shadow = registry.filter.getRequiredRef().front().get<FilterEffect::DropShadow>();
+    const auto& shadow =
+        (*registry.filter.getStoredValue()).front().get<FilterEffect::DropShadow>();
     EXPECT_EQ(shadow.color, Color(RGBA(0xFF, 0, 0, 0xFF)));
   }
 

--- a/donner/svg/renderer/RendererDriver.cc
+++ b/donner/svg/renderer/RendererDriver.cc
@@ -93,12 +93,14 @@ std::optional<Box2d> LocalDrawableBoundsWithStroke(
   }
 
   const auto& props = style.properties.value();
-  const PaintServer& strokeServer = props.stroke.getRequired();
+  // Value (not reference): `get()` returns a temporary optional, so binding a
+  // reference to its `.value()` would dangle. PaintServer is a small variant.
+  const PaintServer strokeServer = props.stroke.get().value();
   if (strokeServer.is<PaintServer::None>()) {
     return box;
   }
 
-  const double strokeWidth = props.strokeWidth.getRequired().value;
+  const double strokeWidth = props.strokeWidth.get().value().value;
   if (strokeWidth <= 0.0) {
     return box;
   }
@@ -194,16 +196,16 @@ void resolvePerSpanStyles(Registry& registry, components::ComputedTextComponent&
     }
 
     if (style && style->properties) {
-      span.resolvedFill = resolvePaintServer(registry, style->properties->fill.getRequired());
-      span.resolvedStroke = resolvePaintServer(registry, style->properties->stroke.getRequired());
-      span.fillOpacity = style->properties->fillOpacity.getRequired();
-      span.strokeOpacity = style->properties->strokeOpacity.getRequired();
-      span.strokeWidth = style->properties->strokeWidth.getRequired().toPixels(
+      span.resolvedFill = resolvePaintServer(registry, style->properties->fill.get().value());
+      span.resolvedStroke = resolvePaintServer(registry, style->properties->stroke.get().value());
+      span.fillOpacity = style->properties->fillOpacity.get().value();
+      span.strokeOpacity = style->properties->strokeOpacity.get().value();
+      span.strokeWidth = style->properties->strokeWidth.get().value().toPixels(
           viewBox, baseFm, Lengthd::Extent::Mixed);
-      span.strokeLinecap = style->properties->strokeLinecap.getRequired();
-      span.strokeLinejoin = style->properties->strokeLinejoin.getRequired();
-      span.strokeMiterLimit = style->properties->strokeMiterlimit.getRequired();
-      span.paintOrder = style->properties->paintOrder.getRequired();
+      span.strokeLinecap = style->properties->strokeLinecap.get().value();
+      span.strokeLinejoin = style->properties->strokeLinejoin.get().value();
+      span.strokeMiterLimit = style->properties->strokeMiterlimit.get().value();
+      span.paintOrder = style->properties->paintOrder.get().value();
     }
 
     // Resolve decoration from ancestors. Per CSS Text Decoration §3, text-decoration is NOT
@@ -232,7 +234,7 @@ void resolvePerSpanStyles(Registry& registry, components::ComputedTextComponent&
 
         auto* walkStyle = registry.try_get<components::ComputedStyleComponent>(walkEntity);
         if (walkStyle && walkStyle->properties) {
-          const TextDecoration ancestorDeco = walkStyle->properties->textDecoration.getRequired();
+          const TextDecoration ancestorDeco = walkStyle->properties->textDecoration.get().value();
           if (ancestorDeco != TextDecoration::None) {
             // This ancestor declares decoration — accumulate it for descendant glyphs.
             span.textDecoration |= ancestorDeco;
@@ -261,15 +263,15 @@ void resolvePerSpanStyles(Registry& registry, components::ComputedTextComponent&
             registry.try_get<components::ComputedStyleComponent>(decorationPaintEntity);
         if (decoStyle && decoStyle->properties) {
           const auto& decoProps = decoStyle->properties.value();
-          span.resolvedDecorationFill = resolvePaintServer(registry, decoProps.fill.getRequired());
+          span.resolvedDecorationFill = resolvePaintServer(registry, decoProps.fill.get().value());
           span.resolvedDecorationStroke =
-              resolvePaintServer(registry, decoProps.stroke.getRequired());
-          span.decorationFillOpacity = decoProps.fillOpacity.getRequired();
-          span.decorationStrokeOpacity = decoProps.strokeOpacity.getRequired();
+              resolvePaintServer(registry, decoProps.stroke.get().value());
+          span.decorationFillOpacity = decoProps.fillOpacity.get().value();
+          span.decorationStrokeOpacity = decoProps.strokeOpacity.get().value();
           span.decorationStrokeWidth =
-              decoProps.strokeWidth.getRequired().toPixels(viewBox, baseFm, Lengthd::Extent::Mixed);
+              decoProps.strokeWidth.get().value().toPixels(viewBox, baseFm, Lengthd::Extent::Mixed);
           span.decorationFontSizePx = static_cast<float>(
-              decoProps.fontSize.getRequired().toPixels(viewBox, baseFm, Lengthd::Extent::Mixed));
+              decoProps.fontSize.get().value().toPixels(viewBox, baseFm, Lengthd::Extent::Mixed));
         }
       }
     }
@@ -280,7 +282,7 @@ PathShape toPathShape(EntityHandle sourceEntity, const components::ComputedPathC
                       const components::ComputedStyleComponent& style) {
   PathShape shape;
   shape.path = path.spline;
-  shape.fillRule = style.properties->fillRule.getRequired();
+  shape.fillRule = style.properties->fillRule.get().value();
   shape.sourceEntity = sourceEntity;
   return shape;
 }
@@ -293,7 +295,7 @@ StrokeParams toStrokeParams(Registry& registry,
 
   const Box2d viewBox = components::LayoutSystem().getViewBox(instance.dataHandle(registry));
   const FontMetrics baseFontMetrics = FontMetrics::DefaultsWithFontSize(12.0);
-  const double fontSizePx = properties.fontSize.getRequired().toPixels(viewBox, baseFontMetrics);
+  const double fontSizePx = properties.fontSize.get().value().toPixels(viewBox, baseFontMetrics);
   const FontMetrics fontMetrics = FontMetrics::DefaultsWithFontSize(fontSizePx);
 
   const auto toPixels = [&](const Lengthd& length,
@@ -301,11 +303,11 @@ StrokeParams toStrokeParams(Registry& registry,
     return length.toPixels(viewBox, fontMetrics, extent);
   };
 
-  stroke.strokeWidth = toPixels(properties.strokeWidth.getRequired());
-  stroke.lineCap = properties.strokeLinecap.getRequired();
-  stroke.lineJoin = properties.strokeLinejoin.getRequired();
-  stroke.miterLimit = properties.strokeMiterlimit.getRequired();
-  stroke.dashOffset = toPixels(properties.strokeDashoffset.getRequired());
+  stroke.strokeWidth = toPixels(properties.strokeWidth.get().value());
+  stroke.lineCap = properties.strokeLinecap.get().value();
+  stroke.lineJoin = properties.strokeLinejoin.get().value();
+  stroke.miterLimit = properties.strokeMiterlimit.get().value();
+  stroke.dashOffset = toPixels(properties.strokeDashoffset.get().value());
 
   if (const std::optional<StrokeDasharray> dashArray = properties.strokeDasharray.get()) {
     stroke.dashArray.reserve(dashArray->size());
@@ -328,12 +330,12 @@ PaintParams toPaintParams(Registry& registry,
   PaintParams paint;
   const auto& properties = style.properties.value();
 
-  paint.opacity = properties.opacity.getRequired();
+  paint.opacity = properties.opacity.get().value();
   paint.fill = instance.resolvedFill;
-  paint.fillOpacity = properties.fillOpacity.getRequired();
+  paint.fillOpacity = properties.fillOpacity.get().value();
   paint.stroke = instance.resolvedStroke;
-  paint.strokeOpacity = properties.strokeOpacity.getRequired();
-  paint.currentColor = properties.color.getRequired();
+  paint.strokeOpacity = properties.strokeOpacity.get().value();
+  paint.currentColor = properties.color.get().value();
   paint.viewBox = components::LayoutSystem().getViewBox(instance.dataHandle(registry));
   paint.strokeParams = toStrokeParams(registry, instance, style);
 
@@ -378,7 +380,7 @@ ResolvedClip toResolvedClip(const components::RenderingInstanceComponent& instan
   // The computed clip rule is inherited if undefined on the clip path itself.
   for (PathShape& path : clip.clipPaths) {
     if (path.fillRule == FillRule::NonZero &&
-        style.properties->clipRule.getRequired() == ClipRule::EvenOdd) {
+        style.properties->clipRule.get().value() == ClipRule::EvenOdd) {
       path.fillRule = FillRule::EvenOdd;
     }
   }
@@ -696,8 +698,8 @@ std::optional<Box2d> computeFilterRegion(Registry& registry,
 css::Color resolveFillColor(const components::RenderingInstanceComponent& instance,
                             const components::ComputedStyleComponent& style) {
   const auto& properties = style.properties.value();
-  const css::RGBA currentColor = properties.color.getRequired().rgba();
-  const float fillOpacity = NarrowToFloat(properties.fillOpacity.getRequired());
+  const css::RGBA currentColor = properties.color.get().value().rgba();
+  const float fillOpacity = NarrowToFloat(properties.fillOpacity.get().value());
 
   const auto resolveSolid = [&](const PaintServer::Solid& solid) {
     return css::Color(solid.color.resolve(currentColor, fillOpacity));
@@ -707,7 +709,7 @@ css::Color resolveFillColor(const components::RenderingInstanceComponent& instan
     return resolveSolid(*resolved);
   }
 
-  const PaintServer fill = properties.fill.getRequired();
+  const PaintServer fill = properties.fill.get().value();
   if (const auto* solid = std::get_if<PaintServer::Solid>(&fill.value)) {
     return resolveSolid(*solid);
   }
@@ -721,13 +723,13 @@ TextParams toTextParams(Registry& registry, const components::RenderingInstanceC
                         const components::TextComponent* textComp) {
   TextParams params;
   const auto& properties = style.properties.value();
-  const css::RGBA currentColor = properties.color.getRequired().rgba();
+  const css::RGBA currentColor = properties.color.get().value().rgba();
 
-  params.opacity = properties.opacity.getRequired();
+  params.opacity = properties.opacity.get().value();
   params.fillColor = resolveFillColor(instance, style);
 
   if (const auto* stroke = std::get_if<PaintServer::Solid>(&instance.resolvedStroke)) {
-    const float strokeOpacity = NarrowToFloat(properties.strokeOpacity.getRequired());
+    const float strokeOpacity = NarrowToFloat(properties.strokeOpacity.get().value());
     params.strokeColor = css::Color(stroke->color.resolve(currentColor, strokeOpacity));
   }
 
@@ -737,8 +739,8 @@ TextParams toTextParams(Registry& registry, const components::RenderingInstanceC
     params.strokeParams = toStrokeParams(registry, instance, style);
   }
 
-  params.fontFamilies = properties.fontFamily.getRequired();
-  params.fontSize = properties.fontSize.getRequired();
+  params.fontFamilies = properties.fontFamily.get().value();
+  params.fontSize = properties.fontSize.get().value();
   params.viewBox = components::LayoutSystem().getViewBox(instance.dataHandle(registry));
   // Resolve font size so that em/ex units in text positioning attributes resolve correctly.
   {
@@ -747,15 +749,15 @@ TextParams toTextParams(Registry& registry, const components::RenderingInstanceC
         params.fontSize.toPixels(params.viewBox, baseFontMetrics, Lengthd::Extent::Mixed);
     params.fontMetrics = FontMetrics::DefaultsWithFontSize(fontSizePx);
   }
-  params.textAnchor = properties.textAnchor.getRequired();
-  params.textDecoration = properties.textDecoration.getRequired();
-  params.dominantBaseline = properties.dominantBaseline.getRequired();
-  params.writingMode = properties.writingMode.getRequired();
+  params.textAnchor = properties.textAnchor.get().value();
+  params.textDecoration = properties.textDecoration.get().value();
+  params.dominantBaseline = properties.dominantBaseline.get().value();
+  params.writingMode = properties.writingMode.get().value();
 
   // Resolve letter-spacing and word-spacing to pixels.
-  params.letterSpacingPx = properties.letterSpacing.getRequired().toPixels(
+  params.letterSpacingPx = properties.letterSpacing.get().value().toPixels(
       params.viewBox, params.fontMetrics, Lengthd::Extent::X);
-  params.wordSpacingPx = properties.wordSpacing.getRequired().toPixels(
+  params.wordSpacingPx = properties.wordSpacing.get().value().toPixels(
       params.viewBox, params.fontMetrics, Lengthd::Extent::X);
 
   if (textComp) {
@@ -789,14 +791,14 @@ std::optional<ImageParams> toImageParams(const components::RenderingInstanceComp
   }
 
   ImageParams params;
-  params.opacity = style.properties->opacity.getRequired();
+  params.opacity = style.properties->opacity.get().value();
   params.targetRect = Box2d::WithSize(Vector2d(image.image->width, image.image->height));
 
   // `image-rendering: pixelated` and `crisp-edges` (plus the legacy
   // SVG 1.1 `optimizeSpeed` alias) disable bilinear filtering and use
   // nearest-neighbor sampling instead. `auto`, `smooth`, and
   // `optimizeQuality` all fall back to the backend default (bilinear).
-  const ImageRendering imageRendering = style.properties->imageRendering.getRequired();
+  const ImageRendering imageRendering = style.properties->imageRendering.get().value();
   params.imageRenderingPixelated = imageRendering == ImageRendering::Pixelated ||
                                    imageRendering == ImageRendering::CrispEdges ||
                                    imageRendering == ImageRendering::OptimizeSpeed;
@@ -976,9 +978,9 @@ void RendererDriver::drawEntityRange(Registry& registry, Entity firstEntity, Ent
     // regression guarded by TightBoundsRotatedEllipseWithRotatingGradient.
     renderer_.setTransform(instance.worldFromEntityTransform * surfaceFromCanvasTransform_);
 
-    const double opacity = style.properties->opacity.getRequired();
-    const MixBlendMode blendMode = style.properties->mixBlendMode.getRequired();
-    const Isolation isolation = style.properties->isolation.getRequired();
+    const double opacity = style.properties->opacity.get().value();
+    const MixBlendMode blendMode = style.properties->mixBlendMode.get().value();
+    const Isolation isolation = style.properties->isolation.get().value();
     const bool hasIsolatedLayer =
         opacity < 1.0 || blendMode != MixBlendMode::Normal || isolation == Isolation::Isolate;
     if (hasIsolatedLayer) {
@@ -1198,7 +1200,7 @@ std::optional<Box2d> RendererDriver::computeEntityRangeBounds(
     if (!instance.visible) {
       continue;
     }
-    if (style.properties->display.getRequired() == Display::None) {
+    if (style.properties->display.get().value() == Display::None) {
       continue;
     }
 
@@ -1365,11 +1367,11 @@ void RendererDriver::prepareFilterGraphs(Registry& registry, std::span<const Ent
         components::LayoutSystem().getViewBox(instance->dataHandle(registry));
     const FontMetrics filterBaseFontMetrics = FontMetrics::DefaultsWithFontSize(16.0);
     const double filterFontSizePx =
-        style.properties->fontSize.getRequired().toPixels(filterViewBox, filterBaseFontMetrics);
+        style.properties->fontSize.get().value().toPixels(filterViewBox, filterBaseFontMetrics);
     const FontMetrics filterFontMetrics = FontMetrics::DefaultsWithFontSize(filterFontSizePx);
 
     std::optional<components::FilterGraph> filterGraph = resolveFilterGraph(
-        registry, instance->resolvedFilter.value(), style.properties->color.getRequired().rgba(),
+        registry, instance->resolvedFilter.value(), style.properties->color.get().value().rgba(),
         filterViewBox, filterFontMetrics);
     const std::optional<Box2d> filterRegion =
         computeFilterRegion(registry, instance->resolvedFilter.value(), *instance);
@@ -1435,9 +1437,9 @@ void RendererDriver::traverse(RenderingInstanceView& view, Registry& registry) {
     }
     renderer_.setTransform(surfaceFromCanvasTransform_ * instance.worldFromEntityTransform);
 
-    const double opacity = style.properties->opacity.getRequired();
-    const MixBlendMode blendMode = style.properties->mixBlendMode.getRequired();
-    const Isolation isolation = style.properties->isolation.getRequired();
+    const double opacity = style.properties->opacity.get().value();
+    const MixBlendMode blendMode = style.properties->mixBlendMode.get().value();
+    const Isolation isolation = style.properties->isolation.get().value();
     const bool hasIsolatedLayer =
         opacity < 1.0 || blendMode != MixBlendMode::Normal || isolation == Isolation::Isolate;
     if (hasIsolatedLayer) {
@@ -1552,7 +1554,7 @@ void RendererDriver::traverse(RenderingInstanceView& view, Registry& registry) {
             const PreserveAspectRatio aspectRatio =
                 preserveAspectRatioComp != nullptr ? preserveAspectRatioComp->preserveAspectRatio
                                                    : PreserveAspectRatio::Default();
-            const double opacity = style.properties->opacity.getRequired();
+            const double opacity = style.properties->opacity.get().value();
 
             SVGDocument subDoc = SVGDocument::CreateFromHandle(svgImage->subDocument);
             drawSubDocument(subDoc, sizedElement->bounds, aspectRatio, opacity,
@@ -1570,12 +1572,12 @@ void RendererDriver::traverse(RenderingInstanceView& view, Registry& registry) {
             const Transform2d parentAbsoluteTransform =
                 surfaceFromCanvasTransform_ * instance.worldFromEntityTransform;
             drawSubDocumentElement(subDoc, externalUse->fragment, parentAbsoluteTransform,
-                                   style.properties->opacity.getRequired());
+                                   style.properties->opacity.get().value());
           } else {
             const Vector2i subDocSize = subDoc.canvasSize();
             const Box2d viewportBounds = Box2d::WithSize(Vector2d(subDocSize.x, subDocSize.y));
             drawSubDocument(subDoc, viewportBounds, PreserveAspectRatio::Default(),
-                            style.properties->opacity.getRequired(),
+                            style.properties->opacity.get().value(),
                             surfaceFromCanvasTransform_ * instance.worldFromEntityTransform);
           }
 
@@ -1715,9 +1717,9 @@ void RendererDriver::traverseRange(RenderingInstanceView& view, Registry& regist
     }
     renderer_.setTransform(instance.worldFromEntityTransform * surfaceFromCanvasTransform_);
 
-    const double opacity = style.properties->opacity.getRequired();
-    const MixBlendMode blendMode = style.properties->mixBlendMode.getRequired();
-    const Isolation isolation = style.properties->isolation.getRequired();
+    const double opacity = style.properties->opacity.get().value();
+    const MixBlendMode blendMode = style.properties->mixBlendMode.get().value();
+    const Isolation isolation = style.properties->isolation.get().value();
     const bool hasIsolatedLayer =
         opacity < 1.0 || blendMode != MixBlendMode::Normal || isolation == Isolation::Isolate;
     if (hasIsolatedLayer) {
@@ -1816,7 +1818,7 @@ void RendererDriver::traverseRange(RenderingInstanceView& view, Registry& regist
 
             SVGDocument subDoc = SVGDocument::CreateFromHandle(svgImage->subDocument);
             drawSubDocument(subDoc, sizedElement->bounds, aspectRatio,
-                            style.properties->opacity.getRequired(),
+                            style.properties->opacity.get().value(),
                             instance.worldFromEntityTransform * surfaceFromCanvasTransform_);
           }
         }
@@ -2085,7 +2087,7 @@ void RendererDriver::drawPathWithPaintOrder(RenderingInstanceView& view, Registr
                                             const components::ComputedStyleComponent& style,
                                             const PaintParams& paint,
                                             const Transform2d& deviceFromLocalForShape) {
-  const PaintOrder paintOrder = style.properties->paintOrder.getRequired();
+  const PaintOrder paintOrder = style.properties->paintOrder.get().value();
   const PathShape pathShape = toPathShape(instance.dataHandle(registry), path, style);
 
   // Fast path: canonical order (fill, stroke, markers) is the common case and lets a
@@ -2234,7 +2236,7 @@ void RendererDriver::drawMarker(RenderingInstanceView& view, Registry& registry,
 
   double markerScale = 1.0;
   if (markerComponent->markerUnits == MarkerUnits::StrokeWidth) {
-    const double strokeWidth = style.properties->strokeWidth.getRequired().value;
+    const double strokeWidth = style.properties->strokeWidth.get().value().value;
     markerScale = strokeWidth;
   }
 
@@ -2262,7 +2264,7 @@ void RendererDriver::drawMarker(RenderingInstanceView& view, Registry& registry,
   // Apply overflow clipping if needed. The clip rect is in world coordinates,
   // so reset the transform to identity before clipping.
   const auto& markerStyle = markerHandle.get<components::ComputedStyleComponent>();
-  const Overflow overflow = markerStyle.properties->overflow.getRequired();
+  const Overflow overflow = markerStyle.properties->overflow.get().value();
   const bool needsClip = overflow != Overflow::Visible && overflow != Overflow::Auto;
 
   if (needsClip) {

--- a/donner/svg/renderer/RenderingContext.cc
+++ b/donner/svg/renderer/RenderingContext.cc
@@ -176,7 +176,7 @@ public:
     const auto& styleComponent = registry_.get<ComputedStyleComponent>(styleEntity);
     const auto& properties = styleComponent.properties.value();
 
-    if (properties.display.getRequired() == Display::None) {
+    if (properties.display.get().value() == Display::None) {
       return;
     }
 
@@ -197,7 +197,7 @@ public:
     }
 
     if (auto maybeClipRect = LayoutSystem().clipRect(EntityHandle(registry_, treeEntity))) {
-      const Overflow overflow = styleComponent.properties->overflow.getRequired();
+      const Overflow overflow = styleComponent.properties->overflow.get().value();
 
       if (overflow != Overflow::Visible && overflow != Overflow::Auto) {
         ++layerDepth;
@@ -233,10 +233,16 @@ public:
       std::cout << "\n";
     }
 
-    const std::vector<FilterEffect>& filterEffects = properties.filter.getRequired();
+    // No-copy access to the stored effect list (avoids copying the vector on
+    // every recompute). An unset/initial `filter` has no stored value and means
+    // "no effects", so fall back to an empty list.
+    static const std::vector<FilterEffect> kNoFilterEffects;
+    const std::vector<FilterEffect>* storedFilter = properties.filter.getStoredValue();
+    const std::vector<FilterEffect>& filterEffects =
+        storedFilter != nullptr ? *storedFilter : kNoFilterEffects;
     const bool hasFilterEffect = !filterEffects.empty();
 
-    if (properties.visibility.getRequired() != Visibility::Visible) {
+    if (properties.visibility.get().value() != Visibility::Visible) {
       instance.visible = false;
     }
 
@@ -246,7 +252,7 @@ public:
 
     if (!isShadowOnlyInLightTree) {
       if (properties.clipPath.get()) {
-        if (auto resolved = resolveClipPath(dataHandle, properties.clipPath.getRequired());
+        if (auto resolved = resolveClipPath(dataHandle, properties.clipPath.get().value());
             resolved.valid()) {
           instance.clipPath = resolved;
 
@@ -261,7 +267,7 @@ public:
 
       if (properties.mask.get()) {
         if (auto resolved =
-                resolveMask(EntityHandle(registry_, styleEntity), properties.mask.getRequired());
+                resolveMask(EntityHandle(registry_, styleEntity), properties.mask.get().value());
             resolved.valid()) {
           instance.mask = std::move(resolved);
         }
@@ -271,7 +277,7 @@ public:
     if (isShape) {
       if (properties.markerStart.get()) {
         if (auto resolved = resolveMarker(EntityHandle(registry_, styleEntity),
-                                          properties.markerStart.getRequired(),
+                                          properties.markerStart.get().value(),
                                           ShadowBranchType::OffscreenMarkerStart);
             resolved.valid()) {
           instance.markerStart = resolved;
@@ -280,7 +286,7 @@ public:
 
       if (properties.markerMid.get()) {
         if (auto resolved = resolveMarker(EntityHandle(registry_, styleEntity),
-                                          properties.markerMid.getRequired(),
+                                          properties.markerMid.get().value(),
                                           ShadowBranchType::OffscreenMarkerMid);
             resolved.valid()) {
           instance.markerMid = resolved;
@@ -289,7 +295,7 @@ public:
 
       if (properties.markerEnd.get()) {
         if (auto resolved = resolveMarker(EntityHandle(registry_, styleEntity),
-                                          properties.markerEnd.getRequired(),
+                                          properties.markerEnd.get().value(),
                                           ShadowBranchType::OffscreenMarkerEnd);
             resolved.valid()) {
           instance.markerEnd = resolved;
@@ -299,7 +305,7 @@ public:
 
     // Create a new layer if opacity is less than 1 or if there is an effect that requires an
     // isolated group.
-    if (properties.opacity.getRequired() < 1.0) {
+    if (properties.opacity.get().value() < 1.0) {
       instance.isolatedLayer = true;
       ++layerDepth;
     }
@@ -319,8 +325,8 @@ public:
       layerDepth += 2;
     }
 
-    if (properties.mixBlendMode.getRequired() != MixBlendMode::Normal ||
-        properties.isolation.getRequired() == Isolation::Isolate) {
+    if (properties.mixBlendMode.get().value() != MixBlendMode::Normal ||
+        properties.isolation.get().value() == Isolation::Isolate) {
       instance.isolatedLayer = true;
       ++layerDepth;
     }
@@ -393,14 +399,14 @@ public:
       }
 
       const auto& style = computedStyle->properties.value();
-      if (enforceVisibility && (style.visibility.getRequired() != Visibility::Visible ||
-                                style.display.getRequired() == Display::None)) {
+      if (enforceVisibility && (style.visibility.get().value() != Visibility::Visible ||
+                                style.display.get().value() == Display::None)) {
         return;
       }
 
       // Check to see if this element has its own clip paths set.
       if (style.clipPath.get()) {
-        if (auto resolved = resolveClipPath(entity, style.clipPath.getRequired());
+        if (auto resolved = resolveClipPath(entity, style.clipPath.get().value());
             resolved.valid()) {
           if (!guard.hasRecursion(resolved.reference.handle)) {
             if (!collectClipPaths(resolved.reference.handle, clipPaths,
@@ -423,7 +429,7 @@ public:
     if (const auto* computedStyle = clipPathHandle.try_get<components::ComputedStyleComponent>()) {
       const auto& style = computedStyle->properties.value();
       if (style.clipPath.get()) {
-        if (auto resolved = resolveClipPath(clipPathHandle, style.clipPath.getRequired());
+        if (auto resolved = resolveClipPath(clipPathHandle, style.clipPath.get().value());
             resolved.valid()) {
           if (!guard.hasRecursion(resolved.reference.handle)) {
             if (!collectClipPaths(resolved.reference.handle, clipPaths,
@@ -449,8 +455,8 @@ public:
       }
 
       const auto& useProperties = useStyle->properties.value();
-      if (useProperties.visibility.getRequired() != Visibility::Visible ||
-          useProperties.display.getRequired() == Display::None) {
+      if (useProperties.visibility.get().value() != Visibility::Visible ||
+          useProperties.display.get().value() == Display::None) {
         return;
       }
 
@@ -813,7 +819,7 @@ bool RenderingContext::hitTestEntity(Entity entity, const Vector2d& point) {
   ParseWarningSink disabledSink = ParseWarningSink::Disabled();
   const ComputedStyleComponent& style =
       StyleSystem().computeStyle(EntityHandle(registry_, entity), disabledSink);
-  const PointerEvents pointerEvents = style.properties->pointerEvents.getRequired();
+  const PointerEvents pointerEvents = style.properties->pointerEvents.get().value();
 
   if (pointerEvents == PointerEvents::None) {
     return false;
@@ -826,10 +832,10 @@ bool RenderingContext::hitTestEntity(Entity entity, const Vector2d& point) {
     return false;
   }
 
-  const bool hasFillPaint = style.properties->fill.getRequired() != PaintServer::None();
-  const bool hasStrokePaint = style.properties->stroke.getRequired() != PaintServer::None();
+  const bool hasFillPaint = style.properties->fill.get().value() != PaintServer::None();
+  const bool hasStrokePaint = style.properties->stroke.get().value() != PaintServer::None();
   const double strokeWidth =
-      hasStrokePaint ? style.properties->strokeWidth.getRequired().value : 0.0;
+      hasStrokePaint ? style.properties->strokeWidth.get().value().value : 0.0;
 
   if (const auto bounds = ShapeSystem().getShapeWorldBounds(EntityHandle(registry_, entity));
       bounds && bounds->inflatedBy(strokeWidth).contains(point)) {
@@ -847,7 +853,7 @@ bool RenderingContext::hitTestEntity(Entity entity, const Vector2d& point) {
       const bool skipBecauseNotPainted = config.requirePaintedFill && !hasFillPaint;
       if (!skipBecauseNotPainted &&
           ShapeSystem().pathFillIntersects(EntityHandle(registry_, entity), pointInLocal,
-                                           style.properties->fillRule.getRequired())) {
+                                           style.properties->fillRule.get().value())) {
         return true;
       }
     }

--- a/donner/svg/tests/SVGElement_tests.cc
+++ b/donner/svg/tests/SVGElement_tests.cc
@@ -343,9 +343,9 @@ TEST_F(SVGElementTests, SetStyleReplacesStyleOriginPropertiesPreservingPresentat
   ASSERT_TRUE(fillResult.hasResult() && fillResult.result());
   styleComponent.setStyle("stroke: green; opacity: 0.5");
 
-  EXPECT_TRUE(styleComponent.properties.fill.hasValue());
-  EXPECT_TRUE(styleComponent.properties.stroke.hasValue());
-  EXPECT_TRUE(styleComponent.properties.opacity.hasValue());
+  EXPECT_TRUE(styleComponent.properties.fill.isSpecified());
+  EXPECT_TRUE(styleComponent.properties.stroke.isSpecified());
+  EXPECT_TRUE(styleComponent.properties.opacity.isSpecified());
   EXPECT_EQ(styleComponent.properties.fill.specificity, css::Specificity::FromABC(0, 0, 0));
   EXPECT_EQ(styleComponent.properties.stroke.specificity, css::Specificity::StyleAttribute());
 
@@ -357,10 +357,10 @@ TEST_F(SVGElementTests, SetStyleReplacesStyleOriginPropertiesPreservingPresentat
   // style-origin.
   styleComponent.setStyle("stroke: blue");
 
-  EXPECT_TRUE(styleComponent.properties.fill.hasValue())
+  EXPECT_TRUE(styleComponent.properties.fill.isSpecified())
       << "fill presentation attribute must survive setStyle rewrite";
-  EXPECT_TRUE(styleComponent.properties.stroke.hasValue());
-  EXPECT_FALSE(styleComponent.properties.opacity.hasValue())
+  EXPECT_TRUE(styleComponent.properties.stroke.isSpecified());
+  EXPECT_FALSE(styleComponent.properties.opacity.isSpecified())
       << "opacity must be cleared — it was style-origin and no longer appears";
 }
 
@@ -631,7 +631,7 @@ TEST_F(SVGElementTests, InheritedStyleChangeRecomputesDescendantStyle) {
   const auto* initialComputed = child->entityHandle().try_get<components::ComputedStyleComponent>();
   ASSERT_NE(initialComputed, nullptr);
   ASSERT_TRUE(initialComputed->properties.has_value());
-  EXPECT_EQ(initialComputed->properties->fill.getRequired(),
+  EXPECT_EQ(initialComputed->properties->fill.get().value(),
             PaintServer::Solid(css::Color(css::RGBA::RGB(0, 0, 255))));
 
   parent->setAttribute("fill", "red");
@@ -646,7 +646,7 @@ TEST_F(SVGElementTests, InheritedStyleChangeRecomputesDescendantStyle) {
   const auto* updatedComputed = child->entityHandle().try_get<components::ComputedStyleComponent>();
   ASSERT_NE(updatedComputed, nullptr);
   ASSERT_TRUE(updatedComputed->properties.has_value());
-  EXPECT_EQ(updatedComputed->properties->fill.getRequired(),
+  EXPECT_EQ(updatedComputed->properties->fill.get().value(),
             PaintServer::Solid(css::Color(css::RGBA::RGB(255, 0, 0))));
 }
 
@@ -698,12 +698,12 @@ TEST_F(SVGElementTests, SelectiveStyleRecomputeSkipsCleanSiblingsAfterFirstBuild
   const auto* targetComputed = target->entityHandle().try_get<components::ComputedStyleComponent>();
   ASSERT_NE(targetComputed, nullptr);
   ASSERT_TRUE(targetComputed->properties.has_value());
-  EXPECT_DOUBLE_EQ(targetComputed->properties->opacity.getRequired(), 0.5);
+  EXPECT_DOUBLE_EQ(targetComputed->properties->opacity.get().value(), 0.5);
 
   siblingComputed = sibling->entityHandle().try_get<components::ComputedStyleComponent>();
   ASSERT_NE(siblingComputed, nullptr);
   ASSERT_TRUE(siblingComputed->properties.has_value());
-  EXPECT_EQ(siblingComputed->properties->fill.getRequired(),
+  EXPECT_EQ(siblingComputed->properties->fill.get().value(),
             PaintServer::Solid(css::Color(css::RGBA::RGB(0, 255, 0))));
 }
 
@@ -741,7 +741,7 @@ TEST_F(SVGElementTests, NonLocalSelectorMutationRequestsFullStyleRecompute) {
       second->entityHandle().try_get<components::ComputedStyleComponent>();
   ASSERT_NE(initialComputed, nullptr);
   ASSERT_TRUE(initialComputed->properties.has_value());
-  EXPECT_EQ(initialComputed->properties->fill.getRequired(),
+  EXPECT_EQ(initialComputed->properties->fill.get().value(),
             PaintServer::Solid(css::Color(css::RGBA::RGB(0, 0, 255))));
 
   first->setClassName("");
@@ -756,7 +756,7 @@ TEST_F(SVGElementTests, NonLocalSelectorMutationRequestsFullStyleRecompute) {
       second->entityHandle().try_get<components::ComputedStyleComponent>();
   ASSERT_NE(updatedComputed, nullptr);
   ASSERT_TRUE(updatedComputed->properties.has_value());
-  EXPECT_EQ(updatedComputed->properties->fill.getRequired(),
+  EXPECT_EQ(updatedComputed->properties->fill.get().value(),
             PaintServer::Solid(css::Color(css::RGBA::RGB(0, 0, 0))));
 }
 

--- a/donner/svg/tests/SVGInvalidation_tests.cc
+++ b/donner/svg/tests/SVGInvalidation_tests.cc
@@ -508,7 +508,7 @@ TEST_F(SVGInvalidationTests, SourceEditPathDataUpdatesGeometryAttribute) {
 
   const auto* path = target->entityHandle().try_get<components::PathComponent>();
   ASSERT_NE(path, nullptr);
-  EXPECT_EQ(path->d.getRequired(), RcString(updatedPath));
+  EXPECT_EQ(path->d.get().value(), RcString(updatedPath));
   EXPECT_NE(doc.source().find(R"(d="M 1 2 L 3 4")"), std::string_view::npos);
   EXPECT_TRUE(hasDirtyFlags(*target, DirtyFlagsComponent::Style));
   EXPECT_TRUE(hasDirtyFlags(*target, DirtyFlagsComponent::Shape));
@@ -533,7 +533,7 @@ TEST_F(SVGInvalidationTests, SourceEditElementSubtreeAttributeRemovalClearsPathP
   ASSERT_TRUE(target.has_value());
   const auto* path = target->entityHandle().try_get<components::PathComponent>();
   ASSERT_NE(path, nullptr);
-  EXPECT_EQ(path->d.getRequired(), RcString("M 0 0 L 10 10"));
+  EXPECT_EQ(path->d.get().value(), RcString("M 0 0 L 10 10"));
 
   xml::ApplySourceEditResult result = doc.applySourceEdit(xml::XMLEditIntent{
       .range = {FileOffset::Offset(pathOffset), FileOffset::Offset(pathEnd + 2)},
@@ -554,7 +554,7 @@ TEST_F(SVGInvalidationTests, SourceEditElementSubtreeAttributeRemovalClearsPathP
   EXPECT_TRUE(sawPathDataRemoved);
 
   EXPECT_FALSE(target->getAttribute("d").has_value());
-  EXPECT_TRUE(path->d.getRequired().empty());
+  EXPECT_TRUE(path->d.get().value().empty());
   EXPECT_EQ(doc.source().find(R"(d="M 0 0 L 10 10")"), std::string_view::npos);
   EXPECT_TRUE(hasDirtyFlags(*target, DirtyFlagsComponent::Shape));
 }

--- a/donner/svg/text/TextEngine.cc
+++ b/donner/svg/text/TextEngine.cc
@@ -196,8 +196,8 @@ TextLayoutParams buildTextLayoutParams(Registry& registry, EntityHandle handle,
   TextLayoutParams params;
   const auto& properties = style.properties.value();
 
-  params.fontFamilies = properties.fontFamily.getRequired();
-  params.fontSize = properties.fontSize.getRequired();
+  params.fontFamilies = properties.fontFamily.get().value();
+  params.fontSize = properties.fontSize.get().value();
   params.viewBox = components::LayoutSystem().getViewBox(handle);
 
   const FontMetrics baseFontMetrics = FontMetrics::DefaultsWithFontSize(12.0);
@@ -205,12 +205,12 @@ TextLayoutParams buildTextLayoutParams(Registry& registry, EntityHandle handle,
       params.fontSize.toPixels(params.viewBox, baseFontMetrics, Lengthd::Extent::Mixed);
   params.fontMetrics = FontMetrics::DefaultsWithFontSize(fontSizePx);
 
-  params.textAnchor = properties.textAnchor.getRequired();
-  params.dominantBaseline = properties.dominantBaseline.getRequired();
-  params.writingMode = properties.writingMode.getRequired();
-  params.letterSpacingPx = properties.letterSpacing.getRequired().toPixels(
+  params.textAnchor = properties.textAnchor.get().value();
+  params.dominantBaseline = properties.dominantBaseline.get().value();
+  params.writingMode = properties.writingMode.get().value();
+  params.letterSpacingPx = properties.letterSpacing.get().value().toPixels(
       params.viewBox, params.fontMetrics, Lengthd::Extent::X);
-  params.wordSpacingPx = properties.wordSpacing.getRequired().toPixels(
+  params.wordSpacingPx = properties.wordSpacing.get().value().toPixels(
       params.viewBox, params.fontMetrics, Lengthd::Extent::X);
   params.textLength = textComp.textLength;
   params.lengthAdjust = textComp.lengthAdjust;
@@ -242,20 +242,20 @@ void ResolvePerSpanLayoutStyles(Registry& registry, components::ComputedTextComp
       continue;
     }
 
-    span.textAnchor = style->properties->textAnchor.getRequired();
-    span.textDecoration = style->properties->textDecoration.getRequired();
-    span.baselineShift = style->properties->baselineShift.getRequired();
-    span.alignmentBaseline = style->properties->alignmentBaseline.getRequired();
-    span.fontWeight = style->properties->fontWeight.getRequired();
-    span.fontStyle = style->properties->fontStyle.getRequired();
-    span.fontStretch = static_cast<FontStretch>(style->properties->fontStretch.getRequired());
-    span.fontVariant = style->properties->fontVariant.getRequired();
-    span.fontSize = style->properties->fontSize.getRequired();
-    span.visibility = style->properties->visibility.getRequired();
-    span.opacity = style->properties->opacity.getRequired();
-    span.letterSpacingPx = style->properties->letterSpacing.getRequired().toPixels(
+    span.textAnchor = style->properties->textAnchor.get().value();
+    span.textDecoration = style->properties->textDecoration.get().value();
+    span.baselineShift = style->properties->baselineShift.get().value();
+    span.alignmentBaseline = style->properties->alignmentBaseline.get().value();
+    span.fontWeight = style->properties->fontWeight.get().value();
+    span.fontStyle = style->properties->fontStyle.get().value();
+    span.fontStretch = static_cast<FontStretch>(style->properties->fontStretch.get().value());
+    span.fontVariant = style->properties->fontVariant.get().value();
+    span.fontSize = style->properties->fontSize.get().value();
+    span.visibility = style->properties->visibility.get().value();
+    span.opacity = style->properties->opacity.get().value();
+    span.letterSpacingPx = style->properties->letterSpacing.get().value().toPixels(
         viewBox, fontMetrics, Lengthd::Extent::X);
-    span.wordSpacingPx = style->properties->wordSpacing.getRequired().toPixels(viewBox, fontMetrics,
+    span.wordSpacingPx = style->properties->wordSpacing.get().value().toPixels(viewBox, fontMetrics,
                                                                                Lengthd::Extent::X);
 
     const bool isTextRoot = registry.any_of<components::TextRootComponent>(styleEntity);
@@ -286,9 +286,9 @@ void ResolvePerSpanLayoutStyles(Registry& registry, components::ComputedTextComp
           continue;
         }
 
-        const Lengthd ancestorShift = ancestorStyle->properties->baselineShift.getRequired();
+        const Lengthd ancestorShift = ancestorStyle->properties->baselineShift.get().value();
         const double ancestorFontSizePx =
-            ancestorStyle->properties->fontSize.getRequired().toPixels(viewBox, fontMetrics,
+            ancestorStyle->properties->fontSize.get().value().toPixels(viewBox, fontMetrics,
                                                                        Lengthd::Extent::Mixed);
         BSK ancestorKeyword = BSK::Length;
         if (ancestorShift.unit == Lengthd::Unit::Em && ancestorShift.value == -0.33) {


### PR DESCRIPTION
`Property::hasValue()` returned `state != NotSet` — true for `inherit`/`initial`/`unset` — while `get()`/`getRequired()` resolve to a value only when `Set` (or an initial exists). The `hasValue()`-then-`getRequired()` idiom therefore **aborted** ("Required property not set") whenever a property was specified as a CSS-wide keyword with no resolved value — e.g. a root `<svg width="inherit">` crashing document-size computation (found by `editor_state_machine_fuzzer`). The name `hasValue()` actively invited the bug.

### New access pattern on `Property<T>`
| method | returns | notes |
|---|---|---|
| `get()` | `std::optional<T>` | unchanged; the resolving reader |
| `getOr(fallback)` | `T` | **new**; resolved value or fallback, never aborts |
| `getStoredValue()` | `const T*` | **new**; no-copy access to the *stored* value, or null |
| `isSpecified()` | `bool` | **renamed** from `hasValue()`; cascade predicate only |
| `getRequired()` / `getRequiredRef()` | — | **removed** |

Migrated all ~363 call sites: `getRequired()` → `get().value()` (explicit assert) or `getOr()` where a default fits; `getRequiredRef()` → `*getStoredValue()`; `hasValue()` → `isSpecified()`. Two `const&` bindings of `getRequired()` were changed to value / `getStoredValue()` so a reference isn't bound to `get()`'s temporary.

`LayoutSystem::IsAbsolute` — the crash the rename made glaringly obvious — now guards on the resolved value. Regression test `LayoutSystemTest.RootSizeCssWideKeywordDoesNotCrash` aborts at the parent commit and passes here.

Full `bazel test //...` green (verified on Mesa lavapipe locally).