### PR TITLE
Raise branch coverage toward 85 percent

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -13,9 +13,9 @@ Do not publish draft PR diffs. Open PRs only when they are ready for review afte
 local validation; keep work-in-progress diffs local until they have a coherent
 reviewable boundary.
 
-When monitoring pull requests, do not expect code-review comments while the PR is
-still a draft. Keep monitoring CI and mergeability, but treat review/comment
-silence as expected until the PR is published and out of draft.
+Do not publish draft diffs or open draft pull requests. Keep unfinished work
+local; once the change is validated and ready for review, open a normal
+reviewable pull request and monitor CI, mergeability, and review comments.
 """
 
 [shell_environment_policy]

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -166,7 +166,7 @@ jobs:
             esac
 
             case "$path" in
-              .bazelrc|.github/workflows/*|.github/actions/*|docs/*|*.md|tools/binary_size.sh|tools/build_docs.sh|tools/coverage.sh|tools/filter_coverage.py|tools/generate_build_report.py|tools/generate_build_report_tests.py)
+              .bazelrc|.github/workflows/*|.github/actions/*|docs/*|*.md|tools/binary_size.sh|tools/build_docs.sh|tools/coverage.sh|tools/filter_coverage.py|tools/lcov_metrics.py|tools/lcov_metrics_tests.py|tools/generate_build_report.py|tools/generate_build_report_tests.py)
                 ;;
               *)
                 smoke_only=false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,14 +97,13 @@ When creating a pull request:
    - `python3 tools/cmake/gen_cmakelists.py --check` (CMake generator + output validator; runs outside bazel because it uses `bazel query`).
    - **`clang-format -i` on every modified C/C++ file** before committing — `git clang-format` covers staged changes. The project `.clang-format` is tuned so clang-format 18 and 19 produce identical output, so any locally-installed clang-format works.
 3. **For fuzzer-sensitive changes**, run `bazel test --config=asan-fuzzer <fuzzer target>`. macOS needs this config because Apple Clang lacks `libclang_rt.fuzzer_osx.a`; `--config=asan-fuzzer` activates the LLVM 21 toolchain which provides it.
-4. **Monitor CI and code review by default for every created PR** — whenever you create or open a PR, automatically keep monitoring CI status, merge conflicts, and review comments every ~7 minutes until the PR is green and reviewed; do not wait for a separate user prompt. For PR monitoring, the policy is to check both comments and CI/status checks on each ~7-minute pass until the PR has stabilized. For draft PRs, keep monitoring CI and mergeability, but do not expect CR/review comments until the PR is published and out of draft. Use `gh pr checks <number>` and `gh api repos/jwmcglynn/donner/pulls/<number>/comments` when `gh` is authenticated, or the GitHub connector equivalents when `gh` is unavailable.
-5. **No agent branding in PR titles** — do not prefix pull request titles with `[codex]`, agent names, or other tool branding. Use a plain project-style title that describes the change.
-6. **Omit `## Summary` in PR descriptions** — the first paragraph or bullet list is implicitly the
+4. **Do not publish draft diffs** — agents must not open draft pull requests. Keep unfinished
+   work local; once the change is validated and ready for review, open a normal reviewable PR.
+5. **Monitor CI and code review by default for every created PR** — whenever you create or open a PR, automatically keep monitoring CI status, merge conflicts, and review comments every ~7 minutes until the PR is green and reviewed; do not wait for a separate user prompt. For PR monitoring, the policy is to check both comments and CI/status checks on each ~7-minute pass until the PR has stabilized. Use `gh pr checks <number>` and `gh api repos/jwmcglynn/donner/pulls/<number>/comments` when `gh` is authenticated, or the GitHub connector equivalents when `gh` is unavailable.
+6. **No agent branding in PR titles** — do not prefix pull request titles with `[codex]`, agent names, or other tool branding. Use a plain project-style title that describes the change.
+7. **Omit `## Summary` in PR descriptions** — the first paragraph or bullet list is implicitly the
    summary, so start with the summary content directly instead of adding a redundant heading.
-7. **Do not publish draft diffs** — open PRs only when they are ready for review
-   after local validation. Do not use draft PRs to share work-in-progress diffs;
-   keep WIP local until it has a coherent reviewable boundary.
-8. **Expect a Codex code review** within the first few minutes after the PR is published and out of draft — address feedback promptly by pushing follow-up commits. If Codex finds no issues it will approve the PR (👍 / APPROVED state). A Codex approval alone is not sufficient to merge — a `jwmcglynn` review is always required.
+8. **Expect a Codex code review** within the first few minutes after the PR is opened — address feedback promptly by pushing follow-up commits. If Codex finds no issues it will approve the PR (👍 / APPROVED state). A Codex approval alone is not sufficient to merge — a `jwmcglynn` review is always required.
 9. **Transient CI failures** (apt/bazel fetch/chromium rate-limits) are retried automatically. Test, compile, linker, and pixel-diff failures are never transient — investigate the root cause, don't re-run blindly.
 10. **Fix CI diagnosability gaps** — if a CI failure cannot be diagnosed because logs, test output,
    screenshots, undeclared outputs, pixel diffs, artifacts, or job summaries are missing or

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,8 @@
 - Never use merge commits or rebase-and-merge on this repository.
 - **Omit `## Summary` in PR descriptions.** The first paragraph or bullet list is implicitly the
   summary, so start directly with the summary content.
+- **Do not publish draft diffs.** Agents must not open draft PRs. Keep unfinished work local; once
+  the change is validated and ready for review, open a normal reviewable PR.
 
 ## AI Comment Convention
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -25,6 +25,10 @@ coverage:
 comment:
   layout: "header, diff, flags, files, footer"
 
+flags:
+  unittests:
+    carryforward: true
+
 parsers:
   gcov:
     branch_detection:

--- a/donner/base/tests/PathOps_tests.cc
+++ b/donner/base/tests/PathOps_tests.cc
@@ -149,6 +149,26 @@ Path RegionBelowLinePrefixBoundary() {
       .build();
 }
 
+Path RegionAboveReversedLineContainedBoundary() {
+  return PathBuilder()
+      .moveTo({75, 50})
+      .lineTo({25, 50})
+      .lineTo({25, 0})
+      .lineTo({75, 0})
+      .closePath()
+      .build();
+}
+
+Path RegionAboveReversedLineSuffixBoundary() {
+  return PathBuilder()
+      .moveTo({100, 50})
+      .lineTo({25, 50})
+      .lineTo({25, 0})
+      .lineTo({100, 0})
+      .closePath()
+      .build();
+}
+
 Path RegionAboveStraightQuadraticBoundary() {
   return PathBuilder()
       .moveTo({0, 50})
@@ -768,6 +788,49 @@ TEST(PathOpsTest, DifferenceRetainsPartiallySharedLineAndStraightCubicBoundarySi
   EXPECT_THAT(path, IsOutside(Vector2d(90, 75)));
 }
 
+TEST(PathOpsTest, IntersectOfOppositeDirectionContainedLineBoundaryIsEmpty) {
+  const PathBooleanResult result = Boolean(
+      PathBooleanOp::Intersect,
+      {Input(RegionBelowLineBoundary()), Input(RegionAboveReversedLineContainedBoundary())});
+
+  EXPECT_EQ(result.status, PathBooleanStatus::EmptyResult) << Diagnostics(result);
+  EXPECT_TRUE(result.paths.empty());
+}
+
+TEST(PathOpsTest, DifferenceRetainsOppositeDirectionContainedLineBoundarySide) {
+  const PathBooleanResult result = Boolean(
+      PathBooleanOp::Difference,
+      {Input(RegionBelowLineBoundary()), Input(RegionAboveReversedLineContainedBoundary())});
+
+  ASSERT_EQ(result.status, PathBooleanStatus::Ok) << Diagnostics(result);
+  ASSERT_FALSE(result.paths.empty());
+  const Path& path = result.paths.front();
+  EXPECT_TRUE(path.isInside({50, 75}));
+  EXPECT_FALSE(path.isInside({50, 25}));
+}
+
+TEST(PathOpsTest, IntersectOfOppositeDirectionOverlappingLineBoundaryIsEmpty) {
+  const PathBooleanResult result = Boolean(
+      PathBooleanOp::Intersect,
+      {Input(RegionBelowLinePrefixBoundary()), Input(RegionAboveReversedLineSuffixBoundary())});
+
+  EXPECT_EQ(result.status, PathBooleanStatus::EmptyResult) << Diagnostics(result);
+  EXPECT_TRUE(result.paths.empty());
+}
+
+TEST(PathOpsTest, DifferenceRetainsOppositeDirectionOverlappingLineBoundarySide) {
+  const PathBooleanResult result = Boolean(
+      PathBooleanOp::Difference,
+      {Input(RegionBelowLinePrefixBoundary()), Input(RegionAboveReversedLineSuffixBoundary())});
+
+  ASSERT_EQ(result.status, PathBooleanStatus::Ok) << Diagnostics(result);
+  ASSERT_FALSE(result.paths.empty());
+  const Path& path = result.paths.front();
+  EXPECT_TRUE(path.isInside({50, 75}));
+  EXPECT_FALSE(path.isInside({50, 25}));
+  EXPECT_FALSE(path.isInside({90, 75}));
+}
+
 TEST(PathOpsTest, TransformedInputsParticipateInOutputCoordinates) {
   PathBooleanInput translated = Input(RectPath(0, 0, 20, 20));
   translated.outputFromPath = Transform2d::Translate({20, 15});
@@ -1269,6 +1332,68 @@ TEST(PathOpsTest, MultiInputIntersectionRequiresEveryInput) {
   EXPECT_EQ(PathData(result), "M 20 10 L 40 10 L 40 40 L 20 40 Z");
 }
 
+TEST(PathOpsTest, RequiresAtLeastTwoInputs) {
+  const std::array<PathBooleanInput, 1> inputs = {
+      Input(RectPath(0, 0, 20, 20)),
+  };
+
+  const PathBooleanResult result = ApplyPathBoolean(PathBooleanOp::Union, inputs);
+
+  EXPECT_EQ(result.status, PathBooleanStatus::InvalidInput);
+  EXPECT_TRUE(result.paths.empty());
+  EXPECT_FALSE(result.diagnostics.empty());
+}
+
+TEST(PathOpsTest, OpenContoursAreClosedAtMoveToAndPathEnd) {
+  const Path openTriangles = PathBuilder()
+                                 .moveTo({0, 0})
+                                 .lineTo({20, 0})
+                                 .lineTo({0, 20})
+                                 .moveTo({40, 0})
+                                 .lineTo({60, 0})
+                                 .lineTo({40, 20})
+                                 .build();
+
+  const PathBooleanResult result = Boolean(
+      PathBooleanOp::Intersect, {Input(openTriangles), Input(RectPath(-10, -10, 100, 100))});
+
+  EXPECT_EQ(result.status, PathBooleanStatus::EmptyResult);
+  EXPECT_TRUE(result.paths.empty());
+  EXPECT_NE(Diagnostics(result).find("dropping"), std::string::npos);
+}
+
+TEST(PathOpsTest, MoveOnlyContoursDoNotEmitSegments) {
+  const Path path = PathBuilder()
+                        .moveTo({0, 0})
+                        .moveTo({10, 10})
+                        .lineTo({30, 10})
+                        .lineTo({10, 30})
+                        .moveTo({80, 80})
+                        .closePath()
+                        .build();
+
+  const PathBooleanResult result =
+      Boolean(PathBooleanOp::Intersect, {Input(path), Input(RectPath(0, 0, 40, 40))});
+
+  EXPECT_EQ(result.status, PathBooleanStatus::EmptyResult);
+  EXPECT_TRUE(result.paths.empty());
+  EXPECT_NE(Diagnostics(result).find("dropping"), std::string::npos);
+}
+
+TEST(PathOpsTest, RejectsMoveOnlyInputContours) {
+  const Path moveOnly = PathBuilder().moveTo({0, 0}).moveTo({10, 10}).closePath().build();
+  const std::array<PathBooleanInput, 2> inputs = {
+      Input(moveOnly),
+      Input(RectPath(0, 0, 20, 20)),
+  };
+
+  const PathBooleanResult result = ApplyPathBoolean(PathBooleanOp::Union, inputs);
+
+  EXPECT_EQ(result.status, PathBooleanStatus::InvalidInput);
+  EXPECT_TRUE(result.paths.empty());
+  EXPECT_FALSE(result.diagnostics.empty());
+}
+
 TEST(PathOpsTest, RespectsOutputCommandCap) {
   PathBooleanOptions options;
   options.maxOutputCommands = 2;
@@ -1375,6 +1500,48 @@ TEST(PathOpsTest, RejectsNonFiniteInputCoordinates) {
   EXPECT_EQ(result.status, PathBooleanStatus::InvalidInput);
   EXPECT_TRUE(result.paths.empty());
   EXPECT_FALSE(result.diagnostics.empty());
+}
+
+TEST(PathOpsTest, RejectsNonFiniteCurveCoordinates) {
+  const double inf = std::numeric_limits<double>::infinity();
+  const Path invalidQuadratic =
+      PathBuilder().moveTo({0, 0}).quadTo({10, inf}, {20, 0}).closePath().build();
+  const std::array<PathBooleanInput, 2> quadraticInputs = {
+      Input(invalidQuadratic),
+      Input(RectPath(0, 0, 20, 20)),
+  };
+  const PathBooleanResult quadraticResult = ApplyPathBoolean(PathBooleanOp::Union, quadraticInputs);
+  EXPECT_EQ(quadraticResult.status, PathBooleanStatus::InvalidInput);
+  EXPECT_TRUE(quadraticResult.paths.empty());
+  EXPECT_FALSE(quadraticResult.diagnostics.empty());
+
+  const Path invalidCubic =
+      PathBuilder().moveTo({0, 0}).curveTo({10, 0}, {15, 10}, {inf, 20}).closePath().build();
+  const std::array<PathBooleanInput, 2> cubicInputs = {
+      Input(invalidCubic),
+      Input(RectPath(0, 0, 20, 20)),
+  };
+  const PathBooleanResult cubicResult = ApplyPathBoolean(PathBooleanOp::Union, cubicInputs);
+  EXPECT_EQ(cubicResult.status, PathBooleanStatus::InvalidInput);
+  EXPECT_TRUE(cubicResult.paths.empty());
+  EXPECT_FALSE(cubicResult.diagnostics.empty());
+}
+
+TEST(PathOpsTest, InvalidGeometricToleranceUsesDefaultTolerance) {
+  for (double invalidTolerance : {0.0, -1.0, std::numeric_limits<double>::quiet_NaN(),
+                                  std::numeric_limits<double>::infinity()}) {
+    PathBooleanOptions options;
+    options.geometricTolerance = invalidTolerance;
+    const std::array<PathBooleanInput, 2> inputs = {
+        Input(RectPath(0, 0, 20, 20)),
+        Input(RectPath(10, 10, 20, 20)),
+    };
+
+    const PathBooleanResult result = ApplyPathBoolean(PathBooleanOp::Intersect, inputs, options);
+
+    ASSERT_EQ(result.status, PathBooleanStatus::Ok) << Diagnostics(result);
+    EXPECT_EQ(PathData(result), "M 10 10 L 20 10 L 20 20 L 10 20 Z");
+  }
 }
 
 TEST(PathOpsTest, DeterministicCommandOrder) {

--- a/donner/base/tests/Path_tests.cc
+++ b/donner/base/tests/Path_tests.cc
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <limits>
 #include <sstream>
 #include <vector>
 
@@ -223,6 +224,22 @@ TEST(Path, BoundsQuadPath) {
   EXPECT_NEAR(box.bottomRight.x, 100.0, 1e-9);
   EXPECT_GT(box.bottomRight.y, 0.0);
   EXPECT_LT(box.bottomRight.y, 100.0);
+}
+
+TEST(Path, BoundsCurvesAfterPreviousSegmentsUsePreviousEndpointAsStart) {
+  Path path = PathBuilder()
+                  .moveTo({2, 3})
+                  .lineTo({4, 5})
+                  .quadTo({6, 12}, {8, 5})
+                  .curveTo({10, -4}, {12, -4}, {14, 5})
+                  .closePath()
+                  .build();
+
+  Box2d box = path.bounds();
+  EXPECT_NEAR(box.topLeft.x, 2.0, 1e-9);
+  EXPECT_LT(box.topLeft.y, 0.0);
+  EXPECT_NEAR(box.bottomRight.x, 14.0, 1e-9);
+  EXPECT_GT(box.bottomRight.y, 8.0);
 }
 
 // =============================================================================
@@ -466,6 +483,25 @@ TEST(Path, FlattenFlatCurvesUseSingleLineSegments) {
   EXPECT_EQ(lineCount, 2u);
 }
 
+TEST(Path, FlattenZeroToleranceStillTerminatesDeepSubdivision) {
+  Path path = PathBuilder()
+                  .moveTo({0, 0})
+                  .quadTo({50, 100}, {100, 0})
+                  .curveTo({100, -100}, {200, -100}, {200, 0})
+                  .build();
+
+  Path result = path.flatten(0.0);
+
+  size_t lineCount = 0;
+  result.forEach([&](Path::Verb verb, std::span<const Vector2d>) {
+    if (verb == Path::Verb::LineTo) {
+      ++lineCount;
+    }
+  });
+  EXPECT_GT(lineCount, 100u);
+  EXPECT_LT(lineCount, 3000u);
+}
+
 // =============================================================================
 // pointsPerVerb
 // =============================================================================
@@ -544,6 +580,22 @@ TEST(Path, TransformedBoundsCurves) {
   Box2d transformedCubic = cubic.transformedBounds(Transform2d::Translate({7, -3}));
   ExpectNear(transformedCubic.topLeft, Vector2d(7, -3));
   ExpectNear(transformedCubic.bottomRight, Vector2d(107, 72));
+}
+
+TEST(Path, TransformedBoundsCurvesAfterPreviousSegmentsUsePreviousEndpointAsStart) {
+  Path path = PathBuilder()
+                  .moveTo({2, 3})
+                  .lineTo({4, 5})
+                  .quadTo({6, 12}, {8, 5})
+                  .curveTo({10, -4}, {12, -4}, {14, 5})
+                  .closePath()
+                  .build();
+
+  Box2d box = path.transformedBounds(Transform2d::Translate({10, -2}));
+  EXPECT_NEAR(box.topLeft.x, 12.0, 1e-9);
+  EXPECT_LT(box.topLeft.y, -2.0);
+  EXPECT_NEAR(box.bottomRight.x, 24.0, 1e-9);
+  EXPECT_GT(box.bottomRight.y, 6.0);
 }
 
 TEST(Path, TransformedBoundsUsesTightTransformedPathNotTransformedLocalAabb) {
@@ -710,6 +762,65 @@ TEST(Path, PointAtArcLengthCurveStartAndEnd) {
   ExpectNear(cubicStart.point, Vector2d(0, 0), 1e-6);
   EXPECT_TRUE(cubicEnd.valid);
   ExpectNear(cubicEnd.point, Vector2d(100, 0), 1e-6);
+}
+
+TEST(Path, PointAtArcLengthCurvesUseBinarySearchAwayFromEndpoints) {
+  Path quad = PathBuilder().moveTo({0, 0}).quadTo({50, 100}, {100, 0}).build();
+  Path::PointOnPath quadMid = quad.pointAtArcLength(quad.pathLength() * 0.5);
+  ASSERT_TRUE(quadMid.valid);
+  EXPECT_NEAR(quadMid.point.x, 50.0, 0.25);
+  EXPECT_GT(quadMid.point.y, 45.0);
+  EXPECT_LT(quadMid.point.y, 55.0);
+  EXPECT_GT(quadMid.tangent.x, 0.0);
+
+  Path cubic = PathBuilder().moveTo({0, 0}).curveTo({0, 100}, {100, 100}, {100, 0}).build();
+  Path::PointOnPath cubicMid = cubic.pointAtArcLength(cubic.pathLength() * 0.5);
+  ASSERT_TRUE(cubicMid.valid);
+  EXPECT_NEAR(cubicMid.point.x, 50.0, 0.25);
+  EXPECT_GT(cubicMid.point.y, 70.0);
+  EXPECT_LT(cubicMid.point.y, 80.0);
+  EXPECT_NEAR(cubicMid.tangent.y, 0.0, 1e-2);
+}
+
+TEST(Path, PointAtArcLengthSkipsCurvesBeforeSamplingLaterSegments) {
+  Path path = PathBuilder()
+                  .moveTo({0, 0})
+                  .quadTo({5, 0}, {10, 0})
+                  .curveTo({10.0 + 10.0 / 3.0, 0}, {10.0 + 20.0 / 3.0, 0}, {20, 0})
+                  .lineTo({30, 0})
+                  .closePath()
+                  .build();
+
+  Path::PointOnPath onCubic = path.pointAtArcLength(15.0);
+  ASSERT_TRUE(onCubic.valid);
+  ExpectNear(onCubic.point, Vector2d(15, 0), 1e-3);
+
+  Path::PointOnPath onLine = path.pointAtArcLength(25.0);
+  ASSERT_TRUE(onLine.valid);
+  ExpectNear(onLine.point, Vector2d(25, 0), 1e-6);
+
+  Path::PointOnPath onClose = path.pointAtArcLength(45.0);
+  ASSERT_TRUE(onClose.valid);
+  ExpectNear(onClose.point, Vector2d(15, 0), 1e-6);
+}
+
+TEST(Path, PointAtArcLengthAsymmetricCurvesAdjustBinarySearchBothWays) {
+  Path path = PathBuilder()
+                  .moveTo({0, 0})
+                  .curveTo({80, 180}, {-40, 20}, {100, 0})
+                  .curveTo({160, -120}, {20, -40}, {180, 0})
+                  .build();
+  const double length = path.pathLength();
+
+  Path::PointOnPath early = path.pointAtArcLength(length * 0.15);
+  Path::PointOnPath late = path.pointAtArcLength(length * 0.85);
+
+  ASSERT_TRUE(early.valid);
+  ASSERT_TRUE(late.valid);
+  EXPECT_GT(early.point.x, -1.0);
+  EXPECT_LT(early.point.x, 100.0);
+  EXPECT_GT(late.point.x, 80.0);
+  EXPECT_LT(late.point.x, 181.0);
 }
 
 // =============================================================================
@@ -881,6 +992,34 @@ TEST(Path, IsInsideTreatsPointsOnCurvesAsInside) {
   EXPECT_TRUE(cubic.isInside({50, 75}));
 }
 
+TEST(Path, IsInsideCurvedContoursCoversBothWindingDirections) {
+  Path clockwise = PathBuilder()
+                       .moveTo({0, 0})
+                       .curveTo({0, 100}, {100, 100}, {100, 0})
+                       .lineTo({0, 0})
+                       .closePath()
+                       .build();
+  Path counterClockwise = PathBuilder()
+                              .moveTo({0, 0})
+                              .lineTo({100, 0})
+                              .curveTo({100, 100}, {0, 100}, {0, 0})
+                              .closePath()
+                              .build();
+
+  EXPECT_TRUE(clockwise.isInside({50, 20}, FillRule::NonZero));
+  EXPECT_TRUE(counterClockwise.isInside({50, 20}, FillRule::NonZero));
+  EXPECT_FALSE(clockwise.isInside({50, -20}, FillRule::NonZero));
+  EXPECT_FALSE(counterClockwise.isInside({50, -20}, FillRule::NonZero));
+}
+
+TEST(Path, IsInsideUsesDownwardClosingEdgeForWinding) {
+  Path path = PathBuilder().moveTo({0, 0}).lineTo({10, 0}).lineTo({10, 10}).closePath().build();
+
+  EXPECT_TRUE(path.isInside({8, 5}, FillRule::NonZero));
+  EXPECT_TRUE(path.isInside({8, 5}, FillRule::EvenOdd));
+  EXPECT_FALSE(path.isInside({2, 5}, FillRule::NonZero));
+}
+
 // =============================================================================
 // Path::isOnPath
 // =============================================================================
@@ -916,6 +1055,12 @@ TEST(Path, IsOnPathClosePath) {
   Path path = PathBuilder().moveTo({0, 0}).lineTo({10, 0}).lineTo({10, 10}).closePath().build();
   // Closing edge goes diagonally from (10,10) to (0,0).
   EXPECT_TRUE(path.isOnPath({5, 5}, 1.0));
+}
+
+TEST(Path, IsOnPathClosePathRejectsPointAwayFromClosingEdge) {
+  Path path = PathBuilder().moveTo({0, 0}).lineTo({10, 0}).lineTo({10, 10}).closePath().build();
+
+  EXPECT_FALSE(path.isOnPath({8, 3}, 0.1));
 }
 
 TEST(Path, IsOnPathMoveOnlyAndDistantCurves) {
@@ -1774,6 +1919,19 @@ TEST(Path, StrokeToFillDashPathLengthScaling) {
   EXPECT_EQ(countSubpaths(filled), 3u);
 }
 
+TEST(Path, StrokeToFillDashInfinitePathLengthFallsBackToSolid) {
+  Path path = PathBuilder().moveTo({0, 0}).lineTo({100, 0}).build();
+  StrokeStyle style;
+  style.width = 1.0;
+  style.dashArray = {10.0, 10.0};
+  style.pathLength = std::numeric_limits<double>::infinity();
+
+  Path filled = path.strokeToFill(style);
+
+  EXPECT_FALSE(filled.empty());
+  EXPECT_EQ(countSubpaths(filled), 1u);
+}
+
 TEST(Path, StrokeToFillDashAllZeroIsSolid) {
   // Per SVG, an all-zero dasharray renders as a solid stroke.
   Path path = PathBuilder().moveTo({0, 0}).lineTo({100, 0}).build();
@@ -1798,6 +1956,19 @@ TEST(Path, StrokeToFillDashZeroEntryDoesNotHang) {
   // Should produce *something*, not hang. (Whether it's one big stroke or
   // chopped up depends on the cycle handling, but it must terminate.)
   EXPECT_FALSE(filled.empty());
+}
+
+TEST(Path, StrokeToFillDashLeadingZeroEntryDoesNotHang) {
+  // {0, 10} starts on a zero-length ON entry. It should terminate without
+  // emitting a visible dash or falling back to a solid stroke.
+  Path path = PathBuilder().moveTo({0, 0}).lineTo({100, 0}).build();
+  StrokeStyle style;
+  style.width = 1.0;
+  style.dashArray = {0.0, 10.0};
+
+  Path filled = path.strokeToFill(style);
+
+  EXPECT_TRUE(filled.empty());
 }
 
 TEST(Path, StrokeToFillDashNegativeIsSolid) {
@@ -1850,6 +2021,20 @@ TEST(Path, StrokeToFillEmptyOrNonPositiveWidthReturnsEmpty) {
 
   style.width = -1.0;
   EXPECT_TRUE(line.strokeToFill(style).empty());
+}
+
+TEST(Path, StrokeToFillMoveOnlySubpathsReturnEmpty) {
+  StrokeStyle style;
+  style.width = 2.0;
+
+  Path moveOnly = PathBuilder().moveTo({5, 5}).build();
+  EXPECT_TRUE(moveOnly.strokeToFill(style).empty());
+
+  Path closedMoveOnly = PathBuilder().moveTo({5, 5}).closePath().build();
+  EXPECT_TRUE(closedMoveOnly.strokeToFill(style).empty());
+
+  style.dashArray = {1.0, 1.0};
+  EXPECT_TRUE(closedMoveOnly.strokeToFill(style).empty());
 }
 
 TEST(Path, StrokeToFillZeroLengthSubpathCaps) {
@@ -1918,6 +2103,47 @@ TEST(Path, StrokeToFillUsesCurveBoundaryTangentsAtMixedJoins) {
   EXPECT_FALSE(filled.empty());
   EXPECT_NE(rayCastWinding(filled, {5, 0}), 0);
   EXPECT_NE(rayCastWinding(filled, {10, 5}), 0);
+}
+
+TEST(Path, StrokeToFillDegenerateCurveBoundaryTangentsFallBackToChord) {
+  Path path = PathBuilder()
+                  .moveTo({0, 0})
+                  .curveTo({0, 0}, {0, 0}, {10, 0})
+                  .quadTo({10, 0}, {10, 10})
+                  .lineTo({20, 10})
+                  .build();
+  StrokeStyle style;
+  style.width = 2.0;
+  style.join = LineJoin::Miter;
+  style.miterLimit = 4.0;
+
+  Path filled = path.strokeToFill(style);
+
+  EXPECT_FALSE(filled.empty());
+  EXPECT_NE(rayCastWinding(filled, {5, 0}), 0);
+  EXPECT_NE(rayCastWinding(filled, {10, 5}), 0);
+}
+
+TEST(Path, StrokeToFillCurveBoundaryTangentsUseAllDegenerateFallbacks) {
+  Path path = PathBuilder()
+                  .moveTo({0, 0})
+                  .curveTo({10, 0}, {10, 0}, {10, 0})
+                  .lineTo({10, 10})
+                  .curveTo({10, 10}, {15, 10}, {20, 10})
+                  .curveTo({20, 10}, {20, 10}, {20, 20})
+                  .build();
+  StrokeStyle style;
+  style.width = 2.0;
+  style.join = LineJoin::Miter;
+  style.miterLimit = 4.0;
+
+  Path filled = path.strokeToFill(style);
+
+  EXPECT_FALSE(filled.empty());
+  EXPECT_NE(rayCastWinding(filled, {5, 0}), 0);
+  EXPECT_NE(rayCastWinding(filled, {10, 5}), 0);
+  EXPECT_NE(rayCastWinding(filled, {15, 10}), 0);
+  EXPECT_NE(rayCastWinding(filled, {20, 15}), 0);
 }
 
 // =============================================================================
@@ -2083,6 +2309,11 @@ TEST(Path, VerticesArcSkipsInternalDecompositionSegments) {
 }
 
 TEST(Path, VerticesInteriorCuspsResolveBothPerpendicularBranches) {
+  Path positiveYHalfPlane = PathBuilder().moveTo({0, 0}).lineTo({0, 10}).lineTo({0, 0}).build();
+  std::vector<Path::Vertex> positiveYVerts = positiveYHalfPlane.vertices();
+  ASSERT_GE(positiveYVerts.size(), 3u);
+  ExpectNear(positiveYVerts[1].orientation, Vector2d(-1, 0));
+
   Path positiveHalfPlane = PathBuilder().moveTo({0, 0}).lineTo({10, 0}).lineTo({0, 0}).build();
   std::vector<Path::Vertex> positiveVerts = positiveHalfPlane.vertices();
   ASSERT_GE(positiveVerts.size(), 3u);
@@ -2101,6 +2332,21 @@ TEST(Path, VerticesClosedDegenerateSubpathKeepsZeroOrientation) {
 
   ASSERT_FALSE(verts.empty());
   ExpectNear(verts.front().orientation, Vector2d(0, 0));
+}
+
+TEST(Path, VerticesDegenerateCurveStartWalksForwardToNextNonZeroTangent) {
+  Path path = PathBuilder()
+                  .moveTo({0, 0})
+                  .quadTo({0, 0}, {0, 0})
+                  .curveTo({0, 0}, {0, 0}, {10, 0})
+                  .lineTo({20, 0})
+                  .build();
+
+  std::vector<Path::Vertex> verts = path.vertices();
+
+  ASSERT_GE(verts.size(), 2u);
+  ExpectNear(verts.front().point, Vector2d(0, 0));
+  ExpectNear(verts.front().orientation, Vector2d(1, 0));
 }
 
 // =============================================================================

--- a/donner/base/xml/tests/XMLDocument_tests.cc
+++ b/donner/base/xml/tests/XMLDocument_tests.cc
@@ -243,6 +243,58 @@ TEST_F(XMLDocumentTests, AttributeAtSourceOffsetWithSourceOnlyDocumentReturnsNul
   EXPECT_THAT(doc.attributeAtSourceOffset(5), Eq(std::nullopt));
 }
 
+TEST_F(XMLDocumentTests, AttributeAtSourceOffsetIgnoresMalformedFallbackAttributeSpan) {
+  XMLDocument doc = ParseDocument(R"(<svg><rect fill="red" stroke="blue"/></svg>)");
+  XMLNode rect = doc.root().firstChild()->firstChild().value();
+  rect.clearAttributeSourceLocation("fill");
+  const std::size_t fillOffset = doc.source().find("fill");
+  ASSERT_NE(fillOffset, std::string_view::npos);
+  ASSERT_TRUE(doc.sourceStore()
+                  ->replace(fillOffset, std::string_view(R"(fill="red")").size(), "fill=")
+                  .has_value());
+
+  EXPECT_THAT(doc.attributeAtSourceOffset(fillOffset), Eq(std::nullopt));
+}
+
+TEST_F(XMLDocumentTests, AttributeAtSourceOffsetIgnoresFallbackAttributeWithUnquotedValue) {
+  XMLDocument doc = ParseDocument(R"(<svg><rect fill="red" stroke="blue"/></svg>)");
+  XMLNode rect = doc.root().firstChild()->firstChild().value();
+  rect.clearAttributeSourceLocation("fill");
+  const std::size_t fillOffset = doc.source().find("fill");
+  ASSERT_NE(fillOffset, std::string_view::npos);
+  ASSERT_TRUE(doc.sourceStore()
+                  ->replace(fillOffset, std::string_view(R"(fill="red")").size(), "fill=red")
+                  .has_value());
+
+  EXPECT_THAT(doc.attributeAtSourceOffset(fillOffset), Eq(std::nullopt));
+}
+
+TEST_F(XMLDocumentTests, AttributeAtSourceOffsetIgnoresFallbackAttributeWithMismatchedQuote) {
+  XMLDocument doc = ParseDocument(R"(<svg><rect fill="red" stroke="blue"/></svg>)");
+  XMLNode rect = doc.root().firstChild()->firstChild().value();
+  rect.clearAttributeSourceLocation("fill");
+  const std::size_t fillOffset = doc.source().find("fill");
+  ASSERT_NE(fillOffset, std::string_view::npos);
+  ASSERT_TRUE(doc.sourceStore()
+                  ->replace(fillOffset, std::string_view(R"(fill="red")").size(), "fill='red\"")
+                  .has_value());
+
+  EXPECT_THAT(doc.attributeAtSourceOffset(fillOffset), Eq(std::nullopt));
+}
+
+TEST_F(XMLDocumentTests, AttributeAtSourceOffsetIgnoresFallbackAttributeWithoutEquals) {
+  XMLDocument doc = ParseDocument(R"(<svg><rect fill="red" stroke="blue"/></svg>)");
+  XMLNode rect = doc.root().firstChild()->firstChild().value();
+  rect.clearAttributeSourceLocation("fill");
+  const std::size_t fillOffset = doc.source().find("fill");
+  ASSERT_NE(fillOffset, std::string_view::npos);
+  ASSERT_TRUE(doc.sourceStore()
+                  ->replace(fillOffset, std::string_view(R"(fill="red")").size(), "fill")
+                  .has_value());
+
+  EXPECT_THAT(doc.attributeAtSourceOffset(fillOffset), Eq(std::nullopt));
+}
+
 //
 // applySourceEdit - error paths.
 //
@@ -327,6 +379,26 @@ TEST_F(XMLDocumentTests, ApplySourceEditUpdatesAttributeValueScope) {
   EXPECT_EQ(doc.source(), R"(<svg><rect fill="blue"/></svg>)");
 }
 
+TEST_F(XMLDocumentTests, ApplySourceEditAttributeValueUsesFallbackSourceRange) {
+  XMLDocument doc = ParseDocument(R"(<svg><rect fill="red"/></svg>)");
+  XMLNode rect = doc.root().firstChild()->firstChild().value();
+  rect.clearAttributeSourceLocation("fill");
+  const std::size_t valueOffset = doc.source().find("red");
+  ASSERT_NE(valueOffset, std::string_view::npos);
+
+  ApplySourceEditResult result = doc.applySourceEdit(XMLEditIntent{
+      .range = SourceRange{FileOffset::Offset(valueOffset), FileOffset::Offset(valueOffset + 3)},
+      .replacement = "blue",
+      .sourceVersion = doc.sourceVersion(),
+  });
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_EQ(result.scope, ReparseScope::AttributeValue);
+  EXPECT_THAT(result.diagnostic, Eq(std::nullopt));
+  EXPECT_THAT(rect.getAttribute("fill"), Optional(Eq("blue")));
+  EXPECT_EQ(doc.source(), R"(<svg><rect fill="blue"/></svg>)");
+}
+
 TEST_F(XMLDocumentTests, ApplySourceEditMalformedAttributeValueKeepsDomAndReportsDiagnostic) {
   XMLDocument doc = ParseDocument(R"(<svg><rect fill="red"/></svg>)");
   XMLNode rect = doc.root().firstChild()->firstChild().value();
@@ -344,6 +416,90 @@ TEST_F(XMLDocumentTests, ApplySourceEditMalformedAttributeValueKeepsDomAndReport
   EXPECT_THAT(result, DiagnosticReasonContains("Node not closed"));
   EXPECT_THAT(rect.getAttribute("fill"), Optional(Eq("red")));
   EXPECT_THAT(MutationKinds(result),
+              testing::ElementsAre(XMLMutation::Kind::SourceDiagnosticChanged));
+}
+
+TEST_F(XMLDocumentTests, ApplySourceEditAttributeValueReportsInvalidatedOpeningTagRange) {
+  XMLDocument doc = ParseDocument(R"(<svg><rect fill="red"/></svg>)");
+  XMLNode rect = doc.root().firstChild()->firstChild().value();
+  const std::size_t attributeOffset = doc.source().find("fill");
+  ASSERT_NE(attributeOffset, std::string_view::npos);
+  const std::size_t attributeEnd = attributeOffset + std::string_view(R"(fill="red")").size();
+  rect.setAttributeSourceLocation(
+      "fill", SourceRange{FileOffset::Offset(attributeOffset), FileOffset::Offset(attributeEnd)},
+      SourceRange{FileOffset::Offset(attributeOffset), FileOffset::Offset(attributeEnd)}, '"');
+
+  ApplySourceEditResult result = doc.applySourceEdit(XMLEditIntent{
+      .range = SourceRange{FileOffset::Offset(attributeOffset), FileOffset::Offset(attributeEnd)},
+      .replacement = R"(fool="red")",
+      .sourceVersion = doc.sourceVersion(),
+  });
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_EQ(result.scope, ReparseScope::AttributeValue);
+  EXPECT_THAT(result, DiagnosticReasonContains("opening tag malformed"));
+  EXPECT_THAT(rect.getAttribute("fill"), Optional(Eq("red")));
+  EXPECT_EQ(doc.source(), R"(<svg><rect fool="red"/></svg>)");
+}
+
+TEST_F(XMLDocumentTests, ApplySourceEditRepeatedDiagnosticDoesNotEmitDuplicateMutation) {
+  XMLDocument doc = ParseDocument(R"(<svg><rect fill="red"/></svg>)");
+  const std::size_t valueOffset = doc.source().find("red");
+  ASSERT_NE(valueOffset, std::string_view::npos);
+
+  ApplySourceEditResult first = doc.applySourceEdit(XMLEditIntent{
+      .range = SourceRange{FileOffset::Offset(valueOffset), FileOffset::Offset(valueOffset + 3)},
+      .replacement = "bad\"",
+      .sourceVersion = doc.sourceVersion(),
+  });
+  ASSERT_TRUE(first.applied);
+  ASSERT_TRUE(first.diagnostic.has_value());
+
+  const std::size_t updatedValueOffset = doc.source().find("bad");
+  ASSERT_NE(updatedValueOffset, std::string_view::npos);
+  ApplySourceEditResult repeated = doc.applySourceEdit(XMLEditIntent{
+      .range = SourceRange{FileOffset::Offset(updatedValueOffset),
+                           FileOffset::Offset(updatedValueOffset + 4)},
+      .replacement = "bad\"",
+      .sourceVersion = doc.sourceVersion(),
+  });
+
+  EXPECT_TRUE(repeated.applied);
+  EXPECT_EQ(repeated.scope, ReparseScope::AttributeValue);
+  EXPECT_THAT(repeated.diagnostic, Eq(first.diagnostic));
+  EXPECT_THAT(MutationKinds(repeated), IsEmpty());
+}
+
+TEST_F(XMLDocumentTests, ApplySourceEditChangedDiagnosticRangeEmitsMutation) {
+  XMLDocument doc = ParseDocument(R"(<svg><rect fill="red"/></svg>)");
+  const std::size_t valueOffset = doc.source().find("red");
+  ASSERT_NE(valueOffset, std::string_view::npos);
+
+  ApplySourceEditResult first = doc.applySourceEdit(XMLEditIntent{
+      .range = SourceRange{FileOffset::Offset(valueOffset), FileOffset::Offset(valueOffset + 3)},
+      .replacement = "bad\"",
+      .sourceVersion = doc.sourceVersion(),
+  });
+  ASSERT_TRUE(first.applied);
+  ASSERT_TRUE(first.diagnostic.has_value());
+
+  auto& context = doc.registry().ctx().get<donner::xml::components::XMLDocumentContext>();
+  context.sourceDiagnostic = ParseDiagnostic::Error(
+      first.diagnostic->reason, SourceRange{FileOffset::Offset(0), FileOffset::Offset(0)});
+
+  const std::size_t updatedValueOffset = doc.source().find("bad");
+  ASSERT_NE(updatedValueOffset, std::string_view::npos);
+  ApplySourceEditResult repeated = doc.applySourceEdit(XMLEditIntent{
+      .range = SourceRange{FileOffset::Offset(updatedValueOffset),
+                           FileOffset::Offset(updatedValueOffset + 4)},
+      .replacement = "bad\"",
+      .sourceVersion = doc.sourceVersion(),
+  });
+
+  EXPECT_TRUE(repeated.applied);
+  EXPECT_EQ(repeated.scope, ReparseScope::AttributeValue);
+  EXPECT_THAT(repeated.diagnostic, Eq(first.diagnostic));
+  EXPECT_THAT(MutationKinds(repeated),
               testing::ElementsAre(XMLMutation::Kind::SourceDiagnosticChanged));
 }
 
@@ -492,6 +648,26 @@ TEST_F(XMLDocumentTests, ApplySourceEditDirtyOpeningTagUsesNodeRangeForDiagnosti
   EXPECT_THAT(rect.getAttribute("fill"), Optional(Eq("red")));
 }
 
+TEST_F(XMLDocumentTests, ApplySourceEditWithStaleElementStartFallsBackToParentSubtreeScope) {
+  XMLDocument doc = ParseDocument(R"(<svg><rect fill="red"/></svg>)");
+  XMLNode rect = doc.root().firstChild()->firstChild().value();
+  const std::size_t rectNameOffset = doc.source().find("rect");
+  ASSERT_NE(rectNameOffset, std::string_view::npos);
+  rect.setSourceStartOffset(FileOffset::Offset(rectNameOffset));
+
+  ApplySourceEditResult result = doc.applySourceEdit(XMLEditIntent{
+      .range =
+          SourceRange{FileOffset::Offset(rectNameOffset), FileOffset::Offset(rectNameOffset + 4)},
+      .replacement = "rect",
+      .sourceVersion = doc.sourceVersion(),
+  });
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_EQ(result.scope, ReparseScope::ElementSubtree);
+  EXPECT_THAT(result.diagnostic, Eq(std::nullopt));
+  EXPECT_EQ(rect.tagName(), XMLQualifiedNameRef("rect"));
+}
+
 TEST_F(XMLDocumentTests, ApplySourceEditAtOpeningTagStartUsesElementSubtreeScope) {
   XMLDocument doc = ParseDocument(R"(<svg><rect/></svg>)");
   const std::size_t rectStart = doc.source().find("<rect");
@@ -590,6 +766,33 @@ TEST_F(XMLDocumentTests, ApplySourceEditElementTextFallbackUsesTagBoundaries) {
   EXPECT_THAT(text.value(), Optional(Eq("world")));
 }
 
+TEST_F(XMLDocumentTests,
+       ApplySourceEditElementTextWithStaleClosingTagFallsBackToElementSubtreeScope) {
+  XMLDocument doc = ParseDocument(R"(<svg><text>hello</text></svg>)");
+  XMLNode text = doc.root().firstChild()->firstChild().value();
+  XMLNode textChild = text.firstChild().value();
+  textChild.clearSourceLocation();
+  text.clearValueLocation();
+  const std::size_t closingOffset = doc.source().find("</text>");
+  ASSERT_NE(closingOffset, std::string_view::npos);
+  ASSERT_TRUE(doc.sourceStore()
+                  ->replace(closingOffset, std::string_view("</text>").size(), "")
+                  .has_value());
+
+  const std::size_t textOffset = doc.source().find("hello");
+  ASSERT_NE(textOffset, std::string_view::npos);
+  ApplySourceEditResult result = doc.applySourceEdit(XMLEditIntent{
+      .range = SourceRange{FileOffset::Offset(textOffset), FileOffset::Offset(textOffset + 5)},
+      .replacement = "world",
+      .sourceVersion = doc.sourceVersion(),
+  });
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_EQ(result.scope, ReparseScope::ElementSubtree);
+  EXPECT_THAT(result, DiagnosticReasonContains("Mismatched closing tag"));
+  EXPECT_THAT(text.value(), Optional(Eq("hello")));
+}
+
 TEST_F(XMLDocumentTests, ApplySourceEditElementTextWithElementChildUsesSubtreeScope) {
   XMLDocument doc = ParseDocument(R"(<svg><text>hello<tspan/>world</text></svg>)");
   XMLNode text = doc.root().firstChild()->firstChild().value();
@@ -668,6 +871,29 @@ TEST_F(XMLDocumentTests, ApplySourceEditCommentTextNodeScopeUpdatesRawText) {
   EXPECT_EQ(result.scope, ReparseScope::ElementSubtree);
   EXPECT_THAT(result.diagnostic, Eq(std::nullopt));
   EXPECT_EQ(doc.source(), R"(<svg><!--goodbye--></svg>)");
+}
+
+TEST_F(XMLDocumentTests, ApplySourceEditParsedCommentRejectsSplitCommentStructure) {
+  ParseResult<XMLDocument> maybeDocument =
+      XMLParser::Parse(R"(<svg><!--hello--></svg>)", XMLParser::Options::ParseAll());
+  ASSERT_THAT(maybeDocument, NoParseError());
+  XMLDocument doc = std::move(maybeDocument.result());
+  XMLNode comment = doc.root().firstChild()->firstChild().value();
+  ASSERT_EQ(comment.type(), XMLNode::Type::Comment);
+  const std::size_t textOffset = doc.source().find("hello");
+  ASSERT_NE(textOffset, std::string_view::npos);
+
+  ApplySourceEditResult result = doc.applySourceEdit(XMLEditIntent{
+      .range = SourceRange{FileOffset::Offset(textOffset), FileOffset::Offset(textOffset + 5)},
+      .replacement = "goodbye--><!--again",
+      .sourceVersion = doc.sourceVersion(),
+  });
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_EQ(result.scope, ReparseScope::TextNode);
+  EXPECT_THAT(result, DiagnosticReasonContains("changed the local XML structure"));
+  EXPECT_THAT(comment.value(), Optional(Eq("hello")));
+  EXPECT_EQ(doc.source(), R"(<svg><!--goodbye--><!--again--></svg>)");
 }
 
 TEST_F(XMLDocumentTests, ApplySourceEditTextNodeRejectsInsertedMarkup) {
@@ -953,6 +1179,33 @@ TEST_F(XMLDocumentTests, ApplySourceEditElementSubtreeMalformedReportsDiagnostic
               testing::ElementsAre(XMLMutation::Kind::SourceDiagnosticChanged));
 }
 
+TEST_F(XMLDocumentTests, ApplySourceEditElementSubtreeRenamedSourceReportsDiagnostic) {
+  XMLDocument doc = ParseDocument(R"(<svg><g><rect/></g></svg>)");
+  XMLNode group = doc.root().firstChild()->firstChild().value();
+  const std::size_t openingTagOffset = doc.source().find("<g");
+  const std::size_t closingTagOffset = doc.source().find("</g>");
+  ASSERT_NE(openingTagOffset, std::string_view::npos);
+  ASSERT_NE(closingTagOffset, std::string_view::npos);
+  ASSERT_TRUE(doc.sourceStore()->replace(openingTagOffset + 1, 1, "h").has_value());
+  ASSERT_TRUE(doc.sourceStore()->replace(closingTagOffset + 2, 1, "h").has_value());
+  const std::size_t editStart = doc.source().find("<rect");
+  ASSERT_NE(editStart, std::string_view::npos);
+  const std::size_t editEnd = editStart + std::string_view("<rect/>").size();
+
+  ApplySourceEditResult result = doc.applySourceEdit(XMLEditIntent{
+      .range = SourceRange{FileOffset::Offset(editStart), FileOffset::Offset(editEnd)},
+      .replacement = "<circle/>",
+      .sourceVersion = doc.sourceVersion(),
+  });
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_EQ(result.scope, ReparseScope::ElementSubtree);
+  EXPECT_THAT(result, DiagnosticReasonContains("renamed the target element"));
+  EXPECT_EQ(group.tagName(), XMLQualifiedNameRef("g"));
+  ASSERT_TRUE(group.firstChild().has_value());
+  EXPECT_EQ(group.firstChild()->tagName(), XMLQualifiedNameRef("rect"));
+}
+
 TEST_F(XMLDocumentTests, ApplySourceEditSuccessClearsPreviousScopedDiagnostic) {
   XMLDocument doc = ParseDocument(R"(<svg><rect fill="red"/></svg>)");
   const std::size_t valueOffset = doc.source().find("red");
@@ -1010,6 +1263,24 @@ TEST_F(XMLDocumentTests, SetAttributeFallsBackToOpeningTagScanWhenCachedRangeIsM
   EXPECT_EQ(result.scope, ReparseScope::AttributeValue);
   EXPECT_THAT(rect.getAttribute("fill"), Optional(Eq("blue")));
   EXPECT_EQ(doc.source(), R"(<svg><rect fill = 'blue' /></svg>)");
+}
+
+TEST_F(XMLDocumentTests, SetAttributeFallsBackWhenCachedValueRangeIsMissing) {
+  XMLDocument doc = ParseDocument(R"(<svg><rect fill="red"/></svg>)");
+  XMLNode rect = doc.root().firstChild()->firstChild().value();
+  std::optional<XMLAttributeSourceLocation> sourceLocation =
+      rect.getAttributeSourceLocation("fill");
+  ASSERT_TRUE(sourceLocation.has_value());
+  rect.setAttributeSourceLocation("fill", sourceLocation->fullRange,
+                                  SourceRange{FileOffset::EndOfString(), FileOffset::EndOfString()},
+                                  sourceLocation->quote);
+
+  ApplySourceEditResult result = doc.setAttribute(rect, "fill", "blue");
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_EQ(result.scope, ReparseScope::AttributeValue);
+  EXPECT_THAT(rect.getAttribute("fill"), Optional(Eq("blue")));
+  EXPECT_EQ(doc.source(), R"(<svg><rect fill="blue"/></svg>)");
 }
 
 TEST_F(XMLDocumentTests, SetAttributePreservesSingleQuoteStyleAndEscapesValue) {
@@ -1171,6 +1442,23 @@ TEST_F(XMLDocumentTests, SetAttributeExistingDomOnlyAttributeFailsWithoutSourceR
   XMLDocument doc = ParseDocument(R"(<svg><rect/></svg>)");
   XMLNode rect = doc.root().firstChild()->firstChild().value();
   rect.setAttribute("fill", "red");
+
+  ApplySourceEditResult result = doc.setAttribute(rect, "fill", "blue");
+
+  EXPECT_FALSE(result.applied);
+  EXPECT_THAT(result, DiagnosticReasonContains("without a source range"));
+  EXPECT_THAT(rect.getAttribute("fill"), Optional(Eq("red")));
+}
+
+TEST_F(XMLDocumentTests, SetAttributeExistingAttributeWithMalformedFallbackRangeFails) {
+  XMLDocument doc = ParseDocument(R"(<svg><rect fill="red"/></svg>)");
+  XMLNode rect = doc.root().firstChild()->firstChild().value();
+  rect.clearAttributeSourceLocation("fill");
+  const std::size_t fillOffset = doc.source().find("fill");
+  ASSERT_NE(fillOffset, std::string_view::npos);
+  ASSERT_TRUE(doc.sourceStore()
+                  ->replace(fillOffset, std::string_view(R"(fill="red")").size(), "fill=")
+                  .has_value());
 
   ApplySourceEditResult result = doc.setAttribute(rect, "fill", "blue");
 
@@ -1894,6 +2182,22 @@ TEST_F(XMLDocumentTests, SetElementTextExpandsSelfClosingElement) {
   EXPECT_EQ(doc.source(), R"(<svg><text>hello</text></svg>)");
 }
 
+TEST_F(XMLDocumentTests, SetElementTextExpandsSelfClosingElementWithWhitespaceBeforeSlash) {
+  for (std::string_view whitespace : {"\t", "\n", "\r"}) {
+    SCOPED_TRACE(testing::Message() << "whitespace byte " << static_cast<int>(whitespace[0]));
+    XMLDocument doc =
+        ParseDocument(std::string("<svg><text") + std::string(whitespace) + "/></svg>");
+    XMLNode text = doc.root().firstChild()->firstChild().value();
+
+    ApplySourceEditResult result = doc.setElementText(text, "hello");
+
+    EXPECT_TRUE(result.applied);
+    EXPECT_EQ(result.scope, ReparseScope::TextNode);
+    EXPECT_THAT(text.value(), Optional(Eq("hello")));
+    EXPECT_EQ(doc.source(), R"(<svg><text>hello</text></svg>)");
+  }
+}
+
 TEST_F(XMLDocumentTests, SetElementTextEmptyTextWithoutExistingValueIsNoOp) {
   XMLDocument doc = ParseDocument(R"(<svg><text></text></svg>)");
   XMLNode text = doc.root().firstChild()->firstChild().value();
@@ -1948,6 +2252,22 @@ TEST_F(XMLDocumentTests, SetElementTextRejectsInvalidXmlText) {
   EXPECT_FALSE(result.applied);
   EXPECT_THAT(result, DiagnosticReasonContains("cannot be represented"));
   EXPECT_EQ(doc.source(), R"(<svg><text>hello</text></svg>)");
+}
+
+TEST_F(XMLDocumentTests, SetElementTextRejectsInsertionWhenEndOffsetIsNotUtf8Boundary) {
+  XMLDocument doc = ParseDocument(R"(<svg><text/></svg>)");
+  XMLNode text = doc.root().firstChild()->firstChild().value();
+  std::string corruptSource(doc.source());
+  const std::size_t selfClosingEnd = corruptSource.find("/>") + 2;
+  corruptSource.insert(selfClosingEnd, std::string("\x80", 1));
+  doc.setSource(corruptSource);
+
+  ApplySourceEditResult result = doc.setElementText(text, "hello");
+
+  EXPECT_FALSE(result.applied);
+  EXPECT_THAT(result, DiagnosticReasonContains("Invalid source replacement"));
+  EXPECT_FALSE(text.value().has_value());
+  EXPECT_EQ(doc.source(), corruptSource);
 }
 
 TEST_F(XMLDocumentTests, SetElementTextOnSourcelessElementInSourceDocumentFails) {

--- a/donner/base/xml/tests/XMLParser_tests.cc
+++ b/donner/base/xml/tests/XMLParser_tests.cc
@@ -3,6 +3,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <array>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -51,6 +52,26 @@ auto SourceDiagnosticMutationIs(XMLNode node, DiagnosticMatcher diagnosticMatche
                                 ReparseScope scope) {
   return AllOf(MutationIs(XMLMutation::Kind::SourceDiagnosticChanged, node, scope),
                Field("diagnostic", &XMLMutation::diagnostic, diagnosticMatcher));
+}
+
+std::string Utf8(char32_t codepoint) {
+  std::string result;
+  if (codepoint <= 0x7F) {
+    result.push_back(static_cast<char>(codepoint));
+  } else if (codepoint <= 0x7FF) {
+    result.push_back(static_cast<char>(0xC0 | (codepoint >> 6)));
+    result.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+  } else if (codepoint <= 0xFFFF) {
+    result.push_back(static_cast<char>(0xE0 | (codepoint >> 12)));
+    result.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
+    result.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+  } else {
+    result.push_back(static_cast<char>(0xF0 | (codepoint >> 18)));
+    result.push_back(static_cast<char>(0x80 | ((codepoint >> 12) & 0x3F)));
+    result.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
+    result.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+  }
+  return result;
 }
 
 std::string_view SourceText(const XMLDocument& document, SourceRange range) {
@@ -353,6 +374,110 @@ TEST_F(XMLParserTests, ParsedTextLikeNodeValueSubspans) {
   EXPECT_EQ(SourceText(document, *cdata.getClosingTagLocation()), "]]>");
   ASSERT_TRUE(cdata.getValueLocation().has_value());
   EXPECT_EQ(SourceText(document, *cdata.getValueLocation()), "x<y");
+}
+
+TEST_F(XMLParserTests, ParsesRepresentativeUnicodeNameStartRanges) {
+  constexpr std::array<char32_t, 24> kNameStartCodepoints = {
+      U'_',   U'a',   U'Z',   0x00C0, 0x00D6, 0x00D8, 0x00F6, 0x00F8,
+      0x02FF, 0x0370, 0x037D, 0x037F, 0x1FFF, 0x200C, 0x200D, 0x2070,
+      0x218F, 0x2C00, 0x2FEF, 0x3001, 0xD7FF, 0xF900, 0xFDF0, 0xEFFFF,
+  };
+
+  std::string xml = "<root>";
+  for (std::size_t index = 0; index < kNameStartCodepoints.size(); ++index) {
+    xml += "<";
+    xml += Utf8(kNameStartCodepoints[index]);
+    xml += "node";
+    xml += std::to_string(index);
+    xml += "/>";
+  }
+  xml += "</root>";
+
+  ParseResult<XMLDocument> maybeDocument = XMLParser::Parse(xml);
+
+  ASSERT_THAT(maybeDocument, NoParseError());
+  XMLNode root = maybeDocument.result().root().firstChild().value();
+  std::size_t childCount = 0;
+  for (std::optional<XMLNode> child = root.firstChild(); child.has_value();
+       child = child->nextSibling()) {
+    ++childCount;
+  }
+  EXPECT_EQ(childCount, kNameStartCodepoints.size());
+}
+
+TEST_F(XMLParserTests, ParsesRepresentativeUnicodeNameCharRanges) {
+  constexpr std::array<char32_t, 10> kNameCharCodepoints = {
+      U'-', U'.', U'9', 0x00B7, 0x0300, 0x036F, 0x203F, 0x2040, 0x3001, 0xE0100,
+  };
+
+  std::string name = "a";
+  for (char32_t codepoint : kNameCharCodepoints) {
+    name += Utf8(codepoint);
+  }
+  const std::string xml = "<root " + name + R"(="value"/>)";
+
+  ParseResult<XMLDocument> maybeDocument = XMLParser::Parse(xml);
+
+  ASSERT_THAT(maybeDocument, NoParseError());
+  XMLNode root = maybeDocument.result().root().firstChild().value();
+  EXPECT_THAT(root.getAttribute(XMLQualifiedNameRef(name)), testing::Optional(RcString("value")));
+}
+
+TEST_F(XMLParserTests, RejectsInvalidUnicodeNameStartAndNameChar) {
+  EXPECT_THAT(
+      XMLParser::Parse("<root><" + Utf8(0x0300) + "bad/></root>"),
+      ParseErrorIs("Invalid element name: Expected qualified name, found invalid character"));
+  EXPECT_THAT(XMLParser::Parse("<root a" + Utf8(0xFFFE) + R"(="value"/>)"),
+              ParseErrorIs("Attribute name without value, expected '=' followed by a string"));
+}
+
+TEST_F(XMLParserTests, MalformedUtf8NamesArePreservedAsNameBytes) {
+  std::string invalidElementTagName;
+  invalidElementTagName.push_back(static_cast<char>(0xC3));
+  invalidElementTagName += "bad";
+  std::string invalidElementName = "<root><";
+  invalidElementName += invalidElementTagName;
+  invalidElementName += "/></root>";
+  ParseResult<XMLDocument> maybeElementDocument = XMLParser::Parse(invalidElementName);
+  ASSERT_THAT(maybeElementDocument, NoParseError());
+  XMLNode malformedElement =
+      maybeElementDocument.result().root().firstChild()->firstChild().value();
+  EXPECT_THAT(malformedElement.tagName(), Eq(invalidElementTagName));
+
+  std::string invalidAttributeQualifiedName = "a";
+  invalidAttributeQualifiedName.push_back(static_cast<char>(0xCC));
+  std::string invalidAttributeName = "<root a";
+  invalidAttributeName.push_back(static_cast<char>(0xCC));
+  invalidAttributeName += R"(="value"/>)";
+  ParseResult<XMLDocument> maybeAttributeDocument = XMLParser::Parse(invalidAttributeName);
+  ASSERT_THAT(maybeAttributeDocument, NoParseError());
+  XMLNode root = maybeAttributeDocument.result().root().firstChild().value();
+  EXPECT_THAT(root.getAttribute(XMLQualifiedNameRef(invalidAttributeQualifiedName)),
+              testing::Optional(RcString("value")));
+
+  XMLParser::Options options = XMLParser::Options::ParseAll();
+  std::string invalidInstructionTarget;
+  invalidInstructionTarget.push_back(static_cast<char>(0xC3));
+  std::string invalidProcessingInstructionTarget = "<?";
+  invalidProcessingInstructionTarget += invalidInstructionTarget;
+  invalidProcessingInstructionTarget += " value?><root/>";
+  ParseResult<XMLDocument> maybeInstructionDocument =
+      XMLParser::Parse(invalidProcessingInstructionTarget, options);
+  ASSERT_THAT(maybeInstructionDocument, NoParseError());
+  XMLNode instruction = maybeInstructionDocument.result().root().firstChild().value();
+  EXPECT_THAT(instruction.tagName(), Eq(invalidInstructionTarget));
+}
+
+TEST_F(XMLParserTests, MalformedUtf8EntityNamesRemainLiteral) {
+  std::string invalidEntityStart = "<node>&";
+  invalidEntityStart.push_back(static_cast<char>(0xC3));
+  invalidEntityStart += ";</node>";
+  EXPECT_THAT(parseAndGetNodeContents(invalidEntityStart), ParseResultIs(RcString("&\xC3;")));
+
+  std::string invalidEntityNameChar = "<node>&a";
+  invalidEntityNameChar.push_back(static_cast<char>(0xCC));
+  invalidEntityNameChar += ";</node>";
+  EXPECT_THAT(parseAndGetNodeContents(invalidEntityNameChar), ParseResultIs(RcString("&a\xCC;")));
 }
 
 TEST_F(XMLParserTests, XMLIncrementalParserParsesLocalFragments) {
@@ -2039,6 +2164,26 @@ TEST_F(XMLParserTests, ParseDoctypeSystemEntity) {
   ASSERT_TRUE(result.has_value()) << "SYSTEM entity declaration should parse without error";
 }
 
+TEST_F(XMLParserTests, ParseDoctypeEntityEndSkipsQuotedGreaterThan) {
+  auto result = XMLParser::Parse(R"(<!DOCTYPE test [<!ENTITY custom 'a>b'>]><node>&custom;</node>)",
+                                 optionsCustomEntities());
+
+  ASSERT_THAT(result, NoParseError());
+  XMLNode node = result.result().root().firstChild()->nextSibling().value();
+  ASSERT_TRUE(node.firstChild().has_value());
+  EXPECT_THAT(node.firstChild()->value(), testing::Optional(RcString("a>b")));
+}
+
+TEST_F(XMLParserTests, ParseDoctypePublicEntityAcceptsSingleQuotedSystemLiteral) {
+  XMLParser::Options options = optionsCustomEntities();
+
+  auto result = XMLParser::Parse(
+      R"(<!DOCTYPE svg [<!ENTITY logo PUBLIC "-//W3C//ENTITIES Logo//EN" 'logo.svg'>]><root/>)",
+      options);
+
+  EXPECT_THAT(result, NoParseError());
+}
+
 TEST_F(XMLParserTests, ParseProcessingInstructions) {
   // By default PI parsing is disabled
   {
@@ -2057,6 +2202,54 @@ TEST_F(XMLParserTests, ParseProcessingInstructions) {
   EXPECT_EQ(node.type(), XMLNode::Type::ProcessingInstruction);
   EXPECT_THAT(node.tagName(), Eq("php"));
   EXPECT_THAT(node.value(), Eq("contents "));
+}
+
+TEST_F(XMLParserTests, ParseProcessingInstructionTargetAllowsColonName) {
+  XMLParser::Options options = XMLParser::Options::ParseAll();
+
+  ParseResult<XMLDocument> result = XMLParser::Parse(R"(<?p:q value?><root/>)", options);
+
+  ASSERT_THAT(result, NoParseError());
+  XMLNode instruction = result.result().root().firstChild().value();
+  EXPECT_EQ(instruction.type(), XMLNode::Type::ProcessingInstruction);
+  EXPECT_THAT(instruction.tagName(), Eq("p:q"));
+  EXPECT_THAT(instruction.value(), Eq("value"));
+}
+
+TEST_F(XMLParserTests, ParseProcessingInstructionTargetAllowsLeadingColonName) {
+  XMLParser::Options options = XMLParser::Options::ParseAll();
+
+  ParseResult<XMLDocument> result = XMLParser::Parse(R"(<?:target value?><root/>)", options);
+
+  ASSERT_THAT(result, NoParseError());
+  XMLNode instruction = result.result().root().firstChild().value();
+  EXPECT_EQ(instruction.type(), XMLNode::Type::ProcessingInstruction);
+  EXPECT_THAT(instruction.tagName(), Eq(":target"));
+  EXPECT_THAT(instruction.value(), Eq("value"));
+}
+
+TEST_F(XMLParserTests, ParseProcessingInstructionTargetAllowsUnicodeName) {
+  XMLParser::Options options = XMLParser::Options::ParseAll();
+
+  ParseResult<XMLDocument> result = XMLParser::Parse("<?\xC3\xA9 value?><root/>", options);
+
+  ASSERT_THAT(result, NoParseError());
+  XMLNode instruction = result.result().root().firstChild().value();
+  EXPECT_EQ(instruction.type(), XMLNode::Type::ProcessingInstruction);
+  EXPECT_THAT(instruction.tagName(), Eq("\xC3\xA9"));
+  EXPECT_THAT(instruction.value(), Eq("value"));
+}
+
+TEST_F(XMLParserTests, ParseProcessingInstructionTargetAllowsUnicodeNameChar) {
+  XMLParser::Options options = XMLParser::Options::ParseAll();
+
+  ParseResult<XMLDocument> result = XMLParser::Parse("<?a\xCC\x80 value?><root/>", options);
+
+  ASSERT_THAT(result, NoParseError());
+  XMLNode instruction = result.result().root().firstChild().value();
+  EXPECT_EQ(instruction.type(), XMLNode::Type::ProcessingInstruction);
+  EXPECT_THAT(instruction.tagName(), Eq("a\xCC\x80"));
+  EXPECT_THAT(instruction.value(), Eq("value"));
 }
 
 TEST_F(XMLParserTests, ParseProcessingInstructionsErrors) {
@@ -2115,6 +2308,11 @@ TEST_F(XMLParserTests, EntitiesBuiltin) {
   // Invalid entities are not parsed.
   EXPECT_THAT(parseAndGetNodeContents(R"(<node>&invalid;</node>)"),
               ParseResultIs(RcString("&invalid;")));
+  EXPECT_THAT(parseAndGetNodeContents(R"(<node>&;</node>)"), ParseResultIs(RcString("&;")));
+  EXPECT_THAT(parseAndGetNodeContents(R"(<node>&invalid</node>)"),
+              ParseResultIs(RcString("&invalid")));
+  EXPECT_THAT(parseAndGetNodeContents(R"(<node>&bad-name;</node>)"),
+              ParseResultIs(RcString("&bad-name;")));
 }
 
 TEST_F(XMLParserTests, EntitiesNumeric) {
@@ -2268,6 +2466,20 @@ TEST_F(XMLParserTests, EntitiesCustom) {
   EXPECT_EQ(dataNode->value(), "replacement text");
 }
 
+TEST_F(XMLParserTests, CustomEntityNamesAllowUnicodeStartAndNameChars) {
+  auto result = XMLParser::Parse(
+      "<!DOCTYPE test ["
+      "<!ENTITY \xC3\xA9 \"acute\">"
+      "<!ENTITY n\xCC\x80 \"combining\">"
+      "]><node>&\xC3\xA9; &n\xCC\x80;</node>",
+      optionsCustomEntities());
+
+  ASSERT_THAT(result, NoParseError());
+  XMLNode node = result.result().root().firstChild()->nextSibling().value();
+  ASSERT_TRUE(node.firstChild().has_value());
+  EXPECT_THAT(node.firstChild()->value(), testing::Optional(RcString("acute combining")));
+}
+
 TEST_F(XMLParserTests, EntitiesCustomErrors) {
   using std::string_view_literals::operator""sv;
 
@@ -2300,6 +2512,10 @@ TEST_F(XMLParserTests, EntitiesCustomErrors) {
   EXPECT_THAT(
       XMLParser::Parse(R"(<!DOCTYPE test [<!ENTITY ext OTHER]>)", XMLParser::Options::ParseAll()),
       ParseErrorIs("Expected quoted string in entity decl"));
+
+  EXPECT_THAT(XMLParser::Parse(R"(<!DOCTYPE test [<!ENTITY ext "value" junk>]><node/>)",
+                               optionsCustomEntities()),
+              ParseErrorIs("Expected '>' at end of entity declaration"));
 
   EXPECT_THAT(XMLParser::Parse(R"(<!DOCTYPE [<!ENTITY "
 ">]>)",
@@ -2412,6 +2628,22 @@ TEST_F(XMLParserTests, MaxElementsLimitExceeded) {
 
   // Expect: root <a> (1), <b/> (2), <c/> (3), <d/> (exceeds) → error on <d/>.
   EXPECT_THAT(result, ParseErrorIs("Maximum element count exceeded"));
+}
+
+TEST_F(XMLParserTests, MaxElementsLimitAppliesToNonElementNodes) {
+  XMLParser::Options options = XMLParser::Options::ParseAll();
+  options.maxElements = 0;
+
+  EXPECT_THAT(XMLParser::Parse("<?xml version=\"1.0\"?>", options),
+              ParseErrorIs("Maximum element count exceeded"));
+  EXPECT_THAT(XMLParser::Parse("<!--x-->", options),
+              ParseErrorIs("Maximum element count exceeded"));
+  EXPECT_THAT(XMLParser::Parse("<![CDATA[x]]>", options),
+              ParseErrorIs("Maximum element count exceeded"));
+  EXPECT_THAT(XMLParser::Parse("<!DOCTYPE html>", options),
+              ParseErrorIs("Maximum element count exceeded"));
+  EXPECT_THAT(XMLParser::Parse("<?pi value?>", options),
+              ParseErrorIs("Maximum element count exceeded"));
 }
 
 TEST_F(XMLParserTests, MaxElementsLimitAllowsRealisticDocuments) {
@@ -2689,6 +2921,31 @@ TEST_F(XMLParserTests, NameRejectsInvalidUnicodeRange) {
   EXPECT_THAT(
       XMLParser::Parse("<\xC3\x97tag />"),
       ParseErrorIs("Invalid element name: Expected qualified name, found invalid character"));
+}
+
+TEST_F(XMLParserTests, NameParsingHandlesMalformedUtf8Sequences) {
+  const auto makeXml = [](std::string_view nameStartBytes) {
+    std::string xml = "<";
+    xml.append(nameStartBytes);
+    xml.append("tag />");
+    return xml;
+  };
+
+  // Malformed code points are decoded as U+FFFD, which XML names accept.
+  EXPECT_THAT(XMLParser::Parse(makeXml(std::string_view("\xC3", 1))), NoParseError());
+  EXPECT_THAT(XMLParser::Parse(makeXml(std::string_view("\xC0\xAF", 2))), NoParseError());
+  EXPECT_THAT(XMLParser::Parse(makeXml(std::string_view("\xE0\x80\x80", 3))), NoParseError());
+  EXPECT_THAT(XMLParser::Parse(makeXml(std::string_view("\xF0\x80\x80\x80", 4))), NoParseError());
+  EXPECT_THAT(XMLParser::Parse(makeXml(std::string_view("\xF4\x90\x80\x80", 4))), NoParseError());
+
+  constexpr std::string_view kUnclosedNodeError = "Node not closed with '>' or '/>'";
+
+  EXPECT_THAT(XMLParser::Parse(makeXml(std::string_view("\xC3\x28", 2))),
+              ParseErrorIs(kUnclosedNodeError));
+  EXPECT_THAT(XMLParser::Parse(makeXml(std::string_view("\xE2\x28\xA1", 3))),
+              ParseErrorIs(kUnclosedNodeError));
+  EXPECT_THAT(XMLParser::Parse(makeXml(std::string_view("\xF0\x28\x8C\xBC", 4))),
+              ParseErrorIs(kUnclosedNodeError));
 }
 
 TEST_F(XMLParserTests, NameCharAllowsMiddleDotB7) {

--- a/donner/base/xml/tests/XMLTokenizer_tests.cc
+++ b/donner/base/xml/tests/XMLTokenizer_tests.cc
@@ -175,6 +175,20 @@ TEST(XMLTokenizer, WhitespaceAroundEquals) {
                   Tok(T::Whitespace, " "), Tok(T::TagSelfClose, "/>")));
 }
 
+TEST(XMLTokenizer, TabNewlineAndCarriageReturnWhitespaceAroundAttributeEquals) {
+  EXPECT_THAT(TokenizeWithText("<a\tb\n=\r\"c\"/>"),
+              ElementsAre(Tok(T::TagOpen, "<"), Tok(T::TagName, "a"), Tok(T::Whitespace, "\t"),
+                          Tok(T::AttributeName, "b"), Tok(T::Whitespace, "\n"),
+                          Tok(T::Whitespace, "="), Tok(T::Whitespace, "\r"),
+                          Tok(T::AttributeValue, R"("c")"), Tok(T::TagSelfClose, "/>")));
+}
+
+TEST(XMLTokenizer, NonAsciiAndPunctuationNameCharacters) {
+  EXPECT_THAT(
+      TokenizeWithText("<é.attr-1/>"),
+      ElementsAre(Tok(T::TagOpen, "<"), Tok(T::TagName, "é.attr-1"), Tok(T::TagSelfClose, "/>")));
+}
+
 // =============================================================================
 // Special node types
 // =============================================================================
@@ -205,6 +219,16 @@ TEST(XMLTokenizer, XmlDeclaration) {
 TEST(XMLTokenizer, ProcessingInstruction) {
   EXPECT_THAT(TokenizeWithText("<?php echo 1; ?>"),
               ElementsAre(Tok(T::ProcessingInstruction, "<?php echo 1; ?>")));
+}
+
+TEST(XMLTokenizer, UnterminatedSpecialMarkupUsesErrorRecovery) {
+  EXPECT_THAT(TokenizeWithText("<![CDATA[unterminated"),
+              ElementsAre(Tok(T::ErrorRecovery, "<![CDATA[unterminated")));
+  EXPECT_THAT(TokenizeWithText("<!DOCTYPE svg [ <!ENTITY a \"b\"> "),
+              ElementsAre(Tok(T::ErrorRecovery, "<!DOCTYPE svg [ <!ENTITY a \"b\"> ")));
+  EXPECT_THAT(TokenizeWithText(R"(<?xml version="1.0")"),
+              ElementsAre(Tok(T::ErrorRecovery, R"(<?xml version="1.0")")));
+  EXPECT_THAT(TokenizeWithText("<?pi no end"), ElementsAre(Tok(T::ErrorRecovery, "<?pi no end")));
 }
 
 // =============================================================================
@@ -329,6 +353,34 @@ TEST(XMLTokenizer, EntityInTextEmitsEntityRefWithoutExpanding) {
       ElementsAre(Tok(T::TextContent, "a"), Tok(T::EntityRef, "&amp;"), Tok(T::TextContent, "b"),
                   Tok(T::EntityRef, "&#x20;"), Tok(T::TextContent, "c"), Tok(T::EntityRef, "&#32;"),
                   Tok(T::TextContent, "d&notClosed")));
+}
+
+TEST(XMLTokenizer, InvalidEntityFormsRemainTextContent) {
+  EXPECT_THAT(TokenizeWithText("& &#; &#x; &1; &name"),
+              ElementsAre(Tok(T::TextContent, "& &#; &#x; &1; &name")));
+}
+
+TEST(XMLTokenizer, ClosingTagWhitespaceAndMalformedCloseRecover) {
+  EXPECT_THAT(TokenizeWithText("</a \t>"),
+              ElementsAre(Tok(T::TagOpen, "</"), Tok(T::TagName, "a"), Tok(T::Whitespace, " \t"),
+                          Tok(T::TagClose, ">")));
+
+  EXPECT_THAT(TokenizeWithText("</a attr><b/>"),
+              ElementsAre(Tok(T::TagOpen, "</"), Tok(T::TagName, "a"), Tok(T::Whitespace, " "),
+                          Tok(T::ErrorRecovery, "attr>"), Tok(T::TagOpen, "<"),
+                          Tok(T::TagName, "b"), Tok(T::TagSelfClose, "/>")));
+}
+
+TEST(XMLTokenizer, AttributeNameRecoveryAndUnclosedOpeningTag) {
+  EXPECT_THAT(TokenizeWithText(R"(<a ="x"><b/>)"),
+              ElementsAre(Tok(T::TagOpen, "<"), Tok(T::TagName, "a"), Tok(T::Whitespace, " "),
+                          Tok(T::ErrorRecovery, R"(="x">)"), Tok(T::TagOpen, "<"),
+                          Tok(T::TagName, "b"), Tok(T::TagSelfClose, "/>")));
+
+  const auto tokens = TokenizeWithText("<a attr");
+  ASSERT_FALSE(tokens.empty());
+  EXPECT_EQ(tokens.back().type, T::ErrorRecovery);
+  EXPECT_EQ(Reconstruct("<a attr"), "<a attr");
 }
 
 TEST(XMLTokenizer, RepresentativeCorpusReconstructsInputByteForByte) {

--- a/donner/editor/DialogPresenter.h
+++ b/donner/editor/DialogPresenter.h
@@ -25,6 +25,15 @@ public:
   void setSaveFileError(std::string error);
   void clearSaveFileError();
 
+  /// Whether an Open SVG modal has been requested but not yet opened by render().
+  [[nodiscard]] bool openFileModalRequested() const { return openFileModalRequested_; }
+
+  /// Whether a Save SVG modal has been requested but not yet opened by render().
+  [[nodiscard]] bool saveFileModalRequested() const { return saveFileModalRequested_; }
+
+  /// Whether the About modal has been requested but not yet opened by render().
+  [[nodiscard]] bool aboutPopupRequested() const { return openAboutPopup_; }
+
 private:
   bool openFileModalRequested_ = false;
   bool saveFileModalRequested_ = false;

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -1425,6 +1425,110 @@ void EditorShell::updateWindowTitle() {
   }
 }
 
+void EditorShell::applyMenuActions(const MenuBarActions& menuActions) {
+  if (menuActions.openAbout) {
+    dialogPresenter_.requestAbout();
+  }
+  if (menuActions.openFile) {
+    dialogPresenter_.requestOpenFile(app_.currentFilePath());
+  }
+  if (menuActions.saveFile) {
+    requestSave();
+  }
+  if (menuActions.saveFileAs) {
+    requestSaveAs();
+  }
+  if (menuActions.exportViewportSvg) {
+    requestExportViewportSvg(/*includeOverlay=*/false);
+  }
+  if (menuActions.exportViewportSvgWithOverlay) {
+    requestExportViewportSvg(/*includeOverlay=*/true);
+  }
+  if (menuActions.revertFile) {
+    requestRevert();
+  }
+  if (menuActions.quit) {
+    glfwSetWindowShouldClose(window_.rawHandle(), GLFW_TRUE);
+  }
+  if (menuActions.undo && app_.canUndo()) {
+    app_.undo();
+  }
+  if (menuActions.redo && app_.canRedo()) {
+    app_.redo();
+  }
+  const bool sourcePaneFocusedForMenu = sourcePaneVisible_ && textEditor_.isFocused();
+  if (menuActions.cut) {
+    if (sourcePaneFocusedForMenu) {
+      textEditor_.cut();
+    } else {
+      cutSelectedShapesToClipboard();
+    }
+  }
+  if (menuActions.copy) {
+    if (sourcePaneFocusedForMenu) {
+      textEditor_.copy();
+    } else {
+      copySelectedShapesToClipboard();
+    }
+  }
+  if (menuActions.paste) {
+    if (sourcePaneFocusedForMenu) {
+      textEditor_.paste();
+    } else {
+      pasteShapesFromClipboard(/*inFront=*/false);
+    }
+  }
+  if (menuActions.pasteInFront) {
+    pasteShapesFromClipboard(/*inFront=*/true);
+  }
+  if (menuActions.convertTextToOutlines) {
+    convertSelectedTextToOutlines();
+  }
+  if (menuActions.selectAll) {
+    textEditor_.selectAll();
+  }
+  if (menuActions.selectAllCanvas) {
+    // Same canonical canvas Select-All path as the Cmd+A shortcut.
+    selectAllCanvasElements();
+  }
+  if (menuActions.deselectAll) {
+    // Source/XML pane focused: collapse the text selection to the caret, mirroring the
+    // focus-aware Cmd+Shift+A shortcut.
+    textEditor_.clearSelection();
+  }
+  if (menuActions.deselectAllCanvas) {
+    // Same canonical clear path as the Cmd+Shift+A shortcut and Escape.
+    app_.clearSelection();
+  }
+  if (menuActions.zoomIn) {
+    if (interactionController_.applyZoom(kKeyboardZoomStep,
+                                         interactionController_.viewport().paneCenter())) {
+      requestRenderAtEndOfFrame_ = true;
+    }
+  }
+  if (menuActions.zoomOut) {
+    if (interactionController_.applyZoom(1.0 / kKeyboardZoomStep,
+                                         interactionController_.viewport().paneCenter())) {
+      requestRenderAtEndOfFrame_ = true;
+    }
+  }
+  if (menuActions.actualSize) {
+    if (interactionController_.resetToActualSize()) {
+      requestRenderAtEndOfFrame_ = true;
+    }
+  }
+  if (menuActions.toggleSourceFocusMode) {
+    toggleSourceFocusMode();
+  }
+  const bool showCompositorDebugPanelBeforeMenu = showCompositorDebugPanel_;
+  const bool showPerfOverlayBeforeMenu = showPerfOverlay_;
+  ApplyViewMenuToggleActions(menuActions, &showCompositorDebugPanel_, &showPerfOverlay_);
+  if (showCompositorDebugPanel_ != showCompositorDebugPanelBeforeMenu ||
+      showPerfOverlay_ != showPerfOverlayBeforeMenu) {
+    window_.wakeEventLoop();
+  }
+}
+
 void EditorShell::handleGlobalShortcuts() {
   const bool anyPopupOpen = ImGui::IsPopupOpen(nullptr, ImGuiPopupFlags_AnyPopup);
   const bool cmd = ImGui::GetIO().KeyCtrl || ImGui::GetIO().KeySuper;
@@ -3999,107 +4103,7 @@ void EditorShell::runFrame() {
       .showPerfOverlay = showPerfOverlay_,
   };
   const MenuBarActions menuActions = menuBarPresenter_.render(menuState, uiFontBold_);
-  if (menuActions.openAbout) {
-    dialogPresenter_.requestAbout();
-  }
-  if (menuActions.openFile) {
-    dialogPresenter_.requestOpenFile(app_.currentFilePath());
-  }
-  if (menuActions.saveFile) {
-    requestSave();
-  }
-  if (menuActions.saveFileAs) {
-    requestSaveAs();
-  }
-  if (menuActions.exportViewportSvg) {
-    requestExportViewportSvg(/*includeOverlay=*/false);
-  }
-  if (menuActions.exportViewportSvgWithOverlay) {
-    requestExportViewportSvg(/*includeOverlay=*/true);
-  }
-  if (menuActions.revertFile) {
-    requestRevert();
-  }
-  if (menuActions.quit) {
-    glfwSetWindowShouldClose(window_.rawHandle(), GLFW_TRUE);
-  }
-  if (menuActions.undo && app_.canUndo()) {
-    app_.undo();
-  }
-  if (menuActions.redo && app_.canRedo()) {
-    app_.redo();
-  }
-  const bool sourcePaneFocusedForMenu = sourcePaneVisible_ && textEditor_.isFocused();
-  if (menuActions.cut) {
-    if (sourcePaneFocusedForMenu) {
-      textEditor_.cut();
-    } else {
-      cutSelectedShapesToClipboard();
-    }
-  }
-  if (menuActions.copy) {
-    if (sourcePaneFocusedForMenu) {
-      textEditor_.copy();
-    } else {
-      copySelectedShapesToClipboard();
-    }
-  }
-  if (menuActions.paste) {
-    if (sourcePaneFocusedForMenu) {
-      textEditor_.paste();
-    } else {
-      pasteShapesFromClipboard(/*inFront=*/false);
-    }
-  }
-  if (menuActions.pasteInFront) {
-    pasteShapesFromClipboard(/*inFront=*/true);
-  }
-  if (menuActions.convertTextToOutlines) {
-    convertSelectedTextToOutlines();
-  }
-  if (menuActions.selectAll) {
-    textEditor_.selectAll();
-  }
-  if (menuActions.selectAllCanvas) {
-    // Same canonical canvas Select-All path as the Cmd+A shortcut.
-    selectAllCanvasElements();
-  }
-  if (menuActions.deselectAll) {
-    // Source/XML pane focused: collapse the text selection to the caret, mirroring the
-    // focus-aware Cmd+Shift+A shortcut.
-    textEditor_.clearSelection();
-  }
-  if (menuActions.deselectAllCanvas) {
-    // Same canonical clear path as the Cmd+Shift+A shortcut and Escape.
-    app_.clearSelection();
-  }
-  if (menuActions.zoomIn) {
-    if (interactionController_.applyZoom(kKeyboardZoomStep,
-                                         interactionController_.viewport().paneCenter())) {
-      requestRenderAtEndOfFrame_ = true;
-    }
-  }
-  if (menuActions.zoomOut) {
-    if (interactionController_.applyZoom(1.0 / kKeyboardZoomStep,
-                                         interactionController_.viewport().paneCenter())) {
-      requestRenderAtEndOfFrame_ = true;
-    }
-  }
-  if (menuActions.actualSize) {
-    if (interactionController_.resetToActualSize()) {
-      requestRenderAtEndOfFrame_ = true;
-    }
-  }
-  if (menuActions.toggleSourceFocusMode) {
-    toggleSourceFocusMode();
-  }
-  const bool showCompositorDebugPanelBeforeMenu = showCompositorDebugPanel_;
-  const bool showPerfOverlayBeforeMenu = showPerfOverlay_;
-  ApplyViewMenuToggleActions(menuActions, &showCompositorDebugPanel_, &showPerfOverlay_);
-  if (showCompositorDebugPanel_ != showCompositorDebugPanelBeforeMenu ||
-      showPerfOverlay_ != showPerfOverlayBeforeMenu) {
-    window_.wakeEventLoop();
-  }
+  applyMenuActions(menuActions);
 
   dialogPresenter_.render(
       [this](std::string_view path, std::string* error) { return tryOpenPath(path, error); },

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -301,6 +301,7 @@ private:
   bool tryExportViewportSvgToPath(std::string_view path, std::string* error);
   bool synchronizeSourceBeforeSave(std::string* error);
   void updateWindowTitle();
+  void applyMenuActions(const MenuBarActions& menuActions);
   void handleGlobalShortcuts();
   /// True when the document has at least one selectable element (the canonical marquee/Select-All
   /// set). Gates whether Cmd+A / the Edit menu's "Select All" act on the canvas.

--- a/donner/editor/TextEditorCore.cc
+++ b/donner/editor/TextEditorCore.cc
@@ -1032,21 +1032,12 @@ void TextEditorCore::handleRegularCharacter(UndoState& state, const Coordinates&
 
   // Insert the character(s) at the current cursor position
   for (char ch : chars) {
-    if (ch == '\t' && insertSpaces_) {
-      // If we get a tab and we're using spaces, insert tabSize_ spaces
-      for (int i = 0; i < tabSize_; i++) {
-        line.insert(line.begin() + charIndex++, Glyph(' ', ColorIndex::Default));
-      }
-      added.append(tabSize_, ' ');
-    } else {
-      line.insert(line.begin() + charIndex++, Glyph(ch, ColorIndex::Default));
-      added.push_back(ch);
-    }
+    line.insert(line.begin() + charIndex++, Glyph(ch, ColorIndex::Default));
+    added.push_back(ch);
   }
 
   // Update cursor position
-  // For a tab, move cursor by tab size if using spaces, otherwise by 1
-  const int advance = (chars[0] == '\t' && insertSpaces_) ? tabSize_ : (int)chars.size();
+  const int advance = static_cast<int>(chars.size());
   state_.cursorPosition = Coordinates(coord.line, coord.column + advance);
 
   // Record what was added for undo
@@ -1791,7 +1782,7 @@ void TextEditorCore::colorize(int fromLine, int lines) {
 }
 
 void TextEditorCore::colorizeRange(int fromLine, int toLine) {
-  if (text_.getTotalLines() == 0 || !colorizerEnabled_) {
+  if (!colorizerEnabled_) {
     return;
   }
 

--- a/donner/editor/repro/ReproFile_tests.cc
+++ b/donner/editor/repro/ReproFile_tests.cc
@@ -1093,6 +1093,8 @@ TEST(ReproFileTest, RejectsMalformedEventAndHitVariants) {
       {"hit_empty_not_number", R"(,"e":[{"k":"mdown","hit":{"empty":"bad"}}])"},
       {"hit_tag_not_string", R"(,"e":[{"k":"mdown","hit":{"tag":123}}])"},
       {"hit_id_not_string", R"(,"e":[{"k":"mdown","hit":{"id":123}}])"},
+      {"hit_index_not_number", R"(,"e":[{"k":"mdown","hit":{"idx":"bad"}}])"},
+      {"event_array_missing_open_bracket", R"(,"e":{})"},
   };
 
   for (const auto& testCase : cases) {
@@ -1105,6 +1107,66 @@ TEST(ReproFileTest, RejectsMalformedEventAndHitVariants) {
     std::error_code ec;
     std::filesystem::remove(path, ec);
   }
+}
+
+TEST(ReproFileTest, RejectsMalformedActionVariants) {
+  const struct {
+    std::string_view label;
+    std::string_view actionSuffix;
+  } cases[] = {
+      {"action_array_missing_open_bracket", R"(,"a":{})"},
+      {"action_array_non_object", R"(,"a":[42])"},
+      {"action_missing_kind", R"(,"a":[{}])"},
+      {"action_kind_not_string", R"(,"a":[{"k":123}])"},
+      {"action_kind_unknown", R"(,"a":[{"k":"unknown"}])"},
+      {"active_tool_missing_tool", R"(,"a":[{"k":"active_tool"}])"},
+      {"active_tool_tool_not_string", R"(,"a":[{"k":"active_tool","tool":123}])"},
+      {"style_missing_property", R"(,"a":[{"k":"style","v":"red"}])"},
+      {"style_property_not_string", R"(,"a":[{"k":"style","p":123,"v":"red"}])"},
+      {"style_missing_value", R"(,"a":[{"k":"style","p":"fill"}])"},
+      {"style_value_not_string", R"(,"a":[{"k":"style","p":"fill","v":123}])"},
+  };
+
+  for (const auto& testCase : cases) {
+    SCOPED_TRACE(testCase.label);
+    const auto path = TempFile(testCase.label);
+    WriteTextFile(path, MetadataLineWith("") + FrameLineWith(testCase.actionSuffix));
+
+    EXPECT_FALSE(ReadReproFile(path).has_value());
+
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+  }
+}
+
+TEST(ReproFileTest, ReadsWhitespacePrefixedNestedBlocksAndEmptyArrays) {
+  const auto path = TempFile("whitespace_nested_blocks");
+  const std::string viewport =
+      R"("ox":0,"oy":1,"pw":100,"ph":200,"dpr":2,"z":3,)"
+      R"("pdx":4,"pdy":5,"psx":6,"psy":7,"vbx":8,"vby":9,"vbw":10,"vbh":11)";
+  const std::string expect =
+      R"("left_mouse_down_ordinal":1,"frame_offset_after_left_mouse_down":2,)"
+      R"("min_frame_index":3,"max_frame_index":4,"target_selector":"#target",)"
+      R"("crop_mode":"document","crop": 	{"x":5,"y":6,"w":7,"h":8})";
+  WriteTextFile(path,
+                MetadataLineWith(std::string(R"(,"expect": 	{)") + expect + "}") +
+                    FrameLineWith(std::string(R"(,"vp": 	{)") + viewport +
+                                  R"(},"a":[],"e":[{"k":"mdown","hit": 	{"tag":"rect"}}])"));
+
+  auto loaded = ReadReproFile(path);
+  ASSERT_TRUE(loaded.has_value());
+  ASSERT_TRUE(loaded->metadata.expect.has_value());
+  ASSERT_TRUE(loaded->metadata.expect->cropRect.has_value());
+  EXPECT_EQ(loaded->metadata.expect->cropRect->height, 8);
+  ASSERT_EQ(loaded->frames.size(), 1u);
+  ASSERT_TRUE(loaded->frames[0].viewport.has_value());
+  EXPECT_DOUBLE_EQ(loaded->frames[0].viewport->paneOriginY, 1.0);
+  ASSERT_EQ(loaded->frames[0].events.size(), 1u);
+  ASSERT_TRUE(loaded->frames[0].events[0].hit.has_value());
+  EXPECT_EQ(loaded->frames[0].events[0].hit->tag, "rect");
+
+  std::error_code ec;
+  std::filesystem::remove(path, ec);
 }
 
 TEST(ReproFileTest, RejectsMalformedExpectationVariants) {
@@ -1145,6 +1207,7 @@ TEST(ReproFileTest, RejectsMalformedExpectationVariants) {
       {"crop_x_missing", std::string(required) + R"(,"crop":{"y":2,"w":3,"h":4})"},
       {"crop_y_missing", std::string(required) + R"(,"crop":{"x":1,"w":3,"h":4})"},
       {"crop_w_missing", std::string(required) + R"(,"crop":{"x":1,"y":2,"h":4})"},
+      {"crop_h_missing", std::string(required) + R"(,"crop":{"x":1,"y":2,"w":3})"},
       {"crop_x_bad", std::string(required) + R"(,"crop":{"x":bad,"y":2,"w":3,"h":4})"},
       {"active_frame_bad", std::string(required) + R"(,"active_frame_index":"bad")"},
       {"comparison_frame_bad", std::string(required) + R"(,"comparison_frame_index":"bad")"},
@@ -1172,6 +1235,42 @@ TEST(ReproFileTest, RejectsMalformedExpectationVariants) {
     std::error_code ec;
     std::filesystem::remove(path, ec);
   }
+}
+
+TEST(ReproFileTest, ReadsMetadataWithWhitespaceAndWindowFallbacks) {
+  const auto path = TempFile("metadata_whitespace_fallbacks");
+  WriteTextFile(path, R"({"v":3,"svg": 	"\u0041.svg","wnd":[120,bad],"scale": 	2.5,"exp": 	1})"
+                      "\n" +
+                          FrameLineWith(R"(,"mdx":3,"mdy":4)"));
+
+  auto loaded = ReadReproFile(path);
+  ASSERT_TRUE(loaded.has_value());
+  EXPECT_EQ(loaded->metadata.svgPath, "A.svg");
+  EXPECT_EQ(loaded->metadata.windowWidth, 0);
+  EXPECT_EQ(loaded->metadata.windowHeight, 0);
+  EXPECT_DOUBLE_EQ(loaded->metadata.displayScale, 2.5);
+  EXPECT_TRUE(loaded->metadata.experimentalMode);
+  ASSERT_EQ(loaded->frames.size(), 1u);
+  EXPECT_DOUBLE_EQ(*loaded->frames[0].mouseDocX, 3.0);
+  EXPECT_DOUBLE_EQ(*loaded->frames[0].mouseDocY, 4.0);
+
+  std::error_code ec;
+  std::filesystem::remove(path, ec);
+}
+
+TEST(ReproFileTest, ReadsMetadataWithoutWindowArray) {
+  const auto path = TempFile("metadata_without_window_array");
+  WriteTextFile(path, R"({"v":3,"svg":"foo.svg","wnd":123,"scale":1.0,"exp":0})"
+                      "\n" +
+                          FrameLineWith(""));
+
+  auto loaded = ReadReproFile(path);
+  ASSERT_TRUE(loaded.has_value());
+  EXPECT_EQ(loaded->metadata.windowWidth, 0);
+  EXPECT_EQ(loaded->metadata.windowHeight, 0);
+
+  std::error_code ec;
+  std::filesystem::remove(path, ec);
 }
 
 TEST(ReproFileTest, WriteFailureWhenDestinationIsDirectory) {

--- a/donner/editor/tests/AttributeWriteback_tests.cc
+++ b/donner/editor/tests/AttributeWriteback_tests.cc
@@ -352,6 +352,25 @@ TEST(AttributeWritebackRegressionTest, RemoveSelfClosingElementConsumesCrLfLineE
             "<svg xmlns=\"http://www.w3.org/2000/svg\">\r\n  <circle id=\"b\"/>\r\n</svg>\r\n");
 }
 
+TEST(AttributeWritebackRegressionTest, RemoveSelfClosingElementConsumesBareCrLineEnding) {
+  constexpr std::string_view kSource =
+      "<svg xmlns=\"http://www.w3.org/2000/svg\">\r  <circle id=\"a\"/>\r  <circle id=\"b\"/>\r"
+      "</svg>\r";
+  auto document = ParseDocument(kSource);
+  ASSERT_TRUE(document.has_value());
+  const svg::SVGElement circle = GetElementById(*document, "#a");
+  const auto target = captureAttributeWritebackTarget(circle);
+  ASSERT_TRUE(target.has_value());
+
+  auto patch = buildElementRemoveWriteback(kSource, *target);
+  ASSERT_TRUE(patch.has_value());
+
+  std::string source(kSource);
+  const auto result = applyPatches(source, {{*patch}});
+  ASSERT_EQ(result.applied, 1u);
+  EXPECT_EQ(source, "<svg xmlns=\"http://www.w3.org/2000/svg\">\r  <circle id=\"b\"/>\r</svg>\r");
+}
+
 TEST(AttributeWritebackRegressionTest, RemoveInlineElementConsumesFollowingSpaceOnly) {
   constexpr std::string_view kSource =
       R"(<svg xmlns="http://www.w3.org/2000/svg"><circle id="a"/> <circle id="b"/></svg>)";
@@ -572,6 +591,20 @@ TEST(AttributeWritebackResolveTest, ElementOverloadAcceptsOpeningTagWhitespaceTe
   }
 }
 
+TEST(AttributeWritebackResolveTest, ElementOverloadReturnsNulloptForUnterminatedQuotedTag) {
+  auto document = ParseDocument(kSimpleSvg);
+  ASSERT_TRUE(document.has_value());
+  const svg::SVGElement rect = GetElementById(*document, "#r1");
+
+  const std::size_t rectStart = kSimpleSvg.find("<rect");
+  ASSERT_NE(rectStart, std::string_view::npos);
+
+  std::string staleSource(kSimpleSvg.substr(0, rectStart));
+  staleSource += R"(<rect id="r1" data-label="unterminated)";
+
+  EXPECT_FALSE(buildAttributeWriteback(staleSource, rect, "fill", "blue").has_value());
+}
+
 // --- target overload + malformed source ------------------------------------
 
 TEST(AttributeWritebackTargetOverloadTest, MalformedSourceReturnsNullopt) {
@@ -597,6 +630,36 @@ TEST(AttributeWritebackTargetOverloadTest, TargetNotInSourceReturnsNullopt) {
   EXPECT_FALSE(buildAttributeWriteback(kSource, target, "fill", "blue").has_value());
   EXPECT_FALSE(buildAttributeRemoveWriteback(kSource, target, "fill").has_value());
   EXPECT_FALSE(buildElementRemoveWriteback(kSource, target).has_value());
+}
+
+TEST(AttributeWritebackTargetOverloadTest, EmptyTargetReturnsNullopt) {
+  AttributeWritebackTarget target;
+
+  EXPECT_FALSE(buildAttributeWriteback(kSimpleSvg, target, "fill", "blue").has_value());
+  EXPECT_FALSE(buildAttributeRemoveWriteback(kSimpleSvg, target, "fill").has_value());
+  EXPECT_FALSE(buildElementRemoveWriteback(kSimpleSvg, target).has_value());
+}
+
+TEST(AttributeWritebackTargetOverloadTest, IdSearchWinsWhenSiblingOrderChanges) {
+  constexpr std::string_view kOriginalSource =
+      R"(<svg xmlns="http://www.w3.org/2000/svg"><rect id="a"/><rect id="b"/></svg>)";
+  auto originalDocument = ParseDocument(kOriginalSource);
+  ASSERT_TRUE(originalDocument.has_value());
+  const svg::SVGElement rectB = GetElementById(*originalDocument, "#b");
+  const auto target = captureAttributeWritebackTarget(rectB);
+  ASSERT_TRUE(target.has_value());
+
+  constexpr std::string_view kReorderedSource =
+      R"(<svg xmlns="http://www.w3.org/2000/svg"><rect id="b"/><rect id="a"/></svg>)";
+  auto patch = buildAttributeWriteback(kReorderedSource, *target, "fill", "blue");
+  ASSERT_TRUE(patch.has_value());
+
+  std::string source(kReorderedSource);
+  const auto result = applyPatches(source, {{*patch}});
+  ASSERT_EQ(result.applied, 1u);
+  EXPECT_EQ(
+      source,
+      R"(<svg xmlns="http://www.w3.org/2000/svg"><rect id="b" fill="blue"/><rect id="a"/></svg>)");
 }
 
 TEST(AttributeWritebackTargetOverloadTest, InsertsAttributeViaTargetOverload) {
@@ -682,6 +745,24 @@ TEST(AttributeWritebackTargetOverloadTest, InsertScannerSkipsQuotedTagCloseChara
   EXPECT_THAT(source, testing::HasSubstr(R"(data-note="a > b / c" fill="blue")"));
 }
 
+TEST(AttributeWritebackTargetOverloadTest, InsertScannerSkipsSingleQuotedTagCloseCharacters) {
+  constexpr std::string_view kSource =
+      R"(<svg xmlns="http://www.w3.org/2000/svg"><rect id="r1" data-note='a > b / c'/></svg>)";
+  auto document = ParseDocument(kSource);
+  ASSERT_TRUE(document.has_value());
+  const svg::SVGElement rect = GetElementById(*document, "#r1");
+  const auto target = captureAttributeWritebackTarget(rect);
+  ASSERT_TRUE(target.has_value());
+
+  auto patch = buildAttributeWriteback(kSource, *target, "fill", "blue");
+  ASSERT_TRUE(patch.has_value());
+
+  std::string source(kSource);
+  const auto result = applyPatches(source, {{*patch}});
+  ASSERT_EQ(result.applied, 1u);
+  EXPECT_THAT(source, testing::HasSubstr(R"(data-note='a > b / c' fill="blue")"));
+}
+
 TEST(AttributeWritebackTargetOverloadTest, RemoveInlineElementAfterNonIndentTextKeepsPrefix) {
   constexpr std::string_view kSource =
       R"(<svg xmlns="http://www.w3.org/2000/svg">prefix<circle id="a"/></svg>)";
@@ -698,6 +779,64 @@ TEST(AttributeWritebackTargetOverloadTest, RemoveInlineElementAfterNonIndentText
   const auto result = applyPatches(source, {{*patch}});
   ASSERT_EQ(result.applied, 1u);
   EXPECT_EQ(source, R"(<svg xmlns="http://www.w3.org/2000/svg">prefix</svg>)");
+}
+
+TEST(AttributeWritebackTargetOverloadTest, RemoveAttributeConsumesXmlWhitespaceKinds) {
+  struct Case {
+    std::string_view source;
+    std::string_view expected;
+  };
+
+  constexpr Case kCases[] = {
+      {
+          "<svg xmlns=\"http://www.w3.org/2000/svg\"><circle cx=\"1\"\ttransform=\"translate(5)\" "
+          "r=\"2\"/></svg>",
+          "<svg xmlns=\"http://www.w3.org/2000/svg\"><circle cx=\"1\" r=\"2\"/></svg>",
+      },
+      {
+          "<svg xmlns=\"http://www.w3.org/2000/svg\"><circle cx=\"1\"\ntransform=\"translate(5)\" "
+          "r=\"2\"/></svg>",
+          "<svg xmlns=\"http://www.w3.org/2000/svg\"><circle cx=\"1\" r=\"2\"/></svg>",
+      },
+      {
+          "<svg xmlns=\"http://www.w3.org/2000/svg\"><circle cx=\"1\"\rtransform=\"translate(5)\" "
+          "r=\"2\"/></svg>",
+          "<svg xmlns=\"http://www.w3.org/2000/svg\"><circle cx=\"1\" r=\"2\"/></svg>",
+      },
+  };
+
+  for (const Case& testCase : kCases) {
+    SCOPED_TRACE(testCase.source);
+    auto document = ParseDocument(testCase.source);
+    ASSERT_TRUE(document.has_value());
+    const svg::SVGElement circle = GetElementById(*document, "circle");
+    const auto target = captureAttributeWritebackTarget(circle);
+    ASSERT_TRUE(target.has_value());
+
+    auto patch = buildAttributeRemoveWriteback(testCase.source, *target, "transform");
+    ASSERT_TRUE(patch.has_value());
+
+    std::string source(testCase.source);
+    const auto result = applyPatches(source, {{*patch}});
+    ASSERT_EQ(result.applied, 1u);
+    EXPECT_EQ(source, testCase.expected);
+  }
+}
+
+TEST(AttributeWritebackTargetOverloadTest, RemoveRootElementAtEndOfSource) {
+  constexpr std::string_view kSource = R"(<svg xmlns="http://www.w3.org/2000/svg"/>)";
+  auto document = ParseDocument(kSource);
+  ASSERT_TRUE(document.has_value());
+  const auto target = captureAttributeWritebackTarget(document->svgElement());
+  ASSERT_TRUE(target.has_value());
+
+  auto patch = buildElementRemoveWriteback(kSource, *target);
+  ASSERT_TRUE(patch.has_value());
+
+  std::string source(kSource);
+  const auto result = applyPatches(source, {{*patch}});
+  ASSERT_EQ(result.applied, 1u);
+  EXPECT_TRUE(source.empty());
 }
 
 }  // namespace

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -54,6 +54,7 @@ donner_cc_test(
     name = "editor_shell_tests",
     srcs = ["EditorShell_tests.cc"],
     deps = [
+        "//donner/editor:clipboard_interface",
         "//donner/editor:editor_shell",
         "//donner/editor/gui:editor_window",
         "@com_google_gtest//:gtest_main",

--- a/donner/editor/tests/DocumentSave_tests.cc
+++ b/donner/editor/tests/DocumentSave_tests.cc
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <iterator>
 #include <optional>
+#include <sstream>
 #include <string>
 #include <string_view>
 
@@ -195,6 +196,48 @@ TEST(DocumentSaveTest, RejectsSymlinkDestinationWithoutTouchingTarget) {
   std::filesystem::remove(symlink);
   std::filesystem::remove(target);
 #endif
+}
+
+TEST(DocumentSaveTest, StreamsStatusesAndResultOkFlag) {
+  std::ostringstream statuses;
+  statuses << DocumentSaveStatus::Ok << " " << DocumentSaveStatus::OpenFailed << " "
+           << DocumentSaveStatus::WriteFailed << " " << DocumentSaveStatus::CloseFailed;
+
+  EXPECT_EQ(statuses.str(), "Ok OpenFailed WriteFailed CloseFailed");
+  EXPECT_TRUE(DocumentSaveResult{.status = DocumentSaveStatus::Ok}.ok());
+  EXPECT_FALSE(DocumentSaveResult{.status = DocumentSaveStatus::OpenFailed}.ok());
+}
+
+TEST(DocumentSaveTest, CreatesAndTruncatesDestinationWithoutFollowingSymlinks) {
+  const std::filesystem::path path = UniqueTestPath("created.svg");
+  std::filesystem::remove(path);
+
+  DocumentSaveResult result = SaveSourceToPath(path, "<svg id=\"first\"/>");
+  ASSERT_TRUE(result.ok()) << result.message;
+  EXPECT_EQ(result.bytesWritten, 17u);
+  EXPECT_EQ(ReadFile(path), "<svg id=\"first\"/>");
+
+  result = SaveSourceToPath(path, "");
+  ASSERT_TRUE(result.ok()) << result.message;
+  EXPECT_EQ(result.bytesWritten, 0u);
+  EXPECT_EQ(ReadFile(path), "");
+
+  std::filesystem::remove(path);
+}
+
+TEST(DocumentSaveTest, ReportsOpenFailureForDirectoryDestination) {
+  const std::filesystem::path directory = TestOutputDir() / "document_save_directory_destination";
+  std::filesystem::create_directories(directory);
+
+  const DocumentSaveResult result = SaveSourceToPath(directory, "<svg/>");
+
+  EXPECT_EQ(result.status, DocumentSaveStatus::OpenFailed);
+  EXPECT_NE(result.errorNumber, 0);
+  EXPECT_EQ(result.bytesWritten, 0u);
+  EXPECT_NE(result.message.find("Could not open "), std::string::npos);
+  EXPECT_NE(result.message.find(directory.string()), std::string::npos);
+
+  std::filesystem::remove(directory);
 }
 
 }  // namespace

--- a/donner/editor/tests/EditorApp_tests.cc
+++ b/donner/editor/tests/EditorApp_tests.cc
@@ -416,7 +416,58 @@ TEST(EditorAppTest, EmptySelectionMutatorsReturnFalseWithoutQueueingCommands) {
 
   EXPECT_FALSE(app.setAttributeOnSelection("fill", "#112233"));
   EXPECT_FALSE(app.setStylePropertyOnSelection("fill", "#112233"));
+  EXPECT_FALSE(app.setStrokeWidthOnSelection(5.0));
+  EXPECT_FALSE(app.deleteSelectionWithUndo(app.document().document().source()));
   EXPECT_EQ(app.document().queue().size(), 0u);
+}
+
+TEST(EditorAppTest, DeleteSelectionWithUndoKeepsLockedElementsSelected) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kTrivialSvg));
+
+  auto r1 = app.document().document().querySelector("#r1");
+  auto r2 = app.document().document().querySelector("#r2");
+  ASSERT_TRUE(r1.has_value());
+  ASSERT_TRUE(r2.has_value());
+
+  app.setElementLocked(*r1, true);
+  ASSERT_TRUE(app.flushFrame());
+  r1 = app.document().document().querySelector("#r1");
+  r2 = app.document().document().querySelector("#r2");
+  ASSERT_TRUE(r1.has_value());
+  ASSERT_TRUE(r2.has_value());
+
+  app.setSelection(std::vector<svg::SVGElement>{*r1, *r2});
+  const std::string sourceBefore(app.document().document().source());
+  EXPECT_TRUE(app.deleteSelectionWithUndo(sourceBefore));
+  ASSERT_TRUE(app.flushFrame());
+
+  EXPECT_TRUE(app.document().document().querySelector("#r1").has_value());
+  EXPECT_FALSE(app.document().document().querySelector("#r2").has_value());
+  ASSERT_EQ(app.selectedElements().size(), 1u);
+  EXPECT_EQ(app.selectedElements().front().id(), "r1");
+  ASSERT_EQ(app.undoTimeline().entryCount(), 1u);
+  ASSERT_TRUE(app.undoTimeline().nextUndoLabel().has_value());
+  EXPECT_EQ(*app.undoTimeline().nextUndoLabel(), "Delete element");
+}
+
+TEST(EditorAppTest, DeleteSelectionWithUndoRefusesAllLockedSelection) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kTrivialSvg));
+
+  auto r1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(r1.has_value());
+  app.setElementLocked(*r1, true);
+  ASSERT_TRUE(app.flushFrame());
+
+  r1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(r1.has_value());
+  app.setSelection(*r1);
+  EXPECT_FALSE(app.deleteSelectionWithUndo(app.document().document().source()));
+  EXPECT_FALSE(app.flushFrame());
+  EXPECT_TRUE(app.document().document().querySelector("#r1").has_value());
+  ASSERT_EQ(app.selectedElements().size(), 1u);
+  EXPECT_EQ(app.selectedElements().front().id(), "r1");
 }
 
 TEST(EditorAppTest, SetStylePropertyOnSelectionMergesIntoStyleAttribute) {
@@ -1648,6 +1699,28 @@ TEST(EditorAppReorderTest, NoOpWhenElementLocked) {
   EXPECT_THAT(ChildIds(app), ::testing::ElementsAre("r1", "r2", "r3"));
 }
 
+TEST(EditorAppReorderTest, DirectReorderRejectsRootSelfCrossParentAndCurrentPosition) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(R"svg(<svg xmlns="http://www.w3.org/2000/svg">
+    <g id="group"><rect id="child" width="10" height="10"/></g>
+    <rect id="sibling" x="20" width="10" height="10"/>
+  </svg>)svg"));
+
+  svg::SVGElement root = app.document().document().svgElement();
+  auto group = app.document().document().querySelector("#group");
+  auto child = app.document().document().querySelector("#child");
+  auto sibling = app.document().document().querySelector("#sibling");
+  ASSERT_TRUE(group.has_value());
+  ASSERT_TRUE(child.has_value());
+  ASSERT_TRUE(sibling.has_value());
+
+  EXPECT_FALSE(app.reorderElementBeforeSibling(root, std::nullopt));
+  EXPECT_FALSE(app.reorderElementBeforeSibling(*child, *child));
+  EXPECT_FALSE(app.reorderElementBeforeSibling(*child, *sibling));
+  EXPECT_FALSE(app.reorderElementBeforeSibling(*group, *sibling));
+  EXPECT_FALSE(app.flushFrame());
+}
+
 std::optional<std::string> AttrOf(EditorApp& app, std::string_view id, const char* attr) {
   const std::optional<svg::SVGElement> el =
       app.document().document().querySelector("#" + std::string(id));
@@ -1776,6 +1849,48 @@ TEST(EditorAppRenameTest, RenameLeavesHexColorLiteralsAndCommentsUntouched) {
 /* #abc historical note */
 .badge { content: "#abc"; clip-path: url(#brandBox) }
 @media (min-width: 10px) { #brandBox { opacity: 0.5 } })css")));
+}
+
+TEST(EditorAppRenameTest, RenameLeavesEscapedQuotedCssAndUnclosedCommentsUntouched) {
+  constexpr std::string_view kCssStringDoc =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+         <style>#target { fill: red }
+.badge { content: "#target \"literal\""; clip-path: url(#target); marker: url(#targeted) }
+@supports (display: grid) { #target { opacity: 0.5 } }
+/* #target unfinished comment</style>
+         <rect id="target" x="0" y="0" width="50" height="50"/>
+       </svg>)svg";
+
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(std::string(kCssStringDoc)));
+  SelectById(app, "target");
+  EXPECT_TRUE(app.renameSelectedElement("renamed"));
+  ASSERT_TRUE(app.flushFrame());
+
+  EXPECT_THAT(StyleTextOf(app), ::testing::Optional(std::string(
+                                    R"css(#renamed { fill: red }
+.badge { content: "#target \"literal\""; clip-path: url(#renamed); marker: url(#targeted) }
+@supports (display: grid) { #renamed { opacity: 0.5 } }
+/* #target unfinished comment)css")));
+}
+
+TEST(EditorAppRenameTest, RenameRepointsOnlyExactUrlIdTokensWithIdCharSuffixes) {
+  constexpr std::string_view kBoundaryDoc =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+         <defs><linearGradient id="grad"/></defs>
+         <rect id="r" x="0" y="0" width="50" height="50"
+               data-refs="url(#grad) url(#grad-a) url(#grad_a) url(#grad:variant) url(#grad.variant) url(#grad9) url(#gradA)"/>
+       </svg>)svg";
+
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(std::string(kBoundaryDoc)));
+  SelectById(app, "grad");
+  EXPECT_TRUE(app.renameSelectedElement("g2"));
+  ASSERT_TRUE(app.flushFrame());
+
+  EXPECT_EQ(AttrOf(app, "r", "data-refs"),
+            "url(#g2) url(#grad-a) url(#grad_a) url(#grad:variant) "
+            "url(#grad.variant) url(#grad9) url(#gradA)");
 }
 
 TEST(EditorAppRenameTest, RefusesEmptySameAndDuplicateIds) {

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -1,5 +1,6 @@
 #include "donner/editor/EditorShell.h"
 
+#include <GLFW/glfw3.h>
 #include <gtest/gtest.h>
 
 #include <chrono>
@@ -11,7 +12,9 @@
 #include <thread>
 #include <vector>
 
+#include "donner/editor/InMemoryClipboard.h"
 #include "donner/editor/gui/EditorWindow.h"
+#include "donner/editor/repro/ReproFile.h"
 
 namespace donner::editor {
 namespace {
@@ -49,6 +52,29 @@ constexpr std::string_view kReferencedSvg = R"svg(
   </defs>
   <rect id="target" x="10" y="12" width="40" height="24" fill="url(#paint)" clip-path="url(#clip)"/>
   <circle id="referrer" cx="80" cy="40" r="10" fill="url(#paint)"/>
+</svg>
+)svg";
+
+constexpr std::string_view kPaintToolbarSvg = R"svg(
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="80" viewBox="0 0 120 80">
+  <defs>
+    <linearGradient id="paint">
+      <stop offset="0" stop-color="red"/>
+    </linearGradient>
+  </defs>
+  <rect id="local" x="10" y="12" width="20" height="20" fill="url(#paint)" stroke="url(#paint)"/>
+  <rect id="missing" x="40" y="12" width="20" height="20" fill="url(#missing)"/>
+  <rect id="contextual" x="70" y="12" width="20" height="20" fill="context-fill"/>
+  <rect id="styled-none-attribute" x="70" y="42" width="20" height="20"
+        fill="context-stroke" style="fill: none"/>
+  <rect id="external" x="10" y="42" width="20" height="20"
+        fill="url(https://example.invalid/paint.svg#paint)"/>
+</svg>
+)svg";
+
+constexpr std::string_view kIntrinsicSizeSvg = R"svg(
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="90">
+  <rect id="target" width="160" height="90"/>
 </svg>
 )svg";
 
@@ -113,6 +139,36 @@ public:
     shell.requestSaveAs(std::move(error));
   }
 
+  static void RequestExportViewportSvg(EditorShell& shell, bool includeOverlay,
+                                       std::string error = std::string()) {
+    shell.requestExportViewportSvg(includeOverlay, std::move(error));
+  }
+
+  static bool TryExportViewportSvgToPath(EditorShell& shell, std::string_view path,
+                                         std::string* error) {
+    return shell.tryExportViewportSvgToPath(path, error);
+  }
+
+  static bool PendingViewportExport(const EditorShell& shell) {
+    return shell.pendingViewportExport_;
+  }
+
+  static bool PendingViewportExportOverlay(const EditorShell& shell) {
+    return shell.pendingViewportExportOverlay_;
+  }
+
+  static bool OpenFileModalRequested(const EditorShell& shell) {
+    return shell.dialogPresenter_.openFileModalRequested();
+  }
+
+  static bool SaveFileModalRequested(const EditorShell& shell) {
+    return shell.dialogPresenter_.saveFileModalRequested();
+  }
+
+  static bool AboutPopupRequested(const EditorShell& shell) {
+    return shell.dialogPresenter_.aboutPopupRequested();
+  }
+
   static void MaybeLogResourceDiagnostics(EditorShell& shell, const FrameCostBreakdown& frameCost) {
     shell.maybeLogResourceDiagnostics(frameCost);
   }
@@ -166,11 +222,15 @@ public:
   static void ConfigureViewport(EditorShell& shell, const Box2d& documentViewBox) {
     shell.interactionController_.updatePaneLayout(Vector2d(20.0, 30.0), Vector2d(400.0, 260.0),
                                                   documentViewBox);
-    shell.interactionController_.resetToActualSize();
+    (void)shell.interactionController_.resetToActualSize();
   }
 
   static void RefreshSelectionBoundsCache(EditorShell& shell) {
     shell.renderCoordinator_.refreshSelectionBoundsCache(shell.app_);
+  }
+
+  static bool FlushQueuedMutationAndRefreshOverlay(EditorShell& shell) {
+    return shell.flushQueuedMutationAndRefreshOverlay();
   }
 
   static std::size_t DisplayedSelectionBoundsCount(const EditorShell& shell) {
@@ -194,6 +254,14 @@ public:
     return shell.styleFocusAtSourceCursor();
   }
 
+  static void ApplyPendingDocumentSpaceReplayInput(EditorShell& shell) {
+    shell.applyPendingDocumentSpaceReplayInputForTesting();
+  }
+
+  static void ApplyReplayAction(EditorShell& shell, const repro::ReproAction& action) {
+    shell.applyReplayActionForTesting(action);
+  }
+
   static void ApplyStyleFocus(EditorShell& shell, StyleFocus styleFocus) {
     shell.applyStyleFocus(std::move(styleFocus));
   }
@@ -204,6 +272,10 @@ public:
 
   static void OpenRenderPaneContextMenu(EditorShell& shell, const Vector2d& documentPoint) {
     shell.openRenderPaneContextMenu(documentPoint);
+  }
+
+  static void RenderRenderPaneContextMenu(EditorShell& shell) {
+    shell.renderRenderPaneContextMenu();
   }
 
   static std::vector<SourceByteRange> SourceHoverRangesForElements(
@@ -251,7 +323,187 @@ public:
     return shell.toolPaletteScreenRect(paneOrigin, contentRegion);
   }
 
+  static bool CanvasHasSelectableElements(EditorShell& shell) {
+    return shell.canvasHasSelectableElements();
+  }
+
+  static void SelectAllCanvasElements(EditorShell& shell) { shell.selectAllCanvasElements(); }
+
+  static bool SelectionIsAllText(const EditorShell& shell) { return shell.selectionIsAllText(); }
+
+  static void ConvertSelectedTextToOutlines(EditorShell& shell) {
+    shell.convertSelectedTextToOutlines();
+  }
+
+  static const std::string& LastConvertTextError(const EditorShell& shell) {
+    return shell.lastConvertTextError_;
+  }
+
+  static void RenderSourcePane(EditorShell& shell, float paneOriginY, float paneHeight,
+                               float paneWidth, ImFont* codeFont) {
+    shell.renderSourcePane(paneOriginY, paneHeight, paneWidth, codeFont);
+  }
+
+  static void RenderRenderPane(EditorShell& shell, const Vector2d& renderPaneOrigin,
+                               const Vector2d& renderPaneSize, ImGuiWindowFlags paneFlags) {
+    shell.renderRenderPane(renderPaneOrigin, renderPaneSize, paneFlags);
+  }
+
+  static void RenderFillStrokeToolbarWidget(EditorShell& shell) {
+    shell.renderFillStrokeToolbarWidget();
+  }
+
+  static void RenderToolPalette(EditorShell& shell, const ImVec2& paneOrigin,
+                                const ImVec2& contentRegion) {
+    shell.renderToolPalette(paneOrigin, contentRegion);
+  }
+
+  static void RenderSourcePaneSplitter(EditorShell& shell, float windowWidth, float paneOriginY,
+                                       float paneHeight, float sourcePaneWidth) {
+    shell.renderSourcePaneSplitter(windowWidth, paneOriginY, paneHeight, sourcePaneWidth);
+  }
+
+  static void RenderRightPaneSplitter(EditorShell& shell, float windowWidth, float paneOriginY,
+                                      float paneHeight) {
+    shell.renderRightPaneSplitter(windowWidth, paneOriginY, paneHeight);
+  }
+
+  static void RenderDockedLayerPanelDragHandle(EditorShell& shell) {
+    shell.renderDockedLayerPanelDragHandle();
+  }
+
+  static void RenderFloatingLayerPanel(EditorShell& shell) { shell.renderFloatingLayerPanel(); }
+
+  static void RenderLayerPanelContents(EditorShell& shell) { shell.renderLayerPanelContents(); }
+
+  static void ApplyMenuActions(EditorShell& shell, const MenuBarActions& actions) {
+    shell.applyMenuActions(actions);
+  }
+
+  static void UseInMemoryShapeClipboard(EditorShell& shell) {
+    shell.shapeClipboard_ = std::make_unique<InMemoryClipboard>();
+  }
+
+  static void ClearShapeClipboard(EditorShell& shell) { shell.shapeClipboard_.reset(); }
+
+  static void SetShapeClipboardText(EditorShell& shell, std::string_view text) {
+    ASSERT_NE(shell.shapeClipboard_, nullptr);
+    shell.shapeClipboard_->setText(text);
+  }
+
+  static std::string ShapeClipboardText(const EditorShell& shell) {
+    return shell.shapeClipboard_ != nullptr ? shell.shapeClipboard_->getText() : std::string();
+  }
+
+  static bool ShapeClipboardHasText(const EditorShell& shell) {
+    return shell.shapeClipboard_ != nullptr && shell.shapeClipboard_->hasText();
+  }
+
+  static void CopySelectedShapesToClipboard(EditorShell& shell) {
+    shell.copySelectedShapesToClipboard();
+  }
+
+  static void CutSelectedShapesToClipboard(EditorShell& shell) {
+    shell.cutSelectedShapesToClipboard();
+  }
+
+  static void PasteShapesFromClipboard(EditorShell& shell, bool inFront) {
+    shell.pasteShapesFromClipboard(inFront);
+  }
+
+  static void HandleGlobalShortcuts(EditorShell& shell) { shell.handleGlobalShortcuts(); }
+
+  static bool ActiveToolIsSelect(const EditorShell& shell) {
+    return shell.activeTool_ == EditorShell::ActiveTool::Select;
+  }
+
+  static bool ActiveToolIsPen(const EditorShell& shell) {
+    return shell.activeTool_ == EditorShell::ActiveTool::Pen;
+  }
+
+  static bool ActiveToolIsText(const EditorShell& shell) {
+    return shell.activeTool_ == EditorShell::ActiveTool::Text;
+  }
+
+  static bool PenToolIsDrafting(const EditorShell& shell) { return shell.penTool_.isDrafting(); }
+
+  static bool PenToolIsDraggingAnchor(const EditorShell& shell) {
+    return shell.penTool_.isDraggingAnchor();
+  }
+
+  static const std::string& PenToolActivePathData(const EditorShell& shell) {
+    return shell.penTool_.activePathData();
+  }
+
+  static bool PenDragFlushedThisFrame(const EditorShell& shell) {
+    return shell.penDragFlushedThisFrame_;
+  }
+
+  static bool SelectToolIsMarqueeing(const EditorShell& shell) {
+    return shell.selectTool_.isMarqueeing();
+  }
+
+  static void BufferPendingClick(EditorShell& shell, const Vector2d& documentPoint,
+                                 MouseModifiers modifiers = MouseModifiers{}) {
+    shell.interactionController_.bufferPendingClick(documentPoint, modifiers);
+  }
+
+  static bool HasPendingClick(const EditorShell& shell) {
+    return shell.interactionController_.pendingClick().has_value();
+  }
+
+  static void SetPendingSelectClickStartSeconds(EditorShell& shell, double seconds) {
+    shell.pendingSelectClickStartSeconds_ = seconds;
+  }
+
+  static bool RequestRenderAtEndOfFrame(const EditorShell& shell) {
+    return shell.requestRenderAtEndOfFrame_;
+  }
+
+  static void ClearRequestRenderAtEndOfFrame(EditorShell& shell) {
+    shell.requestRenderAtEndOfFrame_ = false;
+  }
+
+  static void SetShowCompositorDebugPanel(EditorShell& shell, bool value) {
+    shell.showCompositorDebugPanel_ = value;
+  }
+
+  static bool ShowCompositorDebugPanel(const EditorShell& shell) {
+    return shell.showCompositorDebugPanel_;
+  }
+
+  static bool ShowPerfOverlay(const EditorShell& shell) { return shell.showPerfOverlay_; }
+
+  static void SetLayerPanelDetached(EditorShell& shell, bool value) {
+    shell.layerPanelDetached_ = value;
+  }
+
+  static void SetLayerPanelDetachDragActive(EditorShell& shell, bool value) {
+    shell.layerPanelDetachDragActive_ = value;
+  }
+
+  static void SetLayerPanelFloatingNeedsPlacement(EditorShell& shell, bool value) {
+    shell.layerPanelFloatingNeedsPlacement_ = value;
+  }
+
+  static void SetLayerPanelFloatingGeometry(EditorShell& shell, const ImVec2& pos,
+                                            const ImVec2& size) {
+    shell.layerPanelFloatingPos_ = pos;
+    shell.layerPanelFloatingSize_ = size;
+  }
+
+  static bool LayerPanelDetached(const EditorShell& shell) { return shell.layerPanelDetached_; }
+
+  static bool LayerPanelDetachDragActive(const EditorShell& shell) {
+    return shell.layerPanelDetachDragActive_;
+  }
+
+  static bool LayerPanelFloatingNeedsPlacement(const EditorShell& shell) {
+    return shell.layerPanelFloatingNeedsPlacement_;
+  }
+
   static bool SourcePaneVisible(const EditorShell& shell) { return shell.sourcePaneVisible_; }
+  static float SourcePaneWidth(const EditorShell& shell) { return shell.sourcePaneWidth_; }
   static bool SourceFocusMode(const EditorShell& shell) { return shell.sourceFocusMode_; }
   static bool SourceFocusOriginatedInStyle(const EditorShell& shell) {
     return shell.sourceFocusOriginatedInStyle_;
@@ -319,6 +571,196 @@ void RunFramesUntilDisplayedSelectionBounds(gui::EditorWindow& window, EditorShe
   }
 }
 
+void DriveGlobalShortcut(EditorShell& shell, const std::vector<ImGuiKey>& keys, bool ctrl = false,
+                         bool shift = false, bool super = false) {
+  ImGuiIO& io = ImGui::GetIO();
+  io.DisplaySize = ImVec2(640.0f, 480.0f);
+  io.ConfigMacOSXBehaviors = false;
+  if (!io.Fonts->IsBuilt()) {
+    io.Fonts->Build();
+  }
+  if (ctrl) {
+    io.AddKeyEvent(ImGuiMod_Ctrl, true);
+  }
+  if (shift) {
+    io.AddKeyEvent(ImGuiMod_Shift, true);
+  }
+  if (super) {
+    io.AddKeyEvent(ImGuiMod_Super, true);
+  }
+  for (ImGuiKey key : keys) {
+    io.AddKeyEvent(key, true);
+  }
+
+  ImGui::NewFrame();
+  EditorShellTestAccess::HandleGlobalShortcuts(shell);
+  ImGui::Render();
+
+  for (ImGuiKey key : keys) {
+    io.AddKeyEvent(key, false);
+  }
+  if (super) {
+    io.AddKeyEvent(ImGuiMod_Super, false);
+  }
+  if (shift) {
+    io.AddKeyEvent(ImGuiMod_Shift, false);
+  }
+  if (ctrl) {
+    io.AddKeyEvent(ImGuiMod_Ctrl, false);
+  }
+  ImGui::NewFrame();
+  ImGui::Render();
+}
+
+void RenderToolbarFrame(gui::EditorWindow& window, EditorShell& shell, const ImVec2& cursor,
+                        const ImVec2& mouse, bool mouseDown) {
+  (void)window;
+  ImGuiIO& io = ImGui::GetIO();
+  io.DisplaySize = ImVec2(640.0f, 480.0f);
+  if (!io.Fonts->IsBuilt()) {
+    io.Fonts->Build();
+  }
+  io.AddMousePosEvent(mouse.x, mouse.y);
+  io.AddMouseButtonEvent(0, mouseDown);
+
+  ImGui::NewFrame();
+  constexpr ImGuiWindowFlags kHostFlags =
+      ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings;
+  ImGui::SetNextWindowPos(ImVec2(0.0f, 0.0f), ImGuiCond_Always);
+  ImGui::SetNextWindowSize(ImVec2(220.0f, 100.0f), ImGuiCond_Always);
+  ImGui::Begin("EditorShellToolbarMouseHost", nullptr, kHostFlags);
+  ImGui::SetCursorScreenPos(cursor);
+  EditorShellTestAccess::RenderFillStrokeToolbarWidget(shell);
+  ImGui::End();
+  ImGui::Render();
+}
+
+void ClickToolbar(gui::EditorWindow& window, EditorShell& shell, const ImVec2& cursor,
+                  const ImVec2& mouse) {
+  RenderToolbarFrame(window, shell, cursor, mouse, /*mouseDown=*/false);
+  RenderToolbarFrame(window, shell, cursor, mouse, /*mouseDown=*/true);
+  RenderToolbarFrame(window, shell, cursor, mouse, /*mouseDown=*/false);
+}
+
+void RenderToolPaletteFrame(gui::EditorWindow& window, EditorShell& shell, const ImVec2& paneOrigin,
+                            const ImVec2& contentRegion, const ImVec2& mouse, bool mouseDown) {
+  ImGuiIO& io = ImGui::GetIO();
+  io.DisplaySize = ImVec2(640.0f, 480.0f);
+  if (!io.Fonts->IsBuilt()) {
+    io.Fonts->Build();
+  }
+  io.AddMousePosEvent(mouse.x, mouse.y);
+  io.AddMouseButtonEvent(0, mouseDown);
+
+  window.beginFrame();
+  constexpr ImGuiWindowFlags kHostFlags =
+      ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings;
+  ImGui::SetNextWindowPos(ImVec2(0.0f, 0.0f), ImGuiCond_Always);
+  ImGui::SetNextWindowSize(ImVec2(640.0f, 480.0f), ImGuiCond_Always);
+  ImGui::Begin("EditorShellToolPaletteMouseHost", nullptr, kHostFlags);
+  EditorShellTestAccess::RenderToolPalette(shell, paneOrigin, contentRegion);
+  ImGui::End();
+  window.endFrame();
+}
+
+void RenderPaneMouseFrame(gui::EditorWindow& window, EditorShell& shell,
+                          const Vector2d& documentPoint, bool mouseDown,
+                          const Vector2d& renderPaneOrigin = Vector2d(20.0, 30.0),
+                          const Vector2d& renderPaneSize = Vector2d(400.0, 260.0),
+                          bool shift = false, bool option = false, bool command = false,
+                          bool doubleClick = false) {
+  const Vector2d screenPoint = shell.viewportForReadback().documentToScreen(documentPoint);
+
+  ImGuiIO& io = ImGui::GetIO();
+  io.DisplaySize = ImVec2(640.0f, 480.0f);
+  io.AddKeyEvent(ImGuiMod_Shift, shift);
+  io.AddKeyEvent(ImGuiMod_Alt, option);
+  io.AddKeyEvent(ImGuiMod_Ctrl, command);
+  io.AddMousePosEvent(static_cast<float>(screenPoint.x), static_cast<float>(screenPoint.y));
+  io.AddMouseButtonEvent(0, mouseDown);
+
+  window.beginFrame();
+  if (doubleClick) {
+    io.MouseClickedCount[0] = 2;
+  }
+  EditorShellTestAccess::RenderRenderPane(
+      shell, renderPaneOrigin, renderPaneSize,
+      ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings);
+  window.endFrame();
+
+  io.AddKeyEvent(ImGuiMod_Ctrl, false);
+  io.AddKeyEvent(ImGuiMod_Alt, false);
+  io.AddKeyEvent(ImGuiMod_Shift, false);
+}
+
+void RenderContextMenuFrame(gui::EditorWindow& window, EditorShell& shell) {
+  ImGuiIO& io = ImGui::GetIO();
+  io.DisplaySize = ImVec2(640.0f, 480.0f);
+  if (!io.Fonts->IsBuilt()) {
+    io.Fonts->Build();
+  }
+
+  window.beginFrame();
+  ImGui::SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond_Always);
+  ImGui::SetNextWindowSize(ImVec2(220.0f, 120.0f), ImGuiCond_Always);
+  ImGui::Begin(
+      "EditorShellContextMenuHost", nullptr,
+      ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings);
+  EditorShellTestAccess::RenderRenderPaneContextMenu(shell);
+  ImGui::End();
+  window.endFrame();
+}
+
+Box2d RenderDockedLayerPanelDragHandleFrame(gui::EditorWindow& window, EditorShell& shell,
+                                            const ImVec2& mouse, bool mouseDown) {
+  ImGuiIO& io = ImGui::GetIO();
+  io.DisplaySize = ImVec2(640.0f, 480.0f);
+  io.AddMousePosEvent(mouse.x, mouse.y);
+  io.AddMouseButtonEvent(0, mouseDown);
+
+  window.beginFrame();
+  constexpr ImGuiWindowFlags kHostFlags =
+      ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings;
+  ImGui::SetNextWindowPos(ImVec2(80.0f, 60.0f), ImGuiCond_Always);
+  ImGui::SetNextWindowSize(ImVec2(260.0f, 100.0f), ImGuiCond_Always);
+  ImGui::Begin("EditorShellDockedLayerPanelDragHost", nullptr, kHostFlags);
+  EditorShellTestAccess::RenderDockedLayerPanelDragHandle(shell);
+  const ImVec2 itemMin = ImGui::GetItemRectMin();
+  const ImVec2 itemMax = ImGui::GetItemRectMax();
+  ImGui::End();
+  window.endFrame();
+  return Box2d(Vector2d(itemMin.x, itemMin.y), Vector2d(itemMax.x, itemMax.y));
+}
+
+void RenderFloatingLayerPanelFrame(gui::EditorWindow& window, EditorShell& shell,
+                                   const ImVec2& mouse, bool mouseDown) {
+  ImGuiIO& io = ImGui::GetIO();
+  io.DisplaySize = ImVec2(640.0f, 480.0f);
+  io.AddMousePosEvent(mouse.x, mouse.y);
+  io.AddMouseButtonEvent(0, mouseDown);
+
+  window.beginFrame();
+  EditorShellTestAccess::RenderFloatingLayerPanel(shell);
+  window.endFrame();
+}
+
+Box2d RenderSourcePaneSplitterFrame(gui::EditorWindow& window, EditorShell& shell,
+                                    float sourcePaneWidth, const ImVec2& mouse, bool mouseDown,
+                                    float windowWidth = 640.0f) {
+  ImGuiIO& io = ImGui::GetIO();
+  io.DisplaySize = ImVec2(640.0f, 480.0f);
+  io.AddMousePosEvent(mouse.x, mouse.y);
+  io.AddMouseButtonEvent(0, mouseDown);
+
+  window.beginFrame();
+  EditorShellTestAccess::RenderSourcePaneSplitter(shell, windowWidth, /*paneOriginY=*/0.0f,
+                                                  /*paneHeight=*/220.0f, sourcePaneWidth);
+  const ImVec2 itemMin = ImGui::GetItemRectMin();
+  const ImVec2 itemMax = ImGui::GetItemRectMax();
+  window.endFrame();
+  return Box2d(Vector2d(itemMin.x, itemMin.y), Vector2d(itemMax.x, itemMax.y));
+}
+
 TEST(EditorShellTest, HiddenWindowShellConstructsAndRunsFrames) {
   gui::EditorWindow window = MakeHiddenWindow();
   if (!window.valid()) {
@@ -358,6 +800,78 @@ TEST(EditorShellTest, HiddenWindowShellConstructsAndRunsFrames) {
   EXPECT_TRUE(shell.valid());
 }
 
+TEST(EditorShellTest, FullFrameSmokeCoversPanelSourceAndContextMenuStates) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kReferencedSvg, "referenced.svg"));
+  ASSERT_TRUE(shell.valid());
+  EditorShellTestAccess::ConfigureViewport(shell, Box2d::FromXYWH(0.0, 0.0, 120.0, 80.0));
+
+  auto target = EditorShellTestAccess::App(shell).document().document().querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  EditorShellTestAccess::App(shell).setSelection(*target);
+  RunFramesUntilDisplayedSelectionBounds(window, shell);
+
+  EditorShellTestAccess::SetShowCompositorDebugPanel(shell, true);
+  EditorShellTestAccess::SetLayerPanelDetached(shell, false);
+  window.beginFrame();
+  shell.runFrame();
+  window.endFrame();
+  EXPECT_TRUE(shell.valid());
+
+  EditorShellTestAccess::SetLayerPanelDetached(shell, true);
+  EditorShellTestAccess::SetLayerPanelFloatingNeedsPlacement(shell, true);
+  EditorShellTestAccess::SetLayerPanelFloatingGeometry(shell, ImVec2(80.0f, 60.0f),
+                                                       ImVec2(260.0f, 220.0f));
+  window.beginFrame();
+  shell.runFrame();
+  window.endFrame();
+  EXPECT_TRUE(EditorShellTestAccess::LayerPanelDetached(shell));
+
+  EditorShellTestAccess::SetSourcePaneVisible(shell, false);
+  window.beginFrame();
+  shell.runFrame();
+  window.endFrame();
+  EXPECT_FALSE(EditorShellTestAccess::SourcePaneVisible(shell));
+
+  EditorShellTestAccess::SetSourcePaneVisible(shell, true);
+  EditorShellTestAccess::SetSourceFocusMode(shell, true);
+  EditorShellTestAccess::UpdateSourceFocusView(shell, /*scrollToSelection=*/true);
+  window.beginFrame();
+  shell.runFrame();
+  window.endFrame();
+  EXPECT_TRUE(EditorShellTestAccess::SourceFocusMode(shell));
+
+  EditorShellTestAccess::OpenRenderPaneContextMenu(shell, Vector2d(12.0, 14.0));
+  window.beginFrame();
+  shell.runFrame();
+  window.endFrame();
+  EXPECT_FALSE(EditorShellTestAccess::RenderContextMenuOpenRequested(shell));
+}
+
+TEST(EditorShellTest, IntrinsicSizeDocumentInitializesViewportWithoutViewBox) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kIntrinsicSizeSvg, "intrinsic.svg"));
+  ASSERT_TRUE(shell.valid());
+
+  window.beginFrame();
+  EditorShellTestAccess::RenderRenderPane(
+      shell, Vector2d(0.0, 0.0), Vector2d(320.0, 200.0),
+      ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings);
+  window.endFrame();
+
+  const ViewportState viewport = shell.viewportForReadback();
+  EXPECT_GT(viewport.documentViewBox.width(), 100.0);
+  EXPECT_GT(viewport.documentViewBox.height(), 50.0);
+}
+
 TEST(EditorShellTest, SelectionReadbackAndIdleWakeReflectSourceState) {
   gui::EditorWindow window = MakeHiddenWindow();
   if (!window.valid()) {
@@ -385,6 +899,214 @@ TEST(EditorShellTest, SelectionReadbackAndIdleWakeReflectSourceState) {
   const std::optional<float> idleWake = shell.nextIdleWakeSeconds();
   ASSERT_TRUE(idleWake.has_value());
   EXPECT_GE(*idleWake, 0.0f);
+}
+
+TEST(EditorShellTest, ReplayActionsSwitchToolsAndIgnoreUnknownToolNames) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg));
+  ASSERT_TRUE(shell.valid());
+  EXPECT_TRUE(EditorShellTestAccess::ActiveToolIsSelect(shell));
+
+  EditorShellTestAccess::ApplyReplayAction(shell,
+                                           repro::ReproAction{
+                                               .kind = repro::ReproAction::Kind::SetActiveTool,
+                                               .tool = "pen",
+                                           });
+  EXPECT_TRUE(EditorShellTestAccess::ActiveToolIsPen(shell));
+
+  EditorShellTestAccess::ApplyReplayAction(shell,
+                                           repro::ReproAction{
+                                               .kind = repro::ReproAction::Kind::SetActiveTool,
+                                               .tool = "text",
+                                           });
+  EXPECT_TRUE(EditorShellTestAccess::ActiveToolIsText(shell));
+
+  EditorShellTestAccess::ApplyReplayAction(shell,
+                                           repro::ReproAction{
+                                               .kind = repro::ReproAction::Kind::SetActiveTool,
+                                               .tool = "select",
+                                           });
+  EXPECT_TRUE(EditorShellTestAccess::ActiveToolIsSelect(shell));
+
+  EditorShellTestAccess::ApplyReplayAction(shell,
+                                           repro::ReproAction{
+                                               .kind = repro::ReproAction::Kind::SetActiveTool,
+                                               .tool = "unsupported",
+                                           });
+  EXPECT_TRUE(EditorShellTestAccess::ActiveToolIsSelect(shell));
+
+  EditorShellTestAccess::ApplyReplayAction(shell,
+                                           repro::ReproAction{
+                                               .kind = repro::ReproAction::Kind::CommitPenPath,
+                                           });
+  EXPECT_TRUE(EditorShellTestAccess::ActiveToolIsSelect(shell));
+}
+
+TEST(EditorShellTest, ReplayActionSelectCommitsDraftPenPath) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg));
+  ASSERT_TRUE(shell.valid());
+
+  EditorShellTestAccess::ApplyReplayAction(shell,
+                                           repro::ReproAction{
+                                               .kind = repro::ReproAction::Kind::SetActiveTool,
+                                               .tool = "pen",
+                                           });
+  ASSERT_TRUE(EditorShellTestAccess::ActiveToolIsPen(shell));
+
+  shell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(5.0, 6.0),
+      .leftMouseDown = true,
+      .leftMousePressed = true,
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+  shell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(5.0, 6.0),
+      .leftMouseReleased = true,
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+
+  shell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(25.0, 16.0),
+      .leftMouseDown = true,
+      .leftMousePressed = true,
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+  shell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(25.0, 16.0),
+      .leftMouseReleased = true,
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+  ASSERT_TRUE(EditorShellTestAccess::PenToolIsDrafting(shell));
+
+  EditorShellTestAccess::ApplyReplayAction(shell,
+                                           repro::ReproAction{
+                                               .kind = repro::ReproAction::Kind::SetActiveTool,
+                                               .tool = "select",
+                                           });
+
+  EXPECT_TRUE(EditorShellTestAccess::ActiveToolIsSelect(shell));
+  EXPECT_FALSE(EditorShellTestAccess::PenToolIsDrafting(shell));
+  EXPECT_NE(EditorShellTestAccess::App(shell).document().document().source().find("<path"),
+            std::string_view::npos);
+}
+
+TEST(EditorShellTest, ReplayActionCommitPenPathCommitsDraftPathInPlace) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg));
+  ASSERT_TRUE(shell.valid());
+
+  EditorShellTestAccess::ApplyReplayAction(shell,
+                                           repro::ReproAction{
+                                               .kind = repro::ReproAction::Kind::SetActiveTool,
+                                               .tool = "pen",
+                                           });
+  ASSERT_TRUE(EditorShellTestAccess::ActiveToolIsPen(shell));
+
+  shell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(8.0, 9.0),
+      .leftMouseDown = true,
+      .leftMousePressed = true,
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+  shell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(8.0, 9.0),
+      .leftMouseReleased = true,
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+
+  shell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(28.0, 19.0),
+      .leftMouseDown = true,
+      .leftMousePressed = true,
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+  shell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(28.0, 19.0),
+      .leftMouseReleased = true,
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+  ASSERT_TRUE(EditorShellTestAccess::PenToolIsDrafting(shell));
+
+  EditorShellTestAccess::ApplyReplayAction(shell,
+                                           repro::ReproAction{
+                                               .kind = repro::ReproAction::Kind::CommitPenPath,
+                                           });
+
+  EXPECT_TRUE(EditorShellTestAccess::ActiveToolIsPen(shell));
+  EXPECT_FALSE(EditorShellTestAccess::PenToolIsDrafting(shell));
+  EXPECT_NE(EditorShellTestAccess::App(shell).document().document().source().find("<path"),
+            std::string_view::npos);
+}
+
+TEST(EditorShellTest, ReplayStyleActionsUpdateSelectionAndActivePaintFallbacks) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg));
+  ASSERT_TRUE(shell.valid());
+  auto target = EditorShellTestAccess::App(shell).document().document().querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  EditorShellTestAccess::App(shell).setSelection(*target);
+
+  EditorShellTestAccess::ApplyReplayAction(shell,
+                                           repro::ReproAction{
+                                               .kind = repro::ReproAction::Kind::SetStyleProperty,
+                                               .propertyName = "fill",
+                                               .propertyValue = "#010203",
+                                           });
+  (void)EditorShellTestAccess::App(shell).flushFrame();
+  target = EditorShellTestAccess::App(shell).document().document().querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  ASSERT_TRUE(target->getAttribute("style").has_value());
+  EXPECT_NE(target->getAttribute("style")->str().find("fill: #010203"), std::string::npos);
+
+  EditorShellTestAccess::ApplyReplayAction(shell,
+                                           repro::ReproAction{
+                                               .kind = repro::ReproAction::Kind::SetStyleProperty,
+                                               .propertyName = "stroke",
+                                               .propertyValue = "#040506",
+                                           });
+  (void)EditorShellTestAccess::App(shell).flushFrame();
+  target = EditorShellTestAccess::App(shell).document().document().querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  ASSERT_TRUE(target->getAttribute("style").has_value());
+  EXPECT_NE(target->getAttribute("style")->str().find("stroke: #040506"), std::string::npos);
+
+  EditorShellTestAccess::ApplyReplayAction(shell,
+                                           repro::ReproAction{
+                                               .kind = repro::ReproAction::Kind::SetStyleProperty,
+                                               .propertyName = "stroke-width",
+                                               .propertyValue = "7.5",
+                                           });
+  (void)EditorShellTestAccess::App(shell).flushFrame();
+  target = EditorShellTestAccess::App(shell).document().document().querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  ASSERT_TRUE(target->getAttribute("style").has_value());
+  EXPECT_NE(target->getAttribute("style")->str().find("stroke-width: 7.5"), std::string::npos);
+
+  EditorShellTestAccess::App(shell).clearSelection();
+  EditorShellTestAccess::ApplyReplayAction(shell,
+                                           repro::ReproAction{
+                                               .kind = repro::ReproAction::Kind::SetStyleProperty,
+                                               .propertyName = "stroke-width",
+                                               .propertyValue = "not-a-number",
+                                           });
+  EXPECT_TRUE(EditorShellTestAccess::App(shell).document().queue().empty());
 }
 
 TEST(EditorShellTest, ConstructsFromSvgPathAndKeepsInvalidSourceEditable) {
@@ -459,6 +1181,36 @@ TEST(EditorShellTest, OpenSaveAndRevertUpdateDocumentAndSourceState) {
   EXPECT_NE(EditorShellTestAccess::Source(shell).getText().find("opened"), std::string::npos);
 }
 
+TEST(EditorShellTest, RevertRequestIgnoresGuardStates) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell invalidShell(window, OptionsWithSource("<svg><rect></svg>", "broken.svg"));
+  ASSERT_TRUE(invalidShell.valid());
+  EditorShellTestAccess::RequestRevert(invalidShell);
+  EXPECT_FALSE(EditorShellTestAccess::App(invalidShell).hasDocument());
+
+  EditorShell cleanShell(window, OptionsWithSource(kInitialSvg, "clean.svg"));
+  ASSERT_TRUE(cleanShell.valid());
+  const std::string cleanSource = EditorShellTestAccess::Source(cleanShell).getText();
+  EditorShellTestAccess::RequestRevert(cleanShell);
+  EXPECT_EQ(EditorShellTestAccess::Source(cleanShell).getText(), cleanSource);
+  EXPECT_FALSE(EditorShellTestAccess::App(cleanShell).isDirty());
+
+  EditorShell dirtyWithoutCleanSource(window, OptionsWithSource(kInitialSvg, "dirty.svg"));
+  ASSERT_TRUE(dirtyWithoutCleanSource.valid());
+  EditorShellTestAccess::Source(dirtyWithoutCleanSource).setText("<svg>dirty</svg>");
+  EditorShellTestAccess::App(dirtyWithoutCleanSource).setCleanSourceText("");
+  EditorShellTestAccess::App(dirtyWithoutCleanSource).markDirty();
+
+  EditorShellTestAccess::RequestRevert(dirtyWithoutCleanSource);
+
+  EXPECT_EQ(EditorShellTestAccess::Source(dirtyWithoutCleanSource).getText(), "<svg>dirty</svg>");
+  EXPECT_TRUE(EditorShellTestAccess::App(dirtyWithoutCleanSource).isDirty());
+}
+
 TEST(EditorShellTest, SaveRequestsUseCurrentPathAndFallbackToSaveAs) {
   gui::EditorWindow window = MakeHiddenWindow();
   if (!window.valid()) {
@@ -479,6 +1231,64 @@ TEST(EditorShellTest, SaveRequestsUseCurrentPathAndFallbackToSaveAs) {
   EditorShellTestAccess::RequestSaveAs(untitledShell, "choose a path");
   EditorShellTestAccess::RequestSave(untitledShell);
   EXPECT_TRUE(untitledShell.valid());
+}
+
+TEST(EditorShellTest, ViewportSvgExportRequestsAndWritesCroppedSvg) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  const std::filesystem::path sourcePath = TempPathForTest("source.svg");
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, sourcePath.string()));
+  ASSERT_TRUE(shell.valid());
+  EditorShellTestAccess::ConfigureViewport(shell, Box2d::FromXYWH(0.0, 0.0, 120.0, 80.0));
+
+  EditorShellTestAccess::RequestExportViewportSvg(shell, /*includeOverlay=*/false);
+  EXPECT_TRUE(EditorShellTestAccess::PendingViewportExport(shell));
+  EXPECT_FALSE(EditorShellTestAccess::PendingViewportExportOverlay(shell));
+
+  EditorShellTestAccess::RequestExportViewportSvg(shell, /*includeOverlay=*/true, "try again");
+  EXPECT_TRUE(EditorShellTestAccess::PendingViewportExport(shell));
+  EXPECT_TRUE(EditorShellTestAccess::PendingViewportExportOverlay(shell));
+
+  const std::filesystem::path exportPath = TempPathForTest("viewport.svg");
+  std::string error;
+  EXPECT_TRUE(EditorShellTestAccess::TryExportViewportSvgToPath(shell, exportPath.string(), &error))
+      << error;
+  EXPECT_FALSE(EditorShellTestAccess::PendingViewportExport(shell));
+  EXPECT_FALSE(EditorShellTestAccess::PendingViewportExportOverlay(shell));
+  const std::string exported = ReadTextFile(exportPath);
+  EXPECT_NE(exported.find("<svg"), std::string::npos);
+  EXPECT_NE(exported.find("target"), std::string::npos);
+
+  EditorShell invalidShell(window, OptionsWithSource("<svg><rect></svg>", "broken.svg"));
+  ASSERT_TRUE(invalidShell.valid());
+  error.clear();
+  EXPECT_FALSE(
+      EditorShellTestAccess::TryExportViewportSvgToPath(invalidShell, exportPath.string(), &error));
+  EXPECT_EQ(error, "No document is open to export.");
+
+  error.clear();
+  EXPECT_FALSE(EditorShellTestAccess::TryExportViewportSvgToPath(
+      shell, TempPathForTest("missing_directory/viewport.svg").string(), &error));
+  EXPECT_FALSE(error.empty());
+}
+
+TEST(EditorShellTest, ViewportSvgExportRequestUsesUntitledDocument) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, ""));
+  ASSERT_TRUE(shell.valid());
+  EditorShellTestAccess::App(shell).setCurrentFilePath("");
+
+  EditorShellTestAccess::RequestExportViewportSvg(shell, /*includeOverlay=*/false);
+
+  EXPECT_TRUE(EditorShellTestAccess::PendingViewportExport(shell));
+  EXPECT_FALSE(EditorShellTestAccess::PendingViewportExportOverlay(shell));
 }
 
 TEST(EditorShellTest, DiagnosticsLoggingHonorsEnvironmentTargets) {
@@ -517,6 +1327,22 @@ TEST(EditorShellTest, DiagnosticsLoggingHonorsEnvironmentTargets) {
   setenv("DONNER_EDITOR_FRAME_MISS_LOG", telemetryPath.string().c_str(), /*overwrite=*/1);
   EditorShellTestAccess::MaybeLogFrameMissTelemetry(shell, frameCost);
   EXPECT_NE(ReadTextFile(telemetryPath).find("frame_budget_miss"), std::string::npos);
+
+  for (std::string_view stderrTarget : {"", "1", "true", "stderr"}) {
+    setenv("DONNER_EDITOR_FRAME_MISS_LOG", std::string(stderrTarget).c_str(), /*overwrite=*/1);
+    EditorShellTestAccess::MaybeLogFrameMissTelemetry(shell, frameCost);
+    EXPECT_FALSE(EditorShellTestAccess::FrameMissTelemetryWriteErrorLogged(shell));
+  }
+
+  setenv("DONNER_EDITOR_FRAME_MISS_LOG", "0", /*overwrite=*/1);
+  EditorShellTestAccess::MaybeLogFrameMissTelemetry(shell, frameCost);
+  EXPECT_FALSE(EditorShellTestAccess::FrameMissTelemetryWriteErrorLogged(shell));
+
+  unsetenv("DONNER_EDITOR_FRAME_MISS_LOG");
+  setenv("DONNER_EDITOR_RESOURCE_LOG", "1", /*overwrite=*/1);
+  EditorShellTestAccess::MaybeLogFrameMissTelemetry(shell, frameCost);
+  EXPECT_FALSE(EditorShellTestAccess::FrameMissTelemetryWriteErrorLogged(shell));
+  unsetenv("DONNER_EDITOR_RESOURCE_LOG");
 
   const std::filesystem::path badTelemetryPath =
       TempPathForTest("missing_directory/frame_miss.jsonl");
@@ -616,6 +1442,208 @@ TEST(EditorShellTest, RenderContextMenuOpenStoresPointAndHitElement) {
   EditorShellTestAccess::OpenRenderPaneContextMenu(invalidShell, Vector2d(1.0, 1.0));
   EXPECT_TRUE(EditorShellTestAccess::RenderContextMenuOpenRequested(invalidShell));
   EXPECT_FALSE(EditorShellTestAccess::RenderContextMenuHasHitElement(invalidShell));
+}
+
+TEST(EditorShellTest, RenderContextMenuRendersHitEmptyAndNoDocumentStates) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+  EditorShellTestAccess::OpenRenderPaneContextMenu(shell, Vector2d(12.0, 14.0));
+  RenderContextMenuFrame(window, shell);
+  EXPECT_FALSE(EditorShellTestAccess::RenderContextMenuOpenRequested(shell));
+  EXPECT_TRUE(EditorShellTestAccess::RenderContextMenuHasHitElement(shell));
+
+  EditorShellTestAccess::OpenRenderPaneContextMenu(shell, Vector2d(400.0, 300.0));
+  RenderContextMenuFrame(window, shell);
+  EXPECT_FALSE(EditorShellTestAccess::RenderContextMenuOpenRequested(shell));
+  EXPECT_FALSE(EditorShellTestAccess::RenderContextMenuHasHitElement(shell));
+
+  EditorShell invalidShell(window, OptionsWithSource("<svg><rect></svg>", "broken.svg"));
+  ASSERT_TRUE(invalidShell.valid());
+  EditorShellTestAccess::OpenRenderPaneContextMenu(invalidShell, Vector2d(1.0, 1.0));
+  RenderContextMenuFrame(window, invalidShell);
+  EXPECT_FALSE(EditorShellTestAccess::RenderContextMenuOpenRequested(invalidShell));
+  EXPECT_FALSE(EditorShellTestAccess::RenderContextMenuHasHitElement(invalidShell));
+}
+
+TEST(EditorShellTest, DocumentSpaceReplayInputSelectsHitElementAndHandlesGuards) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+  EXPECT_TRUE(EditorShellTestAccess::App(shell).selectedElements().empty());
+
+  EditorShell invalidShell(window, OptionsWithSource("<svg><rect></svg>", "broken.svg"));
+  ASSERT_TRUE(invalidShell.valid());
+  invalidShell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(12.0, 14.0),
+      .hitElementId = std::string("target"),
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(invalidShell);
+  EXPECT_TRUE(EditorShellTestAccess::App(invalidShell).selectedElements().empty());
+
+  shell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(12.0, 14.0),
+      .hitElementId = std::string("target"),
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+  ASSERT_TRUE(EditorShellTestAccess::App(shell).selectedElement().has_value());
+  EXPECT_EQ(EditorShellTestAccess::App(shell).selectedElement()->id(), "target");
+
+  shell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(12.0, 14.0),
+      .hitElementId = std::string("target"),
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+  ASSERT_TRUE(EditorShellTestAccess::App(shell).selectedElement().has_value());
+  EXPECT_EQ(EditorShellTestAccess::App(shell).selectedElement()->id(), "target");
+
+  shell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(20.0, 30.0),
+      .hitElementId = std::string(),
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+  ASSERT_TRUE(EditorShellTestAccess::App(shell).selectedElement().has_value());
+  EXPECT_EQ(EditorShellTestAccess::App(shell).selectedElement()->id(), "target");
+}
+
+TEST(EditorShellTest, DocumentSpaceReplayInputRoutesSelectPressAndRelease) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+  EditorShellTestAccess::ConfigureViewport(shell, Box2d::FromXYWH(0.0, 0.0, 120.0, 80.0));
+  EditorShellTestAccess::ClearRequestRenderAtEndOfFrame(shell);
+
+  shell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(12.0, 14.0),
+      .leftMouseDown = true,
+      .leftMousePressed = true,
+      .hitElementId = std::string("target"),
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+
+  ASSERT_TRUE(EditorShellTestAccess::App(shell).selectedElement().has_value());
+  EXPECT_EQ(EditorShellTestAccess::App(shell).selectedElement()->id(), "target");
+  EXPECT_TRUE(EditorShellTestAccess::RequestRenderAtEndOfFrame(shell));
+
+  EditorShellTestAccess::ClearRequestRenderAtEndOfFrame(shell);
+  shell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(24.0, 22.0),
+      .leftMouseDown = true,
+      .hitElementId = std::string("target"),
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+
+  ASSERT_TRUE(EditorShellTestAccess::App(shell).selectedElement().has_value());
+  EXPECT_EQ(EditorShellTestAccess::App(shell).selectedElement()->id(), "target");
+  EXPECT_TRUE(EditorShellTestAccess::RequestRenderAtEndOfFrame(shell));
+
+  EditorShellTestAccess::ClearRequestRenderAtEndOfFrame(shell);
+  shell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(12.0, 14.0),
+      .leftMouseReleased = true,
+      .hitElementId = std::string("target"),
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+
+  ASSERT_TRUE(EditorShellTestAccess::App(shell).selectedElement().has_value());
+  EXPECT_EQ(EditorShellTestAccess::App(shell).selectedElement()->id(), "target");
+  EXPECT_TRUE(EditorShellTestAccess::RequestRenderAtEndOfFrame(shell));
+}
+
+TEST(EditorShellTest, DocumentSpaceReplayInputRoutesTextToolClick) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+  DriveGlobalShortcut(shell, {ImGuiKey_T});
+  ASSERT_TRUE(EditorShellTestAccess::ActiveToolIsText(shell));
+
+  shell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(30.0, 40.0),
+      .leftMouseDown = true,
+      .leftMousePressed = true,
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+
+  ASSERT_TRUE(EditorShellTestAccess::App(shell).selectedElement().has_value());
+  const svg::SVGElement selected = *EditorShellTestAccess::App(shell).selectedElement();
+  EXPECT_EQ(selected.type(), svg::ElementType::Text);
+  ASSERT_TRUE(selected.getAttribute("x").has_value());
+  EXPECT_EQ(*selected.getAttribute("x"), "30");
+  ASSERT_TRUE(selected.getAttribute("y").has_value());
+  EXPECT_EQ(*selected.getAttribute("y"), "40");
+  EXPECT_TRUE(EditorShellTestAccess::ActiveToolIsSelect(shell));
+  EXPECT_NE(EditorShellTestAccess::App(shell).document().document().source().find(">Text<"),
+            std::string_view::npos);
+}
+
+TEST(EditorShellTest, DocumentSpaceReplayInputRoutesPenPressReleaseAndHover) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+  DriveGlobalShortcut(shell, {ImGuiKey_P});
+  ASSERT_TRUE(EditorShellTestAccess::ActiveToolIsPen(shell));
+
+  shell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(5.0, 6.0),
+      .leftMouseDown = true,
+      .leftMousePressed = true,
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+
+  EXPECT_TRUE(EditorShellTestAccess::PenToolIsDrafting(shell));
+  EXPECT_TRUE(EditorShellTestAccess::PenToolIsDraggingAnchor(shell));
+  EXPECT_FALSE(EditorShellTestAccess::PenToolActivePathData(shell).empty());
+
+  shell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(10.0, 12.0),
+      .leftMouseDown = true,
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+
+  EXPECT_TRUE(EditorShellTestAccess::PenDragFlushedThisFrame(shell));
+  EXPECT_TRUE(EditorShellTestAccess::PenToolIsDrafting(shell));
+  EXPECT_TRUE(EditorShellTestAccess::PenToolIsDraggingAnchor(shell));
+
+  shell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(5.0, 6.0),
+      .leftMouseReleased = true,
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+
+  EXPECT_TRUE(EditorShellTestAccess::PenToolIsDrafting(shell));
+  EXPECT_FALSE(EditorShellTestAccess::PenToolIsDraggingAnchor(shell));
+  EXPECT_FALSE(EditorShellTestAccess::PenToolActivePathData(shell).empty());
+  EXPECT_NE(EditorShellTestAccess::App(shell).document().document().source().find("<path"),
+            std::string_view::npos);
+
+  shell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(18.0, 24.0),
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+
+  EXPECT_TRUE(EditorShellTestAccess::PenToolIsDrafting(shell));
 }
 
 TEST(EditorShellTest, SourcePaneVisibilityRevealAndHoverRangesUseCurrentDocumentSource) {
@@ -759,6 +1787,229 @@ TEST(EditorShellTest, ShellGeometryHelpersClampToViewportAndSelectionCache) {
                                                                      ImVec2(500.0f, 300.0f));
   EXPECT_GT(palette.width(), 0.0);
   EXPECT_GT(palette.height(), 0.0);
+}
+
+TEST(EditorShellTest, PrivateUiRenderHelpersCoverPaneToolbarAndPanelStates) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kReferencedSvg));
+  ASSERT_TRUE(shell.valid());
+  auto target = EditorShellTestAccess::App(shell).document().document().querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  EditorShellTestAccess::App(shell).setSelection(*target);
+  EditorShellTestAccess::ConfigureViewport(shell, Box2d::FromXYWH(0.0, 0.0, 120.0, 80.0));
+
+  if (!ImGui::GetIO().Fonts->IsBuilt()) {
+    ImGui::GetIO().Fonts->Build();
+  }
+  window.beginFrame();
+  ImGuiIO& io = ImGui::GetIO();
+  ASSERT_FALSE(io.Fonts->Fonts.empty());
+  EditorShellTestAccess::RenderSourcePane(shell, /*paneOriginY=*/0.0f, /*paneHeight=*/180.0f,
+                                          /*paneWidth=*/260.0f, io.Fonts->Fonts[0]);
+
+  constexpr ImGuiWindowFlags kHostFlags =
+      ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings;
+  ImGui::SetNextWindowPos(ImVec2(280.0f, 0.0f), ImGuiCond_Always);
+  ImGui::SetNextWindowSize(ImVec2(340.0f, 220.0f), ImGuiCond_Always);
+  ImGui::Begin("EditorShellPrivateUiHost", nullptr, kHostFlags);
+  EditorShellTestAccess::RenderFillStrokeToolbarWidget(shell);
+  EditorShellTestAccess::RenderLayerPanelContents(shell);
+  ImGui::End();
+
+  EditorShellTestAccess::RenderSourcePaneSplitter(shell, /*windowWidth=*/640.0f,
+                                                  /*paneOriginY=*/0.0f, /*paneHeight=*/220.0f,
+                                                  /*sourcePaneWidth=*/260.0f);
+  EditorShellTestAccess::RenderRightPaneSplitter(shell, /*windowWidth=*/640.0f,
+                                                 /*paneOriginY=*/0.0f, /*paneHeight=*/220.0f);
+  window.endFrame();
+
+  EditorShellTestAccess::SetSourcePaneVisible(shell, false);
+  EditorShellTestAccess::SetSourceFocusMode(shell, true);
+  EditorShell invalidShell(window, OptionsWithSource("<svg><rect></svg>"));
+  ASSERT_TRUE(invalidShell.valid());
+
+  if (!ImGui::GetIO().Fonts->IsBuilt()) {
+    ImGui::GetIO().Fonts->Build();
+  }
+  window.beginFrame();
+  ImGui::SetNextWindowPos(ImVec2(0.0f, 0.0f), ImGuiCond_Always);
+  ImGui::SetNextWindowSize(ImVec2(240.0f, 80.0f), ImGuiCond_Always);
+  ImGui::Begin("EditorShellInvalidToolbarHost", nullptr, kHostFlags);
+  EditorShellTestAccess::RenderFillStrokeToolbarWidget(invalidShell);
+  EditorShellTestAccess::RenderLayerPanelContents(invalidShell);
+  ImGui::End();
+  EditorShellTestAccess::RenderSourcePaneSplitter(shell, /*windowWidth=*/640.0f,
+                                                  /*paneOriginY=*/0.0f, /*paneHeight=*/220.0f,
+                                                  /*sourcePaneWidth=*/0.0f);
+  EditorShellTestAccess::RenderRightPaneSplitter(shell, /*windowWidth=*/640.0f,
+                                                 /*paneOriginY=*/0.0f, /*paneHeight=*/220.0f);
+  window.endFrame();
+
+  EXPECT_TRUE(shell.valid());
+  EXPECT_TRUE(invalidShell.valid());
+}
+
+TEST(EditorShellTest, CompositorDebugPanelDragHandleDetachesAndMovesFloatingPanel) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+  EditorShellTestAccess::SetShowCompositorDebugPanel(shell, true);
+
+  const Box2d handleRect =
+      RenderDockedLayerPanelDragHandleFrame(window, shell, ImVec2(-100.0f, -100.0f),
+                                            /*mouseDown=*/false);
+  const ImVec2 handleCenter(
+      static_cast<float>((handleRect.topLeft.x + handleRect.bottomRight.x) * 0.5),
+      static_cast<float>((handleRect.topLeft.y + handleRect.bottomRight.y) * 0.5));
+  RenderDockedLayerPanelDragHandleFrame(window, shell, handleCenter, /*mouseDown=*/true);
+  RenderDockedLayerPanelDragHandleFrame(window, shell,
+                                        ImVec2(handleCenter.x + 30.0f, handleCenter.y + 25.0f),
+                                        /*mouseDown=*/true);
+
+  EXPECT_TRUE(EditorShellTestAccess::LayerPanelDetached(shell));
+  EXPECT_TRUE(EditorShellTestAccess::LayerPanelDetachDragActive(shell));
+  EXPECT_TRUE(EditorShellTestAccess::LayerPanelFloatingNeedsPlacement(shell));
+
+  RenderFloatingLayerPanelFrame(window, shell, ImVec2(150.0f, 125.0f), /*mouseDown=*/true);
+
+  EXPECT_TRUE(EditorShellTestAccess::LayerPanelDetached(shell));
+  EXPECT_FALSE(EditorShellTestAccess::LayerPanelFloatingNeedsPlacement(shell));
+
+  RenderFloatingLayerPanelFrame(window, shell, ImVec2(150.0f, 125.0f), /*mouseDown=*/false);
+
+  EXPECT_TRUE(EditorShellTestAccess::LayerPanelDetached(shell));
+  EXPECT_FALSE(EditorShellTestAccess::LayerPanelDetachDragActive(shell));
+}
+
+TEST(EditorShellTest, SourcePaneSplitterDragCollapsesPane) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+
+  const Box2d sourceRect = RenderSourcePaneSplitterFrame(
+      window, shell, /*sourcePaneWidth=*/260.0f, ImVec2(-100.0f, -100.0f), /*mouseDown=*/false);
+  const ImVec2 sourceCenter(
+      static_cast<float>((sourceRect.topLeft.x + sourceRect.bottomRight.x) * 0.5),
+      static_cast<float>((sourceRect.topLeft.y + sourceRect.bottomRight.y) * 0.5));
+  RenderSourcePaneSplitterFrame(window, shell, /*sourcePaneWidth=*/260.0f, sourceCenter,
+                                /*mouseDown=*/true);
+  RenderSourcePaneSplitterFrame(window, shell, /*sourcePaneWidth=*/260.0f,
+                                ImVec2(sourceCenter.x - 120.0f, sourceCenter.y),
+                                /*mouseDown=*/true);
+
+  EXPECT_FALSE(EditorShellTestAccess::SourcePaneVisible(shell));
+}
+
+TEST(EditorShellTest, FillStrokeToolbarMouseHitTestingCoversChipsSwatchesAndTooltips) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kPaintToolbarSvg, "paint_toolbar.svg"));
+  ASSERT_TRUE(shell.valid());
+  svg::SVGDocument& document = EditorShellTestAccess::App(shell).document().document();
+
+  auto selectById = [&](std::string_view id) {
+    std::optional<svg::SVGElement> element = document.querySelector("#" + std::string(id));
+    ASSERT_TRUE(element.has_value()) << id;
+    EditorShellTestAccess::App(shell).setSelection(*element);
+  };
+
+  constexpr ImVec2 kCursor(20.0f, 40.0f);
+  constexpr ImVec2 kStrokeChip(70.0f, 47.0f);
+  constexpr ImVec2 kFillChip(70.0f, 63.0f);
+  constexpr ImVec2 kStrokeSwatchOnly(50.0f, 47.0f);
+  constexpr ImVec2 kFillSwatchOnly(30.0f, 65.0f);
+  constexpr ImVec2 kWidgetBackground(58.0f, 70.0f);
+
+  selectById("local");
+  RunFramesUntilDisplayedSelectionBounds(window, shell);
+  EditorShellTestAccess::SetSourcePaneVisible(shell, false);
+  ClickToolbar(window, shell, kCursor, kFillChip);
+  ClickToolbar(window, shell, kCursor, kStrokeChip);
+  RenderToolbarFrame(window, shell, kCursor, kStrokeChip, /*mouseDown=*/false);
+  ClickToolbar(window, shell, kCursor, kFillSwatchOnly);
+  ClickToolbar(window, shell, kCursor, kStrokeSwatchOnly);
+  ClickToolbar(window, shell, kCursor, kWidgetBackground);
+
+  for (std::string_view id : {"missing", "contextual", "styled-none-attribute", "external"}) {
+    selectById(id);
+    RenderToolbarFrame(window, shell, kCursor, kFillChip, /*mouseDown=*/false);
+  }
+
+  EXPECT_TRUE(shell.valid());
+}
+
+TEST(EditorShellTest, ToolPaletteSelectCommitsOpenPenPath) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+  EditorShellTestAccess::ConfigureViewport(shell, Box2d::FromXYWH(0.0, 0.0, 120.0, 80.0));
+  DriveGlobalShortcut(shell, {ImGuiKey_P});
+  ASSERT_TRUE(EditorShellTestAccess::ActiveToolIsPen(shell));
+
+  shell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(5.0, 6.0),
+      .leftMouseDown = true,
+      .leftMousePressed = true,
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+  shell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(5.0, 6.0),
+      .leftMouseReleased = true,
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+
+  shell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(25.0, 16.0),
+      .leftMouseDown = true,
+      .leftMousePressed = true,
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+  shell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(25.0, 16.0),
+      .leftMouseReleased = true,
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+  ASSERT_TRUE(EditorShellTestAccess::PenToolIsDrafting(shell));
+
+  constexpr ImVec2 kPaneOrigin(20.0f, 30.0f);
+  constexpr ImVec2 kContentRegion(400.0f, 260.0f);
+  const Box2d palette =
+      EditorShellTestAccess::ToolPaletteScreenRect(shell, kPaneOrigin, kContentRegion);
+  const ImVec2 selectCenter(static_cast<float>(palette.topLeft.x + 20.0),
+                            static_cast<float>(palette.topLeft.y + 20.0));
+
+  RenderToolPaletteFrame(window, shell, kPaneOrigin, kContentRegion,
+                         ImVec2(selectCenter.x, selectCenter.y), /*mouseDown=*/false);
+  RenderToolPaletteFrame(window, shell, kPaneOrigin, kContentRegion, selectCenter,
+                         /*mouseDown=*/false);
+  RenderToolPaletteFrame(window, shell, kPaneOrigin, kContentRegion, selectCenter,
+                         /*mouseDown=*/true);
+  RenderToolPaletteFrame(window, shell, kPaneOrigin, kContentRegion, selectCenter,
+                         /*mouseDown=*/false);
+
+  EXPECT_TRUE(EditorShellTestAccess::ActiveToolIsSelect(shell));
+  EXPECT_FALSE(EditorShellTestAccess::PenToolIsDrafting(shell));
+  EXPECT_NE(EditorShellTestAccess::App(shell).document().document().source().find("<path"),
+            std::string_view::npos);
 }
 
 TEST(EditorShellTest, HighlightSelectionSourceHandlesTextOriginAndClearedSelection) {
@@ -916,6 +2167,652 @@ TEST(EditorShellTest, SourcePaneVisibilityNoOpsWhenAlreadyMatching) {
   EXPECT_FALSE(EditorShellTestAccess::SourcePaneVisible(shell));
   EditorShellTestAccess::SetSourcePaneVisible(shell, false);
   EXPECT_FALSE(EditorShellTestAccess::SourcePaneVisible(shell));
+}
+
+TEST(EditorShellTest, SelectAllCanvasAndTextSelectionPreconditions) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+
+  EXPECT_TRUE(EditorShellTestAccess::CanvasHasSelectableElements(shell));
+  EditorShellTestAccess::SelectAllCanvasElements(shell);
+  EXPECT_GT(EditorShellTestAccess::App(shell).selectedElements().size(), 1u);
+  EXPECT_FALSE(EditorShellTestAccess::SelectionIsAllText(shell));
+
+  auto label = EditorShellTestAccess::App(shell).document().document().querySelector("#label");
+  ASSERT_TRUE(label.has_value());
+  EditorShellTestAccess::App(shell).setSelection(*label);
+  EXPECT_TRUE(EditorShellTestAccess::SelectionIsAllText(shell));
+
+  EditorShellTestAccess::App(shell).clearSelection();
+  EXPECT_FALSE(EditorShellTestAccess::SelectionIsAllText(shell));
+
+  EditorShell invalidShell(window, OptionsWithSource("<svg><rect></svg>", "broken.svg"));
+  ASSERT_TRUE(invalidShell.valid());
+  EXPECT_FALSE(EditorShellTestAccess::CanvasHasSelectableElements(invalidShell));
+  EditorShellTestAccess::SelectAllCanvasElements(invalidShell);
+  EXPECT_TRUE(EditorShellTestAccess::App(invalidShell).selectedElements().empty());
+}
+
+TEST(EditorShellTest, ConvertSelectedTextToOutlinesGuardsNonTextSelection) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+
+  auto target = EditorShellTestAccess::App(shell).document().document().querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  EditorShellTestAccess::App(shell).setSelection(*target);
+  const std::string sourceBefore(EditorShellTestAccess::App(shell).document().document().source());
+
+  EditorShellTestAccess::ConvertSelectedTextToOutlines(shell);
+  (void)EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell);
+
+  EXPECT_EQ(EditorShellTestAccess::App(shell).document().document().source(), sourceBefore);
+  EXPECT_TRUE(EditorShellTestAccess::LastConvertTextError(shell).empty());
+  EXPECT_TRUE(EditorShellTestAccess::App(shell).document().document().querySelector("#target"));
+}
+
+TEST(EditorShellTest, ConvertSelectedTextToOutlinesReplacesTextWithPathGroup) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+
+  auto label = EditorShellTestAccess::App(shell).document().document().querySelector("#label");
+  ASSERT_TRUE(label.has_value());
+  EditorShellTestAccess::App(shell).setSelection(*label);
+
+  EditorShellTestAccess::ConvertSelectedTextToOutlines(shell);
+  EXPECT_TRUE(EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell));
+
+  svg::SVGDocument& document = EditorShellTestAccess::App(shell).document().document();
+  EXPECT_FALSE(document.querySelector("#label").has_value());
+  ASSERT_TRUE(document.querySelector("#label_outlines").has_value());
+  EXPECT_TRUE(document.querySelector("#label_outlines_0").has_value());
+  EXPECT_NE(document.source().find(R"(id="label_outlines")"), std::string_view::npos);
+  EXPECT_EQ(EditorShellTestAccess::App(shell).selectedElements().size(), 1u);
+  EXPECT_EQ(EditorShellTestAccess::App(shell).selectedElements().front().id(), "label_outlines");
+  EXPECT_TRUE(EditorShellTestAccess::LastConvertTextError(shell).empty());
+}
+
+TEST(EditorShellTest, RenderPaneDeferredEmptyClickStartsMarqueeAfterHold) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+  EditorShellTestAccess::BufferPendingClick(shell, Vector2d(400.0, 300.0));
+  EditorShellTestAccess::SetPendingSelectClickStartSeconds(shell, -1.0);
+
+  ImGuiIO& io = ImGui::GetIO();
+  io.DisplaySize = ImVec2(640.0f, 480.0f);
+  io.AddMousePosEvent(-50.0f, -50.0f);
+  io.AddMouseButtonEvent(0, true);
+
+  window.beginFrame();
+  EditorShellTestAccess::RenderRenderPane(
+      shell, Vector2d(0.0, 0.0), Vector2d(320.0, 220.0),
+      ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings);
+  window.endFrame();
+
+  EXPECT_FALSE(EditorShellTestAccess::HasPendingClick(shell));
+  EXPECT_TRUE(EditorShellTestAccess::SelectToolIsMarqueeing(shell));
+  EXPECT_TRUE(EditorShellTestAccess::RequestRenderAtEndOfFrame(shell));
+
+  io.AddMouseButtonEvent(0, false);
+  window.beginFrame();
+  window.endFrame();
+}
+
+TEST(EditorShellTest, RenderPaneTextToolClickCreatesTextAndReturnsToSelect) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+  EditorShellTestAccess::ConfigureViewport(shell, Box2d::FromXYWH(0.0, 0.0, 120.0, 80.0));
+
+  DriveGlobalShortcut(shell, {ImGuiKey_T});
+  ASSERT_TRUE(EditorShellTestAccess::ActiveToolIsText(shell));
+
+  EditorShellTestAccess::BufferPendingClick(shell, Vector2d(24.0, 34.0));
+  RenderPaneMouseFrame(window, shell, Vector2d(24.0, 34.0), /*mouseDown=*/false);
+  EXPECT_TRUE(EditorShellTestAccess::ActiveToolIsSelect(shell));
+  (void)EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell);
+
+  const std::string_view source = EditorShellTestAccess::App(shell).document().document().source();
+  EXPECT_NE(source.find(R"(x="24")"), std::string_view::npos);
+  EXPECT_NE(source.find(R"(y="34")"), std::string_view::npos);
+  EXPECT_NE(source.find(">Text</text>"), std::string_view::npos);
+}
+
+TEST(EditorShellTest, RenderPanePenToolClickDragAndCommitOpenPath) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+  EditorShellTestAccess::ConfigureViewport(shell, Box2d::FromXYWH(0.0, 0.0, 120.0, 80.0));
+
+  DriveGlobalShortcut(shell, {ImGuiKey_P});
+  ASSERT_TRUE(EditorShellTestAccess::ActiveToolIsPen(shell));
+
+  EditorShellTestAccess::BufferPendingClick(shell, Vector2d(12.0, 18.0));
+  RenderPaneMouseFrame(window, shell, Vector2d(18.0, 24.0), /*mouseDown=*/false);
+  EXPECT_TRUE(EditorShellTestAccess::PenToolIsDrafting(shell));
+  EXPECT_FALSE(EditorShellTestAccess::PenToolActivePathData(shell).empty());
+
+  MouseModifiers constrainedClick;
+  constrainedClick.shift = true;
+  constrainedClick.pixelsPerDocUnit = shell.viewportForReadback().pixelsPerDocUnit();
+  EditorShellTestAccess::BufferPendingClick(shell, Vector2d(42.0, 24.0), constrainedClick);
+  RenderPaneMouseFrame(window, shell, Vector2d(42.0, 24.0), /*mouseDown=*/false);
+  EXPECT_TRUE(EditorShellTestAccess::PenToolIsDrafting(shell));
+
+  DriveGlobalShortcut(shell, {ImGuiKey_Enter});
+  EXPECT_FALSE(EditorShellTestAccess::PenToolIsDrafting(shell));
+  (void)EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell);
+  EXPECT_NE(EditorShellTestAccess::App(shell).document().document().source().find("<path"),
+            std::string_view::npos);
+}
+
+TEST(EditorShellTest, RenderPanePenToolDragsAnchorAndCommitsOnDoubleClick) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+  EditorShellTestAccess::ConfigureViewport(shell, Box2d::FromXYWH(0.0, 0.0, 120.0, 80.0));
+
+  DriveGlobalShortcut(shell, {ImGuiKey_P});
+  ASSERT_TRUE(EditorShellTestAccess::ActiveToolIsPen(shell));
+
+  EditorShellTestAccess::BufferPendingClick(shell, Vector2d(12.0, 18.0));
+  RenderPaneMouseFrame(window, shell, Vector2d(12.0, 18.0), /*mouseDown=*/true);
+  ASSERT_TRUE(EditorShellTestAccess::PenToolIsDrafting(shell));
+  ASSERT_TRUE(EditorShellTestAccess::PenToolIsDraggingAnchor(shell));
+
+  RenderPaneMouseFrame(window, shell, Vector2d(22.0, 28.0), /*mouseDown=*/true);
+  EXPECT_TRUE(EditorShellTestAccess::PenDragFlushedThisFrame(shell));
+  EXPECT_TRUE(EditorShellTestAccess::PenToolIsDraggingAnchor(shell));
+
+  RenderPaneMouseFrame(window, shell, Vector2d(22.0, 28.0), /*mouseDown=*/false);
+  EXPECT_TRUE(EditorShellTestAccess::PenToolIsDrafting(shell));
+  EXPECT_FALSE(EditorShellTestAccess::PenToolIsDraggingAnchor(shell));
+
+  EditorShellTestAccess::BufferPendingClick(shell, Vector2d(42.0, 24.0));
+  RenderPaneMouseFrame(window, shell, Vector2d(42.0, 24.0), /*mouseDown=*/false);
+  ASSERT_TRUE(EditorShellTestAccess::PenToolIsDrafting(shell));
+
+  RenderPaneMouseFrame(window, shell, Vector2d(42.0, 24.0), /*mouseDown=*/true,
+                       Vector2d(20.0, 30.0), Vector2d(400.0, 260.0),
+                       /*shift=*/false, /*option=*/false, /*command=*/false,
+                       /*doubleClick=*/true);
+  EXPECT_FALSE(EditorShellTestAccess::PenToolIsDrafting(shell));
+  EXPECT_NE(EditorShellTestAccess::App(shell).document().document().source().find("<path"),
+            std::string_view::npos);
+}
+
+TEST(EditorShellTest, GlobalShortcutDeleteWhilePenDraftingRemovesAnchorBeforeCanvasDelete) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+
+  DriveGlobalShortcut(shell, {ImGuiKey_P});
+  ASSERT_TRUE(EditorShellTestAccess::ActiveToolIsPen(shell));
+
+  shell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(12.0, 18.0),
+      .leftMouseDown = true,
+      .leftMousePressed = true,
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+  shell.queueDocumentSpaceReplayInputForTesting(EditorShellDocumentReplayInput{
+      .documentPoint = Vector2d(12.0, 18.0),
+      .leftMouseReleased = true,
+  });
+  EditorShellTestAccess::ApplyPendingDocumentSpaceReplayInput(shell);
+  ASSERT_TRUE(EditorShellTestAccess::PenToolIsDrafting(shell));
+
+  DriveGlobalShortcut(shell, {ImGuiKey_Delete});
+
+  EXPECT_TRUE(EditorShellTestAccess::ActiveToolIsPen(shell));
+  EXPECT_FALSE(EditorShellTestAccess::PenToolIsDrafting(shell));
+  EXPECT_TRUE(EditorShellTestAccess::App(shell).hasDocument());
+}
+
+TEST(EditorShellTest, GlobalShortcutsSwitchToolsZoomAndSourceFocus) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+  EditorShellTestAccess::ConfigureViewport(shell, Box2d::FromXYWH(0.0, 0.0, 120.0, 80.0));
+
+  EXPECT_TRUE(EditorShellTestAccess::ActiveToolIsSelect(shell));
+  DriveGlobalShortcut(shell, {ImGuiKey_P});
+  EXPECT_TRUE(EditorShellTestAccess::ActiveToolIsPen(shell));
+  DriveGlobalShortcut(shell, {ImGuiKey_T});
+  EXPECT_TRUE(EditorShellTestAccess::ActiveToolIsText(shell));
+  DriveGlobalShortcut(shell, {ImGuiKey_Escape});
+  EXPECT_TRUE(EditorShellTestAccess::ActiveToolIsSelect(shell));
+  DriveGlobalShortcut(shell, {ImGuiKey_P});
+  EXPECT_TRUE(EditorShellTestAccess::ActiveToolIsPen(shell));
+  DriveGlobalShortcut(shell, {ImGuiKey_V});
+  EXPECT_TRUE(EditorShellTestAccess::ActiveToolIsSelect(shell));
+
+  const bool sourceFocusBefore = EditorShellTestAccess::SourceFocusMode(shell);
+  DriveGlobalShortcut(shell, {ImGuiKey_Enter}, /*ctrl=*/true);
+  EXPECT_NE(EditorShellTestAccess::SourceFocusMode(shell), sourceFocusBefore);
+
+  EditorShellTestAccess::ClearRequestRenderAtEndOfFrame(shell);
+  DriveGlobalShortcut(shell, {ImGuiKey_Equal}, /*ctrl=*/true);
+  EXPECT_TRUE(EditorShellTestAccess::RequestRenderAtEndOfFrame(shell));
+
+  EditorShellTestAccess::ClearRequestRenderAtEndOfFrame(shell);
+  DriveGlobalShortcut(shell, {ImGuiKey_Minus}, /*ctrl=*/true);
+  EXPECT_TRUE(EditorShellTestAccess::RequestRenderAtEndOfFrame(shell));
+
+  DriveGlobalShortcut(shell, {ImGuiKey_Equal}, /*ctrl=*/true);
+  EditorShellTestAccess::ClearRequestRenderAtEndOfFrame(shell);
+  DriveGlobalShortcut(shell, {ImGuiKey_0}, /*ctrl=*/true);
+  EXPECT_TRUE(EditorShellTestAccess::RequestRenderAtEndOfFrame(shell));
+
+  EditorShellTestAccess::ClearRequestRenderAtEndOfFrame(shell);
+  DriveGlobalShortcut(shell, {ImGuiKey_KeypadAdd}, /*ctrl=*/true);
+  EXPECT_TRUE(EditorShellTestAccess::RequestRenderAtEndOfFrame(shell));
+
+  EditorShellTestAccess::ClearRequestRenderAtEndOfFrame(shell);
+  DriveGlobalShortcut(shell, {ImGuiKey_KeypadSubtract}, /*ctrl=*/true);
+  EXPECT_TRUE(EditorShellTestAccess::RequestRenderAtEndOfFrame(shell));
+
+  const bool sourceFocusBeforeKeypadEnter = EditorShellTestAccess::SourceFocusMode(shell);
+  DriveGlobalShortcut(shell, {ImGuiKey_KeypadEnter}, /*ctrl=*/true);
+  EXPECT_NE(EditorShellTestAccess::SourceFocusMode(shell), sourceFocusBeforeKeypadEnter);
+}
+
+TEST(EditorShellTest, GlobalShortcutsRouteFileDialogsSaveAndQuit) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  const std::filesystem::path savePath = TempPathForTest("shortcut_save.svg");
+  std::filesystem::remove(savePath);
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, savePath.string()));
+  ASSERT_TRUE(shell.valid());
+
+  DriveGlobalShortcut(shell, {ImGuiKey_O}, /*ctrl=*/true);
+  EXPECT_TRUE(EditorShellTestAccess::OpenFileModalRequested(shell));
+
+  DriveGlobalShortcut(shell, {ImGuiKey_S}, /*ctrl=*/true);
+  ASSERT_TRUE(std::filesystem::exists(savePath));
+  EXPECT_NE(ReadTextFile(savePath).find("target"), std::string::npos);
+
+  DriveGlobalShortcut(shell, {ImGuiKey_S}, /*ctrl=*/true, /*shift=*/true);
+  EXPECT_TRUE(EditorShellTestAccess::SaveFileModalRequested(shell));
+
+  glfwSetWindowShouldClose(window.rawHandle(), GLFW_FALSE);
+  DriveGlobalShortcut(shell, {ImGuiKey_Q}, /*ctrl=*/true);
+  EXPECT_NE(glfwWindowShouldClose(window.rawHandle()), 0);
+}
+
+TEST(EditorShellTest, GlobalShortcutsRouteCanvasSelectionAndShapeClipboard) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+  EditorShellTestAccess::UseInMemoryShapeClipboard(shell);
+
+  DriveGlobalShortcut(shell, {ImGuiKey_A}, /*ctrl=*/true);
+  EXPECT_GT(EditorShellTestAccess::App(shell).selectedElements().size(), 1u);
+
+  DriveGlobalShortcut(shell, {ImGuiKey_A}, /*ctrl=*/true, /*shift=*/true);
+  EXPECT_FALSE(EditorShellTestAccess::App(shell).hasSelection());
+
+  auto target = EditorShellTestAccess::App(shell).document().document().querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  EditorShellTestAccess::App(shell).setSelection(*target);
+
+  DriveGlobalShortcut(shell, {ImGuiKey_C}, /*ctrl=*/true);
+  ASSERT_TRUE(EditorShellTestAccess::ShapeClipboardHasText(shell));
+  EXPECT_NE(EditorShellTestAccess::ShapeClipboardText(shell).find("target"), std::string::npos);
+
+  DriveGlobalShortcut(shell, {ImGuiKey_V}, /*ctrl=*/true);
+  EXPECT_TRUE(EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell));
+  EXPECT_NE(EditorShellTestAccess::App(shell).document().document().source().find("target_pasted"),
+            std::string_view::npos);
+
+  DriveGlobalShortcut(shell, {ImGuiKey_F}, /*ctrl=*/true);
+  EXPECT_TRUE(EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell));
+  EXPECT_NE(EditorShellTestAccess::App(shell).document().document().source().find("target_pasted2"),
+            std::string_view::npos);
+
+  auto pasted =
+      EditorShellTestAccess::App(shell).document().document().querySelector("#target_pasted");
+  ASSERT_TRUE(pasted.has_value());
+  EditorShellTestAccess::App(shell).setSelection(*pasted);
+  DriveGlobalShortcut(shell, {ImGuiKey_X}, /*ctrl=*/true);
+  EXPECT_TRUE(EditorShellTestAccess::ShapeClipboardHasText(shell));
+  EXPECT_TRUE(EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell));
+  EXPECT_FALSE(
+      EditorShellTestAccess::App(shell).document().document().querySelector("#target_pasted"));
+}
+
+TEST(EditorShellTest, GlobalShortcutsDeleteUndoRedoAndReorderSelection) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  constexpr std::string_view kStackedSvg = R"svg(
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="80" viewBox="0 0 120 80">
+  <rect id="back" x="0" y="0" width="10" height="10"/>
+  <rect id="middle" x="20" y="0" width="10" height="10"/>
+  <rect id="front" x="40" y="0" width="10" height="10"/>
+</svg>
+)svg";
+  EditorShell shell(window, OptionsWithSource(kStackedSvg, "stacked.svg"));
+  ASSERT_TRUE(shell.valid());
+
+  auto middle = EditorShellTestAccess::App(shell).document().document().querySelector("#middle");
+  ASSERT_TRUE(middle.has_value());
+  EditorShellTestAccess::App(shell).setSelection(*middle);
+
+  const std::string beforeForward(EditorShellTestAccess::App(shell).document().document().source());
+  DriveGlobalShortcut(shell, {ImGuiKey_RightBracket}, /*ctrl=*/true);
+  EXPECT_TRUE(EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell));
+  const std::string afterForward(EditorShellTestAccess::App(shell).document().document().source());
+  EXPECT_NE(afterForward, beforeForward);
+
+  DriveGlobalShortcut(shell, {ImGuiKey_LeftBracket}, /*ctrl=*/true);
+  EXPECT_TRUE(EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell));
+  const std::string afterBackward(EditorShellTestAccess::App(shell).document().document().source());
+  EXPECT_NE(afterBackward, afterForward);
+
+  DriveGlobalShortcut(shell, {ImGuiKey_RightBracket}, /*ctrl=*/true, /*shift=*/true);
+  EXPECT_TRUE(EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell));
+  DriveGlobalShortcut(shell, {ImGuiKey_LeftBracket}, /*ctrl=*/true, /*shift=*/true);
+  EXPECT_TRUE(EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell));
+
+  middle = EditorShellTestAccess::App(shell).document().document().querySelector("#middle");
+  ASSERT_TRUE(middle.has_value());
+  EditorShellTestAccess::App(shell).setSelection(*middle);
+  DriveGlobalShortcut(shell, {ImGuiKey_Delete});
+  EXPECT_TRUE(EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell));
+  EXPECT_FALSE(EditorShellTestAccess::App(shell).document().document().querySelector("#middle"));
+
+  DriveGlobalShortcut(shell, {ImGuiKey_Z}, /*ctrl=*/true);
+  EXPECT_TRUE(EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell));
+  EXPECT_TRUE(EditorShellTestAccess::App(shell).document().document().querySelector("#middle"));
+
+  DriveGlobalShortcut(shell, {ImGuiKey_Z}, /*ctrl=*/true, /*shift=*/true);
+  EXPECT_TRUE(EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell));
+  EXPECT_FALSE(EditorShellTestAccess::App(shell).document().document().querySelector("#middle"));
+
+  middle = EditorShellTestAccess::App(shell).document().document().querySelector("#front");
+  ASSERT_TRUE(middle.has_value());
+  EditorShellTestAccess::App(shell).setSelection(*middle);
+  DriveGlobalShortcut(shell, {ImGuiKey_Backspace});
+  EXPECT_TRUE(EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell));
+  EXPECT_FALSE(EditorShellTestAccess::App(shell).document().document().querySelector("#front"));
+}
+
+TEST(EditorShellTest, MenuActionsRouteCanvasClipboardHistorySelectionAndViewState) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+  EditorShellTestAccess::ConfigureViewport(shell, Box2d::FromXYWH(0.0, 0.0, 120.0, 80.0));
+  EditorShellTestAccess::UseInMemoryShapeClipboard(shell);
+
+  auto target = EditorShellTestAccess::App(shell).document().document().querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  EditorShellTestAccess::App(shell).setSelection(*target);
+
+  MenuBarActions actions;
+  actions.copy = true;
+  EditorShellTestAccess::ApplyMenuActions(shell, actions);
+  ASSERT_TRUE(EditorShellTestAccess::ShapeClipboardHasText(shell));
+  EXPECT_NE(EditorShellTestAccess::ShapeClipboardText(shell).find("target"), std::string::npos);
+
+  actions = MenuBarActions{};
+  actions.cut = true;
+  EditorShellTestAccess::ApplyMenuActions(shell, actions);
+  EXPECT_TRUE(EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell));
+  EXPECT_FALSE(EditorShellTestAccess::App(shell).document().document().querySelector("#target"));
+
+  actions = MenuBarActions{};
+  actions.undo = true;
+  EditorShellTestAccess::ApplyMenuActions(shell, actions);
+  EXPECT_TRUE(EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell));
+  EXPECT_TRUE(EditorShellTestAccess::App(shell).document().document().querySelector("#target"));
+
+  actions = MenuBarActions{};
+  actions.redo = true;
+  EditorShellTestAccess::ApplyMenuActions(shell, actions);
+  EXPECT_TRUE(EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell));
+  EXPECT_FALSE(EditorShellTestAccess::App(shell).document().document().querySelector("#target"));
+
+  actions = MenuBarActions{};
+  actions.revertFile = true;
+  EditorShellTestAccess::ApplyMenuActions(shell, actions);
+  EXPECT_TRUE(EditorShellTestAccess::App(shell).document().document().querySelector("#target"));
+
+  actions = MenuBarActions{};
+  actions.paste = true;
+  EditorShellTestAccess::ApplyMenuActions(shell, actions);
+  EXPECT_TRUE(EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell));
+  EXPECT_TRUE(
+      EditorShellTestAccess::App(shell).document().document().querySelector("#target_pasted"));
+
+  actions = MenuBarActions{};
+  actions.pasteInFront = true;
+  EditorShellTestAccess::ApplyMenuActions(shell, actions);
+  EXPECT_TRUE(EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell));
+  EXPECT_TRUE(
+      EditorShellTestAccess::App(shell).document().document().querySelector("#target_pasted2"));
+
+  actions = MenuBarActions{};
+  actions.selectAllCanvas = true;
+  EditorShellTestAccess::ApplyMenuActions(shell, actions);
+  EXPECT_GT(EditorShellTestAccess::App(shell).selectedElements().size(), 1u);
+
+  actions = MenuBarActions{};
+  actions.deselectAllCanvas = true;
+  EditorShellTestAccess::ApplyMenuActions(shell, actions);
+  EXPECT_FALSE(EditorShellTestAccess::App(shell).hasSelection());
+
+  actions = MenuBarActions{};
+  actions.selectAll = true;
+  EditorShellTestAccess::ApplyMenuActions(shell, actions);
+  EXPECT_EQ(EditorShellTestAccess::Source(shell).getSelectedText(),
+            EditorShellTestAccess::Source(shell).getText());
+
+  actions = MenuBarActions{};
+  actions.deselectAll = true;
+  EditorShellTestAccess::ApplyMenuActions(shell, actions);
+  EXPECT_TRUE(EditorShellTestAccess::Source(shell).getSelectedText().empty());
+
+  auto label = EditorShellTestAccess::App(shell).document().document().querySelector("#label");
+  ASSERT_TRUE(label.has_value());
+  EditorShellTestAccess::App(shell).setSelection(*label);
+  actions = MenuBarActions{};
+  actions.convertTextToOutlines = true;
+  EditorShellTestAccess::ApplyMenuActions(shell, actions);
+  EXPECT_TRUE(EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell));
+  EXPECT_TRUE(
+      EditorShellTestAccess::App(shell).document().document().querySelector("#label_outlines"));
+
+  EditorShellTestAccess::ClearRequestRenderAtEndOfFrame(shell);
+  const bool sourceFocusBefore = EditorShellTestAccess::SourceFocusMode(shell);
+  const bool compositorDebugBefore = EditorShellTestAccess::ShowCompositorDebugPanel(shell);
+  const bool perfOverlayBefore = EditorShellTestAccess::ShowPerfOverlay(shell);
+
+  actions = MenuBarActions{};
+  actions.zoomIn = true;
+  actions.zoomOut = true;
+  actions.actualSize = true;
+  actions.toggleSourceFocusMode = true;
+  actions.toggleCompositorDebugPanel = true;
+  actions.togglePerfOverlay = true;
+  EditorShellTestAccess::ApplyMenuActions(shell, actions);
+
+  EXPECT_TRUE(EditorShellTestAccess::RequestRenderAtEndOfFrame(shell));
+  EXPECT_NE(EditorShellTestAccess::SourceFocusMode(shell), sourceFocusBefore);
+  EXPECT_NE(EditorShellTestAccess::ShowCompositorDebugPanel(shell), compositorDebugBefore);
+  EXPECT_NE(EditorShellTestAccess::ShowPerfOverlay(shell), perfOverlayBefore);
+}
+
+TEST(EditorShellTest, MenuActionsRouteDialogAndExportRequestsWithoutCurrentPath) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShellOptions options;
+  options.initialSource = std::string(kInitialSvg);
+  EditorShell shell(window, std::move(options));
+  ASSERT_TRUE(shell.valid());
+
+  MenuBarActions actions;
+  actions.openAbout = true;
+  actions.openFile = true;
+  actions.saveFile = true;
+  actions.saveFileAs = true;
+  actions.exportViewportSvg = true;
+  actions.exportViewportSvgWithOverlay = true;
+  actions.quit = true;
+  actions.undo = true;
+  actions.redo = true;
+
+  EditorShellTestAccess::ApplyMenuActions(shell, actions);
+
+  EXPECT_TRUE(EditorShellTestAccess::PendingViewportExport(shell));
+  EXPECT_TRUE(EditorShellTestAccess::PendingViewportExportOverlay(shell));
+  EXPECT_TRUE(shell.valid());
+}
+
+TEST(EditorShellTest, ShapeClipboardCopyCutAndPasteUseCanvasSelection) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+  EditorShellTestAccess::UseInMemoryShapeClipboard(shell);
+
+  auto target = EditorShellTestAccess::App(shell).document().document().querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  EditorShellTestAccess::App(shell).setSelection(*target);
+
+  EditorShellTestAccess::CopySelectedShapesToClipboard(shell);
+  EXPECT_TRUE(EditorShellTestAccess::ShapeClipboardHasText(shell));
+  EXPECT_NE(EditorShellTestAccess::ShapeClipboardText(shell).find("target"), std::string::npos);
+
+  EditorShellTestAccess::PasteShapesFromClipboard(shell, /*inFront=*/false);
+  EXPECT_TRUE(EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell));
+  EXPECT_NE(EditorShellTestAccess::App(shell).document().document().source().find("target_pasted"),
+            std::string_view::npos);
+
+  auto pasted =
+      EditorShellTestAccess::App(shell).document().document().querySelector("#target_pasted");
+  ASSERT_TRUE(pasted.has_value());
+  EditorShellTestAccess::App(shell).setSelection(*pasted);
+  EditorShellTestAccess::CutSelectedShapesToClipboard(shell);
+  EXPECT_TRUE(EditorShellTestAccess::ShapeClipboardHasText(shell));
+  EXPECT_TRUE(EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell));
+  EXPECT_EQ(EditorShellTestAccess::App(shell).document().document().source().find("target_pasted"),
+            std::string_view::npos);
+
+  EditorShellTestAccess::ClearShapeClipboard(shell);
+  const std::string_view sourceBeforeNullClipboardPaste =
+      EditorShellTestAccess::App(shell).document().document().source();
+  EditorShellTestAccess::CopySelectedShapesToClipboard(shell);
+  EXPECT_FALSE(EditorShellTestAccess::ShapeClipboardHasText(shell));
+  EditorShellTestAccess::PasteShapesFromClipboard(shell, /*inFront=*/true);
+  (void)EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell);
+  EXPECT_EQ(EditorShellTestAccess::App(shell).document().document().source(),
+            sourceBeforeNullClipboardPaste);
+}
+
+TEST(EditorShellTest, ShapeClipboardRejectsMalformedAndPastesIntoSelectedGroup) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  constexpr std::string_view kGroupedSvg = R"svg(
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="80" viewBox="0 0 120 80">
+  <g id="group"><circle id="inside" cx="12" cy="12" r="4"/></g>
+  <rect id="target" x="10" y="12" width="40" height="24" fill="#3366cc"/>
+</svg>
+)svg";
+  EditorShell shell(window, OptionsWithSource(kGroupedSvg, "grouped.svg"));
+  ASSERT_TRUE(shell.valid());
+  EditorShellTestAccess::UseInMemoryShapeClipboard(shell);
+
+  EditorShellTestAccess::SetShapeClipboardText(shell, "<rect");
+  const std::string_view sourceBeforeMalformedPaste =
+      EditorShellTestAccess::App(shell).document().document().source();
+  EditorShellTestAccess::PasteShapesFromClipboard(shell, /*inFront=*/false);
+  (void)EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell);
+  EXPECT_EQ(EditorShellTestAccess::App(shell).document().document().source(),
+            sourceBeforeMalformedPaste);
+
+  auto target = EditorShellTestAccess::App(shell).document().document().querySelector("#target");
+  auto group = EditorShellTestAccess::App(shell).document().document().querySelector("#group");
+  ASSERT_TRUE(target.has_value());
+  ASSERT_TRUE(group.has_value());
+
+  EditorShellTestAccess::App(shell).setSelection(*target);
+  EditorShellTestAccess::CopySelectedShapesToClipboard(shell);
+  ASSERT_TRUE(EditorShellTestAccess::ShapeClipboardHasText(shell));
+
+  EditorShellTestAccess::App(shell).setSelection(*group);
+  EditorShellTestAccess::PasteShapesFromClipboard(shell, /*inFront=*/false);
+  EXPECT_TRUE(EditorShellTestAccess::FlushQueuedMutationAndRefreshOverlay(shell));
+  const std::string_view source = EditorShellTestAccess::App(shell).document().document().source();
+  const std::size_t groupOffset = source.find(R"(id="group")");
+  const std::size_t pastedOffset = source.find(R"(id="target_pasted")");
+  const std::size_t groupCloseOffset = source.find("</g>");
+  ASSERT_NE(groupOffset, std::string_view::npos);
+  ASSERT_NE(pastedOffset, std::string_view::npos);
+  ASSERT_NE(groupCloseOffset, std::string_view::npos);
+  EXPECT_GT(pastedOffset, groupOffset);
+  EXPECT_LT(pastedOffset, groupCloseOffset);
 }
 
 }  // namespace donner::editor

--- a/donner/editor/tests/FocusView_tests.cc
+++ b/donner/editor/tests/FocusView_tests.cc
@@ -9,6 +9,7 @@
 #include <string_view>
 #include <vector>
 
+#include "donner/base/xml/XMLNode.h"
 #include "donner/editor/DocumentSyncController.h"
 #include "donner/editor/EditorApp.h"
 #include "donner/editor/TextEditor.h"
@@ -267,6 +268,24 @@ constexpr std::string_view kLooseReferenceSyntaxSvg =
   <use id="ignored" href=" not-a-fragment "/>
 </svg>)svg";
 
+constexpr std::string_view kAdditionalReferenceSyntaxSvg =
+    R"svg(<svg xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .target { fill: url('#paint'); stroke: url(#accent ); clip-path: url(#); }
+  </style>
+  <defs>
+    <linearGradient id="paint"><stop offset="0"/></linearGradient>
+    <clipPath id="accent"><circle/></clipPath>
+  </defs>
+  <rect id="target" class="target"/>
+</svg>)svg";
+
+constexpr std::string_view kMissingReferenceSvg =
+    R"svg(<svg xmlns="http://www.w3.org/2000/svg">
+  <rect id="target" fill="url(#missing)"/>
+  <rect id="sibling"/>
+</svg>)svg";
+
 std::size_t OffsetForNeedle(std::string_view source, std::string_view needle) {
   const std::size_t offset = source.find(needle);
   EXPECT_NE(offset, std::string_view::npos) << needle;
@@ -492,6 +511,122 @@ TEST(FocusViewTest, ReferenceSummaryHandlesLooseReferenceSyntax) {
   const ReferenceHighlightSummary ignoredSummary = ComputeReferenceHighlightSummary(
       app.document().document(), std::span<const svg::SVGElement>(&*ignored, 1));
   EXPECT_EQ(ignoredSummary.totalCount(), 0u);
+}
+
+TEST(FocusViewTest, ParsesSingleQuotedAndUnquotedUrlReferenceBoundaries) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kAdditionalReferenceSyntaxSvg));
+  std::optional<svg::SVGElement> target = app.document().document().querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+
+  const FocusPartition partition = ComputeFocusPartition(app.document().document(), *target);
+
+  EXPECT_TRUE(ContainsLine(
+      partition.referenceColor,
+      PointForNeedle(kAdditionalReferenceSyntaxSvg, R"(<linearGradient id="paint")").line));
+  EXPECT_TRUE(
+      ContainsLine(partition.referenceColor,
+                   PointForNeedle(kAdditionalReferenceSyntaxSvg, R"(<clipPath id="accent")").line));
+  EXPECT_TRUE(ContainsLink(partition.referenceLinks,
+                           FocusReferenceLink{
+                               .from = PointForNeedle(kAdditionalReferenceSyntaxSvg, "#paint"),
+                               .to = PointForOpeningTagEnd(kAdditionalReferenceSyntaxSvg,
+                                                           R"(<linearGradient id="paint")"),
+                           }));
+  EXPECT_TRUE(ContainsLink(
+      partition.referenceLinks,
+      FocusReferenceLink{
+          .from = PointForNeedle(kAdditionalReferenceSyntaxSvg, "#accent"),
+          .to = PointForOpeningTagEnd(kAdditionalReferenceSyntaxSvg, R"(<clipPath id="accent")"),
+      }));
+  EXPECT_GE(partition.referenceLinks.size(), 2u);
+}
+
+TEST(FocusViewTest, MissingReferencesDoNotCreateSourceLinksOrSummaryEntries) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kMissingReferenceSvg));
+  std::optional<svg::SVGElement> target = app.document().document().querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+
+  const FocusPartition partition = ComputeFocusPartition(app.document().document(), *target);
+
+  EXPECT_TRUE(partition.referenceColor.empty());
+  EXPECT_TRUE(partition.referenceLinks.empty());
+
+  const ReferenceHighlightSummary summary = ComputeReferenceHighlightSummary(
+      app.document().document(), std::span<const svg::SVGElement>(&*target, 1));
+  EXPECT_EQ(summary.totalCount(), 0u);
+}
+
+TEST(FocusViewTest, SourceLocationLossDropsFocusRatherThanGuessingRanges) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kReferencedSvg));
+  std::optional<svg::SVGElement> target = app.document().document().querySelector("#target");
+  std::optional<svg::SVGElement> paint = app.document().document().querySelector("#paint");
+  ASSERT_TRUE(target.has_value());
+  ASSERT_TRUE(paint.has_value());
+
+  {
+    std::optional<xml::XMLNode> paintNode = xml::XMLNode::TryCast(paint->entityHandle());
+    ASSERT_TRUE(paintNode.has_value());
+    paintNode->clearSourceLocation();
+  }
+
+  const FocusPartition partitionWithMissingReferenceRange =
+      ComputeFocusPartition(app.document().document(), *target);
+  EXPECT_FALSE(
+      ContainsLink(partitionWithMissingReferenceRange.referenceLinks,
+                   FocusReferenceLink{
+                       .from = PointForNeedle(kReferencedSvg, "#paint"),
+                       .to = PointForOpeningTagEnd(kReferencedSvg, R"(<linearGradient id="paint")"),
+                   }));
+  EXPECT_FALSE(ContainsLine(partitionWithMissingReferenceRange.referenceColor,
+                            PointForNeedle(kReferencedSvg, R"(<linearGradient id="paint")").line));
+
+  {
+    std::optional<xml::XMLNode> targetNode = xml::XMLNode::TryCast(target->entityHandle());
+    ASSERT_TRUE(targetNode.has_value());
+    targetNode->clearSourceLocation();
+  }
+
+  EXPECT_TRUE(ComputeFocusPartition(app.document().document(), *target).empty());
+}
+
+TEST(FocusViewTest, MissingResourceOpeningTagLocationFallsBackToNodeStartForLinks) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kReferencedSvg));
+  std::optional<svg::SVGElement> target = app.document().document().querySelector("#target");
+  std::optional<svg::SVGElement> paint = app.document().document().querySelector("#paint");
+  ASSERT_TRUE(target.has_value());
+  ASSERT_TRUE(paint.has_value());
+
+  std::optional<xml::XMLNode> paintNode = xml::XMLNode::TryCast(paint->entityHandle());
+  ASSERT_TRUE(paintNode.has_value());
+  paintNode->clearOpeningTagLocation();
+
+  const FocusPartition partition = ComputeFocusPartition(app.document().document(), *target);
+
+  EXPECT_TRUE(
+      ContainsLink(partition.referenceLinks,
+                   FocusReferenceLink{
+                       .from = PointForNeedle(kReferencedSvg, "#paint"),
+                       .to = PointForNeedle(kReferencedSvg, R"(<linearGradient id="paint")"),
+                   }));
+}
+
+TEST(FocusViewTest, MissingSelectedAncestorSourceRangeReturnsEmptyPartition) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kNestedSvg));
+  std::optional<svg::SVGElement> target = app.document().document().querySelector("#target");
+  std::optional<svg::SVGElement> inner = app.document().document().querySelector("#inner");
+  ASSERT_TRUE(target.has_value());
+  ASSERT_TRUE(inner.has_value());
+
+  std::optional<xml::XMLNode> innerNode = xml::XMLNode::TryCast(inner->entityHandle());
+  ASSERT_TRUE(innerNode.has_value());
+  innerNode->clearSourceLocation();
+
+  EXPECT_TRUE(ComputeFocusPartition(app.document().document(), *target).empty());
 }
 
 TEST(FocusViewTest, ReferenceHighlightSummaryCountsForwardReferences) {

--- a/donner/editor/tests/GlRnrReplay_tests.cc
+++ b/donner/editor/tests/GlRnrReplay_tests.cc
@@ -164,6 +164,61 @@ std::optional<svg::RendererBitmap> RenderGroundTruth(std::string_view svgSource,
   renderer.draw(referenceApp.document().document());
   return NormalizeBitmap(renderer.takeSnapshot());
 }
+
+TEST(GlRnrReplayTest, CropModeParsingAcceptsAliasesAndRejectsUnknownValues) {
+  EXPECT_EQ(repro::ParseGlRnrReplayCropMode("full"), repro::GlRnrReplayCropMode::Full);
+  EXPECT_EQ(repro::ParseGlRnrReplayCropMode("render-pane"), repro::GlRnrReplayCropMode::RenderPane);
+  EXPECT_EQ(repro::ParseGlRnrReplayCropMode("document-canvas"),
+            repro::GlRnrReplayCropMode::DocumentCanvas);
+  EXPECT_EQ(repro::ParseGlRnrReplayCropMode("canvas"), repro::GlRnrReplayCropMode::DocumentCanvas);
+  EXPECT_EQ(repro::ParseGlRnrReplayCropMode("unknown"), std::nullopt);
+
+  EXPECT_EQ(repro::GlRnrReplayCropModeSuffix(repro::GlRnrReplayCropMode::Full), "");
+  EXPECT_EQ(repro::GlRnrReplayCropModeSuffix(repro::GlRnrReplayCropMode::RenderPane),
+            "render_pane");
+  EXPECT_EQ(repro::GlRnrReplayCropModeSuffix(repro::GlRnrReplayCropMode::DocumentCanvas), "canvas");
+}
+
+TEST(GlRnrReplayTest, RunGlRnrReplayValidatesOptionsBeforeOpeningWindow) {
+  repro::GlRnrReplayOptions options;
+  repro::GlRnrReplayResult result;
+  std::string error;
+
+  EXPECT_FALSE(repro::RunGlRnrReplay(options, nullptr, nullptr));
+
+  EXPECT_FALSE(repro::RunGlRnrReplay(options, &result, &error));
+  EXPECT_EQ(error, "rnrPath is required");
+
+  options.rnrPath = DiagnosticOutputDir() / "missing.rnr";
+  error.clear();
+  EXPECT_FALSE(repro::RunGlRnrReplay(options, &result, &error));
+  EXPECT_EQ(error, "at least one GL capture selector is required");
+
+  options.captureFrames = {1};
+  options.holdFramesBehind = -1;
+  error.clear();
+  EXPECT_FALSE(repro::RunGlRnrReplay(options, &result, &error));
+  EXPECT_EQ(error, "holdFramesBehind must be non-negative");
+
+  options.holdFramesBehind = 0;
+  options.workerRenderDelayMsForTesting = -1;
+  error.clear();
+  EXPECT_FALSE(repro::RunGlRnrReplay(options, &result, &error));
+  EXPECT_EQ(error, "workerRenderDelayMsForTesting must be non-negative");
+
+  options.workerRenderDelayMsForTesting = 0;
+  options.holdFramesBehind = 1;
+  options.workerScheduling = repro::GlRnrReplayWorkerScheduling::Realtime;
+  error.clear();
+  EXPECT_FALSE(repro::RunGlRnrReplay(options, &result, &error));
+  EXPECT_EQ(error, "holdFramesBehind requires HoldFramesBehind worker scheduling");
+
+  options.holdFramesBehind = 0;
+  error.clear();
+  EXPECT_FALSE(repro::RunGlRnrReplay(options, &result, &error));
+  EXPECT_NE(error.find("failed to read .rnr file"), std::string::npos);
+}
+
 constexpr std::string_view kStaticContentOnlySvg =
     "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"200\" height=\"120\" "
     "viewBox=\"0 0 200 120\"><rect width=\"200\" height=\"120\" "
@@ -2140,7 +2195,11 @@ TEST(GlRnrReplayTest, UsesEmbeddedSvgSourceWhenOriginalPathIsMissing) {
   options.rnrPath = reproPath;
   options.outputDir = outputDir;
   options.captureFrames.insert(0);
+  options.maxFrame = 0;
+  options.cropMode = repro::GlRnrReplayCropMode::DocumentCanvas;
   options.pace = false;
+  options.workerScheduling = repro::GlRnrReplayWorkerScheduling::DrainEachFrame;
+  options.contentOnlyCapture = true;
 
   repro::GlRnrReplayResult result;
   std::string error;

--- a/donner/editor/tests/GlTextureCache_tests.cc
+++ b/donner/editor/tests/GlTextureCache_tests.cc
@@ -143,6 +143,134 @@ TEST(GlTextureCacheTest, PayloadIdentityUsesActualBitmapDimensions) {
   EXPECT_EQ(PowerOfTwoTextureDimensionsForPayload(identity.textureDimsPx), Vector2i(8, 16));
 }
 
+TEST(GlTextureCacheTest, PayloadSizeHelpersHandleEmptyAndInvalidDimensions) {
+  svg::RendererBitmap bitmap;
+  EXPECT_EQ(BitmapPayloadBytes(bitmap), 0u);
+
+  bitmap.dimensions = Vector2i(3, 2);
+  bitmap.rowBytes = 0u;
+  bitmap.pixels.resize(24u);
+  EXPECT_EQ(BitmapPayloadBytes(bitmap), 0u);
+
+  bitmap.rowBytes = 12u;
+  bitmap.dimensions = Vector2i(3, 0);
+  EXPECT_EQ(BitmapPayloadBytes(bitmap), 0u);
+
+  EXPECT_EQ(TexturePayloadBytes(Vector2i(-1, 10)), 0u);
+  EXPECT_EQ(TexturePayloadBytes(Vector2i(3, 4)), 48u);
+  EXPECT_EQ(PowerOfTwoTextureDimensionsForPayload(Vector2i((1 << 30) + 1, 3)),
+            Vector2i((1 << 30) + 1, 4));
+
+  EXPECT_EQ(TextureUvBottomRightForPayload(Vector2i(0, 1), Vector2i(2, 2)), Vector2d(1.0, 1.0));
+  EXPECT_EQ(TextureUvBottomRightForPayload(Vector2i(3, 1), Vector2i(4, 0)), Vector2d(1.0, 1.0));
+}
+
+TEST(GlTextureCacheTest, MetadataOnlyCompositedUploadTracksMissesAndViewportDiagnostics) {
+  RenderResult::CompositedPreview preview;
+  RenderResult::CompositedTile tile = MetadataTile(RenderResult::CompositedTile::Kind::Segment, 7,
+                                                   Vector2i(8, 9), Vector2i(20, 20));
+  tile.id = "seg:0";
+  tile.canvasOffsetDoc = Vector2d(1.0, 2.0);
+  tile.bitmapDimsDoc = Vector2d(3.0, 4.0);
+  tile.dragTranslationDoc = Vector2d(5.0, 6.0);
+  preview.tiles.push_back(std::move(tile));
+
+  GlTextureCache cache;
+  cache.uploadComposited(preview, RasterViewportForTest(/*viewportBounded=*/true));
+
+  EXPECT_TRUE(cache.tiles().empty());
+  EXPECT_TRUE(cache.overviewTiles().empty());
+  EXPECT_TRUE(cache.activeTilesViewportBounded());
+  EXPECT_EQ(cache.metadataOnlyMissCount(), 1);
+  EXPECT_EQ(cache.duplicateLiveTextureCount(), 0);
+  EXPECT_EQ(cache.lastCompositedUploadCost().tileCount, 1);
+  EXPECT_EQ(cache.lastCompositedUploadCost().metadataOnlyTileCount, 1);
+  EXPECT_EQ(cache.lastCompositedUploadCost().tilePixelArea, 8u * 9u);
+  EXPECT_EQ(cache.lastCompositedUploadCost().payloadBytes, 0u);
+
+  const PresentationCoverageDiagnostics coverage = cache.coverageDiagnostics();
+  EXPECT_TRUE(coverage.activeTilesViewportBounded);
+  EXPECT_FALSE(coverage.overviewInfillAvailable);
+  EXPECT_EQ(coverage.activeRasterDocumentRect, Box2d::FromXYWH(0.0, 0.0, 100.0, 100.0));
+  EXPECT_EQ(coverage.overviewRasterDocumentRect, Box2d());
+  EXPECT_EQ(coverage.activeOutputSizePx, Vector2i(20, 20));
+  EXPECT_EQ(coverage.overviewOutputSizePx, Vector2i::Zero());
+}
+
+TEST(GlTextureCacheTest, MetadataOnlyOverviewUploadTracksMissAndRetainsViewport) {
+  RenderResult::CompositedPreview preview;
+  RenderResult::CompositedTile tile = MetadataTile(RenderResult::CompositedTile::Kind::Layer, 8,
+                                                   Vector2i(6, 7), Vector2i(100, 100));
+  tile.id = "layer:0";
+  preview.tiles.push_back(std::move(tile));
+
+  GlTextureCache cache;
+  cache.uploadCompositedOverview(preview, RasterViewportForTest(/*viewportBounded=*/false));
+
+  EXPECT_TRUE(cache.tiles().empty());
+  EXPECT_TRUE(cache.overviewTiles().empty());
+  EXPECT_FALSE(cache.activeTilesViewportBounded());
+  EXPECT_EQ(cache.metadataOnlyMissCount(), 1);
+  EXPECT_EQ(cache.lastCompositedUploadCost().tileCount, 1);
+  EXPECT_EQ(cache.lastCompositedUploadCost().metadataOnlyTileCount, 1);
+  EXPECT_EQ(cache.lastCompositedUploadCost().tilePixelArea, 6u * 7u);
+
+  const PresentationCoverageDiagnostics coverage = cache.coverageDiagnostics();
+  EXPECT_FALSE(coverage.activeTilesViewportBounded);
+  EXPECT_FALSE(coverage.overviewInfillAvailable);
+  EXPECT_EQ(coverage.activeRasterDocumentRect, Box2d());
+  EXPECT_EQ(coverage.overviewRasterDocumentRect, Box2d::FromXYWH(0.0, 0.0, 100.0, 100.0));
+  EXPECT_EQ(coverage.activeOutputSizePx, Vector2i::Zero());
+  EXPECT_EQ(coverage.overviewOutputSizePx, Vector2i(100, 100));
+}
+
+TEST(GlTextureCacheTest, ResetCompositedClearsMetadataBookkeepingAndCost) {
+  RenderResult::CompositedPreview preview;
+  RenderResult::CompositedTile tile = MetadataTile(RenderResult::CompositedTile::Kind::Immediate, 9,
+                                                   Vector2i(4, 5), Vector2i(20, 20));
+  tile.id = "immediate:0";
+  preview.tiles.push_back(std::move(tile));
+
+  GlTextureCache cache;
+  cache.uploadComposited(preview, RasterViewportForTest(/*viewportBounded=*/true));
+  ASSERT_TRUE(cache.activeTilesViewportBounded());
+  ASSERT_EQ(cache.metadataOnlyMissCount(), 1);
+  ASSERT_EQ(cache.lastCompositedUploadCost().tileCount, 1);
+
+  cache.resetComposited();
+
+  EXPECT_TRUE(cache.tiles().empty());
+  EXPECT_TRUE(cache.overviewTiles().empty());
+  EXPECT_FALSE(cache.activeTilesViewportBounded());
+  EXPECT_EQ(cache.metadataOnlyMissCount(), 0);
+  EXPECT_EQ(cache.duplicateLiveTextureCount(), 0);
+  EXPECT_EQ(cache.lastCompositedUploadCost().tileCount, 0);
+  EXPECT_EQ(cache.lastCompositedUploadCost().tilePixelArea, 0u);
+
+  const PresentationCoverageDiagnostics coverage = cache.coverageDiagnostics();
+  EXPECT_FALSE(coverage.activeTilesViewportBounded);
+  EXPECT_FALSE(coverage.overviewInfillAvailable);
+  EXPECT_EQ(coverage.activeRasterDocumentRect, Box2d());
+  EXPECT_EQ(coverage.overviewRasterDocumentRect, Box2d());
+  EXPECT_EQ(coverage.activeOutputSizePx, Vector2i::Zero());
+  EXPECT_EQ(coverage.overviewOutputSizePx, Vector2i::Zero());
+}
+
+TEST(GlTextureCacheTest, EmptyThumbnailAndRetainOnEmptyDoNotAllocate) {
+  GlTextureCache cache;
+  svg::RendererBitmap bitmap;
+
+  const GlTextureCache::ThumbnailTextureView view = cache.uploadThumbnail(42u, bitmap);
+
+  EXPECT_EQ(view.texture, 0);
+  EXPECT_EQ(view.uvBottomRight, Vector2d(1.0, 1.0));
+  EXPECT_EQ(cache.thumbnailTextureCount(), 0u);
+
+  cache.retainThumbnailsOnly({42u});
+  EXPECT_EQ(cache.thumbnailTextureCount(), 0u);
+  EXPECT_EQ(cache.presentationResourceStats().totalTrackedBytes, 0u);
+}
+
 #ifdef DONNER_EDITOR_WGPU
 std::shared_ptr<geode::GeodeDevice> SharedGeodeDevice() {
   static const std::shared_ptr<geode::GeodeDevice> device(geode::GeodeDevice::CreateHeadless());

--- a/donner/editor/tests/LayersPanel_tests.cc
+++ b/donner/editor/tests/LayersPanel_tests.cc
@@ -182,6 +182,21 @@ TEST(LayersPanelTest, MissingRowPreviewQueriesReturnEmpty) {
   EXPECT_EQ(panel.rowThumbnail(missingStableId), nullptr);
 }
 
+TEST(LayersPanelTest, RefreshSnapshotWithoutDocumentClearsRowsAndThumbnailState) {
+  EditorApp app;
+
+  LayersPanel panel;
+  panel.refreshSnapshot(app);
+
+  EXPECT_EQ(panel.visibleRowCount(), 0u);
+  EXPECT_TRUE(panel.rows().empty());
+  EXPECT_EQ(panel.thumbnailRefreshStats().rowCount, 0u);
+  EXPECT_EQ(panel.thumbnailRefreshStats().renderedCount, 0u);
+  EXPECT_EQ(panel.thumbnailRefreshStats().reusedCount, 0u);
+  EXPECT_EQ(panel.thumbnailRefreshStats().skippedForCanvasInvalidationCount, 0u);
+  EXPECT_FALSE(panel.hasThumbnailOrSwatch(1u));
+}
+
 TEST(LayersPanelTest, BeginRenameFindsVisibleRowsAndIgnoresMissingRows) {
   EditorApp app;
   ASSERT_TRUE(app.loadFromString(kSvg));
@@ -1310,6 +1325,11 @@ protected:
     int imageQuads = 0;
   };
 
+  struct FocusedFrameDiagnostics {
+    int totalVertices = 0;
+    bool popupOpen = false;
+  };
+
   void SetUp() override {
     IMGUI_CHECKVERSION();
     ctx_ = ImGui::CreateContext();
@@ -1341,6 +1361,47 @@ protected:
     panel.render(&app);
     ImGui::End();
     ImGui::Render();
+  }
+
+  FocusedFrameDiagnostics RenderFocusedFrame(
+      LayersPanel& panel, EditorApp* liveApp, const std::vector<ImGuiKey>& pressedKeys = {},
+      std::optional<std::uint64_t> popupStableId = std::nullopt) {
+    ImGuiIO& io = ImGui::GetIO();
+    io.DisplaySize = ImVec2(400, 300);
+    io.AddMousePosEvent(-1.0f, -1.0f);
+    io.AddMouseButtonEvent(0, false);
+    for (ImGuiKey key : pressedKeys) {
+      io.AddKeyEvent(key, true);
+    }
+
+    ImGui::NewFrame();
+    ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_Always);
+    ImGui::SetNextWindowSize(ImVec2(300, 250), ImGuiCond_Always);
+    ImGui::SetNextWindowFocus();
+    ImGui::Begin("##layers_focused_frame_test", nullptr,
+                 ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
+                     ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoScrollbar);
+    if (popupStableId.has_value()) {
+      ImGui::PushID(static_cast<int>(static_cast<std::uint32_t>(*popupStableId)));
+      ImGui::OpenPopup("##layer_row_menu");
+      ImGui::PopID();
+    }
+    panel.render(liveApp);
+    FocusedFrameDiagnostics diagnostics;
+    if (popupStableId.has_value()) {
+      ImGui::PushID(static_cast<int>(static_cast<std::uint32_t>(*popupStableId)));
+      diagnostics.popupOpen = ImGui::IsPopupOpen("##layer_row_menu");
+      ImGui::PopID();
+    }
+    ImGui::End();
+    ImGui::Render();
+    if (const ImDrawData* drawData = ImGui::GetDrawData(); drawData != nullptr) {
+      diagnostics.totalVertices = drawData->TotalVtxCount;
+    }
+    for (ImGuiKey key : pressedKeys) {
+      io.AddKeyEvent(key, false);
+    }
+    return diagnostics;
   }
 
   int RenderCompositorDebugPanelFrame(
@@ -1935,6 +1996,144 @@ TEST_F(LayersPanelImGuiTest, LayerAffordancesRenderSvgBitmapButtons) {
       << "layer affordance icons are drawn at 14 logical px and must be rasterized at 2x or "
          "higher before ImGui scales them";
   EXPECT_GE(diagnostics.imageQuads, 2) << "eye/lock controls should emit image quads";
+}
+
+TEST_F(LayersPanelImGuiTest, LayerAffordancesRenderHiddenAndLockedIconVariants) {
+  EditorApp app;
+  LoadDocument(app, R"(<svg xmlns="http://www.w3.org/2000/svg">
+    <rect id="rect1" x="0" y="0" width="10" height="10"/>
+  </svg>)");
+  LayersPanel panel;
+  panel.refreshSnapshot(app);
+  const int rectIndex = RowIndex(panel, "rect1");
+  ASSERT_GE(rectIndex, 0);
+
+  panel.handleEyeClick(app, static_cast<std::size_t>(rectIndex));
+  panel.handleLockClick(app, static_cast<std::size_t>(rectIndex));
+  ASSERT_TRUE(app.document().flushFrame());
+  panel.refreshSnapshot(app);
+  const std::optional<LayerTreeRow> row = FindRow(panel, "rect1");
+  ASSERT_TRUE(row.has_value());
+  EXPECT_FALSE(row->isVisible);
+  EXPECT_TRUE(row->isLocked);
+
+  const IconButtonDiagnostics diagnostics = MeasureIconButtons(panel, app);
+  EXPECT_GE(diagnostics.providerCalls, 2)
+      << "hidden/locked rows should request the alternate eye and lock icon textures";
+  EXPECT_EQ(diagnostics.providerCalls, diagnostics.nonEmptyBitmaps);
+  EXPECT_EQ(diagnostics.providerCalls, diagnostics.retinaBitmaps);
+  EXPECT_GE(diagnostics.imageQuads, 2);
+}
+
+TEST_F(LayersPanelImGuiTest, InlineRenameFieldRendersForTheActiveRow) {
+  EditorApp app;
+  LoadDocument(app, R"(<svg xmlns="http://www.w3.org/2000/svg">
+    <rect id="rect1" x="0" y="0" width="10" height="10"/>
+  </svg>)");
+  LayersPanel panel;
+  panel.refreshSnapshot(app);
+  const std::optional<LayerTreeRow> row = FindRow(panel, "rect1");
+  ASSERT_TRUE(row.has_value());
+
+  panel.beginRename(row->stableId);
+  EXPECT_EQ(panel.renamingStableId(), std::optional(row->stableId));
+
+  const FocusedFrameDiagnostics diagnostics = RenderFocusedFrame(panel, &app);
+  EXPECT_GT(diagnostics.totalVertices, 0);
+  EXPECT_EQ(panel.renamingStableId(), std::optional(row->stableId))
+      << "the inline rename edit should stay open until Enter or focus loss";
+}
+
+TEST_F(LayersPanelImGuiTest, RowContextMenusRenderVisibleAndLockedActionsWithoutImplicitMutation) {
+  EditorApp app;
+  LoadDocument(app, R"(<svg xmlns="http://www.w3.org/2000/svg">
+    <rect id="visible" x="0" y="0" width="10" height="10"/>
+    <rect id="hiddenLocked" x="20" y="0" width="10" height="10"/>
+  </svg>)");
+  LayersPanel panel;
+  panel.refreshSnapshot(app);
+  const int hiddenLockedIndex = RowIndex(panel, "hiddenLocked");
+  ASSERT_GE(hiddenLockedIndex, 0);
+  panel.handleEyeClick(app, static_cast<std::size_t>(hiddenLockedIndex));
+  panel.handleLockClick(app, static_cast<std::size_t>(hiddenLockedIndex));
+  ASSERT_TRUE(app.document().flushFrame());
+  EXPECT_TRUE(panel.consumeQueuedMutation());
+  panel.refreshSnapshot(app);
+
+  const std::optional<LayerTreeRow> visible = FindRow(panel, "visible");
+  const std::optional<LayerTreeRow> hiddenLocked = FindRow(panel, "hiddenLocked");
+  ASSERT_TRUE(visible.has_value());
+  ASSERT_TRUE(hiddenLocked.has_value());
+  EXPECT_TRUE(visible->isVisible);
+  EXPECT_FALSE(visible->isLocked);
+  EXPECT_FALSE(hiddenLocked->isVisible);
+  EXPECT_TRUE(hiddenLocked->isLocked);
+
+  EXPECT_TRUE(RenderFocusedFrame(panel, &app, {}, visible->stableId).popupOpen);
+  EXPECT_TRUE(RenderFocusedFrame(panel, &app, {}, hiddenLocked->stableId).popupOpen);
+  EXPECT_FALSE(panel.consumeSelectionChanged());
+  EXPECT_FALSE(panel.consumeQueuedMutation());
+}
+
+TEST_F(LayersPanelImGuiTest, KeyboardNavigationSelectsAdjacentRows) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kSvg));
+  LayersPanel panel;
+  panel.refreshSnapshot(app);
+  ASSERT_GE(panel.visibleRowCount(), 2u);
+  const svg::SVGElement firstRow = panel.rows()[0].element;
+  const svg::SVGElement secondRow = panel.rows()[1].element;
+
+  RenderFocusedFrame(panel, &app, {ImGuiKey_DownArrow});
+  RenderFocusedFrame(panel, &app, {ImGuiKey_Enter});
+  ASSERT_EQ(app.selectedElements().size(), 1u);
+  EXPECT_EQ(app.selectedElements().front(), secondRow);
+  EXPECT_TRUE(panel.consumeSelectionChanged());
+
+  RenderFocusedFrame(panel, &app, {ImGuiKey_UpArrow});
+  RenderFocusedFrame(panel, &app, {ImGuiKey_KeypadEnter});
+  ASSERT_EQ(app.selectedElements().size(), 1u);
+  EXPECT_EQ(app.selectedElements().front(), firstRow);
+  EXPECT_TRUE(panel.consumeSelectionChanged());
+}
+
+TEST_F(LayersPanelImGuiTest, KeyboardLeftAndRightToggleActiveGroupExpansion) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kSvg));
+  LayersPanel panel;
+  panel.refreshSnapshot(app);
+  const int groupIndex = RowIndex(panel, "groupA");
+  ASSERT_GE(groupIndex, 0);
+  const LayerTreeRow groupRow = panel.rows()[static_cast<std::size_t>(groupIndex)];
+  ASSERT_TRUE(groupRow.hasChildren);
+  ASSERT_TRUE(groupRow.isExpanded);
+
+  panel.handleRowClick(app, static_cast<std::size_t>(groupIndex), LayersPanel::ClickModifiers{});
+  RenderFocusedFrame(panel, &app, {ImGuiKey_LeftArrow});
+  EXPECT_FALSE(panel.model().isExpanded(groupRow.stableId));
+
+  panel.refreshSnapshot(app);
+  RenderFocusedFrame(panel, &app, {ImGuiKey_RightArrow});
+  EXPECT_TRUE(panel.model().isExpanded(groupRow.stableId));
+}
+
+TEST_F(LayersPanelImGuiTest, KeyboardLeftOnLeafMovesActiveRowToVisibleParent) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kSvg));
+  LayersPanel panel;
+  panel.refreshSnapshot(app);
+  const int rectIndex = RowIndex(panel, "rectTop");
+  const int groupIndex = RowIndex(panel, "groupA");
+  ASSERT_GE(rectIndex, 0);
+  ASSERT_GE(groupIndex, 0);
+  const svg::SVGElement groupElement = panel.rows()[static_cast<std::size_t>(groupIndex)].element;
+
+  panel.handleRowClick(app, static_cast<std::size_t>(rectIndex), LayersPanel::ClickModifiers{});
+  RenderFocusedFrame(panel, &app, {ImGuiKey_LeftArrow});
+  RenderFocusedFrame(panel, &app, {ImGuiKey_Enter});
+
+  ASSERT_EQ(app.selectedElements().size(), 1u);
+  EXPECT_EQ(app.selectedElements().front(), groupElement);
 }
 
 TEST_F(LayersPanelImGuiTest, LockButtonReceivesClick) {

--- a/donner/editor/tests/MenuBarPresenter_tests.cc
+++ b/donner/editor/tests/MenuBarPresenter_tests.cc
@@ -30,6 +30,14 @@ protected:
     return actions;
   }
 
+  static void PrimeMainMenuPopup(const char* menuLabel) {
+    ImGui::NewFrame();
+    ASSERT_TRUE(ImGui::BeginMainMenuBar());
+    ImGui::OpenPopup(menuLabel);
+    ImGui::EndMainMenuBar();
+    ImGui::Render();
+  }
+
 private:
   ImGuiContext* context_ = nullptr;
 };
@@ -91,6 +99,78 @@ TEST_F(MenuBarPresenterTest, RendersEnabledStateWithBoldMenuFont) {
   EXPECT_FALSE(actions.zoomOut);
   EXPECT_FALSE(actions.actualSize);
   EXPECT_FALSE(actions.toggleSourceFocusMode);
+}
+
+TEST_F(MenuBarPresenterTest, RendersEachOpenMenuWithoutImplicitActions) {
+  MenuBarState state;
+  state.sourcePaneFocused = true;
+  state.canSave = true;
+  state.canRevert = true;
+  state.canUndo = true;
+  state.canRedo = true;
+  state.hasShapeSelection = true;
+  state.hasShapeClipboard = true;
+  state.hasTextSelection = true;
+  state.hasSelectableElements = true;
+  state.sourceFocusMode = true;
+  state.showCompositorDebugPanel = true;
+  state.showPerfOverlay = true;
+
+  for (const char* menuLabel : {"Donner SVG Editor", "File", "Edit", "View"}) {
+    PrimeMainMenuPopup(menuLabel);
+    const MenuBarActions actions = RenderFrame(state);
+    EXPECT_FALSE(actions.openAbout) << menuLabel;
+    EXPECT_FALSE(actions.openFile) << menuLabel;
+    EXPECT_FALSE(actions.saveFile) << menuLabel;
+    EXPECT_FALSE(actions.saveFileAs) << menuLabel;
+    EXPECT_FALSE(actions.exportViewportSvg) << menuLabel;
+    EXPECT_FALSE(actions.exportViewportSvgWithOverlay) << menuLabel;
+    EXPECT_FALSE(actions.revertFile) << menuLabel;
+    EXPECT_FALSE(actions.quit) << menuLabel;
+    EXPECT_FALSE(actions.undo) << menuLabel;
+    EXPECT_FALSE(actions.redo) << menuLabel;
+    EXPECT_FALSE(actions.cut) << menuLabel;
+    EXPECT_FALSE(actions.copy) << menuLabel;
+    EXPECT_FALSE(actions.paste) << menuLabel;
+    EXPECT_FALSE(actions.pasteInFront) << menuLabel;
+    EXPECT_FALSE(actions.convertTextToOutlines) << menuLabel;
+    EXPECT_FALSE(actions.selectAll) << menuLabel;
+    EXPECT_FALSE(actions.selectAllCanvas) << menuLabel;
+    EXPECT_FALSE(actions.deselectAll) << menuLabel;
+    EXPECT_FALSE(actions.deselectAllCanvas) << menuLabel;
+    EXPECT_FALSE(actions.zoomIn) << menuLabel;
+    EXPECT_FALSE(actions.zoomOut) << menuLabel;
+    EXPECT_FALSE(actions.actualSize) << menuLabel;
+    EXPECT_FALSE(actions.toggleSourceFocusMode) << menuLabel;
+    EXPECT_FALSE(actions.toggleCompositorDebugPanel) << menuLabel;
+    EXPECT_FALSE(actions.togglePerfOverlay) << menuLabel;
+  }
+}
+
+TEST(MenuBarPresenterActionsTest, ApplyViewMenuToggleActionsHandlesNullAndIndependentToggles) {
+  bool showCompositorDebugPanel = false;
+  bool showPerfOverlay = true;
+
+  ApplyViewMenuToggleActions(MenuBarActions{}, &showCompositorDebugPanel, &showPerfOverlay);
+  EXPECT_FALSE(showCompositorDebugPanel);
+  EXPECT_TRUE(showPerfOverlay);
+
+  MenuBarActions actions;
+  actions.toggleCompositorDebugPanel = true;
+  ApplyViewMenuToggleActions(actions, &showCompositorDebugPanel, nullptr);
+  EXPECT_TRUE(showCompositorDebugPanel);
+  EXPECT_TRUE(showPerfOverlay);
+
+  actions = MenuBarActions{};
+  actions.togglePerfOverlay = true;
+  ApplyViewMenuToggleActions(actions, nullptr, &showPerfOverlay);
+  EXPECT_TRUE(showCompositorDebugPanel);
+  EXPECT_FALSE(showPerfOverlay);
+
+  actions.toggleCompositorDebugPanel = true;
+  ApplyViewMenuToggleActions(actions, &showCompositorDebugPanel, &showPerfOverlay);
+  EXPECT_FALSE(showCompositorDebugPanel);
+  EXPECT_TRUE(showPerfOverlay);
 }
 
 }  // namespace

--- a/donner/editor/tests/PenTool_tests.cc
+++ b/donner/editor/tests/PenTool_tests.cc
@@ -233,6 +233,30 @@ TEST_F(PenToolTest, RemoveLastAnchorOnLoneAnchorDiscardsDraft) {
   EXPECT_FALSE(app.hasSelection()) << "discarding a lone-anchor draft removes the created path";
 }
 
+TEST_F(PenToolTest, CancelCreatedDraftRemovesPathAndSelection) {
+  tool.onMouseDown(app, Vector2d(10.0, 20.0), MouseModifiers{});
+  ASSERT_TRUE(app.flushFrame());
+  ASSERT_TRUE(tool.isDrafting());
+  ASSERT_TRUE(app.hasSelection());
+
+  tool.cancel(app);
+  ASSERT_TRUE(app.flushFrame());
+
+  EXPECT_FALSE(tool.isDrafting());
+  EXPECT_FALSE(app.hasSelection());
+  EXPECT_FALSE(app.document().document().querySelector("path").has_value());
+}
+
+TEST_F(PenToolTest, CancelWithoutDraftIsNoOp) {
+  const std::string before(app.document().document().source());
+
+  tool.cancel(app);
+
+  EXPECT_FALSE(app.flushFrame());
+  EXPECT_FALSE(tool.isDrafting());
+  EXPECT_EQ(app.document().document().source(), before);
+}
+
 TEST_F(PenToolTest, RemoveLastAnchorIsNoOpDuringDrag) {
   tool.onMouseDown(app, Vector2d(10.0, 20.0), MouseModifiers{});
   ASSERT_TRUE(app.flushFrame());
@@ -374,6 +398,19 @@ TEST_F(PenToolTest, FinalizedPenPathStaysInsideSvgRootSource) {
   EXPECT_EQ(*reparsedParent, reparsed.document().document().svgElement()) << source;
 }
 
+TEST_F(PenToolTest, CommitOpenPathIsNoOpWithoutDraftOrSingleAnchor) {
+  EXPECT_FALSE(tool.commitOpenPath(app));
+
+  tool.onMouseDown(app, Vector2d(10.0, 20.0), MouseModifiers{});
+  tool.onMouseUp(app, Vector2d(10.0, 20.0));
+  ASSERT_TRUE(app.flushFrame());
+
+  EXPECT_FALSE(tool.commitOpenPath(app));
+  EXPECT_FALSE(app.flushFrame());
+  EXPECT_TRUE(tool.isDrafting());
+  EXPECT_EQ(path().d(), "M 10 20");
+}
+
 TEST_F(PenToolTest, DragControlPointUsesAlignedCouplingOnSmoothAnchor) {
   // Place a corner anchor, then a smooth anchor via click-drag so the path is
   // "M 10 10 C 10 10 50 -10 50 10" with mirrored handles on (50,10).
@@ -443,6 +480,34 @@ TEST_F(PenToolTest, ShiftDragControlPointConstrainsAngle) {
   ASSERT_TRUE(app.flushFrame());
 
   EXPECT_EQ(path().d(), "M 10 10 C 10 10 30 10 50 10");
+}
+
+TEST_F(PenToolTest, DragIncomingControlPointUsesAlignedCouplingOnSmoothAnchor) {
+  tool.onMouseDown(app, Vector2d(10.0, 10.0), MouseModifiers{});
+  tool.onMouseUp(app, Vector2d(10.0, 10.0));
+  ASSERT_TRUE(app.flushFrame());
+
+  tool.onMouseDown(app, Vector2d(50.0, 10.0), MouseModifiers{});
+  tool.onMouseMove(app, Vector2d(50.0, 30.0), /*buttonHeld=*/true);
+  tool.onMouseUp(app, Vector2d(50.0, 30.0));
+  ASSERT_TRUE(app.flushFrame());
+
+  // Grab the smooth anchor's incoming handle at (50,-10). Dragging it to the
+  // left keeps the outgoing handle collinear on the opposite side, so the next
+  // appended segment starts with an outgoing handle at (70,10).
+  tool.onMouseDown(app, Vector2d(50.0, -10.0), MouseModifiers{});
+  ASSERT_TRUE(tool.isDraggingAnchor());
+  tool.onMouseMove(app, Vector2d(30.0, 10.0), /*buttonHeld=*/true);
+  tool.onMouseUp(app, Vector2d(30.0, 10.0));
+  ASSERT_TRUE(app.flushFrame());
+
+  EXPECT_EQ(path().d(), "M 10 10 C 10 10 30 10 50 10");
+
+  tool.onMouseDown(app, Vector2d(90.0, 10.0), MouseModifiers{});
+  tool.onMouseUp(app, Vector2d(90.0, 10.0));
+  ASSERT_TRUE(app.flushFrame());
+
+  EXPECT_EQ(path().d(), "M 10 10 C 10 10 30 10 50 10 C 70 10 90 10 90 10");
 }
 
 TEST_F(PenToolTest, DragAnchorMovesPointAndHandles) {
@@ -549,6 +614,30 @@ TEST_F(PenToolTest, AltClickCornerAnchorConvertsToSmooth) {
   EXPECT_TRUE(tool.isDrafting());
 }
 
+TEST_F(PenToolTest, AltClickClosedContourEndpointSynthesizesWrappedSmoothHandles) {
+  constexpr std::string_view kClosedPathSvg =
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+           <path id="c" d="M 10 10 L 40 10 L 40 40 Z" fill="none" stroke="black"/>
+         </svg>)";
+  ASSERT_TRUE(app.loadFromString(kClosedPathSvg));
+  auto selected = app.document().document().querySelector("#c");
+  ASSERT_TRUE(selected.has_value());
+  app.setSelection(*selected);
+
+  MouseModifiers option;
+  option.option = true;
+  tool.onMouseDown(app, Vector2d(10.0, 10.0), option);
+  tool.onMouseUp(app, Vector2d(10.0, 10.0));
+  ASSERT_TRUE(app.flushFrame());
+
+  const std::string d(std::string_view(selected->cast<svg::SVGPathElement>().d()));
+  EXPECT_THAT(d, ::testing::StartsWith("M 10 10 C "))
+      << "the wrapped next neighbor should give the first segment an outgoing handle: " << d;
+  EXPECT_THAT(d, ::testing::HasSubstr(" Z"))
+      << "smooth conversion of a closed endpoint must preserve closure: " << d;
+  EXPECT_FALSE(tool.isDrafting());
+}
+
 TEST_F(PenToolTest, ClickDragOnCloseShapesClosingAnchorHandles) {
   tool.onMouseDown(app, Vector2d(10.0, 10.0), MouseModifiers{});
   tool.onMouseUp(app, Vector2d(10.0, 10.0));
@@ -577,6 +666,23 @@ TEST_F(PenToolTest, ClickDragOnCloseShapesClosingAnchorHandles) {
   EXPECT_THAT(d, ::testing::HasSubstr("C 40 70 -10 30 10 10 Z"))
       << "the closing segment must serialize as an explicit cubic into the start anchor: " << d;
   EXPECT_FALSE(tool.isDrafting()) << "close-drag finalizes on mouse-up";
+}
+
+TEST_F(PenToolTest, CommitOpenPathWhileDraggingNewestAnchorPersistsDragGeometry) {
+  tool.onMouseDown(app, Vector2d(10.0, 10.0), MouseModifiers{});
+  tool.onMouseUp(app, Vector2d(10.0, 10.0));
+  ASSERT_TRUE(app.flushFrame());
+
+  tool.onMouseDown(app, Vector2d(40.0, 10.0), MouseModifiers{});
+  tool.onMouseMove(app, Vector2d(40.0, 30.0), /*buttonHeld=*/true);
+  ASSERT_TRUE(tool.isDraggingAnchor());
+
+  ASSERT_TRUE(tool.commitOpenPath(app));
+  ASSERT_TRUE(app.flushFrame());
+
+  EXPECT_EQ(path().d(), "M 10 10 C 10 10 40 -10 40 10");
+  EXPECT_FALSE(tool.isDrafting());
+  EXPECT_FALSE(tool.isDraggingAnchor());
 }
 
 TEST_F(PenToolTest, ClickOnDraftSegmentInsertsAnchor) {
@@ -616,6 +722,83 @@ TEST_F(PenToolTest, ClickOnCommittedSelectedPathSegmentInsertsAnchor) {
 
   EXPECT_EQ(selected->cast<svg::SVGPathElement>().d(), "M 0 0 L 20 0 L 40 0");
   EXPECT_FALSE(tool.isDrafting());
+}
+
+TEST_F(PenToolTest, CommandClickWithNonEditableSelectionDoesNotStartDraft) {
+  struct Scenario {
+    std::string_view svg;
+    std::vector<std::string_view> selectionIds;
+  };
+  const std::array scenarios = {
+      Scenario{
+          .svg = R"(<svg xmlns="http://www.w3.org/2000/svg"><rect id="r"/></svg>)",
+          .selectionIds = {"r"},
+      },
+      Scenario{
+          .svg =
+              R"(<svg xmlns="http://www.w3.org/2000/svg"><path id="p" d="M"/><rect id="r"/></svg>)",
+          .selectionIds = {"p"},
+      },
+      Scenario{
+          .svg =
+              R"(<svg xmlns="http://www.w3.org/2000/svg"><path id="p" d=""/><rect id="r"/></svg>)",
+          .selectionIds = {"p"},
+      },
+      Scenario{
+          .svg =
+              R"(<svg xmlns="http://www.w3.org/2000/svg"><path id="p" d="M 0 0 M 10 10"/><rect id="r"/></svg>)",
+          .selectionIds = {"p"},
+      },
+      Scenario{
+          .svg =
+              R"(<svg xmlns="http://www.w3.org/2000/svg"><path id="p" d="M 0 0 L 10 0 Z L 20 0"/><rect id="r"/></svg>)",
+          .selectionIds = {"p"},
+      },
+      Scenario{
+          .svg =
+              R"(<svg xmlns="http://www.w3.org/2000/svg"><path id="p" d="M 0 0 L 10 0"/><rect id="r"/></svg>)",
+          .selectionIds = {"p", "r"},
+      },
+  };
+
+  MouseModifiers command;
+  command.command = true;
+  for (const Scenario& scenario : scenarios) {
+    ASSERT_TRUE(app.loadFromString(scenario.svg));
+    std::vector<svg::SVGElement> selection;
+    for (std::string_view id : scenario.selectionIds) {
+      auto element = app.document().document().querySelector("#" + std::string(id));
+      ASSERT_TRUE(element.has_value()) << id;
+      selection.push_back(*element);
+    }
+    app.setSelection(std::move(selection));
+
+    PenTool localTool;
+    const std::string before(app.document().document().source());
+    localTool.onMouseDown(app, Vector2d(50.0, 50.0), command);
+    localTool.onMouseUp(app, Vector2d(50.0, 50.0));
+
+    EXPECT_FALSE(localTool.isDrafting()) << scenario.svg;
+    EXPECT_FALSE(app.flushFrame()) << scenario.svg;
+    EXPECT_EQ(app.document().document().source(), before) << scenario.svg;
+  }
+}
+
+TEST_F(PenToolTest, ClickOpenEndpointOfQuadraticPathResumesDrafting) {
+  ASSERT_TRUE(app.loadFromString(
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+           <path id="q" d="M 0 0 Q 30 30 60 0" fill="none" stroke="black"/>
+         </svg>)"));
+  auto selected = app.document().document().querySelector("#q");
+  ASSERT_TRUE(selected.has_value());
+  app.setSelection(*selected);
+
+  tool.onMouseDown(app, Vector2d(60.0, 0.0), MouseModifiers{});
+  tool.onMouseUp(app, Vector2d(60.0, 0.0));
+
+  EXPECT_FALSE(app.flushFrame());
+  EXPECT_TRUE(tool.isDrafting());
+  EXPECT_EQ(tool.activePathData(), "M 0 0 C 20 20 40 20 60 0");
 }
 
 TEST_F(PenToolTest, EditingCommittedSelectedPathDragsAnchor) {
@@ -733,6 +916,55 @@ TEST_F(PenToolTest, ShiftConstrainsNextSegment) {
   ASSERT_TRUE(app.flushFrame());
 
   EXPECT_EQ(path().d(), "M 10 10 L 40 10");
+}
+
+TEST_F(PenToolTest, PreviewSegmentPathCoversLineCurveShiftAndCloseAffordance) {
+  EXPECT_FALSE(tool.previewSegmentPath(Vector2d(20.0, 20.0), MouseModifiers{}).has_value());
+  EXPECT_FALSE(tool.wouldCloseAt(Vector2d(10.0, 10.0), MouseModifiers{}));
+
+  tool.onMouseDown(app, Vector2d(10.0, 10.0), MouseModifiers{});
+  EXPECT_FALSE(tool.previewSegmentPath(Vector2d(20.0, 20.0), MouseModifiers{}).has_value());
+  tool.onMouseUp(app, Vector2d(10.0, 10.0));
+  ASSERT_TRUE(app.flushFrame());
+
+  std::optional<Path> linePreview = tool.previewSegmentPath(Vector2d(30.0, 10.0), MouseModifiers{});
+  ASSERT_TRUE(linePreview.has_value());
+  EXPECT_EQ(linePreview->toSVGPathData(), "M 10 10 L 30 10");
+
+  MouseModifiers shift;
+  shift.shift = true;
+  std::optional<Path> shiftedPreview = tool.previewSegmentPath(Vector2d(38.0, 32.0), shift);
+  ASSERT_TRUE(shiftedPreview.has_value());
+  EXPECT_EQ(shiftedPreview->toSVGPathData(), "M 10 10 L 35 35");
+
+  tool.onMouseDown(app, Vector2d(40.0, 10.0), MouseModifiers{});
+  tool.onMouseUp(app, Vector2d(40.0, 10.0));
+  ASSERT_TRUE(app.flushFrame());
+  tool.onMouseDown(app, Vector2d(40.0, 40.0), MouseModifiers{});
+  tool.onMouseUp(app, Vector2d(40.0, 40.0));
+  ASSERT_TRUE(app.flushFrame());
+
+  MouseModifiers closeModifiers;
+  closeModifiers.pixelsPerDocUnit = 1.0;
+  EXPECT_TRUE(tool.wouldCloseAt(Vector2d(11.0, 10.0), closeModifiers));
+  std::optional<Path> closePreview = tool.previewSegmentPath(Vector2d(11.0, 10.0), closeModifiers);
+  ASSERT_TRUE(closePreview.has_value());
+  EXPECT_EQ(closePreview->toSVGPathData(), "M 40 40 L 10 10");
+
+  EditorApp curvedApp;
+  ASSERT_TRUE(curvedApp.loadFromString(kEmptySvg));
+  PenTool curvedTool;
+  curvedTool.onMouseDown(curvedApp, Vector2d(10.0, 10.0), MouseModifiers{});
+  curvedTool.onMouseMove(curvedApp, Vector2d(20.0, 10.0), /*buttonHeld=*/true);
+  curvedTool.onMouseUp(curvedApp, Vector2d(20.0, 10.0));
+  ASSERT_TRUE(curvedApp.flushFrame());
+
+  std::optional<Path> curvePreview =
+      curvedTool.previewSegmentPath(Vector2d(30.0, 20.0), MouseModifiers{});
+  ASSERT_TRUE(curvePreview.has_value());
+  ASSERT_EQ(curvePreview->commands().size(), 2u);
+  EXPECT_EQ(curvePreview->commands()[1].verb, Path::Verb::CurveTo);
+  EXPECT_EQ(curvePreview->toSVGPathData(), "M 10 10 C 20 10 30 20 30 20");
 }
 
 TEST_F(PenToolTest, SelectedOpenPathCanBeContinued) {

--- a/donner/editor/tests/PresentedFrameComposer_tests.cc
+++ b/donner/editor/tests/PresentedFrameComposer_tests.cc
@@ -234,6 +234,15 @@ TEST(PresentedFrameComposerTest, RejectsInvalidTileGeometry) {
 
   tile.bitmapDimsDoc = Vector2d(30.0, -1.0);
   EXPECT_FALSE(ComputePresentedTileRect(tile, Transform2d::Scale(2.0), std::nullopt).has_value());
+
+  const double infinity = std::numeric_limits<double>::infinity();
+  tile.bitmapDimsDoc = Vector2d(30.0, 40.0);
+  tile.canvasOffsetDoc = Vector2d(10.0, infinity);
+  EXPECT_FALSE(ComputePresentedTileRect(tile, Transform2d::Scale(2.0), std::nullopt).has_value());
+
+  tile.canvasOffsetDoc = Vector2d(10.0, 20.0);
+  tile.dragTranslationDoc = Vector2d(infinity, 0.0);
+  EXPECT_FALSE(ComputePresentedTileRect(tile, Transform2d::Scale(2.0), std::nullopt).has_value());
 }
 
 TEST(PresentedFrameComposerTest, RejectsInvalidOutputTransform) {
@@ -247,6 +256,25 @@ TEST(PresentedFrameComposerTest, RejectsInvalidOutputTransform) {
   EXPECT_FALSE(
       ComputePresentedTileRect(tile, Transform2d::Translate(Vector2d(infinity, 0.0)), std::nullopt)
           .has_value());
+}
+
+TEST(PresentedFrameComposerTest, RejectsInvalidEffectiveDragBaseline) {
+  const double infinity = std::numeric_limits<double>::infinity();
+  PresentedFrameTileGeometry tile;
+  tile.canvasOffsetDoc = Vector2d(0.0, 0.0);
+  tile.bitmapDimsDoc = Vector2d(10.0, 10.0);
+  tile.isDragTarget = true;
+
+  std::optional<PresentedDragBaseline> baseline = PresentedDragBaseline{
+      .entity = Entity{123},
+      .representedTranslationDoc = Vector2d::Zero(),
+      .activeTranslationDoc = Vector2d(infinity, 0.0),
+  };
+  EXPECT_FALSE(ComputePresentedTileQuad(tile, Transform2d(), baseline).has_value());
+
+  baseline->activeTranslationDoc = Vector2d::Zero();
+  baseline->activeDocumentFromCachedDocument = Transform2d::Translate(Vector2d(0.0, infinity));
+  EXPECT_FALSE(ComputePresentedTileQuad(tile, Transform2d(), baseline).has_value());
 }
 
 TEST(PresentedFrameComposerTest, RoundsPresentedRectToPixelRect) {
@@ -264,6 +292,24 @@ TEST(PresentedFrameComposerTest, RoundsPresentedRectToPixelRect) {
                                                      }));
 }
 
+TEST(PresentedFrameComposerTest, RejectsDegeneratePresentedPixelRects) {
+  EXPECT_FALSE(RoundPresentedTileRectToPixelRect(PresentedTileRect{
+                                                     .topLeft = Vector2d(10.0, 10.0),
+                                                     .bottomRight = Vector2d(10.0, 20.0),
+                                                 })
+                   .has_value());
+  EXPECT_FALSE(RoundPresentedTileRectToPixelRect(PresentedTileRect{
+                                                     .topLeft = Vector2d(10.0, 10.0),
+                                                     .bottomRight = Vector2d(20.0, 10.0),
+                                                 })
+                   .has_value());
+  EXPECT_FALSE(RoundPresentedTileRectToPixelRect(PresentedTileRect{
+                                                     .topLeft = Vector2d(10.0, 10.0),
+                                                     .bottomRight = Vector2d(10.2, 10.2),
+                                                 })
+                   .has_value());
+}
+
 TEST(PresentedFrameComposerTest, SubtractsCoveredTileBoundsFromOverviewClip) {
   const Box2d clip = Box2d::FromXYWH(0.0, 0.0, 100.0, 100.0);
   const std::array<Box2d, 1> covered{Box2d::FromXYWH(25.0, 25.0, 50.0, 50.0)};
@@ -277,6 +323,29 @@ TEST(PresentedFrameComposerTest, SubtractsCoveredTileBoundsFromOverviewClip) {
       Box2d::FromXYWH(75.0, 25.0, 25.0, 50.0),
   };
   EXPECT_EQ(uncovered, expected);
+}
+
+TEST(PresentedFrameComposerTest, SubtractIgnoresInvalidAndNonIntersectingCoveredRects) {
+  const Box2d clip = Box2d::FromXYWH(0.0, 0.0, 100.0, 100.0);
+  const std::array<Box2d, 3> covered{
+      Box2d::FromXYWH(150.0, 150.0, 10.0, 10.0),
+      Box2d(Vector2d(25.0, 25.0), Vector2d(25.0, 50.0)),
+      Box2d::FromXYWH(10.0, 10.0, 20.0, 20.0),
+  };
+
+  const std::vector<Box2d> uncovered = SubtractPresentedTileBoundsFromClip(clip, covered);
+
+  EXPECT_EQ(uncovered.size(), 4u);
+}
+
+TEST(PresentedFrameComposerTest, SubtractReturnsEmptyForInvalidClipOrFullCoverage) {
+  EXPECT_TRUE(SubtractPresentedTileBoundsFromClip(Box2d(Vector2d(0.0, 0.0), Vector2d(0.0, 10.0)),
+                                                  std::span<const Box2d>())
+                  .empty());
+
+  const Box2d clip = Box2d::FromXYWH(0.0, 0.0, 100.0, 100.0);
+  const std::array<Box2d, 1> covered{clip};
+  EXPECT_TRUE(SubtractPresentedTileBoundsFromClip(clip, covered).empty());
 }
 
 }  // namespace

--- a/donner/editor/tests/RenderCoordinator_tests.cc
+++ b/donner/editor/tests/RenderCoordinator_tests.cc
@@ -1,6 +1,7 @@
 #include "donner/editor/RenderCoordinator.h"
 
 #include <chrono>
+#include <limits>
 #include <thread>
 #include <vector>
 
@@ -48,6 +49,15 @@ constexpr std::string_view kHiddenRectSvg =
     R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
          <rect id="visible" x="10" y="10" width="20" height="20" fill="red"/>
          <rect id="hidden" x="50" y="50" width="20" height="20" fill="blue"
+               style="display:none"/>
+       </svg>)";
+
+constexpr std::string_view kMixedSelectionSvg =
+    R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+         <defs id="defs"><rect id="in-defs" x="0" y="0" width="10" height="10"/></defs>
+         <rect id="visible1" x="10" y="10" width="20" height="20" fill="red"/>
+         <rect id="visible2" x="40" y="10" width="20" height="20" fill="green"/>
+         <rect id="hidden" x="70" y="10" width="20" height="20" fill="blue"
                style="display:none"/>
        </svg>)";
 
@@ -147,6 +157,9 @@ TEST(RenderCoordinatorPolicyTest, ReleaseSettleWaitsForQueuedTransformFlush) {
       << "Mouse-up can queue the final transform while the renderer is busy. A stale in-flight "
          "render at the already-flushed version must not close the settle window before that "
          "queued transform is flushed.";
+  EXPECT_EQ(PostReleaseSettleTargetVersion(std::numeric_limits<std::uint64_t>::max(),
+                                           /*hasPendingMutations=*/true),
+            std::numeric_limits<std::uint64_t>::max());
 }
 
 TEST(RenderCoordinatorPolicyTest, PendingSelectedLayerRasterizationBypassesViewportDefer) {
@@ -163,6 +176,35 @@ TEST(RenderCoordinatorPolicyTest, PendingSelectedLayerRasterizationBypassesViewp
       << "A style/fill edit marks the selected layer pixels stale; the coordinator must request "
          "the forced layer rasterization immediately instead of deferring forever on an unsettled "
          "viewport.";
+}
+
+TEST(RenderCoordinatorPolicyTest, SelectedViewportRefreshDeferRequiresEveryPredicate) {
+  const Entity selectedEntity = static_cast<Entity>(7);
+
+  EXPECT_FALSE(ShouldDeferSelectedViewportRefresh(
+      entt::null, /*hasActiveDrag=*/false, /*currentVersion=*/8, /*displayedDocVersion=*/8,
+      /*hasCachedSelectedTexture=*/true, /*rasterViewportSettled=*/false,
+      /*needsOverviewInfill=*/false, /*pendingSelectedLayerRasterization=*/false));
+  EXPECT_FALSE(ShouldDeferSelectedViewportRefresh(
+      selectedEntity, /*hasActiveDrag=*/true, /*currentVersion=*/8, /*displayedDocVersion=*/8,
+      /*hasCachedSelectedTexture=*/true, /*rasterViewportSettled=*/false,
+      /*needsOverviewInfill=*/false, /*pendingSelectedLayerRasterization=*/false));
+  EXPECT_FALSE(ShouldDeferSelectedViewportRefresh(
+      selectedEntity, /*hasActiveDrag=*/false, /*currentVersion=*/9, /*displayedDocVersion=*/8,
+      /*hasCachedSelectedTexture=*/true, /*rasterViewportSettled=*/false,
+      /*needsOverviewInfill=*/false, /*pendingSelectedLayerRasterization=*/false));
+  EXPECT_FALSE(ShouldDeferSelectedViewportRefresh(
+      selectedEntity, /*hasActiveDrag=*/false, /*currentVersion=*/8, /*displayedDocVersion=*/8,
+      /*hasCachedSelectedTexture=*/false, /*rasterViewportSettled=*/false,
+      /*needsOverviewInfill=*/false, /*pendingSelectedLayerRasterization=*/false));
+  EXPECT_FALSE(ShouldDeferSelectedViewportRefresh(
+      selectedEntity, /*hasActiveDrag=*/false, /*currentVersion=*/8, /*displayedDocVersion=*/8,
+      /*hasCachedSelectedTexture=*/true, /*rasterViewportSettled=*/true,
+      /*needsOverviewInfill=*/false, /*pendingSelectedLayerRasterization=*/false));
+  EXPECT_FALSE(ShouldDeferSelectedViewportRefresh(
+      selectedEntity, /*hasActiveDrag=*/false, /*currentVersion=*/8, /*displayedDocVersion=*/8,
+      /*hasCachedSelectedTexture=*/true, /*rasterViewportSettled=*/false,
+      /*needsOverviewInfill=*/true, /*pendingSelectedLayerRasterization=*/false));
 }
 
 TEST(RenderCoordinatorPolicyTest, OnlyForcedSelectedResultClearsPendingLayerRasterization) {
@@ -189,6 +231,30 @@ TEST(RenderCoordinatorPolicyTest, OnlyForcedSelectedResultClearsPendingLayerRast
   forcedSelectionPreview.entity = static_cast<Entity>(8);
   EXPECT_FALSE(ShouldClearPendingSelectedLayerRasterization(
       forcedSelectionPreview, selectedEntity, /*resultVersion=*/8, /*pendingVersion=*/8));
+}
+
+TEST(RenderCoordinatorPolicyTest, PendingSelectedLayerClearRequiresEntityPreviewAndVersion) {
+  const Entity selectedEntity = static_cast<Entity>(7);
+
+  RenderRequest::DragPreview forcedPreview;
+  forcedPreview.entity = selectedEntity;
+  forcedPreview.forceLayerRasterization = true;
+
+  EXPECT_FALSE(ShouldClearPendingSelectedLayerRasterization(
+      forcedPreview, entt::null, /*resultVersion=*/8, /*pendingVersion=*/8));
+  EXPECT_FALSE(ShouldClearPendingSelectedLayerRasterization(
+      forcedPreview, selectedEntity, /*resultVersion=*/7, /*pendingVersion=*/8));
+  EXPECT_FALSE(ShouldClearPendingSelectedLayerRasterization(
+      std::nullopt, selectedEntity, /*resultVersion=*/8, /*pendingVersion=*/8));
+
+  forcedPreview.entity = static_cast<Entity>(8);
+  EXPECT_FALSE(ShouldClearPendingSelectedLayerRasterization(
+      forcedPreview, selectedEntity, /*resultVersion=*/8, /*pendingVersion=*/8));
+
+  forcedPreview.entity = selectedEntity;
+  forcedPreview.forceLayerRasterization = false;
+  EXPECT_FALSE(ShouldClearPendingSelectedLayerRasterization(
+      forcedPreview, selectedEntity, /*resultVersion=*/8, /*pendingVersion=*/8));
 }
 
 TEST(RenderCoordinatorPolicyTest, RepresentedDragPreviewFollowsActiveTargetWhenPresentable) {
@@ -237,6 +303,21 @@ TEST(RenderCoordinatorPolicyTest, RepresentedDragPreviewFallsBackForMismatchedDi
   EXPECT_EQ(represented->dragGeneration, active.dragGeneration);
 }
 
+TEST(RenderCoordinatorPolicyTest, RepresentedDragPreviewFallsBackForGenerationMismatch) {
+  const SelectTool::ActiveDragPreview active =
+      DragPreview(static_cast<Entity>(42), 7, Vector2d(5.0, 2.0));
+  const SelectTool::ActiveDragPreview staleDisplayed =
+      DragPreview(static_cast<Entity>(42), 6, Vector2d(1.0, 1.0));
+
+  const std::optional<SelectTool::ActiveDragPreview> represented =
+      OverlayRepresentedDragPreviewForPresentation(active, staleDisplayed,
+                                                   /*hasPresentableActiveDragTarget=*/false);
+  ASSERT_TRUE(represented.has_value());
+  EXPECT_EQ(represented->entity, active.entity);
+  EXPECT_EQ(represented->translation, Vector2d::Zero());
+  EXPECT_EQ(represented->dragGeneration, active.dragGeneration);
+}
+
 TEST(RenderCoordinatorPolicyTest, RepresentedDocumentTransformRequiresMatchingInvertibleDrag) {
   const SelectTool::ActiveDragPreview live = DragPreview(
       static_cast<Entity>(42), 7, Vector2d(10.0, 0.0), Transform2d::Translate(Vector2d(10.0, 0.0)));
@@ -277,6 +358,28 @@ TEST(RenderCoordinatorPolicyTest, GesturePreviewProjectsOntoRepresentedDragState
   ASSERT_TRUE(projected.has_value());
   EXPECT_EQ(projected->currentDocumentDelta, represented.translation);
   EXPECT_FALSE(projected->documentFromStartDocument.isIdentity());
+}
+
+TEST(RenderCoordinatorPolicyTest, GesturePreviewKeepsLiveDeltaForUnmatchedRepresentedDrag) {
+  SelectTool::ActiveGesturePreview gesture;
+  gesture.kind = SelectTool::ActiveGestureKind::Move;
+  gesture.startBoundsDoc = Box2d::FromXYWH(10.0, 10.0, 20.0, 20.0);
+  gesture.documentFromStartDocument = Transform2d::Translate(Vector2d(10.0, 0.0));
+  gesture.currentDocumentDelta = Vector2d(10.0, 0.0);
+
+  const SelectTool::ActiveDragPreview live = DragPreview(
+      static_cast<Entity>(42), 7, Vector2d(10.0, 0.0), Transform2d::Translate(Vector2d(10.0, 0.0)));
+  const SelectTool::ActiveDragPreview represented = DragPreview(
+      static_cast<Entity>(43), 7, Vector2d(3.0, 0.0), Transform2d::Translate(Vector2d(3.0, 0.0)));
+
+  const std::optional<SelectTool::ActiveGesturePreview> projected =
+      OverlayGesturePreviewForPresentation(gesture, live, represented);
+  ASSERT_TRUE(projected.has_value());
+  EXPECT_EQ(projected->currentDocumentDelta, gesture.currentDocumentDelta);
+  EXPECT_EQ(projected->documentFromStartDocument.data[4],
+            gesture.documentFromStartDocument.data[4]);
+  EXPECT_EQ(projected->documentFromStartDocument.data[5],
+            gesture.documentFromStartDocument.data[5]);
 }
 
 // ---------------------------------------------------------------------------
@@ -341,6 +444,24 @@ TEST(RenderCoordinatorTest, SelectedElementIsDisplayNoneFalseForNonGraphicsSelec
   // display:none graphics selection.
   app.setSelection(QuerySelector(app, "#d1"));
   EXPECT_FALSE(coordinator.selectedElementIsDisplayNone(app));
+}
+
+TEST(RenderCoordinatorTest, SelectedCompositedEntityDiagnosticsSkipsDisplayNoneAndNonGraphics) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kMixedSelectionSvg));
+  RenderCoordinator coordinator;
+
+  const svg::SVGElement visible1 = QuerySelector(app, "#visible1");
+  const svg::SVGElement visible2 = QuerySelector(app, "#visible2");
+  const svg::SVGElement hidden = QuerySelector(app, "#hidden");
+  const svg::SVGElement defs = QuerySelector(app, "#defs");
+  const Entity visible1Entity = visible1.unsafeEntityHandle().entity();
+
+  app.setSelection(hidden);
+  EXPECT_EQ(coordinator.selectedCompositedEntityForDiagnostics(app), kNullEntity);
+
+  app.setSelection({visible1, visible2, visible1, hidden, defs});
+  EXPECT_EQ(coordinator.selectedCompositedEntityForDiagnostics(app), visible1Entity);
 }
 
 // ---------------------------------------------------------------------------
@@ -589,6 +710,80 @@ TEST(RenderCoordinatorTest, RasterizeOverlayWithEmptySelectionIsAccepted) {
   // pending against the undisplayed version.
   EXPECT_TRUE(coordinator.rasterizeOverlayForCurrentSelection(app, viewport,
                                                               /*marqueeRectDoc=*/std::nullopt));
+}
+
+TEST(RenderCoordinatorTest, RasterizeOverlayTracksTransientChromeAndDegenerateScale) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kTwoRectSvg));
+  RenderCoordinator coordinator;
+  ViewportState viewport = MakeViewport(app);
+  viewport.devicePixelRatio = 0.0;
+
+  const svg::SVGElement r1 = QuerySelector(app, "#r1");
+  const svg::SVGElement r2 = QuerySelector(app, "#r2");
+  app.setSelection(r1);
+  ASSERT_TRUE(coordinator.setSourceHoverElements({r2}));
+  coordinator.setLockedRejectionFlash(SelectTool::LockedRejectionFlash{
+      .element = r2,
+      .intensity = 0.5f,
+  });
+  coordinator.setPenHoverChrome(
+      PathBuilder().moveTo(Vector2d(10.0, 10.0)).lineTo(Vector2d(20.0, 20.0)).build(),
+      Vector2d(12.0, 12.0));
+
+  const Entity entity = r1.unsafeEntityHandle().entity();
+  const SelectTool::ActiveDragPreview represented =
+      DragPreview(entity, 3, Vector2d(2.0, 3.0), Transform2d::Translate(Vector2d(2.0, 3.0)));
+  const SelectTool::ActiveDragPreview live =
+      DragPreview(entity, 3, Vector2d(5.0, 7.0), Transform2d::Translate(Vector2d(5.0, 7.0)));
+
+  EXPECT_TRUE(coordinator.rasterizeOverlayForCurrentSelection(
+      app, viewport, Box2d::FromXYWH(0.0, 0.0, 15.0, 15.0), represented, std::nullopt,
+      SelectionChromeDetail::CombinedBoundsOnly, live));
+
+  const FrameCostBreakdown::Overlay& overlay = coordinator.lastFrameCostBreakdown().overlay;
+  EXPECT_EQ(overlay.canvasSize, Vector2i(1, 1));
+  EXPECT_EQ(overlay.selectedElementCount, 1);
+  EXPECT_EQ(overlay.sourceHoverElementCount, 1);
+  EXPECT_TRUE(overlay.selectionBoundsOnly);
+  EXPECT_TRUE(overlay.hasLiveDragPreview);
+  EXPECT_TRUE(overlay.hasRepresentedDragPreview);
+  EXPECT_EQ(overlay.liveDragTranslationDoc, Vector2d(5.0, 7.0));
+  EXPECT_EQ(overlay.representedDragTranslationDoc, Vector2d(2.0, 3.0));
+  EXPECT_EQ(overlay.payloadBytes, 4u);
+  EXPECT_TRUE(overlay.hasMarquee);
+  EXPECT_TRUE(coordinator.hasLockedRejectionFlash());
+  ASSERT_TRUE(coordinator.immediateOverlaySnapshot().has_value());
+  EXPECT_TRUE(coordinator.immediateOverlaySnapshot()->penPreviewSegmentDoc.has_value());
+  EXPECT_TRUE(coordinator.immediateOverlaySnapshot()->penCloseAffordanceDoc.has_value());
+
+  coordinator.setLockedRejectionFlash(SelectTool::LockedRejectionFlash{
+      .element = r2,
+      .intensity = 0.0f,
+  });
+  EXPECT_FALSE(coordinator.hasLockedRejectionFlash());
+}
+
+TEST(RenderCoordinatorTest, RasterizeOverlayForPresentationRejectsInvalidInputsBeforeGl) {
+  EditorApp app;
+  RenderCoordinator coordinator;
+  SelectTool selectTool;
+  GlTextureCache textures;
+  ViewportState viewport;
+  viewport.paneSize = Vector2d(100.0, 100.0);
+
+  EXPECT_FALSE(coordinator.rasterizeOverlayForPresentation(app, selectTool, viewport, textures,
+                                                           std::nullopt, std::nullopt));
+
+  ASSERT_TRUE(app.loadFromString(kTwoRectSvg));
+  viewport = MakeViewport(app);
+  viewport.paneSize = Vector2d(0.0, 100.0);
+  EXPECT_FALSE(coordinator.rasterizeOverlayForPresentation(app, selectTool, viewport, textures,
+                                                           std::nullopt, std::nullopt));
+
+  viewport.paneSize = Vector2d(100.0, -1.0);
+  EXPECT_FALSE(coordinator.rasterizeOverlayForPresentation(app, selectTool, viewport, textures,
+                                                           std::nullopt, std::nullopt));
 }
 
 // ---------------------------------------------------------------------------

--- a/donner/editor/tests/RenderPanePresenter_tests.cc
+++ b/donner/editor/tests/RenderPanePresenter_tests.cc
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <fstream>
+#include <limits>
 #include <optional>
 #include <span>
 #include <sstream>
@@ -128,6 +129,32 @@ TEST(RenderPanePresenterTest, SelectionPrewarmLayerMatchesGroupedActiveDragPrevi
          "even though the worker did not mark them as drag targets during the idle prewarm.";
 }
 
+TEST(RenderPanePresenterTest, ActiveDragPreviewMatchingHandlesPrimaryAndMissingPreview) {
+  GlTextureCache::TileView tile;
+  tile.texture = static_cast<ImTextureID>(static_cast<std::uintptr_t>(7));
+  tile.kind = RenderResult::CompositedTile::Kind::Layer;
+  tile.layerEntity = static_cast<Entity>(42);
+  tile.isDragTarget = false;
+
+  EXPECT_FALSE(TileMatchesActiveDragPreview(tile, std::nullopt));
+
+  const SelectTool::ActiveDragPreview activeDrag{
+      .entity = static_cast<Entity>(42),
+      .extraEntities = {},
+      .translation = Vector2d(8.0, 0.0),
+      .documentFromCachedDocument = Transform2d::Translate(Vector2d(8.0, 0.0)),
+      .dragGeneration = 5,
+  };
+  EXPECT_TRUE(TileMatchesActiveDragPreview(tile, activeDrag));
+
+  tile.layerEntity = static_cast<Entity>(7);
+  EXPECT_FALSE(TileMatchesActiveDragPreview(tile, activeDrag));
+
+  tile.layerEntity = entt::null;
+  tile.isDragTarget = true;
+  EXPECT_TRUE(TileMatchesActiveDragPreview(tile, activeDrag));
+}
+
 TEST(RenderPanePresenterTest, OverviewTilesAreOnlyPresentedUnderViewportBoundedActiveTiles) {
   GlTextureCache::TileView overviewTile;
   overviewTile.texture = static_cast<ImTextureID>(static_cast<std::uintptr_t>(7));
@@ -186,6 +213,24 @@ TEST(RenderPanePresenterTest, PresentedTileQuadTouchingPaneEdgeIsCulled) {
       quad, Box2d::FromXYWH(/*x=*/0.0, /*y=*/0.0, /*width=*/20.0, /*height=*/20.0)));
 }
 
+TEST(RenderPanePresenterTest, PresentedTileQuadRejectsNonFiniteAndEmptyScreenRects) {
+  PresentedTileQuad quad;
+  quad.topLeft = Vector2d(10.0, 10.0);
+  quad.topRight = Vector2d(30.0, 10.0);
+  quad.bottomRight = Vector2d(30.0, 30.0);
+  quad.bottomLeft = Vector2d(10.0, 30.0);
+
+  PresentedTileQuad nonFiniteQuad = quad;
+  nonFiniteQuad.bottomRight.x = std::numeric_limits<double>::quiet_NaN();
+  EXPECT_FALSE(PresentedTileQuadIntersectsScreenRect(
+      nonFiniteQuad, Box2d::FromXYWH(/*x=*/0.0, /*y=*/0.0, /*width=*/40.0, /*height=*/40.0)));
+
+  EXPECT_FALSE(PresentedTileQuadIntersectsScreenRect(
+      quad, Box2d(Vector2d(20.0, 0.0), Vector2d(20.0, 40.0))));
+  EXPECT_FALSE(PresentedTileQuadIntersectsScreenRect(
+      quad, Box2d(Vector2d(0.0, 20.0), Vector2d(40.0, 20.0))));
+}
+
 TEST(RenderPanePresenterTest, PresentedImageClipRectIntersectsPaneWithArtboard) {
   const std::optional<Box2d> clip = PresentedImageClipRect(
       Box2d::FromXYWH(/*x=*/0.0, /*y=*/0.0, /*width=*/100.0, /*height=*/80.0),
@@ -199,6 +244,20 @@ TEST(RenderPanePresenterTest, PresentedImageClipRectRejectsDisjointArtboard) {
   EXPECT_FALSE(PresentedImageClipRect(
                    Box2d::FromXYWH(/*x=*/0.0, /*y=*/0.0, /*width=*/100.0, /*height=*/80.0),
                    Box2d::FromXYWH(/*x=*/100.0, /*y=*/10.0, /*width=*/40.0, /*height=*/40.0))
+                   .has_value());
+}
+
+TEST(RenderPanePresenterTest, PresentedImageClipRectRejectsNonFiniteAndEmptyIntersections) {
+  const Box2d paneRect = Box2d::FromXYWH(/*x=*/0.0, /*y=*/0.0, /*width=*/100.0,
+                                         /*height=*/80.0);
+  Box2d nonFiniteImage = Box2d::FromXYWH(/*x=*/20.0, /*y=*/10.0, /*width=*/40.0,
+                                         /*height=*/20.0);
+  nonFiniteImage.bottomRight.y = std::numeric_limits<double>::quiet_NaN();
+  EXPECT_FALSE(PresentedImageClipRect(paneRect, nonFiniteImage).has_value());
+
+  EXPECT_FALSE(PresentedImageClipRect(paneRect, Box2d(Vector2d(20.0, 10.0), Vector2d(80.0, 10.0)))
+                   .has_value());
+  EXPECT_FALSE(PresentedImageClipRect(paneRect, Box2d(Vector2d(20.0, 10.0), Vector2d(20.0, 60.0)))
                    .has_value());
 }
 

--- a/donner/editor/tests/RenderPaneViewport_tests.cc
+++ b/donner/editor/tests/RenderPaneViewport_tests.cc
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <limits>
 
 #include "donner/editor/ViewportState.h"
 
@@ -488,6 +489,78 @@ TEST(ViewportStateTest, DesiredCanvasSizeHandlesZeroViewBox) {
   const Vector2i size = v.desiredCanvasSize();
   EXPECT_GE(size.x, 1);
   EXPECT_GE(size.y, 1);
+}
+
+TEST(ViewportStateTest, RasterViewportClampsTinyNegativeAndInvalidDimensions) {
+  {
+    ViewportState v;
+    v.documentViewBox = Box2d::FromXYWH(0.0, 0.0, 0.2, 0.2);
+    v.zoom = 1.0;
+    v.devicePixelRatio = 1.0;
+
+    const EditorRasterViewport raster = v.rasterViewport();
+
+    EXPECT_EQ(raster.outputSizePx, Vector2i(1, 1));
+    EXPECT_FALSE(raster.viewportBounded);
+  }
+
+  {
+    ViewportState v;
+    v.documentViewBox = Box2d::FromXYWH(0.0, 0.0, 100.0, 50.0);
+    v.zoom = 4.0;
+    v.devicePixelRatio = -1.0;
+
+    const EditorRasterViewport raster = v.rasterViewport();
+
+    EXPECT_EQ(raster.outputSizePx, Vector2i(1, 1));
+    EXPECT_FALSE(raster.viewportBounded);
+  }
+
+  {
+    ViewportState v;
+    v.documentViewBox = Box2d::FromXYWH(0.0, 0.0, std::numeric_limits<double>::quiet_NaN(), 10.0);
+
+    const EditorRasterViewport raster = v.rasterViewport();
+
+    EXPECT_EQ(raster.outputSizePx.x, 1);
+    EXPECT_FALSE(raster.viewportBounded);
+  }
+}
+
+TEST(ViewportStateTest, SelectedPrewarmGuardsDegenerateBoundedViewports) {
+  ViewportState bounded = MakeFreshState(Vector2d::Zero(), Vector2d(800.0, 600.0),
+                                         Box2d::FromXYWH(0.0, 0.0, 1000.0, 1000.0),
+                                         /*dpr=*/2.0);
+  bounded.zoomAround(ViewportState::kMaxZoom, Vector2d(400.0, 300.0));
+  ASSERT_TRUE(bounded.rasterViewport().viewportBounded);
+
+  ViewportState noPane = bounded;
+  noPane.paneSize = Vector2d::Zero();
+  EXPECT_EQ(noPane.selectedPrewarmRasterViewport().outputSizePx,
+            noPane.rasterViewport().outputSizePx);
+
+  ViewportState noDpr = bounded;
+  noDpr.devicePixelRatio = 0.0;
+  EXPECT_EQ(noDpr.selectedPrewarmRasterViewport().outputSizePx,
+            noDpr.rasterViewport().outputSizePx);
+
+  ViewportState noScale = bounded;
+  noScale.zoom = 0.0;
+  EXPECT_EQ(noScale.selectedPrewarmRasterViewport().outputSizePx,
+            noScale.rasterViewport().outputSizePx);
+}
+
+TEST(ViewportStateTest, OverviewInfillGuardsDegenerateDocumentAndDpr) {
+  ViewportState emptyDocument;
+  emptyDocument.documentViewBox = Box2d::FromXYWH(0.0, 0.0, -10.0, 0.0);
+  EXPECT_EQ(emptyDocument.overviewInfillRasterViewport().outputSizePx,
+            emptyDocument.rasterViewport().outputSizePx);
+
+  ViewportState invalidDpr = MakeFreshState(Vector2d::Zero(), Vector2d(800.0, 600.0),
+                                            Box2d::FromXYWH(0.0, 0.0, 100.0, 50.0),
+                                            /*dpr=*/-1.0);
+  EXPECT_EQ(invalidDpr.overviewInfillRasterViewport().outputSizePx,
+            invalidDpr.rasterViewport().outputSizePx);
 }
 
 }  // namespace

--- a/donner/editor/tests/RopeSimulation_tests.cc
+++ b/donner/editor/tests/RopeSimulation_tests.cc
@@ -151,6 +151,37 @@ TEST(RopeSimulationTest, ResetCatenaryHangsBetweenEndpoints) {
   EXPECT_GT(middle.y, 20.0);
 }
 
+TEST(RopeSimulationTest, ResetCatenaryHandlesReversedEndpoints) {
+  RopeSimulationOptions options = TestOptions();
+  options.gravityPxPerSec2 = 0.0;
+  options.catenaryMinSlackPx = 24.0;
+  RopeSimulation rope;
+
+  rope.resetCatenary(Vector2d(120.0, 20.0), Vector2d(0.0, 20.0), options);
+
+  ASSERT_GE(rope.points().size(), 3u);
+  EXPECT_NEAR(rope.points().front().x, 120.0, 1e-9);
+  EXPECT_NEAR(rope.points().back().x, 0.0, 1e-9);
+  const Vector2d middle = rope.points()[rope.points().size() / 2u];
+  EXPECT_NEAR(middle.x, 60.0, 1.0);
+  EXPECT_GT(middle.y, 20.0);
+}
+
+TEST(RopeSimulationTest, ResetCatenaryFallsBackWhenSlackCannotExceedChord) {
+  RopeSimulationOptions options = TestOptions();
+  options.gravityPxPerSec2 = 0.0;
+  options.catenaryMinSlackPx = 0.0;
+  options.catenaryMaxSlackPx = 0.0;
+  RopeSimulation rope;
+
+  rope.resetCatenary(Vector2d(0.0, 0.0), Vector2d(120.0, 0.0), options);
+
+  ASSERT_GE(rope.points().size(), 3u);
+  EXPECT_EQ(rope.points().front(), Vector2d(0.0, 0.0));
+  EXPECT_EQ(rope.points().back(), Vector2d(120.0, 0.0));
+  EXPECT_GT(rope.points()[rope.points().size() / 2u].y, 0.0);
+}
+
 TEST(RopeSimulationTest, ResetCatenaryStartsSettledWithZeroVelocity) {
   RopeSimulationOptions options = TestOptions();
   RopeSimulation rope;
@@ -163,6 +194,38 @@ TEST(RopeSimulationTest, ResetCatenaryStartsSettledWithZeroVelocity) {
 
   EXPECT_EQ(std::vector<Vector2d>(rope.points().begin(), rope.points().end()), before);
   EXPECT_FALSE(rope.needsAnimation());
+}
+
+TEST(RopeSimulationTest, ResetSkipsDegeneratePolylineSegmentsWhenSampling) {
+  RopeSimulationOptions options = TestOptions();
+  options.segmentCount = 4;
+  const std::vector<Vector2d> route = {
+      Vector2d(0.0, 0.0),
+      Vector2d(0.0, 0.0),
+      Vector2d(100.0, 0.0),
+  };
+  RopeSimulation rope;
+
+  rope.reset(route, options);
+
+  ASSERT_EQ(rope.points().size(), 5u);
+  EXPECT_EQ(rope.points().front(), Vector2d(0.0, 0.0));
+  EXPECT_EQ(rope.points().back(), Vector2d(100.0, 0.0));
+  EXPECT_NEAR(rope.points()[2].x, 50.0, 1e-9);
+}
+
+TEST(RopeSimulationTest, TwoParticleUpdateExercisesAverageSpeedBaseCase) {
+  RopeSimulationOptions options = TestOptions();
+  options.segmentCount = 1;
+  options.gravityPxPerSec2 = 0.0;
+  RopeSimulation rope = MakeStraightRope(options);
+
+  rope.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 60.0, 0.0, 1.0 / 60.0, 1u, false,
+              options);
+
+  ASSERT_EQ(rope.points().size(), 2u);
+  EXPECT_EQ(rope.points().front(), Vector2d(0.0, 0.0));
+  EXPECT_EQ(rope.points().back(), Vector2d(100.0, 0.0));
 }
 
 TEST(RopeSimulationTest, ScrollImpulseAffectsInteriorOnly) {
@@ -557,6 +620,20 @@ TEST(RopeSimulationTest, ResetWithCoincidentEndpointsCollapsesToPoint) {
   EXPECT_THAT(rope.points(), testing::Each(Vector2d(7.0, 9.0)));
 }
 
+TEST(RopeSimulationTest, ZeroDeltaCoincidentRouteSolvesZeroLengthConstraints) {
+  const RopeSimulationOptions options = TestOptions();
+  const std::vector<Vector2d> route = {Vector2d(4.0, 5.0), Vector2d(4.0, 5.0)};
+  RopeSimulation rope;
+  rope.reset(route, options);
+
+  rope.update(Vector2d(4.0, 5.0), Vector2d(4.0, 5.0), 0.0, 0.0, 0.0, 1u, false, options);
+
+  ASSERT_GE(rope.points().size(), 2u);
+  for (const Vector2d& point : rope.points()) {
+    EXPECT_EQ(point, Vector2d(4.0, 5.0));
+  }
+}
+
 // --- Self-healing update on an empty/uninitialized rope --------------------
 
 TEST(RopeSimulationTest, UpdateOnEmptyRopeSelfInitializesCatenary) {
@@ -692,6 +769,41 @@ TEST(RopeSimulationTest, CoincidentEndpointCatenaryStaysAtSharedPoint) {
 
   ASSERT_GE(rope.points().size(), 2u);
   EXPECT_THAT(rope.points(), EndpointsAre(Vector2d(10.0, 10.0), Vector2d(10.0, 10.0)));
+}
+
+TEST(RopeSimulationTest, OverdueDampingSupportsImmediateRamp) {
+  RopeSimulationOptions options = TestOptions();
+  options.gravityPxPerSec2 = 0.0;
+  options.settleTimeSeconds = 0.0;
+  options.overdueDampingRampSeconds = 0.0;
+  options.overdueDamping = 0.25;
+  options.settleStillnessSeconds = 10.0;
+  RopeSimulation rope = MakeStraightRope(options);
+
+  rope.applyImpulse(Vector2d(3.0, 0.0));
+  rope.update(Vector2d(0.0, 0.0), Vector2d(100.0, 0.0), 1.0 / 60.0, 0.0, 1.0 / 60.0, 1u, false,
+              options);
+
+  EXPECT_TRUE(rope.needsAnimation());
+  EXPECT_EQ(rope.points().front(), Vector2d(0.0, 0.0));
+  EXPECT_EQ(rope.points().back(), Vector2d(100.0, 0.0));
+}
+
+TEST(RopeSimulationTest, EndpointMotionCanClampImpulseToZero) {
+  RopeSimulationOptions options = TestOptions();
+  options.gravityPxPerSec2 = 0.0;
+  options.constraintIterations = 0;
+  options.endpointCatenaryBlend = 0.0;
+  options.endpointImpulse = 1.0;
+  options.maxEndpointImpulsePx = -1.0;
+  RopeSimulation rope = MakeStraightRope(options);
+
+  rope.update(Vector2d(0.0, 5.0), Vector2d(100.0, 5.0), 1.0 / 60.0, 0.0, 1.0 / 60.0, 1u, false,
+              options);
+
+  ASSERT_GE(rope.points().size(), 3u);
+  EXPECT_EQ(rope.points().front(), Vector2d(0.0, 5.0));
+  EXPECT_EQ(rope.points().back(), Vector2d(100.0, 5.0));
 }
 
 TEST(RopeSimulationTest, FrozenUpdateRigidlyCarriesBodyWithMovedEndpoints) {

--- a/donner/editor/tests/SelectionAabb_tests.cc
+++ b/donner/editor/tests/SelectionAabb_tests.cc
@@ -66,6 +66,15 @@ TEST(SelectionAabbTest, SnapshotBoundsAllowConcurrentDom) {
   EXPECT_THAT(bounds, testing::ElementsAre(BoxFromXYWHIs(20.0, 20.0, 40.0, 40.0)));
 }
 
+TEST(SelectionAabbTest, SnapshotWorldBoundsRejectsSourcelessElements) {
+  svg::SVGDocument document;
+  const svg::SVGElement root = document.svgElement();
+  const std::vector<svg::SVGElement> selection = {root};
+
+  EXPECT_TRUE(CollectRenderableGeometry(root).empty());
+  EXPECT_TRUE(SnapshotSelectionWorldBounds(std::span<const svg::SVGElement>(selection)).empty());
+}
+
 TEST(SelectionAabbTest, SnapshotSelectionWorldBoundsMovesWithDrag) {
   EditorApp app;
   ASSERT_TRUE(app.loadFromString(kTwoRectSvg));
@@ -140,6 +149,64 @@ TEST(SelectionAabbTest, SnapshotSkipsNonRenderedContainerDescendants) {
   EXPECT_THAT(bounds, testing::ElementsAre(BoxFromXYWHIs(80.0, 80.0, 40.0, 40.0)));
 }
 
+TEST(SelectionAabbTest, SnapshotSkipsGeometryWithoutWorldBounds) {
+  constexpr std::string_view kSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+              <g id="grp">
+                <path id="empty" d=""/>
+                <rect id="visible" x="80" y="80" width="40" height="40" fill="green"/>
+              </g>
+            </svg>)svg";
+
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kSvg));
+  auto group = app.document().document().querySelector("#grp");
+  ASSERT_TRUE(group.has_value());
+
+  const std::vector<svg::SVGElement> selection = {*group};
+  const std::vector<Box2d> bounds =
+      SnapshotSelectionWorldBounds(std::span<const svg::SVGElement>(selection));
+
+  ASSERT_EQ(bounds.size(), 1u);
+  EXPECT_EQ(bounds[0], Box2d::FromXYWH(80.0, 80.0, 40.0, 40.0));
+}
+
+TEST(SelectionAabbTest, CollectRenderableGeometrySkipsAllNonRenderedContainerTypes) {
+  constexpr std::string_view kSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+              <defs id="defs">
+                <rect id="defs_rect" x="1" y="1" width="2" height="2"/>
+              </defs>
+              <clipPath id="clip"><rect id="clip_rect" x="2" y="2" width="2" height="2"/></clipPath>
+              <mask id="mask"><rect id="mask_rect" x="3" y="3" width="2" height="2"/></mask>
+              <filter id="filter"><feGaussianBlur stdDeviation="1"/></filter>
+              <pattern id="pattern"><rect id="pattern_rect" x="4" y="4" width="2" height="2"/></pattern>
+              <linearGradient id="linear"><stop offset="0"/></linearGradient>
+              <radialGradient id="radial"><stop offset="1"/></radialGradient>
+              <symbol id="symbol"><rect id="symbol_rect" x="5" y="5" width="2" height="2"/></symbol>
+              <marker id="marker"><path id="marker_path" d="M0 0 L1 1"/></marker>
+              <style id="style">rect { fill: red; }</style>
+              <rect id="visible" x="80" y="80" width="40" height="40" fill="green"/>
+            </svg>)svg";
+
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kSvg));
+
+  constexpr std::string_view kContainerIds[] = {
+      "defs", "clip", "mask", "filter", "pattern", "linear", "radial", "symbol", "marker", "style",
+  };
+  for (std::string_view id : kContainerIds) {
+    auto container = app.document().document().querySelector(std::string("#") + std::string(id));
+    ASSERT_TRUE(container.has_value()) << id;
+    EXPECT_TRUE(CollectRenderableGeometry(*container).empty()) << id;
+  }
+
+  const std::vector<svg::SVGGeometryElement> geometry =
+      CollectRenderableGeometry(app.document().document().svgElement());
+  ASSERT_EQ(geometry.size(), 1u);
+  EXPECT_EQ(geometry.front().id(), "visible");
+}
+
 TEST(SelectionAabbTest, SnapshotUsesTightTransformedPathBounds) {
   constexpr std::string_view kTriangleSvg =
       R"svg(<svg xmlns="http://www.w3.org/2000/svg" viewBox="-20 0 120 120">
@@ -196,6 +263,58 @@ TEST(SelectionAabbTest, SnapshotOccludingWorldBoundsIncludesOnlyLaterPaintedGeom
 
   EXPECT_THAT(bounds, testing::ElementsAre(BoxFromXYWHIs(70.0, 80.0, 10.0, 20.0),
                                            BoxFromXYWHIs(100.0, 110.0, 30.0, 40.0)));
+}
+
+TEST(SelectionAabbTest, SnapshotOccludingWorldBoundsRejectsEmptyAndMultiSelection) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kTwoRectSvg));
+  auto r1 = app.document().document().querySelector("#r1");
+  auto r2 = app.document().document().querySelector("#r2");
+  ASSERT_TRUE(r1.has_value());
+  ASSERT_TRUE(r2.has_value());
+
+  EXPECT_TRUE(SnapshotSelectionOccludingWorldBounds({}).empty());
+
+  const std::vector<svg::SVGElement> multiSelection = {*r1, *r2};
+  EXPECT_TRUE(
+      SnapshotSelectionOccludingWorldBounds(std::span<const svg::SVGElement>(multiSelection))
+          .empty());
+}
+
+TEST(SelectionAabbTest, SnapshotOccludingWorldBoundsRejectsSourcelessElements) {
+  svg::SVGDocument document;
+  const svg::SVGElement root = document.svgElement();
+  const std::vector<svg::SVGElement> selection = {root};
+
+  EXPECT_TRUE(
+      SnapshotSelectionOccludingWorldBounds(std::span<const svg::SVGElement>(selection)).empty());
+}
+
+TEST(SelectionAabbTest, RefreshSelectionBoundsCachePromotesOnlyDisplayedVersionAndClearsEmpty) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kTwoRectSvg));
+  auto rect = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(rect.has_value());
+
+  SelectionBoundsCache cache;
+  const std::vector<svg::SVGElement> selection = {*rect};
+  RefreshSelectionBoundsCache(cache, std::span<const svg::SVGElement>(selection),
+                              /*currentDocVersion=*/7, /*displayedDocVersion=*/6);
+
+  ASSERT_EQ(cache.pendingBoundsDoc.size(), 1u);
+  EXPECT_TRUE(cache.displayedBoundsDoc.empty());
+  PromoteSelectionBoundsIfReady(cache, /*displayedDocVersion=*/6);
+  EXPECT_TRUE(cache.displayedBoundsDoc.empty());
+
+  PromoteSelectionBoundsIfReady(cache, /*displayedDocVersion=*/7);
+  ASSERT_EQ(cache.displayedBoundsDoc.size(), 1u);
+  EXPECT_TRUE(cache.pendingBoundsDoc.empty());
+  EXPECT_EQ(cache.pendingVersion, 0u);
+
+  RefreshSelectionBoundsCache(cache, {}, /*currentDocVersion=*/8, /*displayedDocVersion=*/8);
+  EXPECT_TRUE(cache.lastSelection.empty());
+  EXPECT_TRUE(cache.displayedBoundsDoc.empty());
+  EXPECT_TRUE(cache.displayedOccludingBoundsDoc.empty());
 }
 
 TEST(SelectionAabbTest, SnapshotOccludingBoundsAllowConcurrentDom) {

--- a/donner/editor/tests/SelectionTransformHandles_tests.cc
+++ b/donner/editor/tests/SelectionTransformHandles_tests.cc
@@ -1,6 +1,7 @@
 #include "donner/editor/SelectionTransformHandles.h"
 
 #include <array>
+#include <limits>
 
 #include "gtest/gtest.h"
 
@@ -72,6 +73,70 @@ TEST(SelectionTransformHandlesTest, CombinesMultiSelectionBounds) {
   const Box2d combined = CombinedSelectionBounds(bounds);
 
   EXPECT_EQ(combined, Box2d::FromXYWH(20.0, 30.0, 110.0, 120.0));
+}
+
+TEST(SelectionTransformHandlesTest, EmptyAndDegenerateInputsReturnNoIntent) {
+  const std::array<Box2d, 0> emptyBounds{};
+  EXPECT_EQ(HitTestSelectionTransformHandles(emptyBounds, Vector2d(0.0, 0.0),
+                                             /*pixelsPerDocUnit=*/1.0)
+                .kind,
+            SelectionTransformHandleKind::None);
+
+  const std::array<Box2d, 1> bounds{Box2d::FromXYWH(20.0, 30.0, 80.0, 40.0)};
+  EXPECT_EQ(HitTestSelectionTransformHandles(
+                bounds, Vector2d(std::numeric_limits<double>::infinity(), 30.0),
+                /*pixelsPerDocUnit=*/1.0)
+                .kind,
+            SelectionTransformHandleKind::None);
+  EXPECT_EQ(HitTestSelectionTransformHandles(bounds, Vector2d(20.0, 30.0),
+                                             /*pixelsPerDocUnit=*/0.0)
+                .kind,
+            SelectionTransformHandleKind::None);
+  EXPECT_EQ(HitTestSelectionTransformHandles(bounds, Vector2d(20.0, 30.0),
+                                             /*pixelsPerDocUnit=*/
+                                             std::numeric_limits<double>::quiet_NaN())
+                .kind,
+            SelectionTransformHandleKind::None);
+  const std::array<Box2d, 1> emptyBoxBounds{Box2d()};
+  EXPECT_EQ(HitTestSelectionTransformHandles(emptyBoxBounds, Vector2d(0.0, 0.0),
+                                             /*pixelsPerDocUnit=*/1.0)
+                .kind,
+            SelectionTransformHandleKind::None);
+}
+
+TEST(SelectionTransformHandlesTest, CornerHelpersCoverAllCorners) {
+  const Box2d bounds = Box2d::FromXYWH(10.0, 20.0, 30.0, 40.0);
+
+  EXPECT_EQ(SelectionTransformCornerPoint(bounds, SelectionTransformCorner::TopLeft),
+            Vector2d(10.0, 20.0));
+  EXPECT_EQ(SelectionTransformCornerPoint(bounds, SelectionTransformCorner::TopRight),
+            Vector2d(40.0, 20.0));
+  EXPECT_EQ(SelectionTransformCornerPoint(bounds, SelectionTransformCorner::BottomRight),
+            Vector2d(40.0, 60.0));
+  EXPECT_EQ(SelectionTransformCornerPoint(bounds, SelectionTransformCorner::BottomLeft),
+            Vector2d(10.0, 60.0));
+
+  EXPECT_EQ(OppositeSelectionTransformCorner(SelectionTransformCorner::TopLeft),
+            SelectionTransformCorner::BottomRight);
+  EXPECT_EQ(OppositeSelectionTransformCorner(SelectionTransformCorner::TopRight),
+            SelectionTransformCorner::BottomLeft);
+  EXPECT_EQ(OppositeSelectionTransformCorner(SelectionTransformCorner::BottomRight),
+            SelectionTransformCorner::TopLeft);
+  EXPECT_EQ(OppositeSelectionTransformCorner(SelectionTransformCorner::BottomLeft),
+            SelectionTransformCorner::TopRight);
+}
+
+TEST(SelectionTransformHandlesTest, RotateRingRejectsInsideBoundsAndOutsideOuterRadius) {
+  const std::array<Box2d, 1> bounds{Box2d::FromXYWH(20.0, 30.0, 80.0, 40.0)};
+
+  EXPECT_EQ(HitTestSelectionTransformHandles(bounds, Vector2d(50.0, 50.0),
+                                             /*pixelsPerDocUnit=*/1.0)
+                .kind,
+            SelectionTransformHandleKind::None);
+  EXPECT_EQ(HitTestSelectionTransformHandles(bounds, Vector2d(20.0, 4.0),
+                                             /*pixelsPerDocUnit=*/1.0)
+                .kind,
+            SelectionTransformHandleKind::None);
 }
 
 }  // namespace

--- a/donner/editor/tests/ShapeClipboard_tests.cc
+++ b/donner/editor/tests/ShapeClipboard_tests.cc
@@ -209,6 +209,22 @@ TEST(ShapeClipboardCommands, CopyProgrammaticElementWithoutSourceMappingReturnsN
   EXPECT_FALSE(copySelectionToPayload(document, {rect}).has_value());
 }
 
+TEST(ShapeClipboardCommands, CopySkipsProgrammaticSiblingsButKeepsSourceBackedSelection) {
+  svg::SVGDocument document = Parse(kTwoRects);
+  std::vector<svg::SVGElement> selection = Select(document, {"a"});
+  svg::SVGRectElement programmatic = svg::SVGRectElement::Create(document);
+  selection.push_back(programmatic);
+
+  std::optional<ShapeClipboardPayload> payload = copySelectionToPayload(document, selection);
+
+  ASSERT_TRUE(payload.has_value());
+  EXPECT_THAT(payload->svgFragment, HasSubstr("id=\"a\""));
+  EXPECT_THAT(payload->svgFragment, Not(HasSubstr("<rect/>")));
+  EXPECT_THAT(payload->sourceElementIds, ::testing::ElementsAre("a"));
+  EXPECT_FALSE(payload->wasGroupSelection);
+  ASSERT_TRUE(payload->documentBounds.has_value());
+}
+
 TEST(ShapeClipboardCommands, CopyGroupSelectionMarksPayloadAsGroupSelection) {
   constexpr std::string_view kGrouped =
       R"(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
@@ -297,6 +313,23 @@ TEST(ShapeClipboardCommands, PasteUniqueIdsKeepsFragmentIdsAndIgnoresIdSubstring
   EXPECT_THAT(result.mergedSource, Not(HasSubstr("fresh_pasted")));
 }
 
+TEST(ShapeClipboardCommands, PasteIdRepairIgnoresNonReferenceAndEmptyReferenceTokens) {
+  svg::SVGDocument document = Parse(kTwoRects);
+  ShapeClipboardPayload payload;
+  payload.svgFragment =
+      R"SVG(<rect data-id="ignored" id="a" fill="url(#)" href="not-a-fragment" x="1" y="2" width="3" height="4"/>)SVG";
+  payload.sourceElementIds = {"a"};
+
+  PreparePasteResult result = preparePaste(document, payload, PastePlacement::EndOfRootOffset);
+  ASSERT_TRUE(result.ok) << result.error;
+
+  EXPECT_THAT(result.pastedElementIds, ::testing::ElementsAre("a_pasted"));
+  EXPECT_THAT(result.mergedSource, HasSubstr("data-id=\"ignored\""));
+  EXPECT_THAT(result.mergedSource, HasSubstr("id=\"a_pasted\""));
+  EXPECT_THAT(result.mergedSource, HasSubstr("fill=\"url(#)\""));
+  EXPECT_THAT(result.mergedSource, HasSubstr("href=\"not-a-fragment\""));
+}
+
 TEST(ShapeClipboardCommands, PasteRepairsUrlAndHrefReferencesToRenamedIds) {
   constexpr std::string_view kDestination =
       R"(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
@@ -318,6 +351,30 @@ TEST(ShapeClipboardCommands, PasteRepairsUrlAndHrefReferencesToRenamedIds) {
   EXPECT_THAT(result.mergedSource, HasSubstr("id='grad_pasted'"));
   EXPECT_THAT(result.mergedSource, HasSubstr("fill=\"url(#grad_pasted)\""));
   EXPECT_THAT(result.mergedSource, HasSubstr("xlink:href='#shape_pasted'"));
+}
+
+TEST(ShapeClipboardCommands, PasteRepairsReferencesWithIdTokenCharacters) {
+  constexpr std::string_view kDestination =
+      R"(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+<defs><linearGradient id="a:b.c_d-1"/></defs>
+<rect id="shape" x="0" y="0" width="10" height="10"/>
+</svg>)";
+  svg::SVGDocument document = Parse(kDestination);
+  ShapeClipboardPayload payload;
+  payload.svgFragment =
+      R"SVG(<defs><linearGradient id="a:b.c_d-1"/></defs>
+<style>.shape { fill: url(#a:b.c_d-1); }</style>
+<rect id="shape" x="1" y="1" width="10" height="10" fill="url(#a:b.c_d-1)" href="#shape"/>)SVG";
+  payload.sourceElementIds = {"shape", ""};
+
+  PreparePasteResult result = preparePaste(document, payload, PastePlacement::EndOfRootOffset);
+  ASSERT_TRUE(result.ok) << result.error;
+
+  EXPECT_THAT(result.pastedElementIds, ::testing::ElementsAre("shape_pasted"));
+  EXPECT_THAT(result.mergedSource, HasSubstr("id=\"a:b.c_d-1_pasted\""));
+  EXPECT_THAT(result.mergedSource, HasSubstr("fill=\"url(#a:b.c_d-1_pasted)\""));
+  EXPECT_THAT(result.mergedSource, HasSubstr("fill: url(#a:b.c_d-1_pasted)"));
+  EXPECT_THAT(result.mergedSource, HasSubstr("href=\"#shape_pasted\""));
 }
 
 TEST(ShapeClipboardCommands, PasteIdRepairSkipsAlreadyTakenGeneratedIds) {
@@ -409,6 +466,39 @@ TEST(ShapeClipboardCommands, PasteIntoNestedSelectedGroupUsesMatchingCloseTag) {
   EXPECT_LT(wrapperPos, outerClose);
 }
 
+TEST(ShapeClipboardCommands, PasteIntoSelectedGroupHandlesTabAndNewlineAfterTagName) {
+  constexpr std::string_view kTabGrouped =
+      "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\">\n"
+      "<g\tid=\"grp\"><rect id=\"inside\" x=\"0\" y=\"0\" width=\"4\" height=\"4\"/></g>\n"
+      "<rect id=\"loose\" x=\"50\" y=\"50\" width=\"4\" height=\"4\"/>\n"
+      "</svg>";
+  constexpr std::string_view kNewlineGrouped =
+      "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\">\n"
+      "<g\nid=\"grp\"><rect id=\"inside\" x=\"0\" y=\"0\" width=\"4\" height=\"4\"/></g>\n"
+      "<rect id=\"loose\" x=\"50\" y=\"50\" width=\"4\" height=\"4\"/>\n"
+      "</svg>";
+
+  for (std::string_view source : {kTabGrouped, kNewlineGrouped}) {
+    SCOPED_TRACE(source);
+    svg::SVGDocument document = Parse(source);
+    std::optional<ShapeClipboardPayload> payload =
+        copySelectionToPayload(document, Select(document, {"loose"}));
+    ASSERT_TRUE(payload.has_value());
+
+    std::optional<svg::SVGElement> group = document.querySelector("#grp");
+    ASSERT_TRUE(group.has_value());
+    PreparePasteResult result =
+        preparePaste(document, *payload, PastePlacement::EndOfRootOffset, group);
+    ASSERT_TRUE(result.ok) << result.error;
+
+    const std::size_t wrapperPos = result.mergedSource.find("loose_pasted");
+    const std::size_t groupClose = result.mergedSource.find("</g>");
+    ASSERT_NE(wrapperPos, std::string::npos);
+    ASSERT_NE(groupClose, std::string::npos);
+    EXPECT_LT(wrapperPos, groupClose);
+  }
+}
+
 TEST(ShapeClipboardCommands, PasteWithNonGroupSelectedElementFallsBackToRoot) {
   svg::SVGDocument document = Parse(kTwoRects);
   std::optional<ShapeClipboardPayload> payload =
@@ -429,6 +519,28 @@ TEST(ShapeClipboardCommands, PasteWithNonGroupSelectedElementFallsBackToRoot) {
   ASSERT_NE(wrapperPos, std::string::npos);
   ASSERT_NE(rootClose, std::string::npos);
   EXPECT_GT(wrapperPos, rectClose);
+  EXPECT_LT(wrapperPos, rootClose);
+}
+
+TEST(ShapeClipboardCommands, PasteWithSelectedGroupFromAnotherDocumentFallsBackToRoot) {
+  svg::SVGDocument document = Parse(kTwoRects);
+  std::optional<ShapeClipboardPayload> payload =
+      copySelectionToPayload(document, Select(document, {"b"}));
+  ASSERT_TRUE(payload.has_value());
+
+  svg::SVGDocument otherDocument =
+      Parse(R"(<svg xmlns="http://www.w3.org/2000/svg"><g id="elsewhere"/></svg>)");
+  std::optional<svg::SVGElement> otherGroup = otherDocument.querySelector("#elsewhere");
+  ASSERT_TRUE(otherGroup.has_value());
+
+  PreparePasteResult result =
+      preparePaste(document, *payload, PastePlacement::EndOfRootOffset, otherGroup);
+  ASSERT_TRUE(result.ok) << result.error;
+
+  const std::size_t wrapperPos = result.mergedSource.find("b_pasted");
+  const std::size_t rootClose = result.mergedSource.rfind("</svg>");
+  ASSERT_NE(wrapperPos, std::string::npos);
+  ASSERT_NE(rootClose, std::string::npos);
   EXPECT_LT(wrapperPos, rootClose);
 }
 

--- a/donner/editor/tests/SoftWrap_tests.cc
+++ b/donner/editor/tests/SoftWrap_tests.cc
@@ -42,5 +42,27 @@ TEST(SoftWrapTest, EmptyLineStillProducesOneVisualRow) {
   EXPECT_EQ(ComputeSoftWrapSegments("", 20), (std::vector<SoftWrapSegment>{SoftWrapSegment{}}));
 }
 
+TEST(SoftWrapTest, XmlContinuationIndentFallsBackForSpecialTagsAndBareOpen) {
+  EXPECT_EQ(ComputeXmlContinuationIndent("\t</g>"), 2);
+  EXPECT_EQ(ComputeXmlContinuationIndent("  <!-- comment -->"), 2);
+  EXPECT_EQ(ComputeXmlContinuationIndent("  <?xml version=\"1.0\"?>"), 2);
+  EXPECT_EQ(ComputeXmlContinuationIndent("<"), 0);
+}
+
+TEST(SoftWrapTest, SegmentsBreakOnTabsAndForceLongUnbrokenRuns) {
+  const std::vector<SoftWrapSegment> tabBreak =
+      ComputeSoftWrapSegments("alpha\tbeta gamma delta", 16);
+  ASSERT_GE(tabBreak.size(), 2u);
+  EXPECT_EQ(tabBreak[0].endColumn, 10);
+  EXPECT_EQ(tabBreak[1].startColumn, 11);
+
+  const std::vector<SoftWrapSegment> unbroken =
+      ComputeSoftWrapSegments("abcdefghijklmnopqrstuvwxyz", 12);
+  ASSERT_GE(unbroken.size(), 2u);
+  EXPECT_EQ(unbroken[0].startColumn, 0);
+  EXPECT_EQ(unbroken[0].endColumn, 12);
+  EXPECT_TRUE(unbroken[1].continuation);
+}
+
 }  // namespace
 }  // namespace donner::editor

--- a/donner/editor/tests/SourceSelection_tests.cc
+++ b/donner/editor/tests/SourceSelection_tests.cc
@@ -149,12 +149,35 @@ TEST(SourceSelectionTest, ReturnsEntitySourceByteRangeForReferencedPaintServer) 
   EXPECT_EQ(textEditor.getSelectedText(), selected);
 }
 
+TEST(SourceSelectionTest, SourceByteRangesReturnEmptyForSourcelessElements) {
+  svg::SVGDocument document;
+  const svg::SVGElement root = document.svgElement();
+
+  EXPECT_EQ(ElementSourceByteRange(root, ""), std::nullopt);
+  EXPECT_EQ(EntitySourceByteRange(root.entityHandle(), ""), std::nullopt);
+}
+
 TEST(SourceSelectionTest, RejectsInvalidRawSourceByteRange) {
   TextEditor textEditor;
   textEditor.setText("abc");
 
+  EXPECT_FALSE(HighlightSourceByteRange(textEditor, SourceByteRange{.start = 3, .end = 2}));
   EXPECT_FALSE(HighlightSourceByteRange(textEditor, SourceByteRange{.start = 1, .end = 1}));
   EXPECT_FALSE(HighlightSourceByteRange(textEditor, SourceByteRange{.start = 1, .end = 4}));
+}
+
+TEST(SourceSelectionTest, HighlightElementSourceRejectsStaleEditorText) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kSvg));
+
+  auto target = app.document().document().querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+
+  TextEditor textEditor;
+  textEditor.setText("<svg/>");
+
+  EXPECT_FALSE(HighlightElementSource(textEditor, *target));
+  EXPECT_TRUE(textEditor.getSelectedText().empty());
 }
 
 TEST(SourceSelectionTest, ExcludesSelectedElementsFromSourceHoverCandidates) {
@@ -171,6 +194,22 @@ TEST(SourceSelectionTest, ExcludesSelectedElementsFromSourceHoverCandidates) {
 
   ASSERT_EQ(filtered.size(), 1u);
   EXPECT_EQ(filtered.front().id(), "layer");
+}
+
+TEST(SourceSelectionTest, ExcludeSelectedSourceHoverElementsNoOpsForEmptyInputs) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kSvg));
+
+  auto rect = app.document().document().querySelector("#target");
+  ASSERT_TRUE(rect.has_value());
+
+  EXPECT_TRUE(
+      ExcludeSelectedSourceHoverElements({}, std::span<const svg::SVGElement>(&*rect, 1)).empty());
+
+  std::vector<svg::SVGElement> unchanged =
+      ExcludeSelectedSourceHoverElements({*rect}, std::span<const svg::SVGElement>());
+  ASSERT_EQ(unchanged.size(), 1u);
+  EXPECT_EQ(unchanged.front().id(), "target");
 }
 
 TEST(SourceSelectionTest, ExcludesDocumentRootFromSourceHoverCandidates) {
@@ -190,6 +229,13 @@ TEST(SourceSelectionTest, ExcludesDocumentRootFromSourceHoverCandidates) {
   EXPECT_TRUE(filtered.empty());
 }
 
+TEST(SourceSelectionTest, ExcludeDocumentRootSourceHoverElementNoOpsForEmptyInput) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kSvg));
+
+  EXPECT_TRUE(ExcludeDocumentRootSourceHoverElement({}, app.document().document()).empty());
+}
+
 TEST(SourceSelectionTest, RootSvgStillResolvesAtSourceOffsetForExplicitSelection) {
   EditorApp app;
   ASSERT_TRUE(app.loadFromString(kSvg));
@@ -201,6 +247,83 @@ TEST(SourceSelectionTest, RootSvgStillResolvesAtSourceOffsetForExplicitSelection
       FindElementNearSourceOffset(app.document().document(), source, rootOffset + 1);
   ASSERT_TRUE(root.has_value());
   EXPECT_EQ(*root, app.document().document().svgElement());
+}
+
+TEST(SourceSelectionTest, SourceOffsetFindersRejectDocumentEndAndEmptySource) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kSvg));
+  const std::string source(app.document().document().source());
+
+  EXPECT_EQ(FindElementAtSourceOffset(app.document().document(), source, source.size()),
+            std::nullopt);
+  EXPECT_EQ(FindElementNearSourceOffset(app.document().document(), source, source.size() + 5),
+            std::nullopt);
+  EXPECT_EQ(FindElementNearSourceOffset(app.document().document(), "", 0), std::nullopt);
+}
+
+TEST(SourceSelectionTest, FindElementNearSourceOffsetAtStartReturnsContainingRoot) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kSvg));
+  const std::string source(app.document().document().source());
+
+  std::optional<svg::SVGElement> root =
+      FindElementNearSourceOffset(app.document().document(), source, 0);
+  ASSERT_TRUE(root.has_value());
+  EXPECT_EQ(*root, app.document().document().svgElement());
+}
+
+TEST(SourceSelectionTest, FindElementNearSourceOffsetAtLeadingWhitespaceReturnsEmpty) {
+  constexpr std::string_view source =
+      R"(
+<svg xmlns="http://www.w3.org/2000/svg"><rect id="target"/></svg>)";
+
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(source));
+  const std::string currentSource(app.document().document().source());
+
+  EXPECT_EQ(FindElementNearSourceOffset(app.document().document(), currentSource, 0), std::nullopt);
+
+  const std::size_t rootOffset = currentSource.find("<svg");
+  ASSERT_NE(rootOffset, std::string::npos);
+  std::optional<svg::SVGElement> root =
+      FindElementNearSourceOffset(app.document().document(), currentSource, rootOffset + 1);
+  ASSERT_TRUE(root.has_value());
+  EXPECT_EQ(*root, app.document().document().svgElement());
+}
+
+TEST(SourceSelectionTest, FindsPreviousElementWhenCursorLeavesChildForAncestor) {
+  constexpr std::string_view source =
+      R"(<svg xmlns="http://www.w3.org/2000/svg"><g id="layer"><rect id="target"/></g><circle id="next"/></svg>)";
+
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(source));
+  const std::string currentSource(app.document().document().source());
+
+  const std::size_t afterRect = currentSource.find("</g>");
+  ASSERT_NE(afterRect, std::string::npos);
+
+  std::optional<svg::SVGElement> rect =
+      FindElementNearSourceOffset(app.document().document(), currentSource, afterRect);
+  ASSERT_TRUE(rect.has_value());
+  EXPECT_EQ(rect->id(), "target");
+}
+
+TEST(SourceSelectionTest, FindsCurrentElementWhenPreviousSiblingIsNotAncestor) {
+  constexpr std::string_view source =
+      R"(<svg xmlns="http://www.w3.org/2000/svg"><rect id="first"/>
+<circle id="second"/></svg>)";
+
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(source));
+  const std::string currentSource(app.document().document().source());
+
+  const std::size_t circleOffset = currentSource.find("<circle");
+  ASSERT_NE(circleOffset, std::string::npos);
+
+  std::optional<svg::SVGElement> circle =
+      FindElementNearSourceOffset(app.document().document(), currentSource, circleOffset);
+  ASSERT_TRUE(circle.has_value());
+  EXPECT_EQ(circle->id(), "second");
 }
 
 TEST(SourceSelectionTest, FindsElementAtTextEditorCursor) {

--- a/donner/editor/tests/StyleSourceAnnotations_tests.cc
+++ b/donner/editor/tests/StyleSourceAnnotations_tests.cc
@@ -264,6 +264,43 @@ TEST(StyleSourceAnnotations, ReferenceResourceClassificationSkipsNonResourceDefi
   EXPECT_EQ(symbol->matchedElementCount, 2);
 }
 
+TEST(StyleSourceAnnotations, ReferenceResourceKindsAreAnnotated) {
+  constexpr std::string_view kSource = R"svg(<svg xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <clipPath id="clip"><rect/></clipPath>
+    <filter id="blur"><feGaussianBlur/></filter>
+    <marker id="arrow"><path d="M0 0L5 5"/></marker>
+    <mask id="mask"><rect/></mask>
+    <pattern id="pattern"><rect/></pattern>
+    <radialGradient id="radial"><stop offset="1"/></radialGradient>
+    <path id="shape"/>
+  </defs>
+  <g clip-path="url(#clip)" filter="url(#blur)" marker-end="url(#arrow)"
+     mask="url(#mask)" fill="url(#pattern)" stroke="url(#radial)">
+    <use href="#shape"/>
+  </g>
+</svg>)svg";
+  svg::SVGDocument document = ParseSvg(kSource);
+
+  const StyleSourceAnnotations annotations = ComputeStyleSourceAnnotations(document, kSource);
+
+  for (const auto [tagName, idNeedle] : {
+           std::pair<std::string_view, std::string_view>{"clipPath", R"(id="clip")"},
+           std::pair<std::string_view, std::string_view>{"filter", R"(id="blur")"},
+           std::pair<std::string_view, std::string_view>{"marker", R"(id="arrow")"},
+           std::pair<std::string_view, std::string_view>{"mask", R"(id="mask")"},
+           std::pair<std::string_view, std::string_view>{"pattern", R"(id="pattern")"},
+           std::pair<std::string_view, std::string_view>{"radialGradient", R"(id="radial")"},
+           std::pair<std::string_view, std::string_view>{"path", R"(id="shape")"},
+       }) {
+    const StyleSourceContribution* contribution = FindContribution(
+        annotations, StyleContributionKind::ReferenceResourceElement, tagName, idNeedle, kSource);
+    ASSERT_NE(contribution, nullptr) << tagName;
+    EXPECT_TRUE(contribution->effective) << tagName;
+    EXPECT_EQ(contribution->matchedElementCount, 1) << tagName;
+  }
+}
+
 TEST(StyleSourceAnnotations, EmptyFragmentReferencesDoNotIncrementResourceCounts) {
   constexpr std::string_view kSource = R"svg(<svg xmlns="http://www.w3.org/2000/svg">
   <defs><path id="shape"/></defs>
@@ -280,6 +317,37 @@ TEST(StyleSourceAnnotations, EmptyFragmentReferencesDoNotIncrementResourceCounts
   ASSERT_NE(shape, nullptr);
   EXPECT_FALSE(shape->effective);
   EXPECT_EQ(shape->matchedElementCount, 0);
+}
+
+TEST(StyleSourceAnnotations, CssUrlReferencesHandleSingleQuotesAndUnquotedWhitespace) {
+  constexpr std::string_view kSource = R"svg(<svg xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .quoted { fill: url( '#paint' ); stroke: url(#stroke ); }
+    .external { filter: url(http://example.invalid/filter); }
+  </style>
+  <defs>
+    <linearGradient id="paint"><stop offset="1"/></linearGradient>
+    <linearGradient id="stroke"><stop offset="1"/></linearGradient>
+  </defs>
+  <rect class="quoted external"/>
+</svg>)svg";
+  svg::SVGDocument document = ParseSvg(kSource);
+
+  const StyleSourceAnnotations annotations = ComputeStyleSourceAnnotations(document, kSource);
+
+  const StyleSourceContribution* paint =
+      FindContribution(annotations, StyleContributionKind::ReferenceResourceElement,
+                       "linearGradient", R"(id="paint")", kSource);
+  ASSERT_NE(paint, nullptr);
+  EXPECT_TRUE(paint->effective);
+  EXPECT_EQ(paint->matchedElementCount, 1);
+
+  const StyleSourceContribution* stroke =
+      FindContribution(annotations, StyleContributionKind::ReferenceResourceElement,
+                       "linearGradient", R"(id="stroke")", kSource);
+  ASSERT_NE(stroke, nullptr);
+  EXPECT_TRUE(stroke->effective);
+  EXPECT_EQ(stroke->matchedElementCount, 1);
 }
 
 TEST(StyleSourceAnnotations, InlineStyleDeclarationDoesNotShowSelectorChip) {
@@ -374,6 +442,19 @@ TEST(StyleSourceAnnotations, PresentationAttributeWithoutSourceLocationIsSkipped
   EXPECT_EQ(FindContribution(annotations, StyleContributionKind::PresentationAttribute, "fill",
                              "fill=\"red\"", kSource),
             nullptr);
+}
+
+TEST(StyleSourceAnnotations, StaleNonEmptySourceRangesAreSkipped) {
+  constexpr std::string_view kSource = R"svg(<svg xmlns="http://www.w3.org/2000/svg">
+  <style>.hit { fill: red; }</style>
+  <defs><linearGradient id="paint"><stop offset="1"/></linearGradient></defs>
+  <rect class="hit" fill="url(#paint)"/>
+</svg>)svg";
+  svg::SVGDocument document = ParseSvg(kSource);
+
+  const StyleSourceAnnotations annotations = ComputeStyleSourceAnnotations(document, "<svg");
+
+  EXPECT_TRUE(annotations.contributions.empty());
 }
 
 TEST(StyleSourceAnnotations, LaterInlineDeclarationWinsEqualSpecificityTie) {

--- a/donner/editor/tests/TextEditorCore_tests.cc
+++ b/donner/editor/tests/TextEditorCore_tests.cc
@@ -9,6 +9,7 @@
 #include <ostream>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace donner::editor {
@@ -126,6 +127,194 @@ protected:
 
   TextEditorCore editor_;
 };
+
+// ---------------------------------------------------------------------------
+// TextBuffer direct edge cases
+// ---------------------------------------------------------------------------
+
+TEST(TextBufferTests, CountLeadingWhitespaceStopsAtFirstNonWhitespace) {
+  Line line;
+  line.emplace_back(' ', ColorIndex::Default);
+  line.emplace_back('\t', ColorIndex::Default);
+  line.emplace_back(' ', ColorIndex::Default);
+  line.emplace_back('x', ColorIndex::Default);
+
+  EXPECT_EQ(details::CountLeadingWhitespace(line, 4), 6);
+  EXPECT_EQ(details::CountLeadingWhitespace(Line(), 4), 0);
+}
+
+TEST(TextBufferTests, SetTextKeepsAtLeastOneLineAndDropsTrailingNewline) {
+  TextBuffer buffer;
+
+  buffer.setText("");
+  EXPECT_EQ(buffer.getTotalLines(), 1);
+  EXPECT_THAT(buffer.getText(), IsEmpty());
+
+  buffer.setText("abc\n");
+  EXPECT_EQ(buffer.getTotalLines(), 1);
+  EXPECT_THAT(buffer.getText(), Eq("abc"));
+}
+
+TEST(TextBufferTests, GetTextRangeHandlesInvalidEmptyReversedAndExclusiveEnd) {
+  TextBuffer buffer;
+  buffer.setText("abcdef\nsecond");
+
+  Coordinates invalid;
+  invalid.line = -1;
+  EXPECT_THAT(buffer.getText(invalid, Coordinates(0, 1)), IsEmpty());
+  EXPECT_THAT(buffer.getText(Coordinates(0, 1), invalid), IsEmpty());
+  EXPECT_THAT(buffer.getText(Coordinates(0, 2), Coordinates(0, 2)), IsEmpty());
+  EXPECT_THAT(buffer.getText(Coordinates(0, 4), Coordinates(0, 1)), Eq("bcd"));
+  EXPECT_THAT(buffer.getText(Coordinates(0, 1), Coordinates(1, 3)), Eq("bcdef\nsec"));
+
+  buffer.setText("abc");
+  Coordinates invalidHighLine(99, 0);
+  EXPECT_THAT(buffer.getText(Coordinates(0, 1), invalidHighLine), IsEmpty());
+  EXPECT_THAT(buffer.getText(Coordinates(0, 1), Coordinates(0, 4)), Eq("bc"));
+}
+
+TEST(TextBufferTests, InsertTextAtHandlesCarriageReturnsAndIndentModes) {
+  TextBuffer buffer;
+  Coordinates where(0, 6);
+  buffer.setText("  headtail");
+
+  EXPECT_EQ(buffer.insertTextAt(where, "\r\n}", /*indent=*/true), 1);
+
+  EXPECT_THAT(buffer.getText(), Eq("  head\n}tail"));
+  EXPECT_EQ(where, Coordinates(1, 1));
+
+  buffer.setText("    headtail");
+  where = Coordinates(0, 8);
+
+  EXPECT_EQ(buffer.insertTextAt(where, "\n  child", /*indent=*/true), 1);
+
+  EXPECT_THAT(buffer.getText(), Eq("    head\n  childtail"));
+  EXPECT_EQ(where, Coordinates(1, 7));
+
+  buffer.setText("  headtail");
+  where = Coordinates(0, 6);
+
+  EXPECT_EQ(buffer.insertTextAt(where, "\n  ", /*indent=*/true), 1);
+
+  EXPECT_THAT(buffer.getText(), Eq("  head\n  tail"));
+  EXPECT_EQ(where, Coordinates(1, 2));
+
+  buffer.setText("  headtail");
+  where = Coordinates(0, 6);
+
+  EXPECT_EQ(buffer.insertTextAt(where, "\n\rchild", /*indent=*/true), 1);
+
+  EXPECT_THAT(buffer.getText(), Eq("  head\n  childtail"));
+  EXPECT_EQ(where, Coordinates(1, 7));
+}
+
+TEST(TextBufferTests, InsertTextAtClampsCharacterIndexPastLineEnd) {
+  TextBuffer buffer;
+  buffer.setText("ab");
+  Coordinates where(0, 99);
+
+  buffer.insertTextAt(where, "X");
+
+  EXPECT_THAT(buffer.getText(), Eq("abX"));
+  EXPECT_EQ(where, Coordinates(0, 100));
+}
+
+TEST(TextBufferTests, DeleteRangeHandlesNoOpSingleLineAndExclusiveLineEnd) {
+  TextBuffer buffer;
+  buffer.setText("abc\ndef\nghi");
+
+  buffer.deleteRange(Coordinates(0, 3), Coordinates(0, 3));
+  EXPECT_THAT(buffer.getText(), Eq("abc\ndef\nghi"));
+
+  buffer.deleteRange(Coordinates(0, 1), Coordinates(0, 3));
+  EXPECT_THAT(buffer.getText(), Eq("a\ndef\nghi"));
+
+  buffer.setText("abc\ndef\nghi");
+  buffer.deleteRange(Coordinates(0, 1), Coordinates(1, 4));
+  EXPECT_THAT(buffer.getText(), Eq("aghi"));
+
+  buffer.setText("abc\n\nghi");
+  buffer.deleteRange(Coordinates(0, 1), Coordinates(1, 0));
+  EXPECT_THAT(buffer.getText(), Eq("a\nghi"));
+}
+
+TEST(TextBufferTests, InsertLineHandlesBoundsAndSplitPastLineEnd) {
+  TextBuffer buffer;
+  buffer.setText("abc");
+
+  buffer.insertLine(-5);
+  EXPECT_THAT(buffer.getText(), Eq("\nabc"));
+
+  buffer.insertLine(99);
+  EXPECT_THAT(buffer.getText(), Eq("\nabc\n"));
+
+  buffer.setText("abc");
+  buffer.insertLine(0, 99);
+  EXPECT_THAT(buffer.getText(), Eq("abc\n"));
+
+  buffer.setText("abc");
+  buffer.insertLine(1, 3);
+  EXPECT_THAT(buffer.getText(), Eq("abc\n"));
+}
+
+TEST(TextBufferTests, RemoveLineHandlesInvalidRangesAndKeepsOneLine) {
+  TextBuffer buffer;
+  buffer.setText("a\nb");
+
+  buffer.removeLine(-1);
+  buffer.removeLine(99);
+  EXPECT_THAT(buffer.getText(), Eq("a\nb"));
+
+  buffer.removeLine(0);
+  EXPECT_THAT(buffer.getText(), Eq("b"));
+
+  buffer.removeLine(0);
+  EXPECT_THAT(buffer.getText(), IsEmpty());
+  EXPECT_EQ(buffer.getTotalLines(), 1);
+
+  buffer.setText("a\nb\nc");
+  buffer.removeLine(2, 1);
+  EXPECT_THAT(buffer.getText(), Eq("a\nb\nc"));
+
+  buffer.removeLine(-5, 1);
+  EXPECT_THAT(buffer.getText(), Eq("b\nc"));
+
+  buffer.removeLine(1, 99);
+  EXPECT_THAT(buffer.getText(), Eq("b"));
+
+  buffer.setText("a\nb");
+  buffer.removeLine(-5, 99);
+  EXPECT_THAT(buffer.getText(), IsEmpty());
+  EXPECT_EQ(buffer.getTotalLines(), 1);
+}
+
+TEST(TextBufferTests, MetricsHandleTabsUtf8OutOfRangeAndByteOffsets) {
+  TextBuffer buffer;
+  buffer.setText(std::string("\tab\n\xC3\xA9"));
+
+  EXPECT_EQ(buffer.getLineMaxColumn(0), 4);
+  EXPECT_EQ(buffer.getLineMaxColumn(99), 0);
+  EXPECT_EQ(buffer.getLineCharacterCount(1), 1);
+  EXPECT_EQ(buffer.getLineCharacterCount(99), 0);
+  EXPECT_EQ(buffer.getCharacterIndex(Coordinates(0, 3)), 2);
+  EXPECT_EQ(buffer.getCharacterColumn(0, 0), 0);
+  EXPECT_EQ(buffer.getCharacterColumn(0, 2), 3);
+  EXPECT_EQ(buffer.getCharacterColumn(99, 2), 0);
+  EXPECT_EQ(buffer.getByteOffset(Coordinates(99, 0)), 6u);
+
+  Coordinates negativeLine;
+  negativeLine.line = -1;
+  negativeLine.column = 7;
+  EXPECT_EQ(buffer.getByteOffset(negativeLine), 3u);
+
+  EXPECT_EQ(buffer.getCoordinatesAtByteOffset(3), Coordinates(0, 4));
+  EXPECT_EQ(buffer.getCoordinatesAtByteOffset(4), Coordinates(1, 0));
+  EXPECT_EQ(buffer.getCoordinatesAtByteOffset(999), Coordinates(1, 1));
+
+  TextBuffer oneLine;
+  oneLine.setText("abc");
+  EXPECT_EQ(oneLine.getCoordinatesAtByteOffset(999), Coordinates(0, 3));
+}
 
 TEST_F(TextEditorCoreTests, DragUpAcrossMultipleLinesPreservesOriginalAnchor) {
   BeginDrag(Coordinates(3, 5));
@@ -508,6 +697,66 @@ TEST_F(TextEditorCoreTests, ShiftMoveDownThenUpContractsSelection) {
   EXPECT_EQ(editor_.getSelectionEnd(), Coordinates(2, 0));
 }
 
+TEST_F(TextEditorCoreTests, ShiftMoveUpUpdatesAnchorFromEitherSelectionSide) {
+  editor_.setCursorPosition(Coordinates(2, 0));
+  editor_.interactiveStart() = Coordinates(2, 0);
+  editor_.interactiveEnd() = Coordinates(3, 0);
+
+  editor_.moveUp(1, /*select=*/true);
+
+  EXPECT_EQ(editor_.getSelectionStart(), Coordinates(1, 0));
+  EXPECT_EQ(editor_.getSelectionEnd(), Coordinates(3, 0));
+
+  editor_.setCursorPosition(Coordinates(2, 0));
+  editor_.interactiveStart() = Coordinates(1, 0);
+  editor_.interactiveEnd() = Coordinates(2, 0);
+
+  editor_.moveUp(1, /*select=*/true);
+
+  EXPECT_EQ(editor_.getSelectionStart(), Coordinates(1, 0));
+  EXPECT_EQ(editor_.getSelectionEnd(), Coordinates(1, 0));
+}
+
+TEST_F(TextEditorCoreTests, ShiftMoveDownUpdatesAnchorFromEitherSelectionSide) {
+  editor_.setCursorPosition(Coordinates(2, 0));
+  editor_.interactiveStart() = Coordinates(1, 0);
+  editor_.interactiveEnd() = Coordinates(2, 0);
+
+  editor_.moveDown(1, /*select=*/true);
+
+  EXPECT_EQ(editor_.getSelectionStart(), Coordinates(1, 0));
+  EXPECT_EQ(editor_.getSelectionEnd(), Coordinates(3, 0));
+
+  editor_.setCursorPosition(Coordinates(2, 0));
+  editor_.interactiveStart() = Coordinates(2, 0);
+  editor_.interactiveEnd() = Coordinates(3, 0);
+
+  editor_.moveDown(1, /*select=*/true);
+
+  EXPECT_EQ(editor_.getSelectionStart(), Coordinates(3, 0));
+  EXPECT_EQ(editor_.getSelectionEnd(), Coordinates(3, 0));
+}
+
+TEST_F(TextEditorCoreTests, ShiftHorizontalMovesHandleWrappedAndUnanchoredSelections) {
+  editor_.setCursorPosition(Coordinates(1, 0));
+  editor_.interactiveStart() = Coordinates(0, 0);
+  editor_.interactiveEnd() = Coordinates(4, 0);
+
+  editor_.moveLeft(1, /*select=*/true);
+
+  EXPECT_EQ(editor_.getSelectionStart(), Coordinates(0, 10));
+  EXPECT_EQ(editor_.getSelectionEnd(), Coordinates(1, 0));
+
+  editor_.setCursorPosition(Coordinates(0, 10));
+  editor_.interactiveStart() = Coordinates(0, 0);
+  editor_.interactiveEnd() = Coordinates(4, 0);
+
+  editor_.moveRight(1, /*select=*/true);
+
+  EXPECT_EQ(editor_.getSelectionStart(), Coordinates(0, 10));
+  EXPECT_EQ(editor_.getSelectionEnd(), Coordinates(1, 0));
+}
+
 TEST_F(TextEditorCoreTests, ShiftMoveTopAndBottomCreateFullRangeSelection) {
   editor_.setCursorPosition(Coordinates(2, 4));
 
@@ -535,6 +784,26 @@ TEST_F(TextEditorCoreTests, ShiftHomeAndEndExtendFromInteractiveSide) {
   editor_.interactiveEnd() = Coordinates(2, 7);
   editor_.moveEnd(/*select=*/true);
   EXPECT_EQ(editor_.getSelectionStart(), Coordinates(2, 7));
+  EXPECT_EQ(editor_.getSelectionEnd(), Coordinates(2, 10));
+}
+
+TEST_F(TextEditorCoreTests, ShiftHomeAndEndResetUnanchoredSelectionAroundOldCursor) {
+  editor_.setCursorPosition(Coordinates(2, 5));
+  editor_.interactiveStart() = Coordinates(1, 0);
+  editor_.interactiveEnd() = Coordinates(3, 0);
+
+  editor_.moveHome(/*select=*/true);
+
+  EXPECT_EQ(editor_.getSelectionStart(), Coordinates(2, 0));
+  EXPECT_EQ(editor_.getSelectionEnd(), Coordinates(2, 5));
+
+  editor_.setCursorPosition(Coordinates(2, 5));
+  editor_.interactiveStart() = Coordinates(1, 0);
+  editor_.interactiveEnd() = Coordinates(3, 0);
+
+  editor_.moveEnd(/*select=*/true);
+
+  EXPECT_EQ(editor_.getSelectionStart(), Coordinates(2, 5));
   EXPECT_EQ(editor_.getSelectionEnd(), Coordinates(2, 10));
 }
 
@@ -674,6 +943,19 @@ TEST_F(TextEditorCoreTests, EnterTabCanInsertLiteralTab) {
   EXPECT_EQ(editor_.getCursorPosition(), Coordinates(0, 1));
 }
 
+TEST_F(TextEditorCoreTests, RegularCharacterHelperCanExpandTabUtf8Payload) {
+  editor_.setText("x");
+  editor_.setInsertSpaces(true);
+  editor_.setTabSize(3);
+
+  UndoState state;
+  editor_.handleRegularCharacter(state, Coordinates(0, 0), '\t');
+
+  EXPECT_THAT(editor_.getText(), Eq("   x"));
+  EXPECT_EQ(editor_.getCursorPosition(), Coordinates(0, 3));
+  EXPECT_EQ(state.record.added, "   ");
+}
+
 TEST_F(TextEditorCoreTests, InsertTextWithIndentUnindentsClosingBrace) {
   editor_.setText("    {tail");
   editor_.resetTextChanged();
@@ -699,6 +981,31 @@ TEST_F(TextEditorCoreTests, OpeningBraceCompletionCreatesIndentedClosingBrace) {
 
   EXPECT_THAT(editor_.getText(), Eq("  {\n  }"));
   EXPECT_EQ(editor_.getCursorPosition(), Coordinates(1, 2));
+}
+
+TEST_F(TextEditorCoreTests, InsertLineShiftsFoldMarkersOnSplitColumn) {
+  editor_.setText("{\t}\nnext");
+  editor_.foldBegin() = {Coordinates(0, 0), Coordinates(1, 0)};
+  editor_.foldEnd() = {Coordinates(0, 2), Coordinates(1, 4)};
+
+  editor_.insertLine(1, 1);
+
+  EXPECT_THAT(editor_.foldBegin(), ElementsAre(Coordinates(0, 0), Coordinates(2, 0)));
+  EXPECT_THAT(editor_.foldEnd(), ElementsAre(Coordinates(1, 2), Coordinates(2, 4)));
+}
+
+TEST_F(TextEditorCoreTests, RemoveFoldsUpdatesColumnsAcrossTabsAndJoinedLines) {
+  editor_.setText("{\tfoo\n  bar}\nkeep");
+  editor_.setTabSize(4);
+  editor_.foldBegin() = {Coordinates(0, 0), Coordinates(0, 2), Coordinates(2, 0)};
+  editor_.foldEnd() = {Coordinates(1, 6), Coordinates(1, 6), Coordinates(2, 4)};
+
+  editor_.removeFolds(Coordinates(0, 1), Coordinates(1, 2));
+
+  EXPECT_FALSE(editor_.foldSorted());
+  ASSERT_EQ(editor_.foldBegin().size(), 2u);
+  EXPECT_EQ(editor_.foldBegin()[0], Coordinates(0, 0));
+  EXPECT_EQ(editor_.foldBegin()[1], Coordinates(1, 0));
 }
 
 // ---------------------------------------------------------------------------
@@ -743,6 +1050,17 @@ TEST_F(TextEditorCoreTests, BackspaceRemovesLiteralTabWhenInsertSpacesDisabled) 
   EXPECT_EQ(editor_.getCursorPosition(), Coordinates(0, 1));
 }
 
+TEST_F(TextEditorCoreTests, BackspaceAtLiteralTabColumnRemovesTheTab) {
+  editor_.setText("\t");
+  editor_.setInsertSpaces(false);
+  editor_.setCursorPosition(Coordinates(0, 1));
+
+  editor_.backspace();
+
+  EXPECT_THAT(editor_.getText(), IsEmpty());
+  EXPECT_EQ(editor_.getCursorPosition(), Coordinates(0, 0));
+}
+
 TEST_F(TextEditorCoreTests, DeleteMidLineRemovesCharacterUnderCursor) {
   editor_.setText("abc");
   editor_.setCursorPosition(Coordinates(0, 1));
@@ -777,6 +1095,15 @@ TEST_F(TextEditorCoreTests, DeleteRangeUpdatesScrollbarMarkers) {
   editor_.deleteRange(Coordinates(1, 0), Coordinates(3, 0));
 
   EXPECT_THAT(editor_.changedLines(), ElementsAre(0, 1, 2));
+}
+
+TEST_F(TextEditorCoreTests, DeleteRangeKeepsInteriorChangedLineRemapStable) {
+  editor_.setScrollbarMarkers(true);
+  editor_.changedLines() = {0, 2, 3, 4};
+
+  editor_.deleteRange(Coordinates(1, 2), Coordinates(3, 4));
+
+  EXPECT_THAT(editor_.changedLines(), ElementsAre(0, 3, 2));
 }
 
 TEST_F(TextEditorCoreTests, DeleteSelectionRemovesAndCollapsesCursor) {
@@ -928,6 +1255,58 @@ TEST_F(TextEditorCoreTests, RemoveFoldsKeepsFoldBeforeSameLineDeletedRange) {
   EXPECT_THAT(editor_.foldEnd(), ElementsAre(Coordinates(0, 0), Coordinates(0, 3)));
 }
 
+TEST_F(TextEditorCoreTests, RemoveFoldsMultiLineKeepsStartLineFoldBeforeDeletedColumns) {
+  editor_.setText("abcdef\nsecond\nthird");
+  editor_.foldBegin() = {Coordinates(0, 1), Coordinates(0, 4), Coordinates(2, 0)};
+  editor_.foldEnd() = {Coordinates(0, 1), Coordinates(0, 4), Coordinates(2, 0)};
+  editor_.foldSorted() = true;
+
+  editor_.removeFolds(Coordinates(0, 3), Coordinates(1, 2));
+
+  EXPECT_THAT(editor_.foldBegin(), ElementsAre(Coordinates(0, 1), Coordinates(1, 0)));
+  EXPECT_THAT(editor_.foldEnd(), ElementsAre(Coordinates(0, 1), Coordinates(1, 0)));
+  EXPECT_FALSE(editor_.foldSorted());
+}
+
+TEST_F(TextEditorCoreTests, RemoveFoldsMultiLineRecomputesFoldAfterEndLineColumn) {
+  editor_.setText("abcde\nWXYZ\nlast");
+  editor_.foldBegin() = {Coordinates(1, 4)};
+  editor_.foldEnd() = {Coordinates(1, 4)};
+  editor_.foldSorted() = true;
+
+  editor_.removeFolds(Coordinates(0, 2), Coordinates(1, 2));
+
+  EXPECT_THAT(editor_.foldBegin(), ElementsAre(Coordinates(0, 7)));
+  EXPECT_THAT(editor_.foldEnd(), ElementsAre(Coordinates(0, 7)));
+  EXPECT_TRUE(editor_.foldSorted());
+}
+
+TEST_F(TextEditorCoreTests, RemoveFoldsMultiLineErasesEndLineFoldBeforeEndColumn) {
+  editor_.setText("abcde\nWXYZ\nlast");
+  editor_.foldBegin() = {Coordinates(1, 1), Coordinates(1, 3)};
+  editor_.foldEnd() = {Coordinates(1, 1), Coordinates(1, 3)};
+  editor_.foldSorted() = true;
+
+  editor_.removeFolds(Coordinates(0, 2), Coordinates(1, 2));
+
+  EXPECT_THAT(editor_.foldBegin(), ElementsAre(Coordinates(0, 5)));
+  EXPECT_THAT(editor_.foldEnd(), ElementsAre(Coordinates(0, 6)));
+  EXPECT_FALSE(editor_.foldSorted());
+}
+
+TEST_F(TextEditorCoreTests, RemoveFoldsOutOfRangeStartLeavesRecomputedColumnUnchanged) {
+  editor_.setText("only");
+  editor_.foldBegin() = {Coordinates(3, 2)};
+  editor_.foldEnd() = {Coordinates(3, 2)};
+  editor_.foldSorted() = true;
+
+  editor_.removeFolds(Coordinates(2, 0), Coordinates(3, 1));
+
+  EXPECT_THAT(editor_.foldBegin(), ElementsAre(Coordinates(2, 2)));
+  EXPECT_THAT(editor_.foldEnd(), ElementsAre(Coordinates(2, 2)));
+  EXPECT_TRUE(editor_.foldSorted());
+}
+
 // ---------------------------------------------------------------------------
 // Undo / redo across compound edits
 // ---------------------------------------------------------------------------
@@ -1077,6 +1456,19 @@ TEST_F(TextEditorCoreTests, ShiftTabOutdentsMixedTabsAndSpaces) {
   EXPECT_EQ(editor_.getSelectionEnd(), Coordinates(1, 1));
 }
 
+TEST_F(TextEditorCoreTests, ShiftTabOutdentsPublicReversedMultilineSelection) {
+  editor_.setText("  a\n  b\nc");
+  editor_.setInsertSpaces(true);
+  editor_.setTabSize(2);
+  editor_.setSelection(Coordinates(1, 3), Coordinates(0, 0));
+
+  editor_.enterCharacter('\t', /*shift=*/true);
+
+  EXPECT_THAT(editor_.getText(), Eq("a\nb\nc"));
+  EXPECT_EQ(editor_.getSelectionStart(), Coordinates(0, 0));
+  EXPECT_EQ(editor_.getSelectionEnd(), Coordinates(1, 1));
+}
+
 TEST_F(TextEditorCoreTests, MultiLineTabCanInsertLiteralTabs) {
   editor_.setText("a\nb\nc");
   editor_.setInsertSpaces(false);
@@ -1097,6 +1489,21 @@ TEST_F(TextEditorCoreTests, ShiftTabNoOpDoesNotCreateUndoRecord) {
 
   EXPECT_THAT(editor_.getText(), Eq("a\nb"));
   EXPECT_FALSE(editor_.canUndo());
+}
+
+TEST_F(TextEditorCoreTests, MultiLineTabHelperClampsOversizedSelectionEnd) {
+  editor_.setText("a\nb");
+  editor_.setInsertSpaces(true);
+  editor_.setTabSize(2);
+  editor_.mutableState().selectionStart = Coordinates(0, 0);
+  editor_.mutableState().selectionEnd = Coordinates(99, 0);
+
+  UndoState state;
+  editor_.handleMultiLineTab(state, /*shift=*/false);
+
+  EXPECT_THAT(editor_.getText(), Eq("  a\n  b"));
+  EXPECT_EQ(editor_.getSelectionStart(), Coordinates(0, 0));
+  EXPECT_EQ(editor_.getSelectionEnd(), Coordinates(99, 0));
 }
 
 // ---------------------------------------------------------------------------
@@ -1249,6 +1656,30 @@ TEST_F(TextEditorCoreTests, AppendSourceEditIntentDeduplicatesAndInvokesHook) {
   EXPECT_EQ(hookCalls, 1);
 }
 
+TEST_F(TextEditorCoreTests, AppendSourceEditIntentKeepsDistinctAdjacentVariants) {
+  const auto makeIntent = [](std::size_t offset, std::size_t removedLength, std::string replacement,
+                             SourceEditIntentKind kind) {
+    SourceEditIntent intent;
+    intent.offset = offset;
+    intent.removedLength = removedLength;
+    intent.replacement = std::move(replacement);
+    intent.kind = kind;
+    return intent;
+  };
+
+  editor_.appendSourceEditIntent(makeIntent(1, 1, "x", SourceEditIntentKind::Replace));
+  editor_.appendSourceEditIntent(makeIntent(2, 1, "x", SourceEditIntentKind::Replace));
+  editor_.appendSourceEditIntent(makeIntent(2, 2, "x", SourceEditIntentKind::Replace));
+  editor_.appendSourceEditIntent(makeIntent(2, 2, "y", SourceEditIntentKind::Replace));
+  editor_.appendSourceEditIntent(makeIntent(2, 2, "y", SourceEditIntentKind::Delete));
+  editor_.appendSourceEditIntent(makeIntent(2, 2, "y", SourceEditIntentKind::Delete));
+
+  const std::vector<SourceEditIntent> intents = editor_.takePendingSourceEditIntents();
+  ASSERT_EQ(intents.size(), 5u);
+  EXPECT_EQ(intents[0].bufferVersion, 1u);
+  EXPECT_EQ(intents[4].bufferVersion, 5u);
+}
+
 TEST_F(TextEditorCoreTests, EditingHooksFireForAutocompleteAndContentUpdates) {
   int autocompleteRequests = 0;
   int contentUpdates = 0;
@@ -1273,6 +1704,159 @@ TEST_F(TextEditorCoreTests, EditingHooksFireForAutocompleteAndContentUpdates) {
   EXPECT_GE(contentUpdates, 1);
   EXPECT_EQ(sourceIntentHooks, 1);
   EXPECT_EQ(tooltipHooks, 1);
+}
+
+TEST_F(TextEditorCoreTests, ActiveAutocompleteRequestsForUnderscoreButNotDigitsOrUnicode) {
+  int autocompleteRequests = 0;
+  editor_.requestAutocompleteHook = [&] { ++autocompleteRequests; };
+  editor_.setText("");
+  editor_.setCompleteBraces(false);
+  editor_.setActiveAutocomplete(true);
+
+  editor_.setCursorPosition(Coordinates(0, 0));
+  editor_.enterCharacter('_', false);
+  EXPECT_EQ(autocompleteRequests, 1);
+
+  editor_.enterCharacter('7', false);
+  editor_.enterCharacter(static_cast<char32_t>(0x00E9), false);
+  EXPECT_EQ(autocompleteRequests, 1);
+}
+
+TEST_F(TextEditorCoreTests, CoreEdgeBranchesHandleNoOpAndBoundaryOperations) {
+  Coordinates pastEnd(99, 3);
+  editor_.advance(pastEnd);
+  EXPECT_EQ(pastEnd, Coordinates(99, 3));
+
+  editor_.setSelection(Coordinates(1, 2), Coordinates(1, 4));
+  editor_.setCursorPositionChanged(false);
+  editor_.setSelection(Coordinates(1, 2), Coordinates(1, 4));
+  EXPECT_FALSE(editor_.cursorPositionChanged());
+
+  editor_.setText("abc");
+  editor_.resetTextChanged();
+  editor_.setSelection(Coordinates(0, 1), Coordinates(0, 1));
+  editor_.deleteSelection();
+  EXPECT_THAT(editor_.getText(), Eq("abc"));
+  EXPECT_FALSE(editor_.isTextChanged());
+
+  editor_.setCursorPosition(Coordinates(0, 0));
+  editor_.backspace();
+  EXPECT_THAT(editor_.getText(), Eq("abc"));
+}
+
+TEST_F(TextEditorCoreTests, WordAndSearchEdgesHandleBoundaryCoordinates) {
+  editor_.setText("alpha end");
+  editor_.setColorizerEnabled(false);
+
+  const Coordinates lineEnd(0, editor_.buffer().getLineMaxColumn(0));
+  EXPECT_EQ(editor_.findWordStart(lineEnd), lineEnd);
+  EXPECT_EQ(editor_.findWordEnd(lineEnd), lineEnd);
+  EXPECT_TRUE(editor_.isOnWordBoundary(lineEnd));
+  EXPECT_EQ(editor_.findNextWord(Coordinates(99, 0)), Coordinates(99, 0));
+
+  Coordinates negativeStart;
+  negativeStart.line = -1;
+  EXPECT_EQ(editor_.findFirst("x", negativeStart),
+            Coordinates(editor_.buffer().getTotalLines(), 0));
+}
+
+TEST_F(TextEditorCoreTests, UndoPureDeleteRestoresTextAndEmitsUndoIntent) {
+  editor_.setText("abc");
+  editor_.setSelection(Coordinates(0, 1), Coordinates(0, 2));
+  editor_.delete_();
+  editor_.takePendingSourceEditIntents();
+
+  editor_.undo();
+
+  EXPECT_THAT(editor_.getText(), Eq("abc"));
+  const std::vector<SourceEditIntent> intents = editor_.takePendingSourceEditIntents();
+  ASSERT_EQ(intents.size(), 1u);
+  EXPECT_EQ(intents[0].kind, SourceEditIntentKind::Undo);
+  EXPECT_EQ(intents[0].removedLength, 0u);
+  EXPECT_EQ(intents[0].replacement, "b");
+}
+
+TEST_F(TextEditorCoreTests, UndoRecordUndoAndRedoHandlePureInsertAndPureDelete) {
+  editor_.setText("abc");
+
+  EditorState before;
+  before.cursorPosition = Coordinates(0, 1);
+  before.selectionStart = before.cursorPosition;
+  before.selectionEnd = before.cursorPosition;
+
+  EditorState afterInsert;
+  afterInsert.cursorPosition = Coordinates(0, 2);
+  afterInsert.selectionStart = afterInsert.cursorPosition;
+  afterInsert.selectionEnd = afterInsert.cursorPosition;
+
+  UndoRecord insertRecord("X", Coordinates(0, 1), Coordinates(0, 2), "", Coordinates(0, 1),
+                          Coordinates(0, 1), before, afterInsert);
+  insertRecord.redo(&editor_);
+  EXPECT_THAT(editor_.getText(), Eq("aXbc"));
+  insertRecord.undo(&editor_);
+  EXPECT_THAT(editor_.getText(), Eq("abc"));
+
+  EditorState afterDelete = before;
+  UndoRecord deleteRecord("", Coordinates(0, 1), Coordinates(0, 1), "b", Coordinates(0, 1),
+                          Coordinates(0, 2), before, afterDelete);
+  deleteRecord.redo(&editor_);
+  EXPECT_THAT(editor_.getText(), Eq("ac"));
+  deleteRecord.undo(&editor_);
+  EXPECT_THAT(editor_.getText(), Eq("abc"));
+}
+
+TEST_F(TextEditorCoreTests, NewlineWithoutLanguageAutoIndentDoesNotCopyWhitespace) {
+  LanguageDefinition language;
+  language.autoIndentation = false;
+  editor_.setLanguageDefinition(language);
+  editor_.setText("  x");
+  editor_.setCompleteBraces(false);
+  editor_.setSmartIndent(true);
+  editor_.setCursorPosition(Coordinates(0, 3));
+
+  editor_.enterCharacter('\n', false);
+
+  EXPECT_THAT(editor_.getText(), Eq("  x\n"));
+  EXPECT_EQ(editor_.getCursorPosition(), Coordinates(1, 0));
+}
+
+TEST_F(TextEditorCoreTests, ChangeTrackingSkipsLineAlreadyMarked) {
+  editor_.setText("abc");
+  editor_.setScrollbarMarkers(true);
+  editor_.changedLines() = {0};
+  editor_.setCompleteBraces(false);
+  editor_.setCursorPosition(Coordinates(0, 1));
+
+  editor_.enterCharacter('X', false);
+
+  EXPECT_THAT(editor_.getText(), Eq("aXbc"));
+  EXPECT_THAT(editor_.changedLines(), ElementsAre(0));
+}
+
+TEST_F(TextEditorCoreTests, InsertTextAtRecordsFoldsAndScrollbarMarker) {
+  editor_.setText("tail");
+  editor_.setScrollbarMarkers(true);
+  Coordinates where(0, 0);
+
+  editor_.insertTextAt(where, "{}");
+
+  EXPECT_THAT(editor_.getText(), Eq("{}tail"));
+  EXPECT_THAT(editor_.changedLines(), ElementsAre(0));
+  ASSERT_EQ(editor_.foldBegin().size(), 1u);
+  ASSERT_EQ(editor_.foldEnd().size(), 1u);
+}
+
+TEST_F(TextEditorCoreTests, InsertLineShiftsFoldsAtAndAfterSplitPoint) {
+  editor_.setText("abcdef\nnext");
+  editor_.foldBegin() = {Coordinates(0, 1), Coordinates(0, 4), Coordinates(1, 0)};
+  editor_.foldEnd() = {Coordinates(0, 1), Coordinates(0, 4), Coordinates(1, 0)};
+
+  editor_.insertLine(1, 3);
+
+  EXPECT_THAT(editor_.foldBegin(),
+              ElementsAre(Coordinates(0, 1), Coordinates(1, 4), Coordinates(2, 0)));
+  EXPECT_THAT(editor_.foldEnd(),
+              ElementsAre(Coordinates(0, 1), Coordinates(1, 4), Coordinates(2, 0)));
 }
 
 // ---------------------------------------------------------------------------
@@ -1436,10 +2020,18 @@ void ExpectSvgToken(const TokenExpectation& expectation) {
 
 TEST_F(TextEditorCoreTests, SvgTokenizerClassifiesXmlSyntaxTokens) {
   const TokenExpectation cases[] = {
-      {"<rect", "<", ColorIndex::Punctuation},      {"</rect>", "</", ColorIndex::Punctuation},
-      {">", ">", ColorIndex::Punctuation},          {"/>", "/>", ColorIndex::Punctuation},
-      {"\"value\"", "\"", ColorIndex::Punctuation}, {"'value'", "'", ColorIndex::Punctuation},
-      {"=", "=", ColorIndex::Punctuation},          {"@unknown", "", ColorIndex::Default},
+      {"", "", ColorIndex::Default},
+      {"<", "<", ColorIndex::Punctuation},
+      {"<rect", "<", ColorIndex::Punctuation},
+      {"</rect>", "</", ColorIndex::Punctuation},
+      {">", ">", ColorIndex::Punctuation},
+      {"/", "", ColorIndex::Default},
+      {"/rect", "", ColorIndex::Default},
+      {"/>", "/>", ColorIndex::Punctuation},
+      {"\"value\"", "\"", ColorIndex::Punctuation},
+      {"'value'", "'", ColorIndex::Punctuation},
+      {"=", "=", ColorIndex::Punctuation},
+      {"@unknown", "", ColorIndex::Default},
   };
 
   for (const TokenExpectation& expectation : cases) {
@@ -1460,17 +2052,35 @@ TEST_F(TextEditorCoreTests, SvgTokenizerClassifiesXmlSyntaxTokens) {
 
 TEST_F(TextEditorCoreTests, SvgTokenizerClassifiesEntitiesNumbersAndIdentifiers) {
   const TokenExpectation cases[] = {
+      {"&", "&", ColorIndex::Number},
       {"&amp; tail", "&amp;", ColorIndex::Number},
       {"&name<tag", "&name", ColorIndex::Number},
+      {"&name>tail", "&name", ColorIndex::Number},
+      {"&name\ttail", "&name", ColorIndex::Number},
+      {"&name\ntail", "&name", ColorIndex::Number},
+      {"&#", "&#", ColorIndex::Number},
       {"&#65; tail", "&#65;", ColorIndex::Number},
       {"&#x41; tail", "&#x41;", ColorIndex::Number},
+      {"&#X41; tail", "&#X41;", ColorIndex::Number},
       {"&unterminated tail", "&unterminated", ColorIndex::Number},
+      {"1", "1", ColorIndex::Number},
+      {"1 ", "1", ColorIndex::Number},
+      {"1)", "1", ColorIndex::Number},
+      {"12px", "12px", ColorIndex::Number},
+      {"1e2", "1e2", ColorIndex::Number},
+      {"1e", "1e", ColorIndex::Number},
       {"1e next", "1e", ColorIndex::Number},
+      {"1E+", "1E+", ColorIndex::Number},
       {"-1.5e+2px", "-1.5e+2px", ColorIndex::Number},
       {".5%", ".5%", ColorIndex::Number},
       {"9E-2em", "9E-2em", ColorIndex::Number},
+      {"a", "a", ColorIndex::Identifier},
+      {"a@", "a", ColorIndex::Identifier},
+      {":href", ":href", ColorIndex::Identifier},
+      {"A1", "A1", ColorIndex::Identifier},
       {"_private:name", "_private:name", ColorIndex::Identifier},
       {"xml:name-1.2", "xml:name-1.2", ColorIndex::Identifier},
+      {"a:b.c-1", "a:b.c-1", ColorIndex::Identifier},
       {std::string_view("\xC3\xA9"
                         "lement attr"),
        std::string_view("\xC3\xA9"
@@ -1528,6 +2138,33 @@ TEST_F(TextEditorCoreTests, ColorizeInternalMarksSingleAndMultilineComments) {
   const Line& line2 = editor_.buffer().getLineGlyphs(2);
   EXPECT_TRUE(line2[0].isMultiLineComment);
   EXPECT_FALSE(line2[9].isMultiLineComment);
+}
+
+TEST_F(TextEditorCoreTests, ColorizeInternalHandlesStringEscapesAndDoubledQuotes) {
+  LanguageDefinition language;
+  language.commentStart = "/*";
+  language.commentEnd = "*/";
+  language.singleLineComment = "//";
+
+  const std::string text =
+      "\"a\"\"b /* not comment */\" c // line\n\"slash \\\" /* still string */\"";
+  editor_.setText(text);
+  editor_.setLanguageDefinition(language);
+  editor_.colorizeInternal();
+
+  const Line& doubledQuoteLine = editor_.buffer().getLineGlyphs(0);
+  const std::size_t firstLineBlockComment = text.find("/*");
+  ASSERT_NE(firstLineBlockComment, std::string::npos);
+  EXPECT_FALSE(doubledQuoteLine[firstLineBlockComment].isMultiLineComment);
+  const std::size_t singleLineComment = text.find("//");
+  ASSERT_NE(singleLineComment, std::string::npos);
+  EXPECT_TRUE(doubledQuoteLine[singleLineComment].isComment);
+
+  const Line& escapedLine = editor_.buffer().getLineGlyphs(1);
+  const std::string_view escapedLineText = "\"slash \\\" /* still string */\"";
+  const std::size_t escapedLineBlockComment = escapedLineText.find("/*");
+  ASSERT_NE(escapedLineBlockComment, std::string_view::npos);
+  EXPECT_FALSE(escapedLine[escapedLineBlockComment].isMultiLineComment);
 }
 
 }  // namespace donner::editor

--- a/donner/editor/tests/TextEditor_tests.cc
+++ b/donner/editor/tests/TextEditor_tests.cc
@@ -179,12 +179,16 @@ protected:
   }
 
   void RenderEditorFrameWithMouse(const ImVec2& mousePos, bool mouseDown,
-                                  const ImVec2& editorSize = ImVec2(240.0f, 180.0f)) {
+                                  const ImVec2& editorSize = ImVec2(240.0f, 180.0f),
+                                  bool ctrl = false, bool shift = false, bool alt = false) {
     editor.setHandleKeyboardInputs(false);
     editor.setHandleMouseInputs(true);
 
     ImGuiIO& io = ImGui::GetIO();
     io.DisplaySize = ImVec2(800.0f, 600.0f);
+    io.AddKeyEvent(ImGuiMod_Ctrl, ctrl);
+    io.AddKeyEvent(ImGuiMod_Shift, shift);
+    io.AddKeyEvent(ImGuiMod_Alt, alt);
     io.AddMousePosEvent(mousePos.x, mousePos.y);
     io.AddMouseButtonEvent(0, mouseDown);
 
@@ -409,6 +413,11 @@ protected:
     }
     editor.autocompleteIndex_ = 0;
     editor.autocompletePosition_ = editor.getCursorPosition();
+  }
+
+  void RequestAutocompleteBuildOnNextKeyboardFrame() {
+    editor.requestAutocomplete_ = true;
+    editor.readyForAutocomplete_ = true;
   }
 
   [[nodiscard]] int VisualLineCount() const { return static_cast<int>(editor.visualLines_.size()); }
@@ -687,6 +696,44 @@ protected:
     return editor.isByteOffsetInIneffectiveStyleDecoration(byteOffset);
   }
 
+  void SetSingleSourceStyleChipHitRect(std::size_t id, const ImVec2& min, const ImVec2& max,
+                                       std::string tooltip = "") {
+    editor.sourceStyleChipHitRects_ = {TextEditor::SourceStyleChipHitRect{
+        .id = id,
+        .min = min,
+        .max = max,
+        .tooltip = std::move(tooltip),
+    }};
+  }
+
+  void RenderSourceStyleDecorationTooltipDirect(const ImVec2& mousePos,
+                                                std::optional<Coordinates> hoveredTextPosition) {
+    ImGuiIO& io = ImGui::GetIO();
+    io.AddMousePosEvent(mousePos.x, mousePos.y);
+    RunFrameWithChild("##source_style_tooltip_host", ImVec2(260.0f, 120.0f),
+                      [&](ImGuiWindow*, ImDrawList*) {
+                        editor.hoveredTextPosition_ = hoveredTextPosition;
+                        editor.renderSourceStyleDecorationTooltip();
+                      });
+  }
+
+  [[nodiscard]] int RenderErrorMarkersDirect(int lineNo, const ImVec2& start, const ImVec2& end,
+                                             std::optional<ImVec2> mousePos = std::nullopt) {
+    ImGuiIO& io = ImGui::GetIO();
+    if (mousePos.has_value()) {
+      io.AddMousePosEvent(mousePos->x, mousePos->y);
+    }
+
+    int addedVertices = 0;
+    RunFrameWithChild("##error_marker_host", ImVec2(260.0f, 120.0f),
+                      [&](ImGuiWindow*, ImDrawList* drawList) {
+                        const int before = drawList->VtxBuffer.Size;
+                        editor.renderErrorMarkers(lineNo, start, end, drawList);
+                        addedVertices = drawList->VtxBuffer.Size - before;
+                      });
+    return addedVertices;
+  }
+
   [[nodiscard]] std::size_t SourceStyleChipHitRectCount() const {
     return editor.sourceStyleChipHitRects_.size();
   }
@@ -728,8 +775,59 @@ protected:
     return editor.expandedFocusHiddenRanges_;
   }
 
+  void SetRawFocusPartition(FocusPartition partition, bool active = true) {
+    editor.focusPartition_ = std::move(partition);
+    editor.focusPartitionActive_ = active;
+  }
+
+  [[nodiscard]] bool IsLineHiddenByFocusDirect(int lineNo) const {
+    return editor.isLineHiddenByFocus(lineNo);
+  }
+
+  [[nodiscard]] bool IsLineReferenceColoredByFocusDirect(int lineNo) const {
+    return editor.isLineReferenceColoredByFocus(lineNo);
+  }
+
+  [[nodiscard]] bool IsLineDimmedByFocusDirect(int lineNo) const {
+    return editor.isLineDimmedByFocus(lineNo);
+  }
+
+  [[nodiscard]] bool IsLineExpandedHiddenByFocusDirect(int lineNo) const {
+    return editor.isLineExpandedHiddenByFocus(lineNo);
+  }
+
+  [[nodiscard]] std::optional<LineRange> FocusHiddenRangeForLineDirect(int lineNo) const {
+    return editor.focusHiddenRangeForLine(lineNo);
+  }
+
+  [[nodiscard]] bool IsFocusHiddenRangeExpandedDirect(LineRange range) const {
+    return editor.isFocusHiddenRangeExpanded(range);
+  }
+
+  void ExpandFocusHiddenRangeDirect(LineRange range) { editor.expandFocusHiddenRange(range); }
+
+  [[nodiscard]] bool TryExpandFocusHiddenPlaceholderAtDirect(const ImVec2& position) {
+    return editor.tryExpandFocusHiddenPlaceholderAt(position);
+  }
+
+  void RebuildVisualLinesDirect(const ImVec2& contentSize) {
+    editor.rebuildVisualLines(contentSize);
+  }
+
+  void ClearVisualLinesDirect() { editor.visualLines_.clear(); }
+
   [[nodiscard]] Coordinates VisibleSelectionEndCoordinatesDirect() const {
     return editor.visibleSelectionEndCoordinates();
+  }
+
+  [[nodiscard]] float VisibleTextRegionHeightDirect() const {
+    return editor.visibleTextRegionHeight();
+  }
+
+  void SetScrollViewportHeight(float height) { editor.scrollViewportHeight_ = height; }
+
+  void ScrollCoordinatesRangeIntoViewDirect(const Coordinates& start, const Coordinates& end) {
+    editor.scrollCoordinatesRangeIntoView(start, end);
   }
 
   [[nodiscard]] std::string TextRange(const Coordinates& start, const Coordinates& end) const {
@@ -778,6 +876,29 @@ protected:
 
   [[nodiscard]] Coordinates MousePosToCoordinatesDirect(const ImVec2& position) const {
     return editor.mousePosToCoordinates(position);
+  }
+
+  [[nodiscard]] Coordinates VisualScreenPosToCoordinatesDirect(const ImVec2& position) const {
+    return editor.visualScreenPosToCoordinates(position);
+  }
+
+  [[nodiscard]] std::optional<Coordinates> HoveredTextPosition() const {
+    return editor.hoveredTextPosition_;
+  }
+
+  void SetCharAdvanceForTesting(const ImVec2& value) { editor.charAdvance_ = value; }
+
+  void UpdateHoveredTextPositionDirect(const ImVec2& mousePos, bool leftDown = false,
+                                       bool rightDown = false,
+                                       const ImVec2& childSize = ImVec2(240.0f, 100.0f)) {
+    ImGuiIO& io = ImGui::GetIO();
+    io.AddMousePosEvent(mousePos.x, mousePos.y);
+    io.AddMouseButtonEvent(0, leftDown);
+    io.AddMouseButtonEvent(1, rightDown);
+    RunFrameWithChild("##hover_host", childSize,
+                      [&](ImGuiWindow*, ImDrawList*) { editor.updateHoveredTextPosition(); });
+    io.AddMouseButtonEvent(1, false);
+    io.AddMouseButtonEvent(0, false);
   }
 
   void OpenAutocompleteReplacement(std::size_t replaceStart, std::size_t replaceEnd,
@@ -912,6 +1033,55 @@ protected:
     return scrollTargetY;
   }
 
+  [[nodiscard]] float ScrollRangeIntoViewDirectInChild(const Coordinates& start,
+                                                       const Coordinates& end, float initialScrollY,
+                                                       const ImVec2& childSize = ImVec2(240.0f,
+                                                                                        80.0f)) {
+    float scrollTargetY = 0.0f;
+    RunFrameWithChild("##scroll_range_host", childSize, [&](ImGuiWindow* window, ImDrawList*) {
+      window->Scroll.y = initialScrollY;
+      editor.scrollViewportHeight_ = childSize.y;
+      editor.withinRender_ = true;
+      editor.scrollCoordinatesRangeIntoView(start, end);
+      editor.withinRender_ = false;
+      scrollTargetY = window->ScrollTarget.y;
+    });
+    return scrollTargetY;
+  }
+
+  [[nodiscard]] float EnsureCursorVisibleDirectInChild(float initialScrollY,
+                                                       const ImVec2& childSize = ImVec2(240.0f,
+                                                                                        80.0f)) {
+    float scrollTargetY = 0.0f;
+    RunFrameWithChild("##ensure_cursor_host", childSize, [&](ImGuiWindow* window, ImDrawList*) {
+      window->Scroll.y = initialScrollY;
+      editor.scrollViewportHeight_ = childSize.y;
+      editor.withinRender_ = true;
+      editor.ensureCursorVisible();
+      editor.withinRender_ = false;
+      scrollTargetY = window->ScrollTarget.y;
+    });
+    return scrollTargetY;
+  }
+
+  [[nodiscard]] int RenderCursorDirectInChild(const ImVec2& lineStart,
+                                              const ImVec2& childSize = ImVec2(240.0f, 80.0f)) {
+    int addedVertices = 0;
+    RunFrameWithChild("##cursor_host", childSize, [&](ImGuiWindow* window, ImDrawList* drawList) {
+      ImGui::FocusWindow(window);
+      const int before = drawList->VtxBuffer.Size;
+      editor.textChanged_ = true;
+      editor.renderCursor(lineStart, drawList);
+      editor.textChanged_ = false;
+      addedVertices = drawList->VtxBuffer.Size - before;
+    });
+    return addedVertices;
+  }
+
+  [[nodiscard]] float TextDistanceToLineStartDirect(const Coordinates& coordinates) {
+    return editor.getTextDistanceToLineStart(coordinates);
+  }
+
   [[nodiscard]] bool ScrollToCursorRequested() const { return editor.scrollToCursor_; }
   [[nodiscard]] bool ScrollSelectionIntoViewRequested() const {
     return editor.scrollSelectionIntoView_;
@@ -951,7 +1121,15 @@ protected:
     editor.openFunctionDeclarationTooltip(declaration, coords);
   }
 
+  void HandleFunctionTooltipDirect(ImWchar character, const Coordinates& coords) {
+    editor.handleFunctionTooltip(character, coords);
+  }
+
   [[nodiscard]] bool FunctionTooltipOpen() const { return editor.functionDeclarationTooltip_; }
+
+  [[nodiscard]] std::string FunctionTooltipDeclaration() const {
+    return editor.functionDeclaration_;
+  }
 
   [[nodiscard]] int WindowCountContaining(std::string_view text) const {
     const ImGuiContext* context = ImGui::GetCurrentContext();
@@ -1113,6 +1291,60 @@ TEST_F(TextEditorTests, SourceStyleDecorationsAreClampedAndCleared) {
   EXPECT_TRUE(editor.sourceStyleDecorations().empty());
 }
 
+TEST_F(TextEditorTests, SourceStyleDecorationsSortByEndThenId) {
+  editor.setText("abcdef");
+
+  ASSERT_TRUE(editor.setSourceStyleDecorations({
+      TextEditor::SourceStyleDecoration{
+          .id = 4,
+          .range = SourceByteRange{.start = 0, .end = 5},
+      },
+      TextEditor::SourceStyleDecoration{
+          .id = 3,
+          .range = SourceByteRange{.start = 0, .end = 3},
+      },
+      TextEditor::SourceStyleDecoration{
+          .id = 1,
+          .range = SourceByteRange{.start = 0, .end = 3},
+          .chipRange = SourceByteRange{.start = 5, .end = 5},
+      },
+      TextEditor::SourceStyleDecoration{
+          .id = 2,
+          .range = SourceByteRange{.start = 0, .end = 3},
+      },
+  }));
+
+  ASSERT_EQ(editor.sourceStyleDecorations().size(), 4u);
+  EXPECT_EQ(editor.sourceStyleDecorations()[0].id, 1u);
+  EXPECT_EQ(editor.sourceStyleDecorations()[0].range, (SourceByteRange{.start = 0, .end = 3}));
+  EXPECT_EQ(editor.sourceStyleDecorations()[0].chipRange, (SourceByteRange{.start = 0, .end = 3}));
+  EXPECT_EQ(editor.sourceStyleDecorations()[1].id, 2u);
+  EXPECT_EQ(editor.sourceStyleDecorations()[2].id, 3u);
+  EXPECT_EQ(editor.sourceStyleDecorations()[3].id, 4u);
+  EXPECT_EQ(editor.sourceStyleDecorations()[3].range, (SourceByteRange{.start = 0, .end = 5}));
+}
+
+TEST_F(TextEditorTests, IneffectiveStyleLookupSkipsEffectiveDecorationsAtSameOffset) {
+  editor.setText("abcdef");
+  ASSERT_TRUE(editor.setSourceStyleDecorations({
+      TextEditor::SourceStyleDecoration{
+          .id = 1,
+          .range = SourceByteRange{.start = 0, .end = 4},
+          .ineffective = false,
+      },
+      TextEditor::SourceStyleDecoration{
+          .id = 2,
+          .range = SourceByteRange{.start = 1, .end = 3},
+          .ineffective = true,
+      },
+  }));
+
+  EXPECT_FALSE(IsByteOffsetInIneffectiveStyleDecoration(0));
+  EXPECT_TRUE(IsByteOffsetInIneffectiveStyleDecoration(1));
+  EXPECT_TRUE(IsByteOffsetInIneffectiveStyleDecoration(2));
+  EXPECT_FALSE(IsByteOffsetInIneffectiveStyleDecoration(3));
+}
+
 TEST_F(TextEditorTests, SourceStyleDecorationsStrikeRangesWithoutRenderingHiddenChips) {
   editor.setText("fill: red;");
   ASSERT_TRUE(editor.setSourceStyleDecorations({
@@ -1226,6 +1458,24 @@ TEST_F(TextEditorTests, SourceStyleDecorationOverflowMarkerHasTooltipAndIsNotCli
   EXPECT_EQ(editor.takeClickedSourceStyleChipId(), std::nullopt);
 }
 
+TEST_F(TextEditorTests, HoveringSourceStyleChipSuppressesRangeTooltip) {
+  editor.setText("fill: red;");
+  SetRawSourceStyleDecorations({
+      TextEditor::SourceStyleDecoration{
+          .id = 21,
+          .range = SourceByteRange{.start = 0, .end = 4},
+          .ineffective = true,
+          .tooltip = "range tooltip",
+      },
+  });
+  SetSingleSourceStyleChipHitRect(/*id=*/21, ImVec2(-100.0f, -100.0f), ImVec2(1000.0f, 1000.0f),
+                                  "chip tooltip");
+
+  RenderSourceStyleDecorationTooltipDirect(ImVec2(16.0f, 16.0f), Coordinates(0, 2));
+
+  EXPECT_EQ(SourceStyleChipHitRectCount(), 1u);
+}
+
 TEST_F(TextEditorTests, RemapFocusMetadataNoOpLeavesExistingRanges) {
   editor.setText("abcdef");
   SetRawHoverSourceRanges({SourceByteRange{.start = 1, .end = 4}});
@@ -1300,6 +1550,88 @@ TEST_F(TextEditorTests, RemapFocusMetadataMapsRangesAndFocusPartitionAfterEdit) 
                                                SourcePoint{.line = 2, .column = 0})));
 }
 
+TEST_F(TextEditorTests, RemapFocusMetadataHandlesInsertionAtRangeBoundary) {
+  editor.setText("abXYZ\ncd\nef");
+  SetRawHoverSourceRanges({
+      SourceByteRange{.start = 2, .end = 3},
+      SourceByteRange{.start = 0, .end = 1},
+  });
+  SetRawSourceStyleDecorations({
+      TextEditor::SourceStyleDecoration{
+          .id = 12,
+          .range = SourceByteRange{.start = 2, .end = 4},
+          .chipRange = SourceByteRange{.start = 2, .end = 2},
+          .showChip = true,
+      },
+  });
+  SetRawFocusPartition(FocusPartition{
+      .fullColor = {LineRange{.startLine = 0, .endLine = 1}},
+      .referenceLinks =
+          {
+              FocusReferenceLink{
+                  .from = SourcePoint{.line = 0, .column = 2},
+                  .to = SourcePoint{.line = 1, .column = 0},
+              },
+          },
+  });
+
+  SourceEditIntent intent;
+  intent.offset = 2;
+  intent.removedLength = 0;
+  intent.replacement = "XYZ";
+  intent.start = SourceEditPoint{.line = 0, .column = 2};
+  intent.removedEnd = SourceEditPoint{.line = 0, .column = 2};
+  intent.replacementEnd = SourceEditPoint{.line = 0, .column = 5};
+
+  RemapFocusMetadataForSourceEdit(intent);
+
+  ASSERT_EQ(editor.hoverSourceRanges().size(), 2u);
+  EXPECT_EQ(editor.hoverSourceRanges()[0], (SourceByteRange{.start = 5, .end = 6}));
+  EXPECT_EQ(editor.hoverSourceRanges()[1], (SourceByteRange{.start = 0, .end = 1}));
+  ASSERT_EQ(editor.sourceStyleDecorations().size(), 1u);
+  EXPECT_EQ(editor.sourceStyleDecorations()[0].range, (SourceByteRange{.start = 5, .end = 7}));
+  EXPECT_EQ(editor.sourceStyleDecorations()[0].chipRange, (SourceByteRange{.start = 5, .end = 5}));
+  ASSERT_EQ(ActiveFocusPartition().referenceLinks.size(), 1u);
+  EXPECT_EQ(ActiveFocusPartition().referenceLinks[0].from, (SourcePoint{.line = 0, .column = 5}));
+  EXPECT_EQ(ActiveFocusPartition().referenceLinks[0].to, (SourcePoint{.line = 1, .column = 0}));
+}
+
+TEST_F(TextEditorTests, RemapFocusMetadataHandlesShrinkingDeletionAndRawInvalidRanges) {
+  editor.setText("ab\ncd\nef");
+  SetRawHoverSourceRanges({
+      SourceByteRange{.start = 7, .end = 9},
+      SourceByteRange{.start = 8, .end = 4},
+  });
+  SetRawFocusPartition(FocusPartition{
+      .fullColor = {LineRange{.startLine = 2, .endLine = 1}},
+      .hidden = {LineRange{.startLine = 0, .endLine = 3}},
+      .referenceLinks =
+          {
+              FocusReferenceLink{
+                  .from = SourcePoint{.line = 0, .column = 3},
+                  .to = SourcePoint{.line = 2, .column = 0},
+              },
+          },
+  });
+
+  SourceEditIntent intent;
+  intent.offset = 2;
+  intent.removedLength = 3;
+  intent.replacement = "";
+  intent.start = SourceEditPoint{.line = 0, .column = 2};
+  intent.removedEnd = SourceEditPoint{.line = 0, .column = 5};
+  intent.replacementEnd = SourceEditPoint{.line = 0, .column = 2};
+
+  RemapFocusMetadataForSourceEdit(intent);
+
+  ASSERT_EQ(editor.hoverSourceRanges().size(), 1u);
+  EXPECT_EQ(editor.hoverSourceRanges()[0], (SourceByteRange{.start = 4, .end = 6}));
+  EXPECT_TRUE(ActiveFocusPartition().fullColor.empty());
+  ASSERT_EQ(ActiveFocusPartition().referenceLinks.size(), 1u);
+  EXPECT_EQ(ActiveFocusPartition().referenceLinks[0].from, (SourcePoint{.line = 0, .column = 2}));
+  EXPECT_EQ(ActiveFocusPartition().referenceLinks[0].to, (SourcePoint{.line = 2, .column = 0}));
+}
+
 TEST_F(TextEditorTests, ContentUpdateHookRunsForShellEdits) {
   int updateCount = 0;
   editor.onContentUpdate = [&updateCount](TextEditor*) { ++updateCount; };
@@ -1349,6 +1681,10 @@ TEST_F(TextEditorTests, DirectCoordinateConversionHandlesTabsAndMouseAdjustment)
 
   RenderEditorFrame(ImVec2(320.0f, 120.0f));
 
+  const ImVec2 beforeTabMidpoint = ScreenPointAtUnwrappedVisualLine(0, 1.0f);
+  EXPECT_EQ(ScreenPosToCoordinatesDirect(beforeTabMidpoint), Coordinates(0, 0));
+  EXPECT_EQ(MousePosToCoordinatesDirect(beforeTabMidpoint), Coordinates(0, 0));
+
   const ImVec2 tabLinePoint = ScreenPointAtCoordinates(Coordinates(0, 1));
   EXPECT_EQ(ScreenPosToCoordinatesDirect(tabLinePoint).line, 0);
   EXPECT_GE(ScreenPosToCoordinatesDirect(tabLinePoint).column, 1);
@@ -1360,6 +1696,138 @@ TEST_F(TextEditorTests, DirectCoordinateConversionHandlesTabsAndMouseAdjustment)
   const ImVec2 belowText(tabLinePoint.x, tabLinePoint.y + 500.0f);
   EXPECT_EQ(ScreenPosToCoordinatesDirect(belowText).line, 1);
   EXPECT_EQ(MousePosToCoordinatesDirect(belowText).line, 1);
+}
+
+TEST_F(TextEditorTests, DirectCoordinateConversionHandlesUtf8GlyphWidths) {
+  editor.setWordWrapEnabled(false);
+  editor.setText("\xC3\xA9x");
+
+  RenderEditorFrame(ImVec2(320.0f, 120.0f));
+
+  const ImVec2 afterFirstGlyph = ScreenPointAtCoordinates(Coordinates(0, 1));
+  EXPECT_EQ(ScreenPosToCoordinatesDirect(afterFirstGlyph), Coordinates(0, 2));
+  EXPECT_EQ(MousePosToCoordinatesDirect(afterFirstGlyph), Coordinates(0, 2));
+}
+
+TEST_F(TextEditorTests, VisualLineHelpersHandleCacheEmptyLayoutAndFallbacks) {
+  editor.setText("alpha\nbeta\ngamma");
+  RenderEditorFrame(ImVec2(320.0f, 140.0f));
+
+  RebuildVisualLinesDirect(ImVec2(320.0f, 140.0f));
+  const int visualLineCount = VisualLineCount();
+  RebuildVisualLinesDirect(ImVec2(320.0f, 140.0f));
+  EXPECT_EQ(VisualLineCount(), visualLineCount);
+
+  ClearVisualLinesDirect();
+  EXPECT_EQ(VisualLineIndexForCoordinates(Coordinates(3, 0)), 3);
+  EXPECT_EQ(VisualScreenPosToCoordinatesDirect(ImVec2(12.0f, 18.0f)), Coordinates(0, 0));
+
+  editor.setFocusPartition(FocusPartition{
+      .fullColor = {LineRange{.startLine = 2, .endLine = 3}},
+      .hidden = {LineRange{.startLine = 1, .endLine = 2}},
+  });
+  RenderEditorFrame(ImVec2(320.0f, 140.0f));
+  ASSERT_TRUE(VisualLineIsFocusHiddenPlaceholder(1));
+
+  EXPECT_EQ(VisualLineIndexForCoordinates(Coordinates(1, 99)), 1);
+
+  const ImVec2 farLeft =
+      ScreenPointAtVisualTextOffset(/*visualIndex=*/2, /*visualColumnOffset=*/-100);
+  EXPECT_EQ(VisualScreenPosToCoordinatesDirect(farLeft), Coordinates(2, 0));
+}
+
+TEST_F(TextEditorTests, VisibleSelectionEndAndScrollHelpersCoverBoundaryCases) {
+  editor.setText("alpha\nbeta");
+
+  editor.setSelection(Coordinates(0, 2), Coordinates(1, 0));
+  EXPECT_EQ(VisibleSelectionEndCoordinatesDirect(), Coordinates(0, 5));
+
+  editor.setSelection(Coordinates(0, 1), Coordinates(0, 4));
+  EXPECT_EQ(VisibleSelectionEndCoordinatesDirect(), Coordinates(0, 3));
+
+  SetScrollViewportHeight(37.0f);
+  EXPECT_FLOAT_EQ(VisibleTextRegionHeightDirect(), 37.0f);
+
+  editor.setCursorPosition(Coordinates(1, 0));
+  ScrollCoordinatesRangeIntoViewDirect(Coordinates(1, 0), Coordinates(1, 2));
+  EXPECT_EQ(editor.getCursorPosition(), Coordinates(1, 0));
+}
+
+TEST_F(TextEditorTests, WrappedScrollHelpersUseVisualLineRanges) {
+  editor.setText("alpha beta gamma delta epsilon zeta eta theta iota kappa lambda");
+  editor.setWordWrapEnabled(true);
+  RenderEditorFrame(ImVec2(140.0f, 80.0f));
+  RebuildVisualLinesDirect(ImVec2(140.0f, 80.0f));
+  ASSERT_GT(VisualLineCount(), 1);
+
+  const float scrollTarget = ScrollRangeIntoViewDirectInChild(
+      Coordinates(0, 45), Coordinates(0, 55), 0.0f, ImVec2(140.0f, CharacterAdvanceY() * 2.0f));
+  EXPECT_GT(scrollTarget, 0.0f);
+
+  editor.setCursorPosition(Coordinates(0, 55));
+  const float cursorScrollTarget =
+      EnsureCursorVisibleDirectInChild(0.0f, ImVec2(140.0f, CharacterAdvanceY() * 2.0f));
+  EXPECT_GT(cursorScrollTarget, 0.0f);
+}
+
+TEST_F(TextEditorTests, FocusPartitionScrollHelpersUseVisualLineRangesWithoutWordWrap) {
+  editor.setWordWrapEnabled(false);
+  editor.setText("alpha\nhidden one\nhidden two\nvisible tail");
+  editor.setFocusPartition(FocusPartition{
+      .fullColor = {LineRange{.startLine = 0, .endLine = 1},
+                    LineRange{.startLine = 3, .endLine = 4}},
+      .hidden = {LineRange{.startLine = 1, .endLine = 3}},
+  });
+  RenderEditorFrame(ImVec2(220.0f, 80.0f));
+  ASSERT_GT(VisualLineCount(), 1);
+
+  const float rangeTarget = ScrollRangeIntoViewDirectInChild(Coordinates(3, 0), Coordinates(3, 8),
+                                                             /*initialScrollY=*/0.0f,
+                                                             ImVec2(220.0f, CharacterAdvanceY()));
+  EXPECT_GT(rangeTarget, 0.0f);
+
+  editor.setCursorPosition(Coordinates(3, 4));
+  const float cursorTarget =
+      EnsureCursorVisibleDirectInChild(0.0f, ImVec2(220.0f, CharacterAdvanceY()));
+  EXPECT_GT(cursorTarget, 0.0f);
+}
+
+TEST_F(TextEditorTests, WrappedCursorUsesVisualLineColumn) {
+  editor.setText("alpha beta gamma delta epsilon zeta eta theta");
+  editor.setWordWrapEnabled(true);
+  RenderEditorFrame(ImVec2(140.0f, 80.0f));
+  RebuildVisualLinesDirect(ImVec2(140.0f, 80.0f));
+  ASSERT_GT(VisualLineCount(), 1);
+
+  editor.setCursorPosition(Coordinates(0, 24));
+  EXPECT_GT(
+      RenderCursorDirectInChild(ImVec2(0.0f, 0.0f), ImVec2(140.0f, CharacterAdvanceY() * 2.0f)), 0);
+}
+
+TEST_F(TextEditorTests, FocusPartitionCursorUsesVisualLineColumnWithoutWordWrap) {
+  editor.setWordWrapEnabled(false);
+  editor.setText("alpha\nhidden one\nhidden two\nvisible tail");
+  editor.setFocusPartition(FocusPartition{
+      .fullColor = {LineRange{.startLine = 0, .endLine = 1},
+                    LineRange{.startLine = 3, .endLine = 4}},
+      .hidden = {LineRange{.startLine = 1, .endLine = 3}},
+  });
+  RenderEditorFrame(ImVec2(220.0f, 80.0f));
+  ASSERT_GT(VisualLineCount(), 1);
+
+  editor.setCursorPosition(Coordinates(3, 7));
+  EXPECT_GT(RenderCursorDirectInChild(ImVec2(0.0f, CharacterAdvanceY()),
+                                      ImVec2(220.0f, CharacterAdvanceY() * 2.0f)),
+            0);
+}
+
+TEST_F(TextEditorTests, TextDistanceHandlesTruncatedUtf8GlyphBytes) {
+  editor.setWordWrapEnabled(false);
+  editor.setText(std::string("a\xF0\x9F", 3));
+  RenderEditorFrame(ImVec2(320.0f, 120.0f));
+
+  EXPECT_GT(TextDistanceToLineStartDirect(Coordinates(0, 2)),
+            TextDistanceToLineStartDirect(Coordinates(0, 1)));
 }
 
 TEST_F(TextEditorTests, FoldedScreenPositionMapsPastCollapsedRegion) {
@@ -1385,15 +1853,52 @@ TEST_F(TextEditorTests, FoldedScreenPositionIgnoresInvalidFoldConnection) {
   EXPECT_EQ(ScreenPosToCoordinatesDirect(secondVisibleLine).line, 1);
 }
 
+TEST_F(TextEditorTests, FoldedScreenPositionIgnoresOutOfRangeFoldMetadata) {
+  editor.setWordWrapEnabled(false);
+  editor.setText("zero\none\ntwo");
+  RenderEditorFrame(ImVec2(320.0f, 120.0f));
+
+  ConfigureFoldState({Coordinates(0, 0)}, {Coordinates(2, 0)}, {true}, {7});
+
+  const ImVec2 secondVisibleLine = ScreenPointAtUnwrappedVisualLine(1, 40.0f);
+  EXPECT_EQ(ScreenPosToCoordinatesDirect(secondVisibleLine).line, 1);
+
+  ConfigureFoldState({Coordinates(0, 0), Coordinates(1, 0)}, {Coordinates(2, 0)}, {false}, {0});
+  const ImVec2 thirdVisibleLine = ScreenPointAtUnwrappedVisualLine(2, 40.0f);
+  EXPECT_EQ(MousePosToCoordinatesDirect(thirdVisibleLine).line, 2);
+}
+
+TEST_F(TextEditorTests, HoveredTextPositionRejectsDegenerateCharacterAdvance) {
+  editor.setWordWrapEnabled(false);
+  editor.setText("alpha");
+  RenderEditorFrame(ImVec2(320.0f, 120.0f));
+
+  SetCharAdvanceForTesting(ImVec2(0.0f, CharacterAdvanceY()));
+  UpdateHoveredTextPositionDirect(ImVec2(TextStart() + 20.0f, 20.0f));
+
+  EXPECT_FALSE(HoveredTextPosition().has_value());
+}
+
 TEST_F(TextEditorTests, CharacterInputSkipsControlCharactersAndTracksLetters) {
   editor.setText("");
 
-  const std::array<ImWchar, 4> characters = {1, 'a', '.', '\n'};
+  const std::array<ImWchar, 5> characters = {0, 1, 'a', '.', '\n'};
   const auto [keepAutocompleteOpen, hasWrittenLetter] = HandleCharacterInputDirect(characters);
 
   EXPECT_FALSE(keepAutocompleteOpen);
   EXPECT_TRUE(hasWrittenLetter);
   EXPECT_EQ(editor.getText(), "a.\n");
+}
+
+TEST_F(TextEditorTests, CharacterInputLeavesLetterFlagClearForDigitsAndPunctuation) {
+  editor.setText("");
+
+  const std::array<ImWchar, 2> characters = {'1', '_'};
+  const auto [keepAutocompleteOpen, hasWrittenLetter] = HandleCharacterInputDirect(characters);
+
+  EXPECT_FALSE(keepAutocompleteOpen);
+  EXPECT_FALSE(hasWrittenLetter);
+  EXPECT_EQ(editor.getText(), "1_");
 }
 
 TEST_F(TextEditorTests, SnippetTypingPropagatesRepeatedPlaceholderText) {
@@ -1460,6 +1965,14 @@ TEST_F(TextEditorTests, ExecuteActionDirectCoversAutocompleteCases) {
   ExecuteActionDirect(TextEditor::ShortcutId::AutocompleteSelectActive, keepAutocompleteOpen);
   EXPECT_FALSE(keepAutocompleteOpen);
   EXPECT_EQ(editor.getText(), "alpha");
+  EXPECT_FALSE(AutocompleteOpened());
+
+  editor.setText("");
+  OpenAutocompleteWithSuggestions({"gamma"});
+  keepAutocompleteOpen = true;
+  ExecuteActionDirect(TextEditor::ShortcutId::AutocompleteSelect, keepAutocompleteOpen);
+  EXPECT_FALSE(keepAutocompleteOpen);
+  EXPECT_EQ(editor.getText(), "gamma");
   EXPECT_FALSE(AutocompleteOpened());
 }
 
@@ -2047,6 +2560,23 @@ TEST_F(TextEditorTests, PasteWithSelectionReplacesSelection) {
   EXPECT_EQ(editor.getText(), "Hello world");
 }
 
+TEST_F(TextEditorTests, PasteWithEmptyOrUnavailableClipboardIsNoOp) {
+  editor.setText("Hello");
+  editor.resetTextChanged();
+  editor.setCursorPosition(Coordinates(0, 5));
+
+  ImGui::SetClipboardText("");
+  editor.paste();
+  EXPECT_EQ(editor.getText(), "Hello");
+  EXPECT_TRUE(editor.takePendingSourceEditIntents().empty());
+
+  ImGuiPlatformIO& platformIo = ImGui::GetPlatformIO();
+  platformIo.Platform_GetClipboardTextFn = [](ImGuiContext*) -> const char* { return nullptr; };
+  editor.paste();
+  EXPECT_EQ(editor.getText(), "Hello");
+  EXPECT_TRUE(editor.takePendingSourceEditIntents().empty());
+}
+
 TEST_F(TextEditorTests, ProcessReplaceCapturesReplaceIntentAndUndoRestoresText) {
   editor.setText("red blue red");
   editor.resetTextChanged();
@@ -2123,6 +2653,56 @@ TEST_F(TextEditorTests, FocusPartitionHidesLinesFromRenderedVisualLayout) {
   EXPECT_EQ(CoordinatesAtVisualTextOffset(2, 2), Coordinates(3, 2));
 }
 
+TEST_F(TextEditorTests, FocusPartitionDirectPredicatesCoverOverlapAndExpansion) {
+  const LineRange hiddenRange{.startLine = 4, .endLine = 5};
+
+  EXPECT_FALSE(IsLineHiddenByFocusDirect(4));
+  EXPECT_FALSE(IsLineReferenceColoredByFocusDirect(1));
+  EXPECT_FALSE(IsLineDimmedByFocusDirect(3));
+  EXPECT_FALSE(IsLineExpandedHiddenByFocusDirect(4));
+  EXPECT_FALSE(FocusHiddenRangeForLineDirect(4).has_value());
+  EXPECT_FALSE(IsFocusHiddenRangeExpandedDirect(hiddenRange));
+
+  const FocusPartition partition{
+      .fullColor = {LineRange{.startLine = 0, .endLine = 1},
+                    LineRange{.startLine = 2, .endLine = 3}},
+      .referenceColor = {LineRange{.startLine = 1, .endLine = 3}},
+      .dimmed = {LineRange{.startLine = 3, .endLine = 5}},
+      .hidden = {hiddenRange},
+  };
+  editor.setFocusPartition(partition);
+
+  EXPECT_FALSE(IsLineHiddenByFocusDirect(3));
+  EXPECT_TRUE(IsLineHiddenByFocusDirect(4));
+  EXPECT_TRUE(IsLineReferenceColoredByFocusDirect(1));
+  EXPECT_FALSE(IsLineReferenceColoredByFocusDirect(2));
+  EXPECT_TRUE(IsLineDimmedByFocusDirect(3));
+  EXPECT_FALSE(IsLineDimmedByFocusDirect(2));
+  EXPECT_EQ(FocusHiddenRangeForLineDirect(4), hiddenRange);
+  EXPECT_FALSE(FocusHiddenRangeForLineDirect(5).has_value());
+
+  ExpandFocusHiddenRangeDirect(LineRange{.startLine = 5, .endLine = 5});
+  EXPECT_TRUE(ExpandedFocusHiddenRanges().empty());
+
+  ExpandFocusHiddenRangeDirect(hiddenRange);
+  ASSERT_EQ(ExpandedFocusHiddenRanges().size(), 1u);
+  EXPECT_TRUE(IsFocusHiddenRangeExpandedDirect(hiddenRange));
+  EXPECT_TRUE(IsLineExpandedHiddenByFocusDirect(4));
+  EXPECT_FALSE(IsLineHiddenByFocusDirect(4));
+  EXPECT_TRUE(IsLineDimmedByFocusDirect(4));
+
+  ExpandFocusHiddenRangeDirect(hiddenRange);
+  EXPECT_EQ(ExpandedFocusHiddenRanges().size(), 1u);
+
+  editor.setFocusPartition(partition);
+  EXPECT_EQ(ExpandedFocusHiddenRanges().size(), 1u);
+
+  FocusPartition changed = partition;
+  changed.hidden = {LineRange{.startLine = 4, .endLine = 6}};
+  editor.setFocusPartition(changed);
+  EXPECT_TRUE(ExpandedFocusHiddenRanges().empty());
+}
+
 TEST_F(TextEditorTests, ClickingFocusHiddenPlaceholderExpandsRangeWithoutMovingCursor) {
   editor.setText("root\nhidden-a\nhidden-b\ntarget\nclose");
   const FocusPartition partition{
@@ -2149,6 +2729,34 @@ TEST_F(TextEditorTests, ClickingFocusHiddenPlaceholderExpandsRangeWithoutMovingC
   editor.setFocusPartition(partition);
   RenderEditorFrame(ImVec2(300.0f, 180.0f));
   EXPECT_THAT(VisualLineLogicalLines(), ElementsAre(0, 1, 2, 3, 4));
+}
+
+TEST_F(TextEditorTests, FocusHiddenPlaceholderExpansionRejectsInvalidRows) {
+  editor.setText("root\nhidden\ntarget");
+  EXPECT_FALSE(TryExpandFocusHiddenPlaceholderAtDirect(ImVec2(0.0f, 0.0f)));
+
+  editor.setFocusPartition(FocusPartition{
+      .fullColor = {LineRange{.startLine = 2, .endLine = 3}},
+      .hidden = {LineRange{.startLine = 1, .endLine = 2}},
+  });
+  RenderEditorFrame(ImVec2(300.0f, 160.0f));
+  ASSERT_TRUE(VisualLineIsFocusHiddenPlaceholder(1));
+
+  EXPECT_FALSE(TryExpandFocusHiddenPlaceholderAtDirect(
+      ScreenPointAtVisualTextOffset(/*visualIndex=*/0, /*visualColumnOffset=*/1)));
+
+  ImVec2 above = ScreenPointAtVisualTextOffset(/*visualIndex=*/0, /*visualColumnOffset=*/1);
+  above.y -= CharacterAdvanceY() * 2.0f;
+  EXPECT_FALSE(TryExpandFocusHiddenPlaceholderAtDirect(above));
+
+  ImVec2 below = ScreenPointAtVisualTextOffset(/*visualIndex=*/0, /*visualColumnOffset=*/1);
+  below.y += CharacterAdvanceY() * 20.0f;
+  EXPECT_FALSE(TryExpandFocusHiddenPlaceholderAtDirect(below));
+
+  EXPECT_TRUE(TryExpandFocusHiddenPlaceholderAtDirect(
+      ScreenPointAtVisualTextOffset(/*visualIndex=*/1, /*visualColumnOffset=*/1)));
+  EXPECT_EQ(ExpandedFocusHiddenRanges(),
+            (std::vector<LineRange>{LineRange{.startLine = 1, .endLine = 2}}));
 }
 
 TEST_F(TextEditorTests, CursorInsideFocusRangeTracksVisibleFocusBrightnessLines) {
@@ -2334,6 +2942,61 @@ TEST_F(TextEditorTests, FocusReferenceRopeOptionsUseDenseFastRopeTuning) {
   EXPECT_EQ(options.maxEndpointImpulsePx, 0.0);
   EXPECT_LE(options.endpointMotionVelocityRetention, 0.25);
   EXPECT_GE(options.endpointCatenaryBlend, 0.15);
+}
+
+TEST_F(TextEditorTests, FocusReferenceConnectorLayoutRejectsHiddenEndpoints) {
+  editor.setText("from\nto\nvisible");
+
+  const FocusReferenceLink hiddenSource{
+      .from = SourcePoint{.line = 0, .column = 0},
+      .to = SourcePoint{.line = 2, .column = 0},
+  };
+  editor.setFocusPartition(FocusPartition{
+      .fullColor = {LineRange{.startLine = 2, .endLine = 3}},
+      .hidden = {LineRange{.startLine = 0, .endLine = 1}},
+      .referenceLinks = {hiddenSource},
+  });
+  RenderEditorFrame(ImVec2(360.0f, 140.0f));
+  EXPECT_FALSE(FocusReferenceLayout(hiddenSource, 0).has_value());
+
+  const FocusReferenceLink hiddenTarget{
+      .from = SourcePoint{.line = 0, .column = 0},
+      .to = SourcePoint{.line = 1, .column = 0},
+  };
+  editor.setFocusPartition(FocusPartition{
+      .fullColor = {LineRange{.startLine = 0, .endLine = 1}},
+      .hidden = {LineRange{.startLine = 1, .endLine = 2}},
+      .referenceLinks = {hiddenTarget},
+  });
+  RenderEditorFrame(ImVec2(360.0f, 140.0f));
+  EXPECT_FALSE(FocusReferenceLayout(hiddenTarget, 0).has_value());
+}
+
+TEST_F(TextEditorTests, FocusReferenceSourceUnderlineHandlesReferenceCharactersAndPunctuation) {
+  const std::string source = "\nfill:url(#foo-bar.baz:50%) !";
+  editor.setText(source);
+  RenderEditorFrame(ImVec2(420.0f, 140.0f));
+
+  EXPECT_FALSE(FocusReferenceSourceUnderlineDirect(SourcePoint{.line = 0, .column = 0}));
+
+  const int percentColumn = static_cast<int>(source.find('%') - source.find('\n') - 1);
+  const int closeParenColumn = static_cast<int>(source.find(')') - source.find('\n') - 1);
+  ASSERT_GE(percentColumn, 0);
+  ASSERT_GE(closeParenColumn, 0);
+
+  const auto percentUnderline =
+      FocusReferenceSourceUnderlineDirect(SourcePoint{.line = 1, .column = percentColumn});
+  const auto closeParenUnderline =
+      FocusReferenceSourceUnderlineDirect(SourcePoint{.line = 1, .column = closeParenColumn});
+  ASSERT_TRUE(percentUnderline.has_value());
+  ASSERT_TRUE(closeParenUnderline.has_value());
+  EXPECT_FLOAT_EQ(closeParenUnderline->start.x, percentUnderline->start.x);
+  EXPECT_FLOAT_EQ(closeParenUnderline->end.x, percentUnderline->end.x);
+
+  const auto bangUnderline =
+      FocusReferenceSourceUnderlineDirect(SourcePoint{.line = 1, .column = closeParenColumn + 2});
+  ASSERT_TRUE(bangUnderline.has_value());
+  EXPECT_LT(bangUnderline->start.x, bangUnderline->end.x);
 }
 
 TEST_F(TextEditorTests, FocusReferenceRopesCullOffscreenLinksBeforeSimulation) {
@@ -2844,6 +3507,81 @@ TEST_F(TextEditorTests, HandleScrollingDirectScrollsUnwrappedCursorAboveAndBelow
 
   EXPECT_LT(scrollTargetAbove, scrolledDownY);
   EXPECT_FALSE(ScrollToCursorRequested());
+}
+
+TEST_F(TextEditorTests, ScrollRangeIntoViewHandlesDirectWrappedAndUnwrappedBranches) {
+  std::ostringstream source;
+  for (int i = 0; i < 80; ++i) {
+    source << "line" << i << "\n";
+  }
+  editor.setText(source.str());
+  RenderEditorFrame(ImVec2(240.0f, 80.0f));
+
+  const float hugeSelectionTarget = ScrollRangeIntoViewDirectInChild(
+      Coordinates(10, 0), Coordinates(40, 0), /*initialScrollY=*/0.0f);
+  EXPECT_GT(hugeSelectionTarget, 0.0f);
+
+  const float scrolledDownY = 30.0f * CharacterAdvanceY();
+  const float aboveViewportTarget =
+      ScrollRangeIntoViewDirectInChild(Coordinates(2, 0), Coordinates(3, 0), scrolledDownY);
+  EXPECT_LT(aboveViewportTarget, scrolledDownY);
+
+  const float belowViewportTarget = ScrollRangeIntoViewDirectInChild(
+      Coordinates(35, 0), Coordinates(35, 4), /*initialScrollY=*/0.0f);
+  EXPECT_GT(belowViewportTarget, 0.0f);
+
+  editor.setText(
+      "  <rect id=\"target\" x=\"10\" y=\"20\" width=\"30\" height=\"40\" "
+      "fill=\"red\" stroke=\"blue\" opacity=\"0.5\" transform=\"translate(1 2)\"/>\n");
+  RenderEditorFrame(ImVec2(220.0f, 80.0f));
+  const Coordinates wrappedTail(0, 112);
+  ASSERT_GT(VisualLineIndexForCoordinates(wrappedTail), 0);
+
+  const float wrappedTarget = ScrollRangeIntoViewDirectInChild(
+      Coordinates(0, 0), wrappedTail, /*initialScrollY=*/0.0f, ImVec2(220.0f, 80.0f));
+  EXPECT_GE(wrappedTarget, 0.0f);
+}
+
+TEST_F(TextEditorTests, VisualCoordinatesClampWrappedRowsAtHorizontalAndVerticalExtremes) {
+  editor.setText(
+      "  <rect id=\"target\" x=\"10\" y=\"20\" width=\"30\" height=\"40\" "
+      "fill=\"red\" stroke=\"blue\" opacity=\"0.5\" transform=\"translate(1 2)\"/>\n"
+      "tail");
+  RenderEditorFrame(ImVec2(220.0f, 80.0f));
+
+  const int continuationIndex = FirstContinuationVisualLineForLine(0);
+  ASSERT_NE(continuationIndex, -1);
+  const ImVec2 farRight = ScreenPointAtVisualTextOffset(continuationIndex, 400);
+  EXPECT_EQ(VisualScreenPosToCoordinatesDirect(farRight),
+            Coordinates(0, VisualLineEndColumn(continuationIndex)));
+
+  ImVec2 farAbove = farRight;
+  farAbove.y -= 500.0f;
+  EXPECT_EQ(VisualScreenPosToCoordinatesDirect(farAbove).line, 0);
+
+  ImVec2 farBelow = farRight;
+  farBelow.y += 500.0f;
+  EXPECT_EQ(VisualScreenPosToCoordinatesDirect(farBelow).line, 1);
+}
+
+TEST_F(TextEditorTests, RenderSelectionBranchesCoverUnwrappedAndWrappedLineRanges) {
+  editor.setWordWrapEnabled(false);
+  editor.setText("alpha\nbeta\ngamma");
+  editor.setSelection(Coordinates(0, 2), Coordinates(2, 3));
+  RenderEditorFrame(ImVec2(320.0f, 120.0f));
+  EXPECT_EQ(editor.getSelectedText(), "pha\nbeta\ngam");
+
+  editor.setWordWrapEnabled(true);
+  editor.setText(
+      "  <rect id=\"target\" x=\"10\" y=\"20\" width=\"30\" height=\"40\" "
+      "fill=\"red\" stroke=\"blue\" opacity=\"0.5\" transform=\"translate(1 2)\"/>\n"
+      "after");
+  RenderEditorFrame(ImVec2(220.0f, 80.0f));
+  const int continuationIndex = FirstContinuationVisualLineForLine(0);
+  ASSERT_NE(continuationIndex, -1);
+  editor.setSelection(Coordinates(0, 4), Coordinates(1, 3));
+  RenderEditorFrame(ImVec2(220.0f, 80.0f));
+  EXPECT_TRUE(editor.hasSelection());
 }
 
 TEST_F(TextEditorTests, TypingOnTopVisibleLineDoesNotNudgeScrollUp) {
@@ -3544,6 +4282,26 @@ TEST_F(TextEditorTests, HoveringErrorMarkerRendersTooltip) {
   EXPECT_GT(WindowCountContaining("##Tooltip"), 0);
 }
 
+TEST_F(TextEditorTests, ErrorMarkerRendererSkipsLinesWithoutMarkers) {
+  editor.setText("first\nsecond");
+  editor.setErrorMarkers(ErrorMarkers{{2, "syntax error"}});
+
+  const int addedVertices =
+      RenderErrorMarkersDirect(/*lineNo=*/0, ImVec2(20.0f, 20.0f), ImVec2(180.0f, 38.0f));
+
+  EXPECT_EQ(addedVertices, 0);
+}
+
+TEST_F(TextEditorTests, ErrorMarkerRendererShowsTooltipWhenHovered) {
+  editor.setText("first\nsecond");
+  editor.setErrorMarkers(ErrorMarkers{{1, "syntax error"}});
+
+  (void)RenderErrorMarkersDirect(/*lineNo=*/0, ImVec2(20.0f, 20.0f), ImVec2(180.0f, 38.0f),
+                                 ImVec2(60.0f, 28.0f));
+
+  EXPECT_GT(WindowCountContaining("##Tooltip"), 0);
+}
+
 TEST_F(TextEditorTests, HighlightedLinesRender) {
   editor.setWordWrapEnabled(false);
   editor.setText("one\ntwo\nthree");
@@ -3653,6 +4411,20 @@ TEST_F(TextEditorTests, ProcessFindInitialOutsideFrameDoesNotCrash) {
   EXPECT_EQ(editor.getCursorPosition(), Coordinates(0, 10));
 }
 
+TEST_F(TextEditorTests, ProcessFindInitialInsideFrameRestoresKeyboardFocusSafely) {
+  editor.setText("alpha beta gamma beta");
+  editor.setCursorPosition(Coordinates(0, 0));
+
+  ImGui::NewFrame();
+  ImGui::Begin("ProcessFindFocusWindow");
+  editor.processFind("beta", /*findNext=*/false);
+  ImGui::End();
+  ImGui::Render();
+
+  EXPECT_EQ(editor.getSelectedText(), "beta");
+  EXPECT_EQ(editor.getCursorPosition(), Coordinates(0, 10));
+}
+
 TEST_F(TextEditorTests, ProcessFindNextAdvancesPastCurrentMatch) {
   editor.setText("beta and beta again");
   editor.setCursorPosition(Coordinates(0, 5));
@@ -3680,6 +4452,35 @@ TEST_F(TextEditorTests, ProcessReplaceAllReplacesEveryOccurrence) {
 
   EXPECT_EQ(editor.getText(), "blue blue blue")
       << "replaceAll should replace every occurrence in the buffer";
+}
+
+TEST_F(TextEditorTests, ProcessReplaceSingleWrapsWhenNoMatchAhead) {
+  editor.setText("red blue red");
+  editor.setCursorPosition(Coordinates(0, 11));
+
+  editor.processReplace("red", "green", /*replaceAll=*/false);
+
+  EXPECT_EQ(editor.getText(), "green blue red")
+      << "single replace should wrap to the first match when none remains after replaceIndex";
+}
+
+TEST_F(TextEditorTests, ProcessReplaceSingleAdvancesReplaceIndex) {
+  editor.setText("red blue red");
+
+  editor.processReplace("red", "green", /*replaceAll=*/false);
+  editor.processReplace("red", "green", /*replaceAll=*/false);
+
+  EXPECT_EQ(editor.getText(), "green blue green")
+      << "single replace should continue after the previous replacement";
+}
+
+TEST_F(TextEditorTests, ProcessReplaceSingleNoMatchLeavesTextUnchanged) {
+  editor.setText("unchanged");
+
+  editor.processReplace("missing", "X", /*replaceAll=*/false);
+
+  EXPECT_EQ(editor.getText(), "unchanged")
+      << "single replace should be a no-op when the term is absent";
 }
 
 TEST_F(TextEditorTests, ProcessReplaceWithEmptyFindIsNoOp) {
@@ -3738,6 +4539,42 @@ TEST_F(TextEditorTests, FunctionTooltipRendersAndClosesOnEscape) {
   EXPECT_FALSE(FunctionTooltipOpen());
 }
 
+TEST_F(TextEditorTests, HandleFunctionTooltipHonorsDisabledStateAndOpeningParen) {
+  editor.setText("draw(");
+  editor.setCursorPosition(Coordinates(0, 4));
+
+  editor.setFunctionDeclarationTooltip(false);
+  HandleFunctionTooltipDirect('(', editor.getCursorPosition());
+  EXPECT_FALSE(FunctionTooltipOpen());
+
+  editor.setFunctionDeclarationTooltip(true);
+  HandleFunctionTooltipDirect('(', editor.getCursorPosition());
+  EXPECT_TRUE(FunctionTooltipOpen());
+  EXPECT_FALSE(FunctionTooltipDeclaration().empty());
+}
+
+TEST_F(TextEditorTests, HandleFunctionTooltipCommaFindsNearestOpenCall) {
+  editor.setText("outer(inner(a, b), c)");
+  editor.setCursorPosition(Coordinates(0, 16));
+  editor.setFunctionDeclarationTooltip(true);
+
+  HandleFunctionTooltipDirect(',', editor.getCursorPosition());
+
+  EXPECT_TRUE(FunctionTooltipOpen());
+  EXPECT_FALSE(FunctionTooltipDeclaration().empty());
+}
+
+TEST_F(TextEditorTests, HandleFunctionTooltipCommaIgnoresClosedNestedCall) {
+  editor.setText("outer(inner(a), b)");
+  editor.setCursorPosition(Coordinates(0, 15));
+  editor.setFunctionDeclarationTooltip(true);
+
+  HandleFunctionTooltipDirect(',', editor.getCursorPosition());
+
+  EXPECT_TRUE(FunctionTooltipOpen());
+  EXPECT_FALSE(FunctionTooltipDeclaration().empty());
+}
+
 // ============================================================================
 // AUTOCOMPLETE NAVIGATION & SELECTION THROUGH THE RENDER PATH
 // ============================================================================
@@ -3782,6 +4619,31 @@ TEST_F(TextEditorTests, AutocompletePopupClosesOnEscapeThroughRenderPath) {
                                 /*shift=*/false, /*alt=*/false, ImVec2(320.0f, 180.0f));
 
   EXPECT_FALSE(AutocompleteOpened());
+}
+
+TEST_F(TextEditorTests, KeyboardInputBuildsPendingAutocompleteThroughRenderPath) {
+  editor.setText("ap");
+  editor.setCursorPosition(Coordinates(0, 2));
+  editor.setLanguageDefinition(TextEditor::LanguageDefinition{});
+  editor.addAutocompleteEntry("apple", "apple entry", "apple()");
+  RequestAutocompleteBuildOnNextKeyboardFrame();
+
+  RenderEditorFrameWithKeyboard({});
+
+  EXPECT_TRUE(AutocompleteOpened());
+  EXPECT_EQ(AutocompleteSuggestionCount(), 1);
+  EXPECT_EQ(AutocompleteSuggestion(0).first, RcString("apple entry"));
+}
+
+TEST_F(TextEditorTests, TypedLetterClosesAutocompleteAndFunctionTooltipThroughRenderPath) {
+  editor.setText("");
+  OpenAutocompleteWithSuggestions({"alpha"});
+  OpenFunctionTooltipDirect("fn(value)", Coordinates(0, 0));
+
+  RenderEditorFrameWithKeyboard({}, "a");
+
+  EXPECT_FALSE(AutocompleteOpened());
+  EXPECT_FALSE(FunctionTooltipOpen());
 }
 
 // ============================================================================
@@ -3836,6 +4698,40 @@ TEST_F(TextEditorTests, ClickingLineNumberMarginDoesNotMoveCursorThroughRenderPa
   EXPECT_EQ(editor.getCursorPosition(), Coordinates(0, 5));
 }
 
+TEST_F(TextEditorTests, AltAndShiftHoverDoNotMoveCursorThroughRenderPath) {
+  editor.setText("Hello world");
+  editor.setCursorPosition(Coordinates(0, 0));
+  RenderEditorFrame();
+
+  const ImVec2 textPoint =
+      ScreenPointAtVisualTextOffset(/*visualIndex=*/0, /*visualColumnOffset=*/6);
+
+  RenderEditorFrameWithMouse(textPoint, /*mouseDown=*/false, ImVec2(240.0f, 180.0f),
+                             /*ctrl=*/false, /*shift=*/false, /*alt=*/true);
+  EXPECT_EQ(editor.getCursorPosition(), Coordinates(0, 0));
+  EXPECT_FALSE(editor.didMouseChangeCursorPosition());
+
+  RenderEditorFrameWithMouse(textPoint, /*mouseDown=*/false, ImVec2(240.0f, 180.0f),
+                             /*ctrl=*/false, /*shift=*/true, /*alt=*/false);
+  EXPECT_EQ(editor.getCursorPosition(), Coordinates(0, 0));
+  EXPECT_FALSE(editor.didMouseChangeCursorPosition());
+}
+
+TEST_F(TextEditorTests, CtrlClickSelectsWordThroughRenderPath) {
+  editor.setText("Hello world");
+  editor.setCursorPosition(Coordinates(0, 0));
+  RenderEditorFrame();
+
+  const ImVec2 clickPos =
+      ScreenPointAtVisualTextOffset(/*visualIndex=*/0, /*visualColumnOffset=*/7);
+  RenderEditorFrameWithMouse(clickPos, /*mouseDown=*/false);
+  RenderEditorFrameWithMouse(clickPos, /*mouseDown=*/true, ImVec2(240.0f, 180.0f),
+                             /*ctrl=*/true);
+
+  EXPECT_EQ(editor.getSelectedText(), "world");
+  EXPECT_TRUE(editor.didMouseChangeCursorPosition());
+}
+
 TEST_F(TextEditorTests, MouseDragExtendsSelectionThroughRenderPath) {
   editor.setText("Hello world");
   editor.setCursorPosition(Coordinates(0, 0));
@@ -3849,6 +4745,22 @@ TEST_F(TextEditorTests, MouseDragExtendsSelectionThroughRenderPath) {
   RenderEditorFrameWithMouse(end, true);  // drag with button held
 
   EXPECT_TRUE(editor.hasSelection()) << "Dragging the mouse should create a selection";
+}
+
+TEST_F(TextEditorTests, MouseDragNearBottomAutoscrollsThroughRenderPath) {
+  editor.setText("line0\nline1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\n");
+  editor.setCursorPosition(Coordinates(0, 0));
+  const ImVec2 editorSize(240.0f, 80.0f);
+  RenderEditorFrame(editorSize);
+
+  const ImVec2 start = ScreenPointAtVisualTextOffset(/*visualIndex=*/0, /*visualColumnOffset=*/0);
+  const ImVec2 bottomEdge(start.x + 20.0f, start.y + 54.0f);
+
+  RenderEditorFrameWithMouse(start, /*mouseDown=*/false, editorSize);
+  RenderEditorFrameWithMouse(start, /*mouseDown=*/true, editorSize);
+  RenderEditorFrameWithMouse(bottomEdge, /*mouseDown=*/true, editorSize);
+
+  EXPECT_TRUE(editor.hasSelection());
 }
 
 }  // namespace donner::editor

--- a/donner/editor/tests/TextInspectorPanel_tests.cc
+++ b/donner/editor/tests/TextInspectorPanel_tests.cc
@@ -84,6 +84,16 @@ TEST_F(TextInspectorPanelTest, RendersSelectedTextUnderConcurrentDomWithoutCrash
   EXPECT_EQ(app.selectedElements().size(), 1u);
 }
 
+TEST_F(TextInspectorPanelTest, RenderWithNoLiveAppIsNoOp) {
+  TextInspectorPanel panel;
+
+  ImGui::NewFrame();
+  ImGui::Begin("##text_inspector_null_app", nullptr, ImGuiWindowFlags_NoSavedSettings);
+  EXPECT_FALSE(panel.render(nullptr, /*nowSeconds=*/0.0));
+  ImGui::End();
+  ImGui::Render();
+}
+
 TEST_F(TextInspectorPanelTest, ClearingTrackedTextSelectionCommitsNoCleanMutation) {
   EditorApp app;
   ASSERT_TRUE(app.loadFromString(std::string(kTextDoc)));

--- a/donner/editor/tests/UndoTimeline_tests.cc
+++ b/donner/editor/tests/UndoTimeline_tests.cc
@@ -176,6 +176,36 @@ TEST(UndoTimelineTest, TransactionBeginCommitAppendsEntry) {
   EXPECT_EQ(timeline.entryCount(), 1u);
 }
 
+TEST(UndoTimelineTest, NestedTransactionKeepsOutermostEntry) {
+  auto doc = ParseOrDie();
+  auto rect = FirstRect(doc);
+
+  UndoTimeline timeline;
+  timeline.beginTransaction("Outer", UndoSnapshot{.element = rect, .transform = Transform2d()});
+  timeline.beginTransaction(
+      "Inner",
+      UndoSnapshot{.element = rect, .transform = Transform2d::Translate(Vector2d(5.0, 0.0))});
+
+  timeline.commitTransaction(
+      UndoSnapshot{.element = rect, .transform = Transform2d::Translate(Vector2d(10.0, 0.0))});
+
+  ASSERT_TRUE(timeline.nextUndoLabel().has_value());
+  EXPECT_EQ(*timeline.nextUndoLabel(), "Outer");
+  EXPECT_EQ(timeline.entryCount(), 1u);
+}
+
+TEST(UndoTimelineTest, CommitWithoutTransactionIsNoOp) {
+  auto doc = ParseOrDie();
+  auto rect = FirstRect(doc);
+
+  UndoTimeline timeline;
+  timeline.commitTransaction(UndoSnapshot{.element = rect, .transform = Transform2d()});
+
+  EXPECT_FALSE(timeline.inTransaction());
+  EXPECT_EQ(timeline.entryCount(), 0u);
+  EXPECT_FALSE(timeline.canUndo());
+}
+
 TEST(UndoTimelineTest, AbortTransactionLeavesNoEntry) {
   auto doc = ParseOrDie();
   auto rect = FirstRect(doc);
@@ -188,6 +218,27 @@ TEST(UndoTimelineTest, AbortTransactionLeavesNoEntry) {
   EXPECT_FALSE(timeline.inTransaction());
   EXPECT_EQ(timeline.entryCount(), 0u);
   EXPECT_FALSE(timeline.canUndo());
+}
+
+TEST(UndoTimelineTest, NextUndoLabelTracksUndoChainCursor) {
+  auto doc = ParseOrDie();
+  auto rect = FirstRect(doc);
+
+  UndoTimeline timeline;
+  timeline.record(
+      "A", UndoSnapshot{.element = rect, .transform = Transform2d()},
+      UndoSnapshot{.element = rect, .transform = Transform2d::Translate(Vector2d(1.0, 0.0))});
+  timeline.record(
+      "B", UndoSnapshot{.element = rect, .transform = Transform2d::Translate(Vector2d(1.0, 0.0))},
+      UndoSnapshot{.element = rect, .transform = Transform2d::Translate(Vector2d(2.0, 0.0))});
+
+  ASSERT_TRUE(timeline.nextUndoLabel().has_value());
+  EXPECT_EQ(*timeline.nextUndoLabel(), "B");
+  ASSERT_TRUE(timeline.undo().has_value());
+  ASSERT_TRUE(timeline.nextUndoLabel().has_value());
+  EXPECT_EQ(*timeline.nextUndoLabel(), "A");
+  ASSERT_TRUE(timeline.undo().has_value());
+  EXPECT_FALSE(timeline.nextUndoLabel().has_value());
 }
 
 TEST(UndoTimelineTest, ClearResetsEverything) {

--- a/donner/editor/tests/ViewportInteractionController_tests.cc
+++ b/donner/editor/tests/ViewportInteractionController_tests.cc
@@ -16,6 +16,39 @@ TEST(ViewportInteractionControllerTest, FrameHistoryTracksLatestAndMax) {
   EXPECT_FLOAT_EQ(controller.frameHistory().max(), 24.0f);
 }
 
+TEST(ViewportInteractionControllerTest, EmptyFrameHistoryAccessorsAndSettersAreNoOps) {
+  ViewportInteractionController controller;
+  FrameCostBreakdown cost;
+  cost.mainFrame.layoutMs = 5.0;
+
+  controller.frameHistory().setLatestBackendMs(8.0f);
+  controller.frameHistory().setLatestFrameCost(cost);
+  controller.frameHistory().setLatestMemorySample(FrameMemorySample{.totalTrackedBytes = 64u});
+
+  EXPECT_FLOAT_EQ(controller.frameHistory().latest(), 0.0f);
+  EXPECT_FLOAT_EQ(controller.frameHistory().latestBackend(), 0.0f);
+  EXPECT_FLOAT_EQ(controller.frameHistory().max(), 0.0f);
+  EXPECT_FLOAT_EQ(controller.frameHistory().lastBackendMs, 0.0f);
+  EXPECT_EQ(controller.frameHistory().latestNonZeroMemorySample().totalTrackedBytes, 0u);
+}
+
+TEST(ViewportInteractionControllerTest, BackendSamplesResetPerFrameButKeepLastNonZeroLatency) {
+  ViewportInteractionController controller;
+
+  controller.noteFrameDelta(16.0f);
+  controller.frameHistory().setLatestBackendMs(0.0f);
+  EXPECT_FLOAT_EQ(controller.frameHistory().latestBackend(), 0.0f);
+  EXPECT_FLOAT_EQ(controller.frameHistory().lastBackendMs, 0.0f);
+
+  controller.frameHistory().setLatestBackendMs(7.5f);
+  EXPECT_FLOAT_EQ(controller.frameHistory().latestBackend(), 7.5f);
+  EXPECT_FLOAT_EQ(controller.frameHistory().lastBackendMs, 7.5f);
+
+  controller.noteFrameDelta(17.0f);
+  EXPECT_FLOAT_EQ(controller.frameHistory().latestBackend(), 0.0f);
+  EXPECT_FLOAT_EQ(controller.frameHistory().lastBackendMs, 7.5f);
+}
+
 TEST(ViewportInteractionControllerTest, FrameHistoryTracksProfilerCostForLatestFrame) {
   ViewportInteractionController controller;
 
@@ -164,6 +197,25 @@ TEST(ViewportInteractionControllerTest, ApplyZoomUsesViewportCenterMath) {
   EXPECT_NEAR(documentBefore.y, documentAfter.y, 1e-9);
 }
 
+TEST(ViewportInteractionControllerTest, PaneLayoutAndDevicePixelRatioUpdateState) {
+  ViewportInteractionController controller;
+  const Box2d initialDocumentViewBox = controller.viewport().documentViewBox;
+
+  controller.updatePaneLayout(Vector2d(4.0, 5.0), Vector2d(300.0, 200.0), std::nullopt);
+  EXPECT_EQ(controller.viewport().paneOrigin, Vector2d(4.0, 5.0));
+  EXPECT_EQ(controller.viewport().paneSize, Vector2d(300.0, 200.0));
+  EXPECT_EQ(controller.viewport().documentViewBox, initialDocumentViewBox);
+
+  controller.updatePaneLayout(Vector2d(6.0, 7.0), Vector2d(400.0, 250.0),
+                              Box2d::FromXYWH(10.0, 20.0, 30.0, 40.0));
+  EXPECT_EQ(controller.viewport().paneOrigin, Vector2d(6.0, 7.0));
+  EXPECT_EQ(controller.viewport().paneSize, Vector2d(400.0, 250.0));
+  EXPECT_EQ(controller.viewport().documentViewBox, Box2d::FromXYWH(10.0, 20.0, 30.0, 40.0));
+
+  controller.updateDevicePixelRatio(2.5);
+  EXPECT_DOUBLE_EQ(controller.viewport().devicePixelRatio, 2.5);
+}
+
 TEST(ViewportInteractionControllerTest, MousePanReportsViewportChange) {
   ViewportInteractionController controller;
   controller.viewport().paneOrigin = Vector2d::Zero();
@@ -180,6 +232,29 @@ TEST(ViewportInteractionControllerTest, MousePanReportsViewportChange) {
 
   EXPECT_NEAR(controller.viewport().panScreenPoint.x, 108.0, 1e-9);
   EXPECT_NEAR(controller.viewport().panScreenPoint.y, 96.0, 1e-9);
+}
+
+TEST(ViewportInteractionControllerTest, MiddleMousePanStartsWithoutHoverOrSpaceAndStopsOnRelease) {
+  ViewportInteractionController controller;
+  controller.viewport().paneOrigin = Vector2d::Zero();
+  controller.viewport().paneSize = Vector2d(200.0, 200.0);
+  controller.viewport().documentViewBox = Box2d::FromXYWH(0.0, 0.0, 200.0, 200.0);
+  EXPECT_TRUE(controller.resetToActualSize());
+
+  EXPECT_FALSE(controller.updatePanState(/*paneHovered=*/false, /*spaceHeld=*/false,
+                                         /*middleDown=*/true, /*leftDown=*/false,
+                                         ImVec2(25.0f, 25.0f)));
+  EXPECT_TRUE(controller.panning());
+
+  EXPECT_TRUE(controller.updatePanState(/*paneHovered=*/false, /*spaceHeld=*/false,
+                                        /*middleDown=*/true, /*leftDown=*/false,
+                                        ImVec2(30.0f, 35.0f)));
+  EXPECT_TRUE(controller.panning());
+
+  EXPECT_FALSE(controller.updatePanState(/*paneHovered=*/false, /*spaceHeld=*/false,
+                                         /*middleDown=*/false, /*leftDown=*/false,
+                                         ImVec2(30.0f, 35.0f)));
+  EXPECT_FALSE(controller.panning());
 }
 
 TEST(ViewportInteractionControllerTest, PanCursorShowsForSpacePanModeOrActivePan) {
@@ -263,6 +338,35 @@ TEST(ViewportInteractionControllerTest, ConsumeScrollEventsReportsNoChangeWhenMo
   EXPECT_NEAR(controller.viewport().panScreenPoint.y, 100.0, 1e-9);
 }
 
+TEST(ViewportInteractionControllerTest, ConsumeScrollEventsClearsIgnoredEventsWhilePanning) {
+  ViewportInteractionController controller;
+  controller.viewport().paneOrigin = Vector2d::Zero();
+  controller.viewport().paneSize = Vector2d(200.0, 200.0);
+  controller.viewport().documentViewBox = Box2d::FromXYWH(0.0, 0.0, 200.0, 200.0);
+  EXPECT_TRUE(controller.resetToActualSize());
+  ASSERT_FALSE(controller.updatePanState(/*paneHovered=*/false, /*spaceHeld=*/false,
+                                         /*middleDown=*/true, /*leftDown=*/false,
+                                         ImVec2(10.0f, 10.0f)));
+  ASSERT_TRUE(controller.panning());
+
+  std::vector<RenderPaneScrollEvent> events = {
+      RenderPaneScrollEvent{
+          .scrollDelta = Vector2d(0.0, 2.0),
+          .cursorScreen = Vector2d(100.0, 100.0),
+          .zoomModifierHeld = true,
+      },
+  };
+
+  const ScrollConsumptionResult result =
+      controller.consumeScrollEvents(events, Box2d::FromXYWH(0.0, 0.0, 200.0, 200.0),
+                                     /*modalCapturingInput=*/false, /*wheelZoomStep=*/1.1,
+                                     /*panPixelsPerScrollUnit=*/10.0);
+
+  EXPECT_FALSE(result.viewportChanged);
+  EXPECT_FALSE(result.zoomChanged);
+  EXPECT_TRUE(events.empty());
+}
+
 TEST(ViewportInteractionControllerTest, PendingClickBuffersAndClears) {
   ViewportInteractionController controller;
   MouseModifiers modifiers;
@@ -276,6 +380,156 @@ TEST(ViewportInteractionControllerTest, PendingClickBuffersAndClears) {
 
   controller.clearPendingClick();
   EXPECT_FALSE(controller.pendingClick().has_value());
+}
+
+TEST(ViewportStateTest, ZeroZoomScreenToDocumentFallsBackToAnchor) {
+  ViewportState viewport;
+  viewport.zoom = 0.0;
+  viewport.panDocPoint = Vector2d(12.0, 34.0);
+  viewport.panScreenPoint = Vector2d(100.0, 200.0);
+
+  EXPECT_EQ(viewport.screenToDocument(Vector2d(300.0, 400.0)), Vector2d(12.0, 34.0));
+
+  const Box2d documentBox = viewport.screenToDocument(Box2d::FromXYWH(1.0, 2.0, 3.0, 4.0));
+  EXPECT_EQ(documentBox.topLeft, Vector2d(12.0, 34.0));
+  EXPECT_EQ(documentBox.bottomRight, Vector2d(12.0, 34.0));
+}
+
+TEST(ViewportStateTest, RasterViewportClampsDegenerateDocumentAxis) {
+  ViewportState viewport;
+  viewport.documentViewBox = Box2d::FromXYWH(10.0, 20.0, 0.0, 50.0);
+  viewport.zoom = 2.0;
+  viewport.devicePixelRatio = 2.0;
+  viewport.paneSize = Vector2d(100.0, 100.0);
+
+  const EditorRasterViewport raster = viewport.rasterViewport();
+
+  EXPECT_EQ(raster.semanticCanvasSizePx, Vector2i(1, 200));
+  EXPECT_EQ(raster.outputSizePx, Vector2i(1, 200));
+  EXPECT_FALSE(raster.viewportBounded);
+}
+
+TEST(ViewportStateTest, RasterViewportDoesNotViewportBoundWithoutUsablePane) {
+  struct Case {
+    Vector2d paneSize;
+    double devicePixelRatio;
+  };
+
+  constexpr Case kCases[] = {
+      {Vector2d(0.0, 100.0), 1.0},
+      {Vector2d(100.0, 0.0), 1.0},
+      {Vector2d(100.0, 100.0), 0.0},
+  };
+
+  for (const Case& testCase : kCases) {
+    ViewportState viewport;
+    viewport.documentViewBox = Box2d::FromXYWH(0.0, 0.0, 1000.0, 1000.0);
+    viewport.zoom = 20.0;
+    viewport.devicePixelRatio = testCase.devicePixelRatio;
+    viewport.paneSize = testCase.paneSize;
+
+    const EditorRasterViewport raster = viewport.rasterViewport();
+
+    EXPECT_FALSE(raster.viewportBounded);
+  }
+}
+
+TEST(ViewportStateTest, RasterViewportBoundsTallDocumentTargets) {
+  ViewportState viewport;
+  viewport.documentViewBox = Box2d::FromXYWH(0.0, 0.0, 100.0, 1000.0);
+  viewport.zoom = 10.0;
+  viewport.devicePixelRatio = 1.0;
+  viewport.paneOrigin = Vector2d(10.0, 20.0);
+  viewport.paneSize = Vector2d(200.0, 120.0);
+  viewport.resetTo100Percent();
+  viewport.zoomAround(10.0, viewport.paneCenter());
+
+  const EditorRasterViewport raster = viewport.rasterViewport();
+
+  EXPECT_TRUE(raster.viewportBounded);
+  EXPECT_EQ(raster.outputSizePx, Vector2i(200 + 2 * ViewportState::kHighZoomRasterMarginScreenPx,
+                                          120 + 2 * ViewportState::kHighZoomRasterMarginScreenPx));
+}
+
+TEST(ViewportStateTest, SelectedPrewarmExpandsViewportBoundedRaster) {
+  ViewportState viewport;
+  viewport.documentViewBox = Box2d::FromXYWH(0.0, 0.0, 2000.0, 2000.0);
+  viewport.zoom = 12.0;
+  viewport.devicePixelRatio = 1.0;
+  viewport.paneOrigin = Vector2d(50.0, 60.0);
+  viewport.paneSize = Vector2d(100.0, 80.0);
+  viewport.resetTo100Percent();
+  viewport.zoomAround(12.0, viewport.paneCenter());
+
+  const EditorRasterViewport base = viewport.rasterViewport();
+  const EditorRasterViewport prewarm = viewport.selectedPrewarmRasterViewport();
+
+  ASSERT_TRUE(base.viewportBounded);
+  EXPECT_TRUE(prewarm.viewportBounded);
+  EXPECT_GT(prewarm.outputSizePx.x, base.outputSizePx.x);
+  EXPECT_GT(prewarm.outputSizePx.y, base.outputSizePx.y);
+}
+
+TEST(ViewportStateTest, SelectedPrewarmKeepsMaxSizedViewportBoundedRaster) {
+  ViewportState viewport;
+  viewport.documentViewBox = Box2d::FromXYWH(0.0, 0.0, 100000.0, 100000.0);
+  viewport.zoom = 1.0;
+  viewport.devicePixelRatio = 1.0;
+  viewport.paneSize = Vector2d(10000.0, 10000.0);
+
+  const EditorRasterViewport base = viewport.rasterViewport();
+  const EditorRasterViewport prewarm = viewport.selectedPrewarmRasterViewport();
+
+  ASSERT_TRUE(base.viewportBounded);
+  EXPECT_EQ(base.outputSizePx,
+            Vector2i(ViewportState::kMaxCanvasDim, ViewportState::kMaxCanvasDim));
+  EXPECT_EQ(prewarm.outputSizePx, base.outputSizePx);
+  EXPECT_EQ(prewarm.documentRect, base.documentRect);
+}
+
+TEST(ViewportStateTest, SelectedPrewarmKeepsViewportBoundedRasterWhenScaleIsNonPositive) {
+  ViewportState viewport;
+  viewport.documentViewBox = Box2d(Vector2d(1000.0, 1000.0), Vector2d(0.0, 0.0));
+  viewport.zoom = -10.0;
+  viewport.devicePixelRatio = 1.0;
+  viewport.paneSize = Vector2d(100.0, 100.0);
+
+  const EditorRasterViewport base = viewport.rasterViewport();
+  const EditorRasterViewport prewarm = viewport.selectedPrewarmRasterViewport();
+
+  ASSERT_TRUE(base.viewportBounded);
+  EXPECT_EQ(prewarm.outputSizePx, base.outputSizePx);
+  EXPECT_EQ(prewarm.documentRect, base.documentRect);
+}
+
+TEST(ViewportStateTest, OverviewInfillReturnsBaseForDegenerateInputs) {
+  ViewportState zeroDocument;
+  zeroDocument.documentViewBox = Box2d::FromXYWH(0.0, 0.0, 0.0, 0.0);
+  zeroDocument.zoom = 4.0;
+  zeroDocument.devicePixelRatio = 2.0;
+  EXPECT_EQ(zeroDocument.overviewInfillRasterViewport().outputSizePx,
+            zeroDocument.rasterViewport().outputSizePx);
+
+  ViewportState zeroDpr;
+  zeroDpr.documentViewBox = Box2d::FromXYWH(0.0, 0.0, 100.0, 100.0);
+  zeroDpr.zoom = 4.0;
+  zeroDpr.devicePixelRatio = 0.0;
+  EXPECT_EQ(zeroDpr.overviewInfillRasterViewport().outputSizePx,
+            zeroDpr.rasterViewport().outputSizePx);
+}
+
+TEST(ViewportStateTest, OverviewInfillUsesFullDocumentAtCappedScale) {
+  ViewportState viewport;
+  viewport.documentViewBox = Box2d::FromXYWH(10.0, 20.0, 5000.0, 1000.0);
+  viewport.zoom = 20.0;
+  viewport.devicePixelRatio = 2.0;
+  viewport.paneSize = Vector2d(200.0, 200.0);
+
+  const EditorRasterViewport overview = viewport.overviewInfillRasterViewport();
+
+  EXPECT_FALSE(overview.viewportBounded);
+  EXPECT_EQ(overview.documentRect, viewport.documentViewBox);
+  EXPECT_EQ(overview.outputSizePx, Vector2i(ViewportState::kOverviewInfillMaxCanvasDim, 307));
 }
 
 }  // namespace

--- a/donner/editor/tests/ViewportSvgExport_tests.cc
+++ b/donner/editor/tests/ViewportSvgExport_tests.cc
@@ -7,6 +7,7 @@
 #include <limits>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "donner/base/Box.h"
 #include "donner/base/ParseDiagnostic.h"
@@ -326,6 +327,71 @@ TEST(ViewportSvgExportTest, RootAttributeEscapingIsDeterministic) {
   EXPECT_TRUE(Contains(result.value, "data-owner=\"Bob&apos;s\"")) << result.value;
 }
 
+TEST(ViewportSvgExportTest, RootAttributeGreaterThanAndMissingDimensionsAreNormalized) {
+  const SVGDocument doc = ParseOrDie(
+      "<svg id=\"root\" data-arrow=\"a>b\" xmlns=\"http://www.w3.org/2000/svg\">"
+      "<rect width=\"10\" height=\"10\"/>"
+      "</svg>");
+  const ViewportState viewport = IdentityViewport();
+  const Recti renderPaneRect(Vector2i(0, 0), Vector2i(100, 100));
+
+  const Result<std::string, std::string> result =
+      ExportViewportAsSvg(doc, viewport, renderPaneRect, ViewportExportOptions{});
+
+  ASSERT_TRUE(result.ok()) << result.error;
+  EXPECT_TRUE(Contains(result.value, "data-arrow=\"a&gt;b\"")) << result.value;
+  EXPECT_TRUE(Contains(result.value, "width=\"100\"")) << result.value;
+  EXPECT_TRUE(Contains(result.value, "height=\"100\"")) << result.value;
+  EXPECT_TRUE(Contains(result.value, "viewBox=\"0 0 100 100\"")) << result.value;
+}
+
+TEST(ViewportSvgExportTest, RootScannerSkipsPrologCommentsDoctypeAndProcessingInstructions) {
+  const SVGDocument doc = ParseOrDie(
+      "<?xml version=\"1.0\"?>"
+      "<!-- <svg-not-root/> -->"
+      "<?editor instruction?>"
+      "<!DOCTYPE svg>"
+      "<svg width=\"100\" height=\"100\" xmlns=\"http://www.w3.org/2000/svg\">"
+      "<rect id=\"real-root-child\" width=\"10\" height=\"10\"/>"
+      "</svg>");
+  const ViewportState viewport = IdentityViewport();
+  const Recti renderPaneRect(Vector2i(0, 0), Vector2i(100, 100));
+
+  const Result<std::string, std::string> result =
+      ExportViewportAsSvg(doc, viewport, renderPaneRect, ViewportExportOptions{});
+
+  ASSERT_TRUE(result.ok()) << result.error;
+  EXPECT_TRUE(Contains(result.value, "real-root-child")) << result.value;
+  EXPECT_FALSE(Contains(result.value, "svg-not-root")) << result.value;
+}
+
+TEST(ViewportSvgExportTest, RootScannerAcceptsSvgNameTerminators) {
+  const std::vector<std::string> sources = {
+      "<svg xmlns=\"http://www.w3.org/2000/svg\"><rect id=\"plain\" width=\"10\" "
+      "height=\"10\"/></svg>",
+      "<svg\twidth='100'\nheight = \"80\"\r\nviewBox = '0 0 100 80' "
+      "xmlns='http://www.w3.org/2000/svg'><rect id='tabbed' width='10' "
+      "height='10'/></svg>",
+      "<svg\nxmlns=\"http://www.w3.org/2000/svg\" width=\"100\" height=\"80\">"
+      "<rect id=\"newline\" width=\"10\" height=\"10\"/></svg>",
+      "<svg\rxmlns=\"http://www.w3.org/2000/svg\" width=\"100\" height=\"80\">"
+      "<rect id=\"carriage\" width=\"10\" height=\"10\"/></svg>",
+      "<svg xmlns=\"http://www.w3.org/2000/svg\"/>",
+  };
+
+  for (const std::string& source : sources) {
+    SCOPED_TRACE(source);
+    const SVGDocument doc = ParseOrDie(source);
+    const Result<std::string, std::string> result = ExportViewportAsSvg(
+        doc, IdentityViewport(), Recti(Vector2i(0, 0), Vector2i(100, 80)), ViewportExportOptions{});
+
+    ASSERT_TRUE(result.ok()) << result.error;
+    EXPECT_TRUE(Contains(result.value, "<svg")) << result.value;
+    EXPECT_TRUE(Contains(result.value, "width=\"100\"")) << result.value;
+    EXPECT_TRUE(Contains(result.value, "height=\"80\"")) << result.value;
+  }
+}
+
 TEST(ViewportSvgExportTest, SelfClosingRootExportsEmptyContentGroup) {
   const SVGDocument doc =
       ParseOrDie("<svg width=\"100\" height=\"100\" xmlns=\"http://www.w3.org/2000/svg\"/>");
@@ -352,6 +418,128 @@ TEST(ViewportSvgExportTest, NonFiniteViewportValuesFormatAsZero) {
 
   ASSERT_TRUE(result.ok()) << result.error;
   EXPECT_TRUE(Contains(result.value, "viewBox=\"0 0 0 0\"")) << result.value;
+}
+
+TEST(ViewportSvgExportTest, NegativeZeroViewportValuesFormatAsZero) {
+  const SVGDocument doc = ParseOrDie(kSelfContainedSvg);
+  ViewportState viewport = IdentityViewport();
+  viewport.panDocPoint = Vector2d(-0.0, -0.0);
+  const Recti renderPaneRect(Vector2i(0, 0), Vector2i(0, 0));
+
+  const Result<std::string, std::string> result =
+      ExportViewportAsSvg(doc, viewport, renderPaneRect, ViewportExportOptions{});
+
+  ASSERT_TRUE(result.ok()) << result.error;
+  EXPECT_TRUE(Contains(result.value, "viewBox=\"0 0 0 0\"")) << result.value;
+  EXPECT_FALSE(Contains(result.value, "-0")) << result.value;
+}
+
+TEST(ViewportSvgExportTest, FractionalViewportValuesTrimTrailingZeros) {
+  const SVGDocument doc = ParseOrDie(kSelfContainedSvg);
+  const ViewportState viewport =
+      MakeViewport(/*zoom=*/3.0, /*panDocPoint=*/Vector2d(0.5, 0.25),
+                   /*panScreenPoint=*/Vector2d(0.0, 0.0),
+                   /*paneOrigin=*/Vector2d(0.0, 0.0), /*paneSize=*/Vector2d(1.0, 2.0));
+  const Recti renderPaneRect(Vector2i(0, 0), Vector2i(1, 2));
+
+  const Result<std::string, std::string> result =
+      ExportViewportAsSvg(doc, viewport, renderPaneRect, ViewportExportOptions{});
+
+  ASSERT_TRUE(result.ok()) << result.error;
+  EXPECT_TRUE(Contains(result.value, "viewBox=\"0.5 0.25 0.333333 0.666667\"")) << result.value;
+}
+
+TEST(ViewportSvgExportTest, SourceWithoutRootSvgIsRejected) {
+  SVGDocument doc =
+      ParseOrDie("<svg width=\"100\" height=\"100\" xmlns=\"http://www.w3.org/2000/svg\"/>");
+  const std::size_t nameOffset = doc.source().find("svg");
+  ASSERT_NE(nameOffset, std::string_view::npos);
+
+  const xml::ApplySourceEditResult edit = doc.applySourceEdit(xml::XMLEditIntent{
+      .range = SourceRange{FileOffset::Offset(nameOffset), FileOffset::Offset(nameOffset + 3)},
+      .replacement = "g",
+      .sourceVersion = doc.sourceVersion(),
+  });
+  ASSERT_TRUE(edit.applied);
+  ASSERT_TRUE(edit.diagnostic.has_value());
+
+  const Result<std::string, std::string> result = ExportViewportAsSvg(
+      doc, IdentityViewport(), Recti(Vector2i(0, 0), Vector2i(100, 100)), ViewportExportOptions{});
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_TRUE(Contains(result.error, "root <svg>")) << result.error;
+}
+
+TEST(ViewportSvgExportTest, RootScannerSkipsSvgPrefixedElementNamesBeforeRealRoot) {
+  SVGDocument doc =
+      ParseOrDie("<svg width=\"100\" height=\"100\" xmlns=\"http://www.w3.org/2000/svg\"/>");
+
+  const xml::ApplySourceEditResult edit = doc.applySourceEdit(xml::XMLEditIntent{
+      .range = SourceRange{FileOffset::Offset(0), FileOffset::Offset(0)},
+      .replacement = "<svgx id=\"not-root\"/>",
+      .sourceVersion = doc.sourceVersion(),
+  });
+  ASSERT_TRUE(edit.applied);
+
+  const Result<std::string, std::string> result = ExportViewportAsSvg(
+      doc, IdentityViewport(), Recti(Vector2i(0, 0), Vector2i(100, 100)), ViewportExportOptions{});
+
+  ASSERT_TRUE(result.ok()) << result.error;
+  EXPECT_FALSE(Contains(result.value, "not-root")) << result.value;
+  EXPECT_TRUE(Contains(result.value, "width=\"100\"")) << result.value;
+}
+
+TEST(ViewportSvgExportTest, MissingRootCloseTagUsesSourceRemainderAsBody) {
+  SVGDocument doc = ParseOrDie(
+      "<svg width=\"100\" height=\"100\" xmlns=\"http://www.w3.org/2000/svg\">"
+      "<rect id=\"kept\" width=\"10\" height=\"10\"/></svg>");
+  const std::size_t closeOffset = doc.source().find("</svg>");
+  ASSERT_NE(closeOffset, std::string_view::npos);
+
+  const xml::ApplySourceEditResult edit = doc.applySourceEdit(xml::XMLEditIntent{
+      .range = SourceRange{FileOffset::Offset(closeOffset), FileOffset::Offset(closeOffset + 6)},
+      .replacement = "",
+      .sourceVersion = doc.sourceVersion(),
+  });
+  ASSERT_TRUE(edit.applied);
+  ASSERT_TRUE(edit.diagnostic.has_value());
+
+  const Result<std::string, std::string> result = ExportViewportAsSvg(
+      doc, IdentityViewport(), Recti(Vector2i(0, 0), Vector2i(100, 100)), ViewportExportOptions{});
+
+  ASSERT_TRUE(result.ok()) << result.error;
+  EXPECT_TRUE(Contains(result.value, "id=\"kept\"")) << result.value;
+}
+
+TEST(ViewportSvgExportTest, HrefLikeTextWithoutQuotedValueIsIgnored) {
+  const SVGDocument doc = ParseOrDie(
+      "<svg width=\"100\" height=\"100\" xmlns=\"http://www.w3.org/2000/svg\">"
+      "<text>href = https://example.com/not-an-attribute.png</text>"
+      "<text>href</text>"
+      "</svg>");
+  const ViewportState viewport = IdentityViewport();
+  const Recti renderPaneRect(Vector2i(0, 0), Vector2i(100, 100));
+
+  const Result<std::string, std::string> result =
+      ExportViewportAsSvg(doc, viewport, renderPaneRect, ViewportExportOptions{});
+
+  ASSERT_TRUE(result.ok()) << result.error;
+  EXPECT_TRUE(Contains(result.value, "not-an-attribute.png")) << result.value;
+}
+
+TEST(ViewportSvgExportTest, ExternalReferenceScannerHandlesWhitespaceAndUppercaseSchemes) {
+  const SVGDocument doc = ParseOrDie(
+      "<svg width=\"100\" height=\"100\" xmlns=\"http://www.w3.org/2000/svg\">"
+      "<image href \n = \r\n \" \tHTTPS://example.com/image.png\" width=\"10\" height=\"10\"/>"
+      "</svg>");
+  const ViewportState viewport = IdentityViewport();
+  const Recti renderPaneRect(Vector2i(0, 0), Vector2i(100, 100));
+
+  const Result<std::string, std::string> result =
+      ExportViewportAsSvg(doc, viewport, renderPaneRect, ViewportExportOptions{});
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_TRUE(Contains(result.error, "HTTPS://example.com/image.png")) << result.error;
 }
 
 // --- Milestone 7: overlay serialization ---------------------------------

--- a/donner/editor/tests/XmlAutocomplete_tests.cc
+++ b/donner/editor/tests/XmlAutocomplete_tests.cc
@@ -236,6 +236,16 @@ TEST(XmlAutocomplete, StyleAttributeSecondPropertyAfterSemicolonResetsSegment) {
   EXPECT_TRUE(HasSuggestion(BuildXmlAutocompleteSuggestions(context), "stroke"));
 }
 
+TEST(XmlAutocomplete, SingleQuotedStyleAttributeSuggestsProperties) {
+  constexpr std::string_view kSource = "<svg><rect style='Fi'/></svg>";
+  const std::size_t cursorOffset = kSource.find("Fi") + 2;
+  const XmlAutocompleteContext context = DetectXmlAutocompleteContext(kSource, cursorOffset);
+
+  EXPECT_EQ(context.kind, XmlAutocompleteContextKind::StyleValue);
+  EXPECT_EQ(context.prefix, "Fi");
+  EXPECT_TRUE(HasSuggestion(BuildXmlAutocompleteSuggestions(context), "fill"));
+}
+
 TEST(XmlAutocomplete, StyleAttributeSecondPropertyAfterBraceAndWhitespaceResetsSegment) {
   constexpr std::string_view kSource = "<svg><style>rect {\n\tfill: red;\r\n st</style></svg>";
   const std::size_t cursorOffset = kSource.find("st</style>");
@@ -292,6 +302,17 @@ TEST(XmlAutocomplete, StylePropertyNameReplacementStopsAfterCssNameCharacters) {
   EXPECT_EQ(context.replaceEndOffset, kSource.find("_name"));
 }
 
+TEST(XmlAutocomplete, StylePropertyReplacementAcceptsAllCssNameCharacterClasses) {
+  constexpr std::string_view kSource = "<svg><style>a { Ab9-c: red }</style></svg>";
+  const std::size_t cursorOffset = kSource.find("Ab9") + 1;
+  const XmlAutocompleteContext context = DetectXmlAutocompleteContext(kSource, cursorOffset);
+
+  EXPECT_EQ(context.kind, XmlAutocompleteContextKind::StyleValue);
+  EXPECT_EQ(context.prefix, "A");
+  EXPECT_EQ(context.replaceStartOffset, kSource.find("Ab9-c"));
+  EXPECT_EQ(context.replaceEndOffset, kSource.find(": red"));
+}
+
 TEST(XmlAutocomplete, StyleAttributeCursorOnQuotesUsesTokenBoundaryContexts) {
   constexpr std::string_view kSource = R"(<svg><rect style="fill"/></svg>)";
 
@@ -320,6 +341,35 @@ TEST(XmlAutocomplete, NonStyleAttributeValueOffersNoSuggestions) {
 
   EXPECT_EQ(context.kind, XmlAutocompleteContextKind::Unknown);
   EXPECT_TRUE(BuildXmlAutocompleteSuggestions(context).empty());
+}
+
+TEST(XmlAutocomplete, ClosedStyleElementReturnsToTextContentContext) {
+  constexpr std::string_view kSource = "<svg><style>rect { fill:red }</style>fi</svg>";
+  const std::size_t cursorOffset = kSource.find("fi</svg>") + 2;
+  const XmlAutocompleteContext context = DetectXmlAutocompleteContext(kSource, cursorOffset);
+
+  EXPECT_EQ(context.kind, XmlAutocompleteContextKind::TextContent);
+  EXPECT_TRUE(BuildXmlAutocompleteSuggestions(context).empty());
+}
+
+TEST(XmlAutocomplete, DeclarationDoctypeAndEntityBeforeCursorAreIgnored) {
+  constexpr std::string_view kSource = R"(<?xml version="1.0"?><!DOCTYPE svg><svg>&amp;<rect )";
+  const XmlAutocompleteContext context = DetectXmlAutocompleteContext(kSource, kSource.size());
+
+  EXPECT_EQ(context.kind, XmlAutocompleteContextKind::AttributeName);
+  EXPECT_TRUE(HasSuggestion(BuildXmlAutocompleteSuggestions(context), "class"));
+}
+
+TEST(XmlAutocomplete, CursorOnSelfCloseAndCommentTokensIsUnknown) {
+  constexpr std::string_view kSelfClose = "<svg><rect/>";
+  const XmlAutocompleteContext selfClose =
+      DetectXmlAutocompleteContext(kSelfClose, kSelfClose.size());
+  EXPECT_EQ(selfClose.kind, XmlAutocompleteContextKind::Unknown);
+
+  constexpr std::string_view kComment = "<svg><!--note--></svg>";
+  const XmlAutocompleteContext comment =
+      DetectXmlAutocompleteContext(kComment, kComment.find("note"));
+  EXPECT_EQ(comment.kind, XmlAutocompleteContextKind::Unknown);
 }
 
 // --- Element name partial replacement bounds -------------------------------

--- a/donner/svg/compositor/CompositorController_tests.cc
+++ b/donner/svg/compositor/CompositorController_tests.cc
@@ -174,6 +174,25 @@ TEST_F(CompositorControllerTest, PromoteSameEntityTwiceSucceeds) {
   EXPECT_EQ(compositor.layerCount(), 1u);
 }
 
+TEST_F(CompositorControllerTest, PromoteSameEntityWithInteractionGateDisabledStaysExplicit) {
+  SVGDocument document = makeDocument(R"svg(
+    <rect id="target" width="10" height="10" fill="red" />
+  )svg");
+
+  auto target = document.querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  const Entity entity = target->unsafeEntityHandle().entity();
+
+  CompositorConfig config;
+  config.autoPromoteInteractions = false;
+  CompositorController compositor(document, renderer_, config);
+
+  EXPECT_TRUE(compositor.promoteEntity(entity, InteractionHint::Selection));
+  EXPECT_TRUE(compositor.promoteEntity(entity, InteractionHint::ActiveDrag));
+  EXPECT_TRUE(compositor.isPromoted(entity));
+  EXPECT_EQ(compositor.layerCount(), 1u);
+}
+
 TEST_F(CompositorControllerTest, PromoteInvalidEntityFails) {
   SVGDocument document = makeDocument(R"svg(
     <rect width="10" height="10" fill="red" />
@@ -2021,6 +2040,73 @@ TEST_F(CompositorControllerTest, BuildStructuralEntityRemapRejectsStructuralMism
   EXPECT_TRUE(BuildStructuralEntityRemap(oldDocument, tagMismatch).empty());
   EXPECT_TRUE(BuildStructuralEntityRemap(oldDocument, idMismatch).empty());
   EXPECT_TRUE(BuildStructuralEntityRemap(oldDocument, childCountMismatch).empty());
+}
+
+TEST_F(CompositorControllerTest, RemapAfterStructuralReplaceFailsWhenActiveHintIsMissing) {
+  SVGDocument document = makeDocument(R"svg(
+    <rect id="target" width="10" height="10" fill="red" />
+  )svg");
+
+  auto target = document.querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  const Entity entity = target->unsafeEntityHandle().entity();
+
+  CompositorController compositor(document, renderer_);
+  ASSERT_TRUE(compositor.promoteEntity(entity));
+
+  EXPECT_FALSE(compositor.remapAfterStructuralReplace({}));
+
+  compositor.resetAllLayers();
+}
+
+TEST_F(CompositorControllerTest, RemapAfterStructuralReplaceFailsWhenMandatoryLayerIsMissing) {
+  SVGDocument document = makeDocument(R"svg(
+    <defs>
+      <filter id="blur"><feGaussianBlur stdDeviation="2" /></filter>
+    </defs>
+    <g id="target" filter="url(#blur)">
+      <rect width="10" height="10" fill="red" />
+    </g>
+  )svg");
+
+  auto target = document.querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  const Entity entity = target->unsafeEntityHandle().entity();
+
+  CompositorController compositor(document, renderer_);
+  configureMockForCaching();
+  compositor.renderFrame(RenderViewport{kTestSvgDefaultSize});
+  ASSERT_NE(compositor.findLayerForTest(entity), nullptr)
+      << "test setup requires a mandatory filter layer";
+
+  EXPECT_FALSE(compositor.remapAfterStructuralReplace({}));
+
+  compositor.resetAllLayers();
+}
+
+TEST_F(CompositorControllerTest, RemapAfterStructuralReplaceFailsWhenLayerRangeIsPartial) {
+  SVGDocument document = makeDocument(R"svg(
+    <g id="group">
+      <rect id="child" width="10" height="10" fill="red" />
+    </g>
+  )svg");
+
+  ParseWarningSink warningSink;
+  RendererUtils::prepareDocumentForRendering(document, /*verbose=*/false, warningSink);
+
+  auto group = document.querySelector("#group");
+  ASSERT_TRUE(group.has_value());
+  const Entity groupEntity = group->unsafeEntityHandle().entity();
+
+  CompositorController compositor(document, renderer_);
+  ASSERT_TRUE(compositor.promoteEntity(groupEntity));
+  const CompositorLayer* layer = compositor.findLayerForTest(groupEntity);
+  ASSERT_NE(layer, nullptr);
+  ASSERT_NE(layer->lastEntity(), groupEntity) << "test setup needs a widened group paint range";
+
+  EXPECT_FALSE(compositor.remapAfterStructuralReplace({{groupEntity, groupEntity}}));
+
+  compositor.resetAllLayers();
 }
 
 }  // namespace donner::svg::compositor

--- a/donner/svg/parser/tests/AttributeParser_tests.cc
+++ b/donner/svg/parser/tests/AttributeParser_tests.cc
@@ -1667,6 +1667,138 @@ TEST(AttributeParserTest, ExperimentalFilterInvalidNumberBranchesPreserveDefault
   EXPECT_DOUBLE_EQ(offset.dy, 0.0);
 }
 
+TEST(AttributeParserTest, InvalidShapeGradientAndTextPathAttributesPreserveDefaults) {
+  ParseWarningSink warningSink;
+  auto maybeDocument = SVGParser::ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <linearGradient id="linear" x1="bad" y1="bad" x2="bad" y2="bad"/>
+        <radialGradient id="radial" cx="bad" cy="bad" r="bad" fx="bad" fy="bad" fr="bad"/>
+      </defs>
+      <line id="line" x1="bad" y1="bad" x2="bad" y2="bad"/>
+      <text>
+        <a id="link-spacing-glyphs" textLength="bad" lengthAdjust="spacingAndGlyphs">link</a>
+      </text>
+      <text>
+        <tspan id="span-spacing" textLength="bad" lengthAdjust="spacing">span</tspan>
+      </text>
+      <text>
+        <textPath id="bad-path-text" href="#path" startOffset="bad" method="bad" side="bad"
+                  spacing="bad" x="bad" y="bad" dx="bad" dy="bad" rotate="bad">path</textPath>
+      </text>
+    </svg>
+  )",
+                                           warningSink);
+  ASSERT_TRUE(maybeDocument.hasResult());
+  auto document = std::move(maybeDocument).result();
+
+  auto line = QueryElement<SVGLineElement>(document, "#line");
+  EXPECT_EQ(line.x1(), Lengthd());
+  EXPECT_EQ(line.y1(), Lengthd());
+  EXPECT_EQ(line.x2(), Lengthd());
+  EXPECT_EQ(line.y2(), Lengthd());
+
+  auto linear = QueryElement<SVGLinearGradientElement>(document, "#linear");
+  EXPECT_EQ(linear.x1(), std::nullopt);
+  EXPECT_EQ(linear.y1(), std::nullopt);
+  EXPECT_EQ(linear.x2(), std::nullopt);
+  EXPECT_EQ(linear.y2(), std::nullopt);
+
+  auto radial = QueryElement<SVGRadialGradientElement>(document, "#radial");
+  EXPECT_EQ(radial.cx(), std::nullopt);
+  EXPECT_EQ(radial.cy(), std::nullopt);
+  EXPECT_EQ(radial.r(), std::nullopt);
+  EXPECT_EQ(radial.fx(), std::nullopt);
+  EXPECT_EQ(radial.fy(), std::nullopt);
+  EXPECT_EQ(radial.fr(), std::nullopt);
+
+  auto link = QueryElement<SVGAElement>(document, "#link-spacing-glyphs");
+  EXPECT_EQ(link.textLength(), std::nullopt);
+  EXPECT_EQ(link.lengthAdjust(), LengthAdjust::SpacingAndGlyphs);
+
+  auto span = QueryElement<SVGTSpanElement>(document, "#span-spacing");
+  EXPECT_EQ(span.textLength(), std::nullopt);
+  EXPECT_EQ(span.lengthAdjust(), LengthAdjust::Spacing);
+
+  auto pathText = QueryElement<SVGTextPathElement>(document, "#bad-path-text");
+  EXPECT_EQ(pathText.startOffset(), std::nullopt);
+  EXPECT_THAT(pathText.xList(), testing::IsEmpty());
+  EXPECT_THAT(pathText.yList(), testing::IsEmpty());
+  EXPECT_THAT(pathText.dxList(), testing::IsEmpty());
+  EXPECT_THAT(pathText.dyList(), testing::IsEmpty());
+  EXPECT_THAT(pathText.rotateList(), testing::IsEmpty());
+
+  const auto& pathTextComponent =
+      QueryComponent<components::TextPathComponent>(document, "#bad-path-text");
+  EXPECT_EQ(pathTextComponent.method, components::TextPathMethod::Align);
+  EXPECT_EQ(pathTextComponent.side, components::TextPathSide::Left);
+  EXPECT_EQ(pathTextComponent.spacing, components::TextPathSpacing::Exact);
+}
+
+TEST(AttributeParserTest, ExperimentalFilterSeparatorAndInvalidEnumFallbackBranches) {
+  auto document = ParseSVGExperimental(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <filter id="f">
+          <feComponentTransfer>
+            <feFuncR id="func-separators" type="bad" tableValues="&#10;,&#9;0&#13;,1 "/>
+          </feComponentTransfer>
+          <feColorMatrix id="cm-separators" values="&#10;,&#9;1&#13;,2 "/>
+          <feMorphology id="morph-second-bad" radius="5 bad"/>
+          <feDisplacementMap id="disp-invalid-channels" xChannelSelector="bad"
+                             yChannelSelector="bad"/>
+          <feConvolveMatrix id="conv-order-second-bad" order="2 bad"
+                            kernelMatrix="&#10;,&#9;1&#13;,2 " edgeMode="bad"
+                            preserveAlpha="bad"/>
+          <feTurbulence id="turb-second-bad" baseFrequency="0.25 bad" type="bad"
+                        stitchTiles="bad"/>
+        </filter>
+      </defs>
+    </svg>
+  )");
+
+  const auto funcView = document.registry().view<components::FEFuncComponent>();
+  const components::FEFuncComponent* func = nullptr;
+  for (const Entity entity : funcView) {
+    const auto& candidate = funcView.get<components::FEFuncComponent>(entity);
+    if (candidate.channel == components::FEFuncComponent::Channel::R) {
+      func = &candidate;
+      break;
+    }
+  }
+  ASSERT_NE(func, nullptr);
+  EXPECT_EQ(func->type, components::FEFuncComponent::FuncType::Identity);
+  EXPECT_THAT(func->tableValues, testing::ElementsAre(0.0, 1.0));
+
+  EXPECT_THAT(QueryComponent<components::FEColorMatrixComponent>(document, "#cm-separators").values,
+              testing::ElementsAre(1.0, 2.0));
+
+  const auto& morphology =
+      QueryComponent<components::FEMorphologyComponent>(document, "#morph-second-bad");
+  EXPECT_DOUBLE_EQ(morphology.radiusX, 5.0);
+  EXPECT_DOUBLE_EQ(morphology.radiusY, 5.0);
+
+  const auto& displacement =
+      QueryComponent<components::FEDisplacementMapComponent>(document, "#disp-invalid-channels");
+  EXPECT_EQ(displacement.xChannelSelector, components::FEDisplacementMapComponent::Channel::A);
+  EXPECT_EQ(displacement.yChannelSelector, components::FEDisplacementMapComponent::Channel::A);
+
+  const auto& convolve =
+      QueryComponent<components::FEConvolveMatrixComponent>(document, "#conv-order-second-bad");
+  EXPECT_EQ(convolve.orderX, 2);
+  EXPECT_EQ(convolve.orderY, 2);
+  EXPECT_THAT(convolve.kernelMatrix, testing::ElementsAre(1.0, 2.0));
+  EXPECT_EQ(convolve.edgeMode, components::FEConvolveMatrixComponent::EdgeMode::Duplicate);
+  EXPECT_FALSE(convolve.preserveAlpha);
+
+  const auto& turbulence =
+      QueryComponent<components::FETurbulenceComponent>(document, "#turb-second-bad");
+  EXPECT_DOUBLE_EQ(turbulence.baseFrequencyX, 0.25);
+  EXPECT_DOUBLE_EQ(turbulence.baseFrequencyY, 0.25);
+  EXPECT_EQ(turbulence.type, components::FETurbulenceComponent::Type::Turbulence);
+  EXPECT_FALSE(turbulence.stitchTiles);
+}
+
 TEST(AttributeParserTest, TextAnchorAndPathAttributes) {
   ParseWarningSink warningSink;
   auto maybeDocument = SVGParser::ParseSVG(R"(

--- a/donner/svg/properties/tests/PropertyRegistry_tests.cc
+++ b/donner/svg/properties/tests/PropertyRegistry_tests.cc
@@ -1269,6 +1269,107 @@ TEST(PropertyRegistry, DisplayAnchorVisibilityOverflowAndPointerEventsErrors) {
   }
 }
 
+TEST(PropertyRegistry, EmptyComponentDeclarationsReportPropertySpecificErrors) {
+  const std::pair<const char*, const char*> cases[] = {
+      {"display", "Invalid display value"},
+      {"text-anchor", "Invalid text-anchor value"},
+      {"isolation", "Invalid isolation value"},
+      {"image-rendering", "Invalid image-rendering value"},
+      {"paint-order", "Invalid paint-order value"},
+      {"dominant-baseline", "Invalid dominant-baseline value"},
+      {"alignment-baseline", "Invalid alignment-baseline value"},
+      {"mix-blend-mode", "Invalid mix-blend-mode value"},
+      {"writing-mode", "Invalid writing-mode value"},
+      {"visibility", "Invalid display value"},
+      {"overflow", "Invalid overflow value"},
+      {"fill-rule", "Invalid fill rule"},
+      {"color-interpolation-filters", "Invalid color-interpolation-filters value"},
+      {"clip-rule", "Invalid clip-rule value"},
+      {"stroke-linecap", "Invalid linecap"},
+      {"stroke-linejoin", "Invalid linejoin"},
+      {"stroke-miterlimit", "Invalid number"},
+      {"pointer-events", "Invalid pointer-events"},
+  };
+
+  for (const auto& [property, reason] : cases) {
+    PropertyRegistry registry;
+    EXPECT_THAT(registry.parseProperty(css::Declaration(property, {}), Specificity()),
+                ParseErrorIs(reason))
+        << property;
+  }
+}
+
+TEST(PropertyRegistry, NonIdentSingleTokenDeclarationsReportPropertySpecificErrors) {
+  const std::pair<const char*, const char*> cases[] = {
+      {"display", "Invalid display value"},
+      {"text-anchor", "Invalid text-anchor value"},
+      {"isolation", "Invalid isolation value"},
+      {"image-rendering", "Invalid image-rendering value"},
+      {"paint-order", "Invalid paint-order value"},
+      {"dominant-baseline", "Invalid dominant-baseline value"},
+      {"alignment-baseline", "Invalid alignment-baseline value"},
+      {"mix-blend-mode", "Invalid mix-blend-mode value"},
+      {"writing-mode", "Invalid writing-mode value"},
+      {"visibility", "Invalid display value"},
+      {"overflow", "Invalid overflow value"},
+      {"fill-rule", "Invalid fill rule"},
+      {"color-interpolation-filters", "Invalid color-interpolation-filters value"},
+      {"clip-rule", "Invalid clip-rule value"},
+      {"stroke-linecap", "Invalid linecap"},
+      {"stroke-linejoin", "Invalid linejoin"},
+      {"pointer-events", "Invalid pointer-events"},
+  };
+
+  const ComponentValue number(Token(Token::Number(1.0, "1", css::NumberType::Integer), 0));
+  for (const auto& [property, reason] : cases) {
+    PropertyRegistry registry;
+    EXPECT_THAT(registry.parseProperty(css::Declaration(property, {number}), Specificity()),
+                ParseErrorIs(reason))
+        << property;
+  }
+}
+
+TEST(PropertyRegistry, PaintOrderGrammar) {
+  {
+    const std::pair<const char*, PaintOrder> cases[] = {
+        {"normal", PaintOrder{}},
+        {"stroke",
+         PaintOrder{{PaintComponent::Stroke, PaintComponent::Fill, PaintComponent::Markers}}},
+        {"markers fill",
+         PaintOrder{{PaintComponent::Markers, PaintComponent::Fill, PaintComponent::Stroke}}},
+        {"stroke markers fill",
+         PaintOrder{{PaintComponent::Stroke, PaintComponent::Markers, PaintComponent::Fill}}},
+    };
+
+    for (const auto& [value, expected] : cases) {
+      PropertyRegistry registry;
+      registry.parseStyle(std::string("paint-order: ") + value);
+      EXPECT_THAT(registry.paintOrder.get(), Optional(expected)) << value;
+    }
+  }
+
+  {
+    const char* invalidCases[] = {
+        "paint-order: ",
+        "paint-order: fill fill",
+        "paint-order: stroke stroke",
+        "paint-order: markers markers",
+        "paint-order: fill stroke markers fill",
+        "paint-order: fill / stroke",
+        "paint-order: bogus",
+        "paint-order: normal fill",
+    };
+
+    for (const char* property : invalidCases) {
+      PropertyRegistry registry;
+      css::Declaration declaration = css::CSS::ParseStyleAttribute(property).at(0);
+      EXPECT_THAT(registry.parseProperty(declaration, Specificity()),
+                  ParseErrorIs("Invalid paint-order value"))
+          << property;
+    }
+  }
+}
+
 TEST(PropertyRegistry, PaintReferenceTransformOriginAndFilterFunctionEdges) {
   {
     PropertyRegistry registry;
@@ -1662,6 +1763,12 @@ TEST(PropertyRegistry, TransformOriginStrokeMiterlimitAndFilterEdgeCases) {
 
   {
     PropertyRegistry registry;
+    css::Declaration declaration = css::CSS::ParseStyleAttribute("stroke-miterlimit: 1 2").at(0);
+    EXPECT_THAT(registry.parseProperty(declaration, Specificity()), ParseErrorIs("Invalid number"));
+  }
+
+  {
+    PropertyRegistry registry;
     registry.parseStyle("filter: hue-rotate(200grad) hue-rotate(3.141592653589793rad)");
     const auto& effects = (*registry.filter.getStoredValue());
     EXPECT_THAT(effects, testing::ElementsAre(FilterHueRotateIs(180.0, 0.0),
@@ -1688,6 +1795,30 @@ TEST(PropertyRegistry, TransformOriginStrokeMiterlimitAndFilterEdgeCases) {
     const auto& shadow =
         (*registry.filter.getStoredValue()).front().get<FilterEffect::DropShadow>();
     EXPECT_EQ(shadow.color, Color(RGBA(0xFF, 0, 0, 0xFF)));
+  }
+
+  {
+    PropertyRegistry registry;
+    css::Declaration declaration =
+        css::CSS::ParseStyleAttribute("filter: drop-shadow(1% 2px)").at(0);
+    EXPECT_THAT(registry.parseProperty(declaration, Specificity()),
+                ParseErrorIs("Expected offset-x for drop-shadow"));
+  }
+
+  {
+    PropertyRegistry registry;
+    css::Declaration declaration =
+        css::CSS::ParseStyleAttribute("filter: drop-shadow(1px 2%)").at(0);
+    EXPECT_THAT(registry.parseProperty(declaration, Specificity()),
+                ParseErrorIs("Expected offset-y for drop-shadow"));
+  }
+
+  {
+    PropertyRegistry registry;
+    css::Declaration declaration =
+        css::CSS::ParseStyleAttribute("filter: drop-shadow(1px 2px 3%)").at(0);
+    EXPECT_THAT(registry.parseProperty(declaration, Specificity()),
+                ParseErrorIs("Unexpected extra values in drop-shadow()"));
   }
 
   {

--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -337,6 +337,21 @@ donner_cc_test(
 )
 
 donner_cc_test(
+    name = "text_engine_scripted_tests",
+    srcs = ["TextEngineScripted_tests.cc"],
+    deps = [
+        "//donner/base/xml/components",
+        "//donner/svg/components/layout:components",
+        "//donner/svg/components/style:components",
+        "//donner/svg/components/text:components",
+        "//donner/svg/text:text_backend",
+        "//donner/svg/text:text_engine",
+        "//donner/svg/text:text_layout_params",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
     name = "text_engine_helpers_tests",
     srcs = [
         "MockTextBackend.h",

--- a/donner/svg/renderer/tests/TerminalImageViewer_tests.cc
+++ b/donner/svg/renderer/tests/TerminalImageViewer_tests.cc
@@ -293,12 +293,68 @@ TEST(TerminalImageViewerCapabilityDetectionTest, DetectsTrueColorFromColorterm) 
 TEST(TerminalImageViewerCapabilityDetectionTest, FallsBackTo256ColorWhenUnknown) {
   ScopedEnvVar colorTerm("COLORTERM", "");
   ScopedEnvVar termProgram("TERM_PROGRAM", "xterm");
+  ScopedEnvVar lcTerminal("LC_TERMINAL", "");
+  ScopedEnvVar forceIterm("DONNER_FORCE_ITERM_IMAGES", "");
   ScopedEnvVar term("TERM", "xterm-256color");
 
   TerminalImageViewerConfig config = TerminalImageViewer::DetectConfigFromEnvironment();
 
   EXPECT_FALSE(config.useTrueColor);
   EXPECT_FALSE(config.enableITermInlineImages);
+}
+
+TEST(TerminalImageViewerCapabilityDetectionTest, ForceItermImagesEnablesInlineAndTrueColor) {
+  ScopedEnvVar forceIterm("DONNER_FORCE_ITERM_IMAGES", "true");
+  ScopedEnvVar colorTerm("COLORTERM", "");
+  ScopedEnvVar term("TERM", "xterm-256color");
+  ScopedEnvVar termProgram("TERM_PROGRAM", "xterm");
+  ScopedEnvVar lcTerminal("LC_TERMINAL", "");
+
+  const TerminalImageViewerConfig config = TerminalImageViewer::DetectConfigFromEnvironment();
+
+  EXPECT_TRUE(config.enableITermInlineImages);
+  EXPECT_TRUE(config.useTrueColor);
+}
+
+TEST(TerminalImageViewerCapabilityDetectionTest, ForceItermImagesFalseKeepsColorDetection) {
+  ScopedEnvVar forceIterm("DONNER_FORCE_ITERM_IMAGES", "0");
+  ScopedEnvVar colorTerm("COLORTERM", "24BIT");
+  ScopedEnvVar term("TERM", "xterm-256color");
+  ScopedEnvVar termProgram("TERM_PROGRAM", "xterm");
+  ScopedEnvVar lcTerminal("LC_TERMINAL", "");
+
+  const TerminalImageViewerConfig config = TerminalImageViewer::DetectConfigFromEnvironment();
+
+  EXPECT_FALSE(config.enableITermInlineImages);
+  EXPECT_TRUE(config.useTrueColor);
+}
+
+TEST(TerminalImageViewerCapabilityDetectionTest, DetectsItermFromLcTerminalAndTermTrueColor) {
+  {
+    ScopedEnvVar forceIterm("DONNER_FORCE_ITERM_IMAGES", "");
+    ScopedEnvVar colorTerm("COLORTERM", "");
+    ScopedEnvVar term("TERM", "xterm-256color");
+    ScopedEnvVar termProgram("TERM_PROGRAM", "xterm");
+    ScopedEnvVar lcTerminal("LC_TERMINAL", "iTerm2");
+
+    const TerminalImageViewerConfig config = TerminalImageViewer::DetectConfigFromEnvironment();
+
+    EXPECT_TRUE(config.enableITermInlineImages);
+    EXPECT_TRUE(config.useTrueColor);
+  }
+
+  {
+    ScopedEnvVar forceIterm("DONNER_FORCE_ITERM_IMAGES", "");
+    ScopedEnvVar colorTerm("COLORTERM", "");
+    ScopedEnvVar term("TERM", "xterm-truecolor");
+    ScopedEnvVar termProgram("TERM_PROGRAM", "xterm");
+    ScopedEnvVar lcTerminal("LC_TERMINAL", "");
+
+    const TerminalImageViewerConfig config = TerminalImageViewer::DetectConfigFromEnvironment();
+
+    EXPECT_FALSE(config.enableITermInlineImages);
+    EXPECT_TRUE(config.useTrueColor);
+  }
 }
 
 TEST(TerminalImageViewerCapabilityDetectionTest, AutoDetectionInfluencesRenderingDefaults) {
@@ -425,6 +481,60 @@ TEST(TerminalImageViewerTest, DetectTerminalSizeFromEnv) {
   const TerminalSize size = TerminalImageViewer::DetectTerminalSize();
   EXPECT_EQ(size.columns, 123);
   EXPECT_EQ(size.rows, 45);
+}
+
+TEST(TerminalImageViewerTest, SamplingOverscaledSinglePixelRepeatsLastAvailableSample) {
+  std::vector<uint8_t> pixels;
+  pixels.reserve(4);
+  appendPixel(pixels, makeColor(0x80, 0x40, 0x20));
+  const TerminalImageView view{pixels, 1, 1, 1};
+
+  TerminalImageViewer viewer;
+  const TerminalImage sampled = viewer.sampleImage(
+      view, {.pixelMode = TerminalPixelMode::kHalfPixel, .scale = 2.0, .verticalScaleFactor = 0.5});
+
+  ASSERT_EQ(sampled.columns, 2);
+  ASSERT_EQ(sampled.rows, 1);
+  EXPECT_EQ(sampled.cellAt(0, 0).half.upper, makeColor(0x80, 0x40, 0x20));
+  EXPECT_EQ(sampled.cellAt(0, 0).half.lower, makeColor(0, 0, 0, 0));
+  EXPECT_EQ(sampled.cellAt(1, 0).half.upper, makeColor(0x80, 0x40, 0x20));
+  EXPECT_EQ(sampled.cellAt(1, 0).half.lower, makeColor(0, 0, 0, 0));
+}
+
+TEST(TerminalImageViewerTest, AutoScaleUsesTerminalBounds) {
+  ScopedEnvVar columns("COLUMNS", "2");
+  ScopedEnvVar rows("LINES", "1");
+
+  std::vector<uint8_t> pixels;
+  pixels.reserve(4 * 4 * 4);
+  for (int i = 0; i < 16; ++i) {
+    appendPixel(pixels, makeColor(static_cast<uint8_t>(0x10 + i), 0x20, 0x30));
+  }
+  const TerminalImageView view{pixels, 4, 4, 4};
+
+  TerminalImageViewer viewer;
+  const TerminalImage sampled =
+      viewer.sampleImage(view, {.pixelMode = TerminalPixelMode::kQuarterPixel, .autoScale = true});
+
+  ASSERT_EQ(sampled.columns, 2);
+  ASSERT_EQ(sampled.rows, 1);
+  EXPECT_EQ(sampled.cellAt(0, 0).quarter.topLeft, makeColor(0x10, 0x20, 0x30));
+  EXPECT_EQ(sampled.cellAt(1, 0).quarter.bottomRight, makeColor(0x17, 0x20, 0x30));
+}
+
+TEST(TerminalImageViewerRenderTest, CompositesTransparentAndPartialAlphaHalfPixels) {
+  std::vector<uint8_t> pixels;
+  pixels.reserve(1 * 2 * 4);
+  appendPixel(pixels, makeColor(0x00, 0x00, 0x00, 0x00));
+  appendPixel(pixels, makeColor(0x00, 0x00, 0x00, 0x80));
+
+  const TerminalImageView view{pixels, 1, 2, 1};
+
+  TerminalImageViewer viewer;
+  std::ostringstream stream;
+  viewer.render(view, stream, {.pixelMode = TerminalPixelMode::kHalfPixel, .scale = 1.0});
+
+  EXPECT_EQ(stream.str(), "\x1b[38;2;204;204;204m\x1b[48;2;102;102;102m▀\x1b[0m\n");
 }
 
 TEST(TerminalImageViewerRenderTest, FuzzesRandomFramesAcrossModes) {

--- a/donner/svg/renderer/tests/TextEngineHelpers_tests.cc
+++ b/donner/svg/renderer/tests/TextEngineHelpers_tests.cc
@@ -3,6 +3,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <iterator>
+
+#include "donner/base/Utf8.h"
 #include "donner/svg/SVGDocument.h"
 #include "donner/svg/components/text/ComputedTextComponent.h"
 #include "donner/svg/parser/SVGParser.h"
@@ -221,6 +224,34 @@ TEST(BuildByteIndexMappingsTest, JoinerAndVariationSelectorShareBaseIndex) {
 
   EXPECT_THAT(m.byteToCharIdx, ElementsAre(0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 1u));
   EXPECT_THAT(m.byteToRawCpIdx, ElementsAre(0u, 1u, 1u, 1u, 2u, 3u, 3u, 3u, 4u));
+}
+
+TEST(BuildByteIndexMappingsTest, RepresentativeNonSpacingRangesShareBaseIndex) {
+  std::string text;
+  std::vector<size_t> offsets;
+  auto append = [&](char32_t cp) {
+    offsets.push_back(text.size());
+    Utf8::Append(cp, std::back_inserter(text));
+  };
+
+  append(U'A');
+  for (const char32_t cp :
+       {U'\u0300', U'\u0483', U'\u0591', U'\u0610', U'\u064B', U'\u0670',    U'\u06D6',
+        U'\u0730', U'\u0E31', U'\u0E34', U'\u0EB1', U'\u0EB4', U'\u1AB0',    U'\u1DC0',
+        U'\u20D0', U'\uFE20', U'\u200C', U'\u034F', U'\uFE00', U'\U000E0100'}) {
+    append(cp);
+  }
+  append(U'\u200D');
+  append(U'B');
+  const size_t cOffsetIndex = offsets.size();
+  append(U'C');
+
+  const auto m = buildByteIndexMappings(text);
+
+  for (size_t i = 0; i < cOffsetIndex; ++i) {
+    EXPECT_EQ(m.byteToCharIdx[offsets[i]], 0u) << "offset index " << i;
+  }
+  EXPECT_EQ(m.byteToCharIdx[offsets[cOffsetIndex]], 1u);
 }
 
 TEST(BuildByteIndexMappingsTest, SupplementaryCharacterConsumeTwoIndices) {
@@ -679,6 +710,45 @@ TEST_F(TextEngineLayoutTest, PerCharacterXPositioning) {
   EXPECT_THAT(runs,
               ElementsAre(RunGlyphsAre(ElementsAre(GlyphXPositionIs(DoubleNear(10.0, 0.1)),
                                                    GlyphXPositionIs(DoubleNear(50.0, 0.1))))));
+}
+
+TEST_F(TextEngineLayoutTest, SupplementaryCharacterLowSurrogateCoordinatesSetNextPen) {
+  ON_CALL(*mockBackend_, shapeRun(testing::_, testing::_, testing::_, testing::_, testing::_,
+                                  testing::_, testing::_, testing::_))
+      .WillByDefault([](FontHandle, float, std::string_view text, size_t offset, size_t length,
+                        bool, FontVariant, bool) {
+        TextBackend::ShapedRun run;
+        run.glyphs.push_back(TextBackend::ShapedGlyph{
+            .glyphIndex = 1,
+            .xAdvance = 0.0,
+            .cluster = static_cast<uint32_t>(offset),
+        });
+        if (offset + 4 < text.size() && length > 4) {
+          run.glyphs.push_back(TextBackend::ShapedGlyph{
+              .glyphIndex = 2,
+              .xAdvance = 10.0,
+              .cluster = static_cast<uint32_t>(offset + 4),
+          });
+        }
+        return run;
+      });
+
+  components::ComputedTextComponent text;
+  auto span = makeSpan(
+      "\xF0\x9F\x98\x81"
+      "A");
+  span.xList = {Lengthd(10.0, Lengthd::Unit::None), Lengthd(70.0, Lengthd::Unit::None)};
+  span.yList = {Lengthd(20.0, Lengthd::Unit::None), Lengthd(80.0, Lengthd::Unit::None)};
+  text.spans.push_back(std::move(span));
+
+  const auto runs = engine_->layout(text, makeParams());
+
+  ASSERT_EQ(runs.size(), 1u);
+  ASSERT_EQ(runs[0].glyphs.size(), 2u);
+  EXPECT_NEAR(runs[0].glyphs[0].xPosition, 10.0, 0.1);
+  EXPECT_NEAR(runs[0].glyphs[0].yPosition, 20.0, 0.1);
+  EXPECT_NEAR(runs[0].glyphs[1].xPosition, 70.0, 0.1);
+  EXPECT_NEAR(runs[0].glyphs[1].yPosition, 80.0, 0.1);
 }
 
 TEST_F(TextEngineLayoutTest, TextAnchorMiddleShifts) {

--- a/donner/svg/renderer/tests/TextEngineScripted_tests.cc
+++ b/donner/svg/renderer/tests/TextEngineScripted_tests.cc
@@ -1,0 +1,655 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <iterator>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "donner/base/Utf8.h"
+#include "donner/base/xml/components/TreeComponent.h"
+#include "donner/css/FontFace.h"
+#include "donner/svg/components/layout/ViewBoxComponent.h"
+#include "donner/svg/components/style/ComputedStyleComponent.h"
+#include "donner/svg/components/text/TextComponent.h"
+#include "donner/svg/components/text/TextRootComponent.h"
+#include "donner/svg/text/TextBackend.h"
+#include "donner/svg/text/TextEngine.h"
+#include "donner/svg/text/TextLayoutParams.h"
+
+namespace donner::svg {
+namespace {
+
+components::ComputedTextComponent::TextSpan MakeSpan(const std::string& str) {
+  components::ComputedTextComponent::TextSpan span;
+  span.text = RcString(str);
+  span.start = 0;
+  span.end = str.size();
+  span.startsNewChunk = true;
+  return span;
+}
+
+TextLayoutParams MakeTextParams(double fontSize) {
+  TextLayoutParams params;
+  params.fontSize = Lengthd(fontSize, Lengthd::Unit::Px);
+  params.viewBox = Box2d(Vector2d::Zero(), Vector2d(200, 200));
+  params.fontMetrics = FontMetrics();
+  return params;
+}
+
+class ScriptedTextBackend : public TextBackend {
+public:
+  bool reverseClusters = false;
+  std::optional<SubSuperMetrics> subSuper;
+
+  FontVMetrics fontVMetrics(FontHandle /*font*/) const override {
+    return FontVMetrics{
+        .ascent = 1000,
+        .descent = -200,
+        .lineGap = 0,
+        .xHeight = 500,
+    };
+  }
+
+  float scaleForPixelHeight(FontHandle /*font*/, float pixelHeight) const override {
+    return pixelHeight / 1200.0f;
+  }
+
+  float scaleForEmToPixels(FontHandle /*font*/, float pixelHeight) const override {
+    return pixelHeight / 1000.0f;
+  }
+
+  std::optional<UnderlineMetrics> underlineMetrics(FontHandle /*font*/) const override {
+    return UnderlineMetrics{.position = -100.0, .thickness = 50.0};
+  }
+
+  std::optional<UnderlineMetrics> strikeoutMetrics(FontHandle /*font*/) const override {
+    return UnderlineMetrics{.position = 300.0, .thickness = 40.0};
+  }
+
+  std::optional<SubSuperMetrics> subSuperMetrics(FontHandle /*font*/) const override {
+    return subSuper;
+  }
+
+  Path glyphOutline(FontHandle /*font*/, int glyphIndex, float /*scale*/) const override {
+    if (glyphIndex == 0) {
+      return Path();
+    }
+    return PathBuilder().addRect(Box2d::FromXYWH(0.0, -8.0, 6.0, 8.0)).build();
+  }
+
+  bool isBitmapOnly(FontHandle /*font*/) const override { return false; }
+
+  bool isCursive(uint32_t codepoint) const override { return codepoint == U'c'; }
+
+  bool hasSmallCapsFeature(FontHandle /*font*/) const override { return false; }
+
+  std::optional<BitmapGlyph> bitmapGlyph(FontHandle /*font*/, int /*glyphIndex*/,
+                                         float /*scale*/) const override {
+    return std::nullopt;
+  }
+
+  ShapedRun shapeRun(FontHandle /*font*/, float /*fontSizePx*/, std::string_view spanText,
+                     size_t byteOffset, size_t byteLength, bool /*isVertical*/,
+                     FontVariant fontVariant, bool forceLogicalOrder) const override {
+    ShapedRun run;
+    const size_t byteEnd = std::min(spanText.size(), byteOffset + byteLength);
+    for (size_t pos = byteOffset; pos < byteEnd;) {
+      const size_t cluster = pos;
+      const auto [codepoint, codepointLength] = Utf8::NextCodepointLenient(spanText.substr(pos));
+      pos += static_cast<size_t>(std::max(codepointLength, 1));
+
+      TextBackend::ShapedGlyph glyph;
+      glyph.glyphIndex = static_cast<int>(codepoint % 997u) + 1;
+      glyph.xAdvance = 10.0;
+      glyph.yAdvance = 12.0;
+      if (codepoint == 0x0301) {
+        glyph.xAdvance = 0.0;
+      }
+      glyph.xKern = run.glyphs.empty() ? 0.0 : 1.0;
+      glyph.yKern = run.glyphs.empty() ? 0.0 : 2.0;
+      glyph.cluster = static_cast<uint32_t>(cluster);
+      glyph.fontSizeScale = fontVariant == FontVariant::SmallCaps ? 0.8f : 1.0f;
+      if (codepoint >= 0x2E80) {
+        glyph.xOffset = 2.0;
+        glyph.yOffset = 3.0;
+      }
+      run.glyphs.push_back(glyph);
+    }
+
+    if (reverseClusters && !forceLogicalOrder) {
+      std::reverse(run.glyphs.begin(), run.glyphs.end());
+    }
+    return run;
+  }
+
+  double crossSpanKern(FontHandle /*prevFont*/, float /*prevSizePx*/, FontHandle /*curFont*/,
+                       float /*curSizePx*/, uint32_t /*prevCodepoint*/, uint32_t /*curCodepoint*/,
+                       bool isVertical) const override {
+    return isVertical ? 4.0 : 3.0;
+  }
+};
+
+TextEngine MakeScriptedEngine(Registry& registry, FontManager& fontManager,
+                              bool reverseClusters = false,
+                              std::optional<SubSuperMetrics> subSuper = std::nullopt) {
+  auto backend = std::make_unique<ScriptedTextBackend>();
+  backend->reverseClusters = reverseClusters;
+  backend->subSuper = subSuper;
+  return TextEngine(fontManager, registry, std::move(backend));
+}
+
+}  // namespace
+
+TEST(TextEngineScriptedTest, AddFontFacesOnlyRegistersNewBatchEntries) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  std::vector<css::FontFace> faces;
+  css::FontFace first;
+  first.familyName = RcString("First");
+  faces.push_back(first);
+  css::FontFace second;
+  second.familyName = RcString("Second");
+  faces.push_back(second);
+
+  engine.addFontFaces(faces);
+  EXPECT_EQ(fontManager.numFaces(), 2u);
+
+  engine.addFontFaces(faces);
+  EXPECT_EQ(fontManager.numFaces(), 2u);
+
+  css::FontFace third;
+  third.familyName = RcString("Third");
+  faces.push_back(third);
+  engine.addFontFaces(faces);
+  EXPECT_EQ(fontManager.numFaces(), 3u);
+}
+
+TEST(TextEngineScriptedTest, CachedGeometryReturnsEmptyCacheWhenRequiredComponentsAreMissing) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  const Entity root = registry.create();
+  registry.emplace<donner::components::TreeComponent>(root, xml::XMLQualifiedNameRef("text"));
+  registry.emplace<components::TextRootComponent>(root);
+
+  const EntityHandle rootHandle(registry, root);
+  EXPECT_EQ(engine.getNumberOfChars(rootHandle), 0);
+  EXPECT_TRUE(engine.computedGlyphPaths(rootHandle).empty());
+  EXPECT_EQ(engine.computedObjectBoundingBox(rootHandle), Box2d());
+}
+
+TEST(TextEngineScriptedTest, CachedGeometryBuildsCharacterGlyphAndBoundsData) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  const Entity root = registry.create();
+  registry.emplace<donner::components::TreeComponent>(root, xml::XMLQualifiedNameRef("text"));
+  registry.emplace<components::TextRootComponent>(root);
+  registry.emplace<components::ComputedViewBoxComponent>(root,
+                                                         Box2d::FromXYWH(0.0, 0.0, 200.0, 100.0));
+
+  components::TextComponent textComponent;
+  textComponent.text = RcString(
+      "A\xCC\x81"
+      "B");
+  textComponent.textLength = Lengthd(72.0, Lengthd::Unit::None);
+  textComponent.lengthAdjust = LengthAdjust::SpacingAndGlyphs;
+  registry.emplace<components::TextComponent>(root, textComponent);
+
+  components::ComputedTextComponent computedText;
+  auto span = MakeSpan(
+      "A\xCC\x81"
+      "B");
+  span.sourceEntity = root;
+  span.rotateList = {30.0, 30.0};
+  computedText.spans.push_back(std::move(span));
+  registry.emplace<components::ComputedTextComponent>(root, computedText);
+
+  components::ComputedStyleComponent style;
+  style.properties.emplace();
+  registry.emplace<components::ComputedStyleComponent>(root, style);
+
+  const EntityHandle rootHandle(registry, root);
+  EXPECT_EQ(engine.getNumberOfChars(rootHandle), 2);
+
+  const std::vector<Path> glyphPaths = engine.computedGlyphPaths(rootHandle);
+  EXPECT_EQ(glyphPaths.size(), 3u);
+  EXPECT_GT(engine.computedInkBounds(rootHandle).width(), 0.0);
+  EXPECT_GT(engine.computedObjectBoundingBox(rootHandle).height(), 0.0);
+  EXPECT_GT(engine.getComputedTextLength(rootHandle), 0.0);
+  EXPECT_GT(engine.getSubStringLength(rootHandle, 0, 1), 0.0);
+  EXPECT_EQ(engine.getStartPositionOfChar(rootHandle, 2), Vector2d());
+  EXPECT_NE(engine.getRotationOfChar(rootHandle, 0), 0.0);
+  EXPECT_TRUE(engine.getExtentOfChar(rootHandle, 0).width() > 0.0);
+  EXPECT_EQ(engine.getCharNumAtPosition(rootHandle, engine.getStartPositionOfChar(rootHandle, 0)),
+            0);
+}
+
+TEST(TextEngineScriptedTest, HorizontalLayoutCoversChunkAndSpanPositioningBranches) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  components::ComputedTextComponent text;
+  auto span1 = MakeSpan("A");
+  span1.xList = {Lengthd(10.0, Lengthd::Unit::None)};
+  span1.yList = {Lengthd(20.0, Lengthd::Unit::None)};
+  span1.dxList = {Lengthd(1.0, Lengthd::Unit::None)};
+  span1.dyList = {Lengthd(2.0, Lengthd::Unit::None)};
+
+  auto span2 = MakeSpan("B c");
+  span2.startsNewChunk = false;
+  span2.xList = {std::nullopt, std::nullopt, Lengthd(80.0, Lengthd::Unit::None)};
+  span2.yList = {std::nullopt, std::nullopt, Lengthd(40.0, Lengthd::Unit::None)};
+  span2.dxList = {std::nullopt, Lengthd(1.0, Lengthd::Unit::None),
+                  Lengthd(2.0, Lengthd::Unit::None)};
+  span2.dyList = {std::nullopt, Lengthd(3.0, Lengthd::Unit::None),
+                  Lengthd(4.0, Lengthd::Unit::None)};
+  span2.rotateList = {5.0, 15.0};
+  span2.letterSpacingPx = 2.0;
+  span2.wordSpacingPx = 5.0;
+
+  text.spans.push_back(std::move(span1));
+  text.spans.push_back(std::move(span2));
+
+  const auto runs = engine.layout(text, MakeTextParams(20.0));
+
+  ASSERT_EQ(runs.size(), 2u);
+  ASSERT_EQ(runs[0].glyphs.size(), 1u);
+  ASSERT_EQ(runs[1].glyphs.size(), 3u);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[0].xPosition, 11.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[0].yPosition, 22.0);
+  EXPECT_DOUBLE_EQ(runs[1].glyphs[0].xPosition, 24.0);
+  EXPECT_DOUBLE_EQ(runs[1].glyphs[1].xPosition, 38.0);
+  EXPECT_DOUBLE_EQ(runs[1].glyphs[2].xPosition, 82.0);
+  EXPECT_DOUBLE_EQ(runs[1].glyphs[2].yPosition, 44.0);
+  EXPECT_DOUBLE_EQ(runs[1].glyphs[0].rotateDegrees, 5.0);
+  EXPECT_DOUBLE_EQ(runs[1].glyphs[1].rotateDegrees, 15.0);
+  EXPECT_DOUBLE_EQ(runs[1].glyphs[2].rotateDegrees, 15.0);
+}
+
+TEST(TextEngineScriptedTest, SupplementaryCoordinateListsUseLowSurrogateSlot) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  std::string textValue = "A";
+  Utf8::Append(U'\U0001F600', std::back_inserter(textValue));
+  textValue += "B";
+
+  components::ComputedTextComponent text;
+  auto span = MakeSpan(textValue);
+  span.xList = {Lengthd(0.0, Lengthd::Unit::None), std::nullopt, std::nullopt,
+                Lengthd(70.0, Lengthd::Unit::None)};
+  span.yList = {Lengthd(0.0, Lengthd::Unit::None), std::nullopt, std::nullopt,
+                Lengthd(90.0, Lengthd::Unit::None)};
+  text.spans.push_back(std::move(span));
+
+  const auto runs = engine.layout(text, MakeTextParams(20.0));
+
+  ASSERT_EQ(runs.size(), 1u);
+  ASSERT_EQ(runs[0].glyphs.size(), 3u);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[0].xPosition, 0.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[1].xPosition, 13.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[2].xPosition, 70.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[2].yPosition, 90.0);
+}
+
+TEST(TextEngineScriptedTest, SupplementaryLowSurrogateCoordinatesApplyToFollowingGlyph) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  std::string textValue;
+  Utf8::Append(U'\U0001F600', std::back_inserter(textValue));
+  textValue += "B";
+
+  components::ComputedTextComponent text;
+  auto span = MakeSpan(textValue);
+  span.xList = {Lengthd(0.0, Lengthd::Unit::None), Lengthd(70.0, Lengthd::Unit::None)};
+  span.yList = {Lengthd(0.0, Lengthd::Unit::None), Lengthd(90.0, Lengthd::Unit::None)};
+  text.spans.push_back(std::move(span));
+
+  const auto runs = engine.layout(text, MakeTextParams(20.0));
+
+  ASSERT_EQ(runs.size(), 1u);
+  ASSERT_EQ(runs[0].glyphs.size(), 2u);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[1].xPosition, 70.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[1].yPosition, 90.0);
+}
+
+TEST(TextEngineScriptedTest, VerticalLayoutCoversSidewaysUprightSpacingAndRotation) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  std::string textValue = "A";
+  Utf8::Append(U'\u65E5', std::back_inserter(textValue));
+  textValue += " ";
+
+  components::ComputedTextComponent text;
+  auto span = MakeSpan(textValue);
+  span.xList = {Lengthd(100.0, Lengthd::Unit::None), Lengthd(110.0, Lengthd::Unit::None)};
+  span.yList = {Lengthd(10.0, Lengthd::Unit::None), Lengthd(40.0, Lengthd::Unit::None)};
+  span.dxList = {Lengthd(1.0, Lengthd::Unit::None), Lengthd(2.0, Lengthd::Unit::None)};
+  span.dyList = {Lengthd(3.0, Lengthd::Unit::None), Lengthd(4.0, Lengthd::Unit::None)};
+  span.rotateList = {7.0, 17.0};
+  span.letterSpacingPx = 2.0;
+  span.wordSpacingPx = 5.0;
+  text.spans.push_back(std::move(span));
+
+  TextLayoutParams params = MakeTextParams(20.0);
+  params.writingMode = WritingMode::VerticalRl;
+  const auto runs = engine.layout(text, params);
+
+  ASSERT_EQ(runs.size(), 1u);
+  ASSERT_EQ(runs[0].glyphs.size(), 3u);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[0].rotateDegrees, 97.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[1].rotateDegrees, 17.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[2].rotateDegrees, 107.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[1].xPosition, 114.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[1].yPosition, 47.0);
+  EXPECT_GT(runs[0].glyphs[2].yPosition, runs[0].glyphs[1].yPosition);
+}
+
+TEST(TextEngineScriptedTest, VerticalLayoutStartsNewChunksForLaterAbsoluteCoordinates) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  components::ComputedTextComponent text;
+  auto span = MakeSpan("ABCD");
+  span.xList = {std::nullopt, Lengthd(50.0, Lengthd::Unit::None), std::nullopt,
+                Lengthd(80.0, Lengthd::Unit::None)};
+  span.yList = {std::nullopt, Lengthd(20.0, Lengthd::Unit::None), std::nullopt,
+                Lengthd(70.0, Lengthd::Unit::None)};
+  text.spans.push_back(std::move(span));
+
+  TextLayoutParams params = MakeTextParams(20.0);
+  params.writingMode = WritingMode::VerticalRl;
+  const auto runs = engine.layout(text, params);
+
+  ASSERT_EQ(runs.size(), 1u);
+  ASSERT_EQ(runs[0].glyphs.size(), 4u);
+  EXPECT_GT(runs[0].glyphs[1].xPosition, runs[0].glyphs[0].xPosition);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[1].yPosition, 20.0);
+  EXPECT_GT(runs[0].glyphs[3].xPosition, runs[0].glyphs[1].xPosition);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[3].yPosition, 70.0);
+}
+
+TEST(TextEngineScriptedTest, RtlChunkYOverrideKeepsVisualGlyphsOnSameBaseline) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager, /*reverseClusters=*/true);
+
+  components::ComputedTextComponent text;
+  auto span = MakeSpan("ABCD");
+  span.xList = {Lengthd(0.0, Lengthd::Unit::None), std::nullopt,
+                Lengthd(50.0, Lengthd::Unit::None)};
+  span.yList = {Lengthd(0.0, Lengthd::Unit::None), std::nullopt,
+                Lengthd(60.0, Lengthd::Unit::None)};
+  text.spans.push_back(std::move(span));
+
+  const auto runs = engine.layout(text, MakeTextParams(20.0));
+
+  ASSERT_EQ(runs.size(), 1u);
+  ASSERT_EQ(runs[0].glyphs.size(), 4u);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[2].yPosition, 60.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[3].yPosition, 60.0);
+}
+
+TEST(TextEngineScriptedTest, TextAnchorAdjustsIndependentHorizontalChunks) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  components::ComputedTextComponent text;
+  auto middle = MakeSpan("AB");
+  middle.textAnchor = TextAnchor::Middle;
+
+  auto end = MakeSpan("CD");
+  end.xList = {Lengthd(50.0, Lengthd::Unit::None)};
+  end.textAnchor = TextAnchor::End;
+
+  text.spans.push_back(std::move(middle));
+  text.spans.push_back(std::move(end));
+
+  const auto runs = engine.layout(text, MakeTextParams(20.0));
+
+  ASSERT_EQ(runs.size(), 2u);
+  ASSERT_EQ(runs[0].glyphs.size(), 2u);
+  ASSERT_EQ(runs[1].glyphs.size(), 2u);
+  EXPECT_NEAR(runs[0].glyphs[0].xPosition, -10.5, 0.001);
+  EXPECT_NEAR(runs[0].glyphs[1].xPosition, 0.5, 0.001);
+  EXPECT_NEAR(runs[1].glyphs[0].xPosition, 29.0, 0.001);
+  EXPECT_NEAR(runs[1].glyphs[1].xPosition, 40.0, 0.001);
+}
+
+TEST(TextEngineScriptedTest, HiddenAndFailedSpansResetLayoutContinuity) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  components::ComputedTextComponent text;
+  auto hidden = MakeSpan("A");
+  hidden.hidden = true;
+
+  auto failedPath = MakeSpan("B");
+  failedPath.textPathFailed = true;
+
+  auto visible = MakeSpan("C");
+  visible.startsNewChunk = false;
+
+  text.spans.push_back(std::move(hidden));
+  text.spans.push_back(std::move(failedPath));
+  text.spans.push_back(std::move(visible));
+
+  const auto runs = engine.layout(text, MakeTextParams(20.0));
+
+  ASSERT_EQ(runs.size(), 3u);
+  EXPECT_TRUE(runs[0].glyphs.empty());
+  EXPECT_TRUE(runs[1].glyphs.empty());
+  ASSERT_EQ(runs[2].glyphs.size(), 1u);
+  EXPECT_DOUBLE_EQ(runs[2].glyphs[0].xPosition, 0.0);
+  EXPECT_DOUBLE_EQ(runs[2].glyphs[0].yPosition, 0.0);
+}
+
+TEST(TextEngineScriptedTest, TextPathUsesAnchorContinuationAndVisibility) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+  const entt::entity textPathEntity = registry.create();
+  const Path path = PathBuilder().moveTo(Vector2d(0.0, 0.0)).lineTo(Vector2d(200.0, 0.0)).build();
+
+  components::ComputedTextComponent text;
+  auto first = MakeSpan("AB");
+  first.pathSpline = path;
+  first.textPathSourceEntity = textPathEntity;
+  first.pathStartOffset = 10.0;
+  first.textAnchor = TextAnchor::Middle;
+
+  auto continued = MakeSpan("C");
+  continued.startsNewChunk = false;
+  continued.pathSpline = path;
+  continued.textPathSourceEntity = textPathEntity;
+
+  auto hidden = MakeSpan("D");
+  hidden.pathSpline = path;
+  hidden.textPathSourceEntity = textPathEntity;
+  hidden.pathStartOffset = 80.0;
+  hidden.visibility = Visibility::Hidden;
+
+  text.spans.push_back(std::move(first));
+  text.spans.push_back(std::move(continued));
+  text.spans.push_back(std::move(hidden));
+
+  const auto runs = engine.layout(text, MakeTextParams(20.0));
+
+  ASSERT_EQ(runs.size(), 3u);
+  ASSERT_EQ(runs[0].glyphs.size(), 2u);
+  ASSERT_EQ(runs[1].glyphs.size(), 1u);
+  EXPECT_TRUE(runs[0].onPath);
+  EXPECT_TRUE(runs[1].onPath);
+  EXPECT_TRUE(runs[2].onPath);
+  EXPECT_NEAR(runs[0].glyphs[0].xPosition, -0.5, 0.001);
+  EXPECT_NEAR(runs[0].glyphs[1].xPosition, 10.5, 0.001);
+  EXPECT_NEAR(runs[1].glyphs[0].xPosition, 20.5, 0.001);
+  EXPECT_TRUE(runs[2].glyphs.empty());
+}
+
+TEST(TextEngineScriptedTest, PerSpanTextLengthSpacingAndGlyphsScalesHorizontalAdvances) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  components::ComputedTextComponent text;
+  auto span = MakeSpan("ABC");
+  span.textLength = Lengthd(64.0, Lengthd::Unit::None);
+  span.lengthAdjust = LengthAdjust::SpacingAndGlyphs;
+  text.spans.push_back(std::move(span));
+
+  const auto runs = engine.layout(text, MakeTextParams(20.0));
+
+  ASSERT_EQ(runs.size(), 1u);
+  ASSERT_EQ(runs[0].glyphs.size(), 3u);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[0].xPosition, 0.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[1].xPosition, 22.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[2].xPosition, 44.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[0].xAdvance, 20.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[1].xAdvance, 20.0);
+  EXPECT_FLOAT_EQ(runs[0].glyphs[0].stretchScaleX, 2.0f);
+}
+
+TEST(TextEngineScriptedTest, GlobalTextLengthSpacingAdjustsVerticalGlyphGaps) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  components::ComputedTextComponent text;
+  text.spans.push_back(MakeSpan("AB"));
+
+  TextLayoutParams params = MakeTextParams(20.0);
+  params.writingMode = WritingMode::VerticalRl;
+  params.textLength = Lengthd(44.0, Lengthd::Unit::None);
+  params.lengthAdjust = LengthAdjust::Spacing;
+
+  const auto runs = engine.layout(text, params);
+
+  ASSERT_EQ(runs.size(), 1u);
+  ASSERT_EQ(runs[0].glyphs.size(), 2u);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[0].yPosition, 0.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[1].yPosition, 34.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[0].yAdvance, 10.0);
+  EXPECT_FLOAT_EQ(runs[0].glyphs[0].stretchScaleY, 1.0f);
+}
+
+TEST(TextEngineScriptedTest, RotatedCombiningMarkOffsetsRotateAroundBaseGlyph) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  components::ComputedTextComponent text;
+  auto span = MakeSpan("A\xCC\x81");
+  span.rotateList = {90.0, 90.0};
+  text.spans.push_back(std::move(span));
+
+  const auto runs = engine.layout(text, MakeTextParams(20.0));
+
+  ASSERT_EQ(runs.size(), 1u);
+  ASSERT_EQ(runs[0].glyphs.size(), 2u);
+  const TextGlyph& base = runs[0].glyphs[0];
+  const TextGlyph& mark = runs[0].glyphs[1];
+  EXPECT_NEAR(mark.xPosition, base.xPosition, 1e-6);
+  EXPECT_NEAR(mark.yPosition, base.yPosition + 11.0, 1e-6);
+}
+
+TEST(TextEngineScriptedTest, GlobalTextLengthSpacingAndGlyphsScalesVerticalAdvances) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  components::ComputedTextComponent text;
+  text.spans.push_back(MakeSpan("AB"));
+
+  TextLayoutParams params = MakeTextParams(20.0);
+  params.writingMode = WritingMode::VerticalRl;
+  params.textLength = Lengthd(44.0, Lengthd::Unit::None);
+  params.lengthAdjust = LengthAdjust::SpacingAndGlyphs;
+
+  const auto runs = engine.layout(text, params);
+
+  ASSERT_EQ(runs.size(), 1u);
+  ASSERT_EQ(runs[0].glyphs.size(), 2u);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[0].yPosition, 0.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[1].yPosition, 24.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[0].yAdvance, 20.0);
+  EXPECT_FLOAT_EQ(runs[0].glyphs[0].stretchScaleY, 2.0f);
+}
+
+TEST(TextEngineScriptedTest, SubSuperMetricsResolveSpanAndAncestorBaselineShifts) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine =
+      MakeScriptedEngine(registry, fontManager, /*reverseClusters=*/false,
+                         SubSuperMetrics{.subscriptYOffset = 300, .superscriptYOffset = 500});
+
+  using BaselineShiftKeyword = components::ComputedTextComponent::TextSpan::BaselineShiftKeyword;
+  components::ComputedTextComponent text;
+
+  auto sub = MakeSpan("A");
+  sub.baselineShiftKeyword = BaselineShiftKeyword::Sub;
+
+  auto super = MakeSpan("B");
+  super.baselineShiftKeyword = BaselineShiftKeyword::Super;
+
+  auto inherited = MakeSpan("C");
+  inherited.ancestorBaselineShifts.push_back(
+      {BaselineShiftKeyword::Sub, Lengthd(-0.33, Lengthd::Unit::Em), 20.0});
+  inherited.ancestorBaselineShifts.push_back(
+      {BaselineShiftKeyword::Super, Lengthd(0.4, Lengthd::Unit::Em), 20.0});
+
+  text.spans.push_back(std::move(sub));
+  text.spans.push_back(std::move(super));
+  text.spans.push_back(std::move(inherited));
+
+  const auto runs = engine.layout(text, MakeTextParams(20.0));
+
+  ASSERT_EQ(runs.size(), 3u);
+  ASSERT_EQ(runs[0].glyphs.size(), 1u);
+  ASSERT_EQ(runs[1].glyphs.size(), 1u);
+  ASSERT_EQ(runs[2].glyphs.size(), 1u);
+  EXPECT_NEAR(runs[0].glyphs[0].yPosition, 6.0, 1e-6);
+  EXPECT_NEAR(runs[1].glyphs[0].yPosition, -10.0, 1e-6);
+  EXPECT_NEAR(runs[2].glyphs[0].yPosition, -4.0, 1e-6);
+}
+
+TEST(TextEngineScriptedTest, TextPathEndAnchorAndExhaustedPathHideGlyphs) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+  const entt::entity textPathEntity = registry.create();
+  const Path path = PathBuilder().moveTo(Vector2d(0.0, 0.0)).lineTo(Vector2d(5.0, 0.0)).build();
+
+  components::ComputedTextComponent text;
+  auto span = MakeSpan("AB");
+  span.pathSpline = path;
+  span.textPathSourceEntity = textPathEntity;
+  span.pathStartOffset = 100.0;
+  span.textAnchor = TextAnchor::End;
+  text.spans.push_back(std::move(span));
+
+  const auto runs = engine.layout(text, MakeTextParams(20.0));
+
+  ASSERT_EQ(runs.size(), 1u);
+  ASSERT_EQ(runs[0].glyphs.size(), 2u);
+  EXPECT_TRUE(runs[0].onPath);
+  EXPECT_EQ(runs[0].glyphs[0].glyphIndex, 0);
+  EXPECT_EQ(runs[0].glyphs[1].glyphIndex, 0);
+}
+
+}  // namespace donner::svg

--- a/donner/svg/renderer/tests/TextEngine_tests.cc
+++ b/donner/svg/renderer/tests/TextEngine_tests.cc
@@ -3,13 +3,23 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cmath>
 #include <fstream>
+#include <iterator>
+#include <memory>
+#include <optional>
+#include <tuple>
+#include <vector>
 
 #include "donner/base/MathUtils.h"
+#include "donner/base/Utf8.h"
 #include "donner/base/tests/Runfiles.h"
+#include "donner/base/xml/components/TreeComponent.h"
 #include "donner/css/FontFace.h"
+#include "donner/svg/components/text/TextRootComponent.h"
 #include "donner/svg/text/TextBackendFull.h"
+#include "donner/svg/text/TextEngineHelpers.h"
 #include "donner/svg/text/TextLayoutParams.h"
 
 namespace donner::svg {
@@ -107,7 +117,637 @@ MATCHER_P(FirstGlyphMatches, glyphMatcher, "first glyph matches") {
   return testing::ExplainMatchResult(glyphMatcher, arg.front(), result_listener);
 }
 
+class FakeTextBackend : public TextBackend {
+public:
+  std::optional<SubSuperMetrics> subSuperMetricsResult;
+
+  FontVMetrics fontVMetrics(FontHandle /*font*/) const override { return {}; }
+
+  float scaleForPixelHeight(FontHandle /*font*/, float pixelHeight) const override {
+    return pixelHeight / 1000.0f;
+  }
+
+  float scaleForEmToPixels(FontHandle /*font*/, float pixelHeight) const override {
+    return pixelHeight / 1000.0f;
+  }
+
+  std::optional<UnderlineMetrics> underlineMetrics(FontHandle /*font*/) const override {
+    return std::nullopt;
+  }
+
+  std::optional<UnderlineMetrics> strikeoutMetrics(FontHandle /*font*/) const override {
+    return std::nullopt;
+  }
+
+  std::optional<SubSuperMetrics> subSuperMetrics(FontHandle /*font*/) const override {
+    return subSuperMetricsResult;
+  }
+
+  Path glyphOutline(FontHandle /*font*/, int /*glyphIndex*/, float /*scale*/) const override {
+    return Path();
+  }
+
+  bool isBitmapOnly(FontHandle /*font*/) const override { return false; }
+
+  bool isCursive(uint32_t /*codepoint*/) const override { return false; }
+
+  bool hasSmallCapsFeature(FontHandle /*font*/) const override { return false; }
+
+  std::optional<BitmapGlyph> bitmapGlyph(FontHandle /*font*/, int /*glyphIndex*/,
+                                         float /*scale*/) const override {
+    return std::nullopt;
+  }
+
+  ShapedRun shapeRun(FontHandle /*font*/, float /*fontSizePx*/, std::string_view /*spanText*/,
+                     size_t /*byteOffset*/, size_t /*byteLength*/, bool /*isVertical*/,
+                     FontVariant /*fontVariant*/, bool /*forceLogicalOrder*/) const override {
+    return {};
+  }
+
+  double crossSpanKern(FontHandle /*prevFont*/, float /*prevSizePx*/, FontHandle /*curFont*/,
+                       float /*curSizePx*/, uint32_t /*prevCodepoint*/, uint32_t /*curCodepoint*/,
+                       bool /*isVertical*/) const override {
+    return 0.0;
+  }
+};
+
+class ScriptedTextBackend : public TextBackend {
+public:
+  bool reverseClusters = false;
+
+  FontVMetrics fontVMetrics(FontHandle /*font*/) const override {
+    return FontVMetrics{
+        .ascent = 1000,
+        .descent = -200,
+        .lineGap = 0,
+        .xHeight = 500,
+    };
+  }
+
+  float scaleForPixelHeight(FontHandle /*font*/, float pixelHeight) const override {
+    return pixelHeight / 1200.0f;
+  }
+
+  float scaleForEmToPixels(FontHandle /*font*/, float pixelHeight) const override {
+    return pixelHeight / 1000.0f;
+  }
+
+  std::optional<UnderlineMetrics> underlineMetrics(FontHandle /*font*/) const override {
+    return UnderlineMetrics{.position = -100.0, .thickness = 50.0};
+  }
+
+  std::optional<UnderlineMetrics> strikeoutMetrics(FontHandle /*font*/) const override {
+    return UnderlineMetrics{.position = 300.0, .thickness = 40.0};
+  }
+
+  std::optional<SubSuperMetrics> subSuperMetrics(FontHandle /*font*/) const override {
+    return std::nullopt;
+  }
+
+  Path glyphOutline(FontHandle /*font*/, int glyphIndex, float /*scale*/) const override {
+    if (glyphIndex == 0) {
+      return Path();
+    }
+    return PathBuilder().addRect(Box2d::FromXYWH(0.0, -8.0, 6.0, 8.0)).build();
+  }
+
+  bool isBitmapOnly(FontHandle /*font*/) const override { return false; }
+
+  bool isCursive(uint32_t codepoint) const override { return codepoint == U'c'; }
+
+  bool hasSmallCapsFeature(FontHandle /*font*/) const override { return false; }
+
+  std::optional<BitmapGlyph> bitmapGlyph(FontHandle /*font*/, int /*glyphIndex*/,
+                                         float /*scale*/) const override {
+    return std::nullopt;
+  }
+
+  ShapedRun shapeRun(FontHandle /*font*/, float /*fontSizePx*/, std::string_view spanText,
+                     size_t byteOffset, size_t byteLength, bool /*isVertical*/,
+                     FontVariant fontVariant, bool forceLogicalOrder) const override {
+    ShapedRun run;
+    const size_t byteEnd = std::min(spanText.size(), byteOffset + byteLength);
+    for (size_t pos = byteOffset; pos < byteEnd;) {
+      const size_t cluster = pos;
+      const auto [codepoint, codepointLength] = Utf8::NextCodepointLenient(spanText.substr(pos));
+      pos += static_cast<size_t>(std::max(codepointLength, 1));
+
+      TextBackend::ShapedGlyph glyph;
+      glyph.glyphIndex = static_cast<int>(codepoint % 997u) + 1;
+      glyph.xAdvance = 10.0;
+      glyph.yAdvance = 12.0;
+      glyph.xKern = run.glyphs.empty() ? 0.0 : 1.0;
+      glyph.yKern = run.glyphs.empty() ? 0.0 : 2.0;
+      glyph.cluster = static_cast<uint32_t>(cluster);
+      glyph.fontSizeScale = fontVariant == FontVariant::SmallCaps ? 0.8f : 1.0f;
+      if (codepoint >= 0x2E80) {
+        glyph.xOffset = 2.0;
+        glyph.yOffset = 3.0;
+      }
+      run.glyphs.push_back(glyph);
+    }
+
+    if (reverseClusters && !forceLogicalOrder) {
+      std::reverse(run.glyphs.begin(), run.glyphs.end());
+    }
+    return run;
+  }
+
+  double crossSpanKern(FontHandle /*prevFont*/, float /*prevSizePx*/, FontHandle /*curFont*/,
+                       float /*curSizePx*/, uint32_t /*prevCodepoint*/, uint32_t /*curCodepoint*/,
+                       bool isVertical) const override {
+    return isVertical ? 4.0 : 3.0;
+  }
+};
+
+TextEngine MakeScriptedEngine(Registry& registry, FontManager& fontManager,
+                              bool reverseClusters = false) {
+  auto backend = std::make_unique<ScriptedTextBackend>();
+  backend->reverseClusters = reverseClusters;
+  return TextEngine(fontManager, registry, std::move(backend));
+}
+
 }  // namespace
+
+TEST(TextEngineHelperTest, ComputeBaselineShiftCoversBaselineKeywords) {
+  const FontVMetrics metrics{
+      .ascent = 1000,
+      .descent = -200,
+      .lineGap = 0,
+      .xHeight = 500,
+  };
+  constexpr float kScale = 0.01f;
+
+  EXPECT_DOUBLE_EQ(
+      text_engine_detail::computeBaselineShift(DominantBaseline::Auto, metrics, kScale), 0.0);
+  EXPECT_DOUBLE_EQ(
+      text_engine_detail::computeBaselineShift(DominantBaseline::Alphabetic, metrics, kScale), 0.0);
+  EXPECT_DOUBLE_EQ(
+      text_engine_detail::computeBaselineShift(DominantBaseline::UseScript, metrics, kScale), 0.0);
+  EXPECT_DOUBLE_EQ(
+      text_engine_detail::computeBaselineShift(DominantBaseline::NoChange, metrics, kScale), 0.0);
+  EXPECT_DOUBLE_EQ(
+      text_engine_detail::computeBaselineShift(DominantBaseline::ResetSize, metrics, kScale), 0.0);
+  EXPECT_NEAR(text_engine_detail::computeBaselineShift(DominantBaseline::Middle, metrics, kScale),
+              2.5, 1e-6);
+  EXPECT_NEAR(text_engine_detail::computeBaselineShift(DominantBaseline::Central, metrics, kScale),
+              4.0, 1e-6);
+  EXPECT_NEAR(text_engine_detail::computeBaselineShift(DominantBaseline::Hanging, metrics, kScale),
+              8.0, 1e-6);
+  EXPECT_NEAR(
+      text_engine_detail::computeBaselineShift(DominantBaseline::Mathematical, metrics, kScale),
+      5.0, 1e-6);
+  EXPECT_NEAR(text_engine_detail::computeBaselineShift(DominantBaseline::TextTop, metrics, kScale),
+              10.0, 1e-6);
+  EXPECT_NEAR(
+      text_engine_detail::computeBaselineShift(DominantBaseline::TextBottom, metrics, kScale), -2.0,
+      1e-6);
+  EXPECT_NEAR(
+      text_engine_detail::computeBaselineShift(DominantBaseline::Ideographic, metrics, kScale),
+      -2.0, 1e-6);
+
+  FontVMetrics noXHeight = metrics;
+  noXHeight.xHeight = 0;
+  EXPECT_NEAR(text_engine_detail::computeBaselineShift(DominantBaseline::Middle, noXHeight, kScale),
+              2.7, 1e-6);
+}
+
+TEST(TextEngineHelperTest, ByteMappingsAndChunkRangesCollapseNonSpacingSequences) {
+  std::string text;
+  std::vector<size_t> offsets;
+  auto append = [&](char32_t cp) {
+    offsets.push_back(text.size());
+    Utf8::Append(cp, std::back_inserter(text));
+  };
+
+  append(U'A');
+  for (const char32_t cp :
+       {U'\u0300', U'\u0483', U'\u0591', U'\u0610', U'\u064B', U'\u0670',    U'\u06D6',
+        U'\u0730', U'\u0E31', U'\u0E34', U'\u0EB1', U'\u0EB4', U'\u1AB0',    U'\u1DC0',
+        U'\u20D0', U'\uFE20', U'\u200C', U'\u034F', U'\uFE00', U'\U000E0100'}) {
+    append(cp);
+  }
+  append(U'\u200D');
+  append(U'B');
+  const size_t cOffsetIndex = offsets.size();
+  append(U'C');
+  const size_t emojiOffsetIndex = offsets.size();
+  append(U'\U0001F600');
+  const size_t dOffsetIndex = offsets.size();
+  append(U'D');
+
+  const auto mappings = text_engine_detail::buildByteIndexMappings(text);
+  for (size_t i = 0; i < cOffsetIndex; ++i) {
+    EXPECT_EQ(mappings.byteToCharIdx[offsets[i]], 0u) << "offset index " << i;
+  }
+  EXPECT_EQ(mappings.byteToCharIdx[offsets[cOffsetIndex]], 1u);
+  EXPECT_EQ(mappings.byteToCharIdx[offsets[emojiOffsetIndex]], 3u);
+  EXPECT_EQ(mappings.byteToCharIdx[offsets[dOffsetIndex]], 4u);
+
+  SmallVector<std::optional<Lengthd>, 1> xList;
+  xList.push_back(std::nullopt);
+  xList.push_back(Lengthd(10.0, Lengthd::Unit::None));
+  xList.push_back(std::nullopt);
+  xList.push_back(Lengthd(20.0, Lengthd::Unit::None));
+  SmallVector<std::optional<Lengthd>, 1> yList;
+
+  const auto chunks = text_engine_detail::findChunkRanges(text, xList, yList);
+
+  ASSERT_EQ(chunks.size(), 3u);
+  EXPECT_EQ(chunks[0].byteStart, 0u);
+  EXPECT_EQ(chunks[0].byteEnd, offsets[cOffsetIndex]);
+  EXPECT_EQ(chunks[1].byteStart, offsets[cOffsetIndex]);
+  EXPECT_EQ(chunks[1].byteEnd, offsets[emojiOffsetIndex]);
+  EXPECT_EQ(chunks[2].byteStart, offsets[emojiOffsetIndex]);
+  EXPECT_EQ(chunks[2].byteEnd, text.size());
+}
+
+TEST(TextEngineHelperTest, ApplyTextLengthAdjustsPerSpanSpacingAndVerticalGlyphScaling) {
+  {
+    std::vector<TextRun> runs = {
+        {.glyphs = {{.xPosition = 10.0, .xAdvance = 10.0}, {.xPosition = 20.0, .xAdvance = 10.0}}},
+    };
+    components::ComputedTextComponent text;
+    text.spans.resize(1);
+    text.spans[0].textLength = Lengthd(40.0, Lengthd::Unit::None);
+    text.spans[0].lengthAdjust = LengthAdjust::Spacing;
+    const std::vector<text_engine_detail::RunPenExtent> extents = {
+        {.startX = 10.0, .endX = 30.0},
+    };
+
+    text_engine_detail::applyTextLength(runs, text, extents, MakeTextParams(10.0),
+                                        /*vertical=*/false, /*currentPenX=*/30.0,
+                                        /*currentPenY=*/0.0);
+
+    EXPECT_DOUBLE_EQ(runs[0].glyphs[0].xPosition, 10.0);
+    EXPECT_DOUBLE_EQ(runs[0].glyphs[1].xPosition, 40.0);
+    EXPECT_DOUBLE_EQ(runs[0].glyphs[1].xAdvance, 10.0);
+  }
+
+  {
+    std::vector<TextRun> runs = {
+        {.glyphs = {{.yPosition = 5.0, .yAdvance = 5.0}, {.yPosition = 15.0, .yAdvance = 5.0}}},
+    };
+    components::ComputedTextComponent text;
+    text.spans.resize(1);
+    text.spans[0].textLength = Lengthd(40.0, Lengthd::Unit::None);
+    text.spans[0].lengthAdjust = LengthAdjust::SpacingAndGlyphs;
+    const std::vector<text_engine_detail::RunPenExtent> extents = {
+        {.startY = 5.0, .endY = 25.0},
+    };
+
+    text_engine_detail::applyTextLength(runs, text, extents, MakeTextParams(10.0),
+                                        /*vertical=*/true, /*currentPenX=*/0.0,
+                                        /*currentPenY=*/25.0);
+
+    EXPECT_DOUBLE_EQ(runs[0].glyphs[0].yPosition, 5.0);
+    EXPECT_DOUBLE_EQ(runs[0].glyphs[1].yPosition, 25.0);
+    EXPECT_DOUBLE_EQ(runs[0].glyphs[1].yAdvance, 10.0);
+    EXPECT_FLOAT_EQ(runs[0].glyphs[1].stretchScaleY, 2.0f);
+  }
+}
+
+TEST(TextEngineHelperTest, ApplyTextLengthAdjustsGlobalSpacing) {
+  std::vector<TextRun> runs = {
+      {.glyphs = {{.xPosition = 10.0, .xAdvance = 10.0}, {.xPosition = 20.0, .xAdvance = 10.0}}},
+      {.glyphs = {{.xPosition = 30.0, .xAdvance = 10.0}}},
+  };
+  components::ComputedTextComponent text;
+  text.spans.resize(2);
+  TextLayoutParams params = MakeTextParams(10.0);
+  params.textLength = Lengthd(50.0, Lengthd::Unit::None);
+  params.lengthAdjust = LengthAdjust::Spacing;
+
+  text_engine_detail::applyTextLength(runs, text, {}, params, /*vertical=*/false,
+                                      /*currentPenX=*/40.0, /*currentPenY=*/0.0);
+
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[0].xPosition, 10.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[1].xPosition, 30.0);
+  EXPECT_DOUBLE_EQ(runs[1].glyphs[0].xPosition, 50.0);
+}
+
+TEST(TextEngineHelperTest, ApplyTextLengthAdjustsGlobalSpacingAndGlyphsHorizontally) {
+  std::vector<TextRun> runs = {
+      {.glyphs = {{.xPosition = 10.0, .xAdvance = 10.0}, {.xPosition = 20.0, .xAdvance = 10.0}}},
+      {.glyphs = {{.xPosition = 30.0, .xAdvance = 10.0}}},
+  };
+  components::ComputedTextComponent text;
+  text.spans.resize(2);
+  TextLayoutParams params = MakeTextParams(10.0);
+  params.textLength = Lengthd(60.0, Lengthd::Unit::None);
+  params.lengthAdjust = LengthAdjust::SpacingAndGlyphs;
+
+  text_engine_detail::applyTextLength(runs, text, {}, params, /*vertical=*/false,
+                                      /*currentPenX=*/40.0, /*currentPenY=*/0.0);
+
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[0].xPosition, 10.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[1].xPosition, 30.0);
+  EXPECT_DOUBLE_EQ(runs[1].glyphs[0].xPosition, 50.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[0].xAdvance, 20.0);
+  EXPECT_FLOAT_EQ(runs[0].glyphs[0].stretchScaleX, 2.0f);
+}
+
+TEST(TextEngineHelperTest, ApplyTextAnchorSkipsOnPathRunsAndUsesFirstGlyphSpanAnchor) {
+  std::vector<TextRun> runs = {
+      {},
+      {.glyphs = {{.xPosition = 10.0, .xAdvance = 5.0}}},
+      {.glyphs = {{.xPosition = 100.0, .xAdvance = 10.0}}, .onPath = true},
+  };
+  components::ComputedTextComponent text;
+  text.spans.resize(3);
+  text.spans[1].textAnchor = TextAnchor::End;
+  std::vector<text_engine_detail::ChunkBoundary> chunks = {
+      {.runIndex = 0, .glyphIndex = 0, .textAnchor = TextAnchor::Start},
+  };
+
+  text_engine_detail::applyTextAnchor(runs, chunks, text, /*vertical=*/false);
+
+  ASSERT_EQ(chunks.size(), 1u);
+  EXPECT_EQ(chunks[0].textAnchor, TextAnchor::End);
+  EXPECT_DOUBLE_EQ(runs[1].glyphs[0].xPosition, 5.0);
+  EXPECT_DOUBLE_EQ(runs[2].glyphs[0].xPosition, 100.0);
+}
+
+TEST(TextEngineHelperTest, ApplyTextAnchorAdjustsVerticalMiddleChunks) {
+  std::vector<TextRun> runs = {
+      {.glyphs = {{.yPosition = 0.0, .yAdvance = 10.0}, {.yPosition = 10.0, .yAdvance = 10.0}}},
+  };
+  components::ComputedTextComponent text;
+  text.spans.resize(1);
+  text.spans[0].textAnchor = TextAnchor::Middle;
+  std::vector<text_engine_detail::ChunkBoundary> chunks = {
+      {.runIndex = 0, .glyphIndex = 0, .textAnchor = TextAnchor::Start},
+  };
+
+  text_engine_detail::applyTextAnchor(runs, chunks, text, /*vertical=*/true);
+
+  EXPECT_EQ(chunks[0].textAnchor, TextAnchor::Middle);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[0].yPosition, -10.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[1].yPosition, 0.0);
+}
+
+TEST(TextEngineHelperTest, ApplyTextAnchorLeavesEmptyEndChunksUnchanged) {
+  std::vector<TextRun> runs = {
+      {},
+      {.glyphs = {{.xPosition = 20.0, .xAdvance = 10.0}}, .onPath = true},
+  };
+  components::ComputedTextComponent text;
+  text.spans.resize(2);
+  text.spans[1].textAnchor = TextAnchor::End;
+  std::vector<text_engine_detail::ChunkBoundary> chunks = {
+      {.runIndex = 0, .glyphIndex = 0, .textAnchor = TextAnchor::End},
+  };
+
+  text_engine_detail::applyTextAnchor(runs, chunks, text, /*vertical=*/false);
+
+  EXPECT_EQ(chunks[0].textAnchor, TextAnchor::End);
+  EXPECT_DOUBLE_EQ(runs[1].glyphs[0].xPosition, 20.0);
+}
+
+TEST(TextEngineHelperTest, ComputeSpanBaselineShiftUsesFontMetricsAndLengthFallbacks) {
+  using BSK = components::ComputedTextComponent::TextSpan::BaselineShiftKeyword;
+
+  TextLayoutParams params = MakeTextParams(10.0);
+
+  FakeTextBackend backendWithMetrics;
+  backendWithMetrics.subSuperMetricsResult = SubSuperMetrics{
+      .subscriptYOffset = 200,
+      .superscriptYOffset = 300,
+  };
+  components::ComputedTextComponent::TextSpan span;
+  span.baselineShiftKeyword = BSK::Sub;
+  span.baselineShift = Lengthd(-0.33, Lengthd::Unit::Em);
+  span.ancestorBaselineShifts.push_back({BSK::Super, Lengthd(0.4, Lengthd::Unit::Em), 20.0});
+  span.ancestorBaselineShifts.push_back({BSK::Sub, Lengthd(-0.33, Lengthd::Unit::Em), 30.0});
+  span.ancestorBaselineShifts.push_back({BSK::Length, Lengthd(3.0, Lengthd::Unit::None), 12.0});
+
+  EXPECT_NEAR(text_engine_detail::computeSpanBaselineShiftPx(backendWithMetrics, span, FontHandle{},
+                                                             0.01f, params),
+              1.0, 1e-6);
+
+  FakeTextBackend backendWithoutMetrics;
+  components::ComputedTextComponent::TextSpan fallbackSpan;
+  fallbackSpan.fontSize = Lengthd(20.0, Lengthd::Unit::Px);
+  fallbackSpan.baselineShiftKeyword = BSK::Super;
+  fallbackSpan.baselineShift = Lengthd(0.5, Lengthd::Unit::Em);
+  fallbackSpan.ancestorBaselineShifts.push_back(
+      {BSK::Sub, Lengthd(-0.33, Lengthd::Unit::Em), 20.0});
+
+  EXPECT_NEAR(text_engine_detail::computeSpanBaselineShiftPx(backendWithoutMetrics, fallbackSpan,
+                                                             FontHandle{}, 0.01f, params),
+              3.4, 1e-6);
+}
+
+TEST(TextEngineTest, CachedGeometryApisFilterToRequestedSubtree) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  const Entity root = registry.create();
+  const Entity child = registry.create();
+  const Entity outside = registry.create();
+  registry.emplace<donner::components::TreeComponent>(root, xml::XMLQualifiedNameRef("text"));
+  registry.emplace<donner::components::TreeComponent>(child, xml::XMLQualifiedNameRef("tspan"));
+  registry.emplace<donner::components::TreeComponent>(outside, xml::XMLQualifiedNameRef("text"));
+  registry.get<donner::components::TreeComponent>(root).appendChild(registry, child);
+  registry.emplace<components::TextRootComponent>(root);
+
+  components::ComputedTextGeometryComponent cache;
+  cache.glyphs.push_back(components::ComputedTextGeometryComponent::GlyphGeometry{
+      .sourceEntity = root,
+      .path = PathBuilder().addRect(Box2d::FromXYWH(0.0, 0.0, 5.0, 5.0)).build(),
+      .extent = Box2d::FromXYWH(0.0, 0.0, 5.0, 5.0),
+  });
+  cache.glyphs.push_back(components::ComputedTextGeometryComponent::GlyphGeometry{
+      .sourceEntity = child,
+      .path = PathBuilder().addRect(Box2d::FromXYWH(10.0, 0.0, 5.0, 5.0)).build(),
+      .extent = Box2d::FromXYWH(10.0, 0.0, 5.0, 5.0),
+  });
+  cache.glyphs.push_back(components::ComputedTextGeometryComponent::GlyphGeometry{
+      .sourceEntity = outside,
+      .path = PathBuilder().addRect(Box2d::FromXYWH(100.0, 0.0, 5.0, 5.0)).build(),
+      .extent = Box2d::FromXYWH(100.0, 0.0, 5.0, 5.0),
+  });
+  cache.characters.push_back(components::ComputedTextGeometryComponent::CharacterGeometry{
+      .sourceEntity = root,
+      .startPosition = Vector2d(0.0, 0.0),
+      .endPosition = Vector2d(5.0, 0.0),
+      .extent = Box2d::FromXYWH(0.0, 0.0, 5.0, 5.0),
+      .rotation = 0.0,
+      .advance = 5.0,
+      .rendered = true,
+      .hasExtent = true,
+  });
+  cache.characters.push_back(components::ComputedTextGeometryComponent::CharacterGeometry{
+      .sourceEntity = child,
+      .startPosition = Vector2d(10.0, 0.0),
+      .endPosition = Vector2d(16.0, 0.0),
+      .extent = Box2d::FromXYWH(10.0, 0.0, 6.0, 5.0),
+      .rotation = 15.0,
+      .advance = 6.0,
+      .rendered = true,
+      .hasExtent = true,
+  });
+  cache.characters.push_back(components::ComputedTextGeometryComponent::CharacterGeometry{
+      .sourceEntity = outside,
+      .startPosition = Vector2d(100.0, 0.0),
+      .endPosition = Vector2d(108.0, 0.0),
+      .extent = Box2d::FromXYWH(100.0, 0.0, 8.0, 5.0),
+      .rotation = 30.0,
+      .advance = 8.0,
+      .rendered = true,
+      .hasExtent = true,
+  });
+  cache.inkBounds = Box2d::FromXYWH(0.0, 0.0, 105.0, 5.0);
+  cache.emBoxBounds = Box2d::FromXYWH(0.0, -10.0, 16.0, 20.0);
+  registry.emplace<components::ComputedTextGeometryComponent>(root, std::move(cache));
+
+  const EntityHandle rootHandle(registry, root);
+  const EntityHandle childHandle(registry, child);
+  EXPECT_EQ(engine.computedGlyphPaths(rootHandle).size(), 2u);
+  EXPECT_EQ(engine.computedGlyphPaths(childHandle).size(), 1u);
+  EXPECT_EQ(engine.getNumberOfChars(rootHandle), 2);
+  EXPECT_EQ(engine.getNumberOfChars(childHandle), 1);
+  EXPECT_DOUBLE_EQ(engine.getComputedTextLength(rootHandle), 11.0);
+  EXPECT_DOUBLE_EQ(engine.getSubStringLength(rootHandle, 1, 99), 6.0);
+  EXPECT_EQ(engine.getStartPositionOfChar(childHandle, 0), Vector2d(10.0, 0.0));
+  EXPECT_EQ(engine.getStartPositionOfChar(childHandle, 1), Vector2d());
+  EXPECT_EQ(engine.getEndPositionOfChar(childHandle, 0), Vector2d(16.0, 0.0));
+  EXPECT_EQ(engine.getEndPositionOfChar(childHandle, 1), Vector2d());
+  EXPECT_EQ(engine.getExtentOfChar(childHandle, 0), Box2d::FromXYWH(10.0, 0.0, 6.0, 5.0));
+  EXPECT_EQ(engine.getExtentOfChar(childHandle, 1), Box2d());
+  EXPECT_DOUBLE_EQ(engine.getRotationOfChar(childHandle, 0), 15.0);
+  EXPECT_DOUBLE_EQ(engine.getRotationOfChar(childHandle, 1), 0.0);
+  EXPECT_EQ(engine.getCharNumAtPosition(rootHandle, Vector2d(12.0, 2.0)), 1);
+  EXPECT_EQ(engine.getCharNumAtPosition(rootHandle, Vector2d(90.0, 2.0)), -1);
+  EXPECT_EQ(engine.computedObjectBoundingBox(rootHandle), Box2d::FromXYWH(0.0, -10.0, 16.0, 20.0));
+  EXPECT_EQ(engine.computedObjectBoundingBox(childHandle), Box2d::FromXYWH(10.0, 0.0, 5.0, 5.0));
+}
+
+TEST(TextEngineTest, ScriptedHorizontalLayoutCoversChunkAndSpanPositioningBranches) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  components::ComputedTextComponent text;
+  auto span1 = MakeSpan("A");
+  span1.xList = {Lengthd(10.0, Lengthd::Unit::None)};
+  span1.yList = {Lengthd(20.0, Lengthd::Unit::None)};
+  span1.dxList = {Lengthd(1.0, Lengthd::Unit::None)};
+  span1.dyList = {Lengthd(2.0, Lengthd::Unit::None)};
+
+  auto span2 = MakeSpan("B c");
+  span2.startsNewChunk = false;
+  span2.xList = {std::nullopt, std::nullopt, Lengthd(80.0, Lengthd::Unit::None)};
+  span2.yList = {std::nullopt, std::nullopt, Lengthd(40.0, Lengthd::Unit::None)};
+  span2.dxList = {std::nullopt, Lengthd(1.0, Lengthd::Unit::None),
+                  Lengthd(2.0, Lengthd::Unit::None)};
+  span2.dyList = {std::nullopt, Lengthd(3.0, Lengthd::Unit::None),
+                  Lengthd(4.0, Lengthd::Unit::None)};
+  span2.rotateList = {5.0, 15.0};
+  span2.letterSpacingPx = 2.0;
+  span2.wordSpacingPx = 5.0;
+
+  text.spans.push_back(std::move(span1));
+  text.spans.push_back(std::move(span2));
+
+  const auto runs = engine.layout(text, MakeTextParams(20.0));
+
+  ASSERT_EQ(runs.size(), 2u);
+  ASSERT_EQ(runs[0].glyphs.size(), 1u);
+  ASSERT_EQ(runs[1].glyphs.size(), 3u);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[0].xPosition, 11.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[0].yPosition, 22.0);
+  EXPECT_DOUBLE_EQ(runs[1].glyphs[0].xPosition, 24.0);
+  EXPECT_DOUBLE_EQ(runs[1].glyphs[1].xPosition, 38.0);
+  EXPECT_DOUBLE_EQ(runs[1].glyphs[2].xPosition, 82.0);
+  EXPECT_DOUBLE_EQ(runs[1].glyphs[2].yPosition, 44.0);
+  EXPECT_DOUBLE_EQ(runs[1].glyphs[0].rotateDegrees, 5.0);
+  EXPECT_DOUBLE_EQ(runs[1].glyphs[1].rotateDegrees, 15.0);
+  EXPECT_DOUBLE_EQ(runs[1].glyphs[2].rotateDegrees, 15.0);
+}
+
+TEST(TextEngineTest, ScriptedSupplementaryCoordinateListsUseLowSurrogateSlot) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  std::string textValue = "A";
+  Utf8::Append(U'\U0001F600', std::back_inserter(textValue));
+  textValue += "B";
+
+  components::ComputedTextComponent text;
+  auto span = MakeSpan(textValue);
+  span.xList = {Lengthd(0.0, Lengthd::Unit::None), std::nullopt, std::nullopt,
+                Lengthd(70.0, Lengthd::Unit::None)};
+  span.yList = {Lengthd(0.0, Lengthd::Unit::None), std::nullopt, std::nullopt,
+                Lengthd(90.0, Lengthd::Unit::None)};
+  text.spans.push_back(std::move(span));
+
+  const auto runs = engine.layout(text, MakeTextParams(20.0));
+
+  ASSERT_EQ(runs.size(), 1u);
+  ASSERT_EQ(runs[0].glyphs.size(), 3u);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[0].xPosition, 0.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[1].xPosition, 13.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[2].xPosition, 70.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[2].yPosition, 90.0);
+}
+
+TEST(TextEngineTest, ScriptedVerticalLayoutCoversSidewaysUprightSpacingAndRotation) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  std::string textValue = "A";
+  Utf8::Append(U'\u65E5', std::back_inserter(textValue));
+  textValue += " ";
+
+  components::ComputedTextComponent text;
+  auto span = MakeSpan(textValue);
+  span.xList = {Lengthd(100.0, Lengthd::Unit::None), Lengthd(110.0, Lengthd::Unit::None)};
+  span.yList = {Lengthd(10.0, Lengthd::Unit::None), Lengthd(40.0, Lengthd::Unit::None)};
+  span.dxList = {Lengthd(1.0, Lengthd::Unit::None), Lengthd(2.0, Lengthd::Unit::None)};
+  span.dyList = {Lengthd(3.0, Lengthd::Unit::None), Lengthd(4.0, Lengthd::Unit::None)};
+  span.rotateList = {7.0, 17.0};
+  span.letterSpacingPx = 2.0;
+  span.wordSpacingPx = 5.0;
+  text.spans.push_back(std::move(span));
+
+  TextLayoutParams params = MakeTextParams(20.0);
+  params.writingMode = WritingMode::VerticalRl;
+  const auto runs = engine.layout(text, params);
+
+  ASSERT_EQ(runs.size(), 1u);
+  ASSERT_EQ(runs[0].glyphs.size(), 3u);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[0].rotateDegrees, 97.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[1].rotateDegrees, 17.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[2].rotateDegrees, 107.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[1].xPosition, 114.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[1].yPosition, 47.0);
+  EXPECT_GT(runs[0].glyphs[2].yPosition, runs[0].glyphs[1].yPosition);
+}
+
+TEST(TextEngineTest, ScriptedRtlChunkYOverrideKeepsVisualGlyphsOnSameBaseline) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager, /*reverseClusters=*/true);
+
+  components::ComputedTextComponent text;
+  auto span = MakeSpan("ABCD");
+  span.xList = {Lengthd(0.0, Lengthd::Unit::None), std::nullopt,
+                Lengthd(50.0, Lengthd::Unit::None)};
+  span.yList = {Lengthd(0.0, Lengthd::Unit::None), std::nullopt,
+                Lengthd(60.0, Lengthd::Unit::None)};
+  text.spans.push_back(std::move(span));
+
+  const auto runs = engine.layout(text, MakeTextParams(20.0));
+
+  ASSERT_EQ(runs.size(), 1u);
+  ASSERT_EQ(runs[0].glyphs.size(), 4u);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[2].yPosition, 60.0);
+  EXPECT_DOUBLE_EQ(runs[0].glyphs[3].yPosition, 60.0);
+}
 
 TEST(TextEngineTest, UsesCoverageFallbackForArabicText) {
   Registry registry;

--- a/donner/svg/tests/SVGDocument_tests.cc
+++ b/donner/svg/tests/SVGDocument_tests.cc
@@ -7,6 +7,8 @@
 #include "donner/base/Transform.h"
 #include "donner/base/tests/ParseResultTestUtils.h"
 #include "donner/svg/SVGRectElement.h"
+#include "donner/svg/SVGStyleElement.h"
+#include "donner/svg/components/DirtyFlagsComponent.h"
 #include "donner/svg/components/StylesheetComponent.h"
 #include "donner/svg/components/text/TextComponent.h"
 #include "donner/svg/components/text/TextRootComponent.h"
@@ -35,6 +37,13 @@ MATCHER_P(ElementIdEq, id, "") {
   return arg.id() == id;
 }
 
+components::RenderTreeState& EnsureRenderTreeState(Registry& registry) {
+  if (!registry.ctx().contains<components::RenderTreeState>()) {
+    registry.ctx().emplace<components::RenderTreeState>();
+  }
+  return registry.ctx().get<components::RenderTreeState>();
+}
+
 }  // namespace
 
 TEST(SVGDocument, Create) {
@@ -58,6 +67,27 @@ TEST(SVGDocument, CanvasSize) {
 
   document.useAutomaticCanvasSize();
   EXPECT_EQ(document.canvasSize(), Vector2i(512, 512));
+}
+
+TEST(SVGDocument, SetCanvasSizeNoOpDoesNotInvalidateBuiltRenderTree) {
+  SVGDocument document;
+  document.setCanvasSize(100, 200);
+
+  auto& renderState = EnsureRenderTreeState(document.registry());
+  renderState.hasBeenBuilt = true;
+  renderState.needsFullRebuild = false;
+  renderState.needsFullStyleRecompute = false;
+  document.registry().clear<components::DirtyFlagsComponent>();
+
+  document.setCanvasSize(100, 200);
+
+  EXPECT_FALSE(document.hasPendingRenderInvalidation());
+  EXPECT_EQ(document.canvasSize(), Vector2i(100, 200));
+
+  document.setCanvasSize(100, 201);
+
+  EXPECT_TRUE(document.hasPendingRenderInvalidation());
+  EXPECT_EQ(document.canvasSize(), Vector2i(100, 201));
 }
 
 TEST(SVGDocument, CanvasSizeFromFile) {
@@ -89,6 +119,49 @@ TEST(SVGDocument, SourceBackedAccessorsReflectParsedXmlSource) {
   EXPECT_TRUE(document.hasSourceStore());
   EXPECT_THAT(document.source(), testing::HasSubstr(R"(<rect id="r"/>)"));
   EXPECT_EQ(document.sourceVersion(), 0u);
+}
+
+TEST(SVGDocument, PendingRenderInvalidationRequiresBuiltRenderTree) {
+  SVGDocument document;
+
+  EXPECT_FALSE(document.hasPendingRenderInvalidation());
+
+  auto& renderState = document.registry().ctx().emplace<components::RenderTreeState>();
+  renderState.hasBeenBuilt = false;
+  renderState.needsFullRebuild = true;
+  renderState.needsFullStyleRecompute = true;
+  document.svgElement().entityHandle().get_or_emplace<components::DirtyFlagsComponent>().mark(
+      components::DirtyFlagsComponent::RenderInstance);
+
+  EXPECT_FALSE(document.hasPendingRenderInvalidation());
+}
+
+TEST(SVGDocument, PendingRenderInvalidationReflectsDirtyFlagsAndFullInvalidation) {
+  SVGDocument document;
+  Registry& registry = document.registry();
+  auto& renderState = EnsureRenderTreeState(registry);
+  renderState.hasBeenBuilt = true;
+  renderState.needsFullRebuild = false;
+  renderState.needsFullStyleRecompute = false;
+  registry.clear<components::DirtyFlagsComponent>();
+
+  EXPECT_FALSE(document.hasPendingRenderInvalidation());
+
+  document.svgElement().entityHandle().get_or_emplace<components::DirtyFlagsComponent>().mark(
+      components::DirtyFlagsComponent::RenderInstance);
+
+  EXPECT_TRUE(document.hasPendingRenderInvalidation());
+
+  registry.clear<components::DirtyFlagsComponent>();
+  renderState.needsFullRebuild = true;
+  renderState.needsFullStyleRecompute = false;
+
+  EXPECT_TRUE(document.hasPendingRenderInvalidation());
+
+  renderState.needsFullRebuild = false;
+  renderState.needsFullStyleRecompute = true;
+
+  EXPECT_TRUE(document.hasPendingRenderInvalidation());
 }
 
 TEST(SVGDocument, QuerySelector) {
@@ -183,11 +256,30 @@ TEST(SVGDocument, ApplySourceEditProjectsCDataTextMutation) {
   EXPECT_THAT(textComponent.textChunks, testing::ElementsAre(RcString("world")));
 }
 
+TEST(SVGDocument, ApplySourceEditRejectsTextMutationOnNonTextElement) {
+  auto document = ParseSVG(
+      R"(<svg xmlns="http://www.w3.org/2000/svg"><custom id="custom">hello</custom></svg>)");
+  const std::size_t valueOffset = document.source().find("hello");
+  ASSERT_NE(valueOffset, std::string_view::npos);
+
+  xml::ApplySourceEditResult result = document.applySourceEdit(xml::XMLEditIntent{
+      .range = SourceRange{FileOffset::Offset(valueOffset), FileOffset::Offset(valueOffset + 5)},
+      .replacement = "world",
+      .sourceVersion = document.sourceVersion(),
+  });
+
+  EXPECT_TRUE(result.applied);
+  ASSERT_TRUE(result.diagnostic.has_value());
+  EXPECT_THAT(result.diagnostic->reason, testing::HasSubstr("not SVG text or style content"));
+  EXPECT_THAT(document.source(), testing::HasSubstr(">world</custom>"));
+}
+
 TEST(SVGDocument, TextProjectionPreservesChunkBoundariesAroundChildElements) {
   auto document = ParseSVG(R"(
     <svg xmlns="http://www.w3.org/2000/svg">
       <text id="label">one<tspan>two</tspan>three<![CDATA[four]]></text>
       <text id="leading-child"><tspan/>tail</text>
+      <text id="adjacent-children"><tspan/>middle<tspan/>tail</text>
     </svg>
   )");
 
@@ -201,6 +293,12 @@ TEST(SVGDocument, TextProjectionPreservesChunkBoundariesAroundChildElements) {
   const auto& leadingText = leadingChild.entityHandle().get<components::TextComponent>();
   EXPECT_EQ(leadingText.text, "tail");
   EXPECT_THAT(leadingText.textChunks, testing::ElementsAre(RcString(""), RcString("tail")));
+
+  SVGElement adjacentChildren = document.querySelector("#adjacent-children").value();
+  const auto& adjacentText = adjacentChildren.entityHandle().get<components::TextComponent>();
+  EXPECT_EQ(adjacentText.text, "middletail");
+  EXPECT_THAT(adjacentText.textChunks,
+              testing::ElementsAre(RcString(""), RcString("middle"), RcString("tail")));
 }
 
 TEST(SVGDocument, ApplySourceEditProjectsStyleMutationWithSourceMap) {
@@ -225,6 +323,50 @@ TEST(SVGDocument, ApplySourceEditProjectsStyleMutationWithSourceMap) {
   const auto& stylesheet = style.entityHandle().get<components::StylesheetComponent>();
   EXPECT_EQ(stylesheet.stylesheet.rules().size(), 1u);
   EXPECT_TRUE(stylesheet.sourceMap.empty());
+}
+
+TEST(SVGDocument, StyleProjectionCombinesDataAndCDataTextChildren) {
+  auto document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <style id="style">rect { fill: red; }<![CDATA[circle { fill: blue; }]]></style>
+      <rect/>
+      <circle/>
+    </svg>
+  )");
+  SVGElement style = document.querySelector("#style").value();
+
+  const auto& stylesheet = style.entityHandle().get<components::StylesheetComponent>();
+  EXPECT_THAT(stylesheet.text, testing::HasSubstr("rect { fill: red; }"));
+  EXPECT_THAT(stylesheet.text, testing::HasSubstr("circle { fill: blue; }"));
+  EXPECT_EQ(stylesheet.stylesheet.rules().size(), 2u);
+}
+
+TEST(SVGDocument, StyleProjectionSkipsNonCssType) {
+  auto document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <style id="style" type="text/plain">rect { fill: red; }</style>
+      <rect/>
+    </svg>
+  )");
+  SVGElement style = document.querySelector("#style").value();
+
+  const auto& stylesheet = style.entityHandle().get<components::StylesheetComponent>();
+  EXPECT_FALSE(stylesheet.isCssType());
+  EXPECT_TRUE(stylesheet.text.empty());
+  EXPECT_TRUE(stylesheet.stylesheet.rules().empty());
+}
+
+TEST(SVGDocument, StyleProjectionHandlesEmptyCssStyleElement) {
+  auto document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <style id="empty-style"></style>
+      <rect/>
+    </svg>
+  )");
+  SVGElement style = document.querySelector("#empty-style").value();
+
+  EXPECT_EQ(style.entityHandle().try_get<components::StylesheetComponent>(), nullptr);
+  EXPECT_EQ(style.cast<SVGStyleElement>().textContent(), "");
 }
 
 TEST(SVGDocument, StyleProjectionRejectsElementChildren) {
@@ -260,6 +402,28 @@ TEST(SVGDocument, ApplySourceEditProjectsSubtreeReplacement) {
   EXPECT_THAT(document.querySelector("#old"), Eq(std::nullopt));
   ASSERT_THAT(document.querySelector("#new"), Optional(ElementIdEq("new")));
   EXPECT_EQ(document.querySelector("#new")->type(), ElementType::Circle);
+}
+
+TEST(SVGDocument, ApplySourceEditReportsOpeningTagRenameUnsupported) {
+  auto document = ParseSVG(R"(<svg xmlns="http://www.w3.org/2000/svg"><custom id="shape"/></svg>)");
+  SVGElement element = document.querySelector("#shape").value();
+  ASSERT_EQ(element.type(), ElementType::Unknown);
+  const std::size_t openNameOffset = document.source().find("custom");
+  ASSERT_NE(openNameOffset, std::string_view::npos);
+
+  xml::ApplySourceEditResult result = document.applySourceEdit(xml::XMLEditIntent{
+      .range =
+          SourceRange{FileOffset::Offset(openNameOffset), FileOffset::Offset(openNameOffset + 6)},
+      .replacement = "rect",
+      .sourceVersion = document.sourceVersion(),
+  });
+
+  EXPECT_TRUE(result.applied);
+  ASSERT_TRUE(result.diagnostic.has_value());
+  EXPECT_THAT(result.diagnostic->reason,
+              testing::HasSubstr("Opening tag element rename is not implemented"));
+  ASSERT_THAT(document.querySelector("#shape"), Optional(ElementIdEq("shape")));
+  EXPECT_EQ(document.querySelector("#shape")->type(), ElementType::Unknown);
 }
 
 TEST(SVGDocument, SourceBackedElementAttributeHelpersUpdateSourceAndProjection) {
@@ -307,6 +471,22 @@ TEST(SVGDocument, ProgrammaticElementAttributeHelpersUseDomFallback) {
   EXPECT_FALSE(rect.hasAttribute("fill"));
 }
 
+TEST(SVGDocument, SourceBackedDetachedElementAttributeHelpersUseDomFallback) {
+  auto document = ParseSVG(R"(<svg xmlns="http://www.w3.org/2000/svg"/>)");
+  SVGRectElement detached = SVGRectElement::Create(document);
+
+  xml::ApplySourceEditResult setResult = document.setElementAttribute(detached, "fill", "green");
+  EXPECT_FALSE(setResult.applied);
+  EXPECT_THAT(setResult.diagnostic, Eq(std::nullopt));
+  EXPECT_THAT(detached.getAttribute("fill"), Optional(Eq("green")));
+  EXPECT_THAT(document.source(), testing::Not(testing::HasSubstr("green")));
+
+  xml::ApplySourceEditResult removeResult = document.removeElementAttribute(detached, "fill");
+  EXPECT_FALSE(removeResult.applied);
+  EXPECT_THAT(removeResult.diagnostic, Eq(std::nullopt));
+  EXPECT_FALSE(detached.hasAttribute("fill"));
+}
+
 TEST(SVGDocument, ProgrammaticInvalidAttributeSetReportsDiagnostic) {
   SVGDocument document;
   SVGRectElement rect = SVGRectElement::Create(document);
@@ -332,6 +512,21 @@ TEST(SVGDocument, SourceBackedSetElementTextContentUpdatesSourceAndProjection) {
   const auto& textComponent = text.entityHandle().get<components::TextComponent>();
   EXPECT_EQ(textComponent.text, "hello & goodbye");
   EXPECT_THAT(textComponent.textChunks, testing::ElementsAre(RcString("hello & goodbye")));
+}
+
+TEST(SVGDocument, SourceBackedSetElementTextContentEmptyRemovesExistingTextNode) {
+  auto document =
+      ParseSVG(R"(<svg xmlns="http://www.w3.org/2000/svg"><text id="label">hello</text></svg>)");
+  SVGElement text = document.querySelector("#label").value();
+
+  xml::ApplySourceEditResult result = document.setElementTextContent(text, "");
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_THAT(result.diagnostic, Eq(std::nullopt));
+  EXPECT_THAT(document.source(), testing::HasSubstr(R"(<text id="label"></text>)"));
+  const auto& textComponent = text.entityHandle().get<components::TextComponent>();
+  EXPECT_EQ(textComponent.text, "");
+  EXPECT_THAT(textComponent.textChunks, testing::ElementsAre(RcString("")));
 }
 
 TEST(SVGDocument, SourceBackedSetElementTextContentWithElementChildrenStaysComponentOnly) {
@@ -387,6 +582,29 @@ TEST(SVGDocument, SourceBackedInsertAndRemoveElementUpdateSource) {
   EXPECT_TRUE(removeResult.applied);
   EXPECT_THAT(document.querySelector("#inserted"), Eq(std::nullopt));
   EXPECT_THAT(document.source(), testing::Not(testing::HasSubstr("inserted")));
+}
+
+TEST(SVGDocument, SourceBackedInsertBeforeXmlReferenceUpdatesSourceOrder) {
+  auto document =
+      ParseSVG(R"(<svg xmlns="http://www.w3.org/2000/svg"><rect id="a"/><rect id="b"/></svg>)");
+  SVGElement reference = document.querySelector("#b").value();
+  SVGRectElement inserted = SVGRectElement::Create(document);
+  inserted.setId("inserted");
+
+  xml::ApplySourceEditResult result =
+      document.insertElement(document.svgElement(), inserted, reference);
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_THAT(result.diagnostic, Eq(std::nullopt));
+  const std::string_view source = document.source();
+  const std::size_t aOffset = source.find(R"(id="a")");
+  const std::size_t insertedOffset = source.find(R"(id="inserted")");
+  const std::size_t bOffset = source.find(R"(id="b")");
+  ASSERT_NE(aOffset, std::string_view::npos);
+  ASSERT_NE(insertedOffset, std::string_view::npos);
+  ASSERT_NE(bOffset, std::string_view::npos);
+  EXPECT_LT(aOffset, insertedOffset);
+  EXPECT_LT(insertedOffset, bOffset);
 }
 
 TEST(SVGDocument, SourceBackedMoveElementBetweenParentsMarksOldParentRemoved) {
@@ -453,6 +671,35 @@ TEST(SVGDocument, ProgrammaticInsertElementFallbackDoesNotMutateSourceLessDocume
   EXPECT_THAT(document.querySelector("#detached"), Eq(std::nullopt));
 }
 
+TEST(SVGDocument, SourceBackedInsertElementWithoutXmlParentIdentityFallsBackToUnapplied) {
+  auto document = ParseSVG(R"(<svg xmlns="http://www.w3.org/2000/svg"/>)");
+  SVGRectElement detachedParent = SVGRectElement::Create(document);
+  SVGRectElement child = SVGRectElement::Create(document);
+  child.setId("child");
+
+  xml::ApplySourceEditResult result = document.insertElement(detachedParent, child);
+
+  EXPECT_FALSE(result.applied);
+  EXPECT_THAT(result.diagnostic, Eq(std::nullopt));
+  EXPECT_THAT(document.querySelector("#child"), Eq(std::nullopt));
+  EXPECT_THAT(document.source(), testing::Not(testing::HasSubstr("child")));
+}
+
+TEST(SVGDocument, SourceBackedRemoveProgrammaticElementWithXmlIdentityUpdatesSource) {
+  auto document = ParseSVG(R"(<svg xmlns="http://www.w3.org/2000/svg"/>)");
+  SVGRectElement rect = SVGRectElement::Create(document);
+  rect.setId("programmatic");
+  document.svgElement().appendChild(rect);
+  ASSERT_THAT(document.querySelector("#programmatic"), Optional(ElementIdEq("programmatic")));
+
+  xml::ApplySourceEditResult result = document.removeElement(rect);
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_THAT(result.diagnostic, Eq(std::nullopt));
+  EXPECT_THAT(document.querySelector("#programmatic"), Eq(std::nullopt));
+  EXPECT_THAT(document.source(), testing::Not(testing::HasSubstr("programmatic")));
+}
+
 TEST(SVGDocument, ProgrammaticRemoveElementFallbackRemovesAttachedElement) {
   SVGDocument document;
   SVGRectElement rect = SVGRectElement::Create(document);
@@ -465,6 +712,19 @@ TEST(SVGDocument, ProgrammaticRemoveElementFallbackRemovesAttachedElement) {
   EXPECT_FALSE(result.applied);
   EXPECT_THAT(result.diagnostic, Eq(std::nullopt));
   EXPECT_THAT(document.querySelector("#attached"), Eq(std::nullopt));
+}
+
+TEST(SVGDocument, SourceBackedRemoveDetachedElementWithoutXmlIdentityIsUnapplied) {
+  auto document = ParseSVG(R"(<svg xmlns="http://www.w3.org/2000/svg"/>)");
+  SVGRectElement detached = SVGRectElement::Create(document);
+  detached.setId("detached");
+
+  xml::ApplySourceEditResult result = document.removeElement(detached);
+
+  EXPECT_FALSE(result.applied);
+  EXPECT_THAT(result.diagnostic, Eq(std::nullopt));
+  EXPECT_THAT(document.querySelector("#detached"), Eq(std::nullopt));
+  EXPECT_THAT(document.source(), testing::Not(testing::HasSubstr("detached")));
 }
 
 TEST(SVGDocument, TypedMutationHelperWrapsDomOperations) {
@@ -519,6 +779,7 @@ TEST(SVGDocument, ProjectsKnownElementTypes) {
       <polyline id="polyline"/>
       <rect id="rect"/>
       <style id="style">rect { fill: red; }</style>
+      <switch id="switch"/>
       <text id="text"><tspan id="tspan">hello</tspan></text>
       <custom id="custom"/>
     </svg>
@@ -538,6 +799,7 @@ TEST(SVGDocument, ProjectsKnownElementTypes) {
   EXPECT_EQ(document.querySelector("#polyline")->type(), ElementType::Polyline);
   EXPECT_EQ(document.querySelector("#rect")->type(), ElementType::Rect);
   EXPECT_EQ(document.querySelector("#style")->type(), ElementType::Style);
+  EXPECT_EQ(document.querySelector("#switch")->type(), ElementType::Switch);
   EXPECT_EQ(document.querySelector("#text")->type(), ElementType::Text);
   EXPECT_EQ(document.querySelector("#tspan")->type(), ElementType::TSpan);
   EXPECT_EQ(document.querySelector("#custom")->type(), ElementType::Unknown);

--- a/donner/svg/tests/SVGElement_tests.cc
+++ b/donner/svg/tests/SVGElement_tests.cc
@@ -84,6 +84,16 @@ MATCHER_P(ElementIdEq, id, "") {
   return arg.id() == id;
 }
 
+void AssignAnchorToSelf(ElementAnchor& anchor) {
+  ElementAnchor& same = anchor;
+  anchor = same;
+}
+
+void MoveAssignAnchorToSelf(ElementAnchor& anchor) {
+  ElementAnchor& same = anchor;
+  anchor = std::move(same);
+}
+
 }  // namespace
 
 TEST_F(SVGElementTests, Equality) {
@@ -108,6 +118,30 @@ TEST_F(SVGElementTests, Assign) {
   element3 = std::move(element2);
   EXPECT_EQ(element1, element3);
   EXPECT_NE(element2, element3);  // element2 should be invalid.
+}
+
+TEST_F(SVGElementTests, ElementAnchorHandlesEmptyAndSelfAssignment) {
+  ElementAnchor empty;
+  EXPECT_FALSE(empty);
+  EXPECT_FALSE(empty.valid());
+  EXPECT_EQ(empty.unsafeRegistry(), nullptr);
+  EXPECT_FALSE(empty.unsafeResolve().valid());
+
+  SVGRectElement rect = createRect();
+  ElementAnchor anchor(rect.entityHandle());
+  ASSERT_TRUE(anchor.valid());
+  const Entity entity = anchor.entity();
+  const std::uint32_t generation = anchor.generation();
+
+  AssignAnchorToSelf(anchor);
+  EXPECT_TRUE(anchor.valid());
+  EXPECT_EQ(anchor.entity(), entity);
+  EXPECT_EQ(anchor.generation(), generation);
+
+  MoveAssignAnchorToSelf(anchor);
+  EXPECT_TRUE(anchor.valid());
+  EXPECT_EQ(anchor.entity(), entity);
+  EXPECT_EQ(anchor.generation(), generation);
 }
 
 TEST_F(SVGElementTests, ScopedAccessExposesResolvedHandle) {
@@ -1053,6 +1087,30 @@ TEST_F(SVGElementTests, TraversalSkipsXmlTextNodes) {
   EXPECT_THAT(label->lastChild(), Optional(ElementIdEq("span")));
   EXPECT_THAT(span->nextSibling(), testing::Eq(std::nullopt));
   EXPECT_THAT(span->previousSibling(), testing::Eq(std::nullopt));
+}
+
+TEST_F(SVGElementTests, TraversalSkipsCommentsAndCDataNodes) {
+  auto document = parseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <!-- before -->
+      <![CDATA[ignored]]>
+      <rect id="a"/>
+      <!-- middle -->
+      <rect id="b"/>
+      <![CDATA[ignored too]]>
+    </svg>
+  )");
+
+  SVGElement root = document.svgElement();
+  ASSERT_THAT(root.firstChild(), Optional(ElementIdEq("a")));
+  ASSERT_THAT(root.lastChild(), Optional(ElementIdEq("b")));
+
+  SVGElement a = root.firstChild().value();
+  SVGElement b = root.lastChild().value();
+  ASSERT_THAT(a.nextSibling(), Optional(ElementIdEq("b")));
+  ASSERT_THAT(b.previousSibling(), Optional(ElementIdEq("a")));
+  EXPECT_THAT(a.previousSibling(), testing::Eq(std::nullopt));
+  EXPECT_THAT(b.nextSibling(), testing::Eq(std::nullopt));
 }
 
 TEST_F(SVGElementTests, IsKnownType) {

--- a/donner/svg/tests/SVGTextElement_tests.cc
+++ b/donner/svg/tests/SVGTextElement_tests.cc
@@ -6,6 +6,10 @@
 #include "donner/base/tests/BaseTestUtils.h"
 #include "donner/base/xml/components/TreeComponent.h"
 #include "donner/svg/SVGTSpanElement.h"
+#include "donner/svg/components/DirtyFlagsComponent.h"
+#include "donner/svg/components/text/ComputedTextComponent.h"
+#include "donner/svg/components/text/ComputedTextGeometryComponent.h"
+#include "donner/svg/components/text/TextPositioningComponent.h"
 #include "donner/svg/renderer/tests/RendererTestUtils.h"
 #include "donner/svg/tests/ParserTestUtils.h"
 
@@ -68,6 +72,56 @@ TEST(SVGTextElementTests, PositionAttributes) {
   EXPECT_THAT(text->xList(), testing::ElementsAre(LengthIs(10.0, Lengthd::Unit::None),
                                                   LengthIs(20.0, Lengthd::Unit::None)));
   EXPECT_THAT(text->rotateList(), testing::ElementsAre(0.0, 45.0, 90.0));
+}
+
+TEST(SVGTextElementTests, SetAttributeUpdatesPositioningAndInvalidatesTextRoot) {
+  SVGDocument document = instantiateSubtree(R"(
+    <svg viewBox="0 0 120 40">
+      <text id="root" x="1" y="2">A<tspan id="span">BC</tspan></text>
+    </svg>
+  )",
+                                            kExperimentalOptions);
+
+  auto root = document.querySelector("#root")->cast<SVGTextElement>();
+  auto span = document.querySelector("#span")->cast<SVGTSpanElement>();
+  auto& registry = document.registry();
+  const Entity rootEntity = root.unsafeEntityHandle().entity();
+  const Entity spanEntity = span.unsafeEntityHandle().entity();
+
+  registry.emplace_or_replace<components::ComputedTextComponent>(rootEntity);
+  registry.emplace_or_replace<components::ComputedTextGeometryComponent>(rootEntity);
+  registry.remove<components::DirtyFlagsComponent>(rootEntity);
+
+  span.setAttribute("dx", "4px, 5%, 6");
+  const auto& positioning = registry.get<components::TextPositioningComponent>(spanEntity);
+
+  EXPECT_THAT(positioning.dx, testing::ElementsAre(LengthIs(4.0, Lengthd::Unit::Px),
+                                                   LengthIs(5.0, Lengthd::Unit::Percent),
+                                                   LengthIs(6.0, Lengthd::Unit::None)));
+  EXPECT_FALSE(registry.any_of<components::ComputedTextComponent>(rootEntity));
+  EXPECT_FALSE(registry.any_of<components::ComputedTextGeometryComponent>(rootEntity));
+  ASSERT_TRUE(registry.any_of<components::DirtyFlagsComponent>(rootEntity));
+  EXPECT_TRUE(registry.get<components::DirtyFlagsComponent>(rootEntity)
+                  .test(components::DirtyFlagsComponent::TextGeometry |
+                        components::DirtyFlagsComponent::RenderInstance));
+
+  span.setAttribute("dy", "7 8");
+  span.setAttribute("rotate", "15, 30");
+  const auto& updatedPositioning = registry.get<components::TextPositioningComponent>(spanEntity);
+  EXPECT_THAT(updatedPositioning.dy, testing::ElementsAre(LengthIs(7.0, Lengthd::Unit::None),
+                                                          LengthIs(8.0, Lengthd::Unit::None)));
+  EXPECT_THAT(updatedPositioning.rotateDegrees, testing::ElementsAre(15.0, 30.0));
+}
+
+TEST(SVGTextElementTests, SetAttributeRejectsInvalidPositioningLists) {
+  auto text = instantiateSubtreeElementAs<SVGTextElement>(R"(<text x="10">ABC</text>)",
+                                                          kExperimentalOptions);
+
+  text->setAttribute("x", "20bogus");
+  text->setAttribute("rotate", "10deg");
+
+  EXPECT_THAT(text->xList(), testing::ElementsAre(LengthIs(10.0, Lengthd::Unit::None)));
+  EXPECT_THAT(text->rotateList(), testing::IsEmpty());
 }
 
 TEST(SVGTextElementTests, TextLengthAndAdjust) {

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -21,30 +21,38 @@ py_binary(
 genrule(
     name = "generate_embedded_test_resources",
     srcs = ["//third_party/public-sans:PublicSans-Medium.otf"],  # The resource file
-    outs = ["py_embedded_dir/public_sans_embedded.h", "py_embedded_dir/PublicSans_Medium_otf.cpp"],
+    outs = [
+        "py_embedded_dir/public_sans_embedded.h",
+        "py_embedded_dir/PublicSans_Medium_otf.cpp",
+    ],
     cmd = """
         # Create the output dir in case the action is sandboxed
         mkdir -p "$(@D)/py_embedded_dir"
         $(location //tools:embed_resources) --out "$(@D)/py_embedded_dir" --header public_sans_embedded.h kPublicSansMediumOtf=$(SRCS)
     """,
     tools = [":embed_resources"],  # Depends on the py_binary
-    visibility = ["//visibility:private"], # Only used by the test in this file
+    visibility = ["//visibility:private"],  # Only used by the test in this file
 )
 
 py_test(
     name = "embed_resources_tests",
     srcs = ["embed_resources_tests.py"],
     args = [
-        "--generated_header_name", "public_sans_embedded.h",
-        "--generated_cpp_name", "PublicSans_Medium_otf.cpp",
-        "--generated_files_subdir", "donner/tools/py_embedded_dir",
-        "--golden_header_path", "$(location //third_party/public-sans:embedded_header)",
-        "--golden_cpp_path", "$(location //third_party/public-sans:embedded_cpp)",
+        "--generated_header_name",
+        "public_sans_embedded.h",
+        "--generated_cpp_name",
+        "PublicSans_Medium_otf.cpp",
+        "--generated_files_subdir",
+        "donner/tools/py_embedded_dir",
+        "--golden_header_path",
+        "$(location //third_party/public-sans:embedded_header)",
+        "--golden_cpp_path",
+        "$(location //third_party/public-sans:embedded_cpp)",
     ],
     data = [
         ":generate_embedded_test_resources",
-        "//third_party/public-sans:embedded_header",
         "//third_party/public-sans:embedded_cpp",
+        "//third_party/public-sans:embedded_header",
     ],
     deps = ["@rules_python//python/runfiles"],
 )
@@ -62,6 +70,22 @@ py_test(
     srcs = [
         "check_lcov_report.py",
         "check_lcov_report_tests.py",
+    ],
+)
+
+py_test(
+    name = "ci_diagnostics_report_tests",
+    srcs = [
+        "ci_diagnostics_report.py",
+        "ci_diagnostics_report_tests.py",
+    ],
+)
+
+py_test(
+    name = "lcov_metrics_tests",
+    srcs = [
+        "lcov_metrics.py",
+        "lcov_metrics_tests.py",
     ],
 )
 

--- a/tools/ci_diagnostics_report.py
+++ b/tools/ci_diagnostics_report.py
@@ -7,10 +7,12 @@ Reads the artifact layout produced by the self-hosted CI jobs:
     <diag_dir>/target-list.txt
     <diag_dir>/{build,test}/profile.gz   Bazel --profile (Chrome trace JSON)
     <diag_dir>/{build,test}/bep.json     Bazel --build_event_json_file
+    <diag_dir>/{build,test}/console.log  Bazel stdout/stderr
 
 and prints markdown with phase timing, the slowest compile/link/test actions,
-and per-test wall times. Stdlib only; safe to run on partial artifacts (a
-failed build uploads whatever exists).
+per-test wall times, and console tails for incomplete Bazel event streams.
+Stdlib only; safe to run on partial artifacts (a failed build uploads whatever
+exists).
 
 Usage: python3 tools/ci_diagnostics_report.py <diag_dir>
 """
@@ -19,8 +21,10 @@ import gzip
 import json
 import os
 import sys
+from collections import deque
 
 TOP_N = 20
+CONSOLE_TAIL_LINES = 80
 
 
 def load_profile_events(path):
@@ -73,6 +77,40 @@ def profile_summary(name, path, lines):
     top("Slowest other actions",
         lambda n: not n.startswith(("Compiling", "Linking", "Archiving",
                                     "Testing")))
+    lines.append("")
+
+
+def has_build_finished(path):
+    if not os.path.exists(path):
+        return False
+    with open(path, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if event.get("id", {}).get("buildFinished") is not None:
+                return True
+    return False
+
+
+def console_tail_summary(name, bep_path, console_path, lines):
+    if not os.path.exists(console_path) or has_build_finished(bep_path):
+        return
+
+    tail = deque(maxlen=CONSOLE_TAIL_LINES)
+    with open(console_path, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            tail.append(line.rstrip("\n"))
+
+    if not tail:
+        return
+
+    lines.append(
+        f"**{name} console tail (no terminal Bazel build event captured):**")
+    lines.append("```")
+    lines.extend(tail)
+    lines.append("```")
     lines.append("")
 
 
@@ -129,8 +167,12 @@ def main():
 
     profile_summary("Build", os.path.join(diag_dir, "build", "profile.gz"),
                     lines)
+    console_tail_summary("Build", os.path.join(diag_dir, "build", "bep.json"),
+                         os.path.join(diag_dir, "build", "console.log"), lines)
     profile_summary("Test", os.path.join(diag_dir, "test", "profile.gz"),
                     lines)
+    console_tail_summary("Test", os.path.join(diag_dir, "test", "bep.json"),
+                         os.path.join(diag_dir, "test", "console.log"), lines)
     test_summary(os.path.join(diag_dir, "test", "bep.json"), lines)
 
     print("\n".join(lines))

--- a/tools/ci_diagnostics_report_tests.py
+++ b/tools/ci_diagnostics_report_tests.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Tests for ci_diagnostics_report.py."""
+
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import ci_diagnostics_report
+
+
+class CiDiagnosticsReportTests(unittest.TestCase):
+    def test_console_tail_is_reported_for_incomplete_bep(self) -> None:
+        bep = self._write("build/bep.json", json.dumps({"id": {"started": {}}}) + "\n")
+        console_lines = [f"line-{index}" for index in range(1, 86)]
+        console = self._write("build/console.log", "\n".join(console_lines) + "\n")
+
+        lines: list[str] = []
+        ci_diagnostics_report.console_tail_summary("Build", bep, console, lines)
+
+        report = "\n".join(lines)
+        self.assertIn("Build console tail", report)
+        self.assertIn("line-85", report)
+        self.assertIn("line-6", report)
+        self.assertNotIn("line-5", lines)
+
+    def test_console_tail_is_suppressed_for_complete_bep(self) -> None:
+        bep = self._write("build/bep.json", json.dumps({"id": {"buildFinished": {}}}) + "\n")
+        console = self._write("build/console.log", "last visible line\n")
+
+        lines: list[str] = []
+        ci_diagnostics_report.console_tail_summary("Build", bep, console, lines)
+
+        self.assertEqual(lines, [])
+
+    def _write(self, relative_path: str, contents: str) -> str:
+        path = Path(self._tmpdir.name) / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(contents, encoding="utf-8")
+        return str(path)
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -1,20 +1,23 @@
 #!/bin/bash -e
 
 function print_help() {
-  echo "Usage: $0 [--quiet] [--no-html] [TARGETS...]"
+  echo "Usage: $0 [--quiet] [--no-html] [--branch-target PERCENT] [--output-dir DIR] [TARGETS...]"
   echo "Run coverage analysis on the specified Bazel targets."
   echo "If no targets are specified, coverage is run on '//donner/...'."
   echo ""
   echo "Options:"
-  echo "  --quiet  Suppress debug output."
-  echo "  --no-html  Skip HTML generation and only emit filtered LCOV output."
-  echo "  --help   Show this help message."
+  echo "  --quiet                  Suppress debug output."
+  echo "  --no-html                Skip HTML generation and only emit filtered LCOV output."
+  echo "  --branch-target PERCENT  Print branch-hit shortfall to this target (default: 85)."
+  echo "  --output-dir DIR         Directory for filtered LCOV/HTML output (default: coverage-report)."
+  echo "  --help                   Show this help message."
   exit 0
 }
 
 TARGETS=()
 BAZEL_COVERAGE_FLAGS=()
 DEFAULT_BAZEL_COVERAGE_FLAGS=()
+read -r -a BAZEL_CMD <<< "${DONNER_BAZEL:-bazel}"
 
 if [[ -n "${DONNER_COVERAGE_BAZEL_FLAGS:-}" ]]; then
   read -r -a BAZEL_COVERAGE_FLAGS <<< "$DONNER_COVERAGE_BAZEL_FLAGS"
@@ -30,17 +33,50 @@ fi
 # Check for --quiet option
 QUIET=false
 NO_HTML=false
-for arg in "$@"; do
-  # --quiet: suppress debug output
-  if [[ $arg == "--quiet" ]]; then
-    QUIET=true
-  elif [[ $arg == "--no-html" ]]; then
-    NO_HTML=true
-  elif [[ $arg == "--help" ]]; then
-    print_help
-  else
-    TARGETS+=("$arg")
-  fi
+BRANCH_TARGET=85
+COVERAGE_OUTPUT_DIR=coverage-report
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --quiet)
+      QUIET=true
+      shift
+      ;;
+    --no-html)
+      NO_HTML=true
+      shift
+      ;;
+    --branch-target)
+      if [[ $# -lt 2 ]]; then
+        echo "ERROR: --branch-target requires a percentage value"
+        exit 1
+      fi
+      BRANCH_TARGET="$2"
+      shift 2
+      ;;
+    --branch-target=*)
+      BRANCH_TARGET="${1#--branch-target=}"
+      shift
+      ;;
+    --output-dir)
+      if [[ $# -lt 2 ]]; then
+        echo "ERROR: --output-dir requires a directory"
+        exit 1
+      fi
+      COVERAGE_OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --output-dir=*)
+      COVERAGE_OUTPUT_DIR="${1#--output-dir=}"
+      shift
+      ;;
+    --help)
+      print_help
+      ;;
+    *)
+      TARGETS+=("$1")
+      shift
+      ;;
+  esac
 done
 
 # Default to //donner/... if no targets are specified
@@ -65,7 +101,7 @@ if ! which java > /dev/null; then
 fi
 
 JAVA_HOME=$(dirname $(dirname $(which java)))
-WORKSPACE_ROOT=$(bazel info workspace)
+WORKSPACE_ROOT=$("${BAZEL_CMD[@]}" info workspace)
 
 BAZEL_TEST_ENV=()
 if [[ "$(uname)" == "Darwin" ]]; then
@@ -103,10 +139,10 @@ LLVM_COVERAGE_FLAGS=(
 (
   cd "$WORKSPACE_ROOT"
 
-  COVERAGE_HTML_DIR=coverage-report
+  COVERAGE_HTML_DIR="$COVERAGE_OUTPUT_DIR"
   GENHTML_OPTIONS="--legend --branch-coverage --ignore-errors category --ignore-errors inconsistent --output-directory $COVERAGE_HTML_DIR"
 
-  COVERAGE_REPORT=$(bazel info output_path)/_coverage/_coverage_report.dat
+  COVERAGE_REPORT=$("${BAZEL_CMD[@]}" info output_path)/_coverage/_coverage_report.dat
 
   # CI diagnostics: when DONNER_CI_DIAGNOSTICS_DIR is set (self-hosted CI),
   # capture the inner `bazel coverage` profile + BEP there and record phase
@@ -132,14 +168,14 @@ LLVM_COVERAGE_FLAGS=(
   rm -f "$COVERAGE_REPORT"
 
   if [ "$QUIET" = true ]; then
-    bazel coverage --config=latest_llvm --ui_event_filters=-info,-stdout,-stderr --noshow_progress \
+    "${BAZEL_CMD[@]}" coverage --config=latest_llvm --ui_event_filters=-info,-stdout,-stderr --noshow_progress \
       "${DEFAULT_BAZEL_COVERAGE_FLAGS[@]}" \
       "${BAZEL_COVERAGE_FLAGS[@]}" \
       "${LLVM_COVERAGE_FLAGS[@]}" \
       "${DIAG_FLAGS[@]}" \
       "${BAZEL_TEST_ENV[@]}" "${TARGETS[@]}" || true
   else
-    bazel coverage --config=latest_llvm \
+    "${BAZEL_CMD[@]}" coverage --config=latest_llvm \
       "${DEFAULT_BAZEL_COVERAGE_FLAGS[@]}" \
       "${BAZEL_COVERAGE_FLAGS[@]}" \
       "${LLVM_COVERAGE_FLAGS[@]}" \
@@ -163,6 +199,8 @@ LLVM_COVERAGE_FLAGS=(
     python3 tools/filter_coverage.py --verbose "${FILTER_ARGS[@]}"
   fi
   python3 tools/check_lcov_report.py "$COVERAGE_HTML_DIR/filtered_report.dat"
+  python3 tools/lcov_metrics.py "$COVERAGE_HTML_DIR/filtered_report.dat" \
+    --branch-target "$BRANCH_TARGET"
   phase_mark filter_done
 
   if [ "$NO_HTML" = false ]; then
@@ -176,7 +214,7 @@ LLVM_COVERAGE_FLAGS=(
 )
 
 if [ "$NO_HTML" = true ]; then
-  echo "Filtered coverage report saved to coverage-report/filtered_report.dat"
+  echo "Filtered coverage report saved to $COVERAGE_OUTPUT_DIR/filtered_report.dat"
 else
-  echo "Coverage report saved to coverage-report/index.html"
+  echo "Coverage report saved to $COVERAGE_OUTPUT_DIR/index.html"
 fi

--- a/tools/lcov_metrics.py
+++ b/tools/lcov_metrics.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Report Codecov-relevant LCOV line and branch coverage metrics."""
+
+import argparse
+from dataclasses import dataclass, field
+import json
+from math import ceil
+from pathlib import Path
+import sys
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CoverageCounts:
+    """Hit/found coverage counts."""
+
+    hit: int = 0
+    found: int = 0
+
+    @property
+    def percent(self) -> float:
+        """Return hit/found as a percentage, or 100 for an empty denominator."""
+        if self.found == 0:
+            return 100.0
+        return self.hit / self.found * 100.0
+
+    def hits_needed_for(self, target_percent: float) -> int:
+        """Return additional hits needed to reach target_percent for this denominator."""
+        if self.found == 0:
+            return 0
+        target_hits = ceil(target_percent / 100.0 * self.found)
+        return max(0, target_hits - self.hit)
+
+
+@dataclass(frozen=True)
+class FileCoverage:
+    """Coverage counters for one LCOV source file record."""
+
+    source_file: str
+    lines: CoverageCounts = field(default_factory=CoverageCounts)
+    branches: CoverageCounts = field(default_factory=CoverageCounts)
+
+    @property
+    def missed_branches(self) -> int:
+        """Return uncovered branch counters for this file."""
+        return self.branches.found - self.branches.hit
+
+
+@dataclass(frozen=True)
+class LcovMetrics:
+    """Coverage counters for an LCOV report."""
+
+    files: list[FileCoverage]
+    lines: CoverageCounts
+    branches: CoverageCounts
+
+
+def collect_lcov_metrics(path: Path) -> LcovMetrics:
+    """Collect line and branch coverage counters from an LCOV report."""
+    files: list[FileCoverage] = []
+    source_file: str | None = None
+    line_found = 0
+    line_hit = 0
+    branch_found = 0
+    branch_hit = 0
+
+    def flush_record() -> None:
+        nonlocal source_file, line_found, line_hit, branch_found, branch_hit
+        if source_file is not None:
+            files.append(
+                FileCoverage(
+                    source_file=source_file,
+                    lines=CoverageCounts(hit=line_hit, found=line_found),
+                    branches=CoverageCounts(hit=branch_hit, found=branch_found),
+                )
+            )
+        source_file = None
+        line_found = 0
+        line_hit = 0
+        branch_found = 0
+        branch_hit = 0
+
+    with path.open(encoding="utf-8", errors="replace") as lcov_file:
+        for raw_line in lcov_file:
+            line = raw_line.rstrip("\n")
+            if line.startswith("SF:"):
+                flush_record()
+                source_file = line[3:]
+            elif line.startswith("DA:"):
+                line_found += 1
+                if _parse_da_hit(line) > 0:
+                    line_hit += 1
+            elif line.startswith("BRDA:"):
+                branch_found += 1
+                if _parse_brda_hit(line) > 0:
+                    branch_hit += 1
+            elif line == "end_of_record":
+                flush_record()
+
+    flush_record()
+    return LcovMetrics(
+        files=files,
+        lines=CoverageCounts(
+            hit=sum(file.lines.hit for file in files),
+            found=sum(file.lines.found for file in files),
+        ),
+        branches=CoverageCounts(
+            hit=sum(file.branches.hit for file in files),
+            found=sum(file.branches.found for file in files),
+        ),
+    )
+
+
+def _parse_da_hit(line: str) -> int:
+    try:
+        return int(line.split(",", 1)[1])
+    except (IndexError, ValueError):
+        return 0
+
+
+def _parse_brda_hit(line: str) -> int:
+    try:
+        value = line.rsplit(",", 1)[1]
+    except IndexError:
+        return 0
+    if value == "-":
+        return 0
+    try:
+        return int(value)
+    except ValueError:
+        return 0
+
+
+def metrics_to_json(metrics: LcovMetrics, branch_target: float, top_misses: int) -> dict[str, Any]:
+    """Return a JSON-serializable metrics summary."""
+    top_files = sorted(metrics.files, key=lambda file: file.missed_branches, reverse=True)
+    return {
+        "source_files": len(metrics.files),
+        "lines": {
+            "hit": metrics.lines.hit,
+            "found": metrics.lines.found,
+            "percent": metrics.lines.percent,
+        },
+        "branches": {
+            "hit": metrics.branches.hit,
+            "found": metrics.branches.found,
+            "percent": metrics.branches.percent,
+            "target_percent": branch_target,
+            "hits_needed_for_target": metrics.branches.hits_needed_for(branch_target),
+        },
+        "top_branch_misses": [
+            {
+                "source_file": file.source_file,
+                "missed": file.missed_branches,
+                "hit": file.branches.hit,
+                "found": file.branches.found,
+                "percent": file.branches.percent,
+            }
+            for file in top_files
+            if file.missed_branches > 0
+        ][:top_misses],
+    }
+
+
+def print_text_summary(metrics: LcovMetrics, branch_target: float, top_misses: int) -> None:
+    """Print a compact human-readable coverage summary."""
+    print("Filtered LCOV coverage metrics:")
+    print(f"  source files: {len(metrics.files)}")
+    print(
+        f"  lines: {metrics.lines.hit}/{metrics.lines.found} "
+        f"({metrics.lines.percent:.2f}%)"
+    )
+    if metrics.branches.found == 0:
+        print("  branches: no branch counters in this report")
+    else:
+        print(
+            f"  branches: {metrics.branches.hit}/{metrics.branches.found} "
+            f"({metrics.branches.percent:.2f}%)"
+        )
+        print(
+            f"  branches to {branch_target:g}%: "
+            f"{metrics.branches.hits_needed_for(branch_target)}"
+        )
+
+    top_files = sorted(metrics.files, key=lambda file: file.missed_branches, reverse=True)
+    printed = 0
+    for file in top_files:
+        if file.missed_branches <= 0:
+            continue
+        if printed == 0:
+            print("  top branch misses:")
+        print(
+            f"    {file.missed_branches:4d} "
+            f"{file.branches.hit:4d}/{file.branches.found:<4d} {file.source_file}"
+        )
+        printed += 1
+        if printed >= top_misses:
+            break
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", type=Path, help="Filtered LCOV report to summarize")
+    parser.add_argument(
+        "--branch-target",
+        type=float,
+        default=85.0,
+        help="Branch coverage target percentage to compute the hit shortfall for",
+    )
+    parser.add_argument(
+        "--top-misses",
+        type=int,
+        default=20,
+        help="Number of source files with the most missed branch counters to print",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    args = parser.parse_args()
+
+    try:
+        metrics = collect_lcov_metrics(args.report)
+    except FileNotFoundError:
+        print(f"ERROR: Coverage report not found: {args.report}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(metrics_to_json(metrics, args.branch_target, args.top_misses), indent=2))
+    else:
+        print_text_summary(metrics, args.branch_target, args.top_misses)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/lcov_metrics_tests.py
+++ b/tools/lcov_metrics_tests.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Tests for lcov_metrics.py."""
+
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import lcov_metrics
+
+
+class LcovMetricsTest(unittest.TestCase):
+    def test_collects_line_and_branch_counts_from_brda_entries(self) -> None:
+        report = self._write_report(
+            """\
+SF:donner/base/Foo.cc
+DA:10,1
+DA:11,0
+BRDA:10,0,0,1
+BRDA:10,0,1,0
+BRDA:11,0,0,-
+end_of_record
+SF:donner/base/Bar.cc
+DA:5,3
+BRDA:5,0,0,2
+end_of_record
+"""
+        )
+
+        metrics = lcov_metrics.collect_lcov_metrics(report)
+
+        self.assertEqual(metrics.lines.hit, 2)
+        self.assertEqual(metrics.lines.found, 3)
+        self.assertEqual(metrics.branches.hit, 2)
+        self.assertEqual(metrics.branches.found, 4)
+        self.assertEqual(metrics.branches.hits_needed_for(75.0), 1)
+        self.assertEqual(metrics.files[0].missed_branches, 2)
+
+    def test_json_summary_reports_branch_target_shortfall_and_top_misses(self) -> None:
+        report = self._write_report(
+            """\
+SF:donner/base/Foo.cc
+DA:10,1
+BRDA:10,0,0,1
+BRDA:10,0,1,0
+end_of_record
+SF:donner/base/Bar.cc
+DA:5,0
+BRDA:5,0,0,0
+BRDA:5,0,1,0
+end_of_record
+"""
+        )
+
+        summary = lcov_metrics.metrics_to_json(
+            lcov_metrics.collect_lcov_metrics(report),
+            branch_target=85.0,
+            top_misses=1,
+        )
+
+        self.assertEqual(summary["source_files"], 2)
+        self.assertEqual(summary["branches"]["hit"], 1)
+        self.assertEqual(summary["branches"]["found"], 4)
+        self.assertEqual(summary["branches"]["hits_needed_for_target"], 3)
+        self.assertEqual(len(summary["top_branch_misses"]), 1)
+        self.assertEqual(summary["top_branch_misses"][0]["source_file"], "donner/base/Bar.cc")
+
+    def _write_report(self, contents: str) -> Path:
+        report = Path(self._tmpdir.name) / "report.dat"
+        report.write_text(contents, encoding="utf-8")
+        return report
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the next batch of focused unit coverage across editor presenters and shell behavior, XML/path helpers, SVG document/text behavior, renderer text helpers, and coverage/CI diagnostic tooling.

Current Codecov-style filtered LCOV branch coverage from the pre-rebase coverage run:

- Branches: `24853/29460` = `84.36%`
- Lines: `58640/63002` = `93.08%`
- Remaining to 85%: `188` covered branches

Also updates the LLM/PR rules to stop publishing draft diffs, adds `tools/lcov_metrics.py` so partial-target coverage runs report branch-target shortfall directly, and carries forward the `unittests` Codecov flag.

Validation before opening:

- `tools/llm-bazel-wrap.sh test //... --test_output=errors`
- `python3 tools/cmake/gen_cmakelists.py --check`
- `DONNER_BAZEL=tools/llm-bazel-wrap.sh tools/coverage.sh --quiet --no-html --branch-target 85 --output-dir /private/tmp/donner-coverage-85-stacked`

Post-rebase conflict validation:

- `tools/llm-bazel-wrap.sh test //donner/base/xml:xml_tests //donner/editor/tests:text_editor_core_tests --test_output=errors`
- `tools/llm-bazel-wrap.sh test --config=text-full //donner/svg/renderer/tests:text_engine_tests --test_output=errors`

Note: the first non-escalated CMake check failed because Bazel's output base was not writable from the sandbox; the same command passed with filesystem approval.