### PR TITLE
Editor: add adaptive touch UI

### DIFF
--- a/docs/design_docs/0047-v0_8_showcase.md
+++ b/docs/design_docs/0047-v0_8_showcase.md
@@ -989,9 +989,10 @@ The compact canvas uses a separate DockSpace root. Entering or leaving the profi
 not destroy the desktop dock tree or overwrite source/sidebar preferences. A right-side sheet also
 recenters the floating tool palette in the visible canvas region instead of covering it.
 
-This milestone owns UI policy and ImGui interaction geometry only. The WebAssembly platform layer
-owns Safari resize, touch-event, virtual-keyboard, and lifecycle translation into the existing
-editor input seam. The compact subset intentionally omits source editing, paint controls, the text
+The WebAssembly bootstrap now maps one primary touch pointer into the existing ImGui mouse stream,
+including pointer capture and cancel handling, so taps and direct drags reuse normal editor
+commands. Safari resize, virtual-keyboard, lifecycle, and multi-touch gesture translation remain
+platform work. The compact subset intentionally omits source editing, paint controls, the text
 format bar, canvas scrollbars, and compositor diagnostics for the first pass.
 
 ### Iconography + toolbar

--- a/docs/design_docs/0047-v0_8_showcase.md
+++ b/docs/design_docs/0047-v0_8_showcase.md
@@ -2,8 +2,9 @@
 
 **Status:** Implemented (v0.8 drive)
 **Author:** Codex
+**Reviewed by:** GPT-5.6 Sol
 **Created:** 2026-05-30
-**Updated:** 2026-07-02
+**Updated:** 2026-07-10
 **Related:** [0010-text_rendering](0010-text_rendering.md),
 [0033-2-editor_design_tool_responsiveness](0033-2-editor_design_tool_responsiveness.md),
 [0041-2-path_authoring_and_boolean_operations](0041-2-path_authoring_and_boolean_operations.md),
@@ -50,12 +51,12 @@ Per-milestone outcome:
     `//donner/editor/tests:pen_tool_tests`. (See also the Pen tool crash fix below.)
 - **M3 — Complete Layers panel:** `LayerTreeModel` + `LayersPanel`; the old `LayerInspectorPanel` was
   renamed to `CompositorDebugPanel` (keeping render diagnostics separate). Covered by
-  `//donner/editor/tests:layer_tree_model_tests` and `:layers_panel_tests`. *Caveat:* per-row preview
+  `//donner/editor/tests:layer_tree_model_tests` and `:layers_panel_tests`. _Caveat:_ per-row preview
   ships as a deterministic fill-swatch fallback in this prototype; real per-row subtree thumbnails are
   a follow-up.
 - **M4 — Text authoring UI:** `TextTool` + `TextInspectorPanel`, `Kind::InsertText` /
   `SetTextContent`, `ActiveTool::Text`, covered by `//donner/editor/tests:text_tool_tests`.
-  *Caveat:* editing is inspector-only with no in-canvas caret — matches the design's Non-Goal.
+  _Caveat:_ editing is inspector-only with no in-canvas caret — matches the design's Non-Goal.
 - **M5 — Convert Text to Outlines:** `donner/editor/TextToOutlines.{h,cc}` (`convertTextToOutlines`),
   which reuses `TextEngine::computedGlyphPaths()` via `SVGTextElement::convertToPath()`;
   `Kind::ConvertTextToOutlines`; covered by `//donner/editor/tests:text_outline_tests` with an exact
@@ -68,7 +69,7 @@ Per-milestone outcome:
   stroke `#1ea7fd` / handle `#fff`, reusing the M6 clipPath.
 - **M8 — Produce the v0.8 showcase:** the runnable tool
   `//donner/editor/tools:generate_showcase_asset` produced `donner_splash_v0_8.svg` (outlined `SVG`
-  letters, no live `<text>`, `donner-editor-overlay` chrome). *Repro mechanism:* the final asset was
+  letters, no live `<text>`, `donner-editor-overlay` chrome). _Repro mechanism:_ the final asset was
   produced **programmatically** via the merged `convertTextToOutlines` (M5) + `ExportViewportAsSvg`
   (M6) code paths, not by driving the editor GUI — the editor GUI cannot run headless in CI.
 - **M9 — Rebrand and release packaging:** README / RELEASE_NOTES / docs / About updated to
@@ -79,7 +80,7 @@ Per-milestone outcome:
 The v0.8 drive added work that was not in the original milestone list:
 
 - **Preview-vs-source save/reload coherence test**
-  (`//donner/editor/tests:preview_source_coherence_tests`). Proves that after *every* committed
+  (`//donner/editor/tests:preview_source_coherence_tests`). Proves that after _every_ committed
   editor op, the live preview render is pixel-identical (zero-diff) to rendering the
   saved-then-reloaded source. This guarantees the "what you see == what you save" invariant across
   the whole authoring surface, not just per-feature.
@@ -92,7 +93,7 @@ The v0.8 drive added work that was not in the original milestone list:
 
 ### Preexisting compositor bug surfaced (not a v0.8 regression)
 
-Running the full `bazel test //...` gate across the *entire* repo for the first time as part of this
+Running the full `bazel test //...` gate across the _entire_ repo for the first time as part of this
 drive revealed ~11 failing targets, all tracing to a single **preexisting** bug — a broken
 translation-only drag compose-offset / layer fast path
 (`composeOffset.translation()` / `dragTranslationDoc` / golden delta all reported `(0,0)`, so
@@ -182,20 +183,20 @@ These are process mistakes that cost hours across the drive. They are documented
 starts clean instead of re-learning them.
 
 1. **Believing test results that came through the corrupted channel.** The human-readable
-   `PASSED`/`FAILED` lines were garbled, elided, and — worst — *replayed from earlier runs interleaved
-   with new output*. This produced **three** confidently-wrong status claims: "5 of 7 green" when all 7
+   `PASSED`/`FAILED` lines were garbled, elided, and — worst — _replayed from earlier runs interleaved
+   with new output_. This produced **three** confidently-wrong status claims: "5 of 7 green" when all 7
    were red; "all 2530 pass" when the suite hadn't passed; "async is contention-flaky" when it was
    deterministic. **Rule: a test is green only if its captured `bazel` exit code says so.** Do
-   `cmd > /tmp/log 2>&1; echo "rc=$?" > /tmp/rc; ` then Read `/tmp/rc`. Never report pass/fail from the
+   `cmd > /tmp/log 2>&1; echo "rc=$?" > /tmp/rc;` then Read `/tmp/rc`. Never report pass/fail from the
    streamed stdout of a multi-line bazel run.
 
 2. **Misreading a failing exit code as success.** The ASan run was reported as "passed, segfault is a
-   symptom" — but it had `ASAN_RC=3` (failed) with zero sanitizer reports, which actually *disproves*
+   symptom" — but it had `ASAN_RC=3` (failed) with zero sanitizer reports, which actually _disproves_
    the heap-overflow theory and points to a deterministic logic bug. The agent that re-ran it caught
    this. **Rule: read the rc number before forming a conclusion; rc=0 is the only "passed".**
 
 3. **Over-batching tool calls that cascade-cancel.** Multiple times a single message fired ~10+
-   parallel Bash/Edit/Agent calls; when any one errored or the user interrupted, the *entire batch* was
+   parallel Bash/Edit/Agent calls; when any one errored or the user interrupted, the _entire batch_ was
    cancelled, leaving edits half-applied (e.g. a duplicated `noteRowHovered` definition, a stray brace
    in `PenTool.cc`, an uncompilable `EditorShell.cc` that got committed). **Rule: when the channel is
    flaky, ONE Bash per message for anything stateful (git, edits, builds). Verify each before the next.**
@@ -206,7 +207,7 @@ starts clean instead of re-learning them.
    amend only after green.**
 
 5. **Editing tests to encode the wrong contract, then "fixing" them again.** The layer-order test was
-   first updated to assert reverse order, failed, then had to be re-fixed — because there were *two*
+   first updated to assert reverse order, failed, then had to be re-fixed — because there were _two_
    emission loops (nested recursion AND top-level) and only one was changed. **Rule: when changing a
    behavior, grep for ALL sites that implement it before editing the test; let the test define the
    contract and make production match it, not vice-versa.**
@@ -484,8 +485,8 @@ flowchart LR
 
 ### Text Authoring
 
-*(Updated 2026-07-02: in-canvas editing sessions shipped, superseding the
-inspector-only plan below.)* The Text tool now follows the standard design-tool
+_(Updated 2026-07-02: in-canvas editing sessions shipped, superseding the
+inspector-only plan below.)_ The Text tool now follows the standard design-tool
 contract:
 
 - A click places point text; a click-drag draws a text box. Either opens an
@@ -544,7 +545,7 @@ The Pen tool must be good enough to author the showcase without source edits:
 - Closing a path is predictable and creates a valid closed contour.
 - Escape ends the session committing the placed anchors as an open path (same as Enter, one
   undoable operation) — undo is the discard mechanism. A segmentless single-anchor draft is
-  discarded, leaving the document unchanged. *(Contract updated 2026-07-02, matching 0041-2.)*
+  discarded, leaving the document unchanged. _(Contract updated 2026-07-02, matching 0041-2.)_
 - Every placed point updates the path bounds and overlay **in the same presented frame as the
   gesture's document flush** — this includes plain clicks, close-path clicks, and commits, not
   only active handle drags. The overlay must be captured from the post-flush DOM geometry; it
@@ -925,13 +926,13 @@ Manual validation:
 
 Captured after the stabilization pass that took `v0_8_drive` green (segfault, gl_rnr
 selection-loss, the #633 paint-leak compose bug, and the deterministic immediate
-heuristic all landed). The v0.8 *functional* milestones shipped, but the following
+heuristic all landed). The v0.8 _functional_ milestones shipped, but the following
 UX/polish gaps remain before the showcase feels finished — plus one milestone that
 was marked done but is not actually usable.
 
 ### ✅ Resolved: Text tool (M4) is reachable in the live editor
 
-*(Updated 2026-07-02.)* The Text tool now has a toolbar button (Select / Pen /
+_(Updated 2026-07-02.)_ The Text tool now has a toolbar button (Select / Pen /
 Text palette) and the `T` single-key shortcut; a canvas click (or box drag)
 opens an in-canvas editing session with a live caret — see "Text Authoring"
 above for the full session contract. Covered by `TextTool_tests.cc`, the
@@ -971,6 +972,27 @@ land, and about 4.0 ms steady-state. Viewport, document, compositor, and tile ca
 gesture bounds, stale tile identity, replacement-document annotation rejection, locator batching,
 and pane-center preservation. The Inspector UI fuzzer completed a 31-second ASan mutation run with
 138 executions and no crash.
+
+### Resolved: adaptive touch UI shell (2026-07-10)
+
+The editor now has a tested compact profile for constrained windows and touch-preferred WebAssembly
+builds. It keeps the canvas primary, replaces the desktop menu with a 52 px command bar, uses 44 px
+tool and command targets, and presents one Layers or Inspector sheet at a time. The sheet uses the
+right edge in landscape and the bottom edge in portrait. Layer rows, visibility, lock, disclosure,
+Inspector fields, zoom, and the close action receive touch-sized targets; transform and pen hit
+tolerance expands without changing crisp overlay artwork.
+
+The command bar keeps Open/Samples reachable after a document loads. Wide desktop WebAssembly
+windows retain full desktop chrome unless the browser reports touch points or a coarse pointer.
+
+The compact canvas uses a separate DockSpace root. Entering or leaving the profile therefore does
+not destroy the desktop dock tree or overwrite source/sidebar preferences. A right-side sheet also
+recenters the floating tool palette in the visible canvas region instead of covering it.
+
+This milestone owns UI policy and ImGui interaction geometry only. The WebAssembly platform layer
+owns Safari resize, touch-event, virtual-keyboard, and lifecycle translation into the existing
+editor input seam. The compact subset intentionally omits source editing, paint controls, the text
+format bar, canvas scrollbars, and compositor diagnostics for the first pass.
 
 ### Iconography + toolbar
 
@@ -1049,7 +1071,7 @@ and the chrome fully renderer-backed. The gap slate was implemented on
       `ClickLastAnchorRetractsOnlyOutgoingHandle`.
 - [ ] **Contextual cursors**: one static pen cursor; no close-path / add /
       delete / continue-endpoint variants. (Remaining follow-up; a dedicated
-      delete-anchor *gesture* beyond Backspace also remains open.)
+      delete-anchor _gesture_ beyond Backspace also remains open.)
 - [x] **Escape semantics doc conflict** — resolved 2026-07-02 (operator
       decision): Escape commits the open path, same as Enter (the standard
       design-tool contract, matching 0041-2); a segmentless draft is
@@ -1084,7 +1106,7 @@ and the chrome fully renderer-backed. The gap slate was implemented on
 
 The intended model (see `CLAUDE.md` / `AGENTS.md` § "DOM-Level Editing Only") is
 that **even typing in the source pane is DOM-aware**: an edit should be
-incrementally reparsed and applied to the *live DOM tree in place*, preserving
+incrementally reparsed and applied to the _live DOM tree in place_, preserving
 entity identity so selection, compositor caches, and references survive the
 keystroke.
 
@@ -1105,12 +1127,12 @@ The original `ChangeClassifier::classifyTextChange` gate this section used to
 describe was **superseded** by `applySourceEdit` and had been off every live path
 (only its own unit test consumed it); it has now been **deleted**.
 
-**Remaining gap (narrow):** the whole-text *diff fallback*
+**Remaining gap (narrow):** the whole-text _diff fallback_
 (`DispatchSourceTextChange` → `BuildSingleSourceTextEdit`) is only reached when an
 edit arrives without precise `SourceEditIntent`s (e.g. a programmatic `setText`
 that bypasses the text editor's intent recording — normal typing/undo/paste all
 record intents and take the correct precise path). For that fallback, inserting an
-element *textually similar to an adjacent sibling* collapses under minimal
+element _textually similar to an adjacent sibling_ collapses under minimal
 prefix/suffix diffing into what looks like a single-character attribute-value edit,
 so the structured apply renames the existing sibling and never materializes the new
 element in the DOM even though the source bytes are correct — a silent DOM/source

--- a/docs/design_docs/0047-v0_8_showcase.md
+++ b/docs/design_docs/0047-v0_8_showcase.md
@@ -1,7 +1,8 @@
 # Design: Donner v0.8 Showcase and Rebrand
 
 **Status:** Implemented (v0.8 drive)
-**Author:** Codex
+**Author:** unknown (historical provenance debt)
+**Drafted by:** unknown (historical provenance debt)
 **Reviewed by:** GPT-5.6 Sol
 **Created:** 2026-05-30
 **Updated:** 2026-07-10

--- a/docs/editor_architecture.md
+++ b/docs/editor_architecture.md
@@ -49,8 +49,9 @@ Guarantees callers can rely on:
   GL textures via `RenderCoordinator::pollRenderResult`; (2) if `!isBusy()`, flush
   queued edits (`EditorApp::flushFrame`) and refresh selection bounds; (3) sync
   parse-error markers and apply pending canvas→source writebacks through
-  `DocumentSyncController`; (4) compute pane layout, handle shortcuts, and render
-  the menu bar; (5) render the panes; (6) if `!isBusy()`, request the next render
+  `DocumentSyncController`; (4) compute the adaptive UI profile and pane layout,
+  handle shortcuts, and render the desktop menu bar or compact command bar; (5)
+  render the panes; (6) if `!isBusy()`, request the next render
   via `RenderCoordinator::maybeRequestRender`; (7) collect a `FrameCostBreakdown`
   and emit frame-miss/resource telemetry. Queued canvas-text characters are
   coalesced before the mutation flush, so one UI frame performs one text-content
@@ -87,12 +88,12 @@ immediately.
 - **`AsyncRenderer`** (`donner/editor/AsyncRenderer.h`) owns a dedicated worker
   thread that owns the `svg::Renderer` and a `CompositorController` for its
   lifetime. Its state is a variant over `Idle`/`Rendering`/`Cancelling`/`Done`/
-  `Shutdown`. `isBusy()` is true while a render is in flight *or* a finished result
+  `Shutdown`. `isBusy()` is true while a render is in flight _or_ a finished result
   awaits polling; the UI thread must not mutate the document or touch the renderer
   while it is true. `requestRender()` is non-blocking and cancels+replaces an
   in-flight request; cancellation is delivered through a
   `svg::compositor::CancellationToken` polled at compositor safe points.
-- **Threading model.** The worker shares the *live* registry rather than deep-copying
+- **Threading model.** The worker shares the _live_ registry rather than deep-copying
   (`SVGDocument` is a value facade over a `shared_ptr<Registry>`). On first render
   the document is flipped to `svg::ThreadingMode::ConcurrentDom` for the editor's
   lifetime; the worker takes a `DocumentWriteAccess` guard across the render and
@@ -133,13 +134,12 @@ describes the editor's consumption of it.
 - **Panes** are immediate-mode borderless ImGui windows; layout math lives in
   `EditorShellLayout`. The **render pane** (`RenderPanePresenter`) blits tiles and
   overlay chrome and owns pointer capture; the **source pane** is `TextEditor`
-  (headless core split into `TextEditorCore`); the **sidebar**
-  (`SidebarPresenter`) renders the element tree and attribute inspector from a
-  snapshot refreshed only while the worker is idle; the **layers panel**
-  (`LayerInspectorPanel`) is a read-only view of the compositor's paint-order
-  tiles; the **menu bar** (`MenuBarPresenter`) returns a semantic `MenuBarActions`
-  struct the shell acts on; **dialogs** (Open/Save/About/Licenses) are
-  `DialogPresenter`.
+  (headless core split into `TextEditorCore`); **Layers** (`LayersPanel`) renders
+  the user-facing document tree; **Inspector** (`SidebarPresenter`) renders XML,
+  CSS, and transform state from a snapshot refreshed only while the worker is
+  idle; `LayerInspectorPanel` is the separate compositor diagnostics view; the
+  **menu bar** (`MenuBarPresenter`) returns a semantic `MenuBarActions` struct the
+  shell acts on; **dialogs** (Open/Save/About/Licenses) are `DialogPresenter`.
 - **Tools** implement the `Tool` interface (`onMouseDown`/`onMouseMove`/`onMouseUp`
   in document-space coordinates) and only ever call `EditorApp::applyMutation` —
   never the DOM directly. `SelectTool` handles select / marquee / move / resize /
@@ -158,6 +158,27 @@ describes the editor's consumption of it.
   `ViewportState` selects a pane-bounded raster only when its pixel area is smaller
   than the full-document raster, unless a backend dimension cap requires bounds.
 
+### Adaptive UI profile
+
+`ComputeEditorAdaptiveUiLayout` in `EditorShellLayout` is the pure policy boundary
+between desktop and `CompactTouch` chrome. It receives logical window dimensions
+and a platform touch preference, then returns top-bar, tool-size, sheet-placement,
+and feature-subset decisions. Native constrained windows use the compact profile;
+the WebAssembly shell prefers it when the browser reports touch points or a coarse pointer.
+
+Compact mode gives the render pane the full DockSpace and presents one Layers or
+Inspector sheet over it. Portrait uses a bottom sheet; landscape uses a right
+sheet clamped to a useful reading width. Desktop and compact layouts have distinct
+DockSpace ids. The shell rebinds only the Render window when switching profiles,
+leaving the desktop dock tree, source visibility, and sidebar width intact.
+
+Touch adaptation is deliberately above the document and renderer layers. Compact
+commands call the same `EditorApp`, tool, and presenter seams as desktop commands.
+The shell increases hit tolerance without increasing selection-handle artwork and
+uses 44 logical pixel command, row, and field targets. Browser code remains
+responsible for mapping Safari touch, resize, and virtual-keyboard events into the
+ordinary ImGui input stream.
+
 ## API Surface
 
 The editor is an application, not a reusable library API, but the load-bearing
@@ -167,6 +188,8 @@ entry points are:
 - `EditorApp::loadFromString(std::string_view)` / `AsyncSVGDocument::flushFrame()`
   / `currentFrameVersion()` — document lifecycle used by the frame loop.
 - `EditorShell::runFrame()` / `nextIdleWakeSeconds()` — the per-frame tick.
+- `ComputeEditorAdaptiveUiLayout()` - pure desktop/compact profile selection and
+  sheet geometry.
 - `AsyncRenderer::requestRender()` / `pollResult()` / `isBusy()` — the render
   handoff; plus the replay-only test hooks documented in
   \ref DeterministicReplayTesting.
@@ -190,6 +213,9 @@ entry points are:
 - **Dynamic strings** are rendered with `ImGui::TextUnformatted(...)` rather than as
   format strings; this is an enforced-by-convention practice in the editor code, not
   a separate lint rule.
+- **Adaptive chrome adds no authority.** Compact commands reuse existing mutation,
+  file-dialog, and render seams. The profile itself performs no network, storage,
+  clipboard, or document access.
 - **`stb_image`** is not used anywhere under `donner/editor/`; image decoding runs
   behind `svg::Renderer` on the worker.
 - **Profiling.** Tracy instrumentation compiles to no-ops unless `ENABLE_TRACY` is
@@ -210,7 +236,9 @@ Tests live under `donner/editor/tests/`. By area:
   `RenderPaneClick_tests.cc`, `RenderPaneGesture_tests.cc`, `DragCoalesce_tests.cc`,
   `ViewportInteractionController_tests.cc`.
 - **Presenters / UI:** `SidebarPresenter_tests.cc`, `RenderPanePresenter_tests.cc`,
-  `OverlayRenderer_tests.cc`, `LayerInspectorDiagnostics_tests.cc`.
+  `OverlayRenderer_tests.cc`, `LayerInspectorDiagnostics_tests.cc`,
+  `EditorShellLayout_tests.cc`, `EditorDockLayout_tests.cc`, and
+  `LayersPanel_tests.cc`.
 - **Persistence / replay:** `DocumentSave_tests.cc`, `RnrReplay_tests.cc`,
   `GlRnrReplay_tests.cc` (see \ref DeterministicReplayTesting).
 - **Fuzz / telemetry:** `EditorStateMachine_fuzzer.cc`,
@@ -225,5 +253,8 @@ surfaced for both the live layers panel and the replay/readback harnesses.
   lands.
 - `PenTool` is a prototype path-authoring tool; richer path editing and boolean
   operations are tracked in their own design docs.
+- Compact touch mode intentionally omits source editing, paint controls, the
+  contextual text format bar, canvas scrollbars, and compositor diagnostics. It
+  is a canvas-first editing subset, not a compressed copy of every desktop panel.
 - The editor is an application binary, not a stable embedding API; the entry points
   above are internal contracts, not a supported external interface.

--- a/docs/editor_architecture.md
+++ b/docs/editor_architecture.md
@@ -43,7 +43,8 @@ Guarantees callers can rely on:
   `EditorShell::nextIdleWakeSeconds()` so throttled UI work still wakes the loop.
 - **`EditorShell`** (`donner/editor/EditorShell.h`) is the stateful frontend that
   owns essentially all long-lived orchestration state: `EditorApp`, the tools,
-  `TextEditor`, `GlTextureCache`, `RenderCoordinator`, `DocumentSyncController`,
+  `TextEditor`, its purpose-specific `GlTextureCache` instances, `RenderCoordinator`,
+  `DocumentSyncController`,
   the viewport/input controllers, and the presenters.
 - **`EditorShell::runFrame()`** each frame: (1) poll the latest async render into
   GL textures via `RenderCoordinator::pollRenderResult`; (2) if `!isBusy()`, flush
@@ -56,6 +57,13 @@ Guarantees callers can rely on:
   and emit frame-miss/resource telemetry. Queued canvas-text characters are
   coalesced before the mutation flush, so one UI frame performs one text-content
   synchronization rather than one synchronization per queued codepoint.
+
+The welcome catalog renders each bundled SVG once through a dedicated offscreen
+`svg::Renderer` at thumbnail resolution. A dedicated texture cache uploads those owned bitmaps for
+`SamplePickerPresenter`; ImGui only lays out cards and blits the resulting textures. Keeping this
+cache separate from Layers previews prevents the live-row retention sweep from evicting samples.
+Generation advances by at most one catalog entry per UI frame and explicitly wakes the event loop
+until the bounded cache is complete.
 
 ### The mutation seam
 

--- a/docs/editor_architecture.md
+++ b/docs/editor_architecture.md
@@ -183,9 +183,10 @@ leaving the desktop dock tree, source visibility, and sidebar width intact.
 Touch adaptation is deliberately above the document and renderer layers. Compact
 commands call the same `EditorApp`, tool, and presenter seams as desktop commands.
 The shell increases hit tolerance without increasing selection-handle artwork and
-uses 44 logical pixel command, row, and field targets. Browser code remains
-responsible for mapping Safari touch, resize, and virtual-keyboard events into the
-ordinary ImGui input stream.
+uses 44 logical pixel command, row, and field targets. The Wasm bootstrap translates
+one captured touch pointer into the ordinary ImGui mouse stream for taps and direct
+drags. Browser code remains responsible for resize, virtual-keyboard, lifecycle, and
+future multi-touch gesture integration.
 
 ## API Surface
 

--- a/docs/editor_design_language.md
+++ b/docs/editor_design_language.md
@@ -96,9 +96,12 @@ and desktop modes use separate DockSpace roots, so resizing into the touch profi
 custom desktop panel arrangement. Source visibility and desktop sidebar width remain preferences,
 not transient compact state.
 
-The UI profile consumes ordinary ImGui pointer and resize events. Browser touch translation,
-viewport sizing, and Safari lifecycle integration belong to the WebAssembly platform layer; they
-must feed that existing input seam rather than add touch-specific document mutation paths.
+The UI profile consumes ordinary ImGui pointer and resize events. The WebAssembly bootstrap maps
+one primary touch pointer into the existing mouse-compatible ImGui stream, with pointer capture and
+cancel handling so taps and direct drags use the desktop mutation paths. Viewport sizing,
+multi-touch gestures, virtual-keyboard behavior, and Safari lifecycle integration remain platform
+responsibilities; they must continue to feed existing editor seams rather than add touch-specific
+document mutation paths.
 
 ### Text Authoring
 
@@ -222,7 +225,9 @@ can be reopened through File > Open Sample and dismissed to reveal the current d
 Document replacement requested from the sample surface is deferred to the next orchestration frame.
 The shell waits for the renderer to become idle and detaches any prior direct-presentation callback
 before releasing old WebGPU resources. This ordering prevents the prior frame callback from
-retaining presentation handles across document replacement.
+retaining presentation handles across document replacement. If the document or source buffer has
+unsaved edits, replacement stops at an explicit Discard and Load confirmation; Cancel leaves both
+the current document and pending source text untouched.
 
 ## Verification
 

--- a/docs/editor_design_language.md
+++ b/docs/editor_design_language.md
@@ -207,10 +207,16 @@ Launching without a filename, including the WebAssembly build, opens a first-run
 real editor workspace. It keeps Donner as the first visual signal, offers Open SVG and a fixed
 GitHub destination, and lists a bounded offline catalog of reviewed SVG samples. Loading a sample
 creates an untitled document, so Save cannot overwrite a local file without an explicit path.
+Each sample card uses a small bitmap rendered by Donner from the exact bundled SVG source. ImGui
+only blits the cached texture; it does not approximate sample artwork with hand-drawn UI geometry.
+The catalog has a dedicated texture cache so Layers-panel retention cannot evict welcome previews.
+The shell renders at most one missing preview per UI frame and keeps a fixed placeholder slot while
+the bounded catalog fills in, avoiding a first-frame Wasm stall or card-layout shift.
 
 The welcome surface owns the workspace while visible rather than competing with docked Layers and
 Inspector panels. Its sample controls use at least 44 logical pixels of height, lay out in one
-column below the compact breakpoint, and use at most three columns on wider displays. The surface
+column below the compact breakpoint, and use at most three columns on wider displays. Cards reserve
+a fixed preview slot while keeping their complete surface clickable as a touch target. The surface
 can be reopened through File > Open Sample and dismissed to reveal the current document.
 
 Document replacement requested from the sample surface is deferred to the next orchestration frame.

--- a/docs/editor_design_language.md
+++ b/docs/editor_design_language.md
@@ -45,8 +45,9 @@ but product chrome should not choose a different accent per widget.
 ## Geometry And Type
 
 Spacing uses 4, 8, 12, 16, 24, and 32 px tokens. Controls use a 4 px radius; floating containers
-use a 6 px radius. Tool buttons are 32 px square. New fixed-format controls should use stable
-dimensions and reserve enough room for their longest label.
+use a 6 px radius. Tool buttons are 32 px square on desktop and 44 px square in the compact touch
+profile. New fixed-format controls should use stable dimensions and reserve enough room for their
+longest label.
 
 Roboto is the UI face and Fira Code is the source face. UI text uses regular weight for values and
 bold weight for identity or compact section emphasis. Large display type does not belong in panels,
@@ -69,6 +70,35 @@ leak through the white halo during downsampling.
 The Inspector contains document and selection controls only. Viewport implementation telemetry does
 not occupy the Inspector. Zoom state lives on the canvas in a compact control that resets to 100
 percent when clicked.
+
+### Adaptive Touch Profile
+
+`ComputeEditorAdaptiveUiLayout` selects a canvas-first compact profile for constrained windows and
+touch-preferred builds. Native windows enter it below 760 px wide or 520 px high. WebAssembly enters
+it at those constraints or when the browser reports touch points or a coarse pointer, so desktop
+browsers retain the full editor while iOS starts with stable touch geometry.
+
+The compact profile keeps the same Graphite language but changes the command hierarchy:
+
+- a fixed 52 px top bar presents `DONNER` plus icon-only Open/Samples, Undo, Redo, Layers, and
+  Inspector actions;
+- the canvas tool palette keeps Select, Pen, and Text with 44 px buttons, while the dense paint
+  widget, source pane, text format bar, canvas scrollbars, and compositor diagnostics are omitted;
+- Layers and Inspector open one at a time in an overlay sheet, on the right in landscape and at the
+  bottom in portrait, with a 44 px close target;
+- layer rows and their disclosure, visibility, and lock controls use at least 44 px interaction
+  targets; compact Inspector fields receive equivalent vertical padding;
+- selection, text-frame, and pen geometry stays visually unchanged while invisible pointer hit
+  tolerance doubles for touch.
+
+Opening a right-side sheet recenters the tool palette within the unobscured canvas region. Compact
+and desktop modes use separate DockSpace roots, so resizing into the touch profile cannot rewrite a
+custom desktop panel arrangement. Source visibility and desktop sidebar width remain preferences,
+not transient compact state.
+
+The UI profile consumes ordinary ImGui pointer and resize events. Browser touch translation,
+viewport sizing, and Safari lifecycle integration belong to the WebAssembly platform layer; they
+must feed that existing input seam rather than add touch-specific document mutation paths.
 
 ### Text Authoring
 
@@ -195,6 +225,9 @@ Theme, menu, and source-palette contracts run in:
 ```sh
 bazel test //donner/editor/tests:editor_theme_tests \
   //donner/editor/tests:editor_shell_tests \
+  //donner/editor/tests:editor_shell_layout_tests \
+  //donner/editor/tests:editor_dock_layout_tests \
+  //donner/editor/tests:layers_panel_tests \
   //donner/editor/tests:menu_bar_presenter_tests \
   //donner/editor/tests:sample_picker_presenter_tests \
   //donner/editor/tests:sidebar_presenter_tests \

--- a/donner/editor/EditorDockLayout.cc
+++ b/donner/editor/EditorDockLayout.cc
@@ -8,6 +8,10 @@ ImGuiID EditorDockSpaceId() {
   return ImHashStr(kEditorDockSpaceName);
 }
 
+ImGuiID EditorCompactDockSpaceId() {
+  return ImHashStr(kEditorCompactDockSpaceName);
+}
+
 EditorDockNodes BuildDefaultDockLayout(ImGuiID dockspaceId, const EditorDockLayoutParams& params) {
   EditorDockNodes nodes;
   nodes.root = dockspaceId;
@@ -17,6 +21,17 @@ EditorDockNodes BuildDefaultDockLayout(ImGuiID dockspaceId, const EditorDockLayo
   ImGui::DockBuilderRemoveNode(dockspaceId);
   ImGui::DockBuilderAddNode(dockspaceId, ImGuiDockNodeFlags_DockSpace);
   ImGui::DockBuilderSetNodeSize(dockspaceId, params.size);
+
+  if (!params.includeSidebars) {
+    nodes.central = dockspaceId;
+    if (ImGuiDockNode* centralNode = ImGui::DockBuilderGetNode(dockspaceId)) {
+      centralNode->SetLocalFlags(centralNode->LocalFlags | ImGuiDockNodeFlags_CentralNode |
+                                 ImGuiDockNodeFlags_NoTabBar);
+    }
+    ImGui::DockBuilderDockWindow(kRenderPaneWindowName, dockspaceId);
+    ImGui::DockBuilderFinish(dockspaceId);
+    return nodes;
+  }
 
   // Split the right panel column off the canvas. The opposite side is the
   // central node that hosts the canvas / render pane.

--- a/donner/editor/EditorDockLayout.h
+++ b/donner/editor/EditorDockLayout.h
@@ -15,11 +15,16 @@ inline constexpr const char* kCompositorDebugWindowName = "Compositor Debug";
 
 /// Stable string hashed into the editor's root DockSpace id.
 inline constexpr const char* kEditorDockSpaceName = "EditorDockSpace";
+/// Stable string hashed into the compact editor's canvas-only DockSpace id.
+inline constexpr const char* kEditorCompactDockSpaceName = "EditorCompactDockSpace";
 
 /// The editor's root DockSpace id. Hashed directly from \ref
 /// kEditorDockSpaceName so it is stable and independent of the ImGui window
 /// stack (unlike `ImGui::GetID`, which dereferences the current window).
 [[nodiscard]] ImGuiID EditorDockSpaceId();
+/// The compact editor's root DockSpace id. Kept separate so entering compact
+/// mode cannot rewrite a customized desktop DockSpace tree.
+[[nodiscard]] ImGuiID EditorCompactDockSpaceId();
 
 /// Node ids produced by \ref BuildDefaultDockLayout. Ids of zero mean the node
 /// was not created (e.g. \ref EditorDockNodes::rightBottom when the compositor
@@ -50,6 +55,9 @@ struct EditorDockLayoutParams {
   float compositorRatio = 0.34f;
   /// Whether the Compositor Debug panel gets a reserved node in the layout.
   bool includeCompositorDebug = false;
+  /// Whether persistent Layers and Inspector nodes are included. Compact touch
+  /// mode omits them and presents one panel at a time as an overlay sheet.
+  bool includeSidebars = true;
 };
 
 /**

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -3943,7 +3943,10 @@ void EditorShell::renderSidebars() {
   const bool rendererBusy = renderCoordinator_.asyncRenderer().isBusy();
   if (!rendererBusy) {
     sidebarPresenter_.refreshSnapshot(app_);
-    layersPanel_.refreshSnapshot(app_, &layerThumbnailRenderer_);
+    // Compact sheets use deterministic fill swatches. Avoiding per-row raster
+    // rendering and texture uploads keeps the touch panel responsive and also
+    // avoids backend-specific thumbnail presentation differences in Wasm.
+    layersPanel_.refreshSnapshot(app_, compactSheet ? nullptr : &layerThumbnailRenderer_);
   }
   EditorApp* liveAppForClicks = rendererBusy ? nullptr : &app_;
 
@@ -4055,8 +4058,10 @@ void EditorShell::renderSidebars() {
     lastTreeSelection_ = app_.selectedElement();
     return;
   }
-  layersPanel_.render(liveAppForClicks, thumbnailTextureProvider, layerIconTextureProvider,
-                      compactSheet ? 44.0f : 0.0f);
+  layersPanel_.render(
+      liveAppForClicks,
+      compactSheet ? LayersPanel::ThumbnailTextureProvider{} : thumbnailTextureProvider,
+      layerIconTextureProvider, compactSheet ? 44.0f : 0.0f);
   // Feed the Layers-panel hover into the shared source-hover preview so the
   // canvas (and source pane) highlight the hovered element, the same way
   // hovering a source-pane token does.

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -265,13 +265,15 @@ bool CanvasChromeCapturesInput(const ImVec2& point, const std::optional<Box2d>& 
                                const Box2d& toolPaletteRect,
                                const std::optional<Box2d>& textFormatBarRect,
                                const std::optional<Box2d>& editingScopeBreadcrumbRect,
-                               const Box2d& canvasZoomControlRect) {
+                               const Box2d& canvasZoomControlRect,
+                               const std::optional<Box2d>& compactPanelRect) {
   return (referenceChipRect.has_value() && ContainsScreenPoint(*referenceChipRect, point)) ||
          ContainsScreenPoint(toolPaletteRect, point) ||
          (textFormatBarRect.has_value() && ContainsScreenPoint(*textFormatBarRect, point)) ||
          (editingScopeBreadcrumbRect.has_value() &&
           ContainsScreenPoint(*editingScopeBreadcrumbRect, point)) ||
-         ContainsScreenPoint(canvasZoomControlRect, point);
+         ContainsScreenPoint(canvasZoomControlRect, point) ||
+         (compactPanelRect.has_value() && ContainsScreenPoint(*compactPanelRect, point));
 }
 
 bool GroupOperationCanDispatch(bool rendererBusy,
@@ -1704,7 +1706,8 @@ void EditorShell::applyMenuActions(const MenuBarActions& menuActions) {
   if (menuActions.redo && app_.canRedo()) {
     app_.redo();
   }
-  const bool sourcePaneFocusedForMenu = sourcePaneVisible_ && textEditor_.isFocused();
+  const bool sourcePaneFocusedForMenu =
+      !adaptiveUiLayout_.compactTouch() && sourcePaneVisible_ && textEditor_.isFocused();
   if (menuActions.cut) {
     if (sourcePaneFocusedForMenu) {
       textEditor_.cut();
@@ -1812,7 +1815,8 @@ void EditorShell::handleGlobalShortcuts() {
   const bool pressedZ = ImGui::IsKeyPressed(ImGuiKey_Z, /*repeat=*/false);
   const bool pressedEnter = ImGui::IsKeyPressed(ImGuiKey_Enter, /*repeat=*/false) ||
                             ImGui::IsKeyPressed(ImGuiKey_KeypadEnter, /*repeat=*/false);
-  const bool sourcePaneFocused = sourcePaneVisible_ && textEditor_.isFocused();
+  const bool sourcePaneFocused =
+      !adaptiveUiLayout_.compactTouch() && sourcePaneVisible_ && textEditor_.isFocused();
 
   // An in-canvas text editing session captures the keyboard: typing, caret
   // movement, style toggles, and Escape all act on the session, and no
@@ -2366,12 +2370,31 @@ void EditorShell::renderSourcePane(float paneOriginY, float paneHeight, float pa
 Box2d EditorShell::toolPaletteScreenRect(const ImVec2& paneOrigin,
                                          const ImVec2& contentRegion) const {
   constexpr float kButtonCount = 3.0f;
-  const float width = kToolPalettePadding * 2.0f + kToolPaletteButtonSize * kButtonCount +
-                      kToolPalettePaintWidgetWidth + kToolPaletteGap * kButtonCount;
-  const float height = kToolPalettePadding * 2.0f + kToolPaletteButtonSize;
-  const float x = paneOrigin.x + std::max(0.0f, (contentRegion.x - width) * 0.5f);
+  const float buttonSize = adaptiveUiLayout_.toolButtonSize;
+  const float paintWidth =
+      adaptiveUiLayout_.showPaintControls ? kToolPalettePaintWidgetWidth : 0.0f;
+  const float gapCount = adaptiveUiLayout_.showPaintControls ? kButtonCount : kButtonCount - 1.0f;
+  const float width = kToolPalettePadding * 2.0f + buttonSize * kButtonCount + paintWidth +
+                      kToolPaletteGap * gapCount;
+  const float height = kToolPalettePadding * 2.0f + buttonSize;
+  float visibleContentWidth = contentRegion.x;
+  if (const std::optional<Box2d> panelRect = compactPanelScreenRect();
+      panelRect.has_value() && adaptiveUiLayout_.panelPlacement == CompactPanelPlacement::Right) {
+    visibleContentWidth =
+        std::min(visibleContentWidth,
+                 std::max(0.0f, static_cast<float>(panelRect->topLeft.x) - paneOrigin.x));
+  }
+  const float x = paneOrigin.x + std::max(0.0f, (visibleContentWidth - width) * 0.5f);
   const float y = paneOrigin.y + kToolPaletteTopInset;
   return Box2d::FromXYWH(x, y, width, height);
+}
+
+std::optional<Box2d> EditorShell::compactPanelScreenRect() const {
+  if (!adaptiveUiLayout_.compactTouch() || !compactPanelVisible_) {
+    return std::nullopt;
+  }
+  return Box2d::FromXYWH(adaptiveUiLayout_.panelX, adaptiveUiLayout_.panelY,
+                         adaptiveUiLayout_.panelWidth, adaptiveUiLayout_.panelHeight);
 }
 
 Box2d EditorShell::canvasZoomControlScreenRect() const {
@@ -2379,11 +2402,15 @@ Box2d EditorShell::canvasZoomControlScreenRect() const {
   char label[16];
   std::snprintf(label, sizeof(label), "%.0f%%", viewport.zoom * 100.0);
   const ImVec2 textSize = ImGui::CalcTextSize(label);
-  const float width = textSize.x + kCanvasZoomPaddingX * 2.0f;
-  const float height = textSize.y + kCanvasZoomPaddingY * 2.0f;
+  const float width = std::max(textSize.x + kCanvasZoomPaddingX * 2.0f,
+                               adaptiveUiLayout_.compactTouch() ? 44.0f : 0.0f);
+  const float height = std::max(textSize.y + kCanvasZoomPaddingY * 2.0f,
+                                adaptiveUiLayout_.compactTouch() ? 44.0f : 0.0f);
   const float x = static_cast<float>(viewport.paneOrigin.x) + kCanvasZoomInset;
+  const float scrollbarInset =
+      adaptiveUiLayout_.showCanvasScrollbars ? static_cast<float>(kCanvasScrollbarRailPx) : 0.0f;
   const float y = static_cast<float>(viewport.paneOrigin.y + viewport.paneSize.y) - height -
-                  static_cast<float>(kCanvasScrollbarRailPx) - kCanvasZoomInset;
+                  scrollbarInset - kCanvasZoomInset;
   return Box2d::FromXYWH(x, y, width, height);
 }
 
@@ -2640,7 +2667,8 @@ void EditorShell::renderToolPalette(const ImVec2& paneOrigin, const ImVec2& cont
       ImGui::PushStyleColor(ImGuiCol_ButtonHovered, fill);
       ImGui::PushStyleColor(ImGuiCol_ButtonActive, fillActive);
     }
-    if (ImGui::Button(label, ImVec2(kToolPaletteButtonSize, kToolPaletteButtonSize))) {
+    if (ImGui::Button(label,
+                      ImVec2(adaptiveUiLayout_.toolButtonSize, adaptiveUiLayout_.toolButtonSize))) {
       // Leaving a tool commits its in-progress session as one undoable
       // command rather than dropping it.
       if (tool != ActiveTool::Pen && penTool_.commitOpenPath(app_)) {
@@ -2675,8 +2703,10 @@ void EditorShell::renderToolPalette(const ImVec2& paneOrigin, const ImVec2& cont
   renderButton(ActiveTool::Pen, "##pen_tool", ToolbarIcon::Pen, penTooltip.c_str());
   ImGui::SameLine(0.0f, kToolPaletteGap);
   renderButton(ActiveTool::Text, "##text_tool", ToolbarIcon::Text, textTooltip.c_str());
-  ImGui::SameLine(0.0f, kToolPaletteGap);
-  renderFillStrokeToolbarWidget();
+  if (adaptiveUiLayout_.showPaintControls) {
+    ImGui::SameLine(0.0f, kToolPaletteGap);
+    renderFillStrokeToolbarWidget();
+  }
 
   ImGui::PopStyleVar(2);
   ImGui::PopID();
@@ -2748,13 +2778,15 @@ void EditorShell::renderRenderPane(ImGuiWindowFlags paneFlags) {
   const Box2d toolPaletteRect = toolPaletteScreenRect(paneOriginImGui, contentRegion);
   const std::optional<Box2d> textFormatBarRect =
       TextFormatBarScreenRect(paneOriginImGui, contentRegion, toolPaletteRect,
-                              formatBarShouldShow(), TextFormatBarPresenter::BarHeight());
+                              adaptiveUiLayout_.showTextFormatBar && formatBarShouldShow(),
+                              TextFormatBarPresenter::BarHeight());
   const std::optional<Box2d> editingScopeBreadcrumbRect =
       EditingScopeBreadcrumbScreenRect(paneOriginImGui, toolPaletteRect, app_.editingScope());
   const Box2d canvasZoomControlRect = canvasZoomControlScreenRect();
+  const std::optional<Box2d> compactPanelRect = compactPanelScreenRect();
   const bool canvasChromeHovered = CanvasChromeCapturesInput(
       ImGui::GetMousePos(), referenceChipRect, toolPaletteRect, textFormatBarRect,
-      editingScopeBreadcrumbRect, canvasZoomControlRect);
+      editingScopeBreadcrumbRect, canvasZoomControlRect, compactPanelRect);
 
   ImGui::SetNextItemAllowOverlap();
   ImGui::InvisibleButton("##render_canvas", contentRegion,
@@ -2834,6 +2866,12 @@ void EditorShell::renderRenderPane(ImGuiWindowFlags paneFlags) {
     return interactionController_.viewport().screenToDocument(
         Vector2d(screenPoint.x, screenPoint.y));
   };
+  // Keep handles visually crisp while making their invisible hit regions more
+  // forgiving under touch. The tools express hit sizes in screen pixels by
+  // dividing by this scale, so halving it doubles only interaction tolerance.
+  const double pointerHitTestPixelsPerDocUnit =
+      interactionController_.viewport().pixelsPerDocUnit() /
+      (adaptiveUiLayout_.compactTouch() ? 2.0 : 1.0);
 
   if (canvasHovered && ImGui::IsMouseClicked(ImGuiMouseButton_Right, /*repeat=*/false)) {
     openRenderPaneContextMenu(screenToDocument(ImGui::GetMousePos()));
@@ -2856,8 +2894,7 @@ void EditorShell::renderRenderPane(ImGuiWindowFlags paneFlags) {
                                               ? boundsCache.displayedBoundsDoc
                                               : boundsCache.pendingBoundsDoc;
     return HitTestSelectionTransformHandles(boundsDoc, documentPoint,
-                                            interactionController_.viewport().pixelsPerDocUnit(),
-                                            includeRotate);
+                                            pointerHitTestPixelsPerDocUnit, includeRotate);
   };
   SelectionTransformHandleIntent hoverTransformIntent;
   if (penToolActive && !rotateCursorLocked && toolEligible) {
@@ -2870,7 +2907,7 @@ void EditorShell::renderRenderPane(ImGuiWindowFlags paneFlags) {
       hoverModifiers.shift = ImGui::GetIO().KeyShift;
       hoverModifiers.option = ImGui::GetIO().KeyAlt;
       hoverModifiers.command = ImGui::GetIO().KeyCtrl || ImGui::GetIO().KeySuper;
-      hoverModifiers.pixelsPerDocUnit = interactionController_.viewport().pixelsPerDocUnit();
+      hoverModifiers.pixelsPerDocUnit = pointerHitTestPixelsPerDocUnit;
       if (penTool_.wouldCloseAt(screenToDocument(ImGui::GetMousePos()), hoverModifiers)) {
         penHint = PenCursorHint::Close;
       }
@@ -2921,10 +2958,9 @@ void EditorShell::renderRenderPane(ImGuiWindowFlags paneFlags) {
       textFrameIntent.corner = textTool_.frameCorner();
     } else if (textTool_.isEditing() && !ImGui::IsMouseDown(ImGuiMouseButton_Left) &&
                !renderCoordinator_.asyncRenderer().isBusy()) {
-      textFrameIntent =
-          textTool_.frameHandleIntentAt(screenToDocument(ImGui::GetMousePos()),
-                                        interactionController_.viewport().pixelsPerDocUnit(),
-                                        /*includeRotate=*/!ImGui::GetIO().KeyShift);
+      textFrameIntent = textTool_.frameHandleIntentAt(screenToDocument(ImGui::GetMousePos()),
+                                                      pointerHitTestPixelsPerDocUnit,
+                                                      /*includeRotate=*/!ImGui::GetIO().KeyShift);
     }
     if (textFrameIntent.kind == SelectionTransformHandleKind::Rotate &&
         rotateCursorSet_.setRotateCursor(textFrameIntent.corner)) {
@@ -2954,7 +2990,7 @@ void EditorShell::renderRenderPane(ImGuiWindowFlags paneFlags) {
     modifiers.option = ImGui::GetIO().KeyAlt;
     modifiers.command = ImGui::GetIO().KeyCtrl || ImGui::GetIO().KeySuper;
     modifiers.doubleClick = ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left);
-    modifiers.pixelsPerDocUnit = interactionController_.viewport().pixelsPerDocUnit();
+    modifiers.pixelsPerDocUnit = pointerHitTestPixelsPerDocUnit;
     interactionController_.bufferPendingClick(screenToDocument(ImGui::GetMousePos()), modifiers);
     pendingSelectClickStartSeconds_ = ImGui::GetTime();
   }
@@ -3137,7 +3173,7 @@ void EditorShell::renderRenderPane(ImGuiWindowFlags paneFlags) {
         MouseModifiers modifiers;
         modifiers.shift = ImGui::GetIO().KeyShift;
         modifiers.option = ImGui::GetIO().KeyAlt;
-        modifiers.pixelsPerDocUnit = interactionController_.viewport().pixelsPerDocUnit();
+        modifiers.pixelsPerDocUnit = pointerHitTestPixelsPerDocUnit;
         selectTool_.onMouseMove(app_, screenToDocument(currentScreen), /*buttonHeld=*/true,
                                 modifiers);
         lastPostedScreenPoint_ = currentScreen;
@@ -3212,7 +3248,7 @@ void EditorShell::renderRenderPane(ImGuiWindowFlags paneFlags) {
       dragModifiers.shift = ImGui::GetIO().KeyShift;
       dragModifiers.option = ImGui::GetIO().KeyAlt;
       dragModifiers.command = ImGui::GetIO().KeyCtrl || ImGui::GetIO().KeySuper;
-      dragModifiers.pixelsPerDocUnit = interactionController_.viewport().pixelsPerDocUnit();
+      dragModifiers.pixelsPerDocUnit = pointerHitTestPixelsPerDocUnit;
       penTool_.onMouseMove(app_, screenToDocument(ImGui::GetMousePos()), /*buttonHeld=*/true,
                            dragModifiers);
       if (app_.document().hasPendingMutations() && flushQueuedMutationAndRefreshOverlay()) {
@@ -3234,7 +3270,7 @@ void EditorShell::renderRenderPane(ImGuiWindowFlags paneFlags) {
     hoverModifiers.shift = ImGui::GetIO().KeyShift;
     hoverModifiers.option = ImGui::GetIO().KeyAlt;
     hoverModifiers.command = ImGui::GetIO().KeyCtrl || ImGui::GetIO().KeySuper;
-    hoverModifiers.pixelsPerDocUnit = interactionController_.viewport().pixelsPerDocUnit();
+    hoverModifiers.pixelsPerDocUnit = pointerHitTestPixelsPerDocUnit;
     const Vector2d hoverDocPoint = screenToDocument(ImGui::GetMousePos());
     renderCoordinator_.setPenHoverChrome(penTool_.previewSegmentPath(hoverDocPoint, hoverModifiers),
                                          penTool_.wouldCloseAt(hoverDocPoint, hoverModifiers)
@@ -3440,7 +3476,8 @@ void EditorShell::renderRenderPane(ImGuiWindowFlags paneFlags) {
     const FormatBarState formatBarState = computeFormatBarState();
     const std::optional<Box2d> formatBarRect =
         TextFormatBarScreenRect(paneOriginImGui, contentRegion, toolPaletteRect,
-                                formatBarState.visible, TextFormatBarPresenter::BarHeight());
+                                adaptiveUiLayout_.showTextFormatBar && formatBarState.visible,
+                                TextFormatBarPresenter::BarHeight());
     if (formatBarRect.has_value()) {
       const FormatBarActions actions =
           textFormatBarPresenter_.render(formatBarState,
@@ -3450,7 +3487,9 @@ void EditorShell::renderRenderPane(ImGuiWindowFlags paneFlags) {
       applyFormatBarActions(formatBarState, actions);
     }
     renderCanvasZoomControl();
-    renderCanvasScrollbars();
+    if (adaptiveUiLayout_.showCanvasScrollbars) {
+      renderCanvasScrollbars();
+    }
     renderRenderPaneContextMenu();
   }
   ImGui::End();
@@ -3604,8 +3643,8 @@ void EditorShell::renderTextToolHint() {
   if (activeTool_ != ActiveTool::Text) {
     return;
   }
-  const std::string_view label =
-      internal::TextToolHintLabel(textTool_.isEditing(), textTool_.isDraggingBox());
+  const std::string_view label = internal::TextToolHintLabel(
+      textTool_.isEditing(), textTool_.isDraggingBox(), adaptiveUiLayout_.compactTouch());
   if (label.empty()) {
     return;
   }
@@ -3618,8 +3657,10 @@ void EditorShell::renderTextToolHint() {
   const float height = textSize.y + 2.0f * kReferenceChipPaddingY;
   const float paneCenterX = static_cast<float>(viewport.paneOrigin.x + viewport.paneSize.x * 0.5);
   const float x = paneCenterX - width * 0.5f;
-  const float y = static_cast<float>(viewport.paneOrigin.y + viewport.paneSize.y) - height -
-                  static_cast<float>(kCanvasScrollbarRailPx) - 10.0f;
+  const float y =
+      static_cast<float>(viewport.paneOrigin.y + viewport.paneSize.y) - height -
+      (adaptiveUiLayout_.showCanvasScrollbars ? static_cast<float>(kCanvasScrollbarRailPx) : 0.0f) -
+      10.0f;
   if (width > static_cast<float>(viewport.paneSize.x) || y < viewport.paneOrigin.y) {
     return;  // Pane too small for the hint.
   }
@@ -3635,6 +3676,9 @@ void EditorShell::renderTextToolHint() {
 }
 
 void EditorShell::renderCanvasScrollbars() {
+  if (!adaptiveUiLayout_.showCanvasScrollbars) {
+    return;
+  }
   const ViewportState& viewport = interactionController_.viewport();
   const CanvasScrollbars bars = ComputeCanvasScrollbars(viewport);
   if (!bars.horizontal.visible && !bars.vertical.visible) {
@@ -3706,13 +3750,185 @@ void EditorShell::renderCanvasScrollbars() {
   }
 }
 
+void EditorShell::renderCompactTopBar() {
+  if (!adaptiveUiLayout_.compactTouch()) {
+    return;
+  }
+
+  const Vector2i windowSize = window_.windowSize();
+  const EditorTheme& theme = EditorTheme::Active();
+  constexpr ImGuiWindowFlags kTopBarFlags =
+      ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
+      ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoDocking |
+      ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse;
+  ImGui::SetNextWindowPos(ImVec2(0.0f, 0.0f), ImGuiCond_Always);
+  ImGui::SetNextWindowSize(ImVec2(static_cast<float>(windowSize.x), adaptiveUiLayout_.topBarHeight),
+                           ImGuiCond_Always);
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(8.0f, 4.0f));
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
+  ImGui::PushStyleColor(ImGuiCol_WindowBg, theme.surfaceRaised);
+  ImGui::Begin("##compact_top_bar", nullptr, kTopBarFlags);
+  ImGui::PopStyleColor();
+  ImGui::PopStyleVar(2);
+
+  const float targetSize = std::max(44.0f, adaptiveUiLayout_.toolButtonSize);
+  constexpr float kButtonGap = 4.0f;
+  constexpr int kButtonCount = 5;
+  const float controlsWidth = targetSize * kButtonCount + kButtonGap * (kButtonCount - 1);
+  const float controlsX = std::max(8.0f, static_cast<float>(windowSize.x) - controlsWidth - 8.0f);
+
+  if (controlsX >= 84.0f) {
+    const ImVec2 brandSize = ImGui::CalcTextSize("DONNER");
+    ImGui::SetCursorPos(ImVec2(12.0f, (adaptiveUiLayout_.topBarHeight - brandSize.y) * 0.5f));
+    ImGui::TextColored(ImGui::ColorConvertU32ToFloat4(theme.textMuted), "DONNER");
+  }
+
+  enum class CompactIcon { Open, Undo, Redo, Layers, Inspector };
+  const auto drawIcon = [&](CompactIcon icon, const ImVec2& min, const ImVec2& max, ImU32 color) {
+    ImDrawList* drawList = ImGui::GetWindowDrawList();
+    const ImVec2 center((min.x + max.x) * 0.5f, (min.y + max.y) * 0.5f);
+    constexpr float kStroke = 2.0f;
+    switch (icon) {
+      case CompactIcon::Open:
+        drawList->AddRect(ImVec2(center.x - 9.0f, center.y - 5.0f),
+                          ImVec2(center.x + 9.0f, center.y + 8.0f), color, 2.0f, 0, kStroke);
+        drawList->AddLine(ImVec2(center.x - 8.0f, center.y - 5.0f),
+                          ImVec2(center.x - 4.0f, center.y - 9.0f), color, kStroke);
+        drawList->AddLine(ImVec2(center.x - 4.0f, center.y - 9.0f),
+                          ImVec2(center.x + 2.0f, center.y - 9.0f), color, kStroke);
+        break;
+      case CompactIcon::Undo:
+      case CompactIcon::Redo: {
+        const float direction = icon == CompactIcon::Undo ? -1.0f : 1.0f;
+        const std::array<ImVec2, 5> points = {
+            ImVec2(center.x + direction * 8.0f, center.y - 2.0f),
+            ImVec2(center.x + direction * 3.0f, center.y - 7.0f),
+            ImVec2(center.x - direction * 4.0f, center.y - 7.0f),
+            ImVec2(center.x - direction * 8.0f, center.y - 2.0f),
+            ImVec2(center.x - direction * 7.0f, center.y + 6.0f),
+        };
+        drawList->AddPolyline(points.data(), static_cast<int>(points.size()), color, 0, kStroke);
+        drawList->AddLine(points.front(), ImVec2(points.front().x, points.front().y - 7.0f), color,
+                          kStroke);
+        drawList->AddLine(points.front(),
+                          ImVec2(points.front().x - direction * 7.0f, points.front().y), color,
+                          kStroke);
+        break;
+      }
+      case CompactIcon::Layers:
+        for (int row = -1; row <= 1; ++row) {
+          const float y = center.y + static_cast<float>(row) * 6.0f;
+          drawList->AddRect(ImVec2(center.x - 9.0f, y - 2.0f), ImVec2(center.x - 5.0f, y + 2.0f),
+                            color, 1.0f, 0, kStroke);
+          drawList->AddLine(ImVec2(center.x - 1.0f, y), ImVec2(center.x + 9.0f, y), color, kStroke);
+        }
+        break;
+      case CompactIcon::Inspector: {
+        constexpr std::array<float, 3> kKnobOffsets = {-4.0f, 5.0f, -1.0f};
+        for (int row = 0; row < 3; ++row) {
+          const float y = center.y - 6.0f + static_cast<float>(row) * 6.0f;
+          drawList->AddLine(ImVec2(center.x - 9.0f, y), ImVec2(center.x + 9.0f, y), color, kStroke);
+          drawList->AddCircleFilled(ImVec2(center.x + kKnobOffsets[row], y), 2.5f, color);
+        }
+        break;
+      }
+    }
+  };
+  const auto button = [&](const char* id, CompactIcon icon, const char* tooltip, bool enabled,
+                          bool selected) {
+    if (selected) {
+      ImVec4 selectedFill = ImGui::ColorConvertU32ToFloat4(theme.accentDefault);
+      selectedFill.w = theme.selectionFillAlpha;
+      ImGui::PushStyleColor(ImGuiCol_Button, selectedFill);
+      ImGui::PushStyleColor(ImGuiCol_ButtonHovered, selectedFill);
+    }
+    ImGui::BeginDisabled(!enabled);
+    const bool clicked = ImGui::Button(id, ImVec2(targetSize, targetSize));
+    const ImVec2 itemMin = ImGui::GetItemRectMin();
+    const ImVec2 itemMax = ImGui::GetItemRectMax();
+    const bool hovered = ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled);
+    ImGui::EndDisabled();
+    drawIcon(icon, itemMin, itemMax,
+             enabled ? (selected ? theme.accentDefault : theme.textPrimary) : theme.textDisabled);
+    if (selected) {
+      ImGui::GetWindowDrawList()->AddRect(itemMin, itemMax, theme.accentDefault,
+                                          theme.radiusControl, 0, 1.5f);
+    }
+    if (hovered) {
+      ImGui::SetTooltip("%s", tooltip);
+    }
+    if (selected) {
+      ImGui::PopStyleColor(2);
+    }
+    return enabled && clicked;
+  };
+
+  ImGui::SetCursorPos(ImVec2(controlsX, 4.0f));
+  if (button("##compact_open", CompactIcon::Open, "Open or sample", true, false)) {
+    pendingSampleLoadId_.clear();
+    compactPanelVisible_ = false;
+    showSamplePicker_ = true;
+    window_.wakeEventLoop();
+  }
+  ImGui::SameLine(0.0f, kButtonGap);
+  if (button("##compact_undo", CompactIcon::Undo, "Undo", app_.canUndo(), false)) {
+    app_.undo();
+    requestRenderAtEndOfFrame_ = true;
+  }
+  ImGui::SameLine(0.0f, kButtonGap);
+  if (button("##compact_redo", CompactIcon::Redo, "Redo", app_.canRedo(), false)) {
+    app_.redo();
+    requestRenderAtEndOfFrame_ = true;
+  }
+  ImGui::SameLine(0.0f, kButtonGap);
+  if (button("##compact_layers", CompactIcon::Layers, "Layers", true,
+             compactPanelVisible_ && !compactInspectorSheet_)) {
+    if (compactPanelVisible_ && !compactInspectorSheet_) {
+      compactPanelVisible_ = false;
+    } else {
+      compactPanelVisible_ = true;
+      compactInspectorSheet_ = false;
+    }
+  }
+  ImGui::SameLine(0.0f, kButtonGap);
+  if (button("##compact_inspector", CompactIcon::Inspector, "Inspector", true,
+             compactPanelVisible_ && compactInspectorSheet_)) {
+    if (compactPanelVisible_ && compactInspectorSheet_) {
+      compactPanelVisible_ = false;
+    } else {
+      compactPanelVisible_ = true;
+      compactInspectorSheet_ = true;
+    }
+  }
+  ImGui::GetWindowDrawList()->AddLine(
+      ImVec2(0.0f, adaptiveUiLayout_.topBarHeight - 1.0f),
+      ImVec2(static_cast<float>(windowSize.x), adaptiveUiLayout_.topBarHeight - 1.0f),
+      theme.borderSubtle);
+  ImGui::End();
+}
+
 void EditorShell::renderSidebars() {
   // The right-column panels are dockable windows owned by the DockSpace (see
   // renderDockSpaceHost); their position, size, and tab bars are managed by
   // docking, so we no longer place them with SetNextWindowPos/Size. NoCollapse
   // keeps the docked tab from adding a collapse arrow; scrollbars stay enabled
   // so long panel content scrolls within its own node.
+  const bool compactSheet = adaptiveUiLayout_.compactTouch() && compactPanelVisible_;
+  if (adaptiveUiLayout_.compactTouch() && !compactSheet) {
+    layersPanelHoverElement_.reset();
+    updateSourceHoverPreview();
+    return;
+  }
   constexpr ImGuiWindowFlags kDockedPaneFlags = ImGuiWindowFlags_NoCollapse;
+  if (compactSheet) {
+    const Box2d sheetRect = *compactPanelScreenRect();
+    ImGui::SetNextWindowPos(
+        ImVec2(static_cast<float>(sheetRect.topLeft.x), static_cast<float>(sheetRect.topLeft.y)),
+        ImGuiCond_Always);
+    ImGui::SetNextWindowSize(
+        ImVec2(static_cast<float>(sheetRect.width()), static_cast<float>(sheetRect.height())),
+        ImGuiCond_Always);
+  }
   const auto& selectionBeforeTree = app_.selectedElement();
   if (selectionBeforeTree != lastTreeSelection_) {
     treeviewPendingScroll_ = selectionBeforeTree.has_value() && !treeSelectionOriginatedInTree_;
@@ -3735,7 +3951,39 @@ void EditorShell::renderSidebars() {
   // sidebar window. `SidebarPresenter` is still the
   // Inspector backend below (`renderInspector`), and its `renderTreeView` /
   // tests remain; it is simply no longer the user-facing outline.
-  ImGui::Begin(kLayersWindowName, nullptr, kDockedPaneFlags);
+  const char* firstPanelWindowName = compactSheet ? "##compact_panel_sheet" : kLayersWindowName;
+  const ImGuiWindowFlags firstPanelFlags =
+      compactSheet ? kDockedPaneFlags | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove |
+                         ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings |
+                         ImGuiWindowFlags_NoDocking
+                   : kDockedPaneFlags;
+  ImGui::Begin(firstPanelWindowName, nullptr, firstPanelFlags);
+  if (compactSheet) {
+    const EditorTheme& theme = EditorTheme::Active();
+    const ImVec2 headerStart = ImGui::GetCursorScreenPos();
+    const float headerWidth = ImGui::GetContentRegionAvail().x;
+    const float headerHeight = std::max(44.0f, adaptiveUiLayout_.toolButtonSize);
+    ImGui::SetCursorScreenPos(
+        ImVec2(headerStart.x, headerStart.y + (headerHeight - ImGui::GetTextLineHeight()) * 0.5f));
+    ImGui::TextUnformatted(compactInspectorSheet_ ? "Inspector" : "Layers");
+    const ImVec2 closeMin(headerStart.x + std::max(0.0f, headerWidth - headerHeight),
+                          headerStart.y);
+    ImGui::SetCursorScreenPos(closeMin);
+    if (ImGui::InvisibleButton("##compact_panel_close", ImVec2(headerHeight, headerHeight))) {
+      compactPanelVisible_ = false;
+    }
+    const ImVec2 closeMax = ImGui::GetItemRectMax();
+    const ImVec2 closeCenter((closeMin.x + closeMax.x) * 0.5f, (closeMin.y + closeMax.y) * 0.5f);
+    const ImU32 closeColor = ImGui::IsItemHovered() ? theme.textPrimary : theme.textMuted;
+    ImGui::GetWindowDrawList()->AddLine(ImVec2(closeCenter.x - 6.0f, closeCenter.y - 6.0f),
+                                        ImVec2(closeCenter.x + 6.0f, closeCenter.y + 6.0f),
+                                        closeColor, 2.0f);
+    ImGui::GetWindowDrawList()->AddLine(ImVec2(closeCenter.x + 6.0f, closeCenter.y - 6.0f),
+                                        ImVec2(closeCenter.x - 6.0f, closeCenter.y + 6.0f),
+                                        closeColor, 2.0f);
+    ImGui::SetCursorScreenPos(ImVec2(headerStart.x, headerStart.y + headerHeight));
+    ImGui::Separator();
+  }
   std::vector<std::uint64_t> liveThumbnailKeys;
   liveThumbnailKeys.reserve(layersPanel_.rows().size() + 4u);
   // Donner renders each row's preview to a bitmap during refreshSnapshot; here
@@ -3787,7 +4035,28 @@ void EditorShell::renderSidebars() {
   } else {
     layersPanel_.setLockedRejectionFlash(std::nullopt);
   }
-  layersPanel_.render(liveAppForClicks, thumbnailTextureProvider, layerIconTextureProvider);
+  if (compactSheet && compactInspectorSheet_) {
+    const ImGuiStyle& style = ImGui::GetStyle();
+    const float touchPaddingY =
+        std::max(style.FramePadding.y, (44.0f - ImGui::GetTextLineHeight()) * 0.5f);
+    ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(style.FramePadding.x, touchPaddingY));
+    const bool inspectorQueuedMutation = sidebarPresenter_.renderInspector(
+        liveAppForClicks, interactionController_.viewport(), sidebarIconTextureProvider);
+    const bool textInspectorQueuedMutation =
+        textInspectorPanel_.render(liveAppForClicks, ImGui::GetTime(), &fontCatalog_);
+    ImGui::PopStyleVar();
+    ImGui::End();
+    layersPanelHoverElement_.reset();
+    updateSourceHoverPreview();
+    if (inspectorQueuedMutation || textInspectorQueuedMutation) {
+      flushQueuedMutationAndRefreshOverlay();
+    }
+    thumbnailTextures_.retainThumbnailsOnly(liveThumbnailKeys);
+    lastTreeSelection_ = app_.selectedElement();
+    return;
+  }
+  layersPanel_.render(liveAppForClicks, thumbnailTextureProvider, layerIconTextureProvider,
+                      compactSheet ? 44.0f : 0.0f);
   // Feed the Layers-panel hover into the shared source-hover preview so the
   // canvas (and source pane) highlight the hovered element, the same way
   // hovering a source-pane token does.
@@ -3811,6 +4080,11 @@ void EditorShell::renderSidebars() {
   }
   ImGui::End();
   lastTreeSelection_ = app_.selectedElement();
+
+  if (compactSheet) {
+    thumbnailTextures_.retainThumbnailsOnly(liveThumbnailKeys);
+    return;
+  }
 
   ImGui::Begin(kInspectorWindowName, nullptr, kDockedPaneFlags);
   const bool inspectorQueuedMutation = sidebarPresenter_.renderInspector(
@@ -3956,7 +4230,8 @@ void EditorShell::renderSourcePaneSplitter(float windowWidth, float paneOriginY,
 }
 
 void EditorShell::renderDockSpaceHost(float hostX, float hostY, float hostWidth, float hostHeight) {
-  const ImGuiID dockspaceId = EditorDockSpaceId();
+  const bool sidebarsIncluded = !adaptiveUiLayout_.compactTouch();
+  const ImGuiID dockspaceId = sidebarsIncluded ? EditorDockSpaceId() : EditorCompactDockSpaceId();
 
   ImGui::SetNextWindowPos(ImVec2(hostX, hostY), ImGuiCond_Always);
   ImGui::SetNextWindowSize(ImVec2(hostWidth, hostHeight), ImGuiCond_Always);
@@ -3978,24 +4253,49 @@ void EditorShell::renderDockSpaceHost(float hostX, float hostY, float hostWidth,
   // missing/corrupt ini leaves no node, so we fall back to the default layout.
   // A reset request or a change to the docked-panel set always rebuilds.
   const bool hasNode = ImGui::DockBuilderGetNode(dockspaceId) != nullptr;
-  const bool compositorSetChanged = dockCompositorIncludedInLayout_ != showCompositorDebugPanel_;
+  const bool compositorSetChanged =
+      sidebarsIncluded && dockCompositorIncludedInLayout_ != showCompositorDebugPanel_;
+  const bool sidebarSetChanged = dockSidebarsIncludedInLayout_ != sidebarsIncluded;
   const bool needBuild =
-      dockLayoutResetRequested_ || !dockLayoutBuilt_ || !hasNode || compositorSetChanged;
+      sidebarsIncluded
+          ? dockLayoutResetRequested_ || !dockLayoutBuilt_ || !hasNode || compositorSetChanged
+          : dockLayoutResetRequested_ || !compactDockLayoutBuilt_ || !hasNode;
   if (needBuild) {
-    const bool adoptPersisted =
-        hasNode && !dockLayoutResetRequested_ && !dockLayoutBuilt_ && !compositorSetChanged;
+    const bool adoptPersisted = sidebarsIncluded && hasNode && !dockLayoutResetRequested_ &&
+                                !dockLayoutBuilt_ && !compositorSetChanged;
     if (!adoptPersisted) {
       EditorDockLayoutParams params;
       params.size = ImVec2(hostWidth, hostHeight);
       params.rightColumnRatio =
           hostWidth > 0.0f ? std::clamp(rightPaneWidth_ / hostWidth, 0.15f, 0.5f) : 0.26f;
       params.includeCompositorDebug = showCompositorDebugPanel_;
+      params.includeSidebars = sidebarsIncluded;
       BuildDefaultDockLayout(dockspaceId, params);
     }
-    dockLayoutBuilt_ = true;
-    dockLayoutResetRequested_ = false;
-    dockCompositorIncludedInLayout_ = showCompositorDebugPanel_;
+    if (sidebarsIncluded) {
+      dockLayoutBuilt_ = true;
+      dockLayoutResetRequested_ = false;
+      dockCompositorIncludedInLayout_ = showCompositorDebugPanel_;
+    } else {
+      compactDockLayoutBuilt_ = true;
+      if (dockLayoutResetRequested_) {
+        // Consume the request now, but force the preserved desktop tree to be
+        // rebuilt when desktop mode is next active.
+        dockLayoutBuilt_ = false;
+        dockLayoutResetRequested_ = false;
+      }
+    }
   }
+
+  if (sidebarSetChanged && !needBuild) {
+    // Compact mode temporarily docks Render into its canvas-only root. On the
+    // way back, restore it to the still-intact desktop central node without
+    // rebuilding or otherwise disturbing customized desktop panel nodes.
+    if (const ImGuiDockNode* centralNode = ImGui::DockBuilderGetCentralNode(dockspaceId)) {
+      ImGui::DockBuilderDockWindow(kRenderPaneWindowName, centralNode->ID);
+    }
+  }
+  dockSidebarsIncludedInLayout_ = sidebarsIncluded;
 
   ImGui::DockSpace(dockspaceId, ImVec2(0.0f, 0.0f), EditorDockSpaceFlags(dockLayoutLocked_));
   ImGui::End();
@@ -5240,22 +5540,42 @@ void EditorShell::runFrame() {
   markPhase(mainFrameCost.documentSyncMs);
 
   const Vector2i windowSize = window_.windowSize();
-  const float menuBarHeight = ImGui::GetFrameHeight();
+#ifdef __EMSCRIPTEN__
+  static const bool kPreferTouchInput =
+      EM_ASM_INT({
+        const hasTouchPoints = typeof navigator != = 'undefined' && navigator.maxTouchPoints > 0;
+        const hasCoarsePointer = typeof window != = 'undefined' && typeof window.matchMedia ==
+            = 'function' && window.matchMedia('(pointer: coarse)').matches;
+        return hasTouchPoints || hasCoarsePointer ? 1 : 0;
+      }) != 0;
+#else
+  constexpr bool kPreferTouchInput = false;
+#endif
+  adaptiveUiLayout_ = ComputeEditorAdaptiveUiLayout({
+      .windowWidth = static_cast<float>(windowSize.x),
+      .windowHeight = static_cast<float>(windowSize.y),
+      .preferTouch = kPreferTouchInput,
+  });
+  const bool compactUi = adaptiveUiLayout_.compactTouch();
+  const float menuBarHeight = compactUi ? adaptiveUiLayout_.topBarHeight : ImGui::GetFrameHeight();
   const float paneOriginY = menuBarHeight;
   const float paneHeight = std::max(0.0f, static_cast<float>(windowSize.y) - paneOriginY);
   const EditorMainPaneLayout mainPaneLayout = ComputeEditorMainPaneLayout({
       .windowWidth = static_cast<float>(windowSize.x),
-      .sourcePaneVisible = sourcePaneVisible_,
+      .sourcePaneVisible = !compactUi && sourcePaneVisible_,
       .sourcePaneWidth = sourcePaneWidth_,
       .minSourcePaneWidth = kMinSourcePaneWidth,
       .maxSourcePaneWidth = kMaxSourcePaneWidth,
       .sourcePaneRailWidth = kSourcePaneRevealHandleWidth,
       .rightPaneWidth = rightPaneWidth_,
+      .rightPaneVisible = !compactUi,
       .minRightPaneWidth = kMinRightPaneWidth,
       .maxRightPaneWidth = kMaxRightPaneWidth,
       .minRenderPaneWidth = kMinRightPaneWidth,
   });
-  rightPaneWidth_ = mainPaneLayout.rightPaneWidth;
+  if (!compactUi) {
+    rightPaneWidth_ = mainPaneLayout.rightPaneWidth;
+  }
   const float dockHostX = mainPaneLayout.renderPaneX;
   const float dockHostWidth = std::max(0.0f, static_cast<float>(windowSize.x) - dockHostX);
 
@@ -5271,7 +5591,8 @@ void EditorShell::runFrame() {
   // window's content region below.
   Vector2d renderPaneOrigin(dockHostX, paneOriginY);
   Vector2d renderPaneSize(dockHostWidth, paneHeight);
-  if (const ImGuiDockNode* centralNode = ImGui::DockBuilderGetCentralNode(EditorDockSpaceId())) {
+  const ImGuiID activeDockspaceId = compactUi ? EditorCompactDockSpaceId() : EditorDockSpaceId();
+  if (const ImGuiDockNode* centralNode = ImGui::DockBuilderGetCentralNode(activeDockspaceId)) {
     if (centralNode->Size.x > 0.0f && centralNode->Size.y > 0.0f) {
       renderPaneOrigin = Vector2d(centralNode->Pos.x, centralNode->Pos.y);
       renderPaneSize = Vector2d(centralNode->Size.x, centralNode->Size.y);
@@ -5289,7 +5610,7 @@ void EditorShell::runFrame() {
 
   const bool rendererIdle = !renderCoordinator_.asyncRenderer().isBusy();
   MenuBarState menuState{
-      .sourcePaneFocused = sourcePaneVisible_ && textEditor_.isFocused(),
+      .sourcePaneFocused = !compactUi && sourcePaneVisible_ && textEditor_.isFocused(),
       .canSave = app_.hasDocument(),
       .canRevert = app_.hasDocument() && app_.isDirty() && !app_.cleanSourceText().empty(),
       .canUndo = app_.canUndo(),
@@ -5307,7 +5628,12 @@ void EditorShell::runFrame() {
       .perfOverlayMode = perfOverlayMode_,
       .panelLayoutLocked = dockLayoutLocked_,
   };
-  const MenuBarActions menuActions = menuBarPresenter_.render(menuState, uiFontBold_);
+  MenuBarActions menuActions;
+  if (compactUi) {
+    renderCompactTopBar();
+  } else {
+    menuActions = menuBarPresenter_.render(menuState, uiFontBold_);
+  }
   applyMenuActions(menuActions);
 
   // On macOS, service any pending open/save with a native OS panel; this
@@ -5323,7 +5649,7 @@ void EditorShell::runFrame() {
   markPhase(mainFrameCost.menusDialogsMs);
 
   std::ignore = highlightSelectionSourceIfNeeded();
-  if (sourcePaneVisible_) {
+  if (!compactUi && sourcePaneVisible_) {
     renderSourcePane(paneOriginY, paneHeight, mainPaneLayout.sourcePaneWidth, codeFont_);
   }
   markPhase(mainFrameCost.sourcePaneMs);
@@ -5342,8 +5668,10 @@ void EditorShell::runFrame() {
   // The left source/render splitter stays manual (its collapse/reveal behavior is
   // out of scope for docking); the right-column splitters and the Compositor
   // Debug float are now owned by the DockSpace submitted above.
-  renderSourcePaneSplitter(static_cast<float>(windowSize.x), paneOriginY, paneHeight,
-                           mainPaneLayout.sourcePaneWidth);
+  if (!compactUi) {
+    renderSourcePaneSplitter(static_cast<float>(windowSize.x), paneOriginY, paneHeight,
+                             mainPaneLayout.sourcePaneWidth);
+  }
   if (!contentOnlyCaptureThisFrame_ && showSamplePicker_) {
     renderSamplePicker(ImVec2(0.0f, paneOriginY),
                        ImVec2(static_cast<float>(windowSize.x), paneHeight));
@@ -5401,11 +5729,12 @@ void EditorShell::runFrame() {
 
 namespace internal {
 
-std::string_view TextToolHintLabel(bool isEditing, bool isDraggingBox) {
+std::string_view TextToolHintLabel(bool isEditing, bool isDraggingBox, bool touchPreferred) {
   if (isEditing || isDraggingBox) {
     return {};
   }
-  return "Double-click to place text. Drag to draw a text box.";
+  return touchPreferred ? "Double-tap to place text. Drag to draw a text box."
+                        : "Double-click to place text. Drag to draw a text box.";
 }
 
 PendingClickBusyAction PendingClickBusyActionForState(bool tookFastRedrag, bool rendererBusy) {

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -276,6 +276,11 @@ bool CanvasChromeCapturesInput(const ImVec2& point, const std::optional<Box2d>& 
          (compactPanelRect.has_value() && ContainsScreenPoint(*compactPanelRect, point));
 }
 
+bool CanvasScrollbarsCaptureInput(bool scrollbarsVisible, const ViewportState& viewport,
+                                  const Vector2d& screenPoint) noexcept {
+  return scrollbarsVisible && CanvasScrollbarsContain(viewport, screenPoint);
+}
+
 bool GroupOperationCanDispatch(bool rendererBusy,
                                const GroupOperationAvailability& availability) noexcept {
   return !rendererBusy && availability.canApply;
@@ -2880,8 +2885,9 @@ void EditorShell::renderRenderPane(ImGuiWindowFlags paneFlags) {
   }
 
   const ImVec2 hoverMousePos = ImGui::GetMousePos();
-  const bool overCanvasScrollbar = CanvasScrollbarsContain(
-      interactionController_.viewport(), Vector2d(hoverMousePos.x, hoverMousePos.y));
+  const bool overCanvasScrollbar = internal::CanvasScrollbarsCaptureInput(
+      adaptiveUiLayout_.showCanvasScrollbars, interactionController_.viewport(),
+      Vector2d(hoverMousePos.x, hoverMousePos.y));
   const bool toolEligible =
       canvasHovered && !interactionController_.panning() && !spaceHeld && !overCanvasScrollbar;
   const bool selectToolActive = activeTool_ == ActiveTool::Select;
@@ -3999,7 +4005,10 @@ void EditorShell::renderSidebars() {
     // Compact sheets use deterministic fill swatches. Avoiding per-row raster
     // rendering and texture uploads keeps the touch panel responsive and also
     // avoids backend-specific thumbnail presentation differences in Wasm.
-    layersPanel_.refreshSnapshot(app_, compactSheet ? nullptr : &layerThumbnailRenderer_);
+    layersPanel_.refreshSnapshot(
+        app_, compactSheet ? nullptr : &layerThumbnailRenderer_,
+        compactSheet ? LayersPanel::ThumbnailRefreshMode::SwatchesOnly
+                     : LayersPanel::ThumbnailRefreshMode::Render);
   }
   EditorApp* liveAppForClicks = rendererBusy ? nullptr : &app_;
 

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -5543,9 +5543,9 @@ void EditorShell::runFrame() {
 #ifdef __EMSCRIPTEN__
   static const bool kPreferTouchInput =
       EM_ASM_INT({
-        const hasTouchPoints = typeof navigator != = 'undefined' && navigator.maxTouchPoints > 0;
-        const hasCoarsePointer = typeof window != = 'undefined' && typeof window.matchMedia ==
-            = 'function' && window.matchMedia('(pointer: coarse)').matches;
+        const hasTouchPoints = navigator.maxTouchPoints > 0;
+        const hasCoarsePointer =
+            window.matchMedia && window.matchMedia('(pointer: coarse)').matches;
         return hasTouchPoints || hasCoarsePointer ? 1 : 0;
       }) != 0;
 #else

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -3604,7 +3604,13 @@ void EditorShell::renderSamplePicker(const ImVec2& paneOrigin, const ImVec2& con
   }
   if (actions.openGitHub) {
 #ifdef __EMSCRIPTEN__
-    EM_ASM({ window.open('https://github.com/jwmcglynn/donner', '_blank', 'noopener'); });
+    EM_ASM({
+      const url = 'https://github.com/jwmcglynn/donner';
+      const opened = window.open(url, '_blank', 'noopener');
+      if (!opened) {
+        window.location.assign(url);
+      }
+    });
 #else
     ImGui::SetClipboardText(kSamplePickerGitHubUrl.data());
 #endif

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -709,8 +709,10 @@ EditorShell::EditorShell(gui::EditorWindow& window, EditorShellOptions options)
       textEditor_(),
       textures_(window.geodeDevice()),
       thumbnailTextures_(window.geodeDevice()),
+      sampleThumbnailTextures_(window.geodeDevice()),
       toolbarIconTextures_(window.geodeDevice()),
       layerThumbnailRenderer_(window.geodeDevice()),
+      sampleThumbnailRenderer_(window.geodeDevice()),
       renderCoordinator_(window.geodeDevice()),
       rotateCursorSet_(),
       documentSyncController_(InitialDocumentSyncSource(options_)),
@@ -3495,6 +3497,35 @@ void EditorShell::renderRenderPane(ImGuiWindowFlags paneFlags) {
   ImGui::End();
 }
 
+void EditorShell::ensureSampleThumbnails() {
+  constexpr int kThumbnailWidthPx = 192;
+  constexpr int kThumbnailHeightPx = 120;
+  const std::span<const EditorSample> samples = GetEditorSampleCatalog();
+  if (sampleThumbnailBitmaps_.empty()) {
+    sampleThumbnailBitmaps_.resize(samples.size());
+  }
+  if (sampleThumbnailGenerationCursor_ >= samples.size()) {
+    return;
+  }
+
+  const std::size_t index = sampleThumbnailGenerationCursor_++;
+  const EditorSample& sample = samples[index];
+  ParseWarningSink warnings = ParseWarningSink::Disabled();
+  auto parsed = svg::parser::SVGParser::ParseSVG(sample.source, warnings);
+  if (!parsed.hasError()) {
+    svg::SVGDocument document = std::move(parsed.result());
+    document.setCanvasSize(kThumbnailWidthPx, kThumbnailHeightPx);
+    sampleThumbnailRenderer_.draw(document);
+    svg::RendererBitmap bitmap = sampleThumbnailRenderer_.takeSnapshot();
+    if (!bitmap.empty()) {
+      sampleThumbnailBitmaps_[index] = std::move(bitmap);
+    }
+  }
+  if (sampleThumbnailGenerationCursor_ < samples.size()) {
+    window_.wakeEventLoop();
+  }
+}
+
 void EditorShell::renderSamplePicker(const ImVec2& paneOrigin, const ImVec2& contentRegion) {
   if (contentRegion.x <= 0.0f || contentRegion.y <= 0.0f) {
     return;
@@ -3519,8 +3550,24 @@ void EditorShell::renderSamplePicker(const ImVec2& paneOrigin, const ImVec2& con
   ImGui::SetCursorPosY(contentRegion.y < 560.0f ? 8.0f : 32.0f);
   ImGui::BeginChild("##sample_picker_content", ImVec2(contentWidth, 0.0f), ImGuiChildFlags_None,
                     ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoSavedSettings);
+  ensureSampleThumbnails();
+  const SamplePickerThumbnailProvider thumbnailProvider =
+      [this](const EditorSample&, std::size_t index) -> SamplePickerThumbnail {
+    if (index >= sampleThumbnailBitmaps_.size() || !sampleThumbnailBitmaps_[index].has_value()) {
+      return {};
+    }
+    constexpr std::uint64_t kSampleThumbnailKeyBase = 0x53414d5000000000ULL;
+    const GlTextureCache::ThumbnailTextureView uploaded = sampleThumbnailTextures_.uploadThumbnail(
+        kSampleThumbnailKeyBase + index, *sampleThumbnailBitmaps_[index]);
+    return SamplePickerThumbnail{
+        .texture = uploaded.texture,
+        .uvBottomRight = uploaded.uvBottomRight,
+        .aspectRatio = static_cast<float>(sampleThumbnailBitmaps_[index]->dimensions.x) /
+                       static_cast<float>(sampleThumbnailBitmaps_[index]->dimensions.y),
+    };
+  };
   const SamplePickerActions actions = samplePickerPresenter_.render(
-      SamplePickerState{.visible = true, .selectedSampleId = activeSampleId_});
+      SamplePickerState{.visible = true, .selectedSampleId = activeSampleId_}, thumbnailProvider);
   ImGui::EndChild();
 
   if (pendingSampleLoadNeedsConfirmation_) {

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -376,6 +376,7 @@ private:
   void renderFillStrokeToolbarWidget();
   void renderCompactTopBar();
   void renderSidebars();
+  void ensureSampleThumbnails();
   void renderSamplePicker(const ImVec2& paneOrigin, const ImVec2& contentRegion);
   void renderSourcePaneSplitter(float windowWidth, float paneOriginY, float paneHeight,
                                 float sourcePaneWidth);
@@ -486,6 +487,9 @@ private:
   /// preview bitmap to a GL/WGPU texture (same path as the render pane) keyed by
   /// row stable id, so ImGui can blit the real thumbnail instead of a swatch.
   GlTextureCache thumbnailTextures_;
+  /// Dedicated cache for the bounded welcome catalog. It is intentionally
+  /// separate from row thumbnails, whose retention sweep follows live layers.
+  GlTextureCache sampleThumbnailTextures_;
   /// Toolbar tool-icon texture cache. Holds the Donner-rendered white-mask
   /// bitmaps for the palette icons, keyed by a stable per-icon id. Never
   /// retention-swept (unlike `thumbnailTextures_`), so the four icons upload
@@ -495,6 +499,10 @@ private:
   /// shares the editor's Geode device but is never bound to the live framebuffer,
   /// so row previews cannot inherit presentation state from the main renderer.
   svg::Renderer layerThumbnailRenderer_;
+  /// Offscreen renderer and owned bitmaps for the four built-in sample cards.
+  svg::Renderer sampleThumbnailRenderer_;
+  std::vector<std::optional<svg::RendererBitmap>> sampleThumbnailBitmaps_;
+  std::size_t sampleThumbnailGenerationCursor_ = 0;
   RenderCoordinator renderCoordinator_;
   RotateCursorSet rotateCursorSet_;
   DocumentSyncController documentSyncController_;

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -374,6 +374,7 @@ private:
   void renderEditingScopeBreadcrumb();
   void renderCanvasZoomControl();
   void renderFillStrokeToolbarWidget();
+  void renderCompactTopBar();
   void renderSidebars();
   void renderSamplePicker(const ImVec2& paneOrigin, const ImVec2& contentRegion);
   void renderSourcePaneSplitter(float windowWidth, float paneOriginY, float paneHeight,
@@ -382,6 +383,7 @@ private:
   /// the right-column dockable panels, (re)building the default locked layout on
   /// first frame, after a reset, or when the docked-panel set changes.
   void renderDockSpaceHost(float hostX, float hostY, float hostWidth, float hostHeight);
+  [[nodiscard]] std::optional<Box2d> compactPanelScreenRect() const;
   void renderLayerPanelContents();
   void maybeLogResourceDiagnostics(const FrameCostBreakdown& frameCost);
   void maybeLogFrameMissTelemetry(const FrameCostBreakdown& frameCost);
@@ -565,6 +567,11 @@ private:
   /// Whether the DockSpace layout has been built (or adopted from the persisted
   /// .ini) at least once this session.
   bool dockLayoutBuilt_ = false;
+  /// Whether the canvas-only compact DockSpace has been built this session.
+  bool compactDockLayoutBuilt_ = false;
+  /// Whether the active DockSpace includes persistent sidebars. Used to rebind
+  /// the canvas between separate desktop and compact roots on profile changes.
+  bool dockSidebarsIncludedInLayout_ = true;
   /// Whether the currently built layout reserves a node for the Compositor Debug
   /// panel. Tracks \ref showCompositorDebugPanel_ so toggling the panel rebuilds
   /// the layout to add or reclaim its slot.
@@ -619,6 +626,11 @@ private:
   std::string pendingSampleLoadId_;
   bool pendingSampleLoadNeedsConfirmation_ = false;
   bool pendingSampleLoadDiscardConfirmed_ = false;
+  /// Current compact sheet state. Desktop keeps the source/sidebar preferences
+  /// above intact so switching profiles does not rewrite user layout choices.
+  bool compactPanelVisible_ = false;
+  bool compactInspectorSheet_ = false;
+  EditorAdaptiveUiLayout adaptiveUiLayout_;
   /// Whether the Compositor Debug panel window renders. Off by default: it is a
   /// developer-facing composite-tile diagnostics view, toggled on via the View
   /// menu. The user-facing Layers panel is unrelated and always visible.

--- a/donner/editor/EditorShellInternal.h
+++ b/donner/editor/EditorShellInternal.h
@@ -10,6 +10,7 @@
 #include "donner/base/Box.h"
 #include "donner/base/Transform.h"
 #include "donner/css/Color.h"
+#include "donner/editor/CanvasScrollbars.h"
 #include "donner/editor/EditorApp.h"
 #include "donner/editor/FocusView.h"
 #include "donner/editor/FrameMissTelemetry.h"
@@ -80,6 +81,9 @@ enum class PendingClickIdleAction {
     const Box2d& toolPaletteRect, const std::optional<Box2d>& textFormatBarRect,
     const std::optional<Box2d>& editingScopeBreadcrumbRect, const Box2d& canvasZoomControlRect,
     const std::optional<Box2d>& compactPanelRect = std::nullopt);
+[[nodiscard]] bool CanvasScrollbarsCaptureInput(bool scrollbarsVisible,
+                                                const ViewportState& viewport,
+                                                const Vector2d& screenPoint) noexcept;
 [[nodiscard]] bool GroupOperationCanDispatch(
     bool rendererBusy, const GroupOperationAvailability& availability) noexcept;
 [[nodiscard]] bool PendingDocumentReplacementCanProcess(bool hasPendingRequest, bool rendererBusy,

--- a/donner/editor/EditorShellInternal.h
+++ b/donner/editor/EditorShellInternal.h
@@ -75,12 +75,11 @@ enum class PendingClickIdleAction {
                                                            const ImVec2& contentRegion,
                                                            const Box2d& toolPaletteRect,
                                                            bool visible, float barHeight);
-[[nodiscard]] bool CanvasChromeCapturesInput(const ImVec2& point,
-                                             const std::optional<Box2d>& referenceChipRect,
-                                             const Box2d& toolPaletteRect,
-                                             const std::optional<Box2d>& textFormatBarRect,
-                                             const std::optional<Box2d>& editingScopeBreadcrumbRect,
-                                             const Box2d& canvasZoomControlRect);
+[[nodiscard]] bool CanvasChromeCapturesInput(
+    const ImVec2& point, const std::optional<Box2d>& referenceChipRect,
+    const Box2d& toolPaletteRect, const std::optional<Box2d>& textFormatBarRect,
+    const std::optional<Box2d>& editingScopeBreadcrumbRect, const Box2d& canvasZoomControlRect,
+    const std::optional<Box2d>& compactPanelRect = std::nullopt);
 [[nodiscard]] bool GroupOperationCanDispatch(
     bool rendererBusy, const GroupOperationAvailability& availability) noexcept;
 [[nodiscard]] bool PendingDocumentReplacementCanProcess(bool hasPendingRequest, bool rendererBusy,
@@ -93,7 +92,8 @@ enum class PendingClickIdleAction {
 /// Discoverability hint for the idle text tool ("double-click places point
 /// text, drag draws a box"). Empty while a session or box drag is active -
 /// the hint only shows when the next click/drag would act on empty canvas.
-[[nodiscard]] std::string_view TextToolHintLabel(bool isEditing, bool isDraggingBox);
+[[nodiscard]] std::string_view TextToolHintLabel(bool isEditing, bool isDraggingBox,
+                                                 bool touchPreferred = false);
 [[nodiscard]] css::RGBA PaintServerFallbackColor();
 [[nodiscard]] ToolbarPaintSlotState ToolbarPaintSlotStateForActiveAttribute(std::string_view value);
 [[nodiscard]] ToolbarPaintReferenceState ToolbarPaintReferenceStateFor(

--- a/donner/editor/EditorShellLayout.cc
+++ b/donner/editor/EditorShellLayout.cc
@@ -4,13 +4,70 @@
 
 namespace donner::editor {
 
+namespace {
+
+constexpr float kCompactWidthThreshold = 760.0f;
+constexpr float kCompactHeightThreshold = 520.0f;
+constexpr float kCompactTopBarHeight = 52.0f;
+constexpr float kCompactToolButtonSize = 44.0f;
+constexpr float kCompactPanelFraction = 0.42f;
+constexpr float kCompactPanelMinWidth = 280.0f;
+constexpr float kCompactPanelMaxWidth = 380.0f;
+constexpr float kCompactPanelMinHeight = 220.0f;
+constexpr float kCompactPanelMaxHeight = 360.0f;
+
+}  // namespace
+
+EditorAdaptiveUiLayout ComputeEditorAdaptiveUiLayout(const EditorAdaptiveUiInput& input) {
+  const float windowWidth = std::max(0.0f, input.windowWidth);
+  const float windowHeight = std::max(0.0f, input.windowHeight);
+  const bool constrained =
+      windowWidth < kCompactWidthThreshold || windowHeight < kCompactHeightThreshold;
+
+  EditorAdaptiveUiLayout layout;
+  if (!input.preferTouch && !constrained) {
+    return layout;
+  }
+
+  layout.mode = EditorUiMode::CompactTouch;
+  layout.topBarHeight = std::min(kCompactTopBarHeight, windowHeight);
+  layout.toolButtonSize = kCompactToolButtonSize;
+  layout.showPaintControls = false;
+  layout.showTextFormatBar = false;
+  layout.showCanvasScrollbars = false;
+
+  if (windowWidth > windowHeight) {
+    layout.panelPlacement = CompactPanelPlacement::Right;
+    const float availableHeight = std::max(0.0f, windowHeight - layout.topBarHeight);
+    const float requestedWidth = windowWidth * kCompactPanelFraction;
+    layout.panelWidth = std::min(
+        windowWidth, std::clamp(requestedWidth, kCompactPanelMinWidth, kCompactPanelMaxWidth));
+    layout.panelHeight = availableHeight;
+    layout.panelX = windowWidth - layout.panelWidth;
+    layout.panelY = layout.topBarHeight;
+  } else {
+    layout.panelPlacement = CompactPanelPlacement::Bottom;
+    const float availableHeight = std::max(0.0f, windowHeight - layout.topBarHeight);
+    const float requestedHeight = windowHeight * kCompactPanelFraction;
+    layout.panelWidth = windowWidth;
+    layout.panelHeight =
+        std::min(availableHeight,
+                 std::clamp(requestedHeight, kCompactPanelMinHeight, kCompactPanelMaxHeight));
+    layout.panelX = 0.0f;
+    layout.panelY = windowHeight - layout.panelHeight;
+  }
+  return layout;
+}
+
 EditorMainPaneLayout ComputeEditorMainPaneLayout(const EditorMainPaneLayoutInput& input) {
   const float windowWidth = std::max(0.0f, input.windowWidth);
   const float minSourcePaneWidth = std::max(0.0f, input.minSourcePaneWidth);
   const float maxSourcePaneWidth = std::max(minSourcePaneWidth, input.maxSourcePaneWidth);
-  const float minRightPaneWidth = std::max(0.0f, input.minRightPaneWidth);
+  const float minRightPaneWidth =
+      input.rightPaneVisible ? std::max(0.0f, input.minRightPaneWidth) : 0.0f;
   const float minRenderPaneWidth = std::max(0.0f, input.minRenderPaneWidth);
-  const float maxRightPaneWidth = std::max(minRightPaneWidth, input.maxRightPaneWidth);
+  const float maxRightPaneWidth =
+      input.rightPaneVisible ? std::max(minRightPaneWidth, input.maxRightPaneWidth) : 0.0f;
   const float sourcePaneRailWidth =
       input.sourcePaneVisible ? 0.0f : std::clamp(input.sourcePaneRailWidth, 0.0f, windowWidth);
   const float sourcePaneUpperBound = std::max(
@@ -28,7 +85,10 @@ EditorMainPaneLayout ComputeEditorMainPaneLayout(const EditorMainPaneLayoutInput
   EditorMainPaneLayout layout;
   layout.sourcePaneWidth = sourcePaneWidth;
   layout.sourcePaneRailWidth = sourcePaneRailWidth;
-  layout.rightPaneWidth = std::clamp(input.rightPaneWidth, minRightPaneWidth, rightPaneUpperBound);
+  layout.rightPaneWidth =
+      input.rightPaneVisible
+          ? std::clamp(input.rightPaneWidth, minRightPaneWidth, rightPaneUpperBound)
+          : 0.0f;
   layout.renderPaneX = leftChromeWidth;
   layout.renderPaneWidth = std::max(0.0f, windowWidth - leftChromeWidth - layout.rightPaneWidth);
   layout.rightPaneX = windowWidth - layout.rightPaneWidth;

--- a/donner/editor/EditorShellLayout.h
+++ b/donner/editor/EditorShellLayout.h
@@ -3,6 +3,66 @@
 
 namespace donner::editor {
 
+/// Editor chrome profile selected from viewport constraints and input type.
+enum class EditorUiMode {
+  Desktop,       ///< Persistent desktop menus, source access, and docked panels.
+  CompactTouch,  ///< Canvas-first chrome with touch-sized controls and one panel sheet.
+};
+
+/// Edge used for the compact Layers or Inspector sheet.
+enum class CompactPanelPlacement {
+  Right,   ///< Landscape viewport: panel overlays the right edge.
+  Bottom,  ///< Portrait or square viewport: panel overlays the bottom edge.
+};
+
+/// Inputs used to select and size the adaptive editor chrome.
+struct EditorAdaptiveUiInput {
+  /// Full editor window width in logical screen pixels.
+  float windowWidth = 0.0f;
+  /// Full editor window height in logical screen pixels.
+  float windowHeight = 0.0f;
+  /// Whether the current platform or pointer source should prefer touch controls.
+  bool preferTouch = false;
+};
+
+/// Adaptive editor chrome geometry and feature subset for one frame.
+struct EditorAdaptiveUiLayout {
+  /// Selected desktop or compact-touch profile.
+  EditorUiMode mode = EditorUiMode::Desktop;
+  /// Edge used by the compact panel sheet.
+  CompactPanelPlacement panelPlacement = CompactPanelPlacement::Right;
+  /// Height reserved for compact top-level commands. Zero in desktop mode.
+  float topBarHeight = 0.0f;
+  /// Square tool-button size in logical pixels.
+  float toolButtonSize = 32.0f;
+  /// Compact sheet origin and size. Zero-sized in desktop mode.
+  float panelX = 0.0f;
+  float panelY = 0.0f;
+  float panelWidth = 0.0f;
+  float panelHeight = 0.0f;
+  /// Whether the canvas palette includes the combined fill/stroke control.
+  bool showPaintControls = true;
+  /// Whether the contextual text format bar is available.
+  bool showTextFormatBar = true;
+  /// Whether mouse-oriented canvas scrollbars are drawn.
+  bool showCanvasScrollbars = true;
+
+  /// Return true when the compact touch profile is active.
+  [[nodiscard]] bool compactTouch() const { return mode == EditorUiMode::CompactTouch; }
+};
+
+/**
+ * Select and size the editor's desktop or compact-touch chrome.
+ *
+ * Constrained native windows use the compact profile even before a touch event.
+ * Touch-preferred platforms use it at every size so controls never shrink after
+ * the first gesture.
+ *
+ * @param input Window geometry and input preference.
+ */
+[[nodiscard]] EditorAdaptiveUiLayout ComputeEditorAdaptiveUiLayout(
+    const EditorAdaptiveUiInput& input);
+
 /// Inputs used to compute the editor's horizontal source/render/sidebar layout.
 struct EditorMainPaneLayoutInput {
   /// Full editor window width in screen pixels.
@@ -19,6 +79,8 @@ struct EditorMainPaneLayoutInput {
   float sourcePaneRailWidth = 0.0f;
   /// Persisted/requested right sidebar width.
   float rightPaneWidth = 0.0f;
+  /// Whether the persistent right sidebar participates in the layout.
+  bool rightPaneVisible = true;
   /// Minimum right sidebar width.
   float minRightPaneWidth = 0.0f;
   /// Maximum right sidebar width.

--- a/donner/editor/LayersPanel.cc
+++ b/donner/editor/LayersPanel.cc
@@ -219,7 +219,8 @@ ImU32 ToImU32(const css::RGBA& rgba) {
 
 }  // namespace
 
-void LayersPanel::refreshSnapshot(const EditorApp& app, svg::Renderer* renderer) {
+void LayersPanel::refreshSnapshot(const EditorApp& app, svg::Renderer* renderer,
+                                  ThumbnailRefreshMode mode) {
   model_.refresh(app);
 
   const auto renderStart = std::chrono::steady_clock::now();
@@ -239,9 +240,10 @@ void LayersPanel::refreshSnapshot(const EditorApp& app, svg::Renderer* renderer)
 
   std::unordered_set<std::uint64_t> liveStableIds;
   liveStableIds.reserve(model_.rows().size());
-  const bool renderThumbnails = !app.document().document().hasPendingRenderInvalidation();
+  const bool renderThumbnails = mode == ThumbnailRefreshMode::Render &&
+                                !app.document().document().hasPendingRenderInvalidation();
   const Vector2i thumbnailMaxSizePx(kPreviewWidthPx, kPreviewHeightPx);
-  if (!renderThumbnails) {
+  if (mode == ThumbnailRefreshMode::Render && !renderThumbnails) {
     thumbnailRefreshStats_.skippedForCanvasInvalidationCount = model_.rows().size();
   }
   std::optional<svg::Renderer> fallbackRenderer;

--- a/donner/editor/LayersPanel.cc
+++ b/donner/editor/LayersPanel.cc
@@ -147,8 +147,8 @@ bool DrawLayerIconButton(const char* id, LayerAffordanceIcon icon,
       const LayersPanel::IconTexture iconTexture =
           iconTextureProvider(LayerAffordanceIconTextureKey(icon), *bitmap);
       if (iconTexture.texture != 0) {
-        const ImVec2 iconMin(buttonMin.x + style.FramePadding.x,
-                             buttonMin.y + style.FramePadding.y);
+        const ImVec2 iconMin(buttonMin.x + (buttonSize.x - iconSize.x) * 0.5f,
+                             buttonMin.y + (buttonSize.y - iconSize.y) * 0.5f);
         const ImVec2 iconMax(iconMin.x + iconSize.x, iconMin.y + iconSize.y);
         const ImVec2 uvTopLeft(0.0f, 0.0f);
         const ImVec2 uvBottomRight(static_cast<float>(iconTexture.uvBottomRight.x),

--- a/donner/editor/LayersPanel.cc
+++ b/donner/editor/LayersPanel.cc
@@ -110,8 +110,10 @@ std::uint64_t DisclosureChevronTextureKey(bool expanded) {
 /// click. The chevron points right when collapsed and down when expanded, drawn
 /// from the Donner-rendered chevron mask and tinted with the current text color.
 bool DrawDisclosureChevronButton(const char* id, bool expanded,
-                                 const LayersPanel::IconTextureProvider& iconTextureProvider) {
-  const ImVec2 cellSize(ImGui::GetFrameHeight(), ImGui::GetFrameHeight());
+                                 const LayersPanel::IconTextureProvider& iconTextureProvider,
+                                 float minimumInteractionHeight) {
+  const float targetSize = std::max(ImGui::GetFrameHeight(), minimumInteractionHeight);
+  const ImVec2 cellSize(targetSize, targetSize);
   const ImVec2 cellMin = ImGui::GetCursorScreenPos();
   const bool clicked = ImGui::InvisibleButton(id, cellSize);
   if (iconTextureProvider) {
@@ -129,11 +131,13 @@ bool DrawDisclosureChevronButton(const char* id, bool expanded,
 }
 
 bool DrawLayerIconButton(const char* id, LayerAffordanceIcon icon,
-                         const LayersPanel::IconTextureProvider& iconTextureProvider) {
+                         const LayersPanel::IconTextureProvider& iconTextureProvider,
+                         float minimumInteractionHeight) {
   const ImVec2 iconSize(kAffordanceIconSize, kAffordanceIconSize);
   const ImGuiStyle& style = ImGui::GetStyle();
-  const ImVec2 buttonSize(iconSize.x + style.FramePadding.x * 2.0f,
-                          iconSize.y + style.FramePadding.y * 2.0f);
+  const ImVec2 buttonSize(
+      std::max(iconSize.x + style.FramePadding.x * 2.0f, minimumInteractionHeight),
+      std::max(iconSize.y + style.FramePadding.y * 2.0f, minimumInteractionHeight));
   const ImVec2 buttonMin = ImGui::GetCursorScreenPos();
   const bool clicked = ImGui::InvisibleButton(id, buttonSize);
 
@@ -482,7 +486,8 @@ void LayersPanel::beginRename(std::uint64_t stableId) {
 }
 
 void LayersPanel::render(EditorApp* liveApp, const ThumbnailTextureProvider& textureProvider,
-                         const IconTextureProvider& iconTextureProvider) {
+                         const IconTextureProvider& iconTextureProvider,
+                         float minimumInteractionHeight) {
   const std::vector<LayerTreeRow>& rows = model_.rows();
   if (rows.empty()) {
     ImGui::TextDisabled("(no document)");
@@ -492,6 +497,7 @@ void LayersPanel::render(EditorApp* liveApp, const ThumbnailTextureProvider& tex
   constexpr float kPreviewWidth = static_cast<float>(kPreviewWidthPx);
   constexpr float kPreviewHeight = static_cast<float>(kPreviewHeightPx);
   constexpr float kIndentStep = 14.0f;
+  const float rowHeight = std::max(kPreviewHeight, minimumInteractionHeight);
   ImDrawList* drawList = ImGui::GetWindowDrawList();
 
   // The visible row (if any) whose element matches the active locked-rejection
@@ -525,11 +531,12 @@ void LayersPanel::render(EditorApp* liveApp, const ThumbnailTextureProvider& tex
     // the owned model. A non-expandable row gets a same-width spacer so names
     // stay aligned.
     if (row.hasChildren) {
-      if (DrawDisclosureChevronButton("##layer_disclosure", row.isExpanded, iconTextureProvider)) {
+      if (DrawDisclosureChevronButton("##layer_disclosure", row.isExpanded, iconTextureProvider,
+                                      minimumInteractionHeight)) {
         model_.toggleExpanded(row.stableId);
       }
     } else {
-      ImGui::Dummy(ImVec2(ImGui::GetFrameHeight(), 0.0f));
+      ImGui::Dummy(ImVec2(std::max(ImGui::GetFrameHeight(), minimumInteractionHeight), 0.0f));
     }
     ImGui::SameLine();
 
@@ -541,7 +548,8 @@ void LayersPanel::render(EditorApp* liveApp, const ThumbnailTextureProvider& tex
     // no rendered thumbnail (or no GL texture context) fall back to the
     // deterministic fill swatch. See CLAUDE.md "No Rendering Vector Graphics
     // With ImGui".
-    const ImVec2 slotMin = ImGui::GetCursorScreenPos();
+    const ImVec2 slotCellMin = ImGui::GetCursorScreenPos();
+    const ImVec2 slotMin(slotCellMin.x, slotCellMin.y + (rowHeight - kPreviewHeight) * 0.5f);
     const ImVec2 slotMax(slotMin.x + kPreviewWidth, slotMin.y + kPreviewHeight);
     const svg::RendererBitmap* thumbnailBitmap = nullptr;
     ThumbnailTexture thumbnailTexture;
@@ -587,7 +595,7 @@ void LayersPanel::render(EditorApp* liveApp, const ThumbnailTextureProvider& tex
       drawList->AddRectFilled(swatchMin, swatchMax, ToImU32(swatch), 3.0f);
       drawList->AddRect(swatchMin, swatchMax, IM_COL32(255, 255, 255, 60), 3.0f);
     }
-    ImGui::Dummy(ImVec2(slotMax.x - slotMin.x, slotMax.y - slotMin.y));
+    ImGui::Dummy(ImVec2(slotMax.x - slotMin.x, rowHeight));
     ImGui::SameLine();
 
     // Selection highlight. Only a *truly* selected row gets the filled row
@@ -645,7 +653,7 @@ void LayersPanel::render(EditorApp* liveApp, const ThumbnailTextureProvider& tex
       const ImVec2 labelMin = ImGui::GetCursorScreenPos();
       if (ImGui::Selectable("##layer_row_select", selected,
                             ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_AllowOverlap,
-                            ImVec2(0.0f, kPreviewHeight))) {
+                            ImVec2(0.0f, rowHeight))) {
         if (liveApp != nullptr) {
           ClickModifiers mods{
               .shift = ImGui::GetIO().KeyShift,
@@ -655,7 +663,7 @@ void LayersPanel::render(EditorApp* liveApp, const ThumbnailTextureProvider& tex
         }
       }
       const ImVec2 labelPos(labelMin.x,
-                            slotMin.y + (kPreviewHeight - ImGui::GetTextLineHeight()) * 0.5f);
+                            slotCellMin.y + (rowHeight - ImGui::GetTextLineHeight()) * 0.5f);
       drawList->AddText(labelPos, ImGui::GetColorU32(ImGuiCol_Text), row.displayName.c_str());
       // Track the hovered row so the canvas/source panes can highlight the
       // element under the cursor, mirroring source-pane hover. `IsItemHovered`
@@ -693,8 +701,9 @@ void LayersPanel::render(EditorApp* liveApp, const ThumbnailTextureProvider& tex
     // (design doc 0054 selection token), not the neutral header surface.
     if (partialOnly) {
       const ImU32 accent = WithAlpha(EditorTheme::Active().accentDefault, 230);
-      const ImVec2 barMin(ImGui::GetWindowPos().x + ImGui::GetWindowContentRegionMin().x, slotMin.y);
-      const ImVec2 barMax(barMin.x + 2.0f, slotMin.y + kPreviewHeight);
+      const ImVec2 barMin(ImGui::GetWindowPos().x + ImGui::GetWindowContentRegionMin().x,
+                          slotCellMin.y);
+      const ImVec2 barMax(barMin.x + 2.0f, slotCellMin.y + rowHeight);
       drawList->AddRectFilled(barMin, barMax, accent, 1.0f);
     }
 
@@ -709,18 +718,23 @@ void LayersPanel::render(EditorApp* liveApp, const ThumbnailTextureProvider& tex
     const LayerAffordanceIcon lockIcon =
         row.isLocked ? LayerAffordanceIcon::Locked : LayerAffordanceIcon::Unlocked;
     const ImGuiStyle& style = ImGui::GetStyle();
-    const float buttonWidth = kAffordanceIconSize + style.FramePadding.x * 2.0f;
+    const float buttonWidth =
+        std::max(kAffordanceIconSize + style.FramePadding.x * 2.0f, minimumInteractionHeight);
     const float affordancesWidth = buttonWidth * 2.0f + style.ItemSpacing.x;
     ImGui::SameLine();
     ImGui::SetCursorPosX(ImGui::GetWindowContentRegionMax().x - affordancesWidth);
-    if (DrawLayerIconButton("##layer_eye", eyeIcon, iconTextureProvider) && liveApp != nullptr) {
+    if (DrawLayerIconButton("##layer_eye", eyeIcon, iconTextureProvider,
+                            minimumInteractionHeight) &&
+        liveApp != nullptr) {
       handleEyeClick(*liveApp, i);
     }
     if (ImGui::IsItemHovered()) {
       ImGui::SetTooltip("%s", row.isVisible ? "Hide layer" : "Show layer");
     }
     ImGui::SameLine();
-    if (DrawLayerIconButton("##layer_lock", lockIcon, iconTextureProvider) && liveApp != nullptr) {
+    if (DrawLayerIconButton("##layer_lock", lockIcon, iconTextureProvider,
+                            minimumInteractionHeight) &&
+        liveApp != nullptr) {
       handleLockClick(*liveApp, i);
     }
     if (ImGui::IsItemHovered()) {

--- a/donner/editor/LayersPanel.h
+++ b/donner/editor/LayersPanel.h
@@ -131,8 +131,12 @@ public:
   /// @param iconTextureProvider Uploads the static Donner-rendered layer icon
   ///   bitmaps to ImGui textures for display, or null to keep a blank hit area
   ///   in headless tests.
+  /// @param minimumInteractionHeight Minimum row and icon-button target height.
+  ///   Compact touch sheets pass 44 logical pixels; desktop keeps the dense
+  ///   default by passing zero.
   void render(EditorApp* liveApp, const ThumbnailTextureProvider& textureProvider = {},
-              const IconTextureProvider& iconTextureProvider = {});
+              const IconTextureProvider& iconTextureProvider = {},
+              float minimumInteractionHeight = 0.0f);
 
   /// Set the current locked-rejection flash (or clear it with `std::nullopt`).
   /// When set with a positive intensity and the flashed element matches a

--- a/donner/editor/LayersPanel.h
+++ b/donner/editor/LayersPanel.h
@@ -51,6 +51,11 @@ struct LayersLockedRejectionFlash {
 /// ImGui Layers panel backed by a `LayerTreeModel` snapshot.
 class LayersPanel {
 public:
+  enum class ThumbnailRefreshMode {
+    Render,
+    SwatchesOnly,
+  };
+
   LayersPanel() = default;
 
   /// Maps a per-row rendered thumbnail bitmap to an ImGui texture handle for
@@ -119,7 +124,9 @@ public:
   ///
   /// @param app Live editor app to snapshot.
   /// @param renderer Optional renderer to use for thumbnail rasterization.
-  void refreshSnapshot(const EditorApp& app, svg::Renderer* renderer = nullptr);
+  /// @param mode Whether to render thumbnails or refresh only the row swatches.
+  void refreshSnapshot(const EditorApp& app, svg::Renderer* renderer = nullptr,
+                       ThumbnailRefreshMode mode = ThumbnailRefreshMode::Render);
 
   /// Render the panel into the current ImGui window. Must be called inside an
   /// `ImGui::Begin(...) / End()` pair. When @p liveApp is null (the worker owns

--- a/donner/editor/SamplePickerPresenter.cc
+++ b/donner/editor/SamplePickerPresenter.cc
@@ -12,7 +12,9 @@ namespace {
 
 constexpr float kGridGap = 12.0f;
 constexpr float kMinimumCardWidth = 220.0f;
-constexpr float kCardHeight = 72.0f;
+constexpr float kCardHeight = 96.0f;
+constexpr float kThumbnailWidth = 104.0f;
+constexpr float kThumbnailHeight = 64.0f;
 constexpr float kHeadingSpacing = 8.0f;
 #ifdef __EMSCRIPTEN__
 constexpr std::string_view kGitHubActionLabel = "View on GitHub";
@@ -26,7 +28,8 @@ std::size_t BoundedSampleCount(std::size_t sampleCount) noexcept {
 
 void DrawSampleButton(const EditorSample& sample, std::string_view description,
                       const SamplePickerState& state, float width, float height,
-                      SamplePickerActions* actions, std::size_t index) {
+                      const SamplePickerThumbnail& thumbnail, SamplePickerActions* actions,
+                      std::size_t index) {
   const EditorTheme& theme = EditorTheme::Active();
   ImGui::PushID(static_cast<int>(index));
   const bool clicked = ImGui::InvisibleButton("##sample", ImVec2(width, height));
@@ -47,9 +50,27 @@ void DrawSampleButton(const EditorSample& sample, std::string_view description,
   drawList->AddRect(min, max, selected ? theme.accentDefault : theme.borderSubtle,
                     theme.radiusControl, 0, selected ? 2.0f : 1.0f);
 
-  const float textX = min.x + theme.space3;
-  const float titleY = min.y + theme.space2;
   drawList->PushClipRect(min, max, true);
+  const ImVec2 thumbnailSlotMin(min.x + theme.space2,
+                                min.y + std::max(0.0f, (height - kThumbnailHeight) * 0.5f));
+  const ImVec2 thumbnailSlotMax(thumbnailSlotMin.x + kThumbnailWidth,
+                                thumbnailSlotMin.y + kThumbnailHeight);
+  drawList->AddRectFilled(thumbnailSlotMin, thumbnailSlotMax, theme.surfaceCanvas,
+                          theme.radiusControl);
+  if (thumbnail.texture != 0) {
+    const float aspectRatio = std::max(0.01f, thumbnail.aspectRatio);
+    const float previewWidth = std::min(kThumbnailWidth, kThumbnailHeight * aspectRatio);
+    const float previewHeight = std::min(kThumbnailHeight, previewWidth / aspectRatio);
+    const ImVec2 thumbnailMin(thumbnailSlotMin.x + (kThumbnailWidth - previewWidth) * 0.5f,
+                              thumbnailSlotMin.y + (kThumbnailHeight - previewHeight) * 0.5f);
+    const ImVec2 thumbnailMax(thumbnailMin.x + previewWidth, thumbnailMin.y + previewHeight);
+    drawList->AddImage(thumbnail.texture, thumbnailMin, thumbnailMax, ImVec2(0.0f, 0.0f),
+                       ImVec2(static_cast<float>(thumbnail.uvBottomRight.x),
+                              static_cast<float>(thumbnail.uvBottomRight.y)));
+  }
+  drawList->AddRect(thumbnailSlotMin, thumbnailSlotMax, theme.borderSubtle, theme.radiusControl);
+  const float textX = thumbnailSlotMax.x + theme.space3;
+  const float titleY = min.y + (height - ImGui::GetTextLineHeight() * 2.0f - 2.0f) * 0.5f;
   drawList->AddText(ImVec2(textX, titleY), theme.textPrimary, sample.title.data(),
                     sample.title.data() + sample.title.size());
   drawList->AddText(ImVec2(textX, titleY + ImGui::GetTextLineHeight() + 2.0f), theme.textMuted,
@@ -128,7 +149,8 @@ void ApplySamplePickerCommand(bool activated, SamplePickerCommand command,
   }
 }
 
-SamplePickerActions SamplePickerPresenter::render(const SamplePickerState& state) const {
+SamplePickerActions SamplePickerPresenter::render(
+    const SamplePickerState& state, const SamplePickerThumbnailProvider& thumbnailProvider) const {
   SamplePickerActions actions;
   if (!state.visible) {
     return actions;
@@ -172,8 +194,10 @@ SamplePickerActions SamplePickerPresenter::render(const SamplePickerState& state
       ImGui::SameLine(0.0f, kGridGap);
     }
     const EditorSample& sample = samples[index];
+    const SamplePickerThumbnail thumbnail =
+        thumbnailProvider ? thumbnailProvider(sample, index) : SamplePickerThumbnail{};
     DrawSampleButton(sample, SamplePickerDescription(sample.id), state, layout.cardWidth,
-                     layout.cardHeight, &actions, index);
+                     layout.cardHeight, thumbnail, &actions, index);
   }
 
   return actions;

--- a/donner/editor/SamplePickerPresenter.h
+++ b/donner/editor/SamplePickerPresenter.h
@@ -2,12 +2,13 @@
 /// @file
 
 #include <cstddef>
+#include <functional>
 #include <string>
 #include <string_view>
 
+#include "donner/base/Vector2.h"
 #include "donner/editor/EditorSampleCatalog.h"
-
-struct ImVec2;
+#include "donner/editor/ImGuiIncludes.h"
 
 namespace donner::editor {
 
@@ -62,6 +63,17 @@ struct SamplePickerActions {
   bool openGitHub = false;
 };
 
+/// Donner-rendered sample artwork uploaded to a texture the picker can blit.
+struct SamplePickerThumbnail {
+  ImTextureID texture = 0;
+  Vector2d uvBottomRight = Vector2d(1.0, 1.0);
+  float aspectRatio = 1.0f;
+};
+
+/// Resolve one catalog entry to its already-rendered thumbnail texture.
+using SamplePickerThumbnailProvider =
+    std::function<SamplePickerThumbnail(const EditorSample& sample, std::size_t index)>;
+
 enum class SamplePickerCommand {
   Dismiss,
   OpenFile,
@@ -80,7 +92,9 @@ void ApplySamplePickerCommand(bool activated, SamplePickerCommand command,
 class SamplePickerPresenter {
 public:
   /// Render using the current pane's available width and return edge-triggered actions.
-  [[nodiscard]] SamplePickerActions render(const SamplePickerState& state) const;
+  [[nodiscard]] SamplePickerActions render(
+      const SamplePickerState& state,
+      const SamplePickerThumbnailProvider& thumbnailProvider = {}) const;
 };
 
 }  // namespace donner::editor

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -119,6 +119,7 @@ donner_cc_test(
         "//donner/editor:editor_sample_catalog",
         "//donner/svg",
         "//donner/svg/parser",
+        "//donner/svg/renderer",
         "@com_google_gtest//:gtest_main",
     ],
 )

--- a/donner/editor/tests/EditorDockLayout_tests.cc
+++ b/donner/editor/tests/EditorDockLayout_tests.cc
@@ -125,9 +125,8 @@ TEST_F(EditorDockLayoutTest, DocksEachPanelIntoItsDefaultNode) {
   const ImGuiID dockspaceId = EditorDockSpaceId();
   const EditorDockLayoutParams params = DefaultParams(/*includeCompositorDebug=*/true);
 
-  const EditorDockNodes nodes =
-      RenderDockFrame(dockspaceId, /*locked=*/true, /*showCompositorDebug=*/true, /*build=*/true,
-                      params);
+  const EditorDockNodes nodes = RenderDockFrame(
+      dockspaceId, /*locked=*/true, /*showCompositorDebug=*/true, /*build=*/true, params);
   // A second frame lets the freshly-submitted windows settle into their nodes.
   RenderDockFrame(dockspaceId, /*locked=*/true, /*showCompositorDebug=*/true, /*build=*/false);
 
@@ -152,13 +151,36 @@ TEST_F(EditorDockLayoutTest, ExcludesCompositorDebugNodeWhenNotRequested) {
   EXPECT_EQ(DockNodeIdForWindow(kCompositorDebugWindowName), 0u);
 }
 
+TEST_F(EditorDockLayoutTest, CompactLayoutReservesEntireDockspaceForCanvas) {
+  const ImGuiID dockspaceId = EditorCompactDockSpaceId();
+  EXPECT_NE(dockspaceId, EditorDockSpaceId());
+  EditorDockLayoutParams params = DefaultParams(/*includeCompositorDebug=*/false);
+  params.includeSidebars = false;
+
+  const EditorDockNodes nodes =
+      RenderDockFrame(dockspaceId, /*locked=*/true, /*showCompositorDebug=*/false,
+                      /*build=*/true, params);
+  RenderDockFrame(dockspaceId, /*locked=*/true, /*showCompositorDebug=*/false,
+                  /*build=*/false);
+
+  EXPECT_EQ(nodes.central, dockspaceId);
+  EXPECT_EQ(nodes.rightTop, 0u);
+  EXPECT_EQ(nodes.rightMid, 0u);
+  EXPECT_EQ(nodes.rightBottom, 0u);
+  ImGuiDockNode* central = ImGui::DockBuilderGetNode(nodes.central);
+  ASSERT_NE(central, nullptr);
+  EXPECT_TRUE(central->IsCentralNode());
+  EXPECT_TRUE(central->IsNoTabBar());
+  EXPECT_TRUE(central->IsLeafNode());
+  EXPECT_EQ(DockNodeIdForWindow(kRenderPaneWindowName), nodes.central);
+}
+
 TEST_F(EditorDockLayoutTest, ResetRestoresDefaultLayoutAfterRearrange) {
   const ImGuiID dockspaceId = EditorDockSpaceId();
   const EditorDockLayoutParams params = DefaultParams(/*includeCompositorDebug=*/true);
 
-  const EditorDockNodes original =
-      RenderDockFrame(dockspaceId, /*locked=*/false, /*showCompositorDebug=*/true, /*build=*/true,
-                      params);
+  const EditorDockNodes original = RenderDockFrame(
+      dockspaceId, /*locked=*/false, /*showCompositorDebug=*/true, /*build=*/true, params);
   RenderDockFrame(dockspaceId, /*locked=*/false, /*showCompositorDebug=*/true, /*build=*/false);
 
   // Simulate a user rearrange: move the Inspector into the canvas/central node.
@@ -168,9 +190,8 @@ TEST_F(EditorDockLayoutTest, ResetRestoresDefaultLayoutAfterRearrange) {
   EXPECT_EQ(DockNodeIdForWindow(kInspectorWindowName), original.central);
 
   // Reset rebuilds the default layout; the Inspector returns to its own node.
-  const EditorDockNodes rebuilt =
-      RenderDockFrame(dockspaceId, /*locked=*/false, /*showCompositorDebug=*/true, /*build=*/true,
-                      params);
+  const EditorDockNodes rebuilt = RenderDockFrame(
+      dockspaceId, /*locked=*/false, /*showCompositorDebug=*/true, /*build=*/true, params);
   RenderDockFrame(dockspaceId, /*locked=*/false, /*showCompositorDebug=*/true, /*build=*/false);
   EXPECT_EQ(DockNodeIdForWindow(kInspectorWindowName), rebuilt.rightMid);
   EXPECT_NE(DockNodeIdForWindow(kInspectorWindowName), original.central);

--- a/donner/editor/tests/EditorSampleCatalog_tests.cc
+++ b/donner/editor/tests/EditorSampleCatalog_tests.cc
@@ -11,6 +11,7 @@
 #include "donner/base/ParseWarningSink.h"
 #include "donner/svg/SVGSVGElement.h"
 #include "donner/svg/parser/SVGParser.h"
+#include "donner/svg/renderer/Renderer.h"
 #include "gtest/gtest.h"
 
 namespace donner::editor {
@@ -61,6 +62,25 @@ TEST(EditorSampleCatalog, SourcesParseWithUsableRootDimensions) {
     ASSERT_TRUE(root.height().has_value()) << sample.id << " has no height";
     EXPECT_GT(root.width()->value, 0.0) << sample.id;
     EXPECT_GT(root.height()->value, 0.0) << sample.id;
+  }
+}
+
+TEST(EditorSampleCatalog, SourcesRenderNonemptyPickerThumbnails) {
+  svg::Renderer renderer;
+  for (const EditorSample& sample : GetEditorSampleCatalog()) {
+    ParseWarningSink warningSink = ParseWarningSink::Disabled();
+    auto result = svg::parser::SVGParser::ParseSVG(sample.source, warningSink);
+    ASSERT_FALSE(result.hasError()) << sample.id << ": " << result.error();
+
+    svg::SVGDocument document = std::move(result).result();
+    document.setCanvasSize(192, 120);
+    renderer.draw(document);
+    const svg::RendererBitmap bitmap = renderer.takeSnapshot();
+    EXPECT_FALSE(bitmap.empty()) << sample.id;
+    EXPECT_GT(bitmap.dimensions.x, 0) << sample.id;
+    EXPECT_GT(bitmap.dimensions.y, 0) << sample.id;
+    EXPECT_LE(bitmap.dimensions.x, 192) << sample.id;
+    EXPECT_LE(bitmap.dimensions.y, 120) << sample.id;
   }
 }
 

--- a/donner/editor/tests/EditorShellLayout_tests.cc
+++ b/donner/editor/tests/EditorShellLayout_tests.cc
@@ -5,6 +5,66 @@
 namespace donner::editor {
 namespace {
 
+TEST(EditorShellLayoutTest, UsesDesktopChromeForUnconstrainedMouseViewport) {
+  const EditorAdaptiveUiLayout layout = ComputeEditorAdaptiveUiLayout({
+      .windowWidth = 1440.0f,
+      .windowHeight = 900.0f,
+      .preferTouch = false,
+  });
+
+  EXPECT_EQ(layout.mode, EditorUiMode::Desktop);
+  EXPECT_FLOAT_EQ(layout.topBarHeight, 0.0f);
+  EXPECT_FLOAT_EQ(layout.toolButtonSize, 32.0f);
+  EXPECT_TRUE(layout.showPaintControls);
+  EXPECT_TRUE(layout.showTextFormatBar);
+  EXPECT_TRUE(layout.showCanvasScrollbars);
+}
+
+TEST(EditorShellLayoutTest, UsesRightTouchSheetForLandscapeViewport) {
+  const EditorAdaptiveUiLayout layout = ComputeEditorAdaptiveUiLayout({
+      .windowWidth = 844.0f,
+      .windowHeight = 390.0f,
+      .preferTouch = true,
+  });
+
+  EXPECT_EQ(layout.mode, EditorUiMode::CompactTouch);
+  EXPECT_EQ(layout.panelPlacement, CompactPanelPlacement::Right);
+  EXPECT_FLOAT_EQ(layout.topBarHeight, 52.0f);
+  EXPECT_FLOAT_EQ(layout.toolButtonSize, 44.0f);
+  EXPECT_FLOAT_EQ(layout.panelX, 489.52f);
+  EXPECT_FLOAT_EQ(layout.panelY, 52.0f);
+  EXPECT_FLOAT_EQ(layout.panelWidth, 354.48f);
+  EXPECT_FLOAT_EQ(layout.panelHeight, 338.0f);
+  EXPECT_FALSE(layout.showPaintControls);
+  EXPECT_FALSE(layout.showTextFormatBar);
+  EXPECT_FALSE(layout.showCanvasScrollbars);
+}
+
+TEST(EditorShellLayoutTest, UsesBottomTouchSheetForPortraitViewport) {
+  const EditorAdaptiveUiLayout layout = ComputeEditorAdaptiveUiLayout({
+      .windowWidth = 390.0f,
+      .windowHeight = 844.0f,
+      .preferTouch = true,
+  });
+
+  EXPECT_EQ(layout.mode, EditorUiMode::CompactTouch);
+  EXPECT_EQ(layout.panelPlacement, CompactPanelPlacement::Bottom);
+  EXPECT_FLOAT_EQ(layout.panelX, 0.0f);
+  EXPECT_FLOAT_EQ(layout.panelY, 489.52f);
+  EXPECT_FLOAT_EQ(layout.panelWidth, 390.0f);
+  EXPECT_FLOAT_EQ(layout.panelHeight, 354.48f);
+}
+
+TEST(EditorShellLayoutTest, ConstrainedMouseViewportStillUsesCompactChrome) {
+  const EditorAdaptiveUiLayout layout = ComputeEditorAdaptiveUiLayout({
+      .windowWidth = 700.0f,
+      .windowHeight = 700.0f,
+      .preferTouch = false,
+  });
+
+  EXPECT_EQ(layout.mode, EditorUiMode::CompactTouch);
+}
+
 RightSidebarLayoutInput DefaultLayoutInput() {
   return RightSidebarLayoutInput{
       .paneOriginY = 20.0f,
@@ -72,6 +132,28 @@ TEST(EditorShellLayoutTest, MainLayoutGivesSourceWidthBackToRenderPaneWhenHidden
   EXPECT_FLOAT_EQ(layout.renderPaneWidth, 1148.0f);
   EXPECT_FLOAT_EQ(layout.rightPaneX, 1180.0f);
   EXPECT_FLOAT_EQ(layout.rightPaneWidth, 420.0f);
+}
+
+TEST(EditorShellLayoutTest, MainLayoutGivesFullWidthToCompactCanvas) {
+  const EditorMainPaneLayout layout = ComputeEditorMainPaneLayout({
+      .windowWidth = 390.0f,
+      .sourcePaneVisible = false,
+      .sourcePaneWidth = 560.0f,
+      .minSourcePaneWidth = 240.0f,
+      .maxSourcePaneWidth = 900.0f,
+      .sourcePaneRailWidth = 0.0f,
+      .rightPaneWidth = 420.0f,
+      .rightPaneVisible = false,
+      .minRightPaneWidth = 220.0f,
+      .maxRightPaneWidth = 900.0f,
+      .minRenderPaneWidth = 220.0f,
+  });
+
+  EXPECT_FLOAT_EQ(layout.sourcePaneWidth, 0.0f);
+  EXPECT_FLOAT_EQ(layout.sourcePaneRailWidth, 0.0f);
+  EXPECT_FLOAT_EQ(layout.renderPaneX, 0.0f);
+  EXPECT_FLOAT_EQ(layout.renderPaneWidth, 390.0f);
+  EXPECT_FLOAT_EQ(layout.rightPaneWidth, 0.0f);
 }
 
 TEST(EditorShellLayoutTest, MainLayoutClampsSourcePaneWidthWhenVisible) {

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -355,6 +355,20 @@ TEST(EditorShellInternalTest, CompactChromeCapturesSheetAndUsesTouchHint) {
             std::string_view::npos);
 }
 
+TEST(EditorShellInternalTest, HiddenCanvasScrollbarsDoNotCaptureCanvasInput) {
+  ViewportState viewport;
+  viewport.paneOrigin = Vector2d(0.0, 0.0);
+  viewport.paneSize = Vector2d(100.0, 100.0);
+  viewport.documentViewBox = Box2d::FromXYWH(0.0, 0.0, 400.0, 400.0);
+  viewport.zoom = 1.0;
+  viewport.panDocPoint = Vector2d(50.0, 50.0);
+  viewport.panScreenPoint = Vector2d(50.0, 50.0);
+
+  const Vector2d bottomRailPoint(50.0, 95.0);
+  EXPECT_TRUE(internal::CanvasScrollbarsCaptureInput(true, viewport, bottomRailPoint));
+  EXPECT_FALSE(internal::CanvasScrollbarsCaptureInput(false, viewport, bottomRailPoint));
+}
+
 TEST(EditorShellInternalTest, PendingClickBusyActionPrefersFastRedragThenCancelsBusyRender) {
   EXPECT_EQ(internal::PendingClickBusyActionForState(/*tookFastRedrag=*/true,
                                                      /*rendererBusy=*/true),

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -344,6 +344,17 @@ TEST(EditorShellInternalTest, StructuralDocumentActionsWaitForExclusiveDomOwners
       /*hasPendingRequest=*/true, /*rendererBusy=*/false, /*hasPendingMutations=*/false));
 }
 
+TEST(EditorShellInternalTest, CompactChromeCapturesSheetAndUsesTouchHint) {
+  const Box2d panelRect = Box2d::FromXYWH(480.0, 52.0, 360.0, 338.0);
+  EXPECT_TRUE(internal::CanvasChromeCapturesInput(
+      ImVec2(500.0f, 100.0f), std::nullopt, Box2d::FromXYWH(20.0, 70.0, 156.0, 60.0), std::nullopt,
+      std::nullopt, Box2d::FromXYWH(20.0, 320.0, 44.0, 44.0), panelRect));
+  EXPECT_NE(internal::TextToolHintLabel(/*isEditing=*/false, /*isDraggingBox=*/false,
+                                        /*touchPreferred=*/true)
+                .find("Double-tap"),
+            std::string_view::npos);
+}
+
 TEST(EditorShellInternalTest, PendingClickBusyActionPrefersFastRedragThenCancelsBusyRender) {
   EXPECT_EQ(internal::PendingClickBusyActionForState(/*tookFastRedrag=*/true,
                                                      /*rendererBusy=*/true),
@@ -1016,6 +1027,18 @@ public:
     return shell.dockLayoutResetRequested_;
   }
 
+  static const EditorAdaptiveUiLayout& AdaptiveUiLayout(const EditorShell& shell) {
+    return shell.adaptiveUiLayout_;
+  }
+
+  static void SetAdaptiveUiLayout(EditorShell& shell, const EditorAdaptiveUiLayout& layout) {
+    shell.adaptiveUiLayout_ = layout;
+  }
+
+  static void SetCompactPanelVisible(EditorShell& shell, bool visible) {
+    shell.compactPanelVisible_ = visible;
+  }
+
   static bool SourcePaneVisible(const EditorShell& shell) { return shell.sourcePaneVisible_; }
   static float SourcePaneWidth(const EditorShell& shell) { return shell.sourcePaneWidth_; }
   static void SetSourcePaneWidth(EditorShell& shell, float value) {
@@ -1326,6 +1349,14 @@ TEST(EditorShellTest, HiddenWindowShellConstructsAndRunsFrames) {
   window.beginFrame();
   shell.runFrame();
   window.endFrame();
+
+  const EditorAdaptiveUiLayout& adaptiveLayout = EditorShellTestAccess::AdaptiveUiLayout(shell);
+  EXPECT_TRUE(adaptiveLayout.compactTouch());
+  EXPECT_FLOAT_EQ(adaptiveLayout.topBarHeight, 52.0f);
+  EXPECT_FLOAT_EQ(adaptiveLayout.toolButtonSize, 44.0f);
+  EXPECT_FALSE(adaptiveLayout.showPaintControls);
+  EXPECT_FALSE(adaptiveLayout.showTextFormatBar);
+  EXPECT_FALSE(adaptiveLayout.showCanvasScrollbars);
 
   const LayerInspectorStatusReadback status = shell.layerInspectorStatusForReadback();
   EXPECT_GE(status.viewportDesiredCanvas.x, 0);
@@ -2574,6 +2605,19 @@ TEST(EditorShellTest, ShellGeometryHelpersClampToViewportAndSelectionCache) {
                                                                      ImVec2(500.0f, 300.0f));
   EXPECT_GT(palette.width(), 0.0);
   EXPECT_GT(palette.height(), 0.0);
+
+  const EditorAdaptiveUiLayout compactLandscape = ComputeEditorAdaptiveUiLayout({
+      .windowWidth = 844.0f,
+      .windowHeight = 390.0f,
+      .preferTouch = true,
+  });
+  EditorShellTestAccess::SetAdaptiveUiLayout(shell, compactLandscape);
+  EditorShellTestAccess::SetCompactPanelVisible(shell, true);
+  const Box2d compactPalette = EditorShellTestAccess::ToolPaletteScreenRect(
+      shell, ImVec2(0.0f, compactLandscape.topBarHeight),
+      ImVec2(844.0f, 390.0f - compactLandscape.topBarHeight));
+  EXPECT_LE(compactPalette.bottomRight.x, compactLandscape.panelX);
+  EXPECT_FLOAT_EQ(compactPalette.width(), 156.0f);
 }
 
 TEST(EditorShellTest, PrivateUiRenderHelpersCoverPaneToolbarAndPanelStates) {

--- a/donner/editor/tests/LayersPanel_tests.cc
+++ b/donner/editor/tests/LayersPanel_tests.cc
@@ -73,6 +73,20 @@ TEST(LayersPanelTest, PlainClickSelectsRowElement) {
   EXPECT_TRUE(panel.consumeSelectionChanged());
 }
 
+TEST(LayersPanelTest, SwatchesOnlyRefreshDoesNotRasterizeThumbnails) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(kSvg));
+
+  LayersPanel panel;
+  panel.refreshSnapshot(app, nullptr, LayersPanel::ThumbnailRefreshMode::SwatchesOnly);
+
+  EXPECT_EQ(panel.thumbnailRefreshStats().renderedCount, 0u);
+  EXPECT_EQ(panel.thumbnailRefreshStats().reusedCount, 0u);
+  ASSERT_FALSE(panel.rows().empty());
+  EXPECT_EQ(panel.rowThumbnail(panel.rows().front().stableId), nullptr);
+  EXPECT_TRUE(panel.hasThumbnailOrSwatch(panel.rows().front().stableId));
+}
+
 TEST(LayersPanelTest, ShiftClickSelectsContiguousRange) {
   EditorApp app;
   ASSERT_TRUE(app.loadFromString(kSvg));

--- a/donner/editor/tests/SamplePickerPresenter_tests.cc
+++ b/donner/editor/tests/SamplePickerPresenter_tests.cc
@@ -16,6 +16,7 @@ TEST(SamplePickerPresenter, NarrowLayoutUsesOneTouchSizedColumn) {
   EXPECT_EQ(layout.rows, 4u);
   EXPECT_GE(layout.cardWidth, 0.0f);
   EXPECT_GE(layout.cardHeight, kSamplePickerMinTouchTarget);
+  EXPECT_FLOAT_EQ(layout.cardHeight, 96.0f);
 }
 
 TEST(SamplePickerPresenter, WideLayoutUsesCompactBoundedColumns) {
@@ -26,6 +27,7 @@ TEST(SamplePickerPresenter, WideLayoutUsesCompactBoundedColumns) {
   EXPECT_EQ(layout.rows, 2u);
   EXPECT_GT(layout.cardWidth, 0.0f);
   EXPECT_GE(layout.cardHeight, kSamplePickerMinTouchTarget);
+  EXPECT_FLOAT_EQ(layout.cardHeight, 96.0f);
   EXPECT_FLOAT_EQ(layout.cardWidth * 3.0f + 12.0f * 2.0f, 1024.0f);
 }
 

--- a/donner/editor/wasm/editor-bootstrap.js
+++ b/donner/editor/wasm/editor-bootstrap.js
@@ -11,6 +11,59 @@ function ShowCapabilityError(message) {
   console.error(message);
 }
 
+function InstallTouchPointerBridge(targetCanvas) {
+  if (!window.PointerEvent) {
+    return;
+  }
+
+  let activeTouchId = null;
+  const dispatchMouse = (type, event, buttons) => {
+    targetCanvas.dispatchEvent(
+      new MouseEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+        clientX: event.clientX,
+        clientY: event.clientY,
+        button: 0,
+        buttons,
+      }),
+    );
+  };
+
+  targetCanvas.style.touchAction = "none";
+  targetCanvas.addEventListener("pointerdown", (event) => {
+    if (event.pointerType !== "touch" || activeTouchId !== null) {
+      return;
+    }
+    activeTouchId = event.pointerId;
+    event.preventDefault();
+    targetCanvas.focus();
+    targetCanvas.setPointerCapture?.(event.pointerId);
+    dispatchMouse("mousedown", event, 1);
+  });
+  targetCanvas.addEventListener("pointermove", (event) => {
+    if (event.pointerType !== "touch" || event.pointerId !== activeTouchId) {
+      return;
+    }
+    event.preventDefault();
+    dispatchMouse("mousemove", event, 1);
+  });
+  const finishTouch = (event) => {
+    if (event.pointerType !== "touch" || event.pointerId !== activeTouchId) {
+      return;
+    }
+    event.preventDefault();
+    dispatchMouse("mouseup", event, 0);
+    targetCanvas.releasePointerCapture?.(event.pointerId);
+    activeTouchId = null;
+  };
+  targetCanvas.addEventListener("pointerup", finishTouch);
+  targetCanvas.addEventListener("pointercancel", finishTouch);
+}
+
+InstallTouchPointerBridge(canvas);
+
 window.__donnerCanStartWasm = typeof SharedArrayBuffer !== "undefined";
 if (!window.__donnerCanStartWasm) {
   const reason = window.isSecureContext

--- a/donner/editor/wasm/editor.css
+++ b/donner/editor/wasm/editor.css
@@ -20,6 +20,10 @@ body {
   outline: none;
 }
 
+#canvas {
+  touch-action: none;
+}
+
 #status {
   position: fixed;
   left: 16px;

--- a/donner/editor/wasm/tests/backend-selector.spec.mjs
+++ b/donner/editor/wasm/tests/backend-selector.spec.mjs
@@ -61,6 +61,61 @@ async function runBootstrapWithoutThreads() {
   return { elements, window };
 }
 
+async function loadTouchPointerBridge() {
+  const source = await readFile(new URL("../editor-bootstrap.js", import.meta.url), "utf8");
+  const handlers = new Map();
+  const dispatched = [];
+  const captured = [];
+  const released = [];
+  const canvas = {
+    addEventListener(type, handler) {
+      handlers.set(type, handler);
+    },
+    dispatchEvent(event) {
+      dispatched.push(event);
+    },
+    focus() {},
+    hidden: false,
+    releasePointerCapture(pointerId) {
+      released.push(pointerId);
+    },
+    setPointerCapture(pointerId) {
+      captured.push(pointerId);
+    },
+    style: {},
+  };
+  const elements = {
+    canvas,
+    status: { hidden: false, textContent: "" },
+    "capability-error": { hidden: true },
+    "capability-error-detail": { textContent: "" },
+  };
+  const window = {
+    __donnerBackendPromise: Promise.reject(new Error("WebGL2 is unavailable")),
+    isSecureContext: false,
+    PointerEvent: function PointerEvent() {},
+  };
+  class MouseEvent {
+    constructor(type, init) {
+      this.type = type;
+      Object.assign(this, init);
+    }
+  }
+  const context = vm.createContext({
+    console,
+    document: {
+      body: { appendChild() {} },
+      getElementById: (id) => elements[id],
+    },
+    MouseEvent,
+    SharedArrayBuffer: undefined,
+    window,
+  });
+  vm.runInContext(source, context, { filename: "editor-bootstrap.js" });
+  await new Promise((resolve) => setImmediate(resolve));
+  return { canvas, captured, dispatched, handlers, released };
+}
+
 test("auto mode prefers Geode when WebGPU has an adapter", async () => {
   const selectBackend = await loadSelector();
   const result = await selectBackend({
@@ -69,6 +124,36 @@ test("auto mode prefers Geode when WebGPU has an adapter", async () => {
     hasWebGl2: () => true,
   });
   assert.deepEqual({ ...result }, { name: "geode", base: "geode/" });
+});
+
+test("touch pointer bridge emits one captured mouse drag", async () => {
+  const { canvas, captured, dispatched, handlers, released } = await loadTouchPointerBridge();
+  const pointer = (type, overrides = {}) => ({
+    clientX: 12,
+    clientY: 34,
+    pointerId: 7,
+    pointerType: "touch",
+    preventDefault() {},
+    type,
+    ...overrides,
+  });
+
+  handlers.get("pointerdown")(pointer("pointerdown"));
+  handlers.get("pointermove")(pointer("pointermove", { clientX: 20 }));
+  handlers.get("pointerdown")(pointer("pointerdown", { pointerId: 8 }));
+  handlers.get("pointerup")(pointer("pointerup"));
+
+  assert.equal(canvas.style.touchAction, "none");
+  assert.deepEqual(captured, [7]);
+  assert.deepEqual(released, [7]);
+  assert.deepEqual(
+    dispatched.map((event) => [event.type, event.clientX, event.buttons]),
+    [
+      ["mousedown", 12, 1],
+      ["mousemove", 20, 1],
+      ["mouseup", 12, 0],
+    ],
+  );
 });
 
 test("auto mode falls back to TinySkia when WebGPU is absent", async () => {


### PR DESCRIPTION
- add compact adaptive layouts for narrow and touch-first viewports
- map one captured touch pointer into the existing ImGui mouse stream for taps and direct drags
- replace desktop-only interactions with touch-sized controls where needed
- center layer icons within their 44 px interaction targets
- correct Wasm touch capability detection and add a blocked-popup fallback for the GitHub action
- use lightweight layer swatches in compact mode
- render sample thumbnails through Donner
- update editor architecture and design-language documentation

## Why

The Wasm editor needs a usable subset on mobile Safari without forcing the desktop docking model onto a touch viewport or creating touch-specific document mutation paths.

## Validation

- `bazel test //donner/editor/tests:editor_shell_layout_tests //donner/editor/tests:editor_dock_layout_tests //donner/editor/tests:editor_shell_tests //donner/editor/tests:layers_panel_tests //donner/editor/tests:editor_sample_catalog_tests //donner/editor/tests:sample_picker_presenter_tests`
- `npm run test:selector`
- `bazel build --config=editor-wasm //donner/editor/wasm:wasm_web_package`
- `bazel build --config=editor-wasm-tiny-skia //donner/editor/wasm:wasm_tiny_skia_web_package`
- `bazel build //donner/editor:editor`
- `bazel test //tools:check_design_doc_provenance_tests`

Physical iPhone startup and multi-touch gesture validation remain release gates.

## Stack

5 of 5. PRs #827-#830 have merged; this final stack packet is rebased directly onto current `main`.