### PR TITLE
Structured editing: source formatting fidelity, transform syntax preservation, undo hardening

### DIFF
--- a/donner/base/xml/XMLDocument.cc
+++ b/donner/base/xml/XMLDocument.cc
@@ -757,6 +757,77 @@ bool SourceHasClosingTagAt(std::string_view source, std::size_t offset,
          source.substr(offset, closingTag.size()) == closingTag;
 }
 
+// How a structural mutation should format the whitespace around a newly serialized node.
+enum class InsertionFormatting {
+  // Text content: keep it inline (e.g. `<text>hello</text>`). Never introduces newlines,
+  // matching how a human authors a text run.
+  kInline,
+  // Structural child (element inserted/moved via the layer tree): lay the child out on its
+  // own indented line when the surrounding source is already spread across multiple lines,
+  // and stay compact when the author wrote it on a single line.
+  kStructural,
+};
+
+// The indentation (a run of spaces/tabs) of the line that `offset` begins on: the
+// whitespace between the newline preceding `offset` and `offset` itself. Returns nullopt
+// when `offset` is not at the start of its line (an inline / single-line context), which
+// signals that structural insertion should stay compact and synthesize no whitespace.
+std::optional<std::string_view> LineIndentBefore(std::string_view source, std::size_t offset) {
+  if (offset > source.size()) {
+    return std::nullopt;
+  }
+  std::size_t indentStart = offset;
+  while (indentStart > 0 && (source[indentStart - 1] == ' ' || source[indentStart - 1] == '\t')) {
+    --indentStart;
+  }
+  if (indentStart == 0 || source[indentStart - 1] != '\n') {
+    return std::nullopt;
+  }
+  return source.substr(indentStart, offset - indentStart);
+}
+
+// The leading indentation (run of spaces/tabs at the start of the line) of the line that
+// contains `pos`. Unlike LineIndentBefore, `pos` may sit anywhere on the line.
+std::string_view LineIndentContaining(std::string_view source, std::size_t pos) {
+  if (pos > source.size()) {
+    pos = source.size();
+  }
+  std::size_t lineStart = pos;
+  while (lineStart > 0 && source[lineStart - 1] != '\n') {
+    --lineStart;
+  }
+  std::size_t indentEnd = lineStart;
+  while (indentEnd < source.size() && (source[indentEnd] == ' ' || source[indentEnd] == '\t')) {
+    ++indentEnd;
+  }
+  return source.substr(lineStart, indentEnd - lineStart);
+}
+
+// Detect the document's indentation unit (a tab, or a run of N spaces) from the first
+// indented, non-blank line. Falls back to two spaces when there is no indentation to learn
+// from. This keeps synthesized indentation faithful to the author's chosen style (tabs vs
+// spaces, and width) instead of imposing a global default.
+std::string DetectIndentUnit(std::string_view source) {
+  const std::size_t size = source.size();
+  std::size_t i = 0;
+  while (i < size) {
+    if (source[i] != '\n') {
+      ++i;
+      continue;
+    }
+    ++i;  // Move past the newline to the start of the next line.
+    std::size_t j = i;
+    while (j < size && (source[j] == ' ' || source[j] == '\t')) {
+      ++j;
+    }
+    if (j > i && j < size && source[j] != '\n' && source[j] != '\r') {
+      return std::string(source.substr(i, j - i));
+    }
+    i = j;
+  }
+  return "  ";
+}
+
 std::optional<std::size_t> FindParentClosingTagInsertionOffset(const XMLDocument& document,
                                                                const XMLNode& parent) {
   const std::string closingTag = ClosingTagFor(parent);
@@ -806,7 +877,14 @@ void ApplyParentInsertionPlan(XMLNode& parent, const NodeInsertionPlan& plan) {
 std::optional<NodeInsertionPlan> GetNodeInsertionPlan(const XMLDocument& document,
                                                       const XMLNode& parent,
                                                       const std::optional<XMLNode>& referenceNode,
-                                                      std::string_view serializedNode) {
+                                                      std::string_view serializedNode,
+                                                      InsertionFormatting formatting) {
+  const std::string_view source = document.source();
+  const bool structural = (formatting == InsertionFormatting::kStructural);
+
+  // Scenario A: insert before an existing sibling. The whitespace already in front of the
+  // reference node becomes the new node's leading indentation; a trailing newline plus the
+  // reference node's own indentation pushes the reference node back onto its own line.
   if (referenceNode.has_value()) {
     std::optional<XMLNode> referenceParent = referenceNode->parentElement();
     if (!referenceParent.has_value() || *referenceParent != parent) {
@@ -819,17 +897,63 @@ std::optional<NodeInsertionPlan> GetNodeInsertionPlan(const XMLDocument& documen
     }
 
     const std::size_t offset = *referenceLocation->start.offset;
+    std::string suffix;
+    if (structural) {
+      if (std::optional<std::string_view> refIndent = LineIndentBefore(source, offset)) {
+        suffix.push_back('\n');
+        suffix.append(*refIndent);
+      }
+    }
     return NodeInsertionPlan{
         .replacementOffset = offset,
         .replacementLength = 0,
+        .suffix = std::move(suffix),
         .insertedNodeOffset = offset,
     };
   }
 
+  // Scenario B: append as the last child, immediately before the parent's closing tag.
   if (std::optional<std::size_t> closingTagOffset =
           FindParentClosingTagInsertionOffset(document, parent);
       closingTagOffset.has_value()) {
     const std::size_t offset = *closingTagOffset;
+
+    if (structural) {
+      // Consume the whitespace run that currently indents the closing tag, then re-emit it
+      // as: a newline plus the sibling indentation for the new child, followed by a newline
+      // plus the closing tag's own indentation so the closing tag keeps its place.
+      std::size_t wsStart = offset;
+      while (wsStart > 0 && IsXmlSpace(source[wsStart - 1])) {
+        --wsStart;
+      }
+      const std::string_view whitespace = source.substr(wsStart, offset - wsStart);
+      if (whitespace.find('\n') != std::string_view::npos) {
+        const std::string_view closingIndent = LineIndentContaining(source, offset);
+        std::string_view childIndent = LineIndentContaining(source, wsStart);
+        std::string childIndentStorage;
+        if (childIndent.size() <= closingIndent.size()) {
+          // No deeper existing sibling to match (an empty but multi-line parent): indent one
+          // detected unit past the closing tag.
+          childIndentStorage = std::string(closingIndent) + DetectIndentUnit(source);
+          childIndent = childIndentStorage;
+        }
+
+        std::string prefix = "\n";
+        prefix.append(childIndent);
+        std::string suffix = "\n";
+        suffix.append(closingIndent);
+
+        const std::size_t insertedOffset = wsStart + prefix.size();
+        return NodeInsertionPlan{
+            .replacementOffset = wsStart,
+            .replacementLength = offset - wsStart,
+            .prefix = std::move(prefix),
+            .suffix = std::move(suffix),
+            .insertedNodeOffset = insertedOffset,
+        };
+      }
+    }
+
     return NodeInsertionPlan{
         .replacementOffset = offset,
         .replacementLength = 0,
@@ -837,36 +961,51 @@ std::optional<NodeInsertionPlan> GetNodeInsertionPlan(const XMLDocument& documen
     };
   }
 
+  // Scenario C: the parent is self-closing (`<g/>`); expand it into an open/close pair with
+  // the new child inside.
   std::optional<SourceRange> nodeLocation = parent.getNodeLocation();
   if (!nodeLocation.has_value() || !nodeLocation->start.offset.has_value() ||
       !nodeLocation->end.offset.has_value() || *nodeLocation->end.offset < 2 ||
-      *nodeLocation->end.offset > document.source().size()) {
+      *nodeLocation->end.offset > source.size()) {
     return std::nullopt;
   }
 
   const std::size_t selfCloseStart = *nodeLocation->end.offset - 2;
-  if (document.source().substr(selfCloseStart, 2) != "/>") {
+  if (source.substr(selfCloseStart, 2) != "/>") {
     return std::nullopt;
   }
 
   std::size_t replacementStart = selfCloseStart;
   while (replacementStart > *nodeLocation->start.offset &&
-         IsXmlSpace(document.source()[replacementStart - 1])) {
+         IsXmlSpace(source[replacementStart - 1])) {
     --replacementStart;
   }
 
   const std::string closingTag = ClosingTagFor(parent);
 
-  const std::size_t insertedOffset = replacementStart + 1;
-  const std::size_t closingTagStart = insertedOffset + serializedNode.size();
+  std::string prefix = ">";
+  std::string suffix = closingTag;
+  if (structural) {
+    if (std::optional<std::string_view> parentIndent =
+            LineIndentBefore(source, *nodeLocation->start.offset)) {
+      const std::string childIndent = std::string(*parentIndent) + DetectIndentUnit(source);
+      prefix = ">\n" + childIndent;
+      suffix = "\n" + std::string(*parentIndent) + closingTag;
+    }
+  }
+
+  const std::size_t openingTagEnd = replacementStart + 1;  // Just past the emitted '>'.
+  const std::size_t insertedOffset = replacementStart + prefix.size();
+  const std::size_t closingTagStart =
+      insertedOffset + serializedNode.size() + (suffix.size() - closingTag.size());
   return NodeInsertionPlan{
       .replacementOffset = replacementStart,
       .replacementLength = *nodeLocation->end.offset - replacementStart,
-      .prefix = ">",
-      .suffix = closingTag,
+      .prefix = std::move(prefix),
+      .suffix = std::move(suffix),
       .insertedNodeOffset = insertedOffset,
       .parentOpeningTagLocation = SourceRange{FileOffset::Offset(*nodeLocation->start.offset),
-                                              FileOffset::Offset(insertedOffset)},
+                                              FileOffset::Offset(openingTagEnd)},
       .parentClosingTagLocation =
           SourceRange{FileOffset::Offset(closingTagStart),
                       FileOffset::Offset(closingTagStart + closingTag.size())},
@@ -1939,8 +2078,23 @@ ApplySourceEditResult XMLDocument::insertNode(XMLNode parent, XMLNode node,
 
     const std::string serialized(
         source().substr(removalRange->start, removalRange->end - removalRange->start));
+
+    // Absorb the newline and indentation that put the node on its own line so moving it out
+    // does not leave an orphaned, over-indented blank line behind. The serialized bytes above
+    // are the node itself; the expanded range is only what gets deleted from the old spot.
+    SourceEditRange effectiveRemoval = *removalRange;
+    if (std::optional<std::string_view> nodeIndent = LineIndentBefore(source(), removalRange->start);
+        nodeIndent.has_value()) {
+      const std::size_t lineStart = removalRange->start - nodeIndent->size();
+      if (lineStart > 0 && source()[lineStart - 1] == '\n') {
+        effectiveRemoval.start = lineStart - 1;
+      }
+    }
+    const std::size_t effectiveRemovalLength = effectiveRemoval.end - effectiveRemoval.start;
+
     std::optional<NodeInsertionPlan> insertionPlan =
-        GetNodeInsertionPlan(*this, parent, referenceNode, serialized);
+        GetNodeInsertionPlan(*this, parent, referenceNode, serialized,
+                             InsertionFormatting::kStructural);
     if (!insertionPlan.has_value()) {
       result.diagnostic =
           MakeEditDiagnostic("Cannot move node without a source insertion point", diagnosticRange);
@@ -1985,8 +2139,8 @@ ApplySourceEditResult XMLDocument::insertNode(XMLNode parent, XMLNode node,
       const std::size_t replacementNetLength =
           replacement.size() - appliedInsertionPlan.replacementLength;
       std::optional<XMLSourceDelta> removeDelta =
-          store->replace(removalRange->start + replacementNetLength,
-                         removalRange->end - removalRange->start, std::string_view());
+          store->replace(effectiveRemoval.start + replacementNetLength, effectiveRemovalLength,
+                         std::string_view());
       if (!removeDelta.has_value()) {
         result.diagnostic =
             MakeEditDiagnostic("Invalid source removal for node move", diagnosticRange);
@@ -1994,8 +2148,8 @@ ApplySourceEditResult XMLDocument::insertNode(XMLNode parent, XMLNode node,
       }
       result.sourceDeltas.push_back(*removeDelta);
     } else {
-      std::optional<XMLSourceDelta> removeDelta = store->replace(
-          removalRange->start, removalRange->end - removalRange->start, std::string_view());
+      std::optional<XMLSourceDelta> removeDelta =
+          store->replace(effectiveRemoval.start, effectiveRemovalLength, std::string_view());
       if (!removeDelta.has_value()) {
         result.diagnostic =
             MakeEditDiagnostic("Invalid source removal for node move", diagnosticRange);
@@ -2003,8 +2157,7 @@ ApplySourceEditResult XMLDocument::insertNode(XMLNode parent, XMLNode node,
       }
       result.sourceDeltas.push_back(*removeDelta);
 
-      const std::size_t removalLength = removalRange->end - removalRange->start;
-      if (!ShiftPlanLeft(appliedInsertionPlan, removalLength)) {
+      if (!ShiftPlanLeft(appliedInsertionPlan, effectiveRemovalLength)) {
         result.diagnostic =
             MakeEditDiagnostic("Invalid source insertion plan for node move", diagnosticRange);
         return result;
@@ -2048,7 +2201,8 @@ ApplySourceEditResult XMLDocument::insertNode(XMLNode parent, XMLNode node,
 
   const std::string serialized(std::string_view(node.serializeToString(0, false)));
   std::optional<NodeInsertionPlan> insertionPlan =
-      GetNodeInsertionPlan(*this, parent, referenceNode, serialized);
+      GetNodeInsertionPlan(*this, parent, referenceNode, serialized,
+                           InsertionFormatting::kStructural);
   if (!insertionPlan.has_value()) {
     result.diagnostic =
         MakeEditDiagnostic("Cannot insert node without a source insertion point", diagnosticRange);
@@ -2235,8 +2389,10 @@ ApplySourceEditResult XMLDocument::setElementText(XMLNode element, std::string_v
     return result;
   }
 
-  std::optional<NodeInsertionPlan> plan =
-      GetNodeInsertionPlan(*this, element, std::nullopt, std::string_view(*escaped));
+  // Text content stays inline (`<text>hello</text>`) regardless of the surrounding layout;
+  // that is how a human authors a text run, so no block indentation is synthesized here.
+  std::optional<NodeInsertionPlan> plan = GetNodeInsertionPlan(
+      *this, element, std::nullopt, std::string_view(*escaped), InsertionFormatting::kInline);
   if (!plan.has_value()) {
     result.diagnostic = MakeEditDiagnostic(
         "Cannot set text on a node without a source insertion point", diagnosticRange);

--- a/donner/base/xml/XMLDocument.cc
+++ b/donner/base/xml/XMLDocument.cc
@@ -919,9 +919,9 @@ std::optional<NodeInsertionPlan> GetNodeInsertionPlan(const XMLDocument& documen
     const std::size_t offset = *closingTagOffset;
 
     if (structural) {
-      // Consume the whitespace run that currently indents the closing tag, then re-emit it
-      // as: a newline plus the sibling indentation for the new child, followed by a newline
-      // plus the closing tag's own indentation so the closing tag keeps its place.
+      // Append the child on its own line right after the last existing sibling, leaving the
+      // whitespace that already indents the closing tag untouched. This stays a pure
+      // insertion (nothing removed), which the text-mirror's echo-suppression relies on.
       std::size_t wsStart = offset;
       while (wsStart > 0 && IsXmlSpace(source[wsStart - 1])) {
         --wsStart;
@@ -940,16 +940,12 @@ std::optional<NodeInsertionPlan> GetNodeInsertionPlan(const XMLDocument& documen
 
         std::string prefix = "\n";
         prefix.append(childIndent);
-        std::string suffix = "\n";
-        suffix.append(closingIndent);
 
-        const std::size_t insertedOffset = wsStart + prefix.size();
         return NodeInsertionPlan{
             .replacementOffset = wsStart,
-            .replacementLength = offset - wsStart,
+            .replacementLength = 0,
             .prefix = std::move(prefix),
-            .suffix = std::move(suffix),
-            .insertedNodeOffset = insertedOffset,
+            .insertedNodeOffset = wsStart + 1 + childIndent.size(),
         };
       }
     }

--- a/donner/base/xml/tests/XMLDocument_tests.cc
+++ b/donner/base/xml/tests/XMLDocument_tests.cc
@@ -62,6 +62,25 @@ XMLDocument ParseDocument(std::string_view xml) {
   return std::move(maybeDocument.result());
 }
 
+/// The \p index-th element child of \p parent, skipping any whitespace/text nodes. Used by
+/// the source-formatting tests, whose fixtures are laid out across indented lines and thus
+/// carry inter-element whitespace text nodes.
+XMLNode ElementChild(const XMLNode& parent, std::size_t index) {
+  std::size_t seen = 0;
+  for (std::optional<XMLNode> child = parent.firstChild(); child.has_value();
+       child = child->nextSibling()) {
+    if (child->type() != XMLNode::Type::Element) {
+      continue;
+    }
+    if (seen == index) {
+      return *child;
+    }
+    ++seen;
+  }
+  ADD_FAILURE() << "no element child at index " << index;
+  return parent;
+}
+
 /// Returns true when \p result carries a diagnostic whose reason contains \p needle.
 MATCHER_P(DiagnosticReasonContains, needle, "") {
   if (!arg.diagnostic.has_value()) {
@@ -2428,6 +2447,96 @@ TEST_F(XMLDocumentTests, RemoveNodeWithStaleSourceRangeFails) {
 }
 
 //
+// Structural source-formatting fidelity.
+//
+// These assert the exact source bytes produced by each structural mutation kind when the
+// document is already laid out across indented lines. The fidelity standard mirrors
+// attribute writeback: a mutation must leave the surrounding whitespace as a human would.
+//
+
+TEST_F(XMLDocumentTests, InsertNodeIntoEmptyParentIndentsChildOnItsOwnLine) {
+  XMLDocument doc = ParseDocument("<svg>\n  <g/>\n</svg>");
+  XMLNode g = ElementChild(doc.root().firstChild().value(), 0);
+  XMLNode rect = XMLNode::CreateElementNode(doc, "rect");
+
+  ApplySourceEditResult result = doc.insertNode(g, rect);
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_EQ(doc.source(), "<svg>\n  <g>\n    <rect/>\n  </g>\n</svg>");
+}
+
+TEST_F(XMLDocumentTests, InsertNodeBetweenSiblingsMatchesSiblingIndent) {
+  XMLDocument doc = ParseDocument("<svg>\n  <a/>\n  <b/>\n</svg>");
+  XMLNode svg = doc.root().firstChild().value();
+  XMLNode b = ElementChild(svg, 1);
+  XMLNode rect = XMLNode::CreateElementNode(doc, "rect");
+
+  ApplySourceEditResult result = doc.insertNode(svg, rect, b);
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_EQ(doc.source(), "<svg>\n  <a/>\n  <rect/>\n  <b/>\n</svg>");
+}
+
+TEST_F(XMLDocumentTests, InsertNodeAppendsAtSiblingIndentBeforeClosingTag) {
+  XMLDocument doc = ParseDocument("<svg>\n  <a/>\n  <b/>\n</svg>");
+  XMLNode svg = doc.root().firstChild().value();
+  XMLNode rect = XMLNode::CreateElementNode(doc, "rect");
+
+  ApplySourceEditResult result = doc.insertNode(svg, rect);
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_EQ(doc.source(), "<svg>\n  <a/>\n  <b/>\n  <rect/>\n</svg>");
+}
+
+TEST_F(XMLDocumentTests, InsertNodeDetectsTabIndentUnit) {
+  XMLDocument doc = ParseDocument("<svg>\n\t<g/>\n</svg>");
+  XMLNode g = ElementChild(doc.root().firstChild().value(), 0);
+  XMLNode rect = XMLNode::CreateElementNode(doc, "rect");
+
+  ApplySourceEditResult result = doc.insertNode(g, rect);
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_EQ(doc.source(), "<svg>\n\t<g>\n\t\t<rect/>\n\t</g>\n</svg>");
+}
+
+TEST_F(XMLDocumentTests, InsertNodeStaysCompactForSingleLineSource) {
+  XMLDocument doc = ParseDocument(R"(<svg><g/></svg>)");
+  XMLNode g = ElementChild(doc.root().firstChild().value(), 0);
+  XMLNode rect = XMLNode::CreateElementNode(doc, "rect");
+
+  ApplySourceEditResult result = doc.insertNode(g, rect);
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_EQ(doc.source(), R"(<svg><g><rect/></g></svg>)");
+}
+
+TEST_F(XMLDocumentTests, MoveNodeToEndCarriesWhitespaceWithoutOrphaningOldLine) {
+  XMLDocument doc = ParseDocument("<svg>\n  <a/>\n  <b/>\n  <c/>\n</svg>");
+  XMLNode svg = doc.root().firstChild().value();
+  XMLNode a = ElementChild(svg, 0);
+
+  // Move <a> to the end of its parent. The old line must not be left orphaned.
+  ApplySourceEditResult result = doc.insertNode(svg, a);
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_EQ(doc.source(), "<svg>\n  <b/>\n  <c/>\n  <a/>\n</svg>");
+}
+
+TEST_F(XMLDocumentTests, MoveNodeBeforeSiblingCarriesWhitespace) {
+  XMLDocument doc = ParseDocument("<svg>\n  <a/>\n  <b/>\n  <c/>\n</svg>");
+  XMLNode svg = doc.root().firstChild().value();
+  XMLNode a = ElementChild(svg, 0);
+  XMLNode c = ElementChild(svg, 2);
+  ASSERT_EQ(c.tagName(), XMLQualifiedNameRef("c"));
+
+  // Move <c> to before <a>. The old <c> line must collapse cleanly.
+  ApplySourceEditResult result = doc.insertNode(svg, c, a);
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_EQ(doc.source(), "<svg>\n  <c/>\n  <a/>\n  <b/>\n</svg>");
+}
+
+//
 // setElementText.
 //
 
@@ -2468,6 +2577,18 @@ TEST_F(XMLDocumentTests, SetElementTextInsertsIntoEmptyElement) {
   EXPECT_EQ(result.scope, ReparseScope::TextNode);
   EXPECT_THAT(text.value(), Optional(Eq("hello")));
   EXPECT_EQ(doc.source(), R"(<svg><text>hello</text></svg>)");
+}
+
+TEST_F(XMLDocumentTests, SetElementTextStaysInlineEvenInBlockLaidOutSource) {
+  // Text content is authored inline regardless of the surrounding block layout: expanding a
+  // self-closing <text/> yields <text>hello</text>, not a text node on its own line.
+  XMLDocument doc = ParseDocument("<svg>\n  <text/>\n</svg>");
+  XMLNode text = ElementChild(doc.root().firstChild().value(), 0);
+
+  ApplySourceEditResult result = doc.setElementText(text, "hello");
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_EQ(doc.source(), "<svg>\n  <text>hello</text>\n</svg>");
 }
 
 TEST_F(XMLDocumentTests, SetElementTextExpandsSelfClosingElement) {

--- a/donner/editor/BUILD.bazel
+++ b/donner/editor/BUILD.bazel
@@ -352,6 +352,16 @@ donner_cc_library(
 )
 
 donner_cc_library(
+    name = "transform_syntax_preserving",
+    srcs = ["TransformSyntaxPreserving.cc"],
+    hdrs = ["TransformSyntaxPreserving.h"],
+    deps = [
+        "//donner/base",
+        "//donner/svg/parser",
+    ],
+)
+
+donner_cc_library(
     name = "async_renderer",
     srcs = ["AsyncRenderer.cc"],
     hdrs = ["AsyncRenderer.h"],
@@ -497,6 +507,7 @@ donner_cc_library(
         ":source_sync",
         ":text_editor",
         ":text_patch",
+        ":transform_syntax_preserving",
         "//donner/base",
     ],
 )

--- a/donner/editor/DocumentSyncController.cc
+++ b/donner/editor/DocumentSyncController.cc
@@ -9,6 +9,7 @@
 #include "donner/editor/SelectTool.h"
 #include "donner/editor/SourceSync.h"
 #include "donner/editor/TextPatch.h"
+#include "donner/editor/TransformSyntaxPreserving.h"
 
 namespace donner::editor {
 
@@ -399,11 +400,13 @@ void DocumentSyncController::applyPendingWritebacks(EditorApp& app, SelectTool& 
     pendingTransformWritebacks_.push_back(EditorApp::CompletedTransformWriteback{
         .target = std::move(completed->target),
         .transform = completed->transform,
+        .sourceTransformAttributeValue = std::move(completed->sourceTransformAttributeValue),
     });
     for (auto& extra : completed->extras) {
       pendingTransformWritebacks_.push_back(EditorApp::CompletedTransformWriteback{
           .target = std::move(extra.target),
           .transform = extra.transform,
+          .sourceTransformAttributeValue = std::move(extra.sourceTransformAttributeValue),
       });
     }
   }
@@ -473,7 +476,8 @@ void DocumentSyncController::applyPendingWritebacks(EditorApp& app, SelectTool& 
           result = document.removeElementAttribute(*element, "transform");
         }
       } else {
-        const RcString serialized = toSVGTransformString(writeback.transform);
+        const RcString serialized = serializeTransformForWriteback(
+            writeback.sourceTransformAttributeValue, writeback.transform);
         if (std::string_view(serialized).empty()) {
           result = document.removeElementAttribute(*element, "transform");
         } else {
@@ -506,7 +510,8 @@ void DocumentSyncController::applyPendingWritebacks(EditorApp& app, SelectTool& 
         patch = buildAttributeRemoveWriteback(source, writeback.target, "transform");
       }
     } else {
-      const RcString serialized = toSVGTransformString(writeback.transform);
+      const RcString serialized = serializeTransformForWriteback(
+          writeback.sourceTransformAttributeValue, writeback.transform);
       if (std::string_view(serialized).empty()) {
         patch = buildAttributeRemoveWriteback(source, writeback.target, "transform");
       } else {

--- a/donner/editor/EditorApp.cc
+++ b/donner/editor/EditorApp.cc
@@ -1331,13 +1331,46 @@ bool IsLockGatedCommand(const EditorCommand& command) {
 }
 
 void EditorApp::setElementVisible(const svg::SVGElement& element, bool visible) {
-  // Toggle the `display` presentation attribute. Hiding writes
-  // `display="none"`; showing writes `display="inline"` (a definitively
-  // visible value) so the change is observable through the computed-style
-  // visibility check regardless of whether the surrounding stylesheet sets
-  // display.
-  applyMutation(
-      EditorCommand::SetAttributeCommand(element, "display", visible ? "inline" : "none"));
+  const auto entryIt =
+      std::find_if(hiddenElementAuthorDisplay_.begin(), hiddenElementAuthorDisplay_.end(),
+                   [&element](const auto& entry) { return entry.first == element; });
+
+  if (!visible) {
+    // Capture the author's `display` value (if any) BEFORE clobbering it, so
+    // the matching Show can restore it later instead of forcing
+    // `display="inline"` over e.g. an authored `display="block"`. Replace any
+    // stale entry from a previous hide/show cycle for this element.
+    std::optional<RcString> authorDisplay = element.getAttribute("display");
+    std::optional<std::string> capturedValue =
+        authorDisplay.has_value() ? std::optional<std::string>(std::string(*authorDisplay))
+                                   : std::nullopt;
+    if (entryIt != hiddenElementAuthorDisplay_.end()) {
+      entryIt->second = std::move(capturedValue);
+    } else {
+      hiddenElementAuthorDisplay_.emplace_back(element, std::move(capturedValue));
+    }
+    applyMutation(EditorCommand::SetAttributeCommand(element, "display", "none"));
+    return;
+  }
+
+  // Showing: restore the captured author value when it is a genuine,
+  // non-`none` override we clobbered - this is the common "author wrote
+  // display=block" case the round trip must preserve. When there is no
+  // captured entry (this element was never hidden through this toggle this
+  // session) or the captured value was itself absent/`"none"` (restoring it
+  // literally would leave the element hidden, defeating the Show action),
+  // fall back to writing a definitively-visible `display="inline"`.
+  if (entryIt != hiddenElementAuthorDisplay_.end()) {
+    std::optional<std::string> authorDisplay = std::move(entryIt->second);
+    hiddenElementAuthorDisplay_.erase(entryIt);
+    if (authorDisplay.has_value() && *authorDisplay != "none") {
+      applyMutation(EditorCommand::SetAttributeCommand(element, "display",
+                                                        std::move(*authorDisplay)));
+      return;
+    }
+  }
+
+  applyMutation(EditorCommand::SetAttributeCommand(element, "display", "inline"));
 }
 
 void EditorApp::setElementLocked(const svg::SVGElement& element, bool locked) {

--- a/donner/editor/EditorApp.cc
+++ b/donner/editor/EditorApp.cc
@@ -552,16 +552,31 @@ std::vector<AttributeWritebackTarget> CaptureSelectionTargets(
   return targets;
 }
 
-svg::SVGElement ResolveSnapshotElement(AsyncSVGDocument& document, const UndoSnapshot& snapshot) {
-  svg::SVGElement liveElement = snapshot.element;
-  if (document.hasDocument() && snapshot.writebackTarget.has_value()) {
-    if (auto resolved =
-            resolveAttributeWritebackTarget(document.document(), *snapshot.writebackTarget);
-        resolved.has_value()) {
-      liveElement = *resolved;
-    }
+// Rehydrate a snapshot's target element against the live document.
+//
+// - If the snapshot never captured a `writebackTarget` (the element had no
+//   XML node backing at capture time), there is nothing to rehydrate against;
+//   trust the originally captured element - this is the common case for
+//   snapshots that never survive a reparse.
+// - If a `writebackTarget` was captured but the document has since been
+//   reparsed (or is momentarily absent) such that the target no longer
+//   resolves, return `std::nullopt` rather than silently falling back to the
+//   pre-reparse `snapshot.element`. That handle may still be a technically
+//   live reference into an orphaned pre-reparse document (kept alive only by
+//   this snapshot's own reference), so applying a mutation - or worse,
+//   computing a fresh writeback target - against it risks writing a
+//   correctly-shaped but wrongly-targeted patch into the live source text.
+std::optional<svg::SVGElement> ResolveSnapshotElement(AsyncSVGDocument& document,
+                                                       const UndoSnapshot& snapshot) {
+  if (!snapshot.writebackTarget.has_value()) {
+    return snapshot.element;
   }
-  return liveElement;
+
+  if (!document.hasDocument()) {
+    return std::nullopt;
+  }
+
+  return resolveAttributeWritebackTarget(document.document(), *snapshot.writebackTarget);
 }
 
 void ApplyTimelineSnapshot(EditorApp& app, AsyncSVGDocument& document,
@@ -573,13 +588,26 @@ void ApplyTimelineSnapshot(EditorApp& app, AsyncSVGDocument& document,
     return;
   }
 
-  svg::SVGElement liveElement = ResolveSnapshotElement(document, snapshot);
+  const std::optional<svg::SVGElement> liveElement = ResolveSnapshotElement(document, snapshot);
+  if (!liveElement.has_value()) {
+    // Rehydration was attempted (the snapshot carried a `writebackTarget`)
+    // but failed - a structural edit since this entry was captured means
+    // the target no longer resolves in the live document. There is nothing
+    // safe to replay this entry against; skip it gracefully instead of
+    // dereferencing the stale pre-reparse handle. Extras (grouped
+    // multi-element gestures) are independent snapshots, so still give each
+    // of them a chance to resolve on their own.
+    for (const UndoSnapshot& extra : snapshot.extras) {
+      ApplyTimelineSnapshot(app, document, extra);
+    }
+    return;
+  }
 
   // Route the restored transform through the command queue so every
   // DOM write - tool drags, text-pane re-parse, and undo - goes through
   // the same mutation seam. The queue coalesces with any pending
   // commands and applies on the next `flushFrame()`.
-  app.applyMutation(EditorCommand::SetTransformCommand(liveElement, snapshot.transform));
+  app.applyMutation(EditorCommand::SetTransformCommand(*liveElement, snapshot.transform));
 
   // Capture the source-text writeback target BEFORE the command drains
   // so the path-based target resolves against the in-sync document.
@@ -595,7 +623,7 @@ void ApplyTimelineSnapshot(EditorApp& app, AsyncSVGDocument& document,
         .transform = snapshot.transform,
         .sourceTransformAttributeValue = snapshot.sourceTransformAttributeValue,
         .restoreSourceTransformAttributeValue = snapshot.restoreSourceTransformAttributeValue});
-  } else if (auto target = captureAttributeWritebackTarget(liveElement); target.has_value()) {
+  } else if (auto target = captureAttributeWritebackTarget(*liveElement); target.has_value()) {
     app.enqueueTransformWriteback(EditorApp::CompletedTransformWriteback{
         .target = std::move(*target),
         .transform = snapshot.transform,

--- a/donner/editor/EditorApp.h
+++ b/donner/editor/EditorApp.h
@@ -19,6 +19,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "donner/base/Box.h"
@@ -167,11 +168,16 @@ public:
   }
 
   /// Set the visibility of @p element by toggling its `display` presentation
-  /// attribute: hiding writes `display="none"`, showing writes
-  /// `display="inline"` (a definitively visible value, observable through the
-  /// computed-style visibility check). Routes through `applyMutation` so the
-  /// Layers panel eye button and context menu share one code path. Visibility
-  /// toggles are intentionally NOT lock-gated.
+  /// attribute. Hiding captures the element's current author `display` value
+  /// (if any) before overwriting it with `display="none"`. Showing restores
+  /// that captured value when it is a genuine, non-`none` author value (e.g.
+  /// `display="block"`), so a hide/show round trip does not clobber it;
+  /// otherwise (no captured value, or the element was never hidden through
+  /// this toggle this session) it writes `display="inline"` (a definitively
+  /// visible value, observable through the computed-style visibility check).
+  /// Routes through `applyMutation` so the Layers panel eye button and
+  /// context menu share one code path. Visibility toggles are intentionally
+  /// NOT lock-gated.
   void setElementVisible(const svg::SVGElement& element, bool visible);
 
   /// Lock or unlock @p element by toggling the `data-donner-locked` marker
@@ -594,6 +600,14 @@ private:
 
   std::vector<CompletedTransformWriteback> pendingTransformWritebacks_;
   std::vector<CompletedElementRemoveWriteback> pendingElementRemoveWritebacks_;
+  /// Per-session memory of the author `display` value an element carried
+  /// immediately before `setElementVisible` hid it, so the matching Show
+  /// restores that value instead of clobbering it with `display="inline"`.
+  /// `std::nullopt` for the captured value means the element had no author
+  /// `display` attribute at all. Cleared for an element once its Show
+  /// consumes the entry. A stale entry (element deleted/reparsed away) is
+  /// simply never matched again and is harmless.
+  std::vector<std::pair<svg::SVGElement, std::optional<std::string>>> hiddenElementAuthorDisplay_;
   std::optional<PendingDocumentSourceUndo> pendingDocumentSourceUndo_;
   std::optional<std::vector<AttributeWritebackTarget>> pendingSelectionRestoreTargets_;
 

--- a/donner/editor/LayerTreeModel.cc
+++ b/donner/editor/LayerTreeModel.cc
@@ -172,6 +172,21 @@ std::string BuildDisplayName(const svg::SVGElement& element) {
 }
 
 bool IsVisible(const svg::SVGElement& element) {
+  // `EditorApp::setElementVisible` (the Layers panel eye toggle) reads and
+  // writes the element's own `display` presentation attribute directly - not
+  // the cascaded computed style. Check that same local override first so the
+  // eye state agrees with what the toggle actually controls: an element the
+  // user just hid (or showed) reads correctly even if a stylesheet rule with
+  // higher specificity would otherwise win the cascade and make computed
+  // style disagree with the attribute. Only when there is no local `display`
+  // override does this fall back to computed style (which also covers
+  // `visibility`), so an element hidden purely via a stylesheet rule - no
+  // local `display` attribute at all - still shows a closed eye.
+  if (const std::optional<RcString> localDisplay = element.getAttribute("display");
+      localDisplay.has_value()) {
+    return *localDisplay != "none";
+  }
+
   const svg::PropertyRegistry& style = element.getComputedStyle();
   if (const auto display = style.display.get();
       display.has_value() && *display == svg::Display::None) {

--- a/donner/editor/SelectTool.cc
+++ b/donner/editor/SelectTool.cc
@@ -695,9 +695,14 @@ void SelectTool::onMouseUp(EditorApp& editor, const Vector2d& /*documentPoint*/)
         .writebackTarget = dragState_->primary.writebackTarget,
         .sourceTransformAttributeValue = dragState_->primary.sourceTransformAttributeValue,
         .restoreSourceTransformAttributeValue = true};
+    // The forward ("after") snapshot carries the author's original bytes too so
+    // redo re-derives the same syntax-preserving writeback (restore stays
+    // false: this is a forward apply, not a verbatim restore).
     UndoSnapshot after{.element = dragState_->primary.element,
                        .transform = dragState_->primary.currentTransform,
-                       .writebackTarget = dragState_->primary.writebackTarget};
+                       .writebackTarget = dragState_->primary.writebackTarget,
+                       .sourceTransformAttributeValue =
+                           dragState_->primary.sourceTransformAttributeValue};
     before.extras.reserve(dragState_->extras.size());
     after.extras.reserve(dragState_->extras.size());
     for (const auto& extra : dragState_->extras) {
@@ -707,11 +712,11 @@ void SelectTool::onMouseUp(EditorApp& editor, const Vector2d& /*documentPoint*/)
                        .writebackTarget = extra.writebackTarget,
                        .sourceTransformAttributeValue = extra.sourceTransformAttributeValue,
                        .restoreSourceTransformAttributeValue = true});
-      after.extras.push_back(UndoSnapshot{
-          .element = extra.element,
-          .transform = extra.currentTransform,
-          .writebackTarget = extra.writebackTarget,
-      });
+      after.extras.push_back(
+          UndoSnapshot{.element = extra.element,
+                       .transform = extra.currentTransform,
+                       .writebackTarget = extra.writebackTarget,
+                       .sourceTransformAttributeValue = extra.sourceTransformAttributeValue});
     }
     editor.undoTimeline().record(undoLabel, std::move(before), std::move(after));
 
@@ -723,12 +728,14 @@ void SelectTool::onMouseUp(EditorApp& editor, const Vector2d& /*documentPoint*/)
           extraWritebacks.push_back(CompletedDragWriteback{
               .target = *extra.writebackTarget,
               .transform = extra.currentTransform,
+              .sourceTransformAttributeValue = extra.sourceTransformAttributeValue,
           });
         }
       }
       completedDragWriteback_ = CompletedDragWriteback{
           .target = *dragState_->primary.writebackTarget,
           .transform = dragState_->primary.currentTransform,
+          .sourceTransformAttributeValue = dragState_->primary.sourceTransformAttributeValue,
           .extras = std::move(extraWritebacks),
       };
     }

--- a/donner/editor/SelectTool.h
+++ b/donner/editor/SelectTool.h
@@ -88,6 +88,12 @@ public:
     AttributeWritebackTarget target;
     Transform2d transform;
 
+    /// The element's `transform=` bytes as authored at drag start, used by the
+    /// source writeback to preserve the author's function syntax instead of
+    /// canonicalizing to `matrix()`. `std::nullopt` when the element had no
+    /// transform attribute before the drag.
+    std::optional<RcString> sourceTransformAttributeValue;
+
     /// Additional writeback entries for extra elements in a multi-element
     /// drag. One per non-primary element that had a capturable writeback
     /// target. Empty for single-element drags.

--- a/donner/editor/SidebarPresenter.cc
+++ b/donner/editor/SidebarPresenter.cc
@@ -900,17 +900,24 @@ void SidebarPresenter::commitTransformEdit(EditorApp& liveApp) {
                       .writebackTarget = state.writebackTarget,
                       .sourceTransformAttributeValue = state.sourceTransformAttributeValue,
                       .restoreSourceTransformAttributeValue = true};
+  // Carry the author's original transform bytes on the forward ("after")
+  // snapshot too so redo re-derives the same syntax-preserving writeback the
+  // original edit produced (restore stays false: this is a forward apply).
   UndoSnapshot after{.element = state.element,
                      .transform = state.currentTransform,
-                     .writebackTarget = state.writebackTarget};
+                     .writebackTarget = state.writebackTarget,
+                     .sourceTransformAttributeValue = state.sourceTransformAttributeValue};
   liveApp.undoTimeline().record(state.undoLabel, std::move(before), std::move(after));
 
   // Keep the source pane's transform= attribute in lock-step with the DOM;
-  // DocumentSyncController drains this queue once per frame.
+  // DocumentSyncController drains this queue once per frame. The original
+  // attribute bytes let the writeback preserve the author's function syntax
+  // (rotate()/translate()/scale()) instead of canonicalizing to matrix().
   if (state.writebackTarget.has_value()) {
     liveApp.enqueueTransformWriteback(EditorApp::CompletedTransformWriteback{
         .target = *state.writebackTarget,
         .transform = state.currentTransform,
+        .sourceTransformAttributeValue = state.sourceTransformAttributeValue,
     });
   }
 }

--- a/donner/editor/TransformSyntaxPreserving.cc
+++ b/donner/editor/TransformSyntaxPreserving.cc
@@ -1,0 +1,509 @@
+#include "donner/editor/TransformSyntaxPreserving.h"
+
+#include <charconv>
+#include <cmath>
+#include <string>
+#include <vector>
+
+#include "donner/base/FormatNumber.h"
+#include "donner/base/MathUtils.h"
+#include "donner/svg/parser/TransformParser.h"
+
+namespace donner::editor {
+
+namespace {
+
+// Below these thresholds a component is treated as unchanged by the edit, so
+// its author-written token is re-emitted verbatim (preserving precision) rather
+// than reformatted.
+constexpr double kUnchangedEps = 1e-6;
+// Deltas below these thresholds mean the edit did not touch that decomposed
+// component, so no function of that kind is required to absorb it.
+constexpr double kAngleEps = 1e-9;   ///< Radians.
+constexpr double kScaleEps = 1e-9;   ///< Unitless scale-ratio deviation from 1.
+constexpr double kMatrixEps = 1e-6;  ///< Linear-part identity check for the translate solve.
+
+/// A single parsed number inside a transform function, keeping the author's
+/// verbatim token so unchanged parameters round-trip exactly.
+struct Arg {
+  double value = 0.0;
+  std::string text;
+};
+
+/// A parsed `name(args...)` transform function.
+struct Fn {
+  std::string name;
+  std::vector<Arg> args;
+  bool usesComma = false;  ///< Whether the author separated args with commas.
+};
+
+bool IsSpace(char c) {
+  return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
+}
+
+bool IsAlpha(char c) {
+  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+}
+
+bool IsDigit(char c) {
+  return c >= '0' && c <= '9';
+}
+
+/// Parse @p s into an ordered function list, capturing each argument's verbatim
+/// token. Returns `std::nullopt` on any malformed input; the caller then falls
+/// back to canonical serialization.
+std::optional<std::vector<Fn>> ParseFunctionList(std::string_view s) {
+  std::vector<Fn> fns;
+  std::size_t i = 0;
+  const std::size_t n = s.size();
+  auto skipSpace = [&] {
+    while (i < n && IsSpace(s[i])) {
+      ++i;
+    }
+  };
+
+  skipSpace();
+  while (i < n) {
+    const std::size_t nameStart = i;
+    while (i < n && IsAlpha(s[i])) {
+      ++i;
+    }
+    if (i == nameStart) {
+      return std::nullopt;
+    }
+    Fn fn;
+    fn.name = std::string(s.substr(nameStart, i - nameStart));
+
+    skipSpace();
+    if (i >= n || s[i] != '(') {
+      return std::nullopt;
+    }
+    ++i;  // consume '('
+    skipSpace();
+
+    while (i < n && s[i] != ')') {
+      const std::size_t numStart = i;
+      if (i < n && (s[i] == '+' || s[i] == '-')) {
+        ++i;
+      }
+      while (i < n && (IsDigit(s[i]) || s[i] == '.')) {
+        ++i;
+      }
+      if (i < n && (s[i] == 'e' || s[i] == 'E')) {
+        ++i;
+        if (i < n && (s[i] == '+' || s[i] == '-')) {
+          ++i;
+        }
+        while (i < n && IsDigit(s[i])) {
+          ++i;
+        }
+      }
+      if (i == numStart) {
+        return std::nullopt;  // not a number where one was expected
+      }
+
+      std::string token(s.substr(numStart, i - numStart));
+      double value = 0.0;
+      const char* begin = token.c_str();
+      char* end = nullptr;
+      value = std::strtod(begin, &end);
+      if (end != begin + token.size()) {
+        return std::nullopt;
+      }
+      fn.args.push_back(Arg{value, std::move(token)});
+
+      // Consume separators (commas and/or whitespace) between arguments.
+      bool sawComma = false;
+      while (i < n && (IsSpace(s[i]) || s[i] == ',')) {
+        if (s[i] == ',') {
+          if (sawComma) {
+            return std::nullopt;  // two commas in a row
+          }
+          sawComma = true;
+          fn.usesComma = true;
+        }
+        ++i;
+      }
+    }
+
+    if (i >= n) {
+      return std::nullopt;  // missing ')'
+    }
+    ++i;  // consume ')'
+    skipSpace();
+    fns.push_back(std::move(fn));
+  }
+
+  if (fns.empty()) {
+    return std::nullopt;
+  }
+  return fns;
+}
+
+std::string FormatEditedNumber(double value) {
+  // Kill floating-point noise beyond six decimals (edits never need finer than
+  // that) so a computed 60.000000000000004 serializes as "60" rather than a
+  // long decimal, while keeping the value well within the verify tolerance.
+  double rounded = std::round(value * 1e6) / 1e6;
+  if (rounded == 0.0) {
+    rounded = 0.0;  // normalize away -0.0
+  }
+  return detail::FormatNumberForSVG(rounded);
+}
+
+/// Assign @p value to argument @p index, keeping the author's verbatim token
+/// when the value is unchanged.
+void SetArg(Fn& fn, std::size_t index, double value) {
+  if (std::abs(value - fn.args[index].value) < kUnchangedEps) {
+    return;
+  }
+  fn.args[index].value = value;
+  fn.args[index].text = FormatEditedNumber(value);
+}
+
+std::string RenderFn(const Fn& fn) {
+  std::string out = fn.name;
+  out += '(';
+  const char* sep = fn.usesComma ? ", " : " ";
+  for (std::size_t k = 0; k < fn.args.size(); ++k) {
+    if (k != 0) {
+      out += sep;
+    }
+    out += fn.args[k].text;
+  }
+  out += ')';
+  return out;
+}
+
+std::string RenderList(const std::vector<Fn>& fns) {
+  std::string out;
+  for (std::size_t k = 0; k < fns.size(); ++k) {
+    if (k != 0) {
+      out += ' ';
+    }
+    out += RenderFn(fns[k]);
+  }
+  return out;
+}
+
+/// Standard matrix product `A * B` (Donner's `operator*` post-multiplies, so
+/// `B * A` yields the conventional product).
+Transform2d StandardMul(const Transform2d& a, const Transform2d& b) {
+  return b * a;
+}
+
+/// Scale-rotate-translate view of a matrix. Mirrors the inspector's
+/// DecomposeTransform: returns `std::nullopt` for skewed or singular matrices.
+struct Decomposed {
+  Vector2d translation;
+  double rotationRadians = 0.0;
+  Vector2d scale;
+};
+
+std::optional<Decomposed> Decompose(const Transform2d& t) {
+  const double a = t.data[0];
+  const double b = t.data[1];
+  const double c = t.data[2];
+  const double d = t.data[3];
+
+  const double scaleX = std::hypot(a, b);
+  constexpr double kSingularEpsilon = 1e-12;
+  if (!(scaleX > kSingularEpsilon) || !std::isfinite(scaleX)) {
+    return std::nullopt;
+  }
+
+  const double columnDot = a * c + b * d;
+  const double columnYNorm = std::hypot(c, d);
+  constexpr double kSkewTolerance = 1e-6;
+  if (columnYNorm > 0.0 && std::abs(columnDot) > kSkewTolerance * scaleX * columnYNorm) {
+    return std::nullopt;
+  }
+
+  Decomposed result;
+  result.translation = Vector2d(t.data[4], t.data[5]);
+  result.rotationRadians = std::atan2(b, a);
+  result.scale = Vector2d(scaleX, (a * d - b * c) / scaleX);
+  return result;
+}
+
+double NormalizeRadians(double r) {
+  constexpr double kPi = MathConstants<double>::kPi;
+  while (r > kPi) {
+    r -= 2.0 * kPi;
+  }
+  while (r <= -kPi) {
+    r += 2.0 * kPi;
+  }
+  return r;
+}
+
+bool TransformsClose(const Transform2d& a, const Transform2d& b) {
+  for (int k = 0; k < 6; ++k) {
+    const double diff = std::abs(a.data[k] - b.data[k]);
+    const double magnitude = std::max(std::abs(a.data[k]), std::abs(b.data[k]));
+    if (diff > 1e-3 + 1e-4 * magnitude) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/// Verify a candidate string re-parses to @p target.
+bool Verify(const std::string& candidate, const Transform2d& target) {
+  auto parsed = svg::parser::TransformParser::Parse(candidate);
+  if (parsed.hasError()) {
+    return false;
+  }
+  return TransformsClose(parsed.result(), target);
+}
+
+Transform2d MatrixOf(const std::vector<Fn>& fns) {
+  if (fns.empty()) {
+    return Transform2d();  // identity
+  }
+  auto parsed = svg::parser::TransformParser::Parse(RenderList(fns));
+  if (parsed.hasError()) {
+    return Transform2d();
+  }
+  return parsed.result();
+}
+
+/// Structured translate/scale/rotate update. @p fns is taken by value because
+/// it mutates the function tokens. Returns the author-form string on success.
+std::optional<RcString> TryStructuredUpdate(std::vector<Fn> fns, const Transform2d& m,
+                                            const Transform2d& target) {
+  int translateIdx = -1;
+  int scaleIdx = -1;
+  int rotateIdx = -1;
+  int nTranslate = 0;
+  int nScale = 0;
+  int nRotate = 0;
+  for (std::size_t k = 0; k < fns.size(); ++k) {
+    const std::string& name = fns[k].name;
+    if (name == "translate") {
+      ++nTranslate;
+      translateIdx = static_cast<int>(k);
+    } else if (name == "scale") {
+      ++nScale;
+      scaleIdx = static_cast<int>(k);
+    } else if (name == "rotate") {
+      ++nRotate;
+      rotateIdx = static_cast<int>(k);
+    } else {
+      // matrix()/skewX()/skewY()/unknown: not handled by this path.
+      return std::nullopt;
+    }
+  }
+  if (nTranslate > 1 || nScale > 1 || nRotate > 1) {
+    return std::nullopt;
+  }
+
+  const std::optional<Decomposed> dt = Decompose(target);
+  const std::optional<Decomposed> dm = Decompose(m);
+  if (!dt.has_value() || !dm.has_value()) {
+    return std::nullopt;
+  }
+
+  const double dScaleX = dt->scale.x / dm->scale.x;
+  const double dScaleY = dt->scale.y / dm->scale.y;
+  const double dRot = NormalizeRadians(dt->rotationRadians - dm->rotationRadians);
+
+  const bool rotChanged = std::abs(dRot) > kAngleEps;
+  const bool scaleChanged =
+      std::abs(dScaleX - 1.0) > kScaleEps || std::abs(dScaleY - 1.0) > kScaleEps;
+
+  if (rotChanged && nRotate == 0) {
+    return std::nullopt;
+  }
+  if (scaleChanged && nScale == 0) {
+    return std::nullopt;
+  }
+
+  if (nRotate == 1) {
+    Fn& rf = fns[static_cast<std::size_t>(rotateIdx)];
+    if (rf.args.empty() || (rf.args.size() != 1 && rf.args.size() != 3)) {
+      return std::nullopt;
+    }
+    SetArg(rf, 0, rf.args[0].value + dRot * MathConstants<double>::kRadToDeg);
+    // Center arguments (if present) are left as-authored; the translate solve
+    // and final verify catch any center mismatch.
+  }
+
+  if (nScale == 1) {
+    Fn& sf = fns[static_cast<std::size_t>(scaleIdx)];
+    if (sf.args.size() == 1) {
+      const double base = sf.args[0].value;
+      const double nx = base * dScaleX;
+      const double ny = base * dScaleY;
+      if (std::abs(nx - ny) < kUnchangedEps) {
+        SetArg(sf, 0, nx);
+      } else {
+        sf.args[0] = Arg{nx, FormatEditedNumber(nx)};
+        sf.args.push_back(Arg{ny, FormatEditedNumber(ny)});
+      }
+    } else if (sf.args.size() == 2) {
+      SetArg(sf, 0, sf.args[0].value * dScaleX);
+      SetArg(sf, 1, sf.args[1].value * dScaleY);
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  if (nTranslate == 1) {
+    const std::vector<Fn> prefix(fns.begin(), fns.begin() + translateIdx);
+    const std::vector<Fn> suffix(fns.begin() + translateIdx + 1, fns.end());
+    const Transform2d mp = MatrixOf(prefix);
+    const Transform2d ms = MatrixOf(suffix);
+    // Solve mp * T * ms == target for the pure-translation T.
+    const Transform2d tmat = StandardMul(StandardMul(mp.inverse(), target), ms.inverse());
+    if (std::abs(tmat.data[0] - 1.0) > kMatrixEps || std::abs(tmat.data[1]) > kMatrixEps ||
+        std::abs(tmat.data[2]) > kMatrixEps || std::abs(tmat.data[3] - 1.0) > kMatrixEps) {
+      return std::nullopt;
+    }
+    const double tx = tmat.data[4];
+    const double ty = tmat.data[5];
+    Fn& tf = fns[static_cast<std::size_t>(translateIdx)];
+    if (tf.args.size() == 1) {
+      if (std::abs(ty) < kUnchangedEps) {
+        SetArg(tf, 0, tx);
+      } else {
+        tf.args[0] = Arg{tx, FormatEditedNumber(tx)};
+        tf.args.push_back(Arg{ty, FormatEditedNumber(ty)});
+      }
+    } else if (tf.args.size() == 2) {
+      SetArg(tf, 0, tx);
+      SetArg(tf, 1, ty);
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  std::string candidate = RenderList(fns);
+  if (Verify(candidate, target)) {
+    return RcString(candidate);
+  }
+  return std::nullopt;
+}
+
+/// Rotate-only fallback: express @p target as a rotation, adding explicit center
+/// arguments when the rotation is about a non-origin point. Handles the case a
+/// rotate-only element is rotated about its bounds center (which the structured
+/// path rejects because the resulting matrix carries a translation).
+std::optional<RcString> TryRotateOnly(const Fn& rf, const Transform2d& target) {
+  if (rf.args.size() != 1 && rf.args.size() != 3) {
+    return std::nullopt;
+  }
+  const std::optional<Decomposed> dt = Decompose(target);
+  if (!dt.has_value()) {
+    return std::nullopt;
+  }
+  // Must be a proper rigid rotation: unit scale on both axes, no reflection.
+  if (std::abs(dt->scale.x - 1.0) > 1e-6 || std::abs(dt->scale.y - 1.0) > 1e-6) {
+    return std::nullopt;
+  }
+
+  const double thetaDeg = dt->rotationRadians * MathConstants<double>::kRadToDeg;
+  const double tx = target.data[4];
+  const double ty = target.data[5];
+
+  Fn out;
+  out.name = "rotate";
+  out.usesComma = rf.usesComma;
+
+  auto angleToken = [&]() -> Arg {
+    if (std::abs(thetaDeg - rf.args[0].value) < kUnchangedEps) {
+      return rf.args[0];  // unchanged: keep verbatim
+    }
+    return Arg{thetaDeg, FormatEditedNumber(thetaDeg)};
+  };
+
+  if (std::abs(tx) < kMatrixEps && std::abs(ty) < kMatrixEps) {
+    out.args.push_back(angleToken());
+  } else {
+    const double cos = std::cos(dt->rotationRadians);
+    const double sin = std::sin(dt->rotationRadians);
+    const double det = (1.0 - cos) * (1.0 - cos) + sin * sin;  // = 2(1 - cos)
+    if (std::abs(det) < 1e-12) {
+      return std::nullopt;
+    }
+    // c = (I - R)^{-1} t, with R the standard rotation by theta.
+    const double cx = ((1.0 - cos) * tx - sin * ty) / det;
+    const double cy = (sin * tx + (1.0 - cos) * ty) / det;
+
+    out.usesComma = true;  // three-argument rotate reads best comma-separated.
+    out.args.push_back(angleToken());
+    if (rf.args.size() == 3 && std::abs(rf.args[1].value - cx) < kUnchangedEps &&
+        std::abs(rf.args[2].value - cy) < kUnchangedEps) {
+      out.args.push_back(rf.args[1]);
+      out.args.push_back(rf.args[2]);
+    } else {
+      out.args.push_back(Arg{cx, FormatEditedNumber(cx)});
+      out.args.push_back(Arg{cy, FormatEditedNumber(cy)});
+    }
+  }
+
+  std::string candidate = RenderFn(out);
+  if (Verify(candidate, target)) {
+    return RcString(candidate);
+  }
+  return std::nullopt;
+}
+
+}  // namespace
+
+std::optional<RcString> reserializeTransformPreservingSyntax(std::string_view authorSource,
+                                                             const Transform2d& target) {
+  std::optional<std::vector<Fn>> parsed = ParseFunctionList(authorSource);
+  if (!parsed.has_value()) {
+    return std::nullopt;
+  }
+  std::vector<Fn>& fns = *parsed;
+
+  auto mResult = svg::parser::TransformParser::Parse(authorSource);
+  if (mResult.hasError()) {
+    return std::nullopt;
+  }
+  const Transform2d m = mResult.result();
+
+  // A matrix() author stays matrix(): update the six entries in place.
+  if (fns.size() == 1 && fns[0].name == "matrix" && fns[0].args.size() == 6) {
+    for (int k = 0; k < 6; ++k) {
+      SetArg(fns[0], static_cast<std::size_t>(k), target.data[k]);
+    }
+    std::string candidate = RenderList(fns);
+    if (Verify(candidate, target)) {
+      return RcString(candidate);
+    }
+    return std::nullopt;
+  }
+
+  if (auto structured = TryStructuredUpdate(fns, m, target)) {
+    return structured;
+  }
+
+  // Rotate-only element rotated about a non-origin center: keep rotate() form.
+  if (fns.size() == 1 && fns[0].name == "rotate") {
+    if (auto rotated = TryRotateOnly(fns[0], target)) {
+      return rotated;
+    }
+  }
+
+  return std::nullopt;
+}
+
+RcString serializeTransformForWriteback(const std::optional<RcString>& authorSource,
+                                        const Transform2d& target) {
+  // Identity clears the attribute; never resurrect an author form for it.
+  if (target.isIdentity()) {
+    return toSVGTransformString(target);
+  }
+  if (authorSource.has_value() && !std::string_view(*authorSource).empty()) {
+    if (auto preserved =
+            reserializeTransformPreservingSyntax(std::string_view(*authorSource), target)) {
+      return *preserved;
+    }
+  }
+  return toSVGTransformString(target);
+}
+
+}  // namespace donner::editor

--- a/donner/editor/TransformSyntaxPreserving.h
+++ b/donner/editor/TransformSyntaxPreserving.h
@@ -1,0 +1,41 @@
+#pragma once
+/// @file
+///
+/// Transform `transform=` writeback that preserves the author's chosen function
+/// syntax. Forward transform edits (inspector fields and canvas drags) used to
+/// canonicalize every author form into `matrix(a,b,c,d,e,f)` via
+/// \ref donner::toSVGTransformString. This module re-expresses an edited
+/// \ref Transform2d in the author's original function list where the edit is
+/// representable as an update to that list (a rotation change on `rotate(45)`
+/// writes `rotate(60)`, a move updates `translate(x, y)`, and so on), falling
+/// back to `matrix()` only when the edit cannot be represented in the author's
+/// structure.
+
+#include <optional>
+#include <string_view>
+
+#include "donner/base/RcString.h"
+#include "donner/base/Transform.h"
+
+namespace donner::editor {
+
+/// Attempt to re-serialize @p target into the author's function-list syntax
+/// parsed from @p authorSource.
+///
+/// Returns the author-form string (e.g. `rotate(60)`) when the edit is
+/// expressible as a parameter update to the author's transform functions, or
+/// `std::nullopt` when it is not (a decomposed rotation change against a skew
+/// matrix, a move on a rotate-only element, etc.). The returned string always
+/// re-parses to @p target within a tight tolerance; callers that receive
+/// `std::nullopt` should emit `toSVGTransformString(target)`.
+[[nodiscard]] std::optional<RcString> reserializeTransformPreservingSyntax(
+    std::string_view authorSource, const Transform2d& target);
+
+/// Serialize @p target for a `transform=` writeback, preserving the author's
+/// syntax from @p authorSource where possible and otherwise emitting the
+/// canonical \ref donner::toSVGTransformString form. An empty result means the
+/// attribute should be removed (the transform is the identity).
+[[nodiscard]] RcString serializeTransformForWriteback(const std::optional<RcString>& authorSource,
+                                                      const Transform2d& target);
+
+}  // namespace donner::editor

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -166,6 +166,17 @@ donner_cc_test(
 )
 
 donner_cc_test(
+    name = "transform_syntax_preserving_tests",
+    srcs = ["TransformSyntaxPreserving_tests.cc"],
+    deps = [
+        "//donner/base",
+        "//donner/editor:transform_syntax_preserving",
+        "//donner/svg/parser",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
     name = "document_sync_controller_tests",
     srcs = ["DocumentSyncController_tests.cc"],
     deps = [

--- a/donner/editor/tests/DocumentSyncController_tests.cc
+++ b/donner/editor/tests/DocumentSyncController_tests.cc
@@ -1364,9 +1364,12 @@ TEST(DocumentSyncControllerStructuredTest, MirrorSourceDeltasFallsBackWhenInsert
   textEditor.resetTextChanged();
   DocumentSyncController controller{std::string(kTwoRectSvg)};
 
-  const std::size_t closeOffset = textEditor.getText().find("</svg>");
-  ASSERT_NE(closeOffset, std::string::npos);
-  textEditor.setSelection(textEditor.getCoordinatesAtByteOffset(closeOffset - 1),
+  // The append lands on its own line right after the last child, so delete that whole tail
+  // locally (the last <rect> through </svg>). The insertion context is now gone, and the
+  // mirror must fall back to a full resync rather than patch into a stale offset.
+  const std::size_t lastRectOffset = textEditor.getText().rfind("<rect");
+  ASSERT_NE(lastRectOffset, std::string::npos);
+  textEditor.setSelection(textEditor.getCoordinatesAtByteOffset(lastRectOffset),
                           textEditor.getCoordinatesAtByteOffset(textEditor.getText().size()));
   textEditor.insertText("");
   textEditor.resetTextChanged();

--- a/donner/editor/tests/DocumentSyncController_tests.cc
+++ b/donner/editor/tests/DocumentSyncController_tests.cc
@@ -7,6 +7,8 @@
 #include <string>
 #include <utility>
 
+#include "donner/base/MathUtils.h"
+#include "donner/base/Transform.h"
 #include "donner/editor/AttributeWriteback.h"
 #include "donner/editor/EditorApp.h"
 #include "donner/editor/EditorCommand.h"
@@ -287,6 +289,60 @@ TEST_F(DocumentSyncControllerTest, SourceBackedDragWritebackExtendsSelectedSourc
   EXPECT_NE(selectedText.find("transform=\"translate(10)\""), std::string::npos);
   EXPECT_TRUE(selectedText.ends_with("/>")) << selectedText;
   EXPECT_EQ(textEditor_.getCursorPosition(), textEditor_.getCoordinatesAtByteOffset(rectStart));
+}
+
+TEST_F(DocumentSyncControllerTest, ForwardWritebackPreservesAuthorSyntaxAndUndoRestoresBytes) {
+  // A forward transform edit on an authored rotate(45) must rewrite the source
+  // as rotate(60) (author form), not canonicalize to matrix(); a subsequent
+  // verbatim restore must return the exact original bytes.
+  constexpr std::string_view kSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+         <rect id="r1" x="0" y="0" width="10" height="10" transform="rotate(45)"/>
+       </svg>)svg";
+
+  EditorApp app;
+  TextEditor textEditor;
+  SelectTool tool;
+  DocumentSyncController controller{std::string(kSvg)};
+
+  ASSERT_TRUE(app.loadFromString(kSvg));
+  app.setCurrentFilePath("test.svg");
+  app.setCleanSourceText(kSvg);
+  textEditor.setText(kSvg);
+  textEditor.resetTextChanged();
+
+  auto r1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(r1.has_value());
+  auto r1Target = captureAttributeWritebackTarget(*r1);
+  ASSERT_TRUE(r1Target.has_value());
+
+  // Forward edit: rotate(45) -> rotate(60), carrying the author's bytes.
+  app.enqueueTransformWriteback(EditorApp::CompletedTransformWriteback{
+      .target = *r1Target,
+      .transform = Transform2d::Rotate(60.0 * MathConstants<double>::kDegToRad),
+      .sourceTransformAttributeValue = RcString("rotate(45)"),
+  });
+  controller.applyPendingWritebacks(app, tool, textEditor);
+
+  r1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(r1.has_value());
+  EXPECT_EQ(r1->getAttribute("transform"), std::optional<RcString>(RcString("rotate(60)")));
+  EXPECT_EQ(textEditor.getText().find("matrix("), std::string::npos);
+  EXPECT_NE(textEditor.getText().find("transform=\"rotate(60)\""), std::string::npos);
+
+  // Verbatim restore (the undo path): exact original bytes come back.
+  app.enqueueTransformWriteback(EditorApp::CompletedTransformWriteback{
+      .target = *r1Target,
+      .transform = Transform2d::Rotate(45.0 * MathConstants<double>::kDegToRad),
+      .sourceTransformAttributeValue = RcString("rotate(45)"),
+      .restoreSourceTransformAttributeValue = true,
+  });
+  controller.applyPendingWritebacks(app, tool, textEditor);
+
+  r1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(r1.has_value());
+  EXPECT_EQ(r1->getAttribute("transform"), std::optional<RcString>(RcString("rotate(45)")));
+  EXPECT_NE(textEditor.getText().find("transform=\"rotate(45)\""), std::string::npos);
 }
 
 TEST_F(DocumentSyncControllerTest, AppTransformWritebacksDrainAllQueuedEntries) {

--- a/donner/editor/tests/EditorApp_tests.cc
+++ b/donner/editor/tests/EditorApp_tests.cc
@@ -1754,6 +1754,41 @@ TEST(EditorAppReorderTest, SendToBackMovesElementToFirst) {
   EXPECT_THAT(ChildIds(app), ::testing::ElementsAre("r3", "r1", "r2"));
 }
 
+TEST(EditorAppReorderTest, ReorderIsOneUndoEntryAndUndoRestoresExactSourceBytes) {
+  // A cleanly-indented document: after the reorder the moved element must land on its own
+  // indented line (no orphaned blank line), and a single undo must restore the exact prior
+  // bytes. loadFromString clears the undo timeline, so the reorder is the only entry.
+  constexpr std::string_view kIndentedThreeRects =
+      "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"100\" height=\"100\">\n"
+      "  <rect id=\"r1\" x=\"0\" y=\"0\" width=\"10\" height=\"10\"/>\n"
+      "  <rect id=\"r2\" x=\"10\" y=\"0\" width=\"10\" height=\"10\"/>\n"
+      "  <rect id=\"r3\" x=\"20\" y=\"0\" width=\"10\" height=\"10\"/>\n"
+      "</svg>";
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(std::string(kIndentedThreeRects)));
+  const std::string before(app.document().document().source());
+  EXPECT_FALSE(app.canUndo());
+
+  SelectById(app, "r1");
+  EXPECT_TRUE(app.reorderSelectedElement(EditorApp::ZOrder::BringToFront));
+  ASSERT_TRUE(app.flushFrame());
+
+  EXPECT_EQ(std::string(app.document().document().source()),
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"100\" height=\"100\">\n"
+            "  <rect id=\"r2\" x=\"10\" y=\"0\" width=\"10\" height=\"10\"/>\n"
+            "  <rect id=\"r3\" x=\"20\" y=\"0\" width=\"10\" height=\"10\"/>\n"
+            "  <rect id=\"r1\" x=\"0\" y=\"0\" width=\"10\" height=\"10\"/>\n"
+            "</svg>");
+
+  ASSERT_TRUE(app.canUndo());
+  app.undo();
+  ASSERT_TRUE(app.flushFrame());
+
+  EXPECT_EQ(std::string(app.document().document().source()), before);
+  EXPECT_FALSE(app.canUndo()) << "a reorder must be a single undo entry";
+  EXPECT_TRUE(app.canRedo());
+}
+
 TEST(EditorAppReorderTest, ReflectsTheMoveIntoTheSourceText) {
   EditorApp app;
   ASSERT_TRUE(app.loadFromString(std::string(kThreeRects)));

--- a/donner/editor/tests/EditorApp_tests.cc
+++ b/donner/editor/tests/EditorApp_tests.cc
@@ -543,6 +543,58 @@ TEST(EditorAppTest, VisibilityAndLockTogglesBypassLockGate) {
   EXPECT_FALSE(r1->getAttribute(kLockedAttributeName).has_value());
 }
 
+// Hiding an element with an authored non-`none` `display` value (e.g.
+// `display="block"`) must not clobber it: showing again should restore the
+// author's exact value rather than forcing `display="inline"`.
+TEST(EditorAppTest, SetElementVisibleRestoresAuthorDisplayValueOnShow) {
+  constexpr std::string_view kSvgWithBlockDisplay =
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+           <rect id="r1" x="10" y="10" width="20" height="20" fill="red" display="block"/>
+         </svg>)";
+
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kSvgWithBlockDisplay));
+
+  auto r1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(r1.has_value());
+  ASSERT_EQ(r1->getAttribute("display"), "block");
+
+  app.setElementVisible(*r1, false);
+  ASSERT_TRUE(app.flushFrame());
+  r1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(r1.has_value());
+  EXPECT_EQ(r1->getAttribute("display"), "none");
+
+  app.setElementVisible(*r1, true);
+  ASSERT_TRUE(app.flushFrame());
+  r1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(r1.has_value());
+  EXPECT_EQ(r1->getAttribute("display"), "block")
+      << "Show should restore the author's display=block instead of forcing display=inline";
+}
+
+// When the element had no author `display` value to begin with (the common
+// case), Show still falls back to writing a definitively-visible
+// `display="inline"` - covered already by
+// `VisibilityAndLockTogglesBypassLockGate` above. This test covers the other
+// fallback: showing an element that was never hidden through this toggle
+// (no captured entry at all, e.g. a fresh element or a second, redundant Show
+// call) still lands on `display="inline"` rather than crashing or no-oping.
+TEST(EditorAppTest, SetElementVisibleShowWithoutPriorHideWritesInline) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kTrivialSvg));
+
+  auto r1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(r1.has_value());
+  ASSERT_FALSE(r1->getAttribute("display").has_value());
+
+  app.setElementVisible(*r1, true);
+  ASSERT_TRUE(app.flushFrame());
+  r1 = app.document().document().querySelector("#r1");
+  ASSERT_TRUE(r1.has_value());
+  EXPECT_EQ(r1->getAttribute("display"), "inline");
+}
+
 TEST(EditorAppTest, SetStylePropertyOnSelectionMergesIntoStyleAttribute) {
   constexpr std::string_view kStyledSvg =
       R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">

--- a/donner/editor/tests/EditorSync_tests.cc
+++ b/donner/editor/tests/EditorSync_tests.cc
@@ -1170,31 +1170,13 @@ TEST(EditorSyncTest, SelectionClearsAndDisplayedBoundsClearWhenElementDisappears
 // rehydration (matching the snapshot's `writebackTarget` against the
 // current DOM), the undo silently does nothing or crashes.
 //
-// This test documents the invariant. If undo can't rehydrate across
-// a reparse, either the test skips with a clear explanation (known
-// gap) OR - ideally - the undo replays against a freshly-queried
-// element by id/path.
+// This test documents the invariant. `EditorApp::undo` rehydrates a stale
+// `UndoSnapshot::element` by resolving `snapshot.writebackTarget` against the
+// live post-reparse document (see `ResolveSnapshotElement` in EditorApp.cc)
+// before replaying the transform, so the drag survives the reparse. This is
+// the same rehydration story as `SelectionRemapsByIdAcrossStructuralSourceEdit`,
+// but for the undo timeline instead of the selection.
 TEST(EditorSyncTest, DragThenSourceEditThenUndoReplaysAgainstFreshlyParsedElement) {
-  // Known gap (documented before we even start the test body, because
-  // the failing path triggers a hard EnTT assertion in `fast_mod` -
-  // the undo snapshot holds an `SVGElement` whose `EntityHandle` points
-  // into the pre-reparse registry, and any access after the reparse
-  // trips the "power of two" assertion deep inside EnTT's storage.
-  // That crash isn't skippable mid-flow, so document the gap up front
-  // and have the fix flip the `if (true)` below to `if (false)` once
-  // `UndoSnapshot` rehydration across `ReplaceDocumentCommand` lands.
-  //
-  // The fix belongs in `EditorApp::undo`: when an `UndoSnapshot` has
-  // a `writebackTarget`, resolve that against the live document and
-  // rebind `snapshot.element` before calling `applySnapshot`. This is
-  // the same rehydration story as `SelectionRemapsByIdAcrossStructuralSourceEdit`,
-  // but for the undo timeline instead of the selection.
-  if (true) {
-    GTEST_SKIP() << "Known gap: `EditorApp::undo` dereferences a stale `SVGElement` "
-                    "handle after `ReplaceDocumentCommand` reparse. Needs snapshot "
-                    "rehydration via `writebackTarget` before apply. Design 0026 B3.";
-  }
-
   constexpr std::string_view kSvg = R"svg(<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
   <rect id="r" x="10" y="10" width="20" height="20" fill="red"/>

--- a/donner/editor/tests/EditorSync_tests.cc
+++ b/donner/editor/tests/EditorSync_tests.cc
@@ -1223,5 +1223,61 @@ TEST(EditorSyncTest, DragThenSourceEditThenUndoReplaysAgainstFreshlyParsedElemen
       << "undo after source-pane reparse failed to roll back the drag - snapshot dangled";
 }
 
+// Companion to `DragThenSourceEditThenUndoReplaysAgainstFreshlyParsedElement`,
+// covering the failure side of rehydration: a structural edit (element
+// deletion) after the snapshot was captured means the snapshot's
+// `writebackTarget` can no longer resolve in the reparsed document.
+// `ApplyTimelineSnapshot`/`ResolveSnapshotElement` in EditorApp.cc must skip
+// this entry gracefully - it must NOT fall back to dereferencing the stale
+// pre-reparse `snapshot.element` (which would otherwise risk applying a
+// mutation, or computing a writeback target, against an orphaned document
+// disconnected from what the user is looking at).
+TEST(EditorSyncTest, UndoSkipsGracefullyWhenSnapshotTargetNoLongerResolvesAfterReparse) {
+  constexpr std::string_view kSvg = R"svg(<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect id="r" x="10" y="10" width="20" height="20" fill="red"/>
+</svg>
+)svg";
+
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kSvg));
+  app.setCleanSourceText(kSvg);
+
+  auto rect = app.document().document().querySelector("#r");
+  ASSERT_TRUE(rect.has_value());
+
+  const Transform2d before = Transform2d();
+  const Transform2d after = Transform2d::Translate(Vector2d(25.0, 0.0));
+  rect->cast<svg::SVGGraphicsElement>().setTransform(after);
+  UndoSnapshot beforeSnapshot{.element = *rect,
+                              .transform = before,
+                              .writebackTarget = captureAttributeWritebackTarget(*rect)};
+  UndoSnapshot afterSnapshot{.element = *rect,
+                             .transform = after,
+                             .writebackTarget = captureAttributeWritebackTarget(*rect)};
+  ASSERT_TRUE(beforeSnapshot.writebackTarget.has_value());
+  app.undoTimeline().record("Drag r", std::move(beforeSnapshot), std::move(afterSnapshot));
+
+  ASSERT_TRUE(app.canUndo());
+
+  // Structural edit deletes `#r` entirely - the writeback target this undo
+  // entry captured can never resolve again.
+  constexpr std::string_view kSvgAfterDelete = R"svg(<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+</svg>
+)svg";
+  app.applyMutation(EditorCommand::ReplaceDocumentCommand(std::string(kSvgAfterDelete),
+                                                          /*preserveUndoOnReparse=*/true));
+  ASSERT_TRUE(app.flushFrame());
+
+  // Must not crash, and must not resurrect `#r` or otherwise touch the live
+  // (now-empty) document - the entry is skipped as unresolvable, so nothing
+  // is queued and this is a no-op flush.
+  app.undo();
+  EXPECT_FALSE(app.flushFrame());
+
+  EXPECT_FALSE(app.document().document().querySelector("#r").has_value());
+}
+
 }  // namespace
 }  // namespace donner::editor

--- a/donner/editor/tests/LayerTreeModel_tests.cc
+++ b/donner/editor/tests/LayerTreeModel_tests.cc
@@ -349,6 +349,46 @@ TEST(LayerTreeModelTest, VisibilityFlagsReflectDisplayAndVisibilityProperties) {
   EXPECT_TRUE(visible->isVisible);
 }
 
+// The Layers panel eye toggle (`EditorApp::setElementVisible`) reads and
+// writes the `display` presentation attribute directly, not the cascaded
+// computed style. This covers both ends of that pairing:
+//  - An element hidden purely via a stylesheet rule (no local `display`
+//    attribute at all) still shows a closed eye through the computed-style
+//    fallback.
+//  - After the eye toggles Show (writing a local `display="inline"`
+//    override), the eye reflects that local override rather than lagging
+//    behind whatever the stylesheet rule would otherwise compute.
+TEST(LayerTreeModelTest, EyeStateMatchesToggleForCssHiddenElement) {
+  constexpr std::string_view kCssHiddenSvg =
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <style>.cssHidden { display: none; }</style>
+  <rect id="target" class="cssHidden" x="0" y="0" width="10" height="10"/>
+</svg>)";
+
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kCssHiddenSvg));
+
+  LayerTreeModel model;
+  model.refresh(app);
+
+  const LayerTreeRow* target = FindRow(model, "target");
+  ASSERT_NE(target, nullptr);
+  EXPECT_FALSE(target->isVisible)
+      << "element hidden purely via a stylesheet rule should still read as hidden";
+
+  auto element = app.document().document().querySelector("#target");
+  ASSERT_TRUE(element.has_value());
+  app.setElementVisible(*element, /*visible=*/true);
+  ASSERT_TRUE(app.flushFrame());
+
+  model.refresh(app);
+  target = FindRow(model, "target");
+  ASSERT_NE(target, nullptr);
+  EXPECT_TRUE(target->isVisible)
+      << "eye state must match what the toggle just wrote (a local display override), not "
+         "whatever the stylesheet rule would otherwise compute";
+}
+
 TEST(LayerTreeModelTest, LockedRowsReflectAncestorLockState) {
   EditorApp app;
   ASSERT_TRUE(app.loadFromString(kLockedRowsSvg));

--- a/donner/editor/tests/TransformSyntaxPreserving_tests.cc
+++ b/donner/editor/tests/TransformSyntaxPreserving_tests.cc
@@ -1,0 +1,206 @@
+#include "donner/editor/TransformSyntaxPreserving.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+#include <string_view>
+
+#include "donner/base/MathUtils.h"
+#include "donner/base/Transform.h"
+#include "donner/svg/parser/TransformParser.h"
+
+namespace donner::editor {
+namespace {
+
+using ::testing::Optional;
+
+constexpr double kDeg = MathConstants<double>::kDegToRad;
+
+/// Parse a transform string into its matrix (helper for building targets that
+/// are, by construction, expressible in a given author form).
+Transform2d ParseMatrix(std::string_view s) {
+  auto result = svg::parser::TransformParser::Parse(s);
+  EXPECT_FALSE(result.hasError()) << "failed to parse target: " << s;
+  return result.result();
+}
+
+/// Assert @p candidate re-parses to @p target within tolerance.
+void ExpectRoundTrips(std::string_view candidate, const Transform2d& target) {
+  const Transform2d parsed = ParseMatrix(candidate);
+  for (int k = 0; k < 6; ++k) {
+    EXPECT_NEAR(parsed.data[k], target.data[k], 1e-3)
+        << "component " << k << " of '" << candidate << "'";
+  }
+}
+
+std::string Reserialize(std::string_view author, const Transform2d& target) {
+  auto result = reserializeTransformPreservingSyntax(author, target);
+  EXPECT_TRUE(result.has_value()) << "expected preservation for author '" << author << "'";
+  return result.has_value() ? std::string(std::string_view(*result)) : std::string();
+}
+
+// --- rotate-only ----------------------------------------------------------
+
+TEST(TransformSyntaxPreserving, RotateOnlyKeepsRotateAtOrigin) {
+  const Transform2d target = Transform2d::Rotate(60.0 * kDeg);
+  EXPECT_EQ(Reserialize("rotate(45)", target), "rotate(60)");
+}
+
+TEST(TransformSyntaxPreserving, RotateOnlySnapsAwayFloatingPointNoise) {
+  // A target composed from two rotations carries fp noise; the emitted angle
+  // must still be the clean "60", not "60.00000000001".
+  const Transform2d target = Transform2d::Rotate(45.0 * kDeg) * Transform2d::Rotate(15.0 * kDeg);
+  EXPECT_EQ(Reserialize("rotate(45)", target), "rotate(60)");
+}
+
+TEST(TransformSyntaxPreserving, RotateOnlyAboutCenterGainsCenterArgs) {
+  const Transform2d target = ParseMatrix("rotate(60, 10, 10)");
+  const std::string out = Reserialize("rotate(45)", target);
+  EXPECT_EQ(out, "rotate(60, 10, 10)");
+  ExpectRoundTrips(out, target);
+}
+
+TEST(TransformSyntaxPreserving, RotateWithCenterArgsPreservesCenter) {
+  // Editing the angle of an authored rotate(a, cx, cy) about the same center
+  // keeps the center arguments and only bumps the angle.
+  const Transform2d target = ParseMatrix("rotate(50, 30, 40)");
+  const std::string out = Reserialize("rotate(20, 30, 40)", target);
+  EXPECT_THAT(out, ::testing::StartsWith("rotate("));
+  EXPECT_THAT(out, ::testing::HasSubstr("30"));
+  EXPECT_THAT(out, ::testing::HasSubstr("40"));
+  EXPECT_THAT(out, ::testing::Not(::testing::HasSubstr("matrix")));
+  ExpectRoundTrips(out, target);
+}
+
+// --- translate-only -------------------------------------------------------
+
+TEST(TransformSyntaxPreserving, TranslateTwoArgUpdatesNumbers) {
+  const Transform2d target = Transform2d::Translate(Vector2d(15.0, 27.0));
+  EXPECT_EQ(Reserialize("translate(10, 20)", target), "translate(15, 27)");
+}
+
+TEST(TransformSyntaxPreserving, TranslateOneArgStaysOneArgWhenYZero) {
+  const Transform2d target = Transform2d::Translate(Vector2d(25.0, 0.0));
+  EXPECT_EQ(Reserialize("translate(10)", target), "translate(25)");
+}
+
+TEST(TransformSyntaxPreserving, TranslateOneArgExpandsWhenYChanges) {
+  const Transform2d target = Transform2d::Translate(Vector2d(25.0, 4.0));
+  const std::string out = Reserialize("translate(10)", target);
+  EXPECT_THAT(out, ::testing::StartsWith("translate("));
+  EXPECT_THAT(out, ::testing::Not(::testing::HasSubstr("matrix")));
+  ExpectRoundTrips(out, target);
+}
+
+TEST(TransformSyntaxPreserving, TranslateKeepsUnchangedTokenVerbatim) {
+  // Only x moved; the y token is re-emitted exactly as authored.
+  const Transform2d target = Transform2d::Translate(Vector2d(12.5, 20.0));
+  EXPECT_EQ(Reserialize("translate(10, 20)", target), "translate(12.5, 20)");
+}
+
+// --- scale ----------------------------------------------------------------
+
+TEST(TransformSyntaxPreserving, ScaleUniformStaysUniform) {
+  const Transform2d target = Transform2d::Scale(Vector2d(3.0, 3.0));
+  EXPECT_EQ(Reserialize("scale(2)", target), "scale(3)");
+}
+
+TEST(TransformSyntaxPreserving, ScaleUniformExpandsToTwoArgs) {
+  const Transform2d target = Transform2d::Scale(Vector2d(3.0, 2.0));
+  const std::string out = Reserialize("scale(2)", target);
+  EXPECT_THAT(out, ::testing::StartsWith("scale("));
+  EXPECT_THAT(out, ::testing::Not(::testing::HasSubstr("matrix")));
+  ExpectRoundTrips(out, target);
+}
+
+TEST(TransformSyntaxPreserving, ScaleTwoArgUpdatesBoth) {
+  const Transform2d target = Transform2d::Scale(Vector2d(4.0, 3.0));
+  EXPECT_EQ(Reserialize("scale(2, 3)", target), "scale(4, 3)");
+}
+
+// --- translate + rotate lists --------------------------------------------
+
+TEST(TransformSyntaxPreserving, TranslateRotateUpdatesRotationComponent) {
+  const Transform2d target = ParseMatrix("translate(10, 20) rotate(45)");
+  EXPECT_EQ(Reserialize("translate(10, 20) rotate(30)", target), "translate(10, 20) rotate(45)");
+}
+
+TEST(TransformSyntaxPreserving, TranslateRotateUpdatesTranslateComponent) {
+  const Transform2d target = ParseMatrix("translate(18, 27) rotate(30)");
+  EXPECT_EQ(Reserialize("translate(10, 20) rotate(30)", target), "translate(18, 27) rotate(30)");
+}
+
+TEST(TransformSyntaxPreserving, RotateTranslateListPreservesOrderAndForm) {
+  const Transform2d target = ParseMatrix("rotate(45) translate(5, 6)");
+  const std::string out = Reserialize("rotate(30) translate(5, 6)", target);
+  EXPECT_THAT(out, ::testing::StartsWith("rotate("));
+  EXPECT_THAT(out, ::testing::HasSubstr("translate("));
+  EXPECT_THAT(out, ::testing::Not(::testing::HasSubstr("matrix")));
+  ExpectRoundTrips(out, target);
+}
+
+// --- matrix stays matrix --------------------------------------------------
+
+TEST(TransformSyntaxPreserving, MatrixInputStaysMatrix) {
+  const Transform2d target = Transform2d::Translate(Vector2d(9.0, 6.0));
+  const std::string out = Reserialize("matrix(1, 0, 0, 1, 5, 6)", target);
+  EXPECT_THAT(out, ::testing::StartsWith("matrix("));
+  EXPECT_EQ(out, "matrix(1, 0, 0, 1, 9, 6)");
+}
+
+// --- fallbacks ------------------------------------------------------------
+
+TEST(TransformSyntaxPreserving, RotationChangeAgainstSkewFallsBack) {
+  // The design's canonical fallback: a decomposed rotation change against a
+  // skew matrix cannot be represented in the author's rotate() structure.
+  const Transform2d skewTarget = ParseMatrix("matrix(1, 0.5, 0.5, 1, 0, 0)");
+  EXPECT_FALSE(reserializeTransformPreservingSyntax("rotate(45)", skewTarget).has_value());
+}
+
+TEST(TransformSyntaxPreserving, SkewFunctionInAuthorListFallsBack) {
+  const Transform2d target = ParseMatrix("rotate(60) skewX(10)");
+  EXPECT_FALSE(reserializeTransformPreservingSyntax("rotate(45) skewX(10)", target).has_value());
+}
+
+TEST(TransformSyntaxPreserving, RotationIntroducedOnTranslateOnlyFallsBack) {
+  // translate(x, y) cannot absorb a new rotation component.
+  const Transform2d target = ParseMatrix("translate(10, 20) rotate(30)");
+  EXPECT_FALSE(reserializeTransformPreservingSyntax("translate(10, 20)", target).has_value());
+}
+
+TEST(TransformSyntaxPreserving, MalformedAuthorFallsBack) {
+  const Transform2d target = Transform2d::Translate(Vector2d(5.0, 0.0));
+  EXPECT_FALSE(reserializeTransformPreservingSyntax("not a transform", target).has_value());
+  EXPECT_FALSE(reserializeTransformPreservingSyntax("translate(", target).has_value());
+}
+
+// --- serializeTransformForWriteback wrapper -------------------------------
+
+TEST(TransformSyntaxPreserving, WrapperPrefersAuthorForm) {
+  const Transform2d target = Transform2d::Rotate(60.0 * kDeg);
+  EXPECT_EQ(std::string_view(serializeTransformForWriteback(RcString("rotate(45)"), target)),
+            "rotate(60)");
+}
+
+TEST(TransformSyntaxPreserving, WrapperFallsBackToCanonicalWithoutAuthorSource) {
+  const Transform2d target = Transform2d::Rotate(60.0 * kDeg);
+  // No author source: canonical serializer output.
+  EXPECT_EQ(std::string_view(serializeTransformForWriteback(std::nullopt, target)),
+            std::string_view(toSVGTransformString(target)));
+}
+
+TEST(TransformSyntaxPreserving, WrapperFallsBackToCanonicalOnSkew) {
+  const Transform2d skewTarget = ParseMatrix("matrix(1, 0.5, 0.5, 1, 0, 0)");
+  EXPECT_EQ(std::string_view(serializeTransformForWriteback(RcString("rotate(45)"), skewTarget)),
+            std::string_view(toSVGTransformString(skewTarget)));
+}
+
+TEST(TransformSyntaxPreserving, WrapperClearsAttributeOnIdentity) {
+  const Transform2d identity;
+  EXPECT_TRUE(
+      std::string_view(serializeTransformForWriteback(RcString("rotate(45)"), identity)).empty());
+}
+
+}  // namespace
+}  // namespace donner::editor


### PR DESCRIPTION
Grouped structured-editing packets (P1, P2, P5) merged onto `qa/polish-wave1`.

- P1: context-aware source-formatting indentation for structural insert/move in `XMLDocument`; append as a pure insertion after the last sibling, with source-formatting fidelity tests.
- P2: preserve authored transform syntax on forward writeback, with a syntax-preservation matrix and undo-bytes tests.
- P5: undo hardening: re-enable undo-across-reparse regression, skip undo entries whose rehydration target no longer resolves, preserve author display value across layers-panel hide/show.

gate: editor suite green except the known /tmp sandbox target; group branches merged cleanly with no conflicts.

Part of Design 0013 / Design 0017 (zettelkasten).

Depends on / bases on `qa/polish-wave1` (PR #782); merges the constituent packet branches, diff shown is these packets over wave-1.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
