### PR TITLE
Structured editing P5: undo hardening across reparse and layers panel

### DIFF
--- a/donner/editor/EditorApp.cc
+++ b/donner/editor/EditorApp.cc
@@ -1331,13 +1331,46 @@ bool IsLockGatedCommand(const EditorCommand& command) {
 }
 
 void EditorApp::setElementVisible(const svg::SVGElement& element, bool visible) {
-  // Toggle the `display` presentation attribute. Hiding writes
-  // `display="none"`; showing writes `display="inline"` (a definitively
-  // visible value) so the change is observable through the computed-style
-  // visibility check regardless of whether the surrounding stylesheet sets
-  // display.
-  applyMutation(
-      EditorCommand::SetAttributeCommand(element, "display", visible ? "inline" : "none"));
+  const auto entryIt =
+      std::find_if(hiddenElementAuthorDisplay_.begin(), hiddenElementAuthorDisplay_.end(),
+                   [&element](const auto& entry) { return entry.first == element; });
+
+  if (!visible) {
+    // Capture the author's `display` value (if any) BEFORE clobbering it, so
+    // the matching Show can restore it later instead of forcing
+    // `display="inline"` over e.g. an authored `display="block"`. Replace any
+    // stale entry from a previous hide/show cycle for this element.
+    std::optional<RcString> authorDisplay = element.getAttribute("display");
+    std::optional<std::string> capturedValue =
+        authorDisplay.has_value() ? std::optional<std::string>(std::string(*authorDisplay))
+                                   : std::nullopt;
+    if (entryIt != hiddenElementAuthorDisplay_.end()) {
+      entryIt->second = std::move(capturedValue);
+    } else {
+      hiddenElementAuthorDisplay_.emplace_back(element, std::move(capturedValue));
+    }
+    applyMutation(EditorCommand::SetAttributeCommand(element, "display", "none"));
+    return;
+  }
+
+  // Showing: restore the captured author value when it is a genuine,
+  // non-`none` override we clobbered - this is the common "author wrote
+  // display=block" case the round trip must preserve. When there is no
+  // captured entry (this element was never hidden through this toggle this
+  // session) or the captured value was itself absent/`"none"` (restoring it
+  // literally would leave the element hidden, defeating the Show action),
+  // fall back to writing a definitively-visible `display="inline"`.
+  if (entryIt != hiddenElementAuthorDisplay_.end()) {
+    std::optional<std::string> authorDisplay = std::move(entryIt->second);
+    hiddenElementAuthorDisplay_.erase(entryIt);
+    if (authorDisplay.has_value() && *authorDisplay != "none") {
+      applyMutation(EditorCommand::SetAttributeCommand(element, "display",
+                                                        std::move(*authorDisplay)));
+      return;
+    }
+  }
+
+  applyMutation(EditorCommand::SetAttributeCommand(element, "display", "inline"));
 }
 
 void EditorApp::setElementLocked(const svg::SVGElement& element, bool locked) {

--- a/donner/editor/EditorApp.cc
+++ b/donner/editor/EditorApp.cc
@@ -552,16 +552,31 @@ std::vector<AttributeWritebackTarget> CaptureSelectionTargets(
   return targets;
 }
 
-svg::SVGElement ResolveSnapshotElement(AsyncSVGDocument& document, const UndoSnapshot& snapshot) {
-  svg::SVGElement liveElement = snapshot.element;
-  if (document.hasDocument() && snapshot.writebackTarget.has_value()) {
-    if (auto resolved =
-            resolveAttributeWritebackTarget(document.document(), *snapshot.writebackTarget);
-        resolved.has_value()) {
-      liveElement = *resolved;
-    }
+// Rehydrate a snapshot's target element against the live document.
+//
+// - If the snapshot never captured a `writebackTarget` (the element had no
+//   XML node backing at capture time), there is nothing to rehydrate against;
+//   trust the originally captured element - this is the common case for
+//   snapshots that never survive a reparse.
+// - If a `writebackTarget` was captured but the document has since been
+//   reparsed (or is momentarily absent) such that the target no longer
+//   resolves, return `std::nullopt` rather than silently falling back to the
+//   pre-reparse `snapshot.element`. That handle may still be a technically
+//   live reference into an orphaned pre-reparse document (kept alive only by
+//   this snapshot's own reference), so applying a mutation - or worse,
+//   computing a fresh writeback target - against it risks writing a
+//   correctly-shaped but wrongly-targeted patch into the live source text.
+std::optional<svg::SVGElement> ResolveSnapshotElement(AsyncSVGDocument& document,
+                                                       const UndoSnapshot& snapshot) {
+  if (!snapshot.writebackTarget.has_value()) {
+    return snapshot.element;
   }
-  return liveElement;
+
+  if (!document.hasDocument()) {
+    return std::nullopt;
+  }
+
+  return resolveAttributeWritebackTarget(document.document(), *snapshot.writebackTarget);
 }
 
 void ApplyTimelineSnapshot(EditorApp& app, AsyncSVGDocument& document,
@@ -573,13 +588,26 @@ void ApplyTimelineSnapshot(EditorApp& app, AsyncSVGDocument& document,
     return;
   }
 
-  svg::SVGElement liveElement = ResolveSnapshotElement(document, snapshot);
+  const std::optional<svg::SVGElement> liveElement = ResolveSnapshotElement(document, snapshot);
+  if (!liveElement.has_value()) {
+    // Rehydration was attempted (the snapshot carried a `writebackTarget`)
+    // but failed - a structural edit since this entry was captured means
+    // the target no longer resolves in the live document. There is nothing
+    // safe to replay this entry against; skip it gracefully instead of
+    // dereferencing the stale pre-reparse handle. Extras (grouped
+    // multi-element gestures) are independent snapshots, so still give each
+    // of them a chance to resolve on their own.
+    for (const UndoSnapshot& extra : snapshot.extras) {
+      ApplyTimelineSnapshot(app, document, extra);
+    }
+    return;
+  }
 
   // Route the restored transform through the command queue so every
   // DOM write - tool drags, text-pane re-parse, and undo - goes through
   // the same mutation seam. The queue coalesces with any pending
   // commands and applies on the next `flushFrame()`.
-  app.applyMutation(EditorCommand::SetTransformCommand(liveElement, snapshot.transform));
+  app.applyMutation(EditorCommand::SetTransformCommand(*liveElement, snapshot.transform));
 
   // Capture the source-text writeback target BEFORE the command drains
   // so the path-based target resolves against the in-sync document.
@@ -595,7 +623,7 @@ void ApplyTimelineSnapshot(EditorApp& app, AsyncSVGDocument& document,
         .transform = snapshot.transform,
         .sourceTransformAttributeValue = snapshot.sourceTransformAttributeValue,
         .restoreSourceTransformAttributeValue = snapshot.restoreSourceTransformAttributeValue});
-  } else if (auto target = captureAttributeWritebackTarget(liveElement); target.has_value()) {
+  } else if (auto target = captureAttributeWritebackTarget(*liveElement); target.has_value()) {
     app.enqueueTransformWriteback(EditorApp::CompletedTransformWriteback{
         .target = std::move(*target),
         .transform = snapshot.transform,

--- a/donner/editor/EditorApp.h
+++ b/donner/editor/EditorApp.h
@@ -19,6 +19,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "donner/base/Box.h"
@@ -167,11 +168,16 @@ public:
   }
 
   /// Set the visibility of @p element by toggling its `display` presentation
-  /// attribute: hiding writes `display="none"`, showing writes
-  /// `display="inline"` (a definitively visible value, observable through the
-  /// computed-style visibility check). Routes through `applyMutation` so the
-  /// Layers panel eye button and context menu share one code path. Visibility
-  /// toggles are intentionally NOT lock-gated.
+  /// attribute. Hiding captures the element's current author `display` value
+  /// (if any) before overwriting it with `display="none"`. Showing restores
+  /// that captured value when it is a genuine, non-`none` author value (e.g.
+  /// `display="block"`), so a hide/show round trip does not clobber it;
+  /// otherwise (no captured value, or the element was never hidden through
+  /// this toggle this session) it writes `display="inline"` (a definitively
+  /// visible value, observable through the computed-style visibility check).
+  /// Routes through `applyMutation` so the Layers panel eye button and
+  /// context menu share one code path. Visibility toggles are intentionally
+  /// NOT lock-gated.
   void setElementVisible(const svg::SVGElement& element, bool visible);
 
   /// Lock or unlock @p element by toggling the `data-donner-locked` marker
@@ -594,6 +600,14 @@ private:
 
   std::vector<CompletedTransformWriteback> pendingTransformWritebacks_;
   std::vector<CompletedElementRemoveWriteback> pendingElementRemoveWritebacks_;
+  /// Per-session memory of the author `display` value an element carried
+  /// immediately before `setElementVisible` hid it, so the matching Show
+  /// restores that value instead of clobbering it with `display="inline"`.
+  /// `std::nullopt` for the captured value means the element had no author
+  /// `display` attribute at all. Cleared for an element once its Show
+  /// consumes the entry. A stale entry (element deleted/reparsed away) is
+  /// simply never matched again and is harmless.
+  std::vector<std::pair<svg::SVGElement, std::optional<std::string>>> hiddenElementAuthorDisplay_;
   std::optional<PendingDocumentSourceUndo> pendingDocumentSourceUndo_;
   std::optional<std::vector<AttributeWritebackTarget>> pendingSelectionRestoreTargets_;
 

--- a/donner/editor/LayerTreeModel.cc
+++ b/donner/editor/LayerTreeModel.cc
@@ -172,6 +172,21 @@ std::string BuildDisplayName(const svg::SVGElement& element) {
 }
 
 bool IsVisible(const svg::SVGElement& element) {
+  // `EditorApp::setElementVisible` (the Layers panel eye toggle) reads and
+  // writes the element's own `display` presentation attribute directly - not
+  // the cascaded computed style. Check that same local override first so the
+  // eye state agrees with what the toggle actually controls: an element the
+  // user just hid (or showed) reads correctly even if a stylesheet rule with
+  // higher specificity would otherwise win the cascade and make computed
+  // style disagree with the attribute. Only when there is no local `display`
+  // override does this fall back to computed style (which also covers
+  // `visibility`), so an element hidden purely via a stylesheet rule - no
+  // local `display` attribute at all - still shows a closed eye.
+  if (const std::optional<RcString> localDisplay = element.getAttribute("display");
+      localDisplay.has_value()) {
+    return *localDisplay != "none";
+  }
+
   const svg::PropertyRegistry& style = element.getComputedStyle();
   if (const auto display = style.display.get();
       display.has_value() && *display == svg::Display::None) {

--- a/donner/editor/tests/EditorApp_tests.cc
+++ b/donner/editor/tests/EditorApp_tests.cc
@@ -543,6 +543,58 @@ TEST(EditorAppTest, VisibilityAndLockTogglesBypassLockGate) {
   EXPECT_FALSE(r1->getAttribute(kLockedAttributeName).has_value());
 }
 
+// Hiding an element with an authored non-`none` `display` value (e.g.
+// `display="block"`) must not clobber it: showing again should restore the
+// author's exact value rather than forcing `display="inline"`.
+TEST(EditorAppTest, SetElementVisibleRestoresAuthorDisplayValueOnShow) {
+  constexpr std::string_view kSvgWithBlockDisplay =
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+           <rect id="r1" x="10" y="10" width="20" height="20" fill="red" display="block"/>
+         </svg>)";
+
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kSvgWithBlockDisplay));
+
+  auto r1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(r1.has_value());
+  ASSERT_EQ(r1->getAttribute("display"), "block");
+
+  app.setElementVisible(*r1, false);
+  ASSERT_TRUE(app.flushFrame());
+  r1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(r1.has_value());
+  EXPECT_EQ(r1->getAttribute("display"), "none");
+
+  app.setElementVisible(*r1, true);
+  ASSERT_TRUE(app.flushFrame());
+  r1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(r1.has_value());
+  EXPECT_EQ(r1->getAttribute("display"), "block")
+      << "Show should restore the author's display=block instead of forcing display=inline";
+}
+
+// When the element had no author `display` value to begin with (the common
+// case), Show still falls back to writing a definitively-visible
+// `display="inline"` - covered already by
+// `VisibilityAndLockTogglesBypassLockGate` above. This test covers the other
+// fallback: showing an element that was never hidden through this toggle
+// (no captured entry at all, e.g. a fresh element or a second, redundant Show
+// call) still lands on `display="inline"` rather than crashing or no-oping.
+TEST(EditorAppTest, SetElementVisibleShowWithoutPriorHideWritesInline) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kTrivialSvg));
+
+  auto r1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(r1.has_value());
+  ASSERT_FALSE(r1->getAttribute("display").has_value());
+
+  app.setElementVisible(*r1, true);
+  ASSERT_TRUE(app.flushFrame());
+  r1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(r1.has_value());
+  EXPECT_EQ(r1->getAttribute("display"), "inline");
+}
+
 TEST(EditorAppTest, SetStylePropertyOnSelectionMergesIntoStyleAttribute) {
   constexpr std::string_view kStyledSvg =
       R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">

--- a/donner/editor/tests/EditorSync_tests.cc
+++ b/donner/editor/tests/EditorSync_tests.cc
@@ -1170,31 +1170,13 @@ TEST(EditorSyncTest, SelectionClearsAndDisplayedBoundsClearWhenElementDisappears
 // rehydration (matching the snapshot's `writebackTarget` against the
 // current DOM), the undo silently does nothing or crashes.
 //
-// This test documents the invariant. If undo can't rehydrate across
-// a reparse, either the test skips with a clear explanation (known
-// gap) OR - ideally - the undo replays against a freshly-queried
-// element by id/path.
+// This test documents the invariant. `EditorApp::undo` rehydrates a stale
+// `UndoSnapshot::element` by resolving `snapshot.writebackTarget` against the
+// live post-reparse document (see `ResolveSnapshotElement` in EditorApp.cc)
+// before replaying the transform, so the drag survives the reparse. This is
+// the same rehydration story as `SelectionRemapsByIdAcrossStructuralSourceEdit`,
+// but for the undo timeline instead of the selection.
 TEST(EditorSyncTest, DragThenSourceEditThenUndoReplaysAgainstFreshlyParsedElement) {
-  // Known gap (documented before we even start the test body, because
-  // the failing path triggers a hard EnTT assertion in `fast_mod` -
-  // the undo snapshot holds an `SVGElement` whose `EntityHandle` points
-  // into the pre-reparse registry, and any access after the reparse
-  // trips the "power of two" assertion deep inside EnTT's storage.
-  // That crash isn't skippable mid-flow, so document the gap up front
-  // and have the fix flip the `if (true)` below to `if (false)` once
-  // `UndoSnapshot` rehydration across `ReplaceDocumentCommand` lands.
-  //
-  // The fix belongs in `EditorApp::undo`: when an `UndoSnapshot` has
-  // a `writebackTarget`, resolve that against the live document and
-  // rebind `snapshot.element` before calling `applySnapshot`. This is
-  // the same rehydration story as `SelectionRemapsByIdAcrossStructuralSourceEdit`,
-  // but for the undo timeline instead of the selection.
-  if (true) {
-    GTEST_SKIP() << "Known gap: `EditorApp::undo` dereferences a stale `SVGElement` "
-                    "handle after `ReplaceDocumentCommand` reparse. Needs snapshot "
-                    "rehydration via `writebackTarget` before apply. Design 0026 B3.";
-  }
-
   constexpr std::string_view kSvg = R"svg(<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
   <rect id="r" x="10" y="10" width="20" height="20" fill="red"/>

--- a/donner/editor/tests/EditorSync_tests.cc
+++ b/donner/editor/tests/EditorSync_tests.cc
@@ -1223,5 +1223,61 @@ TEST(EditorSyncTest, DragThenSourceEditThenUndoReplaysAgainstFreshlyParsedElemen
       << "undo after source-pane reparse failed to roll back the drag - snapshot dangled";
 }
 
+// Companion to `DragThenSourceEditThenUndoReplaysAgainstFreshlyParsedElement`,
+// covering the failure side of rehydration: a structural edit (element
+// deletion) after the snapshot was captured means the snapshot's
+// `writebackTarget` can no longer resolve in the reparsed document.
+// `ApplyTimelineSnapshot`/`ResolveSnapshotElement` in EditorApp.cc must skip
+// this entry gracefully - it must NOT fall back to dereferencing the stale
+// pre-reparse `snapshot.element` (which would otherwise risk applying a
+// mutation, or computing a writeback target, against an orphaned document
+// disconnected from what the user is looking at).
+TEST(EditorSyncTest, UndoSkipsGracefullyWhenSnapshotTargetNoLongerResolvesAfterReparse) {
+  constexpr std::string_view kSvg = R"svg(<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect id="r" x="10" y="10" width="20" height="20" fill="red"/>
+</svg>
+)svg";
+
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kSvg));
+  app.setCleanSourceText(kSvg);
+
+  auto rect = app.document().document().querySelector("#r");
+  ASSERT_TRUE(rect.has_value());
+
+  const Transform2d before = Transform2d();
+  const Transform2d after = Transform2d::Translate(Vector2d(25.0, 0.0));
+  rect->cast<svg::SVGGraphicsElement>().setTransform(after);
+  UndoSnapshot beforeSnapshot{.element = *rect,
+                              .transform = before,
+                              .writebackTarget = captureAttributeWritebackTarget(*rect)};
+  UndoSnapshot afterSnapshot{.element = *rect,
+                             .transform = after,
+                             .writebackTarget = captureAttributeWritebackTarget(*rect)};
+  ASSERT_TRUE(beforeSnapshot.writebackTarget.has_value());
+  app.undoTimeline().record("Drag r", std::move(beforeSnapshot), std::move(afterSnapshot));
+
+  ASSERT_TRUE(app.canUndo());
+
+  // Structural edit deletes `#r` entirely - the writeback target this undo
+  // entry captured can never resolve again.
+  constexpr std::string_view kSvgAfterDelete = R"svg(<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+</svg>
+)svg";
+  app.applyMutation(EditorCommand::ReplaceDocumentCommand(std::string(kSvgAfterDelete),
+                                                          /*preserveUndoOnReparse=*/true));
+  ASSERT_TRUE(app.flushFrame());
+
+  // Must not crash, and must not resurrect `#r` or otherwise touch the live
+  // (now-empty) document - the entry is skipped as unresolvable, so nothing
+  // is queued and this is a no-op flush.
+  app.undo();
+  EXPECT_FALSE(app.flushFrame());
+
+  EXPECT_FALSE(app.document().document().querySelector("#r").has_value());
+}
+
 }  // namespace
 }  // namespace donner::editor

--- a/donner/editor/tests/LayerTreeModel_tests.cc
+++ b/donner/editor/tests/LayerTreeModel_tests.cc
@@ -349,6 +349,46 @@ TEST(LayerTreeModelTest, VisibilityFlagsReflectDisplayAndVisibilityProperties) {
   EXPECT_TRUE(visible->isVisible);
 }
 
+// The Layers panel eye toggle (`EditorApp::setElementVisible`) reads and
+// writes the `display` presentation attribute directly, not the cascaded
+// computed style. This covers both ends of that pairing:
+//  - An element hidden purely via a stylesheet rule (no local `display`
+//    attribute at all) still shows a closed eye through the computed-style
+//    fallback.
+//  - After the eye toggles Show (writing a local `display="inline"`
+//    override), the eye reflects that local override rather than lagging
+//    behind whatever the stylesheet rule would otherwise compute.
+TEST(LayerTreeModelTest, EyeStateMatchesToggleForCssHiddenElement) {
+  constexpr std::string_view kCssHiddenSvg =
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <style>.cssHidden { display: none; }</style>
+  <rect id="target" class="cssHidden" x="0" y="0" width="10" height="10"/>
+</svg>)";
+
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kCssHiddenSvg));
+
+  LayerTreeModel model;
+  model.refresh(app);
+
+  const LayerTreeRow* target = FindRow(model, "target");
+  ASSERT_NE(target, nullptr);
+  EXPECT_FALSE(target->isVisible)
+      << "element hidden purely via a stylesheet rule should still read as hidden";
+
+  auto element = app.document().document().querySelector("#target");
+  ASSERT_TRUE(element.has_value());
+  app.setElementVisible(*element, /*visible=*/true);
+  ASSERT_TRUE(app.flushFrame());
+
+  model.refresh(app);
+  target = FindRow(model, "target");
+  ASSERT_NE(target, nullptr);
+  EXPECT_TRUE(target->isVisible)
+      << "eye state must match what the toggle just wrote (a local display override), not "
+         "whatever the stylesheet rule would otherwise compute";
+}
+
 TEST(LayerTreeModelTest, LockedRowsReflectAncestorLockState) {
   EditorApp app;
   ASSERT_TRUE(app.loadFromString(kLockedRowsSvg));


### PR DESCRIPTION
Structured-editing: undo hardening around reparse and the layers panel.

- Re-enable the undo-across-reparse regression test.
- Skip undo entries whose rehydration target no longer resolves.
- Preserve the author display value across layers-panel hide/show; align the layers-panel eye read with what the toggle writes.

gate: editor suite green except the known /tmp sandbox target.

Part of Design 0013 / Design 0017 (zettelkasten).

Depends on / bases on `qa/polish-wave1` (PR #782); diff shown is this packet only.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
