### PR TITLE
Skip PR coverage when no instrumentable C/C++ is affected

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,18 @@ name: Coverage
 # the 21-min re-run we are eliminating, so the PR coverage jobs SKIP instead --
 # the main-push baseline already covers those lines. Only the affected subset
 # (fallback_reason == bazel_diff), the cheap smoke subset (coverage_smoke), and
-# the explicit ci:full-test opt-in still produce PR coverage. Future readers:
+# the explicit ci:full-test opt-in still produce PR coverage.
+#
+# One more skip: a genuine incremental subset whose affected targets contain
+# NO instrumentable C/C++ (docs-only, shell/python tooling, filegroup/flag-only
+# changes) also SKIPs the coverage lane. Building coverage over such a subset
+# yields an empty LCOV report and trips check_lcov_report.py's "no executable
+# line data" guard -- a deterministic red no rerun can clear. That subset is
+# detected from target KINDS via a bazel query over the affected set
+# (fallback_reason == no_instrumentable_targets), never from file extensions,
+# and the detection fails closed: any query/classifier error or unrecognized
+# rule kind runs coverage with the guard intact. A subset that DOES touch
+# instrumentable code keeps the guard at full strength. Future readers:
 # do not silently re-add a full instrumented PR coverage run.
 on:
   push:
@@ -195,7 +206,7 @@ jobs:
             esac
 
             case "$path" in
-              .bazelrc|.github/workflows/*|.github/actions/*|docs/*|*.md|tools/binary_size.sh|tools/build_docs.sh|tools/coverage.sh|tools/filter_coverage.py|tools/filter_coverage_tests.py|tools/lcov_metrics.py|tools/lcov_metrics_tests.py|tools/generate_build_report.py|tools/generate_build_report_tests.py)
+              .bazelrc|.github/workflows/*|.github/actions/*|docs/*|*.md|tools/binary_size.sh|tools/build_docs.sh|tools/coverage.sh|tools/filter_coverage.py|tools/filter_coverage_tests.py|tools/lcov_metrics.py|tools/lcov_metrics_tests.py|tools/generate_build_report.py|tools/generate_build_report_tests.py|tools/coverage_instrumentable_targets.py|tools/coverage_instrumentable_targets_tests.py)
                 ;;
               *)
                 smoke_only=false
@@ -288,6 +299,38 @@ jobs:
             echo "bazel-diff produced no affected targets; using full coverage target set."
             emit_targets true no_affected_targets "$FULL_COVERAGE_TARGETS"
             exit 0
+          fi
+
+          # Instrumentability gate. A genuine incremental subset that contains
+          # zero instrumentable C/C++ targets (docs-only, shell/python tooling,
+          # filegroup/flag-only changes) would build an empty LCOV report and
+          # trip check_lcov_report.py's "no executable line data" guard -- a
+          # deterministic red no rerun can clear. Decide from target KINDS via a
+          # bazel query over the affected set (not file-extension heuristics) and
+          # skip only when nothing instrumentable is affected. Fail closed: any
+          # query/classifier error, or any unrecognized rule kind, keeps the
+          # guard by running the bazel_diff subset as before.
+          kind_query_file="$work_dir/affected-query.txt"
+          { printf 'set('; tr '\n' ' ' < "$work_dir/affected.txt"; printf ')\n'; } > "$kind_query_file"
+          label_kind_file="$work_dir/affected-label-kind.txt"
+          if ( cd "$head_dir" && bazelisk query --query_file="$kind_query_file" \
+              --output label_kind --keep_going ) > "$label_kind_file" 2> "$diagnostics_dir/kind-query.log"; then
+            cp "$label_kind_file" "$diagnostics_dir/affected-label-kind.txt"
+            if instrumentable_decision="$(python3 tools/coverage_instrumentable_targets.py \
+                --label-kind-file "$label_kind_file" 2> "$diagnostics_dir/instrumentability.log")"; then
+              cat "$diagnostics_dir/instrumentability.log" || true
+              if [[ "$instrumentable_decision" == "instrumentable_present=false" ]]; then
+                echo "Affected subset has no instrumentable C/C++ targets; skipping PR coverage."
+                emit_targets true no_instrumentable_targets ""
+                exit 0
+              fi
+              echo "Affected subset includes instrumentable C/C++ targets; running coverage."
+            else
+              echo "Instrumentability classifier errored; running coverage on affected subset (guard intact)."
+            fi
+          else
+            echo "Kind query failed; running coverage on affected subset (guard intact)."
+            cat "$diagnostics_dir/kind-query.log" || true
           fi
 
           emit_targets false bazel_diff "$affected"

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -74,6 +74,14 @@ py_test(
 )
 
 py_test(
+    name = "coverage_instrumentable_targets_tests",
+    srcs = [
+        "coverage_instrumentable_targets.py",
+        "coverage_instrumentable_targets_tests.py",
+    ],
+)
+
+py_test(
     name = "filter_coverage_tests",
     srcs = [
         "filter_coverage.py",

--- a/tools/coverage_instrumentable_targets.py
+++ b/tools/coverage_instrumentable_targets.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Decide whether an affected-target set contains instrumentable C/C++ code.
+
+Reads the output of `bazel query --output label_kind` for the affected-target
+set (as produced by the coverage lane's bazel-diff step) and reports whether any
+affected target is an instrumentable C/C++ compilation unit.
+
+The coverage lane uses this to skip PR coverage when a change's affected targets
+are all non-instrumentable (docs, shell/python tooling, filegroups, build
+flags), which would otherwise produce an empty LCOV report and trip the
+"no executable line data" guard in check_lcov_report.py with a deterministic red
+that no rerun can clear.
+
+Fail-closed contract: the decision is `instrumentable_present=true` unless EVERY
+classified target is a recognized, definitely-non-instrumentable kind. Any rule
+kind outside the non-instrumentable allowlist (every cc_* kind, the donner C++
+wrapper rules, and any kind this tool does not recognize) counts as
+instrumentable, so an unknown or newly-added C++ rule keeps the coverage guard at
+full strength rather than silently skipping it.
+"""
+
+import argparse
+from dataclasses import dataclass, field
+from pathlib import Path
+import sys
+
+# Rule kinds that never contribute C/C++ line coverage. Skipping coverage is
+# only allowed when the affected set consists ENTIRELY of these. Keep this list
+# conservative: never add a kind that compiles or wraps C/C++, because a false
+# entry here would silently disable the empty-report guard for real code.
+NON_INSTRUMENTABLE_RULE_KINDS = frozenset(
+    {
+        # Python / shell / other-language rules.
+        "py_test",
+        "py_binary",
+        "py_library",
+        "sh_test",
+        "sh_binary",
+        "sh_library",
+        "java_library",
+        "java_binary",
+        "java_test",
+        "proto_library",
+        # Grouping / aliasing / query rules (no compilation of their own).
+        "filegroup",
+        "genrule",
+        "genquery",
+        "alias",
+        "test_suite",
+        "serve_http",
+        # Configuration, flags, and platform/toolchain declarations.
+        "config_setting",
+        "bool_flag",
+        "int_flag",
+        "string_flag",
+        "label_flag",
+        "label_setting",
+        "platform",
+        "constraint_setting",
+        "constraint_value",
+        "toolchain",
+        "toolchain_type",
+        # Internal helper rules that emit files but no instrumented objects.
+        "_expand_template",
+        "_check_python_version",
+    }
+)
+
+# `bazel query --output label_kind` phrases for non-rule targets. These never
+# carry coverage either.
+NON_RULE_PHRASES = frozenset(
+    {
+        "source file",
+        "generated file",
+        "package group",
+        "environment group",
+    }
+)
+
+
+@dataclass
+class Classification:
+    """Bucketed classification of an affected-target set."""
+
+    instrumentable: list[str] = field(default_factory=list)
+    non_instrumentable: list[str] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return len(self.instrumentable) + len(self.non_instrumentable)
+
+    @property
+    def instrumentable_present(self) -> bool:
+        # Fail closed: an empty classification (e.g. every target dropped by a
+        # keep-going query) is treated as instrumentable so coverage still runs.
+        if self.total == 0:
+            return True
+        return len(self.instrumentable) > 0
+
+
+def _split_kind_and_label(line: str) -> tuple[str, str]:
+    """Split a `--output label_kind` line into (kind phrase, label).
+
+    Args:
+        line: A single non-empty output line.
+
+    Returns:
+        The kind phrase (e.g. "cc_library rule", "source file") and the label.
+    """
+    tokens = line.split()
+    label = tokens[-1]
+    kind_phrase = " ".join(tokens[:-1])
+    return kind_phrase, label
+
+
+def classify(lines: list[str]) -> Classification:
+    """Classify label_kind output lines into instrumentable vs. not.
+
+    Args:
+        lines: Raw lines from `bazel query --output label_kind`.
+
+    Returns:
+        The bucketed classification.
+    """
+    result = Classification()
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line:
+            continue
+        kind_phrase, label = _split_kind_and_label(line)
+        if not kind_phrase:
+            # No kind phrase (malformed): fail closed and treat as instrumentable.
+            result.instrumentable.append(label)
+            continue
+        if kind_phrase in NON_RULE_PHRASES:
+            result.non_instrumentable.append(label)
+            continue
+        if kind_phrase.endswith(" rule"):
+            rule_kind = kind_phrase[: -len(" rule")]
+            if rule_kind in NON_INSTRUMENTABLE_RULE_KINDS:
+                result.non_instrumentable.append(label)
+            else:
+                # Every cc_* kind, the donner C++ wrapper rules, and any
+                # unrecognized rule kind land here: run coverage (fail closed).
+                result.instrumentable.append(label)
+            continue
+        # Unrecognized phrase shape: fail closed.
+        result.instrumentable.append(label)
+    return result
+
+
+def _print_summary(classification: Classification, preview: int = 25) -> None:
+    print(
+        "Coverage instrumentability classification: "
+        f"total={classification.total} "
+        f"instrumentable={len(classification.instrumentable)} "
+        f"non_instrumentable={len(classification.non_instrumentable)}",
+        file=sys.stderr,
+    )
+    if classification.instrumentable:
+        print("Instrumentable (forces coverage run):", file=sys.stderr)
+        for label in classification.instrumentable[:preview]:
+            print(f"  {label}", file=sys.stderr)
+        if len(classification.instrumentable) > preview:
+            remaining = len(classification.instrumentable) - preview
+            print(f"  ... and {remaining} more", file=sys.stderr)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--label-kind-file",
+        type=Path,
+        required=True,
+        help="File containing `bazel query --output label_kind` output.",
+    )
+    args = parser.parse_args()
+
+    try:
+        text = args.label_kind_file.read_text(encoding="utf-8", errors="replace")
+    except OSError as error:
+        # Fail closed: emit the run decision and a nonzero status so the caller
+        # runs coverage with the guard intact.
+        print("instrumentable_present=true")
+        print(f"ERROR: could not read {args.label_kind_file}: {error}", file=sys.stderr)
+        return 1
+
+    classification = classify(text.splitlines())
+    _print_summary(classification)
+    value = "true" if classification.instrumentable_present else "false"
+    print(f"instrumentable_present={value}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/coverage_instrumentable_targets_tests.py
+++ b/tools/coverage_instrumentable_targets_tests.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Tests for coverage_instrumentable_targets.py."""
+
+from pathlib import Path
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import coverage_instrumentable_targets as mod
+
+
+class ClassifyTest(unittest.TestCase):
+    def test_docs_and_tools_only_is_not_instrumentable(self):
+        # A docs + python/shell tooling change (the #808 shape): filegroup for
+        # docs plus tool py_tests. No C/C++ compilation unit is affected.
+        lines = [
+            "filegroup rule //:docs_files",
+            "py_test rule //tools:filter_coverage_tests",
+            "py_test rule //tools:check_lcov_report_tests",
+            "sh_test rule //tools:some_shell_test",
+            "genrule rule //tools:generate_embedded_test_resources",
+        ]
+        result = mod.classify(lines)
+        self.assertFalse(result.instrumentable_present)
+        self.assertEqual(result.instrumentable, [])
+        self.assertEqual(len(result.non_instrumentable), 5)
+
+    def test_cc_target_forces_coverage_run(self):
+        # A change touching a native C++ target must run coverage even though a
+        # lint py_test is also affected.
+        lines = [
+            "cc_library rule //donner/base:foo",
+            "py_test rule //donner/base:foo_banned_patterns_lint_test",
+            "filegroup rule //:docs_files",
+        ]
+        result = mod.classify(lines)
+        self.assertTrue(result.instrumentable_present)
+        self.assertEqual(result.instrumentable, ["//donner/base:foo"])
+
+    def test_donner_wrapper_rule_is_instrumentable(self):
+        # The custom donner C++ wrapper rules forward InstrumentedFilesInfo and
+        # must be treated as instrumentable, not as unknown-and-skipped.
+        lines = [
+            "donner_multi_transitioned_test rule //donner/svg:bar_skia",
+            "_donner_perf_sensitive_cc_library rule //donner/svg:hot",
+            "_wasm_cc_binary rule //donner/svg:wasm_thing",
+        ]
+        result = mod.classify(lines)
+        self.assertTrue(result.instrumentable_present)
+        self.assertEqual(len(result.instrumentable), 3)
+        self.assertEqual(result.non_instrumentable, [])
+
+    def test_unknown_rule_kind_fails_closed(self):
+        # An unrecognized rule kind must run coverage (uncertainty never skips).
+        lines = [
+            "brand_new_custom_cc_rule rule //donner/svg:mystery",
+            "filegroup rule //:docs_files",
+        ]
+        result = mod.classify(lines)
+        self.assertTrue(result.instrumentable_present)
+        self.assertEqual(result.instrumentable, ["//donner/svg:mystery"])
+
+    def test_non_rule_lines_are_not_instrumentable(self):
+        lines = [
+            "source file //donner/base:foo.cc",
+            "generated file //donner/base:generated.h",
+            "package group //donner:pkg",
+        ]
+        result = mod.classify(lines)
+        self.assertFalse(result.instrumentable_present)
+        self.assertEqual(result.total, 3)
+
+    def test_empty_input_fails_closed(self):
+        # Every target dropped by a keep-going query => run coverage.
+        result = mod.classify([])
+        self.assertTrue(result.instrumentable_present)
+        self.assertEqual(result.total, 0)
+
+    def test_blank_lines_ignored(self):
+        lines = ["", "  ", "filegroup rule //:docs_files", ""]
+        result = mod.classify(lines)
+        self.assertEqual(result.total, 1)
+        self.assertFalse(result.instrumentable_present)
+
+    def test_malformed_single_token_fails_closed(self):
+        result = mod.classify(["//weird:label_with_no_kind"])
+        self.assertTrue(result.instrumentable_present)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

PRs whose affected-target set contains no instrumentable C/C++ (docs-only,
tools-only, or workflow-only changes) still run the incremental PR coverage
lane. bazel-diff resolves such a change to a genuine incremental subset made up
entirely of non-compilation targets (for example a docs `filegroup` and a couple
of tooling `py_test`s). `bazel coverage` over that subset produces an empty LCOV
report, and `tools/check_lcov_report.py` correctly rejects it with
`Coverage report has no executable line data (records=0)`. The result is a
deterministic red on the coverage lane that no rerun can clear.

## Fix

Add an instrumentability gate to the coverage lane's `determine-targets` step.
After bazel-diff computes the affected subset, the step queries the target
**kinds** over exactly that subset (`bazel query --output label_kind`) and
classifies them with a new `tools/coverage_instrumentable_targets.py` helper.
When every affected target is a recognized non-instrumentable kind, the step
emits a new `fallback_reason=no_instrumentable_targets` decision.

No job conditions change. The existing coverage jobs already skip for any
fallback reason other than `coverage_smoke` / `full_test_label`, so the new
reason routes straight into the existing skip path (including the Codecov upload
job, which mirrors the same gate, so there is no dangling required upload).

## Guard integrity (fail closed)

- Every `cc_*` kind and every donner C++ wrapper rule
  (`donner_multi_transitioned_test`, `_donner_perf_sensitive_cc_library`,
  `_wasm_cc_binary`, etc.) is classified as instrumentable, so a C++-touching
  PR still runs coverage and still fails on an empty report. The guard that
  catches silently-broken coverage collection is untouched.
- The decision comes from target kinds computed by the existing
  bazel-diff / determine-targets machinery, not from file-extension heuristics.
- Any query error, classifier error, or unrecognized rule kind runs coverage on
  the affected subset with the guard intact. Uncertainty never skips a gate.
- Concurrency groups, timeouts, and routing conditions are unchanged.

## Validation

The classifier ships with unit tests (also wired as a bazel `py_test`). The
end-to-end decision was exercised against real `bazel query` output for three
cases:

| Case | Affected kinds | Decision |
| --- | --- | --- |
| docs + tooling only | `filegroup`, `py_test`, `py_binary`, `genrule` | `instrumentable_present=false` -> skip coverage |
| C++ change | `cc_library` | `instrumentable_present=true` -> run coverage |
| mixed docs + C++ | `filegroup`, `cc_library`, `py_test` | `instrumentable_present=true` -> run coverage |

Because this PR itself touches the coverage workflow, its own coverage run
exercises this new logic on a tools-and-workflow-only diff, whose affected
subset is entirely non-instrumentable. The three-case table above and the unit
tests confirm the classifier behavior independent of this PR's own run.

`YAML parses; the new py_test passes under bazel.`

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
