### PR TITLE
Improve editor app test diagnostics

### DIFF
--- a/donner/editor/tests/EditorApp_tests.cc
+++ b/donner/editor/tests/EditorApp_tests.cc
@@ -22,6 +22,11 @@
 namespace donner::editor {
 namespace {
 
+using ::testing::ElementsAre;
+using ::testing::Eq;
+using ::testing::IsEmpty;
+using ::testing::SizeIs;
+
 constexpr std::string_view kTrivialSvg =
     R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
          <rect id="r1" x="10" y="10" width="20" height="20" fill="red"/>
@@ -246,9 +251,8 @@ TEST(EditorAppTest, MarqueeHitTestRectUnderConcurrentDomHoldsAccess) {
   const std::vector<svg::SVGGeometryElement> hits =
       app.hitTestRect(Box2d(Vector2d(0.0, 0.0), Vector2d(40.0, 40.0)));
 
-  ASSERT_EQ(hits.size(), 1u);
   app.document().document().withReadAccess(
-      [&](svg::DocumentReadAccess&) { EXPECT_EQ(hits.front().id(), "r1"); });
+      [&](svg::DocumentReadAccess&) { EXPECT_THAT(ElementIds(hits), ElementsAre("r1")); });
 }
 
 TEST(EditorAppTest, ApplyMutationFlowsThroughDocument) {
@@ -261,9 +265,9 @@ TEST(EditorAppTest, ApplyMutationFlowsThroughDocument) {
   app.applyMutation(
       EditorCommand::SetTransformCommand(*rect, Transform2d::Translate(Vector2d(99.0, 0.0))));
 
-  EXPECT_EQ(app.document().queue().size(), 1u);
+  EXPECT_THAT(app.document().queue().size(), Eq(1u));
   EXPECT_TRUE(app.flushFrame());
-  EXPECT_EQ(app.document().queue().size(), 0u);
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
 }
 
 TEST(EditorAppTest, SelectionSetAndClear) {
@@ -277,11 +281,11 @@ TEST(EditorAppTest, SelectionSetAndClear) {
   EXPECT_TRUE(app.hasSelection());
   ASSERT_TRUE(app.selectedElement().has_value());
   EXPECT_TRUE(*app.selectedElement() == *r1);
-  EXPECT_EQ(app.selectedElements().size(), 1u);
+  EXPECT_THAT(app.selectedElements(), ElementsAre(*r1));
 
   app.setSelection(std::nullopt);
   EXPECT_FALSE(app.hasSelection());
-  EXPECT_TRUE(app.selectedElements().empty());
+  EXPECT_THAT(app.selectedElements(), IsEmpty());
 }
 
 // Multi-select API (Milestone 4 of the editor UX design doc): a
@@ -299,7 +303,7 @@ TEST(EditorAppTest, MultiSelectionStoresEveryElement) {
 
   app.setSelection(std::vector<svg::SVGElement>{*r1, *r2});
   EXPECT_TRUE(app.hasSelection());
-  EXPECT_THAT(ElementIds(app.selectedElements()), ::testing::ElementsAre("r1", "r2"));
+  EXPECT_THAT(ElementIds(app.selectedElements()), ElementsAre("r1", "r2"));
   // Single-element compat: returns the *first* element.
   ASSERT_TRUE(app.selectedElement().has_value());
   EXPECT_TRUE(*app.selectedElement() == *r1);
@@ -307,7 +311,7 @@ TEST(EditorAppTest, MultiSelectionStoresEveryElement) {
   // clearSelection reads as the natural opposite of "set N elements".
   app.clearSelection();
   EXPECT_FALSE(app.hasSelection());
-  EXPECT_TRUE(app.selectedElements().empty());
+  EXPECT_THAT(app.selectedElements(), IsEmpty());
   EXPECT_FALSE(app.selectedElement().has_value());
 }
 
@@ -323,9 +327,7 @@ TEST(EditorAppTest, SelectableElementsReturnsEveryGeometryElement) {
   // "Select All" returns both rects regardless of position, in document order — the same selectable
   // set marquee selection uses.
   const std::vector<svg::SVGElement> selectable = app.selectableElements();
-  ASSERT_EQ(selectable.size(), 2u);
-  EXPECT_EQ(selectable.at(0), *r1);
-  EXPECT_EQ(selectable.at(1), *r2);
+  EXPECT_THAT(selectable, ElementsAre(*r1, *r2));
 }
 
 TEST(EditorAppTest, SelectableElementsExcludesNonGeometryNodes) {
@@ -341,13 +343,12 @@ TEST(EditorAppTest, SelectableElementsExcludesNonGeometryNodes) {
   ASSERT_TRUE(r1.has_value());
 
   const std::vector<svg::SVGElement> selectable = app.selectableElements();
-  ASSERT_EQ(selectable.size(), 1u);
-  EXPECT_EQ(selectable.at(0), *r1);
+  EXPECT_THAT(selectable, ElementsAre(*r1));
 }
 
 TEST(EditorAppTest, SelectableElementsIsEmptyWithoutDocument) {
   EditorApp app;
-  EXPECT_TRUE(app.selectableElements().empty());
+  EXPECT_THAT(app.selectableElements(), IsEmpty());
 }
 
 TEST(EditorAppTest, ToggleInSelectionAddsThenRemoves) {
@@ -385,7 +386,7 @@ TEST(EditorAppTest, AddToSelectionIsIdempotent) {
   app.addToSelection(*r1);
   app.addToSelection(*r1);
   app.addToSelection(*r1);
-  EXPECT_EQ(app.selectedElements().size(), 1u);
+  EXPECT_THAT(app.selectedElements(), ElementsAre(*r1));
 }
 
 TEST(EditorAppTest, SetAttributeOnSelectionQueuesEverySelectedElement) {
@@ -399,7 +400,7 @@ TEST(EditorAppTest, SetAttributeOnSelectionQueuesEverySelectedElement) {
   app.setSelection(std::vector<svg::SVGElement>{*r1, *r2});
 
   ASSERT_TRUE(app.setAttributeOnSelection("fill", "#112233"));
-  EXPECT_EQ(app.document().queue().size(), 2u);
+  EXPECT_THAT(app.document().queue().size(), Eq(2u));
   ASSERT_TRUE(app.flushFrame());
 
   auto updatedR1 = app.document().document().querySelector("#r1");
@@ -416,7 +417,7 @@ TEST(EditorAppTest, EmptySelectionMutatorsReturnFalseWithoutQueueingCommands) {
 
   EXPECT_FALSE(app.setAttributeOnSelection("fill", "#112233"));
   EXPECT_FALSE(app.setStylePropertyOnSelection("fill", "#112233"));
-  EXPECT_EQ(app.document().queue().size(), 0u);
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
 }
 
 TEST(EditorAppTest, SetStylePropertyOnSelectionMergesIntoStyleAttribute) {
@@ -434,7 +435,7 @@ TEST(EditorAppTest, SetStylePropertyOnSelectionMergesIntoStyleAttribute) {
   app.setSelection(*r1);
 
   ASSERT_TRUE(app.setStylePropertyOnSelection("fill", "#112233"));
-  EXPECT_EQ(app.document().queue().size(), 1u);
+  EXPECT_THAT(app.document().queue().size(), Eq(1u));
   ASSERT_TRUE(app.flushFrame());
 
   auto updatedR1 = app.document().document().querySelector("#r1");
@@ -474,7 +475,7 @@ TEST(EditorAppTest, SetStylePropertyOnSelectionSkipsUnparseableDeclarations) {
   app.setSelection(*r1);
 
   EXPECT_FALSE(app.setStylePropertyOnSelection("", "#112233"));
-  EXPECT_EQ(app.document().queue().size(), 0u);
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
 }
 
 TEST(EditorAppTest, SetStrokeWidthOnSelectionClampsNegativeValues) {
@@ -695,7 +696,7 @@ TEST(EditorAppTest, UnbundleCompoundPathReplacesExplicitTargetAndRestoresUndoSel
   EXPECT_TRUE(app.compoundPathUnbundleAvailability(*compound).canApply);
 
   ASSERT_TRUE(app.unbundleCompoundPath(*compound));
-  ASSERT_EQ(app.selectedElements().size(), 2u);
+  ASSERT_THAT(app.selectedElements(), SizeIs(2u));
   for (const svg::SVGElement& selected : app.selectedElements()) {
     ASSERT_TRUE(selected.isa<svg::SVGPathElement>());
     EXPECT_FALSE(selected.getAttribute("id").has_value());
@@ -719,8 +720,8 @@ TEST(EditorAppTest, UnbundleCompoundPathReplacesExplicitTargetAndRestoresUndoSel
   app.undo();
   ASSERT_TRUE(app.flushFrame());
   EXPECT_TRUE(app.document().document().querySelector("#compound").has_value());
-  EXPECT_EQ(RootPathChildren(app).size(), 1u);
-  EXPECT_THAT(ElementIds(app.selectedElements()), ::testing::ElementsAre("compound"));
+  EXPECT_THAT(RootPathChildren(app), SizeIs(1u));
+  EXPECT_THAT(ElementIds(app.selectedElements()), ElementsAre("compound"));
 }
 
 TEST(EditorAppTest, UnbundleCompoundPathReleasesNestedHoleContours) {
@@ -789,7 +790,7 @@ TEST(EditorAppTest, PathUnionReplacesSelectionWithBooleanPath) {
   app.setSelection(std::vector<svg::SVGElement>{*r1, *r2});
 
   ASSERT_TRUE(app.applyPathOperation(PathOperationKind::Union));
-  ASSERT_EQ(app.selectedElements().size(), 1u);
+  ASSERT_THAT(app.selectedElements(), SizeIs(1u));
   ASSERT_TRUE(app.selectedElements().front().isa<svg::SVGPathElement>());
   EXPECT_EQ(std::string_view(app.selectedElements().front().cast<svg::SVGPathElement>().d()),
             "M 10 10 L 30 10 L 30 30 L 10 30 Z M 50 50 L 70 50 L 70 70 L 50 70 Z");
@@ -880,8 +881,8 @@ TEST(EditorAppTest, PathIntersectUnavailableWhenBoundsDoNotOverlap) {
   EXPECT_FALSE(app.pathOperationAvailability(PathOperationKind::Intersect).canApply);
   EXPECT_FALSE(app.applyPathOperation(PathOperationKind::Intersect));
   EXPECT_EQ(app.document().document().source(), sourceBefore);
-  EXPECT_EQ(app.document().queue().size(), 0u);
-  EXPECT_EQ(app.selectedElements().size(), 2u);
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
+  EXPECT_THAT(app.selectedElements(), SizeIs(2u));
   EXPECT_EQ(app.undoTimeline().entryCount(), 0u);
 }
 
@@ -906,8 +907,8 @@ TEST(EditorAppTest, EmptyPathIntersectLeavesDocumentUnchanged) {
   EXPECT_TRUE(app.pathOperationAvailability(PathOperationKind::Intersect).canApply);
   EXPECT_FALSE(app.applyPathOperation(PathOperationKind::Intersect));
   EXPECT_EQ(app.document().document().source(), sourceBefore);
-  EXPECT_EQ(app.document().queue().size(), 0u);
-  EXPECT_EQ(app.selectedElements().size(), 2u);
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
+  EXPECT_THAT(app.selectedElements(), SizeIs(2u));
   EXPECT_EQ(app.undoTimeline().entryCount(), 0u);
 }
 
@@ -1239,7 +1240,7 @@ TEST(EditorAppTest, PathOperationsHandleOverlappingDonnerLetters) {
     EXPECT_TRUE(app.applyPathOperation(operation));
     EXPECT_TRUE(app.flushFrame());
 
-    EXPECT_EQ(app.selectedElements().size(), 1u);
+    EXPECT_THAT(app.selectedElements(), SizeIs(1u));
     if (app.selectedElements().empty() ||
         !app.selectedElements().front().isa<svg::SVGPathElement>()) {
       return std::optional<Path>();
@@ -1297,7 +1298,7 @@ TEST(EditorAppTest, HitTestRectFindsAllIntersectingElements) {
   // r1 lives at (10,10..30,30), r2 at (50,50..70,70). A marquee
   // covering the full document grabs both.
   auto bothHits = app.hitTestRect(Box2d::FromXYWH(0.0, 0.0, 100.0, 100.0));
-  EXPECT_EQ(bothHits.size(), 2u);
+  EXPECT_THAT(ElementIds(bothHits), ElementsAre("r1", "r2"));
 
   // A marquee that only overlaps r1 returns just r1.
   auto r1Only = app.hitTestRect(Box2d::FromXYWH(5.0, 5.0, 20.0, 20.0));
@@ -1305,7 +1306,7 @@ TEST(EditorAppTest, HitTestRectFindsAllIntersectingElements) {
 
   // A marquee that misses both returns empty.
   auto noHits = app.hitTestRect(Box2d::FromXYWH(80.0, 80.0, 5.0, 5.0));
-  EXPECT_TRUE(noHits.empty());
+  EXPECT_THAT(noHits, IsEmpty());
 
   // Edge contact (marquee touches r1's edge) counts as intersection.
   auto edgeHits = app.hitTestRect(Box2d::FromXYWH(30.0, 30.0, 5.0, 5.0));

--- a/donner/editor/tests/EditorSync_tests.cc
+++ b/donner/editor/tests/EditorSync_tests.cc
@@ -1,3 +1,5 @@
+#include <gmock/gmock.h>
+
 #include <cstddef>
 #include <optional>
 #include <string>
@@ -21,6 +23,15 @@
 
 namespace donner::editor {
 namespace {
+
+using ::testing::AllOf;
+using ::testing::ElementsAre;
+using ::testing::Eq;
+using ::testing::Field;
+using ::testing::Gt;
+using ::testing::IsEmpty;
+using ::testing::Not;
+using ::testing::SizeIs;
 
 constexpr std::string_view kCircleSvg =
     R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
@@ -433,7 +444,7 @@ TEST(EditorSyncTest, DeleteMutationWritesElementRemovalBackToSource) {
   ASSERT_TRUE(app.flushFrame());
 
   auto pendingRemove = app.consumeElementRemoveWritebacks();
-  ASSERT_EQ(pendingRemove.size(), 1u);
+  ASSERT_THAT(pendingRemove, SizeIs(1u));
   ASSERT_TRUE(ApplyElementRemoveWriteback(&source, pendingRemove.front().target));
   EXPECT_EQ(source.find("id=\"a\""), std::string::npos);
   EXPECT_NE(source.find("id=\"b\""), std::string::npos);
@@ -575,7 +586,7 @@ TEST(EditorSyncTest, DeleteWritebackReparseRefreshesFollowingElementLocation) {
   ASSERT_TRUE(app.flushFrame());
 
   auto pendingRemove = app.consumeElementRemoveWritebacks();
-  ASSERT_EQ(pendingRemove.size(), 1u);
+  ASSERT_THAT(pendingRemove, SizeIs(1u));
   ASSERT_TRUE(QueueElementRemoveWritebackReparse(
       app, &source, &previousSourceText, &lastWritebackSourceText, pendingRemove.front().target));
 
@@ -615,7 +626,7 @@ TEST(EditorSyncTest, StructuredSourceEditAppliesThroughXMLDocumentWithoutCommand
 
   EXPECT_TRUE(dispatch.dispatchedMutation);
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
-  EXPECT_TRUE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
   EXPECT_FALSE(app.flushFrame());
   EXPECT_GT(app.document().currentFrameVersion(), previousFrameVersion);
   EXPECT_EQ(app.document().document().source(), kEditedSvg);
@@ -663,7 +674,7 @@ TEST(EditorSyncTest, StructuredSourceEditInsertsChildElementIncrementally) {
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
   // Incremental: a fallback would queue a ReplaceDocumentCommand, which would make
   // flushFrame() return true. An incremental apply queues nothing.
-  EXPECT_TRUE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
   EXPECT_FALSE(app.flushFrame());
 
   EXPECT_EQ(app.document().document().source(), editedSource);
@@ -704,7 +715,7 @@ TEST(EditorSyncTest, StructuredSourceEditDeletesChildElementIncrementally) {
 
   EXPECT_TRUE(dispatch.dispatchedMutation);
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
-  EXPECT_TRUE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
   EXPECT_FALSE(app.flushFrame());
 
   EXPECT_EQ(app.document().document().source(), editedSource);
@@ -769,7 +780,7 @@ TEST(EditorSyncTest, StructuredSourceEditingIsDefaultForNewEditorApps) {
 
   EXPECT_TRUE(dispatch.dispatchedMutation);
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
-  EXPECT_TRUE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
   EXPECT_FALSE(app.flushFrame());
   EXPECT_EQ(app.document().document().source(), kEditedSvg);
 }
@@ -792,7 +803,7 @@ TEST(EditorSyncTest, StructuredSourceEditingRuntimeOptOutUsesDocumentReplace) {
 
   EXPECT_TRUE(dispatch.dispatchedMutation);
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
-  EXPECT_FALSE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Gt(0u));
   ASSERT_TRUE(app.flushFrame());
   EXPECT_TRUE(app.document().lastFlushResult().replacedDocument);
   EXPECT_EQ(app.document().document().source(), kEditedSvg);
@@ -816,7 +827,7 @@ TEST(EditorSyncTest, StructuredMalformedOpeningTagEditDoesNotQueueReplaceDocumen
 
   EXPECT_TRUE(dispatch.dispatchedMutation);
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
-  EXPECT_TRUE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
   EXPECT_FALSE(app.flushFrame());
   EXPECT_EQ(app.document().document().source(), kEditedSvg);
   ASSERT_TRUE(app.document().lastParseError().has_value());
@@ -850,7 +861,7 @@ TEST(EditorSyncTest, StructuredOpeningTagRecoveryClearsDiagnosticWithoutCommand)
 
   EXPECT_TRUE(dispatch.dispatchedMutation);
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
-  EXPECT_TRUE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
   EXPECT_FALSE(app.flushFrame());
   EXPECT_EQ(app.document().document().source(), kSvg);
   EXPECT_EQ(app.document().lastParseError(), std::nullopt);
@@ -876,7 +887,7 @@ TEST(EditorSyncTest, DispatchSourceTextChangeNoOpDoesNotDispatch) {
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
   EXPECT_EQ(previousSourceText, kCircleSvg);
   EXPECT_FALSE(lastWritebackSourceText.has_value());
-  EXPECT_TRUE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
 }
 
 TEST(EditorSyncTest, DispatchSourceEditIntentsSkipsSelfWritebackEcho) {
@@ -896,7 +907,7 @@ TEST(EditorSyncTest, DispatchSourceEditIntentsSkipsSelfWritebackEcho) {
   EXPECT_TRUE(dispatch.skippedSelfWriteback);
   EXPECT_EQ(previousSourceText, kCircleAt40Svg);
   EXPECT_FALSE(lastWritebackSourceText.has_value());
-  EXPECT_TRUE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
 }
 
 TEST(EditorSyncTest, DispatchSourceEditIntentsNoOpDoesNotApplyStaleIntent) {
@@ -915,7 +926,7 @@ TEST(EditorSyncTest, DispatchSourceEditIntentsNoOpDoesNotApplyStaleIntent) {
   EXPECT_FALSE(dispatch.dispatchedMutation);
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
   EXPECT_EQ(previousSourceText, kCircleSvg);
-  EXPECT_TRUE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
 }
 
 TEST(EditorSyncTest, DispatchSourceEditIntentsEmptyListDelegatesToTextChange) {
@@ -935,7 +946,7 @@ TEST(EditorSyncTest, DispatchSourceEditIntentsEmptyListDelegatesToTextChange) {
 
   EXPECT_TRUE(dispatch.dispatchedMutation);
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
-  EXPECT_TRUE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
   EXPECT_FALSE(app.flushFrame());
   EXPECT_EQ(app.document().document().source(), kEditedSvg);
   EXPECT_EQ(previousSourceText, kEditedSvg);
@@ -958,7 +969,7 @@ TEST(EditorSyncTest, DispatchSourceEditIntentsInvalidIntentQueuesDocumentReplace
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
   EXPECT_EQ(previousSourceText, kCircleAt40Svg);
   EXPECT_FALSE(lastWritebackSourceText.has_value());
-  EXPECT_FALSE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Gt(0u));
   ASSERT_TRUE(app.flushFrame());
   EXPECT_TRUE(app.document().lastFlushResult().replacedDocument);
   EXPECT_EQ(app.document().document().source(), kCircleAt40Svg);
@@ -987,7 +998,7 @@ TEST(EditorSyncTest, DispatchSourceEditIntentsStructuredOptOutQueuesDocumentRepl
 
   EXPECT_TRUE(dispatch.dispatchedMutation);
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
-  EXPECT_FALSE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Gt(0u));
   ASSERT_TRUE(app.flushFrame());
   EXPECT_TRUE(app.document().lastFlushResult().replacedDocument);
   EXPECT_EQ(app.document().document().source(), kEditedSvg);
@@ -1018,7 +1029,7 @@ TEST(EditorSyncTest, DispatchSourceEditIntentsFinalMismatchQueuesDocumentReplace
   EXPECT_TRUE(dispatch.dispatchedMutation);
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
   EXPECT_EQ(app.document().document().source(), kIntentSvg);
-  EXPECT_FALSE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Gt(0u));
   ASSERT_TRUE(app.flushFrame());
   EXPECT_TRUE(app.document().lastFlushResult().replacedDocument);
   EXPECT_EQ(app.document().document().source(), kNewSvg);
@@ -1050,7 +1061,7 @@ TEST(EditorSyncTest, DispatchSourceEditIntentsAppliesMultipleStructuredEdits) {
 
   EXPECT_TRUE(dispatch.dispatchedMutation);
   EXPECT_FALSE(dispatch.skippedSelfWriteback);
-  EXPECT_TRUE(app.document().queue().empty());
+  EXPECT_THAT(app.document().queue().size(), Eq(0u));
   EXPECT_FALSE(app.flushFrame());
   EXPECT_EQ(app.document().document().source(), kEditedSvg);
   EXPECT_EQ(previousSourceText, kEditedSvg);
@@ -1084,10 +1095,11 @@ TEST(EditorSyncTest, SelfInitiatedWritebackDoesNotDispatchDuplicateReplaceDocume
   EXPECT_TRUE(dispatch.skippedSelfWriteback);
 
   auto effective = app.document().queue().flush();
-  ASSERT_EQ(effective.effectiveCommands.size(), 1u);
-  EXPECT_EQ(effective.effectiveCommands.front().kind, EditorCommand::Kind::ReplaceDocument);
-  EXPECT_EQ(effective.effectiveCommands.front().bytes, source);
-  EXPECT_TRUE(effective.effectiveCommands.front().preserveUndoOnReparse);
+  EXPECT_THAT(effective.effectiveCommands,
+              ElementsAre(AllOf(
+                  Field("kind", &EditorCommand::kind, EditorCommand::Kind::ReplaceDocument),
+                  Field("bytes", &EditorCommand::bytes, source),
+                  Field("preserveUndoOnReparse", &EditorCommand::preserveUndoOnReparse, true))));
   EXPECT_TRUE(effective.hadReplaceDocument);
   EXPECT_TRUE(effective.preserveUndoOnReparse);
 }
@@ -1144,7 +1156,7 @@ TEST(EditorSyncTest, SelectionClearsAndDisplayedBoundsClearWhenElementDisappears
   const std::uint64_t initialVersion = app.document().currentFrameVersion();
   RefreshSelectionBoundsCache(cache, std::span<const svg::SVGElement>(app.selectedElements()),
                               initialVersion, initialVersion);
-  ASSERT_FALSE(cache.displayedBoundsDoc.empty());
+  ASSERT_THAT(cache.displayedBoundsDoc, Not(IsEmpty()));
 
   app.applyMutation(
       EditorCommand::ReplaceDocumentCommand("<svg xmlns=\"http://www.w3.org/2000/svg\"/>"));
@@ -1153,7 +1165,7 @@ TEST(EditorSyncTest, SelectionClearsAndDisplayedBoundsClearWhenElementDisappears
 
   RefreshSelectionBoundsCache(cache, std::span<const svg::SVGElement>(app.selectedElements()),
                               app.document().currentFrameVersion(), initialVersion);
-  EXPECT_TRUE(cache.displayedBoundsDoc.empty());
+  EXPECT_THAT(cache.displayedBoundsDoc, IsEmpty());
 }
 
 // Interleave of drag + source-pane edit + undo. The user:


### PR DESCRIPTION
- Convert editor app queue and selection cardinality checks to gMock matchers.
- Replace hit-test and selectable-vector size/front assertions with whole-collection expectations.
- Upgrade `EditorSync` command queue and bounds-cache assertions to field-aware gMock matchers.

Stacked on #736 (`test-diagnostics-after-editor-diagnostics`).

## Validation

- `tools/llm-bazel-wrap.sh test //donner/editor/tests:editor_app_tests //donner/editor/tests:editor_sync_tests`
- `tools/llm-bazel-wrap.sh test //...`
- `python3 tools/cmake/gen_cmakelists.py --check`