### PR TITLE
Binary size: optimize wasm build for size (-Oz + emmalloc)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -150,6 +150,18 @@ common:wasm --//donner/svg/renderer:text_full=false
 # toolchain without cross-configuration link conflicts.
 common:wasm --//build_defs:disable_perf_opt_transition=true
 
+# Size-optimized production wasm. The .wasm + JS glue is a browser download, so
+# the shipped/downloaded artifact should be built for size. This layers size
+# optimization on --config=wasm: -c opt compiles every translation unit
+# optimized, and -Oz (compile + link) minimizes code size and drives
+# Emscripten's whole-module wasm-opt pass. --config=wasm alone stays
+# unoptimized for fast iteration. Usage:
+#   bazel build --config=wasm-size //donner/svg/renderer/wasm:donner_wasm
+common:wasm-size --config=wasm
+build:wasm-size -c opt
+build:wasm-size --copt=-Oz
+build:wasm-size --linkopt=-Oz
+
 # Full editor WASM build. Uses Geode/WebGPU by default because the editor
 # presentation and performance work target Geode. Usage:
 #   bazel build --config=editor-wasm //donner/editor/wasm:wasm

--- a/docs/design_docs/0055-binary_size.md
+++ b/docs/design_docs/0055-binary_size.md
@@ -43,10 +43,10 @@ noted as follow-on surfaces but are not the primary focus.
 
 ## Next Steps
 
-- Land this baseline plus the extended `tools/binary_size.sh` (native + wasm)
-  so the report is regenerable by anyone with one command.
-- First reduction: build the shipped wasm optimized for size (`-Oz`), which the
-  measurements below show is the single largest lever.
+- Baseline plus the extended `tools/binary_size.sh` (native + wasm) landed so
+  the report is regenerable by anyone with one command.
+- First reduction (R1) landed: size-optimized `--config=wasm-size` cuts the wasm
+  gzip transfer 48.5%. Next: native identical-code folding and LTO.
 
 ## Implementation Plan
 
@@ -56,11 +56,14 @@ noted as follow-on surfaces but are not the primary focus.
         section/symbol breakdown of the `.wasm`).
   - [x] Record the measured baseline for all representative targets (below).
   - [x] Commit and push before starting reductions.
-- [ ] Milestone 2: WebAssembly size reduction (largest lever)
-  - [ ] Build the shipped wasm optimized for size (`-c opt` + `-Oz` compile and
-        link) instead of the current unoptimized default; measure the delta.
-  - [ ] Evaluate `emmalloc` (small, safe) and surface `--closure=1` /
-        `-sFILESYSTEM=0` as JS-glue wins gated on a headless render test.
+- [x] Milestone 2: WebAssembly size reduction (largest lever)
+  - [x] Add a size-optimized `--config=wasm-size` (`-c opt` + `-Oz` compile and
+        link) layered on `--config=wasm`; point `tools/binary_size.sh` at it as
+        the shipping build. Measured delta below.
+  - [x] Add `emmalloc` to the tiny_skia renderer wasm binary (safe: it sets
+        `USE_PTHREADS=0`).
+  - [ ] Surface `--closure=1` / `-sFILESYSTEM=0` as JS-glue wins gated on a
+        headless render test (deferred; needs the test harness first).
 - [ ] Milestone 3: Native reductions
   - [ ] Evaluate identical-code folding (lld `--icf=all`) and confirm
         `--gc-sections` / `-dead_strip` behavior on each platform.
@@ -133,10 +136,33 @@ Reading: `-Oz` on the wasm build is the single largest lever, cutting the raw
 check before it ships, since the tiny_skia renderer wasm has no automated
 browser test today (only a manual `test.html`).
 
+## Landed reductions
+
+### R1: size-optimized wasm (`--config=wasm-size` + emmalloc)
+
+Adds a `--config=wasm-size` that layers `-c opt --copt=-Oz --linkopt=-Oz` on
+`--config=wasm`, plus `-sMALLOC=emmalloc` on the tiny_skia renderer wasm binary.
+`--config=wasm` alone is left unoptimized so dev iteration and the editor wasm
+CI lanes are unchanged. Measured with `bash tools/binary_size.sh`:
+
+| Artifact               | Baseline raw | R1 raw    | Baseline gzip | R1 gzip |
+| ---------------------- | ------------ | --------- | ------------- | ------- |
+| `donner_wasm_bin.wasm` | 5,688,030    | 1,603,318 | 1,184,620     | 614,919 |
+| `donner_wasm_bin.js`   | 154,601      | 57,617    | 41,847        | 16,358  |
+| Total transfer         | 5,842,631    | 1,660,935 | 1,226,467     | 631,277 |
+
+Raw `.wasm` down 71.8%; total gzip transfer down 48.5% (1.23 MiB to 631 KiB).
+Validation: the module validates under `wasm-opt --all-features`, and the
+optimized JS glue exposes the same public C API (`donner_init`,
+`donner_render_svg`, `donner_free_pixels`, `donner_get_last_error`) as the
+baseline. No source, API, or feature changes; `-Oz` and `emmalloc` are
+behavior-preserving optimizer/allocator flags (no closure minification).
+
 ## Ranked opportunities
 
-1. Build the shipped wasm with `-Oz` (largest lever; safe). ~72% raw, ~48% gzip.
-2. `emmalloc` on the wasm build (safe, small; a few KiB of `.wasm`).
+1. DONE (R1): Build the shipped wasm with `-Oz` (largest lever; safe). Realized
+   ~72% raw, ~48% gzip.
+2. DONE (R1): `emmalloc` on the tiny_skia wasm binary (safe, small).
 3. `--closure=1` + `-sFILESYSTEM=0` for the JS glue (10x on `.js`, gated on a
    headless render test that does not exist yet; build the test first).
 4. Native identical-code folding (`lld --icf=all`) and LTO for the shipped

--- a/donner/svg/renderer/wasm/BUILD.bazel
+++ b/donner/svg/renderer/wasm/BUILD.bazel
@@ -49,6 +49,8 @@ cc_binary(
         "-sENVIRONMENT=web",
         "-sALLOW_MEMORY_GROWTH=1",
         "-sEXPORTED_FUNCTIONS=_donner_init,_donner_render_svg,_donner_free_pixels,_donner_get_last_error,_malloc,_free",
+        # Smaller allocator than the default dlmalloc; safe with USE_PTHREADS=0.
+        "-sMALLOC=emmalloc",
         "-sEXPORTED_RUNTIME_METHODS=ccall,cwrap,UTF8ToString",
         "-sUSE_PTHREADS=0",
         "-sSTACK_SIZE=1048576",

--- a/tools/binary_size.sh
+++ b/tools/binary_size.sh
@@ -109,11 +109,14 @@ echo '```'
 ## bridge). Skipped automatically when emcc is not on PATH.
 ##
 if [[ -z "$SKIP_WASM" ]] && command -v emcc >/dev/null 2>&1; then
+  # wasm-size is the size-optimized production config (see .bazelrc). Override
+  # with WASM_CONFIG=wasm to measure the unoptimized dev build instead.
+  WASM_CONFIG="${WASM_CONFIG:-wasm-size}"
   echo ""
-  echo "### WebAssembly build (\`//donner/svg/renderer/wasm:donner_wasm\`)"
+  echo "### WebAssembly build (\`//donner/svg/renderer/wasm:donner_wasm\`, --config=$WASM_CONFIG)"
   echo ""
 
-  bazel build "${BAZEL_QUIET_OPTIONS[@]}" "${BAZEL_LOCAL_OPTIONS[@]}" --config=wasm //donner/svg/renderer/wasm:donner_wasm
+  bazel build "${BAZEL_QUIET_OPTIONS[@]}" "${BAZEL_LOCAL_OPTIONS[@]}" --config="$WASM_CONFIG" //donner/svg/renderer/wasm:donner_wasm
 
   cp -f bazel-bin/donner/svg/renderer/wasm/donner_wasm_bin.wasm build-binary-size/donner_wasm.wasm
   cp -f bazel-bin/donner/svg/renderer/wasm/donner_wasm_bin.js build-binary-size/donner_wasm.js


### PR DESCRIPTION
Stacked on #808. First reduction from the size pass (doc 0055, R1).

## What

The shipped wasm was built unoptimized (fastbuild -O0, no wasm-opt). This adds a size-optimized `--config=wasm-size` that layers `-c opt --copt=-Oz --linkopt=-Oz` on `--config=wasm`, and adds `-sMALLOC=emmalloc` to the tiny_skia renderer wasm binary (safe: it sets `USE_PTHREADS=0`). `tools/binary_size.sh` now measures the `wasm-size` shipping build (override with `WASM_CONFIG=wasm`).

The shared `--config=wasm` is intentionally left unoptimized so dev iteration and the editor wasm CI lanes are unchanged (editor wasm is a non-goal for this pass).

## Measured (tools/binary_size.sh, an internal build host macOS arm64)

| Artifact | Baseline raw | New raw | Baseline gzip | New gzip |
| --- | --- | --- | --- | --- |
| donner_wasm_bin.wasm | 5,688,030 | 1,603,318 | 1,184,620 | 614,919 |
| donner_wasm_bin.js | 154,601 | 57,617 | 41,847 | 16,358 |
| Total transfer | 5,842,631 | 1,660,935 | 1,226,467 | 631,277 |

Raw .wasm down 71.8%; total gzip transfer down 48.5% (1.23 MiB to 631 KiB).

## Validation

- Module validates under `wasm-opt --all-features`.
- The optimized JS glue exposes the same public C API (`donner_init`, `donner_render_svg`, `donner_free_pixels`, `donner_get_last_error`) as the baseline.
- No source, API, or feature changes; `-Oz` and `emmalloc` are behavior-preserving optimizer/allocator flags (no closure minification).

## Not done here (flagged)

- `--closure=1` + `-sFILESYSTEM=0` shrink the JS glue ~10x more but need a headless render test (the renderer wasm has no automated browser test today). Deferred, see doc 0055.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
