### PR TITLE
Fix #552: cap chained feImage fragment recursion depth (macOS/Metal segfault)

### DIFF
--- a/donner/svg/renderer/RendererDriver.cc
+++ b/donner/svg/renderer/RendererDriver.cc
@@ -60,6 +60,17 @@ namespace {
 /// the bounds before this check.
 inline constexpr double kMinCullableExtentDevicePx = 0.25;
 
+/// Maximum nesting depth for chained `<feImage>` fragment references
+/// (filter1→rect3→filter2→rect4→…). The visited-set guard already stops a true
+/// *cycle*, but an arbitrarily long *acyclic* chain would otherwise recurse once
+/// per link — each level standing up a GPU offscreen instance — and can exhaust
+/// the native stack (issue #552, segfault on macOS/Metal). Past this depth the
+/// over-deep fragment is rendered as empty/transparent instead of recursing
+/// further. Real documents nest at most a couple of levels (resvg's
+/// `chained-feImage` is depth 2); 32 is far above any legitimate use while still
+/// safely bounding stack growth.
+inline constexpr int kMaxFeImageFragmentDepth = 32;
+
 /// Slack margin (in device pixels) applied when intersecting the viewport for
 /// culling. Keeps fractional-pixel strokes at the viewport edge safely on-screen
 /// — we'd rather do a little extra work than cull content the user should see.
@@ -2576,6 +2587,28 @@ void RendererDriver::preRenderFeImageFragments(components::FilterGraph& filterGr
     feImageFragmentGuard_ = &localGuard;
   }
 
+  // Depth cap: a long acyclic chain of feImage fragment references would recurse once per link
+  // (each level standing up a GPU offscreen instance) and can exhaust the native stack on some
+  // drivers (issue #552). Beyond the cap, leave each unresolved fragment as empty (its `imageData`
+  // stays empty and `applyImage` paints transparent) rather than recursing further. We still clear
+  // `fragmentId` so the renderer treats it as a resolved-but-empty image instead of retrying.
+  if (feImageFragmentDepth_ >= kMaxFeImageFragmentDepth) {
+    if (verbose_) {
+      std::cerr << "[preRenderFeImageFragments] feImage fragment nesting exceeded "
+                << kMaxFeImageFragmentDepth << "; rendering deeper fragments as empty\n";
+    }
+    for (auto& node : filterGraph.nodes) {
+      if (auto* imageNode = std::get_if<components::filter_primitive::Image>(&node.primitive);
+          imageNode && !imageNode->fragmentId.empty() && imageNode->imageData.empty()) {
+        imageNode->fragmentId = RcString();
+      }
+    }
+    if (ownsGuard) {
+      feImageFragmentGuard_ = nullptr;
+    }
+    return;
+  }
+
   for (auto& node : filterGraph.nodes) {
     auto* imageNode = std::get_if<components::filter_primitive::Image>(&node.primitive);
     if (!imageNode || imageNode->fragmentId.empty() || !imageNode->imageData.empty()) {
@@ -2653,10 +2686,13 @@ void RendererDriver::preRenderFeImageFragments(components::FilterGraph& filterGr
     viewport.devicePixelRatio = 1.0;
     offscreen->beginFrame(viewport);
 
-    // Create a sub-driver for offscreen rendering and share the recursion guard.
+    // Create a sub-driver for offscreen rendering and share the recursion guard. The depth is
+    // carried into the sub-driver (one level deeper) so the chain-length cap above accumulates
+    // across the whole nested-fragment recursion, not just within a single driver instance.
     RendererDriver subDriver(*offscreen, verbose_);
     subDriver.renderingSize_ = renderingSize_;
     subDriver.feImageFragmentGuard_ = feImageFragmentGuard_;
+    subDriver.feImageFragmentDepth_ = feImageFragmentDepth_ + 1;
 
     // The fragment is rendered at its natural position in the document coordinate system
     // (no surfaceFromCanvasTransform_ offset). The filter pipeline applies a device-space

--- a/donner/svg/renderer/RendererDriver.h
+++ b/donner/svg/renderer/RendererDriver.h
@@ -248,6 +248,17 @@ private:
   /// instances via pointer.
   std::unordered_set<entt::id_type>* feImageFragmentGuard_ = nullptr;
 
+  /// Nesting depth of the current feImage fragment pre-render. The visited-set above stops a
+  /// *cyclic* reference (A→A, A→B→A) because it keys on the light-tree entity, but a sufficiently
+  /// long *acyclic* chain (filter1→rect3→filter2→rect4→…) still recurses once per link and could
+  /// exhaust the native stack — observed as a segfault on macOS/Metal CI (issue #552), where every
+  /// nested fragment pre-render also stands up a GPU offscreen instance and amplifies per-frame
+  /// stack usage. This counter caps the chain length so an over-deep fragment renders as empty
+  /// (transparent) rather than crashing, matching Donner's never-crash-on-untrusted-input
+  /// invariant. Shared across nested `RendererDriver` instances by copying the parent's value into
+  /// the sub-driver (see `preRenderFeImageFragments`).
+  int feImageFragmentDepth_ = 0;
+
   /// Filter graphs resolved and pre-rendered by \ref prepareFilterGraphs. Keyed by the entity
   /// whose filter produced the graph. Populated in a pre-pass before \ref traverse so the main
   /// traversal never mutates \ref components::RenderingInstanceComponent storage mid-iteration.

--- a/donner/svg/renderer/tests/Renderer_tests.cc
+++ b/donner/svg/renderer/tests/Renderer_tests.cc
@@ -477,5 +477,80 @@ TEST_F(RendererTests, Z0rlyTest6_MusicNotation) {
                           parser::SVGParser::Options());
 }
 
+// Builds a document whose root `<rect>` applies a chain of `<feImage>` fragment
+// references `chainLength` links long: `filter0`→`rect0`→`filter1`→`rect1`→…,
+// each rect (except the terminal one) carrying the *next* filter so the renderer
+// must recurse one fragment pre-render per link. Every link is a *distinct*
+// element, so the existing visited-set recursion guard — which keys on the
+// referenced light-tree entity — cannot collapse the chain; only the
+// fragment-depth cap bounds it.
+std::string MakeChainedFeImageSvg(int chainLength) {
+  std::string svg =
+      R"SVG(<svg id="svg1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"
+              xmlns:xlink="http://www.w3.org/1999/xlink"><defs>)SVG";
+  for (int i = 0; i < chainLength; ++i) {
+    svg += "<filter id=\"filter" + std::to_string(i) +
+           "\" x=\"0\" y=\"0\" width=\"1\" height=\"1\"><feImage xlink:href=\"#rect" +
+           std::to_string(i) + "\"/></filter>";
+    svg += "<rect id=\"rect" + std::to_string(i) +
+           "\" width=\"120\" height=\"120\" fill=\"red\" filter=\"url(#filter" +
+           std::to_string(i + 1) + ")\"/>";
+  }
+  // Terminal filter references a plain rect with no further filter — ends the chain.
+  svg += "<filter id=\"filter" + std::to_string(chainLength) +
+         "\" x=\"0\" y=\"0\" width=\"1\" height=\"1\"><feImage xlink:href=\"#rectEnd\"/></filter>";
+  svg += R"SVG(<rect id="rectEnd" x="40" y="40" width="120" height="120" fill="green"/></defs>
+           <rect id="root" x="20" y="20" width="160" height="160" fill="red"
+                 filter="url(#filter0)"/>
+         </svg>)SVG";
+  return svg;
+}
+
+RendererBitmap RenderSvgString(const std::string& svg) {
+  ParseWarningSink disabled = ParseWarningSink::Disabled();
+  auto maybeResult = parser::SVGParser::ParseSVG(svg, disabled, parser::SVGParser::Options());
+  EXPECT_FALSE(maybeResult.hasError()) << "Parse Error: " << maybeResult.error();
+  if (maybeResult.hasError()) {
+    return RendererBitmap();
+  }
+  SVGDocument document = std::move(maybeResult.result());
+  return RenderDocumentWithBackend(document, ActiveRendererBackend(), /*verbose=*/false);
+}
+
+// Regression for issue #552: a long *acyclic* chain of `<feImage>` fragment
+// references recursed once per link in `RendererDriver::preRenderFeImageFragments`
+// — each level standing up a GPU offscreen instance — with no depth bound. The
+// visited-set guard only stops a *cycle* (it keys on the referenced light-tree
+// entity, which is distinct at every link here), so deep chains recursed
+// unbounded and crashed (`Segmentation fault` on macOS/Metal CI; GPU-resource /
+// stack exhaustion in the nested offscreen renderers).
+//
+// The fix caps the recursion at `kMaxFeImageFragmentDepth` (32); past that, each
+// over-deep fragment renders as empty/transparent. That makes the output
+// invariant to chain length once the chain exceeds the cap: links beyond depth 32
+// cannot influence any pixel. We render two chains that are *both* longer than the
+// cap (40 and 90 links) and require pixel-identical output.
+//
+// On the unbounded (pre-fix) code these two renders recurse to different depths,
+// produce different images (and on the CI host, crash), so this test is red→green.
+// The contract — bounded recursion → chain-length-invariant output — is
+// backend-independent, so it gates both the tiny-skia and Geode variants.
+TEST_F(RendererTests, ChainedFeImageDeepRecursionIsBoundedAndStable) {
+  const RendererBitmap shorterChain = RenderSvgString(MakeChainedFeImageSvg(40));
+  const RendererBitmap longerChain = RenderSvgString(MakeChainedFeImageSvg(90));
+
+  ASSERT_FALSE(shorterChain.pixels.empty())
+      << "Renderer returned an empty bitmap for the 40-link feImage chain";
+  ASSERT_FALSE(longerChain.pixels.empty())
+      << "Renderer returned an empty bitmap for the 90-link feImage chain";
+
+  // Both chains exceed the depth cap, so everything past depth 32 renders empty
+  // and the extra 50 links of the longer chain must not change a single pixel.
+  EXPECT_EQ(shorterChain.dimensions, longerChain.dimensions);
+  EXPECT_EQ(shorterChain.pixels, longerChain.pixels)
+      << "feImage chains of length 40 and 90 produced different images; the recursion is not "
+         "bounded by the depth cap (issue #552)";
+}
+
 }  // namespace
 }  // namespace donner::svg


### PR DESCRIPTION
Closes #552.

`<feImage>` same-document fragment resolution in `RendererDriver::preRenderFeImageFragments` rendered each referenced fragment in its own nested GPU offscreen instance, guarded only by a visited-set keyed on the referenced entity. That stops a *cycle* but not a long *acyclic* chain (`filter1→rect3→filter2→rect4→…`): distinct entities at every link mean the visited-set never trips, so deep chains recursed unbounded — one live offscreen renderer per link. On the GHA virtualized-Metal runner this exhausted GPU/stack resources and segfaulted in `resvg_test_suite_geode` (`FiltersFeImage/chained_feImage`, `link_on_an_element_with_complex_transform`). It does not reproduce on bare Apple Silicon, where the desktop budget survives the ~100-deep nesting.

**Fix:** cap the recursion at `kMaxFeImageFragmentDepth` (32), carried into each nested sub-driver. Past the cap, the over-deep fragment renders as empty/transparent (the path `GeodeFilterEngine::applyImage` already handles) instead of recursing — never crashing on untrusted input. Backend-agnostic, so it protects tiny-skia and Geode alike.

**Regression:** `RendererTests.ChainedFeImageDeepRecursionIsBoundedAndStable` renders 40- and 90-link chains (both > cap) and requires pixel-identical output (once a chain exceeds the cap, deeper links can't affect any pixel). Red at the parent commit, green here, under both backends. resvg `FiltersFeImage/*` (40/40) and the Geode unit/golden suites stay green.

The crash itself is GHA-virtualized-Metal-specific (not reproducible on this machine's GPU), so the test is anchored on the deterministic bounded-recursion *contract* rather than the platform crash — a more robust gate.

**Follow-up (not in this PR):** the sibling `preRenderSvgFeImages` (external-SVG-subdocument feImages) resets depth per sub-document; a chain alternating external-SVG and fragment feImages would re-bound to 32 per sub-document rather than globally. Different reference type, not a known crash — worth a follow-up only if mixed-reference depth becomes a concern.