### PR TITLE
Fix CI build warnings

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -39,6 +39,14 @@ build --features=-layering_check
 build --copt=-fno-exceptions
 build --copt=-fno-rtti
 
+# Keep CI warning output focused on Donner-owned code. These filters are scoped
+# to vendored/external sources and the warning classes they currently emit under
+# the repo's clang configuration.
+build --per_file_copt=external/google_benchmark[+]/.*@-Wno-thread-safety-analysis
+build --per_file_copt=external/glfw[+]/.*@-Wno-enum-enum-conversion
+build --per_file_copt=external/freetype[+]/.*@-Wno-macro-redefined
+build --per_file_copt=external/imgui[+]/.*@-Wno-missing-braces
+
 # Use registered clang toolchain.
 build --incompatible_enable_cc_toolchain_resolution
 
@@ -65,6 +73,12 @@ common:latest_llvm --@rules_python//python/config_settings:bootstrap_impl=script
 # anything. `--jitless` keeps Node in the interpreter-only mode, which
 # emscripten's `compiler.mjs` is happy with.
 common:latest_llvm --action_env=NODE_OPTIONS=--jitless
+# toolchains_llvm selects builtin libc++ with a clang driver argument. On
+# self-hosted Linux, compile-only actions can report that stdlib-selection
+# argument as unused even though the toolchain has already supplied the libc++
+# include paths and link inputs. Suppress that driver-only warning in the LLVM
+# toolchain config so real compiler diagnostics are not buried in CI logs.
+common:latest_llvm --copt=-Qunused-arguments
 
 # Renderer backend selection
 common:tiny-skia --//donner/svg/renderer:renderer_backend=tiny_skia
@@ -135,11 +149,6 @@ build:wasm-geode --cxxopt=-fconstexpr-steps=10000000
 #   bazel build --config=editor-wasm-geode //donner/editor/wasm:wasm
 common:editor-wasm-geode --config=editor-wasm
 
-# Clang with libc++
-build:libc++ --action_env=CXXFLAGS=-stdlib=libc++
-build:libc++ --action_env=LDFLAGS=-stdlib=libc++
-build:libc++ --define force_libcpp=enabled
-
 # C++20
 build:c++20 --cxxopt=-std=c++20
 
@@ -176,7 +185,12 @@ build:macos-binary-size --linkopt=-exported_symbols_list --linkopt=/dev/null
 build:macos-binary-size --copt=-gline-tables-only
 build:macos-binary-size --linkopt=-dead_strip
 
-build --config=libc++ --config=c++20
+# The registered LLVM toolchains select their C++ standard library themselves
+# (`builtin-libc++` for Linux), and Apple clang uses the SDK libc++ by default.
+# Do not inject `-stdlib=libc++` through CXXFLAGS/LDFLAGS here: self-hosted
+# Linux toolchain setup propagates those environment flags into compile actions
+# and clang reports them as unused for every source file.
+build --config=c++20
 
 # Debug builds
 build:debug -c dbg --copt=-O0 --copt=-g --copt=-fdebug-compilation-dir=. --linkopt=-g --strip=never --apple_generate_dsym --spawn_strategy=standalone

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -111,8 +111,8 @@ bazel_dep(name = "brotli", version = "1.2.0.bcr.1")
 ##
 ## Test dependencies
 ##
-# re2 is not used directly, but needs to use this version to resolve a build error in deps (googletest)
-bazel_dep(name = "re2", version = "2024-07-02.bcr.1", dev_dependency = True)
+# re2 is not used directly, but is selected by googletest and transitive test dependencies.
+bazel_dep(name = "re2", version = "2025-08-12.bcr.1", dev_dependency = True)
 bazel_dep(name = "googletest", repo_name = "com_google_gtest", version = "1.17.0.bcr.2", dev_dependency = True)
 
 bazel_dep(name = "nlohmann_json", version = "3.12.0.bcr.1", dev_dependency = True)

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -590,9 +590,9 @@ bool ContainsElement(std::span<const svg::SVGElement> elements, const svg::SVGEl
 
 std::string ElementContextMenuLabel(const svg::SVGElement& element) {
   return element.withReadAccess([&element](svg::DocumentReadAccess&, EntityHandle) {
-    const std::string_view tagName = element.tagName().name;
+    const std::string tagName(element.tagName().name);
     std::string label = "<";
-    label.append(tagName.data(), tagName.size());
+    label.append(tagName);
     label.push_back('>');
 
     const RcString id = element.id();

--- a/donner/editor/tests/RnrReplay_tests.cc
+++ b/donner/editor/tests/RnrReplay_tests.cc
@@ -55,11 +55,6 @@ Entity SelectedGraphicsEntity(EditorApp& app) {
   return app.selectedElement()->unsafeEntityHandle().entity();
 }
 
-std::string ElementId(const svg::SVGElement& element) {
-  return element.withReadAccess(
-      [&element](svg::DocumentReadAccess&, EntityHandle) { return std::string(element.id()); });
-}
-
 constexpr std::size_t kTargetMouseUpCount = 2;
 constexpr char kReplayPath[] = "donner/editor/tests/filter_elm_disappear-3.rnr";
 constexpr char kGoldenPath[] = "donner/editor/tests/testdata/filter_disappear_rnr3_after_mup2.png";


### PR DESCRIPTION
## Summary

Fix the warning noise seen in current CI builds:

- stop injecting `-stdlib=libc++` through global `CXXFLAGS`/`LDFLAGS`; the registered LLVM toolchains already select their standard library
- add a targeted `latest_llvm` clang driver suppressor for the self-hosted Linux `-stdlib=libc++` unused-argument warning
- align the root `re2` dev dependency with the version Bazel resolves, removing the module-version warning
- fix Donner-owned warnings by copying the SVG tag name before using it and deleting an unused replay-test helper
- add narrow per-external-repository suppressions for current vendor warnings from `google_benchmark`, `glfw`, `freetype`, and `imgui`

## Validation

- `bazel build --config=text-full //donner/editor:editor_shell //donner/editor/tests:rnr_replay_tests //donner/benchmarks:css_parse_perf_bench //donner/svg/text:text_backend_full`
- `bazel build --config=geode //examples:geode_embed //donner/editor/gui:editor_window`
- `bazel test //...`
- `python3 tools/cmake/gen_cmakelists.py --check`
- `git diff --check`
