### PR TITLE
ci: compare base tip vs PR merge commit in bazel-diff target selection

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -112,11 +112,25 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "base_sha=$(python3 -c 'import json, os; print(json.load(open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8")).get("pull_request", {}).get("base", {}).get("sha", ""))')" >> "$GITHUB_OUTPUT"
+          eval "$(
+            python3 -c 'import json, os, shlex; event = json.load(open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8")); pr = event.get("pull_request", {}); print("\n".join(f"{key}={shlex.quote(value)}" for key, value in {"EVENT_BASE_SHA": pr.get("base", {}).get("sha", ""), "EVENT_HEAD_SHA": pr.get("head", {}).get("sha", "")}.items()))'
+          )"
+          # Key the base-hash cache by the MERGE-BASE, not the base tip.
+          # bazel-diff's base worktree is checked out at this same SHA (see the
+          # determine step), so the cache key must match. The merge-base is
+          # itself a main commit, so main.yml's main-push pre-warm still
+          # populates it. Fail closed: if merge-base cannot be computed, key by
+          # the base tip exactly as before.
+          base_sha="$EVENT_BASE_SHA"
+          if [[ -n "$EVENT_BASE_SHA" && -n "$EVENT_HEAD_SHA" ]] && \
+             merge_base="$(git merge-base "$EVENT_BASE_SHA" "$EVENT_HEAD_SHA")"; then
+            base_sha="$merge_base"
+          fi
+          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
 
       # Shares the cache convention (and main-push pre-warm) with main.yml's
       # determine-targets: base hashes are keyed by (bazel-diff version,
-      # base SHA) and skip half the bazel-diff work on a hit.
+      # merge-base SHA) and skip half the bazel-diff work on a hit.
       - name: Cache bazel-diff base hashes
         if: github.event_name == 'pull_request' && steps.pr-meta.outputs.base_sha != ''
         uses: actions/cache@v6
@@ -333,12 +347,22 @@ jobs:
             exit 0
           fi
 
-          cached_base="$HOME/.cache/bazel-diff-base-hashes/$BASE_SHA.json"
+          # Hash the base at the MERGE-BASE ($diff_base, computed above), not
+          # the base tip. Hashing the base tip attributes post-fork drift on
+          # main to the PR, inflating the affected set on any branch that has
+          # not rebased (measured up to 126x over-inclusion; see
+          # docs/design_docs/0029-2). Merge-base hashing sees only branch-side
+          # changes. This is sound because the PR merges INTO current main:
+          # target impact from base-side drift is validated by main's own CI on
+          # each main push, not by re-testing it on every stale PR. $diff_base
+          # fails closed to $BASE_SHA above, which preserves the old behavior.
+          # The pr-meta step keys the cache by the same merge-base.
+          cached_base="$HOME/.cache/bazel-diff-base-hashes/$diff_base.json"
           if [[ -s "$cached_base" ]]; then
-            echo "Using cached bazel-diff base hashes for $BASE_SHA."
+            echo "Using cached bazel-diff base hashes for $diff_base."
             cp "$cached_base" "$work_dir/base-hashes.json"
           else
-            if ! git worktree add --detach "$base_dir" "$BASE_SHA"; then
+            if ! git worktree add --detach "$base_dir" "$diff_base"; then
               echo "Failed to check out PR base; using full coverage target set."
               emit_targets true base_checkout_failed "$FULL_COVERAGE_TARGETS"
               exit 0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -112,25 +112,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          eval "$(
-            python3 -c 'import json, os, shlex; event = json.load(open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8")); pr = event.get("pull_request", {}); print("\n".join(f"{key}={shlex.quote(value)}" for key, value in {"EVENT_BASE_SHA": pr.get("base", {}).get("sha", ""), "EVENT_HEAD_SHA": pr.get("head", {}).get("sha", "")}.items()))'
-          )"
-          # Key the base-hash cache by the MERGE-BASE, not the base tip.
-          # bazel-diff's base worktree is checked out at this same SHA (see the
-          # determine step), so the cache key must match. The merge-base is
-          # itself a main commit, so main.yml's main-push pre-warm still
-          # populates it. Fail closed: if merge-base cannot be computed, key by
-          # the base tip exactly as before.
-          base_sha="$EVENT_BASE_SHA"
-          if [[ -n "$EVENT_BASE_SHA" && -n "$EVENT_HEAD_SHA" ]] && \
-             merge_base="$(git merge-base "$EVENT_BASE_SHA" "$EVENT_HEAD_SHA")"; then
-            base_sha="$merge_base"
-          fi
-          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+          echo "base_sha=$(python3 -c 'import json, os; print(json.load(open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8")).get("pull_request", {}).get("base", {}).get("sha", ""))')" >> "$GITHUB_OUTPUT"
 
       # Shares the cache convention (and main-push pre-warm) with main.yml's
       # determine-targets: base hashes are keyed by (bazel-diff version,
-      # merge-base SHA) and skip half the bazel-diff work on a hit.
+      # base SHA) and skip half the bazel-diff work on a hit.
       - name: Cache bazel-diff base hashes
         if: github.event_name == 'pull_request' && steps.pr-meta.outputs.base_sha != ''
         uses: actions/cache@v6
@@ -341,28 +327,33 @@ jobs:
           }
           trap cleanup EXIT
 
-          if ! git worktree add --detach "$head_dir" "$HEAD_SHA"; then
-            echo "Failed to check out PR head; using full coverage target set."
+          # Hash the current base TIP against the PR's MERGE commit (the
+          # workspace checkout, refs/pull/N/merge), not against HEAD_SHA.
+          # Hashing base-tip vs HEAD_SHA attributes post-fork drift on main to
+          # the PR, inflating the affected set on any branch that has not
+          # rebased (measured up to 126x over-inclusion; see
+          # docs/design_docs/0029-2). In the tip-vs-merge comparison, drift is
+          # present on BOTH sides, so unchanged-by-the-PR targets hash
+          # identically and drop out; and because the merge graph is the one
+          # hashed, reverse dependencies that exist ONLY in the merge (a dep
+          # edge added on main after the fork onto code this PR touches) are
+          # still caught - the coverage job builds this same merge ref.
+          # Fail closed: if the workspace is not a merge commit (e.g. a
+          # checkout override), it IS the PR head and this degrades to exactly
+          # the old base-tip-vs-head comparison.
+          merge_sha="$(git rev-parse HEAD)"
+          if ! git worktree add --detach "$head_dir" "$merge_sha"; then
+            echo "Failed to check out PR merge commit; using full coverage target set."
             emit_targets true head_checkout_failed "$FULL_COVERAGE_TARGETS"
             exit 0
           fi
 
-          # Hash the base at the MERGE-BASE ($diff_base, computed above), not
-          # the base tip. Hashing the base tip attributes post-fork drift on
-          # main to the PR, inflating the affected set on any branch that has
-          # not rebased (measured up to 126x over-inclusion; see
-          # docs/design_docs/0029-2). Merge-base hashing sees only branch-side
-          # changes. This is sound because the PR merges INTO current main:
-          # target impact from base-side drift is validated by main's own CI on
-          # each main push, not by re-testing it on every stale PR. $diff_base
-          # fails closed to $BASE_SHA above, which preserves the old behavior.
-          # The pr-meta step keys the cache by the same merge-base.
-          cached_base="$HOME/.cache/bazel-diff-base-hashes/$diff_base.json"
+          cached_base="$HOME/.cache/bazel-diff-base-hashes/$BASE_SHA.json"
           if [[ -s "$cached_base" ]]; then
-            echo "Using cached bazel-diff base hashes for $diff_base."
+            echo "Using cached bazel-diff base hashes for $BASE_SHA."
             cp "$cached_base" "$work_dir/base-hashes.json"
           else
-            if ! git worktree add --detach "$base_dir" "$diff_base"; then
+            if ! git worktree add --detach "$base_dir" "$BASE_SHA"; then
               echo "Failed to check out PR base; using full coverage target set."
               emit_targets true base_checkout_failed "$FULL_COVERAGE_TARGETS"
               exit 0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -650,7 +650,14 @@ jobs:
       # remote execution is down/degraded: a CPU-capped runner executing the
       # whole graph locally is the measured 2-3 h tail. Fast-fail on RE
       # degradation; the wedge-watch + rerun recover.
-      BAZEL_SELF_HOSTED_REMOTE_FALLBACK_FLAGS: "--remote_local_fallback=false --incompatible_remote_local_fallback_for_remote_cache=false --remote_timeout=5s"
+      # --remote_timeout is 60s (not 5s) for the same reason as the coverage
+      # lane: a healthy-but-BUSY endpoint legitimately takes >5s on bulk
+      # transfers under a multi-job burst (observed as spurious
+      # DEADLINE_EXCEEDED-after-4.999s failures on full-`//...` fallback runs,
+      # 2026-07-11, twice in a row on organic load; same signature as the
+      # 2026-07-02 coverage-lane incident that motivated coverage.yml's 60s).
+      # 60s still fast-fails a genuinely dead endpoint.
+      BAZEL_SELF_HOSTED_REMOTE_FALLBACK_FLAGS: "--remote_local_fallback=false --incompatible_remote_local_fallback_for_remote_cache=false --remote_timeout=60s"
       # Every self-hosted run uploads Bazel profiles + BEP + compact execution
       # logs so slow runs can be attributed to targets/actions without live
       # SSH. Keep artifacts small; retention is 3 days. DIAG_DIR is exported

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -264,18 +264,34 @@ jobs:
           set -euo pipefail
           base_sha=""
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            base_sha="$(python3 -c 'import json, os; print(json.load(open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8")).get("pull_request", {}).get("base", {}).get("sha", ""))')"
+            eval "$(
+              python3 -c 'import json, os, shlex; event = json.load(open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8")); pr = event.get("pull_request", {}); print("\n".join(f"{key}={shlex.quote(value)}" for key, value in {"EVENT_BASE_SHA": pr.get("base", {}).get("sha", ""), "EVENT_HEAD_SHA": pr.get("head", {}).get("sha", "")}.items()))'
+            )"
+            # Key the base-hash cache by the MERGE-BASE, not the base tip.
+            # bazel-diff's base worktree is checked out at this same SHA (see
+            # the determine step), so the cache key must match. The merge-base
+            # is itself a main commit, so the main-push pre-warm below still
+            # populates it. Fail closed: if merge-base cannot be computed, key
+            # by the base tip exactly as before.
+            base_sha="$EVENT_BASE_SHA"
+            if [[ -n "$EVENT_BASE_SHA" && -n "$EVENT_HEAD_SHA" ]] && \
+               merge_base="$(git merge-base "$EVENT_BASE_SHA" "$EVENT_HEAD_SHA")"; then
+              base_sha="$merge_base"
+            fi
           elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            # Pre-warm the cache for future PRs whose base is this main commit.
+            # Pre-warm the cache for future PRs whose merge-base is this main
+            # commit.
             base_sha="${{ github.sha }}"
           fi
           echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
 
       # Base hashes are a pure function of (bazel-diff version, base SHA), and
       # generating them is roughly half of this job's bazel-diff wall time.
-      # PRs restore them here; pushes to main generate and save them below so
-      # the first PR against any main commit already hits warm. Caches created
-      # on main are visible to all PR branches.
+      # PRs restore them here (keyed by the PR's merge-base); pushes to main
+      # generate and save them below so the first PR forking from any main
+      # commit already hits warm. Caches created on main are visible to all PR
+      # branches. Merge-base keying also makes the key stable across base-branch
+      # drift: pushes to main no longer invalidate a PR's cached base hashes.
       - name: Cache bazel-diff base hashes
         if: steps.pr-meta.outputs.base_sha != ''
         uses: actions/cache@v6
@@ -400,12 +416,22 @@ jobs:
 
           git worktree add --detach "$head_dir" "$HEAD_SHA"
 
-          cached_base="$HOME/.cache/bazel-diff-base-hashes/$BASE_SHA.json"
+          # Hash the base at the MERGE-BASE ($diff_base, computed above), not
+          # the base tip. Hashing the base tip attributes post-fork drift on
+          # main to the PR, inflating the affected set on any branch that has
+          # not rebased (measured up to 126x over-inclusion; see
+          # docs/design_docs/0029-2). Merge-base hashing sees only branch-side
+          # changes. This is sound because the PR merges INTO current main:
+          # target impact from base-side drift is validated by main's own CI on
+          # each main push, not by re-testing it on every stale PR. $diff_base
+          # fails closed to $BASE_SHA above, which preserves the old behavior.
+          # The pr-meta step keys the cache by the same merge-base.
+          cached_base="$HOME/.cache/bazel-diff-base-hashes/$diff_base.json"
           if [[ -s "$cached_base" ]]; then
-            echo "Using cached bazel-diff base hashes for $BASE_SHA."
+            echo "Using cached bazel-diff base hashes for $diff_base."
             cp "$cached_base" "$work_dir/base-hashes.json"
           else
-            git worktree add --detach "$base_dir" "$BASE_SHA"
+            git worktree add --detach "$base_dir" "$diff_base"
             java -jar "$RUNNER_TEMP/bazel-diff.jar" generate-hashes \
             --includeTargetType \
               -w "$base_dir" \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -264,34 +264,18 @@ jobs:
           set -euo pipefail
           base_sha=""
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            eval "$(
-              python3 -c 'import json, os, shlex; event = json.load(open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8")); pr = event.get("pull_request", {}); print("\n".join(f"{key}={shlex.quote(value)}" for key, value in {"EVENT_BASE_SHA": pr.get("base", {}).get("sha", ""), "EVENT_HEAD_SHA": pr.get("head", {}).get("sha", "")}.items()))'
-            )"
-            # Key the base-hash cache by the MERGE-BASE, not the base tip.
-            # bazel-diff's base worktree is checked out at this same SHA (see
-            # the determine step), so the cache key must match. The merge-base
-            # is itself a main commit, so the main-push pre-warm below still
-            # populates it. Fail closed: if merge-base cannot be computed, key
-            # by the base tip exactly as before.
-            base_sha="$EVENT_BASE_SHA"
-            if [[ -n "$EVENT_BASE_SHA" && -n "$EVENT_HEAD_SHA" ]] && \
-               merge_base="$(git merge-base "$EVENT_BASE_SHA" "$EVENT_HEAD_SHA")"; then
-              base_sha="$merge_base"
-            fi
+            base_sha="$(python3 -c 'import json, os; print(json.load(open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8")).get("pull_request", {}).get("base", {}).get("sha", ""))')"
           elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            # Pre-warm the cache for future PRs whose merge-base is this main
-            # commit.
+            # Pre-warm the cache for future PRs whose base is this main commit.
             base_sha="${{ github.sha }}"
           fi
           echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
 
       # Base hashes are a pure function of (bazel-diff version, base SHA), and
       # generating them is roughly half of this job's bazel-diff wall time.
-      # PRs restore them here (keyed by the PR's merge-base); pushes to main
-      # generate and save them below so the first PR forking from any main
-      # commit already hits warm. Caches created on main are visible to all PR
-      # branches. Merge-base keying also makes the key stable across base-branch
-      # drift: pushes to main no longer invalidate a PR's cached base hashes.
+      # PRs restore them here; pushes to main generate and save them below so
+      # the first PR against any main commit already hits warm. Caches created
+      # on main are visible to all PR branches.
       - name: Cache bazel-diff base hashes
         if: steps.pr-meta.outputs.base_sha != ''
         uses: actions/cache@v6
@@ -414,24 +398,29 @@ jobs:
           }
           trap cleanup EXIT
 
-          git worktree add --detach "$head_dir" "$HEAD_SHA"
+          # Hash the current base TIP against the PR's MERGE commit (the
+          # workspace checkout, refs/pull/N/merge), not against HEAD_SHA.
+          # Hashing base-tip vs HEAD_SHA attributes post-fork drift on main to
+          # the PR, inflating the affected set on any branch that has not
+          # rebased (measured up to 126x over-inclusion; see
+          # docs/design_docs/0029-2). In the tip-vs-merge comparison, drift is
+          # present on BOTH sides, so unchanged-by-the-PR targets hash
+          # identically and drop out; and because the merge graph is the one
+          # hashed, reverse dependencies that exist ONLY in the merge (a dep
+          # edge added on main after the fork onto code this PR touches) are
+          # still caught - the downstream jobs build this same merge ref.
+          # Fail closed: if the workspace is not a merge commit (e.g. a
+          # checkout override), it IS the PR head and this degrades to exactly
+          # the old base-tip-vs-head comparison.
+          merge_sha="$(git rev-parse HEAD)"
+          git worktree add --detach "$head_dir" "$merge_sha"
 
-          # Hash the base at the MERGE-BASE ($diff_base, computed above), not
-          # the base tip. Hashing the base tip attributes post-fork drift on
-          # main to the PR, inflating the affected set on any branch that has
-          # not rebased (measured up to 126x over-inclusion; see
-          # docs/design_docs/0029-2). Merge-base hashing sees only branch-side
-          # changes. This is sound because the PR merges INTO current main:
-          # target impact from base-side drift is validated by main's own CI on
-          # each main push, not by re-testing it on every stale PR. $diff_base
-          # fails closed to $BASE_SHA above, which preserves the old behavior.
-          # The pr-meta step keys the cache by the same merge-base.
-          cached_base="$HOME/.cache/bazel-diff-base-hashes/$diff_base.json"
+          cached_base="$HOME/.cache/bazel-diff-base-hashes/$BASE_SHA.json"
           if [[ -s "$cached_base" ]]; then
-            echo "Using cached bazel-diff base hashes for $diff_base."
+            echo "Using cached bazel-diff base hashes for $BASE_SHA."
             cp "$cached_base" "$work_dir/base-hashes.json"
           else
-            git worktree add --detach "$base_dir" "$diff_base"
+            git worktree add --detach "$base_dir" "$BASE_SHA"
             java -jar "$RUNNER_TEMP/bazel-diff.jar" generate-hashes \
             --includeTargetType \
               -w "$base_dir" \

--- a/docs/design_docs/0029-2-ci_runtime.md
+++ b/docs/design_docs/0029-2-ci_runtime.md
@@ -778,36 +778,42 @@ threshold routes broad PRs to the hosted lane and fired on editor-v08-ux-polish
 Levers 1 and 2 remain the only ones that reach P99<=15 on worst-case
 header-fanout PRs, and both are operator-reserved (infra load / coverage scope).
 
-### As-built: bazel-diff base aligned to the merge-base (lever 3, 2026-07-11)
+### As-built: bazel-diff compares base TIP vs the PR MERGE commit (lever 3, 2026-07-11)
 
-Implemented in both `main.yml` and `coverage.yml` determine-targets: the
-bazel-diff base worktree is checked out and hashed at `git merge-base
-BASE_SHA HEAD_SHA` (the same `diff_base` the #825 changed-files fix uses), and
-the base-hash cache is keyed by that merge-base (computed identically in the
-`pr-meta` step). Fail-closed: if merge-base cannot be computed, both sites fall
-back to the base tip, which is exactly the prior behavior.
+Implemented in both `main.yml` and `coverage.yml` determine-targets: bazel-diff
+now hashes the CURRENT BASE TIP against the PR's MERGE commit (the workspace
+checkout, `refs/pull/N/merge`) instead of base tip vs `HEAD_SHA`. The base-hash
+cache keying (base tip, main-push pre-warmed) is unchanged. Fail-closed: if the
+workspace is not a merge commit, it is the PR head and the comparison degrades
+to exactly the old behavior.
 
-Soundness: the PR merges INTO current main, so target impact from base-side
-drift is validated by main's own CI on each main push. Interaction impact needs
-a target that depends on the PR's changed targets; every such target is in the
-merge-base affected set by construction (it is a reverse dependency of the
-branch-side change) and is built/tested on the PR's MERGE checkout, where the
-drift is present. Only redundant re-testing of pure-drift targets is dropped.
-Side benefit: merge-base cache keys are stable across base drift, so main
-pushes no longer invalidate a PR's cached base hashes, and the main-push
-pre-warm still hits (a merge-base is itself a main commit).
+Design history, recorded for provenance: the first draft hashed the base at the
+MERGE-BASE (fork point) vs `HEAD_SHA`. Review (PR #836, P1) correctly identified
+an escape hole in that scheme: a reverse dependency added on main AFTER the fork
+(a dep edge onto code the PR touches) exists in neither the fork-point graph nor
+the PR-head graph, so fork-vs-head hashing cannot see it, while the CI jobs
+build the merge ref where it is live. The tip-vs-merge comparison dominates both
+schemes: post-fork drift is present on BOTH sides (identical hashes, drops out,
+killing the inflation), and the merge graph is the one hashed (merge-only
+reverse dependencies hash differently vs the base tip, so they stay in the
+affected set).
 
-Validation (controlled stale-branch reproduction, hub-local bazel-diff
-v18.1.0, same flags as CI): fork point 3 commits behind main tip (drift = the
-#828 + #829 editor/svg merges plus a docs commit), true change = one comment
-line in `donner/base/tests/Box_tests.cc`.
+Validation (controlled reproductions, hub-local bazel-diff v18.1.0, same flags
+as CI; fork point 3 commits behind main tip):
 
-| basis | affected targets |
-|---|---:|
-| base hashed at base TIP (old behavior) | 376 |
-| base hashed at MERGE-BASE (this change) | **2** (`//donner/base:base_tests`, `base_tests_lint`) |
+| test | scheme | result |
+|---|---|---|
+| A: inflation (one-line change to `donner/base/tests/Box_tests.cc`) | old: tip vs HEAD_SHA | 130 affected targets |
+| A | new: tip vs MERGE | **2** (`//donner/base:base_tests`, `base_tests_lint`) |
+| B: merge-only rdep escape (drifted base adds `//probe_drift:probe_dep` depending on `//donner/css:css`; PR touches `donner/css/CSS.cc`) | rejected draft: fork vs HEAD_SHA | 422 targets, probe_dep **MISSED** |
+| B | new: tip vs MERGE | 425 targets, probe_dep **CAUGHT** |
 
-The 376 matches the #829-scale inflation measured in this audit; the 2 is
-exactly the true change. This closes the known bazel-diff over-inclusion
-residual flagged in the #825 fix and in the determination-quality audit above
-(126x tail).
+Test A shows the over-inclusion fix (matches the 126x-tail signature in the
+determination-quality audit above); Test B constructs the reviewer's escape
+scenario and shows the shipped scheme closes it while the rejected draft did
+not. Same PR also raises the CI Linux lane's `--remote_timeout` from 5s to 60s,
+mirroring the coverage lane's documented 2026-07-02 rationale, after two
+consecutive spurious DEADLINE_EXCEEDED-after-4.999s failures on organic load
+(the serialized coverage job passed concurrently under its 60s timeout; the
+first tip-vs-merge run then passed full-`//...` in 17m28s on the same busy
+backend).

--- a/docs/design_docs/0029-2-ci_runtime.md
+++ b/docs/design_docs/0029-2-ci_runtime.md
@@ -777,3 +777,37 @@ threshold routes broad PRs to the hosted lane and fired on editor-v08-ux-polish
 
 Levers 1 and 2 remain the only ones that reach P99<=15 on worst-case
 header-fanout PRs, and both are operator-reserved (infra load / coverage scope).
+
+### As-built: bazel-diff base aligned to the merge-base (lever 3, 2026-07-11)
+
+Implemented in both `main.yml` and `coverage.yml` determine-targets: the
+bazel-diff base worktree is checked out and hashed at `git merge-base
+BASE_SHA HEAD_SHA` (the same `diff_base` the #825 changed-files fix uses), and
+the base-hash cache is keyed by that merge-base (computed identically in the
+`pr-meta` step). Fail-closed: if merge-base cannot be computed, both sites fall
+back to the base tip, which is exactly the prior behavior.
+
+Soundness: the PR merges INTO current main, so target impact from base-side
+drift is validated by main's own CI on each main push. Interaction impact needs
+a target that depends on the PR's changed targets; every such target is in the
+merge-base affected set by construction (it is a reverse dependency of the
+branch-side change) and is built/tested on the PR's MERGE checkout, where the
+drift is present. Only redundant re-testing of pure-drift targets is dropped.
+Side benefit: merge-base cache keys are stable across base drift, so main
+pushes no longer invalidate a PR's cached base hashes, and the main-push
+pre-warm still hits (a merge-base is itself a main commit).
+
+Validation (controlled stale-branch reproduction, hub-local bazel-diff
+v18.1.0, same flags as CI): fork point 3 commits behind main tip (drift = the
+#828 + #829 editor/svg merges plus a docs commit), true change = one comment
+line in `donner/base/tests/Box_tests.cc`.
+
+| basis | affected targets |
+|---|---:|
+| base hashed at base TIP (old behavior) | 376 |
+| base hashed at MERGE-BASE (this change) | **2** (`//donner/base:base_tests`, `base_tests_lint`) |
+
+The 376 matches the #829-scale inflation measured in this audit; the 2 is
+exactly the true change. This closes the known bazel-diff over-inclusion
+residual flagged in the #825 fix and in the determination-quality audit above
+(126x tail).


### PR DESCRIPTION
## Summary

Fixes bazel-diff's stale-branch over-inclusion in both `main.yml` and
`coverage.yml` determine-targets by comparing the **current base TIP against
the PR's MERGE commit** (the `refs/pull/N/merge` workspace checkout) instead of
base tip vs `HEAD_SHA`. The #825 fix corrected the changed-FILES diff basis;
the bazel-diff hashing basis still attributed post-fork drift on main to the
PR, inflating affected sets on any branch that had not rebased (up to 126x in
the determination-quality audit in `docs/design_docs/0029-2`).

## Why tip-vs-merge is the sound comparison

- **Over-inclusion fixed:** post-fork drift is present on BOTH sides of the
  comparison, hashes identically, and drops out of the affected set.
- **No escape hole:** the merge graph is the one hashed, so a reverse
  dependency added on main after the fork onto code this PR touches hashes
  differently vs the base tip and STAYS in the affected set - and the
  downstream jobs build this same merge ref. (An earlier draft of this PR
  hashed merge-base vs head; the P1 review correctly identified that it missed
  exactly those merge-only reverse dependencies. Fixed by taking the review's
  suggestion; validation below constructs that scenario.)
- **Fail-closed:** if the workspace is not a merge commit, it is the PR head
  and the comparison degrades to exactly the old base-tip-vs-head behavior.
  Base-hash caching (base tip, main-push pre-warm) is unchanged.

## Validation (controlled reproductions, bazel-diff v18.1.0, CI flags)

Fork point 3 commits behind main tip; measured on the repo hub.

| test | scheme | result |
|---|---|---|
| A: stale-branch inflation (one-line change to `donner/base/tests/Box_tests.cc`) | old: tip vs HEAD_SHA | 130 affected targets |
| A | **new: tip vs MERGE** | **2** (`//donner/base:base_tests`, `base_tests_lint`) |
| B: merge-only rdep escape (drifted base adds `//probe_drift:probe_dep` on `//donner/css:css`; PR touches `donner/css/CSS.cc`) | rejected draft: fork vs HEAD_SHA | 422 targets, probe_dep MISSED |
| B | **new: tip vs MERGE** | 425 targets, **probe_dep CAUGHT** |

## Second commit: linux-self-hosted `--remote_timeout` 5s -> 60s

This PR's own full-`//...` fallback runs failed twice in a row with spurious
`DEADLINE_EXCEEDED after 4.999s` on every bulk transfer while the RE endpoint
was healthy but busy (the serialized coverage job passed concurrently under its
60s timeout). This mirrors the coverage lane's documented 2026-07-02 rationale
onto the CI Linux lane; 60s still fast-fails a genuinely dead endpoint and the
lane keeps `remote_local_fallback=false`. Measured on this PR: the first
post-fix full-`//...` run passed in 17m28s on the same busy backend that failed
twice at 5s.

## Measurement note

This PR touches `.github/workflows/*`, so its own CI takes the infra-change
full-`//...` fallback by design. Post-merge validation: compare affected-set
sizes on the next stale-branch PR and watch determine-targets logs.

## Constraints honored

No gate weakening: fallback paths, classifiers, and skip logic untouched; the
affected-set change only removes drift work that main-push CI already
validated, and the review-identified escape vector is closed with a
constructed-scenario proof. Fail-closed to prior behavior throughout.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
