### PR TITLE
Fix compositor generation test nondeterminism

### DIFF
--- a/donner/svg/compositor/CompositorGolden_tests.cc
+++ b/donner/svg/compositor/CompositorGolden_tests.cc
@@ -7,6 +7,8 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <unordered_map>
+#include <unordered_set>
 
 #include "donner/base/ParseWarningSink.h"
 #include "donner/base/Transform.h"
@@ -1214,12 +1216,17 @@ TEST_F(CompositorGoldenTest, SelectionToActiveDragDoesNotAdvanceUnchangedTileGen
   compositor.renderFrame(viewport_);
 
   const auto preDragTiles = compositor.snapshotTilesForUpload();
-  std::unordered_map<uint64_t, uint64_t> preDragGenerations;
+  std::unordered_map<uint64_t, uint64_t> preDragRetainedGenerations;
+  std::unordered_set<uint64_t> preDragImmediateTileIds;
   for (const CompositorTile& tile : preDragTiles) {
     ASSERT_FALSE(tile.bitmap.empty()) << "prewarmed tile " << tile.tileId << " has no pixels";
-    preDragGenerations[tile.tileId] = tile.generation;
+    if (tile.immediate) {
+      preDragImmediateTileIds.insert(tile.tileId);
+      continue;
+    }
+    preDragRetainedGenerations[tile.tileId] = tile.generation;
   }
-  ASSERT_FALSE(preDragGenerations.empty());
+  ASSERT_FALSE(preDragRetainedGenerations.empty());
 
   // Starting an active drag on an already-elevated target changes only presentation geometry: the
   // target's cached pixels are reused through canvasFromBitmap, and unrelated retained
@@ -1241,9 +1248,12 @@ TEST_F(CompositorGoldenTest, SelectionToActiveDragDoesNotAdvanceUnchangedTileGen
     if (tile.immediate) {
       continue;
     }
-    const auto it = preDragGenerations.find(tile.tileId);
-    ASSERT_NE(it, preDragGenerations.end())
-        << "new tile id appeared on drag start: " << tile.tileId;
+    const auto it = preDragRetainedGenerations.find(tile.tileId);
+    if (it == preDragRetainedGenerations.end()) {
+      EXPECT_TRUE(preDragImmediateTileIds.contains(tile.tileId))
+          << "new retained tile id appeared on drag start: " << tile.tileId;
+      continue;
+    }
     EXPECT_EQ(tile.generation, it->second)
         << "tile " << tile.tileId
         << " advanced generation even though drag start changed only presentation geometry";


### PR DESCRIPTION
## Summary

- Update the compositor golden regression test to baseline only retained tile generations before active drag.
- Track baseline-immediate tile IDs separately so timing-dependent immediate spans can later appear as retained tiles without being treated as a cache-generation regression.
- Add explicit standard headers for the unordered containers used by the test.

## Root cause

The failing macOS main CI job asserted that every non-immediate tile after drag start must have the same generation it had during selection prewarm. That incorrectly included tiles that were immediate during the baseline frame. Dynamic immediate static spans are wall-clock dependent by design, so on a slower/shared CI runner an immediate span can demote to a retained cached tile later with a fresh generation. That is not the invariant the test intended to protect.

## Validation

- `bazel test //... --remote_executor= --remote_cache= --remote_upload_local_results=false --noremote_accept_cached` (633 passed, 58 skipped)
- `python3 tools/cmake/gen_cmakelists.py --check`
- `git diff --check`