### PR TITLE
Serialize self-hosted RE lanes to stop backend oversubscription

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -412,16 +412,20 @@ jobs:
     # buffer: RE degradation fast-fails (no local fallback, below) instead of
     # the CPU-capped 2-3 h local re-run that produced the 3.3 h tail.
     timeout-minutes: 60
-    # Admission control on the shared bazel-re2 backend. TWO concurrent
-    # instrumented coverage builds were the measured failure that hit the 60 min
-    # timeout on #808/#809: both farm to one 14-core NativeLink backend on
-    # deep-thought and thrash it ~20x (uncontended median is 2.5 min; two
-    # concurrent = 60 min timeout). See docs/design_docs/0029-2-ci_runtime.md
-    # appendix (2026-07-10). This group serializes coverage-self-hosted across
-    # all of the operator's in-flight PRs so at most one instrumented coverage
-    # build runs at a time; the CI linux-self-hosted lane uses a separate group.
-    # cancel-in-progress: false never kills a running build (a superseded push
-    # to the SAME PR is already cancelled by the workflow-level group).
+    # Admission control on the shared RE path. TWO concurrent instrumented
+    # coverage builds were the measured failure that hit the 60 min timeout on
+    # #808/#809. The coverage lane merges lcov LOCALLY on gha-host1 (8 vcpu
+    # shared by four runners) and executes actions on bazel-re1 (96-vcpu VM on
+    # event-horizon, shared with the priority dev host dev1); N concurrent
+    # coverage jobs thrash both (uncontended median 2.5 min; two concurrent =
+    # 60 min timeout; live 2026-07-10 a smoke subset sat 45+ min under 3-way
+    # contention). See docs/design_docs/0029-2-ci_runtime.md appendix. This
+    # group serializes coverage-self-hosted across all of the operator's
+    # in-flight PRs so at most one instrumented coverage build runs at a time,
+    # which also protects dev1's bazel-re1 latency; the CI linux-self-hosted
+    # lane uses a separate group. cancel-in-progress: false never kills a
+    # running build (a superseded push to the SAME PR is already cancelled by
+    # the workflow-level group).
     concurrency:
       group: donner-selfhosted-coverage-re
       cancel-in-progress: false

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -412,6 +412,19 @@ jobs:
     # buffer: RE degradation fast-fails (no local fallback, below) instead of
     # the CPU-capped 2-3 h local re-run that produced the 3.3 h tail.
     timeout-minutes: 60
+    # Admission control on the shared bazel-re2 backend. TWO concurrent
+    # instrumented coverage builds were the measured failure that hit the 60 min
+    # timeout on #808/#809: both farm to one 14-core NativeLink backend on
+    # deep-thought and thrash it ~20x (uncontended median is 2.5 min; two
+    # concurrent = 60 min timeout). See docs/design_docs/0029-2-ci_runtime.md
+    # appendix (2026-07-10). This group serializes coverage-self-hosted across
+    # all of the operator's in-flight PRs so at most one instrumented coverage
+    # build runs at a time; the CI linux-self-hosted lane uses a separate group.
+    # cancel-in-progress: false never kills a running build (a superseded push
+    # to the SAME PR is already cancelled by the workflow-level group).
+    concurrency:
+      group: donner-selfhosted-coverage-re
+      cancel-in-progress: false
     env:
       # RE-availability SLA: do NOT fall back to local execution when remote
       # execution is unavailable or degraded. A CPU-capped self-hosted runner

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -447,6 +447,22 @@ jobs:
     # it at 60 min for buffer while a wedged/degraded RE endpoint still
     # fast-fails instead of silently tailing for hours.
     timeout-minutes: 60
+    # Admission control on the shared bazel-re2 backend. The Linux self-hosted
+    # lanes are thin RE clients: their build/test actions all execute on ONE
+    # 14-core NativeLink backend on deep-thought. Two-plus concurrent operator
+    # PRs oversubscribe it ~20x and crawl into the 60 min timeout (measured
+    # 2026-07-10; see docs/design_docs/0029-2-ci_runtime.md appendix). This
+    # per-lane group serializes linux-self-hosted across all of the operator's
+    # in-flight PRs so at most one runs at a time; the sibling
+    # coverage-self-hosted lane has its own group, so a Linux build and a
+    # coverage build may overlap but two of the same heavy lane never do.
+    # cancel-in-progress: false never kills a running build (a superseded push
+    # to the SAME PR is already cancelled by the workflow-level concurrency
+    # group). Loosen to a single shared group only if 1 linux + 1 coverage is
+    # still shown to oversubscribe the backend.
+    concurrency:
+      group: donner-selfhosted-linux-re
+      cancel-in-progress: false
     env:
       # The runner host may add the LAN Bazel cache from its home rc. Use that
       # acceleration when healthy, but do NOT fall back to local execution when

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -447,19 +447,22 @@ jobs:
     # it at 60 min for buffer while a wedged/degraded RE endpoint still
     # fast-fails instead of silently tailing for hours.
     timeout-minutes: 60
-    # Admission control on the shared bazel-re2 backend. The Linux self-hosted
-    # lanes are thin RE clients: their build/test actions all execute on ONE
-    # 14-core NativeLink backend on deep-thought. Two-plus concurrent operator
-    # PRs oversubscribe it ~20x and crawl into the 60 min timeout (measured
+    # Admission control on the shared RE path. The Linux self-hosted lanes
+    # execute on bazel-re1 (a 96-vcpu Incus VM on event-horizon, reached via the
+    # runner bazelrc --config=ci -> ci-re -> remote_executor=bazel-re1:50051),
+    # which the priority dev host dev1 also uses; the runner-side work runs on
+    # gha-host1 (8 vcpu shared by all four runners). Two-plus concurrent operator
+    # PRs oversubscribe that path ~20x and crawl into the 60 min timeout (measured
     # 2026-07-10; see docs/design_docs/0029-2-ci_runtime.md appendix). This
     # per-lane group serializes linux-self-hosted across all of the operator's
     # in-flight PRs so at most one runs at a time; the sibling
     # coverage-self-hosted lane has its own group, so a Linux build and a
     # coverage build may overlap but two of the same heavy lane never do.
-    # cancel-in-progress: false never kills a running build (a superseded push
-    # to the SAME PR is already cancelled by the workflow-level concurrency
-    # group). Loosen to a single shared group only if 1 linux + 1 coverage is
-    # still shown to oversubscribe the backend.
+    # Bounding CI's demand on bazel-re1 also protects dev1's interactive
+    # latency. cancel-in-progress: false never kills a running build (a
+    # superseded push to the SAME PR is already cancelled by the workflow-level
+    # concurrency group). This job-level group composes with the workflow-level
+    # group and with the centralized routing in PR #818 (it is gate-agnostic).
     concurrency:
       group: donner-selfhosted-linux-re
       cancel-in-progress: false

--- a/docs/design_docs/0029-2-ci_runtime.md
+++ b/docs/design_docs/0029-2-ci_runtime.md
@@ -272,3 +272,167 @@ this measurement repeatable. Optional but recommended before starting M1.
    policy than the default 7 days.
 3. Is there a budget for `macos-15-large` (M4)? If not, skip and rely on
    the other levers.
+
+## Appendix: 2026-07-10 timing profile (self-hosted lane P95/P99 investigation)
+
+**Author:** Claude Opus 4.8 (CI-runtime agent)
+**Scope:** Root-cause the `linux-self-hosted` and `coverage-self-hosted` lanes
+that ran past 60 minutes under queue contention and were cancelled at the job
+timeout (PRs #808, #809). Timeouts were raised 60 -> 120 as a stopgap on
+affected branches by another agent; this appendix targets the root cause so the
+stopgap becomes unnecessary. Aligns with
+[0018: Donner Build, Test and CI Speed P0] (Verification section).
+
+### Stated goal (operator, 2026-07-10)
+
+End-to-end PR CI wall-clock, measured from PR trigger to the last required
+check finishing and INCLUDING queue wait, must reach:
+
+- **P95 <= 15 minutes**
+- **P99 <= 30 minutes**
+
+Primary metric is end-to-end run completion on that definition; a per-lane view
+is reported alongside it. Speed is the target, never coverage: no test removed,
+no lane skipped, no required check made optional.
+
+### Method
+
+- Data: GitHub Actions REST API (`gh api`), workflows CI (`main.yml`, id
+  1413161) and Coverage (`coverage.yml`, id 6956149), window 2026-06-26 to
+  2026-07-10. 1001 unique runs; job-level `started_at`/`completed_at` pulled
+  for every run. Execution = job started -> completed. Queue = run created ->
+  job started (includes upstream `determine-targets` dependency plus runner
+  slot wait). End-to-end per PR = latest run per workflow at a head SHA,
+  max(job completed) - min(run created), non-skipped jobs only.
+- Split at Packet A (#799, "CI: PR lane under 15 minutes", merged 2026-07-06
+  ~19:00Z), because Packet A changed the shape of the problem. Post-A is the
+  state that matters; pre-A is kept for contrast.
+
+### End-to-end per PR (PR events, trigger -> last check, incl queue)
+
+| Window | n (head SHAs) | median | p90 | p95 | p99 | max | >15m | >30m |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| PRE Packet A (06-26..07-06) | 267 | 58.1 | 254 | 688 | 1028 | 1067 | 85% | 72% |
+| POST Packet A (07-06..07-10) | 43 | 15.3 | 71.0 | 270.6 | 304.0 | 306.6 | 51% | 33% |
+
+All values minutes. **Gap to goal (post-A): P95 270.6 vs 15 target; P99 304 vs
+30 target.** Packet A already fixed the median (58 -> 15.3 min); the entire
+remaining gap is in the tail.
+
+### Per-lane wall-clock, POST Packet A (PR events, minutes)
+
+| Workflow:job | n | exec med | exec p90 | exec p95 | exec max | queue med | queue p90 | queue p95 | queue max |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| Co:coverage-self-hosted | 31 | 2.5 | 30.4 | 48.1 | 60 | 0.8 | 1 | 239 | 270 |
+| CI:linux-self-hosted | 30 | 0.0 | 30.4 | 46.5 | 60 | 0.6 | 24 | 240 | 270 |
+| CI:linux (hosted) | 36 | 5.7 | 65.5 | 66.7 | 77 | 0.6 | 1 | 1 | 1 |
+| Co:build (hosted) | 26 | 0.0 | 16.4 | 25.6 | 71 | 0.8 | 1 | 1 | 1 |
+| CI:macos (hosted) | 36 | 6.1 | 38.8 | 45.2 | 50 | 0.6 | 1 | 1 | 1 |
+| CI:macos-self-hosted | 30 | 0.0 | 3.3 | 4.1 | 5 | 0.6 | 1 | 1 | 3 |
+| Co:determine-targets | 43 | 0.6 | 0.8 | 0.9 | 1 | 0.1 | 0 | 0 | 0 |
+| CI:determine-targets | 43 | 0.3 | 0.8 | 0.9 | 1 | 0.2 | 1 | 1 | 1 |
+| CI:gatekeeper | 43 | 0.1 | 0.2 | 0.2 | 0 | 0.1 | 0 | 0 | 1 |
+
+`exec max = 60` for both self-hosted lanes is the job timeout firing, not an
+honest completion. exec med 0.0 means the lane was gated off (skipped) on that
+SHA and only ran on a subset.
+
+### Dominant cost: self-hosted RE oversubscription (drives P95/P99)
+
+The three worst post-A PR SHAs decompose as:
+
+| e2e | max queue | max exec | worst-exec job |
+|---:|---:|---:|---|
+| 307 | 247 | 60 (timeout) | Co:coverage-self-hosted |
+| 300 | 270 | 30 | CI:linux-self-hosted |
+| 292 | 232 | 60 (timeout) | CI:linux-self-hosted |
+
+Step-level on the two 60-minute cancellations (runs 29076327250,
+29077015684, both PRs, started within one second of each other at
+11:24:44-45Z): checkout 11s, `Sync Bazel toolchain` 10s, `Fetch Bazel LLVM
+toolchain` 32-45s, then `Generate coverage` runs from 11:25 to 12:24:5x and is
+cancelled at the 60-minute timeout. Setup is ~1 minute; 100% of the wasted hour
+is one instrumented build/test step that never finished.
+
+Capacity (measured, deep-thought via ssh; GitHub runners API):
+
+- deep-thought: 14 cores / 64 GB, Apple silicon, hosts the bazel-re2 NativeLink
+  backend (launchd, `/usr/local/bin/nativelink /opt/mcglynn/bazel-re2/nativelink-config.json5`;
+  config is root-owned and not readable without sudo) plus the single macOS
+  self-hosted runner.
+- Linux self-hosted lanes run on 4 runner slots on host event-horizon
+  (`donner-runner-linux-06..09`, labels self-hosted/ARM64/Linux). These are
+  thin RE clients (`--remote_local_fallback=false`); their build/test actions
+  execute on the shared bazel-re2 backend on deep-thought.
+
+So peak concurrent RE demand is up to 4 Linux jobs (the `linux-self-hosted` and
+`coverage-self-hosted` lanes across the operator's simultaneously-active PRs)
+against one 14-core backend. Uncontended, an incremental coverage run's
+`Generate coverage` step is ~2.5 min (post-Packet-A median). Two concurrent
+instrumented coverage builds crawl to the 60-minute timeout: a ~20x, superlinear
+blowup consistent with CPU and memory thrash once the 14-core box is
+oversubscribed. The huge queue wait (p95 239-240 min, max 270) is the same
+pathology seen from the front: while all runner slots are held by jobs crawling
+for an hour, later jobs wait hours for a slot. Queue and execution are coupled
+through backend saturation.
+
+The self-hosted lanes are gated on `github.actor == jwmcglynn &&
+github.triggering_actor == jwmcglynn`, so this is the operator's own concurrent
+PRs saturating a shared backend, not third-party load.
+
+### Secondary cost: hosted full //... fallback on infra-file PRs (drives P90)
+
+A cluster of post-A PR SHAs sits at e2e 66-78 min with near-zero queue, exec
+concentrated in the hosted `CI:linux` (66-77 min) or hosted `Co:build` (71 min)
+jobs. These are PRs whose diff touches build-graph infrastructure
+(`MODULE.bazel`, `WORKSPACE*`, `.bazelrc`, `build_defs/*`, `.github/workflows/*`,
+`.github/actions/*`): `determine-targets` correctly forces a full `//...` set,
+the self-hosted lanes skip by design (their gate requires `fallback != 'true'`),
+and the hosted lane runs the entire graph on GitHub's disk cache (cold-ish),
+landing at 60-78 min. About 19% of post-A PR SHAs hit this. It is a separate
+population from the self-hosted tail (those PRs never reach the self-hosted
+lanes) and is largely by design; it matters for P90, not for the P95/P99 gap.
+
+### Not significant (ruled out with numbers)
+
+- Checkout / toolchain sync / LLVM fetch on self-hosted: ~1 min total (11s +
+  10s + 32-45s measured). Not a lever.
+- `determine-targets` / `gatekeeper` / `bazel-diff`: ~1 min. Not a lever.
+- Cold caches on the healthy path: Packet A's incremental scoping works;
+  coverage-self-hosted exec median fell 17 -> 2.5 min pre->post Packet A. The
+  problem is not per-run build cost, it is concurrency against a shared backend.
+- macos-self-hosted: exec p95 4.1 min. Healthy; leave unchanged.
+
+### Ranked levers toward the P95<=15 / P99<=30 goal
+
+1. **Admission control on the self-hosted RE lanes (software, this agent).**
+   Serialize `linux-self-hosted` + `coverage-self-hosted` onto the shared
+   bazel-re2 backend with a GitHub Actions job-level concurrency group so at
+   most one RE-client job farms to the 14-core backend at a time. This removes
+   the superlinear oversubscription that produces the 35-60 min crawls and the
+   60-min timeouts; serialized-but-uncontended runs finish in ~3-8 min. Directly
+   attacks the dominant P95/P99 driver. Predicted, with the caveat that
+   `pull_request` runs the base-branch copy of the workflow, so the change is
+   validated on the first post-merge bursts (ci-times monitor red-count), not on
+   the PR that introduces it. Removes the need for the 60 -> 120 timeout stopgap
+   on the degraded-RE case (fast-fail via `remote_local_fallback=false` +
+   `remote_timeout` still covers a genuinely down endpoint).
+2. **RE backend capacity / runner-to-RE ratio (operator, Packet C).** The
+   software ceiling with lever 1 is one self-hosted RE job at a time; under a
+   burst of K simultaneous operator PRs the Kth still waits ~K x exec. Closing
+   the gap for bursts needs backend capacity: either more bazel-re2 executor
+   cores/host, or fewer runner slots matched to backend capacity, or splitting
+   RE across hosts. Requires the root-owned nativelink config (executor slot
+   count) which this agent cannot read without sudo. Operator action.
+3. **Hosted full //... fallback cost (secondary, P90).** An internal
+   authenticated remote cache for hosted runs (0029-2 Milestone 6) would cut the
+   60-78 min infra-change fallback, but it is a larger change and out of the
+   P95/P99 critical path. Ranked below 1 and 2.
+
+### Reconciliation with the 60 -> 120 timeout stopgap
+
+The stopgap raised the self-hosted job timeout so contention-slowed runs would
+not cancel. With lever 1 (serialization) the lanes no longer oversubscribe, so
+uncontended exec stays well under 60 min and the raise is unnecessary; the
+timeout can stay at 60 min as a fast-fail bound on a genuinely wedged endpoint,
+matching the 0018 end-state (SLA lanes that fast-fail, not tail for hours).

--- a/docs/design_docs/0029-2-ci_runtime.md
+++ b/docs/design_docs/0029-2-ci_runtime.md
@@ -273,7 +273,8 @@ this measurement repeatable. Optional but recommended before starting M1.
 3. Is there a budget for `macos-15-large` (M4)? If not, skip and rely on
    the other levers.
 
-## Appendix: 2026-07-10 timing profile (self-hosted lane P95/P99 investigation)
+
+## Appendix: 2026-07-10 timing profile and RE-topology inventory
 
 **Author:** Claude Opus 4.8 (CI-runtime agent)
 **Scope:** Root-cause the `linux-self-hosted` and `coverage-self-hosted` lanes
@@ -281,32 +282,36 @@ that ran past 60 minutes under queue contention and were cancelled at the job
 timeout (PRs #808, #809). Timeouts were raised 60 -> 120 as a stopgap on
 affected branches by another agent; this appendix targets the root cause so the
 stopgap becomes unnecessary. Aligns with
-[0018: Donner Build, Test and CI Speed P0] (Verification section).
+[0018: Donner Build, Test and CI Speed P0] (Verification section) and its
+Packet C (event-horizon capacity).
 
 ### Stated goal (operator, 2026-07-10)
 
 End-to-end PR CI wall-clock, measured from PR trigger to the last required
-check finishing and INCLUDING queue wait, must reach:
+check finishing and INCLUDING queue wait:
 
 - **P95 <= 15 minutes**
 - **P99 <= 30 minutes**
 
 Primary metric is end-to-end run completion on that definition; a per-lane view
 is reported alongside it. Speed is the target, never coverage: no test removed,
-no lane skipped, no required check made optional.
+no lane skipped, no required check made optional. Governing infra principle
+(operator Packet C): all build/test executes on RE (NativeLink workers); GHA
+runner hosts stay thin dispatchers; solve tail latency by shifting cores to the
+RE backend, not by multiplying runner hosts. dev1 (the interactive dev host)
+has PRIORITY on shared RE capacity: if CI and dev1 contend, dev1 wins and the
+cost is paid in CI tail latency, stated here rather than eroding dev1 priority.
 
 ### Method
 
 - Data: GitHub Actions REST API (`gh api`), workflows CI (`main.yml`, id
   1413161) and Coverage (`coverage.yml`, id 6956149), window 2026-06-26 to
-  2026-07-10. 1001 unique runs; job-level `started_at`/`completed_at` pulled
-  for every run. Execution = job started -> completed. Queue = run created ->
-  job started (includes upstream `determine-targets` dependency plus runner
-  slot wait). End-to-end per PR = latest run per workflow at a head SHA,
-  max(job completed) - min(run created), non-skipped jobs only.
+  2026-07-10. 1001 unique runs; job-level `started_at`/`completed_at` for every
+  run. Execution = job started -> completed. Queue = run created -> job started.
+  End-to-end per PR = latest run per workflow at a head SHA, max(job completed)
+  - min(run created), non-skipped jobs only.
 - Split at Packet A (#799, "CI: PR lane under 15 minutes", merged 2026-07-06
-  ~19:00Z), because Packet A changed the shape of the problem. Post-A is the
-  state that matters; pre-A is kept for contrast.
+  ~19:00Z). Post-A is the state that matters; pre-A kept for contrast.
 
 ### End-to-end per PR (PR events, trigger -> last check, incl queue)
 
@@ -315,9 +320,8 @@ no lane skipped, no required check made optional.
 | PRE Packet A (06-26..07-06) | 267 | 58.1 | 254 | 688 | 1028 | 1067 | 85% | 72% |
 | POST Packet A (07-06..07-10) | 43 | 15.3 | 71.0 | 270.6 | 304.0 | 306.6 | 51% | 33% |
 
-All values minutes. **Gap to goal (post-A): P95 270.6 vs 15 target; P99 304 vs
-30 target.** Packet A already fixed the median (58 -> 15.3 min); the entire
-remaining gap is in the tail.
+All minutes. **Gap to goal (post-A): P95 270.6 vs 15; P99 304 vs 30.** Packet A
+fixed the median (58 -> 15.3); the entire remaining gap is tail.
 
 ### Per-lane wall-clock, POST Packet A (PR events, minutes)
 
@@ -333,106 +337,157 @@ remaining gap is in the tail.
 | CI:determine-targets | 43 | 0.3 | 0.8 | 0.9 | 1 | 0.2 | 1 | 1 | 1 |
 | CI:gatekeeper | 43 | 0.1 | 0.2 | 0.2 | 0 | 0.1 | 0 | 0 | 1 |
 
-`exec max = 60` for both self-hosted lanes is the job timeout firing, not an
-honest completion. exec med 0.0 means the lane was gated off (skipped) on that
-SHA and only ran on a subset.
+`exec max = 60` on both self-hosted lanes is the timeout firing, not a real
+completion. exec med 0.0 means the lane was gated off (skipped) on that SHA.
 
-### Dominant cost: self-hosted RE oversubscription (drives P95/P99)
+### Measured RE topology (event-horizon / deep-thought, read-only via ssh + incus)
 
-The three worst post-A PR SHAs decompose as:
+The self-hosted lanes are NOT a single flat backend; correcting an earlier draft
+of this appendix that attributed the Linux lanes to deep-thought:
 
-| e2e | max queue | max exec | worst-exec job |
-|---:|---:|---:|---|
-| 307 | 247 | 60 (timeout) | Co:coverage-self-hosted |
-| 300 | 270 | 30 | CI:linux-self-hosted |
-| 292 | 232 | 60 (timeout) | CI:linux-self-hosted |
+- **event-horizon**: 128 physical cores, 125 GB, Ampere Altra (aarch64), running
+  Incus/qemu VMs. Host load average was ~5-8 of 128 during this profiling (the
+  host itself is far from saturated). It hosts the RE executor, the runner host,
+  the CAS cache, AND the dev host, all as guests:
+  - `bazel-re1` VM: **96 vcpu / 80 GiB** = the RE executor at
+    `grpcs://bazel-re1.mcglynn.dev:50051` (192.168.1.83). This is the executor
+    the Linux `--config=ci` lanes use: gha-host1's bazelrc chains `--config=ci`
+    -> `--config=ci-re` -> `--remote_executor=grpcs://bazel-re1...:50051` for
+    build, test, AND coverage.
+  - `gha-host1` VM: **8 vcpu / 40 GiB** = the GitHub Actions runner host. All
+    four Linux runners (`donner-runner-linux-06..09`) share these 8 vcpu.
+  - `dev1` VM: **unlimited cpu (up to 128) / 80 GiB** = the interactive dev host.
+    dev1 also targets bazel-re1 for RE (`build:re --remote_executor=...1.83:50051`).
+  - `bazel-cache1` VM + `bazel-remote` (grpc `192.168.1.63:9092`, 100 GB zstd)
+    = the shared CAS/AC cache.
+  - Plus ~10 small service VMs (hub1, code1, zk1, sites1, etc., 1-8 vcpu each).
+- **deep-thought**: 14 cores / 64 GB, Apple silicon, runs `bazel-re2`
+  (nativelink launchd, `/opt/mcglynn/bazel-re2/nativelink-config.json5`, config
+  root-owned/unreadable without sudo) + the single macOS self-hosted runner.
+  bazel-re2 is the **macOS** executor (`build:re-macos ->
+  bazel-re2.mcglynn.dev:50051`), NOT the Linux/coverage executor.
 
-Step-level on the two 60-minute cancellations (runs 29076327250,
-29077015684, both PRs, started within one second of each other at
-11:24:44-45Z): checkout 11s, `Sync Bazel toolchain` 10s, `Fetch Bazel LLVM
-toolchain` 32-45s, then `Generate coverage` runs from 11:25 to 12:24:5x and is
-cancelled at the 60-minute timeout. Setup is ~1 minute; 100% of the wasted hour
-is one instrumented build/test step that never finished.
+**Allocation math:** bazel-re1 (96 vcpu) + dev1 (up to 128 vcpu) alone
+overcommit the 128 physical cores ~1.75x before counting gha-host1 and the
+service VMs. So the executor and the dev host structurally compete for the same
+silicon, which is exactly the dev1-vs-CI RE contention the operator flagged.
 
-Capacity (measured, deep-thought via ssh; GitHub runners API):
+### Dominant cost: two contention points on the shared RE path (drives P95/P99)
 
-- deep-thought: 14 cores / 64 GB, Apple silicon, hosts the bazel-re2 NativeLink
-  backend (launchd, `/usr/local/bin/nativelink /opt/mcglynn/bazel-re2/nativelink-config.json5`;
-  config is root-owned and not readable without sudo) plus the single macOS
-  self-hosted runner.
-- Linux self-hosted lanes run on 4 runner slots on host event-horizon
-  (`donner-runner-linux-06..09`, labels self-hosted/ARM64/Linux). These are
-  thin RE clients (`--remote_local_fallback=false`); their build/test actions
-  execute on the shared bazel-re2 backend on deep-thought.
+The three worst post-A PR SHAs decompose as queue 232-270 min + a 30-60 min
+(timeout) exec on a self-hosted lane, e2e 292-307 min. Step-level on the two
+60-min cancellations (runs 29076327250, 29077015684, two different PRs started
+within one second at 11:24:44-45Z): checkout 11s, toolchain sync 10s, LLVM fetch
+32-45s, then `Generate coverage` runs the full 60 min and is cancelled at the
+timeout. Setup is ~1 minute; 100% of the wasted hour is one coverage step that
+never finished.
 
-So peak concurrent RE demand is up to 4 Linux jobs (the `linux-self-hosted` and
-`coverage-self-hosted` lanes across the operator's simultaneously-active PRs)
-against one 14-core backend. Uncontended, an incremental coverage run's
-`Generate coverage` step is ~2.5 min (post-Packet-A median). Two concurrent
-instrumented coverage builds crawl to the 60-minute timeout: a ~20x, superlinear
-blowup consistent with CPU and memory thrash once the 14-core box is
-oversubscribed. The huge queue wait (p95 239-240 min, max 270) is the same
-pathology seen from the front: while all runner slots are held by jobs crawling
-for an hour, later jobs wait hours for a slot. Queue and execution are coupled
-through backend saturation.
+Uncontended, an incremental `coverage-self-hosted` run is ~2.5 min (post-A
+median). Under concurrency it blows up ~20x (superlinear) into the timeout. Two
+contention points compound, neither of them raw executor cores (96 is ample):
+
+1. **Runner-side, gha-host1 8 vcpu.** The coverage lane is not a thin client:
+   `tools/coverage.sh` pulls coverage outputs back and runs the profdata/lcov
+   merge LOCALLY on the runner (the coverage lane does not set
+   `--remote_download_outputs=minimal`, unlike the CI build lane which does).
+   Up to four runners share 8 vcpu on gha-host1, so N concurrent coverage merges
+   get ~8/N vcpu and thrash. LIVE evidence 2026-07-10: with three
+   `coverage-self-hosted` jobs running at once (branches ci/runtime-opt,
+   size/binary-size-pass, editor-v08-ux-polish), a SMOKE-subset
+   (`//donner/base/...`) coverage run sat in `Generate coverage` for 45+ minutes
+   versus its ~2-3 min uncontended cost.
+2. **Executor-side, bazel-re1 shared with dev1.** CI coverage/linux actions and
+   dev1 interactive builds both execute on bazel-re1, whose 96 vcpu overcommit
+   the host against dev1's unlimited allocation. When dev1 (priority) or several
+   CI jobs are active, CI RE actions are descheduled.
+
+The huge queue wait (self-hosted p95 239-240 min, max 270) is the same pathology
+from the front: while runner slots are held by jobs crawling for an hour, later
+jobs wait hours for a slot. Queue and execution are coupled through contention.
 
 The self-hosted lanes are gated on `github.actor == jwmcglynn &&
 github.triggering_actor == jwmcglynn`, so this is the operator's own concurrent
-PRs saturating a shared backend, not third-party load.
+PRs (and dev1) contending, not third-party load.
 
 ### Secondary cost: hosted full //... fallback on infra-file PRs (drives P90)
 
-A cluster of post-A PR SHAs sits at e2e 66-78 min with near-zero queue, exec
-concentrated in the hosted `CI:linux` (66-77 min) or hosted `Co:build` (71 min)
-jobs. These are PRs whose diff touches build-graph infrastructure
-(`MODULE.bazel`, `WORKSPACE*`, `.bazelrc`, `build_defs/*`, `.github/workflows/*`,
-`.github/actions/*`): `determine-targets` correctly forces a full `//...` set,
-the self-hosted lanes skip by design (their gate requires `fallback != 'true'`),
-and the hosted lane runs the entire graph on GitHub's disk cache (cold-ish),
-landing at 60-78 min. About 19% of post-A PR SHAs hit this. It is a separate
-population from the self-hosted tail (those PRs never reach the self-hosted
-lanes) and is largely by design; it matters for P90, not for the P95/P99 gap.
+A cluster of post-A PR SHAs sits at e2e 66-78 min with near-zero queue, exec in
+the hosted `CI:linux` (66-77 min) or hosted `Co:build` (71 min). These are PRs
+touching build-graph infra (`MODULE.bazel`, `WORKSPACE*`, `.bazelrc`,
+`build_defs/*`, `.github/workflows/*`, `.github/actions/*`): `determine-targets`
+correctly forces a full `//...`, the self-hosted lanes skip by design (gate
+requires `fallback != 'true'`), and the hosted lane runs the whole graph on
+GitHub's disk cache. About 19% of post-A PR SHAs. Separate population from the
+self-hosted tail; matters for P90, not the P95/P99 gap.
 
 ### Not significant (ruled out with numbers)
 
-- Checkout / toolchain sync / LLVM fetch on self-hosted: ~1 min total (11s +
-  10s + 32-45s measured). Not a lever.
+- Checkout / toolchain sync / LLVM fetch on self-hosted: ~1 min total (measured
+  11s + 10s + 32-45s). Not a lever.
 - `determine-targets` / `gatekeeper` / `bazel-diff`: ~1 min. Not a lever.
-- Cold caches on the healthy path: Packet A's incremental scoping works;
-  coverage-self-hosted exec median fell 17 -> 2.5 min pre->post Packet A. The
-  problem is not per-run build cost, it is concurrency against a shared backend.
+- Raw executor cores: bazel-re1 has 96 vcpu; the crawl is contention (runner
+  8-vcpu merge + dev1 overcommit), not an undersized executor.
+- Packet A incremental scoping works: coverage-self-hosted exec median fell
+  17 -> 2.5 min pre->post Packet A.
 - macos-self-hosted: exec p95 4.1 min. Healthy; leave unchanged.
 
 ### Ranked levers toward the P95<=15 / P99<=30 goal
 
-1. **Admission control on the self-hosted RE lanes (software, this agent).**
-   Serialize `linux-self-hosted` + `coverage-self-hosted` onto the shared
-   bazel-re2 backend with a GitHub Actions job-level concurrency group so at
-   most one RE-client job farms to the 14-core backend at a time. This removes
-   the superlinear oversubscription that produces the 35-60 min crawls and the
-   60-min timeouts; serialized-but-uncontended runs finish in ~3-8 min. Directly
-   attacks the dominant P95/P99 driver. Predicted, with the caveat that
-   `pull_request` runs the base-branch copy of the workflow, so the change is
-   validated on the first post-merge bursts (ci-times monitor red-count), not on
-   the PR that introduces it. Removes the need for the 60 -> 120 timeout stopgap
-   on the degraded-RE case (fast-fail via `remote_local_fallback=false` +
-   `remote_timeout` still covers a genuinely down endpoint).
-2. **RE backend capacity / runner-to-RE ratio (operator, Packet C).** The
-   software ceiling with lever 1 is one self-hosted RE job at a time; under a
-   burst of K simultaneous operator PRs the Kth still waits ~K x exec. Closing
-   the gap for bursts needs backend capacity: either more bazel-re2 executor
-   cores/host, or fewer runner slots matched to backend capacity, or splitting
-   RE across hosts. Requires the root-owned nativelink config (executor slot
-   count) which this agent cannot read without sudo. Operator action.
-3. **Hosted full //... fallback cost (secondary, P90).** An internal
-   authenticated remote cache for hosted runs (0029-2 Milestone 6) would cut the
-   60-78 min infra-change fallback, but it is a larger change and out of the
-   P95/P99 critical path. Ranked below 1 and 2.
+1. **CI-side admission control on the self-hosted RE lanes (software, this
+   agent; landed as PR #817).** Per-lane GitHub Actions job concurrency groups
+   (`donner-selfhosted-linux-re`, `donner-selfhosted-coverage-re`,
+   `cancel-in-progress: false`) so at most one coverage build and one linux
+   build hit bazel-re1 at a time across all of the operator's in-flight PRs.
+   This removes the superlinear oversubscription that produces the 35-60 min
+   crawls and the 60-min timeouts, and it DIRECTLY serves dev1 priority by
+   bounding CI's demand on the shared bazel-re1. Per-lane (not one shared) group
+   keeps the common two-PR burst free of pending-eviction while making the
+   measured failure (two concurrent coverage builds) impossible. Caveat: for
+   `pull_request`, GitHub runs the base-branch workflow, so this validates on
+   the first post-merge bursts (ci-times monitor red-count), not on the
+   introducing PR.
+2. **Make the coverage lane a thin RE client (software, follow-up).** The
+   coverage merge runs locally on gha-host1's 8 vcpu. Either move the
+   profdata/lcov merge into a bazel-executed (RE) action, or scope
+   `--remote_download_*` so only the merged report returns, keeping gha-host1
+   thin per the Packet C principle. Needs care to preserve the exact Codecov
+   output; not attempted here.
+3. **RE-vs-dev1 capacity rebalance on event-horizon (operator, Packet C;
+   RECOMMEND, do not self-apply while CI is in flight).** The host has 128 cores
+   at ~5-8 load but bazel-re1 (96) and dev1 (unlimited) overcommit it. Options,
+   each reversible via `incus config set` but each requiring a dev1-latency
+   measurement under CI load before/after: (a) give dev1 a guaranteed cpu
+   reservation / higher scheduler weight so its interactive builds always
+   preempt CI on bazel-re1 (encodes dev1 priority in the scheduler instead of by
+   luck); (b) cap bazel-re1 to leave physical-core headroom for dev1; (c) if
+   NativeLink on bazel-re1 supports action priority/queue tiers, give dev1 a
+   higher tier than CI. Requires reading bazel-re1's nativelink config (inside
+   the VM; needs operator access). This is the lever that closes the burst tail
+   once lever 1 caps CI concurrency.
+4. **Hosted full //... fallback cost (secondary, P90).** An internal
+   authenticated remote cache/executor for hosted runs (0029-2 Milestone 6)
+   would cut the 60-78 min infra-change fallback; larger change, off the
+   P95/P99 critical path.
 
 ### Reconciliation with the 60 -> 120 timeout stopgap
 
-The stopgap raised the self-hosted job timeout so contention-slowed runs would
-not cancel. With lever 1 (serialization) the lanes no longer oversubscribe, so
-uncontended exec stays well under 60 min and the raise is unnecessary; the
-timeout can stay at 60 min as a fast-fail bound on a genuinely wedged endpoint,
-matching the 0018 end-state (SLA lanes that fast-fail, not tail for hours).
+With lever 1 the lanes no longer oversubscribe bazel-re1, so uncontended exec
+stays well under 60 min and the raise is unnecessary; the 60 min bound stays as
+a fast-fail on a genuinely wedged endpoint (paired with
+`remote_local_fallback=false`), matching the 0018 end-state.
+
+### Projected P95/P99 after lever 1 (and required for the goal)
+
+- Lever 1 alone converts the superlinear contention blowup into serial,
+  uncontended runs: each self-hosted job returns to ~3-8 min, and a K-PR burst
+  processes serially at ~K x (uncontended). For the observed 2-PR bursts this
+  takes the ~290-307 min tail to roughly 15-25 min, i.e. P95 from 270 min toward
+  ~15-25 min and P99 from 304 min toward ~25-35 min. This is a projection: the
+  base-branch workflow semantics above mean it is confirmed on post-merge
+  traffic, not pre-merge.
+- Reaching P99 <= 30 under heavier bursts, without eroding dev1 priority, needs
+  lever 3 (protect dev1 in the scheduler so CI can safely use more of bazel-re1
+  when dev1 is idle) and/or lever 2 (thin coverage client). Software alone
+  (lever 1) is projected to clear P95 <= 15 for the common case and get P99
+  close to 30; the last margin and the dev1-priority guarantee are operator
+  infra decisions, quantified above.


### PR DESCRIPTION
## What and why

Self-hosted PR CI (`linux-self-hosted`, `coverage-self-hosted`) was hitting the
60 minute job timeout under contention (#808, #809), and the timeout was raised
60 -> 120 as a stopgap. This PR attacks the root cause so the stopgap becomes
unnecessary, and it bounds CI's demand on the shared remote-execution (RE)
backend that an interactive development host with priority also uses.

## Measured RE-backend structure (read-only, 2026-07-10)

The Linux self-hosted lanes execute on a shared remote-execution backend,
reached via the runner bazelrc chain `--config=ci` -> `ci-re` -> the RE
endpoint. The runner-side work (checkout, and the coverage lcov merge) runs on
a runner host with limited cores shared by all the Linux runners. The macOS
lanes use a **separate** macOS remote-execution backend, not the Linux one. An
interactive development host with priority also targets the shared RE backend,
and the backend plus that interactive host are provisioned to overcommit the
underlying shared build host, so CI and interactive development structurally
contend.

The crawl to the 60-min timeout is contention, not undersized executor cores
(the backend is not core-starved): concurrent coverage jobs thrash the runner
host's local merge and the shared RE backend (against interactive development).
Live evidence 2026-07-10: three concurrent `coverage-self-hosted` jobs made a
smoke-subset (`//donner/base/...`) run sit 45+ min in `Generate coverage`
versus ~2-3 min uncontended.

## Measured profile (1001 runs over two weeks; full appendix in `docs/design_docs/0029-2-ci_runtime.md`)

Goal (operator): end-to-end PR wall-clock, trigger to last required check
including queue wait, **P95 <= 15 min, P99 <= 30 min**.

End-to-end per PR, after the #799 PR-lane speedup, n=43 head SHAs:

| metric | value | goal |
|---|---:|---:|
| median | 15.3 min | - |
| p95 | 270.6 min | 15 |
| p99 | 304.0 min | 30 |

The #799 speedup already fixed the median (was 58 min before it); the whole
remaining gap is tail, dominated by self-hosted RE oversubscription (worst SHAs:
queue 232-270
min + a 60-min-timeout exec = e2e 292-307 min).

## Change

Per-lane GitHub Actions **job-level** concurrency groups:

- `linux-self-hosted`: `group: donner-selfhosted-linux-re`, `cancel-in-progress: false`
- `coverage-self-hosted`: `group: donner-selfhosted-coverage-re`, `cancel-in-progress: false`

At most one coverage build and one linux build hit the shared RE backend at a
time across all of the operator's in-flight PRs. Per-lane (not one shared)
groups keep the common two-PR burst free of pending-eviction while making the
measured failure (two concurrent coverage builds) impossible.
`cancel-in-progress: false` never kills a running build. No test, lane, or gate
is touched - pure admission control (speed, not coverage), and it directly
serves interactive-development priority by bounding CI's demand on the shared RE
backend.

## Composition with PR #818 (centralized routing)

#818's concurrency edits are **workflow-level** groups and routing-gate rewrites
(`use_self_hosted_linux/macos`). This PR adds **job-level** groups on the
self-hosted jobs - a different scope that composes (a job carries both its
inherited workflow-level group and its own job-level group). The job-level
serialization is gate-agnostic, so it survives #818's routing rewrite and
extends cleanly to #818's main-push self-hosted routing. Expect a textual
rebase (not a logic conflict) when #818 lands; the two concurrency blocks move
onto the same self-hosted jobs unchanged.

## Predicted effect

Serialization converts the superlinear contention blowup into serial,
uncontended runs (~3-8 min each). For the observed 2-PR bursts this takes the
~290-307 min tail to roughly 15-25 min: P95 from 270 toward ~15-25 min, P99 from
304 toward ~25-35 min. Reaching P99 <= 30 under heavier bursts, without eroding
interactive-development priority, additionally needs the shared-backend capacity rebalance
(protect interactive development in the scheduler; thin the coverage client) -
operator infra, quantified in the 0029-2 appendix.

## Verification note (honest limitation)

For `pull_request` events GitHub runs the workflow file from the **base** branch,
so this concurrency change cannot be A/B measured on the PR that introduces it;
it takes effect on the first post-merge bursts (ci-times monitor >15 min
red-count trending to zero). CI on this PR routes to the hosted
`//...` fallback (workflow-file change) and exercises the non-self-hosted lanes.

## Not addressed here (ranked remaining work)

1. **RE-vs-interactive capacity rebalance on the shared build host (operator).**
   The shared RE backend and the interactive host are provisioned to overcommit
   the shared build host, which runs at low average load; give the interactive
   host a scheduler reservation/priority so it always preempts CI, and cap CI
   concurrency (this PR). Reversible via host config but needs an
   interactive-latency measurement before/after; not self-applied while CI is in
   flight.
2. **Thin the coverage client**: move the lcov merge to an RE action or scope
   `--remote_download_*` so the runner host stays thin.
3. **Hosted full //... fallback** on infra-file PRs (60-78 min, ~19% of PRs):
   secondary P90 driver, off the P95/P99 critical path.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
