### PR TITLE
Re-vendor tiny-skia AA edge bounds fix

### DIFF
--- a/third_party/tiny-skia-cpp/src/tiny_skia/pipeline/PipelineBlitter.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/pipeline/PipelineBlitter.cpp
@@ -730,28 +730,31 @@ void RasterPipelineBlitter::blitAntiH2(std::uint32_t x, std::uint32_t y, AlphaU8
     return;
   }
 
-  const auto bounds = ScreenIntRect::fromXYWH(x, y, 2, 1);
-  if (!bounds.has_value()) {
+  if (pixmap_ == nullptr || x >= pixmap_->width() || y >= pixmap_->height()) {
     return;
   }
+  const auto boundsWidth = static_cast<LengthU32>(std::min<std::size_t>(2u, pixmap_->width() - x));
+  const auto bounds = ScreenIntRect::fromXYWHSafe(x, y, boundsWidth, 1u);
   const AAMaskCtx aaMaskCtx{
-      {alpha0, alpha1}, 2u, static_cast<std::size_t>(bounds->x() + bounds->y() * 2)};
+      {alpha0, alpha1}, 2u, static_cast<std::size_t>(bounds.x() + bounds.y() * 2)};
   const auto maskCtx = makeMaskCtx(mask_);
   const auto pixmapSrcRef = pixmapSrcStorage_.view();
-  blitMaskRp_.run(*bounds, aaMaskCtx, maskCtx, pixmapSrcRef, pixmap_);
+  blitMaskRp_.run(bounds, aaMaskCtx, maskCtx, pixmapSrcRef, pixmap_);
 }
 
 void RasterPipelineBlitter::blitAntiV2(std::uint32_t x, std::uint32_t y, AlphaU8 alpha0,
                                        AlphaU8 alpha1) {
-  const auto bounds = ScreenIntRect::fromXYWH(x, y, 1, 2);
-  if (!bounds.has_value()) {
+  if (pixmap_ == nullptr || x >= pixmap_->width() || y >= pixmap_->height()) {
     return;
   }
+  const auto boundsHeight =
+      static_cast<LengthU32>(std::min<std::size_t>(2u, pixmap_->height() - y));
+  const auto bounds = ScreenIntRect::fromXYWHSafe(x, y, 1u, boundsHeight);
   const AAMaskCtx aaMaskCtx{
-      {alpha0, alpha1}, 1u, static_cast<std::size_t>(bounds->x() + bounds->y() * 1)};
+      {alpha0, alpha1}, 1u, static_cast<std::size_t>(bounds.x() + bounds.y() * 1)};
   const auto maskCtx = makeMaskCtx(mask_);
   const auto pixmapSrcRef = pixmapSrcStorage_.view();
-  blitMaskRp_.run(*bounds, aaMaskCtx, maskCtx, pixmapSrcRef, pixmap_);
+  blitMaskRp_.run(bounds, aaMaskCtx, maskCtx, pixmapSrcRef, pixmap_);
 }
 
 void RasterPipelineBlitter::blitAntiRect(std::int32_t x, std::int32_t y, std::int32_t width,

--- a/third_party/tiny-skia-cpp/src/tiny_skia/pipeline/tests/BlitterTest.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/pipeline/tests/BlitterTest.cpp
@@ -286,6 +286,24 @@ TEST(PipelineBlitterTest, BlitAntiH2WritesPerPixelCoverage) {
   EXPECT_THAT(alpha, ElementsAre(64u, 200u));
 }
 
+TEST(PipelineBlitterTest, BlitAntiH2ClipsSlowPathAtRightEdge) {
+  auto pixmap = tiny_skia::Pixmap::fromSize(3, 1);
+  ASSERT_TRUE(pixmap.has_value());
+  const auto clip = tiny_skia::IntRect::fromXYWH(0, 0, 2, 1);
+  ASSERT_TRUE(clip.has_value());
+  auto sub = pixmap->mutableView().subpixmap(*clip);
+  ASSERT_TRUE(sub.has_value());
+
+  auto blitter = tiny_skia::pipeline::RasterPipelineBlitter::createMask(&*sub);
+  ASSERT_TRUE(blitter.has_value());
+
+  blitter->blitAntiH2(1, 0, 64u, 200u);
+
+  const auto alpha = std::vector<std::uint8_t>{alphaAt(*pixmap, 0, 0), alphaAt(*pixmap, 1, 0),
+                                               alphaAt(*pixmap, 2, 0)};
+  EXPECT_THAT(alpha, ElementsAre(0u, 64u, 0u));
+}
+
 TEST(PipelineBlitterTest, PartialCoverageComposesWithExistingDestinationAlpha) {
   auto pixmap = tiny_skia::Pixmap::fromSize(1, 1);
   ASSERT_TRUE(pixmap.has_value());
@@ -413,6 +431,24 @@ TEST(PipelineBlitterTest, BlitAntiV2WritesSeparatePixelCoverages) {
   const auto antiV2Alpha =
       std::vector<std::uint8_t>{alphaAt(*pixmap, 0, 0), alphaAt(*pixmap, 0, 1)};
   EXPECT_THAT(antiV2Alpha, ElementsAre(10u, 240u));
+}
+
+TEST(PipelineBlitterTest, BlitAntiV2ClipsSlowPathAtBottomEdge) {
+  auto pixmap = tiny_skia::Pixmap::fromSize(1, 3);
+  ASSERT_TRUE(pixmap.has_value());
+  const auto clip = tiny_skia::IntRect::fromXYWH(0, 0, 1, 2);
+  ASSERT_TRUE(clip.has_value());
+  auto sub = pixmap->mutableView().subpixmap(*clip);
+  ASSERT_TRUE(sub.has_value());
+
+  auto blitter = tiny_skia::pipeline::RasterPipelineBlitter::createMask(&*sub);
+  ASSERT_TRUE(blitter.has_value());
+
+  blitter->blitAntiV2(0, 1, 10u, 240u);
+
+  const auto alpha = std::vector<std::uint8_t>{alphaAt(*pixmap, 0, 0), alphaAt(*pixmap, 0, 1),
+                                               alphaAt(*pixmap, 0, 2)};
+  EXPECT_THAT(alpha, ElementsAre(0u, 10u, 0u));
 }
 
 }  // namespace


### PR DESCRIPTION
Re-vendors the upstream tiny-skia-cpp fix and regression coverage for the right/bottom-edge AA slow paths. This completes the upstream-first work tracked in #604 and removes Donner's divergence from the vendored source.

**Why**

`blitAntiH2` and `blitAntiV2` could construct a two-pixel slow-path rectangle at the final pixmap column or row. The upstream fix clamps the rectangle to the remaining destination extent, preventing the out-of-bounds destination access while preserving in-bounds output.

**Changes**

- Update `PipelineBlitter.cpp` to the exact upstream fixed source.
- Re-vendor upstream horizontal and vertical edge regression tests.
- Keep the vendored source and tests byte-identical to their upstream blobs.

**Verification**

- tiny-skia pipeline tests, native and scalar: pass.
- tiny-skia pipeline tests under ASan, native and scalar: pass.
- Donner renderer and zoom-filter repro tests: pass.
- CMake generated-file check: pass.
- Full `bazel test //...`: 737 tests passed; all renderer, Geode, resvg, lint, and affected integration lanes passed. One source-pane pixel assertion failed identically on the exact parent commit, and one editor-shell shard hit its 300-second timeout under load but passed on exact isolated rerun.

Fixes #604.