### PR TITLE
Improve compositor test diagnostics

### DIFF
--- a/donner/svg/compositor/BUILD.bazel
+++ b/donner/svg/compositor/BUILD.bazel
@@ -70,6 +70,19 @@ donner_cc_library(
     ],
 )
 
+donner_cc_library(
+    name = "compositor_test_matchers",
+    testonly = 1,
+    hdrs = ["CompositorTestMatchers.h"],
+    visibility = ["//donner/svg:__subpackages__"],
+    deps = [
+        ":compositor",
+        ":dual_path_verifier",
+        "//donner/svg/renderer:renderer_interface",
+        "@com_google_gtest//:gtest",
+    ],
+)
+
 donner_cc_test(
     name = "compositor_tests",
     srcs = [
@@ -84,9 +97,11 @@ donner_cc_test(
     ],
     deps = [
         ":compositor",
+        ":compositor_test_matchers",
         "//donner/svg/renderer:renderer_interface",
         "//donner/svg/renderer:renderer_utils",
         "//donner/svg/renderer/tests:mock_renderer_interface",
+        "//donner/svg/renderer/tests:renderer_test_matchers",
         "//donner/svg/tests:parser_test_utils",
         "@com_google_gtest//:gtest_main",
     ],
@@ -127,6 +142,7 @@ donner_cc_test(
     ],
     deps = [
         ":compositor",
+        ":compositor_test_matchers",
         "@com_google_gtest//:gtest_main",
     ],
 )
@@ -163,6 +179,7 @@ donner_cc_test(
     ],
     deps = [
         ":compositor",
+        ":compositor_test_matchers",
         "@com_google_gtest//:gtest_main",
     ],
 )
@@ -214,9 +231,11 @@ donner_cc_test(
     ],
     deps = [
         ":compositor",
+        ":compositor_test_matchers",
         ":dual_path_verifier",
         "//donner/svg/renderer",
         "//donner/svg/renderer:renderer_interface",
+        "//donner/svg/renderer/tests:renderer_test_matchers",
         "@com_google_gtest//:gtest_main",
     ],
 )
@@ -237,9 +256,11 @@ donner_cc_test(
     ],
     deps = [
         ":compositor",
+        ":compositor_test_matchers",
         ":dual_path_verifier",
         "//donner/svg/renderer",
         "//donner/svg/renderer:renderer_interface",
+        "//donner/svg/renderer/tests:renderer_test_matchers",
         "@com_google_gtest//:gtest_main",
     ],
 )

--- a/donner/svg/compositor/ComplexityBucketer_tests.cc
+++ b/donner/svg/compositor/ComplexityBucketer_tests.cc
@@ -1,7 +1,9 @@
 #include "donner/svg/compositor/ComplexityBucketer.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <array>
 #include <vector>
 
 #include "donner/base/EcsRegistry.h"
@@ -221,19 +223,22 @@ TEST_F(ComplexityBucketerTest, Deterministic) {
 
   ComplexityBucketer bucketer;
   bucketer.reconcile(registry_);
-  const auto after1 = std::vector<bool>{
-      countHints(c1, HintSource::ComplexityBucket) == 1u,
-      countHints(c2, HintSource::ComplexityBucket) == 1u,
-      countHints(c3, HintSource::ComplexityBucket) == 1u,
+  const auto after1 = std::array<size_t, 3>{
+      countHints(c1, HintSource::ComplexityBucket),
+      countHints(c2, HintSource::ComplexityBucket),
+      countHints(c3, HintSource::ComplexityBucket),
   };
 
   for (int i = 0; i < 9; ++i) {
     bucketer.reconcile(registry_);
   }
 
-  EXPECT_EQ(countHints(c1, HintSource::ComplexityBucket) == 1u, after1[0]);
-  EXPECT_EQ(countHints(c2, HintSource::ComplexityBucket) == 1u, after1[1]);
-  EXPECT_EQ(countHints(c3, HintSource::ComplexityBucket) == 1u, after1[2]);
+  EXPECT_THAT((std::array<size_t, 3>{
+                  countHints(c1, HintSource::ComplexityBucket),
+                  countHints(c2, HintSource::ComplexityBucket),
+                  countHints(c3, HintSource::ComplexityBucket),
+              }),
+              testing::ElementsAre(after1[0], after1[1], after1[2]));
 }
 
 TEST_F(ComplexityBucketerTest, ReservedSlotsReduceBudget) {

--- a/donner/svg/compositor/CompositorController_tests.cc
+++ b/donner/svg/compositor/CompositorController_tests.cc
@@ -11,10 +11,12 @@
 
 #include "donner/svg/SVGDocument.h"
 #include "donner/svg/SVGGraphicsElement.h"
+#include "donner/svg/compositor/CompositorTestMatchers.h"
 #include "donner/svg/compositor/ComputedLayerAssignmentComponent.h"
 #include "donner/svg/renderer/RendererInterface.h"
 #include "donner/svg/renderer/RendererUtils.h"
 #include "donner/svg/renderer/tests/MockRendererInterface.h"
+#include "donner/svg/renderer/tests/RendererTestMatchers.h"
 #include "donner/svg/tests/ParserTestUtils.h"
 
 using ::testing::_;
@@ -97,6 +99,9 @@ void PrintTo(const CompositorTile& tile, std::ostream* os) {
 namespace {
 
 using MockRendererInterface = tests::MockRendererInterface;
+using ::donner::svg::test::EmptyRendererBitmap;
+using ::donner::svg::test::NonEmptyRendererBitmap;
+using ::donner::svg::test::NullEntity;
 using CompositeTileSnapshot = CompositorController::CompositeTileSnapshot;
 using LayerInspectorRow = CompositorController::LayerInspectorRow;
 using SegmentInspectorRow = CompositorController::SegmentInspectorRow;
@@ -457,13 +462,13 @@ TEST_F(CompositorControllerTest, PromoteInvalidEntityFails) {
   EXPECT_FALSE(compositor.isPromoted(entt::null));
   EXPECT_TRUE(compositor.layerComposeOffset(entt::null).isIdentity());
   EXPECT_EQ(compositor.fallbackReasonsOf(entt::null), FallbackReason::None);
-  EXPECT_TRUE(compositor.layerBitmapOf(entt::null).empty());
+  EXPECT_THAT(compositor.layerBitmapOf(entt::null), EmptyRendererBitmap());
   EXPECT_EQ(compositor.layerCanvasOffsetOf(entt::null), Vector2d::Zero());
 
   const auto state = compositor.snapshotState();
   EXPECT_EQ(state.lastPromoteRefusalReason,
             CompositorController::PromoteRefusalReason::InvalidEntity);
-  EXPECT_TRUE(state.lastPromoteRefusalEntity == entt::null);
+  EXPECT_THAT(state.lastPromoteRefusalEntity, NullEntity());
 }
 
 TEST_F(CompositorControllerTest, DemoteRemovesLayer) {
@@ -719,7 +724,7 @@ TEST_F(CompositorControllerTest, DemoteDetachedPromotedEntityClearsInteractionHi
   EXPECT_FALSE(compositor.isPromoted(entity));
   const auto state = compositor.snapshotState();
   EXPECT_EQ(state.activeHintsCount, 0u);
-  EXPECT_TRUE(state.splitStaticLayersEntity == entt::null);
+  EXPECT_THAT(state.splitStaticLayersEntity, NullEntity());
 }
 
 TEST_F(CompositorControllerTest, ComputedLayerAssignmentAttachedOnPromote) {
@@ -880,7 +885,7 @@ TEST_F(CompositorControllerTest, SinglePromotedLayerBuildsSplitStaticLayers) {
   // exists. Assert the layer's bitmap is non-empty (the editor reads
   // it directly via `snapshotTilesForUpload`).
   EXPECT_TRUE(compositor.hasSplitStaticLayers());
-  EXPECT_FALSE(compositor.layerBitmapOf(entity).empty());
+  EXPECT_THAT(compositor.layerBitmapOf(entity), NonEmptyRendererBitmap());
 }
 
 TEST_F(CompositorControllerTest, MultiplePromotedLayersDoNotBuildSplitStaticLayers) {
@@ -962,7 +967,8 @@ TEST_F(CompositorControllerTest, FilterTriggersFallback) {
 
   CompositorController compositor(document, renderer_);
   compositor.promoteEntity(entity);
-  EXPECT_NE(compositor.fallbackReasonsOf(entity) & FallbackReason::Filter, FallbackReason::None);
+  EXPECT_THAT(compositor.fallbackReasonsOf(entity),
+              test::FallbackReasonsInclude(FallbackReason::Filter));
 }
 
 TEST_F(CompositorControllerTest, ClipPathTriggersFallback) {
@@ -982,7 +988,8 @@ TEST_F(CompositorControllerTest, ClipPathTriggersFallback) {
 
   CompositorController compositor(document, renderer_);
   compositor.promoteEntity(entity);
-  EXPECT_NE(compositor.fallbackReasonsOf(entity) & FallbackReason::ClipPath, FallbackReason::None);
+  EXPECT_THAT(compositor.fallbackReasonsOf(entity),
+              test::FallbackReasonsInclude(FallbackReason::ClipPath));
 }
 
 TEST_F(CompositorControllerTest, MaskTriggersFallback) {
@@ -1002,7 +1009,8 @@ TEST_F(CompositorControllerTest, MaskTriggersFallback) {
 
   CompositorController compositor(document, renderer_);
   compositor.promoteEntity(entity);
-  EXPECT_NE(compositor.fallbackReasonsOf(entity) & FallbackReason::Mask, FallbackReason::None);
+  EXPECT_THAT(compositor.fallbackReasonsOf(entity),
+              test::FallbackReasonsInclude(FallbackReason::Mask));
 }
 
 TEST_F(CompositorControllerTest, OpacityTriggersFallback) {
@@ -1019,8 +1027,8 @@ TEST_F(CompositorControllerTest, OpacityTriggersFallback) {
 
   CompositorController compositor(document, renderer_);
   compositor.promoteEntity(entity);
-  EXPECT_NE(compositor.fallbackReasonsOf(entity) & FallbackReason::IsolatedLayer,
-            FallbackReason::None);
+  EXPECT_THAT(compositor.fallbackReasonsOf(entity),
+              test::FallbackReasonsInclude(FallbackReason::IsolatedLayer));
 }
 
 TEST_F(CompositorControllerTest, GradientFillTriggersFallback) {
@@ -1043,8 +1051,8 @@ TEST_F(CompositorControllerTest, GradientFillTriggersFallback) {
 
   CompositorController compositor(document, renderer_);
   compositor.promoteEntity(entity);
-  EXPECT_NE(compositor.fallbackReasonsOf(entity) & FallbackReason::ExternalPaint,
-            FallbackReason::None);
+  EXPECT_THAT(compositor.fallbackReasonsOf(entity),
+              test::FallbackReasonsInclude(FallbackReason::ExternalPaint));
 }
 
 TEST_F(CompositorControllerTest, FallbackReasonsOfUnpromotedEntity) {
@@ -1218,7 +1226,7 @@ TEST_F(CompositorControllerTest, SnapshotLayerInspectorRowsIsEmptyBeforePromotio
   )svg");
 
   CompositorController compositor(document, renderer_);
-  EXPECT_TRUE(compositor.snapshotLayerInspectorRows().empty());
+  EXPECT_THAT(compositor.snapshotLayerInspectorRows(), IsEmpty());
 }
 
 TEST_F(CompositorControllerTest, SnapshotLayerInspectorRowsEmitsRowPerLayerWithBitmapDims) {
@@ -1241,14 +1249,14 @@ TEST_F(CompositorControllerTest, SnapshotLayerInspectorRowsEmitsRowPerLayerWithB
   compositor.renderFrame(RenderViewport{kTestSvgDefaultSize});
 
   const auto rows = compositor.snapshotLayerInspectorRows();
-  ASSERT_EQ(rows.size(), 2u);
+  ASSERT_THAT(rows, SizeIs(2u));
 
   // Every row must point at one of the promoted entities; every row must
   // have a populated bitmap (the mock renderer's dummy bitmap) and a
   // non-zero rasterize count after the first renderFrame.
   std::vector<Entity> entitiesInRows;
   for (const auto& row : rows) {
-    EXPECT_TRUE(row.hasValidBitmap);
+    EXPECT_THAT(row, LayerHasValidBitmapIs(true));
     EXPECT_NE(row.bitmapSize, Vector2i::Zero());
     EXPECT_GE(row.rasterizeCount, 1u);
     EXPECT_GE(row.generation, 1u);
@@ -1443,9 +1451,9 @@ TEST_F(CompositorControllerTest, SnapshotLayerInspectorRowsEmitsThumbnailWithMax
   compositor.renderFrame(RenderViewport{kTestSvgDefaultSize});
 
   const auto rows = compositor.snapshotLayerInspectorRows();
-  ASSERT_EQ(rows.size(), 1u);
+  ASSERT_THAT(rows, SizeIs(1u));
   const auto& row = rows.front();
-  ASSERT_TRUE(row.hasValidBitmap);
+  ASSERT_THAT(row, LayerHasValidBitmapIs(true));
 
   // Thumbnail must be non-empty, longer side clamped to `kLayerThumbnailMaxSide`,
   // and the RGBA8 byte buffer must match the dimensions.
@@ -1453,8 +1461,8 @@ TEST_F(CompositorControllerTest, SnapshotLayerInspectorRowsEmitsThumbnailWithMax
   EXPECT_GT(row.thumbnailDims.y, 0);
   EXPECT_LE(std::max(row.thumbnailDims.x, row.thumbnailDims.y),
             CompositorController::kLayerThumbnailMaxSide);
-  EXPECT_EQ(row.thumbnailPixels.size(), static_cast<size_t>(row.thumbnailDims.x) *
-                                            static_cast<size_t>(row.thumbnailDims.y) * 4u);
+  EXPECT_THAT(row.thumbnailPixels, SizeIs(static_cast<size_t>(row.thumbnailDims.x) *
+                                          static_cast<size_t>(row.thumbnailDims.y) * 4u));
 }
 
 TEST_F(CompositorControllerTest, SnapshotSegmentInspectorRowsEmitsOneRowPerSlot) {
@@ -2049,7 +2057,7 @@ TEST_F(CompositorControllerTest, MandatoryFilterLayerSurvivesCanvasResize) {
 
   // First render: mandatory detector picks up the filter group.
   compositor.renderFrame(RenderViewport{kTestSvgDefaultSize});
-  ASSERT_FALSE(compositor.snapshotLayerInspectorRows().empty())
+  ASSERT_THAT(compositor.snapshotLayerInspectorRows(), Not(IsEmpty()))
       << "Sanity check: mandatory filter detection should have promoted #target on first frame.";
 
   // Simulate a canvas resize — same code path as the editor's pinch-zoom
@@ -2062,7 +2070,7 @@ TEST_F(CompositorControllerTest, MandatoryFilterLayerSurvivesCanvasResize) {
   // render. Without the fix, the snapshot returns zero rows because
   // the detector ran before prepare and saw an empty RIC view.
   const auto rows = compositor.snapshotLayerInspectorRows();
-  EXPECT_FALSE(rows.empty())
+  EXPECT_THAT(rows, Not(IsEmpty()))
       << "Canvas resize dropped the mandatory filter layer (detector ran against empty RICs).";
   bool sawFilterAfterResize = false;
   for (const auto& row : rows) {
@@ -2070,7 +2078,7 @@ TEST_F(CompositorControllerTest, MandatoryFilterLayerSurvivesCanvasResize) {
       sawFilterAfterResize = true;
     }
   }
-  EXPECT_TRUE(sawFilterAfterResize)
+  EXPECT_THAT(sawFilterAfterResize, testing::IsTrue())
       << "Filter-bearing layer should still be promoted after canvas resize.";
 }
 
@@ -2094,7 +2102,7 @@ TEST_F(CompositorControllerTest, SnapshotLayerInspectorRowsFormatsFallbackReason
   compositor.renderFrame(RenderViewport{kTestSvgDefaultSize});
 
   const auto rows = compositor.snapshotLayerInspectorRows();
-  ASSERT_FALSE(rows.empty());
+  ASSERT_THAT(rows, Not(IsEmpty()));
 
   // At least one row should have the Filter fallback flag set, with the
   // string representation matching the FallbackReasonToString output.
@@ -2102,11 +2110,10 @@ TEST_F(CompositorControllerTest, SnapshotLayerInspectorRowsFormatsFallbackReason
   for (const auto& row : rows) {
     if ((row.fallbackReasons & FallbackReason::Filter) != FallbackReason::None) {
       sawFilter = true;
-      EXPECT_NE(row.fallbackReasonsText.find("Filter"), std::string::npos)
-          << "fallbackReasonsText='" << row.fallbackReasonsText << "'";
+      EXPECT_THAT(row.fallbackReasonsText, HasSubstr("Filter"));
     }
   }
-  EXPECT_TRUE(sawFilter);
+  EXPECT_THAT(sawFilter, testing::IsTrue());
 }
 
 TEST_F(CompositorControllerTest, ResetAllLayersAllowsRepromotion) {
@@ -2158,7 +2165,7 @@ TEST_F(CompositorControllerTest, BuildStructuralEntityRemapMapsEquivalentTrees) 
 
   const auto remap = BuildStructuralEntityRemap(oldDocument, newDocument);
 
-  ASSERT_FALSE(remap.empty());
+  ASSERT_THAT(remap, Not(IsEmpty()));
   EXPECT_EQ(remap.at(oldDocument.svgElement().unsafeEntityHandle().entity()),
             newDocument.svgElement().unsafeEntityHandle().entity());
   EXPECT_EQ(remap.at(oldParent->unsafeEntityHandle().entity()),
@@ -2191,9 +2198,9 @@ TEST_F(CompositorControllerTest, BuildStructuralEntityRemapRejectsStructuralMism
     </g>
   )svg");
 
-  EXPECT_TRUE(BuildStructuralEntityRemap(oldDocument, tagMismatch).empty());
-  EXPECT_TRUE(BuildStructuralEntityRemap(oldDocument, idMismatch).empty());
-  EXPECT_TRUE(BuildStructuralEntityRemap(oldDocument, childCountMismatch).empty());
+  EXPECT_THAT(BuildStructuralEntityRemap(oldDocument, tagMismatch), IsEmpty());
+  EXPECT_THAT(BuildStructuralEntityRemap(oldDocument, idMismatch), IsEmpty());
+  EXPECT_THAT(BuildStructuralEntityRemap(oldDocument, childCountMismatch), IsEmpty());
 }
 
 }  // namespace donner::svg::compositor

--- a/donner/svg/compositor/CompositorGolden_tests.cc
+++ b/donner/svg/compositor/CompositorGolden_tests.cc
@@ -18,16 +18,25 @@
 #include "donner/svg/SVGGraphicsElement.h"
 #include "donner/svg/components/RenderingInstanceComponent.h"
 #include "donner/svg/compositor/CompositorController.h"
+#include "donner/svg/compositor/CompositorTestMatchers.h"
 #include "donner/svg/compositor/DualPathVerifier.h"
 #include "donner/svg/parser/SVGParser.h"
 #include "donner/svg/renderer/Renderer.h"
 #include "donner/svg/renderer/RendererDriver.h"
 #include "donner/svg/renderer/RendererImageIO.h"
 #include "donner/svg/renderer/common/RenderingInstanceView.h"
+#include "donner/svg/renderer/tests/RendererTestMatchers.h"
 
 namespace donner::svg::compositor {
 
 namespace {
+
+using ::donner::svg::test::EmptyRendererBitmap;
+using ::donner::svg::test::NonEmptyRendererBitmap;
+using ::testing::Contains;
+using ::testing::IsEmpty;
+using ::testing::Not;
+using ::testing::SizeIs;
 
 struct Pixel {
   uint8_t r = 0;
@@ -58,6 +67,11 @@ MATCHER(IsRed, "") {
 MATCHER(IsWhite, "") {
   *result_listener << "pixel is " << arg;
   return arg.r > 200 && arg.g > 200 && arg.b > 200 && arg.a > 200;
+}
+
+MATCHER(IsWarmYellow, "") {
+  *result_listener << "pixel is " << arg;
+  return arg.r > 200 && arg.g > 150 && arg.b < 100;
 }
 
 std::array<double, 6> TransformData(const Transform2d& transform) {
@@ -118,9 +132,7 @@ TEST_F(CompositorGoldenTest, PixelIdentityOnSimpleDocument) {
   DualPathVerifier verifier(compositor, renderer_);
   const auto result = verifier.renderAndVerify(viewport_);
 
-  EXPECT_TRUE(result.isExact()) << result;
-  EXPECT_EQ(result.mismatchCount, 0u);
-  EXPECT_EQ(result.maxChannelDiff, 0);
+  EXPECT_THAT(result, test::ExactVerifyResult());
 }
 
 // With an entity explicitly promoted to its own layer, compositor output is
@@ -143,7 +155,7 @@ TEST_F(CompositorGoldenTest, PromotedEntityMatchesFullRender) {
   DualPathVerifier verifier(compositor, renderer_);
   const auto result = verifier.renderAndVerify(viewport_);
 
-  EXPECT_TRUE(result.isExact()) << result;
+  EXPECT_THAT(result, test::ExactVerifyResult());
 }
 
 // Translation-only drag: composited fast path produces the same pixels as a
@@ -205,8 +217,7 @@ TEST_F(CompositorGoldenTest, RotationDragProducesCorrectPixels) {
 
   DualPathVerifier verifier(compositor, renderer_);
   const auto result = verifier.renderAndVerify(viewport_);
-  EXPECT_TRUE(result.isExact()) << result;
-  EXPECT_EQ(result.mismatchCount, 0u);
+  EXPECT_THAT(result, test::ExactVerifyResult());
 }
 
 // Scale analog of RotationDragProducesCorrectPixels: a scale drag also reuses
@@ -236,8 +247,7 @@ TEST_F(CompositorGoldenTest, ScaleDragProducesCorrectPixels) {
 
   DualPathVerifier verifier(compositor, renderer_);
   const auto result = verifier.renderAndVerify(viewport_);
-  EXPECT_TRUE(result.isExact()) << result;
-  EXPECT_EQ(result.mismatchCount, 0u);
+  EXPECT_THAT(result, test::ExactVerifyResult());
 }
 
 // Editor-reported QA regression (#3, "hiding a layer leaves a ghost"): toggling
@@ -269,8 +279,7 @@ TEST_F(CompositorGoldenTest, HidingElementClearsItsPixelsFromComposite) {
 
   DualPathVerifier verifier(compositor, renderer_);
   const auto result = verifier.renderAndVerify(viewport_);
-  EXPECT_TRUE(result.isExact()) << result;
-  EXPECT_EQ(result.mismatchCount, 0u);
+  EXPECT_THAT(result, test::ExactVerifyResult());
   EXPECT_THAT(getPixel(renderer_.takeSnapshot(), 35, 35), IsWhite())
       << "hidden rect must not leave a ghost";
 }
@@ -842,7 +851,7 @@ TEST_F(CompositorGoldenTest, FilterGroupAutoPromotesOnFirstRender) {
   // not the full canvas. Just check it's populated and ≤ canvas; the
   // exact dims depend on the gaussian blur expansion math.
   const auto& glowBitmap = compositor.layerBitmapOf(glowEntity);
-  EXPECT_FALSE(glowBitmap.empty());
+  EXPECT_THAT(glowBitmap, NonEmptyRendererBitmap());
   EXPECT_LE(glowBitmap.dimensions.x, 200);
   EXPECT_LE(glowBitmap.dimensions.y, 100);
 }
@@ -874,9 +883,7 @@ TEST_F(CompositorGoldenTest, FilteredLayerBoundsStopAtLayerSubtree) {
   compositor.renderFrame(largeViewport);
 
   const RendererBitmap& glowBitmap = compositor.layerBitmapOf(glowEntity);
-  ASSERT_FALSE(glowBitmap.empty());
-  EXPECT_EQ(glowBitmap.dimensions.x, 52);
-  EXPECT_EQ(glowBitmap.dimensions.y, 52);
+  ASSERT_THAT(glowBitmap, test::NonEmptyRendererBitmapWithDimensions(Vector2i(52, 52)));
 
   const Vector2d glowOffset = compositor.layerCanvasOffsetOf(glowEntity);
   EXPECT_DOUBLE_EQ(glowOffset.x, 74.0);
@@ -892,7 +899,7 @@ TEST_F(CompositorGoldenTest, RealSplashLightningBlurLayerUsesFilterBounds) {
   std::ostringstream splashBuf;
   splashBuf << splashStream.rdbuf();
   const std::string splashSource = splashBuf.str();
-  ASSERT_FALSE(splashSource.empty());
+  ASSERT_THAT(splashSource, Not(IsEmpty()));
 
   SVGDocument document = parseDocument(splashSource);
   auto glow = document.querySelector("#Lightning_glow_dark");
@@ -907,7 +914,7 @@ TEST_F(CompositorGoldenTest, RealSplashLightningBlurLayerUsesFilterBounds) {
   compositor.renderFrame(splashViewport);
 
   const RendererBitmap& glowBitmap = compositor.layerBitmapOf(glowEntity);
-  ASSERT_FALSE(glowBitmap.empty());
+  ASSERT_THAT(glowBitmap, NonEmptyRendererBitmap());
   EXPECT_LT(glowBitmap.dimensions.x * glowBitmap.dimensions.y, (892 * 512) / 10);
   EXPECT_LT(glowBitmap.dimensions.x, 160);
   EXPECT_LT(glowBitmap.dimensions.y, 160);
@@ -939,7 +946,7 @@ TEST_F(CompositorGoldenTest, EmptyStaticSegmentsArePrunedFromPublicTileSnapshots
   for (const CompositorTile& tile : uploadTiles) {
     if (tile.layerEntity == entt::null) {
       ++uploadSegmentCount;
-      EXPECT_NE(tile.bitmapDims, Vector2i(1, 1));
+      EXPECT_THAT(tile, test::UploadTileBitmapDimsAreNotPlaceholder());
     } else {
       ++uploadLayerCount;
     }
@@ -953,7 +960,7 @@ TEST_F(CompositorGoldenTest, EmptyStaticSegmentsArePrunedFromPublicTileSnapshots
   for (const auto& tile : inspectorTiles) {
     if (tile.kind == CompositorController::CompositeTileSnapshot::Kind::Segment) {
       ++inspectorSegmentCount;
-      EXPECT_NE(tile.bitmapDims, Vector2i(1, 1));
+      EXPECT_THAT(tile, test::BitmapDimsAreNotPlaceholder());
     } else if (tile.kind == CompositorController::CompositeTileSnapshot::Kind::Layer) {
       ++inspectorLayerCount;
     }
@@ -1393,7 +1400,7 @@ TEST_F(CompositorGoldenTest, SplitBitmapsStableAcrossTranslationOnlyDragFrames) 
       nonDragGenerations[tile.tileId] = tile.generation;
     }
   }
-  ASSERT_FALSE(nonDragGenerations.empty());
+  ASSERT_THAT(nonDragGenerations, Not(IsEmpty()));
 
   // Simulate 10 more drag frames with only translation changes.
   for (int i = 2; i <= 11; ++i) {
@@ -1406,11 +1413,7 @@ TEST_F(CompositorGoldenTest, SplitBitmapsStableAcrossTranslationOnlyDragFrames) 
     if (tile.isDragTarget) {
       continue;
     }
-    auto it = nonDragGenerations.find(tile.tileId);
-    ASSERT_NE(it, nonDragGenerations.end())
-        << "non-drag tile id " << tile.tileId
-        << " disappeared between drag frames — segment cache rebuilt mid-drag";
-    EXPECT_EQ(it->second, tile.generation)
+    EXPECT_THAT(tile, test::CompositorTileGenerationPreservedIn(nonDragGenerations))
         << "non-drag tile id " << tile.tileId
         << " re-rasterized between drag frames — cache invalidated incorrectly";
   }
@@ -1439,24 +1442,19 @@ TEST_F(CompositorGoldenTest, DragTargetOnlySnapshotKeepsNonDragTileMetadata) {
   const auto dragTargetOnlyTiles =
       compositor.snapshotTilesForUpload(CompositorTileBitmapPayload::DragTargetOnly);
 
-  ASSERT_EQ(dragTargetOnlyTiles.size(), fullTiles.size());
+  ASSERT_THAT(dragTargetOnlyTiles, SizeIs(fullTiles.size()));
 
   bool sawDragTargetBitmap = false;
   bool sawNonDragMetadataOnlyTile = false;
   for (size_t i = 0; i < fullTiles.size(); ++i) {
     const CompositorTile& full = fullTiles[i];
     const CompositorTile& partial = dragTargetOnlyTiles[i];
-    EXPECT_EQ(partial.tileId, full.tileId);
-    EXPECT_EQ(partial.generation, full.generation);
-    EXPECT_EQ(partial.bitmapDims, full.bitmapDims);
-    EXPECT_EQ(partial.canvasOffsetPx, full.canvasOffsetPx);
-    EXPECT_EQ(partial.isDragTarget, full.isDragTarget);
     if (partial.isDragTarget) {
       sawDragTargetBitmap = true;
-      EXPECT_FALSE(partial.bitmap.empty());
+      EXPECT_THAT(partial, test::CompositorTileMetadataMatches(full, NonEmptyRendererBitmap()));
     } else {
       sawNonDragMetadataOnlyTile = true;
-      EXPECT_TRUE(partial.bitmap.empty())
+      EXPECT_THAT(partial, test::CompositorTileMetadataMatches(full, EmptyRendererBitmap()))
           << "non-drag tile " << partial.tileId
           << " should keep metadata without forcing a pixel payload";
       EXPECT_GT(partial.bitmapDims.x, 0);
@@ -1464,8 +1462,8 @@ TEST_F(CompositorGoldenTest, DragTargetOnlySnapshotKeepsNonDragTileMetadata) {
     }
   }
 
-  EXPECT_TRUE(sawDragTargetBitmap);
-  EXPECT_TRUE(sawNonDragMetadataOnlyTile);
+  EXPECT_THAT(sawDragTargetBitmap, testing::IsTrue());
+  EXPECT_THAT(sawNonDragMetadataOnlyTile, testing::IsTrue());
 }
 
 TEST_F(CompositorGoldenTest, SelectionToActiveDragDoesNotAdvanceUnchangedTileGenerations) {
@@ -1496,14 +1494,15 @@ TEST_F(CompositorGoldenTest, SelectionToActiveDragDoesNotAdvanceUnchangedTileGen
   std::unordered_map<uint64_t, uint64_t> preDragRetainedGenerations;
   std::unordered_set<uint64_t> preDragImmediateTileIds;
   for (const CompositorTile& tile : preDragTiles) {
-    ASSERT_FALSE(tile.bitmap.empty()) << "prewarmed tile " << tile.tileId << " has no pixels";
+    ASSERT_THAT(tile.bitmap, NonEmptyRendererBitmap())
+        << "prewarmed tile " << tile.tileId << " has no pixels";
     if (tile.immediate) {
       preDragImmediateTileIds.insert(tile.tileId);
       continue;
     }
     preDragRetainedGenerations[tile.tileId] = tile.generation;
   }
-  ASSERT_FALSE(preDragRetainedGenerations.empty());
+  ASSERT_THAT(preDragRetainedGenerations, Not(IsEmpty()));
 
   // Starting an active drag on an already-elevated target changes only presentation
   // geometry: the target's cached pixels are reused through canvasFromBitmap, and unrelated
@@ -1513,32 +1512,32 @@ TEST_F(CompositorGoldenTest, SelectionToActiveDragDoesNotAdvanceUnchangedTileGen
   compositor.renderFrame(viewport_);
 
   const auto activeDragTiles = compositor.snapshotTilesForUpload();
-  ASSERT_EQ(activeDragTiles.size(), preDragTiles.size());
+  ASSERT_THAT(activeDragTiles, SizeIs(preDragTiles.size()));
 
   bool sawTargetLayer = false;
   for (const CompositorTile& tile : activeDragTiles) {
     if (tile.layerEntity == targetEntity) {
       sawTargetLayer = true;
-      EXPECT_TRUE(tile.isDragTarget);
+      EXPECT_THAT(tile.isDragTarget, testing::IsTrue());
     }
     if (tile.immediate) {
       continue;
     }
     const auto it = preDragRetainedGenerations.find(tile.tileId);
     if (it == preDragRetainedGenerations.end()) {
-      EXPECT_TRUE(preDragImmediateTileIds.contains(tile.tileId))
+      EXPECT_THAT(preDragImmediateTileIds, Contains(tile.tileId))
           << "new retained tile id appeared on drag start: " << tile.tileId;
       continue;
     }
-    EXPECT_EQ(tile.generation, it->second)
+    EXPECT_THAT(tile, test::CompositorTileGenerationPreservedIn(preDragRetainedGenerations))
         << "tile " << tile.tileId
         << " advanced generation even though drag start changed only presentation geometry";
     if (tile.layerEntity == targetEntity) {
       sawTargetLayer = true;
-      EXPECT_TRUE(tile.isDragTarget);
+      EXPECT_THAT(tile.isDragTarget, testing::IsTrue());
     }
   }
-  EXPECT_TRUE(sawTargetLayer);
+  EXPECT_THAT(sawTargetLayer, testing::IsTrue());
 }
 
 // A drag-release `SetTransformCommand` mutation must NOT trigger a full
@@ -1846,7 +1845,7 @@ TEST_F(CompositorGoldenTest, NonPromotedMutationInvalidatesOnlyContainingSegment
   // "did this slot re-raster?" that doesn't depend on whether
   // `backgroundBitmap_` was recomposed (which always reallocates).
   const auto tilesBefore = compositor.snapshotTilesForUpload();
-  ASSERT_EQ(tilesBefore.size(), 3u)
+  ASSERT_THAT(tilesBefore, SizeIs(3u))
       << "expected 2 segments (before/after the promoted layer) + 1 layer tile";
   std::uint64_t segment0GenBefore = 0;
   std::uint64_t segment1GenBefore = 0;
@@ -1970,7 +1969,7 @@ TEST_F(CompositorGoldenTest, SplitBitmapsInvalidateOnViewportResize) {
       generationsAtSmall[tile.tileId] = tile.generation;
     }
   }
-  ASSERT_FALSE(generationsAtSmall.empty());
+  ASSERT_THAT(generationsAtSmall, Not(IsEmpty()));
 
   // Simulate a zoom-in: the editor's RenderCoordinator calls setCanvasSize
   // before requestRender when the viewport's desiredCanvasSize changes, so
@@ -2053,9 +2052,8 @@ TEST_F(CompositorGoldenTest, TightBoundedSegmentsProducePixelIdentityWithMultipl
   // transform is identity, so the full-render reference and the
   // composited output are supposed to be byte-for-byte equal.
   const auto result = verifier.renderAndVerify(viewport);
-  EXPECT_TRUE(result.isExact()) << "multi-segment scene with tight-bounded segments: " << result;
-  EXPECT_EQ(result.mismatchCount, 0u);
-  EXPECT_EQ(result.maxChannelDiff, 0);
+  EXPECT_THAT(result, test::ExactVerifyResult())
+      << "multi-segment scene with tight-bounded segments";
 }
 
 // Stronger variant: explicit drag-target promotion on top of the
@@ -2105,9 +2103,7 @@ TEST_F(CompositorGoldenTest, TightBoundedSegmentsSurviveExplicitDragTargetPromot
   // also identity — composited and reference paths render the same
   // scene, so they must produce pixel-identical output.
   const auto result = verifier.renderAndVerify(viewport);
-  EXPECT_TRUE(result.isExact()) << "explicit drag promote with tight segments: " << result;
-  EXPECT_EQ(result.mismatchCount, 0u);
-  EXPECT_EQ(result.maxChannelDiff, 0);
+  EXPECT_THAT(result, test::ExactVerifyResult()) << "explicit drag promote with tight segments";
 }
 
 // Drives the ACTUAL `donner_splash.svg` through the tight-bound
@@ -2131,7 +2127,7 @@ TEST_F(CompositorGoldenTest, TightBoundedSegmentsPixelIdentityOnRealSplashWithDr
   std::ostringstream splashBuf;
   splashBuf << splashStream.rdbuf();
   const std::string splashSource = splashBuf.str();
-  ASSERT_FALSE(splashSource.empty());
+  ASSERT_THAT(splashSource, Not(IsEmpty()));
 
   SVGDocument document = parseDocument(splashSource);
 
@@ -2181,10 +2177,9 @@ TEST_F(CompositorGoldenTest, TightBoundedSegmentsPixelIdentityOnRealSplashWithDr
   // leaking through where content should be). Tolerance 5 catches
   // the shift/crop class of regression without flaking on the
   // premul round-trip drift.
-  EXPECT_TRUE(result.isWithinTolerance(5))
-      << "real-splash tight-bounds pixel identity under drag failed. Mismatch count="
-      << result.mismatchCount << " max channel diff=" << int(result.maxChannelDiff)
-      << ". If non-zero, tight-bound bounds are cropping or shifting "
+  EXPECT_THAT(result, test::VerifyResultWithinTolerance(5))
+      << "real-splash tight-bounds pixel identity under drag failed. If non-zero, tight-bound "
+         "bounds are cropping or shifting "
          "content during the drag composite. Likely candidates: "
          "(a) bounds computed in doc space without applying canvasFromDoc, "
          "(b) bounds applied in canvas space but offset preserved in doc units, "
@@ -2210,7 +2205,7 @@ TEST_F(CompositorGoldenTest, TightBoundedSegmentsPixelIdentityOnRealSplash) {
   std::ostringstream splashBuf;
   splashBuf << splashStream.rdbuf();
   const std::string splashSource = splashBuf.str();
-  ASSERT_FALSE(splashSource.empty());
+  ASSERT_THAT(splashSource, Not(IsEmpty()));
 
   SVGDocument document = parseDocument(splashSource);
 
@@ -3070,11 +3065,11 @@ TEST_F(CompositorGoldenTest, TwoPhaseDragOfPlainGroupMovesChildren) {
   const Pixel originalPos = getPixel(composited, 30, 50);
   const Pixel newPos = getPixel(composited, 70, 50);
 
-  EXPECT_FALSE(originalPos.r > 200 && originalPos.g > 150 && originalPos.b < 100)
+  EXPECT_THAT(originalPos, Not(IsWarmYellow()))
       << "rect is still at original position (30, 50). got: " << originalPos
       << ". The two-phase Selection→ActiveDrag drag left the rect where it was before drag — "
          "DOM transform change didn't move the promoted layer's content.";
-  EXPECT_TRUE(newPos.r > 200 && newPos.g > 150 && newPos.b < 100)
+  EXPECT_THAT(newPos, IsWarmYellow())
       << "rect didn't move to new position (70, 50). got: " << newPos;
 }
 
@@ -3126,23 +3121,9 @@ TEST_F(CompositorGoldenTest, SetTightBoundedSegmentsEnabledTogglesAtRuntime) {
   compositorRef.renderFrame(viewport_);
   const RendererBitmap reference = renderer_.takeSnapshot();
 
-  ASSERT_EQ(afterFlip.dimensions, reference.dimensions);
-  ASSERT_EQ(afterFlip.pixels.size(), reference.pixels.size());
-  int mismatchCount = 0;
-  int maxDiff = 0;
-  for (size_t i = 0; i < afterFlip.pixels.size(); ++i) {
-    const int diff =
-        std::abs(static_cast<int>(afterFlip.pixels[i]) - static_cast<int>(reference.pixels[i]));
-    if (diff > 0) {
-      ++mismatchCount;
-      maxDiff = std::max(maxDiff, diff);
-    }
-  }
-  EXPECT_EQ(mismatchCount, 0)
+  EXPECT_THAT(afterFlip, test::RendererBitmapPixelsEqualTo(reference))
       << "runtime toggle off did not converge to same pixels as construct-time off. "
-         "mismatchCount="
-      << mismatchCount << " maxDiff=" << maxDiff
-      << ". If non-zero, `setTightBoundedSegmentsEnabled(false)` is not fully "
+         "If non-zero, `setTightBoundedSegmentsEnabled(false)` is not fully "
          "invalidating prior tight-bound caches — likely a missing "
          "`markAllSegmentsDirty` call in the setter.";
 }
@@ -3531,8 +3512,7 @@ TEST_F(CompositorGoldenTest, ClippedGroupWithOpacityChildRendersCorrectly) {
   // Pixel identity with the full-render path. If the child were auto-promoted
   // despite the ancestor clip, the composited path would leak rect content
   // past x=100 and this assertion would catch it.
-  EXPECT_TRUE(result.isExact()) << result;
-  EXPECT_EQ(result.mismatchCount, 0u);
+  EXPECT_THAT(result, test::ExactVerifyResult());
 }
 
 // Splash-shape document, real Skia-backed renderer, full-size 892×512
@@ -3782,7 +3762,7 @@ TEST_F(CompositorGoldenTest, RealSplashDragLatencyOnTinySkia) {
   std::ostringstream splashBuf;
   splashBuf << splashStream.rdbuf();
   const std::string splashSource = splashBuf.str();
-  ASSERT_FALSE(splashSource.empty()) << "donner_splash.svg is empty";
+  ASSERT_THAT(splashSource, Not(IsEmpty())) << "donner_splash.svg is empty";
 
   SVGDocument document = parseDocument(splashSource);
 
@@ -3874,7 +3854,7 @@ TEST_F(CompositorGoldenTest, RealSplashBlueCenterBurstEllipseDragLatency) {
   std::ostringstream splashBuf;
   splashBuf << splashStream.rdbuf();
   const std::string splashSource = splashBuf.str();
-  ASSERT_FALSE(splashSource.empty()) << "donner_splash.svg is empty";
+  ASSERT_THAT(splashSource, Not(IsEmpty())) << "donner_splash.svg is empty";
 
   SVGDocument document = parseDocument(splashSource);
   document.setCanvasSize(1784, 1024);
@@ -4182,7 +4162,7 @@ TEST_F(CompositorGoldenTest, BuildStructuralEntityRemapIdenticalTrees) {
   SVGDocument docB = parseDocument(kSource);
 
   const auto remap = BuildStructuralEntityRemap(docA, docB);
-  EXPECT_FALSE(remap.empty())
+  EXPECT_THAT(remap, Not(IsEmpty()))
       << "BuildStructuralEntityRemap returned empty for byte-identical documents";
 
   // Same-doc trivial lookup: every element should have a remap entry.
@@ -4212,7 +4192,7 @@ TEST_F(CompositorGoldenTest, BuildStructuralEntityRemapMismatchReturnsEmpty) {
   )svg");
 
   const auto remap = BuildStructuralEntityRemap(docA, docB);
-  EXPECT_TRUE(remap.empty()) << "remap must be empty when child counts differ";
+  EXPECT_THAT(remap, IsEmpty()) << "remap must be empty when child counts differ";
 }
 
 // Mismatched `id` → empty remap.
@@ -4229,7 +4209,7 @@ TEST_F(CompositorGoldenTest, BuildStructuralEntityRemapIdChangeReturnsEmpty) {
   )svg");
 
   const auto remap = BuildStructuralEntityRemap(docA, docB);
-  EXPECT_TRUE(remap.empty()) << "id rename must break structural equivalence";
+  EXPECT_THAT(remap, IsEmpty()) << "id rename must break structural equivalence";
 }
 
 // Transform-attribute-only change → remap IS valid. This mirrors the
@@ -4248,7 +4228,7 @@ TEST_F(CompositorGoldenTest, BuildStructuralEntityRemapIgnoresAttributeValueChan
   )svg");
 
   const auto remap = BuildStructuralEntityRemap(docA, docB);
-  EXPECT_FALSE(remap.empty())
+  EXPECT_THAT(remap, Not(IsEmpty()))
       << "attribute-value-only change must leave the structural remap intact";
   auto dragA = docA.querySelector("#drag");
   auto dragB = docB.querySelector("#drag");

--- a/donner/svg/compositor/CompositorHint_tests.cc
+++ b/donner/svg/compositor/CompositorHint_tests.cc
@@ -7,21 +7,19 @@
 
 #include "donner/base/EcsRegistry.h"
 #include "donner/svg/compositor/CompositorHintComponent.h"
+#include "donner/svg/compositor/CompositorTestMatchers.h"
 #include "donner/svg/compositor/ScopedCompositorHint.h"
 
 namespace donner::svg::compositor {
 
 namespace {
 
+using test::HintEntryIs;
+
 class CompositorHintTest : public ::testing::Test {
 protected:
   Registry registry_;
 };
-
-auto HintEntryIs(HintSource source, uint16_t weight) {
-  return testing::AllOf(testing::Field("source", &HintEntry::source, source),
-                        testing::Field("weight", &HintEntry::weight, weight));
-}
 
 }  // namespace
 

--- a/donner/svg/compositor/CompositorTestMatchers.h
+++ b/donner/svg/compositor/CompositorTestMatchers.h
@@ -1,0 +1,188 @@
+#pragma once
+/// @file
+
+#include <gmock/gmock.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+
+#include "donner/base/EcsRegistry.h"
+#include "donner/base/Vector2.h"
+#include "donner/svg/compositor/CompositorController.h"
+#include "donner/svg/compositor/CompositorHintComponent.h"
+#include "donner/svg/compositor/DualPathVerifier.h"
+#include "donner/svg/renderer/RendererInterface.h"
+
+namespace donner::svg::compositor::test {
+
+/// Matches a compositor hint entry by source and weight.
+inline auto HintEntryIs(HintSource source, uint16_t weight) {
+  return ::testing::AllOf(::testing::Field("source", &HintEntry::source, source),
+                          ::testing::Field("weight", &HintEntry::weight, weight));
+}
+
+/// Matches an exact dual-path render result and prints all diff counters on failure.
+MATCHER(ExactVerifyResult, "an exact dual-path verification result") {
+  if (arg.isExact() && arg.mismatchCount == 0u && arg.maxChannelDiff == 0) {
+    return true;
+  }
+
+  *result_listener << "mismatchCount=" << arg.mismatchCount
+                   << ", maxChannelDiff=" << static_cast<int>(arg.maxChannelDiff)
+                   << ", totalPixels=" << arg.totalPixels
+                   << ", dimensionsMatch=" << arg.dimensionsMatch;
+  return false;
+}
+
+/// Matches a dual-path render result whose max channel diff is within @p tolerance.
+MATCHER_P(VerifyResultWithinTolerance, tolerance,
+          "a dual-path verification result within channel tolerance") {
+  if (arg.isWithinTolerance(tolerance)) {
+    return true;
+  }
+
+  *result_listener << "tolerance=" << static_cast<int>(tolerance)
+                   << ", mismatchCount=" << arg.mismatchCount
+                   << ", maxChannelDiff=" << static_cast<int>(arg.maxChannelDiff)
+                   << ", totalPixels=" << arg.totalPixels
+                   << ", dimensionsMatch=" << arg.dimensionsMatch;
+  return false;
+}
+
+/// Matches fallback reasons containing @p reason.
+MATCHER_P(FallbackReasonsInclude, reason, "fallback reasons include the expected flag") {
+  if ((arg & reason) != FallbackReason::None) {
+    return true;
+  }
+
+  *result_listener << "fallbackReasons=" << FallbackReasonToString(arg)
+                   << ", expectedFlag=" << FallbackReasonToString(reason);
+  return false;
+}
+
+/// Matches a non-empty renderer bitmap with the expected dimensions.
+MATCHER_P(NonEmptyRendererBitmapWithDimensions, expectedDimensions,
+          "a non-empty renderer bitmap with expected dimensions") {
+  if (!arg.empty() && arg.dimensions == expectedDimensions) {
+    return true;
+  }
+
+  *result_listener << "dimensions=" << ::testing::PrintToString(arg.dimensions)
+                   << ", expectedDimensions=" << ::testing::PrintToString(expectedDimensions)
+                   << ", rowBytes=" << arg.rowBytes << ", pixels=" << arg.pixels.size()
+                   << ", alphaType=" << static_cast<int>(arg.alphaType);
+  return false;
+}
+
+/// Matches a renderer bitmap whose pixel array is byte-identical to @p expected.
+MATCHER_P(RendererBitmapPixelsEqualTo, expected,
+          "a renderer bitmap with byte-identical dimensions and pixels") {
+  if (arg.dimensions != expected.dimensions) {
+    *result_listener << "dimensions=" << ::testing::PrintToString(arg.dimensions)
+                     << ", expectedDimensions=" << ::testing::PrintToString(expected.dimensions);
+    return false;
+  }
+
+  if (arg.pixels.size() != expected.pixels.size()) {
+    *result_listener << "pixels=" << arg.pixels.size()
+                     << ", expectedPixels=" << expected.pixels.size();
+    return false;
+  }
+
+  size_t mismatchCount = 0;
+  size_t firstMismatch = 0;
+  int maxDiff = 0;
+  for (size_t i = 0; i < arg.pixels.size(); ++i) {
+    const int actual = static_cast<int>(arg.pixels[i]);
+    const int expectedValue = static_cast<int>(expected.pixels[i]);
+    const int diff = std::abs(actual - expectedValue);
+    if (diff == 0) {
+      continue;
+    }
+
+    if (mismatchCount == 0) {
+      firstMismatch = i;
+    }
+    ++mismatchCount;
+    maxDiff = std::max(maxDiff, diff);
+  }
+
+  if (mismatchCount == 0) {
+    return true;
+  }
+
+  *result_listener << "mismatchCount=" << mismatchCount << ", firstMismatch=" << firstMismatch
+                   << ", actual=" << static_cast<int>(arg.pixels[firstMismatch])
+                   << ", expected=" << static_cast<int>(expected.pixels[firstMismatch])
+                   << ", maxDiff=" << maxDiff
+                   << ", dimensions=" << ::testing::PrintToString(arg.dimensions)
+                   << ", rowBytes=" << arg.rowBytes << ", expectedRowBytes=" << expected.rowBytes;
+  return false;
+}
+
+/// Matches an object with `bitmapDims` not equal to the old 1x1 placeholder sentinel.
+MATCHER(BitmapDimsAreNotPlaceholder, "bitmap dimensions are not the 1x1 placeholder") {
+  if (arg.bitmapDims != Vector2i(1, 1)) {
+    return true;
+  }
+
+  *result_listener << "bitmapDims=" << ::testing::PrintToString(arg.bitmapDims);
+  return false;
+}
+
+/// Matches an upload tile whose bitmap dimensions are not the old 1x1 placeholder sentinel.
+MATCHER(UploadTileBitmapDimsAreNotPlaceholder,
+        "an upload tile whose bitmap dimensions are not the 1x1 placeholder") {
+  if (arg.bitmapDims != Vector2i(1, 1)) {
+    return true;
+  }
+
+  *result_listener << "tileId=" << arg.tileId << ", generation=" << arg.generation
+                   << ", layerEntity=" << ::testing::PrintToString(arg.layerEntity)
+                   << ", bitmapPixels=" << arg.bitmap.pixels.size()
+                   << ", textureSnapshot=" << (arg.textureSnapshot != nullptr);
+  return false;
+}
+
+/// Matches a tile whose generation is preserved according to a tileId->generation map.
+MATCHER_P(CompositorTileGenerationPreservedIn, generationsByTileId,
+          "a compositor tile whose generation is preserved in the expected map") {
+  const auto it = generationsByTileId.find(arg.tileId);
+  if (it == generationsByTileId.end()) {
+    *result_listener << "tileId=" << arg.tileId << " is absent; knownTileIds=";
+    bool first = true;
+    for (const auto& [tileId, generation] : generationsByTileId) {
+      if (!first) {
+        *result_listener << ",";
+      }
+      *result_listener << tileId << "->" << generation;
+      first = false;
+    }
+    return false;
+  }
+
+  if (arg.generation == it->second) {
+    return true;
+  }
+
+  *result_listener << "tileId=" << arg.tileId << ", generation=" << arg.generation
+                   << ", expectedGeneration=" << it->second << ", isDragTarget=" << arg.isDragTarget
+                   << ", layerEntity=" << ::testing::PrintToString(arg.layerEntity);
+  return false;
+}
+
+/// Matches tile metadata against @p expected while delegating bitmap payload checks.
+template <typename BitmapMatcher>
+auto CompositorTileMetadataMatches(const CompositorTile& expected, BitmapMatcher bitmapMatcher) {
+  return ::testing::AllOf(
+      ::testing::Field("tileId", &CompositorTile::tileId, expected.tileId),
+      ::testing::Field("generation", &CompositorTile::generation, expected.generation),
+      ::testing::Field("bitmapDims", &CompositorTile::bitmapDims, expected.bitmapDims),
+      ::testing::Field("canvasOffsetPx", &CompositorTile::canvasOffsetPx, expected.canvasOffsetPx),
+      ::testing::Field("isDragTarget", &CompositorTile::isDragTarget, expected.isDragTarget),
+      ::testing::Field("bitmap", &CompositorTile::bitmap, bitmapMatcher));
+}
+
+}  // namespace donner::svg::compositor::test

--- a/donner/svg/compositor/LayerResolver_tests.cc
+++ b/donner/svg/compositor/LayerResolver_tests.cc
@@ -1,5 +1,6 @@
 #include "donner/svg/compositor/LayerResolver.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -31,6 +32,15 @@ protected:
 
   bool hasAssignment(Entity entity) const {
     return registry_.all_of<ComputedLayerAssignmentComponent>(entity);
+  }
+
+  std::vector<uint32_t> layerIdsOf(const std::vector<Entity>& entities) const {
+    std::vector<uint32_t> layerIds;
+    layerIds.reserve(entities.size());
+    for (Entity entity : entities) {
+      layerIds.push_back(layerIdOf(entity));
+    }
+    return layerIds;
   }
 };
 
@@ -120,10 +130,8 @@ TEST_F(LayerResolverTest, TieInWeightsBrokenByLowerEntityId) {
   std::sort(sorted.begin(), sorted.end(), [](Entity a, Entity b) {
     return static_cast<std::uint32_t>(a) < static_cast<std::uint32_t>(b);
   });
-  for (size_t i = 0; i < sorted.size(); ++i) {
-    EXPECT_EQ(layerIdOf(sorted[i]), static_cast<uint32_t>(i + 1u))
-        << "tie-break must be by ascending entity id; mismatch at index " << i;
-  }
+  EXPECT_THAT(layerIdsOf(sorted), testing::ElementsAre(1u, 2u, 3u, 4u))
+      << "tie-break must be by ascending entity id";
 }
 
 TEST_F(LayerResolverTest, MandatoryAlwaysWinsUnderBudgetPressure) {
@@ -148,8 +156,7 @@ TEST_F(LayerResolverTest, MandatoryAlwaysWinsUnderBudgetPressure) {
 
   // Budget is 2. First two mandatory get layers (by entity id). Third mandatory
   // is evicted and logs; all explicit candidates are evicted.
-  EXPECT_EQ(layerIdOf(mandatoryEntities[0]), 1u);
-  EXPECT_EQ(layerIdOf(mandatoryEntities[1]), 2u);
+  EXPECT_THAT(layerIdsOf(mandatoryEntities), testing::ElementsAre(1u, 2u, 0u));
   EXPECT_FALSE(hasAssignment(mandatoryEntities[2]))
       << "over-budget mandatory should have no assignment";
   for (Entity e : explicitEntities) {
@@ -186,10 +193,8 @@ TEST_F(LayerResolverTest, DeterministicAcrossRepeatedCalls) {
 
   for (int run = 0; run < 10; ++run) {
     resolver_.resolve(registry_, kDefaultBudget);
-    for (size_t i = 0; i < entities.size(); ++i) {
-      EXPECT_EQ(layerIdOf(entities[i]), firstAssignment[i])
-          << "assignment diverged on run " << run << " at index " << i;
-    }
+    EXPECT_THAT(layerIdsOf(entities), testing::ElementsAreArray(firstAssignment))
+        << "assignment diverged on run " << run;
   }
 }
 

--- a/donner/svg/compositor/MandatoryHintDetector_tests.cc
+++ b/donner/svg/compositor/MandatoryHintDetector_tests.cc
@@ -11,17 +11,14 @@
 #include "donner/base/xml/components/TreeComponent.h"
 #include "donner/svg/components/RenderingInstanceComponent.h"
 #include "donner/svg/compositor/CompositorHintComponent.h"
+#include "donner/svg/compositor/CompositorTestMatchers.h"
 
 namespace donner::svg::compositor {
 
 namespace {
 
 using components::RenderingInstanceComponent;
-
-auto HintEntryIs(HintSource source, uint16_t weight) {
-  return testing::AllOf(testing::Field("source", &HintEntry::source, source),
-                        testing::Field("weight", &HintEntry::weight, weight));
-}
+using test::HintEntryIs;
 
 }  // namespace
 


### PR DESCRIPTION
Improve compositor test diagnostics by adding reusable compositor matchers and replacing raw collection, bitmap, tile, verifier-result, and fallback-flag assertions across `donner/svg/compositor` tests.

## Changes
- Add `CompositorTestMatchers.h` for dual-path verifier results, fallback reasons, renderer bitmap shape/pixel equality, tile payload metadata, and hint-entry diagnostics.
- Convert compositor golden/controller tests away from raw `empty()`, `size()`, pixel-array loops, and bitmask comparisons where richer gMock output localizes failures from logs.
- Reuse shared hint-entry matching in hint lifecycle and mandatory detector tests, and convert bucketer/layer resolver indexed comparisons to whole-collection matchers.

## Validation
- `tools/llm-bazel-wrap.sh test //donner/svg/compositor/... --test_output=errors`
- `tools/llm-bazel-wrap.sh test //... --test_output=errors`
- `python3 tools/cmake/gen_cmakelists.py --check`