### PR TITLE
Improve editor single-result collection diagnostics

### DIFF
--- a/donner/editor/tests/AsyncSVGDocument_tests.cc
+++ b/donner/editor/tests/AsyncSVGDocument_tests.cc
@@ -17,6 +17,7 @@ using ::testing::DoubleNear;
 using ::testing::Field;
 using ::testing::Gt;
 using ::testing::Lt;
+using ::testing::SizeIs;
 
 constexpr std::string_view kTrivialSvg =
     R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
@@ -104,7 +105,7 @@ TEST(AsyncSVGDocumentTest, MultipleSetTransformsCoalesceAtFlush) {
       EditorCommand::SetTransformCommand(*rect, Transform2d::Translate(Vector2d(2.0, 0.0))));
   doc.applyMutation(
       EditorCommand::SetTransformCommand(*rect, Transform2d::Translate(Vector2d(3.0, 0.0))));
-  EXPECT_EQ(doc.queue().size(), 3u);
+  EXPECT_THAT(doc.queue(), SizeIs(3u));
 
   EXPECT_TRUE(doc.flushFrame());
 

--- a/donner/editor/tests/GlRnrReplay_tests.cc
+++ b/donner/editor/tests/GlRnrReplay_tests.cc
@@ -2,6 +2,8 @@
 
 #include "donner/editor/repro/GlRnrReplay.h"
 
+#include <gmock/gmock.h>
+
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -10,6 +12,7 @@
 #include <cstring>
 #include <filesystem>
 #include <optional>
+#include <ostream>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -28,7 +31,20 @@
 #include "gtest/gtest.h"
 
 namespace donner::editor {
+
+namespace repro {
+
+void PrintTo(const GlRnrReplayCapture& capture, std::ostream* os) {
+  *os << "GlRnrReplayCapture{frameIndex=" << capture.frameIndex << ", reason=" << capture.reason
+      << ", path=" << capture.path.string() << "}";
+}
+
+}  // namespace repro
+
 namespace {
+
+using ::testing::ElementsAre;
+using ::testing::Field;
 
 // Runs a GL replay and, on failure, either GTEST_SKIP()s or FAIL()s. The skip
 // path fires only when the host genuinely cannot provide a GL context (a
@@ -1649,8 +1665,8 @@ TEST(GlRnrReplayTest, DocumentSpaceInputDrivesCanvasSelectionThroughEditorShell)
 
   ASSERT_TRUE(result.finalSelectedElementLabel.has_value());
   EXPECT_EQ(*result.finalSelectedElementLabel, "<rect> #target");
-  ASSERT_EQ(result.captures.size(), 1u);
-  EXPECT_EQ(result.captures.front().frameIndex, 2u);
+  EXPECT_THAT(result.captures,
+              ElementsAre(Field("frameIndex", &repro::GlRnrReplayCapture::frameIndex, 2u)));
 
   std::error_code ec;
   std::filesystem::remove_all(outputDir, ec);

--- a/donner/editor/tests/RnrReplay_tests.cc
+++ b/donner/editor/tests/RnrReplay_tests.cc
@@ -7,6 +7,8 @@
 /// post-second-mouse-up checkpoint, and pin the landed bitmap against
 /// a committed PNG.
 
+#include <gmock/gmock.h>
+
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
@@ -40,6 +42,8 @@
 
 namespace donner::editor {
 namespace {
+
+using ::testing::SizeIs;
 
 bool IsGraphicsElement(const svg::SVGElement& element) {
   return element.withReadAccess([&element](svg::DocumentReadAccess&, EntityHandle) {
@@ -1044,7 +1048,7 @@ TEST_F(RnrReplayTest, DeleteElementDoesNotResetPreviouslyMovedShapes) {
   // exactly what `DocumentSyncController::applyPendingWritebacks`
   // does for the post-delete source-pane sync.
   auto removals = app.consumeElementRemoveWritebacks();
-  ASSERT_EQ(removals.size(), 1u);
+  ASSERT_THAT(removals, SizeIs(1u));
   auto patch = buildElementRemoveWriteback(liveSource_, removals[0].target);
   ASSERT_TRUE(patch.has_value()) << "Failed to build element-remove patch";
   applyPatches(liveSource_, {{*patch}});

--- a/donner/editor/tests/TextEditorCore_tests.cc
+++ b/donner/editor/tests/TextEditorCore_tests.cc
@@ -1206,9 +1206,7 @@ TEST_F(TextEditorCoreTests, ErrorMarkersShiftDownWhenLineInserted) {
   editor_.enterCharacter('\n', false);  // inserts a line before the marker
 
   const ErrorMarkers& markers = editor_.getErrorMarkers();
-  ASSERT_EQ(markers.size(), 1u);
-  EXPECT_EQ(markers.begin()->first, 3);
-  EXPECT_EQ(markers.begin()->second, "msg-on-line-2");
+  EXPECT_THAT(markers, ElementsAre(testing::Pair(3, "msg-on-line-2")));
 }
 
 TEST_F(TextEditorCoreTests, ErrorMarkersAccessibleViaMutableRef) {


### PR DESCRIPTION
- Convert editor queue, error-marker, replay-removal, and GL-capture single-result checks to collection matchers.
- Add `PrintTo` output for GL replay captures so capture collection mismatches include frame, reason, and path context.

## Validation

- `tools/llm-bazel-wrap.sh test //donner/editor/tests:async_svg_document_tests //donner/editor/tests:text_editor_core_tests //donner/editor/tests:rnr_replay_tests //donner/editor/tests:gl_rnr_replay_tests --test_output=errors`
- `git diff --check`
- `tools/llm-bazel-wrap.sh test //... --test_output=errors`
- `python3 tools/cmake/gen_cmakelists.py --check`