### PR TITLE
Clean up Doxygen site navigation

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = Donner
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.5.1
+PROJECT_NUMBER         = $(DONNER_VERSION)
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a
@@ -1460,7 +1460,7 @@ HTML_CODE_FOLDING      = YES
 # Minimum value: 0, maximum value: 9999, default value: 100.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_INDEX_NUM_ENTRIES = 100
+HTML_INDEX_NUM_ENTRIES = 40
 
 # If the GENERATE_DOCSET tag is set to YES, additional index files will be
 # generated that can be used as input for Apple's Xcode 3 integrated development

--- a/docs/api.md
+++ b/docs/api.md
@@ -156,6 +156,7 @@ if (element.isa<SVGCircleElement>()) {
 
 | DOM Type                                   | XML Tag Name            |
 | ------------------------------------------ | ----------------------- |
+| \ref donner::svg::SVGAElement              | \ref xml_a              |
 | \ref donner::svg::SVGCircleElement         | \ref xml_circle         |
 | \ref donner::svg::SVGClipPathElement       | \ref xml_clipPath       |
 | \ref donner::svg::SVGDefsElement           | \ref xml_defs           |
@@ -182,6 +183,7 @@ if (element.isa<SVGCircleElement>()) {
 | \ref donner::svg::SVGStopElement           | \ref xml_stop           |
 | \ref donner::svg::SVGStyleElement          | \ref xml_style          |
 | \ref donner::svg::SVGSVGElement            | \ref xml_svg            |
+| \ref donner::svg::SVGSwitchElement         | \ref xml_switch         |
 | \ref donner::svg::SVGSymbolElement         | \ref xml_symbol         |
 | \ref donner::svg::SVGTextElement           | \ref xml_text           |
 | \ref donner::svg::SVGTextPathElement       | \ref xml_textPath       |

--- a/docs/build_report.md
+++ b/docs/build_report.md
@@ -1,4 +1,4 @@
-# Donner Build Report
+# Donner Build Report {#DonnerBuildReport}
 
 Generated with: tools/generate_build_report.py --all --save docs/build_report.md
 

--- a/docs/design_docs/README.md
+++ b/docs/design_docs/README.md
@@ -1,9 +1,19 @@
-# Donner Design Docs
+# Donner Design Docs {#DonnerDesignDocs}
 
 This directory holds every design doc for the Donner project, numbered
 ADR-style in the order they were first written. New docs append the next
 free number — `NNNN-short_name.md` — and existing numbers never change once
 assigned, so external references stay stable.
+
+## Tree Groups
+
+- \subpage DesignDocsCoreArchitecture
+- \subpage DesignDocsRendering
+- \subpage DesignDocsText
+- \subpage DesignDocsEditor
+- \subpage DesignDocsTesting
+- \subpage DesignDocsReleases
+- \subpage DesignDocsTooling
 
 **On number collisions.**
 
@@ -16,19 +26,18 @@ assigned, so external references stay stable.
   doc keeps its bare `NNNN-` form so external links stay stable. No
   renumbering, no history rewrite.
 
-For how Donner's runtime is organized and documented, start with the
-[Developer Docs](../developer_docs.md). Design docs capture _why_ a piece
-of the system looks the way it does (or will look). Developer docs describe
+For how Donner's runtime is organized and documented, start with \ref DeveloperDocs. Design docs
+capture _why_ a piece of the system looks the way it does (or will look). Developer docs describe
 _what_ ships today.
 
 ## Workflow
 
-1. **Draft (Status: Draft)** — Use [`design_template.md`](design_template.md).
+1. **Draft (Status: Draft)** — Use `docs/design_docs/design_template.md`.
    Goals, non-goals, open questions, a first pass at the implementation plan.
 2. **In Progress** — Mark TODOs in the implementation plan. Check them off as
    milestones land. The doc is the single source of truth for "where is this?"
 3. **Shipped / Implemented** — Write the developer-facing documentation the
-   design earned (a new explainer via [`developer_template.md`](developer_template.md),
+   design earned (a new explainer via `docs/design_docs/developer_template.md`,
    or content folded into `../developer_docs.md`). **Never delete the design doc
    or recycle its number.** Instead, rewrite it in place into a short summary:
    set Status to `Implemented`, briefly describe what the design was, and link
@@ -40,13 +49,13 @@ _what_ ships today.
    history, but their output should be concrete decisions, review findings, and
    follow-up actions.
 
-See [`AGENTS.md`](AGENTS.md) in this directory for more detail on the
+See `docs/design_docs/AGENTS.md` for more detail on the
 conventions automated agents should follow when editing design docs.
 
 ## Templates
 
-- [`design_template.md`](design_template.md) — in-flight designs
-- [`developer_template.md`](developer_template.md) — shipped features
+- `design_template.md` — in-flight designs
+- `developer_template.md` — shipped features
 - [`retrospective_template.md`](retrospective_template.md) — bug/workstream retrospectives
 
 ## Document Index
@@ -125,11 +134,11 @@ conventions automated agents should follow when editing design docs.
 Once a design ships and stabilizes, its runtime surface is documented in the
 developer-facing tree under [`docs/`](../). Especially relevant entry points:
 
-- [Developer Docs index](../developer_docs.md) — top-level Doxygen landing
-- [System architecture](../architecture.md)
-- [ECS overview](../ecs.md)
-- [Coding style](../coding_style.md)
-- [Building Donner](../building.md)
-- [Devtools](../devtools.md)
-- [Project roadmap](../ProjectRoadmap.md)
-- [Release checklist](../release_checklist.md)
+- \ref DeveloperDocs — top-level Doxygen landing
+- \ref SystemArchitecture
+- \ref EcsArchitecture
+- \ref CodingStyle
+- \ref BuildingDonner
+- \ref Devtools
+- \ref DonnerProjectRoadmap
+- \ref ReleaseChecklist

--- a/docs/design_docs/navigation.dox
+++ b/docs/design_docs/navigation.dox
@@ -1,0 +1,116 @@
+/**
+@page DesignDocsCoreArchitecture Core Architecture and DOM
+
+\details Core runtime architecture, DOM behavior, parsing, resource loading, and scripting designs.
+
+- \subpage md_docs_2design__docs_20004-external__svg__references
+- \subpage md_docs_2design__docs_20005-incremental__invalidation
+- \subpage md_docs_2design__docs_20019-css__token__stream
+- \subpage md_docs_2design__docs_20027-2-scripting
+- \subpage md_docs_2design__docs_20033-multithreading__and__dom__lifetime
+*/
+
+/**
+@page DesignDocsRendering Rendering, Filters, and Backends
+
+\details Rendering architecture, backend work, filters, GPU conformance, and rendering bug
+investigations.
+
+- \subpage md_docs_2design__docs_20003-renderer__interface__design
+- \subpage md_docs_2design__docs_20014-filter__performance
+- \subpage md_docs_2design__docs_20017-geode__renderer
+- \subpage md_docs_2design__docs_20025-composited__rendering
+- \subpage md_docs_2design__docs_20027-tight__bounded__segments
+- \subpage md_docs_2design__docs_20028-2-tinyskia__premul__internal
+- \subpage md_docs_2design__docs_20030-geode__performance
+- \subpage md_docs_2design__docs_20034-progressive__rendering
+- \subpage md_docs_2design__docs_20035-filter__layer__compose__offset__bug
+- \subpage md_docs_2design__docs_20037-geode__presentation__glitch__investigation
+- \subpage md_docs_2design__docs_20041-geode__analytical__aa
+- \subpage md_docs_2design__docs_20042-geode__slug__conformance
+*/
+
+/**
+@page DesignDocsText Text, CSS, and Fonts
+
+\details Text rendering, font loading, shaping, and text-backend references.
+
+- \subpage md_docs_2design__docs_20006-color__emoji
+- \subpage md_docs_2design__docs_20008-css__fonts
+- \subpage md_docs_2design__docs_20010-text__rendering
+- \subpage md_docs_2design__docs_20038-geode__tinyskia__text__parity
+- \subpage md_docs_2design__docs_2text_20052-overview
+- \subpage md_docs_2design__docs_2text_20052-2-architecture
+- \subpage md_docs_2design__docs_2text_20052-3-rtl__and__complex__scripts
+- \subpage md_docs_2design__docs_2text_20052-4-testing
+- \subpage md_docs_2design__docs_2text_20052-5-text__backend__refactor
+- \subpage md_docs_2design__docs_2text_20052-6-text__v1__release
+- \subpage md_docs_2design__docs_2text_20052-7-textpath
+*/
+
+/**
+@page DesignDocsEditor Editor and Interaction
+
+\details Editor architecture, interaction design, replay files, source focus, and authoring tools.
+
+- \subpage md_docs_2design__docs_20020-editor
+- \subpage md_docs_2design__docs_20023-editor__sandbox
+- \subpage md_docs_2design__docs_20025-2-editor__ux
+- \subpage md_docs_2design__docs_20026-2-drag__end__latency
+- \subpage md_docs_2design__docs_20029-ui__input__repro
+- \subpage md_docs_2design__docs_20033-2-editor__design__tool__responsiveness
+- \subpage md_docs_2design__docs_20039-text__editor__focus__and__flash
+- \subpage md_docs_2design__docs_20040-semantic__text__completion
+- \subpage md_docs_2design__docs_20041-2-path__authoring__and__boolean__operations
+- \subpage md_docs_2design__docs_20044-2-editor__fluid__canvas__rendering
+- \subpage md_docs_2design__docs_20045-editor__geode__chrome__migration
+- \subpage md_docs_2design__docs_20046-editor__group__layers
+- \subpage md_docs_2design__docs_20049-structured__text__editing
+- \subpage md_docs_2design__docs_20050-text__editor__behavior
+- \subpage md_docs_2design__docs_20051-text__editor__refactor
+*/
+
+/**
+@page DesignDocsTesting Testing, CI, and Conformance
+
+\details Test infrastructure, CI hardening, fuzzing, coverage, resvg tracking, and conformance
+planning.
+
+- \subpage md_docs_2design__docs_20002-mcp__test__triage__server
+- \subpage md_docs_2design__docs_20007-coverage__improvement__plan
+- \subpage md_docs_2design__docs_20009-resvg__test__suite__bugs
+- \subpage md_docs_2design__docs_20012-continuous__fuzzing
+- \subpage md_docs_2design__docs_20013-coverage__improvement
+- \subpage md_docs_2design__docs_20016-ci__escape__prevention
+- \subpage md_docs_2design__docs_20021-resvg__feature__gaps
+- \subpage md_docs_2design__docs_20022-resvg__test__suite__upgrade
+- \subpage md_docs_2design__docs_20026-svg__conformance__testing
+- \subpage md_docs_2design__docs_20029-2-ci__runtime
+- \subpage md_docs_2design__docs_20031-ci__hardening__2026q2
+- \subpage md_docs_2design__docs_20043-deterministic__replay__testing
+- \subpage md_docs_2design__docs_20044-coverage__improvement__2026q2
+*/
+
+/**
+@page DesignDocsReleases Releases and Planning
+
+\details Release planning, distribution, roadmaps, and issue planning.
+
+- \subpage md_docs_2design__docs_20011-v0__5__release
+- \subpage md_docs_2design__docs_20018-bcr__release
+- \subpage md_docs_2design__docs_20024-proposed__issues__2026q2
+- \subpage md_docs_2design__docs_20028-v1__0__release
+- \subpage md_docs_2design__docs_20047-v0__8__showcase
+*/
+
+/**
+@page DesignDocsTooling Tooling, Process, and Retrospectives
+
+\details Developer tooling, process notes, branch management, templates, and retrospectives.
+
+- \subpage TerminalImageViewerDesign
+- \subpage md_docs_2design__docs_20032-sandbox__branch__split
+- \subpage md_docs_2design__docs_20036-composited__presentation__retrospective
+- \subpage md_docs_2design__docs_20048-design__doc__hygiene
+- \subpage md_docs_2design__docs_2retrospective__template
+*/

--- a/docs/developer_docs.md
+++ b/docs/developer_docs.md
@@ -4,34 +4,14 @@
 
 ## Table of Contents
 
-- \subpage SystemArchitecture
-- \subpage CodingStyle
-- \subpage EcsArchitecture
-  - List of \subpage ecs_systems APIs
-- \subpage BuildingDonner
-- \subpage Maintenance
-- \subpage Devtools
-- \subpage EditorArchitecture
-- \subpage EditorVisualDebugging
-- \subpage EditorSourceFocus
-- \subpage StructuredSourceEditing
-- \subpage DeterministicReplayTesting
-- \subpage AgentRoster
-- \subpage TerminalImageViewerGuide
-- \subpage ReSvgTestSuite
-- \subpage DataFormats
-- \subpage DonnerProjectRoadmap
-- \subpage FilterEffectsGuide
-- \subpage ParserDiagnostics
-- \subpage CompileTimeMap
-- \subpage Multithreading
-- \subpage DomElementLifetime
+- \subpage DeveloperArchitectureDocs
+- \subpage BuildAndMaintenanceDocs
+- \subpage DeveloperToolsDocs
+- \subpage ProjectPlanningDocs
 
 ## Design Docs
 
-Historical and in-flight design docs live under
-[`docs/design_docs/`](design_docs/README.md). Each one is numbered ADR-style
-(`NNNN-short_name.md`) in the order it was first written. The
-[design-docs index](design_docs/README.md) lists every doc with status and a
-one-line summary, and is the right place to start when you want to know _why_
-a subsystem looks the way it does.
+Historical and in-flight design docs live under \ref DonnerDesignDocs. Each one is numbered
+ADR-style (`NNNN-short_name.md`) in the order it was first written. The
+\ref DonnerDesignDocs "design-docs index" lists every doc with status and a one-line summary, and
+is the right place to start when you want to know _why_ a subsystem looks the way it does.

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -53,7 +53,7 @@ tools/cloc.sh
 
 ## Editor Visual Debugging
 
-Use \subpage EditorVisualDebugging for the editor replay harness, Geode
+Use \ref EditorVisualDebugging for the editor replay harness, Geode
 direct-texture diagnostics, pixel comparisons, and root-cause patterns for
 one-frame visual bugs.
 

--- a/docs/ecs.md
+++ b/docs/ecs.md
@@ -129,7 +129,7 @@ circle {
 ```
 
 \htmlonly
-<svg width="200" height="100" viewbox="0 0 200 100">
+<svg width="200" height="100" viewBox="0 0 200 100">
 
 <style>
   circle {

--- a/docs/elements_filters.dox
+++ b/docs/elements_filters.dox
@@ -14,9 +14,12 @@ The filter container element:
 
 # Filter Primitives
 
-All 17 SVG filter primitives are supported. Primitives are composed into a graph via the
-`in`, `in2`, and `result` attributes defined on
+All 17 SVG filter primitives have parser-backed DOM wrappers and renderer support. Most primitives
+are composed into a graph via the `in`, `in2`, and `result` attributes defined on
 \ref donner::svg::SVGFilterPrimitiveStandardAttributes "SVGFilterPrimitiveStandardAttributes".
+Source primitives such as \ref xml_feFlood, \ref xml_feTurbulence, and \ref xml_feImage generate
+their own output; their source comes from attributes such as `flood-color`, procedural noise
+settings, or `href` rather than from an input image.
 
 ## Blur, Shadow, and Geometry
 

--- a/docs/elements_media_and_style.dox
+++ b/docs/elements_media_and_style.dox
@@ -1,0 +1,12 @@
+/**
+@page elements_media_and_style Elements: Media and Styling
+
+\details Media and styling elements provide document-level stylesheets and externally referenced
+image content.
+
+The following media and styling elements are supported:
+
+- \subpage xml_image (\ref donner::svg::SVGImageElement "SVGImageElement")
+- \subpage xml_style (\ref donner::svg::SVGStyleElement "SVGStyleElement")
+
+*/

--- a/docs/elements_structural.dox
+++ b/docs/elements_structural.dox
@@ -9,9 +9,11 @@ and containers.
 The following structural elements are supported:
 
 - \subpage xml_svg (\ref donner::svg::SVGSVGElement "SVGSVGElement")
+- \subpage xml_a (\ref donner::svg::SVGAElement "SVGAElement")
 - \subpage xml_g (\ref donner::svg::SVGGElement "SVGGElement")
 - \subpage xml_defs (\ref donner::svg::SVGDefsElement "SVGDefsElement")
 - \subpage xml_use (\ref donner::svg::SVGUseElement "SVGUseElement")
+- \subpage xml_switch (\ref donner::svg::SVGSwitchElement "SVGSwitchElement")
 - \subpage xml_symbol (\ref donner::svg::SVGSymbolElement "SVGSymbolElement")
 
 */

--- a/docs/guides/embedding_geode.md
+++ b/docs/guides/embedding_geode.md
@@ -1,4 +1,4 @@
-# Embedding Geode in a host application
+# Embedding Geode in a host application {#EmbeddingGeode}
 
 Geode is Donner's GPU-native SVG rendering backend. In most uses it runs
 **headless** and owns its own `wgpu::Device`, but the public API also supports

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -37,11 +37,9 @@ Detailed docs: \ref svg_tree_interaction.cc
 
 ## Documentation
 
-- \subpage GettingStarted
+- \subpage Documentation
 - \ref DonnerAPI
-- \subpage SvgDomThreadingAndLifetime
 - [Examples](examples.html)
-- \subpage DeveloperDocs
 
 ## Project Goals
 
@@ -52,7 +50,7 @@ Detailed docs: \ref svg_tree_interaction.cc
 ## Status
 
 - [Project Status](https://github.com/jwmcglynn/donner/issues/149) (github)
-- [Build Report](build_report.md)
+- \ref DonnerBuildReport
 
 ## Building
 

--- a/docs/site_navigation.dox
+++ b/docs/site_navigation.dox
@@ -1,0 +1,121 @@
+/**
+@page Documentation Documentation
+
+\details The Doxygen tree is organized by audience and task. Public guides and API references are
+kept separate from project-internal developer notes, design history, tooling, and reports.
+
+- \subpage UserGuides
+- \subpage ApiReference
+- \subpage DeveloperDocs
+*/
+
+/**
+@page UserGuides User Guides
+
+\details Start here when embedding Donner or using the SVG DOM from an application.
+
+- \subpage GettingStarted
+- \subpage SvgDomThreadingAndLifetime
+- \subpage UnsupportedSvg1Features
+*/
+
+/**
+@page ApiReference API Reference
+
+\details Public API guides and generated reference pages.
+
+- \subpage DonnerAPI
+- \subpage CssArchitecture
+- \subpage SvgElementReference
+*/
+
+/**
+@page SvgElementReference SVG Element Reference
+
+\details Supported SVG element documentation grouped by element family.
+
+- \subpage elements_structural
+- \subpage elements_basic_shapes
+- \subpage elements_text
+- \subpage elements_painting
+- \subpage elements_masking_clipping
+- \subpage elements_filters
+- \subpage elements_media_and_style
+*/
+
+/**
+@page DeveloperArchitectureDocs Architecture and Runtime
+
+\details Internal architecture, runtime behavior, and subsystem reference material.
+
+- \subpage SystemArchitecture
+- \subpage EcsArchitecture
+  - \subpage ecs_systems
+- \subpage Multithreading
+- \subpage DomElementLifetime
+- \subpage DataFormats
+- \subpage FilterEffectsGuide
+- \subpage CompileTimeMap
+- \subpage EmbeddingGeode
+*/
+
+/**
+@page BuildAndMaintenanceDocs Build and Maintenance
+
+\details Local development, style, and maintenance procedures.
+
+- \subpage CodingStyle
+- \subpage BuildingDonner
+- \subpage Maintenance
+*/
+
+/**
+@page DeveloperToolsDocs Developer Tools
+
+\details Debugging, diagnostics, test tools, and editor-specific developer references.
+
+- \subpage Devtools
+- \subpage ParserDiagnostics
+- \subpage AgentRoster
+- \subpage ToolDocs
+- \subpage EditorDocs
+*/
+
+/**
+@page ToolDocs Tools and Test Suites
+
+\details Command-line tools and testing utilities used during development.
+
+- \subpage DonnerSvgTool
+- \subpage TerminalImageViewerGuide
+- \subpage ReSvgTestSuite
+*/
+
+/**
+@page EditorDocs Editor
+
+\details Donner editor application documentation and visual debugging workflows.
+
+- \subpage md_donner_2editor_2README
+- \subpage md_donner_2editor_2repro_2README
+- \subpage EditorSourceFocus
+- \subpage EditorVisualDebugging
+*/
+
+/**
+@page ProjectPlanningDocs Project Planning
+
+\details Project status, roadmap, build reports, and historical design decisions.
+
+- \subpage DonnerProjectRoadmap
+- \subpage ProjectReports
+- \subpage DonnerDesignDocs
+*/
+
+/**
+@page ProjectReports Project Reports
+
+\details Generated project health reports.
+
+- \subpage DonnerBuildReport
+*/

--- a/docs/unsupported_svg1_features.md
+++ b/docs/unsupported_svg1_features.md
@@ -1,4 +1,4 @@
-# Unsupported SVG 1.1 Features
+# Unsupported SVG 1.1 Features {#UnsupportedSvg1Features}
 
 Donner targets **SVG 2** conformance. The following SVG 1.1 features are deprecated or removed
 in SVG 2 and are intentionally not implemented.

--- a/donner/svg/SVGAElement.h
+++ b/donner/svg/SVGAElement.h
@@ -9,7 +9,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_a "<a>"
+ * @page xml_a &lt;a&gt;
  *
  * The `<a>` element creates a hyperlink around its child content. It is a transparent grouping
  * container: it draws nothing of its own and does not establish a new coordinate system, but its
@@ -26,6 +26,19 @@ namespace donner::svg {
  *
  * The link target is given by `href` (or the legacy `xlink:href`). Donner has no interactive
  * navigation, so the target is parsed and retained but does not affect rendering.
+ *
+ * ## Attributes
+ *
+ * | Attribute      | Default | Description |
+ * | -------------: | :-----: | :---------- |
+ * | `href`         | (none)  | Link target retained on the DOM element. `xlink:href` is accepted as an alias. |
+ * | `x`            | `0`     | Absolute X position(s) when the link participates in SVG text layout. |
+ * | `y`            | `0`     | Absolute Y position(s) when the link participates in SVG text layout. |
+ * | `dx`           | (none)  | Relative X shift(s) for linked text glyphs. |
+ * | `dy`           | (none)  | Relative Y shift(s) for linked text glyphs. |
+ * | `rotate`       | (none)  | Rotation values for linked text glyphs, in degrees. |
+ * | `textLength`   | (none)  | Author-specified total advance length for linked text. |
+ * | `lengthAdjust` | `spacing` | `spacing` or `spacingAndGlyphs` adjustment mode. |
  *
  * ```svg
  * <text x="20" y="40">

--- a/donner/svg/SVGCircleElement.h
+++ b/donner/svg/SVGCircleElement.h
@@ -7,7 +7,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_circle "<circle>"
+ * @page xml_circle &lt;circle&gt;
  *
  * Creates a circle centered on `cx`, `cy`, with radius `r`.
  *

--- a/donner/svg/SVGClipPathElement.h
+++ b/donner/svg/SVGClipPathElement.h
@@ -7,7 +7,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_clipPath "<clipPath>"
+ * @page xml_clipPath &lt;clipPath&gt;
  *
  * Defines a clipping path, which is used to clip the rendering of other elements using paths and
  * shapes. The clipping path is defined by the child elements of this element. Compared to

--- a/donner/svg/SVGDefsElement.h
+++ b/donner/svg/SVGDefsElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_defs "<defs>"
+ * @page xml_defs &lt;defs&gt;
  *
  * Container for \b definitions of reusable graphics elements. It is not rendered directly,
  * but its child elements can be referenced by a \ref xml_use or within a `fill` or `stroke`.

--- a/donner/svg/SVGEllipseElement.h
+++ b/donner/svg/SVGEllipseElement.h
@@ -7,7 +7,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_ellipse "<ellipse>"
+ * @page xml_ellipse &lt;ellipse&gt;
  *
  * Creates an ellipse centered on `cx`, `cy`, with radius `rx` and `ry`.
  *

--- a/donner/svg/SVGFEBlendElement.h
+++ b/donner/svg/SVGFEBlendElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_feBlend "<feBlend>"
+ * @page xml_feBlend &lt;feBlend&gt;
  *
  * `<feBlend>` combines two inputs using a blend mode, similar to the layer blend modes in
  * Photoshop, GIMP, or Figma. The result takes the colors of `in` (the "top" layer) and `in2`

--- a/donner/svg/SVGFEColorMatrixElement.h
+++ b/donner/svg/SVGFEColorMatrixElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_feColorMatrix "<feColorMatrix>"
+ * @page xml_feColorMatrix &lt;feColorMatrix&gt;
  *
  * Defines a filter primitive that applies a matrix transformation on color values.
  *

--- a/donner/svg/SVGFEComponentTransferElement.h
+++ b/donner/svg/SVGFEComponentTransferElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_feComponentTransfer "<feComponentTransfer>"
+ * @page xml_feComponentTransfer &lt;feComponentTransfer&gt;
  *
  * Defines a filter primitive that applies per-channel transfer functions (lookup tables)
  * to modify the RGBA components of the input image.

--- a/donner/svg/SVGFECompositeElement.h
+++ b/donner/svg/SVGFECompositeElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_feComposite "<feComposite>"
+ * @page xml_feComposite &lt;feComposite&gt;
  *
  * `<feComposite>` merges two inputs (`in` and `in2`) into a single output using a
  * **Porter-Duff compositing operator**. Unlike \ref xml_feBlend, which mixes the *colors* of
@@ -170,7 +170,7 @@ namespace donner::svg {
  * | ---------: | :--------: | :---------- |
  * | `in`       | *previous* | First input (A). |
  * | `in2`      | *(none)*   | Second input (B). Required. |
- * | `operator` | `over`     | One of `over`, `in`, `out`, `atop`, `xor`, `arithmetic`. |
+ * | `operator` | `over`     | One of `over`, `in`, `out`, `atop`, `xor`, `lighter`, `arithmetic`. |
  * | `k1`       | `0`        | Arithmetic coefficient. Only used when `operator="arithmetic"`. |
  * | `k2`       | `0`        | Arithmetic coefficient. Only used when `operator="arithmetic"`. |
  * | `k3`       | `0`        | Arithmetic coefficient. Only used when `operator="arithmetic"`. |

--- a/donner/svg/SVGFEConvolveMatrixElement.h
+++ b/donner/svg/SVGFEConvolveMatrixElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_feConvolveMatrix "<feConvolveMatrix>"
+ * @page xml_feConvolveMatrix &lt;feConvolveMatrix&gt;
  *
  * `<feConvolveMatrix>` applies a **convolution kernel** to the input image. It's the
  * general-purpose primitive behind blur, sharpen, edge detection, emboss, and countless other
@@ -36,7 +36,7 @@ namespace donner::svg {
  * amplifies local differences (sharpen); a kernel that subtracts opposite neighbours highlights
  * intensity gradients (edge detect).
  *
- * ## A critical gotcha: always set `divisor` explicitly
+ * ## A critical gotcha: always set divisor explicitly
  *
  * If you omit the `divisor` attribute, the default is the **sum of the kernel values**.
  * For a Laplacian-style edge-detect kernel like `0 -1 0 / -1 4 -1 / 0 -1 0`, that sum is
@@ -218,8 +218,10 @@ namespace donner::svg {
  * | `targetX`       | `floor(order.x / 2)`     | Which column of the kernel aligns with the output pixel. |
  * | `targetY`       | `floor(order.y / 2)`     | Which row of the kernel aligns with the output pixel. |
  * | `edgeMode`      | `duplicate`              | How pixels outside the input are sampled: `duplicate` (extend edge pixels), `wrap` (tile), or `none` (treat as transparent black). |
- * | `kernelUnitLength` | `1 1`                 | Physical size of one kernel cell in the user coordinate system. Allows resolution-independent kernels. |
  * | `preserveAlpha` | `false`                  | If `true`, the alpha channel is copied through unchanged and convolution only affects RGB. |
+ *
+ * `kernelUnitLength` is not implemented; kernel cells are evaluated at the renderer's filter
+ * sample spacing.
  *
  * Inherits standard filter primitive attributes (`in`, `result`, `x`, `y`, `width`, `height`)
  * from \ref donner::svg::SVGFilterPrimitiveStandardAttributes.

--- a/donner/svg/SVGFEDiffuseLightingElement.h
+++ b/donner/svg/SVGFEDiffuseLightingElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_feDiffuseLighting "<feDiffuseLighting>"
+ * @page xml_feDiffuseLighting &lt;feDiffuseLighting&gt;
  *
  * `<feDiffuseLighting>` uses the input image's alpha channel as a **height map** - the more
  * opaque a pixel, the taller the imaginary "surface" at that spot - and then computes how a
@@ -275,8 +275,10 @@ namespace donner::svg {
  * | ------------------: | :-----: | :---------- |
  * | `surfaceScale`      | `1`     | Height multiplier applied to the alpha channel. Larger values make the bump appear taller. |
  * | `diffuseConstant`   | `1`     | Lambertian reflectance (kd). Overall brightness multiplier. |
- * | `kernelUnitLength`  | auto    | The step size used when computing surface normals. Two numbers, in filter coordinates. Defaults to one device pixel. |
  * | `lighting-color`    | `white` | Color of the light. Presentation attribute; can be set via CSS. |
+ *
+ * `kernelUnitLength` is not implemented; surface normals use the renderer's filter sample
+ * spacing.
  *
  * Inherits standard filter primitive attributes (`in`, `result`, `x`, `y`, `width`, `height`)
  * from \ref donner::svg::SVGFilterPrimitiveStandardAttributes.

--- a/donner/svg/SVGFEDisplacementMapElement.h
+++ b/donner/svg/SVGFEDisplacementMapElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_feDisplacementMap "<feDisplacementMap>"
+ * @page xml_feDisplacementMap &lt;feDisplacementMap&gt;
  *
  * Uses the pixel values from a second input to spatially displace the first input image.
  *

--- a/donner/svg/SVGFEDistantLightElement.h
+++ b/donner/svg/SVGFEDistantLightElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_feDistantLight "<feDistantLight>"
+ * @page xml_feDistantLight &lt;feDistantLight&gt;
  *
  * `<feDistantLight>` is a parallel light source - think of the sun. All its light rays are
  * parallel, so every pixel on the surface gets hit at the same angle, and the light has no

--- a/donner/svg/SVGFEDropShadowElement.h
+++ b/donner/svg/SVGFEDropShadowElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_feDropShadow "<feDropShadow>"
+ * @page xml_feDropShadow &lt;feDropShadow&gt;
  *
  * Defines a filter primitive that creates a drop shadow effect.
  *

--- a/donner/svg/SVGFEFloodElement.h
+++ b/donner/svg/SVGFEFloodElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_feFlood "<feFlood>"
+ * @page xml_feFlood &lt;feFlood&gt;
  *
  * \htmlonly
  * <style>.donner-fe-fig { background-color: white; font-family: sans-serif; font-size: 12px; }</style>
@@ -153,8 +153,9 @@ namespace donner::svg {
  * Note: the *region* filled by the flood is controlled by the standard primitive attributes
  * (`x`, `y`, `width`, `height`), **not** by these attributes.
  *
- * Inherits standard filter primitive attributes (`in`, `result`, `x`, `y`, `width`, `height`)
- * from \ref donner::svg::SVGFilterPrimitiveStandardAttributes.
+ * Uses the standard filter primitive region and naming attributes (`result`, `x`, `y`, `width`,
+ * `height`) from \ref donner::svg::SVGFilterPrimitiveStandardAttributes. The primitive generates
+ * its own pixels, so `in` / `in2` are not sampled.
  */
 
 /**

--- a/donner/svg/SVGFEFuncAElement.h
+++ b/donner/svg/SVGFEFuncAElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_feFuncA "<feFuncA>"
+ * @page xml_feFuncA &lt;feFuncA&gt;
  *
  * A child element of \ref xml_feComponentTransfer defining the transfer function for the alpha
  * channel.

--- a/donner/svg/SVGFEFuncBElement.h
+++ b/donner/svg/SVGFEFuncBElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_feFuncB "<feFuncB>"
+ * @page xml_feFuncB &lt;feFuncB&gt;
  *
  * A child element of \ref xml_feComponentTransfer defining the transfer function for the blue
  * channel.

--- a/donner/svg/SVGFEFuncGElement.h
+++ b/donner/svg/SVGFEFuncGElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_feFuncG "<feFuncG>"
+ * @page xml_feFuncG &lt;feFuncG&gt;
  *
  * A child element of \ref xml_feComponentTransfer defining the transfer function for the green
  * channel.

--- a/donner/svg/SVGFEFuncRElement.h
+++ b/donner/svg/SVGFEFuncRElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_feFuncR "<feFuncR>"
+ * @page xml_feFuncR &lt;feFuncR&gt;
  *
  * A child element of \ref xml_feComponentTransfer defining the transfer function for the red
  * channel.

--- a/donner/svg/SVGFEGaussianBlurElement.h
+++ b/donner/svg/SVGFEGaussianBlurElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_feGaussianBlur "<feGaussianBlur>"
+ * @page xml_feGaussianBlur &lt;feGaussianBlur&gt;
  *
  * Defines a filter primitive that performs a gaussian blur on the input image.
  *

--- a/donner/svg/SVGFEImageElement.h
+++ b/donner/svg/SVGFEImageElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_feImage "<feImage>"
+ * @page xml_feImage &lt;feImage&gt;
  *
  * `<feImage>` imports an external image - or a fragment of the current document - into the
  * filter graph as an additional input. It's how you use a photograph as a lighting source,
@@ -21,7 +21,7 @@ namespace donner::svg {
  * - DOM object: SVGFEImageElement
  * - SVG2 spec: https://www.w3.org/TR/filter-effects/#feImageElement
  *
- * ## How `href` works
+ * ## How href works
  *
  * The `href` attribute accepts either:
  *
@@ -32,7 +32,7 @@ namespace donner::svg {
  *   document, e.g. `href="#myShape"`. The referenced element is rendered to its own bounding
  *   box, and the resulting pixels are handed to the filter as if they were an image.
  *
- * ## How `preserveAspectRatio` works
+ * ## How preserveAspectRatio works
  *
  * When the source image's aspect ratio doesn't match the destination rectangle (the filter
  * primitive subregion), `preserveAspectRatio` decides whether to stretch, letterbox, or crop
@@ -199,10 +199,10 @@ namespace donner::svg {
  * | --------------------: | :-------------: | :---------- |
  * | `href`                | (none)          | URL or in-document fragment reference (`#id`) for the source image. |
  * | `preserveAspectRatio` | `xMidYMid meet` | How the source is fitted into the primitive subregion when aspect ratios differ. See above. |
- * | `crossorigin`         | (none)          | CORS setting for external URL loads (`anonymous` or `use-credentials`). |
  *
- * Inherits standard filter primitive attributes (`in`, `result`, `x`, `y`, `width`, `height`)
- * from \ref donner::svg::SVGFilterPrimitiveStandardAttributes.
+ * Uses the standard filter primitive region and naming attributes (`result`, `x`, `y`, `width`,
+ * `height`) from \ref donner::svg::SVGFilterPrimitiveStandardAttributes. The source comes from
+ * `href`, so `in` / `in2` are not used by the renderer for this primitive.
  */
 
 /**

--- a/donner/svg/SVGFEMergeElement.h
+++ b/donner/svg/SVGFEMergeElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_feMerge "<feMerge>"
+ * @page xml_feMerge &lt;feMerge&gt;
  *
  * `<feMerge>` stacks multiple filter results on top of each other like layers in an image
  * editor, producing a final composite. It takes **zero direct attributes of its own** - instead,

--- a/donner/svg/SVGFEMergeNodeElement.h
+++ b/donner/svg/SVGFEMergeNodeElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_feMergeNode "<feMergeNode>"
+ * @page xml_feMergeNode &lt;feMergeNode&gt;
  *
  * `<feMergeNode>` is a child of \ref xml_feMerge that names **one layer** to stack. Each
  * `<feMergeNode>` references a named filter result via its `in` attribute, and the parent
@@ -81,7 +81,13 @@ namespace donner::svg {
  *
  * | Attribute | Default       | Description |
  * | --------: | :-----------: | :---------- |
- * | `in`      | *previous*    | Name of the filter result to use as this layer. Either a `result` name defined earlier in the same `<filter>`, or one of the standard sources `SourceGraphic`, `SourceAlpha`, `BackgroundImage`, `BackgroundAlpha`, `FillPaint`, `StrokePaint`. |
+ * | `in`      | *previous*    | Filter result name or implemented standard source keyword. |
+ *
+ * Implemented standard source keywords are `SourceGraphic`, `SourceAlpha`, `FillPaint`, and
+ * `StrokePaint`.
+ *
+ * \note SVG 1.1 `BackgroundImage` and `BackgroundAlpha` filter inputs are not implemented; see
+ *       \ref UnsupportedSvg1Features.
  *
  * \note Unlike most filter primitives, `<feMergeNode>` **does not** inherit the standard
  *       filter primitive attributes. It has no `x`, `y`, `width`, `height`, or `result`

--- a/donner/svg/SVGFEMorphologyElement.h
+++ b/donner/svg/SVGFEMorphologyElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_feMorphology "<feMorphology>"
+ * @page xml_feMorphology &lt;feMorphology&gt;
  *
  * Defines a filter primitive that erodes or dilates the input image.
  *

--- a/donner/svg/SVGFEOffsetElement.h
+++ b/donner/svg/SVGFEOffsetElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_feOffset "<feOffset>"
+ * @page xml_feOffset &lt;feOffset&gt;
  *
  * Defines a filter primitive that offsets the input image by (dx, dy).
  *

--- a/donner/svg/SVGFEPointLightElement.h
+++ b/donner/svg/SVGFEPointLightElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_fePointLight "<fePointLight>"
+ * @page xml_fePointLight &lt;fePointLight&gt;
  *
  * `<fePointLight>` is a positional light source - think of a bare light bulb floating in space.
  * It emits light in all directions from a single `(x, y, z)` point in the filter's coordinate

--- a/donner/svg/SVGFESpecularLightingElement.h
+++ b/donner/svg/SVGFESpecularLightingElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_feSpecularLighting "<feSpecularLighting>"
+ * @page xml_feSpecularLighting &lt;feSpecularLighting&gt;
  *
  * `<feSpecularLighting>` is the shiny-highlight companion of \ref xml_feDiffuseLighting.
  * Where diffuse lighting gives you the *matte* component of the Phong reflection model - the
@@ -253,8 +253,10 @@ namespace donner::svg {
  * | `surfaceScale`      | `1`     | Height multiplier applied to the alpha channel. |
  * | `specularConstant`  | `1`     | Specular reflectance (ks). Overall highlight brightness. |
  * | `specularExponent`  | `1`     | Phong shininess exponent. Larger values give a tighter, sharper highlight. |
- * | `kernelUnitLength`  | auto    | The step size used when computing surface normals. Two numbers, in filter coordinates. Defaults to one device pixel. |
  * | `lighting-color`    | `white` | Color of the light. Presentation attribute; can be set via CSS. |
+ *
+ * `kernelUnitLength` is not implemented; surface normals use the renderer's filter sample
+ * spacing.
  *
  * Inherits standard filter primitive attributes (`in`, `result`, `x`, `y`, `width`, `height`)
  * from \ref donner::svg::SVGFilterPrimitiveStandardAttributes.

--- a/donner/svg/SVGFESpotLightElement.h
+++ b/donner/svg/SVGFESpotLightElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_feSpotLight "<feSpotLight>"
+ * @page xml_feSpotLight &lt;feSpotLight&gt;
  *
  * `<feSpotLight>` is a directional, cone-shaped light - think of a flashlight or a theatre
  * spotlight. It sits at a position `(x, y, z)` in filter coordinates, points at a target

--- a/donner/svg/SVGFETileElement.h
+++ b/donner/svg/SVGFETileElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_feTile "<feTile>"
+ * @page xml_feTile &lt;feTile&gt;
  *
  * Defines a filter primitive that tiles the input image across the output region.
  *

--- a/donner/svg/SVGFETurbulenceElement.h
+++ b/donner/svg/SVGFETurbulenceElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_feTurbulence "<feTurbulence>"
+ * @page xml_feTurbulence &lt;feTurbulence&gt;
  *
  * `<feTurbulence>` generates a procedural noise pattern using the Perlin turbulence algorithm.
  * It's the underlying primitive for paper textures, cloud effects, marbling, water distortions,
@@ -20,7 +20,7 @@ namespace donner::svg {
  * - DOM object: SVGFETurbulenceElement
  * - SVG2 spec: https://www.w3.org/TR/filter-effects/#feTurbulenceElement
  *
- * ## `baseFrequency` - the scale of noise features
+ * ## Base frequency: the scale of noise features
  *
  * Controls how "zoomed in" the noise is. Lower values produce larger blobs; higher values
  * produce finer grain. You can specify one number (same for X and Y) or two (separate X and Y
@@ -48,7 +48,7 @@ namespace donner::svg {
  * </svg>
  * \endhtmlonly
  *
- * ## `numOctaves` - how many layers of detail
+ * ## Number of octaves: how many layers of detail
  *
  * Each octave adds a finer layer of noise on top of the previous one. More octaves produces
  * richer, more natural-looking texture at the cost of more computation per pixel.
@@ -75,7 +75,7 @@ namespace donner::svg {
  * </svg>
  * \endhtmlonly
  *
- * ## `type` - turbulence vs fractalNoise
+ * ## Type: turbulence vs fractalNoise
  *
  * The two supported noise types have a visibly different character:
  *
@@ -101,7 +101,7 @@ namespace donner::svg {
  * </svg>
  * \endhtmlonly
  *
- * ## `seed` - choosing a different random pattern
+ * ## Seed: choosing a different random pattern
  *
  * Same frequency and octaves, different `seed`. The structure is identical but the specific
  * pattern of light and dark changes - use this when two identical noises would look too
@@ -124,7 +124,7 @@ namespace donner::svg {
  * </svg>
  * \endhtmlonly
  *
- * ## `stitchTiles` - tileable noise
+ * ## Stitch tiles: tileable noise
  *
  * Normally the noise doesn't line up at the edges of the primitive subregion, so if you tile
  * it you can see seams. Setting `stitchTiles="stitch"` adjusts the frequency slightly so the
@@ -184,8 +184,9 @@ namespace donner::svg {
  * | `stitchTiles`    | `noStitch`    | Either `noStitch` or `stitch`. `stitch` produces a seamlessly tileable result. |
  * | `type`           | `turbulence`  | Either `turbulence` (sharper, cloudier) or `fractalNoise` (softer). |
  *
- * Inherits standard filter primitive attributes (`in`, `result`, `x`, `y`, `width`, `height`)
- * from \ref donner::svg::SVGFilterPrimitiveStandardAttributes.
+ * Uses the standard filter primitive region and naming attributes (`result`, `x`, `y`, `width`,
+ * `height`) from \ref donner::svg::SVGFilterPrimitiveStandardAttributes. The primitive generates
+ * procedural noise, so `in` / `in2` are not sampled.
  */
 
 /**

--- a/donner/svg/SVGFilterElement.h
+++ b/donner/svg/SVGFilterElement.h
@@ -9,7 +9,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_filter "<filter>"
+ * @page xml_filter &lt;filter&gt;
  *
  * Defines filter effects which can be applied to graphical elements.
  *

--- a/donner/svg/SVGGElement.h
+++ b/donner/svg/SVGGElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_g "<g>"
+ * @page xml_g &lt;g&gt;
  *
  * Creates a group of elements which can be transformed as a single object.
  *

--- a/donner/svg/SVGImageElement.h
+++ b/donner/svg/SVGImageElement.h
@@ -8,7 +8,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_image "&lt;image&gt;"
+ * @page xml_image &lt;image&gt;
  *
  * Embeds an image into the SVG document.
  *
@@ -41,7 +41,7 @@ namespace donner::svg {
  * ```
  *
  * \htmlonly
- * <svg viewbox="-2 -2 18 18" width="300" height="300" xmlns="http://www.w3.org/2000/svg">
+ * <svg viewBox="-2 -2 18 18" width="300" height="300" xmlns="http://www.w3.org/2000/svg">
  *   <image style="image-rendering: pixelated" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQBAMAAADt3eJSAAAAFVBMVEUAAAAisUztHCSo5h3/8gD/fgBNbfOxiPXkAAAAAXRSTlMAQObYZgAAAD9JREFUCNdjwASMDIxABGIICEIZQAFBARADDOEMZMCkxMrAwmAMZCmwBrgwM4AZLCzMbAlABlCKmSEBrgYPAACkeQLx8K5PDQAAAABJRU5ErkJggg==" />
  * </svg>
  * \endhtmlonly

--- a/donner/svg/SVGLineElement.h
+++ b/donner/svg/SVGLineElement.h
@@ -7,7 +7,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_line "<line>"
+ * @page xml_line &lt;line&gt;
  *
  * Creates a line between two points, using the `x1`, `y1`, `x2`, and `y2` attributes.
  *

--- a/donner/svg/SVGLinearGradientElement.h
+++ b/donner/svg/SVGLinearGradientElement.h
@@ -9,7 +9,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_linearGradient "<linearGradient>"
+ * @page xml_linearGradient &lt;linearGradient&gt;
  *
  * Defines the paint server for a linear gradients.
  *

--- a/donner/svg/SVGMarkerElement.h
+++ b/donner/svg/SVGMarkerElement.h
@@ -11,7 +11,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_marker "<marker>"
+ * @page xml_marker &lt;marker&gt;
  *
  * Creates a marker element that can be used to define graphical objects that can be used repeatedly
  * in a drawing, such as arrowheads or other markers on paths.
@@ -58,9 +58,10 @@ namespace donner::svg {
  * | Attribute      | Default | Description  |
  * | -------------: | :-----: | :----------- |
  * | `viewBox` | (none)  | A list of four numbers (min-x, min-y, width, height) separated by whitespace and/or a comma, that specify a rectangle in userspace that should be mapped to the SVG viewport bounds established by the marker. |
- * | `preserveAspectRatio` | `xMidYMid meet` | How to scale the viewport to fit the content. Only applies is `viewBox` is specified. |
+ * | `preserveAspectRatio` | `xMidYMid meet` | How to scale the viewport to fit the content. Only applies if `viewBox` is specified. |
  * | `markerWidth`  | `3`     | Width of the marker viewport. |
  * | `markerHeight` | `3`     | Height of the marker viewport. |
+ * | `markerUnits`  | `strokeWidth` | Coordinate system for marker size and contents: `strokeWidth` or `userSpaceOnUse`. |
  * | `refX`         | `0`     | X coordinate for the reference point of the marker, where the marker is centered. |
  * | `refY`         | `0`     | Y coordinate for the reference point of the marker, where the marker is centered. |
  * | `orient`       | `0`     | Orientation of the marker relative to the path. Supported values: `auto`, `auto-start-reverse`, or an angle for a fixed rotation such as `45deg` or `3.14rad`. |

--- a/donner/svg/SVGMaskElement.h
+++ b/donner/svg/SVGMaskElement.h
@@ -7,7 +7,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_mask "<mask>"
+ * @page xml_mask &lt;mask&gt;
  *
  * Defines a mask, which is used to apply image-based visibility to graphical elements. Compared to
  * \ref xml_clipPath, which requires the contents to be paths, "<mask>" masking is performed based
@@ -47,7 +47,7 @@ namespace donner::svg {
  * This draws a green rectangle with a circle cut out of the middle of it.
  *
  * \htmlonly
- * <svg viewbox="-10 -10 120 120" width="300" height="300" style="background-color: white">
+ * <svg viewBox="-10 -10 120 120" width="300" height="300" style="background-color: white">
  *   <mask id="MyMask">
  *    <!-- Things under a white pixel will be drawn -->
  *    <rect x="0" y="0" width="100" height="100" fill="white" />

--- a/donner/svg/SVGPathElement.h
+++ b/donner/svg/SVGPathElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_path "<path>"
+ * @page xml_path &lt;path&gt;
  *
  * Defines a shape using a path, which can include straight lines, curves, and sub-paths.
  *

--- a/donner/svg/SVGPatternElement.h
+++ b/donner/svg/SVGPatternElement.h
@@ -14,7 +14,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_pattern "<pattern>"
+ * @page xml_pattern &lt;pattern&gt;
  *
  * Defines a paint server containing a repeated pattern, which is tiled to fill the area.
  *
@@ -164,7 +164,7 @@ namespace donner::svg {
  * | Attribute | Default | Description  |
  * | --------: | :-----: | :----------- |
  * | `viewBox` | (none)  | A list of four numbers (min-x, min-y, width, height) separated by whitespace and/or a comma, that specify a rectangle in userspace that should be mapped to the SVG viewport bounds established by the pattern. |
- * | `preserveAspectRatio` | `xMidYMid meet` | How to scale the viewport to fit the content. Only applies is `viewBox` is specified. |
+ * | `preserveAspectRatio` | `xMidYMid meet` | How to scale the viewport to fit the content. Only applies if `viewBox` is specified. |
  * | `x`       | `0`     | Defines the top-left X coordinate of a rectangle indicating how pattern tiles are placed and spread. The coordinate system is determined by the combination of the `patternUnits` and `patternTransform` attributes. |
  * | `y`       | `0`     | Defines the top-left Y coordinate of a rectangle indicating how pattern tiles are placed and spread. The coordinate system is determined by the combination of the `patternUnits` and `patternTransform` attributes. |
  * | `width`   | `0`     | Defines the width of a rectangle indicating how pattern tiles are placed and spread. The coordinate system is determined by the combination of the `patternUnits` and `patternTransform` attributes. |

--- a/donner/svg/SVGPolygonElement.h
+++ b/donner/svg/SVGPolygonElement.h
@@ -8,7 +8,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_polygon "<polygon>"
+ * @page xml_polygon &lt;polygon&gt;
  *
  * Creates a closed polygon with straight lines between the points, using the `points` attribute.
  *

--- a/donner/svg/SVGPolylineElement.h
+++ b/donner/svg/SVGPolylineElement.h
@@ -8,7 +8,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_polyline "<polyline>"
+ * @page xml_polyline &lt;polyline&gt;
  *
  * Creates a set of connected straight line segments, using the `points` attribute.
  *

--- a/donner/svg/SVGRadialGradientElement.h
+++ b/donner/svg/SVGRadialGradientElement.h
@@ -7,7 +7,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_radialGradient "<radialGradient>"
+ * @page xml_radialGradient &lt;radialGradient&gt;
  *
  * Defines the paint server for a radial gradients.
  *

--- a/donner/svg/SVGRectElement.h
+++ b/donner/svg/SVGRectElement.h
@@ -8,7 +8,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_rect "<rect>"
+ * @page xml_rect &lt;rect&gt;
  *
  * Creates a rectangle with the top-left corner at (`x`, `y`) and the specified `width` and
  * `height`, optionally with rounded corners.

--- a/donner/svg/SVGSVGElement.h
+++ b/donner/svg/SVGSVGElement.h
@@ -18,7 +18,7 @@ class SVGParser;
 }  // namespace parser
 
 /**
- * @page xml_svg "<svg>"
+ * @page xml_svg &lt;svg&gt;
  *
  * The root element of an SVG document.
  *

--- a/donner/svg/SVGStopElement.h
+++ b/donner/svg/SVGStopElement.h
@@ -7,7 +7,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_stop "<stop>"
+ * @page xml_stop &lt;stop&gt;
  *
  * Defines a color stop for a gradient. This is a child element of \ref
  * xml_linearGradient and \ref xml_radialGradient.

--- a/donner/svg/SVGStyleElement.h
+++ b/donner/svg/SVGStyleElement.h
@@ -8,7 +8,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_style "<style>"
+ * @page xml_style &lt;style&gt;
  *
  * Defines a CSS stylesheet for the document. Multiple \ref xml_style elements may be defined in a
  * single document, and the aggregate document style is computed from that using CSS cascading

--- a/donner/svg/SVGSwitchElement.h
+++ b/donner/svg/SVGSwitchElement.h
@@ -6,7 +6,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_switch "<switch>"
+ * @page xml_switch &lt;switch&gt;
  *
  * Conditional processing container: renders only the first direct child whose
  * conditional-processing attributes all evaluate to true.
@@ -14,14 +14,23 @@ namespace donner::svg {
  * - DOM object: SVGSwitchElement
  * - SVG2 spec: https://www.w3.org/TR/SVG2/struct.html#SwitchElement
  *
- * The `<switch>` element evaluates the conditional-processing attributes
- * (`requiredExtensions` and `systemLanguage`) on each of its direct children in document order,
- * and renders the first child for which all of them evaluate to true. Children without
- * conditional attributes evaluate to true, so a final unconditional child acts as a fallback.
- * Unknown (non-SVG) child elements are never selected.
+ * The `<switch>` element evaluates the conditional-processing attributes on each of its direct
+ * children in document order, and renders the first child for which all of them evaluate to true.
+ * Children without conditional attributes evaluate to true, so a final unconditional child acts
+ * as a fallback. Unknown (non-SVG) child elements are never selected.
  *
- * Aside from child selection, `<switch>` behaves like \ref xml_g: attributes such as `transform`
+ * Donner evaluates `systemLanguage` against the default user language `en`, treats a non-empty
+ * `requiredExtensions` list as unsupported, and ignores `requiredFeatures` because SVG2
+ * deprecates it.
+ *
+ * Aside from child selection, `<switch>` behaves like \ref xml_g; attributes such as `transform`
  * and `fill` set on it apply to the rendered child.
+ *
+ * ## Attributes
+ *
+ * `<switch>` has no element-specific attributes of its own. It uses standard SVG presentation
+ * attributes plus the common conditional-processing attributes `requiredFeatures`,
+ * `requiredExtensions`, and `systemLanguage`.
  *
  * ```xml
  * <switch>

--- a/donner/svg/SVGSymbolElement.h
+++ b/donner/svg/SVGSymbolElement.h
@@ -11,7 +11,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_symbol "&lt;symbol&gt;"
+ * @page xml_symbol &lt;symbol&gt;
  *
  * Defines a symbol element that can be used to define graphical templates which are not rendered
  * directly but can be instantiated by a \ref xml_use element. A symbol element establishes a nested

--- a/donner/svg/SVGTSpanElement.h
+++ b/donner/svg/SVGTSpanElement.h
@@ -9,7 +9,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_tspan "<tspan>"
+ * @page xml_tspan &lt;tspan&gt;
  *
  * The `<tspan>` element defines a sub-string or sub-group of text that can be independently
  * positioned or styled inside an SVG text flow. Common usage includes changing the color,
@@ -23,7 +23,9 @@ namespace donner::svg {
  * a `<tspan>` simply inherits the parent `<text>`'s styling; wrapping a portion in `<tspan>`
  * lets you override properties like `fill`, `font-weight`, or `font-size`, or explicitly move
  * that portion using the per-glyph positioning attributes `x`, `y`, `dx`, `dy`, and `rotate`.
- * `<tspan>` does not exist on its own - it must always be a descendant of `<text>`.
+ * Donner also supports the SVG text-length calibration attributes `textLength` and
+ * `lengthAdjust` on `<tspan>` runs. `<tspan>` does not exist on its own - it must always be a
+ * descendant of `<text>`.
  *
  * ```svg
  * <text x="20" y="40">
@@ -62,6 +64,8 @@ namespace donner::svg {
  * | `dx`      | (none)  | Relative X shift(s) for glyphs                       |
  * | `dy`      | (none)  | Relative Y shift(s) for glyphs                       |
  * | `rotate`  | (none)  | Rotation(s) for each glyph in degrees                |
+ * | `textLength` | (none) | Author-specified total advance length for this run |
+ * | `lengthAdjust` | `spacing` | `spacing` or `spacingAndGlyphs` adjustment mode |
  *
  */
 
@@ -71,7 +75,8 @@ namespace donner::svg {
  * The `<tspan>` element creates a sub-span of text within a `<text>` (or nested `<tspan>`),
  * allowing partial style changes or explicit repositioning of a portion of text.  It
  * supports the per-glyph positioning attributes (`x`, `y`, `dx`, `dy`, `rotate`) that
- * let you fine-tune the layout of text runs.
+ * let you fine-tune the layout of text runs, plus `textLength` / `lengthAdjust` for text-length
+ * calibration.
  *
  * \see https://www.w3.org/TR/SVG2/text.html#TSpanElement
  *

--- a/donner/svg/SVGTextElement.h
+++ b/donner/svg/SVGTextElement.h
@@ -10,19 +10,18 @@
 namespace donner::svg {
 
 /**
- * @page xml_text "<text>"
+ * @page xml_text &lt;text&gt;
  *
  * Defines a graphics element consisting of text.
  *
  * - DOM object: SVGTextElement
  * - SVG2 spec: https://www.w3.org/TR/SVG2/text.html#TextElement
  *
- * The `<text>` element renders a string of text as a proper graphics primitive. Unlike text
- * rasterized into a bitmap, SVG text is fully live: it remains selectable and searchable,
- * scales cleanly to any resolution, and accepts every normal SVG presentation attribute -
- * `fill`, `stroke`, `opacity`, `transform`, gradients via `url(#id)`, filters, clip paths,
- * and so on. Fonts are loaded through standard CSS `@font-face` rules (TTF, OTF, WOFF, WOFF2)
- * or fall back to a built-in typeface when no match is available.
+ * The `<text>` element renders a string of text as a graphics primitive while preserving the
+ * original text content in the SVG DOM. Text scales with the rest of the SVG scene and accepts
+ * normal SVG presentation attributes - `fill`, `stroke`, `opacity`, `transform`, gradients via
+ * `url(#id)`, filters, clip paths, and so on. Fonts are loaded through standard CSS `@font-face`
+ * rules (TTF, OTF, WOFF, WOFF2) or fall back to a built-in typeface when no match is available.
  *
  * Use `<text>` for labels, titles, axis tick marks, captions, and any other readable content.
  * Substrings inside a `<text>` can be re-styled or repositioned with \ref xml_tspan, and text

--- a/donner/svg/SVGTextPathElement.h
+++ b/donner/svg/SVGTextPathElement.h
@@ -9,7 +9,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_textPath "<textPath>"
+ * @page xml_textPath &lt;textPath&gt;
  *
  * The `<textPath>` element renders text along an arbitrary path referenced by the `href`
  * attribute. It must be a child of a \ref xml_text element.
@@ -51,9 +51,14 @@ namespace donner::svg {
  * | ------------: | :-------: | :------------------------------------------------------- |
  * | `href`        | (none)    | Reference to a `<path>` element                         |
  * | `startOffset` | `0`       | Offset along the path where text begins                  |
- * | `method`      | `align`   | How glyphs are placed: `align` or `stretch`              |
- * | `side`        | `left`    | Which side of the path: `left` or `right`                |
- * | `spacing`     | `exact`   | Spacing control: `auto` or `exact`                       |
+ * | `method`      | `align`   | Parsed: `align` or `stretch`; rendering implements `align` only. |
+ * | `side`        | `left`    | Parsed: `left` or `right`; rendering implements `left` only. |
+ * | `spacing`     | `exact`   | Parsed: `auto` or `exact`; rendering implements `exact` only. |
+ *
+ * \note The parser accepts `x`, `y`, `dx`, `dy`, and `rotate` on `<textPath>` for DOM fidelity,
+ *       but text layout intentionally ignores those attributes on the `<textPath>` element itself,
+ *       matching the SVG text model. Apply positioning to the parent \ref xml_text or nested
+ *       \ref xml_tspan content instead.
  *
  */
 
@@ -62,7 +67,9 @@ namespace donner::svg {
  *
  * The `<textPath>` element places text along an arbitrary SVG path, allowing text to follow
  * curves and complex shapes. It references a `<path>` element via the `href` attribute and
- * supports positioning along the path via `startOffset`.
+ * supports positioning along the path via `startOffset`. The accepted SVG2 `method`, `side`, and
+ * `spacing` attributes are stored on the DOM object; rendering currently implements the default
+ * `align`, `left`, and `exact` behavior.
  *
  * \see https://www.w3.org/TR/SVG2/text.html#TextPathElement
  */

--- a/donner/svg/SVGUseElement.h
+++ b/donner/svg/SVGUseElement.h
@@ -8,7 +8,7 @@
 namespace donner::svg {
 
 /**
- * @page xml_use "&lt;use&gt;"
+ * @page xml_use &lt;use&gt;
  *
  * `<use>` instantiates another element at a specified position, cloning its rendered output.
  * It's the SVG equivalent of "put another copy of that shape over here" - commonly used for
@@ -42,7 +42,7 @@ namespace donner::svg {
  * </svg>
  * ```
  *
- * ## Example 2: icon library via `<symbol>`
+ * ## Example 2: icon library via symbol
  *
  * A `<symbol>` is a template that isn't rendered on its own - it's only visible through a
  * `<use>` reference. Symbols can declare their own `viewBox`, which makes them resolution
@@ -74,13 +74,16 @@ namespace donner::svg {
  * <use href="#star" x="170" y="20" width="60" height="60" />
  * ```
  *
- * ## How `preserveAspectRatio` works
+ * ## How referenced viewports are fitted
  *
  * When `<use>` references a `<symbol>` or nested `<svg>` element that has its own `viewBox`,
- * the `preserveAspectRatio` attribute decides how the referenced content is fitted into the
- * `<use>` element's `width`/`height` box. It answers the question: *"when the symbol's
- * intrinsic aspect ratio doesn't match the destination rectangle, should we stretch,
+ * the referenced element's `preserveAspectRatio` attribute decides how that content is fitted
+ * into the `<use>` element's `width`/`height` box. It answers the question: *"when the
+ * symbol's intrinsic aspect ratio doesn't match the destination rectangle, should we stretch,
  * letterbox, or crop?"*
+ *
+ * Donner parses `preserveAspectRatio` on the referenced `<symbol>` or `<svg>`, not on the
+ * `<use>` element itself. Put the fitting mode on the element being reused.
  *
  * The attribute is a pair: `<align> <meetOrSlice>`.
  *
@@ -101,50 +104,64 @@ namespace donner::svg {
  *
  * The default is `xMidYMid meet`.
  *
- * ## Example 3: `preserveAspectRatio` comparison
+ * ## Example 3: referenced preserveAspectRatio comparison
  *
- * All three instances reference the same square `<symbol>` (`viewBox="0 0 100 100"`) and are
- * sized into a **wider** 120×60 rectangle (dashed outline). Only `preserveAspectRatio` differs:
+ * All three instances reference square symbols (`viewBox="0 0 100 100"`) and are sized into
+ * a **wider** 120×60 rectangle (dashed outline). Only the referenced symbol's
+ * `preserveAspectRatio` differs:
  *
  * \htmlonly
  * <svg width="420" height="130" viewBox="0 0 420 130" style="background-color: white" font-family="sans-serif" font-size="12">
  *   <defs>
- *     <symbol id="xml_use_par_sym" viewBox="0 0 100 100">
+ *     <symbol id="xml_use_par_meet" viewBox="0 0 100 100"
+ *             preserveAspectRatio="xMidYMid meet">
+ *       <rect x="5" y="5" width="90" height="90" fill="#cfe8ff" stroke="#3b82c4" stroke-width="4"/>
+ *       <circle cx="50" cy="50" r="30" fill="#3b82c4"/>
+ *     </symbol>
+ *     <symbol id="xml_use_par_slice" viewBox="0 0 100 100"
+ *             preserveAspectRatio="xMidYMid slice">
+ *       <rect x="5" y="5" width="90" height="90" fill="#cfe8ff" stroke="#3b82c4" stroke-width="4"/>
+ *       <circle cx="50" cy="50" r="30" fill="#3b82c4"/>
+ *     </symbol>
+ *     <symbol id="xml_use_par_none" viewBox="0 0 100 100" preserveAspectRatio="none">
  *       <rect x="5" y="5" width="90" height="90" fill="#cfe8ff" stroke="#3b82c4" stroke-width="4"/>
  *       <circle cx="50" cy="50" r="30" fill="#3b82c4"/>
  *     </symbol>
  *   </defs>
  *   <g transform="translate(15,15)">
  *     <rect width="120" height="60" fill="none" stroke="#888" stroke-dasharray="3,3"/>
- *     <use href="#xml_use_par_sym" width="120" height="60" preserveAspectRatio="xMidYMid meet"/>
+ *     <use href="#xml_use_par_meet" width="120" height="60"/>
  *     <text x="60" y="85" text-anchor="middle" fill="#444">meet (fit)</text>
  *   </g>
  *   <g transform="translate(150,15)">
  *     <rect width="120" height="60" fill="none" stroke="#888" stroke-dasharray="3,3"/>
  *     <clipPath id="xml_use_par_clip"><rect width="120" height="60"/></clipPath>
  *     <g clip-path="url(#xml_use_par_clip)">
- *       <use href="#xml_use_par_sym" width="120" height="60" preserveAspectRatio="xMidYMid slice"/>
+ *       <use href="#xml_use_par_slice" width="120" height="60"/>
  *     </g>
  *     <text x="60" y="85" text-anchor="middle" fill="#444">slice (fill, cropped)</text>
  *   </g>
  *   <g transform="translate(285,15)">
  *     <rect width="120" height="60" fill="none" stroke="#888" stroke-dasharray="3,3"/>
- *     <use href="#xml_use_par_sym" width="120" height="60" preserveAspectRatio="none"/>
+ *     <use href="#xml_use_par_none" width="120" height="60"/>
  *     <text x="60" y="85" text-anchor="middle" fill="#444">none (stretched)</text>
  *   </g>
  * </svg>
  * \endhtmlonly
  *
  * ```xml
- * <symbol id="s" viewBox="0 0 100 100"> ... </symbol>
+ * <symbol id="fit" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid meet"> ... </symbol>
+ * <symbol id="fill" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid slice"> ... </symbol>
+ * <symbol id="stretch" viewBox="0 0 100 100" preserveAspectRatio="none"> ... </symbol>
  *
- * <use href="#s" width="120" height="60" preserveAspectRatio="xMidYMid meet"  />
- * <use href="#s" width="120" height="60" preserveAspectRatio="xMidYMid slice" />
- * <use href="#s" width="120" height="60" preserveAspectRatio="none"           />
+ * <use href="#fit" width="120" height="60" />
+ * <use href="#fill" width="120" height="60" />
+ * <use href="#stretch" width="120" height="60" />
  * ```
  *
- * Note: `preserveAspectRatio` only has an effect when the referenced element has an intrinsic
- * coordinate system (a `viewBox`). Referencing a bare `<circle>` or `<path>` ignores it.
+ * Note: the referenced element's `preserveAspectRatio` only has an effect when that element has
+ * an intrinsic coordinate system (a `viewBox`). Referencing a bare `<circle>` or `<path>` does
+ * not create a fitted viewport.
  *
  * ## Attributes
  *
@@ -155,7 +172,6 @@ namespace donner::svg {
  * | `y`                   | `0`             | Y coordinate where the referenced element is placed. |
  * | `width`               | `auto`          | Width of the instance. Only meaningful when the referenced element has a `viewBox` (e.g. `<symbol>` or `<svg>`). |
  * | `height`              | `auto`          | Height of the instance. Only meaningful when the referenced element has a `viewBox`. |
- * | `preserveAspectRatio` | `xMidYMid meet` | How the referenced content is fitted into `width` × `height` when aspect ratios differ. See above. |
  */
 
 /**
@@ -176,10 +192,10 @@ namespace donner::svg {
  *
  * | Attribute | Default | Description  |
  * | --------: | :-----: | :----------- |
- * | `x`       | `0`     | X coordinate to position the referenced element. |
- * | `y`       | `0`     | Y coordinate to position the referenced element. |
- * | `width`   | `auto`  | Width of the referenced element. |
- * | `height`  | `auto`  | Height of the referenced element. |
+ * | `x`       | `0`     | X coordinate where the referenced element is placed. |
+ * | `y`       | `0`     | Y coordinate where the referenced element is placed. |
+ * | `width`   | `auto`  | Width of the instance viewport for referenced `<symbol>` or `<svg>` content. |
+ * | `height`  | `auto`  | Height of the instance viewport for referenced `<symbol>` or `<svg>` content. |
  * | `href`    | (none)  | URI to the element to reuse. |
  */
 class SVGUseElement : public SVGElement {

--- a/tools/doxygen.sh
+++ b/tools/doxygen.sh
@@ -12,6 +12,19 @@ if [ -d "/workspace/doxygen" ]; then
   fi
 fi
 
+DONNER_VERSION=$(
+  sed -n '/^[[:space:]]*module(/{
+    s/.*version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/
+    p
+    q
+  }' MODULE.bazel
+)
+if [ -z "$DONNER_VERSION" ]; then
+  echo "Unable to read Donner version from MODULE.bazel" >&2
+  exit 1
+fi
+export DONNER_VERSION
+
 $DOXYGEN_BIN Doxyfile
 
 echo "Documentation generated in generated-doxygen/html/index.html"


### PR DESCRIPTION
## Summary
- Add explicit Doxygen navigation pages so the sidebar groups Documentation, API Reference, SVG Element Reference, and Developer Docs instead of one long flat list.
- Route the Doxygen version through `MODULE.bazel` -> `tools/doxygen.sh` -> `Doxyfile`, displaying `0.8.0-pre` from one source of truth.
- Clean up SVG element page titles/grouping and correct several element docs to match current parser/renderer behavior.

## Validation
- `tools/doxygen.sh`
- Playwright generated-docs sweep: 111 tag/class pages checked, 0 problems
- `python3 tools/cmake/gen_cmakelists.py --check`
- `git diff --check`
- `bazel test --remote_executor= --remote_cache= --bes_backend= --spawn_strategy=local --strategy=CppCompile=local --strategy=CppLink=local --strategy=Genrule=local --test_env=VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.json --test_env=XDG_RUNTIME_DIR=/tmp //...` (699 passed, 11 skipped)

Note: without the documented Intel Arc llvmpipe fallback, the local full-suite run failed only in `resvg_test_suite_geode` on the Arc Vulkan driver.