### PR TITLE
test(svg): cover SVGDocument edit projection and AnimationSystem edge branches

### DIFF
--- a/donner/svg/parser/tests/AnimateElement_tests.cc
+++ b/donner/svg/parser/tests/AnimateElement_tests.cc
@@ -833,6 +833,252 @@ TEST(SVGAnimateElement, NumberListInterpolation) {
   EXPECT_NEAR(c, 45.0, 1.0);
 }
 
+TEST(SVGAnimateElement, WhitespaceAroundNumbersIsTrimmed) {
+  // Numeric interpolation must tolerate surrounding whitespace in from/to values.
+  auto document = parseSVGWithExperimental(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <rect id="r" width="100" height="100">
+        <animate attributeName="width" from=" 100 " to=" 200 " begin="0s" dur="2s" />
+      </rect>
+    </svg>
+  )");
+
+  auto val = getAnimatedValue(document, "#r", "width", 1.0);
+  ASSERT_TRUE(val.has_value());
+  EXPECT_NEAR(std::stod(val.value()), 150.0, 0.01);
+}
+
+TEST(SVGAnimateElement, RestartAlwaysAllowsRerunWhenTimeMovesBackward) {
+  // Baseline for the restart="never" test below: with the default restart behavior, sampling an
+  // earlier time after the animation has completed reactivates it.
+  auto document = parseSVGWithExperimental(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <rect id="r" width="100" height="100">
+        <animate attributeName="width" from="0" to="100" begin="0s" dur="1s" />
+      </rect>
+    </svg>
+  )");
+
+  auto valActive = getAnimatedValue(document, "#r", "width", 0.5);
+  ASSERT_TRUE(valActive.has_value());
+  EXPECT_NEAR(std::stod(valActive.value()), 50.0, 0.01);
+
+  // Past the active duration with fill="remove": no override.
+  EXPECT_FALSE(getAnimatedValue(document, "#r", "width", 2.0).has_value());
+
+  // Sampling backwards restarts the animation.
+  auto valAgain = getAnimatedValue(document, "#r", "width", 0.5);
+  ASSERT_TRUE(valAgain.has_value());
+  EXPECT_NEAR(std::stod(valAgain.value()), 50.0, 0.01);
+}
+
+TEST(SVGAnimateElement, RestartNeverPreventsRerunWhenTimeMovesBackward) {
+  // restart="never": once the animation has completed, sampling an earlier time must not
+  // reactivate it.
+  auto document = parseSVGWithExperimental(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <rect id="r" width="100" height="100">
+        <animate attributeName="width" from="0" to="100" begin="0s" dur="1s" restart="never" />
+      </rect>
+    </svg>
+  )");
+
+  auto valActive = getAnimatedValue(document, "#r", "width", 0.5);
+  ASSERT_TRUE(valActive.has_value());
+  EXPECT_NEAR(std::stod(valActive.value()), 50.0, 0.01);
+
+  // Completes; fill="remove" clears the override.
+  EXPECT_FALSE(getAnimatedValue(document, "#r", "width", 2.0).has_value());
+
+  // Unlike the default restart behavior, sampling backwards stays inactive.
+  EXPECT_FALSE(getAnimatedValue(document, "#r", "width", 0.5).has_value());
+}
+
+TEST(SVGAnimateElement, PathQuadCurveCloseInterpolation) {
+  // Structurally compatible paths with Q, C, and Z verbs interpolate pointwise.
+  auto document = parseSVGWithExperimental(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <path id="p" d="M0,0 L10,0 Q20,0 30,0 C40,0 50,0 60,0 Z">
+        <animate attributeName="d"
+                 from="M0,0 L10,0 Q20,0 30,0 C40,0 50,0 60,0 Z"
+                 to="M10,10 L20,10 Q30,10 40,10 C50,10 60,10 70,10 Z"
+                 begin="0s" dur="2s" />
+      </path>
+    </svg>
+  )");
+
+  auto val = getAnimatedValue(document, "#p", "d", 1.0);
+  ASSERT_TRUE(val.has_value());
+  EXPECT_EQ(val.value(), "M5,5 L15,5 Q25,5 35,5 C45,5 55,5 65,5 Z");
+}
+
+TEST(SVGAnimateElement, PathVerbMismatchFallsBackToDiscrete) {
+  // Same command count but different verbs (L vs Q): not interpolable, so discrete fallback.
+  auto document = parseSVGWithExperimental(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <path id="p" d="M0,0 L10,10">
+        <animate attributeName="d" from="M0,0 L10,10" to="M0,0 Q5,5 10,10"
+                 begin="0s" dur="2s" />
+      </path>
+    </svg>
+  )");
+
+  auto val05 = getAnimatedValue(document, "#p", "d", 0.5);
+  ASSERT_TRUE(val05.has_value());
+  EXPECT_EQ(val05.value(), "M0,0 L10,10");
+
+  auto val15 = getAnimatedValue(document, "#p", "d", 1.5);
+  ASSERT_TRUE(val15.has_value());
+  EXPECT_EQ(val15.value(), "M0,0 Q5,5 10,10");
+}
+
+TEST(SVGAnimateElement, NonInterpolableValuesFallBackToDiscrete) {
+  // Values that parse as neither numbers, paths, nor number lists snap at the midpoint.
+  auto document = parseSVGWithExperimental(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <rect id="r" fill="red" width="100" height="100">
+        <animate attributeName="fill" from="red" to="blue" begin="0s" dur="2s" />
+      </rect>
+    </svg>
+  )");
+
+  auto val05 = getAnimatedValue(document, "#r", "fill", 0.5);
+  ASSERT_TRUE(val05.has_value());
+  EXPECT_EQ(val05.value(), "red");
+
+  auto val15 = getAnimatedValue(document, "#r", "fill", 1.5);
+  ASSERT_TRUE(val15.has_value());
+  EXPECT_EQ(val15.value(), "blue");
+}
+
+TEST(SVGAnimateElement, HexColorValuesFallBackToDiscrete) {
+  // Hex colors fail numeric, path, and number-list interpolation, so they snap at the midpoint.
+  auto document = parseSVGWithExperimental(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <rect id="r" fill="#000000" width="100" height="100">
+        <animate attributeName="fill" from="#ff0000" to="#0000ff" begin="0s" dur="2s" />
+      </rect>
+    </svg>
+  )");
+
+  auto val05 = getAnimatedValue(document, "#r", "fill", 0.5);
+  ASSERT_TRUE(val05.has_value());
+  EXPECT_EQ(val05.value(), "#ff0000");
+
+  auto val15 = getAnimatedValue(document, "#r", "fill", 1.5);
+  ASSERT_TRUE(val15.has_value());
+  EXPECT_EQ(val15.value(), "#0000ff");
+}
+
+TEST(SVGAnimateElement, ToOnlyAnimationAppliesToValue) {
+  // A to-only animation applies "to" as a discrete value while active.
+  auto document = parseSVGWithExperimental(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <rect id="r" width="100" height="100">
+        <animate attributeName="width" to="200" begin="0s" dur="2s" />
+      </rect>
+    </svg>
+  )");
+
+  auto val = getAnimatedValue(document, "#r", "width", 1.0);
+  ASSERT_TRUE(val.has_value());
+  EXPECT_EQ(val.value(), "200");
+
+  // After the active interval with fill="remove": no override.
+  EXPECT_FALSE(getAnimatedValue(document, "#r", "width", 3.0).has_value());
+}
+
+TEST(SVGAnimateElement, FromByNonNumericFallsBackToFromValue) {
+  // from/by requires numeric addition; non-numeric values fall back to the from value.
+  auto document = parseSVGWithExperimental(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <rect id="r" fill="green" width="100" height="100">
+        <animate attributeName="fill" from="red" by="blue" begin="0s" dur="2s" />
+      </rect>
+    </svg>
+  )");
+
+  auto val = getAnimatedValue(document, "#r", "fill", 1.0);
+  ASSERT_TRUE(val.has_value());
+  EXPECT_EQ(val.value(), "red");
+}
+
+TEST(SVGAnimateElement, SingleValuesEntryAppliesConstantValue) {
+  // A one-entry values list applies that value for the whole active interval.
+  auto document = parseSVGWithExperimental(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <rect id="r" width="100" height="100">
+        <animate attributeName="width" values="42" begin="0s" dur="2s" />
+      </rect>
+    </svg>
+  )");
+
+  auto val = getAnimatedValue(document, "#r", "width", 1.0);
+  ASSERT_TRUE(val.has_value());
+  EXPECT_EQ(val.value(), "42");
+}
+
+TEST(SVGAnimateElement, NoValueSpecificationProducesNoOverride) {
+  // <animate> without values/from/to/by has nothing to apply.
+  auto document = parseSVGWithExperimental(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <rect id="r" width="100" height="100">
+        <animate attributeName="width" begin="0s" dur="2s" />
+      </rect>
+    </svg>
+  )");
+
+  EXPECT_FALSE(getAnimatedValue(document, "#r", "width", 1.0).has_value());
+}
+
+TEST(SVGAnimateElement, DiscreteAtActiveEndClampsToLastValue) {
+  // Frozen at 100% progress, the discrete index (numValues) clamps to the last value.
+  auto document = parseSVGWithExperimental(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <rect id="r" width="100" height="100">
+        <animate attributeName="width" values="10;20" calcMode="discrete" begin="0s" dur="2s"
+                 fill="freeze" />
+      </rect>
+    </svg>
+  )");
+
+  auto val = getAnimatedValue(document, "#r", "width", 3.0);
+  ASSERT_TRUE(val.has_value());
+  EXPECT_EQ(val.value(), "20");
+}
+
+TEST(SVGAnimateElement, MissingAttributeNameProducesNoOverride) {
+  // <animate> without attributeName cannot target an attribute.
+  auto document = parseSVGWithExperimental(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <rect id="r" width="100" height="100">
+        <animate from="0" to="100" begin="0s" dur="2s" />
+      </rect>
+    </svg>
+  )");
+
+  auto& registry = document.registry();
+  components::AnimationSystem().advance(registry, 1.0, nullptr);
+
+  auto rect = document.querySelector("#r");
+  ASSERT_TRUE(rect.has_value());
+  EXPECT_EQ(registry.try_get<components::AnimatedValuesComponent>(rect->entityHandle().entity()),
+            nullptr);
+}
+
+TEST(SVGAnimateElement, HrefToMissingIdProducesNoOverride) {
+  // An href that resolves to no element leaves the sibling untouched and does not crash.
+  auto document = parseSVGWithExperimental(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <rect id="r" width="100" height="100" />
+      <animate xlink:href="#missing" attributeName="width" from="0" to="100"
+               begin="0s" dur="2s" />
+    </svg>
+  )");
+
+  EXPECT_FALSE(getAnimatedValue(document, "#r", "width", 1.0).has_value());
+}
+
 TEST(SVGAnimateElement, NumberListValuesInterpolation) {
   auto document = parseSVGWithExperimental(R"(
     <svg xmlns="http://www.w3.org/2000/svg">

--- a/donner/svg/parser/tests/AnimateTransformElement_tests.cc
+++ b/donner/svg/parser/tests/AnimateTransformElement_tests.cc
@@ -285,4 +285,100 @@ TEST(SVGAnimateTransformElement, ValuesListInterpolation) {
   EXPECT_EQ(val3.value(), "rotate(45)");
 }
 
+TEST(SVGAnimateTransformElement, SkewYInterpolation) {
+  auto document = parseSVGWithExperimental(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <rect id="r" width="100" height="100">
+        <animateTransform attributeName="transform" type="skewY"
+                          from="0" to="40" begin="0s" dur="2s" />
+      </rect>
+    </svg>
+  )");
+
+  auto val = getAnimatedTransform(document, "#r", 1.0);
+  ASSERT_TRUE(val.has_value());
+  EXPECT_EQ(val.value(), "skewY(20)");
+}
+
+TEST(SVGAnimateTransformElement, SkewXByOnlyStartsFromIdentity) {
+  // A by-only skew animates from the neutral skewX(0) to skewX(by).
+  auto document = parseSVGWithExperimental(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <rect id="r" width="100" height="100">
+        <animateTransform attributeName="transform" type="skewX"
+                          by="30" begin="0s" dur="2s" />
+      </rect>
+    </svg>
+  )");
+
+  auto val = getAnimatedTransform(document, "#r", 1.0);
+  ASSERT_TRUE(val.has_value());
+  EXPECT_EQ(val.value(), "skewX(15)");
+}
+
+TEST(SVGAnimateTransformElement, ToOnlyTranslateAppliesConstant) {
+  // A to-only animateTransform has a single keyframe applied for the whole active interval.
+  auto document = parseSVGWithExperimental(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <rect id="r" width="100" height="100">
+        <animateTransform attributeName="transform" type="translate"
+                          to="100 50" begin="0s" dur="2s" />
+      </rect>
+    </svg>
+  )");
+
+  auto val05 = getAnimatedTransform(document, "#r", 0.5);
+  ASSERT_TRUE(val05.has_value());
+  EXPECT_EQ(val05.value(), "translate(100, 50)");
+
+  auto val15 = getAnimatedTransform(document, "#r", 1.5);
+  ASSERT_TRUE(val15.has_value());
+  EXPECT_EQ(val15.value(), "translate(100, 50)");
+}
+
+TEST(SVGAnimateTransformElement, MissingValueSpecProducesNoOverride) {
+  // <animateTransform> without values/from/to/by has nothing to apply.
+  auto document = parseSVGWithExperimental(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <rect id="r" width="100" height="100">
+        <animateTransform attributeName="transform" type="scale" begin="0s" dur="2s" />
+      </rect>
+    </svg>
+  )");
+
+  EXPECT_FALSE(getAnimatedTransform(document, "#r", 1.0).has_value());
+}
+
+TEST(SVGAnimateTransformElement, SingleNumberTranslatePadsTyToZero) {
+  // translate with one number pads ty to 0, which is omitted from the formatted result.
+  auto document = parseSVGWithExperimental(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <rect id="r" width="100" height="100">
+        <animateTransform attributeName="transform" type="translate"
+                          from="0" to="100" begin="0s" dur="2s" />
+      </rect>
+    </svg>
+  )");
+
+  auto val = getAnimatedTransform(document, "#r", 1.0);
+  ASSERT_TRUE(val.has_value());
+  EXPECT_EQ(val.value(), "translate(50)");
+}
+
+TEST(SVGAnimateTransformElement, TwoNumberRotatePadsCenterY) {
+  // rotate with two numbers pads cy to 0; a nonzero cx keeps the center in the output.
+  auto document = parseSVGWithExperimental(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <rect id="r" width="100" height="100">
+        <animateTransform attributeName="transform" type="rotate"
+                          from="0 25" to="90 25" begin="0s" dur="2s" />
+      </rect>
+    </svg>
+  )");
+
+  auto val = getAnimatedTransform(document, "#r", 1.0);
+  ASSERT_TRUE(val.has_value());
+  EXPECT_EQ(val.value(), "rotate(45, 25, 0)");
+}
+
 }  // namespace donner::svg

--- a/donner/svg/parser/tests/SetElement_tests.cc
+++ b/donner/svg/parser/tests/SetElement_tests.cc
@@ -197,4 +197,24 @@ TEST(SVGSetElement, DocumentSetTime) {
   EXPECT_DOUBLE_EQ(document.currentTime(), 1.5);
 }
 
+TEST(SVGSetElement, MissingAttributeNameProducesNoOverride) {
+  // <set> without attributeName cannot target an attribute, so no override is produced even
+  // while the animation is active.
+  auto document = parseSVGWithExperimental(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <rect id="r" fill="red" width="100" height="100">
+        <set to="blue" begin="0s" dur="2s" />
+      </rect>
+    </svg>
+  )");
+
+  auto& registry = document.registry();
+  components::AnimationSystem().advance(registry, 1.0, nullptr);
+
+  auto rect = document.querySelector("#r");
+  ASSERT_TRUE(rect.has_value());
+  EXPECT_EQ(registry.try_get<components::AnimatedValuesComponent>(rect->entityHandle().entity()),
+            nullptr);
+}
+
 }  // namespace donner::svg

--- a/donner/svg/tests/SVGDocument_tests.cc
+++ b/donner/svg/tests/SVGDocument_tests.cc
@@ -94,6 +94,49 @@ TEST(SVGDocument, SetCanvasSizeNoOpDoesNotInvalidateBuiltRenderTree) {
   EXPECT_EQ(document.canvasSize(), Vector2i(100, 201));
 }
 
+TEST(SVGDocument, SetTimeNoOpDoesNotInvalidateBuiltRenderTree) {
+  SVGDocument document;
+  document.setTime(5.0);
+  EXPECT_EQ(document.currentTime(), 5.0);
+
+  auto& renderState = EnsureRenderTreeState(document.registry());
+  renderState.hasBeenBuilt = true;
+  renderState.needsFullRebuild = false;
+  renderState.needsFullStyleRecompute = false;
+  document.registry().clear<components::DirtyFlagsComponent>();
+
+  document.setTime(5.0);
+
+  EXPECT_FALSE(document.hasPendingRenderInvalidation());
+  EXPECT_EQ(document.currentTime(), 5.0);
+
+  document.setTime(6.0);
+
+  EXPECT_TRUE(document.hasPendingRenderInvalidation());
+  EXPECT_EQ(document.currentTime(), 6.0);
+}
+
+TEST(SVGDocument, UserLanguagesRoundTripAndNoOpSkipsInvalidation) {
+  SVGDocument document;
+  EXPECT_THAT(document.userLanguages(), testing::ElementsAre(RcString("en")));
+
+  auto& renderState = EnsureRenderTreeState(document.registry());
+  renderState.hasBeenBuilt = true;
+  renderState.needsFullRebuild = false;
+  renderState.needsFullStyleRecompute = false;
+  document.registry().clear<components::DirtyFlagsComponent>();
+
+  document.setUserLanguages({RcString("en")});
+
+  EXPECT_FALSE(document.hasPendingRenderInvalidation());
+  EXPECT_THAT(document.userLanguages(), testing::ElementsAre(RcString("en")));
+
+  document.setUserLanguages({RcString("de"), RcString("en")});
+
+  EXPECT_TRUE(document.hasPendingRenderInvalidation());
+  EXPECT_THAT(document.userLanguages(), testing::ElementsAre(RcString("de"), RcString("en")));
+}
+
 TEST(SVGDocument, CanvasSizeFromFile) {
   {
     auto document = ParseSVG(R"(
@@ -692,6 +735,239 @@ TEST(SVGDocument, SourceLessSetElementTextContentReturnsUnappliedResult) {
   EXPECT_FALSE(result.applied);
   EXPECT_EQ(result.scope, xml::ReparseScope::TextNode);
   EXPECT_THAT(result.diagnostic, Eq(std::nullopt));
+}
+
+TEST(SVGDocument, SetElementTextContentOnNonTextElementReportsDiagnostic) {
+  auto document =
+      ParseSVG(R"(<svg xmlns="http://www.w3.org/2000/svg"><custom id="c">old</custom></svg>)");
+  SVGElement custom = document.querySelector("#c").value();
+
+  xml::ApplySourceEditResult result = document.setElementTextContent(custom, "new");
+
+  ASSERT_TRUE(result.diagnostic.has_value());
+  EXPECT_THAT(result.diagnostic->reason, testing::HasSubstr("not SVG text or style content"));
+  EXPECT_THAT(document.source(), testing::HasSubstr(">new</custom>"));
+}
+
+TEST(SVGDocument, MixedContentTextNodeEditReprojectsTextChunks) {
+  // Editing a text node inside an element with mixed content (text plus child elements) reprojects
+  // the parent element's text, preserving chunk boundaries around the child element.
+  auto document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <text id="m">one<tspan id="s">two</tspan>three</text>
+    </svg>
+  )");
+  SVGElement text = document.querySelector("#m").value();
+  const std::size_t valueOffset = document.source().find("one");
+  ASSERT_NE(valueOffset, std::string_view::npos);
+
+  xml::ApplySourceEditResult result = document.applySourceEdit(xml::XMLEditIntent{
+      .range = SourceRange{FileOffset::Offset(valueOffset), FileOffset::Offset(valueOffset + 3)},
+      .replacement = "ONE",
+      .sourceVersion = document.sourceVersion(),
+  });
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_THAT(result.diagnostic, Eq(std::nullopt));
+  EXPECT_THAT(document.source(), testing::HasSubstr(">ONE<tspan"));
+  const auto& textComponent = text.entityHandle().get<components::TextComponent>();
+  EXPECT_EQ(textComponent.text, "ONEthree");
+  EXPECT_THAT(textComponent.textChunks, testing::ElementsAre(RcString("ONE"), RcString("three")));
+}
+
+TEST(SVGDocument, TSpanTextEditInvalidatesAncestorTextRoot) {
+  // Editing text inside a <tspan> marks the ancestor <text> root's text geometry dirty, walking
+  // up the tree from the tspan (which is not itself a text root).
+  auto document = ParseSVG(
+      R"(<svg xmlns="http://www.w3.org/2000/svg"><text id="m"><tspan id="s">two</tspan></text></svg>)");
+  SVGElement tspan = document.querySelector("#s").value();
+  SVGElement text = document.querySelector("#m").value();
+  text.entityHandle().remove<components::DirtyFlagsComponent>();
+  const std::size_t valueOffset = document.source().find("two");
+  ASSERT_NE(valueOffset, std::string_view::npos);
+
+  xml::ApplySourceEditResult result = document.applySourceEdit(xml::XMLEditIntent{
+      .range = SourceRange{FileOffset::Offset(valueOffset), FileOffset::Offset(valueOffset + 3)},
+      .replacement = "TWO",
+      .sourceVersion = document.sourceVersion(),
+  });
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_THAT(result.diagnostic, Eq(std::nullopt));
+  EXPECT_EQ(tspan.entityHandle().get<components::TextComponent>().text, "TWO");
+
+  const auto* dirtyFlags = text.entityHandle().try_get<components::DirtyFlagsComponent>();
+  ASSERT_NE(dirtyFlags, nullptr);
+  EXPECT_TRUE(dirtyFlags->test(components::DirtyFlagsComponent::TextGeometry));
+}
+
+TEST(SVGDocument, StandaloneAnchorTextEditProjectsWithoutTextRoot) {
+  // An <a> outside of text content carries text components but has no <text> root ancestor; the
+  // invalidation walk terminates at the document root without finding one.
+  auto document = ParseSVG(R"(<svg xmlns="http://www.w3.org/2000/svg"><a id="a1">hi</a></svg>)");
+  SVGElement anchor = document.querySelector("#a1").value();
+  const std::size_t valueOffset = document.source().find("hi");
+  ASSERT_NE(valueOffset, std::string_view::npos);
+
+  xml::ApplySourceEditResult result = document.applySourceEdit(xml::XMLEditIntent{
+      .range = SourceRange{FileOffset::Offset(valueOffset), FileOffset::Offset(valueOffset + 2)},
+      .replacement = "bye",
+      .sourceVersion = document.sourceVersion(),
+  });
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_THAT(result.diagnostic, Eq(std::nullopt));
+  EXPECT_EQ(anchor.entityHandle().get<components::TextComponent>().text, "bye");
+}
+
+TEST(SVGDocument, CDataMixedContentEditReprojectsTextChunks) {
+  // Editing CDATA contents adjacent to a plain text sibling reprojects the parent text element,
+  // concatenating the data and CDATA chunks.
+  auto document = ParseSVG(
+      R"(<svg xmlns="http://www.w3.org/2000/svg"><text id="m">one<![CDATA[two]]></text></svg>)");
+  SVGElement text = document.querySelector("#m").value();
+  const std::size_t valueOffset = document.source().find("two");
+  ASSERT_NE(valueOffset, std::string_view::npos);
+
+  xml::ApplySourceEditResult result = document.applySourceEdit(xml::XMLEditIntent{
+      .range = SourceRange{FileOffset::Offset(valueOffset), FileOffset::Offset(valueOffset + 3)},
+      .replacement = "TWO",
+      .sourceVersion = document.sourceVersion(),
+  });
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_THAT(result.diagnostic, Eq(std::nullopt));
+  EXPECT_THAT(document.source(), testing::HasSubstr("<![CDATA[TWO]]>"));
+  const auto& textComponent = text.entityHandle().get<components::TextComponent>();
+  EXPECT_EQ(textComponent.text, "oneTWO");
+  EXPECT_THAT(textComponent.textChunks, testing::ElementsAre(RcString("one"), RcString("TWO")));
+}
+
+TEST(SVGDocument, ProcessingInstructionValueEditAppliesWithoutProjectionDiagnostic) {
+  // Editing processing instruction contents applies to the source without producing a projection
+  // diagnostic, and does not disturb sibling elements.
+  auto document =
+      ParseSVG(R"(<svg xmlns="http://www.w3.org/2000/svg"><?foo bar?><rect id="r"/></svg>)");
+  const std::size_t valueOffset = document.source().find("bar");
+  ASSERT_NE(valueOffset, std::string_view::npos);
+
+  xml::ApplySourceEditResult result = document.applySourceEdit(xml::XMLEditIntent{
+      .range = SourceRange{FileOffset::Offset(valueOffset), FileOffset::Offset(valueOffset + 3)},
+      .replacement = "baz",
+      .sourceVersion = document.sourceVersion(),
+  });
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_THAT(result.diagnostic, Eq(std::nullopt));
+  EXPECT_THAT(document.source(), testing::HasSubstr("<?foo baz?>"));
+  EXPECT_THAT(document.querySelector("#r"), Optional(ElementIdEq("r")));
+}
+
+TEST(SVGDocument, CommentValueEditAppliesWithoutProjectionDiagnostic) {
+  // Editing comment contents applies to the source without producing a projection diagnostic,
+  // and does not disturb sibling elements.
+  auto document =
+      ParseSVG(R"(<svg xmlns="http://www.w3.org/2000/svg"><!-- note --><rect id="r"/></svg>)");
+  const std::size_t valueOffset = document.source().find("note");
+  ASSERT_NE(valueOffset, std::string_view::npos);
+
+  xml::ApplySourceEditResult result = document.applySourceEdit(xml::XMLEditIntent{
+      .range = SourceRange{FileOffset::Offset(valueOffset), FileOffset::Offset(valueOffset + 4)},
+      .replacement = "updated",
+      .sourceVersion = document.sourceVersion(),
+  });
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_THAT(result.diagnostic, Eq(std::nullopt));
+  EXPECT_THAT(document.source(), testing::HasSubstr("<!-- updated -->"));
+  EXPECT_THAT(document.querySelector("#r"), Optional(ElementIdEq("r")));
+}
+
+TEST(SVGDocument, StyleTextEditWithElementChildReportsDiagnostic) {
+  // Insert an element child into a <style> element, then edit the style text: reprojecting the
+  // stylesheet encounters the unexpected element child.
+  auto document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <style id="s">rect { fill: red; }</style>
+      <rect id="r"/>
+    </svg>
+  )");
+  SVGElement style = document.querySelector("#s").value();
+  SVGRectElement inserted = SVGRectElement::Create(document);
+  inserted.setId("inserted");
+  ASSERT_TRUE(document.insertElement(style, inserted).applied);
+
+  const std::size_t valueOffset = document.source().find("red");
+  ASSERT_NE(valueOffset, std::string_view::npos);
+
+  xml::ApplySourceEditResult result = document.applySourceEdit(xml::XMLEditIntent{
+      .range = SourceRange{FileOffset::Offset(valueOffset), FileOffset::Offset(valueOffset + 3)},
+      .replacement = "blue",
+      .sourceVersion = document.sourceVersion(),
+  });
+
+  EXPECT_TRUE(result.applied);
+  ASSERT_TRUE(result.diagnostic.has_value());
+  EXPECT_THAT(result.diagnostic->reason, testing::HasSubstr("Unexpected <style> element contents"));
+}
+
+TEST(SVGDocument, SubtreeEditWithInvalidAttributeReportsProjectionDiagnostic) {
+  // An edit spanning multiple children reparses the parent subtree; projecting the replacement
+  // reports the invalid attribute on the new child.
+  auto document = ParseSVG(
+      R"(<svg xmlns="http://www.w3.org/2000/svg"><g id="host"><rect id="a" width="5"/><rect id="b"/></g></svg>)");
+  const std::size_t editStart = document.source().find(R"(<rect id="a")");
+  const std::string_view lastChild = R"(<rect id="b"/>)";
+  const std::size_t lastChildOffset = document.source().find(lastChild);
+  ASSERT_NE(editStart, std::string_view::npos);
+  ASSERT_NE(lastChildOffset, std::string_view::npos);
+  const std::size_t editEnd = lastChildOffset + lastChild.size();
+
+  xml::ApplySourceEditResult result = document.applySourceEdit(xml::XMLEditIntent{
+      .range = SourceRange{FileOffset::Offset(editStart), FileOffset::Offset(editEnd)},
+      .replacement = R"(<rect id="c" width="not-a-length"/>)",
+      .sourceVersion = document.sourceVersion(),
+  });
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_EQ(result.scope, xml::ReparseScope::ElementSubtree);
+  ASSERT_TRUE(result.diagnostic.has_value());
+  EXPECT_THAT(result.diagnostic->reason, testing::HasSubstr("Invalid length or percentage"));
+  ASSERT_THAT(document.querySelector("#c"), Optional(ElementIdEq("c")));
+  EXPECT_THAT(document.querySelector("#a"), Eq(std::nullopt));
+  EXPECT_THAT(document.querySelector("#b"), Eq(std::nullopt));
+}
+
+TEST(SVGDocument, SubtreeEditProjectsMixedTextChunks) {
+  // Text content inserted through a source edit is projected by SVGDocument's subtree projection,
+  // preserving chunk boundaries around child elements and concatenating adjacent text and CDATA.
+  auto document = ParseSVG(
+      R"(<svg xmlns="http://www.w3.org/2000/svg"><g id="host"><rect id="old"/></g></svg>)");
+  const std::string_view oldChild = R"(<rect id="old"/>)";
+  const std::size_t editStart = document.source().find(oldChild);
+  ASSERT_NE(editStart, std::string_view::npos);
+
+  xml::ApplySourceEditResult result = document.applySourceEdit(xml::XMLEditIntent{
+      .range = SourceRange{FileOffset::Offset(editStart),
+                           FileOffset::Offset(editStart + oldChild.size())},
+      .replacement =
+          R"(<text id="t2"><tspan>lead</tspan>mid<tspan>x</tspan>tail<![CDATA[cd]]></text><text id="t3">solo</text>)",
+      .sourceVersion = document.sourceVersion(),
+  });
+
+  EXPECT_TRUE(result.applied);
+  EXPECT_THAT(result.diagnostic, Eq(std::nullopt));
+
+  SVGElement mixed = document.querySelector("#t2").value();
+  const auto& mixedText = mixed.entityHandle().get<components::TextComponent>();
+  EXPECT_EQ(mixedText.text, "midtailcd");
+  EXPECT_THAT(mixedText.textChunks, testing::ElementsAre(RcString(""), RcString("mid"),
+                                                         RcString("tail"), RcString("cd")));
+
+  SVGElement solo = document.querySelector("#t3").value();
+  const auto& soloText = solo.entityHandle().get<components::TextComponent>();
+  EXPECT_EQ(soloText.text, "solo");
+  EXPECT_THAT(soloText.textChunks, testing::ElementsAre(RcString("solo")));
 }
 
 TEST(SVGDocument, SourceBackedInsertAndRemoveElementUpdateSource) {


### PR DESCRIPTION
## Summary

Adds 33 behavioral test cases across `SVGDocument_tests.cc`, `AnimateElement_tests.cc`, `AnimateTransformElement_tests.cc`, and `SetElement_tests.cc`, covering previously-untested error paths and edge branches in `donner/svg/SVGDocument.cc` (source-edit projection arms) and `donner/svg/components/animation/AnimationSystem.cc` (SMIL timing and interpolation edge cases).

Coverage PR 5 in the ranked campaign toward a 92% Codecov project number. Purely additive test-only change: 638 insertions, no production, BUILD, or config changes.

## What the new cases assert

- SVGDocument source-edit arms: text-content edits on tspan/anchor/mixed-content/CDATA nodes assert both the applied result and the reprojected text chunks; diagnostic arms assert exact diagnostics (non-text element text edit, style with element child, invalid attribute inside a subtree replacement); no-op setters (time, user languages) assert the built render tree is NOT invalidated.
- Animation timing: restart=always vs restart=never with time moving backward assert the animated value re-runs or stays frozen; discrete clamping at the active end; missing attributeName/href-to-missing-id produce no override.
- Interpolation: exact midpoint path string for M/L/Q/C/Z interpolation; verb-mismatch and non-interpolable and hex-color values fall back to discrete; from/by with non-numeric "by" falls back to the from value; skewX/skewY/rotate/translate argument padding asserts exact transforms (e.g. "rotate(45, 25, 0)").

## Coverage delta (local `tools/coverage.sh`, baseline self-measured at origin/main 36ea1c11, Codecov-style: partials count as uncovered)

| File | Before | After |
|---|---|---|
| donner/svg/SVGDocument.cc | 643/71/43 h/m/p (84.9%) | 689/36/32 (91.0%) |
| donner/svg/components/animation/AnimationSystem.cc | 371/61/50 (77.0%) | 436/11/35 (90.5%) |

**+111 lines converted to fully covered.** Projected Codecov project delta: about **+0.17pp**. All 5 affected test targets pass unfiltered.

## Deliberately left uncovered (defensive / unreachable via public API)

- SVGDocument: NodeValueChanged arms for non-Element node types (the XML edit classifier emits NodeValueChanged only for Element nodes, verified empirically with comment/PI/CData probes); null-TreeComponent and missing-RenderTreeState guards (installed on every mutation path); projection-diagnostic arms for removeAttribute/removeNode (those mutations cannot produce projection diagnostics).
- AnimationSystem: restart="whenNotActive" suppression arm is dead by invariant (wasActive == (phase == Active) after every timing computation, so wasActive && phase == After is contradictory); PathParser returns a partial result even for garbage, so !hasResult() is unreachable from strings; remaining lines are case-closing braces and returns after exhaustive switches (llvm-cov artifacts).

## Quality

- No assertion-free tests; follows the existing fixtures and repo matcher idioms in each file.
- CI cost: rides existing test targets; no new binaries, no sharding changes.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
