### PR TITLE
ci: surgically reset @local_config_cc instead of clean --expunge (faster toolchain fetch)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -81,10 +81,17 @@ jobs:
           persist-credentials: false
 
       - name: Sync Bazel toolchain
+        # Keep this in sync with CI's self-hosted Linux cleanup (main.yml).
+        # Surgically reset ONLY @local_config_cc (stale NixOS include paths)
+        # instead of `bazelisk clean --expunge`, which also wiped the
+        # persistent LLVM toolchain and forced a ~5-minute re-fetch every run.
+        shell: bash
         run: |
-          # Keep this in sync with CI's self-hosted Linux cleanup. The persistent
-          # Bazel output base can retain stale external-repository state.
-          bazelisk clean --expunge
+          set -euo pipefail
+          output_base=$(bazelisk info output_base)
+          bazelisk shutdown
+          find "$output_base/external" -maxdepth 1 -name '*local_config_cc*' \
+            -print -exec rm -rf {} + 2>/dev/null || true
 
       - name: Fetch Bazel LLVM toolchain
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -328,12 +328,21 @@ jobs:
 
       - name: Sync Bazel toolchain
         # NixOS injects include paths via NIX_CFLAGS_COMPILE, which Bazel does
-        # not track in cc_configure's cache key; a stale local_config_cc then
+        # not track in cc_configure's cache key; a stale @local_config_cc then
         # omits them and the hermetic include scanner rejects /nix/store
-        # headers. Reset the Bazel-owned output base through Bazel itself so
-        # external-repository markers and directories stay in sync.
+        # headers. Surgically reset ONLY @local_config_cc so it regenerates
+        # against the current env. This replaces `bazelisk clean --expunge`,
+        # which also wiped the persistent /var/cache/bazel LLVM toolchain and
+        # forced a ~5-minute re-download+re-extract of it on every run.
+        shell: bash
         run: |
-          bazelisk clean --expunge
+          set -euo pipefail
+          output_base=$(bazelisk info output_base)
+          bazelisk shutdown
+          # Match the repo dir + marker under any Bzlmod canonical name
+          # (local_config_cc, ...+local_config_cc, @local_config_cc.marker).
+          find "$output_base/external" -maxdepth 1 -name '*local_config_cc*' \
+            -print -exec rm -rf {} + 2>/dev/null || true
 
       - name: Fetch Bazel LLVM toolchain
         shell: bash


### PR DESCRIPTION
🤖 Stacked on #658 (needs its `--jobs=64` cap so the self-hosted validation run can't re-trigger the RE worker-slot leak).

## Problem
The self-hosted Linux `Sync Bazel toolchain` step runs `bazelisk clean --expunge`, which wipes the entire persistent `/var/cache/bazel` output base — including the extracted LLVM toolchain — so `Fetch Bazel LLVM toolchain` re-downloads + re-extracts it (~5 min) **every run**, defeating the persistent per-runner cache volume.

## Fix
The expunge only existed to clear a stale `@local_config_cc` (NixOS `NIX_CFLAGS_COMPILE` isn't in `cc_configure`'s cache key). Reset **only** that repo so it regenerates against the current env, leaving the LLVM toolchain cached across the ephemeral per-job runners.

Expected: `Fetch Bazel LLVM toolchain` drops from ~5 min to seconds on a warm runner.

## Validation
Watch the `Fetch Bazel LLVM toolchain` step duration on this PR's self-hosted run, and confirm the build stays green (the surgical reset must still fix the /nix/store include-path staleness). If insufficient, fall back to a broader reset.