### PR TITLE
coverage: cache test results; capture coverage diagnostics

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -228,7 +228,14 @@ build:coverage --action_env=BAZEL_LLVM_COV=llvm-cov
 build:coverage --action_env=BAZEL_LLVM_PROFDATA=llvm-profdata
 
 test:coverage --collect_code_coverage
-test:coverage --nocache_test_results
+# Coverage test results ARE cacheable: a cache-hit test's coverage.dat is part
+# of its cached result, and --experimental_fetch_all_coverage_outputs makes
+# Bazel download it so the combined lcov report stays complete (validated
+# 2026-07-02: two consecutive runs, second fully cached, byte-identical
+# _coverage_report.dat). The previous `--nocache_test_results` (2024-04,
+# pre-remote-cache) forced every coverage run to re-execute every test in
+# scope, which dominated CI coverage wall time.
+test:coverage --experimental_fetch_all_coverage_outputs
 
 # Basic ASAN/UBSAN that works for gcc
 build:asan --config=latest_llvm

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -350,12 +350,15 @@ jobs:
             cleanup_partial_llvm_fetch
             fetch_llvm
           fi
-          bazelisk shutdown
+          # NOTE: no `bazelisk shutdown` — Generate coverage reuses this
+          # server's loading/analysis instead of paying a fresh JVM start.
 
       - name: Generate coverage
         shell: bash
         run: |
           set -euo pipefail
+          export DONNER_CI_DIAGNOSTICS_DIR="$RUNNER_TEMP/donner-ci-diagnostics"
+          echo "DONNER_CI_DIAGNOSTICS_DIR=$DONNER_CI_DIAGNOSTICS_DIR" >> "$GITHUB_ENV"
           read -r -a TARGETS <<< "${{ needs.determine-targets.outputs.targets }}"
           echo "Coverage target selection: fallback=${{ needs.determine-targets.outputs.fallback }} reason=${{ needs.determine-targets.outputs.fallback_reason }} count=${{ needs.determine-targets.outputs.target_count }}"
           tools/coverage.sh --no-html "${TARGETS[@]}"
@@ -367,6 +370,15 @@ jobs:
           path: coverage-report/filtered_report.dat
           if-no-files-found: error
           retention-days: 1
+
+      - name: Upload coverage diagnostics
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: ci-diagnostics-${{ github.job }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/donner-ci-diagnostics/
+          retention-days: 3
+          if-no-files-found: ignore
 
   upload-self-hosted-coverage:
     needs: coverage-self-hosted

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -108,6 +108,24 @@ LLVM_COVERAGE_FLAGS=(
 
   COVERAGE_REPORT=$(bazel info output_path)/_coverage/_coverage_report.dat
 
+  # CI diagnostics: when DONNER_CI_DIAGNOSTICS_DIR is set (self-hosted CI),
+  # capture the inner `bazel coverage` profile + BEP there and record phase
+  # wall times, so slow coverage runs are attributable from artifacts alone.
+  DIAG_FLAGS=()
+  if [ -n "${DONNER_CI_DIAGNOSTICS_DIR:-}" ]; then
+    mkdir -p "$DONNER_CI_DIAGNOSTICS_DIR/coverage"
+    DIAG_FLAGS=(
+      --profile="$DONNER_CI_DIAGNOSTICS_DIR/coverage/profile.gz"
+      --build_event_json_file="$DONNER_CI_DIAGNOSTICS_DIR/coverage/bep.json"
+    )
+  fi
+  phase_mark() {
+    if [ -n "${DONNER_CI_DIAGNOSTICS_DIR:-}" ]; then
+      echo "$1=$(date +%s)" >> "$DONNER_CI_DIAGNOSTICS_DIR/coverage/timing.txt"
+    fi
+  }
+  phase_mark start
+
   # --keep_going is set in .bazelrc for coverage so that analysis failures
   # don't block the rest of the run. Remove any previous combined report so
   # early exits cannot accidentally process stale data.
@@ -118,14 +136,17 @@ LLVM_COVERAGE_FLAGS=(
       "${DEFAULT_BAZEL_COVERAGE_FLAGS[@]}" \
       "${BAZEL_COVERAGE_FLAGS[@]}" \
       "${LLVM_COVERAGE_FLAGS[@]}" \
+      "${DIAG_FLAGS[@]}" \
       "${BAZEL_TEST_ENV[@]}" "${TARGETS[@]}" || true
   else
     bazel coverage --config=latest_llvm \
       "${DEFAULT_BAZEL_COVERAGE_FLAGS[@]}" \
       "${BAZEL_COVERAGE_FLAGS[@]}" \
       "${LLVM_COVERAGE_FLAGS[@]}" \
+      "${DIAG_FLAGS[@]}" \
       "${BAZEL_TEST_ENV[@]}" "${TARGETS[@]}" || true
   fi
+  phase_mark bazel_coverage_done
 
   if [ ! -f "$COVERAGE_REPORT" ]; then
     echo "ERROR: Coverage report was not generated"
@@ -141,6 +162,7 @@ LLVM_COVERAGE_FLAGS=(
   else
     python3 tools/filter_coverage.py --verbose "${FILTER_ARGS[@]}"
   fi
+  phase_mark filter_done
 
   if [ "$NO_HTML" = false ]; then
     if [ "$QUIET" = true ]; then
@@ -149,6 +171,7 @@ LLVM_COVERAGE_FLAGS=(
       genhtml "$COVERAGE_HTML_DIR/filtered_report.dat" $GENHTML_OPTIONS
     fi
   fi
+  phase_mark end
 )
 
 if [ "$NO_HTML" = true ]; then


### PR DESCRIPTION
Cuts coverage wall time by removing the biggest structural cost: `test:coverage --nocache_test_results` forced **every** coverage run to re-execute **every** test in scope, even unchanged ones (and instrumented tests run slower than normal ones).

## Why caching is sound

A cache-hit test's `coverage.dat` is part of its cached result; `--experimental_fetch_all_coverage_outputs` makes Bazel download coverage outputs for cached tests so the combined lcov report stays complete. Validated locally: two consecutive coverage runs of the same targets, second run fully cached (`Executed 0 out of 2 tests`), **byte-identical** `_coverage_report.dat` (same md5, all `SF:` records present).

The flag dates to 2024-04 ("Fix code coverage on mac"), before the remote cache and affected-target selection existed — re-running everything was the safe default then; now it's the dominant coverage cost. With caching, PR coverage re-runs only tests whose actions actually changed.

## Also in this PR

- **Coverage-lane diagnostics**: `tools/coverage.sh` honors `DONNER_CI_DIAGNOSTICS_DIR` (inner `bazel coverage` profile + BEP, phase wall-times for bazel/filter/genhtml), uploaded by `coverage.yml` as `ci-diagnostics-coverage-self-hosted-*` (3-day retention) — same artifact contract as the CI lane.
- **No `bazelisk shutdown` between Fetch and Generate coverage** (reuses the warm server's analysis, same fix as the CI lane).

## Expected effect

Full-fallback coverage baseline was ~8m11s of `Generate coverage`. With warm cache, an ordinary PR's coverage should re-run only affected tests; unchanged-heavy PRs drop to instrumented-compile + report-merge time. This PR's own coverage run is the first measurement (it falls back to full scope since `.bazelrc` changed — worst case, but with cold coverage cache so treat it as the seeding run; the next PR gets the real number).