### PR TITLE
Fix textPath transform-origin coordinate resolution

### DIFF
--- a/donner/svg/components/text/BUILD.bazel
+++ b/donner/svg/components/text/BUILD.bazel
@@ -59,6 +59,7 @@ cc_library(
         "//donner/base/xml/components",
         "//donner/svg/components:components_core",
         "//donner/svg/components:svg_document_context",
+        "//donner/svg/components/layout:layout_system",
         "//donner/svg/components/shape:components",
         "//donner/svg/components/style:components",
         "//donner/svg/graph",
@@ -68,15 +69,15 @@ cc_library(
 
 donner_cc_test(
     name = "text_system_tests",
+    srcs = [
+        "tests/TextSystem_tests.cc",
+    ],
     # Variant lanes (doc 0031 M2.3): tiny / text_full / geode
     # wrappers run automatically under `bazel test //...`.
     variants = [
         "tiny",
         "text_full",
         "geode",
-    ],
-    srcs = [
-        "tests/TextSystem_tests.cc",
     ],
     deps = [
         ":text_system",

--- a/donner/svg/components/text/TextSystem.cc
+++ b/donner/svg/components/text/TextSystem.cc
@@ -10,7 +10,7 @@
 #include "donner/base/xml/components/TreeComponent.h"
 #include "donner/svg/components/ConditionalProcessingComponent.h"
 #include "donner/svg/components/SVGDocumentContext.h"
-#include "donner/svg/components/layout/TransformComponent.h"
+#include "donner/svg/components/layout/LayoutSystem.h"
 #include "donner/svg/components/shape/ComputedPathComponent.h"
 #include "donner/svg/components/shape/PathComponent.h"
 #include "donner/svg/components/style/ComputedStyleComponent.h"
@@ -101,7 +101,7 @@ void removeTrailingSpace(RcString& text) {
 }
 
 void resolveTextPath(Registry& registry, const TextPathComponent& textPath,
-                     ComputedTextComponent::TextSpan& span, ParseWarningSink& warningSink) {
+                     ComputedTextComponent::TextSpan& span) {
   if (textPath.href.empty()) {
     return;
   }
@@ -136,44 +136,30 @@ void resolveTextPath(Registry& registry, const TextPathComponent& textPath,
     return;
   }
 
-  // Apply the referenced path element's local transform to the path geometry.
-  // Per SVG §10.12.2, textPath uses the path in the referenced element's user coordinate space.
-  //
-  // The transform must include the `transform-origin` pivot so the path the text follows lands
-  // in the same place as the path element renders.
-  // `ComputedLocalTransformComponent::parentFromEntity` is the *raw* transform (pivot not applied);
-  // compose the pivot here exactly as LayoutSystem::getEntityFromParentTransform does - `T(-origin)
-  // * M * T(origin)` in Donner's left-first multiplication order. Without this,
-  // `transform="rotate(90)" transform-origin="center"` rotated the baseline path about the origin
-  // instead of its center, sampling glyphs off-screen (issue #624:
-  // structure/transform-origin/on-text-path).
-  const auto* localTransform =
-      registry.try_get<ComputedLocalTransformComponent>(resolved->handle.entity());
-  const Transform2d parentFromEntity =
-      localTransform ? Transform2d::Translate(-localTransform->transformOrigin) *
-                           localTransform->parentFromEntity *
-                           Transform2d::Translate(localTransform->transformOrigin)
-                     : Transform2d();
-  if (localTransform && !parentFromEntity.isIdentity()) {
+  // The referenced path is treated as if it were defined in the textPath user space. Its own
+  // pivoted transform applies there, while transforms on its original ancestors do not.
+  const Transform2d textRootFromPath =
+      LayoutSystem().getEntityFromParentTransform(resolved->handle);
+  if (!textRootFromPath.isIdentity()) {
     const auto& srcPoints = computedPath->spline.points();
     const auto& srcCommands = computedPath->spline.commands();
     PathBuilder builder;
     for (const auto& cmd : srcCommands) {
       switch (cmd.verb) {
         case Path::Verb::MoveTo:
-          builder.moveTo(parentFromEntity.transformPosition(srcPoints[cmd.pointIndex]));
+          builder.moveTo(textRootFromPath.transformPosition(srcPoints[cmd.pointIndex]));
           break;
         case Path::Verb::LineTo:
-          builder.lineTo(parentFromEntity.transformPosition(srcPoints[cmd.pointIndex]));
+          builder.lineTo(textRootFromPath.transformPosition(srcPoints[cmd.pointIndex]));
           break;
         case Path::Verb::QuadTo:
-          builder.quadTo(parentFromEntity.transformPosition(srcPoints[cmd.pointIndex]),
-                         parentFromEntity.transformPosition(srcPoints[cmd.pointIndex + 1]));
+          builder.quadTo(textRootFromPath.transformPosition(srcPoints[cmd.pointIndex]),
+                         textRootFromPath.transformPosition(srcPoints[cmd.pointIndex + 1]));
           break;
         case Path::Verb::CurveTo:
-          builder.curveTo(parentFromEntity.transformPosition(srcPoints[cmd.pointIndex]),
-                          parentFromEntity.transformPosition(srcPoints[cmd.pointIndex + 1]),
-                          parentFromEntity.transformPosition(srcPoints[cmd.pointIndex + 2]));
+          builder.curveTo(textRootFromPath.transformPosition(srcPoints[cmd.pointIndex]),
+                          textRootFromPath.transformPosition(srcPoints[cmd.pointIndex + 1]),
+                          textRootFromPath.transformPosition(srcPoints[cmd.pointIndex + 2]));
           break;
         case Path::Verb::ClosePath: builder.closePath(); break;
       }
@@ -340,7 +326,7 @@ void TextSystem::instantiateComputedComponent(EntityHandle rootHandle,
         findApplicableTextPathEntity(registry, handle.entity(), invalidTextPathNesting);
     if (textPathEntity != entt::null) {
       const auto& textPath = registry.get<TextPathComponent>(textPathEntity);
-      resolveTextPath(registry, textPath, span, warningSink);
+      resolveTextPath(registry, textPath, span);
       if (!span.pathSpline) {
         // textPath href could not be resolved - mark as failed so glyphs are hidden.
         span.textPathFailed = true;

--- a/donner/svg/components/text/tests/TextSystem_tests.cc
+++ b/donner/svg/components/text/tests/TextSystem_tests.cc
@@ -7,7 +7,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "donner/base/MathUtils.h"
 #include "donner/base/ParseWarningSink.h"
 #include "donner/base/Path.h"
 #include "donner/base/tests/BaseTestUtils.h"
@@ -353,46 +352,66 @@ TEST_F(TextSystemTest, TextPathWithAbsoluteStartOffsetAndTransform) {
   EXPECT_DOUBLE_EQ(computed->spans[1].pathStartOffset, 10.0);
 }
 
-// Issue #624: the textPath baseline geometry must include the referenced path's
-// `transform-origin` pivot, so it lands in the same place the path element renders.
-// A rotate about a non-zero origin must pivot about that origin, not (0,0).
-TEST_F(TextSystemTest, TextPathTransformIncludesTransformOriginPivot) {
-  parser::SVGParser::Options options;
-  options.enableExperimental = true;
-  ParseWarningSink parseSink;
-  auto maybeResult = parser::SVGParser::ParseSVG(R"svg(
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+TEST_F(TextSystemTest, TextPathTransformsPercentageAndAbsoluteOffsetsInTextCoordinates) {
+  auto document = ParseAndCompute(R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
       <defs>
-        <path id="p" d="M 0 0 L 100 0"/>
+        <g transform="translate(50 40)">
+          <g transform="scale(2)">
+            <path id="p" d="M 0 0 L 20 0" transform="matrix(0 2 -3 0 0 0)"
+                  transform-origin="10px 0"/>
+          </g>
+        </g>
       </defs>
-      <text id="t"><textPath href="#p">Pivoted</textPath></text>
+      <g transform="translate(10 5)">
+        <text id="percent" transform="translate(5 15)"><textPath href="#p"
+          startOffset="50%">AB</textPath></text>
+        <text id="absolute" transform="translate(5 15)"><textPath href="#p"
+          startOffset="10">AB</textPath></text>
+      </g>
     </svg>
-  )svg",
-                                                 parseSink, options);
-  ASSERT_THAT(maybeResult, NoParseError());
-  auto document = std::move(maybeResult).result();
+  )svg");
 
   Registry& registry = document.registry();
-  auto pathEntity = document.querySelector("#p")->unsafeEntityHandle().entity();
+  const auto percentEntity = document.querySelector("#percent")->unsafeEntityHandle().entity();
+  const auto absoluteEntity = document.querySelector("#absolute")->unsafeEntityHandle().entity();
+  const auto* percent = registry.try_get<ComputedTextComponent>(percentEntity);
+  const auto* absolute = registry.try_get<ComputedTextComponent>(absoluteEntity);
+  ASSERT_NE(percent, nullptr);
+  ASSERT_NE(absolute, nullptr);
+  ASSERT_THAT(percent->spans, SizeIs(2));
+  ASSERT_THAT(absolute->spans, SizeIs(2));
+  ASSERT_TRUE(percent->spans[1].pathSpline.has_value());
+  ASSERT_TRUE(absolute->spans[1].pathSpline.has_value());
 
-  // rotate(90deg) about the pivot (50, 0): maps (0,0)->(50,-50) and (100,0)->(50,50).
-  // Without the pivot, the same rotation about (0,0) would map (0,0)->(0,0), (100,0)->(0,100).
-  const Transform2d rotate90 = Transform2d::Rotate(MathConstants<double>::kHalfPi);
-  registry.emplace_or_replace<ComputedLocalTransformComponent>(
-      pathEntity, rotate90, CssTransform(rotate90), Vector2d(50, 0));
-  ParseWarningSink warningSink;
-  StyleSystem().computeAllStyles(registry, warningSink);
-  TextSystem().instantiateAllComputedComponents(registry, warningSink);
+  EXPECT_THAT(percent->spans[1].pathSpline->points(),
+              testing::ElementsAre(Vector2Near(10.0, -20.0), Vector2Near(10.0, 20.0)));
+  EXPECT_THAT(absolute->spans[1].pathSpline->points(),
+              testing::ElementsAre(Vector2Near(10.0, -20.0), Vector2Near(10.0, 20.0)));
+  EXPECT_THAT(percent->spans[1].pathStartOffset, testing::DoubleEq(20.0));
+  EXPECT_THAT(absolute->spans[1].pathStartOffset, testing::DoubleEq(10.0));
+}
 
-  auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
-  auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
+TEST_F(TextSystemTest, TextPathTransformOriginCenterResolvesAgainstNonzeroViewBox) {
+  auto document = ParseAndCompute(R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="10 20 200 100">
+      <defs>
+        <path id="p" d="M 100 70 L 120 70" transform="matrix(0 1 -1 0 0 0)"
+              transform-origin="center"/>
+      </defs>
+      <text id="t"><textPath href="#p">AB</textPath></text>
+    </svg>
+  )svg");
+
+  Registry& registry = document.registry();
+  const auto textEntity = document.querySelector("#t")->unsafeEntityHandle().entity();
+  const auto* computed = registry.try_get<ComputedTextComponent>(textEntity);
   ASSERT_NE(computed, nullptr);
   ASSERT_THAT(computed->spans, SizeIs(2));
   ASSERT_TRUE(computed->spans[1].pathSpline.has_value());
 
-  // Pivoted result: T(-origin) * rotate90 * T(origin).
   EXPECT_THAT(computed->spans[1].pathSpline->points(),
-              testing::ElementsAre(Vector2Near(50.0, -50.0), Vector2Near(50.0, 50.0)));
+              testing::ElementsAre(Vector2Near(110.0, 60.0), Vector2Near(110.0, 80.0)));
 }
 
 TEST_F(TextSystemTest, TextPathUsesSplineOverrideWhenComputedPathMissing) {

--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -506,10 +506,12 @@ donner_cc_test(
     deps = [
         ":mock_renderer_interface",
         "//donner/base:base_test_utils",
+        "//donner/svg/components/layout:layout_system",
         "//donner/svg/renderer:renderer_driver",
         "//donner/svg/renderer:renderer_utils",
         "//donner/svg/renderer:rendering_context",
         "//donner/svg/tests:parser_test_utils",
+        "//donner/svg/text:text_engine",
         "@com_google_gtest//:gtest_main",
     ],
 )

--- a/donner/svg/renderer/tests/Renderer_tests.cc
+++ b/donner/svg/renderer/tests/Renderer_tests.cc
@@ -516,6 +516,42 @@ RendererBitmap RenderSvgString(const std::string& svg) {
   return RenderDocumentWithBackend(document, ActiveRendererBackend(), /*verbose=*/false);
 }
 
+TEST_F(RendererTests, TextPathTransformChainMatchesFlattenedTextCoordinates) {
+  const std::string transformed = R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <defs>
+        <g transform="translate(50 40)">
+          <g transform="scale(2)">
+            <path id="p" d="M 0 0 L 20 0" transform="matrix(0 2 -3 0 0 0)"
+                  transform-origin="10px 0"/>
+          </g>
+        </g>
+      </defs>
+      <g transform="translate(10 5)">
+        <text transform="translate(5 15)" rotate="15" font-family="Noto Sans" font-size="12">
+          <textPath href="#p" startOffset="25%">AB</textPath>
+        </text>
+      </g>
+    </svg>
+  )svg";
+  const std::string flattened = R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <defs><path id="p" d="M 10 -20 L 10 20"/></defs>
+      <g transform="translate(10 5)">
+        <text transform="translate(5 15)" rotate="15" font-family="Noto Sans" font-size="12">
+          <textPath href="#p" startOffset="25%">AB</textPath>
+        </text>
+      </g>
+    </svg>
+  )svg";
+
+  const RendererBitmap actual = RenderSvgString(transformed);
+  const RendererBitmap expected = RenderSvgString(flattened);
+  ASSERT_FALSE(actual.empty());
+  ASSERT_FALSE(expected.empty());
+  ExpectBitmapsIdentical(actual, expected, "text_path_transform_chain");
+}
+
 // Regression for issue #552: a long *acyclic* chain of `<feImage>` fragment
 // references recursed once per link in `RendererDriver::preRenderFeImageFragments`
 // - each level standing up a GPU offscreen instance - with no depth bound. The

--- a/donner/svg/renderer/tests/RenderingContext_tests.cc
+++ b/donner/svg/renderer/tests/RenderingContext_tests.cc
@@ -14,11 +14,15 @@
 #include "donner/svg/components/DirtyFlagsComponent.h"
 #include "donner/svg/components/IdComponent.h"
 #include "donner/svg/components/RenderingInstanceComponent.h"
+#include "donner/svg/components/layout/LayoutSystem.h"
 #include "donner/svg/components/style/ComputedStyleComponent.h"
 #include "donner/svg/parser/SVGParser.h"
+#include "donner/svg/text/TextEngine.h"
 
 using testing::ElementsAre;
+using testing::Eq;
 using testing::Gt;
+using testing::Lt;
 using testing::NotNull;
 using testing::Optional;
 
@@ -148,6 +152,46 @@ TEST_F(RenderingContextTest, FindAllIntersecting) {
 
   std::vector<Entity> hits = ctx.findAllIntersecting(Vector2d(50, 50));
   EXPECT_THAT(hits.size(), Gt(0u));
+}
+
+TEST_F(RenderingContextTest, TextPathHitTestUsesTransformedGlyphBounds) {
+  auto document = ParseSVG(R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <g transform="translate(50 40)">
+        <g transform="scale(2)">
+          <path id="p" d="M 0 0 L 20 0" transform="matrix(0 2 -3 0 0 0)"
+                transform-origin="10px 0" fill="none" stroke="gray"/>
+        </g>
+      </g>
+      <g transform="translate(10 5)">
+        <text id="t" transform="translate(5 15)" font-family="Noto Sans" font-size="12">
+          <textPath href="#p" startOffset="25%">AB</textPath>
+        </text>
+      </g>
+    </svg>
+  )svg");
+
+  RenderingContext ctx(document.registry());
+  ctx.instantiateRenderTree(false, warningSink_);
+
+  Registry& registry = document.registry();
+  if (!registry.ctx().contains<TextEngine>()) {
+    GTEST_SKIP() << "Text is disabled in this renderer variant";
+  }
+
+  const EntityHandle textHandle = document.querySelector("#t")->unsafeEntityHandle();
+  const EntityHandle pathHandle = document.querySelector("#p")->unsafeEntityHandle();
+  const Box2d localInkBounds = registry.ctx().get<TextEngine>().computedInkBounds(textHandle);
+  ASSERT_FALSE(localInkBounds.isEmpty());
+
+  EXPECT_THAT(ctx.getWorldBounds(pathHandle.entity()),
+              Optional(BoxEq(Vector2Near(70.0, 0.0), Vector2Near(70.0, 80.0))));
+
+  const Vector2d localCenter = (localInkBounds.topLeft + localInkBounds.bottomRight) * 0.5;
+  const Vector2d worldCenter =
+      LayoutSystem().getEntityFromWorldTransform(textHandle).transformPosition(localCenter);
+  EXPECT_THAT(worldCenter.x, testing::AllOf(Gt(20.0), Lt(40.0)));
+  EXPECT_THAT(ctx.findIntersecting(worldCenter), Eq(textHandle.entity()));
 }
 
 // --- World bounds ---


### PR DESCRIPTION
Routes referenced `textPath` transforms through `LayoutSystem` so `transform-origin` resolves in the correct text user space without inheriting transforms from the referenced path's original ancestors. This is the transform-origin packet for #624; the sibling paint-order packet remains separate, so this PR does not close the issue.

## Root cause

`TextSystem::resolveTextPath()` manually reconstructed a pivoted transform from an optionally precomputed `ComputedLocalTransformComponent`. When text layout ran before that component existed, the referenced path transform was silently omitted. The duplicate composition also made the intended coordinate-space boundary difficult to verify.

The resolver now asks `LayoutSystem::getEntityFromParentTransform()` for the path element's fully resolved local transform. That centralizes `transform-origin` composition and reference-box resolution while preserving SVG textPath semantics: the path element's own transform applies in text user space, and transforms on its original ancestors do not.

## Coverage

- Resolves `transform-origin: center` against a nonzero viewBox.
- Distinguishes percentage `startOffset` after nonuniform scaling from an absolute user-unit offset.
- Compares transformed and flattened textPath rendering with strict bitmap identity.
- Verifies referenced-path world bounds remain distinct from transformed text hit bounds.
- Keeps the no-text `tiny` variant valid by skipping the text-engine-specific hit assertion.

## Verification

- Complete layout, text-system, and renderer-driver suites in default, `tiny`, full-text, and Geode variants.
- Full `structure/transform-origin` and `text/textPath` resvg groups in default and full-text lanes.
- Exact `structure/transform-origin/on-text-path.svg` Geode comparison.
- Strict renderer bitmap parity in default, full-text, and Geode backends.
- Banned-dependency check, targeted lints, `buildifier -mode=check`, `git diff --check`, and CMake generator validation.
