### PR TITLE
Geode: triangle/band geometry debug overlay + editor View-menu toggle

### DIFF
--- a/donner/editor/AsyncRenderer.cc
+++ b/donner/editor/AsyncRenderer.cc
@@ -569,6 +569,18 @@ void AsyncRenderer::workerLoop() {
     compositor_->setTightBoundedSegmentsEnabled(
         tightBoundedSegments_.load(std::memory_order_acquire));
 
+    // Push the Geode geometry debug overlay flag into the document
+    // renderer. Applied unconditionally (cheap bool store, and it must
+    // reach a renderer that changed under us); on a flip, every cached
+    // segment bitmap is stale (the overlay draws into rasterized
+    // tiles), so force a full re-raster.
+    const bool geometryDebugOverlay = geometryDebugOverlay_.load(std::memory_order_acquire);
+    requestRenderer.setDebugGeometryOverlay(geometryDebugOverlay);
+    if (geometryDebugOverlay != appliedGeometryDebugOverlay_) {
+      appliedGeometryDebugOverlay_ = geometryDebugOverlay;
+      compositor_->resetAllLayers();
+    }
+
     // Keep the compositor hint in ActiveDrag across mouse-up so the
     // layer/segment caches survive quick release->drag-again cycles, but
     // only skip the main-renderer compose while an actual drag request is

--- a/donner/editor/AsyncRenderer.h
+++ b/donner/editor/AsyncRenderer.h
@@ -393,6 +393,25 @@ public:
     return tightBoundedSegments_.load(std::memory_order_acquire);
   }
 
+  /// Toggle the Geode geometry debug overlay
+  /// (`RendererInterface::setDebugGeometryOverlay`) on the document
+  /// renderer. The change applies at the start of the next worker
+  /// iteration; on a flip the worker also calls
+  /// `CompositorController::resetAllLayers()` so every cached segment
+  /// re-rasterizes with the new overlay state.
+  ///
+  /// Same threading contract as \ref setTightBoundedSegmentsEnabled:
+  /// safe to call from the UI thread while a render is in flight.
+  void setGeometryDebugOverlayEnabled(bool enabled) {
+    geometryDebugOverlay_.store(enabled, std::memory_order_release);
+  }
+
+  /// Mirror of the current overlay state. UI reads this to render the
+  /// correct check state in the View menu without racing the worker.
+  [[nodiscard]] bool geometryDebugOverlayEnabled() const {
+    return geometryDebugOverlay_.load(std::memory_order_acquire);
+  }
+
   /// Number of times the worker has called `CompositorController::resetAllLayers()`
   /// since construction. Tests use this to assert that frame-version mutations
   /// do not masquerade as document replacements.
@@ -645,6 +664,16 @@ private:
   /// Default-true matches `CompositorConfig::tightBoundedSegments`. See
   /// `setTightBoundedSegmentsEnabled`.
   std::atomic<bool> tightBoundedSegments_{true};
+
+  /// Geode geometry debug overlay request from the UI thread. See
+  /// `setGeometryDebugOverlayEnabled`. Default-off matches the
+  /// renderer's default.
+  std::atomic<bool> geometryDebugOverlay_{false};
+
+  /// Worker-thread-only: the overlay state last applied to the request
+  /// renderer, so the worker can detect flips and invalidate cached
+  /// segments exactly once per change.
+  bool appliedGeometryDebugOverlay_ = false;
 
   /// Replay/test-only fixed delay injected into each worker render attempt.
   std::atomic<std::chrono::milliseconds::rep> replayRenderDelayMsForTesting_{0};

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -1586,7 +1586,16 @@ void EditorShell::applyMenuActions(const MenuBarActions& menuActions) {
   }
   const bool showCompositorDebugPanelBeforeMenu = showCompositorDebugPanel_;
   const PerfOverlayMode perfOverlayModeBeforeMenu = perfOverlayMode_;
-  ApplyViewMenuToggleActions(menuActions, &showCompositorDebugPanel_, &perfOverlayMode_);
+  const bool geometryDebugOverlayBeforeMenu = geometryDebugOverlay_;
+  ApplyViewMenuToggleActions(menuActions, &showCompositorDebugPanel_, &perfOverlayMode_,
+                             &geometryDebugOverlay_);
+  if (geometryDebugOverlay_ != geometryDebugOverlayBeforeMenu) {
+    // Push the new overlay state to the render worker and post a render:
+    // the worker re-rasterizes every cached segment with the overlay
+    // state on its next iteration (see AsyncRenderer::workerLoop).
+    renderCoordinator_.asyncRenderer().setGeometryDebugOverlayEnabled(geometryDebugOverlay_);
+    requestRenderAtEndOfFrame_ = true;
+  }
   // DockSpace layout controls: toggle the lock or request a rebuild of the
   // default layout. renderDockSpaceHost consumes the reset request next frame.
   if (menuActions.toggleLayoutLock) {
@@ -1598,7 +1607,8 @@ void EditorShell::applyMenuActions(const MenuBarActions& menuActions) {
     window_.wakeEventLoop();
   }
   if (showCompositorDebugPanel_ != showCompositorDebugPanelBeforeMenu ||
-      perfOverlayMode_ != perfOverlayModeBeforeMenu) {
+      perfOverlayMode_ != perfOverlayModeBeforeMenu ||
+      geometryDebugOverlay_ != geometryDebugOverlayBeforeMenu) {
     window_.wakeEventLoop();
   }
 }
@@ -4635,6 +4645,7 @@ void EditorShell::runFrame() {
       .hasTextSelection = selectionIsAllText(),
       .hasSelectableElements = canvasHasSelectableElements(),
       .showCompositorDebugPanel = showCompositorDebugPanel_,
+      .geometryDebugOverlay = geometryDebugOverlay_,
       .perfOverlayMode = perfOverlayMode_,
       .panelLayoutLocked = dockLayoutLocked_,
   };

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -586,6 +586,12 @@ private:
   /// Render-pane frame-timing/perf overlay mode. Off by default; set via the
   /// View menu's Performance Overlay submenu.
   PerfOverlayMode perfOverlayMode_ = PerfOverlayMode::Off;
+  /// Whether the Geode geometry debug overlay is enabled on the document
+  /// renderer (band strips + per-path bounding-quad triangles drawn into
+  /// rasterized tiles). Off by default; toggled via the View menu. Applied
+  /// to the render worker through
+  /// `AsyncRenderer::setGeometryDebugOverlayEnabled`.
+  bool geometryDebugOverlay_ = false;
 
   ImFont* uiFontBold_ = nullptr;
   ImFont* codeFont_ = nullptr;

--- a/donner/editor/MenuBarPresenter.cc
+++ b/donner/editor/MenuBarPresenter.cc
@@ -51,6 +51,9 @@ void ApplyMenuBarCommand(bool activated, MenuBarCommand command, const MenuBarSt
     case MenuBarCommand::ToggleCompositorDebugPanel:
       actions->toggleCompositorDebugPanel = true;
       return;
+    case MenuBarCommand::ToggleGeometryDebugOverlay:
+      actions->toggleGeometryDebugOverlay = true;
+      return;
     case MenuBarCommand::SetPerfOverlayOff:
       actions->setPerfOverlayMode = true;
       actions->perfOverlayMode = PerfOverlayMode::Off;
@@ -69,12 +72,15 @@ void ApplyMenuBarCommand(bool activated, MenuBarCommand command, const MenuBarSt
 }
 
 void ApplyViewMenuToggleActions(const MenuBarActions& actions, bool* showCompositorDebugPanel,
-                                PerfOverlayMode* perfOverlayMode) {
+                                PerfOverlayMode* perfOverlayMode, bool* geometryDebugOverlay) {
   if (actions.toggleCompositorDebugPanel && showCompositorDebugPanel != nullptr) {
     *showCompositorDebugPanel = !*showCompositorDebugPanel;
   }
   if (actions.setPerfOverlayMode && perfOverlayMode != nullptr) {
     *perfOverlayMode = actions.perfOverlayMode;
+  }
+  if (actions.toggleGeometryDebugOverlay && geometryDebugOverlay != nullptr) {
+    *geometryDebugOverlay = !*geometryDebugOverlay;
   }
 }
 
@@ -173,6 +179,9 @@ MenuBarActions MenuBarPresenter::render(const MenuBarState& state, ImFont* boldM
     ApplyMenuBarCommand(
         ImGui::MenuItem("Compositor Debug", nullptr, state.showCompositorDebugPanel),
         MenuBarCommand::ToggleCompositorDebugPanel, state, &actions);
+    ApplyMenuBarCommand(
+        ImGui::MenuItem("Geometry Debug Overlay", nullptr, state.geometryDebugOverlay),
+        MenuBarCommand::ToggleGeometryDebugOverlay, state, &actions);
     ImGui::Separator();
     ApplyMenuBarCommand(ImGui::MenuItem("Lock Panel Layout", nullptr, state.panelLayoutLocked),
                         MenuBarCommand::ToggleLayoutLock, state, &actions);

--- a/donner/editor/MenuBarPresenter.h
+++ b/donner/editor/MenuBarPresenter.h
@@ -40,6 +40,10 @@ struct MenuBarState {
   /// Current visibility of the Compositor Debug panel (drives the View-menu
   /// checkmark). Off by default.
   bool showCompositorDebugPanel = false;
+  /// Whether the Geode geometry debug overlay (band strips + per-path
+  /// bounding-quad triangles) is enabled on the document renderer
+  /// (drives the View-menu checkmark). Off by default.
+  bool geometryDebugOverlay = false;
   /// Current render-pane performance overlay mode (drives the View-menu
   /// checkmarks). Off by default.
   PerfOverlayMode perfOverlayMode = PerfOverlayMode::Off;
@@ -80,6 +84,9 @@ struct MenuBarActions {
   bool toggleSourceFocusMode = false;
   /// Set when the user toggles the Compositor Debug panel via the View menu.
   bool toggleCompositorDebugPanel = false;
+  /// Set when the user toggles the Geode geometry debug overlay via the
+  /// View menu.
+  bool toggleGeometryDebugOverlay = false;
   /// Set when the user picks a performance overlay mode via the View menu.
   bool setPerfOverlayMode = false;
   /// Requested performance overlay mode; meaningful only while
@@ -115,6 +122,7 @@ enum class MenuBarCommand {
   ActualSize,
   ToggleSourceFocusMode,
   ToggleCompositorDebugPanel,
+  ToggleGeometryDebugOverlay,
   SetPerfOverlayOff,
   SetPerfOverlayFpsPill,
   SetPerfOverlayFullGraph,
@@ -136,8 +144,11 @@ void ApplyMenuBarCommand(bool activated, MenuBarCommand command, const MenuBarSt
 /// @param actions Edge-triggered menu actions from \ref MenuBarPresenter::render.
 /// @param showCompositorDebugPanel Current Compositor Debug panel visibility.
 /// @param perfOverlayMode Current performance overlay mode.
+/// @param geometryDebugOverlay Current Geode geometry debug overlay state.
+///   Optional (may be null) so callers without a document renderer skip it.
 void ApplyViewMenuToggleActions(const MenuBarActions& actions, bool* showCompositorDebugPanel,
-                                PerfOverlayMode* perfOverlayMode);
+                                PerfOverlayMode* perfOverlayMode,
+                                bool* geometryDebugOverlay = nullptr);
 
 /// Renders the app's top menu bar and reports semantic actions back to the shell.
 class MenuBarPresenter {

--- a/donner/editor/tests/ViewMenuVisibility_tests.cc
+++ b/donner/editor/tests/ViewMenuVisibility_tests.cc
@@ -17,6 +17,8 @@ TEST(ViewMenuVisibility, MenuBarStateDefaultsMatchVisibilityContract) {
       << "Compositor Debug panel must default to hidden (developer diagnostics only)";
   EXPECT_EQ(state.perfOverlayMode, PerfOverlayMode::Off)
       << "Performance overlay must default to off";
+  EXPECT_FALSE(state.geometryDebugOverlay)
+      << "Geode geometry debug overlay must default to off (zero impact on normal rendering)";
 }
 
 // The toggle actions are edge-triggered requests, so they must default to false
@@ -25,6 +27,7 @@ TEST(ViewMenuVisibility, MenuBarActionsToggleRequestsDefaultFalse) {
   const MenuBarActions actions;
   EXPECT_FALSE(actions.toggleCompositorDebugPanel);
   EXPECT_FALSE(actions.setPerfOverlayMode);
+  EXPECT_FALSE(actions.toggleGeometryDebugOverlay);
 }
 
 TEST(ViewMenuVisibility, ToggleActionsFlipCompositorDebugPanel) {
@@ -88,6 +91,31 @@ TEST(ViewMenuVisibility, ToggleActionsIgnoreNullVisibilityPointers) {
   ApplyViewMenuToggleActions(actions, nullptr, nullptr);
   EXPECT_TRUE(showCompositorDebugPanel);
   EXPECT_EQ(perfOverlayMode, PerfOverlayMode::Off);
+}
+
+TEST(ViewMenuVisibility, ToggleActionsFlipGeometryDebugOverlay) {
+  bool showCompositorDebugPanel = false;
+  PerfOverlayMode perfOverlayMode = PerfOverlayMode::Off;
+  bool geometryDebugOverlay = false;
+  MenuBarActions actions;
+  actions.toggleGeometryDebugOverlay = true;
+
+  ApplyViewMenuToggleActions(actions, &showCompositorDebugPanel, &perfOverlayMode,
+                             &geometryDebugOverlay);
+
+  EXPECT_TRUE(geometryDebugOverlay);
+  EXPECT_FALSE(showCompositorDebugPanel);
+  EXPECT_EQ(perfOverlayMode, PerfOverlayMode::Off);
+
+  ApplyViewMenuToggleActions(actions, &showCompositorDebugPanel, &perfOverlayMode,
+                             &geometryDebugOverlay);
+
+  EXPECT_FALSE(geometryDebugOverlay);
+
+  // Callers without a document renderer omit the pointer; the toggle
+  // request must be ignored (default argument is null).
+  ApplyViewMenuToggleActions(actions, &showCompositorDebugPanel, &perfOverlayMode);
+  EXPECT_FALSE(geometryDebugOverlay);
 }
 
 }  // namespace donner::editor

--- a/donner/svg/renderer/Renderer.cc
+++ b/donner/svg/renderer/Renderer.cc
@@ -560,6 +560,14 @@ std::unique_ptr<RendererInterface> Renderer::createOffscreenInstance() const {
   return impl_->createOffscreenInstance();
 }
 
+void Renderer::setDebugGeometryOverlay(bool enabled) {
+  impl_->setDebugGeometryOverlay(enabled);
+}
+
+bool Renderer::debugGeometryOverlay() const {
+  return impl_->debugGeometryOverlay();
+}
+
 bool Renderer::save(const char* filename) {
   const RendererBitmap snapshot = takeSnapshot();
   if (snapshot.empty()) {

--- a/donner/svg/renderer/Renderer.h
+++ b/donner/svg/renderer/Renderer.h
@@ -261,6 +261,13 @@ public:
   /// Creates an offscreen renderer of the active backend type.
   [[nodiscard]] std::unique_ptr<RendererInterface> createOffscreenInstance() const override;
 
+  /// Forwards \ref RendererInterface::setDebugGeometryOverlay to the
+  /// active backend (no-op for backends without a debug overlay).
+  void setDebugGeometryOverlay(bool enabled) override;
+
+  /// Whether the active backend's geometry debug overlay is enabled.
+  [[nodiscard]] bool debugGeometryOverlay() const override;
+
   /**
    * Saves the last rendered frame to a PNG file.
    *

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1402,6 +1402,91 @@ struct RendererGeode::Impl {
   /// registries are never considered "consecutive same-source").
   Entity lastDrawSourceEntity = entt::null;
 
+  /// Debug geometry overlay (see `RendererGeode::setDebugGeometryOverlay`).
+  /// When true, every `drawPath` additionally outlines the Slug band
+  /// decomposition Geode emits for the draw: horizontal band strips,
+  /// vertical band strips, and the single bounding quad (with its
+  /// triangle diagonal) that is the geometry actually rasterized.
+  /// Default off; every overlay code path is behind this flag so the
+  /// disabled state is byte-identical to a build without the feature.
+  bool debugGeometryOverlay = false;
+
+  /// Draw the debug overlay for one encoded path. Called from `drawPath`
+  /// after the normal fill/stroke draws so the overlay renders on top.
+  /// Uses `GeoEncoder::fillPath` directly (hairline rings built as
+  /// EvenOdd outer+inset rectangles), so no new pipelines or shaders are
+  /// involved; overlay draws cost normal draw-call counters, which is
+  /// acceptable for a debug mode.
+  void drawEncodedPathOverlay(const geode::EncodedPath& encoded) {
+    if (!encoder || encoded.empty()) {
+      return;
+    }
+    syncTransform();
+
+    // Hairline width: one device pixel expressed in path space. The
+    // linear part's determinant gives the area scale of the transform;
+    // its square root approximates the isotropic scale factor.
+    const double det = std::abs(deviceFromLocalTransform.determinant());
+    const double scale = det > 0.0 ? std::sqrt(det) : 1.0;
+    const double w = 1.0 / std::max(scale, 1e-6);
+
+    // A hairline rectangular ring: outer rect + inset rect, filled
+    // EvenOdd so only the border remains.
+    const auto addRing = [w](PathBuilder& builder, const Box2d& rect) {
+      builder.addRect(rect);
+      const Box2d inner(rect.topLeft + Vector2d(w, w), rect.bottomRight - Vector2d(w, w));
+      if (inner.bottomRight.x > inner.topLeft.x && inner.bottomRight.y > inner.topLeft.y) {
+        builder.addRect(inner);
+      }
+    };
+
+    // Horizontal (Y-strip) bands: cyan.
+    if (!encoded.bands.empty()) {
+      PathBuilder builder;
+      for (const geode::EncodedPath::Band& band : encoded.bands) {
+        addRing(builder, Box2d(Vector2d(band.xMin, band.yMin), Vector2d(band.xMax, band.yMax)));
+      }
+      encoder->fillPath(builder.build(), css::RGBA(0, 200, 255, 160), FillRule::EvenOdd);
+    }
+
+    // Vertical (X-strip) bands: yellow. Field semantics are transposed
+    // for vertical bands (`xMin`/`xMax` = strip bounds, `yMin`/`yMax` =
+    // curve extent), but both pairs still form the band's rectangle.
+    if (!encoded.vBands.empty()) {
+      PathBuilder builder;
+      for (const geode::EncodedPath::Band& band : encoded.vBands) {
+        addRing(builder, Box2d(Vector2d(band.xMin, band.yMin), Vector2d(band.xMax, band.yMax)));
+      }
+      encoder->fillPath(builder.build(), css::RGBA(255, 200, 0, 140), FillRule::EvenOdd);
+    }
+
+    // Bounding quad + triangle diagonal: magenta. This is the geometry
+    // Geode actually rasterizes - one quad (two triangles) per path
+    // (0041: one fragment per pixel, band lookup in the fragment
+    // shader). The diagonal runs between the shared vertices of the two
+    // triangles: (xMin, yMin) -> (xMax, yMax) per
+    // `GeodePathEncoder::encode`'s quadVertices emission order.
+    {
+      const Box2d& b = encoded.pathBounds;
+      PathBuilder builder;
+      addRing(builder, b);
+      const Vector2d d = (b.bottomRight - b.topLeft);
+      const double len = d.length();
+      if (len > w) {
+        // Thin quad along the diagonal, offset w/2 perpendicular.
+        const Vector2d unit = d / len;
+        const Vector2d perp(-unit.y * w * 0.5, unit.x * w * 0.5);
+        builder.moveTo(b.topLeft + perp)
+            .lineTo(b.bottomRight + perp)
+            .lineTo(b.bottomRight - perp)
+            .lineTo(b.topLeft - perp)
+            .closePath();
+      }
+      encoder->fillPath(builder.build(), css::RGBA(255, 0, 255, 200), FillRule::NonZero);
+    }
+  }
+
+
   /// M6-B step 3 (design doc 0030 §M6 Bullet 2): deferred batch for
   /// consecutive `drawPath` calls that share a source entity + resolved
   /// solid paint + no stroke + no subtree complication. Each matching
@@ -1467,6 +1552,18 @@ struct RendererGeode::Impl {
     /// subpath → NonZero; for closed-path strokes, two → EvenOdd.
     FillRule fillRule = FillRule::NonZero;
   };
+
+  /// Debug-overlay companion for a stroke draw: visualize the encode of
+  /// the stroked outline (the geometry Geode actually emits for the
+  /// stroke). Falls back to a local encode when the stroke came from the
+  /// no-entity path (no cache slot).
+  void drawStrokeOverlay(const Path& strokedOutline, const StrokeDerived& derived) {
+    if (derived.encoded != nullptr) {
+      drawEncodedPathOverlay(*derived.encoded);
+    } else {
+      drawEncodedPathOverlay(geode::GeodePathEncoder::encode(strokedOutline, derived.fillRule));
+    }
+  }
 
   /// Encode-side of the cache. If `source` holds a valid entity handle,
   /// installs / reuses a `GeodePathCacheComponent::fillEncode` on it and
@@ -1968,6 +2065,14 @@ RendererGeode::RendererGeode(std::shared_ptr<geode::GeodeDevice> device, bool ve
 void RendererGeode::enableTimestamps(bool /*enabled*/) {
   // Reserved for future work (design doc 0030, "Future Work"). Counters
   // are the durable regression signal and are always enabled.
+}
+
+void RendererGeode::setDebugGeometryOverlay(bool enabled) {
+  impl_->debugGeometryOverlay = enabled;
+}
+
+bool RendererGeode::debugGeometryOverlay() const {
+  return impl_->debugGeometryOverlay;
 }
 
 FrameTimings RendererGeode::lastFrameTimings() const {
@@ -3551,7 +3656,10 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   // draw.
   const bool hasStroke = !(stroke.strokeWidth <= 0.0 ||
                            std::holds_alternative<PaintServer::None>(impl_->paint.stroke));
-  const bool batchable = !hasStroke && fillEncoded != nullptr &&
+  // The debug geometry overlay draws per-path, immediately after the
+  // path's own draws, so batching is disabled while it is on (debug
+  // mode trades the batching win for draw-order fidelity).
+  const bool batchable = !impl_->debugGeometryOverlay && !hasStroke && fillEncoded != nullptr &&
                          path.sourceEntity.entity() != entt::null &&
                          std::holds_alternative<PaintServer::Solid>(impl_->paint.fill) &&
                          !impl_->patternFillPaint.has_value() && impl_->encoder != nullptr &&
@@ -3573,6 +3681,15 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   // Both default to true, so this is a no-op for ordinary fill-then-stroke draws.
   if (impl_->paint.drawFillComponent) {
     impl_->fillResolved(path.path, path.fillRule, fillEncoded);
+    if (impl_->debugGeometryOverlay &&
+        !std::holds_alternative<PaintServer::None>(impl_->paint.fill)) {
+      if (fillEncoded != nullptr) {
+        impl_->drawEncodedPathOverlay(*fillEncoded);
+      } else {
+        impl_->drawEncodedPathOverlay(
+            geode::GeodePathEncoder::encode(path.path, path.fillRule));
+      }
+    }
   }
 
   // Mirror fillResolved's no-op safety: if there's no encoder (headless
@@ -3633,6 +3750,9 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
       impl_->device->deferDestroy(impl_->patternStrokePaint->tile.take());
     }
     impl_->patternStrokePaint.reset();
+    if (impl_->debugGeometryOverlay) {
+      impl_->drawStrokeOverlay(strokedOutline, strokeDerived);
+    }
     return;
   }
 
@@ -3645,6 +3765,9 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   auto strokeServer = impl_->paint.stroke;
   impl_->drawPaintedPathAgainst(path.path, strokedOutline, strokeServer, effectiveOpacity,
                                 strokeDerived.fillRule, strokeDerived.encoded);
+  if (impl_->debugGeometryOverlay) {
+    impl_->drawStrokeOverlay(strokedOutline, strokeDerived);
+  }
 }
 
 void RendererGeode::drawRect(const Box2d& rect, const StrokeParams& stroke) {

--- a/donner/svg/renderer/RendererGeode.h
+++ b/donner/svg/renderer/RendererGeode.h
@@ -267,6 +267,26 @@ public:
   void enableTimestamps(bool enabled);
 
   /**
+   * Enable or disable the Geode geometry debug overlay.
+   *
+   * When enabled, every path draw (fills, strokes, rects, ellipses)
+   * additionally outlines the Slug band decomposition Geode emits for
+   * that draw: horizontal band strips (cyan), vertical band strips
+   * (yellow), and the per-path bounding quad with its triangle diagonal
+   * (magenta) - the two triangles Geode actually rasterizes (0041).
+   * Overlay draws render through the normal fill pipeline, so they are
+   * included in `lastFrameTimings()` counters. `<use>` instancing is
+   * disabled while the overlay is on so overlays stay in draw order.
+   *
+   * Default off. When off, rendering behavior and performance are
+   * unchanged; the only cost is one boolean test per draw.
+   */
+  void setDebugGeometryOverlay(bool enabled);
+
+  /// Whether the geometry debug overlay is enabled.
+  [[nodiscard]] bool debugGeometryOverlay() const;
+
+  /**
    * Returns per-frame instrumentation for the most recently completed
    * `beginFrame`→`endFrame` window. Valid after the first `endFrame()`;
    * before then all fields are zero.

--- a/donner/svg/renderer/RendererGeode.h
+++ b/donner/svg/renderer/RendererGeode.h
@@ -281,10 +281,10 @@ public:
    * Default off. When off, rendering behavior and performance are
    * unchanged; the only cost is one boolean test per draw.
    */
-  void setDebugGeometryOverlay(bool enabled);
+  void setDebugGeometryOverlay(bool enabled) override;
 
   /// Whether the geometry debug overlay is enabled.
-  [[nodiscard]] bool debugGeometryOverlay() const;
+  [[nodiscard]] bool debugGeometryOverlay() const override;
 
   /**
    * Returns per-frame instrumentation for the most recently completed

--- a/donner/svg/renderer/RendererInterface.h
+++ b/donner/svg/renderer/RendererInterface.h
@@ -472,6 +472,18 @@ public:
   [[nodiscard]] virtual std::unique_ptr<RendererInterface> createOffscreenInstance() const {
     return nullptr;
   }
+
+  /**
+   * Enable or disable the backend's geometry debug overlay, which
+   * visualizes the internal geometry the backend emits per draw (for
+   * Geode: Slug band strips and the per-path bounding-quad triangles).
+   * Default off. Backends without a debug overlay ignore the call.
+   */
+  virtual void setDebugGeometryOverlay(bool /*enabled*/) {}
+
+  /// Whether the backend's geometry debug overlay is enabled. Backends
+  /// without an overlay always report false.
+  [[nodiscard]] virtual bool debugGeometryOverlay() const { return false; }
 };
 
 }  // namespace donner::svg

--- a/donner/svg/renderer/geode/BUILD.bazel
+++ b/donner/svg/renderer/geode/BUILD.bazel
@@ -590,3 +590,27 @@ donner_multi_transitioned_test(
     dep = ":geode_embed_tests_impl",
     renderer_backend = "geode",
 )
+
+# Geode geometry debug overlay (RendererGeode::setDebugGeometryOverlay):
+# default-off contract, overlay-on rendering, and clean toggling.
+donner_cc_test(
+    name = "geode_debug_overlay_tests_impl",
+    srcs = ["tests/GeodeDebugOverlay_tests.cc"],
+    target_compatible_with = _GEODE_ONLY,
+    deps = [
+        ":geode_device",
+        "//donner/base",
+        "//donner/base:gtest_timeout_main",
+        "//donner/svg",
+        "//donner/svg/parser",
+        "//donner/svg/renderer:renderer_geode",
+        "//donner/svg/renderer:renderer_interface",
+    ],
+)
+
+donner_multi_transitioned_test(
+    name = "geode_debug_overlay_tests",
+    testonly = 1,
+    dep = ":geode_debug_overlay_tests_impl",
+    renderer_backend = "geode",
+)

--- a/donner/svg/renderer/geode/tests/GeodeDebugOverlay_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeDebugOverlay_tests.cc
@@ -1,0 +1,162 @@
+/// @file
+/// Tests for `RendererGeode::setDebugGeometryOverlay` - the Geode band /
+/// triangle debug overlay.
+///
+/// Contract under test:
+///  1. Overlay OFF is the default and is byte-identical to a renderer
+///     that never touched the flag (zero behavior change when off).
+///  2. Overlay ON changes the output and paints the overlay palette
+///     (magenta bounding-quad wireframe) over the scene.
+///  3. Overlay ON emits additional draw calls; turning it back off
+///     restores byte-identical output (no sticky state).
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <string_view>
+
+#include "donner/base/ParseWarningSink.h"
+#include "donner/svg/SVGDocument.h"
+#include "donner/svg/parser/SVGParser.h"
+#include "donner/svg/renderer/RendererGeode.h"
+#include "donner/svg/renderer/RendererInterface.h"
+#include "donner/svg/renderer/geode/GeodeDevice.h"
+
+namespace donner::svg {
+namespace {
+
+/// Fixture with a fill, a stroked path, and a curve so the overlay
+/// exercises fill encodes, stroke encodes, and multi-band paths.
+constexpr std::string_view kOverlaySvg = R"SVG(
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect x="20" y="20" width="70" height="70" fill="#336699"/>
+  <path d="M 110 30 C 150 10 180 60 160 100 S 120 180 100 150 Z"
+        fill="#66aa33" stroke="black" stroke-width="4"/>
+</svg>
+)SVG";
+
+SVGDocument parseDocument(std::string_view svgSource) {
+  ParseWarningSink sink = ParseWarningSink::Disabled();
+  auto parsed = parser::SVGParser::ParseSVG(svgSource, sink);
+  EXPECT_FALSE(parsed.hasError()) << (parsed.hasError() ? parsed.error().reason : "");
+  return std::move(parsed.result());
+}
+
+/// Render the fixture and snapshot it. `overlay` selects the debug
+/// overlay state; `std::nullopt`-style third state is covered by
+/// `renderDefault` which never calls the setter.
+RendererBitmap renderWithOverlay(const std::shared_ptr<geode::GeodeDevice>& device, bool overlay) {
+  SVGDocument document = parseDocument(kOverlaySvg);
+  RendererGeode renderer(device);
+  renderer.setDebugGeometryOverlay(overlay);
+  renderer.draw(document);
+  return renderer.takeSnapshot();
+}
+
+/// Render without ever touching the overlay setter.
+RendererBitmap renderDefault(const std::shared_ptr<geode::GeodeDevice>& device) {
+  SVGDocument document = parseDocument(kOverlaySvg);
+  RendererGeode renderer(device);
+  renderer.draw(document);
+  return renderer.takeSnapshot();
+}
+
+bool bitmapsIdentical(const RendererBitmap& a, const RendererBitmap& b) {
+  return a.dimensions == b.dimensions && a.rowBytes == b.rowBytes && a.pixels == b.pixels;
+}
+
+/// Count pixels in the overlay's magenta family (bounding-quad wireframe:
+/// RGBA(255, 0, 255, 200) blended over arbitrary content keeps R and B
+/// high and G low).
+int countMagentaFamilyPixels(const RendererBitmap& bitmap) {
+  int count = 0;
+  for (int y = 0; y < bitmap.dimensions.y; ++y) {
+    const uint8_t* row = bitmap.pixels.data() + static_cast<size_t>(y) * bitmap.rowBytes;
+    for (int x = 0; x < bitmap.dimensions.x; ++x) {
+      const uint8_t* px = row + static_cast<size_t>(x) * 4;
+      if (px[0] > 150 && px[2] > 150 && px[1] < 80) {
+        ++count;
+      }
+    }
+  }
+  return count;
+}
+
+class GeodeDebugOverlayTest : public ::testing::Test {
+protected:
+  static std::shared_ptr<geode::GeodeDevice> sharedDevice() {
+    static auto device = [] {
+      return std::shared_ptr<geode::GeodeDevice>(geode::GeodeDevice::CreateHeadless());
+    }();
+    return device;
+  }
+};
+
+TEST_F(GeodeDebugOverlayTest, DefaultsOff) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  RendererGeode renderer(device);
+  EXPECT_FALSE(renderer.debugGeometryOverlay());
+}
+
+TEST_F(GeodeDebugOverlayTest, OffIsByteIdenticalToDefault) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  const RendererBitmap untouched = renderDefault(device);
+  const RendererBitmap explicitlyOff = renderWithOverlay(device, false);
+
+  ASSERT_FALSE(untouched.empty());
+  EXPECT_TRUE(bitmapsIdentical(untouched, explicitlyOff))
+      << "setDebugGeometryOverlay(false) must not change output vs never calling it.";
+}
+
+TEST_F(GeodeDebugOverlayTest, OnDrawsOverlayGeometry) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  const RendererBitmap off = renderWithOverlay(device, false);
+  const RendererBitmap on = renderWithOverlay(device, true);
+
+  ASSERT_FALSE(off.empty());
+  ASSERT_FALSE(on.empty());
+  EXPECT_FALSE(bitmapsIdentical(off, on)) << "Overlay-on output must differ from overlay-off.";
+
+  // The bounding-quad wireframe is magenta; at least a hairline's worth
+  // of pixels must land in the magenta family. Overlay-off must have none
+  // (the fixture palette has no magenta).
+  EXPECT_EQ(countMagentaFamilyPixels(off), 0);
+  EXPECT_GT(countMagentaFamilyPixels(on), 50);
+}
+
+TEST_F(GeodeDebugOverlayTest, OnEmitsExtraDrawsAndTogglesCleanly) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  SVGDocument document = parseDocument(kOverlaySvg);
+  RendererGeode renderer(device);
+
+  renderer.draw(document);
+  const RendererBitmap beforeBitmap = renderer.takeSnapshot();
+  const uint64_t drawsOff = renderer.lastFrameTimings().counters.drawCalls;
+
+  renderer.setDebugGeometryOverlay(true);
+  renderer.draw(document);
+  const uint64_t drawsOn = renderer.lastFrameTimings().counters.drawCalls;
+  EXPECT_GT(drawsOn, drawsOff) << "Overlay-on frame should emit additional overlay draw calls.";
+
+  // Toggling back off restores byte-identical output on the same renderer.
+  renderer.setDebugGeometryOverlay(false);
+  renderer.draw(document);
+  const RendererBitmap afterBitmap = renderer.takeSnapshot();
+  const uint64_t drawsOffAgain = renderer.lastFrameTimings().counters.drawCalls;
+
+  EXPECT_EQ(drawsOffAgain, drawsOff);
+  EXPECT_TRUE(bitmapsIdentical(beforeBitmap, afterBitmap))
+      << "Disabling the overlay must fully restore non-overlay rendering.";
+}
+
+}  // namespace
+}  // namespace donner::svg


### PR DESCRIPTION
## Summary

Adds a user-visible debug overlay that visualizes the banded/tessellated geometry Geode actually emits, wired end to end from the editor View menu to the document renderer. Stacked on #809.

### Renderer (RendererGeode::setDebugGeometryOverlay)

- Every drawPath (fills, strokes, rects, ellipses) additionally outlines the Slug band decomposition for that draw: horizontal band strips (cyan), vertical band strips (yellow), and the per-path bounding quad with its triangle diagonal (magenta), which is the two-triangle geometry Geode rasterizes per path (design 0041).
- Overlay geometry renders as hairline EvenOdd rings through the existing fill pipeline: no new shaders, pipelines, or compositor changes. use-instancing batching is disabled while the overlay is on to preserve draw order.
- Default off. When off the only cost is one boolean test per draw, and output is byte-identical: guarded by GeodeDebugOverlay_tests.OffIsByteIdenticalToDefault, and geode goldens are unchanged.

### Editor

- New View > Geometry Debug Overlay item following the Compositor Debug toggle plumbing (MenuBarState/MenuBarActions/MenuBarCommand/ApplyViewMenuToggleActions).
- The flag reaches the renderer that actually rasterizes document tiles: setDebugGeometryOverlay is a default-no-op virtual on RendererInterface, overridden by RendererGeode and forwarded by the svg::Renderer facade; AsyncRenderer pushes the UI-thread state into the request renderer each worker iteration (tightBoundedSegments pattern) and calls CompositorController::resetAllLayers() on a flip so cached segments re-rasterize.

## Testing

- New //donner/svg/renderer/geode:geode_debug_overlay_tests (4 tests): default-off, overlay-off byte-identical to untouched renderer, overlay-on draws overlay colors and differs, overlay toggles cleanly with extra draw calls counted.
- ViewMenuVisibility_tests extended for the new toggle (default off, flip, null-pointer case).
- bazel test //donner/editor/... : 260 pass / 6 skipped / 0 fail. //donner/svg/renderer/... : 102 pass / 13 skipped / 0 fail, including renderer_geode_golden_tests (bit-identical with overlay off).

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17