### PR TITLE
Editor polish W2: contextual text formatting bar

### DIFF
--- a/donner/editor/BUILD.bazel
+++ b/donner/editor/BUILD.bazel
@@ -527,6 +527,20 @@ donner_cc_library(
 )
 
 donner_cc_library(
+    name = "text_format_bar_presenter",
+    srcs = ["TextFormatBarPresenter.cc"],
+    hdrs = ["TextFormatBarPresenter.h"],
+    deps = [
+        ":editor_app",
+        ":imgui_headers",
+        "//donner/base",
+        "//donner/base/parser",
+        "//donner/svg",
+        "@imgui",
+    ],
+)
+
+donner_cc_library(
     name = "embedded_svg_icon",
     srcs = ["EmbeddedSvgIcon.cc"],
     hdrs = ["EmbeddedSvgIcon.h"],

--- a/donner/editor/BUILD.bazel
+++ b/donner/editor/BUILD.bazel
@@ -747,6 +747,7 @@ donner_cc_library(
         ":source_selection",
         ":style_source_annotations",
         ":text_editor",
+        ":text_format_bar_presenter",
         ":text_inspector_panel",
         ":text_to_outlines",
         ":text_tool",

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -1975,6 +1975,73 @@ bool EditorShell::selectionIsAllText() const {
   return true;
 }
 
+FormatBarState EditorShell::computeFormatBarState() {
+  FormatBarState state;
+
+  const std::vector<svg::SVGElement>& selection = app_.selectedElements();
+  const bool hasSingleTextSelection =
+      selection.size() == 1u && selection.front().type() == svg::ElementType::Text;
+  const bool textEditingActive = activeTool_ == ActiveTool::Text && textTool_.isEditing();
+  state.visible = FormatBarShouldShow(hasSingleTextSelection, textEditingActive);
+  if (!state.visible) {
+    return state;
+  }
+
+  // Read the current family/size/B/I/U from the styled element. During an
+  // editing session the TextTool keeps that element as the single selection, so
+  // the same read path serves both the selection and editing cases.
+  if (hasSingleTextSelection) {
+    ReadTextFormatState(selection.front(), &state);
+  }
+
+  // Family picker faces: the three embedded TTFs the editor loads today
+  // (Roboto Regular as the default UI face, Roboto Bold, Fira Code). Families
+  // the editor lacks a face for preview in the default font; the free-text box
+  // still round-trips them. W3 replaces this with the real embedded + macOS
+  // system font pipeline.
+  ImFont* regularFace =
+      ImGui::GetIO().Fonts->Fonts.empty() ? nullptr : ImGui::GetIO().Fonts->Fonts[0];
+  state.boldToggleFont = uiFontBold_;
+  state.families = {
+      {"Roboto", regularFace}, {"Fira Code", codeFont_},  {"sans-serif", regularFace},
+      {"serif", nullptr},      {"monospace", codeFont_},
+  };
+  return state;
+}
+
+void EditorShell::applyFormatBarActions(const FormatBarState& state,
+                                        const FormatBarActions& actions) {
+  const bool editing = activeTool_ == ActiveTool::Text && textTool_.isEditing();
+
+  bool changed = false;
+  // Bold/Italic/Underline during an active editing session route to the
+  // TextTool style toggles (they add/remove the attribute and flush). Family
+  // and size, plus the selection-only B/I/U path, route to the attribute-write
+  // seam shared with the Text inspector.
+  if (editing) {
+    if (actions.toggleBold) {
+      textTool_.toggleBold(app_);
+      changed = true;
+    }
+    if (actions.toggleItalic) {
+      textTool_.toggleItalic(app_);
+      changed = true;
+    }
+    if (actions.toggleUnderline) {
+      textTool_.toggleUnderline(app_);
+      changed = true;
+    }
+  }
+
+  changed = ApplyFormatBarActionsToSelection(actions, state, /*routeTogglesToSelection=*/!editing,
+                                             app_) ||
+            changed;
+
+  if (changed) {
+    flushQueuedMutationAndRefreshOverlay();
+  }
+}
+
 void EditorShell::convertSelectedTextToOutlines() {
   if (!app_.hasDocument() || !selectionIsAllText()) {
     return;
@@ -4518,8 +4585,16 @@ void EditorShell::runFrame() {
 
   const Vector2i windowSize = window_.windowSize();
   const float menuBarHeight = ImGui::GetFrameHeight();
-  const float paneOriginY = menuBarHeight;
-  const float paneHeight = std::max(0.0f, static_cast<float>(windowSize.y) - menuBarHeight);
+  // W2: the contextual text-formatting bar sits directly below the menu bar and
+  // reserves its own strip of vertical space while text styling is in context
+  // (a single <text> is selected or an editing session is active). Compute its
+  // visibility/height here so the panes below start beneath it; the bar itself
+  // is rendered next to the menu bar further down.
+  const FormatBarState formatBarState = computeFormatBarState();
+  const float formatBarHeight =
+      formatBarState.visible ? TextFormatBarPresenter::BarHeight() : 0.0f;
+  const float paneOriginY = menuBarHeight + formatBarHeight;
+  const float paneHeight = std::max(0.0f, static_cast<float>(windowSize.y) - paneOriginY);
   const EditorMainPaneLayout mainPaneLayout = ComputeEditorMainPaneLayout({
       .windowWidth = static_cast<float>(windowSize.x),
       .sourcePaneVisible = sourcePaneVisible_,
@@ -4574,6 +4649,15 @@ void EditorShell::runFrame() {
   };
   const MenuBarActions menuActions = menuBarPresenter_.render(menuState, uiFontBold_);
   applyMenuActions(menuActions);
+
+  // W2: render the contextual text-formatting bar beneath the menu bar and
+  // route its actions to the existing styling commands. Space for it was
+  // already reserved above via `formatBarHeight`.
+  if (formatBarState.visible) {
+    const FormatBarActions formatBarActions = textFormatBarPresenter_.render(
+        formatBarState, menuBarHeight, static_cast<float>(windowSize.x));
+    applyFormatBarActions(formatBarState, formatBarActions);
+  }
 
   dialogPresenter_.render(
       [this](std::string_view path, std::string* error) { return tryOpenPath(path, error); },

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -31,6 +31,7 @@
 #include "donner/editor/SidebarPresenter.h"
 #include "donner/editor/StyleSourceAnnotations.h"
 #include "donner/editor/TextEditor.h"
+#include "donner/editor/TextFormatBarPresenter.h"
 #include "donner/editor/TextInspectorPanel.h"
 #include "donner/editor/TextTool.h"
 #include "donner/editor/ViewportInteractionController.h"
@@ -318,6 +319,16 @@ private:
   bool synchronizeSourceBeforeSave(std::string* error);
   void updateWindowTitle();
   void applyMenuActions(const MenuBarActions& menuActions);
+  /// Build the contextual text-formatting bar's state for this frame: whether
+  /// it is visible (single `<text>` selected or an active editing session), the
+  /// current family/size/B/I/U values read from that element, and the embedded
+  /// font faces offered in the family picker.
+  [[nodiscard]] FormatBarState computeFormatBarState();
+  /// Route the format bar's actions to the existing styling commands: B/I/U
+  /// through the `TextTool` toggles while an editing session is active,
+  /// otherwise (and always for family/size) through the selection attribute
+  /// writes.
+  void applyFormatBarActions(const FormatBarState& state, const FormatBarActions& actions);
   void handleGlobalShortcuts();
   /// True when the document has at least one selectable element (the canonical marquee/Select-All
   /// set). Gates whether Cmd+A / the Edit menu's "Select All" act on the canvas.
@@ -465,6 +476,7 @@ private:
   bool penDragFlushedThisFrame_ = false;
   EditorInputBridge inputBridge_;
   MenuBarPresenter menuBarPresenter_;
+  TextFormatBarPresenter textFormatBarPresenter_;
   SidebarPresenter sidebarPresenter_;
   TextInspectorPanel textInspectorPanel_;
   LayersPanel layersPanel_;

--- a/donner/editor/TextFormatBarPresenter.cc
+++ b/donner/editor/TextFormatBarPresenter.cc
@@ -1,0 +1,265 @@
+#include "donner/editor/TextFormatBarPresenter.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdio>
+#include <cstring>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "donner/base/FormatNumber.h"
+#include "donner/base/RcString.h"
+#include "donner/base/parser/NumberParser.h"
+#include "donner/editor/EditorApp.h"
+#include "donner/editor/ImGuiIncludes.h"
+#include "donner/svg/SVGElement.h"
+
+namespace donner::editor {
+
+namespace internal {
+
+/// Copies `value` into a fixed-size, null-terminated buffer.
+template <std::size_t N>
+void AssignBuffer(std::array<char, N>& buffer, std::string_view value) {
+  const std::size_t count = std::min(value.size(), N - 1u);
+  std::memcpy(buffer.data(), value.data(), count);
+  buffer[count] = '\0';
+}
+
+/// Case-insensitive substring match, for the family-picker search filter. An
+/// empty needle matches everything.
+bool ContainsCaseInsensitive(std::string_view haystack, std::string_view needle) {
+  if (needle.empty()) {
+    return true;
+  }
+  const auto lower = [](unsigned char c) { return static_cast<char>(std::tolower(c)); };
+  auto it = std::search(haystack.begin(), haystack.end(), needle.begin(), needle.end(),
+                        [&](char a, char b) { return lower(a) == lower(b); });
+  return it != haystack.end();
+}
+
+/// Parse a leading number from an attribute value (e.g. "16", "16px"). Returns
+/// nullopt when no number is present.
+std::optional<double> ParseLeadingNumber(std::string_view value) {
+  const auto result = ::donner::parser::NumberParser::Parse(value);
+  if (result.hasError()) {
+    return std::nullopt;
+  }
+  return result.result().number;
+}
+
+}  // namespace internal
+
+using internal::AssignBuffer;
+using internal::ContainsCaseInsensitive;
+using internal::ParseLeadingNumber;
+
+bool FormatBarShouldShow(bool hasSingleTextSelection, bool textEditingActive) {
+  return hasSingleTextSelection || textEditingActive;
+}
+
+void ReadTextFormatState(const svg::SVGElement& text, FormatBarState* state) {
+  if (state == nullptr) {
+    return;
+  }
+  // §concurrent-dom: reading attributes (raw ECS access) from the UI thread
+  // needs a scoped read access while the live editor keeps the document in
+  // ThreadingMode::ConcurrentDom, mirroring TextInspectorPanel.
+  text.withReadAccess([&](svg::DocumentReadAccess&, EntityHandle) {
+    if (auto family = text.getAttribute("font-family")) {
+      state->fontFamily = std::string(std::string_view(*family));
+    } else {
+      state->fontFamily.clear();
+    }
+
+    state->hasFontSize = false;
+    state->fontSize = 0.0f;
+    if (auto size = text.getAttribute("font-size")) {
+      if (auto parsed = ParseLeadingNumber(std::string_view(*size))) {
+        state->fontSize = static_cast<float>(*parsed);
+        state->hasFontSize = true;
+      }
+    }
+
+    const auto weight = text.getAttribute("font-weight");
+    state->bold = weight.has_value() && std::string_view(*weight) == "bold";
+
+    const auto style = text.getAttribute("font-style");
+    state->italic = style.has_value() && std::string_view(*style) == "italic";
+
+    const auto decoration = text.getAttribute("text-decoration");
+    state->underline = decoration.has_value() && std::string_view(*decoration) == "underline";
+  });
+}
+
+bool ApplyFormatBarActionsToSelection(const FormatBarActions& actions, const FormatBarState& state,
+                                      bool routeTogglesToSelection, EditorApp& app) {
+  bool queued = false;
+
+  if (actions.setFontFamily) {
+    queued = app.setAttributeOnSelection("font-family", actions.fontFamily) || queued;
+  }
+  if (actions.setFontSize) {
+    queued = app.setAttributeOnSelection(
+                 "font-size", donner::detail::FormatNumberForSVG(
+                                  static_cast<double>(actions.fontSize))) ||
+             queued;
+  }
+
+  if (routeTogglesToSelection) {
+    // Toggle to the opposite of the currently-displayed state. Toggle-off
+    // writes the explicit reset value so this stays on the attribute-write path
+    // (the editing-session path in TextTool removes the attribute instead).
+    if (actions.toggleBold) {
+      queued =
+          app.setAttributeOnSelection("font-weight", state.bold ? "normal" : "bold") || queued;
+    }
+    if (actions.toggleItalic) {
+      queued =
+          app.setAttributeOnSelection("font-style", state.italic ? "normal" : "italic") || queued;
+    }
+    if (actions.toggleUnderline) {
+      queued = app.setAttributeOnSelection("text-decoration",
+                                           state.underline ? "none" : "underline") ||
+               queued;
+    }
+  }
+
+  return queued;
+}
+
+float TextFormatBarPresenter::BarHeight() {
+  const ImGuiStyle& style = ImGui::GetStyle();
+  return ImGui::GetFrameHeight() + style.WindowPadding.y * 2.0f;
+}
+
+FormatBarActions TextFormatBarPresenter::render(const FormatBarState& state, float originY,
+                                                float width) {
+  FormatBarActions actions;
+  if (!state.visible) {
+    return actions;
+  }
+
+  // Re-seed the free-text family buffer whenever the underlying value changes,
+  // so an external edit (selection change, another surface) is reflected while
+  // an in-progress edit here is not clobbered mid-keystroke.
+  if (!trackedFamily_ || lastSyncedFamily_ != state.fontFamily) {
+    AssignBuffer(fontFamilyBuffer_, state.fontFamily);
+    lastSyncedFamily_ = state.fontFamily;
+    trackedFamily_ = true;
+  }
+
+  ImGui::SetNextWindowPos(ImVec2(0.0f, originY));
+  ImGui::SetNextWindowSize(ImVec2(width, BarHeight()));
+  constexpr ImGuiWindowFlags kBarFlags =
+      ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
+      ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoScrollbar |
+      ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoSavedSettings |
+      ImGuiWindowFlags_NoNavFocus | ImGuiWindowFlags_NoBringToFrontOnFocus;
+
+  if (ImGui::Begin("##text_format_bar", nullptr, kBarFlags)) {
+    // --- Font family: free-text input plus a searchable preview dropdown. ---
+    ImGui::SetNextItemWidth(180.0f);
+    ImGui::InputTextWithHint("##format_bar_font_family", "Font family", fontFamilyBuffer_.data(),
+                             fontFamilyBuffer_.size());
+    if (ImGui::IsItemDeactivatedAfterEdit()) {
+      actions.setFontFamily = true;
+      actions.fontFamily = std::string(fontFamilyBuffer_.data());
+      lastSyncedFamily_ = actions.fontFamily;
+    }
+    ImGui::SameLine(0.0f, 0.0f);
+    if (ImGui::BeginCombo("##format_bar_font_family_menu", "", ImGuiComboFlags_NoPreview)) {
+      ImGui::SetNextItemWidth(200.0f);
+      ImGui::InputTextWithHint("##format_bar_font_search", "Search fonts",
+                               familySearchBuffer_.data(), familySearchBuffer_.size());
+      const std::string_view filter(familySearchBuffer_.data());
+      for (const FormatBarFontFamily& family : state.families) {
+        if (!ContainsCaseInsensitive(family.name, filter)) {
+          continue;
+        }
+        const bool selected = family.name == state.fontFamily;
+        // Preview each family in its own face where the editor has one loaded.
+        if (family.previewFont != nullptr) {
+          ImGui::PushFont(family.previewFont);
+        }
+        const bool chosen = ImGui::Selectable(family.name.c_str(), selected);
+        if (family.previewFont != nullptr) {
+          ImGui::PopFont();
+        }
+        if (chosen) {
+          actions.setFontFamily = true;
+          actions.fontFamily = family.name;
+          AssignBuffer(fontFamilyBuffer_, family.name);
+          lastSyncedFamily_ = family.name;
+        }
+      }
+      ImGui::EndCombo();
+    }
+
+    // --- Font size: drag box plus a preset dropdown. ---
+    ImGui::SameLine();
+    if (!sizeControlActive_) {
+      sizeEditValue_ = state.hasFontSize ? state.fontSize : 0.0f;
+    }
+    ImGui::SetNextItemWidth(64.0f);
+    ImGui::DragFloat("##format_bar_font_size", &sizeEditValue_, 0.5f, 1.0f, 512.0f, "%.0f");
+    sizeControlActive_ = ImGui::IsItemActive();
+    if (ImGui::IsItemDeactivatedAfterEdit()) {
+      actions.setFontSize = true;
+      actions.fontSize = sizeEditValue_;
+    }
+    ImGui::SameLine(0.0f, 0.0f);
+    if (ImGui::BeginCombo("##format_bar_font_size_menu", "", ImGuiComboFlags_NoPreview)) {
+      for (const int preset : kFormatBarFontSizePresets) {
+        const bool selected = state.hasFontSize &&
+                              static_cast<int>(state.fontSize + 0.5f) == preset;
+        char label[8];
+        std::snprintf(label, sizeof(label), "%d", preset);
+        if (ImGui::Selectable(label, selected)) {
+          actions.setFontSize = true;
+          actions.fontSize = static_cast<float>(preset);
+          sizeEditValue_ = actions.fontSize;
+        }
+      }
+      ImGui::EndCombo();
+    }
+
+    // --- Bold / Italic / Underline toggles. ---
+    const float toggleWidth = ImGui::GetFrameHeight();
+    const auto toggle = [&](const char* label, bool active, ImFont* face) -> bool {
+      if (active) {
+        ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive));
+      }
+      if (face != nullptr) {
+        ImGui::PushFont(face);
+      }
+      const bool clicked = ImGui::Button(label, ImVec2(toggleWidth, 0.0f));
+      if (face != nullptr) {
+        ImGui::PopFont();
+      }
+      if (active) {
+        ImGui::PopStyleColor();
+      }
+      return clicked;
+    };
+
+    ImGui::SameLine();
+    if (toggle("B##format_bar_bold", state.bold, state.boldToggleFont)) {
+      actions.toggleBold = true;
+    }
+    ImGui::SameLine();
+    if (toggle("I##format_bar_italic", state.italic, nullptr)) {
+      actions.toggleItalic = true;
+    }
+    ImGui::SameLine();
+    if (toggle("U##format_bar_underline", state.underline, nullptr)) {
+      actions.toggleUnderline = true;
+    }
+  }
+  ImGui::End();
+
+  return actions;
+}
+
+}  // namespace donner::editor

--- a/donner/editor/TextFormatBarPresenter.h
+++ b/donner/editor/TextFormatBarPresenter.h
@@ -1,0 +1,155 @@
+#pragma once
+/// @file
+///
+/// `TextFormatBarPresenter` renders a contextual text-formatting bar directly
+/// beneath the editor menu bar. The bar is shown only while text styling is in
+/// context: when the canvas selection is a single `<text>` element or an
+/// in-canvas text editing session is active. It offers a searchable font-family
+/// picker (each known family previewed in its own face, with a free-text
+/// fallback for families the editor lacks), a font-size combo with drag and
+/// preset behavior, and Bold/Italic/Underline toggles.
+///
+/// Following the `MenuBarPresenter` pattern, the presenter is a thin, testable
+/// surface: `render()` draws the imgui controls and returns edge-triggered
+/// `FormatBarActions`, which the shell routes to the *existing* styling
+/// commands. B/I/U during an editing session go through the `TextTool` style
+/// toggles; family, size, and the selection-only B/I/U path go through the
+/// `TextInspectorPanel` attribute-write seam (`setAttributeOnSelection`). This
+/// bar is a second surface over those commands, not a new styling pipeline.
+
+#include <array>
+#include <string>
+#include <vector>
+
+#include "donner/svg/SVGElement.h"
+
+struct ImFont;
+
+namespace donner::editor {
+
+class EditorApp;
+
+/// One selectable font family in the format bar's family picker.
+struct FormatBarFontFamily {
+  /// CSS family name written to the document (e.g. "Roboto", "sans-serif").
+  std::string name;
+  /// Face used to preview this family's menu entry, or null to fall back to the
+  /// default UI font. Lets each family render in its own face when the editor
+  /// has it loaded (the embedded Roboto and Fira Code faces today).
+  ImFont* previewFont = nullptr;
+};
+
+/// Snapshot of the current text formatting context, driving the bar's controls.
+///
+/// The shell fills `visible` and `families`; the attribute-derived fields
+/// (`fontFamily`, `fontSize`, `bold`, `italic`, `underline`) come from
+/// \ref ReadTextFormatState against the single selected/edited `<text>`.
+struct FormatBarState {
+  /// Whether the bar should render at all: true when text is selected or a text
+  /// editing session is active.
+  bool visible = false;
+  /// Current `font-family` value shown in the picker. May name a family the
+  /// editor lacks; preserved verbatim as free text.
+  std::string fontFamily;
+  /// Current `font-size` value (document units) shown in the size combo.
+  float fontSize = 0.0f;
+  /// True when a numeric `font-size` was resolved for the current element.
+  bool hasFontSize = false;
+  /// Current `font-weight: bold` state.
+  bool bold = false;
+  /// Current `font-style: italic` state.
+  bool italic = false;
+  /// Current `text-decoration: underline` state.
+  bool underline = false;
+  /// Face used to render the Bold ("B") toggle glyph, or null for the default.
+  ImFont* boldToggleFont = nullptr;
+  /// Families offered in the picker dropdown, each with its preview face.
+  std::vector<FormatBarFontFamily> families;
+};
+
+/// Edge-triggered requests emitted by the format bar in one frame. Each `set*`
+/// / `toggle*` flag is true only on the frame the user committed the control.
+struct FormatBarActions {
+  /// The user chose a family from the dropdown or committed the free-text box.
+  bool setFontFamily = false;
+  std::string fontFamily;
+  /// The user committed a new font size (drag release, typed entry, or preset).
+  bool setFontSize = false;
+  float fontSize = 0.0f;
+  bool toggleBold = false;
+  bool toggleItalic = false;
+  bool toggleUnderline = false;
+};
+
+/// Common font-size presets offered by the size combo (document units).
+inline constexpr std::array<int, 12> kFormatBarFontSizePresets = {8,  9,  10, 11, 12, 14,
+                                                                  16, 18, 24, 36, 48, 72};
+
+/// Whether the format bar should be shown, given the styling context.
+///
+/// The bar is contextual: it appears while the selection is a single `<text>`
+/// element, or while an in-canvas text editing session is active (which also
+/// makes that element the selection, but the session predicate is kept
+/// explicit so the bar stays up through selection churn during editing).
+///
+/// @param hasSingleTextSelection True when exactly one `<text>` is selected.
+/// @param textEditingActive True when an in-canvas text session owns the caret.
+[[nodiscard]] bool FormatBarShouldShow(bool hasSingleTextSelection, bool textEditingActive);
+
+/// Populate the attribute-derived fields (`fontFamily`, `fontSize`,
+/// `hasFontSize`, `bold`, `italic`, `underline`) of @p state from a single
+/// selected/edited `<text>` element. Reads under a scoped read access so it is
+/// safe while the live editor keeps the document in ConcurrentDom. Leaves
+/// `visible`, `families`, and `boldToggleFont` untouched (owned by the shell).
+void ReadTextFormatState(const svg::SVGElement& text, FormatBarState* state);
+
+/// Route the attribute-write half of the bar's actions onto the app's current
+/// selection (the `TextInspectorPanel` seam): font family, font size, and -
+/// when @p routeTogglesToSelection is true - the B/I/U toggles. During an
+/// editing session the shell handles B/I/U through `TextTool` instead and
+/// passes `routeTogglesToSelection=false`, so this only writes family/size.
+///
+/// Toggle-off writes the "normal"/"none" value (rather than removing the
+/// attribute) to stay on the pure attribute-write path; the value that flips is
+/// derived from @p state's current B/I/U flags.
+///
+/// @return true if any document mutation was queued.
+bool ApplyFormatBarActionsToSelection(const FormatBarActions& actions, const FormatBarState& state,
+                                      bool routeTogglesToSelection, EditorApp& app);
+
+/// Contextual text-formatting bar shown beneath the menu bar.
+class TextFormatBarPresenter {
+public:
+  /// Height (pixels) the bar occupies for the current imgui style, so the shell
+  /// can reserve space below the menu bar. Valid only inside a frame (reads the
+  /// active style/frame height).
+  [[nodiscard]] static float BarHeight();
+
+  /**
+   * Render the bar and report the actions requested this frame.
+   *
+   * Draws nothing and returns an empty result when `state.visible` is false.
+   * The bar is a fixed, full-width strip at @p originY spanning @p width.
+   *
+   * @param state Current formatting context (visibility, values, families).
+   * @param originY Top edge of the bar in window pixels (menu-bar height).
+   * @param width Bar width in window pixels (the window width).
+   * @return Edge-triggered actions to route to the styling commands.
+   */
+  [[nodiscard]] FormatBarActions render(const FormatBarState& state, float originY, float width);
+
+private:
+  /// Free-text font-family buffer, re-seeded when the underlying value changes.
+  std::array<char, 256> fontFamilyBuffer_{};
+  /// Family the buffer was last seeded from, to detect external changes.
+  std::string lastSyncedFamily_;
+  bool trackedFamily_ = false;
+  /// Filter text for the searchable family dropdown.
+  std::array<char, 64> familySearchBuffer_{};
+  /// Working value for the size drag; only re-seeded from state while the drag
+  /// control is idle, so an in-progress drag is not clobbered each frame.
+  float sizeEditValue_ = 0.0f;
+  bool sizeControlActive_ = false;
+};
+
+}  // namespace donner::editor

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -784,6 +784,19 @@ donner_cc_test(
 )
 
 donner_cc_test(
+    name = "text_format_bar_presenter_tests",
+    srcs = ["TextFormatBarPresenter_tests.cc"],
+    deps = [
+        "//donner/base",
+        "//donner/editor:editor_app",
+        "//donner/editor:text_format_bar_presenter",
+        "//donner/svg",
+        "@com_google_gtest//:gtest_main",
+        "@imgui",
+    ],
+)
+
+donner_cc_test(
     name = "drag_release_pop_back_tests",
     srcs = ["DragReleasePopBack_tests.cc"],
     deps = [

--- a/donner/editor/tests/TextFormatBarPresenter_tests.cc
+++ b/donner/editor/tests/TextFormatBarPresenter_tests.cc
@@ -1,0 +1,292 @@
+#include "donner/editor/TextFormatBarPresenter.h"
+
+#include <gtest/gtest.h>
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "donner/editor/EditorApp.h"
+#include "donner/editor/ImGuiIncludes.h"
+
+namespace donner::editor {
+namespace {
+
+/// Attribute value of the lone `<text id="t">` after a flush, or nullopt.
+std::optional<std::string> TextAttribute(EditorApp& app, std::string_view name) {
+  const std::optional<svg::SVGElement> text = app.document().document().querySelector("#t");
+  if (!text.has_value()) {
+    return std::nullopt;
+  }
+  const std::optional<RcString> value = text->getAttribute(name);
+  if (!value.has_value()) {
+    return std::nullopt;
+  }
+  return std::string(std::string_view(*value));
+}
+
+// ---------------------------------------------------------------------------
+// Visibility rule
+// ---------------------------------------------------------------------------
+
+TEST(TextFormatBarPresenterActionsTest, VisibleWhileTextSelectedOrEditing) {
+  EXPECT_FALSE(FormatBarShouldShow(/*hasSingleTextSelection=*/false, /*textEditingActive=*/false));
+  EXPECT_TRUE(FormatBarShouldShow(/*hasSingleTextSelection=*/true, /*textEditingActive=*/false));
+  EXPECT_TRUE(FormatBarShouldShow(/*hasSingleTextSelection=*/false, /*textEditingActive=*/true));
+  EXPECT_TRUE(FormatBarShouldShow(/*hasSingleTextSelection=*/true, /*textEditingActive=*/true));
+}
+
+// ---------------------------------------------------------------------------
+// State reading
+// ---------------------------------------------------------------------------
+
+TEST(TextFormatBarPresenterActionsTest, ReadsFamilySizeAndStyleFlags) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+           <text id="t" font-family="Fira Code" font-size="24" font-weight="bold"
+                 font-style="italic" text-decoration="underline">Hi</text>
+         </svg>)"));
+  const std::optional<svg::SVGElement> text = app.document().document().querySelector("#t");
+  ASSERT_TRUE(text.has_value());
+
+  FormatBarState state;
+  ReadTextFormatState(*text, &state);
+
+  EXPECT_EQ(state.fontFamily, "Fira Code");
+  EXPECT_TRUE(state.hasFontSize);
+  EXPECT_FLOAT_EQ(state.fontSize, 24.0f);
+  EXPECT_TRUE(state.bold);
+  EXPECT_TRUE(state.italic);
+  EXPECT_TRUE(state.underline);
+}
+
+TEST(TextFormatBarPresenterActionsTest, ReadsDefaultsWhenStyleAttributesAbsent) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+           <text id="t">Plain</text>
+         </svg>)"));
+  const std::optional<svg::SVGElement> text = app.document().document().querySelector("#t");
+  ASSERT_TRUE(text.has_value());
+
+  FormatBarState state;
+  ReadTextFormatState(*text, &state);
+
+  EXPECT_TRUE(state.fontFamily.empty());
+  EXPECT_FALSE(state.hasFontSize);
+  EXPECT_FALSE(state.bold);
+  EXPECT_FALSE(state.italic);
+  EXPECT_FALSE(state.underline);
+}
+
+TEST(TextFormatBarPresenterActionsTest, ReadTextFormatStateIgnoresNullState) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+           <text id="t" font-size="16">Hi</text>
+         </svg>)"));
+  const std::optional<svg::SVGElement> text = app.document().document().querySelector("#t");
+  ASSERT_TRUE(text.has_value());
+  // Must not dereference a null out-parameter.
+  ReadTextFormatState(*text, nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// Command routing: bar actions reach the document
+// ---------------------------------------------------------------------------
+
+TEST(TextFormatBarPresenterActionsTest, ToggleBoldWritesFontWeightBoldToDocument) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+           <text id="t">Hi</text>
+         </svg>)"));
+  const std::optional<svg::SVGElement> text = app.document().document().querySelector("#t");
+  ASSERT_TRUE(text.has_value());
+  app.setSelection(*text);
+
+  FormatBarState state;  // Currently not bold.
+  FormatBarActions actions;
+  actions.toggleBold = true;
+
+  EXPECT_TRUE(ApplyFormatBarActionsToSelection(actions, state,
+                                               /*routeTogglesToSelection=*/true, app));
+  EXPECT_TRUE(app.flushFrame());
+  EXPECT_EQ(TextAttribute(app, "font-weight"), "bold");
+}
+
+TEST(TextFormatBarPresenterActionsTest, ToggleBoldOffWritesFontWeightNormal) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+           <text id="t" font-weight="bold">Hi</text>
+         </svg>)"));
+  const std::optional<svg::SVGElement> text = app.document().document().querySelector("#t");
+  ASSERT_TRUE(text.has_value());
+  app.setSelection(*text);
+
+  FormatBarState state;
+  state.bold = true;  // Currently bold, so the toggle turns it off.
+  FormatBarActions actions;
+  actions.toggleBold = true;
+
+  EXPECT_TRUE(ApplyFormatBarActionsToSelection(actions, state,
+                                               /*routeTogglesToSelection=*/true, app));
+  EXPECT_TRUE(app.flushFrame());
+  EXPECT_EQ(TextAttribute(app, "font-weight"), "normal");
+}
+
+TEST(TextFormatBarPresenterActionsTest, ItalicAndUnderlineTogglesWriteToDocument) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+           <text id="t">Hi</text>
+         </svg>)"));
+  const std::optional<svg::SVGElement> text = app.document().document().querySelector("#t");
+  ASSERT_TRUE(text.has_value());
+  app.setSelection(*text);
+
+  FormatBarState state;
+  FormatBarActions actions;
+  actions.toggleItalic = true;
+  actions.toggleUnderline = true;
+
+  EXPECT_TRUE(ApplyFormatBarActionsToSelection(actions, state,
+                                               /*routeTogglesToSelection=*/true, app));
+  EXPECT_TRUE(app.flushFrame());
+  EXPECT_EQ(TextAttribute(app, "font-style"), "italic");
+  EXPECT_EQ(TextAttribute(app, "text-decoration"), "underline");
+}
+
+TEST(TextFormatBarPresenterActionsTest, FontFamilyAndSizeWritesReachDocument) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+           <text id="t" font-family="serif" font-size="12">Hi</text>
+         </svg>)"));
+  const std::optional<svg::SVGElement> text = app.document().document().querySelector("#t");
+  ASSERT_TRUE(text.has_value());
+  app.setSelection(*text);
+
+  FormatBarState state;
+  FormatBarActions actions;
+  actions.setFontFamily = true;
+  actions.fontFamily = "Roboto";
+  actions.setFontSize = true;
+  actions.fontSize = 18.0f;
+
+  EXPECT_TRUE(ApplyFormatBarActionsToSelection(actions, state,
+                                               /*routeTogglesToSelection=*/false, app));
+  EXPECT_TRUE(app.flushFrame());
+  EXPECT_EQ(TextAttribute(app, "font-family"), "Roboto");
+  EXPECT_EQ(TextAttribute(app, "font-size"), "18");
+}
+
+TEST(TextFormatBarPresenterActionsTest, TogglesSkippedWhenRoutedToEditingSession) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+           <text id="t">Hi</text>
+         </svg>)"));
+  const std::optional<svg::SVGElement> text = app.document().document().querySelector("#t");
+  ASSERT_TRUE(text.has_value());
+  app.setSelection(*text);
+
+  FormatBarState state;
+  FormatBarActions actions;
+  actions.toggleBold = true;
+
+  // With routeTogglesToSelection=false the shell owns B/I/U via TextTool, so the
+  // attribute-write path must not queue a font-weight write.
+  EXPECT_FALSE(ApplyFormatBarActionsToSelection(actions, state,
+                                                /*routeTogglesToSelection=*/false, app));
+  EXPECT_FALSE(app.flushFrame());
+  EXPECT_EQ(TextAttribute(app, "font-weight"), std::nullopt);
+}
+
+TEST(TextFormatBarPresenterActionsTest, NoActionsQueueNoMutation) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+           <text id="t">Hi</text>
+         </svg>)"));
+  const std::optional<svg::SVGElement> text = app.document().document().querySelector("#t");
+  ASSERT_TRUE(text.has_value());
+  app.setSelection(*text);
+
+  EXPECT_FALSE(ApplyFormatBarActionsToSelection(FormatBarActions{}, FormatBarState{},
+                                                /*routeTogglesToSelection=*/true, app));
+  EXPECT_FALSE(app.flushFrame());
+}
+
+// ---------------------------------------------------------------------------
+// Render seam (visibility gating through the imgui surface)
+// ---------------------------------------------------------------------------
+
+class TextFormatBarPresenterTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    IMGUI_CHECKVERSION();
+    context_ = ImGui::CreateContext();
+    ImGuiIO& io = ImGui::GetIO();
+    io.DisplaySize = ImVec2(1280.0f, 720.0f);
+    io.DeltaTime = 1.0f / 60.0f;
+    io.Fonts->Build();
+  }
+
+  void TearDown() override {
+    ImGui::DestroyContext(context_);
+    context_ = nullptr;
+  }
+
+  static FormatBarActions RenderFrame(TextFormatBarPresenter& bar, const FormatBarState& state) {
+    ImGui::NewFrame();
+    const FormatBarActions actions = bar.render(state, /*originY=*/20.0f, /*width=*/1280.0f);
+    ImGui::Render();
+    return actions;
+  }
+
+private:
+  ImGuiContext* context_ = nullptr;
+};
+
+TEST_F(TextFormatBarPresenterTest, HiddenStateRendersNothingAndReturnsNoActions) {
+  TextFormatBarPresenter bar;
+  FormatBarState state;  // visible == false.
+
+  const FormatBarActions actions = RenderFrame(bar, state);
+
+  EXPECT_FALSE(actions.setFontFamily);
+  EXPECT_FALSE(actions.setFontSize);
+  EXPECT_FALSE(actions.toggleBold);
+  EXPECT_FALSE(actions.toggleItalic);
+  EXPECT_FALSE(actions.toggleUnderline);
+}
+
+TEST_F(TextFormatBarPresenterTest, VisibleBarRendersControlsWithoutImplicitActions) {
+  TextFormatBarPresenter bar;
+  ImFont* face = ImGui::GetIO().Fonts->Fonts[0];
+
+  FormatBarState state;
+  state.visible = true;
+  state.fontFamily = "Roboto";
+  state.fontSize = 16.0f;
+  state.hasFontSize = true;
+  state.bold = true;
+  state.boldToggleFont = face;
+  state.families = {FormatBarFontFamily{"Roboto", face}, FormatBarFontFamily{"serif", nullptr}};
+
+  // Two frames: the first seeds internal buffers, the second exercises the
+  // steady state. Neither involves user input, so no actions should fire.
+  EXPECT_FALSE(RenderFrame(bar, state).toggleBold);
+  const FormatBarActions actions = RenderFrame(bar, state);
+  EXPECT_FALSE(actions.setFontFamily);
+  EXPECT_FALSE(actions.setFontSize);
+  EXPECT_FALSE(actions.toggleBold);
+  EXPECT_FALSE(actions.toggleItalic);
+  EXPECT_FALSE(actions.toggleUnderline);
+}
+
+}  // namespace
+}  // namespace donner::editor


### PR DESCRIPTION
Contextual text formatting bar for the editor.

- Add `TextFormatBarPresenter` (contextual text formatting bar).
- Wire the text formatting bar into `EditorShell`.
- Tests for the text formatting bar.

gate: editor suite green except the known /tmp sandbox target.

Part of Design 0013 / Design 0017 (zettelkasten).

Depends on / bases on `qa/polish-wave1` (PR #782); diff shown is this packet only.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
