### PR TITLE
Improve compositor segment dirty test diagnostics

### DIFF
--- a/donner/svg/compositor/CompositorController_tests.cc
+++ b/donner/svg/compositor/CompositorController_tests.cc
@@ -23,7 +23,9 @@ using ::testing::Contains;
 using ::testing::Each;
 using ::testing::Field;
 using ::testing::HasSubstr;
+using ::testing::IsEmpty;
 using ::testing::NiceMock;
+using ::testing::Not;
 using ::testing::SizeIs;
 
 namespace donner::svg::compositor {
@@ -1857,23 +1859,23 @@ TEST_F(CompositorControllerTest, SetTightBoundedSegmentsEnabledMarksExistingSegm
   compositor.renderFrame(RenderViewport{kTestSvgDefaultSize});
 
   const auto rowsBeforeToggle = compositor.snapshotSegmentInspectorRows();
-  ASSERT_FALSE(rowsBeforeToggle.empty());
-  EXPECT_TRUE(std::none_of(rowsBeforeToggle.begin(), rowsBeforeToggle.end(),
-                           [](const auto& row) { return row.dirty; }));
+  ASSERT_THAT(rowsBeforeToggle, Not(IsEmpty()));
+  EXPECT_THAT(rowsBeforeToggle,
+              Each(Field("dirty", &CompositorController::SegmentInspectorRow::dirty, false)));
 
   compositor.setTightBoundedSegmentsEnabled(false);
   EXPECT_FALSE(compositor.tightBoundedSegmentsEnabled());
 
   const auto rowsAfterToggle = compositor.snapshotSegmentInspectorRows();
-  ASSERT_EQ(rowsAfterToggle.size(), rowsBeforeToggle.size());
-  EXPECT_TRUE(std::all_of(rowsAfterToggle.begin(), rowsAfterToggle.end(),
-                          [](const auto& row) { return row.dirty; }));
+  ASSERT_THAT(rowsAfterToggle, SizeIs(rowsBeforeToggle.size()));
+  EXPECT_THAT(rowsAfterToggle,
+              Each(Field("dirty", &CompositorController::SegmentInspectorRow::dirty, true)));
 
   compositor.setTightBoundedSegmentsEnabled(false);
   const auto rowsAfterIdempotentToggle = compositor.snapshotSegmentInspectorRows();
-  ASSERT_EQ(rowsAfterIdempotentToggle.size(), rowsAfterToggle.size());
-  EXPECT_TRUE(std::all_of(rowsAfterIdempotentToggle.begin(), rowsAfterIdempotentToggle.end(),
-                          [](const auto& row) { return row.dirty; }));
+  ASSERT_THAT(rowsAfterIdempotentToggle, SizeIs(rowsAfterToggle.size()));
+  EXPECT_THAT(rowsAfterIdempotentToggle,
+              Each(Field("dirty", &CompositorController::SegmentInspectorRow::dirty, true)));
 }
 
 TEST_F(CompositorControllerTest, CancelledRenderLeavesDirtyLayerForNextFrame) {


### PR DESCRIPTION
- Convert the tight-bounded segment dirty-state checks from `empty`, `none_of`, `all_of`, and raw size assertions to gMock collection expectations.
- Preserve row-level diagnostic output by matching segment rows with `Not(IsEmpty())`, `SizeIs`, and `Each(Field("dirty", ...))`.

## Validation

- `tools/llm-bazel-wrap.sh test //donner/svg/compositor:compositor_tests`
- `tools/llm-bazel-wrap.sh test //...`
- `python3 tools/cmake/gen_cmakelists.py --check`