### PR TITLE
Skip PR coverage for wasm-platform-only affected sets

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,8 +30,14 @@ name: Coverage
 # detected from target KINDS via a bazel query over the affected set
 # (fallback_reason == no_instrumentable_targets), never from file extensions,
 # and the detection fails closed: any query/classifier error or unrecognized
-# rule kind runs coverage with the guard intact. A subset that DOES touch
-# instrumentable code keeps the guard at full strength. Future readers:
+# rule kind runs coverage with the guard intact. "Instrumentable" means
+# HOST-instrumentable: wasm-platform targets (the emsdk wasm_cc_binary
+# wrapper and its host-incompatible cc_binary shim, detected via a host
+# cquery) never emit host profile data, so a wasm-packaging-only subset
+# also skips instead of failing on a guaranteed-empty report. A subset
+# that DOES touch host-instrumentable code keeps the guard at full
+# strength: shared C++ sources always impact their host cc_library/cc_test
+# owners too, which classify as instrumentable. Future readers:
 # do not silently re-add a full instrumented PR coverage run.
 on:
   push:
@@ -414,13 +420,51 @@ jobs:
           if ( cd "$head_dir" && bazelisk query --query_file="$kind_query_file" \
               --output label_kind --keep_going ) > "$label_kind_file" 2> "$diagnostics_dir/kind-query.log"; then
             cp "$label_kind_file" "$diagnostics_dir/affected-label-kind.txt"
+            instrumentable_file="$work_dir/instrumentable-label-kind.txt"
             if instrumentable_decision="$(python3 tools/coverage_instrumentable_targets.py \
-                --label-kind-file "$label_kind_file" 2> "$diagnostics_dir/instrumentability.log")"; then
+                --label-kind-file "$label_kind_file" \
+                --instrumentable-out "$instrumentable_file" 2> "$diagnostics_dir/instrumentability.log")"; then
               cat "$diagnostics_dir/instrumentability.log" || true
               if [[ "$instrumentable_decision" == "instrumentable_present=false" ]]; then
                 echo "Affected subset has no instrumentable C/C++ targets; skipping PR coverage."
                 emit_targets true no_instrumentable_targets ""
                 exit 0
+              fi
+              # Host-compatibility recheck. "Instrumentable" means HOST-
+              # instrumentable: a wasm bridge shim is a plain cc_binary by
+              # kind but is target_compatible_with @platforms//:incompatible
+              # on the host, so --skip_incompatible_explicit_targets (set in
+              # --config=ci) silently drops it from the coverage build and
+              # the run is guaranteed to produce an empty report (the #810
+              # false RUN). Only when EVERY remaining instrumentable target
+              # is a cc_binary do we spend a cquery to test host
+              # compatibility; sets containing cc_library/cc_test/wrapper
+              # kinds are host code and run coverage with zero extra cost.
+              # Fail closed: cquery failure, or any label the cquery does
+              # not report as incompatible, keeps the coverage run.
+              if [[ -s "$instrumentable_file" ]] && ! grep -qv '^cc_binary rule ' "$instrumentable_file"; then
+                echo "All instrumentable targets are cc_binary; rechecking host compatibility."
+                compat_file="$work_dir/host-compat.txt"
+                sed 's/^cc_binary rule //' "$instrumentable_file" | tr '\n' ' ' > "$work_dir/compat-labels.txt"
+                if ( cd "$head_dir" && bazelisk cquery "set($(cat "$work_dir/compat-labels.txt"))" \
+                    --output=starlark \
+                    --starlark:expr='"{} {}".format(target.label, "HOST_INCOMPATIBLE" if "IncompatiblePlatformProvider" in providers(target) else "HOST_COMPATIBLE")' \
+                    ) > "$compat_file" 2> "$diagnostics_dir/compat-query.log"; then
+                  cp "$compat_file" "$diagnostics_dir/host-compat.txt"
+                  grep ' HOST_INCOMPATIBLE$' "$compat_file" | sed 's/ HOST_INCOMPATIBLE$//' > "$work_dir/host-incompatible.txt" || true
+                  if recheck_decision="$(python3 tools/coverage_instrumentable_targets.py \
+                      --label-kind-file "$label_kind_file" \
+                      --host-incompatible-file "$work_dir/host-incompatible.txt" 2>> "$diagnostics_dir/instrumentability.log")"; then
+                    if [[ "$recheck_decision" == "instrumentable_present=false" ]]; then
+                      echo "All remaining instrumentable targets are host-incompatible (wasm-platform); skipping PR coverage."
+                      emit_targets true no_instrumentable_targets ""
+                      exit 0
+                    fi
+                  fi
+                else
+                  echo "Host-compatibility cquery failed; running coverage (guard intact)."
+                  cat "$diagnostics_dir/compat-query.log" || true
+                fi
               fi
               echo "Affected subset includes instrumentable C/C++ targets; running coverage."
             else

--- a/tools/coverage_instrumentable_targets.py
+++ b/tools/coverage_instrumentable_targets.py
@@ -18,6 +18,14 @@ kind outside the non-instrumentable allowlist (every cc_* kind, the donner C++
 wrapper rules, and any kind this tool does not recognize) counts as
 instrumentable, so an unknown or newly-added C++ rule keeps the coverage guard at
 full strength rather than silently skipping it.
+
+Host-instrumentability refinement: "instrumentable" means HOST-instrumentable.
+Wasm-platform targets never produce host profile data: the emsdk wasm_cc_binary
+wrapper is excluded by kind, and the underlying wasm cc_binary shim (whose kind
+is indistinguishable from a host cc_binary) can be excluded by passing the
+host-configuration cquery incompatibility result via --host-incompatible-file.
+Labels absent from that file keep their kind-based classification, so a missing
+or partial incompatibility list still fails closed toward running coverage.
 """
 
 import argparse
@@ -71,6 +79,19 @@ NON_INSTRUMENTABLE_RULE_KINDS = frozenset(
         # Internal helper rules that emit files but no instrumented objects.
         "_expand_template",
         "_check_python_version",
+        # Wasm-platform packaging rules. The emsdk wasm_cc_binary wrapper (kind
+        # `_wasm_cc_binary`; both spellings listed defensively) transitions its
+        # cc_target to the wasm platform and only ever emits .js/.wasm
+        # artifacts. It can never contribute HOST profile data, so lcov can
+        # never see it, and running coverage over a wasm-only affected set
+        # yields an empty report that trips the "no executable line data"
+        # guard: a deterministic false RUN. The underlying `cc_binary` shim
+        # (target_compatible_with @platforms//:incompatible on the host) is NOT
+        # listed here: its kind is indistinguishable from a host cc_binary, so
+        # the coverage lane resolves it with a host-compatibility cquery and
+        # feeds the result in via --host-incompatible-file instead.
+        "_wasm_cc_binary",
+        "wasm_cc_binary",
     }
 )
 
@@ -92,6 +113,10 @@ class Classification:
 
     instrumentable: list[str] = field(default_factory=list)
     non_instrumentable: list[str] = field(default_factory=list)
+    # Original label_kind lines for the instrumentable bucket, so callers can
+    # inspect the kinds (e.g. the coverage lane's cc_binary-only
+    # host-compatibility recheck) without re-deriving them.
+    instrumentable_lines: list[str] = field(default_factory=list)
 
     @property
     def total(self) -> int:
@@ -121,11 +146,37 @@ def _split_kind_and_label(line: str) -> tuple[str, str]:
     return kind_phrase, label
 
 
-def classify(lines: list[str]) -> Classification:
+def normalize_label(label: str) -> str:
+    """Normalize a bazel label for comparison across query/cquery output.
+
+    `bazel cquery` prints canonical labels (`@@//pkg:name`) while `bazel query`
+    prints apparent ones (`//pkg:name`). Both refer to the main repository.
+
+    Args:
+        label: A bazel target label.
+
+    Returns:
+        The label with a leading `@@` or `@` main-repo prefix stripped.
+    """
+    if label.startswith("@@//"):
+        return label[2:]
+    if label.startswith("@//"):
+        return label[1:]
+    return label
+
+
+def classify(
+    lines: list[str], host_incompatible: frozenset[str] = frozenset()
+) -> Classification:
     """Classify label_kind output lines into instrumentable vs. not.
 
     Args:
         lines: Raw lines from `bazel query --output label_kind`.
+        host_incompatible: Normalized labels that a host-configuration cquery
+            reported as IncompatiblePlatformProvider (e.g. wasm-only cc_binary
+            shims). These can never contribute host coverage, so they classify
+            as non-instrumentable regardless of kind. Labels NOT in this set
+            keep their kind-based classification (fail closed).
 
     Returns:
         The bucketed classification.
@@ -139,6 +190,16 @@ def classify(lines: list[str]) -> Classification:
         if not kind_phrase:
             # No kind phrase (malformed): fail closed and treat as instrumentable.
             result.instrumentable.append(label)
+            result.instrumentable_lines.append(line)
+            continue
+        if normalize_label(label) in host_incompatible:
+            # Host-incompatible targets (e.g. a wasm bridge cc_binary marked
+            # target_compatible_with @platforms//:incompatible on the host)
+            # never produce host profile data; bazel's
+            # --skip_incompatible_explicit_targets silently drops them from the
+            # coverage build, so counting them as instrumentable would force a
+            # run whose report is guaranteed empty.
+            result.non_instrumentable.append(label)
             continue
         if kind_phrase in NON_RULE_PHRASES:
             result.non_instrumentable.append(label)
@@ -151,9 +212,11 @@ def classify(lines: list[str]) -> Classification:
                 # Every cc_* kind, the donner C++ wrapper rules, and any
                 # unrecognized rule kind land here: run coverage (fail closed).
                 result.instrumentable.append(label)
+                result.instrumentable_lines.append(line)
             continue
         # Unrecognized phrase shape: fail closed.
         result.instrumentable.append(label)
+        result.instrumentable_lines.append(line)
     return result
 
 
@@ -182,6 +245,25 @@ def main() -> int:
         required=True,
         help="File containing `bazel query --output label_kind` output.",
     )
+    parser.add_argument(
+        "--host-incompatible-file",
+        type=Path,
+        default=None,
+        help=(
+            "Optional file of labels (one per line) that a host-configuration "
+            "cquery reported as incompatible (IncompatiblePlatformProvider). "
+            "These classify as non-instrumentable regardless of kind."
+        ),
+    )
+    parser.add_argument(
+        "--instrumentable-out",
+        type=Path,
+        default=None,
+        help=(
+            "Optional path to write the label_kind lines of targets classified "
+            "as instrumentable, for the caller's host-compatibility recheck."
+        ),
+    )
     args = parser.parse_args()
 
     try:
@@ -193,8 +275,40 @@ def main() -> int:
         print(f"ERROR: could not read {args.label_kind_file}: {error}", file=sys.stderr)
         return 1
 
-    classification = classify(text.splitlines())
+    host_incompatible: frozenset[str] = frozenset()
+    if args.host_incompatible_file is not None:
+        try:
+            host_incompatible = frozenset(
+                normalize_label(line.strip())
+                for line in args.host_incompatible_file.read_text(
+                    encoding="utf-8", errors="replace"
+                ).splitlines()
+                if line.strip()
+            )
+        except OSError as error:
+            # Fail closed: an unreadable incompatibility list must never skip
+            # the gate, so classify without it (targets stay instrumentable).
+            print(
+                f"WARNING: could not read {args.host_incompatible_file}: {error}; "
+                "classifying without host-incompatibility data.",
+                file=sys.stderr,
+            )
+
+    classification = classify(text.splitlines(), host_incompatible)
     _print_summary(classification)
+
+    if args.instrumentable_out is not None:
+        try:
+            args.instrumentable_out.write_text(
+                "".join(f"{line}\n" for line in classification.instrumentable_lines),
+                encoding="utf-8",
+            )
+        except OSError as error:
+            print(
+                f"WARNING: could not write {args.instrumentable_out}: {error}",
+                file=sys.stderr,
+            )
+
     value = "true" if classification.instrumentable_present else "false"
     print(f"instrumentable_present={value}")
     return 0

--- a/tools/coverage_instrumentable_targets_tests.py
+++ b/tools/coverage_instrumentable_targets_tests.py
@@ -44,12 +44,85 @@ class ClassifyTest(unittest.TestCase):
         lines = [
             "donner_multi_transitioned_test rule //donner/svg:bar_skia",
             "_donner_perf_sensitive_cc_library rule //donner/svg:hot",
-            "_wasm_cc_binary rule //donner/svg:wasm_thing",
         ]
         result = mod.classify(lines)
         self.assertTrue(result.instrumentable_present)
-        self.assertEqual(len(result.instrumentable), 3)
+        self.assertEqual(len(result.instrumentable), 2)
         self.assertEqual(result.non_instrumentable, [])
+
+    def test_wasm_wrapper_rule_is_not_host_instrumentable(self):
+        # Regression (#810 shape): the emsdk wasm_cc_binary wrapper transitions
+        # to the wasm platform and emits .js/.wasm only. It can never produce
+        # host profile data, so a wasm-packaging-only affected set must SKIP
+        # coverage instead of building a guaranteed-empty report that trips the
+        # empty-coverage guard (a deterministic false RUN).
+        lines = [
+            "_wasm_cc_binary rule //donner/svg/renderer/wasm:donner_wasm",
+            "serve_http rule //donner/svg/renderer/wasm:serve_test",
+            "filegroup rule //donner/svg/renderer/wasm:test_page",
+        ]
+        result = mod.classify(lines)
+        self.assertFalse(result.instrumentable_present)
+        self.assertEqual(result.instrumentable, [])
+
+    def test_host_incompatible_cc_binary_is_not_instrumentable(self):
+        # The wasm bridge shim is a plain cc_binary by kind but is marked
+        # target_compatible_with @platforms//:incompatible on the host; bazel's
+        # --skip_incompatible_explicit_targets silently drops it from the
+        # coverage build. With the cquery result supplied, PR #810's real
+        # affected set classifies as skip.
+        lines = [
+            "filegroup rule //:docs_files",
+            "_wasm_cc_binary rule //donner/svg/renderer/wasm:donner_wasm",
+            "cc_binary rule //donner/svg/renderer/wasm:donner_wasm_bin",
+            "serve_http rule //donner/svg/renderer/wasm:serve_test",
+            "filegroup rule //donner/svg/renderer/wasm:test_page",
+            "py_test rule //tools:binary_size_tests",
+            "py_test rule //tools:coverage_instrumentable_targets_tests",
+        ]
+        incompatible = frozenset(["//donner/svg/renderer/wasm:donner_wasm_bin"])
+        result = mod.classify(lines, incompatible)
+        self.assertFalse(result.instrumentable_present)
+        self.assertEqual(result.instrumentable, [])
+
+    def test_host_incompatible_labels_normalize_canonical_form(self):
+        # cquery prints canonical labels (@@//pkg:name); query prints
+        # apparent ones (//pkg:name). They must match after normalization.
+        self.assertEqual(
+            mod.normalize_label("@@//donner/svg/renderer/wasm:donner_wasm_bin"),
+            "//donner/svg/renderer/wasm:donner_wasm_bin",
+        )
+        lines = ["cc_binary rule //donner/svg/renderer/wasm:donner_wasm_bin"]
+        incompatible = frozenset(
+            [mod.normalize_label("@@//donner/svg/renderer/wasm:donner_wasm_bin")]
+        )
+        result = mod.classify(lines, incompatible)
+        self.assertFalse(result.instrumentable_present)
+
+    def test_cc_binary_not_listed_incompatible_stays_instrumentable(self):
+        # Fail closed: a cc_binary absent from the host-incompatible list keeps
+        # its kind-based classification and forces a coverage run.
+        lines = [
+            "cc_binary rule //donner/svg/tool:donner-svg",
+            "cc_binary rule //donner/svg/renderer/wasm:donner_wasm_bin",
+        ]
+        incompatible = frozenset(["//donner/svg/renderer/wasm:donner_wasm_bin"])
+        result = mod.classify(lines, incompatible)
+        self.assertTrue(result.instrumentable_present)
+        self.assertEqual(result.instrumentable, ["//donner/svg/tool:donner-svg"])
+
+    def test_instrumentable_lines_expose_kinds(self):
+        # The coverage lane's recheck gate needs the KINDS of the instrumentable
+        # residue (it only cqueries cc_binary-only sets).
+        lines = [
+            "filegroup rule //:docs_files",
+            "cc_binary rule //donner/svg/renderer/wasm:donner_wasm_bin",
+        ]
+        result = mod.classify(lines)
+        self.assertEqual(
+            result.instrumentable_lines,
+            ["cc_binary rule //donner/svg/renderer/wasm:donner_wasm_bin"],
+        )
 
     def test_unknown_rule_kind_fails_closed(self):
         # An unrecognized rule kind must run coverage (uncertainty never skips).


### PR DESCRIPTION
## Problem

Third refinement of the coverage instrumentability gate (#822, #823), fixing the
inverse of #823's false skip: a **false run**. A PR whose affected set is
wasm-platform targets plus docs/py satellites (e.g. a wasm `linkopts`/BUILD-only
size optimization) ran coverage anyway:

- the affected set's only "instrumentable" kinds were the emsdk wasm wrapper
  (`_wasm_cc_binary`) and its `cc_binary` bridge shim;
- the shim is `target_compatible_with @platforms//:incompatible` on the host,
  so `--skip_incompatible_explicit_targets` (set in `--config=ci`) silently
  dropped both from the coverage build;
- the surviving docs/py targets produce no C++ line data, so the run was
  **guaranteed** to emit an empty LCOV report and trip the
  `no executable line data` guard - a deterministic red on every push.

## Fix

"Instrumentable" now means **HOST-instrumentable**, in two parts:

1. **Classifier kind:** `_wasm_cc_binary` (and the `wasm_cc_binary` spelling,
   defensively) is non-instrumentable by construction - it transitions its
   `cc_target` to the wasm platform and only ever emits `.js`/`.wasm`; lcov can
   never see host profile data from it.
2. **Host-compatibility recheck:** the wasm bridge shim is a plain `cc_binary`
   by kind, indistinguishable from a host `cc_binary`. When - and only when -
   every remaining instrumentable target is a `cc_binary`, the lane runs a
   host-configuration `cquery` testing `IncompatiblePlatformProvider` and
   re-runs the classifier with the incompatible labels excluded (new
   `--host-incompatible-file` option, with canonical `@@//` label
   normalization). Affected sets containing `cc_library`/`cc_test`/wrapper
   kinds are host code and run coverage with **zero added cost** (no cquery).

## Safety argument (verified)

Real code changes still run coverage: any diff touching C++ source shared with
host targets also impacts the owning host `cc_library`/`cc_test` in bazel-diff's
affected set (the wasm shim's deps are ordinary host libraries; its only
exclusive source is the wasm bridge translation unit). Those host kinds classify
as instrumentable with no recheck spent, so the guard keeps catching
silently-broken coverage collection. Only wasm-packaging/config-only diffs skip,
and that code can never appear in host lcov output.

Fail-closed posture unchanged:

- unknown rule kinds still classify instrumentable (run);
- cquery failure runs coverage with the guard intact;
- any label the cquery does not explicitly report as `HOST_INCOMPATIBLE` keeps
  its kind-based classification (run);
- a missing/unreadable incompatibility file classifies without it (run).

## Validation

Against the **real affected set** from the failing run's target-selection
artifact (7 targets), plus the prior regression cases, exercising the exact new
decision flow end to end (alias resolution, kind query, classifier, cquery
recheck; full battery runs in ~1.3s on a warm bazel server):

| Case | Resolved kinds | Recheck | Decision |
| --- | --- | --- | --- |
| failing PR's real affected set (wasm packaging + docs/py) | `filegroup` x2, `_wasm_cc_binary`, `cc_binary`, `serve_http`, `py_test` x2 | shim = `HOST_INCOMPATIBLE` | **skip** (was: false run) |
| geode C++ change | `cc_library` | none spent | run |
| alias resolving to `cc_test` (#823 case) | `cc_test` | none spent | run |
| mixed wasm `cc_binary` + host `cc_binary` | `cc_binary` x2 | one `HOST_INCOMPATIBLE`, one `HOST_COMPATIBLE` | run |
| docs + tools only (#822 case) | `filegroup`, `py_test` | n/a | skip |

Unit tests are red-then-green: the wasm wrapper test and the host-incompatible
`cc_binary` test both fail against the pre-fix classifier and pass after. 16/16
tests pass, also as a bazel `py_test`.

Because this PR itself touches the coverage workflow and its tooling, its own
coverage run takes the smoke path; the table above and the unit tests confirm
the wasm behavior independent of this PR's own run.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
