### PR TITLE
ci: shard slow tests, minimal remote downloads, per-run diagnostics

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -181,6 +181,17 @@ build --config=libc++ --config=c++20
 # Debug builds
 build:debug -c dbg --copt=-O0 --copt=-g --copt=-fdebug-compilation-dir=. --linkopt=-g --strip=never --apple_generate_dsym --spawn_strategy=standalone
 
+# Compile-time deep dive (see tools/time_trace_report.py). Clang writes a
+# <object>.json trace next to each .o. Those are undeclared outputs, so
+# sandboxing and remote execution would
+# discard them — force standalone local execution and disable the remote
+# cache/executor for this config. Usage:
+#   bazel build --config=time-trace //donner/svg/...
+#   python3 tools/time_trace_report.py
+build:time-trace --copt=-ftime-trace
+build:time-trace --strategy=CppCompile=standalone --spawn_strategy=standalone
+build:time-trace --remote_executor= --remote_cache= --noremote_upload_local_results
+
 # Binary-size builds: optimized for size while preserving debug attribution.
 build:binary-size -c opt --copt=-Os --copt=-g --strip=never
 build:binary-size --copt=-ffunction-sections --copt=-fdata-sections

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -337,8 +337,9 @@ jobs:
       BAZEL_SELF_HOSTED_REMOTE_FALLBACK_FLAGS: "--remote_local_fallback=true --incompatible_remote_local_fallback_for_remote_cache=true --remote_timeout=5s"
       # Every self-hosted run uploads Bazel profiles + BEP + compact execution
       # logs so slow runs can be attributed to targets/actions without live
-      # SSH. Keep artifacts small; retention is 3 days.
-      DIAG_DIR: ${{ runner.temp }}/donner-ci-diagnostics
+      # SSH. Keep artifacts small; retention is 3 days. DIAG_DIR is exported
+      # from the first step ($RUNNER_TEMP; the `runner` context is not
+      # available in job-level env).
       # Build without the Bytes: the runner microvm is a thin RE client on a
       # CPU-capped host. Downloading every toplevel output (unstripped ARM64
       # test binaries) added minutes of pure transfer per run. Tests execute
@@ -355,6 +356,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          DIAG_DIR="$RUNNER_TEMP/donner-ci-diagnostics"
+          echo "DIAG_DIR=$DIAG_DIR" >> "$GITHUB_ENV"
           mkdir -p "$DIAG_DIR"/{fetch,build,test}
           {
             echo "run_id=${{ github.run_id }} attempt=${{ github.run_attempt }} sha=${{ github.sha }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -335,11 +335,37 @@ jobs:
       # that acceleration when it is healthy, but fall back to local execution
       # if the private gRPC endpoint is down.
       BAZEL_SELF_HOSTED_REMOTE_FALLBACK_FLAGS: "--remote_local_fallback=true --incompatible_remote_local_fallback_for_remote_cache=true --remote_timeout=5s"
+      # Every self-hosted run uploads Bazel profiles + BEP + compact execution
+      # logs so slow runs can be attributed to targets/actions without live
+      # SSH. Keep artifacts small; retention is 3 days.
+      DIAG_DIR: ${{ runner.temp }}/donner-ci-diagnostics
+      # Build without the Bytes: the runner microvm is a thin RE client on a
+      # CPU-capped host. Downloading every toplevel output (unstripped ARM64
+      # test binaries) added minutes of pure transfer per run. Tests execute
+      # remotely, so only test logs/XML need to come back.
+      DIAG_BUILD_FLAGS: "--remote_download_outputs=minimal"
+      DIAG_TEST_FLAGS: "--remote_download_outputs=minimal --remote_download_regex=.*(test\\.log|test\\.xml|outputs\\.zip)$"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+
+      - name: Record target selection
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$DIAG_DIR"/{fetch,build,test}
+          {
+            echo "run_id=${{ github.run_id }} attempt=${{ github.run_attempt }} sha=${{ github.sha }}"
+            echo "fallback=${{ needs.determine-targets.outputs.fallback }}"
+          } | tee "$DIAG_DIR/manifest.txt"
+          if [[ "${{ needs.determine-targets.outputs.fallback }}" == "true" ]]; then
+            echo "//..." > "$DIAG_DIR/target-list.txt"
+          else
+            echo "${{ needs.determine-targets.outputs.affected }}" | tr ' ' '\n' > "$DIAG_DIR/target-list.txt"
+          fi
+          echo "target_count=$(grep -c . "$DIAG_DIR/target-list.txt")" | tee -a "$DIAG_DIR/manifest.txt"
 
       - name: Sync Bazel toolchain
         # NixOS injects include paths via NIX_CFLAGS_COMPILE, which Bazel does
@@ -395,7 +421,9 @@ jobs:
             cleanup_partial_llvm_fetch
             fetch_llvm
           fi
-          bazelisk shutdown
+          # NOTE: no `bazelisk shutdown` here. Keeping the server alive lets
+          # Build reuse this invocation's loading/analysis instead of paying
+          # a fresh JVM start + ~30 s re-analysis.
 
       - name: Build
         shell: bash
@@ -406,7 +434,12 @@ jobs:
           else
             echo "${{ needs.determine-targets.outputs.affected }}"
           fi)
-          bazelisk build --config=ci --config=latest_llvm $TARGETS
+          bazelisk build --config=ci --config=latest_llvm \
+            $DIAG_BUILD_FLAGS \
+            --profile="$DIAG_DIR/build/profile.gz" \
+            --build_event_json_file="$DIAG_DIR/build/bep.json" \
+            --execution_log_compact_file="$DIAG_DIR/build/exec.log.zst" \
+            $TARGETS
 
       - name: Test
         shell: bash
@@ -417,7 +450,33 @@ jobs:
           else
             echo "${{ needs.determine-targets.outputs.affected }}"
           fi)
-          bazelisk test --config=ci --config=latest_llvm --test_output=errors $TARGETS
+          bazelisk test --config=ci --config=latest_llvm --test_output=errors \
+            $DIAG_TEST_FLAGS \
+            --profile="$DIAG_DIR/test/profile.gz" \
+            --build_event_json_file="$DIAG_DIR/test/bep.json" \
+            --execution_log_compact_file="$DIAG_DIR/test/exec.log.zst" \
+            $TARGETS
+
+      - name: Summarize diagnostics
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -f tools/ci_diagnostics_report.py && -f "$DIAG_DIR/build/profile.gz" ]]; then
+            python3 tools/ci_diagnostics_report.py "$DIAG_DIR" | tee "$DIAG_DIR/report.md" || true
+            if [[ -s "$DIAG_DIR/report.md" ]]; then
+              cat "$DIAG_DIR/report.md" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          fi
+
+      - name: Upload CI diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-diagnostics-${{ github.job }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/donner-ci-diagnostics/
+          retention-days: 3
+          if-no-files-found: ignore
 
       - name: Upload Bazel test failure artifacts
         if: failure()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ See `docs/design_docs/0016-ci_escape_prevention.md` for the full rationale behin
 ## General Practices
 
 - Prefer existing Donner utilities (`Transform2d`, `RcString`, `StringUtils`) before adding dependencies.
+- **No private-infra references.** Donner is public: never cite the operator's private repos, their design-doc numbers, or personal notes in code, comments, commits, or PRs. State the motivation in self-contained terms instead. See `CLAUDE.md` §"No Private-Infra References".
 - Docs: follow `docs/AGENTS.md`, use templates under `docs/design_docs/`. Run `tools/doxygen.sh` to regenerate.
 - **All code changes should include tests.** Use gMock/gTest. Add fuzzers for parser paths when practical.
 - Fix root causes, not symptoms; include necessary error handling without asking. Mainline must stay green — investigate failures rather than dismissing them as pre-existing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,11 @@
 - **Always prefix AI-generated GitHub comments with 🤖.** This applies to all PR comments, review comments, and issue comments posted by any AI agent (Claude, Codex, Copilot, etc.).
 - This distinguishes human comments from AI comments, since all AI activity goes through `jwmcglynn`'s GitHub account.
 
+## No Private-Infra References
+
+- **Never reference the operator's private infrastructure repos or their design docs in this repository** — not in code, comments, commit messages, PR descriptions, or docs. That includes design-doc numbers (e.g. "design 0018"), repo names like `event-horizon`, private hostnames beyond what CI configs already expose, and personal-notes references (zettelkasten pages, handoff notes).
+- Donner is public. Describe the *reason* for a change in self-contained terms ("CI baseline, 2026-07-01: this test ran ~307 s serially on the self-hosted lane") instead of pointing at a private document.
+
 ## Always-Green Main
 
 - **`main` is always green.** There is no such thing as a "preexisting test failure" — any red test blocks merge, full stop. If something on `main` breaks, the next PR is fixing it, not routing around it.

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -734,7 +734,6 @@ donner_cc_test(
     # but use gtest_timeout_main below so an individual hung replay still fails
     # with the offending test-case name instead of a silent target timeout.
     timeout = "long",
-    env = {"DONNER_TEST_TIMEOUT_SECONDS": "180"},
     srcs = ["GlRnrReplay_tests.cc"],
     data = [
         "drag_start_hang_repro.rnr",
@@ -744,6 +743,11 @@ donner_cc_test(
         "//:donner_splash.svg",
         "//:zoom-out-drag-jump.rnr",
     ],
+    env = {"DONNER_TEST_TIMEOUT_SECONDS": "180"},
+    # 12 independent replay scenarios ran serially at ~307 s total on the
+    # self-hosted RE lane (CI baseline, 2026-07-01). Sharding runs
+    # them as parallel RE actions, cutting the test-step critical path.
+    shard_count = 6,
     target_compatible_with = select({
         "@platforms//os:macos": [],
         "@platforms//os:linux": [],
@@ -751,11 +755,11 @@ donner_cc_test(
     }),
     deps = [
         ":bitmap_golden_compare",
+        "//donner/base:gtest_timeout_main",
         "//donner/editor:editor_app",
         "//donner/editor:imgui_headers",
         "//donner/editor/repro:gl_rnr_replay",
         "//donner/editor/repro:repro_file",
-        "//donner/base:gtest_timeout_main",
         "//donner/svg/renderer",
         "//donner/svg/renderer:renderer_interface",
         "//donner/svg/renderer/tests:renderer_image_test_utils",
@@ -788,6 +792,10 @@ donner_cc_test(
         ":rnr_replay_testdata",
         "//:donner_splash.svg",
     ],
+    # 5 independent replay scenarios ran serially at ~331 s total on the
+    # self-hosted RE lane (CI baseline, 2026-07-01). One shard per
+    # scenario caps the target at its slowest single replay.
+    shard_count = 5,
     deps = [
         ":bitmap_golden_compare",
         "//donner/editor:async_renderer",

--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -213,6 +213,9 @@ donner_cc_test(
     name = "zoom_filter_repro_tests",
     srcs = ["ZoomFilterRepro_tests.cc"],
     data = ["//:donner_splash.svg"],
+    # 4 independent zoom/filter repro scenarios, ~80 s serial on the
+    # self-hosted RE lane (CI baseline, 2026-07-01).
+    shard_count = 4,
     deps = [
         "//donner/svg",
         "//donner/svg/parser",
@@ -528,6 +531,11 @@ donner_variant_cc_test(
             "text_full": "false",
         },
     ],
+    # Hundreds of independent image comparisons per variant. Unsharded, the
+    # geode variant alone ran ~267 s on the self-hosted RE lane
+    # (CI baseline, 2026-07-01) and sat on the test-step critical path. 8 shards
+    # per variant turn that into parallel ~35 s RE actions.
+    shard_count = 8,
 )
 
 donner_cc_test(

--- a/tools/ci_diagnostics_report.py
+++ b/tools/ci_diagnostics_report.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Summarize donner CI diagnostics into a compact markdown report.
+
+Reads the artifact layout produced by the self-hosted CI jobs:
+
+    <diag_dir>/manifest.txt
+    <diag_dir>/target-list.txt
+    <diag_dir>/{build,test}/profile.gz   Bazel --profile (Chrome trace JSON)
+    <diag_dir>/{build,test}/bep.json     Bazel --build_event_json_file
+
+and prints markdown with phase timing, the slowest compile/link/test actions,
+and per-test wall times. Stdlib only; safe to run on partial artifacts (a
+failed build uploads whatever exists).
+
+Usage: python3 tools/ci_diagnostics_report.py <diag_dir>
+"""
+
+import gzip
+import json
+import os
+import sys
+
+TOP_N = 20
+
+
+def load_profile_events(path):
+    """Return the list of Chrome-trace events from a Bazel --profile file."""
+    opener = gzip.open if path.endswith(".gz") else open
+    with opener(path, "rt", encoding="utf-8", errors="replace") as f:
+        data = json.load(f)
+    return data.get("traceEvents", data if isinstance(data, list) else [])
+
+
+def fmt_secs(us):
+    return f"{us / 1e6:.1f}s"
+
+
+def profile_summary(name, path, lines):
+    if not os.path.exists(path):
+        lines.append(f"_No {name} profile captured._")
+        return
+
+    events = load_profile_events(path)
+    complete = [e for e in events if e.get("ph") == "X" and "dur" in e]
+
+    # Bazel emits one span per lifecycle phase under this category.
+    phases = [e for e in complete if e.get("cat") == "build phase marker"]
+    if phases:
+        lines.append(f"**{name} phases:** " + ", ".join(
+            f"{e['name']}={fmt_secs(e['dur'])}"
+            for e in sorted(phases, key=lambda e: e.get("ts", 0))))
+
+    actions = [e for e in complete if e.get("cat") == "action processing"]
+    total_action_us = sum(e["dur"] for e in actions)
+    lines.append(
+        f"**{name}:** {len(actions)} actions, "
+        f"{total_action_us / 1e6:.0f}s total action time")
+
+    def top(title, predicate):
+        rows = sorted((e for e in actions if predicate(e["name"])),
+                      key=lambda e: -e["dur"])[:TOP_N]
+        if not rows:
+            return
+        lines.append("")
+        lines.append(f"**{title} ({name}):**")
+        lines.append("| duration | action |")
+        lines.append("|---:|---|")
+        for e in rows:
+            lines.append(f"| {fmt_secs(e['dur'])} | {e['name']} |")
+
+    top("Slowest compiles", lambda n: n.startswith("Compiling"))
+    top("Slowest links", lambda n: n.startswith(("Linking", "Archiving")))
+    top("Slowest other actions",
+        lambda n: not n.startswith(("Compiling", "Linking", "Archiving",
+                                    "Testing")))
+    lines.append("")
+
+
+def test_summary(path, lines):
+    if not os.path.exists(path):
+        return
+    durations = []
+    with open(path, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            test_id = event.get("id", {}).get("testResult")
+            if not test_id:
+                continue
+            millis = int(
+                event.get("testResult", {}).get("testAttemptDurationMillis", 0)
+                or 0)
+            if not millis:
+                # Bazel >=7 uses testAttemptDuration ("123.4s" proto duration).
+                duration = event.get("testResult", {}).get(
+                    "testAttemptDuration", "0s")
+                try:
+                    millis = int(float(str(duration).rstrip("s")) * 1000)
+                except ValueError:
+                    millis = 0
+            durations.append(
+                (millis, test_id.get("label", "?"), test_id.get("shard", 0)))
+    if not durations:
+        return
+    lines.append(f"**Slowest test executions (top {TOP_N}):**")
+    lines.append("| duration | test | shard |")
+    lines.append("|---:|---|---:|")
+    for millis, label, shard in sorted(durations, reverse=True)[:TOP_N]:
+        lines.append(f"| {millis / 1000:.1f}s | {label} | {shard} |")
+    lines.append("")
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(__doc__, file=sys.stderr)
+        return 1
+    diag_dir = sys.argv[1]
+    lines = ["## CI diagnostics report", ""]
+
+    manifest = os.path.join(diag_dir, "manifest.txt")
+    if os.path.exists(manifest):
+        with open(manifest, encoding="utf-8") as f:
+            lines.append("```")
+            lines.append(f.read().strip())
+            lines.append("```")
+        lines.append("")
+
+    profile_summary("Build", os.path.join(diag_dir, "build", "profile.gz"),
+                    lines)
+    profile_summary("Test", os.path.join(diag_dir, "test", "profile.gz"),
+                    lines)
+    test_summary(os.path.join(diag_dir, "test", "bep.json"), lines)
+
+    print("\n".join(lines))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/time_trace_report.py
+++ b/tools/time_trace_report.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Aggregate Clang -ftime-trace output from a Bazel output tree.
+
+Companion to `--config=time-trace` (see .bazelrc). After
+
+    bazel build --config=time-trace //donner/svg/...
+
+each compiled object has a Chrome-trace JSON next to it under bazel-out.
+This tool aggregates those traces and prints markdown tables of:
+
+  * top translation units by ExecuteCompiler time (frontend vs backend split),
+  * top repeated header/source parse costs (Source events, summed per file),
+  * top template instantiation costs (InstantiateClass/InstantiateFunction),
+  * total time by Clang phase (Frontend / PerformPendingInstantiations /
+    Backend / ...).
+
+Raw traces stay local — only this summary is meant to be persisted. Measure
+first; keep raw trace artifacts out of git.
+
+Usage:
+    python3 tools/time_trace_report.py [--top N] [trace_dir ...]
+
+With no trace_dir arguments, scans bazel-out/*/bin for *_objs/**/*.json.
+"""
+
+import argparse
+import collections
+import glob
+import json
+import os
+import sys
+
+
+def find_trace_files(roots):
+    if roots:
+        for root in roots:
+            yield from glob.iglob(os.path.join(root, "**", "*.json"),
+                                  recursive=True)
+        return
+    for pattern in ("bazel-out/*/bin",):
+        for bin_dir in glob.iglob(pattern):
+            yield from glob.iglob(
+                os.path.join(bin_dir, "**", "_objs", "**", "*.json"),
+                recursive=True)
+
+
+def load_events(path):
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            return json.load(f).get("traceEvents", [])
+    except (json.JSONDecodeError, OSError):
+        return []
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("trace_dirs", nargs="*")
+    parser.add_argument("--top", type=int, default=20)
+    args = parser.parse_args()
+
+    # Per-TU rows: (execute_us, frontend_us, backend_us, tu_name)
+    tu_rows = []
+    # Aggregations across all TUs.
+    source_cost = collections.Counter()  # header/source path -> total us
+    source_count = collections.Counter()  # header/source path -> parse count
+    instantiation_cost = collections.Counter()  # symbol -> total us
+    phase_cost = collections.Counter()  # phase event name -> total us
+
+    trace_files = sorted(set(find_trace_files(args.trace_dirs)))
+    if not trace_files:
+        print("No time-trace JSON files found. Build with "
+              "`--config=time-trace` first.", file=sys.stderr)
+        return 1
+
+    for path in trace_files:
+        events = load_events(path)
+        if not events:
+            continue
+        execute = frontend = backend = 0
+        for e in events:
+            if e.get("ph") != "X":
+                continue
+            name, dur = e.get("name", ""), e.get("dur", 0)
+            detail = e.get("args", {}).get("detail", "")
+            if name == "ExecuteCompiler":
+                execute = max(execute, dur)
+            elif name == "Frontend":
+                frontend += dur
+            elif name == "Backend":
+                backend += dur
+            elif name == "Source" and detail:
+                source_cost[detail] += dur
+                source_count[detail] += 1
+            elif name in ("InstantiateClass", "InstantiateFunction") and detail:
+                instantiation_cost[detail] += dur
+            if name in ("Frontend", "Backend", "Source", "ParseClass",
+                        "InstantiateClass", "InstantiateFunction",
+                        "PerformPendingInstantiations", "CodeGenPasses",
+                        "OptModule"):
+                phase_cost[name] += dur
+        if execute:
+            tu = os.path.relpath(path).replace(".json", ".o")
+            tu_rows.append((execute, frontend, backend, tu))
+
+    print(f"# Clang -ftime-trace summary ({len(tu_rows)} translation units)\n")
+
+    print("## Total time by Clang phase\n")
+    print("| phase | total |")
+    print("|---|---:|")
+    for name, us in phase_cost.most_common():
+        print(f"| {name} | {us / 1e6:.1f}s |")
+
+    print(f"\n## Top {args.top} translation units by ExecuteCompiler\n")
+    print("| total | frontend | backend | object |")
+    print("|---:|---:|---:|---|")
+    for execute, frontend, backend, tu in sorted(tu_rows, reverse=True)[:args.top]:
+        print(f"| {execute / 1e6:.1f}s | {frontend / 1e6:.1f}s "
+              f"| {backend / 1e6:.1f}s | {tu} |")
+
+    print(f"\n## Top {args.top} header/source parse costs (summed over TUs)\n")
+    print("| total | parses | file |")
+    print("|---:|---:|---|")
+    for path, us in source_cost.most_common(args.top):
+        print(f"| {us / 1e6:.1f}s | {source_count[path]} | {path} |")
+
+    print(f"\n## Top {args.top} template instantiations (summed over TUs)\n")
+    print("| total | symbol |")
+    print("|---:|---|")
+    for symbol, us in instantiation_cost.most_common(args.top):
+        symbol = symbol.replace("|", "\\|")
+        print(f"| {us / 1e6:.1f}s | `{symbol}` |")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
🤖 Cuts self-hosted Linux CI wall time by attacking the three measured dominant costs (baseline: 2026-07-01 runs).

## What was slow

| Cost | Evidence |
|---|---|
| Unsharded long tests serialize the test step | `rnr_replay_tests` 331s (5 scenarios), `gl_rnr_replay_tests` 307s (12 scenarios), `resvg_test_suite_geode` 267s, `zoom_filter_repro_tests` 80s |
| Toplevel output downloads to the thin runner | A fully cache-hit `//...` build still took 264s wall with a 64s critical path — ~200s was downloading unstripped arm64 binaries |
| Bazel server restart mid-job | `bazelisk shutdown` after Fetch forced a fresh JVM + ~30s re-analysis in Build |

## Changes

- **Shard slow tests** so the slowest shard sets the critical path: replay suites (5/6 shards), resvg variant wrappers (8), zoom-filter repros (4). All are independent scenario/image-comparison cases; the resvg impl target already shards at 16, the variant wrappers just never inherited it.
- **`--remote_download_outputs=minimal`** for Build and Test on the self-hosted lane; a `--remote_download_regex` keeps `test.log`/`test.xml`/`outputs.zip` so failure artifact upload still works.
- **Keep the Bazel server alive** between Fetch and Build.
- **Always-on diagnostics artifacts** (`ci-diagnostics-*`, 3-day retention): Bazel profile, BEP JSON, compact execution log for Build and Test, plus target-selection manifest and a rendered `report.md` in the step summary (`tools/ci_diagnostics_report.py`).
- **`--config=time-trace`** + `tools/time_trace_report.py` for local per-TU compile-time deep dives (clang `-ftime-trace`; standalone strategy since sandbox/RE drop the undeclared trace JSONs).
- **CLAUDE.md/AGENTS.md**: document the no-private-infra-references rule.

## Notes

- `filter_drag_repro_tests_correctness` (149s) is a *single* test case and cannot shard; it needs its own root-cause pass (tracked separately).
- This PR's own CI run doubles as the first instrumented baseline; expect the diagnostics artifact on this run.