### PR TITLE
Improve editor collection test diagnostics

### DIFF
--- a/donner/editor/tests/CompositedPresentation_tests.cc
+++ b/donner/editor/tests/CompositedPresentation_tests.cc
@@ -1,9 +1,12 @@
 #include "donner/editor/CompositedPresentation.h"
 
-#include "gtest/gtest.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 namespace donner::editor {
 namespace {
+
+using ::testing::ElementsAre;
 
 using Phase = CompositedPresentation::Phase;
 
@@ -308,7 +311,7 @@ TEST(CompositedPresentationTest, ActiveDragKeepsGroupedSelectionPrewarmEntities)
 
   ASSERT_TRUE(displayed.has_value());
   EXPECT_EQ(displayed->entity, Entity(7));
-  EXPECT_EQ(displayed->extraEntities, std::vector<Entity>{Entity(8)})
+  EXPECT_THAT(displayed->extraEntities, ElementsAre(Entity(8)))
       << "Selection-prewarmed grouped tiles must remain tied to the active drag group so the "
          "first live drag frames translate every unbundled component.";
   EXPECT_EQ(displayed->dragGeneration, active.dragGeneration);

--- a/donner/editor/tests/FilterDragReproTestUtils.cc
+++ b/donner/editor/tests/FilterDragReproTestUtils.cc
@@ -19,6 +19,9 @@
 
 #include "donner/editor/tests/FilterDragReproTestUtils.h"
 
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
 #include <algorithm>
 #include <chrono>
 #include <cmath>
@@ -50,10 +53,13 @@
 #include "donner/svg/compositor/ScopedCompositorHint.h"
 #include "donner/svg/renderer/Renderer.h"
 #include "donner/svg/renderer/RendererInterface.h"
-#include "gtest/gtest.h"
 
 namespace donner::editor::filter_drag_repro {
 namespace {
+
+using ::testing::IsEmpty;
+using ::testing::Not;
+using ::testing::SizeIs;
 
 bool IsGraphicsElement(const svg::SVGElement& element) {
   return element.withReadAccess([&element](svg::DocumentReadAccess&, EntityHandle) {
@@ -400,10 +406,10 @@ void RunFilterDragReproScenario(FilterDragReproResult* out) {
   }
 
   ReplayResults r = ReplayRepro(reproPath, svgPath);
-  ASSERT_FALSE(r.frames.empty()) << "repro produced zero frames";
-  ASSERT_EQ(r.mouseDownFrameIndices.size(), 2u)
+  ASSERT_THAT(r.frames, Not(IsEmpty())) << "repro produced zero frames";
+  ASSERT_THAT(r.mouseDownFrameIndices, SizeIs(2u))
       << "expected exactly two mouse-down events in the repro (first drag, second drag)";
-  ASSERT_EQ(r.mouseUpFrameIndices.size(), 2u) << "expected two mouse-up events in the repro";
+  ASSERT_THAT(r.mouseUpFrameIndices, SizeIs(2u)) << "expected two mouse-up events in the repro";
 
   const uint64_t firstDown = r.mouseDownFrameIndices[0];
   const uint64_t firstUp = r.mouseUpFrameIndices[0];
@@ -431,14 +437,15 @@ void RunFilterDragReproScenario(FilterDragReproResult* out) {
   std::cerr << "[FilterDragRepro] fast-path counters at end: fast=" << r.fastPathFrames
             << " slowWithDirty=" << r.slowPathFramesWithDirty << " noDirty=" << r.noDirtyFrames
             << "\n";
-  ASSERT_EQ(r.selectionElementIds.size(), 2u);
+  ASSERT_THAT(r.selectionElementIds, SizeIs(2u));
+  ASSERT_THAT(r.selectionFilterAncestorIds, SizeIs(2u));
   std::cerr << "[FilterDragRepro] firstSel id=" << r.selectionElementIds[0]
             << " filterAncestor=" << r.selectionFilterAncestorIds[0] << "\n";
   std::cerr << "[FilterDragRepro] secondSel id=" << r.selectionElementIds[1]
             << " filterAncestor=" << r.selectionFilterAncestorIds[1] << "\n";
 
-  ASSERT_EQ(r.selectionAfterMouseUp.size(), 2u);
-  ASSERT_EQ(r.selectionSizesAfterMouseUp.size(), 2u);
+  ASSERT_THAT(r.selectionAfterMouseUp, SizeIs(2u));
+  ASSERT_THAT(r.selectionSizesAfterMouseUp, SizeIs(2u));
   const Entity firstSel = r.selectionAfterMouseUp[0];
   const Entity secondSel = r.selectionAfterMouseUp[1];
   out->firstSelectionExists = (firstSel != entt::null);

--- a/donner/editor/tests/PresentationRenderScheduler_tests.cc
+++ b/donner/editor/tests/PresentationRenderScheduler_tests.cc
@@ -1,12 +1,15 @@
 #include "donner/editor/PresentationRenderScheduler.h"
 
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
 #include <utility>
 #include <vector>
 
-#include "gtest/gtest.h"
-
 namespace donner::editor {
 namespace {
+
+using ::testing::ElementsAre;
 
 const Vector2i kCanvasSize(100, 100);
 
@@ -62,7 +65,7 @@ TEST(PresentationRenderSchedulerTest, SelectionPrewarmCarriesGroupedSelectionEnt
 
   ASSERT_TRUE(decision.dragPreview.has_value());
   EXPECT_EQ(decision.dragPreview->entity, Entity(7));
-  EXPECT_EQ(decision.dragPreview->extraEntities, std::vector<Entity>{Entity(8)});
+  EXPECT_THAT(decision.dragPreview->extraEntities, ElementsAre(Entity(8)));
   EXPECT_EQ(decision.dragPreview->interactionKind, svg::compositor::InteractionHint::Selection);
 }
 
@@ -88,7 +91,7 @@ TEST(PresentationRenderSchedulerTest, ChangedGroupedSelectionRewarmsSamePrimaryE
 
   EXPECT_TRUE(changed.needsCompositedPrewarm);
   ASSERT_TRUE(changed.dragPreview.has_value());
-  EXPECT_EQ(changed.dragPreview->extraEntities, std::vector<Entity>{Entity(9)});
+  EXPECT_THAT(changed.dragPreview->extraEntities, ElementsAre(Entity(9)));
 }
 
 TEST(PresentationRenderSchedulerTest, RepeatedUpToDateSelectionDoesNotRequestRender) {

--- a/donner/editor/tests/RopeSimulation_tests.cc
+++ b/donner/editor/tests/RopeSimulation_tests.cc
@@ -161,7 +161,7 @@ TEST(RopeSimulationTest, ResetCatenaryStartsSettledWithZeroVelocity) {
   rope.update(Vector2d(0.0, 0.0), Vector2d(120.0, 0.0), 1.0 / 60.0, 0.0, 1.0 / 60.0, 123u, false,
               options);
 
-  EXPECT_EQ(std::vector<Vector2d>(rope.points().begin(), rope.points().end()), before);
+  EXPECT_THAT(rope.points(), testing::ElementsAreArray(before));
   EXPECT_FALSE(rope.needsAnimation());
 }
 
@@ -386,7 +386,7 @@ TEST(RopeSimulationTest, SleepsAfterStillnessAndWakesOnImpulse) {
   const std::vector<Vector2d> asleep(rope.points().begin(), rope.points().end());
   rope.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 60.0, 0.0, 3.0 / 60.0, 123u, false,
               options);
-  EXPECT_EQ(std::vector<Vector2d>(rope.points().begin(), rope.points().end()), asleep);
+  EXPECT_THAT(rope.points(), testing::ElementsAreArray(asleep));
 
   rope.applyImpulse(Vector2d(1.0, 0.0));
   EXPECT_TRUE(rope.needsAnimation());
@@ -507,7 +507,7 @@ TEST(RopeSimulationTest, HoverFreezePreservesBodyWhenAnchorsDoNotMove) {
 
   rope.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 60.0, 30.0, 1.0, 12u, true, options);
 
-  EXPECT_EQ(std::vector<Vector2d>(rope.points().begin(), rope.points().end()), before);
+  EXPECT_THAT(rope.points(), testing::ElementsAreArray(before));
 }
 
 TEST(RopeSimulationTest, ConvertsToBezierPathEndingAtTarget) {
@@ -659,7 +659,7 @@ TEST(RopeSimulationTest, TwoParticleRopeProducesSingleLineSegmentPath) {
   RopeSimulation rope;
   rope.reset(route, options);
 
-  ASSERT_EQ(rope.points().size(), 2u);
+  ASSERT_THAT(rope.points(), testing::SizeIs(2u));
   const Path path = rope.toPath(options);
   ASSERT_GE(path.commands().size(), 2u);
   EXPECT_THAT(path.commands(), PathCommandEndpointVerbsAre(Path::Verb::MoveTo, Path::Verb::LineTo));


### PR DESCRIPTION
- Convert editor collection assertions from whole-vector `EXPECT_EQ` and raw `.size()` guards to gMock collection matchers.
- Improve replay-helper failure isolation by reporting unexpected frame/event/selection collections through `Not(IsEmpty())` and `SizeIs`.
- Preserve existing behavioral coverage while letting failures show the mismatched entities or rope points directly in the test log.

## Validation

- `tools/llm-bazel-wrap.sh test //donner/editor/tests:rope_simulation_tests //donner/editor/tests:presentation_render_scheduler_tests //donner/editor/tests:composited_presentation_tests --test_output=errors`
- `tools/llm-bazel-wrap.sh test //donner/editor/tests:filter_drag_repro_tests_correctness //donner/editor/tests:filter_drag_repro_tests_wallclock --test_output=errors`
- `tools/llm-bazel-wrap.sh test //... --test_output=errors`
- `python3 tools/cmake/gen_cmakelists.py --check`