### PR TITLE
Fix Geode replay and resource loading regressions

### DIFF
--- a/donner/editor/repro/GlRnrReplay.cc
+++ b/donner/editor/repro/GlRnrReplay.cc
@@ -216,14 +216,29 @@ void QueueRecordedScrollEvents(EditorShell& shell, const ReproFrame& frame) {
   return modifiers;
 }
 
+[[nodiscard]] std::optional<Vector2d> DocumentPointFromFrame(const ReproFrame& frame) {
+  if (frame.mouseDocX.has_value() && frame.mouseDocY.has_value()) {
+    return Vector2d(*frame.mouseDocX, *frame.mouseDocY);
+  }
+
+  if (!frame.viewport.has_value() || frame.viewport->zoom <= 0.0) {
+    return std::nullopt;
+  }
+
+  const ReproViewport& viewport = *frame.viewport;
+  return Vector2d(viewport.panDocX + (frame.mouseX - viewport.panScreenX) / viewport.zoom,
+                  viewport.panDocY + (frame.mouseY - viewport.panScreenY) / viewport.zoom);
+}
+
 [[nodiscard]] std::optional<EditorShellDocumentReplayInput> DocumentReplayInputFromFrame(
     const ReproFrame& frame) {
-  if (!frame.mouseDocX.has_value() || !frame.mouseDocY.has_value()) {
+  const std::optional<Vector2d> documentPoint = DocumentPointFromFrame(frame);
+  if (!documentPoint.has_value()) {
     return std::nullopt;
   }
 
   return EditorShellDocumentReplayInput{
-      .documentPoint = Vector2d(*frame.mouseDocX, *frame.mouseDocY),
+      .documentPoint = *documentPoint,
       .leftMouseDown = (frame.mouseButtonMask & 1) != 0,
       .leftMousePressed = HasLeftMouseEvent(frame, ReproEvent::Kind::MouseDown),
       .leftMouseReleased = HasLeftMouseEvent(frame, ReproEvent::Kind::MouseUp),
@@ -594,7 +609,7 @@ bool RunGlRnrReplay(const GlRnrReplayOptions& options, GlRnrReplayResult* result
     window.pollEvents();
     window.beginFrameWithInput(options.driveDocumentSpaceInput ? NonCanvasInputFromFrame(frame)
                                                                : InputFromFrame(frame));
-    if (frame.viewport.has_value() && !options.driveDocumentSpaceInput) {
+    if (frame.viewport.has_value()) {
       shell.overrideViewportForReplay(ViewportFromReproViewport(*frame.viewport));
     }
     if (options.driveDocumentSpaceInput) {

--- a/donner/editor/tests/GlRnrReplay_tests.cc
+++ b/donner/editor/tests/GlRnrReplay_tests.cc
@@ -2377,6 +2377,7 @@ TEST(GlRnrReplayTest, GeodeDragZoomRerasterizesDonnerDOverlayEveryPresentedFrame
   options.pace = false;
   options.workerScheduling = repro::GlRnrReplayWorkerScheduling::Realtime;
   options.workerRenderDelayMsForTesting = 2;
+  options.driveDocumentSpaceInput = true;
   options.visible = false;
 
   repro::GlRnrReplayResult result;
@@ -2422,6 +2423,7 @@ TEST(GlRnrReplayTest, GeodeZoomThenDragKeepsDonnerDOverlayLockedToPresentedConte
   options.pace = false;
   options.workerScheduling = repro::GlRnrReplayWorkerScheduling::Realtime;
   options.workerRenderDelayMsForTesting = 40;
+  options.driveDocumentSpaceInput = true;
   options.visible = false;
 
   repro::GlRnrReplayResult result;
@@ -2471,6 +2473,7 @@ TEST(GlRnrReplayTest, GeodeZoomThenDragDoesNotFreezeLiveDragPreviewWhileWorkerBu
   options.pace = false;
   options.workerScheduling = repro::GlRnrReplayWorkerScheduling::Realtime;
   options.workerRenderDelayMsForTesting = 500;
+  options.driveDocumentSpaceInput = true;
   options.visible = false;
 
   repro::GlRnrReplayResult result;
@@ -2521,6 +2524,7 @@ TEST(GlRnrReplayTest, GeodeFarZoomThenDragKeepsDonnerNOverlayLockedToPresentedCo
   options.pace = false;
   options.workerScheduling = repro::GlRnrReplayWorkerScheduling::Realtime;
   options.workerRenderDelayMsForTesting = 500;
+  options.driveDocumentSpaceInput = true;
   options.visible = false;
 
   repro::GlRnrReplayResult result;
@@ -2603,6 +2607,7 @@ TEST(GlRnrReplayTest, FilteredElementOThenRDragDoesNotPopOBackOnRClick) {
   options.pace = false;
   options.workerScheduling = repro::GlRnrReplayWorkerScheduling::DrainEachFrame;
   options.contentOnlyCapture = true;
+  options.driveDocumentSpaceInput = true;
   options.visible = false;
 
   repro::GlRnrReplayResult result;
@@ -2623,7 +2628,7 @@ TEST(GlRnrReplayTest, FilteredElementOThenRDragDoesNotPopOBackOnRClick) {
       .width = expect.cropRect->width,
       .height = expect.cropRect->height,
   };
-  // Keep the identity compare focused on the dragged target. The recorded repro crop also contains
+  // Keep the identity compare focused on the dragged target. The broader repro crop also contains
   // neighboring Donner letters and lightning highlights; those pixels are useful for centroid
   // context below, but they are not the behavior this regression is pinning.
   const PixelCrop selectedOCrop{
@@ -2634,17 +2639,26 @@ TEST(GlRnrReplayTest, FilteredElementOThenRDragDoesNotPopOBackOnRClick) {
   };
   const svg::RendererBitmap firstRClickTarget = CropBitmap(*firstRClickFrame, selectedOCrop);
   const svg::RendererBitmap settledTarget = CropBitmap(*settledRClickFrame, selectedOCrop);
+  const bool hasArchivedTargetCrop = !firstRClickTarget.empty() && !settledTarget.empty();
 
-  tests::CompareBitmapToBitmap(firstRClickTarget, settledTarget,
+  tests::CompareBitmapToBitmap(hasArchivedTargetCrop ? firstRClickTarget : *firstRClickFrame,
+                               hasArchivedTargetCrop ? settledTarget : *settledRClickFrame,
                                "gl_o_then_r_frame_153_o_target_vs_frame_155",
                                tests::PixelmatchIdentityParams());
 
-  const std::optional<double> beforeCentroidY =
-      YellowCentroidY(CropBitmap(*beforeRClick, broadCrop));
-  const std::optional<double> firstCentroidY =
-      YellowCentroidY(CropBitmap(*firstRClickFrame, broadCrop));
-  const std::optional<double> settledCentroidY =
-      YellowCentroidY(CropBitmap(*settledRClickFrame, broadCrop));
+  svg::RendererBitmap beforeCentroidTarget = CropBitmap(*beforeRClick, broadCrop);
+  svg::RendererBitmap firstCentroidTarget = CropBitmap(*firstRClickFrame, broadCrop);
+  svg::RendererBitmap settledCentroidTarget = CropBitmap(*settledRClickFrame, broadCrop);
+  if (beforeCentroidTarget.empty() || firstCentroidTarget.empty() ||
+      settledCentroidTarget.empty()) {
+    beforeCentroidTarget = *beforeRClick;
+    firstCentroidTarget = *firstRClickFrame;
+    settledCentroidTarget = *settledRClickFrame;
+  }
+
+  const std::optional<double> beforeCentroidY = YellowCentroidY(beforeCentroidTarget);
+  const std::optional<double> firstCentroidY = YellowCentroidY(firstCentroidTarget);
+  const std::optional<double> settledCentroidY = YellowCentroidY(settledCentroidTarget);
   ASSERT_TRUE(beforeCentroidY.has_value());
   ASSERT_TRUE(firstCentroidY.has_value());
   ASSERT_TRUE(settledCentroidY.has_value());

--- a/donner/svg/components/resources/ResourceManagerContext.cc
+++ b/donner/svg/components/resources/ResourceManagerContext.cc
@@ -1,5 +1,8 @@
 #include "donner/svg/components/resources/ResourceManagerContext.h"
 
+#include <cstdint>
+#include <span>
+
 #include "donner/base/EcsRegistry.h"
 #include "donner/base/ParseDiagnostic.h"
 #include "donner/base/ParseWarningSink.h"
@@ -14,6 +17,31 @@
 
 namespace donner::svg::components {
 namespace {
+
+constexpr uint32_t kWoffMagic = 0x774F4646;          // "wOFF"
+constexpr uint32_t kSfntTrueTypeMagic = 0x00010000;  // TrueType sfnt
+constexpr uint32_t kSfntCffMagic = 0x4F54544F;       // "OTTO"
+constexpr uint32_t kSfntAppleMagic = 0x74727565;     // "true"
+constexpr uint32_t kSfntType1Magic = 0x74797031;     // "typ1"
+
+uint32_t ReadBigEndianU32(std::span<const uint8_t> data) {
+  return (static_cast<uint32_t>(data[0]) << 24u) | (static_cast<uint32_t>(data[1]) << 16u) |
+         (static_cast<uint32_t>(data[2]) << 8u) | static_cast<uint32_t>(data[3]);
+}
+
+bool IsRawSfntFont(std::span<const uint8_t> data) {
+  if (data.size() < 4u) {
+    return false;
+  }
+
+  const uint32_t magic = ReadBigEndianU32(data);
+  return magic == kSfntTrueTypeMagic || magic == kSfntCffMagic || magic == kSfntAppleMagic ||
+         magic == kSfntType1Magic;
+}
+
+bool IsWoffFont(std::span<const uint8_t> data) {
+  return data.size() >= 4u && ReadBigEndianU32(data) == kWoffMagic;
+}
 
 void AssertNoDocumentWriteAccessForUserCallback(Registry& registry, const char* callbackName) {
   const auto* context = registry.ctx().find<SVGDocumentContext>();
@@ -74,7 +102,9 @@ void ResourceManagerContext::loadResources(ParseWarningSink& warningSink) {
   // would need one. `data:` URLs are decoded inline in `UrlLoader::fromUri`
   // without touching the resource loader, so their presence alone doesn't
   // justify the warning.
-  const auto needsExternalLoader = [](std::string_view uri) { return !uri.starts_with("data:"); };
+  const auto needsExternalLoader = [](std::string_view uri) {
+    return !uri.empty() && !uri.starts_with("data:");
+  };
 
   const bool hasExternalImage = [&] {
     for (auto entity : imageView) {
@@ -115,6 +145,9 @@ void ResourceManagerContext::loadResources(ParseWarningSink& warningSink) {
     }
 
     auto [image] = view.get(entity);
+    if (image.href.empty()) {
+      continue;
+    }
 
     ImageLoader imageLoader(loader);
 
@@ -175,6 +208,16 @@ void ResourceManagerContext::loadResources(ParseWarningSink& warningSink) {
         }
       } else if (source.kind == css::FontFaceSource::Kind::Data) {
         const auto& dataPtr = std::get<std::shared_ptr<const std::vector<uint8_t>>>(source.payload);
+        if (!dataPtr || IsRawSfntFont(*dataPtr)) {
+          continue;
+        }
+        if (!IsWoffFont(*dataPtr)) {
+          ParseDiagnostic err;
+          err.reason = std::string(ToString(UrlLoaderError::DataCorrupt));
+          warningSink.add(std::move(err));
+          continue;
+        }
+
         auto maybeFontData = fontLoader.fromData(*dataPtr);
 
         if (std::holds_alternative<UrlLoaderError>(maybeFontData)) {

--- a/donner/svg/components/resources/tests/SubDocumentCache_tests.cc
+++ b/donner/svg/components/resources/tests/SubDocumentCache_tests.cc
@@ -446,6 +446,16 @@ TEST_F(ResourceManagerContextTest, LoadResourcesWithoutLoaderWarnsForExternalIma
   EXPECT_TRUE(warnings.hasWarnings());
 }
 
+TEST_F(ResourceManagerContextTest, LoadResourcesSkipsEmptyImageHref) {
+  const Entity imageEntity = addImage("");
+
+  ParseWarningSink warnings;
+  resourceManager_->loadResources(warnings);
+
+  EXPECT_FALSE(registry_.all_of<LoadedImageComponent>(imageEntity));
+  EXPECT_FALSE(warnings.hasWarnings());
+}
+
 TEST_F(ResourceManagerContextTest, LoadResourcesSkipsAlreadyLoadedImages) {
   const Entity imageEntity = addImage("missing.png");
   registry_.emplace<LoadedImageComponent>(imageEntity);
@@ -567,6 +577,24 @@ TEST_F(ResourceManagerContextTest, AddFontFacesLoadsUrlAndDataFonts) {
   EXPECT_EQ(resourceManager_->fontFaces().size(), 2u);
   EXPECT_EQ(resourceManager_->loadedFonts().size(), 2u);
   EXPECT_FALSE(warnings.hasWarnings());
+}
+
+TEST_F(ResourceManagerContextTest, LoadResourcesLeavesRawSfntDataFontsForFontManager) {
+  css::FontFace dataFace;
+  dataFace.familyName = "RawSfnt";
+  css::FontFaceSource dataSource;
+  dataSource.kind = css::FontFaceSource::Kind::Data;
+  dataSource.payload =
+      std::make_shared<const std::vector<uint8_t>>(std::vector<uint8_t>{0x00, 0x01, 0x00, 0x00});
+  dataFace.sources.push_back(dataSource);
+
+  resourceManager_->addFontFaces(std::array<css::FontFace, 1>{dataFace});
+
+  ParseWarningSink warnings;
+  resourceManager_->loadResources(warnings);
+
+  EXPECT_FALSE(warnings.hasWarnings());
+  EXPECT_TRUE(resourceManager_->loadedFonts().empty());
 }
 
 TEST_F(ResourceManagerContextTest, LoadResourcesWarnsForInvalidAndUnsupportedFonts) {

--- a/donner/svg/renderer/tests/RendererImageTestUtils.cc
+++ b/donner/svg/renderer/tests/RendererImageTestUtils.cc
@@ -3,15 +3,58 @@
 #include <gtest/gtest.h>
 #include <stb/stb_image.h>
 
+#include <optional>
+
 namespace donner::svg {
+
+namespace {
+
+constexpr int kMaxImageDimension = 16384;
+constexpr size_t kMaxDecodedImageBytes = 256u * 1024u * 1024u;
+
+std::optional<size_t> RgbaByteSize(int width, int height) {
+  if (width <= 0 || height <= 0 || width > kMaxImageDimension || height > kMaxImageDimension) {
+    return std::nullopt;
+  }
+
+  constexpr size_t kRgbaChannels = 4u;
+  const size_t widthSize = static_cast<size_t>(width);
+  const size_t heightSize = static_cast<size_t>(height);
+  if (widthSize > kMaxDecodedImageBytes / heightSize / kRgbaChannels) {
+    return std::nullopt;
+  }
+
+  return widthSize * heightSize * kRgbaChannels;
+}
+
+}  // namespace
 
 std::optional<Image> RendererImageTestUtils::readRgbaImageFromPngFile(const char* filename) {
   int width = 0;
   int height = 0;
   int channels = 0;
+  if (stbi_info(filename, &width, &height, &channels) == 0) {
+    ADD_FAILURE() << "Failed to read image info: " << filename;
+    return std::nullopt;
+  }
+
+  std::optional<size_t> dataSize = RgbaByteSize(width, height);
+  if (!dataSize.has_value()) {
+    ADD_FAILURE() << "Unsupported image dimensions for " << filename << ": " << width << "x"
+                  << height;
+    return std::nullopt;
+  }
+
   auto* data = stbi_load(filename, &width, &height, &channels, 4);
   if (data == nullptr) {
     ADD_FAILURE() << "Failed to load image: " << filename;
+    return std::nullopt;
+  }
+  dataSize = RgbaByteSize(width, height);
+  if (!dataSize.has_value()) {
+    stbi_image_free(data);
+    ADD_FAILURE() << "Unsupported decoded image dimensions for " << filename << ": " << width << "x"
+                  << height;
     return std::nullopt;
   }
 
@@ -19,7 +62,7 @@ std::optional<Image> RendererImageTestUtils::readRgbaImageFromPngFile(const char
       width,
       height,
       static_cast<size_t>(width),
-      std::vector<uint8_t>(data, data + static_cast<std::ptrdiff_t>(width * height * 4)),
+      std::vector<uint8_t>(data, data + *dataSize),
   };
   stbi_image_free(data);
   return result;

--- a/donner/svg/renderer/tests/resvg_test_suite.cc
+++ b/donner/svg/renderer/tests/resvg_test_suite.cc
@@ -286,9 +286,6 @@ INSTANTIATE_TEST_SUITE_P(
         ValuesIn(getTestsInCategory(
             "filters/feImage",
             {
-                {"empty.svg",
-                 Params::Skip("Bug: std::bad_alloc crash on Linux CI runners (passes on macOS); "
-                              "likely shares the resource-loading root cause of issue #576")},
                 {"svg.svg",
                  Params::WithGoldenOverride("donner/svg/renderer/testdata/golden/resvg-svg.png")
                      .withReason("We render higher quality")
@@ -451,14 +448,15 @@ INSTANTIATE_TEST_SUITE_P(
         ValuesIn(ActiveComparisonModes())),
     TestNameFromFilename);
 
-// TODO: The entire filters/filter-functions category produces "Data corrupted"
-// parse errors on CI x86_64 runners but passes locally on aarch64. The root
-// cause is unknown — possibly a resvg test suite data integrity issue on CI,
-// or an x86_64-specific parser bug. Disabled until investigated.
+// TODO: The filters/filter-functions category has CSS filter-function pixel-parity gaps when
+// enabled wholesale. Keep the category disabled until those rendering mismatches are triaged; the
+// previous resource-loading "Data corrupted" warnings are covered by ResourceManagerContext tests,
+// and filters/feImage/empty.svg now runs in the active FiltersFeImage suite.
 //
 // INSTANTIATE_TEST_SUITE_P(
 //     FiltersFilterFunctions, ImageComparisonTestFixture,
-//     ValuesIn(getTestsInCategory("filters/filter-functions")),
+//     Combine(ValuesIn(getTestsInCategory("filters/filter-functions")),
+//             ValuesIn(ActiveComparisonModes())),
 //     TestNameFromFilename);
 
 INSTANTIATE_TEST_SUITE_P(

--- a/donner/svg/resources/BUILD.bazel
+++ b/donner/svg/resources/BUILD.bazel
@@ -108,13 +108,6 @@ donner_cc_library(
 
 donner_cc_test(
     name = "font_manager_tests",
-    # Variant lanes (doc 0031 M2.3): tiny / text_full / geode
-    # wrappers run automatically under `bazel test //...`.
-    variants = [
-        "tiny",
-        "text_full",
-        "geode",
-    ],
     srcs = ["tests/FontManager_tests.cc"],
     data = [
         "//donner/base/fonts:testdata/valid-001.woff",
@@ -124,6 +117,13 @@ donner_cc_test(
         "//donner/svg/renderer:text_full_enabled": ["DONNER_TEXT_WOFF2_ENABLED"],
         "//conditions:default": [],
     }),
+    # Variant lanes (doc 0031 M2.3): tiny / text_full / geode
+    # wrappers run automatically under `bazel test //...`.
+    variants = [
+        "tiny",
+        "text_full",
+        "geode",
+    ],
     deps = [
         ":font_manager",
         "//third_party/public-sans",
@@ -134,15 +134,15 @@ donner_cc_test(
 
 donner_cc_test(
     name = "url_loader_tests",
+    srcs = [
+        "tests/UrlLoader_tests.cc",
+    ],
     # Variant lanes (doc 0031 M2.3): tiny / text_full / geode
     # wrappers run automatically under `bazel test //...`.
     variants = [
         "tiny",
         "text_full",
         "geode",
-    ],
-    srcs = [
-        "tests/UrlLoader_tests.cc",
     ],
     deps = [
         ":url_loader",
@@ -152,7 +152,10 @@ donner_cc_test(
 )
 
 donner_cc_test(
-    name = "resource_loader_tests",
+    name = "image_loader_tests",
+    srcs = [
+        "tests/ImageLoader_tests.cc",
+    ],
     # Variant lanes (doc 0031 M2.3): tiny / text_full / geode
     # wrappers run automatically under `bazel test //...`.
     variants = [
@@ -160,9 +163,25 @@ donner_cc_test(
         "text_full",
         "geode",
     ],
+    deps = [
+        ":image_loader",
+        ":resource_loader_interface",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
+    name = "resource_loader_tests",
     srcs = [
         "tests/NullResourceLoader_tests.cc",
         "tests/SandboxedFileResourceLoader_tests.cc",
+    ],
+    # Variant lanes (doc 0031 M2.3): tiny / text_full / geode
+    # wrappers run automatically under `bazel test //...`.
+    variants = [
+        "tiny",
+        "text_full",
+        "geode",
     ],
     deps = [
         ":resource_loader_interface",

--- a/donner/svg/resources/ImageLoader.cc
+++ b/donner/svg/resources/ImageLoader.cc
@@ -2,9 +2,15 @@
 
 #include <stb/stb_image.h>
 
+#include <limits>
+#include <optional>
+
 namespace donner::svg {
 
 namespace {
+
+constexpr int kMaxImageDimension = 16384;
+constexpr size_t kMaxDecodedImageBytes = 256u * 1024u * 1024u;
 
 /// Detect if file contents look like SVG (XML starting with '<') or SVGZ (gzip magic bytes).
 bool LooksLikeSvgContent(const std::vector<uint8_t>& data) {
@@ -28,6 +34,30 @@ bool LooksLikeSvgContent(const std::vector<uint8_t>& data) {
   return false;
 }
 
+std::optional<int> StbiInputLength(size_t byteCount) {
+  if (byteCount > static_cast<size_t>(std::numeric_limits<int>::max())) {
+    return std::nullopt;
+  }
+
+  return static_cast<int>(byteCount);
+}
+
+std::optional<size_t> RgbaByteSize(int width, int height) {
+  if (width <= 0 || height <= 0 || width > kMaxImageDimension || height > kMaxImageDimension) {
+    return std::nullopt;
+  }
+
+  constexpr size_t kRgbaChannels = 4u;
+  const size_t widthSize = static_cast<size_t>(width);
+  const size_t heightSize = static_cast<size_t>(height);
+
+  if (widthSize > kMaxDecodedImageBytes / heightSize / kRgbaChannels) {
+    return std::nullopt;
+  }
+
+  return widthSize * heightSize * kRgbaChannels;
+}
+
 std::variant<ImageResource, UrlLoaderError> LoadImage(std::string_view mimeType,
                                                       const std::vector<uint8_t>& fileContents) {
   // Allow known formats and an empty mime type (stb_image will auto-detect)
@@ -36,21 +66,40 @@ std::variant<ImageResource, UrlLoaderError> LoadImage(std::string_view mimeType,
     return UrlLoaderError::UnsupportedFormat;
   }
 
-  int width = 0;
-  int height = 0;
-  int channels = 0;
-  uint8_t* data =
-      stbi_load_from_memory(reinterpret_cast<const unsigned char*>(
-                                fileContents.data()),  // NOLINT, allow reinterpret_cast.
-                            fileContents.size(), &width, &height, &channels, 4);
-  if (!data) {
+  const std::optional<int> inputLength = StbiInputLength(fileContents.size());
+  if (!inputLength.has_value()) {
     return UrlLoaderError::DataCorrupt;
   }
 
-  const size_t dataSize = static_cast<size_t>(width) * height * 4;
+  int width = 0;
+  int height = 0;
+  int channels = 0;
+  if (stbi_info_from_memory(reinterpret_cast<const unsigned char*>(
+                                fileContents.data()),  // NOLINT, allow reinterpret_cast.
+                            *inputLength, &width, &height, &channels) == 0) {
+    return UrlLoaderError::DataCorrupt;
+  }
+
+  const std::optional<size_t> dataSize = RgbaByteSize(width, height);
+  if (!dataSize.has_value()) {
+    return UrlLoaderError::DataCorrupt;
+  }
+
+  uint8_t* data =
+      stbi_load_from_memory(reinterpret_cast<const unsigned char*>(
+                                fileContents.data()),  // NOLINT, allow reinterpret_cast.
+                            *inputLength, &width, &height, &channels, 4);
+  if (!data) {
+    return UrlLoaderError::DataCorrupt;
+  }
+  const std::optional<size_t> loadedDataSize = RgbaByteSize(width, height);
+  if (!loadedDataSize.has_value()) {
+    stbi_image_free(data);
+    return UrlLoaderError::DataCorrupt;
+  }
 
   ImageResource result;
-  result.data = std::vector<uint8_t>(data, data + dataSize);
+  result.data = std::vector<uint8_t>(data, data + *loadedDataSize);
   result.width = width;
   result.height = height;
 

--- a/donner/svg/resources/tests/ImageLoader_tests.cc
+++ b/donner/svg/resources/tests/ImageLoader_tests.cc
@@ -1,0 +1,74 @@
+#include "donner/svg/resources/ImageLoader.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string_view>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "donner/svg/resources/NullResourceLoader.h"
+#include "donner/svg/resources/ResourceLoaderInterface.h"
+
+namespace donner::svg {
+namespace {
+
+class StaticResourceLoader : public ResourceLoaderInterface {
+public:
+  explicit StaticResourceLoader(std::vector<uint8_t> data) : data_(std::move(data)) {}
+
+  std::variant<std::vector<uint8_t>, ResourceLoaderError> fetchExternalResource(
+      std::string_view /*url*/) override {
+    return data_;
+  }
+
+private:
+  std::vector<uint8_t> data_;
+};
+
+std::vector<uint8_t> PngHeaderWithDimensions(int width, int height) {
+  const auto appendUint32 = [](std::vector<uint8_t>& data, uint32_t value) {
+    data.push_back(static_cast<uint8_t>((value >> 24u) & 0xFFu));
+    data.push_back(static_cast<uint8_t>((value >> 16u) & 0xFFu));
+    data.push_back(static_cast<uint8_t>((value >> 8u) & 0xFFu));
+    data.push_back(static_cast<uint8_t>(value & 0xFFu));
+  };
+
+  std::vector<uint8_t> data{
+      0x89u, 0x50u, 0x4Eu, 0x47u, 0x0Du, 0x0Au, 0x1Au, 0x0Au,
+  };
+  appendUint32(data, 13u);
+  data.insert(data.end(), {'I', 'H', 'D', 'R'});
+  appendUint32(data, static_cast<uint32_t>(width));
+  appendUint32(data, static_cast<uint32_t>(height));
+  data.insert(data.end(), {8u, 6u, 0u, 0u, 0u});
+  appendUint32(data, 0u);
+  appendUint32(data, 0u);
+  data.insert(data.end(), {'I', 'E', 'N', 'D'});
+  appendUint32(data, 0u);
+  return data;
+}
+
+TEST(ImageLoader, CorruptRasterDataUrlReturnsDataCorrupt) {
+  NullResourceLoader resourceLoader;
+  ImageLoader imageLoader(resourceLoader);
+
+  ImageLoader::Result result = imageLoader.fromUri("data:image/png;base64,AAAA");
+
+  ASSERT_TRUE(std::holds_alternative<UrlLoaderError>(result));
+  EXPECT_EQ(std::get<UrlLoaderError>(result), UrlLoaderError::DataCorrupt);
+}
+
+TEST(ImageLoader, OversizedPngHeaderReturnsDataCorruptBeforeDecode) {
+  StaticResourceLoader resourceLoader(PngHeaderWithDimensions(20000, 1));
+  ImageLoader imageLoader(resourceLoader);
+
+  ImageLoader::Result result = imageLoader.fromUri("oversized.png");
+
+  ASSERT_TRUE(std::holds_alternative<UrlLoaderError>(result));
+  EXPECT_EQ(std::get<UrlLoaderError>(result), UrlLoaderError::DataCorrupt);
+}
+
+}  // namespace
+}  // namespace donner::svg


### PR DESCRIPTION
## Summary

- Fix deterministic GL replay so document-space input can be reconstructed from recorded viewport snapshots and viewport overrides are applied consistently.
- Keep the Geode replay regression tests deterministic across backend capture sizes while preserving zero-threshold pixel checks for the affected target when available.
- Fix resource loading warnings/crashes by skipping empty image hrefs, leaving raw sfnt font data for `FontManager`, validating WOFF-only font data before `FontLoader`, and hardening raster decode size checks.
- Re-enable `filters/feImage/empty.svg`; leave `filters/filter-functions` disabled for separate pixel-parity gaps rather than the old resource-loading `Data corrupted` issue.

## Root Cause

#654 was caused by the replay harness/tests not actually using deterministic document-space input for the failing generated repros, and by document-space replay ignoring recorded viewport snapshots. Older `.rnr` files also lacked explicit document mouse coordinates, so the harness needed to reconstruct them from the recorded viewport.

#576 was caused by resource loading rather than Geode rendering: raw resvg TTF/OTF font bytes were registered as data font sources and then parsed by the WOFF-only `FontLoader`, producing `Data corrupted`. Empty image hrefs also went through image loading, and raster decode paths trusted stb dimensions without enough preflight validation.

## Validation

- `bazel test //... --test_output=errors`
- `python3 tools/cmake/gen_cmakelists.py --check`
- Focused checks while fixing:
  - `bazel test //donner/editor/tests:gl_rnr_replay_tests --test_output=errors`
  - `bazel test --config=geode //donner/editor/tests:gl_rnr_replay_tests --test_output=errors`
  - `bazel test //donner/svg/resources:image_loader_tests //donner/svg/components/resources/tests:sub_document_cache_tests --test_output=errors`
  - `bazel run --config=geode //donner/svg/renderer/tests:resvg_test_suite_impl -- --gtest_filter='*FiltersFeImage*empty*:*FiltersFilterFunctions*blur_function_no_values*'`