### PR TITLE
Add missing AnimationSystem dep exposed by the gold-linker canary

### DIFF
--- a/donner/svg/components/animation/BUILD.bazel
+++ b/donner/svg/components/animation/BUILD.bazel
@@ -23,6 +23,12 @@ donner_cc_library(
     name = "animation_system",
     srcs = ["AnimationSystem.cc"],
     hdrs = ["AnimationSystem.h"],
+    # AnimationSystem::advance is referenced by //donner/svg/renderer:rendering_context
+    # (RenderingContext.cc). Under gold (linker canary), RenderingContext.o is pulled
+    # from its archive after libanimation_system.a has already been scanned, so gold
+    # discards AnimationSystem.o and the reference goes undefined. lld tolerates this via
+    # iterative archive resolution; gold does not. Force the object in via whole-archive.
+    alwayslink = True,
     visibility = [
         "//donner/svg:__subpackages__",
     ],


### PR DESCRIPTION
## Root cause

The Linker canary (non-lld linker support) step on `main` is red: building `//donner/svg/tool:donner-svg` with `--linkopt=-fuse-ld=gold` fails with `undefined reference to donner::svg::components::AnimationSystem::advance(...)` from `RenderingContext.cc` (see run https://github.com/jwmcglynn/donner/actions/runs/28793694393, also reproduced identically on PRs #796/#799). The SMIL merge (#778) introduced a direct call from `//donner/svg/renderer:rendering_context` (`RenderingContext.cc`) into `AnimationSystem::advance`. The `rendering_context` target already declares the `animation_system` dep, but under gold `RenderingContext.o` is pulled from its own archive after `libanimation_system.a` has already been scanned, so gold discards `AnimationSystem.o` and the reference goes undefined. lld tolerates this via iterative archive resolution; gold does a single left-to-right pass and does not.

## Fix

Mark the `animation_system` cc_library `alwayslink = True` so `AnimationSystem.o` is force-included via whole-archive regardless of archive ordering. The dep edge itself was already present, so this is the smallest correct fix for the ordering-sensitive discard.

## Verification

On dev1 (aarch64 Linux, clang):
- Reproduced the failure at `origin/main` with the canary exact shape: `bazel build --config=ci --linkopt=-fuse-ld=gold //donner/svg/tool:donner-svg //donner/svg/renderer/tests:filter_graph_executor_tests` -> undefined reference to `AnimationSystem::advance`.
- After the fix, the same gold-linker build completes successfully.
- Normal (non-gold) `bazel build //donner/svg/tool:donner-svg //donner/svg/renderer/tests:filter_graph_executor_tests` completes successfully, no regression.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
