### PR TITLE
Editor polish W9: native macOS chrome and file dialogs

### DIFF
--- a/donner/editor/BUILD.bazel
+++ b/donner/editor/BUILD.bazel
@@ -258,6 +258,76 @@ objc_library(
 )
 
 donner_cc_library(
+    name = "file_dialog_state",
+    srcs = ["FileDialogState.cc"],
+    hdrs = ["FileDialogState.h"],
+    deps = [],
+)
+
+donner_cc_library(
+    name = "native_file_dialog",
+    srcs = select({
+        "@platforms//os:macos": [],
+        "//conditions:default": ["NativeFileDialogStub.cc"],
+    }),
+    hdrs = ["NativeFileDialog.h"],
+    deps = [
+        ":file_dialog_state",
+    ],
+)
+
+objc_library(
+    name = "native_file_dialog_macos",
+    srcs = ["NativeFileDialogMac.mm"],
+    sdk_frameworks = [
+        "Cocoa",
+        "UniformTypeIdentifiers",
+    ],
+    target_compatible_with = select({
+        "@platforms//os:macos": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = [
+        ":native_file_dialog",
+        "@glfw",
+    ],
+)
+
+donner_cc_library(
+    name = "native_window_chrome",
+    srcs = ["NativeWindowChrome.cc"] + select({
+        "@platforms//os:macos": [],
+        "//conditions:default": ["NativeWindowChromeStub.cc"],
+    }),
+    hdrs = ["NativeWindowChrome.h"],
+    deps = [],
+)
+
+objc_library(
+    name = "native_window_chrome_macos",
+    srcs = ["NativeWindowChromeMac.mm"],
+    sdk_frameworks = ["Cocoa"],
+    target_compatible_with = select({
+        "@platforms//os:macos": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = [
+        ":native_window_chrome",
+        "@glfw",
+    ],
+)
+
+donner_cc_library(
+    name = "native_dialog_coordinator",
+    srcs = ["NativeDialogCoordinator.cc"],
+    hdrs = ["NativeDialogCoordinator.h"],
+    deps = [
+        ":file_dialog_state",
+        ":native_file_dialog",
+    ],
+)
+
+donner_cc_library(
     name = "command_queue",
     srcs = ["CommandQueue.cc"],
     hdrs = [
@@ -721,6 +791,8 @@ donner_cc_library(
         ":layer_tree_model",
         ":layers_panel",
         ":menu_bar_presenter",
+        ":native_dialog_coordinator",
+        ":native_window_chrome",
         ":pen_tool",
         ":render_coordinator",
         ":render_pane_presenter",
@@ -767,6 +839,12 @@ donner_cc_library(
         "//conditions:default": [
             "@glfw",
         ],
+    }) + select({
+        "@platforms//os:macos": [
+            ":native_file_dialog_macos",
+            ":native_window_chrome_macos",
+        ],
+        "//conditions:default": [],
     }),
 )
 

--- a/donner/editor/DialogPresenter.h
+++ b/donner/editor/DialogPresenter.h
@@ -31,6 +31,20 @@ public:
   /// Whether a Save SVG modal has been requested but not yet opened by render().
   [[nodiscard]] bool saveFileModalRequested() const { return saveFileModalRequested_; }
 
+  /// Consume a pending Open SVG request without showing the ImGui modal.
+  /// Used when a native OS dialog handles the interaction instead.
+  void consumeOpenFileModalRequest() { openFileModalRequested_ = false; }
+
+  /// Consume a pending Save SVG request without showing the ImGui modal.
+  /// Used when a native OS dialog handles the interaction instead.
+  void consumeSaveFileModalRequest() { saveFileModalRequested_ = false; }
+
+  /// The path pre-filled into the pending Save SVG request (the current file
+  /// path, or the suggested export/save-as name). Empty when none was set.
+  [[nodiscard]] std::string pendingSaveFilePath() const {
+    return std::string(saveFilePathBuffer_.data());
+  }
+
   /// Whether the About modal has been requested but not yet opened by render().
   [[nodiscard]] bool aboutPopupRequested() const { return openAboutPopup_; }
 

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -32,6 +32,7 @@
 #include "donner/editor/FrameMissTelemetry.h"
 #include "donner/editor/ImGuiClipboard.h"
 #include "donner/editor/KeyboardShortcutPolicy.h"
+#include "donner/editor/NativeWindowChrome.h"
 #include "donner/editor/SelectionTransformHandles.h"
 #include "donner/editor/ShapeClipboardCommands.h"
 #include "donner/editor/ShapeClipboardPayload.h"
@@ -1409,6 +1410,23 @@ bool EditorShell::trySavePath(std::string_view path, std::string* error) {
 
 void EditorShell::requestSaveAs(std::string error) {
   pendingViewportExport_ = false;
+
+  if (nativeDialogs_.available()) {
+    const std::optional<std::string> chosen =
+        nativeDialogs_.saveFile(window_.rawHandle(), app_.currentFilePath());
+    if (!chosen.has_value()) {
+      return;  // User cancelled.
+    }
+    std::string saveError;
+    if (!trySavePath(*chosen, &saveError)) {
+      // Fall back to the in-editor modal so the error is visible and the
+      // user can retry.
+      dialogPresenter_.requestSaveFile(std::make_optional(*chosen), std::move(saveError));
+    }
+    window_.wakeEventLoop();
+    return;
+  }
+
   dialogPresenter_.requestSaveFile(app_.currentFilePath(), std::move(error));
 }
 
@@ -1426,6 +1444,23 @@ void EditorShell::requestExportViewportSvg(bool includeOverlay, std::string erro
   } else {
     defaultPath = "untitled_viewport.svg";
   }
+
+  if (nativeDialogs_.available()) {
+    const std::optional<std::string> chosen =
+        nativeDialogs_.saveFile(window_.rawHandle(), std::make_optional(defaultPath));
+    if (!chosen.has_value()) {
+      pendingViewportExport_ = false;
+      pendingViewportExportOverlay_ = false;
+      return;  // User cancelled.
+    }
+    std::string saveError;
+    if (!tryExportViewportSvgToPath(*chosen, &saveError)) {
+      dialogPresenter_.requestSaveFile(std::make_optional(*chosen), std::move(saveError));
+    }
+    window_.wakeEventLoop();
+    return;
+  }
+
   dialogPresenter_.requestSaveFile(std::make_optional(defaultPath), std::move(error));
 }
 
@@ -1485,6 +1520,28 @@ bool EditorShell::tryExportViewportSvgToPath(std::string_view path, std::string*
   return true;
 }
 
+void EditorShell::promptOpenFile() {
+  if (!nativeDialogs_.available()) {
+    dialogPresenter_.requestOpenFile(app_.currentFilePath());
+    return;
+  }
+
+  const std::optional<std::string> chosen =
+      nativeDialogs_.openFile(window_.rawHandle(), app_.currentFilePath());
+  if (!chosen.has_value()) {
+    return;  // User cancelled.
+  }
+
+  std::string error;
+  if (!tryOpenPath(*chosen, &error)) {
+    // Surface the failure through the in-editor modal, pre-filled with the
+    // path and error so the user can retry or correct it.
+    dialogPresenter_.requestOpenFile(std::make_optional(*chosen));
+    dialogPresenter_.setOpenFileError(std::move(error));
+  }
+  window_.wakeEventLoop();
+}
+
 void EditorShell::requestSave() {
   if (!app_.currentFilePath().has_value()) {
     requestSaveAs();
@@ -1515,20 +1572,19 @@ void EditorShell::requestRevert() {
 }
 
 void EditorShell::updateWindowTitle() {
-  std::string title;
-  if (app_.isDirty()) {
-    title += "● ";
-  }
-  if (app_.currentFilePath().has_value()) {
-    title += std::filesystem::path(*app_.currentFilePath()).filename().string();
-  } else {
-    title += "untitled";
-  }
-  title += " - Donner SVG Editor";
+  const WindowChromeState chromeState{.filePath = app_.currentFilePath(),
+                                      .edited = app_.isDirty()};
+
+  // On platforms with native title-bar chrome (macOS) the edited "dot" and
+  // proxy icon are shown by the OS, so keep them out of the title text.
+  const bool nativeChrome = NativeWindowChromeAvailable();
+  std::string title = ComposeWindowTitle(chromeState, /*showEditedDotInText=*/!nativeChrome);
   if (title != lastWindowTitle_) {
     window_.setTitle(title);
     lastWindowTitle_ = std::move(title);
   }
+
+  ApplyNativeWindowChrome(window_.rawHandle(), chromeState);
 }
 
 void EditorShell::applyMenuActions(const MenuBarActions& menuActions) {
@@ -1536,7 +1592,7 @@ void EditorShell::applyMenuActions(const MenuBarActions& menuActions) {
     dialogPresenter_.requestAbout();
   }
   if (menuActions.openFile) {
-    dialogPresenter_.requestOpenFile(app_.currentFilePath());
+    promptOpenFile();
   }
   if (menuActions.saveFile) {
     requestSave();
@@ -1656,7 +1712,7 @@ void EditorShell::handleGlobalShortcuts() {
   }
 
   if (!anyPopupOpen && cmd && !shift && ImGui::IsKeyPressed(ImGuiKey_O, /*repeat=*/false)) {
-    dialogPresenter_.requestOpenFile(app_.currentFilePath());
+    promptOpenFile();
   }
 
   if (!anyPopupOpen && cmd && !shift && ImGui::IsKeyPressed(ImGuiKey_Q, /*repeat=*/false)) {

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -1410,23 +1410,6 @@ bool EditorShell::trySavePath(std::string_view path, std::string* error) {
 
 void EditorShell::requestSaveAs(std::string error) {
   pendingViewportExport_ = false;
-
-  if (nativeDialogs_.available()) {
-    const std::optional<std::string> chosen =
-        nativeDialogs_.saveFile(window_.rawHandle(), app_.currentFilePath());
-    if (!chosen.has_value()) {
-      return;  // User cancelled.
-    }
-    std::string saveError;
-    if (!trySavePath(*chosen, &saveError)) {
-      // Fall back to the in-editor modal so the error is visible and the
-      // user can retry.
-      dialogPresenter_.requestSaveFile(std::make_optional(*chosen), std::move(saveError));
-    }
-    window_.wakeEventLoop();
-    return;
-  }
-
   dialogPresenter_.requestSaveFile(app_.currentFilePath(), std::move(error));
 }
 
@@ -1444,23 +1427,6 @@ void EditorShell::requestExportViewportSvg(bool includeOverlay, std::string erro
   } else {
     defaultPath = "untitled_viewport.svg";
   }
-
-  if (nativeDialogs_.available()) {
-    const std::optional<std::string> chosen =
-        nativeDialogs_.saveFile(window_.rawHandle(), std::make_optional(defaultPath));
-    if (!chosen.has_value()) {
-      pendingViewportExport_ = false;
-      pendingViewportExportOverlay_ = false;
-      return;  // User cancelled.
-    }
-    std::string saveError;
-    if (!tryExportViewportSvgToPath(*chosen, &saveError)) {
-      dialogPresenter_.requestSaveFile(std::make_optional(*chosen), std::move(saveError));
-    }
-    window_.wakeEventLoop();
-    return;
-  }
-
   dialogPresenter_.requestSaveFile(std::make_optional(defaultPath), std::move(error));
 }
 
@@ -1520,28 +1486,6 @@ bool EditorShell::tryExportViewportSvgToPath(std::string_view path, std::string*
   return true;
 }
 
-void EditorShell::promptOpenFile() {
-  if (!nativeDialogs_.available()) {
-    dialogPresenter_.requestOpenFile(app_.currentFilePath());
-    return;
-  }
-
-  const std::optional<std::string> chosen =
-      nativeDialogs_.openFile(window_.rawHandle(), app_.currentFilePath());
-  if (!chosen.has_value()) {
-    return;  // User cancelled.
-  }
-
-  std::string error;
-  if (!tryOpenPath(*chosen, &error)) {
-    // Surface the failure through the in-editor modal, pre-filled with the
-    // path and error so the user can retry or correct it.
-    dialogPresenter_.requestOpenFile(std::make_optional(*chosen));
-    dialogPresenter_.setOpenFileError(std::move(error));
-  }
-  window_.wakeEventLoop();
-}
-
 void EditorShell::requestSave() {
   if (!app_.currentFilePath().has_value()) {
     requestSaveAs();
@@ -1571,6 +1515,46 @@ void EditorShell::requestRevert() {
   window_.wakeEventLoop();
 }
 
+void EditorShell::serviceNativeDialogs() {
+  if (!nativeDialogs_.available()) {
+    return;  // Non-macOS: the ImGui modal handles open/save.
+  }
+
+  if (dialogPresenter_.openFileModalRequested()) {
+    dialogPresenter_.consumeOpenFileModalRequest();
+    if (const std::optional<std::string> chosen =
+            nativeDialogs_.openFile(window_.rawHandle(), app_.currentFilePath())) {
+      std::string error;
+      if (!tryOpenPath(*chosen, &error)) {
+        // Surface the failure through the in-editor modal, pre-filled so the
+        // user can retry or correct the path.
+        dialogPresenter_.requestOpenFile(std::make_optional(*chosen));
+        dialogPresenter_.setOpenFileError(std::move(error));
+      }
+    }
+    window_.wakeEventLoop();
+  }
+
+  if (dialogPresenter_.saveFileModalRequested()) {
+    const std::string suggested = dialogPresenter_.pendingSaveFilePath();
+    dialogPresenter_.consumeSaveFileModalRequest();
+    const std::optional<std::string> suggestedOpt =
+        suggested.empty() ? std::nullopt : std::make_optional(suggested);
+    if (const std::optional<std::string> chosen =
+            nativeDialogs_.saveFile(window_.rawHandle(), suggestedOpt)) {
+      std::string error;
+      // Mirror the render() callback's routing: an in-flight viewport export
+      // writes cropped SVG, otherwise this is a normal document save.
+      const bool ok = pendingViewportExport_ ? tryExportViewportSvgToPath(*chosen, &error)
+                                             : trySavePath(*chosen, &error);
+      if (!ok) {
+        dialogPresenter_.requestSaveFile(std::make_optional(*chosen), std::move(error));
+      }
+    }
+    window_.wakeEventLoop();
+  }
+}
+
 void EditorShell::updateWindowTitle() {
   const WindowChromeState chromeState{.filePath = app_.currentFilePath(),
                                       .edited = app_.isDirty()};
@@ -1592,7 +1576,7 @@ void EditorShell::applyMenuActions(const MenuBarActions& menuActions) {
     dialogPresenter_.requestAbout();
   }
   if (menuActions.openFile) {
-    promptOpenFile();
+    dialogPresenter_.requestOpenFile(app_.currentFilePath());
   }
   if (menuActions.saveFile) {
     requestSave();
@@ -1712,7 +1696,7 @@ void EditorShell::handleGlobalShortcuts() {
   }
 
   if (!anyPopupOpen && cmd && !shift && ImGui::IsKeyPressed(ImGuiKey_O, /*repeat=*/false)) {
-    promptOpenFile();
+    dialogPresenter_.requestOpenFile(app_.currentFilePath());
   }
 
   if (!anyPopupOpen && cmd && !shift && ImGui::IsKeyPressed(ImGuiKey_Q, /*repeat=*/false)) {
@@ -4631,6 +4615,10 @@ void EditorShell::runFrame() {
   const MenuBarActions menuActions = menuBarPresenter_.render(menuState, uiFontBold_);
   applyMenuActions(menuActions);
 
+  // On macOS, service any pending open/save with a native OS panel; this
+  // consumes the request so the ImGui modal below stays closed. On other
+  // platforms it is a no-op and the ImGui modal renders as before.
+  serviceNativeDialogs();
   dialogPresenter_.render(
       [this](std::string_view path, std::string* error) { return tryOpenPath(path, error); },
       [this](std::string_view path, std::string* error) {

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -23,6 +23,7 @@
 #include "donner/editor/LayerInspectorDiagnostics.h"
 #include "donner/editor/LayersPanel.h"
 #include "donner/editor/MenuBarPresenter.h"
+#include "donner/editor/NativeDialogCoordinator.h"
 #include "donner/editor/PenTool.h"
 #include "donner/editor/RenderCoordinator.h"
 #include "donner/editor/RenderPanePresenter.h"
@@ -306,6 +307,9 @@ private:
   [[nodiscard]] bool selectionIsAllText() const;
   void resetPresentationForLoadedDocument(std::string_view canonicalSource);
   void requestRevert();
+  /// Present the "Open SVG" chooser. Uses the native OS dialog when
+  /// available (macOS), otherwise the in-editor ImGui path modal.
+  void promptOpenFile();
   void requestSave();
   void requestSaveAs(std::string error = std::string());
   /// Open the save dialog to export the current viewport as a cropped SVG.
@@ -476,6 +480,7 @@ private:
   CompositorDebugPanel compositorDebugPanel_;
   RenderPanePresenter renderPanePresenter_;
   DialogPresenter dialogPresenter_;
+  NativeDialogCoordinator nativeDialogs_;
 #ifdef DONNER_EDITOR_WGPU
   std::unique_ptr<FramebufferCheckerboardRenderer> directCheckerboardRenderer_;
   std::unique_ptr<svg::RendererGeode> directDocumentRenderer_;

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -307,9 +307,13 @@ private:
   [[nodiscard]] bool selectionIsAllText() const;
   void resetPresentationForLoadedDocument(std::string_view canonicalSource);
   void requestRevert();
-  /// Present the "Open SVG" chooser. Uses the native OS dialog when
-  /// available (macOS), otherwise the in-editor ImGui path modal.
-  void promptOpenFile();
+  /// When native OS file dialogs are available (macOS), consume any pending
+  /// open/save request and service it with a native `NSOpenPanel` /
+  /// `NSSavePanel` instead of the in-editor ImGui modal. No-op on other
+  /// platforms, where the ImGui modal renders as before. Called each frame
+  /// just before the ImGui dialog render pass, so headless callers that only
+  /// drive the request/try-path methods never present native UI.
+  void serviceNativeDialogs();
   void requestSave();
   void requestSaveAs(std::string error = std::string());
   /// Open the save dialog to export the current viewport as a cropped SVG.

--- a/donner/editor/FileDialogState.cc
+++ b/donner/editor/FileDialogState.cc
@@ -1,0 +1,54 @@
+#include "donner/editor/FileDialogState.h"
+
+#include <filesystem>
+#include <utility>
+
+namespace donner::editor {
+
+std::vector<FileDialogFilter> SvgFileDialogFilters() {
+  return {FileDialogFilter{.description = "SVG Image", .extensions = {"svg"}}};
+}
+
+FileDialogState::FileDialogState(std::size_t maxRecents) : maxRecents_(maxRecents) {}
+
+std::optional<std::string> FileDialogState::defaultDirectory(
+    const std::optional<std::string>& currentFilePath) const {
+  if (lastDirectory_.has_value()) {
+    return lastDirectory_;
+  }
+  if (currentFilePath.has_value() && !currentFilePath->empty()) {
+    const std::filesystem::path parent = std::filesystem::path(*currentFilePath).parent_path();
+    if (!parent.empty()) {
+      return parent.string();
+    }
+  }
+  return std::nullopt;
+}
+
+void FileDialogState::noteChosenPath(std::string_view path) {
+  if (path.empty()) {
+    return;
+  }
+
+  const std::filesystem::path fsPath{std::string(path)};
+  const std::filesystem::path parent = fsPath.parent_path();
+  if (!parent.empty()) {
+    lastDirectory_ = parent.string();
+  }
+
+  const std::string pathStr(path);
+  // Move-to-front with de-duplication: an already-listed file jumps back to
+  // the top rather than appearing twice.
+  for (auto it = recentFiles_.begin(); it != recentFiles_.end(); ++it) {
+    if (*it == pathStr) {
+      recentFiles_.erase(it);
+      break;
+    }
+  }
+  recentFiles_.insert(recentFiles_.begin(), pathStr);
+  if (recentFiles_.size() > maxRecents_) {
+    recentFiles_.resize(maxRecents_);
+  }
+}
+
+}  // namespace donner::editor

--- a/donner/editor/FileDialogState.h
+++ b/donner/editor/FileDialogState.h
@@ -1,0 +1,68 @@
+#pragma once
+/// @file
+///
+/// Pure, platform-independent bookkeeping for the editor's native file
+/// dialogs: default-directory memory and an in-process recent-files list.
+///
+/// The actual `NSOpenPanel` / `NSSavePanel` presentation lives in the
+/// platform layer (`NativeFileDialog.h`); this module holds only the
+/// logic that can be exercised headlessly under unit test.
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace donner::editor {
+
+/// A single file-type filter offered by a native open/save dialog.
+struct FileDialogFilter {
+  /// Human-readable description shown in the dialog (e.g. "SVG Image").
+  std::string description;
+  /// Lowercase file extensions without the leading dot (e.g. {"svg"}).
+  std::vector<std::string> extensions;
+};
+
+/// The editor's canonical filter set: SVG documents.
+[[nodiscard]] std::vector<FileDialogFilter> SvgFileDialogFilters();
+
+/// Tracks the directory the user last browsed to and the most-recently
+/// opened/saved files, so the next dialog can seed a sensible starting
+/// directory and (on platforms without an OS recents list) an in-editor
+/// recent-files menu.
+class FileDialogState {
+public:
+  /// @param maxRecents Maximum number of remembered recent files.
+  explicit FileDialogState(std::size_t maxRecents = 10);
+
+  /// Directory to seed the next dialog with.
+  ///
+  /// Preference order: the directory of the last chosen file, then the
+  /// parent directory of \p currentFilePath if one is open, then empty
+  /// (let the OS pick its own default).
+  ///
+  /// @param currentFilePath Path of the document currently open, if any.
+  [[nodiscard]] std::optional<std::string> defaultDirectory(
+      const std::optional<std::string>& currentFilePath) const;
+
+  /// Record that the user opened or saved \p path. Updates the remembered
+  /// directory and pushes the file to the front of the recents list
+  /// (de-duplicated, most-recent first, bounded by `maxRecents`).
+  ///
+  /// Empty paths are ignored.
+  void noteChosenPath(std::string_view path);
+
+  /// Most-recently opened/saved files, newest first.
+  [[nodiscard]] const std::vector<std::string>& recentFiles() const { return recentFiles_; }
+
+  /// Directory remembered from the last chosen file, if any.
+  [[nodiscard]] const std::optional<std::string>& lastDirectory() const { return lastDirectory_; }
+
+private:
+  std::size_t maxRecents_;
+  std::optional<std::string> lastDirectory_;
+  std::vector<std::string> recentFiles_;
+};
+
+}  // namespace donner::editor

--- a/donner/editor/NativeDialogCoordinator.cc
+++ b/donner/editor/NativeDialogCoordinator.cc
@@ -1,0 +1,51 @@
+#include "donner/editor/NativeDialogCoordinator.h"
+
+#include <filesystem>
+
+#include "donner/editor/NativeFileDialog.h"
+
+namespace donner::editor {
+
+bool NativeDialogCoordinator::available() const {
+  return NativeFileDialogAvailable();
+}
+
+std::optional<std::string> NativeDialogCoordinator::openFile(
+    GLFWwindow* window, const std::optional<std::string>& currentFilePath) {
+  NativeOpenDialogRequest request;
+  request.title = "Open SVG";
+  request.defaultDirectory = state_.defaultDirectory(currentFilePath);
+  request.filters = SvgFileDialogFilters();
+
+  std::optional<std::string> chosen = ShowNativeOpenFileDialog(window, request);
+  if (chosen.has_value()) {
+    recordChosen(*chosen);
+  }
+  return chosen;
+}
+
+std::optional<std::string> NativeDialogCoordinator::saveFile(
+    GLFWwindow* window, const std::optional<std::string>& suggestedPath) {
+  NativeSaveDialogRequest request;
+  request.title = "Save SVG";
+  request.defaultDirectory = state_.defaultDirectory(suggestedPath);
+  request.filters = SvgFileDialogFilters();
+  if (suggestedPath.has_value() && !suggestedPath->empty()) {
+    request.defaultName = std::filesystem::path(*suggestedPath).filename().string();
+  } else {
+    request.defaultName = "untitled.svg";
+  }
+
+  std::optional<std::string> chosen = ShowNativeSaveFileDialog(window, request);
+  if (chosen.has_value()) {
+    recordChosen(*chosen);
+  }
+  return chosen;
+}
+
+void NativeDialogCoordinator::recordChosen(const std::string& path) {
+  state_.noteChosenPath(path);
+  NoteNativeRecentDocument(path);
+}
+
+}  // namespace donner::editor

--- a/donner/editor/NativeDialogCoordinator.h
+++ b/donner/editor/NativeDialogCoordinator.h
@@ -1,0 +1,59 @@
+#pragma once
+/// @file
+///
+/// Bridges the pure `FileDialogState` bookkeeping with the platform
+/// `NativeFileDialog` panels. The editor shell holds one of these and asks
+/// it to present open/save dialogs; the coordinator seeds the dialog with
+/// the remembered directory, records the chosen file for directory memory
+/// and recents, and registers it with the OS recent-documents list.
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "donner/editor/FileDialogState.h"
+
+struct GLFWwindow;
+
+namespace donner::editor {
+
+/// Presents native open/save dialogs and tracks directory/recents state.
+class NativeDialogCoordinator {
+public:
+  /// Whether native dialogs are available on this platform. When false,
+  /// callers should fall back to the in-editor ImGui modal.
+  [[nodiscard]] bool available() const;
+
+  /// Present a native "Open SVG" dialog.
+  ///
+  /// @param window Owning editor window.
+  /// @param currentFilePath Path of the open document, used to seed the
+  ///   start directory when nothing better is remembered.
+  /// @return Chosen absolute path (already recorded into directory memory
+  ///   and recents), or `std::nullopt` if cancelled/unavailable.
+  [[nodiscard]] std::optional<std::string> openFile(
+      GLFWwindow* window, const std::optional<std::string>& currentFilePath);
+
+  /// Present a native "Save SVG" dialog.
+  ///
+  /// @param window Owning editor window.
+  /// @param suggestedPath Path or name to pre-fill; its directory seeds the
+  ///   start directory and its filename seeds the name field. When empty,
+  ///   defaults to "untitled.svg".
+  /// @return Chosen absolute path (already recorded), or `std::nullopt` if
+  ///   cancelled/unavailable.
+  [[nodiscard]] std::optional<std::string> saveFile(
+      GLFWwindow* window, const std::optional<std::string>& suggestedPath);
+
+  /// In-process recent-files list, newest first.
+  [[nodiscard]] const std::vector<std::string>& recentFiles() const {
+    return state_.recentFiles();
+  }
+
+private:
+  void recordChosen(const std::string& path);
+
+  FileDialogState state_;
+};
+
+}  // namespace donner::editor

--- a/donner/editor/NativeFileDialog.h
+++ b/donner/editor/NativeFileDialog.h
@@ -1,0 +1,71 @@
+#pragma once
+/// @file
+///
+/// Platform-native file open/save dialogs. On macOS these present
+/// `NSOpenPanel` / `NSSavePanel` with a UTType filter for `.svg`, seeded
+/// from a remembered default directory, and register chosen files with
+/// the OS recent-documents list. On other platforms the functions report
+/// unavailable so callers fall back to the in-editor ImGui modal.
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "donner/editor/FileDialogState.h"
+
+struct GLFWwindow;
+
+namespace donner::editor {
+
+/// Parameters for a native open dialog.
+struct NativeOpenDialogRequest {
+  /// Window title / prompt.
+  std::string title = "Open";
+  /// Directory to start in, if any.
+  std::optional<std::string> defaultDirectory;
+  /// Allowed file-type filters. Empty means "any file".
+  std::vector<FileDialogFilter> filters;
+};
+
+/// Parameters for a native save dialog.
+struct NativeSaveDialogRequest {
+  /// Window title / prompt.
+  std::string title = "Save";
+  /// Directory to start in, if any.
+  std::optional<std::string> defaultDirectory;
+  /// Pre-filled file name (e.g. "untitled.svg"), if any.
+  std::optional<std::string> defaultName;
+  /// Allowed file-type filters. Empty means "any file".
+  std::vector<FileDialogFilter> filters;
+};
+
+/// Whether native file dialogs are available on this platform/build.
+///
+/// True only on macOS; other platforms return false and callers should
+/// keep using the ImGui path-entry modal.
+[[nodiscard]] bool NativeFileDialogAvailable();
+
+/// Present a native modal open dialog.
+///
+/// @param parent Owning window (may be nullptr; used for association).
+/// @param request Dialog configuration.
+/// @return Absolute path of the chosen file, or `std::nullopt` if the
+///   user cancelled or native dialogs are unavailable.
+[[nodiscard]] std::optional<std::string> ShowNativeOpenFileDialog(
+    GLFWwindow* parent, const NativeOpenDialogRequest& request);
+
+/// Present a native modal save dialog.
+///
+/// @param parent Owning window (may be nullptr; used for association).
+/// @param request Dialog configuration.
+/// @return Absolute path chosen for saving, or `std::nullopt` if the user
+///   cancelled or native dialogs are unavailable.
+[[nodiscard]] std::optional<std::string> ShowNativeSaveFileDialog(
+    GLFWwindow* parent, const NativeSaveDialogRequest& request);
+
+/// Register \p path with the OS recent-documents list (macOS
+/// `NSDocumentController noteNewRecentDocumentURL:`). No-op where native
+/// dialogs are unavailable or for empty paths.
+void NoteNativeRecentDocument(const std::string& path);
+
+}  // namespace donner::editor

--- a/donner/editor/NativeFileDialogMac.mm
+++ b/donner/editor/NativeFileDialogMac.mm
@@ -1,0 +1,119 @@
+#include "donner/editor/NativeFileDialog.h"
+
+#import <Cocoa/Cocoa.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+
+namespace donner::editor {
+
+namespace {
+
+/// Build the AppKit content-type list for the given filters. Returns an
+/// empty array when no usable extensions were provided (dialog allows any).
+NSArray<UTType*>* ContentTypesForFilters(const std::vector<FileDialogFilter>& filters)
+    API_AVAILABLE(macos(11.0)) {
+  NSMutableArray<UTType*>* types = [NSMutableArray array];
+  for (const FileDialogFilter& filter : filters) {
+    for (const std::string& ext : filter.extensions) {
+      NSString* extString = [NSString stringWithUTF8String:ext.c_str()];
+      UTType* type = [UTType typeWithFilenameExtension:extString];
+      if (type != nil) {
+        [types addObject:type];
+      }
+    }
+  }
+  return types;
+}
+
+void ApplyContentTypeFilters(NSSavePanel* panel, const std::vector<FileDialogFilter>& filters) {
+  if (filters.empty()) {
+    return;
+  }
+  // UniformTypeIdentifiers requires macOS 11+. On older systems the dialog is
+  // simply left unfiltered rather than falling back to the deprecated
+  // -allowedFileTypes API.
+  if (@available(macOS 11.0, *)) {
+    NSArray<UTType*>* types = ContentTypesForFilters(filters);
+    if (types.count > 0) {
+      panel.allowedContentTypes = types;
+    }
+  }
+}
+
+void ApplyDefaultDirectory(NSSavePanel* panel, const std::optional<std::string>& directory) {
+  if (directory.has_value() && !directory->empty()) {
+    NSString* dirString = [NSString stringWithUTF8String:directory->c_str()];
+    panel.directoryURL = [NSURL fileURLWithPath:dirString isDirectory:YES];
+  }
+}
+
+}  // namespace
+
+bool NativeFileDialogAvailable() {
+  return true;
+}
+
+std::optional<std::string> ShowNativeOpenFileDialog(GLFWwindow* parent,
+                                                    const NativeOpenDialogRequest& request) {
+  (void)parent;
+  @autoreleasepool {
+    NSOpenPanel* panel = [NSOpenPanel openPanel];
+    panel.canChooseFiles = YES;
+    panel.canChooseDirectories = NO;
+    panel.allowsMultipleSelection = NO;
+    panel.message = [NSString stringWithUTF8String:request.title.c_str()];
+
+    ApplyDefaultDirectory(panel, request.defaultDirectory);
+    ApplyContentTypeFilters(panel, request.filters);
+
+    if ([panel runModal] != NSModalResponseOK) {
+      return std::nullopt;
+    }
+    NSURL* url = panel.URL;
+    if (url == nil || url.path == nil) {
+      return std::nullopt;
+    }
+    return std::string(url.path.UTF8String);
+  }
+}
+
+std::optional<std::string> ShowNativeSaveFileDialog(GLFWwindow* parent,
+                                                    const NativeSaveDialogRequest& request) {
+  (void)parent;
+  @autoreleasepool {
+    NSSavePanel* panel = [NSSavePanel savePanel];
+    panel.message = [NSString stringWithUTF8String:request.title.c_str()];
+    panel.canCreateDirectories = YES;
+
+    ApplyDefaultDirectory(panel, request.defaultDirectory);
+
+    if (request.defaultName.has_value() && !request.defaultName->empty()) {
+      panel.nameFieldStringValue = [NSString stringWithUTF8String:request.defaultName->c_str()];
+    }
+
+    ApplyContentTypeFilters(panel, request.filters);
+
+    if ([panel runModal] != NSModalResponseOK) {
+      return std::nullopt;
+    }
+    NSURL* url = panel.URL;
+    if (url == nil || url.path == nil) {
+      return std::nullopt;
+    }
+    return std::string(url.path.UTF8String);
+  }
+}
+
+void NoteNativeRecentDocument(const std::string& path) {
+  if (path.empty()) {
+    return;
+  }
+  @autoreleasepool {
+    NSString* pathString = [NSString stringWithUTF8String:path.c_str()];
+    NSURL* url = [NSURL fileURLWithPath:pathString];
+    if (url != nil) {
+      [[NSDocumentController sharedDocumentController] noteNewRecentDocumentURL:url];
+    }
+  }
+}
+
+}  // namespace donner::editor

--- a/donner/editor/NativeFileDialogStub.cc
+++ b/donner/editor/NativeFileDialogStub.cc
@@ -1,0 +1,30 @@
+#include "donner/editor/NativeFileDialog.h"
+
+// Non-macOS fallback: native file dialogs are unavailable, so callers keep
+// using the in-editor ImGui path-entry modal.
+
+namespace donner::editor {
+
+bool NativeFileDialogAvailable() {
+  return false;
+}
+
+std::optional<std::string> ShowNativeOpenFileDialog(GLFWwindow* parent,
+                                                    const NativeOpenDialogRequest& request) {
+  (void)parent;
+  (void)request;
+  return std::nullopt;
+}
+
+std::optional<std::string> ShowNativeSaveFileDialog(GLFWwindow* parent,
+                                                    const NativeSaveDialogRequest& request) {
+  (void)parent;
+  (void)request;
+  return std::nullopt;
+}
+
+void NoteNativeRecentDocument(const std::string& path) {
+  (void)path;
+}
+
+}  // namespace donner::editor

--- a/donner/editor/NativeWindowChrome.cc
+++ b/donner/editor/NativeWindowChrome.cc
@@ -1,0 +1,21 @@
+#include "donner/editor/NativeWindowChrome.h"
+
+#include <filesystem>
+
+namespace donner::editor {
+
+std::string ComposeWindowTitle(const WindowChromeState& state, bool showEditedDotInText) {
+  std::string title;
+  if (showEditedDotInText && state.edited) {
+    title += "\xE2\x97\x8F ";  // U+25CF BLACK CIRCLE.
+  }
+  if (state.filePath.has_value() && !state.filePath->empty()) {
+    title += std::filesystem::path(*state.filePath).filename().string();
+  } else {
+    title += "untitled";
+  }
+  title += " - Donner SVG Editor";
+  return title;
+}
+
+}  // namespace donner::editor

--- a/donner/editor/NativeWindowChrome.h
+++ b/donner/editor/NativeWindowChrome.h
@@ -1,0 +1,58 @@
+#pragma once
+/// @file
+///
+/// Native window chrome integration for the editor's title bar.
+///
+/// Two concerns live here:
+///   1. `ComposeWindowTitle` - pure derivation of the title-bar text from
+///      the open file and unsaved-changes state. Testable headlessly.
+///   2. The platform hooks - on macOS these drive the native title bar's
+///      edited "dot" (`setDocumentEdited:`) and proxy icon
+///      (`setRepresentedURL:`), so the editor behaves like a real Mac app.
+///      Other platforms provide no-op stubs.
+
+#include <optional>
+#include <string>
+
+struct GLFWwindow;
+
+namespace donner::editor {
+
+/// Inputs to the window title / chrome derivation.
+struct WindowChromeState {
+  /// Path of the open document, or `std::nullopt` for an untitled buffer.
+  std::optional<std::string> filePath;
+  /// Whether the document has unsaved changes.
+  bool edited = false;
+};
+
+/// Compose the window title-bar text.
+///
+/// @param state Current document/edited state.
+/// @param showEditedDotInText When true, an unsaved document is prefixed
+///   with a bullet ("● ") in the text itself. Callers pass false on
+///   platforms that show the edited state natively (macOS), where the dot
+///   is rendered by the OS via `setDocumentEdited:` instead.
+/// @return Title such as "diagram.svg - Donner SVG Editor" or, for an
+///   unsaved untitled buffer with `showEditedDotInText`, "● untitled -
+///   Donner SVG Editor".
+[[nodiscard]] std::string ComposeWindowTitle(const WindowChromeState& state,
+                                             bool showEditedDotInText);
+
+/// Whether this platform/build drives native title-bar chrome (the edited
+/// dot and proxy icon). True only on macOS.
+[[nodiscard]] bool NativeWindowChromeAvailable();
+
+/// Push the document's edited state and file identity into the native
+/// title bar.
+///
+/// On macOS this sets the window's `documentEdited` flag (the close-button
+/// dot) and `representedURL` (the draggable proxy icon). No-op elsewhere,
+/// or when \p window is null.
+///
+/// @param window GLFW window backing the editor.
+/// @param state Current document/edited state. A missing or non-existent
+///   file path clears the proxy icon.
+void ApplyNativeWindowChrome(GLFWwindow* window, const WindowChromeState& state);
+
+}  // namespace donner::editor

--- a/donner/editor/NativeWindowChromeMac.mm
+++ b/donner/editor/NativeWindowChromeMac.mm
@@ -1,0 +1,47 @@
+#include "donner/editor/NativeWindowChrome.h"
+
+#import <Cocoa/Cocoa.h>
+
+#include <filesystem>
+#include <system_error>
+
+#define GLFW_EXPOSE_NATIVE_COCOA
+extern "C" {
+#include "GLFW/glfw3.h"
+#include "GLFW/glfw3native.h"
+}
+
+namespace donner::editor {
+
+bool NativeWindowChromeAvailable() {
+  return true;
+}
+
+void ApplyNativeWindowChrome(GLFWwindow* window, const WindowChromeState& state) {
+  if (window == nullptr) {
+    return;
+  }
+  NSWindow* cocoaWindow = glfwGetCocoaWindow(window);
+  if (cocoaWindow == nil) {
+    return;
+  }
+
+  // The native close-button "dot" reflects unsaved changes.
+  cocoaWindow.documentEdited = state.edited ? YES : NO;
+
+  // The proxy icon (draggable title-bar file icon) tracks the open file.
+  // Only point it at a file that actually exists on disk; otherwise clear
+  // it so an untitled or not-yet-saved buffer shows no proxy.
+  NSURL* representedUrl = nil;
+  if (state.filePath.has_value() && !state.filePath->empty()) {
+    std::error_code ec;
+    std::filesystem::path absolute = std::filesystem::absolute(*state.filePath, ec);
+    if (!ec && std::filesystem::exists(absolute, ec) && !ec) {
+      NSString* pathString = [NSString stringWithUTF8String:absolute.string().c_str()];
+      representedUrl = [NSURL fileURLWithPath:pathString];
+    }
+  }
+  cocoaWindow.representedURL = representedUrl;
+}
+
+}  // namespace donner::editor

--- a/donner/editor/NativeWindowChromeStub.cc
+++ b/donner/editor/NativeWindowChromeStub.cc
@@ -1,0 +1,17 @@
+#include "donner/editor/NativeWindowChrome.h"
+
+// Non-macOS fallback: no native title-bar chrome. The edited state is shown
+// in the title text instead (see ComposeWindowTitle's showEditedDotInText).
+
+namespace donner::editor {
+
+bool NativeWindowChromeAvailable() {
+  return false;
+}
+
+void ApplyNativeWindowChrome(GLFWwindow* window, const WindowChromeState& state) {
+  (void)window;
+  (void)state;
+}
+
+}  // namespace donner::editor

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -60,6 +60,24 @@ donner_cc_test(
 )
 
 donner_cc_test(
+    name = "native_window_chrome_tests",
+    srcs = ["NativeWindowChrome_tests.cc"],
+    deps = [
+        "//donner/editor:native_window_chrome",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
+    name = "file_dialog_state_tests",
+    srcs = ["FileDialogState_tests.cc"],
+    deps = [
+        "//donner/editor:file_dialog_state",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
     name = "editor_shell_tests",
     srcs = ["EditorShell_tests.cc"],
     deps = [

--- a/donner/editor/tests/FileDialogState_tests.cc
+++ b/donner/editor/tests/FileDialogState_tests.cc
@@ -1,0 +1,78 @@
+#include "donner/editor/FileDialogState.h"
+
+#include <gtest/gtest.h>
+
+namespace donner::editor {
+
+TEST(SvgFileDialogFilters, ExposesSvgExtension) {
+  const std::vector<FileDialogFilter> filters = SvgFileDialogFilters();
+  ASSERT_EQ(filters.size(), 1u);
+  EXPECT_EQ(filters[0].description, "SVG Image");
+  ASSERT_EQ(filters[0].extensions.size(), 1u);
+  EXPECT_EQ(filters[0].extensions[0], "svg");
+}
+
+TEST(FileDialogState, DefaultDirectoryEmptyWithNoContext) {
+  const FileDialogState state;
+  EXPECT_FALSE(state.defaultDirectory(std::nullopt).has_value());
+}
+
+TEST(FileDialogState, DefaultDirectoryDerivedFromCurrentFile) {
+  const FileDialogState state;
+  const auto dir = state.defaultDirectory(std::optional<std::string>("/home/user/art/a.svg"));
+  ASSERT_TRUE(dir.has_value());
+  EXPECT_EQ(*dir, "/home/user/art");
+}
+
+TEST(FileDialogState, DefaultDirectoryEmptyForBareFilename) {
+  const FileDialogState state;
+  EXPECT_FALSE(state.defaultDirectory(std::optional<std::string>("a.svg")).has_value());
+}
+
+TEST(FileDialogState, RememberedDirectoryWinsOverCurrentFile) {
+  FileDialogState state;
+  state.noteChosenPath("/tmp/chosen/foo.svg");
+  const auto dir = state.defaultDirectory(std::optional<std::string>("/home/user/art/a.svg"));
+  ASSERT_TRUE(dir.has_value());
+  EXPECT_EQ(*dir, "/tmp/chosen");
+}
+
+TEST(FileDialogState, NoteChosenPathRecordsRecentsNewestFirst) {
+  FileDialogState state;
+  state.noteChosenPath("/a/one.svg");
+  state.noteChosenPath("/a/two.svg");
+  state.noteChosenPath("/a/three.svg");
+  ASSERT_EQ(state.recentFiles().size(), 3u);
+  EXPECT_EQ(state.recentFiles()[0], "/a/three.svg");
+  EXPECT_EQ(state.recentFiles()[1], "/a/two.svg");
+  EXPECT_EQ(state.recentFiles()[2], "/a/one.svg");
+}
+
+TEST(FileDialogState, RepeatedPathMovesToFrontWithoutDuplicating) {
+  FileDialogState state;
+  state.noteChosenPath("/a/one.svg");
+  state.noteChosenPath("/a/two.svg");
+  state.noteChosenPath("/a/one.svg");
+  ASSERT_EQ(state.recentFiles().size(), 2u);
+  EXPECT_EQ(state.recentFiles()[0], "/a/one.svg");
+  EXPECT_EQ(state.recentFiles()[1], "/a/two.svg");
+}
+
+TEST(FileDialogState, RecentsBoundedByMax) {
+  FileDialogState state(/*maxRecents=*/2);
+  state.noteChosenPath("/a/one.svg");
+  state.noteChosenPath("/a/two.svg");
+  state.noteChosenPath("/a/three.svg");
+  ASSERT_EQ(state.recentFiles().size(), 2u);
+  EXPECT_EQ(state.recentFiles()[0], "/a/three.svg");
+  EXPECT_EQ(state.recentFiles()[1], "/a/two.svg");
+}
+
+TEST(FileDialogState, EmptyPathIgnored) {
+  FileDialogState state;
+  state.noteChosenPath("");
+  EXPECT_TRUE(state.recentFiles().empty());
+  EXPECT_FALSE(state.lastDirectory().has_value());
+}
+
+}  // namespace donner::editor

--- a/donner/editor/tests/NativeWindowChrome_tests.cc
+++ b/donner/editor/tests/NativeWindowChrome_tests.cc
@@ -1,0 +1,59 @@
+#include "donner/editor/NativeWindowChrome.h"
+
+#include <gtest/gtest.h>
+
+namespace donner::editor {
+
+namespace {
+// U+25CF BLACK CIRCLE followed by a space, matching ComposeWindowTitle's dot.
+constexpr const char* kDotPrefix = "\xE2\x97\x8F ";
+}  // namespace
+
+TEST(ComposeWindowTitle, UntitledNoEdits) {
+  const WindowChromeState state{.filePath = std::nullopt, .edited = false};
+  EXPECT_EQ(ComposeWindowTitle(state, /*showEditedDotInText=*/true),
+            "untitled - Donner SVG Editor");
+}
+
+TEST(ComposeWindowTitle, UntitledEditedShowsDotInText) {
+  const WindowChromeState state{.filePath = std::nullopt, .edited = true};
+  EXPECT_EQ(ComposeWindowTitle(state, /*showEditedDotInText=*/true),
+            std::string(kDotPrefix) + "untitled - Donner SVG Editor");
+}
+
+TEST(ComposeWindowTitle, UntitledEditedNativeIndicatorOmitsDot) {
+  const WindowChromeState state{.filePath = std::nullopt, .edited = true};
+  // Native platforms (macOS) show the edited dot via the OS, so it must not
+  // appear in the text.
+  EXPECT_EQ(ComposeWindowTitle(state, /*showEditedDotInText=*/false),
+            "untitled - Donner SVG Editor");
+}
+
+TEST(ComposeWindowTitle, NamedFileUsesBasename) {
+  const WindowChromeState state{.filePath = std::optional<std::string>("/home/user/art/diagram.svg"),
+                                .edited = false};
+  EXPECT_EQ(ComposeWindowTitle(state, /*showEditedDotInText=*/true),
+            "diagram.svg - Donner SVG Editor");
+}
+
+TEST(ComposeWindowTitle, NamedFileEditedShowsDotInText) {
+  const WindowChromeState state{.filePath = std::optional<std::string>("/home/user/art/diagram.svg"),
+                                .edited = true};
+  EXPECT_EQ(ComposeWindowTitle(state, /*showEditedDotInText=*/true),
+            std::string(kDotPrefix) + "diagram.svg - Donner SVG Editor");
+}
+
+TEST(ComposeWindowTitle, NamedFileEditedNativeIndicatorOmitsDot) {
+  const WindowChromeState state{.filePath = std::optional<std::string>("/home/user/art/diagram.svg"),
+                                .edited = true};
+  EXPECT_EQ(ComposeWindowTitle(state, /*showEditedDotInText=*/false),
+            "diagram.svg - Donner SVG Editor");
+}
+
+TEST(ComposeWindowTitle, EmptyPathTreatedAsUntitled) {
+  const WindowChromeState state{.filePath = std::optional<std::string>(""), .edited = false};
+  EXPECT_EQ(ComposeWindowTitle(state, /*showEditedDotInText=*/true),
+            "untitled - Donner SVG Editor");
+}
+
+}  // namespace donner::editor


### PR DESCRIPTION
Native macOS window chrome and file dialogs.

- Native macOS titlebar chrome and file dialogs.
- Service native file dialogs at the render step, not the request step.

gate: editor suite green except the known /tmp sandbox target.

Part of Design 0013 / Design 0017 (zettelkasten).

Depends on / bases on `qa/polish-wave1` (PR #782); diff shown is this packet only.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
