### PR TITLE
ci: cache bazel-diff base hashes keyed by base SHA

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -67,6 +67,24 @@ jobs:
         if: github.event_name == 'pull_request'
         run: curl -fsSL -o "$RUNNER_TEMP/bazel-diff.jar" "https://github.com/Tinder/bazel-diff/releases/download/${BAZEL_DIFF_TAG}/bazel-diff_deploy.jar"
 
+      - id: pr-meta
+        name: Extract PR base SHA for hash caching
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "base_sha=$(python3 -c 'import json, os; print(json.load(open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8")).get("pull_request", {}).get("base", {}).get("sha", ""))')" >> "$GITHUB_OUTPUT"
+
+      # Shares the cache convention (and main-push pre-warm) with main.yml's
+      # determine-targets: base hashes are keyed by (bazel-diff version,
+      # base SHA) and skip half the bazel-diff work on a hit.
+      - name: Cache bazel-diff base hashes
+        if: github.event_name == 'pull_request' && steps.pr-meta.outputs.base_sha != ''
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/bazel-diff-base-hashes/${{ steps.pr-meta.outputs.base_sha }}.json
+          key: bazel-diff-base-hashes-${{ env.BAZEL_DIFF_TAG }}-${{ steps.pr-meta.outputs.base_sha }}
+
       - id: determine
         name: Determine coverage targets
         shell: bash
@@ -174,24 +192,35 @@ jobs:
           }
           trap cleanup EXIT
 
-          if ! git worktree add --detach "$base_dir" "$BASE_SHA"; then
-            echo "Failed to check out PR base; using full coverage target set."
-            emit_targets true base_checkout_failed "$FULL_COVERAGE_TARGETS"
-            exit 0
-          fi
           if ! git worktree add --detach "$head_dir" "$HEAD_SHA"; then
             echo "Failed to check out PR head; using full coverage target set."
             emit_targets true head_checkout_failed "$FULL_COVERAGE_TARGETS"
             exit 0
           fi
 
-          if ! java -jar "$RUNNER_TEMP/bazel-diff.jar" generate-hashes \
-            -w "$base_dir" \
-            -b bazelisk \
-            "$work_dir/base-hashes.json"; then
-            echo "bazel-diff failed while hashing base; using full coverage target set."
-            emit_targets true base_hash_failed "$FULL_COVERAGE_TARGETS"
-            exit 0
+          cached_base="$HOME/.cache/bazel-diff-base-hashes/$BASE_SHA.json"
+          if [[ -s "$cached_base" ]]; then
+            echo "Using cached bazel-diff base hashes for $BASE_SHA."
+            cp "$cached_base" "$work_dir/base-hashes.json"
+          else
+            if ! git worktree add --detach "$base_dir" "$BASE_SHA"; then
+              echo "Failed to check out PR base; using full coverage target set."
+              emit_targets true base_checkout_failed "$FULL_COVERAGE_TARGETS"
+              exit 0
+            fi
+
+            if ! java -jar "$RUNNER_TEMP/bazel-diff.jar" generate-hashes \
+              -w "$base_dir" \
+              -b bazelisk \
+              "$work_dir/base-hashes.json"; then
+              echo "bazel-diff failed while hashing base; using full coverage target set."
+              emit_targets true base_hash_failed "$FULL_COVERAGE_TARGETS"
+              exit 0
+            fi
+
+            # Save for subsequent pushes to this PR (post-job cache step).
+            mkdir -p "$(dirname "$cached_base")"
+            cp "$work_dir/base-hashes.json" "$cached_base"
           fi
 
           if ! java -jar "$RUNNER_TEMP/bazel-diff.jar" generate-hashes \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,6 +154,32 @@ jobs:
       - name: Download bazel-diff
         run: curl -fsSL -o "$RUNNER_TEMP/bazel-diff.jar" "https://github.com/Tinder/bazel-diff/releases/download/${BAZEL_DIFF_TAG}/bazel-diff_deploy.jar"
 
+      - id: pr-meta
+        name: Extract SHA for hash caching
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_sha=""
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base_sha="$(python3 -c 'import json, os; print(json.load(open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8")).get("pull_request", {}).get("base", {}).get("sha", ""))')"
+          elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            # Pre-warm the cache for future PRs whose base is this main commit.
+            base_sha="${{ github.sha }}"
+          fi
+          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+
+      # Base hashes are a pure function of (bazel-diff version, base SHA), and
+      # generating them is roughly half of this job's bazel-diff wall time.
+      # PRs restore them here; pushes to main generate and save them below so
+      # the first PR against any main commit already hits warm. Caches created
+      # on main are visible to all PR branches.
+      - name: Cache bazel-diff base hashes
+        if: steps.pr-meta.outputs.base_sha != ''
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/bazel-diff-base-hashes/${{ steps.pr-meta.outputs.base_sha }}.json
+          key: bazel-diff-base-hashes-${{ env.BAZEL_DIFF_TAG }}-${{ steps.pr-meta.outputs.base_sha }}
+
       - id: determine
         name: Determine affected Bazel targets
         shell: bash
@@ -164,6 +190,18 @@ jobs:
             echo "Non-PR event; keeping full //... coverage."
             echo "fallback=true" >> "$GITHUB_OUTPUT"
             echo "affected=" >> "$GITHUB_OUTPUT"
+
+            if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+              cached="$HOME/.cache/bazel-diff-base-hashes/${{ github.sha }}.json"
+              if [[ ! -f "$cached" ]]; then
+                echo "Pre-warming bazel-diff hash cache for ${{ github.sha }}."
+                mkdir -p "$(dirname "$cached")"
+                java -jar "$RUNNER_TEMP/bazel-diff.jar" generate-hashes \
+                  -w "$GITHUB_WORKSPACE" \
+                  -b bazelisk \
+                  "$cached" || rm -f "$cached"
+              fi
+            fi
             exit 0
           fi
 
@@ -222,13 +260,22 @@ jobs:
           }
           trap cleanup EXIT
 
-          git worktree add --detach "$base_dir" "$BASE_SHA"
           git worktree add --detach "$head_dir" "$HEAD_SHA"
 
-          java -jar "$RUNNER_TEMP/bazel-diff.jar" generate-hashes \
-            -w "$base_dir" \
-            -b bazelisk \
-            "$work_dir/base-hashes.json"
+          cached_base="$HOME/.cache/bazel-diff-base-hashes/$BASE_SHA.json"
+          if [[ -s "$cached_base" ]]; then
+            echo "Using cached bazel-diff base hashes for $BASE_SHA."
+            cp "$cached_base" "$work_dir/base-hashes.json"
+          else
+            git worktree add --detach "$base_dir" "$BASE_SHA"
+            java -jar "$RUNNER_TEMP/bazel-diff.jar" generate-hashes \
+              -w "$base_dir" \
+              -b bazelisk \
+              "$work_dir/base-hashes.json"
+            # Save for subsequent pushes to this PR (post-job cache step).
+            mkdir -p "$(dirname "$cached_base")"
+            cp "$work_dir/base-hashes.json" "$cached_base"
+          fi
 
           java -jar "$RUNNER_TEMP/bazel-diff.jar" generate-hashes \
             -w "$head_dir" \


### PR DESCRIPTION
`determine-targets` runs `bazel-diff generate-hashes` twice per PR (base + head) — roughly half of its 45–60s wall time, all of it serial before any self-hosted runner starts. Base hashes are a pure function of (bazel-diff version, base SHA), so:

- **PR runs** restore `~/.cache/bazel-diff-base-hashes/<base_sha>.json` via `actions/cache` and skip the base worktree + hash generation entirely on a hit; on a miss they generate and save (warming subsequent pushes to the same PR).
- **Main pushes pre-warm** the cache for their own SHA (main-scope caches are visible to all PR branches), so the first PR against any main commit already hits.

Same key convention in `main.yml` and `coverage.yml`, so one pre-warm serves both determinators.

Expected effect: determine-targets drops ~15–25s on every PR run — straight off the serial critical path ahead of the runner jobs. Failure behavior is unchanged: cache miss or unreadable file falls back to generating hashes exactly as today.