### PR TITLE
Constrain borrowed XML name lifetimes

### DIFF
--- a/build_defs/check_banned_patterns.py
+++ b/build_defs/check_banned_patterns.py
@@ -12,6 +12,7 @@ Rules enforced:
   - No `std::aligned_storage`: use alignas(T) on a byte buffer
   - No `std::aligned_union`: same reason
   - No user-defined literal operators (operator"" _foo): use named helpers
+  - No `XMLQualifiedNameRef` / `RcStringOrRef` return types: return owning values instead
   - No imgui / GLFW / Tracy headers outside `donner/editor/**` (path-scoped)
   - No ImGui `AddImageQuad`: present document textures through direct framebuffer composition
   - No direct TreeComponent structural mutation outside approved low-level code
@@ -197,6 +198,85 @@ def _strip_comments_and_strings(text: str) -> str:
 
 _NOLINT_RE = re.compile(r"//\s*NOLINT\(banned_patterns(?::[^)]*)?\)")
 
+_REF_RETURN_RE = re.compile(
+    r"""
+    ^\s*
+    (?:\[\[[^\]]+\]\]\s*)*
+    (?:(?:static|inline|constexpr|friend|virtual)\s+)*
+    (?P<type>
+      (?:std::optional\s*<\s*)?
+      (?:(?:[A-Za-z_][A-Za-z0-9_]*)::)*(?:XMLQualifiedNameRef|RcStringOrRef)
+      (?:\s*>)?
+    )
+    \s+
+    (?P<name>(?:(?:[A-Za-z_][A-Za-z0-9_]*)::)*[A-Za-z_][A-Za-z0-9_]*)
+    \s*\((?P<params>[^;{}]*)\)
+    (?P<suffix>\s*(?:const\s*)?(?:noexcept\s*)?(?:override\s*)?(?:final\s*)?(?:;|\{))
+    """,
+    re.MULTILINE | re.VERBOSE,
+)
+
+_REF_RETURN_EXEMPT_PATHS = (
+    # RcStringOrRef is the view/owning bridge type itself. Its substring helper intentionally
+    # preserves the input lifetime model.
+    "donner/base/RcStringOrRef.h",
+)
+
+
+def _looks_like_parameter_list(params: str) -> bool:
+    """Return true if `params` looks like C++ parameter declarations, not ctor arguments."""
+    params = params.strip()
+    if not params:
+        return True
+    if any(token in params for token in ('"', "'", "(", ")")):
+        return False
+
+    # Function signatures contain parameter types. Local direct-initialization false positives
+    # usually contain literals, variable names, or function calls instead.
+    return bool(
+        re.search(
+            r"\b(?:const|std::|donner::|xml::|svg::|RcString|XMLQualifiedName|"
+            r"XMLQualifiedNameRef|RcStringOrRef|string_view|size_t|int|bool|char|auto)\b|[&*]",
+            params,
+        )
+    )
+
+
+def _check_ref_return_types(
+    stripped: str, raw_lines: List[str], posix_path: str
+) -> List[Tuple[int, str, str]]:
+    if any(prefix in posix_path for prefix in _REF_RETURN_EXEMPT_PATHS):
+        return []
+
+    errors: List[Tuple[int, str, str]] = []
+    for m in _REF_RETURN_RE.finditer(stripped):
+        if not _looks_like_parameter_list(m.group("params")):
+            continue
+
+        line = stripped.count("\n", 0, m.start()) + 1
+        suppressed = False
+        for offset in (0, 1, 2):
+            idx = line - 1 + offset
+            if 0 <= idx < len(raw_lines) and _NOLINT_RE.search(raw_lines[idx]):
+                suppressed = True
+                break
+        if suppressed:
+            continue
+
+        errors.append(
+            (
+                line,
+                f"`{m.group('type').strip()}` return type",
+                (
+                    "Return an owning value such as XMLQualifiedName or RcString instead. "
+                    "`*Ref` types are for input parameters; returning them makes it easy to "
+                    "bind a view to storage owned by a temporary."
+                ),
+            )
+        )
+
+    return errors
+
 
 def check_file(path: Path) -> List[Tuple[int, str, str]]:
     """Check a single file; return list of (line_number, description, remediation).
@@ -230,6 +310,8 @@ def check_file(path: Path) -> List[Tuple[int, str, str]]:
             if suppressed:
                 continue
             errors.append((line, rule.description, rule.remediation))
+
+    errors.extend(_check_ref_return_types(stripped, raw_lines, posix_path))
 
     return sorted(errors)
 

--- a/build_defs/check_banned_patterns.py
+++ b/build_defs/check_banned_patterns.py
@@ -204,9 +204,15 @@ _REF_RETURN_RE = re.compile(
     (?:\[\[[^\]]+\]\]\s*)*
     (?:(?:static|inline|constexpr|friend|virtual)\s+)*
     (?P<type>
-      (?:std::optional\s*<\s*)?
-      (?:(?:[A-Za-z_][A-Za-z0-9_]*)::)*(?:XMLQualifiedNameRef|RcStringOrRef)
-      (?:\s*>)?
+      (?:const\s+)?
+      (?:
+        std::optional\s*<\s*
+        (?:(?:[A-Za-z_][A-Za-z0-9_]*)::)*(?:XMLQualifiedNameRef|RcStringOrRef)
+        \s*>
+        |
+        (?:(?:[A-Za-z_][A-Za-z0-9_]*)::)*(?:XMLQualifiedNameRef|RcStringOrRef)
+      )
+      (?:\s*[&*])?
     )
     \s+
     (?P<name>(?:(?:[A-Za-z_][A-Za-z0-9_]*)::)*[A-Za-z_][A-Za-z0-9_]*)

--- a/docs/coding_style.md
+++ b/docs/coding_style.md
@@ -454,6 +454,38 @@ for (std::string_view part : StringUtils::Split("a,b,c", ',')) {
 }
 ```
 
+#### View and Ref Lifetimes
+
+- `*Ref` types such as `XMLQualifiedNameRef` and `RcStringOrRef` are input parameter types.
+  Return owning values (`XMLQualifiedName`, `RcString`) from public APIs so callers can safely
+  store the result.
+- Returning `XMLQualifiedNameRef` or `RcStringOrRef` is banned by the per-target
+  `banned_patterns` lint. The only exemption is the view type implementation itself.
+- `std::string_view` and `std::span` return values are allowed only when the backing storage is
+  obvious from the API and stable for the documented lifetime, such as object-owned buffers,
+  static tables, or views into an input parameter.
+- Data members that store non-owning views need an explicit local lifetime contract. Prefer owning
+  members unless there is a measured parser/storage reason to keep a view.
+
+Audit classification for the current view-returning APIs:
+
+- `SVGElement::tagName()` and `SVGElement::tryTagName()` return owning `XMLQualifiedName` values
+  because the public SVG API crosses the concurrent DOM read-access boundary. These were risky as
+  `XMLQualifiedNameRef` returns because callers could bind `tagName().name` to a dangling
+  `std::string_view`.
+- `XMLNode::tagName()` and `TreeComponent::tagName()` return `const XMLQualifiedName&` annotated
+  with `UTILS_LIFETIME_BOUND`; their lifetimes are tied to the underlying XML tree storage.
+- Attribute-name list APIs (`AttributesComponent::attributes()`,
+  `AttributesComponent::findMatchingAttributes()`, `XMLNode::attributes()`, and
+  `SVGElement::findMatchingAttributes()`) return copied `XMLQualifiedNameRef` entries whose
+  `RcStringOrRef` members own copied `RcString` storage.
+- `Reference::documentUrl()`, `Reference::fragment()`, `XMLDocument::source()`,
+  `XMLSourceStore::source()`, parser token text helpers, and enum/name helpers return views into
+  object storage, input parameters, or static strings. The caller must not outlive that backing
+  storage.
+- `ChunkedString` stores `RcStringOrRef` pieces for the XML parser. Its non-owning pieces point
+  into `XMLParserImpl::str_`, and parser-created replacement pieces are owning `RcString`s.
+
 ### Limit Use of auto
 
 `auto` should only be used when the type is visible on the same source line, or if the type is well-understood, such as for iterators (`auto it = ...`).

--- a/donner/base/ChunkedString.h
+++ b/donner/base/ChunkedString.h
@@ -30,7 +30,7 @@ public:
    *
    * @param sv The string_view to initialize with.
    */
-  explicit ChunkedString(std::string_view sv) { append(sv); }
+  explicit ChunkedString(std::string_view sv UTILS_LIFETIME_BOUND) { append(sv); }
 
   /**
    * Constructor from an RcString.
@@ -51,7 +51,7 @@ public:
    *
    * @param str The C-style string to initialize with.
    */
-  explicit ChunkedString(const char* str) { append(std::string_view(str)); }
+  explicit ChunkedString(const char* str UTILS_LIFETIME_BOUND) { append(std::string_view(str)); }
 
   /**
    * Copy constructor from another ChunkedString.
@@ -195,7 +195,7 @@ public:
   /**
    * Return the first chunk as a string_view.
    */
-  std::string_view firstChunk() const {
+  std::string_view firstChunk() const UTILS_LIFETIME_BOUND {
     if (pieces_.empty()) {
       return std::string_view();
     }

--- a/donner/base/Path.h
+++ b/donner/base/Path.h
@@ -10,6 +10,7 @@
 #include "donner/base/Box.h"
 #include "donner/base/FillRule.h"
 #include "donner/base/Transform.h"
+#include "donner/base/Utils.h"
 #include "donner/base/Vector2.h"
 
 namespace donner {
@@ -137,10 +138,10 @@ public:
   /// @{
 
   /// Returns the points array.
-  std::span<const Vector2d> points() const { return points_; }
+  std::span<const Vector2d> points() const UTILS_LIFETIME_BOUND { return points_; }
 
   /// Returns the commands array.
-  std::span<const Command> commands() const { return commands_; }
+  std::span<const Command> commands() const UTILS_LIFETIME_BOUND { return commands_; }
 
   /// Returns true if the path has no commands.
   bool empty() const { return commands_.empty(); }

--- a/donner/base/RcStringOrRef.h
+++ b/donner/base/RcStringOrRef.h
@@ -60,7 +60,8 @@ public:
    *
    * @param value Input string to reference.
    */
-  /* implicit */ constexpr RcStringOrRef(std::string_view value) : value_(value) {}
+  /* implicit */ constexpr RcStringOrRef(std::string_view value UTILS_LIFETIME_BOUND)
+      : value_(value) {}
 
   /**
    * Constructs a new RcStringOrRef containing a transferrable RcString.
@@ -76,7 +77,7 @@ public:
    * @param len Length of the string, or npos to automatically measure, which requires that \ref
    *   data is null-terminated.
    */
-  /* implicit */ constexpr RcStringOrRef(const char* value, size_t len = npos)
+  /* implicit */ constexpr RcStringOrRef(const char* value UTILS_LIFETIME_BOUND, size_t len = npos)
       : RcStringOrRef(len == npos ? std::string_view(value) : std::string_view(value, len)) {}
 
   /// Copy constructor.

--- a/donner/base/element/ElementLike.h
+++ b/donner/base/element/ElementLike.h
@@ -25,7 +25,7 @@ concept ElementLike =
       { t.lastChild() } -> std::same_as<std::optional<T>>;
       { t.previousSibling() } -> std::same_as<std::optional<T>>;
       { t.nextSibling() } -> std::same_as<std::optional<T>>;
-      { t.tagName() } -> std::same_as<xml::XMLQualifiedNameRef>;
+      { t.tagName() } -> std::convertible_to<xml::XMLQualifiedNameRef>;
       { t.isKnownType() } -> std::same_as<bool>;
       { t.id() } -> std::same_as<RcString>;
       { t.className() } -> std::same_as<RcString>;

--- a/donner/base/element/tests/FakeElement.h
+++ b/donner/base/element/tests/FakeElement.h
@@ -40,7 +40,7 @@ public:
   bool operator==(const FakeElement& other) const { return data_ == other.data_; }
 
   /// Get the XML tag name string for this element.
-  xml::XMLQualifiedNameRef tagName() const { return data_->tagName; }
+  xml::XMLQualifiedName tagName() const { return data_->tagName; }
 
   /// Returns true if this is a known element type. For FakeElement, returns false for "unknown"
   /// elements.

--- a/donner/base/xml/XMLDocument.h
+++ b/donner/base/xml/XMLDocument.h
@@ -147,7 +147,7 @@ public:
    * Documents created programmatically may not have source text; in that case this returns an
    * empty view.
    */
-  std::string_view source() const;
+  std::string_view source() const UTILS_LIFETIME_BOUND;
 
   /// Return the source version, or 0 for documents without a source store.
   std::uint64_t sourceVersion() const;

--- a/donner/base/xml/XMLNode.cc
+++ b/donner/base/xml/XMLNode.cc
@@ -299,7 +299,7 @@ XMLNode::Type XMLNode::type() const {
   return handle_.get<XMLNodeTypeComponent>().type();
 }
 
-XMLQualifiedNameRef XMLNode::tagName() const {
+const XMLQualifiedName& XMLNode::tagName() const {
   return handle_.get<TreeComponent>().tagName();
 }
 

--- a/donner/base/xml/XMLNode.h
+++ b/donner/base/xml/XMLNode.h
@@ -229,8 +229,8 @@ public:
   /// Get the type of this node.
   Type type() const;
 
-  /// Get the XML tag name string for this node.
-  XMLQualifiedNameRef tagName() const;
+  /// Get the XML qualified tag name for this node.
+  const XMLQualifiedName& tagName() const UTILS_LIFETIME_BOUND;
 
   /// Get the underlying \ref EntityHandle, for advanced use-cases that require direct access to the
   /// ECS.

--- a/donner/base/xml/XMLQualifiedName.h
+++ b/donner/base/xml/XMLQualifiedName.h
@@ -6,9 +6,11 @@
  */
 
 #include <ostream>
+#include <string_view>
 
 #include "donner/base/RcString.h"
 #include "donner/base/RcStringOrRef.h"
+#include "donner/base/Utils.h"
 
 namespace donner::xml {
 
@@ -62,6 +64,20 @@ struct XMLQualifiedName {
   /* implicit */ XMLQualifiedName(const RcString& name) : namespacePrefix(), name(name) {}
 
   /**
+   * Construct from an attribute with an empty (default) namespace.
+   *
+   * @param name The attribute name.
+   */
+  explicit XMLQualifiedName(const char* name) : XMLQualifiedName(RcString(name)) {}
+
+  /**
+   * Construct from an attribute with an empty (default) namespace.
+   *
+   * @param name The attribute name.
+   */
+  explicit XMLQualifiedName(std::string_view name) : XMLQualifiedName(RcString(name)) {}
+
+  /**
    * Construct from an attribute with a namespace prefix.
    *
    * @param namespacePrefix The namespace of the name, or empty if the name belongs to the default
@@ -70,6 +86,13 @@ struct XMLQualifiedName {
    */
   XMLQualifiedName(const RcString& namespacePrefix, const RcString& name)
       : namespacePrefix(namespacePrefix), name(name) {}
+
+  /**
+   * Construct by copying from a qualified-name reference.
+   *
+   * @param attr Qualified name reference to copy from.
+   */
+  explicit XMLQualifiedName(const XMLQualifiedNameRef& attr);
 
   /// Destructor.
   ~XMLQualifiedName() = default;
@@ -94,6 +117,14 @@ struct XMLQualifiedName {
 
   /// Equality operator for gtest.
   bool operator==(const XMLQualifiedName& other) const = default;
+
+  /// Compare against an unqualified name string in the default namespace.
+  friend bool operator==(const XMLQualifiedName& lhs, std::string_view rhs) {
+    return lhs.namespacePrefix.empty() && lhs.name == rhs;
+  }
+
+  /// Compare against an unqualified name string in the default namespace.
+  friend bool operator==(std::string_view lhs, const XMLQualifiedName& rhs) { return rhs == lhs; }
 
   /// Ostream output operator using XML syntax (e.g. "ns:name").
   friend std::ostream& operator<<(std::ostream& os, const XMLQualifiedName& obj) {
@@ -154,14 +185,15 @@ struct XMLQualifiedNameRef {
    *
    * @param name The attribute name.
    */
-  /* implicit */ constexpr XMLQualifiedNameRef(const char* name) : namespacePrefix(), name(name) {}
+  /* implicit */ constexpr XMLQualifiedNameRef(const char* name UTILS_LIFETIME_BOUND)
+      : namespacePrefix(), name(name) {}
 
   /**
    * Construct from an attribute name as a \c std::string_view, assumes no namespacePrefix.
    *
    * @param name The attribute name.
    */
-  /* implicit */ constexpr XMLQualifiedNameRef(std::string_view name)
+  /* implicit */ constexpr XMLQualifiedNameRef(std::string_view name UTILS_LIFETIME_BOUND)
       : namespacePrefix(), name(name) {}
 
   /**
@@ -269,6 +301,9 @@ struct XMLQualifiedNameRef {
     return details::DeferredCssSyntaxPrinter<XMLQualifiedNameRef>{*this};
   }
 };
+
+inline XMLQualifiedName::XMLQualifiedName(const XMLQualifiedNameRef& attr)
+    : namespacePrefix(RcString(attr.namespacePrefix)), name(RcString(attr.name)) {}
 
 }  // namespace donner::xml
 

--- a/donner/base/xml/XMLSourceStore.h
+++ b/donner/base/xml/XMLSourceStore.h
@@ -9,6 +9,8 @@
 #include <string_view>
 #include <vector>
 
+#include "donner/base/Utils.h"
+
 namespace donner::xml {
 
 /// Stable identifier for a source anchor stored in \ref XMLSourceStore.
@@ -81,7 +83,7 @@ public:
   explicit XMLSourceStore(std::string source);
 
   /// Return the current source bytes.
-  [[nodiscard]] std::string_view source() const { return source_; }
+  [[nodiscard]] std::string_view source() const UTILS_LIFETIME_BOUND { return source_; }
 
   /// Return the monotonically increasing source version.
   [[nodiscard]] std::uint64_t sourceVersion() const { return sourceVersion_; }

--- a/donner/base/xml/XMLTokenType.h
+++ b/donner/base/xml/XMLTokenType.h
@@ -9,6 +9,7 @@
 #include <ostream>
 
 #include "donner/base/FileOffset.h"
+#include "donner/base/Utils.h"
 
 namespace donner::xml {
 
@@ -70,7 +71,7 @@ struct XMLToken {
   SourceRange range;  ///< Source byte range `[start, end)`.
 
   /// Convenience: extract the token's text from the original source.
-  std::string_view text(std::string_view source) const {
+  std::string_view text(std::string_view source UTILS_LIFETIME_BOUND) const {
     if (!range.start.offset || !range.end.offset) {
       return {};
     }

--- a/donner/base/xml/components/TreeComponent.h
+++ b/donner/base/xml/components/TreeComponent.h
@@ -4,6 +4,7 @@
 #include "donner/base/EcsRegistry.h"
 #include "donner/base/RcString.h"
 #include "donner/base/SmallVector.h"
+#include "donner/base/Utils.h"
 #include "donner/base/xml/XMLQualifiedName.h"
 
 namespace donner::components {
@@ -78,8 +79,13 @@ public:
    */
   void remove(Registry& registry);
 
-  /// Get the qualified tag name of the element, e.g. "svg".
-  xml::XMLQualifiedNameRef tagName() const { return tagName_; }
+  /**
+   * Get the qualified tag name of the element, e.g. "svg".
+   *
+   * The returned reference is tied to this component and remains valid until the component is
+   * destroyed or its tag name is replaced.
+   */
+  const xml::XMLQualifiedName& tagName() const UTILS_LIFETIME_BOUND { return tagName_; }
 
   /// Get the parent of this node, if it has one. Returns \c entt::null if this is the root.
   Entity parent() const { return parent_; }

--- a/donner/css/Stylesheet.h
+++ b/donner/css/Stylesheet.h
@@ -3,6 +3,7 @@
 
 #include <ostream>
 
+#include "donner/base/Utils.h"
 #include "donner/css/Declaration.h"
 #include "donner/css/FontFace.h"
 #include "donner/css/Selector.h"
@@ -81,12 +82,12 @@ public:
   /**
    * Get the list of rules in this stylesheet.
    */
-  std::span<const SelectorRule> rules() const { return rules_; }
+  std::span<const SelectorRule> rules() const UTILS_LIFETIME_BOUND { return rules_; }
 
   /**
    * Get the list of `@font-face` rules in this stylesheet.
    */
-  std::span<const FontFace> fontFaces() const { return fontFaces_; }
+  std::span<const FontFace> fontFaces() const UTILS_LIFETIME_BOUND { return fontFaces_; }
 
   /**
    * Output a human-readable representation of the stylesheet to a stream.

--- a/donner/css/selectors/TypeSelector.h
+++ b/donner/css/selectors/TypeSelector.h
@@ -79,7 +79,7 @@ struct TypeSelector {
    */
   template <ElementLike T>
   bool matches(const T& element) const {
-    const xml::XMLQualifiedName elementName = element.tagName();
+    const xml::XMLQualifiedName elementName(element.tagName());
 
     // Match namespace.
     const bool namespaceMatched =

--- a/donner/css/selectors/TypeSelector.h
+++ b/donner/css/selectors/TypeSelector.h
@@ -79,7 +79,7 @@ struct TypeSelector {
    */
   template <ElementLike T>
   bool matches(const T& element) const {
-    const xml::XMLQualifiedNameRef elementName = element.tagName();
+    const xml::XMLQualifiedName elementName = element.tagName();
 
     // Match namespace.
     const bool namespaceMatched =

--- a/donner/editor/AttributeWriteback.cc
+++ b/donner/editor/AttributeWriteback.cc
@@ -105,8 +105,7 @@ std::optional<std::vector<AttributeWritebackPathSegment>> BuildElementPath(
 
     reversedPath.push_back(AttributeWritebackPathSegment{
         childIndex,
-        xml::XMLQualifiedName(RcString(current->tagName().namespacePrefix),
-                              RcString(current->tagName().name)),
+        current->tagName(),
     });
 
     if (parent->type() == xml::XMLNode::Type::Document) {

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "GLFW/glfw3.h"
+#include "donner/base/RcString.h"
 #include "donner/css/parser/ColorParser.h"
 #include "donner/editor/AttributeWriteback.h"
 #include "donner/editor/DocumentSave.h"

--- a/donner/editor/FocusView.cc
+++ b/donner/editor/FocusView.cc
@@ -157,7 +157,7 @@ std::optional<svg::ElementType> SafeElementType(const svg::SVGElement& element) 
   return element.tryType();
 }
 
-std::optional<xml::XMLQualifiedNameRef> SafeTagName(const svg::SVGElement& element) {
+std::optional<xml::XMLQualifiedName> SafeTagName(const svg::SVGElement& element) {
   return element.tryTagName();
 }
 
@@ -712,7 +712,7 @@ bool AddUniqueElement(const svg::SVGElement& element, std::vector<svg::SVGElemen
 bool HasAncestorNamed(const svg::SVGElement& element, std::string_view tagName) {
   for (std::optional<svg::SVGElement> ancestor = SafeParentElement(element); ancestor.has_value();
        ancestor = SafeParentElement(*ancestor)) {
-    const std::optional<xml::XMLQualifiedNameRef> ancestorTagName = SafeTagName(*ancestor);
+    const std::optional<xml::XMLQualifiedName> ancestorTagName = SafeTagName(*ancestor);
     if (ancestorTagName.has_value() && std::string_view(ancestorTagName->name) == tagName) {
       return true;
     }
@@ -722,7 +722,7 @@ bool HasAncestorNamed(const svg::SVGElement& element, std::string_view tagName) 
 }
 
 bool IsReferenceResourceElement(const svg::SVGElement& element) {
-  const std::optional<xml::XMLQualifiedNameRef> tagNameRef = SafeTagName(element);
+  const std::optional<xml::XMLQualifiedName> tagNameRef = SafeTagName(element);
   if (!SafeElementType(element).has_value() || !tagNameRef.has_value()) {
     return false;
   }

--- a/donner/editor/SelectTool.cc
+++ b/donner/editor/SelectTool.cc
@@ -106,7 +106,7 @@ std::optional<Transform2d> RotateTransform(const Vector2d& center, double startA
 /// `<defs>` block doesn't prevent a top-level `<g>` from being recognised
 /// as the sole render child.
 bool IsNonRenderChild(const svg::SVGElement& element) {
-  const auto tag = element.tagName().name;
+  const RcString tag = element.tagName().name;
   return tag == RcString("defs") || tag == RcString("title") || tag == RcString("desc") ||
          tag == RcString("metadata") || tag == RcString("style") || tag == RcString("script");
 }
@@ -157,7 +157,7 @@ svg::SVGElement DeepestWrappingContainer(svg::SVGElement root) {
     // Stop at non-`<g>` children (terminal geometry) and at `<g>`s that
     // carry semantic attributes — a `<g id="Foo">` or `<g filter="…">`
     // is itself a top-level object, not a wrapper.
-    const auto tag = soleRenderChild->tagName().name;
+    const RcString tag = soleRenderChild->tagName().name;
     if (tag != RcString("g")) {
       return current;
     }

--- a/donner/editor/SidebarPresenter.cc
+++ b/donner/editor/SidebarPresenter.cc
@@ -38,12 +38,10 @@ bool IsSelectedInTree(std::span<const donner::svg::SVGElement> selection,
 }
 
 std::string BuildTreeNodeLabel(const donner::svg::SVGElement& element) {
-  // Keep the returned XMLQualifiedNameRef alive: `.name` is an RcStringOrRef whose string_view can
-  // point into the returned value's own storage, so binding `.name` off a temporary dangles.
-  const donner::xml::XMLQualifiedNameRef qualifiedTagName = element.tagName();
-  const std::string_view tagName = qualifiedTagName.name;
+  const donner::RcString tagName = element.tagName().name;
+  const std::string_view tagNameSv = tagName;
   std::string label = "<";
-  label.append(tagName.data(), tagName.size());
+  label.append(tagNameSv.data(), tagNameSv.size());
   label.push_back('>');
 
   const donner::RcString id = element.id();
@@ -344,10 +342,8 @@ void SidebarPresenter::refreshSnapshot(const EditorApp& app) {
   if (selectionList.size() == 1) {
     inspector.hasSelection = true;
     const donner::svg::SVGElement& selected = selectionList.front();
-    // Keep the returned XMLQualifiedNameRef alive; see BuildTreeNodeLabel for why binding `.name`
-    // off the temporary dangles.
-    const donner::xml::XMLQualifiedNameRef selectedTagName = selected.tagName();
-    const std::string_view tagSv = selectedTagName.name;
+    const donner::RcString selectedTagName = selected.tagName().name;
+    const std::string_view tagSv = selectedTagName;
     const donner::RcString idStr = selected.id();
     const std::string_view idSv = idStr;
     if (!idSv.empty()) {

--- a/donner/editor/StyleSourceAnnotations.cc
+++ b/donner/editor/StyleSourceAnnotations.cc
@@ -91,7 +91,7 @@ struct FragmentReference {
 }
 
 [[nodiscard]] std::string TagNameForElement(const svg::SVGElement& element) {
-  if (std::optional<xml::XMLQualifiedNameRef> tagName = element.tryTagName()) {
+  if (std::optional<xml::XMLQualifiedName> tagName = element.tryTagName()) {
     return std::string(tagName->name);
   }
 
@@ -101,7 +101,7 @@ struct FragmentReference {
 [[nodiscard]] bool HasAncestorNamed(const svg::SVGElement& element, std::string_view tagName) {
   for (std::optional<svg::SVGElement> ancestor = element.parentElement(); ancestor.has_value();
        ancestor = ancestor->parentElement()) {
-    if (std::optional<xml::XMLQualifiedNameRef> ancestorTagName = ancestor->tryTagName();
+    if (std::optional<xml::XMLQualifiedName> ancestorTagName = ancestor->tryTagName();
         ancestorTagName.has_value() && std::string_view(ancestorTagName->name) == tagName) {
       return true;
     }

--- a/donner/svg/SVGDocument.cc
+++ b/donner/svg/SVGDocument.cc
@@ -609,11 +609,13 @@ bool SVGDocument::hasSourceStore() const {
 }
 
 std::string_view SVGDocument::source() const {
-  if (!documentState_->registry().ctx().contains<xml::components::XMLDocumentContext>()) {
+  Registry& registry = documentState_->registry();
+  if (!registry.ctx().contains<xml::components::XMLDocumentContext>()) {
     return std::string_view();
   }
 
-  return xmlDocument().source();
+  const auto& context = registry.ctx().get<xml::components::XMLDocumentContext>();
+  return context.sourceStore != nullptr ? context.sourceStore->source() : std::string_view();
 }
 
 std::uint64_t SVGDocument::sourceVersion() const {

--- a/donner/svg/SVGElement.cc
+++ b/donner/svg/SVGElement.cc
@@ -320,12 +320,12 @@ std::optional<ElementType> SVGElement::tryType() const {
   return handle_.get<components::ElementTypeComponent>().type();
 }
 
-xml::XMLQualifiedNameRef SVGElement::tagName() const {
+xml::XMLQualifiedName SVGElement::tagName() const {
   [[maybe_unused]] DocumentReadAccess access = handle_.readAccess();
   return handle_.get<donner::components::TreeComponent>().tagName();
 }
 
-std::optional<xml::XMLQualifiedNameRef> SVGElement::tryTagName() const {
+std::optional<xml::XMLQualifiedName> SVGElement::tryTagName() const {
   if (!handle_) {
     return std::nullopt;
   }

--- a/donner/svg/SVGElement.h
+++ b/donner/svg/SVGElement.h
@@ -284,11 +284,11 @@ public:
   /// Get the ElementType if this handle still has SVG element identity.
   std::optional<ElementType> tryType() const;
 
-  /// Get the XML tag name string for this element.
-  xml::XMLQualifiedNameRef tagName() const;
+  /// Get the owning XML qualified tag name for this element.
+  xml::XMLQualifiedName tagName() const;
 
-  /// Get the XML tag name if this handle still has XML tree identity.
-  std::optional<xml::XMLQualifiedNameRef> tryTagName() const;
+  /// Get the owning XML qualified tag name if this handle still has XML tree identity.
+  std::optional<xml::XMLQualifiedName> tryTagName() const;
 
   /// Returns true if this is a known element type, returns false if this is an
   /// \ref donner::svg::SVGUnknownElement.

--- a/donner/svg/components/StylesheetComponent.h
+++ b/donner/svg/components/StylesheetComponent.h
@@ -7,6 +7,7 @@
 
 #include "donner/base/FileOffset.h"
 #include "donner/base/ParseWarningSink.h"
+#include "donner/base/Utils.h"
 #include "donner/css/Stylesheet.h"
 
 namespace donner::svg::components {
@@ -59,7 +60,9 @@ public:
   /**
    * Get the stored mapping segments.
    */
-  std::span<const StylesheetSourceMapSegment> segments() const { return segments_; }
+  std::span<const StylesheetSourceMapSegment> segments() const UTILS_LIFETIME_BOUND {
+    return segments_;
+  }
 
 private:
   std::optional<FileOffset> mapOffset(const FileOffset& localOffset) const;

--- a/donner/svg/components/style/StyleSystem.cc
+++ b/donner/svg/components/style/StyleSystem.cc
@@ -65,7 +65,7 @@ struct ShadowedElementAdapter {
     return target != entt::null ? std::make_optional(create(target)) : std::nullopt;
   }
 
-  xml::XMLQualifiedNameRef tagName() const {
+  xml::XMLQualifiedName tagName() const {
     return registry_.get().get<donner::components::TreeComponent>(treeEntity_).tagName();
   }
 

--- a/donner/svg/graph/Reference.h
+++ b/donner/svg/graph/Reference.h
@@ -6,6 +6,7 @@
 
 #include "donner/base/EcsRegistry.h"
 #include "donner/base/RcString.h"
+#include "donner/base/Utils.h"
 
 namespace donner::svg {
 
@@ -78,7 +79,7 @@ struct Reference {
    * - `file.svg#elementId` → `"file.svg"`
    * - `path/to/file.svg#id` → `"path/to/file.svg"`
    */
-  std::string_view documentUrl() const;
+  std::string_view documentUrl() const UTILS_LIFETIME_BOUND;
 
   /**
    * Returns the fragment component of the reference (without the `#` prefix), or an empty
@@ -89,7 +90,7 @@ struct Reference {
    * - `file.svg` → `""`
    * - `file.svg#elementId` → `"elementId"`
    */
-  std::string_view fragment() const;
+  std::string_view fragment() const UTILS_LIFETIME_BOUND;
 
   /**
    * Attempts to resolve the reference as a same-document reference using the provided registry.

--- a/donner/svg/parser/details/SVGParserContext.h
+++ b/donner/svg/parser/details/SVGParserContext.h
@@ -3,6 +3,7 @@
 #include "donner/base/FileOffset.h"
 #include "donner/base/ParseDiagnostic.h"
 #include "donner/base/ParseWarningSink.h"
+#include "donner/base/Utils.h"
 #include "donner/base/parser/LineOffsets.h"
 #include "donner/base/xml/XMLNode.h"
 #include "donner/base/xml/XMLQualifiedName.h"
@@ -39,7 +40,7 @@ public:
    * @param warningSink Sink to collect warnings encountered during parsing.
    * @param options Options for parsing.
    */
-  SVGParserContext(std::string_view input, ParseWarningSink& warningSink,
+  SVGParserContext(std::string_view input UTILS_LIFETIME_BOUND, ParseWarningSink& warningSink,
                    const SVGParser::Options& options)
       : input_(input), lineOffsets_(input), warningSink_(warningSink), options_(options) {}
 
@@ -54,7 +55,7 @@ public:
   void setNamespacePrefix(const RcString& namespacePrefix) { namespacePrefix_ = namespacePrefix; }
 
   /// Get the XML document's default namespace prefix, such as "http://www.w3.org/2000/svg".
-  std::string_view namespacePrefix() const { return namespacePrefix_; }
+  std::string_view namespacePrefix() const UTILS_LIFETIME_BOUND { return namespacePrefix_; }
 
   /**
    * Remap a parse error from a subparser back to the original input string, translating the line

--- a/donner/svg/tool/DonnerSvgToolUtils.cc
+++ b/donner/svg/tool/DonnerSvgToolUtils.cc
@@ -11,7 +11,7 @@ namespace donner::svg {
 namespace {
 
 std::string TagNameForSelector(const SVGElement& element) {
-  return std::string(element.tagName().name);
+  return element.tagName().name.str();
 }
 
 std::string ClassToken(const SVGElement& element) {


### PR DESCRIPTION
Fixes #603.

## Summary
- Return `XMLNode::tagName()` and `TreeComponent::tagName()` as lifetime-bound `const XMLQualifiedName&`, while keeping public `SVGElement` tag-name APIs owning across document read access.
- Keep CSS selector helper inputs as `XMLQualifiedNameRef` and update call sites to avoid dangling borrowed names.
- Add `UTILS_LIFETIME_BOUND` annotations to audited view-returning APIs and extend the banned-pattern lint/docs to prevent returning `XMLQualifiedNameRef` or `RcStringOrRef` from APIs.

## Validation
- `python3 build_defs/check_banned_patterns.py donner`
- `git diff --check`
- `python3 tools/cmake/gen_cmakelists.py --check`
- `bazel test //donner/base/xml:xml_tests`
- `bazel test --test_output=errors //donner/svg/tests:svg_tests`
- Header/implementation syntax-only smoke checks for the touched XML, SVG, CSS, editor, and SVG document translation units.
- `bazel build //donner/benchmarks:tinyskia_render_perf_bench` after aggregate-suite linker `Exit 9` rerun.

## Known local validation caveat
- `bazel test //...` did not complete green locally: `//donner/editor/tests:text_editor_tests` reproducibly fails 7 clipboard cases because `ImGui::GetClipboardText()` returns `NULL` and paste is a no-op in this test environment. The failures are isolated to editor clipboard behavior and do not intersect this XML/SVG lifetime change.