### PR TITLE
Editor polish W4: retain text paint on convert-to-outlines

### DIFF
--- a/donner/editor/TextToOutlines.cc
+++ b/donner/editor/TextToOutlines.cc
@@ -1,17 +1,21 @@
 #include "donner/editor/TextToOutlines.h"
 
-#include <array>
 #include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
 
+#include "donner/base/FillRule.h"
+#include "donner/base/FormatNumber.h"
+#include "donner/base/Length.h"
 #include "donner/base/Path.h"
 #include "donner/base/RcString.h"
-#include "donner/base/xml/XMLQualifiedName.h"
+#include "donner/css/Color.h"
 #include "donner/svg/SVGGElement.h"
 #include "donner/svg/SVGPathElement.h"
 #include "donner/svg/SVGTextElement.h"
+#include "donner/svg/properties/PaintServer.h"
+#include "donner/svg/properties/PropertyRegistry.h"
 
 namespace donner::editor {
 
@@ -29,6 +33,72 @@ bool copyAttributeIfPresent(const svg::SVGElement& textElement, std::string_view
   return true;
 }
 
+/// Serialize a resolved \ref svg::PaintServer to an SVG attribute value, resolving `currentColor`
+/// against \p currentColor so the outlined geometry paints identically once detached from the
+/// source text (which may carry the `color` that defines `currentColor`). Solid colors serialize
+/// to hex; paint-server references serialize back to `url(#id)` (with an optional resolved
+/// fallback color).
+std::string serializePaint(const svg::PaintServer& paint, const css::RGBA& currentColor) {
+  if (paint.is<svg::PaintServer::None>()) {
+    return "none";
+  }
+  if (paint.is<svg::PaintServer::ContextFill>()) {
+    return "context-fill";
+  }
+  if (paint.is<svg::PaintServer::ContextStroke>()) {
+    return "context-stroke";
+  }
+  if (paint.is<svg::PaintServer::Solid>()) {
+    return paint.get<svg::PaintServer::Solid>().color.resolve(currentColor, 1.0f).toHexString();
+  }
+  if (paint.is<svg::PaintServer::ElementReference>()) {
+    const auto& ref = paint.get<svg::PaintServer::ElementReference>();
+    std::string out = "url(" + std::string(std::string_view(ref.reference.href)) + ")";
+    if (ref.fallback.has_value()) {
+      out += " " + ref.fallback->resolve(currentColor, 1.0f).toHexString();
+    }
+    return out;
+  }
+  return "none";
+}
+
+/// The paint-affecting computed style of one element, serialized to SVG attribute strings. Resolved
+/// from \ref svg::SVGElement::getComputedStyle so it captures every styling form (presentation
+/// attributes, CSS rules, inline `style`, inheritance, `currentColor`, and `url(#)` references),
+/// not just presentation attributes.
+struct ResolvedPaint {
+  std::string fill;           ///< `fill` value (`none`, hex, or `url(#id)`).
+  std::string fillRule;       ///< `fill-rule` value (`nonzero` / `evenodd`).
+  std::string fillOpacity;    ///< `fill-opacity` value.
+  std::string stroke;         ///< `stroke` value (`none`, hex, or `url(#id)`).
+  std::string strokeWidth;    ///< `stroke-width` value.
+  std::string strokeOpacity;  ///< `stroke-opacity` value.
+
+  bool hasStroke() const { return stroke != "none"; }
+};
+
+/// Resolve the paint-affecting computed style of \p element into serialized SVG attribute strings.
+ResolvedPaint resolvePaint(const svg::SVGElement& element) {
+  static constexpr css::RGBA kBlack = css::RGBA(0, 0, 0, 0xFF);
+  const svg::PropertyRegistry& style = element.getComputedStyle();
+
+  const css::RGBA currentColor = style.color.getOr(css::Color(kBlack)).resolve(kBlack, 1.0f);
+
+  ResolvedPaint paint;
+  paint.fill = serializePaint(
+      style.fill.getOr(svg::PaintServer(svg::PaintServer::Solid(css::Color(kBlack)))), currentColor);
+  paint.fillRule = style.fillRule.getOr(FillRule::NonZero) == FillRule::EvenOdd ? "evenodd"
+                                                                                : "nonzero";
+  paint.fillOpacity = detail::FormatNumberForSVG(style.fillOpacity.getOr(1.0));
+  paint.stroke =
+      serializePaint(style.stroke.getOr(svg::PaintServer(svg::PaintServer::None())), currentColor);
+  paint.strokeWidth =
+      std::string(std::string_view(style.strokeWidth.getOr(Lengthd(1, Lengthd::Unit::None))
+                                       .toRcString()));
+  paint.strokeOpacity = detail::FormatNumberForSVG(style.strokeOpacity.getOr(1.0));
+  return paint;
+}
+
 }  // namespace
 
 ConvertTextToOutlinesResult convertTextToOutlines(svg::SVGDocument& document,
@@ -41,23 +111,24 @@ ConvertTextToOutlinesResult convertTextToOutlines(svg::SVGDocument& document,
     return result;
   }
 
-  // Resolve placed glyph outlines via the renderer-facing text geometry. This
-  // routes through `TextEngine::computedGlyphPaths()` - the SAME positioned
-  // outlines the renderer fills - so the converted paths land exactly where the
-  // text rendered. `convertToPath()` is non-const, so operate on a copy of the
-  // value-type element handle.
+  // Resolve placed glyph outlines via the renderer-facing text geometry, retaining the source
+  // element that painted each glyph. This routes through `TextEngine::computedGlyphOutlines()` -
+  // the SAME positioned outlines the renderer fills - so the converted paths land exactly where
+  // the text rendered, and each glyph carries the `<text>`/`<tspan>` whose computed style colors
+  // it (so per-span paint survives). `convertToOutlineGlyphs()` is non-const, so operate on a copy
+  // of the value-type element handle.
   svg::SVGTextElement text = textElement.cast<svg::SVGTextElement>();
-  const std::vector<Path> glyphPaths = text.convertToPath();
+  const std::vector<svg::TextGlyphOutline> glyphs = text.convertToOutlineGlyphs();
 
-  // Empty outlines (missing font, layout failure, empty text) fail the whole
-  // conversion without mutating.
-  if (glyphPaths.empty()) {
+  // Empty outlines (missing font, layout failure, empty text) fail the whole conversion without
+  // mutating.
+  if (glyphs.empty()) {
     result.error = "Convert to outlines failed: <text> produced no glyph outlines.";
     return result;
   }
   bool anyNonEmpty = false;
-  for (const Path& path : glyphPaths) {
-    if (!path.empty()) {
+  for (const svg::TextGlyphOutline& glyph : glyphs) {
+    if (!glyph.path.empty()) {
       anyNonEmpty = true;
       break;
     }
@@ -73,29 +144,84 @@ ConvertTextToOutlinesResult convertTextToOutlines(svg::SVGDocument& document,
       textId.empty() ? std::string("text_outlines") : (textId.str() + "_outlines");
   result.outlineGroupId = groupId;
 
-  // Build the detached replacement group. Style is preserved at the group
-  // level so the outlined geometry inherits the same paint/transform as the
-  // original text (fill, fill-rule, opacity, stroke, stroke-width, transform).
+  // Build the detached replacement group. Paint is resolved from the text element's computed style
+  // (not just its presentation attributes) so CSS, inline styles, inheritance, currentColor, and
+  // paint-server references are all preserved. Per-<tspan> paint is applied on the individual
+  // glyph paths below, overriding the group only where a run's paint differs.
   svg::SVGGElement group = svg::SVGGElement::Create(document);
   group.setAttribute("id", groupId);
   group.setAttribute("data-donner-converted-from", "text");
-  static constexpr std::array<std::string_view, 6> kPreservedAttributes = {
-      "fill", "fill-rule", "opacity", "stroke", "stroke-width", "transform"};
   svg::SVGElement groupElement = group;
-  for (const std::string_view name : kPreservedAttributes) {
-    copyAttributeIfPresent(textElement, name, groupElement);
-  }
 
-  // Build one detached `<path>` per placed glyph, in paint order. Empty glyph
-  // paths (e.g. whitespace) are skipped - they contribute no geometry.
+  const ResolvedPaint groupPaint = resolvePaint(textElement);
+  groupElement.setAttribute("fill", groupPaint.fill);
+  if (groupPaint.fillRule != "nonzero") {
+    groupElement.setAttribute("fill-rule", groupPaint.fillRule);
+  }
+  if (groupPaint.fillOpacity != "1") {
+    groupElement.setAttribute("fill-opacity", groupPaint.fillOpacity);
+  }
+  if (groupPaint.hasStroke()) {
+    groupElement.setAttribute("stroke", groupPaint.stroke);
+    groupElement.setAttribute("stroke-width", groupPaint.strokeWidth);
+    if (groupPaint.strokeOpacity != "1") {
+      groupElement.setAttribute("stroke-opacity", groupPaint.strokeOpacity);
+    }
+  }
+  // `opacity` is a (non-inherited) group property, and `transform` positions the outlined geometry;
+  // carry both from the text element so the group sits and composites exactly as the text did.
+  const std::string opacity =
+      detail::FormatNumberForSVG(textElement.getComputedStyle().opacity.getOr(1.0));
+  if (opacity != "1") {
+    groupElement.setAttribute("opacity", opacity);
+  }
+  copyAttributeIfPresent(textElement, "transform", groupElement);
+
+  // Build one detached `<path>` per placed glyph, in paint order. Empty glyph paths (e.g.
+  // whitespace) are skipped - they contribute no geometry. Each path overrides the group paint
+  // only where its source run's computed paint differs, so per-<tspan> fill/stroke is preserved
+  // without collapsing to the group level. Resolution is cached per contiguous same-source run.
   int pathIndex = 0;
-  for (const Path& path : glyphPaths) {
-    if (path.empty()) {
+  std::optional<svg::SVGElement> cachedSource;
+  ResolvedPaint cachedPaint;
+  for (const svg::TextGlyphOutline& glyph : glyphs) {
+    if (glyph.path.empty()) {
       continue;
     }
     svg::SVGPathElement pathElement = svg::SVGPathElement::Create(document);
     pathElement.setAttribute("id", groupId + "_" + std::to_string(pathIndex));
-    pathElement.setAttribute("d", std::string_view(path.toSVGPathData()));
+    pathElement.setAttribute("d", std::string_view(glyph.path.toSVGPathData()));
+
+    if (glyph.source != textElement) {
+      if (!cachedSource.has_value() || *cachedSource != glyph.source) {
+        cachedSource = glyph.source;
+        cachedPaint = resolvePaint(glyph.source);
+      }
+      const ResolvedPaint& runPaint = cachedPaint;
+
+      svg::SVGElement pathAsElement = pathElement;
+      if (runPaint.fill != groupPaint.fill) {
+        pathAsElement.setAttribute("fill", runPaint.fill);
+      }
+      if (runPaint.fillRule != groupPaint.fillRule) {
+        pathAsElement.setAttribute("fill-rule", runPaint.fillRule);
+      }
+      if (runPaint.fillOpacity != groupPaint.fillOpacity) {
+        pathAsElement.setAttribute("fill-opacity", runPaint.fillOpacity);
+      }
+      if (runPaint.stroke != groupPaint.stroke) {
+        pathAsElement.setAttribute("stroke", runPaint.stroke);
+      }
+      if (runPaint.hasStroke()) {
+        if (runPaint.strokeWidth != groupPaint.strokeWidth) {
+          pathAsElement.setAttribute("stroke-width", runPaint.strokeWidth);
+        }
+        if (runPaint.strokeOpacity != groupPaint.strokeOpacity) {
+          pathAsElement.setAttribute("stroke-opacity", runPaint.strokeOpacity);
+        }
+      }
+    }
+
     result.outlinePaths.push_back(pathElement);
     ++pathIndex;
   }

--- a/donner/editor/TextToOutlines.h
+++ b/donner/editor/TextToOutlines.h
@@ -9,13 +9,20 @@
 ///
 /// - `convertTextToOutlines` resolves the computed glyph outlines for a single
 ///   selected `<text>` element using Donner's renderer-facing text geometry
-///   (`SVGTextElement::convertToPath()`, which drives the same
-///   `TextEngine::computedGlyphPaths()` the renderer consumes), serializes each
-///   placed glyph `Path` to an SVG `<path d="...">` in paint order, and builds
-///   a detached replacement `<g>` group carrying one `<path>` per glyph. Visual
-///   style (`fill`, `fill-rule`, `opacity`, `stroke`, `stroke-width`,
-///   `transform`) is carried onto the group so the outlined geometry lands
-///   exactly where the text rendered.
+///   (`SVGTextElement::convertToOutlineGlyphs()`, which drives the same
+///   `TextEngine` geometry the renderer consumes and retains the source element
+///   that painted each glyph), serializes each placed glyph `Path` to an SVG
+///   `<path d="...">` in paint order, and builds a detached replacement `<g>`
+///   group carrying one `<path>` per glyph.
+/// - Paint is preserved from the text element's *computed style* (via
+///   `SVGElement::getComputedStyle()`), not just its presentation attributes, so
+///   every styling form survives: presentation attributes, CSS rules (class and
+///   inline `style`), inherited paint, `currentColor` (resolved against the
+///   element's `color`), and `url(#id)` paint-server references. The group
+///   carries the text root's resolved `fill`, `fill-rule`, `fill-opacity`,
+///   `stroke`, `stroke-width`, `stroke-opacity`, `opacity`, and `transform`;
+///   per-`<tspan>` paint that differs from the group is applied on the
+///   individual glyph `<path>`s so multi-color runs are not collapsed.
 ///
 /// The conversion is DOM-first: it builds unattached DOM elements and never
 /// mutates the document. The caller applies it as ordinary structural DOM

--- a/donner/editor/tests/TextToOutlines_tests.cc
+++ b/donner/editor/tests/TextToOutlines_tests.cc
@@ -231,11 +231,12 @@ TEST(TextToOutlines, PreservesStyleAndPaintOrder) {
   ASSERT_TRUE(result.ok) << result.error;
   const std::string mergedSource = ApplyConversion(document, text, result);
 
-  // Style is carried onto the `<g>` group.
+  // Style is carried onto the `<g>` group. Paint is resolved from computed style, so named colors
+  // serialize to their canonical hex form (`black` -> `#000000`); `transform` is carried verbatim.
   EXPECT_THAT(mergedSource, HasSubstr("fill=\"#0033aa\""));
   EXPECT_THAT(mergedSource, HasSubstr("fill-rule=\"evenodd\""));
   EXPECT_THAT(mergedSource, HasSubstr("opacity=\"0.5\""));
-  EXPECT_THAT(mergedSource, HasSubstr("stroke=\"black\""));
+  EXPECT_THAT(mergedSource, HasSubstr("stroke=\"#000000\""));
   EXPECT_THAT(mergedSource, HasSubstr("stroke-width=\"2\""));
   EXPECT_THAT(mergedSource, HasSubstr("transform=\"translate(5,5)\""));
 

--- a/donner/editor/tests/TextToOutlines_tests.cc
+++ b/donner/editor/tests/TextToOutlines_tests.cc
@@ -90,6 +90,29 @@ std::string ApplyConversion(svg::SVGDocument& document, svg::SVGElement text,
   return std::string(document.source());
 }
 
+/// Paint-retention matrix helper. Parses \p svg, converts its first `<text>` to
+/// outlines, applies the structural edit, and asserts the converted document
+/// renders pixel-identical to the original text. This is the load-bearing
+/// assertion for W4: whatever styling form painted the source text (presentation
+/// attribute, CSS rule, inline style, inheritance, per-tspan override, paint
+/// server, currentColor, or an opacity interaction) must survive the conversion.
+void ExpectPaintRetained(std::string_view svg, std::string_view label) {
+  svg::SVGDocument converted = Parse(svg);
+  svg::SVGElement text = TextElement(converted);
+
+  ConvertTextToOutlinesResult result = convertTextToOutlines(converted, text);
+  ASSERT_TRUE(result.ok) << result.error;
+  const std::string mergedSource = ApplyConversion(converted, text, result);
+
+  svg::SVGDocument beforeFresh = Parse(svg);
+  svg::SVGDocument after = Parse(mergedSource);
+  const svg::RendererBitmap beforeBitmap = RenderToBitmap(beforeFresh);
+  const svg::RendererBitmap afterBitmap = RenderToBitmap(after);
+
+  tests::CompareBitmapToBitmap(afterBitmap, beforeBitmap, std::string(label),
+                               tests::PixelmatchIdentityParams());
+}
+
 }  // namespace
 
 // Converts `SVG` text to path geometry: the converted source contains `<path>`
@@ -319,6 +342,134 @@ TEST(TextToOutlines, ThreeGlyphConversionWithinBudget) {
   ASSERT_TRUE(result.ok) << result.error;
   // Design-doc target is 100 ms; CI ceiling is intentionally generous.
   EXPECT_LT(elapsedMs, 500) << "three-glyph conversion took " << elapsedMs << " ms";
+}
+
+// ---------------------------------------------------------------------------
+// W4 paint-retention matrix (Design 0013). One case per styling form. Each
+// asserts the outlined result renders pixel-identical to the source text, so a
+// dropped or mis-resolved paint is a hard failure. Forms that historically lost
+// paint (CSS/inline style, per-tspan, currentColor, fill-opacity, CSS stroke)
+// are the red-then-green regression cases.
+// ---------------------------------------------------------------------------
+
+// Presentation attribute on <text>: the historically-supported path. Green
+// before and after the fix - a guard that the computed-style rewrite does not
+// regress the plain case.
+TEST(TextToOutlinesPaint, PresentationAttributeFill) {
+  ExpectPaintRetained(
+      R"(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+<rect x="0" y="0" width="200" height="200" fill="white"/>
+<text x="10" y="120" font-size="64" fill="#0033aa">SVG</text>
+</svg>)",
+      "paint_matrix_presentation_fill");
+}
+
+// CSS class rule: `.brand { fill: ... }`. `getAttribute("fill")` never sees a
+// class-cascaded paint, so the pre-fix converter dropped it (rendered default
+// black). Requires resolving computed style.
+TEST(TextToOutlinesPaint, CssClassFill) {
+  ExpectPaintRetained(
+      R"(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+<style>.brand { fill: #0033aa; }</style>
+<rect x="0" y="0" width="200" height="200" fill="white"/>
+<text class="brand" x="10" y="120" font-size="64">SVG</text>
+</svg>)",
+      "paint_matrix_css_class_fill");
+}
+
+// Inline `style="fill:..."`: the fill lives in the style attribute, not the
+// `fill` presentation attribute, so the pre-fix attribute copy dropped it.
+TEST(TextToOutlinesPaint, InlineStyleFill) {
+  ExpectPaintRetained(
+      R"(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+<rect x="0" y="0" width="200" height="200" fill="white"/>
+<text style="fill:#0033aa" x="10" y="120" font-size="64">SVG</text>
+</svg>)",
+      "paint_matrix_inline_style_fill");
+}
+
+// Paint inherited from an ancestor <g>. The outline group is inserted into the
+// same parent, so inheritance already carries the paint; this pins that.
+TEST(TextToOutlinesPaint, InheritedFillFromAncestor) {
+  ExpectPaintRetained(
+      R"(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+<rect x="0" y="0" width="200" height="200" fill="white"/>
+<g fill="#0033aa"><text x="10" y="120" font-size="64">SVG</text></g>
+</svg>)",
+      "paint_matrix_inherited_fill");
+}
+
+// Per-<tspan> paint overrides: each glyph run carries its own fill. A single
+// group-level paint cannot represent per-run color, so the pre-fix converter
+// collapsed all glyphs to one paint.
+TEST(TextToOutlinesPaint, PerTspanFillOverrides) {
+  ExpectPaintRetained(
+      R"(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+<rect x="0" y="0" width="200" height="200" fill="white"/>
+<text x="10" y="120" font-size="64" fill="#aa0000"><tspan fill="#0033aa">S</tspan><tspan fill="#008a33">V</tspan><tspan fill="#aa00aa">G</tspan></text>
+</svg>)",
+      "paint_matrix_per_tspan_fill");
+}
+
+// Paint-server reference via presentation attribute: `fill="url(#grad)"`. Uses
+// userSpaceOnUse so the gradient maps identically regardless of which element
+// carries the reference (isolating retention from bbox-unit semantics).
+TEST(TextToOutlinesPaint, GradientPaintServerPresentation) {
+  ExpectPaintRetained(
+      R"SVG(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+<defs><linearGradient id="grad" gradientUnits="userSpaceOnUse" x1="0" y1="0" x2="200" y2="0"><stop offset="0" stop-color="#0033aa"/><stop offset="1" stop-color="#008a33"/></linearGradient></defs>
+<rect x="0" y="0" width="200" height="200" fill="white"/>
+<text x="10" y="120" font-size="64" fill="url(#grad)">SVG</text>
+</svg>)SVG",
+      "paint_matrix_gradient_presentation");
+}
+
+// Paint-server reference through a CSS class: `.g { fill: url(#grad) }`.
+// Exercises paint-server retention AND computed-style resolution together.
+TEST(TextToOutlinesPaint, GradientPaintServerViaCss) {
+  ExpectPaintRetained(
+      R"(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+<defs><linearGradient id="grad" gradientUnits="userSpaceOnUse" x1="0" y1="0" x2="200" y2="0"><stop offset="0" stop-color="#0033aa"/><stop offset="1" stop-color="#008a33"/></linearGradient></defs>
+<style>.g { fill: url(#grad); }</style>
+<rect x="0" y="0" width="200" height="200" fill="white"/>
+<text class="g" x="10" y="120" font-size="64">SVG</text>
+</svg>)",
+      "paint_matrix_gradient_css");
+}
+
+// currentColor: `fill="currentColor"` resolved against the element's `color`.
+// The pre-fix converter copied `fill="currentColor"` but not the `color` that
+// defines it, so the group resolved currentColor against a different (default)
+// color.
+TEST(TextToOutlinesPaint, CurrentColorFill) {
+  ExpectPaintRetained(
+      R"(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+<rect x="0" y="0" width="200" height="200" fill="white"/>
+<text style="color:#0033aa" fill="currentColor" x="10" y="120" font-size="64">SVG</text>
+</svg>)",
+      "paint_matrix_current_color");
+}
+
+// fill-opacity was absent from the pre-fix preserved-attribute list, so a
+// semi-transparent fill became fully opaque after conversion.
+TEST(TextToOutlinesPaint, FillOpacityInteraction) {
+  ExpectPaintRetained(
+      R"(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+<rect x="0" y="0" width="200" height="200" fill="white"/>
+<text x="10" y="120" font-size="64" fill="#0033aa" fill-opacity="0.45">SVG</text>
+</svg>)",
+      "paint_matrix_fill_opacity");
+}
+
+// Stroke declared through inline CSS with stroke-width and stroke-opacity. The
+// pre-fix attribute copy missed style-declared stroke entirely.
+TEST(TextToOutlinesPaint, StrokeViaCss) {
+  ExpectPaintRetained(
+      R"(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+<rect x="0" y="0" width="200" height="200" fill="white"/>
+<text style="fill:#0033aa;stroke:#aa0000;stroke-width:3;stroke-opacity:0.8" x="10" y="120" font-size="64">SVG</text>
+</svg>)",
+      "paint_matrix_stroke_css");
 }
 
 }  // namespace donner::editor

--- a/donner/svg/SVGElement.h
+++ b/donner/svg/SVGElement.h
@@ -262,6 +262,18 @@ protected:
    */
   explicit SVGElement(EntityHandle handle);
 
+  /**
+   * Wrap an arbitrary existing entity as a generic \ref SVGElement.
+   *
+   * Unlike the protected constructor (which the language only permits for constructing a base
+   * subobject), this lets a derived class produce a standalone \ref SVGElement reference to
+   * *another* entity - e.g. wrapping a glyph's source `<tspan>` so callers can read its computed
+   * style. The entity must belong to \p handle's document.
+   *
+   * @param handle EntityHandle to wrap.
+   */
+  static SVGElement CreateFromEntityHandle(EntityHandle handle) { return SVGElement(handle); }
+
 public:
   /// Create another reference to the same SVGElement.
   SVGElement(const SVGElement& other);

--- a/donner/svg/SVGTextContentElement.cc
+++ b/donner/svg/SVGTextContentElement.cc
@@ -60,6 +60,26 @@ std::vector<Path> SVGTextContentElement::computedGlyphPaths() const {
   return getPreparedTextEngine(handle_).computedGlyphPaths(handle_);
 }
 
+std::vector<TextGlyphOutline> SVGTextContentElement::computedGlyphOutlines() const {
+  [[maybe_unused]] DocumentWriteAccess access = handle_.writeAccess();
+  Registry& registry = *handle_.registry();
+  const std::vector<TextEngine::GlyphOutline> raw =
+      getPreparedTextEngine(handle_).computedGlyphOutlines(handle_);
+
+  std::vector<TextGlyphOutline> result;
+  result.reserve(raw.size());
+  for (const TextEngine::GlyphOutline& glyph : raw) {
+    // Wrap the glyph's painting source (text/tspan) as a public element so callers can resolve its
+    // computed style. Fall back to this element when the source is unresolvable.
+    SVGElement source =
+        glyph.sourceEntity != entt::null
+            ? SVGElement::CreateFromEntityHandle(EntityHandle(registry, glyph.sourceEntity))
+            : SVGElement::CreateFromEntityHandle(handle_);
+    result.push_back(TextGlyphOutline{glyph.path, source});
+  }
+  return result;
+}
+
 Box2d SVGTextContentElement::computedInkBounds() const {
   [[maybe_unused]] DocumentWriteAccess access = handle_.writeAccess();
   return getPreparedTextEngine(handle_).computedInkBounds(handle_);

--- a/donner/svg/SVGTextContentElement.h
+++ b/donner/svg/SVGTextContentElement.h
@@ -14,6 +14,20 @@
 namespace donner::svg {
 
 /**
+ * A single placed glyph outline paired with the element that painted it.
+ *
+ * `source` is the `<text>` or `<tspan>` whose computed style (fill, stroke,
+ * opacity, paint-server reference, currentColor, ...) colors this glyph. Callers
+ * that must preserve per-span paint - such as "Convert Text to Outlines" -
+ * resolve paint from `source.getComputedStyle()` rather than from the text
+ * root's attributes alone.
+ */
+struct TextGlyphOutline {
+  Path path;          ///< Glyph outline in text-element local coordinates.
+  SVGElement source;  ///< Element (text/tspan) whose computed style paints this glyph.
+};
+
+/**
  * Base class for elements that support rendering child text content.
  *
  * This class matches the behavior of the IDL interface `SVGTextContentElement`.
@@ -37,6 +51,12 @@ protected:
    * Return glyph outlines for this text subtree, in local coordinates.
    */
   std::vector<Path> computedGlyphPaths() const;
+
+  /**
+   * Return glyph outlines with their painting source elements for this text
+   * subtree, in local coordinates. See \ref TextGlyphOutline.
+   */
+  std::vector<TextGlyphOutline> computedGlyphOutlines() const;
 
   /**
    * Return the ink bounds for this text subtree, in local coordinates.

--- a/donner/svg/SVGTextElement.cc
+++ b/donner/svg/SVGTextElement.cc
@@ -18,6 +18,10 @@ std::vector<Path> SVGTextElement::convertToPath() const {
   return computedGlyphPaths();
 }
 
+std::vector<TextGlyphOutline> SVGTextElement::convertToOutlineGlyphs() const {
+  return computedGlyphOutlines();
+}
+
 Box2d SVGTextElement::inkBoundingBox() const {
   return computedInkBounds();
 }

--- a/donner/svg/SVGTextElement.h
+++ b/donner/svg/SVGTextElement.h
@@ -120,6 +120,14 @@ public:
   std::vector<Path> convertToPath() const;
 
   /**
+   * Convert this text element to positioned glyph outlines paired with the element that painted
+   * each glyph. Unlike \ref convertToPath, this retains the per-glyph painting source (the `<text>`
+   * or `<tspan>` whose computed style colors the glyph), so callers can preserve per-span paint
+   * when the geometry is detached from the text tree. See \ref TextGlyphOutline.
+   */
+  std::vector<TextGlyphOutline> convertToOutlineGlyphs() const;
+
+  /**
    * Return the tight bounding box of the actual rendered glyphs (ink extents). This is the
    * smallest rectangle that encloses all painted pixels.
    */

--- a/donner/svg/text/TextEngine.cc
+++ b/donner/svg/text/TextEngine.cc
@@ -1664,6 +1664,17 @@ std::vector<Path> TextEngine::computedGlyphPaths(EntityHandle handle) const {
   return result;
 }
 
+std::vector<TextEngine::GlyphOutline> TextEngine::computedGlyphOutlines(EntityHandle handle) const {
+  const auto& cache = ensureComputedTextGeometryComponent(handle);
+  std::vector<GlyphOutline> result;
+  for (const auto& glyph : cache.glyphs) {
+    if (isDescendantOf(registry_, glyph.sourceEntity, handle.entity())) {
+      result.push_back(GlyphOutline{glyph.path, glyph.sourceEntity});
+    }
+  }
+  return result;
+}
+
 Box2d TextEngine::computedInkBounds(EntityHandle handle) const {
   const auto& cache = ensureComputedTextGeometryComponent(handle);
   Box2d result;

--- a/donner/svg/text/TextEngine.h
+++ b/donner/svg/text/TextEngine.h
@@ -88,8 +88,19 @@ public:
   const components::ComputedTextGeometryComponent& ensureComputedTextGeometryComponent(
       EntityHandle handle) const;
 
+  /// A placed glyph outline paired with the source element that produced it.
+  struct GlyphOutline {
+    Path path;                         ///< Glyph outline in text-element local coordinates.
+    Entity sourceEntity = entt::null;  ///< Span source entity (text/tspan) that owns this glyph.
+  };
+
   /// Return glyph outlines for the text subtree rooted at \p handle.
   std::vector<Path> computedGlyphPaths(EntityHandle handle) const;
+
+  /// Return glyph outlines paired with their source entities for the subtree rooted at \p handle.
+  /// The paint that colored each glyph lives on its source entity's computed style; callers that
+  /// must preserve per-span paint (e.g. text-to-outlines) resolve style from `sourceEntity`.
+  std::vector<GlyphOutline> computedGlyphOutlines(EntityHandle handle) const;
 
   /// Return the ink bounds for the text subtree rooted at \p handle.
   Box2d computedInkBounds(EntityHandle handle) const;


### PR DESCRIPTION
Retain text paint when converting text to outlines.

- Retain text paint in all styling forms on convert-to-outlines.
- W4 text-to-outlines paint-retention matrix (red-then-green regression).

gate: editor suite green except the known /tmp sandbox target.

Part of Design 0013 / Design 0017 (zettelkasten).

Depends on / bases on `qa/polish-wave1` (PR #782); diff shown is this packet only.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
