### PR TITLE
Add SVGAElement so <a> hyperlinks render their text/content children (#622)

### DIFF
--- a/docs/design_docs/0021-resvg_feature_gaps.md
+++ b/docs/design_docs/0021-resvg_feature_gaps.md
@@ -293,7 +293,6 @@ content-placement transform.
 
 | Category | Tests | Gap |
 |---|---:|---|
-| ~~structure/a~~ | ~~3~~ | ✅ Fixed (#622): `<a>` now parses as `SVGAElement`, a transparent grouping/text-content element. |
 | structure/svg | 2 | nested-svg `overflow` |
 | structure/style | 1 | CSS `@import` / external CSS |
 | structure/symbol | 1 | `transform` on `<symbol>` (SVG2) |

--- a/docs/design_docs/0021-resvg_feature_gaps.md
+++ b/docs/design_docs/0021-resvg_feature_gaps.md
@@ -293,7 +293,7 @@ content-placement transform.
 
 | Category | Tests | Gap |
 |---|---:|---|
-| structure/a | 3 | `<a>` hyperlink rendering |
+| ~~structure/a~~ | ~~3~~ | ✅ Fixed (#622): `<a>` now parses as `SVGAElement`, a transparent grouping/text-content element. |
 | structure/svg | 2 | nested-svg `overflow` |
 | structure/style | 1 | CSS `@import` / external CSS |
 | structure/symbol | 1 | `transform` on `<symbol>` (SVG2) |

--- a/donner/svg/AllSVGElements.h
+++ b/donner/svg/AllSVGElements.h
@@ -8,6 +8,7 @@
 
 #include <entt/entity/fwd.hpp>  // entt::type_list
 
+#include "donner/svg/SVGAElement.h"                    // IWYU pragma: export
 #include "donner/svg/SVGCircleElement.h"               // IWYU pragma: export
 #include "donner/svg/SVGClipPathElement.h"             // IWYU pragma: export
 #include "donner/svg/SVGDefsElement.h"                 // IWYU pragma: export
@@ -70,6 +71,7 @@ namespace donner::svg {
  * donner::svg::parser::SVGParser.
  */
 using AllSVGElements = entt::type_list<  //
+    SVGAElement,                         //
     SVGCircleElement,                    //
     SVGClipPathElement,                  //
     SVGDefsElement,                      //

--- a/donner/svg/BUILD.bazel
+++ b/donner/svg/BUILD.bazel
@@ -18,6 +18,7 @@ donner_cc_library(
     name = "svg_core",
     srcs = [
         "DonnerController.cc",
+        "SVGAElement.cc",
         "SVGCircleElement.cc",
         "SVGClipPathElement.cc",
         "SVGDefsElement.cc",
@@ -84,6 +85,7 @@ donner_cc_library(
         "AllSVGElements.h",
         "DocumentState.h",
         "DonnerController.h",
+        "SVGAElement.h",
         "SVGCircleElement.h",
         "SVGClipPathElement.h",
         "SVGDefsElement.h",

--- a/donner/svg/ElementType.cc
+++ b/donner/svg/ElementType.cc
@@ -6,6 +6,7 @@ namespace donner::svg {
 
 std::ostream& operator<<(std::ostream& os, ElementType type) {
   switch (type) {
+    case ElementType::A: return os << "A";
     case ElementType::Circle: return os << "Circle";
     case ElementType::ClipPath: return os << "ClipPath";
     case ElementType::Defs: return os << "Defs";

--- a/donner/svg/ElementType.h
+++ b/donner/svg/ElementType.h
@@ -11,6 +11,7 @@ namespace donner::svg {
  * \ref xml_rect, etc.
  */
 enum class ElementType : uint8_t {
+  A,                    //!< \ref xml_a
   Circle,               //!< \ref xml_circle
   ClipPath,             //!< \ref xml_clipPath
   Defs,                 //!< \ref xml_defs
@@ -103,6 +104,7 @@ std::ostream& operator<<(std::ostream& os, ElementType type);
 template <typename ReturnType, typename FnT>
 ReturnType ToConstexpr(ElementType type, FnT fn) {
   switch (type) {
+    case ElementType::A: return fn(std::integral_constant<ElementType, ElementType::A>());
     case ElementType::Circle: return fn(std::integral_constant<ElementType, ElementType::Circle>());
     case ElementType::ClipPath:
       return fn(std::integral_constant<ElementType, ElementType::ClipPath>());

--- a/donner/svg/SVGAElement.cc
+++ b/donner/svg/SVGAElement.cc
@@ -1,0 +1,36 @@
+#include "donner/svg/SVGAElement.h"
+
+#include "donner/svg/components/HyperlinkComponent.h"
+#include "donner/svg/components/RenderingBehaviorComponent.h"
+
+namespace donner::svg {
+
+SVGAElement SVGAElement::CreateOn(EntityHandle handle) {
+  CreateEntityOn(handle, Tag, Type);
+
+  // `<a>` is a transparent grouping element: outside of text it groups arbitrary graphics like
+  // `<g>`, so it must traverse its children normally (RenderingBehavior::Default). Inside a text
+  // root the renderer never reaches it — the text layout descends through it via the
+  // TextComponent/TextPositioningComponent inherited from SVGTextPositioningElement — so it acts as
+  // a `<tspan>`-style text-content group without needing NoTraverseChildren.
+
+  return SVGAElement(handle);
+}
+
+void SVGAElement::setHref(const std::optional<RcString>& value) {
+  DocumentMutationBatch mutation = handle_.mutationBatch();
+  DocumentWriteAccess& access = mutation.access();
+  handle_.get_or_emplace<components::HyperlinkComponent>(access).href = value ? *value : RcString();
+}
+
+std::optional<RcString> SVGAElement::href() const {
+  if (const auto* component = handle_.try_get<components::HyperlinkComponent>()) {
+    if (!component->href.empty()) {
+      return component->href;
+    }
+  }
+
+  return std::nullopt;
+}
+
+}  // namespace donner::svg

--- a/donner/svg/SVGAElement.h
+++ b/donner/svg/SVGAElement.h
@@ -1,0 +1,97 @@
+#pragma once
+/// @file
+
+#include <optional>
+
+#include "donner/base/RcString.h"
+#include "donner/svg/SVGTextPositioningElement.h"
+
+namespace donner::svg {
+
+/**
+ * @page xml_a "<a>"
+ *
+ * The `<a>` element creates a hyperlink around its child content. It is a transparent grouping
+ * container: it draws nothing of its own and does not establish a new coordinate system, but its
+ * children render in-place exactly as if the `<a>` were not there.
+ *
+ * - DOM object: SVGAElement
+ * - SVG2 spec: https://www.w3.org/TR/SVG2/linking.html#AElement
+ *
+ * Unlike \ref xml_g, `<a>` is allowed both inside and outside of text content. When it appears
+ * inside a \ref xml_text (or \ref xml_tspan) flow it behaves like a \ref xml_tspan — a text-content
+ * group whose text children participate in the surrounding text layout, and which supports the
+ * per-glyph positioning attributes `x`, `y`, `dx`, `dy`, and `rotate`. When it appears outside of
+ * text it behaves like a \ref xml_g, grouping arbitrary graphics elements.
+ *
+ * The link target is given by `href` (or the legacy `xlink:href`). Donner has no interactive
+ * navigation, so the target is parsed and retained but does not affect rendering.
+ *
+ * ```svg
+ * <text x="20" y="40">
+ *   <a href="https://www.w3.org/TR/SVG2/">SVG 2</a>
+ * </text>
+ * ```
+ */
+
+/**
+ * DOM object for a \ref xml_a element.
+ *
+ * `<a>` is a transparent grouping element that wraps its children in a hyperlink. It acts as a
+ * text-content group (like \ref xml_tspan) when nested inside text, and as a general grouping
+ * container (like \ref xml_g) otherwise.
+ *
+ * \see https://www.w3.org/TR/SVG2/linking.html#AElement
+ */
+class SVGAElement : public SVGTextPositioningElement {
+  friend class parser::SVGParserImpl;
+
+private:
+  /// Create an SVGAElement wrapper from an entity.
+  explicit SVGAElement(EntityHandle handle) : SVGTextPositioningElement(handle) {}
+
+  /**
+   * Internal constructor to create the element on an existing \ref Entity.
+   *
+   * @param handle Entity handle.
+   */
+  static SVGAElement CreateOn(EntityHandle handle);
+
+public:
+  /// Element type.
+  static constexpr ElementType Type = ElementType::A;
+  /// XML tag name, \ref xml_a.
+  static constexpr std::string_view Tag{"a"};
+
+  static_assert(SVGTextPositioningElement::IsBaseOf(Type));
+  static_assert(SVGTextContentElement::IsBaseOf(Type));
+  static_assert(SVGGraphicsElement::IsBaseOf(Type));
+
+  /**
+   * Create a new \ref xml_a element.
+   *
+   * @param document Containing document.
+   */
+  static SVGAElement Create(SVGDocument& document) {
+    DocumentMutationBatch mutation = CreateElementMutationBatch(document);
+    DocumentWriteAccess& access = mutation.access();
+    SVGAElement result = CreateOn(CreateEmptyEntity(access));
+    return result;
+  }
+
+  /**
+   * Set the hyperlink target (`href` / `xlink:href`).
+   *
+   * @param value Link target, or \c std::nullopt to clear it.
+   */
+  void setHref(const std::optional<RcString>& value);
+
+  /**
+   * Get the hyperlink target (`href` / `xlink:href`).
+   *
+   * @return Link target, or \c std::nullopt if not set.
+   */
+  std::optional<RcString> href() const;
+};
+
+}  // namespace donner::svg

--- a/donner/svg/SVGDocument.cc
+++ b/donner/svg/SVGDocument.cc
@@ -136,6 +136,9 @@ std::optional<ParseDiagnostic> ApplyNodeValueChanged(std::string_view source,
 }
 
 ElementType ElementTypeForTag(const xml::XMLQualifiedNameRef& tagName) {
+  if (tagName.name == "a") {
+    return ElementType::A;
+  }
   if (tagName.name == "circle") {
     return ElementType::Circle;
   }
@@ -248,7 +251,10 @@ void EnsureProjectedElementComponents(EntityHandle handle,
         components::RenderingBehavior::NoTraverseChildren);
   }
 
-  if (type == ElementType::Text || type == ElementType::TSpan) {
+  if (type == ElementType::A || type == ElementType::Text || type == ElementType::TSpan) {
+    // `<a>` is a transparent text-content group: when nested in text its children participate in
+    // the text layout (like `<tspan>`), so it needs the text components. Unlike `<tspan>` it is
+    // NOT in UsesNoTraverseChildren — outside of text it groups arbitrary graphics like `<g>`.
     [[maybe_unused]] auto& text = handle.get_or_emplace<components::TextComponent>();
     [[maybe_unused]] auto& positioning =
         handle.get_or_emplace<components::TextPositioningComponent>();

--- a/donner/svg/SVGGraphicsElement.h
+++ b/donner/svg/SVGGraphicsElement.h
@@ -25,7 +25,7 @@ protected:
 public:
   /// Returns true if the given element type can be cast to \ref SVGTextContentElement.
   static constexpr bool IsBaseOf(ElementType type) {
-    return type == ElementType::Circle || type == ElementType::Defs ||
+    return type == ElementType::A || type == ElementType::Circle || type == ElementType::Defs ||
            type == ElementType::Ellipse || type == ElementType::G || type == ElementType::Image ||
            type == ElementType::Line || type == ElementType::Path || type == ElementType::Polygon ||
            type == ElementType::Polyline || type == ElementType::Rect || type == ElementType::SVG ||

--- a/donner/svg/SVGTextContentElement.h
+++ b/donner/svg/SVGTextContentElement.h
@@ -51,7 +51,8 @@ protected:
 public:
   /// Returns true if the given element type can be cast to \ref SVGTextContentElement.
   static constexpr bool IsBaseOf(ElementType type) {
-    return type == ElementType::Text || type == ElementType::TextPath || type == ElementType::TSpan;
+    return type == ElementType::A || type == ElementType::Text || type == ElementType::TextPath ||
+           type == ElementType::TSpan;
   }
 
   /**

--- a/donner/svg/SVGTextPositioningElement.h
+++ b/donner/svg/SVGTextPositioningElement.h
@@ -32,7 +32,8 @@ protected:
 public:
   /// Returns true if the given element type can be cast to \ref SVGTextPositioningElement.
   static constexpr bool IsBaseOf(ElementType type) {
-    return type == ElementType::Text || type == ElementType::TextPath || type == ElementType::TSpan;
+    return type == ElementType::A || type == ElementType::Text || type == ElementType::TextPath ||
+           type == ElementType::TSpan;
   }
 
   /**

--- a/donner/svg/components/BUILD.bazel
+++ b/donner/svg/components/BUILD.bazel
@@ -63,6 +63,7 @@ donner_cc_library(
         "DirtyFlagsComponent.h",
         "ElementTypeComponent.h",
         "EvaluatedReferenceComponent.h",
+        "HyperlinkComponent.h",
         "NodeLifetimeCollector.h",
         "PathLengthComponent.h",
         "PreserveAspectRatioComponent.h",

--- a/donner/svg/components/HyperlinkComponent.h
+++ b/donner/svg/components/HyperlinkComponent.h
@@ -1,0 +1,21 @@
+#pragma once
+/// @file
+
+#include "donner/base/RcString.h"
+
+namespace donner::svg::components {
+
+/**
+ * Stores the hyperlink target for an \ref xml_a element.
+ *
+ * The `<a>` element is a transparent grouping/text-content container whose only element-specific
+ * state is the link target (`href` / `xlink:href`). The reference is retained so it round-trips
+ * through the DOM, but it does not affect rendering — Donner has no interactive navigation, so the
+ * link target is purely informational, matching how resvg rasterizes `<a>`.
+ */
+struct HyperlinkComponent {
+  /// Link target, an IRI reference (e.g. "https://example.com/" or "#fragment").
+  RcString href;
+};
+
+}  // namespace donner::svg::components

--- a/donner/svg/compositor/CompositorController.cc
+++ b/donner/svg/compositor/CompositorController.cc
@@ -291,6 +291,7 @@ bool IsNonDrawingContainer(const EntityHandle& dataHandle) {
   }
 
   switch (type->type()) {
+    case ElementType::A:
     case ElementType::Defs:
     case ElementType::G:
     case ElementType::SVG:

--- a/donner/svg/parser/AttributeParser.cc
+++ b/donner/svg/parser/AttributeParser.cc
@@ -1922,6 +1922,92 @@ std::optional<ParseDiagnostic> ParseAttribute<SVGTextElement>(SVGParserContext& 
 }
 
 /**
+ * Parses attributes for \ref xml_a elements.
+ *
+ * `<a>` is a transparent grouping/text-content element. It carries the hyperlink target
+ * (`href` / `xlink:href`) and, as a text-content group, the per-glyph positioning attributes
+ * (`x`, `y`, `dx`, `dy`, `rotate`) plus `textLength` / `lengthAdjust`, mirroring \ref xml_tspan.
+ *
+ * @param context The parser context.
+ * @param element The element to parse.
+ * @param name The name of the attribute to parse.
+ * @param value The value of the attribute to parse.
+ */
+template <>
+std::optional<ParseDiagnostic> ParseAttribute<SVGAElement>(SVGParserContext& context,
+                                                           SVGAElement element,
+                                                           const XMLQualifiedNameRef& name,
+                                                           std::string_view value) {
+  if (name == XMLQualifiedNameRef("href") || name == XMLQualifiedNameRef("xlink", "href")) {
+    element.setHref(RcString(value));
+  } else if (name == XMLQualifiedNameRef("x")) {
+    SmallVector<Lengthd, 1> list;
+    if (auto error = parser::ListParser::Parse(value, [&](std::string_view token) {
+          if (auto length = ParseLengthAttribute(context, token)) {
+            list.push_back(*length);
+          }
+        })) {
+      context.addSubparserWarning(std::move(error.value()), context.parserOriginFrom(value));
+    }
+    element.setXList(std::move(list));
+  } else if (name == XMLQualifiedNameRef("y")) {
+    SmallVector<Lengthd, 1> list;
+    if (auto error = parser::ListParser::Parse(value, [&](std::string_view token) {
+          if (auto length = ParseLengthAttribute(context, token)) {
+            list.push_back(*length);
+          }
+        })) {
+      context.addSubparserWarning(std::move(error.value()), context.parserOriginFrom(value));
+    }
+    element.setYList(std::move(list));
+  } else if (name == XMLQualifiedNameRef("dx")) {
+    SmallVector<Lengthd, 1> list;
+    if (auto error = parser::ListParser::Parse(value, [&](std::string_view token) {
+          if (auto length = ParseLengthAttribute(context, token)) {
+            list.push_back(*length);
+          }
+        })) {
+      context.addSubparserWarning(std::move(error.value()), context.parserOriginFrom(value));
+    }
+    element.setDxList(std::move(list));
+  } else if (name == XMLQualifiedNameRef("dy")) {
+    SmallVector<Lengthd, 1> list;
+    if (auto error = parser::ListParser::Parse(value, [&](std::string_view token) {
+          if (auto length = ParseLengthAttribute(context, token)) {
+            list.push_back(*length);
+          }
+        })) {
+      context.addSubparserWarning(std::move(error.value()), context.parserOriginFrom(value));
+    }
+    element.setDyList(std::move(list));
+  } else if (name == XMLQualifiedNameRef("rotate")) {
+    SmallVector<double, 1> list;
+    if (auto error = parser::ListParser::Parse(value, [&](std::string_view token) {
+          if (auto angleRad = ParseAngleAttribute(context, token)) {
+            list.push_back(*angleRad * MathConstants<double>::kRadToDeg);
+          }
+        })) {
+      context.addSubparserWarning(std::move(error.value()), context.parserOriginFrom(value));
+    }
+    element.setRotateList(std::move(list));
+  } else if (name == XMLQualifiedNameRef("textLength")) {
+    if (auto length = ParseLengthAttribute(context, value)) {
+      element.setTextLength(length);
+    }
+  } else if (name == XMLQualifiedNameRef("lengthAdjust")) {
+    if (value == "spacing") {
+      element.setLengthAdjust(LengthAdjust::Spacing);
+    } else if (value == "spacingAndGlyphs") {
+      element.setLengthAdjust(LengthAdjust::SpacingAndGlyphs);
+    }
+  } else {
+    return ParseCommonAttribute(context, element, name, value);
+  }
+
+  return std::nullopt;
+}
+
+/**
  * Parses attributes for \ref xml_tspan elements.
  *
  * @tparam SVGTSpanElement The type of the element to parse.

--- a/donner/svg/parser/SVGParser.cc
+++ b/donner/svg/parser/SVGParser.cc
@@ -114,6 +114,35 @@ std::optional<ParseDiagnostic> ParseNodeContents<SVGTextElement>(SVGParserContex
 }
 
 /**
+ * Parse text content for \ref xml_a elements.
+ *
+ * `<a>` is a transparent text-content group when nested in text, so its direct text children must
+ * be captured into the text layout (with chunk boundaries around nested elements) exactly like
+ * \ref xml_tspan. Outside of text the captured chunks are inert — the text layout only descends
+ * from a text root — so the same handling is safe for the general-container case.
+ *
+ * @param context The parser context.
+ * @param element The `<a>` element to parse contents for.
+ * @param node The XML node containing the text content.
+ * @return std::nullopt if successful, otherwise a ParseDiagnostic describing the failure.
+ */
+template <>
+std::optional<ParseDiagnostic> ParseNodeContents<SVGAElement>(SVGParserContext& context,
+                                                              SVGAElement element,
+                                                              const XMLNode& node) {
+  for (auto child = node.firstChild(); child; child = child->nextSibling()) {
+    if (child->type() == XMLNode::Type::Data || child->type() == XMLNode::Type::CData) {
+      if (auto maybeValue = child->value()) {
+        element.appendText(maybeValue.value());
+      }
+    } else if (child->type() == XMLNode::Type::Element) {
+      element.advanceTextChunk();
+    }
+  }
+  return std::nullopt;
+}
+
+/**
  * Parse text content for \ref xml_tspan elements.
  *
  * @param context The parser context.

--- a/donner/svg/renderer/RendererDriver.cc
+++ b/donner/svg/renderer/RendererDriver.cc
@@ -129,6 +129,7 @@ bool IsNonDrawingContainer(const EntityHandle& dataHandle) {
   }
 
   switch (type->type()) {
+    case ElementType::A:
     case ElementType::Defs:
     case ElementType::G:
     case ElementType::SVG:

--- a/donner/svg/renderer/tests/resvg_test_suite.cc
+++ b/donner/svg/renderer/tests/resvg_test_suite.cc
@@ -1003,21 +1003,10 @@ INSTANTIATE_TEST_SUITE_P(ShapesRect, ImageComparisonTestFixture,
                                  ValuesIn(ActiveComparisonModes())),
                          TestNameFromFilename);
 
-INSTANTIATE_TEST_SUITE_P(
-    StructureA, ImageComparisonTestFixture,
-    Combine(ValuesIn(getTestsInCategory(
-                "structure/a",
-                {
-                    // `<a>` parses as SVGUnknownElement, so it lacks the TextComponent/
-                    // TextPositioningComponent the text layout descends into — its text
-                    // children are dropped. Needs a real SVGAElement that acts as a text-content
-                    // grouping element (like <tspan>); larger than a renderer-side change.
-                    {"inside-text.svg", Params::Skip("Not impl: <a> as text-content element")},
-                    {"inside-tspan.svg", Params::Skip("Not impl: <a> as text-content element")},
-                    {"on-tspan.svg", Params::Skip("Not impl: <a> as text-content element")},
-                })),
-            ValuesIn(ActiveComparisonModes())),
-    TestNameFromFilename);
+INSTANTIATE_TEST_SUITE_P(StructureA, ImageComparisonTestFixture,
+                         Combine(ValuesIn(getTestsInCategory("structure/a")),
+                                 ValuesIn(ActiveComparisonModes())),
+                         TestNameFromFilename);
 
 INSTANTIATE_TEST_SUITE_P(
     StructureDefs, ImageComparisonTestFixture,

--- a/donner/svg/tests/BUILD.bazel
+++ b/donner/svg/tests/BUILD.bazel
@@ -45,6 +45,7 @@ donner_cc_test(
     srcs = [
         "ElementStyle_tests.cc",
         "ElementType_tests.cc",
+        "SVGAElement_tests.cc",
         "SVGCircleElement_tests.cc",
         "SVGClipPathElement_tests.cc",
         "SVGDefsElement_tests.cc",

--- a/donner/svg/tests/ElementType_tests.cc
+++ b/donner/svg/tests/ElementType_tests.cc
@@ -12,6 +12,7 @@ namespace donner::svg {
 
 /// @test Ostream output \c operator<< for all \ref ElementType values.
 TEST(ElementTypeTest, OstreamOutput) {
+  EXPECT_THAT(ElementType::A, ToStringIs("A"));
   EXPECT_THAT(ElementType::Circle, ToStringIs("Circle"));
   EXPECT_THAT(ElementType::ClipPath, ToStringIs("ClipPath"));
   EXPECT_THAT(ElementType::Defs, ToStringIs("Defs"));

--- a/donner/svg/tests/SVGAElement_tests.cc
+++ b/donner/svg/tests/SVGAElement_tests.cc
@@ -1,0 +1,74 @@
+#include "donner/svg/SVGAElement.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "donner/base/tests/BaseTestUtils.h"
+#include "donner/svg/tests/ParserTestUtils.h"
+
+using testing::Eq;
+using testing::Ne;
+using testing::Optional;
+
+namespace donner::svg {
+
+// Tests for the <a> hyperlink element, which is a transparent grouping/text-content container.
+TEST(SVGAElementTests, CreateAndCast) {
+  auto a = instantiateSubtreeElementAs<SVGAElement>("<a />");
+  EXPECT_THAT(a->tryCast<SVGAElement>(), Ne(std::nullopt));
+  // `<a>` is a text-content group (like <tspan>) so it must cast to the text interfaces, which is
+  // what lets the text layout descend into its children.
+  EXPECT_THAT(a->tryCast<SVGTextPositioningElement>(), Ne(std::nullopt));
+  EXPECT_THAT(a->tryCast<SVGTextContentElement>(), Ne(std::nullopt));
+  // It is also a general grouping element (like <g>).
+  EXPECT_THAT(a->tryCast<SVGGraphicsElement>(), Ne(std::nullopt));
+}
+
+TEST(SVGAElementTests, EnabledWithoutExperimental) {
+  auto a = instantiateSubtreeElement("<a />");
+  EXPECT_THAT(a->tryCast<SVGAElement>(), Ne(std::nullopt));
+}
+
+TEST(SVGAElementTests, HrefDefaultsToNullopt) {
+  auto a = instantiateSubtreeElementAs<SVGAElement>("<a />");
+  EXPECT_THAT(a->href(), Eq(std::nullopt));
+}
+
+TEST(SVGAElementTests, ParsesHref) {
+  auto a = instantiateSubtreeElementAs<SVGAElement>(R"(<a href="https://example.com/" />)");
+  EXPECT_THAT(a->href(), Optional(RcString("https://example.com/")));
+}
+
+TEST(SVGAElementTests, ParsesXlinkHref) {
+  auto a = instantiateSubtreeElementAs<SVGAElement>(
+      R"(<a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#target" />)");
+  EXPECT_THAT(a->href(), Optional(RcString("#target")));
+}
+
+TEST(SVGAElementTests, SetHref) {
+  auto a = instantiateSubtreeElementAs<SVGAElement>("<a />");
+  a->setHref(RcString("#anchor"));
+  EXPECT_THAT(a->href(), Optional(RcString("#anchor")));
+
+  a->setHref(std::nullopt);
+  EXPECT_THAT(a->href(), Eq(std::nullopt));
+}
+
+/// @test `<a>` captures direct text content like <tspan>, so text children participate in layout.
+TEST(SVGAElementTests, TextContentNodes) {
+  auto a = instantiateSubtreeElementAs<SVGAElement>("<a>linked text</a>");
+  EXPECT_THAT(a->textContent(), ToStringIs("linked text"));
+}
+
+/// @test `<a>` supports the per-glyph positioning attributes inherited from <tspan>'s base.
+TEST(SVGAElementTests, PositionAttributes) {
+  auto a =
+      instantiateSubtreeElementAs<SVGAElement>(R"(<a x="1" y="2" dx="3" dy="4" rotate="30" />)");
+  EXPECT_THAT(a->x(), Optional(LengthIs(1.0, Lengthd::Unit::None)));
+  EXPECT_THAT(a->y(), Optional(LengthIs(2.0, Lengthd::Unit::None)));
+  EXPECT_THAT(a->dx(), Optional(LengthIs(3.0, Lengthd::Unit::None)));
+  EXPECT_THAT(a->dy(), Optional(LengthIs(4.0, Lengthd::Unit::None)));
+  EXPECT_THAT(a->rotate(), Optional(testing::DoubleNear(30.0, 1e-6)));
+}
+
+}  // namespace donner::svg


### PR DESCRIPTION
Fixes #622.

`<a>` previously parsed as `SVGUnknownElement`, which lacks the `TextComponent`/`TextPositioningComponent` the text layout descends into — so an `<a>` wrapping text rendered blank.

This adds a real `SVGAElement`, a transparent grouping element that behaves like `<tspan>` for text content (it derives from `SVGTextPositioningElement`, so the text layout descends into its children and it supports `x`/`y`/`dx`/`dy`/`rotate`) and like `<g>` for general content (it keeps `RenderingBehavior::Default` and traverses children). `href`/`xlink:href` is parsed and retained in a new `HyperlinkComponent` but does not affect rendering, matching resvg.

`ElementType::A` is registered across the enum, `ToConstexpr`, the parser type list / attribute+contents parsers, the DOM-projection path (`EnsureProjectedElementComponents`), and the non-drawing-container checks in the renderer driver and compositor.

Un-skips the 3 `structure/a` resvg tests (`inside-text`, `inside-tspan`, `on-tspan`) and adds `SVGAElement` unit tests. Red→green verified by temporarily de-registering the element (all 3 fail blank) vs. with the fix (all pass). Full `bazel test` across parser/svg/renderer/compositor + all resvg variants (default_text, max, geode) is green.