### PR TITLE
Use the default rounded marker comparison budget

### DIFF
--- a/donner/svg/renderer/tests/resvg_test_suite.cc
+++ b/donner/svg/renderer/tests/resvg_test_suite.cc
@@ -743,8 +743,9 @@ INSTANTIATE_TEST_SUITE_P(
                 // Issue #623: the rounded-rect start corner now stacks marker-start +
                 // arrival marker-mid + marker-end (3 markers), matching resvg, after
                 // Path::vertices() emits the arrival mid for zero-length-close corner
-                // contours. Residual is sub-marker edge coverage.
-                {"marker-on-rounded-rect.svg", WithMaxPixels(60, "Marker stack edge coverage")},
+                // contours. Residual sub-marker edge coverage is a measured ~24px, under
+                // the default comparison budget, so no per-test override is needed.
+                {"marker-on-rounded-rect.svg", Params{}},
                 {"recursive-5.svg", Params{}},
             })),
         ValuesIn(ActiveComparisonModes())),


### PR DESCRIPTION
Removes the legacy per-case budget for `marker-on-rounded-rect.svg` after confirming the original extra-marker geometry defect is fixed on main.

**Evidence**

- A forced-zero comparison renders the correct marker-start, arrival marker-mid, and marker-end stack.
- The remaining residual is exactly 24 pixels, confined to the overlap between the semi-transparent marker edge and the green stroke.
- The residual is below the suite's default sub-100 cross-rasterizer budget, so a bespoke threshold is neither needed nor consistent with the documented convention.

**Change**

Remove the old 60-pixel override and let this case use the standard comparison parameters.

**Verification**

- Focused default-text comparison: pass.
- Focused full-text comparison: pass.
- Focused Geode comparison: pass.
- Fresh exact-head PR CI is required after the rebase.

Refs #623.