### PR TITLE
ci: rule-only bazel-diff targets; sane coverage remote_timeout

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -322,9 +322,15 @@ jobs:
     if: ${{ github.ref != 'refs/heads/main' && vars.SELFHOSTED_LINUX_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
     env:
       # The runner host may add the LAN Bazel cache from its home rc. Keep
-      # coverage resilient when the private gRPC endpoint is down.
-      BAZEL_SELF_HOSTED_REMOTE_FALLBACK_FLAGS: "--remote_local_fallback=true --incompatible_remote_local_fallback_for_remote_cache=true --remote_timeout=5s"
-      DONNER_COVERAGE_BAZEL_FLAGS: "--remote_local_fallback=true --incompatible_remote_local_fallback_for_remote_cache=true --remote_timeout=5s"
+      # coverage resilient when the private gRPC endpoint is down
+      # (remote_local_fallback), but do NOT use an aggressive call deadline:
+      # --remote_timeout applies to every remote call, and a healthy-but-busy
+      # RE endpoint can legitimately take >5s to accept large coverage
+      # uploads under a multi-job burst (observed 2026-07-02 as
+      # DEADLINE_EXCEEDED upload failures). 60s fails fast enough on a dead
+      # endpoint while tolerating a loaded one.
+      BAZEL_SELF_HOSTED_REMOTE_FALLBACK_FLAGS: "--remote_local_fallback=true --incompatible_remote_local_fallback_for_remote_cache=true --remote_timeout=60s"
+      DONNER_COVERAGE_BAZEL_FLAGS: "--remote_local_fallback=true --incompatible_remote_local_fallback_for_remote_cache=true --remote_timeout=60s"
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/bazel-diff-base-hashes/${{ steps.pr-meta.outputs.base_sha }}.json
-          key: bazel-diff-base-hashes-${{ env.BAZEL_DIFF_TAG }}-${{ steps.pr-meta.outputs.base_sha }}
+          key: bazel-diff-base-hashes-tt-${{ env.BAZEL_DIFF_TAG }}-${{ steps.pr-meta.outputs.base_sha }}
 
       - id: determine
         name: Determine coverage targets
@@ -210,6 +210,7 @@ jobs:
             fi
 
             if ! java -jar "$RUNNER_TEMP/bazel-diff.jar" generate-hashes \
+            --includeTargetType \
               -w "$base_dir" \
               -b bazelisk \
               "$work_dir/base-hashes.json"; then
@@ -224,6 +225,7 @@ jobs:
           fi
 
           if ! java -jar "$RUNNER_TEMP/bazel-diff.jar" generate-hashes \
+            --includeTargetType \
             -w "$head_dir" \
             -b bazelisk \
             "$work_dir/head-hashes.json"; then
@@ -233,6 +235,7 @@ jobs:
           fi
 
           if ! java -jar "$RUNNER_TEMP/bazel-diff.jar" get-impacted-targets \
+            -tt Rule \
             -w "$head_dir" \
             -b bazelisk \
             -sh "$work_dir/base-hashes.json" \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -178,7 +178,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/bazel-diff-base-hashes/${{ steps.pr-meta.outputs.base_sha }}.json
-          key: bazel-diff-base-hashes-${{ env.BAZEL_DIFF_TAG }}-${{ steps.pr-meta.outputs.base_sha }}
+          key: bazel-diff-base-hashes-tt-${{ env.BAZEL_DIFF_TAG }}-${{ steps.pr-meta.outputs.base_sha }}
 
       - id: determine
         name: Determine affected Bazel targets
@@ -197,6 +197,7 @@ jobs:
                 echo "Pre-warming bazel-diff hash cache for ${{ github.sha }}."
                 mkdir -p "$(dirname "$cached")"
                 java -jar "$RUNNER_TEMP/bazel-diff.jar" generate-hashes \
+            --includeTargetType \
                   -w "$GITHUB_WORKSPACE" \
                   -b bazelisk \
                   "$cached" || rm -f "$cached"
@@ -269,6 +270,7 @@ jobs:
           else
             git worktree add --detach "$base_dir" "$BASE_SHA"
             java -jar "$RUNNER_TEMP/bazel-diff.jar" generate-hashes \
+            --includeTargetType \
               -w "$base_dir" \
               -b bazelisk \
               "$work_dir/base-hashes.json"
@@ -278,11 +280,13 @@ jobs:
           fi
 
           java -jar "$RUNNER_TEMP/bazel-diff.jar" generate-hashes \
+            --includeTargetType \
             -w "$head_dir" \
             -b bazelisk \
             "$work_dir/head-hashes.json"
 
           java -jar "$RUNNER_TEMP/bazel-diff.jar" get-impacted-targets \
+            -tt Rule \
             -w "$head_dir" \
             -b bazelisk \
             -sh "$work_dir/base-hashes.json" \


### PR DESCRIPTION
Two small CI follow-ups that were pushed to #673/#680's branches after those PRs merged (stranded commits, cherry-picked onto main):

1. **`-tt Rule` bazel-diff filtering** (with `--includeTargetType` hash generation): source-file labels like `//donner/base:Transform.h` stop reaching the build/test target lists — removes the "is a source file, nothing will be built" warning wall and un-inflates target counts. Base-hash cache key bumped (`-tt` component) since the hash JSON schema changed.
2. **Coverage lane `--remote_timeout` 5s → 60s**: the 5s call deadline predates remote execution (fail-fast for a *down* LAN cache) and applies to every remote call — under a multi-job burst, large coverage uploads legitimately exceeded 5s and failed with `DEADLINE_EXCEEDED`. Dead endpoints still fail fast via connection errors, and `--remote_local_fallback` still covers outages. (The server-side upload-concurrency bound was also raised in parallel.)