### PR TITLE
Fix zero-gap dash seams across renderer backends

### DIFF
--- a/donner/base/Path.cc
+++ b/donner/base/Path.cc
@@ -2228,8 +2228,7 @@ std::optional<ResolvedDashPattern> resolveDashPattern(const std::vector<double>&
   // reasonable size. Matches spec behavior (odd -> double) but bails out if
   // the result would be unreasonably large. Real SVG dasharrays are rarely
   // longer than ~16 entries.
-  constexpr size_t kMaxDashEntries = 256;
-  if (rawDashes.size() > kMaxDashEntries) {
+  if (rawDashes.size() > StrokeStyle::kMaxDashEntries) {
     return std::nullopt;
   }
 

--- a/donner/base/Path.h
+++ b/donner/base/Path.h
@@ -1,6 +1,7 @@
 #pragma once
 /// @file
 
+#include <cstddef>
 #include <cstdint>
 #include <ostream>
 #include <span>
@@ -51,6 +52,9 @@ inline std::ostream& operator<<(std::ostream& os, LineJoin join) {
 
 /// Parameters for converting a stroked path to a filled outline.
 struct StrokeStyle {
+  /// Maximum dash entries accepted by \ref Path::strokeToFill before falling back to solid.
+  static constexpr std::size_t kMaxDashEntries = 256;
+
   double width = 1.0;               ///< Stroke width.
   LineCap cap = LineCap::Butt;      ///< Line cap style for open subpath endpoints.
   LineJoin join = LineJoin::Miter;  ///< Line join style for corners between segments.

--- a/donner/base/tests/Path_tests.cc
+++ b/donner/base/tests/Path_tests.cc
@@ -2077,15 +2077,18 @@ TEST(Path, StrokeToFillZeroLengthSubpathCaps) {
 }
 
 TEST(Path, StrokeToFillDashOversizedPatternFallsBackToSolid) {
-  Path path = PathBuilder().moveTo({0, 0}).lineTo({100, 0}).build();
+  Path path = PathBuilder().addRect(Box2d({0, 0}, {100, 100})).build();
   StrokeStyle style;
-  style.width = 1.0;
+  style.width = 10.0;
   style.dashArray.assign(257, 1.0);
 
-  Path filled = path.strokeToFill(style);
+  const Path filled = path.strokeToFill(style);
+  style.dashArray.clear();
+  const Path solid = path.strokeToFill(style);
 
-  EXPECT_FALSE(filled.empty());
-  EXPECT_EQ(countSubpaths(filled), 1u);
+  ASSERT_FALSE(filled.empty());
+  EXPECT_EQ(filled, solid) << "an oversized dash pattern must retain the exact solid outline";
+  EXPECT_EQ(countSubpaths(filled), 2u);
 }
 
 TEST(Path, StrokeToFillDashSkipsZeroLengthSegments) {

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1686,11 +1686,12 @@ struct RendererGeode::Impl {
   /// Determine the fill rule for a stroked outline. Each painted interval of
   /// a valid dash pattern becomes a separate closed ribbon. Those ribbons use
   /// NonZero so adjacent or wrapped dashes union instead of canceling their
-  /// overlaps. Invalid and all-zero patterns fall back to solid stroking, where
+  /// overlaps. Invalid, oversized, and all-zero patterns fall back to solid stroking, where
   /// open paths produce one subpath (NonZero) and closed paths produce two
   /// same-winding subpaths (EvenOdd hollow-ring semantics).
   static FillRule strokeFillRuleFor(const Path& strokedOutline, const StrokeStyle& strokeStyle) {
-    if (!strokeStyle.dashArray.empty()) {
+    if (!strokeStyle.dashArray.empty() &&
+        strokeStyle.dashArray.size() <= StrokeStyle::kMaxDashEntries) {
       double dashSum = 0.0;
       for (double dash : strokeStyle.dashArray) {
         if (!std::isfinite(dash) || dash < 0.0) {

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1683,11 +1683,27 @@ struct RendererGeode::Impl {
     return true;
   }
 
-  /// Determine the fill rule for a stroked outline per the subpath-count
-  /// rule documented in `RendererGeode::drawPath`. Open-path strokes
-  /// produce one subpath (NonZero); closed-path strokes produce two
+  /// Determine the fill rule for a stroked outline. Each painted interval of
+  /// a valid dash pattern becomes a separate closed ribbon. Those ribbons use
+  /// NonZero so adjacent or wrapped dashes union instead of canceling their
+  /// overlaps. Invalid and all-zero patterns fall back to solid stroking, where
+  /// open paths produce one subpath (NonZero) and closed paths produce two
   /// same-winding subpaths (EvenOdd hollow-ring semantics).
-  static FillRule strokeFillRuleFor(const Path& strokedOutline) {
+  static FillRule strokeFillRuleFor(const Path& strokedOutline, const StrokeStyle& strokeStyle) {
+    if (!strokeStyle.dashArray.empty()) {
+      double dashSum = 0.0;
+      for (double dash : strokeStyle.dashArray) {
+        if (!std::isfinite(dash) || dash < 0.0) {
+          dashSum = 0.0;
+          break;
+        }
+        dashSum += dash;
+      }
+      if (std::isfinite(dashSum) && dashSum > 0.0) {
+        return FillRule::NonZero;
+      }
+    }
+
     size_t subpathCount = 0;
     for (const auto& cmd : strokedOutline.commands()) {
       if (cmd.verb == Path::Verb::MoveTo) {
@@ -1718,7 +1734,7 @@ struct RendererGeode::Impl {
           cache.strokeSlot.reset();
           return result;  // strokedPath stays null.
         }
-        const FillRule fillRule = strokeFillRuleFor(stroked);
+        const FillRule fillRule = strokeFillRuleFor(stroked, strokeStyle);
         device->countPathEncode();
         geode::EncodedPath encoded = geode::GeodePathEncoder::encode(stroked, fillRule);
         // GCC 14 libstdc++ rejects `.emplace()` here with "is_constructible_v<StrokeSlot> was not
@@ -1752,7 +1768,7 @@ struct RendererGeode::Impl {
       return result;
     }
     result.strokedPath = &strokeScratchPath;
-    result.fillRule = strokeFillRuleFor(strokeScratchPath);
+    result.fillRule = strokeFillRuleFor(strokeScratchPath, strokeStyle);
     return result;
   }
 
@@ -3885,7 +3901,7 @@ void RendererGeode::drawText(Registry& registry, const components::ComputedTextC
         // not a hardcoded NonZero -- see RendererGeode::drawPath's stroke notes.
         const Path stroked = placed.strokeToFill(*strokeStyle);
         if (!stroked.empty()) {
-          const FillRule strokeRule = Impl::strokeFillRuleFor(stroked);
+          const FillRule strokeRule = Impl::strokeFillRuleFor(stroked, *strokeStyle);
           if (strokeIsGradient) {
             // Gradient stroke: resolve against the text bbox (the *original*
             // geometry, per SVG), fill the stroked outline.
@@ -3981,7 +3997,8 @@ void RendererGeode::drawText(Registry& registry, const components::ComputedTextC
         if (decoStrokeColor.has_value()) {
           const Path stroked = path.strokeToFill(*decoStrokeStyle);
           if (!stroked.empty()) {
-            impl_->encoder->fillPath(stroked, *decoStrokeColor, Impl::strokeFillRuleFor(stroked));
+            impl_->encoder->fillPath(stroked, *decoStrokeColor,
+                                     Impl::strokeFillRuleFor(stroked, *decoStrokeStyle));
           }
         }
       };

--- a/donner/svg/renderer/RendererTinySkia.cc
+++ b/donner/svg/renderer/RendererTinySkia.cc
@@ -120,7 +120,14 @@ tiny_skia::SpreadMode toTinySpreadMode(GradientSpreadMethod spreadMethod) {
   UTILS_UNREACHABLE();
 }
 
-tiny_skia::Path toTinyPath(const Path& spline) {
+enum class TinyPathCloseBehavior : uint8_t {
+  Preserve,
+  EndWithLine,
+};
+
+tiny_skia::Path toTinyPath(
+    const Path& spline,
+    TinyPathCloseBehavior closeBehavior = TinyPathCloseBehavior::Preserve) {
   tiny_skia::PathBuilder builder(spline.commands().size(), spline.points().size());
   const auto points = spline.points();
 
@@ -153,7 +160,12 @@ tiny_skia::Path toTinyPath(const Path& spline) {
         break;
       }
       case Path::Verb::ClosePath: {
-        builder.close();
+        if (closeBehavior == TinyPathCloseBehavior::Preserve) {
+          builder.close();
+        } else {
+          const Vector2d& subpathStart = points[command.pointIndex];
+          builder.lineTo(NarrowToFloat(subpathStart.x), NarrowToFloat(subpathStart.y));
+        }
         break;
       }
     }
@@ -1169,6 +1181,7 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
     tinyStroke.lineCap = toTinyLineCap(adjustedStroke.lineCap);
     tinyStroke.lineJoin = toTinyLineJoin(adjustedStroke.lineJoin);
 
+    bool dashHasOnlyZeroLengthGaps = false;
     if (!adjustedStroke.dashArray.empty()) {
       const int repeats = (adjustedStroke.dashArray.size() & 1u) != 0u ? 2 : 1;
       std::vector<float> dashArray;
@@ -1179,16 +1192,35 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
         }
       }
 
+      dashHasOnlyZeroLengthGaps = true;
+      for (std::size_t i = 1; i < dashArray.size(); i += 2) {
+        if (dashArray[i] != 0.0f) {
+          dashHasOnlyZeroLengthGaps = false;
+          break;
+        }
+      }
+
       tinyStroke.dash = tiny_skia::StrokeDash::create(std::move(dashArray),
                                                       NarrowToFloat(adjustedStroke.dashOffset));
     }
 
+    // A zero-length gap still terminates one dash and starts the next. TinySkia otherwise joins
+    // those ranges across ClosePath, filling the seam as if the stroke were solid. Replace only
+    // the stroke's ClosePath commands with explicit closing lines so the dash stroker emits caps
+    // at that boundary; fills and ordinary dashed/solid strokes keep their closed contours.
+    std::optional<tiny_skia::Path> openDashSeamPath;
+    const tiny_skia::Path* strokePath = &tinyPath;
+    if (tinyStroke.dash.has_value() && dashHasOnlyZeroLengthGaps) {
+      openDashSeamPath = toTinyPath(path.path, TinyPathCloseBehavior::EndWithLine);
+      strokePath = &*openDashSeamPath;
+    }
+
     auto pixmapView = currentPixmapView();
-    tiny_skia::Painter::strokePath(pixmapView, tinyPath, *strokePaint, tinyStroke,
+    tiny_skia::Painter::strokePath(pixmapView, *strokePath, *strokePaint, tinyStroke,
                                    toTinyTransform(deviceFromLocalTransform_), mask);
     if (strokePaintPixmap != nullptr) {
       auto strokePaintView = strokePaintPixmap->mutableView();
-      tiny_skia::Painter::strokePath(strokePaintView, tinyPath, *strokePaint, tinyStroke,
+      tiny_skia::Painter::strokePath(strokePaintView, *strokePath, *strokePaint, tinyStroke,
                                      toTinyTransform(deviceFromLocalTransform_), mask);
     }
     if (usedPatternStroke) {

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -680,6 +680,31 @@ TEST_F(RendererGeodeTest, StrokeSharedVertexDoesNotExtendVertically) {
         << "Stroke must not extend vertically above the shared vertex at y=" << y;
   }
 }
+/// Dash patterns beyond `Path::strokeToFill`'s allocation guardrail fall back to a solid stroke.
+/// The closed-path outline must retain EvenOdd semantics so its interior remains hollow.
+TEST_F(RendererGeodeTest, OversizedDashArrayPreservesSolidStrokeFallback) {
+  RendererGeode renderer = createRenderer();
+  beginFrame(renderer);
+
+  renderer.setPaint(solidStroke(css::RGBA(255, 0, 0, 255)));
+  StrokeParams stroke;
+  stroke.strokeWidth = 4.0;
+  stroke.dashArray.assign(257, 1.0);
+
+  PathShape shape;
+  shape.path = PathBuilder().addRect(Box2d({16, 16}, {48, 48})).build();
+  shape.fillRule = FillRule::NonZero;
+  renderer.drawPath(shape, stroke);
+
+  renderer.endFrame();
+
+  const RendererBitmap snapshot = renderer.takeSnapshot();
+  ASSERT_FALSE(snapshot.empty());
+  EXPECT_THAT(pixelAt(snapshot, 32, 16), RgbaEq(255, 0, 0, 255))
+      << "oversized dash fallback should retain the solid stroke band";
+  EXPECT_THAT(pixelAt(snapshot, 32, 32), IsTransparent())
+      << "oversized dash fallback must not fill the closed stroke interior";
+}
 
 /// Fill and stroke together: interior should be the fill color, the stroke
 /// ring around the edge should be the stroke color.

--- a/donner/svg/renderer/tests/Renderer_tests.cc
+++ b/donner/svg/renderer/tests/Renderer_tests.cc
@@ -587,11 +587,10 @@ TEST_F(RendererTests, ChainedFeImageDeepRecursionIsBoundedAndStable) {
          "bounded by the depth cap (issue #552)";
 }
 
-// A zero-length gap does not split adjacent painted ranges. Closed contours therefore retain
-// their joins, including the join at the start/end seam, while an explicitly open contour keeps
-// its endpoint caps. Pin the native TinySkia behavior as the renderer-level baseline for the
-// shared path stroker used by Geode.
-TEST_F(RendererTests, DashSeamClosedContourMitersStartCorner) {
+// A zero-length gap still separates adjacent painted ranges. At a closed contour's start/end
+// seam those ranges have caps rather than a join. A dash that remains painted across the seam,
+// and an ordinary solid stroke, retain the closed-contour join.
+TEST_F(RendererTests, DashSeamDistinguishesZeroGapBoundaryFromContinuousStroke) {
   auto renderInner = [&](const std::string& inner) {
     const std::string svg =
         "<svg viewBox=\"0 0 200 200\" xmlns=\"http://www.w3.org/2000/svg\">" + inner + "</svg>";
@@ -631,18 +630,28 @@ TEST_F(RendererTests, DashSeamClosedContourMitersStartCorner) {
       renderInner("<path d=\"M40,40 L160,40 L160,160 L40,160 Z\" " + attrs + "/>");
   const RendererBitmap openPath =
       renderInner("<path d=\"M40,40 L160,40 L160,160 L40,160 L40,40\" " + attrs + "/>");
+  const RendererBitmap continuousDash = renderInner(
+      "<path d=\"M40,40 L160,40 L160,160 L40,160 Z\" fill=\"none\" stroke=\"green\" "
+      "stroke-width=\"20\" stroke-dasharray=\"50 10\" stroke-dashoffset=\"10\"/>");
+  const RendererBitmap solidPath = renderInner(
+      "<path d=\"M40,40 L160,40 L160,160 L40,160 Z\" fill=\"none\" stroke=\"green\" "
+      "stroke-width=\"20\"/>");
 
   ASSERT_FALSE(rectEl.empty());
   ASSERT_FALSE(closedPath.empty());
   ASSERT_FALSE(openPath.empty());
+  ASSERT_FALSE(continuousDash.empty());
+  ASSERT_FALSE(solidPath.empty());
 
-  // <rect> is a closed contour -> the dash seam-joins -> mitered start corner (quadrant filled).
-  EXPECT_EQ(greenInOuterCorner(rectEl), 64) << "dashed <rect> should miter its start corner";
-  // An explicit closed <path ... Z> behaves identically.
-  EXPECT_EQ(greenInOuterCorner(closedPath), 64)
-      << "closed <path ... Z> should miter its start corner";
-  // An explicitly open path (no Z) butt-caps the start vertex, like the resvg golden.
+  EXPECT_EQ(greenInOuterCorner(rectEl), 0)
+      << "a zero-gap dash boundary should cap the <rect> seam";
+  EXPECT_EQ(greenInOuterCorner(closedPath), 0)
+      << "a zero-gap dash boundary should cap the closed-path seam";
   EXPECT_EQ(greenInOuterCorner(openPath), 0) << "open dashed path should butt-cap its start corner";
+  EXPECT_EQ(greenInOuterCorner(continuousDash), 64)
+      << "a dash painted across the seam should retain the closed-path join";
+  EXPECT_EQ(greenInOuterCorner(solidPath), 64)
+      << "a solid closed path should retain its start-corner join";
 }
 
 }  // namespace

--- a/donner/svg/renderer/tests/Renderer_tests.cc
+++ b/donner/svg/renderer/tests/Renderer_tests.cc
@@ -587,22 +587,10 @@ TEST_F(RendererTests, ChainedFeImageDeepRecursionIsBoundedAndStable) {
          "bounded by the depth cap (issue #552)";
 }
 
-// Root-cause documentation for issue #623's stroke-dasharray/n-0 residual.
-//
-// The resvg golden draws a *butt-capped* (notched) top-left corner on a `40 0`-dashed closed
-// rect. Donner renders an SVG `<rect>` as a genuinely closed path (`M L L L Z`), and tiny-skia
-// (a line-faithful port of Rust tiny-skia) seam-joins the first and last dash across the start
-// vertex into one continuous dash - so the start corner becomes an interior miter join that
-// fills the outer corner quadrant. This is the spec-conformant closed-dashed-path behavior
-// (Skia / Chrome / Firefox seam-join closed dashed contours); resvg's golden differs because
-// usvg flattens the rect to a non-closed path before dashing.
-//
-// This test pins the difference to closed-vs-open dash seam handling - NOT a rasterizer,
-// coverage, or transform bug - by rendering the same `40 0`-dashed square three ways and
-// measuring green coverage in the outer start-corner quadrant. A `<rect>` and an equivalent
-// closed `<path ... Z>` both miter (fill); only an explicitly open `<path>` butt-caps (empty),
-// reproducing the resvg golden. If a future change makes Donner stop seam-joining closed dashed
-// paths, the rect/closed expectations here trip loudly.
+// A zero-length gap does not split adjacent painted ranges. Closed contours therefore retain
+// their joins, including the join at the start/end seam, while an explicitly open contour keeps
+// its endpoint caps. Pin the native TinySkia behavior as the renderer-level baseline for the
+// shared path stroker used by Geode.
 TEST_F(RendererTests, DashSeamClosedContourMitersStartCorner) {
   auto renderInner = [&](const std::string& inner) {
     const std::string svg =

--- a/donner/svg/renderer/tests/resvg_test_suite.cc
+++ b/donner/svg/renderer/tests/resvg_test_suite.cc
@@ -832,21 +832,7 @@ INSTANTIATE_TEST_SUITE_P(
                     {"negative-sum.svg", Params::RenderOnly("UB (negative sum)")},
                     {"negative-values.svg", Params::RenderOnly("UB (negative values)")},
 
-                    // `0 N` dash patterns (zero-length dashes -> caps/dots) now render. `40 0`
-                    // (zero gap) differs by ~625px at exactly the closed-rect dash-START corner
-                    // (doc (40,40), the outer top-left stroke quadrant). Root-caused (#623): the
-                    // `<rect>` is a *closed* contour, so tiny-skia (faithful Rust port) seam-joins
-                    // the first and last `40`-unit dash across the start vertex into one continuous
-                    // dash - making that corner an interior MITER (filled quadrant). resvg's golden
-                    // butt-caps it (notched) because usvg flattens the rect to a *non-closed* path
-                    // before dashing. Donner's mitered closed-contour seam is the spec-conformant
-                    // behavior (matches Skia/Chrome/Firefox); the residual is a resvg-pipeline
-                    // (usvg path-normalization) difference, not a Donner/tiny-skia bug. Pinned by
-                    // RendererTests.DashSeamClosedContourMitersStartCorner in Renderer_tests.cc.
-                    {"n-0.svg",
-                     Params::Skip("resvg golden butt-caps the closed-rect dash-start corner; "
-                                  "Donner spec-correctly seam-joins it (usvg flattens rect to an "
-                                  "open path). See DashSeamClosedContourMitersStartCorner.")},
+                    {"n-0.svg", Params::WithThreshold(0.0f, 0, "Closed-path dash seam identity")},
                     // `0 N` round/square caps render as dots on the CPU backend; Geode's dot
                     // rendering for zero-length dashes differs. Compare CPU, disable Geode.
                     {"0-n-with-round-caps.svg", GeodeDisabled("Geode 0-N dash cap rendering gap")},


### PR DESCRIPTION
Fixes the remaining `painting/stroke-dasharray/n-0.svg` residual on TinySkia and Geode while preserving ordinary closed-path joins and solid fallback behavior.

**Root cause**

SVG 2 computes a separate capped stroke shape for every painted dash interval. A zero-length gap therefore still separates adjacent dash intervals. TinySkia instead joined those intervals across `ClosePath`, filling the start-corner seam. Geode generated separate ribbon outlines but filled valid dashed strokes with EvenOdd, allowing adjacent or wrapped ribbon overlap to cancel.

**Changes**

- For valid normalized dash patterns whose gaps are all exactly zero, convert only the TinySkia stroke path's close commands to explicit closing lines so the dash stroker emits seam caps.
- Fill valid Geode dashed-stroke ribbons with NonZero so adjacent intervals union.
- Share `StrokeStyle::kMaxDashEntries` with Geode's fill-rule selection so oversized patterns rejected by `Path::strokeToFill` retain the solid EvenOdd hollow-outline fallback.
- Preserve existing fallback behavior for invalid, non-finite, negative, all-zero, and oversized patterns.
- Add native renderer contracts for zero-gap seams, continuous dashes, open paths, solid closed paths, and oversized closed-path fallback.
- Enable exact-zero `n-0.svg` comparisons.

**Verification**

- Native dash seam and oversized fallback regressions: pass.
- Exact `n-0.svg` comparison, default-text, full-text, and Geode: pass at zero tolerance.
- Entire stroke-dasharray category on all three variants: pass.
- Affected renderer and resvg lint targets: pass.
- CMake generated-file validation: pass.

Refs #623.