### PR TITLE
refactor(editor): drop dead body of TextEditor::buildMemberSuggestions

### DIFF
--- a/donner/editor/TextEditor.cc
+++ b/donner/editor/TextEditor.cc
@@ -3708,23 +3708,14 @@ std::string toLowercase(std::string_view str) {
 
 }  // namespace
 
-void TextEditor::buildMemberSuggestions(bool* keepAutocompleteOpen) {
+void TextEditor::buildMemberSuggestions(bool*) {
+  // Member-completion after a '.' was never implemented: no code path ever
+  // populates autocompleteSuggestions_ here, so the guarded block below was
+  // unreachable (the vector is always empty immediately after the clear), and
+  // its `object`/`curPos` inputs were computed and discarded. Only the clear
+  // is observable; the real suggestion list is (re)built by buildSuggestions on
+  // the following frame. Reduced to the one behavior that is actually reached.
   autocompleteSuggestions_.clear();
-
-  auto curPos = getCorrectCursorPosition();
-  RcString object = getWordAt(curPos);
-
-  if (!autocompleteSuggestions_.empty()) {
-    autocompleteOpened_ = true;
-    autocompleteWord_.clear();
-
-    if (keepAutocompleteOpen != nullptr) {
-      *keepAutocompleteOpen = true;
-    }
-
-    Coordinates curCursor = getCursorPosition();
-    autocompletePosition_ = findWordStart(curCursor);
-  }
 }
 
 void TextEditor::buildSuggestions(bool* keepAutocompleteOpen) {


### PR DESCRIPTION
## What

Removes the unreachable body of `TextEditor::buildMemberSuggestions` (plan item
6: dead code deletion with an argument).

The function is invoked when the user types `.` and was a never-completed
member-completion stub:

```cpp
autocompleteSuggestions_.clear();
auto curPos = getCorrectCursorPosition();
RcString object = getWordAt(curPos);
if (!autocompleteSuggestions_.empty()) {   // always false
  ...populate + autocompleteOpened_ = true...
}
```

## Argument that it is dead

- The `if (!autocompleteSuggestions_.empty())` guard is **always false**: the
  vector is `.clear()`ed two lines above and nothing inserts into it before the
  check. The entire guarded block is unreachable.
- `curPos` and `object` feed only that dead block (`object` is never read at
  all); both are side-effect-free reads (`getWordAt` is const,
  `getCorrectCursorPosition` only computes), so removing them changes nothing.
- The dead block is the only place the function would set `autocompleteOpened_`
  or `*keepAutocompleteOpen`, so the function's **only observable effect is the
  clear**.
- That clear is itself transient: `enterCharacter` sets
  `readyForAutocomplete_ = false` on the same frame, so `buildSuggestions` (the
  real autocomplete builder, which clears and rebuilds) runs on the **next**
  frame regardless.

## Change

Reduce the function to its one reached statement (`autocompleteSuggestions_.clear();`),
preserving behavior exactly. The call site and header declaration are left
untouched so the clear-on-dot timing is unchanged. Completing real member
completion is explicitly out of scope (flagged, not attempted).

## Coverage effect

Removes ~13 permanently-uncovered lines from the denominator (legitimate: the
lines are provably dead, not excluded from measurement). Net project coverage
ticks up slightly.

## Testing

`bazel test //donner/editor/tests:text_editor_tests` and the editor widget /
XML-autocomplete suite both pass unchanged.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
