### PR TITLE
test: use TEST_TMPDIR for editor-control rnr scratch files

### DIFF
--- a/donner/base/BUILD.bazel
+++ b/donner/base/BUILD.bazel
@@ -76,8 +76,11 @@ donner_cc_library(
         "tests/BaseTestUtils.h",
         "tests/ParseResultTestUtils.h",
         "tests/Runfiles.h",
+        "tests/TestTempDir.h",
     ],
-    visibility = donner_internal_visibility(),
+    # //tools tests (MCP servers, build tooling) share the same test-hygiene
+    # helpers (TestTempDir) as //donner tests.
+    visibility = donner_internal_visibility() + ["//tools:__subpackages__"],
     deps = [
         "@com_google_gtest//:gtest",
         "@rules_cc//cc/runfiles",

--- a/donner/base/tests/TestTempDir.h
+++ b/donner/base/tests/TestTempDir.h
@@ -1,0 +1,26 @@
+#pragma once
+/// @file
+
+#include <cstdlib>
+#include <filesystem>
+
+namespace donner {
+
+/**
+ * Bazel's per-test scratch directory (`TEST_TMPDIR`), falling back to the system
+ * temp dir when running outside `bazel test`.
+ *
+ * Use this instead of `std::filesystem::temp_directory_path()` in tests: the
+ * latter resolves to the shared `/tmp` on remote-execution workers (which do not
+ * set `TMPDIR`), so fixed filenames written there collide across users — a file
+ * left by one worker user makes a later run under a different user fail to open
+ * the same path for write.
+ */
+inline std::filesystem::path TestTempDir() {
+  if (const char* testTmpdir = std::getenv("TEST_TMPDIR"); testTmpdir && *testTmpdir) {
+    return std::filesystem::path(testTmpdir);
+  }
+  return std::filesystem::temp_directory_path();
+}
+
+}  // namespace donner

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -90,6 +90,7 @@ donner_cc_test(
     deps = [
         ":bitmap_golden_compare",
         "//donner/base",
+        "//donner/base:base_test_utils",
         "//donner/editor:document_save",
         "//donner/editor:document_sync_controller",
         "//donner/editor:editor_app",
@@ -272,6 +273,7 @@ donner_cc_test(
     srcs = ["RenderPanePresenterVisualRepro_tests.cc"],
     deps = [
         "//donner/base",
+        "//donner/base:base_test_utils",
         "//donner/editor:gl_texture_cache",
         "//donner/editor:imgui_headers",
         "//donner/editor:render_pane_presenter",
@@ -798,6 +800,7 @@ donner_cc_test(
     shard_count = 5,
     deps = [
         ":bitmap_golden_compare",
+        "//donner/base:base_test_utils",
         "//donner/editor:async_renderer",
         "//donner/editor:attribute_writeback",
         "//donner/editor:composited_presentation",

--- a/donner/editor/tests/DocumentSave_tests.cc
+++ b/donner/editor/tests/DocumentSave_tests.cc
@@ -11,6 +11,7 @@
 #include <string>
 #include <string_view>
 
+#include "donner/base/tests/TestTempDir.h"
 #include "donner/editor/DocumentSyncController.h"
 #include "donner/editor/EditorApp.h"
 #include "donner/editor/ImGuiIncludes.h"
@@ -35,7 +36,7 @@ std::filesystem::path TestOutputDir() {
   if (const char* outputDir = std::getenv("TEST_UNDECLARED_OUTPUTS_DIR")) {
     return std::filesystem::path(outputDir);
   }
-  return std::filesystem::temp_directory_path();
+  return TestTempDir();
 }
 
 std::filesystem::path UniqueTestPath(std::string_view suffix) {

--- a/donner/editor/tests/RenderPanePresenterVisualRepro_tests.cc
+++ b/donner/editor/tests/RenderPanePresenterVisualRepro_tests.cc
@@ -9,6 +9,7 @@
 #include <string_view>
 #include <utility>
 
+#include "donner/base/tests/TestTempDir.h"
 #include "donner/editor/ImGuiIncludes.h"
 #include "donner/editor/RenderPanePresenter.h"
 #include "donner/editor/gui/EditorWindow.h"
@@ -114,16 +115,12 @@ svg::RendererBitmap MakeOverlayBitmap() {
 }
 
 std::filesystem::path StableOutputDir() {
-  // A fixed, easy-to-open location for the diagnostic screenshots. Use the
-  // platform temp dir rather than a hardcoded "/private/tmp" so the directory
-  // is writable on Linux CI (which has no "/private") as well as macOS. The
+  // A fixed, easy-to-open location for the diagnostic screenshots. Prefer the
+  // per-test scratch dir (TestTempDir): a fixed directory name in the shared
+  // system temp collides across users on remote-execution workers — a
+  // directory created by one worker user is unwritable for the next. The
   // canonical CI artifacts still land in $TEST_UNDECLARED_OUTPUTS_DIR below.
-  std::error_code error;
-  const std::filesystem::path tempDir = std::filesystem::temp_directory_path(error);
-  if (error) {
-    return std::filesystem::path("donner-display-none-ui-repro");
-  }
-  return tempDir / "donner-display-none-ui-repro";
+  return TestTempDir() / "donner-display-none-ui-repro";
 }
 
 void WriteBitmap(const svg::RendererBitmap& bitmap, const std::filesystem::path& outputPath) {

--- a/donner/editor/tests/RnrReplay_tests.cc
+++ b/donner/editor/tests/RnrReplay_tests.cc
@@ -21,6 +21,7 @@
 
 #include "donner/base/Transform.h"
 #include "donner/base/Vector2.h"
+#include "donner/base/tests/TestTempDir.h"
 #include "donner/editor/AsyncRenderer.h"
 #include "donner/editor/AttributeWriteback.h"
 #include "donner/editor/CompositedPresentation.h"
@@ -82,7 +83,7 @@ std::filesystem::path DiagnosticOutputDir() {
   if (const char* dir = std::getenv("TEST_UNDECLARED_OUTPUTS_DIR"); dir != nullptr) {
     return std::filesystem::path(dir);
   }
-  return std::filesystem::temp_directory_path();
+  return TestTempDir();
 }
 
 std::string LoadFileOrEmpty(const std::filesystem::path& path) {

--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -114,6 +114,7 @@ donner_cc_library(
     deps = [
         ":renderer_image_test_utils",
         ":renderer_test_backend",
+        "//donner/base:base_test_utils",
         "//donner/css:core",
         "//donner/svg/components/resources:resource_manager_context",
         "//donner/svg/parser",

--- a/donner/svg/renderer/tests/ImageComparisonTestFixture.cc
+++ b/donner/svg/renderer/tests/ImageComparisonTestFixture.cc
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "donner/base/ParseWarningSink.h"
+#include "donner/base/tests/TestTempDir.h"
 #include "donner/css/FontFace.h"
 #include "donner/svg/components/resources/ResourceManagerContext.h"
 #include "donner/svg/parser/SVGParser.h"
@@ -361,7 +362,7 @@ std::filesystem::path parityOutputDir() {
   if (const char* dir = std::getenv("TEST_UNDECLARED_OUTPUTS_DIR")) {
     return std::filesystem::path(dir);
   }
-  return std::filesystem::temp_directory_path();
+  return TestTempDir();
 }
 
 std::string escapeFilename(std::string filename) {
@@ -886,12 +887,12 @@ void ImageComparisonTestFixture::renderAndCompare(SVGDocument& document,
               << params.effectiveMaxMismatchedPixels() << " max)\n";
 
     const std::filesystem::path actualImagePath =
-        std::filesystem::temp_directory_path() / escapeFilename(effectiveGoldenFilename);
+        TestTempDir() / escapeFilename(effectiveGoldenFilename);
     RendererImageIO::writeRgbaPixelsToPngFile(actualImagePath.string().c_str(), snapshot.pixels,
                                               width, height, strideInPixels);
 
-    const std::filesystem::path diffFilePath = std::filesystem::temp_directory_path() /
-                                               ("diff_" + escapeFilename(effectiveGoldenFilename));
+    const std::filesystem::path diffFilePath =
+        TestTempDir() / ("diff_" + escapeFilename(effectiveGoldenFilename));
     RendererImageIO::writeRgbaPixelsToPngFile(diffFilePath.string().c_str(), diffImage, width,
                                               height, strideInPixels);
 

--- a/tools/mcp-servers/editor-control/BUILD.bazel
+++ b/tools/mcp-servers/editor-control/BUILD.bazel
@@ -68,6 +68,7 @@ cc_test(
     target_compatible_with = EDITOR_CONTROL_COMPATIBLE_WITH,
     deps = [
         ":editor_control_session",
+        "//donner/base:base_test_utils",
         "//donner/editor/repro:repro_file",
         "@com_google_gtest//:gtest",
         "@com_google_gtest//:gtest_main",

--- a/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
@@ -25,7 +25,7 @@ using ::testing::ElementsAreArray;
 /// resolves to the shared /tmp on remote-execution workers (which do not set
 /// TMPDIR), so fixed filenames written there collide across users: a file left
 /// by one worker user makes a later run under a different user fail to open the
-/// same path for write (observed on the shared macOS RE host, 2026-07-02).
+/// same path for write.
 std::filesystem::path TestTempDir() {
   if (const char* testTmpdir = std::getenv("TEST_TMPDIR"); testTmpdir && *testTmpdir) {
     return std::filesystem::path(testTmpdir);

--- a/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
@@ -1,6 +1,7 @@
 #include "tools/mcp-servers/editor-control/EditorControlSession.h"
 
 #include <cstdint>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <optional>
@@ -18,6 +19,19 @@ namespace {
 
 using nlohmann::json;
 using ::testing::ElementsAreArray;
+
+/// Bazel's per-test scratch directory, falling back to the system temp dir when
+/// running outside `bazel test`. `std::filesystem::temp_directory_path()` alone
+/// resolves to the shared /tmp on remote-execution workers (which do not set
+/// TMPDIR), so fixed filenames written there collide across users: a file left
+/// by one worker user makes a later run under a different user fail to open the
+/// same path for write (observed on the shared macOS RE host, 2026-07-02).
+std::filesystem::path TestTempDir() {
+  if (const char* testTmpdir = std::getenv("TEST_TMPDIR"); testTmpdir && *testTmpdir) {
+    return std::filesystem::path(testTmpdir);
+  }
+  return std::filesystem::temp_directory_path();
+}
 
 constexpr std::string_view kFilteredScene = R"svg(
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 80" width="120" height="80">
@@ -646,7 +660,7 @@ TEST(EditorControlSessionTest,
 }
 
 TEST(EditorControlSessionTest, RecordsAndReplaysRnrFromSelectorDrag) {
-  const std::filesystem::path tempDir = std::filesystem::temp_directory_path();
+  const std::filesystem::path tempDir = TestTempDir();
   const std::filesystem::path svgPath = tempDir / "donner_editor_control_rnr_roundtrip.svg";
   const std::filesystem::path rnrPath = tempDir / "donner_editor_control_rnr_roundtrip.rnr";
   {
@@ -754,7 +768,7 @@ TEST(EditorControlSessionTest, RecordsAndReplaysRnrFromSelectorDrag) {
 }
 
 TEST(EditorControlSessionTest, RecordsInMemoryRnrWithEmbeddedSource) {
-  const std::filesystem::path tempDir = std::filesystem::temp_directory_path();
+  const std::filesystem::path tempDir = TestTempDir();
   const std::filesystem::path rnrPath = tempDir / "donner_editor_control_rnr_memory.rnr";
 
   EditorControlSession session;

--- a/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "donner/base/tests/TestTempDir.h"
 #include "donner/editor/repro/ReproFile.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -20,18 +21,7 @@ namespace {
 using nlohmann::json;
 using ::testing::ElementsAreArray;
 
-/// Bazel's per-test scratch directory, falling back to the system temp dir when
-/// running outside `bazel test`. `std::filesystem::temp_directory_path()` alone
-/// resolves to the shared /tmp on remote-execution workers (which do not set
-/// TMPDIR), so fixed filenames written there collide across users: a file left
-/// by one worker user makes a later run under a different user fail to open the
-/// same path for write.
-std::filesystem::path TestTempDir() {
-  if (const char* testTmpdir = std::getenv("TEST_TMPDIR"); testTmpdir && *testTmpdir) {
-    return std::filesystem::path(testTmpdir);
-  }
-  return std::filesystem::temp_directory_path();
-}
+using donner::TestTempDir;
 
 constexpr std::string_view kFilteredScene = R"svg(
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 80" width="120" height="80">


### PR DESCRIPTION
`EditorControlSession_tests` wrote **fixed filenames** into `std::filesystem::temp_directory_path()`, which on remote-execution workers (no `TMPDIR` set) resolves to the shared `/tmp`. A file left there by one worker user makes later runs under a different user fail to open the same path (sticky bit): `RecordsAndReplaysRnrFromSelectorDrag` failed on the macOS self-hosted lane with `svg.is_open()==false` — `/tmp/donner_editor_control_rnr_roundtrip.svg` was owned by another user.

Fix: prefer `TEST_TMPDIR` (Bazel's per-test scratch, always writable) with a `temp_directory_path()` fallback for non-bazel runs.

**Follow-up (not this PR):** the same pattern exists in `DocumentSave_tests`, `RnrReplay_tests`, `ImageComparisonTestFixture`, and `RenderPanePresenterVisualRepro_tests` — worth a shared `TestTempDir()` helper in `base_test_utils` and a sweep.

**Operator note:** the poisoned files on the shared macOS host need a one-time cleanup (`sudo rm -f /tmp/donner_editor_control_rnr_roundtrip.*`) before reruns of affected jobs go green.