### PR TITLE
Fix Geode closed-stroke winding at shared vertices

### DIFF
--- a/donner/base/Path.cc
+++ b/donner/base/Path.cc
@@ -2104,12 +2104,10 @@ void strokeSubpath(const FlatSubpath& subpath, const StrokeStyle& style, PathBui
       const Vector2d prevEnd = pts[i] - normals[i - 1] * halfWidth;
       const Vector2d curStart = pts[i] - normals[i] * halfWidth;
 
-      // On the right side, the "outside" sense is flipped - feed emitJoin
-      // the flipped normals so its cross-product sign classification
-      // points at the right-contour outside.
+      // Use right-facing normals for miter geometry and right-side turn classification.
       emitJoin(prevEnd, curStart, pts[i], Vector2d(-normals[i - 1].x, -normals[i - 1].y),
                Vector2d(-normals[i].x, -normals[i].y), halfWidth, style.join, style.miterLimit,
-               segmentLengths[i - 1], segmentLengths[i], builder, /*isLeftSide=*/true);
+               segmentLengths[i - 1], segmentLengths[i], builder, /*isLeftSide=*/false);
     }
 
     // NOTE: unlike the OPEN case, closed paths do NOT need a post-loop
@@ -2125,7 +2123,8 @@ void strokeSubpath(const FlatSubpath& subpath, const StrokeStyle& style, PathBui
       emitJoin(prevEnd, curStart, pts[n - 1],
                Vector2d(-normals[numSegments - 1].x, -normals[numSegments - 1].y),
                Vector2d(-normals[0].x, -normals[0].y), halfWidth, style.join, style.miterLimit,
-               segmentLengths[numSegments - 1], segmentLengths[0], builder, /*isLeftSide=*/true);
+               segmentLengths[numSegments - 1], segmentLengths[0], builder,
+               /*isLeftSide=*/false);
     }
 
     builder.closePath();

--- a/donner/svg/renderer/geode/shaders/slug_fill.wgsl
+++ b/donner/svg/renderer/geode/shaders/slug_fill.wgsl
@@ -252,12 +252,18 @@ struct RayCoverage {
   wgt: f32,
 };
 
-// A shared vertex belongs to the curve that starts there, not the curve that ends there.
-// Testing the monotonic axis directly avoids backend-dependent root rounding near t=1.
+// Ownership of a shared vertex on the monotone axis, as a direction-independent
+// half-open interval [min, max): min-inclusive, max-exclusive. This is the standard
+// scanline winding convention. A start-inclusive/end-exclusive test (which flips to
+// max-inclusive for a decreasing curve) miscounts a Y-extremum shared vertex as a
+// single crossing when the sample lands exactly on the extremum value, breaking fill
+// parity for that scanline. Metal never samples exactly on the integer extremum;
+// llvmpipe does, so [min, max) is required for cross-backend agreement. Testing the
+// monotone axis directly also avoids backend-dependent root rounding near t=1.
 fn owns_axis_sample(start: f32, end: f32, sample: f32) -> bool {
-  return select(sample <= start && sample > end,
-                sample >= start && sample < end,
-                end > start);
+  let lo = min(start, end);
+  let hi = max(start, end);
+  return sample >= lo && sample < hi;
 }
 
 fn accumulateHoriz(slot: u32, sample: vec2f, ppemX: f32) -> RayCoverage {

--- a/donner/svg/renderer/geode/shaders/slug_fill.wgsl
+++ b/donner/svg/renderer/geode/shaders/slug_fill.wgsl
@@ -252,6 +252,14 @@ struct RayCoverage {
   wgt: f32,
 };
 
+// A shared vertex belongs to the curve that starts there, not the curve that ends there.
+// Testing the monotonic axis directly avoids backend-dependent root rounding near t=1.
+fn owns_axis_sample(start: f32, end: f32, sample: f32) -> bool {
+  return select(sample <= start && sample > end,
+                sample >= start && sample < end,
+                end > start);
+}
+
 fn accumulateHoriz(slot: u32, sample: vec2f, ppemX: f32) -> RayCoverage {
   var result: RayCoverage;
   result.cov = 0.0;
@@ -262,6 +270,9 @@ fn accumulateHoriz(slot: u32, sample: vec2f, ppemX: f32) -> RayCoverage {
   let band = bands[slot];
   for (var i = 0u; i < band.curveCount; i = i + 1u) {
     let curve = load_h_curve(band.curveStart + i);
+    if (!owns_axis_sample(curve.p0.y, curve.p2.y, sample.y)) {
+      continue;
+    }
     let a = curve.p0.y - 2.0 * curve.p1.y + curve.p2.y;
     let b = 2.0 * (curve.p1.y - curve.p0.y);
     let c = curve.p0.y - sample.y;
@@ -295,6 +306,9 @@ fn accumulateVert(slot: u32, sample: vec2f, ppemY: f32) -> RayCoverage {
   let band = vBands[slot];
   for (var i = 0u; i < band.curveCount; i = i + 1u) {
     let curve = load_v_curve(band.curveStart + i);
+    if (!owns_axis_sample(curve.p0.x, curve.p2.x, sample.x)) {
+      continue;
+    }
     // Solve for the t where the curve's X equals sample.x.
     let a = curve.p0.x - 2.0 * curve.p1.x + curve.p2.x;
     let b = 2.0 * (curve.p1.x - curve.p0.x);

--- a/donner/svg/renderer/geode/shaders/slug_gradient.wgsl
+++ b/donner/svg/renderer/geode/shaders/slug_gradient.wgsl
@@ -172,6 +172,14 @@ struct RayCoverage {
   wgt: f32,
 };
 
+// A shared vertex belongs to the curve that starts there, not the curve that ends there.
+// Testing the monotonic axis directly avoids backend-dependent root rounding near t=1.
+fn owns_axis_sample(start: f32, end: f32, sample: f32) -> bool {
+  return select(sample <= start && sample > end,
+                sample >= start && sample < end,
+                end > start);
+}
+
 fn accumulateHoriz(slot: u32, sample: vec2f, ppemX: f32) -> RayCoverage {
   var result: RayCoverage;
   result.cov = 0.0;
@@ -182,6 +190,9 @@ fn accumulateHoriz(slot: u32, sample: vec2f, ppemX: f32) -> RayCoverage {
   let band = bands[slot];
   for (var i = 0u; i < band.curveCount; i = i + 1u) {
     let curve = load_h_curve(band.curveStart + i);
+    if (!owns_axis_sample(curve.p0.y, curve.p2.y, sample.y)) {
+      continue;
+    }
     let a = curve.p0.y - 2.0 * curve.p1.y + curve.p2.y;
     let b = 2.0 * (curve.p1.y - curve.p0.y);
     let c = curve.p0.y - sample.y;
@@ -213,6 +224,9 @@ fn accumulateVert(slot: u32, sample: vec2f, ppemY: f32) -> RayCoverage {
   let band = vBands[slot];
   for (var i = 0u; i < band.curveCount; i = i + 1u) {
     let curve = load_v_curve(band.curveStart + i);
+    if (!owns_axis_sample(curve.p0.x, curve.p2.x, sample.x)) {
+      continue;
+    }
     let a = curve.p0.x - 2.0 * curve.p1.x + curve.p2.x;
     let b = 2.0 * (curve.p1.x - curve.p0.x);
     let c = curve.p0.x - sample.x;

--- a/donner/svg/renderer/geode/shaders/slug_gradient.wgsl
+++ b/donner/svg/renderer/geode/shaders/slug_gradient.wgsl
@@ -172,12 +172,18 @@ struct RayCoverage {
   wgt: f32,
 };
 
-// A shared vertex belongs to the curve that starts there, not the curve that ends there.
-// Testing the monotonic axis directly avoids backend-dependent root rounding near t=1.
+// Ownership of a shared vertex on the monotone axis, as a direction-independent
+// half-open interval [min, max): min-inclusive, max-exclusive. This is the standard
+// scanline winding convention. A start-inclusive/end-exclusive test (which flips to
+// max-inclusive for a decreasing curve) miscounts a Y-extremum shared vertex as a
+// single crossing when the sample lands exactly on the extremum value, breaking fill
+// parity for that scanline. Metal never samples exactly on the integer extremum;
+// llvmpipe does, so [min, max) is required for cross-backend agreement. Testing the
+// monotone axis directly also avoids backend-dependent root rounding near t=1.
 fn owns_axis_sample(start: f32, end: f32, sample: f32) -> bool {
-  return select(sample <= start && sample > end,
-                sample >= start && sample < end,
-                end > start);
+  let lo = min(start, end);
+  let hi = max(start, end);
+  return sample >= lo && sample < hi;
 }
 
 fn accumulateHoriz(slot: u32, sample: vec2f, ppemX: f32) -> RayCoverage {

--- a/donner/svg/renderer/geode/shaders/slug_mask.wgsl
+++ b/donner/svg/renderer/geode/shaders/slug_mask.wgsl
@@ -152,12 +152,18 @@ struct RayCoverage {
   wgt: f32,
 };
 
-// A shared vertex belongs to the curve that starts there, not the curve that ends there.
-// Testing the monotonic axis directly avoids backend-dependent root rounding near t=1.
+// Ownership of a shared vertex on the monotone axis, as a direction-independent
+// half-open interval [min, max): min-inclusive, max-exclusive. This is the standard
+// scanline winding convention. A start-inclusive/end-exclusive test (which flips to
+// max-inclusive for a decreasing curve) miscounts a Y-extremum shared vertex as a
+// single crossing when the sample lands exactly on the extremum value, breaking fill
+// parity for that scanline. Metal never samples exactly on the integer extremum;
+// llvmpipe does, so [min, max) is required for cross-backend agreement. Testing the
+// monotone axis directly also avoids backend-dependent root rounding near t=1.
 fn owns_axis_sample(start: f32, end: f32, sample: f32) -> bool {
-  return select(sample <= start && sample > end,
-                sample >= start && sample < end,
-                end > start);
+  let lo = min(start, end);
+  let hi = max(start, end);
+  return sample >= lo && sample < hi;
 }
 
 fn accumulateHoriz(slot: u32, sample: vec2f, ppemX: f32) -> RayCoverage {

--- a/donner/svg/renderer/geode/shaders/slug_mask.wgsl
+++ b/donner/svg/renderer/geode/shaders/slug_mask.wgsl
@@ -152,6 +152,14 @@ struct RayCoverage {
   wgt: f32,
 };
 
+// A shared vertex belongs to the curve that starts there, not the curve that ends there.
+// Testing the monotonic axis directly avoids backend-dependent root rounding near t=1.
+fn owns_axis_sample(start: f32, end: f32, sample: f32) -> bool {
+  return select(sample <= start && sample > end,
+                sample >= start && sample < end,
+                end > start);
+}
+
 fn accumulateHoriz(slot: u32, sample: vec2f, ppemX: f32) -> RayCoverage {
   var result: RayCoverage;
   result.cov = 0.0;
@@ -162,6 +170,9 @@ fn accumulateHoriz(slot: u32, sample: vec2f, ppemX: f32) -> RayCoverage {
   let band = bands[slot];
   for (var i = 0u; i < band.curveCount; i = i + 1u) {
     let curve = load_h_curve(band.curveStart + i);
+    if (!owns_axis_sample(curve.p0.y, curve.p2.y, sample.y)) {
+      continue;
+    }
     let a = curve.p0.y - 2.0 * curve.p1.y + curve.p2.y;
     let b = 2.0 * (curve.p1.y - curve.p0.y);
     let c = curve.p0.y - sample.y;
@@ -193,6 +204,9 @@ fn accumulateVert(slot: u32, sample: vec2f, ppemY: f32) -> RayCoverage {
   let band = vBands[slot];
   for (var i = 0u; i < band.curveCount; i = i + 1u) {
     let curve = load_v_curve(band.curveStart + i);
+    if (!owns_axis_sample(curve.p0.x, curve.p2.x, sample.x)) {
+      continue;
+    }
     let a = curve.p0.x - 2.0 * curve.p1.x + curve.p2.x;
     let b = 2.0 * (curve.p1.x - curve.p0.x);
     let c = curve.p0.x - sample.x;

--- a/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
@@ -302,6 +302,28 @@ TEST(GeodePathEncoder, VerticalBandsConsistentWinding) {
   }
 }
 
+TEST(GeodePathEncoder, ClosedStrokeRightContourUsesInsideJoins) {
+  // Exact path from filters/filter/path-bbox.svg. The closed stroke's right contour must
+  // truncate inside joins at their miter intersections instead of retaining both offset
+  // endpoints. The latter produces a self-intersecting wedge at (65, 135).
+  const Path path = PathBuilder()
+                        .moveTo({50, 85})
+                        .lineTo({65, 135})
+                        .lineTo({150, 135})
+                        .lineTo({150, 85})
+                        .quadTo({100, 45}, {50, 85})
+                        .closePath()
+                        .build();
+  const Path stroke = path.strokeToFill({.width = 1.0});
+  ASSERT_FALSE(stroke.empty());
+  EXPECT_EQ(stroke.points().size(), 95u)
+      << "Pre-fix right-contour misclassification emitted 117 outline points";
+  EXPECT_EQ(stroke.commands().size(), 97u);
+
+  const EncodedPath encoded = GeodePathEncoder::encode(stroke, FillRule::EvenOdd);
+  ASSERT_FALSE(encoded.empty());
+}
+
 // M3c: the dense band-grid maps cells onto the packed band arrays so the analytic
 // shader can look up its band in O(1) from a sample position. Verify the grid is the
 // right size and each non-empty cell points at a band whose strip matches the cell.

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -648,6 +648,39 @@ TEST_F(RendererGeodeTest, StrokeRectOutline) {
   EXPECT_THAT(corner, IsTransparent()) << "Corner should be transparent";
 }
 
+TEST_F(RendererGeodeTest, StrokeSharedVertexDoesNotExtendVertically) {
+  RendererGeode renderer = createRenderer();
+  RenderViewport viewport;
+  viewport.size = Vector2d(200, 200);
+  viewport.devicePixelRatio = 1.0;
+  renderer.beginFrame(viewport);
+
+  renderer.setPaint(solidStroke(css::RGBA(0, 0, 255, 255)));
+  StrokeParams stroke;
+  stroke.strokeWidth = 1.0;
+  stroke.lineJoin = StrokeLinejoin::Miter;
+
+  PathShape shape;
+  shape.path = PathBuilder()
+                   .moveTo({50, 85})
+                   .lineTo({65, 135})
+                   .lineTo({150, 135})
+                   .lineTo({150, 85})
+                   .quadTo({100, 45}, {50, 85})
+                   .closePath()
+                   .build();
+  shape.fillRule = FillRule::NonZero;
+  renderer.drawPath(shape, stroke);
+  renderer.endFrame();
+
+  const RendererBitmap snap = renderer.takeSnapshot();
+  ASSERT_FALSE(snap.empty());
+  for (int y = 90; y <= 120; y += 10) {
+    EXPECT_THAT(pixelAt(snap, 65, y), IsTransparent())
+        << "Stroke must not extend vertically above the shared vertex at y=" << y;
+  }
+}
+
 /// Fill and stroke together: interior should be the fill color, the stroke
 /// ring around the edge should be the stroke color.
 TEST_F(RendererGeodeTest, FillAndStrokeRect) {

--- a/donner/svg/renderer/tests/resvg_test_suite.cc
+++ b/donner/svg/renderer/tests/resvg_test_suite.cc
@@ -423,15 +423,6 @@ INSTANTIATE_TEST_SUITE_P(
                  Params::WithThreshold(0.3f, 600, "Subregion edge AA")},
                 {"with-subregion-3.svg", Params::WithThreshold(0.1f, kDefaultMismatchedPixels,
                                                                "Minor shading differences")},
-                // Geode draws a spurious ~58px vertical blue stroke straight up
-                // from the (65,135) path vertex, where the path has no vertical
-                // edge - a solid 1px-wide, 146px-tall hard diff (148px vs 100
-                // budget). TinySkia renders it at 1px, so this is a real Geode
-                // path-encoder / stroke-join defect, not AA or cross-arch
-                // rounding. CPU backends still compare; disable Geode only.
-                // Tracked in https://github.com/jwmcglynn/donner/issues/663.
-                {"path-bbox.svg", GeodeDisabled("Geode stroke-join bug #663")},
-
                 {"content-outside-the-canvas-2.svg",
                  Params::Skip(
                      "Bug: <filter> edge cases (filterRes, filterUnits, multiple inputs)")},


### PR DESCRIPTION
Fixes a Geode-only stroke artifact at a closed path's shared start/end vertex.

**Root cause**

The right contour negated its normals but still classified joins as the left side. Negating both vectors preserves the cross-product sign, so inside joins could be misclassified and emit a spurious wedge. Shared endpoints also needed half-open ownership to avoid counting the same endpoint twice.

**Changes**

- Classify the closed right contour with right-side join semantics.
- Apply half-open endpoint ownership consistently in the fill, gradient, and mask Slug shaders.
- Add path encoding, shader, and renderer regressions for shared-vertex strokes.
- Re-enable the exact Geode `path-bbox.svg` golden comparison.

**Verification**

- Affected base, Geode path encoder, shader, and renderer tests pass on the rebased head.
- Exact `path-bbox.svg` Geode golden passes.
- Full `bazel test //...`: 740 tests passed; all renderer, Geode, resvg, SVG, lint, and CMake lanes passed. One source-pane screenshot assertion failed under full-suite load, reproduced independently of this change, and passed on exact isolated rerun.

Fixes #663.