### PR TITLE
Fix reciprocal recursive marker rendering

### DIFF
--- a/donner/svg/renderer/RendererDriver.cc
+++ b/donner/svg/renderer/RendererDriver.cc
@@ -2486,6 +2486,29 @@ void RendererDriver::drawMarkers(RenderingInstanceView& view, Registry& registry
   considerMarkerSubtree(instance.markerMid);
   considerMarkerSubtree(instance.markerEnd);
 
+  // Marker render ranges intentionally exclude nested marker definitions because nested paths
+  // render those definitions through drawMarker(). Walk later instances in draw order and extend
+  // the cleanup frontier whenever an in-range instance owns another inline marker subtree.
+  std::vector<const components::RenderingInstanceComponent*> laterInstances;
+  for (const Entity entity : registry.view<components::RenderingInstanceComponent>()) {
+    const auto& candidate = registry.get<components::RenderingInstanceComponent>(entity);
+    if (candidate.drawOrder > instance.drawOrder) {
+      laterInstances.push_back(&candidate);
+    }
+  }
+  std::ranges::sort(laterInstances, {},
+                    &components::RenderingInstanceComponent::drawOrder);
+
+  for (const auto* nestedInstance : laterInstances) {
+    if (nestedInstance->drawOrder > skipToDrawOrder) {
+      break;
+    }
+
+    considerMarkerSubtree(nestedInstance->markerStart);
+    considerMarkerSubtree(nestedInstance->markerMid);
+    considerMarkerSubtree(nestedInstance->markerEnd);
+  }
+
   if (skipToEntity != entt::null) {
     skipUntil(view, skipToEntity);
   }

--- a/donner/svg/renderer/RendererDriver.cc
+++ b/donner/svg/renderer/RendererDriver.cc
@@ -2487,26 +2487,23 @@ void RendererDriver::drawMarkers(RenderingInstanceView& view, Registry& registry
   considerMarkerSubtree(instance.markerEnd);
 
   // Marker render ranges intentionally exclude nested marker definitions because nested paths
-  // render those definitions through drawMarker(). Walk later instances in draw order and extend
-  // the cleanup frontier whenever an in-range instance owns another inline marker subtree.
-  std::vector<const components::RenderingInstanceComponent*> laterInstances;
-  for (const Entity entity : registry.view<components::RenderingInstanceComponent>()) {
-    const auto& candidate = registry.get<components::RenderingInstanceComponent>(entity);
-    if (candidate.drawOrder > instance.drawOrder) {
-      laterInstances.push_back(&candidate);
-    }
-  }
-  std::ranges::sort(laterInstances, {},
-                    &components::RenderingInstanceComponent::drawOrder);
-
-  for (const auto* nestedInstance : laterInstances) {
-    if (nestedInstance->drawOrder > skipToDrawOrder) {
+  // render those definitions through drawMarker(). Walk the active traversal snapshot in draw
+  // order and extend the cleanup frontier whenever an in-range instance owns another inline
+  // marker subtree. Do not scan the registry: it can contain offscreen filter instances that are
+  // deliberately absent from this view.
+  RenderingInstanceView nestedView = view;
+  while (!nestedView.done()) {
+    const auto& nestedInstance = nestedView.get();
+    if (nestedInstance.drawOrder > skipToDrawOrder) {
       break;
     }
 
-    considerMarkerSubtree(nestedInstance->markerStart);
-    considerMarkerSubtree(nestedInstance->markerMid);
-    considerMarkerSubtree(nestedInstance->markerEnd);
+    if (nestedInstance.drawOrder > instance.drawOrder) {
+      considerMarkerSubtree(nestedInstance.markerStart);
+      considerMarkerSubtree(nestedInstance.markerMid);
+      considerMarkerSubtree(nestedInstance.markerEnd);
+    }
+    nestedView.advance();
   }
 
   if (skipToEntity != entt::null) {

--- a/donner/svg/renderer/RenderingContext.cc
+++ b/donner/svg/renderer/RenderingContext.cc
@@ -4,7 +4,7 @@
 #include <map>
 #include <optional>
 #include <set>
-#include <utility>
+#include <tuple>
 #include <vector>
 
 #include "donner/base/parser/LengthParser.h"
@@ -625,7 +625,7 @@ public:
       contextPaintServers_.contextBounds = dataHandle.get<ComputedPathComponent>().localBounds();
       contextPaintServers_.resolveAtDrawTime = true;
 
-      const bool ownsMarkerResolutionSession = activeMarkerElements_.empty();
+      const bool ownsMarkerResolutionSession = activeMarkerStack_.empty();
       if (ownsMarkerResolutionSession) {
         cyclicMarkerReferences_.clear();
       }
@@ -1118,14 +1118,16 @@ public:
         resolvedRef && IsValidMarker(resolvedRef->handle)) {
       const Entity markerElement = resolvedRef->handle.entity();
       if (!activeMarkerStack_.empty() &&
-          cyclicMarkerReferences_.count({activeMarkerStack_.back(), markerElement})) {
+          cyclicMarkerReferences_.count(
+              {activeMarkerStack_.front(), activeMarkerStack_.back(), markerElement})) {
         return ResolvedMarker{ResolvedReference{EntityHandle()}, std::nullopt,
                               MarkerUnits::Default};
       }
 
       if (activeMarkerElements_.count(markerElement)) {
         assert(!activeMarkerStack_.empty());
-        cyclicMarkerReferences_.insert({activeMarkerStack_.back(), markerElement});
+        cyclicMarkerReferences_.insert(
+            {activeMarkerStack_.front(), activeMarkerStack_.back(), markerElement});
         return ResolvedMarker{ResolvedReference{EntityHandle()}, std::nullopt,
                               MarkerUnits::Default};
       }
@@ -1205,9 +1207,10 @@ private:
   /// Marker expansion order, used to identify the exact reference edge that closes a cycle.
   std::vector<Entity> activeMarkerStack_;
 
-  /// Cycle-closing marker reference edges discovered while resolving one shape's markers.
-  /// Reusing these decisions keeps repeated marker definitions structurally consistent.
-  std::set<std::pair<Entity, Entity>> cyclicMarkerReferences_;
+  /// Cycle-closing marker reference edges, keyed by top-level marker root, source, and target.
+  /// Reusing decisions within a root keeps repeated definitions structurally consistent without
+  /// suppressing the reverse orientation when another marker becomes the root.
+  std::set<std::tuple<Entity, Entity, Entity>> cyclicMarkerReferences_;
 
   /// The last rendered entity of each offscreen subtree instantiated by \ref
   /// instantiateOffscreenSubtree, keyed by the subtree's root entity. Used to rebuild a correct

--- a/donner/svg/renderer/RenderingContext.cc
+++ b/donner/svg/renderer/RenderingContext.cc
@@ -1,8 +1,10 @@
 #include "donner/svg/renderer/RenderingContext.h"
 
+#include <cassert>
 #include <map>
 #include <optional>
 #include <set>
+#include <utility>
 #include <vector>
 
 #include "donner/base/parser/LengthParser.h"
@@ -623,6 +625,11 @@ public:
       contextPaintServers_.contextBounds = dataHandle.get<ComputedPathComponent>().localBounds();
       contextPaintServers_.resolveAtDrawTime = true;
 
+      const bool ownsMarkerResolutionSession = activeMarkerElements_.empty();
+      if (ownsMarkerResolutionSession) {
+        cyclicMarkerReferences_.clear();
+      }
+
       if (properties.markerStart.get()) {
         if (auto resolved = resolveMarker(EntityHandle(registry_, styleEntity),
                                           properties.markerStart.get().value(),
@@ -648,6 +655,10 @@ public:
             resolved.valid()) {
           instance.markerEnd = resolved;
         }
+      }
+
+      if (ownsMarkerResolutionSession) {
+        cyclicMarkerReferences_.clear();
       }
 
       contextPaintServers_ = savedForMarkers;
@@ -1106,7 +1117,15 @@ public:
     if (auto resolvedRef = reference.resolve(*styleHandle.registry());
         resolvedRef && IsValidMarker(resolvedRef->handle)) {
       const Entity markerElement = resolvedRef->handle.entity();
+      if (!activeMarkerStack_.empty() &&
+          cyclicMarkerReferences_.count({activeMarkerStack_.back(), markerElement})) {
+        return ResolvedMarker{ResolvedReference{EntityHandle()}, std::nullopt,
+                              MarkerUnits::Default};
+      }
+
       if (activeMarkerElements_.count(markerElement)) {
+        assert(!activeMarkerStack_.empty());
+        cyclicMarkerReferences_.insert({activeMarkerStack_.back(), markerElement});
         return ResolvedMarker{ResolvedReference{EntityHandle()}, std::nullopt,
                               MarkerUnits::Default};
       }
@@ -1122,7 +1141,9 @@ public:
       if (const auto* computedShadow = shadowTreeHost.try_get<ComputedShadowTreeComponent>();
           computedShadow && computedShadow->findOffscreenShadow(branchType).has_value()) {
         activeMarkerElements_.insert(markerElement);
+        activeMarkerStack_.push_back(markerElement);
         auto subtree = instantiateOffscreenSubtree(shadowTreeHost, branchType);
+        activeMarkerStack_.pop_back();
         activeMarkerElements_.erase(markerElement);
 
         return ResolvedMarker{resolvedRef.value(), std::move(subtree),
@@ -1180,6 +1201,13 @@ private:
   /// Tracks marker elements currently being instantiated so recursive marker references stop
   /// after the first level instead of repeatedly expanding the same cycle.
   std::set<Entity> activeMarkerElements_;
+
+  /// Marker expansion order, used to identify the exact reference edge that closes a cycle.
+  std::vector<Entity> activeMarkerStack_;
+
+  /// Cycle-closing marker reference edges discovered while resolving one shape's markers.
+  /// Reusing these decisions keeps repeated marker definitions structurally consistent.
+  std::set<std::pair<Entity, Entity>> cyclicMarkerReferences_;
 
   /// The last rendered entity of each offscreen subtree instantiated by \ref
   /// instantiateOffscreenSubtree, keyed by the subtree's root entity. Used to rebuild a correct

--- a/donner/svg/renderer/RenderingContext.cc
+++ b/donner/svg/renderer/RenderingContext.cc
@@ -4,7 +4,7 @@
 #include <map>
 #include <optional>
 #include <set>
-#include <tuple>
+#include <utility>
 #include <vector>
 
 #include "donner/base/parser/LengthParser.h"
@@ -1118,16 +1118,14 @@ public:
         resolvedRef && IsValidMarker(resolvedRef->handle)) {
       const Entity markerElement = resolvedRef->handle.entity();
       if (!activeMarkerStack_.empty() &&
-          cyclicMarkerReferences_.count(
-              {activeMarkerStack_.front(), activeMarkerStack_.back(), markerElement})) {
+          cyclicMarkerReferences_.count({activeMarkerStack_.back(), markerElement})) {
         return ResolvedMarker{ResolvedReference{EntityHandle()}, std::nullopt,
                               MarkerUnits::Default};
       }
 
       if (activeMarkerElements_.count(markerElement)) {
         assert(!activeMarkerStack_.empty());
-        cyclicMarkerReferences_.insert(
-            {activeMarkerStack_.front(), activeMarkerStack_.back(), markerElement});
+        cyclicMarkerReferences_.insert({activeMarkerStack_.back(), markerElement});
         return ResolvedMarker{ResolvedReference{EntityHandle()}, std::nullopt,
                               MarkerUnits::Default};
       }
@@ -1207,10 +1205,10 @@ private:
   /// Marker expansion order, used to identify the exact reference edge that closes a cycle.
   std::vector<Entity> activeMarkerStack_;
 
-  /// Cycle-closing marker reference edges, keyed by top-level marker root, source, and target.
-  /// Reusing decisions within a root keeps repeated definitions structurally consistent without
-  /// suppressing the reverse orientation when another marker becomes the root.
-  std::set<std::tuple<Entity, Entity, Entity>> cyclicMarkerReferences_;
+  /// Cycle-closing marker reference edges, keyed by source and target marker. Decisions remain
+  /// active while all markers on one host shape are resolved, so a reciprocal marker does not
+  /// expand the same cycle again from the opposite endpoint.
+  std::set<std::pair<Entity, Entity>> cyclicMarkerReferences_;
 
   /// The last rendered entity of each offscreen subtree instantiated by \ref
   /// instantiateOffscreenSubtree, keyed by the subtree's root entity. Used to rebuild a correct

--- a/donner/svg/renderer/tests/RendererPublicApi_tests.cc
+++ b/donner/svg/renderer/tests/RendererPublicApi_tests.cc
@@ -853,6 +853,40 @@ TEST(RendererPublicApiTest, RecursiveMarkerStopsAtOneLevel) {
   EXPECT_THAT(PixelAt(snapshot, 34, 18), IsTransparent());
 }
 
+TEST(RendererPublicApiTest, RecursiveMarkersRetainFirstNestedLevelForEachRoot) {
+  SVGDocument document = ParseDocument(R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="80" height="32" viewBox="0 0 80 32">
+        <defs>
+          <marker id="a" refX="0" refY="0" markerWidth="32" markerHeight="10"
+                  markerUnits="userSpaceOnUse" orient="0" style="overflow:visible">
+            <rect x="0" y="0" width="4" height="4" fill="red" />
+            <use href="#recursive-path" />
+          </marker>
+          <marker id="b" refX="0" refY="0" markerWidth="32" markerHeight="10"
+                  markerUnits="userSpaceOnUse" orient="0" style="overflow:visible">
+            <rect x="0" y="0" width="4" height="4" fill="blue" />
+            <use href="#recursive-path" />
+          </marker>
+          <path id="recursive-path" d="M 8 0 H 16" fill="none" stroke="black"
+                stroke-opacity="0" marker-start="url(#a)" marker-end="url(#b)" />
+        </defs>
+        <polyline points="8,16 48,16" fill="none" stroke="black" stroke-opacity="0"
+                  marker-start="url(#a)" marker-end="url(#b)" />
+      </svg>
+    )svg");
+
+  Renderer renderer;
+  renderer.draw(document);
+  const RendererBitmap snapshot = NormalizeSnapshot(renderer.takeSnapshot());
+  ASSERT_FALSE(snapshot.empty());
+
+  EXPECT_THAT(PixelAt(snapshot, 10, 18), IsRedish());
+  EXPECT_THAT(PixelAt(snapshot, 26, 18), IsBlueish());
+  EXPECT_THAT(PixelAt(snapshot, 50, 18), IsBlueish());
+  EXPECT_THAT(PixelAt(snapshot, 58, 18), IsRedish());
+  EXPECT_THAT(PixelAt(snapshot, 74, 18), IsTransparent());
+}
+
 // 6. Use element rendering
 TEST(RendererPublicApiTest, UseElementRendering) {
   SVGDocument document = ParseDocument(R"svg(

--- a/donner/svg/renderer/tests/RendererPublicApi_tests.cc
+++ b/donner/svg/renderer/tests/RendererPublicApi_tests.cc
@@ -853,7 +853,7 @@ TEST(RendererPublicApiTest, RecursiveMarkerStopsAtOneLevel) {
   EXPECT_THAT(PixelAt(snapshot, 34, 18), IsTransparent());
 }
 
-TEST(RendererPublicApiTest, RecursiveMarkersRetainFirstNestedLevelForEachRoot) {
+TEST(RendererPublicApiTest, RecursiveMarkerCycleEdgesRemainStableAcrossHostMarkers) {
   SVGDocument document = ParseDocument(R"svg(
       <svg xmlns="http://www.w3.org/2000/svg" width="80" height="32" viewBox="0 0 80 32">
         <defs>
@@ -883,7 +883,7 @@ TEST(RendererPublicApiTest, RecursiveMarkersRetainFirstNestedLevelForEachRoot) {
   EXPECT_THAT(PixelAt(snapshot, 10, 18), IsRedish());
   EXPECT_THAT(PixelAt(snapshot, 26, 18), IsBlueish());
   EXPECT_THAT(PixelAt(snapshot, 50, 18), IsBlueish());
-  EXPECT_THAT(PixelAt(snapshot, 58, 18), IsRedish());
+  EXPECT_THAT(PixelAt(snapshot, 58, 18), IsTransparent());
   EXPECT_THAT(PixelAt(snapshot, 74, 18), IsTransparent());
   EXPECT_THAT(PixelAt(snapshot, 2, 2), IsTransparent());
 }

--- a/donner/svg/renderer/tests/RendererPublicApi_tests.cc
+++ b/donner/svg/renderer/tests/RendererPublicApi_tests.cc
@@ -885,6 +885,7 @@ TEST(RendererPublicApiTest, RecursiveMarkersRetainFirstNestedLevelForEachRoot) {
   EXPECT_THAT(PixelAt(snapshot, 50, 18), IsBlueish());
   EXPECT_THAT(PixelAt(snapshot, 58, 18), IsRedish());
   EXPECT_THAT(PixelAt(snapshot, 74, 18), IsTransparent());
+  EXPECT_THAT(PixelAt(snapshot, 2, 2), IsTransparent());
 }
 
 // 6. Use element rendering

--- a/donner/svg/renderer/tests/RenderingContext_tests.cc
+++ b/donner/svg/renderer/tests/RenderingContext_tests.cc
@@ -602,6 +602,59 @@ TEST_F(RenderingContextTest, FindIntersectingRectReturnsFrontToBackOrder) {
   EXPECT_THAT(hits, testing::Contains(backEntity));
 }
 
+TEST_F(RenderingContextTest, RecursiveMarkerRangeContainsNestedMarkerSubtree) {
+  auto document = ParseSVG(R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <defs>
+        <marker id="a" markerWidth="6" markerHeight="6" refX="1" refY="3" orient="auto">
+          <use href="#recursive-path" transform="matrix(-1 0 0 1 6 0)"/>
+        </marker>
+        <marker id="b" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+          <use href="#recursive-path"/>
+        </marker>
+        <path id="recursive-path" d="M 1 1 5 3 1 5" fill="none" stroke="blue"
+              marker-start="url(#a)" marker-end="url(#b)"/>
+      </defs>
+      <path id="host" d="M 10 10 L 190 190" fill="none" stroke="green" stroke-width="5"
+            marker-start="url(#a)" marker-end="url(#b)"/>
+    </svg>
+  )svg");
+
+  RenderingContext ctx(document.registry());
+  ctx.instantiateRenderTree(false, warningSink_);
+
+  Registry& registry = document.registry();
+  const Entity hostEntity = document.querySelector("#host")->unsafeEntityHandle().entity();
+  const auto& hostInstance = registry.get<RenderingInstanceComponent>(hostEntity);
+  ASSERT_TRUE(hostInstance.markerEnd.has_value());
+  ASSERT_TRUE(hostInstance.markerEnd->subtreeInfo.has_value());
+
+  const SubtreeInfo& rootInfo = *hostInstance.markerEnd->subtreeInfo;
+  const int rootFirstOrder =
+      registry.get<RenderingInstanceComponent>(rootInfo.firstRenderedEntity).drawOrder;
+  const int rootLastOrder =
+      registry.get<RenderingInstanceComponent>(rootInfo.lastRenderedEntity).drawOrder;
+
+  const RenderingInstanceComponent* nestedPath = nullptr;
+  for (const Entity entity : registry.view<RenderingInstanceComponent>()) {
+    const auto& candidate = registry.get<RenderingInstanceComponent>(entity);
+    const auto* id = registry.try_get<IdComponent>(candidate.dataEntity);
+    if (id && id->id() == "recursive-path" && candidate.drawOrder >= rootFirstOrder &&
+        candidate.drawOrder <= rootLastOrder && candidate.markerStart.has_value()) {
+      nestedPath = &candidate;
+      break;
+    }
+  }
+
+  ASSERT_THAT(nestedPath, NotNull());
+  ASSERT_TRUE(nestedPath->markerStart->subtreeInfo.has_value());
+  const int nestedLastOrder =
+      registry
+          .get<RenderingInstanceComponent>(nestedPath->markerStart->subtreeInfo->lastRenderedEntity)
+          .drawOrder;
+  EXPECT_LE(nestedLastOrder, rootLastOrder);
+}
+
 // --- context-fill / context-stroke resolution ---
 
 /// Matches a ResolvedPaintServer holding a solid color equal to @p expectedColor.

--- a/donner/svg/renderer/tests/RenderingContext_tests.cc
+++ b/donner/svg/renderer/tests/RenderingContext_tests.cc
@@ -602,7 +602,7 @@ TEST_F(RenderingContextTest, FindIntersectingRectReturnsFrontToBackOrder) {
   EXPECT_THAT(hits, testing::Contains(backEntity));
 }
 
-TEST_F(RenderingContextTest, RecursiveMarkerRangeContainsNestedMarkerSubtree) {
+TEST_F(RenderingContextTest, RecursiveMarkerKeepsNestedSubtreeOutsideParentRenderRange) {
   auto document = ParseSVG(R"svg(
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
       <defs>
@@ -652,7 +652,9 @@ TEST_F(RenderingContextTest, RecursiveMarkerRangeContainsNestedMarkerSubtree) {
       registry
           .get<RenderingInstanceComponent>(nestedPath->markerStart->subtreeInfo->lastRenderedEntity)
           .drawOrder;
-  EXPECT_LE(nestedLastOrder, rootLastOrder);
+  // Nested markers are rendered through their referencing path, not as part of the parent's direct
+  // range. Renderer cleanup must still skip their separate inline ranges after drawing the parent.
+  EXPECT_GT(nestedLastOrder, rootLastOrder);
 }
 
 // --- context-fill / context-stroke resolution ---

--- a/donner/svg/renderer/tests/RenderingContext_tests.cc
+++ b/donner/svg/renderer/tests/RenderingContext_tests.cc
@@ -626,10 +626,10 @@ TEST_F(RenderingContextTest, RecursiveMarkerKeepsNestedSubtreeOutsideParentRende
   Registry& registry = document.registry();
   const Entity hostEntity = document.querySelector("#host")->unsafeEntityHandle().entity();
   const auto& hostInstance = registry.get<RenderingInstanceComponent>(hostEntity);
-  ASSERT_TRUE(hostInstance.markerEnd.has_value());
-  ASSERT_TRUE(hostInstance.markerEnd->subtreeInfo.has_value());
+  ASSERT_TRUE(hostInstance.markerStart.has_value());
+  ASSERT_TRUE(hostInstance.markerStart->subtreeInfo.has_value());
 
-  const SubtreeInfo& rootInfo = *hostInstance.markerEnd->subtreeInfo;
+  const SubtreeInfo& rootInfo = *hostInstance.markerStart->subtreeInfo;
   const int rootFirstOrder =
       registry.get<RenderingInstanceComponent>(rootInfo.firstRenderedEntity).drawOrder;
   const int rootLastOrder =
@@ -640,17 +640,17 @@ TEST_F(RenderingContextTest, RecursiveMarkerKeepsNestedSubtreeOutsideParentRende
     const auto& candidate = registry.get<RenderingInstanceComponent>(entity);
     const auto* id = registry.try_get<IdComponent>(candidate.dataEntity);
     if (id && id->id() == "recursive-path" && candidate.drawOrder >= rootFirstOrder &&
-        candidate.drawOrder <= rootLastOrder && candidate.markerStart.has_value()) {
+        candidate.drawOrder <= rootLastOrder && candidate.markerEnd.has_value()) {
       nestedPath = &candidate;
       break;
     }
   }
 
   ASSERT_THAT(nestedPath, NotNull());
-  ASSERT_TRUE(nestedPath->markerStart->subtreeInfo.has_value());
+  ASSERT_TRUE(nestedPath->markerEnd->subtreeInfo.has_value());
   const int nestedLastOrder =
       registry
-          .get<RenderingInstanceComponent>(nestedPath->markerStart->subtreeInfo->lastRenderedEntity)
+          .get<RenderingInstanceComponent>(nestedPath->markerEnd->subtreeInfo->lastRenderedEntity)
           .drawOrder;
   // Nested markers are rendered through their referencing path, not as part of the parent's direct
   // range. Renderer cleanup must still skip their separate inline ranges after drawing the parent.

--- a/donner/svg/renderer/tests/resvg_test_suite.cc
+++ b/donner/svg/renderer/tests/resvg_test_suite.cc
@@ -754,7 +754,7 @@ INSTANTIATE_TEST_SUITE_P(
                 // Path::vertices() emits the arrival mid for zero-length-close corner
                 // contours. Residual is sub-marker edge coverage.
                 {"marker-on-rounded-rect.svg", WithMaxPixels(60, "Marker stack edge coverage")},
-                {"recursive-5.svg", Params::Skip("Recursive marker rendering edge case (~787px)")},
+                {"recursive-5.svg", Params{}},
             })),
         ValuesIn(ActiveComparisonModes())),
     TestNameFromFilename);


### PR DESCRIPTION
Stops reciprocal marker references at the SVG-defined finite expansion point while preserving the first nested marker that should render.

**Root cause**

Recursive marker decisions were either recomputed independently for each host endpoint or their nested inline definitions remained visible to the caller's document traversal. That made one endpoint expand the same cycle again and could draw marker definitions a second time outside their intended marker traversal.

**Changes**

- Memoize cycle-closing source-to-target marker edges for the complete marker-resolution session of one host shape.
- Reuse those decisions at later marker endpoints.
- Extend inline marker cleanup transitively in draw order so nested marker definition ranges are skipped once rendered.
- Add public API and rendering-context regressions.
- Enable the resvg `painting/marker/recursive-5.svg` golden comparison.

**Verification**

- Recursive marker unit regressions, TinySkia and Geode: pass.
- Full resvg `painting/marker` category, default, full-text, and Geode variants: pass.
- Affected renderer and resvg lint targets: pass.

Refs #623.