### PR TITLE
Switch conformance follow-ups: user-language API and child-eligibility fix

### DIFF
--- a/donner/svg/SVGDocument.cc
+++ b/donner/svg/SVGDocument.cc
@@ -570,6 +570,26 @@ Transform2d SVGDocument::canvasFromDocumentTransform() const {
   return components::LayoutSystem().getCanvasFromDocumentTransform(access.registry());
 }
 
+void SVGDocument::setUserLanguages(std::vector<RcString> languages) {
+  DocumentMutationBatch mutation(*documentState_, true);
+  DocumentWriteAccess& access = mutation.access();
+  Registry& registry = access.registry();
+  auto& documentContext = registry.ctx().get<components::SVGDocumentContext>();
+  if (documentContext.userLanguages == languages) {
+    mutation.cancel();
+    return;
+  }
+  // Changing the language list changes which conditional-processing branches render, so the render
+  // tree (and any downstream text layout) must be rebuilt.
+  components::RenderingContext(registry).invalidateRenderTree();
+  documentContext.userLanguages = std::move(languages);
+}
+
+std::vector<RcString> SVGDocument::userLanguages() const {
+  DocumentReadAccess access = documentState_->read();
+  return access.registry().ctx().get<components::SVGDocumentContext>().userLanguages;
+}
+
 void SVGDocument::useAutomaticCanvasSize() {
   DocumentMutationBatch mutation(*documentState_, true);
   DocumentWriteAccess& access = mutation.access();

--- a/donner/svg/SVGDocument.h
+++ b/donner/svg/SVGDocument.h
@@ -12,6 +12,7 @@
 #include "donner/base/EcsRegistry.h"
 #include "donner/base/ParseDiagnostic.h"
 #include "donner/base/ParseWarningSink.h"
+#include "donner/base/RcString.h"
 #include "donner/base/Utils.h"
 #include "donner/base/xml/XMLDocument.h"
 #include "donner/base/xml/XMLQualifiedName.h"
@@ -328,6 +329,26 @@ public:
    * click math in editors/viewers) should invert it.
    */
   Transform2d canvasFromDocumentTransform() const;
+
+  /**
+   * Set the user's preferred languages, in priority order, used to evaluate the `systemLanguage`
+   * conditional processing attribute (on \ref xml_switch children and on renderable elements).
+   *
+   * Each entry is a BCP 47 language tag such as `"en"` or `"en-US"`. A `systemLanguage` value
+   * matches when it equals (case-insensitive) one of these languages, or begins with one of these
+   * languages followed by `-` (e.g. user language `"en"` matches `systemLanguage="en-GB"`).
+   *
+   * Defaults to `{"en"}` when not set. Passing an empty list disables all `systemLanguage` matches.
+   *
+   * @param languages User's preferred languages, in priority order.
+   */
+  void setUserLanguages(std::vector<RcString> languages);
+
+  /**
+   * Get the user's preferred languages used to evaluate the `systemLanguage` conditional processing
+   * attribute. Defaults to `{"en"}`.
+   */
+  std::vector<RcString> userLanguages() const;
 
   /**
    * Returns true if the two SVGDocument handles reference the same underlying document.

--- a/donner/svg/components/ConditionalProcessingComponent.cc
+++ b/donner/svg/components/ConditionalProcessingComponent.cc
@@ -6,12 +6,6 @@ namespace donner::svg::components {
 
 namespace {
 
-/**
- * The user-preferred language used to evaluate `systemLanguage`, matching resvg's default
- * language list of `["en"]`, which the resvg-test-suite goldens are rendered with.
- */
-constexpr std::string_view kUserLanguage = "en";
-
 using ConditionalProcessingField = std::optional<RcString> ConditionalProcessingComponent::*;
 
 ConditionalProcessingField FieldForConditionalProcessingAttribute(
@@ -88,7 +82,8 @@ bool SystemLanguageMatches(std::string_view systemLanguage, std::string_view use
   return false;
 }
 
-bool EvaluateConditionalProcessing(const ConditionalProcessingComponent& conditional) {
+bool EvaluateConditionalProcessing(const ConditionalProcessingComponent& conditional,
+                                   std::span<const RcString> userLanguages) {
   // `requiredFeatures` is deprecated in SVG2 and always evaluates to true (matching resvg, which
   // ignores it) - intentionally not checked here.
 
@@ -101,12 +96,28 @@ bool EvaluateConditionalProcessing(const ConditionalProcessingComponent& conditi
   }
 
   if (conditional.systemLanguage.has_value()) {
-    if (!SystemLanguageMatches(*conditional.systemLanguage, kUserLanguage)) {
+    // The attribute passes if any user-preferred language matches. An empty language list
+    // therefore evaluates any present `systemLanguage` to false.
+    bool matched = false;
+    for (const RcString& userLanguage : userLanguages) {
+      if (SystemLanguageMatches(*conditional.systemLanguage, userLanguage)) {
+        matched = true;
+        break;
+      }
+    }
+    if (!matched) {
       return false;
     }
   }
 
   return true;
+}
+
+bool EvaluateConditionalProcessing(const ConditionalProcessingComponent& conditional) {
+  // Default user language list of `{"en"}`, matching resvg's default (the resvg-test-suite goldens
+  // are rendered with it).
+  static const std::vector<RcString> kDefaultUserLanguages = {RcString("en")};
+  return EvaluateConditionalProcessing(conditional, kDefaultUserLanguages);
 }
 
 }  // namespace donner::svg::components

--- a/donner/svg/components/ConditionalProcessingComponent.h
+++ b/donner/svg/components/ConditionalProcessingComponent.h
@@ -2,7 +2,9 @@
 /// @file
 
 #include <optional>
+#include <span>
 #include <string_view>
+#include <vector>
 
 #include "donner/base/RcString.h"
 #include "donner/base/xml/XMLQualifiedName.h"
@@ -85,6 +87,19 @@ bool HasConditionalProcessingAttributes(const ConditionalProcessingComponent& co
  * - `requiredExtensions` evaluates to true only when empty (no extensions are supported).
  * - `systemLanguage` evaluates to true if any comma-separated tag equals a user language or is a
  *   sub-tag of it (e.g. both "en" and "en-GB" match the default user language "en").
+ *
+ * @param conditional Conditional-processing attribute values to evaluate.
+ * @param userLanguages User's preferred languages, in priority order (see \ref
+ *   SVGDocument::setUserLanguages). A `systemLanguage` value matches if any of these languages
+ *   matches per \ref SystemLanguageMatches. An empty list disables all `systemLanguage` matches.
+ * @return true if all present attributes evaluate to true (the element may render).
+ */
+bool EvaluateConditionalProcessing(const ConditionalProcessingComponent& conditional,
+                                   std::span<const RcString> userLanguages);
+
+/**
+ * Overload of \ref EvaluateConditionalProcessing that uses the default user language list of
+ * `{"en"}`, matching resvg's default (the resvg-test-suite goldens are rendered with it).
  *
  * @param conditional Conditional-processing attribute values to evaluate.
  * @return true if all present attributes evaluate to true (the element may render).

--- a/donner/svg/components/SVGDocumentContext.h
+++ b/donner/svg/components/SVGDocumentContext.h
@@ -2,6 +2,7 @@
 /// @file
 
 #include <cstdint>
+#include <vector>
 
 #include "donner/base/EcsRegistry.h"
 #include "donner/base/RcString.h"
@@ -75,6 +76,12 @@ public:
   /// Current canvas size, if set. Equivalent to the window size, which controls how the SVG
   /// contents are rendered.
   std::optional<Vector2i> canvasSize;
+
+  /// User's preferred languages, in priority order, used to evaluate the `systemLanguage`
+  /// conditional processing attribute (see \ref
+  /// donner::svg::components::ConditionalProcessingComponent and \ref xml_switch). Defaults to
+  /// `{"en"}`. Configure via \ref SVGDocument::setUserLanguages.
+  std::vector<RcString> userLanguages = {RcString("en")};
 
   /// Root entity of the document, which contains the \ref xml_svg element.
   Entity rootEntity = entt::null;

--- a/donner/svg/components/text/BUILD.bazel
+++ b/donner/svg/components/text/BUILD.bazel
@@ -58,6 +58,7 @@ cc_library(
         "//donner/base",
         "//donner/base/xml/components",
         "//donner/svg/components:components_core",
+        "//donner/svg/components:svg_document_context",
         "//donner/svg/components/shape:components",
         "//donner/svg/components/style:components",
         "//donner/svg/graph",

--- a/donner/svg/components/text/TextSystem.cc
+++ b/donner/svg/components/text/TextSystem.cc
@@ -9,6 +9,7 @@
 #include "donner/base/xml/components/AttributesComponent.h"
 #include "donner/base/xml/components/TreeComponent.h"
 #include "donner/svg/components/ConditionalProcessingComponent.h"
+#include "donner/svg/components/SVGDocumentContext.h"
 #include "donner/svg/components/layout/TransformComponent.h"
 #include "donner/svg/components/shape/ComputedPathComponent.h"
 #include "donner/svg/components/shape/PathComponent.h"
@@ -365,6 +366,13 @@ void TextSystem::instantiateComputedComponent(EntityHandle rootHandle,
 
   std::vector<PendingSpan> pendingSpans;
 
+  // User's preferred languages, used to evaluate the `systemLanguage` conditional processing
+  // attribute on text spans. Defaults to {"en"} when the document context is unavailable.
+  std::vector<RcString> userLanguages = {RcString("en")};
+  if (registry.ctx().contains<SVGDocumentContext>()) {
+    userLanguages = registry.ctx().get<SVGDocumentContext>().userLanguages;
+  }
+
   std::function<void(EntityHandle, size_t, bool)> collectSpans = [&](EntityHandle handle,
                                                                      size_t depth,
                                                                      bool parentHidden) {
@@ -388,7 +396,7 @@ void TextSystem::instantiateComputedComponent(EntityHandle rootHandle,
     // its children when they evaluate to false, e.g. `<tspan systemLanguage="ru-RU">`.
     if (!isHidden) {
       if (const auto* conditional = handle.try_get<ConditionalProcessingComponent>();
-          conditional && !EvaluateConditionalProcessing(*conditional)) {
+          conditional && !EvaluateConditionalProcessing(*conditional, userLanguages)) {
         isHidden = true;
       }
     }

--- a/donner/svg/renderer/RenderingContext.cc
+++ b/donner/svg/renderer/RenderingContext.cc
@@ -3,7 +3,9 @@
 #include <map>
 #include <optional>
 #include <set>
+#include <vector>
 
+#include "donner/base/RcString.h"
 #include "donner/base/xml/components/TreeComponent.h"
 #include "donner/svg/components/ComputedClipPathsComponent.h"
 #include "donner/svg/components/ConditionalProcessingComponent.h"
@@ -136,6 +138,13 @@ public:
     canvasFromDocumentWorldTransform_ =
         layoutSystem ? layoutSystem->getCanvasFromDocumentTransform(registry)
                      : LayoutSystem().getCanvasFromDocumentTransform(registry);
+
+    // Cache the user's preferred languages, used to evaluate the `systemLanguage` conditional
+    // processing attribute (see ConditionalProcessingComponent). Defaults to {"en"} when unset.
+    if (registry_.ctx().contains<SVGDocumentContext>()) {
+      userLanguages_ = registry_.ctx().get<SVGDocumentContext>().userLanguages;
+    }
+
     if (verbose_) {
       std::cout << "Canvas from document-world transform: " << canvasFromDocumentWorldTransform_
                 << "\n";
@@ -172,7 +181,7 @@ public:
     // referenced by IRI (gradients, <clipPath>, <defs> content) are resolved elsewhere and are
     // intentionally not affected, matching resvg.
     if (const auto* conditional = dataHandle.try_get<ConditionalProcessingComponent>();
-        conditional && !EvaluateConditionalProcessing(*conditional)) {
+        conditional && !EvaluateConditionalProcessing(*conditional, userLanguages_)) {
       return;
     }
 
@@ -450,7 +459,7 @@ public:
       }
 
       if (const auto* conditional = childDataHandle.try_get<ConditionalProcessingComponent>();
-          conditional && !EvaluateConditionalProcessing(*conditional)) {
+          conditional && !EvaluateConditionalProcessing(*conditional, userLanguages_)) {
         continue;
       }
 
@@ -882,6 +891,10 @@ private:
 
   /// Transform from the canvas to the SVG document root, for the current canvas scale.
   Transform2d canvasFromDocumentWorldTransform_;
+
+  /// User's preferred languages for evaluating the `systemLanguage` conditional processing
+  /// attribute. Defaults to {"en"} when the document context is unavailable.
+  std::vector<RcString> userLanguages_ = {RcString("en")};
 
   /// Tracks mask elements currently being rendered to detect mutual recursion
   /// (e.g., mask1→mask2→mask1). When a mask reference resolves to an element already in this

--- a/donner/svg/renderer/RenderingContext.cc
+++ b/donner/svg/renderer/RenderingContext.cc
@@ -120,6 +120,38 @@ bool IsValidMarker(EntityHandle handle) {
   return handle.all_of<MarkerComponent>();
 }
 
+/**
+ * Returns true if the element type participates in `<switch>` child selection. Per the SVG spec,
+ * `<switch>` evaluates conditional processing attributes only on its direct children that are
+ * directly-rendered element types (`a`, `g`, `svg`, `switch`, `text`, `use`, `image`, and
+ * graphical shape elements). Any other child (descriptive elements such as `title`/`desc`/
+ * `metadata`, `defs`, `symbol`, and unknown elements) is ignored and does not consume the selection
+ * slot.
+ *
+ * This is a positive whitelist of directly-rendered types, so non-rendered children are excluded
+ * regardless of whether they are currently typed as \ref ElementType::Unknown or gain a dedicated
+ * element type later (e.g. `title`/`desc`/`metadata`).
+ */
+bool IsSwitchProcessedElementType(ElementType type) {
+  switch (type) {
+    case ElementType::A:
+    case ElementType::Circle:
+    case ElementType::Ellipse:
+    case ElementType::G:
+    case ElementType::Image:
+    case ElementType::Line:
+    case ElementType::Path:
+    case ElementType::Polygon:
+    case ElementType::Polyline:
+    case ElementType::Rect:
+    case ElementType::SVG:
+    case ElementType::Switch:
+    case ElementType::Text:
+    case ElementType::Use: return true;
+    default: return false;
+  }
+}
+
 class RenderingContextImpl {
 public:
   explicit RenderingContextImpl(Registry& registry, bool verbose,
@@ -439,9 +471,10 @@ public:
 
   /**
    * Select the first direct child of a \ref xml_switch whose conditional-processing attributes
-   * all evaluate to true. Non-element children (comments, text) and unknown (non-SVG) elements
-   * are never selected. `display` does not participate in selection, so a selected child with
-   * `display: none` still wins and renders nothing.
+   * all evaluate to true. Non-element children (comments, text) and children that are not
+   * directly-rendered element types (descriptive elements, `defs`, `symbol`, unknown elements) are
+   * never selected and do not consume the selection slot. `display` does not participate in
+   * selection, so a selected child with `display: none` still wins and renders nothing.
    *
    * @param switchTree Tree component of the `<switch>` element (or its shadow instance).
    * @return The selected child entity, or `entt::null` if no child matches.
@@ -454,7 +487,7 @@ public:
           registry_, shadowEntityComponent ? shadowEntityComponent->lightEntity : cur);
 
       const auto* typeComponent = childDataHandle.try_get<ElementTypeComponent>();
-      if (!typeComponent || typeComponent->type() == ElementType::Unknown) {
+      if (!typeComponent || !IsSwitchProcessedElementType(typeComponent->type())) {
         continue;
       }
 

--- a/donner/svg/tests/SVGSwitchElement_tests.cc
+++ b/donner/svg/tests/SVGSwitchElement_tests.cc
@@ -6,9 +6,11 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include "donner/base/FileOffset.h"
 #include "donner/base/ParseWarningSink.h"
+#include "donner/base/RcString.h"
 #include "donner/svg/parser/SVGParser.h"
 #include "donner/svg/renderer/tests/RendererTestUtils.h"
 #include "donner/svg/tests/ParserTestUtils.h"
@@ -352,6 +354,33 @@ TEST(SVGSwitchElementTests, FailingConditionalOnContainerDisablesSubtree) {
   )");
 
   EXPECT_TRUE(generatedAscii.matches(kAllEmpty));
+}
+
+/**
+ * `systemLanguage` is evaluated against the document's configured user language list. The default
+ * `{"en"}` does not match `systemLanguage="ru"`, but configuring the list to `{"ru"}` does.
+ */
+TEST(SVGSwitchElementTests, SystemLanguageHonorsConfiguredLanguages) {
+  constexpr std::string_view kSvg = R"(
+    <svg width="16" height="16">
+      <rect x="0" y="0" width="16" height="16" fill="black" systemLanguage="ru"/>
+    </svg>
+  )";
+
+  // Default user language "en" does not match systemLanguage="ru".
+  {
+    SVGDocument document = instantiateSubtree(kSvg);
+    const AsciiImage generatedAscii = RendererTestUtils::renderToAsciiImage(std::move(document));
+    EXPECT_TRUE(generatedAscii.matches(kAllEmpty));
+  }
+
+  // After configuring the user language list to {"ru"}, the rect renders.
+  {
+    SVGDocument document = instantiateSubtree(kSvg);
+    document.setUserLanguages({RcString("ru")});
+    const AsciiImage generatedAscii = RendererTestUtils::renderToAsciiImage(std::move(document));
+    EXPECT_TRUE(generatedAscii.matches(kAllFilled));
+  }
 }
 
 }  // namespace donner::svg

--- a/donner/svg/tests/SVGSwitchElement_tests.cc
+++ b/donner/svg/tests/SVGSwitchElement_tests.cc
@@ -378,6 +378,48 @@ TEST(SVGSwitchElementTests, SwitchSkipsNonRenderedChildTypes) {
 }
 
 /**
+ * When no direct child passes conditional processing, the `<switch>` renders nothing.
+ */
+TEST(SVGSwitchElementTests, SwitchNoValidChildRendersNothing) {
+  const AsciiImage generatedAscii = RendererTestUtils::renderToAsciiImage(R"(
+    <svg width="16" height="16">
+      <switch>
+        <rect x="0" y="0" width="16" height="16" fill="black"
+              requiredExtensions="http://example.org/bogus"/>
+        <rect x="0" y="0" width="16" height="16" fill="black"
+              systemLanguage="zz"/>
+      </switch>
+    </svg>
+  )");
+
+  EXPECT_TRUE(generatedAscii.matches(kAllEmpty));
+}
+
+/**
+ * A `<switch>` nested as the first child of another `<switch>` is itself a directly-rendered
+ * element type, so the outer switch selects it and the inner switch selects its own first valid
+ * child. The outer switch's later children are never rendered.
+ */
+TEST(SVGSwitchElementTests, NestedSwitch) {
+  const AsciiImage generatedAscii = RendererTestUtils::renderToAsciiImage(R"(
+    <svg width="16" height="16">
+      <switch>
+        <switch>
+          <rect x="0" y="0" width="16" height="16" fill="black"
+                requiredExtensions="http://example.org/bogus"/>
+          <rect x="0" y="0" width="16" height="16" fill="black"/>
+        </switch>
+        <rect x="0" y="0" width="8" height="16" fill="black"/>
+      </switch>
+    </svg>
+  )");
+
+  // The inner switch selects its full-size second child; the outer switch's 8-wide child is never
+  // rendered.
+  EXPECT_TRUE(generatedAscii.matches(kAllFilled));
+}
+
+/**
  * `systemLanguage` is evaluated against the document's configured user language list. The default
  * `{"en"}` does not match `systemLanguage="ru"`, but configuring the list to `{"ru"}` does.
  */

--- a/donner/svg/tests/SVGSwitchElement_tests.cc
+++ b/donner/svg/tests/SVGSwitchElement_tests.cc
@@ -357,6 +357,27 @@ TEST(SVGSwitchElementTests, FailingConditionalOnContainerDisablesSubtree) {
 }
 
 /**
+ * A child that is not a directly-rendered element type (here `<defs>`) is not eligible for
+ * selection and does not consume the selection slot, so the following `<rect>` is selected. This
+ * distinguishes the whitelist behavior from skipping only unknown element types: `<defs>` is a
+ * known element type but is still not rendered by a `<switch>`.
+ */
+TEST(SVGSwitchElementTests, SwitchSkipsNonRenderedChildTypes) {
+  const AsciiImage generatedAscii = RendererTestUtils::renderToAsciiImage(R"(
+    <svg width="16" height="16">
+      <switch>
+        <defs>
+          <rect x="0" y="0" width="16" height="16" fill="black"/>
+        </defs>
+        <rect x="0" y="0" width="8" height="16" fill="black"/>
+      </switch>
+    </svg>
+  )");
+
+  EXPECT_TRUE(generatedAscii.matches(kLeftHalfFilled));
+}
+
+/**
  * `systemLanguage` is evaluated against the document's configured user language list. The default
  * `{"en"}` does not match `systemLanguage="ru"`, but configuring the list to `{"ru"}` does.
  */


### PR DESCRIPTION
Three follow-ups to #718's <switch> implementation, surfaced by a conformance re-check:

1. **`SVGDocument::setUserLanguages()`** - #718 hard-codes `kUserLanguage = "en"`; this adds a priority-ordered user-language list (default `{"en"}`) threaded through conditional-processing evaluation, switch child selection, and text span collection, with render-tree invalidation on change. Mirrors the `setCanvasSize` mutation pattern.
2. **Switch child eligibility** - `selectSwitchChild` skipped only `ElementType::Unknown`, so a `<defs>`/`<title>`-typed first child would consume the selection slot and render nothing, hiding valid siblings. Per SVG 2, only directly-rendered child types participate; ported as a positive whitelist that stays correct after #776 adds dedicated title/desc/metadata types.
3. **Test gaps** - NestedSwitch, SwitchNoValidChildRendersNothing, SwitchSkipsNonRenderedChildTypes, SystemLanguageHonorsConfiguredLanguages, written in main's ASCII-golden idiom.

All switch/systemLanguage resvg categories pass on both text variants; every commit builds independently.

https://claude.ai/code/session_01WcXFtPoHgJMjdeC8rd7ZQR