### PR TITLE
Fix transform-origin pivot order on paint-servers (gradient/pattern) (#621)

### DIFF
--- a/docs/design_docs/0021-resvg_feature_gaps.md
+++ b/docs/design_docs/0021-resvg_feature_gaps.md
@@ -94,7 +94,7 @@ bottom for completeness.
 | B2 | `filters/filter-functions` disabled (CI "Data corrupted") | ~30 | CI gap — whole category dark |
 | B3 | `<image>` embedded/data-URL sizing | 13 | Bug — one investigation |
 | B4 | `<use>` → inline `<svg>` sizing | 5 | Bug (shares machinery with B3) |
-| F12 | `transform-origin` on paint-servers / `<image>` / text | 1 left | **on-text/on-image/paint-servers DONE**; only on-text-path remains → ~~[#621](https://github.com/jwmcglynn/donner/issues/621)~~, [#624](https://github.com/jwmcglynn/donner/issues/624) |
+| F12 | `transform-origin` on `<textPath>` baseline | 1 | gradient/pattern/`<image>`/text resolve the pivot; `on-text-path` baseline still drops it → [#624](https://github.com/jwmcglynn/donner/issues/624) |
 | F3 | `context-fill` / `context-stroke` | 13 | Feature |
 | F5 | full `dominant-baseline` keyword set | 14 | Feature |
 | F4 | `<switch>` conditional processing | 12 (+systemLanguage 3) | Feature |
@@ -273,26 +273,21 @@ algorithm + RTL shaping (`text-full`). Group as one workstream.
 
 ### F12: `transform-origin` on paint-servers / `<image>` / text
 
-**Impact:** 7 tests in `structure/transform-origin/` (`on-gradient` ×2, `on-pattern`
-×2, `on-image`, `on-text`, `on-text-path`), kept skipped after the F2 regression fix.
-Only `on-text-path` remains (see [#624](https://github.com/jwmcglynn/donner/issues/624)).
+**Impact:** 1 remaining test in `structure/transform-origin/` (`on-text-path`); the
+`on-gradient` ×2, `on-pattern` ×2, `on-image`, and `on-text` cases pass.
 
-**Paint-servers (gradient/pattern) — DONE (#621).** The renderer *did* apply a
-`transform-origin` pivot, but with the **translations reversed** vs. the shape fix
-(#609): `Translate(origin)·M·Translate(-origin)` instead of
-`Translate(-origin)·M·Translate(origin)`. Donner's `operator*` is left-first, so the
-reversed product pivots about `+origin` instead of `-origin`, pushing a scaled
-gradient's center off the shape — a `scale(2)` radial gradient collapsed to a single
-stop color (solid green) instead of a centered radial fade. Fixed in the three
-transform-resolution sites: `RendererTinySkia::resolveGradientTransform`,
+Gradient/pattern paint-servers and `<image>`/text apply the `transform-origin` pivot
+as `Translate(-origin)·M·Translate(origin)` (matching the shape path; Donner's
+`operator*` is left-first). For paint-servers the pivot is recomputed in the renderers
+from each entity's `ComputedLocalTransformComponent` —
+`RendererTinySkia::resolveGradientTransform`,
 `RendererGeode::resolveGradientTransform`, and the shared pattern transform in
-`RendererDriver` (used by both backends). The `getRawEntityFromParentTransform`
-accessor in `SVGGradientElement.cc` / `SVGPatternElement.cc` is unrelated — the live
-pivot is recomputed in the renderers from the gradient/pattern's
-`ComputedLocalTransformComponent`.
+`RendererDriver` — not via the `getRawEntityFromParentTransform` accessor, which is
+unrelated. For `<image>`/text the layout composes the resolved origin with the
+content-placement transform.
 
-**`<image>` / text — DONE.** The layout computes the correct origin and now composes it
-with the content-placement transform.
+`on-text-path` still renders the baseline path without the pivot, so a rotated
+`<textPath>` samples its glyphs off-screen → [#624](https://github.com/jwmcglynn/donner/issues/624).
 
 ### Smaller feature gaps
 

--- a/docs/design_docs/0021-resvg_feature_gaps.md
+++ b/docs/design_docs/0021-resvg_feature_gaps.md
@@ -94,7 +94,7 @@ bottom for completeness.
 | B2 | `filters/filter-functions` disabled (CI "Data corrupted") | ~30 | CI gap — whole category dark |
 | B3 | `<image>` embedded/data-URL sizing | 13 | Bug — one investigation |
 | B4 | `<use>` → inline `<svg>` sizing | 5 | Bug (shares machinery with B3) |
-| F12 | `transform-origin` on paint-servers / `<image>` / text | 5 (2 gaps) | **on-text/on-image DONE**; paint-servers (gradient/pattern, 4 tests) + on-text-path (1 test) remain → [#621](https://github.com/jwmcglynn/donner/issues/621), [#624](https://github.com/jwmcglynn/donner/issues/624) |
+| F12 | `transform-origin` on paint-servers / `<image>` / text | 1 left | **on-text/on-image/paint-servers DONE**; only on-text-path remains → ~~[#621](https://github.com/jwmcglynn/donner/issues/621)~~, [#624](https://github.com/jwmcglynn/donner/issues/624) |
 | F3 | `context-fill` / `context-stroke` | 13 | Feature |
 | F5 | full `dominant-baseline` keyword set | 14 | Feature |
 | F4 | `<switch>` conditional processing | 12 (+systemLanguage 3) | Feature |
@@ -273,18 +273,26 @@ algorithm + RTL shaping (`text-full`). Group as one workstream.
 
 ### F12: `transform-origin` on paint-servers / `<image>` / text
 
-**Impact:** 5 tests remain skipped in `structure/transform-origin/` (`on-gradient` ×2,
-`on-pattern` ×2, `on-text-path`); `on-image` and `on-text` are now fixed.
+**Impact:** 7 tests in `structure/transform-origin/` (`on-gradient` ×2, `on-pattern`
+×2, `on-image`, `on-text`, `on-text-path`), kept skipped after the F2 regression fix.
+Only `on-text-path` remains (see [#624](https://github.com/jwmcglynn/donner/issues/624)).
 
-**Symptom:** these were *never* green — they are a separate never-implemented gap, not
-the #514 regression. Gradients/patterns route their transform through
-`getRawEntityFromParentTransform` (`SVGGradientElement.cc`, `SVGPatternElement.cc`),
-which intentionally drops the `transform-origin` pivot; for `<image>`/text the layout
-computes the correct origin (verified) but it doesn't compose with the content-placement
-transform, so they render off-screen.
+**Paint-servers (gradient/pattern) — DONE (#621).** The renderer *did* apply a
+`transform-origin` pivot, but with the **translations reversed** vs. the shape fix
+(#609): `Translate(origin)·M·Translate(-origin)` instead of
+`Translate(-origin)·M·Translate(origin)`. Donner's `operator*` is left-first, so the
+reversed product pivots about `+origin` instead of `-origin`, pushing a scaled
+gradient's center off the shape — a `scale(2)` radial gradient collapsed to a single
+stop color (solid green) instead of a centered radial fade. Fixed in the three
+transform-resolution sites: `RendererTinySkia::resolveGradientTransform`,
+`RendererGeode::resolveGradientTransform`, and the shared pattern transform in
+`RendererDriver` (used by both backends). The `getRawEntityFromParentTransform`
+accessor in `SVGGradientElement.cc` / `SVGPatternElement.cc` is unrelated — the live
+pivot is recomputed in the renderers from the gradient/pattern's
+`ComputedLocalTransformComponent`.
 
-**Next step:** thread the resolved origin pivot through the paint-server and
-image/text content transforms (the shape path is now correct after #609 — mirror it).
+**`<image>` / text — DONE.** The layout computes the correct origin and now composes it
+with the content-placement transform.
 
 ### Smaller feature gaps
 

--- a/donner/svg/renderer/RendererDriver.cc
+++ b/donner/svg/renderer/RendererDriver.cc
@@ -2143,9 +2143,12 @@ void RendererDriver::renderPattern(RenderingInstanceView& view, Registry& regist
   Transform2d patternTransform;
   if (maybeTransformComponent) {
     const Vector2d origin = maybeTransformComponent->transformOrigin;
-    patternTransform = Transform2d::Translate(origin) *
+    // Pivot order matches shapes (LayoutSystem::getEntityFromParentTransform, #609):
+    // `Translate(-origin)·M·Translate(origin)` (left-first `operator*`). The reversed order
+    // offsets the pattern tile away from its `transform-origin` pivot (#621).
+    patternTransform = Transform2d::Translate(-origin) *
                        maybeTransformComponent->rawCssTransform.compute(viewBox, FontMetrics()) *
-                       Transform2d::Translate(-origin);
+                       Transform2d::Translate(origin);
   }
 
   const Transform2d patternTileFromTarget = Transform2d::Translate(rect.topLeft) * patternTransform;

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -436,7 +436,10 @@ Transform2d resolveGradientTransform(
   const Vector2d origin = maybeTransformComponent->transformOrigin;
   const Transform2d parentFromEntity =
       maybeTransformComponent->rawCssTransform.compute(viewBox, FontMetrics());
-  return Transform2d::Translate(origin) * parentFromEntity * Transform2d::Translate(-origin);
+  // Pivot order matches shapes (LayoutSystem::getEntityFromParentTransform, #609) and the software
+  // renderer: `Translate(-origin)·M·Translate(origin)` (left-first `operator*`). The reversed order
+  // pushes a scaled gradient's center off the shape, collapsing it to one stop color (#621).
+  return Transform2d::Translate(-origin) * parentFromEntity * Transform2d::Translate(origin);
 }
 
 /// Resolved frame for either kind of gradient: the bounds against which

--- a/donner/svg/renderer/RendererTinySkia.cc
+++ b/donner/svg/renderer/RendererTinySkia.cc
@@ -197,7 +197,12 @@ Transform2d resolveGradientTransform(
   const Vector2d origin = maybeTransformComponent->transformOrigin;
   const Transform2d parentFromEntity =
       maybeTransformComponent->rawCssTransform.compute(viewBox, FontMetrics());
-  return Transform2d::Translate(origin) * parentFromEntity * Transform2d::Translate(-origin);
+  // Apply the `transform-origin` pivot in the same `Translate(-origin)·M·Translate(origin)` order
+  // used for shapes (LayoutSystem::getEntityFromParentTransform, #609). Donner's `operator*` is
+  // left-first (`A * B` applies A, then B), so the pivot-out `Translate(-origin)` must come first
+  // and the pivot-back `Translate(origin)` last. The reversed order pushes the gradient center off
+  // the shape, collapsing scaled radial gradients to a single stop color (#621).
+  return Transform2d::Translate(-origin) * parentFromEntity * Transform2d::Translate(origin);
 }
 
 std::optional<tiny_skia::Shader> instantiateGradientShader(

--- a/donner/svg/renderer/tests/resvg_test_suite.cc
+++ b/donner/svg/renderer/tests/resvg_test_suite.cc
@@ -1256,22 +1256,6 @@ INSTANTIATE_TEST_SUITE_P(
     Combine(ValuesIn(getTestsInCategory(
                 "structure/transform-origin",
                 {
-                    // gradient/pattern transform-origin needs the paint-server coordinate
-                    // transform to compose the pivot; the radial gradient does not even render
-                    // with a scaled gradientTransform here, so this is a deeper paint-server
-                    // transform gap than the shape pivot fix (#609).
-                    {"on-gradient-object-bounding-box.svg",
-                     Params::Skip("transform-origin on gradientTransform: paint-server transform "
-                                  "gap")},
-                    {"on-gradient-user-space-on-use.svg",
-                     Params::Skip("transform-origin on gradientTransform: paint-server transform "
-                                  "gap")},
-                    {"on-pattern-object-bounding-box.svg",
-                     Params::Skip("transform-origin on patternTransform: paint-server transform "
-                                  "gap")},
-                    {"on-pattern-user-space-on-use.svg",
-                     Params::Skip("transform-origin on patternTransform: paint-server transform "
-                                  "gap")},
                     // transform-origin pivot composes for plain text/image now; textPath layout
                     // still drifts (entangled with the textPath SVG2 attribute gap, F10).
                     {"on-text-path.svg",


### PR DESCRIPTION
Fixes #621.

Gradient and pattern `transform-origin` was applied with the two pivot translations reversed relative to the shape fix (#609). Donner's `operator*` is left-first, so the reversed `Translate(origin)·M·Translate(-origin)` product pivots about `+origin` instead of `-origin`, pushing a scaled gradient's center off the shape — a `scale(2)` radial gradient collapsed to a single stop color (solid green) instead of a centered radial fade. (The issue's "deeper coordinate-space gap" hypothesis was a red herring; `getRawEntityFromParentTransform` is unrelated — the live pivot is recomputed in the renderers.)

Corrected the pivot order to `Translate(-origin)·M·Translate(origin)` in all three transform-resolution sites: `RendererTinySkia::resolveGradientTransform`, `RendererGeode::resolveGradientTransform`, and the shared pattern transform in `RendererDriver`.

**Red→green:** `structure/transform-origin` `on-gradient-{object-bounding-box,user-space-on-use}` and `on-pattern-{object-bounding-box,user-space-on-use}` went from FAIL (21728/108008/78408 px diff, solid-green output) to OK across the `default_text`, `max`, and `geode` variants. Un-skip lands on its own commit (red baseline) before the fix. Full `//donner/svg/...` green (327 pass / 10 skipped / 0 fail).