### PR TITLE
CI matrix: retarget text_full variant from tiny_skia to geode (Design 0018 Packet B)

### DIFF
--- a/build_defs/rules.bzl
+++ b/build_defs/rules.bzl
@@ -427,7 +427,10 @@ _VARIANT_SPECS = {
         "text_full": "false",
     },
     "text_full": {
-        "backend": "tiny_skia",
+        # Retargeted from tiny_skia to geode (Design 0018 P0): tiny_skia pairs
+        # ONLY with the tiny, size-optimized variant. The full text stack
+        # (FreeType+HarfBuzz+WOFF2) now exercises the geode backend instead.
+        "backend": "geode",
         "text": "true",
         "text_full": "true",
     },

--- a/donner/svg/tests/SVGTextElement_tests.cc
+++ b/donner/svg/tests/SVGTextElement_tests.cc
@@ -291,20 +291,31 @@ TEST(SVGTextElementPublicApiTests, TextGeometryApisReturnComputedValues) {
 
   const std::vector<Path> paths = textElement.convertToPath();
   EXPECT_FALSE(paths.empty());
+  // NOTE: branches on the compile-time DONNER_TEXT_FULL flag, not
+  // ActiveRendererSupportsFeature(TextFull). That runtime query answers a
+  // different question for the Geode backend: GeodeSupportsFeature always
+  // reports TextFull as unsupported so the resvg golden-image suite skips
+  // categories where Geode is not yet Multisample-tuned to match tiny-skia
+  // (see RendererTestBackendGeode.cc). This assertion is a plain (non
+  // golden-image) glyph-metrics check: what matters here is whether HarfBuzz
+  // + FreeType shaping was actually compiled in for this variant, which is
+  // exactly what DONNER_TEXT_FULL means, independent of which backend is
+  // active (Design 0018 Packet B retargeted the text_full variant from
+  // tiny_skia to geode).
   const Box2d inkBounds = textElement.inkBoundingBox();
-  if (ActiveRendererSupportsFeature(RendererBackendFeature::TextFull)) {
-    // HarfBuzz v14 + FreeType produces slightly wider glyph advances.
-    EXPECT_THAT(inkBounds, BoxEq(Vector2Near(10.45, 11.20), Vector2Near(34.375, 20.125)));
-  } else {
-    EXPECT_THAT(inkBounds, BoxEq(Vector2Near(10.45, 11.204), Vector2Near(34.36, 20.12)));
-  }
+#ifdef DONNER_TEXT_FULL
+  // HarfBuzz v14 + FreeType produces slightly wider glyph advances.
+  EXPECT_THAT(inkBounds, BoxEq(Vector2Near(10.45, 11.20), Vector2Near(34.375, 20.125)));
+#else
+  EXPECT_THAT(inkBounds, BoxEq(Vector2Near(10.45, 11.204), Vector2Near(34.36, 20.12)));
+#endif
 
   const Box2d objectBounds = textElement.objectBoundingBox();
-  if (ActiveRendererSupportsFeature(RendererBackendFeature::TextFull)) {
-    EXPECT_THAT(objectBounds, BoxEq(Vector2Near(10.0, 8.6), Vector2Near(35.0, 22.7)));
-  } else {
-    EXPECT_THAT(objectBounds, BoxEq(Vector2Near(10.0, 8.6), Vector2Near(34.984, 22.7)));
-  }
+#ifdef DONNER_TEXT_FULL
+  EXPECT_THAT(objectBounds, BoxEq(Vector2Near(10.0, 8.6), Vector2Near(35.0, 22.7)));
+#else
+  EXPECT_THAT(objectBounds, BoxEq(Vector2Near(10.0, 8.6), Vector2Near(34.984, 22.7)));
+#endif
 }
 
 TEST(SVGTextElementPublicApiTests, AppendTextAndAdvanceTextChunkUpdateTextContent) {


### PR DESCRIPTION
## Summary

Design 0018 P0 speed program, Packet B (matrix cut). Operator matrix policy:
tiny_skia pairs ONLY with the `tiny`, size-optimized variant. This removes
the `tiny_skia` + `text_full` pairing (the combination the operator cut) by
retargeting the `text_full` variant's backend from `tiny_skia` to `geode`
in `_VARIANT_SPECS` (`build_defs/rules.bzl`). The variant *name* is
unchanged, so no per-target `variants = [...]` lists needed scrubbing (see
Enumeration below) and no edits were needed in the off-limits
`donner/svg/compositor/` tree.

A second commit fixes a real test bug the retarget surfaced: see
"Bug found and fixed" below.

## Enumeration (bazel query, done before deciding disposition)

```
bazel query 'attr(tags, "variant_text_full", //...)'
```
37 targets carry the `variant_text_full` tag (list in commit `dfdc3651`'s
parent's session log), across 9 packages, including 9 inside
`donner/svg/compositor` (query-visible only; no source edits needed there
since the variant name didn't change).

`grep -rl text_full` across BUILD/bzl files: 21 files reference `text_full`
at all; every one is either the `_VARIANT_SPECS` definition itself or a
`variants = [..., "text_full", ...]` list entry keyed on the (unchanged)
name. Disposition is **retarget in place**, not delete: the numbers show no
per-target list edits are required.

## Before/after wall-clock (`bazel test --config=ci --test_output=errors //...`, dev1, shared disk/remote cache)

- **Before** (`d78799c8`, tiny_skia+text_full): real 4m49.1s; 730 pass / 1
  fails locally (`resvg_test_suite_geode`, pre-existing flake, see below) /
  11 skipped, out of 742.
- **After, retarget only** (`8ff046bb`): real 2m27.6s; 729 pass / 2 fail
  locally (the same pre-existing `resvg_test_suite_geode` flake, plus the
  new `svg_tests_text_full` failure fixed in the second commit).
- **After, retarget + test fix** (`dfdc3651`, this PR's tip): real 28.6s
  (mostly warm-cache reuse from the prior run); 730 pass / 1 fails locally
  (the same pre-existing flake) / 11 skipped, out of 742.

Wall-clock deltas here are dominated by cache-state, not by the backend
switch's true marginal cost (the "after" runs reuse a warm shared
disk/remote cache that the "before" run built up). The real cost signal:
target *count* under `//...` is identical before and after (742 in both),
and the geode backend's toolchain/objects are already warm across the
graph from the pre-existing `geode` variant, so the retarget's only new
work per target is a re-link (sub-second per Design 0018's own
measurement) plus the already-being-compiled FreeType/HarfBuzz/WOFF2 text
stack (backend-agnostic, unchanged compile cost). None of the three runs
came close to the "~5 min added to `//...`" disproportionate-cost line
from Design 0018; delete was never indicated by the numbers.

Pre-existing, unrelated flake for the record: `resvg_test_suite_geode`
(the standalone `geode` variant, not `text_full`) intermittently fails 4-8
of its golden-image shards on this host with `GeodeGolden` pixel mismatches
(Mesa Xe-KMD experimental-platform warning present in the log); reproduces
identically on the pre-change baseline, so it is not caused by this PR.
Filed here for visibility, not fixed in this PR (out of Packet B's scope).

## Bug found and fixed (test-only, in scope)

`SVGTextElementPublicApiTests.TextGeometryApisReturnComputedValues`
(`donner/svg/tests/SVGTextElement_tests.cc`) branched on
`ActiveRendererSupportsFeature(RendererBackendFeature::TextFull)` to pick
between two sets of expected glyph-metric literals. That runtime query is
deliberately hardcoded `false` for Geode
(`RendererTestBackendGeode.cc`) for an unrelated reason: the resvg
golden-image suite's Geode 4x MSAA drifts too far from tiny-skia's 16x
supersampled reference, so image-diff categories skip cleanly on Geode.
Under `geode` + `text_full=true` the glyph metrics genuinely ARE the
full-text-stack (HarfBuzz+FreeType) values, but the test picked the
tiny_skia-only literals via that query and failed with a ~0.015-unit
bounds mismatch.

Fixed by branching on the compile-time `DONNER_TEXT_FULL` define instead
(the same signal `RendererTestBackendTinySkia.cc` already uses for this
exact enum value) — the correct signal for "was full text shaping compiled
in", independent of which backend is active. Test-only change; does not
touch `RendererTestBackendGeode.cc`'s feature registration or the
resvg_test_suite golden-image gating.

## Escalation / flag for operator or Fable review (not fixed here, out of Packet B's mandate)

`GeodeSupportsFeature(Text)` and `(TextFull)` are unconditionally `false`,
which means **every** `ActiveRendererSupportsFeature(Text)`-gated test body
(a `GTEST_SKIP()` guard, not a failure) now silently skips under the
retargeted `text_full` variant, same as it already does under the
pre-existing `geode` variant. That includes the resvg golden-image
`text/*` and `filters/*` categories, which used to run for real under
`tiny_skia`+`text_full`. The retarget removes the disallowed
`tiny_skia`+`text_full` pairing as instructed, but it does not preserve
"full engine tests against full backend" coverage for anything gated on
that feature flag — it mostly trades a compile-cost line item for a
mostly-skipped test lane, with the fixed `TextGeometryApisReturnComputedValues`
(a non-golden-image plain-metrics test) as the one meaningful assertion
that still executes. Whether that residual coverage is judged sufficient,
or whether Geode's AA needs to close the gap first (comment in
`RendererTestBackendGeode.cc` says "revisit once Geode picks up a finer
sample pattern"), is a design call for the operator/Fable, not something I
changed.

## Acceptance criteria (Design 0018 Packet B / Design 0021 C3)

- [x] Enumerate `variant_text_full` targets via bazel query before deciding disposition: 37 targets, listed above.
- [x] Default disposition (retarget to geode) applied; delete not indicated by the numbers (no >5 min//... cost found).
- [x] Scrub per-target `variants=[...]` lists as required: none required (variant name unchanged); confirmed by enumeration.
- [x] Prove `//...` green on dev1 with before/after wall-clock: see above; one pre-existing unrelated flake noted, not introduced by this PR.
- [x] Ready PR with the numbers (this PR).

Claude-Session: https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
