### PR TITLE
Re-enable passing Geode marker ref regression

### DIFF
--- a/donner/svg/tests/SVGMarkerElement_tests.cc
+++ b/donner/svg/tests/SVGMarkerElement_tests.cc
@@ -282,10 +282,6 @@ TEST(SVGMarkerElementTests, MarkerEndProperty) {
 /// 16 = 8, displacing the marker. Asserted differentially so the expected placement needs no
 /// hand-derived golden.
 TEST(SVGMarkerElementRenderingTests, RefKeywordResolvesAgainstMarkerViewBox) {
-  if (ActiveRendererBackend() == RendererBackend::Geode) {
-    GTEST_SKIP() << "Known broken on Geode backend (jwmcglynn/donner#566).";
-  }
-
   const AsciiImage keyword = RendererTestUtils::renderToAsciiImage(R"-(
     <svg viewBox="0 0 16 16">
       <defs>


### PR DESCRIPTION
Removes one stale Geode backend skip discovered during the issue #566 test-surface audit.

**Audit result**

All 18 issue-tagged Geode guards were temporarily removed and exercised. Seventeen still fail and remain guarded: four clip-path cases, three ellipse cases, four marker cases, and six pattern cases. `SVGMarkerElementRenderingTests.RefKeywordResolvesAgainstMarkerViewBox` is the sole stale guard and passes on Geode.

**Change**

Remove only that test's Geode skip. The test continues to assert `refX="50%"` / `refY="50%"` resolution against the marker viewBox through differential placement.

**Verification**

- Exact Geode regression: pass on the rebased head.
- Full affected `svg_tests_geode` target: pass.
- Full `bazel test //...` was attempted twice. The first run was interrupted by a signal-9 remote GLFW compile; its exact target passed on verbose rerun. The second reached 150 tests before a remote license tool could not load `libpython3.12.dylib`; that exact notice target also passed on isolated rerun. Fresh PR CI remains the required full gate.

This PR does not close #566; the 17 genuine failures and the broader M2.3 work remain open.

Refs #566.