### PR TITLE
fix: force software GL for offscreen replay so gl_rnr_replay is host-independent

### DIFF
--- a/donner/editor/gui/EditorWindow.cc
+++ b/donner/editor/gui/EditorWindow.cc
@@ -450,6 +450,15 @@ EditorWindow::EditorWindow(EditorWindowOptions options) : options_(std::move(opt
   useNullPlatform = useNullPlatform || !hasDisplay;
   if (useNullPlatform) {
     glfwInitHint(GLFW_PLATFORM, GLFW_PLATFORM_NULL);
+    // Force Mesa's software renderer (llvmpipe) for offscreen/headless replay.
+    // The null-platform path uses an EGL surfaceless context, which otherwise
+    // binds the host GPU when one is present (e.g. an Intel Arc dev box). That
+    // driver renders replay frames differently from CI's GPU-less software
+    // path, making golden/content checks host-dependent (gl_rnr_replay passed
+    // on CI but failed on Arc). CI already lands on llvmpipe because it has no
+    // GPU; set it explicitly so every host matches. overwrite=0 honors an
+    // operator who deliberately pre-set it.
+    setenv("LIBGL_ALWAYS_SOFTWARE", "1", /*overwrite=*/0);
   }
 #endif
 #endif


### PR DESCRIPTION
`EditorWindow`'s offscreen/headless path (GLFW null platform + EGL surfaceless) is documented to render on software GL "even when a display is available", which is why `gl_rnr_replay`'s frames are reproducible against CI's GPU-less captures. But EGL surfaceless actually binds the **host GPU** when one is present: on an Intel Arc A380 dev box (Mesa Xe-KMD, experimental) the replay rendered differently than CI, so `ReplaysSourcePaneCharacterInput` (0 bright-green px) and `FilteredElementOThenRDragDoesNotPopOBackOnRClick` (no centroid) failed locally while passing on CI. The #601 determinism diffs still matched (0px) — it was the host GPU's pixels, not non-determinism.

Fix: force Mesa's software renderer for the null-platform path via `setenv("LIBGL_ALWAYS_SOFTWARE", "1", /*overwrite=*/0)` before `glfwInit()`. CI is unchanged (no GPU → already llvmpipe); GPU dev boxes now match it. `overwrite=0` honors an operator who pre-set the variable. The interactive editor (visible window with a display) keeps its real GPU context — only the offscreen/headless replay surface is affected.

Verified: `//donner/editor/tests:gl_rnr_replay_tests` passes on this Arc box with **no env overrides** (previously 2/8 failed); still passes on CI. Independent of #628/#629.