### PR TITLE
Document ready-only PR policy

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -6,6 +6,12 @@ keys. When writing commands in docs and to the user, use `bazel` instead.
 
 When creating pull requests, do not prefix PR titles with `[codex]`, agent names,
 or other tool branding. Use plain project-style titles that describe the change.
+Omit a `## Summary` heading or first line in PR descriptions; the first line of
+the body is implicitly the summary. Start directly with that content, then add
+sections such as `## Validation` as needed.
+Do not publish draft PR diffs. Open PRs only when they are ready for review after
+local validation; keep work-in-progress diffs local until they have a coherent
+reviewable boundary.
 
 When monitoring pull requests, do not expect code-review comments while the PR is
 still a draft. Keep monitoring CI and mergeability, but treat review/comment

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,9 +100,12 @@ When creating a pull request:
 5. **No agent branding in PR titles** — do not prefix pull request titles with `[codex]`, agent names, or other tool branding. Use a plain project-style title that describes the change.
 6. **Omit `## Summary` in PR descriptions** — the first paragraph or bullet list is implicitly the
    summary, so start with the summary content directly instead of adding a redundant heading.
-7. **Expect a Codex code review** within the first few minutes after the PR is published and out of draft — address feedback promptly by pushing follow-up commits. If Codex finds no issues it will approve the PR (👍 / APPROVED state). A Codex approval alone is not sufficient to merge — a `jwmcglynn` review is always required.
-8. **Transient CI failures** (apt/bazel fetch/chromium rate-limits) are retried automatically. Test, compile, linker, and pixel-diff failures are never transient — investigate the root cause, don't re-run blindly.
-9. **Fix CI diagnosability gaps** — if a CI failure cannot be diagnosed because logs, test output,
+7. **Do not publish draft diffs** — open PRs only when they are ready for review
+   after local validation. Do not use draft PRs to share work-in-progress diffs;
+   keep WIP local until it has a coherent reviewable boundary.
+8. **Expect a Codex code review** within the first few minutes after the PR is published and out of draft — address feedback promptly by pushing follow-up commits. If Codex finds no issues it will approve the PR (👍 / APPROVED state). A Codex approval alone is not sufficient to merge — a `jwmcglynn` review is always required.
+9. **Transient CI failures** (apt/bazel fetch/chromium rate-limits) are retried automatically. Test, compile, linker, and pixel-diff failures are never transient — investigate the root cause, don't re-run blindly.
+10. **Fix CI diagnosability gaps** — if a CI failure cannot be diagnosed because logs, test output,
    screenshots, undeclared outputs, pixel diffs, artifacts, or job summaries are missing or
    inaccessible, treat that as a CI bug and fix the workflow/test harness to expose the missing
    evidence. Do not leave failures opaque or rely on blind reruns when better GitHub Actions


### PR DESCRIPTION
- Add a pull-request workflow rule that agents should keep work-in-progress diffs local instead of publishing draft PRs.
- Mirror the PR body and ready-only PR conventions in `.codex/config.toml` for short-form agent instructions.

## Validation

- `git diff --cached --check`
- Docs/config-only change; no build run.