### PR TITLE
Fix text object-bounding-box filter clipping

### DIFF
--- a/donner/svg/renderer/FilterGraphExecutor.cc
+++ b/donner/svg/renderer/FilterGraphExecutor.cc
@@ -750,16 +750,17 @@ void ClipFilterOutputToRegion(tiny_skia::Pixmap& pixmap, const std::optional<Box
   const Box2d pixelRegion = deviceFromFilter.transformBox(*filterRegion);
   const int width = static_cast<int>(pixmap.width());
   const int height = static_cast<int>(pixmap.height());
-  // Clamp the kept-rect origin to the pixmap bounds as well as the far edge. Clamping x0/y0 only at
-  // the low end (max(0, ...)) leaves them able to exceed width/height when the region maps entirely
-  // past the right/bottom edge; the per-row "clear the left border [0, x0)" fill would then write
-  // x0*4 bytes into a width*4-byte row and walk past the buffer (heap-buffer-overflow). Clamping to
-  // [0, width]/[0, height] keeps every fill in bounds; a fully-outside region collapses to an empty
-  // kept rect (x0 == x1 or y0 == y1) so the whole pixmap is cleared.
-  const int x0 = std::clamp(static_cast<int>(std::floor(pixelRegion.topLeft.x)), 0, width);
-  const int y0 = std::clamp(static_cast<int>(std::floor(pixelRegion.topLeft.y)), 0, height);
-  const int x1 = std::clamp(static_cast<int>(std::ceil(pixelRegion.bottomRight.x)), 0, width);
-  const int y1 = std::clamp(static_cast<int>(std::ceil(pixelRegion.bottomRight.y)), 0, height);
+  // A pixel belongs to the filter region when its center lies inside the half-open rectangle.
+  // This is the same rule used by the non-axis-aligned path above. Convert each continuous edge to
+  // the first integer pixel index whose center is on or beyond that edge. Clamp both sides so a
+  // fully offscreen region collapses to an empty kept rectangle without an out-of-bounds clear.
+  const auto firstPixelAtOrBeyond = [](double edge) {
+    return static_cast<int>(std::ceil(edge - 0.5));
+  };
+  const int x0 = std::clamp(firstPixelAtOrBeyond(pixelRegion.topLeft.x), 0, width);
+  const int y0 = std::clamp(firstPixelAtOrBeyond(pixelRegion.topLeft.y), 0, height);
+  const int x1 = std::clamp(firstPixelAtOrBeyond(pixelRegion.bottomRight.x), 0, width);
+  const int y1 = std::clamp(firstPixelAtOrBeyond(pixelRegion.bottomRight.y), 0, height);
 
   auto data = pixmap.data();
   for (int y = 0; y < y0; ++y) {

--- a/donner/svg/renderer/RendererDriver.cc
+++ b/donner/svg/renderer/RendererDriver.cc
@@ -146,6 +146,33 @@ std::optional<Box2d> LocalDrawableBoundsWithStroke(
                box.bottomRight + Vector2d(halfStroke, halfStroke));
 }
 
+/// Return the SVG object bounding box used by objectBoundingBox effects.
+///
+/// ShapeSystem covers path-backed elements and their path-backed descendants, but text geometry
+/// is produced by TextEngine instead of ComputedPathComponent. Falling back to an empty shape box
+/// for text collapses objectBoundingBox filter regions to zero and clips the entire filter output.
+std::optional<Box2d> RenderingObjectBoundingBox(Registry& registry, EntityHandle handle) {
+  if (const auto shapeBounds = components::ShapeSystem().getShapeBounds(handle);
+      shapeBounds.has_value() && !shapeBounds->isEmpty()) {
+    return shapeBounds;
+  }
+
+#ifdef DONNER_TEXT_ENABLED
+  if (handle.all_of<components::TextComponent>()) {
+    if (auto* textEngine = registry.ctx().find<TextEngine>()) {
+      const Box2d textBounds = textEngine->computedObjectBoundingBox(handle);
+      if (!textBounds.isEmpty()) {
+        return textBounds;
+      }
+    }
+  }
+#else
+  (void)registry;
+#endif
+
+  return std::nullopt;
+}
+
 bool IsNonDrawingContainer(const EntityHandle& dataHandle) {
   const auto* type = dataHandle.try_get<components::ElementTypeComponent>();
   if (type == nullptr) {
@@ -740,7 +767,7 @@ std::optional<Box2d> computeFilterRegion(Registry& registry,
 
     // Mixed list with url() references: use the default filter region.
     const std::optional<Box2d> shapeBounds =
-        components::ShapeSystem().getShapeBounds(instance.dataHandle(registry));
+        RenderingObjectBoundingBox(registry, instance.dataHandle(registry));
     if (!shapeBounds) {
       return std::nullopt;
     }
@@ -758,7 +785,7 @@ std::optional<Box2d> computeFilterRegion(Registry& registry,
 
   // Determine the bounds reference for resolving percentages.
   const Box2d shapeBounds =
-      components::ShapeSystem().getShapeBounds(instance.dataHandle(registry)).value_or(Box2d());
+      RenderingObjectBoundingBox(registry, instance.dataHandle(registry)).value_or(Box2d());
 
   if (computed->filterUnits == FilterUnits::ObjectBoundingBox) {
     // In objectBoundingBox mode, x/y/width/height are fractions/percentages of the bbox.
@@ -1544,7 +1571,7 @@ void RendererDriver::prepareFilterGraphs(Registry& registry, std::span<const Ent
       filterGraph->filterRegion = filterRegion;
       if (filterGraph->primitiveUnits == PrimitiveUnits::ObjectBoundingBox) {
         filterGraph->elementBoundingBox =
-            components::ShapeSystem().getShapeBounds(instance->dataHandle(registry));
+            RenderingObjectBoundingBox(registry, instance->dataHandle(registry));
       }
       if (filterViewBox.width() > 0 && filterViewBox.height() > 0) {
         filterGraph->userToPixelScale = Vector2d(renderingSize_.x / filterViewBox.width(),

--- a/donner/svg/renderer/RendererDriver.cc
+++ b/donner/svg/renderer/RendererDriver.cc
@@ -152,25 +152,17 @@ std::optional<Box2d> LocalDrawableBoundsWithStroke(
 /// is produced by TextEngine instead of ComputedPathComponent. Falling back to an empty shape box
 /// for text collapses objectBoundingBox filter regions to zero and clips the entire filter output.
 std::optional<Box2d> RenderingObjectBoundingBox(Registry& registry, EntityHandle handle) {
-  if (const auto shapeBounds = components::ShapeSystem().getShapeBounds(handle);
-      shapeBounds.has_value() && !shapeBounds->isEmpty()) {
-    return shapeBounds;
-  }
-
 #ifdef DONNER_TEXT_ENABLED
   if (handle.all_of<components::TextComponent>()) {
     if (auto* textEngine = registry.ctx().find<TextEngine>()) {
-      const Box2d textBounds = textEngine->computedObjectBoundingBox(handle);
-      if (!textBounds.isEmpty()) {
-        return textBounds;
-      }
+      return textEngine->computedObjectBoundingBox(handle);
     }
   }
 #else
   (void)registry;
 #endif
 
-  return std::nullopt;
+  return components::ShapeSystem().getShapeBounds(handle);
 }
 
 bool IsNonDrawingContainer(const EntityHandle& dataHandle) {

--- a/donner/svg/renderer/tests/FilterGraphExecutor_tests.cc
+++ b/donner/svg/renderer/tests/FilterGraphExecutor_tests.cc
@@ -128,6 +128,29 @@ TEST(FilterGraphExecutorTest, ClipsFilterOutputUsingCapturedFilterTransform) {
   EXPECT_THAT(GetPixel(pixmap, 6, 6), Rgba(0, 0, 0, 0));
 }
 
+TEST(FilterGraphExecutorTest, ClipsFractionalAxisAlignedRegionByPixelCenter) {
+  auto maybePixmap = tiny_skia::Pixmap::fromSize(4, 4);
+  ASSERT_TRUE(maybePixmap.has_value());
+  tiny_skia::Pixmap pixmap = std::move(*maybePixmap);
+
+  for (int y = 0; y < 4; ++y) {
+    for (int x = 0; x < 4; ++x) {
+      SetPixel(pixmap, x, y, Pixel{255, 255, 255, 255});
+    }
+  }
+
+  ClipFilterOutputToRegion(pixmap, Box2d::FromXYWH(0.6, 1.4, 2.0, 2.0), Transform2d());
+
+  for (int y = 0; y < 4; ++y) {
+    for (int x = 0; x < 4; ++x) {
+      const bool pixelCenterInside = x >= 1 && x <= 2 && y >= 1 && y <= 2;
+      EXPECT_THAT(GetPixel(pixmap, x, y),
+                  pixelCenterInside ? Rgba(255, 255, 255, 255) : Rgba(0, 0, 0, 0))
+          << "at " << x << "," << y;
+    }
+  }
+}
+
 TEST(FilterGraphExecutorTest, ClipsCompletelyOffscreenFilterRegion) {
   auto maybePixmap = tiny_skia::Pixmap::fromSize(8, 8);
   ASSERT_TRUE(maybePixmap.has_value());

--- a/donner/svg/renderer/tests/RendererDriver_tests.cc
+++ b/donner/svg/renderer/tests/RendererDriver_tests.cc
@@ -1014,6 +1014,36 @@ TEST_F(RendererDriverTest, DrawEntityRangeUsesResolvedFilterReferenceObjectBound
   EXPECT_THAT(transforms, testing::Contains(TransformNear(baseTransform, 1e-6)));
 }
 
+TEST_F(RendererDriverTest, DrawPreservesDegenerateShapeObjectBoundingBoxForFilterPrimitives) {
+  SVGDocument document = makeDocument(R"svg(
+    <defs>
+      <filter id="offset" x="0" y="0" width="100" height="100"
+              filterUnits="userSpaceOnUse" primitiveUnits="objectBoundingBox">
+        <feOffset dx="0.5" />
+      </filter>
+    </defs>
+    <line x1="10" y1="20" x2="50" y2="20" stroke="red" filter="url(#offset)" />
+  )svg",
+                                      Vector2i(100, 100));
+
+  EXPECT_CALL(renderer, beginFrame(_)).Times(1);
+  EXPECT_CALL(renderer, endFrame()).Times(1);
+  EXPECT_CALL(renderer, setTransform(_)).Times(AtLeast(1));
+  EXPECT_CALL(renderer, setPaint(_)).Times(AtLeast(1));
+  EXPECT_CALL(renderer, drawPath(_, _)).Times(1);
+  EXPECT_CALL(renderer, pushFilterLayer(_, _))
+      .WillOnce(
+          [](const components::FilterGraph& filterGraph, const std::optional<Box2d>& filterRegion) {
+            ASSERT_TRUE(filterRegion.has_value());
+            EXPECT_EQ(*filterRegion, Box2d::FromXYWH(0.0, 0.0, 100.0, 100.0));
+            ASSERT_TRUE(filterGraph.elementBoundingBox.has_value());
+            EXPECT_EQ(*filterGraph.elementBoundingBox, Box2d::FromXYWH(10.0, 20.0, 40.0, 0.0));
+          });
+  EXPECT_CALL(renderer, popFilterLayer()).Times(1);
+
+  driver.draw(document);
+}
+
 #ifdef DONNER_TEXT_ENABLED
 TEST_F(RendererDriverTest, DrawUsesTextObjectBoundingBoxForFilterRegion) {
   SVGDocument document = makeDocument(R"svg(

--- a/donner/svg/renderer/tests/RendererDriver_tests.cc
+++ b/donner/svg/renderer/tests/RendererDriver_tests.cc
@@ -1014,6 +1014,41 @@ TEST_F(RendererDriverTest, DrawEntityRangeUsesResolvedFilterReferenceObjectBound
   EXPECT_THAT(transforms, testing::Contains(TransformNear(baseTransform, 1e-6)));
 }
 
+#ifdef DONNER_TEXT_ENABLED
+TEST_F(RendererDriverTest, DrawUsesTextObjectBoundingBoxForFilterRegion) {
+  SVGDocument document = makeDocument(R"svg(
+    <defs>
+      <filter id="flood" x="0" y="0" width="1" height="1"
+              primitiveUnits="objectBoundingBox">
+        <feFlood flood-color="green" />
+      </filter>
+    </defs>
+    <text x="100" y="100" text-anchor="middle" font-family="Noto Sans" font-size="64"
+          filter="url(#flood)">Text</text>
+  )svg",
+                                      Vector2i(200, 200));
+
+  EXPECT_CALL(renderer, beginFrame(_)).Times(1);
+  EXPECT_CALL(renderer, endFrame()).Times(1);
+  EXPECT_CALL(renderer, setTransform(_)).Times(AtLeast(1));
+  EXPECT_CALL(renderer, setPaint(_)).Times(AtLeast(1));
+  EXPECT_CALL(renderer, drawText(_, _, _)).Times(1);
+  EXPECT_CALL(renderer, pushFilterLayer(_, _))
+      .WillOnce(
+          [](const components::FilterGraph& filterGraph, const std::optional<Box2d>& filterRegion) {
+            ASSERT_TRUE(filterRegion.has_value());
+            EXPECT_FALSE(filterRegion->isEmpty());
+            ASSERT_TRUE(filterGraph.elementBoundingBox.has_value());
+            EXPECT_EQ(*filterRegion, *filterGraph.elementBoundingBox);
+            EXPECT_GT(filterRegion->width(), 100.0);
+            EXPECT_GT(filterRegion->height(), 50.0);
+          });
+  EXPECT_CALL(renderer, popFilterLayer()).Times(1);
+
+  driver.draw(document);
+}
+#endif  // DONNER_TEXT_ENABLED
+
 TEST_F(RendererDriverTest, DrawEntityRangeCopiesUrlFilterNodesIntoCssFilterGraph) {
   SVGDocument document = makeDocument(R"svg(
     <rect x="10" y="20" width="40" height="10" fill="red" />

--- a/donner/svg/renderer/tests/resvg_test_suite.cc
+++ b/donner/svg/renderer/tests/resvg_test_suite.cc
@@ -1387,8 +1387,6 @@ INSTANTIATE_TEST_SUITE_P(
                     {"on-Arabic.svg", Params()
                                           .requireFeature(RendererBackendFeature::TextFull)
                                           .withReason("Arabic text")},
-
-                    {"filter-bbox.svg", Params{}},
                 })),
             ValuesIn(ActiveComparisonModes())),
     TestNameFromFilename);
@@ -1444,8 +1442,6 @@ INSTANTIATE_TEST_SUITE_P(
                     {"zalgo.svg", Params().withMaxPixelsDifferent(300).onlyTextFull().withReason(
                                       "Complex diacritics; vertical-axis AA diff "
                                       "not the focus of the test")},
-
-                    {"filter-bbox.svg", Params{}},
                     {"ligatures-handling-in-mixed-fonts-1.svg",
                      Params::Skip(
                          "Bug: text rendering edge cases (mixed inline content, BiDi-adjacent)")},

--- a/donner/svg/renderer/tests/resvg_test_suite.cc
+++ b/donner/svg/renderer/tests/resvg_test_suite.cc
@@ -1388,7 +1388,7 @@ INSTANTIATE_TEST_SUITE_P(
                                           .requireFeature(RendererBackendFeature::TextFull)
                                           .withReason("Arabic text")},
 
-                    {"filter-bbox.svg", Params::Skip("Bug: letter-spacing edge cases")},
+                    {"filter-bbox.svg", Params{}},
                 })),
             ValuesIn(ActiveComparisonModes())),
     TestNameFromFilename);
@@ -1445,9 +1445,7 @@ INSTANTIATE_TEST_SUITE_P(
                                       "Complex diacritics; vertical-axis AA diff "
                                       "not the focus of the test")},
 
-                    {"filter-bbox.svg",
-                     Params::Skip(
-                         "Bug: text rendering edge cases (mixed inline content, BiDi-adjacent)")},
+                    {"filter-bbox.svg", Params{}},
                     {"ligatures-handling-in-mixed-fonts-1.svg",
                      Params::Skip(
                          "Bug: text rendering edge cases (mixed inline content, BiDi-adjacent)")},


### PR DESCRIPTION
## Problem

Object-bounding-box filters on text were clipped away because filter region resolution queried only path-backed shape geometry. Two resvg text `filter-bbox.svg` cases therefore remained disabled.

## Root cause

Text geometry is produced by `TextEngine`, not `ShapeSystem`. The empty object bounding box collapsed the filter region. After restoring the text bounds, the axis-aligned filter clip also retained pixels whose centers were outside fractional region edges because it rounded outward with `floor` and `ceil`.

## Changes

- Resolve drawable object bounds from `TextEngine` for text entities.
- Use pixel-center inclusion when clipping axis-aligned fractional filter regions.
- Add unit regressions for both behaviors.
- Re-enable the two affected resvg cases with the default zero-tolerance comparison.

## Validation

- `renderer_driver_tests`, including `tiny` and `text_full` variants
- `filter_graph_executor_tests`
- default-text and max resvg suites, all shards
- exact focused resvg `filter-bbox.svg` cases
- CMake generator validation
- `bazel test //...` was attempted repeatedly; the remote cache stopped the matrix on unrelated lost-input errors. One earlier attempt also exposed and led to fixing the now-green `tiny` test configuration guard.

Stacked on #873 because that PR carries the resvg gap packet containing these test entries.
