### PR TITLE
ci: cancel-in-progress concurrency on cmake + sanitizers-pr (Design 0018 Packet C)

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main, feature/ci-hardening-2026q2]
 
+# Superseded PR pushes cancel their in-flight CMake run so a rapid push storm
+# does not pile up redundant hosted builds. Push runs stay unique (never
+# cancel each other) via run_id in the group key.
+concurrency:
+  group: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.workflow, github.event.pull_request.number) || format('push-{0}-{1}', github.workflow, github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   gatekeeper:
     runs-on: ubuntu-24.04

--- a/.github/workflows/sanitizers-pr.yml
+++ b/.github/workflows/sanitizers-pr.yml
@@ -8,6 +8,12 @@ on:
       - "donner/svg/renderer/RendererDriver.*"
       - "donner/svg/renderer/RendererGeode.*"
 
+# Superseded PR pushes cancel their in-flight sanitizer run so a rapid push
+# storm does not pile up redundant hosted sanitizer builds.
+concurrency:
+  group: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.workflow, github.event.pull_request.number) || format('push-{0}-{1}', github.workflow, github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   asan-geode:
     name: asan-geode


### PR DESCRIPTION
## What

Adds per-PR `concurrency` groups with `cancel-in-progress` to the two PR-path workflows that lacked them:
- `.github/workflows/cmake.yml`
- `.github/workflows/sanitizers-pr.yml`

Both use the exact group-key pattern already established in `main.yml`, `coverage.yml`, and `lint.yml`:
- PRs: `pr-<workflow>-<pr_number>` with cancel-in-progress → a superseded push cancels the stale run.
- Pushes: `push-<workflow>-<run_id>` (unique) → push runs never cancel each other.

## Why

Design 0018 Packet C (CI throughput). During a rapid PR push storm, superseded pushes previously piled up redundant CMake/sanitizer builds. This trims that waste. Both workflows are GitHub-hosted (ubuntu-24.04/macos), so this reduces hosted-runner churn; the self-hosted event-horizon RE lanes (main.yml `linux-self-hosted`, coverage.yml self-hosted) already carry the same concurrency guard and are unchanged.

## Risk

Minimal and reversible (config-only, matches existing pattern). No effect on push-to-main or nightly paths.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17