### PR TITLE
docs: PR merges require explicit operator approval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,8 @@ Stages transform components through the ECS:
 
 ## Pull Request Workflow
 
+**NEVER merge a PR without explicit operator approval.** Agents open, update, monitor, and review PRs — but `gh pr merge` (any flavor) is operator-gated: the operator must approve merging that specific PR in the current conversation. Green CI, passing reviews, or "obviously safe" changes do not substitute for approval.
+
 When creating a pull request:
 
 1. **Rebase on latest `origin/main`** before pushing — `git fetch origin main && git rebase origin/main`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,8 @@
 
 ## Pull Requests
 
-- **Always squash-and-merge** when merging PRs. Use `gh pr merge --squash`.
+- **NEVER merge a PR without explicit operator approval.** AI agents may open, update, and review PRs, but must not run `gh pr merge` (or merge via any other means) unless the operator approved merging that specific PR in the current conversation. Green CI does not constitute approval.
+- **Always squash-and-merge** when merging PRs (post-approval). Use `gh pr merge --squash`.
 - Never use merge commits or rebase-and-merge on this repository.
 
 ## AI Comment Convention


### PR DESCRIPTION
AI agents must never run `gh pr merge` (any flavor) unless the operator approved merging that specific PR in the current conversation. Green CI and passing reviews do not substitute for approval.

Adds the rule to CLAUDE.md §Pull Requests and AGENTS.md §Pull Request Workflow.