### PR TITLE
Editor: add isolated group editing

### DIFF
--- a/docs/design_docs/0046-editor_group_layers.md
+++ b/docs/design_docs/0046-editor_group_layers.md
@@ -1,7 +1,7 @@
 # Design: Editor Group Layers
 
-**Status:** Design
-**Author:** Codex
+**Status:** Implementing
+**Author:** GPT-5.6 Sol
 **Created:** 2026-05-30
 **Related:** [0033-2-editor_design_tool_responsiveness](0033-2-editor_design_tool_responsiveness.md),
 [0044-2-editor_fluid_canvas_rendering](0044-2-editor_fluid_canvas_rendering.md),
@@ -71,32 +71,32 @@ model or compositor diagnostics split. For the release, "complete" means:
 - Compositor Debug remains separate and hidden by default so render-cache tiles are not confused
   with editable document layers.
 
-Structural group editing commands, such as Group, Ungroup, and drag-to-reorder, can remain a
-follow-up unless the showcase artwork workflow directly needs them. The panel itself is still
-showcase-gating.
+Structural group editing is now part of the v0.8 editor scope. Group/Ungroup remain DOM-first and
+lossless-by-default; isolated group editing constrains selection, hit testing, Layers rows, source
+structural moves, and arrange commands to the active group.
 
 ## Implementation Plan
 
-- [ ] **Milestone 1: Layer tree model**
-  - [ ] Add `LayerTreeModel` / `LayerTreeSnapshot` types under `donner/editor/`.
-  - [ ] Build rows from the SVG light tree, classifying document root, groups, and renderable
+- [x] **Milestone 1: Layer tree model**
+  - [x] Add `LayerTreeModel` / `LayerTreeSnapshot` types under `donner/editor/`.
+  - [x] Build rows from the SVG light tree, classifying document root, groups, and renderable
         leaves.
-  - [ ] Generate display names from `id`, `<title>`, semantic label attributes, then tag fallback.
-  - [ ] Preserve stable expansion and scroll-target keys across idle snapshot refreshes.
-  - [ ] Add model tests for nested groups, unnamed groups, hidden/non-renderable resource subtrees,
+  - [x] Generate display names from `id`, `<title>`, semantic label attributes, then tag fallback.
+  - [x] Preserve stable expansion and scroll-target keys across idle snapshot refreshes.
+  - [x] Add model tests for nested groups, unnamed groups, hidden/non-renderable resource subtrees,
         compound paths, and multi-selection.
-- [ ] **Milestone 2: Layers panel UI**
-  - [ ] Replace `SidebarPresenter::renderTreeView` with a Layers panel presenter backed by
+- [x] **Milestone 2: Layers panel UI**
+  - [x] Replace `SidebarPresenter::renderTreeView` with a Layers panel presenter backed by
         `LayerTreeSnapshot`.
-  - [ ] Render rows with disclosure arrow, thumbnail slot, layer name, element kind, and selection
+  - [x] Render rows with disclosure arrow, thumbnail slot, layer name, element kind, and selection
         state.
-  - [ ] Sync row clicks with `EditorApp::setSelection` / `toggleInSelection`.
-  - [ ] Auto-expand and scroll to the selected row when selection changes from the canvas or source
+  - [x] Sync row clicks with `EditorApp::setSelection` / `toggleInSelection`.
+  - [x] Auto-expand and scroll to the selected row when selection changes from the canvas or source
         pane.
-  - [ ] Rename the current compositor `LayerInspectorPanel` surface to Render Diagnostics in the UI
+  - [x] Rename the current compositor `LayerInspectorPanel` surface to Render Diagnostics in the UI
         so users do not confuse render cache tiles with editable layers.
 - [ ] **Milestone 3: Per-tier previews**
-  - [ ] Add `LayerPreviewRenderer` that renders a single row's entity range into a fixed-size
+  - [x] Add `LayerPreviewRenderer` that renders a single row's entity range into a fixed-size
         thumbnail.
   - [ ] Use lazy preview requests only for visible rows and rows entering the overscan band.
   - [ ] Cache previews by row key, document version, style/layout generation, preview size, DPR, and
@@ -106,11 +106,11 @@ showcase-gating.
   - [ ] Add preview tests for root, nested group, transformed group, filtered group, compound path
         with a hole, transparent content, and clipping.
 - [ ] **Milestone 4: Interaction polish**
-  - [ ] Add keyboard navigation for expand/collapse and selection.
+  - [x] Add keyboard navigation for expand/collapse and selection.
   - [ ] Add context-menu entries for Select, Add to Selection, Expand All, Collapse All, and Reveal
         in Source.
-  - [ ] Add a compact multi-selection state that shows partially selected groups.
-  - [ ] Keep row hover/selection highlights in lockstep with canvas overlay selection.
+  - [x] Add a compact multi-selection state that shows partially selected groups.
+  - [x] Keep row hover/selection highlights in lockstep with canvas overlay selection.
 - [ ] **Milestone 5: Structural group editing**
   - [ ] Add Group Selection: wrap compatible selected siblings in a `<g>` while preserving paint
         order and visual output.
@@ -118,6 +118,9 @@ showcase-gating.
         styles.
   - [ ] Add drag-to-reorder after group/ungroup source writeback is covered by undo, source sync,
         and preview invalidation tests.
+  - [x] Add isolated group editing with double-click entry, one-level Escape/breadcrumb exit,
+        scope-aware exact hit testing, marquee/Select All filtering, scoped Layers rows, and
+        scope-relative arrange/source-drag behavior.
 
 ## User Stories
 

--- a/docs/design_docs/provenance_debt.txt
+++ b/docs/design_docs/provenance_debt.txt
@@ -24,5 +24,4 @@ docs/design_docs/0042-geode_slug_conformance.md
 docs/design_docs/0043-deterministic_replay_testing.md
 docs/design_docs/0044-2-editor_fluid_canvas_rendering.md
 docs/design_docs/0045-editor_geode_chrome_migration.md
-docs/design_docs/0046-editor_group_layers.md
 docs/design_docs/0047-v0_8_showcase.md

--- a/donner/editor/EditorApp.cc
+++ b/donner/editor/EditorApp.cc
@@ -913,6 +913,7 @@ EditorApp::EditorApp() = default;
 
 bool EditorApp::loadFromString(std::string_view svgBytes) {
   selection_.clear();
+  editingScope_.reset();
   refreshFirstSelectionCache();
   controller_.reset();
   undoTimeline_.clear();
@@ -973,6 +974,7 @@ bool EditorApp::flushFrame() {
   const auto& documentFlush = document_.lastFlushResult();
   if (documentBeforeFlush.has_value() && document_.hasDocument() &&
       !(*documentBeforeFlush == document_.document())) {
+    editingScope_.reset();
     std::vector<svg::SVGElement> remappedSelection;
     remappedSelection.reserve(selectionTargets.size());
     for (const auto& target : selectionTargets) {
@@ -1120,7 +1122,7 @@ bool EditorApp::reorderSelectedElement(ZOrder direction) {
   // the child inherits no transform, paint, clip, or opacity from it);
   // otherwise we fall through to the within-parent sibling reorder below, which
   // never changes how the element paints.
-  const svg::SVGElement root = document_.document().svgElement();
+  const svg::SVGElement root = editingScope_.value_or(document_.document().svgElement());
   if (parent != root && (direction == ZOrder::BringToFront || direction == ZOrder::SendToBack) &&
       CanLiftToRoot(element, root)) {
     if (direction == ZOrder::BringToFront) {
@@ -1349,13 +1351,16 @@ bool EditorApp::renameSelectedElement(std::string_view newId) {
 
 void EditorApp::setSelection(std::optional<svg::SVGElement> element) {
   selection_.clear();
-  if (element.has_value()) {
+  if (element.has_value() && isElementInEditingScope(*element)) {
     selection_.push_back(std::move(*element));
   }
   refreshFirstSelectionCache();
 }
 
 void EditorApp::setSelection(std::vector<svg::SVGElement> elements) {
+  std::erase_if(elements, [this](const svg::SVGElement& element) {
+    return !isElementInEditingScope(element);
+  });
   selection_ = std::move(elements);
   refreshFirstSelectionCache();
 }
@@ -1442,11 +1447,17 @@ void EditorApp::toggleInSelection(const svg::SVGElement& element) {
       return;
     }
   }
+  if (!isElementInEditingScope(element)) {
+    return;
+  }
   selection_.push_back(element);
   refreshFirstSelectionCache();
 }
 
 void EditorApp::addToSelection(const svg::SVGElement& element) {
+  if (!isElementInEditingScope(element)) {
+    return;
+  }
   for (const auto& existing : selection_) {
     if (existing == element) {
       return;
@@ -1454,6 +1465,44 @@ void EditorApp::addToSelection(const svg::SVGElement& element) {
   }
   selection_.push_back(element);
   refreshFirstSelectionCache();
+}
+
+bool EditorApp::enterGroupEdit(const svg::SVGElement& group) {
+  if (!document_.hasDocument() || group.tryType() != svg::ElementType::G || IsLocked(group)) {
+    return false;
+  }
+  const svg::SVGElement root = document_.document().svgElement();
+  if (!IsElementOrDescendant(root, group) ||
+      (editingScope_.has_value() && !IsElementOrDescendant(*editingScope_, group)) ||
+      editingScope_ == group) {
+    return false;
+  }
+
+  editingScope_ = group;
+  clearSelection();
+  return true;
+}
+
+bool EditorApp::exitGroupEdit() {
+  if (!editingScope_.has_value()) {
+    return false;
+  }
+  const svg::SVGElement exited = *editingScope_;
+  std::optional<svg::SVGElement> parent = exited.parentElement();
+  editingScope_.reset();
+  while (parent.has_value() && parent->tryType() != svg::ElementType::G) {
+    parent = parent->parentElement();
+  }
+  if (parent.has_value()) {
+    editingScope_ = parent;
+  }
+  setSelection(exited);
+  return true;
+}
+
+bool EditorApp::isElementInEditingScope(const svg::SVGElement& element) const {
+  return !editingScope_.has_value() ||
+         (*editingScope_ != element && IsElementOrDescendant(*editingScope_, element));
 }
 
 bool EditorApp::setAttributeOnSelection(std::string_view attrName, std::string_view attrValue) {
@@ -1746,7 +1795,15 @@ std::optional<svg::SVGGraphicsElement> EditorApp::hitTest(const Vector2d& docume
     controllerVersion_ = currentVersion;
   }
 
-  return controller_->findIntersecting(documentPoint);
+  if (!editingScope_.has_value()) {
+    return controller_->findIntersecting(documentPoint);
+  }
+  for (const svg::SVGGraphicsElement& hit : controller_->findAllIntersecting(documentPoint)) {
+    if (isElementInEditingScope(hit)) {
+      return hit;
+    }
+  }
+  return std::nullopt;
 }
 
 std::vector<svg::SVGGraphicsElement> EditorApp::hitTestRect(const Box2d& documentRect) {
@@ -1765,7 +1822,7 @@ std::vector<svg::SVGGraphicsElement> EditorApp::hitTestRect(const Box2d& documen
   // computes shape state under *write* access, so the whole traversal takes one coarse write guard.
   svg::SVGDocument doc = document_.document();
   doc.withWriteAccess([&](svg::DocumentWriteAccess&) {
-    const svg::SVGElement root = doc.svgElement();
+    const svg::SVGElement root = editingScope_.value_or(doc.svgElement());
     auto visit = [&](const svg::SVGGraphicsElement& element) {
       if (element.isa<svg::SVGGeometryElement>()) {
         if (GeometryIntersectsRect(element.cast<svg::SVGGeometryElement>(), documentRect)) {
@@ -1797,7 +1854,7 @@ std::vector<svg::SVGElement> EditorApp::selectableElements() {
   // scoped access guard against the live ConcurrentDom document.
   svg::SVGDocument doc = document_.document();
   doc.withWriteAccess([&](svg::DocumentWriteAccess&) {
-    const svg::SVGElement root = doc.svgElement();
+    const svg::SVGElement root = editingScope_.value_or(doc.svgElement());
     auto visit = [&](const svg::SVGGraphicsElement& element) { selectable.emplace_back(element); };
     ForEachSelectableElement(root, visit);
   });

--- a/donner/editor/EditorApp.h
+++ b/donner/editor/EditorApp.h
@@ -332,6 +332,23 @@ public:
   void addToSelection(const svg::SVGElement& element);
 
   /**
+   * Enter isolated editing for a group in the current document.
+   *
+   * Selection and hit testing are constrained to strict descendants until
+   * ef exitGroupEdit is called. Nested groups may become the new scope.
+   */
+  bool enterGroupEdit(const svg::SVGElement& group);
+
+  /// Exit one isolated editing level and select the group that was being edited.
+  bool exitGroupEdit();
+
+  /// Current isolated group, or null when editing the full document.
+  [[nodiscard]] const std::optional<svg::SVGElement>& editingScope() const { return editingScope_; }
+
+  /// Whether p element is selectable within the current isolated group.
+  [[nodiscard]] bool isElementInEditingScope(const svg::SVGElement& element) const;
+
+  /**
    * Queue an attribute write for every selected element.
    *
    * @param attrName Attribute name to set, e.g. `"fill"`.
@@ -609,6 +626,7 @@ private:
   /// Mirrors `selection_.front()` (or `std::nullopt`) so the
   /// single-element compatibility accessor can hand out a reference.
   std::optional<svg::SVGElement> cachedFirstSelection_;
+  std::optional<svg::SVGElement> editingScope_;
   UndoTimeline undoTimeline_;
 
   // Lazily-rebuilt hit-test controller. Recreated whenever the document's

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -1834,10 +1834,10 @@ void EditorShell::handleGlobalShortcuts() {
   }
 
   if (!anyPopupOpen && ImGui::IsKeyPressed(ImGuiKey_Escape, /*repeat=*/false)) {
-    if (app_.hasSelection()) {
-      app_.clearSelection();
-    } else if (app_.exitGroupEdit()) {
+    if (app_.editingScope().has_value() && app_.exitGroupEdit()) {
       window_.wakeEventLoop();
+    } else if (app_.hasSelection()) {
+      app_.clearSelection();
     }
   }
 

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -238,13 +238,34 @@ std::optional<Box2d> TextFormatBarScreenRect(const ImVec2& paneOrigin, const ImV
   return Box2d::FromXYWH(barX, barY, barWidth, barHeight);
 }
 
+std::optional<Box2d> EditingScopeBreadcrumbScreenRect(
+    const ImVec2& paneOrigin, const Box2d& toolPaletteRect,
+    const std::optional<svg::SVGElement>& editingScope) {
+  if (!editingScope.has_value()) {
+    return std::nullopt;
+  }
+  const std::string scopeName =
+      editingScope->id().empty() ? std::string("Group") : editingScope->id().str();
+  const float width = ImGui::CalcTextSize(("<  " + scopeName).c_str()).x + 20.0f;
+  const float height = ImGui::GetFrameHeight() + 6.0f;
+  const float x = paneOrigin.x + 12.0f;
+  float y = paneOrigin.y + kToolPaletteTopInset;
+  if (x + width + 8.0f > toolPaletteRect.topLeft.x) {
+    y = static_cast<float>(toolPaletteRect.bottomRight.y) + 8.0f;
+  }
+  return Box2d::FromXYWH(x, y, width, height);
+}
+
 bool CanvasChromeCapturesInput(const ImVec2& point, const std::optional<Box2d>& referenceChipRect,
                                const Box2d& toolPaletteRect,
                                const std::optional<Box2d>& textFormatBarRect,
+                               const std::optional<Box2d>& editingScopeBreadcrumbRect,
                                const Box2d& canvasZoomControlRect) {
   return (referenceChipRect.has_value() && ContainsScreenPoint(*referenceChipRect, point)) ||
          ContainsScreenPoint(toolPaletteRect, point) ||
          (textFormatBarRect.has_value() && ContainsScreenPoint(*textFormatBarRect, point)) ||
+         (editingScopeBreadcrumbRect.has_value() &&
+          ContainsScreenPoint(*editingScopeBreadcrumbRect, point)) ||
          ContainsScreenPoint(canvasZoomControlRect, point);
 }
 
@@ -1812,9 +1833,12 @@ void EditorShell::handleGlobalShortcuts() {
     return;
   }
 
-  if (!anyPopupOpen && ImGui::IsKeyPressed(ImGuiKey_Escape, /*repeat=*/false) &&
-      app_.hasSelection()) {
-    app_.setSelection(std::nullopt);
+  if (!anyPopupOpen && ImGui::IsKeyPressed(ImGuiKey_Escape, /*repeat=*/false)) {
+    if (app_.hasSelection()) {
+      app_.clearSelection();
+    } else if (app_.exitGroupEdit()) {
+      window_.wakeEventLoop();
+    }
   }
 
   // Cmd+A ("Select All") is focus-aware. When the source pane owns keyboard focus it selects all
@@ -2601,10 +2625,12 @@ void EditorShell::renderRenderPane(ImGuiWindowFlags paneFlags) {
   const std::optional<Box2d> textFormatBarRect =
       TextFormatBarScreenRect(paneOriginImGui, contentRegion, toolPaletteRect,
                               formatBarShouldShow(), TextFormatBarPresenter::BarHeight());
+  const std::optional<Box2d> editingScopeBreadcrumbRect =
+      EditingScopeBreadcrumbScreenRect(paneOriginImGui, toolPaletteRect, app_.editingScope());
   const Box2d canvasZoomControlRect = canvasZoomControlScreenRect();
-  const bool canvasChromeHovered =
-      CanvasChromeCapturesInput(ImGui::GetMousePos(), referenceChipRect, toolPaletteRect,
-                                textFormatBarRect, canvasZoomControlRect);
+  const bool canvasChromeHovered = CanvasChromeCapturesInput(
+      ImGui::GetMousePos(), referenceChipRect, toolPaletteRect, textFormatBarRect,
+      editingScopeBreadcrumbRect, canvasZoomControlRect);
 
   ImGui::SetNextItemAllowOverlap();
   ImGui::InvisibleButton("##render_canvas", contentRegion,
@@ -3285,6 +3311,7 @@ void EditorShell::renderRenderPane(ImGuiWindowFlags paneFlags) {
     renderReferenceHighlightChip();
     renderTextToolHint();
     renderToolPalette(paneOriginImGui, contentRegion);
+    renderEditingScopeBreadcrumb();
     const FormatBarState formatBarState = computeFormatBarState();
     const std::optional<Box2d> formatBarRect =
         TextFormatBarScreenRect(paneOriginImGui, contentRegion, toolPaletteRect,
@@ -3303,6 +3330,46 @@ void EditorShell::renderRenderPane(ImGuiWindowFlags paneFlags) {
   }
 
   ImGui::End();
+}
+
+void EditorShell::renderEditingScopeBreadcrumb() {
+  if (!app_.editingScope().has_value()) {
+    return;
+  }
+
+  const EditorTheme& theme = EditorTheme::Active();
+  const svg::SVGElement& scope = *app_.editingScope();
+  const std::string scopeName = scope.id().empty() ? std::string("Group") : scope.id().str();
+  const ViewportState& viewport = interactionController_.viewport();
+  const Box2d toolPaletteRect = toolPaletteScreenRect(
+      ImVec2(static_cast<float>(viewport.paneOrigin.x), static_cast<float>(viewport.paneOrigin.y)),
+      ImVec2(static_cast<float>(viewport.paneSize.x), static_cast<float>(viewport.paneSize.y)));
+  const std::optional<Box2d> rect = EditingScopeBreadcrumbScreenRect(
+      ImVec2(static_cast<float>(viewport.paneOrigin.x), static_cast<float>(viewport.paneOrigin.y)),
+      toolPaletteRect, app_.editingScope());
+  if (!rect.has_value()) {
+    return;
+  }
+  ImGui::SetCursorScreenPos(
+      ImVec2(static_cast<float>(rect->topLeft.x), static_cast<float>(rect->topLeft.y)));
+  ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, theme.radiusControl);
+  ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(10.0f, 7.0f));
+  ImGui::PushStyleColor(ImGuiCol_Button, ImGui::ColorConvertU32ToFloat4(theme.surfaceOverlay));
+  ImGui::PushStyleColor(ImGuiCol_ButtonHovered,
+                        ImGui::ColorConvertU32ToFloat4(theme.surfaceRaised));
+  ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImGui::ColorConvertU32ToFloat4(theme.surfaceCanvas));
+  const std::string label = "<  " + scopeName + "##exit_group_edit";
+  if (ImGui::Button(label.c_str(), ImVec2(static_cast<float>(rect->width()),
+                                          static_cast<float>(rect->height())))) {
+    if (app_.exitGroupEdit()) {
+      window_.wakeEventLoop();
+    }
+  }
+  if (ImGui::IsItemHovered()) {
+    ImGui::SetTooltip("Exit group edit");
+  }
+  ImGui::PopStyleColor(3);
+  ImGui::PopStyleVar(2);
 }
 
 void EditorShell::renderCanvasZoomControl() {

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -361,6 +361,7 @@ private:
                                             const ImVec2& contentRegion) const;
   [[nodiscard]] Box2d canvasZoomControlScreenRect() const;
   void renderToolPalette(const ImVec2& paneOrigin, const ImVec2& contentRegion);
+  void renderEditingScopeBreadcrumb();
   void renderCanvasZoomControl();
   void renderFillStrokeToolbarWidget();
   void renderSidebars();

--- a/donner/editor/EditorShellInternal.h
+++ b/donner/editor/EditorShellInternal.h
@@ -79,6 +79,7 @@ enum class PendingClickIdleAction {
                                              const std::optional<Box2d>& referenceChipRect,
                                              const Box2d& toolPaletteRect,
                                              const std::optional<Box2d>& textFormatBarRect,
+                                             const std::optional<Box2d>& editingScopeBreadcrumbRect,
                                              const Box2d& canvasZoomControlRect);
 [[nodiscard]] PendingClickBusyAction PendingClickBusyActionForState(bool tookFastRedrag,
                                                                     bool rendererBusy);

--- a/donner/editor/LayerTreeModel.cc
+++ b/donner/editor/LayerTreeModel.cc
@@ -289,10 +289,10 @@ void LayerTreeModel::refresh(const EditorApp& app) {
   [[maybe_unused]] const svg::DocumentWriteAccess snapshotWriteAccess =
       app.document().document().writeAccess();
 
-  const svg::SVGElement root = app.document().document().svgElement();
+  const svg::SVGElement root = app.editingScope().value_or(app.document().document().svgElement());
 
-  // The Layers panel omits the document root `<svg>` row entirely and shows its
-  // editor-visible children (top-level groups and shapes) as the tree's roots.
+  // The Layers panel omits the current editing root (`<svg>` normally, or the
+  // isolated `<g>`) and shows its editor-visible children as the tree's roots.
   std::vector<svg::SVGElement> topLevel;
   for (std::optional<svg::SVGElement> child = root.firstChild(); child.has_value();
        child = child->nextSibling()) {

--- a/donner/editor/SelectTool.cc
+++ b/donner/editor/SelectTool.cc
@@ -186,6 +186,20 @@ svg::SVGElement TopLevelAncestor(svg::SVGElement hit, const svg::SVGElement& con
   return hit;
 }
 
+std::optional<svg::SVGElement> NearestEditableGroupAncestor(
+    const svg::SVGElement& hit, const std::optional<svg::SVGElement>& currentScope) {
+  for (std::optional<svg::SVGElement> current = hit.parentElement(); current.has_value();
+       current = current->parentElement()) {
+    if (currentScope.has_value() && *current == *currentScope) {
+      return std::nullopt;
+    }
+    if (current->tryType() == svg::ElementType::G) {
+      return current;
+    }
+  }
+  return std::nullopt;
+}
+
 }  // namespace
 
 bool SelectTool::tryStartRedragOnSelected(EditorApp& editor, const Vector2d& documentPoint,
@@ -407,6 +421,15 @@ void SelectTool::onMouseDown(EditorApp& editor, const Vector2d& documentPoint,
         .additive = modifiers.shift,
     };
     return;
+  }
+
+  if (modifiers.doubleClick && !IsLocked(*hit)) {
+    if (const std::optional<svg::SVGElement> group =
+            NearestEditableGroupAncestor(*hit, editor.editingScope());
+        group.has_value() && editor.enterGroupEdit(*group)) {
+      editor.setSelection(*hit);
+      return;
+    }
   }
 
   // Shift+click on an element → toggle membership in the current

--- a/donner/editor/SelectTool.cc
+++ b/donner/editor/SelectTool.cc
@@ -476,8 +476,10 @@ void SelectTool::onMouseDown(EditorApp& editor, const Vector2d& documentPoint,
   // filter-group - select the clicked path instead of the whole group.
   // Requires double-click detection in the pointer-event protocol.
   svg::SVGDocument& doc = editor.document().document();
+  const std::optional<svg::SVGElement> editingScope = editor.editingScope();
   const svg::SVGElement element = doc.withReadAccess([&](svg::DocumentReadAccess&) {
-    const svg::SVGElement container = DeepestWrappingContainer(doc.svgElement());
+    const svg::SVGElement container =
+        editingScope.has_value() ? *editingScope : DeepestWrappingContainer(doc.svgElement());
     const svg::SVGElement topLevel = TopLevelAncestor(*hit, container);
     return HasCompositingAttribute(topLevel) ? topLevel : *hit;
   });

--- a/donner/editor/SourceStructuralMove.cc
+++ b/donner/editor/SourceStructuralMove.cc
@@ -85,6 +85,11 @@ SourceStructuralMoveEvaluation BuildSourceStructuralMovePlan(
   if (element == root) {
     return {.status = SourceStructuralMoveStatus::RootElement};
   }
+  if (app.editingScope().has_value() &&
+      (!app.isElementInEditingScope(element) ||
+       (parent != *app.editingScope() && !app.isElementInEditingScope(parent)))) {
+    return {.status = SourceStructuralMoveStatus::InvalidParent};
+  }
   if (!IsElementOrDescendant(root, element) || !IsElementOrDescendant(root, parent) ||
       !IsMoveContainer(parent)) {
     return {.status = SourceStructuralMoveStatus::InvalidParent};

--- a/donner/editor/tests/EditorApp_tests.cc
+++ b/donner/editor/tests/EditorApp_tests.cc
@@ -2210,5 +2210,115 @@ TEST(EditorAppRenameTest, RefusesWithoutSingleSelectionOrWhenLocked) {
   EXPECT_TRUE(app.document().document().querySelector("#r").has_value());
 }
 
+TEST(EditorAppGroupEditTest, ConstrainsSelectionMarqueeAndSelectAllToScope) {
+  constexpr std::string_view kScopedSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="200" height="120">
+        <g id="scope">
+          <rect id="inside" x="10" y="10" width="30" height="30"/>
+          <g id="nested"><circle id="nestedChild" cx="80" cy="25" r="15"/></g>
+        </g>
+        <rect id="outside" x="140" y="10" width="30" height="30"/>
+      </svg>)svg";
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kScopedSvg));
+  const svg::SVGElement scope = *app.document().document().querySelector("#scope");
+  const svg::SVGElement inside = *app.document().document().querySelector("#inside");
+  const svg::SVGElement outside = *app.document().document().querySelector("#outside");
+
+  ASSERT_TRUE(app.enterGroupEdit(scope));
+  EXPECT_EQ(app.editingScope(), std::optional<svg::SVGElement>(scope));
+  EXPECT_FALSE(app.hasSelection());
+
+  app.setSelection(outside);
+  EXPECT_FALSE(app.hasSelection());
+  app.setSelection(std::vector<svg::SVGElement>{inside, outside, scope});
+  EXPECT_THAT(ElementIds(app.selectedElements()), ::testing::ElementsAre("inside"));
+
+  EXPECT_THAT(ElementIds(app.selectableElements()),
+              ::testing::ElementsAre("inside", "nestedChild"));
+  EXPECT_THAT(ElementIds(app.hitTestRect(Box2d::FromXYWH(0, 0, 200, 120))),
+              ::testing::ElementsAre("inside", "nestedChild"));
+  EXPECT_THAT(app.hitTest(Vector2d(20, 20)),
+              ::testing::Optional(::testing::Property(&svg::SVGElement::id, RcString("inside"))));
+  EXPECT_FALSE(app.hitTest(Vector2d(150, 20)).has_value());
+}
+
+TEST(EditorAppGroupEditTest, ScopedHitTestingPassesThroughOutOfScopeOccluders) {
+  constexpr std::string_view kOccludedSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+        <g id="scope"><rect id="inside" x="10" y="10" width="60" height="60" fill="red"/></g>
+        <rect id="outside" x="10" y="10" width="60" height="60" fill="blue"/>
+      </svg>)svg";
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kOccludedSvg));
+  EXPECT_EQ(app.hitTest(Vector2d(20, 20))->id(), "outside");
+  ASSERT_TRUE(app.enterGroupEdit(*app.document().document().querySelector("#scope")));
+
+  const std::optional<svg::SVGGraphicsElement> hit = app.hitTest(Vector2d(20, 20));
+  ASSERT_TRUE(hit.has_value());
+  EXPECT_EQ(hit->id(), "inside");
+}
+
+TEST(EditorAppGroupEditTest, SupportsNestedEntryAndOneLevelExit) {
+  constexpr std::string_view kNestedSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg"><g id="outer"><g id="inner"><rect id="leaf" width="10" height="10"/></g></g></svg>)svg";
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kNestedSvg));
+  const svg::SVGElement outer = *app.document().document().querySelector("#outer");
+  const svg::SVGElement inner = *app.document().document().querySelector("#inner");
+
+  ASSERT_TRUE(app.enterGroupEdit(outer));
+  ASSERT_TRUE(app.enterGroupEdit(inner));
+  EXPECT_EQ(app.editingScope(), std::optional<svg::SVGElement>(inner));
+
+  ASSERT_TRUE(app.exitGroupEdit());
+  EXPECT_EQ(app.editingScope(), std::optional<svg::SVGElement>(outer));
+  EXPECT_EQ(app.selectedElement(), std::optional<svg::SVGElement>(inner));
+
+  ASSERT_TRUE(app.exitGroupEdit());
+  EXPECT_FALSE(app.editingScope().has_value());
+  EXPECT_EQ(app.selectedElement(), std::optional<svg::SVGElement>(outer));
+  EXPECT_FALSE(app.exitGroupEdit());
+}
+
+TEST(EditorAppGroupEditTest, RejectsNonGroupDetachedLockedAndOutsideNestedScopes) {
+  constexpr std::string_view kScopedSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg"><g id="a"><g id="nested"/></g><g id="b"/><rect id="leaf"/></svg>)svg";
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kScopedSvg));
+  const svg::SVGElement a = *app.document().document().querySelector("#a");
+  const svg::SVGElement b = *app.document().document().querySelector("#b");
+  const svg::SVGElement leaf = *app.document().document().querySelector("#leaf");
+
+  EXPECT_FALSE(app.enterGroupEdit(leaf));
+  ASSERT_TRUE(app.enterGroupEdit(a));
+  EXPECT_FALSE(app.enterGroupEdit(b));
+  EXPECT_FALSE(app.enterGroupEdit(a));
+  ASSERT_TRUE(app.exitGroupEdit());
+
+  app.setElementLocked(b, true);
+  ASSERT_TRUE(app.flushFrame());
+  EXPECT_FALSE(app.enterGroupEdit(b));
+}
+
+TEST(EditorAppGroupEditTest, AbsoluteArrangeStopsAtActiveScope) {
+  constexpr std::string_view kArrangeSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg"><g id="scope"><g id="wrapper"><rect id="moving"/></g><rect id="fixed"/></g><rect id="outside"/></svg>)svg";
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kArrangeSvg));
+  const svg::SVGElement scope = *app.document().document().querySelector("#scope");
+  const svg::SVGElement moving = *app.document().document().querySelector("#moving");
+  ASSERT_TRUE(app.enterGroupEdit(scope));
+  app.setSelection(moving);
+
+  ASSERT_TRUE(app.reorderSelectedElement(EditorApp::ZOrder::BringToFront));
+  ASSERT_TRUE(app.flushFrame());
+
+  const svg::SVGElement moved = *app.document().document().querySelector("#moving");
+  EXPECT_EQ(moved.parentElement(), std::optional<svg::SVGElement>(scope));
+  EXPECT_EQ(scope.lastChild(), std::optional<svg::SVGElement>(moved));
+  EXPECT_EQ(app.editingScope(), std::optional<svg::SVGElement>(scope));
+}
+
 }  // namespace
 }  // namespace donner::editor

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -310,9 +310,11 @@ TEST(EditorShellInternalTest, TextFormatBarCapturesCanvasInputWithinItsLayoutRec
   const ImVec2 formatControlPoint(static_cast<float>(formatBarRect->topLeft.x + 20.0),
                                   static_cast<float>(formatBarRect->topLeft.y + 20.0));
   EXPECT_TRUE(internal::CanvasChromeCapturesInput(formatControlPoint, referenceChipRect,
-                                                  toolPaletteRect, formatBarRect, zoomControlRect));
+                                                  toolPaletteRect, formatBarRect, std::nullopt,
+                                                  zoomControlRect));
   EXPECT_FALSE(internal::CanvasChromeCapturesInput(
-      ImVec2(150.0f, 220.0f), referenceChipRect, toolPaletteRect, formatBarRect, zoomControlRect));
+      ImVec2(150.0f, 220.0f), referenceChipRect, toolPaletteRect, formatBarRect, std::nullopt,
+      zoomControlRect));
 
   EXPECT_FALSE(internal::TextFormatBarScreenRect(ImVec2(10.0f, 20.0f), ImVec2(580.0f, 360.0f),
                                                  toolPaletteRect,
@@ -3160,6 +3162,31 @@ TEST(EditorShellTest, GlobalShortcutsSwitchToolsZoomAndSourceFocus) {
   const bool sourceFocusBeforeKeypadEnter = EditorShellTestAccess::SourceFocusMode(shell);
   DriveGlobalShortcut(shell, {ImGuiKey_KeypadEnter}, /*ctrl=*/true);
   EXPECT_NE(EditorShellTestAccess::SourceFocusMode(shell), sourceFocusBeforeKeypadEnter);
+}
+
+TEST(EditorShellTest, EscapeExitsGroupEditEvenWhenSelectionIsActive) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  constexpr std::string_view kGroupSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120">
+        <g id="scope"><rect id="leaf" x="10" y="10" width="40" height="40"/></g>
+      </svg>)svg";
+  EditorShell shell(window, OptionsWithSource(kGroupSvg, "group.svg"));
+  ASSERT_TRUE(shell.valid());
+  EditorApp& app = EditorShellTestAccess::App(shell);
+  const svg::SVGElement scope = *app.document().document().querySelector("#scope");
+  const svg::SVGElement leaf = *app.document().document().querySelector("#leaf");
+  ASSERT_TRUE(app.enterGroupEdit(scope));
+  app.setSelection(leaf);
+  ASSERT_TRUE(app.hasSelection());
+
+  DriveGlobalShortcut(shell, {ImGuiKey_Escape});
+
+  EXPECT_FALSE(app.editingScope().has_value());
+  EXPECT_EQ(app.selectedElement(), std::optional<svg::SVGElement>(scope));
 }
 
 TEST(EditorShellTest, GlobalShortcutsRouteFileDialogsSaveAndQuit) {

--- a/donner/editor/tests/LayerTreeModel_tests.cc
+++ b/donner/editor/tests/LayerTreeModel_tests.cc
@@ -491,5 +491,22 @@ TEST(LayerTreeModelTest, CollapsedGroupHidesDescendantsButKeepsChevron) {
   EXPECT_EQ(FindRow(model, "rectTop"), nullptr);
 }
 
+TEST(LayerTreeModelTest, GroupEditScopeShowsOnlyChildrenOfIsolatedGroup) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kSvg));
+  const std::optional<svg::SVGElement> groupA = FindElement(app, "groupA");
+  ASSERT_TRUE(groupA.has_value());
+  ASSERT_TRUE(app.enterGroupEdit(*groupA));
+
+  LayerTreeModel model;
+  model.refresh(app);
+
+  EXPECT_EQ(FindRow(model, "groupA"), nullptr);
+  EXPECT_EQ(FindRow(model, "comp"), nullptr);
+  EXPECT_EQ(FindRow(model, "leaf"), nullptr);
+  EXPECT_NE(FindRow(model, "rectTop"), nullptr);
+  EXPECT_NE(FindRow(model, "rectBottom"), nullptr);
+}
+
 }  // namespace
 }  // namespace donner::editor

--- a/donner/editor/tests/SelectTool_tests.cc
+++ b/donner/editor/tests/SelectTool_tests.cc
@@ -1319,6 +1319,39 @@ TEST_F(SelectToolTest, RedragFastPathDoesNotStealClickFromFrontOverlappingObject
   EXPECT_TRUE(selectionIs("#front"));
 }
 
+TEST_F(SelectToolTest, DoubleClickEntersNearestGroupAndSelectsHitLeaf) {
+  constexpr std::string_view kNestedGroupsSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120">
+        <g id="outer"><g id="inner"><rect id="leaf" x="10" y="10" width="40" height="40"/></g></g>
+        <rect id="outside" x="70" y="10" width="40" height="40"/>
+      </svg>)svg";
+  loadSvg(kNestedGroupsSvg);
+
+  tool.onMouseDown(app, Vector2d(20, 20), MouseModifiers{.doubleClick = true});
+  tool.onMouseUp(app, Vector2d(20, 20));
+
+  ASSERT_TRUE(app.editingScope().has_value());
+  EXPECT_EQ(app.editingScope()->id(), "inner");
+  EXPECT_TRUE(selectionIs("#leaf"));
+  EXPECT_FALSE(app.hitTest(Vector2d(80, 20)).has_value());
+}
+
+TEST_F(SelectToolTest, DoubleClickInsideCurrentScopeEntersNestedGroupOnly) {
+  constexpr std::string_view kNestedGroupsSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120">
+        <g id="outer"><g id="inner"><rect id="leaf" x="10" y="10" width="40" height="40"/></g></g>
+      </svg>)svg";
+  loadSvg(kNestedGroupsSvg);
+  ASSERT_TRUE(app.enterGroupEdit(elementById("#outer")));
+
+  tool.onMouseDown(app, Vector2d(20, 20), MouseModifiers{.doubleClick = true});
+  tool.onMouseUp(app, Vector2d(20, 20));
+
+  ASSERT_TRUE(app.editingScope().has_value());
+  EXPECT_EQ(app.editingScope()->id(), "inner");
+  EXPECT_TRUE(selectionIs("#leaf"));
+}
+
 TEST_F(SelectToolTest, CornerHandleResizesSelectionFromOppositeCorner) {
   loadSvg(kResizeRectSvg);
   app.setSelection(elementById("#target"));

--- a/donner/editor/tests/SelectTool_tests.cc
+++ b/donner/editor/tests/SelectTool_tests.cc
@@ -1352,6 +1352,25 @@ TEST_F(SelectToolTest, DoubleClickInsideCurrentScopeEntersNestedGroupOnly) {
   EXPECT_TRUE(selectionIs("#leaf"));
 }
 
+TEST_F(SelectToolTest, ClickInsideCompositeEditingScopeDoesNotSelectScope) {
+  constexpr std::string_view kCompositeScopeSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120">
+        <defs><filter id="blur"><feGaussianBlur stdDeviation="1"/></filter></defs>
+        <g id="scope" filter="url(#blur)">
+          <rect id="leaf" x="10" y="10" width="40" height="40"/>
+        </g>
+      </svg>)svg";
+  loadSvg(kCompositeScopeSvg);
+  ASSERT_TRUE(app.enterGroupEdit(elementById("#scope")));
+
+  tool.onMouseDown(app, Vector2d(20, 20), MouseModifiers{});
+  tool.onMouseUp(app, Vector2d(20, 20));
+
+  ASSERT_TRUE(app.editingScope().has_value());
+  EXPECT_EQ(app.editingScope()->id(), "scope");
+  EXPECT_TRUE(selectionIs("#leaf"));
+}
+
 TEST_F(SelectToolTest, CornerHandleResizesSelectionFromOppositeCorner) {
   loadSvg(kResizeRectSvg);
   app.setSelection(elementById("#target"));

--- a/donner/editor/tests/SourceStructuralMove_tests.cc
+++ b/donner/editor/tests/SourceStructuralMove_tests.cc
@@ -111,5 +111,20 @@ TEST(SourceStructuralMove, AcceptsEditorSourceWithHiddenTerminalNewline) {
             SourceStructuralMoveStatus::Ready);
 }
 
+TEST(SourceStructuralMove, RejectsMovesThatEscapeActiveGroupEditScope) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kSvg));
+  svg::SVGElement a = RequiredElement(app, "#a");
+  svg::SVGElement r1 = RequiredElement(app, "#r1");
+  svg::SVGElement b = RequiredElement(app, "#b");
+  svg::SVGElement c = RequiredElement(app, "#c");
+  ASSERT_TRUE(app.enterGroupEdit(a));
+
+  EXPECT_EQ(BuildSourceStructuralMovePlan(app, kSvg, r1, b, c).status,
+            SourceStructuralMoveStatus::InvalidParent);
+  EXPECT_EQ(BuildSourceStructuralMovePlan(app, kSvg, c, a, std::nullopt).status,
+            SourceStructuralMoveStatus::InvalidParent);
+}
+
 }  // namespace
 }  // namespace donner::editor

--- a/donner/svg/DonnerController.cc
+++ b/donner/svg/DonnerController.cc
@@ -20,4 +20,19 @@ std::optional<SVGGraphicsElement> DonnerController::findIntersecting(const Vecto
   return std::nullopt;
 }
 
+std::vector<SVGGraphicsElement> DonnerController::findAllIntersecting(const Vector2d& point) {
+  DocumentWriteAccess access = document_.writeAccess();
+  Registry& registry = access.registry();
+  const std::vector<Entity> entities =
+      components::RenderingContext(registry).findAllIntersecting(point);
+  std::vector<SVGGraphicsElement> results;
+  results.reserve(entities.size());
+  for (const Entity entity : entities) {
+    SVGElement element(EntityHandle(registry, entity));
+    UTILS_RELEASE_ASSERT(element.isa<SVGGraphicsElement>());
+    results.push_back(element.cast<SVGGraphicsElement>());
+  }
+  return results;
+}
+
 }  // namespace donner::svg

--- a/donner/svg/DonnerController.h
+++ b/donner/svg/DonnerController.h
@@ -1,6 +1,8 @@
 #pragma once
 /// @file
 
+#include <vector>
+
 #include "donner/svg/SVGDocument.h"
 #include "donner/svg/SVGGeometryElement.h"
 #include "donner/svg/SVGGraphicsElement.h"
@@ -41,6 +43,14 @@ public:
    * @return The topmost intersecting geometry element, or \c std::nullopt if no element is hit.
    */
   std::optional<SVGGraphicsElement> findIntersecting(const Vector2d& point);
+
+  /**
+   * Return every painted element intersecting p point, front to back.
+   *
+   * This supports scoped editor hit testing without allowing an element
+   * outside the active scope to occlude an eligible descendant.
+   */
+  std::vector<SVGGraphicsElement> findAllIntersecting(const Vector2d& point);
 
 private:
   SVGDocument document_;


### PR DESCRIPTION
## Summary

- add group and ungroup commands plus front/back ordering support
- add isolated group edit scope with selection containment
- integrate group scope with layer traversal and structural source movement
- add controller, selection, layer model, and editor tests

## Why

Grouped artwork needs predictable hierarchy operations and an isolation mode that prevents accidental edits outside the active group.

## Validation

- `bazel test //donner/editor/tests:editor_app_tests //donner/editor/tests:layer_tree_model_tests //donner/editor/tests:select_tool_tests //donner/editor/tests:source_structural_move_tests`
- `bazel build //donner/editor:editor`

## Stack

3 of 5. PRs #827 and #828 have merged; this PR is rebased directly onto current `main`. PR #830 follows after this one.