### PR TITLE
Improve editor selection test diagnostics

### DIFF
--- a/donner/editor/tests/DocumentSyncController_tests.cc
+++ b/donner/editor/tests/DocumentSyncController_tests.cc
@@ -1,12 +1,15 @@
 #include "donner/editor/DocumentSyncController.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <span>
 #include <string>
 #include <utility>
+#include <vector>
 
+#include "donner/base/RcString.h"
+#include "donner/base/xml/XMLSourceStore.h"
 #include "donner/editor/AttributeWriteback.h"
 #include "donner/editor/EditorApp.h"
 #include "donner/editor/EditorCommand.h"
@@ -23,6 +26,14 @@
 namespace donner::editor {
 namespace {
 
+using ::testing::AllOf;
+using ::testing::Contains;
+using ::testing::ElementsAre;
+using ::testing::Field;
+using ::testing::Gt;
+using ::testing::ResultOf;
+using ::testing::SizeIs;
+
 constexpr std::string_view kTrivialSvg =
     R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
          <rect id="r1" x="10" y="10" width="20" height="20" fill="red"/>
@@ -38,6 +49,29 @@ constexpr std::string_view kTwoRectSvg =
          <rect id="r1" x="0" y="0" width="10" height="10"/>
          <rect id="r2" x="20" y="0" width="10" height="10"/>
        </svg>)";
+
+std::vector<RcString> SelectedElementIds(const EditorApp& app) {
+  std::vector<RcString> ids;
+  ids.reserve(app.selectedElements().size());
+  for (const svg::SVGElement& element : app.selectedElements()) {
+    ids.push_back(element.id());
+  }
+
+  return ids;
+}
+
+auto IsLockedElement() {
+  return ResultOf(
+      "IsLocked", [](const svg::SVGElement& element) { return IsLocked(element); }, true);
+}
+
+auto SourceDeltaRemovedLengthIs(auto matcher) {
+  return Field("removedLength", &xml::XMLSourceDelta::removedLength, matcher);
+}
+
+auto SourceDeltaInsertedLengthIs(auto matcher) {
+  return Field("insertedLength", &xml::XMLSourceDelta::insertedLength, matcher);
+}
 
 class DocumentSyncControllerTest : public ::testing::Test {
 protected:
@@ -150,15 +184,14 @@ TEST_F(DocumentSyncControllerTest, PartialOpeningTagEditPreservesSelectionWhileI
     controller_.handleTextEdits(app_, textEditor_, /*deltaSeconds=*/0.0f);
 
     ASSERT_TRUE(app_.hasSelection()) << "lost selection after typing '" << ch << "'";
-    ASSERT_EQ(app_.selectedElements().size(), 1u);
-    EXPECT_TRUE(app_.selectedElements().front() == *rect);
+    EXPECT_THAT(app_.selectedElements(), ElementsAre(*rect));
 
     controller_.handleTextEdits(app_, textEditor_, /*deltaSeconds=*/0.2f);
   }
 
   EXPECT_FALSE(app_.document().lastParseError().has_value());
   ASSERT_TRUE(app_.hasSelection());
-  EXPECT_TRUE(app_.selectedElements().front() == *rect);
+  EXPECT_THAT(app_.selectedElements(), ElementsAre(*rect));
   EXPECT_NE(app_.document().document().source().find(R"(style="display:none")"),
             std::string_view::npos);
 }
@@ -194,7 +227,7 @@ TEST_F(DocumentSyncControllerTest, TypingDisplayNoneBeforePathClassKeepsSelectio
     (void)app_.flushFrame();
 
     ASSERT_TRUE(app_.hasSelection()) << "lost selection after typing '" << ch << "'";
-    ASSERT_EQ(app_.selectedElements().size(), 1u);
+    ASSERT_THAT(app_.selectedElements(), SizeIs(1u));
     EXPECT_TRUE(app_.selectedElement()->isa<svg::SVGGeometryElement>());
   }
 
@@ -446,7 +479,7 @@ TEST_F(DocumentSyncControllerTest, SourceBackedDeleteWritebackMirrorsFlushDeltaW
   ASSERT_TRUE(app_.flushFrame());
   EXPECT_FALSE(app_.document().lastFlushResult().replacedDocument);
   EXPECT_EQ(app_.document().documentGeneration(), documentGeneration);
-  ASSERT_EQ(app_.document().lastFlushResult().sourceDeltas.size(), 1u);
+  ASSERT_THAT(app_.document().lastFlushResult().sourceDeltas, SizeIs(1u));
 
   controller_.applyPendingWritebacks(app_, tool, textEditor_);
 
@@ -581,8 +614,7 @@ TEST_F(DocumentSyncControllerTest, DeleteSelectionSkipsLockedElementsInSourceToo
   EXPECT_EQ(textEditor.getText().find("id=\"free\""), std::string::npos);
   EXPECT_TRUE(app.document().document().querySelector("#locked").has_value());
   EXPECT_NE(textEditor.getText().find("id=\"locked\""), std::string::npos);
-  ASSERT_EQ(app.selectedElements().size(), 1u);
-  EXPECT_TRUE(IsLocked(app.selectedElements().front()));
+  EXPECT_THAT(app.selectedElements(), ElementsAre(IsLockedElement()));
 }
 
 TEST_F(DocumentSyncControllerTest, SetTextContentMirrorsIntoSourceText) {
@@ -841,8 +873,7 @@ TEST(DocumentSyncControllerStructuredTest, SelectedElementSourceAttributeEditsKe
   textEditor.insertText(kNewWidth);
   controller.handleTextEdits(app, textEditor, /*deltaSeconds=*/0.0f);
 
-  ASSERT_EQ(app.selectedElements().size(), 1u);
-  EXPECT_EQ(app.selectedElements().front().id(), "r1");
+  EXPECT_THAT(SelectedElementIds(app), ElementsAre(RcString("r1")));
   SelectionBoundsCache cache;
   RefreshSelectionBoundsCache(cache, std::span<const svg::SVGElement>(app.selectedElements()),
                               app.document().currentFrameVersion(),
@@ -875,8 +906,7 @@ TEST(DocumentSyncControllerStructuredTest, SourceInsertNearSelectionKeepsBoundsS
 
   controller.handleTextEdits(app, textEditor, /*deltaSeconds=*/0.0f);
 
-  ASSERT_EQ(app.selectedElements().size(), 1u);
-  EXPECT_EQ(app.selectedElements().front().id(), "a");
+  EXPECT_THAT(SelectedElementIds(app), ElementsAre(RcString("a")));
   SelectionBoundsCache cache;
   RefreshSelectionBoundsCache(cache, std::span<const svg::SVGElement>(app.selectedElements()),
                               app.document().currentFrameVersion(),
@@ -1206,10 +1236,8 @@ TEST(DocumentSyncControllerStructuredTest, MultiDeltaMoveMirrorsIntoTextPane) {
 
   xml::ApplySourceEditResult result = app.document().document().insertElement(*target, *moved);
   ASSERT_TRUE(result.applied);
-  ASSERT_EQ(result.sourceDeltas.size(), 2u);
-  EXPECT_TRUE(std::ranges::any_of(result.sourceDeltas, [](const xml::XMLSourceDelta& delta) {
-    return delta.insertedLength > 0;
-  }));
+  ASSERT_THAT(result.sourceDeltas, SizeIs(2u));
+  EXPECT_THAT(result.sourceDeltas, Contains(SourceDeltaInsertedLengthIs(Gt(0u))));
 
   EXPECT_TRUE(controller.mirrorSourceDeltas(app, textEditor, result.sourceDeltas));
 
@@ -1343,8 +1371,7 @@ TEST(DocumentSyncControllerStructuredTest, MirrorSourceDeltasFallsBackWhenDelete
   ASSERT_TRUE(rect.has_value());
   xml::ApplySourceEditResult result = app.document().document().removeElement(*rect);
   ASSERT_TRUE(result.applied);
-  ASSERT_EQ(result.sourceDeltas.size(), 1u);
-  ASSERT_GT(result.sourceDeltas.front().removedLength, 0u);
+  ASSERT_THAT(result.sourceDeltas, ElementsAre(SourceDeltaRemovedLengthIs(Gt(0u))));
 
   EXPECT_TRUE(controller.mirrorSourceDeltas(app, textEditor, result.sourceDeltas));
 
@@ -1378,8 +1405,7 @@ TEST(DocumentSyncControllerStructuredTest, MirrorSourceDeltasFallsBackWhenInsert
   xml::ApplySourceEditResult result =
       app.document().document().insertElement(app.document().document().svgElement(), inserted);
   ASSERT_TRUE(result.applied);
-  ASSERT_EQ(result.sourceDeltas.size(), 1u);
-  ASSERT_EQ(result.sourceDeltas.front().removedLength, 0u);
+  ASSERT_THAT(result.sourceDeltas, ElementsAre(SourceDeltaRemovedLengthIs(0u)));
 
   EXPECT_TRUE(controller.mirrorSourceDeltas(app, textEditor, result.sourceDeltas));
 
@@ -1412,9 +1438,8 @@ TEST(DocumentSyncControllerStructuredTest, MirrorSourceDeltasInsertsNewRootChild
   xml::ApplySourceEditResult result =
       app.document().document().insertElement(app.document().document().svgElement(), inserted);
   ASSERT_TRUE(result.applied);
-  ASSERT_EQ(result.sourceDeltas.size(), 1u);
-  ASSERT_EQ(result.sourceDeltas.front().removedLength, 0u);
-  ASSERT_GT(result.sourceDeltas.front().insertedLength, 0u);
+  ASSERT_THAT(result.sourceDeltas, ElementsAre(AllOf(SourceDeltaRemovedLengthIs(0u),
+                                                     SourceDeltaInsertedLengthIs(Gt(0u)))));
 
   EXPECT_TRUE(controller.mirrorSourceDeltas(app, textEditor, result.sourceDeltas));
 

--- a/donner/editor/tests/EditorApp_tests.cc
+++ b/donner/editor/tests/EditorApp_tests.cc
@@ -22,6 +22,11 @@
 namespace donner::editor {
 namespace {
 
+using ::testing::ElementsAre;
+using ::testing::Eq;
+using ::testing::IsEmpty;
+using ::testing::SizeIs;
+
 constexpr std::string_view kTrivialSvg =
     R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
          <rect id="r1" x="10" y="10" width="20" height="20" fill="red"/>
@@ -246,9 +251,8 @@ TEST(EditorAppTest, MarqueeHitTestRectUnderConcurrentDomHoldsAccess) {
   const std::vector<svg::SVGGeometryElement> hits =
       app.hitTestRect(Box2d(Vector2d(0.0, 0.0), Vector2d(40.0, 40.0)));
 
-  ASSERT_EQ(hits.size(), 1u);
   app.document().document().withReadAccess(
-      [&](svg::DocumentReadAccess&) { EXPECT_EQ(hits.front().id(), "r1"); });
+      [&](svg::DocumentReadAccess&) { EXPECT_THAT(ElementIds(hits), ElementsAre("r1")); });
 }
 
 TEST(EditorAppTest, ApplyMutationFlowsThroughDocument) {
@@ -261,9 +265,9 @@ TEST(EditorAppTest, ApplyMutationFlowsThroughDocument) {
   app.applyMutation(
       EditorCommand::SetTransformCommand(*rect, Transform2d::Translate(Vector2d(99.0, 0.0))));
 
-  EXPECT_EQ(app.document().queue().size(), 1u);
+  EXPECT_THAT(app.document().queue().size(), Eq(1u));
   EXPECT_TRUE(app.flushFrame());
-  EXPECT_EQ(app.document().queue().size(), 0u);
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
 }
 
 TEST(EditorAppTest, SelectionSetAndClear) {
@@ -277,11 +281,11 @@ TEST(EditorAppTest, SelectionSetAndClear) {
   EXPECT_TRUE(app.hasSelection());
   ASSERT_TRUE(app.selectedElement().has_value());
   EXPECT_TRUE(*app.selectedElement() == *r1);
-  EXPECT_EQ(app.selectedElements().size(), 1u);
+  EXPECT_THAT(app.selectedElements(), ElementsAre(*r1));
 
   app.setSelection(std::nullopt);
   EXPECT_FALSE(app.hasSelection());
-  EXPECT_TRUE(app.selectedElements().empty());
+  EXPECT_THAT(app.selectedElements(), IsEmpty());
 }
 
 // Multi-select API (Milestone 4 of the editor UX design doc): a
@@ -299,7 +303,7 @@ TEST(EditorAppTest, MultiSelectionStoresEveryElement) {
 
   app.setSelection(std::vector<svg::SVGElement>{*r1, *r2});
   EXPECT_TRUE(app.hasSelection());
-  EXPECT_THAT(ElementIds(app.selectedElements()), ::testing::ElementsAre("r1", "r2"));
+  EXPECT_THAT(ElementIds(app.selectedElements()), ElementsAre("r1", "r2"));
   // Single-element compat: returns the *first* element.
   ASSERT_TRUE(app.selectedElement().has_value());
   EXPECT_TRUE(*app.selectedElement() == *r1);
@@ -307,7 +311,7 @@ TEST(EditorAppTest, MultiSelectionStoresEveryElement) {
   // clearSelection reads as the natural opposite of "set N elements".
   app.clearSelection();
   EXPECT_FALSE(app.hasSelection());
-  EXPECT_TRUE(app.selectedElements().empty());
+  EXPECT_THAT(app.selectedElements(), IsEmpty());
   EXPECT_FALSE(app.selectedElement().has_value());
 }
 
@@ -323,9 +327,7 @@ TEST(EditorAppTest, SelectableElementsReturnsEveryGeometryElement) {
   // "Select All" returns both rects regardless of position, in document order — the same selectable
   // set marquee selection uses.
   const std::vector<svg::SVGElement> selectable = app.selectableElements();
-  ASSERT_EQ(selectable.size(), 2u);
-  EXPECT_EQ(selectable.at(0), *r1);
-  EXPECT_EQ(selectable.at(1), *r2);
+  EXPECT_THAT(selectable, ElementsAre(*r1, *r2));
 }
 
 TEST(EditorAppTest, SelectableElementsExcludesNonGeometryNodes) {
@@ -341,13 +343,12 @@ TEST(EditorAppTest, SelectableElementsExcludesNonGeometryNodes) {
   ASSERT_TRUE(r1.has_value());
 
   const std::vector<svg::SVGElement> selectable = app.selectableElements();
-  ASSERT_EQ(selectable.size(), 1u);
-  EXPECT_EQ(selectable.at(0), *r1);
+  EXPECT_THAT(selectable, ElementsAre(*r1));
 }
 
 TEST(EditorAppTest, SelectableElementsIsEmptyWithoutDocument) {
   EditorApp app;
-  EXPECT_TRUE(app.selectableElements().empty());
+  EXPECT_THAT(app.selectableElements(), IsEmpty());
 }
 
 TEST(EditorAppTest, ToggleInSelectionAddsThenRemoves) {
@@ -385,7 +386,7 @@ TEST(EditorAppTest, AddToSelectionIsIdempotent) {
   app.addToSelection(*r1);
   app.addToSelection(*r1);
   app.addToSelection(*r1);
-  EXPECT_EQ(app.selectedElements().size(), 1u);
+  EXPECT_THAT(app.selectedElements(), ElementsAre(*r1));
 }
 
 TEST(EditorAppTest, SetAttributeOnSelectionQueuesEverySelectedElement) {
@@ -399,7 +400,7 @@ TEST(EditorAppTest, SetAttributeOnSelectionQueuesEverySelectedElement) {
   app.setSelection(std::vector<svg::SVGElement>{*r1, *r2});
 
   ASSERT_TRUE(app.setAttributeOnSelection("fill", "#112233"));
-  EXPECT_EQ(app.document().queue().size(), 2u);
+  EXPECT_THAT(app.document().queue().size(), Eq(2u));
   ASSERT_TRUE(app.flushFrame());
 
   auto updatedR1 = app.document().document().querySelector("#r1");
@@ -416,7 +417,7 @@ TEST(EditorAppTest, EmptySelectionMutatorsReturnFalseWithoutQueueingCommands) {
 
   EXPECT_FALSE(app.setAttributeOnSelection("fill", "#112233"));
   EXPECT_FALSE(app.setStylePropertyOnSelection("fill", "#112233"));
-  EXPECT_EQ(app.document().queue().size(), 0u);
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
 }
 
 TEST(EditorAppTest, SetStylePropertyOnSelectionMergesIntoStyleAttribute) {
@@ -434,7 +435,7 @@ TEST(EditorAppTest, SetStylePropertyOnSelectionMergesIntoStyleAttribute) {
   app.setSelection(*r1);
 
   ASSERT_TRUE(app.setStylePropertyOnSelection("fill", "#112233"));
-  EXPECT_EQ(app.document().queue().size(), 1u);
+  EXPECT_THAT(app.document().queue().size(), Eq(1u));
   ASSERT_TRUE(app.flushFrame());
 
   auto updatedR1 = app.document().document().querySelector("#r1");
@@ -474,7 +475,7 @@ TEST(EditorAppTest, SetStylePropertyOnSelectionSkipsUnparseableDeclarations) {
   app.setSelection(*r1);
 
   EXPECT_FALSE(app.setStylePropertyOnSelection("", "#112233"));
-  EXPECT_EQ(app.document().queue().size(), 0u);
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
 }
 
 TEST(EditorAppTest, SetStrokeWidthOnSelectionClampsNegativeValues) {
@@ -695,7 +696,7 @@ TEST(EditorAppTest, UnbundleCompoundPathReplacesExplicitTargetAndRestoresUndoSel
   EXPECT_TRUE(app.compoundPathUnbundleAvailability(*compound).canApply);
 
   ASSERT_TRUE(app.unbundleCompoundPath(*compound));
-  ASSERT_EQ(app.selectedElements().size(), 2u);
+  ASSERT_THAT(app.selectedElements(), SizeIs(2u));
   for (const svg::SVGElement& selected : app.selectedElements()) {
     ASSERT_TRUE(selected.isa<svg::SVGPathElement>());
     EXPECT_FALSE(selected.getAttribute("id").has_value());
@@ -719,8 +720,8 @@ TEST(EditorAppTest, UnbundleCompoundPathReplacesExplicitTargetAndRestoresUndoSel
   app.undo();
   ASSERT_TRUE(app.flushFrame());
   EXPECT_TRUE(app.document().document().querySelector("#compound").has_value());
-  EXPECT_EQ(RootPathChildren(app).size(), 1u);
-  EXPECT_THAT(ElementIds(app.selectedElements()), ::testing::ElementsAre("compound"));
+  EXPECT_THAT(RootPathChildren(app), SizeIs(1u));
+  EXPECT_THAT(ElementIds(app.selectedElements()), ElementsAre("compound"));
 }
 
 TEST(EditorAppTest, UnbundleCompoundPathReleasesNestedHoleContours) {
@@ -789,7 +790,7 @@ TEST(EditorAppTest, PathUnionReplacesSelectionWithBooleanPath) {
   app.setSelection(std::vector<svg::SVGElement>{*r1, *r2});
 
   ASSERT_TRUE(app.applyPathOperation(PathOperationKind::Union));
-  ASSERT_EQ(app.selectedElements().size(), 1u);
+  ASSERT_THAT(app.selectedElements(), SizeIs(1u));
   ASSERT_TRUE(app.selectedElements().front().isa<svg::SVGPathElement>());
   EXPECT_EQ(std::string_view(app.selectedElements().front().cast<svg::SVGPathElement>().d()),
             "M 10 10 L 30 10 L 30 30 L 10 30 Z M 50 50 L 70 50 L 70 70 L 50 70 Z");
@@ -880,8 +881,8 @@ TEST(EditorAppTest, PathIntersectUnavailableWhenBoundsDoNotOverlap) {
   EXPECT_FALSE(app.pathOperationAvailability(PathOperationKind::Intersect).canApply);
   EXPECT_FALSE(app.applyPathOperation(PathOperationKind::Intersect));
   EXPECT_EQ(app.document().document().source(), sourceBefore);
-  EXPECT_EQ(app.document().queue().size(), 0u);
-  EXPECT_EQ(app.selectedElements().size(), 2u);
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
+  EXPECT_THAT(app.selectedElements(), SizeIs(2u));
   EXPECT_EQ(app.undoTimeline().entryCount(), 0u);
 }
 
@@ -906,8 +907,8 @@ TEST(EditorAppTest, EmptyPathIntersectLeavesDocumentUnchanged) {
   EXPECT_TRUE(app.pathOperationAvailability(PathOperationKind::Intersect).canApply);
   EXPECT_FALSE(app.applyPathOperation(PathOperationKind::Intersect));
   EXPECT_EQ(app.document().document().source(), sourceBefore);
-  EXPECT_EQ(app.document().queue().size(), 0u);
-  EXPECT_EQ(app.selectedElements().size(), 2u);
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
+  EXPECT_THAT(app.selectedElements(), SizeIs(2u));
   EXPECT_EQ(app.undoTimeline().entryCount(), 0u);
 }
 
@@ -1239,7 +1240,7 @@ TEST(EditorAppTest, PathOperationsHandleOverlappingDonnerLetters) {
     EXPECT_TRUE(app.applyPathOperation(operation));
     EXPECT_TRUE(app.flushFrame());
 
-    EXPECT_EQ(app.selectedElements().size(), 1u);
+    EXPECT_THAT(app.selectedElements(), SizeIs(1u));
     if (app.selectedElements().empty() ||
         !app.selectedElements().front().isa<svg::SVGPathElement>()) {
       return std::optional<Path>();
@@ -1297,7 +1298,7 @@ TEST(EditorAppTest, HitTestRectFindsAllIntersectingElements) {
   // r1 lives at (10,10..30,30), r2 at (50,50..70,70). A marquee
   // covering the full document grabs both.
   auto bothHits = app.hitTestRect(Box2d::FromXYWH(0.0, 0.0, 100.0, 100.0));
-  EXPECT_EQ(bothHits.size(), 2u);
+  EXPECT_THAT(ElementIds(bothHits), ElementsAre("r1", "r2"));
 
   // A marquee that only overlaps r1 returns just r1.
   auto r1Only = app.hitTestRect(Box2d::FromXYWH(5.0, 5.0, 20.0, 20.0));
@@ -1305,7 +1306,7 @@ TEST(EditorAppTest, HitTestRectFindsAllIntersectingElements) {
 
   // A marquee that misses both returns empty.
   auto noHits = app.hitTestRect(Box2d::FromXYWH(80.0, 80.0, 5.0, 5.0));
-  EXPECT_TRUE(noHits.empty());
+  EXPECT_THAT(noHits, IsEmpty());
 
   // Edge contact (marquee touches r1's edge) counts as intersection.
   auto edgeHits = app.hitTestRect(Box2d::FromXYWH(30.0, 30.0, 5.0, 5.0));

--- a/donner/editor/tests/EditorSync_tests.cc
+++ b/donner/editor/tests/EditorSync_tests.cc
@@ -1,3 +1,5 @@
+#include <gmock/gmock.h>
+
 #include <cstddef>
 #include <optional>
 #include <string>
@@ -21,6 +23,15 @@
 
 namespace donner::editor {
 namespace {
+
+using ::testing::AllOf;
+using ::testing::ElementsAre;
+using ::testing::Eq;
+using ::testing::Field;
+using ::testing::Gt;
+using ::testing::IsEmpty;
+using ::testing::Not;
+using ::testing::SizeIs;
 
 constexpr std::string_view kCircleSvg =
     R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
@@ -433,7 +444,7 @@ TEST(EditorSyncTest, DeleteMutationWritesElementRemovalBackToSource) {
   ASSERT_TRUE(app.flushFrame());
 
   auto pendingRemove = app.consumeElementRemoveWritebacks();
-  ASSERT_EQ(pendingRemove.size(), 1u);
+  ASSERT_THAT(pendingRemove, SizeIs(1u));
   ASSERT_TRUE(ApplyElementRemoveWriteback(&source, pendingRemove.front().target));
   EXPECT_EQ(source.find("id=\"a\""), std::string::npos);
   EXPECT_NE(source.find("id=\"b\""), std::string::npos);
@@ -575,7 +586,7 @@ TEST(EditorSyncTest, DeleteWritebackReparseRefreshesFollowingElementLocation) {
   ASSERT_TRUE(app.flushFrame());
 
   auto pendingRemove = app.consumeElementRemoveWritebacks();
-  ASSERT_EQ(pendingRemove.size(), 1u);
+  ASSERT_THAT(pendingRemove, SizeIs(1u));
   ASSERT_TRUE(QueueElementRemoveWritebackReparse(
       app, &source, &previousSourceText, &lastWritebackSourceText, pendingRemove.front().target));
 
@@ -615,7 +626,7 @@ TEST(EditorSyncTest, StructuredSourceEditAppliesThroughXMLDocumentWithoutCommand
 
   EXPECT_TRUE(dispatch.dispatchedMutation);
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
-  EXPECT_TRUE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
   EXPECT_FALSE(app.flushFrame());
   EXPECT_GT(app.document().currentFrameVersion(), previousFrameVersion);
   EXPECT_EQ(app.document().document().source(), kEditedSvg);
@@ -663,7 +674,7 @@ TEST(EditorSyncTest, StructuredSourceEditInsertsChildElementIncrementally) {
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
   // Incremental: a fallback would queue a ReplaceDocumentCommand, which would make
   // flushFrame() return true. An incremental apply queues nothing.
-  EXPECT_TRUE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
   EXPECT_FALSE(app.flushFrame());
 
   EXPECT_EQ(app.document().document().source(), editedSource);
@@ -704,7 +715,7 @@ TEST(EditorSyncTest, StructuredSourceEditDeletesChildElementIncrementally) {
 
   EXPECT_TRUE(dispatch.dispatchedMutation);
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
-  EXPECT_TRUE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
   EXPECT_FALSE(app.flushFrame());
 
   EXPECT_EQ(app.document().document().source(), editedSource);
@@ -769,7 +780,7 @@ TEST(EditorSyncTest, StructuredSourceEditingIsDefaultForNewEditorApps) {
 
   EXPECT_TRUE(dispatch.dispatchedMutation);
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
-  EXPECT_TRUE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
   EXPECT_FALSE(app.flushFrame());
   EXPECT_EQ(app.document().document().source(), kEditedSvg);
 }
@@ -792,7 +803,7 @@ TEST(EditorSyncTest, StructuredSourceEditingRuntimeOptOutUsesDocumentReplace) {
 
   EXPECT_TRUE(dispatch.dispatchedMutation);
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
-  EXPECT_FALSE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Gt(0u));
   ASSERT_TRUE(app.flushFrame());
   EXPECT_TRUE(app.document().lastFlushResult().replacedDocument);
   EXPECT_EQ(app.document().document().source(), kEditedSvg);
@@ -816,7 +827,7 @@ TEST(EditorSyncTest, StructuredMalformedOpeningTagEditDoesNotQueueReplaceDocumen
 
   EXPECT_TRUE(dispatch.dispatchedMutation);
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
-  EXPECT_TRUE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
   EXPECT_FALSE(app.flushFrame());
   EXPECT_EQ(app.document().document().source(), kEditedSvg);
   ASSERT_TRUE(app.document().lastParseError().has_value());
@@ -850,7 +861,7 @@ TEST(EditorSyncTest, StructuredOpeningTagRecoveryClearsDiagnosticWithoutCommand)
 
   EXPECT_TRUE(dispatch.dispatchedMutation);
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
-  EXPECT_TRUE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
   EXPECT_FALSE(app.flushFrame());
   EXPECT_EQ(app.document().document().source(), kSvg);
   EXPECT_EQ(app.document().lastParseError(), std::nullopt);
@@ -876,7 +887,7 @@ TEST(EditorSyncTest, DispatchSourceTextChangeNoOpDoesNotDispatch) {
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
   EXPECT_EQ(previousSourceText, kCircleSvg);
   EXPECT_FALSE(lastWritebackSourceText.has_value());
-  EXPECT_TRUE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
 }
 
 TEST(EditorSyncTest, DispatchSourceEditIntentsSkipsSelfWritebackEcho) {
@@ -896,7 +907,7 @@ TEST(EditorSyncTest, DispatchSourceEditIntentsSkipsSelfWritebackEcho) {
   EXPECT_TRUE(dispatch.skippedSelfWriteback);
   EXPECT_EQ(previousSourceText, kCircleAt40Svg);
   EXPECT_FALSE(lastWritebackSourceText.has_value());
-  EXPECT_TRUE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
 }
 
 TEST(EditorSyncTest, DispatchSourceEditIntentsNoOpDoesNotApplyStaleIntent) {
@@ -915,7 +926,7 @@ TEST(EditorSyncTest, DispatchSourceEditIntentsNoOpDoesNotApplyStaleIntent) {
   EXPECT_FALSE(dispatch.dispatchedMutation);
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
   EXPECT_EQ(previousSourceText, kCircleSvg);
-  EXPECT_TRUE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
 }
 
 TEST(EditorSyncTest, DispatchSourceEditIntentsEmptyListDelegatesToTextChange) {
@@ -935,7 +946,7 @@ TEST(EditorSyncTest, DispatchSourceEditIntentsEmptyListDelegatesToTextChange) {
 
   EXPECT_TRUE(dispatch.dispatchedMutation);
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
-  EXPECT_TRUE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
   EXPECT_FALSE(app.flushFrame());
   EXPECT_EQ(app.document().document().source(), kEditedSvg);
   EXPECT_EQ(previousSourceText, kEditedSvg);
@@ -958,7 +969,7 @@ TEST(EditorSyncTest, DispatchSourceEditIntentsInvalidIntentQueuesDocumentReplace
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
   EXPECT_EQ(previousSourceText, kCircleAt40Svg);
   EXPECT_FALSE(lastWritebackSourceText.has_value());
-  EXPECT_FALSE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Gt(0u));
   ASSERT_TRUE(app.flushFrame());
   EXPECT_TRUE(app.document().lastFlushResult().replacedDocument);
   EXPECT_EQ(app.document().document().source(), kCircleAt40Svg);
@@ -987,7 +998,7 @@ TEST(EditorSyncTest, DispatchSourceEditIntentsStructuredOptOutQueuesDocumentRepl
 
   EXPECT_TRUE(dispatch.dispatchedMutation);
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
-  EXPECT_FALSE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Gt(0u));
   ASSERT_TRUE(app.flushFrame());
   EXPECT_TRUE(app.document().lastFlushResult().replacedDocument);
   EXPECT_EQ(app.document().document().source(), kEditedSvg);
@@ -1018,7 +1029,7 @@ TEST(EditorSyncTest, DispatchSourceEditIntentsFinalMismatchQueuesDocumentReplace
   EXPECT_TRUE(dispatch.dispatchedMutation);
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
   EXPECT_EQ(app.document().document().source(), kIntentSvg);
-  EXPECT_FALSE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Gt(0u));
   ASSERT_TRUE(app.flushFrame());
   EXPECT_TRUE(app.document().lastFlushResult().replacedDocument);
   EXPECT_EQ(app.document().document().source(), kNewSvg);
@@ -1050,7 +1061,7 @@ TEST(EditorSyncTest, DispatchSourceEditIntentsAppliesMultipleStructuredEdits) {
 
   EXPECT_TRUE(dispatch.dispatchedMutation);
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
-  EXPECT_TRUE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
   EXPECT_FALSE(app.flushFrame());
   EXPECT_EQ(app.document().document().source(), kEditedSvg);
   EXPECT_EQ(previousSourceText, kEditedSvg);
@@ -1084,10 +1095,11 @@ TEST(EditorSyncTest, SelfInitiatedWritebackDoesNotDispatchDuplicateReplaceDocume
   EXPECT_TRUE(dispatch.skippedSelfWriteback);
 
   auto effective = app.document().queue().flush();
-  ASSERT_EQ(effective.effectiveCommands.size(), 1u);
-  EXPECT_EQ(effective.effectiveCommands.front().kind, EditorCommand::Kind::ReplaceDocument);
-  EXPECT_EQ(effective.effectiveCommands.front().bytes, source);
-  EXPECT_TRUE(effective.effectiveCommands.front().preserveUndoOnReparse);
+  EXPECT_THAT(effective.effectiveCommands,
+              ElementsAre(AllOf(
+                  Field("kind", &EditorCommand::kind, EditorCommand::Kind::ReplaceDocument),
+                  Field("bytes", &EditorCommand::bytes, source),
+                  Field("preserveUndoOnReparse", &EditorCommand::preserveUndoOnReparse, true))));
   EXPECT_TRUE(effective.hadReplaceDocument);
   EXPECT_TRUE(effective.preserveUndoOnReparse);
 }
@@ -1144,7 +1156,7 @@ TEST(EditorSyncTest, SelectionClearsAndDisplayedBoundsClearWhenElementDisappears
   const std::uint64_t initialVersion = app.document().currentFrameVersion();
   RefreshSelectionBoundsCache(cache, std::span<const svg::SVGElement>(app.selectedElements()),
                               initialVersion, initialVersion);
-  ASSERT_FALSE(cache.displayedBoundsDoc.empty());
+  ASSERT_THAT(cache.displayedBoundsDoc, Not(IsEmpty()));
 
   app.applyMutation(
       EditorCommand::ReplaceDocumentCommand("<svg xmlns=\"http://www.w3.org/2000/svg\"/>"));
@@ -1153,7 +1165,7 @@ TEST(EditorSyncTest, SelectionClearsAndDisplayedBoundsClearWhenElementDisappears
 
   RefreshSelectionBoundsCache(cache, std::span<const svg::SVGElement>(app.selectedElements()),
                               app.document().currentFrameVersion(), initialVersion);
-  EXPECT_TRUE(cache.displayedBoundsDoc.empty());
+  EXPECT_THAT(cache.displayedBoundsDoc, IsEmpty());
 }
 
 // Interleave of drag + source-pane edit + undo. The user:

--- a/donner/editor/tests/LayersPanel_tests.cc
+++ b/donner/editor/tests/LayersPanel_tests.cc
@@ -31,6 +31,11 @@
 namespace donner::editor {
 namespace {
 
+using ::testing::ElementsAre;
+using ::testing::Gt;
+using ::testing::ResultOf;
+using ::testing::SizeIs;
+
 constexpr std::string_view kSvg =
     R"(<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
   <g id="groupA">
@@ -51,6 +56,10 @@ int RowIndex(const LayersPanel& panel, std::string_view name) {
   return -1;
 }
 
+auto ElementIdIs(auto matcher) {
+  return ResultOf("id()", [](const svg::SVGElement& element) { return element.id(); }, matcher);
+}
+
 // The Layers panel is a distinct type from the compositor diagnostics panel.
 static_assert(!std::is_same_v<LayersPanel, CompositorDebugPanel>,
               "LayersPanel must be a distinct type from CompositorDebugPanel");
@@ -67,8 +76,7 @@ TEST(LayersPanelTest, PlainClickSelectsRowElement) {
   const svg::SVGElement leafElement = panel.rows()[leafIdx].element;
   panel.handleRowClick(app, static_cast<std::size_t>(leafIdx), LayersPanel::ClickModifiers{});
 
-  ASSERT_EQ(app.selectedElements().size(), 1u);
-  EXPECT_EQ(app.selectedElements().front(), leafElement);
+  EXPECT_THAT(app.selectedElements(), ElementsAre(leafElement));
   EXPECT_TRUE(panel.consumeSelectionChanged());
 }
 
@@ -89,7 +97,7 @@ TEST(LayersPanelTest, ShiftClickSelectsContiguousRange) {
   shift.shift = true;
   panel.handleRowClick(app, panel.visibleRowCount() - 1, shift);
 
-  EXPECT_GT(app.selectedElements().size(), 1u)
+  EXPECT_THAT(app.selectedElements(), SizeIs(Gt(1u)))
       << "shift-click should select a contiguous range of rows";
 }
 
@@ -106,15 +114,15 @@ TEST(LayersPanelTest, CtrlClickTogglesMembership) {
   ASSERT_GE(groupAIdx, 0);
 
   panel.handleRowClick(app, static_cast<std::size_t>(leafIdx), LayersPanel::ClickModifiers{});
-  EXPECT_EQ(app.selectedElements().size(), 1u);
+  EXPECT_THAT(app.selectedElements(), SizeIs(1u));
 
   LayersPanel::ClickModifiers ctrl;
   ctrl.ctrl = true;
   panel.handleRowClick(app, static_cast<std::size_t>(groupAIdx), ctrl);
-  EXPECT_EQ(app.selectedElements().size(), 2u) << "ctrl-click adds to selection";
+  EXPECT_THAT(app.selectedElements(), SizeIs(2u)) << "ctrl-click adds to selection";
 
   panel.handleRowClick(app, static_cast<std::size_t>(groupAIdx), ctrl);
-  EXPECT_EQ(app.selectedElements().size(), 1u) << "ctrl-click again toggles it back off";
+  EXPECT_THAT(app.selectedElements(), SizeIs(1u)) << "ctrl-click again toggles it back off";
 }
 
 TEST(LayersPanelTest, EveryVisibleRowHasThumbnailOrSwatch) {
@@ -189,8 +197,7 @@ TEST(LayersPanelTest, RowRenameChangesIdAndSelectsRow) {
 
   // The element kept its identity but took the new id, and the rename selected it.
   EXPECT_EQ(element.id(), RcString("renamed"));
-  ASSERT_EQ(app.selectedElements().size(), 1u);
-  EXPECT_EQ(app.selectedElements().front(), element);
+  EXPECT_THAT(app.selectedElements(), ElementsAre(element));
   EXPECT_TRUE(panel.consumeSelectionChanged());
 
   panel.refreshSnapshot(app);
@@ -333,8 +340,7 @@ TEST(LayersPanelTest, RowZOrderBringsElementForward) {
   panel.refreshSnapshot(app);
   EXPECT_LT(RowIndex(panel, "b"), RowIndex(panel, "a"));
   // The reorder selected the acted-on row.
-  ASSERT_EQ(app.selectedElements().size(), 1u);
-  EXPECT_EQ(app.selectedElements().front().id(), RcString("a"));
+  EXPECT_THAT(app.selectedElements(), ElementsAre(ElementIdIs(RcString("a"))));
 }
 
 TEST(LayersPanelTest, RowZOrderOutOfRangeIsNoOp) {

--- a/donner/editor/tests/SelectTool_tests.cc
+++ b/donner/editor/tests/SelectTool_tests.cc
@@ -17,6 +17,11 @@
 namespace donner::editor {
 namespace {
 
+using ::testing::ElementsAre;
+using ::testing::IsEmpty;
+using ::testing::SizeIs;
+using ::testing::UnorderedElementsAre;
+
 constexpr std::string_view kTwoRectsSvg =
     R"(<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
          <rect id="r1" x="10" y="10" width="20" height="20" fill="red"/>
@@ -120,15 +125,6 @@ protected:
       return false;
     }
     return *selection == elementById(id);
-  }
-
-  bool selectionContainsId(std::string_view id) const {
-    for (const svg::SVGElement& selected : app.selectedElements()) {
-      if (selected.id() == id) {
-        return true;
-      }
-    }
-    return false;
   }
 
   void quickClick(const Vector2d& point) {
@@ -262,8 +258,7 @@ TEST_F(SelectToolTest, ClickInsideFilterGroupSelectsTheGroupNotSiblings) {
 
   quickClick(Vector2d(12.0, 20.0));
 
-  ASSERT_EQ(app.selectedElements().size(), 1u);
-  EXPECT_THAT(selectedElementIds(), testing::ElementsAre("anchor"))
+  EXPECT_THAT(selectedElementIds(), ElementsAre("anchor"))
       << "elevation lands on the filter-g, single-element selection";
 
   drag(Vector2d(12.0, 20.0), Vector2d(42.0, 50.0));
@@ -283,8 +278,7 @@ TEST_F(SelectToolTest, NonCompositingGroupSelectsLeafNotGroup) {
 
   quickClick(Vector2d(12.0, 20.0));
 
-  ASSERT_EQ(app.selectedElements().size(), 1u);
-  EXPECT_THAT(selectedElementIds(), testing::ElementsAre("plain_leaf"))
+  EXPECT_THAT(selectedElementIds(), ElementsAre("plain_leaf"))
       << "plain `<g>` is not a compositing object — select the leaf path";
 
   drag(Vector2d(12.0, 20.0), Vector2d(32.0, 40.0));
@@ -535,27 +529,26 @@ TEST_F(SelectToolTest, ShiftClickAddsElementsToSelection) {
   // Plain click on r1 → selection = {r1}.
   tool.onMouseDown(app, Vector2d(15.0, 15.0), MouseModifiers{});
   tool.onMouseUp(app, Vector2d(15.0, 15.0));
-  ASSERT_EQ(app.selectedElements().size(), 1u);
-  EXPECT_THAT(selectedElementIds(), testing::ElementsAre("r1"));
+  EXPECT_THAT(selectedElementIds(), ElementsAre("r1"));
 
   // Shift+click on r2 → selection = {r1, r2}.
   MouseModifiers shift;
   shift.shift = true;
   tool.onMouseDown(app, Vector2d(120.0, 120.0), shift);
   tool.onMouseUp(app, Vector2d(120.0, 120.0));
-  ASSERT_EQ(app.selectedElements().size(), 2u);
+  EXPECT_THAT(app.selectedElements(), SizeIs(2u));
 }
 
 TEST_F(SelectToolTest, ShiftClickOnSelectedElementTogglesItOff) {
   tool.onMouseDown(app, Vector2d(15.0, 15.0), MouseModifiers{});
   tool.onMouseUp(app, Vector2d(15.0, 15.0));
-  ASSERT_EQ(app.selectedElements().size(), 1u);
+  ASSERT_THAT(app.selectedElements(), SizeIs(1u));
 
   MouseModifiers shift;
   shift.shift = true;
   tool.onMouseDown(app, Vector2d(15.0, 15.0), shift);
   tool.onMouseUp(app, Vector2d(15.0, 15.0));
-  EXPECT_TRUE(app.selectedElements().empty());
+  EXPECT_THAT(app.selectedElements(), IsEmpty());
 }
 
 TEST_F(SelectToolTest, ShiftClickDoesNotStartDrag) {
@@ -588,9 +581,7 @@ TEST_F(SelectToolTest, ShiftClickInRotateRingAddsNearbyElementInsteadOfRotating)
   tool.onMouseUp(app, Vector2d(20.0, 44.0));
 
   EXPECT_FALSE(tool.activeGesturePreview().has_value());
-  ASSERT_EQ(app.selectedElements().size(), 2u);
-  EXPECT_TRUE(selectionContainsId("target"));
-  EXPECT_TRUE(selectionContainsId("nearby"));
+  EXPECT_THAT(selectedElementIds(), UnorderedElementsAre("target", "nearby"));
   EXPECT_DOUBLE_EQ(transformOf("#target").data[0], 1.0);
   EXPECT_DOUBLE_EQ(transformOf("#target").data[1], 0.0);
   EXPECT_DOUBLE_EQ(transformOf("#nearby").data[0], 1.0);
@@ -675,8 +666,7 @@ TEST_F(SelectToolTest, QuickClickOnUnselectedBackgroundStillSelectsIt) {
   tool.onMouseDown(app, Vector2d(5.0, 5.0), MouseModifiers{});
   tool.onMouseUp(app, Vector2d(5.0, 5.0));
 
-  ASSERT_EQ(app.selectedElements().size(), 1u);
-  EXPECT_THAT(selectedElementIds(), testing::ElementsAre("background"));
+  EXPECT_THAT(selectedElementIds(), ElementsAre("background"));
 }
 
 TEST_F(SelectToolTest, MarqueeUsesShapeIntersectionNotShapeBounds) {
@@ -688,7 +678,7 @@ TEST_F(SelectToolTest, MarqueeUsesShapeIntersectionNotShapeBounds) {
   tool.onMouseMove(app, Vector2d(90.0, 90.0), /*buttonHeld=*/true);
   tool.onMouseUp(app, Vector2d(90.0, 90.0));
 
-  EXPECT_TRUE(app.selectedElements().empty())
+  EXPECT_THAT(app.selectedElements(), IsEmpty())
       << "The marquee overlaps the triangle AABB but not the filled triangle.";
 }
 
@@ -703,8 +693,7 @@ TEST_F(SelectToolTest, MarqueeReleaseSkipsLockedElements) {
   tool.onMouseMove(app, Vector2d(120.0, 120.0), /*buttonHeld=*/true);
   tool.onMouseUp(app, Vector2d(120.0, 120.0));
 
-  ASSERT_EQ(app.selectedElements().size(), 1u);
-  EXPECT_THAT(selectedElementIds(), testing::ElementsAre("target"));
+  EXPECT_THAT(selectedElementIds(), ElementsAre("target"));
 }
 
 TEST_F(SelectToolTest, MarqueeDoesNotSelectShapeThatContainsDragBox) {
@@ -717,8 +706,7 @@ TEST_F(SelectToolTest, MarqueeDoesNotSelectShapeThatContainsDragBox) {
   tool.onMouseMove(app, Vector2d(95.0, 95.0), /*buttonHeld=*/true);
   tool.onMouseUp(app, Vector2d(95.0, 95.0));
 
-  ASSERT_EQ(app.selectedElements().size(), 1u);
-  EXPECT_THAT(selectedElementIds(), testing::ElementsAre("target"));
+  EXPECT_THAT(selectedElementIds(), ElementsAre("target"));
 }
 
 TEST_F(SelectToolTest, MarqueeGrowsToCoverDraggedRect) {
@@ -754,7 +742,7 @@ TEST_F(SelectToolTest, MarqueeReleaseSelectsIntersectingElements) {
 
   EXPECT_FALSE(tool.isMarqueeing());
   EXPECT_FALSE(tool.marqueeRect().has_value());
-  EXPECT_EQ(app.selectedElements().size(), 2u);
+  EXPECT_THAT(app.selectedElements(), SizeIs(2u));
 }
 
 TEST_F(SelectToolTest, MarqueeReleaseSelectsOneWhenOnlyOneIntersects) {
@@ -762,8 +750,7 @@ TEST_F(SelectToolTest, MarqueeReleaseSelectsOneWhenOnlyOneIntersects) {
   tool.onMouseMove(app, Vector2d(50.0, 50.0), /*buttonHeld=*/true);
   tool.onMouseUp(app, Vector2d(50.0, 50.0));
 
-  ASSERT_EQ(app.selectedElements().size(), 1u);
-  EXPECT_THAT(selectedElementIds(), testing::ElementsAre("r1"));
+  EXPECT_THAT(selectedElementIds(), ElementsAre("r1"));
 }
 
 TEST_F(SelectToolTest, MarqueeReleaseSelectsZeroWhenEmpty) {
@@ -772,7 +759,7 @@ TEST_F(SelectToolTest, MarqueeReleaseSelectsZeroWhenEmpty) {
   tool.onMouseDown(app, Vector2d(60.0, 60.0), MouseModifiers{});
   tool.onMouseMove(app, Vector2d(80.0, 80.0), /*buttonHeld=*/true);
   tool.onMouseUp(app, Vector2d(80.0, 80.0));
-  EXPECT_TRUE(app.selectedElements().empty());
+  EXPECT_THAT(app.selectedElements(), IsEmpty());
 }
 
 TEST_F(SelectToolTest, PlainDragFromEmptySpaceWithExistingSelectionStartsMarquee) {
@@ -789,8 +776,7 @@ TEST_F(SelectToolTest, PlainDragFromEmptySpaceWithExistingSelectionStartsMarquee
 
   EXPECT_FALSE(tool.isMarqueeing());
   EXPECT_FALSE(tool.marqueeRect().has_value());
-  ASSERT_EQ(app.selectedElements().size(), 1u);
-  EXPECT_THAT(selectedElementIds(), testing::ElementsAre("r2"));
+  EXPECT_THAT(selectedElementIds(), ElementsAre("r2"));
 }
 
 TEST_F(SelectToolTest, PlainDragStartingOnSelectedShapeDoesNotStartMarquee) {
@@ -824,7 +810,7 @@ TEST_F(SelectToolTest, ShiftMarqueeAppendsToSelection) {
   // Pre-select r1.
   tool.onMouseDown(app, Vector2d(15.0, 15.0), MouseModifiers{});
   tool.onMouseUp(app, Vector2d(15.0, 15.0));
-  ASSERT_EQ(app.selectedElements().size(), 1u);
+  ASSERT_THAT(app.selectedElements(), SizeIs(1u));
 
   // Shift+marquee over r2.
   MouseModifiers shift;
@@ -834,7 +820,7 @@ TEST_F(SelectToolTest, ShiftMarqueeAppendsToSelection) {
   tool.onMouseUp(app, Vector2d(145.0, 145.0));
 
   // Both should now be selected.
-  EXPECT_EQ(app.selectedElements().size(), 2u);
+  EXPECT_THAT(app.selectedElements(), SizeIs(2u));
 }
 
 TEST_F(SelectToolTest, ShiftMarqueeOverAlreadySelectedDoesNotDuplicate) {
@@ -845,14 +831,14 @@ TEST_F(SelectToolTest, ShiftMarqueeOverAlreadySelectedDoesNotDuplicate) {
   shift.shift = true;
   tool.onMouseDown(app, Vector2d(120.0, 120.0), shift);
   tool.onMouseUp(app, Vector2d(120.0, 120.0));
-  ASSERT_EQ(app.selectedElements().size(), 2u);
+  ASSERT_THAT(app.selectedElements(), SizeIs(2u));
 
   // Shift+marquee over r1 (already selected). `addToSelection` is
   // idempotent, so the size shouldn't grow.
   tool.onMouseDown(app, Vector2d(0.0, 0.0), shift);
   tool.onMouseMove(app, Vector2d(50.0, 50.0), /*buttonHeld=*/true);
   tool.onMouseUp(app, Vector2d(50.0, 50.0));
-  EXPECT_EQ(app.selectedElements().size(), 2u);
+  EXPECT_THAT(app.selectedElements(), SizeIs(2u));
 }
 
 // ── Multi-select drag ───────────────────────────────────────────────────────
@@ -865,7 +851,7 @@ TEST_F(SelectToolTest, ShiftMarqueeOverAlreadySelectedDoesNotDuplicate) {
 TEST_F(SelectToolTest, MultiSelectDragMovesAllSelectedElements) {
   // Marquee-select both rects.
   app.setSelection(std::vector<svg::SVGElement>{elementById("#r1"), elementById("#r2")});
-  ASSERT_EQ(app.selectedElements().size(), 2u);
+  ASSERT_THAT(app.selectedElements(), SizeIs(2u));
 
   const Transform2d r1Start = transformOf("#r1");
   const Transform2d r2Start = transformOf("#r2");
@@ -873,7 +859,7 @@ TEST_F(SelectToolTest, MultiSelectDragMovesAllSelectedElements) {
   // Click-drag on r1 (an already-selected element). Both should move.
   tool.onMouseDown(app, Vector2d(15.0, 15.0), MouseModifiers{});
   ASSERT_TRUE(tool.isDragging()) << "click on selected element starts a drag";
-  EXPECT_EQ(app.selectedElements().size(), 2u)
+  EXPECT_THAT(app.selectedElements(), SizeIs(2u))
       << "selection preserved — clicking an already-selected element does not collapse";
   const auto moveGestureBeforeMove = tool.activeGesturePreview();
   ASSERT_TRUE(moveGestureBeforeMove.has_value());
@@ -900,22 +886,22 @@ TEST_F(SelectToolTest, MultiSelectDragMovesAllSelectedElements) {
 TEST_F(SelectToolTest, ClickOnUnselectedElementCollapsesMultiSelection) {
   // Marquee-select both.
   app.setSelection(std::vector<svg::SVGElement>{elementById("#r1"), elementById("#r2")});
-  ASSERT_EQ(app.selectedElements().size(), 2u);
+  ASSERT_THAT(app.selectedElements(), SizeIs(2u));
 
   // Click on r1 — already in selection — the "grab any, move all" case:
   // selection preserved.
   tool.onMouseDown(app, Vector2d(15.0, 15.0), MouseModifiers{});
-  EXPECT_EQ(app.selectedElements().size(), 2u);
+  EXPECT_THAT(app.selectedElements(), SizeIs(2u));
   tool.onMouseUp(app, Vector2d(15.0, 15.0));
 
   // Reset to multi-selection. Now click on empty space BETWEEN the rects so
   // the marquee path clears selection. Re-select and then click r1.
   app.setSelection(std::vector<svg::SVGElement>{elementById("#r1"), elementById("#r2")});
-  ASSERT_EQ(app.selectedElements().size(), 2u);
+  ASSERT_THAT(app.selectedElements(), SizeIs(2u));
 
   // Now simulate "click on a different selected element" (r2): still preserves.
   tool.onMouseDown(app, Vector2d(120.0, 120.0), MouseModifiers{});
-  EXPECT_EQ(app.selectedElements().size(), 2u)
+  EXPECT_THAT(app.selectedElements(), SizeIs(2u))
       << "clicking on r2 (also in selection) preserves the whole selection";
   tool.onMouseUp(app, Vector2d(120.0, 120.0));
 }
@@ -923,7 +909,7 @@ TEST_F(SelectToolTest, ClickOnUnselectedElementCollapsesMultiSelection) {
 TEST_F(SelectToolTest, SingleSelectionStaysSingleWhenDragged) {
   // Only r1 selected. Click-drag on r1 → single-element drag, no extras.
   app.setSelection(elementById("#r1"));
-  ASSERT_EQ(app.selectedElements().size(), 1u);
+  ASSERT_THAT(app.selectedElements(), SizeIs(1u));
 
   const Transform2d r1Start = transformOf("#r1");
   const Transform2d r2Start = transformOf("#r2");
@@ -964,7 +950,7 @@ TEST_F(SelectToolTest, MultiSelectDragPreservesExtraElementTransforms) {
   r2Handle.setTransform(Transform2d::Translate(Vector2d(5.0, 7.0)));
 
   app.setSelection(std::vector<svg::SVGElement>{elementById("#r1"), elementById("#r2")});
-  ASSERT_EQ(app.selectedElements().size(), 2u);
+  ASSERT_THAT(app.selectedElements(), SizeIs(2u));
 
   const Transform2d r1Start = transformOf("#r1");
   const Transform2d r2Start = transformOf("#r2");
@@ -1471,7 +1457,7 @@ TEST_F(SelectToolTest, OptionCanToggleCenterResizeDuringResize) {
 
 TEST_F(SelectToolTest, MultiSelectionCornerResizeUsesCombinedBounds) {
   app.setSelection(std::vector<svg::SVGElement>{elementById("#r1"), elementById("#r2")});
-  ASSERT_EQ(app.selectedElements().size(), 2u);
+  ASSERT_THAT(app.selectedElements(), SizeIs(2u));
 
   const Box2d r1StartBounds = worldBoundsOf("#r1");
   const Box2d r2StartBounds = worldBoundsOf("#r2");

--- a/donner/editor/tests/SourceSelection_tests.cc
+++ b/donner/editor/tests/SourceSelection_tests.cc
@@ -1,5 +1,6 @@
 #include "donner/editor/SourceSelection.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <fstream>
@@ -17,6 +18,10 @@
 
 namespace donner::editor {
 namespace {
+
+using ::testing::ElementsAre;
+using ::testing::IsEmpty;
+using ::testing::ResultOf;
 
 RcString ElementId(const svg::SVGElement& element) {
   return element.withReadAccess(
@@ -169,8 +174,7 @@ TEST(SourceSelectionTest, ExcludesSelectedElementsFromSourceHoverCandidates) {
   const std::vector<svg::SVGElement> filtered = ExcludeSelectedSourceHoverElements(
       {*group, *rect}, std::span<const svg::SVGElement>(&*rect, 1));
 
-  ASSERT_EQ(filtered.size(), 1u);
-  EXPECT_EQ(filtered.front().id(), "layer");
+  EXPECT_THAT(filtered, ElementsAre(ResultOf("ElementId", ElementId, RcString("layer"))));
 }
 
 TEST(SourceSelectionTest, ExcludesDocumentRootFromSourceHoverCandidates) {
@@ -183,11 +187,10 @@ TEST(SourceSelectionTest, ExcludesDocumentRootFromSourceHoverCandidates) {
 
   std::vector<svg::SVGElement> filtered =
       ExcludeDocumentRootSourceHoverElement({root, *rect}, document);
-  ASSERT_EQ(filtered.size(), 1u);
-  EXPECT_EQ(filtered.front().id(), "target");
+  EXPECT_THAT(filtered, ElementsAre(ResultOf("ElementId", ElementId, RcString("target"))));
 
   filtered = ExcludeDocumentRootSourceHoverElement({root}, document);
-  EXPECT_TRUE(filtered.empty());
+  EXPECT_THAT(filtered, IsEmpty());
 }
 
 TEST(SourceSelectionTest, RootSvgStillResolvesAtSourceOffsetForExplicitSelection) {

--- a/donner/editor/tests/TextTool_tests.cc
+++ b/donner/editor/tests/TextTool_tests.cc
@@ -1,5 +1,7 @@
 #include "donner/editor/TextTool.h"
 
+#include <gmock/gmock.h>
+
 #include <string>
 #include <string_view>
 
@@ -12,6 +14,8 @@
 
 namespace donner::editor {
 namespace {
+
+using ::testing::ElementsAre;
 
 constexpr std::string_view kEmptySvg =
     R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"></svg>)";
@@ -72,8 +76,7 @@ TEST_F(TextToolTest, InsertSelectsNewText) {
   tool.onMouseDown(app, Vector2d(20.0, 30.0), MouseModifiers{});
   ASSERT_TRUE(app.flushFrame());
 
-  ASSERT_EQ(app.selectedElements().size(), 1u);
-  EXPECT_EQ(app.selectedElements().front(), text());
+  EXPECT_THAT(app.selectedElements(), ElementsAre(svg::SVGElement(text())));
   ASSERT_TRUE(tool.insertedTextElement().has_value());
   EXPECT_EQ(*tool.insertedTextElement(), svg::SVGElement(text()));
 }
@@ -93,8 +96,7 @@ TEST_F(TextToolTest, UndoRemovesAndRestoresSelection) {
   ASSERT_TRUE(app.flushFrame());
 
   EXPECT_FALSE(hasTextElement());
-  ASSERT_EQ(app.selectedElements().size(), 1u);
-  EXPECT_EQ(app.selectedElements().front(), *rect);
+  EXPECT_THAT(app.selectedElements(), ElementsAre(*rect));
 }
 
 TEST_F(TextToolTest, RedoReinsertsAndSelects) {
@@ -109,8 +111,7 @@ TEST_F(TextToolTest, RedoReinsertsAndSelects) {
   ASSERT_TRUE(app.flushFrame());
 
   ASSERT_TRUE(hasTextElement());
-  ASSERT_EQ(app.selectedElements().size(), 1u);
-  EXPECT_EQ(app.selectedElements().front(), text());
+  EXPECT_THAT(app.selectedElements(), ElementsAre(svg::SVGElement(text())));
 }
 
 TEST_F(TextToolTest, SetTextContentUpdatesNode) {


### PR DESCRIPTION
- Convert editor selection collection assertions from size/front checks to gMock collection matchers.
- Add reusable test helpers for selected element IDs, locked-element checks, and source-delta length diagnostics.
- Apply the pattern across `SelectTool`, `TextTool`, `LayersPanel`, `SourceSelection`, and `DocumentSyncController` tests.

Stacked on #735 (`test-diagnostics-after-object-state`).

## Validation

- `tools/llm-bazel-wrap.sh test //donner/editor/tests:document_sync_controller_tests //donner/editor/tests:source_selection_tests //donner/editor/tests:select_tool_tests //donner/editor/tests:text_tool_tests //donner/editor/tests:layers_panel_tests`
- `tools/llm-bazel-wrap.sh test //...`
- `python3 tools/cmake/gen_cmakelists.py --check`