### PR TITLE
Ignore Renovate updates in third_party

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,6 @@
     }
   ],
   "ignorePaths": [
-    "**/third_party/doxygen-awesome-css/**"
+    "**/third_party/**"
   ]
 }


### PR DESCRIPTION
## Summary

- Broaden Renovate `ignorePaths` from the vendored doxygen-awesome package to the entire `third_party` tree.
- Leave existing package rules unchanged so only updates inside `third_party` are excluded.

## Validation

- `jq empty renovate.json`
- `tools/llm-bazel-wrap.sh test //...`
- Skipped `python3 tools/cmake/gen_cmakelists.py --check` per request for this external Renovate config change.