### PR TITLE
Diff changed files from merge-base, not base tip

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -76,9 +76,22 @@ jobs:
             return 1
           }
 
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          head_sha="${{ github.event.pull_request.head.sha }}"
+          # Diff from the merge-base, not the base tip: base.sha is the base
+          # branch's CURRENT tip, so a two-dot diff attributes post-fork drift
+          # on main to the PR and can wrongly clear docs_only for a genuine
+          # docs-only branch. Fail closed: if merge-base cannot be computed,
+          # keep the base-tip diff (drift can only flip docs_only to false,
+          # which runs MORE CI, never less).
+          if diff_base="$(git merge-base "$base_sha" "$head_sha")"; then
+            echo "Using merge-base $diff_base as diff basis."
+          else
+            echo "git merge-base failed; using base tip $base_sha as diff basis."
+            diff_base="$base_sha"
+          fi
           changed_files="$(git diff --name-only --diff-filter=ACMR \
-            "${{ github.event.pull_request.base.sha }}" \
-            "${{ github.event.pull_request.head.sha }}")"
+            "$diff_base" "$head_sha")"
 
           if [[ -z "$changed_files" ]]; then
             echo "docs_only=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -249,7 +249,21 @@ jobs:
             exit 0
           fi
 
-          changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+          # Diff from the merge-base, not the base tip. The event payload's
+          # base.sha is the base branch's CURRENT tip, so a two-dot diff
+          # attributes post-fork drift on main (e.g. a workflow file merged
+          # after this branch forked) to the PR, tripping the infra detector
+          # and forcing a spurious full //... fallback. Merge-base semantics
+          # sees only branch-side changes. Fail closed: if merge-base cannot
+          # be computed, keep the base-tip diff (over-inclusion only ever
+          # widens to the fallback path, never skips it).
+          if diff_base="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"; then
+            echo "Using merge-base $diff_base as diff basis."
+          else
+            echo "git merge-base failed; using base tip $BASE_SHA as diff basis."
+            diff_base="$BASE_SHA"
+          fi
+          changed_files="$(git diff --name-only "$diff_base" "$HEAD_SHA")"
           printf "%s\n" "$changed_files" > "$diagnostics_dir/changed-files.txt"
           changed_file_count="$(printf '%s\n' "$changed_files" | sed '/^$/d' | wc -l | tr -d ' ')"
           if (( changed_file_count > SELF_HOSTED_MAX_CHANGED_FILES )); then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,9 +100,22 @@ jobs:
             return 1
           }
 
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          head_sha="${{ github.event.pull_request.head.sha }}"
+          # Diff from the merge-base, not the base tip: base.sha is the base
+          # branch's CURRENT tip, so a two-dot diff attributes post-fork drift
+          # on main to the PR and can wrongly clear docs_only for a genuine
+          # docs-only branch. Fail closed: if merge-base cannot be computed,
+          # keep the base-tip diff (drift can only flip docs_only to false,
+          # which runs MORE CI, never less).
+          if diff_base="$(git merge-base "$base_sha" "$head_sha")"; then
+            echo "Using merge-base $diff_base as diff basis."
+          else
+            echo "git merge-base failed; using base tip $base_sha as diff basis."
+            diff_base="$base_sha"
+          fi
           changed_files="$(git diff --name-only --diff-filter=ACMR \
-            "${{ github.event.pull_request.base.sha }}" \
-            "${{ github.event.pull_request.head.sha }}")"
+            "$diff_base" "$head_sha")"
 
           if [[ -z "$changed_files" ]]; then
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
@@ -326,7 +339,21 @@ jobs:
 
           echo "full_test=false" >> "$GITHUB_OUTPUT"
 
-          changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+          # Diff from the merge-base, not the base tip. The event payload's
+          # base.sha is the base branch's CURRENT tip, so a two-dot diff
+          # attributes post-fork drift on main (e.g. a workflow file merged
+          # after this branch forked) to the PR, tripping the infra detector
+          # and forcing a spurious full //... fallback. Merge-base semantics
+          # sees only branch-side changes. Fail closed: if merge-base cannot
+          # be computed, keep the base-tip diff (over-inclusion only ever
+          # widens to the fallback path, never skips it).
+          if diff_base="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"; then
+            echo "Using merge-base $diff_base as diff basis."
+          else
+            echo "git merge-base failed; using base tip $BASE_SHA as diff basis."
+            diff_base="$BASE_SHA"
+          fi
+          changed_files="$(git diff --name-only "$diff_base" "$HEAD_SHA")"
           changed_file_count="$(printf '%s\n' "$changed_files" | sed '/^$/d' | wc -l | tr -d ' ')"
           large_change=false
           if (( changed_file_count > SELF_HOSTED_MAX_CHANGED_FILES )); then


### PR DESCRIPTION
## Problem

The changed-file detectors computed `git diff base.sha head.sha`. The
`pull_request` event payload's `base.sha` is the base branch's **current tip**,
not the fork point, so a two-dot diff attributes post-fork drift on main to the
PR. Every PR branched before a workflow change landed on main was flagged
`Infra change requires full //... coverage: .github/workflows/...` for a file
its branch never touched, replacing a ~6 minute scoped affected-target run with
a spurious full `//...` fallback (40-60 minutes). The docs-only detectors had
the same skew: base-side drift could wrongly clear `docs_only` for a genuine
docs-only branch.

## Fix

Compute the diff basis as `git merge-base BASE_SHA HEAD_SHA` so only branch-side
changes are attributed to the PR. All four sites that compute changed files are
fixed the same way (audited every `git diff` in the workflows; lint/sanitizers/
editor_wasm/fuzz have none):

| Workflow | Site |
| --- | --- |
| `coverage.yml` | determine-targets changed-file computation |
| `main.yml` | determine-targets changed-file computation |
| `main.yml` | gatekeeper docs-only detector |
| `cmake.yml` | gatekeeper docs-only detector |

**Fail closed:** if `git merge-base` fails, the diff basis falls back to the
previous base-tip behavior. Over-inclusion there only ever widens to the
fallback path (or flips `docs_only` to false, running more CI), never skips a
gate. All four sites run in jobs that check out with `fetch-depth: 0`, so the
merge-base is computable from full history; both SHAs were already required by
the existing two-dot diff.

## Validation (real refs)

| Case | Diff basis | Changed files | Detector verdict |
| --- | --- | --- | --- |
| Stale-fork docs+tools PR, base gained workflow changes after fork (pre-fix) | base tip | 8 files incl. `.github/workflows/coverage.yml` (never touched by the branch) | spurious `infra_fallback` |
| Same PR (post-fix) | merge-base | its true 5 branch-side files (docs + tools), zero `.github` | none - scoped run preserved |
| PR that genuinely modifies a workflow file (post-fix) | merge-base | includes `.github/workflows/coverage.yml` | `infra_fallback` (guard intact) |
| Bogus base SHA (merge-base fails) | falls back to base tip | n/a | current behavior (fallback), fail closed |

The exact new shell logic was exercised verbatim against these refs; the
stale-fork case's merge-base resolved to the true fork point and the flagged
workflow file disappeared from the attribution.

Note: this PR itself touches `.github/workflows/*`, so its own CI run takes the
fallback path by design (workflow changes must always fall back). The logic was
therefore verified locally via the table above rather than by this PR's own
routing.

Deliberately unchanged: bazel-diff's target hashing still compares the base-tip
worktree against the head worktree. That can over-include drift-affected targets
(slower, never unsound) and is a separate concern from the changed-file
detectors.

`YAML parses for all three workflows.`

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
