### PR TITLE
test: shard layers_panel_tests for CI parallelism

### DIFF
--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -1163,6 +1163,10 @@ donner_cc_test(
 donner_cc_test(
     name = "layers_panel_tests",
     srcs = ["LayersPanel_tests.cc"],
+    # 71 independent panel/golden cases. The geode variant runs them through
+    # software Vulkan on GPU-less CI (~23 s single-shard); shard so the render
+    # work runs as parallel RE actions.
+    shard_count = 4,
     data = [
         "//:donner_splash.svg",
     ] + glob(["testdata/layer_thumbnails/*.png"]),


### PR DESCRIPTION
## Summary

Part of the CI test-runtime optimization campaign (test-execution lane). `layers_panel_tests_geode` was the #4 slowest test action in the last main CI profile (~23.5s, single shard) on the self-hosted Linux lane, where its 71 independent panel/golden cases render through software Vulkan (lavapipe). The cases are independent, so gtest sharding partitions the render work across parallel Bazel RE actions.

Measured on the Apple Silicon hub (geode backend = Metal, uncached, per-shard exec):

| target | cases | before (1 shard) | after (4 shards, max) |
|---|---:|---:|---:|
| `layers_panel_tests_geode` | 71 | 6.5s | 3.5s (2.4/2.9/3.0/3.5) |

The Mac uses Metal, where device init is cheap, so this shows a ~2x wall reduction. On the Linux lane, per-shard software-Vulkan device init is a larger fixed cost, so the CI ratio will be smaller, but the dominant per-case render work still parallelizes across the four shards.

## Coverage

No coverage change: sharding only partitions the same 71-case test set across processes.

## Test plan

- `bazelisk test //donner/editor/tests:layers_panel_tests_geode --nocache_test_results`: pass, per-shard balance verified via BEP (above).

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17