### PR TITLE
Optimize CI runner routing

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,11 +7,11 @@ on:
     branches: [main, feature/ci-hardening-2026q2]
 
 # Superseded PR pushes cancel their in-flight CMake run so a rapid push storm
-# does not pile up redundant hosted builds. Push runs stay unique (never
-# cancel each other) via run_id in the group key.
+# does not pile up redundant hosted builds. Non-main branch pushes also cancel
+# stale runs; main pushes stay unique via run_id so every main commit gets CI.
 concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.workflow, github.event.pull_request.number) || format('push-{0}-{1}', github.workflow, github.run_id) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.workflow, github.event.pull_request.number) || (github.ref == 'refs/heads/main' && format('push-{0}-{1}', github.workflow, github.run_id) || format('push-{0}-{1}', github.workflow, github.ref)) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/main') }}
 
 jobs:
   gatekeeper:
@@ -126,10 +126,12 @@ jobs:
       - name: Install build tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y ccache ninja-build
+          sudo apt-get install -y --no-install-recommends ccache ninja-build
           if [[ "${{ matrix.backend }}" == "skia" ]]; then
-            sudo apt-get install -y pkg-config libfontconfig1-dev libfreetype6-dev
+            sudo apt-get install -y --no-install-recommends \
+              pkg-config libfontconfig1-dev libfreetype6-dev
           fi
+          sudo apt-get clean
 
       # Cache key includes both gen_cmakelists.py AND MODULE.bazel because the
       # generated CMakeLists.txt embeds FetchContent versions extracted from

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,6 +31,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.workflow, github.event.pull_request.number) || format('push-{0}-{1}', github.workflow, github.run_id) }}
@@ -44,10 +45,10 @@ concurrency:
 # runner or seeing the Codecov secret there. Everyone else stays on hosted
 # Ubuntu.
 #
-# Main coverage stays GitHub-hosted. PR coverage uses the self-hosted lane
-# only when the trusted runner gate passes; hosted Ubuntu remains the PR
-# fallback for untrusted actors, unavailable self-hosted runners, and
-# `ci:full-test` fanout runs.
+# Trusted operator PRs and main pushes generate coverage on the self-hosted
+# runner when SELFHOSTED_LINUX_RUNNER is enabled. Renovate and non-operator
+# diffs stay on hosted Ubuntu. The Codecov upload remains a tiny hosted handoff
+# for self-hosted coverage so the Codecov secret is not exposed to the runner.
 jobs:
   determine-targets:
     runs-on: ubuntu-24.04
@@ -63,6 +64,7 @@ jobs:
       target_count: ${{ steps.determine.outputs.target_count }}
       large_change: ${{ steps.determine.outputs.large_change }}
       changed_file_count: ${{ steps.determine.outputs.changed_file_count }}
+      use_self_hosted_linux: ${{ steps.determine.outputs.use_self_hosted_linux }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -108,6 +110,15 @@ jobs:
       - id: determine
         name: Determine coverage targets
         shell: bash
+        env:
+          ACTOR: ${{ github.actor }}
+          EVENT_NAME: ${{ github.event_name }}
+          GH_TOKEN: ${{ github.token }}
+          REF: ${{ github.ref }}
+          REPOSITORY: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+          SELFHOSTED_LINUX_RUNNER: ${{ vars.SELFHOSTED_LINUX_RUNNER }}
         run: |
           set -euo pipefail
           SELF_HOSTED_MAX_CHANGED_FILES=75
@@ -116,6 +127,67 @@ jobs:
 
           diagnostics_dir="$RUNNER_TEMP/coverage-target-selection"
           mkdir -p "$diagnostics_dir"
+
+          is_renovate="$(
+            python3 - <<'PY'
+          import json
+          import os
+
+          event = json.load(open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8"))
+          paths = [
+              ("sender", "login"),
+              ("pull_request", "user", "login"),
+              ("head_commit", "author", "username"),
+              ("head_commit", "author", "name"),
+              ("head_commit", "author", "email"),
+              ("head_commit", "committer", "username"),
+              ("head_commit", "committer", "name"),
+              ("head_commit", "committer", "email"),
+              ("pusher", "name"),
+              ("pusher", "email"),
+          ]
+
+          values = []
+          for path in paths:
+              value = event
+              for key in path:
+                  if not isinstance(value, dict):
+                      value = None
+                      break
+                  value = value.get(key)
+              if value:
+                  values.append(str(value))
+
+          print("true" if any("renovate" in value.lower() for value in values) else "false")
+          PY
+          )"
+
+          pr_author="$(
+            python3 - <<'PY'
+          import json
+          import os
+
+          event = json.load(open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8"))
+          print(event.get("pull_request", {}).get("user", {}).get("login", ""))
+          PY
+          )"
+
+          if [[ -z "$pr_author" && "$EVENT_NAME" == "push" && "$REF" == "refs/heads/main" ]]; then
+            if ! pr_author="$(gh api -H "Accept: application/vnd.github+json" \
+              "/repos/$REPOSITORY/commits/$SHA/pulls" \
+              --jq '.[0].user.login // ""')"; then
+              pr_author="unknown"
+            fi
+          fi
+
+          use_self_hosted_linux=false
+          if [[ "$ACTOR" == "jwmcglynn" && "$TRIGGERING_ACTOR" == "jwmcglynn" && "$is_renovate" != "true" && "$SELFHOSTED_LINUX_RUNNER" == "true" ]]; then
+            if [[ -z "$pr_author" || "$pr_author" == "jwmcglynn" ]]; then
+              use_self_hosted_linux=true
+            fi
+          fi
+          echo "use_self_hosted_linux=$use_self_hosted_linux" >> "$GITHUB_OUTPUT"
+          echo "coverage_runner=self_hosted_linux:$use_self_hosted_linux renovate:$is_renovate pr_author:$pr_author"
 
           emit_targets() {
             local fallback="$1"
@@ -304,14 +376,14 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     needs: determine-targets
-    # Hosted PR coverage fallback (broad PRs, untrusted actors, self-hosted
-    # unavailable, or ci:full-test fanout). On PRs it runs ONLY when the target
-    # set is a genuine incremental subset (fallback == false => bazel_diff),
-    # the cheap smoke subset, or an explicit ci:full-test opt-in. A full //...
-    # fallback on a PR (infra change, bazel-diff failure, empty diff) is SKIPPED
-    # here because the main-push baseline covers those lines under the 15-minute
-    # PR budget.
-    if: ${{ github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && (needs.determine-targets.outputs.fallback == 'false' || needs.determine-targets.outputs.fallback_reason == 'coverage_smoke' || needs.determine-targets.outputs.fallback_reason == 'full_test_label') && (needs.determine-targets.outputs.large_change == 'true' || needs.determine-targets.outputs.fallback_reason == 'full_test_label' || vars.SELFHOSTED_LINUX_RUNNER != 'true' || github.actor != 'jwmcglynn' || github.triggering_actor != 'jwmcglynn')) }}
+    # Hosted PR coverage fallback (large-change PRs, untrusted actors,
+    # self-hosted unavailable, or ci:full-test fanout). On PRs it runs ONLY when
+    # the target set is a genuine incremental subset (fallback == false =>
+    # bazel_diff), the cheap smoke subset, or an explicit ci:full-test opt-in. A
+    # full //... fallback on a PR (infra change, bazel-diff failure, empty diff)
+    # is SKIPPED here -- the main-push baseline covers those lines under the
+    # 15-minute PR budget.
+    if: ${{ (needs.determine-targets.outputs.use_self_hosted_linux != 'true' || needs.determine-targets.outputs.large_change == 'true') && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && (needs.determine-targets.outputs.fallback == 'false' || needs.determine-targets.outputs.fallback_reason == 'coverage_smoke' || needs.determine-targets.outputs.fallback_reason == 'full_test_label'))) }}
 
     steps:
       - uses: actions/checkout@v7
@@ -360,7 +432,8 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libncurses-dev pkg-config libfontconfig1-dev libfreetype6-dev \
+          sudo apt-get install -y --no-install-recommends \
+            libncurses-dev pkg-config libfontconfig1-dev libfreetype6-dev \
             mesa-vulkan-drivers libvulkan1 libvulkan-dev \
             libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
             libgl1-mesa-dev libosmesa6-dev
@@ -404,28 +477,25 @@ jobs:
   coverage-self-hosted:
     runs-on: [self-hosted, linux, arm64]
     needs: determine-targets
-    # Only the incremental (bazel_diff) subset or the cheap smoke subset run
-    # here. A full //... fallback is skipped on PRs (main-push baseline covers
-    # it); ci:full-test routes to the hosted `build` job. See header.
-    if: ${{ github.event_name == 'pull_request' && (needs.determine-targets.outputs.fallback == 'false' || needs.determine-targets.outputs.fallback_reason == 'coverage_smoke') && needs.determine-targets.outputs.large_change != 'true' && vars.SELFHOSTED_LINUX_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
+    # here on PRs, plus explicit ci:full-test opt-ins. A full //... fallback is
+    # skipped on PRs (main-push baseline covers it). Trusted main pushes run
+    # here instead of hosted Ubuntu. Large-change PRs (over the changed-file
+    # cap) stay on the hosted coverage lane.
+    if: ${{ needs.determine-targets.outputs.use_self_hosted_linux == 'true' && needs.determine-targets.outputs.large_change != 'true' && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && (needs.determine-targets.outputs.fallback == 'false' || needs.determine-targets.outputs.fallback_reason == 'coverage_smoke' || needs.determine-targets.outputs.fallback_reason == 'full_test_label'))) }}
     # Coverage healthy median is ~21 min, so bound this SLA lane at 60 min for
     # buffer: RE degradation fast-fails (no local fallback, below) instead of
     # the CPU-capped 2-3 h local re-run that produced the 3.3 h tail.
     timeout-minutes: 60
-    # Admission control on the shared RE path. TWO concurrent instrumented
-    # coverage builds were the measured failure that hit the 60 min timeout on
-    # #808/#809. The coverage lane merges lcov LOCALLY on gha-host1 (8 vcpu
-    # shared by four runners) and executes actions on bazel-re1 (96-vcpu VM on
-    # event-horizon, shared with the priority dev host dev1); N concurrent
-    # coverage jobs thrash both (uncontended median 2.5 min; two concurrent =
-    # 60 min timeout; live 2026-07-10 a smoke subset sat 45+ min under 3-way
-    # contention). See docs/design_docs/0029-2-ci_runtime.md appendix. This
-    # group serializes coverage-self-hosted across all of the operator's
-    # in-flight PRs so at most one instrumented coverage build runs at a time,
-    # which also protects dev1's bazel-re1 latency; the CI linux-self-hosted
-    # lane uses a separate group. cancel-in-progress: false never kills a
-    # running build (a superseded push to the SAME PR is already cancelled by
-    # the workflow-level group).
+    # Admission control on the shared remote-execution backend. Two concurrent
+    # instrumented coverage builds were the measured failure that hit the
+    # timeout: both self-hosted lanes execute on a shared remote-execution
+    # backend that an interactive development host also uses with priority, so
+    # two-plus concurrent instrumented builds oversubscribe it and crawl into
+    # the timeout (measured). This group serializes coverage-self-hosted across
+    # all of the operator's in-flight PRs so at most one instrumented coverage
+    # build runs at a time; the CI linux-self-hosted lane uses a separate group.
+    # cancel-in-progress: false never kills a running build (a superseded push
+    # to the SAME PR is already cancelled by the workflow-level group).
     concurrency:
       group: donner-selfhosted-coverage-re
       cancel-in-progress: false
@@ -531,8 +601,9 @@ jobs:
     needs: [determine-targets, coverage-self-hosted]
     runs-on: ubuntu-24.04
     # Mirrors coverage-self-hosted's gate so the upload skips whenever the
-    # self-hosted coverage job skips (full-fallback PRs produce no artifact).
-    if: ${{ github.event_name == 'pull_request' && (needs.determine-targets.outputs.fallback == 'false' || needs.determine-targets.outputs.fallback_reason == 'coverage_smoke') && needs.determine-targets.outputs.large_change != 'true' && vars.SELFHOSTED_LINUX_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
+    # self-hosted coverage job skips or fails (large-change and full-fallback
+    # PRs produce no artifact).
+    if: ${{ needs.coverage-self-hosted.result == 'success' }}
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -26,6 +26,10 @@ on:
       - "build_defs/rules.bzl"
       - ".github/workflows/fuzz.yml"
 
+concurrency:
+  group: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.workflow, github.event.pull_request.number) || format('run-{0}-{1}', github.workflow, github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   linux:
     runs-on: ubuntu-24.04

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,8 +7,8 @@ on:
     branches: [main, feature/ci-hardening-2026q2]
 
 concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.workflow, github.event.pull_request.number) || format('push-{0}-{1}', github.workflow, github.run_id) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.workflow, github.event.pull_request.number) || (github.ref == 'refs/heads/main' && format('push-{0}-{1}', github.workflow, github.run_id) || format('push-{0}-{1}', github.workflow, github.ref)) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/main') }}
 
 # Fast lint jobs covering checks that don't live inside `bazel test //...`:
 #

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -496,6 +496,54 @@ jobs:
           bazelisk test --config=ci --test_output=errors \
             $TARGETS
 
+      - name: Upload Bazel test failure artifacts
+        if: failure() && steps.test.outcome == 'failure'
+        uses: ./.github/actions/upload-bazel-test-artifacts
+        with:
+          name: bazel-test-failure-${{ github.job }}-${{ runner.os }}-${{ runner.arch }}
+
+
+  # Non-lld linker canary, split into its own always-on hosted job so it runs
+  # regardless of Linux runner routing. The hosted `linux` lane is suppressed
+  # for small operator PRs when self-hosted routing is active, and the
+  # self-hosted lane's hermetic LLVM toolchain ships lld (not gold), so the gold
+  # canary has no home there. Keeping it on a dedicated ubuntu-24.04 job runs it
+  # on the runner that actually has gold and preserves coverage on every
+  # non-docs PR and main push. It shares the `linux` lane's Bazel disk-cache key
+  # so the compile actions are warm cache hits and only the final gold relink is
+  # new; this is a link-only check on a fixed minimal target set. See #665.
+  linker-canary:
+    runs-on: ubuntu-24.04
+    needs: [gatekeeper]
+    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install system dependencies
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends \
+              pkg-config libfontconfig1-dev libfreetype6-dev \
+              mesa-vulkan-drivers libvulkan1 libvulkan-dev \
+              libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
+              libgl1-mesa-dev libosmesa6 clang-tidy-19
+            sudo apt-get clean
+
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-${{ runner.os }}-default
+          repository-cache: true
+          external-cache: true
+          cache-save: ${{ github.ref == 'refs/heads/main' }}
+
       # Forces a single-pass linker (gold) so a diamond-dependency archive that
       # loses its alwayslink (or a new one that needs it) is caught immediately
       # instead of only surfacing on a dev box whose default linker isn't lld.
@@ -507,12 +555,6 @@ jobs:
           bazelisk build --config=ci --linkopt=-fuse-ld=gold \
             //donner/svg/tool:donner-svg \
             //donner/svg/renderer/tests:filter_graph_executor_tests
-
-      - name: Upload Bazel test failure artifacts
-        if: failure() && steps.test.outcome == 'failure'
-        uses: ./.github/actions/upload-bazel-test-artifacts
-        with:
-          name: bazel-test-failure-${{ github.job }}-${{ runner.os }}-${{ runner.arch }}
 
 
   # Operator's ARM64 Linux runs on the operator's self-hosted runner.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,8 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.workflow, github.event.pull_request.number) || format('push-{0}-{1}', github.workflow, github.run_id) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.workflow, github.event.pull_request.number) || (github.ref == 'refs/heads/main' && format('push-{0}-{1}', github.workflow, github.run_id) || format('push-{0}-{1}', github.workflow, github.ref)) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/main') }}
 
 permissions:
   contents: read
@@ -21,19 +21,14 @@ permissions:
 # are NOT retried -- a real test failure should surface immediately.
 
 # Self-hosted runner gates (repo Settings -> Variables). Setting
-# SELFHOSTED_LINUX_RUNNER / SELFHOSTED_MACOS_RUNNER to "true" routes the
-# operator's own matching OS lane onto the homelab ARM64 runner and skips the
-# matching GitHub-hosted lane; everyone else stays GitHub-hosted. Gated on BOTH
-# github.actor and github.triggering_actor == jwmcglynn so that no collaborator
-# push -- and no rerun of the operator's run by someone else -- can execute on
-# the runner or poison the shared LAN Bazel cache. Unset is a no-op: behavior
-# is identical to the GitHub-hosted-only workflow.
-#
-# Main CI stays GitHub-hosted so a stuck/offline self-hosted runner can never
-# hang main's required check. PR CI uses the self-hosted lane only for trusted
-# partial-target runs; hosted runners remain the PR fallback for untrusted
-# actors, unavailable self-hosted runners, fallback //... runs, and
-# `ci:full-test` fanout runs. Other branch refs do not run build/test jobs.
+# SELFHOSTED_LINUX_RUNNER / SELFHOSTED_MACOS_RUNNER to "true" routes trusted
+# operator PRs and main pushes onto the matching self-hosted ARM64 runner and
+# skips the matching GitHub-hosted lane. Renovate and non-operator diffs stay
+# GitHub-hosted. Gated on BOTH github.actor and github.triggering_actor ==
+# jwmcglynn so that no collaborator push -- and no rerun of the operator's run
+# by someone else -- can execute on the runner or poison the shared LAN Bazel
+# cache. Unset is a no-op: behavior is identical to the GitHub-hosted-only
+# workflow.
 
 jobs:
   gatekeeper:
@@ -41,6 +36,8 @@ jobs:
     outputs:
       docs_only: ${{ steps.docs_only.outputs.docs_only }}
       is_duplicate_push: ${{ steps.dup_push.outputs.is_duplicate_push }}
+      use_self_hosted_linux: ${{ steps.runner_gate.outputs.use_self_hosted_linux }}
+      use_self_hosted_macos: ${{ steps.runner_gate.outputs.use_self_hosted_macos }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -123,6 +120,94 @@ jobs:
           done <<< "$changed_files"
 
           echo "docs_only=${docs_only}" >> "$GITHUB_OUTPUT"
+
+      - id: runner_gate
+        name: Determine trusted self-hosted runner routing
+        env:
+          ACTOR: ${{ github.actor }}
+          EVENT_NAME: ${{ github.event_name }}
+          GH_TOKEN: ${{ github.token }}
+          REF: ${{ github.ref }}
+          REPOSITORY: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+          SELFHOSTED_LINUX_RUNNER: ${{ vars.SELFHOSTED_LINUX_RUNNER }}
+          SELFHOSTED_MACOS_RUNNER: ${{ vars.SELFHOSTED_MACOS_RUNNER }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          is_renovate="$(
+            python3 - <<'PY'
+          import json
+          import os
+
+          event = json.load(open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8"))
+          paths = [
+              ("sender", "login"),
+              ("pull_request", "user", "login"),
+              ("head_commit", "author", "username"),
+              ("head_commit", "author", "name"),
+              ("head_commit", "author", "email"),
+              ("head_commit", "committer", "username"),
+              ("head_commit", "committer", "name"),
+              ("head_commit", "committer", "email"),
+              ("pusher", "name"),
+              ("pusher", "email"),
+          ]
+
+          values = []
+          for path in paths:
+              value = event
+              for key in path:
+                  if not isinstance(value, dict):
+                      value = None
+                      break
+                  value = value.get(key)
+              if value:
+                  values.append(str(value))
+
+          print("true" if any("renovate" in value.lower() for value in values) else "false")
+          PY
+          )"
+
+          pr_author="$(
+            python3 - <<'PY'
+          import json
+          import os
+
+          event = json.load(open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8"))
+          print(event.get("pull_request", {}).get("user", {}).get("login", ""))
+          PY
+          )"
+
+          if [[ -z "$pr_author" && "$EVENT_NAME" == "push" && "$REF" == "refs/heads/main" ]]; then
+            if ! pr_author="$(gh api -H "Accept: application/vnd.github+json" \
+              "/repos/$REPOSITORY/commits/$SHA/pulls" \
+              --jq '.[0].user.login // ""')"; then
+              pr_author="unknown"
+            fi
+          fi
+
+          trusted_operator=false
+          if [[ "$ACTOR" == "jwmcglynn" && "$TRIGGERING_ACTOR" == "jwmcglynn" && "$is_renovate" != "true" ]]; then
+            if [[ -z "$pr_author" || "$pr_author" == "jwmcglynn" ]]; then
+              trusted_operator=true
+            fi
+          fi
+
+          use_linux=false
+          use_macos=false
+          if [[ "$trusted_operator" == "true" && "$SELFHOSTED_LINUX_RUNNER" == "true" ]]; then
+            use_linux=true
+          fi
+          if [[ "$trusted_operator" == "true" && "$SELFHOSTED_MACOS_RUNNER" == "true" ]]; then
+            use_macos=true
+          fi
+
+          echo "use_self_hosted_linux=$use_linux" >> "$GITHUB_OUTPUT"
+          echo "use_self_hosted_macos=$use_macos" >> "$GITHUB_OUTPUT"
+          echo "trusted_operator=$trusted_operator renovate=$is_renovate pr_author=$pr_author linux=$use_linux macos=$use_macos"
 
   determine-targets:
     runs-on: ubuntu-24.04
@@ -358,7 +443,7 @@ jobs:
     # required Linux path canceled.
     runs-on: ubuntu-24.04
     needs: [gatekeeper, determine-targets]
-    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && (needs.determine-targets.outputs.fallback == 'true' || needs.determine-targets.outputs.full_test == 'true' || needs.determine-targets.outputs.large_change == 'true' || vars.SELFHOSTED_LINUX_RUNNER != 'true' || github.actor != 'jwmcglynn' || github.triggering_actor != 'jwmcglynn'))) && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') }}
+    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') && (needs.gatekeeper.outputs.use_self_hosted_linux != 'true' || needs.determine-targets.outputs.large_change == 'true') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -371,10 +456,12 @@ jobs:
           retry_wait_seconds: 15
           command: |
             sudo apt-get update
-            sudo apt-get install -y pkg-config libfontconfig1-dev libfreetype6-dev \
+            sudo apt-get install -y --no-install-recommends \
+              pkg-config libfontconfig1-dev libfreetype6-dev \
               mesa-vulkan-drivers libvulkan1 libvulkan-dev \
               libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
               libgl1-mesa-dev libosmesa6 clang-tidy-19
+            sudo apt-get clean
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0
@@ -429,10 +516,9 @@ jobs:
 
 
   # Operator's ARM64 Linux runs on the operator's self-hosted runner.
-  # Replaces `linux` for small trusted partial-target operator runs (extra arch
-  # coverage + homelab cache). Full fallback and broad PR runs stay on hosted
-  # Linux because the self-hosted lane is tuned for narrow affected-target
-  # checks.
+  # Replaces `linux` for trusted operator PRs and main pushes (extra arch
+  # coverage + homelab cache). Renovate and non-operator runs stay hosted.
+  # Large-change PRs (over the changed-file cap) stay on hosted Linux.
   # The NixOS host pre-provisions the toolchain (fontconfig, freetype, mesa,
   # vulkan, X11, clang-tidy) and writes bazel-cache1 over LAN gRPC, so there
   # is no apt/setup-bazel step. The runner intentionally has no host GPU
@@ -442,27 +528,24 @@ jobs:
   linux-self-hosted:
     runs-on: [self-hosted, linux, arm64]
     needs: [gatekeeper, determine-targets]
-    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && github.event_name == 'pull_request' && needs.gatekeeper.outputs.docs_only != 'true' && needs.determine-targets.outputs.fallback != 'true' && needs.determine-targets.outputs.large_change != 'true' && vars.SELFHOSTED_LINUX_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
+    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') && needs.gatekeeper.outputs.use_self_hosted_linux == 'true' && needs.determine-targets.outputs.large_change != 'true' }}
     # RE-availability SLA lane. A healthy affected-target run is ~21 min; bound
     # it at 60 min for buffer while a wedged/degraded RE endpoint still
     # fast-fails instead of silently tailing for hours.
     timeout-minutes: 60
-    # Admission control on the shared RE path. The Linux self-hosted lanes
-    # execute on bazel-re1 (a 96-vcpu Incus VM on event-horizon, reached via the
-    # runner bazelrc --config=ci -> ci-re -> remote_executor=bazel-re1:50051),
-    # which the priority dev host dev1 also uses; the runner-side work runs on
-    # gha-host1 (8 vcpu shared by all four runners). Two-plus concurrent operator
-    # PRs oversubscribe that path ~20x and crawl into the 60 min timeout (measured
-    # 2026-07-10; see docs/design_docs/0029-2-ci_runtime.md appendix). This
+    # Admission control on the shared remote-execution backend. Both self-hosted
+    # lanes execute on a shared remote-execution backend that an interactive
+    # development host also uses with priority; two-plus concurrent operator PRs
+    # oversubscribe it and crawl into the 60 min timeout (measured). This
     # per-lane group serializes linux-self-hosted across all of the operator's
     # in-flight PRs so at most one runs at a time; the sibling
     # coverage-self-hosted lane has its own group, so a Linux build and a
     # coverage build may overlap but two of the same heavy lane never do.
-    # Bounding CI's demand on bazel-re1 also protects dev1's interactive
+    # Bounding CI's demand on the backend also protects the interactive host's
     # latency. cancel-in-progress: false never kills a running build (a
     # superseded push to the SAME PR is already cancelled by the workflow-level
     # concurrency group). This job-level group composes with the workflow-level
-    # group and with the centralized routing in PR #818 (it is gate-agnostic).
+    # group and with the centralized routing (it is gate-agnostic).
     concurrency:
       group: donner-selfhosted-linux-re
       cancel-in-progress: false
@@ -478,8 +561,8 @@ jobs:
       # SSH. Keep artifacts small; retention is 3 days. DIAG_DIR is exported
       # from the first step ($RUNNER_TEMP; the `runner` context is not
       # available in job-level env).
-      # Build without the Bytes: the runner microvm is a thin RE client on a
-      # CPU-capped host. Downloading every toplevel output (unstripped ARM64
+      # Build without the Bytes: the runner is a thin remote-execution client on
+      # a CPU-capped host. Downloading every toplevel output (unstripped ARM64
       # test binaries) added minutes of pure transfer per run. Tests execute
       # remotely, so only test logs/XML need to come back.
       DIAG_BUILD_FLAGS: "--remote_download_outputs=minimal"
@@ -672,7 +755,7 @@ jobs:
   macos:
     runs-on: macos-26
     needs: [gatekeeper, determine-targets]
-    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && (needs.determine-targets.outputs.fallback == 'true' || needs.determine-targets.outputs.full_test == 'true' || vars.SELFHOSTED_MACOS_RUNNER != 'true' || github.actor != 'jwmcglynn' || github.triggering_actor != 'jwmcglynn'))) && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') }}
+    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') && needs.gatekeeper.outputs.use_self_hosted_macos != 'true' }}
     env:
       # Xcode's libc++ marks std::format floating-point support as macOS 13.3+.
       # Set the CI deployment target explicitly so hosted and self-hosted macOS
@@ -739,13 +822,13 @@ jobs:
 
 
   # Operator's ARM64 macOS runs on the operator's self-hosted runner.
-  # Replaces `macos` for trusted partial-target operator runs. Full fallback
-  # runs stay on hosted macOS. The host pre-provisions Bazelisk, Homebrew
+  # Replaces `macos` for trusted operator PRs and main pushes. Renovate and
+  # non-operator runs stay hosted. The host pre-provisions Bazelisk, Homebrew
   # llvm@19, and Xcode Command Line Tools.
   macos-self-hosted:
     runs-on: [self-hosted, macOS, ARM64]
     needs: [gatekeeper, determine-targets]
-    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && github.event_name == 'pull_request' && needs.gatekeeper.outputs.docs_only != 'true' && needs.determine-targets.outputs.fallback != 'true' && vars.SELFHOSTED_MACOS_RUNNER == 'true' && github.actor == 'jwmcglynn' && github.triggering_actor == 'jwmcglynn' }}
+    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') && needs.gatekeeper.outputs.use_self_hosted_macos == 'true' }}
     # RE-availability SLA lane. Bound at 60 min so healthy affected-target
     # runs have buffer while RE degradation still fast-fails instead of tailing
     # for hours on the capped host.

--- a/.github/workflows/sanitizers-pr.yml
+++ b/.github/workflows/sanitizers-pr.yml
@@ -41,10 +41,12 @@ jobs:
           retry_wait_seconds: 15
           command: |
             sudo apt-get update
-            sudo apt-get install -y pkg-config libfontconfig1-dev libfreetype6-dev \
+            sudo apt-get install -y --no-install-recommends \
+              pkg-config libfontconfig1-dev libfreetype6-dev \
               mesa-vulkan-drivers libvulkan1 libvulkan-dev \
               libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
               libgl1-mesa-dev clang-tidy-19
+            sudo apt-get clean
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0


### PR DESCRIPTION
Centralizes self-hosted runner routing across the CI workflows so the hosted and self-hosted lanes are mutually exclusive per run and the routing decision is computed once instead of repeated inline.

- A single "Determine trusted self-hosted runner routing" step computes `use_self_hosted_linux` / `use_self_hosted_macos`; job `if:` conditions consume that output instead of duplicating the `vars.SELFHOSTED_*_RUNNER` + actor checks in five places.
- Self-hosted routing now also applies to main pushes and the `full_test_label` fallback case, not only actor-triggered PRs; the hosted twin runs exactly when the self-hosted lane does not.
- Coverage upload gates on `coverage-self-hosted` succeeding rather than re-deriving the routing condition.
- Concurrency hygiene: `fuzz.yml` gains a concurrency group, and non-main push groups now key by ref instead of run id so repeated pushes to the same branch supersede.

Part of the CI runtime effort toward P95 <= 15 min / P99 <= 30 min end-to-end (design doc `0029-2_ci_runtime.md`); complements the self-hosted lane serialization in #817. Branch tip is exactly 913a678fd4b2739e763fbf96f999c0344945f813.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
