### PR TITLE
Improve object-state test diagnostics

### DIFF
--- a/donner/base/tests/SmallVector_tests.cc
+++ b/donner/base/tests/SmallVector_tests.cc
@@ -579,31 +579,29 @@ TEST(SmallVector, Front) {
   // Test with int
   {
     SmallVector<int, 4> vec = {1, 2, 3, 4};
-    EXPECT_EQ(vec.front(), 1);
+    EXPECT_THAT(vec, ElementsAre(1, 2, 3, 4));
     vec.front() = 10;
-    EXPECT_EQ(vec.front(), 10);
     EXPECT_THAT(vec, ElementsAre(10, 2, 3, 4));
   }
 
   // Test with single element
   {
     SmallVector<int, 4> vec = {42};
-    EXPECT_EQ(vec.front(), 42);
+    EXPECT_THAT(vec, ElementsAre(42));
   }
 
   // Test with string (non-trivial type)
   {
     SmallVector<std::string, 4> vec = {"hello", "world", "test"};
-    EXPECT_EQ(vec.front(), "hello");
+    EXPECT_THAT(vec, ElementsAre("hello", "world", "test"));
     vec.front() = "modified";
-    EXPECT_EQ(vec.front(), "modified");
     EXPECT_THAT(vec, ElementsAre("modified", "world", "test"));
   }
 
   // Test with vector that exceeds small size
   {
     SmallVector<int, 2> vec = {1, 2, 3, 4, 5};
-    EXPECT_EQ(vec.front(), 1);
+    EXPECT_THAT(vec, ElementsAre(1, 2, 3, 4, 5));
   }
 }
 
@@ -612,10 +610,10 @@ TEST(SmallVector, Front) {
  */
 TEST(SmallVector, FrontConst) {
   const SmallVector<int, 4> vec = {1, 2, 3, 4};
-  EXPECT_EQ(vec.front(), 1);
+  EXPECT_THAT(vec, ElementsAre(1, 2, 3, 4));
 
   const SmallVector<std::string, 4> strVec = {"hello", "world"};
-  EXPECT_EQ(strVec.front(), "hello");
+  EXPECT_THAT(strVec, ElementsAre("hello", "world"));
 }
 
 /**
@@ -625,42 +623,39 @@ TEST(SmallVector, Back) {
   // Test with int
   {
     SmallVector<int, 4> vec = {1, 2, 3, 4};
-    EXPECT_EQ(vec.back(), 4);
+    EXPECT_THAT(vec, ElementsAre(1, 2, 3, 4));
     vec.back() = 40;
-    EXPECT_EQ(vec.back(), 40);
     EXPECT_THAT(vec, ElementsAre(1, 2, 3, 40));
   }
 
   // Test with single element
   {
     SmallVector<int, 4> vec = {42};
-    EXPECT_EQ(vec.back(), 42);
-    EXPECT_EQ(vec.front(), vec.back());
+    EXPECT_THAT(vec, ElementsAre(42));
   }
 
   // Test with string (non-trivial type)
   {
     SmallVector<std::string, 4> vec = {"hello", "world", "test"};
-    EXPECT_EQ(vec.back(), "test");
+    EXPECT_THAT(vec, ElementsAre("hello", "world", "test"));
     vec.back() = "modified";
-    EXPECT_EQ(vec.back(), "modified");
     EXPECT_THAT(vec, ElementsAre("hello", "world", "modified"));
   }
 
   // Test with vector that exceeds small size
   {
     SmallVector<int, 2> vec = {1, 2, 3, 4, 5};
-    EXPECT_EQ(vec.back(), 5);
+    EXPECT_THAT(vec, ElementsAre(1, 2, 3, 4, 5));
   }
 
   // Test back() after push_back and pop_back
   {
     SmallVector<int, 4> vec = {1, 2, 3};
-    EXPECT_EQ(vec.back(), 3);
+    EXPECT_THAT(vec, ElementsAre(1, 2, 3));
     vec.push_back(4);
-    EXPECT_EQ(vec.back(), 4);
+    EXPECT_THAT(vec, ElementsAre(1, 2, 3, 4));
     vec.pop_back();
-    EXPECT_EQ(vec.back(), 3);
+    EXPECT_THAT(vec, ElementsAre(1, 2, 3));
   }
 }
 
@@ -669,10 +664,10 @@ TEST(SmallVector, Back) {
  */
 TEST(SmallVector, BackConst) {
   const SmallVector<int, 4> vec = {1, 2, 3, 4};
-  EXPECT_EQ(vec.back(), 4);
+  EXPECT_THAT(vec, ElementsAre(1, 2, 3, 4));
 
   const SmallVector<std::string, 4> strVec = {"hello", "world"};
-  EXPECT_EQ(strVec.back(), "world");
+  EXPECT_THAT(strVec, ElementsAre("hello", "world"));
 }
 
 /**
@@ -680,8 +675,7 @@ TEST(SmallVector, BackConst) {
  */
 TEST(SmallVector, FrontAndBack) {
   SmallVector<int, 4> vec = {1, 2, 3, 4, 5};
-  EXPECT_EQ(vec.front(), 1);
-  EXPECT_EQ(vec.back(), 5);
+  EXPECT_THAT(vec, ElementsAre(1, 2, 3, 4, 5));
 
   vec.front() = 10;
   vec.back() = 50;

--- a/donner/css/tests/Selector_tests.cc
+++ b/donner/css/tests/Selector_tests.cc
@@ -44,6 +44,19 @@ protected:
   }
 };
 
+MATCHER_P(MatchesSelector, selectorText, "") {
+  auto maybeSelector = SelectorParser::Parse(selectorText);
+  if (maybeSelector.hasError()) {
+    *result_listener << "selector parse error: " << maybeSelector.error().reason;
+    return false;
+  }
+
+  const bool matched = maybeSelector.result().matches(arg).matched;
+  *result_listener << "selector " << testing::PrintToString(selectorText) << " matched element "
+                   << testing::PrintToString(arg) << " = " << matched;
+  return matched;
+}
+
 TEST_F(SelectorTests, TypeMatch) {
   FakeElement root("rect");
   FakeElement child1("a");
@@ -448,32 +461,33 @@ TEST_F(SelectorTests, PseudoClassSelectorNthChildForgivingSelectorList) {
   SCOPED_TRACE(testing::Message() << "*** Tree structure:\n" << root.printAsTree() << "\n");
 
   // Test :nth-child with forgiving selector list
-  EXPECT_TRUE(matches(":nth-child(2 of p, div, span)", children[1]))
+  EXPECT_THAT(children[1], MatchesSelector(":nth-child(2 of p, div, span)"))
       << "Should match 2nd child, which is a p element";
-  EXPECT_TRUE(matches(":nth-child(3 of span, :invalid, p)", children[2]))
+  EXPECT_THAT(children[2], MatchesSelector(":nth-child(3 of span, :invalid, p)"))
       << "Should match 3rd child (span) despite invalid selector in list";
-  EXPECT_FALSE(matches(":nth-child(1 of p, :invalid)", children[0]))
+  EXPECT_THAT(children[0], testing::Not(MatchesSelector(":nth-child(1 of p, :invalid)")))
       << "Should not match 1st child (span) as it doesn't match any valid selector in the list";
 
   // Test :nth-last-child with forgiving selector list
-  EXPECT_TRUE(matches(":nth-last-child(2 of p, span, :invalid)", children[3]))
+  EXPECT_THAT(children[3], MatchesSelector(":nth-last-child(2 of p, span, :invalid)"))
       << "Should match 2nd-to-last child, which is a p element";
-  EXPECT_TRUE(matches(":nth-last-child(1 of span, :invalid, div)", children[4]))
+  EXPECT_THAT(children[4], MatchesSelector(":nth-last-child(1 of span, :invalid, div)"))
       << "Should match last child (span) despite invalid selector in list";
-  EXPECT_FALSE(matches(":nth-last-child(3 of p, :invalid)", children[2]))
+  EXPECT_THAT(children[2], testing::Not(MatchesSelector(":nth-last-child(3 of p, :invalid)")))
       << "Should not match 3rd-to-last child (span) as it doesn't match any valid selector in the "
          "list";
 
   // Test complex selectors within the forgiving list
-  EXPECT_TRUE(matches(":nth-child(odd of span, p[class], div > *)", children[2]))
+  EXPECT_THAT(children[2], MatchesSelector(":nth-child(odd of span, p[class], div > *)"))
       << "Should match 3rd child (span) with complex selectors in the list";
-  EXPECT_TRUE(matches(":nth-last-child(even of p, :invalid)", children[1]))
+  EXPECT_THAT(children[1], MatchesSelector(":nth-last-child(even of p, :invalid)"))
       << "Should match 2nd-to-last child (p) with complex selectors and an invalid selector";
 
   // Test with all invalid selectors
-  EXPECT_FALSE(matches(":nth-child(1 of :invalid1, :invalid2)", children[0]))
+  EXPECT_THAT(children[0], testing::Not(MatchesSelector(":nth-child(1 of :invalid1, :invalid2)")))
       << "Should not match when all selectors in the list are invalid";
-  EXPECT_FALSE(matches(":nth-last-child(1 of :invalid1, :invalid2)", children[4]))
+  EXPECT_THAT(children[4],
+              testing::Not(MatchesSelector(":nth-last-child(1 of :invalid1, :invalid2)")))
       << "Should not match when all selectors in the list are invalid";
 }
 

--- a/donner/editor/tests/GlTextureCache_tests.cc
+++ b/donner/editor/tests/GlTextureCache_tests.cc
@@ -1,5 +1,7 @@
 #include "donner/editor/GlTextureCache.h"
 
+#include <gmock/gmock.h>
+
 #include <memory>
 #include <utility>
 
@@ -12,6 +14,10 @@
 
 namespace donner::editor {
 namespace {
+
+using ::testing::ElementsAre;
+using ::testing::Field;
+using ::testing::IsEmpty;
 
 class PayloadTextureSnapshot final : public svg::RendererTextureSnapshot {
 public:
@@ -43,6 +49,14 @@ RenderResult::CompositedTile MetadataTile(RenderResult::CompositedTile::Kind kin
   viewport.outputFromDocument = Transform2d();
   viewport.viewportBounded = viewportBounded;
   return viewport;
+}
+
+auto TileIdIs(auto matcher) {
+  return Field("id", &GlTextureCache::TileView::id, matcher);
+}
+
+auto TileRasterCanvasSizeIs(auto matcher) {
+  return Field("rasterCanvasSize", &GlTextureCache::TileView::rasterCanvasSize, matcher);
 }
 
 TEST(GlTextureCacheTest, MetadataOnlyReuseRequiresFullTextureIdentity) {
@@ -309,9 +323,8 @@ TEST(GlTextureCacheTest, UnboundedUploadRetainsSeparateOverviewAcrossBoundedUplo
   GlTextureCache cache(device);
   cache.uploadComposited(overviewPreview, RasterViewportForTest(/*viewportBounded=*/false));
   ASSERT_EQ(cache.tiles().size(), 1u);
-  ASSERT_EQ(cache.overviewTiles().size(), 1u);
+  ASSERT_THAT(cache.overviewTiles(), ElementsAre(TileRasterCanvasSizeIs(Vector2i(100, 100))));
   EXPECT_FALSE(cache.activeTilesViewportBounded());
-  EXPECT_EQ(cache.overviewTiles().front().rasterCanvasSize, Vector2i(100, 100));
 
   int boundedDestructionCount = 0;
   RenderResult::CompositedPreview boundedPreview;
@@ -328,7 +341,7 @@ TEST(GlTextureCacheTest, UnboundedUploadRetainsSeparateOverviewAcrossBoundedUplo
   cache.uploadComposited(boundedPreview, RasterViewportForTest(/*viewportBounded=*/true));
 
   ASSERT_EQ(cache.tiles().size(), 1u);
-  ASSERT_EQ(cache.overviewTiles().size(), 1u);
+  ASSERT_THAT(cache.overviewTiles(), ElementsAre(TileRasterCanvasSizeIs(Vector2i(100, 100))));
   EXPECT_TRUE(cache.activeTilesViewportBounded());
   const PresentationCoverageDiagnostics coverage = cache.coverageDiagnostics();
   EXPECT_TRUE(coverage.activeTilesViewportBounded);
@@ -337,8 +350,8 @@ TEST(GlTextureCacheTest, UnboundedUploadRetainsSeparateOverviewAcrossBoundedUplo
   EXPECT_EQ(coverage.overviewRasterDocumentRect, Box2d::FromXYWH(0.0, 0.0, 100.0, 100.0));
   EXPECT_EQ(coverage.activeOutputSizePx, Vector2i(20, 20));
   EXPECT_EQ(coverage.overviewOutputSizePx, Vector2i(100, 100));
-  EXPECT_EQ(cache.tiles().front().rasterCanvasSize, Vector2i(20, 20));
-  EXPECT_EQ(cache.overviewTiles().front().rasterCanvasSize, Vector2i(100, 100))
+  EXPECT_THAT(cache.tiles(), ElementsAre(TileRasterCanvasSizeIs(Vector2i(20, 20))));
+  EXPECT_THAT(cache.overviewTiles(), ElementsAre(TileRasterCanvasSizeIs(Vector2i(100, 100))))
       << "Bounded uploads may reuse tile ids and must not overwrite the retained overview.";
   EXPECT_EQ(overviewDestructionCount, 0);
   EXPECT_EQ(boundedDestructionCount, 0);
@@ -363,7 +376,7 @@ TEST(GlTextureCacheTest, OverviewUploadDoesNotReplaceActiveBoundedTiles) {
   GlTextureCache cache(device);
   cache.uploadComposited(boundedPreview, RasterViewportForTest(/*viewportBounded=*/true));
   ASSERT_EQ(cache.tiles().size(), 1u);
-  EXPECT_TRUE(cache.overviewTiles().empty());
+  EXPECT_THAT(cache.overviewTiles(), IsEmpty());
 
   int overviewDestructionCount = 0;
   RenderResult::CompositedPreview overviewPreview;
@@ -378,11 +391,9 @@ TEST(GlTextureCacheTest, OverviewUploadDoesNotReplaceActiveBoundedTiles) {
 
   cache.uploadCompositedOverview(overviewPreview, RasterViewportForTest(/*viewportBounded=*/false));
 
-  ASSERT_EQ(cache.tiles().size(), 1u);
-  ASSERT_EQ(cache.overviewTiles().size(), 1u);
+  ASSERT_THAT(cache.tiles(), ElementsAre(TileIdIs("seg:0")));
+  ASSERT_THAT(cache.overviewTiles(), ElementsAre(TileIdIs("full-canvas")));
   EXPECT_TRUE(cache.activeTilesViewportBounded());
-  EXPECT_EQ(cache.tiles().front().id, "seg:0");
-  EXPECT_EQ(cache.overviewTiles().front().id, "full-canvas");
   EXPECT_TRUE(cache.coverageDiagnostics().overviewInfillAvailable);
   EXPECT_EQ(boundedDestructionCount, 0);
   EXPECT_EQ(overviewDestructionCount, 0);

--- a/donner/editor/tests/OverlayRenderer_tests.cc
+++ b/donner/editor/tests/OverlayRenderer_tests.cc
@@ -33,6 +33,9 @@ using ::testing::AllOf;
 using ::testing::DoubleNear;
 using ::testing::ElementsAre;
 using ::testing::Field;
+using ::testing::IsEmpty;
+using ::testing::ResultOf;
+using ::testing::SizeIs;
 
 constexpr double kPi = 3.14159265358979323846;
 
@@ -50,11 +53,24 @@ auto Vector2dNear(Vector2d expected, double tolerance) {
                Field("y", &Vector2d::y, DoubleNear(expected.y, tolerance)));
 }
 
+auto Box2dNear(Box2d expected, double tolerance) {
+  return AllOf(
+      Field("topLeft", &Box2d::topLeft, Vector2dNear(expected.topLeft, tolerance)),
+      Field("bottomRight", &Box2d::bottomRight, Vector2dNear(expected.bottomRight, tolerance)));
+}
+
 auto PathControlLineIs(Vector2d anchorDoc, Vector2d controlDoc) {
   return AllOf(Field("anchorDoc", &SelectionChromeSnapshot::PathControlLine::anchorDoc,
                      Vector2dNear(anchorDoc, 1e-9)),
                Field("controlDoc", &SelectionChromeSnapshot::PathControlLine::controlDoc,
                      Vector2dNear(controlDoc, 1e-9)));
+}
+
+auto PathBoundsAre(Box2d expected) {
+  return ResultOf(
+      "pathDoc.bounds()",
+      [](const SelectionChromeSnapshot::PathItem& item) { return item.pathDoc.bounds(); },
+      Box2dNear(expected, 1e-9));
 }
 
 MATCHER(DimmedGrayBlueStrokePixel,
@@ -293,12 +309,12 @@ TEST(OverlayRendererTest, CaptureSnapshotCullsOffscreenSelectionAndHoverChrome) 
       std::nullopt, std::span<const svg::SVGElement>(hoverElements),
       Box2d::FromXYWH(0.0, 0.0, 100.0, 100.0));
 
-  ASSERT_EQ(snapshot.paths.size(), 1u);
-  ASSERT_EQ(snapshot.aabbsDoc.size(), 1u);
-  EXPECT_EQ(snapshot.aabbsDoc.front(), Box2d::FromXYWH(10.0, 10.0, 20.0, 20.0));
-  EXPECT_TRUE(snapshot.hoverPaths.empty());
-  EXPECT_TRUE(snapshot.hoverAabbsDoc.empty());
-  EXPECT_EQ(snapshot.handleBoxesDoc.size(), 4u);
+  EXPECT_THAT(snapshot.paths, SizeIs(1));
+  EXPECT_THAT(snapshot.aabbsDoc,
+              ElementsAre(Box2dNear(Box2d::FromXYWH(10.0, 10.0, 20.0, 20.0), 1e-9)));
+  EXPECT_THAT(snapshot.hoverPaths, IsEmpty());
+  EXPECT_THAT(snapshot.hoverAabbsDoc, IsEmpty());
+  EXPECT_THAT(snapshot.handleBoxesDoc, SizeIs(4));
 }
 
 TEST(OverlayRendererTest, CaptureSnapshotCullsOffscreenHandles) {
@@ -346,10 +362,10 @@ TEST(OverlayRendererTest, CaptureSnapshotCombinedBoundsOnlySkipsSelectionPaths) 
       std::nullopt, std::span<const svg::SVGElement>(), std::nullopt,
       SelectionChromeDetail::CombinedBoundsOnly);
 
-  EXPECT_TRUE(snapshot.paths.empty());
-  ASSERT_EQ(snapshot.aabbsDoc.size(), 1u);
-  EXPECT_EQ(snapshot.aabbsDoc.front(), Box2d::FromXYWH(10.0, 10.0, 50.0, 60.0));
-  EXPECT_EQ(snapshot.handleBoxesDoc.size(), 4u);
+  EXPECT_THAT(snapshot.paths, IsEmpty());
+  EXPECT_THAT(snapshot.aabbsDoc,
+              ElementsAre(Box2dNear(Box2d::FromXYWH(10.0, 10.0, 50.0, 60.0), 1e-9)));
+  EXPECT_THAT(snapshot.handleBoxesDoc, SizeIs(4));
 }
 
 // The editor draws selection chrome into a *second* renderer's frame
@@ -494,8 +510,7 @@ TEST(OverlayRendererTest, ActiveRotationUsesOrientedBoundsUntilGestureEnds) {
   const SelectionChromeSnapshot settledSnapshot = OverlayRenderer::captureChromeSnapshot(
       std::span<const svg::SVGElement>(app.selectedElements()), std::nullopt, canvasFromDoc);
   EXPECT_FALSE(settledSnapshot.orientedBoundsDoc.has_value());
-  ASSERT_EQ(settledSnapshot.aabbsDoc.size(), 1u);
-  EXPECT_EQ(settledSnapshot.aabbsDoc.front(), startBounds);
+  EXPECT_THAT(settledSnapshot.aabbsDoc, ElementsAre(Box2dNear(startBounds, 1e-9)));
 }
 
 TEST(OverlayRendererTest, CaptureSnapshotCanProjectLiveDragBackToRepresentedDocument) {
@@ -516,10 +531,9 @@ TEST(OverlayRendererTest, CaptureSnapshotCanProjectLiveDragBackToRepresentedDocu
       /*cullRectDoc=*/std::nullopt, SelectionChromeDetail::Full,
       Transform2d::Translate(-50.0, 0.0));
 
-  ASSERT_EQ(snapshot.aabbsDoc.size(), 1u);
-  EXPECT_EQ(snapshot.aabbsDoc.front(), Box2d::FromXYWH(20.0, 30.0, 40.0, 50.0));
-  ASSERT_EQ(snapshot.paths.size(), 1u);
-  EXPECT_EQ(snapshot.paths.front().pathDoc.bounds(), Box2d::FromXYWH(20.0, 30.0, 40.0, 50.0));
+  EXPECT_THAT(snapshot.aabbsDoc,
+              ElementsAre(Box2dNear(Box2d::FromXYWH(20.0, 30.0, 40.0, 50.0), 1e-9)));
+  EXPECT_THAT(snapshot.paths, ElementsAre(PathBoundsAre(Box2d::FromXYWH(20.0, 30.0, 40.0, 50.0))));
 }
 
 // Calling the overlay-only render path repeatedly (the click→reselect

--- a/donner/editor/tests/PenTool_tests.cc
+++ b/donner/editor/tests/PenTool_tests.cc
@@ -95,8 +95,7 @@ TEST_F(PenToolTest, FirstClickInsertsSelectedPath) {
 
   svg::SVGPathElement inserted = path();
   EXPECT_EQ(inserted.d(), "M 10 20");
-  ASSERT_EQ(app.selectedElements().size(), 1u);
-  EXPECT_EQ(app.selectedElements().front(), inserted);
+  EXPECT_THAT(app.selectedElements(), testing::ElementsAre(inserted));
   const std::string source(app.document().document().source());
   const std::size_t pathOffset = source.find(R"(<path d="M 10 20")");
   const std::size_t svgCloseOffset = source.find("</svg>");
@@ -252,11 +251,9 @@ TEST_F(PenToolTest, BoundsIncludeNewestPointAfterImmediateIdleFlush) {
 
   const std::vector<Box2d> bounds =
       SnapshotSelectionWorldBounds(std::span<const svg::SVGElement>(app.selectedElements()));
-  ASSERT_EQ(bounds.size(), 1u);
-  EXPECT_LE(bounds.front().topLeft.x, 10.0);
-  EXPECT_LE(bounds.front().topLeft.y, 20.0);
-  EXPECT_GE(bounds.front().bottomRight.x, 80.0);
-  EXPECT_GE(bounds.front().bottomRight.y, 90.0);
+  EXPECT_THAT(bounds,
+              testing::ElementsAre(testing::AllOf(BoxContainingPoint(Vector2d(10.0, 20.0)),
+                                                  BoxContainingPoint(Vector2d(80.0, 90.0)))));
 }
 
 TEST_F(PenToolTest, ConsecutiveClicksBeforeFlushStayInsideSvgRoot) {

--- a/donner/editor/tests/TextEditorCore_tests.cc
+++ b/donner/editor/tests/TextEditorCore_tests.cc
@@ -105,6 +105,36 @@ std::vector<std::optional<ColorIndex>> ColorIndexesAt(const Line& line,
   return colors;
 }
 
+std::vector<std::optional<bool>> SingleLineCommentStatesAt(
+    const Line& line, std::initializer_list<std::size_t> indexes) {
+  std::vector<std::optional<bool>> states;
+  states.reserve(indexes.size());
+  for (std::size_t index : indexes) {
+    if (index < line.size()) {
+      states.emplace_back(line[index].isComment);
+    } else {
+      states.emplace_back(std::nullopt);
+    }
+  }
+
+  return states;
+}
+
+std::vector<std::optional<bool>> MultiLineCommentStatesAt(
+    const Line& line, std::initializer_list<std::size_t> indexes) {
+  std::vector<std::optional<bool>> states;
+  states.reserve(indexes.size());
+  for (std::size_t index : indexes) {
+    if (index < line.size()) {
+      states.emplace_back(line[index].isMultiLineComment);
+    } else {
+      states.emplace_back(std::nullopt);
+    }
+  }
+
+  return states;
+}
+
 class TextEditorCoreTests : public ::testing::Test {
 protected:
   void SetUp() override {
@@ -1482,16 +1512,16 @@ TEST_F(TextEditorCoreTests, ColorizeInternalMarksSingleAndMultilineComments) {
   editor_.colorizeInternal();
 
   const Line& line0 = editor_.buffer().getLineGlyphs(0);
-  EXPECT_FALSE(line0[0].isComment);
-  EXPECT_TRUE(line0[2].isComment);
+  EXPECT_THAT(SingleLineCommentStatesAt(line0, {0u, 2u}),
+              ElementsAre(Optional(false), Optional(true)));
 
   const Line& line1 = editor_.buffer().getLineGlyphs(1);
-  EXPECT_TRUE(line1[0].isMultiLineComment);
-  EXPECT_TRUE(line1[3].isMultiLineComment);
+  EXPECT_THAT(MultiLineCommentStatesAt(line1, {0u, 3u}),
+              ElementsAre(Optional(true), Optional(true)));
 
   const Line& line2 = editor_.buffer().getLineGlyphs(2);
-  EXPECT_TRUE(line2[0].isMultiLineComment);
-  EXPECT_FALSE(line2[9].isMultiLineComment);
+  EXPECT_THAT(MultiLineCommentStatesAt(line2, {0u, 9u}),
+              ElementsAre(Optional(true), Optional(false)));
 }
 
 }  // namespace donner::editor

--- a/donner/svg/components/text/tests/TextSystem_tests.cc
+++ b/donner/svg/components/text/tests/TextSystem_tests.cc
@@ -21,7 +21,11 @@
 #include "donner/svg/components/text/TextRootComponent.h"
 #include "donner/svg/parser/SVGParser.h"
 
+using testing::_;
+using testing::AllOf;
+using testing::DoubleNear;
 using testing::Eq;
+using testing::Field;
 using testing::IsEmpty;
 using testing::SizeIs;
 
@@ -50,6 +54,29 @@ MATCHER(NoLengthValue, "") {
 
 MATCHER_P(PathCommandVerbIs, expectedVerb, "") {
   return testing::ExplainMatchResult(Eq(expectedVerb), arg.verb, result_listener);
+}
+
+MATCHER(HasTextPathSpline, "") {
+  *result_listener << "pathSpline.has_value()=" << arg.pathSpline.has_value();
+  return arg.pathSpline.has_value();
+}
+
+MATCHER(HasNoTextPathSpline, "") {
+  *result_listener << "pathSpline.has_value()=" << arg.pathSpline.has_value();
+  return !arg.pathSpline.has_value();
+}
+
+MATCHER_P(TextPathFailedIs, expected, "") {
+  return testing::ExplainMatchResult(Eq(expected), arg.textPathFailed, result_listener);
+}
+
+MATCHER_P(TextSpanHiddenIs, expected, "") {
+  return testing::ExplainMatchResult(Eq(expected), arg.hidden, result_listener);
+}
+
+auto PathStartOffsetNear(double expected, double tolerance) {
+  return Field("pathStartOffset", &ComputedTextComponent::TextSpan::pathStartOffset,
+               DoubleNear(expected, tolerance));
 }
 
 }  // namespace
@@ -286,11 +313,8 @@ TEST_F(TextSystemTest, TextPathReference) {
 
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
-  // Root span + textPath child span.
-  ASSERT_THAT(computed->spans, SizeIs(2));
-
   // The textPath span should have a path spline attached.
-  EXPECT_TRUE(computed->spans[1].pathSpline.has_value());
+  EXPECT_THAT(computed->spans, testing::ElementsAre(_, HasTextPathSpline()));
 }
 
 // --- textPath with startOffset ---
@@ -310,12 +334,9 @@ TEST_F(TextSystemTest, TextPathWithStartOffset) {
 
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
-  // Root span + textPath child span.
-  ASSERT_THAT(computed->spans, SizeIs(2));
-
   // 50% of a 100-unit path should be ~50.
-  EXPECT_TRUE(computed->spans[1].pathSpline.has_value());
-  EXPECT_NEAR(computed->spans[1].pathStartOffset, 50.0, 1.0);
+  EXPECT_THAT(computed->spans,
+              testing::ElementsAre(_, AllOf(HasTextPathSpline(), PathStartOffsetNear(50.0, 1.0))));
 }
 
 TEST_F(TextSystemTest, TextPathWithAbsoluteStartOffsetAndTransform) {
@@ -346,11 +367,11 @@ TEST_F(TextSystemTest, TextPathWithAbsoluteStartOffsetAndTransform) {
   auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
-  ASSERT_THAT(computed->spans, SizeIs(2));
-  ASSERT_TRUE(computed->spans[1].pathSpline.has_value());
-  EXPECT_THAT(computed->spans[1].pathSpline->points(),
+  ASSERT_THAT(computed->spans, testing::ElementsAre(_, HasTextPathSpline()));
+  const auto& textPathSpan = computed->spans[1];
+  EXPECT_THAT(textPathSpan.pathSpline->points(),
               testing::ElementsAre(Vector2d(5, 7), Vector2d(105, 7)));
-  EXPECT_DOUBLE_EQ(computed->spans[1].pathStartOffset, 10.0);
+  EXPECT_THAT(textPathSpan, PathStartOffsetNear(10.0, 0.0));
 }
 
 // Issue #624: the textPath baseline geometry must include the referenced path's
@@ -387,11 +408,11 @@ TEST_F(TextSystemTest, TextPathTransformIncludesTransformOriginPivot) {
   auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
-  ASSERT_THAT(computed->spans, SizeIs(2));
-  ASSERT_TRUE(computed->spans[1].pathSpline.has_value());
+  ASSERT_THAT(computed->spans, testing::ElementsAre(_, HasTextPathSpline()));
+  const auto& textPathSpan = computed->spans[1];
 
   // Pivoted result: T(-origin) * rotate90 * T(origin).
-  EXPECT_THAT(computed->spans[1].pathSpline->points(),
+  EXPECT_THAT(textPathSpan.pathSpline->points(),
               testing::ElementsAre(Vector2Near(50.0, -50.0), Vector2Near(50.0, 50.0)));
 }
 
@@ -423,9 +444,9 @@ TEST_F(TextSystemTest, TextPathUsesSplineOverrideWhenComputedPathMissing) {
   auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
-  ASSERT_THAT(computed->spans, SizeIs(2));
-  ASSERT_TRUE(computed->spans[1].pathSpline.has_value());
-  EXPECT_THAT(computed->spans[1].pathSpline->points(),
+  ASSERT_THAT(computed->spans, testing::ElementsAre(_, HasTextPathSpline()));
+  const auto& textPathSpan = computed->spans[1];
+  EXPECT_THAT(textPathSpan.pathSpline->points(),
               testing::ElementsAre(Vector2d(1, 2), Vector2d(3, 4)));
 }
 
@@ -440,9 +461,8 @@ TEST_F(TextSystemTest, TextPathWithInvalidReferenceMarksFailure) {
   auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
-  ASSERT_THAT(computed->spans, SizeIs(2));
-  EXPECT_FALSE(computed->spans[1].pathSpline.has_value());
-  EXPECT_TRUE(computed->spans[1].textPathFailed);
+  EXPECT_THAT(computed->spans,
+              testing::ElementsAre(_, AllOf(HasNoTextPathSpline(), TextPathFailedIs(true))));
 }
 
 TEST_F(TextSystemTest, TextPathWithEmptyReferencedPathMarksFailure) {
@@ -457,9 +477,8 @@ TEST_F(TextSystemTest, TextPathWithEmptyReferencedPathMarksFailure) {
   auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
-  ASSERT_THAT(computed->spans, SizeIs(2));
-  EXPECT_FALSE(computed->spans[1].pathSpline.has_value());
-  EXPECT_TRUE(computed->spans[1].textPathFailed);
+  EXPECT_THAT(computed->spans,
+              testing::ElementsAre(_, AllOf(HasNoTextPathSpline(), TextPathFailedIs(true))));
 }
 
 TEST_F(TextSystemTest, MixedTextPathChildrenProduceSeparateSpans) {
@@ -769,9 +788,8 @@ TEST_F(TextSystemTest, TextPathWithoutHrefIsHidden) {
   auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
   auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
-  ASSERT_THAT(computed->spans, SizeIs(2));
-  EXPECT_TRUE(computed->spans[1].hidden);
-  EXPECT_FALSE(computed->spans[1].textPathFailed);
+  EXPECT_THAT(computed->spans,
+              testing::ElementsAre(_, AllOf(TextSpanHiddenIs(true), TextPathFailedIs(false))));
 }
 
 TEST_F(TextSystemTest, TextPathNestedUnderTspanMarksFailure) {

--- a/donner/svg/compositor/CompositorController_tests.cc
+++ b/donner/svg/compositor/CompositorController_tests.cc
@@ -50,6 +50,7 @@ void PrintTo(const CompositorController::StaticSpanPlan& plan, std::ostream* os)
 namespace {
 
 using MockRendererInterface = tests::MockRendererInterface;
+using LayerInspectorRow = CompositorController::LayerInspectorRow;
 using StaticSpanPlan = CompositorController::StaticSpanPlan;
 
 MATCHER(EstimatedRedrawCostNoMoreThanCacheOverhead, "") {
@@ -74,6 +75,34 @@ template <typename... Matchers>
 auto StaticSpanPlanAtSlot(size_t slotIndex, Matchers... matchers) {
   return ::testing::AllOf(::testing::Field("slotIndex", &StaticSpanPlan::slotIndex, slotIndex),
                           matchers...);
+}
+
+auto LayerRasterizeCountIs(auto matcher) {
+  return ::testing::Field("rasterizeCount", &LayerInspectorRow::rasterizeCount, matcher);
+}
+
+auto LayerGenerationIs(auto matcher) {
+  return ::testing::Field("generation", &LayerInspectorRow::generation, matcher);
+}
+
+auto LayerHasValidBitmapIs(auto matcher) {
+  return ::testing::Field("hasValidBitmap", &LayerInspectorRow::hasValidBitmap, matcher);
+}
+
+auto LayerDirtyIs(auto matcher) {
+  return ::testing::Field("dirty", &LayerInspectorRow::dirty, matcher);
+}
+
+auto LayerBitmapSizeIs(auto matcher) {
+  return ::testing::Field("bitmapSize", &LayerInspectorRow::bitmapSize, matcher);
+}
+
+auto LayerThumbnailDimsIs(auto matcher) {
+  return ::testing::Field("thumbnailDims", &LayerInspectorRow::thumbnailDims, matcher);
+}
+
+auto LayerThumbnailPixelsAre(auto matcher) {
+  return ::testing::Field("thumbnailPixels", &LayerInspectorRow::thumbnailPixels, matcher);
 }
 
 class FakeTextureSnapshot : public RendererTextureSnapshot {
@@ -1004,16 +1033,14 @@ TEST_F(CompositorControllerTest, SnapshotLayerInspectorRowsTracksRasterizeCountA
   // First frame: layer must rasterize exactly once.
   compositor.renderFrame(RenderViewport{kTestSvgDefaultSize});
   const auto rowsAfterFirst = compositor.snapshotLayerInspectorRows();
-  ASSERT_EQ(rowsAfterFirst.size(), 1u);
-  EXPECT_EQ(rowsAfterFirst.front().rasterizeCount, 1u);
+  EXPECT_THAT(rowsAfterFirst, ::testing::ElementsAre(LayerRasterizeCountIs(1u)));
 
   // A pure-translation drag goes through the fast path — bitmap is reused,
   // rasterize count does NOT advance.
   target->cast<SVGGraphicsElement>().setTransform(Transform2d::Translate(5.0, 0.0));
   compositor.renderFrame(RenderViewport{kTestSvgDefaultSize});
   const auto rowsAfterTranslate = compositor.snapshotLayerInspectorRows();
-  ASSERT_EQ(rowsAfterTranslate.size(), 1u);
-  EXPECT_EQ(rowsAfterTranslate.front().rasterizeCount, 1u)
+  EXPECT_THAT(rowsAfterTranslate, ::testing::ElementsAre(LayerRasterizeCountIs(1u)))
       << "Pure-translation drag must reuse the cached bitmap rather than re-rasterize.";
 }
 
@@ -1034,8 +1061,7 @@ TEST_F(CompositorControllerTest, TextureOnlyDragReusesPayloadWithoutRasterize) {
   ASSERT_TRUE(compositor.hasSplitStaticLayers())
       << "Texture-backed drag layers must count as cached split layers.";
   const auto rowsAfterFirst = compositor.snapshotLayerInspectorRows();
-  ASSERT_EQ(rowsAfterFirst.size(), 1u);
-  ASSERT_TRUE(rowsAfterFirst.front().hasValidBitmap);
+  ASSERT_THAT(rowsAfterFirst, ::testing::ElementsAre(LayerHasValidBitmapIs(true)));
   const uint64_t generationAfterFirst = rowsAfterFirst.front().generation;
   const uint32_t rasterizeCountAfterFirst = rowsAfterFirst.front().rasterizeCount;
 
@@ -1057,11 +1083,10 @@ TEST_F(CompositorControllerTest, TextureOnlyDragReusesPayloadWithoutRasterize) {
   compositor.renderFrame(RenderViewport{kTestSvgDefaultSize});
 
   const auto rowsAfterDrag = compositor.snapshotLayerInspectorRows();
-  ASSERT_EQ(rowsAfterDrag.size(), 1u);
-  EXPECT_EQ(rowsAfterDrag.front().generation, generationAfterFirst)
+  EXPECT_THAT(rowsAfterDrag, ::testing::ElementsAre(
+                                 ::testing::AllOf(LayerGenerationIs(generationAfterFirst),
+                                                  LayerRasterizeCountIs(rasterizeCountAfterFirst))))
       << "Pure-translation drag must not mint a new texture generation.";
-  EXPECT_EQ(rowsAfterDrag.front().rasterizeCount, rasterizeCountAfterFirst)
-      << "Pure-translation drag must reuse the cached texture rather than re-rasterize.";
 
   const auto countersAfterDrag = compositor.fastPathCountersForTesting();
   EXPECT_EQ(countersAfterDrag.fastPathFrames, countersBeforeDrag.fastPathFrames + 1u);
@@ -1656,11 +1681,11 @@ TEST_F(CompositorControllerTest, SnapshotLayerInspectorRowsCanOmitThumbnails) {
 
   const auto rows =
       compositor.snapshotLayerInspectorRows(CompositorController::SnapshotThumbnails::Omit);
-  ASSERT_EQ(rows.size(), 1u);
-  EXPECT_TRUE(rows.front().hasValidBitmap);
-  EXPECT_NE(rows.front().bitmapSize, Vector2i::Zero());
-  EXPECT_EQ(rows.front().thumbnailDims, Vector2i::Zero());
-  EXPECT_TRUE(rows.front().thumbnailPixels.empty());
+  EXPECT_THAT(
+      rows,
+      ::testing::ElementsAre(::testing::AllOf(
+          LayerHasValidBitmapIs(true), LayerBitmapSizeIs(::testing::Ne(Vector2i::Zero())),
+          LayerThumbnailDimsIs(Vector2i::Zero()), LayerThumbnailPixelsAre(::testing::IsEmpty()))));
 }
 
 TEST_F(CompositorControllerTest, SetTightBoundedSegmentsEnabledMarksExistingSegmentsDirty) {
@@ -1722,18 +1747,16 @@ TEST_F(CompositorControllerTest, CancelledRenderLeavesDirtyLayerForNextFrame) {
 
   {
     const auto rows = compositor.snapshotLayerInspectorRows();
-    ASSERT_EQ(rows.size(), 1u);
-    EXPECT_TRUE(rows.front().dirty);
-    EXPECT_FALSE(rows.front().hasValidBitmap);
+    EXPECT_THAT(rows, ::testing::ElementsAre(
+                          ::testing::AllOf(LayerDirtyIs(true), LayerHasValidBitmapIs(false))));
   }
 
   token.reset();
   EXPECT_TRUE(compositor.renderFrame(RenderViewport{kTestSvgDefaultSize}, token));
 
   const auto rows = compositor.snapshotLayerInspectorRows();
-  ASSERT_EQ(rows.size(), 1u);
-  EXPECT_FALSE(rows.front().dirty);
-  EXPECT_TRUE(rows.front().hasValidBitmap);
+  EXPECT_THAT(rows, ::testing::ElementsAre(
+                        ::testing::AllOf(LayerDirtyIs(false), LayerHasValidBitmapIs(true))));
 }
 
 TEST_F(CompositorControllerTest, IntrinsicSizeMandatoryFilterLayerHasNonZeroCanvasOffset) {


### PR DESCRIPTION
## Summary

- Convert object-state assertions in `SmallVector`, selector, text-system, and compositor-controller tests to `EXPECT_THAT` matchers.
- Add selector and textPath span matchers so failures include selector text, element/span state, and path-start offset context.
- Match compositor inspector rows as whole row snapshots instead of separate `rows.front().field` assertions.

## Stack

This is stacked on #732 (`test-diagnostics-followup`) and should be retargeted after the earlier diagnostics PRs land.

## Validation

- `git fetch origin main` (origin/main unchanged)
- `git diff --check`
- `clang-format -i` on modified C++ sources
- focused tests:
  - `bazel test //donner/base:base_tests`
  - `bazel test //donner/css:css_tests`
  - `bazel test //donner/svg/components/text:text_system_tests`
  - `bazel test //donner/svg/compositor:compositor_tests`
- `bazel test //...`
- `python3 tools/cmake/gen_cmakelists.py --check`

Note: the first CMake generator check hit the known sandbox restriction on Bazel's output base; the escalated rerun passed.