### PR TITLE
Binary size: baseline report + wasm size tooling

### DIFF
--- a/docs/design_docs/0055-binary_size.md
+++ b/docs/design_docs/0055-binary_size.md
@@ -1,7 +1,7 @@
 # Design: Binary Size Reduction
 
 **Status:** Draft
-**Author:** Claude Opus 4.8
+**Author:** Claude Fable 5 (reviewed; drafted by Claude Opus 4.8)
 **Created:** 2026-07-10
 
 ## Summary
@@ -87,7 +87,7 @@ file. The wasm target builds under `--config=wasm` and is measured both raw and
 gzip -9 (the transfer-size proxy), with a bloaty section/symbol breakdown of the
 `.wasm`.
 
-## Baseline (measured 2026-07-10, deep-thought, macOS arm64)
+## Baseline (measured 2026-07-10, an internal build host, macOS arm64)
 
 Native, `--config=macos-binary-size`, stripped, arm64 Mach-O:
 

--- a/docs/design_docs/0055-binary_size.md
+++ b/docs/design_docs/0055-binary_size.md
@@ -1,0 +1,167 @@
+# Design: Binary Size Reduction
+
+**Status:** Draft
+**Author:** Claude Opus 4.8
+**Created:** 2026-07-10
+
+## Summary
+
+Donner should build fast, stay small, embed easily into apps, and download
+cheaply as WebAssembly. This design makes binary size a first-class, measured
+property: it records a reproducible baseline for the representative
+native and wasm artifacts, extends the checked-in tooling so anyone can
+regenerate the full per-component report with one command, and then drives size
+down in a series of measured steps, stopping at diminishing returns.
+
+Scope is the shipped surface a real embedder links: the SVG parser tool, the
+`donner-svg` CLI, and the tiny_skia WebAssembly renderer (parser + svg +
+software renderer + a thin bridge). The editor and Geode/WebGPU wasm builds are
+noted as follow-on surfaces but are not the primary focus.
+
+## Goals
+
+- One command regenerates a per-component size report covering native and wasm,
+  with per-section / per-compile-unit / per-symbol attribution (bloaty) and,
+  for wasm, the gzip-compressed transfer size that a browser actually downloads.
+- A recorded baseline (below), with every subsequent reduction carrying a
+  measured before/after delta from that tooling.
+- Meaningful size reductions on the wasm transfer size and the native binaries,
+  achieved without public API breaks or silent feature removals.
+- A final ranked list of remaining opportunities, including feature-removal
+  tradeoffs deliberately not taken.
+
+## Non-Goals
+
+- No public API changes or feature removals without prominently flagging them.
+- Not chasing the editor wasm or Geode/WebGPU wasm to their floor in this pass;
+  they are large, separate surfaces. They are called out as follow-on work.
+- Not changing the default renderer feature tiers (filters/text) that a normal
+  build ships; feature-flag driven size wins are surfaced, not silently applied.
+- Not switching exceptions/RTTI policy: the repo already builds with
+  `-fno-exceptions -fno-rtti` globally, so that lever is already spent.
+
+## Next Steps
+
+- Land this baseline plus the extended `tools/binary_size.sh` (native + wasm)
+  so the report is regenerable by anyone with one command.
+- First reduction: build the shipped wasm optimized for size (`-Oz`), which the
+  measurements below show is the single largest lever.
+
+## Implementation Plan
+
+- [x] Milestone 1: Baseline and tooling
+  - [x] Extend `tools/binary_size.sh` to build and measure the wasm target
+        (raw + gzip transfer size for `.wasm` and JS glue, plus a bloaty
+        section/symbol breakdown of the `.wasm`).
+  - [x] Record the measured baseline for all representative targets (below).
+  - [x] Commit and push before starting reductions.
+- [ ] Milestone 2: WebAssembly size reduction (largest lever)
+  - [ ] Build the shipped wasm optimized for size (`-c opt` + `-Oz` compile and
+        link) instead of the current unoptimized default; measure the delta.
+  - [ ] Evaluate `emmalloc` (small, safe) and surface `--closure=1` /
+        `-sFILESYSTEM=0` as JS-glue wins gated on a headless render test.
+- [ ] Milestone 3: Native reductions
+  - [ ] Evaluate identical-code folding (lld `--icf=all`) and confirm
+        `--gc-sections` / `-dead_strip` behavior on each platform.
+  - [ ] Evaluate ThinLTO for the shipped (non-attribution) build.
+  - [ ] Audit the largest compile units (AttributeParser, SVGParser,
+        PropertyRegistry, css/Token) for template/table bloat.
+- [ ] Milestone 4: Finalize
+  - [ ] Record final-vs-baseline numbers per target and the ranked remaining
+        opportunities; rewrite this doc's status.
+
+## Proposed Architecture
+
+The report is produced by `tools/binary_size.sh`, run from any Donner checkout:
+
+```
+bash tools/binary_size.sh            # native + wasm report to stdout
+SKIP_WASM=1 bash tools/binary_size.sh   # native only (no emcc required)
+```
+
+Native targets build under `--config={macos,linux}-binary-size` (`-c opt -Os`,
+`-ffunction-sections -fdata-sections`, symbols preserved for attribution, then
+measured on the `.stripped` output). bloaty attributes size by
+`donner_package,compileunits,symbols` using the unstripped binary as the debug
+file. The wasm target builds under `--config=wasm` and is measured both raw and
+gzip -9 (the transfer-size proxy), with a bloaty section/symbol breakdown of the
+`.wasm`.
+
+## Baseline (measured 2026-07-10, deep-thought, macOS arm64)
+
+Native, `--config=macos-binary-size`, stripped, arm64 Mach-O:
+
+| Target                                          | Size (bytes) | Size    |
+| ----------------------------------------------- | ------------ | ------- |
+| `//donner/svg/parser:svg_parser_tool.stripped`  | 2,527,384    | 2.41 MiB |
+| `//donner/svg/tool:donner-svg.stripped`         | 4,182,688    | 3.99 MiB |
+
+WebAssembly, `//donner/svg/renderer/wasm:donner_wasm`, current default
+`--config=wasm` (this is the shipped config today: no `-c opt`, so the module is
+built unoptimized at fastbuild `-O0` with no `wasm-opt` pass):
+
+| Artifact               | Raw bytes | gzip -9   |
+| ---------------------- | --------- | --------- |
+| `donner_wasm_bin.wasm` | 5,688,030 | 1,184,620 |
+| `donner_wasm_bin.js`   | 154,601   | 41,847    |
+| Total transfer         | 5,842,631 | 1,226,467 |
+
+Top native compile units (bloaty, `svg_parser_tool`): `donner` package is 87% of
+the binary; the heaviest single units are `parser/AttributeParser.cc` (374 KiB),
+`parser/SVGParser.cc` (270 KiB), `SVGDocument.cc` (176 KiB),
+`properties/PropertyRegistry.cc` (100 KiB), and `css/Token.cc` (95 KiB).
+
+## Measured reduction experiments (wasm)
+
+All measured with the tooling on the same host; the current default is the
+baseline row. These informed the ranked plan; each will be re-measured when
+landed as a real change.
+
+| Variant                                        | wasm raw  | wasm gzip | js raw  | js gzip |
+| ---------------------------------------------- | --------- | --------- | ------- | ------- |
+| baseline (`--config=wasm`, fastbuild `-O0`)    | 5,688,030 | 1,184,620 | 154,601 | 41,847  |
+| `-c opt` (`-O2`)                               | 2,808,926 | 890,331   | 58,319  | 16,565  |
+| `-c opt` + `-Oz` (compile and link)            | 1,610,071 | 617,970   | 57,617  | 16,362  |
+| `-Oz` + `emmalloc` + `--closure=1` + FS off    | 1,603,318 | 614,923   | 5,486   | 2,713   |
+
+Reading: `-Oz` on the wasm build is the single largest lever, cutting the raw
+`.wasm` by 72% (5.69 MiB to 1.61 MiB) and the gzip transfer by 48% (1.18 MiB to
+618 KiB). `emmalloc` is a small, safe further win. `--closure=1` and
+`-sFILESYSTEM=0` shrink the JS glue by roughly 10x (58 KiB to 5.5 KiB), but
+`--closure=1` can rename exported runtime methods and needs a headless render
+check before it ships, since the tiny_skia renderer wasm has no automated
+browser test today (only a manual `test.html`).
+
+## Ranked opportunities
+
+1. Build the shipped wasm with `-Oz` (largest lever; safe). ~72% raw, ~48% gzip.
+2. `emmalloc` on the wasm build (safe, small; a few KiB of `.wasm`).
+3. `--closure=1` + `-sFILESYSTEM=0` for the JS glue (10x on `.js`, gated on a
+   headless render test that does not exist yet; build the test first).
+4. Native identical-code folding (`lld --icf=all`) and LTO for the shipped
+   (non-attribution) native build.
+5. Compile-unit audits of the heaviest units (AttributeParser, SVGParser,
+   PropertyRegistry, css/Token) for template instantiation and static-table
+   bloat.
+6. Feature-tier tradeoffs deliberately NOT taken by default: `--config=tiny`
+   (filters=false, text=false) and `--config=no-filters` remove real
+   functionality and are surfaced here as opt-in size levers, not applied.
+
+## Testing and Validation
+
+- Size numbers come only from `tools/binary_size.sh`; every reported delta is a
+  before/after from that tool on the same host.
+- Functional safety: native reductions are covered by the existing test suites;
+  each reduction PR runs the affected suites and reports CI state. The wasm
+  `-Oz`/`emmalloc` changes are functional-behavior-preserving optimizer flags;
+  `--closure=1` is held back until a headless render check exists.
+- No public API breaks or feature removals land without prominent flagging in
+  the PR description and this doc.
+
+## Open Questions
+
+- Should `--config=wasm` imply size optimization for all wasm consumers
+  (including the editor and Geode wasm lanes), or should a dedicated
+  size-optimized wasm config carry the flags so the editor test lane keeps its
+  faster unoptimized build? The reduction PR will pick the least surprising
+  option and record the rationale.

--- a/docs/design_docs/README.md
+++ b/docs/design_docs/README.md
@@ -129,6 +129,7 @@ conventions automated agents should follow when editing design docs.
 | 0052-6 | [text/text_v1_release](text/0052-6-text_v1_release.md)                                     | Reference                                                         | Text v1 release checklist.                                                                                                                  |
 | 0052-7 | [text/textpath](text/0052-7-textpath.md)                                                   | Reference                                                         | `<textPath>` implementation notes.                                                                                                          |
 | 0054   | [editor_design_language](0054-editor_design_language.md)                                   | In Progress                                                       | Graphite editor chrome, Signal Teal interaction states, source palette, fixed control geometry, and deterministic visual verification.       |
+| 0055   | [binary_size](0055-binary_size.md)                                                         | Draft                                                             | Binary size reduction: reproducible native + wasm size report tooling, measured baseline, and ranked reduction plan.                        |
 
 ## Cross-reference: developer docs
 

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -104,3 +104,12 @@ py_test(
         "feature_loc_tests.py",
     ],
 )
+
+# Smoke test for the binary-size report tooling. Keeps binary_size.sh mapped to
+# a real Bazel test target (see binary_size_tests.py for why).
+py_test(
+    name = "binary_size_tests",
+    srcs = ["binary_size_tests.py"],
+    data = ["binary_size.sh"],
+    deps = ["@rules_python//python/runfiles"],
+)

--- a/tools/binary_size.sh
+++ b/tools/binary_size.sh
@@ -98,3 +98,47 @@ echo '```'
 run_bloaty -c tools/binary_size_config.bloaty -d donner_package,compileunits -n 20 "${DEBUG_FILE_ARG[@]}" build-binary-size/svg_parser_tool
 
 echo '```'
+
+##
+## WebAssembly transfer size (Emscripten).
+##
+## The .wasm + JS glue is the artifact a browser downloads, so the number that
+## matters for the "downloadable as wasm" story is the gzip-compressed transfer
+## size, not the on-disk size. Measure the tiny_skia SVG renderer wasm target
+## (the minimal embedder surface: parser + svg + software renderer + a thin
+## bridge). Skipped automatically when emcc is not on PATH.
+##
+if [[ -z "$SKIP_WASM" ]] && command -v emcc >/dev/null 2>&1; then
+  echo ""
+  echo "### WebAssembly build (\`//donner/svg/renderer/wasm:donner_wasm\`)"
+  echo ""
+
+  bazel build "${BAZEL_QUIET_OPTIONS[@]}" "${BAZEL_LOCAL_OPTIONS[@]}" --config=wasm //donner/svg/renderer/wasm:donner_wasm
+
+  cp -f bazel-bin/donner/svg/renderer/wasm/donner_wasm_bin.wasm build-binary-size/donner_wasm.wasm
+  cp -f bazel-bin/donner/svg/renderer/wasm/donner_wasm_bin.js build-binary-size/donner_wasm.js
+
+  wasm_raw=$(wc -c < build-binary-size/donner_wasm.wasm)
+  wasm_gz=$(gzip -9 -c build-binary-size/donner_wasm.wasm | wc -c)
+  js_raw=$(wc -c < build-binary-size/donner_wasm.js)
+  js_gz=$(gzip -9 -c build-binary-size/donner_wasm.js | wc -c)
+
+  echo '```'
+  printf '%-24s %14s %14s\n' "artifact" "raw bytes" "gzip -9"
+  printf '%-24s %14s %14s\n' "donner_wasm_bin.wasm" "$wasm_raw" "$wasm_gz"
+  printf '%-24s %14s %14s\n' "donner_wasm_bin.js" "$js_raw" "$js_gz"
+  printf '%-24s %14s %14s\n' "total transfer" "$((wasm_raw + js_raw))" "$((wasm_gz + js_gz))"
+  echo '```'
+  echo ""
+
+  # Section-level attribution of the .wasm. Symbol attribution is best-effort:
+  # it only appears when the module still carries a name section.
+  echo '`bloaty -d sections,symbols -n 20` output for donner_wasm_bin.wasm'
+  echo '```'
+  run_bloaty -d sections,symbols -n 20 build-binary-size/donner_wasm.wasm || \
+    run_bloaty -d sections -n 20 build-binary-size/donner_wasm.wasm || true
+  echo '```'
+else
+  echo ""
+  echo "_emcc not found on PATH (or SKIP_WASM set); skipping WebAssembly size measurement._"
+fi

--- a/tools/binary_size_tests.py
+++ b/tools/binary_size_tests.py
@@ -1,0 +1,32 @@
+import os
+import subprocess
+import unittest
+
+from python.runfiles import runfiles
+
+
+class BinarySizeToolTest(unittest.TestCase):
+    """Smoke test for the binary-size report script.
+
+    binary_size.sh needs Bazel, bloaty, and emcc to run end-to-end, so this
+    test does not execute it. It confirms the script parses cleanly with
+    `bash -n`, which catches syntax regressions and, just as importantly, gives
+    the size tooling a real Bazel test target so a change to it maps to a test
+    under affected-target CI rather than to a non-test filegroup.
+    """
+
+    def test_script_parses(self):
+        r = runfiles.Create()
+        location = r.Rlocation("donner/tools/binary_size.sh")
+        self.assertIsNotNone(location, "binary_size.sh not found in runfiles")
+        self.assertTrue(os.path.exists(location), location)
+        result = subprocess.run(
+            ["bash", "-n", location],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Makes binary size a measured, first-class property and records a reproducible baseline. Tooling and docs only; no functional or API changes.

- Extend `tools/binary_size.sh` to also build and measure the tiny_skia WebAssembly renderer (`//donner/svg/renderer/wasm:donner_wasm`) alongside the native binaries. It now reports raw and gzip-9 transfer sizes for the `.wasm` and JS glue, plus a bloaty section/symbol breakdown of the `.wasm`. `SKIP_WASM=1` (or a host without emcc) skips the wasm section.
- New design doc `docs/design_docs/0055-binary_size.md` records the baseline and a ranked reduction plan.

## Measured baseline (an internal build host, macOS arm64)

Native, `--config=macos-binary-size`, stripped:

| Target | Size |
| --- | --- |
| svg_parser_tool.stripped | 2,527,384 bytes (2.41 MiB) |
| donner-svg.stripped | 4,182,688 bytes (3.99 MiB) |

WebAssembly, `--config=wasm` (current default; note it builds unoptimized at fastbuild -O0 with no wasm-opt):

| Artifact | Raw | gzip -9 |
| --- | --- | --- |
| donner_wasm_bin.wasm | 5,688,030 | 1,184,620 |
| donner_wasm_bin.js | 154,601 | 41,847 |
| Total transfer | 5,842,631 | 1,226,467 |

## Regenerate

```
bash tools/binary_size.sh
```

## Follow-on

Reduction PRs land on top of this. The largest measured lever is building the shipped wasm with -Oz (see doc 0055 for the full ranked plan and per-variant measurements).

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
