### PR TITLE
refactor(base): delete dead PointKey::operator<

### DIFF
--- a/donner/base/PathOps.cc
+++ b/donner/base/PathOps.cc
@@ -68,12 +68,6 @@ struct PointKey {
   std::int64_t y = 0;
 
   bool operator==(const PointKey& other) const = default;
-  bool operator<(const PointKey& other) const {
-    if (x != other.x) {
-      return x < other.x;
-    }
-    return y < other.y;
-  }
 };
 
 struct TraceEdge {


### PR DESCRIPTION
## Summary

Deletes the dead `PointKey::operator<` from `donner/base/PathOps.cc` (6 lines). Found during the coverage campaign (gap analysis for #844); per campaign rules, genuinely dead code is deleted in a separate argued PR rather than covered with tests.

## Why it is dead

- No `std::map`/`std::set` (or any ordered container) is keyed on `PointKey`.
- Every `std::sort` in the file sorts doubles or uses an explicit lambda comparator.
- Key equality uses the defaulted `operator==`, which stays.

## Why it is safe

- The recompiled object file is byte-identical: the unused inline member was never emitted, so the link and test actions cache-hit unchanged. Provably behavior-neutral.
- `//donner/base:base_tests` passes.

## Coverage effect

Removes 6 permanently-uncovered lines from the measurement (lines 71-76 were miss in the main baseline).

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
