### PR TITLE
Editor: add sample picker and compositor tile overlay

### DIFF
--- a/docs/design_docs/0046-editor_group_layers.md
+++ b/docs/design_docs/0046-editor_group_layers.md
@@ -112,15 +112,23 @@ structural moves, and arrange commands to the active group.
   - [x] Add a compact multi-selection state that shows partially selected groups.
   - [x] Keep row hover/selection highlights in lockstep with canvas overlay selection.
 - [ ] **Milestone 5: Structural group editing**
-  - [ ] Add Group Selection: wrap compatible selected siblings in a `<g>` while preserving paint
+  - [x] Add Group Selection: wrap compatible selected siblings in a `<g>` while preserving paint
         order and visual output.
-  - [ ] Add Ungroup: splice children into the parent while preserving effective transforms and
-        styles.
+  - [x] Add lossless Ungroup: splice children from an attribute-free `<g>` into its parent. Groups
+        carrying transform, style, class, paint, filter, clip, mask, opacity, visibility, or other
+        attributes remain grouped with an explanatory disabled state until semantic composition is
+        implemented.
   - [ ] Add drag-to-reorder after group/ungroup source writeback is covered by undo, source sync,
         and preview invalidation tests.
   - [x] Add isolated group editing with double-click entry, one-level Escape/breadcrumb exit,
         scope-aware exact hit testing, marquee/Select All filtering, scoped Layers rows, and
         scope-relative arrange/source-drag behavior.
+
+Group and Ungroup are available from the Edit menu, canvas context menu, and `Cmd+G` /
+`Cmd+Shift+G`. Group requires at least two adjacent, unlocked, source-backed siblings under the
+same editable parent; refusing nonadjacent siblings avoids changing their paint order relative to
+unselected content. Each operation is one source-level undo entry and defers its resulting selection
+until the structural command batch has committed, including inside isolated group editing.
 
 ## User Stories
 
@@ -407,6 +415,12 @@ CI targets for core invariants:
 - `//donner/editor/tests:editor_sync_tests`
   - Row selection focuses the corresponding source range.
   - Source edits that preserve structure keep layer expansion and selection remapped.
+- `//donner/editor/tests:editor_app_tests`
+  - Group preserves sibling paint order, source reflection, undo, selection, and isolated scope.
+  - Ungroup accepts only attribute-free groups and selects the lifted children.
+- `//donner/editor/tests:editor_shell_tests`
+  - Group dispatch and deferred document replacement wait for exclusive DOM ownership.
+  - A newer Open or Revert request cancels an older deferred sample replacement.
 
 Manual validation:
 

--- a/docs/editor_design_language.md
+++ b/docs/editor_design_language.md
@@ -20,24 +20,24 @@ and supplies tokens to custom `ImDrawList` chrome, the canvas overlay, and sourc
 
 ## Core Tokens
 
-| Role | Token | Value |
-| --- | --- | --- |
-| Canvas surround | `surfaceCanvas` | `#111215` |
-| Inset well | `surfaceSunken` | `#151619` |
-| Panel background | `surfaceBase` | `#1B1D20` |
-| Menu, tab, field | `surfaceRaised` | `#24272B` |
-| Floating chrome | `surfaceOverlay` | `#2B2F34` |
-| Hover | `surfaceHover` | `#343940` |
-| Active | `surfaceActive` | `#3C424A` |
-| Subtle rule | `borderSubtle` | `#30343A` |
-| Strong rule | `borderStrong` | `#464C55` |
-| Primary text | `textPrimary` | `#F1F2F4` |
-| Secondary text | `textMuted` | `#A8ADB5` |
-| Disabled text | `textDisabled` | `#656B74` |
-| Focus and selection | `accentDefault` | `#31C6B3` |
-| Warning | `warning` | `#E3B341` |
-| Error or destructive | `destructive` | `#F0616A` |
-| Success | `success` | `#3FB984` |
+| Role                 | Token            | Value     |
+| -------------------- | ---------------- | --------- |
+| Canvas surround      | `surfaceCanvas`  | `#111215` |
+| Inset well           | `surfaceSunken`  | `#151619` |
+| Panel background     | `surfaceBase`    | `#1B1D20` |
+| Menu, tab, field     | `surfaceRaised`  | `#24272B` |
+| Floating chrome      | `surfaceOverlay` | `#2B2F34` |
+| Hover                | `surfaceHover`   | `#343940` |
+| Active               | `surfaceActive`  | `#3C424A` |
+| Subtle rule          | `borderSubtle`   | `#30343A` |
+| Strong rule          | `borderStrong`   | `#464C55` |
+| Primary text         | `textPrimary`    | `#F1F2F4` |
+| Secondary text       | `textMuted`      | `#A8ADB5` |
+| Disabled text        | `textDisabled`   | `#656B74` |
+| Focus and selection  | `accentDefault`  | `#31C6B3` |
+| Warning              | `warning`        | `#E3B341` |
+| Error or destructive | `destructive`    | `#F0616A` |
+| Success              | `success`        | `#3FB984` |
 
 The shipped accent is `Accent::SignalTeal`. Other accent variants remain test-covered theme inputs,
 but product chrome should not choose a different accent per widget.
@@ -171,13 +171,32 @@ ranges remain legible.
 7. Add or update a focused test when a token, mapped ImGui slot, palette value, or control contract
    changes.
 
+## Welcome And Samples
+
+Launching without a filename, including the WebAssembly build, opens a first-run surface over the
+real editor workspace. It keeps Donner as the first visual signal, offers Open SVG and a fixed
+GitHub destination, and lists a bounded offline catalog of reviewed SVG samples. Loading a sample
+creates an untitled document, so Save cannot overwrite a local file without an explicit path.
+
+The welcome surface owns the workspace while visible rather than competing with docked Layers and
+Inspector panels. Its sample controls use at least 44 logical pixels of height, lay out in one
+column below the compact breakpoint, and use at most three columns on wider displays. The surface
+can be reopened through File > Open Sample and dismissed to reveal the current document.
+
+Document replacement requested from the sample surface is deferred to the next orchestration frame.
+The shell waits for the renderer to become idle and detaches any prior direct-presentation callback
+before releasing old WebGPU resources. This ordering prevents the prior frame callback from
+retaining presentation handles across document replacement.
+
 ## Verification
 
 Theme, menu, and source-palette contracts run in:
 
 ```sh
 bazel test //donner/editor/tests:editor_theme_tests \
+  //donner/editor/tests:editor_shell_tests \
   //donner/editor/tests:menu_bar_presenter_tests \
+  //donner/editor/tests:sample_picker_presenter_tests \
   //donner/editor/tests:sidebar_presenter_tests \
   //donner/editor/tests:text_editor_tests
 ```
@@ -212,6 +231,12 @@ includes text creation, active fill, typing, frame reveal, resize, release, relo
 
 ## Security And Privacy
 
-The design language does not add file, network, clipboard, or document mutation paths. SVG icon
-assets continue through Donner's renderer. Public captures and documentation must use public sample
-documents and must not include private paths, host data, credentials, or operator content.
+The sample catalog is compiled into the editor and never fetches document content. Sample loading
+uses the same parser and full document-replacement path as a local open, produces an untitled
+document, and waits for renderer ownership to return before releasing presentation resources. The
+only external destination is the fixed Donner repository URL: browser builds open it after an
+explicit click with `noopener`, while native builds copy the same fixed URL only after an explicit
+click. Neither path derives a destination from SVG content.
+
+SVG icon assets continue through Donner's renderer. Public captures and documentation use public
+sample documents and exclude private paths, host data, credentials, and operator content.

--- a/docs/editor_visual_debugging.md
+++ b/docs/editor_visual_debugging.md
@@ -150,6 +150,25 @@ If a visual frame is wrong but diagnostics look correct, suspect a lower backend
 layer: stale texture handle, bind group cache, command buffer lifetime, or
 framebuffer readback.
 
+### Compositor Tile Overlay
+
+Enable **View > Compositor Tile Overlay** to inspect tile boundaries on the live canvas without
+opening a separate panel. The overlay uses the presenter's exact transformed tile quadrilaterals,
+so its borders remain aligned through pan, zoom, cached transforms, and active drags.
+
+Tile labels begin with `S`, `L`, or `I` for segment, promoted layer, or immediate content, followed
+by the stable tile ID and generation. Teal marks segments, amber marks promoted layers, pink marks
+immediate content, and white marks the active drag target. A muted `cached` suffix identifies a
+metadata-only update that reused an existing texture payload.
+
+Use the overlay to decide whether a defect originates before or after presentation:
+
+- Correct boundaries with wrong pixels suggest texture identity, lifetime, or backend binding.
+- Wrong boundaries suggest compositor metadata or presenter geometry.
+- A boundary that moves separately from selection chrome suggests differing drag baselines.
+
+The overlay is disabled by default and omitted from content-only captures.
+
 ### Unit Test Boundaries
 
 Use focused tests before reaching for full replay tests:

--- a/donner/editor/BUILD.bazel
+++ b/donner/editor/BUILD.bazel
@@ -922,6 +922,7 @@ donner_cc_library(
         ":editor_app",
         ":editor_dock_layout",
         ":editor_input_bridge",
+        ":editor_sample_catalog",
         ":editor_shell_layout",
         ":editor_theme",
         ":focus_view",
@@ -941,6 +942,7 @@ donner_cc_library(
         ":render_coordinator",
         ":render_pane_presenter",
         ":rotate_cursor_set",
+        ":sample_picker_presenter",
         ":select_tool",
         ":selection_transform_handles",
         ":shape_clipboard_commands",
@@ -1236,6 +1238,18 @@ donner_cc_library(
 )
 
 donner_cc_library(
+    name = "sample_picker_presenter",
+    srcs = ["SamplePickerPresenter.cc"],
+    hdrs = ["SamplePickerPresenter.h"],
+    deps = [
+        ":editor_sample_catalog",
+        ":editor_theme",
+        ":imgui_headers",
+        "@imgui",
+    ],
+)
+
+donner_cc_library(
     name = "editor_notice_inputs",
     target_compatible_with = select({
         "@platforms//os:macos": [],
@@ -1262,6 +1276,7 @@ donner_cc_binary(
     visibility = ["//visibility:private"],
     deps = [
         ":editor_shell",
+        ":editor_splash",
         ":notice",
         ":tracy_wrapper",
         "//donner/base",

--- a/donner/editor/BUILD.bazel
+++ b/donner/editor/BUILD.bazel
@@ -1229,6 +1229,13 @@ embed_resources(
 )
 
 donner_cc_library(
+    name = "editor_sample_catalog",
+    srcs = ["EditorSampleCatalog.cc"],
+    hdrs = ["EditorSampleCatalog.h"],
+    deps = [":editor_splash"],
+)
+
+donner_cc_library(
     name = "editor_notice_inputs",
     target_compatible_with = select({
         "@platforms//os:macos": [],

--- a/donner/editor/EditorApp.cc
+++ b/donner/editor/EditorApp.cc
@@ -16,6 +16,7 @@
 #include "donner/editor/TextPatch.h"
 #include "donner/svg/ElementType.h"
 #include "donner/svg/SVGDocument.h"
+#include "donner/svg/SVGGElement.h"
 #include "donner/svg/SVGGraphicsElement.h"
 #include "donner/svg/SVGPathElement.h"
 #include "donner/svg/SVGStyleElement.h"
@@ -920,6 +921,7 @@ bool EditorApp::loadFromString(std::string_view svgBytes) {
   pendingTransformWritebacks_.clear();
   pendingElementRemoveWritebacks_.clear();
   pendingDocumentSourceUndo_.reset();
+  pendingSelectionAfterFlush_.reset();
   pendingSelectionRestoreTargets_.reset();
   const bool result = document_.loadFromString(svgBytes);
   // A successful load resets the dirty state - the in-memory document
@@ -1008,6 +1010,11 @@ bool EditorApp::flushFrame() {
     controller_.reset();
     controllerVersion_ = 0;
     pendingSelectionRestoreTargets_.reset();
+  }
+
+  if (pendingSelectionAfterFlush_.has_value()) {
+    setSelection(std::move(*pendingSelectionAfterFlush_));
+    pendingSelectionAfterFlush_.reset();
   }
 
   consumePendingDocumentSourceUndo();
@@ -1226,6 +1233,137 @@ bool EditorApp::moveElementBefore(svg::SVGElement element, svg::SVGElement paren
   }
 
   return applyElementMove(element, parent, referenceElement, undoLabel);
+}
+
+GroupOperationAvailability EditorApp::groupSelectionAvailability() const {
+  if (!document_.hasDocument()) {
+    return {.reason = "No SVG document is loaded"};
+  }
+  if (document_.hasPendingMutations()) {
+    return {.reason = "Document edits are still applying"};
+  }
+  if (!document_.document().hasSourceStore()) {
+    return {.reason = "Grouping requires source-backed elements"};
+  }
+  if (selection_.size() < 2u) {
+    return {.reason = "Select at least two adjacent elements"};
+  }
+
+  const std::optional<svg::SVGElement> parent = selection_.front().parentElement();
+  if (!parent.has_value() || !IsStructuralMoveContainer(*parent) || IsLocked(*parent)) {
+    return {.reason = "Selected elements need an editable container"};
+  }
+  for (const svg::SVGElement& element : selection_) {
+    if (element.parentElement() != parent || IsLocked(element)) {
+      return {.reason = "Select unlocked elements with the same parent"};
+    }
+  }
+
+  bool insideSelection = false;
+  bool passedSelection = false;
+  std::size_t selectedChildCount = 0;
+  for (std::optional<svg::SVGElement> child = parent->firstChild(); child.has_value();
+       child = child->nextSibling()) {
+    const bool selected =
+        std::find(selection_.begin(), selection_.end(), *child) != selection_.end();
+    if (selected) {
+      if (passedSelection) {
+        return {.reason = "Selected elements must be adjacent"};
+      }
+      insideSelection = true;
+      ++selectedChildCount;
+    } else if (insideSelection) {
+      passedSelection = true;
+    }
+  }
+  if (selectedChildCount != selection_.size()) {
+    return {.reason = "Selection includes detached elements"};
+  }
+  return {.canApply = true};
+}
+
+bool EditorApp::groupSelection() {
+  if (!groupSelectionAvailability().canApply) {
+    return false;
+  }
+
+  svg::SVGDocument& document = document_.document();
+  const svg::SVGElement parent = *selection_.front().parentElement();
+  std::vector<svg::SVGElement> orderedSelection;
+  orderedSelection.reserve(selection_.size());
+  for (std::optional<svg::SVGElement> child = parent.firstChild(); child.has_value();
+       child = child->nextSibling()) {
+    if (std::find(selection_.begin(), selection_.end(), *child) != selection_.end()) {
+      orderedSelection.push_back(*child);
+    }
+  }
+  if (orderedSelection.size() != selection_.size()) {
+    return false;
+  }
+
+  svg::SVGGElement group = svg::SVGGElement::Create(document);
+  recordDocumentSourceUndoOnNextFlush("Group", orderedSelection.front(),
+                                      std::string(document.source()));
+  applyMutation(EditorCommand::InsertElementCommand(parent, group, orderedSelection.front()));
+  for (const svg::SVGElement& element : orderedSelection) {
+    applyMutation(EditorCommand::InsertElementCommand(group, element));
+  }
+  pendingSelectionAfterFlush_ = std::vector<svg::SVGElement>{group};
+  return true;
+}
+
+GroupOperationAvailability EditorApp::ungroupSelectionAvailability() const {
+  if (!document_.hasDocument()) {
+    return {.reason = "No SVG document is loaded"};
+  }
+  if (document_.hasPendingMutations()) {
+    return {.reason = "Document edits are still applying"};
+  }
+  if (!document_.document().hasSourceStore()) {
+    return {.reason = "Ungrouping requires a source-backed group"};
+  }
+  if (selection_.size() != 1u || selection_.front().tryType() != svg::ElementType::G) {
+    return {.reason = "Select one group"};
+  }
+
+  const svg::SVGElement group = selection_.front();
+  const std::optional<svg::SVGElement> parent = group.parentElement();
+  if (!parent.has_value() || IsLocked(group) || IsLocked(*parent)) {
+    return {.reason = "Select an unlocked attached group"};
+  }
+  if (!group.attributes().empty()) {
+    return {.reason = "Remove group attributes before ungrouping"};
+  }
+  if (!group.firstChild().has_value()) {
+    return {.reason = "The selected group is empty"};
+  }
+  return {.canApply = true};
+}
+
+bool EditorApp::ungroupSelection() {
+  if (!ungroupSelectionAvailability().canApply) {
+    return false;
+  }
+
+  svg::SVGDocument& document = document_.document();
+  const svg::SVGElement group = selection_.front();
+  const svg::SVGElement parent = *group.parentElement();
+  std::vector<svg::SVGElement> children;
+  for (std::optional<svg::SVGElement> child = group.firstChild(); child.has_value();
+       child = child->nextSibling()) {
+    children.push_back(*child);
+  }
+  if (children.empty()) {
+    return false;
+  }
+
+  recordDocumentSourceUndoOnNextFlush("Ungroup", group, std::string(document.source()));
+  for (const svg::SVGElement& child : children) {
+    applyMutation(EditorCommand::InsertElementCommand(parent, child, group));
+  }
+  applyMutation(EditorCommand::DeleteElementCommand(group));
+  pendingSelectionAfterFlush_ = children;
+  return true;
 }
 
 bool EditorApp::applyElementMove(svg::SVGElement element, svg::SVGElement parent,

--- a/donner/editor/EditorApp.h
+++ b/donner/editor/EditorApp.h
@@ -51,6 +51,12 @@ struct PathOperationAvailability {
   std::string reason;     ///< Short disabled-state reason for tooltips and tests.
 };
 
+/// Whether a lossless group or ungroup operation can currently be applied.
+struct GroupOperationAvailability {
+  bool canApply = false;
+  std::string reason;
+};
+
 /// Whether @p command is a geometry-changing or destructive mutation targeting
 /// a locked element and must be dropped by the edit-gating path. Returns true
 /// only for `SetTransform` / `DeleteElement` whose target `IsLocked` (which
@@ -114,6 +120,12 @@ public:
   /// loop when a file is loaded. Clears the dirty flag.
   void setCurrentFilePath(std::string path) {
     currentFilePath_ = std::move(path);
+    isDirty_ = false;
+  }
+
+  /// Clear the backing path for an untitled or built-in document.
+  void clearCurrentFilePath() {
+    currentFilePath_.reset();
     isDirty_ = false;
   }
 
@@ -269,6 +281,18 @@ public:
   bool moveElementBefore(svg::SVGElement element, svg::SVGElement parent,
                          std::optional<svg::SVGElement> referenceElement,
                          std::string_view undoLabel = "Move element");
+
+  /// Return whether the current selection can be wrapped in one lossless structural group.
+  [[nodiscard]] GroupOperationAvailability groupSelectionAvailability() const;
+
+  /// Wrap the current contiguous same-parent selection in an attribute-free `<g>`.
+  bool groupSelection();
+
+  /// Return whether the selected attribute-free `<g>` can be removed losslessly.
+  [[nodiscard]] GroupOperationAvailability ungroupSelectionAvailability() const;
+
+  /// Lift the selected attribute-free group's children into its parent.
+  bool ungroupSelection();
 
   /**
    * Rename the single selected element's `id` to @p newId, updating every
@@ -647,6 +671,7 @@ private:
   /// simply never matched again and is harmless.
   std::vector<std::pair<svg::SVGElement, std::optional<std::string>>> hiddenElementAuthorDisplay_;
   std::optional<PendingDocumentSourceUndo> pendingDocumentSourceUndo_;
+  std::optional<std::vector<svg::SVGElement>> pendingSelectionAfterFlush_;
   std::optional<std::vector<AttributeWritebackTarget>> pendingSelectionRestoreTargets_;
 
   std::optional<std::string> currentFilePath_;

--- a/donner/editor/EditorSampleCatalog.cc
+++ b/donner/editor/EditorSampleCatalog.cc
@@ -1,0 +1,91 @@
+#include "donner/editor/EditorSampleCatalog.h"
+
+#include <array>
+#include <span>
+
+#include "donner/editor/EditorSplash.h"
+
+namespace donner::editor {
+namespace {
+
+constexpr std::string_view kBasicShapesSvg =
+    R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="640" height="400" viewBox="0 0 640 400">
+  <rect width="640" height="400" fill="#f7f8fa"/>
+  <rect x="32" y="32" width="180" height="120" rx="16" fill="#2f6fed"/>
+  <circle cx="320" cy="92" r="60" fill="#f0b429"/>
+  <ellipse cx="500" cy="92" rx="72" ry="48" fill="#35a16b"/>
+  <line x1="48" y1="220" x2="192" y2="348" stroke="#db3a34" stroke-width="16" stroke-linecap="round"/>
+  <polyline points="256,330 320,220 384,330" fill="none" stroke="#8a4fff" stroke-width="14" stroke-linejoin="round"/>
+  <polygon points="500,220 584,270 500,348 416,270" fill="#e76f51"/>
+</svg>)svg";
+
+constexpr std::string_view kTextStyleSvg =
+    R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360">
+  <rect width="640" height="360" fill="#17202a"/>
+  <style>
+    .heading { fill: #f8f9fa; font-family: sans-serif; font-size: 42px; font-weight: bold; }
+    .body { fill: #9fe3c0; font-family: sans-serif; font-size: 22px; }
+    .rule { stroke: #f0b429; stroke-width: 5; }
+  </style>
+  <text class="heading" x="48" y="110">Donner editor</text>
+  <text class="body" x="48" y="158">Text and style inspection</text>
+  <line class="rule" x1="48" y1="202" x2="592" y2="202"/>
+  <text x="48" y="270" fill="#f8f9fa" font-family="sans-serif" font-size="24px">Editable SVG source</text>
+  <text x="48" y="310" fill="#aeb6bf" font-family="sans-serif" font-size="18px" font-style="italic">Selectors, inheritance, and typography</text>
+</svg>)svg";
+
+constexpr std::string_view kGradientsClipSvg =
+    R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="640" height="400" viewBox="0 0 640 400">
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#2f6fed"/>
+      <stop offset="1" stop-color="#9b5de5"/>
+    </linearGradient>
+    <radialGradient id="sun" cx="35%" cy="35%" r="70%">
+      <stop offset="0" stop-color="#fff3b0"/>
+      <stop offset="1" stop-color="#f0b429"/>
+    </radialGradient>
+    <clipPath id="window-clip">
+      <rect x="64" y="48" width="512" height="304" rx="28"/>
+    </clipPath>
+  </defs>
+  <rect width="640" height="400" fill="#e9edf2"/>
+  <g clip-path="url(#window-clip)">
+    <rect x="64" y="48" width="512" height="304" fill="url(#sky)"/>
+    <circle cx="210" cy="142" r="74" fill="url(#sun)"/>
+    <path d="M0 330 C120 240 220 290 320 250 C420 210 500 260 640 190 L640 400 L0 400 Z" fill="#35a16b" opacity=".9"/>
+    <path d="M0 370 C140 300 270 350 390 300 C490 260 560 320 640 280 L640 400 L0 400 Z" fill="#174f3a" opacity=".8"/>
+  </g>
+  <rect x="64" y="48" width="512" height="304" rx="28" fill="none" stroke="#ffffff" stroke-width="8"/>
+</svg>)svg";
+
+std::string_view SourceFromEmbedded(std::span<const unsigned char> bytes) noexcept {
+  if (!bytes.empty() && bytes.back() == '\0') {
+    bytes = bytes.first(bytes.size() - 1);
+  }
+  return {reinterpret_cast<const char*>(bytes.data()), bytes.size()};
+}
+
+const std::array<EditorSample, 4> kEditorSamples = {{
+    {"donner-splash", "Donner Splash", SourceFromEmbedded(embedded::kEditorSplashSvg)},
+    {"basic-shapes", "Basic Shapes", kBasicShapesSvg},
+    {"text-style", "Text and Style", kTextStyleSvg},
+    {"gradients-clip", "Gradients and Clip", kGradientsClipSvg},
+}};
+
+}  // namespace
+
+std::span<const EditorSample> GetEditorSampleCatalog() noexcept {
+  return kEditorSamples;
+}
+
+const EditorSample* FindEditorSample(std::string_view id) noexcept {
+  for (const EditorSample& sample : kEditorSamples) {
+    if (sample.id == id) {
+      return &sample;
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace donner::editor

--- a/donner/editor/EditorSampleCatalog.h
+++ b/donner/editor/EditorSampleCatalog.h
@@ -1,0 +1,25 @@
+#pragma once
+/// @file
+
+#include <span>
+#include <string_view>
+
+namespace donner::editor {
+
+/// One built-in SVG document that can be loaded by editor UI surfaces.
+///
+/// The catalog owns none of the strings. Each view refers to static compiled
+/// data, so callers can retain a view for as long as the process is running.
+struct EditorSample {
+  std::string_view id;
+  std::string_view title;
+  std::string_view source;
+};
+
+/// Return the bounded, ordered set of built-in editor samples.
+[[nodiscard]] std::span<const EditorSample> GetEditorSampleCatalog() noexcept;
+
+/// Find a built-in sample by its stable ASCII ID, or return nullptr.
+[[nodiscard]] const EditorSample* FindEditorSample(std::string_view id) noexcept;
+
+}  // namespace donner::editor

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -1657,10 +1657,11 @@ void EditorShell::applyMenuActions(const MenuBarActions& menuActions) {
     toggleSourceFocusMode();
   }
   const bool showCompositorDebugPanelBeforeMenu = showCompositorDebugPanel_;
+  const bool compositorTileOverlayBeforeMenu = compositorTileOverlay_;
   const PerfOverlayMode perfOverlayModeBeforeMenu = perfOverlayMode_;
   const bool geometryDebugOverlayBeforeMenu = geometryDebugOverlay_;
   ApplyViewMenuToggleActions(menuActions, &showCompositorDebugPanel_, &perfOverlayMode_,
-                             &geometryDebugOverlay_);
+                             &geometryDebugOverlay_, &compositorTileOverlay_);
   if (geometryDebugOverlay_ != geometryDebugOverlayBeforeMenu) {
     // Push the new overlay state to the render worker and post a render:
     // the worker re-rasterizes every cached segment with the overlay
@@ -1679,6 +1680,7 @@ void EditorShell::applyMenuActions(const MenuBarActions& menuActions) {
     window_.wakeEventLoop();
   }
   if (showCompositorDebugPanel_ != showCompositorDebugPanelBeforeMenu ||
+      compositorTileOverlay_ != compositorTileOverlayBeforeMenu ||
       perfOverlayMode_ != perfOverlayModeBeforeMenu ||
       geometryDebugOverlay_ != geometryDebugOverlayBeforeMenu) {
     window_.wakeEventLoop();
@@ -3303,6 +3305,7 @@ void EditorShell::renderRenderPane(ImGuiWindowFlags paneFlags) {
       .suppressedLayerEntity = presentSuppressedLayerEntity,
       .suppressDragTargetTiles = suppressDragTargetTiles,
       .documentPresentedDirectly = documentPresentedDirectly,
+      .compositorTileOverlay = !contentOnlyCaptureThisFrame_ && compositorTileOverlay_,
       .perfOverlayMode = contentOnlyCaptureThisFrame_ ? PerfOverlayMode::Off : perfOverlayMode_,
   };
   renderPanePresenter_.render(paneState);
@@ -5089,6 +5092,7 @@ void EditorShell::runFrame() {
       .hasTextSelection = selectionIsAllText(),
       .hasSelectableElements = canvasHasSelectableElements(),
       .showCompositorDebugPanel = showCompositorDebugPanel_,
+      .compositorTileOverlay = compositorTileOverlay_,
       .geometryDebugOverlay = geometryDebugOverlay_,
       .perfOverlayMode = perfOverlayMode_,
       .panelLayoutLocked = dockLayoutLocked_,

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -1330,6 +1330,7 @@ bool EditorShell::tryLoadSource(std::string_view source, std::optional<std::stri
     return false;
   }
 
+  showSamplePicker_ = false;
   textEditor_.setText(std::string(source));
   textEditor_.resetTextChanged();
   const std::string canonicalSource = textEditor_.getText();

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -22,6 +22,10 @@
 #include <variant>
 #include <vector>
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
 #include "GLFW/glfw3.h"
 #include "donner/base/RcString.h"
 #include "donner/base/StringUtils.h"
@@ -30,6 +34,7 @@
 #include "donner/editor/DocumentSave.h"
 #include "donner/editor/DragCoalesce.h"
 #include "donner/editor/EditorDockLayout.h"
+#include "donner/editor/EditorSampleCatalog.h"
 #include "donner/editor/EditorShellInternal.h"
 #include "donner/editor/EditorShellPresentation.h"
 #include "donner/editor/EditorTheme.h"
@@ -267,6 +272,16 @@ bool CanvasChromeCapturesInput(const ImVec2& point, const std::optional<Box2d>& 
          (editingScopeBreadcrumbRect.has_value() &&
           ContainsScreenPoint(*editingScopeBreadcrumbRect, point)) ||
          ContainsScreenPoint(canvasZoomControlRect, point);
+}
+
+bool GroupOperationCanDispatch(bool rendererBusy,
+                               const GroupOperationAvailability& availability) noexcept {
+  return !rendererBusy && availability.canApply;
+}
+
+bool PendingDocumentReplacementCanProcess(bool hasPendingRequest, bool rendererBusy,
+                                          bool hasPendingMutations) noexcept {
+  return hasPendingRequest && !rendererBusy && !hasPendingMutations;
 }
 
 // Build the "<label> (<key>)" tooltip string for a tool button from the shared
@@ -811,6 +826,7 @@ EditorShell::EditorShell(gui::EditorWindow& window, EditorShellOptions options)
     std::fprintf(stderr, "[repro] recording UI inputs to %s\n", options_.reproOutputPath->c_str());
   }
 
+  showSamplePicker_ = options_.showWelcome;
   valid_ = true;
 }
 
@@ -1298,22 +1314,81 @@ void EditorShell::maybeLogFrameMissTelemetry(const FrameCostBreakdown& frameCost
 }
 
 bool EditorShell::tryOpenPath(std::string_view path, std::string* error) {
+  pendingSampleLoadId_.clear();
   auto contents = LoadFile(std::string(path));
   if (!contents.has_value()) {
     *error = "Could not open file.";
     return false;
   }
-  if (!app_.loadFromString(*contents)) {
+  return tryLoadSource(*contents, std::string(path), error);
+}
+
+bool EditorShell::tryLoadSource(std::string_view source, std::optional<std::string> path,
+                                std::string* error) {
+  if (!app_.loadFromString(source)) {
     *error = "Failed to parse SVG.";
     return false;
   }
 
-  textEditor_.setText(*contents);
+  textEditor_.setText(std::string(source));
   textEditor_.resetTextChanged();
   const std::string canonicalSource = textEditor_.getText();
-  app_.setCurrentFilePath(std::string(path));
+  if (path.has_value()) {
+    app_.setCurrentFilePath(std::move(*path));
+  } else {
+    app_.clearCurrentFilePath();
+  }
   resetPresentationForLoadedDocument(canonicalSource);
+  viewportInitialized_ = false;
+  requestRenderAtEndOfFrame_ = true;
   return true;
+}
+
+void EditorShell::processPendingSampleLoad() {
+  if (!internal::PendingDocumentReplacementCanProcess(!pendingSampleLoadId_.empty(),
+                                                      renderCoordinator_.asyncRenderer().isBusy(),
+                                                      app_.document().hasPendingMutations())) {
+    return;
+  }
+
+  const std::string sampleId = std::exchange(pendingSampleLoadId_, {});
+  const EditorSample* sample = FindEditorSample(sampleId);
+  if (sample == nullptr) {
+    showSamplePicker_ = true;
+    return;
+  }
+
+#ifdef DONNER_EDITOR_WGPU
+  // The previous frame's direct callback has run, but remains installed until the next render-pane
+  // submission. Detach it before releasing presentation resources for the old document.
+  window_.setWgpuDirectRenderCallback({});
+#endif
+  std::string error;
+  if (tryLoadSource(sample->source, std::nullopt, &error)) {
+    activeSampleId_ = sampleId;
+    showSamplePicker_ = false;
+  } else {
+    showSamplePicker_ = true;
+    std::fprintf(stderr, "[editor] failed to load built-in sample %s: %s\n", sampleId.c_str(),
+                 error.c_str());
+  }
+}
+
+bool EditorShell::tryApplyGroupOperation(bool ungroup) {
+  const bool rendererBusy = renderCoordinator_.asyncRenderer().isBusy();
+  const GroupOperationAvailability availability =
+      rendererBusy
+          ? GroupOperationAvailability{.reason = "Renderer busy"}
+          : (ungroup ? app_.ungroupSelectionAvailability() : app_.groupSelectionAvailability());
+  if (!internal::GroupOperationCanDispatch(rendererBusy, availability)) {
+    return false;
+  }
+
+  const bool queued = ungroup ? app_.ungroupSelection() : app_.groupSelection();
+  if (queued) {
+    flushQueuedMutationAndRefreshOverlay();
+  }
+  return queued;
 }
 
 void EditorShell::resetPresentationForLoadedDocument(std::string_view canonicalSource) {
@@ -1494,6 +1569,8 @@ void EditorShell::requestRevert() {
     return;
   }
 
+  pendingSampleLoadId_.clear();
+
   const std::string source(app_.cleanSourceText());
   if (!app_.revertToCleanSource()) {
     return;
@@ -1566,7 +1643,12 @@ void EditorShell::applyMenuActions(const MenuBarActions& menuActions) {
     dialogPresenter_.requestAbout();
   }
   if (menuActions.openFile) {
+    pendingSampleLoadId_.clear();
     dialogPresenter_.requestOpenFile(app_.currentFilePath());
+  }
+  if (menuActions.openSamples) {
+    showSamplePicker_ = true;
+    window_.wakeEventLoop();
   }
   if (menuActions.saveFile) {
     requestSave();
@@ -1619,6 +1701,12 @@ void EditorShell::applyMenuActions(const MenuBarActions& menuActions) {
   }
   if (menuActions.convertTextToOutlines) {
     convertSelectedTextToOutlines();
+  }
+  if (menuActions.group) {
+    std::ignore = tryApplyGroupOperation(/*ungroup=*/false);
+  }
+  if (menuActions.ungroup) {
+    std::ignore = tryApplyGroupOperation(/*ungroup=*/true);
   }
   if (menuActions.selectAll) {
     textEditor_.selectAll();
@@ -1882,6 +1970,10 @@ void EditorShell::handleGlobalShortcuts() {
     } else if (ImGui::IsKeyPressed(ImGuiKey_F, /*repeat=*/false)) {
       pasteShapesFromClipboard(/*inFront=*/true);
     }
+  }
+  if (!sourcePaneFocused && !anyPopupOpen && cmd &&
+      ImGui::IsKeyPressed(ImGuiKey_G, /*repeat=*/false)) {
+    std::ignore = tryApplyGroupOperation(/*ungroup=*/shift);
   }
 
   const bool deleteKey = ImGui::IsKeyPressed(ImGuiKey_Delete, /*repeat=*/false) ||
@@ -2638,7 +2730,7 @@ void EditorShell::renderRenderPane(ImGuiWindowFlags paneFlags) {
   ImGui::InvisibleButton("##render_canvas", contentRegion,
                          ImGuiButtonFlags_MouseButtonLeft | ImGuiButtonFlags_MouseButtonMiddle);
   const bool paneHovered = ImGui::IsItemHovered();
-  const bool canvasHovered = paneHovered && !canvasChromeHovered;
+  const bool canvasHovered = paneHovered && !canvasChromeHovered && !showSamplePicker_;
   const Box2d paneRect = Box2d::FromXYWH(interactionController_.viewport().paneOrigin.x,
                                          interactionController_.viewport().paneOrigin.y,
                                          interactionController_.viewport().paneSize.x,
@@ -2693,8 +2785,8 @@ void EditorShell::renderRenderPane(ImGuiWindowFlags paneFlags) {
     }
   }
 
-  const bool modalCapturingInput =
-      canvasChromeHovered || ImGui::IsPopupOpen(nullptr, ImGuiPopupFlags_AnyPopup);
+  const bool modalCapturingInput = showSamplePicker_ || canvasChromeHovered ||
+                                   ImGui::IsPopupOpen(nullptr, ImGuiPopupFlags_AnyPopup);
   // Publish the canvas scroll-capture rect for the raw GLFW scroll callback:
   // wheel events inside the render pane are consumed by the canvas (pan/zoom)
   // and must not also reach ImGui window scrolling, or scrolling the canvas
@@ -3174,7 +3266,7 @@ void EditorShell::renderRenderPane(ImGuiWindowFlags paneFlags) {
       activeDragPreview, displayedDragPreview, hasPresentableActiveDragTarget);
   const auto representedGesturePreview = OverlayGesturePreviewForPresentation(
       activeGesturePreview, liveActiveDragPreview, representedDragPreview);
-  if (!contentOnlyCaptureThisFrame_) {
+  if (!contentOnlyCaptureThisFrame_ && !showSamplePicker_) {
     // While the Pen tool is active the selected path is itself the live
     // interaction surface, so chrome must track the live DOM even between
     // anchor drags (close-path clicks, deferred clicks processed after
@@ -3331,8 +3423,60 @@ void EditorShell::renderRenderPane(ImGuiWindowFlags paneFlags) {
     renderCanvasScrollbars();
     renderRenderPaneContextMenu();
   }
-
   ImGui::End();
+}
+
+void EditorShell::renderSamplePicker(const ImVec2& paneOrigin, const ImVec2& contentRegion) {
+  if (contentRegion.x <= 0.0f || contentRegion.y <= 0.0f) {
+    return;
+  }
+
+  const EditorTheme& theme = EditorTheme::Active();
+  ImGui::SetNextWindowPos(paneOrigin, ImGuiCond_Always);
+  ImGui::SetNextWindowSize(contentRegion, ImGuiCond_Always);
+  ImGui::PushStyleColor(ImGuiCol_WindowBg, ImGui::ColorConvertU32ToFloat4(theme.surfaceCanvas));
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(16.0f, 16.0f));
+  constexpr ImGuiWindowFlags kWelcomeFlags =
+      ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
+      ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoDocking;
+  ImGui::Begin("##sample_picker_surface", nullptr, kWelcomeFlags);
+
+  const float horizontalInset = contentRegion.x < kSamplePickerNarrowBreakpoint ? 0.0f : 32.0f;
+  const float contentWidth = std::max(0.0f, std::min(920.0f, contentRegion.x - 32.0f));
+  if (horizontalInset > 0.0f && contentWidth < contentRegion.x) {
+    ImGui::SetCursorPosX(std::max(horizontalInset, (contentRegion.x - contentWidth) * 0.5f));
+  }
+  ImGui::SetCursorPosY(contentRegion.y < 560.0f ? 8.0f : 32.0f);
+  ImGui::BeginChild("##sample_picker_content", ImVec2(contentWidth, 0.0f), ImGuiChildFlags_None,
+                    ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoSavedSettings);
+  const SamplePickerActions actions = samplePickerPresenter_.render(
+      SamplePickerState{.visible = true, .selectedSampleId = activeSampleId_});
+  ImGui::EndChild();
+  ImGui::End();
+  ImGui::PopStyleVar(2);
+  ImGui::PopStyleColor();
+
+  if (actions.dismiss) {
+    pendingSampleLoadId_.clear();
+    showSamplePicker_ = false;
+  }
+  if (actions.openFile) {
+    pendingSampleLoadId_.clear();
+    showSamplePicker_ = false;
+    dialogPresenter_.requestOpenFile(app_.currentFilePath());
+  }
+  if (actions.openGitHub) {
+#ifdef __EMSCRIPTEN__
+    EM_ASM({ window.open('https://github.com/jwmcglynn/donner', '_blank', 'noopener'); });
+#else
+    ImGui::SetClipboardText(kSamplePickerGitHubUrl.data());
+#endif
+  }
+  if (actions.loadSample) {
+    pendingSampleLoadId_ = actions.sampleId;
+    window_.wakeEventLoop();
+  }
 }
 
 void EditorShell::renderEditingScopeBreadcrumb() {
@@ -4539,6 +4683,18 @@ void EditorShell::renderRenderPaneContextMenu() {
   if (ImGui::MenuItem("Delete Selection", nullptr, false, app_.hasSelection())) {
     selectionChanged = app_.deleteSelectionWithUndo(textEditor_.getText());
   }
+  const GroupOperationAvailability groupAvailability =
+      rendererBusy ? GroupOperationAvailability{.reason = "Renderer busy"}
+                   : app_.groupSelectionAvailability();
+  if (ImGui::MenuItem("Group", "Cmd+G", false, groupAvailability.canApply)) {
+    selectionChanged = tryApplyGroupOperation(/*ungroup=*/false);
+  }
+  const GroupOperationAvailability ungroupAvailability =
+      rendererBusy ? GroupOperationAvailability{.reason = "Renderer busy"}
+                   : app_.ungroupSelectionAvailability();
+  if (ImGui::MenuItem("Ungroup", "Cmd+Shift+G", false, ungroupAvailability.canApply)) {
+    selectionChanged = tryApplyGroupOperation(/*ungroup=*/true);
+  }
 
   // Arrange (paint/z-order). Acts on the right-clicked element, or on the single
   // selection when the menu was opened over empty canvas. Reuses the shared
@@ -5013,6 +5169,7 @@ void EditorShell::runFrame() {
       requestRenderAtEndOfFrame_ = true;
     }
   }
+  processPendingSampleLoad();
   markPhase(mainFrameCost.documentFlushMs);
 
   // Re-rasterize the overlay against the just-flushed DOM while a locked-rejection flash is (or was
@@ -5080,6 +5237,7 @@ void EditorShell::runFrame() {
   handleGlobalShortcuts();
   markPhase(mainFrameCost.shortcutsMs);
 
+  const bool rendererIdle = !renderCoordinator_.asyncRenderer().isBusy();
   MenuBarState menuState{
       .sourcePaneFocused = sourcePaneVisible_ && textEditor_.isFocused(),
       .canSave = app_.hasDocument(),
@@ -5090,6 +5248,8 @@ void EditorShell::runFrame() {
       .hasShapeSelection = app_.hasSelection(),
       .hasShapeClipboard = shapeClipboard_ != nullptr && shapeClipboard_->hasText(),
       .hasTextSelection = selectionIsAllText(),
+      .canGroup = rendererIdle && app_.groupSelectionAvailability().canApply,
+      .canUngroup = rendererIdle && app_.ungroupSelectionAvailability().canApply,
       .hasSelectableElements = canvasHasSelectableElements(),
       .showCompositorDebugPanel = showCompositorDebugPanel_,
       .compositorTileOverlay = compositorTileOverlay_,
@@ -5134,6 +5294,10 @@ void EditorShell::runFrame() {
   // Debug float are now owned by the DockSpace submitted above.
   renderSourcePaneSplitter(static_cast<float>(windowSize.x), paneOriginY, paneHeight,
                            mainPaneLayout.sourcePaneWidth);
+  if (!contentOnlyCaptureThisFrame_ && showSamplePicker_) {
+    renderSamplePicker(ImVec2(0.0f, paneOriginY),
+                       ImVec2(static_cast<float>(windowSize.x), paneHeight));
+  }
   markPhase(mainFrameCost.splittersMs);
   if (requestRenderAtEndOfFrame_) {
     if (!app_.hasDocument()) {

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -1314,7 +1314,7 @@ void EditorShell::maybeLogFrameMissTelemetry(const FrameCostBreakdown& frameCost
 }
 
 bool EditorShell::tryOpenPath(std::string_view path, std::string* error) {
-  pendingSampleLoadId_.clear();
+  cancelPendingSampleLoad();
   auto contents = LoadFile(std::string(path));
   if (!contents.has_value()) {
     *error = "Could not open file.";
@@ -1344,6 +1344,27 @@ bool EditorShell::tryLoadSource(std::string_view source, std::optional<std::stri
   return true;
 }
 
+void EditorShell::queuePendingSampleLoad(std::string sampleId) {
+  pendingSampleLoadId_ = std::move(sampleId);
+  pendingSampleLoadNeedsConfirmation_ = false;
+  pendingSampleLoadDiscardConfirmed_ = false;
+}
+
+void EditorShell::cancelPendingSampleLoad() {
+  pendingSampleLoadId_.clear();
+  pendingSampleLoadNeedsConfirmation_ = false;
+  pendingSampleLoadDiscardConfirmed_ = false;
+}
+
+void EditorShell::confirmPendingSampleLoadDiscard() {
+  if (pendingSampleLoadId_.empty()) {
+    return;
+  }
+  pendingSampleLoadNeedsConfirmation_ = false;
+  pendingSampleLoadDiscardConfirmed_ = true;
+  window_.wakeEventLoop();
+}
+
 void EditorShell::processPendingSampleLoad() {
   if (!internal::PendingDocumentReplacementCanProcess(!pendingSampleLoadId_.empty(),
                                                       renderCoordinator_.asyncRenderer().isBusy(),
@@ -1351,7 +1372,15 @@ void EditorShell::processPendingSampleLoad() {
     return;
   }
 
+  if (!pendingSampleLoadDiscardConfirmed_ && (app_.isDirty() || textEditor_.isTextChanged())) {
+    pendingSampleLoadNeedsConfirmation_ = true;
+    showSamplePicker_ = true;
+    return;
+  }
+
   const std::string sampleId = std::exchange(pendingSampleLoadId_, {});
+  pendingSampleLoadNeedsConfirmation_ = false;
+  pendingSampleLoadDiscardConfirmed_ = false;
   const EditorSample* sample = FindEditorSample(sampleId);
   if (sample == nullptr) {
     showSamplePicker_ = true;
@@ -1569,7 +1598,7 @@ void EditorShell::requestRevert() {
     return;
   }
 
-  pendingSampleLoadId_.clear();
+  cancelPendingSampleLoad();
 
   const std::string source(app_.cleanSourceText());
   if (!app_.revertToCleanSource()) {
@@ -1643,7 +1672,7 @@ void EditorShell::applyMenuActions(const MenuBarActions& menuActions) {
     dialogPresenter_.requestAbout();
   }
   if (menuActions.openFile) {
-    pendingSampleLoadId_.clear();
+    cancelPendingSampleLoad();
     dialogPresenter_.requestOpenFile(app_.currentFilePath());
   }
   if (menuActions.openSamples) {
@@ -3453,16 +3482,36 @@ void EditorShell::renderSamplePicker(const ImVec2& paneOrigin, const ImVec2& con
   const SamplePickerActions actions = samplePickerPresenter_.render(
       SamplePickerState{.visible = true, .selectedSampleId = activeSampleId_});
   ImGui::EndChild();
+
+  if (pendingSampleLoadNeedsConfirmation_) {
+    if (!ImGui::IsPopupOpen("Discard changes?")) {
+      ImGui::OpenPopup("Discard changes?");
+    }
+    if (ImGui::BeginPopupModal("Discard changes?", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+      ImGui::TextUnformatted("Loading a sample replaces the current document.");
+      ImGui::Spacing();
+      if (ImGui::Button("Cancel", ImVec2(112.0f, 40.0f))) {
+        cancelPendingSampleLoad();
+        ImGui::CloseCurrentPopup();
+      }
+      ImGui::SameLine();
+      if (ImGui::Button("Discard & Load", ImVec2(148.0f, 40.0f))) {
+        confirmPendingSampleLoadDiscard();
+        ImGui::CloseCurrentPopup();
+      }
+      ImGui::EndPopup();
+    }
+  }
   ImGui::End();
   ImGui::PopStyleVar(2);
   ImGui::PopStyleColor();
 
   if (actions.dismiss) {
-    pendingSampleLoadId_.clear();
+    cancelPendingSampleLoad();
     showSamplePicker_ = false;
   }
   if (actions.openFile) {
-    pendingSampleLoadId_.clear();
+    cancelPendingSampleLoad();
     showSamplePicker_ = false;
     dialogPresenter_.requestOpenFile(app_.currentFilePath());
   }
@@ -3474,7 +3523,7 @@ void EditorShell::renderSamplePicker(const ImVec2& paneOrigin, const ImVec2& con
 #endif
   }
   if (actions.loadSample) {
-    pendingSampleLoadId_ = actions.sampleId;
+    queuePendingSampleLoad(actions.sampleId);
     window_.wakeEventLoop();
   }
 }

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -606,6 +606,8 @@ private:
   /// developer-facing composite-tile diagnostics view, toggled on via the View
   /// menu. The user-facing Layers panel is unrelated and always visible.
   bool showCompositorDebugPanel_ = false;
+  /// Draw compositor tile geometry and identity directly over the canvas.
+  bool compositorTileOverlay_ = false;
   /// Render-pane frame-timing/perf overlay mode. Off by default; set via the
   /// View menu's Performance Overlay submenu.
   PerfOverlayMode perfOverlayMode_ = PerfOverlayMode::Off;

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -298,6 +298,9 @@ public:
 private:
   bool tryOpenPath(std::string_view path, std::string* error);
   bool tryLoadSource(std::string_view source, std::optional<std::string> path, std::string* error);
+  void queuePendingSampleLoad(std::string sampleId);
+  void cancelPendingSampleLoad();
+  void confirmPendingSampleLoadDiscard();
   void processPendingSampleLoad();
   /// Apply Group or Ungroup only while the render worker releases DOM ownership.
   bool tryApplyGroupOperation(bool ungroup);
@@ -614,6 +617,8 @@ private:
   bool showSamplePicker_ = false;
   std::string activeSampleId_;
   std::string pendingSampleLoadId_;
+  bool pendingSampleLoadNeedsConfirmation_ = false;
+  bool pendingSampleLoadDiscardConfirmed_ = false;
   /// Whether the Compositor Debug panel window renders. Off by default: it is a
   /// developer-facing composite-tile diagnostics view, toggled on via the View
   /// menu. The user-facing Layers panel is unrelated and always visible.

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -29,6 +29,7 @@
 #include "donner/editor/RenderCoordinator.h"
 #include "donner/editor/RenderPanePresenter.h"
 #include "donner/editor/RotateCursorSet.h"
+#include "donner/editor/SamplePickerPresenter.h"
 #include "donner/editor/SelectTool.h"
 #include "donner/editor/SidebarPresenter.h"
 #include "donner/editor/SourceDiagnosticsPanel.h"
@@ -67,6 +68,8 @@ struct EditorShellOptions {
   std::string svgPath;
   std::optional<std::string> initialSource;
   std::optional<std::string> initialPath;
+  /// Show the in-workspace welcome and sample picker on the first frame.
+  bool showWelcome = false;
   std::string editorNoticeText;
   /// Optional destination path for a `.donner-repro` recording of the
   /// user's UI interactions. When set, the shell constructs a
@@ -294,6 +297,10 @@ public:
 
 private:
   bool tryOpenPath(std::string_view path, std::string* error);
+  bool tryLoadSource(std::string_view source, std::optional<std::string> path, std::string* error);
+  void processPendingSampleLoad();
+  /// Apply Group or Ungroup only while the render worker releases DOM ownership.
+  bool tryApplyGroupOperation(bool ungroup);
   bool trySavePath(std::string_view path, std::string* error);
   void applyPendingDocumentSpaceReplayInputForTesting();
 
@@ -365,6 +372,7 @@ private:
   void renderCanvasZoomControl();
   void renderFillStrokeToolbarWidget();
   void renderSidebars();
+  void renderSamplePicker(const ImVec2& paneOrigin, const ImVec2& contentRegion);
   void renderSourcePaneSplitter(float windowWidth, float paneOriginY, float paneHeight,
                                 float sourcePaneWidth);
   /// Submit the host window and DockSpace that own the canvas (central node) and
@@ -511,6 +519,7 @@ private:
   bool penDragFlushedThisFrame_ = false;
   EditorInputBridge inputBridge_;
   MenuBarPresenter menuBarPresenter_;
+  SamplePickerPresenter samplePickerPresenter_;
   TextFormatBarPresenter textFormatBarPresenter_;
   SidebarPresenter sidebarPresenter_;
   TextInspectorPanel textInspectorPanel_;
@@ -602,6 +611,9 @@ private:
   /// Preferred width for the source pane when it is visible.
   float sourcePaneWidth_ = 560.0f;
   bool sourcePaneVisible_ = false;
+  bool showSamplePicker_ = false;
+  std::string activeSampleId_;
+  std::string pendingSampleLoadId_;
   /// Whether the Compositor Debug panel window renders. Off by default: it is a
   /// developer-facing composite-tile diagnostics view, toggled on via the View
   /// menu. The user-facing Layers panel is unrelated and always visible.

--- a/donner/editor/EditorShellInternal.h
+++ b/donner/editor/EditorShellInternal.h
@@ -81,6 +81,10 @@ enum class PendingClickIdleAction {
                                              const std::optional<Box2d>& textFormatBarRect,
                                              const std::optional<Box2d>& editingScopeBreadcrumbRect,
                                              const Box2d& canvasZoomControlRect);
+[[nodiscard]] bool GroupOperationCanDispatch(
+    bool rendererBusy, const GroupOperationAvailability& availability) noexcept;
+[[nodiscard]] bool PendingDocumentReplacementCanProcess(bool hasPendingRequest, bool rendererBusy,
+                                                        bool hasPendingMutations) noexcept;
 [[nodiscard]] PendingClickBusyAction PendingClickBusyActionForState(bool tookFastRedrag,
                                                                     bool rendererBusy);
 [[nodiscard]] PendingClickIdleAction PendingClickIdleActionForState(

--- a/donner/editor/MenuBarPresenter.cc
+++ b/donner/editor/MenuBarPresenter.cc
@@ -52,6 +52,9 @@ void ApplyMenuBarCommand(bool activated, MenuBarCommand command, const MenuBarSt
     case MenuBarCommand::ToggleCompositorDebugPanel:
       actions->toggleCompositorDebugPanel = true;
       return;
+    case MenuBarCommand::ToggleCompositorTileOverlay:
+      actions->toggleCompositorTileOverlay = true;
+      return;
     case MenuBarCommand::ToggleGeometryDebugOverlay:
       actions->toggleGeometryDebugOverlay = true;
       return;
@@ -73,7 +76,8 @@ void ApplyMenuBarCommand(bool activated, MenuBarCommand command, const MenuBarSt
 }
 
 void ApplyViewMenuToggleActions(const MenuBarActions& actions, bool* showCompositorDebugPanel,
-                                PerfOverlayMode* perfOverlayMode, bool* geometryDebugOverlay) {
+                                PerfOverlayMode* perfOverlayMode, bool* geometryDebugOverlay,
+                                bool* compositorTileOverlay) {
   if (actions.toggleCompositorDebugPanel && showCompositorDebugPanel != nullptr) {
     *showCompositorDebugPanel = !*showCompositorDebugPanel;
   }
@@ -82,6 +86,9 @@ void ApplyViewMenuToggleActions(const MenuBarActions& actions, bool* showComposi
   }
   if (actions.toggleGeometryDebugOverlay && geometryDebugOverlay != nullptr) {
     *geometryDebugOverlay = !*geometryDebugOverlay;
+  }
+  if (actions.toggleCompositorTileOverlay && compositorTileOverlay != nullptr) {
+    *compositorTileOverlay = !*compositorTileOverlay;
   }
 }
 
@@ -194,6 +201,9 @@ MenuBarActions MenuBarPresenter::render(const MenuBarState& state, ImFont* boldM
     ApplyMenuBarCommand(
         ImGui::MenuItem("Compositor Debug", nullptr, state.showCompositorDebugPanel),
         MenuBarCommand::ToggleCompositorDebugPanel, state, &actions);
+    ApplyMenuBarCommand(
+        ImGui::MenuItem("Compositor Tile Overlay", nullptr, state.compositorTileOverlay),
+        MenuBarCommand::ToggleCompositorTileOverlay, state, &actions);
     ApplyMenuBarCommand(
         ImGui::MenuItem("Geometry Debug Overlay", nullptr, state.geometryDebugOverlay),
         MenuBarCommand::ToggleGeometryDebugOverlay, state, &actions);

--- a/donner/editor/MenuBarPresenter.cc
+++ b/donner/editor/MenuBarPresenter.cc
@@ -16,6 +16,7 @@ void ApplyMenuBarCommand(bool activated, MenuBarCommand command, const MenuBarSt
   switch (command) {
     case MenuBarCommand::OpenAbout: actions->openAbout = true; return;
     case MenuBarCommand::OpenFile: actions->openFile = true; return;
+    case MenuBarCommand::OpenSamples: actions->openSamples = true; return;
     case MenuBarCommand::SaveFile: actions->saveFile = true; return;
     case MenuBarCommand::SaveFileAs: actions->saveFileAs = true; return;
     case MenuBarCommand::ExportViewportSvg: actions->exportViewportSvg = true; return;
@@ -31,6 +32,8 @@ void ApplyMenuBarCommand(bool activated, MenuBarCommand command, const MenuBarSt
     case MenuBarCommand::Paste: actions->paste = true; return;
     case MenuBarCommand::PasteInFront: actions->pasteInFront = true; return;
     case MenuBarCommand::ConvertTextToOutlines: actions->convertTextToOutlines = true; return;
+    case MenuBarCommand::Group: actions->group = true; return;
+    case MenuBarCommand::Ungroup: actions->ungroup = true; return;
     case MenuBarCommand::SelectAll:
       if (state.sourcePaneFocused) {
         actions->selectAll = true;
@@ -131,6 +134,8 @@ MenuBarActions MenuBarPresenter::render(const MenuBarState& state, ImFont* boldM
   if (ImGui::BeginMenu("File")) {
     ApplyMenuBarCommand(ImGui::MenuItem("Open...", "Cmd+O"), MenuBarCommand::OpenFile, state,
                         &actions);
+    ApplyMenuBarCommand(ImGui::MenuItem("Open Sample..."), MenuBarCommand::OpenSamples, state,
+                        &actions);
     ApplyMenuBarCommand(ImGui::MenuItem("Save", "Cmd+S", false, state.canSave),
                         MenuBarCommand::SaveFile, state, &actions);
     ApplyMenuBarCommand(ImGui::MenuItem("Save As...", "Cmd+Shift+S", false, state.canSave),
@@ -171,6 +176,10 @@ MenuBarActions MenuBarPresenter::render(const MenuBarState& state, ImFont* boldM
     ApplyMenuBarCommand(
         ImGui::MenuItem("Convert Text to Outlines", nullptr, false, state.hasTextSelection),
         MenuBarCommand::ConvertTextToOutlines, state, &actions);
+    ApplyMenuBarCommand(ImGui::MenuItem("Group", "Cmd+G", false, state.canGroup),
+                        MenuBarCommand::Group, state, &actions);
+    ApplyMenuBarCommand(ImGui::MenuItem("Ungroup", "Cmd+Shift+G", false, state.canUngroup),
+                        MenuBarCommand::Ungroup, state, &actions);
     // "Select All" routes to the source/XML pane's text Select-All while it owns keyboard focus,
     // and otherwise to the canvas Select-All (every selectable element). Enabled when either path
     // can act.

--- a/donner/editor/MenuBarPresenter.h
+++ b/donner/editor/MenuBarPresenter.h
@@ -34,6 +34,8 @@ struct MenuBarState {
   /// True when the canvas selection is exactly one or more `<text>` elements,
   /// the precondition for "Convert Text to Outlines".
   bool hasTextSelection = false;
+  bool canGroup = false;
+  bool canUngroup = false;
   /// True when the document has at least one selectable element. Enables the canvas "Select All"
   /// when the source pane is not focused.
   bool hasSelectableElements = false;
@@ -57,6 +59,7 @@ struct MenuBarState {
 struct MenuBarActions {
   bool openAbout = false;
   bool openFile = false;
+  bool openSamples = false;
   bool saveFile = false;
   bool saveFileAs = false;
   bool exportViewportSvg = false;
@@ -70,6 +73,8 @@ struct MenuBarActions {
   bool paste = false;
   bool pasteInFront = false;
   bool convertTextToOutlines = false;
+  bool group = false;
+  bool ungroup = false;
   /// Text Select-All in the source/XML pane (fires when the source pane owns keyboard focus).
   bool selectAll = false;
   /// Canvas Select-All - selects every selectable element (fires when the source pane is not
@@ -106,6 +111,7 @@ struct MenuBarActions {
 enum class MenuBarCommand {
   OpenAbout,
   OpenFile,
+  OpenSamples,
   SaveFile,
   SaveFileAs,
   ExportViewportSvg,
@@ -119,6 +125,8 @@ enum class MenuBarCommand {
   Paste,
   PasteInFront,
   ConvertTextToOutlines,
+  Group,
+  Ungroup,
   SelectAll,
   DeselectAll,
   ZoomIn,

--- a/donner/editor/MenuBarPresenter.h
+++ b/donner/editor/MenuBarPresenter.h
@@ -40,6 +40,8 @@ struct MenuBarState {
   /// Current visibility of the Compositor Debug panel (drives the View-menu
   /// checkmark). Off by default.
   bool showCompositorDebugPanel = false;
+  /// Whether compositor tile boundaries and identities are drawn directly over the canvas.
+  bool compositorTileOverlay = false;
   /// Whether the Geode geometry debug overlay (band strips + per-path
   /// bounding-quad triangles) is enabled on the document renderer
   /// (drives the View-menu checkmark). Off by default.
@@ -84,6 +86,8 @@ struct MenuBarActions {
   bool toggleSourceFocusMode = false;
   /// Set when the user toggles the Compositor Debug panel via the View menu.
   bool toggleCompositorDebugPanel = false;
+  /// Set when the user toggles compositor tile boundaries over the canvas.
+  bool toggleCompositorTileOverlay = false;
   /// Set when the user toggles the Geode geometry debug overlay via the
   /// View menu.
   bool toggleGeometryDebugOverlay = false;
@@ -122,6 +126,7 @@ enum class MenuBarCommand {
   ActualSize,
   ToggleSourceFocusMode,
   ToggleCompositorDebugPanel,
+  ToggleCompositorTileOverlay,
   ToggleGeometryDebugOverlay,
   SetPerfOverlayOff,
   SetPerfOverlayFpsPill,
@@ -148,7 +153,8 @@ void ApplyMenuBarCommand(bool activated, MenuBarCommand command, const MenuBarSt
 ///   Optional (may be null) so callers without a document renderer skip it.
 void ApplyViewMenuToggleActions(const MenuBarActions& actions, bool* showCompositorDebugPanel,
                                 PerfOverlayMode* perfOverlayMode,
-                                bool* geometryDebugOverlay = nullptr);
+                                bool* geometryDebugOverlay = nullptr,
+                                bool* compositorTileOverlay = nullptr);
 
 /// Renders the app's top menu bar and reports semantic actions back to the shell.
 class MenuBarPresenter {

--- a/donner/editor/RenderPanePresenter.cc
+++ b/donner/editor/RenderPanePresenter.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cinttypes>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -504,8 +505,8 @@ void DrawCompositorTileOverlay(ImDrawList* drawList, const GlTextureCache::TileV
   }
 
   char label[64];
-  std::snprintf(label, sizeof(label), "%c %.24s g%llu%s", CompositorTileKindLabel(tile.kind),
-                tile.id.c_str(), static_cast<unsigned long long>(tile.generation),
+  std::snprintf(label, sizeof(label), "%c %.24s g%" PRIu64 "%s",
+                CompositorTileKindLabel(tile.kind), tile.id.c_str(), tile.generation,
                 tile.metadataOnly ? " cached" : "");
   const ImVec2 labelOrigin(static_cast<float>(bounds.topLeft.x + 4.0),
                            static_cast<float>(bounds.topLeft.y + 3.0));
@@ -738,11 +739,15 @@ void RenderPanePresenter::render(const RenderPanePresenterState& state) const {
     for (const auto& tile : state.textures.tiles()) {
       drawTile(tile);
     }
-    if (state.compositorTileOverlay) {
-      for (const auto& tile : state.textures.tiles()) {
-        if (const std::optional<PresentedTileQuad> tileQuad = computeTileQuad(tile)) {
-          DrawCompositorTileOverlay(paneDrawList, tile, *tileQuad);
-        }
+    paneDrawList->PopClipRect();
+  }
+  if (state.compositorTileOverlay && imageClipRect.has_value()) {
+    paneDrawList->PushClipRect(ToImVec2(imageClipRect->topLeft),
+                               ToImVec2(imageClipRect->bottomRight),
+                               /*intersect_with_current_clip_rect=*/true);
+    for (const auto& tile : state.textures.tiles()) {
+      if (const std::optional<PresentedTileQuad> tileQuad = computeTileQuad(tile)) {
+        DrawCompositorTileOverlay(paneDrawList, tile, *tileQuad);
       }
     }
     paneDrawList->PopClipRect();

--- a/donner/editor/RenderPanePresenter.cc
+++ b/donner/editor/RenderPanePresenter.cc
@@ -1,6 +1,7 @@
 #include "donner/editor/RenderPanePresenter.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -465,6 +466,57 @@ Box2d PresentedTileQuadBounds(const PresentedTileQuad& tileQuad) {
   return bounds;
 }
 
+ImU32 CompositorTileOverlayColor(const GlTextureCache::TileView& tile) {
+  if (tile.isDragTarget) {
+    return IM_COL32(255, 255, 255, tile.metadataOnly ? 150 : 245);
+  }
+
+  const int alpha = tile.metadataOnly ? 120 : 230;
+  switch (tile.kind) {
+    case RenderResult::CompositedTile::Kind::Segment: return IM_COL32(42, 214, 196, alpha);
+    case RenderResult::CompositedTile::Kind::Layer: return IM_COL32(255, 178, 66, alpha);
+    case RenderResult::CompositedTile::Kind::Immediate: return IM_COL32(255, 92, 138, alpha);
+  }
+  return IM_COL32(220, 220, 220, alpha);
+}
+
+char CompositorTileKindLabel(RenderResult::CompositedTile::Kind kind) {
+  switch (kind) {
+    case RenderResult::CompositedTile::Kind::Segment: return 'S';
+    case RenderResult::CompositedTile::Kind::Layer: return 'L';
+    case RenderResult::CompositedTile::Kind::Immediate: return 'I';
+  }
+  return '?';
+}
+
+void DrawCompositorTileOverlay(ImDrawList* drawList, const GlTextureCache::TileView& tile,
+                               const PresentedTileQuad& tileQuad) {
+  const ImU32 color = CompositorTileOverlayColor(tile);
+  const std::array<ImVec2, 4> points = {ToImVec2(tileQuad.topLeft), ToImVec2(tileQuad.topRight),
+                                        ToImVec2(tileQuad.bottomRight),
+                                        ToImVec2(tileQuad.bottomLeft)};
+  drawList->AddPolyline(points.data(), static_cast<int>(points.size()), color, ImDrawFlags_Closed,
+                        tile.isDragTarget ? 2.0f : 1.5f);
+
+  const Box2d bounds = PresentedTileQuadBounds(tileQuad);
+  if (bounds.width() < 44.0 || bounds.height() < ImGui::GetTextLineHeight() + 6.0) {
+    return;
+  }
+
+  char label[64];
+  std::snprintf(label, sizeof(label), "%c %.24s g%llu%s", CompositorTileKindLabel(tile.kind),
+                tile.id.c_str(), static_cast<unsigned long long>(tile.generation),
+                tile.metadataOnly ? " cached" : "");
+  const ImVec2 labelOrigin(static_cast<float>(bounds.topLeft.x + 4.0),
+                           static_cast<float>(bounds.topLeft.y + 3.0));
+  const ImVec2 labelSize = ImGui::CalcTextSize(label);
+  drawList->AddRectFilled(
+      ImVec2(labelOrigin.x - 2.0f, labelOrigin.y - 1.0f),
+      ImVec2(labelOrigin.x + labelSize.x + 2.0f, labelOrigin.y + labelSize.y + 1.0f),
+      IM_COL32(20, 22, 26, 210), 2.0f);
+  drawList->AddText(labelOrigin, color, label);
+}
+
 }  // namespace
 
 bool ShouldPresentCompositedTile(const GlTextureCache::TileView& tile, Entity suppressedLayerEntity,
@@ -685,6 +737,13 @@ void RenderPanePresenter::render(const RenderPanePresenterState& state) const {
     }
     for (const auto& tile : state.textures.tiles()) {
       drawTile(tile);
+    }
+    if (state.compositorTileOverlay) {
+      for (const auto& tile : state.textures.tiles()) {
+        if (const std::optional<PresentedTileQuad> tileQuad = computeTileQuad(tile)) {
+          DrawCompositorTileOverlay(paneDrawList, tile, *tileQuad);
+        }
+      }
     }
     paneDrawList->PopClipRect();
   }

--- a/donner/editor/RenderPanePresenter.h
+++ b/donner/editor/RenderPanePresenter.h
@@ -33,6 +33,7 @@ struct RenderPanePresenterState {
   Entity suppressedLayerEntity = entt::null;
   bool suppressDragTargetTiles = false;
   bool documentPresentedDirectly = false;
+  bool compositorTileOverlay = false;
   PerfOverlayMode perfOverlayMode = PerfOverlayMode::Off;
 };
 

--- a/donner/editor/SamplePickerPresenter.cc
+++ b/donner/editor/SamplePickerPresenter.cc
@@ -1,0 +1,182 @@
+#include "donner/editor/SamplePickerPresenter.h"
+
+#include <algorithm>
+#include <cmath>
+#include <span>
+
+#include "donner/editor/EditorTheme.h"
+#include "donner/editor/ImGuiIncludes.h"
+
+namespace donner::editor {
+namespace {
+
+constexpr float kGridGap = 12.0f;
+constexpr float kMinimumCardWidth = 220.0f;
+constexpr float kCardHeight = 72.0f;
+constexpr float kHeadingSpacing = 8.0f;
+#ifdef __EMSCRIPTEN__
+constexpr std::string_view kGitHubActionLabel = "View on GitHub";
+#else
+constexpr std::string_view kGitHubActionLabel = "Copy GitHub Link";
+#endif
+
+std::size_t BoundedSampleCount(std::size_t sampleCount) noexcept {
+  return std::min(sampleCount, kSamplePickerMaxVisibleSamples);
+}
+
+void DrawSampleButton(const EditorSample& sample, std::string_view description,
+                      const SamplePickerState& state, float width, float height,
+                      SamplePickerActions* actions, std::size_t index) {
+  const EditorTheme& theme = EditorTheme::Active();
+  ImGui::PushID(static_cast<int>(index));
+  const bool clicked = ImGui::InvisibleButton("##sample", ImVec2(width, height));
+  const ImVec2 min = ImGui::GetItemRectMin();
+  const ImVec2 max = ImGui::GetItemRectMax();
+  const bool hovered = ImGui::IsItemHovered();
+  const bool active = ImGui::IsItemActive();
+  const bool selected = state.selectedSampleId == sample.id;
+
+  ImU32 fill = theme.surfaceRaised;
+  if (active || selected) {
+    fill = theme.surfaceActive;
+  } else if (hovered) {
+    fill = theme.surfaceHover;
+  }
+  ImDrawList* drawList = ImGui::GetWindowDrawList();
+  drawList->AddRectFilled(min, max, fill, theme.radiusControl);
+  drawList->AddRect(min, max, selected ? theme.accentDefault : theme.borderSubtle,
+                    theme.radiusControl, 0, selected ? 2.0f : 1.0f);
+
+  const float textX = min.x + theme.space3;
+  const float titleY = min.y + theme.space2;
+  drawList->PushClipRect(min, max, true);
+  drawList->AddText(ImVec2(textX, titleY), theme.textPrimary, sample.title.data(),
+                    sample.title.data() + sample.title.size());
+  drawList->AddText(ImVec2(textX, titleY + ImGui::GetTextLineHeight() + 2.0f), theme.textMuted,
+                    description.data(), description.data() + description.size());
+  drawList->PopClipRect();
+
+  if (clicked) {
+    ApplySamplePickerCommand(true, SamplePickerCommand::LoadSample, sample.id, actions);
+  }
+  ImGui::PopID();
+}
+
+}  // namespace
+
+SamplePickerLayout ComputeSamplePickerLayout(float availableWidth,
+                                             std::size_t sampleCount) noexcept {
+  SamplePickerLayout layout;
+  const std::size_t boundedCount = BoundedSampleCount(sampleCount);
+  const float width = std::isfinite(availableWidth) ? std::max(0.0f, availableWidth) : 0.0f;
+  if (boundedCount == 0u) {
+    layout.columns = 0u;
+    layout.rows = 0u;
+    return layout;
+  }
+
+  if (width < kSamplePickerNarrowBreakpoint) {
+    layout.mode = SamplePickerLayoutMode::Narrow;
+    layout.columns = 1u;
+  } else {
+    layout.mode = SamplePickerLayoutMode::Wide;
+    const auto columnEstimate = static_cast<std::size_t>(
+        std::max(1.0f, std::floor((width + kGridGap) / (kMinimumCardWidth + kGridGap))));
+    layout.columns = std::clamp(columnEstimate, std::size_t{2}, kSamplePickerMaxColumns);
+    layout.columns = std::min(layout.columns, boundedCount);
+  }
+
+  layout.rows = (boundedCount + layout.columns - 1u) / layout.columns;
+  layout.cardWidth = std::max(0.0f, (width - kGridGap * static_cast<float>(layout.columns - 1u)) /
+                                        static_cast<float>(layout.columns));
+  layout.cardHeight = kCardHeight;
+  return layout;
+}
+
+std::string_view SamplePickerDescription(std::string_view sampleId) noexcept {
+  if (sampleId == "donner-splash") {
+    return "A quick look at Donner";
+  }
+  if (sampleId == "basic-shapes") {
+    return "Shapes, fills, and strokes";
+  }
+  if (sampleId == "text-style") {
+    return "Text and inherited styles";
+  }
+  if (sampleId == "gradients-clip") {
+    return "Gradients and clipping";
+  }
+  return "Built-in SVG sample";
+}
+
+void ApplySamplePickerCommand(bool activated, SamplePickerCommand command,
+                              std::string_view sampleId, SamplePickerActions* actions) {
+  if (!activated || actions == nullptr) {
+    return;
+  }
+
+  switch (command) {
+    case SamplePickerCommand::Dismiss: actions->dismiss = true; return;
+    case SamplePickerCommand::OpenFile: actions->openFile = true; return;
+    case SamplePickerCommand::LoadSample:
+      if (FindEditorSample(sampleId) != nullptr) {
+        actions->loadSample = true;
+        actions->sampleId.assign(sampleId.data(), sampleId.size());
+      }
+      return;
+    case SamplePickerCommand::OpenGitHub: actions->openGitHub = true; return;
+  }
+}
+
+SamplePickerActions SamplePickerPresenter::render(const SamplePickerState& state) const {
+  SamplePickerActions actions;
+  if (!state.visible) {
+    return actions;
+  }
+
+  const EditorTheme& theme = EditorTheme::Active();
+  const float availableWidth = ImGui::GetContentRegionAvail().x;
+  const std::span<const EditorSample> samples = GetEditorSampleCatalog();
+  const SamplePickerLayout layout = ComputeSamplePickerLayout(availableWidth, samples.size());
+
+  const float dismissSize = kSamplePickerMinTouchTarget;
+  ImGui::SetCursorPosX(std::max(0.0f, availableWidth - dismissSize));
+  if (ImGui::Button("X##dismiss_samples", ImVec2(dismissSize, dismissSize))) {
+    ApplySamplePickerCommand(true, SamplePickerCommand::Dismiss, {}, &actions);
+  }
+  if (ImGui::IsItemHovered()) {
+    ImGui::SetTooltip("Close samples");
+  }
+  ImGui::TextUnformatted("Donner");
+  ImGui::Spacing();
+  ImGui::TextWrapped("Edit SVG graphics and source together.");
+  ImGui::Dummy(ImVec2(0.0f, kHeadingSpacing));
+
+  const float openWidth = std::max(112.0f, ImGui::CalcTextSize("Open SVG").x + 2.0f * theme.space4);
+  if (ImGui::Button("Open SVG", ImVec2(openWidth, kSamplePickerMinTouchTarget))) {
+    ApplySamplePickerCommand(true, SamplePickerCommand::OpenFile, {}, &actions);
+  }
+  ImGui::SameLine(0.0f, theme.space2);
+  const float githubWidth =
+      std::max(128.0f, ImGui::CalcTextSize(kGitHubActionLabel.data()).x + 2.0f * theme.space4);
+  if (ImGui::Button(kGitHubActionLabel.data(), ImVec2(githubWidth, kSamplePickerMinTouchTarget))) {
+    ApplySamplePickerCommand(true, SamplePickerCommand::OpenGitHub, {}, &actions);
+  }
+  ImGui::Dummy(ImVec2(0.0f, theme.space3));
+
+  for (std::size_t index = 0; index < layout.rows * layout.columns; ++index) {
+    if (index >= samples.size() || index >= kSamplePickerMaxVisibleSamples) {
+      break;
+    }
+    if (index > 0u && index % layout.columns != 0u) {
+      ImGui::SameLine(0.0f, kGridGap);
+    }
+    const EditorSample& sample = samples[index];
+    DrawSampleButton(sample, SamplePickerDescription(sample.id), state, layout.cardWidth,
+                     layout.cardHeight, &actions, index);
+  }
+
+  return actions;
+}
+
+}  // namespace donner::editor

--- a/donner/editor/SamplePickerPresenter.h
+++ b/donner/editor/SamplePickerPresenter.h
@@ -1,0 +1,86 @@
+#pragma once
+/// @file
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+
+#include "donner/editor/EditorSampleCatalog.h"
+
+struct ImVec2;
+
+namespace donner::editor {
+
+/// Minimum logical height used by every primary picker action.
+inline constexpr float kSamplePickerMinTouchTarget = 44.0f;
+
+/// Width below which the picker keeps its sample actions in one column.
+inline constexpr float kSamplePickerNarrowBreakpoint = 640.0f;
+
+/// Maximum number of columns and visible catalog entries in the bounded surface.
+inline constexpr std::size_t kSamplePickerMaxColumns = 3;
+inline constexpr std::size_t kSamplePickerMaxVisibleSamples = 8;
+
+/// Public destination for the presenter's GitHub action. The presenter only
+/// reports the action; the host decides whether and how to navigate to it.
+inline constexpr std::string_view kSamplePickerGitHubUrl = "https://github.com/jwmcglynn/donner";
+
+enum class SamplePickerLayoutMode {
+  Narrow,
+  Wide,
+};
+
+/// Pure geometry for the sample grid. Values are logical pixels in the pane.
+struct SamplePickerLayout {
+  SamplePickerLayoutMode mode = SamplePickerLayoutMode::Narrow;
+  std::size_t columns = 1;
+  std::size_t rows = 0;
+  float cardWidth = 0.0f;
+  float cardHeight = kSamplePickerMinTouchTarget;
+};
+
+/// Compute a bounded, touch-sized grid without requiring an ImGui context.
+[[nodiscard]] SamplePickerLayout ComputeSamplePickerLayout(float availableWidth,
+                                                           std::size_t sampleCount) noexcept;
+
+/// Return the concise description used for a catalog sample card.
+[[nodiscard]] std::string_view SamplePickerDescription(std::string_view sampleId) noexcept;
+
+struct SamplePickerState {
+  /// The host can hide the welcome surface while a document-specific surface is active.
+  bool visible = true;
+  /// Stable catalog ID of the currently selected sample, if any.
+  std::string_view selectedSampleId;
+};
+
+/// Edge-triggered requests emitted by one rendered picker frame.
+struct SamplePickerActions {
+  bool dismiss = false;
+  bool openFile = false;
+  bool loadSample = false;
+  std::string sampleId;
+  bool openGitHub = false;
+};
+
+enum class SamplePickerCommand {
+  Dismiss,
+  OpenFile,
+  LoadSample,
+  OpenGitHub,
+};
+
+/// Apply a semantic picker command to an action accumulator.
+///
+/// This helper is deliberately independent of ImGui so command routing can be
+/// tested and kept separate from the presenter's drawing code.
+void ApplySamplePickerCommand(bool activated, SamplePickerCommand command,
+                              std::string_view sampleId, SamplePickerActions* actions);
+
+/// Draw the welcome/sample surface inside the current ImGui pane.
+class SamplePickerPresenter {
+public:
+  /// Render using the current pane's available width and return edge-triggered actions.
+  [[nodiscard]] SamplePickerActions render(const SamplePickerState& state) const;
+};
+
+}  // namespace donner::editor

--- a/donner/editor/main.cc
+++ b/donner/editor/main.cc
@@ -11,13 +11,12 @@
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
-
-#include "donner/editor/EditorSplash.h"
 #else
 #include "donner/base/FailureSignalHandler.h"
 #endif
 
 #include "donner/editor/EditorShell.h"
+#include "donner/editor/EditorSplash.h"
 #include "donner/editor/Notice.h"
 #include "donner/editor/TracyWrapper.h"
 #include "donner/editor/gui/EditorWindow.h"
@@ -122,12 +121,13 @@ int main(int argc, char** argv) {
   std::optional<std::string> initialSource;
   std::optional<std::string> initialPath;
   std::optional<std::string> reproOutputPath;
+  bool showWelcome = false;
 #ifdef __EMSCRIPTEN__
   initialSource = EmbeddedBytesToString(donner::embedded::kEditorSplashSvg);
-  initialPath = std::string("donner_splash.svg");
+  showWelcome = true;
 #else
   constexpr std::string_view kUsage =
-      "Usage: donner-editor [--experimental] [--save-repro <path>] <filename>\n";
+      "Usage: donner-editor [--experimental] [--save-repro <path>] [filename]\n";
   for (int i = 1; i < argc; ++i) {
     const std::string_view arg(argv[i]);
     if (arg == "--experimental") {
@@ -160,8 +160,8 @@ int main(int argc, char** argv) {
   }
 
   if (!svgPath.has_value()) {
-    std::cerr << kUsage;
-    return 1;
+    initialSource = EmbeddedBytesToString(donner::embedded::kEditorSplashSvg);
+    showWelcome = true;
   }
 #endif
 
@@ -184,6 +184,7 @@ int main(int argc, char** argv) {
                    .svgPath = svgPath.value_or(""),
                    .initialSource = initialSource,
                    .initialPath = initialPath,
+                   .showWelcome = showWelcome,
                    .editorNoticeText = EmbeddedBytesToString(donner::embedded::kEditorNoticeText),
                    .reproOutputPath = reproOutputPath});
   if (!shell->valid()) {

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -142,6 +142,15 @@ donner_cc_test(
 )
 
 donner_cc_test(
+    name = "sample_picker_presenter_tests",
+    srcs = ["SamplePickerPresenter_tests.cc"],
+    deps = [
+        "//donner/editor:sample_picker_presenter",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
     name = "editor_window_tests",
     srcs = ["EditorWindow_tests.cc"],
     data = [

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -130,6 +130,18 @@ donner_cc_test(
 )
 
 donner_cc_test(
+    name = "editor_sample_catalog_tests",
+    srcs = ["EditorSampleCatalog_tests.cc"],
+    deps = [
+        "//donner/base",
+        "//donner/editor:editor_sample_catalog",
+        "//donner/svg",
+        "//donner/svg/parser",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
     name = "editor_window_tests",
     srcs = ["EditorWindow_tests.cc"],
     data = [

--- a/donner/editor/tests/EditorApp_tests.cc
+++ b/donner/editor/tests/EditorApp_tests.cc
@@ -1860,6 +1860,96 @@ TEST(EditorAppReorderTest, ReflectsTheMoveIntoTheSourceText) {
   EXPECT_LT(r3, r1) << source;
 }
 
+TEST(EditorAppGroupTest, GroupsAdjacentElementsAndUndoRestoresExactSource) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(std::string(kThreeRects)));
+  const std::string sourceBefore(app.document().document().source());
+  const auto r1 = app.document().document().querySelector("#r1");
+  const auto r2 = app.document().document().querySelector("#r2");
+  ASSERT_TRUE(r1.has_value());
+  ASSERT_TRUE(r2.has_value());
+  app.setSelection(std::vector<svg::SVGElement>{*r2, *r1});
+
+  EXPECT_TRUE(app.groupSelectionAvailability().canApply);
+  ASSERT_TRUE(app.groupSelection());
+  ASSERT_TRUE(app.flushFrame());
+
+  const svg::SVGElement root = app.document().document().svgElement();
+  ASSERT_TRUE(root.firstChild().has_value());
+  const svg::SVGElement group = *root.firstChild();
+  EXPECT_EQ(group.tryType(), svg::ElementType::G);
+  ASSERT_TRUE(group.firstChild().has_value());
+  EXPECT_EQ(group.firstChild()->id(), "r1");
+  ASSERT_TRUE(group.firstChild()->nextSibling().has_value());
+  EXPECT_EQ(group.firstChild()->nextSibling()->id(), "r2");
+  ASSERT_TRUE(group.nextSibling().has_value());
+  EXPECT_EQ(group.nextSibling()->id(), "r3");
+  ASSERT_EQ(app.selectedElements().size(), 1u);
+  EXPECT_EQ(app.selectedElements().front(), group);
+
+  ASSERT_TRUE(app.canUndo());
+  app.undo();
+  ASSERT_TRUE(app.flushFrame());
+  EXPECT_EQ(std::string(app.document().document().source()), sourceBefore);
+  EXPECT_FALSE(app.canUndo());
+}
+
+TEST(EditorAppGroupTest, UngroupsAttributeFreeGroupAndSelectsChildren) {
+  constexpr std::string_view kGrouped =
+      R"(<svg xmlns="http://www.w3.org/2000/svg"><g><rect id="a"/><circle id="b"/></g><path id="c"/></svg>)";
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(std::string(kGrouped)));
+  const svg::SVGElement group = *app.document().document().svgElement().firstChild();
+  app.setSelection(group);
+
+  EXPECT_TRUE(app.ungroupSelectionAvailability().canApply);
+  ASSERT_TRUE(app.ungroupSelection());
+  ASSERT_TRUE(app.flushFrame());
+
+  EXPECT_THAT(ChildIds(app), ::testing::ElementsAre("a", "b", "c"));
+  ASSERT_EQ(app.selectedElements().size(), 2u);
+  EXPECT_EQ(app.selectedElements()[0].id(), "a");
+  EXPECT_EQ(app.selectedElements()[1].id(), "b");
+  EXPECT_TRUE(app.canUndo());
+}
+
+TEST(EditorAppGroupTest, RefusesNonAdjacentSelectionAndAttributedUngroup) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(std::string(kThreeRects)));
+  const auto r1 = app.document().document().querySelector("#r1");
+  const auto r3 = app.document().document().querySelector("#r3");
+  ASSERT_TRUE(r1.has_value());
+  ASSERT_TRUE(r3.has_value());
+  app.setSelection(std::vector<svg::SVGElement>{*r1, *r3});
+  EXPECT_FALSE(app.groupSelectionAvailability().canApply);
+  EXPECT_FALSE(app.groupSelection());
+
+  ASSERT_TRUE(app.loadFromString(R"svg(<svg xmlns="http://www.w3.org/2000/svg">
+    <g transform="translate(2 3)"><rect/></g>
+  </svg>)svg"));
+  app.setSelection(*app.document().document().svgElement().firstChild());
+  EXPECT_FALSE(app.ungroupSelectionAvailability().canApply);
+  EXPECT_FALSE(app.ungroupSelection());
+}
+
+TEST(EditorAppGroupTest, GroupSelectionRemainsInsideIsolatedScope) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(
+      R"(<svg xmlns="http://www.w3.org/2000/svg"><g id="scope"><rect id="a"/><circle id="b"/></g></svg>)"));
+  const svg::SVGElement scope = *app.document().document().querySelector("#scope");
+  ASSERT_TRUE(app.enterGroupEdit(scope));
+  const svg::SVGElement a = *app.document().document().querySelector("#a");
+  const svg::SVGElement b = *app.document().document().querySelector("#b");
+  app.setSelection(std::vector<svg::SVGElement>{a, b});
+
+  ASSERT_TRUE(app.groupSelection());
+  ASSERT_TRUE(app.flushFrame());
+  ASSERT_EQ(app.selectedElements().size(), 1u);
+  EXPECT_EQ(app.selectedElements().front().tryType(), svg::ElementType::G);
+  EXPECT_EQ(app.selectedElements().front().parentElement(), scope);
+  EXPECT_EQ(app.editingScope(), scope);
+}
+
 TEST(EditorAppReorderTest, NoOpWhenAlreadyAtExtreme) {
   EditorApp app;
   ASSERT_TRUE(app.loadFromString(std::string(kThreeRects)));

--- a/donner/editor/tests/EditorSampleCatalog_tests.cc
+++ b/donner/editor/tests/EditorSampleCatalog_tests.cc
@@ -1,0 +1,68 @@
+#include "donner/editor/EditorSampleCatalog.h"
+
+#include <array>
+#include <cctype>
+#include <optional>
+#include <string_view>
+#include <unordered_set>
+#include <utility>
+
+#include "donner/base/Box.h"
+#include "donner/base/ParseWarningSink.h"
+#include "donner/svg/SVGSVGElement.h"
+#include "donner/svg/parser/SVGParser.h"
+#include "gtest/gtest.h"
+
+namespace donner::editor {
+namespace {
+
+TEST(EditorSampleCatalog, HasStableUniqueAsciiIdsInDisplayOrder) {
+  const std::span<const EditorSample> samples = GetEditorSampleCatalog();
+  ASSERT_EQ(samples.size(), 4u);
+
+  constexpr std::array<std::string_view, 4> kExpectedIds = {"donner-splash", "basic-shapes",
+                                                            "text-style", "gradients-clip"};
+  std::unordered_set<std::string_view> ids;
+  for (std::size_t i = 0; i < samples.size(); ++i) {
+    EXPECT_EQ(samples[i].id, kExpectedIds[i]);
+    EXPECT_TRUE(ids.insert(samples[i].id).second);
+    for (const unsigned char character : samples[i].id) {
+      EXPECT_LT(character, 0x80u);
+      EXPECT_TRUE(std::isalnum(character) || character == '-')
+          << "non-stable ID character in " << samples[i].id;
+    }
+  }
+}
+
+TEST(EditorSampleCatalog, EntriesHaveTitlesAndSources) {
+  for (const EditorSample& sample : GetEditorSampleCatalog()) {
+    EXPECT_FALSE(sample.id.empty());
+    EXPECT_FALSE(sample.title.empty()) << sample.id;
+    EXPECT_FALSE(sample.source.empty()) << sample.id;
+    EXPECT_EQ(FindEditorSample(sample.id), &sample);
+  }
+  EXPECT_EQ(FindEditorSample("missing-sample"), nullptr);
+}
+
+TEST(EditorSampleCatalog, SourcesParseWithUsableRootDimensions) {
+  for (const EditorSample& sample : GetEditorSampleCatalog()) {
+    ParseWarningSink warningSink = ParseWarningSink::Disabled();
+    auto result = svg::parser::SVGParser::ParseSVG(sample.source, warningSink);
+    ASSERT_FALSE(result.hasError()) << sample.id << ": " << result.error();
+
+    svg::SVGDocument document = std::move(result).result();
+    const svg::SVGSVGElement root = document.svgElement();
+    const std::optional<Box2d> viewBox = root.viewBox();
+    ASSERT_TRUE(viewBox.has_value()) << sample.id << " has no viewBox";
+    EXPECT_GT(viewBox->width(), 0.0) << sample.id;
+    EXPECT_GT(viewBox->height(), 0.0) << sample.id;
+
+    ASSERT_TRUE(root.width().has_value()) << sample.id << " has no width";
+    ASSERT_TRUE(root.height().has_value()) << sample.id << " has no height";
+    EXPECT_GT(root.width()->value, 0.0) << sample.id;
+    EXPECT_GT(root.height()->value, 0.0) << sample.id;
+  }
+}
+
+}  // namespace
+}  // namespace donner::editor

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -630,7 +630,7 @@ public:
   }
 
   static void QueueSampleLoad(EditorShell& shell, std::string sampleId) {
-    shell.pendingSampleLoadId_ = std::move(sampleId);
+    shell.queuePendingSampleLoad(std::move(sampleId));
     shell.showSamplePicker_ = true;
   }
 
@@ -638,6 +638,14 @@ public:
 
   static std::string_view PendingSampleLoad(const EditorShell& shell) {
     return shell.pendingSampleLoadId_;
+  }
+
+  static bool PendingSampleLoadNeedsConfirmation(const EditorShell& shell) {
+    return shell.pendingSampleLoadNeedsConfirmation_;
+  }
+
+  static void ConfirmPendingSampleLoadDiscard(EditorShell& shell) {
+    shell.confirmPendingSampleLoadDiscard();
   }
 
   static void RequestSave(EditorShell& shell) { shell.requestSave(); }
@@ -1793,9 +1801,45 @@ TEST(EditorShellTest, GroupDispatchFlushesAtomicallyAndDeferredSampleWaitsForQue
 
   ASSERT_TRUE(app.flushFrame());
   EditorShellTestAccess::ProcessPendingSampleLoad(shell);
+  EXPECT_TRUE(EditorShellTestAccess::PendingSampleLoadNeedsConfirmation(shell));
+  EXPECT_EQ(EditorShellTestAccess::PendingSampleLoad(shell), "basic-shapes");
+  EditorShellTestAccess::ConfirmPendingSampleLoadDiscard(shell);
+  EditorShellTestAccess::ProcessPendingSampleLoad(shell);
   EXPECT_TRUE(EditorShellTestAccess::PendingSampleLoad(shell).empty());
   EXPECT_TRUE(app.document().document().querySelector("polygon").has_value());
   EXPECT_FALSE(app.currentFilePath().has_value());
+}
+
+TEST(EditorShellTest, SampleLoadRequiresConfirmationForPendingSourceEdits) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+  EditorShellTestAccess::Source(shell).setText("<svg>unsaved</svg>");
+  EditorShellTestAccess::QueueSampleLoad(shell, "basic-shapes");
+
+  EditorShellTestAccess::ProcessPendingSampleLoad(shell);
+
+  EXPECT_TRUE(EditorShellTestAccess::PendingSampleLoadNeedsConfirmation(shell));
+  EXPECT_EQ(EditorShellTestAccess::PendingSampleLoad(shell), "basic-shapes");
+  EXPECT_FALSE(EditorShellTestAccess::App(shell)
+                   .document()
+                   .document()
+                   .querySelector("polygon")
+                   .has_value());
+
+  EditorShellTestAccess::ConfirmPendingSampleLoadDiscard(shell);
+  EditorShellTestAccess::ProcessPendingSampleLoad(shell);
+
+  EXPECT_TRUE(EditorShellTestAccess::PendingSampleLoad(shell).empty());
+  EXPECT_TRUE(EditorShellTestAccess::App(shell)
+                  .document()
+                  .document()
+                  .querySelector("polygon")
+                  .has_value());
 }
 
 TEST(EditorShellTest, NewerFileAndRevertRequestsCancelDeferredSampleReplacement) {

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -306,20 +306,42 @@ TEST(EditorShellInternalTest, TextFormatBarCapturesCanvasInputWithinItsLayoutRec
   EXPECT_DOUBLE_EQ(formatBarRect->width(), TextFormatBarPresenter::PreferredWidth());
 
   const Box2d referenceChipRect = Box2d::FromXYWH(20.0, 300.0, 80.0, 24.0);
+  const Box2d editingScopeBreadcrumbRect = Box2d::FromXYWH(20.0, 40.0, 96.0, 32.0);
   const Box2d zoomControlRect = Box2d::FromXYWH(520.0, 320.0, 48.0, 28.0);
   const ImVec2 formatControlPoint(static_cast<float>(formatBarRect->topLeft.x + 20.0),
                                   static_cast<float>(formatBarRect->topLeft.y + 20.0));
   EXPECT_TRUE(internal::CanvasChromeCapturesInput(formatControlPoint, referenceChipRect,
-                                                  toolPaletteRect, formatBarRect, std::nullopt,
-                                                  zoomControlRect));
-  EXPECT_FALSE(internal::CanvasChromeCapturesInput(
-      ImVec2(150.0f, 220.0f), referenceChipRect, toolPaletteRect, formatBarRect, std::nullopt,
-      zoomControlRect));
+                                                  toolPaletteRect, formatBarRect,
+                                                  editingScopeBreadcrumbRect, zoomControlRect));
+  EXPECT_TRUE(internal::CanvasChromeCapturesInput(ImVec2(40.0f, 50.0f), referenceChipRect,
+                                                  toolPaletteRect, formatBarRect,
+                                                  editingScopeBreadcrumbRect, zoomControlRect));
+  EXPECT_FALSE(internal::CanvasChromeCapturesInput(ImVec2(150.0f, 220.0f), referenceChipRect,
+                                                   toolPaletteRect, formatBarRect,
+                                                   editingScopeBreadcrumbRect, zoomControlRect));
 
   EXPECT_FALSE(internal::TextFormatBarScreenRect(ImVec2(10.0f, 20.0f), ImVec2(580.0f, 360.0f),
                                                  toolPaletteRect,
                                                  /*visible=*/false, /*barHeight=*/48.0f)
                    .has_value());
+}
+
+TEST(EditorShellInternalTest, StructuralDocumentActionsWaitForExclusiveDomOwnership) {
+  EXPECT_FALSE(internal::GroupOperationCanDispatch(
+      /*rendererBusy=*/true, GroupOperationAvailability{.canApply = true}));
+  EXPECT_FALSE(internal::GroupOperationCanDispatch(
+      /*rendererBusy=*/false, GroupOperationAvailability{.reason = "Select more elements"}));
+  EXPECT_TRUE(internal::GroupOperationCanDispatch(
+      /*rendererBusy=*/false, GroupOperationAvailability{.canApply = true}));
+
+  EXPECT_FALSE(internal::PendingDocumentReplacementCanProcess(
+      /*hasPendingRequest=*/false, /*rendererBusy=*/false, /*hasPendingMutations=*/false));
+  EXPECT_FALSE(internal::PendingDocumentReplacementCanProcess(
+      /*hasPendingRequest=*/true, /*rendererBusy=*/true, /*hasPendingMutations=*/false));
+  EXPECT_FALSE(internal::PendingDocumentReplacementCanProcess(
+      /*hasPendingRequest=*/true, /*rendererBusy=*/false, /*hasPendingMutations=*/true));
+  EXPECT_TRUE(internal::PendingDocumentReplacementCanProcess(
+      /*hasPendingRequest=*/true, /*rendererBusy=*/false, /*hasPendingMutations=*/false));
 }
 
 TEST(EditorShellInternalTest, PendingClickBusyActionPrefersFastRedragThenCancelsBusyRender) {
@@ -602,6 +624,21 @@ public:
   }
 
   static void RequestRevert(EditorShell& shell) { shell.requestRevert(); }
+
+  static bool TryApplyGroupOperation(EditorShell& shell, bool ungroup) {
+    return shell.tryApplyGroupOperation(ungroup);
+  }
+
+  static void QueueSampleLoad(EditorShell& shell, std::string sampleId) {
+    shell.pendingSampleLoadId_ = std::move(sampleId);
+    shell.showSamplePicker_ = true;
+  }
+
+  static void ProcessPendingSampleLoad(EditorShell& shell) { shell.processPendingSampleLoad(); }
+
+  static std::string_view PendingSampleLoad(const EditorShell& shell) {
+    return shell.pendingSampleLoadId_;
+  }
 
   static void RequestSave(EditorShell& shell) { shell.requestSave(); }
 
@@ -1720,6 +1757,80 @@ TEST(EditorShellTest, OpenSaveAndRevertUpdateDocumentAndSourceState) {
 
   EXPECT_FALSE(EditorShellTestAccess::App(shell).isDirty());
   EXPECT_NE(EditorShellTestAccess::Source(shell).getText().find("opened"), std::string::npos);
+}
+
+TEST(EditorShellTest, GroupDispatchFlushesAtomicallyAndDeferredSampleWaitsForQueuedEdits) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  constexpr std::string_view kGroupableSvg = R"svg(<svg xmlns="http://www.w3.org/2000/svg">
+    <rect id="a"/><circle id="b"/>
+  </svg>)svg";
+  EditorShell shell(window, OptionsWithSource(kGroupableSvg, "groupable.svg"));
+  ASSERT_TRUE(shell.valid());
+  EditorApp& app = EditorShellTestAccess::App(shell);
+  const svg::SVGElement a = *app.document().document().querySelector("#a");
+  const svg::SVGElement b = *app.document().document().querySelector("#b");
+  app.setSelection(std::vector<svg::SVGElement>{a, b});
+
+  ASSERT_TRUE(EditorShellTestAccess::TryApplyGroupOperation(shell, /*ungroup=*/false));
+  EXPECT_FALSE(app.document().hasPendingMutations());
+  ASSERT_EQ(app.selectedElements().size(), 1u);
+  EXPECT_EQ(app.selectedElements().front().tryType(), svg::ElementType::G);
+
+  ASSERT_TRUE(EditorShellTestAccess::TryApplyGroupOperation(shell, /*ungroup=*/true));
+  EXPECT_FALSE(app.document().hasPendingMutations());
+  ASSERT_EQ(app.selectedElements().size(), 2u);
+
+  ASSERT_TRUE(app.groupSelection());
+  ASSERT_TRUE(app.document().hasPendingMutations());
+  EditorShellTestAccess::QueueSampleLoad(shell, "basic-shapes");
+  EditorShellTestAccess::ProcessPendingSampleLoad(shell);
+  EXPECT_EQ(EditorShellTestAccess::PendingSampleLoad(shell), "basic-shapes");
+  EXPECT_FALSE(app.document().document().querySelector("polygon").has_value());
+
+  ASSERT_TRUE(app.flushFrame());
+  EditorShellTestAccess::ProcessPendingSampleLoad(shell);
+  EXPECT_TRUE(EditorShellTestAccess::PendingSampleLoad(shell).empty());
+  EXPECT_TRUE(app.document().document().querySelector("polygon").has_value());
+  EXPECT_FALSE(app.currentFilePath().has_value());
+}
+
+TEST(EditorShellTest, NewerFileAndRevertRequestsCancelDeferredSampleReplacement) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+  EditorShellTestAccess::QueueSampleLoad(shell, "basic-shapes");
+
+  const std::filesystem::path openPath = TempPathForTest("sample-cancel-open.svg");
+  constexpr std::string_view kOpenedSvg =
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg"><rect id="newer-file"/></svg>)svg";
+  WriteTextFile(openPath, kOpenedSvg);
+  std::string error;
+  ASSERT_TRUE(EditorShellTestAccess::TryOpenPath(shell, openPath.string(), &error)) << error;
+  EXPECT_TRUE(EditorShellTestAccess::PendingSampleLoad(shell).empty());
+  EXPECT_TRUE(EditorShellTestAccess::App(shell)
+                  .document()
+                  .document()
+                  .querySelector("#newer-file")
+                  .has_value());
+
+  EditorShellTestAccess::QueueSampleLoad(shell, "gradients-clip");
+  EditorShellTestAccess::Source(shell).setText("<svg>dirty</svg>");
+  EditorShellTestAccess::App(shell).markDirty();
+  EditorShellTestAccess::RequestRevert(shell);
+  EXPECT_TRUE(EditorShellTestAccess::PendingSampleLoad(shell).empty());
+  EXPECT_TRUE(EditorShellTestAccess::App(shell)
+                  .document()
+                  .document()
+                  .querySelector("#newer-file")
+                  .has_value());
 }
 
 TEST(EditorShellTest, RevertRequestIgnoresGuardStates) {

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -619,6 +619,12 @@ public:
     return shell.tryOpenPath(path, error);
   }
 
+  static void SetShowSamplePicker(EditorShell& shell, bool visible) {
+    shell.showSamplePicker_ = visible;
+  }
+
+  static bool ShowSamplePicker(const EditorShell& shell) { return shell.showSamplePicker_; }
+
   static bool TrySavePath(EditorShell& shell, std::string_view path, std::string* error) {
     return shell.trySavePath(path, error);
   }
@@ -1718,10 +1724,13 @@ TEST(EditorShellTest, OpenSaveAndRevertUpdateDocumentAndSourceState) {
   EditorShell shell(window, OptionsWithSource(kInitialSvg));
   ASSERT_TRUE(shell.valid());
 
+  EditorShellTestAccess::SetShowSamplePicker(shell, true);
+
   std::string error;
   EXPECT_FALSE(
       EditorShellTestAccess::TryOpenPath(shell, TempPathForTest("missing.svg").string(), &error));
   EXPECT_EQ(error, "Could not open file.");
+  EXPECT_TRUE(EditorShellTestAccess::ShowSamplePicker(shell));
 
   const std::filesystem::path invalidPath = TempPathForTest("invalid.svg");
   WriteTextFile(invalidPath, "<svg><rect></svg>");
@@ -1737,6 +1746,7 @@ TEST(EditorShellTest, OpenSaveAndRevertUpdateDocumentAndSourceState) {
   EXPECT_TRUE(EditorShellTestAccess::TryOpenPath(shell, openPath.string(), &error)) << error;
   EXPECT_TRUE(EditorShellTestAccess::App(shell).hasDocument());
   EXPECT_NE(EditorShellTestAccess::Source(shell).getText().find("opened"), std::string::npos);
+  EXPECT_FALSE(EditorShellTestAccess::ShowSamplePicker(shell));
 
   error.clear();
   EXPECT_FALSE(EditorShellTestAccess::TrySavePath(shell, "", &error));

--- a/donner/editor/tests/MenuBarPresenter_tests.cc
+++ b/donner/editor/tests/MenuBarPresenter_tests.cc
@@ -143,12 +143,14 @@ TEST_F(MenuBarPresenterTest, RendersEachOpenMenuWithoutImplicitActions) {
     EXPECT_FALSE(actions.actualSize) << menuLabel;
     EXPECT_FALSE(actions.toggleSourceFocusMode) << menuLabel;
     EXPECT_FALSE(actions.toggleCompositorDebugPanel) << menuLabel;
+    EXPECT_FALSE(actions.toggleCompositorTileOverlay) << menuLabel;
     EXPECT_FALSE(actions.setPerfOverlayMode) << menuLabel;
   }
 }
 
 TEST(MenuBarPresenterActionsTest, ApplyViewMenuToggleActionsHandlesNullAndIndependentToggles) {
   bool showCompositorDebugPanel = false;
+  bool compositorTileOverlay = false;
   PerfOverlayMode perfOverlayMode = PerfOverlayMode::Off;
 
   ApplyViewMenuToggleActions(MenuBarActions{}, &showCompositorDebugPanel, &perfOverlayMode);
@@ -160,6 +162,11 @@ TEST(MenuBarPresenterActionsTest, ApplyViewMenuToggleActionsHandlesNullAndIndepe
   ApplyViewMenuToggleActions(actions, &showCompositorDebugPanel, nullptr);
   EXPECT_TRUE(showCompositorDebugPanel);
   EXPECT_EQ(perfOverlayMode, PerfOverlayMode::Off);
+
+  actions = MenuBarActions{};
+  actions.toggleCompositorTileOverlay = true;
+  ApplyViewMenuToggleActions(actions, nullptr, nullptr, nullptr, &compositorTileOverlay);
+  EXPECT_TRUE(compositorTileOverlay);
 
   actions = MenuBarActions{};
   actions.setPerfOverlayMode = true;
@@ -268,6 +275,10 @@ TEST(MenuBarPresenterActionsTest, ApplyMenuBarCommandMapsSimpleCommandsToActions
   actions = MenuBarActions{};
   ApplyMenuBarCommand(true, MenuBarCommand::ToggleCompositorDebugPanel, state, &actions);
   EXPECT_TRUE(actions.toggleCompositorDebugPanel);
+
+  actions = MenuBarActions{};
+  ApplyMenuBarCommand(true, MenuBarCommand::ToggleCompositorTileOverlay, state, &actions);
+  EXPECT_TRUE(actions.toggleCompositorTileOverlay);
 
   actions = MenuBarActions{};
   ApplyMenuBarCommand(true, MenuBarCommand::SetPerfOverlayOff, state, &actions);

--- a/donner/editor/tests/MenuBarPresenter_tests.cc
+++ b/donner/editor/tests/MenuBarPresenter_tests.cc
@@ -121,6 +121,7 @@ TEST_F(MenuBarPresenterTest, RendersEachOpenMenuWithoutImplicitActions) {
     const MenuBarActions actions = RenderFrame(state);
     EXPECT_FALSE(actions.openAbout) << menuLabel;
     EXPECT_FALSE(actions.openFile) << menuLabel;
+    EXPECT_FALSE(actions.openSamples) << menuLabel;
     EXPECT_FALSE(actions.saveFile) << menuLabel;
     EXPECT_FALSE(actions.saveFileAs) << menuLabel;
     EXPECT_FALSE(actions.exportViewportSvg) << menuLabel;
@@ -134,6 +135,8 @@ TEST_F(MenuBarPresenterTest, RendersEachOpenMenuWithoutImplicitActions) {
     EXPECT_FALSE(actions.paste) << menuLabel;
     EXPECT_FALSE(actions.pasteInFront) << menuLabel;
     EXPECT_FALSE(actions.convertTextToOutlines) << menuLabel;
+    EXPECT_FALSE(actions.group) << menuLabel;
+    EXPECT_FALSE(actions.ungroup) << menuLabel;
     EXPECT_FALSE(actions.selectAll) << menuLabel;
     EXPECT_FALSE(actions.selectAllCanvas) << menuLabel;
     EXPECT_FALSE(actions.deselectAll) << menuLabel;
@@ -205,6 +208,10 @@ TEST(MenuBarPresenterActionsTest, ApplyMenuBarCommandMapsSimpleCommandsToActions
   EXPECT_TRUE(actions.openFile);
 
   actions = MenuBarActions{};
+  ApplyMenuBarCommand(true, MenuBarCommand::OpenSamples, state, &actions);
+  EXPECT_TRUE(actions.openSamples);
+
+  actions = MenuBarActions{};
   ApplyMenuBarCommand(true, MenuBarCommand::SaveFile, state, &actions);
   EXPECT_TRUE(actions.saveFile);
 
@@ -255,6 +262,14 @@ TEST(MenuBarPresenterActionsTest, ApplyMenuBarCommandMapsSimpleCommandsToActions
   actions = MenuBarActions{};
   ApplyMenuBarCommand(true, MenuBarCommand::ConvertTextToOutlines, state, &actions);
   EXPECT_TRUE(actions.convertTextToOutlines);
+
+  actions = MenuBarActions{};
+  ApplyMenuBarCommand(true, MenuBarCommand::Group, state, &actions);
+  EXPECT_TRUE(actions.group);
+
+  actions = MenuBarActions{};
+  ApplyMenuBarCommand(true, MenuBarCommand::Ungroup, state, &actions);
+  EXPECT_TRUE(actions.ungroup);
 
   actions = MenuBarActions{};
   ApplyMenuBarCommand(true, MenuBarCommand::ZoomIn, state, &actions);

--- a/donner/editor/tests/RenderPanePresenterVisualRepro_tests.cc
+++ b/donner/editor/tests/RenderPanePresenterVisualRepro_tests.cc
@@ -138,7 +138,8 @@ void WriteDiagnosticBitmap(const svg::RendererBitmap& bitmap, std::string_view f
 svg::RendererBitmap CapturePresenterFrame(
     gui::EditorWindow* window, GlTextureCache* textures, Entity suppressedLayerEntity,
     std::optional<SelectTool::ActiveDragPreview> activePreview = std::nullopt,
-    std::optional<SelectTool::ActiveDragPreview> displayedPreview = std::nullopt) {
+    std::optional<SelectTool::ActiveDragPreview> displayedPreview = std::nullopt,
+    bool documentPresentedDirectly = false, bool compositorTileOverlay = false) {
   ViewportState viewport;
   viewport.paneOrigin = Vector2d(0.0, 0.0);
   viewport.paneSize = Vector2d(kLogicalWidth, kLogicalHeight);
@@ -176,6 +177,8 @@ svg::RendererBitmap CapturePresenterFrame(
       .displayedDragPreview = displayedPreview,
       .contentRegion = Vector2d(kLogicalWidth, kLogicalHeight),
       .suppressedLayerEntity = suppressedLayerEntity,
+      .documentPresentedDirectly = documentPresentedDirectly,
+      .compositorTileOverlay = compositorTileOverlay,
   });
   ImGui::End();
   ImGui::PopStyleVar();
@@ -266,6 +269,55 @@ TEST(RenderPanePresenterVisualReproTest, WritesDisplayNoneSuppressionScreenshots
   EXPECT_GT(expectedVisiblePixels, 2500)
       << "The expected screenshot should keep the selected drag target visible while the "
          "display:none layer is suppressed.";
+}
+
+TEST(RenderPanePresenterVisualReproTest, CompositorTileOverlayRendersDuringDirectPresentation) {
+  gui::EditorWindow window(gui::EditorWindowOptions{
+      .title = "Direct Presentation Compositor Tile Overlay Repro",
+      .initialWidth = kLogicalWidth,
+      .initialHeight = kLogicalHeight,
+      .visible = false,
+      .offscreen = true,
+      .offscreenContentScale = 1.0,
+      .clearColor = {0.08f, 0.09f, 0.10f, 1.0f},
+      .enableFramebufferReadback = true,
+  });
+  if (!window.valid()) {
+    GTEST_SKIP() << "Hidden editor window is unavailable on this host";
+  }
+
+  RenderResult::CompositedPreview preview;
+  preview.tiles.push_back(MakeTile(
+      "layer:7", RenderResult::CompositedTile::Kind::Layer, kVisibleDragEntity,
+      Vector2d(54.0, 44.0), Vector2d(78.0, 78.0), kVisibleDragLayer, /*isDragTarget=*/false));
+
+  GlTextureCache textures(window.geodeDevice());
+  textures.initialize();
+  textures.uploadComposited(preview);
+
+  const svg::RendererBitmap withoutOverlay =
+      CapturePresenterFrame(&window, &textures, entt::null, std::nullopt, std::nullopt,
+                            /*documentPresentedDirectly=*/true,
+                            /*compositorTileOverlay=*/false);
+  const svg::RendererBitmap withOverlay =
+      CapturePresenterFrame(&window, &textures, entt::null, std::nullopt, std::nullopt,
+                            /*documentPresentedDirectly=*/true,
+                            /*compositorTileOverlay=*/true);
+
+  ASSERT_FALSE(withoutOverlay.empty());
+  ASSERT_FALSE(withOverlay.empty());
+  int changedPixels = 0;
+  for (std::size_t offset = 0; offset + 3u < withOverlay.pixels.size(); offset += 4u) {
+    if (withOverlay.pixels[offset + 0u] != withoutOverlay.pixels[offset + 0u] ||
+        withOverlay.pixels[offset + 1u] != withoutOverlay.pixels[offset + 1u] ||
+        withOverlay.pixels[offset + 2u] != withoutOverlay.pixels[offset + 2u] ||
+        withOverlay.pixels[offset + 3u] != withoutOverlay.pixels[offset + 3u]) {
+      ++changedPixels;
+    }
+  }
+  EXPECT_GT(changedPixels, 0)
+      << "The compositor tile overlay must remain visible when document pixels are presented "
+         "directly to the framebuffer.";
 }
 
 TEST(RenderPanePresenterVisualReproTest, OverviewInfillDoesNotBleedThroughTransparentActiveTile) {

--- a/donner/editor/tests/SamplePickerPresenter_tests.cc
+++ b/donner/editor/tests/SamplePickerPresenter_tests.cc
@@ -1,0 +1,101 @@
+#include "donner/editor/SamplePickerPresenter.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <string_view>
+
+namespace donner::editor {
+namespace {
+
+TEST(SamplePickerPresenter, NarrowLayoutUsesOneTouchSizedColumn) {
+  const SamplePickerLayout layout = ComputeSamplePickerLayout(480.0f, 4u);
+
+  EXPECT_EQ(layout.mode, SamplePickerLayoutMode::Narrow);
+  EXPECT_EQ(layout.columns, 1u);
+  EXPECT_EQ(layout.rows, 4u);
+  EXPECT_GE(layout.cardWidth, 0.0f);
+  EXPECT_GE(layout.cardHeight, kSamplePickerMinTouchTarget);
+}
+
+TEST(SamplePickerPresenter, WideLayoutUsesCompactBoundedColumns) {
+  const SamplePickerLayout layout = ComputeSamplePickerLayout(1024.0f, 4u);
+
+  EXPECT_EQ(layout.mode, SamplePickerLayoutMode::Wide);
+  EXPECT_EQ(layout.columns, 3u);
+  EXPECT_EQ(layout.rows, 2u);
+  EXPECT_GT(layout.cardWidth, 0.0f);
+  EXPECT_GE(layout.cardHeight, kSamplePickerMinTouchTarget);
+  EXPECT_FLOAT_EQ(layout.cardWidth * 3.0f + 12.0f * 2.0f, 1024.0f);
+}
+
+TEST(SamplePickerPresenter, LayoutClampsInvalidWidthAndVisibleCount) {
+  const SamplePickerLayout layout =
+      ComputeSamplePickerLayout(-20.0f, kSamplePickerMaxVisibleSamples + 4u);
+
+  EXPECT_EQ(layout.mode, SamplePickerLayoutMode::Narrow);
+  EXPECT_EQ(layout.columns, 1u);
+  EXPECT_EQ(layout.rows, kSamplePickerMaxVisibleSamples);
+  EXPECT_FLOAT_EQ(layout.cardWidth, 0.0f);
+}
+
+TEST(SamplePickerPresenter, EmptyCatalogLayoutHasNoRowsOrColumns) {
+  const SamplePickerLayout layout = ComputeSamplePickerLayout(800.0f, 0u);
+
+  EXPECT_EQ(layout.columns, 0u);
+  EXPECT_EQ(layout.rows, 0u);
+  EXPECT_FLOAT_EQ(layout.cardWidth, 0.0f);
+}
+
+TEST(SamplePickerPresenter, DescriptionsCoverCatalogAndFallback) {
+  constexpr std::array<std::string_view, 4> kSampleIds = {"donner-splash", "basic-shapes",
+                                                          "text-style", "gradients-clip"};
+  for (const std::string_view id : kSampleIds) {
+    EXPECT_FALSE(SamplePickerDescription(id).empty());
+  }
+  EXPECT_EQ(SamplePickerDescription("unknown"), "Built-in SVG sample");
+}
+
+TEST(SamplePickerPresenter, CommandsProduceSemanticActions) {
+  SamplePickerActions actions;
+
+  ApplySamplePickerCommand(true, SamplePickerCommand::Dismiss, {}, &actions);
+  EXPECT_TRUE(actions.dismiss);
+
+  actions = SamplePickerActions{};
+  ApplySamplePickerCommand(true, SamplePickerCommand::OpenFile, {}, &actions);
+  EXPECT_TRUE(actions.openFile);
+
+  actions = SamplePickerActions{};
+
+  ApplySamplePickerCommand(false, SamplePickerCommand::LoadSample, "basic-shapes", &actions);
+  EXPECT_FALSE(actions.loadSample);
+  EXPECT_TRUE(actions.sampleId.empty());
+
+  ApplySamplePickerCommand(true, SamplePickerCommand::LoadSample, "basic-shapes", &actions);
+  EXPECT_TRUE(actions.loadSample);
+  EXPECT_EQ(actions.sampleId, "basic-shapes");
+  EXPECT_FALSE(actions.openGitHub);
+
+  actions = SamplePickerActions{};
+  ApplySamplePickerCommand(true, SamplePickerCommand::OpenGitHub, {}, &actions);
+  EXPECT_FALSE(actions.loadSample);
+  EXPECT_TRUE(actions.openGitHub);
+}
+
+TEST(SamplePickerPresenter, CommandsIgnoreEmptySampleAndNullAccumulator) {
+  SamplePickerActions actions;
+  ApplySamplePickerCommand(true, SamplePickerCommand::LoadSample, {}, &actions);
+  EXPECT_FALSE(actions.loadSample);
+  EXPECT_TRUE(actions.sampleId.empty());
+
+  ApplySamplePickerCommand(true, SamplePickerCommand::LoadSample, "unknown", &actions);
+  EXPECT_FALSE(actions.loadSample);
+  EXPECT_TRUE(actions.sampleId.empty());
+
+  ApplySamplePickerCommand(true, SamplePickerCommand::OpenGitHub, {}, nullptr);
+  EXPECT_FALSE(actions.openGitHub);
+}
+
+}  // namespace
+}  // namespace donner::editor


### PR DESCRIPTION
- add a built-in sample SVG catalog and welcome picker
- require explicit confirmation before a sample replaces unsaved document or source edits
- add structural grouping actions to the editor shell
- expose compositor tile visualization alongside existing render diagnostics
- document the sample workflow and visual-debugging surface
- add catalog, presenter, menu, shell, and editor tests

## Why

The web editor needs an immediate, inspectable starting point, and renderer debugging should remain integrated with the canvas workflow. Sample selection must not silently discard work.

## Validation

- `bazel test //donner/editor/tests:editor_sample_catalog_tests //donner/editor/tests:sample_picker_presenter_tests //donner/editor/tests:menu_bar_presenter_tests //donner/editor/tests:editor_shell_tests //donner/editor/tests:editor_app_tests`
- `bazel build //donner/editor:editor`
- `bazel test //tools:check_design_doc_provenance_tests`

## Stack

4 of 5. PRs #827-#829 have merged; this PR is rebased directly onto current `main`. PR #831 follows after this one.