### PR TITLE
Docs: Donner SVG Editor & Engine branding pass

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -42,7 +42,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = Donner
+PROJECT_NAME           = "Donner SVG Editor & Engine"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version
@@ -54,7 +54,7 @@ PROJECT_NUMBER         = $(DONNER_VERSION)
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "Donner SVG Editor & Engine: embeddable browser-grade SVG2 engine"
+PROJECT_BRIEF          = "An SVG editor application plus a reusable SVG rendering, geometry, and DOM engine"
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55

--- a/Doxyfile
+++ b/Doxyfile
@@ -54,7 +54,7 @@ PROJECT_NUMBER         = $(DONNER_VERSION)
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "An SVG editor application plus a reusable SVG rendering, geometry, and DOM engine"
+PROJECT_BRIEF          = "SVG-native editor and embeddable SVG2 + CSS3 engine in C++20, with GPU (WebGPU) and compact CPU renderers, built for correctness, security, and performance."
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55

--- a/README.md
+++ b/README.md
@@ -17,9 +17,8 @@ size-optimized software renderer.
 ## Why Donner
 
 - An SVG-native editor. Selection and transform tools with oriented bounding boxes, a pen
-  tool, rich text editing with real font support, layers, a dockable panel system, and
-  native macOS chrome. Every icon and cursor is an SVG rendered by Donner itself; the
-  document you edit is the SVG, always.
+  tool, rich text editing with real font support, and layers. Every icon and cursor is an
+  SVG rendered by Donner itself; the document you edit is the SVG, always.
 - High SVG spec conformance. Conformance is tracked continuously against the resvg test suite with visual regression in CI.
 - Fully featured. SVG2 rendering with CSS3 styling, text with a full font stack (FreeType,
   HarfBuzz, WOFF2) or a compact built-in stack, filters, and the first slice of SMIL
@@ -29,8 +28,8 @@ size-optimized software renderer.
 - Secure. Built for untrusted content: 24 fuzzers run continuously, and the
   engine's design lineage includes shipping untrusted SVG and glTF rendering inside
   privileged apps.
-- Embeddable. Available on the Bazel Central Registry as a C++20 module; the tiny variant
-  is tuned for binary size.
+- Embeddable. A C++20 Bazel module with an exception-free, RTTI-free API surface; the tiny
+  variant is tuned for binary size.
 
 ## The editor
 

--- a/README.md
+++ b/README.md
@@ -1,46 +1,40 @@
-# Donner SVG: Embeddable browser-grade SVG2 engine for your application
+# Donner SVG Editor & Engine
 
 [![Build Status](https://github.com/jwmcglynn/donner/actions/workflows/main.yml/badge.svg)](https://github.com/jwmcglynn/donner/actions/workflows/main.yml) [![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](https://opensource.org/licenses/ISC) [![Code coverage %](https://codecov.io/gh/jwmcglynn/donner/branch/main/graph/badge.svg?token=Z3YJZNKGU0)](https://codecov.io/gh/jwmcglynn/donner) ![Product lines of code](https://gist.githubusercontent.com/jwmcglynn/91f7f490a72af9c06506c8176729d218/raw/loc.svg) ![Test lines of code](https://gist.githubusercontent.com/jwmcglynn/91f7f490a72af9c06506c8176729d218/raw/loc-tests.svg)
 ![Comments %](https://gist.githubusercontent.com/jwmcglynn/91f7f490a72af9c06506c8176729d218/raw/comments.svg)
 
-Donner SVG Editor & Engine is an editor application plus an embeddable, reusable SVG rendering, geometry, and DOM engine, providing full access to the SVG DOM. [Try it out online!](https://jwmcglynn.github.io/donner-editor/)
+A native SVG editor, built on its own SVG2 + CSS3 engine, written from scratch in C++20.
+
+Donner is an SVG-native editor: a fast, native tool for creating and editing SVG, backed by an engine
+built for browser-grade correctness, security, and performance. The same engine that powers
+the editor embeds cleanly into your application, from a full GPU-rendered canvas down to a
+size-optimized software renderer.
 
 ![Donner splash image](donner_splash.svg)
 
-```cpp
-ParseWarningSink warnings;
-ParseResult<SVGDocument> maybeDocument = SVGParser::ParseSVG(
-    loadFile("donner_splash.svg"), warnings);
+[Try it out online!](https://jwmcglynn.github.io/donner-editor/)
 
-if (maybeDocument.hasError()) {
-  std::cerr << "Parse Error: " << maybeDocument.error() << "\n";
-  std::abort();
-}
+## Why Donner
 
-Renderer renderer;
-renderer.draw(maybeDocument.result());
+- An SVG-native editor. Selection and transform tools with oriented bounding boxes, a pen
+  tool, rich text editing with real font support, layers, a dockable panel system, and
+  native macOS chrome. Every icon and cursor is an SVG rendered by Donner itself; the
+  document you edit is the SVG, always.
+- High SVG spec conformance. Conformance is tracked continuously against the resvg test suite with visual regression in CI.
+- Fully featured. SVG2 rendering with CSS3 styling, text with a full font stack (FreeType,
+  HarfBuzz, WOFF2) or a compact built-in stack, filters, and the first slice of SMIL
+  animation with time-sampled rendering.
+- High performance. Geode, a GPU renderer built on WebGPU, drives the editor canvas; a
+  tiny_skia-based CPU backend serves the size-optimized embeddable build.
+- Secure. Built for untrusted content: 24 fuzzers run continuously, and the
+  engine's design lineage includes shipping untrusted SVG and glTF rendering inside
+  privileged apps.
+- Embeddable. Available on the Bazel Central Registry as a C++20 module; the tiny variant
+  is tuned for binary size.
 
-const bool success = renderer.save("output.png");
-```
+## The editor
 
-## Why Donner?
-
-- It's designed to be embeddable, and provides an exception-free API surface
-- For malformed files, it produces detailed parse errors, which includes file/line information
-- Donner provides an extensive and well-documented SVG API surface, which enables inspecting and modifying the SVG in-memory
-- Donner implements the latest standards, SVG2 and CSS3 and aims for high-conformance
-
-Donner supports:
-
-- SVG2 core functionality, such as shapes, fills, strokes, and gradients
-- Text rendering with `<text>`, `<tspan>`, and `<textPath>`, including WOFF2 web fonts and optional HarfBuzz shaping
-- All 17 SVG filter primitives (feGaussianBlur, feColorMatrix, feComposite, etc.)
-- CSS3 parsing and cascading support, with a hand-rolled library
-- Detailed validation and diagnostics, errors point to the exact location
-- A game-engine-inspired [EnTT](https://github.com/skypjack/entt) ECS-backed document tree, optimized for performance
-- A SVG DOM-style API to traverse, inspect, and modify documents in memory
-- A two-phase renderer, which builds and caches a rendering tree for efficient frame-based rendering
-- Two renderer backends: **tiny-skia** (default, a lightweight software renderer) and **Skia** (Chromium's renderer)
+The editor ships with the engine and is under active development. Open a file, edit visually or in the built-in XML view with two-way sync, and export clean SVG.
 
 ## Supported Elements
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Detailed docs: [svg_to_png.cc](https://jwmcglynn.github.io/donner/svg_to_png_8cc
 
 ## CMake Support
 
-CMake support is available for integrating Donner into CMake-based projects. The CMake build fetches dependencies and builds the library. Both the Skia and tiny-skia backends are supported.
+CMake support is available for integrating Donner into CMake-based projects. The CMake build fetches dependencies and builds the library. Both the tiny_skia (CPU) and Geode (WebGPU) backends are selectable via `DONNER_RENDERER_BACKEND` (default `tiny_skia`).
 
 See the [CMake Documentation](https://jwmcglynn.github.io/donner/BuildingDonner.html#cmake-build) for more details.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -2,7 +2,14 @@
 
 \tableofcontents
 
-Donner is an embeddable browser-grade SVG2 engine in C++20, providing full access to the SVG DOM with complete rendering support including text and filters.
+Donner SVG Editor & Engine is an SVG-native editor and the C++20 engine underneath it,
+designed to be embedded. The engine renders
+SVG2 with CSS3 styling through either Geode (a GPU renderer built on WebGPU) or a compact
+CPU backend, tracks conformance against the resvg test suite, and treats all input as
+untrusted: fuzzing runs continuously across the parser, style, and text subsystems.
+
+These pages document the engine API. Start with the core document model below; the editor
+is documented separately in the repository.
 
 \htmlonly <style>img[src="donner_splash.svg"]{max-width:800px;}</style> \endhtmlonly
 ![Donner splash image](donner_splash.svg)
@@ -17,7 +24,7 @@ Donner supports:
 - A performance-oriented document tree optimized for dynamic inspection, mutation, and rendering.
 - A SVG DOM-style API to traverse, inspect, and modify documents in memory.
 - A two-phase renderer, which builds and caches a rendering tree for efficient frame-based rendering.
-- Two renderer backends: **tiny-skia** (default, a lightweight software renderer) and **Skia** (Chromium's renderer).
+- Two renderer backends: **tiny_skia** (a compact CPU software renderer) and **Geode** (a GPU renderer built on WebGPU).
 
 Donner focuses on security and performance, which is validated with code coverage and fuzz testing.
 


### PR DESCRIPTION
## W14: Donner SVG Editor & Engine branding pass

Repositions the product identity as **Donner SVG Editor & Engine** (the SVG-native editor
named first, the engine underneath it second) across the root README, the doxygen landing
page, and the Doxyfile project fields. Homepage prose authored by Fable and applied verbatim,
except where a claim was not verifiable against origin/main (see below). Placeholders resolved
only against verified repo/CI evidence.

### Files changed
- `README.md` -- new H1, hero, "Why Donner", and "The editor" sections (badges and all
  sections from "Supported Elements" onward kept as-is; the redundant intro C++ snippet,
  a duplicate of "API Demo 2", was dropped). Stale "Skia and tiny-skia" CMake line corrected.
- `docs/introduction.md` -- doxygen landing opening paragraph replaced; stale
  "tiny-skia and Skia" backend line corrected to "tiny_skia (CPU) and Geode (WebGPU GPU)".
- `Doxyfile` -- `PROJECT_NAME` set to "Donner SVG Editor & Engine"; `PROJECT_BRIEF` set to
  Fable's editor-first factual brief.

Docs build verified: `doxygen 1.9.8` runs clean (exit 0, `index.html` generated); the edited
`introduction.md` reads without new warnings.

### Placeholder resolution (verified evidence only)
- FUZZER_COUNT -> **24** continuously-run fuzzers (`donner_cc_fuzzer` targets under `donner/`).
- PERF_CLAIM_IF_ANY -> **omitted** (page fallback): in-repo perf figures are stated relative
  to the removed full-Skia backend, so no clean standalone claim was published.
- BCR_MODULE_NAME_AND_MIN_LINE -> **omitted** (page fallback).
- ONE_SENTENCE_EDITOR_STATUS_WITH_VERSION -> page fallback (v0.8 unreleased / frozen).
- RESVG_PASS_SUMMARY -> page **fallback** applied. `resvg_test_suite` is green in CI
  (`docs/build_report.md`); the repo carries 1,679 resvg `.svg` test files with 130 documented
  per-test skips in `resvg_test_suite.cc`. An exact "N of M pass" gtest count was not
  substituted: a from-scratch renderer build on the host did not finish inside the window.

### Corrections to unverified copy claims (fixed, not just flagged)
Two claims in the draft could not be verified against origin/main (12d3c32d) and were removed,
independently confirmed by the Codex reviewer and answered on the threads:
- "Available on the Bazel Central Registry" -- donner is 404 on bcr.bazel.build; BCR publish is
  blocked with no version published (`docs/design_docs/0018-bcr_release.md`). Embeddable bullet
  now states only the verifiable C++20 Bazel module + exception-free / RTTI-free API surface
  (`-fno-exceptions -fno-rtti` in `.bazelrc`).
- "a dockable panel system" and "native macOS chrome" -- editor panes are fixed
  (`NoMove|NoResize`, `SetNextWindowPos(..., ImGuiCond_Always)` in `EditorShell.cc`); W7 docking
  and W9 native chrome are not on main. Removed from the editor bullet.

### Remaining claim for operator to confirm
- "the engine's design lineage includes shipping untrusted SVG and glTF rendering inside
  privileged apps" -- a biographical/lineage statement not verifiable from the repo; left as
  written for the operator to confirm or adjust.

Verified-present claims kept: pen tool, text editing, layers, oriented bounding boxes,
embedded real fonts; SVG2 + CSS3, 17 filter primitives, FreeType + HarfBuzz + WOFF2 full text
stack plus compact text-base variant, SMIL animate/animateTransform/set slice, Geode
(wgpu-native WebGPU) + tiny_skia backends, C++20.

ASCII punctuation only; no code, workflows, or docs/design_docs/ history touched.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
