### PR TITLE
Fix textPath transform-origin pivot; re-triage paint-order/on-tspan (#624)

### DIFF
--- a/donner/svg/components/text/TextSystem.cc
+++ b/donner/svg/components/text/TextSystem.cc
@@ -136,10 +136,23 @@ void resolveTextPath(Registry& registry, const TextPathComponent& textPath,
 
   // Apply the referenced path element's local transform to the path geometry.
   // Per SVG §10.12.2, textPath uses the path in the referenced element's user coordinate space.
+  //
+  // The transform must include the `transform-origin` pivot so the path the text follows lands
+  // in the same place as the path element renders.
+  // `ComputedLocalTransformComponent::parentFromEntity` is the *raw* transform (pivot not applied);
+  // compose the pivot here exactly as LayoutSystem::getEntityFromParentTransform does — `T(-origin)
+  // * M * T(origin)` in Donner's left-first multiplication order. Without this,
+  // `transform="rotate(90)" transform-origin="center"` rotated the baseline path about the origin
+  // instead of its center, sampling glyphs off-screen (issue #624:
+  // structure/transform-origin/on-text-path).
   const auto* localTransform =
       registry.try_get<ComputedLocalTransformComponent>(resolved->handle.entity());
-  if (localTransform && !localTransform->parentFromEntity.isIdentity()) {
-    const Transform2d& parentFromEntity = localTransform->parentFromEntity;
+  const Transform2d parentFromEntity =
+      localTransform ? Transform2d::Translate(-localTransform->transformOrigin) *
+                           localTransform->parentFromEntity *
+                           Transform2d::Translate(localTransform->transformOrigin)
+                     : Transform2d();
+  if (localTransform && !parentFromEntity.isIdentity()) {
     const auto& srcPoints = computedPath->spline.points();
     const auto& srcCommands = computedPath->spline.commands();
     PathBuilder builder;

--- a/donner/svg/components/text/tests/TextSystem_tests.cc
+++ b/donner/svg/components/text/tests/TextSystem_tests.cc
@@ -7,6 +7,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "donner/base/MathUtils.h"
 #include "donner/base/ParseWarningSink.h"
 #include "donner/base/Path.h"
 #include "donner/base/tests/BaseTestUtils.h"
@@ -346,6 +347,48 @@ TEST_F(TextSystemTest, TextPathWithAbsoluteStartOffsetAndTransform) {
   EXPECT_EQ(computed->spans[1].pathSpline->points()[0], Vector2d(5, 7));
   EXPECT_EQ(computed->spans[1].pathSpline->points()[1], Vector2d(105, 7));
   EXPECT_DOUBLE_EQ(computed->spans[1].pathStartOffset, 10.0);
+}
+
+// Issue #624: the textPath baseline geometry must include the referenced path's
+// `transform-origin` pivot, so it lands in the same place the path element renders.
+// A rotate about a non-zero origin must pivot about that origin, not (0,0).
+TEST_F(TextSystemTest, TextPathTransformIncludesTransformOriginPivot) {
+  parser::SVGParser::Options options;
+  options.enableExperimental = true;
+  ParseWarningSink parseSink;
+  auto maybeResult = parser::SVGParser::ParseSVG(R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <defs>
+        <path id="p" d="M 0 0 L 100 0"/>
+      </defs>
+      <text id="t"><textPath href="#p">Pivoted</textPath></text>
+    </svg>
+  )svg",
+                                                 parseSink, options);
+  ASSERT_THAT(maybeResult, NoParseError());
+  auto document = std::move(maybeResult).result();
+
+  Registry& registry = document.registry();
+  auto pathEntity = document.querySelector("#p")->unsafeEntityHandle().entity();
+
+  // rotate(90deg) about the pivot (50, 0): maps (0,0)->(50,-50) and (100,0)->(50,50).
+  // Without the pivot, the same rotation about (0,0) would map (0,0)->(0,0), (100,0)->(0,100).
+  const Transform2d rotate90 = Transform2d::Rotate(MathConstants<double>::kHalfPi);
+  registry.emplace_or_replace<ComputedLocalTransformComponent>(
+      pathEntity, rotate90, CssTransform(rotate90), Vector2d(50, 0));
+  ParseWarningSink warningSink;
+  StyleSystem().computeAllStyles(registry, warningSink);
+  TextSystem().instantiateAllComputedComponents(registry, warningSink);
+
+  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
+  auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
+  ASSERT_NE(computed, nullptr);
+  ASSERT_THAT(computed->spans, SizeIs(2));
+  ASSERT_TRUE(computed->spans[1].pathSpline.has_value());
+
+  // Pivoted result: T(-origin) * rotate90 * T(origin).
+  EXPECT_THAT(computed->spans[1].pathSpline->points()[0], Vector2Near(50.0, -50.0));
+  EXPECT_THAT(computed->spans[1].pathSpline->points()[1], Vector2Near(50.0, 50.0));
 }
 
 TEST_F(TextSystemTest, TextPathUsesSplineOverrideWhenComputedPathMissing) {

--- a/donner/svg/renderer/tests/resvg_test_suite.cc
+++ b/donner/svg/renderer/tests/resvg_test_suite.cc
@@ -836,25 +836,33 @@ INSTANTIATE_TEST_SUITE_P(PaintingOverflow, ImageComparisonTestFixture,
 
 INSTANTIATE_TEST_SUITE_P(
     PaintingPaintOrder, ImageComparisonTestFixture,
-    Combine(ValuesIn(getTestsInCategory(
-                "painting/paint-order",
-                {
-                    // paint-order itself is honored (stroke-under-fill renders correctly); the
-                    // residual diff is tspan-split glyph positioning drift, present even in the
-                    // default-order "Te" run. Tracked under the text/tspan interaction gap.
-                    {"on-tspan.svg", Params::Skip("tspan-split glyph positioning drift, not "
-                                                  "paint-order")},
-                    // paint-order rendering is implemented on the CPU backend only; Geode does not
-                    // honor the fill/stroke/marker reordering yet. Compare CPU, disable Geode.
-                    {"fill-markers-stroke.svg", GeodeDisabled("Geode paint-order rendering gap")},
-                    {"markers-stroke.svg", GeodeDisabled("Geode paint-order rendering gap")},
-                    {"markers.svg", GeodeDisabled("Geode paint-order rendering gap")},
-                    {"stroke-markers-fill.svg", GeodeDisabled("Geode paint-order rendering gap")},
-                    {"stroke-markers.svg", GeodeDisabled("Geode paint-order rendering gap")},
-                    {"stroke.svg", GeodeDisabled("Geode paint-order rendering gap")},
-                    {"on-text.svg", GeodeDisabled("Geode paint-order rendering gap")},
-                })),
-            ValuesIn(ActiveComparisonModes())),
+    Combine(
+        ValuesIn(getTestsInCategory(
+            "painting/paint-order",
+            {
+                // `Te<tspan paint-order="stroke fill">xt</tspan>`. NOT a positioning bug:
+                // the glyph positions are correct (identical to the unsplit on-text.svg, which
+                // passes — cross-tspan kerning keeps "xt" at the same x as "Text"). The ~1968px
+                // residual is a paint-order *layering* difference across the two runs with
+                // different paint-orders: Donner draws run "Te" (default order: fill then
+                // stroke-on-top) fully, then run "xt" (stroke then fill) fully on top, so at the
+                // e/x overlap "x"'s green fill covers "e"'s on-top blue stroke where resvg keeps
+                // the blue (≈1.6k green↔blue edge swaps). resvg layers paint-order across the
+                // whole <text> rather than per-run. Fixing this needs the renderer's text
+                // paint-order passes to span runs, not the text layout. See #624.
+                {"on-tspan.svg",
+                 Params::Skip("paint-order layering across tspan runs (not positioning) — #624")},
+                // paint-order rendering is implemented on the CPU backend only; Geode does not
+                // honor the fill/stroke/marker reordering yet. Compare CPU, disable Geode.
+                {"fill-markers-stroke.svg", GeodeDisabled("Geode paint-order rendering gap")},
+                {"markers-stroke.svg", GeodeDisabled("Geode paint-order rendering gap")},
+                {"markers.svg", GeodeDisabled("Geode paint-order rendering gap")},
+                {"stroke-markers-fill.svg", GeodeDisabled("Geode paint-order rendering gap")},
+                {"stroke-markers.svg", GeodeDisabled("Geode paint-order rendering gap")},
+                {"stroke.svg", GeodeDisabled("Geode paint-order rendering gap")},
+                {"on-text.svg", GeodeDisabled("Geode paint-order rendering gap")},
+            })),
+        ValuesIn(ActiveComparisonModes())),
     TestNameFromFilename);
 
 INSTANTIATE_TEST_SUITE_P(PaintingShapeRendering, ImageComparisonTestFixture,
@@ -1253,16 +1261,8 @@ INSTANTIATE_TEST_SUITE_P(
 
 INSTANTIATE_TEST_SUITE_P(
     StructureTransformOrigin, ImageComparisonTestFixture,
-    Combine(ValuesIn(getTestsInCategory(
-                "structure/transform-origin",
-                {
-                    // transform-origin pivot composes for plain text/image now; textPath layout
-                    // still drifts (entangled with the textPath SVG2 attribute gap, F10).
-                    {"on-text-path.svg",
-                     Params::Skip("transform-origin on textPath: entangled with textPath layout "
-                                  "(F10)")},
-                },
-                Params::WithThreshold(0.13f, 300, "Rotated edge AA"))),
+    Combine(ValuesIn(getTestsInCategory("structure/transform-origin", {},
+                                        Params::WithThreshold(0.13f, 300, "Rotated edge AA"))),
             ValuesIn(ActiveComparisonModes())),
     TestNameFromFilename);
 


### PR DESCRIPTION
Issue #624 grouped two resvg-suite cases as a shared "tspan/textPath positioning" root. They are two unrelated bugs; this PR fixes the tractable one and re-triages the other.

**`structure/transform-origin/on-text-path` — fixed.** `resolveTextPath()` applied the raw `ComputedLocalTransformComponent::parentFromEntity` (transform-origin pivot dropped) to the path the text follows. With `transform="rotate(90)" transform-origin="center"` the baseline path rotated about the origin instead of its center, sampling every glyph off-screen, so the text-on-path was invisible while the `<path>` rendered fine. Compose the pivot `T(-origin)·M·T(origin)`, matching `LayoutSystem::getEntityFromParentTransform`. resvg diff 4981px → 61px; un-skipped. Red→green unit test `TextSystemTest.TextPathTransformIncludesTransformOriginPivot`.

**`painting/paint-order/on-tspan` — re-triaged, stays skipped.** Despite the issue title, this is **not** a positioning bug: the split `Te<tspan>xt</tspan>` glyph positions are identical to the passing unsplit `on-text.svg` (cross-tspan kerning is correct and required by `text/tspan/text-shaping-across-multiple-tspan`). The 1968px residual is a paint-order *layering* difference across two runs with different paint-orders, which needs the renderer's text paint-order passes to span runs rather than execute per-run. Skip note corrected to point at the real cause.

Tests: resvg max/default_text/geode all green; text_system_tests all variants green. (Pre-existing, unrelated editor clipboard/visual-repro test failures in the headless sandbox are not touched by this change.)