### PR TITLE
ci(coverage): representative-variant PR patch coverage (lever 2) + lever-1 verification

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -298,7 +298,7 @@ jobs:
             esac
 
             case "$path" in
-              .bazelrc|.github/workflows/*|.github/actions/*|docs/*|*.md|tools/binary_size.sh|tools/build_docs.sh|tools/coverage.sh|tools/filter_coverage.py|tools/filter_coverage_tests.py|tools/lcov_metrics.py|tools/lcov_metrics_tests.py|tools/generate_build_report.py|tools/generate_build_report_tests.py|tools/coverage_instrumentable_targets.py|tools/coverage_instrumentable_targets_tests.py)
+              .bazelrc|.github/workflows/*|.github/actions/*|docs/*|*.md|tools/binary_size.sh|tools/build_docs.sh|tools/coverage.sh|tools/filter_coverage.py|tools/filter_coverage_tests.py|tools/lcov_metrics.py|tools/lcov_metrics_tests.py|tools/generate_build_report.py|tools/generate_build_report_tests.py|tools/coverage_instrumentable_targets.py|tools/coverage_instrumentable_targets_tests.py|tools/coverage_variant_trim.py|tools/coverage_variant_trim_tests.py)
                 ;;
               *)
                 smoke_only=false
@@ -488,6 +488,32 @@ jobs:
           else
             echo "Kind query failed; running coverage on affected subset (guard intact)."
             cat "$diagnostics_dir/kind-query.log" || true
+          fi
+
+          # Representative-variant trim (operator-approved policy, 2026-07-11):
+          # PR PATCH coverage runs one representative variant per test - the
+          # base/default target - and drops `_tiny`/`_text_full`/`_geode`
+          # variant wrappers whose base sibling is in the set. The wrappers
+          # compile the SAME sources under different backend/feature flags, so
+          # for patch coverage they are redundant parameterizations whose
+          # unique signal (backend/feature-gated lines) stays covered by the
+          # main-push FULL multi-variant baseline. Fail closed: tool failure
+          # keeps the untrimmed set; variant-only targets (no base sibling)
+          # are never dropped. See tools/coverage_variant_trim.py and
+          # docs/design_docs/0029-2.
+          printf '%s\n' $affected > "$work_dir/affected-pretrim.txt"
+          if trimmed="$(python3 tools/coverage_variant_trim.py \
+              --affected-file "$work_dir/affected-pretrim.txt" \
+              --dropped-out "$diagnostics_dir/variant-trim-dropped.txt" 2> "$diagnostics_dir/variant-trim.log")"; then
+            cat "$diagnostics_dir/variant-trim.log" || true
+            if [[ -n "$trimmed" ]]; then
+              affected="$(tr '\n' ' ' <<< "$trimmed" | sed 's/ $//')"
+            else
+              echo "Variant trim produced an empty set; keeping untrimmed affected set (guard intact)."
+            fi
+          else
+            echo "Variant trim tool errored; keeping untrimmed affected set (guard intact)."
+            cat "$diagnostics_dir/variant-trim.log" || true
           fi
 
           emit_targets false bazel_diff "$affected"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -497,13 +497,19 @@ jobs:
           # compile the SAME sources under different backend/feature flags, so
           # for patch coverage they are redundant parameterizations whose
           # unique signal (backend/feature-gated lines) stays covered by the
-          # main-push FULL multi-variant baseline. Fail closed: tool failure
-          # keeps the untrimmed set; variant-only targets (no base sibling)
+          # main-push FULL multi-variant baseline. Only targets whose rule
+          # kind (from the label_kind query above) is the generated
+          # donner_multi_transitioned_test wrapper are ever dropped, so
+          # handwritten targets that merely share the suffix (e.g. a
+          # cc_library named renderer_geode) are untouched. Fail closed: tool
+          # failure, a failed kind query, or an unknown kind keeps the
+          # untrimmed set / target; variant-only targets (no base sibling)
           # are never dropped. See tools/coverage_variant_trim.py and
           # docs/design_docs/0029-2.
           printf '%s\n' $affected > "$work_dir/affected-pretrim.txt"
           if trimmed="$(python3 tools/coverage_variant_trim.py \
               --affected-file "$work_dir/affected-pretrim.txt" \
+              --label-kind-file "$label_kind_file" \
               --dropped-out "$diagnostics_dir/variant-trim-dropped.txt" 2> "$diagnostics_dir/variant-trim.log")"; then
             cat "$diagnostics_dir/variant-trim.log" || true
             if [[ -n "$trimmed" ]]; then

--- a/docs/design_docs/0029-2-ci_runtime.md
+++ b/docs/design_docs/0029-2-ci_runtime.md
@@ -869,9 +869,16 @@ failure keeps the untrimmed set. Implemented in
 determine-targets after the instrumentability classifier (which therefore
 still sees the full set).
 
-Measured on the #829 exemplar's real affected list: 376 -> 277 targets (99
-variant wrappers dropped, all with base siblings present: 38 `_geode`, 31
-`_text_full`, 30 `_tiny`); on the run's execution profile those wrappers
+Review hardening (PR #840 P2): trimming is kind-gated on the generated
+wrapper rule kind (`donner_multi_transitioned_test`, from the label_kind
+query the classifier already runs), so handwritten targets that merely share
+the suffix (e.g. the `cc_library` named `renderer_geode` beside
+`renderer`) are never dropped; unknown kinds fail safe to keep.
+
+Measured on the #829 exemplar's real affected list with its real label_kind
+data: 376 -> 281 targets (95 generated wrappers dropped; 4 name-coincident
+non-wrapper targets correctly kept by the kind gate; 7 wrapper targets kept
+for lacking a base sibling); on the run's execution profile those wrappers
 account for 90 of 296 test executions and the transitioned compile closures
 behind the ~7x per-element instrumented compile multiplier. Projected: the
 cache-miss compile set on a variant-heavy PR shrinks by roughly the wrapper

--- a/docs/design_docs/0029-2-ci_runtime.md
+++ b/docs/design_docs/0029-2-ci_runtime.md
@@ -817,3 +817,63 @@ consecutive spurious DEADLINE_EXCEEDED-after-4.999s failures on organic load
 (the serialized coverage job passed concurrently under its 60s timeout; the
 first tip-vs-merge run then passed full-`//...` in 17m28s on the same busy
 backend).
+
+### As-built: levers 1 and 2 (operator-approved, 2026-07-11)
+
+**Lever 1 (seed the RE coverage cache from main-push) is already live, and its
+verification CORRECTS this audit's cold-cache claim.** The main-push coverage
+baseline has been routing to the self-hosted RE lane (same job, executor, and
+flags as PR coverage) since the runner-routing change (#818) took effect; the
+hosted `build` job now runs only as the PR fallback path. Measured main-push
+lane duration: 5-11 min on the RE lane versus the ~70 min hosted median in the
+48h profile above (the profile window straddled the cutover; 69.7 median was
+the before-state). Codecov baseline semantics are intact: the artifact +
+hosted-upload path is unchanged, verified on live main-push runs.
+
+**Correction (integrity note):** this audit's "`cachedRemotely: true` = 4, the
+coverage cache is effectively cold" was WRONG. BEP `action` events are emitted
+only for failed actions, so grepping them undercounts cache hits by orders of
+magnitude. The authoritative `buildMetrics.actionSummary.runnerCount` shows:
+
+| run | remote cache hit | remote exec | internal | wall |
+|---|---:|---:|---:|---:|
+| PR #829 coverage (the 54-min exemplar) | 3107 | 1519 | 5854 | 54 min |
+| main-push 19:32Z | 5526 | 10 | 10610 | 7.5 min |
+| main-push 15:30Z | 3748 | 1 | 104 | 5.7 min |
+
+The seed works: main-to-main runs are ~97 percent cache-hit, and even the #829
+worst case got 3107 hits. The revised root cause of the 54-minute run: the
+1519 genuine cache-miss actions (the real reverse-dependency recompiles of the
+PR's changed headers - which can never be cache hits on first run) spent
+**4511 cpu-min in remote-execution QUEUE versus 158 cpu-min executing** (96
+percent queuing) at CI's floor scheduler priority during a contended window
+(the PR's own linux lane ran concurrently on the same backend, plus
+interactive dev priority). The lane's tail is therefore demand x contention on
+cache-miss actions, not cache coldness. Levers that cut miss-set size (the
+merge-ref hashing fix #836, and lever 2 below) attack it directly; scheduler
+priority is operator-reserved and untouched.
+
+**Lever 2 (representative-variant PR coverage) as-built.** PR PATCH coverage
+now trims `donner_variant_cc_test` wrapper targets (`_tiny`, `_text_full`,
+`_geode`; build_defs/rules.bzl `_VARIANT_SPECS`) from the bazel-diff affected
+set when their base sibling is present; the base/default target is the
+representative. The full multi-variant matrix stays on the main-push baseline.
+Coverage-semantics change, stated plainly: patch coverage on PRs reflects the
+default variant only; backend/feature-gated lines and cross-variant
+regressions surface on main-push (and in CI's own test lanes, which are
+untouched - this trims only the coverage lane's instrumented re-run).
+Fail-safe: variant-only targets (no base sibling) are never dropped; tool
+failure keeps the untrimmed set. Implemented in
+`tools/coverage_variant_trim.py` (unit-tested,
+`//tools:coverage_variant_trim_tests`), called from coverage.yml
+determine-targets after the instrumentability classifier (which therefore
+still sees the full set).
+
+Measured on the #829 exemplar's real affected list: 376 -> 277 targets (99
+variant wrappers dropped, all with base siblings present: 38 `_geode`, 31
+`_text_full`, 30 `_tiny`); on the run's execution profile those wrappers
+account for 90 of 296 test executions and the transitioned compile closures
+behind the ~7x per-element instrumented compile multiplier. Projected: the
+cache-miss compile set on a variant-heavy PR shrinks by roughly the wrapper
+share; measured before/after cache-hit and wall numbers ride the next organic
+C/C++ PR (post-merge measurement, pull_request runs the base workflow).

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -82,6 +82,14 @@ py_test(
 )
 
 py_test(
+    name = "coverage_variant_trim_tests",
+    srcs = [
+        "coverage_variant_trim.py",
+        "coverage_variant_trim_tests.py",
+    ],
+)
+
+py_test(
     name = "filter_coverage_tests",
     srcs = [
         "filter_coverage.py",

--- a/tools/coverage_variant_trim.py
+++ b/tools/coverage_variant_trim.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Trim redundant variant-wrapper targets from the PR coverage target set.
+
+Policy (operator-approved, 2026-07-11): PR PATCH coverage instruments and runs
+ONE representative variant per test - the base/default target - and the full
+multi-variant matrix stays on the main-push coverage baseline. Rationale: the
+`donner_variant_cc_test` wrappers (`{name}_tiny`, `{name}_text_full`,
+`{name}_geode`; see build_defs/rules.bzl `_VARIANT_SPECS`) compile the SAME
+source files under different backend/feature flags, so for Codecov patch
+coverage of a PR's changed lines they are redundant parameterizations - their
+unique coverage is limited to backend/feature-gated lines, which the main-push
+full run keeps covering. The measured cost of the redundancy on the coverage
+lane is a ~7x instrumented compile multiplier on SVG element translation units
+and 90 of 296 test executions (docs/design_docs/0029-2, PR #829 exemplar).
+
+The base variant is the representative because it is the default build graph
+(what `bazel test` and the CI lanes exercise by default), it already accounts
+for the majority of coverage test executions (206 of 296 on the exemplar), and
+its instrumented surface is the broadest default-feature surface.
+
+Fail-safe contract: a variant-suffixed target is dropped ONLY when its base
+sibling (the label with the suffix stripped) is itself present in the affected
+set, so every test's coverage keeps at least one representative in the PR run.
+Variant-only entries (no base sibling in the set) are kept. Non-variant labels
+are never touched. Any error in this tool must be treated by the caller as
+"keep the full set" (fail closed).
+
+Reads one label per line, writes the trimmed set (one per line) to stdout and
+a summary line to stderr.
+"""
+
+import argparse
+from pathlib import Path
+import sys
+
+# Keep in sync with build_defs/rules.bzl _VARIANT_SPECS. Order matters only
+# for readability; suffixes are tested longest-first to keep `_text_full`
+# from being misread as a `_full` variant of `..._text`.
+VARIANT_SUFFIXES = ("_text_full", "_tiny", "_geode")
+
+
+def trim_variants(labels):
+    """Return (kept, dropped) lists. See module docstring for the policy."""
+    label_set = set(labels)
+    kept = []
+    dropped = []
+    for label in labels:
+        drop = False
+        for suffix in VARIANT_SUFFIXES:
+            if label.endswith(suffix):
+                base = label[: -len(suffix)]
+                # Only a real target name qualifies (guard against a label
+                # that IS the suffix, e.g. "//pkg:_geode").
+                base_name = base.rsplit(":", 1)[-1]
+                if base_name and base in label_set:
+                    drop = True
+                break
+        (dropped if drop else kept).append(label)
+    return kept, dropped
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--affected-file",
+        required=True,
+        help="File with one affected target label per line.",
+    )
+    parser.add_argument(
+        "--dropped-out",
+        help="Optional file to record the dropped variant labels.",
+    )
+    args = parser.parse_args(argv)
+
+    labels = [
+        line.strip()
+        for line in Path(args.affected_file).read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    kept, dropped = trim_variants(labels)
+
+    if args.dropped_out:
+        Path(args.dropped_out).write_text(
+            "".join(f"{label}\n" for label in dropped), encoding="utf-8"
+        )
+
+    sys.stdout.write("".join(f"{label}\n" for label in kept))
+    sys.stderr.write(
+        f"variant trim: kept={len(kept)} dropped={len(dropped)} of {len(labels)}\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/coverage_variant_trim.py
+++ b/tools/coverage_variant_trim.py
@@ -18,12 +18,16 @@ The base variant is the representative because it is the default build graph
 for the majority of coverage test executions (206 of 296 on the exemplar), and
 its instrumented surface is the broadest default-feature surface.
 
-Fail-safe contract: a variant-suffixed target is dropped ONLY when its base
-sibling (the label with the suffix stripped) is itself present in the affected
-set, so every test's coverage keeps at least one representative in the PR run.
-Variant-only entries (no base sibling in the set) are kept. Non-variant labels
-are never touched. Any error in this tool must be treated by the caller as
-"keep the full set" (fail closed).
+Fail-safe contract: a target is dropped ONLY when ALL of the following hold:
+(1) its label carries a variant suffix, (2) its base sibling (the label with
+the suffix stripped) is itself present in the affected set, and (3) its rule
+kind, per the caller-provided `bazel query --output label_kind` result, is the
+generated wrapper kind (`donner_multi_transitioned_test`). The kind gate keeps
+handwritten targets that merely share the naming convention (e.g. a
+`cc_library` named `renderer_geode` beside `renderer`) out of the trim. A
+label missing from the kind file, an unreadable kind file, or any error in
+this tool must be treated as "keep the target" / "keep the full set" (fail
+closed toward more coverage).
 
 Reads one label per line, writes the trimmed set (one per line) to stdout and
 a summary line to stderr.
@@ -38,10 +42,34 @@ import sys
 # from being misread as a `_full` variant of `..._text`.
 VARIANT_SUFFIXES = ("_text_full", "_tiny", "_geode")
 
+# The rule kind donner_cc_test's `variants` attr generates for each
+# `{name}_{variant}` wrapper (build_defs/rules.bzl). Only this kind is ever
+# trimmed.
+WRAPPER_KIND = "donner_multi_transitioned_test"
 
-def trim_variants(labels):
-    """Return (kept, dropped) lists. See module docstring for the policy."""
+
+def parse_label_kinds(label_kind_text):
+    """Parse `bazel query --output label_kind` text into {label: kind}.
+
+    Lines look like `donner_multi_transitioned_test rule //pkg:name`. Lines
+    that do not match are skipped (fail-safe: unknown labels are not trimmed).
+    """
+    kinds = {}
+    for line in label_kind_text.splitlines():
+        parts = line.strip().split(" ")
+        if len(parts) >= 3 and parts[-2] == "rule":
+            kinds[parts[-1]] = " ".join(parts[:-2])
+    return kinds
+
+
+def trim_variants(labels, label_kinds=None):
+    """Return (kept, dropped) lists. See module docstring for the policy.
+
+    label_kinds: {label: kind} from parse_label_kinds, or None. When None or
+    when a label is missing from it, that label is NEVER trimmed (fail-safe).
+    """
     label_set = set(labels)
+    kinds = label_kinds or {}
     kept = []
     dropped = []
     for label in labels:
@@ -52,7 +80,11 @@ def trim_variants(labels):
                 # Only a real target name qualifies (guard against a label
                 # that IS the suffix, e.g. "//pkg:_geode").
                 base_name = base.rsplit(":", 1)[-1]
-                if base_name and base in label_set:
+                if (
+                    base_name
+                    and base in label_set
+                    and kinds.get(label) == WRAPPER_KIND
+                ):
                     drop = True
                 break
         (dropped if drop else kept).append(label)
@@ -70,6 +102,12 @@ def main(argv=None):
         "--dropped-out",
         help="Optional file to record the dropped variant labels.",
     )
+    parser.add_argument(
+        "--label-kind-file",
+        help="`bazel query --output label_kind` result for the affected set. "
+        "REQUIRED for any trimming to happen: labels without a known "
+        "wrapper kind are never dropped (fail-safe).",
+    )
     args = parser.parse_args(argv)
 
     labels = [
@@ -77,7 +115,20 @@ def main(argv=None):
         for line in Path(args.affected_file).read_text(encoding="utf-8").splitlines()
         if line.strip()
     ]
-    kept, dropped = trim_variants(labels)
+
+    label_kinds = None
+    if args.label_kind_file:
+        try:
+            label_kinds = parse_label_kinds(
+                Path(args.label_kind_file).read_text(encoding="utf-8")
+            )
+        except OSError as error:
+            sys.stderr.write(
+                f"variant trim: kind file unreadable ({error}); trimming nothing\n"
+            )
+            label_kinds = None
+
+    kept, dropped = trim_variants(labels, label_kinds)
 
     if args.dropped_out:
         Path(args.dropped_out).write_text(

--- a/tools/coverage_variant_trim_tests.py
+++ b/tools/coverage_variant_trim_tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tests for coverage_variant_trim.trim_variants."""
+"""Tests for coverage_variant_trim."""
 
 from pathlib import Path
 import sys
@@ -7,25 +7,63 @@ import unittest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from coverage_variant_trim import trim_variants
+from coverage_variant_trim import WRAPPER_KIND, parse_label_kinds, trim_variants
+
+
+def kinds_for(wrappers=(), others=()):
+    """Build a label->kind map: wrappers get WRAPPER_KIND, others cc_library."""
+    result = {label: WRAPPER_KIND for label in wrappers}
+    result.update({label: "cc_library" for label in others})
+    return result
 
 
 class TrimVariantsTest(unittest.TestCase):
-    def test_variant_with_base_sibling_is_dropped(self):
+    def test_wrapper_with_base_sibling_is_dropped(self):
         labels = [
             "//donner/svg/compositor:compositor_tests",
             "//donner/svg/compositor:compositor_tests_geode",
             "//donner/svg/compositor:compositor_tests_text_full",
             "//donner/svg/compositor:compositor_tests_tiny",
         ]
-        kept, dropped = trim_variants(labels)
+        kinds = kinds_for(wrappers=labels[1:], others=labels[:1])
+        kept, dropped = trim_variants(labels, kinds)
         self.assertEqual(kept, ["//donner/svg/compositor:compositor_tests"])
         self.assertEqual(len(dropped), 3)
 
-    def test_variant_without_base_sibling_is_kept(self):
-        # Fail-safe: a variant-only entry keeps its coverage representative.
+    def test_handwritten_geode_library_is_kept(self):
+        # The review scenario: renderer_geode is a real cc_library beside
+        # renderer. The kind gate must keep it despite the suffix+sibling.
+        labels = [
+            "//donner/svg/renderer:renderer",
+            "//donner/svg/renderer:renderer_geode",
+        ]
+        kinds = kinds_for(others=labels)
+        kept, dropped = trim_variants(labels, kinds)
+        self.assertEqual(kept, labels)
+        self.assertEqual(dropped, [])
+
+    def test_unknown_kind_is_never_trimmed(self):
+        # Fail-safe: a label absent from the kind map keeps its target.
+        labels = [
+            "//donner/a:foo_tests",
+            "//donner/a:foo_tests_geode",
+        ]
+        kept, dropped = trim_variants(labels, kinds_for())  # empty map
+        self.assertEqual(kept, labels)
+        self.assertEqual(dropped, [])
+
+    def test_no_kind_map_trims_nothing(self):
+        labels = [
+            "//donner/a:foo_tests",
+            "//donner/a:foo_tests_geode",
+        ]
+        kept, dropped = trim_variants(labels, None)
+        self.assertEqual(kept, labels)
+        self.assertEqual(dropped, [])
+
+    def test_wrapper_without_base_sibling_is_kept(self):
         labels = ["//donner/svg/renderer/tests:resvg_test_suite_geode"]
-        kept, dropped = trim_variants(labels)
+        kept, dropped = trim_variants(labels, kinds_for(wrappers=labels))
         self.assertEqual(kept, labels)
         self.assertEqual(dropped, [])
 
@@ -34,71 +72,66 @@ class TrimVariantsTest(unittest.TestCase):
             "//donner/editor:editor_shell",
             "//donner/base:base_tests",
             "//donner/base:base_tests_lint",
-            "//donner/editor/tests:lock_state_tests",
         ]
-        kept, dropped = trim_variants(labels)
+        kept, dropped = trim_variants(labels, kinds_for(others=labels))
         self.assertEqual(kept, labels)
         self.assertEqual(dropped, [])
 
-    def test_text_full_not_misread_as_tiny_or_geode(self):
-        # _text_full must be recognized as one suffix; base is the stripped name.
+    def test_text_full_recognized_as_one_suffix(self):
         labels = [
             "//donner/svg/components/paint:paint_component_tests",
             "//donner/svg/components/paint:paint_component_tests_text_full",
         ]
-        kept, dropped = trim_variants(labels)
+        kinds = kinds_for(wrappers=labels[1:], others=labels[:1])
+        kept, dropped = trim_variants(labels, kinds)
         self.assertEqual(
             kept, ["//donner/svg/components/paint:paint_component_tests"]
         )
         self.assertEqual(
-            dropped, ["//donner/svg/components/paint:paint_component_tests_text_full"]
+            dropped,
+            ["//donner/svg/components/paint:paint_component_tests_text_full"],
         )
 
     def test_suffix_only_name_is_kept(self):
-        # A label whose name IS the suffix has no valid base; keep it.
         labels = ["//pkg:_geode", "//pkg:_tiny"]
-        kept, dropped = trim_variants(labels)
+        kept, dropped = trim_variants(labels, kinds_for(wrappers=labels))
         self.assertEqual(kept, labels)
         self.assertEqual(dropped, [])
 
     def test_base_in_other_package_does_not_count(self):
-        # The sibling must be the same package-qualified label.
         labels = [
             "//donner/a:foo_tests",
             "//donner/b:foo_tests_geode",
         ]
-        kept, dropped = trim_variants(labels)
+        kinds = kinds_for(wrappers=["//donner/b:foo_tests_geode"],
+                          others=["//donner/a:foo_tests"])
+        kept, dropped = trim_variants(labels, kinds)
         self.assertEqual(kept, labels)
         self.assertEqual(dropped, [])
 
-    def test_mixed_realistic_set(self):
-        labels = [
-            "//donner/svg/compositor:layer_resolver_tests_text_full",
-            "//donner/svg/compositor:layer_resolver_tests",
-            "//donner/svg/components/shadow:shadow_tree_system_tests_text_full",
-            "//donner/editor:select_tool",
-            "//donner/svg/renderer/tests:renderer_driver_tests_geode",
-            "//donner/svg/renderer/tests:renderer_driver_tests",
-        ]
-        kept, dropped = trim_variants(labels)
-        self.assertIn("//donner/svg/compositor:layer_resolver_tests", kept)
-        self.assertIn(
-            "//donner/svg/components/shadow:shadow_tree_system_tests_text_full", kept
-        )  # variant-only: kept
-        self.assertIn("//donner/editor:select_tool", kept)
-        self.assertIn("//donner/svg/renderer/tests:renderer_driver_tests", kept)
-        self.assertEqual(
-            sorted(dropped),
-            [
-                "//donner/svg/compositor:layer_resolver_tests_text_full",
-                "//donner/svg/renderer/tests:renderer_driver_tests_geode",
-            ],
-        )
-
     def test_order_preserved(self):
         labels = ["//a:t2", "//a:t1", "//a:t3"]
-        kept, _ = trim_variants(labels)
+        kept, _ = trim_variants(labels, kinds_for(others=labels))
         self.assertEqual(kept, labels)
+
+
+class ParseLabelKindsTest(unittest.TestCase):
+    def test_parses_label_kind_lines(self):
+        text = (
+            "cc_test rule //donner/svg/compositor:compositor_tests\n"
+            "donner_multi_transitioned_test rule //donner/svg/compositor:compositor_tests_geode\n"
+            "cc_library rule //donner/svg/renderer:renderer_geode\n"
+        )
+        kinds = parse_label_kinds(text)
+        self.assertEqual(kinds["//donner/svg/compositor:compositor_tests"], "cc_test")
+        self.assertEqual(
+            kinds["//donner/svg/compositor:compositor_tests_geode"], WRAPPER_KIND
+        )
+        self.assertEqual(kinds["//donner/svg/renderer:renderer_geode"], "cc_library")
+
+    def test_malformed_lines_skipped(self):
+        kinds = parse_label_kinds("garbage\n\nrule\n//lonely:label\n")
+        self.assertEqual(kinds, {})
 
 
 if __name__ == "__main__":

--- a/tools/coverage_variant_trim_tests.py
+++ b/tools/coverage_variant_trim_tests.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Tests for coverage_variant_trim.trim_variants."""
+
+from pathlib import Path
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from coverage_variant_trim import trim_variants
+
+
+class TrimVariantsTest(unittest.TestCase):
+    def test_variant_with_base_sibling_is_dropped(self):
+        labels = [
+            "//donner/svg/compositor:compositor_tests",
+            "//donner/svg/compositor:compositor_tests_geode",
+            "//donner/svg/compositor:compositor_tests_text_full",
+            "//donner/svg/compositor:compositor_tests_tiny",
+        ]
+        kept, dropped = trim_variants(labels)
+        self.assertEqual(kept, ["//donner/svg/compositor:compositor_tests"])
+        self.assertEqual(len(dropped), 3)
+
+    def test_variant_without_base_sibling_is_kept(self):
+        # Fail-safe: a variant-only entry keeps its coverage representative.
+        labels = ["//donner/svg/renderer/tests:resvg_test_suite_geode"]
+        kept, dropped = trim_variants(labels)
+        self.assertEqual(kept, labels)
+        self.assertEqual(dropped, [])
+
+    def test_non_variant_labels_untouched(self):
+        labels = [
+            "//donner/editor:editor_shell",
+            "//donner/base:base_tests",
+            "//donner/base:base_tests_lint",
+            "//donner/editor/tests:lock_state_tests",
+        ]
+        kept, dropped = trim_variants(labels)
+        self.assertEqual(kept, labels)
+        self.assertEqual(dropped, [])
+
+    def test_text_full_not_misread_as_tiny_or_geode(self):
+        # _text_full must be recognized as one suffix; base is the stripped name.
+        labels = [
+            "//donner/svg/components/paint:paint_component_tests",
+            "//donner/svg/components/paint:paint_component_tests_text_full",
+        ]
+        kept, dropped = trim_variants(labels)
+        self.assertEqual(
+            kept, ["//donner/svg/components/paint:paint_component_tests"]
+        )
+        self.assertEqual(
+            dropped, ["//donner/svg/components/paint:paint_component_tests_text_full"]
+        )
+
+    def test_suffix_only_name_is_kept(self):
+        # A label whose name IS the suffix has no valid base; keep it.
+        labels = ["//pkg:_geode", "//pkg:_tiny"]
+        kept, dropped = trim_variants(labels)
+        self.assertEqual(kept, labels)
+        self.assertEqual(dropped, [])
+
+    def test_base_in_other_package_does_not_count(self):
+        # The sibling must be the same package-qualified label.
+        labels = [
+            "//donner/a:foo_tests",
+            "//donner/b:foo_tests_geode",
+        ]
+        kept, dropped = trim_variants(labels)
+        self.assertEqual(kept, labels)
+        self.assertEqual(dropped, [])
+
+    def test_mixed_realistic_set(self):
+        labels = [
+            "//donner/svg/compositor:layer_resolver_tests_text_full",
+            "//donner/svg/compositor:layer_resolver_tests",
+            "//donner/svg/components/shadow:shadow_tree_system_tests_text_full",
+            "//donner/editor:select_tool",
+            "//donner/svg/renderer/tests:renderer_driver_tests_geode",
+            "//donner/svg/renderer/tests:renderer_driver_tests",
+        ]
+        kept, dropped = trim_variants(labels)
+        self.assertIn("//donner/svg/compositor:layer_resolver_tests", kept)
+        self.assertIn(
+            "//donner/svg/components/shadow:shadow_tree_system_tests_text_full", kept
+        )  # variant-only: kept
+        self.assertIn("//donner/editor:select_tool", kept)
+        self.assertIn("//donner/svg/renderer/tests:renderer_driver_tests", kept)
+        self.assertEqual(
+            sorted(dropped),
+            [
+                "//donner/svg/compositor:layer_resolver_tests_text_full",
+                "//donner/svg/renderer/tests:renderer_driver_tests_geode",
+            ],
+        )
+
+    def test_order_preserved(self):
+        labels = ["//a:t2", "//a:t1", "//a:t3"]
+        kept, _ = trim_variants(labels)
+        self.assertEqual(kept, labels)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements the operator-approved coverage-lane levers from the
`docs/design_docs/0029-2` audit, and corrects that audit with better data.

### Lever 2 (this PR's code change): representative-variant PR patch coverage

PR PATCH coverage now trims `donner_variant_cc_test` wrapper targets
(`_tiny` / `_text_full` / `_geode`, per `build_defs/rules.bzl
_VARIANT_SPECS`) from the bazel-diff affected set when their **base sibling is
present** - the base/default target is the representative. The full
multi-variant matrix stays on the main-push coverage baseline.

**Coverage-semantics change, stated plainly:** patch coverage on PRs reflects
the default variant only; backend/feature-gated lines and cross-variant
regressions surface on main-push. CI's own test lanes are untouched - this
trims only the coverage lane's instrumented re-run of the same tests.

Why the base variant is the representative: it is the default build graph that
`bazel test` and the CI lanes exercise, it already accounts for 206 of 296
coverage test executions on the exemplar run, and the variant wrappers compile
the SAME sources under different feature flags - for changed-line patch
coverage they are redundant parameterizations.

Fail-safe: variant-only targets (no base sibling in the set) are never
dropped; tool failure keeps the untrimmed set; the instrumentability
classifier still sees the full set. Logic in `tools/coverage_variant_trim.py`
with unit tests (`//tools:coverage_variant_trim_tests`, 8 cases, PASSED, plus
a live run against the #829 exemplar's real affected list).

**Measured on the #829 exemplar set:** 376 -> 277 targets (99 wrappers
dropped: 38 `_geode`, 31 `_text_full`, 30 `_tiny`), accounting for 90 of 296
test executions and the transitioned compile closures behind the measured ~7x
per-element instrumented compile multiplier.

### Lever 1 (verified already live) + audit correction

The main-push coverage baseline already routes to the self-hosted RE lane
(same job/executor/flags as PR coverage) via the runner-routing change (#818):
measured 5-11 min per main push vs the ~70 min hosted before-state, with
main-to-main runs ~97% remote-cache hits and the Codecov baseline
artifact/upload path unchanged. No code change needed; this PR records the
as-built in `0029-2`.

It also **corrects the audit's cold-cache claim**: `cachedRemotely=4` was a
BEP artifact (`action` events exist only for failed actions). The
authoritative `runnerCount` metrics show the #829 run had **3107 remote cache
hits vs 1519 remote executions**; its 54 minutes were **4511 cpu-min of
remote-execution queuing vs 158 cpu-min of execution** on the genuine
cache-miss recompiles at CI's floor scheduler priority in a contended window -
demand x contention, not cache coldness. That makes miss-set reduction (this
PR, plus the merged #836 merge-ref hashing fix) the correct attack, and it is
why this trim targets exactly the miss set.

### Measurement plan

This PR's own coverage run takes the smoke path (tooling-only change), and
pull_request events run the base-branch workflow, so before/after
cache-hit/wall numbers ride the next organic C/C++ PR post-merge; the #829
exemplar (54 min, 1519 misses) is the before-state.

## Constraints honored

Operator explicitly approved the coverage-scope change and it is stated
plainly above. No CI test lanes touched; classifier/skip logic unchanged;
fail-closed throughout; main-push full coverage unchanged.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
