### PR TITLE
Fix GL replay CI diagnostics

### DIFF
--- a/.github/actions/upload-bazel-test-artifacts/action.yml
+++ b/.github/actions/upload-bazel-test-artifacts/action.yml
@@ -1,0 +1,46 @@
+name: Upload Bazel test artifacts
+description: Collect Bazel test logs and undeclared outputs for failed CI jobs.
+
+inputs:
+  name:
+    description: Artifact name.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Collect Bazel test artifacts
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        output_dir="${RUNNER_TEMP}/bazel-test-artifacts"
+        rm -rf "${output_dir}"
+        mkdir -p "${output_dir}"
+
+        if [[ ! -e bazel-testlogs ]]; then
+          echo "No bazel-testlogs symlink found."
+          exit 0
+        fi
+
+        while IFS= read -r -d '' file; do
+          rel="${file#bazel-testlogs/}"
+          dest="${output_dir}/${rel}"
+          mkdir -p "$(dirname "${dest}")"
+          cp "${file}" "${dest}"
+        done < <(
+          find -L bazel-testlogs \
+            \( -name test.log -o -name test.xml -o -path '*/test.outputs/*' \) \
+            -type f -print0
+        )
+
+        echo "Collected Bazel test artifacts:"
+        find "${output_dir}" -type f -print | sort || true
+
+    - name: Upload Bazel test artifacts
+      uses: actions/upload-artifact@v6
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ runner.temp }}/bazel-test-artifacts
+        if-no-files-found: ignore
+        retention-days: 14

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -311,6 +311,12 @@ jobs:
           bazelisk test --config=ci --test_output=errors \
             $TARGETS
 
+      - name: Upload Bazel test failure artifacts
+        if: failure()
+        uses: ./.github/actions/upload-bazel-test-artifacts
+        with:
+          name: bazel-test-failure-${{ github.job }}-${{ runner.os }}-${{ runner.arch }}
+
 
   # Operator's ARM64 Linux runs on the operator's self-hosted runner.
   # Replaces `linux` for operator runs (extra arch coverage + homelab cache).
@@ -413,6 +419,12 @@ jobs:
           fi)
           bazelisk test --config=ci --config=latest_llvm --test_output=errors $TARGETS
 
+      - name: Upload Bazel test failure artifacts
+        if: failure()
+        uses: ./.github/actions/upload-bazel-test-artifacts
+        with:
+          name: bazel-test-failure-${{ github.job }}-${{ runner.os }}-${{ runner.arch }}
+
 
   macos:
     runs-on: macos-15
@@ -475,6 +487,12 @@ jobs:
         # nightly cron so it doesn't gate every main push. PRs touching
         # fuzzer code re-trigger that workflow via path filter.
 
+      - name: Upload Bazel test failure artifacts
+        if: failure()
+        uses: ./.github/actions/upload-bazel-test-artifacts
+        with:
+          name: bazel-test-failure-${{ github.job }}-${{ runner.os }}-${{ runner.arch }}
+
 
   # Operator's ARM64 macOS runs on the operator's self-hosted runner.
   # Replaces `macos` for operator runs. The host pre-provisions Bazelisk,
@@ -531,3 +549,9 @@ jobs:
         # Fuzzer regression suite runs in `.github/workflows/fuzz.yml` on a
         # nightly cron so it doesn't gate every main push. PRs touching
         # fuzzer code re-trigger that workflow via path filter.
+
+      - name: Upload Bazel test failure artifacts
+        if: failure()
+        uses: ./.github/actions/upload-bazel-test-artifacts
+        with:
+          name: bazel-test-failure-${{ github.job }}-${{ runner.os }}-${{ runner.arch }}

--- a/donner/editor/tests/GlRnrReplay_tests.cc
+++ b/donner/editor/tests/GlRnrReplay_tests.cc
@@ -732,19 +732,21 @@ TEST(GlRnrReplayTest, DrainEachFrameContentCaptureIsDeterministicAcrossPaceAndDe
       std::optional<svg::RendererBitmap> capture = LoadCaptureBitmap(result, 1);
       ASSERT_TRUE(capture.has_value());
       const svg::RendererBitmap normalizedCapture = NormalizeBitmap(*capture);
-      const std::string diagnostics = CanonicalReplayDiagnostics(result);
+      // Frame 0 observes initial async-renderer warm-up and can report a transient stale canvas on
+      // slower software GL hosts. The invariant for this matrix is the explicit capture frame.
+      const std::string captureFrameDiagnostics = CanonicalReplayDiagnostics(result, 1u, 1u);
       const std::string label = std::string("gl_replay_matrix_") + (pace ? "paced" : "unpaced") +
                                 "_delay_" + std::to_string(delayMs);
 
       if (!baselineCapture.has_value()) {
         baselineCapture = normalizedCapture;
-        baselineDiagnostics = diagnostics;
+        baselineDiagnostics = captureFrameDiagnostics;
         continue;
       }
 
       tests::CompareBitmapToBitmap(normalizedCapture, *baselineCapture, label,
                                    tests::PixelmatchIdentityParams());
-      EXPECT_EQ(diagnostics, *baselineDiagnostics) << label;
+      EXPECT_EQ(captureFrameDiagnostics, *baselineDiagnostics) << label;
     }
   }
 


### PR DESCRIPTION
## Summary
- Compare GL replay matrix diagnostics at the explicit capture frame instead of the host-timing-sensitive warm-up frame.
- Upload Bazel test logs, XML, and undeclared outputs when CI Bazel jobs fail.

## Root Cause
The latest `main` CI failure was `//donner/editor/tests:gl_rnr_replay_tests` on Linux, specifically `GlRnrReplayTest.DrainEachFrameContentCaptureIsDeterministicAcrossPaceAndDelay`. The replay bitmap matched exactly, but the test compared frame 0 layer-inspector diagnostics. On slower software GL hosts, frame 0 can legitimately report an initial async renderer commit stall before the explicit capture frame drains and stabilizes.

## Validation
- `bazel --batch --output_user_root=/private/tmp/donner-bazel-codex --nohome_rc test //... --test_output=errors`
- `python3 tools/cmake/gen_cmakelists.py --check`
- Focused GL replay matrix test
- Full `//donner/editor/tests:gl_rnr_replay_tests`
- `git diff --check`
- YAML parse check