### PR TITLE
Structured editing P1: context-aware source formatting on structural edits

### DIFF
--- a/donner/base/xml/XMLDocument.cc
+++ b/donner/base/xml/XMLDocument.cc
@@ -757,6 +757,77 @@ bool SourceHasClosingTagAt(std::string_view source, std::size_t offset,
          source.substr(offset, closingTag.size()) == closingTag;
 }
 
+// How a structural mutation should format the whitespace around a newly serialized node.
+enum class InsertionFormatting {
+  // Text content: keep it inline (e.g. `<text>hello</text>`). Never introduces newlines,
+  // matching how a human authors a text run.
+  kInline,
+  // Structural child (element inserted/moved via the layer tree): lay the child out on its
+  // own indented line when the surrounding source is already spread across multiple lines,
+  // and stay compact when the author wrote it on a single line.
+  kStructural,
+};
+
+// The indentation (a run of spaces/tabs) of the line that `offset` begins on: the
+// whitespace between the newline preceding `offset` and `offset` itself. Returns nullopt
+// when `offset` is not at the start of its line (an inline / single-line context), which
+// signals that structural insertion should stay compact and synthesize no whitespace.
+std::optional<std::string_view> LineIndentBefore(std::string_view source, std::size_t offset) {
+  if (offset > source.size()) {
+    return std::nullopt;
+  }
+  std::size_t indentStart = offset;
+  while (indentStart > 0 && (source[indentStart - 1] == ' ' || source[indentStart - 1] == '\t')) {
+    --indentStart;
+  }
+  if (indentStart == 0 || source[indentStart - 1] != '\n') {
+    return std::nullopt;
+  }
+  return source.substr(indentStart, offset - indentStart);
+}
+
+// The leading indentation (run of spaces/tabs at the start of the line) of the line that
+// contains `pos`. Unlike LineIndentBefore, `pos` may sit anywhere on the line.
+std::string_view LineIndentContaining(std::string_view source, std::size_t pos) {
+  if (pos > source.size()) {
+    pos = source.size();
+  }
+  std::size_t lineStart = pos;
+  while (lineStart > 0 && source[lineStart - 1] != '\n') {
+    --lineStart;
+  }
+  std::size_t indentEnd = lineStart;
+  while (indentEnd < source.size() && (source[indentEnd] == ' ' || source[indentEnd] == '\t')) {
+    ++indentEnd;
+  }
+  return source.substr(lineStart, indentEnd - lineStart);
+}
+
+// Detect the document's indentation unit (a tab, or a run of N spaces) from the first
+// indented, non-blank line. Falls back to two spaces when there is no indentation to learn
+// from. This keeps synthesized indentation faithful to the author's chosen style (tabs vs
+// spaces, and width) instead of imposing a global default.
+std::string DetectIndentUnit(std::string_view source) {
+  const std::size_t size = source.size();
+  std::size_t i = 0;
+  while (i < size) {
+    if (source[i] != '\n') {
+      ++i;
+      continue;
+    }
+    ++i;  // Move past the newline to the start of the next line.
+    std::size_t j = i;
+    while (j < size && (source[j] == ' ' || source[j] == '\t')) {
+      ++j;
+    }
+    if (j > i && j < size && source[j] != '\n' && source[j] != '\r') {
+      return std::string(source.substr(i, j - i));
+    }
+    i = j;
+  }
+  return "  ";
+}
+
 std::optional<std::size_t> FindParentClosingTagInsertionOffset(const XMLDocument& document,
                                                                const XMLNode& parent) {
   const std::string closingTag = ClosingTagFor(parent);
@@ -806,7 +877,14 @@ void ApplyParentInsertionPlan(XMLNode& parent, const NodeInsertionPlan& plan) {
 std::optional<NodeInsertionPlan> GetNodeInsertionPlan(const XMLDocument& document,
                                                       const XMLNode& parent,
                                                       const std::optional<XMLNode>& referenceNode,
-                                                      std::string_view serializedNode) {
+                                                      std::string_view serializedNode,
+                                                      InsertionFormatting formatting) {
+  const std::string_view source = document.source();
+  const bool structural = (formatting == InsertionFormatting::kStructural);
+
+  // Scenario A: insert before an existing sibling. The whitespace already in front of the
+  // reference node becomes the new node's leading indentation; a trailing newline plus the
+  // reference node's own indentation pushes the reference node back onto its own line.
   if (referenceNode.has_value()) {
     std::optional<XMLNode> referenceParent = referenceNode->parentElement();
     if (!referenceParent.has_value() || *referenceParent != parent) {
@@ -819,17 +897,63 @@ std::optional<NodeInsertionPlan> GetNodeInsertionPlan(const XMLDocument& documen
     }
 
     const std::size_t offset = *referenceLocation->start.offset;
+    std::string suffix;
+    if (structural) {
+      if (std::optional<std::string_view> refIndent = LineIndentBefore(source, offset)) {
+        suffix.push_back('\n');
+        suffix.append(*refIndent);
+      }
+    }
     return NodeInsertionPlan{
         .replacementOffset = offset,
         .replacementLength = 0,
+        .suffix = std::move(suffix),
         .insertedNodeOffset = offset,
     };
   }
 
+  // Scenario B: append as the last child, immediately before the parent's closing tag.
   if (std::optional<std::size_t> closingTagOffset =
           FindParentClosingTagInsertionOffset(document, parent);
       closingTagOffset.has_value()) {
     const std::size_t offset = *closingTagOffset;
+
+    if (structural) {
+      // Consume the whitespace run that currently indents the closing tag, then re-emit it
+      // as: a newline plus the sibling indentation for the new child, followed by a newline
+      // plus the closing tag's own indentation so the closing tag keeps its place.
+      std::size_t wsStart = offset;
+      while (wsStart > 0 && IsXmlSpace(source[wsStart - 1])) {
+        --wsStart;
+      }
+      const std::string_view whitespace = source.substr(wsStart, offset - wsStart);
+      if (whitespace.find('\n') != std::string_view::npos) {
+        const std::string_view closingIndent = LineIndentContaining(source, offset);
+        std::string_view childIndent = LineIndentContaining(source, wsStart);
+        std::string childIndentStorage;
+        if (childIndent.size() <= closingIndent.size()) {
+          // No deeper existing sibling to match (an empty but multi-line parent): indent one
+          // detected unit past the closing tag.
+          childIndentStorage = std::string(closingIndent) + DetectIndentUnit(source);
+          childIndent = childIndentStorage;
+        }
+
+        std::string prefix = "\n";
+        prefix.append(childIndent);
+        std::string suffix = "\n";
+        suffix.append(closingIndent);
+
+        const std::size_t insertedOffset = wsStart + prefix.size();
+        return NodeInsertionPlan{
+            .replacementOffset = wsStart,
+            .replacementLength = offset - wsStart,
+            .prefix = std::move(prefix),
+            .suffix = std::move(suffix),
+            .insertedNodeOffset = insertedOffset,
+        };
+      }
+    }
+
     return NodeInsertionPlan{
         .replacementOffset = offset,
         .replacementLength = 0,
@@ -837,36 +961,51 @@ std::optional<NodeInsertionPlan> GetNodeInsertionPlan(const XMLDocument& documen
     };
   }
 
+  // Scenario C: the parent is self-closing (`<g/>`); expand it into an open/close pair with
+  // the new child inside.
   std::optional<SourceRange> nodeLocation = parent.getNodeLocation();
   if (!nodeLocation.has_value() || !nodeLocation->start.offset.has_value() ||
       !nodeLocation->end.offset.has_value() || *nodeLocation->end.offset < 2 ||
-      *nodeLocation->end.offset > document.source().size()) {
+      *nodeLocation->end.offset > source.size()) {
     return std::nullopt;
   }
 
   const std::size_t selfCloseStart = *nodeLocation->end.offset - 2;
-  if (document.source().substr(selfCloseStart, 2) != "/>") {
+  if (source.substr(selfCloseStart, 2) != "/>") {
     return std::nullopt;
   }
 
   std::size_t replacementStart = selfCloseStart;
   while (replacementStart > *nodeLocation->start.offset &&
-         IsXmlSpace(document.source()[replacementStart - 1])) {
+         IsXmlSpace(source[replacementStart - 1])) {
     --replacementStart;
   }
 
   const std::string closingTag = ClosingTagFor(parent);
 
-  const std::size_t insertedOffset = replacementStart + 1;
-  const std::size_t closingTagStart = insertedOffset + serializedNode.size();
+  std::string prefix = ">";
+  std::string suffix = closingTag;
+  if (structural) {
+    if (std::optional<std::string_view> parentIndent =
+            LineIndentBefore(source, *nodeLocation->start.offset)) {
+      const std::string childIndent = std::string(*parentIndent) + DetectIndentUnit(source);
+      prefix = ">\n" + childIndent;
+      suffix = "\n" + std::string(*parentIndent) + closingTag;
+    }
+  }
+
+  const std::size_t openingTagEnd = replacementStart + 1;  // Just past the emitted '>'.
+  const std::size_t insertedOffset = replacementStart + prefix.size();
+  const std::size_t closingTagStart =
+      insertedOffset + serializedNode.size() + (suffix.size() - closingTag.size());
   return NodeInsertionPlan{
       .replacementOffset = replacementStart,
       .replacementLength = *nodeLocation->end.offset - replacementStart,
-      .prefix = ">",
-      .suffix = closingTag,
+      .prefix = std::move(prefix),
+      .suffix = std::move(suffix),
       .insertedNodeOffset = insertedOffset,
       .parentOpeningTagLocation = SourceRange{FileOffset::Offset(*nodeLocation->start.offset),
-                                              FileOffset::Offset(insertedOffset)},
+                                              FileOffset::Offset(openingTagEnd)},
       .parentClosingTagLocation =
           SourceRange{FileOffset::Offset(closingTagStart),
                       FileOffset::Offset(closingTagStart + closingTag.size())},
@@ -1939,8 +2078,23 @@ ApplySourceEditResult XMLDocument::insertNode(XMLNode parent, XMLNode node,
 
     const std::string serialized(
         source().substr(removalRange->start, removalRange->end - removalRange->start));
+
+    // Absorb the newline and indentation that put the node on its own line so moving it out
+    // does not leave an orphaned, over-indented blank line behind. The serialized bytes above
+    // are the node itself; the expanded range is only what gets deleted from the old spot.
+    SourceEditRange effectiveRemoval = *removalRange;
+    if (std::optional<std::string_view> nodeIndent = LineIndentBefore(source(), removalRange->start);
+        nodeIndent.has_value()) {
+      const std::size_t lineStart = removalRange->start - nodeIndent->size();
+      if (lineStart > 0 && source()[lineStart - 1] == '\n') {
+        effectiveRemoval.start = lineStart - 1;
+      }
+    }
+    const std::size_t effectiveRemovalLength = effectiveRemoval.end - effectiveRemoval.start;
+
     std::optional<NodeInsertionPlan> insertionPlan =
-        GetNodeInsertionPlan(*this, parent, referenceNode, serialized);
+        GetNodeInsertionPlan(*this, parent, referenceNode, serialized,
+                             InsertionFormatting::kStructural);
     if (!insertionPlan.has_value()) {
       result.diagnostic =
           MakeEditDiagnostic("Cannot move node without a source insertion point", diagnosticRange);
@@ -1985,8 +2139,8 @@ ApplySourceEditResult XMLDocument::insertNode(XMLNode parent, XMLNode node,
       const std::size_t replacementNetLength =
           replacement.size() - appliedInsertionPlan.replacementLength;
       std::optional<XMLSourceDelta> removeDelta =
-          store->replace(removalRange->start + replacementNetLength,
-                         removalRange->end - removalRange->start, std::string_view());
+          store->replace(effectiveRemoval.start + replacementNetLength, effectiveRemovalLength,
+                         std::string_view());
       if (!removeDelta.has_value()) {
         result.diagnostic =
             MakeEditDiagnostic("Invalid source removal for node move", diagnosticRange);
@@ -1994,8 +2148,8 @@ ApplySourceEditResult XMLDocument::insertNode(XMLNode parent, XMLNode node,
       }
       result.sourceDeltas.push_back(*removeDelta);
     } else {
-      std::optional<XMLSourceDelta> removeDelta = store->replace(
-          removalRange->start, removalRange->end - removalRange->start, std::string_view());
+      std::optional<XMLSourceDelta> removeDelta =
+          store->replace(effectiveRemoval.start, effectiveRemovalLength, std::string_view());
       if (!removeDelta.has_value()) {
         result.diagnostic =
             MakeEditDiagnostic("Invalid source removal for node move", diagnosticRange);
@@ -2003,8 +2157,7 @@ ApplySourceEditResult XMLDocument::insertNode(XMLNode parent, XMLNode node,
       }
       result.sourceDeltas.push_back(*removeDelta);
 
-      const std::size_t removalLength = removalRange->end - removalRange->start;
-      if (!ShiftPlanLeft(appliedInsertionPlan, removalLength)) {
+      if (!ShiftPlanLeft(appliedInsertionPlan, effectiveRemovalLength)) {
         result.diagnostic =
             MakeEditDiagnostic("Invalid source insertion plan for node move", diagnosticRange);
         return result;
@@ -2048,7 +2201,8 @@ ApplySourceEditResult XMLDocument::insertNode(XMLNode parent, XMLNode node,
 
   const std::string serialized(std::string_view(node.serializeToString(0, false)));
   std::optional<NodeInsertionPlan> insertionPlan =
-      GetNodeInsertionPlan(*this, parent, referenceNode, serialized);
+      GetNodeInsertionPlan(*this, parent, referenceNode, serialized,
+                           InsertionFormatting::kStructural);
   if (!insertionPlan.has_value()) {
     result.diagnostic =
         MakeEditDiagnostic("Cannot insert node without a source insertion point", diagnosticRange);
@@ -2235,8 +2389,10 @@ ApplySourceEditResult XMLDocument::setElementText(XMLNode element, std::string_v
     return result;
   }
 
-  std::optional<NodeInsertionPlan> plan =
-      GetNodeInsertionPlan(*this, element, std::nullopt, std::string_view(*escaped));
+  // Text content stays inline (`<text>hello</text>`) regardless of the surrounding layout;
+  // that is how a human authors a text run, so no block indentation is synthesized here.
+  std::optional<NodeInsertionPlan> plan = GetNodeInsertionPlan(
+      *this, element, std::nullopt, std::string_view(*escaped), InsertionFormatting::kInline);
   if (!plan.has_value()) {
     result.diagnostic = MakeEditDiagnostic(
         "Cannot set text on a node without a source insertion point", diagnosticRange);

--- a/donner/base/xml/XMLDocument.cc
+++ b/donner/base/xml/XMLDocument.cc
@@ -919,9 +919,9 @@ std::optional<NodeInsertionPlan> GetNodeInsertionPlan(const XMLDocument& documen
     const std::size_t offset = *closingTagOffset;
 
     if (structural) {
-      // Consume the whitespace run that currently indents the closing tag, then re-emit it
-      // as: a newline plus the sibling indentation for the new child, followed by a newline
-      // plus the closing tag's own indentation so the closing tag keeps its place.
+      // Append the child on its own line right after the last existing sibling, leaving the
+      // whitespace that already indents the closing tag untouched. This stays a pure
+      // insertion (nothing removed), which the text-mirror's echo-suppression relies on.
       std::size_t wsStart = offset;
       while (wsStart > 0 && IsXmlSpace(source[wsStart - 1])) {
         --wsStart;
@@ -940,16 +940,12 @@ std::optional<NodeInsertionPlan> GetNodeInsertionPlan(const XMLDocument& documen
 
         std::string prefix = "\n";
         prefix.append(childIndent);
-        std::string suffix = "\n";
-        suffix.append(closingIndent);
 
-        const std::size_t insertedOffset = wsStart + prefix.size();
         return NodeInsertionPlan{
             .replacementOffset = wsStart,
-            .replacementLength = offset - wsStart,
+            .replacementLength = 0,
             .prefix = std::move(prefix),
-            .suffix = std::move(suffix),
-            .insertedNodeOffset = insertedOffset,
+            .insertedNodeOffset = wsStart + 1 + childIndent.size(),
         };
       }
     }

--- a/donner/base/xml/tests/XMLDocument_tests.cc
+++ b/donner/base/xml/tests/XMLDocument_tests.cc
@@ -62,6 +62,25 @@ XMLDocument ParseDocument(std::string_view xml) {
   return std::move(maybeDocument.result());
 }
 
+/// The \p index-th element child of \p parent, skipping any whitespace/text nodes. Used by
+/// the source-formatting tests, whose fixtures are laid out across indented lines and thus
+/// carry inter-element whitespace text nodes.
+XMLNode ElementChild(const XMLNode& parent, std::size_t index) {
+  std::size_t seen = 0;
+  for (std::optional<XMLNode> child = parent.firstChild(); child.has_value();
+       child = child->nextSibling()) {
+    if (child->type() != XMLNode::Type::Element) {
+      continue;
+    }
+    if (seen == index) {
+      return *child;
+    }
+    ++seen;
+  }
+  ADD_FAILURE() << "no element child at index " << index;
+  return parent;
+}
+
 /// Returns true when \p result carries a diagnostic whose reason contains \p needle.
 MATCHER_P(DiagnosticReasonContains, needle, "") {
   if (!arg.diagnostic.has_value()) {
@@ -2428,6 +2447,96 @@ TEST_F(XMLDocumentTests, RemoveNodeWithStaleSourceRangeFails) {
 }
 
 //
+// Structural source-formatting fidelity.
+//
+// These assert the exact source bytes produced by each structural mutation kind when the
+// document is already laid out across indented lines. The fidelity standard mirrors
+// attribute writeback: a mutation must leave the surrounding whitespace as a human would.
+//
+
+TEST_F(XMLDocumentTests, InsertNodeIntoEmptyParentIndentsChildOnItsOwnLine) {
+  XMLDocument doc = ParseDocument("<svg>\n  <g/>\n</svg>");
+  XMLNode g = ElementChild(doc.root().firstChild().value(), 0);
+  XMLNode rect = XMLNode::CreateElementNode(doc, "rect");
+
+  ApplySourceEditResult result = doc.insertNode(g, rect);
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_EQ(doc.source(), "<svg>\n  <g>\n    <rect/>\n  </g>\n</svg>");
+}
+
+TEST_F(XMLDocumentTests, InsertNodeBetweenSiblingsMatchesSiblingIndent) {
+  XMLDocument doc = ParseDocument("<svg>\n  <a/>\n  <b/>\n</svg>");
+  XMLNode svg = doc.root().firstChild().value();
+  XMLNode b = ElementChild(svg, 1);
+  XMLNode rect = XMLNode::CreateElementNode(doc, "rect");
+
+  ApplySourceEditResult result = doc.insertNode(svg, rect, b);
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_EQ(doc.source(), "<svg>\n  <a/>\n  <rect/>\n  <b/>\n</svg>");
+}
+
+TEST_F(XMLDocumentTests, InsertNodeAppendsAtSiblingIndentBeforeClosingTag) {
+  XMLDocument doc = ParseDocument("<svg>\n  <a/>\n  <b/>\n</svg>");
+  XMLNode svg = doc.root().firstChild().value();
+  XMLNode rect = XMLNode::CreateElementNode(doc, "rect");
+
+  ApplySourceEditResult result = doc.insertNode(svg, rect);
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_EQ(doc.source(), "<svg>\n  <a/>\n  <b/>\n  <rect/>\n</svg>");
+}
+
+TEST_F(XMLDocumentTests, InsertNodeDetectsTabIndentUnit) {
+  XMLDocument doc = ParseDocument("<svg>\n\t<g/>\n</svg>");
+  XMLNode g = ElementChild(doc.root().firstChild().value(), 0);
+  XMLNode rect = XMLNode::CreateElementNode(doc, "rect");
+
+  ApplySourceEditResult result = doc.insertNode(g, rect);
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_EQ(doc.source(), "<svg>\n\t<g>\n\t\t<rect/>\n\t</g>\n</svg>");
+}
+
+TEST_F(XMLDocumentTests, InsertNodeStaysCompactForSingleLineSource) {
+  XMLDocument doc = ParseDocument(R"(<svg><g/></svg>)");
+  XMLNode g = ElementChild(doc.root().firstChild().value(), 0);
+  XMLNode rect = XMLNode::CreateElementNode(doc, "rect");
+
+  ApplySourceEditResult result = doc.insertNode(g, rect);
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_EQ(doc.source(), R"(<svg><g><rect/></g></svg>)");
+}
+
+TEST_F(XMLDocumentTests, MoveNodeToEndCarriesWhitespaceWithoutOrphaningOldLine) {
+  XMLDocument doc = ParseDocument("<svg>\n  <a/>\n  <b/>\n  <c/>\n</svg>");
+  XMLNode svg = doc.root().firstChild().value();
+  XMLNode a = ElementChild(svg, 0);
+
+  // Move <a> to the end of its parent. The old line must not be left orphaned.
+  ApplySourceEditResult result = doc.insertNode(svg, a);
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_EQ(doc.source(), "<svg>\n  <b/>\n  <c/>\n  <a/>\n</svg>");
+}
+
+TEST_F(XMLDocumentTests, MoveNodeBeforeSiblingCarriesWhitespace) {
+  XMLDocument doc = ParseDocument("<svg>\n  <a/>\n  <b/>\n  <c/>\n</svg>");
+  XMLNode svg = doc.root().firstChild().value();
+  XMLNode a = ElementChild(svg, 0);
+  XMLNode c = ElementChild(svg, 2);
+  ASSERT_EQ(c.tagName(), XMLQualifiedNameRef("c"));
+
+  // Move <c> to before <a>. The old <c> line must collapse cleanly.
+  ApplySourceEditResult result = doc.insertNode(svg, c, a);
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_EQ(doc.source(), "<svg>\n  <c/>\n  <a/>\n  <b/>\n</svg>");
+}
+
+//
 // setElementText.
 //
 
@@ -2468,6 +2577,18 @@ TEST_F(XMLDocumentTests, SetElementTextInsertsIntoEmptyElement) {
   EXPECT_EQ(result.scope, ReparseScope::TextNode);
   EXPECT_THAT(text.value(), Optional(Eq("hello")));
   EXPECT_EQ(doc.source(), R"(<svg><text>hello</text></svg>)");
+}
+
+TEST_F(XMLDocumentTests, SetElementTextStaysInlineEvenInBlockLaidOutSource) {
+  // Text content is authored inline regardless of the surrounding block layout: expanding a
+  // self-closing <text/> yields <text>hello</text>, not a text node on its own line.
+  XMLDocument doc = ParseDocument("<svg>\n  <text/>\n</svg>");
+  XMLNode text = ElementChild(doc.root().firstChild().value(), 0);
+
+  ApplySourceEditResult result = doc.setElementText(text, "hello");
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_EQ(doc.source(), "<svg>\n  <text>hello</text>\n</svg>");
 }
 
 TEST_F(XMLDocumentTests, SetElementTextExpandsSelfClosingElement) {

--- a/donner/editor/tests/DocumentSyncController_tests.cc
+++ b/donner/editor/tests/DocumentSyncController_tests.cc
@@ -1364,9 +1364,12 @@ TEST(DocumentSyncControllerStructuredTest, MirrorSourceDeltasFallsBackWhenInsert
   textEditor.resetTextChanged();
   DocumentSyncController controller{std::string(kTwoRectSvg)};
 
-  const std::size_t closeOffset = textEditor.getText().find("</svg>");
-  ASSERT_NE(closeOffset, std::string::npos);
-  textEditor.setSelection(textEditor.getCoordinatesAtByteOffset(closeOffset - 1),
+  // The append lands on its own line right after the last child, so delete that whole tail
+  // locally (the last <rect> through </svg>). The insertion context is now gone, and the
+  // mirror must fall back to a full resync rather than patch into a stale offset.
+  const std::size_t lastRectOffset = textEditor.getText().rfind("<rect");
+  ASSERT_NE(lastRectOffset, std::string::npos);
+  textEditor.setSelection(textEditor.getCoordinatesAtByteOffset(lastRectOffset),
                           textEditor.getCoordinatesAtByteOffset(textEditor.getText().size()));
   textEditor.insertText("");
   textEditor.resetTextChanged();

--- a/donner/editor/tests/EditorApp_tests.cc
+++ b/donner/editor/tests/EditorApp_tests.cc
@@ -1754,6 +1754,41 @@ TEST(EditorAppReorderTest, SendToBackMovesElementToFirst) {
   EXPECT_THAT(ChildIds(app), ::testing::ElementsAre("r3", "r1", "r2"));
 }
 
+TEST(EditorAppReorderTest, ReorderIsOneUndoEntryAndUndoRestoresExactSourceBytes) {
+  // A cleanly-indented document: after the reorder the moved element must land on its own
+  // indented line (no orphaned blank line), and a single undo must restore the exact prior
+  // bytes. loadFromString clears the undo timeline, so the reorder is the only entry.
+  constexpr std::string_view kIndentedThreeRects =
+      "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"100\" height=\"100\">\n"
+      "  <rect id=\"r1\" x=\"0\" y=\"0\" width=\"10\" height=\"10\"/>\n"
+      "  <rect id=\"r2\" x=\"10\" y=\"0\" width=\"10\" height=\"10\"/>\n"
+      "  <rect id=\"r3\" x=\"20\" y=\"0\" width=\"10\" height=\"10\"/>\n"
+      "</svg>";
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(std::string(kIndentedThreeRects)));
+  const std::string before(app.document().document().source());
+  EXPECT_FALSE(app.canUndo());
+
+  SelectById(app, "r1");
+  EXPECT_TRUE(app.reorderSelectedElement(EditorApp::ZOrder::BringToFront));
+  ASSERT_TRUE(app.flushFrame());
+
+  EXPECT_EQ(std::string(app.document().document().source()),
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"100\" height=\"100\">\n"
+            "  <rect id=\"r2\" x=\"10\" y=\"0\" width=\"10\" height=\"10\"/>\n"
+            "  <rect id=\"r3\" x=\"20\" y=\"0\" width=\"10\" height=\"10\"/>\n"
+            "  <rect id=\"r1\" x=\"0\" y=\"0\" width=\"10\" height=\"10\"/>\n"
+            "</svg>");
+
+  ASSERT_TRUE(app.canUndo());
+  app.undo();
+  ASSERT_TRUE(app.flushFrame());
+
+  EXPECT_EQ(std::string(app.document().document().source()), before);
+  EXPECT_FALSE(app.canUndo()) << "a reorder must be a single undo entry";
+  EXPECT_TRUE(app.canRedo());
+}
+
 TEST(EditorAppReorderTest, ReflectsTheMoveIntoTheSourceText) {
   EditorApp app;
   ASSERT_TRUE(app.loadFromString(std::string(kThreeRects)));


### PR DESCRIPTION
Structured-editing: context-aware source formatting on structural edits.

- `XMLDocument`: context-aware indentation for structural insert/move.
- Append as a pure insertion after the last sibling, not a whitespace splice.
- Source-formatting fidelity tests for structural mutations.

gate: editor suite green except the known /tmp sandbox target.

Part of Design 0013 / Design 0017 (zettelkasten).

Depends on / bases on `qa/polish-wave1` (PR #782); diff shown is this packet only.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
