### PR TITLE
Improve renderer test diagnostics

### DIFF
--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -24,6 +24,22 @@ donner_cc_library(
 )
 
 donner_cc_library(
+    name = "renderer_test_matchers",
+    testonly = 1,
+    hdrs = [
+        "RendererTestMatchers.h",
+    ],
+    visibility = [
+        "//donner/editor/tests:__pkg__",
+        "//donner/svg:__subpackages__",
+    ],
+    deps = [
+        "//donner/svg/renderer:renderer_interface",
+        "@com_google_gtest//:gtest",
+    ],
+)
+
+donner_cc_library(
     name = "renderer_image_test_utils",
     testonly = 1,
     srcs = [
@@ -180,6 +196,7 @@ donner_cc_test(
     ],
     deps = [
         ":image_comparison_test_fixture",
+        ":renderer_test_matchers",
         "//donner/base:base_test_utils",
         "//donner/base:gtest_timeout_main",
     ],
@@ -219,6 +236,7 @@ donner_cc_test(
     # of `docs/design_docs/0017-geode_renderer.md`.
     deps = [
         ":image_comparison_test_fixture",
+        ":renderer_test_matchers",
         ":renderer_test_utils",
         "//donner/svg/parser",
         "//donner/svg/resources:sandboxed_file_resource_loader",
@@ -234,6 +252,7 @@ donner_cc_test(
     # self-hosted RE lane (CI baseline, 2026-07-01).
     shard_count = 4,
     deps = [
+        ":renderer_test_matchers",
         "//donner/svg",
         "//donner/svg/parser",
         "//donner/svg/renderer",
@@ -258,6 +277,7 @@ donner_cc_test(
     deps = [
         ":mock_renderer_interface",
         ":renderer_test_backend",
+        ":renderer_test_matchers",
         "//donner/svg/renderer",
         "@com_google_gtest//:gtest_main",
     ],
@@ -276,6 +296,7 @@ donner_cc_test(
         "geode",
     ],
     deps = [
+        ":renderer_test_matchers",
         "//donner/svg/parser",
         "//donner/svg/renderer",
         "//donner/svg/renderer:renderer_image_io",
@@ -411,6 +432,7 @@ donner_cc_test(
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     deps = [
+        ":renderer_test_matchers",
         "//donner/base",
         "//donner/base:gtest_timeout_main",
         "//donner/css:core",
@@ -461,6 +483,7 @@ donner_cc_test(
     ],
     deps = [
         ":mock_renderer_interface",
+        ":renderer_test_matchers",
         "//donner/base:base_test_utils",
         "//donner/svg/renderer:renderer_driver",
         "//donner/svg/renderer:renderer_utils",

--- a/donner/svg/renderer/tests/FilterGraphExecutor_tests.cc
+++ b/donner/svg/renderer/tests/FilterGraphExecutor_tests.cc
@@ -16,8 +16,11 @@ using ::testing::AllOf;
 using ::testing::ElementsAre;
 using ::testing::Ge;
 using ::testing::Gt;
+using ::testing::IsEmpty;
 using ::testing::Le;
 using ::testing::Lt;
+using ::testing::Not;
+using ::testing::SizeIs;
 
 using Pixel = std::array<std::uint8_t, 4>;
 
@@ -264,7 +267,7 @@ TEST(FilterGraphExecutorTest, RotationDoesNotChangeBlurSigma) {
   const tiny_skia::Pixmap identityBlurred = CreateBlurredDotPixmap(Transform2d());
   const tiny_skia::Pixmap rotatedBlurred = CreateBlurredDotPixmap(Transform2d::Rotate(M_PI / 4.0));
 
-  EXPECT_EQ(identityBlurred.data().size(), rotatedBlurred.data().size());
+  EXPECT_THAT(rotatedBlurred.data(), SizeIs(identityBlurred.data().size()));
   for (std::size_t i = 0; i < identityBlurred.data().size(); ++i) {
     EXPECT_EQ(identityBlurred.data()[i], rotatedBlurred.data()[i]) << "byte index=" << i;
   }
@@ -755,8 +758,8 @@ TEST(FilterGraphExecutorTest, SRGBColorInterpolationProducesDifferentResultThanL
   // Both should produce valid non-empty output. The actual pixel values may or may not differ
   // depending on the blend mode and input colors (Normal blend with premultiplied alpha can
   // produce identical results in both color spaces for some inputs).
-  EXPECT_FALSE(srgbResult.data().empty());
-  EXPECT_FALSE(linearResult.data().empty());
+  EXPECT_THAT(srgbResult.data(), Not(IsEmpty()));
+  EXPECT_THAT(linearResult.data(), Not(IsEmpty()));
 }
 
 TEST(FilterGraphExecutorTest, PerNodeColorInterpolationOverridesGraphDefault) {

--- a/donner/svg/renderer/tests/RendererDriver_tests.cc
+++ b/donner/svg/renderer/tests/RendererDriver_tests.cc
@@ -26,15 +26,22 @@
 #include "donner/svg/renderer/RendererUtils.h"
 #include "donner/svg/renderer/RenderingContext.h"
 #include "donner/svg/renderer/tests/MockRendererInterface.h"
+#include "donner/svg/renderer/tests/RendererTestMatchers.h"
 #include "donner/svg/tests/ParserTestUtils.h"
 
 using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::Eq;
 using ::testing::Field;
+using ::testing::IsEmpty;
+using ::testing::Not;
+using ::testing::SizeIs;
 
 namespace donner::svg {
 namespace {
+
+using test::NonEmptyRendererBitmap;
+using test::NonNullEntity;
 
 MATCHER_P(Vector2dEq, expected, "matches Vector2d") {
   return arg.x == expected.x && arg.y == expected.y;
@@ -126,7 +133,7 @@ TEST_F(RendererDriverTest, BeginsAndEndsFrameAroundTraversal) {
   driver.draw(document);
 
   const RendererBitmap bitmap = driver.takeSnapshot();
-  EXPECT_FALSE(bitmap.empty());
+  EXPECT_THAT(bitmap, NonEmptyRendererBitmap());
   EXPECT_THAT(bitmap.dimensions, Eq(Vector2i(16, 16)));
 }
 
@@ -287,7 +294,7 @@ TEST_F(RendererDriverTest, EmitsImageDrawCallsWithClipAndTransform) {
                                       Vector2i(10, 8));
 
   auto images = document.registry().view<components::ImageComponent>();
-  ASSERT_FALSE(images.empty());
+  ASSERT_THAT(images, Not(IsEmpty()));
 
   for (const Entity entity : images) {
     auto& loaded = document.registry().emplace<components::LoadedImageComponent>(entity);
@@ -319,7 +326,7 @@ TEST_F(RendererDriverTest, AppliesDefaultPreserveAspectRatioWhenComponentMissing
                                       Vector2i(12, 6));
 
   auto images = document.registry().view<components::ImageComponent>();
-  ASSERT_FALSE(images.empty());
+  ASSERT_THAT(images, Not(IsEmpty()));
 
   std::vector<Transform2d> transforms;
   EXPECT_CALL(renderer, pushTransform(_))
@@ -707,8 +714,8 @@ TEST_F(RendererDriverTest, DrawEntityRangeDefersSubtreeCleanupAndAppliesBaseTran
     }
   }
 
-  ASSERT_TRUE(subtreeRoot != entt::null);
-  ASSERT_TRUE(subtreeLast != entt::null);
+  ASSERT_THAT(subtreeRoot, NonNullEntity());
+  ASSERT_THAT(subtreeLast, NonNullEntity());
 
   std::vector<Transform2d> transforms;
   int pushLayerCount = 0;
@@ -757,7 +764,7 @@ TEST_F(RendererDriverTest, DrawEntityRangeConvertsCssFilterFunctionsToFilterGrap
     }
   }
 
-  ASSERT_TRUE(rectEntity != entt::null);
+  ASSERT_THAT(rectEntity, NonNullEntity());
 
   auto& instance = document.registry().get<components::RenderingInstanceComponent>(rectEntity);
   auto& style = document.registry().get<components::ComputedStyleComponent>(rectEntity);
@@ -796,7 +803,7 @@ TEST_F(RendererDriverTest, DrawEntityRangeConvertsCssFilterFunctionsToFilterGrap
                     const std::optional<Box2d>& filterRegion) {
         EXPECT_FALSE(filterRegion.has_value());
         EXPECT_EQ(filterGraph.colorInterpolationFilters, ColorInterpolationFilters::SRGB);
-        ASSERT_EQ(filterGraph.nodes.size(), 10u);
+        ASSERT_THAT(filterGraph.nodes, SizeIs(10u));
 
         const auto* blur = std::get_if<components::filter_primitive::GaussianBlur>(
             &filterGraph.nodes[0].primitive);
@@ -853,7 +860,7 @@ TEST_F(RendererDriverTest, DrawEntityRangeConvertsCssFilterFunctionsToFilterGrap
             std::get_if<components::filter_primitive::ColorMatrix>(&filterGraph.nodes[8].primitive);
         ASSERT_NE(sepia, nullptr);
         EXPECT_EQ(sepia->type, components::filter_primitive::ColorMatrix::Type::Matrix);
-        ASSERT_EQ(sepia->values.size(), 20u);
+        ASSERT_THAT(sepia->values, SizeIs(20u));
 
         const auto* dropShadow =
             std::get_if<components::filter_primitive::DropShadow>(&filterGraph.nodes[9].primitive);
@@ -893,7 +900,7 @@ TEST_F(RendererDriverTest, DrawEntityRangeUsesResolvedFilterReferenceObjectBound
       break;
     }
   }
-  ASSERT_TRUE(rectEntity != entt::null);
+  ASSERT_THAT(rectEntity, NonNullEntity());
 
   Entity filterEntity = document.registry().create();
   components::ComputedFilterComponent computedFilter;
@@ -974,7 +981,7 @@ TEST_F(RendererDriverTest, DrawEntityRangeCopiesUrlFilterNodesIntoCssFilterGraph
       break;
     }
   }
-  ASSERT_TRUE(rectEntity != entt::null);
+  ASSERT_THAT(rectEntity, NonNullEntity());
 
   Entity filterEntity = document.registry().create();
   document.registry().emplace<components::IdComponent>(filterEntity, RcString("refFilter"));
@@ -1010,7 +1017,7 @@ TEST_F(RendererDriverTest, DrawEntityRangeCopiesUrlFilterNodesIntoCssFilterGraph
         EXPECT_NEAR(filterRegion->width(), 48.0, 1e-6);
         EXPECT_NEAR(filterRegion->height(), 12.0, 1e-6);
 
-        ASSERT_EQ(filterGraph.nodes.size(), 2u);
+        ASSERT_THAT(filterGraph.nodes, SizeIs(2u));
         const auto* blur = std::get_if<components::filter_primitive::GaussianBlur>(
             &filterGraph.nodes[0].primitive);
         ASSERT_NE(blur, nullptr);

--- a/donner/svg/renderer/tests/RendererErrorPaths_tests.cc
+++ b/donner/svg/renderer/tests/RendererErrorPaths_tests.cc
@@ -15,9 +15,15 @@
 #include "donner/svg/SVG.h"
 #include "donner/svg/renderer/Renderer.h"
 #include "donner/svg/renderer/RendererImageIO.h"
+#include "donner/svg/renderer/tests/RendererTestMatchers.h"
 
 namespace donner::svg {
 namespace {
+
+using test::EmptyRendererBitmap;
+using test::NonEmptyRendererBitmap;
+using ::testing::IsEmpty;
+using ::testing::Not;
 
 MATCHER(PngSignaturePrefix, "") {
   constexpr std::array<uint8_t, 8> kPngSignature = {0x89, 'P', 'N', 'G', '\r', '\n', 0x1A, '\n'};
@@ -58,7 +64,7 @@ TEST(RendererErrorPathsTest, SaveBeforeDrawReturnsFalse) {
 TEST(RendererErrorPathsTest, SnapshotBeforeDrawIsEmpty) {
   Renderer renderer;
   const RendererBitmap snapshot = renderer.takeSnapshot();
-  EXPECT_TRUE(snapshot.empty());
+  EXPECT_THAT(snapshot, EmptyRendererBitmap());
 }
 
 TEST(RendererErrorPathsTest, SaveToInvalidPathReturnsFalse) {
@@ -85,7 +91,7 @@ TEST(RendererImageIOTest, WritePngToInvalidPath) {
 TEST(RendererImageIOTest, WritePngToMemory) {
   std::vector<uint8_t> pixels(2 * 2 * 4, 255);  // 2x2 white RGBA
   std::vector<uint8_t> encoded = RendererImageIO::writeRgbaPixelsToPngMemory(pixels, 2, 2, 0);
-  EXPECT_FALSE(encoded.empty());
+  EXPECT_THAT(encoded, Not(IsEmpty()));
   EXPECT_THAT(encoded, PngSignaturePrefix());
 }
 
@@ -103,7 +109,7 @@ TEST(RendererImageIOTest, WritePngWithCustomStride) {
   // The API asserts that rgbaPixels.size() == width * height * 4.
   std::vector<uint8_t> pixels(2 * 2 * 4, 200);  // 2 pixels per row × 2 rows × 4 bytes/pixel
   std::vector<uint8_t> encoded = RendererImageIO::writeRgbaPixelsToPngMemory(pixels, 2, 2, 2);
-  EXPECT_FALSE(encoded.empty());
+  EXPECT_THAT(encoded, Not(IsEmpty()));
 }
 
 // --- Rendering broken/degenerate SVGs ---
@@ -118,7 +124,7 @@ TEST(RendererErrorPathsTest, EmptySvgDocument) {
 
   const RendererBitmap snapshot = renderer.takeSnapshot();
   // Empty document should still produce a valid (transparent) bitmap.
-  EXPECT_FALSE(snapshot.empty());
+  EXPECT_THAT(snapshot, NonEmptyRendererBitmap());
   EXPECT_EQ(snapshot.dimensions, Vector2i(8, 8));
 }
 
@@ -134,7 +140,7 @@ TEST(RendererErrorPathsTest, BrokenGradientReference) {
   renderer.draw(document);
 
   const RendererBitmap snapshot = renderer.takeSnapshot();
-  EXPECT_FALSE(snapshot.empty());
+  EXPECT_THAT(snapshot, NonEmptyRendererBitmap());
 }
 
 TEST(RendererErrorPathsTest, EmptyFilterPrimitive) {
@@ -152,7 +158,7 @@ TEST(RendererErrorPathsTest, EmptyFilterPrimitive) {
   renderer.draw(document);
 
   const RendererBitmap snapshot = renderer.takeSnapshot();
-  EXPECT_FALSE(snapshot.empty());
+  EXPECT_THAT(snapshot, NonEmptyRendererBitmap());
 }
 
 TEST(RendererErrorPathsTest, ZeroDimensionViewBox) {
@@ -166,7 +172,7 @@ TEST(RendererErrorPathsTest, ZeroDimensionViewBox) {
   renderer.draw(document);
 
   const RendererBitmap snapshot = renderer.takeSnapshot();
-  EXPECT_FALSE(snapshot.empty());
+  EXPECT_THAT(snapshot, NonEmptyRendererBitmap());
 }
 
 TEST(RendererErrorPathsTest, GradientWithNoStops) {
@@ -183,7 +189,7 @@ TEST(RendererErrorPathsTest, GradientWithNoStops) {
   renderer.draw(document);
 
   const RendererBitmap snapshot = renderer.takeSnapshot();
-  EXPECT_FALSE(snapshot.empty());
+  EXPECT_THAT(snapshot, NonEmptyRendererBitmap());
 }
 
 TEST(RendererErrorPathsTest, SelfReferencingClipPath) {
@@ -203,7 +209,7 @@ TEST(RendererErrorPathsTest, SelfReferencingClipPath) {
   renderer.draw(document);
 
   const RendererBitmap snapshot = renderer.takeSnapshot();
-  EXPECT_FALSE(snapshot.empty());
+  EXPECT_THAT(snapshot, NonEmptyRendererBitmap());
 }
 
 TEST(RendererErrorPathsTest, ZeroSizeRect) {
@@ -217,7 +223,7 @@ TEST(RendererErrorPathsTest, ZeroSizeRect) {
   renderer.draw(document);
 
   const RendererBitmap snapshot = renderer.takeSnapshot();
-  EXPECT_FALSE(snapshot.empty());
+  EXPECT_THAT(snapshot, NonEmptyRendererBitmap());
 }
 
 TEST(RendererErrorPathsTest, NegativeRadiiEllipse) {
@@ -232,7 +238,7 @@ TEST(RendererErrorPathsTest, NegativeRadiiEllipse) {
   renderer.draw(document);
 
   const RendererBitmap snapshot = renderer.takeSnapshot();
-  EXPECT_FALSE(snapshot.empty());
+  EXPECT_THAT(snapshot, NonEmptyRendererBitmap());
 }
 
 TEST(RendererErrorPathsTest, PatternWithZeroSize) {
@@ -251,7 +257,7 @@ TEST(RendererErrorPathsTest, PatternWithZeroSize) {
   renderer.draw(document);
 
   const RendererBitmap snapshot = renderer.takeSnapshot();
-  EXPECT_FALSE(snapshot.empty());
+  EXPECT_THAT(snapshot, NonEmptyRendererBitmap());
 }
 
 TEST(RendererErrorPathsTest, MaskWithNoContent) {
@@ -268,7 +274,7 @@ TEST(RendererErrorPathsTest, MaskWithNoContent) {
   renderer.draw(document);
 
   const RendererBitmap snapshot = renderer.takeSnapshot();
-  EXPECT_FALSE(snapshot.empty());
+  EXPECT_THAT(snapshot, NonEmptyRendererBitmap());
 }
 
 TEST(RendererErrorPathsTest, DisplayNoneElement) {
@@ -282,7 +288,7 @@ TEST(RendererErrorPathsTest, DisplayNoneElement) {
   renderer.draw(document);
 
   const RendererBitmap snapshot = renderer.takeSnapshot();
-  EXPECT_FALSE(snapshot.empty());
+  EXPECT_THAT(snapshot, NonEmptyRendererBitmap());
 }
 
 TEST(RendererErrorPathsTest, VisibilityHiddenElement) {
@@ -296,7 +302,7 @@ TEST(RendererErrorPathsTest, VisibilityHiddenElement) {
   renderer.draw(document);
 
   const RendererBitmap snapshot = renderer.takeSnapshot();
-  EXPECT_FALSE(snapshot.empty());
+  EXPECT_THAT(snapshot, NonEmptyRendererBitmap());
 }
 
 TEST(RendererErrorPathsTest, ZeroOpacityElement) {
@@ -310,7 +316,7 @@ TEST(RendererErrorPathsTest, ZeroOpacityElement) {
   renderer.draw(document);
 
   const RendererBitmap snapshot = renderer.takeSnapshot();
-  EXPECT_FALSE(snapshot.empty());
+  EXPECT_THAT(snapshot, NonEmptyRendererBitmap());
 }
 
 TEST(RendererErrorPathsTest, StrokeWithZeroWidth) {
@@ -324,7 +330,7 @@ TEST(RendererErrorPathsTest, StrokeWithZeroWidth) {
   renderer.draw(document);
 
   const RendererBitmap snapshot = renderer.takeSnapshot();
-  EXPECT_FALSE(snapshot.empty());
+  EXPECT_THAT(snapshot, NonEmptyRendererBitmap());
 }
 
 TEST(RendererErrorPathsTest, FillNone) {
@@ -338,7 +344,7 @@ TEST(RendererErrorPathsTest, FillNone) {
   renderer.draw(document);
 
   const RendererBitmap snapshot = renderer.takeSnapshot();
-  EXPECT_FALSE(snapshot.empty());
+  EXPECT_THAT(snapshot, NonEmptyRendererBitmap());
 }
 
 }  // namespace

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -26,6 +26,7 @@
 #include "donner/svg/renderer/RendererUtils.h"
 #include "donner/svg/renderer/StrokeParams.h"
 #include "donner/svg/renderer/geode/GeodeDevice.h"
+#include "donner/svg/renderer/tests/RendererTestMatchers.h"
 #include "donner/svg/renderer/tests/RgbaTestMatchers.h"
 #include "donner/svg/resources/ImageResource.h"
 #include "tiny_skia/Pixmap.h"
@@ -37,10 +38,15 @@ namespace {
 constexpr double kViewportSize = 64.0;
 
 using test::Alpha;
+using test::EmptyRendererBitmap;
 using test::IsTransparent;
 using test::Near;
+using test::NonEmptyRendererBitmap;
 using test::Rgba;
 using test::RgbaEq;
+using ::testing::IsEmpty;
+using ::testing::Not;
+using ::testing::NotNull;
 
 struct BitmapDiffStats {
   int differingChannels = 0;
@@ -274,7 +280,7 @@ TEST_F(RendererGeodeTest, EmptyFrameIsTransparent) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
   EXPECT_EQ(snap.dimensions.x, static_cast<int>(kViewportSize));
   EXPECT_EQ(snap.dimensions.y, static_cast<int>(kViewportSize));
 
@@ -290,14 +296,14 @@ TEST_F(RendererGeodeTest, EmptyFrameAfterOpaqueFrameClearsReusedTarget) {
   renderer.endFrame();
 
   RendererBitmap opaqueSnap = renderer.takeSnapshot();
-  ASSERT_FALSE(opaqueSnap.empty());
+  ASSERT_THAT(opaqueSnap, NonEmptyRendererBitmap());
   EXPECT_THAT(pixelAt(opaqueSnap, 32, 32), RgbaEq(255, 0, 0, 255));
 
   beginFrame(renderer);
   renderer.endFrame();
 
   RendererBitmap transparentSnap = renderer.takeSnapshot();
-  ASSERT_FALSE(transparentSnap.empty());
+  ASSERT_THAT(transparentSnap, NonEmptyRendererBitmap());
   EXPECT_THAT(pixelAt(transparentSnap, 32, 32), IsTransparent())
       << "A same-size Geode frame with no draws must clear pixels from the previous frame.";
 }
@@ -316,7 +322,7 @@ TEST_F(RendererGeodeTest, WidthHeightReflectViewport) {
 }
 
 TEST_F(RendererGeodeTest, TakeTextureSnapshotReturnsTextureAndDetachesTarget) {
-  ASSERT_TRUE(sharedDevice() != nullptr);
+  ASSERT_THAT(sharedDevice(), NotNull());
   RendererGeode renderer = createRenderer();
   beginFrame(renderer);
   renderer.setPaint(solidFill(css::RGBA(255, 0, 0, 255)));
@@ -324,7 +330,7 @@ TEST_F(RendererGeodeTest, TakeTextureSnapshotReturnsTextureAndDetachesTarget) {
   renderer.endFrame();
 
   std::shared_ptr<const RendererTextureSnapshot> texture = renderer.takeTextureSnapshot();
-  ASSERT_TRUE(texture != nullptr);
+  ASSERT_THAT(texture, NotNull());
   EXPECT_EQ(texture->backend(), RendererTextureSnapshotBackend::Geode);
   EXPECT_EQ(texture->dimensions(),
             Vector2i(static_cast<int>(kViewportSize), static_cast<int>(kViewportSize)));
@@ -332,18 +338,19 @@ TEST_F(RendererGeodeTest, TakeTextureSnapshotReturnsTextureAndDetachesTarget) {
   EXPECT_TRUE(static_cast<bool>(geodeTexture->texture()));
   EXPECT_TRUE(static_cast<bool>(geodeTexture->textureView()));
 
-  EXPECT_TRUE(renderer.takeSnapshot().empty()) << "Texture export detaches the internal target so "
-                                                  "presentation cannot be overwritten by readback";
+  EXPECT_THAT(renderer.takeSnapshot(), EmptyRendererBitmap())
+      << "Texture export detaches the internal target so presentation cannot be overwritten by "
+         "readback";
 
   beginFrame(renderer);
   renderer.endFrame();
   std::shared_ptr<const RendererTextureSnapshot> secondTexture = renderer.takeTextureSnapshot();
-  ASSERT_TRUE(secondTexture != nullptr);
+  ASSERT_THAT(secondTexture, NotNull());
   EXPECT_EQ(secondTexture->dimensions(), texture->dimensions());
 }
 
 TEST_F(RendererGeodeTest, DrawTextureSnapshotPreservesPremultipliedAlpha) {
-  ASSERT_TRUE(sharedDevice() != nullptr);
+  ASSERT_THAT(sharedDevice(), NotNull());
 
   RendererGeode source = createRenderer();
   beginFrame(source);
@@ -352,7 +359,7 @@ TEST_F(RendererGeodeTest, DrawTextureSnapshotPreservesPremultipliedAlpha) {
   source.endFrame();
 
   std::shared_ptr<const RendererTextureSnapshot> texture = source.takeTextureSnapshot();
-  ASSERT_TRUE(texture != nullptr);
+  ASSERT_THAT(texture, NotNull());
   EXPECT_EQ(texture->alphaType(), AlphaType::Premultiplied);
 
   RendererGeode composited = createRenderer();
@@ -369,8 +376,8 @@ TEST_F(RendererGeodeTest, DrawTextureSnapshotPreservesPremultipliedAlpha) {
   reference.endFrame();
   const RendererBitmap expected = reference.takeSnapshot();
 
-  ASSERT_FALSE(actual.empty());
-  ASSERT_FALSE(expected.empty());
+  ASSERT_THAT(actual, NonEmptyRendererBitmap());
+  ASSERT_THAT(expected, NonEmptyRendererBitmap());
   ASSERT_EQ(actual.dimensions, expected.dimensions);
   EXPECT_EQ(pixelAt(actual, 32, 32), pixelAt(expected, 32, 32))
       << "Texture snapshots are premultiplied render-target pixels. The blit shader must not "
@@ -378,7 +385,7 @@ TEST_F(RendererGeodeTest, DrawTextureSnapshotPreservesPremultipliedAlpha) {
 }
 
 TEST_F(RendererGeodeTest, DrawTextureSnapshotHonorsCurrentTransform) {
-  ASSERT_TRUE(sharedDevice() != nullptr);
+  ASSERT_THAT(sharedDevice(), NotNull());
 
   RendererGeode source = createRenderer();
   beginFrame(source);
@@ -387,7 +394,7 @@ TEST_F(RendererGeodeTest, DrawTextureSnapshotHonorsCurrentTransform) {
   source.endFrame();
 
   std::shared_ptr<const RendererTextureSnapshot> texture = source.takeTextureSnapshot();
-  ASSERT_TRUE(texture != nullptr);
+  ASSERT_THAT(texture, NotNull());
 
   RendererGeode composited = createRenderer();
   beginFrame(composited);
@@ -396,7 +403,7 @@ TEST_F(RendererGeodeTest, DrawTextureSnapshotHonorsCurrentTransform) {
   composited.endFrame();
 
   const RendererBitmap actual = composited.takeSnapshot();
-  ASSERT_FALSE(actual.empty());
+  ASSERT_THAT(actual, NonEmptyRendererBitmap());
   EXPECT_THAT(pixelAt(actual, 8, 8), IsTransparent())
       << "The texture snapshot must be translated out of its local-space source rect.";
   EXPECT_THAT(pixelAt(actual, 32, 32), RgbaEq(0, 255, 0, 255))
@@ -404,7 +411,7 @@ TEST_F(RendererGeodeTest, DrawTextureSnapshotHonorsCurrentTransform) {
 }
 
 TEST_F(RendererGeodeTest, DrawTextureSnapshotHonorsCurrentTransformWithClip) {
-  ASSERT_TRUE(sharedDevice() != nullptr);
+  ASSERT_THAT(sharedDevice(), NotNull());
 
   RendererGeode source = createRenderer();
   beginFrame(source);
@@ -413,7 +420,7 @@ TEST_F(RendererGeodeTest, DrawTextureSnapshotHonorsCurrentTransformWithClip) {
   source.endFrame();
 
   std::shared_ptr<const RendererTextureSnapshot> texture = source.takeTextureSnapshot();
-  ASSERT_TRUE(texture != nullptr);
+  ASSERT_THAT(texture, NotNull());
 
   RendererGeode composited = createRenderer();
   beginFrame(composited);
@@ -426,7 +433,7 @@ TEST_F(RendererGeodeTest, DrawTextureSnapshotHonorsCurrentTransformWithClip) {
   composited.endFrame();
 
   const RendererBitmap actual = composited.takeSnapshot();
-  ASSERT_FALSE(actual.empty());
+  ASSERT_THAT(actual, NonEmptyRendererBitmap());
   EXPECT_THAT(pixelAt(actual, 8, 8), IsTransparent());
   EXPECT_THAT(pixelAt(actual, 32, 32), RgbaEq(0, 255, 0, 255))
       << "Texture-snapshot presentation must still draw when the document-image clip is active.";
@@ -447,14 +454,14 @@ TEST_F(RendererGeodeTest, DrawEntityRangeInvalidatesCachedFillEncodeAfterPathMut
 
   RendererGeode renderer = createRenderer();
   const RendererBitmap before = drawPreparedEntityRange(renderer, document, pathEntity);
-  ASSERT_FALSE(before.empty());
+  ASSERT_THAT(before, NonEmptyRendererBitmap());
   EXPECT_THAT(pixelAt(before, 24, 24), IsTransparent());
 
   path->setAttribute("d", "M 10 10 L 80 10 L 10 80 Z");
   path->setAttribute("style", "fill: #00ff00; stroke: none");
 
   const RendererBitmap after = drawPreparedEntityRange(renderer, document, pathEntity);
-  ASSERT_FALSE(after.empty());
+  ASSERT_THAT(after, NonEmptyRendererBitmap());
   EXPECT_THAT(pixelAt(after, 24, 24),
               Rgba(testing::Lt(20), testing::Gt(220), testing::Lt(20), testing::Gt(220)))
       << "drawEntityRange must not reuse a Geode fill encode cached before the path's `d` "
@@ -463,7 +470,7 @@ TEST_F(RendererGeodeTest, DrawEntityRangeInvalidatesCachedFillEncodeAfterPathMut
 
 TEST_F(RendererGeodeTest, EmbeddedDeviceDrawPathExportsTextureSnapshot) {
   std::shared_ptr<geode::GeodeDevice> host = sharedDevice();
-  ASSERT_TRUE(host != nullptr);
+  ASSERT_THAT(host, NotNull());
 
   geode::GeodeEmbedConfig config;
   config.device = host->device();
@@ -487,7 +494,7 @@ TEST_F(RendererGeodeTest, EmbeddedDeviceDrawPathExportsTextureSnapshot) {
   renderer.endFrame();
 
   std::shared_ptr<const RendererTextureSnapshot> texture = renderer.takeTextureSnapshot();
-  ASSERT_TRUE(texture != nullptr);
+  ASSERT_THAT(texture, NotNull());
   EXPECT_EQ(texture->backend(), RendererTextureSnapshotBackend::Geode);
   EXPECT_EQ(texture->dimensions(),
             Vector2i(static_cast<int>(kViewportSize), static_cast<int>(kViewportSize)));
@@ -495,7 +502,7 @@ TEST_F(RendererGeodeTest, EmbeddedDeviceDrawPathExportsTextureSnapshot) {
 
 TEST_F(RendererGeodeTest, BgraTargetSnapshotReturnsStraightRgba) {
   std::shared_ptr<geode::GeodeDevice> host = sharedDevice();
-  ASSERT_TRUE(host != nullptr);
+  ASSERT_THAT(host, NotNull());
 
   geode::GeodeEmbedConfig config;
   config.device = host->device();
@@ -513,7 +520,7 @@ TEST_F(RendererGeodeTest, BgraTargetSnapshotReturnsStraightRgba) {
   renderer.endFrame();
 
   const RendererBitmap actual = renderer.takeSnapshot();
-  ASSERT_FALSE(actual.empty());
+  ASSERT_THAT(actual, NonEmptyRendererBitmap());
   EXPECT_EQ(actual.alphaType, AlphaType::Unpremultiplied);
 
   const std::array<uint8_t, 4> center = pixelAt(actual, 32, 32);
@@ -538,7 +545,7 @@ TEST_F(RendererGeodeTest, DrawPathWithSolidFill) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   // Center should be red, transparent at the corner.
   auto center = pixelAt(snap, 32, 32);
@@ -780,7 +787,7 @@ TEST_F(RendererGeodeTest, DrawImageFourColorQuadrants) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   // Top-left quadrant (pixel at ~24, 24) — red.
   auto tl = pixelAt(snap, 24, 24);
@@ -965,7 +972,7 @@ TEST_F(RendererGeodeTest, PathClipMaskClipsSolidFillToLeftHalf) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   auto inside = pixelAt(snap, 16, 32);
   EXPECT_THAT(inside, RgbaEq(0, 0, 255, 255)) << "Inside clip should be blue";
@@ -1000,7 +1007,7 @@ TEST_F(RendererGeodeTest, PathClipMaskClipsIsolatedLayerComposite) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   auto inside = pixelAt(snap, 16, 32);
   EXPECT_THAT(inside, RgbaEq(0, 0, 255, 255)) << "Inside clip should be blue";
@@ -1034,7 +1041,7 @@ TEST_F(RendererGeodeTest, PathClipMaskClipsIsolatedLayerCompositeForTriangle) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   auto inside = pixelAt(snap, 32, 40);
   EXPECT_THAT(inside, RgbaEq(0, 0, 255, 255)) << "Inside clip should be blue";
@@ -1068,7 +1075,7 @@ TEST_F(RendererGeodeTest, PathClipMaskClipsFilterLayerCompositeForTriangle) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   auto inside = pixelAt(snap, 32, 40);
   EXPECT_THAT(inside, RgbaEq(0, 0, 255, 255)) << "Inside clip should be blue";
@@ -1134,7 +1141,7 @@ TEST_F(RendererGeodeTest, GaussianBlurSmokes) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   // Center pixel should still be red (fully opaque).
   auto center = pixelAt(snap, 32, 32);
@@ -1173,7 +1180,7 @@ TEST_F(RendererGeodeTest, GaussianBlurZeroStdDevPassthrough) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   // Center should be green (the blur is a passthrough).
   auto center = pixelAt(snap, 32, 32);
@@ -1208,7 +1215,7 @@ TEST_F(RendererGeodeTest, FilterOffsetShiftsPixels) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   // After offset dx=4 dy=4, the rect should shift: center moves from (32,32)
   // to effectively be at (32,32) still red (inside shifted rect), but (16,16)
@@ -1246,7 +1253,7 @@ TEST_F(RendererGeodeTest, FilterColorMatrixLuminanceToAlpha) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   // luminanceToAlpha: R'=0, G'=0, B'=0, A'= 0.2126*R + 0.7152*G + 0.0722*B.
   // For pure red (R=1.0): A' = 0.2126 → ~54 in [0, 255].
@@ -1282,7 +1289,7 @@ TEST_F(RendererGeodeTest, FilterSourceAlphaInputExtractsAlphaChannel) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   const auto center = pixelAt(snap, 32, 32);
   EXPECT_THAT(center, RgbaEq(0, 0, 0, 255));
@@ -1314,7 +1321,7 @@ TEST_F(RendererGeodeTest, FilterSpecularLightingExponentBelowOneIsTransparent) {
 
   const Transform2d deviceFromFilter = Transform2d();
   const RendererBitmap actual = renderFlatSourceThroughFilter(graph, deviceFromFilter);
-  ASSERT_FALSE(actual.empty());
+  ASSERT_THAT(actual, NonEmptyRendererBitmap());
 
   // Every pixel must be transparent black (the lighting dispatch is skipped).
   EXPECT_THAT(pixelAt(actual, 32, 32), RgbaEq(0, 0, 0, 0));
@@ -1351,10 +1358,10 @@ TEST_F(RendererGeodeTest, FilterDiffuseLightingSpotLightConeMatchesCpuReference)
 
   const Transform2d deviceFromFilter = Transform2d();
   const RendererBitmap actual = renderFlatSourceThroughFilter(graph, deviceFromFilter);
-  ASSERT_FALSE(actual.empty());
+  ASSERT_THAT(actual, NonEmptyRendererBitmap());
   const std::vector<uint8_t> expected =
       CpuDiffuseLightingReferenceForFlatSource(diffuse, deviceFromFilter);
-  ASSERT_FALSE(expected.empty());
+  ASSERT_THAT(expected, Not(IsEmpty()));
 
   const BitmapDiffStats diff = DiffBitmapAgainstStraightRgba(actual, expected, 1, 1);
   EXPECT_EQ(diff.differingChannels, 0)
@@ -1383,7 +1390,7 @@ TEST_F(RendererGeodeTest, FilterEmptyMergeProducesTransparentBlack) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   EXPECT_THAT(pixelAt(snap, 32, 32), RgbaEq(0, 0, 0, 0));
 }
@@ -1414,7 +1421,7 @@ TEST_F(RendererGeodeTest, FilterFloodFillsSubregion) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   // feFlood with red at 50% opacity. The GPU stores premultiplied (128,0,0,128)
   // but takeSnapshot() unpremultiplies to straight alpha: (255,0,0,128).
@@ -1479,7 +1486,7 @@ TEST_F(RendererGeodeTest, FilterMergeCompositesInputs) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   // GPU alpha-over of premul red(128,0,0,128) then premul blue(0,0,128,128):
   //   premul result ≈ (64, 0, 128, 192)
@@ -1540,7 +1547,7 @@ TEST_F(RendererGeodeTest, FilterCompositeInOperator) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   // in1 premul = (255,0,0,255), in2 premul = (0,128,0,128).
   // operator=in: result = in1 * in2.a = (255,0,0,255) * (128/255) ≈ (128,0,0,128).
@@ -1598,7 +1605,7 @@ TEST_F(RendererGeodeTest, FilterCompositeOverDefault) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   // feComposite operates in linearRGB by default (the `color-interpolation-
   // filters` property), matching tiny-skia and the SVG spec. With pure blue
@@ -1670,7 +1677,7 @@ TEST_F(RendererGeodeTest, FilterCompositeArithmetic) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   // k1*red*white = red. Expected: (255,0,0,255).
   auto center = pixelAt(snap, 32, 32);
@@ -1727,7 +1734,7 @@ TEST_F(RendererGeodeTest, FilterBlendMultiply) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   // Multiply: red(1,0,0)*blue(0,0,1) = (0,0,0), both opaque → black opaque.
   auto center = pixelAt(snap, 32, 32);
@@ -1784,7 +1791,7 @@ TEST_F(RendererGeodeTest, FilterBlendScreen) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   // Screen: red+blue-red*blue = (1,0,1) = magenta, opaque.
   auto center = pixelAt(snap, 32, 32);
@@ -1818,7 +1825,7 @@ TEST_F(RendererGeodeTest, FilterMorphologyDilateExpands) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   // After dilate r=4, the rect expands by 4 in each direction.
   // Pixel at (22-3, 32) = (19, 32) should be white (inside expanded region).
@@ -1857,7 +1864,7 @@ TEST_F(RendererGeodeTest, FilterMorphologyErodeShrinks) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   // After erode r=4, the rect shrinks by 4 inward from each edge.
   // Corner pixel (17, 17) should now be transparent (eroded away).
@@ -1892,7 +1899,7 @@ TEST_F(RendererGeodeTest, FilterComponentTransferIdentityPasses) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   auto center = pixelAt(snap, 32, 32);
   EXPECT_THAT(center, Rgba(Near(128, 2), Near(64, 2), Near(200, 2), Near(255, 1)))
@@ -1927,7 +1934,7 @@ TEST_F(RendererGeodeTest, FilterComponentTransferGammaInverts) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   auto center = pixelAt(snap, 32, 32);
   // R=128/255≈0.502, R²≈0.252, premultiplied: R*A=0.252*1.0=0.252 → ~64.
@@ -1965,7 +1972,7 @@ TEST_F(RendererGeodeTest, FilterConvolveMatrixBoxBlur) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   // Center should still be near-white (all neighbours are white).
   auto center = pixelAt(snap, 32, 32);
@@ -2010,7 +2017,7 @@ TEST_F(RendererGeodeTest, FilterConvolveMatrixEdgeDetect) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   // Interior pixel (32, 32): all neighbours are identical white, so
   // Laplacian = 4*1 - 4*1 = 0. Output should be near-black/transparent.
@@ -2073,7 +2080,7 @@ TEST_F(RendererGeodeTest, FilterAppliedBeforeClipPathSvgRenderingOrder) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
 
   // (30, 32): inside the clipped region (clip is x<32) but only 2 pixels
   // from the right edge. The blur kernel (stdDev=3) at this x-coordinate

--- a/donner/svg/renderer/tests/RendererPublicApi_tests.cc
+++ b/donner/svg/renderer/tests/RendererPublicApi_tests.cc
@@ -11,10 +11,12 @@
 #include "donner/svg/renderer/Renderer.h"
 #include "donner/svg/renderer/tests/MockRendererInterface.h"
 #include "donner/svg/renderer/tests/RendererTestBackend.h"
+#include "donner/svg/renderer/tests/RendererTestMatchers.h"
 
 namespace donner::svg {
 namespace {
 
+using test::NonEmptyRendererBitmap;
 using ::testing::_;
 using ::testing::AllOf;
 using ::testing::ElementsAre;
@@ -107,7 +109,7 @@ TEST(RendererPublicApiTest, DrawProducesSnapshotAndPng) {
   renderer.draw(document);
 
   const RendererBitmap snapshot = renderer.takeSnapshot();
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
   EXPECT_EQ(renderer.width(), 8);
   EXPECT_EQ(renderer.height(), 6);
   EXPECT_EQ(snapshot.dimensions, Vector2i(8, 6));
@@ -136,7 +138,7 @@ TEST(RendererPublicApiTest, IncrementalStyleInvalidationMatchesFullRender) {
 
   incrementalRenderer.draw(incrementalDocument);
   const RendererBitmap incrementalSnapshot = NormalizeSnapshot(incrementalRenderer.takeSnapshot());
-  ASSERT_FALSE(incrementalSnapshot.empty());
+  ASSERT_THAT(incrementalSnapshot, NonEmptyRendererBitmap());
 
   SVGDocument fullDocument = ParseDocument(R"svg(
       <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12">
@@ -147,7 +149,7 @@ TEST(RendererPublicApiTest, IncrementalStyleInvalidationMatchesFullRender) {
   Renderer fullRenderer;
   fullRenderer.draw(fullDocument);
   const RendererBitmap fullSnapshot = NormalizeSnapshot(fullRenderer.takeSnapshot());
-  ASSERT_FALSE(fullSnapshot.empty());
+  ASSERT_THAT(fullSnapshot, NonEmptyRendererBitmap());
 
   EXPECT_EQ(incrementalSnapshot.dimensions, fullSnapshot.dimensions);
   EXPECT_EQ(incrementalSnapshot.rowBytes, fullSnapshot.rowBytes);
@@ -176,7 +178,7 @@ TEST(RendererPublicApiTest, TextUsesDocumentTransformForGlyphPlacement) {
   renderer.draw(document);
 
   const RendererBitmap snapshot = renderer.takeSnapshot();
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
   ASSERT_EQ(snapshot.dimensions, Vector2i(500, 500));
 
   const auto pixelAt = [&](int x, int y) -> std::array<uint8_t, 4> {
@@ -204,13 +206,13 @@ TEST(RendererPublicApiTest, DoubleDrawWithoutMutationProducesSameOutput) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap firstSnapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(firstSnapshot.empty());
+  ASSERT_THAT(firstSnapshot, NonEmptyRendererBitmap());
 
   // Second draw without any DOM mutation — exercises the dirty-flag fast path in
   // RenderingContext::instantiateRenderTree().
   renderer.draw(document);
   const RendererBitmap secondSnapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(secondSnapshot.empty());
+  ASSERT_THAT(secondSnapshot, NonEmptyRendererBitmap());
 
   EXPECT_EQ(firstSnapshot.dimensions, secondSnapshot.dimensions);
   EXPECT_EQ(firstSnapshot.pixels, secondSnapshot.pixels);
@@ -263,7 +265,7 @@ TEST(RendererPublicApiTest, DrawBitmapHonorsPaddedRows) {
   renderer.endFrame();
 
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
   ASSERT_EQ(snapshot.dimensions, Vector2i(2, 2));
   EXPECT_THAT(PixelAt(snapshot, 0, 0), Rgba(255, 0, 0, 255));
   EXPECT_THAT(PixelAt(snapshot, 1, 0), Rgba(0, 255, 0, 255));
@@ -301,7 +303,7 @@ TEST(RendererPublicApiTest, ChangeFillColorInvalidatesAndProducesNewOutput) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap before = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(before.empty());
+  ASSERT_THAT(before, NonEmptyRendererBitmap());
 
   auto elem = document.querySelector("#r");
   ASSERT_TRUE(elem.has_value());
@@ -309,7 +311,7 @@ TEST(RendererPublicApiTest, ChangeFillColorInvalidatesAndProducesNewOutput) {
 
   renderer.draw(document);
   const RendererBitmap after = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(after.empty());
+  ASSERT_THAT(after, NonEmptyRendererBitmap());
 
   EXPECT_EQ(before.dimensions, after.dimensions);
   // Pixels must differ because fill changed from red to blue.
@@ -431,7 +433,7 @@ TEST(RendererPublicApiTest, AppendChildInvalidates) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap before = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(before.empty());
+  ASSERT_THAT(before, NonEmptyRendererBitmap());
 
   // Add a filled rect that covers the entire canvas.
   SVGRectElement rect = SVGRectElement::Create(document);
@@ -442,7 +444,7 @@ TEST(RendererPublicApiTest, AppendChildInvalidates) {
 
   renderer.draw(document);
   const RendererBitmap after = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(after.empty());
+  ASSERT_THAT(after, NonEmptyRendererBitmap());
 
   EXPECT_EQ(before.dimensions, after.dimensions);
   EXPECT_NE(before.pixels, after.pixels);
@@ -557,7 +559,7 @@ TEST(RendererPublicApiTest, StrokeRenderingOnRect) {
   EXPECT_EQ(renderer.height(), 50);
 
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
 
   // The center of the rect should be transparent (fill=none).
   auto center = PixelAt(snapshot, 25, 25);
@@ -592,8 +594,8 @@ TEST(RendererPublicApiTest, StrokeDasharrayDiffersFromSolid) {
   rDashed.draw(docDashed);
   const RendererBitmap snapDashed = NormalizeSnapshot(rDashed.takeSnapshot());
 
-  ASSERT_FALSE(snapSolid.empty());
-  ASSERT_FALSE(snapDashed.empty());
+  ASSERT_THAT(snapSolid, NonEmptyRendererBitmap());
+  ASSERT_THAT(snapDashed, NonEmptyRendererBitmap());
   EXPECT_EQ(snapSolid.dimensions, snapDashed.dimensions);
   // Pixels must differ because of the dash gaps.
   EXPECT_NE(snapSolid.pixels, snapDashed.pixels);
@@ -610,7 +612,7 @@ TEST(RendererPublicApiTest, ShapeOpacity) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
 
   // The pixel should be semi-transparent red (~128 alpha).
   auto px = PixelAt(snapshot, 10, 10);
@@ -630,7 +632,7 @@ TEST(RendererPublicApiTest, FillOpacityAndStrokeOpacity) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
 
   // Interior should have semi-transparent green fill.
   auto interior = PixelAt(snapshot, 20, 20);
@@ -661,7 +663,7 @@ TEST(RendererPublicApiTest, MarkerRendering) {
   EXPECT_EQ(renderer.width(), 80);
   EXPECT_EQ(renderer.height(), 40);
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
 
   // Sample above the polyline stroke (y=20) where only the marker circle extends.
   // The marker is a red circle with r=5 at markerUnits=strokeWidth (stroke-width=2),
@@ -689,7 +691,7 @@ TEST(RendererPublicApiTest, RecursiveMarkerStopsAtOneLevel) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
 
   EXPECT_THAT(PixelAt(snapshot, 26, 18), IsRedish());
   EXPECT_THAT(PixelAt(snapshot, 34, 18), IsTransparent());
@@ -710,7 +712,7 @@ TEST(RendererPublicApiTest, UseElementRendering) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
 
   // Both use instances should produce blue pixels.
   auto first = PixelAt(snapshot, 10, 10);
@@ -735,7 +737,7 @@ TEST(RendererPublicApiTest, NestedGroupTransforms) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
 
   // The rect should be 20x20 at position (10,10) due to translate + scale(2).
   // Inside the transformed rect (e.g., 20, 20) should be red.
@@ -766,7 +768,7 @@ TEST(RendererPublicApiTest, ViewBoxScaling) {
   EXPECT_EQ(renderer.height(), 50);
 
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
 
   // The green rect should fill the entire 50x50 canvas.
   auto corner = PixelAt(snapshot, 0, 0);
@@ -792,7 +794,7 @@ TEST(RendererPublicApiTest, SymbolWithUse) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
 
   // The symbol should be rendered at (5,5) with 20x20 size, containing magenta.
   auto inside = PixelAt(snapshot, 15, 15);
@@ -815,7 +817,7 @@ TEST(RendererPublicApiTest, CssClassStyling) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
 
   auto px = PixelAt(snapshot, 10, 10);
   EXPECT_THAT(px, IsRedish());
@@ -832,7 +834,7 @@ TEST(RendererPublicApiTest, InlineStyleOverridesAttribute) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
 
   // Style should override the fill attribute — result should be red, not blue.
   auto px = PixelAt(snapshot, 10, 10);
@@ -862,7 +864,7 @@ TEST(RendererPublicApiTest, MultipleLinearGradients) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
 
   // Left rect's left edge should be reddish.
   auto leftEdge = PixelAt(snapshot, 1, 10);
@@ -890,7 +892,7 @@ TEST(RendererPublicApiTest, RadialGradient) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
 
   // Center should be white (near 255 in all channels).
   auto center = PixelAt(snapshot, 20, 20);
@@ -918,7 +920,7 @@ TEST(RendererPublicApiTest, ImageElementDataUri) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
   EXPECT_EQ(snapshot.dimensions, Vector2i(20, 20));
 
   // The data URI image should be decoded and rendered.  The 2x2 red PNG is scaled
@@ -940,7 +942,7 @@ TEST(RendererPublicApiTest, EmptyDocumentProducesValidOutput) {
   EXPECT_EQ(renderer.height(), 30);
 
   const RendererBitmap snapshot = renderer.takeSnapshot();
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
   EXPECT_EQ(snapshot.dimensions, Vector2i(30, 30));
 
   // All pixels should be transparent.
@@ -959,7 +961,7 @@ TEST(RendererPublicApiTest, CircleElement) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
 
   // Center should be green.
   auto center = PixelAt(snapshot, 20, 20);
@@ -981,7 +983,7 @@ TEST(RendererPublicApiTest, EllipseElement) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
 
   // Center should be blue.
   auto center = PixelAt(snapshot, 30, 15);
@@ -1005,7 +1007,7 @@ TEST(RendererPublicApiTest, PatternFill) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
 
   // The pattern should produce non-transparent content.
   auto px = PixelAt(snapshot, 2, 2);
@@ -1032,7 +1034,7 @@ TEST(RendererPublicApiTest, ClipPathCropsContent) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
 
   // Inside clip region should be red.
   auto inside = PixelAt(snapshot, 20, 20);
@@ -1060,7 +1062,7 @@ TEST(RendererPublicApiTest, MaskElement) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
 
   // Outside the black hole (corner) — mask is white, so green should show.
   auto corner = PixelAt(snapshot, 2, 2);
@@ -1086,7 +1088,7 @@ TEST(RendererPublicApiTest, MixBlendModeIsolatedLayer) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
 
   // multiply(#ffff00, #00ffff) = #00ff00 (green)
   auto px = PixelAt(snapshot, 15, 15);
@@ -1104,7 +1106,7 @@ TEST(RendererPublicApiTest, VisibilityHidden) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
 
   // Hidden element should not render — pixel should be transparent.
   auto px = PixelAt(snapshot, 10, 10);
@@ -1124,7 +1126,7 @@ TEST(RendererPublicApiTest, DisplayNone) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
 
   auto px = PixelAt(snapshot, 10, 10);
   EXPECT_THAT(px, IsTransparent());
@@ -1148,7 +1150,7 @@ TEST(RendererPublicApiTest, GradientWithTransform) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
 
   // Because of 90-degree rotation, the gradient should go top to bottom.
   auto top = PixelAt(snapshot, 20, 1);
@@ -1168,7 +1170,7 @@ TEST(RendererPublicApiTest, PathElement) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
 
   // Inside the path should be orange.
   auto inside = PixelAt(snapshot, 20, 20);
@@ -1193,7 +1195,7 @@ TEST(RendererPublicApiTest, GradientUserSpaceOnUse) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
 
   // Left edge should be cyan (R=0, G=255, B=255).
   auto left = PixelAt(snapshot, 1, 20);
@@ -1216,7 +1218,7 @@ TEST(RendererPublicApiTest, StrokeOnPath) {
   Renderer renderer;
   renderer.draw(document);
   const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
-  ASSERT_FALSE(snapshot.empty());
+  ASSERT_THAT(snapshot, NonEmptyRendererBitmap());
 
   // On the line at y=25 should be red.
   auto onLine = PixelAt(snapshot, 25, 25);

--- a/donner/svg/renderer/tests/RendererRegression_tests.cc
+++ b/donner/svg/renderer/tests/RendererRegression_tests.cc
@@ -4,10 +4,12 @@
 
 #include "donner/base/tests/Runfiles.h"
 #include "donner/svg/renderer/tests/ImageComparisonTestFixture.h"
+#include "donner/svg/renderer/tests/RendererTestMatchers.h"
 
 namespace donner::svg {
 namespace {
 
+using test::NonEmptyRendererBitmap;
 using Params = ImageComparisonParams;
 
 std::filesystem::path ResvgResourceRoot() {
@@ -71,8 +73,8 @@ TEST_F(RendererRegressionTests, NestedBaselineShiftRedrawIsIdempotent) {
   const RendererBitmap first = RenderDocumentWithBackend(document, RendererBackend::TinySkia);
   const RendererBitmap second = RenderDocumentWithBackend(document, RendererBackend::TinySkia);
 
-  ASSERT_FALSE(first.empty());
-  ASSERT_FALSE(second.empty());
+  ASSERT_THAT(first, NonEmptyRendererBitmap());
+  ASSERT_THAT(second, NonEmptyRendererBitmap());
   ExpectBitmapsIdentical(second, first, "nested_baseline_shift_redraw");
 }
 
@@ -83,8 +85,8 @@ TEST_F(RendererRegressionTests, FeImageFragmentRedrawIsIdempotent) {
   const RendererBitmap first = RenderDocumentWithBackend(document, RendererBackend::TinySkia);
   const RendererBitmap second = RenderDocumentWithBackend(document, RendererBackend::TinySkia);
 
-  ASSERT_FALSE(first.empty());
-  ASSERT_FALSE(second.empty());
+  ASSERT_THAT(first, NonEmptyRendererBitmap());
+  ASSERT_THAT(second, NonEmptyRendererBitmap());
   ExpectBitmapsIdentical(second, first, "feimage_fragment_redraw");
 }
 

--- a/donner/svg/renderer/tests/RendererSnapshot_tests.cc
+++ b/donner/svg/renderer/tests/RendererSnapshot_tests.cc
@@ -19,6 +19,8 @@
 
 using ::testing::_;
 using ::testing::AtLeast;
+using ::testing::IsEmpty;
+using ::testing::Not;
 
 namespace donner::svg {
 namespace {
@@ -71,7 +73,7 @@ TEST(RendererSnapshotTests, ReplayingCapturedSnapshotIgnoresLaterDomMutations) {
 
   driver.draw(snapshot);
 
-  ASSERT_FALSE(replayedFills.empty());
+  ASSERT_THAT(replayedFills, Not(IsEmpty()));
   EXPECT_EQ(replayedFills.back(), css::RGBA(255, 0, 0, 255));
 }
 
@@ -104,7 +106,7 @@ TEST(RendererSnapshotTests, LaterSnapshotObservesLaterDomRevision) {
 
   driver.draw(laterSnapshot);
 
-  ASSERT_FALSE(replayedFills.empty());
+  ASSERT_THAT(replayedFills, Not(IsEmpty()));
   EXPECT_EQ(replayedFills.back(), css::RGBA(0, 0, 255, 255));
 }
 
@@ -192,13 +194,13 @@ TEST(RendererSnapshotTests, GradientPaintReferencesAreSnapshotOwned) {
 
   driver.draw(snapshot);
 
-  ASSERT_FALSE(replayedFillRefs.empty());
+  ASSERT_THAT(replayedFillRefs, Not(IsEmpty()));
   const components::PaintResolvedReference& ref = replayedFillRefs.back();
   EXPECT_NE(ref.reference.handle.registry(), &document.registry());
 
   const auto* gradient = ref.reference.handle.try_get<components::ComputedGradientComponent>();
   ASSERT_NE(gradient, nullptr);
-  ASSERT_FALSE(gradient->stops.empty());
+  ASSERT_THAT(gradient->stops, Not(IsEmpty()));
   EXPECT_EQ(gradient->stops.front().color.resolve(css::RGBA(0, 0, 0, 255),
                                                   gradient->stops.front().opacity),
             css::RGBA(255, 0, 0, 255));
@@ -239,7 +241,7 @@ TEST(RendererSnapshotTests, PatternPaintReferencesAreSnapshotOwned) {
 
   driver.draw(snapshot);
 
-  ASSERT_FALSE(replayedPatternRefs.empty());
+  ASSERT_THAT(replayedPatternRefs, Not(IsEmpty()));
   const components::PaintResolvedReference& ref = replayedPatternRefs.back();
   EXPECT_NE(ref.reference.handle.registry(), &document.registry());
   EXPECT_NE(ref.reference.handle.try_get<components::ComputedPatternComponent>(), nullptr);
@@ -273,12 +275,12 @@ TEST(RendererSnapshotTests, FeImageFragmentReferencesAreClearedBeforeReplay) {
 
   driver.draw(snapshot);
 
-  ASSERT_FALSE(replayedFilterGraphs.empty());
-  ASSERT_FALSE(replayedFilterGraphs.front().nodes.empty());
+  ASSERT_THAT(replayedFilterGraphs, Not(IsEmpty()));
+  ASSERT_THAT(replayedFilterGraphs.front().nodes, Not(IsEmpty()));
   const auto* image = std::get_if<components::filter_primitive::Image>(
       &replayedFilterGraphs.front().nodes.front().primitive);
   ASSERT_NE(image, nullptr);
-  EXPECT_TRUE(image->fragmentId.empty());
+  EXPECT_THAT(image->fragmentId, IsEmpty());
   EXPECT_FALSE(image->svgSubDocument);
 }
 
@@ -321,7 +323,7 @@ TEST(RendererSnapshotTests, TextPaintReferencesAreSnapshotOwned) {
 
   driver.draw(snapshot);
 
-  ASSERT_FALSE(replayedSpanFillRefs.empty());
+  ASSERT_THAT(replayedSpanFillRefs, Not(IsEmpty()));
   const components::PaintResolvedReference& ref = replayedSpanFillRefs.back();
   EXPECT_NE(ref.reference.handle.registry(), &document.registry());
   EXPECT_NE(ref.reference.handle.try_get<components::ComputedGradientComponent>(), nullptr);

--- a/donner/svg/renderer/tests/RendererTestMatchers.h
+++ b/donner/svg/renderer/tests/RendererTestMatchers.h
@@ -1,0 +1,55 @@
+#pragma once
+/// @file
+
+#include <gmock/gmock.h>
+
+#include "donner/base/EcsRegistry.h"
+#include "donner/svg/renderer/RendererInterface.h"
+
+namespace donner::svg::test {
+
+/// Matches an empty \ref RendererBitmap and prints shape details on failure.
+MATCHER(EmptyRendererBitmap, "an empty renderer bitmap") {
+  if (arg.empty()) {
+    return true;
+  }
+
+  *result_listener << "dimensions=(" << arg.dimensions.x << ", " << arg.dimensions.y
+                   << "), rowBytes=" << arg.rowBytes << ", pixels=" << arg.pixels.size()
+                   << ", alphaType=" << static_cast<int>(arg.alphaType);
+  return false;
+}
+
+/// Matches a non-empty \ref RendererBitmap and prints shape details on failure.
+MATCHER(NonEmptyRendererBitmap, "a non-empty renderer bitmap") {
+  if (!arg.empty()) {
+    return true;
+  }
+
+  *result_listener << "dimensions=(" << arg.dimensions.x << ", " << arg.dimensions.y
+                   << "), rowBytes=" << arg.rowBytes << ", pixels=" << arg.pixels.size()
+                   << ", alphaType=" << static_cast<int>(arg.alphaType);
+  return false;
+}
+
+/// Matches a null \ref Entity and prints the entity value on failure.
+MATCHER(NullEntity, "a null entity") {
+  if (arg == entt::null) {
+    return true;
+  }
+
+  *result_listener << "entity=" << arg;
+  return false;
+}
+
+/// Matches a non-null \ref Entity and prints the entity value on failure.
+MATCHER(NonNullEntity, "a non-null entity") {
+  if (arg != entt::null) {
+    return true;
+  }
+
+  *result_listener << "entity=" << arg;
+  return false;
+}
+
+}  // namespace donner::svg::test

--- a/donner/svg/renderer/tests/Renderer_tests.cc
+++ b/donner/svg/renderer/tests/Renderer_tests.cc
@@ -1,3 +1,4 @@
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <filesystem>
@@ -12,6 +13,7 @@
 #include "donner/svg/parser/SVGParser.h"
 #include "donner/svg/renderer/tests/ImageComparisonTestFixture.h"
 #include "donner/svg/renderer/tests/RendererTestBackend.h"
+#include "donner/svg/renderer/tests/RendererTestMatchers.h"
 #include "donner/svg/resources/SandboxedFileResourceLoader.h"
 
 // clang-format off
@@ -32,6 +34,7 @@
 namespace donner::svg {
 namespace {
 
+using test::NonEmptyRendererBitmap;
 using Params = ImageComparisonParams;
 
 /// Default per-pixel threshold for the Geode backend when a test doesn't have
@@ -539,9 +542,9 @@ TEST_F(RendererTests, ChainedFeImageDeepRecursionIsBoundedAndStable) {
   const RendererBitmap shorterChain = RenderSvgString(MakeChainedFeImageSvg(40));
   const RendererBitmap longerChain = RenderSvgString(MakeChainedFeImageSvg(90));
 
-  ASSERT_FALSE(shorterChain.pixels.empty())
+  ASSERT_THAT(shorterChain, NonEmptyRendererBitmap())
       << "Renderer returned an empty bitmap for the 40-link feImage chain";
-  ASSERT_FALSE(longerChain.pixels.empty())
+  ASSERT_THAT(longerChain, NonEmptyRendererBitmap())
       << "Renderer returned an empty bitmap for the 90-link feImage chain";
 
   // Both chains exceed the depth cap, so everything past depth 32 renders empty
@@ -609,9 +612,9 @@ TEST_F(RendererTests, DashSeamClosedContourMitersStartCorner) {
   const RendererBitmap openPath =
       renderInner("<path d=\"M40,40 L160,40 L160,160 L40,160 L40,40\" " + attrs + "/>");
 
-  ASSERT_FALSE(rectEl.empty());
-  ASSERT_FALSE(closedPath.empty());
-  ASSERT_FALSE(openPath.empty());
+  ASSERT_THAT(rectEl, NonEmptyRendererBitmap());
+  ASSERT_THAT(closedPath, NonEmptyRendererBitmap());
+  ASSERT_THAT(openPath, NonEmptyRendererBitmap());
 
   // <rect> is a closed contour -> the dash seam-joins -> mitered start corner (quadrant filled).
   EXPECT_EQ(greenInOuterCorner(rectEl), 64) << "dashed <rect> should miter its start corner";

--- a/donner/svg/renderer/tests/RenderingContext_tests.cc
+++ b/donner/svg/renderer/tests/RenderingContext_tests.cc
@@ -16,6 +16,7 @@
 #include "donner/svg/components/RenderingInstanceComponent.h"
 #include "donner/svg/components/style/ComputedStyleComponent.h"
 #include "donner/svg/parser/SVGParser.h"
+#include "donner/svg/renderer/tests/RendererTestMatchers.h"
 
 using testing::ElementsAre;
 using testing::Gt;
@@ -23,6 +24,9 @@ using testing::NotNull;
 using testing::Optional;
 
 namespace donner::svg::components {
+
+using test::NonNullEntity;
+using test::NullEntity;
 
 class RenderingContextTest : public ::testing::Test {
 protected:
@@ -118,7 +122,7 @@ TEST_F(RenderingContextTest, FindIntersectingHitsRect) {
   ctx.instantiateRenderTree(false, warningSink_);
 
   Entity hit = ctx.findIntersecting(Vector2d(50, 50));
-  EXPECT_TRUE(hit != entt::null);
+  EXPECT_THAT(hit, NonNullEntity());
 }
 
 TEST_F(RenderingContextTest, FindIntersectingMissesEmptyArea) {
@@ -132,7 +136,7 @@ TEST_F(RenderingContextTest, FindIntersectingMissesEmptyArea) {
   ctx.instantiateRenderTree(false, warningSink_);
 
   Entity hit = ctx.findIntersecting(Vector2d(5, 5));
-  EXPECT_TRUE(hit == entt::null);
+  EXPECT_THAT(hit, NullEntity());
 }
 
 TEST_F(RenderingContextTest, FindAllIntersecting) {
@@ -484,7 +488,7 @@ TEST_F(RenderingContextTest, DisplayNoneNotIntersectable) {
   ctx.instantiateRenderTree(false, warningSink_);
 
   Entity hit = ctx.findIntersecting(Vector2d(50, 50));
-  EXPECT_TRUE(hit == entt::null);
+  EXPECT_THAT(hit, NullEntity());
 }
 
 TEST_F(RenderingContextTest, RectIntersection) {
@@ -552,7 +556,7 @@ TEST_F(RenderingContextTest, PointerEventsPaintedRequiresVisiblePaint) {
   )");
 
   RenderingContext ctx(document.registry());
-  EXPECT_TRUE(ctx.findIntersecting(Vector2d(50, 50)) == entt::null);
+  EXPECT_THAT(ctx.findIntersecting(Vector2d(50, 50)), NullEntity());
 }
 
 TEST_F(RenderingContextTest, PointerEventsVisibleStrokeRequiresVisibility) {
@@ -565,7 +569,7 @@ TEST_F(RenderingContextTest, PointerEventsVisibleStrokeRequiresVisibility) {
   )");
 
   RenderingContext ctx(document.registry());
-  EXPECT_TRUE(ctx.findIntersecting(Vector2d(15, 50)) == entt::null);
+  EXPECT_THAT(ctx.findIntersecting(Vector2d(15, 50)), NullEntity());
 }
 
 TEST_F(RenderingContextTest, PointerEventsStrokeHitsHiddenStrokeGeometry) {
@@ -580,7 +584,7 @@ TEST_F(RenderingContextTest, PointerEventsStrokeHitsHiddenStrokeGeometry) {
   RenderingContext ctx(document.registry());
   const Entity rectEntity = document.querySelector("#r")->unsafeEntityHandle().entity();
   EXPECT_EQ(ctx.findIntersecting(Vector2d(15, 50)), rectEntity);
-  EXPECT_TRUE(ctx.findIntersecting(Vector2d(50, 50)) == entt::null);
+  EXPECT_THAT(ctx.findIntersecting(Vector2d(50, 50)), NullEntity());
 }
 
 TEST_F(RenderingContextTest, FindIntersectingRectReturnsFrontToBackOrder) {

--- a/donner/svg/renderer/tests/TextBackend_tests.cc
+++ b/donner/svg/renderer/tests/TextBackend_tests.cc
@@ -257,7 +257,6 @@ TEST_P(TextBackendTest, GlyphOutlineProducesNonEmptyPath) {
 
   const float scale = backend().scaleForEmToPixels(font, 16.0f);
   const Path path = backend().glyphOutline(font, shaped.glyphs[0].glyphIndex, scale);
-  EXPECT_FALSE(path.empty());
   EXPECT_THAT(path.commands(), Not(IsEmpty()));
 }
 

--- a/donner/svg/renderer/tests/TextEngine_tests.cc
+++ b/donner/svg/renderer/tests/TextEngine_tests.cc
@@ -163,7 +163,7 @@ TEST(TextEngineTest, UsesCoverageFallbackForVerticalJapaneseText) {
   const float scale = engine.scaleForEmToPixels(runs[0].font, 64.0f);
   const Path firstGlyphPath =
       engine.glyphOutline(runs[0].font, runs[0].glyphs[0].glyphIndex, scale);
-  ASSERT_FALSE(firstGlyphPath.empty());
+  ASSERT_THAT(firstGlyphPath.commands(), Not(IsEmpty()));
 
   Box2d positionedBounds = firstGlyphPath.bounds();
   positionedBounds += Vector2d(runs[0].glyphs[0].xPosition, runs[0].glyphs[0].yPosition);

--- a/donner/svg/renderer/tests/ZoomFilterRepro_tests.cc
+++ b/donner/svg/renderer/tests/ZoomFilterRepro_tests.cc
@@ -47,10 +47,14 @@
 #include "donner/svg/SVGDocument.h"
 #include "donner/svg/parser/SVGParser.h"
 #include "donner/svg/renderer/Renderer.h"
+#include "donner/svg/renderer/tests/RendererTestMatchers.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace donner::svg {
 namespace {
+
+using test::NonEmptyRendererBitmap;
 
 std::string LoadSplash() {
   std::ifstream stream("donner_splash.svg");
@@ -131,7 +135,7 @@ TEST(ZoomFilterRepro, TinyCanvasRendersNonEmptySnapshot) {
   // Sanity: a 100×100 canvas must render. If this fails, something is
   // wrong with the test harness itself, not the cap.
   const RendererBitmap snapshot = RenderAt(kTinySvg, 100, 100, /*outName=*/nullptr);
-  EXPECT_FALSE(snapshot.empty()) << "100×100 canvas produced an empty snapshot";
+  EXPECT_THAT(snapshot, NonEmptyRendererBitmap()) << "100×100 canvas produced an empty snapshot";
 }
 
 TEST(ZoomFilterRepro, SquareCanvasAtPriorCapBoundaryRenders) {
@@ -139,7 +143,7 @@ TEST(ZoomFilterRepro, SquareCanvasAtPriorCapBoundaryRenders) {
   // `len.value() > kMaxAllocationBytes` (strict greater-than), so this size
   // is on the boundary and was historically allowed.
   const RendererBitmap snapshot = RenderAt(kTinySvg, 4096, 4096, /*outName=*/nullptr);
-  EXPECT_FALSE(snapshot.empty())
+  EXPECT_THAT(snapshot, NonEmptyRendererBitmap())
       << "4096×4096 canvas (64 MiB exactly) failed to render — the cap may have moved.";
 }
 
@@ -157,7 +161,7 @@ TEST(ZoomFilterRepro, SplashAtEditorClampBoundaryRenders) {
   }
   const RendererBitmap snapshot =
       RenderAt(std::string_view{source}, 8192, 4708, "splash_at_editor_clamp_8192x4708.png");
-  EXPECT_FALSE(snapshot.empty())
+  EXPECT_THAT(snapshot, NonEmptyRendererBitmap())
       << "Splash @ 8192×4708 produced an empty snapshot — main pixmap allocation failed. "
          "Check `Pixmap::fromSize` cap in third_party/tiny-skia-cpp.";
   // Renderer preserves the 892:512 viewBox aspect inside the requested canvas,
@@ -181,9 +185,9 @@ TEST(ZoomFilterRepro, SplashHaloSurvivesHighZoom) {
     GTEST_SKIP() << "donner_splash.svg not in runfiles";
   }
   const RendererBitmap lo = RenderAt(std::string_view{source}, 892, 512, "splash_halo_lo.png");
-  ASSERT_FALSE(lo.empty());
+  ASSERT_THAT(lo, NonEmptyRendererBitmap());
   const RendererBitmap hi = RenderAt(std::string_view{source}, 8192, 4708, "splash_halo_hi.png");
-  ASSERT_FALSE(hi.empty());
+  ASSERT_THAT(hi, NonEmptyRendererBitmap());
 
   // Probe inside the Lightning_glow_dark halo on the small bottom bolt
   // (low-zoom doc coords near (478, 440)) — the bright cyan glow that's


### PR DESCRIPTION
Improve renderer test diagnostics by replacing raw bitmap, entity-null, and collection emptiness checks with reusable gMock matchers across `donner/svg/renderer/tests`.

## Changes
- Add shared renderer test matchers for `RendererBitmap` emptiness and `Entity` nullability.
- Convert renderer snapshot, driver, Geode, public API, regression, zoom/filter, and error-path tests away from bare `.empty()` and `entt::null` boolean checks.
- Replace size/emptiness assertions in renderer filter, text, and snapshot tests with gMock matchers that print expected-vs-actual context.

## Validation
- `bazel test //... --test_output=errors`
- `bazel test --config=text-full //donner/svg/renderer/tests:text_backend_tests //donner/svg/renderer/tests:text_engine_tests --test_output=errors`
- `python3 tools/cmake/gen_cmakelists.py --check`