### PR TITLE
CI: PR lane under 15 minutes -- incremental PR coverage, bounded self-hosted tails

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,12 +1,27 @@
 name: Coverage
 
-# Runs coverage on: main merges, every PR push (so Codecov has data to
-# annotate the patch with), and on-demand via workflow_dispatch.
+# Runs coverage on: main merges (the Codecov baseline), PR pushes (INCREMENTAL:
+# only the changed code's affected targets, so Codecov can still patch-annotate),
+# and on-demand via workflow_dispatch.
 #
-# We previously dropped the pull_request trigger thinking Codecov could
-# patch-annotate without a PR-side run, but Codecov's patch-coverage signal
-# requires the PR head's own `coverage.dat` upload to compute "X% of changed
-# lines covered" against the main-branch baseline.
+# Codecov's patch-coverage signal ("X% of changed lines covered") requires the
+# PR head's own coverage upload measured against the main-branch baseline, so we
+# cannot simply drop the pull_request trigger. But the FULL instrumented re-run
+# on every PR was the single worst violator of the 15-minute PR CI budget: the
+# A 40-run CI speed profile measured it at ~21 min median with a 3.3 h tail,
+# ~99% of that being one instrumented re-run of tests CI already runs, whose
+# only unique output is the Codecov patch percentage.
+#
+# So PR coverage is scoped to the affected-target subset via the same bazel-diff
+# mechanism as CI (see determine-targets below); the patch annotation survives
+# on the subset that actually changed. When the diff cannot be scoped to a
+# genuine subset (infra-file changes, bazel-diff failure, missing/empty diff),
+# the reason resolves to a FULL //... target set: running that on a PR is exactly
+# the 21-min re-run we are eliminating, so the PR coverage jobs SKIP instead --
+# the main-push baseline already covers those lines. Only the affected subset
+# (fallback_reason == bazel_diff), the cheap smoke subset (coverage_smoke), and
+# the explicit ci:full-test opt-in still produce PR coverage. Future readers:
+# do not silently re-add a full instrumented PR coverage run.
 on:
   push:
     branches: [main]
@@ -275,7 +290,13 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     needs: determine-targets
-    if: ${{ github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && (needs.determine-targets.outputs.fallback_reason == 'full_test_label' || vars.SELFHOSTED_LINUX_RUNNER != 'true' || github.actor != 'jwmcglynn' || github.triggering_actor != 'jwmcglynn')) }}
+    # Hosted PR coverage fallback (untrusted actors / self-hosted unavailable /
+    # ci:full-test fanout). On PRs it runs ONLY when the target set is a genuine
+    # incremental subset (fallback == false => bazel_diff), the cheap smoke
+    # subset, or an explicit ci:full-test opt-in. A full //... fallback on a PR
+    # (infra change, bazel-diff failure, empty diff) is SKIPPED here -- the
+    # main-push baseline covers those lines under the 15-minute PR budget.
+    if: ${{ github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && (needs.determine-targets.outputs.fallback == 'false' || needs.determine-targets.outputs.fallback_reason == 'coverage_smoke' || needs.determine-targets.outputs.fallback_reason == 'full_test_label') && (needs.determine-targets.outputs.fallback_reason == 'full_test_label' || vars.SELFHOSTED_LINUX_RUNNER != 'true' || github.actor != 'jwmcglynn' || github.triggering_actor != 'jwmcglynn')) }}
 
     steps:
       - uses: actions/checkout@v7
@@ -368,18 +389,26 @@ jobs:
   coverage-self-hosted:
     runs-on: [self-hosted, linux, arm64]
     needs: determine-targets
-    if: ${{ github.event_name == 'pull_request' && vars.SELFHOSTED_LINUX_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
+    # Only the incremental (bazel_diff) subset or the cheap smoke subset run
+    # here. A full //... fallback is skipped on PRs (main-push baseline covers
+    # it); ci:full-test routes to the hosted `build` job. See header.
+    if: ${{ github.event_name == 'pull_request' && (needs.determine-targets.outputs.fallback == 'false' || needs.determine-targets.outputs.fallback_reason == 'coverage_smoke') && vars.SELFHOSTED_LINUX_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
+    # Coverage healthy median is ~21 min, so bound this SLA lane at 30 min:
+    # RE degradation fast-fails (no local fallback, below) instead of the
+    # CPU-capped 2-3 h local re-run that produced the 3.3 h tail.
+    timeout-minutes: 30
     env:
-      # The runner host may add the LAN Bazel cache from its home rc. Keep
-      # coverage resilient when the private gRPC endpoint is down
-      # (remote_local_fallback), but do NOT use an aggressive call deadline:
-      # --remote_timeout applies to every remote call, and a healthy-but-busy
-      # RE endpoint can legitimately take >5s to accept large coverage
-      # uploads under a multi-job burst (observed 2026-07-02 as
-      # DEADLINE_EXCEEDED upload failures). 60s fails fast enough on a dead
-      # endpoint while tolerating a loaded one.
-      BAZEL_SELF_HOSTED_REMOTE_FALLBACK_FLAGS: "--remote_local_fallback=true --incompatible_remote_local_fallback_for_remote_cache=true --remote_timeout=60s"
-      DONNER_COVERAGE_BAZEL_FLAGS: "--remote_local_fallback=true --incompatible_remote_local_fallback_for_remote_cache=true --remote_timeout=60s"
+      # RE-availability SLA: do NOT fall back to local execution when remote
+      # execution is unavailable or degraded. A CPU-capped self-hosted runner
+      # executing an instrumented coverage build
+      # locally is exactly the measured 2-3 h tail; fast-fail and let the
+      # wedge-watch + rerun handle RE recovery instead. --remote_timeout
+      # stays at 60s (not 5s): a healthy-but-busy endpoint can legitimately take
+      # >5s to accept large coverage uploads under a multi-job burst (observed
+      # 2026-07-02 as DEADLINE_EXCEEDED upload failures); 60s fails fast enough
+      # on a dead endpoint while tolerating a loaded one.
+      BAZEL_SELF_HOSTED_REMOTE_FALLBACK_FLAGS: "--remote_local_fallback=false --incompatible_remote_local_fallback_for_remote_cache=false --remote_timeout=60s"
+      DONNER_COVERAGE_BAZEL_FLAGS: "--remote_local_fallback=false --incompatible_remote_local_fallback_for_remote_cache=false --remote_timeout=60s"
 
     steps:
       - uses: actions/checkout@v7
@@ -467,9 +496,11 @@ jobs:
           if-no-files-found: ignore
 
   upload-self-hosted-coverage:
-    needs: coverage-self-hosted
+    needs: [determine-targets, coverage-self-hosted]
     runs-on: ubuntu-24.04
-    if: ${{ github.event_name == 'pull_request' && vars.SELFHOSTED_LINUX_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
+    # Mirrors coverage-self-hosted's gate so the upload skips whenever the
+    # self-hosted coverage job skips (full-fallback PRs produce no artifact).
+    if: ${{ github.event_name == 'pull_request' && (needs.determine-targets.outputs.fallback == 'false' || needs.determine-targets.outputs.fallback_reason == 'coverage_smoke') && vars.SELFHOSTED_LINUX_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -423,11 +423,17 @@ jobs:
     runs-on: [self-hosted, linux, arm64]
     needs: [gatekeeper, determine-targets]
     if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && github.event_name == 'pull_request' && needs.gatekeeper.outputs.docs_only != 'true' && needs.determine-targets.outputs.fallback != 'true' && vars.SELFHOSTED_LINUX_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
+    # RE-availability SLA lane. A healthy affected-target run is ~21 min; bound
+    # it at 30 so healthy runs can finish while a wedged/degraded RE endpoint
+    # still fast-fails instead of silently tailing for hours.
+    timeout-minutes: 30
     env:
-      # The runner host may add the LAN Bazel cache from its home rc. Keep
-      # that acceleration when it is healthy, but fall back to local execution
-      # if the private gRPC endpoint is down.
-      BAZEL_SELF_HOSTED_REMOTE_FALLBACK_FLAGS: "--remote_local_fallback=true --incompatible_remote_local_fallback_for_remote_cache=true --remote_timeout=5s"
+      # The runner host may add the LAN Bazel cache from its home rc. Use that
+      # acceleration when healthy, but do NOT fall back to local execution when
+      # remote execution is down/degraded: a CPU-capped runner executing the
+      # whole graph locally is the measured 2-3 h tail. Fast-fail on RE
+      # degradation; the wedge-watch + rerun recover.
+      BAZEL_SELF_HOSTED_REMOTE_FALLBACK_FLAGS: "--remote_local_fallback=false --incompatible_remote_local_fallback_for_remote_cache=false --remote_timeout=5s"
       # Every self-hosted run uploads Bazel profiles + BEP + compact execution
       # logs so slow runs can be attributed to targets/actions without live
       # SSH. Keep artifacts small; retention is 3 days. DIAG_DIR is exported
@@ -701,12 +707,18 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64]
     needs: [gatekeeper, determine-targets]
     if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && github.event_name == 'pull_request' && needs.gatekeeper.outputs.docs_only != 'true' && needs.determine-targets.outputs.fallback != 'true' && vars.SELFHOSTED_MACOS_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
+    # RE-availability SLA lane. Bound at 30 min so healthy affected-target
+    # runs can finish while RE degradation still fast-fails instead of tailing
+    # for hours on the capped host.
+    timeout-minutes: 30
     env:
       # The runner host has an operator ~/.bazelrc for interactive RE/cache work.
       # The invocations below use --nohome_rc so CI matches GitHub-hosted macOS
-      # and only picks up cache settings declared in this workflow. Cache/RE
-      # outages degrade to local execution instead of failing the CI gate.
-      BAZEL_MACOS_BUILD_FLAGS: "--macos_minimum_os=13.3 --remote_cache=grpc://192.168.1.63:9092 --remote_upload_local_results=true --remote_local_fallback=true --incompatible_remote_local_fallback_for_remote_cache=true --remote_timeout=5s"
+      # and only picks up cache settings declared in this workflow. RE/cache
+      # outages now FAST-FAIL (no local fallback) rather than degrading to a
+      # multi-hour local build on the capped host. The wedge-watch + rerun
+      # handle recovery.
+      BAZEL_MACOS_BUILD_FLAGS: "--macos_minimum_os=13.3 --remote_cache=grpc://192.168.1.63:9092 --remote_upload_local_results=true --remote_local_fallback=false --incompatible_remote_local_fallback_for_remote_cache=false --remote_timeout=5s"
       BAZEL_MACOS_TEST_FLAGS: "--test_env=HOME"
     steps:
       - name: Checkout


### PR DESCRIPTION
## What

Packet A of the Donner PR CI speed work brings PR wall-clock back under the 15-minute target by fixing the two measured violators from the recent CI speed profile.

## Measured justification

- **Coverage on PRs: ~21 min median, 3.3 h tail.** ~99% of that time is one instrumented re-run of tests CI already runs; the only PR-unique output is the Codecov patch percentage. No PR-unique regression was observed from the full re-run.
- **Self-hosted tail: 2-3 h runs.** These are remote-execution availability degradation: local fallback makes the CPU-capped self-hosted runner execute the affected graph locally when RE is slow. The healthy affected-target runtime is ~21 min.

## Changes

`.github/workflows/coverage.yml`
- PR coverage is now **incremental**: scoped to the affected-target subset via the same bazel-diff mechanism already in `determine-targets`. The Codecov patch annotation survives because it is computed on the subset that actually changed, against the main-push baseline.
- When the diff cannot be scoped to a genuine subset (infra-file change, bazel-diff failure, empty diff => full `//...` set), the PR coverage jobs **skip** instead of running the 21-minute re-run. The main-push baseline covers those lines. `ci:full-test` opt-in and the cheap smoke subset still run.
- Full coverage still runs on **push-to-main** (Codecov baseline) and `workflow_dispatch`, unchanged.
- `coverage-self-hosted` gets `timeout-minutes: 30` (healthy median ~21 min) and disables local fallback.

`.github/workflows/main.yml`
- `linux-self-hosted` and `macos-self-hosted`: `timeout-minutes: 30` and local fallback disabled. RE degradation now fast-fails and reruns instead of tailing for hours; the standing wedge-watch handles recovery.

Fallback is set purely via workflow env flags; RE routing lives in runner configuration, so no `.bazelrc` change was needed.

## Signal lost (reversible)

The per-PR Codecov **patch annotation on full-fallback PRs** (infra-only changes that force the `//...` set). Normal PRs keep the affected-subset patch annotation. Fully reversible; a smoke-coverage PR subset is a documented follow-up if missed.

## Branch protection

`main` currently has no required status checks. Nothing demoted or skipped here can block a PR merge until branch protection is configured.

## Validation

Both workflow files parse as YAML. `git diff --check` passes for the workflow changes. actionlint is not installed on the build host and fetching its installer was out of scope; expressions were reviewed by hand for parenthesis balance and `needs` references.