### PR TITLE
Fix rounded-rect marker close-vertex; root-cause stroke-dasharray/n-0 dash seam (#623)

### DIFF
--- a/docs/design_docs/0021-resvg_feature_gaps.md
+++ b/docs/design_docs/0021-resvg_feature_gaps.md
@@ -302,8 +302,22 @@ content-placement transform.
 | masking/mask | 8 | `mask-type`, `mask-units`, `color-interpolation`, mask-on-self |
 | text/font | 2 | `font` shorthand; canvas-size mismatch (test harness) |
 | text/tspan | 3 | tspan interaction with `clip-path`/`filter`/`mask` |
-| painting/stroke-dasharray | 4 | `0 n` dash patterns with caps |
-| painting/marker | 4 | multiple closepaths, rounded-rect corners, recursive-5 |
+| painting/stroke-dasharray | 4 | `0 n` dash patterns with caps; `40 0` closed-rect dash-seam (see note) |
+| painting/marker | 3 | multiple closepaths, recursive-5 (rounded-rect corner fixed, [#623](https://github.com/jwmcglynn/donner/issues/623)) |
+
+**`painting/stroke-dasharray/n-0` (`40 0`)** — root-caused under [#623](https://github.com/jwmcglynn/donner/issues/623)
+and intentionally left skipped: an SVG `<rect>` is a *closed* contour, so tiny-skia
+(the faithful Rust-tiny-skia port) seam-joins the first and last `40`-unit dash across
+the start vertex into one continuous dash, making the start corner an interior MITER.
+resvg's golden butt-caps that corner because usvg flattens the rect to a *non-closed*
+path before dashing. Donner's mitered closed-contour seam is the spec-conformant
+behavior (matches Skia/Chrome/Firefox); the diff is a resvg-pipeline difference, not a
+Donner/tiny-skia bug. Pinned by `RendererTests.DashSeamClosedContourMitersStartCorner`.
+
+**`painting/marker/marker-on-rounded-rect`** — fixed under [#623](https://github.com/jwmcglynn/donner/issues/623):
+`Path::vertices()` now emits the arrival marker-mid at a rounded rect's zero-length-close
+start corner (stacking start + mid + end, matching resvg), while still excluding smooth
+all-curve loops (circle/ellipse).
 | text/writing-mode | ~6 | `writing-mode=tb` with `dx`/`dy`, vertical-lr/rl edge cases |
 
 ---

--- a/donner/base/Path.cc
+++ b/donner/base/Path.cc
@@ -981,6 +981,11 @@ std::vector<Path::Vertex> Path::vertices() const {
   std::vector<Vertex> result;
   std::optional<size_t> openPathCommand;
   bool justMoved = false;
+  // Whether the current subpath contains at least one straight `LineTo` edge. Used to
+  // decide whether a zero-length ClosePath emits an "arrival" marker-mid at the coincident
+  // start vertex (corner contours like a rounded rect do; smooth all-curve loops like a
+  // circle/ellipse do not — see the ClosePath branch).
+  bool subpathHasLine = false;
 
   bool wasInternal = false;
   for (size_t i = 0; i < commands_.size(); ++i) {
@@ -992,6 +997,10 @@ std::vector<Path::Vertex> Path::vertices() const {
     wasInternal = command.isInternal;
     if (shouldSkip) {
       continue;
+    }
+
+    if (command.verb == Verb::LineTo) {
+      subpathHasLine = true;
     }
 
     if (command.verb == Verb::MoveTo) {
@@ -1008,6 +1017,7 @@ std::vector<Path::Vertex> Path::vertices() const {
 
       openPathCommand = i;
       justMoved = true;
+      subpathHasLine = false;
 
     } else if (command.verb == Verb::ClosePath) {
       // If this ClosePath draws a line back to the starting point, place a vertex at the current
@@ -1019,10 +1029,31 @@ std::vector<Path::Vertex> Path::vertices() const {
       const Vector2d startPoint = endPointOfCommand(commands_, points_, i - 1);
       const Vector2d endPoint = endPointOfCommand(commands_, points_, i);
 
-      // Only place a vertex if the ClosePath line has non-zero length.
-      if (!NearZero((startPoint - endPoint).lengthSquared())) {
+      // Place a marker-mid vertex at the join between the last drawing segment and the
+      // closing segment — the point where the final drawing command arrives.
+      //
+      // - Non-zero-length ClosePath (e.g. a sharp rect `M L L L Z`): `startPoint` is the
+      //   distinct vertex before the closing line; the mid orientation bisects the incoming
+      //   tangent and the closing line's direction.
+      // - Zero-length ClosePath where the last segment already lands on the subpath start
+      //   (then `Z`): `startPoint == endPoint == subpath start`. Whether an arrival mid is
+      //   emitted there — stacking with the start and end markers — depends on the contour:
+      //     * Corner contours (a rounded rect: `M L C L C L C L C Z`) DO get the arrival
+      //       mid at the start corner, matching resvg / SVG 2 §11.6.2. Issue #623: dropping
+      //       it left one fewer marker at the rounded-rect start corner.
+      //     * Smooth all-curve loops (a circle/ellipse: `M C C C C Z`) do NOT — resvg places
+      //       only start + end at the seam, so emitting an arrival mid would over-stack.
+      //   `subpathHasLine` distinguishes the two: a contour with straight edges is a corner
+      //   contour, a pure-curve loop is smooth.
+      const bool closeIsZeroLength = NearZero((startPoint - endPoint).lengthSquared());
+      if (!closeIsZeroLength || subpathHasLine) {
         const Vector2d prevTangent = tangentAtEnd(commands_, points_, i - 1).normalize();
-        const Vector2d nextTangent = tangentAtStart(commands_, points_, i).normalize();
+        Vector2d nextTangent = tangentAtStart(commands_, points_, i).normalize();
+        if (NearZero(nextTangent.lengthSquared()) && openPathCommand &&
+            *openPathCommand + 1 < commands_.size()) {
+          // Zero-length closing line: use the subpath's first drawing segment direction.
+          nextTangent = tangentAtStart(commands_, points_, *openPathCommand + 1).normalize();
+        }
 
         const Vector2d orientationStart = InterpolateTangents(prevTangent, nextTangent);
         result.push_back(Vertex{startPoint, orientationStart});

--- a/donner/base/tests/Path_tests.cc
+++ b/donner/base/tests/Path_tests.cc
@@ -1573,6 +1573,72 @@ TEST(Path, VerticesClosedPathDegenerateFirstSegment) {
   EXPECT_NEAR(verts.front().orientation.y, 0.0, 1e-9);
 }
 
+// When a closed subpath's final drawing segment already arrives at the subpath start
+// (so the ClosePath line is zero-length, e.g. a circle, ellipse, or rounded rect built
+// from curves), the arrival point is still a real path vertex and must receive a
+// marker-mid. SVG 2 §11.6.2 places marker-start, that marker-mid, and marker-end all at
+// the coincident vertex (they stack). Issue #623: dropping the mid left one fewer marker
+// at the start corner of a rounded rect (and circle), differing from resvg.
+TEST(Path, VerticesClosedCurveEmitsMidAtCoincidentStart) {
+  // A rounded rect built from curves: the last curve lands on (35,20) = the subpath start,
+  // then a zero-length closePath. The (35,20) vertex must appear *twice* — once as the
+  // marker-mid for the last segment's arrival, once as the marker-end at the subpath start
+  // — in addition to the marker-start emitted from the first segment.
+  Path path =
+      PathBuilder().addRoundedRect(Box2d(Vector2d(20, 20), Vector2d(180, 180)), 15, 15).build();
+  std::vector<Path::Vertex> verts = path.vertices();
+
+  // 8 segment endpoints + the coincident-start mid = 10 vertices total: V0 (marker-start),
+  // V1..V8 (marker-mid), V9 (marker-end). V0, V8, V9 all sit on the start point (35,20).
+  ASSERT_EQ(verts.size(), 10u);
+  EXPECT_EQ(verts.front().point, Vector2d(35, 20));  // marker-start
+  EXPECT_EQ(verts.back().point, Vector2d(35, 20));   // marker-end
+  // The second-to-last vertex is the mid emitted for the last curve's arrival at the start.
+  EXPECT_EQ(verts[verts.size() - 2].point, Vector2d(35, 20));
+
+  // Exactly three vertices coincide with the start point (start + arrival-mid + end).
+  int atStart = 0;
+  for (const auto& v : verts) {
+    if (v.point == Vector2d(35, 20)) {
+      ++atStart;
+    }
+  }
+  EXPECT_EQ(atStart, 3);
+}
+
+// A circle is a smooth all-curve loop (`M C C C C Z`) closed with a zero-length closePath.
+// Unlike the rounded rect, it must NOT gain an arrival marker-mid at the seam — resvg
+// stacks only start + end there. (If this regressed to 3, marker-on-circle over-stacks.)
+TEST(Path, VerticesClosedCircleStacksTwiceAtStart) {
+  Path path = PathBuilder().addCircle(Vector2d(100, 100), 80).build();
+  std::vector<Path::Vertex> verts = path.vertices();
+  // start, 3 mids, end = 5 vertices; start + end coincide at (180,100).
+  ASSERT_EQ(verts.size(), 5u);
+  int atStart = 0;
+  for (const auto& v : verts) {
+    if (v.point == Vector2d(180, 100)) {
+      ++atStart;
+    }
+  }
+  EXPECT_EQ(atStart, 2);  // start + end only — no arrival mid on a smooth loop.
+}
+
+// A sharp rect closes with a non-zero-length line (bottom-left back to top-left), so the
+// arrival mid sits on the distinct bottom-left corner — start and end stack only twice at
+// the top-left. This is the control case that must NOT gain an extra vertex.
+TEST(Path, VerticesSharpRectStartStacksTwice) {
+  Path path = PathBuilder().addRect(Box2d(Vector2d(20, 20), Vector2d(180, 180))).build();
+  std::vector<Path::Vertex> verts = path.vertices();
+  ASSERT_EQ(verts.size(), 5u);  // start, 3 mids, end.
+  int atStart = 0;
+  for (const auto& v : verts) {
+    if (v.point == Vector2d(20, 20)) {
+      ++atStart;
+    }
+  }
+  EXPECT_EQ(atStart, 2);  // start + end only; the close-line mid is the distinct BL corner.
+}
+
 // =============================================================================
 // PathBuilder::arcTo
 // =============================================================================

--- a/donner/svg/renderer/tests/Renderer_tests.cc
+++ b/donner/svg/renderer/tests/Renderer_tests.cc
@@ -552,5 +552,75 @@ TEST_F(RendererTests, ChainedFeImageDeepRecursionIsBoundedAndStable) {
          "bounded by the depth cap (issue #552)";
 }
 
+// Root-cause documentation for issue #623's stroke-dasharray/n-0 residual.
+//
+// The resvg golden draws a *butt-capped* (notched) top-left corner on a `40 0`-dashed closed
+// rect. Donner renders an SVG `<rect>` as a genuinely closed path (`M L L L Z`), and tiny-skia
+// (a line-faithful port of Rust tiny-skia) seam-joins the first and last dash across the start
+// vertex into one continuous dash — so the start corner becomes an interior miter join that
+// fills the outer corner quadrant. This is the spec-conformant closed-dashed-path behavior
+// (Skia / Chrome / Firefox seam-join closed dashed contours); resvg's golden differs because
+// usvg flattens the rect to a non-closed path before dashing.
+//
+// This test pins the difference to closed-vs-open dash seam handling — NOT a rasterizer,
+// coverage, or transform bug — by rendering the same `40 0`-dashed square three ways and
+// measuring green coverage in the outer start-corner quadrant. A `<rect>` and an equivalent
+// closed `<path ... Z>` both miter (fill); only an explicitly open `<path>` butt-caps (empty),
+// reproducing the resvg golden. If a future change makes Donner stop seam-joining closed dashed
+// paths, the rect/closed expectations here trip loudly.
+TEST_F(RendererTests, DashSeamClosedContourMitersStartCorner) {
+  auto renderInner = [&](const std::string& inner) {
+    const std::string svg =
+        "<svg viewBox=\"0 0 200 200\" xmlns=\"http://www.w3.org/2000/svg\">" + inner + "</svg>";
+    ParseWarningSink disabled = ParseWarningSink::Disabled();
+    auto result = parser::SVGParser::ParseSVG(svg, disabled);
+    EXPECT_FALSE(result.hasError()) << result.error();
+    SVGDocument document = std::move(result.result());
+    return RenderDocumentWithBackend(document, RendererBackend::TinySkia, /*verbose=*/false);
+  };
+
+  // The outer top-left quadrant of the (40,40) corner is doc [30,40]x[30,40]; the document
+  // renders at its intrinsic 200x200 (scale 1), so that is px [31,39)^2 (sampled inside the
+  // AA edge band). A full miter fills all 64 sampled pixels; a butt cap leaves them empty.
+  auto greenInOuterCorner = [](const RendererBitmap& bmp) {
+    int count = 0;
+    const std::size_t stride = bmp.rowBytes;
+    for (int y = 31; y < 39; ++y) {
+      for (int x = 31; x < 39; ++x) {
+        const std::size_t i =
+            static_cast<std::size_t>(y) * stride + static_cast<std::size_t>(x) * 4;
+        const uint8_t r = bmp.pixels[i];
+        const uint8_t g = bmp.pixels[i + 1];
+        const uint8_t b = bmp.pixels[i + 2];
+        if (g > 100 && r < 120 && b < 120) {
+          ++count;
+        }
+      }
+    }
+    return count;
+  };
+
+  const std::string attrs =
+      "fill=\"none\" stroke=\"green\" stroke-width=\"20\" stroke-dasharray=\"40 0\"";
+  const RendererBitmap rectEl =
+      renderInner("<rect x=\"40\" y=\"40\" width=\"120\" height=\"120\" " + attrs + "/>");
+  const RendererBitmap closedPath =
+      renderInner("<path d=\"M40,40 L160,40 L160,160 L40,160 Z\" " + attrs + "/>");
+  const RendererBitmap openPath =
+      renderInner("<path d=\"M40,40 L160,40 L160,160 L40,160 L40,40\" " + attrs + "/>");
+
+  ASSERT_FALSE(rectEl.empty());
+  ASSERT_FALSE(closedPath.empty());
+  ASSERT_FALSE(openPath.empty());
+
+  // <rect> is a closed contour -> the dash seam-joins -> mitered start corner (quadrant filled).
+  EXPECT_EQ(greenInOuterCorner(rectEl), 64) << "dashed <rect> should miter its start corner";
+  // An explicit closed <path ... Z> behaves identically.
+  EXPECT_EQ(greenInOuterCorner(closedPath), 64)
+      << "closed <path ... Z> should miter its start corner";
+  // An explicitly open path (no Z) butt-caps the start vertex, like the resvg golden.
+  EXPECT_EQ(greenInOuterCorner(openPath), 0) << "open dashed path should butt-cap its start corner";
+}
+
 }  // namespace
 }  // namespace donner::svg

--- a/donner/svg/renderer/tests/resvg_test_suite.cc
+++ b/donner/svg/renderer/tests/resvg_test_suite.cc
@@ -889,10 +889,20 @@ INSTANTIATE_TEST_SUITE_P(
                     {"negative-values.svg", Params::RenderOnly("UB (negative values)")},
 
                     // `0 N` dash patterns (zero-length dashes -> caps/dots) now render. `40 0`
-                    // (zero gap) still differs by ~625px at the closed-rect dash-start vertex —
-                    // a dasher seam/wrap difference at the first contour segment, not the `0 N`
-                    // gap this entry originally covered.
-                    {"n-0.svg", WithMaxPixels(300, "stroke-dasharray 40 0 seam")},
+                    // (zero gap) differs by ~625px at exactly the closed-rect dash-START corner
+                    // (doc (40,40), the outer top-left stroke quadrant). Root-caused (#623): the
+                    // `<rect>` is a *closed* contour, so tiny-skia (faithful Rust port) seam-joins
+                    // the first and last `40`-unit dash across the start vertex into one continuous
+                    // dash — making that corner an interior MITER (filled quadrant). resvg's golden
+                    // butt-caps it (notched) because usvg flattens the rect to a *non-closed* path
+                    // before dashing. Donner's mitered closed-contour seam is the spec-conformant
+                    // behavior (matches Skia/Chrome/Firefox); the residual is a resvg-pipeline
+                    // (usvg path-normalization) difference, not a Donner/tiny-skia bug. Pinned by
+                    // RendererTests.DashSeamClosedContourMitersStartCorner in Renderer_tests.cc.
+                    {"n-0.svg",
+                     Params::Skip("resvg golden butt-caps the closed-rect dash-start corner; "
+                                  "Donner spec-correctly seam-joins it (usvg flattens rect to an "
+                                  "open path). See DashSeamClosedContourMitersStartCorner.")},
                     // `0 N` round/square caps render as dots on the CPU backend; Geode's dot
                     // rendering for zero-length dashes differs. Compare CPU, disable Geode.
                     {"0-n-with-round-caps.svg", GeodeDisabled("Geode 0-N dash cap rendering gap")},

--- a/donner/svg/renderer/tests/resvg_test_suite.cc
+++ b/donner/svg/renderer/tests/resvg_test_suite.cc
@@ -802,12 +802,11 @@ INSTANTIATE_TEST_SUITE_P(
                 {"with-markerUnits=userSpaceOnUse.svg", WithMaxPixels(300, "Marker clip edge AA")},
                 {"with-viewBox-1.svg", Params::RenderOnly("UB: with `viewBox`")},
 
-                // Marker vertex placement on a rounded rect emits an extra start-vertex
-                // marker vs resvg (~666px = one 20x20 marker). Rounded-rect path
-                // decomposition vertex set, distinct from the multiple-closepath case.
-                {"marker-on-rounded-rect.svg",
-                 Params::Skip("Marker vertex set on rounded-rect path differs (extra start "
-                              "marker)")},
+                // Issue #623: the rounded-rect start corner now stacks marker-start +
+                // arrival marker-mid + marker-end (3 markers), matching resvg, after
+                // Path::vertices() emits the arrival mid for zero-length-close corner
+                // contours. Residual is sub-marker edge coverage.
+                {"marker-on-rounded-rect.svg", WithMaxPixels(60, "Marker stack edge coverage")},
                 {"recursive-5.svg", Params::Skip("Recursive marker rendering edge case (~787px)")},
             })),
         ValuesIn(ActiveComparisonModes())),
@@ -893,7 +892,7 @@ INSTANTIATE_TEST_SUITE_P(
                     // (zero gap) still differs by ~625px at the closed-rect dash-start vertex —
                     // a dasher seam/wrap difference at the first contour segment, not the `0 N`
                     // gap this entry originally covered.
-                    {"n-0.svg", Params::Skip("closed-path dash-start-vertex seam (40 0 pattern)")},
+                    {"n-0.svg", WithMaxPixels(300, "stroke-dasharray 40 0 seam")},
                     // `0 N` round/square caps render as dots on the CPU backend; Geode's dot
                     // rendering for zero-length dashes differs. Compare CPU, disable Geode.
                     {"0-n-with-round-caps.svg", GeodeDisabled("Geode 0-N dash cap rendering gap")},


### PR DESCRIPTION
Resolves the two skipped resvg residuals tracked in #623.

**`painting/marker/marker-on-rounded-rect` (fixed, un-skipped): 666px → 24px.** `Path::vertices()` skipped the arrival marker-mid when a closed subpath ends with a zero-length `ClosePath` whose last segment already lands on the start (rounded rect built from curves). resvg / SVG 2 §11.6.2 stacks marker-start + arrival-mid + marker-end at that coincident start corner; Donner drew only start + end. Now emits the arrival mid for corner contours (those with straight edges) while excluding smooth all-curve loops (circle/ellipse), which resvg stacks only twice. Verified against the reference's alpha stacking (3× vs 2× 0.75 markers). New `Path::vertices` unit tests cover rounded-rect, circle, and sharp-rect closures; `marker-on-circle`/`-rect`/`-polygon`/`-polyline` unchanged-PASS, Geode variant green.

**`painting/stroke-dasharray/n-0` (`40 0`): root-caused, stays skipped.** The ~625px diff is one block at the closed rect's dash-start corner. An SVG `<rect>` is a closed contour, so tiny-skia (a faithful Rust-tiny-skia port — `Dash.cpp` matches `dash.rs` line-for-line) seam-joins the first/last dash across the start vertex into a miter; resvg butt-caps it because usvg flattens the rect to a non-closed path before dashing. Donner's mitered closed-contour seam is the spec-conformant behavior (Skia/Chrome/Firefox all do this); the residual is a resvg-pipeline (usvg) difference, **not a Donner/tiny-skia bug**. Pinned by `RendererTests.DashSeamClosedContourMitersStartCorner` (a dashed `<rect>` and a closed `<path … Z>` both miter the start corner; only an open `<path>` butt-caps it, reproducing the golden). No vendored tiny-skia-cpp source changed.