### PR TITLE
Serialize Geode filter passes on Vulkan to fix cross-submit corruption

### DIFF
--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -3060,6 +3060,16 @@ void RendererGeode::popFilterLayer() {
       geode::ScopedWgpuHandle<wgpu::CommandBuffer> copyCmd(copyEncoder.get().finish());
       impl_->device->queue().submit(1, &copyCmd.get());
 
+      // [Vulkan filter-sync] This copy is its own submit, but the blit below
+      // records a sample of `viewportTexture` into the frame encoder, which
+      // submits later - the same cross-submit copy-write -> sampled-read race
+      // class as the filter engine's per-pass submits. Serialize on Vulkan.
+      // Interim workaround; superseded by the single-encoder filter refactor
+      // (design 0030 M3).
+      if (impl_->device->isVulkan()) {
+        impl_->device->device().poll(true, nullptr);
+      }
+
       impl_->encoder->blitFullTarget(viewportTexture.get(), 1.0);
       impl_->device->deferDestroy(viewportTexture.take());
     }

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -327,6 +327,8 @@ std::unique_ptr<GeodeDevice> GeodeDevice::CreateHeadless() {
       // Mesa lavapipe software). GeodeFilterEngine uses this to serialize its
       // per-pass compute submits, working around a nondeterministic
       // cross-submit texture-visibility race that only Vulkan exposes.
+      // If wgpuAdapterGetInfo fails on a real Vulkan device the fix silently
+      // disables (accepted residual risk).
       result->isVulkan_ = (info.backendType == WGPUBackendType_Vulkan);
 
       wgpuAdapterInfoFreeMembers(info);
@@ -438,6 +440,21 @@ std::unique_ptr<GeodeDevice> GeodeDevice::CreateFromExternal(const GeodeEmbedCon
   // Preserve the host-provided adapter for callers that need adapter metadata.
   if (config.adapter) {
     result->adapter_ = config.adapter;
+
+    // Detect a Vulkan backend on the embedder-supplied adapter the same way
+    // CreateHeadless() does, so the filter-engine inter-pass serialization
+    // (see isVulkan()) also protects external Vulkan devices.
+#ifndef __EMSCRIPTEN__
+    {
+      WGPUAdapterInfo info = {};
+      if (wgpuAdapterGetInfo(result->adapter_, &info) == WGPUStatus_Success) {
+        // If wgpuAdapterGetInfo fails on a real Vulkan device the fix
+        // silently disables (accepted residual risk).
+        result->isVulkan_ = (info.backendType == WGPUBackendType_Vulkan);
+        wgpuAdapterInfoFreeMembers(info);
+      }
+    }
+#endif
   }
 
   result->supportsTimestamps_ = config.device.hasFeature(wgpu::FeatureName::TimestampQuery);

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -323,6 +323,12 @@ std::unique_ptr<GeodeDevice> GeodeDevice::CreateHeadless() {
                    device.data(), static_cast<int>(arch.size()), arch.data(), backend, type,
                    info.vendorID, info.deviceID);
 
+      // Record whether we landed on a Vulkan backend (Intel Arc hardware or
+      // Mesa lavapipe software). GeodeFilterEngine uses this to serialize its
+      // per-pass compute submits, working around a nondeterministic
+      // cross-submit texture-visibility race that only Vulkan exposes.
+      result->isVulkan_ = (info.backendType == WGPUBackendType_Vulkan);
+
       wgpuAdapterInfoFreeMembers(info);
     }
   }

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -275,6 +275,13 @@ public:
    */
   bool supportsTimestamps() const { return false; }
 
+  /// True when the active wgpu backend is Vulkan (Intel Arc hardware or Mesa
+  /// lavapipe software). GeodeFilterEngine uses this to force inter-pass
+  /// serialization that eliminates a nondeterministic cross-submit
+  /// storage-write -> sampled-read visibility race observed on Arc Vulkan.
+  /// Metal returns false and keeps the fast multi-submit path.
+  bool isVulkan() const { return isVulkan_; }
+
   /// @name Shared dummy resources (design doc 0030 Milestone 4.2)
   /// @{
   ///
@@ -379,6 +386,10 @@ private:
   wgpu::TextureFormat textureFormat_ = wgpu::TextureFormat::RGBA8Unorm;
 
   bool supportsTimestamps_ = false;
+
+  /// True when the active wgpu backend is Vulkan. Set during adapter
+  /// selection in CreateHeadless(); see isVulkan().
+  bool isVulkan_ = false;
 
   /// True when this device was created via CreateFromExternal(). The destructor
   /// skips releasing the instance/adapter since the host owns them.

--- a/donner/svg/renderer/geode/GeodeFilterEngine.cc
+++ b/donner/svg/renderer/geode/GeodeFilterEngine.cc
@@ -627,11 +627,13 @@ void dispatchTwoInputUniform(GeodeDevice& device, const wgpu::BindGroupLayout& b
 
   ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
   device.queue().submit(1, &cmdBuf.get());
-  // [lavapipe/Arc filter-sync probe] Force each filter compute pass to fully
-  // complete before the next pass samples its storage-texture output. On
-  // hardware Vulkan (Intel Arc) the automatic cross-submit storage-write ->
+  // [Vulkan filter-sync] Force each filter compute pass to fully complete
+  // before the next pass samples its storage-texture output. On hardware
+  // Vulkan (Intel Arc) the automatic cross-submit storage-write ->
   // sampled-read barrier races the async queue, producing nondeterministic
   // large-area filter corruption. Serialize on Vulkan; Metal is unaffected.
+  // Interim workaround; superseded by the single-encoder filter refactor
+  // (design 0030 M3).
   if (device.isVulkan()) {
     device.device().poll(true, nullptr);
   }
@@ -685,11 +687,13 @@ void dispatchInputOutputUniform(GeodeDevice& device, const wgpu::BindGroupLayout
 
   ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
   device.queue().submit(1, &cmdBuf.get());
-  // [lavapipe/Arc filter-sync probe] Force each filter compute pass to fully
-  // complete before the next pass samples its storage-texture output. On
-  // hardware Vulkan (Intel Arc) the automatic cross-submit storage-write ->
+  // [Vulkan filter-sync] Force each filter compute pass to fully complete
+  // before the next pass samples its storage-texture output. On hardware
+  // Vulkan (Intel Arc) the automatic cross-submit storage-write ->
   // sampled-read barrier races the async queue, producing nondeterministic
   // large-area filter corruption. Serialize on Vulkan; Metal is unaffected.
+  // Interim workaround; superseded by the single-encoder filter refactor
+  // (design 0030 M3).
   if (device.isVulkan()) {
     device.device().poll(true, nullptr);
   }
@@ -2172,11 +2176,13 @@ wgpu::Texture GeodeFilterEngine::applyFlood(
 
   ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
   device_.queue().submit(1, &cmdBuf.get());
-  // [lavapipe/Arc filter-sync probe] Force each filter compute pass to fully
-  // complete before the next pass samples its storage-texture output. On
-  // hardware Vulkan (Intel Arc) the automatic cross-submit storage-write ->
+  // [Vulkan filter-sync] Force each filter compute pass to fully complete
+  // before the next pass samples its storage-texture output. On hardware
+  // Vulkan (Intel Arc) the automatic cross-submit storage-write ->
   // sampled-read barrier races the async queue, producing nondeterministic
   // large-area filter corruption. Serialize on Vulkan; Metal is unaffected.
+  // Interim workaround; superseded by the single-encoder filter refactor
+  // (design 0030 M3).
   if (device_.isVulkan()) {
     device_.device().poll(true, nullptr);
   }
@@ -2271,11 +2277,13 @@ wgpu::Texture GeodeFilterEngine::runMergePass(FilterResourceArena& arena, const 
 
   ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
   device_.queue().submit(1, &cmdBuf.get());
-  // [lavapipe/Arc filter-sync probe] Force each filter compute pass to fully
-  // complete before the next pass samples its storage-texture output. On
-  // hardware Vulkan (Intel Arc) the automatic cross-submit storage-write ->
+  // [Vulkan filter-sync] Force each filter compute pass to fully complete
+  // before the next pass samples its storage-texture output. On hardware
+  // Vulkan (Intel Arc) the automatic cross-submit storage-write ->
   // sampled-read barrier races the async queue, producing nondeterministic
   // large-area filter corruption. Serialize on Vulkan; Metal is unaffected.
+  // Interim workaround; superseded by the single-encoder filter refactor
+  // (design 0030 M3).
   if (device_.isVulkan()) {
     device_.device().poll(true, nullptr);
   }
@@ -2488,11 +2496,13 @@ wgpu::Texture GeodeFilterEngine::applyComponentTransfer(
 
   ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
   device_.queue().submit(1, &cmdBuf.get());
-  // [lavapipe/Arc filter-sync probe] Force each filter compute pass to fully
-  // complete before the next pass samples its storage-texture output. On
-  // hardware Vulkan (Intel Arc) the automatic cross-submit storage-write ->
+  // [Vulkan filter-sync] Force each filter compute pass to fully complete
+  // before the next pass samples its storage-texture output. On hardware
+  // Vulkan (Intel Arc) the automatic cross-submit storage-write ->
   // sampled-read barrier races the async queue, producing nondeterministic
   // large-area filter corruption. Serialize on Vulkan; Metal is unaffected.
+  // Interim workaround; superseded by the single-encoder filter refactor
+  // (design 0030 M3).
   if (device_.isVulkan()) {
     device_.device().poll(true, nullptr);
   }
@@ -2612,11 +2622,13 @@ wgpu::Texture GeodeFilterEngine::applyConvolveMatrix(
 
   ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
   device_.queue().submit(1, &cmdBuf.get());
-  // [lavapipe/Arc filter-sync probe] Force each filter compute pass to fully
-  // complete before the next pass samples its storage-texture output. On
-  // hardware Vulkan (Intel Arc) the automatic cross-submit storage-write ->
+  // [Vulkan filter-sync] Force each filter compute pass to fully complete
+  // before the next pass samples its storage-texture output. On hardware
+  // Vulkan (Intel Arc) the automatic cross-submit storage-write ->
   // sampled-read barrier races the async queue, producing nondeterministic
   // large-area filter corruption. Serialize on Vulkan; Metal is unaffected.
+  // Interim workaround; superseded by the single-encoder filter refactor
+  // (design 0030 M3).
   if (device_.isVulkan()) {
     device_.device().poll(true, nullptr);
   }
@@ -2728,11 +2740,13 @@ wgpu::Texture GeodeFilterEngine::applyTurbulence(
 
   ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
   device_.queue().submit(1, &cmdBuf.get());
-  // [lavapipe/Arc filter-sync probe] Force each filter compute pass to fully
-  // complete before the next pass samples its storage-texture output. On
-  // hardware Vulkan (Intel Arc) the automatic cross-submit storage-write ->
+  // [Vulkan filter-sync] Force each filter compute pass to fully complete
+  // before the next pass samples its storage-texture output. On hardware
+  // Vulkan (Intel Arc) the automatic cross-submit storage-write ->
   // sampled-read barrier races the async queue, producing nondeterministic
   // large-area filter corruption. Serialize on Vulkan; Metal is unaffected.
+  // Interim workaround; superseded by the single-encoder filter refactor
+  // (design 0030 M3).
   if (device_.isVulkan()) {
     device_.device().poll(true, nullptr);
   }
@@ -2980,11 +2994,13 @@ wgpu::Texture GeodeFilterEngine::applyDiffuseLighting(
 
   ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
   device_.queue().submit(1, &cmdBuf.get());
-  // [lavapipe/Arc filter-sync probe] Force each filter compute pass to fully
-  // complete before the next pass samples its storage-texture output. On
-  // hardware Vulkan (Intel Arc) the automatic cross-submit storage-write ->
+  // [Vulkan filter-sync] Force each filter compute pass to fully complete
+  // before the next pass samples its storage-texture output. On hardware
+  // Vulkan (Intel Arc) the automatic cross-submit storage-write ->
   // sampled-read barrier races the async queue, producing nondeterministic
   // large-area filter corruption. Serialize on Vulkan; Metal is unaffected.
+  // Interim workaround; superseded by the single-encoder filter refactor
+  // (design 0030 M3).
   if (device_.isVulkan()) {
     device_.device().poll(true, nullptr);
   }
@@ -3107,11 +3123,13 @@ wgpu::Texture GeodeFilterEngine::applySpecularLighting(
 
   ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
   device_.queue().submit(1, &cmdBuf.get());
-  // [lavapipe/Arc filter-sync probe] Force each filter compute pass to fully
-  // complete before the next pass samples its storage-texture output. On
-  // hardware Vulkan (Intel Arc) the automatic cross-submit storage-write ->
+  // [Vulkan filter-sync] Force each filter compute pass to fully complete
+  // before the next pass samples its storage-texture output. On hardware
+  // Vulkan (Intel Arc) the automatic cross-submit storage-write ->
   // sampled-read barrier races the async queue, producing nondeterministic
   // large-area filter corruption. Serialize on Vulkan; Metal is unaffected.
+  // Interim workaround; superseded by the single-encoder filter refactor
+  // (design 0030 M3).
   if (device_.isVulkan()) {
     device_.device().poll(true, nullptr);
   }

--- a/donner/svg/renderer/geode/GeodeFilterEngine.cc
+++ b/donner/svg/renderer/geode/GeodeFilterEngine.cc
@@ -627,6 +627,14 @@ void dispatchTwoInputUniform(GeodeDevice& device, const wgpu::BindGroupLayout& b
 
   ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
   device.queue().submit(1, &cmdBuf.get());
+  // [lavapipe/Arc filter-sync probe] Force each filter compute pass to fully
+  // complete before the next pass samples its storage-texture output. On
+  // hardware Vulkan (Intel Arc) the automatic cross-submit storage-write ->
+  // sampled-read barrier races the async queue, producing nondeterministic
+  // large-area filter corruption. Serialize on Vulkan; Metal is unaffected.
+  if (device.isVulkan()) {
+    device.device().poll(true, nullptr);
+  }
 }
 
 /// Dispatch a compute shader with a standard (input, output, uniform) bind group.
@@ -677,6 +685,14 @@ void dispatchInputOutputUniform(GeodeDevice& device, const wgpu::BindGroupLayout
 
   ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
   device.queue().submit(1, &cmdBuf.get());
+  // [lavapipe/Arc filter-sync probe] Force each filter compute pass to fully
+  // complete before the next pass samples its storage-texture output. On
+  // hardware Vulkan (Intel Arc) the automatic cross-submit storage-write ->
+  // sampled-read barrier races the async queue, producing nondeterministic
+  // large-area filter corruption. Serialize on Vulkan; Metal is unaffected.
+  if (device.isVulkan()) {
+    device.device().poll(true, nullptr);
+  }
 }
 
 /// Create a uniform buffer and upload data to it.
@@ -2156,6 +2172,14 @@ wgpu::Texture GeodeFilterEngine::applyFlood(
 
   ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
   device_.queue().submit(1, &cmdBuf.get());
+  // [lavapipe/Arc filter-sync probe] Force each filter compute pass to fully
+  // complete before the next pass samples its storage-texture output. On
+  // hardware Vulkan (Intel Arc) the automatic cross-submit storage-write ->
+  // sampled-read barrier races the async queue, producing nondeterministic
+  // large-area filter corruption. Serialize on Vulkan; Metal is unaffected.
+  if (device_.isVulkan()) {
+    device_.device().poll(true, nullptr);
+  }
 
   return output;
 }
@@ -2247,6 +2271,14 @@ wgpu::Texture GeodeFilterEngine::runMergePass(FilterResourceArena& arena, const 
 
   ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
   device_.queue().submit(1, &cmdBuf.get());
+  // [lavapipe/Arc filter-sync probe] Force each filter compute pass to fully
+  // complete before the next pass samples its storage-texture output. On
+  // hardware Vulkan (Intel Arc) the automatic cross-submit storage-write ->
+  // sampled-read barrier races the async queue, producing nondeterministic
+  // large-area filter corruption. Serialize on Vulkan; Metal is unaffected.
+  if (device_.isVulkan()) {
+    device_.device().poll(true, nullptr);
+  }
 
   return output;
 }
@@ -2456,6 +2488,14 @@ wgpu::Texture GeodeFilterEngine::applyComponentTransfer(
 
   ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
   device_.queue().submit(1, &cmdBuf.get());
+  // [lavapipe/Arc filter-sync probe] Force each filter compute pass to fully
+  // complete before the next pass samples its storage-texture output. On
+  // hardware Vulkan (Intel Arc) the automatic cross-submit storage-write ->
+  // sampled-read barrier races the async queue, producing nondeterministic
+  // large-area filter corruption. Serialize on Vulkan; Metal is unaffected.
+  if (device_.isVulkan()) {
+    device_.device().poll(true, nullptr);
+  }
   return output;
 }
 
@@ -2572,6 +2612,14 @@ wgpu::Texture GeodeFilterEngine::applyConvolveMatrix(
 
   ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
   device_.queue().submit(1, &cmdBuf.get());
+  // [lavapipe/Arc filter-sync probe] Force each filter compute pass to fully
+  // complete before the next pass samples its storage-texture output. On
+  // hardware Vulkan (Intel Arc) the automatic cross-submit storage-write ->
+  // sampled-read barrier races the async queue, producing nondeterministic
+  // large-area filter corruption. Serialize on Vulkan; Metal is unaffected.
+  if (device_.isVulkan()) {
+    device_.device().poll(true, nullptr);
+  }
   return output;
 }
 
@@ -2680,6 +2728,14 @@ wgpu::Texture GeodeFilterEngine::applyTurbulence(
 
   ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
   device_.queue().submit(1, &cmdBuf.get());
+  // [lavapipe/Arc filter-sync probe] Force each filter compute pass to fully
+  // complete before the next pass samples its storage-texture output. On
+  // hardware Vulkan (Intel Arc) the automatic cross-submit storage-write ->
+  // sampled-read barrier races the async queue, producing nondeterministic
+  // large-area filter corruption. Serialize on Vulkan; Metal is unaffected.
+  if (device_.isVulkan()) {
+    device_.device().poll(true, nullptr);
+  }
   return output;
 }
 
@@ -2924,6 +2980,14 @@ wgpu::Texture GeodeFilterEngine::applyDiffuseLighting(
 
   ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
   device_.queue().submit(1, &cmdBuf.get());
+  // [lavapipe/Arc filter-sync probe] Force each filter compute pass to fully
+  // complete before the next pass samples its storage-texture output. On
+  // hardware Vulkan (Intel Arc) the automatic cross-submit storage-write ->
+  // sampled-read barrier races the async queue, producing nondeterministic
+  // large-area filter corruption. Serialize on Vulkan; Metal is unaffected.
+  if (device_.isVulkan()) {
+    device_.device().poll(true, nullptr);
+  }
   if (linearRGB) {
     output = applyColorSpaceConversion(arena, output, /*srgbToLinear=*/false);
   }
@@ -3043,6 +3107,14 @@ wgpu::Texture GeodeFilterEngine::applySpecularLighting(
 
   ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(encoder.get().finish());
   device_.queue().submit(1, &cmdBuf.get());
+  // [lavapipe/Arc filter-sync probe] Force each filter compute pass to fully
+  // complete before the next pass samples its storage-texture output. On
+  // hardware Vulkan (Intel Arc) the automatic cross-submit storage-write ->
+  // sampled-read barrier races the async queue, producing nondeterministic
+  // large-area filter corruption. Serialize on Vulkan; Metal is unaffected.
+  if (device_.isVulkan()) {
+    device_.device().poll(true, nullptr);
+  }
   if (linearRGB) {
     output = applyColorSpaceConversion(arena, output, /*srgbToLinear=*/false);
   }


### PR DESCRIPTION
The Geode filter engine runs each filter primitive as its own CommandEncoder + queue.submit(), with no synchronization between passes: storage-texture-write -> sampled-texture-read visibility across those submits rests entirely on wgpu-native's automatic barriers. On an asynchronous hardware Vulkan queue (Intel Arc A380, Mesa ANV) that implicit cross-submit barrier races under CPU load, so a later pass can sample a not-yet-visible intermediate. The result is nondeterministic large-area filter corruption: the same golden alternates between clean and 30k-230k px of garbage run to run (for example feDropShadow/with-offset-clipped.svg: PASS 27 px, FAIL 32190 px, PASS 27 px, FAIL 91401 px across consecutive runs).

## Fix

- Add `GeodeDevice::isVulkan()`, detected from `WGPUAdapterInfo.backendType` in both `CreateHeadless()` and `CreateFromExternal()` (so embedder-supplied native Vulkan devices are covered too).
- Gate a `device.poll(true)` after each of the filter engine's nine per-pass submits, so every pass fully completes before the next samples its output.
- Gate the same poll at the sibling boundary in `RendererGeode::popFilterLayer`: the expanded-filter-region `copyTextureToTexture` is its own submit whose output is sampled by the later frame-encoder submit, the same race class.
- Metal reports `isVulkan() == false` and keeps the fast multi-submit path unchanged.

## Evidence

Paired before/after runs of the resvg filter families (`--runs_per_test`, `--jobs=8`) on an Intel Arc A380 (Mesa ANV, Vulkan, aarch64 Linux):

| Configuration | Corruption failures |
|---|---|
| main, natural load, runs=5 | 172 |
| fix, natural load, runs=5 | 0 |
| main, induced CPU load (~110-155 loadavg), runs=6 | 224 (median diff 44678 px, max 228472 px) |
| fix, induced CPU load, runs=6 | 0 |

Mesa lavapipe (software Vulkan) never reproduced the corruption on main, with or without induced load, so it is unaffected either way; the poll is still gated there for consistency since it shares the Vulkan submission model. On macOS/Metal, `renderer_geode_tests` and `resvg_test_suite_geode` both pass with this change and the goldens are bit-identical (the gate means the poll never fires on Metal).

## Notes

- No deterministic regression test is included: the race is load- and hardware-dependent, and the paired induced-load evidence above is the verification.
- This is an interim workaround; it is superseded by the single-encoder filter refactor planned in design 0030 M3 (thread one command encoder through the whole filter graph and submit once), which fixes the same race via intra-encoder barriers without per-pass serialization.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
