### PR TITLE
Use CMake leaf targets for generator discovery

### DIFF
--- a/tools/cmake/gen_cmakelists.py
+++ b/tools/cmake/gen_cmakelists.py
@@ -343,17 +343,31 @@ def _run_bazel(args: List[str]) -> str:
         raise RuntimeError(f"Bazel command failed:\n  {cmd_str}\n{exc.stderr}") from exc
 
 
+_CMAKE_LEAF_TARGET_PATTERNS = (
+    "//:donner",
+    "//donner/base/...",
+    "//donner/css/...",
+    "//donner/svg:all",
+    "//donner/svg/components/...",
+    "//donner/svg/core/...",
+    "//donner/svg/graph/...",
+    "//donner/svg/parser/...",
+    "//donner/svg/properties/...",
+    "//donner/svg/renderer:all",
+    "//donner/svg/renderer/common/...",
+    "//donner/svg/renderer/tests:all",
+    "//donner/svg/resources/...",
+    "//donner/svg/tests:all",
+    "//donner/svg/text/...",
+    "//donner/svg/tool/...",
+    "//examples:custom_css_parser",
+    "//examples:render_test",
+    "//examples:wasm_reproducer",
+)
+_CMAKE_LEAF_TARGET_EXPRESSION = "(" + " + ".join(_CMAKE_LEAF_TARGET_PATTERNS) + ")"
 _CQUERY_TARGET_EXPRESSION = (
     'kind(".*cc_.*|embed_resources_generate_header", '
-    '(//:donner + //donner/... + //examples/... + //third_party/...) '
-    'except //donner/editor/... '
-    'except //donner/benchmarks/... '
-    'except //donner/svg/renderer/benchmarks/... '
-    'except //donner/svg/renderer/geode/... '
-    'except //donner/svg/renderer/wasm/... '
-    'except //third_party/emdawnwebgpu/... '
-    'except //third_party/emscripten-glfw/... '
-    'except //third_party/webgpu-cpp/...)'
+    f"deps({_CMAKE_LEAF_TARGET_EXPRESSION}))"
 )
 
 
@@ -561,20 +575,17 @@ def _record_values(
         dest.setdefault(value, set()).add(config_name)
 
 
+_MANUALLY_HANDLED_CMAKE_PACKAGES = {
+    "",
+    "pixelmatch-cpp17",
+    "third_party",
+    "third_party/stb",
+    "third_party/tiny-skia-cpp",
+}
+
+
 def _is_skipped_package(pkg: str) -> bool:
-    if pkg in {"", "third_party", "third_party/stb", "pixelmatch-cpp17"}:
-        return True
-    skipped_prefixes = (
-        "donner/benchmarks",
-        "donner/editor",
-        "donner/svg/renderer/benchmarks",
-        "donner/svg/renderer/geode",
-        "donner/svg/renderer/wasm",
-        "third_party/emdawnwebgpu",
-        "third_party/emscripten-glfw",
-        "third_party/webgpu-cpp",
-    )
-    return any(pkg == prefix or pkg.startswith(prefix + "/") for prefix in skipped_prefixes)
+    return pkg in _MANUALLY_HANDLED_CMAKE_PACKAGES
 
 
 def _intersect_target_values_with_configs(target: CMakeTarget) -> None:

--- a/tools/cmake/gen_cmakelists_test.py
+++ b/tools/cmake/gen_cmakelists_test.py
@@ -194,6 +194,23 @@ class CqueryBuildOutputTest(unittest.TestCase):
         self.assertEqual(targets[1].kind, "embed_resources")
 
 
+class CqueryExpressionTest(unittest.TestCase):
+    def test_query_uses_positive_leaf_dependency_closure(self):
+        self.assertIn("deps((", g._CQUERY_TARGET_EXPRESSION)
+        self.assertNotIn(" except ", g._CQUERY_TARGET_EXPRESSION)
+        self.assertIn("//:donner", g._CQUERY_TARGET_EXPRESSION)
+        self.assertIn("//donner/svg/renderer/tests:all", g._CQUERY_TARGET_EXPRESSION)
+        self.assertIn("//examples:render_test", g._CQUERY_TARGET_EXPRESSION)
+        self.assertNotIn("//examples:svg_viewer", g._CQUERY_TARGET_EXPRESSION)
+        self.assertNotIn("//donner/editor", g._CQUERY_TARGET_EXPRESSION)
+
+    def test_skipped_packages_are_only_hand_written_cmake_packages(self):
+        self.assertTrue(g._is_skipped_package("third_party/stb"))
+        self.assertTrue(g._is_skipped_package("third_party/tiny-skia-cpp"))
+        self.assertFalse(g._is_skipped_package("donner/editor"))
+        self.assertFalse(g._is_skipped_package("donner/svg/renderer/geode"))
+
+
 class ConditionDerivationTest(unittest.TestCase):
     def _configs_where(self, predicate):
         return {config.name for config in g.CMAKE_CONFIGS if predicate(config)}


### PR DESCRIPTION
## Summary

- Replace the broad CMake generator `cquery` target expression and unsupported-package exclusions with a positive dependency closure rooted at the CMake-supported leaf targets.
- Keep package skipping limited to packages handled manually by generated root CMake, such as STB and tiny-skia.
- Add unit coverage that the query has no `except` clauses and does not name unsupported example/editor/geode targets.

## Validation

- `python3 -m py_compile tools/cmake/gen_cmakelists.py tools/cmake/gen_cmakelists_test.py`
- `git diff --check`
- `tools/llm-bazel-wrap.sh test //tools/cmake:gen_cmakelists_test`
- `python3 tools/cmake/gen_cmakelists.py --check`
- `tools/llm-bazel-wrap.sh test //...` passed: 633 tests passed, 58 skipped.