### PR TITLE
Improve editor conversion result test diagnostics

### DIFF
--- a/donner/editor/tests/AsyncRenderer_tests.cc
+++ b/donner/editor/tests/AsyncRenderer_tests.cc
@@ -50,8 +50,10 @@ using svg::test::Rgba;
 using ::testing::AllOf;
 using ::testing::Contains;
 using ::testing::DoubleNear;
+using ::testing::ElementsAre;
 using ::testing::Field;
 using ::testing::Gt;
+using ::testing::SizeIs;
 
 bool IsGraphicsElement(const svg::SVGElement& element) {
   return element.withReadAccess([&element](svg::DocumentReadAccess&, EntityHandle) {
@@ -88,13 +90,70 @@ Entity SelectedGraphicsEntity(EditorApp& app) {
   return app.selectedElement()->unsafeEntityHandle().entity();
 }
 
-std::string ElementId(const svg::SVGElement& element) {
-  return element.withReadAccess(
-      [&element](svg::DocumentReadAccess&, EntityHandle) { return std::string(element.id()); });
-}
-
 bool HasPresentationPayload(const RenderResult::CompositedTile& tile) {
   return !tile.bitmap.empty() || tile.textureSnapshot != nullptr;
+}
+
+MATCHER_P(DragTargetLayerTileFor, entity,
+          std::string("a drag-target layer tile for entity ") + testing::PrintToString(entity)) {
+  if (arg.isDragTarget && arg.layerEntity == entity) {
+    return true;
+  }
+
+  *result_listener << "id=" << testing::PrintToString(arg.id)
+                   << ", kind=" << static_cast<int>(arg.kind)
+                   << ", layerEntity=" << testing::PrintToString(arg.layerEntity)
+                   << ", isDragTarget=" << testing::PrintToString(arg.isDragTarget);
+  return false;
+}
+
+MATCHER(EmptyRendererBitmap, "an empty renderer bitmap") {
+  if (arg.empty()) {
+    return true;
+  }
+
+  *result_listener << "dimensions=(" << arg.dimensions.x << ", " << arg.dimensions.y
+                   << "), pixels=" << arg.pixels.size() << ", rowBytes=" << arg.rowBytes;
+  return false;
+}
+
+MATCHER(NonEmptyRendererBitmap, "a non-empty renderer bitmap") {
+  if (!arg.empty()) {
+    return true;
+  }
+
+  *result_listener << "dimensions=(" << arg.dimensions.x << ", " << arg.dimensions.y
+                   << "), pixels=" << arg.pixels.size() << ", rowBytes=" << arg.rowBytes;
+  return false;
+}
+
+MATCHER(NullEntity, "a null entity") {
+  if (arg == entt::null) {
+    return true;
+  }
+
+  *result_listener << "entity is " << testing::PrintToString(arg);
+  return false;
+}
+
+MATCHER_P(ByteVectorEq, expected,
+          std::string("byte vector equal to ") + testing::PrintToString(expected.size()) +
+              " bytes") {
+  if (arg.size() != expected.size()) {
+    *result_listener << "size is " << arg.size();
+    return false;
+  }
+
+  const auto mismatch = std::mismatch(arg.begin(), arg.end(), expected.begin());
+  if (mismatch.first == arg.end()) {
+    return true;
+  }
+
+  const auto index = static_cast<std::size_t>(std::distance(arg.begin(), mismatch.first));
+  *result_listener << "first mismatch at byte " << index
+                   << ": actual=" << static_cast<int>(*mismatch.first)
+                   << ", expected=" << static_cast<int>(*mismatch.second);
+  return false;
 }
 
 bool TileCoversDocPoint(const RenderResult::CompositedTile& tile, const Vector2d& point) {
@@ -245,17 +304,10 @@ TEST(AsyncRendererTest, MultiSelectActiveDragMarksEverySelectedLayerAsDragTarget
   ASSERT_TRUE(result.has_value());
   ASSERT_TRUE(result->compositedPreview.has_value());
   ASSERT_TRUE(result->compositedPreview->representedDragPreview.has_value());
-  EXPECT_EQ(result->compositedPreview->representedDragPreview->extraEntities,
-            std::vector<Entity>{r2Entity});
-
-  const auto dragTileFor = [&](Entity entity) {
-    return std::ranges::find_if(result->compositedPreview->tiles,
-                                [entity](const RenderResult::CompositedTile& tile) {
-                                  return tile.isDragTarget && tile.layerEntity == entity;
-                                });
-  };
-  EXPECT_NE(dragTileFor(r1Entity), result->compositedPreview->tiles.end());
-  EXPECT_NE(dragTileFor(r2Entity), result->compositedPreview->tiles.end());
+  EXPECT_THAT(result->compositedPreview->representedDragPreview->extraEntities,
+              ElementsAre(r2Entity));
+  EXPECT_THAT(result->compositedPreview->tiles, Contains(DragTargetLayerTileFor(r1Entity)));
+  EXPECT_THAT(result->compositedPreview->tiles, Contains(DragTargetLayerTileFor(r2Entity)));
 }
 
 TEST(AsyncRendererE2ETest, UnbundledDonnerDDragMarksEveryComponentAsDragTarget) {
@@ -272,7 +324,7 @@ TEST(AsyncRendererE2ETest, UnbundledDonnerDDragMarksEveryComponentAsDragTarget) 
   ASSERT_TRUE(donnerD.has_value());
   ASSERT_TRUE(app.unbundleCompoundPath(*donnerD));
   ASSERT_TRUE(app.flushFrame());
-  ASSERT_EQ(app.selectedElements().size(), 2u);
+  ASSERT_THAT(app.selectedElements(), SizeIs(2u));
 
   const std::vector<svg::SVGElement> unbundled = app.selectedElements();
   const Entity firstEntity = unbundled[0].unsafeEntityHandle().entity();
@@ -285,7 +337,7 @@ TEST(AsyncRendererE2ETest, UnbundledDonnerDDragMarksEveryComponentAsDragTarget) 
   const std::optional<SelectTool::ActiveDragPreview> activeDrag = selectTool.activeDragPreview();
   ASSERT_TRUE(activeDrag.has_value());
   EXPECT_EQ(activeDrag->entity, firstEntity);
-  EXPECT_EQ(activeDrag->extraEntities, std::vector<Entity>{secondEntity});
+  EXPECT_THAT(activeDrag->extraEntities, ElementsAre(secondEntity));
 
   svg::Renderer renderer;
   AsyncRenderer asyncRenderer;
@@ -308,17 +360,10 @@ TEST(AsyncRendererE2ETest, UnbundledDonnerDDragMarksEveryComponentAsDragTarget) 
   ASSERT_TRUE(result.has_value());
   ASSERT_TRUE(result->compositedPreview.has_value());
   ASSERT_TRUE(result->compositedPreview->representedDragPreview.has_value());
-  EXPECT_EQ(result->compositedPreview->representedDragPreview->extraEntities,
-            std::vector<Entity>{secondEntity});
-
-  const auto dragTileFor = [&](Entity entity) {
-    return std::ranges::find_if(result->compositedPreview->tiles,
-                                [entity](const RenderResult::CompositedTile& tile) {
-                                  return tile.isDragTarget && tile.layerEntity == entity;
-                                });
-  };
-  EXPECT_NE(dragTileFor(firstEntity), result->compositedPreview->tiles.end());
-  EXPECT_NE(dragTileFor(secondEntity), result->compositedPreview->tiles.end());
+  EXPECT_THAT(result->compositedPreview->representedDragPreview->extraEntities,
+              ElementsAre(secondEntity));
+  EXPECT_THAT(result->compositedPreview->tiles, Contains(DragTargetLayerTileFor(firstEntity)));
+  EXPECT_THAT(result->compositedPreview->tiles, Contains(DragTargetLayerTileFor(secondEntity)));
 }
 
 TEST(AsyncRendererTest, FullCanvasFallbackCarriesBoundedRasterViewportGeometry) {
@@ -346,7 +391,7 @@ TEST(AsyncRendererTest, FullCanvasFallbackCarriesBoundedRasterViewportGeometry) 
   const std::optional<RenderResult> result = WaitForRenderResult(asyncRenderer);
   ASSERT_TRUE(result.has_value());
   ASSERT_TRUE(result->compositedPreview.has_value());
-  ASSERT_EQ(result->compositedPreview->tiles.size(), 1u);
+  ASSERT_THAT(result->compositedPreview->tiles, SizeIs(1u));
   const RenderResult::CompositedTile& tile = result->compositedPreview->tiles.front();
   EXPECT_EQ(tile.id, "full-canvas");
   EXPECT_EQ(tile.rasterCanvasSize, Vector2i(400, 320));
@@ -1475,24 +1520,24 @@ TEST(AsyncRendererTest, ColdRenderWithoutSelectionProducesFullCanvasCompositedTi
 
   ASSERT_TRUE(result.has_value());
   ASSERT_TRUE(result->compositedPreview.has_value());
-  ASSERT_EQ(result->compositedPreview->tiles.size(), 1u);
+  ASSERT_THAT(result->compositedPreview->tiles, SizeIs(1u));
   const RenderResult::CompositedTile& tile = result->compositedPreview->tiles.front();
   EXPECT_EQ(tile.kind, RenderResult::CompositedTile::Kind::Segment);
   EXPECT_EQ(tile.id, "full-canvas");
   EXPECT_TRUE(HasPresentationPayload(tile));
   if (renderer.requiresTextureSnapshotPresentation()) {
     ASSERT_NE(tile.textureSnapshot, nullptr);
-    EXPECT_TRUE(tile.bitmap.empty());
+    EXPECT_THAT(tile.bitmap, EmptyRendererBitmap());
     EXPECT_EQ(tile.textureSnapshot->dimensions(), Vector2i(64, 64));
   } else {
-    EXPECT_FALSE(tile.bitmap.empty());
+    EXPECT_THAT(tile.bitmap, NonEmptyRendererBitmap());
     EXPECT_EQ(tile.bitmap.dimensions, Vector2i(64, 64));
   }
   EXPECT_EQ(tile.bitmapDimsPx, Vector2i(64, 64));
   EXPECT_EQ(tile.rasterCanvasSize, Vector2i(64, 64));
   EXPECT_EQ(tile.canvasOffsetDoc, Vector2d::Zero());
   EXPECT_EQ(tile.bitmapDimsDoc, Vector2d(64.0, 64.0));
-  EXPECT_TRUE(result->compositedPreview->entity == entt::null);
+  EXPECT_THAT(result->compositedPreview->entity, NullEntity());
 }
 
 TEST(AsyncRendererTest, CompositedTilesCarryRasterCanvasSizeForCacheIdentity) {
@@ -1586,13 +1631,13 @@ TEST(AsyncRendererTest, CompositingContextDescendantsProduceFullCanvasComposited
 
     ASSERT_TRUE(result.has_value());
     ASSERT_TRUE(result->compositedPreview.has_value()) << svgBody;
-    ASSERT_EQ(result->compositedPreview->tiles.size(), 1u) << svgBody;
+    ASSERT_THAT(result->compositedPreview->tiles, SizeIs(1u)) << svgBody;
     const RenderResult::CompositedTile& tile = result->compositedPreview->tiles.front();
     EXPECT_EQ(tile.id, "full-canvas") << svgBody;
     EXPECT_TRUE(HasPresentationPayload(tile)) << svgBody;
     if (!tile.bitmap.empty()) {
       EXPECT_EQ(tile.bitmap.dimensions, result->bitmap.dimensions) << svgBody;
-      EXPECT_EQ(tile.bitmap.pixels, result->bitmap.pixels) << svgBody;
+      EXPECT_THAT(tile.bitmap.pixels, ByteVectorEq(result->bitmap.pixels)) << svgBody;
     }
     if (tile.textureSnapshot != nullptr) {
       EXPECT_EQ(tile.textureSnapshot->dimensions(), tile.bitmapDimsPx) << svgBody;
@@ -1671,7 +1716,7 @@ TEST(AsyncRendererTest, CompositorStaysAliveAcrossDragRelease) {
   const std::vector<uint8_t> promotedPixelsDrag1 = findDragTileBitmap(*drag1->compositedPreview);
   const auto promotedSignatureDrag1 = findDragTileSignature(*drag1->compositedPreview);
   if (!renderer.requiresTextureSnapshotPresentation()) {
-    ASSERT_FALSE(promotedPixelsDrag1.empty());
+    ASSERT_THAT(promotedPixelsDrag1, SizeIs(Gt(0u)));
   } else {
     EXPECT_TRUE(std::get<0>(promotedSignatureDrag1));
   }
@@ -1686,8 +1731,8 @@ TEST(AsyncRendererTest, CompositorStaysAliveAcrossDragRelease) {
   auto held = waitForResult();
   ASSERT_TRUE(held.has_value());
   ASSERT_TRUE(held->compositedPreview.has_value());
-  ASSERT_EQ(held->compositedPreview->tiles.size(), 1u);
-  EXPECT_EQ(held->compositedPreview->tiles.front().id, "full-canvas");
+  ASSERT_THAT(held->compositedPreview->tiles,
+              ElementsAre(Field("id", &RenderResult::CompositedTile::id, "full-canvas")));
 
   // Drag frame 2: same entity, same DOM transform (4, 0). If the compositor
   // were torn down between the release and this drag, it would re-rasterize
@@ -1706,7 +1751,7 @@ TEST(AsyncRendererTest, CompositorStaysAliveAcrossDragRelease) {
   ASSERT_TRUE(drag2.has_value());
   ASSERT_TRUE(drag2->compositedPreview.has_value());
   if (!renderer.requiresTextureSnapshotPresentation()) {
-    EXPECT_EQ(findDragTileBitmap(*drag2->compositedPreview), promotedPixelsDrag1)
+    EXPECT_THAT(findDragTileBitmap(*drag2->compositedPreview), ByteVectorEq(promotedPixelsDrag1))
         << "drag-target tile bitmap should be identical after release -> drag-again";
   } else {
     EXPECT_EQ(findDragTileSignature(*drag2->compositedPreview), promotedSignatureDrag1)

--- a/donner/editor/tests/ShapeClipboard_tests.cc
+++ b/donner/editor/tests/ShapeClipboard_tests.cc
@@ -22,6 +22,7 @@ namespace {
 
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
+using ::testing::IsEmpty;
 using ::testing::Not;
 
 /// Parse \p svg into a source-backed SVGDocument, asserting success.
@@ -67,7 +68,7 @@ TEST(ShapeClipboardPayload, HeaderedRoundTrip) {
   std::optional<ShapeClipboardPayload> parsed = ShapeClipboardPayload::parse(text);
   ASSERT_TRUE(parsed.has_value());
   EXPECT_EQ(parsed->svgFragment, payload.svgFragment);
-  EXPECT_EQ(parsed->sourceElementIds, payload.sourceElementIds);
+  EXPECT_THAT(parsed->sourceElementIds, ElementsAre("a", ""));
   EXPECT_FALSE(parsed->wasGroupSelection);
   ASSERT_TRUE(parsed->documentBounds.has_value());
   EXPECT_DOUBLE_EQ(parsed->documentBounds->topLeft.x, 1.0);
@@ -79,7 +80,7 @@ TEST(ShapeClipboardPayload, HeaderlessTextIsBestEffortFragment) {
   std::optional<ShapeClipboardPayload> parsed = ShapeClipboardPayload::parse(raw);
   ASSERT_TRUE(parsed.has_value());
   EXPECT_EQ(parsed->svgFragment, raw);
-  EXPECT_TRUE(parsed->sourceElementIds.empty());
+  EXPECT_THAT(parsed->sourceElementIds, IsEmpty());
   EXPECT_FALSE(parsed->documentBounds.has_value());
 }
 
@@ -132,7 +133,7 @@ TEST(ShapeClipboardCommands, CopyGroupSelectionMarksPayloadAsGroupSelection) {
   ASSERT_TRUE(payload.has_value());
   EXPECT_TRUE(payload->wasGroupSelection);
   EXPECT_THAT(payload->svgFragment, HasSubstr("<g id=\"group\">"));
-  EXPECT_THAT(payload->sourceElementIds, ::testing::ElementsAre("group"));
+  EXPECT_THAT(payload->sourceElementIds, ElementsAre("group"));
   EXPECT_FALSE(payload->documentBounds.has_value())
       << "group-only selections do not have geometry bounds of their own";
 }
@@ -171,8 +172,7 @@ TEST(ShapeClipboardCommands, PasteWithoutIdSelectsGeneratedWrapper) {
   PreparePasteResult result = preparePaste(document, payload, PastePlacement::EndOfRootOffset);
   ASSERT_TRUE(result.ok) << result.error;
 
-  ASSERT_EQ(result.pastedElementIds.size(), 1u);
-  EXPECT_EQ(result.pastedElementIds[0], "donner-paste_pasted");
+  EXPECT_THAT(result.pastedElementIds, ElementsAre("donner-paste_pasted"));
   EXPECT_THAT(result.mergedSource, HasSubstr("id=\"donner-paste_pasted\""));
 }
 
@@ -187,7 +187,7 @@ TEST(ShapeClipboardCommands, PasteRegeneratesIdsDeterministically) {
   ASSERT_TRUE(first.ok);
   ASSERT_TRUE(second.ok);
   // Same inputs → identical id assignment and merged output.
-  EXPECT_EQ(first.pastedElementIds, second.pastedElementIds);
+  EXPECT_THAT(second.pastedElementIds, ElementsAre("a_pasted", "b_pasted"));
   EXPECT_EQ(first.mergedSource, second.mergedSource);
   EXPECT_THAT(first.pastedElementIds, ElementsAre("a_pasted", "b_pasted"));
 }
@@ -202,7 +202,7 @@ TEST(ShapeClipboardCommands, PasteUniqueIdsKeepsFragmentIdsAndIgnoresIdSubstring
   PreparePasteResult result = preparePaste(document, payload, PastePlacement::EndOfRootOffset);
   ASSERT_TRUE(result.ok) << result.error;
 
-  EXPECT_THAT(result.pastedElementIds, ::testing::ElementsAre("fresh"));
+  EXPECT_THAT(result.pastedElementIds, ElementsAre("fresh"));
   EXPECT_THAT(result.mergedSource, HasSubstr("gradientid=\"ignored\""));
   EXPECT_THAT(result.mergedSource, HasSubstr("id='fresh'"));
   EXPECT_THAT(result.mergedSource, Not(HasSubstr("fresh_pasted")));
@@ -225,7 +225,7 @@ TEST(ShapeClipboardCommands, PasteRepairsUrlAndHrefReferencesToRenamedIds) {
   PreparePasteResult result = preparePaste(document, payload, PastePlacement::EndOfRootOffset);
   ASSERT_TRUE(result.ok) << result.error;
 
-  EXPECT_THAT(result.pastedElementIds, ::testing::ElementsAre("shape_pasted"));
+  EXPECT_THAT(result.pastedElementIds, ElementsAre("shape_pasted"));
   EXPECT_THAT(result.mergedSource, HasSubstr("id='grad_pasted'"));
   EXPECT_THAT(result.mergedSource, HasSubstr("fill=\"url(#grad_pasted)\""));
   EXPECT_THAT(result.mergedSource, HasSubstr("xlink:href='#shape_pasted'"));
@@ -245,7 +245,7 @@ TEST(ShapeClipboardCommands, PasteIdRepairSkipsAlreadyTakenGeneratedIds) {
   PreparePasteResult result = preparePaste(document, payload, PastePlacement::EndOfRootOffset);
   ASSERT_TRUE(result.ok) << result.error;
 
-  EXPECT_THAT(result.pastedElementIds, ::testing::ElementsAre("shape_pasted2"));
+  EXPECT_THAT(result.pastedElementIds, ElementsAre("shape_pasted2"));
   EXPECT_THAT(result.mergedSource, HasSubstr("id=\"shape_pasted2\""));
 }
 
@@ -357,7 +357,7 @@ TEST(ShapeClipboardCommands, FailedPasteLeavesDocumentUnchanged) {
   PreparePasteResult result = preparePaste(document, payload, PastePlacement::EndOfRootOffset);
   EXPECT_FALSE(result.ok);
   EXPECT_THAT(result.error, HasSubstr("missing-grad"));
-  EXPECT_TRUE(result.mergedSource.empty());
+  EXPECT_THAT(result.mergedSource, IsEmpty());
   // The destination document source is untouched (preparePaste never mutates).
   EXPECT_EQ(std::string(document.source()), sourceBefore);
 }
@@ -372,7 +372,7 @@ TEST(ShapeClipboardCommands, FailedPasteWithoutDestinationSourceText) {
 
   EXPECT_FALSE(result.ok);
   EXPECT_THAT(result.error, HasSubstr("no source text"));
-  EXPECT_TRUE(result.mergedSource.empty());
+  EXPECT_THAT(result.mergedSource, IsEmpty());
 }
 
 TEST(ShapeClipboardCommands, FailedPasteWithoutExplicitRootCloseTag) {
@@ -386,7 +386,7 @@ TEST(ShapeClipboardCommands, FailedPasteWithoutExplicitRootCloseTag) {
 
   EXPECT_FALSE(result.ok);
   EXPECT_THAT(result.error, HasSubstr("root <svg>"));
-  EXPECT_TRUE(result.mergedSource.empty());
+  EXPECT_THAT(result.mergedSource, IsEmpty());
 }
 
 TEST(ShapeClipboardCommands, FailedPasteOnMalformedFragment) {
@@ -395,7 +395,7 @@ TEST(ShapeClipboardCommands, FailedPasteOnMalformedFragment) {
   payload.svgFragment = "<rect <<< not valid";
   PreparePasteResult result = preparePaste(document, payload, PastePlacement::EndOfRootOffset);
   EXPECT_FALSE(result.ok);
-  EXPECT_TRUE(result.mergedSource.empty());
+  EXPECT_THAT(result.mergedSource, IsEmpty());
 }
 
 TEST(ShapeClipboardCommands, CopyModifyPasteRoundTripPreservesGeometryAtOffset) {

--- a/donner/editor/tests/TextToOutlines_tests.cc
+++ b/donner/editor/tests/TextToOutlines_tests.cc
@@ -32,6 +32,8 @@ namespace donner::editor {
 namespace {
 
 using ::testing::HasSubstr;
+using ::testing::IsEmpty;
+using ::testing::SizeIs;
 
 constexpr int kCanvas = 200;
 
@@ -76,7 +78,8 @@ std::string ApplyConversion(svg::SVGDocument& document, svg::SVGElement text,
   std::optional<svg::SVGElement> parent = text.parentElement();
   EXPECT_TRUE(parent.has_value());
   EXPECT_TRUE(result.outlineGroup.has_value());
-  xml::ApplySourceEditResult groupInsert = document.insertElement(*parent, *result.outlineGroup, text);
+  xml::ApplySourceEditResult groupInsert =
+      document.insertElement(*parent, *result.outlineGroup, text);
   EXPECT_FALSE(groupInsert.diagnostic.has_value())
       << groupInsert.diagnostic.value_or(ParseDiagnostic()).reason;
   for (svg::SVGElement& path : result.outlinePaths) {
@@ -128,7 +131,7 @@ TEST(TextToOutlines, EmitsOnePathPerGlyph) {
   ASSERT_TRUE(result.ok) << result.error;
 
   // "SVG" → three glyphs, none of which are whitespace, so three `<path>`s.
-  EXPECT_EQ(result.outlinePaths.size(), 3u);
+  EXPECT_THAT(result.outlinePaths, SizeIs(3u));
 }
 
 // Pixel-compare: rendering the document BEFORE conversion and AFTER conversion
@@ -253,7 +256,7 @@ TEST(TextToOutlines, EmptyOutlineFailureLeavesDocumentUnchanged) {
   EXPECT_FALSE(result.ok);
   EXPECT_THAT(result.error, HasSubstr("outline"));
   EXPECT_FALSE(result.outlineGroup.has_value());
-  EXPECT_TRUE(result.outlinePaths.empty());
+  EXPECT_THAT(result.outlinePaths, IsEmpty());
   // The document source is untouched (convertTextToOutlines never mutates).
   EXPECT_EQ(std::string(document.source()), sourceBefore);
   EXPECT_TRUE(document.querySelector("text").has_value());


### PR DESCRIPTION
- Convert ShapeClipboard payload and paste-result vectors to whole-collection gMock expectations.
- Convert empty merged-source and text-outline path result checks to `IsEmpty`/`SizeIs` diagnostics.

## Validation

- `tools/llm-bazel-wrap.sh test //donner/editor/tests:shape_clipboard_tests //donner/editor/tests:text_outline_tests`
- `tools/llm-bazel-wrap.sh test //...`
- `python3 tools/cmake/gen_cmakelists.py --check`