### PR TITLE
Improve SVG document filter test diagnostics

### DIFF
--- a/donner/base/tests/PathOps_tests.cc
+++ b/donner/base/tests/PathOps_tests.cc
@@ -17,6 +17,9 @@
 namespace donner {
 namespace {
 
+using ::testing::AllOf;
+using ::testing::ElementsAre;
+
 Path RectPath(double x, double y, double width, double height) {
   return PathBuilder().addRect(Box2d::FromXYWH(x, y, width, height)).build();
 }
@@ -498,14 +501,11 @@ TEST(PathOpsTest, DifferenceCreatesCurvedHoleForNestedContour) {
               {Input(CirclePath({50, 50}, 40)), Input(CirclePath({50, 50}, 15))});
 
   ASSERT_EQ(result.status, PathBooleanStatus::Ok) << Diagnostics(result);
-  ASSERT_EQ(result.paths.size(), 1u);
-  const Path& path = result.paths.front();
-  EXPECT_THAT(path, CommandCountIs(Path::Verb::MoveTo, 2u));
-  EXPECT_THAT(path, CommandCountIs(Path::Verb::ClosePath, 2u));
-  EXPECT_THAT(path, HasCommandVerb(Path::Verb::CurveTo));
-  EXPECT_THAT(path, IsInside(Vector2d(50, 25)));
-  EXPECT_THAT(path, IsOutside(Vector2d(50, 50)));
-  EXPECT_THAT(path, IsOutside(Vector2d(5, 50)));
+  EXPECT_THAT(result.paths,
+              ElementsAre(AllOf(CommandCountIs(Path::Verb::MoveTo, 2u),
+                                CommandCountIs(Path::Verb::ClosePath, 2u),
+                                HasCommandVerb(Path::Verb::CurveTo), IsInside(Vector2d(50, 25)),
+                                IsOutside(Vector2d(50, 50)), IsOutside(Vector2d(5, 50)))));
 }
 
 TEST(PathOpsTest, IntersectOfNestedCirclesKeepsInnerCircle) {
@@ -513,13 +513,10 @@ TEST(PathOpsTest, IntersectOfNestedCirclesKeepsInnerCircle) {
       PathBooleanOp::Intersect, {Input(CirclePath({50, 50}, 40)), Input(CirclePath({50, 50}, 15))});
 
   ASSERT_EQ(result.status, PathBooleanStatus::Ok) << Diagnostics(result);
-  ASSERT_EQ(result.paths.size(), 1u);
-  const Path& path = result.paths.front();
-  EXPECT_THAT(path, CommandCountIs(Path::Verb::MoveTo, 1u));
-  EXPECT_THAT(path, HasCommandVerb(Path::Verb::CurveTo));
-  EXPECT_THAT(path, IsInside(Vector2d(50, 50)));
-  EXPECT_THAT(path, IsOutside(Vector2d(50, 25)));
-  EXPECT_THAT(path, IsOutside(Vector2d(5, 50)));
+  EXPECT_THAT(result.paths,
+              ElementsAre(AllOf(CommandCountIs(Path::Verb::MoveTo, 1u),
+                                HasCommandVerb(Path::Verb::CurveTo), IsInside(Vector2d(50, 50)),
+                                IsOutside(Vector2d(50, 25)), IsOutside(Vector2d(5, 50)))));
 }
 
 TEST(PathOpsTest, UnionOfNestedCirclesKeepsOuterCircle) {
@@ -527,13 +524,10 @@ TEST(PathOpsTest, UnionOfNestedCirclesKeepsOuterCircle) {
       PathBooleanOp::Union, {Input(CirclePath({50, 50}, 40)), Input(CirclePath({50, 50}, 15))});
 
   ASSERT_EQ(result.status, PathBooleanStatus::Ok) << Diagnostics(result);
-  ASSERT_EQ(result.paths.size(), 1u);
-  const Path& path = result.paths.front();
-  EXPECT_THAT(path, CommandCountIs(Path::Verb::MoveTo, 1u));
-  EXPECT_THAT(path, HasCommandVerb(Path::Verb::CurveTo));
-  EXPECT_THAT(path, IsInside(Vector2d(50, 50)));
-  EXPECT_THAT(path, IsInside(Vector2d(50, 25)));
-  EXPECT_THAT(path, IsOutside(Vector2d(5, 50)));
+  EXPECT_THAT(result.paths,
+              ElementsAre(AllOf(CommandCountIs(Path::Verb::MoveTo, 1u),
+                                HasCommandVerb(Path::Verb::CurveTo), IsInside(Vector2d(50, 50)),
+                                IsInside(Vector2d(50, 25)), IsOutside(Vector2d(5, 50)))));
 }
 
 TEST(PathOpsTest, LowIntersectionCapAllowsNestedCircleContainment) {
@@ -546,16 +540,14 @@ TEST(PathOpsTest, LowIntersectionCapAllowsNestedCircleContainment) {
 
   const PathBooleanResult unionResult = ApplyPathBoolean(PathBooleanOp::Union, inputs, options);
   ASSERT_EQ(unionResult.status, PathBooleanStatus::Ok) << Diagnostics(unionResult);
-  ASSERT_EQ(unionResult.paths.size(), 1u);
-  EXPECT_THAT(unionResult.paths.front(), IsInside(Vector2d(50, 50)));
-  EXPECT_THAT(unionResult.paths.front(), IsOutside(Vector2d(5, 50)));
+  EXPECT_THAT(unionResult.paths,
+              ElementsAre(AllOf(IsInside(Vector2d(50, 50)), IsOutside(Vector2d(5, 50)))));
 
   const PathBooleanResult intersectResult =
       ApplyPathBoolean(PathBooleanOp::Intersect, inputs, options);
   ASSERT_EQ(intersectResult.status, PathBooleanStatus::Ok) << Diagnostics(intersectResult);
-  ASSERT_EQ(intersectResult.paths.size(), 1u);
-  EXPECT_THAT(intersectResult.paths.front(), IsInside(Vector2d(50, 50)));
-  EXPECT_THAT(intersectResult.paths.front(), IsOutside(Vector2d(50, 25)));
+  EXPECT_THAT(intersectResult.paths,
+              ElementsAre(AllOf(IsInside(Vector2d(50, 50)), IsOutside(Vector2d(50, 25)))));
 }
 
 TEST(PathOpsTest, XorOfNestedCirclesCreatesCurvedRing) {
@@ -563,14 +555,11 @@ TEST(PathOpsTest, XorOfNestedCirclesCreatesCurvedRing) {
       PathBooleanOp::Xor, {Input(CirclePath({50, 50}, 40)), Input(CirclePath({50, 50}, 15))});
 
   ASSERT_EQ(result.status, PathBooleanStatus::Ok) << Diagnostics(result);
-  ASSERT_EQ(result.paths.size(), 1u);
-  const Path& path = result.paths.front();
-  EXPECT_THAT(path, CommandCountIs(Path::Verb::MoveTo, 2u));
-  EXPECT_THAT(path, CommandCountIs(Path::Verb::ClosePath, 2u));
-  EXPECT_THAT(path, HasCommandVerb(Path::Verb::CurveTo));
-  EXPECT_THAT(path, IsOutside(Vector2d(50, 50)));
-  EXPECT_THAT(path, IsInside(Vector2d(50, 25)));
-  EXPECT_THAT(path, IsOutside(Vector2d(5, 50)));
+  EXPECT_THAT(result.paths,
+              ElementsAre(AllOf(CommandCountIs(Path::Verb::MoveTo, 2u),
+                                CommandCountIs(Path::Verb::ClosePath, 2u),
+                                HasCommandVerb(Path::Verb::CurveTo), IsOutside(Vector2d(50, 50)),
+                                IsInside(Vector2d(50, 25)), IsOutside(Vector2d(5, 50)))));
 }
 
 TEST(PathOpsTest, DifferenceOfCircleCoveredByLargerCircleIsEmpty) {
@@ -673,13 +662,10 @@ TEST(PathOpsTest, SharedEdgeUnionProducesSingleExteriorContour) {
       PathBooleanOp::Union, {Input(RectPath(0, 0, 10, 10)), Input(RectPath(10, 0, 10, 10))});
 
   ASSERT_EQ(result.status, PathBooleanStatus::Ok);
-  ASSERT_EQ(result.paths.size(), 1u);
-  const Path& path = result.paths.front();
-  EXPECT_THAT(path, CommandCountIs(Path::Verb::MoveTo, 1u));
-  EXPECT_THAT(path, CommandCountIs(Path::Verb::ClosePath, 1u));
-  EXPECT_THAT(path, IsInside(Vector2d(5, 5)));
-  EXPECT_THAT(path, IsInside(Vector2d(15, 5)));
-  EXPECT_THAT(path, IsOutside(Vector2d(25, 5)));
+  EXPECT_THAT(result.paths,
+              ElementsAre(AllOf(CommandCountIs(Path::Verb::MoveTo, 1u),
+                                CommandCountIs(Path::Verb::ClosePath, 1u), IsInside(Vector2d(5, 5)),
+                                IsInside(Vector2d(15, 5)), IsOutside(Vector2d(25, 5)))));
 }
 
 TEST(PathOpsTest, IntersectOfLineAndStraightQuadraticSharedBoundaryIsEmpty) {
@@ -934,13 +920,11 @@ TEST(PathOpsTest, UnionOfDuplicateCurvedContoursKeepsSingleContour) {
   const PathBooleanResult result = Boolean(PathBooleanOp::Union, {Input(circle), Input(circle)});
 
   ASSERT_EQ(result.status, PathBooleanStatus::Ok) << Diagnostics(result);
-  ASSERT_EQ(result.paths.size(), 1u);
-  const Path& path = result.paths.front();
-  EXPECT_THAT(path, CommandCountIs(Path::Verb::MoveTo, 1u));
-  EXPECT_THAT(path, CommandCountIs(Path::Verb::ClosePath, 1u));
-  EXPECT_THAT(path, HasCommandVerb(Path::Verb::CurveTo));
-  EXPECT_THAT(path, IsInside(Vector2d(20, 20)));
-  EXPECT_THAT(path, IsOutside(Vector2d(40, 20)));
+  EXPECT_THAT(result.paths,
+              ElementsAre(AllOf(CommandCountIs(Path::Verb::MoveTo, 1u),
+                                CommandCountIs(Path::Verb::ClosePath, 1u),
+                                HasCommandVerb(Path::Verb::CurveTo), IsInside(Vector2d(20, 20)),
+                                IsOutside(Vector2d(40, 20)))));
 }
 
 TEST(PathOpsTest, IntersectOfDuplicateCurvedContoursKeepsOriginalRegion) {
@@ -949,13 +933,11 @@ TEST(PathOpsTest, IntersectOfDuplicateCurvedContoursKeepsOriginalRegion) {
       Boolean(PathBooleanOp::Intersect, {Input(circle), Input(circle)});
 
   ASSERT_EQ(result.status, PathBooleanStatus::Ok) << Diagnostics(result);
-  ASSERT_EQ(result.paths.size(), 1u);
-  const Path& path = result.paths.front();
-  EXPECT_THAT(path, CommandCountIs(Path::Verb::MoveTo, 1u));
-  EXPECT_THAT(path, CommandCountIs(Path::Verb::ClosePath, 1u));
-  EXPECT_THAT(path, HasCommandVerb(Path::Verb::CurveTo));
-  EXPECT_THAT(path, IsInside(Vector2d(20, 20)));
-  EXPECT_THAT(path, IsOutside(Vector2d(40, 20)));
+  EXPECT_THAT(result.paths,
+              ElementsAre(AllOf(CommandCountIs(Path::Verb::MoveTo, 1u),
+                                CommandCountIs(Path::Verb::ClosePath, 1u),
+                                HasCommandVerb(Path::Verb::CurveTo), IsInside(Vector2d(20, 20)),
+                                IsOutside(Vector2d(40, 20)))));
 }
 
 TEST(PathOpsTest, DifferenceOfDuplicateCurvedContoursIsEmpty) {

--- a/donner/svg/tests/SVGDocument_tests.cc
+++ b/donner/svg/tests/SVGDocument_tests.cc
@@ -12,8 +12,10 @@
 #include "donner/svg/components/text/TextRootComponent.h"
 #include "donner/svg/parser/SVGParser.h"
 
+using testing::ElementsAre;
 using testing::Eq;
 using testing::Optional;
+using testing::SizeIs;
 
 namespace donner::svg {
 
@@ -33,6 +35,15 @@ SVGDocument ParseSVG(std::string_view input) {
 /// Matcher to check for an element with the given id.
 MATCHER_P(ElementIdEq, id, "") {
   return arg.id() == id;
+}
+
+MATCHER(StylesheetSourceMapIsEmpty, "") {
+  if (!arg.empty()) {
+    *result_listener << "source map is not empty";
+    return false;
+  }
+
+  return true;
 }
 
 }  // namespace
@@ -159,8 +170,7 @@ TEST(SVGDocument, ApplySourceEditProjectsTextMutation) {
   EXPECT_THAT(result.diagnostic, Eq(std::nullopt));
   const auto& textComponent = text.entityHandle().get<components::TextComponent>();
   EXPECT_EQ(textComponent.text, "world");
-  ASSERT_EQ(textComponent.textChunks.size(), 1u);
-  EXPECT_EQ(textComponent.textChunks[0], "world");
+  EXPECT_THAT(textComponent.textChunks, ElementsAre(RcString("world")));
 }
 
 TEST(SVGDocument, TextProjectionPreservesChunkBoundariesAroundChildElements) {
@@ -203,8 +213,8 @@ TEST(SVGDocument, ApplySourceEditProjectsStyleMutationWithSourceMap) {
   EXPECT_TRUE(result.applied);
   EXPECT_THAT(result.diagnostic, Eq(std::nullopt));
   const auto& stylesheet = style.entityHandle().get<components::StylesheetComponent>();
-  EXPECT_EQ(stylesheet.stylesheet.rules().size(), 1u);
-  EXPECT_TRUE(stylesheet.sourceMap.empty());
+  EXPECT_THAT(stylesheet.stylesheet.rules(), SizeIs(1u));
+  EXPECT_THAT(stylesheet.sourceMap, StylesheetSourceMapIsEmpty());
 }
 
 TEST(SVGDocument, ApplySourceEditProjectsSubtreeReplacement) {

--- a/donner/svg/tests/SVGFilterElement_tests.cc
+++ b/donner/svg/tests/SVGFilterElement_tests.cc
@@ -21,6 +21,9 @@
 #include "donner/svg/tests/ParserTestUtils.h"
 
 using testing::AllOf;
+using testing::DoubleEq;
+using testing::ElementsAre;
+using testing::Field;
 
 namespace donner::svg {
 
@@ -45,6 +48,21 @@ auto HeightEq(auto valueMatcher, auto unitMatcher) {
 
 MATCHER_P(FilterHas, matchers, "") {
   return testing::ExplainMatchResult(matchers, arg.element, result_listener);
+}
+
+MATCHER_P2(GaussianBlurNodeHasStdDeviation, expectedX, expectedY, "") {
+  const auto* blur = std::get_if<components::filter_primitive::GaussianBlur>(&arg.primitive);
+  if (blur == nullptr) {
+    *result_listener << "primitive variant index is " << arg.primitive.index();
+    return false;
+  }
+
+  return testing::ExplainMatchResult(
+      AllOf(Field("stdDeviationX", &components::filter_primitive::GaussianBlur::stdDeviationX,
+                  DoubleEq(expectedX)),
+            Field("stdDeviationY", &components::filter_primitive::GaussianBlur::stdDeviationY,
+                  DoubleEq(expectedY))),
+      *blur, result_listener);
 }
 
 }  // namespace
@@ -202,13 +220,7 @@ TEST(SVGFilterElementTests, HrefInheritsPrimitivesAndRegion) {
   const auto* computed =
       document.registry().try_get<components::ComputedFilterComponent>(filter1Entity);
   ASSERT_NE(computed, nullptr);
-  ASSERT_EQ(computed->filterGraph.nodes.size(), 1u);
-
-  const auto* blur = std::get_if<components::filter_primitive::GaussianBlur>(
-      &computed->filterGraph.nodes.front().primitive);
-  ASSERT_NE(blur, nullptr);
-  EXPECT_DOUBLE_EQ(blur->stdDeviationX, 4.0);
-  EXPECT_DOUBLE_EQ(blur->stdDeviationY, 4.0);
+  EXPECT_THAT(computed->filterGraph.nodes, ElementsAre(GaussianBlurNodeHasStdDeviation(4.0, 4.0)));
   EXPECT_THAT(computed->x.value, testing::DoubleEq(0.1));
   EXPECT_THAT(computed->y.value, testing::DoubleEq(0.2));
   EXPECT_THAT(computed->width.value, testing::DoubleEq(0.8));
@@ -242,13 +254,7 @@ TEST(SVGFilterElementTests, HrefInheritsAttributesButKeepsLocalPrimitives) {
   const auto* computed =
       document.registry().try_get<components::ComputedFilterComponent>(filter1Entity);
   ASSERT_NE(computed, nullptr);
-  ASSERT_EQ(computed->filterGraph.nodes.size(), 1u);
-
-  const auto* blur = std::get_if<components::filter_primitive::GaussianBlur>(
-      &computed->filterGraph.nodes.front().primitive);
-  ASSERT_NE(blur, nullptr);
-  EXPECT_DOUBLE_EQ(blur->stdDeviationX, 4.0);
-  EXPECT_DOUBLE_EQ(blur->stdDeviationY, 4.0);
+  EXPECT_THAT(computed->filterGraph.nodes, ElementsAre(GaussianBlurNodeHasStdDeviation(4.0, 4.0)));
   EXPECT_THAT(computed->x.value, testing::DoubleEq(0.1));
   EXPECT_THAT(computed->y.value, testing::DoubleEq(0.2));
   EXPECT_THAT(computed->width.value, testing::DoubleEq(0.8));


### PR DESCRIPTION
- Match projected text chunks and stylesheet rule collections directly in SVG document tests.
- Add a named stylesheet-source-map matcher for the source-map empty case.
- Add a Gaussian blur filter-node matcher and replace filter graph size/front checks with collection-level expectations.

## Validation

- `tools/llm-bazel-wrap.sh test //donner/svg/tests:svg_tests --test_output=errors`
- `tools/llm-bazel-wrap.sh test //... --test_output=errors`
- `python3 tools/cmake/gen_cmakelists.py --check`