### PR TITLE
Editor: add bidirectional source diagnostics

### DIFF
--- a/donner/editor/AsyncSVGDocument.cc
+++ b/donner/editor/AsyncSVGDocument.cc
@@ -1,5 +1,8 @@
 #include "donner/editor/AsyncSVGDocument.h"
 
+#include <algorithm>
+#include <cstddef>
+
 #include "donner/base/ParseWarningSink.h"
 #include "donner/base/xml/XMLQualifiedName.h"
 #include "donner/editor/EditorParseOptions.h"
@@ -13,8 +16,12 @@ namespace donner::editor {
 
 namespace {
 
+constexpr std::size_t kMaxPublishedParseDiagnostics = 256;
+
 std::vector<ParseDiagnostic> CopyWarnings(const ParseWarningSink& sink) {
-  return std::vector<ParseDiagnostic>(sink.warnings().begin(), sink.warnings().end());
+  const auto& warnings = sink.warnings();
+  const std::size_t count = std::min(warnings.size(), kMaxPublishedParseDiagnostics);
+  return std::vector<ParseDiagnostic>(warnings.begin(), warnings.begin() + count);
 }
 
 bool InvalidatesExistingCompositedPixels(const EditorCommand& command) {
@@ -41,6 +48,12 @@ AsyncSVGDocument::AsyncSVGDocument() = default;
 void AsyncSVGDocument::publishParseDiagnostics(std::vector<ParseDiagnostic> warnings,
                                                std::optional<ParseDiagnostic> fatalError) {
   lastParseError_ = fatalError;
+  if (warnings.size() > kMaxPublishedParseDiagnostics) {
+    warnings.resize(kMaxPublishedParseDiagnostics);
+  }
+  if (fatalError.has_value() && warnings.size() == kMaxPublishedParseDiagnostics) {
+    warnings.pop_back();
+  }
   parseDiagnostics_ = std::move(warnings);
   if (fatalError.has_value()) {
     parseDiagnostics_.push_back(std::move(*fatalError));

--- a/donner/editor/AsyncSVGDocument.cc
+++ b/donner/editor/AsyncSVGDocument.cc
@@ -13,6 +13,10 @@ namespace donner::editor {
 
 namespace {
 
+std::vector<ParseDiagnostic> CopyWarnings(const ParseWarningSink& sink) {
+  return std::vector<ParseDiagnostic>(sink.warnings().begin(), sink.warnings().end());
+}
+
 bool InvalidatesExistingCompositedPixels(const EditorCommand& command) {
   switch (command.kind) {
     case EditorCommand::Kind::SetAttribute:
@@ -34,10 +38,20 @@ bool InvalidatesExistingCompositedPixels(const EditorCommand& command) {
 
 AsyncSVGDocument::AsyncSVGDocument() = default;
 
+void AsyncSVGDocument::publishParseDiagnostics(std::vector<ParseDiagnostic> warnings,
+                                               std::optional<ParseDiagnostic> fatalError) {
+  lastParseError_ = fatalError;
+  parseDiagnostics_ = std::move(warnings);
+  if (fatalError.has_value()) {
+    parseDiagnostics_.push_back(std::move(*fatalError));
+  }
+  ++parseDiagnosticsRevision_;
+}
+
 void AsyncSVGDocument::setDocument(svg::SVGDocument document) {
   document_ = std::move(document);
   queue_.clear();
-  lastParseError_.reset();
+  publishParseDiagnostics({}, std::nullopt);
   pendingStructuralRemap_.clear();
   frameVersion_.fetch_add(1, std::memory_order_release);
   documentGeneration_.fetch_add(1, std::memory_order_release);
@@ -77,7 +91,7 @@ AsyncSVGDocument::ReplaceKind AsyncSVGDocument::setDocumentMaybeStructural(
   // after.
   document_ = std::move(newDocument);
   queue_.clear();
-  lastParseError_.reset();
+  publishParseDiagnostics({}, std::nullopt);
   frameVersion_.fetch_add(1, std::memory_order_release);
   documentGeneration_.fetch_add(1, std::memory_order_release);
 
@@ -163,16 +177,12 @@ xml::ApplySourceEditResult AsyncSVGDocument::applySourceEdit(const xml::XMLEditI
     xml::ApplySourceEditResult result;
     result.diagnostic =
         ParseDiagnostic::Error("Cannot apply source edit without a loaded document", intent.range);
-    lastParseError_ = result.diagnostic;
+    publishParseDiagnostics({}, result.diagnostic);
     return result;
   }
 
   xml::ApplySourceEditResult result = document_->applySourceEdit(intent);
-  if (result.diagnostic.has_value()) {
-    lastParseError_ = result.diagnostic;
-  } else {
-    lastParseError_.reset();
-  }
+  publishParseDiagnostics({}, result.diagnostic);
 
   if (result.applied || !result.mutations.empty()) {
     frameVersion_.fetch_add(1, std::memory_order_release);
@@ -190,10 +200,11 @@ bool AsyncSVGDocument::loadFromString(std::string_view svgBytes) {
     // until the source parses again. We deliberately do NOT bump the
     // frame version: the renderer's view of the document is unchanged,
     // and the source pane polls `lastParseError()` directly.
-    lastParseError_ = std::move(result.error());
+    publishParseDiagnostics(CopyWarnings(sink), std::move(result.error()));
     return false;
   }
   setDocument(std::move(result.result()));
+  publishParseDiagnostics(CopyWarnings(sink), std::nullopt);
   return true;
 }
 
@@ -239,10 +250,11 @@ void AsyncSVGDocument::applyOne(const EditorCommand& command) {
         ParseWarningSink sink;
         auto result = svg::parser::SVGParser::ParseSVG(command.bytes, sink, EditorParseOptions());
         if (result.hasError()) {
-          lastParseError_ = std::move(result.error());
+          publishParseDiagnostics(CopyWarnings(sink), std::move(result.error()));
           return;
         }
         (void)setDocumentMaybeStructural(std::move(result).result());
+        publishParseDiagnostics(CopyWarnings(sink), std::nullopt);
       } else {
         (void)loadFromString(command.bytes);
       }
@@ -291,7 +303,7 @@ void AsyncSVGDocument::applyOne(const EditorCommand& command) {
       lastFlushResult_.sourceDeltas.insert(lastFlushResult_.sourceDeltas.end(),
                                            result.sourceDeltas.begin(), result.sourceDeltas.end());
       if (result.diagnostic.has_value()) {
-        lastParseError_ = std::move(result.diagnostic);
+        publishParseDiagnostics({}, std::move(result.diagnostic));
       }
       break;
     }
@@ -324,10 +336,11 @@ void AsyncSVGDocument::applyOne(const EditorCommand& command) {
       ParseWarningSink sink;
       auto result = svg::parser::SVGParser::ParseSVG(command.bytes, sink, EditorParseOptions());
       if (result.hasError()) {
-        lastParseError_ = std::move(result.error());
+        publishParseDiagnostics(CopyWarnings(sink), std::move(result.error()));
         return;
       }
       (void)setDocumentMaybeStructural(std::move(result).result());
+      publishParseDiagnostics(CopyWarnings(sink), std::nullopt);
       break;
     }
 
@@ -345,7 +358,7 @@ void AsyncSVGDocument::applyOne(const EditorCommand& command) {
       lastFlushResult_.sourceDeltas.insert(lastFlushResult_.sourceDeltas.end(),
                                            result.sourceDeltas.begin(), result.sourceDeltas.end());
       if (result.diagnostic.has_value()) {
-        lastParseError_ = std::move(result.diagnostic);
+        publishParseDiagnostics({}, std::move(result.diagnostic));
       }
       if (textElement.isa<svg::SVGTextContentElement>()) {
         // Mirror the initial content into the XML tree/source as well: the
@@ -358,7 +371,7 @@ void AsyncSVGDocument::applyOne(const EditorCommand& command) {
                                                textResult.sourceDeltas.begin(),
                                                textResult.sourceDeltas.end());
           if (textResult.diagnostic.has_value() && !lastParseError_.has_value()) {
-            lastParseError_ = std::move(textResult.diagnostic);
+            publishParseDiagnostics({}, std::move(textResult.diagnostic));
           }
         }
         textElement.cast<svg::SVGTextContentElement>().setTextContent(command.textContent);
@@ -383,7 +396,7 @@ void AsyncSVGDocument::applyOne(const EditorCommand& command) {
       lastFlushResult_.sourceDeltas.insert(lastFlushResult_.sourceDeltas.end(),
                                            result.sourceDeltas.begin(), result.sourceDeltas.end());
       if (result.diagnostic.has_value() && !lastParseError_.has_value()) {
-        lastParseError_ = std::move(result.diagnostic);
+        publishParseDiagnostics({}, std::move(result.diagnostic));
       }
       if (textElement.isa<svg::SVGTextContentElement>()) {
         textElement.cast<svg::SVGTextContentElement>().setTextContent(command.textContent);

--- a/donner/editor/AsyncSVGDocument.h
+++ b/donner/editor/AsyncSVGDocument.h
@@ -165,6 +165,14 @@ public:
     return lastParseError_;
   }
 
+  /// All warnings and the fatal error, if any, published by the most recent parse operation.
+  [[nodiscard]] const std::vector<ParseDiagnostic>& parseDiagnostics() const {
+    return parseDiagnostics_;
+  }
+
+  /// Monotonic revision for \ref parseDiagnostics.
+  [[nodiscard]] std::uint64_t parseDiagnosticsRevision() const { return parseDiagnosticsRevision_; }
+
 private:
   // Apply a single (already-coalesced) command. SetTransform finds the
   // target element via the document's Registry and calls
@@ -174,6 +182,9 @@ private:
 
   /// Remap any element handles in `command` through a structural writeback replacement.
   void remapCommandTargets(EditorCommand* command, const std::unordered_map<Entity, Entity>& remap);
+
+  void publishParseDiagnostics(std::vector<ParseDiagnostic> warnings,
+                               std::optional<ParseDiagnostic> fatalError);
 
   std::optional<svg::SVGDocument> document_;
   CommandQueue queue_;
@@ -188,6 +199,8 @@ private:
   /// replacement since the last consumption.
   std::unordered_map<Entity, Entity> pendingStructuralRemap_;
   std::optional<ParseDiagnostic> lastParseError_;
+  std::vector<ParseDiagnostic> parseDiagnostics_;
+  std::uint64_t parseDiagnosticsRevision_ = 0;
   FlushResult lastFlushResult_;
 };
 

--- a/donner/editor/BUILD.bazel
+++ b/donner/editor/BUILD.bazel
@@ -360,6 +360,27 @@ donner_cc_library(
 )
 
 donner_cc_library(
+    name = "source_diagnostics",
+    srcs = ["SourceDiagnostics.cc"],
+    hdrs = ["SourceDiagnostics.h"],
+    deps = [
+        ":flash_decorations",
+        "//donner/base",
+    ],
+)
+
+donner_cc_library(
+    name = "source_diagnostics_panel",
+    srcs = ["SourceDiagnosticsPanel.cc"],
+    hdrs = ["SourceDiagnosticsPanel.h"],
+    deps = [
+        ":imgui_headers",
+        ":source_diagnostics",
+        "@imgui",
+    ],
+)
+
+donner_cc_library(
     name = "shape_clipboard_payload",
     srcs = ["ShapeClipboardPayload.cc"],
     hdrs = ["ShapeClipboardPayload.h"],
@@ -591,6 +612,7 @@ donner_cc_library(
         ":editor_app",
         ":imgui_headers",
         ":select_tool",
+        ":source_diagnostics",
         ":source_edit_intent",
         ":source_sync",
         ":text_editor",
@@ -910,6 +932,7 @@ donner_cc_library(
         ":shape_clipboard_commands",
         ":shape_clipboard_payload",
         ":sidebar_presenter",
+        ":source_diagnostics_panel",
         ":source_selection",
         ":style_source_annotations",
         ":text_editor",
@@ -1332,6 +1355,7 @@ donner_cc_library(
         ":imgui_headers",
         ":rope_simulation",
         ":soft_wrap",
+        ":source_diagnostics",
         ":source_edit_intent",
         ":text_buffer",
         ":text_editor_core",

--- a/donner/editor/DocumentSyncController.cc
+++ b/donner/editor/DocumentSyncController.cc
@@ -16,7 +16,6 @@ namespace donner::editor {
 namespace {
 
 constexpr float kTextChangeDebounceSeconds = 0.15f;
-constexpr int kNoErrorLine = -1;
 
 struct SourceMirrorEdit {
   std::size_t offset = 0;
@@ -300,30 +299,37 @@ void DocumentSyncController::resetForLoadedDocument(const std::string& source) {
   pendingTransformWritebacks_.clear();
   pendingElementRemoveWritebacks_.clear();
   pendingSourceEditIntents_.clear();
-  lastShownErrorLine_ = kNoErrorLine;
-  lastShownErrorReason_.clear();
+  sourceDiagnostics_ = {};
+  lastSyncedDiagnosticsRevision_ = std::numeric_limits<std::uint64_t>::max();
   textChangePending_ = false;
   textDispatchThrottled_ = false;
   textChangeIdleTimer_ = 0.0f;
 }
 
 void DocumentSyncController::syncParseErrorMarkers(EditorApp& app, TextEditor& textEditor) {
-  const auto& parseError = app.document().lastParseError();
-  if (parseError.has_value()) {
-    const int line = parseError->range.start.lineInfo.has_value()
-                         ? static_cast<int>(parseError->range.start.lineInfo->line)
-                         : 1;
-    const std::string_view reasonSv = parseError->reason;
-    if (line != lastShownErrorLine_ || reasonSv != lastShownErrorReason_) {
-      textEditor.setErrorMarkers(ParseErrorToMarkers(*parseError));
-      lastShownErrorLine_ = line;
-      lastShownErrorReason_.assign(reasonSv);
-    }
-  } else if (lastShownErrorLine_ != kNoErrorLine) {
-    textEditor.setErrorMarkers({});
-    lastShownErrorLine_ = kNoErrorLine;
-    lastShownErrorReason_.clear();
+  const std::uint64_t revision = app.document().parseDiagnosticsRevision();
+  if (revision == lastSyncedDiagnosticsRevision_) {
+    return;
   }
+
+  sourceDiagnostics_ = BuildSourceDiagnosticSnapshot(app.document().parseDiagnostics(),
+                                                     textEditor.getText(), revision);
+  lastSyncedDiagnosticsRevision_ = revision;
+  textEditor.setSourceDiagnostics(sourceDiagnostics_.diagnostics);
+
+  TextEditor::ErrorMarkers markers;
+  for (const SourceDiagnostic& diagnostic : sourceDiagnostics_.diagnostics) {
+    if (diagnostic.severity != DiagnosticSeverity::Error) {
+      continue;
+    }
+
+    std::string& message = markers[static_cast<int>(diagnostic.line)];
+    if (!message.empty()) {
+      message += '\n';
+    }
+    message += diagnostic.message;
+  }
+  textEditor.setErrorMarkers(markers);
 }
 
 bool DocumentSyncController::mirrorSourceDeltas(
@@ -531,14 +537,6 @@ void DocumentSyncController::applyPendingWritebacks(EditorApp& app, SelectTool& 
   applyPatches(source, patches);
   textEditor.setText(source, /*preserveScroll=*/true);
   QueueSourceWritebackReparse(app, source, &previousSourceText_, &lastWritebackSourceText_);
-}
-
-TextEditor::ErrorMarkers DocumentSyncController::ParseErrorToMarkers(const ParseDiagnostic& diag) {
-  TextEditor::ErrorMarkers markers;
-  const auto& start = diag.range.start;
-  const int line = start.lineInfo.has_value() ? static_cast<int>(start.lineInfo->line) : 1;
-  markers.emplace(line, std::string(std::string_view(diag.reason)));
-  return markers;
 }
 
 }  // namespace donner::editor

--- a/donner/editor/DocumentSyncController.h
+++ b/donner/editor/DocumentSyncController.h
@@ -1,6 +1,7 @@
 #pragma once
 /// @file
 
+#include <limits>
 #include <optional>
 #include <string>
 #include <vector>
@@ -8,6 +9,7 @@
 #include "donner/base/ParseDiagnostic.h"
 #include "donner/editor/AttributeWriteback.h"
 #include "donner/editor/EditorApp.h"
+#include "donner/editor/SourceDiagnostics.h"
 #include "donner/editor/SourceEditIntent.h"
 #include "donner/editor/TextEditor.h"
 
@@ -23,6 +25,10 @@ public:
   void resetForLoadedDocument(const std::string& source);
 
   void syncParseErrorMarkers(EditorApp& app, TextEditor& textEditor);
+  /// Diagnostics normalized for the current source buffer and parse revision.
+  [[nodiscard]] const SourceDiagnosticSnapshot& sourceDiagnostics() const {
+    return sourceDiagnostics_;
+  }
   /**
    * Mirror XML-owned source deltas into the source pane.
    *
@@ -44,8 +50,6 @@ public:
   void applyPendingWritebacks(EditorApp& app, SelectTool& selectTool, TextEditor& textEditor);
 
 private:
-  static TextEditor::ErrorMarkers ParseErrorToMarkers(const ParseDiagnostic& diag);
-
   std::string previousSourceText_;
   std::optional<std::string> lastWritebackSourceText_;
   /// Pending transform writebacks that haven't been reflected in the source
@@ -55,8 +59,8 @@ private:
   std::vector<EditorApp::CompletedElementRemoveWriteback> pendingElementRemoveWritebacks_;
   std::vector<SourceEditIntent> pendingSourceEditIntents_;
 
-  int lastShownErrorLine_ = -1;
-  std::string lastShownErrorReason_;
+  SourceDiagnosticSnapshot sourceDiagnostics_;
+  std::uint64_t lastSyncedDiagnosticsRevision_ = std::numeric_limits<std::uint64_t>::max();
 
   bool textChangePending_ = false;
   bool textDispatchThrottled_ = false;

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -2149,7 +2149,9 @@ void EditorShell::renderSourcePane(float paneOriginY, float paneHeight, float pa
   ImGui::SetNextWindowPos(ImVec2(0.0f, paneOriginY), ImGuiCond_Always);
   ImGui::SetNextWindowSize(ImVec2(paneWidth, paneHeight), ImGuiCond_Always);
   ImGui::Begin("Source", nullptr, kPaneFlags);
-  const auto& diagnostics = documentSyncController_.sourceDiagnostics().diagnostics;
+  // TextEditor owns the canonical, edit-remapped diagnostic ranges used for both inline
+  // highlighting and panel activation. The controller snapshot remains parse-revision evidence.
+  const auto& diagnostics = textEditor_.sourceDiagnostics();
   const float availableHeight = ImGui::GetContentRegionAvail().y;
   const float diagnosticsHeight = diagnostics.empty()
                                       ? 0.0f

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -2149,16 +2149,43 @@ void EditorShell::renderSourcePane(float paneOriginY, float paneHeight, float pa
   ImGui::SetNextWindowPos(ImVec2(0.0f, paneOriginY), ImGuiCond_Always);
   ImGui::SetNextWindowSize(ImVec2(paneWidth, paneHeight), ImGuiCond_Always);
   ImGui::Begin("Source", nullptr, kPaneFlags);
+  const auto& diagnostics = documentSyncController_.sourceDiagnostics().diagnostics;
+  const float availableHeight = ImGui::GetContentRegionAvail().y;
+  const float diagnosticsHeight = diagnostics.empty()
+                                      ? 0.0f
+                                      : std::min(std::clamp(paneHeight * 0.30f, 118.0f, 220.0f),
+                                                 std::max(0.0f, availableHeight - 80.0f));
   ImGui::PushFont(codeFont);
   textEditor_.setSourceFocusModeContextMenu(sourceFocusMode_);
   updateSourceStyleDecorations();
-  textEditor_.render("##source");
+  textEditor_.render("##source",
+                     ImVec2(0.0f, diagnosticsHeight > 0.0f ? -diagnosticsHeight : 0.0f));
   applySourceStyleDecorationChipClick();
   if (textEditor_.takeSourceFocusModeContextMenuToggleRequest()) {
     toggleSourceFocusMode();
   }
   syncSelectionFromSourceCursorIfNeeded();
+  const std::optional<std::uint64_t> sourceHoveredDiagnostic =
+      textEditor_.hoveredSourceDiagnosticId();
   ImGui::PopFont();
+
+  if (diagnosticsHeight > 0.0f) {
+    const SourceDiagnosticsPanelAction diagnosticsAction =
+        sourceDiagnosticsPanel_.render(diagnostics, sourceHoveredDiagnostic, diagnosticsHeight);
+    textEditor_.setActiveSourceDiagnosticId(diagnosticsAction.hoveredId.has_value()
+                                                ? diagnosticsAction.hoveredId
+                                                : sourceHoveredDiagnostic);
+    if (diagnosticsAction.activatedId.has_value()) {
+      if (const SourceDiagnostic* diagnostic =
+              FindSourceDiagnostic(diagnostics, *diagnosticsAction.activatedId)) {
+        textEditor_.selectAndFocus(textEditor_.getCoordinatesAtByteOffset(diagnostic->range.start),
+                                   textEditor_.getCoordinatesAtByteOffset(diagnostic->range.end));
+        textEditor_.flashSourceRange(diagnostic->range);
+      }
+    }
+  } else {
+    textEditor_.setActiveSourceDiagnosticId(std::nullopt);
+  }
   const bool sourceEditShouldPreserveCursor =
       textEditor_.isTextChanged() && sourceFocusMode_ && textEditor_.isCursorInsideFocusRange();
   if (textEditor_.isTextChanged()) {

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -31,6 +31,7 @@
 #include "donner/editor/RotateCursorSet.h"
 #include "donner/editor/SelectTool.h"
 #include "donner/editor/SidebarPresenter.h"
+#include "donner/editor/SourceDiagnosticsPanel.h"
 #include "donner/editor/StyleSourceAnnotations.h"
 #include "donner/editor/TextEditor.h"
 #include "donner/editor/TextFormatBarPresenter.h"
@@ -449,6 +450,7 @@ private:
   };
   ActiveTool activeTool_ = ActiveTool::Select;
   TextEditor textEditor_;
+  SourceDiagnosticsPanel sourceDiagnosticsPanel_;
   /// Backing store for shape Cut/Copy/Paste. Holds the headered
   /// `# donner-shape-clipboard v1` payload (see `ShapeClipboardPayload`).
   std::unique_ptr<ClipboardInterface> shapeClipboard_;

--- a/donner/editor/SourceDiagnostics.cc
+++ b/donner/editor/SourceDiagnostics.cc
@@ -83,14 +83,16 @@ SourceDiagnosticSnapshot BuildSourceDiagnosticSnapshot(std::span<const ParseDiag
     const SourceByteRange range = NormalizeRange(diagnostic.range, source);
     const std::size_t sourceOffset = std::min(
         diagnostic.range.start.resolveOffset(source).offset.value(), source.size());
-    const FileOffset::LineInfo lineInfo = diagnostic.range.start.lineInfo.value_or(
-        RecoverLineInfo(lineStarts, sourceOffset));
+    const FileOffset::LineInfo lineInfo = RecoverLineInfo(lineStarts, sourceOffset);
+    const FileOffset::LineInfo endLineInfo = RecoverLineInfo(lineStarts, range.end);
     snapshot.diagnostics.push_back(SourceDiagnostic{
         .id = DiagnosticId(diagnostic, range, revision, i),
         .severity = diagnostic.severity,
         .range = range,
         .line = lineInfo.line,
         .column = lineInfo.offsetOnLine,
+        .endLine = endLineInfo.line,
+        .endColumn = endLineInfo.offsetOnLine,
         .message = std::string(std::string_view(diagnostic.reason)),
     });
   }

--- a/donner/editor/SourceDiagnostics.cc
+++ b/donner/editor/SourceDiagnostics.cc
@@ -1,0 +1,96 @@
+#include "donner/editor/SourceDiagnostics.h"
+
+#include <algorithm>
+#include <limits>
+
+namespace donner::editor {
+namespace {
+
+constexpr std::size_t kMaxPublishedDiagnostics = 256;
+constexpr std::uint64_t kFnvOffsetBasis = 14695981039346656037ull;
+constexpr std::uint64_t kFnvPrime = 1099511628211ull;
+
+void HashByte(std::uint64_t* hash, std::uint8_t byte) {
+  *hash ^= byte;
+  *hash *= kFnvPrime;
+}
+
+void HashSize(std::uint64_t* hash, std::size_t value) {
+  for (std::size_t i = 0; i < sizeof(value); ++i) {
+    HashByte(hash, static_cast<std::uint8_t>(value & 0xffu));
+    value >>= 8u;
+  }
+}
+
+std::uint64_t DiagnosticId(const ParseDiagnostic& diagnostic, SourceByteRange range,
+                           std::uint64_t revision, std::size_t index) {
+  std::uint64_t hash = kFnvOffsetBasis;
+  HashSize(&hash, static_cast<std::size_t>(revision));
+  HashSize(&hash, index);
+  HashSize(&hash, static_cast<std::size_t>(diagnostic.severity));
+  HashSize(&hash, range.start);
+  HashSize(&hash, range.end);
+  for (const char value : std::string_view(diagnostic.reason)) {
+    HashByte(&hash, static_cast<std::uint8_t>(value));
+  }
+  return hash;
+}
+
+SourceByteRange NormalizeRange(const SourceRange& range, std::string_view source) {
+  const std::size_t start =
+      std::min(range.start.resolveOffset(source).offset.value(), source.size());
+  std::size_t end = std::min(range.end.resolveOffset(source).offset.value(), source.size());
+  end = std::max(start, end);
+
+  if (start == end && !source.empty()) {
+    if (end < source.size()) {
+      ++end;
+    } else {
+      return SourceByteRange{start - 1, start};
+    }
+  }
+
+  return SourceByteRange{start, end};
+}
+
+FileOffset::LineInfo RecoverLineInfo(std::string_view source, std::size_t offset) {
+  offset = std::min(offset, source.size());
+  FileOffset::LineInfo result{1, 0};
+  for (std::size_t i = 0; i < offset; ++i) {
+    if (source[i] == '\n') {
+      ++result.line;
+      result.offsetOnLine = 0;
+    } else {
+      ++result.offsetOnLine;
+    }
+  }
+  return result;
+}
+
+}  // namespace
+
+SourceDiagnosticSnapshot BuildSourceDiagnosticSnapshot(std::span<const ParseDiagnostic> diagnostics,
+                                                       std::string_view source,
+                                                       std::uint64_t revision) {
+  SourceDiagnosticSnapshot snapshot{.revision = revision};
+  snapshot.diagnostics.reserve(std::min(diagnostics.size(), kMaxPublishedDiagnostics));
+
+  for (std::size_t i = 0; i < diagnostics.size() && i < kMaxPublishedDiagnostics; ++i) {
+    const ParseDiagnostic& diagnostic = diagnostics[i];
+    const SourceByteRange range = NormalizeRange(diagnostic.range, source);
+    const FileOffset::LineInfo lineInfo = diagnostic.range.start.lineInfo.value_or(
+        RecoverLineInfo(source, diagnostic.range.start.resolveOffset(source).offset.value()));
+    snapshot.diagnostics.push_back(SourceDiagnostic{
+        .id = DiagnosticId(diagnostic, range, revision, i),
+        .severity = diagnostic.severity,
+        .range = range,
+        .line = lineInfo.line,
+        .column = lineInfo.offsetOnLine,
+        .message = std::string(std::string_view(diagnostic.reason)),
+    });
+  }
+
+  return snapshot;
+}
+
+}  // namespace donner::editor

--- a/donner/editor/SourceDiagnostics.cc
+++ b/donner/editor/SourceDiagnostics.cc
@@ -53,18 +53,20 @@ SourceByteRange NormalizeRange(const SourceRange& range, std::string_view source
   return SourceByteRange{start, end};
 }
 
-FileOffset::LineInfo RecoverLineInfo(std::string_view source, std::size_t offset) {
-  offset = std::min(offset, source.size());
-  FileOffset::LineInfo result{1, 0};
-  for (std::size_t i = 0; i < offset; ++i) {
+std::vector<std::size_t> BuildLineStarts(std::string_view source) {
+  std::vector<std::size_t> lineStarts{0};
+  for (std::size_t i = 0; i < source.size(); ++i) {
     if (source[i] == '\n') {
-      ++result.line;
-      result.offsetOnLine = 0;
-    } else {
-      ++result.offsetOnLine;
+      lineStarts.push_back(i + 1);
     }
   }
-  return result;
+  return lineStarts;
+}
+
+FileOffset::LineInfo RecoverLineInfo(std::span<const std::size_t> lineStarts, std::size_t offset) {
+  const auto nextLine = std::upper_bound(lineStarts.begin(), lineStarts.end(), offset);
+  const std::size_t lineIndex = static_cast<std::size_t>(nextLine - lineStarts.begin() - 1);
+  return FileOffset::LineInfo{lineIndex + 1, offset - lineStarts[lineIndex]};
 }
 
 }  // namespace
@@ -74,12 +76,15 @@ SourceDiagnosticSnapshot BuildSourceDiagnosticSnapshot(std::span<const ParseDiag
                                                        std::uint64_t revision) {
   SourceDiagnosticSnapshot snapshot{.revision = revision};
   snapshot.diagnostics.reserve(std::min(diagnostics.size(), kMaxPublishedDiagnostics));
+  const std::vector<std::size_t> lineStarts = BuildLineStarts(source);
 
   for (std::size_t i = 0; i < diagnostics.size() && i < kMaxPublishedDiagnostics; ++i) {
     const ParseDiagnostic& diagnostic = diagnostics[i];
     const SourceByteRange range = NormalizeRange(diagnostic.range, source);
+    const std::size_t sourceOffset = std::min(
+        diagnostic.range.start.resolveOffset(source).offset.value(), source.size());
     const FileOffset::LineInfo lineInfo = diagnostic.range.start.lineInfo.value_or(
-        RecoverLineInfo(source, diagnostic.range.start.resolveOffset(source).offset.value()));
+        RecoverLineInfo(lineStarts, sourceOffset));
     snapshot.diagnostics.push_back(SourceDiagnostic{
         .id = DiagnosticId(diagnostic, range, revision, i),
         .severity = diagnostic.severity,

--- a/donner/editor/SourceDiagnostics.h
+++ b/donner/editor/SourceDiagnostics.h
@@ -20,6 +20,8 @@ struct SourceDiagnostic {
   SourceByteRange range;
   std::size_t line = 1;    ///< One-based line number.
   std::size_t column = 0;  ///< Zero-based byte column.
+  std::size_t endLine = 1;    ///< One-based line number for the exclusive range end.
+  std::size_t endColumn = 0;  ///< Zero-based byte column for the exclusive range end.
   std::string message;
 
   bool operator==(const SourceDiagnostic&) const = default;

--- a/donner/editor/SourceDiagnostics.h
+++ b/donner/editor/SourceDiagnostics.h
@@ -1,0 +1,46 @@
+#pragma once
+/// @file
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "donner/base/ParseDiagnostic.h"
+#include "donner/editor/FlashDecorations.h"
+
+namespace donner::editor {
+
+/// Source diagnostic prepared for editor presentation.
+struct SourceDiagnostic {
+  std::uint64_t id = 0;  ///< Stable within one parse revision.
+  DiagnosticSeverity severity = DiagnosticSeverity::Error;
+  SourceByteRange range;
+  std::size_t line = 1;    ///< One-based line number.
+  std::size_t column = 0;  ///< Zero-based byte column.
+  std::string message;
+
+  bool operator==(const SourceDiagnostic&) const = default;
+};
+
+/// Immutable diagnostics published by one parse revision.
+struct SourceDiagnosticSnapshot {
+  std::uint64_t revision = 0;
+  std::vector<SourceDiagnostic> diagnostics;
+
+  bool operator==(const SourceDiagnosticSnapshot&) const = default;
+};
+
+/**
+ * Normalize parser diagnostics for source-editor presentation.
+ *
+ * Ranges are clamped to \p source, point diagnostics expand to a visible byte when possible, and
+ * missing line information is recovered from the source text. Diagnostic ids are deterministic
+ * for the same revision and change when a new parse revision publishes the same diagnostic.
+ */
+[[nodiscard]] SourceDiagnosticSnapshot BuildSourceDiagnosticSnapshot(
+    std::span<const ParseDiagnostic> diagnostics, std::string_view source, std::uint64_t revision);
+
+}  // namespace donner::editor

--- a/donner/editor/SourceDiagnosticsPanel.cc
+++ b/donner/editor/SourceDiagnosticsPanel.cc
@@ -1,0 +1,128 @@
+#include "donner/editor/SourceDiagnosticsPanel.h"
+
+#include <algorithm>
+#include <cstdio>
+
+#include "donner/editor/ImGuiIncludes.h"
+
+namespace donner::editor {
+
+SourceDiagnosticCounts CountSourceDiagnostics(std::span<const SourceDiagnostic> diagnostics) {
+  SourceDiagnosticCounts counts;
+  for (const SourceDiagnostic& diagnostic : diagnostics) {
+    if (diagnostic.severity == DiagnosticSeverity::Error) {
+      ++counts.errors;
+    } else {
+      ++counts.warnings;
+    }
+  }
+  return counts;
+}
+
+const SourceDiagnostic* FindSourceDiagnostic(std::span<const SourceDiagnostic> diagnostics,
+                                             std::uint64_t id) {
+  const auto it =
+      std::find_if(diagnostics.begin(), diagnostics.end(),
+                   [id](const SourceDiagnostic& diagnostic) { return diagnostic.id == id; });
+  return it == diagnostics.end() ? nullptr : &*it;
+}
+
+SourceDiagnosticsPanelAction SourceDiagnosticsPanel::render(
+    std::span<const SourceDiagnostic> diagnostics, std::optional<std::uint64_t> sourceHoveredId,
+    float height) {
+  SourceDiagnosticsPanelAction action;
+  if (diagnostics.empty() || height <= 0.0f) {
+    return action;
+  }
+
+  const float scale = std::max(0.75f, ImGui::GetIO().FontGlobalScale);
+  const ImU32 panelColor = ImGui::ColorConvertFloat4ToU32(ImVec4(0.075f, 0.082f, 0.094f, 1.0f));
+  const ImU32 separatorColor = ImGui::ColorConvertFloat4ToU32(ImVec4(0.24f, 0.27f, 0.31f, 1.0f));
+  const ImU32 textColor = ImGui::GetColorU32(ImGuiCol_Text);
+  const ImU32 mutedColor = ImGui::GetColorU32(ImGuiCol_TextDisabled);
+  const ImU32 errorColor = ImGui::ColorConvertFloat4ToU32(ImVec4(0.95f, 0.34f, 0.31f, 1.0f));
+  const ImU32 warningColor = ImGui::ColorConvertFloat4ToU32(ImVec4(1.0f, 0.72f, 0.24f, 1.0f));
+
+  ImGui::PushStyleColor(ImGuiCol_ChildBg, panelColor);
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
+  ImGui::BeginChild("##source_diagnostics_panel", ImVec2(0.0f, height), false,
+                    ImGuiWindowFlags_NoNav);
+
+  ImDrawList* drawList = ImGui::GetWindowDrawList();
+  const ImVec2 panelMin = ImGui::GetWindowPos();
+  drawList->AddLine(panelMin, ImVec2(panelMin.x + ImGui::GetWindowWidth(), panelMin.y),
+                    separatorColor);
+
+  const float headerHeight = 34.0f * scale;
+  const float horizontalPadding = 12.0f * scale;
+  const ImVec2 headerTextPos(panelMin.x + horizontalPadding,
+                             panelMin.y + (headerHeight - ImGui::GetTextLineHeight()) * 0.5f);
+  drawList->AddText(headerTextPos, textColor, "Problems");
+
+  const SourceDiagnosticCounts counts = CountSourceDiagnostics(diagnostics);
+  char countLabel[96];
+  std::snprintf(countLabel, sizeof(countLabel), "%zu error%s  %zu warning%s", counts.errors,
+                counts.errors == 1 ? "" : "s", counts.warnings, counts.warnings == 1 ? "" : "s");
+  const ImVec2 countSize = ImGui::CalcTextSize(countLabel);
+  drawList->AddText(ImVec2(panelMin.x + ImGui::GetWindowWidth() - horizontalPadding - countSize.x,
+                           headerTextPos.y),
+                    mutedColor, countLabel);
+
+  ImGui::SetCursorPosY(headerHeight);
+  ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0.0f, 0.0f));
+  ImGui::BeginChild("##source_diagnostics_rows", ImVec2(0.0f, 0.0f), false,
+                    ImGuiWindowFlags_AlwaysVerticalScrollbar | ImGuiWindowFlags_NoNav);
+
+  const float rowHeight = 30.0f * scale;
+  for (const SourceDiagnostic& diagnostic : diagnostics) {
+    ImGui::PushID(static_cast<int>(diagnostic.id ^ (diagnostic.id >> 32u)));
+    const ImVec2 rowMin = ImGui::GetCursorScreenPos();
+    const float rowWidth = ImGui::GetContentRegionAvail().x;
+    ImGui::InvisibleButton("##diagnostic", ImVec2(rowWidth, rowHeight));
+    const bool hovered = ImGui::IsItemHovered();
+    const bool selected = hovered || sourceHoveredId == diagnostic.id;
+    if (hovered) {
+      action.hoveredId = diagnostic.id;
+    }
+    if (ImGui::IsItemClicked(ImGuiMouseButton_Left)) {
+      action.activatedId = diagnostic.id;
+    }
+
+    const ImVec2 rowMax(rowMin.x + rowWidth, rowMin.y + rowHeight);
+    if (selected) {
+      drawList->AddRectFilled(
+          rowMin, rowMax,
+          ImGui::ColorConvertFloat4ToU32(ImVec4(0.22f, 0.27f, 0.34f, hovered ? 0.72f : 0.46f)));
+    }
+    drawList->AddLine(ImVec2(rowMin.x + horizontalPadding, rowMax.y - 1.0f),
+                      ImVec2(rowMax.x - horizontalPadding, rowMax.y - 1.0f),
+                      ImGui::ColorConvertFloat4ToU32(ImVec4(0.18f, 0.20f, 0.23f, 1.0f)));
+
+    const ImU32 severityColor =
+        diagnostic.severity == DiagnosticSeverity::Error ? errorColor : warningColor;
+    const float centerY = rowMin.y + rowHeight * 0.5f;
+    drawList->AddCircleFilled(ImVec2(rowMin.x + horizontalPadding + 4.0f * scale, centerY),
+                              3.5f * scale, severityColor);
+
+    char location[48];
+    std::snprintf(location, sizeof(location), "%zu:%zu", diagnostic.line, diagnostic.column + 1);
+    const ImVec2 locationSize = ImGui::CalcTextSize(location);
+    const float locationX = rowMax.x - horizontalPadding - locationSize.x;
+    const float textY = rowMin.y + (rowHeight - ImGui::GetTextLineHeight()) * 0.5f;
+    const ImVec4 clip(rowMin.x + horizontalPadding + 18.0f * scale, rowMin.y, locationX - 8.0f,
+                      rowMax.y);
+    drawList->AddText(nullptr, 0.0f, ImVec2(clip.x, textY), textColor, diagnostic.message.c_str(),
+                      nullptr, 0.0f, &clip);
+    drawList->AddText(ImVec2(locationX, textY), mutedColor, location);
+    ImGui::PopID();
+  }
+
+  ImGui::EndChild();
+  ImGui::PopStyleVar();
+  ImGui::EndChild();
+  ImGui::PopStyleVar();
+  ImGui::PopStyleColor();
+  return action;
+}
+
+}  // namespace donner::editor

--- a/donner/editor/SourceDiagnosticsPanel.cc
+++ b/donner/editor/SourceDiagnosticsPanel.cc
@@ -74,8 +74,9 @@ SourceDiagnosticsPanelAction SourceDiagnosticsPanel::render(
                     ImGuiWindowFlags_AlwaysVerticalScrollbar | ImGuiWindowFlags_NoNav);
 
   const float rowHeight = 30.0f * scale;
-  for (const SourceDiagnostic& diagnostic : diagnostics) {
-    ImGui::PushID(static_cast<int>(diagnostic.id ^ (diagnostic.id >> 32u)));
+  for (std::size_t index = 0; index < diagnostics.size(); ++index) {
+    const SourceDiagnostic& diagnostic = diagnostics[index];
+    ImGui::PushID(static_cast<int>(index));
     const ImVec2 rowMin = ImGui::GetCursorScreenPos();
     const float rowWidth = ImGui::GetContentRegionAvail().x;
     ImGui::InvisibleButton("##diagnostic", ImVec2(rowWidth, rowHeight));

--- a/donner/editor/SourceDiagnosticsPanel.h
+++ b/donner/editor/SourceDiagnosticsPanel.h
@@ -1,0 +1,41 @@
+#pragma once
+/// @file
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+
+#include "donner/editor/SourceDiagnostics.h"
+
+namespace donner::editor {
+
+/// Severity totals shown in the source diagnostics header.
+struct SourceDiagnosticCounts {
+  std::size_t errors = 0;
+  std::size_t warnings = 0;
+
+  bool operator==(const SourceDiagnosticCounts&) const = default;
+};
+
+[[nodiscard]] SourceDiagnosticCounts CountSourceDiagnostics(
+    std::span<const SourceDiagnostic> diagnostics);
+
+[[nodiscard]] const SourceDiagnostic* FindSourceDiagnostic(
+    std::span<const SourceDiagnostic> diagnostics, std::uint64_t id);
+
+/// User interaction emitted by one diagnostics panel frame.
+struct SourceDiagnosticsPanelAction {
+  std::optional<std::uint64_t> hoveredId;
+  std::optional<std::uint64_t> activatedId;
+};
+
+/// Compact bottom panel presenting source warnings and errors.
+class SourceDiagnosticsPanel {
+public:
+  [[nodiscard]] SourceDiagnosticsPanelAction render(std::span<const SourceDiagnostic> diagnostics,
+                                                    std::optional<std::uint64_t> sourceHoveredId,
+                                                    float height);
+};
+
+}  // namespace donner::editor

--- a/donner/editor/TextEditor.cc
+++ b/donner/editor/TextEditor.cc
@@ -1459,9 +1459,8 @@ void TextEditor::renderLineBackground(const VisualLine& visualLine, const ImVec2
   const float textStartX =
       lineStart.x + textStart_ + static_cast<float>(visualLine.indentColumns) * charAdvance_.x;
 
-  const auto drawSourceRange = [&](SourceByteRange byteRange, ImU32 color) {
-    const Coordinates rangeStart = getCoordinatesAtByteOffset(byteRange.start);
-    const Coordinates rangeEnd = getCoordinatesAtByteOffset(byteRange.end);
+  const auto drawSourceCoordinates = [&](const Coordinates& rangeStart,
+                                         const Coordinates& rangeEnd, ImU32 color) {
     if (rangeEnd.line < visualLine.lineNo || rangeStart.line > visualLine.lineNo) {
       return;
     }
@@ -1484,6 +1483,10 @@ void TextEditor::renderLineBackground(const VisualLine& visualLine, const ImVec2
                      lineStart.y + charAdvance_.y};
     drawList->AddRectFilled(start, end, color, 2.0f * uiScale_);
   };
+  const auto drawSourceRange = [&](SourceByteRange byteRange, ImU32 color) {
+    drawSourceCoordinates(getCoordinatesAtByteOffset(byteRange.start),
+                          getCoordinatesAtByteOffset(byteRange.end), color);
+  };
 
   const ImU32 hoverColor = ImGui::ColorConvertFloat4ToU32(ImVec4(0.22f, 0.62f, 1.0f, 0.13f));
   for (const SourceByteRange& range : hoverSourceRanges_) {
@@ -1498,7 +1501,11 @@ void TextEditor::renderLineBackground(const VisualLine& visualLine, const ImVec2
     const ImVec4 color = diagnostic.severity == DiagnosticSeverity::Error
                              ? ImVec4(0.95f, 0.24f, 0.22f, alpha)
                              : ImVec4(1.0f, 0.68f, 0.16f, alpha);
-    drawSourceRange(diagnostic.range, ImGui::ColorConvertFloat4ToU32(color));
+    drawSourceCoordinates(
+        Coordinates(static_cast<int>(diagnostic.line - 1), static_cast<int>(diagnostic.column)),
+        Coordinates(static_cast<int>(diagnostic.endLine - 1),
+                    static_cast<int>(diagnostic.endColumn)),
+        ImGui::ColorConvertFloat4ToU32(color));
   }
 
   const std::vector<ActiveFlash> flashes =
@@ -1971,8 +1978,11 @@ void TextEditor::remapFocusMetadataForSourceEdit(const SourceEditIntent& intent)
   for (SourceDiagnostic& diagnostic : sourceDiagnostics_) {
     diagnostic.range = MapSourceByteRangeForEdit(diagnostic.range, intent, bufferSize);
     const Coordinates start = getCoordinatesAtByteOffset(diagnostic.range.start);
+    const Coordinates end = getCoordinatesAtByteOffset(diagnostic.range.end);
     diagnostic.line = static_cast<std::size_t>(start.line + 1);
     diagnostic.column = static_cast<std::size_t>(start.column);
+    diagnostic.endLine = static_cast<std::size_t>(end.line + 1);
+    diagnostic.endColumn = static_cast<std::size_t>(end.column);
   }
   std::erase_if(sourceDiagnostics_, [](const SourceDiagnostic& diagnostic) {
     return diagnostic.range.end <= diagnostic.range.start;
@@ -2608,8 +2618,11 @@ bool TextEditor::setSourceDiagnostics(std::vector<SourceDiagnostic> diagnostics)
     diagnostic.range.start = std::min(diagnostic.range.start, bufferSize);
     diagnostic.range.end = std::min(diagnostic.range.end, bufferSize);
     const Coordinates start = getCoordinatesAtByteOffset(diagnostic.range.start);
+    const Coordinates end = getCoordinatesAtByteOffset(diagnostic.range.end);
     diagnostic.line = static_cast<std::size_t>(start.line + 1);
     diagnostic.column = static_cast<std::size_t>(start.column);
+    diagnostic.endLine = static_cast<std::size_t>(end.line + 1);
+    diagnostic.endColumn = static_cast<std::size_t>(end.column);
   }
   std::erase_if(diagnostics, [](const SourceDiagnostic& diagnostic) {
     return diagnostic.range.end <= diagnostic.range.start;

--- a/donner/editor/TextEditor.cc
+++ b/donner/editor/TextEditor.cc
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <cstdint>
 #include <functional>
+#include <limits>
 #include <regex>
 #include <span>
 #include <stack>
@@ -1411,7 +1412,12 @@ void TextEditor::renderLineBackground(int lineNo, const ImVec2& lineStart,
 
   // Error markers
   auto errorIt = errorMarkers_.find(lineNo + 1);
-  if (errorIt != errorMarkers_.end()) {
+  const bool hasExactDiagnostic =
+      std::any_of(sourceDiagnostics_.begin(), sourceDiagnostics_.end(),
+                  [lineNo](const SourceDiagnostic& diagnostic) {
+                    return diagnostic.line == static_cast<std::size_t>(lineNo + 1);
+                  });
+  if (errorIt != errorMarkers_.end() && !hasExactDiagnostic) {
     const ImVec2 end{lineStart.x + contentSize.x + 2.0f * ImGui::GetScrollX(),
                      lineStart.y + charAdvance_.y};
 
@@ -1482,6 +1488,17 @@ void TextEditor::renderLineBackground(const VisualLine& visualLine, const ImVec2
   const ImU32 hoverColor = ImGui::ColorConvertFloat4ToU32(ImVec4(0.22f, 0.62f, 1.0f, 0.13f));
   for (const SourceByteRange& range : hoverSourceRanges_) {
     drawSourceRange(range, hoverColor);
+  }
+
+  const std::optional<std::uint64_t> hoveredDiagnostic = hoveredSourceDiagnosticId();
+  for (const SourceDiagnostic& diagnostic : sourceDiagnostics_) {
+    const bool active =
+        diagnostic.id == activeSourceDiagnosticId_ || diagnostic.id == hoveredDiagnostic;
+    const float alpha = active ? 0.34f : 0.14f;
+    const ImVec4 color = diagnostic.severity == DiagnosticSeverity::Error
+                             ? ImVec4(0.95f, 0.24f, 0.22f, alpha)
+                             : ImVec4(1.0f, 0.68f, 0.16f, alpha);
+    drawSourceRange(diagnostic.range, ImGui::ColorConvertFloat4ToU32(color));
   }
 
   const std::vector<ActiveFlash> flashes =
@@ -1950,6 +1967,23 @@ void TextEditor::remapFocusMetadataForSourceEdit(const SourceEditIntent& intent)
   }
   std::erase_if(hoverSourceRanges_,
                 [](const SourceByteRange& range) { return range.end <= range.start; });
+
+  for (SourceDiagnostic& diagnostic : sourceDiagnostics_) {
+    diagnostic.range = MapSourceByteRangeForEdit(diagnostic.range, intent, bufferSize);
+    const Coordinates start = getCoordinatesAtByteOffset(diagnostic.range.start);
+    diagnostic.line = static_cast<std::size_t>(start.line + 1);
+    diagnostic.column = static_cast<std::size_t>(start.column);
+  }
+  std::erase_if(sourceDiagnostics_, [](const SourceDiagnostic& diagnostic) {
+    return diagnostic.range.end <= diagnostic.range.start;
+  });
+  if (activeSourceDiagnosticId_.has_value() &&
+      std::none_of(sourceDiagnostics_.begin(), sourceDiagnostics_.end(),
+                   [this](const SourceDiagnostic& diagnostic) {
+                     return diagnostic.id == activeSourceDiagnosticId_;
+                   })) {
+    activeSourceDiagnosticId_.reset();
+  }
 
   for (SourceStyleDecoration& decoration : sourceStyleDecorations_) {
     decoration.range = MapSourceByteRangeForEdit(decoration.range, intent, bufferSize);
@@ -2566,6 +2600,109 @@ bool TextEditor::setHoverSourceRanges(std::vector<SourceByteRange> ranges) {
 
   hoverSourceRanges_ = std::move(ranges);
   return true;
+}
+
+bool TextEditor::setSourceDiagnostics(std::vector<SourceDiagnostic> diagnostics) {
+  const std::size_t bufferSize = getText().size();
+  for (SourceDiagnostic& diagnostic : diagnostics) {
+    diagnostic.range.start = std::min(diagnostic.range.start, bufferSize);
+    diagnostic.range.end = std::min(diagnostic.range.end, bufferSize);
+    const Coordinates start = getCoordinatesAtByteOffset(diagnostic.range.start);
+    diagnostic.line = static_cast<std::size_t>(start.line + 1);
+    diagnostic.column = static_cast<std::size_t>(start.column);
+  }
+  std::erase_if(diagnostics, [](const SourceDiagnostic& diagnostic) {
+    return diagnostic.range.end <= diagnostic.range.start;
+  });
+  std::sort(diagnostics.begin(), diagnostics.end(),
+            [](const SourceDiagnostic& lhs, const SourceDiagnostic& rhs) {
+              if (lhs.range.start != rhs.range.start) {
+                return lhs.range.start < rhs.range.start;
+              }
+              if (lhs.range.end != rhs.range.end) {
+                return lhs.range.end < rhs.range.end;
+              }
+              return lhs.id < rhs.id;
+            });
+
+  if (sourceDiagnostics_ == diagnostics) {
+    return false;
+  }
+
+  sourceDiagnostics_ = std::move(diagnostics);
+  if (activeSourceDiagnosticId_.has_value() &&
+      std::none_of(sourceDiagnostics_.begin(), sourceDiagnostics_.end(),
+                   [this](const SourceDiagnostic& diagnostic) {
+                     return diagnostic.id == activeSourceDiagnosticId_;
+                   })) {
+    activeSourceDiagnosticId_.reset();
+  }
+  return true;
+}
+
+std::optional<std::uint64_t> TextEditor::sourceDiagnosticAtByteOffset(
+    std::size_t byteOffset) const {
+  const SourceDiagnostic* best = nullptr;
+  for (const SourceDiagnostic& diagnostic : sourceDiagnostics_) {
+    if (byteOffset < diagnostic.range.start || byteOffset >= diagnostic.range.end) {
+      continue;
+    }
+    const std::size_t width = diagnostic.range.end - diagnostic.range.start;
+    const std::size_t bestWidth = best == nullptr ? std::numeric_limits<std::size_t>::max()
+                                                  : best->range.end - best->range.start;
+    if (best == nullptr || width < bestWidth ||
+        (width == bestWidth && diagnostic.severity == DiagnosticSeverity::Error &&
+         best->severity != DiagnosticSeverity::Error)) {
+      best = &diagnostic;
+    }
+  }
+  return best == nullptr ? std::nullopt : std::optional<std::uint64_t>(best->id);
+}
+
+std::optional<std::uint64_t> TextEditor::hoveredSourceDiagnosticId() const {
+  if (!hoveredTextPosition_.has_value()) {
+    return std::nullopt;
+  }
+  return sourceDiagnosticAtByteOffset(getByteOffsetAtCoordinates(*hoveredTextPosition_));
+}
+
+bool TextEditor::setActiveSourceDiagnosticId(std::optional<std::uint64_t> id) {
+  if (id.has_value() &&
+      std::none_of(sourceDiagnostics_.begin(), sourceDiagnostics_.end(),
+                   [id](const SourceDiagnostic& diagnostic) { return diagnostic.id == id; })) {
+    activeSourceDiagnosticId_.reset();
+    return false;
+  }
+  const bool changed = activeSourceDiagnosticId_ != id;
+  activeSourceDiagnosticId_ = id;
+  return changed || id.has_value();
+}
+
+void TextEditor::renderSourceDiagnosticTooltip() {
+  const std::optional<std::uint64_t> hovered = hoveredSourceDiagnosticId();
+  if (!hovered.has_value()) {
+    return;
+  }
+  const auto it = std::find_if(
+      sourceDiagnostics_.begin(), sourceDiagnostics_.end(),
+      [hovered](const SourceDiagnostic& diagnostic) { return diagnostic.id == hovered; });
+  if (it == sourceDiagnostics_.end()) {
+    return;
+  }
+
+  ImGui::BeginTooltip();
+  const ImVec4 color = it->severity == DiagnosticSeverity::Error ? ImVec4(0.95f, 0.34f, 0.31f, 1.0f)
+                                                                 : ImVec4(1.0f, 0.72f, 0.24f, 1.0f);
+  ImGui::PushStyleColor(ImGuiCol_Text, color);
+  ImGui::TextUnformatted(it->severity == DiagnosticSeverity::Error ? "Error" : "Warning");
+  ImGui::PopStyleColor();
+  ImGui::SameLine();
+  ImGui::TextDisabled("%zu:%zu", it->line, it->column + 1);
+  ImGui::Separator();
+  ImGui::PushTextWrapPos(420.0f * uiScale_);
+  ImGui::TextUnformatted(it->message.c_str());
+  ImGui::PopTextWrapPos();
+  ImGui::EndTooltip();
 }
 
 bool TextEditor::setSourceStyleDecorations(std::vector<SourceStyleDecoration> decorations) {
@@ -3731,6 +3868,7 @@ void TextEditor::render(std::string_view title, const ImVec2& size, bool showBor
   colorizeInternal();
   readyForAutocomplete_ = true;
   renderInternal(title);
+  renderSourceDiagnosticTooltip();
 
   // Scrollbar markers
   if (scrollbarMarkers_) {

--- a/donner/editor/TextEditor.h
+++ b/donner/editor/TextEditor.h
@@ -19,6 +19,7 @@
 #include "donner/editor/FrameCostBreakdown.h"
 #include "donner/editor/RopeSimulation.h"
 #include "donner/editor/SoftWrap.h"
+#include "donner/editor/SourceDiagnostics.h"
 #include "donner/editor/TextBuffer.h"
 #include "donner/editor/TextEditorCore.h"
 
@@ -606,6 +607,22 @@ public:
   [[nodiscard]] const std::vector<SourceByteRange>& hoverSourceRanges() const {
     return hoverSourceRanges_;
   }
+  /// Install exact source diagnostics for inline rendering and hit testing.
+  bool setSourceDiagnostics(std::vector<SourceDiagnostic> diagnostics);
+  /// Active source diagnostics.
+  [[nodiscard]] const std::vector<SourceDiagnostic>& sourceDiagnostics() const {
+    return sourceDiagnostics_;
+  }
+  /// Return the narrowest diagnostic containing \p byteOffset.
+  [[nodiscard]] std::optional<std::uint64_t> sourceDiagnosticAtByteOffset(
+      std::size_t byteOffset) const;
+  /// Diagnostic under the source pointer, if any.
+  [[nodiscard]] std::optional<std::uint64_t> hoveredSourceDiagnosticId() const;
+  /// Emphasize a diagnostic selected or hovered by an external presenter.
+  bool setActiveSourceDiagnosticId(std::optional<std::uint64_t> id);
+  [[nodiscard]] std::optional<std::uint64_t> activeSourceDiagnosticId() const {
+    return activeSourceDiagnosticId_;
+  }
   /// Set source style/cascade decorations.
   bool setSourceStyleDecorations(std::vector<SourceStyleDecoration> decorations);
   /// Clear source style/cascade decorations.
@@ -1089,8 +1106,10 @@ private:
   // place; the shell reads them via aliased references.
   bool& scrollbarMarkers_;
   std::vector<int>& changedLines_;
-  std::vector<int> highlightedLines_;               //!< Lines to highlight
-  std::vector<SourceByteRange> hoverSourceRanges_;  //!< Source ranges highlighted on hover
+  std::vector<int> highlightedLines_;                //!< Lines to highlight
+  std::vector<SourceByteRange> hoverSourceRanges_;   //!< Source ranges highlighted on hover
+  std::vector<SourceDiagnostic> sourceDiagnostics_;  //!< Exact parser diagnostic ranges.
+  std::optional<std::uint64_t> activeSourceDiagnosticId_;
   std::vector<SourceStyleDecoration> sourceStyleDecorations_;  //!< Style source decorations.
   FocusPartition focusPartition_;
   bool focusPartitionActive_ = false;
@@ -1425,6 +1444,7 @@ private:
                             ImDrawList* drawList);
   void renderLineBackground(const VisualLine& visualLine, const ImVec2& start,
                             const ImVec2& contentSize, ImDrawList* drawList);
+  void renderSourceDiagnosticTooltip();
   void renderFocusReferenceLinks(ImDrawList* drawList);
 
   /**

--- a/donner/editor/tests/AsyncSVGDocument_tests.cc
+++ b/donner/editor/tests/AsyncSVGDocument_tests.cc
@@ -59,6 +59,8 @@ TEST(AsyncSVGDocumentTest, EmptyByDefault) {
   EXPECT_FALSE(doc.flushFrame());
   EXPECT_EQ(doc.currentFrameVersion(), 0u);
   EXPECT_FALSE(doc.lastFlushResult().appliedCommands);
+  EXPECT_TRUE(doc.parseDiagnostics().empty());
+  EXPECT_EQ(doc.parseDiagnosticsRevision(), 0u);
 }
 
 TEST(AsyncSVGDocumentTest, LoadFromStringSucceedsAndBumpsVersion) {
@@ -69,6 +71,35 @@ TEST(AsyncSVGDocumentTest, LoadFromStringSucceedsAndBumpsVersion) {
 
   auto rect = doc.document().querySelector("#r1");
   ASSERT_TRUE(rect.has_value());
+}
+
+TEST(AsyncSVGDocumentTest, SuccessfulParsePublishesWarnings) {
+  constexpr std::string_view kSvgWithWarning = R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" xmlns:unused="urn:unexpected">
+      <rect width="10" height="10"/>
+    </svg>)svg";
+  AsyncSVGDocument doc;
+
+  ASSERT_TRUE(doc.loadFromString(kSvgWithWarning));
+
+  ASSERT_FALSE(doc.parseDiagnostics().empty());
+  EXPECT_EQ(doc.parseDiagnostics().front().severity, DiagnosticSeverity::Warning);
+  EXPECT_FALSE(doc.lastParseError().has_value());
+  EXPECT_GT(doc.parseDiagnosticsRevision(), 0u);
+}
+
+TEST(AsyncSVGDocumentTest, ParseDiagnosticsAdvanceAndClearOnNextSuccessfulParse) {
+  AsyncSVGDocument doc;
+  ASSERT_FALSE(doc.loadFromString("<svg"));
+  const std::uint64_t failedRevision = doc.parseDiagnosticsRevision();
+  ASSERT_EQ(doc.parseDiagnostics().size(), 1u);
+  EXPECT_EQ(doc.parseDiagnostics().front().severity, DiagnosticSeverity::Error);
+
+  ASSERT_TRUE(doc.loadFromString(kTrivialSvg));
+
+  EXPECT_GT(doc.parseDiagnosticsRevision(), failedRevision);
+  EXPECT_TRUE(doc.parseDiagnostics().empty());
+  EXPECT_FALSE(doc.lastParseError().has_value());
 }
 
 TEST(AsyncSVGDocumentTest, FlushAppliesQueuedSetTransform) {

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -229,6 +229,25 @@ donner_cc_test(
 )
 
 donner_cc_test(
+    name = "source_diagnostics_tests",
+    srcs = ["SourceDiagnostics_tests.cc"],
+    deps = [
+        "//donner/base",
+        "//donner/editor:source_diagnostics",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
+    name = "source_diagnostics_panel_tests",
+    srcs = ["SourceDiagnosticsPanel_tests.cc"],
+    deps = [
+        "//donner/editor:source_diagnostics_panel",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
     name = "viewport_interaction_controller_tests",
     srcs = ["ViewportInteractionController_tests.cc"],
     deps = [

--- a/donner/editor/tests/DocumentSyncController_tests.cc
+++ b/donner/editor/tests/DocumentSyncController_tests.cc
@@ -1088,6 +1088,12 @@ TEST_F(DocumentSyncControllerTest, SyncParseErrorMarkersHandlesErrorAppearAndCle
   ASSERT_TRUE(app_.document().lastParseError().has_value());
   // Error-present branch: sets markers from the diagnostic.
   controller_.syncParseErrorMarkers(app_, textEditor_);
+  ASSERT_EQ(controller_.sourceDiagnostics().diagnostics.size(), 1u);
+  EXPECT_EQ(controller_.sourceDiagnostics().revision, app_.document().parseDiagnosticsRevision());
+  EXPECT_EQ(controller_.sourceDiagnostics().diagnostics.front().severity,
+            DiagnosticSeverity::Error);
+  EXPECT_GT(controller_.sourceDiagnostics().diagnostics.front().range.end,
+            controller_.sourceDiagnostics().diagnostics.front().range.start);
   // Repeated calls with the same error hit the change-detection short-circuit.
   controller_.syncParseErrorMarkers(app_, textEditor_);
 
@@ -1098,6 +1104,7 @@ TEST_F(DocumentSyncControllerTest, SyncParseErrorMarkersHandlesErrorAppearAndCle
   (void)app_.flushFrame();
   ASSERT_FALSE(app_.document().lastParseError().has_value());
   controller_.syncParseErrorMarkers(app_, textEditor_);
+  EXPECT_TRUE(controller_.sourceDiagnostics().diagnostics.empty());
 }
 
 TEST(DocumentSyncControllerStructuredTest, MirrorSourceDeltasWithEmptyDeltasReturnsFalse) {

--- a/donner/editor/tests/SourceDiagnosticsPanel_tests.cc
+++ b/donner/editor/tests/SourceDiagnosticsPanel_tests.cc
@@ -1,0 +1,24 @@
+#include "donner/editor/SourceDiagnosticsPanel.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+
+namespace donner::editor {
+namespace {
+
+TEST(SourceDiagnosticsPanel, CountsSeverityAndFindsStableId) {
+  const std::array diagnostics = {
+      SourceDiagnostic{.id = 11, .severity = DiagnosticSeverity::Warning, .message = "warning"},
+      SourceDiagnostic{.id = 12, .severity = DiagnosticSeverity::Error, .message = "error"},
+      SourceDiagnostic{.id = 13, .severity = DiagnosticSeverity::Error, .message = "error"},
+  };
+
+  EXPECT_EQ(CountSourceDiagnostics(diagnostics), (SourceDiagnosticCounts{2, 1}));
+  ASSERT_NE(FindSourceDiagnostic(diagnostics, 12), nullptr);
+  EXPECT_EQ(FindSourceDiagnostic(diagnostics, 12)->severity, DiagnosticSeverity::Error);
+  EXPECT_EQ(FindSourceDiagnostic(diagnostics, 99), nullptr);
+}
+
+}  // namespace
+}  // namespace donner::editor

--- a/donner/editor/tests/SourceDiagnostics_tests.cc
+++ b/donner/editor/tests/SourceDiagnostics_tests.cc
@@ -3,7 +3,9 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <string>
 #include <string_view>
+#include <vector>
 
 #include "donner/base/FileOffset.h"
 #include "donner/base/ParseDiagnostic.h"
@@ -58,6 +60,23 @@ TEST(SourceDiagnostics, PreservesSeverityAndMessage) {
   EXPECT_EQ(snapshot.diagnostics[0].message, "deprecated");
   EXPECT_EQ(snapshot.diagnostics[1].severity, DiagnosticSeverity::Error);
   EXPECT_EQ(snapshot.diagnostics[1].message, "invalid");
+}
+
+TEST(SourceDiagnostics, CapsPublishedDiagnosticsAndRecoversLocationsInLargeSource) {
+  std::string source;
+  std::vector<ParseDiagnostic> diagnostics;
+  for (std::size_t i = 0; i < 300; ++i) {
+    source += "line\n";
+    diagnostics.push_back(ParseDiagnostic::Warning("warning", FileOffset::Offset(i * 5)));
+  }
+
+  const SourceDiagnosticSnapshot snapshot = BuildSourceDiagnosticSnapshot(diagnostics, source, 1);
+
+  ASSERT_EQ(snapshot.diagnostics.size(), 256u);
+  EXPECT_EQ(snapshot.diagnostics.front().line, 1u);
+  EXPECT_EQ(snapshot.diagnostics.front().column, 0u);
+  EXPECT_EQ(snapshot.diagnostics.back().line, 256u);
+  EXPECT_EQ(snapshot.diagnostics.back().column, 0u);
 }
 
 }  // namespace

--- a/donner/editor/tests/SourceDiagnostics_tests.cc
+++ b/donner/editor/tests/SourceDiagnostics_tests.cc
@@ -1,0 +1,64 @@
+#include "donner/editor/SourceDiagnostics.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <string_view>
+
+#include "donner/base/FileOffset.h"
+#include "donner/base/ParseDiagnostic.h"
+
+namespace donner::editor {
+namespace {
+
+TEST(SourceDiagnostics, NormalizesRangesAndRecoversLineInformation) {
+  constexpr std::string_view kSource = "<svg>\n  <rect/>\n</svg>";
+  const std::array diagnostics = {
+      ParseDiagnostic::Warning("point", FileOffset::Offset(8)),
+      ParseDiagnostic::Error(
+          "past end", SourceRange{FileOffset::Offset(9), FileOffset::Offset(kSource.size() + 20)}),
+  };
+
+  const SourceDiagnosticSnapshot snapshot = BuildSourceDiagnosticSnapshot(diagnostics, kSource, 7);
+
+  ASSERT_EQ(snapshot.diagnostics.size(), 2u);
+  EXPECT_EQ(snapshot.revision, 7u);
+  EXPECT_EQ(snapshot.diagnostics[0].range, (SourceByteRange{8, 9}));
+  EXPECT_EQ(snapshot.diagnostics[0].line, 2u);
+  EXPECT_EQ(snapshot.diagnostics[0].column, 2u);
+  EXPECT_EQ(snapshot.diagnostics[1].range, (SourceByteRange{9, kSource.size()}));
+}
+
+TEST(SourceDiagnostics, UsesRevisionScopedStableIds) {
+  constexpr std::string_view kSource = "<svg/>";
+  const std::array diagnostics = {
+      ParseDiagnostic::Error("invalid", FileOffset::Offset(2)),
+  };
+
+  const SourceDiagnosticSnapshot first = BuildSourceDiagnosticSnapshot(diagnostics, kSource, 3);
+  const SourceDiagnosticSnapshot repeated = BuildSourceDiagnosticSnapshot(diagnostics, kSource, 3);
+  const SourceDiagnosticSnapshot reparsed = BuildSourceDiagnosticSnapshot(diagnostics, kSource, 4);
+
+  ASSERT_EQ(first.diagnostics.size(), 1u);
+  EXPECT_EQ(first.diagnostics[0].id, repeated.diagnostics[0].id);
+  EXPECT_NE(first.diagnostics[0].id, reparsed.diagnostics[0].id);
+}
+
+TEST(SourceDiagnostics, PreservesSeverityAndMessage) {
+  constexpr std::string_view kSource = "<svg/>";
+  const std::array diagnostics = {
+      ParseDiagnostic::Warning("deprecated", FileOffset::Offset(1)),
+      ParseDiagnostic::Error("invalid", FileOffset::Offset(2)),
+  };
+
+  const SourceDiagnosticSnapshot snapshot = BuildSourceDiagnosticSnapshot(diagnostics, kSource, 1);
+
+  ASSERT_EQ(snapshot.diagnostics.size(), 2u);
+  EXPECT_EQ(snapshot.diagnostics[0].severity, DiagnosticSeverity::Warning);
+  EXPECT_EQ(snapshot.diagnostics[0].message, "deprecated");
+  EXPECT_EQ(snapshot.diagnostics[1].severity, DiagnosticSeverity::Error);
+  EXPECT_EQ(snapshot.diagnostics[1].message, "invalid");
+}
+
+}  // namespace
+}  // namespace donner::editor

--- a/donner/editor/tests/SourceDiagnostics_tests.cc
+++ b/donner/editor/tests/SourceDiagnostics_tests.cc
@@ -28,6 +28,8 @@ TEST(SourceDiagnostics, NormalizesRangesAndRecoversLineInformation) {
   EXPECT_EQ(snapshot.diagnostics[0].range, (SourceByteRange{8, 9}));
   EXPECT_EQ(snapshot.diagnostics[0].line, 2u);
   EXPECT_EQ(snapshot.diagnostics[0].column, 2u);
+  EXPECT_EQ(snapshot.diagnostics[0].endLine, 2u);
+  EXPECT_EQ(snapshot.diagnostics[0].endColumn, 3u);
   EXPECT_EQ(snapshot.diagnostics[1].range, (SourceByteRange{9, kSource.size()}));
 }
 
@@ -77,6 +79,8 @@ TEST(SourceDiagnostics, CapsPublishedDiagnosticsAndRecoversLocationsInLargeSourc
   EXPECT_EQ(snapshot.diagnostics.front().column, 0u);
   EXPECT_EQ(snapshot.diagnostics.back().line, 256u);
   EXPECT_EQ(snapshot.diagnostics.back().column, 0u);
+  EXPECT_EQ(snapshot.diagnostics.back().endLine, 256u);
+  EXPECT_EQ(snapshot.diagnostics.back().endColumn, 1u);
 }
 
 }  // namespace

--- a/donner/editor/tests/TextEditor_tests.cc
+++ b/donner/editor/tests/TextEditor_tests.cc
@@ -4622,6 +4622,8 @@ TEST_F(TextEditorTests, SourceDiagnosticsTrackSourceEditsAndValidateActiveId) {
   ASSERT_EQ(editor.sourceDiagnostics().size(), 1u);
   EXPECT_EQ(editor.sourceDiagnostics().front().range, (SourceByteRange{4, 6}));
   EXPECT_EQ(editor.sourceDiagnostics().front().column, 4u);
+  EXPECT_EQ(editor.sourceDiagnostics().front().endLine, 1u);
+  EXPECT_EQ(editor.sourceDiagnostics().front().endColumn, 6u);
   EXPECT_FALSE(editor.setActiveSourceDiagnosticId(99));
   EXPECT_EQ(editor.activeSourceDiagnosticId(), std::nullopt);
 }

--- a/donner/editor/tests/TextEditor_tests.cc
+++ b/donner/editor/tests/TextEditor_tests.cc
@@ -4597,6 +4597,35 @@ TEST_F(TextEditorTests, ErrorMarkersRenderLineBackground) {
   EXPECT_GT(VisualLineCount(), 0);
 }
 
+TEST_F(TextEditorTests, SourceDiagnosticsPreferNarrowestRangeAtByteOffset) {
+  editor.setText("abcdef");
+  ASSERT_TRUE(editor.setSourceDiagnostics({
+      SourceDiagnostic{.id = 1, .range = {1, 5}, .message = "wide"},
+      SourceDiagnostic{.id = 2, .range = {2, 4}, .message = "narrow"},
+  }));
+
+  EXPECT_EQ(editor.sourceDiagnosticAtByteOffset(3), 2u);
+  EXPECT_EQ(editor.sourceDiagnosticAtByteOffset(5), std::nullopt);
+}
+
+TEST_F(TextEditorTests, SourceDiagnosticsTrackSourceEditsAndValidateActiveId) {
+  editor.setText("abcdef");
+  ASSERT_TRUE(editor.setSourceDiagnostics({
+      SourceDiagnostic{.id = 7, .range = {2, 4}, .line = 1, .column = 2, .message = "issue"},
+  }));
+  EXPECT_TRUE(editor.setActiveSourceDiagnosticId(7));
+  EXPECT_EQ(editor.activeSourceDiagnosticId(), 7u);
+
+  editor.setCursorPosition(Coordinates(0, 0));
+  editor.insertText("XX");
+
+  ASSERT_EQ(editor.sourceDiagnostics().size(), 1u);
+  EXPECT_EQ(editor.sourceDiagnostics().front().range, (SourceByteRange{4, 6}));
+  EXPECT_EQ(editor.sourceDiagnostics().front().column, 4u);
+  EXPECT_FALSE(editor.setActiveSourceDiagnosticId(99));
+  EXPECT_EQ(editor.activeSourceDiagnosticId(), std::nullopt);
+}
+
 TEST_F(TextEditorTests, HoveringErrorMarkerRendersTooltip) {
   editor.setText("first\nsecond\nthird");
   editor.setErrorMarkers(ErrorMarkers{{2, "syntax error"}});


### PR DESCRIPTION
## Summary

- surface SVG parse errors and warnings below the source editor
- keep diagnostics synchronized with asynchronous document parsing
- support bidirectional hover and click navigation between source ranges and diagnostics
- add focused parser, panel, synchronization, and editor tests

## Why

Structured editing needs parse failures to remain visible and navigable without disconnecting the source and canvas workflows.

## Validation

- `bazel test //donner/editor/tests:source_diagnostics_tests //donner/editor/tests:source_diagnostics_panel_tests //donner/editor/tests:document_sync_controller_tests //donner/editor/tests:text_editor_tests`
- `bazel build //donner/editor:editor`

## Stack

1 of 5. This PR targets `main`; the following editor PR is based on this branch.