### PR TITLE
Improve editor coordinator test diagnostics

### DIFF
--- a/donner/editor/tests/DragCoalesce_tests.cc
+++ b/donner/editor/tests/DragCoalesce_tests.cc
@@ -27,6 +27,7 @@
 #include "donner/editor/DragCoalesce.h"
 
 #define IMGUI_DEFINE_MATH_OPERATORS
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <optional>
@@ -37,6 +38,16 @@
 
 namespace donner::editor {
 namespace {
+
+using ::testing::AllOf;
+using ::testing::ElementsAre;
+using ::testing::Field;
+using ::testing::FloatEq;
+using ::testing::IsEmpty;
+
+auto ImVec2Is(float x, float y) {
+  return AllOf(Field("x", &ImVec2::x, FloatEq(x)), Field("y", &ImVec2::y, FloatEq(y)));
+}
 
 // First post is always allowed: there's no prior position recorded
 // and no in-flight future yet.
@@ -137,28 +148,22 @@ TEST(ShouldPostDragMove, HighRateRemoteStreamPostsAtMostOneMovePerRoundTrip) {
     EXPECT_FALSE(
         maybePost(ImVec2(100.0f + static_cast<float>(i) * 0.1f, 100.0f), /*pending=*/true));
   }
-  EXPECT_TRUE(postedPoints.empty());
+  EXPECT_THAT(postedPoints, IsEmpty());
   ASSERT_TRUE(lastPosted.has_value());
-  EXPECT_FLOAT_EQ(lastPosted->x, 100.0f);
-  EXPECT_FLOAT_EQ(lastPosted->y, 100.0f);
+  EXPECT_THAT(*lastPosted, ImVec2Is(100.0f, 100.0f));
 
   EXPECT_TRUE(maybePost(ImVec2(200.0f, 100.0f), /*pending=*/false));
-  ASSERT_EQ(postedPoints.size(), 1u);
-  EXPECT_FLOAT_EQ(postedPoints.back().x, 200.0f);
-  EXPECT_FLOAT_EQ(postedPoints.back().y, 100.0f);
+  EXPECT_THAT(postedPoints, ElementsAre(ImVec2Is(200.0f, 100.0f)));
 
   for (int i = 1; i <= 1000; ++i) {
     EXPECT_FALSE(
         maybePost(ImVec2(200.0f + static_cast<float>(i) * 0.1f, 100.0f), /*pending=*/true));
   }
-  ASSERT_EQ(postedPoints.size(), 1u);
-  EXPECT_FLOAT_EQ(lastPosted->x, 200.0f);
-  EXPECT_FLOAT_EQ(lastPosted->y, 100.0f);
+  EXPECT_THAT(postedPoints, ElementsAre(ImVec2Is(200.0f, 100.0f)));
+  EXPECT_THAT(*lastPosted, ImVec2Is(200.0f, 100.0f));
 
   EXPECT_TRUE(maybePost(ImVec2(300.0f, 100.0f), /*pending=*/false));
-  ASSERT_EQ(postedPoints.size(), 2u);
-  EXPECT_FLOAT_EQ(postedPoints.back().x, 300.0f);
-  EXPECT_FLOAT_EQ(postedPoints.back().y, 100.0f);
+  EXPECT_THAT(postedPoints, ElementsAre(ImVec2Is(200.0f, 100.0f), ImVec2Is(300.0f, 100.0f)));
 }
 
 }  // namespace

--- a/donner/editor/tests/RenderCoordinator_tests.cc
+++ b/donner/editor/tests/RenderCoordinator_tests.cc
@@ -30,7 +30,10 @@
 namespace donner::editor {
 namespace {
 
+using ::testing::ElementsAre;
 using ::testing::IsEmpty;
+using ::testing::Not;
+using ::testing::SizeIs;
 
 // gtest cannot stream the untyped `entt::null_t` sentinel, so compare against a
 // concrete `Entity`-typed null. This keeps EXPECT_EQ's self-diagnosing output
@@ -448,11 +451,10 @@ TEST(RenderCoordinatorTest, RefreshSelectionBoundsCacheCapturesSelection) {
 
   coordinator.refreshSelectionBoundsCache(app);
   const SelectionBoundsCache& cache = coordinator.selectionBoundsCache();
-  ASSERT_EQ(cache.lastSelection.size(), 1u);
-  EXPECT_TRUE(cache.lastSelection.front() == r1);
+  EXPECT_THAT(cache.lastSelection, ElementsAre(r1));
   EXPECT_EQ(cache.lastRefreshVersion, app.document().currentFrameVersion());
   // The single selected rect has renderable geometry → one pending bound.
-  ASSERT_EQ(cache.pendingBoundsDoc.size(), 1u);
+  ASSERT_THAT(cache.pendingBoundsDoc, SizeIs(1u));
   // r1 lives at (10,10..30,30) in document space.
   EXPECT_THAT(cache.pendingBoundsDoc.front().topLeft.x, ::testing::DoubleNear(10.0, 1e-6));
   EXPECT_THAT(cache.pendingBoundsDoc.front().topLeft.y, ::testing::DoubleNear(10.0, 1e-6));
@@ -470,12 +472,12 @@ TEST(RenderCoordinatorTest, PromoteSelectionBoundsNoOpUntilDisplayedVersionCatch
   // document version is >= 1, so the pending bounds cannot promote yet.
   ASSERT_GT(app.document().currentFrameVersion(), 0u);
   ASSERT_EQ(coordinator.displayedDocVersion(), 0u);
-  ASSERT_FALSE(coordinator.selectionBoundsCache().pendingBoundsDoc.empty());
+  ASSERT_THAT(coordinator.selectionBoundsCache().pendingBoundsDoc, Not(IsEmpty()));
 
   coordinator.promoteSelectionBoundsIfReady();
   EXPECT_THAT(coordinator.selectionBoundsCache().displayedBoundsDoc, IsEmpty())
       << "Pending bounds must not promote while displayedDocVersion lags the pending version.";
-  EXPECT_FALSE(coordinator.selectionBoundsCache().pendingBoundsDoc.empty())
+  EXPECT_THAT(coordinator.selectionBoundsCache().pendingBoundsDoc, Not(IsEmpty()))
       << "Unpromoted pending bounds must be retained for a later catch-up.";
 }
 
@@ -495,7 +497,7 @@ TEST(RenderCoordinatorTest, ResetForLoadedDocumentClearsCachesAndOverlayState) {
       QuerySelector(app, "#r1").unsafeEntityHandle().entity(), /*version=*/1, Vector2i(100, 100));
   coordinator.setSourceHoverElements({QuerySelector(app, "#r2")});
 
-  ASSERT_FALSE(coordinator.selectionBoundsCache().lastSelection.empty());
+  ASSERT_THAT(coordinator.selectionBoundsCache().lastSelection, Not(IsEmpty()));
   ASSERT_TRUE(coordinator.compositedPresentation().hasCachedTextures());
 
   coordinator.resetForLoadedDocument();
@@ -536,7 +538,7 @@ TEST(RenderCoordinatorTest, RasterizeOverlayPublishesImmediateSnapshot) {
   EXPECT_TRUE(coordinator.rasterizeOverlayForCurrentSelection(app, viewport,
                                                               /*marqueeRectDoc=*/std::nullopt));
   ASSERT_TRUE(coordinator.immediateOverlaySnapshot().has_value());
-  EXPECT_EQ(coordinator.immediateOverlaySnapshot()->paths.size(), 1u);
+  EXPECT_THAT(coordinator.immediateOverlaySnapshot()->paths, SizeIs(1u));
 }
 
 TEST(RenderCoordinatorTest, RasterizeOverlaySkipsUnchangedImmediateSnapshot) {


### PR DESCRIPTION
- Convert DragCoalesce posted-point vector checks to whole-vector gMock matchers with an `ImVec2` matcher.
- Convert RenderCoordinator selection/cache collection guards to gMock matchers before `front()` access.

## Validation

- `tools/llm-bazel-wrap.sh test //donner/editor/tests:drag_coalesce_tests //donner/editor/tests:render_coordinator_tests`
- `tools/llm-bazel-wrap.sh test //...`
- `python3 tools/cmake/gen_cmakelists.py --check`