### PR TITLE
Improve editor rendering bitmap diagnostics

### DIFF
--- a/donner/editor/tests/AsyncRenderer_tests.cc
+++ b/donner/editor/tests/AsyncRenderer_tests.cc
@@ -29,6 +29,7 @@
 #include "donner/editor/SelectTool.h"
 #include "donner/editor/TracyWrapper.h"
 #include "donner/editor/ViewportState.h"
+#include "donner/editor/tests/BitmapTestMatchers.h"
 #include "donner/svg/SVGElement.h"
 #include "donner/svg/SVGGraphicsElement.h"
 #include "donner/svg/compositor/CompositorController.h"
@@ -69,6 +70,7 @@ using ::testing::Gt;
 using ::testing::IsEmpty;
 using ::testing::Not;
 using ::testing::SizeIs;
+using tests::NonEmptyRendererBitmap;
 
 bool IsGraphicsElement(const svg::SVGElement& element) {
   return element.withReadAccess([&element](svg::DocumentReadAccess&, EntityHandle) {
@@ -128,16 +130,6 @@ MATCHER_P(DragTargetLayerTileFor, entity,
 
 MATCHER(EmptyRendererBitmap, "an empty renderer bitmap") {
   if (arg.empty()) {
-    return true;
-  }
-
-  *result_listener << "dimensions=(" << arg.dimensions.x << ", " << arg.dimensions.y
-                   << "), pixels=" << arg.pixels.size() << ", rowBytes=" << arg.rowBytes;
-  return false;
-}
-
-MATCHER(NonEmptyRendererBitmap, "a non-empty renderer bitmap") {
-  if (!arg.empty()) {
     return true;
   }
 
@@ -3410,7 +3402,8 @@ TEST(AsyncRendererE2ETest, ClickThenDragOnSplashShapeMeetsLatencyBudget) {
         svg::RenderViewport{.size = Vector2d(892, 512), .devicePixelRatio = 1.0});
   }
   const auto referenceBitmap = referenceRenderer.takeSnapshot();
-  ASSERT_FALSE(referenceBitmap.empty()) << "reference render produced empty bitmap";
+  ASSERT_THAT(referenceBitmap, NonEmptyRendererBitmap())
+      << "reference render produced empty bitmap";
   EXPECT_EQ(referenceBitmap.dimensions.x, 892);
   EXPECT_EQ(referenceBitmap.dimensions.y, 512);
 }
@@ -4074,7 +4067,7 @@ TEST(AsyncRendererE2ETest, CpuSnapshotStaysNonTransparentAcrossDragTargetSwap) {
   auto checkResult = [&](std::string_view phase) {
     auto result = waitForResult();
     ASSERT_TRUE(result.has_value()) << "no result for " << phase;
-    EXPECT_FALSE(result->bitmap.empty()) << phase << ": CPU snapshot empty";
+    EXPECT_THAT(result->bitmap, NonEmptyRendererBitmap()) << phase << ": CPU snapshot empty";
     EXPECT_FALSE(isBitmapMostlyTransparent(result->bitmap))
         << phase
         << ": CPU snapshot is ≥99% transparent — a full-canvas composited tile seeded from it "
@@ -4229,7 +4222,8 @@ TEST(AsyncRendererE2ETest, DragEndWritebackTakesStructuralRemapPath) {
   ASSERT_TRUE(postReplaceResult.has_value());
 
   const svg::RendererBitmap& postReplaceBitmap = postReplaceResult->bitmap;
-  ASSERT_FALSE(postReplaceBitmap.empty()) << "post-replace CPU snapshot must refresh";
+  ASSERT_THAT(postReplaceBitmap, NonEmptyRendererBitmap())
+      << "post-replace CPU snapshot must refresh";
   const auto pixelAt = [&](int x, int y) -> std::array<uint8_t, 4> {
     const size_t offset =
         static_cast<size_t>(y) * postReplaceBitmap.rowBytes + static_cast<size_t>(x) * 4u;

--- a/donner/editor/tests/AsyncSVGDocument_tests.cc
+++ b/donner/editor/tests/AsyncSVGDocument_tests.cc
@@ -4,6 +4,7 @@
 
 #include <array>
 
+#include "donner/editor/tests/BitmapTestMatchers.h"
 #include "donner/svg/SVGGraphicsElement.h"
 #include "donner/svg/renderer/Renderer.h"
 #include "donner/svg/renderer/tests/RgbaTestMatchers.h"
@@ -18,6 +19,7 @@ using ::testing::Field;
 using ::testing::Gt;
 using ::testing::Lt;
 using ::testing::SizeIs;
+using tests::NonEmptyRendererBitmap;
 
 constexpr std::string_view kTrivialSvg =
     R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
@@ -176,7 +178,7 @@ TEST(AsyncSVGDocumentTest, CommandAfterStructuralWritebackReparseTargetsRemapped
   EXPECT_EQ(pathAfterReparse->getAttribute("style"), "fill: #ff0000; stroke: none");
 
   const svg::RendererBitmap rendered = RenderDocument(doc.document());
-  ASSERT_FALSE(rendered.empty());
+  ASSERT_THAT(rendered, NonEmptyRendererBitmap());
   const std::array<std::uint8_t, 4> pixel = PixelAt(rendered, 24, 24);
   EXPECT_THAT(pixel, Rgba(Gt(200), Lt(40), Lt(40), Gt(200)));
 }

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -8,11 +8,24 @@ load(
 )
 
 donner_cc_library(
+    name = "bitmap_test_matchers",
+    testonly = 1,
+    hdrs = [
+        "BitmapTestMatchers.h",
+    ],
+    deps = [
+        "//donner/svg/renderer:renderer_interface",
+        "@com_google_gtest//:gtest",
+    ],
+)
+
+donner_cc_library(
     name = "bitmap_golden_compare",
     testonly = 1,
     srcs = ["BitmapGoldenCompare.cc"],
     hdrs = ["BitmapGoldenCompare.h"],
     deps = [
+        ":bitmap_test_matchers",
         "//donner/svg/renderer:renderer_image_io",
         "//donner/svg/renderer:renderer_interface",
         "//donner/svg/renderer/tests:renderer_image_test_utils",
@@ -98,6 +111,7 @@ donner_cc_test(
         "@com_google_gtest//:gtest_main",
     ] + select({
         "//donner/svg/renderer:renderer_backend_geode": [
+            ":bitmap_test_matchers",
             "//donner/base:base_test_utils",
             "//donner/editor:async_renderer",
             "//donner/editor:document_sync_controller",
@@ -333,6 +347,7 @@ donner_cc_test(
     name = "render_pane_presenter_visual_repro_tests",
     srcs = ["RenderPanePresenterVisualRepro_tests.cc"],
     deps = [
+        ":bitmap_test_matchers",
         "//donner/base",
         "//donner/base:base_test_utils",
         "//donner/editor:gl_texture_cache",
@@ -398,6 +413,7 @@ donner_cc_test(
     name = "async_svg_document_tests",
     srcs = ["AsyncSVGDocument_tests.cc"],
     deps = [
+        ":bitmap_test_matchers",
         "//donner/editor:async_svg_document",
         "//donner/svg",
         "//donner/svg/renderer",
@@ -441,6 +457,7 @@ donner_cc_test(
         "//:donner_splash.svg",
     ],
     deps = [
+        ":bitmap_test_matchers",
         "//donner/editor:async_renderer",
         "//donner/editor:async_svg_document",
         "//donner/editor:command_queue",
@@ -486,6 +503,7 @@ donner_cc_test(
         "perf",
     ],
     deps = [
+        ":bitmap_test_matchers",
         "//donner/editor:async_renderer",
         "//donner/editor:async_svg_document",
         "//donner/editor:command_queue",
@@ -665,6 +683,7 @@ donner_cc_test(
     srcs = ["PenTool_tests.cc"],
     data = ["//:donner_splash.svg"],
     deps = [
+        ":bitmap_test_matchers",
         "//donner/editor:document_sync_controller",
         "//donner/editor:editor_app",
         "//donner/editor:overlay_renderer",
@@ -682,6 +701,7 @@ donner_cc_test(
     name = "overlay_renderer_tests",
     srcs = ["OverlayRenderer_tests.cc"],
     deps = [
+        ":bitmap_test_matchers",
         "//donner/editor:editor_app",
         "//donner/editor:overlay_renderer",
         "//donner/svg",
@@ -776,6 +796,7 @@ donner_cc_test(
     name = "drag_release_pop_back_tests",
     srcs = ["DragReleasePopBack_tests.cc"],
     deps = [
+        ":bitmap_test_matchers",
         "//donner/editor:composited_presentation",
         "//donner/editor:select_tool",
         "//donner/svg",
@@ -895,6 +916,7 @@ donner_cc_test(
     shard_count = 5,
     deps = [
         ":bitmap_golden_compare",
+        ":bitmap_test_matchers",
         "//donner/base:base_test_utils",
         "//donner/editor:async_renderer",
         "//donner/editor:attribute_writeback",
@@ -1020,6 +1042,7 @@ donner_cc_test(
     data = ["//:donner_splash.svg"],
     variants = ["geode"],
     deps = [
+        ":bitmap_test_matchers",
         "//donner/base:base_test_utils",
         "//donner/editor:editor_app",
         "//donner/editor:layer_tree_model",
@@ -1040,6 +1063,7 @@ donner_cc_test(
     ),
     deps = [
         ":bitmap_golden_compare",
+        ":bitmap_test_matchers",
         "//donner/base:base_test_utils",
         "//donner/svg",
         "//donner/svg/parser",

--- a/donner/editor/tests/BitmapGoldenCompare.cc
+++ b/donner/editor/tests/BitmapGoldenCompare.cc
@@ -11,6 +11,7 @@
 #include <string_view>
 #include <vector>
 
+#include "donner/editor/tests/BitmapTestMatchers.h"
 #include "donner/svg/renderer/RendererImageIO.h"  // IWYU pragma: keep
 #include "donner/svg/renderer/RendererInterface.h"
 #include "donner/svg/renderer/tests/RendererImageTestUtils.h"
@@ -62,7 +63,7 @@ std::vector<uint8_t> BuildSideBySide(const std::vector<uint8_t>& expected, int e
 
 void CompareBitmapToGolden(const svg::RendererBitmap& bitmap, std::string_view goldenPath,
                            std::string_view testLabel, const BitmapGoldenCompareParams& params) {
-  ASSERT_FALSE(bitmap.empty()) << "[" << testLabel << "] bitmap is empty";
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap()) << "[" << testLabel << "] bitmap is empty";
   ASSERT_EQ(bitmap.rowBytes % 4u, 0u)
       << "[" << testLabel << "] bitmap rowBytes must be RGBA-aligned";
 
@@ -154,8 +155,9 @@ void CompareBitmapToGolden(const svg::RendererBitmap& bitmap, std::string_view g
 
 void CompareBitmapToBitmap(const svg::RendererBitmap& actual, const svg::RendererBitmap& expected,
                            std::string_view testLabel, const BitmapGoldenCompareParams& params) {
-  ASSERT_FALSE(actual.empty()) << "[" << testLabel << "] actual bitmap is empty";
-  ASSERT_FALSE(expected.empty()) << "[" << testLabel << "] expected bitmap is empty";
+  ASSERT_THAT(actual, NonEmptyRendererBitmap()) << "[" << testLabel << "] actual bitmap is empty";
+  ASSERT_THAT(expected, NonEmptyRendererBitmap())
+      << "[" << testLabel << "] expected bitmap is empty";
   ASSERT_EQ(actual.rowBytes % 4u, 0u)
       << "[" << testLabel << "] actual rowBytes must be RGBA-aligned";
   const int width = actual.dimensions.x;

--- a/donner/editor/tests/BitmapTestMatchers.h
+++ b/donner/editor/tests/BitmapTestMatchers.h
@@ -1,0 +1,21 @@
+#pragma once
+/// @file
+
+#include <gmock/gmock.h>
+
+#include "donner/svg/renderer/RendererInterface.h"
+
+namespace donner::editor::tests {
+
+/// Matches a non-empty \ref svg::RendererBitmap and prints shape details on failure.
+MATCHER(NonEmptyRendererBitmap, "a non-empty renderer bitmap") {
+  if (!arg.empty()) {
+    return true;
+  }
+
+  *result_listener << "dimensions=(" << arg.dimensions.x << ", " << arg.dimensions.y
+                   << "), rowBytes=" << arg.rowBytes << ", pixels=" << arg.pixels.size();
+  return false;
+}
+
+}  // namespace donner::editor::tests

--- a/donner/editor/tests/DragReleasePopBack_tests.cc
+++ b/donner/editor/tests/DragReleasePopBack_tests.cc
@@ -5,6 +5,7 @@
 #include "donner/base/Transform.h"
 #include "donner/editor/CompositedPresentation.h"
 #include "donner/editor/SelectTool.h"
+#include "donner/editor/tests/BitmapTestMatchers.h"
 #include "donner/svg/SVGDocument.h"
 #include "donner/svg/SVGGraphicsElement.h"
 #include "donner/svg/compositor/CompositorController.h"
@@ -17,6 +18,7 @@ namespace donner::editor {
 namespace {
 
 using svg::SVGGraphicsElement;
+using tests::NonEmptyRendererBitmap;
 
 CompositedPresentation::DiagnosticsSnapshot Snapshot(const CompositedPresentation& state) {
   return state.diagnostics();
@@ -122,7 +124,7 @@ TEST(DragReleasePopBackTest, CompositorProducesCorrectOutputAtEveryPhase) {
 
   {
     const auto flat = renderer.takeSnapshot();
-    ASSERT_FALSE(flat.empty());
+    ASSERT_THAT(flat, NonEmptyRendererBitmap());
     EXPECT_THAT(getPixel(flat, kOrigCenterX, kOrigCenterY), IsRed())
         << "Pre-drag flat: rect at original position";
     EXPECT_THAT(getPixel(flat, kMovedCenterX, kMovedCenterY), IsWhite())
@@ -131,7 +133,7 @@ TEST(DragReleasePopBackTest, CompositorProducesCorrectOutputAtEveryPhase) {
 
   {
     const auto& promoted = compositor.layerBitmapOf(entity);
-    ASSERT_FALSE(promoted.empty());
+    ASSERT_THAT(promoted, NonEmptyRendererBitmap());
     const auto [bx, by] = canvasToBitmap(kOrigCenterX, kOrigCenterY);
     EXPECT_THAT(getPixel(promoted, bx, by), IsRed()) << "Pre-drag promoted: rect at DOM position";
   }
@@ -383,7 +385,7 @@ TEST(DragReleasePopBackTest, CpuSnapshotShowsCorrectImageAfterSettling) {
     driver.draw(document);
   }
   const auto preDragFlat = renderer.takeSnapshot();
-  ASSERT_FALSE(preDragFlat.empty());
+  ASSERT_THAT(preDragFlat, NonEmptyRendererBitmap());
   EXPECT_THAT(getPixel(preDragFlat, kOrigCenterX, kOrigCenterY), IsRed());
 
   // Apply the transform (simulating SetTransformCommand).
@@ -395,7 +397,7 @@ TEST(DragReleasePopBackTest, CpuSnapshotShowsCorrectImageAfterSettling) {
     driver.draw(document);
   }
   const auto settlingFlat = renderer.takeSnapshot();
-  ASSERT_FALSE(settlingFlat.empty());
+  ASSERT_THAT(settlingFlat, NonEmptyRendererBitmap());
 
   // The CPU snapshot must show the element at its new position.
   EXPECT_THAT(getPixel(settlingFlat, kMovedCenterX, kMovedCenterY), IsRed())
@@ -522,10 +524,12 @@ TEST(DragReleasePopBackTest, EndToEndFrameSequence) {
       // Composited path: the promoted texture is drawn at DOM position + screen offset.
       // The "screen offset" in document coordinates is preview->translation.
       // We verify the promoted (drag-target) tile has cached pixels.
-      EXPECT_FALSE(uploadedPromoted.empty()) << label << ": promoted bitmap should exist";
+      EXPECT_THAT(uploadedPromoted, NonEmptyRendererBitmap())
+          << label << ": promoted bitmap should exist";
     } else {
       // No composited texture yet: the CPU snapshot should still contain valid pixels.
-      ASSERT_FALSE(uploadedSnapshot.empty()) << label << ": CPU snapshot must exist";
+      ASSERT_THAT(uploadedSnapshot, NonEmptyRendererBitmap())
+          << label << ": CPU snapshot must exist";
       // After any post-drag render, the snapshot must show the element at the moved position. If it
       // shows the original position, that's the pop.
       EXPECT_THAT(getPixel(uploadedSnapshot, kOrigCenterX, kOrigCenterY), IsNotRed())

--- a/donner/editor/tests/EditorWindow_tests.cc
+++ b/donner/editor/tests/EditorWindow_tests.cc
@@ -37,6 +37,7 @@
 #include "donner/editor/SelectTool.h"
 #include "donner/editor/TextEditor.h"
 #include "donner/editor/ViewportState.h"
+#include "donner/editor/tests/BitmapTestMatchers.h"
 #include "donner/svg/parser/SVGParser.h"
 #include "donner/svg/properties/PaintServer.h"
 #include "donner/svg/renderer/Renderer.h"
@@ -51,6 +52,7 @@ namespace donner::editor::gui {
 namespace {
 
 #if defined(DONNER_EDITOR_WGPU)
+using ::donner::editor::tests::NonEmptyRendererBitmap;
 using svg::test::Near;
 using svg::test::Rgba;
 using ::testing::SizeIs;
@@ -571,7 +573,7 @@ TEST(EditorWindowTest, WgpuDirectRenderCallbackAppendsToFramebuffer) {
   ImGui::GetBackgroundDrawList()->AddRectFilled(ImVec2(0.0f, 0.0f), ImVec2(96.0f, 96.0f),
                                                 IM_COL32(0, 0, 255, 255));
   const svg::RendererBitmap actual = window.endFrameAndReadPixels();
-  ASSERT_FALSE(actual.empty());
+  ASSERT_THAT(actual, NonEmptyRendererBitmap());
   const Vector2d readbackFromLogical = ReadbackScale(actual, 96, 96);
 
   const std::array<std::uint8_t, 4> outside = PixelAtLogical(actual, readbackFromLogical, 16, 16);
@@ -626,7 +628,7 @@ TEST(EditorWindowTest, WgpuUnderlayDirectRenderCallbackDrawsBelowImGui) {
   ImGui::GetBackgroundDrawList()->AddRectFilled(ImVec2(32.0f, 32.0f), ImVec2(64.0f, 64.0f),
                                                 IM_COL32(0, 0, 255, 255));
   const svg::RendererBitmap actual = window.endFrameAndReadPixels();
-  ASSERT_FALSE(actual.empty());
+  ASSERT_THAT(actual, NonEmptyRendererBitmap());
   const Vector2d readbackFromLogical = ReadbackScale(actual, 96, 96);
 
   const std::array<std::uint8_t, 4> underlayOnly =
@@ -727,7 +729,7 @@ TEST(EditorWindowTest, WgpuPresentsFilledPromotedLayerAfterStyleMutation) {
   window.beginFrame();
   const svg::RendererBitmap actual = window.endFrameAndReadPixels();
   WriteDiagnosticBitmap(actual, "filled_promoted_layer_after_style_mutation.png");
-  ASSERT_FALSE(actual.empty());
+  ASSERT_THAT(actual, NonEmptyRendererBitmap());
   EXPECT_GT(CountGreenPixels(actual), 600)
       << "A style mutation on a selected path must publish and present a Geode layer texture whose "
          "pixels include the new fill color.";
@@ -831,7 +833,7 @@ TEST(EditorWindowTest, WgpuPresentsFilledPenCreatedPromotedLayerAfterStyleMutati
   window.beginFrame();
   const svg::RendererBitmap actual = window.endFrameAndReadPixels();
   WriteDiagnosticBitmap(actual, "filled_pen_created_promoted_layer_after_style_mutation.png");
-  ASSERT_FALSE(actual.empty());
+  ASSERT_THAT(actual, NonEmptyRendererBitmap());
   EXPECT_GT(CountGreenPixels(actual), 600)
       << "A fill mutation on a Pen-created selected path must refresh the Geode promoted layer "
          "texture instead of retaining the no-fill snapshot.";
@@ -936,7 +938,7 @@ TEST(EditorWindowTest, WgpuPresentsFilledSplashPenLayerAfterStyleMutation) {
   window.beginFrame();
   const svg::RendererBitmap actual = window.endFrameAndReadPixels();
   WriteDiagnosticBitmap(actual, "filled_splash_pen_layer_after_style_mutation.png");
-  ASSERT_FALSE(actual.empty());
+  ASSERT_THAT(actual, NonEmptyRendererBitmap());
   EXPECT_GT(CountGreenPixels(actual), 600)
       << "The Donner splash compositor must publish the new fill pixels for the Pen-created "
          "selected layer.";
@@ -1046,7 +1048,7 @@ TEST(EditorWindowTest, WgpuPenFillReplayViewportPublishesFilledLayerTile) {
   window.beginFrame();
   const svg::RendererBitmap actual = window.endFrameAndReadPixels();
   WriteDiagnosticBitmap(actual, "pen_fill_replay_viewport_layer_texture.png");
-  ASSERT_FALSE(actual.empty());
+  ASSERT_THAT(actual, NonEmptyRendererBitmap());
   EXPECT_GT(CountGreenPixels(actual), 600)
       << "The promoted-layer texture for the replay path must contain the new fill color.";
 }
@@ -1170,7 +1172,7 @@ TEST(EditorWindowTest, WgpuPenFillLiveSourceSyncPublishesFilledLayerTile) {
   window.beginFrame();
   const svg::RendererBitmap actual = window.endFrameAndReadPixels();
   WriteDiagnosticBitmap(actual, "pen_fill_live_source_sync_layer_texture.png");
-  ASSERT_FALSE(actual.empty());
+  ASSERT_THAT(actual, NonEmptyRendererBitmap());
   EXPECT_GT(CountGreenPixels(actual), 600)
       << "The promoted-layer texture for a live source-synced Pen path must contain the fill "
          "chosen through the UI.";
@@ -1216,7 +1218,7 @@ TEST(EditorWindowTest, WgpuPresentsGeodePremultipliedTextureWithoutDarkening) {
   ImGui::GetBackgroundDrawList()->AddImage(textureId, ImVec2(16.0f, 16.0f), ImVec2(80.0f, 80.0f));
   const svg::RendererBitmap actual = window.endFrameAndReadPixels();
 
-  ASSERT_FALSE(actual.empty());
+  ASSERT_THAT(actual, NonEmptyRendererBitmap());
   const std::array<std::uint8_t, 4> center = PixelAt(actual, 48, 48);
   EXPECT_THAT(center, Rgba(Near(128, 3), testing::Le(3), testing::Le(3), testing::Eq(255)))
       << "A premultiplied red texture should not be multiplied by alpha again during ImGui "
@@ -1272,7 +1274,7 @@ TEST(EditorWindowTest, WgpuPresentsUploadedStraightAlphaBitmapWithStraightBlend)
                                            ImVec2(48.0f, 48.0f));
   const svg::RendererBitmap actual = window.endFrameAndReadPixels();
 
-  ASSERT_FALSE(actual.empty());
+  ASSERT_THAT(actual, NonEmptyRendererBitmap());
   const std::array<std::uint8_t, 4> center = PixelAt(actual, 32, 32);
   EXPECT_THAT(center, Rgba(Near(128, 3), testing::Le(3), testing::Le(3), testing::Eq(255)))
       << "CPU bitmap uploads are straight-alpha RGBA; registering them as premultiplied makes "
@@ -1327,7 +1329,7 @@ TEST(EditorWindowTest, WgpuLayerThumbnailUploadHonorsPayloadUv) {
                                                   static_cast<float>(uploaded.uvBottomRight.y)));
   const svg::RendererBitmap actual = window.endFrameAndReadPixels();
 
-  ASSERT_FALSE(actual.empty());
+  ASSERT_THAT(actual, NonEmptyRendererBitmap());
   const std::array<std::uint8_t, 4> center = PixelAt(actual, 37, 28);
   EXPECT_THAT(center, Rgba(testing::Le(8), testing::Ge(245), testing::Le(8), testing::Eq(255)))
       << "The middle band should stay green; sampling the full power-of-two texture instead of "
@@ -1403,7 +1405,7 @@ TEST(EditorWindowTest, WgpuLayersPanelPresentsBackgroundStickerThumbnailLikeGold
       FindTextureDrawRect(*ImGui::GetWindowDrawList(), actualUpload.texture);
   ImGui::End();
   const svg::RendererBitmap actualFramebuffer = window.endFrameAndReadPixels();
-  ASSERT_FALSE(actualFramebuffer.empty());
+  ASSERT_THAT(actualFramebuffer, NonEmptyRendererBitmap());
   ASSERT_TRUE(actualRect.has_value())
       << "expected the Background_sticker row to draw the uploaded thumbnail texture";
 
@@ -1417,7 +1419,7 @@ TEST(EditorWindowTest, WgpuLayersPanelPresentsBackgroundStickerThumbnailLikeGold
                                       static_cast<float>(expectedUpload.uvBottomRight.y)));
   foregroundDrawList->AddRect(expectedMin, expectedMax, IM_COL32(255, 255, 255, 60), 3.0f);
   const svg::RendererBitmap expectedFramebuffer = window.endFrameAndReadPixels();
-  ASSERT_FALSE(expectedFramebuffer.empty());
+  ASSERT_THAT(expectedFramebuffer, NonEmptyRendererBitmap());
 
   const Vector2d actualReadbackFromLogical = ReadbackScale(actualFramebuffer, 500, 260);
   const Vector2d expectedReadbackFromLogical = ReadbackScale(expectedFramebuffer, 500, 260);
@@ -1500,7 +1502,7 @@ TEST(EditorWindowTest, WgpuPremultipliedTextureSurvivesOnePresentationOwnerRetir
   const svg::RendererBitmap actual = window.endFrameAndReadPixels();
   WriteDiagnosticBitmap(actual, "premul_shared_owner_retire_presentation.png");
 
-  ASSERT_FALSE(actual.empty());
+  ASSERT_THAT(actual, NonEmptyRendererBitmap());
   const Vector2d readbackFromLogical = ReadbackScale(actual, 128, 96);
   const std::array<std::uint8_t, 4> center =
       PixelAtLogical(actual, readbackFromLogical, 32.0, 32.0);
@@ -1536,7 +1538,7 @@ TEST(EditorWindowTest, WgpuPresentsZoomedBlurredPremultipliedTextureWithoutDarke
   const svg::RendererBitmap actual = window.endFrameAndReadPixels();
   WriteDiagnosticBitmap(actual, "zoomed_blurred_premul_presentation.png");
 
-  ASSERT_FALSE(actual.empty());
+  ASSERT_THAT(actual, NonEmptyRendererBitmap());
   const Vector2d readbackFromLogical = ReadbackScale(actual, 368, 232);
   const double referenceLuma =
       MeanLumaAtLogical(actual, readbackFromLogical, 16.0 + 48.0, 68.0 + 48.0, 1.0);
@@ -1588,7 +1590,7 @@ TEST(EditorWindowTest, WgpuPresentsZoomedCompositedBlurredLayerWithoutDarkening)
   const svg::RendererBitmap actual = window.endFrameAndReadPixels();
   WriteDiagnosticBitmap(actual, "zoomed_composited_blurred_layer_presentation.png");
 
-  ASSERT_FALSE(actual.empty());
+  ASSERT_THAT(actual, NonEmptyRendererBitmap());
   const Vector2d readbackFromLogical = ReadbackScale(actual, 592, 368);
   const double referenceCenterLuma =
       MeanLumaAtLogical(actual, readbackFromLogical, 16.0 + 80.0, 24.0 + 80.0, 2.0);
@@ -1662,7 +1664,7 @@ TEST(EditorWindowTest, WgpuPresentsZoomedDonnerSplashFilteredLayerWithoutDarkeni
   const svg::RendererBitmap actual = window.endFrameAndReadPixels();
   WriteDiagnosticBitmap(actual, "zoomed_donner_splash_filtered_layer_presentation.png");
 
-  ASSERT_FALSE(actual.empty());
+  ASSERT_THAT(actual, NonEmptyRendererBitmap());
   const Vector2d readbackFromLogical = ReadbackScale(actual, 760, 300);
   const double referenceCenterLuma =
       MeanLumaAtLogical(actual, readbackFromLogical, kReferenceCenterX, kCenterY, 2.0);

--- a/donner/editor/tests/LayerThumbnailGolden_tests.cc
+++ b/donner/editor/tests/LayerThumbnailGolden_tests.cc
@@ -12,6 +12,7 @@
 
 #include "donner/base/tests/Runfiles.h"
 #include "donner/editor/tests/BitmapGoldenCompare.h"
+#include "donner/editor/tests/BitmapTestMatchers.h"
 #include "donner/svg/SVGDocument.h"
 #include "donner/svg/SVGElement.h"
 #include "donner/svg/parser/SVGParser.h"
@@ -79,7 +80,8 @@ TEST(LayerThumbnailGoldenTest, DonnerSplashLayerThumbnailsMatchGoldens) {
 
     const svg::RendererBitmap bitmap =
         renderer.renderElementToBitmap(*element, kLayerThumbnailMaxSize);
-    ASSERT_FALSE(bitmap.empty()) << "Layer " << testCase.label << " produced an empty thumbnail";
+    ASSERT_THAT(bitmap, NonEmptyRendererBitmap())
+        << "Layer " << testCase.label << " produced an empty thumbnail";
 
     CompareBitmapToGolden(bitmap, testCase.goldenPath, testCase.label, PixelmatchIdentityParams());
   }

--- a/donner/editor/tests/OverlayRenderer_tests.cc
+++ b/donner/editor/tests/OverlayRenderer_tests.cc
@@ -11,6 +11,7 @@
 
 #include "donner/base/Transform.h"
 #include "donner/editor/EditorApp.h"
+#include "donner/editor/tests/BitmapTestMatchers.h"
 #include "donner/svg/DocumentState.h"
 #include "donner/svg/SVGGeometryElement.h"
 #include "donner/svg/SVGGraphicsElement.h"
@@ -37,6 +38,7 @@ using ::testing::IsEmpty;
 using ::testing::Not;
 using ::testing::ResultOf;
 using ::testing::SizeIs;
+using tests::NonEmptyRendererBitmap;
 
 constexpr double kPi = 3.14159265358979323846;
 
@@ -141,7 +143,7 @@ TEST(OverlayRendererTest, EmitsChromeForSelectedElement) {
   // pixels here without going to the framebuffer-golden tier, but we
   // can at least confirm the renderer produced *something*.
   const auto bitmap = renderer.takeSnapshot();
-  EXPECT_FALSE(bitmap.empty());
+  EXPECT_THAT(bitmap, NonEmptyRendererBitmap());
   EXPECT_GT(bitmap.dimensions.x, 0);
   EXPECT_GT(bitmap.dimensions.y, 0);
 }
@@ -412,7 +414,7 @@ TEST(OverlayRendererTest, OverlayRendersIntoStandaloneRendererFrame) {
   overlayRenderer.endFrame();
 
   const auto bitmap = overlayRenderer.takeSnapshot();
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
   EXPECT_EQ(bitmap.dimensions.x, 200);
   EXPECT_EQ(bitmap.dimensions.y, 200);
 
@@ -457,7 +459,7 @@ TEST(OverlayRendererTest, DrawsWhiteCornerHandlesWithSelectionStroke) {
   overlayRenderer.endFrame();
 
   const auto bitmap = overlayRenderer.takeSnapshot();
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
 
   const auto pixelAt = [&](int x, int y, int channel) -> std::uint8_t {
     const std::uint8_t* row = bitmap.pixels.data() + y * bitmap.rowBytes;
@@ -572,7 +574,7 @@ TEST(OverlayRendererTest, RepeatedOverlayRendersWithChangingSelection) {
     OverlayRenderer::drawChromeWithTransform(overlayRenderer, selection, canvasFromDoc);
     overlayRenderer.endFrame();
     auto bitmap = overlayRenderer.takeSnapshot();
-    EXPECT_FALSE(bitmap.empty());
+    EXPECT_THAT(bitmap, NonEmptyRendererBitmap());
     EXPECT_EQ(bitmap.dimensions.x, 200);
     EXPECT_EQ(bitmap.dimensions.y, 200);
   };
@@ -636,7 +638,7 @@ TEST(OverlayRendererTest, PathOutlineFollowsElementTransform) {
   overlayRenderer.endFrame();
 
   const auto bitmap = overlayRenderer.takeSnapshot();
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
 
   // Helper: returns the alpha at a given canvas pixel.
   const auto alphaAt = [&](int x, int y) -> std::uint8_t {
@@ -701,7 +703,7 @@ TEST(OverlayRendererTest, DisplayNoneSelectionStillDrawsPathOutline) {
   overlayRenderer.endFrame();
 
   const auto bitmap = overlayRenderer.takeSnapshot();
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
 
   const auto pixelAt = [&](int x, int y) -> std::array<std::uint8_t, 4> {
     const std::uint8_t* row = bitmap.pixels.data() + y * bitmap.rowBytes;
@@ -752,7 +754,7 @@ TEST(OverlayRendererTest, DisplayNonePathSelectionStillDrawsPathOutline) {
   overlayRenderer.endFrame();
 
   const auto bitmap = overlayRenderer.takeSnapshot();
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
 
   const auto alphaAt = [&](int x, int y) -> std::uint8_t {
     const std::uint8_t* row = bitmap.pixels.data() + y * bitmap.rowBytes;
@@ -815,7 +817,7 @@ TEST(OverlayRendererTest, PathOutlineDrawnAtTransformedLocationNotInverted) {
   overlayRenderer.endFrame();
 
   const auto bitmap = overlayRenderer.takeSnapshot();
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
 
   const auto alphaAt = [&](int x, int y) -> std::uint8_t {
     const std::uint8_t* row = bitmap.pixels.data() + y * bitmap.rowBytes;
@@ -873,7 +875,7 @@ TEST(OverlayRendererTest, PathOutlineStrokeDoesNotInheritElementScale) {
   overlayRenderer.endFrame();
 
   const auto bitmap = overlayRenderer.takeSnapshot();
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
 
   const auto alphaAt = [&](int x, int y) -> std::uint8_t {
     const std::uint8_t* row = bitmap.pixels.data() + y * bitmap.rowBytes;
@@ -918,7 +920,7 @@ TEST(OverlayRendererTest, MultiElementSpanDrawsPathOutlinesForEachSelectedElemen
   overlayRenderer.endFrame();
 
   const auto bitmap = overlayRenderer.takeSnapshot();
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
 
   // Helper: returns the alpha at a given canvas pixel.
   const auto alphaAt = [&](int x, int y) -> std::uint8_t {
@@ -985,7 +987,7 @@ TEST(OverlayRendererTest, MultiSelectDrawsCombinedAabbInSkiaOverlay) {
   overlayRenderer.endFrame();
 
   const auto bitmap = overlayRenderer.takeSnapshot();
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
   const auto alphaAt = [&](int x, int y) {
     const std::uint8_t* row = bitmap.pixels.data() + y * bitmap.rowBytes;
     return row[x * 4 + 3];
@@ -1053,7 +1055,7 @@ TEST(OverlayRendererTest, SelectingFilterGroupDrawsOutlinesOfAllGeometryDescenda
   overlayRenderer.endFrame();
 
   const auto bitmap = overlayRenderer.takeSnapshot();
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
   const auto alphaAt = [&](int x, int y) -> std::uint8_t {
     const std::uint8_t* row = bitmap.pixels.data() + y * bitmap.rowBytes;
     return row[x * 4 + 3];
@@ -1116,7 +1118,7 @@ TEST(OverlayRendererTest, SelectingGroupSkipsNonRenderedContainerChildren) {
   overlayRenderer.endFrame();
 
   const auto bitmap = overlayRenderer.takeSnapshot();
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
   const auto alphaAt = [&](int x, int y) -> std::uint8_t {
     const std::uint8_t* row = bitmap.pixels.data() + y * bitmap.rowBytes;
     return row[x * 4 + 3];
@@ -1160,7 +1162,7 @@ TEST(OverlayRendererTest, EmptySelectionSpanProducesTransparentOverlay) {
   overlayRenderer.endFrame();
 
   const auto bitmap = overlayRenderer.takeSnapshot();
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
 
   for (std::size_t y = 0; y < static_cast<std::size_t>(bitmap.dimensions.y); ++y) {
     const std::uint8_t* row = bitmap.pixels.data() + y * bitmap.rowBytes;
@@ -1187,7 +1189,7 @@ TEST(OverlayRendererTest, EmptySelectionSpanWithIdentityTransformIsNoOp) {
   overlayRenderer.endFrame();
 
   const auto bitmap = overlayRenderer.takeSnapshot();
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
   // Bitmap should be entirely transparent (the beginFrame clear).
   for (std::size_t y = 0; y < static_cast<std::size_t>(bitmap.dimensions.y); ++y) {
     const std::uint8_t* row = bitmap.pixels.data() + y * bitmap.rowBytes;
@@ -1397,7 +1399,7 @@ TEST(OverlayRendererTest, LockedFlashDrawsRedOutlineScaledByIntensity) {
   };
 
   const auto fullBitmap = drawFlashAtIntensity(1.0f);
-  ASSERT_FALSE(fullBitmap.empty());
+  ASSERT_THAT(fullBitmap, NonEmptyRendererBitmap());
 
   const auto pixelAt = [](const auto& bitmap, int x, int y, int channel) -> std::uint8_t {
     const std::uint8_t* row = bitmap.pixels.data() + y * bitmap.rowBytes;
@@ -1427,7 +1429,7 @@ TEST(OverlayRendererTest, LockedFlashDrawsRedOutlineScaledByIntensity) {
 
   // A dimmer flash should produce a lower peak alpha on the same outline band.
   const auto dimBitmap = drawFlashAtIntensity(0.3f);
-  ASSERT_FALSE(dimBitmap.empty());
+  ASSERT_THAT(dimBitmap, NonEmptyRendererBitmap());
   int maxRedAlphaDim = 0;
   for (int y = 28; y <= 82; ++y) {
     for (int x = 18; x <= 62; ++x) {

--- a/donner/editor/tests/PenTool_tests.cc
+++ b/donner/editor/tests/PenTool_tests.cc
@@ -17,6 +17,7 @@
 #include "donner/editor/SelectTool.h"
 #include "donner/editor/SelectionAabb.h"
 #include "donner/editor/TextEditor.h"
+#include "donner/editor/tests/BitmapTestMatchers.h"
 #include "donner/svg/SVGElement.h"
 #include "donner/svg/SVGPathElement.h"
 #include "donner/svg/renderer/Renderer.h"
@@ -26,6 +27,8 @@
 
 namespace donner::editor {
 namespace {
+
+using tests::NonEmptyRendererBitmap;
 
 constexpr std::string_view kEmptySvg =
     R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"></svg>)";
@@ -53,16 +56,6 @@ MATCHER_P(BoxContainingPoint, point,
   *result_listener << "box [" << arg.topLeft.x << ", " << arg.topLeft.y << " — "
                    << arg.bottomRight.x << ", " << arg.bottomRight.y << "] does not contain ("
                    << point.x << ", " << point.y << ")";
-  return false;
-}
-
-MATCHER(NonEmptyRendererBitmap, "a non-empty RendererBitmap") {
-  if (!arg.empty()) {
-    return true;
-  }
-
-  *result_listener << "dimensions=(" << arg.dimensions.x << ", " << arg.dimensions.y
-                   << "), pixels=" << arg.pixels.size() << ", rowBytes=" << arg.rowBytes;
   return false;
 }
 

--- a/donner/editor/tests/RenderElementToBitmap_tests.cc
+++ b/donner/editor/tests/RenderElementToBitmap_tests.cc
@@ -19,11 +19,14 @@
 #include "donner/base/tests/Runfiles.h"
 #include "donner/editor/EditorApp.h"
 #include "donner/editor/LayerTreeModel.h"
+#include "donner/editor/tests/BitmapTestMatchers.h"
 #include "donner/svg/SVGElement.h"
 #include "donner/svg/renderer/Renderer.h"
 
 namespace donner::svg {
 namespace {
+
+using editor::tests::NonEmptyRendererBitmap;
 
 constexpr std::string_view kRedRectSvg =
     R"SVG(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
@@ -180,7 +183,7 @@ TEST(RenderElementToBitmapTest, RedRectFillsCenterRed) {
 
   Renderer renderer;
   const RendererBitmap bitmap = renderer.renderElementToBitmap(*rect, Vector2i(24, 24));
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
   EXPECT_EQ(bitmap.dimensions, Vector2i(24, 24));
 
   // The square fills the cell, so the center pixel is the rect's opaque fill.
@@ -204,7 +207,7 @@ TEST(RenderElementToBitmapTest, GreenCircleCenterGreenCornerTransparent) {
 
   Renderer renderer;
   const RendererBitmap bitmap = renderer.renderElementToBitmap(*circle, Vector2i(24, 24));
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
 
   // Center is inside the circle: green and opaque.
   EXPECT_THAT(PixelAt(bitmap, 12, 12), RgbaNear(0, 200, 0, 255, 6));
@@ -222,7 +225,7 @@ TEST(RenderElementToBitmapTest, ForegroundThumbnailDoesNotIncludeBackgroundSibli
 
   Renderer renderer;
   const RendererBitmap bitmap = renderer.renderElementToBitmap(*dot, Vector2i(24, 24));
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
 
   EXPECT_THAT(PixelAt(bitmap, 12, 12), RgbaNear(250, 225, 0, 255, 6));
   EXPECT_THAT(PixelAt(bitmap, 0, 0), RgbaNear(0, 0, 0, 0, 2))
@@ -241,7 +244,7 @@ TEST(RenderElementToBitmapTest, DonnerSplashLayerThumbnailDoesNotIncludeBackgrou
 
   Renderer renderer;
   const RendererBitmap bitmap = renderer.renderElementToBitmap(*donner, Vector2i(32, 32));
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
 
   EXPECT_THAT(PixelAt(bitmap, 0, 0), RgbaNear(0, 0, 0, 0, 2))
       << "the Donner layer thumbnail should keep empty crop corners transparent instead of "
@@ -259,7 +262,7 @@ TEST(RenderElementToBitmapTest, DonnerSplashDonnerThumbnailShowsLetterFill) {
 
   Renderer renderer;
   const RendererBitmap bitmap = renderer.renderElementToBitmap(*donner, Vector2i(32, 32));
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
 
   EXPECT_THAT(PixelAt(bitmap, 0, 0), RgbaNear(0, 0, 0, 0, 2))
       << "the Donner layer itself does not include the document background or sticker silhouette";
@@ -283,7 +286,7 @@ TEST(RenderElementToBitmapTest, DonnerSplashSunburstThumbnailCentersBrightConten
 
   Renderer renderer;
   const RendererBitmap bitmap = renderer.renderElementToBitmap(*sunburst, Vector2i(32, 32));
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
 
   const int warmPixels = CountPixelsMatching(bitmap, IsBrightWarmPixel);
   ASSERT_GT(warmPixels, 20) << "the Sunburst thumbnail should include the sun, not only shine";
@@ -302,7 +305,7 @@ TEST(RenderElementToBitmapTest, DonnerSplashSunburstThumbnailUsesFullElementBoun
 
   Renderer renderer;
   const RendererBitmap bitmap = renderer.renderElementToBitmap(*sunburst, Vector2i(42, 24));
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
 
   // #Sunburst's full canvas-visible element bounds are the shine ellipse
   // (455.4x272.32 after clipping the off-canvas top to the root viewBox), so
@@ -323,7 +326,7 @@ TEST(RenderElementToBitmapTest, DonnerSplashBlueCenterBurstThumbnailUsesFullElem
 
   Renderer renderer;
   const RendererBitmap bitmap = renderer.renderElementToBitmap(*burst, Vector2i(42, 24));
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
 
   // #Blue_center_burst is a 365.32x420.64 ellipse, clipped by the root viewBox
   // to 365.32x419.06. Fitting the whole element into 42x24 produces 21x24.
@@ -378,7 +381,7 @@ TEST(RenderElementToBitmapTest, WideLayerThumbnailFitsFullContentInRectangularBi
 
   Renderer renderer;
   const RendererBitmap bitmap = renderer.renderElementToBitmap(*group, Vector2i(42, 24));
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
 
   EXPECT_EQ(bitmap.dimensions.x, 42);
   EXPECT_GE(bitmap.dimensions.y, 3);
@@ -403,7 +406,7 @@ TEST(RenderElementToBitmapTest, TransparentGeometryDoesNotBiasTightCrop) {
 
   Renderer renderer;
   const RendererBitmap bitmap = renderer.renderElementToBitmap(*group, Vector2i(24, 24));
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
 
   EXPECT_GT(CountPixelsMatching(bitmap, IsBrightWarmPixel), 250)
       << "the visible circle should fill the thumbnail after alpha-tight cropping";
@@ -420,7 +423,7 @@ TEST(RenderElementToBitmapTest, StrokeOnlyLayerThumbnailUsesStrokeContentBounds)
 
   Renderer renderer;
   const RendererBitmap bitmap = renderer.renderElementToBitmap(*line, Vector2i(24, 24));
-  ASSERT_FALSE(bitmap.empty())
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap())
       << "stroke-only geometry is visible layer content and must not fall back to a fill swatch";
 
   EXPECT_EQ(bitmap.dimensions.x, 24);
@@ -439,7 +442,7 @@ TEST(RenderElementToBitmapTest, GroupComposesDescendants) {
 
   Renderer renderer;
   const RendererBitmap bitmap = renderer.renderElementToBitmap(*group, Vector2i(24, 24));
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
 
   // The group's two halves compose into one preview: left blue, right yellow.
   EXPECT_THAT(PixelAt(bitmap, 6, 12), RgbaNear(80, 200, 255, 255, 6));
@@ -455,7 +458,7 @@ TEST(RenderElementToBitmapTest, WideBackgroundFillsMatchingRectangularThumbnail)
 
   Renderer renderer;
   const RendererBitmap bitmap = renderer.renderElementToBitmap(*background, Vector2i(42, 24));
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
 
   EXPECT_EQ(bitmap.dimensions, Vector2i(42, 24));
   EXPECT_THAT(PixelAt(bitmap, 21, 0), RgbaNear(0, 0, 0, 255, 4))
@@ -474,7 +477,7 @@ TEST(RenderElementToBitmapTest, RootGroupThumbnailIsClippedToSvgViewBox) {
 
   Renderer renderer;
   const RendererBitmap bitmap = renderer.renderElementToBitmap(*group, Vector2i(24, 24));
-  ASSERT_FALSE(bitmap.empty());
+  ASSERT_THAT(bitmap, NonEmptyRendererBitmap());
 
   EXPECT_THAT(PixelAt(bitmap, 12, 0), RgbaNear(0, 0, 0, 255, 4))
       << "off-canvas descendants must not expand the root group thumbnail crop";

--- a/donner/editor/tests/RenderPanePresenterVisualRepro_tests.cc
+++ b/donner/editor/tests/RenderPanePresenterVisualRepro_tests.cc
@@ -15,6 +15,7 @@
 #include "donner/editor/ImGuiIncludes.h"
 #include "donner/editor/RenderPanePresenter.h"
 #include "donner/editor/gui/EditorWindow.h"
+#include "donner/editor/tests/BitmapTestMatchers.h"
 #include "donner/svg/renderer/RendererImageIO.h"
 #include "donner/svg/renderer/tests/RgbaTestMatchers.h"
 #include "gtest/gtest.h"
@@ -25,6 +26,7 @@ namespace {
 using svg::test::Rgba;
 using ::testing::Eq;
 using ::testing::Lt;
+using tests::NonEmptyRendererBitmap;
 
 constexpr int kLogicalWidth = 320;
 constexpr int kLogicalHeight = 220;
@@ -304,7 +306,7 @@ TEST(RenderPanePresenterVisualReproTest, OverviewInfillDoesNotBleedThroughTransp
   const svg::RendererBitmap actual = CapturePresenterFrame(&window, &textures, entt::null);
   WriteDiagnosticBitmap(actual, "actual_transparent_active_overview_infill.png");
 
-  ASSERT_FALSE(actual.empty());
+  ASSERT_THAT(actual, NonEmptyRendererBitmap());
   const std::array<std::uint8_t, 4> center =
       PixelAtLogical(actual, kLogicalWidth / 2, kLogicalHeight / 2);
   EXPECT_THAT(center, Rgba(Lt(100), Lt(100), Lt(100), Eq(255)))
@@ -362,7 +364,7 @@ TEST(RenderPanePresenterVisualReproTest, OverviewInfillDoesNotBleedThroughOldDra
       CapturePresenterFrame(&window, &textures, entt::null, activePreview, displayedPreview);
   WriteDiagnosticBitmap(actual, "actual_drag_target_old_bounds_overview_infill.png");
 
-  ASSERT_FALSE(actual.empty());
+  ASSERT_THAT(actual, NonEmptyRendererBitmap());
   const std::array<std::uint8_t, 4> oldLeftEdge = PixelAtLogical(actual, 40, kLogicalHeight / 2);
   EXPECT_THAT(oldLeftEdge, Rgba(Lt(100), Lt(100), Lt(100), Eq(255)))
       << "Overview infill must not redraw stale drag-target pixels at the old background "

--- a/donner/editor/tests/RnrReplay_tests.cc
+++ b/donner/editor/tests/RnrReplay_tests.cc
@@ -35,6 +35,7 @@
 #include "donner/editor/ViewportState.h"
 #include "donner/editor/repro/ReproFile.h"
 #include "donner/editor/tests/BitmapGoldenCompare.h"
+#include "donner/editor/tests/BitmapTestMatchers.h"
 #include "donner/svg/SVGGraphicsElement.h"
 #include "donner/svg/renderer/Renderer.h"
 #include "donner/svg/renderer/RendererImageIO.h"  // IWYU pragma: keep
@@ -44,6 +45,7 @@ namespace donner::editor {
 namespace {
 
 using ::testing::SizeIs;
+using tests::NonEmptyRendererBitmap;
 
 bool IsGraphicsElement(const svg::SVGElement& element) {
   return element.withReadAccess([&element](svg::DocumentReadAccess&, EntityHandle) {
@@ -413,7 +415,8 @@ protected:
     SyncCanvasSize(app, viewport);
     auto initialResult = RequestRenderAndWait(asyncRenderer, renderer, app, selectTool);
     ASSERT_TRUE(initialResult.has_value()) << "Initial render timed out";
-    ASSERT_FALSE(initialResult->bitmap.empty()) << "Initial render produced an empty bitmap";
+    ASSERT_THAT(initialResult->bitmap, NonEmptyRendererBitmap())
+        << "Initial render produced an empty bitmap";
 
     out->bitmap = initialResult->bitmap;
     out->frameIndex = 0;
@@ -483,7 +486,7 @@ protected:
       if (frameNeedsRender) {
         auto result = RequestRenderAndWait(asyncRenderer, renderer, app, selectTool);
         ASSERT_TRUE(result.has_value()) << "Render timed out at replay frame " << frame.index;
-        ASSERT_FALSE(result->bitmap.empty())
+        ASSERT_THAT(result->bitmap, NonEmptyRendererBitmap())
             << "Render produced an empty bitmap at frame " << frame.index;
         out->bitmap = result->bitmap;
       }
@@ -505,7 +508,8 @@ protected:
     if (out->stoppedForBisection) {
       out->diagnosticPath = DiagnosticOutputDir() /
                             ("rnr_replay_bisect_frame_" + std::to_string(out->frameIndex) + ".png");
-      ASSERT_FALSE(out->bitmap.empty()) << "No bitmap available to dump for BISECTION_FRAME";
+      ASSERT_THAT(out->bitmap, NonEmptyRendererBitmap())
+          << "No bitmap available to dump for BISECTION_FRAME";
       svg::RendererImageIO::writeRgbaPixelsToPngFile(
           out->diagnosticPath.string().c_str(), out->bitmap.pixels, out->bitmap.dimensions.x,
           out->bitmap.dimensions.y, out->bitmap.rowBytes / 4u);
@@ -842,7 +846,7 @@ TEST_F(RnrReplayTest, FilterDisappearRepro3MatchesGoldenAfterSecondMouseUp) {
 
   ASSERT_GE(snapshot.mouseUpCount, kTargetMouseUpCount)
       << "Replay ended before the second mouse-up checkpoint";
-  ASSERT_FALSE(snapshot.bitmap.empty()) << "Replay produced an empty final bitmap";
+  ASSERT_THAT(snapshot.bitmap, NonEmptyRendererBitmap()) << "Replay produced an empty final bitmap";
 
   // Approved exception: this committed golden still has small AA/raster drift across replay runs.
   // The test remains useful for the presented-frame regression while the fixture is not yet
@@ -897,7 +901,7 @@ TEST_F(RnrReplayTest, FilterSnapbackReproPreservesCompositorAcrossWriteback) {
   drainWritebacksEachFrame_ = true;
   ReplayRecording("donner/editor/tests/filter_snapback_repro.rnr", &snapshot);
 
-  ASSERT_FALSE(snapshot.bitmap.empty()) << "Replay produced an empty final bitmap";
+  ASSERT_THAT(snapshot.bitmap, NonEmptyRendererBitmap()) << "Replay produced an empty final bitmap";
   EXPECT_EQ(snapshot.compositorReconstructCount, 1u)
       << "Compositor was reconstructed " << snapshot.compositorReconstructCount
       << " times — the post-drag-release source reparse must route through "
@@ -958,7 +962,7 @@ TEST_F(RnrReplayTest, DeleteElementDoesNotResetPreviouslyMovedShapes) {
   {
     auto initial = RequestRenderAndWait(asyncRenderer, renderer, app, selectTool);
     ASSERT_TRUE(initial.has_value());
-    ASSERT_FALSE(initial->bitmap.empty());
+    ASSERT_THAT(initial->bitmap, NonEmptyRendererBitmap());
   }
 
   // For each "dragged" shape, simulate the drag-end writeback by
@@ -997,14 +1001,14 @@ TEST_F(RnrReplayTest, DeleteElementDoesNotResetPreviouslyMovedShapes) {
     ASSERT_TRUE(app.flushFrame());
     auto result = RequestRenderAndWait(asyncRenderer, renderer, app, selectTool);
     ASSERT_TRUE(result.has_value()) << "Render after drag of " << drag.id << " timed out";
-    ASSERT_FALSE(result->bitmap.empty());
+    ASSERT_THAT(result->bitmap, NonEmptyRendererBitmap());
   }
 
   // Capture the post-drags state. This is the bitmap the user sees
   // right before pressing Delete.
   auto stateAfterMoves = RequestRenderAndWait(asyncRenderer, renderer, app, selectTool);
   ASSERT_TRUE(stateAfterMoves.has_value());
-  ASSERT_FALSE(stateAfterMoves->bitmap.empty());
+  ASSERT_THAT(stateAfterMoves->bitmap, NonEmptyRendererBitmap());
 
   // Find Lightning_glow_dark in the live DOM and select it (matches
   // the user's "I clicked the lighting_glow_dark in my repro" step).
@@ -1032,7 +1036,7 @@ TEST_F(RnrReplayTest, DeleteElementDoesNotResetPreviouslyMovedShapes) {
 
   auto stateAfterDelete = RequestRenderAndWait(asyncRenderer, renderer, app, selectTool);
   ASSERT_TRUE(stateAfterDelete.has_value()) << "Post-delete render timed out";
-  ASSERT_FALSE(stateAfterDelete->bitmap.empty());
+  ASSERT_THAT(stateAfterDelete->bitmap, NonEmptyRendererBitmap());
 
   // Pump enough renders to clear `processPendingDemotions`' 30-frame
   // hysteresis (`kDemotionHysteresisFrames`), then compare the settled
@@ -1058,7 +1062,7 @@ TEST_F(RnrReplayTest, DeleteElementDoesNotResetPreviouslyMovedShapes) {
 
   auto stateAfterReparse = RequestRenderAndWait(asyncRenderer, renderer, app, selectTool);
   ASSERT_TRUE(stateAfterReparse.has_value()) << "Post-reparse render timed out";
-  ASSERT_FALSE(stateAfterReparse->bitmap.empty());
+  ASSERT_THAT(stateAfterReparse->bitmap, NonEmptyRendererBitmap());
 
   // Independent ground truth: render the FINAL source (post-drag,
   // post-delete) through a fresh `EditorApp` + `AsyncRenderer`. No
@@ -1074,7 +1078,7 @@ TEST_F(RnrReplayTest, DeleteElementDoesNotResetPreviouslyMovedShapes) {
   auto groundTruth = RequestRenderAndWait(groundTruthAsync, groundTruthRenderer, groundTruthApp,
                                           groundTruthSelectTool);
   ASSERT_TRUE(groundTruth.has_value());
-  ASSERT_FALSE(groundTruth->bitmap.empty());
+  ASSERT_THAT(groundTruth->bitmap, NonEmptyRendererBitmap());
 
   // Dump all four bitmaps so the human investigator can inspect the
   // delta when this trips.
@@ -1113,7 +1117,7 @@ TEST_F(RnrReplayTest, FilterPostDragJumpReplayMatchesGroundTruth) {
   drainWritebacksEachFrame_ = true;
   ReplayRecording("donner/editor/tests/filter_post_drag_jump.rnr", &snapshot);
 
-  ASSERT_FALSE(snapshot.bitmap.empty());
+  ASSERT_THAT(snapshot.bitmap, NonEmptyRendererBitmap());
 
   EditorApp groundTruthApp;
   AsyncRenderer groundTruthAsync;


### PR DESCRIPTION
Improve editor rendering bitmap test diagnostics by sharing a gMock matcher for non-empty `RendererBitmap` checks across the editor test package.

- Adds `BitmapTestMatchers.h` and a `bitmap_test_matchers` test helper target.
- Converts renderer/readback bitmap emptiness checks in async renderer, replay, overlay, pen tool, editor window, render-element, thumbnail, and golden-compare tests to `ASSERT_THAT` / `EXPECT_THAT`.
- Removes duplicate local bitmap matcher definitions so failures consistently print dimensions, row bytes, and pixel buffer size.

Validation:
- `tools/llm-bazel-wrap.sh test //... --test_output=errors`
- `python3 tools/cmake/gen_cmakelists.py --check`

Note: a direct local `tools/llm-bazel-wrap.sh test --config=geode //donner/editor/tests:editor_window_tests --test_output=errors` run compiled this diff but failed existing WGPU behavioral assertions unrelated to the matcher conversion (`penTool.isDrafting()` and a luma threshold).