### PR TITLE
Improve editor test diagnostics

### DIFF
--- a/donner/editor/tests/GlTextureCache_tests.cc
+++ b/donner/editor/tests/GlTextureCache_tests.cc
@@ -1,5 +1,7 @@
 #include "donner/editor/GlTextureCache.h"
 
+#include <gmock/gmock.h>
+
 #include <memory>
 #include <utility>
 
@@ -12,6 +14,10 @@
 
 namespace donner::editor {
 namespace {
+
+using ::testing::ElementsAre;
+using ::testing::Field;
+using ::testing::IsEmpty;
 
 class PayloadTextureSnapshot final : public svg::RendererTextureSnapshot {
 public:
@@ -43,6 +49,14 @@ RenderResult::CompositedTile MetadataTile(RenderResult::CompositedTile::Kind kin
   viewport.outputFromDocument = Transform2d();
   viewport.viewportBounded = viewportBounded;
   return viewport;
+}
+
+auto TileIdIs(auto matcher) {
+  return Field("id", &GlTextureCache::TileView::id, matcher);
+}
+
+auto TileRasterCanvasSizeIs(auto matcher) {
+  return Field("rasterCanvasSize", &GlTextureCache::TileView::rasterCanvasSize, matcher);
 }
 
 TEST(GlTextureCacheTest, MetadataOnlyReuseRequiresFullTextureIdentity) {
@@ -309,9 +323,8 @@ TEST(GlTextureCacheTest, UnboundedUploadRetainsSeparateOverviewAcrossBoundedUplo
   GlTextureCache cache(device);
   cache.uploadComposited(overviewPreview, RasterViewportForTest(/*viewportBounded=*/false));
   ASSERT_EQ(cache.tiles().size(), 1u);
-  ASSERT_EQ(cache.overviewTiles().size(), 1u);
+  ASSERT_THAT(cache.overviewTiles(), ElementsAre(TileRasterCanvasSizeIs(Vector2i(100, 100))));
   EXPECT_FALSE(cache.activeTilesViewportBounded());
-  EXPECT_EQ(cache.overviewTiles().front().rasterCanvasSize, Vector2i(100, 100));
 
   int boundedDestructionCount = 0;
   RenderResult::CompositedPreview boundedPreview;
@@ -328,7 +341,7 @@ TEST(GlTextureCacheTest, UnboundedUploadRetainsSeparateOverviewAcrossBoundedUplo
   cache.uploadComposited(boundedPreview, RasterViewportForTest(/*viewportBounded=*/true));
 
   ASSERT_EQ(cache.tiles().size(), 1u);
-  ASSERT_EQ(cache.overviewTiles().size(), 1u);
+  ASSERT_THAT(cache.overviewTiles(), ElementsAre(TileRasterCanvasSizeIs(Vector2i(100, 100))));
   EXPECT_TRUE(cache.activeTilesViewportBounded());
   const PresentationCoverageDiagnostics coverage = cache.coverageDiagnostics();
   EXPECT_TRUE(coverage.activeTilesViewportBounded);
@@ -337,8 +350,8 @@ TEST(GlTextureCacheTest, UnboundedUploadRetainsSeparateOverviewAcrossBoundedUplo
   EXPECT_EQ(coverage.overviewRasterDocumentRect, Box2d::FromXYWH(0.0, 0.0, 100.0, 100.0));
   EXPECT_EQ(coverage.activeOutputSizePx, Vector2i(20, 20));
   EXPECT_EQ(coverage.overviewOutputSizePx, Vector2i(100, 100));
-  EXPECT_EQ(cache.tiles().front().rasterCanvasSize, Vector2i(20, 20));
-  EXPECT_EQ(cache.overviewTiles().front().rasterCanvasSize, Vector2i(100, 100))
+  EXPECT_THAT(cache.tiles(), ElementsAre(TileRasterCanvasSizeIs(Vector2i(20, 20))));
+  EXPECT_THAT(cache.overviewTiles(), ElementsAre(TileRasterCanvasSizeIs(Vector2i(100, 100))))
       << "Bounded uploads may reuse tile ids and must not overwrite the retained overview.";
   EXPECT_EQ(overviewDestructionCount, 0);
   EXPECT_EQ(boundedDestructionCount, 0);
@@ -363,7 +376,7 @@ TEST(GlTextureCacheTest, OverviewUploadDoesNotReplaceActiveBoundedTiles) {
   GlTextureCache cache(device);
   cache.uploadComposited(boundedPreview, RasterViewportForTest(/*viewportBounded=*/true));
   ASSERT_EQ(cache.tiles().size(), 1u);
-  EXPECT_TRUE(cache.overviewTiles().empty());
+  EXPECT_THAT(cache.overviewTiles(), IsEmpty());
 
   int overviewDestructionCount = 0;
   RenderResult::CompositedPreview overviewPreview;
@@ -378,11 +391,9 @@ TEST(GlTextureCacheTest, OverviewUploadDoesNotReplaceActiveBoundedTiles) {
 
   cache.uploadCompositedOverview(overviewPreview, RasterViewportForTest(/*viewportBounded=*/false));
 
-  ASSERT_EQ(cache.tiles().size(), 1u);
-  ASSERT_EQ(cache.overviewTiles().size(), 1u);
+  ASSERT_THAT(cache.tiles(), ElementsAre(TileIdIs("seg:0")));
+  ASSERT_THAT(cache.overviewTiles(), ElementsAre(TileIdIs("full-canvas")));
   EXPECT_TRUE(cache.activeTilesViewportBounded());
-  EXPECT_EQ(cache.tiles().front().id, "seg:0");
-  EXPECT_EQ(cache.overviewTiles().front().id, "full-canvas");
   EXPECT_TRUE(cache.coverageDiagnostics().overviewInfillAvailable);
   EXPECT_EQ(boundedDestructionCount, 0);
   EXPECT_EQ(overviewDestructionCount, 0);

--- a/donner/editor/tests/OverlayRenderer_tests.cc
+++ b/donner/editor/tests/OverlayRenderer_tests.cc
@@ -33,6 +33,9 @@ using ::testing::AllOf;
 using ::testing::DoubleNear;
 using ::testing::ElementsAre;
 using ::testing::Field;
+using ::testing::IsEmpty;
+using ::testing::ResultOf;
+using ::testing::SizeIs;
 
 constexpr double kPi = 3.14159265358979323846;
 
@@ -50,11 +53,24 @@ auto Vector2dNear(Vector2d expected, double tolerance) {
                Field("y", &Vector2d::y, DoubleNear(expected.y, tolerance)));
 }
 
+auto Box2dNear(Box2d expected, double tolerance) {
+  return AllOf(
+      Field("topLeft", &Box2d::topLeft, Vector2dNear(expected.topLeft, tolerance)),
+      Field("bottomRight", &Box2d::bottomRight, Vector2dNear(expected.bottomRight, tolerance)));
+}
+
 auto PathControlLineIs(Vector2d anchorDoc, Vector2d controlDoc) {
   return AllOf(Field("anchorDoc", &SelectionChromeSnapshot::PathControlLine::anchorDoc,
                      Vector2dNear(anchorDoc, 1e-9)),
                Field("controlDoc", &SelectionChromeSnapshot::PathControlLine::controlDoc,
                      Vector2dNear(controlDoc, 1e-9)));
+}
+
+auto PathBoundsAre(Box2d expected) {
+  return ResultOf(
+      "pathDoc.bounds()",
+      [](const SelectionChromeSnapshot::PathItem& item) { return item.pathDoc.bounds(); },
+      Box2dNear(expected, 1e-9));
 }
 
 MATCHER(DimmedGrayBlueStrokePixel,
@@ -293,12 +309,12 @@ TEST(OverlayRendererTest, CaptureSnapshotCullsOffscreenSelectionAndHoverChrome) 
       std::nullopt, std::span<const svg::SVGElement>(hoverElements),
       Box2d::FromXYWH(0.0, 0.0, 100.0, 100.0));
 
-  ASSERT_EQ(snapshot.paths.size(), 1u);
-  ASSERT_EQ(snapshot.aabbsDoc.size(), 1u);
-  EXPECT_EQ(snapshot.aabbsDoc.front(), Box2d::FromXYWH(10.0, 10.0, 20.0, 20.0));
-  EXPECT_TRUE(snapshot.hoverPaths.empty());
-  EXPECT_TRUE(snapshot.hoverAabbsDoc.empty());
-  EXPECT_EQ(snapshot.handleBoxesDoc.size(), 4u);
+  EXPECT_THAT(snapshot.paths, SizeIs(1));
+  EXPECT_THAT(snapshot.aabbsDoc,
+              ElementsAre(Box2dNear(Box2d::FromXYWH(10.0, 10.0, 20.0, 20.0), 1e-9)));
+  EXPECT_THAT(snapshot.hoverPaths, IsEmpty());
+  EXPECT_THAT(snapshot.hoverAabbsDoc, IsEmpty());
+  EXPECT_THAT(snapshot.handleBoxesDoc, SizeIs(4));
 }
 
 TEST(OverlayRendererTest, CaptureSnapshotCullsOffscreenHandles) {
@@ -346,10 +362,10 @@ TEST(OverlayRendererTest, CaptureSnapshotCombinedBoundsOnlySkipsSelectionPaths) 
       std::nullopt, std::span<const svg::SVGElement>(), std::nullopt,
       SelectionChromeDetail::CombinedBoundsOnly);
 
-  EXPECT_TRUE(snapshot.paths.empty());
-  ASSERT_EQ(snapshot.aabbsDoc.size(), 1u);
-  EXPECT_EQ(snapshot.aabbsDoc.front(), Box2d::FromXYWH(10.0, 10.0, 50.0, 60.0));
-  EXPECT_EQ(snapshot.handleBoxesDoc.size(), 4u);
+  EXPECT_THAT(snapshot.paths, IsEmpty());
+  EXPECT_THAT(snapshot.aabbsDoc,
+              ElementsAre(Box2dNear(Box2d::FromXYWH(10.0, 10.0, 50.0, 60.0), 1e-9)));
+  EXPECT_THAT(snapshot.handleBoxesDoc, SizeIs(4));
 }
 
 // The editor draws selection chrome into a *second* renderer's frame
@@ -494,8 +510,7 @@ TEST(OverlayRendererTest, ActiveRotationUsesOrientedBoundsUntilGestureEnds) {
   const SelectionChromeSnapshot settledSnapshot = OverlayRenderer::captureChromeSnapshot(
       std::span<const svg::SVGElement>(app.selectedElements()), std::nullopt, canvasFromDoc);
   EXPECT_FALSE(settledSnapshot.orientedBoundsDoc.has_value());
-  ASSERT_EQ(settledSnapshot.aabbsDoc.size(), 1u);
-  EXPECT_EQ(settledSnapshot.aabbsDoc.front(), startBounds);
+  EXPECT_THAT(settledSnapshot.aabbsDoc, ElementsAre(Box2dNear(startBounds, 1e-9)));
 }
 
 TEST(OverlayRendererTest, CaptureSnapshotCanProjectLiveDragBackToRepresentedDocument) {
@@ -516,10 +531,9 @@ TEST(OverlayRendererTest, CaptureSnapshotCanProjectLiveDragBackToRepresentedDocu
       /*cullRectDoc=*/std::nullopt, SelectionChromeDetail::Full,
       Transform2d::Translate(-50.0, 0.0));
 
-  ASSERT_EQ(snapshot.aabbsDoc.size(), 1u);
-  EXPECT_EQ(snapshot.aabbsDoc.front(), Box2d::FromXYWH(20.0, 30.0, 40.0, 50.0));
-  ASSERT_EQ(snapshot.paths.size(), 1u);
-  EXPECT_EQ(snapshot.paths.front().pathDoc.bounds(), Box2d::FromXYWH(20.0, 30.0, 40.0, 50.0));
+  EXPECT_THAT(snapshot.aabbsDoc,
+              ElementsAre(Box2dNear(Box2d::FromXYWH(20.0, 30.0, 40.0, 50.0), 1e-9)));
+  EXPECT_THAT(snapshot.paths, ElementsAre(PathBoundsAre(Box2d::FromXYWH(20.0, 30.0, 40.0, 50.0))));
 }
 
 // Calling the overlay-only render path repeatedly (the click→reselect

--- a/donner/editor/tests/PenTool_tests.cc
+++ b/donner/editor/tests/PenTool_tests.cc
@@ -95,8 +95,7 @@ TEST_F(PenToolTest, FirstClickInsertsSelectedPath) {
 
   svg::SVGPathElement inserted = path();
   EXPECT_EQ(inserted.d(), "M 10 20");
-  ASSERT_EQ(app.selectedElements().size(), 1u);
-  EXPECT_EQ(app.selectedElements().front(), inserted);
+  EXPECT_THAT(app.selectedElements(), testing::ElementsAre(inserted));
   const std::string source(app.document().document().source());
   const std::size_t pathOffset = source.find(R"(<path d="M 10 20")");
   const std::size_t svgCloseOffset = source.find("</svg>");
@@ -252,11 +251,9 @@ TEST_F(PenToolTest, BoundsIncludeNewestPointAfterImmediateIdleFlush) {
 
   const std::vector<Box2d> bounds =
       SnapshotSelectionWorldBounds(std::span<const svg::SVGElement>(app.selectedElements()));
-  ASSERT_EQ(bounds.size(), 1u);
-  EXPECT_LE(bounds.front().topLeft.x, 10.0);
-  EXPECT_LE(bounds.front().topLeft.y, 20.0);
-  EXPECT_GE(bounds.front().bottomRight.x, 80.0);
-  EXPECT_GE(bounds.front().bottomRight.y, 90.0);
+  EXPECT_THAT(bounds,
+              testing::ElementsAre(testing::AllOf(BoxContainingPoint(Vector2d(10.0, 20.0)),
+                                                  BoxContainingPoint(Vector2d(80.0, 90.0)))));
 }
 
 TEST_F(PenToolTest, ConsecutiveClicksBeforeFlushStayInsideSvgRoot) {

--- a/donner/editor/tests/TextEditorCore_tests.cc
+++ b/donner/editor/tests/TextEditorCore_tests.cc
@@ -105,6 +105,36 @@ std::vector<std::optional<ColorIndex>> ColorIndexesAt(const Line& line,
   return colors;
 }
 
+std::vector<std::optional<bool>> SingleLineCommentStatesAt(
+    const Line& line, std::initializer_list<std::size_t> indexes) {
+  std::vector<std::optional<bool>> states;
+  states.reserve(indexes.size());
+  for (std::size_t index : indexes) {
+    if (index < line.size()) {
+      states.emplace_back(line[index].isComment);
+    } else {
+      states.emplace_back(std::nullopt);
+    }
+  }
+
+  return states;
+}
+
+std::vector<std::optional<bool>> MultiLineCommentStatesAt(
+    const Line& line, std::initializer_list<std::size_t> indexes) {
+  std::vector<std::optional<bool>> states;
+  states.reserve(indexes.size());
+  for (std::size_t index : indexes) {
+    if (index < line.size()) {
+      states.emplace_back(line[index].isMultiLineComment);
+    } else {
+      states.emplace_back(std::nullopt);
+    }
+  }
+
+  return states;
+}
+
 class TextEditorCoreTests : public ::testing::Test {
 protected:
   void SetUp() override {
@@ -1482,16 +1512,16 @@ TEST_F(TextEditorCoreTests, ColorizeInternalMarksSingleAndMultilineComments) {
   editor_.colorizeInternal();
 
   const Line& line0 = editor_.buffer().getLineGlyphs(0);
-  EXPECT_FALSE(line0[0].isComment);
-  EXPECT_TRUE(line0[2].isComment);
+  EXPECT_THAT(SingleLineCommentStatesAt(line0, {0u, 2u}),
+              ElementsAre(Optional(false), Optional(true)));
 
   const Line& line1 = editor_.buffer().getLineGlyphs(1);
-  EXPECT_TRUE(line1[0].isMultiLineComment);
-  EXPECT_TRUE(line1[3].isMultiLineComment);
+  EXPECT_THAT(MultiLineCommentStatesAt(line1, {0u, 3u}),
+              ElementsAre(Optional(true), Optional(true)));
 
   const Line& line2 = editor_.buffer().getLineGlyphs(2);
-  EXPECT_TRUE(line2[0].isMultiLineComment);
-  EXPECT_FALSE(line2[9].isMultiLineComment);
+  EXPECT_THAT(MultiLineCommentStatesAt(line2, {0u, 9u}),
+              ElementsAre(Optional(true), Optional(false)));
 }
 
 }  // namespace donner::editor


### PR DESCRIPTION
## Summary

- Convert editor test size/front collection checks to gMock matchers for clearer failure logs.
- Add reusable helpers for `GlTextureCache` tile views, `OverlayRenderer` geometry bounds, and `TextEditorCore` comment-state probes.
- Upgrade selected `PenTool` assertions to whole-collection matchers.

Stacked on #734 (`test-diagnostics-after-geometry`).

## Validation

- `tools/llm-bazel-wrap.sh test //donner/editor/tests:text_editor_core_tests //donner/editor/tests:gl_texture_cache_tests //donner/editor/tests:pen_tool_tests //donner/editor/tests:overlay_renderer_tests`
- `tools/llm-bazel-wrap.sh test //...`
- `python3 tools/cmake/gen_cmakelists.py --check`