### PR TITLE
Stabilize async renderer in-flight test

### DIFF
--- a/donner/editor/tests/AsyncRenderer_tests.cc
+++ b/donner/editor/tests/AsyncRenderer_tests.cc
@@ -578,15 +578,17 @@ TEST(AsyncRendererTest, RenderInFlightForTestingExcludesStagedDoneResult) {
 
   svg::Renderer renderer;
   AsyncRenderer asyncRenderer;
-  asyncRenderer.setReplayRenderDelayForTesting(std::chrono::milliseconds(1));
+
+  std::promise<void> wakeFired;
+  asyncRenderer.setWakeCallback([&] { wakeFired.set_value(); });
 
   RenderRequest request(renderer, document);
   request.version = 1;
   asyncRenderer.requestRender(request);
 
-  EXPECT_TRUE(asyncRenderer.hasRenderInFlightForTesting());
-  ASSERT_TRUE(asyncRenderer.waitUntilNoRenderInFlightForTesting(std::chrono::steady_clock::now() +
-                                                                std::chrono::seconds(5)));
+  auto wakeFuture = wakeFired.get_future();
+  const auto status = wakeFuture.wait_for(std::chrono::seconds(5));
+  ASSERT_EQ(status, std::future_status::ready) << "render result was not staged";
 
   EXPECT_FALSE(asyncRenderer.hasRenderInFlightForTesting());
   EXPECT_TRUE(asyncRenderer.isBusy()) << "staged Done result should still block new requests";


### PR DESCRIPTION
## Summary

- Fix the hosted macOS CI race in `AsyncRendererTest.RenderInFlightForTestingExcludesStagedDoneResult`.
- Wait for the worker Done-transition wake callback before asserting that a staged result is busy but no longer render-in-flight.
- Remove the fragile 1 ms render-delay timing assumption that allowed the worker to finish before the initial in-flight assertion.

## Validation

- `tools/llm-bazel-wrap.sh test //donner/editor/tests:async_renderer_tests --remote_executor= --remote_cache= --noremote_upload_local_results --test_output=errors --test_arg=--gtest_filter=AsyncRendererTest.RenderInFlightForTestingExcludesStagedDoneResult`
- `tools/llm-bazel-wrap.sh test //donner/editor/tests:async_renderer_tests --remote_executor= --remote_cache= --noremote_upload_local_results --test_output=errors`
- `git diff --check`
- `python3 tools/cmake/gen_cmakelists.py --check`
- `tools/llm-bazel-wrap.sh test //... --remote_executor= --remote_cache= --noremote_upload_local_results --test_output=errors`