### PR TITLE
Geode wave 2: persistent GPU residence for cached path geometry

### DIFF
--- a/docs/design_docs/0017-geode_renderer.md
+++ b/docs/design_docs/0017-geode_renderer.md
@@ -867,6 +867,24 @@ removed (or its version key is compared), triggering re-encoding on the next fra
 destroys its cache components. GPU buffer destruction is deferred to the next frame boundary to
 avoid destroying in-flight resources.
 
+**As-built (wave 1 + wave 2).** The path cache landed in two layers. Wave 1's
+`GeodePathCacheComponent` caches the CPU-side `EncodedPath` (bands / curves /
+grids / quad vertices) per entity, not raw GPU buffers, so re-rendering an
+unchanged document skips the encode. Wave 2 adds a sibling
+`GeodeResidentPathComponent` that gives that cached geometry persistent GPU
+residence: a fill slot and a stroke slot, each owning one combined
+`Vertex | Storage | Uniform` buffer plus a cached fill bind group. An
+unchanged frame then re-uploads zero geometry bytes and creates zero bind
+groups; only the per-draw uniform is rewritten, and only when it changed.
+Both components are removed together by the `ComputedPathComponent`
+on_update / on_destroy listener (the incremental-invalidation hook), so GPU
+residence invalidates exactly when the geometry does, and registry teardown
+frees the buffers (RAII, safe post-submit). `GeoEncoder::fillPathResident`
+drives residence for solid fills / strokes with no active clip, one draw per
+slot per frame; clipped, masked, gradient, pattern, and instanced draws keep
+the per-frame arena path. See design doc 0030 (wave 2 as-built appendix) for
+the measured profile.
+
 ### Embeddability Design
 
 Geode is designed to be embedded in host applications that own the GPU context:

--- a/docs/design_docs/0030-geode_performance.md
+++ b/docs/design_docs/0030-geode_performance.md
@@ -815,3 +815,82 @@ Counters `bufferWrites` / `bufferWriteBytes` / `textureWriteBytes` are
 the regression signal for items 1 and 5; `bufferCreates` for item 3
 (pooled, ceilings asserted); `bindgroupCreates` for item 2. Ceilings
 are asserted in `GeodePerf_tests.cc` and tighten as each fix lands.
+
+### Wave 2 as-built: persistent GPU residence (items 1 and 2 resolved)
+
+Wave 2 gives each cached `EncodedPath` a persistent per-entity GPU buffer
+that survives frames, plus a cached bind group, so an unchanged document
+re-uploads ~zero geometry and creates ~zero bind groups in steady state.
+This directly attacks items 1 and 2 above.
+
+Design as-built:
+
+- `GeodeResidentPathComponent` sits beside `GeodePathCacheComponent` on
+  the same entity, holding a fill slot and a stroke slot. Each
+  `GeodeResidentSlot` owns ONE combined `Vertex | Storage | Uniform |
+  CopyDst` buffer laid out as `[ vertex quad | bands | curves | vBands |
+  vCurves | hBandGrid | vBandGrid | uniform ]` (each sub-region aligned to
+  its binding requirement), plus a cached twelve-entry fill bind group
+  whose bindings all reference stable objects (this slot's buffer
+  sub-ranges and the device-owned dummy texture / sampler / identity
+  instance buffer).
+- `GeoEncoder::fillPathResident` uploads the geometry once (one
+  `createBuffer` + one `writeBuffer`), then on every later frame rewrites
+  only the 288-byte uniform, and only when it actually changed. A static
+  re-render at the same viewport produces byte-identical uniforms, so the
+  write is skipped entirely and the frame emits zero buffer writes. The
+  cached bind group is reused, so `bindgroupCreates` is zero.
+- Invalidation reuses the M2 `ComputedPathComponent` on_update / on_destroy
+  listener, which now removes the resident component in lock-step with the
+  encode cache. The `GeodeResidentSlot` destructor frees the buffer, so
+  registry teardown (closing a document) is the eviction path for "many
+  distinct documents"; a device-owned shared live-resident-bytes gauge
+  makes that measurable (`GpuResidence_*` tests).
+- Correctness fences: residence is taken only for solid fills / strokes
+  with no active clip mask, clip polygon, or open mask pass (otherwise the
+  wave-1 arena path runs, keeping clipped and masked draws bit-exact), and
+  only ONCE per slot per frame (a slot's single uniform buffer cannot hold
+  distinct per-instance uniforms, so markers and non-adjacent repeated
+  `<use>` route their repeat draws through the arena path). `populateFillUniform`
+  is shared by both paths so a draw that flips between them is byte-identical.
+  Gradients, patterns, and instanced `<use>` batches keep the arena path.
+
+Measured steady-state (frame 2, unchanged document), same environment as
+above, versus the wave-1 profile:
+
+| Fixture (frame 2) | draws | bindgroupCreates (was) | bufferWrites (was) | bufferWriteBytes (was) |
+|---|---|---|---|---|
+| SimpleShapes  | 3   | 0 (3)   | 0 (24)    | 0 (4,128)         |
+| Moderate      | 3   | 2 (3)   | 9 (17)    | 2,780 (5,372)     |
+| lion.svg      | 132 | 0 (132) | 0 (1,056) | 0 (172,776)       |
+| Ghostscript_Tiger | 304 | 0 (304) | 0 (2,432) | 0 (1,473,888) |
+
+Tiger, the headline fixture, drops from ~1.44 MB re-uploaded per steady
+frame across 2,432 `writeBuffer` calls and 304 bind-group creates to
+literally zero of each, while `drawCalls` stays 304 (the draws still
+happen, they just bind cached resident buffers). That is a >99% reduction,
+far past the 90% acceptance floor. Lion and SimpleShapes reach zero the
+same way. Moderate keeps a small residual: its rounded-rect gradient fill
+stays on the arena path (gradient residence is future work) and its
+`opacity="0.8"` isolated layer runs a composite blit whose per-frame
+uniform is written through `GeodeTextureEncoder`. Both residuals are the
+explained, non-geometry writes called out as items 2 (gradient) and 4
+(blit uniform) rather than re-uploaded path geometry.
+
+Trade-off: residence front-loads the persistent buffers on frame 1, so
+first-frame `bufferCreates` rises from the pooled 1 to one buffer per
+resident solid slot (measured Lion frame 1: 133 = 132 resident + readback).
+This is a one-time cost that buys the zero-write steady state; the
+`Lion_BaselineCeilings` ceiling was raised to match, and the
+`*_NoDirtyPath_*` frame-2 ceilings still hold (frame-2 `bufferCreates == 1`,
+the readback). Collapsing the per-slot buffers into a shared suballocated
+arena to cut the frame-1 buffer count is a ranked future opportunity.
+
+Remaining ranked opportunities after wave 2 (highest first): (1) gradient
+and pattern residence (Moderate's residual, and any gradient-heavy scene);
+(2) route the per-blit composite uniform through resident/pooled storage;
+(3) suballocate resident slots from a shared arena to cut frame-1
+`bufferCreates`; (4) wave-1 carryovers still open - snapshot readback
+`submits` 2 -> 1, band-curve duplication in the vertical SSBO,
+`<use>`-instancing widening, and removing the vestigial
+`useAlphaCoverageAA_` flag (sample count is always 1).

--- a/donner/svg/renderer/BUILD.bazel
+++ b/donner/svg/renderer/BUILD.bazel
@@ -367,6 +367,7 @@ donner_cc_library(
         # (see that target's comment).
         "//donner/svg/renderer/geode:geode_device",
         "//donner/svg/renderer/geode:geode_path_cache_component",
+        "//donner/svg/renderer/geode:geode_resident_path_component",
         "//donner/svg/renderer/geode:geode_path_encoder",
         "//donner/svg/renderer/geode:geode_wgpu_util",
         "//donner/svg/resources:image_resource",

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1628,7 +1628,7 @@ struct RendererGeode::Impl {
                      const geode::EncodedPath* precomputedEncoded,
                      geode::GeodeResidentSlot* residentSlot) {
     if (residentSlot != nullptr && precomputedEncoded != nullptr) {
-      encoder->fillPathResident(*residentSlot, *precomputedEncoded, color, rule);
+      encoder->fillPathResident(*residentSlot, *precomputedEncoded, color, rule, currentFrameIndex);
     } else {
       encoder->fillPath(drawPath, color, rule, precomputedEncoded);
     }

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -33,6 +33,7 @@
 #include "donner/svg/renderer/geode/GeodeFilterEngine.h"
 #include "donner/svg/renderer/geode/GeodeImagePipeline.h"
 #include "donner/svg/renderer/geode/GeodePathCacheComponent.h"
+#include "donner/svg/renderer/geode/GeodeResidentPathComponent.h"
 #include "donner/svg/renderer/geode/GeodePathEncoder.h"
 #include "donner/svg/renderer/geode/GeodePipeline.h"
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
@@ -1521,6 +1522,11 @@ struct RendererGeode::Impl {
     /// uploaded as per-instance transforms (see
     /// `flushPendingBatch` for the math).
     std::vector<Transform2d> deviceFromLocalTransforms;
+    /// Wave 2 GPU-residence slot for this source entity's fill (captured
+    /// when the batch starts). Used only by the size-1 flush path - a
+    /// size >= 2 flush routes through the instanced arena path, which has
+    /// no per-entity residence.
+    geode::GeodeResidentSlot* residentFillSlot = nullptr;
   };
   std::optional<PendingBatch> pendingBatch;
 
@@ -1591,6 +1597,43 @@ struct RendererGeode::Impl {
     return &*cache.fillEncode;
   }
 
+  /// GPU-residence slot for `source`'s fill encode (design doc 0030 wave
+  /// 2). Returns null for a null source (editor/overlay draws stay on the
+  /// arena path). The slot lives on a `GeodeResidentPathComponent` beside
+  /// the M2 encode cache and is invalidated by the same listener.
+  geode::GeodeResidentSlot* residentFillSlot(EntityHandle source) {
+    if (!source) {
+      return nullptr;
+    }
+    ensureCacheInvalidationWired(*source.registry());
+    return &source.get_or_emplace<geode::GeodeResidentPathComponent>().fillSlot;
+  }
+
+  /// GPU-residence slot for `source`'s stroke encode. See `residentFillSlot`.
+  geode::GeodeResidentSlot* residentStrokeSlot(EntityHandle source) {
+    if (!source) {
+      return nullptr;
+    }
+    ensureCacheInvalidationWired(*source.registry());
+    return &source.get_or_emplace<geode::GeodeResidentPathComponent>().strokeSlot;
+  }
+
+  /// Emit a solid fill, preferring the persistent-residence path when a
+  /// resident slot and a cached encode are both available. Falls back to
+  /// the wave-1 arena `fillPath` otherwise (null source, no cached encode,
+  /// or gradient/pattern fallbacks). `GeoEncoder::fillPathResident` itself
+  /// falls back to the arena path when a clip / mask is active, so this is
+  /// always correct.
+  void emitSolidFill(const Path& drawPath, const css::RGBA& color, FillRule rule,
+                     const geode::EncodedPath* precomputedEncoded,
+                     geode::GeodeResidentSlot* residentSlot) {
+    if (residentSlot != nullptr && precomputedEncoded != nullptr) {
+      encoder->fillPathResident(*residentSlot, *precomputedEncoded, color, rule);
+    } else {
+      encoder->fillPath(drawPath, color, rule, precomputedEncoded);
+    }
+  }
+
   /// Pack a 2D affine into the 8-float wire format the shader expects
   /// (two `vec4f` rows, `(a, c, e, 0)` / `(b, d, f, 0)` - see
   /// `struct InstanceTransform` in `shaders/slug_fill.wgsl`).
@@ -1633,10 +1676,13 @@ struct RendererGeode::Impl {
 
     if (batch.deviceFromLocalTransforms.size() == 1) {
       // Single draw - restore the captured transform + use the
-      // non-instanced path.
+      // non-instanced path. Wave 2: prefer the persistent-residence path
+      // so an unbatched solid fill re-uploads zero geometry on an
+      // unchanged frame (the common Lion / Tiger case: distinct source
+      // entities never batch, so almost every solid fill flushes here).
       deviceFromLocalTransform = batch.deviceFromLocalTransforms.front();
       syncTransform();
-      encoder->fillPath(*batch.path, batch.color, batch.rule, batch.encoded);
+      emitSolidFill(*batch.path, batch.color, batch.rule, batch.encoded, batch.residentFillSlot);
     } else {
       // Instanced: set encoder transform to identity so the shader's
       // `uniforms.mvp` carries only the orthographic screen-pixel mapping.
@@ -1672,7 +1718,8 @@ struct RendererGeode::Impl {
   /// "batch-compatible" (solid paint, no stroke, has source entity,
   /// has cached fill encode, no in-flight pattern).
   bool tryAppendOrStartBatch(Entity sourceEntity, const Path& path, const css::RGBA& color,
-                             FillRule rule, const geode::EncodedPath* encoded) {
+                             FillRule rule, const geode::EncodedPath* encoded,
+                             geode::GeodeResidentSlot* residentFillSlot) {
     const bool matches = pendingBatch.has_value() && pendingBatch->sourceEntity == sourceEntity &&
                          pendingBatch->color == color && pendingBatch->rule == rule;
     if (matches) {
@@ -1687,6 +1734,7 @@ struct RendererGeode::Impl {
     pendingBatch->rule = rule;
     pendingBatch->encoded = encoded;
     pendingBatch->path = &path;
+    pendingBatch->residentFillSlot = residentFillSlot;
     pendingBatch->deviceFromLocalTransforms.push_back(deviceFromLocalTransform);
     return true;
   }
@@ -1738,6 +1786,15 @@ struct RendererGeode::Impl {
             .strokedEncode = std::move(encoded),
             .strokeFillRule = fillRule,
         };
+        // The stroke encode was rebuilt in place (stroke-param change)
+        // without removing the entity's components, so the entt listener
+        // does not fire. Drop the stale GPU residence explicitly so the
+        // next draw re-uploads the new stroked geometry (design doc 0030
+        // wave 2). The `GeoEncoder` fingerprint guard is a second line of
+        // defense; this keeps the invariant obvious at the mutation site.
+        if (auto* resident = source.try_get<geode::GeodeResidentPathComponent>()) {
+          resident->strokeSlot.reset();
+        }
       }
       result.strokedPath = &cache.strokeSlot->strokedPath;
       result.encoded = &cache.strokeSlot->strokedEncode;
@@ -1764,7 +1821,8 @@ struct RendererGeode::Impl {
   /// `GeodePathEncoder::encode` + `countPathEncode()` pair; otherwise
   /// `GeoEncoder` runs the inline encode path.
   void fillResolved(const Path& path, FillRule rule,
-                    const geode::EncodedPath* precomputedEncoded = nullptr) {
+                    const geode::EncodedPath* precomputedEncoded = nullptr,
+                    geode::GeodeResidentSlot* residentSlot = nullptr) {
     if (!encoder) {
       return;
     }
@@ -1783,15 +1841,17 @@ struct RendererGeode::Impl {
       return;
     }
     const double effectiveOpacity = paint.fillOpacity;
-    drawPaintedPath(path, paint.fill, effectiveOpacity, rule, precomputedEncoded);
+    drawPaintedPath(path, paint.fill, effectiveOpacity, rule, precomputedEncoded, residentSlot);
   }
 
   /// Core dispatch: given a path and a resolved paint server, emit the
   /// appropriate fill call (solid color or gradient).
   void drawPaintedPath(const Path& path, const components::ResolvedPaintServer& server,
                        double effectiveOpacity, FillRule rule,
-                       const geode::EncodedPath* precomputedEncoded = nullptr) {
-    drawPaintedPathAgainst(path, path, server, effectiveOpacity, rule, precomputedEncoded);
+                       const geode::EncodedPath* precomputedEncoded = nullptr,
+                       geode::GeodeResidentSlot* residentSlot = nullptr) {
+    drawPaintedPathAgainst(path, path, server, effectiveOpacity, rule, precomputedEncoded,
+                           residentSlot);
   }
 
   /// Same as `drawPaintedPath`, but the gradient's objectBoundingBox is
@@ -1803,7 +1863,8 @@ struct RendererGeode::Impl {
   void drawPaintedPathAgainst(const Path& geometryPath, const Path& drawPath,
                               const components::ResolvedPaintServer& server,
                               double effectiveOpacity, FillRule rule,
-                              const geode::EncodedPath* precomputedEncoded = nullptr) {
+                              const geode::EncodedPath* precomputedEncoded = nullptr,
+                              geode::GeodeResidentSlot* residentSlot = nullptr) {
     if (!encoder || drawPath.empty()) {
       return;
     }
@@ -1817,8 +1878,8 @@ struct RendererGeode::Impl {
     // Solid color: straight through the flat fill pipeline.
     if (const auto* solid = std::get_if<PaintServer::Solid>(&server)) {
       syncTransform();
-      encoder->fillPath(drawPath, solid->color.resolve(currentColor, opacity), rule,
-                        precomputedEncoded);
+      emitSolidFill(drawPath, solid->color.resolve(currentColor, opacity), rule, precomputedEncoded,
+                    residentSlot);
       return;
     }
 
@@ -1858,7 +1919,7 @@ struct RendererGeode::Impl {
           // SVG2 degenerate radial (r=0): paint the last stop color as a
           // solid fill so the element remains visible.
           syncTransform();
-          encoder->fillPath(drawPath, *radial->solidFallback, rule, precomputedEncoded);
+          emitSolidFill(drawPath, *radial->solidFallback, rule, precomputedEncoded, residentSlot);
           return;
         }
         // Recognized as radial but otherwise unusable (empty stops, focal
@@ -1877,8 +1938,8 @@ struct RendererGeode::Impl {
       // solid fallback color if one was declared, otherwise drop the draw.
       if (ref->fallback.has_value()) {
         syncTransform();
-        encoder->fillPath(drawPath, ref->fallback->resolve(currentColor, opacity), rule,
-                          precomputedEncoded);
+        emitSolidFill(drawPath, ref->fallback->resolve(currentColor, opacity), rule,
+                      precomputedEncoded, residentSlot);
         return;
       }
 
@@ -2043,6 +2104,13 @@ void RendererGeode::Impl::onComputedPathChanged(Registry& registry, Entity entit
   // entt allows `remove` on a component the entity doesn't hold - it's a
   // cheap no-op in that case. We don't need an `all_of` guard.
   registry.remove<geode::GeodePathCacheComponent>(entity);
+  // Wave 2: drop the GPU residence in lock-step with the CPU encode cache.
+  // Removing the component runs `GeodeResidentSlot::reset()`, which frees
+  // the persistent buffer and settles the live-bytes gauge. This fires on
+  // geometry change (on_update) and entity/registry teardown (on_destroy),
+  // both after the previous frame's submit, so destroying the buffer is
+  // safe (wgpu-native keeps submitted resources alive until GPU-complete).
+  registry.remove<geode::GeodeResidentPathComponent>(entity);
 }
 
 RendererGeode::RendererGeode(bool verbose) : impl_(std::make_unique<Impl>()) {
@@ -3685,12 +3753,23 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
                          std::holds_alternative<PaintServer::Solid>(impl_->paint.fill) &&
                          !impl_->patternFillPaint.has_value() && impl_->encoder != nullptr &&
                          impl_->paint.drawFillComponent;
+
+  // Wave 2 GPU residence: a persistent per-entity fill slot, eligible for
+  // any solid fill with a cached encode. Shared by the batch size-1 flush
+  // and the direct `fillResolved` path so almost every solid fill (which
+  // never batches across distinct source entities) re-uploads zero
+  // geometry on an unchanged frame.
+  geode::GeodeResidentSlot* residentFill =
+      (fillEncoded != nullptr && std::holds_alternative<PaintServer::Solid>(impl_->paint.fill))
+          ? impl_->residentFillSlot(path.sourceEntity)
+          : nullptr;
+
   if (batchable) {
     const auto& solid = std::get<PaintServer::Solid>(impl_->paint.fill);
     const css::RGBA color = solid.color.resolve(impl_->paint.currentColor.rgba(),
                                                 static_cast<float>(impl_->paint.fillOpacity));
     impl_->tryAppendOrStartBatch(path.sourceEntity.entity(), path.path, color, path.fillRule,
-                                 fillEncoded);
+                                 fillEncoded, residentFill);
     return;
   }
 
@@ -3701,7 +3780,7 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   // the fill on stroke-only passes so Geode reorders rather than double-paints.
   // Both default to true, so this is a no-op for ordinary fill-then-stroke draws.
   if (impl_->paint.drawFillComponent) {
-    impl_->fillResolved(path.path, path.fillRule, fillEncoded);
+    impl_->fillResolved(path.path, path.fillRule, fillEncoded, residentFill);
     if (impl_->debugGeometryOverlay &&
         !std::holds_alternative<PaintServer::None>(impl_->paint.fill)) {
       if (fillEncoded != nullptr) {
@@ -3784,8 +3863,14 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   // `strokedOutline.bounds()` here).
   const double effectiveOpacity = impl_->paint.strokeOpacity;
   auto strokeServer = impl_->paint.stroke;
+  // Wave 2 GPU residence for solid strokes (the stroked outline is a solid
+  // fill of the cached stroke encode).
+  geode::GeodeResidentSlot* residentStroke =
+      (strokeDerived.encoded != nullptr && std::holds_alternative<PaintServer::Solid>(strokeServer))
+          ? impl_->residentStrokeSlot(path.sourceEntity)
+          : nullptr;
   impl_->drawPaintedPathAgainst(path.path, strokedOutline, strokeServer, effectiveOpacity,
-                                strokeDerived.fillRule, strokeDerived.encoded);
+                                strokeDerived.fillRule, strokeDerived.encoded, residentStroke);
   if (impl_->debugGeometryOverlay) {
     impl_->drawStrokeOverlay(strokedOutline, strokeDerived);
   }

--- a/donner/svg/renderer/geode/BUILD.bazel
+++ b/donner/svg/renderer/geode/BUILD.bazel
@@ -69,6 +69,19 @@ donner_cc_library(
     visibility = ["//donner/svg/renderer:__subpackages__"],
 )
 
+# Header-only ECS component for wave-2 GPU residence: persistent per-entity
+# GPU buffers for cached encoded paths. See design doc 0030 (wave 2).
+donner_cc_library(
+    name = "geode_resident_path_component",
+    hdrs = ["GeodeResidentPathComponent.h"],
+    target_compatible_with = _GEODE_ONLY,
+    visibility = ["//donner/svg/renderer:__subpackages__"],
+    deps = [
+        ":geode_wgpu_util",
+        "//third_party/webgpu-cpp:webgpu_cpp",
+    ],
+)
+
 donner_cc_test(
     name = "geode_path_encoder_tests",
     srcs = ["tests/GeodePathEncoder_tests.cc"],
@@ -511,6 +524,7 @@ donner_cc_library(
     deps = [
         ":geode_device",
         ":geode_path_encoder",
+        ":geode_resident_path_component",
         ":geode_texture_encoder",
         "//donner/base",
         "//donner/css",

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -9,6 +9,7 @@
 #include "donner/svg/renderer/geode/GeodeImagePipeline.h"
 #include "donner/svg/renderer/geode/GeodePathEncoder.h"
 #include "donner/svg/renderer/geode/GeodePipeline.h"
+#include "donner/svg/renderer/geode/GeodeResidentPathComponent.h"
 #include "donner/svg/renderer/geode/GeodeTextureEncoder.h"
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 #include "donner/svg/resources/ImageResource.h"
@@ -21,6 +22,11 @@ namespace {
 /// multiples of 4 for COPY_SRC/COPY_DST operations).
 constexpr uint64_t roundUp4(uint64_t size) {
   return (size + 3u) & ~uint64_t{3u};
+}
+
+/// Round `value` up to a multiple of `alignment` (a power of two).
+constexpr uint64_t alignUp(uint64_t value, uint64_t alignment) {
+  return (value + alignment - 1u) & ~(alignment - 1u);
 }
 
 // WebGPU binding offset alignment requirements for the per-draw arenas
@@ -362,6 +368,46 @@ struct GeoEncoder::Impl {
       return allocInArena(arena, &kZero, sizeof(kZero), kStorageOffsetAlignment);
     }
     return allocInArena(arena, data, roundUp4(byteCount), kStorageOffsetAlignment);
+  }
+
+  // ---- GPU residence (design doc 0030 wave 2) ------------------------
+  // Defined out-of-line below `FillDrawArgs` (they reference it). See the
+  // `GeodeResidentSlot` header and `submitResidentFillDraw` for the flow.
+
+  /// Populate a solid-fill `Uniforms` block from `args` + `encoded`. The
+  /// single source of truth shared by the arena `submitFillDraw` and the
+  /// resident `submitResidentFillDraw`, so a path that flips between the
+  /// two paths (clip toggling) produces byte-identical uniforms.
+  void populateFillUniform(Uniforms& u, const EncodedPath& encoded, const FillDrawArgs& args);
+
+  /// (Re)upload `encoded` into `slot`'s persistent combined buffer and
+  /// reset its cached bind group. Bumps `bufferCreates` + one
+  /// `bufferWrite` (geometry only; the uniform is written separately).
+  void uploadResidentGeometry(GeodeResidentSlot& slot, const EncodedPath& encoded);
+
+  /// Build + cache the twelve-entry fill bind group for `slot` (all
+  /// bindings reference `slot.buffer` sub-ranges + device dummies).
+  void buildResidentBindGroup(GeodeResidentSlot& slot);
+
+  /// Resident solid-fill draw: ensure geometry residence, rewrite the
+  /// uniform only if it changed, reuse the cached bind group, and record
+  /// the draw. Steady-state (unchanged) frame: zero writes, zero bind
+  /// group creates.
+  void submitResidentFillDraw(GeodeResidentSlot& slot, const EncodedPath& encoded,
+                              const FillDrawArgs& args);
+
+  /// Cheap size fingerprint of an encode, used alongside the
+  /// `EncodedPath*` address to defend a resident slot against a missed
+  /// invalidation (e.g. the in-place stroke-slot rebuild).
+  static uint64_t residentFingerprint(const EncodedPath& e) {
+    uint64_t h = e.quadVertices.size();
+    h = h * 1000003u + e.bands.size();
+    h = h * 1000003u + e.curves.size();
+    h = h * 1000003u + e.vBands.size();
+    h = h * 1000003u + e.vCurves.size();
+    h = h * 1000003u + e.hBandGrid.size();
+    h = h * 1000003u + e.vBandGrid.size();
+    return h;
   }
 
   /// Upload the analytic dual-ray buffers + grid params for a gradient draw,
@@ -1236,6 +1282,232 @@ void GeoEncoder::fillPath(const Path& path, const css::RGBA& color, FillRule rul
   submitFillDraw(args);
 }
 
+// ============================================================================
+// GPU residence (design doc 0030 wave 2)
+// ============================================================================
+
+void GeoEncoder::Impl::populateFillUniform(Uniforms& u, const EncodedPath& encoded,
+                                           const FillDrawArgs& args) {
+  buildMvp(u.mvp);
+  affineToMat4(args.patternFromPath, u.patternFromPath);
+  u.viewport[0] = static_cast<float>(targetWidth);
+  u.viewport[1] = static_cast<float>(targetHeight);
+  u.tileSize[0] = static_cast<float>(args.tileSize.x);
+  u.tileSize[1] = static_cast<float>(args.tileSize.y);
+  u.color[0] = args.solidColor[0];
+  u.color[1] = args.solidColor[1];
+  u.color[2] = args.solidColor[2];
+  u.color[3] = args.solidColor[3];
+  u.fillRule = (args.rule == FillRule::EvenOdd) ? 1u : 0u;
+  u.paintMode = args.paintMode;
+  u.patternOpacity = args.patternOpacity;
+  writeClipPolygonUniforms(u.hasClipPolygon, u.clipPolygonPlanes);
+  u.hasClipMask = activeClipMaskView ? 1u : 0u;
+  u.gridYBase = encoded.yBase;
+  u.gridHStride = encoded.hStride;
+  u.gridHBandCount = encoded.hBandCount;
+  u.gridXBase = encoded.xBase;
+  u.gridVStride = encoded.vStride;
+  u.gridVBandCount = encoded.vBandCount;
+}
+
+void GeoEncoder::Impl::uploadResidentGeometry(GeodeResidentSlot& slot, const EncodedPath& encoded) {
+  // Drop any previous residence (first upload, or a re-upload after the
+  // stroke slot rebuilt in place). Frees the old buffer and settles the
+  // live-bytes gauge before we account the new allocation.
+  slot.reset();
+
+  const uint64_t vBytes = encoded.quadVertices.size() * sizeof(EncodedPath::Vertex);
+  const uint64_t bandsBytes = encoded.bands.size() * sizeof(EncodedPath::Band);
+  const uint64_t curvesBytes = encoded.curves.size() * 6u * sizeof(float);
+  const uint64_t vBandsBytes = encoded.vBands.size() * sizeof(EncodedPath::Band);
+  const uint64_t vCurvesBytes = encoded.vCurves.size() * 6u * sizeof(float);
+  const uint64_t hGridBytes = encoded.hBandGrid.size() * sizeof(uint32_t);
+  const uint64_t vGridBytes = encoded.vBandGrid.size() * sizeof(uint32_t);
+
+  // Lay out the combined buffer. Each storage region's offset satisfies
+  // `kStorageOffsetAlignment`; the vertex region needs 4-byte alignment;
+  // the uniform region needs `kUniformOffsetAlignment`. Empty storage
+  // regions reserve a 4-byte zero-filled dummy slot (the shader's
+  // band-count gate never dereferences them), mirroring the arena
+  // `allocStorageOrDummy` dummy.
+  uint64_t cursor = 0;
+  auto place = [&](GeodeResidentSlot::Region& r, uint64_t bytes, uint64_t alignment,
+                   bool storageDummy) {
+    cursor = alignUp(cursor, alignment);
+    r.offset = cursor;
+    r.size = (storageDummy && bytes == 0) ? uint64_t{4} : roundUp4(bytes);
+    cursor += r.size;
+  };
+  place(slot.vertex, vBytes, kVertexOffsetAlignment, /*storageDummy=*/false);
+  place(slot.bands, bandsBytes, kStorageOffsetAlignment, /*storageDummy=*/true);
+  place(slot.curves, curvesBytes, kStorageOffsetAlignment, /*storageDummy=*/true);
+  place(slot.vBands, vBandsBytes, kStorageOffsetAlignment, /*storageDummy=*/true);
+  place(slot.vCurves, vCurvesBytes, kStorageOffsetAlignment, /*storageDummy=*/true);
+  place(slot.hGrid, hGridBytes, kStorageOffsetAlignment, /*storageDummy=*/true);
+  place(slot.vGrid, vGridBytes, kStorageOffsetAlignment, /*storageDummy=*/true);
+  place(slot.uniform, sizeof(Uniforms), kUniformOffsetAlignment, /*storageDummy=*/false);
+
+  const uint64_t totalSize = cursor;
+  const uint64_t geometrySize = slot.uniform.offset;  // everything before the uniform.
+
+  wgpu::BufferDescriptor desc = {};
+  desc.label = wgpuLabel("GeodeResidentPath");
+  desc.size = totalSize;
+  desc.usage = wgpu::BufferUsage::Vertex | wgpu::BufferUsage::Storage |
+               wgpu::BufferUsage::Uniform | wgpu::BufferUsage::CopyDst;
+  slot.buffer.reset(device->device().createBuffer(desc));
+  device->countBuffer();
+
+  // Assemble the geometry portion in one zero-filled staging blob so
+  // padding + dummy regions read as zero, then upload it in a single
+  // `writeBuffer`. The uniform region is written separately by the draw
+  // path (so a camera/color-only change rewrites just 288 bytes).
+  std::vector<uint8_t> staging(geometrySize, 0u);
+  auto blit = [&](const GeodeResidentSlot::Region& r, const void* data, uint64_t bytes) {
+    if (bytes > 0) {
+      std::memcpy(staging.data() + r.offset, data, bytes);
+    }
+  };
+  blit(slot.vertex, encoded.quadVertices.data(), vBytes);
+  blit(slot.bands, encoded.bands.data(), bandsBytes);
+  blit(slot.curves, encoded.curves.data(), curvesBytes);
+  blit(slot.vBands, encoded.vBands.data(), vBandsBytes);
+  blit(slot.vCurves, encoded.vCurves.data(), vCurvesBytes);
+  blit(slot.hGrid, encoded.hBandGrid.data(), hGridBytes);
+  blit(slot.vGrid, encoded.vBandGrid.data(), vGridBytes);
+
+  device->queue().writeBuffer(slot.buffer.get(), 0, staging.data(), geometrySize);
+  device->countBufferWrite(geometrySize);
+
+  slot.vertexCount = static_cast<uint32_t>(encoded.quadVertices.size());
+  slot.resident = true;
+  slot.lastUniform.clear();  // Force the first uniform write below.
+
+  slot.liveBytesGauge = device->residentBytesGauge();
+  slot.accountedBytes = static_cast<int64_t>(totalSize);
+  slot.liveBytesGauge->fetch_add(slot.accountedBytes, std::memory_order_relaxed);
+}
+
+void GeoEncoder::Impl::buildResidentBindGroup(GeodeResidentSlot& slot) {
+  const wgpu::Device& dev = device->device();
+  const wgpu::Buffer& buf = slot.buffer.get();
+
+  wgpu::BindGroupEntry entries[12] = {};
+  auto bufEntry = [&](int i, uint32_t binding, const GeodeResidentSlot::Region& r) {
+    entries[i].binding = binding;
+    entries[i].buffer = buf;
+    entries[i].offset = r.offset;
+    entries[i].size = r.size;
+  };
+  bufEntry(0, 0, slot.uniform);
+  bufEntry(1, 1, slot.bands);
+  bufEntry(2, 2, slot.curves);
+  entries[3].binding = 3;
+  entries[3].textureView = device->dummyPatternTextureView();
+  entries[4].binding = 4;
+  entries[4].sampler = device->dummyPatternSampler();
+  // Residence is only taken with no active clip, so the clip-mask slot is
+  // always the device's identity-coverage dummy - bind it directly so the
+  // cached bind group is deterministic.
+  entries[5].binding = 5;
+  entries[5].textureView = device->dummyClipMaskTextureView();
+  entries[6].binding = 6;
+  entries[6].sampler = device->dummyClipMaskSampler();
+  entries[7].binding = 7;
+  entries[7].buffer = device->identityInstanceTransformBuffer();
+  entries[7].offset = 0;
+  entries[7].size = 32u;
+  bufEntry(8, 8, slot.vBands);
+  bufEntry(9, 9, slot.vCurves);
+  bufEntry(10, 10, slot.hGrid);
+  bufEntry(11, 11, slot.vGrid);
+
+  wgpu::BindGroupDescriptor bgDesc = {};
+  bgDesc.label = wgpuLabel("GeodeResidentBindGroup");
+  bgDesc.layout = pipeline->bindGroupLayout();
+  bgDesc.entryCount = 12;
+  bgDesc.entries = entries;
+  slot.bindGroup.reset(dev.createBindGroup(bgDesc));
+  device->countBindGroup();
+}
+
+void GeoEncoder::Impl::submitResidentFillDraw(GeodeResidentSlot& slot, const EncodedPath& encoded,
+                                              const FillDrawArgs& args) {
+  ensurePassOpen();
+  bindSolidPipeline();
+
+  // Ensure the geometry is resident and current. Component removal is the
+  // primary invalidation; the pointer + fingerprint guard catches the
+  // in-place stroke-slot rebuild (which replaces the encode contents
+  // without removing the component).
+  const uint64_t fingerprint = residentFingerprint(encoded);
+  const bool needUpload = !slot.resident || !slot.buffer || slot.encodedKey != &encoded ||
+                          slot.encodedFingerprint != fingerprint;
+  if (needUpload) {
+    uploadResidentGeometry(slot, encoded);
+    slot.encodedKey = &encoded;
+    slot.encodedFingerprint = fingerprint;
+  }
+
+  // Rewrite the uniform only when it actually changed. A static
+  // re-render (same viewport, same paint) produces byte-identical
+  // uniforms, so this write is skipped entirely and the frame emits zero
+  // buffer writes.
+  Uniforms u = {};
+  populateFillUniform(u, encoded, args);
+  const auto* uBytes = reinterpret_cast<const uint8_t*>(&u);
+  if (slot.lastUniform.size() != sizeof(Uniforms) ||
+      std::memcmp(slot.lastUniform.data(), uBytes, sizeof(Uniforms)) != 0) {
+    device->queue().writeBuffer(slot.buffer.get(), slot.uniform.offset, &u, sizeof(Uniforms));
+    device->countBufferWrite(sizeof(Uniforms));
+    slot.lastUniform.assign(uBytes, uBytes + sizeof(Uniforms));
+  }
+
+  if (!slot.bindGroup) {
+    buildResidentBindGroup(slot);
+  }
+
+  pass.get().setVertexBuffer(0, slot.buffer.get(), slot.vertex.offset, slot.vertex.size);
+  pass.get().setBindGroup(0, slot.bindGroup.get(), 0, nullptr);
+  pass.get().draw(slot.vertexCount, 1, 0, 0);
+  device->countDraw();
+}
+
+void GeoEncoder::fillPathResident(GeodeResidentSlot& slot, const EncodedPath& encoded,
+                                  const css::RGBA& color, FillRule rule) {
+  if (encoded.empty()) {
+    return;
+  }
+
+  // Build the same solid-fill args `fillPath` would, so both paths share
+  // `populateFillUniform` and the fallback stays bit-exact.
+  FillDrawArgs args = {};
+  args.path = nullptr;
+  args.rule = rule;
+  args.precomputedEncoded = &encoded;
+  args.paintMode = 0u;
+  const float alpha = color.a / 255.0f;
+  args.solidColor[0] = (color.r / 255.0f) * alpha;
+  args.solidColor[1] = (color.g / 255.0f) * alpha;
+  args.solidColor[2] = (color.b / 255.0f) * alpha;
+  args.solidColor[3] = alpha;
+  args.patternOpacity = 1.0f;
+  args.patternView = impl_->device->dummyPatternTextureView();
+  args.patternSampler = impl_->device->dummyPatternSampler();
+  args.tileSize = Vector2d(1.0, 1.0);
+  args.patternFromPath = Transform2d();
+
+  // Residence is only safe (bind group stable, uniform clip flags zero)
+  // when no clip mask / clip polygon / mask pass is active. Otherwise fall
+  // back to the wave-1 arena path so clipped / masked draws stay exact.
+  if (impl_->activeClipMaskView || impl_->clipPolygonActive || impl_->maskPassOpen) {
+    submitFillDraw(args);
+    return;
+  }
+  impl_->submitResidentFillDraw(slot, encoded, args);
+}
+
 void GeoEncoder::fillPathInstanced(const EncodedPath& encoded, const css::RGBA& color,
                                    FillRule rule, std::span<const float> instanceTransforms) {
   if (encoded.empty() || instanceTransforms.empty()) {
@@ -1368,29 +1640,10 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args) {
                                                      encoded.vBandGrid.size() * sizeof(uint32_t));
 
   // Uniform buffer - still per-draw today; Milestone 1.f lifts it into
-  // a ring buffer with dynamic offsets.
+  // a ring buffer with dynamic offsets. `populateFillUniform` is shared
+  // with the resident fill path so both produce byte-identical uniforms.
   Uniforms u = {};
-  impl_->buildMvp(u.mvp);
-  affineToMat4(args.patternFromPath, u.patternFromPath);
-  u.viewport[0] = static_cast<float>(impl_->targetWidth);
-  u.viewport[1] = static_cast<float>(impl_->targetHeight);
-  u.tileSize[0] = static_cast<float>(args.tileSize.x);
-  u.tileSize[1] = static_cast<float>(args.tileSize.y);
-  u.color[0] = args.solidColor[0];
-  u.color[1] = args.solidColor[1];
-  u.color[2] = args.solidColor[2];
-  u.color[3] = args.solidColor[3];
-  u.fillRule = (args.rule == FillRule::EvenOdd) ? 1u : 0u;
-  u.paintMode = args.paintMode;
-  u.patternOpacity = args.patternOpacity;
-  impl_->writeClipPolygonUniforms(u.hasClipPolygon, u.clipPolygonPlanes);
-  u.hasClipMask = impl_->activeClipMaskView ? 1u : 0u;
-  u.gridYBase = encoded.yBase;
-  u.gridHStride = encoded.hStride;
-  u.gridHBandCount = encoded.hBandCount;
-  u.gridXBase = encoded.xBase;
-  u.gridVStride = encoded.vStride;
-  u.gridVBandCount = encoded.vBandCount;
+  impl_->populateFillUniform(u, encoded, args);
 
   const auto uniAlloc =
       impl_->allocInArena(impl_->uniformArena, &u, sizeof(Uniforms), kUniformOffsetAlignment);

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -1475,7 +1475,7 @@ void GeoEncoder::Impl::submitResidentFillDraw(GeodeResidentSlot& slot, const Enc
 }
 
 void GeoEncoder::fillPathResident(GeodeResidentSlot& slot, const EncodedPath& encoded,
-                                  const css::RGBA& color, FillRule rule) {
+                                  const css::RGBA& color, FillRule rule, uint64_t frameId) {
   if (encoded.empty()) {
     return;
   }
@@ -1505,6 +1505,16 @@ void GeoEncoder::fillPathResident(GeodeResidentSlot& slot, const EncodedPath& en
     submitFillDraw(args);
     return;
   }
+  // A slot's single uniform buffer can only carry one draw's uniform per
+  // frame. If this slot was already drawn resident this frame (markers,
+  // non-adjacent repeated `<use>` at distinct transforms), route the
+  // repeat through the arena path so it gets its own uniform + bind group
+  // instead of clobbering the first draw's transform.
+  if (slot.lastResidentFrame == frameId) {
+    submitFillDraw(args);
+    return;
+  }
+  slot.lastResidentFrame = frameId;
   impl_->submitResidentFillDraw(slot, encoded, args);
 }
 

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -1312,10 +1312,15 @@ void GeoEncoder::Impl::populateFillUniform(Uniforms& u, const EncodedPath& encod
 }
 
 void GeoEncoder::Impl::uploadResidentGeometry(GeodeResidentSlot& slot, const EncodedPath& encoded) {
-  // Drop any previous residence (first upload, or a re-upload after the
-  // stroke slot rebuilt in place). Frees the old buffer and settles the
-  // live-bytes gauge before we account the new allocation.
-  slot.reset();
+  // Drop any previous residence (first upload, a re-upload after the stroke
+  // slot rebuilt in place, or a re-upload because a DIFFERENT device now
+  // renders this document). Frees the old buffer and settles the live-bytes
+  // gauge before we account the new allocation. When the existing buffer
+  // belongs to a different device we release our ref WITHOUT calling
+  // `destroy()`: that device may already be gone, and destroy() would route
+  // into it (see `GeodeResidentSlot::owningDeviceId`).
+  const bool ownedByCurrentDevice = slot.owningDeviceId == device->deviceId();
+  slot.reset(/*destroyBuffer=*/ownedByCurrentDevice);
 
   const uint64_t vBytes = encoded.quadVertices.size() * sizeof(EncodedPath::Vertex);
   const uint64_t bandsBytes = encoded.bands.size() * sizeof(EncodedPath::Band);
@@ -1387,6 +1392,11 @@ void GeoEncoder::Impl::uploadResidentGeometry(GeodeResidentSlot& slot, const Enc
   slot.liveBytesGauge = device->residentBytesGauge();
   slot.accountedBytes = static_cast<int64_t>(totalSize);
   slot.liveBytesGauge->fetch_add(slot.accountedBytes, std::memory_order_relaxed);
+
+  // Stamp the current device's identity so a later render by a different
+  // device re-uploads instead of binding this device's buffer / bind group
+  // into the other device's render pass (WebGPU rejects that).
+  slot.owningDeviceId = device->deviceId();
 }
 
 void GeoEncoder::Impl::buildResidentBindGroup(GeodeResidentSlot& slot) {
@@ -1437,13 +1447,16 @@ void GeoEncoder::Impl::submitResidentFillDraw(GeodeResidentSlot& slot, const Enc
   ensurePassOpen();
   bindSolidPipeline();
 
-  // Ensure the geometry is resident and current. Component removal is the
-  // primary invalidation; the pointer + fingerprint guard catches the
-  // in-place stroke-slot rebuild (which replaces the encode contents
-  // without removing the component).
+  // Ensure the geometry is resident and current AND owned by THIS device.
+  // Component removal is the primary invalidation; the pointer + fingerprint
+  // guard catches the in-place stroke-slot rebuild (which replaces the encode
+  // contents without removing the component); the device-id guard catches a
+  // second device rendering a document whose residence was filled by a
+  // now-different device (WebGPU rejects cross-device buffers / bind groups).
   const uint64_t fingerprint = residentFingerprint(encoded);
   const bool needUpload = !slot.resident || !slot.buffer || slot.encodedKey != &encoded ||
-                          slot.encodedFingerprint != fingerprint;
+                          slot.encodedFingerprint != fingerprint ||
+                          slot.owningDeviceId != device->deviceId();
   if (needUpload) {
     uploadResidentGeometry(slot, encoded);
     slot.encodedKey = &encoded;
@@ -1509,8 +1522,13 @@ void GeoEncoder::fillPathResident(GeodeResidentSlot& slot, const EncodedPath& en
   // frame. If this slot was already drawn resident this frame (markers,
   // non-adjacent repeated `<use>` at distinct transforms), route the
   // repeat through the arena path so it gets its own uniform + bind group
-  // instead of clobbering the first draw's transform.
-  if (slot.lastResidentFrame == frameId) {
+  // instead of clobbering the first draw's transform. The frame counter is
+  // per-renderer, so this same-frame gate only applies when the slot is
+  // already resident ON THIS device; a matching frame index carried over
+  // from a DIFFERENT device that previously rendered this document is not a
+  // same-frame repeat and must re-upload (submitResidentFillDraw re-uploads
+  // on the device-id mismatch) rather than fall back.
+  if (slot.owningDeviceId == impl_->device->deviceId() && slot.lastResidentFrame == frameId) {
     submitFillDraw(args);
     return;
   }

--- a/donner/svg/renderer/geode/GeoEncoder.h
+++ b/donner/svg/renderer/geode/GeoEncoder.h
@@ -458,9 +458,13 @@ public:
    * @param color Solid fill color (NOT premultiplied - premultiplied here,
    *   identically to `fillPath`).
    * @param rule Fill rule.
+   * @param frameId Monotonic frame index. A slot serves at most one
+   *   resident draw per frame (its single uniform buffer cannot hold
+   *   distinct per-instance uniforms); repeat draws in the same frame fall
+   *   back to the arena path.
    */
   void fillPathResident(GeodeResidentSlot& slot, const EncodedPath& encoded,
-                        const css::RGBA& color, FillRule rule);
+                        const css::RGBA& color, FillRule rule, uint64_t frameId);
 
   /**
    * Fill N copies of the same encoded path at N different affine

--- a/donner/svg/renderer/geode/GeoEncoder.h
+++ b/donner/svg/renderer/geode/GeoEncoder.h
@@ -24,6 +24,7 @@ struct ImageResource;
 namespace donner::geode {
 
 struct EncodedPath;
+struct GeodeResidentSlot;
 
 class GeodeBufferPool;
 class GeodeDevice;
@@ -429,6 +430,37 @@ public:
   ///   counter bump.
   void fillPath(const Path& path, const css::RGBA& color, FillRule rule,
                 const EncodedPath* precomputedEncoded = nullptr);
+
+  /**
+   * Solid fill of a cached path with persistent GPU residence (design doc
+   * 0030 wave 2: GPU residence).
+   *
+   * `slot` is a per-entity `GeodeResidentSlot` (owned by
+   * `GeodeResidentPathComponent`, invalidated by the same
+   * `ComputedPathComponent` listener that clears the M2 encode cache). On
+   * first use the encoder uploads `encoded` into a persistent combined
+   * Vertex|Storage|Uniform buffer and builds a cached bind group; on every
+   * subsequent unchanged frame it re-uses both and writes zero geometry
+   * bytes. Only the 288-byte per-draw uniform is rewritten, and only when
+   * it actually changed (camera/color move), so a static document's
+   * steady-state frame writes ~zero bytes and creates zero bind groups.
+   *
+   * Residency is taken ONLY for the fast, cacheable case: no active clip
+   * mask, no clip polygon, no open mask pass. When any of those hold the
+   * call transparently falls back to the wave-1 arena path (a fresh
+   * per-draw bind group) so clipped / masked draws stay bit-exact.
+   *
+   * @param slot Persistent residence for this entity's fill or stroke
+   *   encode. Must outlive the frame's submit (it does: the ECS component
+   *   is only removed on geometry change, after the prior frame submitted).
+   * @param encoded Cached encode (stable across frames). Must be non-empty
+   *   for a draw to land.
+   * @param color Solid fill color (NOT premultiplied - premultiplied here,
+   *   identically to `fillPath`).
+   * @param rule Fill rule.
+   */
+  void fillPathResident(GeodeResidentSlot& slot, const EncodedPath& encoded,
+                        const css::RGBA& color, FillRule rule);
 
   /**
    * Fill N copies of the same encoded path at N different affine

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -198,7 +198,15 @@ struct GeodeDevice::Impl {
   std::unique_ptr<GeodeFilterEngine> filterEngine;
 };
 
-GeodeDevice::GeodeDevice() : impl_(std::make_unique<Impl>()) {}
+namespace {
+/// Monotonic source for `GeodeDevice::deviceId()`. Never reused, starts at 1
+/// (0 is the "no device" sentinel on a `GeodeResidentSlot`).
+std::atomic<uint64_t> g_nextDeviceId{0};
+}  // namespace
+
+GeodeDevice::GeodeDevice()
+    : impl_(std::make_unique<Impl>()),
+      deviceId_(g_nextDeviceId.fetch_add(1, std::memory_order_relaxed) + 1) {}
 GeodeDevice::~GeodeDevice() {
   // Release all resources that were created from the device before releasing the
   // root queue/device/adapter/instance handles. `webgpu.hpp` handles are raw

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -198,6 +198,22 @@ public:
   uint32_t sampleCount() const { return 1u; }
 
   /**
+   * Process-unique identity for this device instance, assigned at
+   * construction from a monotonic counter (never reused, starts at 1).
+   *
+   * Used by GPU-residence slots (design doc 0030 wave 2) to detect when a
+   * cached buffer / bind group belongs to a DIFFERENT device than the one
+   * now rendering: a document (and its ECS `GeodeResidentPathComponent`s)
+   * can outlive the device that filled them and later be rendered by a
+   * second `RendererGeode` / `GeodeDevice`. WebGPU rejects cross-device
+   * resources inside a render pass, so a slot whose stored id does not match
+   * `deviceId()` is treated as non-resident and re-uploaded. A monotonic
+   * counter (rather than a raw `this` pointer) avoids the ABA hazard of a
+   * freed device's address being recycled by a later allocation.
+   */
+  uint64_t deviceId() const { return deviceId_; }
+
+  /**
    * Install a `GeodeCounters` struct for this device. Non-owning; the
    * caller must keep the struct alive for as long as the device might
    * increment it. Pass `nullptr` to disable instrumentation.
@@ -398,6 +414,9 @@ private:
   /// True when this device was created via CreateFromExternal(). The destructor
   /// skips releasing the instance/adapter since the host owns them.
   bool external_ = false;
+
+  /// Process-unique identity assigned at construction. See `deviceId()`.
+  const uint64_t deviceId_ = 0;
 
   GeodeCounters* counters_ = nullptr;
 

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -2,6 +2,7 @@
 /// @file
 /// RAII wrapper around a WebGPU device - headless or host-provided.
 
+#include <atomic>
 #include <memory>
 #include <vector>
 #include <webgpu/webgpu.hpp>
@@ -260,6 +261,28 @@ public:
     if (counters_) counters_->textureWriteBytes += bytes;
   }
 
+  /// Shared live-resident-bytes gauge (design doc 0030 wave 2: GPU
+  /// residence). Co-owned with each `GeodeResidentSlot`'s buffer so
+  /// resident-memory accounting stays lifetime-safe even if a document
+  /// (and its ECS registry) outlives this device. Lazily created on first
+  /// access. `GeoEncoder` bumps it when a slot gains residence; the slot
+  /// decrements it on reset / destruction (geometry change or document
+  /// teardown), which is the eviction signal for "many distinct
+  /// documents".
+  const std::shared_ptr<std::atomic<int64_t>>& residentBytesGauge() const {
+    if (!residentBytesGauge_) {
+      residentBytesGauge_ = std::make_shared<std::atomic<int64_t>>(0);
+    }
+    return residentBytesGauge_;
+  }
+
+  /// Current live resident-geometry bytes across every `GeodeResidentSlot`
+  /// buffer created against this device. Zero at construction and after
+  /// all resident documents are torn down; used by eviction tests.
+  int64_t liveResidentBytesForTesting() const {
+    return residentBytesGauge_ ? residentBytesGauge_->load(std::memory_order_relaxed) : 0;
+  }
+
   /**
    * Whether the driver supports GPU timestamp queries. Always false
    * today - reserved for future work (design doc 0030, "Future Work").
@@ -384,6 +407,11 @@ private:
   // (the caller is reporting, not mutating visible state).
   mutable uint64_t lifetimeTextureCreates_ = 0;
   mutable uint64_t lifetimeBufferCreates_ = 0;
+
+  // Shared live-resident-bytes gauge (design doc 0030 wave 2). Mutable +
+  // lazily created so `residentBytesGauge()` stays const like the other
+  // reporting accessors.
+  mutable std::shared_ptr<std::atomic<int64_t>> residentBytesGauge_;
 
   // Deferred-destroy queues: resources enqueued via deferDestroy() are held
   // alive until drainDeferredDestroys() drops them at the next frame boundary.

--- a/donner/svg/renderer/geode/GeodeResidentPathComponent.h
+++ b/donner/svg/renderer/geode/GeodeResidentPathComponent.h
@@ -74,6 +74,17 @@ struct GeodeResidentSlot {
 
   uint32_t vertexCount = 0;  ///< Number of quad vertices (draw count).
 
+  /// Frame index in which this slot was last drawn via the resident path.
+  /// A slot's single uniform buffer + cached bind group can only serve ONE
+  /// draw per frame (all draws recorded against a frame's command buffer
+  /// read the buffer's final contents at submit time). When the same slot
+  /// is drawn again in the same frame at a different transform/color
+  /// (markers, non-adjacent repeated `<use>`), the second and later draws
+  /// fall back to the wave-1 arena path so each gets its own uniform. The
+  /// steady-state win is unaffected for the common case of a path drawn
+  /// once per frame (Tiger / Lion). Sentinel `~0` means "never drawn".
+  uint64_t lastResidentFrame = ~uint64_t{0};
+
   /// True once `buffer` + `bindGroup` hold the current encode. Cleared
   /// when the slot is reset or when a re-upload is required.
   bool resident = false;
@@ -118,6 +129,7 @@ struct GeodeResidentSlot {
       vGrid = other.vGrid;
       uniform = other.uniform;
       vertexCount = other.vertexCount;
+      lastResidentFrame = other.lastResidentFrame;
       resident = other.resident;
       encodedKey = other.encodedKey;
       encodedFingerprint = other.encodedFingerprint;

--- a/donner/svg/renderer/geode/GeodeResidentPathComponent.h
+++ b/donner/svg/renderer/geode/GeodeResidentPathComponent.h
@@ -1,0 +1,166 @@
+#pragma once
+/// @file
+/// Per-entity GPU residence for Geode's cached encoded-path geometry
+/// (design doc 0030 wave 2: "GPU residence").
+///
+/// The M2 `GeodePathCacheComponent` keeps the CPU-side `EncodedPath`
+/// across frames, but wave 1 still re-uploaded that geometry to a fresh
+/// per-frame bump arena on every draw - the measured headline cost was a
+/// static Ghostscript Tiger writing ~1.44 MB per frame across 2,432
+/// `writeBuffer` calls even though the CPU encode cache hit, plus one
+/// `createBindGroup` per draw (304/frame).
+///
+/// This component gives each cached path a persistent GPU buffer that
+/// survives frames, so an unchanged document's steady-state frame writes
+/// ~zero geometry bytes and re-uses a cached bind group. It lives BESIDE
+/// `GeodePathCacheComponent` on the same entity and is removed by the
+/// same `ComputedPathComponent` on_update / on_destroy listener
+/// (`RendererGeode::Impl::onComputedPathChanged`), so the GPU residence
+/// invalidates exactly when the geometry changes. Registry teardown
+/// (document close) destroys the component and RAII-frees the buffer -
+/// the eviction story for "many distinct documents".
+///
+/// Lives in `donner::geode` (not `donner::svg::geode`) to match the other
+/// Geode types referenced unqualified via `geode::` inside `donner::svg`.
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
+
+namespace donner::geode {
+
+/// GPU-resident geometry for one cached `EncodedPath` (a fill slot or a
+/// stroke slot). Owns a single combined-usage GPU buffer that holds the
+/// path's vertex quad, the six analytic dual-ray SSBO regions, and the
+/// per-draw uniform block, plus the cached fill bind group. The buffer
+/// and bind group are built once by `GeoEncoder` on first residence and
+/// reused every subsequent unchanged frame.
+///
+/// Move-only (owns wgpu handles). Default-constructed slots are empty;
+/// `GeoEncoder::fillPathResident` populates them lazily.
+struct GeodeResidentSlot {
+  /// Combined Vertex|Storage|Uniform|CopyDst buffer. Layout (each region
+  /// offset satisfies the binding's alignment requirement):
+  ///   [ vertex quad | bands | curves | vBands | vCurves | hGrid | vGrid | uniform ]
+  ScopedWgpuHandle<wgpu::Buffer> buffer;
+
+  /// Cached fill bind group. All twelve bindings reference stable
+  /// objects (this slot's `buffer` sub-ranges + device-owned dummy
+  /// texture/sampler/identity-instance handles), so it survives frames
+  /// and encoders. Rebuilt only when the geometry buffer is
+  /// re-allocated.
+  ScopedWgpuHandle<wgpu::BindGroup> bindGroup;
+
+  /// A byte sub-range of `buffer`. `size == 0` is never bound directly -
+  /// empty SSBO regions reserve a 4-byte zero-filled slot so the shader's
+  /// band-count gate keeps them un-dereferenced (matching the wave-1
+  /// arena `allocStorageOrDummy` dummy).
+  struct Region {
+    uint64_t offset = 0;
+    uint64_t size = 0;
+  };
+
+  Region vertex;   ///< Vertex quad range (4-byte aligned offset).
+  Region bands;    ///< Horizontal band SSBO (binding 1).
+  Region curves;   ///< Horizontal curve SSBO (binding 2).
+  Region vBands;   ///< Vertical band SSBO (binding 8).
+  Region vCurves;  ///< Vertical curve SSBO (binding 9).
+  Region hGrid;    ///< Horizontal band grid (binding 10).
+  Region vGrid;    ///< Vertical band grid (binding 11).
+  Region uniform;  ///< Per-draw uniform block (binding 0, 256-aligned).
+
+  uint32_t vertexCount = 0;  ///< Number of quad vertices (draw count).
+
+  /// True once `buffer` + `bindGroup` hold the current encode. Cleared
+  /// when the slot is reset or when a re-upload is required.
+  bool resident = false;
+
+  /// Identity guard defending against any missed invalidation: the
+  /// address of the `EncodedPath` last uploaded plus a cheap size
+  /// fingerprint. If either differs at draw time the geometry is
+  /// re-uploaded. Component removal is the primary invalidation; this is
+  /// belt-and-suspenders for the in-place stroke-slot rebuild path.
+  const void* encodedKey = nullptr;
+  uint64_t encodedFingerprint = 0;
+
+  /// Bytes last written to the uniform region. A draw whose recomputed
+  /// uniform matches this skips the `writeBuffer` entirely (steady-state
+  /// static frame => zero buffer writes); a camera/color change rewrites
+  /// only this 288-byte region and keeps the cached bind group.
+  std::vector<uint8_t> lastUniform;
+
+  /// Live-resident-bytes gauge, co-owned with `GeodeDevice` so the
+  /// accounting is lifetime-safe even if the owning document outlives the
+  /// device. Incremented on residence, decremented on reset/destroy.
+  std::shared_ptr<std::atomic<int64_t>> liveBytesGauge;
+  int64_t accountedBytes = 0;
+
+  GeodeResidentSlot() = default;
+  ~GeodeResidentSlot() { reset(); }
+
+  GeodeResidentSlot(const GeodeResidentSlot&) = delete;
+  GeodeResidentSlot& operator=(const GeodeResidentSlot&) = delete;
+  GeodeResidentSlot(GeodeResidentSlot&&) noexcept = default;
+  GeodeResidentSlot& operator=(GeodeResidentSlot&& other) noexcept {
+    if (this != &other) {
+      reset();
+      buffer = std::move(other.buffer);
+      bindGroup = std::move(other.bindGroup);
+      vertex = other.vertex;
+      bands = other.bands;
+      curves = other.curves;
+      vBands = other.vBands;
+      vCurves = other.vCurves;
+      hGrid = other.hGrid;
+      vGrid = other.vGrid;
+      uniform = other.uniform;
+      vertexCount = other.vertexCount;
+      resident = other.resident;
+      encodedKey = other.encodedKey;
+      encodedFingerprint = other.encodedFingerprint;
+      lastUniform = std::move(other.lastUniform);
+      liveBytesGauge = std::move(other.liveBytesGauge);
+      accountedBytes = other.accountedBytes;
+      other.accountedBytes = 0;
+      other.resident = false;
+      other.encodedKey = nullptr;
+    }
+    return *this;
+  }
+
+  /// Release the GPU buffer + bind group and settle the live-bytes gauge.
+  /// Safe to call on an empty slot. Called on geometry change (component
+  /// removal) and on document teardown; both happen after the frame that
+  /// used the buffer was submitted, so dropping the handle is safe
+  /// (wgpu-native ref-counts resources referenced by submitted command
+  /// buffers).
+  void reset() {
+    if (accountedBytes != 0 && liveBytesGauge) {
+      liveBytesGauge->fetch_sub(accountedBytes, std::memory_order_relaxed);
+    }
+    accountedBytes = 0;
+    bindGroup.reset();
+    if (buffer) {
+      buffer.get().destroy();
+      buffer.reset();
+    }
+    resident = false;
+    encodedKey = nullptr;
+    encodedFingerprint = 0;
+    lastUniform.clear();
+  }
+};
+
+/// Sibling of `GeodePathCacheComponent`: holds the GPU residence for an
+/// entity's fill and stroke encodes. Installed lazily by `RendererGeode`
+/// at the solid-fill draw sites; removed by the same entt listener that
+/// clears `GeodePathCacheComponent` when geometry changes.
+struct GeodeResidentPathComponent {
+  GeodeResidentSlot fillSlot;
+  GeodeResidentSlot strokeSlot;
+};
+
+}  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodeResidentPathComponent.h
+++ b/donner/svg/renderer/geode/GeodeResidentPathComponent.h
@@ -85,6 +85,17 @@ struct GeodeResidentSlot {
   /// once per frame (Tiger / Lion). Sentinel `~0` means "never drawn".
   uint64_t lastResidentFrame = ~uint64_t{0};
 
+  /// Process-unique id (see `GeodeDevice::deviceId()`) of the device that
+  /// created `buffer` / `bindGroup`. A document's ECS residence components
+  /// can outlive the device that filled them and later be rendered by a
+  /// second `RendererGeode` / `GeodeDevice`; WebGPU rejects a bind group or
+  /// buffer from device A inside device B's render pass. When this id does
+  /// not match the current device at draw time the slot is treated as
+  /// non-resident and re-uploaded onto the current device (the stale handles
+  /// are released without touching the old device). `0` means "no device
+  /// owns this slot yet".
+  uint64_t owningDeviceId = 0;
+
   /// True once `buffer` + `bindGroup` hold the current encode. Cleared
   /// when the slot is reset or when a re-upload is required.
   bool resident = false;
@@ -133,12 +144,14 @@ struct GeodeResidentSlot {
       resident = other.resident;
       encodedKey = other.encodedKey;
       encodedFingerprint = other.encodedFingerprint;
+      owningDeviceId = other.owningDeviceId;
       lastUniform = std::move(other.lastUniform);
       liveBytesGauge = std::move(other.liveBytesGauge);
       accountedBytes = other.accountedBytes;
       other.accountedBytes = 0;
       other.resident = false;
       other.encodedKey = nullptr;
+      other.owningDeviceId = 0;
     }
     return *this;
   }
@@ -149,19 +162,28 @@ struct GeodeResidentSlot {
   /// used the buffer was submitted, so dropping the handle is safe
   /// (wgpu-native ref-counts resources referenced by submitted command
   /// buffers).
-  void reset() {
+  void reset(bool destroyBuffer = true) {
     if (accountedBytes != 0 && liveBytesGauge) {
       liveBytesGauge->fetch_sub(accountedBytes, std::memory_order_relaxed);
     }
     accountedBytes = 0;
     bindGroup.reset();
     if (buffer) {
-      buffer.get().destroy();
+      // `destroyBuffer` is false only when the buffer was created by a
+      // DIFFERENT (possibly already-destroyed) device than the one now
+      // rendering - see `owningDeviceId`. In that case we must not call
+      // `wgpu::Buffer::destroy()`, which routes into the owning device;
+      // dropping our ref via `buffer.reset()` is the only safe teardown
+      // (wgpu-native frees the backing when the last ref drops).
+      if (destroyBuffer) {
+        buffer.get().destroy();
+      }
       buffer.reset();
     }
     resident = false;
     encodedKey = nullptr;
     encodedFingerprint = 0;
+    owningDeviceId = 0;
     lastUniform.clear();
   }
 };

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -295,8 +295,13 @@ TEST_F(GeodePerfTest, Lion_BaselineCeilings) {
   //                       drawCalls for `<use>`-heavy fixtures; Lion
   //                       has no `<use>` so this ceiling stays at 132.
   EXPECT_LE(c.pathEncodes, 200u);  // M2: target = 0.
-  // 0041 analytic dual-ray fill: 4 extra SSBO arenas grow once on first use.
-  EXPECT_LE(c.bufferCreates, 14u);
+  // Wave 2 (GPU residence): frame 1 now front-loads ONE persistent
+  // combined buffer per cached solid-fill path (132 for Lion) so that
+  // steady-state frames re-upload zero geometry. This trades a one-time
+  // frame-1 buffer-create spike for the steady-state win asserted in
+  // `Lion_NoDirtyPath_ZeroEncodes` (frame-2 bufferCreates == 1, the
+  // readback). Ceiling = 132 resident + readback + arena slack.
+  EXPECT_LE(c.bufferCreates, 150u);
   EXPECT_LE(c.bindgroupCreates, 200u);   // M1.f.2: target <= #pipelines.
   EXPECT_LE(c.textureCreates, 3u);       // Target on first render; 0 on repeat.
   EXPECT_LE(c.submits, 3u);              // M3: target = 1.
@@ -453,6 +458,16 @@ TEST_F(GeodePerfTest, SimpleShapes_NoDirtyPath_ZeroEncodes) {
   // frames. The remaining create is the takeSnapshot readback buffer.
   EXPECT_LE(c.bufferCreates, 2u) << "Arena buffer churn on an unchanged second render: the "
                                     "cross-frame GeodeBufferPool should serve all arena growth.";
+  // Wave 2 (GPU residence) steady-state: the three solid fills are
+  // GPU-resident from frame 1, so frame 2 writes zero geometry AND zero
+  // uniform bytes (same viewport => byte-identical uniforms) and reuses
+  // its cached bind groups. Wave-1 baseline was bufferWriteBytes=4128,
+  // bindgroupCreates=3.
+  EXPECT_LE(c.bufferWriteBytes, 512u)
+      << "Steady-state buffer writes on an unchanged second render: resident geometry "
+         "should not re-upload.";
+  EXPECT_LE(c.bindgroupCreates, 1u)
+      << "Steady-state bind-group creates: resident fills should reuse cached bind groups.";
 }
 
 TEST_F(GeodePerfTest, Moderate_NoDirtyPath_ZeroEncodes) {
@@ -470,6 +485,14 @@ TEST_F(GeodePerfTest, Moderate_NoDirtyPath_ZeroEncodes) {
   // M1 (GeodeBufferPool): readback + one per-blit uniform buffer remain
   // (layer composite blits create a fresh uniform buffer per call).
   EXPECT_LE(c.bufferCreates, 4u) << "Arena buffer churn on an unchanged second render.";
+  // Wave 2 (GPU residence): the opacity-layer solid path is resident, so
+  // the steady-state residual is only the gradient rect (arena path) plus
+  // the isolated-layer composite blit's per-frame uniform. Wave-1 baseline
+  // was bufferWriteBytes=5372, bindgroupCreates=3.
+  EXPECT_LE(c.bufferWriteBytes, 3200u)
+      << "Steady-state buffer writes: only the gradient + layer-blit uniforms should remain.";
+  EXPECT_LE(c.bindgroupCreates, 3u) << "Steady-state bind-group creates: the resident solid fill "
+                                       "should reuse its cached bind group.";
 }
 
 TEST_F(GeodePerfTest, Lion_NoDirtyPath_ZeroEncodes) {
@@ -497,6 +520,17 @@ TEST_F(GeodePerfTest, Lion_NoDirtyPath_ZeroEncodes) {
   // readback buffer only.
   EXPECT_LE(c.bufferCreates, 3u)
       << "Arena buffer churn on an unchanged second render of lion.svg.";
+  // Wave 2 (GPU residence) - the headline steady-state win. All 132 solid
+  // fills are GPU-resident from frame 1, so an unchanged second render
+  // re-uploads zero geometry bytes and creates zero bind groups. Wave-1
+  // baseline was bufferWriteBytes=172776 across 1056 writes, and
+  // bindgroupCreates=132 (one per draw). drawCalls stays 132 - the draws
+  // still happen, they just bind cached resident buffers.
+  EXPECT_LE(c.bufferWriteBytes, 4096u)
+      << "Steady-state geometry re-upload on an unchanged second render of lion.svg: resident "
+         "buffers should serve every draw.";
+  EXPECT_LE(c.bindgroupCreates, 2u)
+      << "Steady-state bind-group creates no longer proportional to draw calls (was 132).";
 }
 
 TEST_F(GeodePerfTest, GhostscriptTiger_NoDirtyPath_ZeroEncodes) {
@@ -524,6 +558,19 @@ TEST_F(GeodePerfTest, GhostscriptTiger_NoDirtyPath_ZeroEncodes) {
   // with a little margin.
   EXPECT_LE(c.bufferCreates, 8u)
       << "Arena buffer churn on an unchanged second render of Ghostscript_Tiger.svg.";
+  // Wave 2 (GPU residence) - THE headline acceptance target. The wave-1
+  // measured profile (design doc 0030 appendix) was ~1.44 MB re-uploaded
+  // per steady-state frame across 2,432 writeBuffer calls, plus 304 bind
+  // group creates (one per draw). With persistent per-entity residence an
+  // unchanged second render re-uploads zero geometry bytes and creates
+  // zero bind groups - a >99% reduction, far past the 90% acceptance
+  // floor (which would be <= 147388 bytes). Both fill AND stroke slots
+  // are exercised (Tiger has strokes). drawCalls stays 304.
+  EXPECT_LE(c.bufferWriteBytes, 8192u)
+      << "Steady-state geometry re-upload on an unchanged second render of Ghostscript_Tiger.svg. "
+         "Wave-1 baseline was 1,473,888 bytes; residency should drive this to ~0.";
+  EXPECT_LE(c.bindgroupCreates, 2u)
+      << "Steady-state bind-group creates no longer proportional to draw calls (was 304).";
 }
 
 // ---------------------------------------------------------------------------
@@ -691,6 +738,94 @@ TEST_F(GeodePerfTest, TextureSnapshotStressReleasesMsaaTargets) {
   EXPECT_GE(textureReleaseDelta, static_cast<uint64_t>(kFrameCount * 2))
       << "Repeated texture snapshots should release both resolved and MSAA targets. "
          "A lower count means the MSAA target is still being overwritten as a raw handle.";
+}
+
+// ---------------------------------------------------------------------------
+// Wave 2 (GPU residence): eviction / no-unbounded-growth.
+//
+// Persistent per-entity GPU buffers must not accumulate across distinct
+// documents. Each document owns its own ECS registry; when the document is
+// torn down its `GeodeResidentPathComponent`s are destroyed and their GPU
+// buffers freed (RAII, settling the device's live-resident-bytes gauge).
+// This test renders a series of distinct documents on the shared device and
+// asserts the live resident bytes return to baseline after each teardown -
+// i.e. GPU memory is bounded no matter how many documents pass through.
+// ---------------------------------------------------------------------------
+
+TEST_F(GeodePerfTest, GpuResidence_FreesResidentBuffersOnDocumentTeardown) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  // Baseline: any residence from earlier tests has already been freed
+  // (their renderers + documents were destroyed), so this is the floor we
+  // must return to after every document below.
+  const int64_t baseline = device->liveResidentBytesForTesting();
+
+  int64_t peakWhileLive = baseline;
+  for (int i = 0; i < 8; ++i) {
+    // Distinct documents (varying shape count) => distinct registries and
+    // distinct resident buffers.
+    std::ostringstream svg;
+    svg << R"(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">)";
+    const int shapes = 3 + i;
+    for (int s = 0; s < shapes; ++s) {
+      svg << "<rect x=\"" << (10 + s * 5) << "\" y=\"" << (10 + s * 7) << "\" width=\"40\" "
+          << "height=\"30\" fill=\"rgb(" << (s * 20 % 256) << ",64,128)\"/>";
+    }
+    svg << "</svg>";
+
+    ParseWarningSink sink = ParseWarningSink::Disabled();
+    auto parsed = parser::SVGParser::ParseSVG(svg.str(), sink);
+    ASSERT_FALSE(parsed.hasError()) << parsed.error().reason;
+
+    {
+      SVGDocument document = std::move(parsed.result());
+      RendererGeode renderer(device);
+      renderer.draw(document);
+      (void)renderer.takeSnapshot();
+      peakWhileLive = std::max(peakWhileLive, device->liveResidentBytesForTesting());
+    }  // document + renderer destroyed => resident components freed.
+
+    EXPECT_EQ(device->liveResidentBytesForTesting(), baseline)
+        << "Resident GPU buffers from document " << i
+        << " were not freed on teardown - residence is leaking across documents.";
+  }
+
+  EXPECT_GT(peakWhileLive, baseline)
+      << "Sanity: at least one document should have held live resident GPU buffers.";
+  EXPECT_EQ(device->liveResidentBytesForTesting(), baseline)
+      << "Live resident bytes must return to baseline after all documents are torn down.";
+}
+
+// ---------------------------------------------------------------------------
+// Wave 2 (GPU residence): repeated same-document renders hold residence
+// steady - they must not grow the live resident-bytes gauge frame over
+// frame (the buffers are reused, not reallocated).
+// ---------------------------------------------------------------------------
+
+TEST_F(GeodePerfTest, GpuResidence_SteadyAcrossRepeatedRenders) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  const int64_t baseline = device->liveResidentBytesForTesting();
+
+  ParseWarningSink sink = ParseWarningSink::Disabled();
+  auto parsed = parser::SVGParser::ParseSVG(kSimpleShapesSvg, sink);
+  ASSERT_FALSE(parsed.hasError());
+  SVGDocument document = std::move(parsed.result());
+
+  RendererGeode renderer(device);
+  renderer.draw(document);
+  (void)renderer.takeSnapshot();
+  const int64_t afterFirst = device->liveResidentBytesForTesting();
+  EXPECT_GT(afterFirst, baseline) << "First render should establish GPU residence.";
+
+  for (int i = 0; i < 6; ++i) {
+    renderer.draw(document);
+    (void)renderer.takeSnapshot();
+    EXPECT_EQ(device->liveResidentBytesForTesting(), afterFirst)
+        << "Repeated unchanged render must not grow resident GPU memory (frame " << i << ").";
+  }
 }
 
 }  // namespace

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -19,6 +19,7 @@
 #include <cinttypes>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <fstream>
 #include <memory>
 #include <sstream>
@@ -826,6 +827,114 @@ TEST_F(GeodePerfTest, GpuResidence_SteadyAcrossRepeatedRenders) {
     EXPECT_EQ(device->liveResidentBytesForTesting(), afterFirst)
         << "Repeated unchanged render must not grow resident GPU memory (frame " << i << ").";
   }
+}
+
+// ---------------------------------------------------------------------------
+// Wave 2 (GPU residence): cross-device safety.
+//
+// A `GeodeResidentPathComponent` lives on the SVGDocument's ECS registry, so
+// it survives the `RendererGeode` that filled it. If the SAME document is
+// later rendered by a SECOND `RendererGeode` backed by a DIFFERENT
+// `GeodeDevice`, the resident buffer + bind group created by the first device
+// must NOT be bound into the second device's render pass - WebGPU rejects
+// cross-device resources. The fix scopes residence to the owning device
+// (`GeodeDevice::deviceId()`) and forces a re-upload when the device changes.
+//
+// Regression: on the pre-fix branch tip device B binds device A's stale
+// handles, so its output diverges from device A's (dropped draw / validation
+// error). This test renders one document on two independent devices and
+// asserts bit-identical output; it FAILS on the pre-fix tip and PASSES with
+// the fix.
+// ---------------------------------------------------------------------------
+
+// Identical dimensions and identical visible pixels (each bitmap's own
+// `rowBytes` absorbs any inter-row padding difference).
+bool bitmapsEqual(const RendererBitmap& a, const RendererBitmap& b) {
+  if (a.dimensions != b.dimensions) {
+    return false;
+  }
+  const int w = a.dimensions.x;
+  const int h = a.dimensions.y;
+  for (int y = 0; y < h; ++y) {
+    const uint8_t* ra = a.pixels.data() + static_cast<size_t>(y) * a.rowBytes;
+    const uint8_t* rb = b.pixels.data() + static_cast<size_t>(y) * b.rowBytes;
+    if (std::memcmp(ra, rb, static_cast<size_t>(w) * 4u) != 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Count pixels with non-zero alpha - a cheap "did anything render" check.
+size_t nonTransparentPixels(const RendererBitmap& bmp) {
+  size_t count = 0;
+  for (int y = 0; y < bmp.dimensions.y; ++y) {
+    const uint8_t* row = bmp.pixels.data() + static_cast<size_t>(y) * bmp.rowBytes;
+    for (int x = 0; x < bmp.dimensions.x; ++x) {
+      if (row[x * 4 + 3] != 0) {
+        ++count;
+      }
+    }
+  }
+  return count;
+}
+
+TEST_F(GeodePerfTest, GpuResidence_ReUploadsWhenDeviceChanges) {
+  // Two INDEPENDENT headless devices (not the shared fixture device): this is
+  // the "document crosses devices" scenario.
+  auto deviceA = std::shared_ptr<geode::GeodeDevice>(geode::GeodeDevice::CreateHeadless());
+  auto deviceB = std::shared_ptr<geode::GeodeDevice>(geode::GeodeDevice::CreateHeadless());
+  ASSERT_TRUE(deviceA) << "GeodeDevice::CreateHeadless (A) failed";
+  ASSERT_TRUE(deviceB) << "GeodeDevice::CreateHeadless (B) failed";
+  ASSERT_NE(deviceA->deviceId(), deviceB->deviceId());
+
+  ParseWarningSink sink = ParseWarningSink::Disabled();
+  auto parsed = parser::SVGParser::ParseSVG(kSimpleShapesSvg, sink);
+  ASSERT_FALSE(parsed.hasError()) << parsed.error().reason;
+  // ONE document, rendered by both devices - its GeodeResidentPathComponents
+  // are filled by device A and then re-encountered by device B.
+  SVGDocument document = std::move(parsed.result());
+
+  // Device A establishes residence and produces the reference image. Drive TWO
+  // frames on the SAME renderer so its per-renderer frame index advances to 2.
+  // This matters for the regression: `fillPathResident`'s same-frame gate
+  // diverts a repeat draw whose frame index equals `slot.lastResidentFrame` to
+  // the (correct) arena path. Device B is a fresh renderer whose first frame
+  // index is 1; if device A had also stopped at frame index 1 the pre-fix gate
+  // would coincidentally send device B down the arena path and mask the
+  // cross-device bug. Advancing device A to frame index 2 guarantees device B
+  // exercises the resident path on the pre-fix code.
+  RendererGeode rendererA(deviceA);
+  rendererA.draw(document);  // frame index 1: establishes residence on A.
+  rendererA.draw(document);  // frame index 2: steady residence, lastResidentFrame=2.
+  const RendererBitmap referenceA = rendererA.takeSnapshot();
+  ASSERT_FALSE(referenceA.empty()) << "device A produced no snapshot";
+  ASSERT_GT(nonTransparentPixels(referenceA), 0u)
+      << "device A rendered nothing - fixture no longer exercises solid fills";
+
+  // Device B (fresh renderer, frame index 1) renders the SAME document. Pre-fix,
+  // the resident slots still hold device A's buffer + bind group; binding those
+  // into device B's pass is a cross-device violation and the draws are dropped,
+  // so the output diverges. With the fix the device-id mismatch forces a
+  // re-upload onto device B and the output matches.
+  RendererGeode rendererB(deviceB);
+  rendererB.draw(document);  // frame index 1 != lastResidentFrame(2): resident path.
+  const RendererBitmap resultB = rendererB.takeSnapshot();
+  ASSERT_FALSE(resultB.empty()) << "device B produced no snapshot";
+
+  EXPECT_TRUE(bitmapsEqual(referenceA, resultB))
+      << "device B output diverged from device A: resident GPU resources from "
+         "device A leaked into device B's render pass (cross-device residence). "
+         "device A non-transparent px="
+      << nonTransparentPixels(referenceA)
+      << ", device B non-transparent px=" << nonTransparentPixels(resultB);
+
+  // A render back on device A must still match (residence re-homes to A).
+  RendererGeode rendererA2(deviceA);
+  rendererA2.draw(document);
+  const RendererBitmap reReferenceA = rendererA2.takeSnapshot();
+  EXPECT_TRUE(bitmapsEqual(referenceA, reReferenceA))
+      << "device A output changed after a device-B render round-trip";
 }
 
 }  // namespace


### PR DESCRIPTION
## What

Wave 2 of the Geode optimization pass. Gives each cached `EncodedPath` persistent per-entity GPU residence plus a cached bind group, so an unchanged document re-uploads ~zero geometry and creates ~zero bind groups in steady state. Builds on the wave-1 stack (targets `geode/opt-pass`).

This attacks the wave-1 measured headline: a static Ghostscript Tiger re-uploaded ~1.44 MB per frame across 2,432 `writeBuffer` calls even though the CPU encode cache hit, and created one bind group per draw (304/frame).

## How

- `GeodeResidentPathComponent` sits beside `GeodePathCacheComponent` (fill slot + stroke slot). Each `GeodeResidentSlot` owns one combined `Vertex | Storage | Uniform` buffer (vertex quad + six analytic dual-ray SSBO regions + the per-draw uniform) and a cached 12-entry fill bind group referencing only stable objects.
- `GeoEncoder::fillPathResident` uploads geometry once, rewrites only the 288-byte uniform when it actually changed (static re-render => zero writes), reuses the cached bind group, records the draw. Shares `populateFillUniform` with the arena path so the two are byte-identical.
- Correctness fences: residence only for solid fills/strokes with no active clip mask / clip polygon / mask pass (else the wave-1 arena path runs, keeping clipped/masked draws bit-exact), and at most one draw per slot per frame (a slot has one uniform buffer, so markers and non-adjacent repeated `<use>` route repeats through the arena path).
- Invalidation reuses the M2 `ComputedPathComponent` listener (removes the resident component in lock-step); registry teardown frees the buffer. A device-owned shared live-resident-bytes gauge makes eviction measurable.
- Gradients, patterns, instanced `<use>` batches, and clipped draws keep the arena path.

## Measured steady-state (frame 2, unchanged document)

macOS / Metal, Apple M4 Pro, headless `GeodeDevice`.

| Fixture | draws | bindgroupCreates (was) | bufferWriteBytes (was) |
|---|---|---|---|
| SimpleShapes | 3 | 0 (3) | 0 (4,128) |
| Moderate | 3 | 2 (3) | 2,780 (5,372) |
| lion.svg | 132 | 0 (132) | 0 (172,776) |
| Ghostscript_Tiger | 304 | 0 (304) | 0 (1,473,888) |

Tiger: >99% reduction in steady-state buffer-write bytes and bind-group creates, far past the 90% acceptance floor; `drawCalls` stays 304. Moderate residual is the gradient rect (arena) + opacity-layer composite blit uniform, both explained (non-geometry). New `GeodePerf_tests` ceilings lock the win; the Lion frame-1 `bufferCreates` ceiling was raised for the one-time residency front-load. Eviction is covered by new `GpuResidence_*` tests.

## Validation

**Repo CI only runs on main-targeting PRs, so this PR is validated by fresh local full-suite runs, not CI.** All green on an internal build host (macOS / Metal):

- `//donner/svg/renderer/geode:geode_perf_tests` - PASS (new steady-state + eviction assertions)
- `//donner/svg/renderer/tests:resvg_test_suite_geode` (8 shards) - PASS (goldens bit-identical)
- `//donner/svg/renderer/tests:renderer_geode_golden_tests`, `renderer_geode_tests`, and all `*_geode` renderer variants - PASS
- `//donner/svg/renderer/...` (full tree, all backends) - 103 pass, 13 skipped, 0 fail
- `//donner/editor/...` - 260 pass, 6 skipped (fuzzers), 0 fail
- `RendererPublicApiTest.MarkerRendering` regression caught and fixed (per-frame residence gate)

This PR **rebases onto main after the wave-1 stack (#809/#811/#812) merges.**

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17

