### PR TITLE
test: shard three heavy CPU test suites for CI parallelism

### DIFF
--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -83,6 +83,9 @@ donner_cc_test(
 donner_cc_test(
     name = "editor_shell_tests",
     srcs = ["EditorShell_tests.cc"],
+    # 83 independent gtest cases; shard so the suite runs as parallel RE
+    # actions instead of one ~18 s serial critical-path action.
+    shard_count = 4,
     deps = [
         "//donner/editor:clipboard_interface",
         "//donner/editor:editor_shell",
@@ -471,6 +474,9 @@ donner_cc_test(
     data = [
         "//:donner_splash.svg",
     ],
+    # 75 independent gtest cases (wall-clock-sensitive cases live in the
+    # separate async_renderer_wallclock_tests target); shard for parallelism.
+    shard_count = 4,
     deps = [
         "//donner/editor:async_renderer",
         "//donner/editor:async_svg_document",

--- a/donner/svg/compositor/BUILD.bazel
+++ b/donner/svg/compositor/BUILD.bazel
@@ -212,6 +212,9 @@ donner_cc_test(
     data = [
         "//:donner_splash.svg",
     ],
+    # 80 independent golden cases (perf cases excluded via the filter above
+    # and split into compositor_golden_perf_tests); shard for parallelism.
+    shard_count = 4,
     deps = [
         ":compositor",
         ":dual_path_verifier",


### PR DESCRIPTION
## Summary

Part of the CI test-runtime optimization campaign (test-execution lane). Shards three heavy but fully-parallelizable CPU-backend test suites so they run as parallel Bazel RE actions instead of single serial actions on the test critical path.

Each of these targets is a large collection of independent gtest cases with no shared wall-clock ordering, so gtest index-based sharding balances cleanly:

| target | cases | before (1 shard) | after (4 shards, max) |
|---|---:|---:|---:|
| `editor_shell_tests` | 83 | 8.4s | 2.6s (2.3/2.5/2.5/2.6) |
| `async_renderer_tests` | 75 | 6.7s | 2.4s (1.3/1.6/1.8/2.4) |
| `compositor_golden_tests` | 80 | 6.5s | 2.0s (0.9/1.4/1.8/2.0) |

Timings are uncached per-shard execution (`testAttemptDurationMillis`) measured on the Apple Silicon hub. On the self-hosted Linux RE lane these suites ran ~16-18s each in the last main CI profile; the ~3x per-shard reduction carries over proportionally.

## Coverage

No coverage change. Sharding only partitions the same test set across processes:
- Wall-clock-sensitive async cases already live in the separate `async_renderer_wallclock_tests` target.
- Compositor perf cases are already excluded here via `gtest_filter` and split into `compositor_golden_perf_tests`.

## Test plan

- `bazelisk test` on all three targets `--nocache_test_results`: pass, per-shard balance verified via BEP (above).

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17