### PR TITLE
Fix rules_python warning and gold-linker archive order

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,6 +27,16 @@ build --enable_platform_specific_config
 ## Build config
 ##
 
+# rules_python has deprecated implicitly creating empty __init__.py files in
+# the runfiles tree for py_binary/py_library/py_test targets (on by default
+# today, will flip in a future release). Opt in to the future default
+# repo-wide now: every py_binary/py_library/py_test in this repo (the
+# generated per-target _lint checks plus tools/* and build_defs/*) builds and
+# tests clean under this flag with no explicit __init__.py additions needed,
+# since none of these targets do package-relative imports across directory
+# boundaries. See https://github.com/bazel-contrib/rules_python/issues/2945.
+common --incompatible_default_to_explicit_init_py
+
 # Force clang to be the default compiler for all Bazel C/C++ actions.
 # Propagates CC/CXX so every action (including host tools) uses clang/clang++.
 build --action_env=CC=clang

--- a/build_defs/rules.bzl
+++ b/build_defs/rules.bzl
@@ -761,7 +761,13 @@ def _donner_perf_sensitive_cc_library_impl(ctx):
         )
 
         if linking_outputs.library_to_link != None:
-            linking_contexts.append(linking_context)
+            # Place this library's own archive BEFORE its deps (matching
+            # native cc_library semantics). Appending it after the deps puts
+            # the consumer archive later on the link line than its providers,
+            # which lld tolerates (backward references from archives) but
+            # single-pass GNU linkers (gold, bfd) reject with undefined
+            # references. Caught by the CI "Linker canary" step.
+            linking_contexts.insert(0, linking_context)
 
     cc_info = CcInfo(
         compilation_context = compilation_context,


### PR DESCRIPTION
Fixes two small but separate issues that surfaced during the CI sprint:

- Opt into the future rules_python default with `common --incompatible_default_to_explicit_init_py`, after validating that the repo's Python targets and generated lint tests do not need implicit `__init__.py` files.
- Fix the gold-linker canary regression exposed by the SMIL merge. `_donner_perf_sensitive_cc_library_impl` was appending a library's own linking context after its deps, which can put a consumer archive after provider archives on the link line. lld tolerates that backward reference, but single-pass GNU linkers such as gold do not. Inserting the library's linking context before its deps matches native `cc_library` link order.

Verification:

- `bazel build //tools:render_notice`: rules_python warning gone.
- `bazel build -- //...`: green on branch validation.
- `bazel build -c opt //donner/editor`: green.
- `bazel test -- //tools/... //build_defs/... //tools/mcp-servers/...`: 12/12 pass.
- `bazel test --test_tag_filters=lint,banned_patterns -- //...`: 395/395 pass.
- Gold-linker root cause validated by the link-order flip and a local canary build.
- GitHub CI: hosted `linux` has passed the linker canary on `f547c500d`.

Out of scope: the analysis-cache churn between operator `-c opt` runs and RE builds remains separate.