### PR TITLE
Editor polish W7: Fill/Stroke widget redesign + shared disclosure chevron

### DIFF
--- a/donner/editor/BUILD.bazel
+++ b/donner/editor/BUILD.bazel
@@ -539,6 +539,36 @@ donner_cc_library(
     ],
 )
 
+# Editor-authored SVG icon assets (Donner-rendered through EmbeddedSvgIcon).
+# W6's cursor/icon suite folds these into the shared icon family; see
+# donner/editor/icons/. Keep new editor icons here rather than reusing the
+# third-party Bootstrap set.
+embed_resources(
+    name = "editor_icons",
+    header_output = "embed_resources/EditorIcons.h",
+    resources = {
+        "kEditorChevronSvg": "icons/chevron.svg",
+    },
+    visibility = ["//donner:__subpackages__"],
+)
+
+# Shared tree-disclosure chevron rendered from the editor_icons chevron asset,
+# used by both the inspector tree (SidebarPresenter) and the LayersPanel so the
+# two trees share one disclosure style.
+donner_cc_library(
+    name = "disclosure_chevron",
+    srcs = ["DisclosureChevron.cc"],
+    hdrs = ["DisclosureChevron.h"],
+    deps = [
+        ":editor_icons",
+        ":embedded_svg_icon",
+        ":imgui_headers",
+        "//donner/base",
+        "//donner/svg/renderer:renderer_interface",
+        "@imgui",
+    ],
+)
+
 donner_cc_library(
     name = "sidebar_presenter",
     srcs = ["SidebarPresenter.cc"],
@@ -688,10 +718,12 @@ donner_cc_library(
         "EditorShell.cc",
         "EditorShellPresentation.cc",
         "EditorShellPresentation.h",
+        "FillStrokeWidget.cc",
     ],
     hdrs = [
         "EditorShell.h",
         "EditorShellInternal.h",
+        "FillStrokeWidget.h",
     ],
     defines = select({
         ":wasm_geode_enabled": ["DONNER_EDITOR_WGPU"],

--- a/donner/editor/BUILD.bazel
+++ b/donner/editor/BUILD.bazel
@@ -547,6 +547,7 @@ embed_resources(
     name = "editor_icons",
     header_output = "embed_resources/EditorIcons.h",
     resources = {
+        "kEditorChevronDownSvg": "icons/chevron-down.svg",
         "kEditorChevronSvg": "icons/chevron.svg",
     },
     visibility = ["//donner:__subpackages__"],
@@ -576,6 +577,7 @@ donner_cc_library(
     deps = [
         ":attribute_writeback",
         ":command_queue",
+        ":disclosure_chevron",
         ":editor_app",
         ":embedded_svg_icon",
         ":imgui_headers",
@@ -1182,6 +1184,7 @@ donner_cc_library(
     srcs = ["LayersPanel.cc"],
     hdrs = ["LayersPanel.h"],
     deps = [
+        ":disclosure_chevron",
         ":editor_app",
         ":embedded_svg_icon",
         ":imgui_headers",

--- a/donner/editor/DisclosureChevron.cc
+++ b/donner/editor/DisclosureChevron.cc
@@ -1,50 +1,33 @@
 #include "donner/editor/DisclosureChevron.h"
 
-#include <cmath>
-
 #include "donner/editor/EmbeddedSvgIcon.h"
 #include "embed_resources/EditorIcons.h"
 
 namespace donner::editor {
 
-const std::optional<svg::RendererBitmap>& CachedDisclosureChevronBitmap() {
-  static const std::optional<svg::RendererBitmap> bitmap =
+const std::optional<svg::RendererBitmap>& CachedDisclosureChevronBitmap(bool expanded) {
+  static const std::optional<svg::RendererBitmap> collapsed =
       RenderEmbeddedSvgIcon(embedded::kEditorChevronSvg, kDisclosureChevronRasterSizePx);
-  return bitmap;
+  static const std::optional<svg::RendererBitmap> expandedBitmap =
+      RenderEmbeddedSvgIcon(embedded::kEditorChevronDownSvg, kDisclosureChevronRasterSizePx);
+  return expanded ? expandedBitmap : collapsed;
 }
 
-int DisclosureChevronQuarterTurns(bool expanded) { return expanded ? 1 : 0; }
+int DisclosureChevronTextureVariant(bool expanded) { return expanded ? 1 : 0; }
 
 void DrawDisclosureChevron(ImDrawList* drawList, ImTextureID texture, const Vector2d& uvBottomRight,
-                           const ImVec2& center, float sizePx, bool expanded, ImU32 tint) {
+                           const ImVec2& center, float sizePx, ImU32 tint) {
   if (texture == 0) {
     return;
   }
 
   const float half = sizePx * 0.5f;
-  // Square corners, clockwise from top-left, centered on the origin.
-  const ImVec2 base[4] = {
-      ImVec2(-half, -half),
-      ImVec2(half, -half),
-      ImVec2(half, half),
-      ImVec2(-half, half),
-  };
-
-  // Screen space is y-down, so a positive angle rotates clockwise; one quarter
-  // turn takes the right-pointing chevron to point down for the expanded state.
-  const float angle = static_cast<float>(DisclosureChevronQuarterTurns(expanded)) * 1.57079632679f;
-  const float ca = std::cos(angle);
-  const float sa = std::sin(angle);
-  ImVec2 p[4];
-  for (int i = 0; i < 4; ++i) {
-    p[i] = ImVec2(center.x + base[i].x * ca - base[i].y * sa,
-                  center.y + base[i].x * sa + base[i].y * ca);
-  }
-
-  const float u = static_cast<float>(uvBottomRight.x);
-  const float v = static_cast<float>(uvBottomRight.y);
-  drawList->AddImageQuad(texture, p[0], p[1], p[2], p[3], ImVec2(0.0f, 0.0f), ImVec2(u, 0.0f),
-                         ImVec2(u, v), ImVec2(0.0f, v), tint);
+  const ImVec2 topLeft(center.x - half, center.y - half);
+  const ImVec2 bottomRight(center.x + half, center.y + half);
+  const ImVec2 uvTopLeft(0.0f, 0.0f);
+  const ImVec2 uvBottomRightVec(static_cast<float>(uvBottomRight.x),
+                                static_cast<float>(uvBottomRight.y));
+  drawList->AddImage(texture, topLeft, bottomRight, uvTopLeft, uvBottomRightVec, tint);
 }
 
 }  // namespace donner::editor

--- a/donner/editor/DisclosureChevron.cc
+++ b/donner/editor/DisclosureChevron.cc
@@ -1,0 +1,50 @@
+#include "donner/editor/DisclosureChevron.h"
+
+#include <cmath>
+
+#include "donner/editor/EmbeddedSvgIcon.h"
+#include "embed_resources/EditorIcons.h"
+
+namespace donner::editor {
+
+const std::optional<svg::RendererBitmap>& CachedDisclosureChevronBitmap() {
+  static const std::optional<svg::RendererBitmap> bitmap =
+      RenderEmbeddedSvgIcon(embedded::kEditorChevronSvg, kDisclosureChevronRasterSizePx);
+  return bitmap;
+}
+
+int DisclosureChevronQuarterTurns(bool expanded) { return expanded ? 1 : 0; }
+
+void DrawDisclosureChevron(ImDrawList* drawList, ImTextureID texture, const Vector2d& uvBottomRight,
+                           const ImVec2& center, float sizePx, bool expanded, ImU32 tint) {
+  if (texture == 0) {
+    return;
+  }
+
+  const float half = sizePx * 0.5f;
+  // Square corners, clockwise from top-left, centered on the origin.
+  const ImVec2 base[4] = {
+      ImVec2(-half, -half),
+      ImVec2(half, -half),
+      ImVec2(half, half),
+      ImVec2(-half, half),
+  };
+
+  // Screen space is y-down, so a positive angle rotates clockwise; one quarter
+  // turn takes the right-pointing chevron to point down for the expanded state.
+  const float angle = static_cast<float>(DisclosureChevronQuarterTurns(expanded)) * 1.57079632679f;
+  const float ca = std::cos(angle);
+  const float sa = std::sin(angle);
+  ImVec2 p[4];
+  for (int i = 0; i < 4; ++i) {
+    p[i] = ImVec2(center.x + base[i].x * ca - base[i].y * sa,
+                  center.y + base[i].x * sa + base[i].y * ca);
+  }
+
+  const float u = static_cast<float>(uvBottomRight.x);
+  const float v = static_cast<float>(uvBottomRight.y);
+  drawList->AddImageQuad(texture, p[0], p[1], p[2], p[3], ImVec2(0.0f, 0.0f), ImVec2(u, 0.0f),
+                         ImVec2(u, v), ImVec2(0.0f, v), tint);
+}
+
+}  // namespace donner::editor

--- a/donner/editor/DisclosureChevron.h
+++ b/donner/editor/DisclosureChevron.h
@@ -3,10 +3,11 @@
 /// Shared tree-disclosure chevron used by both the inspector tree and the
 /// LayersPanel so the two trees present one consistent disclosure style.
 ///
-/// The chevron art is an editor-authored SVG (donner/editor/icons/chevron.svg),
-/// Donner-rendered to a tintable white mask via `RenderEmbeddedSvgIcon`. The
-/// same right-pointing mask is reused for the expanded state by rotating it a
-/// quarter turn at draw time, so callers only manage a single texture.
+/// The chevron art is editor-authored SVG (donner/editor/icons/chevron.svg and
+/// chevron-down.svg), Donner-rendered to a tintable white mask via
+/// `RenderEmbeddedSvgIcon`. Two axis-aligned assets (right for collapsed, down
+/// for expanded) are used so the mask can be blitted with the sanctioned
+/// `AddImage` path rather than a rotated quad.
 
 #include <optional>
 
@@ -16,23 +17,24 @@
 
 namespace donner::editor {
 
-/// Raster size (device px) for the shared chevron mask. Rendered once and
+/// Raster size (device px) for the shared chevron masks. Rendered once each and
 /// scaled down at draw time.
 inline constexpr int kDisclosureChevronRasterSizePx = 32;
 
-/// Cached white-mask bitmap for the (right-pointing, collapsed) chevron, or
+/// Cached white-mask bitmap for the disclosure chevron in the given state
+/// (right-pointing when collapsed, down-pointing when expanded), or
 /// `std::nullopt` if rendering failed. Rendered lazily on first use.
-[[nodiscard]] const std::optional<svg::RendererBitmap>& CachedDisclosureChevronBitmap();
+[[nodiscard]] const std::optional<svg::RendererBitmap>& CachedDisclosureChevronBitmap(
+    bool expanded);
 
-/// Quarter turns (clockwise) to apply to the right-pointing chevron for a given
-/// disclosure state: 0 (points right) when collapsed, 1 (points down) when
-/// expanded.
-[[nodiscard]] int DisclosureChevronQuarterTurns(bool expanded);
+/// Stable texture-cache key suffix (0 collapsed, 1 expanded) so callers upload
+/// and reuse the two chevron masks as distinct textures.
+[[nodiscard]] int DisclosureChevronTextureVariant(bool expanded);
 
-/// Draw the chevron centered at @p center within a @p sizePx square, rotated for
-/// @p expanded and tinted @p tint, from an already-uploaded @p texture whose
-/// valid payload UV range is `[0, uvBottomRight]`.
+/// Blit an already-uploaded chevron @p texture centered at @p center within a
+/// @p sizePx square, tinted @p tint. The texture's valid payload UV range is
+/// `[0, uvBottomRight]`.
 void DrawDisclosureChevron(ImDrawList* drawList, ImTextureID texture, const Vector2d& uvBottomRight,
-                           const ImVec2& center, float sizePx, bool expanded, ImU32 tint);
+                           const ImVec2& center, float sizePx, ImU32 tint);
 
 }  // namespace donner::editor

--- a/donner/editor/DisclosureChevron.h
+++ b/donner/editor/DisclosureChevron.h
@@ -1,0 +1,38 @@
+#pragma once
+/// @file
+/// Shared tree-disclosure chevron used by both the inspector tree and the
+/// LayersPanel so the two trees present one consistent disclosure style.
+///
+/// The chevron art is an editor-authored SVG (donner/editor/icons/chevron.svg),
+/// Donner-rendered to a tintable white mask via `RenderEmbeddedSvgIcon`. The
+/// same right-pointing mask is reused for the expanded state by rotating it a
+/// quarter turn at draw time, so callers only manage a single texture.
+
+#include <optional>
+
+#include "donner/base/Vector2.h"
+#include "donner/editor/ImGuiIncludes.h"
+#include "donner/svg/renderer/RendererInterface.h"
+
+namespace donner::editor {
+
+/// Raster size (device px) for the shared chevron mask. Rendered once and
+/// scaled down at draw time.
+inline constexpr int kDisclosureChevronRasterSizePx = 32;
+
+/// Cached white-mask bitmap for the (right-pointing, collapsed) chevron, or
+/// `std::nullopt` if rendering failed. Rendered lazily on first use.
+[[nodiscard]] const std::optional<svg::RendererBitmap>& CachedDisclosureChevronBitmap();
+
+/// Quarter turns (clockwise) to apply to the right-pointing chevron for a given
+/// disclosure state: 0 (points right) when collapsed, 1 (points down) when
+/// expanded.
+[[nodiscard]] int DisclosureChevronQuarterTurns(bool expanded);
+
+/// Draw the chevron centered at @p center within a @p sizePx square, rotated for
+/// @p expanded and tinted @p tint, from an already-uploaded @p texture whose
+/// valid payload UV range is `[0, uvBottomRight]`.
+void DrawDisclosureChevron(ImDrawList* drawList, ImTextureID texture, const Vector2d& uvBottomRight,
+                           const ImVec2& center, float sizePx, bool expanded, ImU32 tint);
+
+}  // namespace donner::editor

--- a/donner/editor/EditorApp.h
+++ b/donner/editor/EditorApp.h
@@ -61,7 +61,10 @@ struct PathOperationAvailability {
 
 /// Active paint settings used by authoring tools when creating new geometry.
 struct ActivePaintStyle {
-  std::string fill = "none";     ///< SVG fill attribute for new geometry.
+  // Foreground fill defaults to a visible white (design-tool convention) so new
+  // geometry on a fresh document is immediately visible rather than invisible
+  // `fill:none`. See Design 0013 W7 Fill/Stroke widget redesign.
+  std::string fill = "white";    ///< SVG fill attribute for new geometry.
   std::string stroke = "black";  ///< SVG stroke attribute for new geometry.
   double strokeWidth = 1.0;      ///< SVG stroke-width attribute for new geometry.
 };

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -27,6 +27,7 @@
 #include "donner/editor/DocumentSave.h"
 #include "donner/editor/DragCoalesce.h"
 #include "donner/editor/EditorShellInternal.h"
+#include "donner/editor/FillStrokeWidget.h"
 #include "donner/editor/EditorShellPresentation.h"
 #include "donner/editor/FocusView.h"
 #include "donner/editor/FrameMissTelemetry.h"
@@ -457,26 +458,6 @@ ToolbarPaintState ToolbarPaintStateForApp(EditorApp& app, std::optional<std::str
                                   app.hasDocument() ? &app.document().document() : nullptr, source);
   }
   return state;
-}
-
-void DrawPaintSwatch(ImDrawList* drawList, const ImVec2& min, const ImVec2& max,
-                     const ToolbarPaintSlotState& state) {
-  drawList->AddRectFilled(min, max, ImGui::GetColorU32(ColorToImVec4(state.color)), 2.0f);
-  if (state.isCustom) {
-    drawList->PushClipRect(min, max, true);
-    for (float x = min.x - (max.y - min.y); x < max.x; x += 5.0f) {
-      drawList->AddLine(ImVec2(x, max.y), ImVec2(x + (max.y - min.y), min.y),
-                        IM_COL32(255, 255, 255, 95), 1.0f);
-    }
-    drawList->PopClipRect();
-  }
-  drawList->AddRect(min, max, IM_COL32(255, 255, 255, 230), 2.0f, 0, 1.0f);
-  drawList->AddRect(min, max, state.isCustom ? IM_COL32(91, 189, 255, 255) : IM_COL32(0, 0, 0, 210),
-                    2.0f, 0, 2.0f);
-  if (state.isNone) {
-    drawList->AddLine(ImVec2(min.x + 2.0f, max.y - 2.0f), ImVec2(max.x - 2.0f, min.y + 2.0f),
-                      IM_COL32(230, 40, 40, 255), 2.2f);
-  }
 }
 
 std::string PaintChipLabel(std::string_view prefix, const ToolbarPaintSlotState& state) {
@@ -2101,24 +2082,18 @@ void EditorShell::renderFillStrokeToolbarWidget() {
   const ImVec2 min = ImGui::GetItemRectMin();
   const ImVec2 max = ImGui::GetItemRectMax();
   const ImVec2 mouse = ImGui::GetMousePos();
-  const ImVec2 strokeMin(min.x + 15.0f, min.y + 3.0f);
-  const ImVec2 strokeMax(strokeMin.x + 19.0f, strokeMin.y + 19.0f);
-  const ImVec2 fillMin(min.x + 5.0f, min.y + 10.0f);
-  const ImVec2 fillMax(fillMin.x + 19.0f, fillMin.y + 19.0f);
-  const ImVec2 chipMin(min.x + 42.0f, min.y + 1.0f);
-  const ImVec2 chipMax(max.x - 3.0f, min.y + 14.0f);
-  const ImVec2 fillChipMin(chipMin.x, min.y + 16.0f);
-  const ImVec2 fillChipMax(chipMax.x, min.y + 29.0f);
-  const ImVec2 strokeChipMin(chipMin.x, chipMin.y);
-  const ImVec2 strokeChipMax(chipMax.x, chipMax.y);
+  const FillStrokeWidgetLayout layout = ComputeFillStrokeWidgetLayout(min, max);
   ImDrawList* drawList = ImGui::GetWindowDrawList();
-  DrawPaintSwatch(drawList, strokeMin, strokeMax, paintState.stroke);
-  DrawPaintSwatch(drawList, fillMin, fillMax, paintState.fill);
+  // Overlap layout: stroke swatch behind, fill swatch in front.
+  DrawFillStrokeSwatch(drawList, layout.strokeMin, layout.strokeMax, paintState.stroke,
+                       /*front=*/false);
+  DrawFillStrokeSwatch(drawList, layout.fillMin, layout.fillMax, paintState.fill, /*front=*/true);
+  DrawSwapAffordance(drawList, layout.swapMin, layout.swapMax, canEditPaint);
+  DrawNoneAffordance(drawList, layout.strokeNoneMin, layout.strokeNoneMax, /*fillVariant=*/false,
+                     paintState.stroke.isNone);
+  DrawNoneAffordance(drawList, layout.fillNoneMin, layout.fillNoneMax, /*fillVariant=*/true,
+                     paintState.fill.isNone);
 
-  const auto contains = [](const ImVec2& rectMin, const ImVec2& rectMax, const ImVec2& point) {
-    return point.x >= rectMin.x && point.x <= rectMax.x && point.y >= rectMin.y &&
-           point.y <= rectMax.y;
-  };
   const auto fitChipLabel = [](std::string label, float maxWidth) {
     if (ImGui::CalcTextSize(label.c_str()).x <= maxWidth) {
       return label;
@@ -2154,56 +2129,99 @@ void EditorShell::renderFillStrokeToolbarWidget() {
         ImVec2(rectMin.x + 4.0f, rectMin.y + (rectMax.y - rectMin.y - textSize.y) * 0.5f - 0.5f),
         IM_COL32(255, 255, 255, 245), label.c_str());
   };
-  renderChip("S", paintState.stroke, strokeChipMin, strokeChipMax);
-  renderChip("F", paintState.fill, fillChipMin, fillChipMax);
+  renderChip("S", paintState.stroke, layout.strokeChipMin, layout.strokeChipMax);
+  renderChip("F", paintState.fill, layout.fillChipMin, layout.fillChipMax);
+
+  const FillStrokeWidgetRegion region = HitTestFillStrokeWidget(
+      layout, mouse, paintState.fill.isCustom, paintState.stroke.isCustom);
+
+  // Swap fill and stroke on the authoring defaults and, when a selection is
+  // present, on the selected element. Authoring defaults swap verbatim; the
+  // selection swaps the resolved SVG paint strings so referenced/none paints
+  // round-trip correctly.
+  const auto performPaintSwap = [&]() {
+    if (app_.hasSelection()) {
+      const std::string fillStr = SvgPaintStringForSlot(paintState.fill);
+      const std::string strokeStr = SvgPaintStringForSlot(paintState.stroke);
+      app_.setActiveFill(strokeStr);
+      app_.setActiveStroke(fillStr);
+      bool changed = app_.setStylePropertyOnSelection("fill", strokeStr);
+      changed = app_.setStylePropertyOnSelection("stroke", fillStr) || changed;
+      if (changed) {
+        flushQueuedMutationAndRefreshOverlay();
+      } else {
+        window_.wakeEventLoop();
+      }
+    } else {
+      const ActivePaintStyle current = app_.activePaintStyle();
+      app_.setActiveFill(current.stroke);
+      app_.setActiveStroke(current.fill);
+      window_.wakeEventLoop();
+    }
+  };
+  const auto setPaintNone = [&](std::string_view attrName) {
+    if (attrName == "fill") {
+      app_.setActiveFill("none");
+    } else {
+      app_.setActiveStroke("none");
+    }
+    const bool changed = app_.hasSelection() && app_.setStylePropertyOnSelection(attrName, "none");
+    if (changed) {
+      flushQueuedMutationAndRefreshOverlay();
+    } else {
+      window_.wakeEventLoop();
+    }
+  };
+  const auto revealChipSource = [&](const ToolbarPaintSlotState& slot) {
+    if (slot.reference.has_value() && slot.reference->sourceRange.has_value()) {
+      revealSourceRange(*slot.reference->sourceRange);
+    }
+  };
 
   if (canEditPaint && ImGui::IsItemClicked()) {
-    const bool clickedFillChip =
-        paintState.fill.isCustom && contains(fillChipMin, fillChipMax, mouse);
-    const bool clickedStrokeChip =
-        paintState.stroke.isCustom && contains(strokeChipMin, strokeChipMax, mouse);
-    bool handledPaintClick = false;
-    if (clickedFillChip || clickedStrokeChip) {
-      const ToolbarPaintSlotState& slot = clickedFillChip ? paintState.fill : paintState.stroke;
-      if (slot.reference.has_value() && slot.reference->sourceRange.has_value()) {
-        revealSourceRange(*slot.reference->sourceRange);
-      }
-      handledPaintClick = true;
-    }
-
-    if (!handledPaintClick) {
-      const bool clickedFill = mouse.x >= fillMin.x && mouse.x <= fillMax.x &&
-                               mouse.y >= fillMin.y && mouse.y <= fillMax.y;
-      const bool clickedStroke = mouse.x >= strokeMin.x && mouse.x <= strokeMax.x &&
-                                 mouse.y >= strokeMin.y && mouse.y <= strokeMax.y;
-      if (clickedFill || !clickedStroke) {
-        ImGui::OpenPopup("##fill_color_picker");
-      } else {
-        ImGui::OpenPopup("##stroke_color_picker");
-      }
+    switch (region) {
+      case FillStrokeWidgetRegion::Swap: performPaintSwap(); break;
+      case FillStrokeWidgetRegion::FillNone: setPaintNone("fill"); break;
+      case FillStrokeWidgetRegion::StrokeNone: setPaintNone("stroke"); break;
+      case FillStrokeWidgetRegion::FillChip: revealChipSource(paintState.fill); break;
+      case FillStrokeWidgetRegion::StrokeChip: revealChipSource(paintState.stroke); break;
+      case FillStrokeWidgetRegion::StrokeSwatch: ImGui::OpenPopup("##stroke_color_picker"); break;
+      case FillStrokeWidgetRegion::FillSwatch:
+      case FillStrokeWidgetRegion::None: ImGui::OpenPopup("##fill_color_picker"); break;
     }
   }
   if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-    const bool hoveredFillChip =
-        paintState.fill.isCustom && contains(fillChipMin, fillChipMax, mouse);
-    const bool hoveredStrokeChip =
-        paintState.stroke.isCustom && contains(strokeChipMin, strokeChipMax, mouse);
-    if (hoveredFillChip || hoveredStrokeChip) {
-      const char* name = hoveredFillChip ? "Fill" : "Stroke";
-      const ToolbarPaintSlotState& slot = hoveredFillChip ? paintState.fill : paintState.stroke;
-      if (slot.reference.has_value() && slot.reference->sourceRange.has_value()) {
-        ImGui::SetTooltip("%s paint server %s. Click to show source.", name,
-                          slot.reference->href.c_str());
-      } else if (slot.reference.has_value() && slot.reference->external) {
-        ImGui::SetTooltip("%s uses external paint server %s.", name, slot.reference->href.c_str());
-      } else if (slot.reference.has_value()) {
-        ImGui::SetTooltip("%s uses unresolved paint server %s.", name,
-                          slot.reference->href.c_str());
-      } else {
-        ImGui::SetTooltip("%s uses custom paint %s.", name, slot.customLabel.c_str());
+    switch (region) {
+      case FillStrokeWidgetRegion::Swap: ImGui::SetTooltip("Swap fill and stroke"); break;
+      case FillStrokeWidgetRegion::FillNone: ImGui::SetTooltip("Set fill to none"); break;
+      case FillStrokeWidgetRegion::StrokeNone: ImGui::SetTooltip("Set stroke to none"); break;
+      case FillStrokeWidgetRegion::FillChip:
+      case FillStrokeWidgetRegion::StrokeChip: {
+        const bool isFill = region == FillStrokeWidgetRegion::FillChip;
+        const char* name = isFill ? "Fill" : "Stroke";
+        const ToolbarPaintSlotState& slot = isFill ? paintState.fill : paintState.stroke;
+        if (slot.reference.has_value() && slot.reference->sourceRange.has_value()) {
+          ImGui::SetTooltip("%s paint server %s. Click to show source.", name,
+                            slot.reference->href.c_str());
+        } else if (slot.reference.has_value() && slot.reference->external) {
+          ImGui::SetTooltip("%s uses external paint server %s.", name, slot.reference->href.c_str());
+        } else if (slot.reference.has_value()) {
+          ImGui::SetTooltip("%s uses unresolved paint server %s.", name,
+                            slot.reference->href.c_str());
+        } else {
+          ImGui::SetTooltip("%s uses custom paint %s.", name, slot.customLabel.c_str());
+        }
+        break;
       }
-    } else {
-      ImGui::SetTooltip("%s", canEditPaint ? "Fill / stroke" : "Open an SVG document");
+      case FillStrokeWidgetRegion::StrokeSwatch:
+        ImGui::SetTooltip("%s", canEditPaint ? "Stroke color" : "Open an SVG document");
+        break;
+      case FillStrokeWidgetRegion::FillSwatch:
+        ImGui::SetTooltip("%s", canEditPaint ? "Fill color" : "Open an SVG document");
+        break;
+      case FillStrokeWidgetRegion::None:
+        ImGui::SetTooltip("%s", canEditPaint ? "Fill / stroke" : "Open an SVG document");
+        break;
     }
   }
   ImGui::EndDisabled();

--- a/donner/editor/FillStrokeWidget.cc
+++ b/donner/editor/FillStrokeWidget.cc
@@ -1,0 +1,192 @@
+#include "donner/editor/FillStrokeWidget.h"
+
+#include <algorithm>
+#include <utility>
+
+namespace donner::editor::internal {
+
+namespace {
+
+// Widget sub-layout constants, relative to the widget's top-left. The widget is
+// laid out as: an overlapping swatch pair on the left (fill in front / lower
+// left, stroke behind / upper right), a compact affordance column (swap over a
+// pair of "set none" buttons), then the custom-paint label chips.
+constexpr float kSwatchSize = 21.0f;
+constexpr float kFillLeft = 3.0f;
+constexpr float kFillTop = 8.0f;
+constexpr float kStrokeLeft = 14.0f;
+constexpr float kStrokeTop = 1.0f;
+
+constexpr float kSwapLeft = 40.0f;
+constexpr float kSwapTop = 1.0f;
+constexpr float kSwapWidth = 15.0f;
+constexpr float kSwapHeight = 13.0f;
+
+constexpr float kNoneTop = 17.0f;
+constexpr float kNoneBottom = 28.0f;
+constexpr float kStrokeNoneLeft = 40.0f;
+constexpr float kStrokeNoneRight = 47.0f;
+constexpr float kFillNoneLeft = 48.0f;
+constexpr float kFillNoneRight = 55.0f;
+
+constexpr float kChipLeft = 59.0f;
+constexpr float kChipRightInset = 3.0f;
+constexpr float kStrokeChipTop = 1.0f;
+constexpr float kStrokeChipBottom = 14.0f;
+constexpr float kFillChipTop = 16.0f;
+constexpr float kFillChipBottom = 29.0f;
+
+[[nodiscard]] bool Contains(const ImVec2& min, const ImVec2& max, const ImVec2& p) {
+  return p.x >= min.x && p.x <= max.x && p.y >= min.y && p.y <= max.y;
+}
+
+[[nodiscard]] ImU32 SwatchColorU32(const css::RGBA& c) {
+  return IM_COL32(c.r, c.g, c.b, c.a);
+}
+
+}  // namespace
+
+FillStrokeWidgetLayout ComputeFillStrokeWidgetLayout(const ImVec2& widgetMin,
+                                                     const ImVec2& widgetMax) {
+  const float x = widgetMin.x;
+  const float y = widgetMin.y;
+  FillStrokeWidgetLayout layout;
+  layout.fillMin = ImVec2(x + kFillLeft, y + kFillTop);
+  layout.fillMax = ImVec2(x + kFillLeft + kSwatchSize, y + kFillTop + kSwatchSize);
+  layout.strokeMin = ImVec2(x + kStrokeLeft, y + kStrokeTop);
+  layout.strokeMax = ImVec2(x + kStrokeLeft + kSwatchSize, y + kStrokeTop + kSwatchSize);
+  layout.swapMin = ImVec2(x + kSwapLeft, y + kSwapTop);
+  layout.swapMax = ImVec2(x + kSwapLeft + kSwapWidth, y + kSwapTop + kSwapHeight);
+  layout.strokeNoneMin = ImVec2(x + kStrokeNoneLeft, y + kNoneTop);
+  layout.strokeNoneMax = ImVec2(x + kStrokeNoneRight, y + kNoneBottom);
+  layout.fillNoneMin = ImVec2(x + kFillNoneLeft, y + kNoneTop);
+  layout.fillNoneMax = ImVec2(x + kFillNoneRight, y + kNoneBottom);
+  layout.strokeChipMin = ImVec2(x + kChipLeft, y + kStrokeChipTop);
+  layout.strokeChipMax = ImVec2(widgetMax.x - kChipRightInset, y + kStrokeChipBottom);
+  layout.fillChipMin = ImVec2(x + kChipLeft, y + kFillChipTop);
+  layout.fillChipMax = ImVec2(widgetMax.x - kChipRightInset, y + kFillChipBottom);
+  return layout;
+}
+
+FillStrokeWidgetRegion HitTestFillStrokeWidget(const FillStrokeWidgetLayout& layout,
+                                               const ImVec2& point, bool fillIsCustom,
+                                               bool strokeIsCustom) {
+  // Small explicit affordances win over the larger swatches / chips they sit
+  // beside so they stay clickable.
+  if (Contains(layout.swapMin, layout.swapMax, point)) {
+    return FillStrokeWidgetRegion::Swap;
+  }
+  if (Contains(layout.strokeNoneMin, layout.strokeNoneMax, point)) {
+    return FillStrokeWidgetRegion::StrokeNone;
+  }
+  if (Contains(layout.fillNoneMin, layout.fillNoneMax, point)) {
+    return FillStrokeWidgetRegion::FillNone;
+  }
+  if (strokeIsCustom && Contains(layout.strokeChipMin, layout.strokeChipMax, point)) {
+    return FillStrokeWidgetRegion::StrokeChip;
+  }
+  if (fillIsCustom && Contains(layout.fillChipMin, layout.fillChipMax, point)) {
+    return FillStrokeWidgetRegion::FillChip;
+  }
+  // Fill is drawn in front, so it owns the overlapping region.
+  if (Contains(layout.fillMin, layout.fillMax, point)) {
+    return FillStrokeWidgetRegion::FillSwatch;
+  }
+  if (Contains(layout.strokeMin, layout.strokeMax, point)) {
+    return FillStrokeWidgetRegion::StrokeSwatch;
+  }
+  return FillStrokeWidgetRegion::None;
+}
+
+std::string SvgPaintStringForSlot(const ToolbarPaintSlotState& slot) {
+  if (slot.isNone) {
+    return "none";
+  }
+  if (slot.reference.has_value()) {
+    return "url(" + slot.reference->href + ")";
+  }
+  if (slot.isCustom) {
+    return slot.customLabel.empty() ? std::string("currentColor") : slot.customLabel;
+  }
+  return slot.color.toHexString();
+}
+
+void SwapActivePaint(ActivePaintStyle& style) { std::swap(style.fill, style.stroke); }
+
+void DrawFillStrokeSwatch(ImDrawList* drawList, const ImVec2& min, const ImVec2& max,
+                          const ToolbarPaintSlotState& state, bool front) {
+  constexpr float kRounding = 2.5f;
+  const ImU32 color = SwatchColorU32(state.color);
+
+  if (front) {
+    // Fill role: solid filled square.
+    drawList->AddRectFilled(min, max, color, kRounding);
+  } else {
+    // Stroke role: hollow ring so the two swatches read as distinct roles even
+    // when they carry the same color.
+    constexpr float kRing = 4.0f;
+    drawList->AddRectFilled(min, max, color, kRounding);
+    drawList->AddRectFilled(ImVec2(min.x + kRing, min.y + kRing), ImVec2(max.x - kRing, max.y - kRing),
+                            IM_COL32(32, 34, 38, 255), kRounding * 0.5f);
+  }
+
+  if (state.isCustom) {
+    // Diagonal hatch marks non-solid paint (gradients, patterns, context paint).
+    drawList->PushClipRect(min, max, true);
+    for (float lx = min.x - (max.y - min.y); lx < max.x; lx += 5.0f) {
+      drawList->AddLine(ImVec2(lx, max.y), ImVec2(lx + (max.y - min.y), min.y),
+                        IM_COL32(255, 255, 255, 95), 1.0f);
+    }
+    drawList->PopClipRect();
+  }
+
+  // Outlines: a light inner keyline plus a role-colored outer border.
+  drawList->AddRect(min, max, IM_COL32(255, 255, 255, 210), kRounding, 0, 1.0f);
+  drawList->AddRect(min, max, state.isCustom ? IM_COL32(91, 189, 255, 255) : IM_COL32(0, 0, 0, 210),
+                    kRounding, 0, 1.6f);
+
+  if (state.isNone) {
+    drawList->AddLine(ImVec2(min.x + 2.0f, max.y - 2.0f), ImVec2(max.x - 2.0f, min.y + 2.0f),
+                      IM_COL32(230, 40, 40, 255), 2.2f);
+  }
+}
+
+void DrawSwapAffordance(ImDrawList* drawList, const ImVec2& min, const ImVec2& max, bool enabled) {
+  const ImU32 tint = enabled ? IM_COL32(215, 222, 232, 255) : IM_COL32(120, 126, 134, 255);
+  const float w = max.x - min.x;
+  const float h = max.y - min.y;
+  const float cx = min.x + w * 0.5f;
+  const float cy = min.y + h * 0.5f;
+  // A bent double-headed arrow: horizontal shaft with a head on each end, one
+  // pointing left, one pointing right, evoking "swap".
+  const float shaftHalf = w * 0.34f;
+  const float arm = h * 0.24f;
+  const ImVec2 leftTip(cx - shaftHalf, cy);
+  const ImVec2 rightTip(cx + shaftHalf, cy);
+  drawList->AddLine(leftTip, rightTip, tint, 1.4f);
+  // Left head.
+  drawList->AddLine(leftTip, ImVec2(leftTip.x + arm, leftTip.y - arm), tint, 1.4f);
+  drawList->AddLine(leftTip, ImVec2(leftTip.x + arm, leftTip.y + arm), tint, 1.4f);
+  // Right head.
+  drawList->AddLine(rightTip, ImVec2(rightTip.x - arm, rightTip.y - arm), tint, 1.4f);
+  drawList->AddLine(rightTip, ImVec2(rightTip.x - arm, rightTip.y + arm), tint, 1.4f);
+}
+
+void DrawNoneAffordance(ImDrawList* drawList, const ImVec2& min, const ImVec2& max, bool fillVariant,
+                        bool active) {
+  const ImU32 border = active ? IM_COL32(232, 236, 242, 255) : IM_COL32(150, 156, 164, 255);
+  if (fillVariant) {
+    // Solid (fill) motif: filled white square.
+    drawList->AddRectFilled(min, max, IM_COL32(238, 240, 244, 255), 1.5f);
+    drawList->AddRect(min, max, border, 1.5f, 0, 1.0f);
+  } else {
+    // Hollow (stroke) motif: ring.
+    drawList->AddRect(min, max, IM_COL32(238, 240, 244, 255), 1.5f, 0, 1.6f);
+    drawList->AddRect(min, max, border, 1.5f, 0, 1.0f);
+  }
+  // Red "none" slash across the badge.
+  drawList->AddLine(ImVec2(min.x + 1.0f, max.y - 1.0f), ImVec2(max.x - 1.0f, min.y + 1.0f),
+                    IM_COL32(230, 40, 40, 255), 1.6f);
+}
+
+}  // namespace donner::editor::internal

--- a/donner/editor/FillStrokeWidget.h
+++ b/donner/editor/FillStrokeWidget.h
@@ -1,0 +1,73 @@
+#pragma once
+/// @file
+/// Geometry, hit-testing, and drawing for the toolbar Fill/Stroke widget.
+///
+/// The widget presents the classic design-tool paired-swatch control: a filled
+/// "fill" swatch in front and a hollow "stroke" swatch behind, with per-slot
+/// affordances to clear a slot to `none` and to swap fill and stroke. The pure
+/// layout/hit-test/paint-string helpers here are unit tested; `EditorShell`
+/// owns the imgui interaction wiring and the color-picker popups.
+
+#include <string>
+
+#include "donner/editor/EditorShellInternal.h"  // ToolbarPaintSlotState, ActivePaintStyle
+#include "donner/editor/ImGuiIncludes.h"
+
+namespace donner::editor::internal {
+
+/// Interactive regions of the Fill/Stroke widget, in hit-test priority order.
+enum class FillStrokeWidgetRegion {
+  None,         ///< No interactive region under the point.
+  FillSwatch,   ///< Front (fill) swatch: opens the fill color picker.
+  StrokeSwatch,  ///< Back (stroke) swatch: opens the stroke color picker.
+  Swap,          ///< Double-arrow affordance: swaps fill and stroke paints.
+  FillNone,      ///< Fill "set none" affordance.
+  StrokeNone,    ///< Stroke "set none" affordance.
+  FillChip,      ///< Fill custom-paint chip: reveals the paint-server source.
+  StrokeChip,    ///< Stroke custom-paint chip: reveals the paint-server source.
+};
+
+/// Screen-space rectangles for every drawable/interactive part of the widget.
+struct FillStrokeWidgetLayout {
+  ImVec2 fillMin, fillMax;              ///< Front (fill) swatch.
+  ImVec2 strokeMin, strokeMax;         ///< Back (stroke) swatch.
+  ImVec2 swapMin, swapMax;             ///< Swap double-arrow affordance.
+  ImVec2 fillNoneMin, fillNoneMax;     ///< Fill "set none" affordance.
+  ImVec2 strokeNoneMin, strokeNoneMax;  ///< Stroke "set none" affordance.
+  ImVec2 fillChipMin, fillChipMax;     ///< Fill custom-paint label chip.
+  ImVec2 strokeChipMin, strokeChipMax;  ///< Stroke custom-paint label chip.
+};
+
+/// Compute widget sub-rectangles from the widget's outer bounds.
+[[nodiscard]] FillStrokeWidgetLayout ComputeFillStrokeWidgetLayout(const ImVec2& widgetMin,
+                                                                   const ImVec2& widgetMax);
+
+/// Classify @p point against @p layout. Chip regions only match when the
+/// corresponding slot carries custom paint (only then is a chip drawn).
+[[nodiscard]] FillStrokeWidgetRegion HitTestFillStrokeWidget(const FillStrokeWidgetLayout& layout,
+                                                             const ImVec2& point, bool fillIsCustom,
+                                                             bool strokeIsCustom);
+
+/// Reconstruct an SVG paint attribute string ("none", "#rrggbb", "url(#id)",
+/// "context-fill", ...) from a resolved paint slot. Used by the swap action.
+[[nodiscard]] std::string SvgPaintStringForSlot(const ToolbarPaintSlotState& slot);
+
+/// Swap the fill and stroke of an active paint style in place.
+void SwapActivePaint(ActivePaintStyle& style);
+
+/// Draw a paint swatch. @p front draws a solid filled swatch (fill role); a
+/// non-front swatch draws a hollow ring (stroke role). Handles the none (red
+/// slash) and custom (diagonal hatch) presentations.
+void DrawFillStrokeSwatch(ImDrawList* drawList, const ImVec2& min, const ImVec2& max,
+                          const ToolbarPaintSlotState& state, bool front);
+
+/// Draw the swap double-arrow affordance.
+void DrawSwapAffordance(ImDrawList* drawList, const ImVec2& min, const ImVec2& max, bool enabled);
+
+/// Draw a "set none" affordance. @p fillVariant selects the solid (fill) motif
+/// versus the hollow (stroke) motif; @p active brightens it when the slot is
+/// already none.
+void DrawNoneAffordance(ImDrawList* drawList, const ImVec2& min, const ImVec2& max, bool fillVariant,
+                        bool active);
+
+}  // namespace donner::editor::internal

--- a/donner/editor/LayersPanel.cc
+++ b/donner/editor/LayersPanel.cc
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "donner/editor/DisclosureChevron.h"
 #include "donner/editor/EmbeddedSvgIcon.h"
 #include "donner/editor/ImGuiIncludes.h"
 #include "donner/svg/ElementType.h"
@@ -89,6 +90,41 @@ const std::optional<svg::RendererBitmap>& CachedBootstrapIconBitmap(LayerAfforda
 
   static const std::optional<svg::RendererBitmap> empty;
   return empty;
+}
+
+/// Display size (px) of the tree-disclosure chevron drawn in each expandable
+/// row. Shared visual with the inspector tree via DisclosureChevron.
+constexpr float kDisclosureChevronDisplayPx = 11.0f;
+
+/// Texture-cache key for a shared disclosure chevron mask. Lives in the same
+/// high `0xf5..` reserved space as the affordance icons so it can't collide
+/// with per-row thumbnail stable ids; the low bit distinguishes the collapsed
+/// and expanded variants.
+std::uint64_t DisclosureChevronTextureKey(bool expanded) {
+  return 0xf500000000000000ull + 5u +
+         static_cast<std::uint64_t>(DisclosureChevronTextureVariant(expanded));
+}
+
+/// Draw the shared tree-disclosure chevron as a clickable cell. Returns true on
+/// click. The chevron points right when collapsed and down when expanded, drawn
+/// from the Donner-rendered chevron mask and tinted with the current text color.
+bool DrawDisclosureChevronButton(const char* id, bool expanded,
+                                 const LayersPanel::IconTextureProvider& iconTextureProvider) {
+  const ImVec2 cellSize(ImGui::GetFrameHeight(), ImGui::GetFrameHeight());
+  const ImVec2 cellMin = ImGui::GetCursorScreenPos();
+  const bool clicked = ImGui::InvisibleButton(id, cellSize);
+  if (iconTextureProvider) {
+    const std::optional<svg::RendererBitmap>& bitmap = CachedDisclosureChevronBitmap(expanded);
+    if (bitmap.has_value()) {
+      const LayersPanel::IconTexture iconTexture =
+          iconTextureProvider(DisclosureChevronTextureKey(expanded), *bitmap);
+      const ImVec2 center(cellMin.x + cellSize.x * 0.5f, cellMin.y + cellSize.y * 0.5f);
+      DrawDisclosureChevron(ImGui::GetWindowDrawList(), iconTexture.texture,
+                            iconTexture.uvBottomRight, center, kDisclosureChevronDisplayPx,
+                            ImGui::GetColorU32(ImGuiCol_Text));
+    }
+  }
+  return clicked;
 }
 
 bool DrawLayerIconButton(const char* id, LayerAffordanceIcon icon,
@@ -488,8 +524,7 @@ void LayersPanel::render(EditorApp* liveApp, const ThumbnailTextureProvider& tex
     // the owned model. A non-expandable row gets a same-width spacer so names
     // stay aligned.
     if (row.hasChildren) {
-      const char* chevron = row.isExpanded ? "v" : ">";
-      if (ImGui::SmallButton(chevron)) {
+      if (DrawDisclosureChevronButton("##layer_disclosure", row.isExpanded, iconTextureProvider)) {
         model_.toggleExpanded(row.stableId);
       }
     } else {

--- a/donner/editor/SidebarPresenter.cc
+++ b/donner/editor/SidebarPresenter.cc
@@ -14,6 +14,7 @@
 
 #include "donner/base/MathUtils.h"
 #include "donner/base/xml/XMLNode.h"
+#include "donner/editor/DisclosureChevron.h"
 #include "donner/editor/EditorCommand.h"
 #include "donner/editor/EmbeddedSvgIcon.h"
 #include "donner/editor/ImGuiIncludes.h"
@@ -452,34 +453,69 @@ void SidebarPresenter::refreshSnapshot(const EditorApp& app) {
   inspectorSnapshot_ = std::move(inspector);
 }
 
+void SidebarPresenter::toggleTreeNodeExpanded(std::uint32_t entityId) const {
+  if (const auto it = treeExpandedEntities_.find(entityId); it != treeExpandedEntities_.end()) {
+    treeExpandedEntities_.erase(it);
+  } else {
+    treeExpandedEntities_.insert(entityId);
+  }
+}
+
 void SidebarPresenter::renderTreeNode(EditorApp* liveApp, const TreeNodeSnapshot& node,
-                                      TreeViewState& state) const {
+                                      TreeViewState& state,
+                                      const IconTextureProvider& iconTextureProvider) const {
   const bool hasChildren = !node.children.empty();
+  const std::uint32_t entityId =
+      static_cast<std::uint32_t>(node.element->unsafeEntityHandle().entity());
+
+  // Auto-expand ancestors of a pending scroll target so the selection is
+  // revealed, matching the former SetNextItemOpen behavior.
   const bool onSelectionPath = state.pendingScroll && state.scrollTarget.has_value() &&
                                IsAncestorOrSelf(*node.element, *state.scrollTarget);
   if (hasChildren && onSelectionPath) {
-    ImGui::SetNextItemOpen(true, ImGuiCond_Always);
+    treeExpandedEntities_.insert(entityId);
+  }
+  const bool expanded = hasChildren && treeExpandedEntities_.count(entityId) != 0;
+
+  ImGui::PushID(static_cast<int>(entityId));
+
+  const float rowHeight = ImGui::GetFrameHeight();
+  const float chevronCell = rowHeight;
+
+  // Disclosure chevron shared with the LayersPanel: a right-pointing chevron
+  // when collapsed, rotated to point down when expanded. Non-expandable rows
+  // get a same-width spacer so labels stay aligned. Clicking the chevron
+  // toggles the persistent disclosure state (only when a live app is present,
+  // matching the selection click gating).
+  if (hasChildren) {
+    const ImVec2 cellMin = ImGui::GetCursorScreenPos();
+    if (ImGui::InvisibleButton("##disclosure", ImVec2(chevronCell, rowHeight)) &&
+        liveApp != nullptr) {
+      toggleTreeNodeExpanded(entityId);
+    }
+    if (iconTextureProvider) {
+      const std::optional<svg::RendererBitmap>& bitmap = CachedDisclosureChevronBitmap(expanded);
+      if (bitmap.has_value()) {
+        const IconTexture chevronTexture = iconTextureProvider(
+            0xf600000000000000ull + 9u +
+                static_cast<std::uint64_t>(DisclosureChevronTextureVariant(expanded)),
+            *bitmap);
+        const ImVec2 center(cellMin.x + chevronCell * 0.5f, cellMin.y + rowHeight * 0.5f);
+        DrawDisclosureChevron(ImGui::GetWindowDrawList(), chevronTexture.texture,
+                              chevronTexture.uvBottomRight, center, 11.0f,
+                              ImGui::GetColorU32(ImGuiCol_Text));
+      }
+    }
+    ImGui::SameLine(0.0f, 2.0f);
+  } else {
+    ImGui::Dummy(ImVec2(chevronCell, 0.0f));
+    ImGui::SameLine(0.0f, 2.0f);
   }
 
-  ImGuiTreeNodeFlags nodeFlags = ImGuiTreeNodeFlags_OpenOnArrow |
-                                 ImGuiTreeNodeFlags_OpenOnDoubleClick |
-                                 ImGuiTreeNodeFlags_SpanAvailWidth;
-  if (!hasChildren) {
-    nodeFlags |= ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen;
-  }
-  if (node.isSelected) {
-    nodeFlags |= ImGuiTreeNodeFlags_Selected;
-  }
-
-  const donner::Entity entity = node.element->unsafeEntityHandle().entity();
-  ImGui::PushID(static_cast<int>(static_cast<std::uint32_t>(entity)));
-  const bool nodeOpen = ImGui::TreeNodeEx(node.label.c_str(), nodeFlags);
-
-  // Click handling: only valid when we have live access to the EditorApp.
-  // When `liveApp` is null (async renderer is busy), clicks are dropped -
-  // the selection state freezes along with the rest of the snapshot until
-  // the worker finishes and the main loop catches up next frame.
-  if (liveApp != nullptr && ImGui::IsItemClicked()) {
+  // Row label + selection highlight. A default-size selectable already spans
+  // the remaining content width, giving the same hit box and highlight the tree
+  // node used to.
+  if (ImGui::Selectable(node.label.c_str(), node.isSelected) && liveApp != nullptr) {
     const bool toggleSelection = ImGui::GetIO().KeyCtrl || ImGui::GetIO().KeySuper;
     if (toggleSelection) {
       liveApp->toggleInSelection(*node.element);
@@ -490,22 +526,24 @@ void SidebarPresenter::renderTreeNode(EditorApp* liveApp, const TreeNodeSnapshot
     state.pendingScroll = false;
   }
 
-  if (nodeOpen && hasChildren) {
-    for (const auto& child : node.children) {
-      renderTreeNode(liveApp, child, state);
-    }
-    ImGui::TreePop();
-  }
-
   ImGui::PopID();
+
+  if (expanded) {
+    ImGui::Indent(chevronCell);
+    for (const auto& child : node.children) {
+      renderTreeNode(liveApp, child, state, iconTextureProvider);
+    }
+    ImGui::Unindent(chevronCell);
+  }
 }
 
-void SidebarPresenter::renderTreeView(EditorApp* liveApp, TreeViewState& state) const {
+void SidebarPresenter::renderTreeView(EditorApp* liveApp, TreeViewState& state,
+                                      const IconTextureProvider& iconTextureProvider) const {
   if (!treeSnapshot_.has_value()) {
     ImGui::TextDisabled("(no document)");
     return;
   }
-  renderTreeNode(liveApp, *treeSnapshot_, state);
+  renderTreeNode(liveApp, *treeSnapshot_, state, iconTextureProvider);
 }
 
 bool SidebarPresenter::renderInspector(EditorApp* liveApp, const ViewportState& viewport,

--- a/donner/editor/SidebarPresenter.h
+++ b/donner/editor/SidebarPresenter.h
@@ -7,6 +7,7 @@
 #include <optional>
 #include <span>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -97,7 +98,12 @@ public:
   /// non-null, click-induced selection mutations are applied to it; when
   /// null, clicks are dropped (the render is "read-only" because the worker
   /// thread owns the document).
-  void renderTreeView(EditorApp* liveApp, TreeViewState& state) const;
+  ///
+  /// @param iconTextureProvider Uploads the shared disclosure-chevron mask to an
+  ///   ImGui texture; pass null (e.g. headless tests) to skip chevron art while
+  ///   keeping the disclosure interaction.
+  void renderTreeView(EditorApp* liveApp, TreeViewState& state,
+                      const IconTextureProvider& iconTextureProvider = {}) const;
 
   /**
    * Render the inspector pane from the current snapshot.
@@ -118,6 +124,18 @@ public:
   }
 
   [[nodiscard]] bool hasTreeSnapshotForTesting() const { return treeSnapshot_.has_value(); }
+
+  /// Whether the tree node for @p entityId is expanded. Keyed by the element's
+  /// 32-bit entity id (`entity` cast). Drives the disclosure round-trip test.
+  [[nodiscard]] bool isTreeNodeExpandedForTesting(std::uint32_t entityId) const {
+    return treeExpandedEntities_.count(entityId) != 0;
+  }
+
+  /// Toggle the tree disclosure for @p entityId, exactly as clicking the row's
+  /// chevron does.
+  void toggleTreeNodeExpandedForTesting(std::uint32_t entityId) {
+    toggleTreeNodeExpanded(entityId);
+  }
 
   [[nodiscard]] std::string_view inspectorTitleForTesting() const {
     return inspectorSnapshot_.titleText;
@@ -218,7 +236,12 @@ private:
 
   void captureTreeNode(const svg::SVGElement& element, std::span<const svg::SVGElement> selection,
                        TreeNodeSnapshot& out);
-  void renderTreeNode(EditorApp* liveApp, const TreeNodeSnapshot& node, TreeViewState& state) const;
+  void renderTreeNode(EditorApp* liveApp, const TreeNodeSnapshot& node, TreeViewState& state,
+                      const IconTextureProvider& iconTextureProvider) const;
+
+  /// Flip the persistent disclosure state for @p entityId (the model the tree
+  /// chevron drives), shared by the click handler and the testing hook.
+  void toggleTreeNodeExpanded(std::uint32_t entityId) const;
 
   /// Render the editable transform section (decomposed fields plus the raw
   /// matrix disclosure). Returns true if a mutation was queued.
@@ -248,6 +271,12 @@ private:
   std::optional<TreeNodeSnapshot> treeSnapshot_;
   InspectorSnapshot inspectorSnapshot_;
   std::optional<TransformEditState> transformEdit_;
+
+  /// Persistent tree-disclosure state, keyed by 32-bit entity id. A node is
+  /// expanded iff present. Mutable because the tree renders from a const
+  /// snapshot but owns its own view state (like imgui's former internal open
+  /// state). Reset implicitly as entities change across document reloads.
+  mutable std::unordered_set<std::uint32_t> treeExpandedEntities_;
 };
 
 }  // namespace donner::editor

--- a/donner/editor/icons/chevron-down.svg
+++ b/donner/editor/icons/chevron-down.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+  <path d="M3.25 6 L8 10.75 L12.75 6" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/donner/editor/icons/chevron.svg
+++ b/donner/editor/icons/chevron.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+  <path d="M6 3.25 L10.75 8 L6 12.75" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -14,6 +14,7 @@
 
 #include "donner/css/Color.h"
 #include "donner/editor/EditorShellInternal.h"
+#include "donner/editor/FillStrokeWidget.h"
 #include "donner/editor/InMemoryClipboard.h"
 #include "donner/editor/gui/EditorWindow.h"
 #include "donner/editor/repro/ReproFile.h"
@@ -346,6 +347,87 @@ TEST(EditorShellInternalTest, ActivePaintStateUsesFillAndStrokeAttributes) {
   EXPECT_FALSE(state.stroke.isNone);
   EXPECT_TRUE(state.stroke.isCustom);
   EXPECT_EQ(state.stroke.customLabel, "url(#paint)");
+}
+
+TEST(EditorShellInternalTest, ActivePaintStyleDefaultsToWhiteFillBlackStroke) {
+  const ActivePaintStyle style;
+  EXPECT_EQ(style.fill, "white");
+  EXPECT_EQ(style.stroke, "black");
+}
+
+TEST(EditorShellInternalTest, SwapActivePaintSwapsFillAndStroke) {
+  ActivePaintStyle style;
+  style.fill = "#112233";
+  style.stroke = "#445566";
+  internal::SwapActivePaint(style);
+  EXPECT_EQ(style.fill, "#445566");
+  EXPECT_EQ(style.stroke, "#112233");
+
+  // A fresh document's white fill / black stroke swaps cleanly.
+  ActivePaintStyle fresh;
+  internal::SwapActivePaint(fresh);
+  EXPECT_EQ(fresh.fill, "black");
+  EXPECT_EQ(fresh.stroke, "white");
+}
+
+TEST(EditorShellInternalTest, SvgPaintStringForSlotCoversNoneSolidAndReference) {
+  internal::ToolbarPaintSlotState none;
+  none.isNone = true;
+  EXPECT_EQ(internal::SvgPaintStringForSlot(none), "none");
+
+  internal::ToolbarPaintSlotState solid;
+  solid.isNone = false;
+  solid.color = css::RGBA::RGB(0x11, 0x22, 0x33);
+  EXPECT_EQ(internal::SvgPaintStringForSlot(solid), css::RGBA::RGB(0x11, 0x22, 0x33).toHexString());
+
+  internal::ToolbarPaintSlotState reference;
+  reference.isNone = false;
+  reference.isCustom = true;
+  internal::ToolbarPaintReferenceState ref;
+  ref.href = "#grad";
+  reference.reference = ref;
+  EXPECT_EQ(internal::SvgPaintStringForSlot(reference), "url(#grad)");
+
+  internal::ToolbarPaintSlotState context;
+  context.isNone = false;
+  context.isCustom = true;
+  context.customLabel = "context-fill";
+  EXPECT_EQ(internal::SvgPaintStringForSlot(context), "context-fill");
+}
+
+TEST(EditorShellInternalTest, FillStrokeWidgetLayoutAndHitTestClassifyRegions) {
+  const ImVec2 widgetMin(100.0f, 200.0f);
+  const ImVec2 widgetMax(widgetMin.x + 118.0f, widgetMin.y + 30.0f);
+  const internal::FillStrokeWidgetLayout layout =
+      internal::ComputeFillStrokeWidgetLayout(widgetMin, widgetMax);
+
+  const auto center = [](const ImVec2& a, const ImVec2& b) {
+    return ImVec2((a.x + b.x) * 0.5f, (a.y + b.y) * 0.5f);
+  };
+  const auto hit = [&](const ImVec2& p, bool fillCustom, bool strokeCustom) {
+    return internal::HitTestFillStrokeWidget(layout, p, fillCustom, strokeCustom);
+  };
+
+  EXPECT_EQ(hit(center(layout.swapMin, layout.swapMax), false, false),
+            internal::FillStrokeWidgetRegion::Swap);
+  EXPECT_EQ(hit(center(layout.fillNoneMin, layout.fillNoneMax), false, false),
+            internal::FillStrokeWidgetRegion::FillNone);
+  EXPECT_EQ(hit(center(layout.strokeNoneMin, layout.strokeNoneMax), false, false),
+            internal::FillStrokeWidgetRegion::StrokeNone);
+
+  // Fill sits in front of stroke, so it owns the overlap region.
+  EXPECT_EQ(hit(center(layout.fillMin, layout.fillMax), false, false),
+            internal::FillStrokeWidgetRegion::FillSwatch);
+  // The stroke swatch's upper-right corner is clear of the front fill swatch.
+  const ImVec2 strokeOnly(layout.strokeMax.x - 2.0f, layout.strokeMin.y + 2.0f);
+  EXPECT_EQ(hit(strokeOnly, false, false), internal::FillStrokeWidgetRegion::StrokeSwatch);
+
+  // Chips only classify when their slot carries custom paint (only then drawn).
+  const ImVec2 fillChip = center(layout.fillChipMin, layout.fillChipMax);
+  EXPECT_EQ(hit(fillChip, false, false), internal::FillStrokeWidgetRegion::None);
+  EXPECT_EQ(hit(fillChip, true, false), internal::FillStrokeWidgetRegion::FillChip);
+  const ImVec2 strokeChip = center(layout.strokeChipMin, layout.strokeChipMax);
+  EXPECT_EQ(hit(strokeChip, false, true), internal::FillStrokeWidgetRegion::StrokeChip);
 }
 
 TEST(EditorShellInternalTest, SourceHelpersPreferInitialSourceAndCanonicalizeTrailingNewline) {

--- a/donner/editor/tests/SidebarPresenter_tests.cc
+++ b/donner/editor/tests/SidebarPresenter_tests.cc
@@ -621,6 +621,46 @@ TEST_F(SidebarPresenterImGuiTest, TreeViewOpensAncestorsForPendingScrollTarget) 
   EXPECT_GT(drawData->TotalVtxCount, 0);
 }
 
+TEST_F(SidebarPresenterImGuiTest, TreeDisclosureStateRoundTripsForInspectorTree) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kInspectorSvg));
+  app.setCleanSourceText(kInspectorSvg);
+
+  SidebarPresenter presenter;
+  presenter.refreshSnapshot(app);
+
+  const svg::SVGElement root = app.document().document().svgElement();
+  const std::uint32_t rootId = static_cast<std::uint32_t>(root.unsafeEntityHandle().entity());
+
+  // The disclosure state that the shared chevron drives round-trips: collapsed
+  // by default (matching the former imgui default-closed node), expands on
+  // toggle, and collapses again.
+  EXPECT_FALSE(presenter.isTreeNodeExpandedForTesting(rootId));
+  presenter.toggleTreeNodeExpandedForTesting(rootId);
+  EXPECT_TRUE(presenter.isTreeNodeExpandedForTesting(rootId));
+
+  TreeViewState treeState;
+  ImGuiIO& io = ImGui::GetIO();
+  io.DisplaySize = ImVec2(400, 300);
+  io.AddMousePosEvent(-1.0f, -1.0f);
+  io.AddMouseButtonEvent(0, false);
+  ImGui::NewFrame();
+  ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_Always);
+  ImGui::SetNextWindowSize(ImVec2(360, 280), ImGuiCond_Always);
+  ImGui::Begin("##sidebar_tree_disclosure_roundtrip_test", nullptr,
+               ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
+                   ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoScrollbar);
+  presenter.renderTreeView(nullptr, treeState);
+  ImGui::End();
+  ImGui::Render();
+  const ImDrawData* drawData = ImGui::GetDrawData();
+  ASSERT_NE(drawData, nullptr);
+  EXPECT_GT(drawData->TotalVtxCount, 0);
+
+  presenter.toggleTreeNodeExpandedForTesting(rootId);
+  EXPECT_FALSE(presenter.isTreeNodeExpandedForTesting(rootId));
+}
+
 TEST_F(SidebarPresenterImGuiTest, InspectorRendersSingleSelectionWithoutElementDetails) {
   EditorApp app;
   ASSERT_TRUE(app.loadFromString(R"(<svg xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
Fill/Stroke widget redesign and shared disclosure chevron.

- Redesign the Fill/Stroke widget and add shared disclosure chevron scaffold.
- Unify tree disclosure on one shared chevron.

gate: editor suite green except the known /tmp sandbox target.

Part of Design 0013 / Design 0017 (zettelkasten).

Depends on / bases on `qa/polish-wave1` (PR #782); diff shown is this packet only.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
