### PR TITLE
editor: fix per-frame full rebuild + compose copies on drag replays

### DIFF
--- a/donner/svg/SVGDocument.cc
+++ b/donner/svg/SVGDocument.cc
@@ -546,8 +546,20 @@ void SVGDocument::setCanvasSize(int width, int height) {
   DocumentMutationBatch mutation(*documentState_, true);
   DocumentWriteAccess& access = mutation.access();
   Registry& registry = access.registry();
+  auto& documentContext = registry.ctx().get<components::SVGDocumentContext>();
+  if (documentContext.canvasSize == Vector2i(width, height)) {
+    // No-op when the stored explicit canvas size is unchanged: do not
+    // invalidate the render tree (that invalidation cascades into a full
+    // restyle + render-tree rebuild + full recompose on the next rendered
+    // frame) and do not commit a mutation revision. Callers (e.g. per-frame
+    // viewport sync) cannot cheaply detect this themselves: the canvasSize()
+    // getter returns the *derived* canvas-scaled document size, which does
+    // not round-trip with the value stored here.
+    mutation.cancel();
+    return;
+  }
   components::RenderingContext(registry).invalidateRenderTree();
-  registry.ctx().get<components::SVGDocumentContext>().canvasSize = Vector2i(width, height);
+  documentContext.canvasSize = Vector2i(width, height);
 }
 
 Transform2d SVGDocument::canvasFromDocumentTransform() const {

--- a/donner/svg/compositor/CompositorController.cc
+++ b/donner/svg/compositor/CompositorController.cc
@@ -123,19 +123,6 @@ bool IsEntityInLiveTree(Registry& registry, Entity entity, Entity rootEntity) {
   return IsDomDescendantOf(registry, entity, rootEntity);
 }
 
-ImageResource BuildImageResource(const RendererBitmap& bitmap) {
-  ImageResource img;
-  img.width = bitmap.dimensions.x;
-  img.height = bitmap.dimensions.y;
-  if (bitmap.alphaType == AlphaType::Premultiplied) {
-    // ImageResource is interpreted as unpremultiplied RGBA by drawImage.
-    img.data = UnpremultiplyRgba(bitmap.pixels);
-  } else {
-    img.data = bitmap.pixels;
-  }
-  return img;
-}
-
 Vector2i LayerPayloadDimensions(const CompositorLayer& layer) {
   if (layer.hasValidBitmap()) {
     return layer.bitmap().dimensions;
@@ -3115,8 +3102,11 @@ void CompositorController::composeLayers(const RenderViewport& viewport,
       return;
     }
     if (HasPublicTileBitmap(bitmap)) {
-      ImageResource image = BuildImageResource(bitmap);
-      renderer().drawImage(image, params);
+      // drawBitmap consumes the premultiplied raster directly. Routing this
+      // through the unpremultiplied ImageResource contract cost two full
+      // pixel-buffer conversions plus three allocations per layer/segment per
+      // composed frame — the dominant compose cost on drag-heavy replays.
+      renderer().drawBitmap(bitmap, params);
     }
   };
 

--- a/donner/svg/renderer/BUILD.bazel
+++ b/donner/svg/renderer/BUILD.bazel
@@ -136,6 +136,7 @@ donner_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":pixel_format_utils",
         ":stroke_params",
         "//donner/base",
         "//donner/css:core",

--- a/donner/svg/renderer/Renderer.cc
+++ b/donner/svg/renderer/Renderer.cc
@@ -108,6 +108,13 @@ void Renderer::drawImage(const ImageResource& image, const ImageParams& params) 
   impl_->drawImage(image, params);
 }
 
+void Renderer::drawBitmap(const RendererBitmap& bitmap, const ImageParams& params) {
+  // Forward so the backend's zero-copy premultiplied path is reachable —
+  // falling through to the base default here would convert through the
+  // unpremultiplied ImageResource contract on every compositor blit.
+  impl_->drawBitmap(bitmap, params);
+}
+
 bool Renderer::drawTextureSnapshot(const RendererTextureSnapshot& texture, const Box2d& targetRect,
                                    double opacity, bool pixelated) {
   return impl_->drawTextureSnapshot(texture, targetRect, opacity, pixelated);

--- a/donner/svg/renderer/Renderer.h
+++ b/donner/svg/renderer/Renderer.h
@@ -193,6 +193,7 @@ public:
    * @param params Image placement parameters.
    */
   void drawImage(const ImageResource& image, const ImageParams& params) override;
+  void drawBitmap(const RendererBitmap& bitmap, const ImageParams& params) override;
 
   /// Draws a backend-owned texture snapshot when the active backend supports it.
   bool drawTextureSnapshot(const RendererTextureSnapshot& texture, const Box2d& targetRect,

--- a/donner/svg/renderer/RendererInterface.h
+++ b/donner/svg/renderer/RendererInterface.h
@@ -28,6 +28,7 @@
 #include "donner/svg/core/TextAnchor.h"
 #include "donner/svg/core/TextDecoration.h"
 #include "donner/svg/core/WritingMode.h"
+#include "donner/svg/renderer/PixelFormatUtils.h"
 #include "donner/svg/renderer/StrokeParams.h"
 #include "donner/svg/resources/ImageResource.h"
 
@@ -384,6 +385,30 @@ public:
    * Draws an image resource into the given target rectangle.
    */
   virtual void drawImage(const ImageResource& image, const ImageParams& params) = 0;
+
+  /**
+   * Draws a CPU bitmap (typically a compositor layer/segment raster) into the
+   * given target rectangle.
+   *
+   * The `ImageResource` contract is unpremultiplied RGBA, while renderer
+   * snapshots are premultiplied — routing a per-frame compose through
+   * `drawImage` costs an unpremultiply + repremultiply round trip (two full
+   * pixel-buffer conversions and three allocations per layer per frame).
+   * Backends that can consume premultiplied pixels directly should override
+   * this with a zero-copy path; the default converts and delegates so every
+   * backend stays correct.
+   */
+  virtual void drawBitmap(const RendererBitmap& bitmap, const ImageParams& params) {
+    if (bitmap.empty()) {
+      return;
+    }
+    ImageResource image;
+    image.width = bitmap.dimensions.x;
+    image.height = bitmap.dimensions.y;
+    image.data = bitmap.alphaType == AlphaType::Premultiplied ? UnpremultiplyRgba(bitmap.pixels)
+                                                              : bitmap.pixels;
+    drawImage(image, params);
+  }
 
   /**
    * Draws a backend-owned texture snapshot into the given target rectangle.

--- a/donner/svg/renderer/RendererTinySkia.cc
+++ b/donner/svg/renderer/RendererTinySkia.cc
@@ -1359,6 +1359,59 @@ void RendererTinySkia::drawImage(const ImageResource& image, const ImageParams& 
                                  toTinyTransform(imageFromLocal), mask);
 }
 
+void RendererTinySkia::drawBitmap(const RendererBitmap& bitmap, const ImageParams& params) {
+  if (bitmap.empty()) {
+    return;
+  }
+
+  const std::optional<tiny_skia::Rect> targetRect = toTinyRect(params.targetRect);
+  if (!targetRect.has_value()) {
+    return;
+  }
+
+  // Premultiplied payloads draw through a borrowed view: no conversion, no
+  // copy. Unpremultiplied payloads (the root surface stores unpremultiplied
+  // for display, so layer/segment snapshots usually arrive that way)
+  // premultiply directly into the draw scratch — one conversion, zero
+  // intermediate copies. Both beat the ImageResource contract, which costs
+  // an extra full-buffer copy (and, for premultiplied payloads, an extra
+  // unpremultiply) per compose blit.
+  std::optional<tiny_skia::PixmapView> sourceView;
+  std::vector<std::uint8_t> premultipliedScratch;
+  if (bitmap.alphaType == AlphaType::Premultiplied) {
+    sourceView = tiny_skia::PixmapView::fromBytes(std::span<const std::uint8_t>(bitmap.pixels),
+                                                  static_cast<std::uint32_t>(bitmap.dimensions.x),
+                                                  static_cast<std::uint32_t>(bitmap.dimensions.y));
+  } else {
+    premultipliedScratch = PremultiplyRgba(bitmap.pixels);
+    sourceView =
+        tiny_skia::PixmapView::fromBytes(std::span<const std::uint8_t>(premultipliedScratch),
+                                         static_cast<std::uint32_t>(bitmap.dimensions.x),
+                                         static_cast<std::uint32_t>(bitmap.dimensions.y));
+  }
+  if (!sourceView.has_value()) {
+    return;
+  }
+
+  const double scaleX = params.targetRect.width() / static_cast<double>(bitmap.dimensions.x);
+  const double scaleY = params.targetRect.height() / static_cast<double>(bitmap.dimensions.y);
+  const Transform2d imageFromLocal = Transform2d::Scale(scaleX, scaleY) *
+                                     Transform2d::Translate(params.targetRect.topLeft) *
+                                     deviceFromLocalTransform_;
+
+  tiny_skia::PixmapPaint paint;
+  paint.opacity = NarrowToFloat(params.opacity * paintOpacity_);
+  paint.blendMode = tiny_skia::BlendMode::SourceOver;
+  paint.quality = params.imageRenderingPixelated ? tiny_skia::FilterQuality::Nearest
+                                                 : tiny_skia::FilterQuality::Bilinear;
+  paint.unpremulStore = surfaceStack_.empty();
+
+  const tiny_skia::Mask* mask = currentClipMask_.has_value() ? &*currentClipMask_ : nullptr;
+  auto pixmapView = currentPixmapView();
+  tiny_skia::Painter::drawPixmap(pixmapView, 0, 0, *sourceView, paint,
+                                 toTinyTransform(imageFromLocal), mask);
+}
+
 void RendererTinySkia::drawText(Registry& registry, const components::ComputedTextComponent& text,
                                 const TextParams& params) {
 #ifdef DONNER_TEXT_ENABLED

--- a/donner/svg/renderer/RendererTinySkia.h
+++ b/donner/svg/renderer/RendererTinySkia.h
@@ -177,6 +177,19 @@ public:
   void drawImage(const ImageResource& image, const ImageParams& params) override;
 
   /**
+   * Zero-copy compose blit for premultiplied CPU bitmaps.
+   *
+   * tiny-skia consumes premultiplied RGBA natively, so a premultiplied
+   * \ref RendererBitmap is drawn through a borrowed `PixmapView` with no
+   * pixel-buffer conversion or copy. Non-premultiplied bitmaps fall back to
+   * the converting base implementation.
+   *
+   * @param bitmap The bitmap to draw.
+   * @param params Image placement parameters.
+   */
+  void drawBitmap(const RendererBitmap& bitmap, const ImageParams& params) override;
+
+  /**
    * Draws shaped text.
    *
    * @param registry ECS registry used for resolving paint references.

--- a/donner/svg/renderer/RendererTinySkiaBackend.cc
+++ b/donner/svg/renderer/RendererTinySkiaBackend.cc
@@ -70,6 +70,10 @@ public:
     renderer_.drawImage(image, params);
   }
 
+  void drawBitmap(const RendererBitmap& bitmap, const ImageParams& params) override {
+    renderer_.drawBitmap(bitmap, params);
+  }
+
   void drawText(Registry& registry, const components::ComputedTextComponent& text,
                 const TextParams& params) override {
     renderer_.drawText(registry, text, params);


### PR DESCRIPTION
Fixes #677 — but the root cause turned out deeper than the "filtered elements miss the fast path" framing in the issue. Instrumenting the compositor's fast-path bail reasons on `FilterPostDragJumpReplayMatchesGroundTruth` found two compounding problems:

## 1. A self-perpetuating full-rebuild loop via `setCanvasSize`

`SVGDocument::setCanvasSize` called `invalidateRenderTree()` even when the size was unchanged — and per-frame viewport sync calls it every frame. Callers **cannot** guard this themselves: the `canvasSize()` getter returns the *derived* canvas-scaled document size, which never round-trips with the stored value. Each invalidation forced a full restyle + render-tree rebuild + full recompose, and the rebuild re-armed `needsFullRebuild` by re-parsing gradient/stop presentation attributes (whose element setters also call `invalidateRenderTree()`).

Measured on the replay: **284 full prepares across 289 frames; 3,104 `invalidateRenderTree` calls** (~35% of frame cost was selector matching alone).

Fix: `setCanvasSize` is a no-op (and cancels its mutation revision via `DocumentMutationBatch::cancel()`) when the stored size is unchanged. Lock-acquisition counts are unchanged — `AccessDiagnosticsTrackConcurrentDomLocks` pins this.

## 2. A full pixel-buffer copy + alpha conversions per layer per composed frame

Compose blits routed through the unpremultiplied `ImageResource` contract: copy the raster into an `ImageResource` (unpremultiplying if needed), then `drawImage` re-premultiplies into an owned Pixmap. In fastbuild, each multi-MB temporary vector also pays a per-byte destroy loop.

Fix: new `RendererInterface::drawBitmap(const RendererBitmap&, const ImageParams&)` — premultiplied payloads draw through a borrowed `tiny_skia::PixmapView` (zero copy, zero conversion); unpremultiplied payloads premultiply directly into the draw scratch (one conversion, no intermediate copy). The base default converts and delegates so all backends stay correct.

## Results (local, M1 Pro, fastbuild)

| Test | Before | After |
|---|---:|---:|
| `FilterPostDragJumpReplayMatchesGroundTruth` | 137s | **34.7s** |
| `rnr_replay_tests` (max shard) | 150s | 45s |
| `gl_rnr_replay_tests` (max shard) | 139s | 53s |
| `filter_drag_repro_tests_correctness` | ~155s (CI) | 44s |
| `zoom_filter_repro_tests` (max shard) | 41s | 30s |

This is also a real editor fix: drag responsiveness on gradient/filter scenes was burning a core on redundant restyles.

## Verification

- `bazel test //...` full local gate: 633 pass, 58 platform-skips, 0 failures (includes all golden/pixel suites).
- Replay tests compare against ground truth and stored goldens — pixel output is unchanged.