### PR TITLE
Decouple path boolean search budget from intersection cap

### DIFF
--- a/donner/base/PathOps.cc
+++ b/donner/base/PathOps.cc
@@ -323,15 +323,25 @@ double BoxMaxExtent(const Box2d& box) {
   return std::max(std::abs(box.width()), std::abs(box.height()));
 }
 
-std::size_t MaxIntersectionSearchSteps(std::size_t maxIntersections) {
-  constexpr std::size_t kMinIntersectionSearchSteps = 256;
-  constexpr std::size_t kIntersectionSearchMultiplier = 1;
-  if (maxIntersections >
-      (std::numeric_limits<std::size_t>::max() / kIntersectionSearchMultiplier)) {
+std::size_t SaturatingMultiply(std::size_t lhs, std::size_t rhs) {
+  if (lhs != 0 && rhs > std::numeric_limits<std::size_t>::max() / lhs) {
     return std::numeric_limits<std::size_t>::max();
   }
+  return lhs * rhs;
+}
 
-  return std::max(kMinIntersectionSearchSteps, maxIntersections * kIntersectionSearchMultiplier);
+std::size_t MaxIntersectionSearchSteps(const PathBooleanOptions& options,
+                                       std::size_t segmentCount) {
+  constexpr std::size_t kMinIntersectionSearchSteps = 512;
+  constexpr std::size_t kSearchStepsPerSegment = 64;
+  constexpr std::size_t kSearchStepsPerAllowedIntersection = 1;
+
+  const std::size_t segmentBudget = std::max(
+      kMinIntersectionSearchSteps, SaturatingMultiply(segmentCount, kSearchStepsPerSegment));
+  const std::size_t intersectionBudget =
+      SaturatingMultiply(options.maxIntersections, kSearchStepsPerAllowedIntersection);
+
+  return std::max(segmentBudget, intersectionBudget);
 }
 
 std::array<Vector2d, 4> SegmentAsCubic(const Segment& segment) {
@@ -1603,7 +1613,7 @@ PathBooleanResult ApplyPathBoolean(PathBooleanOp op, std::span<const PathBoolean
 
   std::size_t intersectionCount = 0;
   IntersectionSearchBudget intersectionSearchBudget{
-      .maxSteps = MaxIntersectionSearchSteps(options.maxIntersections),
+      .maxSteps = MaxIntersectionSearchSteps(options, segments.size()),
   };
   for (std::size_t i = 0; i < segments.size(); ++i) {
     for (std::size_t j = i + 1; j < segments.size(); ++j) {

--- a/donner/base/tests/PathOps_tests.cc
+++ b/donner/base/tests/PathOps_tests.cc
@@ -522,6 +522,28 @@ TEST(PathOpsTest, UnionOfNestedCirclesKeepsOuterCircle) {
   EXPECT_FALSE(path.isInside({5, 50}));
 }
 
+TEST(PathOpsTest, LowIntersectionCapAllowsNestedCircleContainment) {
+  PathBooleanOptions options;
+  options.maxIntersections = 64;
+  const std::array<PathBooleanInput, 2> inputs = {
+      Input(CirclePath({50, 50}, 40)),
+      Input(CirclePath({50, 50}, 15)),
+  };
+
+  const PathBooleanResult unionResult = ApplyPathBoolean(PathBooleanOp::Union, inputs, options);
+  ASSERT_EQ(unionResult.status, PathBooleanStatus::Ok) << Diagnostics(unionResult);
+  ASSERT_EQ(unionResult.paths.size(), 1u);
+  EXPECT_TRUE(unionResult.paths.front().isInside({50, 50}));
+  EXPECT_FALSE(unionResult.paths.front().isInside({5, 50}));
+
+  const PathBooleanResult intersectResult =
+      ApplyPathBoolean(PathBooleanOp::Intersect, inputs, options);
+  ASSERT_EQ(intersectResult.status, PathBooleanStatus::Ok) << Diagnostics(intersectResult);
+  ASSERT_EQ(intersectResult.paths.size(), 1u);
+  EXPECT_TRUE(intersectResult.paths.front().isInside({50, 50}));
+  EXPECT_FALSE(intersectResult.paths.front().isInside({50, 25}));
+}
+
 TEST(PathOpsTest, XorOfNestedCirclesCreatesCurvedRing) {
   const PathBooleanResult result = Boolean(
       PathBooleanOp::Xor, {Input(CirclePath({50, 50}, 40)), Input(CirclePath({50, 50}, 15))});


### PR DESCRIPTION
## Summary

Adjusts the path boolean cubic intersection search budget so lowering `maxIntersections` does not also collapse the recursive subdivision budget for simple contained-curve cases.

Adds regression coverage for nested concentric circle union/intersection with `maxIntersections = 64`, matching the follow-up review feedback on PR #714.

## Root Cause

PR #714 made the operation-wide recursive search budget depend almost entirely on `maxIntersections`. That bounded adversarial cubic searches, but it also turned the documented output intersection cap into a hidden work cap. Simple nested cubic contours with no boundary intersections could therefore return `TooComplex` when callers lowered `maxIntersections`.

## Validation

- `tools/llm-bazel-wrap.sh test //donner/base:base_tests --test_filter=PathOpsTest.LowIntersectionCapAllowsNestedCircleContainment --test_output=errors --remote_cache= --noremote_upload_local_results`
- `tools/llm-bazel-wrap.sh test //donner/base:base_tests --test_filter='PathOpsTest.LowIntersectionCapAllowsNestedCircleContainment:PathOpsTest.FuzzerTimeout*' --test_output=all --test_sharding_strategy=disabled --nocache_test_results --remote_cache= --noremote_upload_local_results`
- `tools/llm-bazel-wrap.sh test //donner/base:base_tests --test_output=errors --remote_cache= --noremote_upload_local_results`
- `tools/llm-bazel-wrap.sh test //... --test_output=errors --remote_cache= --noremote_upload_local_results`
- `python3 tools/cmake/gen_cmakelists.py --check`
- `git diff --check`