### PR TITLE
Improve SVG element collection test diagnostics

### DIFF
--- a/donner/svg/tests/SVGElementPublicApi_tests.cc
+++ b/donner/svg/tests/SVGElementPublicApi_tests.cc
@@ -21,6 +21,7 @@ using testing::Eq;
 using testing::FloatNear;
 using testing::Ne;
 using testing::Optional;
+using testing::SizeIs;
 
 namespace donner::svg {
 
@@ -225,15 +226,15 @@ TEST(SVGTextPositioningElementTest, PositionLists) {
   auto tspan = instantiateSubtreeElementAs<SVGTSpanElement>(R"(<tspan x="1 2 3" y="4 5 6" />)",
                                                             kExperimentalOptions);
 
-  EXPECT_EQ(tspan->xList().size(), 3u);
-  EXPECT_EQ(tspan->yList().size(), 3u);
+  EXPECT_THAT(tspan->xList(), SizeIs(3u));
+  EXPECT_THAT(tspan->yList(), SizeIs(3u));
 }
 
 TEST(SVGTextPositioningElementTest, RotateList) {
   auto tspan = instantiateSubtreeElementAs<SVGTSpanElement>(R"(<tspan rotate="10 20 30" />)",
                                                             kExperimentalOptions);
 
-  EXPECT_EQ(tspan->rotateList().size(), 3u);
+  EXPECT_THAT(tspan->rotateList(), SizeIs(3u));
 }
 
 }  // namespace donner::svg

--- a/donner/svg/tests/SVGElement_tests.cc
+++ b/donner/svg/tests/SVGElement_tests.cc
@@ -1270,26 +1270,19 @@ TEST_F(SVGElementTests, FindMatchingAttributes) {
   // 1) findMatchingAttributes("foo") -> [ "foo" ]
   {
     auto matches = element.findMatchingAttributes("foo");
-    EXPECT_EQ(matches.size(), 1u);
-    EXPECT_EQ(matches[0].name, "foo");
-    EXPECT_TRUE(matches[0].namespacePrefix.empty());
+    EXPECT_THAT(matches, ElementsAre(xml::XMLQualifiedNameRef("foo")));
   }
 
   // 2) findMatchingAttributes({"namespace", "bar"}) -> exactly [ "namespace:bar" ]
   {
     auto matches = element.findMatchingAttributes({"namespace", "bar"});
-    EXPECT_EQ(matches.size(), 1u);
-    EXPECT_EQ(matches[0].name, "bar");
-    EXPECT_EQ(matches[0].namespacePrefix, "namespace");
+    EXPECT_THAT(matches, ElementsAre(xml::XMLQualifiedNameRef("namespace", "bar")));
   }
 
   // 3) Using a wildcard on the namespace, findMatchingAttributes({ "*", "bar" })
   //    Expect matches from both "namespace:bar" and "anotherNS:bar"
   {
     auto matches = element.findMatchingAttributes({"*", "bar"});
-    ASSERT_EQ(matches.size(), 2u);
-    // Because the order of attributes might not be guaranteed, verify via a set or multiple checks.
-    // For simplicity, just do:
     EXPECT_THAT(matches,
                 testing::UnorderedElementsAre(xml::XMLQualifiedNameRef("namespace", "bar"),
                                               xml::XMLQualifiedNameRef("anotherNS", "bar")));


### PR DESCRIPTION
- Convert `findMatchingAttributes` assertions to match the returned qualified-name collections directly.
- Remove size/index checks from the wildcard attribute case and let `UnorderedElementsAre` report mismatched names.
- Replace SVG text-positioning list size checks with `SizeIs` matchers for clearer list diagnostics.

## Validation

- `tools/llm-bazel-wrap.sh test //donner/svg/tests:svg_tests --test_output=errors`
- `tools/llm-bazel-wrap.sh test //donner/svg/renderer/tests:resvg_test_suite //donner/svg/renderer/tests:resvg_test_suite_impl --test_output=errors`
- `tools/llm-bazel-wrap.sh test //... --test_output=errors`
- `python3 tools/cmake/gen_cmakelists.py --check`