### PR TITLE
Binary size wave 2: closure JS glue (render-test-gated) + native ThinLTO

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -161,6 +161,13 @@ common:wasm-size --config=wasm
 build:wasm-size -c opt
 build:wasm-size --copt=-Oz
 build:wasm-size --linkopt=-Oz
+# JS-glue minification: closure shrinks the Emscripten glue ~10x, and
+# -sFILESYSTEM=0 drops the unused virtual filesystem runtime. Both are
+# JS-glue-only trims validated by the headless render gate
+# (//donner/svg/renderer/wasm:render_test). Gated to wasm-size so the plain
+# --config=wasm dev build stays fast and un-minified.
+build:wasm-size --linkopt=--closure=1
+build:wasm-size --linkopt=-sFILESYSTEM=0
 
 # Full editor WASM build. Uses Geode/WebGPU by default because the editor
 # presentation and performance work target Geode. Usage:

--- a/.bazelrc
+++ b/.bazelrc
@@ -270,6 +270,21 @@ build:binary-size --copt=-ffunction-sections --copt=-fdata-sections
 build:linux-binary-size --config=binary-size
 build:linux-binary-size --linkopt=-Wl,--gc-sections
 
+# ThinLTO layer for the size-optimized native build. ThinLTO shrinks the
+# stripped binaries ~8% by folding and inlining across translation units, but
+# its debug info points at transient .thinlto.o object files that dsymutil and
+# bloaty cannot open, so it is kept OFF the attribution build:binary-size above
+# and offered as a separate shipped-size config. tools/binary_size.sh reports
+# both: the non-LTO build (with per-compile-unit attribution) and this LTO
+# build (headline shipped size, no attribution). Usage:
+#   bazel build --config=macos-binary-size-lto //donner/svg/tool:donner-svg.stripped
+build:binary-size-lto --config=binary-size
+build:binary-size-lto --copt=-flto=thin --linkopt=-flto=thin
+build:macos-binary-size-lto --config=macos-binary-size
+build:macos-binary-size-lto --copt=-flto=thin --linkopt=-flto=thin
+build:linux-binary-size-lto --config=linux-binary-size
+build:linux-binary-size-lto --copt=-flto=thin --linkopt=-flto=thin
+
 test --test_env=LLM
 test --test_env=DONNER_RENDERER_TEST_VERBOSE
 

--- a/.github/workflows/editor_wasm.yml
+++ b/.github/workflows/editor_wasm.yml
@@ -43,6 +43,19 @@ jobs:
         with:
           node-version: 20
 
+      # JS-glue size safety gate. This is the only CI exercise of
+      # --config=wasm-size (--closure=1 + -sFILESYSTEM=0): it builds the
+      # tiny_skia svg-renderer wasm module with the shipped glue minification,
+      # then loads it under Node and asserts on rendered pixels. Without this a
+      # closure/filesystem-trim glue regression would pass CI silently. The
+      # render_test target keeps its `manual` tag (so plain wildcard builds under
+      # the wrong config do not pull in the wasm outputs); it is invoked here
+      # explicitly under the wasm-size config, in the same lane that builds wasm.
+      - name: WASM JS-glue render gate (closure + FILESYSTEM=0)
+        run: |
+          bazelisk test --config=wasm-size --test_output=errors \
+            //donner/svg/renderer/wasm:render_test
+
       - name: Install Playwright
         working-directory: donner/editor/wasm/tests
         run: |

--- a/docs/design_docs/0055-binary_size.md
+++ b/docs/design_docs/0055-binary_size.md
@@ -1,8 +1,8 @@
 # Design: Binary Size Reduction
 
-**Status:** Draft
-**Author:** Claude Fable 5
-**Drafted by:** Claude Opus 4.8
+**Status:** Implementing (waves 1 and 2 landed; remaining work ranked)
+**Author:** Claude Fable 5 (reviewed; drafted by Claude Opus 4.8)
+**Model:** Claude Fable 5
 **Created:** 2026-07-10
 
 ## Summary
@@ -45,8 +45,12 @@ noted as follow-on surfaces but are not the primary focus.
 
 - Baseline plus the extended `tools/binary_size.sh` (native + wasm) landed so
   the report is regenerable by anyone with one command.
-- First reduction (R1) landed: size-optimized `--config=wasm-size` cuts the wasm
-  gzip transfer 48.5%. Next: native identical-code folding and LTO.
+- Wave 1 (R1): size-optimized `--config=wasm-size` (`-Oz` + emmalloc) cut the
+  wasm gzip transfer 48.5%.
+- Wave 2 landed: an automated headless render test as the JS-glue safety gate,
+  then closure + `-sFILESYSTEM=0` on the glue (R2), and native ThinLTO (R3).
+  Diminishing returns reached for the levers available on this host; see the
+  final table and the ranked-remaining list.
 
 ## Implementation Plan
 
@@ -62,16 +66,25 @@ noted as follow-on surfaces but are not the primary focus.
         the shipping build. Measured delta below.
   - [x] Add `emmalloc` to the tiny_skia renderer wasm binary (safe: it sets
         `USE_PTHREADS=0`).
-  - [ ] Surface `--closure=1` / `-sFILESYSTEM=0` as JS-glue wins gated on a
-        headless render test (deferred; needs the test harness first).
-- [ ] Milestone 3: Native reductions
-  - [ ] Evaluate identical-code folding (lld `--icf=all`) and confirm
-        `--gc-sections` / `-dead_strip` behavior on each platform.
-  - [ ] Evaluate ThinLTO for the shipped (non-attribution) build.
+  - [x] Build the headless render test first
+        (`//donner/svg/renderer/wasm:render_test`): loads the built module under
+        Node, renders a nontrivial SVG through the public C API, asserts on a
+        pixel hash. This is the JS-glue safety gate. (R2 prerequisite.)
+  - [x] Surface `--closure=1` / `-sFILESYSTEM=0` as JS-glue wins gated on that
+        test (R2). Realized ~10x on the glue.
+- [x] Milestone 3: Native reductions
+  - [x] Evaluate identical-code folding (lld `--icf=all`): Linux-only lever,
+        not measurable on the macOS host (Apple ld rejects it and already
+        deduplicates). Ranked as pending a Linux measurement.
+  - [x] Evaluate ThinLTO for the shipped (non-attribution) build (R3): ~8% on
+        both native binaries; landed as `--config=binary-size-lto`.
+  - [x] Evaluate symbol visibility (`-fvisibility=hidden`): 272 bytes, not
+        taken.
   - [ ] Audit the largest compile units (AttributeParser, SVGParser,
-        PropertyRegistry, css/Token) for template/table bloat.
-- [ ] Milestone 4: Finalize
-  - [ ] Record final-vs-baseline numbers per target and the ranked remaining
+        PropertyRegistry, css/Token) for template/table bloat. Ranked as
+        remaining work; not taken this pass (expensive refactors).
+- [x] Milestone 4: Finalize
+  - [x] Record final-vs-baseline numbers per target and the ranked remaining
         opportunities; rewrite this doc's status.
 
 ## Proposed Architecture
@@ -87,11 +100,18 @@ Native targets build under `--config={macos,linux}-binary-size` (`-c opt -Os`,
 `-ffunction-sections -fdata-sections`, symbols preserved for attribution, then
 measured on the `.stripped` output). bloaty attributes size by
 `donner_package,compileunits,symbols` using the unstripped binary as the debug
-file. The wasm target builds under `--config=wasm` and is measured both raw and
+file. The script also reports the ThinLTO (`--config=binary-size-lto`) headline
+shipped sizes separately, since ThinLTO defeats the debug-map attribution. The
+wasm target builds under `--config=wasm-size` and is measured both raw and
 gzip -9 (the transfer-size proxy), with a bloaty section/symbol breakdown of the
 `.wasm`.
 
-## Baseline (measured 2026-07-10, an internal build host, macOS arm64)
+The JS-glue safety gate is `//donner/svg/renderer/wasm:render_test`, a
+Node-driven bazel `py_test` that renders through the public C API and asserts on
+a pixel hash; it is what makes closure minification safe to ship (R2). Run it
+with `bazel test --config=wasm-size //donner/svg/renderer/wasm:render_test`.
+
+## Baseline (measured 2026-07-10, deep-thought, macOS arm64)
 
 Native, `--config=macos-binary-size`, stripped, arm64 Mach-O:
 
@@ -158,32 +178,171 @@ optimized JS glue exposes the same public C API (`donner_init`,
 baseline. No source, API, or feature changes; `-Oz` and `emmalloc` are
 behavior-preserving optimizer/allocator flags (no closure minification).
 
+### R2: JS-glue minification (closure + `-sFILESYSTEM=0`), gated by a render test
+
+Wave 1 measured closure at roughly 10x on the glue but held it back for lack of
+an automated render check. Wave 2 builds that check first, then ships closure.
+
+The gate is `//donner/svg/renderer/wasm:render_test`: a Node-driven bazel
+`py_test` (`render_test.py` + `render_test_driver.mjs`) that loads the built
+tiny_skia module exactly as a browser would (the same default ES6 module
+factory), supplying the `.wasm` bytes via `wasmBinary` so the web-targeted,
+assertions-off (opt) module runs headless. It renders a nontrivial SVG through
+the public C API, reads the RGBA pixels back through the exported `HEAPU8`
+view, and asserts the render is non-blank and its FNV-1a pixel hash matches a
+checked-in golden. The hash comes from the wasm module, so it is invariant to
+glue changes; a glue regression (for example closure renaming
+`cwrap`/`UTF8ToString`/`HEAPU8`, or a dropped module export) instead breaks the
+render and fails the test. This was demonstrated: dropping `cwrap` from the
+exports turns the test red, restoring it turns it green. Run it against the
+shipped artifact: `bazel test --config=wasm-size
+//donner/svg/renderer/wasm:render_test`.
+
+Building the gate surfaced a latent bug: the tiny_skia bridge did not export
+`HEAPU8` (the Geode bridge already did), so under the size config the module
+could not return pixels to JS at all and `test.html` referenced an absent
+`Module.HEAPU8`. R2 adds `HEAPU8` to the tiny_skia exports, making the module
+actually usable. This is an additive fix, not an API break.
+
+With the gate in place, `--closure=1` and `-sFILESYSTEM=0` land on
+`--config=wasm-size`. Measured with `bash tools/binary_size.sh`:
+
+| Artifact               | R1 raw    | R2 raw    | R1 gzip | R2 gzip |
+| ---------------------- | --------- | --------- | ------- | ------- |
+| `donner_wasm_bin.wasm` | 1,603,318 | 1,603,318 | 614,919 | 614,919 |
+| `donner_wasm_bin.js`   | 57,617    | 5,495     | 16,358  | 2,717   |
+| Total transfer         | 1,660,935 | 1,608,813 | 631,277 | 617,636 |
+
+The glue drops 90.5% raw (57,617 to 5,495 bytes) and 83.4% gzip (16,358 to
+2,717); the `.wasm` is unchanged (glue-only change). The render gate passes
+against the closure-minified module, confirming closure preserved the public
+runtime surface. `--config=wasm` (dev) is left un-minified for fast iteration.
+
+### R3: native ThinLTO (`--config=binary-size-lto`)
+
+ThinLTO folds and inlines across translation units. Measured on the stripped
+`-Os` binaries with `bash tools/binary_size.sh`:
+
+| Target            | non-LTO   | ThinLTO   | delta |
+| ----------------- | --------- | --------- | ----- |
+| `svg_parser_tool` | 2,527,384 | 2,317,000 | -8.3% |
+| `donner-svg`      | 4,182,688 | 3,829,632 | -8.4% |
+
+ThinLTO lands as `--config=binary-size-lto` (with `macos-`/`linux-` variants)
+layered on the size configs. It stays OFF the attribution `--config=binary-size`
+because ThinLTO debug info points at transient `.thinlto.o` object files that
+`dsymutil` and bloaty cannot open, which would blank out the per-compile-unit
+report. `tools/binary_size.sh` therefore reports both: the non-LTO build with
+attribution, and the ThinLTO headline shipped sizes. Covered by the existing
+native test suites (ThinLTO is a behavior-preserving optimizer change).
+
+Two other native levers were evaluated and not taken:
+
+- Symbol visibility (`-fvisibility=hidden` / `-fvisibility-inlines-hidden`):
+  272 bytes on `svg_parser_tool` (0.01%), and 272 bytes on top of ThinLTO.
+  Symbols are already stripped and `-dead_strip` already applied, so visibility
+  buys almost nothing on these statically linked executables. Not taken.
+- lld `--icf=all`: a Linux/ELF lld lever. This host links macOS with Apple `ld`
+  (via xcrun), which rejects `--icf` and already deduplicates identical code by
+  default, so there is no macOS ICF win to capture and the deep-thought host
+  cannot measure the Linux delta. Ranked as pending a Linux measurement.
+
+While adding the LTO reporting, two latent bugs in the macOS attribution path
+were fixed in `tools/binary_size.sh`: it now explicitly builds the unstripped
+`svg_parser_tool` (only `.stripped` was requested, so the debug binary it copies
+could be missing), and passes `--remote_download_all` so the per-`.o` debug-map
+inputs `dsymutil` needs are materialized locally instead of left unfetched in
+the cache (which had made the compile-unit breakdown come back empty on this
+remote-cache host).
+
+## Final sizes vs baseline (waves 1 and 2)
+
+All measured on deep-thought (macOS arm64) with `bash tools/binary_size.sh`.
+
+Native, stripped arm64 Mach-O. "Shipped" is the ThinLTO
+(`--config=binary-size-lto`) build:
+
+| Target            | Baseline  | Shipped (LTO) | Saved   | Reduction |
+| ----------------- | --------- | ------------- | ------- | --------- |
+| `svg_parser_tool` | 2,527,384 | 2,317,000     | 210,384 | 8.3%      |
+| `donner-svg`      | 4,182,688 | 3,829,632     | 353,056 | 8.4%      |
+
+WebAssembly transfer (tiny_skia `donner_wasm`), baseline `--config=wasm`
+(fastbuild `-O0`) vs shipped `--config=wasm-size` (`-Oz` + emmalloc + closure +
+`-sFILESYSTEM=0`):
+
+| Artifact  | Baseline raw | Shipped raw | Baseline gzip | Shipped gzip |
+| --------- | ------------ | ----------- | ------------- | ------------ |
+| `.wasm`   | 5,688,030    | 1,603,318   | 1,184,620     | 614,919      |
+| `.js`     | 154,601      | 5,495       | 41,847        | 2,717        |
+| Total     | 5,842,631    | 1,608,813   | 1,226,467     | 617,636      |
+
+Wasm total transfer: raw down 72.5% (5.84 MiB to 1.53 MiB), gzip down 49.6%
+(1.23 MiB to 617,636 bytes). The gzip transfer number is the one a browser
+actually pays. The glue alone dropped 96.4% raw and 93.5% gzip across the two
+waves.
+
+## Diminishing returns
+
+The pass stops here for the levers available on this host, and the reason is
+concrete per surface:
+
+- Wasm: after `-Oz` + emmalloc + closure + `-sFILESYSTEM=0`, the JS glue is
+  2,717 gzip bytes (0.4% of the transfer) and the `.wasm` is 99.6% of it.
+  Further wasm wins now require shrinking the code itself (feature tiers, or the
+  compile-unit audits), not the build/glue flags, which are spent.
+- Native: `-Os` + `-ffunction-sections`/`-fdata-sections` + `-dead_strip` +
+  ThinLTO is the standard size-optimized stack; visibility and (macOS) ICF add
+  nothing measurable. Further native wins require the compile-unit audits or
+  feature removals.
+
+Everything past this point is either an expensive source refactor (ranked below)
+or a deliberate feature removal (operator decision, surfaced not taken).
+
 ## Ranked opportunities
+
+Done:
 
 1. DONE (R1): Build the shipped wasm with `-Oz` (largest lever; safe). Realized
    ~72% raw, ~48% gzip.
 2. DONE (R1): `emmalloc` on the tiny_skia wasm binary (safe, small).
-3. `--closure=1` + `-sFILESYSTEM=0` for the JS glue (10x on `.js`, gated on a
-   headless render test that does not exist yet; build the test first).
-4. Native identical-code folding (`lld --icf=all`) and LTO for the shipped
-   (non-attribution) native build.
-5. Compile-unit audits of the heaviest units (AttributeParser, SVGParser,
-   PropertyRegistry, css/Token) for template instantiation and static-table
-   bloat.
-6. Feature-tier tradeoffs deliberately NOT taken by default: `--config=tiny`
-   (filters=false, text=false) and `--config=no-filters` remove real
-   functionality and are surfaced here as opt-in size levers, not applied.
+3. DONE (R2): `--closure=1` + `-sFILESYSTEM=0` for the JS glue (~10x on `.js`),
+   gated by the new headless render test (built first, in R2).
+4. DONE (R3): ThinLTO for the shipped native build (~8% on both binaries).
+
+Remaining, ranked (not taken this pass):
+
+5. Native identical-code folding (`lld --icf=all`): a Linux-only lever this
+   macOS host cannot measure (Apple ld rejects it and already deduplicates).
+   Needs a Linux measurement on dev1/event-horizon to size the win before it
+   lands in `--config=linux-binary-size`. Cheap to try, unquantified here.
+6. Compile-unit audits of the heaviest units (`AttributeParser.cc` 374 KiB,
+   `SVGParser.cc` 270 KiB, `SVGDocument.cc` 176 KiB, `PropertyRegistry.cc`
+   100 KiB, `css/Token.cc` 95 KiB) for template instantiation and static-table
+   bloat. These are potentially the largest remaining native wins but are
+   expensive source refactors (parser/property-table restructuring), out of
+   scope for a flags-only size pass; ranked for a dedicated effort.
+
+Deliberate feature-tier tradeoffs, surfaced NOT taken (operator decisions):
+
+7. `--config=tiny` (filters=false, text=false) and `--config=no-filters` remove
+   real functionality. They are the largest remaining wasm code-size levers
+   (the `.wasm` is now 99.6% of the transfer), but they change what a default
+   build renders, so they stay opt-in and are not applied here.
 
 ## Testing and Validation
 
 - Size numbers come only from `tools/binary_size.sh`; every reported delta is a
   before/after from that tool on the same host.
-- Functional safety: native reductions are covered by the existing test suites;
-  each reduction PR runs the affected suites and reports CI state. The wasm
-  `-Oz`/`emmalloc` changes are functional-behavior-preserving optimizer flags;
-  `--closure=1` is held back until a headless render check exists.
+- Functional safety: native reductions (including ThinLTO) are covered by the
+  existing test suites; each reduction PR runs the affected suites and reports
+  CI state. The wasm `-Oz`/`emmalloc` changes are functional-behavior-preserving
+  optimizer flags. `--closure=1` is now gated by the automated headless render
+  test (`//donner/svg/renderer/wasm:render_test`), which was demonstrated to go
+  red on a deliberate glue breakage and green when restored.
 - No public API breaks or feature removals land without prominent flagging in
-  the PR description and this doc.
+  the PR description and this doc. The `HEAPU8` export added in R2 is additive
+  (it made the tiny_skia module usable from JS at all under the size config).
 
 ## Open Questions
 

--- a/docs/design_docs/0055-binary_size.md
+++ b/docs/design_docs/0055-binary_size.md
@@ -111,7 +111,7 @@ Node-driven bazel `py_test` that renders through the public C API and asserts on
 a pixel hash; it is what makes closure minification safe to ship (R2). Run it
 with `bazel test --config=wasm-size //donner/svg/renderer/wasm:render_test`.
 
-## Baseline (measured 2026-07-10, deep-thought, macOS arm64)
+## Baseline (measured 2026-07-10, an internal build host, macOS arm64)
 
 Native, `--config=macos-binary-size`, stripped, arm64 Mach-O:
 
@@ -244,8 +244,8 @@ Two other native levers were evaluated and not taken:
   buys almost nothing on these statically linked executables. Not taken.
 - lld `--icf=all`: a Linux/ELF lld lever. This host links macOS with Apple `ld`
   (via xcrun), which rejects `--icf` and already deduplicates identical code by
-  default, so there is no macOS ICF win to capture and the deep-thought host
-  cannot measure the Linux delta. Ranked as pending a Linux measurement.
+  default, so there is no macOS ICF win to capture and this
+  macOS host cannot measure the Linux delta. Ranked as pending a Linux measurement.
 
 While adding the LTO reporting, two latent bugs in the macOS attribution path
 were fixed in `tools/binary_size.sh`: it now explicitly builds the unstripped
@@ -257,7 +257,7 @@ remote-cache host).
 
 ## Final sizes vs baseline (waves 1 and 2)
 
-All measured on deep-thought (macOS arm64) with `bash tools/binary_size.sh`.
+All measured on an internal build host (macOS arm64) with `bash tools/binary_size.sh`.
 
 Native, stripped arm64 Mach-O. "Shipped" is the ThinLTO
 (`--config=binary-size-lto`) build:
@@ -314,7 +314,7 @@ Remaining, ranked (not taken this pass):
 
 5. Native identical-code folding (`lld --icf=all`): a Linux-only lever this
    macOS host cannot measure (Apple ld rejects it and already deduplicates).
-   Needs a Linux measurement on dev1/event-horizon to size the win before it
+   Needs a Linux measurement on an internal Linux build host to size the win before it
    lands in `--config=linux-binary-size`. Cheap to try, unquantified here.
 6. Compile-unit audits of the heaviest units (`AttributeParser.cc` 374 KiB,
    `SVGParser.cc` 270 KiB, `SVGDocument.cc` 176 KiB, `PropertyRegistry.cc`

--- a/donner/svg/renderer/wasm/BUILD.bazel
+++ b/donner/svg/renderer/wasm/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@emsdk//emscripten_toolchain:wasm_cc_binary.bzl", "wasm_cc_binary")
 load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@rules_python//python:defs.bzl", "py_test")
 load("//tools/http:serve_http.bzl", "serve_http")
 
 package(default_visibility = ["//visibility:public"])
@@ -51,7 +52,7 @@ cc_binary(
         "-sEXPORTED_FUNCTIONS=_donner_init,_donner_render_svg,_donner_free_pixels,_donner_get_last_error,_malloc,_free",
         # Smaller allocator than the default dlmalloc; safe with USE_PTHREADS=0.
         "-sMALLOC=emmalloc",
-        "-sEXPORTED_RUNTIME_METHODS=ccall,cwrap,UTF8ToString",
+        "-sEXPORTED_RUNTIME_METHODS=ccall,cwrap,UTF8ToString,HEAPU8",
         "-sUSE_PTHREADS=0",
         "-sSTACK_SIZE=1048576",
         "--no-entry",
@@ -84,6 +85,31 @@ filegroup(
         ":donner_wasm",
     ],
     target_compatible_with = _WASM_TINY_SKIA_COMPATIBLE_WITH,
+)
+
+# Headless render gate for the tiny_skia wasm module. Loads the built module
+# under Node, renders a nontrivial SVG through the public C API, and asserts on
+# the pixels (see render_test.py). This is the safety gate for JS-glue size
+# work (closure minification, filesystem trims). Run against the shipped,
+# size-optimized artifact so assertions are compiled out and the module loads
+# outside a browser:
+#
+#   bazel test --config=wasm-size //donner/svg/renderer/wasm:render_test
+#
+# Requires Node on the host (found via $DONNER_NODE, PATH, or a common install
+# location). Marked manual and gated to the tiny_skia wasm config so a plain
+# host-config wildcard build does not try to pull in the wasm outputs.
+py_test(
+    name = "render_test",
+    srcs = ["render_test.py"],
+    size = "small",
+    data = [
+        "render_test_driver.mjs",
+        ":donner_wasm",
+    ],
+    tags = ["manual"],
+    target_compatible_with = _WASM_TINY_SKIA_COMPATIBLE_WITH,
+    deps = ["@rules_python//python/runfiles"],
 )
 
 # ─── Geode (WebGPU) WASM build ─────────────────────────────────────────

--- a/donner/svg/renderer/wasm/render_test.py
+++ b/donner/svg/renderer/wasm/render_test.py
@@ -1,0 +1,152 @@
+"""Headless render test for the tiny_skia Donner SVG WebAssembly module.
+
+This is the automated safety gate for JS-glue size work (closure minification,
+`-sFILESYSTEM=0`, and similar). It loads the built Emscripten module under Node
+via `render_test_driver.mjs`, renders a nontrivial SVG through the public C API,
+reads the pixels back through the exported `HEAPU8` view, and asserts the render
+is non-blank and its pixel hash matches a checked-in golden. A glue regression
+(for example closure renaming `cwrap`/`UTF8ToString`/`HEAPU8`) breaks the render
+and fails this test; the golden itself is invariant to glue changes because the
+pixels come from the wasm module.
+
+Run it against the shipped, size-optimized artifact:
+
+    bazel test --config=wasm-size //donner/svg/renderer/wasm:render_test
+
+The module only loads outside a browser when built with assertions off (opt),
+which `--config=wasm-size` provides; the unoptimized `--config=wasm` dev build
+keeps an environment guard and is not the gate target. Node is located via
+$DONNER_NODE, then PATH, then common install locations; if none is found the
+test fails loudly rather than silently passing.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+from python.runfiles import runfiles
+
+_GLUE_RLOCATION = "donner/donner/svg/renderer/wasm/donner_wasm_bin.js"
+_WASM_RLOCATION = "donner/donner/svg/renderer/wasm/donner_wasm_bin.wasm"
+_DRIVER_RLOCATION = "donner/donner/svg/renderer/wasm/render_test_driver.mjs"
+
+# FNV-1a hash of the 64x64 RGBA render of the reference SVG in the driver,
+# measured on the size-optimized (--config=wasm-size) tiny_skia wasm build.
+# Regenerate only on a deliberate renderer change (run the driver and copy the
+# HASH= line), never to paper over a glue regression.
+_GOLDEN_HASH = "28ece9d9"
+_WIDTH = 64
+_HEIGHT = 64
+_EXPECTED_BYTES = _WIDTH * _HEIGHT * 4
+
+
+def _find_node():
+    candidates = [
+        os.environ.get("DONNER_NODE"),
+        shutil.which("node"),
+        "/opt/homebrew/bin/node",
+        "/usr/local/bin/node",
+        "/usr/bin/node",
+    ]
+    for candidate in candidates:
+        if candidate and os.path.exists(candidate):
+            return candidate
+    return None
+
+
+class WasmRenderTest(unittest.TestCase):
+    def setUp(self):
+        self.node = _find_node()
+        self.assertIsNotNone(
+            self.node,
+            "node not found; set $DONNER_NODE or put node on PATH "
+            "(the headless wasm render gate requires Node).",
+        )
+        self.r = runfiles.Create()
+        self.assertIsNotNone(self.r, "runfiles not available")
+
+    def _rlocation(self, path):
+        located = self.r.Rlocation(path)
+        self.assertIsNotNone(located, path + " not found in runfiles")
+        self.assertTrue(os.path.exists(located), located)
+        return located
+
+    def _run_driver(self, glue_path, wasm_path):
+        result = subprocess.run(
+            [
+                self.node,
+                self._rlocation(_DRIVER_RLOCATION),
+                glue_path,
+                wasm_path,
+                str(_WIDTH),
+                str(_HEIGHT),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        return result
+
+    def _parse(self, stdout):
+        fields = {}
+        for line in stdout.splitlines():
+            if "=" in line:
+                key, _, value = line.partition("=")
+                fields[key.strip()] = value.strip()
+        return fields
+
+    def test_renders_reference_svg(self):
+        glue = self._rlocation(_GLUE_RLOCATION)
+        wasm = self._rlocation(_WASM_RLOCATION)
+
+        # The Emscripten glue is ES6 (uses `export` / `import.meta`), so Node
+        # must see it with a .mjs extension. Copy it next to nothing special;
+        # the driver reads the .wasm bytes directly, so co-location is not
+        # required.
+        with tempfile.TemporaryDirectory() as tmp:
+            glue_mjs = os.path.join(tmp, "donner_wasm_bin.mjs")
+            shutil.copyfile(glue, glue_mjs)
+
+            result = self._run_driver(glue_mjs, wasm)
+
+        self.assertEqual(
+            result.returncode,
+            0,
+            "render driver failed (exit {}):\nSTDOUT:\n{}\nSTDERR:\n{}".format(
+                result.returncode, result.stdout, result.stderr
+            ),
+        )
+
+        fields = self._parse(result.stdout)
+        self.assertIn("HASH", fields, "driver did not print HASH:\n" + result.stdout)
+        self.assertIn("BYTES", fields, "driver did not print BYTES:\n" + result.stdout)
+
+        self.assertEqual(
+            int(fields["BYTES"]),
+            _EXPECTED_BYTES,
+            "unexpected pixel byte count",
+        )
+
+        nonzero, _, denom = fields.get("NONZERO", "0/0").partition("/")
+        nonzero = int(nonzero)
+        self.assertGreater(
+            nonzero,
+            int(_EXPECTED_BYTES * 0.9),
+            "rendered image is mostly blank ({} / {} non-zero bytes); "
+            "the glue likely failed to marshal the render".format(
+                nonzero, _EXPECTED_BYTES
+            ),
+        )
+
+        self.assertEqual(
+            fields["HASH"],
+            _GOLDEN_HASH,
+            "pixel hash {} != golden {}. If this is a deliberate renderer "
+            "change, regenerate the golden; otherwise a glue or rendering "
+            "regression changed the output.".format(fields["HASH"], _GOLDEN_HASH),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/donner/svg/renderer/wasm/render_test.py
+++ b/donner/svg/renderer/wasm/render_test.py
@@ -21,6 +21,7 @@ test fails loudly rather than silently passing.
 """
 
 import os
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -74,6 +75,14 @@ class WasmRenderTest(unittest.TestCase):
         return located
 
     def _run_driver(self, glue_path, wasm_path):
+        env = os.environ.copy()
+        node_options = shlex.split(env.get("NODE_OPTIONS", ""))
+        node_options = [option for option in node_options if option != "--jitless"]
+        if node_options:
+            env["NODE_OPTIONS"] = shlex.join(node_options)
+        else:
+            env.pop("NODE_OPTIONS", None)
+
         result = subprocess.run(
             [
                 self.node,
@@ -84,6 +93,7 @@ class WasmRenderTest(unittest.TestCase):
                 str(_HEIGHT),
             ],
             capture_output=True,
+            env=env,
             text=True,
         )
         return result

--- a/donner/svg/renderer/wasm/render_test_driver.mjs
+++ b/donner/svg/renderer/wasm/render_test_driver.mjs
@@ -1,0 +1,110 @@
+// Headless render driver for the tiny_skia Donner SVG WebAssembly module.
+//
+// Loads the Emscripten ES6 glue exactly as a browser would (the same default
+// module factory), but supplies the .wasm bytes directly via `wasmBinary` so
+// the web-targeted module runs under Node without a browser or a node-specific
+// build. It then renders a nontrivial SVG through the public C API
+// (donner_init / donner_render_svg / donner_free_pixels / donner_get_last_error),
+// reads the RGBA pixels back out of the wasm heap via the exported HEAPU8 view,
+// and prints a stable FNV-1a hash plus a non-zero byte count.
+//
+// This exercises the full JS-glue marshaling path (cwrap, UTF8ToString string
+// passing, HEAPU8 memory access, the exported C functions), so a glue-level
+// regression -- for example closure minification renaming a runtime method --
+// makes it fail. The pixel hash itself comes from the wasm module and is
+// therefore invariant to glue changes; only a real renderer change moves it.
+//
+// Usage: node render_test_driver.mjs <glue.mjs> <module.wasm> <width> <height>
+// Output on success (stdout):
+//   HASH=<8 hex digits>
+//   NONZERO=<n>/<total>
+//   BYTES=<total>
+// Any failure prints a line beginning with "ERROR:" and exits non-zero.
+
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+function fail(message) {
+  console.error('ERROR: ' + message);
+  process.exit(2);
+}
+
+const [, , gluePath, wasmPath, widthArg, heightArg] = process.argv;
+if (!gluePath || !wasmPath) {
+  fail('usage: render_test_driver.mjs <glue.mjs> <module.wasm> [width] [height]');
+}
+const width = Number.parseInt(widthArg ?? '64', 10);
+const height = Number.parseInt(heightArg ?? '64', 10);
+
+const SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#89b4fa"/>
+      <stop offset="100%" stop-color="#f38ba8"/>
+    </linearGradient>
+  </defs>
+  <rect width="200" height="200" rx="24" fill="url(#g)"/>
+  <circle cx="100" cy="90" r="40" fill="#1e1e2e" opacity="0.85"/>
+  <path d="M70 130 Q100 170 130 130" stroke="#a6e3a1" stroke-width="4" fill="none" stroke-linecap="round"/>
+</svg>`;
+
+let wasmBinary;
+try {
+  wasmBinary = readFileSync(wasmPath);
+} catch (err) {
+  fail('could not read wasm file ' + wasmPath + ': ' + err.message);
+}
+
+let createModule;
+try {
+  createModule = (await import(pathToFileURL(gluePath).href)).default;
+} catch (err) {
+  fail('could not import glue module ' + gluePath + ': ' + err.message);
+}
+if (typeof createModule !== 'function') {
+  fail('glue module default export is not a factory function');
+}
+
+let Module;
+try {
+  Module = await createModule({ wasmBinary, print: () => {}, printErr: () => {} });
+} catch (err) {
+  fail('module instantiation failed: ' + err.message);
+}
+
+for (const name of ['cwrap', 'HEAPU8']) {
+  if (Module[name] === undefined) {
+    fail('runtime method/view "' + name + '" is missing from the module (glue regression?)');
+  }
+}
+
+const donnerInit = Module.cwrap('donner_init', null, []);
+const donnerRenderSvg = Module.cwrap('donner_render_svg', 'number', ['string', 'number', 'number']);
+const donnerFreePixels = Module.cwrap('donner_free_pixels', null, ['number']);
+const donnerGetError = Module.cwrap('donner_get_last_error', 'string', []);
+
+donnerInit();
+
+const ptr = donnerRenderSvg(SVG, width, height);
+if (ptr === 0) {
+  fail('donner_render_svg returned null: ' + donnerGetError());
+}
+
+const total = width * height * 4;
+const pixels = Module.HEAPU8.subarray(ptr, ptr + total);
+if (pixels.length !== total) {
+  fail('pixel view has wrong length: ' + pixels.length + ' != ' + total);
+}
+
+let hash = 0x811c9dc5;
+let nonZero = 0;
+for (let i = 0; i < pixels.length; i++) {
+  if (pixels[i] !== 0) nonZero++;
+  hash ^= pixels[i];
+  hash = Math.imul(hash, 0x01000193) >>> 0;
+}
+donnerFreePixels(ptr);
+
+console.log('HASH=' + hash.toString(16).padStart(8, '0'));
+console.log('NONZERO=' + nonZero + '/' + total);
+console.log('BYTES=' + total);

--- a/tools/binary_size.sh
+++ b/tools/binary_size.sh
@@ -19,6 +19,11 @@ BAZEL_LOCAL_OPTIONS=(
   --remote_executor=
   --remote_cache=
   --noremote_upload_local_results
+  # Force every output to materialize locally. On macOS, bloaty attribution runs
+  # through dsymutil, which reads the per-.o debug map embedded in the unstripped
+  # binary; without this those object files can stay in the cache unmaterialized
+  # and attribution comes back empty.
+  --remote_download_all
 )
 BLOATY_BIN="$(command -v bloaty || true)"
 
@@ -28,6 +33,15 @@ if [[ "$(uname)" == "Darwin" ]]; then
   BAZEL_CONFIGS=(--config=macos-binary-size)
 elif [[ "$(uname)" == "Linux" ]]; then
   BAZEL_CONFIGS=(--config=linux-binary-size)
+fi
+# Same size-optimized build plus ThinLTO. ThinLTO shrinks the stripped binaries
+# further but drops the debug info bloaty needs, so it is measured separately
+# (headline shipped size only, no per-compile-unit attribution).
+LTO_CONFIGS=(--config=binary-size-lto)
+if [[ "$(uname)" == "Darwin" ]]; then
+  LTO_CONFIGS=(--config=macos-binary-size-lto)
+elif [[ "$(uname)" == "Linux" ]]; then
+  LTO_CONFIGS=(--config=linux-binary-size-lto)
 fi
 
 function run_bloaty() {
@@ -41,7 +55,7 @@ function run_bloaty() {
 
 # Build the binaries to analyze. Always measure the stripped outputs, and keep an
 # unstripped parser binary around separately so bloaty can attribute sizes using symbols.
-bazel build "${BAZEL_QUIET_OPTIONS[@]}" "${BAZEL_LOCAL_OPTIONS[@]}" "${BAZEL_CONFIGS[@]}" //donner/svg/parser:svg_parser_tool.stripped
+bazel build "${BAZEL_QUIET_OPTIONS[@]}" "${BAZEL_LOCAL_OPTIONS[@]}" "${BAZEL_CONFIGS[@]}" //donner/svg/parser:svg_parser_tool //donner/svg/parser:svg_parser_tool.stripped
 cp -f bazel-bin/donner/svg/parser/svg_parser_tool.stripped build-binary-size/svg_parser_tool
 
 bazel build "${BAZEL_QUIET_OPTIONS[@]}" "${BAZEL_LOCAL_OPTIONS[@]}" "${BAZEL_CONFIGS[@]}" //donner/svg/tool:donner-svg.stripped
@@ -99,6 +113,39 @@ run_bloaty -c tools/binary_size_config.bloaty -d donner_package,compileunits -n 
 
 echo '```'
 
+
+##
+## ThinLTO shipped-size build (native).
+##
+## ThinLTO folds and inlines across translation units for a smaller shipped
+## binary, but its debug info points at transient .thinlto.o files that dsymutil
+## and bloaty cannot open, so it is built separately from the attribution build
+## above and reported as headline sizes only. Set SKIP_LTO=1 to skip.
+##
+if [[ -z "$SKIP_LTO" ]]; then
+  echo ""
+  echo "### ThinLTO shipped native sizes (${LTO_CONFIGS[*]})"
+  echo ""
+
+  bazel build "${BAZEL_QUIET_OPTIONS[@]}" "${BAZEL_LOCAL_OPTIONS[@]}" "${LTO_CONFIGS[@]}" //donner/svg/parser:svg_parser_tool.stripped
+  cp -f bazel-bin/donner/svg/parser/svg_parser_tool.stripped build-binary-size/svg_parser_tool.lto
+  bazel build "${BAZEL_QUIET_OPTIONS[@]}" "${BAZEL_LOCAL_OPTIONS[@]}" "${LTO_CONFIGS[@]}" //donner/svg/tool:donner-svg.stripped
+  cp -f bazel-bin/donner/svg/tool/donner-svg.stripped build-binary-size/donner-svg.lto
+
+  parser_base=$(wc -c < build-binary-size/svg_parser_tool)
+  parser_lto=$(wc -c < build-binary-size/svg_parser_tool.lto)
+  donnersvg_base=$(wc -c < build-binary-size/donner-svg)
+  donnersvg_lto=$(wc -c < build-binary-size/donner-svg.lto)
+
+  parser_delta=$(awk "BEGIN{printf \"%.1f\", ($parser_lto-$parser_base)*100.0/$parser_base}")
+  donnersvg_delta=$(awk "BEGIN{printf \"%.1f\", ($donnersvg_lto-$donnersvg_base)*100.0/$donnersvg_base}")
+
+  echo '```'
+  printf '%-16s %14s %14s %10s\n' "target" "non-LTO" "ThinLTO" "delta"
+  printf '%-16s %14s %14s %9s%%\n' "svg_parser_tool" "$parser_base" "$parser_lto" "$parser_delta"
+  printf '%-16s %14s %14s %9s%%\n' "donner-svg" "$donnersvg_base" "$donnersvg_lto" "$donnersvg_delta"
+  echo '```'
+fi
 ##
 ## WebAssembly transfer size (Emscripten).
 ##


### PR DESCRIPTION
## Binary size, wave 2

Stacked on `size/wasm-oz` (wave-1: `-Oz` + emmalloc, PR #810) which is stacked
on `size/binary-size-pass` (tooling + baseline + design 0055, PR #808). This PR
takes the next measured levers: closure-minified JS glue gated behind a new
automated headless render test, and native ThinLTO. Every number below comes
from the checked-in `tools/binary_size.sh` on an internal build host (macOS arm64).

### What landed

1. **Headless render test (the JS-glue safety gate).**
   `//donner/svg/renderer/wasm:render_test` is a Node-driven bazel `py_test`
   that loads the built tiny_skia module as a browser would (same default ES6
   factory, `.wasm` supplied via `wasmBinary` so the opt module runs headless),
   renders a nontrivial SVG through the public C API, reads pixels back through
   `HEAPU8`, and asserts on a golden FNV-1a hash. The hash comes from the wasm,
   so it is invariant to glue changes; a glue regression breaks the render.
   Demonstrated red-then-green: dropping `cwrap` from the exports fails it,
   restoring it passes. Also exports `HEAPU8` from the tiny_skia bridge (the
   Geode bridge already did) so the module can actually return pixels to JS
   under the size config (additive fix, not an API break).

2. **R2: closure + `-sFILESYSTEM=0` on the glue**, gated by that test:

   | Artifact | R1 raw | R2 raw | R1 gzip | R2 gzip |
   | --- | --- | --- | --- | --- |
   | `.js` | 57,617 | 5,495 | 16,358 | 2,717 |

   Glue down 90.5% raw / 83.4% gzip; `.wasm` unchanged (glue-only). Gate passes
   against the minified module.

3. **R3: native ThinLTO** (`--config=binary-size-lto`):

   | Target | non-LTO | ThinLTO | delta |
   | --- | --- | --- | --- |
   | `svg_parser_tool` | 2,527,384 | 2,317,000 | -8.3% |
   | `donner-svg` | 4,182,688 | 3,829,632 | -8.4% |

   Kept OFF the attribution `--config=binary-size` (ThinLTO defeats the
   debug-map bloaty attribution); the tooling reports both. Also hardens the
   macOS attribution path in `binary_size.sh` (build the unstripped binary
   explicitly; `--remote_download_all` so `dsymutil` finds the per-`.o` debug
   map). Design 0055 updated with all deltas, a final-vs-baseline table, and the
   ranked remaining work.

### Final vs baseline (waves 1 + 2)

| Surface | Baseline | Shipped | Reduction |
| --- | --- | --- | --- |
| wasm total transfer (gzip) | 1,226,467 | 617,636 | 49.6% |
| `svg_parser_tool` (stripped) | 2,527,384 | 2,317,000 | 8.3% |
| `donner-svg` (stripped) | 4,182,688 | 3,829,632 | 8.4% |

### Not taken (surfaced, not applied)

- Symbol visibility: 272 bytes, not worth it.
- lld `--icf=all`: Linux-only; this macOS host cannot measure it (Apple ld
  rejects it and already deduplicates). Ranked pending a Linux measurement.
- Compile-unit audits of the heaviest units (AttributeParser, SVGParser, ...):
  the largest remaining native lever but an expensive refactor; ranked.
- Feature tiers `--config=tiny` / `--config=no-filters`: remove real
  functionality, operator decision. Not applied.

### Validation / CI note

Repo CI only runs main-targeting PRs, so validation is the fresh local runs
above with numbers, plus two green bazel gates on this branch:
`//donner/svg/renderer/wasm:render_test` (`--config=wasm-size`) and
`//tools:binary_size_tests`. This PR rebases after the wave-1 stack merges. The
native ThinLTO config could alternatively be split to a main-targeting PR for
real CI, but the tooling it extends (the wasm-augmented `binary_size.sh`,
`binary_size_tests.py`) and design 0055 live only on this stack, and a
bazelrc-only PR would not get the new config exercised by CI anyway, so it is
kept here for coherence.

No public API breaks or silent feature removals. `--config=wasm` (dev) stays
un-minified for fast iteration.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17

