### PR TITLE
Editor: add DOM-first structural source dragging

### DIFF
--- a/docs/design_docs/0040-semantic_text_completion.md
+++ b/docs/design_docs/0040-semantic_text_completion.md
@@ -1,6 +1,6 @@
 # Design: Semantic Text Editing
 
-**Status:** Design
+**Status:** Implementing
 **Author:** GPT-5
 **Created:** 2026-05-25
 
@@ -79,13 +79,13 @@ anonymous text.
 - [ ] Milestone 3: CSS semantic completions.
   - [ ] Pair CSS strings, braces, parentheses, and comments in `<style>` and inline `style=""`.
   - [ ] Use CSS tokenizer state to avoid pairing delimiters inside existing CSS strings/comments.
-- [ ] Milestone 4: Source block movement.
-  - [ ] Render a move chip above the top-left of a selected element's source range when that range
-        maps cleanly to one XML node.
-  - [ ] Drag the chip over legal source drop targets and preview the insertion point without
-        changing text selection mid-drag.
-  - [ ] Apply the move as a DOM/source operation that preserves the moved element selection and
-        scrolls the new source range into view.
+- [x] Milestone 4: Source block movement.
+  - [x] Render a compact gutter handle beside source-backed element lines.
+  - [x] Drag the handle over legal source drop targets and preview the insertion point without
+        changing text selection mid-drag. Focus mode temporarily reveals the complete source while
+        the gesture is active.
+  - [x] Apply the move as a revision-bound DOM/source operation that preserves the moved element
+        selection and mirrors the new source order in place.
 - [ ] Milestone 5: Editor integration and verification.
   - [ ] Route completions through the same undo path as normal typing.
   - [ ] Add regression tests for focus-mode scrolling, selection preservation, and parseable

--- a/docs/structured_source_editing.md
+++ b/docs/structured_source_editing.md
@@ -14,6 +14,10 @@ edited in both directions:
   removal, attribute changes — mutate the XML document and emit byte-level source
   deltas, which are mirrored back into the source pane in place, preserving the
   surrounding text and formatting rather than regenerating the whole document.
+- **Structural source moves.** Dragging an element's source-gutter handle over
+  another element previews the insertion point on the source and canvas. A valid
+  drop queues one DOM reparent/reorder operation; source deltas then mirror the
+  committed order back into the editor without cut-and-paste string surgery.
 
 Structured editing is on by default (`EditorApp::structuredEditingEnabled()`
 returns `true`). Documents that were not loaded with a source store fall back to
@@ -33,6 +37,9 @@ Guarantees callers can rely on:
   canvas reparse.
 - **Monotonic versioning.** `XMLSourceStore::sourceVersion()` increases on every
   applied edit, and each delta records the version it produced.
+- **Revision-bound structural gestures.** A source move records document
+  generation, frame version, and source hash. Any intervening source or DOM edit
+  rejects the drop instead of applying it to stale elements or offsets.
 
 ## Architecture Snapshot
 
@@ -99,7 +106,15 @@ with the initial source; `resetForLoadedDocument`, `handleTextEdits`,
 `nextTextSyncWakeSeconds`.
 
 `EditorApp`: `structuredEditingEnabled()` / `setStructuredEditingEnabled(bool)`
-(default `true`).
+(default `true`); `moveElementBefore(...)` validates and queues cross-parent or
+same-parent DOM moves used by source dragging.
+
+`SourceStructuralMove` (`donner/editor/SourceStructuralMove.h`):
+`BuildSourceStructuralMovePlan(...)` validates a prospective move without
+mutation; `CommitSourceStructuralMove(...)` revalidates the captured revision and
+queues the DOM operation. The planner rejects the document root, locked
+subtrees, cycles, invalid containers/references, unavailable source ranges, and
+no-op positions.
 
 ## Testing and Observability
 
@@ -112,6 +127,11 @@ with the initial source; `resetForLoadedDocument`, `handleTextEdits`,
 - **`//donner/editor/tests:structured_editing_stress_tests`** — the editor sync
   path under the deterministic replay/stress harness (see
   [Deterministic Replay Testing](deterministic_replay_testing.md)).
+- **`//donner/editor/tests:source_structural_move_tests`** — DOM-first source
+  moves, cross-parent ordering, lock/cycle/root/no-op rejection, terminal-newline
+  canonicalization, and stale-plan rejection.
+- **`//donner/editor/tests:text_editor_tests`** — source-gutter drag event
+  routing, non-mutating preview decoration, and cancellation cleanup.
 
 ## Limitations and Future Extensions
 
@@ -120,3 +140,6 @@ with the initial source; `resetForLoadedDocument`, `handleTextEdits`,
 - When a source edit cannot be reparsed locally, the document falls back to a
   wider reparse scope; the source pane still stays consistent via full-source
   mirroring.
+- Structural source dragging currently moves one complete element before
+  another source-backed element. Arbitrary text drag/drop and cross-document
+  moves are not supported.

--- a/donner/editor/BUILD.bazel
+++ b/donner/editor/BUILD.bazel
@@ -381,6 +381,20 @@ donner_cc_library(
 )
 
 donner_cc_library(
+    name = "source_structural_move",
+    srcs = ["SourceStructuralMove.cc"],
+    hdrs = ["SourceStructuralMove.h"],
+    deps = [
+        ":editor_app",
+        ":flash_decorations",
+        ":lock_state",
+        ":source_selection",
+        "//donner/base/xml",
+        "//donner/svg",
+    ],
+)
+
+donner_cc_library(
     name = "shape_clipboard_payload",
     srcs = ["ShapeClipboardPayload.cc"],
     hdrs = ["ShapeClipboardPayload.h"],
@@ -934,6 +948,7 @@ donner_cc_library(
         ":sidebar_presenter",
         ":source_diagnostics_panel",
         ":source_selection",
+        ":source_structural_move",
         ":style_source_annotations",
         ":text_editor",
         ":text_format_bar_presenter",

--- a/donner/editor/EditorApp.cc
+++ b/donner/editor/EditorApp.cc
@@ -138,6 +138,24 @@ bool FilledPathIntersectsRect(const Path& path, FillRule fillRule,
   return result.status == PathBooleanStatus::Ok;
 }
 
+bool IsElementOrDescendant(const svg::SVGElement& ancestor, const svg::SVGElement& element) {
+  for (std::optional<svg::SVGElement> current = element; current.has_value();
+       current = current->parentElement()) {
+    if (*current == ancestor) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool IsStructuralMoveContainer(const svg::SVGElement& element) {
+  const std::string tagName(element.tagName().name);
+  constexpr std::array<std::string_view, 10> kContainerTags = {
+      "svg", "g", "defs", "symbol", "a", "marker", "mask", "pattern", "clipPath", "switch",
+  };
+  return std::find(kContainerTags.begin(), kContainerTags.end(), tagName) != kContainerTags.end();
+}
+
 bool GeometryIntersectsRect(const svg::SVGGeometryElement& geometry, const Box2d& documentRect) {
   std::optional<Box2d> bounds = geometry.worldBounds();
   if (!bounds.has_value()) {
@@ -567,7 +585,7 @@ std::vector<AttributeWritebackTarget> CaptureSelectionTargets(
 //   computing a fresh writeback target - against it risks writing a
 //   correctly-shaped but wrongly-targeted patch into the live source text.
 std::optional<svg::SVGElement> ResolveSnapshotElement(AsyncSVGDocument& document,
-                                                       const UndoSnapshot& snapshot) {
+                                                      const UndoSnapshot& snapshot) {
   if (!snapshot.writebackTarget.has_value()) {
     return snapshot.element;
   }
@@ -1182,6 +1200,32 @@ bool EditorApp::reorderElementBeforeSibling(svg::SVGElement element,
   return applyElementMove(element, parent, referenceSibling, "Reorder element");
 }
 
+bool EditorApp::moveElementBefore(svg::SVGElement element, svg::SVGElement parent,
+                                  std::optional<svg::SVGElement> referenceElement,
+                                  std::string_view undoLabel) {
+  if (!document_.hasDocument()) {
+    return false;
+  }
+  const svg::SVGElement root = document_.document().svgElement();
+  if (element == root || !IsElementOrDescendant(root, element) ||
+      !IsElementOrDescendant(root, parent) || IsElementOrDescendant(element, parent) ||
+      !IsStructuralMoveContainer(parent) || IsLocked(element) || IsLocked(parent)) {
+    return false;
+  }
+
+  if (referenceElement.has_value()) {
+    if (*referenceElement == element || referenceElement->parentElement() != parent) {
+      return false;
+    }
+  }
+
+  if (element.parentElement() == parent && element.nextSibling() == referenceElement) {
+    return false;
+  }
+
+  return applyElementMove(element, parent, referenceElement, undoLabel);
+}
+
 bool EditorApp::applyElementMove(svg::SVGElement element, svg::SVGElement parent,
                                  std::optional<svg::SVGElement> referenceElement,
                                  std::string_view undoLabel) {
@@ -1343,7 +1387,7 @@ void EditorApp::setElementVisible(const svg::SVGElement& element, bool visible) 
     std::optional<RcString> authorDisplay = element.getAttribute("display");
     std::optional<std::string> capturedValue =
         authorDisplay.has_value() ? std::optional<std::string>(std::string(*authorDisplay))
-                                   : std::nullopt;
+                                  : std::nullopt;
     if (entryIt != hiddenElementAuthorDisplay_.end()) {
       entryIt->second = std::move(capturedValue);
     } else {
@@ -1364,8 +1408,8 @@ void EditorApp::setElementVisible(const svg::SVGElement& element, bool visible) 
     std::optional<std::string> authorDisplay = std::move(entryIt->second);
     hiddenElementAuthorDisplay_.erase(entryIt);
     if (authorDisplay.has_value() && *authorDisplay != "none") {
-      applyMutation(EditorCommand::SetAttributeCommand(element, "display",
-                                                        std::move(*authorDisplay)));
+      applyMutation(
+          EditorCommand::SetAttributeCommand(element, "display", std::move(*authorDisplay)));
       return;
     }
   }

--- a/donner/editor/EditorApp.h
+++ b/donner/editor/EditorApp.h
@@ -254,6 +254,23 @@ public:
                                    std::optional<svg::SVGElement> referenceSibling);
 
   /**
+   * Move \p element into \p parent before \p referenceElement as one undoable DOM edit.
+   *
+   * Unlike \ref reorderElementBeforeSibling, this supports cross-parent moves. It rejects roots,
+   * locked subtrees, non-container parents, cycles, foreign elements, invalid references, and
+   * no-op positions. Structured editing reflects the committed DOM move into source.
+   *
+   * @param element Element to move.
+   * @param parent Destination container in the current document.
+   * @param referenceElement Destination sibling, or \c std::nullopt to append.
+   * @param undoLabel Label for the single undo entry.
+   * @return True when the move was queued.
+   */
+  bool moveElementBefore(svg::SVGElement element, svg::SVGElement parent,
+                         std::optional<svg::SVGElement> referenceElement,
+                         std::string_view undoLabel = "Move element");
+
+  /**
    * Rename the single selected element's `id` to @p newId, updating every
    * internal reference so the document keeps rendering the same - one undoable
    * structural edit.

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -3875,6 +3875,13 @@ void EditorShell::clearSourceStructuralDrag() {
   sourceStructuralMoveTarget_.reset();
   sourceStructuralMovePlan_.reset();
   textEditor_.setSourceStructuralMoveDecoration(std::nullopt);
+  if (sourceFocusModeBeforeStructuralDrag_.has_value()) {
+    sourceFocusMode_ = *sourceFocusModeBeforeStructuralDrag_;
+    sourceFocusModeBeforeStructuralDrag_.reset();
+    if (sourceFocusMode_ && app_.hasDocument() && !app_.document().hasPendingMutations()) {
+      updateSourceFocusView(/*scrollToSelection=*/false);
+    }
+  }
 }
 
 void EditorShell::updateSourceStructuralDrag() {
@@ -3885,14 +3892,19 @@ void EditorShell::updateSourceStructuralDrag() {
   const std::string source = textEditor_.getText();
   if (const std::optional<int> startedLine = textEditor_.takeSourceGutterDragStartedLine()) {
     clearSourceStructuralDrag();
+    sourceFocusModeBeforeStructuralDrag_ = sourceFocusMode_;
+    sourceFocusMode_ = false;
+    textEditor_.clearFocusPartition();
     if (!app_.hasDocument() || textEditor_.isTextChanged() ||
         app_.document().hasPendingMutations()) {
+      clearSourceStructuralDrag();
       textEditor_.cancelSourceGutterDrag();
       return;
     }
     const std::string documentSource =
         CanonicalizeForTextEditor(app_.document().document().source());
     if (source != documentSource) {
+      clearSourceStructuralDrag();
       textEditor_.cancelSourceGutterDrag();
       return;
     }
@@ -3906,7 +3918,6 @@ void EditorShell::updateSourceStructuralDrag() {
       textEditor_.cancelSourceGutterDrag();
       return;
     }
-    textEditor_.clearFocusPartition();
   }
 
   const std::optional<Coordinates> dragTarget = textEditor_.sourceGutterDragTarget();

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -3920,10 +3920,12 @@ void EditorShell::updateSourceStructuralDrag() {
     }
   }
 
-  const std::optional<Coordinates> dragTarget = textEditor_.sourceGutterDragTarget();
-  if (sourceStructuralDragElement_.has_value() && dragTarget.has_value()) {
+  const auto evaluateDragTarget = [&](const Coordinates& dragTarget) {
+    if (!sourceStructuralDragElement_.has_value()) {
+      return;
+    }
     const std::size_t targetOffset =
-        textEditor_.getByteOffsetAtCoordinates(Coordinates{dragTarget->line, 0});
+        textEditor_.getByteOffsetAtCoordinates(Coordinates{dragTarget.line, 0});
     sourceStructuralMoveTarget_ = FindElementNearSourceOffset(
         app_.document().document(), source, FirstSourceContentOffset(source, targetOffset));
     sourceStructuralMovePlan_.reset();
@@ -3961,9 +3963,15 @@ void EditorShell::updateSourceStructuralDrag() {
         .valid = evaluation.status == SourceStructuralMoveStatus::Ready,
         .message = std::string(SourceStructuralMoveStatusMessage(evaluation.status)),
     });
+  };
+
+  if (const std::optional<Coordinates> dragTarget = textEditor_.sourceGutterDragTarget()) {
+    evaluateDragTarget(*dragTarget);
   }
 
-  if (textEditor_.takeSourceGutterDropTarget().has_value()) {
+  if (const std::optional<Coordinates> dropTarget = textEditor_.takeSourceGutterDropTarget()) {
+    // Re-evaluate from the release coordinate: the pointer can move and release between drag frames.
+    evaluateDragTarget(*dropTarget);
     if (sourceStructuralMovePlan_.has_value() &&
         CommitSourceStructuralMove(app_, *sourceStructuralMovePlan_, source) ==
             SourceStructuralMoveStatus::Ready) {

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cctype>
 #include <cfloat>
 #include <chrono>
 #include <cmath>
@@ -586,6 +587,15 @@ std::string CanonicalizeForTextEditor(std::string_view source) {
     result.pop_back();
   }
   return result;
+}
+
+std::size_t FirstSourceContentOffset(std::string_view source, std::size_t lineStart) {
+  std::size_t offset = std::min(lineStart, source.size());
+  while (offset < source.size() && source[offset] != '\n' && source[offset] != '\r' &&
+         std::isspace(static_cast<unsigned char>(source[offset]))) {
+    ++offset;
+  }
+  return offset;
 }
 
 Box2d ResolveDocumentViewBox(svg::SVGDocument& document) {
@@ -2162,11 +2172,14 @@ void EditorShell::renderSourcePane(float paneOriginY, float paneHeight, float pa
   updateSourceStyleDecorations();
   textEditor_.render("##source",
                      ImVec2(0.0f, diagnosticsHeight > 0.0f ? -diagnosticsHeight : 0.0f));
+  updateSourceStructuralDrag();
   applySourceStyleDecorationChipClick();
   if (textEditor_.takeSourceFocusModeContextMenuToggleRequest()) {
     toggleSourceFocusMode();
   }
-  syncSelectionFromSourceCursorIfNeeded();
+  if (!sourceStructuralDragElement_.has_value()) {
+    syncSelectionFromSourceCursorIfNeeded();
+  }
   const std::optional<std::uint64_t> sourceHoveredDiagnostic =
       textEditor_.hoveredSourceDiagnosticId();
   ImGui::PopFont();
@@ -3725,6 +3738,11 @@ void EditorShell::renderDockSpaceHost(float hostX, float hostY, float hostWidth,
 }
 
 bool EditorShell::highlightSelectionSourceIfNeeded() {
+  if (sourceStructuralDragElement_.has_value()) {
+    textEditor_.clearFocusPartition();
+    return false;
+  }
+
   const auto& selectionNow = app_.selectedElements();
   const bool preserveSourceEditCursor =
       preserveSourceEditFocusCursor_ && sourceFocusMode_ && textEditor_.isCursorInsideFocusRange();
@@ -3837,11 +3855,112 @@ std::vector<svg::SVGElement> EditorShell::referenceHighlightElements() const {
 std::vector<svg::SVGElement> EditorShell::combinedSourcePreviewElements() const {
   std::vector<svg::SVGElement> elements = sourceHoverElements();
   AddUniqueElements(&elements, referenceHighlightElements());
+  if (sourceStructuralDragElement_.has_value()) {
+    const std::array<svg::SVGElement, 1> dragged{*sourceStructuralDragElement_};
+    AddUniqueElements(&elements, dragged);
+  }
+  if (sourceStructuralMoveTarget_.has_value()) {
+    const std::array<svg::SVGElement, 1> target{*sourceStructuralMoveTarget_};
+    AddUniqueElements(&elements, target);
+  }
   if (layersPanelHoverElement_.has_value()) {
     const std::array<svg::SVGElement, 1> hovered{*layersPanelHoverElement_};
     AddUniqueElements(&elements, hovered);
   }
   return elements;
+}
+
+void EditorShell::clearSourceStructuralDrag() {
+  sourceStructuralDragElement_.reset();
+  sourceStructuralMoveTarget_.reset();
+  sourceStructuralMovePlan_.reset();
+  textEditor_.setSourceStructuralMoveDecoration(std::nullopt);
+}
+
+void EditorShell::updateSourceStructuralDrag() {
+  if (textEditor_.takeSourceGutterDragCancelled()) {
+    clearSourceStructuralDrag();
+  }
+
+  const std::string source = textEditor_.getText();
+  if (const std::optional<int> startedLine = textEditor_.takeSourceGutterDragStartedLine()) {
+    clearSourceStructuralDrag();
+    if (!app_.hasDocument() || textEditor_.isTextChanged() ||
+        app_.document().hasPendingMutations()) {
+      textEditor_.cancelSourceGutterDrag();
+      return;
+    }
+    const std::string documentSource =
+        CanonicalizeForTextEditor(app_.document().document().source());
+    if (source != documentSource) {
+      textEditor_.cancelSourceGutterDrag();
+      return;
+    }
+    const std::size_t lineStart =
+        textEditor_.getByteOffsetAtCoordinates(Coordinates{*startedLine, 0});
+    sourceStructuralDragElement_ = FindElementNearSourceOffset(
+        app_.document().document(), source, FirstSourceContentOffset(source, lineStart));
+    if (!sourceStructuralDragElement_.has_value() ||
+        *sourceStructuralDragElement_ == app_.document().document().svgElement()) {
+      clearSourceStructuralDrag();
+      textEditor_.cancelSourceGutterDrag();
+      return;
+    }
+    textEditor_.clearFocusPartition();
+  }
+
+  const std::optional<Coordinates> dragTarget = textEditor_.sourceGutterDragTarget();
+  if (sourceStructuralDragElement_.has_value() && dragTarget.has_value()) {
+    const std::size_t targetOffset =
+        textEditor_.getByteOffsetAtCoordinates(Coordinates{dragTarget->line, 0});
+    sourceStructuralMoveTarget_ = FindElementNearSourceOffset(
+        app_.document().document(), source, FirstSourceContentOffset(source, targetOffset));
+    sourceStructuralMovePlan_.reset();
+
+    SourceStructuralMoveEvaluation evaluation;
+    if (sourceStructuralMoveTarget_.has_value() &&
+        sourceStructuralMoveTarget_->parentElement().has_value()) {
+      evaluation = BuildSourceStructuralMovePlan(app_, source, *sourceStructuralDragElement_,
+                                                 *sourceStructuralMoveTarget_->parentElement(),
+                                                 sourceStructuralMoveTarget_);
+    } else {
+      evaluation.status = SourceStructuralMoveStatus::InvalidReference;
+    }
+    sourceStructuralMovePlan_ = std::move(evaluation.plan);
+
+    SourceByteRange draggedRange;
+    if (sourceStructuralMovePlan_.has_value()) {
+      draggedRange = sourceStructuralMovePlan_->elementRange;
+    } else if (const std::optional<SourceByteRange> range =
+                   ElementSourceByteRange(*sourceStructuralDragElement_, source)) {
+      draggedRange = *range;
+    }
+    std::size_t insertionOffset = targetOffset;
+    if (sourceStructuralMovePlan_.has_value()) {
+      insertionOffset = sourceStructuralMovePlan_->insertionOffset;
+    } else if (sourceStructuralMoveTarget_.has_value()) {
+      if (const std::optional<SourceByteRange> range =
+              ElementSourceByteRange(*sourceStructuralMoveTarget_, source)) {
+        insertionOffset = range->start;
+      }
+    }
+    textEditor_.setSourceStructuralMoveDecoration(TextEditor::SourceStructuralMoveDecoration{
+        .elementRange = draggedRange,
+        .insertionOffset = insertionOffset,
+        .valid = evaluation.status == SourceStructuralMoveStatus::Ready,
+        .message = std::string(SourceStructuralMoveStatusMessage(evaluation.status)),
+    });
+  }
+
+  if (textEditor_.takeSourceGutterDropTarget().has_value()) {
+    if (sourceStructuralMovePlan_.has_value() &&
+        CommitSourceStructuralMove(app_, *sourceStructuralMovePlan_, source) ==
+            SourceStructuralMoveStatus::Ready) {
+      app_.setSelection(sourceStructuralDragElement_);
+    }
+    clearSourceStructuralDrag();
+    window_.wakeEventLoop();
+  }
 }
 
 void EditorShell::updateSourceHoverPreview() {

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -32,6 +32,7 @@
 #include "donner/editor/SelectTool.h"
 #include "donner/editor/SidebarPresenter.h"
 #include "donner/editor/SourceDiagnosticsPanel.h"
+#include "donner/editor/SourceStructuralMove.h"
 #include "donner/editor/StyleSourceAnnotations.h"
 #include "donner/editor/TextEditor.h"
 #include "donner/editor/TextFormatBarPresenter.h"
@@ -378,6 +379,8 @@ private:
       const std::vector<svg::SVGElement>& elements) const;
   [[nodiscard]] std::vector<svg::SVGElement> referenceHighlightElements() const;
   [[nodiscard]] std::vector<svg::SVGElement> combinedSourcePreviewElements() const;
+  void updateSourceStructuralDrag();
+  void clearSourceStructuralDrag();
   void updateSourceHoverPreview();
   void refreshReferenceHighlightSummaryIfNeeded();
   void applyReferenceHighlightPreview();
@@ -451,6 +454,9 @@ private:
   ActiveTool activeTool_ = ActiveTool::Select;
   TextEditor textEditor_;
   SourceDiagnosticsPanel sourceDiagnosticsPanel_;
+  std::optional<svg::SVGElement> sourceStructuralDragElement_;
+  std::optional<svg::SVGElement> sourceStructuralMoveTarget_;
+  std::optional<SourceStructuralMovePlan> sourceStructuralMovePlan_;
   /// Backing store for shape Cut/Copy/Paste. Holds the headered
   /// `# donner-shape-clipboard v1` payload (see `ShapeClipboardPayload`).
   std::unique_ptr<ClipboardInterface> shapeClipboard_;

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -457,6 +457,7 @@ private:
   std::optional<svg::SVGElement> sourceStructuralDragElement_;
   std::optional<svg::SVGElement> sourceStructuralMoveTarget_;
   std::optional<SourceStructuralMovePlan> sourceStructuralMovePlan_;
+  std::optional<bool> sourceFocusModeBeforeStructuralDrag_;
   /// Backing store for shape Cut/Copy/Paste. Holds the headered
   /// `# donner-shape-clipboard v1` payload (see `ShapeClipboardPayload`).
   std::unique_ptr<ClipboardInterface> shapeClipboard_;

--- a/donner/editor/SourceStructuralMove.cc
+++ b/donner/editor/SourceStructuralMove.cc
@@ -1,0 +1,167 @@
+#include "donner/editor/SourceStructuralMove.h"
+
+#include <algorithm>
+#include <array>
+#include <string>
+
+#include "donner/base/xml/XMLNode.h"
+#include "donner/editor/EditorApp.h"
+#include "donner/editor/LockState.h"
+#include "donner/editor/SourceSelection.h"
+
+namespace donner::editor {
+namespace {
+
+std::uint64_t SourceHash(std::string_view source) {
+  std::uint64_t hash = 14695981039346656037ull;
+  for (const char byte : source) {
+    hash ^= static_cast<std::uint8_t>(byte);
+    hash *= 1099511628211ull;
+  }
+  return hash;
+}
+
+std::string_view CanonicalEditorSource(std::string_view source) {
+  if (!source.empty() && source.back() == '\n') {
+    source.remove_suffix(1);
+  }
+  return source;
+}
+
+bool IsElementOrDescendant(const svg::SVGElement& ancestor, const svg::SVGElement& element) {
+  for (std::optional<svg::SVGElement> current = element; current.has_value();
+       current = current->parentElement()) {
+    if (*current == ancestor) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool IsMoveContainer(const svg::SVGElement& element) {
+  const std::string tagName(element.tagName().name);
+  constexpr std::array<std::string_view, 10> kContainerTags = {
+      "svg", "g", "defs", "symbol", "a", "marker", "mask", "pattern", "clipPath", "switch",
+  };
+  return std::find(kContainerTags.begin(), kContainerTags.end(), tagName) != kContainerTags.end();
+}
+
+std::optional<std::size_t> ResolvedOffset(std::string_view source, const FileOffset& offset) {
+  const FileOffset resolved = offset.resolveOffset(source);
+  return resolved.offset.has_value()
+             ? std::optional<std::size_t>(std::min(*resolved.offset, source.size()))
+             : std::nullopt;
+}
+
+std::optional<std::size_t> InsertionOffset(std::string_view source, const svg::SVGElement& parent,
+                                           const std::optional<svg::SVGElement>& referenceElement) {
+  if (referenceElement.has_value()) {
+    const std::optional<SourceByteRange> range = ElementSourceByteRange(*referenceElement, source);
+    return range.has_value() ? std::optional<std::size_t>(range->start) : std::nullopt;
+  }
+
+  const std::optional<xml::XMLNode> parentNode = xml::XMLNode::TryCast(parent.entityHandle());
+  if (!parentNode.has_value()) {
+    return std::nullopt;
+  }
+  const std::optional<SourceRange> closingTag = parentNode->getClosingTagLocation();
+  return closingTag.has_value() ? ResolvedOffset(source, closingTag->start) : std::nullopt;
+}
+
+}  // namespace
+
+SourceStructuralMoveEvaluation BuildSourceStructuralMovePlan(
+    EditorApp& app, std::string_view source, svg::SVGElement element, svg::SVGElement parent,
+    std::optional<svg::SVGElement> referenceElement) {
+  if (!app.hasDocument()) {
+    return {.status = SourceStructuralMoveStatus::DocumentUnavailable};
+  }
+  svg::SVGDocument& document = app.document().document();
+  if (!document.hasSourceStore() || CanonicalEditorSource(document.source()) != source) {
+    return {.status = SourceStructuralMoveStatus::StaleRevision};
+  }
+
+  const svg::SVGElement root = document.svgElement();
+  if (element == root) {
+    return {.status = SourceStructuralMoveStatus::RootElement};
+  }
+  if (!IsElementOrDescendant(root, element) || !IsElementOrDescendant(root, parent) ||
+      !IsMoveContainer(parent)) {
+    return {.status = SourceStructuralMoveStatus::InvalidParent};
+  }
+  if (IsLocked(element) || IsLocked(parent)) {
+    return {.status = SourceStructuralMoveStatus::Locked};
+  }
+  if (IsElementOrDescendant(element, parent)) {
+    return {.status = SourceStructuralMoveStatus::Cycle};
+  }
+
+  if (referenceElement.has_value()) {
+    if (*referenceElement == element || referenceElement->parentElement() != parent) {
+      return {.status = SourceStructuralMoveStatus::InvalidReference};
+    }
+  }
+  if (element.parentElement() == parent && element.nextSibling() == referenceElement) {
+    return {.status = SourceStructuralMoveStatus::NoChange};
+  }
+
+  const std::optional<SourceByteRange> elementRange = ElementSourceByteRange(element, source);
+  const std::optional<std::size_t> insertionOffset =
+      InsertionOffset(source, parent, referenceElement);
+  if (!elementRange.has_value() || !insertionOffset.has_value()) {
+    return {.status = SourceStructuralMoveStatus::NoSourceRange};
+  }
+
+  return {
+      .status = SourceStructuralMoveStatus::Ready,
+      .plan =
+          SourceStructuralMovePlan{
+              .element = element,
+              .parent = parent,
+              .referenceElement = referenceElement,
+              .elementRange = *elementRange,
+              .insertionOffset = *insertionOffset,
+              .expectedDocumentGeneration = app.document().documentGeneration(),
+              .expectedFrameVersion = app.document().currentFrameVersion(),
+              .expectedSourceHash = SourceHash(source),
+          },
+  };
+}
+
+SourceStructuralMoveStatus CommitSourceStructuralMove(EditorApp& app,
+                                                      const SourceStructuralMovePlan& plan,
+                                                      std::string_view source) {
+  if (!app.hasDocument()) {
+    return SourceStructuralMoveStatus::DocumentUnavailable;
+  }
+  if (app.document().documentGeneration() != plan.expectedDocumentGeneration ||
+      app.document().currentFrameVersion() != plan.expectedFrameVersion ||
+      SourceHash(source) != plan.expectedSourceHash ||
+      CanonicalEditorSource(app.document().document().source()) != source) {
+    return SourceStructuralMoveStatus::StaleRevision;
+  }
+  return app.moveElementBefore(plan.element, plan.parent, plan.referenceElement,
+                               "Move element from source")
+             ? SourceStructuralMoveStatus::Ready
+             : SourceStructuralMoveStatus::Rejected;
+}
+
+std::string_view SourceStructuralMoveStatusMessage(SourceStructuralMoveStatus status) {
+  switch (status) {
+    case SourceStructuralMoveStatus::Ready: return "Move element here";
+    case SourceStructuralMoveStatus::DocumentUnavailable: return "No editable document";
+    case SourceStructuralMoveStatus::StaleRevision: return "Source changed; start the drag again";
+    case SourceStructuralMoveStatus::RootElement: return "The document root cannot be moved";
+    case SourceStructuralMoveStatus::Locked: return "Locked elements cannot be moved";
+    case SourceStructuralMoveStatus::InvalidParent:
+      return "This element cannot contain SVG children";
+    case SourceStructuralMoveStatus::InvalidReference: return "Invalid insertion target";
+    case SourceStructuralMoveStatus::Cycle: return "An element cannot move inside itself";
+    case SourceStructuralMoveStatus::NoSourceRange: return "Source location is unavailable";
+    case SourceStructuralMoveStatus::NoChange: return "The element is already here";
+    case SourceStructuralMoveStatus::Rejected: return "The document rejected this move";
+  }
+  return "Move unavailable";
+}
+
+}  // namespace donner::editor

--- a/donner/editor/SourceStructuralMove.h
+++ b/donner/editor/SourceStructuralMove.h
@@ -1,0 +1,76 @@
+#pragma once
+/// @file
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+#include "donner/editor/FlashDecorations.h"
+#include "donner/svg/SVGElement.h"
+
+namespace donner::editor {
+
+class EditorApp;
+
+/// Validation result for a source-initiated structural element move.
+enum class SourceStructuralMoveStatus : std::uint8_t {
+  Ready,
+  DocumentUnavailable,
+  StaleRevision,
+  RootElement,
+  Locked,
+  InvalidParent,
+  InvalidReference,
+  Cycle,
+  NoSourceRange,
+  NoChange,
+  Rejected,
+};
+
+/// Revision-bound, DOM-shaped move prepared from a source drag target.
+struct SourceStructuralMovePlan {
+  svg::SVGElement element;
+  svg::SVGElement parent;
+  std::optional<svg::SVGElement> referenceElement;
+  SourceByteRange elementRange;
+  std::size_t insertionOffset = 0;
+  std::uint64_t expectedDocumentGeneration = 0;
+  std::uint64_t expectedFrameVersion = 0;
+  std::uint64_t expectedSourceHash = 0;
+};
+
+/// Result of validating and building a structural move plan.
+struct SourceStructuralMoveEvaluation {
+  SourceStructuralMoveStatus status = SourceStructuralMoveStatus::Rejected;
+  std::optional<SourceStructuralMovePlan> plan;
+};
+
+/**
+ * Build a structural move plan without mutating the document.
+ *
+ * @param app Current editor document owner.
+ * @param source Editable source corresponding exactly to the current DOM.
+ * @param element Complete source-backed element being dragged.
+ * @param parent Destination container.
+ * @param referenceElement Destination sibling, or \c std::nullopt to append.
+ */
+[[nodiscard]] SourceStructuralMoveEvaluation BuildSourceStructuralMovePlan(
+    EditorApp& app, std::string_view source, svg::SVGElement element, svg::SVGElement parent,
+    std::optional<svg::SVGElement> referenceElement);
+
+/**
+ * Commit a previously validated plan if its source and document revisions are still current.
+ *
+ * @param app Current editor document owner.
+ * @param plan Plan returned by \ref BuildSourceStructuralMovePlan.
+ * @param source Current editable source.
+ * @return \ref SourceStructuralMoveStatus::Ready when the DOM move was queued.
+ */
+[[nodiscard]] SourceStructuralMoveStatus CommitSourceStructuralMove(
+    EditorApp& app, const SourceStructuralMovePlan& plan, std::string_view source);
+
+/// Human-readable reason suitable for a disabled drop-target tooltip.
+[[nodiscard]] std::string_view SourceStructuralMoveStatusMessage(SourceStructuralMoveStatus status);
+
+}  // namespace donner::editor

--- a/donner/editor/TextEditor.cc
+++ b/donner/editor/TextEditor.cc
@@ -681,6 +681,11 @@ void TextEditor::handleMouseInputs() {
     return;
   }
 
+  if (sourceGutterDragLine_.has_value()) {
+    io.WantCaptureMouse = true;
+    return;
+  }
+
   const bool click = ImGui::IsMouseClicked(0);
   if (alt || (shift && !click)) {
     return;
@@ -925,6 +930,60 @@ void TextEditor::updateHoveredTextPosition() {
   }
 
   hoveredTextPosition_ = screenPosToCoordinates(mousePos);
+}
+
+void TextEditor::updateSourceGutterDragInput() {
+  if (!showLineNumbers_) {
+    return;
+  }
+
+  ImGuiIO& io = ImGui::GetIO();
+  const ImVec2 mousePos = ImGui::GetMousePos();
+  const ImVec2 local{mousePos.x - uiCursorPos_.x, mousePos.y - uiCursorPos_.y};
+
+  if (sourceGutterDragLine_.has_value()) {
+    io.WantCaptureMouse = true;
+    if (ImGui::IsKeyPressed(ImGuiKey_Escape) || ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
+      sourceGutterDragCancelled_ = true;
+      sourceGutterDragLine_.reset();
+      sourceGutterDragTarget_.reset();
+    } else if (!ImGui::IsWindowHovered()) {
+      if (!ImGui::IsMouseDown(ImGuiMouseButton_Left)) {
+        sourceGutterDragCancelled_ = true;
+        sourceGutterDragLine_.reset();
+        sourceGutterDragTarget_.reset();
+      }
+    } else if (!ImGui::IsMouseDown(ImGuiMouseButton_Left)) {
+      sourceGutterDropTarget_ = sourceGutterDragTarget_;
+      sourceGutterDragLine_.reset();
+      sourceGutterDragTarget_.reset();
+    } else {
+      sourceGutterDragTarget_ = screenPosToCoordinates(mousePos);
+    }
+    return;
+  }
+
+  if (!ImGui::IsWindowHovered()) {
+    return;
+  }
+
+  const float handleWidth = 16.0f * uiScale_;
+  const bool inHandle = local.x >= std::max(0.0f, textStart_ - handleWidth) &&
+                        local.x < textStart_ && local.y >= 0.0f;
+  if (!inHandle || !ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
+    return;
+  }
+
+  const Coordinates position = screenPosToCoordinates(mousePos);
+  if (position.line < 0 || position.line >= text_.getTotalLines()) {
+    return;
+  }
+  sourceGutterDragLine_ = position.line;
+  sourceGutterDragStartedLine_ = position.line;
+  sourceGutterDragTarget_ = position;
+  sourceGutterDropTarget_.reset();
+  sourceGutterDragCancelled_ = false;
+  io.WantCaptureMouse = true;
 }
 
 void TextEditor::rebuildVisualLines(const ImVec2& contentSize) {
@@ -1508,6 +1567,24 @@ void TextEditor::renderLineBackground(const VisualLine& visualLine, const ImVec2
         ImGui::ColorConvertFloat4ToU32(color));
   }
 
+  if (sourceStructuralMoveDecoration_.has_value()) {
+    const SourceStructuralMoveDecoration& decoration = *sourceStructuralMoveDecoration_;
+    const ImVec4 previewColor =
+        decoration.valid ? ImVec4(0.20f, 0.78f, 0.70f, 0.14f) : ImVec4(0.95f, 0.30f, 0.28f, 0.14f);
+    drawSourceRange(decoration.elementRange, ImGui::ColorConvertFloat4ToU32(previewColor));
+
+    const Coordinates insertion = getCoordinatesAtByteOffset(decoration.insertionOffset);
+    if (insertion.line == visualLine.lineNo && insertion.column >= visualLine.startColumn &&
+        insertion.column <= visualLine.endColumn) {
+      const ImU32 lineColor =
+          ImGui::ColorConvertFloat4ToU32(decoration.valid ? ImVec4(0.20f, 0.78f, 0.70f, 0.95f)
+                                                          : ImVec4(0.95f, 0.30f, 0.28f, 0.95f));
+      drawList->AddLine(ImVec2(lineStart.x + textStart_, lineStart.y),
+                        ImVec2(lineStart.x + contentSize.x, lineStart.y), lineColor,
+                        2.0f * uiScale_);
+    }
+  }
+
   const std::vector<ActiveFlash> flashes =
       flashDecorations_.activeBackgrounds(FlashDecorations::Clock::now());
   for (const ActiveFlash& flash : flashes) {
@@ -1994,6 +2071,14 @@ void TextEditor::remapFocusMetadataForSourceEdit(const SourceEditIntent& intent)
                    })) {
     activeSourceDiagnosticId_.reset();
   }
+  if (sourceGutterDragLine_.has_value()) {
+    sourceGutterDragCancelled_ = true;
+  }
+  sourceGutterDragLine_.reset();
+  sourceGutterDragStartedLine_.reset();
+  sourceGutterDragTarget_.reset();
+  sourceGutterDropTarget_.reset();
+  sourceStructuralMoveDecoration_.reset();
 
   for (SourceStyleDecoration& decoration : sourceStyleDecorations_) {
     decoration.range = MapSourceByteRangeForEdit(decoration.range, intent, bufferSize);
@@ -2691,6 +2776,53 @@ bool TextEditor::setActiveSourceDiagnosticId(std::optional<std::uint64_t> id) {
   return changed || id.has_value();
 }
 
+std::optional<int> TextEditor::takeSourceGutterDragStartedLine() {
+  std::optional<int> line = sourceGutterDragStartedLine_;
+  sourceGutterDragStartedLine_.reset();
+  return line;
+}
+
+std::optional<Coordinates> TextEditor::takeSourceGutterDropTarget() {
+  std::optional<Coordinates> target = sourceGutterDropTarget_;
+  sourceGutterDropTarget_.reset();
+  return target;
+}
+
+bool TextEditor::takeSourceGutterDragCancelled() {
+  const bool cancelled = sourceGutterDragCancelled_;
+  sourceGutterDragCancelled_ = false;
+  return cancelled;
+}
+
+void TextEditor::cancelSourceGutterDrag() {
+  if (sourceGutterDragLine_.has_value()) {
+    sourceGutterDragCancelled_ = true;
+  }
+  sourceGutterDragLine_.reset();
+  sourceGutterDragStartedLine_.reset();
+  sourceGutterDragTarget_.reset();
+  sourceGutterDropTarget_.reset();
+  sourceStructuralMoveDecoration_.reset();
+}
+
+bool TextEditor::setSourceStructuralMoveDecoration(
+    std::optional<SourceStructuralMoveDecoration> decoration) {
+  if (decoration.has_value()) {
+    const std::size_t bufferSize = getText().size();
+    decoration->elementRange.start = std::min(decoration->elementRange.start, bufferSize);
+    decoration->elementRange.end = std::min(decoration->elementRange.end, bufferSize);
+    decoration->insertionOffset = std::min(decoration->insertionOffset, bufferSize);
+    if (decoration->elementRange.end <= decoration->elementRange.start) {
+      decoration.reset();
+    }
+  }
+  if (sourceStructuralMoveDecoration_ == decoration) {
+    return false;
+  }
+  sourceStructuralMoveDecoration_ = std::move(decoration);
+  return true;
+}
+
 void TextEditor::renderSourceDiagnosticTooltip() {
   const std::optional<std::uint64_t> hovered = hoveredSourceDiagnosticId();
   if (!hovered.has_value()) {
@@ -2715,6 +2847,17 @@ void TextEditor::renderSourceDiagnosticTooltip() {
   ImGui::PushTextWrapPos(420.0f * uiScale_);
   ImGui::TextUnformatted(it->message.c_str());
   ImGui::PopTextWrapPos();
+  ImGui::EndTooltip();
+}
+
+void TextEditor::renderSourceStructuralMoveTooltip() {
+  if (!sourceStructuralMoveDecoration_.has_value() ||
+      sourceStructuralMoveDecoration_->message.empty()) {
+    return;
+  }
+
+  ImGui::BeginTooltip();
+  ImGui::TextUnformatted(sourceStructuralMoveDecoration_->message.c_str());
   ImGui::EndTooltip();
 }
 
@@ -3022,6 +3165,23 @@ void TextEditor::renderLineNumbers(int lineNo, const ImVec2& pos, ImDrawList* dr
 
   drawList->AddText(ImVec2(pos.x + textStart_ - lineNoWidth, pos.y),
                     palette_[static_cast<int>(ColorIndex::LineNumber)], buf);
+
+  const float handleX = pos.x + textStart_ - 8.0f * uiScale_;
+  const bool handleHovered = ImGui::IsMouseHoveringRect(
+      ImVec2(handleX - 8.0f * uiScale_, pos.y), ImVec2(pos.x + textStart_, pos.y + charAdvance_.y));
+  if (handleHovered || sourceGutterDragLine_ == lineNo) {
+    const ImU32 color = sourceGutterDragLine_ == lineNo
+                            ? ImGui::ColorConvertFloat4ToU32(ImVec4(0.20f, 0.78f, 0.70f, 1.0f))
+                            : palette_[static_cast<int>(ColorIndex::LineNumber)];
+    const float centerY = pos.y + charAdvance_.y * 0.5f;
+    for (int row = -1; row <= 1; ++row) {
+      drawList->AddCircleFilled(ImVec2(handleX, centerY + row * 3.0f * uiScale_), 1.0f * uiScale_,
+                                color);
+    }
+    if (handleHovered) {
+      ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
+    }
+  }
 }
 
 namespace {
@@ -3867,6 +4027,7 @@ void TextEditor::render(std::string_view title, const ImVec2& size, bool showBor
   uiCursorPos_ = ImGui::GetCursorScreenPos();
   visualLayoutMaxColumns_ = 0;
   rebuildVisualLines(ImGui::GetWindowContentRegionMax());
+  updateSourceGutterDragInput();
   updateHoveredTextPosition();
 
   if (handleKeyboardInputs_) {
@@ -3882,6 +4043,7 @@ void TextEditor::render(std::string_view title, const ImVec2& size, bool showBor
   readyForAutocomplete_ = true;
   renderInternal(title);
   renderSourceDiagnosticTooltip();
+  renderSourceStructuralMoveTooltip();
 
   // Scrollbar markers
   if (scrollbarMarkers_) {

--- a/donner/editor/TextEditor.cc
+++ b/donner/editor/TextEditor.cc
@@ -954,7 +954,9 @@ void TextEditor::updateSourceGutterDragInput() {
         sourceGutterDragTarget_.reset();
       }
     } else if (!ImGui::IsMouseDown(ImGuiMouseButton_Left)) {
-      sourceGutterDropTarget_ = sourceGutterDragTarget_;
+      // Resolve the release position from this frame instead of reusing the previous drag frame.
+      // A fast move-and-release can otherwise commit one row behind the pointer.
+      sourceGutterDropTarget_ = screenPosToCoordinates(mousePos);
       sourceGutterDragLine_.reset();
       sourceGutterDragTarget_.reset();
     } else {

--- a/donner/editor/TextEditor.h
+++ b/donner/editor/TextEditor.h
@@ -225,6 +225,16 @@ public:
     bool operator==(const SourceStyleDecoration& other) const = default;
   };
 
+  /// Source structural-drag decoration supplied by the editor shell.
+  struct SourceStructuralMoveDecoration {
+    SourceByteRange elementRange;
+    std::size_t insertionOffset = 0;
+    bool valid = false;
+    std::string message;
+
+    bool operator==(const SourceStructuralMoveDecoration&) const = default;
+  };
+
   // Constants
   static constexpr int kLineNumberSpace = 20;  //!< Width of line number margin in pixels
 
@@ -332,6 +342,18 @@ public:
   [[nodiscard]] std::optional<Coordinates> hoveredTextPosition() const {
     return hoveredTextPosition_;
   }
+  /// Return and clear the line whose gutter handle began a structural drag.
+  [[nodiscard]] std::optional<int> takeSourceGutterDragStartedLine();
+  /// Current source position under an active gutter drag.
+  [[nodiscard]] std::optional<Coordinates> sourceGutterDragTarget() const {
+    return sourceGutterDragTarget_;
+  }
+  /// Return and clear a completed gutter drop position.
+  [[nodiscard]] std::optional<Coordinates> takeSourceGutterDropTarget();
+  /// Return and clear the gutter-drag cancellation flag.
+  [[nodiscard]] bool takeSourceGutterDragCancelled();
+  /// Cancel any active gutter drag without emitting a drop.
+  void cancelSourceGutterDrag();
   void resetTextChanged() { core_.resetTextChanged(); }
   /// True if user-facing edits have pending byte-level source intents.
   bool hasPendingSourceEditIntents() const { return core_.hasPendingSourceEditIntents(); }
@@ -622,6 +644,12 @@ public:
   bool setActiveSourceDiagnosticId(std::optional<std::uint64_t> id);
   [[nodiscard]] std::optional<std::uint64_t> activeSourceDiagnosticId() const {
     return activeSourceDiagnosticId_;
+  }
+  /// Set the current source structural-move preview decoration.
+  bool setSourceStructuralMoveDecoration(std::optional<SourceStructuralMoveDecoration> decoration);
+  [[nodiscard]] const std::optional<SourceStructuralMoveDecoration>&
+  sourceStructuralMoveDecoration() const {
+    return sourceStructuralMoveDecoration_;
   }
   /// Set source style/cascade decorations.
   bool setSourceStyleDecorations(std::vector<SourceStyleDecoration> decorations);
@@ -1110,6 +1138,7 @@ private:
   std::vector<SourceByteRange> hoverSourceRanges_;   //!< Source ranges highlighted on hover
   std::vector<SourceDiagnostic> sourceDiagnostics_;  //!< Exact parser diagnostic ranges.
   std::optional<std::uint64_t> activeSourceDiagnosticId_;
+  std::optional<SourceStructuralMoveDecoration> sourceStructuralMoveDecoration_;
   std::vector<SourceStyleDecoration> sourceStyleDecorations_;  //!< Style source decorations.
   FocusPartition focusPartition_;
   bool focusPartitionActive_ = false;
@@ -1216,15 +1245,20 @@ private:
   // `scrollbarMarkers_`, and `changedLines_` all moved into
   // `TextEditorCore`. The reference aliases below preserve the short
   // names used by the render / input-handling code.
-  bool horizontalScroll_ = false;                           //!< Enable horizontal scrolling
-  bool wordWrapEnabled_ = true;                             //!< Enable source-pane soft wrapping
-  bool showLineNumbers_ = true;                             //!< Show line numbers
-  bool highlightLine_ = true;                               //!< Highlight current line
-  bool highlightBrackets_ = false;                          //!< Highlight matching brackets
-  bool focused_ = false;                                    //!< Editor has keyboard focus
-  bool withinRender_ = false;                               //!< Currently rendering
-  bool cursorPositionChangedByMouse_ = false;               //!< Mouse moved cursor this frame
-  std::optional<Coordinates> hoveredTextPosition_;          //!< Text coordinates under the mouse
+  bool horizontalScroll_ = false;                   //!< Enable horizontal scrolling
+  bool wordWrapEnabled_ = true;                     //!< Enable source-pane soft wrapping
+  bool showLineNumbers_ = true;                     //!< Show line numbers
+  bool highlightLine_ = true;                       //!< Highlight current line
+  bool highlightBrackets_ = false;                  //!< Highlight matching brackets
+  bool focused_ = false;                            //!< Editor has keyboard focus
+  bool withinRender_ = false;                       //!< Currently rendering
+  bool cursorPositionChangedByMouse_ = false;       //!< Mouse moved cursor this frame
+  std::optional<Coordinates> hoveredTextPosition_;  //!< Text coordinates under the mouse
+  std::optional<int> sourceGutterDragLine_;
+  std::optional<int> sourceGutterDragStartedLine_;
+  std::optional<Coordinates> sourceGutterDragTarget_;
+  std::optional<Coordinates> sourceGutterDropTarget_;
+  bool sourceGutterDragCancelled_ = false;
   float textStart_ = 20.0f;                                 //!< X offset where text begins
   int leftMargin_ = kLineNumberSpace;                       //!< Left margin width
   bool handleKeyboardInputs_ = true;                        //!< Process keyboard input
@@ -1402,6 +1436,7 @@ private:
   void expandFocusHiddenRange(LineRange range);
   [[nodiscard]] bool tryExpandFocusHiddenPlaceholderAt(const ImVec2& position);
   void updateHoveredTextPosition();
+  void updateSourceGutterDragInput();
   [[nodiscard]] int visualLineIndexForCoordinates(const Coordinates& position) const;
   [[nodiscard]] Coordinates visualScreenPosToCoordinates(const ImVec2& position) const;
   [[nodiscard]] Coordinates visibleSelectionEndCoordinates() const;
@@ -1445,6 +1480,7 @@ private:
   void renderLineBackground(const VisualLine& visualLine, const ImVec2& start,
                             const ImVec2& contentSize, ImDrawList* drawList);
   void renderSourceDiagnosticTooltip();
+  void renderSourceStructuralMoveTooltip();
   void renderFocusReferenceLinks(ImDrawList* drawList);
 
   /**

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -248,6 +248,17 @@ donner_cc_test(
 )
 
 donner_cc_test(
+    name = "source_structural_move_tests",
+    srcs = ["SourceStructuralMove_tests.cc"],
+    deps = [
+        "//donner/editor:editor_app",
+        "//donner/editor:source_structural_move",
+        "//donner/svg",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
     name = "viewport_interaction_controller_tests",
     srcs = ["ViewportInteractionController_tests.cc"],
     deps = [

--- a/donner/editor/tests/SourceStructuralMove_tests.cc
+++ b/donner/editor/tests/SourceStructuralMove_tests.cc
@@ -1,0 +1,115 @@
+#include "donner/editor/SourceStructuralMove.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "donner/editor/EditorApp.h"
+#include "donner/editor/EditorCommand.h"
+
+namespace donner::editor {
+namespace {
+
+constexpr std::string_view kSvg = R"svg(<svg xmlns="http://www.w3.org/2000/svg">
+  <g id="a">
+    <rect id="r1" width="10" height="10"/>
+    <g id="inner"><rect id="nested" width="2" height="2"/></g>
+    <rect id="r2" width="10" height="10"/>
+  </g>
+  <g id="b"><circle id="c" r="4"/></g>
+</svg>)svg";
+
+svg::SVGElement RequiredElement(EditorApp& app, std::string_view selector) {
+  std::optional<svg::SVGElement> element = app.document().document().querySelector(selector);
+  EXPECT_TRUE(element.has_value()) << selector;
+  return *element;
+}
+
+TEST(SourceStructuralMove, BuildsRevisionBoundCrossParentPlanAndCommitsThroughDom) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kSvg));
+  svg::SVGElement r1 = RequiredElement(app, "#r1");
+  svg::SVGElement b = RequiredElement(app, "#b");
+  svg::SVGElement c = RequiredElement(app, "#c");
+
+  SourceStructuralMoveEvaluation evaluation = BuildSourceStructuralMovePlan(app, kSvg, r1, b, c);
+
+  ASSERT_EQ(evaluation.status, SourceStructuralMoveStatus::Ready);
+  ASSERT_TRUE(evaluation.plan.has_value());
+  EXPECT_EQ(kSvg.substr(evaluation.plan->elementRange.start,
+                        evaluation.plan->elementRange.end - evaluation.plan->elementRange.start)
+                .substr(0, 5),
+            "<rect");
+  EXPECT_EQ(kSvg.substr(evaluation.plan->insertionOffset, 7), "<circle");
+
+  EXPECT_EQ(CommitSourceStructuralMove(app, *evaluation.plan, kSvg),
+            SourceStructuralMoveStatus::Ready);
+  ASSERT_TRUE(app.flushFrame());
+
+  r1 = RequiredElement(app, "#r1");
+  b = RequiredElement(app, "#b");
+  EXPECT_EQ(r1.parentElement(), std::optional<svg::SVGElement>(b));
+  EXPECT_EQ(b.firstChild(), std::optional<svg::SVGElement>(r1));
+  const std::string source(app.document().document().source());
+  EXPECT_LT(source.find("id=\"r1\"", source.find("id=\"b\"")), source.find("id=\"c\""));
+}
+
+TEST(SourceStructuralMove, RejectsRootCycleLockedAndNoOpMoves) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kSvg));
+  svg::SVGElement root = app.document().document().svgElement();
+  svg::SVGElement a = RequiredElement(app, "#a");
+  svg::SVGElement inner = RequiredElement(app, "#inner");
+  svg::SVGElement r1 = RequiredElement(app, "#r1");
+  svg::SVGElement r2 = RequiredElement(app, "#r2");
+
+  EXPECT_EQ(BuildSourceStructuralMovePlan(app, kSvg, root, a, std::nullopt).status,
+            SourceStructuralMoveStatus::RootElement);
+  EXPECT_EQ(BuildSourceStructuralMovePlan(app, kSvg, a, inner, std::nullopt).status,
+            SourceStructuralMoveStatus::Cycle);
+  EXPECT_EQ(BuildSourceStructuralMovePlan(app, kSvg, r1, a, inner).status,
+            SourceStructuralMoveStatus::NoChange);
+
+  app.setElementLocked(r1, true);
+  ASSERT_TRUE(app.flushFrame());
+  r1 = RequiredElement(app, "#r1");
+  a = RequiredElement(app, "#a");
+  r2 = RequiredElement(app, "#r2");
+  EXPECT_EQ(
+      BuildSourceStructuralMovePlan(app, app.document().document().source(), r1, a, r2).status,
+      SourceStructuralMoveStatus::Locked);
+}
+
+TEST(SourceStructuralMove, RejectsPlanAfterDocumentAdvances) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kSvg));
+  svg::SVGElement r1 = RequiredElement(app, "#r1");
+  svg::SVGElement b = RequiredElement(app, "#b");
+  SourceStructuralMoveEvaluation evaluation =
+      BuildSourceStructuralMovePlan(app, kSvg, r1, b, std::nullopt);
+  ASSERT_TRUE(evaluation.plan.has_value());
+
+  app.applyMutation(EditorCommand::SetAttributeCommand(r1, "fill", "red"));
+  ASSERT_TRUE(app.flushFrame());
+
+  EXPECT_EQ(CommitSourceStructuralMove(app, *evaluation.plan, kSvg),
+            SourceStructuralMoveStatus::StaleRevision);
+}
+
+TEST(SourceStructuralMove, AcceptsEditorSourceWithHiddenTerminalNewline) {
+  EditorApp app;
+  const std::string sourceWithNewline = std::string(kSvg) + "\n";
+  ASSERT_TRUE(app.loadFromString(sourceWithNewline));
+  svg::SVGElement r1 = RequiredElement(app, "#r1");
+  svg::SVGElement b = RequiredElement(app, "#b");
+
+  SourceStructuralMoveEvaluation evaluation =
+      BuildSourceStructuralMovePlan(app, kSvg, r1, b, std::nullopt);
+  ASSERT_EQ(evaluation.status, SourceStructuralMoveStatus::Ready);
+  ASSERT_TRUE(evaluation.plan.has_value());
+  EXPECT_EQ(CommitSourceStructuralMove(app, *evaluation.plan, kSvg),
+            SourceStructuralMoveStatus::Ready);
+}
+
+}  // namespace
+}  // namespace donner::editor

--- a/donner/editor/tests/TextEditor_tests.cc
+++ b/donner/editor/tests/TextEditor_tests.cc
@@ -5103,6 +5103,25 @@ TEST_F(TextEditorTests, GutterHandleDragPublishesSourceMoveGestureWithoutEditing
   EXPECT_FALSE(editor.isTextChanged());
 }
 
+TEST_F(TextEditorTests, GutterHandleDropUsesCurrentReleasePosition) {
+  editor.setText("one\ntwo\nthree");
+  RenderEditorFrame();
+
+  const ImVec2 handle = SourceGutterHandlePoint(/*visualIndex=*/0);
+  const ImVec2 release = ScreenPointAtVisualTextOffset(/*visualIndex=*/2,
+                                                       /*visualColumnOffset=*/1);
+  RenderEditorFrameWithMouse(handle, /*mouseDown=*/false);
+  RenderEditorFrameWithMouse(handle, /*mouseDown=*/true);
+  ASSERT_EQ(editor.takeSourceGutterDragStartedLine(), 0);
+
+  // Move and release without a preceding held frame at the destination.
+  RenderEditorFrameWithMouse(release, /*mouseDown=*/false);
+
+  const std::optional<Coordinates> drop = editor.takeSourceGutterDropTarget();
+  ASSERT_TRUE(drop.has_value());
+  EXPECT_EQ(drop->line, 2);
+}
+
 TEST_F(TextEditorTests, StructuralMoveDecorationClampsToSourceAndRenders) {
   editor.setText("<svg><rect/></svg>");
 

--- a/donner/editor/tests/TextEditor_tests.cc
+++ b/donner/editor/tests/TextEditor_tests.cc
@@ -586,6 +586,14 @@ protected:
     };
   }
 
+  [[nodiscard]] ImVec2 SourceGutterHandlePoint(int visualIndex) const {
+    return ImVec2{
+        editor.uiCursorPos_.x + editor.textStart_ - 8.0f * editor.uiScale_,
+        editor.uiCursorPos_.y + static_cast<float>(visualIndex) * editor.charAdvance_.y +
+            editor.charAdvance_.y * 0.5f,
+    };
+  }
+
   [[nodiscard]] int LineMaxColumn(int line) const { return editor.text_.getLineMaxColumn(line); }
 
   [[nodiscard]] bool HasActiveSourceFlash() const {
@@ -5066,6 +5074,70 @@ TEST_F(TextEditorTests, ClickingLineNumberMarginDoesNotMoveCursorThroughRenderPa
   RenderEditorFrameWithMouse(marginPoint, true);
 
   EXPECT_EQ(editor.getCursorPosition(), Coordinates(0, 5));
+}
+
+TEST_F(TextEditorTests, GutterHandleDragPublishesSourceMoveGestureWithoutEditingText) {
+  editor.setText("one\ntwo\nthree");
+  editor.resetTextChanged();
+  RenderEditorFrame();
+
+  const ImVec2 handle = SourceGutterHandlePoint(/*visualIndex=*/0);
+  const ImVec2 target = ScreenPointAtVisualTextOffset(/*visualIndex=*/2,
+                                                      /*visualColumnOffset=*/1);
+  RenderEditorFrameWithMouse(handle, /*mouseDown=*/false);
+  RenderEditorFrameWithMouse(handle, /*mouseDown=*/true);
+
+  EXPECT_EQ(editor.takeSourceGutterDragStartedLine(), 0);
+  ASSERT_TRUE(editor.sourceGutterDragTarget().has_value());
+  EXPECT_EQ(editor.sourceGutterDragTarget()->line, 0);
+
+  RenderEditorFrameWithMouse(target, /*mouseDown=*/true);
+  ASSERT_TRUE(editor.sourceGutterDragTarget().has_value());
+  EXPECT_EQ(editor.sourceGutterDragTarget()->line, 2);
+
+  RenderEditorFrameWithMouse(target, /*mouseDown=*/false);
+  const std::optional<Coordinates> drop = editor.takeSourceGutterDropTarget();
+  ASSERT_TRUE(drop.has_value());
+  EXPECT_EQ(drop->line, 2);
+  EXPECT_EQ(editor.getText(), "one\ntwo\nthree");
+  EXPECT_FALSE(editor.isTextChanged());
+}
+
+TEST_F(TextEditorTests, StructuralMoveDecorationClampsToSourceAndRenders) {
+  editor.setText("<svg><rect/></svg>");
+
+  EXPECT_TRUE(editor.setSourceStructuralMoveDecoration(TextEditor::SourceStructuralMoveDecoration{
+      .elementRange = SourceByteRange{.start = 5, .end = 999},
+      .insertionOffset = 999,
+      .valid = true,
+      .message = "Move before rect",
+  }));
+  ASSERT_TRUE(editor.sourceStructuralMoveDecoration().has_value());
+  EXPECT_EQ(editor.sourceStructuralMoveDecoration()->elementRange,
+            (SourceByteRange{.start = 5, .end = 18}));
+  EXPECT_EQ(editor.sourceStructuralMoveDecoration()->insertionOffset, 18u);
+
+  RenderEditorFrame();
+
+  EXPECT_TRUE(editor.setSourceStructuralMoveDecoration(std::nullopt));
+  EXPECT_FALSE(editor.sourceStructuralMoveDecoration().has_value());
+}
+
+TEST_F(TextEditorTests, CancellingGutterDragClearsPendingGestureState) {
+  editor.setText("one\ntwo");
+  RenderEditorFrame();
+
+  const ImVec2 handle = SourceGutterHandlePoint(/*visualIndex=*/0);
+  RenderEditorFrameWithMouse(handle, /*mouseDown=*/false);
+  RenderEditorFrameWithMouse(handle, /*mouseDown=*/true);
+  ASSERT_TRUE(editor.sourceGutterDragTarget().has_value());
+
+  editor.cancelSourceGutterDrag();
+
+  EXPECT_FALSE(editor.takeSourceGutterDragStartedLine().has_value());
+  EXPECT_FALSE(editor.sourceGutterDragTarget().has_value());
+  EXPECT_FALSE(editor.takeSourceGutterDropTarget().has_value());
+  EXPECT_TRUE(editor.takeSourceGutterDragCancelled());
 }
 
 TEST_F(TextEditorTests, AltAndShiftHoverDoNotMoveCursorThroughRenderPath) {


### PR DESCRIPTION
- add DOM-aware source element movement with source-preserving text edits
- provide live canvas preview while dragging source elements
- suspend source focus mode during structural drags so movement remains visible
- add structural move and text editor coverage

## Why

Rearranging SVG structure should feel continuous between source and canvas while preserving valid document structure and undo semantics.

## Validation

- `bazel test //donner/editor/tests:source_structural_move_tests //donner/editor/tests:text_editor_tests //donner/editor/tests:editor_app_tests //donner/editor/tests:editor_shell_tests`
- `bazel build //donner/editor:editor`

## Stack

2 of 5. PR #827 has merged; this PR is rebased directly onto current `main`. PR #829 follows after this one.