### PR TITLE
Fix Geode ASan WebGPU leaks

### DIFF
--- a/donner/editor/EmbeddedSvgIcon.cc
+++ b/donner/editor/EmbeddedSvgIcon.cc
@@ -41,8 +41,8 @@ void NormalizeIconBitmapToTintableAlphaMask(svg::RendererBitmap* bitmap) {
 /// showed up as a stream of duplicate "[Geode/wgpu-native] Adapter:" logs at
 /// editor startup.
 svg::Renderer& SharedIconRenderer() {
-  static svg::Renderer* renderer = new svg::Renderer();
-  return *renderer;
+  static svg::Renderer renderer;
+  return renderer;
 }
 
 }  // namespace

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -809,12 +809,28 @@ struct RendererGeode::Impl {
       device->queue().submit(1, &cb.get());
       device->countSubmit();
     }
+    frameFinishedEncoders.clear();
     wgpu::CommandEncoderDescriptor desc = {};
     desc.label = wgpuLabel("RendererGeodeFrameCE");
     frameCommandEncoder.reset(device->device().createCommandEncoder(desc));
   }
 
   std::unique_ptr<geode::GeoEncoder> encoder;
+  std::vector<std::unique_ptr<geode::GeoEncoder>> frameFinishedEncoders;
+
+  void retireFinishedEncoder(std::unique_ptr<geode::GeoEncoder> finishedEncoder) {
+    if (finishedEncoder) {
+      frameFinishedEncoders.push_back(std::move(finishedEncoder));
+    }
+  }
+
+  void retireActiveEncoder() {
+    if (!encoder) {
+      return;
+    }
+    encoder->finish();
+    retireFinishedEncoder(std::move(encoder));
+  }
 
   // Reusable scratch storage for gradient stop vectors — keeps the
   // per-fillPath allocation counts down and lets the `std::span` in
@@ -1003,6 +1019,7 @@ struct RendererGeode::Impl {
     wgpu::TextureDescriptor desc;
   };
   std::vector<PendingRelease> framePendingReleases;
+  std::vector<geode::ScopedWgpuHandle<wgpu::TextureView>> framePendingTextureViewReleases;
 
   void releaseTextureAtFrameEnd(wgpu::Texture texture, const wgpu::TextureDescriptor& desc) {
     if (!texture) {
@@ -1011,7 +1028,18 @@ struct RendererGeode::Impl {
     framePendingReleases.push_back({std::move(texture), desc});
   }
 
+  void releaseTextureViewsAtFrameEnd(
+      std::vector<geode::ScopedWgpuHandle<wgpu::TextureView>>& views) {
+    for (auto& view : views) {
+      if (view) {
+        framePendingTextureViewReleases.push_back(std::move(view));
+      }
+    }
+    views.clear();
+  }
+
   void drainPendingReleases() {
+    framePendingTextureViewReleases.clear();
     for (auto& pending : framePendingReleases) {
       releaseTexture(std::move(pending.texture), pending.desc);
     }
@@ -1139,8 +1167,11 @@ struct RendererGeode::Impl {
     /// `maskResolveView`; the intermediate layer textures are parked
     /// in `maskLayerTextures` so their wgpu::Texture ownership
     /// persists until `popClip`.
-    wgpu::Texture maskMsaaTexture;
     wgpu::Texture maskResolveTexture;
+    /// Owned texture views created for each nested mask layer. Released after
+    /// the frame command buffer is submitted because recorded bind groups may
+    /// still reference them after `popClip`.
+    std::vector<geode::ScopedWgpuHandle<wgpu::TextureView>> maskLayerViews;
     wgpu::TextureView maskResolveView;
     /// Paired (texture, descriptor) entries. Every clip-mask texture
     /// allocated by `pushClip` (across all nested layers) lives here
@@ -1735,17 +1766,115 @@ struct RendererGeode::Impl {
     }
   }
 
-  // No custom destructor: the M2 cache-invalidation listener is a
-  // free function with no dependency on `this`, so the natural entt
-  // lifecycle is correct — connections die with the `Registry` they
-  // live on. Calling `.disconnect<&fn>()` from a dtor would UB when
-  // the registry is destroyed BEFORE the renderer (common in tests
-  // where an `SVGDocument` is declared after its `Renderer` in the
-  // same scope, so the document destructs first). Leaving the
-  // connection attached is harmless: either the registry is alive
-  // and a subsequent geometry change fires `remove<GeodePathCacheComponent>`
-  // (which is a no-op if the component isn't present), or the
-  // registry is gone and no signal will ever fire again.
+  // The M2 cache-invalidation listener is a free function with no dependency
+  // on `this`, so Impl teardown intentionally leaves it attached. Connections
+  // die with the `Registry` they live on, and calling `.disconnect<&fn>()` from
+  // a renderer dtor would UB when the registry was destroyed first.
+
+  static void destroyTextureBacking(geode::ScopedWgpuHandle<wgpu::Texture>& texture) {
+    if (texture) {
+      texture.get().destroy();
+    }
+  }
+
+  static void destroyAndReleaseTexture(wgpu::Texture& texture) {
+    if (texture) {
+      texture.destroy();
+      geode::ReleaseWgpuHandle(texture);
+    }
+  }
+
+  static void destroyPendingTexture(PendingRelease& release) {
+    destroyAndReleaseTexture(release.texture);
+  }
+
+  static void destroyClipStackTextures(std::vector<ClipStackEntry>& entries) {
+    for (ClipStackEntry& entry : entries) {
+      entry.maskLayerViews.clear();
+      for (PendingRelease& release : entry.maskLayerTextures) {
+        destroyPendingTexture(release);
+      }
+      entry.maskLayerTextures.clear();
+      entry.maskResolveTexture = wgpu::Texture();
+      entry.maskResolveView = wgpu::TextureView();
+    }
+    entries.clear();
+  }
+
+  void destroyTexturePool() {
+    for (auto& [unusedKey, bucket] : texturePool) {
+      (void)unusedKey;
+      for (geode::ScopedWgpuHandle<wgpu::Texture>& texture : bucket.free) {
+        destroyTextureBacking(texture);
+      }
+    }
+    texturePool.clear();
+  }
+
+  ~Impl() {
+    encoder.reset();
+    frameCommandEncoder.reset();
+    frameFinishedEncoders.clear();
+
+    if (device && device->device()) {
+      device->device().poll(true, nullptr);
+    }
+
+    framePendingTextureViewReleases.clear();
+    for (PendingRelease& release : framePendingReleases) {
+      destroyPendingTexture(release);
+    }
+    framePendingReleases.clear();
+
+    for (LayerStackFrame& frame : layerStack) {
+      destroyAndReleaseTexture(frame.layerTexture);
+      destroyAndReleaseTexture(frame.layerMsaaTexture);
+    }
+    layerStack.clear();
+
+    for (MaskStackFrame& frame : maskStack) {
+      destroyAndReleaseTexture(frame.maskTexture);
+      destroyAndReleaseTexture(frame.maskMsaaTexture);
+      destroyAndReleaseTexture(frame.contentTexture);
+      destroyAndReleaseTexture(frame.contentMsaaTexture);
+    }
+    maskStack.clear();
+
+    destroyClipStackTextures(clipStack);
+    for (FilterStackFrame& frame : filterStack) {
+      destroyAndReleaseTexture(frame.layerTexture);
+      destroyAndReleaseTexture(frame.layerMsaaTexture);
+      destroyClipStackTextures(frame.savedClipStack);
+    }
+    filterStack.clear();
+
+    for (PatternStackFrame& frame : patternStack) {
+      destroyTextureBacking(frame.tileTexture);
+      destroyTextureBacking(frame.tileMsaaTexture);
+    }
+    patternStack.clear();
+    if (patternFillPaint.has_value()) {
+      destroyTextureBacking(patternFillPaint->tile);
+    }
+    if (patternStrokePaint.has_value()) {
+      destroyTextureBacking(patternStrokePaint->tile);
+    }
+    patternFillPaint.reset();
+    patternStrokePaint.reset();
+
+    destroyTextureBacking(ownedTarget);
+    ownedTarget.reset();
+    destroyTextureBacking(ownedMsaaTarget);
+    ownedMsaaTarget.reset();
+    destroyTexturePool();
+
+    if (device) {
+      device->drainDeferredDestroys();
+      if (device->device()) {
+        device->device().poll(true, nullptr);
+      }
+    }
+  }
 
   /// Wire up per-renderer state against the shared GeodeDevice. Before
   /// issue #575's fix each renderer constructed its own pipelines
@@ -1891,6 +2020,7 @@ void RendererGeode::beginFrame(const RenderViewport& viewport) {
   impl_->deviceFromLocalTransformStack.clear();
   impl_->paint = PaintParams();
   impl_->encoder.reset();
+  impl_->frameFinishedEncoders.clear();
 
   // M4.2: stamp each frame with a monotonic index and age out pool
   // buckets that haven't been touched in the last
@@ -2034,8 +2164,7 @@ void RendererGeode::endFrame() {
 
   if (impl_->encoder) {
     // Ends the open render pass without submitting — shared-mode.
-    impl_->encoder->finish();
-    impl_->encoder.reset();
+    impl_->retireActiveEncoder();
   }
 
   // Finalise and submit the single frame-wide CommandEncoder. After
@@ -2049,6 +2178,7 @@ void RendererGeode::endFrame() {
       impl_->device->countSubmit();
     }
     impl_->frameCommandEncoder.reset();
+    impl_->frameFinishedEncoders.clear();
   }
 
   // Now that the command buffer is submitted, it's safe to return the
@@ -2301,7 +2431,11 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
       impl_->encoder->endMaskPass();
 
       nestedMaskTexture = resolveTexture;
-      nestedMaskView = resolveTexture.createView();
+      geode::ScopedWgpuHandle<wgpu::TextureView> resolveView(resolveTexture.createView());
+      nestedMaskView = resolveView.get();
+      if (resolveView) {
+        entry.maskLayerViews.push_back(std::move(resolveView));
+      }
 
       // Keep the intermediate textures alive until popClip, paired
       // with their descs for M4.2 pool release.
@@ -2339,6 +2473,7 @@ void RendererGeode::popClip() {
     // recycling mid-frame could hand the texture to a later acquire
     // before the submit.
     Impl::ClipStackEntry& entry = impl_->clipStack.back();
+    impl_->releaseTextureViewsAtFrameEnd(entry.maskLayerViews);
     for (auto& release : entry.maskLayerTextures) {
       impl_->releaseTextureAtFrameEnd(std::move(release.texture), release.desc);
     }
@@ -2447,8 +2582,9 @@ void RendererGeode::popIsolatedLayer() {
 
   // Finish the layer's render pass so the texture contents are ready.
   if (impl_->encoder) {
-    impl_->encoder->finish();
+    impl_->retireActiveEncoder();
   }
+  impl_->retireFinishedEncoder(std::move(frame.savedEncoder));
 
   // Restore outer target references.
   impl_->target = frame.savedTarget;
@@ -2634,13 +2770,13 @@ void RendererGeode::pushFilterLayer(const components::FilterGraph& filterGraph,
   frame.deviceFromFilter = impl_->deviceFromLocalTransform;
   frame.filterBufferOffsetX = filterBufferOffsetX;
   frame.filterBufferOffsetY = filterBufferOffsetY;
-  frame.savedClipStack = impl_->clipStack;
+  frame.savedClipStack = std::move(impl_->clipStack);
 
   // SVG 2 §15.5: the SourceGraphic that feeds the filter graph must be
   // UNCLIPPED (paint → filter → clip → mask → opacity). Clear the outer
   // clip stack so inner draws into the filter layer aren't gated by the
-  // outer clip-path. The outer mask textures stay alive in
-  // frame.savedClipStack (copy preserves refcounts), and popFilterLayer
+  // outer clip-path. The outer mask textures and views stay alive in
+  // frame.savedClipStack, and popFilterLayer
   // restores the stack and re-binds the mask before the composite blit.
   impl_->clipStack.clear();
 
@@ -2681,7 +2817,7 @@ void RendererGeode::popFilterLayer() {
   }
   Impl::FilterStackFrame frame = std::move(impl_->filterStack.back());
   impl_->filterStack.pop_back();
-  impl_->clipStack = frame.savedClipStack;
+  impl_->clipStack = std::move(frame.savedClipStack);
 
   if (!frame.layerTexture) {
     return;  // Placeholder frame from the headless/error path.
@@ -2689,8 +2825,9 @@ void RendererGeode::popFilterLayer() {
 
   // Finish the filter layer's render pass so the texture is ready.
   if (impl_->encoder) {
-    impl_->encoder->finish();
+    impl_->retireActiveEncoder();
   }
+  impl_->retireFinishedEncoder(std::move(frame.savedEncoder));
 
   // The filter engine runs on its own CommandEncoder + submit, so the
   // layer-texture writes we just recorded into `frameCommandEncoder`
@@ -2824,6 +2961,9 @@ void RendererGeode::popFilterLayer() {
                                     Box2d::FromXYWH(0.0, 0.0, static_cast<double>(localWidth),
                                                     static_cast<double>(localHeight)),
                                     1.0, /*pixelated=*/false);
+        if (localFiltered && localFiltered != localTexture) {
+          impl_->device->deferDestroy(std::move(localFiltered));
+        }
         impl_->encoder->setTransform(Transform2d());
 
         impl_->releaseTextureAtFrameEnd(std::move(localTexture), localDesc);
@@ -3011,7 +3151,7 @@ void RendererGeode::transitionMaskToContent() {
 
   // Flush the mask-capture encoder so the mask texture is ready to
   // sample in popMask.
-  impl_->encoder->finish();
+  impl_->retireActiveEncoder();
 
   impl_->target = frame.contentTexture;
   impl_->msaaTarget = frame.contentMsaaTexture;
@@ -3039,8 +3179,9 @@ void RendererGeode::popMask() {
 
   // Finish the content encoder so its resolve is ready to sample.
   if (impl_->encoder) {
-    impl_->encoder->finish();
+    impl_->retireActiveEncoder();
   }
+  impl_->retireFinishedEncoder(std::move(frame.savedEncoder));
 
   // Restore the outer target and reopen a new encoder with load-
   // preserve on the saved MSAA state.
@@ -3243,8 +3384,9 @@ void RendererGeode::endPatternTile(bool forStroke) {
   // Finish the tile's render pass so the texture contents are available
   // for sampling by subsequent draws.
   if (impl_->encoder) {
-    impl_->encoder->finish();
+    impl_->retireActiveEncoder();
   }
+  impl_->retireFinishedEncoder(std::move(frame.savedEncoder));
   if (frame.tileMsaaTexture) {
     impl_->device->deferDestroy(frame.tileMsaaTexture.take());
   }

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -38,6 +38,13 @@ constexpr uint64_t kStorageOffsetAlignment = 256u;
 // wgpu-native backends (`minUniformBufferOffsetAlignment`).
 constexpr uint64_t kUniformOffsetAlignment = 256u;
 
+template <typename Handle>
+void DestroyResourceBacking(ScopedWgpuHandle<Handle>& handle) {
+  if (handle) {
+    handle.get().destroy();
+  }
+}
+
 /// Layout of the per-draw uniform buffer (must match shaders/slug_fill.wgsl).
 ///
 /// WGSL struct layout requires the total size to be a multiple of the largest
@@ -242,6 +249,32 @@ struct GeoEncoder::Impl {
   /// `InstanceTransform` struct. Alignment uses `kStorageOffsetAlignment`
   /// since the binding is storage read-only.
   Arena instanceTransformArena;
+
+  void destroyArenaBackings(Arena& arena) {
+    DestroyResourceBacking(arena.buffer);
+    arena.buffer.reset();
+    for (ScopedWgpuHandle<wgpu::Buffer>& buffer : arena.retired) {
+      DestroyResourceBacking(buffer);
+      buffer.reset();
+    }
+    arena.retired.clear();
+  }
+
+  void destroyOwnedResourceBackings() {
+    pass.reset();
+    maskPass.reset();
+
+    destroyArenaBackings(vertexArena);
+    destroyArenaBackings(bandArena);
+    destroyArenaBackings(curveArena);
+    destroyArenaBackings(uniformArena);
+    destroyArenaBackings(vBandArena);
+    destroyArenaBackings(vCurveArena);
+    destroyArenaBackings(hGridArena);
+    destroyArenaBackings(vGridArena);
+    destroyArenaBackings(instanceTransformArena);
+    transientResources.destroyBackings();
+  }
 
   // When true, this encoder owns its `commandEncoder` and `finish()`
   // calls `commandEncoder.finish()` + `queue().submit()`. When false
@@ -760,7 +793,11 @@ GeoEncoder::GeoEncoder(GeodeDevice& device, const GeodePipeline& fillPipeline,
   finalizeImpl(*impl_);
 }
 
-GeoEncoder::~GeoEncoder() = default;
+GeoEncoder::~GeoEncoder() {
+  if (impl_) {
+    impl_->destroyOwnedResourceBackings();
+  }
+}
 GeoEncoder::GeoEncoder(GeoEncoder&&) noexcept = default;
 GeoEncoder& GeoEncoder::operator=(GeoEncoder&&) noexcept = default;
 

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -100,6 +100,45 @@ wgpu::Instance CreateHeadlessInstance(wgpu::BackendType backendType) {
   return wgpu::createInstance();
 }
 
+void WaitForSubmittedWork(const wgpu::Device& device, const wgpu::Queue& queue) {
+  if (!device || !queue) {
+    return;
+  }
+
+  struct WorkDoneState {
+    bool done = false;
+  } state;
+
+  wgpu::QueueWorkDoneCallbackInfo callbackInfo{wgpu::Default};
+  callbackInfo.mode = wgpu::CallbackMode::AllowSpontaneous;
+  callbackInfo.callback = [](WGPUQueueWorkDoneStatus /*status*/, void* userdata1,
+                             void* /*userdata2*/) {
+    WorkDoneState* state = static_cast<WorkDoneState*>(userdata1);
+    state->done = true;
+  };
+  callbackInfo.userdata1 = &state;
+  callbackInfo.userdata2 = nullptr;
+
+  queue.onSubmittedWorkDone(callbackInfo);
+  for (int pollIter = 0; !state.done && pollIter < 2000; ++pollIter) {
+    device.poll(true, nullptr);
+  }
+}
+
+template <typename Handle>
+void DestroyResourceBacking(ScopedWgpuHandle<Handle>& handle) {
+  if (handle) {
+    handle.get().destroy();
+  }
+}
+
+template <typename Handle>
+void DestroyResourceBackings(std::vector<ScopedWgpuHandle<Handle>>& handles) {
+  for (ScopedWgpuHandle<Handle>& handle : handles) {
+    DestroyResourceBacking(handle);
+  }
+}
+
 }  // namespace
 
 /// PIMPL struct: holds the wgpu::Instance so its lifetime is tied to
@@ -107,6 +146,12 @@ wgpu::Instance CreateHeadlessInstance(wgpu::BackendType backendType) {
 /// directly on the outer class. In embedded mode, `instance` is null
 /// because the host owns the instance.
 struct GeodeDevice::Impl {
+  ~Impl() {
+    DestroyResourceBacking(dummyPatternTexture);
+    DestroyResourceBacking(dummyClipMaskTexture);
+    DestroyResourceBacking(identityInstanceTransformBuffer);
+  }
+
   wgpu::Instance instance;
 
   // Shared dummies used by every GeoEncoder's bind groups — see
@@ -143,7 +188,38 @@ struct GeodeDevice::Impl {
 };
 
 GeodeDevice::GeodeDevice() : impl_(std::make_unique<Impl>()) {}
-GeodeDevice::~GeodeDevice() = default;
+GeodeDevice::~GeodeDevice() {
+  // Release all resources that were created from the device before releasing the
+  // root queue/device/adapter/instance handles. `webgpu.hpp` handles are raw
+  // wrappers: their destructors do not release native references.
+  WaitForSubmittedWork(device_, queue_);
+  wgpu::Instance instance;
+  if (!external_ && impl_) {
+    instance = impl_->instance;
+    impl_->instance = wgpu::Instance();
+  }
+  drainDeferredDestroys();
+  impl_.reset();
+  if (device_) {
+    device_.poll(true, nullptr);
+    WaitForSubmittedWork(device_, queue_);
+  }
+
+  if (external_) {
+    queue_ = wgpu::Queue();
+    device_ = wgpu::Device();
+    adapter_ = wgpu::Adapter();
+    return;
+  }
+
+  ReleaseWgpuHandle(queue_);
+  if (device_) {
+    device_.destroy();
+  }
+  ReleaseWgpuHandle(device_);
+  ReleaseWgpuHandle(adapter_);
+  ReleaseWgpuHandle(instance);
+}
 
 namespace {
 /// Process-wide count of CreateHeadless calls, for tests that pin device
@@ -491,6 +567,8 @@ void GeodeDevice::deferDestroy(wgpu::Texture texture) {
 }
 
 void GeodeDevice::drainDeferredDestroys() {
+  DestroyResourceBackings(pendingBuffers_);
+  DestroyResourceBackings(pendingTextures_);
   pendingBuffers_.clear();
   pendingTextures_.clear();
 }

--- a/donner/svg/renderer/geode/GeodeFilterEngine.cc
+++ b/donner/svg/renderer/geode/GeodeFilterEngine.cc
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <numbers>
 #include <unordered_map>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -454,14 +455,15 @@ wgpu::Texture createIntermediateTexture(FilterResourceArena& arena, const wgpu::
 /// Helper to create a pipeline with a standard (input, output, uniform) bind group layout.
 /// Used by blur, offset, and color-matrix pipelines.
 struct InputOutputUniformPipeline {
-  wgpu::BindGroupLayout bindGroupLayout;
-  wgpu::ComputePipeline pipeline;
+  ScopedWgpuHandle<wgpu::BindGroupLayout> bindGroupLayout;
+  ScopedWgpuHandle<wgpu::ComputePipeline> pipeline;
 };
 
 InputOutputUniformPipeline createInputOutputUniformPipeline(const wgpu::Device& dev,
                                                             const char* label,
                                                             wgpu::ShaderModule shaderModule,
                                                             size_t uniformSize) {
+  ScopedWgpuHandle<wgpu::ShaderModule> shader(shaderModule);
   wgpu::BindGroupLayoutEntry entries[3]{};
 
   entries[0].binding = 0;
@@ -486,37 +488,38 @@ InputOutputUniformPipeline createInputOutputUniformPipeline(const wgpu::Device& 
   bglDesc.label = wgpuLabel(bglLabel.c_str());
   bglDesc.entryCount = 3;
   bglDesc.entries = entries;
-  auto bgl = dev.createBindGroupLayout(bglDesc);
+  ScopedWgpuHandle<wgpu::BindGroupLayout> bgl(dev.createBindGroupLayout(bglDesc));
 
   std::string plLabel = std::string(label) + "PipelineLayout";
   wgpu::PipelineLayoutDescriptor plDesc{};
   plDesc.label = wgpuLabel(plLabel.c_str());
   plDesc.bindGroupLayoutCount = 1;
-  WGPUBindGroupLayout layouts[1] = {bgl};
+  WGPUBindGroupLayout layouts[1] = {bgl.get()};
   plDesc.bindGroupLayouts = layouts;
-  wgpu::PipelineLayout pipelineLayout = dev.createPipelineLayout(plDesc);
+  ScopedWgpuHandle<wgpu::PipelineLayout> pipelineLayout(dev.createPipelineLayout(plDesc));
 
   std::string cpLabel = std::string(label) + "Pipeline";
   wgpu::ComputePipelineDescriptor cpDesc{};
   cpDesc.label = wgpuLabel(cpLabel.c_str());
-  cpDesc.layout = pipelineLayout;
-  cpDesc.compute.module = shaderModule;
+  cpDesc.layout = pipelineLayout.get();
+  cpDesc.compute.module = shader.get();
   cpDesc.compute.entryPoint = wgpuLabel("main");
-  auto pipeline = dev.createComputePipeline(cpDesc);
+  ScopedWgpuHandle<wgpu::ComputePipeline> pipeline(dev.createComputePipeline(cpDesc));
 
-  return {bgl, pipeline};
+  return {std::move(bgl), std::move(pipeline)};
 }
 
 /// Helper to create a pipeline with a two-input (in1, in2, output, uniform) bind group layout.
 /// Used by feComposite and feBlend pipelines.
 struct TwoInputUniformPipeline {
-  wgpu::BindGroupLayout bindGroupLayout;
-  wgpu::ComputePipeline pipeline;
+  ScopedWgpuHandle<wgpu::BindGroupLayout> bindGroupLayout;
+  ScopedWgpuHandle<wgpu::ComputePipeline> pipeline;
 };
 
 TwoInputUniformPipeline createTwoInputUniformPipeline(const wgpu::Device& dev, const char* label,
                                                       wgpu::ShaderModule shaderModule,
                                                       size_t uniformSize) {
+  ScopedWgpuHandle<wgpu::ShaderModule> shader(shaderModule);
   wgpu::BindGroupLayoutEntry entries[4]{};
 
   // binding 0: in1 (texture_2d)
@@ -551,25 +554,25 @@ TwoInputUniformPipeline createTwoInputUniformPipeline(const wgpu::Device& dev, c
   bglDesc.label = wgpuLabel(bglLabel.c_str());
   bglDesc.entryCount = 4;
   bglDesc.entries = entries;
-  auto bgl = dev.createBindGroupLayout(bglDesc);
+  ScopedWgpuHandle<wgpu::BindGroupLayout> bgl(dev.createBindGroupLayout(bglDesc));
 
   std::string plLabel = std::string(label) + "PipelineLayout";
   wgpu::PipelineLayoutDescriptor plDesc{};
   plDesc.label = wgpuLabel(plLabel.c_str());
   plDesc.bindGroupLayoutCount = 1;
-  WGPUBindGroupLayout layouts[1] = {bgl};
+  WGPUBindGroupLayout layouts[1] = {bgl.get()};
   plDesc.bindGroupLayouts = layouts;
-  wgpu::PipelineLayout pipelineLayout = dev.createPipelineLayout(plDesc);
+  ScopedWgpuHandle<wgpu::PipelineLayout> pipelineLayout(dev.createPipelineLayout(plDesc));
 
   std::string cpLabel = std::string(label) + "Pipeline";
   wgpu::ComputePipelineDescriptor cpDesc{};
   cpDesc.label = wgpuLabel(cpLabel.c_str());
-  cpDesc.layout = pipelineLayout;
-  cpDesc.compute.module = shaderModule;
+  cpDesc.layout = pipelineLayout.get();
+  cpDesc.compute.module = shader.get();
   cpDesc.compute.entryPoint = wgpuLabel("main");
-  auto pipeline = dev.createComputePipeline(cpDesc);
+  ScopedWgpuHandle<wgpu::ComputePipeline> pipeline(dev.createComputePipeline(cpDesc));
 
-  return {bgl, pipeline};
+  return {std::move(bgl), std::move(pipeline)};
 }
 
 /// Dispatch a compute shader with a two-input (in1, in2, output, uniform) bind group.
@@ -896,24 +899,24 @@ GeodeFilterEngine::GeodeFilterEngine(GeodeDevice& device, bool verbose)
   {
     auto [bgl, pipeline] = createInputOutputUniformPipeline(
         dev, "GaussianBlur", createGaussianBlurShader(dev), sizeof(BlurParams));
-    blurBindGroupLayout_ = bgl;
-    gaussianBlurPipeline_ = pipeline;
+    blurBindGroupLayout_ = std::move(bgl);
+    gaussianBlurPipeline_ = std::move(pipeline);
   }
 
   // --- feOffset pipeline ---
   {
     auto [bgl, pipeline] = createInputOutputUniformPipeline(
         dev, "FilterOffset", createFilterOffsetShader(dev), sizeof(OffsetParams));
-    offsetBindGroupLayout_ = bgl;
-    offsetPipeline_ = pipeline;
+    offsetBindGroupLayout_ = std::move(bgl);
+    offsetPipeline_ = std::move(pipeline);
   }
 
   // --- feColorMatrix pipeline ---
   {
     auto [bgl, pipeline] = createInputOutputUniformPipeline(
         dev, "FilterColorMatrix", createFilterColorMatrixShader(dev), sizeof(ColorMatrixParams));
-    colorMatrixBindGroupLayout_ = bgl;
-    colorMatrixPipeline_ = pipeline;
+    colorMatrixBindGroupLayout_ = std::move(bgl);
+    colorMatrixPipeline_ = std::move(pipeline);
   }
 
   // --- feFlood pipeline (output + uniform, no input) ---
@@ -934,21 +937,22 @@ GeodeFilterEngine::GeodeFilterEngine(GeodeDevice& device, bool verbose)
     bglDesc.label = wgpuLabel("FilterFloodBGL");
     bglDesc.entryCount = 2;
     bglDesc.entries = entries;
-    floodBindGroupLayout_ = dev.createBindGroupLayout(bglDesc);
+    floodBindGroupLayout_.reset(dev.createBindGroupLayout(bglDesc));
 
     wgpu::PipelineLayoutDescriptor plDesc{};
     plDesc.label = wgpuLabel("FilterFloodPipelineLayout");
     plDesc.bindGroupLayoutCount = 1;
-    WGPUBindGroupLayout layouts[1] = {floodBindGroupLayout_};
+    WGPUBindGroupLayout layouts[1] = {floodBindGroupLayout_.get()};
     plDesc.bindGroupLayouts = layouts;
-    wgpu::PipelineLayout pipelineLayout = dev.createPipelineLayout(plDesc);
+    ScopedWgpuHandle<wgpu::PipelineLayout> pipelineLayout(dev.createPipelineLayout(plDesc));
+    ScopedWgpuHandle<wgpu::ShaderModule> shader(createFilterFloodShader(dev));
 
     wgpu::ComputePipelineDescriptor cpDesc{};
     cpDesc.label = wgpuLabel("FilterFloodPipeline");
-    cpDesc.layout = pipelineLayout;
-    cpDesc.compute.module = createFilterFloodShader(dev);
+    cpDesc.layout = pipelineLayout.get();
+    cpDesc.compute.module = shader.get();
     cpDesc.compute.entryPoint = wgpuLabel("main");
-    floodPipeline_ = dev.createComputePipeline(cpDesc);
+    floodPipeline_.reset(dev.createComputePipeline(cpDesc));
   }
 
   // --- feMerge alpha-over pipeline (src, dst → output) ---
@@ -976,45 +980,46 @@ GeodeFilterEngine::GeodeFilterEngine(GeodeDevice& device, bool verbose)
     bglDesc.label = wgpuLabel("FilterMergeBGL");
     bglDesc.entryCount = 3;
     bglDesc.entries = entries;
-    mergeBindGroupLayout_ = dev.createBindGroupLayout(bglDesc);
+    mergeBindGroupLayout_.reset(dev.createBindGroupLayout(bglDesc));
 
     wgpu::PipelineLayoutDescriptor plDesc{};
     plDesc.label = wgpuLabel("FilterMergePipelineLayout");
     plDesc.bindGroupLayoutCount = 1;
-    WGPUBindGroupLayout layouts[1] = {mergeBindGroupLayout_};
+    WGPUBindGroupLayout layouts[1] = {mergeBindGroupLayout_.get()};
     plDesc.bindGroupLayouts = layouts;
-    wgpu::PipelineLayout pipelineLayout = dev.createPipelineLayout(plDesc);
+    ScopedWgpuHandle<wgpu::PipelineLayout> pipelineLayout(dev.createPipelineLayout(plDesc));
+    ScopedWgpuHandle<wgpu::ShaderModule> shader(createFilterMergeShader(dev));
 
     wgpu::ComputePipelineDescriptor cpDesc{};
     cpDesc.label = wgpuLabel("FilterMergePipeline");
-    cpDesc.layout = pipelineLayout;
-    cpDesc.compute.module = createFilterMergeShader(dev);
+    cpDesc.layout = pipelineLayout.get();
+    cpDesc.compute.module = shader.get();
     cpDesc.compute.entryPoint = wgpuLabel("main");
-    mergePipeline_ = dev.createComputePipeline(cpDesc);
+    mergePipeline_.reset(dev.createComputePipeline(cpDesc));
   }
 
   // --- feComposite Porter-Duff pipeline (two inputs + output + uniform) ---
   {
     auto [bgl, pipeline] = createTwoInputUniformPipeline(
         dev, "FilterComposite", createFilterCompositeShader(dev), sizeof(CompositeParams));
-    compositeBindGroupLayout_ = bgl;
-    compositePipeline_ = pipeline;
+    compositeBindGroupLayout_ = std::move(bgl);
+    compositePipeline_ = std::move(pipeline);
   }
 
   // --- feBlend W3C blend-mode pipeline (two inputs + output + uniform) ---
   {
     auto [bgl, pipeline] = createTwoInputUniformPipeline(
         dev, "FilterBlend", createFilterBlendShader(dev), sizeof(BlendParams));
-    blendBindGroupLayout_ = bgl;
-    blendPipeline_ = pipeline;
+    blendBindGroupLayout_ = std::move(bgl);
+    blendPipeline_ = std::move(pipeline);
   }
 
   // --- feMorphology pipeline (input + output + uniform) ---
   {
     auto [bgl, pipeline] = createInputOutputUniformPipeline(
         dev, "FilterMorphology", createFilterMorphologyShader(dev), sizeof(MorphologyParams));
-    morphologyBindGroupLayout_ = bgl;
-    morphologyPipeline_ = pipeline;
+    morphologyBindGroupLayout_ = std::move(bgl);
+    morphologyPipeline_ = std::move(pipeline);
   }
 
   // --- feComponentTransfer pipeline (input + output + storage buffer for LUT) ---
@@ -1042,21 +1047,22 @@ GeodeFilterEngine::GeodeFilterEngine(GeodeDevice& device, bool verbose)
     bglDesc.label = wgpuLabel("FilterComponentTransferBGL");
     bglDesc.entryCount = 3;
     bglDesc.entries = entries;
-    componentTransferBindGroupLayout_ = dev.createBindGroupLayout(bglDesc);
+    componentTransferBindGroupLayout_.reset(dev.createBindGroupLayout(bglDesc));
 
     wgpu::PipelineLayoutDescriptor plDesc{};
     plDesc.label = wgpuLabel("FilterComponentTransferPipelineLayout");
     plDesc.bindGroupLayoutCount = 1;
-    WGPUBindGroupLayout layouts[1] = {componentTransferBindGroupLayout_};
+    WGPUBindGroupLayout layouts[1] = {componentTransferBindGroupLayout_.get()};
     plDesc.bindGroupLayouts = layouts;
-    wgpu::PipelineLayout pipelineLayout = dev.createPipelineLayout(plDesc);
+    ScopedWgpuHandle<wgpu::PipelineLayout> pipelineLayout(dev.createPipelineLayout(plDesc));
+    ScopedWgpuHandle<wgpu::ShaderModule> shader(createFilterComponentTransferShader(dev));
 
     wgpu::ComputePipelineDescriptor cpDesc{};
     cpDesc.label = wgpuLabel("FilterComponentTransferPipeline");
-    cpDesc.layout = pipelineLayout;
-    cpDesc.compute.module = createFilterComponentTransferShader(dev);
+    cpDesc.layout = pipelineLayout.get();
+    cpDesc.compute.module = shader.get();
     cpDesc.compute.entryPoint = wgpuLabel("main");
-    componentTransferPipeline_ = dev.createComputePipeline(cpDesc);
+    componentTransferPipeline_.reset(dev.createComputePipeline(cpDesc));
   }
 
   // --- feConvolveMatrix pipeline (input + output + storage buffer for params) ---
@@ -1086,21 +1092,22 @@ GeodeFilterEngine::GeodeFilterEngine(GeodeDevice& device, bool verbose)
     bglDesc.label = wgpuLabel("FilterConvolveMatrixBGL");
     bglDesc.entryCount = 3;
     bglDesc.entries = entries;
-    convolveMatrixBindGroupLayout_ = dev.createBindGroupLayout(bglDesc);
+    convolveMatrixBindGroupLayout_.reset(dev.createBindGroupLayout(bglDesc));
 
     wgpu::PipelineLayoutDescriptor plDesc{};
     plDesc.label = wgpuLabel("FilterConvolveMatrixPipelineLayout");
     plDesc.bindGroupLayoutCount = 1;
-    WGPUBindGroupLayout layouts[1] = {convolveMatrixBindGroupLayout_};
+    WGPUBindGroupLayout layouts[1] = {convolveMatrixBindGroupLayout_.get()};
     plDesc.bindGroupLayouts = layouts;
-    wgpu::PipelineLayout pipelineLayout = dev.createPipelineLayout(plDesc);
+    ScopedWgpuHandle<wgpu::PipelineLayout> pipelineLayout(dev.createPipelineLayout(plDesc));
+    ScopedWgpuHandle<wgpu::ShaderModule> shader(createFilterConvolveMatrixShader(dev));
 
     wgpu::ComputePipelineDescriptor cpDesc{};
     cpDesc.label = wgpuLabel("FilterConvolveMatrixPipeline");
-    cpDesc.layout = pipelineLayout;
-    cpDesc.compute.module = createFilterConvolveMatrixShader(dev);
+    cpDesc.layout = pipelineLayout.get();
+    cpDesc.compute.module = shader.get();
     cpDesc.compute.entryPoint = wgpuLabel("main");
-    convolveMatrixPipeline_ = dev.createComputePipeline(cpDesc);
+    convolveMatrixPipeline_.reset(dev.createComputePipeline(cpDesc));
   }
 
   // --- feTurbulence pipeline (output + params buffer + tables buffer) ---
@@ -1127,21 +1134,22 @@ GeodeFilterEngine::GeodeFilterEngine(GeodeDevice& device, bool verbose)
     bglDesc.label = wgpuLabel("FilterTurbulenceBGL");
     bglDesc.entryCount = 3;
     bglDesc.entries = entries;
-    turbulenceBindGroupLayout_ = dev.createBindGroupLayout(bglDesc);
+    turbulenceBindGroupLayout_.reset(dev.createBindGroupLayout(bglDesc));
 
     wgpu::PipelineLayoutDescriptor plDesc{};
     plDesc.label = wgpuLabel("FilterTurbulencePipelineLayout");
     plDesc.bindGroupLayoutCount = 1;
-    WGPUBindGroupLayout layouts[1] = {turbulenceBindGroupLayout_};
+    WGPUBindGroupLayout layouts[1] = {turbulenceBindGroupLayout_.get()};
     plDesc.bindGroupLayouts = layouts;
-    wgpu::PipelineLayout pipelineLayout = dev.createPipelineLayout(plDesc);
+    ScopedWgpuHandle<wgpu::PipelineLayout> pipelineLayout(dev.createPipelineLayout(plDesc));
+    ScopedWgpuHandle<wgpu::ShaderModule> shader(createFilterTurbulenceShader(dev));
 
     wgpu::ComputePipelineDescriptor cpDesc{};
     cpDesc.label = wgpuLabel("FilterTurbulencePipeline");
-    cpDesc.layout = pipelineLayout;
-    cpDesc.compute.module = createFilterTurbulenceShader(dev);
+    cpDesc.layout = pipelineLayout.get();
+    cpDesc.compute.module = shader.get();
     cpDesc.compute.entryPoint = wgpuLabel("main");
-    turbulencePipeline_ = dev.createComputePipeline(cpDesc);
+    turbulencePipeline_.reset(dev.createComputePipeline(cpDesc));
   }
 
   // --- feDisplacementMap pipeline (two inputs + output + uniform) ---
@@ -1149,8 +1157,8 @@ GeodeFilterEngine::GeodeFilterEngine(GeodeDevice& device, bool verbose)
     auto [bgl, pipeline] = createTwoInputUniformPipeline(dev, "FilterDisplacementMap",
                                                          createFilterDisplacementMapShader(dev),
                                                          sizeof(DisplacementParams));
-    displacementMapBindGroupLayout_ = bgl;
-    displacementMapPipeline_ = pipeline;
+    displacementMapBindGroupLayout_ = std::move(bgl);
+    displacementMapPipeline_ = std::move(pipeline);
   }
 
   // --- feDiffuseLighting pipeline (input + output + storage buffer) ---
@@ -1178,21 +1186,22 @@ GeodeFilterEngine::GeodeFilterEngine(GeodeDevice& device, bool verbose)
     bglDesc.label = wgpuLabel("FilterDiffuseLightingBGL");
     bglDesc.entryCount = 3;
     bglDesc.entries = entries;
-    diffuseLightingBindGroupLayout_ = dev.createBindGroupLayout(bglDesc);
+    diffuseLightingBindGroupLayout_.reset(dev.createBindGroupLayout(bglDesc));
 
     wgpu::PipelineLayoutDescriptor plDesc{};
     plDesc.label = wgpuLabel("FilterDiffuseLightingPipelineLayout");
     plDesc.bindGroupLayoutCount = 1;
-    WGPUBindGroupLayout layouts[1] = {diffuseLightingBindGroupLayout_};
+    WGPUBindGroupLayout layouts[1] = {diffuseLightingBindGroupLayout_.get()};
     plDesc.bindGroupLayouts = layouts;
-    wgpu::PipelineLayout pipelineLayout = dev.createPipelineLayout(plDesc);
+    ScopedWgpuHandle<wgpu::PipelineLayout> pipelineLayout(dev.createPipelineLayout(plDesc));
+    ScopedWgpuHandle<wgpu::ShaderModule> shader(createFilterDiffuseLightingShader(dev));
 
     wgpu::ComputePipelineDescriptor cpDesc{};
     cpDesc.label = wgpuLabel("FilterDiffuseLightingPipeline");
-    cpDesc.layout = pipelineLayout;
-    cpDesc.compute.module = createFilterDiffuseLightingShader(dev);
+    cpDesc.layout = pipelineLayout.get();
+    cpDesc.compute.module = shader.get();
     cpDesc.compute.entryPoint = wgpuLabel("main");
-    diffuseLightingPipeline_ = dev.createComputePipeline(cpDesc);
+    diffuseLightingPipeline_.reset(dev.createComputePipeline(cpDesc));
   }
 
   // --- feSpecularLighting pipeline (input + output + storage buffer) ---
@@ -1220,45 +1229,46 @@ GeodeFilterEngine::GeodeFilterEngine(GeodeDevice& device, bool verbose)
     bglDesc.label = wgpuLabel("FilterSpecularLightingBGL");
     bglDesc.entryCount = 3;
     bglDesc.entries = entries;
-    specularLightingBindGroupLayout_ = dev.createBindGroupLayout(bglDesc);
+    specularLightingBindGroupLayout_.reset(dev.createBindGroupLayout(bglDesc));
 
     wgpu::PipelineLayoutDescriptor plDesc{};
     plDesc.label = wgpuLabel("FilterSpecularLightingPipelineLayout");
     plDesc.bindGroupLayoutCount = 1;
-    WGPUBindGroupLayout layouts[1] = {specularLightingBindGroupLayout_};
+    WGPUBindGroupLayout layouts[1] = {specularLightingBindGroupLayout_.get()};
     plDesc.bindGroupLayouts = layouts;
-    wgpu::PipelineLayout pipelineLayout = dev.createPipelineLayout(plDesc);
+    ScopedWgpuHandle<wgpu::PipelineLayout> pipelineLayout(dev.createPipelineLayout(plDesc));
+    ScopedWgpuHandle<wgpu::ShaderModule> shader(createFilterSpecularLightingShader(dev));
 
     wgpu::ComputePipelineDescriptor cpDesc{};
     cpDesc.label = wgpuLabel("FilterSpecularLightingPipeline");
-    cpDesc.layout = pipelineLayout;
-    cpDesc.compute.module = createFilterSpecularLightingShader(dev);
+    cpDesc.layout = pipelineLayout.get();
+    cpDesc.compute.module = shader.get();
     cpDesc.compute.entryPoint = wgpuLabel("main");
-    specularLightingPipeline_ = dev.createComputePipeline(cpDesc);
+    specularLightingPipeline_.reset(dev.createComputePipeline(cpDesc));
   }
 
   // --- feDropShadow compose pipeline (two inputs + output + uniform) ---
   {
     auto [bgl, pipeline] = createTwoInputUniformPipeline(
         dev, "FilterDropShadow", createFilterDropShadowShader(dev), sizeof(DropShadowParams));
-    dropShadowBindGroupLayout_ = bgl;
-    dropShadowPipeline_ = pipeline;
+    dropShadowBindGroupLayout_ = std::move(bgl);
+    dropShadowPipeline_ = std::move(pipeline);
   }
 
   // --- feImage placement pipeline (input + output + uniform) ---
   {
     auto [bgl, pipeline] = createInputOutputUniformPipeline(
         dev, "FilterImage", createFilterImageShader(dev), sizeof(ImageParams));
-    imageBindGroupLayout_ = bgl;
-    imagePipeline_ = pipeline;
+    imageBindGroupLayout_ = std::move(bgl);
+    imagePipeline_ = std::move(pipeline);
   }
 
   // --- feTile wraparound pipeline (input + output + uniform) ---
   {
     auto [bgl, pipeline] = createInputOutputUniformPipeline(
         dev, "FilterTile", createFilterTileShader(dev), sizeof(TileParams));
-    tileBindGroupLayout_ = bgl;
-    tilePipeline_ = pipeline;
+    tileBindGroupLayout_ = std::move(bgl);
+    tilePipeline_ = std::move(pipeline);
   }
 
   // --- Per-primitive subregion clipping pipeline (input + output + uniform) ---
@@ -1266,8 +1276,8 @@ GeodeFilterEngine::GeodeFilterEngine(GeodeDevice& device, bool verbose)
     auto [bgl, pipeline] = createInputOutputUniformPipeline(dev, "FilterSubregionClip",
                                                             createFilterSubregionClipShader(dev),
                                                             sizeof(SubregionClipParams));
-    subregionClipBindGroupLayout_ = bgl;
-    subregionClipPipeline_ = pipeline;
+    subregionClipBindGroupLayout_ = std::move(bgl);
+    subregionClipPipeline_ = std::move(pipeline);
   }
 
   // --- sRGB↔linearRGB color space conversion pipeline ---
@@ -1275,8 +1285,8 @@ GeodeFilterEngine::GeodeFilterEngine(GeodeDevice& device, bool verbose)
     auto [bgl, pipeline] = createInputOutputUniformPipeline(
         dev, "FilterColorSpaceConvert", createFilterColorSpaceConvertShader(dev),
         sizeof(ColorSpaceConvertParams));
-    colorSpaceConvertBindGroupLayout_ = bgl;
-    colorSpaceConvertPipeline_ = pipeline;
+    colorSpaceConvertBindGroupLayout_ = std::move(bgl);
+    colorSpaceConvertPipeline_ = std::move(pipeline);
   }
 }
 
@@ -1977,8 +1987,8 @@ wgpu::Texture GeodeFilterEngine::runBlurPass(FilterResourceArena& arena, const w
   wgpu::Buffer uniformBuffer =
       createUniformBuffer(arena, device_, &params, sizeof(params), "BlurParamsUniform");
 
-  dispatchInputOutputUniform(device_, blurBindGroupLayout_, gaussianBlurPipeline_, input, output,
-                             uniformBuffer, sizeof(BlurParams), "GaussianBlurPass");
+  dispatchInputOutputUniform(device_, blurBindGroupLayout_.get(), gaussianBlurPipeline_.get(),
+                             input, output, uniformBuffer, sizeof(BlurParams), "GaussianBlurPass");
   return output;
 }
 
@@ -2003,8 +2013,8 @@ wgpu::Texture GeodeFilterEngine::runBoxBlurPass(FilterResourceArena& arena,
   wgpu::Buffer uniformBuffer =
       createUniformBuffer(arena, device_, &params, sizeof(params), "BlurParamsUniform");
 
-  dispatchInputOutputUniform(device_, blurBindGroupLayout_, gaussianBlurPipeline_, input, output,
-                             uniformBuffer, sizeof(BlurParams), "BoxBlurPass");
+  dispatchInputOutputUniform(device_, blurBindGroupLayout_.get(), gaussianBlurPipeline_.get(),
+                             input, output, uniformBuffer, sizeof(BlurParams), "BoxBlurPass");
   return output;
 }
 
@@ -2031,8 +2041,8 @@ wgpu::Texture GeodeFilterEngine::applyOffset(
   wgpu::Buffer uniformBuffer =
       createUniformBuffer(arena, device_, &params, sizeof(params), "OffsetParamsUniform");
 
-  dispatchInputOutputUniform(device_, offsetBindGroupLayout_, offsetPipeline_, input, output,
-                             uniformBuffer, sizeof(OffsetParams), "FilterOffsetPass");
+  dispatchInputOutputUniform(device_, offsetBindGroupLayout_.get(), offsetPipeline_.get(), input,
+                             output, uniformBuffer, sizeof(OffsetParams), "FilterOffsetPass");
   return output;
 }
 
@@ -2058,8 +2068,8 @@ wgpu::Texture GeodeFilterEngine::applyColorMatrix(
   wgpu::Buffer uniformBuffer =
       createUniformBuffer(arena, device_, &params, sizeof(params), "ColorMatrixParamsUniform");
 
-  dispatchInputOutputUniform(device_, colorMatrixBindGroupLayout_, colorMatrixPipeline_, input,
-                             output, uniformBuffer, sizeof(ColorMatrixParams),
+  dispatchInputOutputUniform(device_, colorMatrixBindGroupLayout_.get(), colorMatrixPipeline_.get(),
+                             input, output, uniformBuffer, sizeof(ColorMatrixParams),
                              "FilterColorMatrixPass");
   return output;
 }
@@ -2079,8 +2089,8 @@ wgpu::Texture GeodeFilterEngine::applySourceAlpha(FilterResourceArena& arena,
   wgpu::Buffer uniformBuffer =
       createUniformBuffer(arena, device_, &params, sizeof(params), "SourceAlphaParamsUniform");
 
-  dispatchInputOutputUniform(device_, colorMatrixBindGroupLayout_, colorMatrixPipeline_, input,
-                             output, uniformBuffer, sizeof(ColorMatrixParams),
+  dispatchInputOutputUniform(device_, colorMatrixBindGroupLayout_.get(), colorMatrixPipeline_.get(),
+                             input, output, uniformBuffer, sizeof(ColorMatrixParams),
                              "FilterSourceAlphaPass");
   return output;
 }
@@ -2121,7 +2131,7 @@ wgpu::Texture GeodeFilterEngine::applyFlood(
 
   wgpu::BindGroupDescriptor bgDesc{};
   bgDesc.label = wgpuLabel("FilterFloodBindGroup");
-  bgDesc.layout = floodBindGroupLayout_;
+  bgDesc.layout = floodBindGroupLayout_.get();
   bgDesc.entryCount = 2;
   bgDesc.entries = bgEntries;
   ScopedWgpuHandle<wgpu::BindGroup> bindGroup(dev.createBindGroup(bgDesc));
@@ -2134,7 +2144,7 @@ wgpu::Texture GeodeFilterEngine::applyFlood(
   wgpu::ComputePassDescriptor passDesc{};
   passDesc.label = wgpuLabel("FilterFloodPass");
   ScopedWgpuHandle<wgpu::ComputePassEncoder> pass(encoder.get().beginComputePass(passDesc));
-  pass.get().setPipeline(floodPipeline_);
+  pass.get().setPipeline(floodPipeline_.get());
   pass.get().setBindGroup(0, bindGroup.get(), 0, nullptr);
 
   const uint32_t workgroupsX = (width + 7) / 8;
@@ -2212,7 +2222,7 @@ wgpu::Texture GeodeFilterEngine::runMergePass(FilterResourceArena& arena, const 
 
   wgpu::BindGroupDescriptor bgDesc{};
   bgDesc.label = wgpuLabel("FilterMergeBindGroup");
-  bgDesc.layout = mergeBindGroupLayout_;
+  bgDesc.layout = mergeBindGroupLayout_.get();
   bgDesc.entryCount = 3;
   bgDesc.entries = bgEntries;
   ScopedWgpuHandle<wgpu::BindGroup> bindGroup(dev.createBindGroup(bgDesc));
@@ -2225,7 +2235,7 @@ wgpu::Texture GeodeFilterEngine::runMergePass(FilterResourceArena& arena, const 
   wgpu::ComputePassDescriptor passDesc{};
   passDesc.label = wgpuLabel("FilterMergePass");
   ScopedWgpuHandle<wgpu::ComputePassEncoder> pass(encoder.get().beginComputePass(passDesc));
-  pass.get().setPipeline(mergePipeline_);
+  pass.get().setPipeline(mergePipeline_.get());
   pass.get().setBindGroup(0, bindGroup.get(), 0, nullptr);
 
   const uint32_t workgroupsX = (width + 7) / 8;
@@ -2276,8 +2286,9 @@ wgpu::Texture GeodeFilterEngine::applyComposite(
   wgpu::Buffer uniformBuffer =
       createUniformBuffer(arena, device_, &params, sizeof(params), "CompositeParamsUniform");
 
-  dispatchTwoInputUniform(device_, compositeBindGroupLayout_, compositePipeline_, in1, in2, output,
-                          uniformBuffer, sizeof(CompositeParams), "FilterCompositePass");
+  dispatchTwoInputUniform(device_, compositeBindGroupLayout_.get(), compositePipeline_.get(), in1,
+                          in2, output, uniformBuffer, sizeof(CompositeParams),
+                          "FilterCompositePass");
   return output;
 }
 
@@ -2299,8 +2310,8 @@ wgpu::Texture GeodeFilterEngine::applyBlend(
   wgpu::Buffer uniformBuffer =
       createUniformBuffer(arena, device_, &params, sizeof(params), "BlendParamsUniform");
 
-  dispatchTwoInputUniform(device_, blendBindGroupLayout_, blendPipeline_, in1, in2, output,
-                          uniformBuffer, sizeof(BlendParams), "FilterBlendPass");
+  dispatchTwoInputUniform(device_, blendBindGroupLayout_.get(), blendPipeline_.get(), in1, in2,
+                          output, uniformBuffer, sizeof(BlendParams), "FilterBlendPass");
   return output;
 }
 
@@ -2342,8 +2353,8 @@ wgpu::Texture GeodeFilterEngine::applyMorphology(
     wgpu::Buffer uniformBuffer =
         createUniformBuffer(arena, device_, &params, sizeof(params), "MorphologyParamsUniform");
 
-    dispatchInputOutputUniform(device_, morphologyBindGroupLayout_, morphologyPipeline_, current,
-                               output, uniformBuffer, sizeof(MorphologyParams),
+    dispatchInputOutputUniform(device_, morphologyBindGroupLayout_.get(), morphologyPipeline_.get(),
+                               current, output, uniformBuffer, sizeof(MorphologyParams),
                                "FilterMorphologyPassX");
     current = output;
     remainX -= passX;
@@ -2367,8 +2378,8 @@ wgpu::Texture GeodeFilterEngine::applyMorphology(
     wgpu::Buffer uniformBuffer =
         createUniformBuffer(arena, device_, &params, sizeof(params), "MorphologyParamsUniform");
 
-    dispatchInputOutputUniform(device_, morphologyBindGroupLayout_, morphologyPipeline_, current,
-                               output, uniformBuffer, sizeof(MorphologyParams),
+    dispatchInputOutputUniform(device_, morphologyBindGroupLayout_.get(), morphologyPipeline_.get(),
+                               current, output, uniformBuffer, sizeof(MorphologyParams),
                                "FilterMorphologyPassY");
     current = output;
     remainY -= passY;
@@ -2419,7 +2430,7 @@ wgpu::Texture GeodeFilterEngine::applyComponentTransfer(
 
   wgpu::BindGroupDescriptor bgDesc{};
   bgDesc.label = wgpuLabel("FilterComponentTransferBindGroup");
-  bgDesc.layout = componentTransferBindGroupLayout_;
+  bgDesc.layout = componentTransferBindGroupLayout_.get();
   bgDesc.entryCount = 3;
   bgDesc.entries = bgEntries;
   ScopedWgpuHandle<wgpu::BindGroup> bindGroup(dev.createBindGroup(bgDesc));
@@ -2432,7 +2443,7 @@ wgpu::Texture GeodeFilterEngine::applyComponentTransfer(
   wgpu::ComputePassDescriptor passDesc{};
   passDesc.label = wgpuLabel("FilterComponentTransferPass");
   ScopedWgpuHandle<wgpu::ComputePassEncoder> pass(encoder.get().beginComputePass(passDesc));
-  pass.get().setPipeline(componentTransferPipeline_);
+  pass.get().setPipeline(componentTransferPipeline_.get());
   pass.get().setBindGroup(0, bindGroup.get(), 0, nullptr);
 
   const uint32_t workgroupsX = (width + 7) / 8;
@@ -2534,7 +2545,7 @@ wgpu::Texture GeodeFilterEngine::applyConvolveMatrix(
 
   wgpu::BindGroupDescriptor bgDesc{};
   bgDesc.label = wgpuLabel("FilterConvolveMatrixBindGroup");
-  bgDesc.layout = convolveMatrixBindGroupLayout_;
+  bgDesc.layout = convolveMatrixBindGroupLayout_.get();
   bgDesc.entryCount = 3;
   bgDesc.entries = bgEntries;
   ScopedWgpuHandle<wgpu::BindGroup> bindGroup(dev.createBindGroup(bgDesc));
@@ -2547,7 +2558,7 @@ wgpu::Texture GeodeFilterEngine::applyConvolveMatrix(
   wgpu::ComputePassDescriptor passDesc{};
   passDesc.label = wgpuLabel("FilterConvolveMatrixPass");
   ScopedWgpuHandle<wgpu::ComputePassEncoder> pass(encoder.get().beginComputePass(passDesc));
-  pass.get().setPipeline(convolveMatrixPipeline_);
+  pass.get().setPipeline(convolveMatrixPipeline_.get());
   pass.get().setBindGroup(0, bindGroup.get(), 0, nullptr);
 
   const uint32_t workgroupsX = (width + 7) / 8;
@@ -2640,7 +2651,7 @@ wgpu::Texture GeodeFilterEngine::applyTurbulence(
 
   wgpu::BindGroupDescriptor bgDesc{};
   bgDesc.label = wgpuLabel("FilterTurbulenceBindGroup");
-  bgDesc.layout = turbulenceBindGroupLayout_;
+  bgDesc.layout = turbulenceBindGroupLayout_.get();
   bgDesc.entryCount = 3;
   bgDesc.entries = bgEntries;
   ScopedWgpuHandle<wgpu::BindGroup> bindGroup(dev.createBindGroup(bgDesc));
@@ -2653,7 +2664,7 @@ wgpu::Texture GeodeFilterEngine::applyTurbulence(
   wgpu::ComputePassDescriptor passDesc{};
   passDesc.label = wgpuLabel("FilterTurbulencePass");
   ScopedWgpuHandle<wgpu::ComputePassEncoder> pass(encoder.get().beginComputePass(passDesc));
-  pass.get().setPipeline(turbulencePipeline_);
+  pass.get().setPipeline(turbulencePipeline_.get());
   pass.get().setBindGroup(0, bindGroup.get(), 0, nullptr);
 
   const uint32_t workgroupsX = (width + 7) / 8;
@@ -2697,9 +2708,9 @@ wgpu::Texture GeodeFilterEngine::applyDisplacementMap(
   wgpu::Buffer uniformBuffer =
       createUniformBuffer(arena, device_, &params, sizeof(params), "DisplacementMapParamsUniform");
 
-  dispatchTwoInputUniform(device_, displacementMapBindGroupLayout_, displacementMapPipeline_, in1,
-                          in2, output, uniformBuffer, sizeof(DisplacementParams),
-                          "FilterDisplacementMapPass");
+  dispatchTwoInputUniform(device_, displacementMapBindGroupLayout_.get(),
+                          displacementMapPipeline_.get(), in1, in2, output, uniformBuffer,
+                          sizeof(DisplacementParams), "FilterDisplacementMapPass");
   return output;
 }
 
@@ -2883,7 +2894,7 @@ wgpu::Texture GeodeFilterEngine::applyDiffuseLighting(
 
   wgpu::BindGroupDescriptor bgDesc{};
   bgDesc.label = wgpuLabel("FilterDiffuseLightingBindGroup");
-  bgDesc.layout = diffuseLightingBindGroupLayout_;
+  bgDesc.layout = diffuseLightingBindGroupLayout_.get();
   bgDesc.entryCount = 3;
   bgDesc.entries = bgEntries;
   ScopedWgpuHandle<wgpu::BindGroup> bindGroup(dev.createBindGroup(bgDesc));
@@ -2896,7 +2907,7 @@ wgpu::Texture GeodeFilterEngine::applyDiffuseLighting(
   wgpu::ComputePassDescriptor passDesc{};
   passDesc.label = wgpuLabel("FilterDiffuseLightingPass");
   ScopedWgpuHandle<wgpu::ComputePassEncoder> pass(encoder.get().beginComputePass(passDesc));
-  pass.get().setPipeline(diffuseLightingPipeline_);
+  pass.get().setPipeline(diffuseLightingPipeline_.get());
   pass.get().setBindGroup(0, bindGroup.get(), 0, nullptr);
 
   const uint32_t workgroupsX = (width + 7) / 8;
@@ -3001,7 +3012,7 @@ wgpu::Texture GeodeFilterEngine::applySpecularLighting(
 
   wgpu::BindGroupDescriptor bgDesc{};
   bgDesc.label = wgpuLabel("FilterSpecularLightingBindGroup");
-  bgDesc.layout = specularLightingBindGroupLayout_;
+  bgDesc.layout = specularLightingBindGroupLayout_.get();
   bgDesc.entryCount = 3;
   bgDesc.entries = bgEntries;
   ScopedWgpuHandle<wgpu::BindGroup> bindGroup(dev.createBindGroup(bgDesc));
@@ -3014,7 +3025,7 @@ wgpu::Texture GeodeFilterEngine::applySpecularLighting(
   wgpu::ComputePassDescriptor passDesc{};
   passDesc.label = wgpuLabel("FilterSpecularLightingPass");
   ScopedWgpuHandle<wgpu::ComputePassEncoder> pass(encoder.get().beginComputePass(passDesc));
-  pass.get().setPipeline(specularLightingPipeline_);
+  pass.get().setPipeline(specularLightingPipeline_.get());
   pass.get().setBindGroup(0, bindGroup.get(), 0, nullptr);
 
   const uint32_t workgroupsX = (width + 7) / 8;
@@ -3067,8 +3078,9 @@ wgpu::Texture GeodeFilterEngine::applyDropShadow(
   wgpu::Buffer uniformBuffer =
       createUniformBuffer(arena, device_, &params, sizeof(params), "DropShadowParamsUniform");
 
-  dispatchTwoInputUniform(device_, dropShadowBindGroupLayout_, dropShadowPipeline_, input, blurred,
-                          output, uniformBuffer, sizeof(DropShadowParams), "FilterDropShadowPass");
+  dispatchTwoInputUniform(device_, dropShadowBindGroupLayout_.get(), dropShadowPipeline_.get(),
+                          input, blurred, output, uniformBuffer, sizeof(DropShadowParams),
+                          "FilterDropShadowPass");
   return output;
 }
 
@@ -3109,8 +3121,8 @@ wgpu::Texture GeodeFilterEngine::applyImage(
     params.m12 = -1000.0f;
     wgpu::Buffer ub =
         createUniformBuffer(arena, device_, &params, sizeof(params), "ImageParamsEmpty");
-    dispatchInputOutputUniform(device_, imageBindGroupLayout_, imagePipeline_, emptyTex, output, ub,
-                               sizeof(ImageParams), "FilterImageEmptyPass");
+    dispatchInputOutputUniform(device_, imageBindGroupLayout_.get(), imagePipeline_.get(), emptyTex,
+                               output, ub, sizeof(ImageParams), "FilterImageEmptyPass");
     return output;
   }
 
@@ -3182,8 +3194,9 @@ wgpu::Texture GeodeFilterEngine::applyImage(
 
     wgpu::Buffer uniformBuffer =
         createUniformBuffer(arena, device_, &params, sizeof(params), "ImageParamsFragRef");
-    dispatchInputOutputUniform(device_, imageBindGroupLayout_, imagePipeline_, imgTex, output,
-                               uniformBuffer, sizeof(ImageParams), "FilterImageFragRefPass");
+    dispatchInputOutputUniform(device_, imageBindGroupLayout_.get(), imagePipeline_.get(), imgTex,
+                               output, uniformBuffer, sizeof(ImageParams),
+                               "FilterImageFragRefPass");
     return output;
   }
 
@@ -3207,8 +3220,9 @@ wgpu::Texture GeodeFilterEngine::applyImage(
 
     wgpu::Buffer uniformBuffer =
         createUniformBuffer(arena, device_, &params, sizeof(params), "ImageParamsFragRef");
-    dispatchInputOutputUniform(device_, imageBindGroupLayout_, imagePipeline_, imgTex, output,
-                               uniformBuffer, sizeof(ImageParams), "FilterImageFragRefPass");
+    dispatchInputOutputUniform(device_, imageBindGroupLayout_.get(), imagePipeline_.get(), imgTex,
+                               output, uniformBuffer, sizeof(ImageParams),
+                               "FilterImageFragRefPass");
     return output;
   }
 
@@ -3330,8 +3344,8 @@ wgpu::Texture GeodeFilterEngine::applyImage(
   wgpu::Buffer uniformBuffer =
       createUniformBuffer(arena, device_, &params, sizeof(params), "ImageParamsUniform");
 
-  dispatchInputOutputUniform(device_, imageBindGroupLayout_, imagePipeline_, imgTex, output,
-                             uniformBuffer, sizeof(ImageParams), "FilterImagePass");
+  dispatchInputOutputUniform(device_, imageBindGroupLayout_.get(), imagePipeline_.get(), imgTex,
+                             output, uniformBuffer, sizeof(ImageParams), "FilterImagePass");
   return output;
 }
 
@@ -3352,8 +3366,8 @@ wgpu::Texture GeodeFilterEngine::applyTile(FilterResourceArena& arena, const wgp
   wgpu::Buffer uniformBuffer =
       createUniformBuffer(arena, device_, &params, sizeof(params), "TileParamsUniform");
 
-  dispatchInputOutputUniform(device_, tileBindGroupLayout_, tilePipeline_, input, output,
-                             uniformBuffer, sizeof(TileParams), "FilterTilePass");
+  dispatchInputOutputUniform(device_, tileBindGroupLayout_.get(), tilePipeline_.get(), input,
+                             output, uniformBuffer, sizeof(TileParams), "FilterTilePass");
   return output;
 }
 
@@ -3386,9 +3400,9 @@ wgpu::Texture GeodeFilterEngine::applySubregionClip(FilterResourceArena& arena,
   wgpu::Buffer uniformBuffer =
       createUniformBuffer(arena, device_, &params, sizeof(params), "SubregionClipParamsUniform");
 
-  dispatchInputOutputUniform(device_, subregionClipBindGroupLayout_, subregionClipPipeline_, input,
-                             output, uniformBuffer, sizeof(SubregionClipParams),
-                             "FilterSubregionClipPass");
+  dispatchInputOutputUniform(device_, subregionClipBindGroupLayout_.get(),
+                             subregionClipPipeline_.get(), input, output, uniformBuffer,
+                             sizeof(SubregionClipParams), "FilterSubregionClipPass");
   return output;
 }
 
@@ -3408,9 +3422,9 @@ wgpu::Texture GeodeFilterEngine::applyColorSpaceConversion(FilterResourceArena& 
   wgpu::Buffer uniformBuffer = createUniformBuffer(arena, device_, &params, sizeof(params),
                                                    "ColorSpaceConvertParamsUniform");
 
-  dispatchInputOutputUniform(device_, colorSpaceConvertBindGroupLayout_, colorSpaceConvertPipeline_,
-                             input, output, uniformBuffer, sizeof(ColorSpaceConvertParams),
-                             "FilterColorSpaceConvertPass");
+  dispatchInputOutputUniform(device_, colorSpaceConvertBindGroupLayout_.get(),
+                             colorSpaceConvertPipeline_.get(), input, output, uniformBuffer,
+                             sizeof(ColorSpaceConvertParams), "FilterColorSpaceConvertPass");
   return output;
 }
 

--- a/donner/svg/renderer/geode/GeodeFilterEngine.h
+++ b/donner/svg/renderer/geode/GeodeFilterEngine.h
@@ -18,6 +18,7 @@
 
 #include "donner/base/Box.h"
 #include "donner/base/Transform.h"
+#include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 
 namespace donner::svg::components {
 struct FilterGraph;
@@ -354,80 +355,80 @@ private:
   GeodeDevice& device_;
 
   // Gaussian blur pipeline (reused from Phase 7 initial scope).
-  wgpu::ComputePipeline gaussianBlurPipeline_;
-  wgpu::BindGroupLayout blurBindGroupLayout_;
+  ScopedWgpuHandle<wgpu::ComputePipeline> gaussianBlurPipeline_;
+  ScopedWgpuHandle<wgpu::BindGroupLayout> blurBindGroupLayout_;
 
   // feOffset pipeline.
-  wgpu::ComputePipeline offsetPipeline_;
-  wgpu::BindGroupLayout offsetBindGroupLayout_;
+  ScopedWgpuHandle<wgpu::ComputePipeline> offsetPipeline_;
+  ScopedWgpuHandle<wgpu::BindGroupLayout> offsetBindGroupLayout_;
 
   // feColorMatrix pipeline.
-  wgpu::ComputePipeline colorMatrixPipeline_;
-  wgpu::BindGroupLayout colorMatrixBindGroupLayout_;
+  ScopedWgpuHandle<wgpu::ComputePipeline> colorMatrixPipeline_;
+  ScopedWgpuHandle<wgpu::BindGroupLayout> colorMatrixBindGroupLayout_;
 
   // feFlood pipeline.
-  wgpu::ComputePipeline floodPipeline_;
-  wgpu::BindGroupLayout floodBindGroupLayout_;
+  ScopedWgpuHandle<wgpu::ComputePipeline> floodPipeline_;
+  ScopedWgpuHandle<wgpu::BindGroupLayout> floodBindGroupLayout_;
 
   // feMerge alpha-over blit pipeline.
-  wgpu::ComputePipeline mergePipeline_;
-  wgpu::BindGroupLayout mergeBindGroupLayout_;
+  ScopedWgpuHandle<wgpu::ComputePipeline> mergePipeline_;
+  ScopedWgpuHandle<wgpu::BindGroupLayout> mergeBindGroupLayout_;
 
   // feComposite Porter-Duff pipeline (two inputs + output + uniform).
-  wgpu::ComputePipeline compositePipeline_;
-  wgpu::BindGroupLayout compositeBindGroupLayout_;
+  ScopedWgpuHandle<wgpu::ComputePipeline> compositePipeline_;
+  ScopedWgpuHandle<wgpu::BindGroupLayout> compositeBindGroupLayout_;
 
   // feBlend W3C blend-mode pipeline (two inputs + output + uniform).
-  wgpu::ComputePipeline blendPipeline_;
-  wgpu::BindGroupLayout blendBindGroupLayout_;
+  ScopedWgpuHandle<wgpu::ComputePipeline> blendPipeline_;
+  ScopedWgpuHandle<wgpu::BindGroupLayout> blendBindGroupLayout_;
 
   // feMorphology erode/dilate pipeline (input + output + uniform).
-  wgpu::ComputePipeline morphologyPipeline_;
-  wgpu::BindGroupLayout morphologyBindGroupLayout_;
+  ScopedWgpuHandle<wgpu::ComputePipeline> morphologyPipeline_;
+  ScopedWgpuHandle<wgpu::BindGroupLayout> morphologyBindGroupLayout_;
 
   // feComponentTransfer LUT pipeline (input + output + storage buffer).
-  wgpu::ComputePipeline componentTransferPipeline_;
-  wgpu::BindGroupLayout componentTransferBindGroupLayout_;
+  ScopedWgpuHandle<wgpu::ComputePipeline> componentTransferPipeline_;
+  ScopedWgpuHandle<wgpu::BindGroupLayout> componentTransferBindGroupLayout_;
 
   // feConvolveMatrix kernel pipeline (input + output + uniform).
-  wgpu::ComputePipeline convolveMatrixPipeline_;
-  wgpu::BindGroupLayout convolveMatrixBindGroupLayout_;
+  ScopedWgpuHandle<wgpu::ComputePipeline> convolveMatrixPipeline_;
+  ScopedWgpuHandle<wgpu::BindGroupLayout> convolveMatrixBindGroupLayout_;
 
   // feTurbulence noise pipeline (output + storage buffer, no input texture).
-  wgpu::ComputePipeline turbulencePipeline_;
-  wgpu::BindGroupLayout turbulenceBindGroupLayout_;
+  ScopedWgpuHandle<wgpu::ComputePipeline> turbulencePipeline_;
+  ScopedWgpuHandle<wgpu::BindGroupLayout> turbulenceBindGroupLayout_;
 
   // feDisplacementMap pipeline (two inputs + output + uniform).
-  wgpu::ComputePipeline displacementMapPipeline_;
-  wgpu::BindGroupLayout displacementMapBindGroupLayout_;
+  ScopedWgpuHandle<wgpu::ComputePipeline> displacementMapPipeline_;
+  ScopedWgpuHandle<wgpu::BindGroupLayout> displacementMapBindGroupLayout_;
 
   // feDiffuseLighting pipeline (input + output + storage buffer).
-  wgpu::ComputePipeline diffuseLightingPipeline_;
-  wgpu::BindGroupLayout diffuseLightingBindGroupLayout_;
+  ScopedWgpuHandle<wgpu::ComputePipeline> diffuseLightingPipeline_;
+  ScopedWgpuHandle<wgpu::BindGroupLayout> diffuseLightingBindGroupLayout_;
 
   // feSpecularLighting pipeline (input + output + storage buffer).
-  wgpu::ComputePipeline specularLightingPipeline_;
-  wgpu::BindGroupLayout specularLightingBindGroupLayout_;
+  ScopedWgpuHandle<wgpu::ComputePipeline> specularLightingPipeline_;
+  ScopedWgpuHandle<wgpu::BindGroupLayout> specularLightingBindGroupLayout_;
 
   // feDropShadow compose pipeline (two inputs + output + uniform).
-  wgpu::ComputePipeline dropShadowPipeline_;
-  wgpu::BindGroupLayout dropShadowBindGroupLayout_;
+  ScopedWgpuHandle<wgpu::ComputePipeline> dropShadowPipeline_;
+  ScopedWgpuHandle<wgpu::BindGroupLayout> dropShadowBindGroupLayout_;
 
   // feImage placement pipeline (input texture + output + uniform).
-  wgpu::ComputePipeline imagePipeline_;
-  wgpu::BindGroupLayout imageBindGroupLayout_;
+  ScopedWgpuHandle<wgpu::ComputePipeline> imagePipeline_;
+  ScopedWgpuHandle<wgpu::BindGroupLayout> imageBindGroupLayout_;
 
   // feTile wraparound pipeline (input + output + uniform).
-  wgpu::ComputePipeline tilePipeline_;
-  wgpu::BindGroupLayout tileBindGroupLayout_;
+  ScopedWgpuHandle<wgpu::ComputePipeline> tilePipeline_;
+  ScopedWgpuHandle<wgpu::BindGroupLayout> tileBindGroupLayout_;
 
   // Per-primitive subregion clipping pipeline (input + output + uniform).
-  wgpu::ComputePipeline subregionClipPipeline_;
-  wgpu::BindGroupLayout subregionClipBindGroupLayout_;
+  ScopedWgpuHandle<wgpu::ComputePipeline> subregionClipPipeline_;
+  ScopedWgpuHandle<wgpu::BindGroupLayout> subregionClipBindGroupLayout_;
 
   // sRGB↔linearRGB color space conversion pipeline (input + output + uniform).
-  wgpu::ComputePipeline colorSpaceConvertPipeline_;
-  wgpu::BindGroupLayout colorSpaceConvertBindGroupLayout_;
+  ScopedWgpuHandle<wgpu::ComputePipeline> colorSpaceConvertPipeline_;
+  ScopedWgpuHandle<wgpu::BindGroupLayout> colorSpaceConvertBindGroupLayout_;
 
   bool verbose_ = false;
   bool warnedUnsupported_ = false;

--- a/donner/svg/renderer/geode/GeodeImagePipeline.cc
+++ b/donner/svg/renderer/geode/GeodeImagePipeline.cc
@@ -57,18 +57,18 @@ GeodeImagePipeline::GeodeImagePipeline(const wgpu::Device& device, wgpu::Texture
   bglDesc.label = wgpuLabel("GeodeImageBlitBGL");
   bglDesc.entryCount = 7;
   bglDesc.entries = entries;
-  bindGroupLayout_ = device.createBindGroupLayout(bglDesc);
+  bindGroupLayout_.reset(device.createBindGroupLayout(bglDesc));
 
   // ----- Pipeline layout -----
   wgpu::PipelineLayoutDescriptor plDesc = {};
   plDesc.label = wgpuLabel("GeodeImageBlitPL");
   plDesc.bindGroupLayoutCount = 1;
-  WGPUBindGroupLayout layouts[1] = {bindGroupLayout_};
+  WGPUBindGroupLayout layouts[1] = {bindGroupLayout_.get()};
   plDesc.bindGroupLayouts = layouts;
-  wgpu::PipelineLayout pipelineLayout = device.createPipelineLayout(plDesc);
+  ScopedWgpuHandle<wgpu::PipelineLayout> pipelineLayout(device.createPipelineLayout(plDesc));
 
   // ----- Shader module -----
-  wgpu::ShaderModule shader = createImageBlitShader(device);
+  ScopedWgpuHandle<wgpu::ShaderModule> shader(createImageBlitShader(device));
 
   // ----- Fragment / blending -----
   // Same premultiplied-source-over as the Slug fill pipeline. The fragment
@@ -88,7 +88,7 @@ GeodeImagePipeline::GeodeImagePipeline(const wgpu::Device& device, wgpu::Texture
   colorTarget.writeMask = wgpu::ColorWriteMask::All;
 
   wgpu::FragmentState fragmentState = {};
-  fragmentState.module = shader;
+  fragmentState.module = shader.get();
   fragmentState.entryPoint = wgpuLabel("fs_main");
   fragmentState.targetCount = 1;
   fragmentState.targets = &colorTarget;
@@ -97,8 +97,8 @@ GeodeImagePipeline::GeodeImagePipeline(const wgpu::Device& device, wgpu::Texture
   // No vertex buffers — the shader generates corners from vertex_index.
   wgpu::RenderPipelineDescriptor rpDesc = {};
   rpDesc.label = wgpuLabel("GeodeImageBlit");
-  rpDesc.layout = pipelineLayout;
-  rpDesc.vertex.module = shader;
+  rpDesc.layout = pipelineLayout.get();
+  rpDesc.vertex.module = shader.get();
   rpDesc.vertex.entryPoint = wgpuLabel("vs_main");
   rpDesc.vertex.bufferCount = 0;
   rpDesc.vertex.buffers = nullptr;
@@ -112,7 +112,7 @@ GeodeImagePipeline::GeodeImagePipeline(const wgpu::Device& device, wgpu::Texture
   rpDesc.multisample.count = sampleCount;
   rpDesc.multisample.mask = 0xFFFFFFFF;
 
-  pipeline_ = device.createRenderPipeline(rpDesc);
+  pipeline_.reset(device.createRenderPipeline(rpDesc));
 
   // ----- Samplers -----
   // Linear (bilinear) sampler — the default for SVG's "smooth" image
@@ -127,13 +127,13 @@ GeodeImagePipeline::GeodeImagePipeline(const wgpu::Device& device, wgpu::Texture
   linearDesc.magFilter = wgpu::FilterMode::Linear;
   linearDesc.minFilter = wgpu::FilterMode::Linear;
   linearDesc.maxAnisotropy = 1;
-  linearSampler_ = device.createSampler(linearDesc);
+  linearSampler_.reset(device.createSampler(linearDesc));
 
   // Nearest sampler — for `image-rendering: pixelated`.
   wgpu::SamplerDescriptor nearestDesc{wgpu::Default};
   nearestDesc.label = wgpuLabel("GeodeImageBlitNearest");
   nearestDesc.maxAnisotropy = 1;
-  nearestSampler_ = device.createSampler(nearestDesc);
+  nearestSampler_.reset(device.createSampler(nearestDesc));
 
   wgpu::SamplerDescriptor clipMaskDesc{wgpu::Default};
   clipMaskDesc.label = wgpuLabel("GeodeImageBlitClipMask");
@@ -142,7 +142,7 @@ GeodeImagePipeline::GeodeImagePipeline(const wgpu::Device& device, wgpu::Texture
   clipMaskDesc.magFilter = wgpu::FilterMode::Linear;
   clipMaskDesc.minFilter = wgpu::FilterMode::Linear;
   clipMaskDesc.maxAnisotropy = 1;
-  clipMaskSampler_ = device.createSampler(clipMaskDesc);
+  clipMaskSampler_.reset(device.createSampler(clipMaskDesc));
 }
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodeImagePipeline.h
+++ b/donner/svg/renderer/geode/GeodeImagePipeline.h
@@ -4,6 +4,8 @@
 
 #include <webgpu/webgpu.hpp>
 
+#include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
+
 namespace donner::geode {
 
 /**
@@ -50,33 +52,33 @@ public:
   GeodeImagePipeline& operator=(GeodeImagePipeline&&) noexcept = default;
 
   /// The compiled render pipeline.
-  const wgpu::RenderPipeline& pipeline() const { return pipeline_; }
+  const wgpu::RenderPipeline& pipeline() const { return pipeline_.get(); }
 
   /// Bind group layout used by the pipeline.
-  const wgpu::BindGroupLayout& bindGroupLayout() const { return bindGroupLayout_; }
+  const wgpu::BindGroupLayout& bindGroupLayout() const { return bindGroupLayout_.get(); }
 
   /// Bilinear (mag/min filter = Linear) sampler, clamped to edge.
   /// Used for the default `image-rendering` and the SVG spec's
   /// "smooth" image sampling.
-  const wgpu::Sampler& linearSampler() const { return linearSampler_; }
+  const wgpu::Sampler& linearSampler() const { return linearSampler_.get(); }
 
   /// Nearest-neighbor sampler, clamped to edge. Used when
   /// `ImageParams::imageRenderingPixelated` is true.
-  const wgpu::Sampler& nearestSampler() const { return nearestSampler_; }
+  const wgpu::Sampler& nearestSampler() const { return nearestSampler_.get(); }
 
   /// Linear clamp-to-edge sampler used for Phase 3b clip-mask textures.
-  const wgpu::Sampler& clipMaskSampler() const { return clipMaskSampler_; }
+  const wgpu::Sampler& clipMaskSampler() const { return clipMaskSampler_.get(); }
 
   /// Color format the pipeline was built for.
   wgpu::TextureFormat colorFormat() const { return colorFormat_; }
 
 private:
   wgpu::TextureFormat colorFormat_;
-  wgpu::BindGroupLayout bindGroupLayout_;
-  wgpu::RenderPipeline pipeline_;
-  wgpu::Sampler linearSampler_;
-  wgpu::Sampler nearestSampler_;
-  wgpu::Sampler clipMaskSampler_;
+  ScopedWgpuHandle<wgpu::BindGroupLayout> bindGroupLayout_;
+  ScopedWgpuHandle<wgpu::RenderPipeline> pipeline_;
+  ScopedWgpuHandle<wgpu::Sampler> linearSampler_;
+  ScopedWgpuHandle<wgpu::Sampler> nearestSampler_;
+  ScopedWgpuHandle<wgpu::Sampler> clipMaskSampler_;
 };
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodePipeline.cc
+++ b/donner/svg/renderer/geode/GeodePipeline.cc
@@ -90,21 +90,21 @@ GeodePipeline::GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat col
   bglDesc.label = wgpuLabel("GeodeSlugFillBGL");
   bglDesc.entryCount = 12;
   bglDesc.entries = entries;
-  bindGroupLayout_ = device.createBindGroupLayout(bglDesc);
+  bindGroupLayout_.reset(device.createBindGroupLayout(bglDesc));
 
   // ----- Pipeline layout -----
   wgpu::PipelineLayoutDescriptor plDesc = {};
   plDesc.label = wgpuLabel("GeodeSlugFillPL");
   plDesc.bindGroupLayoutCount = 1;
-  WGPUBindGroupLayout layouts[1] = {bindGroupLayout_};
+  WGPUBindGroupLayout layouts[1] = {bindGroupLayout_.get()};
   plDesc.bindGroupLayouts = layouts;
-  wgpu::PipelineLayout pipelineLayout = device.createPipelineLayout(plDesc);
+  ScopedWgpuHandle<wgpu::PipelineLayout> pipelineLayout(device.createPipelineLayout(plDesc));
 
   // ----- Shader module -----
   // The fill shader is always the analytic dual-ray variant (0041 §8); it runs
   // at sampleCount=1 on every adapter, so there is no alpha-coverage variant.
   (void)useAlphaCoverageShader;
-  wgpu::ShaderModule shader = createSlugFillShader(device);
+  ScopedWgpuHandle<wgpu::ShaderModule> shader(createSlugFillShader(device));
 
   // ----- Vertex buffer layout -----
   // Matches EncodedPath::Vertex: pos (vec2f) + normal (vec2f) + bandIndex (u32)
@@ -144,7 +144,7 @@ GeodePipeline::GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat col
   colorTarget.writeMask = wgpu::ColorWriteMask::All;
 
   wgpu::FragmentState fragmentState = {};
-  fragmentState.module = shader;
+  fragmentState.module = shader.get();
   fragmentState.entryPoint = wgpuLabel("fs_main");
   fragmentState.targetCount = 1;
   fragmentState.targets = &colorTarget;
@@ -152,9 +152,9 @@ GeodePipeline::GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat col
   // ----- Render pipeline -----
   wgpu::RenderPipelineDescriptor rpDesc = {};
   rpDesc.label = wgpuLabel("GeodeSlugFill");
-  rpDesc.layout = pipelineLayout;
+  rpDesc.layout = pipelineLayout.get();
 
-  rpDesc.vertex.module = shader;
+  rpDesc.vertex.module = shader.get();
   rpDesc.vertex.entryPoint = wgpuLabel("vs_main");
   rpDesc.vertex.bufferCount = 1;
   rpDesc.vertex.buffers = &vbLayout;
@@ -169,7 +169,7 @@ GeodePipeline::GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat col
   rpDesc.multisample.count = sampleCount;
   rpDesc.multisample.mask = 0xFFFFFFFF;
 
-  pipeline_ = device.createRenderPipeline(rpDesc);
+  pipeline_.reset(device.createRenderPipeline(rpDesc));
 }
 
 // ============================================================================
@@ -225,18 +225,18 @@ GeodeGradientPipeline::GeodeGradientPipeline(const wgpu::Device& device,
   bglDesc.label = wgpuLabel("GeodeSlugGradientBGL");
   bglDesc.entryCount = 9;
   bglDesc.entries = entries;
-  bindGroupLayout_ = device.createBindGroupLayout(bglDesc);
+  bindGroupLayout_.reset(device.createBindGroupLayout(bglDesc));
 
   wgpu::PipelineLayoutDescriptor plDesc = {};
   plDesc.label = wgpuLabel("GeodeSlugGradientPL");
   plDesc.bindGroupLayoutCount = 1;
-  WGPUBindGroupLayout layouts[1] = {bindGroupLayout_};
+  WGPUBindGroupLayout layouts[1] = {bindGroupLayout_.get()};
   plDesc.bindGroupLayouts = layouts;
-  wgpu::PipelineLayout pipelineLayout = device.createPipelineLayout(plDesc);
+  ScopedWgpuHandle<wgpu::PipelineLayout> pipelineLayout(device.createPipelineLayout(plDesc));
 
   // Always the analytic dual-ray gradient shader (0041 §8); sampleCount=1.
   (void)useAlphaCoverageShader;
-  wgpu::ShaderModule shader = createSlugGradientShader(device);
+  ScopedWgpuHandle<wgpu::ShaderModule> shader(createSlugGradientShader(device));
 
   // Same vertex buffer layout as the solid-fill pipeline.
   wgpu::VertexAttribute vertexAttribs[3] = {};
@@ -272,16 +272,16 @@ GeodeGradientPipeline::GeodeGradientPipeline(const wgpu::Device& device,
   colorTarget.writeMask = wgpu::ColorWriteMask::All;
 
   wgpu::FragmentState fragmentState = {};
-  fragmentState.module = shader;
+  fragmentState.module = shader.get();
   fragmentState.entryPoint = wgpuLabel("fs_main");
   fragmentState.targetCount = 1;
   fragmentState.targets = &colorTarget;
 
   wgpu::RenderPipelineDescriptor rpDesc = {};
   rpDesc.label = wgpuLabel("GeodeSlugGradient");
-  rpDesc.layout = pipelineLayout;
+  rpDesc.layout = pipelineLayout.get();
 
-  rpDesc.vertex.module = shader;
+  rpDesc.vertex.module = shader.get();
   rpDesc.vertex.entryPoint = wgpuLabel("vs_main");
   rpDesc.vertex.bufferCount = 1;
   rpDesc.vertex.buffers = &vbLayout;
@@ -294,7 +294,7 @@ GeodeGradientPipeline::GeodeGradientPipeline(const wgpu::Device& device,
   rpDesc.multisample.count = sampleCount;
   rpDesc.multisample.mask = 0xFFFFFFFF;
 
-  pipeline_ = device.createRenderPipeline(rpDesc);
+  pipeline_.reset(device.createRenderPipeline(rpDesc));
 }
 
 // ============================================================================
@@ -346,18 +346,18 @@ GeodeMaskPipeline::GeodeMaskPipeline(const wgpu::Device& device, bool useAlphaCo
   bglDesc.label = wgpuLabel("GeodeSlugMaskBGL");
   bglDesc.entryCount = 9;
   bglDesc.entries = entries;
-  bindGroupLayout_ = device.createBindGroupLayout(bglDesc);
+  bindGroupLayout_.reset(device.createBindGroupLayout(bglDesc));
 
   wgpu::PipelineLayoutDescriptor plDesc = {};
   plDesc.label = wgpuLabel("GeodeSlugMaskPL");
   plDesc.bindGroupLayoutCount = 1;
-  WGPUBindGroupLayout layouts[1] = {bindGroupLayout_};
+  WGPUBindGroupLayout layouts[1] = {bindGroupLayout_.get()};
   plDesc.bindGroupLayouts = layouts;
-  wgpu::PipelineLayout pipelineLayout = device.createPipelineLayout(plDesc);
+  ScopedWgpuHandle<wgpu::PipelineLayout> pipelineLayout(device.createPipelineLayout(plDesc));
 
   // Always the analytic dual-ray mask shader (0041 §8); sampleCount=1.
   (void)useAlphaCoverageShader;
-  wgpu::ShaderModule shader = createSlugMaskShader(device);
+  ScopedWgpuHandle<wgpu::ShaderModule> shader(createSlugMaskShader(device));
 
   // Same vertex buffer layout as the fill pipelines: pos (vec2f) +
   // normal (vec2f) + bandIndex (u32) = 20 bytes per vertex.
@@ -398,16 +398,16 @@ GeodeMaskPipeline::GeodeMaskPipeline(const wgpu::Device& device, bool useAlphaCo
   colorTarget.writeMask = wgpu::ColorWriteMask::All;
 
   wgpu::FragmentState fragmentState = {};
-  fragmentState.module = shader;
+  fragmentState.module = shader.get();
   fragmentState.entryPoint = wgpuLabel("fs_main");
   fragmentState.targetCount = 1;
   fragmentState.targets = &colorTarget;
 
   wgpu::RenderPipelineDescriptor rpDesc = {};
   rpDesc.label = wgpuLabel("GeodeSlugMask");
-  rpDesc.layout = pipelineLayout;
+  rpDesc.layout = pipelineLayout.get();
 
-  rpDesc.vertex.module = shader;
+  rpDesc.vertex.module = shader.get();
   rpDesc.vertex.entryPoint = wgpuLabel("vs_main");
   rpDesc.vertex.bufferCount = 1;
   rpDesc.vertex.buffers = &vbLayout;
@@ -420,7 +420,7 @@ GeodeMaskPipeline::GeodeMaskPipeline(const wgpu::Device& device, bool useAlphaCo
   rpDesc.multisample.count = sampleCount;
   rpDesc.multisample.mask = 0xFFFFFFFF;
 
-  pipeline_ = device.createRenderPipeline(rpDesc);
+  pipeline_.reset(device.createRenderPipeline(rpDesc));
 }
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodePipeline.h
+++ b/donner/svg/renderer/geode/GeodePipeline.h
@@ -4,6 +4,8 @@
 
 #include <webgpu/webgpu.hpp>
 
+#include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
+
 namespace donner::geode {
 
 /**
@@ -54,18 +56,18 @@ public:
   GeodePipeline& operator=(GeodePipeline&&) noexcept = default;
 
   /// The compiled render pipeline.
-  const wgpu::RenderPipeline& pipeline() const { return pipeline_; }
+  const wgpu::RenderPipeline& pipeline() const { return pipeline_.get(); }
 
   /// The bind group layout used by the pipeline.
-  const wgpu::BindGroupLayout& bindGroupLayout() const { return bindGroupLayout_; }
+  const wgpu::BindGroupLayout& bindGroupLayout() const { return bindGroupLayout_.get(); }
 
   /// Color format the pipeline was built for.
   wgpu::TextureFormat colorFormat() const { return colorFormat_; }
 
 private:
   wgpu::TextureFormat colorFormat_;
-  wgpu::BindGroupLayout bindGroupLayout_;
-  wgpu::RenderPipeline pipeline_;
+  ScopedWgpuHandle<wgpu::BindGroupLayout> bindGroupLayout_;
+  ScopedWgpuHandle<wgpu::RenderPipeline> pipeline_;
 };
 
 /**
@@ -99,16 +101,16 @@ public:
   GeodeGradientPipeline& operator=(GeodeGradientPipeline&&) noexcept = default;
 
   /// The compiled render pipeline.
-  const wgpu::RenderPipeline& pipeline() const { return pipeline_; }
+  const wgpu::RenderPipeline& pipeline() const { return pipeline_.get(); }
   /// The bind group layout used by the pipeline.
-  const wgpu::BindGroupLayout& bindGroupLayout() const { return bindGroupLayout_; }
+  const wgpu::BindGroupLayout& bindGroupLayout() const { return bindGroupLayout_.get(); }
   /// Color format the pipeline was built for.
   wgpu::TextureFormat colorFormat() const { return colorFormat_; }
 
 private:
   wgpu::TextureFormat colorFormat_;
-  wgpu::BindGroupLayout bindGroupLayout_;
-  wgpu::RenderPipeline pipeline_;
+  ScopedWgpuHandle<wgpu::BindGroupLayout> bindGroupLayout_;
+  ScopedWgpuHandle<wgpu::RenderPipeline> pipeline_;
 };
 
 /**
@@ -151,14 +153,14 @@ public:
   GeodeMaskPipeline(GeodeMaskPipeline&&) noexcept = default;
   GeodeMaskPipeline& operator=(GeodeMaskPipeline&&) noexcept = default;
 
-  const wgpu::RenderPipeline& pipeline() const { return pipeline_; }
-  const wgpu::BindGroupLayout& bindGroupLayout() const { return bindGroupLayout_; }
+  const wgpu::RenderPipeline& pipeline() const { return pipeline_.get(); }
+  const wgpu::BindGroupLayout& bindGroupLayout() const { return bindGroupLayout_.get(); }
   /// The color format the pipeline targets. Always `RGBA8Unorm`.
   wgpu::TextureFormat colorFormat() const { return wgpu::TextureFormat::RGBA8Unorm; }
 
 private:
-  wgpu::BindGroupLayout bindGroupLayout_;
-  wgpu::RenderPipeline pipeline_;
+  ScopedWgpuHandle<wgpu::BindGroupLayout> bindGroupLayout_;
+  ScopedWgpuHandle<wgpu::RenderPipeline> pipeline_;
 };
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodeWgpuUtil.h
+++ b/donner/svg/renderer/geode/GeodeWgpuUtil.h
@@ -42,6 +42,20 @@ namespace donner::geode {
 }
 
 /**
+ * Release a raw WebGPU handle and reset the wrapper to null.
+ *
+ * @tparam Handle A `wgpu::` handle type with `operator bool()` and `release()`.
+ * @param handle Owned raw handle to release.
+ */
+template <typename Handle>
+void ReleaseWgpuHandle(Handle& handle) {
+  if (handle) {
+    handle.release();
+    handle = Handle();
+  }
+}
+
+/**
  * Move-only RAII owner for a single WebGPU handle.
  *
  * @tparam Handle A `wgpu::` handle type with `operator bool()` and `release()`.
@@ -97,8 +111,8 @@ public:
 
   /// Release the current handle and optionally take ownership of a replacement.
   void reset(Handle handle = Handle()) noexcept {
-    if (handle_) {
-      handle_.release();
+    if (handle_) {  // Keep the release counter scoped to RAII-owned resources.
+      ReleaseWgpuHandle(handle_);
       releaseCount_.fetch_add(1, std::memory_order_relaxed);
     }
     handle_ = std::move(handle);
@@ -152,6 +166,12 @@ public:
     return retainImpl(bindGroups_, std::move(handle));
   }
 
+  /// Destroy backing storage for retained buffers/textures before release.
+  void destroyBackings() {
+    destroyBackingsImpl(buffers_);
+    destroyBackingsImpl(textures_);
+  }
+
 private:
   template <typename Handle>
   static Handle retainImpl(std::vector<ScopedWgpuHandle<Handle>>& storage, Handle handle) {
@@ -161,6 +181,17 @@ private:
     Handle borrowed = handle;
     storage.push_back(ScopedWgpuHandle<Handle>(std::move(handle)));
     return borrowed;
+  }
+
+  template <typename Handle>
+  static void destroyBackingsImpl(std::vector<ScopedWgpuHandle<Handle>>& storage) {
+    for (ScopedWgpuHandle<Handle>& handle : storage) {
+      if (handle) {
+        handle.get().destroy();
+        handle.reset();
+      }
+    }
+    storage.clear();
   }
 
   std::vector<ScopedWgpuHandle<wgpu::Buffer>> buffers_;

--- a/donner/svg/renderer/geode/tests/GeodeWgpuUtil_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeWgpuUtil_tests.cc
@@ -16,6 +16,24 @@ struct FakeWgpuHandle {
   int* releaseCount = nullptr;
 };
 
+TEST(WgpuHandleTest, ReleaseWgpuHandleReleasesAndResetsOwnedHandle) {
+  int releaseCount = 0;
+  FakeWgpuHandle handle(&releaseCount);
+
+  ReleaseWgpuHandle(handle);
+
+  EXPECT_EQ(releaseCount, 1);
+  EXPECT_FALSE(handle);
+}
+
+TEST(WgpuHandleTest, ReleaseWgpuHandleIgnoresNullHandle) {
+  FakeWgpuHandle handle;
+
+  ReleaseWgpuHandle(handle);
+
+  EXPECT_FALSE(handle);
+}
+
 TEST(ScopedWgpuHandleTest, ReleasesOwnedHandleOnScopeExit) {
   int releaseCount = 0;
   {

--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -93,6 +93,7 @@ donner_cc_library(
         "//donner/svg/renderer",
         # The tiny-skia renderer is linked in every build (pure CPU, no wgpu).
         "//donner/svg/renderer:renderer_tiny_skia",
+        "@com_google_gtest//:gtest",
     ] + select({
         "//donner/svg/renderer:renderer_backend_geode": [
             "//donner/svg/renderer:renderer_geode",

--- a/donner/svg/renderer/tests/RendererTestBackendGeode.cc
+++ b/donner/svg/renderer/tests/RendererTestBackendGeode.cc
@@ -1,3 +1,7 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+
 #include "donner/svg/renderer/RendererGeode.h"
 #include "donner/svg/renderer/geode/GeodeDevice.h"
 #include "donner/svg/renderer/tests/RendererTestBackend.h"
@@ -6,6 +10,16 @@ namespace donner::svg {
 
 namespace {
 
+struct SharedGeodeBackendState {
+  std::shared_ptr<geode::GeodeDevice> device;
+  std::unique_ptr<RendererGeode> renderer;
+};
+
+SharedGeodeBackendState& SharedTestBackendState() {
+  static SharedGeodeBackendState state;
+  return state;
+}
+
 /// Returns a process-wide shared GeodeDevice, created on first access.
 ///
 /// Sharing a single device across all test-constructed renderers avoids the
@@ -13,12 +27,14 @@ namespace {
 /// WebGPU device creations in a single process — the driver state doesn't
 /// reclaim cleanly and the process eventually deadlocks.
 std::shared_ptr<geode::GeodeDevice> SharedTestDevice() {
-  static auto device = [] {
+  SharedGeodeBackendState& state = SharedTestBackendState();
+  if (!state.device) {
     auto d = geode::GeodeDevice::CreateHeadless();
     // Wrap the unique_ptr in a shared_ptr for lifetime sharing.
-    return std::shared_ptr<geode::GeodeDevice>(std::move(d));
-  }();
-  return device;
+    state.device = std::shared_ptr<geode::GeodeDevice>(std::move(d));
+  }
+
+  return state.device;
 }
 
 bool GeodeSupportsFeature(RendererBackendFeature feature) {
@@ -74,11 +90,30 @@ std::unique_ptr<RendererInterface> GeodeCreateInstance(bool verbose) {
 /// resets per-frame state, so a shared renderer behaves identically to a
 /// fresh one as long as each `draw()` call is self-contained (no carried
 /// layer / clip / filter stack), which the image-comparison fixture
-/// guarantees.
+/// guarantees. The gtest environment below destroys this renderer before
+/// LeakSanitizer performs its process-exit leak check.
 RendererGeode& SharedTestRenderer(bool verbose = false) {
-  static auto* renderer = new RendererGeode(SharedTestDevice(), verbose);
-  return *renderer;
+  SharedGeodeBackendState& state = SharedTestBackendState();
+  if (!state.renderer) {
+    state.renderer = std::make_unique<RendererGeode>(SharedTestDevice(), verbose);
+  }
+
+  return *state.renderer;
 }
+
+void ResetSharedTestBackendState() {
+  SharedGeodeBackendState& state = SharedTestBackendState();
+  state.renderer.reset();
+  state.device.reset();
+}
+
+class GeodeBackendEnvironment : public ::testing::Environment {
+public:
+  void TearDown() override { ResetSharedTestBackendState(); }
+};
+
+[[maybe_unused]] const ::testing::Environment* const geodeBackendEnvironment =
+    ::testing::AddGlobalTestEnvironment(new GeodeBackendEnvironment);
 
 RendererBitmap GeodeRender(SVGDocument& document, bool verbose) {
   RendererGeode& renderer = SharedTestRenderer(verbose);


### PR DESCRIPTION
## Summary

- release headless-owned Geode WebGPU root handles and owned resource backings during teardown
- keep submitted Geode encoders alive until the shared frame command encoder is submitted, then retire transient resources
- make shared Geode test and embedded icon renderers destructible instead of intentionally leaked

## Tests

- `tools/llm-bazel-wrap.sh test --test_env=VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.json --test_env=XDG_RUNTIME_DIR=/tmp //...`
- `python3 tools/cmake/gen_cmakelists.py --check`
- `tools/llm-bazel-wrap.sh test --jobs=2 --config=asan --config=geode --test_output=errors --test_env=VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.json --test_env=XDG_RUNTIME_DIR=/tmp //donner/svg/renderer/tests:resvg_test_suite_geode`