### PR TITLE
Design native GPU runtime and enforce design provenance

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,7 @@ concurrency:
 #
 # - build_defs/check_banned_patterns.py (covers the examples/ dir which
 #   is not fully enumerated by the donner_cc_* py_test lint macros)
+# - check_design_doc_provenance.py (ratchets exact model metadata on design docs)
 # - gen_cmakelists.py unit tests + full --check validator (reentrant bazel
 #   prevents running --check from inside bazel test; see design doc 0016)
 jobs:
@@ -79,6 +80,9 @@ jobs:
           )
 
           python3 build_defs/check_banned_patterns.py donner "${example_sources[@]}"
+
+      - name: Check design document provenance
+        run: python3 tools/check_design_doc_provenance.py
 
   cmake-validate:
     runs-on: ubuntu-24.04

--- a/docs/design_docs/0019-css_token_stream.md
+++ b/docs/design_docs/0019-css_token_stream.md
@@ -1,7 +1,9 @@
 # Design: CSS Parser `TokenStream` — Pull-Based Subparser Handoff
 
 **Status:** Implemented (Milestones 1–3 complete; Milestone 4 verdict: STOP HERE)
-**Author:** Claude Opus 4.6 (drafting on behalf of Jeff McGlynn, with input from DuckBot)
+**Author:** Claude Opus 4.6
+**Requested by:** Jeff McGlynn
+**Reviewed by:** DuckBot
 **Created:** 2026-04-10
 
 **Naming note (2026-04-10):** the concept is named `ComponentValueStream` in code to

--- a/docs/design_docs/0024-proposed_issues_2026q2.md
+++ b/docs/design_docs/0024-proposed_issues_2026q2.md
@@ -9,7 +9,8 @@ PRs #515/#609 rather than filed issues; remaining gaps are tracked live in
 deliberately left unset for self-hosted runners rather than raised per B3. This doc
 is kept as a historical proposal snapshot, not an active backlog — see 0021 and 0031
 for current state.
-**Author:** Claude Opus 4.6 (with SpecBot, PerfBot, BazelBot)
+**Author:** Claude Opus 4.6
+**Reviewed by:** SpecBot, PerfBot, BazelBot
 **Created:** 2026-04-12
 
 ## Summary

--- a/docs/design_docs/0026-svg_conformance_testing.md
+++ b/docs/design_docs/0026-svg_conformance_testing.md
@@ -1,7 +1,7 @@
 # Design: SVG Conformance Testing
 
 **Status:** Draft
-**Author:** GPT-5 Codex
+**Author:** GPT-5
 **Created:** 2026-04-16
 
 ## Summary

--- a/docs/design_docs/0028-v1_0_release.md
+++ b/docs/design_docs/0028-v1_0_release.md
@@ -8,7 +8,8 @@ with v1.0 following it. Several items this doc scoped into v1.0 — notably
 "Editor v1 (the app)" (Phase 8) — have since moved into the v0.8 milestone
 in the roadmap. The phase list below has not been re-sequenced to match;
 treat it as directional until reconciled with the roadmap.
-**Author:** Jeff McGlynn (with Claude Opus 4.7)
+**Author:** Jeff McGlynn
+**Model:** Claude Opus 4.7
 **Created:** 2026-04-17
 
 ## Summary
@@ -41,7 +42,11 @@ in [0011-v0_5_release.md](0011-v0_5_release.md#v05-retrospective):
   [0026-svg_conformance_testing.md](0026-svg_conformance_testing.md), plus contributing Donner
   back to the upstream resvg test harness.
 - **Geode on real GPUs** — finishing [0017-geode_renderer.md](0017-geode_renderer.md) beyond
-  software adapters / CI validation.
+  software adapters / CI validation, then replacing the native GPU dependency with the clean-room
+  Donner runtime in [0053-native_gpu_hal.md](0053-native_gpu_hal.md).
+- **Rust-independent release build** — remove Rust toolchains, Cargo execution, Rust-built
+  libraries, and transitive Rust requirements. Inert upstream resvg/tiny-skia reference source is
+  allowed only behind the explicit third-party corpus boundary in design 0053.
 - **Parser hardening, DOM gaps, and entity lifecycle** — the items listed under each of those
   headings in the ProjectRoadmap.
 - **Release-process + docs cleanup** — the retrospective items from 0011: BCR publish,
@@ -86,6 +91,8 @@ re-scoped down later if the schedule demands it.
     documented.
   - Performance and binary-size profiles documented; the "Donner Tiny" tier is usable.
   - Release documentation complete for embedders (embedding guide).
+  - Native GPU builds use the Donner-owned Metal/Vulkan runtime and the complete release build passes
+    the no-Rust-dependency gate from [0053](0053-native_gpu_hal.md).
 - Close out every item from the [v0.5 retrospective](0011-v0_5_release.md#v05-retrospective).
 - Establish scripting and conformance as first-class Donner subsystems, so third-party parity
   checks against browsers and resvg are a routine part of CI.
@@ -102,7 +109,8 @@ re-scoped down later if the schedule demands it.
 - A 100% resvg pass rate. Known architectural gaps (e.g. feImage float rendering path) stay
   tracked in [0021-resvg_feature_gaps.md](0021-resvg_feature_gaps.md).
 - Running the full WPT repository in CI. The conformance design vendors a curated subset.
-- New rendering backends beyond Skia / tiny-skia / Geode.
+- New SVG rendering algorithms beyond tiny-skia and Geode. Replacing Geode's hardware runtime per
+  [0053](0053-native_gpu_hal.md) is required infrastructure, not a new SVG renderer.
 
 ## Next Steps
 
@@ -122,7 +130,7 @@ this doc only tracks "is the v1.0-gating slice of that work done".
 
 - [ ] **Phase 1** — Release-process + docs cleanup (v0.5 retrospective carry-over).
 - [ ] **Phase 2** — Finish in-flight vNext workstreams (sandboxing, composited rendering,
-  Geode-on-GPU) — never shipped in v0.5, land them for v1.0.
+  Geode-on-GPU, and the clean-room native GPU runtime) — never shipped in v0.5, land them for v1.0.
 - [ ] **Phase 3** — SVG feature gaps: `<a>`, `<switch>`, and the P0/P1 items from
   [0024-proposed_issues_2026q2.md](0024-proposed_issues_2026q2.md).
 - [ ] **Phase 4** — Animation (SMIL Phases 1–9) + animation test suite.
@@ -188,6 +196,10 @@ the first feature work to finish for v1.0.
 - [ ] **Geode renderer on a real GPU** — Finish [0017-geode_renderer.md](0017-geode_renderer.md).
   Phase 0–2 and resvg MSAA are green on software adapters; Geode is not yet a user-facing
   backend and has not been validated on physical GPU hardware.
+- [ ] **Clean-room native GPU runtime and Rust dependency purge** — Complete
+  [0053-native_gpu_hal.md](0053-native_gpu_hal.md): native Metal/Vulkan backends, the browser
+  bridge, shader IR and emitters, editor presentation migration, removal of `wgpu-native`, and the
+  repository-wide no-Rust-dependency release gate.
 
 ### Phase 3: SVG feature gaps
 
@@ -417,6 +429,8 @@ Plus the v0.5 retrospective items (all addressed in Phase 1):
 - BCR publish working end-to-end on the v1.0 tag.
 - Doxygen sidebar organized; binary-size report rendering; element lists condensed.
 - Public-target visibility tightened, particularly under `//donner/editor/...`.
+- Native GPU runtime cut over on supported platforms, and the source/archive/artifact
+  no-Rust-dependency gate passes.
 
 ## Proposed Architecture
 
@@ -431,6 +445,7 @@ per-phase design docs:
 - Editor sandbox → [0023-editor_sandbox.md](0023-editor_sandbox.md) records the removed prototype;
   Phase 2 needs a replacement design for the v1.0 sandbox boundary.
 - Geode → [0017-geode_renderer.md](0017-geode_renderer.md).
+- Native GPU runtime and Rust-independent build → [0053-native_gpu_hal.md](0053-native_gpu_hal.md).
 - Incremental invalidation → [0005-incremental_invalidation.md](0005-incremental_invalidation.md).
 - BCR → [0018-bcr_release.md](0018-bcr_release.md).
 - Continuous fuzzing → [0012-continuous_fuzzing.md](0012-continuous_fuzzing.md).
@@ -446,13 +461,17 @@ serialization.
 
 ## Security / Privacy
 
-v1.0 adds two major new trust boundaries beyond v0.5's parser / renderer surface:
+v1.0 adds three major new trust boundaries beyond v0.5's parser / renderer surface:
 
 - **Scripting.** Untrusted JS running inside Donner. The threat model, sandbox, and fuzz
   strategy are owned by [0027-2-scripting.md](0027-2-scripting.md) §Security / privacy.
 - **Editor sandbox.** Process isolation for editor parser/renderer work remains in scope for
   v1.0. The previous prototype was removed, so Phase 2 must define the replacement threat model,
   IPC boundary, and validation strategy before implementation.
+- **Native GPU runtime.** Donner owns descriptor validation, resource lifetime, synchronization,
+  device loss, memory budgets, generated shader artifacts, and native embedding handles. Design
+  [0053](0053-native_gpu_hal.md) owns the threat model, validation layers, fuzzing, provenance, and
+  driver qualification.
 Donner's global invariant — "must safely handle untrusted input and must never crash" — extends
 unchanged across the scripting and editor-sandbox boundaries. Phase 12 (Security pass) is the
 verification step.
@@ -469,6 +488,9 @@ verification step.
 - **Coverage target**: ≥90% line coverage across production code (v0.5 shipped at 81.7%).
 - **Binary-size, build-time, and perf profiles** (Phase 13) are captured in the build report
   and become a release-gate artifact.
+- **GPU and dependency qualification** runs the [0053](0053-native_gpu_hal.md) backend matrix,
+  shader-emitter tests, device-loss/fuzzing suites, provenance audit, and blocking
+  no-Rust-dependency verifier.
 
 ## Dependencies
 
@@ -476,7 +498,9 @@ verification step.
   `non_bcr_deps`. See [0027-2-scripting.md](0027-2-scripting.md) §Dependencies.
 - **WPT subset** — vendored curated snapshot added by the conformance program (Phase 11). See
   [0026-svg_conformance_testing.md](0026-svg_conformance_testing.md) §Dependencies.
-- **Existing deps** unchanged.
+- **Dependency contraction** — [0053](0053-native_gpu_hal.md) removes `wgpu-native`, Rust
+  toolchains, and Rust cross-validation fixtures before v1.0. Inert upstream resvg/tiny-skia
+  reference source may remain only outside every build and runtime dependency path.
 
 ## Open Questions
 

--- a/docs/design_docs/0031-ci_hardening_2026q2.md
+++ b/docs/design_docs/0031-ci_hardening_2026q2.md
@@ -10,7 +10,8 @@ toolchain wiring — this is further along than Milestone 5's "stretch"
 framing anticipated and is not fully reflected in the milestone list below.
 Remaining open items: M1.8b (branch-protection), M2.6 (scheduled triage
 agent), M2.9 (per-library `misc-include-cleaner`), and all of Milestones 3–5.
-**Author:** Claude Opus 4.7 (MiscBot)
+**Author:** Claude Opus 4.7
+**Agent:** MiscBot
 **Created:** 2026-04-20
 **Supersedes:** [0029](0029-2-ci_runtime.md) (runtime reduction scope folded in here)
 **Related:** [0016](0016-ci_escape_prevention.md) (Phase 1 escape-prevention taxonomy)

--- a/docs/design_docs/0032-sandbox_branch_split.md
+++ b/docs/design_docs/0032-sandbox_branch_split.md
@@ -1,7 +1,8 @@
 # Design: Sandbox Branch Split
 
 **Status:** Design
-**Author:** Claude Opus 4.7 (1M context)
+**Author:** Claude Opus 4.7
+**Context window:** 1M tokens
 **Created:** 2026-05-10
 
 ## Summary

--- a/docs/design_docs/0033-2-editor_design_tool_responsiveness.md
+++ b/docs/design_docs/0033-2-editor_design_tool_responsiveness.md
@@ -1,7 +1,8 @@
 # Design: Editor Design-Tool-Grade Responsiveness
 
 **Status:** Implementing (M1, M2, M4, M5, M7, M8, M9 landed; M3/M6/M10 open)
-**Author:** Claude Opus 4.7 (1M context)
+**Author:** Claude Opus 4.7
+**Context window:** 1M tokens
 **Created:** 2026-05-12
 **Last updated:** 2026-07-10
 

--- a/docs/design_docs/0033-multithreading_and_dom_lifetime.md
+++ b/docs/design_docs/0033-multithreading_and_dom_lifetime.md
@@ -1,7 +1,7 @@
 # Design: Multithreading and DOM Lifetime
 
 **Status:** Implemented
-**Author:** Codex (GPT-5)
+**Author:** GPT-5
 **Created:** 2026-05-16
 
 > **This design shipped.** It is summarized here; the living documentation is in

--- a/docs/design_docs/0034-progressive_rendering.md
+++ b/docs/design_docs/0034-progressive_rendering.md
@@ -1,7 +1,8 @@
 # Design: Progressive Rendering for High-Zoom Drag-Start
 
 **Status:** Removed
-**Author:** Claude Opus 4.7 (1M context)
+**Author:** Claude Opus 4.7
+**Context window:** 1M tokens
 **Created:** 2026-05-13
 
 > **Removed 2026-05-20.** This design was implemented experimentally and then

--- a/docs/design_docs/0035-filter_layer_compose_offset_bug.md
+++ b/docs/design_docs/0035-filter_layer_compose_offset_bug.md
@@ -1,7 +1,8 @@
 ## Design: Filter Layer Compose-Offset Bug — Resolution and Stress Coverage
 
 **Status:** Fixed for the 0035 replay; drag+zoom stress coverage added
-**Author:** Claude Opus 4.7 (1M context)
+**Author:** Claude Opus 4.7
+**Context window:** 1M tokens
 **Created:** 2026-05-14
 **Updated:** 2026-05-15
 

--- a/docs/design_docs/0036-composited_presentation_retrospective.md
+++ b/docs/design_docs/0036-composited_presentation_retrospective.md
@@ -2,7 +2,7 @@
 
 **Status:** Retrospective
 **Type:** Retrospective
-**Author:** Codex GPT-5
+**Author:** GPT-5
 **Created:** 2026-05-19
 
 ## Summary

--- a/docs/design_docs/0037-geode_presentation_glitch_investigation.md
+++ b/docs/design_docs/0037-geode_presentation_glitch_investigation.md
@@ -2,7 +2,7 @@
 
 **Status:** Root cause identified
 **Type:** Retrospective / Handoff
-**Author:** Codex GPT-5
+**Author:** GPT-5
 **Created:** 2026-05-21
 
 ## Summary

--- a/docs/design_docs/0040-semantic_text_completion.md
+++ b/docs/design_docs/0040-semantic_text_completion.md
@@ -1,7 +1,7 @@
 # Design: Semantic Text Editing
 
 **Status:** Design
-**Author:** Codex GPT-5
+**Author:** GPT-5
 **Created:** 2026-05-25
 
 ## Summary

--- a/docs/design_docs/0041-2-path_authoring_and_boolean_operations.md
+++ b/docs/design_docs/0041-2-path_authoring_and_boolean_operations.md
@@ -9,7 +9,7 @@ implemented. Donner-level boolean path operations (M6, `PathBooleanOp`/`ApplyPat
 right-side Path Operations panel (M5) is partially wired (actions + undo + selection-preserve
 land; Arrange controls and paint-order commands don't). The Path Edit tool (M4) has not been
 started — no `PathEditTool` exists.
-**Author:** Codex GPT-5
+**Author:** GPT-5
 **Created:** 2026-05-25
 
 ## Summary

--- a/docs/design_docs/0048-design_doc_hygiene.md
+++ b/docs/design_docs/0048-design_doc_hygiene.md
@@ -1,8 +1,10 @@
 # Design: Design Doc Hygiene — 2026-06-30 Audit Follow-Up
 
-**Status:** In Progress — Milestones 1–5 complete; Milestone 6 blocked on `v08/*` merges.
-**Author:** Claude Sonnet 5
+**Status:** In Progress — Milestones 1–5 and 7 complete; Milestone 6 blocked on `v08/*` merges.
+**Author:** GPT-5.6 Sol
+**Drafted by:** Claude Sonnet 5
 **Created:** 2026-06-30
+**Updated:** 2026-07-10
 
 ## Summary
 
@@ -15,6 +17,10 @@ collisions, and ten docs not yet numbered in the index (three top-level editor-t
 docs plus the seven files under `text/`) — that are mechanical cleanup, not
 judgment calls, and were deliberately left unfixed by the audit pass pending review.
 This doc tracks that cleanup to completion.
+
+A subsequent provenance audit added exact model identifiers to recoverable records and introduced a
+CI ratchet for the unresolved historical set. The ratchet rejects missing or generic authorship on
+new designs and rejects stale debt entries after a historical record is corrected.
 
 ## Goals
 
@@ -34,6 +40,8 @@ This doc tracks that cleanup to completion.
   design work is complete, then replaced with a live-CI pointer at finalization.
 - The v0.8 feature-branch docs (`0041-2`, `0044-2`, `0046`, `0047`) get a follow-up
   status pass once `v08/*` branches merge to `main`.
+- Every model-authored design records the exact accountable model identifier. Human-only designs
+  identify the author and explicitly set `Model` to `None (human-only)`.
 
 ## Non-Goals
 
@@ -44,13 +52,13 @@ This doc tracks that cleanup to completion.
 - Deciding the v0.8 vs v1.0 release re-sequencing itself (0028 already flags that
   `ProjectRoadmap.md` has pivoted to v0.8 next) — only re-auditing the affected design
   docs once the merge actually happens.
-- Building tooling/CI to auto-detect stale docs. Worth a future doc if this class of
-  drift recurs, but out of scope here.
+- Automatically deciding whether implementation claims have become stale. CI checks structural
+  metadata and known invariants; implementation-status review still requires source inspection.
 
 ## Next Steps
 
-- Milestones 1–5 are complete and validated (collisions, `0015`, unnumbered-doc
-  numbering, the four Finalization rewrites, and the resvg snapshot re-scoping).
+- Milestones 1–5 and 7 are complete and validated (collisions, `0015`, unnumbered-doc
+  numbering, the four Finalization rewrites, resvg snapshot re-scoping, and model provenance).
 - Only Milestone 6 remains, and it is blocked: re-audit the v0.8 feature-branch docs
   (`0041-2`, `0044-2`, `0046`, `0047`) once the `v08/*` branches merge to `main`.
 
@@ -167,15 +175,24 @@ This doc tracks that cleanup to completion.
         `0044-2-editor_fluid_canvas_rendering.md`, `0046-editor_group_layers.md`, and
         `0047-v0_8_showcase.md` against the merged code, the same way the 2026-06-30
         audit did for everything else.
+- [x] Milestone 7: Model provenance ratchet
+  - [x] Require an exact model identifier in new design and retrospective templates.
+  - [x] Normalize historical `Codex` plus `GPT-5` aliases to `GPT-5`.
+  - [x] Restore exact authorship where the pre-finalization document or parent design provides
+        direct evidence.
+  - [x] Record unresolved historical metadata in `provenance_debt.txt` without guessing.
+  - [x] Add `tools/check_design_doc_provenance.py`, unit coverage, a Bazel test target, and the
+        repository lint workflow gate. New debt and stale allowlist entries both fail.
 
 ## Security / Privacy
 
-N/A — documentation-only changes (renames, index rows, prose). No code, trust
-boundaries, or data handling are touched.
+The checker reads only tracked Markdown and the debt text file, performs no network access, and
+executes no document content. It runs with the existing read-only lint job permissions and emits
+only public repository paths and metadata values. The check is repository-local.
 
 ## Testing and Validation
 
-- No code changes — this is documentation hygiene. "Passing" means: every top-level
+- Structural hygiene passes when every top-level
   number resolves to exactly one logical doc (treating `NNNN-` and `NNNN-2-`/`NNNN-3-`
   as one intentional group, **not** a collision — a naive uniqueness check will
   false-positive on `0033-2`, `0041-2`, `0044-2` otherwise), every number in the
@@ -183,6 +200,9 @@ boundaries, or data handling are touched.
   `docs/design_docs/` (including subdirectories) has a row in the Document Index. These
   are mechanically checkable; commit the check as a small script and run it as the
   closing gate on Milestones 1–3, rather than eyeballing the table.
+- Model provenance is checked by `bazel test //tools:check_design_doc_provenance_tests` and
+  `python3 tools/check_design_doc_provenance.py`. The first verifies parser and ratchet behavior;
+  the second validates the live design corpus and runs in the lint workflow.
 
 ## Open Questions
 
@@ -193,5 +213,5 @@ boundaries, or data handling are touched.
   parent number (`0052`, hub `overview` bare + `-2…-7`) and stay in the `text/`
   subdirectory so their `../00NN` parent links remain valid.
 
-All open questions are resolved; the remaining work (Milestones 4–6) is tracked in the
+All open questions are resolved; the remaining work (Milestone 6) is tracked in the
 Implementation Plan.

--- a/docs/design_docs/0049-structured_text_editing.md
+++ b/docs/design_docs/0049-structured_text_editing.md
@@ -2,6 +2,8 @@
 
 **Status:** Implemented — structured editing is on by default
 (`EditorApp::structuredEditingEnabled()` returns `true`).
+**Author:** Claude Opus 4.6
+**Context window:** 1M tokens
 
 ## Summary
 

--- a/docs/design_docs/0051-text_editor_refactor.md
+++ b/docs/design_docs/0051-text_editor_refactor.md
@@ -6,7 +6,8 @@
 incomplete: `TextEditor.h` still declares `friend class TextEditorTests` and
 `TextEditor_tests.cc` still carries non-rendering tests rather than having fully migrated to
 `TextEditorCore_tests.cc`.
-**Author:** Claude Opus 4.6 (1M context)
+**Author:** Claude Opus 4.6
+**Context window:** 1M tokens
 **Created:** 2026-04-12
 
 ## Summary

--- a/docs/design_docs/0053-native_gpu_hal.md
+++ b/docs/design_docs/0053-native_gpu_hal.md
@@ -1,0 +1,563 @@
+# Design: Donner Native GPU Runtime and Rust-Independent Build
+
+**Status:** Design\
+**Created:** 2026-07-05\
+**Updated:** 2026-07-10\
+**Author:** GPT-5.6 Sol
+
+## Summary
+
+Donner will replace its native `wgpu-native` dependency with an original C++20 GPU runtime built
+inside Donner. The runtime will expose a narrow Donner-owned rendering hardware interface, not the
+WebGPU C ABI. It will target Metal on Apple platforms, Vulkan on Linux and Windows, and the browser's
+WebGPU service through a small Donner-owned WebAssembly bridge.
+
+This is a clean-room, specification-led implementation. It must not copy, translate, vendor, link,
+or ship implementation code from `wgpu`, `wgpu-native`, Naga, Dawn, or Tint. Those projects may not
+become source, build, runtime, or test dependencies of the completed implementation. During the
+transition, the current renderer may be exercised as a black-box baseline, but it has a mandatory
+sunset and cannot remain in Donner's final dependency graph.
+
+The completion boundary is repository-wide. Bazel and CMake graphs, CI toolchains, generated build
+state, and shipped artifacts must contain no Rust compiler, Cargo invocation, Rust-built library, or
+transitive Rust requirement. Inert upstream Rust source and Cargo metadata may remain only in an
+explicitly allowlisted resvg/tiny-skia third-party reference snapshot. That material cannot be
+compiled, linked, executed, or treated as a Donner implementation dependency. The active Rust FFI
+cross-validation fixture and `rules_rust` toolchain graph are removed.
+
+The result is not a general WebGPU implementation. It is the smallest coherent GPU runtime that
+supports Geode, editor presentation, deterministic replay, and Donner's embedding requirements at
+Donner's safety and code-quality bar.
+
+## Decision
+
+- Build an internal `donner::gpu` module with typed C++20 value descriptors, move-only resource
+  handles, explicit errors, deterministic command recording, and platform backends.
+- Do not preserve the WebGPU C ABI or expose `wgpu::`/`WGPU*` types in Donner APIs.
+- Replace WGSL translation with an original, typed Donner shader IR and deterministic WGSL, MSL,
+  and SPIR-V emitters. Do not add Naga, Tint, Dawn, or another third-party shader translator.
+- Build an original ImGui renderer on `donner::gpu`; do not keep the patched ImGui WebGPU backend as
+  a hidden dependency.
+- Keep the current implementation only as a bounded transition baseline. Remove it, its headers,
+  its prebuilts, its patches, and its build rules before completion.
+- Add a repository-wide no-Rust-dependency verifier with a narrow inert-reference allowlist and make
+  it a release gate.
+
+## Why This Shape
+
+The current Geode surface is much smaller than WebGPU. The 2026-07-10 inventory found approximately
+40 distinct GPU operations across 35 Geode and editor files. Geode uses 23 WGSL shaders totaling
+3,687 lines and creates a fixed set of render and compute pipelines. It does not need a public
+browser-compatible device API, runtime shader reflection, render bundles, indirect draws, timestamp
+queries, or a general shader compiler.
+
+Implementing the WebGPU C ABI would force Donner to reproduce compatibility behavior it does not use
+and would preserve API and ownership assumptions inherited from the dependency being removed. A
+narrow Donner API lets the implementation express actual requirements: fixed pipeline layouts,
+premultiplied 2D rendering, explicit texture hand-offs, deterministic captures, bounded readback,
+and predictable embedding into native render loops.
+
+The prior draft proposed Naga at build time and an indefinitely buildable `wgpu-native` oracle.
+Both violate the final invariant. This revision replaces them with original shader emitters and a
+sunsetted, output-only transition baseline.
+
+## Goals
+
+- Ship native Geode through Donner-owned Metal and Vulkan implementations.
+- Preserve browser rendering through a Donner-owned bridge to `navigator.gpu`, without a native
+  Rust implementation or Dawn-generated C wrapper in Donner's dependency graph.
+- Preserve Geode image quality, filter behavior, compositor behavior, editor responsiveness,
+  deterministic replay, and existing performance counters.
+- Make resource ownership, thread affinity, device loss, synchronization, and memory budgets
+  explicit and testable.
+- Improve embedding by accepting carefully scoped native platform objects instead of requiring a
+  WebGPU device.
+- Remove every Rust toolchain edge, Rust-built binary, Cargo execution path, and active Rust test or
+  implementation dependency from the release tree.
+- Ensure the new implementation is original Donner code whose implementation license does not
+  derive from `wgpu`, Naga, Dawn, or Tint.
+
+## Non-Goals
+
+- Implementing WebGPU-the-standard or passing the WebGPU CTS.
+- Providing a drop-in replacement for `webgpu.h`, `wgpu.h`, `webgpu.hpp`, or `wgpu-native`.
+- Supporting arbitrary user-provided shaders or runtime shader parsing.
+- Adding GPU features that Geode and the editor do not use.
+- Rewriting Slug coverage, filter math, the compositor, or SVG traversal as part of the HAL swap.
+- Rewriting the C++ tiny-skia renderer or deleting inert upstream resvg/tiny-skia reference source.
+  This design removes the Rust FFI oracle and Rust build graph; the existing C++ implementation and
+  allowlisted upstream reference snapshot remain separate from the GPU runtime.
+- Rewriting Git history. The requirement applies to the checked-out release tree, generated source
+  archives, build dependency closure, and shipped artifacts.
+
+## Clean-Room and Provenance Rules
+
+### Permitted implementation inputs
+
+- Donner's own renderer requirements, call sites, tests, captures, design docs, and shader
+  algorithms.
+- Normative public specifications: the
+  [WebGPU specification](https://gpuweb.github.io/gpuweb/),
+  [WGSL specification](https://www.w3.org/TR/WGSL/),
+  [Vulkan specification](https://registry.khronos.org/vulkan/), and
+  [SPIR-V specification](https://registry.khronos.org/SPIR-V/).
+- Official Apple Metal documentation and platform SDK interfaces.
+- Black-box outputs from the current Donner renderer: pixels, public error outcomes, counters,
+  command captures, and timing measurements produced from Donner-owned test inputs.
+
+### Prohibited implementation inputs
+
+- Copying or line-by-line translating source from `wgpu`, `wgpu-native`, Naga, Dawn, Tint, or their
+  internal tests.
+- Importing their internal object model, private algorithms, generated headers, state trackers,
+  shader IR, or backend workarounds.
+- Linking those implementations into the completed runtime, shader toolchain, tests, or CI.
+- Keeping an in-tree compatibility backend after the native cutover.
+
+### Provenance evidence
+
+Every implementation packet records:
+
+- the Donner requirement or normative specification section it implements;
+- original design notes for nontrivial algorithms and state machines;
+- the tests that establish the behavior;
+- all third-party headers, tools, or SDKs used to build or validate it;
+- confirmation that no prohibited implementation source was used.
+
+An independent provenance and license audit is a blocking release gate. This design does not claim
+that Donner as a whole has no third-party license obligations. It requires that the new GPU
+implementation does not inherit code or licensing obligations from the implementations it replaces.
+
+## Current-State Inventory
+
+The implementation starts with a checked-in, reproducible inventory rather than the estimates in
+this document. The inventory must cover at least:
+
+- all `wgpu::`, `WGPU*`, `webgpu.hpp`, `wgpu.h`, and `wgpuDevicePoll` use sites;
+- all adapter, device, queue, surface, buffer, texture, sampler, bind-group, pipeline, pass,
+  copy, map, readback, submission, callback, and destruction operations;
+- all 23 WGSL shaders, their entry points, stage inputs and outputs, bindings, storage classes,
+  texture formats, workgroup sizes, and language features;
+- all C++ structs whose layout is shared with shaders;
+- editor surface creation, texture handoff, ImGui rendering, worker ownership, and WebAssembly
+  object-table constraints;
+- Bazel, CMake, WebAssembly, packaging, and CI dependency edges;
+- Rust material. At the time of this revision, the inert tiny-skia upstream reference snapshot
+  contains 93 tracked `.rs` files plus six Cargo manifests/locks present in the checkout but
+  excluded from Git tracking. Those files are allowed as third-party reference material, but the
+  surrounding module also introduces an active Rust FFI test, `rules_rust`, and Rust toolchains into
+  `MODULE.bazel.lock`; those active edges are prohibited;
+- prebuilt `wgpu-native` archives and platform overlay rules in the non-BCR dependency extension;
+- generated and patched ImGui/WebGPU integration code.
+
+The inventory becomes a machine-readable manifest. New GPU operations or shader features cannot be
+added without updating the manifest and the corresponding backend conformance tests.
+
+## Proposed Architecture
+
+```mermaid
+flowchart TD
+    SVG[RendererDriver command stream] --> GEODE[RendererGeode and filter engine]
+    GEODE --> GPU[donner::gpu typed runtime]
+    EDITOR[Editor presentation and ImGui draw data] --> GPU
+
+    GPU --> METAL[Metal backend]
+    GPU --> VULKAN[Vulkan backend]
+    GPU --> WEB[WebAssembly browser bridge]
+    GPU --> RECORD[Recording and validation backend]
+
+    SIR[Donner shader IR] --> WGSL[Deterministic WGSL emitter]
+    SIR --> MSL[Deterministic MSL emitter]
+    SIR --> SPIRV[Deterministic SPIR-V emitter]
+    WGSL --> WEB
+    MSL --> METAL
+    SPIRV --> VULKAN
+```
+
+### Module boundary
+
+The runtime lives under `donner/gpu/`, not under a third-party directory and not inside the SVG
+public API. `RendererInterface` remains the SVG-level backend contract. `RendererGeode` consumes
+`donner::gpu` internally.
+
+The initial API is private to Donner. Native embedding is exposed only after ownership, threading,
+device-loss, and compatibility contracts have survived the backend cutover.
+
+### Build and packaging
+
+Bazel remains the primary implementation and CI build. CMake gains equivalent native GPU targets
+as each backend reaches production; it may not silently remain TinySkia-only while release docs
+claim native Geode support. Generated CMake metadata stays derived from the same target inventory so
+backend sources, shader artifacts, platform libraries, and feature flags cannot drift between build
+systems.
+
+Platform SDK compilers and validators are discovered explicitly and recorded in provenance. Build
+rules do not download opaque compiler binaries. The Tiny profile excludes the GPU module cleanly,
+while Geode profiles link exactly one platform backend plus the recording/validation code selected
+for that configuration.
+
+The browser's own WebGPU implementation and native platform drivers are host services outside
+Donner's source and binary dependency closure. Donner owns and audits the bridge code that talks to
+those services.
+
+### Core types and ownership
+
+- `Device`, `Queue`, `Surface`, `Buffer`, `Texture`, `TextureView`, `Sampler`, `BindGroup`,
+  `PipelineLayout`, `RenderPipeline`, `ComputePipeline`, and `CommandBuffer` are move-only RAII
+  handles.
+- Descriptors are immutable value types with validated sizes, formats, usages, and labels.
+- APIs return explicit `Result<T, GpuError>` or status values. The module uses no exceptions.
+- Handles carry backend and generation identity in checked builds. Cross-device and use-after-free
+  use fail before reaching a driver.
+- Destruction is deferred by submission serial where required. No backend object is destroyed while
+  referenced by an in-flight command buffer.
+- Thread-affinity rules are explicit. The current async renderer's worker ownership remains the
+  default; cross-thread presentation transfers only documented snapshot or external-texture forms.
+- Host-provided native objects are a trusted embedding boundary with explicit borrowed lifetime.
+  Untrusted SVG data can never supply or reinterpret native handles.
+
+### Command model
+
+The command surface covers only operations present in the inventory:
+
+- resource creation and bounded writes;
+- render and compute pipeline creation from generated artifacts plus explicit layout metadata;
+- render and compute pass encoding;
+- vertex and storage buffers, sampled and storage textures, samplers, and bind groups;
+- direct and instanced draws, compute dispatch, and required copy/readback operations;
+- queue submission, completion serials, device polling, and surface presentation;
+- debug labels and capture markers.
+
+There is no public command-stream deserializer. The recording backend stores validated Donner value
+objects, never raw pointers or native handles, and feeds deterministic replay and debugger tooling.
+
+### Validation layer
+
+Validation is not debug-only for memory-safety invariants. Descriptor ranges, row pitches, texture
+extents, binding compatibility, copy bounds, dispatch limits, and resource-device identity are
+checked before backend calls. Expensive diagnostics and full state histories may be build-gated,
+but invalid input must fail closed in release builds.
+
+## Shader System
+
+### Donner shader IR
+
+Geode's shaders migrate from hand-authored WGSL strings into a typed, immutable IR under
+`donner/gpu/shader/`. The IR contains only features proven necessary by the inventory. It owns:
+
+- scalar, vector, matrix, array, and struct types;
+- explicit host-shareable layout and alignment;
+- functions, entry points, structured control flow, and supported built-ins;
+- sampled textures, storage textures, samplers, uniform buffers, and storage buffers;
+- render-stage inputs/outputs and compute workgroup sizes;
+- binding and pipeline-layout metadata.
+
+The IR builder rejects ill-typed programs and unsupported features. It is not a WGSL parser and does
+not accept runtime input.
+
+### Original emitters
+
+- The WGSL emitter serves the browser backend.
+- The MSL emitter serves Metal. Apple builds compile generated trusted MSL with the platform
+  toolchain into a checked artifact when supported by the packaging target.
+- The SPIR-V emitter writes the bounded Vulkan shader subset directly with deterministic IDs and
+  decorations.
+- All emitters consume the same binding and host-layout metadata. C++ host structs use generated
+  `sizeof`, `alignof`, and `offsetof` assertions so layout drift fails at compile time.
+
+No third-party shader compiler is linked or vendored. Platform compilers and validators may be run
+as out-of-process verification tools; they are recorded in build provenance and are not part of
+Donner's implementation source.
+
+### Shader migration
+
+Migration is vertical, one pipeline family at a time. Each packet introduces the IR program, checks
+emitted artifacts, runs it through one native backend, compares pixels and counters to the frozen
+baseline, and deletes the corresponding legacy shader path. There is no final bulk rewrite in which
+all shaders change without per-family evidence.
+
+## Platform Backends
+
+### Metal
+
+Metal is first because it is the primary development platform and requires less explicit hazard
+management than Vulkan. The backend owns command queues, pipeline states, resource options, texture
+views, completion handlers, drawable presentation, and API validation integration. It starts with a
+single render triangle and proceeds through solid fills, gradients/images, clips/masks, filter
+compute chains, readback, and editor presentation.
+
+### Vulkan
+
+Vulkan supports Linux and Windows. It owns instance/device selection, queue families, descriptor
+pools, memory allocation, pipeline caches, surfaces/swapchains, submission fences, and device-loss
+recovery.
+
+The load-bearing subsystem is explicit synchronization. Every resource tracks its last writer,
+stage/access state, image layout, queue ownership, and submission serial. Encoders derive barriers
+from declared resource use. The first implementation is conservative and validation-clean; barrier
+elision is permitted only after counter and timing evidence identifies a bottleneck.
+
+The release matrix includes software Vulkan plus physical Intel, AMD, and NVIDIA coverage where
+available. One software adapter cannot substitute for the real-driver matrix.
+
+### WebAssembly browser bridge
+
+The browser backend maps the Donner descriptor and command subset to `navigator.gpu`. It uses a
+small, audited C++/JavaScript boundary owned by Donner, not the native WebGPU C ABI. It preserves
+worker ownership, asynchronous adapter/device requests, device-loss propagation, canvas
+configuration, and the editor's touch-oriented WebAssembly mode.
+
+The bridge must not expose general JavaScript evaluation or accept source from SVG documents.
+Generated WGSL is trusted build output. Browser-side IDs are range-checked generational handles,
+not raw object-table indices accepted from untrusted input.
+
+### Editor presentation
+
+The editor receives an original ImGui renderer implemented over `donner::gpu`. This removes
+`imgui_impl_wgpu`, its local patches, `EditorWgpuSurface`, and direct `WGPUTextureView` handoff.
+The presentation layer uses backend-neutral texture snapshots and explicit synchronization with the
+async render worker. Native zero-copy handoff is an optimization behind the same ownership contract,
+not a separate UI path.
+
+## Repository-Wide Rust Dependency Removal
+
+The dependency purge is complete only when all of these are true:
+
+- Rust source and Cargo metadata exist only under the reviewed, inert third-party reference
+  allowlist. The initial allowlist covers `third_party/resvg-test-suite/**` and the tiny-skia
+  upstream snapshot under `third_party/tiny-skia-cpp/third_party/tiny-skia/**`;
+- no Rust FFI fixture, Rust-backed test target, Cargo workspace root, or Rust source exists outside
+  that allowlist;
+- `MODULE.bazel`, `MODULE.bazel.lock`, CMake, and all generated build metadata contain no
+  `rules_rust`, `crate_universe`, Rust toolchain, or Rust crate graph;
+- no build rule downloads a Rust-built `wgpu-native` or equivalent archive;
+- `third_party/tiny-skia-cpp/tests/rust_ffi` is removed, with its useful comparison coverage
+  replaced by committed C++ fixtures, property tests, and goldens. The inert upstream reference
+  snapshot remains quarantined from all build targets;
+- `third_party/webgpu-cpp`, emdawnwebgpu stubs/glue, native archive overlays, and obsolete ImGui
+  WebGPU patches are removed once their last consumer is gone;
+- Bazel, CMake, WebAssembly, source-package, and release-artifact provenance list no Rust compiler,
+  Rust standard library, Cargo package, or Rust-built linked object;
+- a checked-in verifier scans the tracked tree, allowlist boundaries, Bzlmod graph, generated source
+  archive, link maps, release SBOM, and relevant vendored directories in the working tree. Any new
+  Rust path, any Rust execution edge, or any build reference into the inert allowlist fails. It runs
+  in presubmit and the release checklist.
+
+Human-readable historical documentation may accurately say that a removed implementation was
+written in Rust. Approved upstream reference source may remain in its inert third-party boundary.
+The mechanical prohibition applies to Donner implementation source, executable dependencies,
+toolchains, generated build state, and artifacts, not to truthful history or the approved corpus.
+
+## Implementation Plan
+
+The work is organized as reviewable packets. Packet boundaries are behavior boundaries, not large
+directory drops.
+
+### Phase 0: Freeze requirements and provenance
+
+- [ ] Generate the GPU-operation, shader-feature, editor-integration, and Rust-dependency manifests.
+- [ ] Freeze representative pixels, counters, captures, error outcomes, and performance baselines
+      from the current implementation using Donner-owned inputs.
+- [ ] Approve the clean-room input rules and provenance template.
+- [ ] Add the no-Rust-dependency verifier and inert-reference allowlist in report-only mode.
+- [ ] Define platform and driver release matrices plus binary-size budgets.
+
+### Phase 1: Live RHI extraction
+
+- [ ] Introduce `donner::gpu` descriptors, status types, ownership wrappers, and recording backend.
+- [ ] Move Geode call sites behind the RHI in small families while keeping one production renderer
+      path per build.
+- [ ] Add model tests for lifetime, submission serials, descriptor validation, and device loss.
+- [ ] Remove every migrated `wgpu` call and type in the same packet; temporary adapter code carries
+      an explicit removal gate.
+
+### Phase 2: Shader IR vertical slice
+
+- [ ] Inventory and specify the required shader language subset.
+- [ ] Implement typed IR validation, layout calculation, deterministic serialization, and source
+      locations for diagnostics.
+- [ ] Implement WGSL, MSL, and SPIR-V emitters for one solid-fill pipeline.
+- [ ] Validate all three outputs with platform/browser validators and compare rendered pixels.
+- [ ] Expand pipeline family by pipeline family, deleting each migrated WGSL-only path.
+
+### Phase 3: Metal production path
+
+- [ ] Implement device/resource management, render/compute commands, copies, readback, completion,
+      and surface presentation.
+- [ ] Port all Geode pipelines and filter chains.
+- [ ] Replace editor WebGPU surface and ImGui integration on macOS.
+- [ ] Pass Metal API validation, deterministic replay, goldens, fuzzing, performance, memory,
+      device-loss, and physical-device tests.
+- [ ] Cut macOS production builds to Metal and remove the macOS `wgpu-native` archive immediately.
+
+### Phase 4: Vulkan production path
+
+- [ ] Implement device selection, resource allocation, descriptors, pipelines, synchronization,
+      submission, readback, and swapchains.
+- [ ] Prove the resource-state model with model tests and Vulkan validation layers.
+- [ ] Replace Linux and Windows editor presentation.
+- [ ] Pass software and physical-driver matrices, deterministic replay, goldens, fuzzing,
+      performance, memory, and device-loss tests.
+- [ ] Cut Linux/Windows production builds to Vulkan and remove their `wgpu-native` archives.
+
+### Phase 5: Browser bridge
+
+- [ ] Replace the C WebGPU wrapper and generated bridge with the Donner descriptor/command bridge.
+- [ ] Port surface configuration, queue completion, device loss, generated WGSL, readback, and
+      browser editor presentation.
+- [ ] Pass Chromium and WebKit browser suites, touch UI tests, worker-ownership tests, and physical
+      iOS verification.
+- [ ] Remove emdawnwebgpu and the remaining `webgpu-cpp`/ImGui WebGPU sources and patches.
+
+### Phase 6: Rust-independent build cutover
+
+- [ ] Remove tiny-skia's Rust FFI comparison target while retaining the approved inert upstream
+      reference snapshot.
+- [ ] Replace lost coverage with C++ fixtures, independent property tests, and durable pixel
+      baselines before deleting the oracle.
+- [ ] Remove `rules_rust`, Rust toolchain extensions, crate metadata, and all stale lockfile entries.
+- [ ] Switch the no-Rust-dependency verifier from report-only to blocking.
+- [ ] Verify clean Bazel and CMake builds from the release source archive on hosts without Rust or
+      Cargo installed.
+
+### Phase 7: Release qualification
+
+- [ ] Complete security, provenance, licensing, architecture, and Doxygen audits.
+- [ ] Publish backend architecture, ownership, synchronization, shader IR, embedding, diagnostics,
+      and failure-mode documentation.
+- [ ] Meet the numeric cutover gates below on the exact release candidate.
+- [ ] Promote only the reviewed immutable artifacts; rollback uses retained reviewed artifacts and
+      does not rebuild.
+
+## Suggested Change Sequence
+
+The expected sequence is 16 to 24 normal-sized pull requests:
+
+1. Baseline manifests and report-only no-Rust-dependency verifier.
+2. RHI value types, validation, and recording backend.
+3. Resource lifetime and submission model.
+4. Shader IR core and layout engine.
+5. WGSL emitter plus browser validation fixture.
+6. MSL emitter and solid-fill Metal vertical slice.
+7. SPIR-V emitter and solid-fill Vulkan vertical slice.
+8. Geode solid/gradient/image pipeline migration.
+9. Geode clip/mask/layer pipeline migration.
+10. Filter compute pipeline migrations in bounded families.
+11. Metal readback, presentation, and editor integration.
+12. Metal cutover and macOS dependency deletion.
+13. Vulkan synchronization/resource manager.
+14. Vulkan presentation and editor integration.
+15. Linux cutover and dependency deletion.
+16. Windows Vulkan enablement and physical-device qualification.
+17. Browser bridge and generated WGSL path.
+18. Donner ImGui renderer and WebGPU integration deletion.
+19. Tiny-skia Rust FFI removal, inert-reference quarantine, and replacement tests.
+20. Bzlmod/CMake/CI/source-package Rust dependency purge.
+21. Security and provenance fixes from independent review.
+22. Documentation, release qualification, and final size/performance report.
+
+Packets may split when review surface becomes too large. They may not combine backend code,
+shader migration, build-graph deletion, and broad golden updates into one unreviewable change.
+
+## Cutover Gates
+
+Each platform becomes native only when all applicable gates pass:
+
+- zero unexpected pixel regressions across Donner goldens, resvg coverage, editor replay, and the
+  v1.0 conformance suite;
+- exact structural counter parity where backend-independent and reviewed per-backend expectations
+  where platform APIs necessarily differ;
+- no Metal API validation or Vulkan validation errors;
+- no crashes, hangs, leaks, use-after-free, or out-of-bounds access under sanitizer, structured GPU
+  fuzzing, device-loss injection, and repeated create/destroy stress;
+- frame time no worse than 5% at the median and 10% at p95 versus the frozen baseline on the
+  agreed corpus, unless the operator explicitly accepts a documented quality or size tradeoff;
+- no unbounded per-frame allocation or submission growth; existing Geode steady-state counters stay
+  within their budgets;
+- native GPU runtime and shader artifacts fit the measured binary-size budget established in
+  Phase 0. The prior 0.3-0.5 MB estimate is not accepted without measurement;
+- browser bridge passes headed Chromium, WebKit, and physical iOS presentation checks;
+- the blocking no-Rust-dependency verifier passes on the source tree and allowlist, module graph,
+  source archive, link maps, SBOM, and release artifacts;
+- independent security and provenance review has no unresolved critical or high findings.
+
+## Testing Strategy
+
+- Unit tests for every descriptor validator, state transition, layout rule, shader IR node, and
+  emitter instruction family.
+- Model-based tests compare resource-state transitions to a simple reference state machine.
+- A recording backend snapshots canonical commands for deterministic replay and editor debugging.
+- Shader tests validate emitted WGSL in browsers, MSL with Apple tools, and SPIR-V with Vulkan tools,
+  then execute cross-backend pixel and compute-buffer cases.
+- Renderer and editor goldens cover static output, repeated frames, transforms, clips, masks,
+  gradients, patterns, images, text, filters, layers, readback, and presentation.
+- Structured fuzzers generate only bounded, type-correct RHI sequences first, then inject one
+  invalid property at a time to verify fail-closed behavior. Real-driver fuzzing has time and memory
+  watchdogs.
+- Fault injection covers allocation failure, device loss, surface loss, submission failure,
+  callback reordering, worker shutdown, and stale external textures.
+- Physical-device tests cover Apple Silicon generations and the agreed Intel/AMD/NVIDIA matrix.
+- Dependency tests prove builds and tests do not discover or invoke Rust even when `rustc` and
+  `cargo` are absent from `PATH`.
+
+## Security and Reliability
+
+Untrusted SVG does not provide shaders or raw GPU commands, but it controls geometry volume, image
+sizes, filter graphs, render-target dimensions, and repetition. The GPU runtime therefore enforces:
+
+- checked arithmetic for byte sizes, row pitches, offsets, workgroup counts, and allocation totals;
+- per-document and per-frame limits for buffers, textures, command count, dispatch size, readback,
+  and temporary memory;
+- initialized resources before observable reads;
+- deterministic rejection of invalid formats, usages, bindings, and cross-device handles;
+- bounded waits and watchdog-visible submission progress;
+- device-loss recovery that tears down backend state without invalidating DOM/editor ownership;
+- no pointer values, native handles, private paths, or process addresses in captures;
+- platform validation layers in qualification builds and negative tests for all failure paths.
+
+GPU and shader inputs produced by Donner remain inside the editor sandbox boundary defined for
+v1.0. Backend crashes, hangs, and driver resets are security findings, not ordinary rendering
+differences.
+
+## Documentation Deliverables
+
+- A five-minute architecture page explaining the SVG-to-Geode-to-GPU flow.
+- Doxygen module pages for `donner::gpu`, resource ownership, command encoding, synchronization,
+  shader IR, and each backend.
+- SVG diagrams for ownership, submission lifetime, Vulkan resource states, browser threading, and
+  device-loss recovery.
+- An embedding guide that distinguishes Donner-owned devices from trusted borrowed native devices.
+- A migration note for embedders that currently pass WebGPU handles.
+- A generated dependency and binary-size report demonstrating the Rust-independent final build.
+
+## Rollback
+
+Development packets keep the last known-good renderer selectable only while the transition requires
+it. That compatibility path is not a release rollback mechanism and must be deleted by Phase 6.
+
+Release rollback reactivates a retained, reviewed v0.8 or v1.0 candidate artifact and compatible
+configuration by digest. It never rebuilds an old revision and never reintroduces a removed Rust
+dependency into a new artifact.
+
+## Open Questions
+
+- Final `donner::gpu` public embedding surface: keep private through v1.0, or expose only native
+  device adoption after platform cutover?
+- Vulkan memory allocator scope: implement only the allocation patterns in the manifest, or add
+  suballocation in the first production backend?
+- Windows release floor and required Vulkan driver versions.
+- Whether iOS uses the Metal backend natively in v1.0 or remains browser-only until a native host
+  exists.
+- Which exact physical GPUs are release-blocking rather than best-effort.
+- Whether the allowlisted upstream reference snapshots stay in the default source package or move to
+  a separate conformance-data archive. Either shape must keep them inert and out of the build graph.
+
+## Related Designs
+
+- [0017: Geode renderer](0017-geode_renderer.md)
+- [0025: Composited rendering](0025-composited_rendering.md)
+- [0028: v1.0 release](0028-v1_0_release.md)
+- [0030: Geode performance](0030-geode_performance.md)
+- [0041: Geode analytical AA](0041-geode_analytical_aa.md)
+- [0042: Geode Slug conformance](0042-geode_slug_conformance.md)
+- [0043: Deterministic replay testing](0043-deterministic_replay_testing.md)

--- a/docs/design_docs/0055-binary_size.md
+++ b/docs/design_docs/0055-binary_size.md
@@ -1,7 +1,8 @@
 # Design: Binary Size Reduction
 
 **Status:** Draft
-**Author:** Claude Fable 5 (reviewed; drafted by Claude Opus 4.8)
+**Author:** Claude Fable 5
+**Drafted by:** Claude Opus 4.8
 **Created:** 2026-07-10
 
 ## Summary

--- a/docs/design_docs/AGENTS.md
+++ b/docs/design_docs/AGENTS.md
@@ -12,6 +12,24 @@ All design documents live under `docs/design_docs/`.
   not renumber the landed doc — external references stay stable.
 - Update the Document Index in [README.md](README.md) when adding a doc.
 
+## Model Provenance
+
+- Every new model-authored design or retrospective must include an `**Author:**` line containing the
+  exact accountable model identifier, for example `GPT-5.6 Sol`. Generic surface names such as
+  `Codex`, broad family names, tier aliases, team names, and `Owner` fields are not substitutes.
+  Put context-window, role, helper-agent, and requester annotations on separate metadata lines; they
+  are not part of the model identifier.
+- If a later model performs a real upgrade review and becomes accountable for the design, update
+  `Author` to that exact model identifier and preserve the drafting model in a `**Drafted by:**`
+  line. Never erase or guess provenance.
+- Human requesters, sponsors, and project owners are not written into the model `Author` field. A
+  human-led, model-assisted design may keep the person in `Author` only when an exact `**Model:**`
+  line records the assisting model. A genuinely human-only design uses the person's name and
+  `**Model:** None (human-only)` so future
+  upgrade audits can distinguish it from missing metadata.
+- When touching an older design with incomplete metadata, backfill only identifiers supported by the
+  document or repository history. Leave unknown provenance explicit instead of inventing a model.
+
 ## Workflow
 
 1. **Goals first.** Write a design doc driven by user/requester goals. Capture scope, constraints, open questions. **Non-goals matter as much as goals** — explicitly state what's out of scope to prevent scope creep, anchor review discussions, and give future readers a clear boundary. Iterate until user confirms ready before planning implementation.

--- a/docs/design_docs/README.md
+++ b/docs/design_docs/README.md
@@ -5,6 +5,14 @@ ADR-style in the order they were first written. New docs append the next
 free number — `NNNN-short_name.md` — and existing numbers never change once
 assigned, so external references stay stable.
 
+Every model-authored design records the exact accountable model identifier on its `Author` line;
+a human-led, model-assisted design records it on a separate `Model` line.
+This provenance is preserved across later review and upgrade passes; see
+[AGENTS.md](AGENTS.md).
+`tools/check_design_doc_provenance.py` enforces the rule in CI. Historical records whose exact
+model cannot be established from the document or repository history are ratcheted in
+`provenance_debt.txt`; that list may shrink but cannot silently grow.
+
 ## Tree Groups
 
 - \subpage DesignDocsCoreArchitecture
@@ -128,6 +136,7 @@ conventions automated agents should follow when editing design docs.
 | 0052-5 | [text/text_backend_refactor](text/0052-5-text_backend_refactor.md)                         | Reference                                                         | stb / FreeType+HarfBuzz backend tier split.                                                                                                 |
 | 0052-6 | [text/text_v1_release](text/0052-6-text_v1_release.md)                                     | Reference                                                         | Text v1 release checklist.                                                                                                                  |
 | 0052-7 | [text/textpath](text/0052-7-textpath.md)                                                   | Reference                                                         | `<textPath>` implementation notes.                                                                                                          |
+| 0053   | [native_gpu_hal](0053-native_gpu_hal.md)                                                   | Design                                                            | Clean-room Donner GPU runtime, native Metal/Vulkan backends, browser bridge, shader IR, and a Rust-independent build graph.                 |
 | 0054   | [editor_design_language](0054-editor_design_language.md)                                   | In Progress                                                       | Graphite editor chrome, Signal Teal interaction states, source palette, fixed control geometry, and deterministic visual verification.       |
 | 0055   | [binary_size](0055-binary_size.md)                                                         | Draft                                                             | Binary size reduction: reproducible native + wasm size report tooling, measured baseline, and ranked reduction plan.                        |
 

--- a/docs/design_docs/design_template.md
+++ b/docs/design_docs/design_template.md
@@ -31,7 +31,7 @@
 # </instructions>
 
 **Status:** Draft
-**Author:** Your Model (e.g. Claude Sonnet 4.5)
+**Author:** Exact Model Identifier (e.g. GPT-5.6 Sol)
 **Created:** YYYY-MM-DD
 
 ## Summary (Required)

--- a/docs/design_docs/navigation.dox
+++ b/docs/design_docs/navigation.dox
@@ -28,6 +28,7 @@ investigations.
 - \subpage md_docs_2design__docs_20037-geode__presentation__glitch__investigation
 - \subpage md_docs_2design__docs_20041-geode__analytical__aa
 - \subpage md_docs_2design__docs_20042-geode__slug__conformance
+- \subpage md_docs_2design__docs_20053-native__gpu__hal
 */
 
 /**

--- a/docs/design_docs/provenance_debt.txt
+++ b/docs/design_docs/provenance_debt.txt
@@ -1,0 +1,27 @@
+# Historical design documents whose exact model provenance is not recoverable from the document or
+# repository history. New entries are prohibited. Remove an entry when supported metadata is added;
+# the provenance checker rejects stale entries.
+docs/design_docs/0001-terminal_image_viewer.md
+docs/design_docs/0002-mcp_test_triage_server.md
+docs/design_docs/0004-external_svg_references.md
+docs/design_docs/0006-color_emoji.md
+docs/design_docs/0007-coverage_improvement_plan.md
+docs/design_docs/0008-css_fonts.md
+docs/design_docs/0009-resvg_test_suite_bugs.md
+docs/design_docs/0011-v0_5_release.md
+docs/design_docs/0013-coverage_improvement.md
+docs/design_docs/0014-filter_performance.md
+docs/design_docs/0015-skia_filter_conformance.md
+docs/design_docs/0017-geode_renderer.md
+docs/design_docs/0018-bcr_release.md
+docs/design_docs/0020-editor.md
+docs/design_docs/0021-resvg_feature_gaps.md
+docs/design_docs/0022-resvg_test_suite_upgrade.md
+docs/design_docs/0038-geode_tinyskia_text_parity.md
+docs/design_docs/0041-geode_analytical_aa.md
+docs/design_docs/0042-geode_slug_conformance.md
+docs/design_docs/0043-deterministic_replay_testing.md
+docs/design_docs/0044-2-editor_fluid_canvas_rendering.md
+docs/design_docs/0045-editor_geode_chrome_migration.md
+docs/design_docs/0046-editor_group_layers.md
+docs/design_docs/0047-v0_8_showcase.md

--- a/docs/design_docs/provenance_debt.txt
+++ b/docs/design_docs/provenance_debt.txt
@@ -1,6 +1,7 @@
 # Historical design documents whose exact model provenance is not recoverable from the document or
 # repository history. New entries are prohibited. Remove an entry when supported metadata is added;
-# the provenance checker rejects stale entries.
+# the provenance checker rejects stale entries and entries outside its code-owned historical
+# baseline.
 docs/design_docs/0001-terminal_image_viewer.md
 docs/design_docs/0002-mcp_test_triage_server.md
 docs/design_docs/0004-external_svg_references.md

--- a/docs/design_docs/retrospective_template.md
+++ b/docs/design_docs/retrospective_template.md
@@ -2,7 +2,7 @@
 
 **Status:** Retrospective
 **Type:** Retrospective
-**Author:** Your Model (e.g. Codex GPT-5)
+**Author:** Exact Model Identifier (e.g. GPT-5.6 Sol)
 **Created:** YYYY-MM-DD
 
 ## Summary

--- a/docs/design_docs/text/0052-2-architecture.md
+++ b/docs/design_docs/text/0052-2-architecture.md
@@ -2,6 +2,8 @@
 
 [Back to hub](../0010-text_rendering.md)
 
+**Author:** Claude Opus 4.6
+
 > Historical note: this document captures the original dependency evaluation and phased design
 > before the `TextEngine` / `TextBackend` refactor landed. The current shipped architecture is
 > summarized in [the hub](../0010-text_rendering.md) and documented in

--- a/docs/design_docs/text/0052-3-rtl_and_complex_scripts.md
+++ b/docs/design_docs/text/0052-3-rtl_and_complex_scripts.md
@@ -2,6 +2,8 @@
 
 [Back to hub](../0010-text_rendering.md)
 
+**Author:** Claude Opus 4.6
+
 ## RTL Text and Complex Scripts (Phase 7) {#rtl}
 
 **Status:** Partially implemented

--- a/docs/design_docs/text/0052-4-testing.md
+++ b/docs/design_docs/text/0052-4-testing.md
@@ -2,6 +2,8 @@
 
 [Back to hub](../0010-text_rendering.md)
 
+**Author:** Claude Opus 4.6
+
 ## Testing and Validation
 
 ### Unit tests

--- a/docs/design_docs/text/0052-6-text_v1_release.md
+++ b/docs/design_docs/text/0052-6-text_v1_release.md
@@ -3,6 +3,7 @@
 [Back to hub](../0010-text_rendering.md)
 
 **Status:** Shipped
+**Author:** Claude Opus 4.6
 
 ## Overview
 

--- a/docs/design_docs/text/0052-7-textpath.md
+++ b/docs/design_docs/text/0052-7-textpath.md
@@ -3,6 +3,7 @@
 [Back to hub](../0010-text_rendering.md)
 
 **Status:** Shipped for Text v1
+**Author:** Claude Opus 4.6
 
 ## Overview
 

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -121,3 +121,17 @@ py_test(
     data = ["binary_size.sh"],
     deps = ["@rules_python//python/runfiles"],
 )
+
+py_binary(
+    name = "check_design_doc_provenance",
+    srcs = ["check_design_doc_provenance.py"],
+    visibility = ["//visibility:public"],
+)
+
+py_test(
+    name = "check_design_doc_provenance_tests",
+    srcs = [
+        "check_design_doc_provenance.py",
+        "check_design_doc_provenance_tests.py",
+    ],
+)

--- a/tools/check_design_doc_provenance.py
+++ b/tools/check_design_doc_provenance.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+AUTHOR_RE = re.compile(r"^\*\*Author:\*\*\s*(.+?)\\?\s*$", re.MULTILINE)
+MODEL_RE = re.compile(r"^\*\*Model:\*\*\s*(.+?)\\?\s*$", re.MULTILINE)
+HUMAN_ONLY_RE = re.compile(
+    r"^\*\*Model:\*\*\s*None \(human-only\)\\?\s*$", re.MULTILINE
+)
+EXACT_MODEL_RES = (
+    re.compile(r"^GPT-[0-9]+(?:\.[0-9]+)*(?: [A-Za-z][A-Za-z0-9.-]*)*$"),
+    re.compile(r"^Claude [A-Za-z][A-Za-z0-9.-]* [0-9]+(?:\.[0-9]+)*$"),
+)
+IGNORED_FILENAMES = {
+    "AGENTS.md",
+    "README.md",
+    "design_template.md",
+    "developer_template.md",
+    "retrospective_template.md",
+}
+
+
+@dataclass(frozen=True)
+class Violation:
+    path: str
+    message: str
+
+
+def is_exact_model_identifier(value: str) -> bool:
+    return "Codex" not in value and any(pattern.match(value) for pattern in EXACT_MODEL_RES)
+
+
+def is_design_doc(path: Path) -> bool:
+    if path.name in IGNORED_FILENAMES:
+        return False
+    return bool(re.match(r"^[0-9]{4}(?:-|\b)", path.name)) or path.name == "animation.md"
+
+
+def validate_document(path: Path, root: Path) -> Violation | None:
+    relative_path = path.relative_to(root).as_posix()
+    content = path.read_text(encoding="utf-8")
+    author_match = AUTHOR_RE.search(content)
+    if author_match is None:
+        return Violation(relative_path, "missing **Author:** metadata")
+
+    author = author_match.group(1).strip()
+    if "Codex" in author:
+        return Violation(
+            relative_path,
+            f"generic surface name in Author metadata: {author!r}",
+        )
+
+    if is_exact_model_identifier(author):
+        return None
+
+    model_match = MODEL_RE.search(content)
+    if model_match is not None and is_exact_model_identifier(model_match.group(1).strip()):
+        return None
+
+    if HUMAN_ONLY_RE.search(content):
+        return None
+
+    return Violation(
+        relative_path,
+        f"Author is not an exact model identifier and is not marked human-only: {author!r}",
+    )
+
+
+def collect_violations(root: Path) -> dict[str, Violation]:
+    design_root = root / "docs" / "design_docs"
+    return {
+        violation.path: violation
+        for path in sorted(design_root.rglob("*.md"))
+        if is_design_doc(path)
+        if (violation := validate_document(path, root)) is not None
+    }
+
+
+def load_debt_allowlist(path: Path) -> set[str]:
+    entries: set[str] = set()
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        entry = line.strip()
+        if not entry or entry.startswith("#"):
+            continue
+        if entry in entries:
+            raise ValueError(f"{path}:{line_number}: duplicate entry {entry!r}")
+        entries.add(entry)
+    return entries
+
+
+def check(root: Path, allowlist_path: Path) -> list[str]:
+    violations = collect_violations(root)
+    debt = load_debt_allowlist(allowlist_path)
+    errors = [
+        f"{violation.path}: {violation.message}"
+        for path, violation in sorted(violations.items())
+        if path not in debt
+    ]
+    errors.extend(
+        f"{path}: stale provenance-debt entry; remove it from {allowlist_path.relative_to(root)}"
+        for path in sorted(debt - violations.keys())
+    )
+    return errors
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Require exact model provenance on Donner design documents."
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Donner repository root",
+    )
+    parser.add_argument(
+        "--allowlist",
+        type=Path,
+        help="Historical provenance-debt file (defaults under docs/design_docs)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = args.root.resolve()
+    allowlist = args.allowlist or root / "docs" / "design_docs" / "provenance_debt.txt"
+    try:
+        errors = check(root, allowlist.resolve())
+    except (OSError, ValueError) as error:
+        print(f"design provenance check failed: {error}", file=sys.stderr)
+        return 1
+
+    if errors:
+        print("Design document provenance violations:", file=sys.stderr)
+        for error in errors:
+            print(f"  {error}", file=sys.stderr)
+        return 1
+
+    print("Design document provenance check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_design_doc_provenance.py
+++ b/tools/check_design_doc_provenance.py
@@ -24,6 +24,34 @@ IGNORED_FILENAMES = {
     "developer_template.md",
     "retrospective_template.md",
 }
+APPROVED_HISTORICAL_DEBT = frozenset(
+    {
+        "docs/design_docs/0001-terminal_image_viewer.md",
+        "docs/design_docs/0002-mcp_test_triage_server.md",
+        "docs/design_docs/0004-external_svg_references.md",
+        "docs/design_docs/0006-color_emoji.md",
+        "docs/design_docs/0007-coverage_improvement_plan.md",
+        "docs/design_docs/0008-css_fonts.md",
+        "docs/design_docs/0009-resvg_test_suite_bugs.md",
+        "docs/design_docs/0011-v0_5_release.md",
+        "docs/design_docs/0013-coverage_improvement.md",
+        "docs/design_docs/0014-filter_performance.md",
+        "docs/design_docs/0015-skia_filter_conformance.md",
+        "docs/design_docs/0017-geode_renderer.md",
+        "docs/design_docs/0018-bcr_release.md",
+        "docs/design_docs/0020-editor.md",
+        "docs/design_docs/0021-resvg_feature_gaps.md",
+        "docs/design_docs/0022-resvg_test_suite_upgrade.md",
+        "docs/design_docs/0038-geode_tinyskia_text_parity.md",
+        "docs/design_docs/0041-geode_analytical_aa.md",
+        "docs/design_docs/0042-geode_slug_conformance.md",
+        "docs/design_docs/0043-deterministic_replay_testing.md",
+        "docs/design_docs/0044-2-editor_fluid_canvas_rendering.md",
+        "docs/design_docs/0045-editor_geode_chrome_migration.md",
+        "docs/design_docs/0046-editor_group_layers.md",
+        "docs/design_docs/0047-v0_8_showcase.md",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -98,10 +126,14 @@ def check(root: Path, allowlist_path: Path) -> list[str]:
     violations = collect_violations(root)
     debt = load_debt_allowlist(allowlist_path)
     errors = [
+        f"{path}: unapproved provenance-debt entry; new debt is prohibited"
+        for path in sorted(debt - APPROVED_HISTORICAL_DEBT)
+    ]
+    errors.extend(
         f"{violation.path}: {violation.message}"
         for path, violation in sorted(violations.items())
         if path not in debt
-    ]
+    )
     errors.extend(
         f"{path}: stale provenance-debt entry; remove it from {allowlist_path.relative_to(root)}"
         for path in sorted(debt - violations.keys())

--- a/tools/check_design_doc_provenance_tests.py
+++ b/tools/check_design_doc_provenance_tests.py
@@ -74,14 +74,25 @@ class DesignDocProvenanceTests(unittest.TestCase):
         )
 
     def test_allowlist_ratchets_historical_debt(self):
-        path = self.write_design("0001-test.md", "**Author:** Codex")
-        relative_path = path.relative_to(self.root).as_posix()
+        relative_path = next(iter(provenance.APPROVED_HISTORICAL_DEBT))
+        path = self.root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("# Design: Test\n\n**Author:** Codex\n", encoding="utf-8")
         self.allowlist.write_text(f"{relative_path}\n", encoding="utf-8")
 
         self.assertEqual(provenance.check(self.root, self.allowlist), [])
 
         path.write_text("# Design: Test\n\n**Author:** GPT-5\n", encoding="utf-8")
         self.assertIn("stale provenance-debt entry", provenance.check(self.root, self.allowlist)[0])
+
+    def test_new_allowlist_entry_is_rejected(self):
+        path = self.write_design("0054-new-debt.md", "**Author:** Codex")
+        relative_path = path.relative_to(self.root).as_posix()
+        self.allowlist.write_text(f"{relative_path}\n", encoding="utf-8")
+
+        errors = provenance.check(self.root, self.allowlist)
+
+        self.assertTrue(any("unapproved provenance-debt entry" in error for error in errors))
 
     def test_non_design_markdown_is_ignored(self):
         self.write_design("README.md", "No author metadata")

--- a/tools/check_design_doc_provenance_tests.py
+++ b/tools/check_design_doc_provenance_tests.py
@@ -1,0 +1,94 @@
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("check_design_doc_provenance.py")
+MODULE_SPEC = importlib.util.spec_from_file_location("check_design_doc_provenance", MODULE_PATH)
+assert MODULE_SPEC is not None
+assert MODULE_SPEC.loader is not None
+provenance = importlib.util.module_from_spec(MODULE_SPEC)
+sys.modules[MODULE_SPEC.name] = provenance
+MODULE_SPEC.loader.exec_module(provenance)
+
+
+class DesignDocProvenanceTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.design_root = self.root / "docs" / "design_docs"
+        self.design_root.mkdir(parents=True)
+        self.allowlist = self.design_root / "provenance_debt.txt"
+        self.allowlist.write_text("", encoding="utf-8")
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def write_design(self, name: str, metadata: str) -> Path:
+        path = self.design_root / name
+        path.write_text(f"# Design: Test\n\n{metadata}\n", encoding="utf-8")
+        return path
+
+    def test_exact_model_identifier_passes(self):
+        self.write_design("0001-test.md", "**Author:** GPT-5.6 Sol")
+
+        self.assertEqual(provenance.check(self.root, self.allowlist), [])
+
+    def test_missing_author_fails(self):
+        self.write_design("0001-test.md", "**Status:** Draft")
+
+        self.assertIn("missing **Author:** metadata", provenance.check(self.root, self.allowlist)[0])
+
+    def test_generic_surface_name_fails(self):
+        self.write_design("0001-test.md", "**Author:** Codex")
+
+        self.assertIn("generic surface name", provenance.check(self.root, self.allowlist)[0])
+
+    def test_human_only_design_is_explicit(self):
+        self.write_design(
+            "0001-test.md",
+            "**Author:** Ada Lovelace\n**Model:** None (human-only)",
+        )
+
+        self.assertEqual(provenance.check(self.root, self.allowlist), [])
+
+    def test_human_author_with_exact_model_passes(self):
+        self.write_design(
+            "0001-test.md",
+            "**Author:** Ada Lovelace\n**Model:** GPT-5.6 Sol",
+        )
+
+        self.assertEqual(provenance.check(self.root, self.allowlist), [])
+
+    def test_author_metadata_must_not_contain_role_annotations(self):
+        self.write_design(
+            "0001-test.md",
+            "**Author:** Claude Opus 4.8 (Architect)",
+        )
+
+        self.assertIn(
+            "not an exact model identifier",
+            provenance.check(self.root, self.allowlist)[0],
+        )
+
+    def test_allowlist_ratchets_historical_debt(self):
+        path = self.write_design("0001-test.md", "**Author:** Codex")
+        relative_path = path.relative_to(self.root).as_posix()
+        self.allowlist.write_text(f"{relative_path}\n", encoding="utf-8")
+
+        self.assertEqual(provenance.check(self.root, self.allowlist), [])
+
+        path.write_text("# Design: Test\n\n**Author:** GPT-5\n", encoding="utf-8")
+        self.assertIn("stale provenance-debt entry", provenance.check(self.root, self.allowlist)[0])
+
+    def test_non_design_markdown_is_ignored(self):
+        self.write_design("README.md", "No author metadata")
+        self.write_design("developer_template.md", "No author metadata")
+
+        self.assertEqual(provenance.check(self.root, self.allowlist), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add Design 0053 for an original C++20 Donner GPU runtime with native Metal and Vulkan backends, a browser bridge, a typed shader IR, and a Rust-independent active build graph.
- Integrate the GPU cutover, clean-room constraints, security gates, release qualification, and proposed change sequence into the v1.0 release design.
- Require exact model identifiers on design documents, normalize recoverable historical metadata, and add a CI ratchet for unresolved provenance debt.

## Impact

This PR changes design documentation and repository tooling only. It does not change renderer or editor runtime behavior. The GPU implementation remains split into the reviewable packets described by Design 0053.

## Validation

- `bazel test //tools:check_design_doc_provenance_tests`
- `python3 tools/check_design_doc_provenance.py`
- `buildifier -mode=check tools/BUILD.bazel`
- Focused `dprint check` for Design 0053 and the design templates
- Doxygen generation completed; existing documentation-warning backlog remains
- `git diff --check`
