### PR TITLE
Improve editor texture test diagnostics

### DIFF
--- a/donner/editor/tests/EditorWindow_tests.cc
+++ b/donner/editor/tests/EditorWindow_tests.cc
@@ -1,5 +1,6 @@
 #include "donner/editor/gui/EditorWindow.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -52,6 +53,7 @@ namespace {
 #if defined(DONNER_EDITOR_WGPU)
 using svg::test::Near;
 using svg::test::Rgba;
+using ::testing::SizeIs;
 
 std::array<std::uint8_t, 4> PixelAt(const svg::RendererBitmap& bitmap, int x, int y) {
   const std::size_t offset =
@@ -777,7 +779,7 @@ TEST(EditorWindowTest, WgpuPresentsFilledPenCreatedPromotedLayerAfterStyleMutati
   ASSERT_TRUE(app.flushFrame());
   ASSERT_TRUE(penTool.commitOpenPath(app));
   ASSERT_TRUE(app.flushFrame());
-  ASSERT_EQ(app.selectedElements().size(), 1u);
+  ASSERT_THAT(app.selectedElements(), SizeIs(1u));
   const Entity targetEntity = app.selectedElements().front().unsafeEntityHandle().entity();
 
   const std::optional<RenderResult> before = RenderSelectedPromotedPreview(
@@ -882,7 +884,7 @@ TEST(EditorWindowTest, WgpuPresentsFilledSplashPenLayerAfterStyleMutation) {
   penTool.onMouseDown(app, Vector2d(313.0, 121.5), MouseModifiers{.pixelsPerDocUnit = 1.0});
   ASSERT_TRUE(app.flushFrame());
   ASSERT_FALSE(penTool.isDrafting());
-  ASSERT_EQ(app.selectedElements().size(), 1u);
+  ASSERT_THAT(app.selectedElements(), SizeIs(1u));
   const Entity targetEntity = app.selectedElements().front().unsafeEntityHandle().entity();
 
   const std::optional<RenderResult> before = RenderSelectedPromotedPreview(
@@ -985,7 +987,7 @@ TEST(EditorWindowTest, WgpuPenFillReplayViewportPublishesFilledLayerTile) {
   ASSERT_TRUE(app.flushFrame());
   penTool.onMouseDown(app, Vector2d(392.0, 228.5), MouseModifiers{.pixelsPerDocUnit = 1.0});
   ASSERT_TRUE(app.flushFrame());
-  ASSERT_EQ(app.selectedElements().size(), 1u);
+  ASSERT_THAT(app.selectedElements(), SizeIs(1u));
   const Entity targetEntity = app.selectedElements().front().unsafeEntityHandle().entity();
 
   const EditorRasterViewport replayRasterViewport =
@@ -1111,7 +1113,7 @@ TEST(EditorWindowTest, WgpuPenFillLiveSourceSyncPublishesFilledLayerTile) {
   penTool.onMouseDown(app, Vector2d(10.0, 10.0), MouseModifiers{.pixelsPerDocUnit = 1.0});
   settle();
   ASSERT_FALSE(penTool.isDrafting());
-  ASSERT_EQ(app.selectedElements().size(), 1u);
+  ASSERT_THAT(app.selectedElements(), SizeIs(1u));
   const Entity targetEntity = app.selectedElements().front().unsafeEntityHandle().entity();
 
   const std::optional<RenderResult> before = RenderSelectedPromotedPreview(
@@ -1262,7 +1264,7 @@ TEST(EditorWindowTest, WgpuPresentsUploadedStraightAlphaBitmapWithStraightBlend)
   GlTextureCache textures(window.geodeDevice());
   textures.initialize();
   textures.uploadComposited(preview);
-  ASSERT_EQ(textures.tiles().size(), 1u);
+  ASSERT_THAT(textures.tiles(), SizeIs(1u));
   ASSERT_NE(textures.tiles().front().texture, 0);
 
   window.beginFrame();
@@ -1479,7 +1481,7 @@ TEST(EditorWindowTest, WgpuPremultipliedTextureSurvivesOnePresentationOwnerRetir
   transientOwner.initialize();
   liveOwner.uploadComposited(sharedSnapshotPreview());
   transientOwner.uploadComposited(sharedSnapshotPreview());
-  ASSERT_EQ(liveOwner.tiles().size(), 1u);
+  ASSERT_THAT(liveOwner.tiles(), SizeIs(1u));
   ASSERT_NE(liveOwner.tiles().front().texture, 0);
   const ImTextureID liveTexture = liveOwner.tiles().front().texture;
 

--- a/donner/editor/tests/GlTextureCache_tests.cc
+++ b/donner/editor/tests/GlTextureCache_tests.cc
@@ -18,6 +18,7 @@ namespace {
 using ::testing::ElementsAre;
 using ::testing::Field;
 using ::testing::IsEmpty;
+using ::testing::SizeIs;
 
 class PayloadTextureSnapshot final : public svg::RendererTextureSnapshot {
 public:
@@ -322,7 +323,7 @@ TEST(GlTextureCacheTest, UnboundedUploadRetainsSeparateOverviewAcrossBoundedUplo
 
   GlTextureCache cache(device);
   cache.uploadComposited(overviewPreview, RasterViewportForTest(/*viewportBounded=*/false));
-  ASSERT_EQ(cache.tiles().size(), 1u);
+  ASSERT_THAT(cache.tiles(), SizeIs(1u));
   ASSERT_THAT(cache.overviewTiles(), ElementsAre(TileRasterCanvasSizeIs(Vector2i(100, 100))));
   EXPECT_FALSE(cache.activeTilesViewportBounded());
 
@@ -340,7 +341,7 @@ TEST(GlTextureCacheTest, UnboundedUploadRetainsSeparateOverviewAcrossBoundedUplo
 
   cache.uploadComposited(boundedPreview, RasterViewportForTest(/*viewportBounded=*/true));
 
-  ASSERT_EQ(cache.tiles().size(), 1u);
+  ASSERT_THAT(cache.tiles(), SizeIs(1u));
   ASSERT_THAT(cache.overviewTiles(), ElementsAre(TileRasterCanvasSizeIs(Vector2i(100, 100))));
   EXPECT_TRUE(cache.activeTilesViewportBounded());
   const PresentationCoverageDiagnostics coverage = cache.coverageDiagnostics();
@@ -375,7 +376,7 @@ TEST(GlTextureCacheTest, OverviewUploadDoesNotReplaceActiveBoundedTiles) {
 
   GlTextureCache cache(device);
   cache.uploadComposited(boundedPreview, RasterViewportForTest(/*viewportBounded=*/true));
-  ASSERT_EQ(cache.tiles().size(), 1u);
+  ASSERT_THAT(cache.tiles(), SizeIs(1u));
   EXPECT_THAT(cache.overviewTiles(), IsEmpty());
 
   int overviewDestructionCount = 0;


### PR DESCRIPTION
- Convert editor window selection/tile size guards to `ASSERT_THAT(..., SizeIs(...))` before `front()` access.
- Convert GlTextureCache tile count guards to gMock matchers for better collection diagnostics.

## Validation

- `tools/llm-bazel-wrap.sh test //donner/editor/tests:editor_window_tests //donner/editor/tests:gl_texture_cache_tests`
- `tools/llm-bazel-wrap.sh test --config=geode //donner/editor/tests:gl_texture_cache_tests`
- `tools/llm-bazel-wrap.sh test //...`
- `python3 tools/cmake/gen_cmakelists.py --check`