### PR TITLE
Honor tspan paint order in Geode

### DIFF
--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -3862,6 +3862,8 @@ void RendererGeode::drawText(Registry& registry, const components::ComputedTextC
       continue;  // Nothing to fill, stroke, or decorate.
     }
 
+    std::vector<Path> runGlyphPaths;
+    runGlyphPaths.reserve(run.glyphs.size());
     for (const auto& glyph : run.glyphs) {
       if (glyph.glyphIndex == 0) {
         continue;  // `.notdef` -- skip to match tiny-skia.
@@ -3879,44 +3881,70 @@ void RendererGeode::drawText(Registry& registry, const components::ComputedTextC
         continue;
       }
 
-      if (fillIsGradient) {
-        // Gradient fill on text: resolve the gradient against the text bbox
-        // (the gradient *geometry*), fill the glyph outline (the *draw* path).
-        impl_->drawPaintedPathAgainst(textBoundsPath, placed, fillServer, fillOpacity,
-                                      FillRule::NonZero);
-      } else if (usePatternFill) {
-        // Fill the glyph outline with the staged pattern tile, same as a
-        // pattern-filled `<path>` (see Impl::fillResolved). The glyph path is
-        // already in the element's local space and `deviceFromLocalTransform`
-        // is set above, so `buildPatternPaint` composes the right sample space.
-        impl_->syncTransform();
-        impl_->encoder->fillPathPattern(
-            placed, FillRule::NonZero,
-            impl_->buildPatternPaint(*impl_->patternFillPaint, impl_->paint.fillOpacity));
-      } else if (hasFill) {
-        impl_->encoder->fillPath(placed, spanFill, FillRule::NonZero);
+      runGlyphPaths.push_back(placed);
+    }
+
+    const auto drawRunFill = [&]() {
+      for (const Path& placed : runGlyphPaths) {
+        if (fillIsGradient) {
+          // Gradient fill on text: resolve the gradient against the text bbox
+          // (the gradient *geometry*), fill the glyph outline (the *draw* path).
+          impl_->drawPaintedPathAgainst(textBoundsPath, placed, fillServer, fillOpacity,
+                                        FillRule::NonZero);
+        } else if (usePatternFill) {
+          // Fill the glyph outline with the staged pattern tile, same as a
+          // pattern-filled `<path>` (see Impl::fillResolved). The glyph path is
+          // already in the element's local space and `deviceFromLocalTransform`
+          // is set above, so `buildPatternPaint` composes the right sample space.
+          impl_->syncTransform();
+          impl_->encoder->fillPathPattern(
+              placed, FillRule::NonZero,
+              impl_->buildPatternPaint(*impl_->patternFillPaint, impl_->paint.fillOpacity));
+        } else if (hasFill) {
+          impl_->encoder->fillPath(placed, spanFill, FillRule::NonZero);
+        }
       }
-      if (hasStrokePaint) {
-        // Closed glyph contours expand to same-winding outer+inner subpaths, so
-        // the stroked outline needs `strokeFillRuleFor` (EvenOdd for the ring),
-        // not a hardcoded NonZero -- see RendererGeode::drawPath's stroke notes.
-        const Path stroked = placed.strokeToFill(*strokeStyle);
-        if (!stroked.empty()) {
-          const FillRule strokeRule = Impl::strokeFillRuleFor(stroked, *strokeStyle);
-          if (strokeIsGradient) {
-            // Gradient stroke: resolve against the text bbox (the *original*
-            // geometry, per SVG), fill the stroked outline.
-            impl_->drawPaintedPathAgainst(textBoundsPath, stroked, *strokeServer, strokeOpacity,
-                                          strokeRule);
-          } else if (usePatternStroke) {
-            impl_->syncTransform();
-            impl_->encoder->fillPathPattern(
-                stroked, strokeRule,
-                impl_->buildPatternPaint(*impl_->patternStrokePaint, strokeOpacity));
-          } else {
-            impl_->encoder->fillPath(stroked, *strokeColor, strokeRule);
+    };
+    const auto drawRunStroke = [&]() {
+      for (const Path& placed : runGlyphPaths) {
+        if (hasStrokePaint) {
+          // Closed glyph contours expand to same-winding outer+inner subpaths, so
+          // the stroked outline needs `strokeFillRuleFor` (EvenOdd for the ring),
+          // not a hardcoded NonZero -- see RendererGeode::drawPath's stroke notes.
+          const Path stroked = placed.strokeToFill(*strokeStyle);
+          if (!stroked.empty()) {
+            const FillRule strokeRule = Impl::strokeFillRuleFor(stroked, *strokeStyle);
+            if (strokeIsGradient) {
+              // Gradient stroke: resolve against the text bbox (the *original*
+              // geometry, per SVG), fill the stroked outline.
+              impl_->drawPaintedPathAgainst(textBoundsPath, stroked, *strokeServer, strokeOpacity,
+                                            strokeRule);
+            } else if (usePatternStroke) {
+              impl_->syncTransform();
+              impl_->encoder->fillPathPattern(
+                  stroked, strokeRule,
+                  impl_->buildPatternPaint(*impl_->patternStrokePaint, strokeOpacity));
+            } else {
+              impl_->encoder->fillPath(stroked, *strokeColor, strokeRule);
+            }
           }
         }
+      }
+    };
+
+    PaintOrder spanPaintOrder;
+    if (runIndex < text.spans.size()) {
+      spanPaintOrder = text.spans[runIndex].paintOrder;
+    }
+    bool fillDrawn = false;
+    bool strokeDrawn = false;
+    for (const PaintComponent component : spanPaintOrder.order) {
+      if (component == PaintComponent::Fill && !fillDrawn) {
+        drawRunFill();
+        fillDrawn = true;
+      } else if (component == PaintComponent::Stroke && !strokeDrawn) {
+        drawRunStroke();
+        strokeDrawn = true;
       }
     }
 

--- a/donner/svg/renderer/tests/RendererAscii_tests.cc
+++ b/donner/svg/renderer/tests/RendererAscii_tests.cc
@@ -39,5 +39,26 @@ TEST(RendererAsciiTests, TinySkiaMismatchDoesNotFallBackToDefault) {
   EXPECT_FALSE(geodeImage.matchBackend().defaultPattern("geode\n").tinySkia("tiny-skia\n"));
 }
 
+TEST(RendererAsciiTests, TspanPaintOrderMatchesExplicitStrokeThenFillPasses) {
+  const AsciiImage actual = RendererTestUtils::renderToAsciiImage(
+      R"(
+        <text x="4" y="24" font-family="Noto Sans" font-size="24"
+              fill="green" stroke="blue" stroke-width="4">
+          <tspan x="4" paint-order="stroke fill">H</tspan>
+        </text>
+        )",
+      Vector2i(32, 32));
+  const AsciiImage expected = RendererTestUtils::renderToAsciiImage(
+      R"(
+        <text x="4" y="24" font-family="Noto Sans" font-size="24"
+              fill="none" stroke="blue" stroke-width="4"><tspan x="4">H</tspan></text>
+        <text x="4" y="24" font-family="Noto Sans" font-size="24"
+              fill="green" stroke="none"><tspan x="4">H</tspan></text>
+        )",
+      Vector2i(32, 32));
+
+  EXPECT_EQ(actual.generated, expected.generated);
+}
+
 }  // namespace
 }  // namespace donner::svg


### PR DESCRIPTION
- Honor each computed text span's `paint-order` in the Geode renderer.
- Paint fill and stroke as whole-run passes, matching the existing TinySkia behavior and SVG compositing semantics.
- Add a backend-independent regression that compares `stroke fill` on a `tspan` with explicit stroke-only and fill-only passes.

Geode previously rendered every glyph with a hardcoded fill-then-stroke sequence. That ignored the resolved `paint-order` on the span and also interleaved fill and stroke per glyph instead of painting the text run as units.

The vendored `painting/paint-order/on-tspan` image remains unsuitable as a geometry oracle because its reference output changes kerning across a paint-only span boundary. The new regression isolates paint order with explicit positioning and preserves correct continuous text shaping. Together with the text-path transform-origin fix in #868, this completes #624.

Validation:

- `bazel test //donner/svg/renderer/tests:renderer_ascii_tests //donner/svg/renderer/tests:renderer_ascii_tests_geode //donner/svg/renderer/tests:renderer_ascii_tests_text_full //donner/svg/renderer/tests:renderer_ascii_tests_lint`
- `bazel test --config=geode //donner/svg/renderer/tests:renderer_geode_tests_impl`
- `python3 tools/cmake/gen_cmakelists.py --check`
- Targeted reruns of the three lint actions affected by transient remote input loss passed.

Closes #624
