### PR TITLE
test: drop duplicate CPU params from resvg geode variant, shard 16

### DIFF
--- a/build_defs/rules.bzl
+++ b/build_defs/rules.bzl
@@ -344,6 +344,17 @@ def donner_variant_cc_test(name, dep, variants = None, named_variants = None, **
     if named_variants:
         for v in named_variants:
             target_name = "{}_{}".format(name, v["name"])
+
+            # Per-variant overrides: a variant dict may carry "args" and/or
+            # "shard_count" to override the shared kwargs for just that
+            # variant (e.g. the resvg geode variant filters out CPU-reference
+            # params and takes a higher shard count than the CPU variants).
+            variant_kwargs = dict(kwargs)
+            if "args" in v:
+                variant_kwargs["args"] = v["args"]
+            if "shard_count" in v:
+                variant_kwargs["shard_count"] = v["shard_count"]
+
             donner_multi_transitioned_test(
                 name = target_name,
                 dep = dep,
@@ -351,7 +362,7 @@ def donner_variant_cc_test(name, dep, variants = None, named_variants = None, **
                 text = v.get("text", "false"),
                 text_full = v.get("text_full", "false"),
                 testonly = 1,
-                **kwargs
+                **variant_kwargs
             )
     elif variants:
         backends = variants[0] if len(variants) > 0 else ["tiny_skia"]

--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -582,11 +582,27 @@ donner_variant_cc_test(
         # Geode variant: runs the same resvg Params and thresholds as the CPU
         # variants. Per-test exceptions belong in the normal Params maps, not in
         # backend-specific gate tables.
+        #
+        # In geode builds every testcase generates a TinyGolden (CPU
+        # reference) and a GeodeGolden param, interleaved. The TinyGolden
+        # half is an exact duplicate of the default_text variant's param
+        # set (verified by enumerating both binaries: the geode variant's
+        # 1636 *_TinyGolden params strip-suffix-equal the default_text
+        # variant's 1636 params, zero missing / zero extra), so the geode
+        # lane filters them out and runs only the GeodeGolden half. The CPU
+        # comparisons still run on every `bazel test //...` via
+        # resvg_test_suite_default_text.
+        #
+        # With the CPU half gone the shard work is pure geode
+        # render+readback+golden-compare volume; 16 shards halves the
+        # per-shard critical path relative to the CPU variants' 8.
         {
             "name": "geode",
             "backend": "geode",
             "text": "true",
             "text_full": "false",
+            "args": ["--gtest_filter=-*_TinyGolden"],
+            "shard_count": 16,
         },
     ],
     # Hundreds of independent image comparisons per variant. Unsharded, the


### PR DESCRIPTION
## Summary

CI test-runtime campaign: attacks the #1 test action on the CI critical path, `resvg_test_suite_geode` (60.3s max shard, 256s total on the self-hosted Linux lane in the last main profile). Two levers, one coherent change:

1. **Redundancy trim (operator trim grant):** in geode builds every resvg testcase generates both a `TinyGolden` (CPU reference) and a `GeodeGolden` param, interleaved — so ~half the geode lane's shard work was tiny-skia CPU renders that duplicate `resvg_test_suite_default_text`. The geode variant now runs with `--gtest_filter=-*_TinyGolden`.
2. **Shard 8 → 16 (geode variant only):** the remaining work is pure geode render+readback+golden-compare volume. Controlled profiling upstream measured the per-process fixed cost at ~0.6s device init + ~2s one-time cold shader JIT (Mesa-cached when warm), so shard multiplication does not multiply meaningful fixed cost. CPU variants keep 8 shards and no filter.

Mechanism: `donner_variant_cc_test`'s `named_variants` dicts accept per-variant `args` / `shard_count` overrides (only the resvg suite uses `named_variants`; other callers unaffected). gtest applies the filter before shard partitioning, so all 16 shards carry balanced geode-only work.

## Coverage argument (set-equivalence proof)

Enumerating both built variant binaries with `--gtest_list_tests`:

| binary | params |
|---|---|
| `resvg_test_suite_geode` | 3272 = 1636 `*_TinyGolden` + 1636 `*_GeodeGolden` (0 unsuffixed) |
| `resvg_test_suite_default_text` | 1636 |

Stripping the `_TinyGolden` suffix, the geode variant's 1636 TinyGolden params and the default_text variant's 1636 params are **equal sets: zero missing, zero extra**. Every dropped comparison still executes on every `bazel test //...` via `resvg_test_suite_default_text`, under the same tiny-skia code path (the only build-config difference, `DONNER_GEODE_BACKEND_AVAILABLE`, gates geode device creation, not tiny-skia rendering). Post-filter execution count verified at exactly 1636.

## Measured (hub, geode = Metal, uncached per-shard exec)

| | shards | max shard | sum |
|---|---:|---:|---:|
| before (both modes) | 8 | 9.9s | 75.0s |
| after (GeodeGolden only) | 16 | 4.5s | 58.9s |

Per-shard balance after: 2.8–4.5s across all 16 shards. On the CI Linux lane (lavapipe), where this suite set the 60.3s test-phase pole, halving the work and doubling the shards should bring the max shard to roughly the ~13s range predicted by the geode investigation — CI numbers will confirm on this PR's run.

`resvg_test_suite_default_text`: unchanged, PASSED (8 shards, its params are the same TinyGolden set, still executed).

## Test plan

- Set-equivalence enumeration (above).
- `bazelisk test //donner/svg/renderer/tests:resvg_test_suite_geode --nocache_test_results`: PASSED, 16 balanced shards.
- `bazelisk test //donner/svg/renderer/tests:resvg_test_suite_default_text --nocache_test_results`: PASSED, unchanged.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17