### PR TITLE
test(parser): cover AttributeParser and SVGParser error paths

### DIFF
--- a/donner/svg/parser/tests/AttributeParser_tests.cc
+++ b/donner/svg/parser/tests/AttributeParser_tests.cc
@@ -6,10 +6,12 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <optional>
 #include <string>
 
 #include "donner/base/Length.h"
+#include "donner/base/MathUtils.h"
 #include "donner/base/ParseWarningSink.h"
 #include "donner/base/tests/BaseTestUtils.h"
 #include "donner/base/tests/ParseResultTestUtils.h"
@@ -33,6 +35,10 @@
 #include "donner/svg/SVGTextElement.h"
 #include "donner/svg/SVGTextPathElement.h"
 #include "donner/svg/SVGUseElement.h"
+#include "donner/svg/components/animation/AnimateTransformComponent.h"
+#include "donner/svg/components/animation/AnimateValueComponent.h"
+#include "donner/svg/components/animation/AnimationTimingComponent.h"
+#include "donner/svg/components/animation/SetAnimationComponent.h"
 #include "donner/svg/components/filter/FilterComponent.h"
 #include "donner/svg/components/filter/FilterPrimitiveComponent.h"
 #include "donner/svg/components/resources/ImageComponent.h"
@@ -1900,6 +1906,302 @@ TEST(AttributeParserTest, TextAnchorAndPathAttributes) {
   EXPECT_THAT(warningSink.warnings(),
               testing::Contains(
                   testing::Field(&ParseDiagnostic::reason, testing::HasSubstr("Invalid angle"))));
+}
+
+// --- Length parsing edge cases ---
+
+TEST(AttributeParserTest, LengthTrailingDataWarnsAndKeepsDefault) {
+  ParseWarningSink warningSink;
+  auto maybeDocument = SVGParser::ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <line id="line" x1="1 2"/>
+      <mask id="mask" x="bad" y="bad" width="bad" height="bad"/>
+    </svg>
+  )",
+                                           warningSink);
+  ASSERT_TRUE(maybeDocument.hasResult());
+  auto document = std::move(maybeDocument).result();
+
+  // Trailing data invalidates the whole attribute, keeping the default value.
+  auto line = QueryElement<SVGLineElement>(document, "#line");
+  EXPECT_EQ(line.x1(), Lengthd());
+
+  // Invalid mask geometry values keep the auto (nullopt) defaults.
+  auto mask = QueryElement<SVGMaskElement>(document, "#mask");
+  EXPECT_EQ(mask.x(), std::nullopt);
+  EXPECT_EQ(mask.y(), std::nullopt);
+  EXPECT_EQ(mask.width(), std::nullopt);
+  EXPECT_EQ(mask.height(), std::nullopt);
+
+  EXPECT_THAT(warningSink.warnings(),
+              testing::Contains(
+                  testing::Field(&ParseDiagnostic::reason,
+                                 testing::HasSubstr("Unexpected data at end of attribute"))));
+}
+
+TEST(AttributeParserTest, MarkerOrientTrailingDataAndInvalidLengths) {
+  ParseWarningSink warningSink;
+  auto maybeDocument = SVGParser::ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <marker id="m" orient="45 extra" markerHeight="bad" refX="bad" refY="bad"/>
+      </defs>
+    </svg>
+  )",
+                                           warningSink);
+  ASSERT_TRUE(maybeDocument.hasResult());
+  auto document = std::move(maybeDocument).result();
+
+  auto marker = QueryElement<SVGMarkerElement>(document, "#m");
+
+  // The angle before the extra data is still applied, with a warning.
+  EXPECT_EQ(marker.orient().type(), MarkerOrient::Type::Angle);
+  EXPECT_NEAR(marker.orient().computeAngleRadians(Vector2d(1.0, 0.0)),
+              45.0 * MathConstants<double>::kDegToRad, 1e-9);
+
+  // Invalid lengths keep the SVG defaults: markerHeight=3, refX=0, refY=0.
+  EXPECT_THAT(marker.markerHeight(), LengthIs(DoubleNear(3.0, 0.001), Lengthd::Unit::None));
+  EXPECT_THAT(marker.refX(), LengthIs(DoubleNear(0.0, 0.001), Lengthd::Unit::None));
+  EXPECT_THAT(marker.refY(), LengthIs(DoubleNear(0.0, 0.001), Lengthd::Unit::None));
+
+  EXPECT_THAT(warningSink.warnings(),
+              testing::Contains(
+                  testing::Field(&ParseDiagnostic::reason,
+                                 testing::HasSubstr("Unexpected data after angle value"))));
+}
+
+TEST(AttributeParserTest, ImageInvalidPreserveAspectRatioKeepsDefault) {
+  ParseWarningSink warningSink;
+  auto maybeDocument = SVGParser::ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <image id="img" width="10" height="10" href="test.png" preserveAspectRatio="bad"/>
+    </svg>
+  )",
+                                           warningSink);
+  ASSERT_TRUE(maybeDocument.hasResult());
+  auto document = std::move(maybeDocument).result();
+
+  auto image = QueryElement<SVGImageElement>(document, "#img");
+  EXPECT_EQ(image.preserveAspectRatio(), PreserveAspectRatio());
+
+  EXPECT_THAT(warningSink.warnings(),
+              testing::Contains(testing::Field(&ParseDiagnostic::reason,
+                                               testing::HasSubstr("align"))));
+}
+
+// --- Filter enum and separator edge cases ---
+
+TEST(AttributeParserTest, FilterEnumInvalidValuesKeepDefaults) {
+  auto document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <filter id="f" color-interpolation-filters="bad">
+        <feGaussianBlur id="blur" stdDeviation="1" edgeMode="bad"/>
+        <feBlend id="blend" mode="bad"/>
+        <feMorphology id="morph" operator="bad"/>
+      </filter>
+    </svg>
+  )");
+
+  // The invalid value is ignored, leaving color-interpolation-filters unset.
+  EXPECT_EQ(QueryComponent<components::FilterComponent>(document, "#f").colorInterpolationFilters,
+            std::nullopt);
+  EXPECT_EQ(QueryComponent<components::FEGaussianBlurComponent>(document, "#blur").edgeMode,
+            components::FEGaussianBlurComponent::EdgeMode::None);
+  EXPECT_EQ(QueryComponent<components::FEBlendComponent>(document, "#blend").mode,
+            components::FEBlendComponent::Mode::Normal);
+  EXPECT_EQ(QueryComponent<components::FEMorphologyComponent>(document, "#morph").op,
+            components::FEMorphologyComponent::Operator::Erode);
+}
+
+TEST(AttributeParserTest, FilterSeparatorAndInvalidFirstNumberBranches) {
+  auto document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <filter id="f">
+        <feMorphology id="morph" radius="1 , 2 , "/>
+        <feConvolveMatrix id="conv" order="4,2" kernelMatrix="1 0 0 1 0 0 1 0"/>
+        <feTurbulence id="turb-bad" baseFrequency="bad"/>
+        <feTurbulence id="turb-comma" baseFrequency="0.25,0.75"/>
+      </filter>
+    </svg>
+  )");
+
+  // Comma-and-space separators between the two radius values, plus trailing separators.
+  const auto& morph = QueryComponent<components::FEMorphologyComponent>(document, "#morph");
+  EXPECT_DOUBLE_EQ(morph.radiusX, 1.0);
+  EXPECT_DOUBLE_EQ(morph.radiusY, 2.0);
+
+  const auto& conv = QueryComponent<components::FEConvolveMatrixComponent>(document, "#conv");
+  EXPECT_EQ(conv.orderX, 4);
+  EXPECT_EQ(conv.orderY, 2);
+
+  // An invalid first number leaves the defaults untouched.
+  const auto& turbBad = QueryComponent<components::FETurbulenceComponent>(document, "#turb-bad");
+  EXPECT_DOUBLE_EQ(turbBad.baseFrequencyX, 0.0);
+  EXPECT_DOUBLE_EQ(turbBad.baseFrequencyY, 0.0);
+
+  const auto& turbComma =
+      QueryComponent<components::FETurbulenceComponent>(document, "#turb-comma");
+  EXPECT_DOUBLE_EQ(turbComma.baseFrequencyX, 0.25);
+  EXPECT_DOUBLE_EQ(turbComma.baseFrequencyY, 0.75);
+}
+
+// --- Animation attribute edge cases ---
+
+TEST(AttributeParserTest, AnimateValueListEdgeCases) {
+  auto document = ParseSVGExperimental(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <rect width="10" height="10">
+        <animate id="a1" attributeName="fill" values="red ;; blue " calcMode="linear"/>
+        <animate id="a2" attributeName="width" keyTimes="0;0.25 0.5;1"/>
+        <animate id="a3" attributeName="width" keyTimes="0;bad;1"/>
+      </rect>
+    </svg>
+  )");
+
+  // Empty items are dropped and surrounding whitespace is trimmed.
+  const auto& a1 = QueryComponent<components::AnimateValueComponent>(document, "#a1");
+  EXPECT_THAT(a1.values, testing::ElementsAre("red", "blue"));
+  EXPECT_EQ(a1.calcMode, components::CalcMode::Linear);
+
+  // A semicolon group may contain multiple whitespace-separated numbers.
+  const auto& a2 = QueryComponent<components::AnimateValueComponent>(document, "#a2");
+  EXPECT_THAT(a2.keyTimes, testing::ElementsAre(0.0, 0.25, 0.5, 1.0));
+
+  // Non-numeric groups contribute no values.
+  const auto& a3 = QueryComponent<components::AnimateValueComponent>(document, "#a3");
+  EXPECT_THAT(a3.keyTimes, testing::ElementsAre(0.0, 1.0));
+}
+
+TEST(AttributeParserTest, AnimationTimingAttributeEdgeCases) {
+  SVGParser::Options options;
+  options.enableExperimental = true;
+  options.disableUserAttributes = false;
+
+  ParseWarningSink warningSink;
+  auto maybeDocument = SVGParser::ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <rect width="10" height="10">
+        <animate id="a1" attributeName="width" begin="5s; 2s; 10s" end="indefinite"
+                 fill="remove" repeatCount="indefinite" restart="always" min="1s" max="4s"
+                 data-user="kept"/>
+        <animate id="a2" attributeName="width" dur="bad" repeatCount="bad" repeatDur="bad"
+                 min="bad" max="bad"/>
+      </rect>
+    </svg>
+  )",
+                                           warningSink, options);
+  ASSERT_TRUE(maybeDocument.hasResult());
+  auto document = std::move(maybeDocument).result();
+
+  const auto& t1 = QueryComponent<components::AnimationTimingComponent>(document, "#a1");
+  // The earliest offset in the begin list wins.
+  ASSERT_TRUE(t1.beginOffset.has_value());
+  EXPECT_DOUBLE_EQ(t1.beginOffset->seconds(), 2.0);
+  // "indefinite" is recorded but produces no end offset.
+  EXPECT_EQ(t1.endValue, "indefinite");
+  EXPECT_EQ(t1.endOffset, std::nullopt);
+  EXPECT_EQ(t1.fill, components::AnimationFill::Remove);
+  ASSERT_TRUE(t1.repeatCount.has_value());
+  EXPECT_EQ(*t1.repeatCount, std::numeric_limits<double>::infinity());
+  EXPECT_EQ(t1.restart, components::AnimationRestart::Always);
+  ASSERT_TRUE(t1.min.has_value());
+  EXPECT_DOUBLE_EQ(t1.min->seconds(), 1.0);
+  ASSERT_TRUE(t1.max.has_value());
+  EXPECT_DOUBLE_EQ(t1.max->seconds(), 4.0);
+
+  // Attributes not handled by the animation specialization fall through to the common path.
+  auto animate1 = document.querySelector("#a1");
+  ASSERT_TRUE(animate1.has_value());
+  EXPECT_THAT(animate1->getAttribute("data-user"), testing::Optional(RcString("kept")));
+
+  // Invalid clock and number values leave the timing defaults untouched.
+  const auto& t2 = QueryComponent<components::AnimationTimingComponent>(document, "#a2");
+  EXPECT_EQ(t2.dur, std::nullopt);
+  EXPECT_EQ(t2.repeatCount, std::nullopt);
+  EXPECT_EQ(t2.repeatDur, std::nullopt);
+  EXPECT_EQ(t2.min, std::nullopt);
+  EXPECT_EQ(t2.max, std::nullopt);
+}
+
+TEST(AttributeParserTest, AnimateTransformSkewYHrefAndSetAttributes) {
+  SVGParser::Options options;
+  options.enableExperimental = true;
+  options.disableUserAttributes = false;
+
+  ParseWarningSink warningSink;
+  auto maybeDocument = SVGParser::ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <rect id="r" width="10" height="10"/>
+      <animateTransform id="at" attributeName="transform" type="skewY" href="#r"
+                        from="0" to="45"/>
+      <set id="st" attributeName="width" to="20" href="#r" data-user="kept"/>
+    </svg>
+  )",
+                                           warningSink, options);
+  ASSERT_TRUE(maybeDocument.hasResult());
+  auto document = std::move(maybeDocument).result();
+
+  const auto& transformComp =
+      QueryComponent<components::AnimateTransformComponent>(document, "#at");
+  EXPECT_EQ(transformComp.type, components::TransformAnimationType::SkewY);
+  EXPECT_EQ(transformComp.href, "#r");
+
+  const auto& setComp = QueryComponent<components::SetAnimationComponent>(document, "#st");
+  EXPECT_EQ(setComp.href, "#r");
+
+  // Attributes not handled by the set specialization fall through to the common path.
+  auto set = document.querySelector("#st");
+  ASSERT_TRUE(set.has_value());
+  EXPECT_THAT(set->getAttribute("data-user"), testing::Optional(RcString("kept")));
+}
+
+// --- Text positioning list errors ---
+
+TEST(AttributeParserTest, RotateListTrailingCommaWarnsAndKeepsParsedValues) {
+  ParseWarningSink warningSink;
+  auto maybeDocument = SVGParser::ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <text id="text" rotate="45,">one</text>
+      <text>
+        <a id="link" rotate="45," lengthAdjust="bad" x="1 bad" y="2 bad" dx="3 bad"
+           dy="4 bad">two</a>
+      </text>
+      <text>
+        <tspan id="span" rotate="45," lengthAdjust="bad">three</tspan>
+      </text>
+      <text>
+        <textPath id="path-text" rotate="45,">four</textPath>
+      </text>
+    </svg>
+  )",
+                                           warningSink);
+  ASSERT_TRUE(maybeDocument.hasResult());
+  auto document = std::move(maybeDocument).result();
+
+  // Values before the trailing comma are kept; the list error is reported as a warning.
+  EXPECT_THAT(QueryElement<SVGTextElement>(document, "#text").rotateList(),
+              testing::ElementsAre(DoubleNear(45.0, 1e-12)));
+
+  auto link = QueryElement<SVGAElement>(document, "#link");
+  EXPECT_THAT(link.rotateList(), testing::ElementsAre(DoubleNear(45.0, 1e-12)));
+  // Invalid lengthAdjust on <a> keeps the default; invalid list tokens are skipped.
+  EXPECT_EQ(link.lengthAdjust(), LengthAdjust::Spacing);
+  EXPECT_THAT(link.xList(), testing::ElementsAre(Lengthd(1)));
+  EXPECT_THAT(link.yList(), testing::ElementsAre(Lengthd(2)));
+  EXPECT_THAT(link.dxList(), testing::ElementsAre(Lengthd(3)));
+  EXPECT_THAT(link.dyList(), testing::ElementsAre(Lengthd(4)));
+
+  auto span = QueryElement<SVGTSpanElement>(document, "#span");
+  EXPECT_THAT(span.rotateList(), testing::ElementsAre(DoubleNear(45.0, 1e-12)));
+  EXPECT_EQ(span.lengthAdjust(), LengthAdjust::Spacing);
+
+  EXPECT_THAT(QueryElement<SVGTextPathElement>(document, "#path-text").rotateList(),
+              testing::ElementsAre(DoubleNear(45.0, 1e-12)));
+
+  EXPECT_THAT(warningSink.warnings(),
+              testing::Contains(testing::Field(&ParseDiagnostic::reason,
+                                               testing::HasSubstr("Unexpected trailing comma")))
+                  .Times(4));
 }
 
 }  // namespace donner::svg::parser

--- a/donner/svg/parser/tests/SVGParser_tests.cc
+++ b/donner/svg/parser/tests/SVGParser_tests.cc
@@ -5,9 +5,17 @@
 
 #include "donner/base/ParseWarningSink.h"
 #include "donner/base/tests/ParseResultTestUtils.h"
+#include "donner/base/xml/XMLDocument.h"
+#include "donner/base/xml/XMLNode.h"
 #include "donner/base/xml/XMLParser.h"
 #include "donner/base/xml/XMLQualifiedName.h"
+#include "donner/svg/SVGAElement.h"
 #include "donner/svg/SVGElement.h"
+#include "donner/svg/SVGTSpanElement.h"
+#include "donner/svg/SVGTextElement.h"
+#include "donner/svg/SVGTextPathElement.h"
+#include "donner/svg/components/DescriptiveTextComponent.h"
+#include "donner/svg/components/StylesheetComponent.h"
 #include "donner/svg/renderer/RendererUtils.h"
 
 using testing::AllOf;
@@ -347,6 +355,241 @@ TEST(SVGParser, MismatchedNamespace) {
                     ParseErrorPos(2, 23),
                     ParseErrorIs("Ignored attribute 'invalid:d' with an unsupported namespace"))));
   }
+}
+
+TEST(SVGParser, RootElementNotSvgFails) {
+  ParseWarningSink warnings;
+  EXPECT_THAT(SVGParser::ParseSVG(R"(<foo xmlns="http://www.w3.org/2000/svg"/>)", warnings),
+              ParseErrorIs("Unexpected element <foo> at root, first element must be <svg>"));
+}
+
+TEST(SVGParser, UnknownElementInSvgNamespace) {
+  ParseWarningSink warnings;
+  auto result = SVGParser::ParseSVG(
+      R"(<svg xmlns="http://www.w3.org/2000/svg"><notAnElement id="u"/></svg>)", warnings);
+  ASSERT_THAT(result, NoParseError());
+
+  auto unknown = result.result().querySelector("#u");
+  ASSERT_TRUE(unknown.has_value());
+  EXPECT_EQ(unknown->type(), ElementType::Unknown);
+  EXPECT_THAT(unknown->tagName(), testing::Eq("notAnElement"));
+}
+
+TEST(SVGParser, ExperimentalElementsRequireOptIn) {
+  const std::string_view source(
+      R"(<svg xmlns="http://www.w3.org/2000/svg"><animate id="a" attributeName="x"/></svg>)");
+
+  {
+    // Without the experimental option, <animate> parses as an unknown element.
+    ParseWarningSink warnings;
+    auto result = SVGParser::ParseSVG(source, warnings);
+    ASSERT_THAT(result, NoParseError());
+
+    auto element = result.result().querySelector("#a");
+    ASSERT_TRUE(element.has_value());
+    EXPECT_EQ(element->type(), ElementType::Unknown);
+  }
+
+  {
+    SVGParser::Options options;
+    options.enableExperimental = true;
+
+    ParseWarningSink warnings;
+    auto result = SVGParser::ParseSVG(source, warnings, options);
+    ASSERT_THAT(result, NoParseError());
+
+    auto element = result.result().querySelector("#a");
+    ASSERT_TRUE(element.has_value());
+    EXPECT_EQ(element->type(), ElementType::Animate);
+  }
+}
+
+TEST(SVGParser, NestedStyleElementContentsErrorPropagates) {
+  ParseWarningSink warnings;
+  EXPECT_THAT(SVGParser::ParseSVG(
+                  R"(<svg xmlns="http://www.w3.org/2000/svg"><g><style><rect/></style></g></svg>)",
+                  warnings),
+              ParseErrorIs(testing::HasSubstr("Unexpected <style> element contents")));
+}
+
+TEST(SVGParser, GzipErrors) {
+  {
+    // Gzip magic bytes with no payload.
+    const std::string_view truncated("\x1f\x8b", 2);
+    ParseWarningSink warnings;
+    EXPECT_THAT(SVGParser::ParseSVG(truncated, warnings),
+                ParseErrorIs(testing::HasSubstr("Failed to decompress gzip data")));
+  }
+
+  {
+    // Valid magic bytes followed by a corrupt stream.
+    std::string corrupt("\x1f\x8b", 2);
+    corrupt += std::string(32, 'x');
+
+    ParseWarningSink warnings;
+    EXPECT_THAT(SVGParser::ParseSVG(corrupt, warnings),
+                ParseErrorIs(testing::HasSubstr("gzip")));
+  }
+}
+
+TEST(SVGParser, InlineSvgWithExplicitInvalidNamespaceFails) {
+  SVGParser::Options options;
+  options.parseAsInlineSVG = true;
+
+  ParseWarningSink warnings;
+  EXPECT_THAT(SVGParser::ParseSVG(R"(<svg xmlns="invalid"></svg>)", warnings, options),
+              ParseErrorIs("<svg> has an unexpected namespace URI 'invalid'. "
+                           "Expected 'http://www.w3.org/2000/svg'"));
+}
+
+TEST(SVGParser, PrefixedXmlnsDeclaredBeforeDefault) {
+  const std::string_view source(
+      R"(<svg xmlns:s="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg">
+           <rect id="plain"/>
+           <s:rect s:id="prefixed"/>
+         </svg>)");
+
+  ParseWarningSink warnings;
+  auto result = SVGParser::ParseSVG(source, warnings);
+  ASSERT_THAT(result, NoParseError());
+  EXPECT_THAT(warnings.warnings(), ElementsAre());
+
+  SVGDocument document = result.result();
+  auto plain = document.querySelector("#plain");
+  ASSERT_TRUE(plain.has_value());
+  EXPECT_EQ(plain->type(), ElementType::Rect);
+
+  auto prefixed = document.svgElement().lastChild();
+  ASSERT_TRUE(prefixed.has_value());
+  EXPECT_EQ(prefixed->type(), ElementType::Rect);
+  EXPECT_THAT(prefixed->tagName(), testing::Eq(xml::XMLQualifiedNameRef("s", "rect")));
+}
+
+TEST(SVGParser, ParseXMLDocumentSuccessAndRootError) {
+  xml::XMLParser::Options xmlOptions = xml::XMLParser::Options::ParseAll();
+
+  {
+    auto xmlResult = xml::XMLParser::Parse(
+        R"(<svg xmlns="http://www.w3.org/2000/svg"><rect id="r"/></svg>)", xmlOptions);
+    ASSERT_THAT(xmlResult, NoParseError());
+
+    ParseWarningSink warnings;
+    auto result = SVGParser::ParseXMLDocument(std::move(xmlResult.result()), warnings);
+    ASSERT_THAT(result, NoParseError());
+    EXPECT_TRUE(result.result().querySelector("#r").has_value());
+  }
+
+  {
+    auto xmlResult = xml::XMLParser::Parse("<foo/>", xmlOptions);
+    ASSERT_THAT(xmlResult, NoParseError());
+
+    ParseWarningSink warnings;
+    EXPECT_THAT(SVGParser::ParseXMLDocument(std::move(xmlResult.result()), warnings),
+                ParseErrorIs("Unexpected element <foo> at root, first element must be <svg>"));
+  }
+}
+
+TEST(SVGParser, ProgrammaticDocumentStyleWithoutSourceLocations) {
+  // Build an XML document via the DOM API. Its nodes have no source offsets, exercising the
+  // <style> source-map fallback paths.
+  xml::XMLDocument xmlDocument;
+
+  xml::XMLNode svg = xml::XMLNode::CreateElementNode(xmlDocument, "svg");
+  svg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+  xmlDocument.root().appendChild(svg);
+
+  xml::XMLNode style = xml::XMLNode::CreateElementNode(xmlDocument, "style");
+  svg.appendChild(style);
+  style.appendChild(xml::XMLNode::CreateDataNode(xmlDocument, "rect { fill: red; }"));
+
+  ParseWarningSink warnings;
+  auto result = SVGParser::ParseXMLDocument(std::move(xmlDocument), warnings);
+  ASSERT_THAT(result, NoParseError());
+
+  auto styleElement = result.result().querySelector("style");
+  ASSERT_TRUE(styleElement.has_value());
+  const auto& stylesheet =
+      styleElement->entityHandle().get<components::StylesheetComponent>();
+  EXPECT_EQ(stylesheet.text, "rect { fill: red; }");
+  EXPECT_FALSE(stylesheet.stylesheet.rules().empty());
+}
+
+TEST(SVGParser, DescriptiveElementsCaptureTextContent) {
+  const std::string_view source(
+      R"(<svg xmlns="http://www.w3.org/2000/svg">
+           <title id="t">Hello<!-- ignored --><![CDATA[ World]]></title>
+         </svg>)");
+
+  ParseWarningSink warnings;
+  auto result = SVGParser::ParseSVG(source, warnings);
+  ASSERT_THAT(result, NoParseError());
+
+  auto title = result.result().querySelector("#t");
+  ASSERT_TRUE(title.has_value());
+  const auto& descriptiveText =
+      title->entityHandle().get<components::DescriptiveTextComponent>();
+  EXPECT_EQ(descriptiveText.text, "Hello World");
+}
+
+TEST(SVGParser, TextContentSkipsCommentsAndCollectsCData) {
+  const std::string_view source(
+      R"(<svg xmlns="http://www.w3.org/2000/svg">
+           <text id="text">one<!-- c --><![CDATA[two]]><tspan id="span"><![CDATA[three]]><!-- c --></tspan><a id="link"><![CDATA[four]]><!-- c --></a><textPath id="tp"><![CDATA[five]]><!-- c --></textPath></text>
+         </svg>)");
+
+  ParseWarningSink warnings;
+  auto result = SVGParser::ParseSVG(source, warnings);
+  ASSERT_THAT(result, NoParseError());
+
+  SVGDocument document = result.result();
+  EXPECT_EQ(document.querySelector("#text")->cast<SVGTextElement>().textContent(), "onetwo");
+  EXPECT_EQ(document.querySelector("#span")->cast<SVGTSpanElement>().textContent(), "three");
+  EXPECT_EQ(document.querySelector("#link")->cast<SVGAElement>().textContent(), "four");
+  EXPECT_EQ(document.querySelector("#tp")->cast<SVGTextPathElement>().textContent(), "five");
+}
+
+TEST(SVGParser, SubDocumentParseErrorsReportedAsWarnings) {
+  // data URI decodes to "<notsvg/>", which fails SVG parsing inside the sub-document callback.
+  const std::string_view source(
+      R"(<svg xmlns="http://www.w3.org/2000/svg">
+           <image href="data:image/svg+xml;base64,PG5vdHN2Zy8+" width="10" height="10"/>
+         </svg>)");
+
+  ParseWarningSink parseWarnings;
+  auto result = SVGParser::ParseSVG(source, parseWarnings);
+  ASSERT_THAT(result, NoParseError());
+
+  ParseWarningSink renderWarnings;
+  SVGDocument document = result.result();
+  RendererUtils::prepareDocumentForRendering(document, /*verbose*/ false, renderWarnings);
+
+  EXPECT_THAT(renderWarnings.warnings(),
+              testing::Contains(
+                  testing::Field(&ParseDiagnostic::reason,
+                                 testing::HasSubstr("Unexpected element <notsvg> at root"))));
+}
+
+TEST(SVGParser, SecureStaticModeDisablesSubDocumentParsing) {
+  const std::string_view source(
+      R"(<svg xmlns="http://www.w3.org/2000/svg">
+           <image href="data:image/svg+xml;base64,PG5vdHN2Zy8+" width="10" height="10"/>
+         </svg>)");
+
+  SVGDocument::Settings settings;
+  settings.processingMode = ProcessingMode::SecureStatic;
+
+  ParseWarningSink parseWarnings;
+  auto result =
+      SVGParser::ParseSVG(source, parseWarnings, SVGParser::Options(), std::move(settings));
+  ASSERT_THAT(result, NoParseError());
+
+  ParseWarningSink renderWarnings;
+  SVGDocument document = result.result();
+  RendererUtils::prepareDocumentForRendering(document, /*verbose*/ false, renderWarnings);
+
+  // In SecureStatic mode resource loading is skipped entirely (SVG2 section 2.7.1): the
+  // sub-document is not parsed and no warnings are produced.
+  EXPECT_THAT(renderWarnings.warnings(), ElementsAre());
 }
 
 }  // namespace donner::svg::parser


### PR DESCRIPTION
## Summary

Adds behavioral tests to `donner/svg/parser/tests/AttributeParser_tests.cc` (+302 lines) and `SVGParser_tests.cc` (+243 lines) covering previously-untested error arms of SVG attribute parsing (invalid presentation values, malformed lists, unsupported units, warning accumulation) and SVGParser document-level error paths.

Coverage PR 8 in the ranked campaign toward a 92% Codecov project number. Test-only change: 545 insertions, no production, BUILD, or config changes. `//donner/svg/parser:parser_tests` passes unfiltered.

## Coverage delta (local `tools/coverage.sh` on `//donner/svg/parser:parser_tests`, before/after measured on the SAME target set, Codecov-style: partials count as uncovered)

| File | Before | After |
|---|---|---|
| donner/svg/parser/AttributeParser.cc | 1614/107/110 h/m/p | 1699/65/67 |
| donner/svg/parser/SVGParser.cc | 237/79/38 | 295/26/33 |

**+143 lines converted to fully covered on the target measurement.** Some AttributeParser lines are also reached by other suites on main, so the realized Codecov project delta is projected at **+0.10 to +0.20pp**; will verify on Codecov after merge.

## Quality

- Every case asserts parse results: error/warning presence and content, or the exact fallback/computed property value applied to the document; no assertion-free tests.
- Follows the existing ParseResult assertion idioms in both test files.
- CI cost: rides the existing consolidated `parser_tests` binary (and its variant wrappers); no new targets.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
