### PR TITLE
Improve editor tool test diagnostics

### DIFF
--- a/donner/editor/tests/PenTool_tests.cc
+++ b/donner/editor/tests/PenTool_tests.cc
@@ -56,6 +56,16 @@ MATCHER_P(BoxContainingPoint, point,
   return false;
 }
 
+MATCHER(NonEmptyRendererBitmap, "a non-empty RendererBitmap") {
+  if (!arg.empty()) {
+    return true;
+  }
+
+  *result_listener << "dimensions=(" << arg.dimensions.x << ", " << arg.dimensions.y
+                   << "), pixels=" << arg.pixels.size() << ", rowBytes=" << arg.rowBytes;
+  return false;
+}
+
 /// Capture pen-path overlay chrome the same way the editor does on a click frame.
 SelectionChromeSnapshot CapturePenChromeSnapshot(EditorApp& app) {
   return OverlayRenderer::captureChromeSnapshot(
@@ -807,7 +817,7 @@ TEST_F(PenToolTest, FirstClickStartsNewPathUnderConcurrentDom) {
   tool.onMouseDown(app, Vector2d(10.0, 20.0), MouseModifiers{});
   ASSERT_TRUE(app.flushFrame());
 
-  ASSERT_EQ(app.selectedElements().size(), 1u);
+  ASSERT_THAT(app.selectedElements(), testing::SizeIs(1u));
   // Verify the result through a scoped read guard, exactly as the live editor
   // reads the selected element under ConcurrentDom (raw `d()` here would itself
   // trip the release assert).
@@ -1024,10 +1034,10 @@ TEST_F(PenToolLiveSyncTest, FillChangeOnNewPathUpdatesRenderedPixels) {
 
   ASSERT_TRUE(tool.commitOpenPath(app));
   Settle();
-  ASSERT_EQ(app.selectedElements().size(), 1u);
+  ASSERT_THAT(app.selectedElements(), testing::SizeIs(1u));
 
   const svg::RendererBitmap beforeFill = RenderDocument();
-  ASSERT_FALSE(beforeFill.empty());
+  ASSERT_THAT(beforeFill, NonEmptyRendererBitmap());
   const std::array<std::uint8_t, 4> beforePixel = PixelAt(beforeFill, 24, 24);
   ASSERT_THAT(beforePixel, svg::test::Alpha(::testing::Lt(16)))
       << "The repro starts with an unfilled, unstroked Pen-created triangle; pixel was "
@@ -1037,12 +1047,12 @@ TEST_F(PenToolLiveSyncTest, FillChangeOnNewPathUpdatesRenderedPixels) {
   Settle();
 
   const std::string source(app.document().document().source());
-  EXPECT_NE(source.find("fill: #ff0000"), std::string::npos)
+  EXPECT_THAT(source, testing::HasSubstr("fill: #ff0000"))
       << "The source pane update must include the selected path fill change:\n"
       << source;
 
   const svg::RendererBitmap afterFill = RenderDocument();
-  ASSERT_FALSE(afterFill.empty());
+  ASSERT_THAT(afterFill, NonEmptyRendererBitmap());
   const std::array<std::uint8_t, 4> afterPixel = PixelAt(afterFill, 24, 24);
   EXPECT_THAT(afterPixel, svg::test::Rgba(::testing::Gt(200), ::testing::Lt(40), ::testing::Lt(40),
                                           ::testing::Gt(200)))
@@ -1070,10 +1080,10 @@ TEST_F(PenToolLiveSyncTest, FillChangeOnClosedNewPathUpdatesRenderedPixels) {
   tool.onMouseUp(app, Vector2d(10.0, 10.0));
   Settle();
   ASSERT_FALSE(tool.isDrafting());
-  ASSERT_EQ(app.selectedElements().size(), 1u);
+  ASSERT_THAT(app.selectedElements(), testing::SizeIs(1u));
 
   const svg::RendererBitmap beforeFill = RenderDocument();
-  ASSERT_FALSE(beforeFill.empty());
+  ASSERT_THAT(beforeFill, NonEmptyRendererBitmap());
   const std::array<std::uint8_t, 4> beforePixel = PixelAt(beforeFill, 24, 24);
   ASSERT_THAT(beforePixel, svg::test::Alpha(::testing::Lt(16)))
       << "The repro starts with an unfilled, unstroked closed Pen path; pixel was "
@@ -1083,7 +1093,7 @@ TEST_F(PenToolLiveSyncTest, FillChangeOnClosedNewPathUpdatesRenderedPixels) {
   Settle();
 
   const std::string source(app.document().document().source());
-  EXPECT_NE(source.find("fill: #ff0000"), std::string::npos)
+  EXPECT_THAT(source, testing::HasSubstr("fill: #ff0000"))
       << "The source pane update must include the selected closed-path fill change:\n"
       << source;
 
@@ -1096,7 +1106,7 @@ TEST_F(PenToolLiveSyncTest, FillChangeOnClosedNewPathUpdatesRenderedPixels) {
       << source;
 
   const svg::RendererBitmap afterFill = RenderDocument();
-  ASSERT_FALSE(afterFill.empty());
+  ASSERT_THAT(afterFill, NonEmptyRendererBitmap());
   const std::array<std::uint8_t, 4> afterPixel = PixelAt(afterFill, 24, 24);
   EXPECT_THAT(afterPixel, svg::test::Rgba(::testing::Gt(200), ::testing::Lt(40), ::testing::Lt(40),
                                           ::testing::Gt(200)))
@@ -1118,10 +1128,10 @@ TEST_F(PenToolLiveSyncTest, FillChangeOnDraftPathUpdatesRenderedPixels) {
   tool.onMouseDown(app, Vector2d(10.0, 80.0), MouseModifiers{});
   Settle();
   ASSERT_TRUE(tool.isDrafting());
-  ASSERT_EQ(app.selectedElements().size(), 1u);
+  ASSERT_THAT(app.selectedElements(), testing::SizeIs(1u));
 
   const svg::RendererBitmap beforeFill = RenderDocument();
-  ASSERT_FALSE(beforeFill.empty());
+  ASSERT_THAT(beforeFill, NonEmptyRendererBitmap());
   const std::array<std::uint8_t, 4> beforePixel = PixelAt(beforeFill, 24, 24);
   ASSERT_THAT(beforePixel, svg::test::Alpha(::testing::Lt(16)))
       << "The repro starts with an unfilled, unstroked Pen draft; pixel was "
@@ -1131,12 +1141,12 @@ TEST_F(PenToolLiveSyncTest, FillChangeOnDraftPathUpdatesRenderedPixels) {
   Settle();
 
   const std::string source(app.document().document().source());
-  EXPECT_NE(source.find("fill: #ff0000"), std::string::npos)
+  EXPECT_THAT(source, testing::HasSubstr("fill: #ff0000"))
       << "The source pane update must include the selected draft path fill change:\n"
       << source;
 
   const svg::RendererBitmap afterFill = RenderDocument();
-  ASSERT_FALSE(afterFill.empty());
+  ASSERT_THAT(afterFill, NonEmptyRendererBitmap());
   const std::array<std::uint8_t, 4> afterPixel = PixelAt(afterFill, 24, 24);
   EXPECT_THAT(afterPixel, svg::test::Rgba(::testing::Gt(200), ::testing::Lt(40), ::testing::Lt(40),
                                           ::testing::Gt(200)))

--- a/donner/editor/tests/RenderPaneClick_tests.cc
+++ b/donner/editor/tests/RenderPaneClick_tests.cc
@@ -1,12 +1,14 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <optional>
 #include <ostream>
 #include <string_view>
 
 #include "donner/editor/EditorApp.h"
 #include "donner/editor/SelectTool.h"
 #include "donner/editor/ViewportState.h"
+#include "donner/svg/SVGElement.h"
 #include "donner/svg/SVGGraphicsElement.h"
 
 namespace donner::editor {
@@ -20,6 +22,7 @@ namespace {
 using ::testing::AllOf;
 using ::testing::DoubleNear;
 using ::testing::Field;
+using ::testing::UnorderedElementsAre;
 
 // Two non-overlapping rects in a 200x200 viewBox. r1 is in the
 // top-left quadrant, r2 in the bottom-right. The test sets the
@@ -367,6 +370,10 @@ TEST(RenderPaneClickTest, MainLoopClickDragSequenceMovesElement) {
 TEST(RenderPaneClickTest, MarqueeDragUpwardSelectsIntersectingElements) {
   EditorApp app;
   ASSERT_TRUE(app.loadFromString(kTwoRectSvg));
+  const std::optional<svg::SVGElement> r1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(r1.has_value());
+  const std::optional<svg::SVGElement> r2 = app.document().document().querySelector("#r2");
+  ASSERT_TRUE(r2.has_value());
   ViewportState v = MakeViewportFor(app, Vector2d::Zero(), Vector2d(800.0, 600.0));
 
   SelectTool tool;
@@ -394,7 +401,7 @@ TEST(RenderPaneClickTest, MarqueeDragUpwardSelectsIntersectingElements) {
   tool.onMouseUp(app, v.screenToDocument(screenEnd));
   EXPECT_FALSE(tool.isMarqueeing());
   EXPECT_FALSE(tool.marqueeRect().has_value());
-  EXPECT_EQ(app.selectedElements().size(), 2u)
+  EXPECT_THAT(app.selectedElements(), UnorderedElementsAre(*r1, *r2))
       << "Upward marquee should select both elements just like a downward marquee does";
 }
 

--- a/donner/editor/tests/TextInspectorPanel_tests.cc
+++ b/donner/editor/tests/TextInspectorPanel_tests.cc
@@ -1,5 +1,6 @@
 #include "donner/editor/TextInspectorPanel.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <optional>
@@ -66,7 +67,7 @@ TEST_F(TextInspectorPanelTest, RendersSelectedTextUnderConcurrentDomWithoutCrash
   ImGui::Render();
 
   // Reaching here means the access-assert did not abort the process.
-  EXPECT_EQ(app.selectedElements().size(), 1u);
+  EXPECT_THAT(app.selectedElements(), ::testing::ElementsAre(*text));
 }
 
 }  // namespace


### PR DESCRIPTION
- Convert remaining editor tool selection cardinality checks to gMock matchers.
- Assert exact selected elements for the render pane marquee regression.
- Add a named non-empty renderer bitmap matcher for PenTool live-sync render guards and use `HasSubstr` for source writeback checks.

## Validation

- `tools/llm-bazel-wrap.sh test //donner/editor/tests:pen_tool_tests //donner/editor/tests:render_pane_click_tests //donner/editor/tests:text_inspector_panel_tests`
- `tools/llm-bazel-wrap.sh test //...`
- `python3 tools/cmake/gen_cmakelists.py --check`