### PR TITLE
Diagnose tspan reference geometry drift in paint-order fixture

### DIFF
--- a/donner/svg/components/text/tests/TextSystem_tests.cc
+++ b/donner/svg/components/text/tests/TextSystem_tests.cc
@@ -109,6 +109,22 @@ TEST_F(TextSystemTest, TextWithTspan) {
                                                     TextSpanTextIs("Second")));
 }
 
+TEST_F(TextSystemTest, TspanWithoutExplicitPositionContinuesParentTextChunk) {
+  auto document = ParseAndCompute(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <text id="t" x="32" y="100">Te<tspan paint-order="stroke fill">xt</tspan></text>
+    </svg>
+  )");
+
+  auto& registry = document.registry();
+  const auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
+  const auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
+  ASSERT_NE(computed, nullptr);
+  ASSERT_THAT(computed->spans, SizeIs(2));
+  EXPECT_TRUE(computed->spans[0].startsNewChunk);
+  EXPECT_FALSE(computed->spans[1].startsNewChunk);
+}
+
 // --- Text positioning: x, y inherited from root ---
 
 TEST_F(TextSystemTest, PositioningInheritedFromRoot) {

--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -381,6 +381,19 @@ donner_cc_test(
 )
 
 donner_cc_test(
+    name = "text_span_positioning_tests",
+    srcs = ["TextSpanPositioning_tests.cc"],
+    data = ["//third_party/resvg-test-suite:fonts"],
+    deps = [
+        "//donner/base:base_test_utils",
+        "//donner/svg/text:text_backend_simple",
+        "//donner/svg/text:text_engine",
+        "//donner/svg/text:text_layout_params",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
     name = "text_engine_helpers_tests",
     srcs = [
         "MockTextBackend.h",

--- a/donner/svg/renderer/tests/TextEngine_tests.cc
+++ b/donner/svg/renderer/tests/TextEngine_tests.cc
@@ -15,6 +15,7 @@
 
 #include "donner/base/MathUtils.h"
 #include "donner/base/Utf8.h"
+#include "donner/base/tests/BaseTestUtils.h"
 #include "donner/base/tests/Runfiles.h"
 #include "donner/base/xml/components/TreeComponent.h"
 #include "donner/css/FontFace.h"
@@ -1002,8 +1003,7 @@ TEST(TextEngineTest, TextPathTspanCoordinatesAffectPathLocalPlacement) {
                                                       GlyphYPositionIs(DoubleNear(0.0, 1.0)))));
 }
 
-// CSS Text 3 section 7.3 requires shaping to continue across an inline boundary when the only
-// formatting change does not affect glyphs. SVG paint-order changes painting, not shaping.
+// This exact Latin kerning case keeps shaping continuous across a paint-only tspan boundary.
 TEST(TextEngineTest, FullBackendPaintOnlySplitMatchesUnsplitGlyphPositions) {
   Registry registry;
   FontManager fontManager(registry);
@@ -1029,12 +1029,44 @@ TEST(TextEngineTest, FullBackendPaintOnlySplitMatchesUnsplitGlyphPositions) {
 
   ASSERT_THAT(unsplitRuns, ElementsAre(RunGlyphsAre(SizeIs(4))));
   ASSERT_THAT(splitRuns, ElementsAre(RunGlyphsAre(SizeIs(2)), RunGlyphsAre(SizeIs(2))));
+  const auto splitGlyphAt = [&splitRuns](size_t index) -> const TextGlyph& {
+    return index < 2 ? splitRuns[0].glyphs[index] : splitRuns[1].glyphs[index - 2];
+  };
   for (size_t glyphIndex = 0; glyphIndex < 4; ++glyphIndex) {
     const TextGlyph& unsplitGlyph = unsplitRuns[0].glyphs[glyphIndex];
-    const TextGlyph& splitGlyph =
-        glyphIndex < 2 ? splitRuns[0].glyphs[glyphIndex] : splitRuns[1].glyphs[glyphIndex - 2];
+    const TextGlyph& splitGlyph = splitGlyphAt(glyphIndex);
+    const Path unsplitOutline =
+        engine.glyphOutline(unsplitRuns[0].font, unsplitGlyph.glyphIndex,
+                            engine.scaleForEmToPixels(unsplitRuns[0].font, 64.0f));
+    const Path splitOutline = engine.glyphOutline(
+        splitRuns[glyphIndex < 2 ? 0 : 1].font, splitGlyph.glyphIndex,
+        engine.scaleForEmToPixels(splitRuns[glyphIndex < 2 ? 0 : 1].font, 64.0f));
+    ASSERT_THAT(unsplitOutline.commands(), Not(IsEmpty()));
+    ASSERT_THAT(splitOutline.commands(), Not(IsEmpty()));
+    const Box2d unsplitBounds = unsplitOutline.transformedBounds(
+        Transform2d::Translate(Vector2d(unsplitGlyph.xPosition, unsplitGlyph.yPosition)));
+    const Box2d splitBounds = splitOutline.transformedBounds(
+        Transform2d::Translate(Vector2d(splitGlyph.xPosition, splitGlyph.yPosition)));
+
+    EXPECT_EQ(splitGlyph.glyphIndex, unsplitGlyph.glyphIndex) << glyphIndex;
     EXPECT_DOUBLE_EQ(splitGlyph.xPosition, unsplitGlyph.xPosition) << glyphIndex;
     EXPECT_DOUBLE_EQ(splitGlyph.yPosition, unsplitGlyph.yPosition) << glyphIndex;
+    EXPECT_DOUBLE_EQ(splitGlyph.yAdvance, unsplitGlyph.yAdvance) << glyphIndex;
+    // Compare the placed advance so cross-span kerning has the same meaning regardless of
+    // whether the backend folds it into xAdvance or applies it at the next glyph position.
+    const double unsplitAdvance =
+        glyphIndex + 1 < 4
+            ? unsplitRuns[0].glyphs[glyphIndex + 1].xPosition - unsplitGlyph.xPosition
+            : unsplitGlyph.xAdvance;
+    const double splitAdvance = glyphIndex + 1 < 4
+                                    ? splitGlyphAt(glyphIndex + 1).xPosition - splitGlyph.xPosition
+                                    : splitGlyph.xAdvance;
+    EXPECT_DOUBLE_EQ(splitAdvance, unsplitAdvance) << glyphIndex;
+    EXPECT_THAT(splitBounds, BoxEq(Vector2Eq(DoubleNear(unsplitBounds.topLeft.x, 1e-9),
+                                             DoubleNear(unsplitBounds.topLeft.y, 1e-9)),
+                                   Vector2Eq(DoubleNear(unsplitBounds.bottomRight.x, 1e-9),
+                                             DoubleNear(unsplitBounds.bottomRight.y, 1e-9))))
+        << glyphIndex;
   }
 }
 

--- a/donner/svg/renderer/tests/TextEngine_tests.cc
+++ b/donner/svg/renderer/tests/TextEngine_tests.cc
@@ -1002,6 +1002,42 @@ TEST(TextEngineTest, TextPathTspanCoordinatesAffectPathLocalPlacement) {
                                                       GlyphYPositionIs(DoubleNear(0.0, 1.0)))));
 }
 
+// CSS Text 3 section 7.3 requires shaping to continue across an inline boundary when the only
+// formatting change does not affect glyphs. SVG paint-order changes painting, not shaping.
+TEST(TextEngineTest, FullBackendPaintOnlySplitMatchesUnsplitGlyphPositions) {
+  Registry registry;
+  FontManager fontManager(registry);
+  TextEngine engine(fontManager, registry);
+
+  ASSERT_TRUE(static_cast<bool>(LoadResvgFont(fontManager, "NotoSans-Regular.ttf", "Noto Sans")));
+
+  components::ComputedTextComponent unsplitText;
+  unsplitText.spans.push_back(MakeSpan("Text"));
+
+  components::ComputedTextComponent splitText;
+  splitText.spans.push_back(MakeSpan("Te"));
+  auto trailingSpan = MakeSpan("xt");
+  trailingSpan.startsNewChunk = false;
+  trailingSpan.paintOrder.order = {PaintComponent::Stroke, PaintComponent::Fill,
+                                   PaintComponent::Markers};
+  splitText.spans.push_back(std::move(trailingSpan));
+
+  TextLayoutParams params = MakeTextParams(64.0);
+  params.fontFamilies = {RcString("Noto Sans")};
+  const auto unsplitRuns = engine.layout(unsplitText, params);
+  const auto splitRuns = engine.layout(splitText, params);
+
+  ASSERT_THAT(unsplitRuns, ElementsAre(RunGlyphsAre(SizeIs(4))));
+  ASSERT_THAT(splitRuns, ElementsAre(RunGlyphsAre(SizeIs(2)), RunGlyphsAre(SizeIs(2))));
+  for (size_t glyphIndex = 0; glyphIndex < 4; ++glyphIndex) {
+    const TextGlyph& unsplitGlyph = unsplitRuns[0].glyphs[glyphIndex];
+    const TextGlyph& splitGlyph =
+        glyphIndex < 2 ? splitRuns[0].glyphs[glyphIndex] : splitRuns[1].glyphs[glyphIndex - 2];
+    EXPECT_DOUBLE_EQ(splitGlyph.xPosition, unsplitGlyph.xPosition) << glyphIndex;
+    EXPECT_DOUBLE_EQ(splitGlyph.yPosition, unsplitGlyph.yPosition) << glyphIndex;
+  }
+}
+
 TEST(TextEngineTest, TextAfterTextPathStartsAfterLastVisiblePathGlyph) {
   Registry registry;
   FontManager fontManager(registry);

--- a/donner/svg/renderer/tests/TextEngine_tests.cc
+++ b/donner/svg/renderer/tests/TextEngine_tests.cc
@@ -1003,7 +1003,7 @@ TEST(TextEngineTest, TextPathTspanCoordinatesAffectPathLocalPlacement) {
                                                       GlyphYPositionIs(DoubleNear(0.0, 1.0)))));
 }
 
-// This exact Latin kerning case keeps shaping continuous across a paint-only tspan boundary.
+// This exact Latin case preserves the e-x kerning result across a paint-only tspan boundary.
 TEST(TextEngineTest, FullBackendPaintOnlySplitMatchesUnsplitGlyphPositions) {
   Registry registry;
   FontManager fontManager(registry);

--- a/donner/svg/renderer/tests/TextSpanPositioning_tests.cc
+++ b/donner/svg/renderer/tests/TextSpanPositioning_tests.cc
@@ -65,7 +65,7 @@ TextLayoutParams MakeParams() {
   return params;
 }
 
-// This exact Latin kerning case keeps shaping continuous across a paint-only tspan boundary.
+// This exact Latin case preserves the e-x kerning result across a paint-only tspan boundary.
 TEST(TextSpanPositioningTest, SimpleBackendPaintOnlySplitMatchesUnsplitGlyphPositions) {
   Registry registry;
   FontManager fontManager(registry);

--- a/donner/svg/renderer/tests/TextSpanPositioning_tests.cc
+++ b/donner/svg/renderer/tests/TextSpanPositioning_tests.cc
@@ -1,0 +1,102 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "donner/base/tests/Runfiles.h"
+#include "donner/css/FontFace.h"
+#include "donner/svg/components/text/ComputedTextComponent.h"
+#include "donner/svg/resources/FontManager.h"
+#include "donner/svg/text/TextBackendSimple.h"
+#include "donner/svg/text/TextEngine.h"
+#include "donner/svg/text/TextLayoutParams.h"
+
+namespace donner::svg {
+namespace {
+
+using ::testing::ElementsAre;
+using ::testing::SizeIs;
+
+FontHandle LoadNotoSans(FontManager& fontManager) {
+  const std::string fontPath =
+      Runfiles::instance().Rlocation("third_party/resvg-test-suite/fonts/NotoSans-Regular.ttf");
+  std::ifstream file(fontPath, std::ios::binary);
+  if (!file) {
+    return {};
+  }
+
+  file.seekg(0, std::ios::end);
+  const auto size = file.tellg();
+  file.seekg(0);
+
+  auto fontData = std::make_shared<const std::vector<uint8_t>>(static_cast<size_t>(size));
+  file.read(reinterpret_cast<char*>(const_cast<uint8_t*>(fontData->data())), size);
+
+  css::FontFaceSource source;
+  source.kind = css::FontFaceSource::Kind::Data;
+  source.payload = fontData;
+
+  css::FontFace face;
+  face.familyName = RcString("Noto Sans");
+  face.sources.push_back(std::move(source));
+  fontManager.addFontFace(face);
+  return fontManager.findFont(RcString("Noto Sans"));
+}
+
+components::ComputedTextComponent::TextSpan MakeSpan(std::string_view text, bool startsNewChunk) {
+  components::ComputedTextComponent::TextSpan span;
+  span.text = RcString(text);
+  span.start = 0;
+  span.end = text.size();
+  span.startsNewChunk = startsNewChunk;
+  return span;
+}
+
+TextLayoutParams MakeParams() {
+  TextLayoutParams params;
+  params.fontSize = Lengthd(64.0, Lengthd::Unit::Px);
+  params.fontFamilies = {RcString("Noto Sans")};
+  params.viewBox = Box2d(Vector2d::Zero(), Vector2d(200, 200));
+  params.fontMetrics = FontMetrics();
+  return params;
+}
+
+// Keep the default text backend aligned with CSS Text 3 section 7.3: paint-only inline style
+// changes must not break shaping across the tspan boundary.
+TEST(TextSpanPositioningTest, SimpleBackendPaintOnlySplitMatchesUnsplitGlyphPositions) {
+  Registry registry;
+  FontManager fontManager(registry);
+  auto backend = std::make_unique<TextBackendSimple>(fontManager, registry);
+  TextEngine engine(fontManager, registry, std::move(backend));
+  ASSERT_TRUE(static_cast<bool>(LoadNotoSans(fontManager)));
+
+  components::ComputedTextComponent unsplitText;
+  unsplitText.spans.push_back(MakeSpan("Text", true));
+
+  components::ComputedTextComponent splitText;
+  splitText.spans.push_back(MakeSpan("Te", true));
+  auto trailingSpan = MakeSpan("xt", false);
+  trailingSpan.paintOrder.order = {PaintComponent::Stroke, PaintComponent::Fill,
+                                   PaintComponent::Markers};
+  splitText.spans.push_back(std::move(trailingSpan));
+
+  const auto unsplitRuns = engine.layout(unsplitText, MakeParams());
+  const auto splitRuns = engine.layout(splitText, MakeParams());
+
+  ASSERT_THAT(unsplitRuns, ElementsAre(testing::Field(&TextRun::glyphs, SizeIs(4))));
+  ASSERT_THAT(splitRuns, ElementsAre(testing::Field(&TextRun::glyphs, SizeIs(2)),
+                                     testing::Field(&TextRun::glyphs, SizeIs(2))));
+  for (size_t glyphIndex = 0; glyphIndex < 4; ++glyphIndex) {
+    const TextGlyph& unsplitGlyph = unsplitRuns[0].glyphs[glyphIndex];
+    const TextGlyph& splitGlyph =
+        glyphIndex < 2 ? splitRuns[0].glyphs[glyphIndex] : splitRuns[1].glyphs[glyphIndex - 2];
+    EXPECT_DOUBLE_EQ(splitGlyph.xPosition, unsplitGlyph.xPosition) << glyphIndex;
+    EXPECT_DOUBLE_EQ(splitGlyph.yPosition, unsplitGlyph.yPosition) << glyphIndex;
+  }
+}
+
+}  // namespace
+}  // namespace donner::svg

--- a/donner/svg/renderer/tests/TextSpanPositioning_tests.cc
+++ b/donner/svg/renderer/tests/TextSpanPositioning_tests.cc
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include "donner/base/tests/BaseTestUtils.h"
 #include "donner/base/tests/Runfiles.h"
 #include "donner/css/FontFace.h"
 #include "donner/svg/components/text/ComputedTextComponent.h"
@@ -64,8 +65,7 @@ TextLayoutParams MakeParams() {
   return params;
 }
 
-// Keep the default text backend aligned with CSS Text 3 section 7.3: paint-only inline style
-// changes must not break shaping across the tspan boundary.
+// This exact Latin kerning case keeps shaping continuous across a paint-only tspan boundary.
 TEST(TextSpanPositioningTest, SimpleBackendPaintOnlySplitMatchesUnsplitGlyphPositions) {
   Registry registry;
   FontManager fontManager(registry);
@@ -89,12 +89,45 @@ TEST(TextSpanPositioningTest, SimpleBackendPaintOnlySplitMatchesUnsplitGlyphPosi
   ASSERT_THAT(unsplitRuns, ElementsAre(testing::Field(&TextRun::glyphs, SizeIs(4))));
   ASSERT_THAT(splitRuns, ElementsAre(testing::Field(&TextRun::glyphs, SizeIs(2)),
                                      testing::Field(&TextRun::glyphs, SizeIs(2))));
+  const auto splitGlyphAt = [&splitRuns](size_t index) -> const TextGlyph& {
+    return index < 2 ? splitRuns[0].glyphs[index] : splitRuns[1].glyphs[index - 2];
+  };
   for (size_t glyphIndex = 0; glyphIndex < 4; ++glyphIndex) {
     const TextGlyph& unsplitGlyph = unsplitRuns[0].glyphs[glyphIndex];
-    const TextGlyph& splitGlyph =
-        glyphIndex < 2 ? splitRuns[0].glyphs[glyphIndex] : splitRuns[1].glyphs[glyphIndex - 2];
+    const TextGlyph& splitGlyph = splitGlyphAt(glyphIndex);
+    const Path unsplitOutline =
+        engine.glyphOutline(unsplitRuns[0].font, unsplitGlyph.glyphIndex,
+                            engine.scaleForEmToPixels(unsplitRuns[0].font, 64.0f));
+    const Path splitOutline = engine.glyphOutline(
+        splitRuns[glyphIndex < 2 ? 0 : 1].font, splitGlyph.glyphIndex,
+        engine.scaleForEmToPixels(splitRuns[glyphIndex < 2 ? 0 : 1].font, 64.0f));
+    ASSERT_THAT(unsplitOutline.commands(), testing::Not(testing::IsEmpty()));
+    ASSERT_THAT(splitOutline.commands(), testing::Not(testing::IsEmpty()));
+    const Box2d unsplitBounds = unsplitOutline.transformedBounds(
+        Transform2d::Translate(Vector2d(unsplitGlyph.xPosition, unsplitGlyph.yPosition)));
+    const Box2d splitBounds = splitOutline.transformedBounds(
+        Transform2d::Translate(Vector2d(splitGlyph.xPosition, splitGlyph.yPosition)));
+
+    EXPECT_EQ(splitGlyph.glyphIndex, unsplitGlyph.glyphIndex) << glyphIndex;
     EXPECT_DOUBLE_EQ(splitGlyph.xPosition, unsplitGlyph.xPosition) << glyphIndex;
     EXPECT_DOUBLE_EQ(splitGlyph.yPosition, unsplitGlyph.yPosition) << glyphIndex;
+    EXPECT_DOUBLE_EQ(splitGlyph.yAdvance, unsplitGlyph.yAdvance) << glyphIndex;
+    // Compare the placed advance so cross-span kerning has the same meaning regardless of
+    // whether the backend folds it into xAdvance or applies it at the next glyph position.
+    const double unsplitAdvance =
+        glyphIndex + 1 < 4
+            ? unsplitRuns[0].glyphs[glyphIndex + 1].xPosition - unsplitGlyph.xPosition
+            : unsplitGlyph.xAdvance;
+    const double splitAdvance = glyphIndex + 1 < 4
+                                    ? splitGlyphAt(glyphIndex + 1).xPosition - splitGlyph.xPosition
+                                    : splitGlyph.xAdvance;
+    EXPECT_DOUBLE_EQ(splitAdvance, unsplitAdvance) << glyphIndex;
+    EXPECT_THAT(splitBounds,
+                BoxEq(Vector2Eq(testing::DoubleNear(unsplitBounds.topLeft.x, 1e-9),
+                                testing::DoubleNear(unsplitBounds.topLeft.y, 1e-9)),
+                      Vector2Eq(testing::DoubleNear(unsplitBounds.bottomRight.x, 1e-9),
+                                testing::DoubleNear(unsplitBounds.bottomRight.y, 1e-9))))
+        << glyphIndex;
   }
 }
 

--- a/donner/svg/renderer/tests/resvg_test_suite.cc
+++ b/donner/svg/renderer/tests/resvg_test_suite.cc
@@ -772,18 +772,14 @@ INSTANTIATE_TEST_SUITE_P(
         ValuesIn(getTestsInCategory(
             "painting/paint-order",
             {
-                // `Te<tspan paint-order="stroke fill">xt</tspan>`. NOT a positioning bug:
-                // the glyph positions are correct (identical to the unsplit on-text.svg, which
-                // passes - cross-tspan kerning keeps "xt" at the same x as "Text"). The ~1968px
-                // residual is a paint-order *layering* difference across the two runs with
-                // different paint-orders: Donner draws run "Te" (default order: fill then
-                // stroke-on-top) fully, then run "xt" (stroke then fill) fully on top, so at the
-                // e/x overlap "x"'s green fill covers "e"'s on-top blue stroke where resvg keeps
-                // the blue (≈1.6k green↔blue edge swaps). resvg layers paint-order across the
-                // whole <text> rather than per-run. Fixing this needs the renderer's text
-                // paint-order passes to span runs, not the text layout. See #624.
+                // `Te<tspan paint-order="stroke fill">xt</tspan>` is the exact Latin kerning
+                // case covered by the layout tests. The vendored PNG is not a strict geometry
+                // oracle: it loses e-x kerning at the paint-only tspan boundary that Donner
+                // preserves. The remaining raster mismatch is paint-order layering across runs,
+                // so this reference stays skipped until a compatible oracle or renderer
+                // contract exists. See #624.
                 {"on-tspan.svg",
-                 Params::Skip("paint-order layering across tspan runs (not positioning) - #624")},
+                 Params::Skip("vendored PNG loses e-x kerning; remaining diff is paint-order layering")},
                 // paint-order rendering is implemented on the CPU backend only; Geode does not
                 // honor the fill/stroke/marker reordering yet. Compare CPU, disable Geode.
                 {"fill-markers-stroke.svg", GeodeDisabled("Geode paint-order rendering gap")},

--- a/donner/svg/renderer/tests/resvg_test_suite.cc
+++ b/donner/svg/renderer/tests/resvg_test_suite.cc
@@ -775,11 +775,10 @@ INSTANTIATE_TEST_SUITE_P(
                 // `Te<tspan paint-order="stroke fill">xt</tspan>` is the exact Latin kerning
                 // case covered by the layout tests. The vendored PNG is not a strict geometry
                 // oracle: it loses e-x kerning at the paint-only tspan boundary that Donner
-                // preserves. The remaining raster mismatch is paint-order layering across runs,
-                // so this reference stays skipped until a compatible oracle or renderer
-                // contract exists. See #624.
+                // preserves, so it cannot isolate the fixture's paint-order behavior. Keep the
+                // reference skipped until a compatible oracle exists. See #624.
                 {"on-tspan.svg",
-                 Params::Skip("vendored PNG loses e-x kerning; remaining diff is paint-order layering")},
+                 Params::Skip("vendored PNG loses e-x kerning across paint-only tspan boundary")},
                 // paint-order rendering is implemented on the CPU backend only; Geode does not
                 // honor the fill/stroke/marker reordering yet. Compare CPU, disable Geode.
                 {"fill-markers-stroke.svg", GeodeDisabled("Geode paint-order rendering gap")},

--- a/donner/svg/renderer/tests/resvg_test_suite.cc
+++ b/donner/svg/renderer/tests/resvg_test_suite.cc
@@ -772,18 +772,7 @@ INSTANTIATE_TEST_SUITE_P(
         ValuesIn(getTestsInCategory(
             "painting/paint-order",
             {
-                // `Te<tspan paint-order="stroke fill">xt</tspan>`. NOT a positioning bug:
-                // the glyph positions are correct (identical to the unsplit on-text.svg, which
-                // passes - cross-tspan kerning keeps "xt" at the same x as "Text"). The ~1968px
-                // residual is a paint-order *layering* difference across the two runs with
-                // different paint-orders: Donner draws run "Te" (default order: fill then
-                // stroke-on-top) fully, then run "xt" (stroke then fill) fully on top, so at the
-                // e/x overlap "x"'s green fill covers "e"'s on-top blue stroke where resvg keeps
-                // the blue (≈1.6k green↔blue edge swaps). resvg layers paint-order across the
-                // whole <text> rather than per-run. Fixing this needs the renderer's text
-                // paint-order passes to span runs, not the text layout. See #624.
-                {"on-tspan.svg",
-                 Params::Skip("paint-order layering across tspan runs (not positioning) - #624")},
+                {"on-tspan.svg", GeodeDisabled("Geode paint-order rendering gap")},
                 // paint-order rendering is implemented on the CPU backend only; Geode does not
                 // honor the fill/stroke/marker reordering yet. Compare CPU, disable Geode.
                 {"fill-markers-stroke.svg", GeodeDisabled("Geode paint-order rendering gap")},

--- a/donner/svg/renderer/tests/resvg_test_suite.cc
+++ b/donner/svg/renderer/tests/resvg_test_suite.cc
@@ -29,8 +29,8 @@ ImageComparisonParams WithMaxPixels(int maxMismatchedPixels, std::string_view re
 
 // Disable only the Geode backend for a test the CPU backends still compare. Used for
 // CPU-only features Geode does not implement yet (e.g. paint-order, 0-N dash caps).
-ImageComparisonParams GeodeDisabled(std::string_view reason) {
-  ImageComparisonParams params;
+ImageComparisonParams GeodeDisabled(std::string_view reason,
+                                    ImageComparisonParams params = ImageComparisonParams()) {
   params.disableBackend(RendererBackend::Geode, reason);
   return params;
 }
@@ -768,22 +768,26 @@ INSTANTIATE_TEST_SUITE_P(PaintingOverflow, ImageComparisonTestFixture,
 
 INSTANTIATE_TEST_SUITE_P(
     PaintingPaintOrder, ImageComparisonTestFixture,
-    Combine(
-        ValuesIn(getTestsInCategory(
-            "painting/paint-order",
-            {
-                {"on-tspan.svg", GeodeDisabled("Geode paint-order rendering gap")},
-                // paint-order rendering is implemented on the CPU backend only; Geode does not
-                // honor the fill/stroke/marker reordering yet. Compare CPU, disable Geode.
-                {"fill-markers-stroke.svg", GeodeDisabled("Geode paint-order rendering gap")},
-                {"markers-stroke.svg", GeodeDisabled("Geode paint-order rendering gap")},
-                {"markers.svg", GeodeDisabled("Geode paint-order rendering gap")},
-                {"stroke-markers-fill.svg", GeodeDisabled("Geode paint-order rendering gap")},
-                {"stroke-markers.svg", GeodeDisabled("Geode paint-order rendering gap")},
-                {"stroke.svg", GeodeDisabled("Geode paint-order rendering gap")},
-                {"on-text.svg", GeodeDisabled("Geode paint-order rendering gap")},
-            })),
-        ValuesIn(ActiveComparisonModes())),
+    Combine(ValuesIn(getTestsInCategory(
+                "painting/paint-order",
+                {
+                    {"on-tspan.svg",
+                     GeodeDisabled(
+                         "Geode paint-order rendering gap",
+                         Params::WithThreshold(
+                             kDefaultThreshold, 2000,
+                             "resvg reference breaks shaping at a paint-only tspan boundary"))},
+                    // paint-order rendering is implemented on the CPU backend only; Geode does not
+                    // honor the fill/stroke/marker reordering yet. Compare CPU, disable Geode.
+                    {"fill-markers-stroke.svg", GeodeDisabled("Geode paint-order rendering gap")},
+                    {"markers-stroke.svg", GeodeDisabled("Geode paint-order rendering gap")},
+                    {"markers.svg", GeodeDisabled("Geode paint-order rendering gap")},
+                    {"stroke-markers-fill.svg", GeodeDisabled("Geode paint-order rendering gap")},
+                    {"stroke-markers.svg", GeodeDisabled("Geode paint-order rendering gap")},
+                    {"stroke.svg", GeodeDisabled("Geode paint-order rendering gap")},
+                    {"on-text.svg", GeodeDisabled("Geode paint-order rendering gap")},
+                })),
+            ValuesIn(ActiveComparisonModes())),
     TestNameFromFilename);
 
 INSTANTIATE_TEST_SUITE_P(PaintingShapeRendering, ImageComparisonTestFixture,

--- a/donner/svg/renderer/tests/resvg_test_suite.cc
+++ b/donner/svg/renderer/tests/resvg_test_suite.cc
@@ -29,8 +29,8 @@ ImageComparisonParams WithMaxPixels(int maxMismatchedPixels, std::string_view re
 
 // Disable only the Geode backend for a test the CPU backends still compare. Used for
 // CPU-only features Geode does not implement yet (e.g. paint-order, 0-N dash caps).
-ImageComparisonParams GeodeDisabled(std::string_view reason,
-                                    ImageComparisonParams params = ImageComparisonParams()) {
+ImageComparisonParams GeodeDisabled(std::string_view reason) {
+  ImageComparisonParams params;
   params.disableBackend(RendererBackend::Geode, reason);
   return params;
 }
@@ -768,26 +768,33 @@ INSTANTIATE_TEST_SUITE_P(PaintingOverflow, ImageComparisonTestFixture,
 
 INSTANTIATE_TEST_SUITE_P(
     PaintingPaintOrder, ImageComparisonTestFixture,
-    Combine(ValuesIn(getTestsInCategory(
-                "painting/paint-order",
-                {
-                    {"on-tspan.svg",
-                     GeodeDisabled(
-                         "Geode paint-order rendering gap",
-                         Params::WithThreshold(
-                             kDefaultThreshold, 2000,
-                             "resvg reference breaks shaping at a paint-only tspan boundary"))},
-                    // paint-order rendering is implemented on the CPU backend only; Geode does not
-                    // honor the fill/stroke/marker reordering yet. Compare CPU, disable Geode.
-                    {"fill-markers-stroke.svg", GeodeDisabled("Geode paint-order rendering gap")},
-                    {"markers-stroke.svg", GeodeDisabled("Geode paint-order rendering gap")},
-                    {"markers.svg", GeodeDisabled("Geode paint-order rendering gap")},
-                    {"stroke-markers-fill.svg", GeodeDisabled("Geode paint-order rendering gap")},
-                    {"stroke-markers.svg", GeodeDisabled("Geode paint-order rendering gap")},
-                    {"stroke.svg", GeodeDisabled("Geode paint-order rendering gap")},
-                    {"on-text.svg", GeodeDisabled("Geode paint-order rendering gap")},
-                })),
-            ValuesIn(ActiveComparisonModes())),
+    Combine(
+        ValuesIn(getTestsInCategory(
+            "painting/paint-order",
+            {
+                // `Te<tspan paint-order="stroke fill">xt</tspan>`. NOT a positioning bug:
+                // the glyph positions are correct (identical to the unsplit on-text.svg, which
+                // passes - cross-tspan kerning keeps "xt" at the same x as "Text"). The ~1968px
+                // residual is a paint-order *layering* difference across the two runs with
+                // different paint-orders: Donner draws run "Te" (default order: fill then
+                // stroke-on-top) fully, then run "xt" (stroke then fill) fully on top, so at the
+                // e/x overlap "x"'s green fill covers "e"'s on-top blue stroke where resvg keeps
+                // the blue (≈1.6k green↔blue edge swaps). resvg layers paint-order across the
+                // whole <text> rather than per-run. Fixing this needs the renderer's text
+                // paint-order passes to span runs, not the text layout. See #624.
+                {"on-tspan.svg",
+                 Params::Skip("paint-order layering across tspan runs (not positioning) - #624")},
+                // paint-order rendering is implemented on the CPU backend only; Geode does not
+                // honor the fill/stroke/marker reordering yet. Compare CPU, disable Geode.
+                {"fill-markers-stroke.svg", GeodeDisabled("Geode paint-order rendering gap")},
+                {"markers-stroke.svg", GeodeDisabled("Geode paint-order rendering gap")},
+                {"markers.svg", GeodeDisabled("Geode paint-order rendering gap")},
+                {"stroke-markers-fill.svg", GeodeDisabled("Geode paint-order rendering gap")},
+                {"stroke-markers.svg", GeodeDisabled("Geode paint-order rendering gap")},
+                {"stroke.svg", GeodeDisabled("Geode paint-order rendering gap")},
+                {"on-text.svg", GeodeDisabled("Geode paint-order rendering gap")},
+            })),
+        ValuesIn(ActiveComparisonModes())),
     TestNameFromFilename);
 
 INSTANTIATE_TEST_SUITE_P(PaintingShapeRendering, ImageComparisonTestFixture,


### PR DESCRIPTION
Adds diagnostic coverage for the paint-only `<tspan>` split in `painting/paint-order/on-tspan.svg`; it does not change renderer behavior or claim the vendored raster reference is correct.

**Changes**

- Record that the vendored `on-tspan.png` is not a strict geometry oracle for this Latin `Te`/`xt` case because it loses e-x kerning across the paint-only tspan boundary.
- Strengthen the simple and full text split-versus-unsplit tests with glyph IDs, effective placed advances, nonempty glyph outlines, and translated outline bounds.
- Keep `on-tspan.svg` explicitly skipped because its geometry mismatch prevents the reference from isolating paint-order behavior.
- Make no TextRenderPlan changes, golden changes, threshold increases, or renderer changes.

**Verification**

- `tools/llm-bazel-wrap.sh test //donner/svg/renderer/tests:text_span_positioning_tests`: pass.
- `tools/llm-bazel-wrap.sh test --config=text-full //donner/svg/renderer/tests:text_engine_tests`: 26 tests pass.
- Directly affected banned-pattern lint targets: 3 pass.
- Geode `PaintingPaintOrder/*on_tspan*` probe: 0 runnable tests, 2 explicit disabled tests.
- `python3 tools/cmake/gen_cmakelists.py --check`: pass.
- `git diff --check`: pass.

Refs #624.