### PR TITLE
Document PR summary heading convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,9 +98,11 @@ When creating a pull request:
 3. **For fuzzer-sensitive changes**, run `bazel test --config=asan-fuzzer <fuzzer target>`. macOS needs this config because Apple Clang lacks `libclang_rt.fuzzer_osx.a`; `--config=asan-fuzzer` activates the LLVM 21 toolchain which provides it.
 4. **Monitor CI and code review by default for every created PR** — whenever you create or open a PR, automatically keep monitoring CI status, merge conflicts, and review comments every ~7 minutes until the PR is green and reviewed; do not wait for a separate user prompt. For PR monitoring, the policy is to check both comments and CI/status checks on each ~7-minute pass until the PR has stabilized. For draft PRs, keep monitoring CI and mergeability, but do not expect CR/review comments until the PR is published and out of draft. Use `gh pr checks <number>` and `gh api repos/jwmcglynn/donner/pulls/<number>/comments` when `gh` is authenticated, or the GitHub connector equivalents when `gh` is unavailable.
 5. **No agent branding in PR titles** — do not prefix pull request titles with `[codex]`, agent names, or other tool branding. Use a plain project-style title that describes the change.
-6. **Expect a Codex code review** within the first few minutes after the PR is published and out of draft — address feedback promptly by pushing follow-up commits. If Codex finds no issues it will approve the PR (👍 / APPROVED state). A Codex approval alone is not sufficient to merge — a `jwmcglynn` review is always required.
-7. **Transient CI failures** (apt/bazel fetch/chromium rate-limits) are retried automatically. Test, compile, linker, and pixel-diff failures are never transient — investigate the root cause, don't re-run blindly.
-8. **Fix CI diagnosability gaps** — if a CI failure cannot be diagnosed because logs, test output,
+6. **Omit `## Summary` in PR descriptions** — the first paragraph or bullet list is implicitly the
+   summary, so start with the summary content directly instead of adding a redundant heading.
+7. **Expect a Codex code review** within the first few minutes after the PR is published and out of draft — address feedback promptly by pushing follow-up commits. If Codex finds no issues it will approve the PR (👍 / APPROVED state). A Codex approval alone is not sufficient to merge — a `jwmcglynn` review is always required.
+8. **Transient CI failures** (apt/bazel fetch/chromium rate-limits) are retried automatically. Test, compile, linker, and pixel-diff failures are never transient — investigate the root cause, don't re-run blindly.
+9. **Fix CI diagnosability gaps** — if a CI failure cannot be diagnosed because logs, test output,
    screenshots, undeclared outputs, pixel diffs, artifacts, or job summaries are missing or
    inaccessible, treat that as a CI bug and fix the workflow/test harness to expose the missing
    evidence. Do not leave failures opaque or rely on blind reruns when better GitHub Actions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,8 @@
 - **NEVER merge a PR without explicit operator approval.** AI agents may open, update, and review PRs, but must not run `gh pr merge` (or merge via any other means) unless the operator approved merging that specific PR in the current conversation. Green CI does not constitute approval.
 - **Always squash-and-merge** when merging PRs (post-approval). Use `gh pr merge --squash`.
 - Never use merge commits or rebase-and-merge on this repository.
+- **Omit `## Summary` in PR descriptions.** The first paragraph or bullet list is implicitly the
+  summary, so start directly with the summary content.
 
 ## AI Comment Convention
 


### PR DESCRIPTION
- Add a PR workflow rule that descriptions should omit the redundant `## Summary` heading.
- Mirror the convention in `CLAUDE.md` so the short LLM PR rules match `AGENTS.md`.

## Validation

- Docs-only change; no build run.
- `git diff --check`