### PR TITLE
test(editor): cover TextEditor gutter-drag cancel paths and diagnostics tooltip

### DIFF
--- a/donner/editor/tests/TextEditor_tests.cc
+++ b/donner/editor/tests/TextEditor_tests.cc
@@ -209,6 +209,33 @@ protected:
     ImGui::Render();
   }
 
+  /// Full-control input frame: mouse position, left/right button state, and an
+  /// optional Escape press. Used by gutter-drag cancellation and context-menu
+  /// tests that need inputs the simpler helpers cannot express.
+  void RenderEditorFrameWithInputs(const ImVec2& mousePos, bool leftDown, bool rightDown,
+                                   bool escapePressed = false,
+                                   const ImVec2& editorSize = ImVec2(240.0f, 180.0f)) {
+    editor.setHandleKeyboardInputs(false);
+    editor.setHandleMouseInputs(true);
+
+    ImGuiIO& io = ImGui::GetIO();
+    io.DisplaySize = ImVec2(800.0f, 600.0f);
+    io.AddMousePosEvent(mousePos.x, mousePos.y);
+    io.AddMouseButtonEvent(0, leftDown);
+    io.AddMouseButtonEvent(1, rightDown);
+    io.AddKeyEvent(ImGuiKey_Escape, escapePressed);
+
+    ImGui::NewFrame();
+    ImGui::SetNextWindowPos(ImVec2(0.0f, 0.0f), ImGuiCond_Always);
+    ImGui::SetNextWindowSize(ImVec2(editorSize.x + 40.0f, editorSize.y + 40.0f), ImGuiCond_Always);
+    ImGui::Begin(
+        "TextEditorTestWindow", nullptr,
+        ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings);
+    editor.render("##editor", editorSize);
+    ImGui::End();
+    ImGui::Render();
+  }
+
   // Drives one render frame with keyboard input handling enabled, injecting
   // the supplied modifier state, key presses, and typed characters. ImGui
   // reports `IsKeyPressed` on the frame a key transitions from up→down, so
@@ -5222,6 +5249,115 @@ TEST_F(TextEditorTests, MouseDragNearBottomAutoscrollsThroughRenderPath) {
   RenderEditorFrameWithMouse(bottomEdge, /*mouseDown=*/true, editorSize);
 
   EXPECT_TRUE(editor.hasSelection());
+}
+
+TEST_F(TextEditorTests, GutterDragCancelsOnEscapeKey) {
+  editor.setText("one\ntwo\nthree");
+  RenderEditorFrame();
+
+  const ImVec2 handle = SourceGutterHandlePoint(/*visualIndex=*/0);
+  RenderEditorFrameWithMouse(handle, /*mouseDown=*/false);
+  RenderEditorFrameWithMouse(handle, /*mouseDown=*/true);
+  ASSERT_EQ(editor.takeSourceGutterDragStartedLine(), 0);
+  ASSERT_TRUE(editor.sourceGutterDragTarget().has_value());
+
+  // Escape while the drag button is still held abandons the gesture.
+  RenderEditorFrameWithInputs(handle, /*leftDown=*/true, /*rightDown=*/false,
+                              /*escapePressed=*/true);
+
+  EXPECT_TRUE(editor.takeSourceGutterDragCancelled());
+  EXPECT_FALSE(editor.sourceGutterDragTarget().has_value());
+  EXPECT_FALSE(editor.takeSourceGutterDropTarget().has_value());
+  EXPECT_EQ(editor.getText(), "one\ntwo\nthree");
+}
+
+TEST_F(TextEditorTests, GutterDragCancelsOnRightClick) {
+  editor.setText("one\ntwo\nthree");
+  RenderEditorFrame();
+
+  const ImVec2 handle = SourceGutterHandlePoint(/*visualIndex=*/0);
+  RenderEditorFrameWithMouse(handle, /*mouseDown=*/false);
+  RenderEditorFrameWithMouse(handle, /*mouseDown=*/true);
+  ASSERT_EQ(editor.takeSourceGutterDragStartedLine(), 0);
+
+  // A right-click mid-drag abandons the gesture without dropping.
+  RenderEditorFrameWithInputs(handle, /*leftDown=*/true, /*rightDown=*/true);
+
+  EXPECT_TRUE(editor.takeSourceGutterDragCancelled());
+  EXPECT_FALSE(editor.sourceGutterDragTarget().has_value());
+  EXPECT_FALSE(editor.takeSourceGutterDropTarget().has_value());
+}
+
+TEST_F(TextEditorTests, GutterDragCancelsWhenReleasedOutsideWindow) {
+  editor.setText("one\ntwo\nthree");
+  RenderEditorFrame();
+
+  const ImVec2 handle = SourceGutterHandlePoint(/*visualIndex=*/0);
+  RenderEditorFrameWithMouse(handle, /*mouseDown=*/false);
+  RenderEditorFrameWithMouse(handle, /*mouseDown=*/true);
+  ASSERT_EQ(editor.takeSourceGutterDragStartedLine(), 0);
+
+  // Drag far outside the editor window, then release there: the gesture
+  // cancels instead of dropping at a bogus position.
+  const ImVec2 outside(780.0f, 580.0f);
+  RenderEditorFrameWithInputs(outside, /*leftDown=*/true, /*rightDown=*/false);
+  RenderEditorFrameWithInputs(outside, /*leftDown=*/false, /*rightDown=*/false);
+
+  EXPECT_TRUE(editor.takeSourceGutterDragCancelled());
+  EXPECT_FALSE(editor.sourceGutterDragTarget().has_value());
+  EXPECT_FALSE(editor.takeSourceGutterDropTarget().has_value());
+  EXPECT_EQ(editor.getText(), "one\ntwo\nthree");
+}
+
+TEST_F(TextEditorTests, SourceDiagnosticTooltipRendersOnHover) {
+  editor.setText("<svg><rect/></svg>");
+  ASSERT_TRUE(editor.setSourceDiagnostics({
+      SourceDiagnostic{.id = 11,
+                       .range = {5, 12},
+                       .line = 1,
+                       .column = 5,
+                       .endLine = 1,
+                       .endColumn = 12,
+                       .severity = DiagnosticSeverity::Error,
+                       .message = "rect is unclosed"},
+  }));
+  RenderEditorFrame();
+
+  // Baseline frame: mouse away from the diagnostic, no tooltip.
+  const ImVec2 away = ScreenPointAtVisualTextOffset(/*visualIndex=*/0, /*visualColumnOffset=*/1);
+  RenderEditorFrameWithMouse(away, /*mouseDown=*/false);
+  EXPECT_FALSE(editor.hoveredSourceDiagnosticId().has_value());
+  const ImDrawData* baseline = ImGui::GetDrawData();
+  ASSERT_NE(baseline, nullptr);
+  const int baselineWindows = baseline->CmdListsCount;
+
+  // Hovering inside the diagnostic range shows the severity tooltip.
+  const ImVec2 hover = ScreenPointAtVisualTextOffset(/*visualIndex=*/0, /*visualColumnOffset=*/7);
+  RenderEditorFrameWithMouse(hover, /*mouseDown=*/false);
+  EXPECT_EQ(editor.hoveredSourceDiagnosticId(), 11u);
+  RenderEditorFrameWithMouse(hover, /*mouseDown=*/false);
+  const ImDrawData* hovered = ImGui::GetDrawData();
+  ASSERT_NE(hovered, nullptr);
+  EXPECT_GT(hovered->CmdListsCount, baselineWindows)
+      << "Hovering a diagnostic must open its tooltip window.";
+}
+
+TEST_F(TextEditorTests, RightClickInTextMovesCursorToClickPosition) {
+  editor.setText("hello world");
+  editor.setCursorPosition(Coordinates(0, 0));
+  RenderEditorFrame();
+
+  // Right-clicking inside the text area (the context-menu gesture) moves the
+  // caret to the clicked position before the popup opens, so a subsequent
+  // Cut/Copy/Paste acts on the intended spot.
+  const ImVec2 textPoint =
+      ScreenPointAtVisualTextOffset(/*visualIndex=*/0, /*visualColumnOffset=*/6);
+  RenderEditorFrameWithInputs(textPoint, /*leftDown=*/false, /*rightDown=*/false);
+  RenderEditorFrameWithInputs(textPoint, /*leftDown=*/false, /*rightDown=*/true);
+
+  EXPECT_EQ(editor.getCursorPosition(), Coordinates(0, 6))
+      << "A right-click over text must reposition the caret to the click point.";
+  EXPECT_EQ(editor.getText(), "hello world") << "A right-click must not modify the text.";
 }
 
 }  // namespace donner::editor


### PR DESCRIPTION
## What

Covers TextEditor gutter-drag cancellation arms and the source-diagnostic
tooltip (plan item, `donner/editor/TextEditor.cc`). Existing gutter tests drove
only the happy-path drop; diagnostics tests exercised the model but never the
hover tooltip render.

Adds a `RenderEditorFrameWithInputs` helper (mouse position, both button states,
optional Escape) and five behavior-asserting tests:

- **GutterDragCancelsOnEscapeKey / GutterDragCancelsOnRightClick /
  GutterDragCancelsWhenReleasedOutsideWindow** - each abandons an in-progress
  gutter drag through a distinct arm and leaves the text unchanged with no drop
  target.
- **SourceDiagnosticTooltipRendersOnHover** - hovering inside a diagnostic's
  range reports its id and opens an extra tooltip draw list; hovering away does
  not.
- **RightClickInTextMovesCursorToClickPosition** - the context-menu right-click
  gesture repositions the caret to the clicked point without modifying text.

## Harness note (reusable)

TextEditor's Cut/Copy/Paste context menu uses `ImGui::BeginPopupContextItem`,
which opens only on right-button **release** while the last-submitted item is
hovered (`IsMouseReleased(1) && IsItemHovered(...)`). In the headless fixture the
trailing item after `renderInternal` is not reliably the hovered text region, so
the popup cannot be opened deterministically. This suite covers the
caret-repositioning arm of the gesture rather than clicking a popup row. (Pairs
with the #856 note: ImGui immediate-mode popups and drag activation are
sensitive to which item/window is hovered on the exact input-transition frame.)

## Coverage delta

Projected from the current Codecov line map: ~+70 previously-uncovered lines in
`TextEditor.cc` (gutter cancel arms 940-966, diagnostic tooltip 2828-2853,
right-click cursor arm 4070-4074). ~+0.10 project points. Will confirm against
Codecov post-merge.

## Testing

`bazel test //donner/editor/tests:text_editor_tests` passes (full suite, ~0.4 s,
pure ImGui context fixture).

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
