### PR TITLE
Fix coverage and CI runner routing

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,11 +29,14 @@ concurrency:
 # runner or seeing the Codecov secret there. Everyone else stays on hosted
 # Ubuntu.
 #
-# EXCEPTION: pushes to main always stay GitHub-hosted, matching main.yml; PRs
-# still route to the self-hosted lane.
+# Main coverage stays GitHub-hosted. PR coverage uses the self-hosted lane
+# only when the trusted runner gate passes; hosted Ubuntu remains the PR
+# fallback for untrusted actors, unavailable self-hosted runners, and
+# `ci:full-test` fanout runs.
 jobs:
   determine-targets:
     runs-on: ubuntu-24.04
+    if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'pull_request' }}
     env:
       BAZEL_DIFF_TAG: "v18.1.0"
       FULL_COVERAGE_TARGETS: "//donner/base/... //donner/css/... //donner/svg/... //donner/editor/..."
@@ -272,10 +275,31 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     needs: determine-targets
-    if: ${{ github.ref == 'refs/heads/main' || vars.SELFHOSTED_LINUX_RUNNER != 'true' || github.actor != 'jwmcglynn' || github.triggering_actor != 'jwmcglynn' }}
+    if: ${{ github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && (needs.determine-targets.outputs.fallback_reason == 'full_test_label' || vars.SELFHOSTED_LINUX_RUNNER != 'true' || github.actor != 'jwmcglynn' || github.triggering_actor != 'jwmcglynn')) }}
 
     steps:
       - uses: actions/checkout@v7
+
+      - name: Free hosted runner disk
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "::group::Disk before cleanup"
+          df -h /
+          echo "::endgroup::"
+
+          sudo rm -rf \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /usr/local/lib/android \
+            /usr/local/share/boost \
+            /usr/share/dotnet \
+            /usr/share/swift
+          sudo apt-get clean
+
+          echo "::group::Disk after cleanup"
+          df -h /
+          echo "::endgroup::"
 
       - name: Set up JDK 11
         uses: actions/setup-java@v5
@@ -308,13 +332,20 @@ jobs:
           echo "Coverage target selection: fallback=${{ needs.determine-targets.outputs.fallback }} reason=${{ needs.determine-targets.outputs.fallback_reason }} count=${{ needs.determine-targets.outputs.target_count }}"
           printf "Coverage targets:\n"
           printf "  %s\n" "${TARGETS[@]}"
+          echo "::group::Disk before coverage"
+          df -h / "$GITHUB_WORKSPACE" "$RUNNER_TEMP"
+          echo "::endgroup::"
           tools/coverage.sh --no-html "${TARGETS[@]}"
+          echo "::group::Disk after coverage"
+          df -h / "$GITHUB_WORKSPACE" "$RUNNER_TEMP"
+          echo "::endgroup::"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage-report/filtered_report.dat
+          disable_search: true
           flags: unittests
           fail_ci_if_error: true
           verbose: true
@@ -322,7 +353,7 @@ jobs:
   coverage-self-hosted:
     runs-on: [self-hosted, linux, arm64]
     needs: determine-targets
-    if: ${{ github.ref != 'refs/heads/main' && vars.SELFHOSTED_LINUX_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
+    if: ${{ github.event_name == 'pull_request' && vars.SELFHOSTED_LINUX_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
     env:
       # The runner host may add the LAN Bazel cache from its home rc. Keep
       # coverage resilient when the private gRPC endpoint is down
@@ -421,7 +452,7 @@ jobs:
   upload-self-hosted-coverage:
     needs: coverage-self-hosted
     runs-on: ubuntu-24.04
-    if: ${{ github.ref != 'refs/heads/main' && vars.SELFHOSTED_LINUX_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
+    if: ${{ github.event_name == 'pull_request' && vars.SELFHOSTED_LINUX_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,9 +29,11 @@ permissions:
 # the runner or poison the shared LAN Bazel cache. Unset is a no-op: behavior
 # is identical to the GitHub-hosted-only workflow.
 #
-# EXCEPTION: pushes to main always stay GitHub-hosted so a stuck/offline
-# self-hosted runner can never hang main's required check. Feature branches and
-# PRs still route to the self-hosted lane.
+# Main CI stays GitHub-hosted so a stuck/offline self-hosted runner can never
+# hang main's required check. PR CI uses the self-hosted lane only when the
+# trusted runner gate passes; hosted runners remain the PR fallback for
+# untrusted actors, unavailable self-hosted runners, and `ci:full-test` fanout
+# runs. Other branch refs do not run build/test jobs.
 
 jobs:
   gatekeeper:
@@ -125,12 +127,13 @@ jobs:
   determine-targets:
     runs-on: ubuntu-24.04
     needs: gatekeeper
-    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') }}
+    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') }}
     env:
       BAZEL_DIFF_TAG: "v18.1.0"
     outputs:
       fallback: ${{ steps.determine.outputs.fallback }}
       affected: ${{ steps.determine.outputs.affected }}
+      full_test: ${{ steps.determine.outputs.full_test }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -190,6 +193,7 @@ jobs:
             echo "Non-PR event; keeping full //... coverage."
             echo "fallback=true" >> "$GITHUB_OUTPUT"
             echo "affected=" >> "$GITHUB_OUTPUT"
+            echo "full_test=false" >> "$GITHUB_OUTPUT"
 
             if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
               cached="$HOME/.cache/bazel-diff-base-hashes/${{ github.sha }}.json"
@@ -214,6 +218,7 @@ jobs:
             echo "Missing PR base/head SHA; falling back to //...."
             echo "fallback=true" >> "$GITHUB_OUTPUT"
             echo "affected=" >> "$GITHUB_OUTPUT"
+            echo "full_test=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -221,8 +226,11 @@ jobs:
             echo "ci:full-test label present; forcing full //... coverage."
             echo "fallback=true" >> "$GITHUB_OUTPUT"
             echo "affected=" >> "$GITHUB_OUTPUT"
+            echo "full_test=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          echo "full_test=false" >> "$GITHUB_OUTPUT"
 
           changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
 
@@ -312,7 +320,7 @@ jobs:
     # self-hosted ARM64 lane is active (see gate comment above).
     runs-on: ubuntu-24.04
     needs: [gatekeeper, determine-targets]
-    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') && (github.ref == 'refs/heads/main' || vars.SELFHOSTED_LINUX_RUNNER != 'true' || github.actor != 'jwmcglynn' || github.triggering_actor != 'jwmcglynn') }}
+    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && (needs.determine-targets.outputs.full_test == 'true' || vars.SELFHOSTED_LINUX_RUNNER != 'true' || github.actor != 'jwmcglynn' || github.triggering_actor != 'jwmcglynn'))) && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -380,7 +388,7 @@ jobs:
   linux-self-hosted:
     runs-on: [self-hosted, linux, arm64]
     needs: [gatekeeper, determine-targets]
-    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && github.ref != 'refs/heads/main' && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') && vars.SELFHOSTED_LINUX_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
+    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && github.event_name == 'pull_request' && needs.gatekeeper.outputs.docs_only != 'true' && vars.SELFHOSTED_LINUX_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
     env:
       # The runner host may add the LAN Bazel cache from its home rc. Keep
       # that acceleration when it is healthy, but fall back to local execution
@@ -542,7 +550,7 @@ jobs:
   macos:
     runs-on: macos-26
     needs: [gatekeeper, determine-targets]
-    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') && (github.ref == 'refs/heads/main' || vars.SELFHOSTED_MACOS_RUNNER != 'true' || github.actor != 'jwmcglynn' || github.triggering_actor != 'jwmcglynn') }}
+    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && (needs.determine-targets.outputs.full_test == 'true' || vars.SELFHOSTED_MACOS_RUNNER != 'true' || github.actor != 'jwmcglynn' || github.triggering_actor != 'jwmcglynn'))) && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') }}
     env:
       # Xcode's libc++ marks std::format floating-point support as macOS 13.3+.
       # Set the CI deployment target explicitly so hosted and self-hosted macOS
@@ -613,7 +621,7 @@ jobs:
   macos-self-hosted:
     runs-on: [self-hosted, macOS, ARM64]
     needs: [gatekeeper, determine-targets]
-    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && github.ref != 'refs/heads/main' && github.event_name == 'pull_request' && needs.gatekeeper.outputs.docs_only != 'true' && vars.SELFHOSTED_MACOS_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
+    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && github.event_name == 'pull_request' && needs.gatekeeper.outputs.docs_only != 'true' && vars.SELFHOSTED_MACOS_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
     env:
       # The runner host has an operator ~/.bazelrc for interactive RE/cache work.
       # The invocations below use --nohome_rc so CI matches GitHub-hosted macOS


### PR DESCRIPTION
## Summary
- keep main CI and coverage on GitHub-hosted runners
- route trusted PR CI/coverage to self-hosted runners, with hosted fallback for untrusted or unavailable self-hosted lanes
- make `ci:full-test` fan out to hosted and self-hosted lanes
- add hosted coverage disk cleanup/diagnostics and disable Codecov report search for explicit hosted uploads

## Root Cause
Main coverage was using the hosted lane as intended, but the hosted coverage job could exhaust runner disk during coverage generation. The self-hosted and hosted routing predicates also did not consistently express the desired main/PR/full-test policy across CI and coverage.

## Validation
- `ruby -e 'require "yaml"; %w[.github/workflows/main.yml .github/workflows/coverage.yml].each { |p| YAML.load_file(p); puts "#{p}: yaml ok" }'`\n- `git diff --check HEAD~1..HEAD`\n\nFull `bazel test //...` was not run locally because this PR only changes GitHub Actions workflow routing.