### PR TITLE
Structured editing P2: preserve authored transform syntax on writeback

### DIFF
--- a/donner/editor/BUILD.bazel
+++ b/donner/editor/BUILD.bazel
@@ -352,6 +352,16 @@ donner_cc_library(
 )
 
 donner_cc_library(
+    name = "transform_syntax_preserving",
+    srcs = ["TransformSyntaxPreserving.cc"],
+    hdrs = ["TransformSyntaxPreserving.h"],
+    deps = [
+        "//donner/base",
+        "//donner/svg/parser",
+    ],
+)
+
+donner_cc_library(
     name = "async_renderer",
     srcs = ["AsyncRenderer.cc"],
     hdrs = ["AsyncRenderer.h"],
@@ -497,6 +507,7 @@ donner_cc_library(
         ":source_sync",
         ":text_editor",
         ":text_patch",
+        ":transform_syntax_preserving",
         "//donner/base",
     ],
 )

--- a/donner/editor/DocumentSyncController.cc
+++ b/donner/editor/DocumentSyncController.cc
@@ -9,6 +9,7 @@
 #include "donner/editor/SelectTool.h"
 #include "donner/editor/SourceSync.h"
 #include "donner/editor/TextPatch.h"
+#include "donner/editor/TransformSyntaxPreserving.h"
 
 namespace donner::editor {
 
@@ -399,11 +400,13 @@ void DocumentSyncController::applyPendingWritebacks(EditorApp& app, SelectTool& 
     pendingTransformWritebacks_.push_back(EditorApp::CompletedTransformWriteback{
         .target = std::move(completed->target),
         .transform = completed->transform,
+        .sourceTransformAttributeValue = std::move(completed->sourceTransformAttributeValue),
     });
     for (auto& extra : completed->extras) {
       pendingTransformWritebacks_.push_back(EditorApp::CompletedTransformWriteback{
           .target = std::move(extra.target),
           .transform = extra.transform,
+          .sourceTransformAttributeValue = std::move(extra.sourceTransformAttributeValue),
       });
     }
   }
@@ -473,7 +476,8 @@ void DocumentSyncController::applyPendingWritebacks(EditorApp& app, SelectTool& 
           result = document.removeElementAttribute(*element, "transform");
         }
       } else {
-        const RcString serialized = toSVGTransformString(writeback.transform);
+        const RcString serialized = serializeTransformForWriteback(
+            writeback.sourceTransformAttributeValue, writeback.transform);
         if (std::string_view(serialized).empty()) {
           result = document.removeElementAttribute(*element, "transform");
         } else {
@@ -506,7 +510,8 @@ void DocumentSyncController::applyPendingWritebacks(EditorApp& app, SelectTool& 
         patch = buildAttributeRemoveWriteback(source, writeback.target, "transform");
       }
     } else {
-      const RcString serialized = toSVGTransformString(writeback.transform);
+      const RcString serialized = serializeTransformForWriteback(
+          writeback.sourceTransformAttributeValue, writeback.transform);
       if (std::string_view(serialized).empty()) {
         patch = buildAttributeRemoveWriteback(source, writeback.target, "transform");
       } else {

--- a/donner/editor/SelectTool.cc
+++ b/donner/editor/SelectTool.cc
@@ -695,9 +695,14 @@ void SelectTool::onMouseUp(EditorApp& editor, const Vector2d& /*documentPoint*/)
         .writebackTarget = dragState_->primary.writebackTarget,
         .sourceTransformAttributeValue = dragState_->primary.sourceTransformAttributeValue,
         .restoreSourceTransformAttributeValue = true};
+    // The forward ("after") snapshot carries the author's original bytes too so
+    // redo re-derives the same syntax-preserving writeback (restore stays
+    // false: this is a forward apply, not a verbatim restore).
     UndoSnapshot after{.element = dragState_->primary.element,
                        .transform = dragState_->primary.currentTransform,
-                       .writebackTarget = dragState_->primary.writebackTarget};
+                       .writebackTarget = dragState_->primary.writebackTarget,
+                       .sourceTransformAttributeValue =
+                           dragState_->primary.sourceTransformAttributeValue};
     before.extras.reserve(dragState_->extras.size());
     after.extras.reserve(dragState_->extras.size());
     for (const auto& extra : dragState_->extras) {
@@ -707,11 +712,11 @@ void SelectTool::onMouseUp(EditorApp& editor, const Vector2d& /*documentPoint*/)
                        .writebackTarget = extra.writebackTarget,
                        .sourceTransformAttributeValue = extra.sourceTransformAttributeValue,
                        .restoreSourceTransformAttributeValue = true});
-      after.extras.push_back(UndoSnapshot{
-          .element = extra.element,
-          .transform = extra.currentTransform,
-          .writebackTarget = extra.writebackTarget,
-      });
+      after.extras.push_back(
+          UndoSnapshot{.element = extra.element,
+                       .transform = extra.currentTransform,
+                       .writebackTarget = extra.writebackTarget,
+                       .sourceTransformAttributeValue = extra.sourceTransformAttributeValue});
     }
     editor.undoTimeline().record(undoLabel, std::move(before), std::move(after));
 
@@ -723,12 +728,14 @@ void SelectTool::onMouseUp(EditorApp& editor, const Vector2d& /*documentPoint*/)
           extraWritebacks.push_back(CompletedDragWriteback{
               .target = *extra.writebackTarget,
               .transform = extra.currentTransform,
+              .sourceTransformAttributeValue = extra.sourceTransformAttributeValue,
           });
         }
       }
       completedDragWriteback_ = CompletedDragWriteback{
           .target = *dragState_->primary.writebackTarget,
           .transform = dragState_->primary.currentTransform,
+          .sourceTransformAttributeValue = dragState_->primary.sourceTransformAttributeValue,
           .extras = std::move(extraWritebacks),
       };
     }

--- a/donner/editor/SelectTool.h
+++ b/donner/editor/SelectTool.h
@@ -88,6 +88,12 @@ public:
     AttributeWritebackTarget target;
     Transform2d transform;
 
+    /// The element's `transform=` bytes as authored at drag start, used by the
+    /// source writeback to preserve the author's function syntax instead of
+    /// canonicalizing to `matrix()`. `std::nullopt` when the element had no
+    /// transform attribute before the drag.
+    std::optional<RcString> sourceTransformAttributeValue;
+
     /// Additional writeback entries for extra elements in a multi-element
     /// drag. One per non-primary element that had a capturable writeback
     /// target. Empty for single-element drags.

--- a/donner/editor/SidebarPresenter.cc
+++ b/donner/editor/SidebarPresenter.cc
@@ -900,17 +900,24 @@ void SidebarPresenter::commitTransformEdit(EditorApp& liveApp) {
                       .writebackTarget = state.writebackTarget,
                       .sourceTransformAttributeValue = state.sourceTransformAttributeValue,
                       .restoreSourceTransformAttributeValue = true};
+  // Carry the author's original transform bytes on the forward ("after")
+  // snapshot too so redo re-derives the same syntax-preserving writeback the
+  // original edit produced (restore stays false: this is a forward apply).
   UndoSnapshot after{.element = state.element,
                      .transform = state.currentTransform,
-                     .writebackTarget = state.writebackTarget};
+                     .writebackTarget = state.writebackTarget,
+                     .sourceTransformAttributeValue = state.sourceTransformAttributeValue};
   liveApp.undoTimeline().record(state.undoLabel, std::move(before), std::move(after));
 
   // Keep the source pane's transform= attribute in lock-step with the DOM;
-  // DocumentSyncController drains this queue once per frame.
+  // DocumentSyncController drains this queue once per frame. The original
+  // attribute bytes let the writeback preserve the author's function syntax
+  // (rotate()/translate()/scale()) instead of canonicalizing to matrix().
   if (state.writebackTarget.has_value()) {
     liveApp.enqueueTransformWriteback(EditorApp::CompletedTransformWriteback{
         .target = *state.writebackTarget,
         .transform = state.currentTransform,
+        .sourceTransformAttributeValue = state.sourceTransformAttributeValue,
     });
   }
 }

--- a/donner/editor/TransformSyntaxPreserving.cc
+++ b/donner/editor/TransformSyntaxPreserving.cc
@@ -1,0 +1,509 @@
+#include "donner/editor/TransformSyntaxPreserving.h"
+
+#include <charconv>
+#include <cmath>
+#include <string>
+#include <vector>
+
+#include "donner/base/FormatNumber.h"
+#include "donner/base/MathUtils.h"
+#include "donner/svg/parser/TransformParser.h"
+
+namespace donner::editor {
+
+namespace {
+
+// Below these thresholds a component is treated as unchanged by the edit, so
+// its author-written token is re-emitted verbatim (preserving precision) rather
+// than reformatted.
+constexpr double kUnchangedEps = 1e-6;
+// Deltas below these thresholds mean the edit did not touch that decomposed
+// component, so no function of that kind is required to absorb it.
+constexpr double kAngleEps = 1e-9;   ///< Radians.
+constexpr double kScaleEps = 1e-9;   ///< Unitless scale-ratio deviation from 1.
+constexpr double kMatrixEps = 1e-6;  ///< Linear-part identity check for the translate solve.
+
+/// A single parsed number inside a transform function, keeping the author's
+/// verbatim token so unchanged parameters round-trip exactly.
+struct Arg {
+  double value = 0.0;
+  std::string text;
+};
+
+/// A parsed `name(args...)` transform function.
+struct Fn {
+  std::string name;
+  std::vector<Arg> args;
+  bool usesComma = false;  ///< Whether the author separated args with commas.
+};
+
+bool IsSpace(char c) {
+  return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
+}
+
+bool IsAlpha(char c) {
+  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+}
+
+bool IsDigit(char c) {
+  return c >= '0' && c <= '9';
+}
+
+/// Parse @p s into an ordered function list, capturing each argument's verbatim
+/// token. Returns `std::nullopt` on any malformed input; the caller then falls
+/// back to canonical serialization.
+std::optional<std::vector<Fn>> ParseFunctionList(std::string_view s) {
+  std::vector<Fn> fns;
+  std::size_t i = 0;
+  const std::size_t n = s.size();
+  auto skipSpace = [&] {
+    while (i < n && IsSpace(s[i])) {
+      ++i;
+    }
+  };
+
+  skipSpace();
+  while (i < n) {
+    const std::size_t nameStart = i;
+    while (i < n && IsAlpha(s[i])) {
+      ++i;
+    }
+    if (i == nameStart) {
+      return std::nullopt;
+    }
+    Fn fn;
+    fn.name = std::string(s.substr(nameStart, i - nameStart));
+
+    skipSpace();
+    if (i >= n || s[i] != '(') {
+      return std::nullopt;
+    }
+    ++i;  // consume '('
+    skipSpace();
+
+    while (i < n && s[i] != ')') {
+      const std::size_t numStart = i;
+      if (i < n && (s[i] == '+' || s[i] == '-')) {
+        ++i;
+      }
+      while (i < n && (IsDigit(s[i]) || s[i] == '.')) {
+        ++i;
+      }
+      if (i < n && (s[i] == 'e' || s[i] == 'E')) {
+        ++i;
+        if (i < n && (s[i] == '+' || s[i] == '-')) {
+          ++i;
+        }
+        while (i < n && IsDigit(s[i])) {
+          ++i;
+        }
+      }
+      if (i == numStart) {
+        return std::nullopt;  // not a number where one was expected
+      }
+
+      std::string token(s.substr(numStart, i - numStart));
+      double value = 0.0;
+      const char* begin = token.c_str();
+      char* end = nullptr;
+      value = std::strtod(begin, &end);
+      if (end != begin + token.size()) {
+        return std::nullopt;
+      }
+      fn.args.push_back(Arg{value, std::move(token)});
+
+      // Consume separators (commas and/or whitespace) between arguments.
+      bool sawComma = false;
+      while (i < n && (IsSpace(s[i]) || s[i] == ',')) {
+        if (s[i] == ',') {
+          if (sawComma) {
+            return std::nullopt;  // two commas in a row
+          }
+          sawComma = true;
+          fn.usesComma = true;
+        }
+        ++i;
+      }
+    }
+
+    if (i >= n) {
+      return std::nullopt;  // missing ')'
+    }
+    ++i;  // consume ')'
+    skipSpace();
+    fns.push_back(std::move(fn));
+  }
+
+  if (fns.empty()) {
+    return std::nullopt;
+  }
+  return fns;
+}
+
+std::string FormatEditedNumber(double value) {
+  // Kill floating-point noise beyond six decimals (edits never need finer than
+  // that) so a computed 60.000000000000004 serializes as "60" rather than a
+  // long decimal, while keeping the value well within the verify tolerance.
+  double rounded = std::round(value * 1e6) / 1e6;
+  if (rounded == 0.0) {
+    rounded = 0.0;  // normalize away -0.0
+  }
+  return detail::FormatNumberForSVG(rounded);
+}
+
+/// Assign @p value to argument @p index, keeping the author's verbatim token
+/// when the value is unchanged.
+void SetArg(Fn& fn, std::size_t index, double value) {
+  if (std::abs(value - fn.args[index].value) < kUnchangedEps) {
+    return;
+  }
+  fn.args[index].value = value;
+  fn.args[index].text = FormatEditedNumber(value);
+}
+
+std::string RenderFn(const Fn& fn) {
+  std::string out = fn.name;
+  out += '(';
+  const char* sep = fn.usesComma ? ", " : " ";
+  for (std::size_t k = 0; k < fn.args.size(); ++k) {
+    if (k != 0) {
+      out += sep;
+    }
+    out += fn.args[k].text;
+  }
+  out += ')';
+  return out;
+}
+
+std::string RenderList(const std::vector<Fn>& fns) {
+  std::string out;
+  for (std::size_t k = 0; k < fns.size(); ++k) {
+    if (k != 0) {
+      out += ' ';
+    }
+    out += RenderFn(fns[k]);
+  }
+  return out;
+}
+
+/// Standard matrix product `A * B` (Donner's `operator*` post-multiplies, so
+/// `B * A` yields the conventional product).
+Transform2d StandardMul(const Transform2d& a, const Transform2d& b) {
+  return b * a;
+}
+
+/// Scale-rotate-translate view of a matrix. Mirrors the inspector's
+/// DecomposeTransform: returns `std::nullopt` for skewed or singular matrices.
+struct Decomposed {
+  Vector2d translation;
+  double rotationRadians = 0.0;
+  Vector2d scale;
+};
+
+std::optional<Decomposed> Decompose(const Transform2d& t) {
+  const double a = t.data[0];
+  const double b = t.data[1];
+  const double c = t.data[2];
+  const double d = t.data[3];
+
+  const double scaleX = std::hypot(a, b);
+  constexpr double kSingularEpsilon = 1e-12;
+  if (!(scaleX > kSingularEpsilon) || !std::isfinite(scaleX)) {
+    return std::nullopt;
+  }
+
+  const double columnDot = a * c + b * d;
+  const double columnYNorm = std::hypot(c, d);
+  constexpr double kSkewTolerance = 1e-6;
+  if (columnYNorm > 0.0 && std::abs(columnDot) > kSkewTolerance * scaleX * columnYNorm) {
+    return std::nullopt;
+  }
+
+  Decomposed result;
+  result.translation = Vector2d(t.data[4], t.data[5]);
+  result.rotationRadians = std::atan2(b, a);
+  result.scale = Vector2d(scaleX, (a * d - b * c) / scaleX);
+  return result;
+}
+
+double NormalizeRadians(double r) {
+  constexpr double kPi = MathConstants<double>::kPi;
+  while (r > kPi) {
+    r -= 2.0 * kPi;
+  }
+  while (r <= -kPi) {
+    r += 2.0 * kPi;
+  }
+  return r;
+}
+
+bool TransformsClose(const Transform2d& a, const Transform2d& b) {
+  for (int k = 0; k < 6; ++k) {
+    const double diff = std::abs(a.data[k] - b.data[k]);
+    const double magnitude = std::max(std::abs(a.data[k]), std::abs(b.data[k]));
+    if (diff > 1e-3 + 1e-4 * magnitude) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/// Verify a candidate string re-parses to @p target.
+bool Verify(const std::string& candidate, const Transform2d& target) {
+  auto parsed = svg::parser::TransformParser::Parse(candidate);
+  if (parsed.hasError()) {
+    return false;
+  }
+  return TransformsClose(parsed.result(), target);
+}
+
+Transform2d MatrixOf(const std::vector<Fn>& fns) {
+  if (fns.empty()) {
+    return Transform2d();  // identity
+  }
+  auto parsed = svg::parser::TransformParser::Parse(RenderList(fns));
+  if (parsed.hasError()) {
+    return Transform2d();
+  }
+  return parsed.result();
+}
+
+/// Structured translate/scale/rotate update. @p fns is taken by value because
+/// it mutates the function tokens. Returns the author-form string on success.
+std::optional<RcString> TryStructuredUpdate(std::vector<Fn> fns, const Transform2d& m,
+                                            const Transform2d& target) {
+  int translateIdx = -1;
+  int scaleIdx = -1;
+  int rotateIdx = -1;
+  int nTranslate = 0;
+  int nScale = 0;
+  int nRotate = 0;
+  for (std::size_t k = 0; k < fns.size(); ++k) {
+    const std::string& name = fns[k].name;
+    if (name == "translate") {
+      ++nTranslate;
+      translateIdx = static_cast<int>(k);
+    } else if (name == "scale") {
+      ++nScale;
+      scaleIdx = static_cast<int>(k);
+    } else if (name == "rotate") {
+      ++nRotate;
+      rotateIdx = static_cast<int>(k);
+    } else {
+      // matrix()/skewX()/skewY()/unknown: not handled by this path.
+      return std::nullopt;
+    }
+  }
+  if (nTranslate > 1 || nScale > 1 || nRotate > 1) {
+    return std::nullopt;
+  }
+
+  const std::optional<Decomposed> dt = Decompose(target);
+  const std::optional<Decomposed> dm = Decompose(m);
+  if (!dt.has_value() || !dm.has_value()) {
+    return std::nullopt;
+  }
+
+  const double dScaleX = dt->scale.x / dm->scale.x;
+  const double dScaleY = dt->scale.y / dm->scale.y;
+  const double dRot = NormalizeRadians(dt->rotationRadians - dm->rotationRadians);
+
+  const bool rotChanged = std::abs(dRot) > kAngleEps;
+  const bool scaleChanged =
+      std::abs(dScaleX - 1.0) > kScaleEps || std::abs(dScaleY - 1.0) > kScaleEps;
+
+  if (rotChanged && nRotate == 0) {
+    return std::nullopt;
+  }
+  if (scaleChanged && nScale == 0) {
+    return std::nullopt;
+  }
+
+  if (nRotate == 1) {
+    Fn& rf = fns[static_cast<std::size_t>(rotateIdx)];
+    if (rf.args.empty() || (rf.args.size() != 1 && rf.args.size() != 3)) {
+      return std::nullopt;
+    }
+    SetArg(rf, 0, rf.args[0].value + dRot * MathConstants<double>::kRadToDeg);
+    // Center arguments (if present) are left as-authored; the translate solve
+    // and final verify catch any center mismatch.
+  }
+
+  if (nScale == 1) {
+    Fn& sf = fns[static_cast<std::size_t>(scaleIdx)];
+    if (sf.args.size() == 1) {
+      const double base = sf.args[0].value;
+      const double nx = base * dScaleX;
+      const double ny = base * dScaleY;
+      if (std::abs(nx - ny) < kUnchangedEps) {
+        SetArg(sf, 0, nx);
+      } else {
+        sf.args[0] = Arg{nx, FormatEditedNumber(nx)};
+        sf.args.push_back(Arg{ny, FormatEditedNumber(ny)});
+      }
+    } else if (sf.args.size() == 2) {
+      SetArg(sf, 0, sf.args[0].value * dScaleX);
+      SetArg(sf, 1, sf.args[1].value * dScaleY);
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  if (nTranslate == 1) {
+    const std::vector<Fn> prefix(fns.begin(), fns.begin() + translateIdx);
+    const std::vector<Fn> suffix(fns.begin() + translateIdx + 1, fns.end());
+    const Transform2d mp = MatrixOf(prefix);
+    const Transform2d ms = MatrixOf(suffix);
+    // Solve mp * T * ms == target for the pure-translation T.
+    const Transform2d tmat = StandardMul(StandardMul(mp.inverse(), target), ms.inverse());
+    if (std::abs(tmat.data[0] - 1.0) > kMatrixEps || std::abs(tmat.data[1]) > kMatrixEps ||
+        std::abs(tmat.data[2]) > kMatrixEps || std::abs(tmat.data[3] - 1.0) > kMatrixEps) {
+      return std::nullopt;
+    }
+    const double tx = tmat.data[4];
+    const double ty = tmat.data[5];
+    Fn& tf = fns[static_cast<std::size_t>(translateIdx)];
+    if (tf.args.size() == 1) {
+      if (std::abs(ty) < kUnchangedEps) {
+        SetArg(tf, 0, tx);
+      } else {
+        tf.args[0] = Arg{tx, FormatEditedNumber(tx)};
+        tf.args.push_back(Arg{ty, FormatEditedNumber(ty)});
+      }
+    } else if (tf.args.size() == 2) {
+      SetArg(tf, 0, tx);
+      SetArg(tf, 1, ty);
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  std::string candidate = RenderList(fns);
+  if (Verify(candidate, target)) {
+    return RcString(candidate);
+  }
+  return std::nullopt;
+}
+
+/// Rotate-only fallback: express @p target as a rotation, adding explicit center
+/// arguments when the rotation is about a non-origin point. Handles the case a
+/// rotate-only element is rotated about its bounds center (which the structured
+/// path rejects because the resulting matrix carries a translation).
+std::optional<RcString> TryRotateOnly(const Fn& rf, const Transform2d& target) {
+  if (rf.args.size() != 1 && rf.args.size() != 3) {
+    return std::nullopt;
+  }
+  const std::optional<Decomposed> dt = Decompose(target);
+  if (!dt.has_value()) {
+    return std::nullopt;
+  }
+  // Must be a proper rigid rotation: unit scale on both axes, no reflection.
+  if (std::abs(dt->scale.x - 1.0) > 1e-6 || std::abs(dt->scale.y - 1.0) > 1e-6) {
+    return std::nullopt;
+  }
+
+  const double thetaDeg = dt->rotationRadians * MathConstants<double>::kRadToDeg;
+  const double tx = target.data[4];
+  const double ty = target.data[5];
+
+  Fn out;
+  out.name = "rotate";
+  out.usesComma = rf.usesComma;
+
+  auto angleToken = [&]() -> Arg {
+    if (std::abs(thetaDeg - rf.args[0].value) < kUnchangedEps) {
+      return rf.args[0];  // unchanged: keep verbatim
+    }
+    return Arg{thetaDeg, FormatEditedNumber(thetaDeg)};
+  };
+
+  if (std::abs(tx) < kMatrixEps && std::abs(ty) < kMatrixEps) {
+    out.args.push_back(angleToken());
+  } else {
+    const double cos = std::cos(dt->rotationRadians);
+    const double sin = std::sin(dt->rotationRadians);
+    const double det = (1.0 - cos) * (1.0 - cos) + sin * sin;  // = 2(1 - cos)
+    if (std::abs(det) < 1e-12) {
+      return std::nullopt;
+    }
+    // c = (I - R)^{-1} t, with R the standard rotation by theta.
+    const double cx = ((1.0 - cos) * tx - sin * ty) / det;
+    const double cy = (sin * tx + (1.0 - cos) * ty) / det;
+
+    out.usesComma = true;  // three-argument rotate reads best comma-separated.
+    out.args.push_back(angleToken());
+    if (rf.args.size() == 3 && std::abs(rf.args[1].value - cx) < kUnchangedEps &&
+        std::abs(rf.args[2].value - cy) < kUnchangedEps) {
+      out.args.push_back(rf.args[1]);
+      out.args.push_back(rf.args[2]);
+    } else {
+      out.args.push_back(Arg{cx, FormatEditedNumber(cx)});
+      out.args.push_back(Arg{cy, FormatEditedNumber(cy)});
+    }
+  }
+
+  std::string candidate = RenderFn(out);
+  if (Verify(candidate, target)) {
+    return RcString(candidate);
+  }
+  return std::nullopt;
+}
+
+}  // namespace
+
+std::optional<RcString> reserializeTransformPreservingSyntax(std::string_view authorSource,
+                                                             const Transform2d& target) {
+  std::optional<std::vector<Fn>> parsed = ParseFunctionList(authorSource);
+  if (!parsed.has_value()) {
+    return std::nullopt;
+  }
+  std::vector<Fn>& fns = *parsed;
+
+  auto mResult = svg::parser::TransformParser::Parse(authorSource);
+  if (mResult.hasError()) {
+    return std::nullopt;
+  }
+  const Transform2d m = mResult.result();
+
+  // A matrix() author stays matrix(): update the six entries in place.
+  if (fns.size() == 1 && fns[0].name == "matrix" && fns[0].args.size() == 6) {
+    for (int k = 0; k < 6; ++k) {
+      SetArg(fns[0], static_cast<std::size_t>(k), target.data[k]);
+    }
+    std::string candidate = RenderList(fns);
+    if (Verify(candidate, target)) {
+      return RcString(candidate);
+    }
+    return std::nullopt;
+  }
+
+  if (auto structured = TryStructuredUpdate(fns, m, target)) {
+    return structured;
+  }
+
+  // Rotate-only element rotated about a non-origin center: keep rotate() form.
+  if (fns.size() == 1 && fns[0].name == "rotate") {
+    if (auto rotated = TryRotateOnly(fns[0], target)) {
+      return rotated;
+    }
+  }
+
+  return std::nullopt;
+}
+
+RcString serializeTransformForWriteback(const std::optional<RcString>& authorSource,
+                                        const Transform2d& target) {
+  // Identity clears the attribute; never resurrect an author form for it.
+  if (target.isIdentity()) {
+    return toSVGTransformString(target);
+  }
+  if (authorSource.has_value() && !std::string_view(*authorSource).empty()) {
+    if (auto preserved =
+            reserializeTransformPreservingSyntax(std::string_view(*authorSource), target)) {
+      return *preserved;
+    }
+  }
+  return toSVGTransformString(target);
+}
+
+}  // namespace donner::editor

--- a/donner/editor/TransformSyntaxPreserving.h
+++ b/donner/editor/TransformSyntaxPreserving.h
@@ -1,0 +1,41 @@
+#pragma once
+/// @file
+///
+/// Transform `transform=` writeback that preserves the author's chosen function
+/// syntax. Forward transform edits (inspector fields and canvas drags) used to
+/// canonicalize every author form into `matrix(a,b,c,d,e,f)` via
+/// \ref donner::toSVGTransformString. This module re-expresses an edited
+/// \ref Transform2d in the author's original function list where the edit is
+/// representable as an update to that list (a rotation change on `rotate(45)`
+/// writes `rotate(60)`, a move updates `translate(x, y)`, and so on), falling
+/// back to `matrix()` only when the edit cannot be represented in the author's
+/// structure.
+
+#include <optional>
+#include <string_view>
+
+#include "donner/base/RcString.h"
+#include "donner/base/Transform.h"
+
+namespace donner::editor {
+
+/// Attempt to re-serialize @p target into the author's function-list syntax
+/// parsed from @p authorSource.
+///
+/// Returns the author-form string (e.g. `rotate(60)`) when the edit is
+/// expressible as a parameter update to the author's transform functions, or
+/// `std::nullopt` when it is not (a decomposed rotation change against a skew
+/// matrix, a move on a rotate-only element, etc.). The returned string always
+/// re-parses to @p target within a tight tolerance; callers that receive
+/// `std::nullopt` should emit `toSVGTransformString(target)`.
+[[nodiscard]] std::optional<RcString> reserializeTransformPreservingSyntax(
+    std::string_view authorSource, const Transform2d& target);
+
+/// Serialize @p target for a `transform=` writeback, preserving the author's
+/// syntax from @p authorSource where possible and otherwise emitting the
+/// canonical \ref donner::toSVGTransformString form. An empty result means the
+/// attribute should be removed (the transform is the identity).
+[[nodiscard]] RcString serializeTransformForWriteback(const std::optional<RcString>& authorSource,
+                                                      const Transform2d& target);
+
+}  // namespace donner::editor

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -166,6 +166,17 @@ donner_cc_test(
 )
 
 donner_cc_test(
+    name = "transform_syntax_preserving_tests",
+    srcs = ["TransformSyntaxPreserving_tests.cc"],
+    deps = [
+        "//donner/base",
+        "//donner/editor:transform_syntax_preserving",
+        "//donner/svg/parser",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
     name = "document_sync_controller_tests",
     srcs = ["DocumentSyncController_tests.cc"],
     deps = [

--- a/donner/editor/tests/DocumentSyncController_tests.cc
+++ b/donner/editor/tests/DocumentSyncController_tests.cc
@@ -7,6 +7,8 @@
 #include <string>
 #include <utility>
 
+#include "donner/base/MathUtils.h"
+#include "donner/base/Transform.h"
 #include "donner/editor/AttributeWriteback.h"
 #include "donner/editor/EditorApp.h"
 #include "donner/editor/EditorCommand.h"
@@ -287,6 +289,60 @@ TEST_F(DocumentSyncControllerTest, SourceBackedDragWritebackExtendsSelectedSourc
   EXPECT_NE(selectedText.find("transform=\"translate(10)\""), std::string::npos);
   EXPECT_TRUE(selectedText.ends_with("/>")) << selectedText;
   EXPECT_EQ(textEditor_.getCursorPosition(), textEditor_.getCoordinatesAtByteOffset(rectStart));
+}
+
+TEST_F(DocumentSyncControllerTest, ForwardWritebackPreservesAuthorSyntaxAndUndoRestoresBytes) {
+  // A forward transform edit on an authored rotate(45) must rewrite the source
+  // as rotate(60) (author form), not canonicalize to matrix(); a subsequent
+  // verbatim restore must return the exact original bytes.
+  constexpr std::string_view kSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+         <rect id="r1" x="0" y="0" width="10" height="10" transform="rotate(45)"/>
+       </svg>)svg";
+
+  EditorApp app;
+  TextEditor textEditor;
+  SelectTool tool;
+  DocumentSyncController controller{std::string(kSvg)};
+
+  ASSERT_TRUE(app.loadFromString(kSvg));
+  app.setCurrentFilePath("test.svg");
+  app.setCleanSourceText(kSvg);
+  textEditor.setText(kSvg);
+  textEditor.resetTextChanged();
+
+  auto r1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(r1.has_value());
+  auto r1Target = captureAttributeWritebackTarget(*r1);
+  ASSERT_TRUE(r1Target.has_value());
+
+  // Forward edit: rotate(45) -> rotate(60), carrying the author's bytes.
+  app.enqueueTransformWriteback(EditorApp::CompletedTransformWriteback{
+      .target = *r1Target,
+      .transform = Transform2d::Rotate(60.0 * MathConstants<double>::kDegToRad),
+      .sourceTransformAttributeValue = RcString("rotate(45)"),
+  });
+  controller.applyPendingWritebacks(app, tool, textEditor);
+
+  r1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(r1.has_value());
+  EXPECT_EQ(r1->getAttribute("transform"), std::optional<RcString>(RcString("rotate(60)")));
+  EXPECT_EQ(textEditor.getText().find("matrix("), std::string::npos);
+  EXPECT_NE(textEditor.getText().find("transform=\"rotate(60)\""), std::string::npos);
+
+  // Verbatim restore (the undo path): exact original bytes come back.
+  app.enqueueTransformWriteback(EditorApp::CompletedTransformWriteback{
+      .target = *r1Target,
+      .transform = Transform2d::Rotate(45.0 * MathConstants<double>::kDegToRad),
+      .sourceTransformAttributeValue = RcString("rotate(45)"),
+      .restoreSourceTransformAttributeValue = true,
+  });
+  controller.applyPendingWritebacks(app, tool, textEditor);
+
+  r1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(r1.has_value());
+  EXPECT_EQ(r1->getAttribute("transform"), std::optional<RcString>(RcString("rotate(45)")));
+  EXPECT_NE(textEditor.getText().find("transform=\"rotate(45)\""), std::string::npos);
 }
 
 TEST_F(DocumentSyncControllerTest, AppTransformWritebacksDrainAllQueuedEntries) {

--- a/donner/editor/tests/TransformSyntaxPreserving_tests.cc
+++ b/donner/editor/tests/TransformSyntaxPreserving_tests.cc
@@ -1,0 +1,206 @@
+#include "donner/editor/TransformSyntaxPreserving.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+#include <string_view>
+
+#include "donner/base/MathUtils.h"
+#include "donner/base/Transform.h"
+#include "donner/svg/parser/TransformParser.h"
+
+namespace donner::editor {
+namespace {
+
+using ::testing::Optional;
+
+constexpr double kDeg = MathConstants<double>::kDegToRad;
+
+/// Parse a transform string into its matrix (helper for building targets that
+/// are, by construction, expressible in a given author form).
+Transform2d ParseMatrix(std::string_view s) {
+  auto result = svg::parser::TransformParser::Parse(s);
+  EXPECT_FALSE(result.hasError()) << "failed to parse target: " << s;
+  return result.result();
+}
+
+/// Assert @p candidate re-parses to @p target within tolerance.
+void ExpectRoundTrips(std::string_view candidate, const Transform2d& target) {
+  const Transform2d parsed = ParseMatrix(candidate);
+  for (int k = 0; k < 6; ++k) {
+    EXPECT_NEAR(parsed.data[k], target.data[k], 1e-3)
+        << "component " << k << " of '" << candidate << "'";
+  }
+}
+
+std::string Reserialize(std::string_view author, const Transform2d& target) {
+  auto result = reserializeTransformPreservingSyntax(author, target);
+  EXPECT_TRUE(result.has_value()) << "expected preservation for author '" << author << "'";
+  return result.has_value() ? std::string(std::string_view(*result)) : std::string();
+}
+
+// --- rotate-only ----------------------------------------------------------
+
+TEST(TransformSyntaxPreserving, RotateOnlyKeepsRotateAtOrigin) {
+  const Transform2d target = Transform2d::Rotate(60.0 * kDeg);
+  EXPECT_EQ(Reserialize("rotate(45)", target), "rotate(60)");
+}
+
+TEST(TransformSyntaxPreserving, RotateOnlySnapsAwayFloatingPointNoise) {
+  // A target composed from two rotations carries fp noise; the emitted angle
+  // must still be the clean "60", not "60.00000000001".
+  const Transform2d target = Transform2d::Rotate(45.0 * kDeg) * Transform2d::Rotate(15.0 * kDeg);
+  EXPECT_EQ(Reserialize("rotate(45)", target), "rotate(60)");
+}
+
+TEST(TransformSyntaxPreserving, RotateOnlyAboutCenterGainsCenterArgs) {
+  const Transform2d target = ParseMatrix("rotate(60, 10, 10)");
+  const std::string out = Reserialize("rotate(45)", target);
+  EXPECT_EQ(out, "rotate(60, 10, 10)");
+  ExpectRoundTrips(out, target);
+}
+
+TEST(TransformSyntaxPreserving, RotateWithCenterArgsPreservesCenter) {
+  // Editing the angle of an authored rotate(a, cx, cy) about the same center
+  // keeps the center arguments and only bumps the angle.
+  const Transform2d target = ParseMatrix("rotate(50, 30, 40)");
+  const std::string out = Reserialize("rotate(20, 30, 40)", target);
+  EXPECT_THAT(out, ::testing::StartsWith("rotate("));
+  EXPECT_THAT(out, ::testing::HasSubstr("30"));
+  EXPECT_THAT(out, ::testing::HasSubstr("40"));
+  EXPECT_THAT(out, ::testing::Not(::testing::HasSubstr("matrix")));
+  ExpectRoundTrips(out, target);
+}
+
+// --- translate-only -------------------------------------------------------
+
+TEST(TransformSyntaxPreserving, TranslateTwoArgUpdatesNumbers) {
+  const Transform2d target = Transform2d::Translate(Vector2d(15.0, 27.0));
+  EXPECT_EQ(Reserialize("translate(10, 20)", target), "translate(15, 27)");
+}
+
+TEST(TransformSyntaxPreserving, TranslateOneArgStaysOneArgWhenYZero) {
+  const Transform2d target = Transform2d::Translate(Vector2d(25.0, 0.0));
+  EXPECT_EQ(Reserialize("translate(10)", target), "translate(25)");
+}
+
+TEST(TransformSyntaxPreserving, TranslateOneArgExpandsWhenYChanges) {
+  const Transform2d target = Transform2d::Translate(Vector2d(25.0, 4.0));
+  const std::string out = Reserialize("translate(10)", target);
+  EXPECT_THAT(out, ::testing::StartsWith("translate("));
+  EXPECT_THAT(out, ::testing::Not(::testing::HasSubstr("matrix")));
+  ExpectRoundTrips(out, target);
+}
+
+TEST(TransformSyntaxPreserving, TranslateKeepsUnchangedTokenVerbatim) {
+  // Only x moved; the y token is re-emitted exactly as authored.
+  const Transform2d target = Transform2d::Translate(Vector2d(12.5, 20.0));
+  EXPECT_EQ(Reserialize("translate(10, 20)", target), "translate(12.5, 20)");
+}
+
+// --- scale ----------------------------------------------------------------
+
+TEST(TransformSyntaxPreserving, ScaleUniformStaysUniform) {
+  const Transform2d target = Transform2d::Scale(Vector2d(3.0, 3.0));
+  EXPECT_EQ(Reserialize("scale(2)", target), "scale(3)");
+}
+
+TEST(TransformSyntaxPreserving, ScaleUniformExpandsToTwoArgs) {
+  const Transform2d target = Transform2d::Scale(Vector2d(3.0, 2.0));
+  const std::string out = Reserialize("scale(2)", target);
+  EXPECT_THAT(out, ::testing::StartsWith("scale("));
+  EXPECT_THAT(out, ::testing::Not(::testing::HasSubstr("matrix")));
+  ExpectRoundTrips(out, target);
+}
+
+TEST(TransformSyntaxPreserving, ScaleTwoArgUpdatesBoth) {
+  const Transform2d target = Transform2d::Scale(Vector2d(4.0, 3.0));
+  EXPECT_EQ(Reserialize("scale(2, 3)", target), "scale(4, 3)");
+}
+
+// --- translate + rotate lists --------------------------------------------
+
+TEST(TransformSyntaxPreserving, TranslateRotateUpdatesRotationComponent) {
+  const Transform2d target = ParseMatrix("translate(10, 20) rotate(45)");
+  EXPECT_EQ(Reserialize("translate(10, 20) rotate(30)", target), "translate(10, 20) rotate(45)");
+}
+
+TEST(TransformSyntaxPreserving, TranslateRotateUpdatesTranslateComponent) {
+  const Transform2d target = ParseMatrix("translate(18, 27) rotate(30)");
+  EXPECT_EQ(Reserialize("translate(10, 20) rotate(30)", target), "translate(18, 27) rotate(30)");
+}
+
+TEST(TransformSyntaxPreserving, RotateTranslateListPreservesOrderAndForm) {
+  const Transform2d target = ParseMatrix("rotate(45) translate(5, 6)");
+  const std::string out = Reserialize("rotate(30) translate(5, 6)", target);
+  EXPECT_THAT(out, ::testing::StartsWith("rotate("));
+  EXPECT_THAT(out, ::testing::HasSubstr("translate("));
+  EXPECT_THAT(out, ::testing::Not(::testing::HasSubstr("matrix")));
+  ExpectRoundTrips(out, target);
+}
+
+// --- matrix stays matrix --------------------------------------------------
+
+TEST(TransformSyntaxPreserving, MatrixInputStaysMatrix) {
+  const Transform2d target = Transform2d::Translate(Vector2d(9.0, 6.0));
+  const std::string out = Reserialize("matrix(1, 0, 0, 1, 5, 6)", target);
+  EXPECT_THAT(out, ::testing::StartsWith("matrix("));
+  EXPECT_EQ(out, "matrix(1, 0, 0, 1, 9, 6)");
+}
+
+// --- fallbacks ------------------------------------------------------------
+
+TEST(TransformSyntaxPreserving, RotationChangeAgainstSkewFallsBack) {
+  // The design's canonical fallback: a decomposed rotation change against a
+  // skew matrix cannot be represented in the author's rotate() structure.
+  const Transform2d skewTarget = ParseMatrix("matrix(1, 0.5, 0.5, 1, 0, 0)");
+  EXPECT_FALSE(reserializeTransformPreservingSyntax("rotate(45)", skewTarget).has_value());
+}
+
+TEST(TransformSyntaxPreserving, SkewFunctionInAuthorListFallsBack) {
+  const Transform2d target = ParseMatrix("rotate(60) skewX(10)");
+  EXPECT_FALSE(reserializeTransformPreservingSyntax("rotate(45) skewX(10)", target).has_value());
+}
+
+TEST(TransformSyntaxPreserving, RotationIntroducedOnTranslateOnlyFallsBack) {
+  // translate(x, y) cannot absorb a new rotation component.
+  const Transform2d target = ParseMatrix("translate(10, 20) rotate(30)");
+  EXPECT_FALSE(reserializeTransformPreservingSyntax("translate(10, 20)", target).has_value());
+}
+
+TEST(TransformSyntaxPreserving, MalformedAuthorFallsBack) {
+  const Transform2d target = Transform2d::Translate(Vector2d(5.0, 0.0));
+  EXPECT_FALSE(reserializeTransformPreservingSyntax("not a transform", target).has_value());
+  EXPECT_FALSE(reserializeTransformPreservingSyntax("translate(", target).has_value());
+}
+
+// --- serializeTransformForWriteback wrapper -------------------------------
+
+TEST(TransformSyntaxPreserving, WrapperPrefersAuthorForm) {
+  const Transform2d target = Transform2d::Rotate(60.0 * kDeg);
+  EXPECT_EQ(std::string_view(serializeTransformForWriteback(RcString("rotate(45)"), target)),
+            "rotate(60)");
+}
+
+TEST(TransformSyntaxPreserving, WrapperFallsBackToCanonicalWithoutAuthorSource) {
+  const Transform2d target = Transform2d::Rotate(60.0 * kDeg);
+  // No author source: canonical serializer output.
+  EXPECT_EQ(std::string_view(serializeTransformForWriteback(std::nullopt, target)),
+            std::string_view(toSVGTransformString(target)));
+}
+
+TEST(TransformSyntaxPreserving, WrapperFallsBackToCanonicalOnSkew) {
+  const Transform2d skewTarget = ParseMatrix("matrix(1, 0.5, 0.5, 1, 0, 0)");
+  EXPECT_EQ(std::string_view(serializeTransformForWriteback(RcString("rotate(45)"), skewTarget)),
+            std::string_view(toSVGTransformString(skewTarget)));
+}
+
+TEST(TransformSyntaxPreserving, WrapperClearsAttributeOnIdentity) {
+  const Transform2d identity;
+  EXPECT_TRUE(
+      std::string_view(serializeTransformForWriteback(RcString("rotate(45)"), identity)).empty());
+}
+
+}  // namespace
+}  // namespace donner::editor


### PR DESCRIPTION
Structured-editing: preserve authored transform syntax.

- Preserve author transform syntax on forward writeback.
- Test the transform-syntax preservation matrix and undo bytes.

gate: editor suite green except the known /tmp sandbox target.

Part of Design 0013 / Design 0017 (zettelkasten).

Depends on / bases on `qa/polish-wave1` (PR #782); diff shown is this packet only.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
