### PR TITLE
Geode: cross-frame arena buffer pool; drop dead per-band vertices; docs to as-built

### DIFF
--- a/docs/design_docs/0017-geode_renderer.md
+++ b/docs/design_docs/0017-geode_renderer.md
@@ -792,6 +792,33 @@ struct GeodeLayerStack {
 - **Patterns:** Render the pattern tile into a texture, then use it as a repeating shader in
   subsequent draws.
 
+### Debug and Diagnostics
+
+Geode ships a geometry debug overlay for inspecting the banded geometry
+it emits per draw:
+
+- `RendererGeode::setDebugGeometryOverlay(bool)` (surfaced as a
+  default-no-op virtual on `RendererInterface` and forwarded by the
+  `svg::Renderer` facade) makes every path draw additionally outline its
+  Slug band decomposition: horizontal band strips (cyan), vertical band
+  strips (yellow), and the whole-path bounding quad with its triangle
+  diagonal (magenta) - the two triangles Geode actually rasterizes per
+  path. Overlay geometry renders as hairline EvenOdd rings through the
+  existing fill pipeline; no dedicated shaders or pipelines exist for it.
+- Default off. When off, rendering is byte-identical to a build without
+  the feature (asserted by `GeodeDebugOverlay_tests` and the geode
+  goldens); the only cost is one boolean test per draw. `<use>`
+  instancing is disabled while the overlay is on so overlay draws stay
+  in paint order.
+- The editor exposes it as View > Geometry Debug Overlay. The flag rides
+  `AsyncRenderer`'s atomic-push channel into the render worker's
+  document renderer, and a flip resets all compositor layers so cached
+  segment bitmaps re-rasterize with the new state.
+
+Per-frame instrumentation (`GeodeCounters`: resource creates, submits,
+draw calls, pipeline switches, writeBuffer/writeTexture call and byte
+volumes) is owned by design doc 0030 (geode_performance).
+
 ### ECS Integration for GPU Resource Caching
 
 Geode introduces ECS components for GPU resource lifetime management:

--- a/docs/design_docs/0030-geode_performance.md
+++ b/docs/design_docs/0030-geode_performance.md
@@ -744,10 +744,10 @@ including one `takeSnapshot()` readback per frame.
 
 | Fixture (frame 2, unchanged) | draws | pathEncodes | bufferCreates | bindgroupCreates | bufferWrites | bufferWriteBytes | textureWriteBytes |
 |---|---|---|---|---|---|---|---|
-| SimpleShapes (3 fills)  | 3   | 0 | 9  | 3   | 24   | 4,128     | 0 |
-| Moderate (layer + grad) | 3   | 0 | 18 | 3   | 17   | 5,372     | 0 |
-| lion.svg (132 paths)    | 132 | 0 | 12 | 132 | 1,056 | 172,776   | 0 |
-| Ghostscript_Tiger (304 paths) | 304 | 0 | 20 | 304 | 2,432 | 1,473,888 | 0 |
+| SimpleShapes (3 fills)  | 3   | 0 | 1 | 3   | 24   | 4,128     | 0 |
+| Moderate (layer + grad) | 3   | 0 | 2 | 3   | 17   | 5,372     | 0 |
+| lion.svg (132 paths)    | 132 | 0 | 1 | 132 | 1,056 | 172,776   | 0 |
+| Ghostscript_Tiger (304 paths) | 304 | 0 | 4 | 304 | 2,432 | 1,473,888 | 0 |
 
 First-frame values differ only in `pathEncodes` (one per path: Lion 132,
 Tiger encodes during frame 1) and `textureCreates` (render target
@@ -771,52 +771,47 @@ allocation); the upload traffic is identical on frame 1 and frame N.
    `dev.createBindGroup` for bindings that are byte-identical to the
    previous frame's. This is the M1.f.2 target
    (`bindgroupCreates <= pipelines`), still open.
-3. **The frame encoder and its arenas are recreated every frame.**
-   `RendererGeode::beginFrame` constructs a fresh `GeoEncoder`
-   (`RendererGeode.cc`, "Per-frame resources, recreated in beginFrame"),
-   so all bump arenas start at zero capacity and re-grow: steady-state
-   `bufferCreates` is 9-20 per frame (Lion 12, Tiger 20; Moderate 18
-   because layer push/pop spawns additional encoders) against the M1
-   target of 0. Every one of those is a `createBuffer` driver allocation
-   plus retirement of last frame's buffer - allocation churn that shows
-   up as frame-time jitter.
+3. **Arena buffers are pooled across frames (`GeodeBufferPool`).**
+   `RendererGeode::beginFrame` constructs a fresh `GeoEncoder` per frame
+   (and per layer / filter / mask push), but each encoder's bump-arena
+   buffers are recycled through a usage+label-keyed pool on
+   `RendererGeode::Impl` (companion to the M4.2 texture pool), so
+   steady-state `bufferCreates` is 1-4 per frame instead of one
+   `createBuffer` per arena per encoder. The residual creates are the
+   `takeSnapshot` readback buffer and the per-blit uniform buffers
+   below. Guarded by the `bufferCreates` ceilings in the
+   `*_NoDirtyPath_ZeroEncodes` tests.
 4. **Per-blit uniform buffers.** `GeodeTextureEncoder::drawTexturedQuad`
    creates a fresh uniform buffer per blit (`createBuffer` +
    `writeBuffer`), contributing to the per-frame `bufferCreates` floor
    on any frame with layer composites or snapshots.
-5. **Dead per-encode work.** `GeodePathEncoder::encode` still builds the
-   legacy per-band quad list `EncodedPath::vertices` (6 vertices per
-   band) for the deleted 4-sample alpha-coverage gradient/mask shaders
-   (0041). No draw path consumes it: the analytic fill, gradient, and
-   mask paths all draw `quadVertices` (one bounding quad per path). It
-   costs allocation + fill on every encode and idle bytes in every
-   cached `EncodedPath`.
-6. **Texture uploads are already clean.** `textureWriteBytes == 0` on all
+5. **Texture uploads are already clean.** `textureWriteBytes == 0` on all
    vector fixtures, and frame-2 `textureCreates == 0` (M4). Image decode
    uploads happen once, off the steady-state path.
-7. **`submits == 2` steady-state** is frame + snapshot readback; the M3
+6. **`submits == 2` steady-state** is frame + snapshot readback; the M3
    target of 1 holds for the render itself.
+7. **Per-encode output is lean.** `GeodePathEncoder::encode` emits only
+   what the analytic dual-ray pipeline draws: band/curve/grid SSBO data
+   plus the single whole-path bounding quad (`quadVertices`). The
+   `GeodePathEncoder.EncodeTimingProbe` test prints the per-encode
+   median for a many-band serpentine fixture (~181 us) as a
+   non-asserting reference number.
 
-### Cost ranking (highest first)
+### Cost ranking of remaining work (highest first)
 
 1. Steady-state GPU re-upload of memoized path data (item 1):
    O(paths) writeBuffer calls and O(scene bytes) transfer per static
    frame. Fix direction: persistent GPU residence for cached
    `EncodedPath` data (per-entity arena slots alongside
-   `GeodePathCacheComponent`), or at minimum persistent arenas plus
-   skip-write when content is unchanged.
+   `GeodePathCacheComponent`), or at minimum skip-write when content
+   and arena placement are unchanged.
 2. Per-draw bind-group creation (item 2): O(paths) driver-object
    creations per frame. Unlocked by 1 (stable buffer bindings make
-   bind groups reusable).
-3. Per-frame encoder/arena recreation (item 3): O(arenas) buffer
-   creates + retires per frame; the direct source of allocation
-   jitter. Fix direction: arenas owned by `RendererGeode::Impl` or
-   `GeodeDevice`, handed to each frame's encoders.
-4. Legacy `EncodedPath::vertices` build (item 5): O(bands) CPU fill +
-   allocation per encode, pure dead work.
-5. Per-blit uniform creation (item 4): small counts on typical scenes.
+   bind groups reusable / cacheable).
+3. Per-blit uniform creation (item 4): small counts on typical scenes;
+   route through the arena + pool machinery.
 
 Counters `bufferWrites` / `bufferWriteBytes` / `textureWriteBytes` are
-the regression signal for items 1 and 6; `bufferCreates` for item 3;
-`bindgroupCreates` for item 2. Ceilings are asserted in
-`GeodePerf_tests.cc` and tighten as each fix lands.
+the regression signal for items 1 and 5; `bufferCreates` for item 3
+(pooled, ceilings asserted); `bindgroupCreates` for item 2. Ceilings
+are asserted in `GeodePerf_tests.cc` and tighten as each fix lands.

--- a/donner/editor/AsyncRenderer.cc
+++ b/donner/editor/AsyncRenderer.cc
@@ -569,6 +569,18 @@ void AsyncRenderer::workerLoop() {
     compositor_->setTightBoundedSegmentsEnabled(
         tightBoundedSegments_.load(std::memory_order_acquire));
 
+    // Push the Geode geometry debug overlay flag into the document
+    // renderer. Applied unconditionally (cheap bool store, and it must
+    // reach a renderer that changed under us); on a flip, every cached
+    // segment bitmap is stale (the overlay draws into rasterized
+    // tiles), so force a full re-raster.
+    const bool geometryDebugOverlay = geometryDebugOverlay_.load(std::memory_order_acquire);
+    requestRenderer.setDebugGeometryOverlay(geometryDebugOverlay);
+    if (geometryDebugOverlay != appliedGeometryDebugOverlay_) {
+      appliedGeometryDebugOverlay_ = geometryDebugOverlay;
+      compositor_->resetAllLayers();
+    }
+
     // Keep the compositor hint in ActiveDrag across mouse-up so the
     // layer/segment caches survive quick release->drag-again cycles, but
     // only skip the main-renderer compose while an actual drag request is

--- a/donner/editor/AsyncRenderer.h
+++ b/donner/editor/AsyncRenderer.h
@@ -393,6 +393,25 @@ public:
     return tightBoundedSegments_.load(std::memory_order_acquire);
   }
 
+  /// Toggle the Geode geometry debug overlay
+  /// (`RendererInterface::setDebugGeometryOverlay`) on the document
+  /// renderer. The change applies at the start of the next worker
+  /// iteration; on a flip the worker also calls
+  /// `CompositorController::resetAllLayers()` so every cached segment
+  /// re-rasterizes with the new overlay state.
+  ///
+  /// Same threading contract as \ref setTightBoundedSegmentsEnabled:
+  /// safe to call from the UI thread while a render is in flight.
+  void setGeometryDebugOverlayEnabled(bool enabled) {
+    geometryDebugOverlay_.store(enabled, std::memory_order_release);
+  }
+
+  /// Mirror of the current overlay state. UI reads this to render the
+  /// correct check state in the View menu without racing the worker.
+  [[nodiscard]] bool geometryDebugOverlayEnabled() const {
+    return geometryDebugOverlay_.load(std::memory_order_acquire);
+  }
+
   /// Number of times the worker has called `CompositorController::resetAllLayers()`
   /// since construction. Tests use this to assert that frame-version mutations
   /// do not masquerade as document replacements.
@@ -645,6 +664,16 @@ private:
   /// Default-true matches `CompositorConfig::tightBoundedSegments`. See
   /// `setTightBoundedSegmentsEnabled`.
   std::atomic<bool> tightBoundedSegments_{true};
+
+  /// Geode geometry debug overlay request from the UI thread. See
+  /// `setGeometryDebugOverlayEnabled`. Default-off matches the
+  /// renderer's default.
+  std::atomic<bool> geometryDebugOverlay_{false};
+
+  /// Worker-thread-only: the overlay state last applied to the request
+  /// renderer, so the worker can detect flips and invalidate cached
+  /// segments exactly once per change.
+  bool appliedGeometryDebugOverlay_ = false;
 
   /// Replay/test-only fixed delay injected into each worker render attempt.
   std::atomic<std::chrono::milliseconds::rep> replayRenderDelayMsForTesting_{0};

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -1586,7 +1586,16 @@ void EditorShell::applyMenuActions(const MenuBarActions& menuActions) {
   }
   const bool showCompositorDebugPanelBeforeMenu = showCompositorDebugPanel_;
   const PerfOverlayMode perfOverlayModeBeforeMenu = perfOverlayMode_;
-  ApplyViewMenuToggleActions(menuActions, &showCompositorDebugPanel_, &perfOverlayMode_);
+  const bool geometryDebugOverlayBeforeMenu = geometryDebugOverlay_;
+  ApplyViewMenuToggleActions(menuActions, &showCompositorDebugPanel_, &perfOverlayMode_,
+                             &geometryDebugOverlay_);
+  if (geometryDebugOverlay_ != geometryDebugOverlayBeforeMenu) {
+    // Push the new overlay state to the render worker and post a render:
+    // the worker re-rasterizes every cached segment with the overlay
+    // state on its next iteration (see AsyncRenderer::workerLoop).
+    renderCoordinator_.asyncRenderer().setGeometryDebugOverlayEnabled(geometryDebugOverlay_);
+    requestRenderAtEndOfFrame_ = true;
+  }
   // DockSpace layout controls: toggle the lock or request a rebuild of the
   // default layout. renderDockSpaceHost consumes the reset request next frame.
   if (menuActions.toggleLayoutLock) {
@@ -1598,7 +1607,8 @@ void EditorShell::applyMenuActions(const MenuBarActions& menuActions) {
     window_.wakeEventLoop();
   }
   if (showCompositorDebugPanel_ != showCompositorDebugPanelBeforeMenu ||
-      perfOverlayMode_ != perfOverlayModeBeforeMenu) {
+      perfOverlayMode_ != perfOverlayModeBeforeMenu ||
+      geometryDebugOverlay_ != geometryDebugOverlayBeforeMenu) {
     window_.wakeEventLoop();
   }
 }
@@ -4635,6 +4645,7 @@ void EditorShell::runFrame() {
       .hasTextSelection = selectionIsAllText(),
       .hasSelectableElements = canvasHasSelectableElements(),
       .showCompositorDebugPanel = showCompositorDebugPanel_,
+      .geometryDebugOverlay = geometryDebugOverlay_,
       .perfOverlayMode = perfOverlayMode_,
       .panelLayoutLocked = dockLayoutLocked_,
   };

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -586,6 +586,12 @@ private:
   /// Render-pane frame-timing/perf overlay mode. Off by default; set via the
   /// View menu's Performance Overlay submenu.
   PerfOverlayMode perfOverlayMode_ = PerfOverlayMode::Off;
+  /// Whether the Geode geometry debug overlay is enabled on the document
+  /// renderer (band strips + per-path bounding-quad triangles drawn into
+  /// rasterized tiles). Off by default; toggled via the View menu. Applied
+  /// to the render worker through
+  /// `AsyncRenderer::setGeometryDebugOverlayEnabled`.
+  bool geometryDebugOverlay_ = false;
 
   ImFont* uiFontBold_ = nullptr;
   ImFont* codeFont_ = nullptr;

--- a/donner/editor/MenuBarPresenter.cc
+++ b/donner/editor/MenuBarPresenter.cc
@@ -51,6 +51,9 @@ void ApplyMenuBarCommand(bool activated, MenuBarCommand command, const MenuBarSt
     case MenuBarCommand::ToggleCompositorDebugPanel:
       actions->toggleCompositorDebugPanel = true;
       return;
+    case MenuBarCommand::ToggleGeometryDebugOverlay:
+      actions->toggleGeometryDebugOverlay = true;
+      return;
     case MenuBarCommand::SetPerfOverlayOff:
       actions->setPerfOverlayMode = true;
       actions->perfOverlayMode = PerfOverlayMode::Off;
@@ -69,12 +72,15 @@ void ApplyMenuBarCommand(bool activated, MenuBarCommand command, const MenuBarSt
 }
 
 void ApplyViewMenuToggleActions(const MenuBarActions& actions, bool* showCompositorDebugPanel,
-                                PerfOverlayMode* perfOverlayMode) {
+                                PerfOverlayMode* perfOverlayMode, bool* geometryDebugOverlay) {
   if (actions.toggleCompositorDebugPanel && showCompositorDebugPanel != nullptr) {
     *showCompositorDebugPanel = !*showCompositorDebugPanel;
   }
   if (actions.setPerfOverlayMode && perfOverlayMode != nullptr) {
     *perfOverlayMode = actions.perfOverlayMode;
+  }
+  if (actions.toggleGeometryDebugOverlay && geometryDebugOverlay != nullptr) {
+    *geometryDebugOverlay = !*geometryDebugOverlay;
   }
 }
 
@@ -173,6 +179,9 @@ MenuBarActions MenuBarPresenter::render(const MenuBarState& state, ImFont* boldM
     ApplyMenuBarCommand(
         ImGui::MenuItem("Compositor Debug", nullptr, state.showCompositorDebugPanel),
         MenuBarCommand::ToggleCompositorDebugPanel, state, &actions);
+    ApplyMenuBarCommand(
+        ImGui::MenuItem("Geometry Debug Overlay", nullptr, state.geometryDebugOverlay),
+        MenuBarCommand::ToggleGeometryDebugOverlay, state, &actions);
     ImGui::Separator();
     ApplyMenuBarCommand(ImGui::MenuItem("Lock Panel Layout", nullptr, state.panelLayoutLocked),
                         MenuBarCommand::ToggleLayoutLock, state, &actions);

--- a/donner/editor/MenuBarPresenter.h
+++ b/donner/editor/MenuBarPresenter.h
@@ -40,6 +40,10 @@ struct MenuBarState {
   /// Current visibility of the Compositor Debug panel (drives the View-menu
   /// checkmark). Off by default.
   bool showCompositorDebugPanel = false;
+  /// Whether the Geode geometry debug overlay (band strips + per-path
+  /// bounding-quad triangles) is enabled on the document renderer
+  /// (drives the View-menu checkmark). Off by default.
+  bool geometryDebugOverlay = false;
   /// Current render-pane performance overlay mode (drives the View-menu
   /// checkmarks). Off by default.
   PerfOverlayMode perfOverlayMode = PerfOverlayMode::Off;
@@ -80,6 +84,9 @@ struct MenuBarActions {
   bool toggleSourceFocusMode = false;
   /// Set when the user toggles the Compositor Debug panel via the View menu.
   bool toggleCompositorDebugPanel = false;
+  /// Set when the user toggles the Geode geometry debug overlay via the
+  /// View menu.
+  bool toggleGeometryDebugOverlay = false;
   /// Set when the user picks a performance overlay mode via the View menu.
   bool setPerfOverlayMode = false;
   /// Requested performance overlay mode; meaningful only while
@@ -115,6 +122,7 @@ enum class MenuBarCommand {
   ActualSize,
   ToggleSourceFocusMode,
   ToggleCompositorDebugPanel,
+  ToggleGeometryDebugOverlay,
   SetPerfOverlayOff,
   SetPerfOverlayFpsPill,
   SetPerfOverlayFullGraph,
@@ -136,8 +144,11 @@ void ApplyMenuBarCommand(bool activated, MenuBarCommand command, const MenuBarSt
 /// @param actions Edge-triggered menu actions from \ref MenuBarPresenter::render.
 /// @param showCompositorDebugPanel Current Compositor Debug panel visibility.
 /// @param perfOverlayMode Current performance overlay mode.
+/// @param geometryDebugOverlay Current Geode geometry debug overlay state.
+///   Optional (may be null) so callers without a document renderer skip it.
 void ApplyViewMenuToggleActions(const MenuBarActions& actions, bool* showCompositorDebugPanel,
-                                PerfOverlayMode* perfOverlayMode);
+                                PerfOverlayMode* perfOverlayMode,
+                                bool* geometryDebugOverlay = nullptr);
 
 /// Renders the app's top menu bar and reports semantic actions back to the shell.
 class MenuBarPresenter {

--- a/donner/editor/tests/ViewMenuVisibility_tests.cc
+++ b/donner/editor/tests/ViewMenuVisibility_tests.cc
@@ -17,6 +17,8 @@ TEST(ViewMenuVisibility, MenuBarStateDefaultsMatchVisibilityContract) {
       << "Compositor Debug panel must default to hidden (developer diagnostics only)";
   EXPECT_EQ(state.perfOverlayMode, PerfOverlayMode::Off)
       << "Performance overlay must default to off";
+  EXPECT_FALSE(state.geometryDebugOverlay)
+      << "Geode geometry debug overlay must default to off (zero impact on normal rendering)";
 }
 
 // The toggle actions are edge-triggered requests, so they must default to false
@@ -25,6 +27,7 @@ TEST(ViewMenuVisibility, MenuBarActionsToggleRequestsDefaultFalse) {
   const MenuBarActions actions;
   EXPECT_FALSE(actions.toggleCompositorDebugPanel);
   EXPECT_FALSE(actions.setPerfOverlayMode);
+  EXPECT_FALSE(actions.toggleGeometryDebugOverlay);
 }
 
 TEST(ViewMenuVisibility, ToggleActionsFlipCompositorDebugPanel) {
@@ -88,6 +91,31 @@ TEST(ViewMenuVisibility, ToggleActionsIgnoreNullVisibilityPointers) {
   ApplyViewMenuToggleActions(actions, nullptr, nullptr);
   EXPECT_TRUE(showCompositorDebugPanel);
   EXPECT_EQ(perfOverlayMode, PerfOverlayMode::Off);
+}
+
+TEST(ViewMenuVisibility, ToggleActionsFlipGeometryDebugOverlay) {
+  bool showCompositorDebugPanel = false;
+  PerfOverlayMode perfOverlayMode = PerfOverlayMode::Off;
+  bool geometryDebugOverlay = false;
+  MenuBarActions actions;
+  actions.toggleGeometryDebugOverlay = true;
+
+  ApplyViewMenuToggleActions(actions, &showCompositorDebugPanel, &perfOverlayMode,
+                             &geometryDebugOverlay);
+
+  EXPECT_TRUE(geometryDebugOverlay);
+  EXPECT_FALSE(showCompositorDebugPanel);
+  EXPECT_EQ(perfOverlayMode, PerfOverlayMode::Off);
+
+  ApplyViewMenuToggleActions(actions, &showCompositorDebugPanel, &perfOverlayMode,
+                             &geometryDebugOverlay);
+
+  EXPECT_FALSE(geometryDebugOverlay);
+
+  // Callers without a document renderer omit the pointer; the toggle
+  // request must be ignored (default argument is null).
+  ApplyViewMenuToggleActions(actions, &showCompositorDebugPanel, &perfOverlayMode);
+  EXPECT_FALSE(geometryDebugOverlay);
 }
 
 }  // namespace donner::editor

--- a/donner/svg/renderer/Renderer.cc
+++ b/donner/svg/renderer/Renderer.cc
@@ -560,6 +560,14 @@ std::unique_ptr<RendererInterface> Renderer::createOffscreenInstance() const {
   return impl_->createOffscreenInstance();
 }
 
+void Renderer::setDebugGeometryOverlay(bool enabled) {
+  impl_->setDebugGeometryOverlay(enabled);
+}
+
+bool Renderer::debugGeometryOverlay() const {
+  return impl_->debugGeometryOverlay();
+}
+
 bool Renderer::save(const char* filename) {
   const RendererBitmap snapshot = takeSnapshot();
   if (snapshot.empty()) {

--- a/donner/svg/renderer/Renderer.h
+++ b/donner/svg/renderer/Renderer.h
@@ -261,6 +261,13 @@ public:
   /// Creates an offscreen renderer of the active backend type.
   [[nodiscard]] std::unique_ptr<RendererInterface> createOffscreenInstance() const override;
 
+  /// Forwards \ref RendererInterface::setDebugGeometryOverlay to the
+  /// active backend (no-op for backends without a debug overlay).
+  void setDebugGeometryOverlay(bool enabled) override;
+
+  /// Whether the active backend's geometry debug overlay is enabled.
+  [[nodiscard]] bool debugGeometryOverlay() const override;
+
   /**
    * Saves the last rendered frame to a PNG file.
    *

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -28,6 +28,7 @@
 #include "donner/svg/properties/PaintServer.h"
 #include "donner/svg/renderer/RendererDriver.h"
 #include "donner/svg/renderer/geode/GeoEncoder.h"
+#include "donner/svg/renderer/geode/GeodeBufferPool.h"
 #include "donner/svg/renderer/geode/GeodeDevice.h"
 #include "donner/svg/renderer/geode/GeodeFilterEngine.h"
 #include "donner/svg/renderer/geode/GeodeImagePipeline.h"
@@ -977,6 +978,13 @@ struct RendererGeode::Impl {
   /// unbounded textures even if a pathological frame pushes and pops
   /// dozens of layers at that size without ever reacquiring.
   static constexpr std::size_t kMaxPoolEntriesPerKey = 8;
+
+  /// Cross-frame arena buffer pool (design doc 0030 M1). Every
+  /// `GeoEncoder` this renderer constructs gets a pointer via
+  /// `setBufferPool`; encoders recycle their fully-grown arena buffers
+  /// through it instead of re-creating them each frame. Companion to
+  /// `texturePool` (M4.2) on the buffer side.
+  geode::GeodeBufferPool arenaBufferPool;
 
   /// Drop a bucket entirely if it hasn't been touched in this many
   /// consecutive frames. At 60 fps this is ~2 seconds of idleness;
@@ -2273,6 +2281,7 @@ void RendererGeode::beginFrame(const RenderViewport& viewport) {
   impl_->encoder = std::make_unique<geode::GeoEncoder>(
       *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
       impl_->msaaTarget, impl_->target, impl_->frameCommandEncoder.get());
+  impl_->encoder->setBufferPool(&impl_->arenaBufferPool);
   if (impl_->preserveTargetOnBeginFrame) {
     impl_->encoder->setLoadPreserve();
   } else {
@@ -2686,6 +2695,7 @@ void RendererGeode::pushIsolatedLayer(double opacity, MixBlendMode blendMode) {
   auto newEncoder = std::make_unique<geode::GeoEncoder>(
       *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
       layerMsaaTexture, layerTexture, impl_->frameCommandEncoder.get());
+  newEncoder->setBufferPool(&impl_->arenaBufferPool);
   newEncoder->clear(css::RGBA(0, 0, 0, 0));
   impl_->encoder = std::move(newEncoder);
   impl_->layerStack.push_back(std::move(frame));
@@ -2767,6 +2777,7 @@ void RendererGeode::popIsolatedLayer() {
       auto newEncoder = std::make_unique<geode::GeoEncoder>(
           *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
           frame.savedMsaaTarget, frame.savedTarget, impl_->frameCommandEncoder.get());
+      newEncoder->setBufferPool(&impl_->arenaBufferPool);
       newEncoder->setLoadPreserve();
       impl_->encoder = std::move(newEncoder);
       impl_->updateEncoderScissor();
@@ -2794,6 +2805,7 @@ void RendererGeode::popIsolatedLayer() {
   auto newEncoder = std::make_unique<geode::GeoEncoder>(
       *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
       frame.savedMsaaTarget, frame.savedTarget, impl_->frameCommandEncoder.get());
+  newEncoder->setBufferPool(&impl_->arenaBufferPool);
   newEncoder->setLoadPreserve();
   impl_->encoder = std::move(newEncoder);
   impl_->updateEncoderScissor();
@@ -2911,6 +2923,7 @@ void RendererGeode::pushFilterLayer(const components::FilterGraph& filterGraph,
   auto newEncoder = std::make_unique<geode::GeoEncoder>(
       *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
       layerMsaaTexture, layerTexture, impl_->frameCommandEncoder.get());
+  newEncoder->setBufferPool(&impl_->arenaBufferPool);
   newEncoder->clear(css::RGBA(0, 0, 0, 0));
   impl_->encoder = std::move(newEncoder);
 
@@ -3048,6 +3061,7 @@ void RendererGeode::popFilterLayer() {
           geode::GeoEncoder resampleEncoder(*impl_->device, *impl_->pipeline,
                                             *impl_->gradientPipeline, *impl_->imagePipeline,
                                             localMsaaTexture, localTexture);
+          resampleEncoder.setBufferPool(&impl_->arenaBufferPool);
           resampleEncoder.setTransform(localFromDevice);
           resampleEncoder.drawTexture(
               frame.layerTexture,
@@ -3079,6 +3093,7 @@ void RendererGeode::popFilterLayer() {
         auto compositeEncoder = std::make_unique<geode::GeoEncoder>(
             *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
             frame.savedMsaaTarget, frame.savedTarget, impl_->frameCommandEncoder.get());
+        compositeEncoder->setBufferPool(&impl_->arenaBufferPool);
         compositeEncoder->setLoadPreserve();
         impl_->encoder = std::move(compositeEncoder);
         impl_->updateEncoderScissor();
@@ -3129,6 +3144,7 @@ void RendererGeode::popFilterLayer() {
   auto newEncoder = std::make_unique<geode::GeoEncoder>(
       *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
       frame.savedMsaaTarget, frame.savedTarget, impl_->frameCommandEncoder.get());
+  newEncoder->setBufferPool(&impl_->arenaBufferPool);
   newEncoder->setLoadPreserve();
   impl_->encoder = std::move(newEncoder);
   impl_->updateEncoderScissor();
@@ -3254,6 +3270,7 @@ void RendererGeode::pushMask(const std::optional<Box2d>& maskBounds) {
   auto captureEncoder = std::make_unique<geode::GeoEncoder>(
       *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
       frame.maskMsaaTexture, frame.maskTexture, impl_->frameCommandEncoder.get());
+  captureEncoder->setBufferPool(&impl_->arenaBufferPool);
   captureEncoder->clear(css::RGBA(0, 0, 0, 0));
   impl_->encoder = std::move(captureEncoder);
   impl_->maskStack.push_back(std::move(frame));
@@ -3284,6 +3301,7 @@ void RendererGeode::transitionMaskToContent() {
   auto contentEncoder = std::make_unique<geode::GeoEncoder>(
       *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
       frame.contentMsaaTexture, frame.contentTexture, impl_->frameCommandEncoder.get());
+  contentEncoder->setBufferPool(&impl_->arenaBufferPool);
   contentEncoder->clear(css::RGBA(0, 0, 0, 0));
   impl_->encoder = std::move(contentEncoder);
   frame.phase = Impl::MaskStackFrame::Phase::Content;
@@ -3316,6 +3334,7 @@ void RendererGeode::popMask() {
   auto newEncoder = std::make_unique<geode::GeoEncoder>(
       *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
       frame.savedMsaaTarget, frame.savedTarget, impl_->frameCommandEncoder.get());
+  newEncoder->setBufferPool(&impl_->arenaBufferPool);
   newEncoder->setLoadPreserve();
   impl_->encoder = std::move(newEncoder);
   impl_->updateEncoderScissor();
@@ -3493,6 +3512,7 @@ void RendererGeode::beginPatternTile(const Box2d& tileRect, const Transform2d& t
   auto newEncoder = std::make_unique<geode::GeoEncoder>(
       *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
       tileMsaaTextureHandle, tileTextureHandle, impl_->frameCommandEncoder.get());
+  newEncoder->setBufferPool(&impl_->arenaBufferPool);
   // Transparent clear so unpainted tile pixels contribute nothing.
   newEncoder->clear(css::RGBA(0, 0, 0, 0));
   impl_->encoder = std::move(newEncoder);
@@ -3568,6 +3588,7 @@ void RendererGeode::endPatternTile(bool forStroke) {
     auto newEncoder = std::make_unique<geode::GeoEncoder>(
         *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
         frame.savedMsaaTarget, frame.savedTarget, impl_->frameCommandEncoder.get());
+    newEncoder->setBufferPool(&impl_->arenaBufferPool);
     // Preserve existing target contents: the pattern subtree may have
     // submitted work on the outer target *before* the pattern tile opened
     // (via the finish() in beginPatternTile), so we must not clear it

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1402,6 +1402,91 @@ struct RendererGeode::Impl {
   /// registries are never considered "consecutive same-source").
   Entity lastDrawSourceEntity = entt::null;
 
+  /// Debug geometry overlay (see `RendererGeode::setDebugGeometryOverlay`).
+  /// When true, every `drawPath` additionally outlines the Slug band
+  /// decomposition Geode emits for the draw: horizontal band strips,
+  /// vertical band strips, and the single bounding quad (with its
+  /// triangle diagonal) that is the geometry actually rasterized.
+  /// Default off; every overlay code path is behind this flag so the
+  /// disabled state is byte-identical to a build without the feature.
+  bool debugGeometryOverlay = false;
+
+  /// Draw the debug overlay for one encoded path. Called from `drawPath`
+  /// after the normal fill/stroke draws so the overlay renders on top.
+  /// Uses `GeoEncoder::fillPath` directly (hairline rings built as
+  /// EvenOdd outer+inset rectangles), so no new pipelines or shaders are
+  /// involved; overlay draws cost normal draw-call counters, which is
+  /// acceptable for a debug mode.
+  void drawEncodedPathOverlay(const geode::EncodedPath& encoded) {
+    if (!encoder || encoded.empty()) {
+      return;
+    }
+    syncTransform();
+
+    // Hairline width: one device pixel expressed in path space. The
+    // linear part's determinant gives the area scale of the transform;
+    // its square root approximates the isotropic scale factor.
+    const double det = std::abs(deviceFromLocalTransform.determinant());
+    const double scale = det > 0.0 ? std::sqrt(det) : 1.0;
+    const double w = 1.0 / std::max(scale, 1e-6);
+
+    // A hairline rectangular ring: outer rect + inset rect, filled
+    // EvenOdd so only the border remains.
+    const auto addRing = [w](PathBuilder& builder, const Box2d& rect) {
+      builder.addRect(rect);
+      const Box2d inner(rect.topLeft + Vector2d(w, w), rect.bottomRight - Vector2d(w, w));
+      if (inner.bottomRight.x > inner.topLeft.x && inner.bottomRight.y > inner.topLeft.y) {
+        builder.addRect(inner);
+      }
+    };
+
+    // Horizontal (Y-strip) bands: cyan.
+    if (!encoded.bands.empty()) {
+      PathBuilder builder;
+      for (const geode::EncodedPath::Band& band : encoded.bands) {
+        addRing(builder, Box2d(Vector2d(band.xMin, band.yMin), Vector2d(band.xMax, band.yMax)));
+      }
+      encoder->fillPath(builder.build(), css::RGBA(0, 200, 255, 160), FillRule::EvenOdd);
+    }
+
+    // Vertical (X-strip) bands: yellow. Field semantics are transposed
+    // for vertical bands (`xMin`/`xMax` = strip bounds, `yMin`/`yMax` =
+    // curve extent), but both pairs still form the band's rectangle.
+    if (!encoded.vBands.empty()) {
+      PathBuilder builder;
+      for (const geode::EncodedPath::Band& band : encoded.vBands) {
+        addRing(builder, Box2d(Vector2d(band.xMin, band.yMin), Vector2d(band.xMax, band.yMax)));
+      }
+      encoder->fillPath(builder.build(), css::RGBA(255, 200, 0, 140), FillRule::EvenOdd);
+    }
+
+    // Bounding quad + triangle diagonal: magenta. This is the geometry
+    // Geode actually rasterizes - one quad (two triangles) per path
+    // (0041: one fragment per pixel, band lookup in the fragment
+    // shader). The diagonal runs between the shared vertices of the two
+    // triangles: (xMin, yMin) -> (xMax, yMax) per
+    // `GeodePathEncoder::encode`'s quadVertices emission order.
+    {
+      const Box2d& b = encoded.pathBounds;
+      PathBuilder builder;
+      addRing(builder, b);
+      const Vector2d d = (b.bottomRight - b.topLeft);
+      const double len = d.length();
+      if (len > w) {
+        // Thin quad along the diagonal, offset w/2 perpendicular.
+        const Vector2d unit = d / len;
+        const Vector2d perp(-unit.y * w * 0.5, unit.x * w * 0.5);
+        builder.moveTo(b.topLeft + perp)
+            .lineTo(b.bottomRight + perp)
+            .lineTo(b.bottomRight - perp)
+            .lineTo(b.topLeft - perp)
+            .closePath();
+      }
+      encoder->fillPath(builder.build(), css::RGBA(255, 0, 255, 200), FillRule::NonZero);
+    }
+  }
+
+
   /// M6-B step 3 (design doc 0030 §M6 Bullet 2): deferred batch for
   /// consecutive `drawPath` calls that share a source entity + resolved
   /// solid paint + no stroke + no subtree complication. Each matching
@@ -1467,6 +1552,18 @@ struct RendererGeode::Impl {
     /// subpath → NonZero; for closed-path strokes, two → EvenOdd.
     FillRule fillRule = FillRule::NonZero;
   };
+
+  /// Debug-overlay companion for a stroke draw: visualize the encode of
+  /// the stroked outline (the geometry Geode actually emits for the
+  /// stroke). Falls back to a local encode when the stroke came from the
+  /// no-entity path (no cache slot).
+  void drawStrokeOverlay(const Path& strokedOutline, const StrokeDerived& derived) {
+    if (derived.encoded != nullptr) {
+      drawEncodedPathOverlay(*derived.encoded);
+    } else {
+      drawEncodedPathOverlay(geode::GeodePathEncoder::encode(strokedOutline, derived.fillRule));
+    }
+  }
 
   /// Encode-side of the cache. If `source` holds a valid entity handle,
   /// installs / reuses a `GeodePathCacheComponent::fillEncode` on it and
@@ -1968,6 +2065,14 @@ RendererGeode::RendererGeode(std::shared_ptr<geode::GeodeDevice> device, bool ve
 void RendererGeode::enableTimestamps(bool /*enabled*/) {
   // Reserved for future work (design doc 0030, "Future Work"). Counters
   // are the durable regression signal and are always enabled.
+}
+
+void RendererGeode::setDebugGeometryOverlay(bool enabled) {
+  impl_->debugGeometryOverlay = enabled;
+}
+
+bool RendererGeode::debugGeometryOverlay() const {
+  return impl_->debugGeometryOverlay;
 }
 
 FrameTimings RendererGeode::lastFrameTimings() const {
@@ -3551,7 +3656,10 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   // draw.
   const bool hasStroke = !(stroke.strokeWidth <= 0.0 ||
                            std::holds_alternative<PaintServer::None>(impl_->paint.stroke));
-  const bool batchable = !hasStroke && fillEncoded != nullptr &&
+  // The debug geometry overlay draws per-path, immediately after the
+  // path's own draws, so batching is disabled while it is on (debug
+  // mode trades the batching win for draw-order fidelity).
+  const bool batchable = !impl_->debugGeometryOverlay && !hasStroke && fillEncoded != nullptr &&
                          path.sourceEntity.entity() != entt::null &&
                          std::holds_alternative<PaintServer::Solid>(impl_->paint.fill) &&
                          !impl_->patternFillPaint.has_value() && impl_->encoder != nullptr &&
@@ -3573,6 +3681,15 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   // Both default to true, so this is a no-op for ordinary fill-then-stroke draws.
   if (impl_->paint.drawFillComponent) {
     impl_->fillResolved(path.path, path.fillRule, fillEncoded);
+    if (impl_->debugGeometryOverlay &&
+        !std::holds_alternative<PaintServer::None>(impl_->paint.fill)) {
+      if (fillEncoded != nullptr) {
+        impl_->drawEncodedPathOverlay(*fillEncoded);
+      } else {
+        impl_->drawEncodedPathOverlay(
+            geode::GeodePathEncoder::encode(path.path, path.fillRule));
+      }
+    }
   }
 
   // Mirror fillResolved's no-op safety: if there's no encoder (headless
@@ -3633,6 +3750,9 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
       impl_->device->deferDestroy(impl_->patternStrokePaint->tile.take());
     }
     impl_->patternStrokePaint.reset();
+    if (impl_->debugGeometryOverlay) {
+      impl_->drawStrokeOverlay(strokedOutline, strokeDerived);
+    }
     return;
   }
 
@@ -3645,6 +3765,9 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   auto strokeServer = impl_->paint.stroke;
   impl_->drawPaintedPathAgainst(path.path, strokedOutline, strokeServer, effectiveOpacity,
                                 strokeDerived.fillRule, strokeDerived.encoded);
+  if (impl_->debugGeometryOverlay) {
+    impl_->drawStrokeOverlay(strokedOutline, strokeDerived);
+  }
 }
 
 void RendererGeode::drawRect(const Box2d& rect, const StrokeParams& stroke) {

--- a/donner/svg/renderer/RendererGeode.h
+++ b/donner/svg/renderer/RendererGeode.h
@@ -267,6 +267,26 @@ public:
   void enableTimestamps(bool enabled);
 
   /**
+   * Enable or disable the Geode geometry debug overlay.
+   *
+   * When enabled, every path draw (fills, strokes, rects, ellipses)
+   * additionally outlines the Slug band decomposition Geode emits for
+   * that draw: horizontal band strips (cyan), vertical band strips
+   * (yellow), and the per-path bounding quad with its triangle diagonal
+   * (magenta) - the two triangles Geode actually rasterizes (0041).
+   * Overlay draws render through the normal fill pipeline, so they are
+   * included in `lastFrameTimings()` counters. `<use>` instancing is
+   * disabled while the overlay is on so overlays stay in draw order.
+   *
+   * Default off. When off, rendering behavior and performance are
+   * unchanged; the only cost is one boolean test per draw.
+   */
+  void setDebugGeometryOverlay(bool enabled);
+
+  /// Whether the geometry debug overlay is enabled.
+  [[nodiscard]] bool debugGeometryOverlay() const;
+
+  /**
    * Returns per-frame instrumentation for the most recently completed
    * `beginFrame`→`endFrame` window. Valid after the first `endFrame()`;
    * before then all fields are zero.

--- a/donner/svg/renderer/RendererGeode.h
+++ b/donner/svg/renderer/RendererGeode.h
@@ -281,10 +281,10 @@ public:
    * Default off. When off, rendering behavior and performance are
    * unchanged; the only cost is one boolean test per draw.
    */
-  void setDebugGeometryOverlay(bool enabled);
+  void setDebugGeometryOverlay(bool enabled) override;
 
   /// Whether the geometry debug overlay is enabled.
-  [[nodiscard]] bool debugGeometryOverlay() const;
+  [[nodiscard]] bool debugGeometryOverlay() const override;
 
   /**
    * Returns per-frame instrumentation for the most recently completed

--- a/donner/svg/renderer/RendererInterface.h
+++ b/donner/svg/renderer/RendererInterface.h
@@ -472,6 +472,18 @@ public:
   [[nodiscard]] virtual std::unique_ptr<RendererInterface> createOffscreenInstance() const {
     return nullptr;
   }
+
+  /**
+   * Enable or disable the backend's geometry debug overlay, which
+   * visualizes the internal geometry the backend emits per draw (for
+   * Geode: Slug band strips and the per-path bounding-quad triangles).
+   * Default off. Backends without a debug overlay ignore the call.
+   */
+  virtual void setDebugGeometryOverlay(bool /*enabled*/) {}
+
+  /// Whether the backend's geometry debug overlay is enabled. Backends
+  /// without an overlay always report false.
+  [[nodiscard]] virtual bool debugGeometryOverlay() const { return false; }
 };
 
 }  // namespace donner::svg

--- a/donner/svg/renderer/geode/BUILD.bazel
+++ b/donner/svg/renderer/geode/BUILD.bazel
@@ -502,7 +502,10 @@ donner_cc_library(
 donner_cc_library(
     name = "geo_encoder",
     srcs = ["GeoEncoder.cc"],
-    hdrs = ["GeoEncoder.h"],
+    hdrs = [
+        "GeoEncoder.h",
+        "GeodeBufferPool.h",
+    ],
     target_compatible_with = _GEODE_ONLY,
     visibility = ["//donner/svg/renderer:__subpackages__"],
     deps = [

--- a/donner/svg/renderer/geode/BUILD.bazel
+++ b/donner/svg/renderer/geode/BUILD.bazel
@@ -590,3 +590,27 @@ donner_multi_transitioned_test(
     dep = ":geode_embed_tests_impl",
     renderer_backend = "geode",
 )
+
+# Geode geometry debug overlay (RendererGeode::setDebugGeometryOverlay):
+# default-off contract, overlay-on rendering, and clean toggling.
+donner_cc_test(
+    name = "geode_debug_overlay_tests_impl",
+    srcs = ["tests/GeodeDebugOverlay_tests.cc"],
+    target_compatible_with = _GEODE_ONLY,
+    deps = [
+        ":geode_device",
+        "//donner/base",
+        "//donner/base:gtest_timeout_main",
+        "//donner/svg",
+        "//donner/svg/parser",
+        "//donner/svg/renderer:renderer_geode",
+        "//donner/svg/renderer:renderer_interface",
+    ],
+)
+
+donner_multi_transitioned_test(
+    name = "geode_debug_overlay_tests",
+    testonly = 1,
+    dep = ":geode_debug_overlay_tests_impl",
+    renderer_backend = "geode",
+)

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <vector>
 
+#include "donner/svg/renderer/geode/GeodeBufferPool.h"
 #include "donner/svg/renderer/geode/GeodeDevice.h"
 #include "donner/svg/renderer/geode/GeodeImagePipeline.h"
 #include "donner/svg/renderer/geode/GeodePathEncoder.h"
@@ -250,7 +251,23 @@ struct GeoEncoder::Impl {
   /// since the binding is storage read-only.
   Arena instanceTransformArena;
 
+  /// Optional cross-frame buffer pool (owned by `RendererGeode::Impl`).
+  /// When set, arena growth prefers recycled buffers and arena teardown
+  /// returns the fully-grown buffers instead of destroying them. See
+  /// `GeodeBufferPool` and design doc 0030 M1.
+  GeodeBufferPool* bufferPool = nullptr;
+
   void destroyArenaBackings(Arena& arena) {
+    // With a pool installed, the current (largest, fully-grown) buffer
+    // is recycled for the next frame's encoders instead of destroyed.
+    // Retired buffers are the outgrown smaller generations - steady
+    // state has none - so they are destroyed as before. Safe because
+    // encoder destruction only happens after the commands referencing
+    // these buffers were submitted (same invariant the eager destroy
+    // below already relies on).
+    if (bufferPool != nullptr && arena.buffer) {
+      bufferPool->release(std::move(arena.buffer), arena.usage, arena.label, arena.capacity);
+    }
     DestroyResourceBacking(arena.buffer);
     arena.buffer.reset();
     for (ScopedWgpuHandle<wgpu::Buffer>& buffer : arena.retired) {
@@ -303,13 +320,27 @@ struct GeoEncoder::Impl {
       constexpr uint64_t kMinGrow = uint64_t{64} * 1024;
       uint64_t newCap = std::max(arena.capacity * 2u, kMinGrow);
       while (newCap < size) newCap *= 2;
-      wgpu::BufferDescriptor desc = {};
-      desc.label = wgpuLabel(arena.label);
-      desc.size = newCap;
-      desc.usage = arena.usage;
-      arena.buffer.reset(device->device().createBuffer(desc));
-      device->countBuffer();
-      arena.capacity = newCap;
+      // Prefer a pooled buffer recycled from a previous frame's encoder
+      // (design doc 0030 M1: steady-state bufferCreates -> 0). Falls
+      // back to a fresh allocation when the pool has no fit.
+      if (bufferPool != nullptr) {
+        uint64_t pooledCapacity = 0;
+        ScopedWgpuHandle<wgpu::Buffer> pooled =
+            bufferPool->acquire(arena.usage, arena.label, newCap, &pooledCapacity);
+        if (pooled) {
+          arena.buffer = std::move(pooled);
+          arena.capacity = pooledCapacity;
+        }
+      }
+      if (!arena.buffer) {
+        wgpu::BufferDescriptor desc = {};
+        desc.label = wgpuLabel(arena.label);
+        desc.size = newCap;
+        desc.usage = arena.usage;
+        arena.buffer.reset(device->device().createBuffer(desc));
+        device->countBuffer();
+        arena.capacity = newCap;
+      }
       arena.offset = 0;
       alignedOffset = 0;
     }
@@ -1124,6 +1155,10 @@ void GeoEncoder::setClipMask(const wgpu::Texture& maskTexture, const wgpu::Textu
 void GeoEncoder::clearClipMask() {
   impl_->activeClipMaskView = wgpu::TextureView{};
   impl_->activeClipMaskTexture = wgpu::Texture{};
+}
+
+void GeoEncoder::setBufferPool(GeodeBufferPool* pool) {
+  impl_->bufferPool = pool;
 }
 
 void GeoEncoder::setLoadPreserve() {

--- a/donner/svg/renderer/geode/GeoEncoder.h
+++ b/donner/svg/renderer/geode/GeoEncoder.h
@@ -25,6 +25,7 @@ namespace donner::geode {
 
 struct EncodedPath;
 
+class GeodeBufferPool;
 class GeodeDevice;
 class GeodeImagePipeline;
 class GeodePipeline;
@@ -173,6 +174,19 @@ public:
              wgpu::CommandEncoder sharedCommandEncoder);
 
   ~GeoEncoder();
+
+  /**
+   * Install a cross-frame buffer pool (design doc 0030 M1). When set,
+   * arena buffer growth prefers recycled buffers from the pool and the
+   * destructor returns the fully-grown arena buffers to it instead of
+   * destroying them, driving steady-state per-frame `bufferCreates`
+   * toward zero.
+   *
+   * Call before the first draw. The pool (typically owned by
+   * `RendererGeode::Impl`) must outlive this encoder. Pass `nullptr`
+   * to disable (default).
+   */
+  void setBufferPool(GeodeBufferPool* pool);
 
   GeoEncoder(const GeoEncoder&) = delete;
   GeoEncoder& operator=(const GeoEncoder&) = delete;

--- a/donner/svg/renderer/geode/GeodeBufferPool.h
+++ b/donner/svg/renderer/geode/GeodeBufferPool.h
@@ -1,0 +1,131 @@
+#pragma once
+/// @file
+/// Frame-transient wgpu buffer pool for GeoEncoder arenas (design doc 0030).
+///
+/// `GeoEncoder` instances are recreated every frame (and per layer /
+/// filter / mask push), so without pooling every frame re-creates its
+/// bump-arena buffers from scratch: 9-20 `createBuffer` driver
+/// allocations per steady-state frame, plus the matching releases. This
+/// pool lets a frame's encoders reuse the buffers grown by earlier
+/// frames, driving steady-state `bufferCreates` toward zero.
+///
+/// Safety: buffers are released into the pool by `~GeoEncoder`, which by
+/// the renderer's existing lifetime discipline only runs after the
+/// commands referencing those buffers have been submitted (shared-mode
+/// encoders are parked in `frameFinishedEncoders` until the frame's
+/// single `queue.submit`; own-CommandEncoder encoders submit in
+/// `finish()`). Re-acquiring a pooled buffer on a later frame is safe:
+/// `queue.writeBuffer` is queue-ordered after previously submitted work.
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
+
+namespace donner::geode {
+
+/**
+ * Size-and-usage-keyed free list of wgpu buffers.
+ *
+ * Owned by `RendererGeode::Impl` (mirrors the M4.2 transient
+ * render-target texture pool) and handed to every `GeoEncoder` the
+ * renderer constructs. Not thread-safe; all use is on the renderer's
+ * thread.
+ */
+class GeodeBufferPool {
+public:
+  /**
+   * Acquire a pooled buffer with exactly `usage` and capacity >=
+   * `minCapacity`.
+   *
+   * Preference order: an entry released under the same `label` (each
+   * arena reacquires its own previous, right-sized buffer, so a Slug
+   * curve arena never trades buffers with a tiny grid arena of the same
+   * usage class), else the smallest usage-compatible entry.
+   *
+   * @param usage Required buffer usage flags (exact match).
+   * @param label Arena debug label (string literal; matched by content).
+   * @param minCapacity Minimum byte capacity.
+   * @param outCapacity Set to the returned buffer's capacity on success.
+   * @return The buffer, or an empty handle if the pool has no match.
+   */
+  ScopedWgpuHandle<wgpu::Buffer> acquire(wgpu::BufferUsage usage, const char* label,
+                                         uint64_t minCapacity, uint64_t* outCapacity) {
+    size_t bestIndex = entries_.size();
+    bool bestLabelMatch = false;
+    for (size_t i = 0; i < entries_.size(); ++i) {
+      const Entry& entry = entries_[i];
+      if (entry.usage != usage || entry.capacity < minCapacity) {
+        continue;
+      }
+      const bool labelMatch = label != nullptr && entry.label != nullptr &&
+                              (entry.label == label || std::strcmp(entry.label, label) == 0);
+      if (bestIndex == entries_.size() || (labelMatch && !bestLabelMatch) ||
+          (labelMatch == bestLabelMatch && entry.capacity < entries_[bestIndex].capacity)) {
+        bestIndex = i;
+        bestLabelMatch = labelMatch;
+      }
+    }
+    if (bestIndex == entries_.size()) {
+      return {};
+    }
+    ScopedWgpuHandle<wgpu::Buffer> buffer = std::move(entries_[bestIndex].buffer);
+    if (outCapacity != nullptr) {
+      *outCapacity = entries_[bestIndex].capacity;
+    }
+    entries_.erase(entries_.begin() + static_cast<ptrdiff_t>(bestIndex));
+    return buffer;
+  }
+
+  /**
+   * Return a buffer to the pool. When the pool is full, the smallest
+   * entry (including the incoming buffer) is dropped instead, bounding
+   * pooled VRAM while keeping the large arenas that are expensive to
+   * re-grow.
+   */
+  void release(ScopedWgpuHandle<wgpu::Buffer> buffer, wgpu::BufferUsage usage, const char* label,
+               uint64_t capacity) {
+    if (!buffer) {
+      return;
+    }
+    if (entries_.size() >= kMaxEntries) {
+      // Find the smallest pooled entry; keep the incoming buffer only if
+      // it is larger.
+      size_t smallest = 0;
+      for (size_t i = 1; i < entries_.size(); ++i) {
+        if (entries_[i].capacity < entries_[smallest].capacity) {
+          smallest = i;
+        }
+      }
+      if (entries_[smallest].capacity >= capacity) {
+        return;  // Incoming buffer is the smallest; drop it.
+      }
+      entries_.erase(entries_.begin() + static_cast<ptrdiff_t>(smallest));
+    }
+    entries_.push_back(Entry{std::move(buffer), usage, label, capacity});
+  }
+
+  /// Number of pooled buffers (for tests).
+  [[nodiscard]] size_t size() const { return entries_.size(); }
+
+  /// Drop every pooled buffer.
+  void clear() { entries_.clear(); }
+
+private:
+  struct Entry {
+    ScopedWgpuHandle<wgpu::Buffer> buffer;
+    wgpu::BufferUsage usage;
+    const char* label = nullptr;  ///< Arena label (string literal).
+    uint64_t capacity = 0;
+  };
+
+  /// Steady-state frames use ~10-20 arena buffers; 64 leaves headroom
+  /// for layer-heavy frames without letting a pathological frame pin
+  /// unbounded VRAM.
+  static constexpr size_t kMaxEntries = 64;
+
+  std::vector<Entry> entries_;
+};
+
+}  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodePathEncoder.cc
+++ b/donner/svg/renderer/geode/GeodePathEncoder.cc
@@ -288,21 +288,6 @@ EncodedPath GeodePathEncoder::encode(const Path& path, FillRule /*fillRule*/, do
     result.vBandCount = vBandCount;
   }
 
-  // Legacy per-band bounding quads (2 triangles = 6 vertices each) for the 4-sample
-  // alpha-coverage gradient/mask shaders.
-  result.vertices.reserve(result.bands.size() * 6);
-  for (size_t i = 0; i < result.bands.size(); ++i) {
-    const auto& band = result.bands[i];
-    const auto bandIdx = static_cast<uint32_t>(i);
-    // Quad corners with outward normals for the vertex-shader half-pixel dilation.
-    result.vertices.push_back({band.xMin, band.yMin, -1.0f, -1.0f, bandIdx});
-    result.vertices.push_back({band.xMax, band.yMin, 1.0f, -1.0f, bandIdx});
-    result.vertices.push_back({band.xMax, band.yMax, 1.0f, 1.0f, bandIdx});
-    result.vertices.push_back({band.xMin, band.yMin, -1.0f, -1.0f, bandIdx});
-    result.vertices.push_back({band.xMax, band.yMax, 1.0f, 1.0f, bandIdx});
-    result.vertices.push_back({band.xMin, band.yMax, -1.0f, 1.0f, bandIdx});
-  }
-
   // Single bounding quad over the whole path for the analytic dual-ray fill shader.
   // One quad → each pixel shaded once → folded coverage composes (no seam double-count).
   {

--- a/donner/svg/renderer/geode/GeodePathEncoder.h
+++ b/donner/svg/renderer/geode/GeodePathEncoder.h
@@ -26,8 +26,8 @@ namespace donner::geode {
  * - **Curves**: Quadratic Bézier control points (3 × Vector2f per curve), packed contiguously.
  * - **Bands**: Horizontal slices through the path. Each band references a contiguous range of
  *   curves and has a bounding quad for rasterization.
- * - **Vertices**: The bounding quads for each band (6 vertices per band = 2 triangles), with
- *   position, outward normal, and band index attributes for the vertex shader.
+ * - **quadVertices**: A single bounding quad over the whole path (6 vertices = 2 triangles),
+ *   with position, outward normal, and band index attributes for the vertex shader.
  */
 struct EncodedPath {
   /// A quadratic Bézier curve segment (3 control points) stored as floats for GPU consumption.
@@ -55,18 +55,16 @@ struct EncodedPath {
   };
   static_assert(sizeof(Band) == 32, "Band struct must match WGSL layout");
 
-  /// Vertex for the band bounding quad (input to the Slug vertex shader).
+  /// Vertex for the path bounding quad (input to the Slug vertex shader).
   struct Vertex {
     float posX, posY;        ///< Position in path space.
     float normalX, normalY;  ///< Outward normal (for dynamic half-pixel dilation).
-    uint32_t bandIndex;      ///< Which band this vertex belongs to.
+    uint32_t bandIndex;      ///< Which band this vertex belongs to (unused by the dual-ray fill).
   };
 
-  std::vector<Curve> curves;     ///< Horizontal (Y-monotonic) curves, sorted by band.
-  std::vector<Band> bands;       ///< Horizontal band metadata (Y-strips), for the horizontal ray.
-  std::vector<Vertex> vertices;  ///< Per-band bounding quad vertices (6 per band) - legacy
-                                 ///< 4-sample path (gradient/mask alpha-coverage shaders).
-  Box2d pathBounds;              ///< Axis-aligned bounding box of the path.
+  std::vector<Curve> curves;  ///< Horizontal (Y-monotonic) curves, sorted by band.
+  std::vector<Band> bands;    ///< Horizontal band metadata (Y-strips), for the horizontal ray.
+  Box2d pathBounds;           ///< Axis-aligned bounding box of the path.
 
   /// Single bounding quad (6 verts) over the whole path, for the analytic dual-ray fill
   /// shader (0041 §8.1). One quad per path means each pixel is rasterized by exactly one
@@ -114,7 +112,7 @@ struct EncodedPath {
  * 2. Split curves at Y-monotone points (Path::toMonotonic)
  * 3. Compute path bounds and determine band count
  * 4. Assign curves to bands and sort
- * 5. Generate bounding quad vertices for each band
+ * 5. Generate the whole-path bounding quad (6 vertices = 2 triangles)
  *
  * The output EncodedPath contains all data needed to fill the path on the GPU.
  */

--- a/donner/svg/renderer/geode/tests/GeodeDebugOverlay_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeDebugOverlay_tests.cc
@@ -1,0 +1,162 @@
+/// @file
+/// Tests for `RendererGeode::setDebugGeometryOverlay` - the Geode band /
+/// triangle debug overlay.
+///
+/// Contract under test:
+///  1. Overlay OFF is the default and is byte-identical to a renderer
+///     that never touched the flag (zero behavior change when off).
+///  2. Overlay ON changes the output and paints the overlay palette
+///     (magenta bounding-quad wireframe) over the scene.
+///  3. Overlay ON emits additional draw calls; turning it back off
+///     restores byte-identical output (no sticky state).
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <string_view>
+
+#include "donner/base/ParseWarningSink.h"
+#include "donner/svg/SVGDocument.h"
+#include "donner/svg/parser/SVGParser.h"
+#include "donner/svg/renderer/RendererGeode.h"
+#include "donner/svg/renderer/RendererInterface.h"
+#include "donner/svg/renderer/geode/GeodeDevice.h"
+
+namespace donner::svg {
+namespace {
+
+/// Fixture with a fill, a stroked path, and a curve so the overlay
+/// exercises fill encodes, stroke encodes, and multi-band paths.
+constexpr std::string_view kOverlaySvg = R"SVG(
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect x="20" y="20" width="70" height="70" fill="#336699"/>
+  <path d="M 110 30 C 150 10 180 60 160 100 S 120 180 100 150 Z"
+        fill="#66aa33" stroke="black" stroke-width="4"/>
+</svg>
+)SVG";
+
+SVGDocument parseDocument(std::string_view svgSource) {
+  ParseWarningSink sink = ParseWarningSink::Disabled();
+  auto parsed = parser::SVGParser::ParseSVG(svgSource, sink);
+  EXPECT_FALSE(parsed.hasError()) << (parsed.hasError() ? parsed.error().reason : "");
+  return std::move(parsed.result());
+}
+
+/// Render the fixture and snapshot it. `overlay` selects the debug
+/// overlay state; `std::nullopt`-style third state is covered by
+/// `renderDefault` which never calls the setter.
+RendererBitmap renderWithOverlay(const std::shared_ptr<geode::GeodeDevice>& device, bool overlay) {
+  SVGDocument document = parseDocument(kOverlaySvg);
+  RendererGeode renderer(device);
+  renderer.setDebugGeometryOverlay(overlay);
+  renderer.draw(document);
+  return renderer.takeSnapshot();
+}
+
+/// Render without ever touching the overlay setter.
+RendererBitmap renderDefault(const std::shared_ptr<geode::GeodeDevice>& device) {
+  SVGDocument document = parseDocument(kOverlaySvg);
+  RendererGeode renderer(device);
+  renderer.draw(document);
+  return renderer.takeSnapshot();
+}
+
+bool bitmapsIdentical(const RendererBitmap& a, const RendererBitmap& b) {
+  return a.dimensions == b.dimensions && a.rowBytes == b.rowBytes && a.pixels == b.pixels;
+}
+
+/// Count pixels in the overlay's magenta family (bounding-quad wireframe:
+/// RGBA(255, 0, 255, 200) blended over arbitrary content keeps R and B
+/// high and G low).
+int countMagentaFamilyPixels(const RendererBitmap& bitmap) {
+  int count = 0;
+  for (int y = 0; y < bitmap.dimensions.y; ++y) {
+    const uint8_t* row = bitmap.pixels.data() + static_cast<size_t>(y) * bitmap.rowBytes;
+    for (int x = 0; x < bitmap.dimensions.x; ++x) {
+      const uint8_t* px = row + static_cast<size_t>(x) * 4;
+      if (px[0] > 150 && px[2] > 150 && px[1] < 80) {
+        ++count;
+      }
+    }
+  }
+  return count;
+}
+
+class GeodeDebugOverlayTest : public ::testing::Test {
+protected:
+  static std::shared_ptr<geode::GeodeDevice> sharedDevice() {
+    static auto device = [] {
+      return std::shared_ptr<geode::GeodeDevice>(geode::GeodeDevice::CreateHeadless());
+    }();
+    return device;
+  }
+};
+
+TEST_F(GeodeDebugOverlayTest, DefaultsOff) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  RendererGeode renderer(device);
+  EXPECT_FALSE(renderer.debugGeometryOverlay());
+}
+
+TEST_F(GeodeDebugOverlayTest, OffIsByteIdenticalToDefault) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  const RendererBitmap untouched = renderDefault(device);
+  const RendererBitmap explicitlyOff = renderWithOverlay(device, false);
+
+  ASSERT_FALSE(untouched.empty());
+  EXPECT_TRUE(bitmapsIdentical(untouched, explicitlyOff))
+      << "setDebugGeometryOverlay(false) must not change output vs never calling it.";
+}
+
+TEST_F(GeodeDebugOverlayTest, OnDrawsOverlayGeometry) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  const RendererBitmap off = renderWithOverlay(device, false);
+  const RendererBitmap on = renderWithOverlay(device, true);
+
+  ASSERT_FALSE(off.empty());
+  ASSERT_FALSE(on.empty());
+  EXPECT_FALSE(bitmapsIdentical(off, on)) << "Overlay-on output must differ from overlay-off.";
+
+  // The bounding-quad wireframe is magenta; at least a hairline's worth
+  // of pixels must land in the magenta family. Overlay-off must have none
+  // (the fixture palette has no magenta).
+  EXPECT_EQ(countMagentaFamilyPixels(off), 0);
+  EXPECT_GT(countMagentaFamilyPixels(on), 50);
+}
+
+TEST_F(GeodeDebugOverlayTest, OnEmitsExtraDrawsAndTogglesCleanly) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  SVGDocument document = parseDocument(kOverlaySvg);
+  RendererGeode renderer(device);
+
+  renderer.draw(document);
+  const RendererBitmap beforeBitmap = renderer.takeSnapshot();
+  const uint64_t drawsOff = renderer.lastFrameTimings().counters.drawCalls;
+
+  renderer.setDebugGeometryOverlay(true);
+  renderer.draw(document);
+  const uint64_t drawsOn = renderer.lastFrameTimings().counters.drawCalls;
+  EXPECT_GT(drawsOn, drawsOff) << "Overlay-on frame should emit additional overlay draw calls.";
+
+  // Toggling back off restores byte-identical output on the same renderer.
+  renderer.setDebugGeometryOverlay(false);
+  renderer.draw(document);
+  const RendererBitmap afterBitmap = renderer.takeSnapshot();
+  const uint64_t drawsOffAgain = renderer.lastFrameTimings().counters.drawCalls;
+
+  EXPECT_EQ(drawsOffAgain, drawsOff);
+  EXPECT_TRUE(bitmapsIdentical(beforeBitmap, afterBitmap))
+      << "Disabling the overlay must fully restore non-overlay rendering.";
+}
+
+}  // namespace
+}  // namespace donner::svg

--- a/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
@@ -2,10 +2,56 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <vector>
+
 #include "donner/base/FillRule.h"
 #include "donner/base/Path.h"
 
 namespace donner::geode {
+
+/// Non-asserting encode-cost probe: times `GeodePathEncoder::encode` on a
+/// synthetic many-curve, many-band path and prints the per-encode median
+/// to stderr. Wall-clock budgets are not CI-stable, so this only reports;
+/// the durable regression signal for encode work is `pathEncodes` in
+/// `GeodePerf_tests.cc`.
+TEST(GeodePathEncoder, EncodeTimingProbe) {
+  // Tall serpentine path: ~200 cubic segments over 2000px of height, so
+  // the encode runs the full pipeline (cubic lowering, dual monotonic
+  // splits, curve extraction, banding) across many bands (~63 at 32px).
+  PathBuilder builder;
+  builder.moveTo(Vector2d(0, 0));
+  for (int i = 0; i < 200; ++i) {
+    const double y = static_cast<double>(i) * 10.0;
+    const double x = (i % 2 == 0) ? 200.0 : 0.0;
+    builder.curveTo(Vector2d(x + 50.0, y), Vector2d(x - 50.0, y + 5.0), Vector2d(x, y + 10.0));
+  }
+  builder.closePath();
+  const Path path = builder.build();
+
+  constexpr int kIterations = 200;
+  std::vector<double> samplesUs;
+  samplesUs.reserve(kIterations);
+  size_t sink = 0;  // Defeat dead-code elimination.
+  for (int i = 0; i < kIterations; ++i) {
+    const auto start = std::chrono::steady_clock::now();
+    const EncodedPath iterEncoded = GeodePathEncoder::encode(path, FillRule::NonZero);
+    const auto end = std::chrono::steady_clock::now();
+    sink += iterEncoded.curves.size() + iterEncoded.quadVertices.size();
+    samplesUs.push_back(std::chrono::duration<double, std::micro>(end - start).count());
+  }
+  std::sort(samplesUs.begin(), samplesUs.end());
+  const EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
+  std::fprintf(stderr,
+               "[GeodePathEncoder] EncodeTimingProbe median=%.1fus p90=%.1fus (bands=%zu "
+               "vBands=%zu curves=%zu vCurves=%zu sink=%zu)\n",
+               samplesUs[samplesUs.size() / 2], samplesUs[(samplesUs.size() * 9) / 10],
+               encoded.bands.size(), encoded.vBands.size(), encoded.curves.size(),
+               encoded.vCurves.size(), sink);
+  EXPECT_FALSE(encoded.empty());
+}
 
 TEST(GeodePathEncoder, EmptyPath) {
   Path path;
@@ -13,7 +59,6 @@ TEST(GeodePathEncoder, EmptyPath) {
   EXPECT_TRUE(encoded.empty());
   EXPECT_TRUE(encoded.curves.empty());
   EXPECT_TRUE(encoded.bands.empty());
-  EXPECT_TRUE(encoded.vertices.empty());
 }
 
 TEST(GeodePathEncoder, SimpleTriangle) {
@@ -33,8 +78,8 @@ TEST(GeodePathEncoder, SimpleTriangle) {
   // Should have at least 1 band.
   EXPECT_GE(encoded.bands.size(), 1u);
 
-  // Each band produces 6 vertices (2 triangles).
-  EXPECT_EQ(encoded.vertices.size(), encoded.bands.size() * 6);
+  // The whole path draws one bounding quad (6 vertices = 2 triangles).
+  EXPECT_EQ(encoded.quadVertices.size(), 6u);
 
   // Bounds should encompass the triangle.
   EXPECT_LE(encoded.pathBounds.topLeft.x, 0.0f);
@@ -139,8 +184,10 @@ TEST(GeodePathEncoder, VertexNormalsPointOutward) {
   EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
   EXPECT_FALSE(encoded.empty());
 
-  // Each band has 6 vertices. Verify normals are non-zero and point in expected directions.
-  for (const auto& v : encoded.vertices) {
+  // The path bounding quad has 6 vertices. Verify normals are non-zero
+  // and point in expected directions.
+  EXPECT_EQ(encoded.quadVertices.size(), 6u);
+  for (const auto& v : encoded.quadVertices) {
     const float normalLen = std::sqrt(v.normalX * v.normalX + v.normalY * v.normalY);
     EXPECT_GT(normalLen, 0.0f) << "Vertex normals should be non-zero";
   }

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -449,6 +449,10 @@ TEST_F(GeodePerfTest, SimpleShapes_NoDirtyPath_ZeroEncodes) {
   // cache. countPathEncode() is only called on cache miss.
   EXPECT_EQ(c.pathEncodes, 0u) << "Cache miss on an unchanged second render: one or more paths "
                                   "re-encoded despite zero geometry changes.";
+  // M1 (GeodeBufferPool): steady-state arena buffers are recycled across
+  // frames. The remaining create is the takeSnapshot readback buffer.
+  EXPECT_LE(c.bufferCreates, 2u) << "Arena buffer churn on an unchanged second render: the "
+                                    "cross-frame GeodeBufferPool should serve all arena growth.";
 }
 
 TEST_F(GeodePerfTest, Moderate_NoDirtyPath_ZeroEncodes) {
@@ -463,6 +467,9 @@ TEST_F(GeodePerfTest, Moderate_NoDirtyPath_ZeroEncodes) {
   // `fillPathLinearGradient` (rounded-rect path).
   EXPECT_EQ(c.pathEncodes, 0u) << "Cache miss on unchanged second render: fill or gradient path "
                                   "re-encoded despite zero geometry changes.";
+  // M1 (GeodeBufferPool): readback + one per-blit uniform buffer remain
+  // (layer composite blits create a fresh uniform buffer per call).
+  EXPECT_LE(c.bufferCreates, 4u) << "Arena buffer churn on an unchanged second render.";
 }
 
 TEST_F(GeodePerfTest, Lion_NoDirtyPath_ZeroEncodes) {
@@ -485,6 +492,11 @@ TEST_F(GeodePerfTest, Lion_NoDirtyPath_ZeroEncodes) {
   // is the whole point of the cache.
   EXPECT_EQ(c.pathEncodes, 0u) << "Cache miss on unchanged second render of lion.svg: "
                                   "re-encoded paths despite zero geometry changes.";
+  // M1 (GeodeBufferPool): pre-pool this was 12 creates/frame (arena
+  // re-growth in the per-frame encoder); pooled steady state is the
+  // readback buffer only.
+  EXPECT_LE(c.bufferCreates, 3u)
+      << "Arena buffer churn on an unchanged second render of lion.svg.";
 }
 
 TEST_F(GeodePerfTest, GhostscriptTiger_NoDirtyPath_ZeroEncodes) {
@@ -507,6 +519,11 @@ TEST_F(GeodePerfTest, GhostscriptTiger_NoDirtyPath_ZeroEncodes) {
   EXPECT_EQ(c.pathEncodes, 0u)
       << "Cache miss on unchanged second render of Ghostscript_Tiger.svg: "
          "fill- or stroke-slot cache missed despite zero geometry changes.";
+  // M1 (GeodeBufferPool): pre-pool this was 20 creates/frame. Observed
+  // pooled steady state is 4 (readback + residual arena churn); assert
+  // with a little margin.
+  EXPECT_LE(c.bufferCreates, 8u)
+      << "Arena buffer churn on an unchanged second render of Ghostscript_Tiger.svg.";
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Optimization slice of the Geode performance pass, targeting the top hitch source from the measured cost profile in #809. Stacked on #811.

### 1. GeodeBufferPool: recycle arena buffers across frames

GeoEncoder instances are recreated every frame (and per layer/filter/mask push), so every steady-state frame re-created all bump-arena buffers from scratch and destroyed last frame's: 9-20 createBuffer driver allocations plus matching releases per unchanged frame - pure allocation churn and a frame-jitter source. A usage+label-keyed pool on RendererGeode::Impl (companion to the M4.2 texture pool) now recycles fully-grown arena buffers; all 13 encoder construction sites install it.

Measured steady-state bufferCreates per unchanged frame (GeodePerf_tests, fresh runs, macOS/Metal M4 Pro):

| Fixture | before | after |
|---|---|---|
| SimpleShapes | 9 | 1 |
| Moderate (layer+gradient) | 18 | 2 |
| lion.svg | 12 | 1 |
| Ghostscript_Tiger | 20 | 4 |

Residual creates are the takeSnapshot readback buffer and per-blit uniform buffers. Guarded by new tightened bufferCreates ceiling assertions in the `*_NoDirtyPath_*` tests (previously unasserted).

Safety: buffers enter the pool in ~GeoEncoder, which the renderer only runs after the commands referencing them are submitted - the same invariant the previous eager destroy() relied on. Re-acquisition writes are queue-ordered after prior submits.

### 2. Remove dead legacy EncodedPath::vertices

GeodePathEncoder still built the per-band 6-vertex quad list for the 4-sample alpha-coverage shaders deleted by design 0041. No draw path consumed it (all draws use the whole-path quadVertices). Removing it saves the per-encode allocation+fill (378 vertices / 7,560 bytes on the new timing-probe fixture) and idle bytes in every cached EncodedPath. Encode timing probe (new, print-only): median 182.8us before, 180.8us after - a noise-level CPU delta, reported as such; the win is dead work and cache memory, not wall clock.

### 3. Docs to as-built

0030's measured cost profile reflects the pooled state and updated remaining-work ranking; 0017 gains a Debug and Diagnostics section for the overlay surface added in #811.

## Testing

- bazel test //donner/svg/renderer/geode/... + renderer_geode_golden_tests + renderer_tests, fresh (--nocache_test_results): 26 pass / 7 skipped / 0 fail; goldens unchanged.
- bazel test //donner/editor/... //donner/svg/renderer/... : 362 pass / 19 skipped / 0 fail (includes the geode resvg suite).

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
