### PR TITLE
test(editor): cover SourceDiagnosticsPanel, SamplePicker, and TextFormatBar presenters

### DIFF
--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -90,8 +90,11 @@ donner_cc_test(
     name = "sample_picker_presenter_tests",
     srcs = ["SamplePickerPresenter_tests.cc"],
     deps = [
+        "//donner/editor:editor_sample_catalog",
+        "//donner/editor:imgui_headers",
         "//donner/editor:sample_picker_presenter",
         "@com_google_gtest//:gtest_main",
+        "@imgui",
     ],
 )
 

--- a/donner/editor/tests/SamplePickerPresenter_tests.cc
+++ b/donner/editor/tests/SamplePickerPresenter_tests.cc
@@ -2,8 +2,18 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <array>
+#include <cstddef>
+#include <limits>
+#include <span>
+#include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
+
+#include "donner/editor/EditorSampleCatalog.h"
+#include "donner/editor/ImGuiIncludes.h"
 
 namespace donner::editor {
 namespace {
@@ -39,6 +49,13 @@ TEST(SamplePickerPresenter, LayoutClampsInvalidWidthAndVisibleCount) {
   EXPECT_EQ(layout.columns, 1u);
   EXPECT_EQ(layout.rows, kSamplePickerMaxVisibleSamples);
   EXPECT_FLOAT_EQ(layout.cardWidth, 0.0f);
+
+  // Non-finite widths clamp to zero as well.
+  const SamplePickerLayout infiniteLayout =
+      ComputeSamplePickerLayout(std::numeric_limits<float>::infinity(), 4u);
+  EXPECT_EQ(infiniteLayout.mode, SamplePickerLayoutMode::Narrow);
+  EXPECT_EQ(infiniteLayout.columns, 1u);
+  EXPECT_FLOAT_EQ(infiniteLayout.cardWidth, 0.0f);
 }
 
 TEST(SamplePickerPresenter, EmptyCatalogLayoutHasNoRowsOrColumns) {
@@ -97,6 +114,216 @@ TEST(SamplePickerPresenter, CommandsIgnoreEmptySampleAndNullAccumulator) {
 
   ApplySamplePickerCommand(true, SamplePickerCommand::OpenGitHub, {}, nullptr);
   EXPECT_FALSE(actions.openGitHub);
+}
+
+// ---------------------------------------------------------------------------
+// Rendered picker behavior (headless ImGui)
+// ---------------------------------------------------------------------------
+
+/// True when no action flag is set on @p actions.
+bool NoActions(const SamplePickerActions& actions) {
+  return !actions.dismiss && !actions.openFile && !actions.loadSample && !actions.openGitHub &&
+         actions.sampleId.empty();
+}
+
+/// Accumulate every edge-triggered flag from @p frame into @p merged.
+void MergeActions(SamplePickerActions& merged, const SamplePickerActions& frame) {
+  merged.dismiss = merged.dismiss || frame.dismiss;
+  merged.openFile = merged.openFile || frame.openFile;
+  merged.loadSample = merged.loadSample || frame.loadSample;
+  merged.openGitHub = merged.openGitHub || frame.openGitHub;
+  if (!frame.sampleId.empty()) {
+    merged.sampleId = frame.sampleId;
+  }
+}
+
+class SamplePickerPresenterImGuiTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    IMGUI_CHECKVERSION();
+    context_ = ImGui::CreateContext();
+    ImGuiIO& io = ImGui::GetIO();
+    io.DisplaySize = ImVec2(1200.0f, 800.0f);
+    io.DeltaTime = 1.0f / 60.0f;
+    io.ConfigMacOSXBehaviors = false;
+    io.Fonts->Build();
+  }
+
+  void TearDown() override {
+    ImGui::DestroyContext(context_);
+    context_ = nullptr;
+  }
+
+  /// Render one picker frame in a host window of the given width.
+  SamplePickerActions Frame(const SamplePickerState& state,
+                            const SamplePickerThumbnailProvider& provider, float hostWidth,
+                            const ImVec2& mouse = ImVec2(-100.0f, -100.0f),
+                            bool mouseDown = false) {
+    ImGuiIO& io = ImGui::GetIO();
+    io.DisplaySize = ImVec2(1200.0f, 800.0f);
+    io.AddMousePosEvent(mouse.x, mouse.y);
+    io.AddMouseButtonEvent(0, mouseDown);
+    ImGui::NewFrame();
+    ImGui::SetNextWindowPos(ImVec2(0.0f, 0.0f), ImGuiCond_Always);
+    ImGui::SetNextWindowSize(ImVec2(hostWidth, 760.0f), ImGuiCond_Always);
+    ImGui::Begin("##sample_picker_host", nullptr,
+                 ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
+                     ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoScrollbar);
+    const SamplePickerActions actions = presenter_.render(state, provider);
+    ImGui::End();
+    ImGui::Render();
+    const ImDrawData* drawData = ImGui::GetDrawData();
+    lastVertexCount_ = drawData != nullptr ? drawData->TotalVtxCount : 0;
+    return actions;
+  }
+
+  /// Simulate a full left-button click (press frame + release frame) at
+  /// @p mouse and return the merged actions of both frames.
+  SamplePickerActions Click(const SamplePickerState& state,
+                            const SamplePickerThumbnailProvider& provider, float hostWidth,
+                            const ImVec2& mouse) {
+    SamplePickerActions merged = Frame(state, provider, hostWidth, mouse, /*mouseDown=*/true);
+    MergeActions(merged, Frame(state, provider, hostWidth, mouse, /*mouseDown=*/false));
+    return merged;
+  }
+
+  SamplePickerPresenter presenter_;
+  int lastVertexCount_ = 0;
+
+private:
+  ImGuiContext* context_ = nullptr;
+};
+
+TEST_F(SamplePickerPresenterImGuiTest, HiddenPickerEmitsNothingAndSkipsDrawing) {
+  SamplePickerState hidden;
+  hidden.visible = false;
+
+  EXPECT_TRUE(NoActions(Frame(hidden, {}, 1024.0f)));
+  const int hiddenVertexCount = lastVertexCount_;
+
+  EXPECT_TRUE(NoActions(Frame(SamplePickerState{}, {}, 1024.0f)));
+  EXPECT_GT(lastVertexCount_, hiddenVertexCount);
+}
+
+TEST_F(SamplePickerPresenterImGuiTest, RenderRequestsOneThumbnailPerVisibleCatalogSample) {
+  const std::span<const EditorSample> samples = GetEditorSampleCatalog();
+  ASSERT_FALSE(samples.empty());
+
+  SamplePickerState state;
+  state.selectedSampleId = samples.front().id;  // Exercises the selected-card styling.
+
+  std::vector<std::pair<std::string, std::size_t>> requests;
+  const SamplePickerThumbnailProvider provider =
+      [&requests](const EditorSample& sample, std::size_t index) {
+        requests.emplace_back(std::string(sample.id), index);
+        SamplePickerThumbnail thumbnail;
+        // Alternate landscape/portrait art so both letterbox arms are drawn.
+        thumbnail.texture = static_cast<ImTextureID>(0x1234);
+        thumbnail.aspectRatio = index % 2 == 0 ? 1.8f : 0.5f;
+        return thumbnail;
+      };
+
+  // A wide pane lays the catalog out in a multi-column grid; rendering asks
+  // the provider for exactly one thumbnail per visible sample, in order.
+  EXPECT_TRUE(NoActions(Frame(state, provider, 1024.0f)));
+  const std::size_t visibleCount = std::min(samples.size(), kSamplePickerMaxVisibleSamples);
+  ASSERT_EQ(requests.size(), visibleCount);
+  for (std::size_t i = 0; i < visibleCount; ++i) {
+    EXPECT_EQ(requests[i].first, std::string_view(samples[i].id));
+    EXPECT_EQ(requests[i].second, i);
+  }
+
+  // Without a provider the cards render placeholder art and still emit no
+  // actions; the frame draws fewer vertices than the thumbnail-backed frame.
+  const int thumbnailVertexCount = lastVertexCount_;
+  EXPECT_TRUE(NoActions(Frame(state, {}, 1024.0f)));
+  EXPECT_LT(lastVertexCount_, thumbnailVertexCount);
+}
+
+TEST_F(SamplePickerPresenterImGuiTest, ClickingDismissButtonEmitsDismiss) {
+  const SamplePickerState state;
+  constexpr float kHostWidth = 1024.0f;
+
+  Frame(state, {}, kHostWidth);  // Warm-up frame for hover state.
+
+  // The dismiss button is a 44px square hugging the top-right content edge;
+  // probe leftward along its row.
+  SamplePickerActions dismissed;
+  for (float x = 1014.0f; x >= 900.0f; x -= 6.0f) {
+    const SamplePickerActions actions = Click(state, {}, kHostWidth, ImVec2(x, 30.0f));
+    EXPECT_FALSE(actions.openFile);
+    EXPECT_FALSE(actions.loadSample);
+    EXPECT_FALSE(actions.openGitHub);
+    if (actions.dismiss) {
+      dismissed = actions;
+      break;
+    }
+  }
+
+  EXPECT_TRUE(dismissed.dismiss) << "Dismiss button not found along the top-right edge";
+}
+
+TEST_F(SamplePickerPresenterImGuiTest, ClickingActionButtonsEmitsOpenFileAndOpenGitHub) {
+  const SamplePickerState state;
+  constexpr float kHostWidth = 1024.0f;
+
+  Frame(state, {}, kHostWidth);
+
+  // The "Open SVG" button hugs the left content edge below the heading text;
+  // its vertical position depends on font metrics, so probe downward.
+  float openRowY = -1.0f;
+  for (float y = 56.0f; y <= 400.0f; y += 6.0f) {
+    const SamplePickerActions actions = Click(state, {}, kHostWidth, ImVec2(60.0f, y));
+    EXPECT_FALSE(actions.dismiss);
+    EXPECT_FALSE(actions.loadSample);
+    if (actions.openFile) {
+      openRowY = y;
+      break;
+    }
+  }
+  ASSERT_GT(openRowY, 0.0f) << "Open SVG button not found along the left edge";
+
+  // The GitHub action sits on the same row, right of the 112px-wide Open SVG
+  // button (8px gap).
+  bool openedGitHub = false;
+  for (float x = 132.0f; x <= 300.0f; x += 12.0f) {
+    const SamplePickerActions actions = Click(state, {}, kHostWidth, ImVec2(x, openRowY));
+    EXPECT_FALSE(actions.dismiss);
+    EXPECT_FALSE(actions.loadSample);
+    if (actions.openGitHub) {
+      openedGitHub = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(openedGitHub) << "GitHub action button not found on the Open SVG row";
+}
+
+TEST_F(SamplePickerPresenterImGuiTest, ClickingFirstSampleCardLoadsThatSample) {
+  const std::span<const EditorSample> samples = GetEditorSampleCatalog();
+  ASSERT_FALSE(samples.empty());
+
+  SamplePickerState state;
+  if (samples.size() > 1u) {
+    state.selectedSampleId = samples[1].id;  // Selected styling on an unclicked card.
+  }
+
+  // A narrow pane stacks full-width cards in one column, so the first card
+  // encountered scanning down the pane center is the first catalog entry.
+  constexpr float kHostWidth = 500.0f;
+  Frame(state, {}, kHostWidth);
+
+  SamplePickerActions loaded;
+  for (float y = 56.0f; y <= 740.0f; y += 8.0f) {
+    const SamplePickerActions actions = Click(state, {}, kHostWidth, ImVec2(250.0f, y));
+    EXPECT_FALSE(actions.dismiss);
+    if (actions.loadSample) {
+      loaded = actions;
+      break;
+    }
+  }
+
+  ASSERT_TRUE(loaded.loadSample) << "No sample card found scanning down the narrow pane";
+  EXPECT_EQ(loaded.sampleId, std::string_view(samples.front().id));
 }
 
 }  // namespace

--- a/donner/editor/tests/SourceDiagnosticsPanel_tests.cc
+++ b/donner/editor/tests/SourceDiagnosticsPanel_tests.cc
@@ -3,6 +3,11 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <cstdint>
+#include <optional>
+#include <span>
+
+#include "donner/editor/ImGuiIncludes.h"
 
 namespace donner::editor {
 namespace {
@@ -18,6 +23,150 @@ TEST(SourceDiagnosticsPanel, CountsSeverityAndFindsStableId) {
   ASSERT_NE(FindSourceDiagnostic(diagnostics, 12), nullptr);
   EXPECT_EQ(FindSourceDiagnostic(diagnostics, 12)->severity, DiagnosticSeverity::Error);
   EXPECT_EQ(FindSourceDiagnostic(diagnostics, 99), nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// Rendered panel behavior (headless ImGui)
+// ---------------------------------------------------------------------------
+
+class SourceDiagnosticsPanelImGuiTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    IMGUI_CHECKVERSION();
+    context_ = ImGui::CreateContext();
+    ImGuiIO& io = ImGui::GetIO();
+    io.DisplaySize = ImVec2(400.0f, 300.0f);
+    io.DeltaTime = 1.0f / 60.0f;
+    io.ConfigMacOSXBehaviors = false;
+    io.Fonts->Build();
+  }
+
+  void TearDown() override {
+    ImGui::DestroyContext(context_);
+    context_ = nullptr;
+  }
+
+  /// Render one panel frame in a fixed 400x300 host window with the given
+  /// mouse state, returning the panel's per-frame action.
+  SourceDiagnosticsPanelAction Frame(std::span<const SourceDiagnostic> diagnostics,
+                                     std::optional<std::uint64_t> sourceHoveredId, float height,
+                                     const ImVec2& mouse = ImVec2(-100.0f, -100.0f),
+                                     bool mouseDown = false) {
+    ImGuiIO& io = ImGui::GetIO();
+    io.DisplaySize = ImVec2(400.0f, 300.0f);
+    io.AddMousePosEvent(mouse.x, mouse.y);
+    io.AddMouseButtonEvent(0, mouseDown);
+    ImGui::NewFrame();
+    ImGui::SetNextWindowPos(ImVec2(0.0f, 0.0f), ImGuiCond_Always);
+    ImGui::SetNextWindowSize(ImVec2(400.0f, 300.0f), ImGuiCond_Always);
+    ImGui::Begin("##diagnostics_host", nullptr,
+                 ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
+                     ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoScrollbar);
+    const SourceDiagnosticsPanelAction action = panel_.render(diagnostics, sourceHoveredId, height);
+    ImGui::End();
+    ImGui::Render();
+    const ImDrawData* drawData = ImGui::GetDrawData();
+    lastVertexCount_ = drawData != nullptr ? drawData->TotalVtxCount : 0;
+    return action;
+  }
+
+  /// Screen-space center of a diagnostics row. The host window sits at (0, 0)
+  /// with the default (8, 8) window padding; the panel draws a 34px header
+  /// (at the default font scale) above 30px rows.
+  static ImVec2 RowCenter(std::size_t rowIndex) {
+    constexpr float kPadding = 8.0f;
+    constexpr float kHeaderHeight = 34.0f;
+    constexpr float kRowHeight = 30.0f;
+    return ImVec2(190.0f,
+                  kPadding + kHeaderHeight + kRowHeight * (static_cast<float>(rowIndex) + 0.5f));
+  }
+
+  SourceDiagnosticsPanel panel_;
+  int lastVertexCount_ = 0;
+
+private:
+  ImGuiContext* context_ = nullptr;
+};
+
+TEST_F(SourceDiagnosticsPanelImGuiTest, EmptyDiagnosticsOrZeroHeightRenderNothing) {
+  const std::array diagnostics = {
+      SourceDiagnostic{.id = 1, .severity = DiagnosticSeverity::Error, .message = "boom"},
+  };
+
+  SourceDiagnosticsPanelAction action = Frame({}, std::nullopt, 120.0f);
+  EXPECT_FALSE(action.hoveredId.has_value());
+  EXPECT_FALSE(action.activatedId.has_value());
+  const int emptyVertexCount = lastVertexCount_;
+
+  action = Frame(diagnostics, std::nullopt, 0.0f);
+  EXPECT_FALSE(action.hoveredId.has_value());
+  EXPECT_FALSE(action.activatedId.has_value());
+  EXPECT_EQ(lastVertexCount_, emptyVertexCount);
+
+  // A populated panel with a positive height draws header and row content.
+  Frame(diagnostics, std::nullopt, 120.0f);
+  EXPECT_GT(lastVertexCount_, emptyVertexCount);
+}
+
+TEST_F(SourceDiagnosticsPanelImGuiTest, HoverReportsRowAndClickActivatesIt) {
+  const std::array diagnostics = {
+      SourceDiagnostic{
+          .id = 21, .severity = DiagnosticSeverity::Error, .line = 3, .column = 4,
+          .message = "unexpected token"},
+      SourceDiagnostic{
+          .id = 22, .severity = DiagnosticSeverity::Warning, .line = 9, .column = 0,
+          .message = "unused attribute"},
+  };
+  constexpr float kHeight = 160.0f;
+
+  // Warm-up frame: hover resolves against the previous frame's window layout.
+  Frame(diagnostics, std::nullopt, kHeight, RowCenter(0));
+
+  SourceDiagnosticsPanelAction action = Frame(diagnostics, std::nullopt, kHeight, RowCenter(0));
+  EXPECT_EQ(action.hoveredId, std::optional<std::uint64_t>(21));
+  EXPECT_FALSE(action.activatedId.has_value());
+
+  // Pressing the left button on the hovered row activates it.
+  action = Frame(diagnostics, std::nullopt, kHeight, RowCenter(0), /*mouseDown=*/true);
+  EXPECT_EQ(action.activatedId, std::optional<std::uint64_t>(21));
+  Frame(diagnostics, std::nullopt, kHeight, RowCenter(0));  // Release.
+
+  // The second row reports its own id on hover.
+  Frame(diagnostics, std::nullopt, kHeight, RowCenter(1));
+  action = Frame(diagnostics, std::nullopt, kHeight, RowCenter(1));
+  EXPECT_EQ(action.hoveredId, std::optional<std::uint64_t>(22));
+  EXPECT_FALSE(action.activatedId.has_value());
+
+  // Off-panel mouse reports nothing.
+  Frame(diagnostics, std::nullopt, kHeight);
+  action = Frame(diagnostics, std::nullopt, kHeight);
+  EXPECT_FALSE(action.hoveredId.has_value());
+  EXPECT_FALSE(action.activatedId.has_value());
+}
+
+TEST_F(SourceDiagnosticsPanelImGuiTest, SourceHoverHighlightsRowWithoutEmittingActions) {
+  const std::array diagnostics = {
+      SourceDiagnostic{.id = 31, .severity = DiagnosticSeverity::Error, .message = "first"},
+      SourceDiagnostic{.id = 32, .severity = DiagnosticSeverity::Error, .message = "second"},
+      SourceDiagnostic{.id = 33, .severity = DiagnosticSeverity::Warning, .message = "third"},
+      SourceDiagnostic{.id = 34, .severity = DiagnosticSeverity::Warning, .message = "fourth"},
+  };
+  constexpr float kHeight = 200.0f;
+
+  // Exercise the clamped font-scale path alongside the highlight comparison.
+  ImGui::GetIO().FontGlobalScale = 0.5f;
+
+  Frame(diagnostics, std::nullopt, kHeight);
+  SourceDiagnosticsPanelAction action = Frame(diagnostics, std::nullopt, kHeight);
+  EXPECT_FALSE(action.hoveredId.has_value());
+  const int plainVertexCount = lastVertexCount_;
+
+  // A source-side hover id draws the selection rect for that row (extra
+  // vertices) but must not report hover or activation back to the caller.
+  action = Frame(diagnostics, std::optional<std::uint64_t>(32), kHeight);
+  EXPECT_FALSE(action.hoveredId.has_value());
+  EXPECT_FALSE(action.activatedId.has_value());
+  EXPECT_GT(lastVertexCount_, plainVertexCount);
 }
 
 }  // namespace

--- a/donner/editor/tests/TextFormatBarPresenter_tests.cc
+++ b/donner/editor/tests/TextFormatBarPresenter_tests.cc
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -77,6 +78,42 @@ TEST(TextFormatBarPresenterActionsTest, ReadsDefaultsWhenStyleAttributesAbsent) 
 
   EXPECT_TRUE(state.fontFamily.empty());
   EXPECT_FALSE(state.hasFontSize);
+  EXPECT_FALSE(state.bold);
+  EXPECT_FALSE(state.italic);
+  EXPECT_FALSE(state.underline);
+}
+
+TEST(TextFormatBarPresenterActionsTest, ReadsUnparseableFontSizeAsAbsent) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+           <text id="t" font-size="large">Hi</text>
+         </svg>)"));
+  const std::optional<svg::SVGElement> text = app.document().document().querySelector("#t");
+  ASSERT_TRUE(text.has_value());
+
+  FormatBarState state;
+  ReadTextFormatState(*text, &state);
+
+  // "large" has no leading number, so the size control shows no resolved size.
+  EXPECT_FALSE(state.hasFontSize);
+  EXPECT_FLOAT_EQ(state.fontSize, 0.0f);
+}
+
+TEST(TextFormatBarPresenterActionsTest, ReadsNonMatchingStyleValuesAsUnset) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+           <text id="t" font-weight="500" font-style="oblique"
+                 text-decoration="line-through">Hi</text>
+         </svg>)"));
+  const std::optional<svg::SVGElement> text = app.document().document().querySelector("#t");
+  ASSERT_TRUE(text.has_value());
+
+  FormatBarState state;
+  ReadTextFormatState(*text, &state);
+
+  // Values other than bold/italic/underline do not light up the toggles.
   EXPECT_FALSE(state.bold);
   EXPECT_FALSE(state.italic);
   EXPECT_FALSE(state.underline);
@@ -204,6 +241,30 @@ TEST(TextFormatBarPresenterActionsTest, TogglesSkippedWhenRoutedToEditingSession
   EXPECT_FALSE(ApplyFormatBarActionsToSelection(actions, state,
                                                 /*routeTogglesToSelection=*/false, app));
   EXPECT_FALSE(app.flushFrame());
+  EXPECT_EQ(TextAttribute(app, "font-weight"), std::nullopt);
+}
+
+TEST(TextFormatBarPresenterActionsTest, ActionsWithEmptySelectionQueueNothing) {
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(
+      R"(<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+           <text id="t">Hi</text>
+         </svg>)"));
+  // No selection: every attribute write is refused, so nothing is queued even
+  // with all actions raised.
+  FormatBarActions actions;
+  actions.setFontFamily = true;
+  actions.fontFamily = "Roboto";
+  actions.setFontSize = true;
+  actions.fontSize = 18.0f;
+  actions.toggleBold = true;
+  actions.toggleItalic = true;
+  actions.toggleUnderline = true;
+
+  EXPECT_FALSE(ApplyFormatBarActionsToSelection(actions, FormatBarState{},
+                                                /*routeTogglesToSelection=*/true, app));
+  EXPECT_FALSE(app.flushFrame());
+  EXPECT_EQ(TextAttribute(app, "font-family"), std::nullopt);
   EXPECT_EQ(TextAttribute(app, "font-weight"), std::nullopt);
 }
 
@@ -343,6 +404,290 @@ TEST_F(TextFormatBarPresenterTest, VisibleBarRendersControlsWithoutImplicitActio
   EXPECT_FALSE(actions.toggleBold);
   EXPECT_FALSE(actions.toggleItalic);
   EXPECT_FALSE(actions.toggleUnderline);
+}
+
+// ---------------------------------------------------------------------------
+// Interactive control behavior (headless ImGui with simulated mouse/keyboard)
+// ---------------------------------------------------------------------------
+
+/// Accumulate every edge-triggered flag from @p frame into @p merged.
+void MergeActions(FormatBarActions& merged, const FormatBarActions& frame) {
+  if (frame.setFontFamily) {
+    merged.setFontFamily = true;
+    merged.fontFamily = frame.fontFamily;
+  }
+  if (frame.setFontSize) {
+    merged.setFontSize = true;
+    merged.fontSize = frame.fontSize;
+  }
+  merged.toggleBold = merged.toggleBold || frame.toggleBold;
+  merged.toggleItalic = merged.toggleItalic || frame.toggleItalic;
+  merged.toggleUnderline = merged.toggleUnderline || frame.toggleUnderline;
+}
+
+class TextFormatBarPresenterInputTest : public ::testing::Test {
+protected:
+  // The bar is placed at a fixed spot with its 8px window padding, so control
+  // positions are derived from ImGui frame metrics captured during rendering.
+  static constexpr float kBarX = 320.0f;
+  static constexpr float kBarY = 80.0f;
+  static constexpr float kPadding = 8.0f;
+  static constexpr float kFamilyInputWidth = 180.0f;
+  static constexpr float kSizeDragWidth = 64.0f;
+
+  void SetUp() override {
+    IMGUI_CHECKVERSION();
+    context_ = ImGui::CreateContext();
+    ImGuiIO& io = ImGui::GetIO();
+    io.DisplaySize = ImVec2(1280.0f, 720.0f);
+    io.DeltaTime = 1.0f / 60.0f;
+    io.ConfigMacOSXBehaviors = false;
+    io.Fonts->Build();
+  }
+
+  void TearDown() override {
+    ImGui::DestroyContext(context_);
+    context_ = nullptr;
+  }
+
+  /// Fully-visible bar state with an Embedded and a System family, so the
+  /// picker shows both group headers and a previewed face.
+  FormatBarState MakeState() {
+    FormatBarState state;
+    state.visible = true;
+    state.fontFamily = "Roboto";
+    state.fontSize = 16.0f;
+    state.hasFontSize = true;
+    ImFont* face = ImGui::GetIO().Fonts->Fonts[0];
+    state.boldToggleFont = face;
+    // Two Embedded families followed by one System family: the picker prints
+    // one header per group and no header between same-group rows.
+    state.families = {
+        FormatBarFontFamily{"Roboto", face, svg::FontSource::Embedded},
+        FormatBarFontFamily{"Fira Code", face, svg::FontSource::Embedded},
+        FormatBarFontFamily{"Zilla Slab", nullptr, svg::FontSource::System},
+    };
+    return state;
+  }
+
+  FormatBarActions Frame(const FormatBarState& state,
+                         const ImVec2& mouse = ImVec2(-100.0f, -100.0f), bool mouseDown = false) {
+    ImGuiIO& io = ImGui::GetIO();
+    io.AddMousePosEvent(mouse.x, mouse.y);
+    io.AddMouseButtonEvent(0, mouseDown);
+    ImGui::NewFrame();
+    frameHeight_ = ImGui::GetFrameHeight();
+    itemSpacingX_ = ImGui::GetStyle().ItemSpacing.x;
+    const FormatBarActions actions =
+        bar_.render(state, ImVec2(kBarX, kBarY), TextFormatBarPresenter::PreferredWidth());
+    ImGui::Render();
+    return actions;
+  }
+
+  /// Simulate a full left click (press + release) and merge both frames.
+  FormatBarActions Click(const FormatBarState& state, const ImVec2& mouse) {
+    FormatBarActions merged = Frame(state, mouse, /*mouseDown=*/true);
+    MergeActions(merged, Frame(state, mouse, /*mouseDown=*/false));
+    return merged;
+  }
+
+  // Horizontal layout of the single control row (left to right): family input,
+  // family combo arrow, size drag, size combo arrow, B, I, U.
+  float RowCenterY() const { return kBarY + kPadding + frameHeight_ * 0.5f; }
+  float RowBottomY() const { return kBarY + kPadding + frameHeight_; }
+  float FamilyInputLeft() const { return kBarX + kPadding; }
+  float FamilyArrowLeft() const { return FamilyInputLeft() + kFamilyInputWidth; }
+  float SizeDragLeft() const { return FamilyArrowLeft() + frameHeight_ + itemSpacingX_; }
+  float SizeArrowLeft() const { return SizeDragLeft() + kSizeDragWidth; }
+  float BoldLeft() const { return SizeArrowLeft() + frameHeight_ + itemSpacingX_; }
+  float ItalicLeft() const { return BoldLeft() + frameHeight_ + itemSpacingX_; }
+  float UnderlineLeft() const { return ItalicLeft() + frameHeight_ + itemSpacingX_; }
+
+  ImVec2 ToggleCenter(float left) const {
+    return ImVec2(left + frameHeight_ * 0.5f, RowCenterY());
+  }
+
+  /// Open the combo popup whose arrow-only control is centered at
+  /// @p arrowCenter. New ImGui windows are hidden their first frame while
+  /// their size is measured, so run one idle frame before interacting with
+  /// the popup contents.
+  void OpenComboPopup(const FormatBarState& state, const ImVec2& arrowCenter) {
+    Click(state, arrowCenter);
+    Frame(state);
+  }
+
+  /// Click down a combo popup (opened at @p popupLeft, below the control row)
+  /// until a row emits an action, returning the merged actions of that click.
+  FormatBarActions ClickFirstActionRowInPopup(const FormatBarState& state, float popupLeft,
+                                              bool (*hasAction)(const FormatBarActions&)) {
+    // 12px in from the popup's left edge lands inside its rows even for the
+    // narrow single-digit size presets.
+    for (float y = RowBottomY() + 4.0f; y <= RowBottomY() + 240.0f; y += 5.0f) {
+      const FormatBarActions actions = Click(state, ImVec2(popupLeft + 12.0f, y));
+      if (hasAction(actions)) {
+        return actions;
+      }
+    }
+    return FormatBarActions{};
+  }
+
+  TextFormatBarPresenter bar_;
+  float frameHeight_ = 0.0f;
+  float itemSpacingX_ = 8.0f;
+
+private:
+  ImGuiContext* context_ = nullptr;
+};
+
+TEST_F(TextFormatBarPresenterInputTest, ClickingToggleButtonsEmitsBoldItalicUnderline) {
+  const FormatBarState state = [&] {
+    FormatBarState s = MakeState();
+    s.bold = true;  // Exercises the highlighted-toggle styling for "B".
+    return s;
+  }();
+
+  Frame(state);  // Warm-up frame: establishes layout metrics and hover state.
+
+  FormatBarActions actions = Click(state, ToggleCenter(BoldLeft()));
+  EXPECT_TRUE(actions.toggleBold);
+  EXPECT_FALSE(actions.toggleItalic);
+  EXPECT_FALSE(actions.toggleUnderline);
+  EXPECT_FALSE(actions.setFontFamily);
+  EXPECT_FALSE(actions.setFontSize);
+
+  actions = Click(state, ToggleCenter(ItalicLeft()));
+  EXPECT_TRUE(actions.toggleItalic);
+  EXPECT_FALSE(actions.toggleBold);
+
+  actions = Click(state, ToggleCenter(UnderlineLeft()));
+  EXPECT_TRUE(actions.toggleUnderline);
+  EXPECT_FALSE(actions.toggleBold);
+}
+
+TEST_F(TextFormatBarPresenterInputTest, DraggingSizeControlCommitsNewFontSize) {
+  const FormatBarState state = MakeState();  // fontSize == 16.
+
+  Frame(state);
+  const ImVec2 dragCenter(SizeDragLeft() + kSizeDragWidth * 0.5f, RowCenterY());
+
+  // Press on the drag control and pull it 30px to the right before releasing;
+  // the presenter commits the edited value on the release frame.
+  Frame(state, dragCenter);
+  FormatBarActions merged = Frame(state, dragCenter, /*mouseDown=*/true);
+  for (float dx = 10.0f; dx <= 30.0f; dx += 10.0f) {
+    MergeActions(merged, Frame(state, ImVec2(dragCenter.x + dx, dragCenter.y),
+                               /*mouseDown=*/true));
+  }
+  MergeActions(merged, Frame(state, ImVec2(dragCenter.x + 30.0f, dragCenter.y),
+                             /*mouseDown=*/false));
+
+  EXPECT_TRUE(merged.setFontSize);
+  EXPECT_GT(merged.fontSize, 16.0f);
+  EXPECT_FALSE(merged.setFontFamily);
+}
+
+TEST_F(TextFormatBarPresenterInputTest, SizePresetMenuSelectsPreset) {
+  FormatBarState state = MakeState();
+  state.fontSize = 8.0f;  // Matches the first preset so its row shows selected.
+
+  Frame(state);
+  // Open the size preset combo (the arrow-only control right of the drag box).
+  OpenComboPopup(state, ImVec2(SizeArrowLeft() + frameHeight_ * 0.5f, RowCenterY()));
+
+  // One frame with no resolved size: the open popup renders every preset row
+  // unselected without emitting actions.
+  FormatBarState noSizeState = state;
+  noSizeState.hasFontSize = false;
+  EXPECT_FALSE(Frame(noSizeState).setFontSize);
+
+  const FormatBarActions actions = ClickFirstActionRowInPopup(
+      state, SizeArrowLeft(), [](const FormatBarActions& a) { return a.setFontSize; });
+
+  ASSERT_TRUE(actions.setFontSize) << "No preset row found in the size popup";
+  EXPECT_FLOAT_EQ(actions.fontSize, static_cast<float>(kFormatBarFontSizePresets.front()));
+}
+
+TEST_F(TextFormatBarPresenterInputTest, FamilyMenuListsGroupsAndSelectsFamily) {
+  const FormatBarState state = MakeState();
+
+  Frame(state);
+  // Open the family picker dropdown (arrow right of the free-text box).
+  OpenComboPopup(state, ImVec2(FamilyArrowLeft() + frameHeight_ * 0.5f, RowCenterY()));
+
+  // Scan down the popup: the search box and the "Embedded" header emit no
+  // actions; the first selectable row is the first configured family.
+  const FormatBarActions actions = ClickFirstActionRowInPopup(
+      state, FamilyArrowLeft(), [](const FormatBarActions& a) { return a.setFontFamily; });
+
+  ASSERT_TRUE(actions.setFontFamily) << "No family row found in the picker popup";
+  EXPECT_EQ(actions.fontFamily, "Roboto");
+}
+
+TEST_F(TextFormatBarPresenterInputTest, FamilySearchFiltersRowsCaseInsensitively) {
+  const FormatBarState state = MakeState();
+
+  Frame(state);
+  OpenComboPopup(state, ImVec2(FamilyArrowLeft() + frameHeight_ * 0.5f, RowCenterY()));
+
+  // Focus the search box at the top of the popup and type a lowercase filter
+  // that only matches "Zilla Slab".
+  const ImVec2 searchCenter(FamilyArrowLeft() + kPadding + 100.0f,
+                            RowBottomY() + kPadding + frameHeight_ * 0.5f);
+  Click(state, searchCenter);
+  ImGuiIO& io = ImGui::GetIO();
+  io.AddInputCharacter('z');
+  io.AddInputCharacter('i');
+  io.AddInputCharacter('l');
+  Frame(state, searchCenter);
+
+  // With the filter applied, the first (and only) selectable row is the
+  // System-group family, proving the case-insensitive match dropped "Roboto".
+  const FormatBarActions actions = ClickFirstActionRowInPopup(
+      state, FamilyArrowLeft(), [](const FormatBarActions& a) { return a.setFontFamily; });
+
+  ASSERT_TRUE(actions.setFontFamily) << "No family row matched the search filter";
+  EXPECT_EQ(actions.fontFamily, "Zilla Slab");
+}
+
+TEST_F(TextFormatBarPresenterInputTest, FreeTextFamilyCommitEmitsSetFontFamily) {
+  FormatBarState state = MakeState();
+  state.fontFamily.clear();  // Start from an empty free-text buffer.
+
+  Frame(state);
+  // Activate the free-text box, type a family name, then click away to commit.
+  Click(state, ImVec2(FamilyInputLeft() + kFamilyInputWidth * 0.5f, RowCenterY()));
+  ImGuiIO& io = ImGui::GetIO();
+  io.AddInputCharacter('F');
+  io.AddInputCharacter('i');
+  io.AddInputCharacter('r');
+  io.AddInputCharacter('a');
+  Frame(state, ImVec2(FamilyInputLeft() + kFamilyInputWidth * 0.5f, RowCenterY()));
+
+  const FormatBarActions actions = Click(state, ImVec2(900.0f, 400.0f));
+  EXPECT_TRUE(actions.setFontFamily);
+  EXPECT_EQ(actions.fontFamily, "Fira");
+}
+
+TEST_F(TextFormatBarPresenterInputTest, ExternalFamilyChangeReseedsFreeTextBuffer) {
+  FormatBarState state = MakeState();
+  state.fontFamily = "Alpha";
+  Frame(state);  // Seeds the buffer from "Alpha".
+
+  state.fontFamily = "Beta";
+  Frame(state);  // External change: the buffer re-seeds to "Beta".
+
+  // Edit and commit: the committed value derives from "Beta", not "Alpha".
+  Click(state, ImVec2(FamilyInputLeft() + kFamilyInputWidth * 0.5f, RowCenterY()));
+  ImGui::GetIO().AddInputCharacter('X');
+  Frame(state, ImVec2(FamilyInputLeft() + kFamilyInputWidth * 0.5f, RowCenterY()));
+
+  const FormatBarActions actions = Click(state, ImVec2(900.0f, 400.0f));
+  ASSERT_TRUE(actions.setFontFamily);
+  std::string committed = actions.fontFamily;
+  const std::size_t inserted = committed.find('X');
+  ASSERT_NE(inserted, std::string::npos) << "Committed value: " << committed;
+  committed.erase(inserted, 1);
+  EXPECT_EQ(committed, "Beta");
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

Adds behavioral tests for three editor ImGui presenters using the repo's headless-ImGui idiom (DialogPresenter-style fixtures) plus press-and-release click simulation as established in the LayersPanel/SidebarPresenter tests:

- `donner/editor/SourceDiagnosticsPanel.cc`: hover reporting, click activation, source-hover highlight (vertex-count delta without action emission), empty/zero-height early-outs, clamped font-scale arm.
- `donner/editor/SamplePickerPresenter.cc`: hidden-picker early-out, one-thumbnail-per-visible-sample provider contract (exact ids/indices/order), dismiss/open-file/open-GitHub button actions, first-sample card click loads that sample id, letterbox and no-provider arms.
- `donner/editor/TextFormatBarPresenter.cc`: unparseable font-size read arm, non-matching style values, empty-selection queues nothing, bold/italic/underline toggles, size drag commit on release, size preset menu, family menu groups and selection, case-insensitive family search filtering, free-text family commit, external change reseeding the text buffer.

Coverage PR 7 in the ranked campaign toward a 92% Codecov project number. Test-only: 724 insertions; the only BUILD change is 3 added deps on the existing `sample_picker_presenter_tests` target.

## Coverage delta (local `tools/coverage.sh`, baseline self-measured at origin/main, Codecov-style)

| File | Before | After |
|---|---|---|
| SourceDiagnosticsPanel.cc | 17/85/0 h/m/p (16.7%) | 102/0/0 (100%) |
| SamplePickerPresenter.cc | 57/97/2 (36.5%) | 154/0/2 (98.7%) |
| TextFormatBarPresenter.cc | 135/67/23 (60.0%) | 218/0/7 (96.9%) |

**+249 missed lines converted (plus 16 partials completed); projected Codecov project delta about +0.40pp.**

## Notes for reviewers

- New ImGui popup windows are hidden their first frame, so combo popups need one idle frame before rows are hit-testable; the `OpenComboPopup` helper documents this.
- Deliberately left uncovered: the switch no-case-matched arm (requires casting garbage into an enum), the >8-samples visible-count guard (requires a production catalog change), the `|| queued` short-circuit mixed arms (structurally unreachable: selection emptiness is constant within one invocation), and the `ImGui::Begin` false arm (a fixed-position NoCollapse window never fails Begin headlessly).

## Quality

- Every case asserts returned action structs, provider-call contracts, or measurable draw-list deltas; no assertion-free frames.
- CI cost: rides existing targets; lint targets and check_banned_patterns pass.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
