### PR TITLE
Implement full dominant-baseline and alignment-baseline keyword sets

### DIFF
--- a/docs/design_docs/0021-resvg_feature_gaps.md
+++ b/docs/design_docs/0021-resvg_feature_gaps.md
@@ -95,8 +95,6 @@ bottom for completeness.
 | B3 | `structure/image` golden kernel-era mismatch | 13 | Golden refresh + `<image>` upscale-kernel decision (see [B3](#b3-structureimage-golden-kernel-era-mismatch)) |
 | F12 | `transform-origin` on `<textPath>` baseline | 1 | gradient/pattern/`<image>`/text resolve the pivot; `on-text-path` baseline still drops it → [#624](https://github.com/jwmcglynn/donner/issues/624) |
 | F3 | `context-fill` / `context-stroke` | 13 | Feature |
-| F5 | full `dominant-baseline` keyword set | 14 | Feature |
-| F6 | full `alignment-baseline` keyword set | 10 | Feature |
 | F7 | `paint-order` rendering | **DONE** (7/8) | Rendered on shapes + text; `on-tspan` residual → [#624](https://github.com/jwmcglynn/donner/issues/624) |
 | F9 | `textLength` + `lengthAdjust` stretch/compress | 8 | Feature |
 | F10 | `textPath` SVG2 attributes (`path`/`side`/`method`/`spacing`) | 8 | Feature |
@@ -242,16 +240,6 @@ Per-test threshold inflation is not an option.
 
 **Impact:** 13 tests in `painting/context/`. Parsed but not honored at render.
 Used by markers and `<use>` to inherit the referencing element's paint.
-
-### F5: full `dominant-baseline` keyword set
-
-**Impact:** 14 tests in `text/dominant-baseline/`. Missing `before-edge`,
-`after-edge`, `no-change`, `reset-size`, `use-script`, etc.
-
-### F6: full `alignment-baseline` keyword set
-
-**Impact:** 10 tests in `text/alignment-baseline/`. Full keyword set + tspan
-baseline alignment.
 
 ### F7: `paint-order` rendering
 

--- a/docs/design_docs/0021-resvg_feature_gaps.md
+++ b/docs/design_docs/0021-resvg_feature_gaps.md
@@ -312,7 +312,7 @@ Donner/tiny-skia bug. Pinned by `RendererTests.DashSeamClosedContourMitersStartC
 `Path::vertices()` now emits the arrival marker-mid at a rounded rect's zero-length-close
 start corner (stacking start + mid + end, matching resvg), while still excluding smooth
 all-curve loops (circle/ellipse).
-| text/writing-mode | ~6 | `writing-mode=tb` with `dx`/`dy`, vertical-lr/rl edge cases |
+| text/writing-mode | ~7 | `writing-mode=tb` with `dx`/`dy`, vertical-lr/rl edge cases, mixed-script (upright CJK + rotated Latin) column geometry (also skips `text/alignment-baseline/hanging-on-vertical`) |
 
 ---
 

--- a/donner/editor/sandbox/SandboxCodecs.cc
+++ b/donner/editor/sandbox/SandboxCodecs.cc
@@ -1026,7 +1026,10 @@ void EncodeTextParams(WireWriter& w, const svg::TextParams& p) {
 
   w.writeU8(static_cast<uint8_t>(p.textAnchor));
   w.writeU8(static_cast<uint8_t>(p.textDecoration));
-  w.writeU8(static_cast<uint8_t>(p.dominantBaseline));
+  // Reserved byte: was TextParams::dominantBaseline. Baseline alignment is now resolved
+  // per span into TextSpan::alignmentBaseline; the byte is kept so the wire layout (and
+  // committed .rnr recordings) stay stable.
+  w.writeU8(0);
   w.writeU8(static_cast<uint8_t>(p.writingMode));
   w.writeF64(p.letterSpacingPx);
   w.writeF64(p.wordSpacingPx);
@@ -1079,8 +1082,8 @@ bool DecodeTextParams(WireReader& r, svg::TextParams& out,
   out.textAnchor = static_cast<svg::TextAnchor>(u);
   if (!r.readU8(u)) return false;
   out.textDecoration = static_cast<svg::TextDecoration>(u);
+  // Reserved byte: was TextParams::dominantBaseline (see EncodeTextParams).
   if (!r.readU8(u)) return false;
-  out.dominantBaseline = static_cast<svg::DominantBaseline>(u);
   if (!r.readU8(u)) return false;
   out.writingMode = static_cast<svg::WritingMode>(u);
   if (!r.readF64(out.letterSpacingPx)) return false;

--- a/donner/svg/components/text/ComputedTextComponent.h
+++ b/donner/svg/components/text/ComputedTextComponent.h
@@ -139,9 +139,9 @@ struct ComputedTextComponent {
     /// Ordered stack of baseline shifts contributed by ancestor text spans.
     SmallVector<AncestorShift, 2> ancestorBaselineShifts;
 
-    /// CSS `alignment-baseline` value for this span. When not Auto, overrides the
-    /// dominant-baseline for this specific inline element. Populated by RendererDriver from
-    /// sourceEntity.
+    /// Effective baseline alignment for this span: the CSS `alignment-baseline` value when not
+    /// Auto, otherwise the span's resolved (inherited) `dominant-baseline`. Auto means the
+    /// alphabetic baseline (no shift). Populated by RendererDriver from sourceEntity.
     DominantBaseline alignmentBaseline = DominantBaseline::Auto;
 
     /// CSS `visibility` value for this span. Hidden/collapsed spans are laid out normally

--- a/donner/svg/core/DominantBaseline.h
+++ b/donner/svg/core/DominantBaseline.h
@@ -21,14 +21,17 @@ namespace donner::svg {
  */
 enum class DominantBaseline : uint8_t {
   Auto,          ///< [DEFAULT] Use the default baseline for the script.
-  TextBottom,    ///< Align to the bottom of the text.
+  TextBottom,    ///< Align to the bottom of the text. Also `text-after-edge` / `after-edge`.
   Alphabetic,    ///< Align to the alphabetic baseline.
   Ideographic,   ///< Align to the ideographic baseline.
-  Middle,        ///< Align to the middle of the em box.
-  Central,       ///< Align to the central baseline.
+  Middle,        ///< Align to the middle of the x-height.
+  Central,       ///< Align to the central baseline (middle of the em box).
   Mathematical,  ///< Align to the mathematical baseline.
   Hanging,       ///< Align to the hanging baseline.
-  TextTop,       ///< Align to the top of the text.
+  TextTop,       ///< Align to the top of the text. Also `text-before-edge` / `before-edge`.
+  UseScript,     ///< Deprecated SVG 1.1 keyword; behaves like \ref Auto.
+  NoChange,      ///< Deprecated SVG 1.1 keyword; uses the parent's dominant baseline.
+  ResetSize,     ///< Deprecated SVG 1.1 keyword; behaves like \ref Auto.
 };
 
 /**
@@ -45,6 +48,9 @@ inline std::ostream& operator<<(std::ostream& os, DominantBaseline value) {
     case DominantBaseline::Mathematical: return os << "mathematical";
     case DominantBaseline::Hanging: return os << "hanging";
     case DominantBaseline::TextTop: return os << "text-top";
+    case DominantBaseline::UseScript: return os << "use-script";
+    case DominantBaseline::NoChange: return os << "no-change";
+    case DominantBaseline::ResetSize: return os << "reset-size";
   }
 
   UTILS_UNREACHABLE();  // LCOV_EXCL_LINE

--- a/donner/svg/properties/PropertyRegistry.cc
+++ b/donner/svg/properties/PropertyRegistry.cc
@@ -293,7 +293,8 @@ ParseResult<DominantBaseline> ParseDominantBaseline(
 
       if (value.equalsLowercase("auto")) {
         return DominantBaseline::Auto;
-      } else if (value.equalsLowercase("text-bottom")) {
+      } else if (value.equalsLowercase("text-bottom") || value.equalsLowercase("text-after-edge")) {
+        // `text-after-edge` is the SVG 1.1 name for CSS Inline 3's `text-bottom`.
         return DominantBaseline::TextBottom;
       } else if (value.equalsLowercase("alphabetic")) {
         return DominantBaseline::Alphabetic;
@@ -307,14 +308,64 @@ ParseResult<DominantBaseline> ParseDominantBaseline(
         return DominantBaseline::Mathematical;
       } else if (value.equalsLowercase("hanging")) {
         return DominantBaseline::Hanging;
-      } else if (value.equalsLowercase("text-top")) {
+      } else if (value.equalsLowercase("text-top") || value.equalsLowercase("text-before-edge")) {
+        // `text-before-edge` is the SVG 1.1 name for CSS Inline 3's `text-top`.
         return DominantBaseline::TextTop;
+      } else if (value.equalsLowercase("use-script")) {
+        return DominantBaseline::UseScript;
+      } else if (value.equalsLowercase("no-change")) {
+        return DominantBaseline::NoChange;
+      } else if (value.equalsLowercase("reset-size")) {
+        return DominantBaseline::ResetSize;
       }
     }
   }
 
   ParseDiagnostic err;
   err.reason = "Invalid dominant-baseline value";
+  err.range.start = !components.empty() ? components.front().sourceOffset() : FileOffset::Offset(0);
+  return err;
+}
+
+/**
+ * Parse the `alignment-baseline` keyword set. Reuses \ref DominantBaseline for the result:
+ * `baseline` maps to \ref DominantBaseline::Auto (both mean "align to the parent's dominant
+ * baseline"), and the SVG 1.1 `before-edge` / `after-edge` keywords map to the same baselines as
+ * `text-before-edge` / `text-after-edge`, matching resvg and Chrome.
+ */
+ParseResult<DominantBaseline> ParseAlignmentBaseline(
+    std::span<const css::ComponentValue> components) {
+  if (components.size() == 1) {
+    const css::ComponentValue& component = components.front();
+    if (const auto* ident = component.tryGetToken<css::Token::Ident>()) {
+      const RcString& value = ident->value;
+
+      if (value.equalsLowercase("auto") || value.equalsLowercase("baseline")) {
+        return DominantBaseline::Auto;
+      } else if (value.equalsLowercase("text-bottom") || value.equalsLowercase("text-after-edge") ||
+                 value.equalsLowercase("after-edge")) {
+        return DominantBaseline::TextBottom;
+      } else if (value.equalsLowercase("alphabetic")) {
+        return DominantBaseline::Alphabetic;
+      } else if (value.equalsLowercase("ideographic")) {
+        return DominantBaseline::Ideographic;
+      } else if (value.equalsLowercase("middle")) {
+        return DominantBaseline::Middle;
+      } else if (value.equalsLowercase("central")) {
+        return DominantBaseline::Central;
+      } else if (value.equalsLowercase("mathematical")) {
+        return DominantBaseline::Mathematical;
+      } else if (value.equalsLowercase("hanging")) {
+        return DominantBaseline::Hanging;
+      } else if (value.equalsLowercase("text-top") || value.equalsLowercase("text-before-edge") ||
+                 value.equalsLowercase("before-edge")) {
+        return DominantBaseline::TextTop;
+      }
+    }
+  }
+
+  ParseDiagnostic err;
+  err.reason = "Invalid alignment-baseline value";
   err.range.start = !components.empty() ? components.front().sourceOffset() : FileOffset::Offset(0);
   return err;
 }
@@ -1648,7 +1699,7 @@ DONNER_CONSTEXPR_MAP auto kProperties =
                    return Parse(
                        params,
                        [](const parser::PropertyParseFnParams& params) {
-                         return ParseDominantBaseline(params.components());
+                         return ParseAlignmentBaseline(params.components());
                        },
                        &registry.alignmentBaseline);
                  }},  //

--- a/donner/svg/properties/PropertyRegistry.h
+++ b/donner/svg/properties/PropertyRegistry.h
@@ -340,8 +340,8 @@ public:
       "text-decoration", []() -> std::optional<TextDecoration> { return TextDecoration::None; }};
 
   /// `dominant-baseline` property, which determines the baseline alignment for text.
-  /// Not inherited. Defaults to \ref DominantBaseline::Auto.
-  Property<DominantBaseline> dominantBaseline{
+  /// Inherited (CSS Inline Layout 3). Defaults to \ref DominantBaseline::Auto.
+  Property<DominantBaseline, PropertyCascade::Inherit> dominantBaseline{
       "dominant-baseline",
       []() -> std::optional<DominantBaseline> { return DominantBaseline::Auto; }};
 
@@ -362,7 +362,8 @@ public:
       "baseline-shift", []() -> std::optional<Lengthd> { return Lengthd(0, Lengthd::Unit::None); }};
 
   /// `alignment-baseline` property. Specifies how an inline element aligns with its parent's
-  /// baseline. Uses the same enum as dominant-baseline. Not inherited.
+  /// baseline. Uses the same enum as dominant-baseline (`baseline` parses to
+  /// \ref DominantBaseline::Auto — both defer to the dominant baseline). Not inherited.
   Property<DominantBaseline> alignmentBaseline{
       "alignment-baseline",
       []() -> std::optional<DominantBaseline> { return DominantBaseline::Auto; }};

--- a/donner/svg/properties/tests/PropertyRegistry_tests.cc
+++ b/donner/svg/properties/tests/PropertyRegistry_tests.cc
@@ -700,6 +700,7 @@ TEST(PropertyRegistry, AdditionalKeywordProperties) {
     const std::pair<const char*, DominantBaseline> cases[] = {
         {"auto", DominantBaseline::Auto},
         {"text-bottom", DominantBaseline::TextBottom},
+        {"text-after-edge", DominantBaseline::TextBottom},
         {"alphabetic", DominantBaseline::Alphabetic},
         {"ideographic", DominantBaseline::Ideographic},
         {"middle", DominantBaseline::Middle},
@@ -707,12 +708,48 @@ TEST(PropertyRegistry, AdditionalKeywordProperties) {
         {"mathematical", DominantBaseline::Mathematical},
         {"hanging", DominantBaseline::Hanging},
         {"text-top", DominantBaseline::TextTop},
+        {"text-before-edge", DominantBaseline::TextTop},
+        {"use-script", DominantBaseline::UseScript},
+        {"no-change", DominantBaseline::NoChange},
+        {"reset-size", DominantBaseline::ResetSize},
     };
 
     for (const auto& [value, expected] : cases) {
       PropertyRegistry registry;
       registry.parseStyle(std::string("dominant-baseline: ") + value);
       EXPECT_THAT(registry.dominantBaseline.get(), Optional(expected));
+    }
+  }
+
+  {
+    const std::pair<const char*, DominantBaseline> cases[] = {
+        {"auto", DominantBaseline::Auto},
+        {"baseline", DominantBaseline::Auto},
+        {"before-edge", DominantBaseline::TextTop},
+        {"text-before-edge", DominantBaseline::TextTop},
+        {"text-top", DominantBaseline::TextTop},
+        {"middle", DominantBaseline::Middle},
+        {"central", DominantBaseline::Central},
+        {"after-edge", DominantBaseline::TextBottom},
+        {"text-after-edge", DominantBaseline::TextBottom},
+        {"text-bottom", DominantBaseline::TextBottom},
+        {"ideographic", DominantBaseline::Ideographic},
+        {"alphabetic", DominantBaseline::Alphabetic},
+        {"hanging", DominantBaseline::Hanging},
+        {"mathematical", DominantBaseline::Mathematical},
+    };
+
+    for (const auto& [value, expected] : cases) {
+      PropertyRegistry registry;
+      registry.parseStyle(std::string("alignment-baseline: ") + value);
+      EXPECT_THAT(registry.alignmentBaseline.get(), Optional(expected));
+    }
+
+    {
+      // `use-script` / `no-change` / `reset-size` are dominant-baseline-only keywords.
+      PropertyRegistry registry;
+      registry.parseStyle("alignment-baseline: use-script");
+      EXPECT_THAT(registry.alignmentBaseline.get(), Optional(DominantBaseline::Auto));
     }
   }
 

--- a/donner/svg/renderer/RendererDriver.cc
+++ b/donner/svg/renderer/RendererDriver.cc
@@ -780,7 +780,6 @@ TextParams toTextParams(Registry& registry, const components::RenderingInstanceC
   }
   params.textAnchor = properties.textAnchor.get().value();
   params.textDecoration = properties.textDecoration.get().value();
-  params.dominantBaseline = properties.dominantBaseline.get().value();
   params.writingMode = properties.writingMode.get().value();
 
   // Resolve letter-spacing and word-spacing to pixels.

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -94,7 +94,6 @@ TextLayoutParams toTextLayoutParams(const TextParams& params) {
   layoutParams.viewBox = params.viewBox;
   layoutParams.fontMetrics = params.fontMetrics;
   layoutParams.textAnchor = params.textAnchor;
-  layoutParams.dominantBaseline = params.dominantBaseline;
   layoutParams.writingMode = params.writingMode;
   layoutParams.letterSpacingPx = params.letterSpacingPx;
   layoutParams.wordSpacingPx = params.wordSpacingPx;

--- a/donner/svg/renderer/RendererInterface.h
+++ b/donner/svg/renderer/RendererInterface.h
@@ -22,7 +22,6 @@
 #include "donner/svg/components/filter/FilterEffect.h"
 #include "donner/svg/components/filter/FilterGraph.h"
 #include "donner/svg/components/text/ComputedTextComponent.h"
-#include "donner/svg/core/DominantBaseline.h"
 #include "donner/svg/core/LengthAdjust.h"
 #include "donner/svg/core/MixBlendMode.h"
 #include "donner/svg/core/TextAnchor.h"
@@ -212,7 +211,6 @@ struct TextParams {
   FontMetrics fontMetrics;
   TextAnchor textAnchor = TextAnchor::Start;
   TextDecoration textDecoration = TextDecoration::None;
-  DominantBaseline dominantBaseline = DominantBaseline::Auto;
   /// CSS `writing-mode` for this text element. Controls horizontal vs vertical text flow.
   WritingMode writingMode = WritingMode::HorizontalTb;
   /// Extra spacing added after each character (CSS `letter-spacing`). 0 = normal.

--- a/donner/svg/renderer/RendererTinySkia.cc
+++ b/donner/svg/renderer/RendererTinySkia.cc
@@ -45,7 +45,6 @@ TextLayoutParams toTextLayoutParams(const TextParams& params) {
   layoutParams.viewBox = params.viewBox;
   layoutParams.fontMetrics = params.fontMetrics;
   layoutParams.textAnchor = params.textAnchor;
-  layoutParams.dominantBaseline = params.dominantBaseline;
   layoutParams.writingMode = params.writingMode;
   layoutParams.letterSpacingPx = params.letterSpacingPx;
   layoutParams.wordSpacingPx = params.wordSpacingPx;

--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -328,6 +328,8 @@ donner_cc_test(
         "TextEngineHelpers_tests.cc",
     ],
     deps = [
+        "//donner/svg/components/text:components",
+        "//donner/svg/parser",
         "//donner/svg/text:text_backend",
         "//donner/svg/text:text_engine",
         "//donner/svg/text:text_layout_params",

--- a/donner/svg/renderer/tests/TextEngineHelpers_tests.cc
+++ b/donner/svg/renderer/tests/TextEngineHelpers_tests.cc
@@ -3,6 +3,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "donner/svg/SVGDocument.h"
+#include "donner/svg/components/text/ComputedTextComponent.h"
+#include "donner/svg/parser/SVGParser.h"
 #include "donner/svg/renderer/tests/MockTextBackend.h"
 #include "donner/svg/text/TextEngine.h"
 
@@ -32,10 +35,23 @@ TEST(ComputeBaselineShiftTest, AlphabeticReturnsZero) {
   EXPECT_DOUBLE_EQ(computeBaselineShift(DominantBaseline::Alphabetic, vm, 1.0f), 0.0);
 }
 
-TEST(ComputeBaselineShiftTest, MiddleCentersEmBox) {
+TEST(ComputeBaselineShiftTest, DeprecatedSvg11KeywordsReturnZero) {
   FontVMetrics vm{800, -200, 0};
-  // (800 + (-200)) * 0.5 * 1.0 = 300.0
-  EXPECT_DOUBLE_EQ(computeBaselineShift(DominantBaseline::Middle, vm, 1.0f), 300.0);
+  EXPECT_DOUBLE_EQ(computeBaselineShift(DominantBaseline::UseScript, vm, 1.0f), 0.0);
+  EXPECT_DOUBLE_EQ(computeBaselineShift(DominantBaseline::NoChange, vm, 1.0f), 0.0);
+  EXPECT_DOUBLE_EQ(computeBaselineShift(DominantBaseline::ResetSize, vm, 1.0f), 0.0);
+}
+
+TEST(ComputeBaselineShiftTest, MiddleIsHalfXHeight) {
+  FontVMetrics vm{800, -200, 0, /*xHeight=*/500};
+  // 500 * 0.5 * 1.0 = 250.0
+  EXPECT_DOUBLE_EQ(computeBaselineShift(DominantBaseline::Middle, vm, 1.0f), 250.0);
+}
+
+TEST(ComputeBaselineShiftTest, MiddleFallsBackTo45PercentHeightWithoutXHeight) {
+  FontVMetrics vm{800, -200, 0};  // xHeight = 0 (font has no OS/2 sxHeight).
+  // 0.45 * (800 - (-200)) * 0.5 * 1.0 = 225.0
+  EXPECT_DOUBLE_EQ(computeBaselineShift(DominantBaseline::Middle, vm, 1.0f), 225.0);
 }
 
 TEST(ComputeBaselineShiftTest, CentralCentersEmBox) {
@@ -575,6 +591,63 @@ TEST_F(TextEngineLayoutTest, LetterSpacingAddsSpace) {
   EXPECT_NEAR(runs[0].glyphs[1].xPosition, 15.0, 0.1);
 }
 
+TEST_F(TextEngineLayoutTest, AlignmentBaselineHangingShiftsGlyphsDown) {
+  ON_CALL(*mockBackend_, shapeRun(testing::_, testing::_, testing::_, testing::_, testing::_,
+                                  testing::_, testing::_, testing::_))
+      .WillByDefault([](FontHandle, float, std::string_view text, size_t offset, size_t length,
+                        bool, FontVariant, bool) {
+        return TextEngineLayoutTest::makeShapedRun(text, offset, length, 10.0);
+      });
+
+  components::ComputedTextComponent text;
+  auto span = makeSpan("AB");
+  span.xList.push_back(Lengthd(0.0, Lengthd::Unit::None));
+  span.yList.push_back(Lengthd(50.0, Lengthd::Unit::None));
+  // Effective baseline (dominant-baseline or alignment-baseline override) resolved per span.
+  span.alignmentBaseline = DominantBaseline::Hanging;
+  text.spans.push_back(std::move(span));
+
+  const auto runs = engine_->layout(text, makeParams());
+
+  ASSERT_EQ(runs.size(), 1u);
+  ASSERT_EQ(runs[0].glyphs.size(), 2u);
+  // Hanging shift = 0.8 * ascent(800) * emScale(0.016) = 10.24, added to y (glyphs move down).
+  EXPECT_THAT(runs[0].glyphs[0].yPosition, testing::DoubleNear(60.24, 0.01));
+  EXPECT_THAT(runs[0].glyphs[1].yPosition, testing::DoubleNear(60.24, 0.01));
+}
+
+TEST_F(TextEngineLayoutTest, BaselineAlignmentIsIgnoredInVerticalWritingMode) {
+  ON_CALL(*mockBackend_, shapeRun(testing::_, testing::_, testing::_, testing::_, testing::_,
+                                  testing::_, testing::_, testing::_))
+      .WillByDefault([](FontHandle, float, std::string_view text, size_t offset, size_t length,
+                        bool, FontVariant, bool) {
+        return TextEngineLayoutTest::makeShapedRun(text, offset, length, 10.0);
+      });
+
+  auto layoutFirstGlyphPosition = [&](DominantBaseline effectiveBaseline) {
+    components::ComputedTextComponent text;
+    auto span = makeSpan("AB");
+    span.xList.push_back(Lengthd(100.0, Lengthd::Unit::None));
+    span.yList.push_back(Lengthd(20.0, Lengthd::Unit::None));
+    span.alignmentBaseline = effectiveBaseline;
+    text.spans.push_back(std::move(span));
+
+    auto params = makeParams();
+    params.writingMode = WritingMode::VerticalRl;
+    const auto runs = engine_->layout(text, params);
+    EXPECT_EQ(runs.size(), 1u);
+    EXPECT_EQ(runs[0].glyphs.size(), 2u);
+    return Vector2d(runs[0].glyphs[0].xPosition, runs[0].glyphs[0].yPosition);
+  };
+
+  // Matching resvg, dominant/alignment baseline shifts apply only to horizontal text: a
+  // vertical span with `hanging` must lay out exactly like one with `auto`.
+  const Vector2d hangingPosition = layoutFirstGlyphPosition(DominantBaseline::Hanging);
+  const Vector2d autoPosition = layoutFirstGlyphPosition(DominantBaseline::Auto);
+  EXPECT_THAT(hangingPosition.x, testing::DoubleEq(autoPosition.x));
+  EXPECT_THAT(hangingPosition.y, testing::DoubleEq(autoPosition.y));
+}
+
 TEST_F(TextEngineLayoutTest, HiddenSpanProducesEmptyGlyphs) {
   components::ComputedTextComponent text;
   auto span = makeSpan("ABC");
@@ -614,6 +687,127 @@ TEST_F(TextEngineLayoutTest, EmptySpanPreservesPosition) {
   EXPECT_TRUE(runs[0].glyphs.empty());
   ASSERT_EQ(runs[1].glyphs.size(), 1u);
   EXPECT_NEAR(runs[1].glyphs[0].xPosition, 100.0, 0.1);
+}
+
+// ── Effective baseline resolution (resolvePerSpanLayoutStyles) ──────────────
+
+/// Matches a TextSpan whose text is \p expectedText and whose resolved effective baseline
+/// (TextSpan::alignmentBaseline) is \p expectedBaseline. On mismatch, prints the span's text
+/// and effective baseline keyword.
+MATCHER_P2(SpanWithEffectiveBaseline, expectedText, expectedBaseline,
+           std::string("span with text '") + expectedText + "' and effective baseline '" +
+               testing::PrintToString(expectedBaseline) + "'") {
+  const std::string_view spanText(arg.text.data() + arg.start, arg.end - arg.start);
+  if (spanText != expectedText) {
+    *result_listener << "span text is '" << spanText << "'";
+    return false;
+  }
+  if (arg.alignmentBaseline != expectedBaseline) {
+    *result_listener << "effective baseline is '" << arg.alignmentBaseline << "'";
+    return false;
+  }
+  return true;
+}
+
+class EffectiveBaselineResolutionTest : public testing::Test {
+protected:
+  /// Parses \p svg, computes styles and text spans, and runs the per-span layout-style
+  /// resolution that folds dominant-baseline / alignment-baseline into each span's
+  /// effective baseline. Returns the resolved spans of the element with id="t".
+  SmallVector<components::ComputedTextComponent::TextSpan, 1> resolveSpans(std::string_view svg) {
+    ParseWarningSink parseSink;
+    auto maybeResult = parser::SVGParser::ParseSVG(svg, parseSink);
+    EXPECT_FALSE(maybeResult.hasError()) << "SVG parse failed";
+    document_ = std::make_unique<SVGDocument>(std::move(maybeResult).result());
+
+    Registry& registry = document_->registry();
+
+    auto maybeText = document_->querySelector("#t");
+    EXPECT_TRUE(maybeText.has_value()) << "No element with id=\"t\"";
+    const EntityHandle textRootHandle = maybeText->unsafeEntityHandle();
+
+    fontManager_ = std::make_unique<FontManager>(registry);
+    engine_ = std::make_unique<TextEngine>(*fontManager_, registry);
+
+    // Compute styles + text spans through the production path, then resolve per-span
+    // layout styles (the step that folds dominant/alignment-baseline per span).
+    ParseWarningSink warningSink;
+    engine_->prepareForElement(textRootHandle, warningSink);
+
+    auto* computed = registry.try_get<components::ComputedTextComponent>(textRootHandle.entity());
+    EXPECT_NE(computed, nullptr);
+    if (!computed) {
+      return {};
+    }
+
+    engine_->resolvePerSpanLayoutStyles(textRootHandle, *computed);
+    return computed->spans;
+  }
+
+  std::unique_ptr<SVGDocument> document_;
+  std::unique_ptr<FontManager> fontManager_;
+  std::unique_ptr<TextEngine> engine_;
+};
+
+TEST_F(EffectiveBaselineResolutionTest, DominantBaselineInheritsToTspan) {
+  const auto spans = resolveSpans(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <text id="t" x="10" y="20" dominant-baseline="middle"><tspan>A</tspan></text>
+    </svg>
+  )");
+
+  EXPECT_THAT(spans, testing::Contains(SpanWithEffectiveBaseline("A", DominantBaseline::Middle)));
+}
+
+TEST_F(EffectiveBaselineResolutionTest, AlignmentBaselineOverridesDominantBaseline) {
+  const auto spans = resolveSpans(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <text id="t" x="10" y="20" dominant-baseline="middle">
+        <tspan alignment-baseline="hanging">A</tspan>
+      </text>
+    </svg>
+  )");
+
+  EXPECT_THAT(spans, testing::Contains(SpanWithEffectiveBaseline("A", DominantBaseline::Hanging)));
+}
+
+TEST_F(EffectiveBaselineResolutionTest, AlignmentBaselineBaselineKeywordDefersToDominant) {
+  // `alignment-baseline: baseline` parses to Auto, so the span's own dominant-baseline
+  // (here `hanging`, set on the tspan) applies — matching resvg and Chrome.
+  const auto spans = resolveSpans(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <text id="t" x="10" y="20" dominant-baseline="middle">
+        <tspan dominant-baseline="hanging" alignment-baseline="baseline">A</tspan>
+      </text>
+    </svg>
+  )");
+
+  EXPECT_THAT(spans, testing::Contains(SpanWithEffectiveBaseline("A", DominantBaseline::Hanging)));
+}
+
+TEST_F(EffectiveBaselineResolutionTest, NoChangeUsesParentDominantBaseline) {
+  const auto spans = resolveSpans(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <text id="t" x="10" y="20" dominant-baseline="middle">
+        <tspan dominant-baseline="no-change">A</tspan>
+      </text>
+    </svg>
+  )");
+
+  EXPECT_THAT(spans, testing::Contains(SpanWithEffectiveBaseline("A", DominantBaseline::Middle)));
+}
+
+TEST_F(EffectiveBaselineResolutionTest, UseScriptResolvesAsIs) {
+  // `use-script` is deprecated and unsupported; it stays in the effective baseline and
+  // computeBaselineShift() maps it to a zero shift (behaves like auto).
+  const auto spans = resolveSpans(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <text id="t" x="10" y="20" dominant-baseline="use-script">A</text>
+    </svg>
+  )");
+
+  EXPECT_THAT(spans,
+              testing::Contains(SpanWithEffectiveBaseline("A", DominantBaseline::UseScript)));
 }
 
 }  // namespace

--- a/donner/svg/renderer/tests/resvg_test_suite.cc
+++ b/donner/svg/renderer/tests/resvg_test_suite.cc
@@ -1205,19 +1205,28 @@ INSTANTIATE_TEST_SUITE_P(
 
 INSTANTIATE_TEST_SUITE_P(
     TextAlignmentBaseline, ImageComparisonTestFixture,
-    Combine(
-        ValuesIn(getTestsInCategory(
-            "text/alignment-baseline",
-            {
-                // UB: resvg's golden PNG is a "UB" placeholder overlay, so no render can
-                // match it. Render for no-crash coverage only.
-                {"after-edge.svg", Params::RenderOnly("UB: golden is a UB placeholder image")},
-                {"baseline.svg", Params::RenderOnly("UB: golden is a UB placeholder image")},
-                {"ideographic.svg", Params::RenderOnly("UB: golden is a UB placeholder image")},
-                {"text-after-edge.svg",
-                 Params::RenderOnly("UB: golden is a UB placeholder image")},
-            })),
-        ValuesIn(ActiveComparisonModes())),
+    Combine(ValuesIn(getTestsInCategory(
+                "text/alignment-baseline",
+                {
+                    // UB: resvg's golden PNG is a "UB" placeholder overlay, so no render can
+                    // match it. Render for no-crash coverage only.
+                    {"after-edge.svg", Params::RenderOnly("UB: golden is a UB placeholder image")},
+                    {"baseline.svg", Params::RenderOnly("UB: golden is a UB placeholder image")},
+                    {"ideographic.svg", Params::RenderOnly("UB: golden is a UB placeholder image")},
+                    {"text-after-edge.svg",
+                     Params::RenderOnly("UB: golden is a UB placeholder image")},
+
+                    {"hanging-on-vertical.svg",
+                     Params::Skip("Bug: mixed-script vertical flow (upright CJK + rotated Latin) "
+                                  "column geometry differs from resvg; alignment-baseline is "
+                                  "correctly ignored in vertical mode. Same gap as the "
+                                  "text/writing-mode mixed-languages-with-tb skip.")},
+                    {"two-textPath-with-middle-on-first.svg",
+                     Params().withMaxPixelsDifferent(200).withReason(
+                         "Sub-pixel glyph placement along the two paths; ~108 scattered "
+                         "edge pixels, no positional drift (bounding boxes match exactly)")},
+                })),
+            ValuesIn(ActiveComparisonModes())),
     TestNameFromFilename);
 
 INSTANTIATE_TEST_SUITE_P(
@@ -1255,6 +1264,13 @@ INSTANTIATE_TEST_SUITE_P(
                     // match it. Render for no-crash coverage only.
                     {"reset-size.svg", Params::RenderOnly("UB: golden is a UB placeholder image")},
                     {"use-script.svg", Params::RenderOnly("UB: golden is a UB placeholder image")},
+
+                    {"hanging.svg",
+                     Params::WithThreshold(
+                         0.1f, kDefaultMismatchedPixels,
+                         "Golden's 0.5px crosshair hairline is rasterized with a sub-pixel x "
+                         "offset (vertical-line alpha 128/192 vs 160/160 in the sibling "
+                         "middle/central/alphabetic goldens); the glyph itself matches")},
                 })),
             ValuesIn(ActiveComparisonModes())),
     TestNameFromFilename);

--- a/donner/svg/renderer/tests/resvg_test_suite.cc
+++ b/donner/svg/renderer/tests/resvg_test_suite.cc
@@ -1209,36 +1209,13 @@ INSTANTIATE_TEST_SUITE_P(
         ValuesIn(getTestsInCategory(
             "text/alignment-baseline",
             {
-                {"after-edge.svg",
-                 Params::Skip(
-                     "Not impl: full alignment-baseline keyword set + tspan baseline alignment")},
-                {"baseline.svg",
-                 Params::Skip(
-                     "Not impl: full alignment-baseline keyword set + tspan baseline alignment")},
-                {"before-edge.svg",
-                 Params::Skip(
-                     "Not impl: full alignment-baseline keyword set + tspan baseline alignment")},
-                {"hanging-on-vertical.svg",
-                 Params::Skip(
-                     "Not impl: full alignment-baseline keyword set + tspan baseline alignment")},
-                {"ideographic.svg",
-                 Params::Skip(
-                     "Not impl: full alignment-baseline keyword set + tspan baseline alignment")},
-                {"middle-on-textPath.svg",
-                 Params::Skip(
-                     "Not impl: full alignment-baseline keyword set + tspan baseline alignment")},
-                {"middle.svg",
-                 Params::Skip(
-                     "Not impl: full alignment-baseline keyword set + tspan baseline alignment")},
+                // UB: resvg's golden PNG is a "UB" placeholder overlay, so no render can
+                // match it. Render for no-crash coverage only.
+                {"after-edge.svg", Params::RenderOnly("UB: golden is a UB placeholder image")},
+                {"baseline.svg", Params::RenderOnly("UB: golden is a UB placeholder image")},
+                {"ideographic.svg", Params::RenderOnly("UB: golden is a UB placeholder image")},
                 {"text-after-edge.svg",
-                 Params::Skip(
-                     "Not impl: full alignment-baseline keyword set + tspan baseline alignment")},
-                {"text-before-edge.svg",
-                 Params::Skip(
-                     "Not impl: full alignment-baseline keyword set + tspan baseline alignment")},
-                {"two-textPath-with-middle-on-first.svg",
-                 Params::Skip(
-                     "Not impl: full alignment-baseline keyword set + tspan baseline alignment")},
+                 Params::RenderOnly("UB: golden is a UB placeholder image")},
             })),
         ValuesIn(ActiveComparisonModes())),
     TestNameFromFilename);
@@ -1274,57 +1251,10 @@ INSTANTIATE_TEST_SUITE_P(
     Combine(ValuesIn(getTestsInCategory(
                 "text/dominant-baseline",
                 {
-                    {"alignment-baseline-and-baseline-shift-on-tspans.svg",
-                     Params::Skip(
-                         "Not impl: full dominant-baseline keyword set (incl. before/after-edge, "
-                         "no-change, reset-size, use-script)")},
-                    {"alignment-baseline=baseline-on-tspan.svg",
-                     Params::Skip(
-                         "Not impl: full dominant-baseline keyword set (incl. before/after-edge, "
-                         "no-change, reset-size, use-script)")},
-                    {"complex.svg",
-                     Params::Skip("Not impl: full dominant-baseline keyword set (incl. "
-                                  "before/after-edge, no-change, reset-size, use-script)")},
-                    {"dummy-tspan.svg",
-                     Params::Skip(
-                         "Not impl: full dominant-baseline keyword set (incl. before/after-edge, "
-                         "no-change, reset-size, use-script)")},
-                    {"hanging.svg",
-                     Params::Skip("Not impl: full dominant-baseline keyword set (incl. "
-                                  "before/after-edge, no-change, reset-size, use-script)")},
-                    {"inherit.svg",
-                     Params::Skip("Not impl: full dominant-baseline keyword set (incl. "
-                                  "before/after-edge, no-change, reset-size, use-script)")},
-                    {"middle.svg",
-                     Params::Skip("Not impl: full dominant-baseline keyword set (incl. "
-                                  "before/after-edge, no-change, reset-size, use-script)")},
-                    {"nested.svg",
-                     Params::Skip("Not impl: full dominant-baseline keyword set (incl. "
-                                  "before/after-edge, no-change, reset-size, use-script)")},
-                    {"no-change.svg",
-                     Params::Skip(
-                         "Not impl: full dominant-baseline keyword set (incl. before/after-edge, "
-                         "no-change, reset-size, use-script)")},
-                    {"reset-size.svg",
-                     Params::Skip(
-                         "Not impl: full dominant-baseline keyword set (incl. before/after-edge, "
-                         "no-change, reset-size, use-script)")},
-                    {"sequential.svg",
-                     Params::Skip(
-                         "Not impl: full dominant-baseline keyword set (incl. before/after-edge, "
-                         "no-change, reset-size, use-script)")},
-                    {"text-after-edge.svg",
-                     Params::Skip(
-                         "Not impl: full dominant-baseline keyword set (incl. before/after-edge, "
-                         "no-change, reset-size, use-script)")},
-                    {"text-before-edge.svg",
-                     Params::Skip(
-                         "Not impl: full dominant-baseline keyword set (incl. before/after-edge, "
-                         "no-change, reset-size, use-script)")},
-                    {"use-script.svg",
-                     Params::Skip(
-                         "Not impl: full dominant-baseline keyword set (incl. before/after-edge, "
-                         "no-change, reset-size, use-script)")},
+                    // UB: resvg's golden PNG is a "UB" placeholder overlay, so no render can
+                    // match it. Render for no-crash coverage only.
+                    {"reset-size.svg", Params::RenderOnly("UB: golden is a UB placeholder image")},
+                    {"use-script.svg", Params::RenderOnly("UB: golden is a UB placeholder image")},
                 })),
             ValuesIn(ActiveComparisonModes())),
     TestNameFromFilename);

--- a/donner/svg/text/TextBackend.h
+++ b/donner/svg/text/TextBackend.h
@@ -13,7 +13,10 @@ namespace donner::svg {
 struct FontVMetrics {
   int ascent = 0;   ///< Positive, above baseline.
   int descent = 0;  ///< Negative, below baseline.
-  int lineGap = 0;
+  int lineGap = 0;  ///< Extra spacing between lines.
+  /// x-height (OS/2 `sxHeight`), or 0 when the font does not provide it. Consumers should
+  /// fall back to 0.45 * (ascent - descent) when 0, matching Firefox and resvg.
+  int xHeight = 0;
 };
 
 /// Line decoration positioning metrics in font design units.

--- a/donner/svg/text/TextBackendFull.cc
+++ b/donner/svg/text/TextBackendFull.cc
@@ -212,21 +212,37 @@ FontVMetrics TextBackendFull::fontVMetrics(FontHandle font) const {
     return {};
   }
 
-  // Search for the 'hhea' table in the TrueType table directory.
+  // Search for the 'hhea' and 'OS/2' tables in the TrueType table directory.
   const auto* d = data.data();
   const int numTables = (d[4] << 8) | d[5];
+  int hheaOffset = 0;
+  int os2Offset = 0;
   for (int i = 0; i < numTables; ++i) {
     const int loc = 12 + 16 * i;
+    const int offset = static_cast<int>(
+        (static_cast<unsigned>(d[loc + 8]) << 24) | (static_cast<unsigned>(d[loc + 9]) << 16) |
+        (static_cast<unsigned>(d[loc + 10]) << 8) | static_cast<unsigned>(d[loc + 11]));
     if (d[loc] == 'h' && d[loc + 1] == 'h' && d[loc + 2] == 'e' && d[loc + 3] == 'a') {
-      const int offset = static_cast<int>(
-          (static_cast<unsigned>(d[loc + 8]) << 24) | (static_cast<unsigned>(d[loc + 9]) << 16) |
-          (static_cast<unsigned>(d[loc + 10]) << 8) | static_cast<unsigned>(d[loc + 11]));
-      FontVMetrics metrics;
-      metrics.ascent = static_cast<int16_t>((d[offset + 4] << 8) | d[offset + 5]);
-      metrics.descent = static_cast<int16_t>((d[offset + 6] << 8) | d[offset + 7]);
-      metrics.lineGap = static_cast<int16_t>((d[offset + 8] << 8) | d[offset + 9]);
-      return metrics;
+      hheaOffset = offset;
+    } else if (d[loc] == 'O' && d[loc + 1] == 'S' && d[loc + 2] == '/' && d[loc + 3] == '2') {
+      os2Offset = offset;
     }
+  }
+
+  if (hheaOffset != 0) {
+    FontVMetrics metrics;
+    metrics.ascent = static_cast<int16_t>((d[hheaOffset + 4] << 8) | d[hheaOffset + 5]);
+    metrics.descent = static_cast<int16_t>((d[hheaOffset + 6] << 8) | d[hheaOffset + 7]);
+    metrics.lineGap = static_cast<int16_t>((d[hheaOffset + 8] << 8) | d[hheaOffset + 9]);
+
+    // x-height from the OS/2 table (`sxHeight`, offset 86), present in version >= 2.
+    if (os2Offset != 0) {
+      const uint16_t os2Version = static_cast<uint16_t>((d[os2Offset] << 8) | d[os2Offset + 1]);
+      if (os2Version >= 2) {
+        metrics.xHeight = static_cast<int16_t>((d[os2Offset + 86] << 8) | d[os2Offset + 87]);
+      }
+    }
+    return metrics;
   }
 
   // Fallback to FreeType if hhea not found.

--- a/donner/svg/text/TextBackendSimple.cc
+++ b/donner/svg/text/TextBackendSimple.cc
@@ -82,6 +82,15 @@ FontVMetrics TextBackendSimple::fontVMetrics(FontHandle font) const {
   }
   FontVMetrics metrics;
   stbtt_GetFontVMetrics(info, &metrics.ascent, &metrics.descent, &metrics.lineGap);
+
+  // x-height from the OS/2 table (`sxHeight`, offset 86), present in version >= 2.
+  if (const int os2 = findFontTable(info->data, info->fontstart, "OS/2")) {
+    const uint16_t version =
+        static_cast<uint16_t>(readInt16BE(info->data, os2));  // USHORT version at offset 0.
+    if (version >= 2) {
+      metrics.xHeight = readInt16BE(info->data, os2 + 86);
+    }
+  }
   return metrics;
 }
 

--- a/donner/svg/text/TextEngine.cc
+++ b/donner/svg/text/TextEngine.cc
@@ -206,7 +206,6 @@ TextLayoutParams buildTextLayoutParams(Registry& registry, EntityHandle handle,
   params.fontMetrics = FontMetrics::DefaultsWithFontSize(fontSizePx);
 
   params.textAnchor = properties.textAnchor.get().value();
-  params.dominantBaseline = properties.dominantBaseline.get().value();
   params.writingMode = properties.writingMode.get().value();
   params.letterSpacingPx = properties.letterSpacing.get().value().toPixels(
       params.viewBox, params.fontMetrics, Lengthd::Extent::X);
@@ -245,7 +244,33 @@ void ResolvePerSpanLayoutStyles(Registry& registry, components::ComputedTextComp
     span.textAnchor = style->properties->textAnchor.get().value();
     span.textDecoration = style->properties->textDecoration.get().value();
     span.baselineShift = style->properties->baselineShift.get().value();
-    span.alignmentBaseline = style->properties->alignmentBaseline.get().value();
+
+    // Effective baseline alignment (matching resvg): a non-auto `alignment-baseline`
+    // overrides; otherwise the span's (inherited) `dominant-baseline` applies.
+    {
+      DominantBaseline dominantBaseline = style->properties->dominantBaseline.get().value();
+      if (dominantBaseline == DominantBaseline::NoChange) {
+        // `no-change` uses the parent element's dominant baseline (one level, matching
+        // resvg). A residual NoChange (parent is also no-change, or there is no parent
+        // style) behaves like auto in computeBaselineShift.
+        if (registry.all_of<donner::components::TreeComponent>(styleEntity)) {
+          const Entity parent =
+              registry.get<donner::components::TreeComponent>(styleEntity).parent();
+          if (const auto* parentStyle =
+                  parent != entt::null
+                      ? registry.try_get<components::ComputedStyleComponent>(parent)
+                      : nullptr;
+              parentStyle && parentStyle->properties) {
+            dominantBaseline = parentStyle->properties->dominantBaseline.get().value();
+          }
+        }
+      }
+
+      const DominantBaseline alignmentBaseline = style->properties->alignmentBaseline.get().value();
+      span.alignmentBaseline =
+          alignmentBaseline != DominantBaseline::Auto ? alignmentBaseline : dominantBaseline;
+    }
+
     span.fontWeight = style->properties->fontWeight.get().value();
     span.fontStyle = style->properties->fontStyle.get().value();
     span.fontStretch = static_cast<FontStretch>(style->properties->fontStretch.get().value());
@@ -315,10 +340,24 @@ void ResolvePerSpanLayoutStyles(Registry& registry, components::ComputedTextComp
 namespace text_engine_detail {
 
 double computeBaselineShift(DominantBaseline baseline, const FontVMetrics& vm, float scale) {
+  // Keyword → offset mapping matches resvg's usvg text layout
+  // (ResolvedFont::alignment_baseline_shift), which in turn matches Chrome's hardcoded
+  // baseline table. Positive values move glyphs down (+Y in SVG coordinates).
   switch (baseline) {
     case DominantBaseline::Auto:
-    case DominantBaseline::Alphabetic: return 0.0;
-    case DominantBaseline::Middle:
+    case DominantBaseline::Alphabetic:
+    case DominantBaseline::UseScript:  // Deprecated SVG 1.1 keyword; behaves like auto.
+    case DominantBaseline::NoChange:   // Resolved to the parent's value before layout; a
+                                       // residual no-change behaves like auto.
+    case DominantBaseline::ResetSize:  // Deprecated SVG 1.1 keyword; behaves like auto.
+      return 0.0;
+    case DominantBaseline::Middle: {
+      // Half the x-height. Fonts without an OS/2 sxHeight fall back to 45% of
+      // ascent−descent (what Firefox and resvg use).
+      const double xHeight = vm.xHeight > 0 ? static_cast<double>(vm.xHeight)
+                                            : static_cast<double>(vm.ascent - vm.descent) * 0.45;
+      return xHeight * 0.5 * scale;
+    }
     case DominantBaseline::Central:
       return static_cast<double>(vm.ascent + vm.descent) * 0.5 * scale;
     case DominantBaseline::Hanging: return static_cast<double>(vm.ascent) * 0.8 * scale;
@@ -788,15 +827,6 @@ std::vector<TextRun> TextEngine::layout(const components::ComputedTextComponent&
   const float fontSizePx = static_cast<float>(
       params.fontSize.toPixels(params.viewBox, params.fontMetrics, Lengthd::Extent::Mixed));
 
-  // ── Compute dominant-baseline shift ───────────────────────────────────────────
-  const float scale = backend_->scaleForPixelHeight(font, fontSizePx);
-  double baselineShift = 0.0;
-  if (params.dominantBaseline != DominantBaseline::Auto &&
-      params.dominantBaseline != DominantBaseline::Alphabetic) {
-    baselineShift =
-        computeBaselineShift(params.dominantBaseline, backend_->fontVMetrics(font), scale);
-  }
-
   // ── Layout state ──────────────────────────────────────────────────────────────
   std::vector<TextRun> runs;
   bool haveCurrentPosition = false;
@@ -867,9 +897,12 @@ std::vector<TextRun> TextEngine::layout(const components::ComputedTextComponent&
     const double spanBaselineShiftPx =
         computeSpanBaselineShiftPx(*backend_, span, spanFont, spanScale, params);
 
-    // ── Alignment-baseline override ─────────────────────────────────────────────
-    double effectiveBaselineShift = baselineShift;
-    if (span.alignmentBaseline != DominantBaseline::Auto) {
+    // ── Baseline alignment (dominant-baseline / alignment-baseline) ────────────
+    // span.alignmentBaseline is the effective baseline resolved per span: a non-auto
+    // alignment-baseline override, otherwise the span's (inherited) dominant-baseline.
+    // Matching resvg, baseline alignment applies only to horizontal text.
+    double effectiveBaselineShift = 0.0;
+    if (!isVertical(params.writingMode) && span.alignmentBaseline != DominantBaseline::Auto) {
       effectiveBaselineShift =
           computeBaselineShift(span.alignmentBaseline, backend_->fontVMetrics(spanFont), spanScale);
     }

--- a/donner/svg/text/TextEngineHelpers.h
+++ b/donner/svg/text/TextEngineHelpers.h
@@ -17,8 +17,12 @@
 
 namespace donner::svg::text_engine_detail {
 
-/// Compute baseline shift for a given DominantBaseline/AlignmentBaseline value.
-/// Returns a Y offset in pixels (positive = shift up toward ascender).
+/// Compute the baseline-alignment offset for a `dominant-baseline` / `alignment-baseline`
+/// keyword, in pixels. The offset is added to the baseline Y position, so positive values
+/// move glyphs down (+Y in SVG coordinates); e.g. `hanging` returns +0.8 * ascent.
+/// @param baseline Effective baseline keyword for the span.
+/// @param vm Font vertical metrics in design units (\ref FontVMetrics::xHeight may be 0).
+/// @param scale Design units → pixels scale (em scale, fontSize / unitsPerEm).
 double computeBaselineShift(DominantBaseline baseline, const FontVMetrics& vm, float scale);
 
 /// Byte range within a span representing a shaping chunk.

--- a/donner/svg/text/TextLayoutParams.h
+++ b/donner/svg/text/TextLayoutParams.h
@@ -8,7 +8,6 @@
 #include "donner/base/RcString.h"
 #include "donner/base/RelativeLengthMetrics.h"
 #include "donner/base/SmallVector.h"
-#include "donner/svg/core/DominantBaseline.h"
 #include "donner/svg/core/LengthAdjust.h"
 #include "donner/svg/core/TextAnchor.h"
 #include "donner/svg/core/WritingMode.h"
@@ -17,6 +16,10 @@ namespace donner::svg {
 
 /**
  * Layout-only parameters consumed by TextEngine.
+ *
+ * Baseline alignment (`dominant-baseline` / `alignment-baseline`) is resolved per span into
+ * \ref donner::svg::components::ComputedTextComponent::TextSpan::alignmentBaseline rather than
+ * carried here, since each span may resolve a different baseline.
  */
 struct TextLayoutParams {
   SmallVector<RcString, 1> fontFamilies;
@@ -24,7 +27,6 @@ struct TextLayoutParams {
   Box2d viewBox;
   FontMetrics fontMetrics;
   TextAnchor textAnchor = TextAnchor::Start;
-  DominantBaseline dominantBaseline = DominantBaseline::Auto;
   WritingMode writingMode = WritingMode::HorizontalTb;
   double letterSpacingPx = 0.0;
   double wordSpacingPx = 0.0;


### PR DESCRIPTION
Implements the full `dominant-baseline` and `alignment-baseline` keyword sets (gaps F5/F6 in `docs/design_docs/0021-resvg_feature_gaps.md`), enabling the previously skipped `text/dominant-baseline` and `text/alignment-baseline` resvg suites. resvg's baseline model (usvg `text/layout.rs`) is the reference for what the goldens expect.

## What changed

- **Parsing**: `dominant-baseline` now accepts the deprecated SVG 1.1 keywords `use-script`, `no-change`, `reset-size` plus the `text-before-edge` / `text-after-edge` aliases. `alignment-baseline` gets its own parser accepting `baseline` (maps to auto — both defer to the dominant baseline), `before-edge` / `after-edge`, and the CSS `text-top` / `text-bottom` aliases.
- **Inheritance**: `dominant-baseline` is now `PropertyCascade::Inherit`, matching CSS Inline Layout 3 and resvg.
- **Per-span resolution**: `ResolvePerSpanLayoutStyles` folds the effective baseline into `TextSpan::alignmentBaseline`: a non-auto `alignment-baseline` overrides the span's (inherited) `dominant-baseline`; `no-change` resolves to the parent element's dominant baseline. Storing the folded value keeps the `.rnr` render-command wire format unchanged (`TextParams::dominantBaseline` becomes a reserved byte in `SandboxCodecs`).
- **Offsets**: `computeBaselineShift` now matches resvg's keyword table. `middle` uses half the x-height — a new `FontVMetrics::xHeight` is read from OS/2 `sxHeight` in both text backends, with the Firefox/resvg 45%-of-height fallback. `use-script` / `no-change` / `reset-size` behave like `auto`.
- **Per-span application**: the shift is computed with each span's own font and font-size (previously the dominant-baseline shift was computed once with the text root's font), and baseline alignment is skipped in vertical writing modes, matching resvg.

## Red→green

The first commit enables the tests and records the red state (18 failures, e.g. `middle` 3406 px, `no-change` 6317 px, `text-before-edge` 5769 px); the second turns them green. Now passing at the default 100 px budget on default, `--config=text-full`, and `--config=geode` builds:

- `text/dominant-baseline`: alignment-baseline-and-baseline-shift-on-tspans, alignment-baseline=baseline-on-tspan, complex, dummy-tspan, inherit, middle, nested, no-change, sequential, text-after-edge, text-before-edge
- `text/alignment-baseline`: before-edge, middle, middle-on-textPath, text-before-edge, two-textPath-with-middle-on-first

## Triage entries needing reviewer sign-off

- `dominant-baseline/hanging.svg` — passes only with `WithThreshold(0.1f)`: the golden's 0.5px crosshair hairline is rasterized with a sub-pixel x offset relative to the sibling goldens (vertical-line coverage alpha 128/192, vs 160/160 in the middle/central/alphabetic goldens; Donner's render matches the 160/160 family exactly and matches the 0.5px-line math). The glyph itself matches — bounding boxes are identical. Same lever as the existing `text/baseline-shift` axis-artifact entries.
- `alignment-baseline/two-textPath-with-middle-on-first.svg` — passes with a 200 px budget: ~108 scattered single-pixel diffs at glyph edges along the two curved paths; bounding boxes match exactly, no positional drift. Same family as the existing `text/textPath` "minor char" thresholds/golden overrides.
- `alignment-baseline/hanging-on-vertical.svg` — left skipped: mixed-script vertical flow (upright CJK + rotated Latin) column geometry differs from resvg's rotate-based vertical model (~6k px). Same gap as the `text/writing-mode` `mixed-languages-with-tb` skip and orthogonal to the baseline keywords — `alignment-baseline` itself is now correctly ignored in vertical mode (unit-tested). Recorded in 0021's writing-mode row.
- UB placeholder goldens (resvg commits a literal "UB" image): `alignment-baseline` after-edge / baseline / ideographic / text-after-edge and `dominant-baseline` use-script / reset-size are registered as `Params::RenderOnly`.

## Tests

- `PropertyRegistry_tests.cc`: keyword-set parsing for both properties (alias mappings; dominant-only keywords rejected in alignment-baseline).
- `TextEngineHelpers_tests.cc`: `computeBaselineShift` x-height / fallback / deprecated keywords; layout-level per-span hanging shift; vertical-mode suppression; document-driven effective-baseline resolution (inheritance to tspans, alignment override, `baseline` keyword deferral, `no-change` parent resolution) with a named `SpanWithEffectiveBaseline` matcher.

`bazel test //...` green locally (default + variant lanes).

https://claude.ai/code/session_01Rk85ZkdhJ4a2pVRtGbjpgt
