### PR TITLE
test(text): cover TextEngine layout branches and TextBackendSimple metrics surface

### DIFF
--- a/donner/svg/renderer/tests/TextEngineHelpers_tests.cc
+++ b/donner/svg/renderer/tests/TextEngineHelpers_tests.cc
@@ -1320,6 +1320,89 @@ TEST_F(EffectiveBaselineResolutionTest, UseScriptResolvesAsIs) {
               testing::Contains(SpanWithEffectiveBaseline("A", DominantBaseline::UseScript)));
 }
 
+// -- baseline-shift keywords, ancestor shifts, and per-span textLength --------
+
+namespace {
+
+/// Returns the resolved span whose text equals \p expectedText, or nullptr.
+const components::ComputedTextComponent::TextSpan* FindSpanWithText(
+    const SmallVector<components::ComputedTextComponent::TextSpan, 1>& spans,
+    std::string_view expectedText) {
+  for (const auto& span : spans) {
+    const std::string_view spanText(span.text.data() + span.start, span.end - span.start);
+    if (spanText == expectedText) {
+      return &span;
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace
+
+TEST_F(EffectiveBaselineResolutionTest, BaselineShiftKeywordsResolvePerSpan) {
+  using BSK = components::ComputedTextComponent::TextSpan::BaselineShiftKeyword;
+
+  const auto spans = resolveSpans(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <text id="t" x="10" y="20"><tspan baseline-shift="sub">A</tspan><tspan
+        baseline-shift="super">B</tspan><tspan baseline-shift="4">C</tspan></text>
+    </svg>
+  )");
+
+  const auto* subSpan = FindSpanWithText(spans, "A");
+  ASSERT_NE(subSpan, nullptr);
+  EXPECT_EQ(subSpan->baselineShiftKeyword, BSK::Sub);
+
+  const auto* superSpan = FindSpanWithText(spans, "B");
+  ASSERT_NE(superSpan, nullptr);
+  EXPECT_EQ(superSpan->baselineShiftKeyword, BSK::Super);
+
+  const auto* lengthSpan = FindSpanWithText(spans, "C");
+  ASSERT_NE(lengthSpan, nullptr);
+  EXPECT_EQ(lengthSpan->baselineShiftKeyword, BSK::Length);
+  EXPECT_DOUBLE_EQ(lengthSpan->baselineShift.value, 4.0);
+}
+
+TEST_F(EffectiveBaselineResolutionTest, AncestorBaselineShiftsAccumulateThroughNestedTspans) {
+  using BSK = components::ComputedTextComponent::TextSpan::BaselineShiftKeyword;
+
+  const auto spans = resolveSpans(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <text id="t" x="10" y="20"><tspan baseline-shift="super"><tspan
+        baseline-shift="sub"><tspan baseline-shift="2">A</tspan></tspan></tspan></text>
+    </svg>
+  )");
+
+  const auto* span = FindSpanWithText(spans, "A");
+  ASSERT_NE(span, nullptr);
+  EXPECT_EQ(span->baselineShiftKeyword, BSK::Length);
+  EXPECT_DOUBLE_EQ(span->baselineShift.value, 2.0);
+
+  // Ancestor shifts accumulate bottom-up: the sub tspan first, then the super tspan.
+  ASSERT_EQ(span->ancestorBaselineShifts.size(), 2u);
+  EXPECT_EQ(span->ancestorBaselineShifts[0].keyword, BSK::Sub);
+  EXPECT_EQ(span->ancestorBaselineShifts[1].keyword, BSK::Super);
+}
+
+TEST_F(EffectiveBaselineResolutionTest, TspanTextLengthResolvesPerSpan) {
+  const auto spans = resolveSpans(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <text id="t" x="10" y="20">A<tspan textLength="50"
+        lengthAdjust="spacingAndGlyphs">BC</tspan></text>
+    </svg>
+  )");
+
+  const auto* plainSpan = FindSpanWithText(spans, "A");
+  ASSERT_NE(plainSpan, nullptr);
+  EXPECT_FALSE(plainSpan->textLength.has_value());
+
+  const auto* sizedSpan = FindSpanWithText(spans, "BC");
+  ASSERT_NE(sizedSpan, nullptr);
+  ASSERT_TRUE(sizedSpan->textLength.has_value());
+  EXPECT_DOUBLE_EQ(sizedSpan->textLength->value, 50.0);
+  EXPECT_EQ(sizedSpan->lengthAdjust, LengthAdjust::SpacingAndGlyphs);
+}
+
 }  // namespace
 
 }  // namespace donner::svg

--- a/donner/svg/renderer/tests/TextEngineScripted_tests.cc
+++ b/donner/svg/renderer/tests/TextEngineScripted_tests.cc
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <cmath>
 #include <iterator>
 #include <memory>
 #include <optional>
@@ -10,6 +11,7 @@
 #include "donner/base/Utf8.h"
 #include "donner/base/xml/components/TreeComponent.h"
 #include "donner/css/FontFace.h"
+#include "donner/css/Specificity.h"
 #include "donner/svg/components/layout/ViewBoxComponent.h"
 #include "donner/svg/components/style/ComputedStyleComponent.h"
 #include "donner/svg/components/text/TextComponent.h"
@@ -673,6 +675,733 @@ TEST(TextEngineScriptedTest, TextPathEndAnchorAndExhaustedPathHideGlyphs) {
   EXPECT_THAT(runs, ElementsAre(AllOf(
                         RunOnPathIs(Eq(true)),
                         RunGlyphsAre(ElementsAre(GlyphIndexIs(Eq(0)), GlyphIndexIs(Eq(0)))))));
+}
+
+// -- Error paths and edge branches (coverage-focused, all default-config) -----
+
+namespace {
+
+/// Backend that shapes non-ASCII codepoints to .notdef unless shaped with `coveringFont`,
+/// for exercising the registered-face coverage-fallback search.
+class CoverageProbeBackend : public ScriptedTextBackend {
+public:
+  FontHandle coveringFont;
+
+  ShapedRun shapeRun(FontHandle font, float fontSizePx, std::string_view spanText,
+                     size_t byteOffset, size_t byteLength, bool isVertical,
+                     FontVariant fontVariant, bool forceLogicalOrder) const override {
+    ShapedRun run = ScriptedTextBackend::shapeRun(font, fontSizePx, spanText, byteOffset,
+                                                  byteLength, isVertical, fontVariant,
+                                                  forceLogicalOrder);
+    for (auto& glyph : run.glyphs) {
+      const auto [codepoint, codepointLength] =
+          Utf8::NextCodepointLenient(spanText.substr(glyph.cluster));
+      (void)codepointLength;
+      if (static_cast<uint32_t>(codepoint) > 0x7F && font != coveringFont) {
+        glyph.glyphIndex = 0;
+      }
+    }
+    return run;
+  }
+};
+
+/// Backend whose font reports no vertical metrics, forcing the inline-size wrap to fall
+/// back to the 1.2 * font-size line height.
+class ZeroVMetricsBackend : public ScriptedTextBackend {
+public:
+  FontVMetrics fontVMetrics(FontHandle /*font*/) const override { return {}; }
+};
+
+/// Backend with no vector outlines: 'A' resolves to a bitmap glyph, everything else to a
+/// zero-sized bitmap (empty extent).
+class BitmapOutlineBackend : public ScriptedTextBackend {
+public:
+  Path glyphOutline(FontHandle /*font*/, int /*glyphIndex*/, float /*scale*/) const override {
+    return Path();
+  }
+
+  std::optional<BitmapGlyph> bitmapGlyph(FontHandle /*font*/, int glyphIndex,
+                                         float /*scale*/) const override {
+    if (glyphIndex == 'A' % 997 + 1) {
+      return BitmapGlyph{.rgbaPixels = {},
+                         .width = 4,
+                         .height = 4,
+                         .bearingX = 1.0,
+                         .bearingY = 2.0,
+                         .scale = 0.5};
+    }
+    return BitmapGlyph{
+        .rgbaPixels = {}, .width = 0, .height = 0, .bearingX = 0.0, .bearingY = 0.0, .scale = 1.0};
+  }
+};
+
+/// Backend whose outlines contain quadratic and cubic curve segments.
+class CurveOutlineBackend : public ScriptedTextBackend {
+public:
+  Path glyphOutline(FontHandle /*font*/, int /*glyphIndex*/, float /*scale*/) const override {
+    return PathBuilder()
+        .moveTo(Vector2d(0.0, 0.0))
+        .quadTo(Vector2d(5.0, -10.0), Vector2d(10.0, 0.0))
+        .curveTo(Vector2d(12.0, 5.0), Vector2d(2.0, 5.0), Vector2d(0.0, 10.0))
+        .build();
+  }
+};
+
+/// Registers a @font-face named \p familyName backed by the embedded fallback font's bytes,
+/// returning its resolved handle.
+FontHandle RegisterFallbackBackedFace(FontManager& fontManager, const std::string& familyName) {
+  const FontHandle fallback = fontManager.fallbackFont();
+  const auto data = fontManager.fontData(fallback);
+  auto payload = std::make_shared<const std::vector<uint8_t>>(data.begin(), data.end());
+
+  css::FontFaceSource source;
+  source.kind = css::FontFaceSource::Kind::Data;
+  source.payload = payload;
+
+  css::FontFace face;
+  face.familyName = RcString(familyName);
+  face.sources.push_back(std::move(source));
+  fontManager.addFontFace(face);
+  return fontManager.findFont(RcString(familyName));
+}
+
+/// Minimal sfnt bytes that pass the outline-table check but fail stb_truetype parsing
+/// (no cmap table), so shaping produces no glyphs.
+std::shared_ptr<const std::vector<uint8_t>> MakeUnparseableOutlineFontData() {
+  std::vector<uint8_t> data = {0x00, 0x01, 0x00, 0x00,  // sfnt version 1.0
+                               0x00, 0x01,              // numTables = 1
+                               0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+  const char tag[4] = {'g', 'l', 'y', 'f'};
+  data.insert(data.end(), tag, tag + 4);
+  for (int i = 0; i < 4; ++i) data.push_back(0);         // Checksum.
+  data.insert(data.end(), {0x00, 0x00, 0x00, 0x1C});     // Offset = 28.
+  for (int i = 0; i < 4; ++i) data.push_back(0);         // Length = 0.
+  return std::make_shared<const std::vector<uint8_t>>(std::move(data));
+}
+
+components::ComputedStyleComponent MakeStyle() {
+  components::ComputedStyleComponent style;
+  style.properties.emplace();
+  return style;
+}
+
+/// Creates a text root entity with computed text/style/viewbox components and a single
+/// span sourced from the root, ready for the cached-geometry APIs.
+Entity MakeTextRootWithSpan(Registry& registry, const std::string& textValue,
+                            components::ComputedTextComponent::TextSpan span) {
+  const Entity root = registry.create();
+  registry.emplace<donner::components::TreeComponent>(root, xml::XMLQualifiedNameRef("text"));
+  registry.emplace<components::TextRootComponent>(root);
+  registry.emplace<components::ComputedViewBoxComponent>(root,
+                                                         Box2d::FromXYWH(0.0, 0.0, 200.0, 100.0));
+
+  components::TextComponent textComponent;
+  textComponent.text = RcString(textValue);
+  registry.emplace<components::TextComponent>(root, textComponent);
+
+  span.sourceEntity = root;
+  components::ComputedTextComponent computedText;
+  computedText.spans.push_back(std::move(span));
+  registry.emplace<components::ComputedTextComponent>(root, computedText);
+
+  registry.emplace<components::ComputedStyleComponent>(root, MakeStyle());
+  return root;
+}
+
+}  // namespace
+
+TEST(TextEngineScriptedTest, PrepareForElementIgnoresElementsWithoutTextRoot) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+  ParseWarningSink warnings;
+
+  // Entity with no TreeComponent: the text-root walk stops immediately.
+  const Entity detached = registry.create();
+  engine.prepareForElement(EntityHandle(registry, detached), warnings);
+
+  // Entity in a tree without any TextRootComponent ancestor.
+  const Entity group = registry.create();
+  registry.emplace<donner::components::TreeComponent>(group, xml::XMLQualifiedNameRef("g"));
+  engine.prepareForElement(EntityHandle(registry, group), warnings);
+
+  EXPECT_FALSE(registry.ctx().contains<FontManager>());
+  EXPECT_EQ(registry.try_get<components::ComputedTextComponent>(group), nullptr);
+}
+
+TEST(TextEngineScriptedTest, PrepareForElementRequiresResourceManagerContext) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+  ParseWarningSink warnings;
+
+  const Entity root = registry.create();
+  registry.emplace<donner::components::TreeComponent>(root, xml::XMLQualifiedNameRef("text"));
+  registry.emplace<components::TextRootComponent>(root);
+
+  engine.prepareForElement(EntityHandle(registry, root), warnings);
+
+  // Without a ResourceManagerContext the engine bails out before installing anything.
+  EXPECT_FALSE(registry.ctx().contains<FontManager>());
+  EXPECT_EQ(registry.try_get<components::ComputedTextComponent>(root), nullptr);
+}
+
+TEST(TextEngineScriptedTest, AddFontFaceRegistersSingleFaceAndBatchSkipsAlreadyRegistered) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  css::FontFace face;
+  face.familyName = RcString("SoloFace");
+  engine.addFontFace(face);
+  EXPECT_EQ(fontManager.numFaces(), 1u);
+
+  // A batch no larger than the registered count is a no-op.
+  const std::vector<css::FontFace> faces = {face};
+  engine.addFontFaces(faces);
+  EXPECT_EQ(fontManager.numFaces(), 1u);
+}
+
+TEST(TextEngineScriptedTest, ResolvePerSpanLayoutStylesRequiresRootTextComponent) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  const Entity root = registry.create();
+  registry.emplace<donner::components::TreeComponent>(root, xml::XMLQualifiedNameRef("text"));
+  registry.emplace<components::TextRootComponent>(root);
+  auto rootStyle = MakeStyle();
+  rootStyle.properties->textAnchor.set(TextAnchor::End, css::Specificity::Override());
+  registry.emplace<components::ComputedStyleComponent>(root, rootStyle);
+
+  components::ComputedTextComponent text;
+  auto span = MakeSpan("A");
+  span.sourceEntity = root;
+  text.spans.push_back(std::move(span));
+
+  // No TextComponent on the root: resolution is skipped and spans stay untouched.
+  engine.resolvePerSpanLayoutStyles(EntityHandle(registry, root), text);
+  EXPECT_EQ(text.spans[0].textAnchor, TextAnchor::Start);
+}
+
+TEST(TextEngineScriptedTest, ResolvePerSpanLayoutStylesFallsBackToParentStyleAndSkipsUnstyled) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  const Entity root = MakeTextRootWithSpan(registry, "ABCD", MakeSpan("A"));
+
+  // A styled tspan parent whose child has no computed style of its own.
+  const Entity styledParent = registry.create();
+  registry.emplace<donner::components::TreeComponent>(styledParent,
+                                                      xml::XMLQualifiedNameRef("tspan"));
+  registry.get<donner::components::TreeComponent>(root).appendChild(registry, styledParent);
+  auto parentStyle = MakeStyle();
+  parentStyle.properties->textAnchor.set(TextAnchor::End, css::Specificity::Override());
+  registry.emplace<components::ComputedStyleComponent>(styledParent, parentStyle);
+
+  const Entity unstyledChild = registry.create();
+  registry.emplace<donner::components::TreeComponent>(unstyledChild,
+                                                      xml::XMLQualifiedNameRef("tspan"));
+  registry.get<donner::components::TreeComponent>(styledParent)
+      .appendChild(registry, unstyledChild);
+
+  const Entity orphanNoTree = registry.create();
+  const Entity orphanWithTree = registry.create();
+  registry.emplace<donner::components::TreeComponent>(orphanWithTree,
+                                                      xml::XMLQualifiedNameRef("tspan"));
+
+  components::ComputedTextComponent text;
+  auto nullSourceSpan = MakeSpan("A");
+  nullSourceSpan.sourceEntity = entt::null;
+  auto orphanSpan = MakeSpan("B");
+  orphanSpan.sourceEntity = orphanNoTree;
+  auto orphanTreeSpan = MakeSpan("C");
+  orphanTreeSpan.sourceEntity = orphanWithTree;
+  auto childSpan = MakeSpan("D");
+  childSpan.sourceEntity = unstyledChild;
+  text.spans.push_back(std::move(nullSourceSpan));
+  text.spans.push_back(std::move(orphanSpan));
+  text.spans.push_back(std::move(orphanTreeSpan));
+  text.spans.push_back(std::move(childSpan));
+
+  engine.resolvePerSpanLayoutStyles(EntityHandle(registry, root), text);
+
+  // Spans without a resolvable style source stay at their defaults.
+  EXPECT_EQ(text.spans[0].textAnchor, TextAnchor::Start);
+  EXPECT_EQ(text.spans[1].textAnchor, TextAnchor::Start);
+  EXPECT_EQ(text.spans[2].textAnchor, TextAnchor::Start);
+  // A span without its own style resolves through its parent element's style.
+  EXPECT_EQ(text.spans[3].textAnchor, TextAnchor::End);
+}
+
+TEST(TextEngineScriptedTest, ResolvePerSpanLayoutStylesResolvesKeywordsAncestorsAndTextLength) {
+  using BSK = components::ComputedTextComponent::TextSpan::BaselineShiftKeyword;
+
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  const Entity root = MakeTextRootWithSpan(registry, "ABX", MakeSpan("X"));
+  auto& rootStyle = registry.get<components::ComputedStyleComponent>(root);
+  rootStyle.properties->baselineShift.set(Lengthd(5.0, Lengthd::Unit::Px),
+                                          css::Specificity::Override());
+
+  auto makeChild = [&](Entity parent, std::optional<Lengthd> baselineShift) {
+    const Entity entity = registry.create();
+    registry.emplace<donner::components::TreeComponent>(entity,
+                                                        xml::XMLQualifiedNameRef("tspan"));
+    registry.get<donner::components::TreeComponent>(parent).appendChild(registry, entity);
+    if (baselineShift.has_value()) {
+      auto style = MakeStyle();
+      style.properties->baselineShift.set(*baselineShift, css::Specificity::Override());
+      registry.emplace<components::ComputedStyleComponent>(entity, style);
+    }
+    return entity;
+  };
+
+  // Chain: root -> super(0.4em) -> sub(-0.33em) -> unstyled -> length(3) -> leaf(-0.33em).
+  const Entity superAncestor = makeChild(root, Lengthd(0.4, Lengthd::Unit::Em));
+  const Entity subAncestor = makeChild(superAncestor, Lengthd(-0.33, Lengthd::Unit::Em));
+  const Entity unstyledAncestor = makeChild(subAncestor, std::nullopt);
+  const Entity lengthAncestor = makeChild(unstyledAncestor, Lengthd(3.0, Lengthd::Unit::None));
+  const Entity leaf = makeChild(lengthAncestor, Lengthd(-0.33, Lengthd::Unit::Em));
+
+  // dominant-baseline: no-change on the leaf resolves to the parent's value.
+  registry.get<components::ComputedStyleComponent>(leaf).properties->dominantBaseline.set(
+      DominantBaseline::NoChange, css::Specificity::Override());
+  registry.get<components::ComputedStyleComponent>(lengthAncestor)
+      .properties->dominantBaseline.set(DominantBaseline::Hanging, css::Specificity::Override());
+
+  // Per-span textLength comes from the source element's TextComponent.
+  components::TextComponent leafText;
+  leafText.text = RcString("A");
+  leafText.textLength = Lengthd(50.0, Lengthd::Unit::None);
+  leafText.lengthAdjust = LengthAdjust::SpacingAndGlyphs;
+  registry.emplace<components::TextComponent>(leaf, leafText);
+
+  const Entity superLeaf = makeChild(root, Lengthd(0.4, Lengthd::Unit::Em));
+
+  components::ComputedTextComponent text;
+  auto leafSpan = MakeSpan("A");
+  leafSpan.sourceEntity = leaf;
+  auto rootSpan = MakeSpan("B");
+  rootSpan.sourceEntity = root;
+  auto superSpan = MakeSpan("X");
+  superSpan.sourceEntity = superLeaf;
+  text.spans.push_back(std::move(leafSpan));
+  text.spans.push_back(std::move(rootSpan));
+  text.spans.push_back(std::move(superSpan));
+
+  engine.resolvePerSpanLayoutStyles(EntityHandle(registry, root), text);
+
+  const auto& resolvedLeaf = text.spans[0];
+  EXPECT_EQ(resolvedLeaf.baselineShiftKeyword, BSK::Sub);
+  EXPECT_EQ(resolvedLeaf.alignmentBaseline, DominantBaseline::Hanging);
+  ASSERT_TRUE(resolvedLeaf.textLength.has_value());
+  EXPECT_DOUBLE_EQ(resolvedLeaf.textLength->value, 50.0);
+  EXPECT_EQ(resolvedLeaf.lengthAdjust, LengthAdjust::SpacingAndGlyphs);
+
+  // Ancestors accumulate bottom-up, skipping the unstyled element.
+  ASSERT_EQ(resolvedLeaf.ancestorBaselineShifts.size(), 3u);
+  EXPECT_EQ(resolvedLeaf.ancestorBaselineShifts[0].keyword, BSK::Length);
+  EXPECT_DOUBLE_EQ(resolvedLeaf.ancestorBaselineShifts[0].shift.value, 3.0);
+  EXPECT_EQ(resolvedLeaf.ancestorBaselineShifts[1].keyword, BSK::Sub);
+  EXPECT_EQ(resolvedLeaf.ancestorBaselineShifts[2].keyword, BSK::Super);
+
+  // Spans sourced from the text root ignore baseline-shift entirely.
+  EXPECT_DOUBLE_EQ(text.spans[1].baselineShift.value, 0.0);
+  EXPECT_TRUE(text.spans[1].ancestorBaselineShifts.empty());
+
+  EXPECT_EQ(text.spans[2].baselineShiftKeyword, BSK::Super);
+}
+
+TEST(TextEngineScriptedTest, CoverageFallbackSwitchesToRegisteredFaceThatCoversCodepoint) {
+  Registry registry;
+  FontManager fontManager(registry);
+  const FontHandle altFace = RegisterFallbackBackedFace(fontManager, "AltFace");
+  ASSERT_TRUE(static_cast<bool>(altFace));
+
+  auto backend = std::make_unique<CoverageProbeBackend>();
+  backend->coveringFont = altFace;
+  TextEngine engine(fontManager, registry, std::move(backend));
+
+  components::ComputedTextComponent text;
+  text.spans.push_back(MakeSpan("\xC3\xA9"));  // e-acute: not covered by the base font.
+
+  const auto runs = engine.layout(text, MakeTextParams(20.0));
+
+  ASSERT_THAT(runs, ElementsAre(RunGlyphsAre(SizeIs(1))));
+  EXPECT_EQ(runs[0].font, altFace);
+  EXPECT_THAT(runs[0].glyphs, ElementsAre(GlyphIndexIs(Gt(0))));
+}
+
+TEST(TextEngineScriptedTest, CoverageFallbackKeepsFontWhenNoRegisteredFaceCovers) {
+  Registry registry;
+  FontManager fontManager(registry);
+  const FontHandle altFace = RegisterFallbackBackedFace(fontManager, "AltFace");
+  ASSERT_TRUE(static_cast<bool>(altFace));
+
+  // No font covers non-ASCII: the search visits the registered face and keeps the original.
+  auto backend = std::make_unique<CoverageProbeBackend>();
+  TextEngine engine(fontManager, registry, std::move(backend));
+
+  components::ComputedTextComponent text;
+  text.spans.push_back(MakeSpan("\xC3\xA9"));
+
+  const auto runs = engine.layout(text, MakeTextParams(20.0));
+
+  ASSERT_THAT(runs, ElementsAre(RunGlyphsAre(SizeIs(1))));
+  EXPECT_EQ(runs[0].font, fontManager.fallbackFont());
+  EXPECT_THAT(runs[0].glyphs, ElementsAre(GlyphIndexIs(Eq(0))));
+}
+
+TEST(TextEngineScriptedTest, BoldSpanResolvesFontThroughWeightAwareLookup) {
+  Registry registry;
+  FontManager fontManager(registry);
+  const FontHandle altFace = RegisterFallbackBackedFace(fontManager, "WeightProbe");
+  ASSERT_TRUE(static_cast<bool>(altFace));
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  components::ComputedTextComponent text;
+  auto span = MakeSpan("A");
+  span.fontWeight = 700;
+  text.spans.push_back(std::move(span));
+
+  TextLayoutParams params = MakeTextParams(20.0);
+  params.fontFamilies = {RcString("WeightProbe")};
+  const auto runs = engine.layout(text, params);
+
+  ASSERT_THAT(runs, ElementsAre(RunGlyphsAre(SizeIs(1))));
+  EXPECT_EQ(runs[0].font, altFace);
+}
+
+TEST(TextEngineScriptedTest, HorizontalCrossSpanKernShiftsContinuationSpan) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  components::ComputedTextComponent text;
+  text.spans.push_back(MakeSpan("A"));
+  auto continuation = MakeSpan("B");
+  continuation.startsNewChunk = false;
+  text.spans.push_back(std::move(continuation));
+
+  const auto runs = engine.layout(text, MakeTextParams(20.0));
+
+  // The continuation span's first glyph picks up the scripted 3px cross-span kern.
+  EXPECT_THAT(runs, ElementsAre(RunGlyphsAre(ElementsAre(GlyphXPositionIs(DoubleEq(0.0)))),
+                                RunGlyphsAre(ElementsAre(GlyphXPositionIs(DoubleEq(13.0))))));
+}
+
+TEST(TextEngineScriptedTest, VerticalCrossSpanKernShiftsContinuationSpan) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  components::ComputedTextComponent text;
+  text.spans.push_back(MakeSpan("A"));
+  auto continuation = MakeSpan("B");
+  continuation.startsNewChunk = false;
+  text.spans.push_back(std::move(continuation));
+
+  TextLayoutParams params = MakeTextParams(20.0);
+  params.writingMode = WritingMode::VerticalRl;
+  const auto runs = engine.layout(text, params);
+
+  // 10px sideways advance for "A", then the scripted 4px vertical cross-span kern.
+  EXPECT_THAT(runs, ElementsAre(RunGlyphsAre(ElementsAre(GlyphYPositionIs(DoubleEq(0.0)))),
+                                RunGlyphsAre(ElementsAre(GlyphYPositionIs(DoubleEq(14.0))))));
+}
+
+TEST(TextEngineScriptedTest, VerticalCjkRotateListRepeatsLastValue) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  components::ComputedTextComponent text;
+  auto span = MakeSpan("\xE6\x97\xA5\xE6\x97\xA5");  // Two upright CJK glyphs.
+  span.rotateList = {7.0};
+  text.spans.push_back(std::move(span));
+
+  TextLayoutParams params = MakeTextParams(20.0);
+  params.writingMode = WritingMode::VerticalRl;
+  const auto runs = engine.layout(text, params);
+
+  // The single rotate value repeats for the second glyph per the SVG spec.
+  EXPECT_THAT(runs, ElementsAre(RunGlyphsAre(ElementsAre(
+                        AllOf(GlyphRotateDegreesIs(DoubleEq(7.0)),
+                              GlyphYPositionIs(DoubleEq(3.0))),
+                        AllOf(GlyphRotateDegreesIs(DoubleEq(7.0)),
+                              GlyphYPositionIs(DoubleEq(17.0)))))));
+}
+
+TEST(TextEngineScriptedTest, PerSpanTextLengthSpacingAdjustsVerticalGaps) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  components::ComputedTextComponent text;
+  auto span = MakeSpan("AB");
+  span.textLength = Lengthd(40.0, Lengthd::Unit::None);
+  span.lengthAdjust = LengthAdjust::Spacing;
+  text.spans.push_back(std::move(span));
+
+  // A sibling span without textLength is skipped by the per-span adjustment.
+  auto plainSpan = MakeSpan("C");
+  plainSpan.startsNewChunk = false;
+  text.spans.push_back(std::move(plainSpan));
+
+  TextLayoutParams params = MakeTextParams(20.0);
+  params.writingMode = WritingMode::VerticalRl;
+  const auto runs = engine.layout(text, params);
+
+  // Natural length 22px (10px advance, 2px kern, 10px advance) stretched to 40px moves
+  // the second glyph down by the 18px gap difference. The plain span keeps its natural
+  // position after the first span's unadjusted 22px extent plus the 4px cross-span kern.
+  EXPECT_THAT(runs, ElementsAre(RunGlyphsAre(ElementsAre(GlyphYPositionIs(DoubleEq(0.0)),
+                                                         GlyphYPositionIs(DoubleEq(30.0)))),
+                                RunGlyphsAre(ElementsAre(GlyphYPositionIs(DoubleEq(26.0))))));
+}
+
+TEST(TextEngineScriptedTest, InlineSizeDoesNotWrapTextOnPath) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+  const entt::entity textPathEntity = registry.create();
+  const Path path = PathBuilder().moveTo(Vector2d(0.0, 0.0)).lineTo(Vector2d(400.0, 0.0)).build();
+
+  components::ComputedTextComponent text;
+  auto span = MakeSpan("aa bb");
+  span.pathSpline = path;
+  span.textPathSourceEntity = textPathEntity;
+  text.spans.push_back(std::move(span));
+
+  TextLayoutParams params = MakeTextParams(20.0);
+  params.inlineSizePx = 25.0;  // Would wrap flat text; ignored for text-on-path.
+  const auto runs = engine.layout(text, params);
+
+  ASSERT_THAT(runs, ElementsAre(RunGlyphsAre(SizeIs(5))));
+  EXPECT_TRUE(runs[0].onPath);
+  for (const auto& glyph : runs[0].glyphs) {
+    EXPECT_THAT(glyph.yPosition, DoubleNear(0.0, 1e-9));  // No stacked lines.
+  }
+}
+
+TEST(TextEngineScriptedTest, InlineSizeIgnoresSingleGlyphContent) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  components::ComputedTextComponent text;
+  text.spans.push_back(MakeSpan("a"));
+
+  TextLayoutParams params = MakeTextParams(20.0);
+  params.inlineSizePx = 5.0;  // Smaller than the glyph; still nothing to wrap.
+  const auto runs = engine.layout(text, params);
+
+  EXPECT_THAT(runs, ElementsAre(RunGlyphsAre(ElementsAre(AllOf(
+                        GlyphXPositionIs(DoubleEq(0.0)), GlyphYPositionIs(DoubleEq(0.0)))))));
+}
+
+TEST(TextEngineScriptedTest, InlineSizeLineHeightFallsBackWhenFontMetricsAreEmpty) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine(fontManager, registry, std::make_unique<ZeroVMetricsBackend>());
+
+  components::ComputedTextComponent text;
+  text.spans.push_back(MakeSpan("aa bb"));
+
+  TextLayoutParams params = MakeTextParams(20.0);
+  params.inlineSizePx = 25.0;  // Each two-glyph word (21px) fits alone; both do not.
+  const auto runs = engine.layout(text, params);
+
+  std::vector<long> baselines;
+  for (const auto& run : runs) {
+    for (const auto& glyph : run.glyphs) {
+      baselines.push_back(std::lround(glyph.yPosition));
+    }
+  }
+  std::sort(baselines.begin(), baselines.end());
+  baselines.erase(std::unique(baselines.begin(), baselines.end()), baselines.end());
+
+  // Zero font metrics force the 1.2 * font-size (24px) line-height fallback.
+  EXPECT_THAT(baselines, ElementsAre(0, 24));
+}
+
+TEST(TextEngineScriptedTest, TextAnchorSkipsOnPathRunsInsideChunks) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+  const entt::entity firstPathEntity = registry.create();
+  const entt::entity secondPathEntity = registry.create();
+  const Path path = PathBuilder().moveTo(Vector2d(0.0, 0.0)).lineTo(Vector2d(200.0, 0.0)).build();
+
+  components::ComputedTextComponent text;
+  auto flatSpan = MakeSpan("AB");
+  flatSpan.textAnchor = TextAnchor::End;
+
+  auto onPathSpan = MakeSpan("C");
+  onPathSpan.startsNewChunk = false;
+  onPathSpan.pathSpline = path;
+  onPathSpan.textPathSourceEntity = firstPathEntity;
+
+  // Second chunk: an empty span (anchor end) followed by on-path glyphs only, so the
+  // chunk has no flat glyphs to anchor.
+  auto emptySpan = MakeSpan("");
+  emptySpan.textAnchor = TextAnchor::End;
+
+  auto onPathTail = MakeSpan("D");
+  onPathTail.startsNewChunk = false;
+  onPathTail.textAnchor = TextAnchor::End;
+  onPathTail.pathSpline = path;
+  onPathTail.textPathSourceEntity = secondPathEntity;
+  onPathTail.pathStartOffset = 80.0;
+
+  text.spans.push_back(std::move(flatSpan));
+  text.spans.push_back(std::move(onPathSpan));
+  text.spans.push_back(std::move(emptySpan));
+  text.spans.push_back(std::move(onPathTail));
+
+  const auto runs = engine.layout(text, MakeTextParams(20.0));
+
+  // Flat glyphs shift by the chunk width (21px); on-path glyphs stay path-positioned.
+  EXPECT_THAT(runs,
+              ElementsAre(RunGlyphsAre(ElementsAre(GlyphXPositionIs(DoubleEq(-21.0)),
+                                                   GlyphXPositionIs(DoubleEq(-10.0)))),
+                          RunGlyphsAre(ElementsAre(GlyphXPositionIs(DoubleEq(0.0)))),
+                          RunGlyphsAre(IsEmpty()),
+                          RunGlyphsAre(ElementsAre(GlyphXPositionIs(DoubleEq(70.0))))));
+}
+
+TEST(TextEngineScriptedTest, GeometryCacheFallsBackToBitmapGlyphExtents) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine(fontManager, registry, std::make_unique<BitmapOutlineBackend>());
+
+  const Entity root = MakeTextRootWithSpan(registry, "AB", MakeSpan("AB"));
+  const EntityHandle rootHandle(registry, root);
+
+  // No vector outlines anywhere.
+  EXPECT_THAT(engine.computedGlyphPaths(rootHandle), IsEmpty());
+
+  // 'A' resolves to a 4x4 bitmap at scale 0.5 with bearing (1, 2).
+  EXPECT_EQ(engine.getExtentOfChar(rootHandle, 0), Box2d::FromXYWH(1.0, -2.0, 2.0, 2.0));
+  // 'B' resolves to a zero-sized bitmap: its extent stays empty.
+  EXPECT_EQ(engine.getExtentOfChar(rootHandle, 1), Box2d());
+
+  EXPECT_EQ(engine.getNumberOfChars(rootHandle), 2);
+  // End position advances by the scripted (10, 12) glyph advance.
+  EXPECT_EQ(engine.getEndPositionOfChar(rootHandle, 0), Vector2d(10.0, 12.0));
+
+  // Out-of-range character queries return empty values.
+  EXPECT_EQ(engine.getEndPositionOfChar(rootHandle, 9), Vector2d());
+  EXPECT_EQ(engine.getExtentOfChar(rootHandle, 9), Box2d());
+  EXPECT_DOUBLE_EQ(engine.getRotationOfChar(rootHandle, 9), 0.0);
+}
+
+TEST(TextEngineScriptedTest, GeometryCacheTransformsQuadraticAndCubicOutlineSegments) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine(fontManager, registry, std::make_unique<CurveOutlineBackend>());
+
+  auto span = MakeSpan("A");
+  span.xList = {Lengthd(7.0, Lengthd::Unit::None)};
+  span.yList = {Lengthd(9.0, Lengthd::Unit::None)};
+  const Entity root = MakeTextRootWithSpan(registry, "A", std::move(span));
+
+  const std::vector<Path> paths = engine.computedGlyphPaths(EntityHandle(registry, root));
+
+  // The outline's move/quad/cubic control points all translate by the glyph position.
+  ASSERT_THAT(paths, SizeIs(1));
+  EXPECT_THAT(paths[0].points(),
+              ElementsAre(Vector2d(7.0, 9.0), Vector2d(12.0, -1.0), Vector2d(17.0, 9.0),
+                          Vector2d(19.0, 14.0), Vector2d(9.0, 14.0), Vector2d(7.0, 19.0)));
+}
+
+TEST(TextEngineScriptedTest, GeometryCacheFilterExcludesEntitiesOutsideTree) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  const Entity root = MakeTextRootWithSpan(registry, "A", MakeSpan("A"));
+  const EntityHandle rootHandle(registry, root);
+  ASSERT_EQ(engine.getNumberOfChars(rootHandle), 1);  // Builds the geometry cache.
+
+  // Inject a cached glyph whose source entity has no TreeComponent: the descendant
+  // filter cannot walk it and excludes it from subtree queries.
+  const Entity detached = registry.create();
+  auto& cache = registry.get<components::ComputedTextGeometryComponent>(root);
+  cache.glyphs.push_back(components::ComputedTextGeometryComponent::GlyphGeometry{
+      .sourceEntity = detached,
+      .path = PathBuilder().addRect(Box2d::FromXYWH(50.0, 0.0, 5.0, 5.0)).build(),
+      .extent = Box2d::FromXYWH(50.0, 0.0, 5.0, 5.0),
+  });
+
+  const auto paths = engine.computedGlyphPaths(rootHandle);
+  EXPECT_THAT(paths, SizeIs(1));  // Only the root-sourced glyph; the detached one is filtered.
+
+  // The outline+source variant applies the same subtree filter.
+  const auto outlines = engine.computedGlyphOutlines(rootHandle);
+  ASSERT_THAT(outlines, SizeIs(1));
+  EXPECT_EQ(outlines[0].sourceEntity, root);
+}
+
+TEST(TextEngineScriptedTest, MetricForwardersExposeBackendValues) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+  const FontHandle font;
+
+  EXPECT_EQ(engine.fontVMetrics(font).ascent, 1000);
+  EXPECT_FLOAT_EQ(engine.scaleForPixelHeight(font, 24.0f), 0.02f);
+  EXPECT_FLOAT_EQ(engine.scaleForEmToPixels(font, 24.0f), 0.024f);
+
+  const auto underline = engine.underlineMetrics(font);
+  ASSERT_TRUE(underline.has_value());
+  EXPECT_DOUBLE_EQ(underline->position, -100.0);
+  EXPECT_DOUBLE_EQ(underline->thickness, 50.0);
+
+  const auto strikeout = engine.strikeoutMetrics(font);
+  ASSERT_TRUE(strikeout.has_value());
+  EXPECT_DOUBLE_EQ(strikeout->position, 300.0);
+  EXPECT_DOUBLE_EQ(strikeout->thickness, 40.0);
+
+  EXPECT_FALSE(engine.subSuperMetrics(font).has_value());
+  EXPECT_FALSE(engine.isBitmapOnly(font));
+  EXPECT_FALSE(engine.bitmapGlyph(font, 3, 1.0f).has_value());
+  EXPECT_FALSE(engine.glyphOutline(font, 5, 1.0f).empty());
+  EXPECT_TRUE(engine.glyphOutline(font, 0, 1.0f).empty());
+}
+
+TEST(TextEngineScriptedTest, MeasureChUnitUsesFallbackFontWhenNoFamilyMatches) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  const std::optional<double> chUnit = engine.measureChUnitInEm({});
+
+  // The embedded fallback font's '0' advance, in ems.
+  ASSERT_TRUE(chUnit.has_value());
+  EXPECT_THAT(*chUnit, AllOf(Gt(0.0), testing::Lt(2.0)));
+}
+
+TEST(TextEngineScriptedTest, MeasureChUnitFailsWhenFontCannotBeShaped) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine = MakeScriptedEngine(registry, fontManager);
+
+  // Register a face whose data passes the outline check but cannot be parsed for shaping.
+  css::FontFaceSource source;
+  source.kind = css::FontFaceSource::Kind::Data;
+  source.payload = MakeUnparseableOutlineFontData();
+  css::FontFace face;
+  face.familyName = RcString("BrokenFont");
+  face.sources.push_back(std::move(source));
+  fontManager.addFontFace(face);
+
+  const std::vector<RcString> families = {RcString("BrokenFont")};
+  EXPECT_FALSE(engine.measureChUnitInEm(families).has_value());
 }
 
 }  // namespace donner::svg

--- a/donner/svg/text/BUILD.bazel
+++ b/donner/svg/text/BUILD.bazel
@@ -113,6 +113,16 @@ donner_cc_test(
 )
 
 donner_cc_test(
+    name = "text_backend_simple_tests",
+    srcs = ["tests/TextBackendSimple_tests.cc"],
+    deps = [
+        ":text_backend",
+        ":text_backend_simple",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
     name = "inline_size_wrap_tests",
     srcs = ["tests/InlineSizeWrap_tests.cc"],
     deps = [

--- a/donner/svg/text/tests/TextBackendSimple_tests.cc
+++ b/donner/svg/text/tests/TextBackendSimple_tests.cc
@@ -1,0 +1,502 @@
+#include "donner/svg/text/TextBackendSimple.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <string_view>
+#include <tuple>
+#include <vector>
+
+namespace donner::svg {
+namespace {
+
+using ::testing::AllOf;
+using ::testing::DoubleEq;
+using ::testing::DoubleNear;
+using ::testing::ElementsAre;
+using ::testing::Field;
+using ::testing::FloatEq;
+using ::testing::IsEmpty;
+
+auto GlyphIndexIs(auto matcher) {
+  return Field("glyphIndex", &TextBackend::ShapedGlyph::glyphIndex, matcher);
+}
+
+auto GlyphXAdvanceIs(auto matcher) {
+  return Field("xAdvance", &TextBackend::ShapedGlyph::xAdvance, matcher);
+}
+
+auto GlyphYAdvanceIs(auto matcher) {
+  return Field("yAdvance", &TextBackend::ShapedGlyph::yAdvance, matcher);
+}
+
+auto GlyphXKernIs(auto matcher) {
+  return Field("xKern", &TextBackend::ShapedGlyph::xKern, matcher);
+}
+
+auto GlyphYKernIs(auto matcher) {
+  return Field("yKern", &TextBackend::ShapedGlyph::yKern, matcher);
+}
+
+auto GlyphFontSizeScaleIs(auto matcher) {
+  return Field("fontSizeScale", &TextBackend::ShapedGlyph::fontSizeScale, matcher);
+}
+
+// -- Synthetic sfnt builder ---------------------------------------------------
+// Builds a minimal TrueType font that stb_truetype accepts, with hand-authored
+// metric tables so every table-derived value asserted below is deterministic.
+
+void AppendBE16(std::vector<uint8_t>* out, uint16_t value) {
+  out->push_back(static_cast<uint8_t>((value >> 8) & 0xFF));
+  out->push_back(static_cast<uint8_t>(value & 0xFF));
+}
+
+void AppendBE32(std::vector<uint8_t>* out, uint32_t value) {
+  out->push_back(static_cast<uint8_t>((value >> 24) & 0xFF));
+  out->push_back(static_cast<uint8_t>((value >> 16) & 0xFF));
+  out->push_back(static_cast<uint8_t>((value >> 8) & 0xFF));
+  out->push_back(static_cast<uint8_t>(value & 0xFF));
+}
+
+void WriteBE16(std::vector<uint8_t>* out, size_t offset, uint16_t value) {
+  (*out)[offset + 0] = static_cast<uint8_t>((value >> 8) & 0xFF);
+  (*out)[offset + 1] = static_cast<uint8_t>(value & 0xFF);
+}
+
+struct TableSpec {
+  std::string_view tag;
+  std::vector<uint8_t> data;
+};
+
+/// Assemble an sfnt binary with sequentially packed, 4-byte-aligned tables.
+std::vector<uint8_t> MakeSfnt(const std::vector<TableSpec>& tables) {
+  std::vector<uint8_t> data;
+  AppendBE32(&data, 0x00010000);
+  AppendBE16(&data, static_cast<uint16_t>(tables.size()));
+  AppendBE16(&data, 0);
+  AppendBE16(&data, 0);
+  AppendBE16(&data, 0);
+
+  size_t offset = 12 + tables.size() * 16;
+  for (const TableSpec& table : tables) {
+    EXPECT_EQ(table.tag.size(), 4u);
+    data.push_back(static_cast<uint8_t>(table.tag[0]));
+    data.push_back(static_cast<uint8_t>(table.tag[1]));
+    data.push_back(static_cast<uint8_t>(table.tag[2]));
+    data.push_back(static_cast<uint8_t>(table.tag[3]));
+    AppendBE32(&data, 0);  // Checksum (unchecked by stb_truetype).
+    AppendBE32(&data, static_cast<uint32_t>(offset));
+    AppendBE32(&data, static_cast<uint32_t>(table.data.size()));
+    offset += (table.data.size() + 3) & ~size_t{3};
+  }
+
+  for (const TableSpec& table : tables) {
+    data.insert(data.end(), table.data.begin(), table.data.end());
+    while (data.size() % 4 != 0) {
+      data.push_back(0);
+    }
+  }
+  return data;
+}
+
+std::vector<uint8_t> HeadTable(uint16_t unitsPerEm) {
+  std::vector<uint8_t> table(54, 0);
+  WriteBE16(&table, 18, unitsPerEm);
+  // indexToLocFormat at offset 50 stays 0 (short loca offsets).
+  return table;
+}
+
+std::vector<uint8_t> HheaTable(int16_t ascent, int16_t descent, int16_t lineGap,
+                               uint16_t numHMetrics) {
+  std::vector<uint8_t> table(36, 0);
+  WriteBE16(&table, 4, static_cast<uint16_t>(ascent));
+  WriteBE16(&table, 6, static_cast<uint16_t>(descent));
+  WriteBE16(&table, 8, static_cast<uint16_t>(lineGap));
+  WriteBE16(&table, 34, numHMetrics);
+  return table;
+}
+
+std::vector<uint8_t> MaxpTable(uint16_t numGlyphs) {
+  std::vector<uint8_t> table;
+  AppendBE32(&table, 0x00005000);
+  AppendBE16(&table, numGlyphs);
+  return table;
+}
+
+std::vector<uint8_t> HmtxTable(const std::vector<uint16_t>& advances) {
+  std::vector<uint8_t> table;
+  for (const uint16_t advance : advances) {
+    AppendBE16(&table, advance);
+    AppendBE16(&table, 0);  // Left side bearing.
+  }
+  return table;
+}
+
+/// Glyph 1's outline: one contour of (0,0) on-curve, (50,100) off-curve, (100,0)
+/// on-curve, decoding to a quadratic curve segment. Padded to 24 bytes.
+std::vector<uint8_t> QuadGlyphData() {
+  std::vector<uint8_t> glyph;
+  AppendBE16(&glyph, 1);  // numberOfContours.
+  AppendBE16(&glyph, 0);  // xMin.
+  AppendBE16(&glyph, 0);  // yMin.
+  AppendBE16(&glyph, 100);  // xMax.
+  AppendBE16(&glyph, 100);  // yMax.
+  AppendBE16(&glyph, 2);  // endPtsOfContours[0]: last point index.
+  AppendBE16(&glyph, 0);  // instructionLength.
+  // Flags: bit0 on-curve, bit1 x-short, bit2 y-short, bits 4/5 positive deltas.
+  glyph.push_back(0x37);  // (0,0) on-curve.
+  glyph.push_back(0x36);  // (+50,+100) off-curve control.
+  glyph.push_back(0x17);  // (+50,-100) on-curve.
+  glyph.insert(glyph.end(), {0, 50, 50});    // x deltas.
+  glyph.insert(glyph.end(), {0, 100, 100});  // y deltas (signs from flags).
+  while (glyph.size() < 24) {
+    glyph.push_back(0);
+  }
+  return glyph;
+}
+
+/// Short-format loca: glyph 0 empty, glyph 1 = the 24-byte quad glyph, glyphs 2-3 empty.
+std::vector<uint8_t> LocaTable() {
+  std::vector<uint8_t> table;
+  for (const uint16_t halfOffset : {0, 0, 12, 12, 12}) {
+    AppendBE16(&table, halfOffset);
+  }
+  return table;
+}
+
+/// cmap with a single format-12 subtable of (start, end, startGlyphId) groups.
+std::vector<uint8_t> CmapTable(
+    const std::vector<std::tuple<uint32_t, uint32_t, uint32_t>>& groups) {
+  std::vector<uint8_t> table;
+  AppendBE16(&table, 0);   // Version.
+  AppendBE16(&table, 1);   // Number of encoding records.
+  AppendBE16(&table, 3);   // Platform: Microsoft.
+  AppendBE16(&table, 10);  // Encoding: UCS-4.
+  AppendBE32(&table, 12);  // Subtable offset.
+  AppendBE16(&table, 12);  // Format 12.
+  AppendBE16(&table, 0);   // Reserved.
+  AppendBE32(&table, static_cast<uint32_t>(16 + groups.size() * 12));  // Length.
+  AppendBE32(&table, 0);  // Language.
+  AppendBE32(&table, static_cast<uint32_t>(groups.size()));
+  for (const auto& [start, end, startGlyph] : groups) {
+    AppendBE32(&table, start);
+    AppendBE32(&table, end);
+    AppendBE32(&table, startGlyph);
+  }
+  return table;
+}
+
+/// Format-0 kern table with (left glyph, right glyph, value) pairs sorted by key.
+std::vector<uint8_t> KernTable(const std::vector<std::tuple<uint16_t, uint16_t, int16_t>>& pairs) {
+  std::vector<uint8_t> table;
+  AppendBE16(&table, 0);  // Table version.
+  AppendBE16(&table, 1);  // Number of subtables.
+  AppendBE16(&table, 0);  // Subtable version.
+  AppendBE16(&table, static_cast<uint16_t>(14 + pairs.size() * 6));  // Subtable length.
+  AppendBE16(&table, 1);  // Coverage: horizontal kerning.
+  AppendBE16(&table, static_cast<uint16_t>(pairs.size()));
+  AppendBE16(&table, 0);  // searchRange (unused by stb_truetype).
+  AppendBE16(&table, 0);  // entrySelector.
+  AppendBE16(&table, 0);  // rangeShift.
+  for (const auto& [left, right, value] : pairs) {
+    AppendBE16(&table, left);
+    AppendBE16(&table, right);
+    AppendBE16(&table, static_cast<uint16_t>(value));
+  }
+  return table;
+}
+
+std::vector<uint8_t> Os2Table(uint16_t version) {
+  std::vector<uint8_t> table(90, 0);
+  WriteBE16(&table, 0, version);
+  WriteBE16(&table, 16, 111);  // ySubscriptYOffset.
+  WriteBE16(&table, 24, 222);  // ySuperscriptYOffset.
+  WriteBE16(&table, 26, 33);   // yStrikeoutSize.
+  WriteBE16(&table, 28, 250);  // yStrikeoutPosition.
+  WriteBE16(&table, 86, 480);  // sxHeight (version >= 2 only).
+  return table;
+}
+
+std::vector<uint8_t> PostTable() {
+  std::vector<uint8_t> table(16, 0);
+  WriteBE16(&table, 8, static_cast<uint16_t>(int16_t{-120}));  // underlinePosition.
+  WriteBE16(&table, 10, 60);                                   // underlineThickness.
+  return table;
+}
+
+/// A complete minimal TrueType font: 1000 units/em, glyphs 1='A'/'a', 2='V',
+/// 3=U+4E00, with kern pairs (A,V)=-100 and (A,U+4E00)=-80.
+std::vector<uint8_t> MakeTestFontData(bool withKern, int os2Version, bool withPost) {
+  std::vector<TableSpec> tables = {
+      {"cmap", CmapTable({{'A', 'A', 1}, {'V', 'V', 2}, {'a', 'a', 1}, {0x4E00, 0x4E00, 3}})},
+      {"glyf", QuadGlyphData()},
+      {"head", HeadTable(1000)},
+      {"hhea", HheaTable(800, -200, 100, 4)},
+      {"hmtx", HmtxTable({400, 500, 600, 700})},
+      {"loca", LocaTable()},
+      {"maxp", MaxpTable(4)},
+  };
+  if (withKern) {
+    tables.push_back({"kern", KernTable({{1, 2, -100}, {1, 3, -80}})});
+  }
+  if (os2Version >= 0) {
+    tables.push_back({"OS/2", Os2Table(static_cast<uint16_t>(os2Version))});
+  }
+  if (withPost) {
+    tables.push_back({"post", PostTable()});
+  }
+  return MakeSfnt(tables);
+}
+
+class TextBackendSimpleTest : public testing::Test {
+protected:
+  FontHandle loadFont(const std::vector<uint8_t>& data) {
+    const FontHandle font = fontManager_.loadFontData(data);
+    EXPECT_TRUE(static_cast<bool>(font));
+    return font;
+  }
+
+  FontHandle fullFont() { return loadFont(MakeTestFontData(true, 2, true)); }
+
+  Registry registry_;
+  FontManager fontManager_{registry_};
+  TextBackendSimple backend_{fontManager_, registry_};
+};
+
+// -- Invalid and degenerate fonts ---------------------------------------------
+
+TEST_F(TextBackendSimpleTest, NullFontHandleYieldsEmptyResults) {
+  const FontHandle nullFont;
+
+  const FontVMetrics metrics = backend_.fontVMetrics(nullFont);
+  EXPECT_EQ(metrics.ascent, 0);
+  EXPECT_EQ(metrics.descent, 0);
+  EXPECT_EQ(metrics.xHeight, 0);
+
+  EXPECT_FLOAT_EQ(backend_.scaleForPixelHeight(nullFont, 16.0f), 0.0f);
+  EXPECT_FLOAT_EQ(backend_.scaleForEmToPixels(nullFont, 16.0f), 0.0f);
+  EXPECT_FALSE(backend_.underlineMetrics(nullFont).has_value());
+  EXPECT_FALSE(backend_.strikeoutMetrics(nullFont).has_value());
+  EXPECT_FALSE(backend_.subSuperMetrics(nullFont).has_value());
+  EXPECT_TRUE(backend_.glyphOutline(nullFont, 1, 1.0f).empty());
+  EXPECT_FALSE(backend_.isBitmapOnly(nullFont));
+  EXPECT_THAT(backend_.shapeRun(nullFont, 16.0f, "AV", 0, 2, false, FontVariant::Normal, false)
+                  .glyphs,
+              IsEmpty());
+  EXPECT_DOUBLE_EQ(backend_.crossSpanKern(nullFont, 16.0f, nullFont, 16.0f, 'A', 'V', false), 0.0);
+}
+
+TEST_F(TextBackendSimpleTest, NonOutlineFontFallsBackToHeadUnitsPerEm) {
+  // Only a head table: no glyf/CFF outlines, so stb parsing is skipped entirely.
+  const FontHandle font = loadFont(MakeSfnt({{"head", HeadTable(2048)}}));
+
+  EXPECT_TRUE(backend_.isBitmapOnly(font));
+  EXPECT_FLOAT_EQ(backend_.scaleForPixelHeight(font, 512.0f), 512.0f / 2048.0f);
+  EXPECT_FLOAT_EQ(backend_.scaleForEmToPixels(font, 512.0f), 0.0f);
+  EXPECT_EQ(backend_.fontVMetrics(font).ascent, 0);
+  EXPECT_THAT(backend_.shapeRun(font, 16.0f, "A", 0, 1, false, FontVariant::Normal, false).glyphs,
+              IsEmpty());
+}
+
+TEST_F(TextBackendSimpleTest, UnparseableOutlineFontFailsInitOnceAndCachesFailure) {
+  // A glyf tag makes HasOutlineTables() pass, but without cmap stbtt_InitFont fails.
+  const FontHandle font = loadFont(MakeSfnt({{"glyf", {0, 0, 0, 0}}, {"head", HeadTable(1000)}}));
+
+  EXPECT_EQ(backend_.fontVMetrics(font).ascent, 0);
+  // Second call hits the cached invalid parse state.
+  EXPECT_EQ(backend_.fontVMetrics(font).ascent, 0);
+  EXPECT_TRUE(backend_.glyphOutline(font, 1, 1.0f).empty());
+  EXPECT_FLOAT_EQ(backend_.scaleForPixelHeight(font, 100.0f), 0.1f);
+}
+
+// -- Table-derived metrics ----------------------------------------------------
+
+TEST_F(TextBackendSimpleTest, MetricsComeFromAuthoredTables) {
+  const FontHandle font = fullFont();
+
+  const FontVMetrics metrics = backend_.fontVMetrics(font);
+  EXPECT_EQ(metrics.ascent, 800);
+  EXPECT_EQ(metrics.descent, -200);
+  EXPECT_EQ(metrics.lineGap, 100);
+  EXPECT_EQ(metrics.xHeight, 480);
+
+  const auto underline = backend_.underlineMetrics(font);
+  ASSERT_TRUE(underline.has_value());
+  EXPECT_DOUBLE_EQ(underline->position, -120.0);
+  EXPECT_DOUBLE_EQ(underline->thickness, 60.0);
+
+  const auto strikeout = backend_.strikeoutMetrics(font);
+  ASSERT_TRUE(strikeout.has_value());
+  EXPECT_DOUBLE_EQ(strikeout->thickness, 33.0);
+  EXPECT_DOUBLE_EQ(strikeout->position, 250.0);
+
+  const auto subSuper = backend_.subSuperMetrics(font);
+  ASSERT_TRUE(subSuper.has_value());
+  EXPECT_EQ(subSuper->subscriptYOffset, 111);
+  EXPECT_EQ(subSuper->superscriptYOffset, 222);
+
+  EXPECT_FLOAT_EQ(backend_.scaleForPixelHeight(font, 100.0f), 0.1f);
+  EXPECT_FLOAT_EQ(backend_.scaleForEmToPixels(font, 100.0f), 0.1f);
+  EXPECT_FALSE(backend_.isBitmapOnly(font));
+}
+
+TEST_F(TextBackendSimpleTest, Os2VersionBelowTwoOmitsXHeight) {
+  const FontHandle font = loadFont(MakeTestFontData(false, 1, false));
+
+  const FontVMetrics metrics = backend_.fontVMetrics(font);
+  EXPECT_EQ(metrics.ascent, 800);
+  EXPECT_EQ(metrics.xHeight, 0);
+}
+
+TEST_F(TextBackendSimpleTest, MissingOs2AndPostTablesYieldNullopt) {
+  const FontHandle font = loadFont(MakeTestFontData(false, -1, false));
+
+  EXPECT_FALSE(backend_.underlineMetrics(font).has_value());
+  EXPECT_FALSE(backend_.strikeoutMetrics(font).has_value());
+  EXPECT_FALSE(backend_.subSuperMetrics(font).has_value());
+  // Vertical metrics still come from hhea.
+  EXPECT_EQ(backend_.fontVMetrics(font).ascent, 800);
+}
+
+// -- Shaping ------------------------------------------------------------------
+
+TEST_F(TextBackendSimpleTest, ShapeRunAppliesHorizontalKerning) {
+  const FontHandle font = fullFont();
+
+  // 100px at 1000 units/em scales design units by 0.1 (as a float).
+  const auto shaped =
+      backend_.shapeRun(font, 100.0f, "AV", 0, 2, false, FontVariant::Normal, false);
+  EXPECT_THAT(shaped.glyphs,
+              ElementsAre(AllOf(GlyphIndexIs(1), GlyphXAdvanceIs(DoubleNear(50.0, 1e-4)),
+                                GlyphXKernIs(DoubleEq(0.0))),
+                          AllOf(GlyphIndexIs(2), GlyphXAdvanceIs(DoubleNear(60.0, 1e-4)),
+                                GlyphXKernIs(DoubleNear(-10.0, 1e-4)),
+                                GlyphYKernIs(DoubleEq(0.0)))));
+}
+
+TEST_F(TextBackendSimpleTest, ShapeRunVerticalLatinUsesSidewaysAdvancesAndVerticalKern) {
+  const FontHandle font = fullFont();
+
+  const auto shaped = backend_.shapeRun(font, 100.0f, "AV", 0, 2, true, FontVariant::Normal, false);
+  EXPECT_THAT(shaped.glyphs,
+              ElementsAre(AllOf(GlyphXAdvanceIs(DoubleEq(0.0)),
+                                GlyphYAdvanceIs(DoubleNear(50.0, 1e-4))),
+                          AllOf(GlyphXAdvanceIs(DoubleEq(0.0)),
+                                GlyphYAdvanceIs(DoubleNear(60.0, 1e-4)),
+                                GlyphYKernIs(DoubleNear(-10.0, 1e-4)),
+                                GlyphXKernIs(DoubleEq(0.0)))));
+}
+
+TEST_F(TextBackendSimpleTest, ShapeRunVerticalCjkAdvancesByEmHeight) {
+  const FontHandle font = fullFont();
+
+  // U+4E00 in vertical mode: upright glyph, advance equals the font size.
+  const auto shaped = backend_.shapeRun(font, 100.0f, "\xE4\xB8\x80", 0, 3, true,
+                                        FontVariant::Normal, false);
+  EXPECT_THAT(shaped.glyphs,
+              ElementsAre(AllOf(GlyphIndexIs(3), GlyphXAdvanceIs(DoubleEq(0.0)),
+                                GlyphYAdvanceIs(DoubleEq(100.0)))));
+}
+
+TEST_F(TextBackendSimpleTest, ShapeRunZeroFontSizeReturnsEmpty) {
+  const FontHandle font = fullFont();
+
+  const auto shaped = backend_.shapeRun(font, 0.0f, "AV", 0, 2, false, FontVariant::Normal, false);
+  EXPECT_THAT(shaped.glyphs, IsEmpty());
+}
+
+TEST_F(TextBackendSimpleTest, SmallCapsSynthesisUppercasesAndScalesLowercase) {
+  const FontHandle font = fullFont();
+
+  const auto shaped =
+      backend_.shapeRun(font, 100.0f, "aV", 0, 2, false, FontVariant::SmallCaps, false);
+  // 'a' maps to the 'A' glyph at 80% scale; kerning still uses the full-size scale.
+  EXPECT_THAT(shaped.glyphs,
+              ElementsAre(AllOf(GlyphIndexIs(1), GlyphFontSizeScaleIs(FloatEq(0.8f)),
+                                GlyphXAdvanceIs(DoubleNear(40.0, 1e-4))),
+                          AllOf(GlyphIndexIs(2), GlyphFontSizeScaleIs(FloatEq(1.0f)),
+                                GlyphXAdvanceIs(DoubleNear(60.0, 1e-4)),
+                                GlyphXKernIs(DoubleNear(-10.0, 1e-4)))));
+}
+
+// -- Cross-span kerning -------------------------------------------------------
+
+TEST_F(TextBackendSimpleTest, CrossSpanKernAppliesPerWritingModeAndOrientation) {
+  const FontHandle font = fullFont();
+
+  // Horizontal: kern pair (A, V) = -100 units at scale 0.1.
+  EXPECT_NEAR(backend_.crossSpanKern(font, 100.0f, font, 100.0f, 'A', 'V', false), -10.0, 1e-4);
+  // Vertical sideways Latin still kerns along the advance direction.
+  EXPECT_NEAR(backend_.crossSpanKern(font, 100.0f, font, 100.0f, 'A', 'V', true), -10.0, 1e-4);
+  // Horizontal kerning against an upright CJK codepoint.
+  EXPECT_NEAR(backend_.crossSpanKern(font, 100.0f, font, 100.0f, 'A', 0x4E00, false), -8.0, 1e-4);
+  // Vertical upright CJK never kerns, even with a matching kern pair.
+  EXPECT_DOUBLE_EQ(backend_.crossSpanKern(font, 100.0f, font, 100.0f, 'A', 0x4E00, true), 0.0);
+  // No kern pair defined in the (V, A) direction.
+  EXPECT_DOUBLE_EQ(backend_.crossSpanKern(font, 100.0f, font, 100.0f, 'V', 'A', false), 0.0);
+}
+
+// -- Glyph outlines -----------------------------------------------------------
+
+TEST_F(TextBackendSimpleTest, GlyphOutlineEmptyForEmptyGlyph) {
+  const FontHandle font = fullFont();
+
+  // Glyph 2 ('V') has a zero-length glyf entry.
+  EXPECT_TRUE(backend_.glyphOutline(font, 2, 0.1f).empty());
+}
+
+TEST_F(TextBackendSimpleTest, GlyphOutlineDecodesQuadraticSegmentsWithFlippedY) {
+  const FontHandle font = fullFont();
+
+  // Glyph 1 is a single quadratic contour; Y flips from font-up to SVG-down.
+  const Path path = backend_.glyphOutline(font, 1, 0.1f);
+  ASSERT_FALSE(path.empty());
+
+  const bool hasQuad =
+      std::any_of(path.commands().begin(), path.commands().end(), [](const auto& command) {
+        return command.verb == Path::Verb::QuadTo;
+      });
+  EXPECT_TRUE(hasQuad);
+
+  const Box2d bounds = path.bounds();
+  EXPECT_NEAR(bounds.topLeft.x, 0.0, 1e-4);
+  EXPECT_NEAR(bounds.bottomRight.x, 10.0, 1e-4);
+  EXPECT_LT(bounds.topLeft.y, 0.0);        // Above the baseline in SVG coordinates.
+  EXPECT_NEAR(bounds.bottomRight.y, 0.0, 1e-4);
+}
+
+TEST_F(TextBackendSimpleTest, GlyphOutlineDecodesCurveSegmentsFromRealFont) {
+  const FontHandle font = fontManager_.fallbackFont();
+  ASSERT_TRUE(static_cast<bool>(font));
+
+  const auto shaped = backend_.shapeRun(font, 100.0f, "O", 0, 1, false, FontVariant::Normal, false);
+  ASSERT_THAT(shaped.glyphs, ElementsAre(GlyphIndexIs(testing::Gt(0))));
+
+  const Path path =
+      backend_.glyphOutline(font, shaped.glyphs[0].glyphIndex, 0.1f);
+  ASSERT_FALSE(path.empty());
+
+  // The letter 'O' must contain curve segments (quadratic for TrueType outlines,
+  // cubic for CFF outlines).
+  const bool hasCurves =
+      std::any_of(path.commands().begin(), path.commands().end(), [](const auto& command) {
+        return command.verb == Path::Verb::QuadTo || command.verb == Path::Verb::CurveTo;
+      });
+  EXPECT_TRUE(hasCurves);
+}
+
+// -- Capability contracts -----------------------------------------------------
+
+TEST_F(TextBackendSimpleTest, SimpleBackendHasNoAdvancedCapabilities) {
+  const FontHandle font = fullFont();
+
+  EXPECT_FALSE(backend_.isCursive('A'));
+  EXPECT_FALSE(backend_.isCursive(0x0627));  // Arabic alef: cursive in the full backend only.
+  EXPECT_FALSE(backend_.hasSmallCapsFeature(font));
+  EXPECT_FALSE(backend_.bitmapGlyph(font, 1, 1.0f).has_value());
+}
+
+}  // namespace
+}  // namespace donner::svg


### PR DESCRIPTION
## Summary

Adds 42 behavioral test cases covering previously-untested branches of `donner/svg/text/TextEngine.cc` and `donner/svg/text/TextBackendSimple.cc`: engine layout guards and fallbacks (per-span style resolution, coverage-based font fallback, cross-span kerning, textLength spacing, inline-size wrapping edge cases, geometry-cache glyph extents) and the simple text backend's full metrics/kerning/decoding surface.

Coverage PR 6 in the ranked campaign toward a 92% Codecov project number. Test-only change: 1,324 insertions across three test files plus one new lightweight unit test target; no production or config changes.

## How the backend tests get deterministic values

`TextBackendSimple_tests.cc` is built around a hand-authored minimal TrueType font (format-12 cmap, format-0 kern, OS/2, post, one real quadratic glyph), so every metric, kern pair, advance, and decoded outline point asserted is exact by construction: null-handle empties, non-outline upem fallback, cached parse failure, OS/2 v1 xHeight omission, missing-table nullopts, horizontal/vertical kerning, CJK em-height advance, zero-font-size guard, small-caps synthesis (glyph a -> A at 0.8 scale, 40px advance), per-orientation crossSpanKern including vertical-CJK suppression, quad decoding with Y flip, CFF cubic decoding via the embedded fallback font.

Engine tests use injected scripted backends and assert concrete outputs: exact kern shifts (3px horizontal / 4px vertical) at span boundaries, end-anchored chunk shifts (-21/-10) that skip on-path runs, the 1.2 * font-size line-height fallback (24px stacking), translated quadratic/cubic control points from the geometry cache, and registry state for the early-return guards.

## Coverage delta (local `tools/coverage.sh` over the svg text test targets, Codecov-style: partials count as uncovered)

| File | Before | After |
|---|---|---|
| donner/svg/text/TextEngine.cc | 1202/141/101 h/m/p | 1349/14/81 |
| donner/svg/text/TextBackendSimple.cc | 150/76/32 | 247/3/8 |

**+244 lines converted to fully covered** in the local measurement. Note: the local baseline is the default-config subset, so some of those lines (about 60-100) are already covered on main by the text-full variant lanes; the realized Codecov project delta is projected at **+0.22 to +0.37pp** and will be verified after merge.

## Deliberately left uncovered (defensive / artifacts)

- `!font` guard in fontSupportsCodepoint (layout always resolves a non-null font via fallbackFont(), candidates null-checked before probing).
- `return 0.0` after an exhaustive DominantBaseline switch; localCharIndex bound guard satisfied by construction of byteToApiCharIdx.
- textPath explicit-x/perpendicular-shift lines are covered on main by text-full-only suites; not duplicated here.
- Case-closing braces and a `default: break` for vertex types stbtt never emits (llvm-cov artifacts).

## Quality

- No assertion-free tests; follows the existing scripted-backend and SVG-parsed test idioms.
- CI cost: one new small unit target (`text_backend_simple_tests`, sub-second, no data deps); everything else rides existing targets. All six affected targets pass unfiltered in both default and text-full configs.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
