### PR TITLE
Resolve aliases before coverage instrumentability check

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -310,8 +310,20 @@ jobs:
           # skip only when nothing instrumentable is affected. Fail closed: any
           # query/classifier error, or any unrecognized rule kind, keeps the
           # guard by running the bazel_diff subset as before.
+          # Resolve aliases to their `actual` targets before classifying: an
+          # alias can point at an instrumentable cc_* target (for example the
+          # default alias donner_variant_cc_test emits, whose actual is a
+          # cc_test), so an alias-only affected set must be judged by what it
+          # resolves to, not by the `alias` kind. The query replaces every
+          # alias in the set with its actual; an alias that cannot be resolved
+          # stays an `alias` kind and the classifier treats it as instrumentable
+          # (fail closed).
           kind_query_file="$work_dir/affected-query.txt"
-          { printf 'set('; tr '\n' ' ' < "$work_dir/affected.txt"; printf ')\n'; } > "$kind_query_file"
+          {
+            printf 'let a = set('
+            tr '\n' ' ' < "$work_dir/affected.txt"
+            printf ') in ($a - kind("^alias rule$", $a)) + labels("actual", kind("^alias rule$", $a))\n'
+          } > "$kind_query_file"
           label_kind_file="$work_dir/affected-label-kind.txt"
           if ( cd "$head_dir" && bazelisk query --query_file="$kind_query_file" \
               --output label_kind --keep_going ) > "$label_kind_file" 2> "$diagnostics_dir/kind-query.log"; then

--- a/tools/coverage_instrumentable_targets.py
+++ b/tools/coverage_instrumentable_targets.py
@@ -2,8 +2,9 @@
 """Decide whether an affected-target set contains instrumentable C/C++ code.
 
 Reads the output of `bazel query --output label_kind` for the affected-target
-set (as produced by the coverage lane's bazel-diff step) and reports whether any
-affected target is an instrumentable C/C++ compilation unit.
+set (as produced by the coverage lane's bazel-diff step, with aliases already
+resolved to their `actual` targets) and reports whether any affected target is
+an instrumentable C/C++ compilation unit.
 
 The coverage lane uses this to skip PR coverage when a change's affected targets
 are all non-instrumentable (docs, shell/python tooling, filegroups, build
@@ -41,11 +42,18 @@ NON_INSTRUMENTABLE_RULE_KINDS = frozenset(
         "java_binary",
         "java_test",
         "proto_library",
-        # Grouping / aliasing / query rules (no compilation of their own).
+        # Grouping / query rules (no compilation of their own). NOTE: `alias`
+        # is deliberately NOT listed. An alias can resolve to an instrumentable
+        # C++ target (for example the default alias donner_variant_cc_test emits,
+        # whose `actual` is a cc_test), so classifying `alias` as
+        # non-instrumentable would wrongly skip coverage on a BUILD-only change
+        # that only touches such an alias. The coverage lane resolves aliases to
+        # their `actual` targets before calling this tool; any `alias` kind that
+        # still reaches here could not be resolved and is treated as
+        # instrumentable below (fail closed: uncertainty never skips the gate).
         "filegroup",
         "genrule",
         "genquery",
-        "alias",
         "test_suite",
         "serve_http",
         # Configuration, flags, and platform/toolchain declarations.

--- a/tools/coverage_instrumentable_targets_tests.py
+++ b/tools/coverage_instrumentable_targets_tests.py
@@ -61,6 +61,34 @@ class ClassifyTest(unittest.TestCase):
         self.assertTrue(result.instrumentable_present)
         self.assertEqual(result.instrumentable, ["//donner/svg:mystery"])
 
+    def test_alias_only_set_is_instrumentable(self):
+        # Regression: a BUILD-only change whose affected set is a single alias
+        # that resolves to a cc_test (e.g. the default alias
+        # donner_variant_cc_test creates) must run coverage. The coverage lane
+        # resolves the alias to its `actual` before classification, so the tool
+        # sees the resolved cc_test rather than the `alias` kind.
+        resolved = mod.classify(["cc_test rule //donner/svg:foo_impl"])
+        self.assertTrue(resolved.instrumentable_present)
+        self.assertEqual(resolved.instrumentable, ["//donner/svg:foo_impl"])
+
+    def test_unresolved_alias_kind_fails_closed(self):
+        # If an `alias` kind still reaches the classifier (resolution could not
+        # expand it), it must be treated as instrumentable, never skipped.
+        result = mod.classify(["alias rule //donner/svg:mystery_alias"])
+        self.assertTrue(result.instrumentable_present)
+        self.assertEqual(result.instrumentable, ["//donner/svg:mystery_alias"])
+
+    def test_alias_resolving_to_docs_is_not_instrumentable(self):
+        # An alias whose `actual` is a filegroup resolves to a non-instrumentable
+        # kind, so an alias-to-docs-only change still skips coverage.
+        result = mod.classify(
+            [
+                "filegroup rule //:docs_files",
+                "py_test rule //tools:some_tool_test",
+            ]
+        )
+        self.assertFalse(result.instrumentable_present)
+
     def test_non_rule_lines_are_not_instrumentable(self):
         lines = [
             "source file //donner/base:foo.cc",


### PR DESCRIPTION
## Problem

Follow-up to #822. The instrumentability classifier treated `alias` as an
always-non-instrumentable rule kind. An affected set containing only an alias
that resolves to a C/C++ target would therefore be classified as
non-instrumentable and wrongly skip coverage on a BUILD-only change. The default
alias `donner_variant_cc_test` creates (in `build_defs/rules.bzl`), whose
`actual` is a `cc_test`, is exactly this shape: a BUILD-only change touching only
that alias would have skipped coverage and defeated the empty-report guard for
real code.

## Fix

- **Coverage lane resolves aliases before classifying.** The kind query now
  replaces every alias in the affected set with its `actual` target:
  `let a = set(...) in ($a - kind("^alias rule$", $a)) + labels("actual", kind("^alias rule$", $a))`.
  An alias-only set is now judged by what it resolves to, not by the `alias`
  kind.
- **Classifier drops `alias` from the non-instrumentable allowlist.** Any
  `alias` kind that still reaches the classifier could not be resolved and is
  treated as instrumentable. This preserves the original fail-closed principle:
  uncertainty never skips the gate.

## Validation

New unit tests (also wired as a bazel `py_test`):

- An unresolved `alias` kind yields `instrumentable_present=true` (red under the
  pre-#822-follow-up classifier, green after) - the regression the fix targets.
- An alias resolved to a `cc_test` yields `instrumentable_present=true`.
- An alias resolved to a docs `filegroup` yields `instrumentable_present=false`.

End-to-end on the same bazel-diff/kind-query pipeline the workflow uses, with
the alias case added to the original three:

| Case | Affected input | Resolved kinds | Decision |
| --- | --- | --- | --- |
| alias-only resolving to cc_test | one `alias` | `cc_test` | `instrumentable_present=true` -> run |
| docs + tooling only | `filegroup`, `py_test` x2 | same | `instrumentable_present=false` -> skip |
| C++ change | `cc_library` | same | `instrumentable_present=true` -> run |
| mixed docs + C++ | `filegroup`, `cc_library`, `py_test` | same | `instrumentable_present=true` -> run |
| mixed alias-to-cc + docs | `alias`, `filegroup` | `cc_test`, `filegroup` | `instrumentable_present=true` -> run |

Any alias that cannot be resolved leaves the query nonzero or a residual `alias`
kind, both of which run coverage with the guard intact.

Because this PR itself touches the coverage workflow, its own coverage run
exercises this logic on a tools-and-workflow-only diff (an all-non-instrumentable
subset). The table above and the unit tests confirm the alias behavior
independent of this PR's own run.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
