### PR TITLE
build report: doxygen link, test-results table, failed-image harvest (#147)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,8 +5,9 @@
 ##
 ##   --config=latest_llvm       - Build with LLVM toolchain (downloads automatically)
 ##   --config=debug             - Build debug with configs set to simplify debugging.
-##   --config=binary-size       - Build optimized build and symbols for binary size analysis.
-##   --config=macos-binary-size - Same as above but with additional flags for macOS.
+##   --config=binary-size       - Common optimized build and symbols for binary size analysis.
+##   --config=linux-binary-size - Binary size analysis with Linux linker size flags.
+##   --config=macos-binary-size - Binary size analysis with macOS linker size flags.
 ##   --config=coverage          - Build with code coverage instrumentation.
 ##   --config=asan              - Build with address sanitizer.
 ##   --config=ubsan             - Build with undefined behavior sanitizer.
@@ -149,6 +150,9 @@ build:linux --config=host_libstdc++ --copt=-fno-modules
 
 # Fixes symbols when debugging on mac.
 build:macos --features=oso_prefix_is_pwd
+# Donner uses C++20 libc++ APIs gated by Apple SDK availability, including
+# std::filesystem and std::format floating-point formatting.
+build:macos --macos_minimum_os=13.3
 
 # apple_support's clang wrapper expects these Xcode paths. The local Darwin
 # sandbox sets them implicitly; remote execution does not.
@@ -171,18 +175,20 @@ build:macos-binary-size --config=binary-size
 build:macos-binary-size --linkopt=-exported_symbols_list --linkopt=/dev/null
 build:macos-binary-size --copt=-gline-tables-only
 build:macos-binary-size --linkopt=-dead_strip
-build:macos-binary-size --copt=-flto=thin --linkopt=-flto=thin
 
 build --config=libc++ --config=c++20
 
 # Debug builds
 build:debug -c dbg --copt=-O0 --copt=-g --copt=-fdebug-compilation-dir=. --linkopt=-g --strip=never --apple_generate_dsym --spawn_strategy=standalone
 
-# Binary-size builds: optimized for size with LTO and dead-code elimination.
+# Binary-size builds: optimized for size while preserving debug attribution.
 build:binary-size -c opt --copt=-Os --copt=-g --strip=never
-build:binary-size --copt=-flto=thin --linkopt=-flto=thin
 build:binary-size --copt=-ffunction-sections --copt=-fdata-sections
-build:binary-size --linkopt=-Wl,--gc-sections
+# Keep LTO off for size reports: bloaty's compile-unit attribution depends on
+# debug info that ThinLTO leaves pointing at transient .thinlto.o files.
+
+build:linux-binary-size --config=binary-size
+build:linux-binary-size --linkopt=-Wl,--gc-sections
 
 test --test_env=LLM
 test --test_env=DONNER_RENDERER_TEST_VERBOSE
@@ -196,15 +202,19 @@ coverage --test_tag_filters=-fuzz_target,-lint
 # that can run.
 coverage --keep_going
 
-coverage:macos --test_env=COVERAGE_GCOV_PATH=/Library/Developer/CommandLineTools/usr/bin/llvm-profdata
 coverage:macos --test_env=LLVM_COV=/Library/Developer/CommandLineTools/usr/bin/llvm-cov
+coverage:macos --test_env=LLVM_PROFDATA=/Library/Developer/CommandLineTools/usr/bin/llvm-profdata
 
 build:coverage --cxxopt=-DNDEBUG
 build:coverage --experimental_generate_llvm_lcov
+build:coverage --features=llvm_coverage_map_format
 build:coverage --copt=-ffile-compilation-dir=.
 build:coverage --action_env=BAZEL_USE_LLVM_NATIVE_COVERAGE=1
+# Bazel's test runner copies GCOV into COVERAGE_GCOV_PATH. For LLVM lcov
+# collection that path is used as llvm-profdata to merge profraw files.
 build:coverage --action_env=GCOV=llvm-profdata
 build:coverage --action_env=BAZEL_LLVM_COV=llvm-cov
+build:coverage --action_env=BAZEL_LLVM_PROFDATA=llvm-profdata
 
 test:coverage --collect_code_coverage
 test:coverage --nocache_test_results

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,6 +17,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.workflow, github.event.pull_request.number) || format('push-{0}-{1}', github.workflow, github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 #
 # Self-hosted coverage uses the same operator-only gate as CI's Linux lane:
@@ -28,8 +32,214 @@ permissions:
 # EXCEPTION: pushes to main always stay GitHub-hosted, matching main.yml; PRs
 # still route to the self-hosted lane.
 jobs:
+  determine-targets:
+    runs-on: ubuntu-24.04
+    env:
+      BAZEL_DIFF_TAG: "v18.1.0"
+      FULL_COVERAGE_TARGETS: "//donner/base/... //donner/css/... //donner/svg/... //donner/editor/..."
+      SMOKE_COVERAGE_TARGETS: "//donner/base/..."
+    outputs:
+      fallback: ${{ steps.determine.outputs.fallback }}
+      fallback_reason: ${{ steps.determine.outputs.fallback_reason }}
+      targets: ${{ steps.determine.outputs.targets }}
+      target_count: ${{ steps.determine.outputs.target_count }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          bazelisk-cache: true
+          repository-cache: true
+          external-cache: true
+          cache-save: false
+
+      - name: Download bazel-diff
+        if: github.event_name == 'pull_request'
+        run: curl -fsSL -o "$RUNNER_TEMP/bazel-diff.jar" "https://github.com/Tinder/bazel-diff/releases/download/${BAZEL_DIFF_TAG}/bazel-diff_deploy.jar"
+
+      - id: determine
+        name: Determine coverage targets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          diagnostics_dir="$RUNNER_TEMP/coverage-target-selection"
+          mkdir -p "$diagnostics_dir"
+
+          emit_targets() {
+            local fallback="$1"
+            local reason="$2"
+            local targets="$3"
+            local count
+            count="$(wc -w <<< "$targets" | tr -d ' ')"
+
+            {
+              echo "fallback=$fallback"
+              echo "fallback_reason=$reason"
+              echo "targets=$targets"
+              echo "target_count=$count"
+            } >> "$GITHUB_OUTPUT"
+
+            {
+              echo "fallback=$fallback"
+              echo "fallback_reason=$reason"
+              echo "target_count=$count"
+              echo
+              echo "$targets" | tr ' ' '\n'
+            } > "$diagnostics_dir/summary.txt"
+          }
+
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "Non-PR event; using full coverage target set."
+            emit_targets true non_pr "$FULL_COVERAGE_TARGETS"
+            exit 0
+          fi
+
+          eval "$(
+            python3 -c 'import json, os, shlex; event = json.load(open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8")); pr = event.get("pull_request", {}); labels = [label.get("name", "") for label in pr.get("labels", [])]; values = {"BASE_SHA": pr.get("base", {}).get("sha", ""), "HEAD_SHA": pr.get("head", {}).get("sha", ""), "FORCE_FULL_TEST": "true" if "ci:full-test" in labels else "false"}; print("\n".join(f"{key}={shlex.quote(value)}" for key, value in values.items()))'
+          )"
+
+          if [[ -z "$BASE_SHA" || -z "$HEAD_SHA" ]]; then
+            echo "Missing PR base/head SHA; using full coverage target set."
+            emit_targets true missing_pr_sha "$FULL_COVERAGE_TARGETS"
+            exit 0
+          fi
+
+          if [[ "$FORCE_FULL_TEST" == "true" ]]; then
+            echo "ci:full-test label present; using full coverage target set."
+            emit_targets true full_test_label "$FULL_COVERAGE_TARGETS"
+            exit 0
+          fi
+
+          changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+          printf "%s\n" "$changed_files" > "$diagnostics_dir/changed-files.txt"
+
+          if [[ -z "$changed_files" ]]; then
+            echo "No changed files detected; using full coverage target set."
+            emit_targets true no_changed_files "$FULL_COVERAGE_TARGETS"
+            exit 0
+          fi
+
+          should_fallback=false
+          fallback_reason=""
+          smoke_only=true
+          while IFS= read -r path; do
+            [[ -z "$path" ]] && continue
+            case "$path" in
+              MODULE.bazel|WORKSPACE|WORKSPACE.*|build_defs/*|third_party/bazel/*)
+                echo "Build graph infrastructure change requires full coverage: $path"
+                should_fallback=true
+                fallback_reason="infra_change"
+                break
+                ;;
+            esac
+
+            case "$path" in
+              .bazelrc|.github/workflows/*|.github/actions/*|docs/*|*.md|tools/binary_size.sh|tools/build_docs.sh|tools/coverage.sh|tools/filter_coverage.py|tools/generate_build_report.py|tools/generate_build_report_tests.py)
+                ;;
+              *)
+                smoke_only=false
+                ;;
+            esac
+          done <<< "$changed_files"
+
+          if [[ "$should_fallback" == "true" ]]; then
+            emit_targets true "$fallback_reason" "$FULL_COVERAGE_TARGETS"
+            exit 0
+          fi
+
+          if [[ "$smoke_only" == "true" ]]; then
+            echo "Coverage/reporting/tooling-only change; using smoke coverage target set."
+            emit_targets true coverage_smoke "$SMOKE_COVERAGE_TARGETS"
+            exit 0
+          fi
+
+          work_dir="$(mktemp -d)"
+          base_dir="$work_dir/base"
+          head_dir="$work_dir/head"
+          cleanup() {
+            git worktree remove --force "$base_dir" 2>/dev/null || true
+            git worktree remove --force "$head_dir" 2>/dev/null || true
+            rm -rf "$work_dir"
+          }
+          trap cleanup EXIT
+
+          if ! git worktree add --detach "$base_dir" "$BASE_SHA"; then
+            echo "Failed to check out PR base; using full coverage target set."
+            emit_targets true base_checkout_failed "$FULL_COVERAGE_TARGETS"
+            exit 0
+          fi
+          if ! git worktree add --detach "$head_dir" "$HEAD_SHA"; then
+            echo "Failed to check out PR head; using full coverage target set."
+            emit_targets true head_checkout_failed "$FULL_COVERAGE_TARGETS"
+            exit 0
+          fi
+
+          if ! java -jar "$RUNNER_TEMP/bazel-diff.jar" generate-hashes \
+            -w "$base_dir" \
+            -b bazelisk \
+            "$work_dir/base-hashes.json"; then
+            echo "bazel-diff failed while hashing base; using full coverage target set."
+            emit_targets true base_hash_failed "$FULL_COVERAGE_TARGETS"
+            exit 0
+          fi
+
+          if ! java -jar "$RUNNER_TEMP/bazel-diff.jar" generate-hashes \
+            -w "$head_dir" \
+            -b bazelisk \
+            "$work_dir/head-hashes.json"; then
+            echo "bazel-diff failed while hashing head; using full coverage target set."
+            emit_targets true head_hash_failed "$FULL_COVERAGE_TARGETS"
+            exit 0
+          fi
+
+          if ! java -jar "$RUNNER_TEMP/bazel-diff.jar" get-impacted-targets \
+            -w "$head_dir" \
+            -b bazelisk \
+            -sh "$work_dir/base-hashes.json" \
+            -fh "$work_dir/head-hashes.json" \
+            -o "$work_dir/affected.txt"; then
+            echo "bazel-diff failed while determining impacted targets; using full coverage target set."
+            emit_targets true impacted_targets_failed "$FULL_COVERAGE_TARGETS"
+            exit 0
+          fi
+
+          cp "$work_dir/affected.txt" "$diagnostics_dir/affected-targets.txt"
+
+          affected="$(
+            python3 -c 'import pathlib, sys; labels = [line.strip() for line in pathlib.Path(sys.argv[1]).read_text(encoding="utf-8").splitlines() if line.strip()]; print(" ".join(labels))' "$work_dir/affected.txt"
+          )"
+
+          if [[ -z "$affected" ]]; then
+            echo "bazel-diff produced no affected targets; using full coverage target set."
+            emit_targets true no_affected_targets "$FULL_COVERAGE_TARGETS"
+            exit 0
+          fi
+
+          emit_targets false bazel_diff "$affected"
+
+      - name: Upload target selection artifact
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: coverage-target-selection-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/coverage-target-selection
+          if-no-files-found: ignore
+          retention-days: 3
+
   build:
     runs-on: ubuntu-24.04
+    needs: determine-targets
     if: ${{ github.ref == 'refs/heads/main' || vars.SELFHOSTED_LINUX_RUNNER != 'true' || github.actor != 'jwmcglynn' || github.triggering_actor != 'jwmcglynn' }}
 
     steps:
@@ -59,12 +269,14 @@ jobs:
             libgl1-mesa-dev libosmesa6-dev
 
       - name: Generate coverage
+        shell: bash
         run: |
-          tools/coverage.sh --no-html \
-            //donner/base/... \
-            //donner/css/... \
-            //donner/svg/... \
-            //donner/editor/...
+          set -euo pipefail
+          read -r -a TARGETS <<< "${{ needs.determine-targets.outputs.targets }}"
+          echo "Coverage target selection: fallback=${{ needs.determine-targets.outputs.fallback }} reason=${{ needs.determine-targets.outputs.fallback_reason }} count=${{ needs.determine-targets.outputs.target_count }}"
+          printf "Coverage targets:\n"
+          printf "  %s\n" "${TARGETS[@]}"
+          tools/coverage.sh --no-html "${TARGETS[@]}"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
@@ -77,6 +289,7 @@ jobs:
 
   coverage-self-hosted:
     runs-on: [self-hosted, linux, arm64]
+    needs: determine-targets
     if: ${{ github.ref != 'refs/heads/main' && vars.SELFHOSTED_LINUX_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
     env:
       # The runner host may add the LAN Bazel cache from its home rc. Keep
@@ -106,12 +319,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          TARGETS=(
-            //donner/base/...
-            //donner/css/...
-            //donner/svg/...
-            //donner/editor/...
-          )
+          read -r -a TARGETS <<< "${{ needs.determine-targets.outputs.targets }}"
+          echo "Coverage target selection: fallback=${{ needs.determine-targets.outputs.fallback }} reason=${{ needs.determine-targets.outputs.fallback_reason }} count=${{ needs.determine-targets.outputs.target_count }}"
+          printf "Coverage targets:\n"
+          printf "  %s\n" "${TARGETS[@]}"
 
           fetch_llvm() {
             bazelisk fetch --config=ci --config=latest_llvm "${TARGETS[@]}"
@@ -142,12 +353,12 @@ jobs:
           bazelisk shutdown
 
       - name: Generate coverage
+        shell: bash
         run: |
-          tools/coverage.sh --no-html \
-            //donner/base/... \
-            //donner/css/... \
-            //donner/svg/... \
-            //donner/editor/...
+          set -euo pipefail
+          read -r -a TARGETS <<< "${{ needs.determine-targets.outputs.targets }}"
+          echo "Coverage target selection: fallback=${{ needs.determine-targets.outputs.fallback }} reason=${{ needs.determine-targets.outputs.fallback_reason }} count=${{ needs.determine-targets.outputs.target_count }}"
+          tools/coverage.sh --no-html "${TARGETS[@]}"
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v6

--- a/tools/binary_size.sh
+++ b/tools/binary_size.sh
@@ -6,28 +6,45 @@ mkdir -p build-binary-size
 
 # If verbose is set, show all output
 if [[ "$1" == "--verbose" ]]; then
-  BAZEL_QUIET_OPTIONS=""
+  BAZEL_QUIET_OPTIONS=()
   set -ex
 else
   # Bazel options used:
   # --incompatible_strict_action_env disables the warning when the analysis cache is discarded (when changing options such as compilation mode)
   # --ui_event_filters=-info,-stdout,-stderr --noshow_progress hides all compile output
-  BAZEL_QUIET_OPTIONS="--ui_event_filters=-info,-warning,-stdout,-stderr --noshow_progress"
+  BAZEL_QUIET_OPTIONS=(--ui_event_filters=-info,-warning,-stdout,-stderr --noshow_progress)
 fi
 
-BAZEL_CONFIGS="--config=binary-size"
+BAZEL_LOCAL_OPTIONS=(
+  --remote_executor=
+  --remote_cache=
+  --noremote_upload_local_results
+)
+BLOATY_BIN="$(command -v bloaty || true)"
 
-# If we're macos also specify the macos-binary-size config
+BAZEL_CONFIGS=(--config=binary-size)
+
 if [[ "$(uname)" == "Darwin" ]]; then
-  BAZEL_CONFIGS="$BAZEL_CONFIGS --config=macos-binary-size"
+  BAZEL_CONFIGS=(--config=macos-binary-size)
+elif [[ "$(uname)" == "Linux" ]]; then
+  BAZEL_CONFIGS=(--config=linux-binary-size)
 fi
+
+function run_bloaty() {
+  if [[ -n "$BLOATY_BIN" ]]; then
+    "$BLOATY_BIN" "$@"
+  else
+    bazel run -c opt "${BAZEL_QUIET_OPTIONS[@]}" "${BAZEL_LOCAL_OPTIONS[@]}" \
+      --run_under="cd $PWD &&" @bloaty//:bloaty -- "$@"
+  fi
+}
 
 # Build the binaries to analyze. Always measure the stripped outputs, and keep an
 # unstripped parser binary around separately so bloaty can attribute sizes using symbols.
-bazel build $BAZEL_QUIET_OPTIONS $BAZEL_CONFIGS //donner/svg/parser:svg_parser_tool.stripped
+bazel build "${BAZEL_QUIET_OPTIONS[@]}" "${BAZEL_LOCAL_OPTIONS[@]}" "${BAZEL_CONFIGS[@]}" //donner/svg/parser:svg_parser_tool.stripped
 cp -f bazel-bin/donner/svg/parser/svg_parser_tool.stripped build-binary-size/svg_parser_tool
 
-bazel build $BAZEL_QUIET_OPTIONS $BAZEL_CONFIGS //donner/svg/tool:donner-svg.stripped
+bazel build "${BAZEL_QUIET_OPTIONS[@]}" "${BAZEL_LOCAL_OPTIONS[@]}" "${BAZEL_CONFIGS[@]}" //donner/svg/tool:donner-svg.stripped
 cp -f bazel-bin/donner/svg/tool/donner-svg.stripped build-binary-size/donner-svg
 
 # Print human-readable binary size of svg_parser_tool.stripped and donner-svg.stripped
@@ -45,14 +62,15 @@ echo ""
 
 # On macOS run dsymutil to generate debug symbols. On Linux point bloaty at the
 # unstripped Bazel output as the debug file while measuring the stripped binary.
-DEBUG_FILE_ARG=
+DEBUG_FILE_ARG=()
 if [[ "$(uname)" == "Darwin" ]]; then
   cp -f bazel-bin/donner/svg/parser/svg_parser_tool build-binary-size/svg_parser_tool.debug
+  rm -rf build-binary-size/svg_parser_tool.debug.dSYM
   dsymutil build-binary-size/svg_parser_tool.debug
-  DEBUG_FILE_ARG="--debug-file=build-binary-size/svg_parser_tool.debug.dSYM/Contents/Resources/DWARF/svg_parser_tool.debug"
+  DEBUG_FILE_ARG=(--debug-file=build-binary-size/svg_parser_tool.debug.dSYM/Contents/Resources/DWARF/svg_parser_tool.debug)
 elif [[ "$(uname)" == "Linux" ]]; then
   cp -f bazel-bin/donner/svg/parser/svg_parser_tool build-binary-size/svg_parser_tool.debug
-  DEBUG_FILE_ARG="--debug-file=build-binary-size/svg_parser_tool.debug"
+  DEBUG_FILE_ARG=(--debug-file=build-binary-size/svg_parser_tool.debug)
 else
   echo "Unknown OS: $(uname)" >&2
   exit 1
@@ -63,13 +81,13 @@ fi
 # To see symbols only: -d donner_package,symbol
 
 # Output an <svg> with a bar chart of the binary size by directory
-bazel run -c opt $BAZEL_QUIET_OPTIONS --run_under="cd $PWD &&" @bloaty//:bloaty -- -c tools/binary_size_config.bloaty -d donner_package,compileunits -n 2000 --csv $DEBUG_FILE_ARG build-binary-size/svg_parser_tool > build-binary-size/svg_parser_tool.bloaty_compileunits.csv
+run_bloaty -c tools/binary_size_config.bloaty -d donner_package,compileunits -n 2000 --csv "${DEBUG_FILE_ARG[@]}" build-binary-size/svg_parser_tool > build-binary-size/svg_parser_tool.bloaty_compileunits.csv
 python3 tools/python/generate_size_barchart_svg.py build-binary-size/svg_parser_tool.bloaty_compileunits.csv > build-binary-size/binary_size_bargraph.svg
 
 echo ""
 
 # Create the binary_size_report webtreemap
-bazel run -c opt $BAZEL_QUIET_OPTIONS --run_under="cd $PWD &&" @bloaty//:bloaty -- -c tools/binary_size_config.bloaty -d donner_package,compileunits,symbols -n 2000 --csv $DEBUG_FILE_ARG build-binary-size/svg_parser_tool > build-binary-size/svg_parser_tool.bloaty.csv
+run_bloaty -c tools/binary_size_config.bloaty -d donner_package,compileunits,symbols -n 2000 --csv "${DEBUG_FILE_ARG[@]}" build-binary-size/svg_parser_tool > build-binary-size/svg_parser_tool.bloaty.csv
 python3 tools/binary_size_analysis.py build-binary-size/svg_parser_tool.bloaty.csv build-binary-size/binary_size_report.html
 
 # Output summary
@@ -77,6 +95,6 @@ echo ""
 echo '`bloaty -d compileunits -n 20` output'
 echo '```'
 
-bazel run -c opt $BAZEL_QUIET_OPTIONS --run_under="cd $PWD &&" @bloaty//:bloaty -- -c tools/binary_size_config.bloaty -d donner_package,compileunits -n 20 $DEBUG_FILE_ARG build-binary-size/svg_parser_tool
+run_bloaty -c tools/binary_size_config.bloaty -d donner_package,compileunits -n 20 "${DEBUG_FILE_ARG[@]}" build-binary-size/svg_parser_tool
 
 echo '```'

--- a/tools/build_docs.sh
+++ b/tools/build_docs.sh
@@ -40,6 +40,16 @@ else
   echo "Note: $REPORTS_SRC/binary-size/ not present; skipping." >&2
 fi
 
+# Test failures: SVG-vs-golden PNGs harvested from failed image-comparison
+# tests (only present when a test failed at report-generation time). Copy the
+# tree verbatim so the embedded ![diff](reports/test-failures/...) links in
+# build_report.md resolve on the deployed docs site.
+if [ -d "$REPORTS_SRC/test-failures" ]; then
+  rm -rf "$REPORTS_DST/test-failures"
+  cp -R "$REPORTS_SRC/test-failures" "$REPORTS_DST/test-failures"
+  echo "Copied $REPORTS_SRC/test-failures/ → $REPORTS_DST/test-failures/"
+fi
+
 # Coverage: shipped as a zip (otherwise the lcov tree is ~hundreds of small
 # files that bloat the repo and make fuzzy file-name search noisy). Extract
 # into the output tree so reports/coverage/index.html is reachable on the

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -14,14 +14,17 @@ function print_help() {
 
 TARGETS=()
 BAZEL_COVERAGE_FLAGS=()
-DEFAULT_BAZEL_COVERAGE_FLAGS=(
-  --remote_executor=
-  --remote_cache=
-  --noremote_upload_local_results
-)
+DEFAULT_BAZEL_COVERAGE_FLAGS=()
 
 if [[ -n "${DONNER_COVERAGE_BAZEL_FLAGS:-}" ]]; then
   read -r -a BAZEL_COVERAGE_FLAGS <<< "$DONNER_COVERAGE_BAZEL_FLAGS"
+else
+  DEFAULT_BAZEL_COVERAGE_FLAGS=(
+    --remote_executor=
+    --remote_cache=
+    --experimental_remote_downloader=
+    --noremote_upload_local_results
+  )
 fi
 
 # Check for --quiet option

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -12,24 +12,13 @@ function print_help() {
   exit 0
 }
 
-function file_mtime() {
-  local file="$1"
-
-  if stat -c %Y "$file" >/dev/null 2>&1; then
-    stat -c %Y "$file"
-    return
-  fi
-
-  if stat -f %m "$file" >/dev/null 2>&1; then
-    stat -f %m "$file"
-    return
-  fi
-
-  echo 0
-}
-
 TARGETS=()
 BAZEL_COVERAGE_FLAGS=()
+DEFAULT_BAZEL_COVERAGE_FLAGS=(
+  --remote_executor=
+  --remote_cache=
+  --noremote_upload_local_results
+)
 
 if [[ -n "${DONNER_COVERAGE_BAZEL_FLAGS:-}" ]]; then
   read -r -a BAZEL_COVERAGE_FLAGS <<< "$DONNER_COVERAGE_BAZEL_FLAGS"
@@ -58,14 +47,6 @@ fi
 
 echo "Analyzing coverage for: ${TARGETS[*]}"
 
-function file_mtime() {
-  if [[ "$(uname)" == "Darwin" ]]; then
-    stat -f %m "$1"
-  else
-    stat -c %Y "$1"
-  fi
-}
-
 # Error if genhtml is not found (only required when HTML output is enabled).
 if [ "$NO_HTML" = false ] && ! which genhtml > /dev/null; then
     echo "ERROR: genhtml not found, please install lcov"
@@ -81,10 +62,11 @@ if ! which java > /dev/null; then
 fi
 
 JAVA_HOME=$(dirname $(dirname $(which java)))
+WORKSPACE_ROOT=$(bazel info workspace)
 
-BAZEL_TEST_ENV=""
+BAZEL_TEST_ENV=()
 if [[ "$(uname)" == "Darwin" ]]; then
-  BAZEL_TEST_ENV="--test_env=DYLD_LIBRARY_PATH=$(bazel info workspace)"
+  BAZEL_TEST_ENV=(--test_env=DYLD_LIBRARY_PATH="$WORKSPACE_ROOT")
 fi
 
 LLVM_COV_PATH=""
@@ -104,31 +86,42 @@ if [[ -z "$LLVM_PROFDATA_PATH" || ! -x "$LLVM_PROFDATA_PATH" ]]; then
   exit 1
 fi
 
-(
-  cd $(bazel info workspace)
+LLVM_COVERAGE_FLAGS=(
+  --features=llvm_coverage_map_format
+  # Bazel's test runner copies GCOV into COVERAGE_GCOV_PATH. For LLVM lcov
+  # collection that path is used as llvm-profdata to merge profraw files.
+  --action_env=GCOV="$LLVM_PROFDATA_PATH"
+  --action_env=BAZEL_LLVM_COV="$LLVM_COV_PATH"
+  --action_env=BAZEL_LLVM_PROFDATA="$LLVM_PROFDATA_PATH"
+  --test_env=LLVM_COV="$LLVM_COV_PATH"
+  --test_env=LLVM_PROFDATA="$LLVM_PROFDATA_PATH"
+)
 
-  GENHTML_OPTIONS="--legend --branch-coverage --ignore-errors category --ignore-errors inconsistent --output-directory coverage-report"
+(
+  cd "$WORKSPACE_ROOT"
+
+  COVERAGE_HTML_DIR=coverage-report
+  GENHTML_OPTIONS="--legend --branch-coverage --ignore-errors category --ignore-errors inconsistent --output-directory $COVERAGE_HTML_DIR"
 
   COVERAGE_REPORT=$(bazel info output_path)/_coverage/_coverage_report.dat
 
   # --keep_going is set in .bazelrc for coverage so that analysis failures
-  # don't block the rest of the run.  Record the timestamp before running so
-  # we can verify a fresh report was produced (avoid processing stale data on
-  # early exit).
-  BEFORE_TS=0
-  if [ -f "$COVERAGE_REPORT" ]; then
-    BEFORE_TS=$(file_mtime "$COVERAGE_REPORT")
-  fi
+  # don't block the rest of the run. Remove any previous combined report so
+  # early exits cannot accidentally process stale data.
+  rm -f "$COVERAGE_REPORT"
 
   if [ "$QUIET" = true ]; then
     bazel coverage --config=latest_llvm --ui_event_filters=-info,-stdout,-stderr --noshow_progress \
+      "${DEFAULT_BAZEL_COVERAGE_FLAGS[@]}" \
       "${BAZEL_COVERAGE_FLAGS[@]}" \
-      --action_env=BAZEL_LLVM_COV=$LLVM_COV_PATH --action_env=GCOV=$LLVM_PROFDATA_PATH \
-      $BAZEL_TEST_ENV "${TARGETS[@]}" || true
+      "${LLVM_COVERAGE_FLAGS[@]}" \
+      "${BAZEL_TEST_ENV[@]}" "${TARGETS[@]}" || true
   else
-    bazel coverage --config=latest_llvm "${BAZEL_COVERAGE_FLAGS[@]}" \
-      --action_env=BAZEL_LLVM_COV=$LLVM_COV_PATH \
-      --action_env=GCOV=$LLVM_PROFDATA_PATH $BAZEL_TEST_ENV "${TARGETS[@]}" || true
+    bazel coverage --config=latest_llvm \
+      "${DEFAULT_BAZEL_COVERAGE_FLAGS[@]}" \
+      "${BAZEL_COVERAGE_FLAGS[@]}" \
+      "${LLVM_COVERAGE_FLAGS[@]}" \
+      "${BAZEL_TEST_ENV[@]}" "${TARGETS[@]}" || true
   fi
 
   if [ ! -f "$COVERAGE_REPORT" ]; then
@@ -136,14 +129,9 @@ fi
     exit 1
   fi
 
-  AFTER_TS=$(file_mtime "$COVERAGE_REPORT")
-  if [ "$AFTER_TS" -le "$BEFORE_TS" ]; then
-    echo "ERROR: Coverage report was not updated (stale data from a previous run)"
-    exit 1
-  fi
-
-  mkdir -p coverage-report
-  FILTER_ARGS=(--input "$COVERAGE_REPORT" --output coverage-report/filtered_report.dat)
+  rm -rf "$COVERAGE_HTML_DIR"
+  mkdir -p "$COVERAGE_HTML_DIR"
+  FILTER_ARGS=(--input "$COVERAGE_REPORT" --output "$COVERAGE_HTML_DIR/filtered_report.dat")
 
   if [ "$QUIET" = true ]; then
     python3 tools/filter_coverage.py "${FILTER_ARGS[@]}"
@@ -153,9 +141,9 @@ fi
 
   if [ "$NO_HTML" = false ]; then
     if [ "$QUIET" = true ]; then
-      genhtml --quiet coverage-report/filtered_report.dat $GENHTML_OPTIONS
+      genhtml --quiet "$COVERAGE_HTML_DIR/filtered_report.dat" $GENHTML_OPTIONS
     else
-      genhtml coverage-report/filtered_report.dat $GENHTML_OPTIONS
+      genhtml "$COVERAGE_HTML_DIR/filtered_report.dat" $GENHTML_OPTIONS
     fi
   fi
 )

--- a/tools/generate_build_report.py
+++ b/tools/generate_build_report.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import platform
+import re
 import shlex
 import shutil
 import subprocess
@@ -48,6 +49,7 @@ class LinkTargets:
     coverage_index: str
     binary_size_report: str
     binary_size_bargraph: str
+    doxygen_index: str
 
 
 def _resolve_link_targets(link_mode: str) -> LinkTargets:
@@ -57,12 +59,16 @@ def _resolve_link_targets(link_mode: str) -> LinkTargets:
             coverage_index="coverage-report/index.html",
             binary_size_report="build-binary-size/binary_size_report.html",
             binary_size_bargraph="build-binary-size/binary_size_bargraph.svg",
+            # The local Doxygen output (built by `tools/build_docs.sh`) lands
+            # in generated-doxygen/html/ at the repo root.
+            doxygen_index="generated-doxygen/html/index.html",
         )
     if link_mode == LINK_MODE_SITE:
         return LinkTargets(
             coverage_index=f"{base}/reports/coverage/index.html",
             binary_size_report=f"{base}/reports/binary-size/binary_size_report.html",
             binary_size_bargraph=f"{base}/reports/binary-size/binary_size_bargraph.svg",
+            doxygen_index=f"{base}/index.html",
         )
     if link_mode == LINK_MODE_DOCS:
         # Coverage is shipped as a zip and only exists as a browsable tree
@@ -71,6 +77,9 @@ def _resolve_link_targets(link_mode: str) -> LinkTargets:
             coverage_index=f"{base}/reports/coverage/index.html",
             binary_size_report="reports/binary-size/binary_size_report.html",
             binary_size_bargraph="reports/binary-size/binary_size_bargraph.svg",
+            # The checked-in build_report.md is itself rendered by Doxygen, so
+            # the API docs root is one level up from this page on the site.
+            doxygen_index=f"{base}/index.html",
         )
     raise ValueError(f"Unknown link_mode: {link_mode!r} (expected one of {LINK_MODES})")
 
@@ -81,6 +90,7 @@ class ReportOptions:
     binary_size: bool = False
     coverage: bool = False
     tests: bool = False
+    documentation: bool = False
     public_targets: bool = False
     external_dependencies: bool = False
 
@@ -680,18 +690,357 @@ def make_code_coverage_section(
     )
 
 
-def make_tests_section(runner: CommandRunner) -> SectionResult:
+# Directory under ``docs/reports/`` that receives copies of the
+# SVG-vs-golden image artifacts from failed image-comparison tests, so they
+# render on the docs site and from GitHub's web view of the report.
+_TEST_FAILURE_IMAGE_DIR = "test-failures"
+
+# Image-comparison fixtures drop these per-case PNGs into a failing test's
+# ``$TEST_UNDECLARED_OUTPUTS_DIR`` (see
+# donner/svg/renderer/tests/ImageComparisonTestFixture.cc): ``expected_*`` is
+# the golden, ``actual_*`` is what the renderer produced, ``diff_*`` is the
+# pixelmatch diff. The ``parity_*`` trio is the Geode-vs-tiny variant.
+_FAILURE_IMAGE_PREFIXES = (
+    "diff_",
+    "actual_",
+    "expected_",
+    "parity_diff_",
+    "parity_geode_",
+    "parity_tiny_",
+)
+
+
+def _target_to_testlogs_subpath(target: str) -> str:
+    """Map a Bazel label to its ``bazel-testlogs`` relative directory.
+
+    ``//donner/svg/renderer/tests:renderer_geode_golden_tests`` →
+    ``donner/svg/renderer/tests/renderer_geode_golden_tests``.
+    """
+    package, _, name = target.lstrip("/").partition(":")
+    return f"{package}/{name}" if name else package
+
+
+def _collect_failure_images_for_target(test_outputs_dir: Path) -> typing.List[Path]:
+    """Return the image-comparison PNGs a failed target left behind.
+
+    A target's undeclared outputs live under ``<testlogs>/<path>/test.outputs``
+    either as loose files or (when there is more than one) inside
+    ``outputs.zip``. We surface the loose-file case directly; callers extract
+    the zip case first.
+    """
+    images: typing.List[Path] = []
+    if not test_outputs_dir.is_dir():
+        return images
+    for path in sorted(test_outputs_dir.rglob("*.png")):
+        if path.name.startswith(_FAILURE_IMAGE_PREFIXES):
+            images.append(path)
+    return images
+
+
+def _harvest_failed_image_artifacts(
+    failed_targets: typing.Sequence[str],
+    destination: Path,
+    bazel_testlogs: Path,
+) -> dict[str, typing.List[str]]:
+    """Copy SVG-vs-golden PNGs from failed targets into ``destination``.
+
+    Returns ``{target: [relative_png_path, ...]}`` for every failed target
+    that produced image-comparison artifacts. Paths are relative to
+    ``destination`` so the report can build links from its ``reports/`` root.
+    Targets that produced no such PNGs (non-image failures) are omitted.
+    """
+    harvested: dict[str, typing.List[str]] = {}
+    for target in failed_targets:
+        subpath = _target_to_testlogs_subpath(target)
+        outputs_dir = bazel_testlogs / subpath / "test.outputs"
+        if not outputs_dir.exists():
+            continue
+
+        # Materialize a flat working copy: loose PNGs plus anything inside a
+        # bundled outputs.zip.
+        staged: typing.List[tuple[str, Path]] = []
+        for path in _collect_failure_images_for_target(outputs_dir):
+            staged.append((path.name, path))
+
+        zip_path = outputs_dir / "outputs.zip"
+        extracted_dir: typing.Optional[Path] = None
+        if zip_path.is_file():
+            extracted_dir = destination / subpath / "_unzip"
+            try:
+                with zipfile.ZipFile(zip_path) as zf:
+                    for member in zf.namelist():
+                        base = Path(member).name
+                        if base.startswith(_FAILURE_IMAGE_PREFIXES) and base.endswith(
+                            ".png"
+                        ):
+                            zf.extract(member, extracted_dir)
+                            staged.append((base, extracted_dir / member))
+            except (OSError, zipfile.BadZipFile):
+                pass
+
+        if not staged:
+            if extracted_dir is not None and extracted_dir.exists():
+                shutil.rmtree(extracted_dir, ignore_errors=True)
+            continue
+
+        target_dir = destination / subpath
+        target_dir.mkdir(parents=True, exist_ok=True)
+        rel_paths: typing.List[str] = []
+        for name, source in staged:
+            dest_file = target_dir / name
+            shutil.copyfile(source, dest_file)
+            rel_paths.append(dest_file.relative_to(destination).as_posix())
+
+        if extracted_dir is not None and extracted_dir.exists():
+            shutil.rmtree(extracted_dir, ignore_errors=True)
+
+        if rel_paths:
+            harvested[target] = sorted(set(rel_paths))
+    return harvested
+
+
+def _resolve_bazel_testlogs() -> typing.Optional[Path]:
+    try:
+        out = subprocess.check_output(["bazel", "info", "bazel-testlogs"], text=True).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    path = Path(out)
+    return path if path.exists() else None
+
+
+def _render_failed_image_comparisons(
+    failed_targets: typing.Sequence[str],
+    reports_root: typing.Optional[Path],
+    *,
+    bazel_testlogs: typing.Optional[Path] = None,
+) -> str:
+    """Render the SVG-vs-golden block for failed image-comparison tests.
+
+    When ``reports_root`` is set (docs-link mode) the PNGs are copied into
+    ``reports/test-failures/`` and the report embeds them. Returns an empty
+    string when there are no failed targets, no artifacts, or no place to
+    stage them.
+    """
+    if not failed_targets:
+        return ""
+    if reports_root is None:
+        # Without a checked-in reports tree we have nowhere to publish the
+        # PNGs, so just name the failing targets.
+        listed = "\n".join(f"- `{t}`" for t in failed_targets)
+        return (
+            "### Failed image comparisons\n\n"
+            "The following targets failed; regenerate with `--save "
+            "docs/build_report.md` to embed their SVG-vs-golden diffs.\n\n"
+            f"{listed}"
+        )
+
+    if bazel_testlogs is None:
+        bazel_testlogs = _resolve_bazel_testlogs()
+    if bazel_testlogs is None:
+        return ""
+
+    destination = reports_root / _TEST_FAILURE_IMAGE_DIR
+    if destination.exists():
+        shutil.rmtree(destination)
+
+    harvested = _harvest_failed_image_artifacts(failed_targets, destination, bazel_testlogs)
+    if not harvested:
+        # No image-comparison artifacts (the failures were non-visual). Leave
+        # the staging dir clean and emit nothing.
+        if destination.exists() and not any(destination.iterdir()):
+            destination.rmdir()
+        return ""
+
+    lines = [
+        "### Failed image comparisons",
+        "",
+        "SVG-vs-golden artifacts for image-comparison tests that failed. "
+        "`expected_*` is the golden, `actual_*` is the rendered output, and "
+        "`diff_*` is the pixelmatch difference.",
+        "",
+    ]
+    for target in sorted(harvested):
+        lines.append(f"#### `{target}`")
+        lines.append("")
+        for rel in harvested[target]:
+            # Build the link relative to docs/ (the report lives at
+            # docs/build_report.md, reports_root is docs/reports).
+            href = f"reports/{_TEST_FAILURE_IMAGE_DIR}/{Path(rel).as_posix()}"
+            caption = Path(rel).name
+            lines.append(f"![{caption}]({href})")
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def make_documentation_section(links: LinkTargets) -> SectionResult:
+    """A static section linking the Doxygen-generated API documentation.
+
+    The API docs are produced by `tools/build_docs.sh` (which runs
+    `doxygen Doxyfile`) and published to the docs site; there is no command to
+    run here, so this section is informational and always reports success.
+    """
+    content = "\n".join(
+        [
+            "Doxygen-generated API documentation for the Donner SVG library.",
+            "",
+            f"Browse: [API documentation]({links.doxygen_index})",
+            "",
+            "Regenerate locally with `tools/build_docs.sh` "
+            "(output: `generated-doxygen/html/`).",
+        ]
+    )
+    return SectionResult("Documentation", "success", 0.0, content)
+
+
+@dataclass(frozen=True)
+class TestCaseResult:
+    """One target's pass/fail/skip status as parsed from `bazel test` output."""
+
+    target: str
+    status: str  # PASSED / FAILED / FLAKY / TIMEOUT / SKIPPED / NO STATUS / ...
+    detail: str  # e.g. "in 1.2s", "(cached)", or "" when absent.
+
+
+# `bazel test` summary lines look like:
+#   //pkg:target                                       PASSED in 1.2s
+#   //pkg:target                                       FAILED in 0.3s
+#   //pkg:target                                       SKIPPED
+#   //pkg:target                              (cached) PASSED in 0.0s
+# Statuses bazel emits in the per-target summary block.
+_BAZEL_TEST_STATUSES = (
+    "PASSED",
+    "FAILED",
+    "FLAKY",
+    "TIMEOUT",
+    "SKIPPED",
+    "NO STATUS",
+    "FAILED TO BUILD",
+)
+_BAZEL_TEST_LINE_RE = re.compile(
+    r"^(?P<target>//\S+)\s+"
+    # Bazel inserts a right-aligned "(cached)" marker between the target and
+    # the status for cached results; capture it as part of the detail.
+    r"(?P<cached>\(cached\)\s+)?"
+    r"(?P<status>" + "|".join(re.escape(s) for s in _BAZEL_TEST_STATUSES) + r")"
+    r"(?P<detail>.*)$"
+)
+
+
+def parse_bazel_test_results(stdout: str) -> typing.List[TestCaseResult]:
+    """Extract per-target pass/fail results from `bazel test` summary output.
+
+    Bazel prints one line per test target in its end-of-run summary; parse
+    those into structured records. Lines that don't match the target/status
+    shape (build progress, the trailing "Executed N out of M tests" line) are
+    ignored. The result is de-duplicated by target (last status wins) so a
+    target that appears in both a per-shard line and the summary isn't double
+    counted.
+    """
+    by_target: dict[str, TestCaseResult] = {}
+    for line in stdout.splitlines():
+        match = _BAZEL_TEST_LINE_RE.match(line.strip())
+        if match is None:
+            continue
+        detail = match.group("detail").strip()
+        if match.group("cached"):
+            detail = f"(cached) {detail}".strip()
+        by_target[match.group("target")] = TestCaseResult(
+            target=match.group("target"),
+            status=match.group("status"),
+            detail=detail,
+        )
+    return sorted(by_target.values(), key=lambda r: (r.status != "FAILED", r.target))
+
+
+# Order test-status groups so failures/flakes surface at the top of the table.
+_TEST_STATUS_ORDER = (
+    "FAILED",
+    "FAILED TO BUILD",
+    "TIMEOUT",
+    "FLAKY",
+    "NO STATUS",
+    "PASSED",
+    "SKIPPED",
+)
+
+
+def _render_test_results_table(results: typing.Sequence[TestCaseResult]) -> str:
+    if not results:
+        return "(no per-target test results parsed from output)"
+
+    counts: dict[str, int] = {}
+    for record in results:
+        counts[record.status] = counts.get(record.status, 0) + 1
+
+    order = {status: index for index, status in enumerate(_TEST_STATUS_ORDER)}
+
+    def status_key(status: str) -> tuple[int, str]:
+        return (order.get(status, len(order)), status)
+
+    summary = ", ".join(
+        f"{count} {status.lower()}"
+        for status, count in sorted(counts.items(), key=lambda kv: status_key(kv[0]))
+    )
+
+    lines = [
+        f"{len(results)} targets: {summary}.",
+        "",
+        "| Target | Result |",
+        "| --- | --- |",
+    ]
+    for record in sorted(results, key=lambda r: (status_key(r.status), r.target)):
+        detail = f" {record.detail}" if record.detail else ""
+        lines.append(f"| `{record.target}` | {record.status}{detail} |")
+    return "\n".join(lines)
+
+
+def make_tests_section(
+    runner: CommandRunner,
+    reports_root: typing.Optional[Path] = None,
+    *,
+    bazel_testlogs: typing.Optional[Path] = None,
+) -> SectionResult:
     args = ["bazel", "test", "//donner/..."]
     result = runner.run("tests", args)
+
+    parsed = parse_bazel_test_results(result.stdout)
+    failed_targets = [r.target for r in parsed if r.status in ("FAILED", "TIMEOUT")]
+
+    lines = [
+        f"Generated with: `{format_command(args)}`",
+        "",
+        "### Test results",
+        "",
+        _render_test_results_table(parsed),
+    ]
+
+    failure_section = _render_failed_image_comparisons(
+        failed_targets, reports_root, bazel_testlogs=bazel_testlogs
+    )
+    if failure_section:
+        lines.extend(["", failure_section])
+
+    # Preserve the raw bazel output for anyone who needs the full log.
+    lines.extend(
+        [
+            "",
+            "<details><summary>Raw <code>bazel test</code> output</summary>",
+            "",
+            _render_command_block(
+                format_command(args),
+                result,
+                empty_output_message="(test command produced no output)",
+            ),
+            "",
+            "</details>",
+        ]
+    )
+
     return SectionResult(
         "Tests",
         _result_status(result),
         result.duration_sec,
-        _render_command_block(
-            format_command(args),
-            result,
-            empty_output_message="(test command produced no output)",
-        ),
+        "\n".join(lines),
     )
 
 
@@ -856,7 +1205,9 @@ def create_build_report(
     if options.all or options.coverage:
         sections.append(make_code_coverage_section(runner, reports_root, links))
     if options.all or options.tests:
-        sections.append(make_tests_section(runner))
+        sections.append(make_tests_section(runner, reports_root))
+    if options.all or options.documentation:
+        sections.append(make_documentation_section(links))
     if options.all or options.public_targets:
         sections.append(make_public_targets_section(runner))
     if options.all or options.external_dependencies:
@@ -895,6 +1246,11 @@ def parse_args(argv: typing.Optional[typing.Sequence[str]] = None) -> argparse.N
         "--coverage", action="store_true", help="Generate the code coverage section"
     )
     parser.add_argument("--tests", action="store_true", help="Generate the tests section")
+    parser.add_argument(
+        "--documentation",
+        action="store_true",
+        help="Generate the documentation (Doxygen link) section",
+    )
     parser.add_argument(
         "--public-targets", action="store_true", help="Generate the public targets section"
     )
@@ -973,6 +1329,7 @@ def main(argv: typing.Optional[typing.Sequence[str]] = None) -> int:
         binary_size=args.binary_size,
         coverage=args.coverage,
         tests=args.tests,
+        documentation=args.documentation,
         public_targets=args.public_targets,
         external_dependencies=args.external_dependencies,
     )

--- a/tools/generate_build_report.py
+++ b/tools/generate_build_report.py
@@ -921,7 +921,11 @@ _BAZEL_TEST_LINE_RE = re.compile(
     # Bazel inserts a right-aligned "(cached)" marker between the target and
     # the status for cached results; capture it as part of the detail.
     r"(?P<cached>\(cached\)\s+)?"
-    r"(?P<status>" + "|".join(re.escape(s) for s in _BAZEL_TEST_STATUSES) + r")"
+    # Sort longest-first so multi-word statuses ("FAILED TO BUILD") win over a
+    # prefix that is itself a status ("FAILED").
+    r"(?P<status>"
+    + "|".join(re.escape(s) for s in sorted(_BAZEL_TEST_STATUSES, key=len, reverse=True))
+    + r")"
     r"(?P<detail>.*)$"
 )
 

--- a/tools/generate_build_report.py
+++ b/tools/generate_build_report.py
@@ -125,6 +125,20 @@ class SectionResult:
     content: str
 
 
+_MAX_COMMAND_OUTPUT_CHARS = 64 * 1024
+_COMMAND_OUTPUT_TAIL_CHARS = 16 * 1024
+
+_TESTS_COMMAND_ARGS = (
+    "bazel",
+    "test",
+    "--test_tag_filters=-lint",
+    "--remote_executor=",
+    "--remote_cache=",
+    "--noremote_upload_local_results",
+    "//donner/...",
+)
+
+
 def format_command(args: typing.Sequence[str]) -> str:
     return " ".join(shlex.quote(arg) for arg in args)
 
@@ -404,14 +418,14 @@ def _render_command_block(
     lines = ["```", f"$ {command_display}"]
 
     if result.stdout:
-        lines.append(result.stdout)
+        lines.append(_limit_report_output(result.stdout))
     elif result.success:
         lines.append(empty_output_message)
 
     if result.stderr and not result.success:
         if result.stdout:
             lines.extend(["", "[stderr]"])
-        lines.append(result.stderr)
+        lines.append(_limit_report_output(result.stderr))
     elif not result.success and not result.stdout:
         lines.append("(command produced no output)")
 
@@ -420,6 +434,25 @@ def _render_command_block(
 
     lines.append("```")
     return "\n".join(lines)
+
+
+def _limit_report_output(
+    output: str, *, max_chars: int = _MAX_COMMAND_OUTPUT_CHARS
+) -> str:
+    """Keep generated Markdown reports from embedding unbounded tool output."""
+    if len(output) <= max_chars:
+        return output
+
+    tail_chars = min(_COMMAND_OUTPUT_TAIL_CHARS, max_chars // 2)
+    head_chars = max_chars - tail_chars
+    omitted_chars = len(output) - head_chars - tail_chars
+    return "\n\n".join(
+        [
+            output[:head_chars].rstrip(),
+            f"[... omitted {omitted_chars:,} characters of command output ...]",
+            output[-tail_chars:].lstrip(),
+        ]
+    )
 
 
 def _render_static_command_block(command_display: str, message: str) -> str:
@@ -967,6 +1000,8 @@ _TEST_STATUS_ORDER = (
     "SKIPPED",
 )
 
+_OMITTED_TEST_TABLE_STATUSES = frozenset({"NO STATUS"})
+
 
 def _render_test_results_table(results: typing.Sequence[TestCaseResult]) -> str:
     if not results:
@@ -992,9 +1027,33 @@ def _render_test_results_table(results: typing.Sequence[TestCaseResult]) -> str:
         "| Target | Result |",
         "| --- | --- |",
     ]
-    for record in sorted(results, key=lambda r: (status_key(r.status), r.target)):
+    omitted_counts = {
+        status: counts[status]
+        for status in _OMITTED_TEST_TABLE_STATUSES
+        if status in counts
+    }
+    visible_results = [
+        record for record in results if record.status not in _OMITTED_TEST_TABLE_STATUSES
+    ]
+    for record in sorted(visible_results, key=lambda r: (status_key(r.status), r.target)):
         detail = f" {record.detail}" if record.detail else ""
         lines.append(f"| `{record.target}` | {record.status}{detail} |")
+    if omitted_counts:
+        omitted_summary = ", ".join(
+            f"{count} {status.lower()}"
+            for status, count in sorted(
+                omitted_counts.items(), key=lambda kv: status_key(kv[0])
+            )
+        )
+        lines.extend(
+            [
+                "",
+                (
+                    f"Omitted {omitted_summary} target rows from the table; "
+                    "Bazel did not execute those targets after an earlier build failure."
+                ),
+            ]
+        )
     return "\n".join(lines)
 
 
@@ -1004,7 +1063,7 @@ def make_tests_section(
     *,
     bazel_testlogs: typing.Optional[Path] = None,
 ) -> SectionResult:
-    args = ["bazel", "test", "//donner/..."]
+    args = list(_TESTS_COMMAND_ARGS)
     result = runner.run("tests", args)
 
     # Bazel emits its per-target test summary on stderr (stdout is usually empty),

--- a/tools/generate_build_report.py
+++ b/tools/generate_build_report.py
@@ -1007,7 +1007,10 @@ def make_tests_section(
     args = ["bazel", "test", "//donner/..."]
     result = runner.run("tests", args)
 
-    parsed = parse_bazel_test_results(result.stdout)
+    # Bazel emits its per-target test summary on stderr (stdout is usually empty),
+    # so parse both streams to populate the results table and failed-image harvest.
+    combined_output = "\n".join(part for part in (result.stdout, result.stderr) if part)
+    parsed = parse_bazel_test_results(combined_output)
     failed_targets = [r.target for r in parsed if r.status in ("FAILED", "TIMEOUT")]
 
     lines = [

--- a/tools/generate_build_report_tests.py
+++ b/tools/generate_build_report_tests.py
@@ -486,6 +486,192 @@ class GenerateBuildReportTests(unittest.TestCase):
             finally:
                 os.chdir(prior_cwd)
 
+    def test_parse_bazel_test_results_extracts_per_target_status(self):
+        stdout = "\n".join(
+            [
+                "INFO: Analyzed 3 targets.",
+                "//donner/base:base_tests                                  PASSED in 1.2s",
+                "//donner/svg:svg_tests                          (cached) PASSED in 0.0s",
+                "//donner/svg/renderer/tests:renderer_geode_tests          SKIPPED",
+                "//donner/css:css_tests                                    FAILED in 0.3s",
+                "Executed 2 out of 3 tests: 2 tests pass and 1 fails.",
+            ]
+        )
+        results = generate_build_report.parse_bazel_test_results(stdout)
+        by_target = {r.target: r for r in results}
+
+        self.assertEqual(by_target["//donner/base:base_tests"].status, "PASSED")
+        self.assertEqual(by_target["//donner/base:base_tests"].detail, "in 1.2s")
+        self.assertEqual(by_target["//donner/svg:svg_tests"].status, "PASSED")
+        self.assertEqual(
+            by_target["//donner/svg/renderer/tests:renderer_geode_tests"].status,
+            "SKIPPED",
+        )
+        self.assertEqual(by_target["//donner/css:css_tests"].status, "FAILED")
+        # The "Executed ... tests" trailer and INFO lines are not targets.
+        self.assertEqual(len(results), 4)
+
+    def test_tests_section_renders_structured_table_and_raw_block(self):
+        stdout = "\n".join(
+            [
+                "//donner/base:base_tests          PASSED in 1.2s",
+                "//donner/css:css_tests            FAILED in 0.3s",
+                "//donner/svg:svg_tests            SKIPPED",
+            ]
+        )
+        runner = FakeRunner(
+            {
+                ("bazel", "test", "//donner/..."): generate_build_report.CommandResult(
+                    label="tests",
+                    args=("bazel", "test", "//donner/..."),
+                    returncode=3,
+                    stdout=stdout,
+                    stderr="",
+                    duration_sec=12.0,
+                )
+            }
+        )
+        section = generate_build_report.make_tests_section(
+            runner,
+            None,  # no reports_root → no image harvest
+            bazel_testlogs=None,
+        )
+
+        self.assertEqual(section.status, "failed")
+        self.assertIn("### Test results", section.content)
+        self.assertIn("| Target | Result |", section.content)
+        self.assertIn("| `//donner/css:css_tests` | FAILED in 0.3s |", section.content)
+        self.assertIn("3 targets: 1 failed, 1 passed, 1 skipped.", section.content)
+        # Failures sort to the top of the table.
+        failed_idx = section.content.index("//donner/css:css_tests")
+        passed_idx = section.content.index("//donner/base:base_tests")
+        self.assertLess(failed_idx, passed_idx)
+        # The raw bazel output is preserved in a collapsible block.
+        self.assertIn("Raw <code>bazel test</code> output", section.content)
+        # Without a reports_root we still name the failed target.
+        self.assertIn("### Failed image comparisons", section.content)
+        self.assertIn("`//donner/css:css_tests`", section.content)
+
+    def test_documentation_section_links_to_doxygen(self):
+        links = generate_build_report._resolve_link_targets(
+            generate_build_report.LINK_MODE_DOCS
+        )
+        section = generate_build_report.make_documentation_section(links)
+        self.assertEqual(section.status, "success")
+        self.assertIn("API documentation", section.content)
+        self.assertIn(generate_build_report.DOCS_SITE_BASE_URL, section.content)
+
+    def test_resolve_link_targets_includes_doxygen(self):
+        local = generate_build_report._resolve_link_targets(
+            generate_build_report.LINK_MODE_LOCAL
+        )
+        self.assertEqual(local.doxygen_index, "generated-doxygen/html/index.html")
+        docs = generate_build_report._resolve_link_targets(
+            generate_build_report.LINK_MODE_DOCS
+        )
+        self.assertTrue(docs.doxygen_index.startswith("https://"))
+
+    def test_harvest_failed_image_artifacts_copies_loose_pngs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            testlogs = tmp_path / "testlogs"
+            outputs = (
+                testlogs
+                / "donner/svg/renderer/tests/renderer_geode_golden_tests/test.outputs"
+            )
+            outputs.mkdir(parents=True)
+            (outputs / "expected_Foo.png").write_bytes(b"\x89PNG-golden")
+            (outputs / "actual_Foo.png").write_bytes(b"\x89PNG-actual")
+            (outputs / "diff_Foo.png").write_bytes(b"\x89PNG-diff")
+            (outputs / "test.log").write_text("ignore me")
+
+            destination = tmp_path / "docs" / "reports" / "test-failures"
+            harvested = generate_build_report._harvest_failed_image_artifacts(
+                ["//donner/svg/renderer/tests:renderer_geode_golden_tests"],
+                destination,
+                testlogs,
+            )
+
+            target = "//donner/svg/renderer/tests:renderer_geode_golden_tests"
+            self.assertIn(target, harvested)
+            rels = harvested[target]
+            self.assertEqual(len(rels), 3)
+            self.assertTrue(
+                any(r.endswith("diff_Foo.png") for r in rels), rels
+            )
+            # Non-image artifacts are not copied.
+            self.assertFalse(any("test.log" in r for r in rels))
+            # The files actually landed under destination.
+            for rel in rels:
+                self.assertTrue((destination / rel).is_file())
+
+    def test_harvest_failed_image_artifacts_reads_outputs_zip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            testlogs = tmp_path / "testlogs"
+            outputs = testlogs / "donner/css/tests/css_tests/test.outputs"
+            outputs.mkdir(parents=True)
+            import zipfile as _zip
+
+            with _zip.ZipFile(outputs / "outputs.zip", "w") as zf:
+                zf.writestr("diff_Bar.png", b"\x89PNG-diff")
+                zf.writestr("expected_Bar.png", b"\x89PNG-golden")
+                zf.writestr("some_other_log.txt", b"not an image")
+
+            destination = tmp_path / "out"
+            harvested = generate_build_report._harvest_failed_image_artifacts(
+                ["//donner/css/tests:css_tests"],
+                destination,
+                testlogs,
+            )
+            target = "//donner/css/tests:css_tests"
+            self.assertIn(target, harvested)
+            self.assertEqual(len(harvested[target]), 2)
+            for rel in harvested[target]:
+                self.assertTrue((destination / rel).is_file())
+            # The transient _unzip staging dir is cleaned up.
+            self.assertFalse(
+                (destination / "donner/css/tests/css_tests/_unzip").exists()
+            )
+
+    def test_render_failed_image_comparisons_embeds_images(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            testlogs = tmp_path / "testlogs"
+            outputs = testlogs / "donner/svg/tests/svg_tests/test.outputs"
+            outputs.mkdir(parents=True)
+            (outputs / "diff_Case.png").write_bytes(b"\x89PNG")
+
+            reports_root = tmp_path / "docs" / "reports"
+            reports_root.mkdir(parents=True)
+            block = generate_build_report._render_failed_image_comparisons(
+                ["//donner/svg/tests:svg_tests"],
+                reports_root,
+                bazel_testlogs=testlogs,
+            )
+            self.assertIn("### Failed image comparisons", block)
+            self.assertIn("#### `//donner/svg/tests:svg_tests`", block)
+            self.assertIn(
+                "![diff_Case.png](reports/test-failures/"
+                "donner/svg/tests/svg_tests/diff_Case.png)",
+                block,
+            )
+
+    def test_render_failed_image_comparisons_omits_when_no_artifacts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            testlogs = tmp_path / "testlogs"
+            # A failed target with no image outputs at all.
+            (testlogs / "donner/base/base_tests/test.outputs").mkdir(parents=True)
+            reports_root = tmp_path / "reports"
+            reports_root.mkdir()
+            block = generate_build_report._render_failed_image_comparisons(
+                ["//donner/base:base_tests"],
+                reports_root,
+                bazel_testlogs=testlogs,
+            )
+            self.assertEqual(block, "")
+
     def test_command_runner_reports_progress(self):
         runner = generate_build_report.CommandRunner(
             progress_interval_sec=0.01,

--- a/tools/generate_build_report_tests.py
+++ b/tools/generate_build_report_tests.py
@@ -14,6 +14,7 @@ assert MODULE_SPEC.loader is not None
 generate_build_report = importlib.util.module_from_spec(MODULE_SPEC)
 sys.modules[MODULE_SPEC.name] = generate_build_report
 MODULE_SPEC.loader.exec_module(generate_build_report)
+TESTS_ARGS = tuple(generate_build_report._TESTS_COMMAND_ARGS)
 
 
 class FakeRunner:
@@ -261,9 +262,9 @@ class GenerateBuildReportTests(unittest.TestCase):
                     stderr="",
                     duration_sec=1.25,
                 ),
-                ("bazel", "test", "//donner/..."): generate_build_report.CommandResult(
+                TESTS_ARGS: generate_build_report.CommandResult(
                     label="tests",
-                    args=("bazel", "test", "//donner/..."),
+                    args=TESTS_ARGS,
                     returncode=0,
                     stdout="//donner/... tests passed",
                     stderr="",
@@ -399,6 +400,39 @@ class GenerateBuildReportTests(unittest.TestCase):
         )
         self.assertIn("lines.......: 85.2%", section.content)
 
+    def test_coverage_section_truncates_large_failure_output(self):
+        limit = generate_build_report._MAX_COMMAND_OUTPUT_CHARS
+        stderr = (
+            "coverage-error-start\n"
+            + ("x" * (limit + 1024))
+            + "\ncoverage-error-end"
+        )
+        runner = FakeRunner(
+            {
+                ("tools/coverage.sh", "--quiet"): generate_build_report.CommandResult(
+                    label="code-coverage",
+                    args=("tools/coverage.sh", "--quiet"),
+                    returncode=1,
+                    stdout="",
+                    stderr=stderr,
+                    duration_sec=120.0,
+                )
+            }
+        )
+        section = generate_build_report.make_code_coverage_section(
+            runner,
+            None,
+            generate_build_report._resolve_link_targets(
+                generate_build_report.LINK_MODE_DOCS
+            ),
+        )
+
+        self.assertEqual(section.status, "failed")
+        self.assertIn("coverage-error-start", section.content)
+        self.assertIn("coverage-error-end", section.content)
+        self.assertIn("omitted", section.content)
+        self.assertLess(len(section.content), len(stderr))
+
     def test_binary_size_section_local_mode_copies_bargraph_next_to_save(self):
         """In local mode with --save, the bargraph SVG must land beside
         the saved markdown so the image link resolves from any viewer."""
@@ -519,6 +553,26 @@ class GenerateBuildReportTests(unittest.TestCase):
         self.assertEqual(results[0].status, "FAILED TO BUILD")
         self.assertEqual(results[0].detail, "")
 
+    def test_render_test_results_table_collapses_no_status_rows(self):
+        table = generate_build_report._render_test_results_table(
+            [
+                generate_build_report.TestCaseResult(
+                    "//donner/css:css_tests", "FAILED TO BUILD", ""
+                ),
+                generate_build_report.TestCaseResult(
+                    "//donner/base:base_tests", "NO STATUS", ""
+                ),
+                generate_build_report.TestCaseResult(
+                    "//donner/svg:svg_tests", "NO STATUS", ""
+                ),
+            ]
+        )
+
+        self.assertIn("3 targets: 1 failed to build, 2 no status.", table)
+        self.assertIn("| `//donner/css:css_tests` | FAILED TO BUILD |", table)
+        self.assertNotIn("| `//donner/base:base_tests` | NO STATUS |", table)
+        self.assertIn("Omitted 2 no status target rows", table)
+
     def test_tests_section_renders_structured_table_and_raw_block(self):
         stdout = "\n".join(
             [
@@ -529,9 +583,9 @@ class GenerateBuildReportTests(unittest.TestCase):
         )
         runner = FakeRunner(
             {
-                ("bazel", "test", "//donner/..."): generate_build_report.CommandResult(
+                TESTS_ARGS: generate_build_report.CommandResult(
                     label="tests",
-                    args=("bazel", "test", "//donner/..."),
+                    args=TESTS_ARGS,
                     returncode=3,
                     stdout=stdout,
                     stderr="",
@@ -546,6 +600,9 @@ class GenerateBuildReportTests(unittest.TestCase):
         )
 
         self.assertEqual(section.status, "failed")
+        self.assertEqual(runner.calls[0], ("tests", TESTS_ARGS))
+        self.assertIn("--test_tag_filters=-lint", TESTS_ARGS)
+        self.assertIn("--remote_executor=", TESTS_ARGS)
         self.assertIn("### Test results", section.content)
         self.assertIn("| Target | Result |", section.content)
         self.assertIn("| `//donner/css:css_tests` | FAILED in 0.3s |", section.content)
@@ -571,9 +628,9 @@ class GenerateBuildReportTests(unittest.TestCase):
         )
         runner = FakeRunner(
             {
-                ("bazel", "test", "//donner/..."): generate_build_report.CommandResult(
+                TESTS_ARGS: generate_build_report.CommandResult(
                     label="tests",
-                    args=("bazel", "test", "//donner/..."),
+                    args=TESTS_ARGS,
                     returncode=3,
                     stdout="",
                     stderr=stderr,

--- a/tools/generate_build_report_tests.py
+++ b/tools/generate_build_report_tests.py
@@ -511,6 +511,14 @@ class GenerateBuildReportTests(unittest.TestCase):
         # The "Executed ... tests" trailer and INFO lines are not targets.
         self.assertEqual(len(results), 4)
 
+    def test_parse_bazel_test_results_prefers_multiword_status(self):
+        # "FAILED TO BUILD" must not be parsed as "FAILED" + detail "TO BUILD".
+        stdout = "//donner/x:y                          FAILED TO BUILD"
+        results = generate_build_report.parse_bazel_test_results(stdout)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].status, "FAILED TO BUILD")
+        self.assertEqual(results[0].detail, "")
+
     def test_tests_section_renders_structured_table_and_raw_block(self):
         stdout = "\n".join(
             [

--- a/tools/generate_build_report_tests.py
+++ b/tools/generate_build_report_tests.py
@@ -560,6 +560,40 @@ class GenerateBuildReportTests(unittest.TestCase):
         self.assertIn("### Failed image comparisons", section.content)
         self.assertIn("`//donner/css:css_tests`", section.content)
 
+    def test_tests_section_parses_results_from_stderr(self):
+        # Real `bazel test` writes its per-target summary to stderr, leaving stdout
+        # empty. The structured table and failed-target harvest must still populate.
+        stderr = "\n".join(
+            [
+                "//donner/base:base_tests          PASSED in 1.2s",
+                "//donner/css:css_tests            FAILED in 0.3s",
+            ]
+        )
+        runner = FakeRunner(
+            {
+                ("bazel", "test", "//donner/..."): generate_build_report.CommandResult(
+                    label="tests",
+                    args=("bazel", "test", "//donner/..."),
+                    returncode=3,
+                    stdout="",
+                    stderr=stderr,
+                    duration_sec=12.0,
+                )
+            }
+        )
+        section = generate_build_report.make_tests_section(
+            runner,
+            None,  # no reports_root → no image harvest
+            bazel_testlogs=None,
+        )
+
+        self.assertEqual(section.status, "failed")
+        self.assertIn("| `//donner/css:css_tests` | FAILED in 0.3s |", section.content)
+        self.assertIn("2 targets: 1 failed, 1 passed.", section.content)
+        # The stderr-only failure is still surfaced for image harvesting.
+        self.assertIn("### Failed image comparisons", section.content)
+        self.assertIn("`//donner/css:css_tests`", section.content)
+
     def test_documentation_section_links_to_doxygen(self):
         links = generate_build_report._resolve_link_targets(
             generate_build_report.LINK_MODE_DOCS


### PR DESCRIPTION
Closes #147. Implements all five items:

- New **Documentation** section linking the Doxygen API docs (`--documentation` flag; `doxygen_index` added to all link modes).
- **Tests** section parses bazel's per-target results into a structured pass/fail table (failures first, status counts), preserving the raw log in a collapsible block; handles `(cached)` and multi-word statuses (`FAILED TO BUILD`).
- Failed image-comparison tests' `expected_/actual_/diff_` PNGs are harvested from `bazel-testlogs/.../test.outputs` (loose files + `outputs.zip`) into `docs/reports/test-failures/` and embedded; `build_docs.sh` stages that tree onto the docs site.
- Binary-size (webtreemap) and coverage-HTML links were already present.

Adds 9 unit tests (parser, doxygen link, image harvest for loose-file and zip layouts, render block, no-false-positive) — `//tools:generate_build_report_tests`, 20 total, all passing. Verified against real `bazel test` output + the real `bazel-testlogs` layout.

Tooling-only change. Regenerating the checked-in `docs/build_report.md` is left to a run on a quiescent machine (cross-agent bazel-server contention poisoned the in-place attempt; the generator itself is proven by the tests).