### PR TITLE
Improve Geode renderer test diagnostics

### DIFF
--- a/donner/svg/compositor/BUILD.bazel
+++ b/donner/svg/compositor/BUILD.bazel
@@ -70,6 +70,19 @@ donner_cc_library(
     ],
 )
 
+donner_cc_library(
+    name = "compositor_test_matchers",
+    testonly = 1,
+    hdrs = ["CompositorTestMatchers.h"],
+    visibility = ["//donner/svg:__subpackages__"],
+    deps = [
+        ":compositor",
+        ":dual_path_verifier",
+        "//donner/svg/renderer:renderer_interface",
+        "@com_google_gtest//:gtest",
+    ],
+)
+
 donner_cc_test(
     name = "compositor_tests",
     srcs = [
@@ -84,9 +97,11 @@ donner_cc_test(
     ],
     deps = [
         ":compositor",
+        ":compositor_test_matchers",
         "//donner/svg/renderer:renderer_interface",
         "//donner/svg/renderer:renderer_utils",
         "//donner/svg/renderer/tests:mock_renderer_interface",
+        "//donner/svg/renderer/tests:renderer_test_matchers",
         "//donner/svg/tests:parser_test_utils",
         "@com_google_gtest//:gtest_main",
     ],
@@ -127,6 +142,7 @@ donner_cc_test(
     ],
     deps = [
         ":compositor",
+        ":compositor_test_matchers",
         "@com_google_gtest//:gtest_main",
     ],
 )
@@ -163,6 +179,7 @@ donner_cc_test(
     ],
     deps = [
         ":compositor",
+        ":compositor_test_matchers",
         "@com_google_gtest//:gtest_main",
     ],
 )
@@ -214,9 +231,11 @@ donner_cc_test(
     ],
     deps = [
         ":compositor",
+        ":compositor_test_matchers",
         ":dual_path_verifier",
         "//donner/svg/renderer",
         "//donner/svg/renderer:renderer_interface",
+        "//donner/svg/renderer/tests:renderer_test_matchers",
         "@com_google_gtest//:gtest_main",
     ],
 )
@@ -237,9 +256,11 @@ donner_cc_test(
     ],
     deps = [
         ":compositor",
+        ":compositor_test_matchers",
         ":dual_path_verifier",
         "//donner/svg/renderer",
         "//donner/svg/renderer:renderer_interface",
+        "//donner/svg/renderer/tests:renderer_test_matchers",
         "@com_google_gtest//:gtest_main",
     ],
 )

--- a/donner/svg/compositor/ComplexityBucketer_tests.cc
+++ b/donner/svg/compositor/ComplexityBucketer_tests.cc
@@ -1,7 +1,9 @@
 #include "donner/svg/compositor/ComplexityBucketer.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <array>
 #include <vector>
 
 #include "donner/base/EcsRegistry.h"
@@ -221,19 +223,22 @@ TEST_F(ComplexityBucketerTest, Deterministic) {
 
   ComplexityBucketer bucketer;
   bucketer.reconcile(registry_);
-  const auto after1 = std::vector<bool>{
-      countHints(c1, HintSource::ComplexityBucket) == 1u,
-      countHints(c2, HintSource::ComplexityBucket) == 1u,
-      countHints(c3, HintSource::ComplexityBucket) == 1u,
+  const auto after1 = std::array<size_t, 3>{
+      countHints(c1, HintSource::ComplexityBucket),
+      countHints(c2, HintSource::ComplexityBucket),
+      countHints(c3, HintSource::ComplexityBucket),
   };
 
   for (int i = 0; i < 9; ++i) {
     bucketer.reconcile(registry_);
   }
 
-  EXPECT_EQ(countHints(c1, HintSource::ComplexityBucket) == 1u, after1[0]);
-  EXPECT_EQ(countHints(c2, HintSource::ComplexityBucket) == 1u, after1[1]);
-  EXPECT_EQ(countHints(c3, HintSource::ComplexityBucket) == 1u, after1[2]);
+  EXPECT_THAT((std::array<size_t, 3>{
+                  countHints(c1, HintSource::ComplexityBucket),
+                  countHints(c2, HintSource::ComplexityBucket),
+                  countHints(c3, HintSource::ComplexityBucket),
+              }),
+              testing::ElementsAre(after1[0], after1[1], after1[2]));
 }
 
 TEST_F(ComplexityBucketerTest, ReservedSlotsReduceBudget) {

--- a/donner/svg/compositor/CompositorController_tests.cc
+++ b/donner/svg/compositor/CompositorController_tests.cc
@@ -11,10 +11,12 @@
 
 #include "donner/svg/SVGDocument.h"
 #include "donner/svg/SVGGraphicsElement.h"
+#include "donner/svg/compositor/CompositorTestMatchers.h"
 #include "donner/svg/compositor/ComputedLayerAssignmentComponent.h"
 #include "donner/svg/renderer/RendererInterface.h"
 #include "donner/svg/renderer/RendererUtils.h"
 #include "donner/svg/renderer/tests/MockRendererInterface.h"
+#include "donner/svg/renderer/tests/RendererTestMatchers.h"
 #include "donner/svg/tests/ParserTestUtils.h"
 
 using ::testing::_;
@@ -97,6 +99,9 @@ void PrintTo(const CompositorTile& tile, std::ostream* os) {
 namespace {
 
 using MockRendererInterface = tests::MockRendererInterface;
+using ::donner::svg::test::EmptyRendererBitmap;
+using ::donner::svg::test::NonEmptyRendererBitmap;
+using ::donner::svg::test::NullEntity;
 using CompositeTileSnapshot = CompositorController::CompositeTileSnapshot;
 using LayerInspectorRow = CompositorController::LayerInspectorRow;
 using SegmentInspectorRow = CompositorController::SegmentInspectorRow;
@@ -457,13 +462,13 @@ TEST_F(CompositorControllerTest, PromoteInvalidEntityFails) {
   EXPECT_FALSE(compositor.isPromoted(entt::null));
   EXPECT_TRUE(compositor.layerComposeOffset(entt::null).isIdentity());
   EXPECT_EQ(compositor.fallbackReasonsOf(entt::null), FallbackReason::None);
-  EXPECT_TRUE(compositor.layerBitmapOf(entt::null).empty());
+  EXPECT_THAT(compositor.layerBitmapOf(entt::null), EmptyRendererBitmap());
   EXPECT_EQ(compositor.layerCanvasOffsetOf(entt::null), Vector2d::Zero());
 
   const auto state = compositor.snapshotState();
   EXPECT_EQ(state.lastPromoteRefusalReason,
             CompositorController::PromoteRefusalReason::InvalidEntity);
-  EXPECT_TRUE(state.lastPromoteRefusalEntity == entt::null);
+  EXPECT_THAT(state.lastPromoteRefusalEntity, NullEntity());
 }
 
 TEST_F(CompositorControllerTest, DemoteRemovesLayer) {
@@ -719,7 +724,7 @@ TEST_F(CompositorControllerTest, DemoteDetachedPromotedEntityClearsInteractionHi
   EXPECT_FALSE(compositor.isPromoted(entity));
   const auto state = compositor.snapshotState();
   EXPECT_EQ(state.activeHintsCount, 0u);
-  EXPECT_TRUE(state.splitStaticLayersEntity == entt::null);
+  EXPECT_THAT(state.splitStaticLayersEntity, NullEntity());
 }
 
 TEST_F(CompositorControllerTest, ComputedLayerAssignmentAttachedOnPromote) {
@@ -880,7 +885,7 @@ TEST_F(CompositorControllerTest, SinglePromotedLayerBuildsSplitStaticLayers) {
   // exists. Assert the layer's bitmap is non-empty (the editor reads
   // it directly via `snapshotTilesForUpload`).
   EXPECT_TRUE(compositor.hasSplitStaticLayers());
-  EXPECT_FALSE(compositor.layerBitmapOf(entity).empty());
+  EXPECT_THAT(compositor.layerBitmapOf(entity), NonEmptyRendererBitmap());
 }
 
 TEST_F(CompositorControllerTest, MultiplePromotedLayersDoNotBuildSplitStaticLayers) {
@@ -962,7 +967,8 @@ TEST_F(CompositorControllerTest, FilterTriggersFallback) {
 
   CompositorController compositor(document, renderer_);
   compositor.promoteEntity(entity);
-  EXPECT_NE(compositor.fallbackReasonsOf(entity) & FallbackReason::Filter, FallbackReason::None);
+  EXPECT_THAT(compositor.fallbackReasonsOf(entity),
+              test::FallbackReasonsInclude(FallbackReason::Filter));
 }
 
 TEST_F(CompositorControllerTest, ClipPathTriggersFallback) {
@@ -982,7 +988,8 @@ TEST_F(CompositorControllerTest, ClipPathTriggersFallback) {
 
   CompositorController compositor(document, renderer_);
   compositor.promoteEntity(entity);
-  EXPECT_NE(compositor.fallbackReasonsOf(entity) & FallbackReason::ClipPath, FallbackReason::None);
+  EXPECT_THAT(compositor.fallbackReasonsOf(entity),
+              test::FallbackReasonsInclude(FallbackReason::ClipPath));
 }
 
 TEST_F(CompositorControllerTest, MaskTriggersFallback) {
@@ -1002,7 +1009,8 @@ TEST_F(CompositorControllerTest, MaskTriggersFallback) {
 
   CompositorController compositor(document, renderer_);
   compositor.promoteEntity(entity);
-  EXPECT_NE(compositor.fallbackReasonsOf(entity) & FallbackReason::Mask, FallbackReason::None);
+  EXPECT_THAT(compositor.fallbackReasonsOf(entity),
+              test::FallbackReasonsInclude(FallbackReason::Mask));
 }
 
 TEST_F(CompositorControllerTest, OpacityTriggersFallback) {
@@ -1019,8 +1027,8 @@ TEST_F(CompositorControllerTest, OpacityTriggersFallback) {
 
   CompositorController compositor(document, renderer_);
   compositor.promoteEntity(entity);
-  EXPECT_NE(compositor.fallbackReasonsOf(entity) & FallbackReason::IsolatedLayer,
-            FallbackReason::None);
+  EXPECT_THAT(compositor.fallbackReasonsOf(entity),
+              test::FallbackReasonsInclude(FallbackReason::IsolatedLayer));
 }
 
 TEST_F(CompositorControllerTest, GradientFillTriggersFallback) {
@@ -1043,8 +1051,8 @@ TEST_F(CompositorControllerTest, GradientFillTriggersFallback) {
 
   CompositorController compositor(document, renderer_);
   compositor.promoteEntity(entity);
-  EXPECT_NE(compositor.fallbackReasonsOf(entity) & FallbackReason::ExternalPaint,
-            FallbackReason::None);
+  EXPECT_THAT(compositor.fallbackReasonsOf(entity),
+              test::FallbackReasonsInclude(FallbackReason::ExternalPaint));
 }
 
 TEST_F(CompositorControllerTest, FallbackReasonsOfUnpromotedEntity) {
@@ -1218,7 +1226,7 @@ TEST_F(CompositorControllerTest, SnapshotLayerInspectorRowsIsEmptyBeforePromotio
   )svg");
 
   CompositorController compositor(document, renderer_);
-  EXPECT_TRUE(compositor.snapshotLayerInspectorRows().empty());
+  EXPECT_THAT(compositor.snapshotLayerInspectorRows(), IsEmpty());
 }
 
 TEST_F(CompositorControllerTest, SnapshotLayerInspectorRowsEmitsRowPerLayerWithBitmapDims) {
@@ -1241,14 +1249,14 @@ TEST_F(CompositorControllerTest, SnapshotLayerInspectorRowsEmitsRowPerLayerWithB
   compositor.renderFrame(RenderViewport{kTestSvgDefaultSize});
 
   const auto rows = compositor.snapshotLayerInspectorRows();
-  ASSERT_EQ(rows.size(), 2u);
+  ASSERT_THAT(rows, SizeIs(2u));
 
   // Every row must point at one of the promoted entities; every row must
   // have a populated bitmap (the mock renderer's dummy bitmap) and a
   // non-zero rasterize count after the first renderFrame.
   std::vector<Entity> entitiesInRows;
   for (const auto& row : rows) {
-    EXPECT_TRUE(row.hasValidBitmap);
+    EXPECT_THAT(row, LayerHasValidBitmapIs(true));
     EXPECT_NE(row.bitmapSize, Vector2i::Zero());
     EXPECT_GE(row.rasterizeCount, 1u);
     EXPECT_GE(row.generation, 1u);
@@ -1443,9 +1451,9 @@ TEST_F(CompositorControllerTest, SnapshotLayerInspectorRowsEmitsThumbnailWithMax
   compositor.renderFrame(RenderViewport{kTestSvgDefaultSize});
 
   const auto rows = compositor.snapshotLayerInspectorRows();
-  ASSERT_EQ(rows.size(), 1u);
+  ASSERT_THAT(rows, SizeIs(1u));
   const auto& row = rows.front();
-  ASSERT_TRUE(row.hasValidBitmap);
+  ASSERT_THAT(row, LayerHasValidBitmapIs(true));
 
   // Thumbnail must be non-empty, longer side clamped to `kLayerThumbnailMaxSide`,
   // and the RGBA8 byte buffer must match the dimensions.
@@ -1453,8 +1461,8 @@ TEST_F(CompositorControllerTest, SnapshotLayerInspectorRowsEmitsThumbnailWithMax
   EXPECT_GT(row.thumbnailDims.y, 0);
   EXPECT_LE(std::max(row.thumbnailDims.x, row.thumbnailDims.y),
             CompositorController::kLayerThumbnailMaxSide);
-  EXPECT_EQ(row.thumbnailPixels.size(), static_cast<size_t>(row.thumbnailDims.x) *
-                                            static_cast<size_t>(row.thumbnailDims.y) * 4u);
+  EXPECT_THAT(row.thumbnailPixels, SizeIs(static_cast<size_t>(row.thumbnailDims.x) *
+                                          static_cast<size_t>(row.thumbnailDims.y) * 4u));
 }
 
 TEST_F(CompositorControllerTest, SnapshotSegmentInspectorRowsEmitsOneRowPerSlot) {
@@ -2049,7 +2057,7 @@ TEST_F(CompositorControllerTest, MandatoryFilterLayerSurvivesCanvasResize) {
 
   // First render: mandatory detector picks up the filter group.
   compositor.renderFrame(RenderViewport{kTestSvgDefaultSize});
-  ASSERT_FALSE(compositor.snapshotLayerInspectorRows().empty())
+  ASSERT_THAT(compositor.snapshotLayerInspectorRows(), Not(IsEmpty()))
       << "Sanity check: mandatory filter detection should have promoted #target on first frame.";
 
   // Simulate a canvas resize — same code path as the editor's pinch-zoom
@@ -2062,7 +2070,7 @@ TEST_F(CompositorControllerTest, MandatoryFilterLayerSurvivesCanvasResize) {
   // render. Without the fix, the snapshot returns zero rows because
   // the detector ran before prepare and saw an empty RIC view.
   const auto rows = compositor.snapshotLayerInspectorRows();
-  EXPECT_FALSE(rows.empty())
+  EXPECT_THAT(rows, Not(IsEmpty()))
       << "Canvas resize dropped the mandatory filter layer (detector ran against empty RICs).";
   bool sawFilterAfterResize = false;
   for (const auto& row : rows) {
@@ -2070,7 +2078,7 @@ TEST_F(CompositorControllerTest, MandatoryFilterLayerSurvivesCanvasResize) {
       sawFilterAfterResize = true;
     }
   }
-  EXPECT_TRUE(sawFilterAfterResize)
+  EXPECT_THAT(sawFilterAfterResize, testing::IsTrue())
       << "Filter-bearing layer should still be promoted after canvas resize.";
 }
 
@@ -2094,7 +2102,7 @@ TEST_F(CompositorControllerTest, SnapshotLayerInspectorRowsFormatsFallbackReason
   compositor.renderFrame(RenderViewport{kTestSvgDefaultSize});
 
   const auto rows = compositor.snapshotLayerInspectorRows();
-  ASSERT_FALSE(rows.empty());
+  ASSERT_THAT(rows, Not(IsEmpty()));
 
   // At least one row should have the Filter fallback flag set, with the
   // string representation matching the FallbackReasonToString output.
@@ -2102,11 +2110,10 @@ TEST_F(CompositorControllerTest, SnapshotLayerInspectorRowsFormatsFallbackReason
   for (const auto& row : rows) {
     if ((row.fallbackReasons & FallbackReason::Filter) != FallbackReason::None) {
       sawFilter = true;
-      EXPECT_NE(row.fallbackReasonsText.find("Filter"), std::string::npos)
-          << "fallbackReasonsText='" << row.fallbackReasonsText << "'";
+      EXPECT_THAT(row.fallbackReasonsText, HasSubstr("Filter"));
     }
   }
-  EXPECT_TRUE(sawFilter);
+  EXPECT_THAT(sawFilter, testing::IsTrue());
 }
 
 TEST_F(CompositorControllerTest, ResetAllLayersAllowsRepromotion) {
@@ -2158,7 +2165,7 @@ TEST_F(CompositorControllerTest, BuildStructuralEntityRemapMapsEquivalentTrees) 
 
   const auto remap = BuildStructuralEntityRemap(oldDocument, newDocument);
 
-  ASSERT_FALSE(remap.empty());
+  ASSERT_THAT(remap, Not(IsEmpty()));
   EXPECT_EQ(remap.at(oldDocument.svgElement().unsafeEntityHandle().entity()),
             newDocument.svgElement().unsafeEntityHandle().entity());
   EXPECT_EQ(remap.at(oldParent->unsafeEntityHandle().entity()),
@@ -2191,9 +2198,9 @@ TEST_F(CompositorControllerTest, BuildStructuralEntityRemapRejectsStructuralMism
     </g>
   )svg");
 
-  EXPECT_TRUE(BuildStructuralEntityRemap(oldDocument, tagMismatch).empty());
-  EXPECT_TRUE(BuildStructuralEntityRemap(oldDocument, idMismatch).empty());
-  EXPECT_TRUE(BuildStructuralEntityRemap(oldDocument, childCountMismatch).empty());
+  EXPECT_THAT(BuildStructuralEntityRemap(oldDocument, tagMismatch), IsEmpty());
+  EXPECT_THAT(BuildStructuralEntityRemap(oldDocument, idMismatch), IsEmpty());
+  EXPECT_THAT(BuildStructuralEntityRemap(oldDocument, childCountMismatch), IsEmpty());
 }
 
 }  // namespace donner::svg::compositor

--- a/donner/svg/compositor/CompositorGolden_tests.cc
+++ b/donner/svg/compositor/CompositorGolden_tests.cc
@@ -18,16 +18,25 @@
 #include "donner/svg/SVGGraphicsElement.h"
 #include "donner/svg/components/RenderingInstanceComponent.h"
 #include "donner/svg/compositor/CompositorController.h"
+#include "donner/svg/compositor/CompositorTestMatchers.h"
 #include "donner/svg/compositor/DualPathVerifier.h"
 #include "donner/svg/parser/SVGParser.h"
 #include "donner/svg/renderer/Renderer.h"
 #include "donner/svg/renderer/RendererDriver.h"
 #include "donner/svg/renderer/RendererImageIO.h"
 #include "donner/svg/renderer/common/RenderingInstanceView.h"
+#include "donner/svg/renderer/tests/RendererTestMatchers.h"
 
 namespace donner::svg::compositor {
 
 namespace {
+
+using ::donner::svg::test::EmptyRendererBitmap;
+using ::donner::svg::test::NonEmptyRendererBitmap;
+using ::testing::Contains;
+using ::testing::IsEmpty;
+using ::testing::Not;
+using ::testing::SizeIs;
 
 struct Pixel {
   uint8_t r = 0;
@@ -58,6 +67,11 @@ MATCHER(IsRed, "") {
 MATCHER(IsWhite, "") {
   *result_listener << "pixel is " << arg;
   return arg.r > 200 && arg.g > 200 && arg.b > 200 && arg.a > 200;
+}
+
+MATCHER(IsWarmYellow, "") {
+  *result_listener << "pixel is " << arg;
+  return arg.r > 200 && arg.g > 150 && arg.b < 100;
 }
 
 std::array<double, 6> TransformData(const Transform2d& transform) {
@@ -118,9 +132,7 @@ TEST_F(CompositorGoldenTest, PixelIdentityOnSimpleDocument) {
   DualPathVerifier verifier(compositor, renderer_);
   const auto result = verifier.renderAndVerify(viewport_);
 
-  EXPECT_TRUE(result.isExact()) << result;
-  EXPECT_EQ(result.mismatchCount, 0u);
-  EXPECT_EQ(result.maxChannelDiff, 0);
+  EXPECT_THAT(result, test::ExactVerifyResult());
 }
 
 // With an entity explicitly promoted to its own layer, compositor output is
@@ -143,7 +155,7 @@ TEST_F(CompositorGoldenTest, PromotedEntityMatchesFullRender) {
   DualPathVerifier verifier(compositor, renderer_);
   const auto result = verifier.renderAndVerify(viewport_);
 
-  EXPECT_TRUE(result.isExact()) << result;
+  EXPECT_THAT(result, test::ExactVerifyResult());
 }
 
 // Translation-only drag: composited fast path produces the same pixels as a
@@ -205,8 +217,7 @@ TEST_F(CompositorGoldenTest, RotationDragProducesCorrectPixels) {
 
   DualPathVerifier verifier(compositor, renderer_);
   const auto result = verifier.renderAndVerify(viewport_);
-  EXPECT_TRUE(result.isExact()) << result;
-  EXPECT_EQ(result.mismatchCount, 0u);
+  EXPECT_THAT(result, test::ExactVerifyResult());
 }
 
 // Scale analog of RotationDragProducesCorrectPixels: a scale drag also reuses
@@ -236,8 +247,7 @@ TEST_F(CompositorGoldenTest, ScaleDragProducesCorrectPixels) {
 
   DualPathVerifier verifier(compositor, renderer_);
   const auto result = verifier.renderAndVerify(viewport_);
-  EXPECT_TRUE(result.isExact()) << result;
-  EXPECT_EQ(result.mismatchCount, 0u);
+  EXPECT_THAT(result, test::ExactVerifyResult());
 }
 
 // Editor-reported QA regression (#3, "hiding a layer leaves a ghost"): toggling
@@ -269,8 +279,7 @@ TEST_F(CompositorGoldenTest, HidingElementClearsItsPixelsFromComposite) {
 
   DualPathVerifier verifier(compositor, renderer_);
   const auto result = verifier.renderAndVerify(viewport_);
-  EXPECT_TRUE(result.isExact()) << result;
-  EXPECT_EQ(result.mismatchCount, 0u);
+  EXPECT_THAT(result, test::ExactVerifyResult());
   EXPECT_THAT(getPixel(renderer_.takeSnapshot(), 35, 35), IsWhite())
       << "hidden rect must not leave a ghost";
 }
@@ -842,7 +851,7 @@ TEST_F(CompositorGoldenTest, FilterGroupAutoPromotesOnFirstRender) {
   // not the full canvas. Just check it's populated and ≤ canvas; the
   // exact dims depend on the gaussian blur expansion math.
   const auto& glowBitmap = compositor.layerBitmapOf(glowEntity);
-  EXPECT_FALSE(glowBitmap.empty());
+  EXPECT_THAT(glowBitmap, NonEmptyRendererBitmap());
   EXPECT_LE(glowBitmap.dimensions.x, 200);
   EXPECT_LE(glowBitmap.dimensions.y, 100);
 }
@@ -874,9 +883,7 @@ TEST_F(CompositorGoldenTest, FilteredLayerBoundsStopAtLayerSubtree) {
   compositor.renderFrame(largeViewport);
 
   const RendererBitmap& glowBitmap = compositor.layerBitmapOf(glowEntity);
-  ASSERT_FALSE(glowBitmap.empty());
-  EXPECT_EQ(glowBitmap.dimensions.x, 52);
-  EXPECT_EQ(glowBitmap.dimensions.y, 52);
+  ASSERT_THAT(glowBitmap, test::NonEmptyRendererBitmapWithDimensions(Vector2i(52, 52)));
 
   const Vector2d glowOffset = compositor.layerCanvasOffsetOf(glowEntity);
   EXPECT_DOUBLE_EQ(glowOffset.x, 74.0);
@@ -892,7 +899,7 @@ TEST_F(CompositorGoldenTest, RealSplashLightningBlurLayerUsesFilterBounds) {
   std::ostringstream splashBuf;
   splashBuf << splashStream.rdbuf();
   const std::string splashSource = splashBuf.str();
-  ASSERT_FALSE(splashSource.empty());
+  ASSERT_THAT(splashSource, Not(IsEmpty()));
 
   SVGDocument document = parseDocument(splashSource);
   auto glow = document.querySelector("#Lightning_glow_dark");
@@ -907,7 +914,7 @@ TEST_F(CompositorGoldenTest, RealSplashLightningBlurLayerUsesFilterBounds) {
   compositor.renderFrame(splashViewport);
 
   const RendererBitmap& glowBitmap = compositor.layerBitmapOf(glowEntity);
-  ASSERT_FALSE(glowBitmap.empty());
+  ASSERT_THAT(glowBitmap, NonEmptyRendererBitmap());
   EXPECT_LT(glowBitmap.dimensions.x * glowBitmap.dimensions.y, (892 * 512) / 10);
   EXPECT_LT(glowBitmap.dimensions.x, 160);
   EXPECT_LT(glowBitmap.dimensions.y, 160);
@@ -939,7 +946,7 @@ TEST_F(CompositorGoldenTest, EmptyStaticSegmentsArePrunedFromPublicTileSnapshots
   for (const CompositorTile& tile : uploadTiles) {
     if (tile.layerEntity == entt::null) {
       ++uploadSegmentCount;
-      EXPECT_NE(tile.bitmapDims, Vector2i(1, 1));
+      EXPECT_THAT(tile, test::UploadTileBitmapDimsAreNotPlaceholder());
     } else {
       ++uploadLayerCount;
     }
@@ -953,7 +960,7 @@ TEST_F(CompositorGoldenTest, EmptyStaticSegmentsArePrunedFromPublicTileSnapshots
   for (const auto& tile : inspectorTiles) {
     if (tile.kind == CompositorController::CompositeTileSnapshot::Kind::Segment) {
       ++inspectorSegmentCount;
-      EXPECT_NE(tile.bitmapDims, Vector2i(1, 1));
+      EXPECT_THAT(tile, test::BitmapDimsAreNotPlaceholder());
     } else if (tile.kind == CompositorController::CompositeTileSnapshot::Kind::Layer) {
       ++inspectorLayerCount;
     }
@@ -1393,7 +1400,7 @@ TEST_F(CompositorGoldenTest, SplitBitmapsStableAcrossTranslationOnlyDragFrames) 
       nonDragGenerations[tile.tileId] = tile.generation;
     }
   }
-  ASSERT_FALSE(nonDragGenerations.empty());
+  ASSERT_THAT(nonDragGenerations, Not(IsEmpty()));
 
   // Simulate 10 more drag frames with only translation changes.
   for (int i = 2; i <= 11; ++i) {
@@ -1406,11 +1413,7 @@ TEST_F(CompositorGoldenTest, SplitBitmapsStableAcrossTranslationOnlyDragFrames) 
     if (tile.isDragTarget) {
       continue;
     }
-    auto it = nonDragGenerations.find(tile.tileId);
-    ASSERT_NE(it, nonDragGenerations.end())
-        << "non-drag tile id " << tile.tileId
-        << " disappeared between drag frames — segment cache rebuilt mid-drag";
-    EXPECT_EQ(it->second, tile.generation)
+    EXPECT_THAT(tile, test::CompositorTileGenerationPreservedIn(nonDragGenerations))
         << "non-drag tile id " << tile.tileId
         << " re-rasterized between drag frames — cache invalidated incorrectly";
   }
@@ -1439,24 +1442,19 @@ TEST_F(CompositorGoldenTest, DragTargetOnlySnapshotKeepsNonDragTileMetadata) {
   const auto dragTargetOnlyTiles =
       compositor.snapshotTilesForUpload(CompositorTileBitmapPayload::DragTargetOnly);
 
-  ASSERT_EQ(dragTargetOnlyTiles.size(), fullTiles.size());
+  ASSERT_THAT(dragTargetOnlyTiles, SizeIs(fullTiles.size()));
 
   bool sawDragTargetBitmap = false;
   bool sawNonDragMetadataOnlyTile = false;
   for (size_t i = 0; i < fullTiles.size(); ++i) {
     const CompositorTile& full = fullTiles[i];
     const CompositorTile& partial = dragTargetOnlyTiles[i];
-    EXPECT_EQ(partial.tileId, full.tileId);
-    EXPECT_EQ(partial.generation, full.generation);
-    EXPECT_EQ(partial.bitmapDims, full.bitmapDims);
-    EXPECT_EQ(partial.canvasOffsetPx, full.canvasOffsetPx);
-    EXPECT_EQ(partial.isDragTarget, full.isDragTarget);
     if (partial.isDragTarget) {
       sawDragTargetBitmap = true;
-      EXPECT_FALSE(partial.bitmap.empty());
+      EXPECT_THAT(partial, test::CompositorTileMetadataMatches(full, NonEmptyRendererBitmap()));
     } else {
       sawNonDragMetadataOnlyTile = true;
-      EXPECT_TRUE(partial.bitmap.empty())
+      EXPECT_THAT(partial, test::CompositorTileMetadataMatches(full, EmptyRendererBitmap()))
           << "non-drag tile " << partial.tileId
           << " should keep metadata without forcing a pixel payload";
       EXPECT_GT(partial.bitmapDims.x, 0);
@@ -1464,8 +1462,8 @@ TEST_F(CompositorGoldenTest, DragTargetOnlySnapshotKeepsNonDragTileMetadata) {
     }
   }
 
-  EXPECT_TRUE(sawDragTargetBitmap);
-  EXPECT_TRUE(sawNonDragMetadataOnlyTile);
+  EXPECT_THAT(sawDragTargetBitmap, testing::IsTrue());
+  EXPECT_THAT(sawNonDragMetadataOnlyTile, testing::IsTrue());
 }
 
 TEST_F(CompositorGoldenTest, SelectionToActiveDragDoesNotAdvanceUnchangedTileGenerations) {
@@ -1496,14 +1494,15 @@ TEST_F(CompositorGoldenTest, SelectionToActiveDragDoesNotAdvanceUnchangedTileGen
   std::unordered_map<uint64_t, uint64_t> preDragRetainedGenerations;
   std::unordered_set<uint64_t> preDragImmediateTileIds;
   for (const CompositorTile& tile : preDragTiles) {
-    ASSERT_FALSE(tile.bitmap.empty()) << "prewarmed tile " << tile.tileId << " has no pixels";
+    ASSERT_THAT(tile.bitmap, NonEmptyRendererBitmap())
+        << "prewarmed tile " << tile.tileId << " has no pixels";
     if (tile.immediate) {
       preDragImmediateTileIds.insert(tile.tileId);
       continue;
     }
     preDragRetainedGenerations[tile.tileId] = tile.generation;
   }
-  ASSERT_FALSE(preDragRetainedGenerations.empty());
+  ASSERT_THAT(preDragRetainedGenerations, Not(IsEmpty()));
 
   // Starting an active drag on an already-elevated target changes only presentation
   // geometry: the target's cached pixels are reused through canvasFromBitmap, and unrelated
@@ -1513,32 +1512,32 @@ TEST_F(CompositorGoldenTest, SelectionToActiveDragDoesNotAdvanceUnchangedTileGen
   compositor.renderFrame(viewport_);
 
   const auto activeDragTiles = compositor.snapshotTilesForUpload();
-  ASSERT_EQ(activeDragTiles.size(), preDragTiles.size());
+  ASSERT_THAT(activeDragTiles, SizeIs(preDragTiles.size()));
 
   bool sawTargetLayer = false;
   for (const CompositorTile& tile : activeDragTiles) {
     if (tile.layerEntity == targetEntity) {
       sawTargetLayer = true;
-      EXPECT_TRUE(tile.isDragTarget);
+      EXPECT_THAT(tile.isDragTarget, testing::IsTrue());
     }
     if (tile.immediate) {
       continue;
     }
     const auto it = preDragRetainedGenerations.find(tile.tileId);
     if (it == preDragRetainedGenerations.end()) {
-      EXPECT_TRUE(preDragImmediateTileIds.contains(tile.tileId))
+      EXPECT_THAT(preDragImmediateTileIds, Contains(tile.tileId))
           << "new retained tile id appeared on drag start: " << tile.tileId;
       continue;
     }
-    EXPECT_EQ(tile.generation, it->second)
+    EXPECT_THAT(tile, test::CompositorTileGenerationPreservedIn(preDragRetainedGenerations))
         << "tile " << tile.tileId
         << " advanced generation even though drag start changed only presentation geometry";
     if (tile.layerEntity == targetEntity) {
       sawTargetLayer = true;
-      EXPECT_TRUE(tile.isDragTarget);
+      EXPECT_THAT(tile.isDragTarget, testing::IsTrue());
     }
   }
-  EXPECT_TRUE(sawTargetLayer);
+  EXPECT_THAT(sawTargetLayer, testing::IsTrue());
 }
 
 // A drag-release `SetTransformCommand` mutation must NOT trigger a full
@@ -1846,7 +1845,7 @@ TEST_F(CompositorGoldenTest, NonPromotedMutationInvalidatesOnlyContainingSegment
   // "did this slot re-raster?" that doesn't depend on whether
   // `backgroundBitmap_` was recomposed (which always reallocates).
   const auto tilesBefore = compositor.snapshotTilesForUpload();
-  ASSERT_EQ(tilesBefore.size(), 3u)
+  ASSERT_THAT(tilesBefore, SizeIs(3u))
       << "expected 2 segments (before/after the promoted layer) + 1 layer tile";
   std::uint64_t segment0GenBefore = 0;
   std::uint64_t segment1GenBefore = 0;
@@ -1970,7 +1969,7 @@ TEST_F(CompositorGoldenTest, SplitBitmapsInvalidateOnViewportResize) {
       generationsAtSmall[tile.tileId] = tile.generation;
     }
   }
-  ASSERT_FALSE(generationsAtSmall.empty());
+  ASSERT_THAT(generationsAtSmall, Not(IsEmpty()));
 
   // Simulate a zoom-in: the editor's RenderCoordinator calls setCanvasSize
   // before requestRender when the viewport's desiredCanvasSize changes, so
@@ -2053,9 +2052,8 @@ TEST_F(CompositorGoldenTest, TightBoundedSegmentsProducePixelIdentityWithMultipl
   // transform is identity, so the full-render reference and the
   // composited output are supposed to be byte-for-byte equal.
   const auto result = verifier.renderAndVerify(viewport);
-  EXPECT_TRUE(result.isExact()) << "multi-segment scene with tight-bounded segments: " << result;
-  EXPECT_EQ(result.mismatchCount, 0u);
-  EXPECT_EQ(result.maxChannelDiff, 0);
+  EXPECT_THAT(result, test::ExactVerifyResult())
+      << "multi-segment scene with tight-bounded segments";
 }
 
 // Stronger variant: explicit drag-target promotion on top of the
@@ -2105,9 +2103,7 @@ TEST_F(CompositorGoldenTest, TightBoundedSegmentsSurviveExplicitDragTargetPromot
   // also identity — composited and reference paths render the same
   // scene, so they must produce pixel-identical output.
   const auto result = verifier.renderAndVerify(viewport);
-  EXPECT_TRUE(result.isExact()) << "explicit drag promote with tight segments: " << result;
-  EXPECT_EQ(result.mismatchCount, 0u);
-  EXPECT_EQ(result.maxChannelDiff, 0);
+  EXPECT_THAT(result, test::ExactVerifyResult()) << "explicit drag promote with tight segments";
 }
 
 // Drives the ACTUAL `donner_splash.svg` through the tight-bound
@@ -2131,7 +2127,7 @@ TEST_F(CompositorGoldenTest, TightBoundedSegmentsPixelIdentityOnRealSplashWithDr
   std::ostringstream splashBuf;
   splashBuf << splashStream.rdbuf();
   const std::string splashSource = splashBuf.str();
-  ASSERT_FALSE(splashSource.empty());
+  ASSERT_THAT(splashSource, Not(IsEmpty()));
 
   SVGDocument document = parseDocument(splashSource);
 
@@ -2181,10 +2177,9 @@ TEST_F(CompositorGoldenTest, TightBoundedSegmentsPixelIdentityOnRealSplashWithDr
   // leaking through where content should be). Tolerance 5 catches
   // the shift/crop class of regression without flaking on the
   // premul round-trip drift.
-  EXPECT_TRUE(result.isWithinTolerance(5))
-      << "real-splash tight-bounds pixel identity under drag failed. Mismatch count="
-      << result.mismatchCount << " max channel diff=" << int(result.maxChannelDiff)
-      << ". If non-zero, tight-bound bounds are cropping or shifting "
+  EXPECT_THAT(result, test::VerifyResultWithinTolerance(5))
+      << "real-splash tight-bounds pixel identity under drag failed. If non-zero, tight-bound "
+         "bounds are cropping or shifting "
          "content during the drag composite. Likely candidates: "
          "(a) bounds computed in doc space without applying canvasFromDoc, "
          "(b) bounds applied in canvas space but offset preserved in doc units, "
@@ -2210,7 +2205,7 @@ TEST_F(CompositorGoldenTest, TightBoundedSegmentsPixelIdentityOnRealSplash) {
   std::ostringstream splashBuf;
   splashBuf << splashStream.rdbuf();
   const std::string splashSource = splashBuf.str();
-  ASSERT_FALSE(splashSource.empty());
+  ASSERT_THAT(splashSource, Not(IsEmpty()));
 
   SVGDocument document = parseDocument(splashSource);
 
@@ -3070,11 +3065,11 @@ TEST_F(CompositorGoldenTest, TwoPhaseDragOfPlainGroupMovesChildren) {
   const Pixel originalPos = getPixel(composited, 30, 50);
   const Pixel newPos = getPixel(composited, 70, 50);
 
-  EXPECT_FALSE(originalPos.r > 200 && originalPos.g > 150 && originalPos.b < 100)
+  EXPECT_THAT(originalPos, Not(IsWarmYellow()))
       << "rect is still at original position (30, 50). got: " << originalPos
       << ". The two-phase Selection→ActiveDrag drag left the rect where it was before drag — "
          "DOM transform change didn't move the promoted layer's content.";
-  EXPECT_TRUE(newPos.r > 200 && newPos.g > 150 && newPos.b < 100)
+  EXPECT_THAT(newPos, IsWarmYellow())
       << "rect didn't move to new position (70, 50). got: " << newPos;
 }
 
@@ -3126,23 +3121,9 @@ TEST_F(CompositorGoldenTest, SetTightBoundedSegmentsEnabledTogglesAtRuntime) {
   compositorRef.renderFrame(viewport_);
   const RendererBitmap reference = renderer_.takeSnapshot();
 
-  ASSERT_EQ(afterFlip.dimensions, reference.dimensions);
-  ASSERT_EQ(afterFlip.pixels.size(), reference.pixels.size());
-  int mismatchCount = 0;
-  int maxDiff = 0;
-  for (size_t i = 0; i < afterFlip.pixels.size(); ++i) {
-    const int diff =
-        std::abs(static_cast<int>(afterFlip.pixels[i]) - static_cast<int>(reference.pixels[i]));
-    if (diff > 0) {
-      ++mismatchCount;
-      maxDiff = std::max(maxDiff, diff);
-    }
-  }
-  EXPECT_EQ(mismatchCount, 0)
+  EXPECT_THAT(afterFlip, test::RendererBitmapPixelsEqualTo(reference))
       << "runtime toggle off did not converge to same pixels as construct-time off. "
-         "mismatchCount="
-      << mismatchCount << " maxDiff=" << maxDiff
-      << ". If non-zero, `setTightBoundedSegmentsEnabled(false)` is not fully "
+         "If non-zero, `setTightBoundedSegmentsEnabled(false)` is not fully "
          "invalidating prior tight-bound caches — likely a missing "
          "`markAllSegmentsDirty` call in the setter.";
 }
@@ -3531,8 +3512,7 @@ TEST_F(CompositorGoldenTest, ClippedGroupWithOpacityChildRendersCorrectly) {
   // Pixel identity with the full-render path. If the child were auto-promoted
   // despite the ancestor clip, the composited path would leak rect content
   // past x=100 and this assertion would catch it.
-  EXPECT_TRUE(result.isExact()) << result;
-  EXPECT_EQ(result.mismatchCount, 0u);
+  EXPECT_THAT(result, test::ExactVerifyResult());
 }
 
 // Splash-shape document, real Skia-backed renderer, full-size 892×512
@@ -3782,7 +3762,7 @@ TEST_F(CompositorGoldenTest, RealSplashDragLatencyOnTinySkia) {
   std::ostringstream splashBuf;
   splashBuf << splashStream.rdbuf();
   const std::string splashSource = splashBuf.str();
-  ASSERT_FALSE(splashSource.empty()) << "donner_splash.svg is empty";
+  ASSERT_THAT(splashSource, Not(IsEmpty())) << "donner_splash.svg is empty";
 
   SVGDocument document = parseDocument(splashSource);
 
@@ -3874,7 +3854,7 @@ TEST_F(CompositorGoldenTest, RealSplashBlueCenterBurstEllipseDragLatency) {
   std::ostringstream splashBuf;
   splashBuf << splashStream.rdbuf();
   const std::string splashSource = splashBuf.str();
-  ASSERT_FALSE(splashSource.empty()) << "donner_splash.svg is empty";
+  ASSERT_THAT(splashSource, Not(IsEmpty())) << "donner_splash.svg is empty";
 
   SVGDocument document = parseDocument(splashSource);
   document.setCanvasSize(1784, 1024);
@@ -4182,7 +4162,7 @@ TEST_F(CompositorGoldenTest, BuildStructuralEntityRemapIdenticalTrees) {
   SVGDocument docB = parseDocument(kSource);
 
   const auto remap = BuildStructuralEntityRemap(docA, docB);
-  EXPECT_FALSE(remap.empty())
+  EXPECT_THAT(remap, Not(IsEmpty()))
       << "BuildStructuralEntityRemap returned empty for byte-identical documents";
 
   // Same-doc trivial lookup: every element should have a remap entry.
@@ -4212,7 +4192,7 @@ TEST_F(CompositorGoldenTest, BuildStructuralEntityRemapMismatchReturnsEmpty) {
   )svg");
 
   const auto remap = BuildStructuralEntityRemap(docA, docB);
-  EXPECT_TRUE(remap.empty()) << "remap must be empty when child counts differ";
+  EXPECT_THAT(remap, IsEmpty()) << "remap must be empty when child counts differ";
 }
 
 // Mismatched `id` → empty remap.
@@ -4229,7 +4209,7 @@ TEST_F(CompositorGoldenTest, BuildStructuralEntityRemapIdChangeReturnsEmpty) {
   )svg");
 
   const auto remap = BuildStructuralEntityRemap(docA, docB);
-  EXPECT_TRUE(remap.empty()) << "id rename must break structural equivalence";
+  EXPECT_THAT(remap, IsEmpty()) << "id rename must break structural equivalence";
 }
 
 // Transform-attribute-only change → remap IS valid. This mirrors the
@@ -4248,7 +4228,7 @@ TEST_F(CompositorGoldenTest, BuildStructuralEntityRemapIgnoresAttributeValueChan
   )svg");
 
   const auto remap = BuildStructuralEntityRemap(docA, docB);
-  EXPECT_FALSE(remap.empty())
+  EXPECT_THAT(remap, Not(IsEmpty()))
       << "attribute-value-only change must leave the structural remap intact";
   auto dragA = docA.querySelector("#drag");
   auto dragB = docB.querySelector("#drag");

--- a/donner/svg/compositor/CompositorHint_tests.cc
+++ b/donner/svg/compositor/CompositorHint_tests.cc
@@ -7,21 +7,19 @@
 
 #include "donner/base/EcsRegistry.h"
 #include "donner/svg/compositor/CompositorHintComponent.h"
+#include "donner/svg/compositor/CompositorTestMatchers.h"
 #include "donner/svg/compositor/ScopedCompositorHint.h"
 
 namespace donner::svg::compositor {
 
 namespace {
 
+using test::HintEntryIs;
+
 class CompositorHintTest : public ::testing::Test {
 protected:
   Registry registry_;
 };
-
-auto HintEntryIs(HintSource source, uint16_t weight) {
-  return testing::AllOf(testing::Field("source", &HintEntry::source, source),
-                        testing::Field("weight", &HintEntry::weight, weight));
-}
 
 }  // namespace
 

--- a/donner/svg/compositor/CompositorTestMatchers.h
+++ b/donner/svg/compositor/CompositorTestMatchers.h
@@ -1,0 +1,188 @@
+#pragma once
+/// @file
+
+#include <gmock/gmock.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+
+#include "donner/base/EcsRegistry.h"
+#include "donner/base/Vector2.h"
+#include "donner/svg/compositor/CompositorController.h"
+#include "donner/svg/compositor/CompositorHintComponent.h"
+#include "donner/svg/compositor/DualPathVerifier.h"
+#include "donner/svg/renderer/RendererInterface.h"
+
+namespace donner::svg::compositor::test {
+
+/// Matches a compositor hint entry by source and weight.
+inline auto HintEntryIs(HintSource source, uint16_t weight) {
+  return ::testing::AllOf(::testing::Field("source", &HintEntry::source, source),
+                          ::testing::Field("weight", &HintEntry::weight, weight));
+}
+
+/// Matches an exact dual-path render result and prints all diff counters on failure.
+MATCHER(ExactVerifyResult, "an exact dual-path verification result") {
+  if (arg.isExact() && arg.mismatchCount == 0u && arg.maxChannelDiff == 0) {
+    return true;
+  }
+
+  *result_listener << "mismatchCount=" << arg.mismatchCount
+                   << ", maxChannelDiff=" << static_cast<int>(arg.maxChannelDiff)
+                   << ", totalPixels=" << arg.totalPixels
+                   << ", dimensionsMatch=" << arg.dimensionsMatch;
+  return false;
+}
+
+/// Matches a dual-path render result whose max channel diff is within @p tolerance.
+MATCHER_P(VerifyResultWithinTolerance, tolerance,
+          "a dual-path verification result within channel tolerance") {
+  if (arg.isWithinTolerance(tolerance)) {
+    return true;
+  }
+
+  *result_listener << "tolerance=" << static_cast<int>(tolerance)
+                   << ", mismatchCount=" << arg.mismatchCount
+                   << ", maxChannelDiff=" << static_cast<int>(arg.maxChannelDiff)
+                   << ", totalPixels=" << arg.totalPixels
+                   << ", dimensionsMatch=" << arg.dimensionsMatch;
+  return false;
+}
+
+/// Matches fallback reasons containing @p reason.
+MATCHER_P(FallbackReasonsInclude, reason, "fallback reasons include the expected flag") {
+  if ((arg & reason) != FallbackReason::None) {
+    return true;
+  }
+
+  *result_listener << "fallbackReasons=" << FallbackReasonToString(arg)
+                   << ", expectedFlag=" << FallbackReasonToString(reason);
+  return false;
+}
+
+/// Matches a non-empty renderer bitmap with the expected dimensions.
+MATCHER_P(NonEmptyRendererBitmapWithDimensions, expectedDimensions,
+          "a non-empty renderer bitmap with expected dimensions") {
+  if (!arg.empty() && arg.dimensions == expectedDimensions) {
+    return true;
+  }
+
+  *result_listener << "dimensions=" << ::testing::PrintToString(arg.dimensions)
+                   << ", expectedDimensions=" << ::testing::PrintToString(expectedDimensions)
+                   << ", rowBytes=" << arg.rowBytes << ", pixels=" << arg.pixels.size()
+                   << ", alphaType=" << static_cast<int>(arg.alphaType);
+  return false;
+}
+
+/// Matches a renderer bitmap whose pixel array is byte-identical to @p expected.
+MATCHER_P(RendererBitmapPixelsEqualTo, expected,
+          "a renderer bitmap with byte-identical dimensions and pixels") {
+  if (arg.dimensions != expected.dimensions) {
+    *result_listener << "dimensions=" << ::testing::PrintToString(arg.dimensions)
+                     << ", expectedDimensions=" << ::testing::PrintToString(expected.dimensions);
+    return false;
+  }
+
+  if (arg.pixels.size() != expected.pixels.size()) {
+    *result_listener << "pixels=" << arg.pixels.size()
+                     << ", expectedPixels=" << expected.pixels.size();
+    return false;
+  }
+
+  size_t mismatchCount = 0;
+  size_t firstMismatch = 0;
+  int maxDiff = 0;
+  for (size_t i = 0; i < arg.pixels.size(); ++i) {
+    const int actual = static_cast<int>(arg.pixels[i]);
+    const int expectedValue = static_cast<int>(expected.pixels[i]);
+    const int diff = std::abs(actual - expectedValue);
+    if (diff == 0) {
+      continue;
+    }
+
+    if (mismatchCount == 0) {
+      firstMismatch = i;
+    }
+    ++mismatchCount;
+    maxDiff = std::max(maxDiff, diff);
+  }
+
+  if (mismatchCount == 0) {
+    return true;
+  }
+
+  *result_listener << "mismatchCount=" << mismatchCount << ", firstMismatch=" << firstMismatch
+                   << ", actual=" << static_cast<int>(arg.pixels[firstMismatch])
+                   << ", expected=" << static_cast<int>(expected.pixels[firstMismatch])
+                   << ", maxDiff=" << maxDiff
+                   << ", dimensions=" << ::testing::PrintToString(arg.dimensions)
+                   << ", rowBytes=" << arg.rowBytes << ", expectedRowBytes=" << expected.rowBytes;
+  return false;
+}
+
+/// Matches an object with `bitmapDims` not equal to the old 1x1 placeholder sentinel.
+MATCHER(BitmapDimsAreNotPlaceholder, "bitmap dimensions are not the 1x1 placeholder") {
+  if (arg.bitmapDims != Vector2i(1, 1)) {
+    return true;
+  }
+
+  *result_listener << "bitmapDims=" << ::testing::PrintToString(arg.bitmapDims);
+  return false;
+}
+
+/// Matches an upload tile whose bitmap dimensions are not the old 1x1 placeholder sentinel.
+MATCHER(UploadTileBitmapDimsAreNotPlaceholder,
+        "an upload tile whose bitmap dimensions are not the 1x1 placeholder") {
+  if (arg.bitmapDims != Vector2i(1, 1)) {
+    return true;
+  }
+
+  *result_listener << "tileId=" << arg.tileId << ", generation=" << arg.generation
+                   << ", layerEntity=" << ::testing::PrintToString(arg.layerEntity)
+                   << ", bitmapPixels=" << arg.bitmap.pixels.size()
+                   << ", textureSnapshot=" << (arg.textureSnapshot != nullptr);
+  return false;
+}
+
+/// Matches a tile whose generation is preserved according to a tileId->generation map.
+MATCHER_P(CompositorTileGenerationPreservedIn, generationsByTileId,
+          "a compositor tile whose generation is preserved in the expected map") {
+  const auto it = generationsByTileId.find(arg.tileId);
+  if (it == generationsByTileId.end()) {
+    *result_listener << "tileId=" << arg.tileId << " is absent; knownTileIds=";
+    bool first = true;
+    for (const auto& [tileId, generation] : generationsByTileId) {
+      if (!first) {
+        *result_listener << ",";
+      }
+      *result_listener << tileId << "->" << generation;
+      first = false;
+    }
+    return false;
+  }
+
+  if (arg.generation == it->second) {
+    return true;
+  }
+
+  *result_listener << "tileId=" << arg.tileId << ", generation=" << arg.generation
+                   << ", expectedGeneration=" << it->second << ", isDragTarget=" << arg.isDragTarget
+                   << ", layerEntity=" << ::testing::PrintToString(arg.layerEntity);
+  return false;
+}
+
+/// Matches tile metadata against @p expected while delegating bitmap payload checks.
+template <typename BitmapMatcher>
+auto CompositorTileMetadataMatches(const CompositorTile& expected, BitmapMatcher bitmapMatcher) {
+  return ::testing::AllOf(
+      ::testing::Field("tileId", &CompositorTile::tileId, expected.tileId),
+      ::testing::Field("generation", &CompositorTile::generation, expected.generation),
+      ::testing::Field("bitmapDims", &CompositorTile::bitmapDims, expected.bitmapDims),
+      ::testing::Field("canvasOffsetPx", &CompositorTile::canvasOffsetPx, expected.canvasOffsetPx),
+      ::testing::Field("isDragTarget", &CompositorTile::isDragTarget, expected.isDragTarget),
+      ::testing::Field("bitmap", &CompositorTile::bitmap, bitmapMatcher));
+}
+
+}  // namespace donner::svg::compositor::test

--- a/donner/svg/compositor/LayerResolver_tests.cc
+++ b/donner/svg/compositor/LayerResolver_tests.cc
@@ -1,5 +1,6 @@
 #include "donner/svg/compositor/LayerResolver.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -31,6 +32,15 @@ protected:
 
   bool hasAssignment(Entity entity) const {
     return registry_.all_of<ComputedLayerAssignmentComponent>(entity);
+  }
+
+  std::vector<uint32_t> layerIdsOf(const std::vector<Entity>& entities) const {
+    std::vector<uint32_t> layerIds;
+    layerIds.reserve(entities.size());
+    for (Entity entity : entities) {
+      layerIds.push_back(layerIdOf(entity));
+    }
+    return layerIds;
   }
 };
 
@@ -120,10 +130,8 @@ TEST_F(LayerResolverTest, TieInWeightsBrokenByLowerEntityId) {
   std::sort(sorted.begin(), sorted.end(), [](Entity a, Entity b) {
     return static_cast<std::uint32_t>(a) < static_cast<std::uint32_t>(b);
   });
-  for (size_t i = 0; i < sorted.size(); ++i) {
-    EXPECT_EQ(layerIdOf(sorted[i]), static_cast<uint32_t>(i + 1u))
-        << "tie-break must be by ascending entity id; mismatch at index " << i;
-  }
+  EXPECT_THAT(layerIdsOf(sorted), testing::ElementsAre(1u, 2u, 3u, 4u))
+      << "tie-break must be by ascending entity id";
 }
 
 TEST_F(LayerResolverTest, MandatoryAlwaysWinsUnderBudgetPressure) {
@@ -148,8 +156,7 @@ TEST_F(LayerResolverTest, MandatoryAlwaysWinsUnderBudgetPressure) {
 
   // Budget is 2. First two mandatory get layers (by entity id). Third mandatory
   // is evicted and logs; all explicit candidates are evicted.
-  EXPECT_EQ(layerIdOf(mandatoryEntities[0]), 1u);
-  EXPECT_EQ(layerIdOf(mandatoryEntities[1]), 2u);
+  EXPECT_THAT(layerIdsOf(mandatoryEntities), testing::ElementsAre(1u, 2u, 0u));
   EXPECT_FALSE(hasAssignment(mandatoryEntities[2]))
       << "over-budget mandatory should have no assignment";
   for (Entity e : explicitEntities) {
@@ -186,10 +193,8 @@ TEST_F(LayerResolverTest, DeterministicAcrossRepeatedCalls) {
 
   for (int run = 0; run < 10; ++run) {
     resolver_.resolve(registry_, kDefaultBudget);
-    for (size_t i = 0; i < entities.size(); ++i) {
-      EXPECT_EQ(layerIdOf(entities[i]), firstAssignment[i])
-          << "assignment diverged on run " << run << " at index " << i;
-    }
+    EXPECT_THAT(layerIdsOf(entities), testing::ElementsAreArray(firstAssignment))
+        << "assignment diverged on run " << run;
   }
 }
 

--- a/donner/svg/compositor/MandatoryHintDetector_tests.cc
+++ b/donner/svg/compositor/MandatoryHintDetector_tests.cc
@@ -11,17 +11,14 @@
 #include "donner/base/xml/components/TreeComponent.h"
 #include "donner/svg/components/RenderingInstanceComponent.h"
 #include "donner/svg/compositor/CompositorHintComponent.h"
+#include "donner/svg/compositor/CompositorTestMatchers.h"
 
 namespace donner::svg::compositor {
 
 namespace {
 
 using components::RenderingInstanceComponent;
-
-auto HintEntryIs(HintSource source, uint16_t weight) {
-  return testing::AllOf(testing::Field("source", &HintEntry::source, source),
-                        testing::Field("weight", &HintEntry::weight, weight));
-}
+using test::HintEntryIs;
 
 }  // namespace
 

--- a/donner/svg/renderer/geode/BUILD.bazel
+++ b/donner/svg/renderer/geode/BUILD.bazel
@@ -69,11 +69,24 @@ donner_cc_library(
     visibility = ["//donner/svg/renderer:__subpackages__"],
 )
 
+donner_cc_library(
+    name = "geode_test_matchers",
+    testonly = 1,
+    hdrs = [
+        "tests/GeodeTestMatchers.h",
+    ],
+    deps = [
+        ":geode_path_encoder",
+        "@com_google_gtest//:gtest",
+    ],
+)
+
 donner_cc_test(
     name = "geode_path_encoder_tests",
     srcs = ["tests/GeodePathEncoder_tests.cc"],
     deps = [
         ":geode_path_encoder",
+        ":geode_test_matchers",
         "//donner/base",
         "//donner/base:gtest_timeout_main",
     ],
@@ -98,6 +111,7 @@ donner_cc_test(
     srcs = ["tests/GeodeWgpuUtil_tests.cc"],
     target_compatible_with = _GEODE_ONLY,
     deps = [
+        ":geode_test_matchers",
         ":geode_wgpu_util",
         "//donner/base:gtest_timeout_main",
     ],
@@ -171,6 +185,7 @@ donner_cc_test(
     target_compatible_with = _GEODE_ONLY,
     deps = [
         ":geode_device",
+        ":geode_test_matchers",
         ":geode_wgpu_util",
         "//donner/base",
         "//donner/base:gtest_timeout_main",
@@ -467,6 +482,7 @@ donner_cc_test(
     deps = [
         ":geode_device",
         ":geode_shaders",
+        ":geode_test_matchers",
         "//donner/base:gtest_timeout_main",
     ],
 )
@@ -523,6 +539,7 @@ donner_cc_test(
     deps = [
         ":geo_encoder",
         ":geode_device",
+        ":geode_test_matchers",
         ":geode_wgpu_util",
         "//donner/base",
         "//donner/base:gtest_timeout_main",
@@ -553,6 +570,7 @@ donner_cc_test(
         ":geode_counters",
         ":geode_device",
         "//donner/base",
+        "//donner/base:base_test_utils",
         "//donner/base:gtest_timeout_main",
         "//donner/svg",
         "//donner/svg/parser",
@@ -574,11 +592,13 @@ donner_cc_test(
     target_compatible_with = _GEODE_ONLY,
     deps = [
         ":geode_device",
+        ":geode_test_matchers",
         ":geode_wgpu_util",
         "//donner/base",
         "//donner/base:gtest_timeout_main",
         "//donner/svg/renderer:renderer_geode",
         "//donner/svg/renderer:renderer_interface",
+        "//donner/svg/renderer/tests:renderer_test_matchers",
         "//donner/svg/renderer/tests:rgba_test_matchers",
     ],
 )

--- a/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
@@ -15,6 +15,7 @@
 #include "donner/svg/renderer/geode/GeodeImagePipeline.h"
 #include "donner/svg/renderer/geode/GeodePipeline.h"
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
+#include "donner/svg/renderer/geode/tests/GeodeTestMatchers.h"
 #include "donner/svg/renderer/tests/RgbaTestMatchers.h"
 #include "donner/svg/resources/ImageResource.h"
 
@@ -30,6 +31,9 @@ using svg::test::FormatRgba;
 using svg::test::Near;
 using svg::test::Rgba;
 using svg::test::RgbaEq;
+using test::TruthyWgpuHandle;
+using ::testing::IsTrue;
+using ::testing::NotNull;
 
 /// Test fixture: shares a process-wide device and creates per-test render
 /// targets + readback buffer.
@@ -48,7 +52,7 @@ protected:
 
   void SetUp() override {
     device_ = sharedDevice();
-    ASSERT_NE(device_, nullptr);
+    ASSERT_THAT(device_, NotNull());
 
     // Build the fixture pipelines with the device's *actual* sample
     // count, not the default. On Intel + Vulkan the device falls back
@@ -72,7 +76,7 @@ protected:
     td.sampleCount = 1;
     td.dimension = wgpu::TextureDimension::_2D;
     target_ = device_->device().createTexture(td);
-    ASSERT_TRUE(static_cast<bool>(target_));
+    ASSERT_THAT(target_, TruthyWgpuHandle());
 
     // MSAA companion required by the GeoEncoder constructor whenever
     // the device uses multisampled rendering. `sampleCount == 1` means
@@ -89,7 +93,7 @@ protected:
       msaaDesc.sampleCount = sampleCount;
       msaaDesc.dimension = wgpu::TextureDimension::_2D;
       msaaTarget_ = device_->device().createTexture(msaaDesc);
-      ASSERT_TRUE(static_cast<bool>(msaaTarget_));
+      ASSERT_THAT(msaaTarget_, TruthyWgpuHandle());
     }
 
     wgpu::BufferDescriptor bd = {};
@@ -97,7 +101,7 @@ protected:
     bd.size = kBytesPerRow * kSize;
     bd.usage = wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::MapRead;
     readback_ = device_->device().createBuffer(bd);
-    ASSERT_TRUE(static_cast<bool>(readback_));
+    ASSERT_THAT(readback_, TruthyWgpuHandle());
   }
 
   /// Read back the rendered texture into a flat RGBA byte array (row-major,
@@ -142,7 +146,7 @@ protected:
     while (!mapState.done) {
       device_->device().poll(true, nullptr);
     }
-    EXPECT_TRUE(mapState.ok) << "buffer map failed";
+    EXPECT_THAT(mapState.ok, IsTrue()) << "buffer map failed";
 
     const uint8_t* mapped =
         static_cast<const uint8_t*>(readback_.getConstMappedRange(0, kBytesPerRow * kSize));
@@ -563,7 +567,7 @@ TEST_F(GeoEncoderTest, FillPathPatternSolidTile) {
   td.sampleCount = 1;
   td.dimension = wgpu::TextureDimension::_2D;
   wgpu::Texture tile = device_->device().createTexture(td);
-  ASSERT_TRUE(static_cast<bool>(tile));
+  ASSERT_THAT(tile, TruthyWgpuHandle());
 
   wgpu::TexelCopyTextureInfo dst = {};
   dst.texture = tile;

--- a/donner/svg/renderer/geode/tests/GeodeDevice_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeDevice_tests.cc
@@ -11,28 +11,32 @@
 #include "donner/svg/renderer/geode/GeodeImagePipeline.h"
 #include "donner/svg/renderer/geode/GeodePipeline.h"
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
+#include "donner/svg/renderer/geode/tests/GeodeTestMatchers.h"
 #include "donner/svg/renderer/tests/RgbaTestMatchers.h"
 
 namespace donner::geode {
 
 using svg::test::RgbaEq;
+using test::TruthyWgpuHandle;
+using ::testing::IsTrue;
+using ::testing::NotNull;
 
 /// Smoke test: can we instantiate a headless Dawn device at all?
 /// If this fails, the entire Geode backend is non-functional.
 TEST(GeodeDevice, CreateHeadlessSucceeds) {
   auto device = GeodeDevice::CreateHeadless();
-  ASSERT_NE(device, nullptr) << "Failed to create headless Dawn device. Check driver availability "
-                                "(Metal on macOS, Vulkan/SwiftShader on Linux).";
+  ASSERT_THAT(device, NotNull()) << "Failed to create headless Dawn device. Check driver "
+                                    "availability (Metal on macOS, Vulkan/SwiftShader on Linux).";
 
-  EXPECT_TRUE(static_cast<bool>(device->device()));
-  EXPECT_TRUE(static_cast<bool>(device->queue()));
-  EXPECT_TRUE(static_cast<bool>(device->adapter()));
+  EXPECT_THAT(device->device(), TruthyWgpuHandle());
+  EXPECT_THAT(device->queue(), TruthyWgpuHandle());
+  EXPECT_THAT(device->adapter(), TruthyWgpuHandle());
 }
 
 /// Can we allocate an offscreen render-target texture?
 TEST(GeodeDevice, CanCreateRenderTargetTexture) {
   auto device = GeodeDevice::CreateHeadless();
-  ASSERT_NE(device, nullptr);
+  ASSERT_THAT(device, NotNull());
 
   wgpu::TextureDescriptor desc = {};
   desc.label = wgpuLabel("TestRenderTarget");
@@ -44,7 +48,7 @@ TEST(GeodeDevice, CanCreateRenderTargetTexture) {
   desc.dimension = wgpu::TextureDimension::_2D;
 
   wgpu::Texture texture = device->device().createTexture(desc);
-  ASSERT_TRUE(static_cast<bool>(texture));
+  ASSERT_THAT(texture, TruthyWgpuHandle());
   EXPECT_EQ(texture.getWidth(), 64u);
   EXPECT_EQ(texture.getHeight(), 64u);
 }
@@ -52,7 +56,7 @@ TEST(GeodeDevice, CanCreateRenderTargetTexture) {
 /// Can we allocate a buffer for readback?
 TEST(GeodeDevice, CanCreateReadbackBuffer) {
   auto device = GeodeDevice::CreateHeadless();
-  ASSERT_NE(device, nullptr);
+  ASSERT_THAT(device, NotNull());
 
   wgpu::BufferDescriptor desc = {};
   desc.label = wgpuLabel("TestReadbackBuffer");
@@ -60,7 +64,7 @@ TEST(GeodeDevice, CanCreateReadbackBuffer) {
   desc.usage = wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::MapRead;
 
   wgpu::Buffer buffer = device->device().createBuffer(desc);
-  ASSERT_TRUE(static_cast<bool>(buffer));
+  ASSERT_THAT(buffer, TruthyWgpuHandle());
   EXPECT_EQ(buffer.getSize(), 1024u);
 }
 
@@ -68,7 +72,7 @@ TEST(GeodeDevice, CanCreateReadbackBuffer) {
 /// This proves that command submission and texture readback actually work.
 TEST(GeodeDevice, CanExecuteClearAndReadback) {
   auto geodeDevice = GeodeDevice::CreateHeadless();
-  ASSERT_NE(geodeDevice, nullptr);
+  ASSERT_THAT(geodeDevice, NotNull());
 
   const wgpu::Device& device = geodeDevice->device();
   const wgpu::Queue& queue = geodeDevice->queue();
@@ -84,7 +88,7 @@ TEST(GeodeDevice, CanExecuteClearAndReadback) {
   texDesc.sampleCount = 1;
   texDesc.dimension = wgpu::TextureDimension::_2D;
   wgpu::Texture target = device.createTexture(texDesc);
-  ASSERT_TRUE(static_cast<bool>(target));
+  ASSERT_THAT(target, TruthyWgpuHandle());
 
   // Create readback buffer. Bytes per row must be a multiple of 256 per WebGPU spec.
   constexpr uint32_t kBytesPerRow = 256;  // Padded from kSize*4=16.
@@ -152,10 +156,10 @@ TEST(GeodeDevice, CanExecuteClearAndReadback) {
   while (!mapState.done) {
     device.poll(true, nullptr);
   }
-  EXPECT_TRUE(mapState.ok) << "buffer map failed";
+  EXPECT_THAT(mapState.ok, IsTrue()) << "buffer map failed";
 
   const uint8_t* pixels = static_cast<const uint8_t*>(readback.getConstMappedRange(0, kBufferSize));
-  ASSERT_NE(pixels, nullptr);
+  ASSERT_THAT(pixels, NotNull());
 
   // First pixel should be red (255, 0, 0, 255).
   const std::array<uint8_t, 4> firstPixel = {pixels[0], pixels[1], pixels[2], pixels[3]};
@@ -169,7 +173,7 @@ TEST(GeodeDevice, CanExecuteClearAndReadback) {
 /// references them doesn't trigger a use-after-free.
 TEST(GeodeDevice, DeferredDestroyBufferSurvivesUntilDrain) {
   auto geodeDevice = GeodeDevice::CreateHeadless();
-  ASSERT_NE(geodeDevice, nullptr);
+  ASSERT_THAT(geodeDevice, NotNull());
 
   const wgpu::Device& device = geodeDevice->device();
   const wgpu::Queue& queue = geodeDevice->queue();
@@ -181,7 +185,7 @@ TEST(GeodeDevice, DeferredDestroyBufferSurvivesUntilDrain) {
   desc.size = kBufSize;
   desc.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
   wgpu::Buffer buffer = device.createBuffer(desc);
-  ASSERT_TRUE(static_cast<bool>(buffer));
+  ASSERT_THAT(buffer, TruthyWgpuHandle());
 
   // Write some data so the buffer is "in use".
   const uint32_t data[4] = {1, 2, 3, 4};
@@ -211,7 +215,7 @@ TEST(GeodeDevice, DeferredDestroyBufferSurvivesUntilDrain) {
 /// Deferred-destroy queue: textures survive until drain.
 TEST(GeodeDevice, DeferredDestroyTextureSurvivesUntilDrain) {
   auto geodeDevice = GeodeDevice::CreateHeadless();
-  ASSERT_NE(geodeDevice, nullptr);
+  ASSERT_THAT(geodeDevice, NotNull());
 
   const wgpu::Device& device = geodeDevice->device();
   const wgpu::Queue& queue = geodeDevice->queue();
@@ -225,7 +229,7 @@ TEST(GeodeDevice, DeferredDestroyTextureSurvivesUntilDrain) {
   desc.sampleCount = 1;
   desc.dimension = wgpu::TextureDimension::_2D;
   wgpu::Texture texture = device.createTexture(desc);
-  ASSERT_TRUE(static_cast<bool>(texture));
+  ASSERT_THAT(texture, TruthyWgpuHandle());
 
   // Use the texture as a render target, then defer destruction.
   wgpu::TextureView view = texture.createView();
@@ -264,7 +268,7 @@ TEST(GeodeDevice, DeferredDestroyTextureSurvivesUntilDrain) {
 /// reference identity is a cheap way to pin the sharing contract.
 TEST(GeodeDevice, SharedPipelinesReturnSameInstance) {
   auto device = GeodeDevice::CreateHeadless();
-  ASSERT_NE(device, nullptr);
+  ASSERT_THAT(device, NotNull());
 
   // Every accessor must return the same reference each time.
   EXPECT_EQ(&device->pipeline(), &device->pipeline());
@@ -285,7 +289,7 @@ TEST(GeodeDevice, SharedPipelinesReturnSameInstance) {
 /// test written against it can't lie to itself.
 TEST(GeodeDevice, LifetimeCountersReflectCountHelpers) {
   auto device = GeodeDevice::CreateHeadless();
-  ASSERT_NE(device, nullptr);
+  ASSERT_THAT(device, NotNull());
 
   const uint64_t beforeTex = device->lifetimeTextureCreates();
   const uint64_t beforeBuf = device->lifetimeBufferCreates();

--- a/donner/svg/renderer/geode/tests/GeodeEmbed_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeEmbed_tests.cc
@@ -13,6 +13,8 @@
 #include "donner/svg/renderer/RendererInterface.h"
 #include "donner/svg/renderer/geode/GeodeDevice.h"
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"  // IWYU pragma: keep — provides wgpuLabel
+#include "donner/svg/renderer/geode/tests/GeodeTestMatchers.h"
+#include "donner/svg/renderer/tests/RendererTestMatchers.h"
 #include "donner/svg/renderer/tests/RgbaTestMatchers.h"
 
 namespace donner::svg {
@@ -20,7 +22,10 @@ namespace {
 
 constexpr double kViewportSize = 32.0;
 
+using ::donner::geode::test::TruthyWgpuHandle;
 using test::IsTransparent;
+using test::NonEmptyRendererBitmap;
+using ::testing::NotNull;
 
 /// RGBA pixel at (x, y) in a tightly packed snapshot bitmap.
 std::array<uint8_t, 4> pixelAt(const RendererBitmap& bitmap, int x, int y) {
@@ -38,7 +43,7 @@ std::array<uint8_t, 4> pixelAt(const RendererBitmap& bitmap, int x, int y) {
 /// application.
 TEST(GeodeEmbed, CreateFromExternalSucceeds) {
   auto headless = geode::GeodeDevice::CreateHeadless();
-  ASSERT_NE(headless, nullptr);
+  ASSERT_THAT(headless, NotNull());
 
   geode::GeodeEmbedConfig config;
   config.device = headless->device();
@@ -47,9 +52,9 @@ TEST(GeodeEmbed, CreateFromExternalSucceeds) {
   config.textureFormat = wgpu::TextureFormat::RGBA8Unorm;
 
   auto embedded = geode::GeodeDevice::CreateFromExternal(config);
-  ASSERT_NE(embedded, nullptr);
-  EXPECT_TRUE(static_cast<bool>(embedded->device()));
-  EXPECT_TRUE(static_cast<bool>(embedded->queue()));
+  ASSERT_THAT(embedded, NotNull());
+  EXPECT_THAT(embedded->device(), TruthyWgpuHandle());
+  EXPECT_THAT(embedded->queue(), TruthyWgpuHandle());
   EXPECT_EQ(embedded->textureFormat(), wgpu::TextureFormat::RGBA8Unorm);
 }
 
@@ -109,7 +114,7 @@ TEST_F(GeodeEmbedTest, EmptyFrameIsTransparent) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
   EXPECT_EQ(snap.dimensions.x, static_cast<int>(kViewportSize));
   EXPECT_EQ(snap.dimensions.y, static_cast<int>(kViewportSize));
 
@@ -125,7 +130,7 @@ TEST_F(GeodeEmbedTest, EmptyFrameIsTransparent) {
 /// Because the "host" target has CopySrc usage, takeSnapshot() should work.
 TEST_F(GeodeEmbedTest, SetTargetTextureRendersIntoHostTexture) {
   auto device = sharedEmbedDevice();
-  ASSERT_NE(device, nullptr);
+  ASSERT_THAT(device, NotNull());
 
   // Create a host-owned target texture.
   constexpr uint32_t kSize = 32;
@@ -139,7 +144,7 @@ TEST_F(GeodeEmbedTest, SetTargetTextureRendersIntoHostTexture) {
   texDesc.sampleCount = 1;
   texDesc.dimension = wgpu::TextureDimension::_2D;
   wgpu::Texture hostTexture = device->device().createTexture(texDesc);
-  ASSERT_TRUE(static_cast<bool>(hostTexture));
+  ASSERT_THAT(hostTexture, TruthyWgpuHandle());
 
   auto renderer = createRenderer();
   renderer.setTargetTexture(hostTexture);
@@ -153,7 +158,7 @@ TEST_F(GeodeEmbedTest, SetTargetTextureRendersIntoHostTexture) {
   renderer.endFrame();
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
   EXPECT_EQ(snap.dimensions.x, static_cast<int>(kSize));
   EXPECT_EQ(snap.dimensions.y, static_cast<int>(kSize));
 
@@ -198,7 +203,7 @@ TEST_F(GeodeEmbedTest, ClearTargetTextureRevertsToInternal) {
   EXPECT_EQ(renderer.height(), 32);
 
   RendererBitmap snap = renderer.takeSnapshot();
-  ASSERT_FALSE(snap.empty());
+  ASSERT_THAT(snap, NonEmptyRendererBitmap());
   EXPECT_EQ(snap.dimensions.x, 32);
 }
 

--- a/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
@@ -1,19 +1,27 @@
 #include "donner/svg/renderer/geode/GeodePathEncoder.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "donner/base/FillRule.h"
 #include "donner/base/Path.h"
+#include "donner/svg/renderer/geode/tests/GeodeTestMatchers.h"
 
 namespace donner::geode {
+
+using test::EmptyEncodedPath;
+using test::HasBandGridsSizedToCounts;
+using test::HasBandVertexQuads;
+using test::NonEmptyEncodedPath;
+using ::testing::Eq;
+using ::testing::IsEmpty;
+using ::testing::Not;
+using ::testing::SizeIs;
 
 TEST(GeodePathEncoder, EmptyPath) {
   Path path;
   EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
-  EXPECT_TRUE(encoded.empty());
-  EXPECT_TRUE(encoded.curves.empty());
-  EXPECT_TRUE(encoded.bands.empty());
-  EXPECT_TRUE(encoded.vertices.empty());
+  EXPECT_THAT(encoded, EmptyEncodedPath());
 }
 
 TEST(GeodePathEncoder, SimpleTriangle) {
@@ -25,7 +33,7 @@ TEST(GeodePathEncoder, SimpleTriangle) {
                   .build();
 
   EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
-  EXPECT_FALSE(encoded.empty());
+  EXPECT_THAT(encoded, NonEmptyEncodedPath());
 
   // Should have curves for each edge (3 edges: bottom, right diagonal, left diagonal + close).
   EXPECT_GT(encoded.curves.size(), 0u);
@@ -34,7 +42,7 @@ TEST(GeodePathEncoder, SimpleTriangle) {
   EXPECT_GE(encoded.bands.size(), 1u);
 
   // Each band produces 6 vertices (2 triangles).
-  EXPECT_EQ(encoded.vertices.size(), encoded.bands.size() * 6);
+  EXPECT_THAT(encoded, HasBandVertexQuads());
 
   // Bounds should encompass the triangle.
   EXPECT_LE(encoded.pathBounds.topLeft.x, 0.0f);
@@ -48,10 +56,10 @@ TEST(GeodePathEncoder, SmallPathSingleBand) {
   Path path = PathBuilder().addRect(Box2d({0, 0}, {10, 10})).build();
 
   EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
-  EXPECT_FALSE(encoded.empty());
+  EXPECT_THAT(encoded, NonEmptyEncodedPath());
 
   // 10px height → single band.
-  EXPECT_EQ(encoded.bands.size(), 1u);
+  EXPECT_THAT(encoded.bands, SizeIs(1u));
 }
 
 TEST(GeodePathEncoder, LargePathMultipleBands) {
@@ -59,7 +67,7 @@ TEST(GeodePathEncoder, LargePathMultipleBands) {
   Path path = PathBuilder().addRect(Box2d({0, 0}, {100, 500})).build();
 
   EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
-  EXPECT_FALSE(encoded.empty());
+  EXPECT_THAT(encoded, NonEmptyEncodedPath());
 
   // 500px / 32px per band ≈ 16 bands.
   EXPECT_GT(encoded.bands.size(), 1u);
@@ -70,7 +78,7 @@ TEST(GeodePathEncoder, BandsCoverFullHeight) {
   Path path = PathBuilder().addRect(Box2d({10, 20}, {90, 120})).build();
 
   EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
-  EXPECT_FALSE(encoded.empty());
+  EXPECT_THAT(encoded, NonEmptyEncodedPath());
 
   // First band should start at or before the path's top.
   EXPECT_LE(encoded.bands.front().yMin, encoded.pathBounds.topLeft.y + 0.01f);
@@ -105,7 +113,7 @@ TEST(GeodePathEncoder, QuadraticCurveEncoded) {
                   .build();
 
   EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
-  EXPECT_FALSE(encoded.empty());
+  EXPECT_THAT(encoded, NonEmptyEncodedPath());
   EXPECT_GT(encoded.curves.size(), 0u);
 }
 
@@ -113,7 +121,7 @@ TEST(GeodePathEncoder, CircleEncoded) {
   Path path = PathBuilder().addCircle(Vector2d(50, 50), 40).build();
 
   EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
-  EXPECT_FALSE(encoded.empty());
+  EXPECT_THAT(encoded, NonEmptyEncodedPath());
 
   // Circle is ~80px tall → should have a few bands.
   EXPECT_GE(encoded.bands.size(), 2u);
@@ -130,14 +138,14 @@ TEST(GeodePathEncoder, DegeneratePath) {
   Path path = PathBuilder().moveTo(Vector2d(50, 50)).build();
 
   EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
-  EXPECT_TRUE(encoded.empty());
+  EXPECT_THAT(encoded, EmptyEncodedPath());
 }
 
 TEST(GeodePathEncoder, VertexNormalsPointOutward) {
   Path path = PathBuilder().addRect(Box2d({0, 0}, {100, 100})).build();
 
   EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
-  EXPECT_FALSE(encoded.empty());
+  EXPECT_THAT(encoded, NonEmptyEncodedPath());
 
   // Each band has 6 vertices. Verify normals are non-zero and point in expected directions.
   for (const auto& v : encoded.vertices) {
@@ -227,9 +235,10 @@ TEST(GeodePathEncoder, VerticalBandsConsistentWinding) {
                   .build();
 
   EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
-  ASSERT_FALSE(encoded.empty());
-  EXPECT_FALSE(encoded.vBands.empty()) << "Vertical bands must be populated for the vertical ray";
-  EXPECT_FALSE(encoded.vCurves.empty());
+  ASSERT_THAT(encoded, NonEmptyEncodedPath());
+  EXPECT_THAT(encoded.vBands, Not(IsEmpty()))
+      << "Vertical bands must be populated for the vertical ray";
+  EXPECT_THAT(encoded.vCurves, Not(IsEmpty()));
 
   // Vertical bands partition the bounds width.
   EXPECT_LE(encoded.vBands.front().xMin, encoded.pathBounds.topLeft.x + 0.01);
@@ -263,10 +272,9 @@ TEST(GeodePathEncoder, BandGridResolvesToCoveringBand) {
                   .build();
 
   EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
-  ASSERT_FALSE(encoded.empty());
+  ASSERT_THAT(encoded, NonEmptyEncodedPath());
 
-  ASSERT_EQ(encoded.hBandGrid.size(), encoded.hBandCount);
-  ASSERT_EQ(encoded.vBandGrid.size(), encoded.vBandCount);
+  ASSERT_THAT(encoded, HasBandGridsSizedToCounts());
   EXPECT_GT(encoded.hBandCount, 0u);
   EXPECT_GT(encoded.hStride, 0.0f);
 
@@ -325,10 +333,10 @@ TEST(GeodePathEncoder, OpenSubpathGetsImplicitClose) {
                             .build();
   EncodedPath openEncoded = GeodePathEncoder::encode(openTriangle, FillRule::NonZero);
   EncodedPath closedEncoded = GeodePathEncoder::encode(closedTriangle, FillRule::NonZero);
-  EXPECT_FALSE(openEncoded.empty());
-  EXPECT_FALSE(closedEncoded.empty());
-  EXPECT_EQ(openEncoded.curves.size(), closedEncoded.curves.size());
-  EXPECT_EQ(openEncoded.bands.size(), closedEncoded.bands.size());
+  EXPECT_THAT(openEncoded, NonEmptyEncodedPath());
+  EXPECT_THAT(closedEncoded, NonEmptyEncodedPath());
+  EXPECT_THAT(openEncoded.curves, SizeIs(closedEncoded.curves.size()));
+  EXPECT_THAT(openEncoded.bands, SizeIs(closedEncoded.bands.size()));
 
   // A straight line (the geometry resvg's `a-stroke-linecap-001` feeds to
   // the fill path before the stroke ribbon is generated) must produce
@@ -336,11 +344,11 @@ TEST(GeodePathEncoder, OpenSubpathGetsImplicitClose) {
   // a single forward curve with no return edge, producing spill fill.
   Path openLine = PathBuilder().moveTo(Vector2d(40, 40)).lineTo(Vector2d(160, 160)).build();
   EncodedPath encoded = GeodePathEncoder::encode(openLine, FillRule::NonZero);
-  EXPECT_FALSE(encoded.empty());
+  EXPECT_THAT(encoded, NonEmptyEncodedPath());
   // There must be an even number of forward+return segments per band
   // (one LineTo forward, one implicit close back). `curves.size()` is
   // band-flattened, so for an N-band span we expect 2*N band curves.
-  EXPECT_EQ(encoded.curves.size() % 2u, 0u);
+  EXPECT_THAT(encoded.curves.size() % 2u, Eq(0u));
 }
 
 // Multi-subpath regression: a MoveTo in the middle of a path starts a new
@@ -372,7 +380,7 @@ TEST(GeodePathEncoder, MultipleOpenSubpathsEachGetClosed) {
                             .build();
   EncodedPath openEncoded = GeodePathEncoder::encode(twoLinesOpen, FillRule::NonZero);
   EncodedPath closedEncoded = GeodePathEncoder::encode(twoLinesClosed, FillRule::NonZero);
-  EXPECT_EQ(openEncoded.curves.size(), closedEncoded.curves.size());
+  EXPECT_THAT(openEncoded.curves, SizeIs(closedEncoded.curves.size()));
 }
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -14,6 +14,7 @@
 /// ceiling(s) it targets; the `// M{N}:` comment beside each assertion
 /// names the milestone that will change it.
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <cinttypes>
@@ -27,6 +28,7 @@
 
 #include "donner/base/ParseWarningSink.h"
 #include "donner/base/Vector2.h"
+#include "donner/base/tests/ParseResultTestUtils.h"
 #include "donner/svg/SVGDocument.h"
 #include "donner/svg/parser/SVGParser.h"
 #include "donner/svg/renderer/RendererGeode.h"
@@ -35,6 +37,9 @@
 
 namespace donner::svg {
 namespace {
+
+using ::donner::NoParseError;
+using ::testing::NotNull;
 
 /// Inline fixture: three disjoint primitives, no gradients/filters/layers.
 /// Exercises the pure `submitFillDraw` path — the Tier-1 hot path from
@@ -159,7 +164,7 @@ protected:
 
 TEST_F(GeodePerfTest, SimpleShapes_BaselineCeilings) {
   auto device = sharedDevice();
-  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+  ASSERT_THAT(device, NotNull()) << "GeodeDevice::CreateHeadless failed";
 
   geode::GeodeCounters c = renderAndGetCounters(kSimpleShapesSvg, device);
 
@@ -204,7 +209,7 @@ TEST_F(GeodePerfTest, SimpleShapes_BaselineCeilings) {
 
 TEST_F(GeodePerfTest, Moderate_BaselineCeilings) {
   auto device = sharedDevice();
-  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+  ASSERT_THAT(device, NotNull()) << "GeodeDevice::CreateHeadless failed";
 
   geode::GeodeCounters c = renderAndGetCounters(kModerateSvg, device);
 
@@ -248,7 +253,7 @@ TEST_F(GeodePerfTest, Moderate_BaselineCeilings) {
 
 TEST_F(GeodePerfTest, Lion_BaselineCeilings) {
   auto device = sharedDevice();
-  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+  ASSERT_THAT(device, NotNull()) << "GeodeDevice::CreateHeadless failed";
 
   const std::string svg = readFile("donner/svg/renderer/testdata/lion.svg");
   if (svg.empty()) {
@@ -305,7 +310,7 @@ TEST_F(GeodePerfTest, Lion_BaselineCeilings) {
 
 TEST_F(GeodePerfTest, UseHeavy_BaselineCeilings) {
   auto device = sharedDevice();
-  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+  ASSERT_THAT(device, NotNull()) << "GeodeDevice::CreateHeadless failed";
 
   geode::GeodeCounters c = renderAndGetCounters(kUseHeavySvg, device);
 
@@ -348,11 +353,11 @@ TEST_F(GeodePerfTest, UseHeavy_BaselineCeilings) {
 
 TEST_F(GeodePerfTest, CountersResetBetweenFrames) {
   auto device = sharedDevice();
-  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+  ASSERT_THAT(device, NotNull()) << "GeodeDevice::CreateHeadless failed";
 
   ParseWarningSink sink = ParseWarningSink::Disabled();
   auto parsed = parser::SVGParser::ParseSVG(kSimpleShapesSvg, sink);
-  ASSERT_FALSE(parsed.hasError());
+  ASSERT_THAT(parsed, NoParseError());
   SVGDocument document = std::move(parsed.result());
 
   RendererGeode renderer(device);
@@ -426,7 +431,7 @@ geode::GeodeCounters countersForSecondRender(std::string_view svgSource,
 
 TEST_F(GeodePerfTest, SimpleShapes_NoDirtyPath_ZeroEncodes) {
   auto device = sharedDevice();
-  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+  ASSERT_THAT(device, NotNull()) << "GeodeDevice::CreateHeadless failed";
 
   const geode::GeodeCounters c = countersForSecondRender(kSimpleShapesSvg, device);
   printCounters("SimpleShapes_NoDirtyPath_ZeroEncodes (frame2)", c);
@@ -439,7 +444,7 @@ TEST_F(GeodePerfTest, SimpleShapes_NoDirtyPath_ZeroEncodes) {
 
 TEST_F(GeodePerfTest, Moderate_NoDirtyPath_ZeroEncodes) {
   auto device = sharedDevice();
-  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+  ASSERT_THAT(device, NotNull()) << "GeodeDevice::CreateHeadless failed";
 
   const geode::GeodeCounters c = countersForSecondRender(kModerateSvg, device);
   printCounters("Moderate_NoDirtyPath_ZeroEncodes (frame2)", c);
@@ -453,7 +458,7 @@ TEST_F(GeodePerfTest, Moderate_NoDirtyPath_ZeroEncodes) {
 
 TEST_F(GeodePerfTest, Lion_NoDirtyPath_ZeroEncodes) {
   auto device = sharedDevice();
-  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+  ASSERT_THAT(device, NotNull()) << "GeodeDevice::CreateHeadless failed";
 
   const std::string svg = readFile("donner/svg/renderer/testdata/lion.svg");
   if (svg.empty()) {
@@ -475,7 +480,7 @@ TEST_F(GeodePerfTest, Lion_NoDirtyPath_ZeroEncodes) {
 
 TEST_F(GeodePerfTest, GhostscriptTiger_NoDirtyPath_ZeroEncodes) {
   auto device = sharedDevice();
-  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+  ASSERT_THAT(device, NotNull()) << "GeodeDevice::CreateHeadless failed";
 
   const std::string svg = readFile("donner/svg/renderer/testdata/Ghostscript_Tiger.svg");
   if (svg.empty()) {
@@ -507,7 +512,7 @@ TEST_F(GeodePerfTest, GhostscriptTiger_NoDirtyPath_ZeroEncodes) {
 
 TEST_F(GeodePerfTest, SimpleShapes_NoDirtyPath_ZeroTextures) {
   auto device = sharedDevice();
-  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+  ASSERT_THAT(device, NotNull()) << "GeodeDevice::CreateHeadless failed";
 
   const geode::GeodeCounters c = countersForSecondRender(kSimpleShapesSvg, device);
   printCounters("SimpleShapes_NoDirtyPath_ZeroTextures (frame2)", c);
@@ -522,7 +527,7 @@ TEST_F(GeodePerfTest, SimpleShapes_NoDirtyPath_ZeroTextures) {
 
 TEST_F(GeodePerfTest, Moderate_NoDirtyPath_ZeroTextures) {
   auto device = sharedDevice();
-  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+  ASSERT_THAT(device, NotNull()) << "GeodeDevice::CreateHeadless failed";
 
   const geode::GeodeCounters c = countersForSecondRender(kModerateSvg, device);
   printCounters("Moderate_NoDirtyPath_ZeroTextures (frame2)", c);
@@ -537,7 +542,7 @@ TEST_F(GeodePerfTest, Moderate_NoDirtyPath_ZeroTextures) {
 
 TEST_F(GeodePerfTest, Lion_NoDirtyPath_ZeroTextures) {
   auto device = sharedDevice();
-  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+  ASSERT_THAT(device, NotNull()) << "GeodeDevice::CreateHeadless failed";
 
   const std::string svg = readFile("donner/svg/renderer/testdata/lion.svg");
   if (svg.empty()) {
@@ -553,7 +558,7 @@ TEST_F(GeodePerfTest, Lion_NoDirtyPath_ZeroTextures) {
 
 TEST_F(GeodePerfTest, GhostscriptTiger_NoDirtyPath_ZeroTextures) {
   auto device = sharedDevice();
-  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+  ASSERT_THAT(device, NotNull()) << "GeodeDevice::CreateHeadless failed";
 
   const std::string svg = readFile("donner/svg/renderer/testdata/Ghostscript_Tiger.svg");
   if (svg.empty()) {
@@ -583,7 +588,7 @@ TEST_F(GeodePerfTest, GhostscriptTiger_NoDirtyPath_ZeroTextures) {
 // ---------------------------------------------------------------------------
 TEST_F(GeodePerfTest, SharedDevice_RendererConstructionDoesNotLeakPipelines) {
   auto device = sharedDevice();
-  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+  ASSERT_THAT(device, NotNull()) << "GeodeDevice::CreateHeadless failed";
 
   // Warm the lazy caches on the shared device (mask pipeline, any
   // first-render device-side buffers) so we measure steady-state
@@ -627,14 +632,14 @@ TEST_F(GeodePerfTest, SharedDevice_RendererConstructionDoesNotLeakPipelines) {
 
 TEST_F(GeodePerfTest, TextureSnapshotStressReleasesMsaaTargets) {
   auto device = sharedDevice();
-  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+  ASSERT_THAT(device, NotNull()) << "GeodeDevice::CreateHeadless failed";
   if (device->sampleCount() <= 1u) {
     GTEST_SKIP() << "MSAA target leak regression only applies when Geode allocates MSAA targets.";
   }
 
   ParseWarningSink sink = ParseWarningSink::Disabled();
   auto parsed = parser::SVGParser::ParseSVG(kSimpleShapesSvg, sink);
-  ASSERT_FALSE(parsed.hasError()) << parsed.error().reason;
+  ASSERT_THAT(parsed, NoParseError());
   SVGDocument document = std::move(parsed.result());
 
   RendererGeode renderer(device);

--- a/donner/svg/renderer/geode/tests/GeodeShaders_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeShaders_tests.cc
@@ -1,20 +1,25 @@
 #include "donner/svg/renderer/geode/GeodeShaders.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "donner/svg/renderer/geode/GeodeDevice.h"
+#include "donner/svg/renderer/geode/tests/GeodeTestMatchers.h"
 
 namespace donner::geode {
+
+using test::TruthyWgpuHandle;
+using ::testing::NotNull;
 
 /// Smoke test: the Slug fill shader compiles without errors.
 /// If the WGSL has a syntax error or undefined symbol, shader module creation
 /// fails and the test fails.
 TEST(GeodeShaders, SlugFillCompiles) {
   auto geodeDevice = GeodeDevice::CreateHeadless();
-  ASSERT_NE(geodeDevice, nullptr);
+  ASSERT_THAT(geodeDevice, NotNull());
 
   wgpu::ShaderModule module = createSlugFillShader(geodeDevice->device());
-  ASSERT_TRUE(static_cast<bool>(module)) << "Slug fill shader failed to compile";
+  ASSERT_THAT(module, TruthyWgpuHandle()) << "Slug fill shader failed to compile";
 
   // Note: Dawn's shader compilation is asynchronous in principle but for
   // WGSL it's typically synchronous. If this test passes the WGSL parsed
@@ -25,34 +30,34 @@ TEST(GeodeShaders, SlugFillCompiles) {
 /// Smoke test for the Phase 3b path-clip mask shader.
 TEST(GeodeShaders, SlugMaskCompiles) {
   auto geodeDevice = GeodeDevice::CreateHeadless();
-  ASSERT_NE(geodeDevice, nullptr);
+  ASSERT_THAT(geodeDevice, NotNull());
 
   wgpu::ShaderModule module = createSlugMaskShader(geodeDevice->device());
-  ASSERT_TRUE(static_cast<bool>(module)) << "Slug mask shader failed to compile";
+  ASSERT_THAT(module, TruthyWgpuHandle()) << "Slug mask shader failed to compile";
 }
 
 TEST(GeodeShaders, FilterDropShadowCompiles) {
   auto geodeDevice = GeodeDevice::CreateHeadless();
-  ASSERT_NE(geodeDevice, nullptr);
+  ASSERT_THAT(geodeDevice, NotNull());
 
   wgpu::ShaderModule module = createFilterDropShadowShader(geodeDevice->device());
-  ASSERT_TRUE(static_cast<bool>(module)) << "feDropShadow compose shader failed to compile";
+  ASSERT_THAT(module, TruthyWgpuHandle()) << "feDropShadow compose shader failed to compile";
 }
 
 TEST(GeodeShaders, FilterImageCompiles) {
   auto geodeDevice = GeodeDevice::CreateHeadless();
-  ASSERT_NE(geodeDevice, nullptr);
+  ASSERT_THAT(geodeDevice, NotNull());
 
   wgpu::ShaderModule module = createFilterImageShader(geodeDevice->device());
-  ASSERT_TRUE(static_cast<bool>(module)) << "feImage shader failed to compile";
+  ASSERT_THAT(module, TruthyWgpuHandle()) << "feImage shader failed to compile";
 }
 
 TEST(GeodeShaders, FilterTileCompiles) {
   auto geodeDevice = GeodeDevice::CreateHeadless();
-  ASSERT_NE(geodeDevice, nullptr);
+  ASSERT_THAT(geodeDevice, NotNull());
 
   wgpu::ShaderModule module = createFilterTileShader(geodeDevice->device());
-  ASSERT_TRUE(static_cast<bool>(module)) << "feTile shader failed to compile";
+  ASSERT_THAT(module, TruthyWgpuHandle()) << "feTile shader failed to compile";
 }
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/tests/GeodeTestMatchers.h
+++ b/donner/svg/renderer/geode/tests/GeodeTestMatchers.h
@@ -1,0 +1,93 @@
+#pragma once
+/// @file
+
+#include <gmock/gmock.h>
+
+#include <cstddef>
+
+#include "donner/svg/renderer/geode/GeodePathEncoder.h"
+
+namespace donner::geode::test {
+
+/// Prints the encoded-path shape that matters when diagnosing encoder failures.
+inline void DescribeEncodedPath(const EncodedPath& encoded,
+                                testing::MatchResultListener* resultListener) {
+  *resultListener << "curves=" << encoded.curves.size() << ", bands=" << encoded.bands.size()
+                  << ", vertices=" << encoded.vertices.size()
+                  << ", quadVertices=" << encoded.quadVertices.size()
+                  << ", vCurves=" << encoded.vCurves.size() << ", vBands=" << encoded.vBands.size()
+                  << ", hBandGrid=" << encoded.hBandGrid.size()
+                  << ", vBandGrid=" << encoded.vBandGrid.size()
+                  << ", hBandCount=" << encoded.hBandCount << ", vBandCount=" << encoded.vBandCount
+                  << ", bounds=(" << encoded.pathBounds.topLeft.x << ", "
+                  << encoded.pathBounds.topLeft.y << ")-(" << encoded.pathBounds.bottomRight.x
+                  << ", " << encoded.pathBounds.bottomRight.y << ")";
+}
+
+/// Matches an encoded path with no generated data and prints all encoded counts on failure.
+MATCHER(EmptyEncodedPath, "an empty encoded path") {
+  if (arg.empty() && arg.curves.empty() && arg.vertices.empty() && arg.quadVertices.empty() &&
+      arg.vCurves.empty() && arg.vBands.empty() && arg.hBandGrid.empty() && arg.vBandGrid.empty()) {
+    return true;
+  }
+
+  DescribeEncodedPath(arg, result_listener);
+  return false;
+}
+
+/// Matches an encoded path with at least one horizontal band and prints all counts on failure.
+MATCHER(NonEmptyEncodedPath, "a non-empty encoded path") {
+  if (!arg.empty()) {
+    return true;
+  }
+
+  DescribeEncodedPath(arg, result_listener);
+  return false;
+}
+
+/// Matches an encoded path whose legacy band vertices contain two triangles per band.
+MATCHER(HasBandVertexQuads, "band vertices sized as two triangles per band") {
+  const size_t expectedVertices = arg.bands.size() * 6u;
+  if (arg.vertices.size() == expectedVertices) {
+    return true;
+  }
+
+  *result_listener << "vertices=" << arg.vertices.size()
+                   << ", expected vertices=" << expectedVertices << ", bands=" << arg.bands.size();
+  return false;
+}
+
+/// Matches an encoded path whose dense band-grid arrays match their advertised counts.
+MATCHER(HasBandGridsSizedToCounts, "band grids sized to their advertised counts") {
+  const bool hMatches = arg.hBandGrid.size() == arg.hBandCount;
+  const bool vMatches = arg.vBandGrid.size() == arg.vBandCount;
+  if (hMatches && vMatches) {
+    return true;
+  }
+
+  *result_listener << "hBandGrid=" << arg.hBandGrid.size() << ", hBandCount=" << arg.hBandCount
+                   << ", vBandGrid=" << arg.vBandGrid.size() << ", vBandCount=" << arg.vBandCount;
+  return false;
+}
+
+/// Matches an object that explicitly converts to true as a WebGPU-style handle.
+MATCHER(TruthyWgpuHandle, "a truthy WebGPU handle") {
+  if (static_cast<bool>(arg)) {
+    return true;
+  }
+
+  *result_listener << "handle converts to false";
+  return false;
+}
+
+/// Matches an object that explicitly converts to false as a WebGPU-style handle.
+MATCHER(FalsyWgpuHandle, "a falsy WebGPU handle") {
+  if (!static_cast<bool>(arg)) {
+    return true;
+  }
+
+  *result_listener << "handle converts to true";
+  return false;
+}
+
+}  // namespace donner::geode::test

--- a/donner/svg/renderer/geode/tests/GeodeWgpuUtil_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeWgpuUtil_tests.cc
@@ -1,9 +1,15 @@
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+#include "donner/svg/renderer/geode/tests/GeodeTestMatchers.h"
 
 namespace donner::geode {
 namespace {
+
+using test::FalsyWgpuHandle;
+using test::TruthyWgpuHandle;
 
 struct FakeWgpuHandle {
   FakeWgpuHandle() = default;
@@ -23,7 +29,7 @@ TEST(WgpuHandleTest, ReleaseWgpuHandleReleasesAndResetsOwnedHandle) {
   ReleaseWgpuHandle(handle);
 
   EXPECT_EQ(releaseCount, 1);
-  EXPECT_FALSE(handle);
+  EXPECT_THAT(handle, FalsyWgpuHandle());
 }
 
 TEST(WgpuHandleTest, ReleaseWgpuHandleIgnoresNullHandle) {
@@ -31,14 +37,14 @@ TEST(WgpuHandleTest, ReleaseWgpuHandleIgnoresNullHandle) {
 
   ReleaseWgpuHandle(handle);
 
-  EXPECT_FALSE(handle);
+  EXPECT_THAT(handle, FalsyWgpuHandle());
 }
 
 TEST(ScopedWgpuHandleTest, ReleasesOwnedHandleOnScopeExit) {
   int releaseCount = 0;
   {
     ScopedWgpuHandle<FakeWgpuHandle> handle{FakeWgpuHandle(&releaseCount)};
-    EXPECT_TRUE(handle);
+    EXPECT_THAT(handle, TruthyWgpuHandle());
   }
   EXPECT_EQ(releaseCount, 1);
 }
@@ -61,8 +67,8 @@ TEST(ScopedWgpuHandleTest, MoveTransfersOwnership) {
   {
     ScopedWgpuHandle<FakeWgpuHandle> source{FakeWgpuHandle(&releaseCount)};
     ScopedWgpuHandle<FakeWgpuHandle> destination(std::move(source));
-    EXPECT_FALSE(source);
-    EXPECT_TRUE(destination);
+    EXPECT_THAT(source, FalsyWgpuHandle());
+    EXPECT_THAT(destination, TruthyWgpuHandle());
   }
   EXPECT_EQ(releaseCount, 1);
 }
@@ -71,8 +77,8 @@ TEST(ScopedWgpuHandleTest, TakeDisarmsRelease) {
   int releaseCount = 0;
   ScopedWgpuHandle<FakeWgpuHandle> handle{FakeWgpuHandle(&releaseCount)};
   FakeWgpuHandle rawHandle = handle.take();
-  EXPECT_TRUE(rawHandle);
-  EXPECT_FALSE(handle);
+  EXPECT_THAT(rawHandle, TruthyWgpuHandle());
+  EXPECT_THAT(handle, FalsyWgpuHandle());
   EXPECT_EQ(releaseCount, 0);
 
   rawHandle.release();


### PR DESCRIPTION
Improve Geode renderer test diagnostics by replacing raw encoded-path, WebGPU-handle, bitmap, device, and parse-result boolean checks with reusable gMock matchers across `donner/svg/renderer/geode/tests`.

## Changes
- Add `GeodeTestMatchers.h` for encoded-path shape diagnostics and truthy/falsy WebGPU handle checks.
- Convert Geode path encoder tests to report curve, band, vertex, grid, and bounds context on failure.
- Convert Geode device, shader, embed, encoder, WGPU utility, and perf tests away from bare boolean checks toward matchers such as `TruthyWgpuHandle`, `NonEmptyRendererBitmap`, `NotNull`, and `NoParseError`.

## Validation
- `bazel test //donner/svg/renderer/geode:geode_path_encoder_tests //donner/svg/renderer/geode:geode_wgpu_util_tests //donner/svg/renderer/geode:geode_device_tests //donner/svg/renderer/geode:geode_shaders_tests //donner/svg/renderer/geode:geo_encoder_tests //donner/svg/renderer/geode:geode_perf_tests //donner/svg/renderer/geode:geode_embed_tests --test_output=errors`
- `bazel test //... --test_output=errors`
- `python3 tools/cmake/gen_cmakelists.py --check`