### PR TITLE
Add SVG2 suite reference runner and adapter protocol

### DIFF
--- a/tools/donner_svg2_suite/BUILD.bazel
+++ b/tools/donner_svg2_suite/BUILD.bazel
@@ -73,3 +73,56 @@ py_test(
         ":spec_seed_data",
     ],
 )
+
+# Milestone 2: reference runner and adapter protocol.
+
+py_binary(
+    name = "runner",
+    srcs = [
+        "adapter_protocol.py",
+        "path_safety.py",
+        "png_image.py",
+        "runner.py",
+    ],
+    main = "runner.py",
+    visibility = ["//visibility:public"],
+)
+
+# Standalone stdlib-only executable adapter used as a test fixture. It depends
+# on nothing else in the suite, mirroring a real external adapter.
+py_binary(
+    name = "reference_adapter",
+    srcs = ["reference_adapter.py"],
+    visibility = ["//visibility:public"],
+)
+
+py_test(
+    name = "runner_tests",
+    srcs = [
+        "adapter_protocol.py",
+        "jsonschema_lite.py",
+        "manifest_validation.py",
+        "path_safety.py",
+        "png_image.py",
+        "runner.py",
+        "runner_tests.py",
+        "suite_test_support.py",
+    ],
+    data = [
+        "reference_adapter.py",
+        ":schemas",
+    ],
+)
+
+py_test(
+    name = "adapter_contract_tests",
+    srcs = [
+        "adapter_contract_tests.py",
+        "adapter_protocol.py",
+        "path_safety.py",
+        "png_image.py",
+        "runner.py",
+        "suite_test_support.py",
+    ],
+    data = ["reference_adapter.py"],
+)

--- a/tools/donner_svg2_suite/adapter_contract_tests.py
+++ b/tools/donner_svg2_suite/adapter_contract_tests.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Adapter-contract tests: request/response protocol and status handling."""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import adapter_protocol
+import runner
+import suite_test_support as support
+
+
+class ParseResponseTest(unittest.TestCase):
+    def test_valid_ok_response(self):
+        response = adapter_protocol.parse_response(
+            '{"status": "ok", "width": 4, "height": 4, "format": "rgba8"}'
+        )
+        self.assertEqual((response.status, response.width, response.height), ("ok", 4, 4))
+
+    def test_unsupported_response(self):
+        response = adapter_protocol.parse_response('{"status": "unsupported"}')
+        self.assertEqual(response.status, "unsupported")
+
+    def test_malformed_json_rejected(self):
+        with self.assertRaises(adapter_protocol.AdapterProtocolError):
+            adapter_protocol.parse_response("{ not json")
+
+    def test_missing_status_rejected(self):
+        with self.assertRaises(adapter_protocol.AdapterProtocolError):
+            adapter_protocol.parse_response('{"width": 4}')
+
+    def test_unknown_status_rejected(self):
+        with self.assertRaises(adapter_protocol.AdapterProtocolError):
+            adapter_protocol.parse_response('{"status": "great"}')
+
+    def test_ok_without_dimensions_rejected(self):
+        with self.assertRaises(adapter_protocol.AdapterProtocolError):
+            adapter_protocol.parse_response('{"status": "ok", "format": "rgba8"}')
+
+    def test_ok_with_wrong_format_rejected(self):
+        with self.assertRaises(adapter_protocol.AdapterProtocolError):
+            adapter_protocol.parse_response('{"status": "ok", "width": 4, "height": 4, "format": "gray8"}')
+
+
+class AdapterStatusThroughRunnerTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.work = self.root / "work"
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def _run_single(self, entry, timeout=30.0, work_dir=None):
+        manifest_path = support.write_manifest(self.root, [entry])
+        return runner.run_manifest(
+            manifest_path,
+            support.adapter_argv(),
+            work_dir=work_dir or self.work,
+            timeout=timeout,
+        )
+
+    def test_unsupported_from_adapter(self):
+        support.make_png(self.root / "tests/base.png")
+        support.make_png(self.root / "tests/base.oracle.png")
+        entry = support.test_entry(
+            test_id="donner-svg2/u",
+            input_rel="tests/base.png",
+            oracle_rel="tests/base.oracle.png",
+            capabilities=["unsupported"],
+        )
+        run = self._run_single(entry)
+        self.assertEqual(run.results[0]["status"], "unsupported")
+        self.assertTrue(run.ok)
+
+    def test_crash_is_adapter_error(self):
+        support.make_png(self.root / "tests/crash.png")
+        support.make_png(self.root / "tests/crash.oracle.png")
+        entry = support.test_entry(
+            test_id="donner-svg2/c", input_rel="tests/crash.png", oracle_rel="tests/crash.oracle.png"
+        )
+        run = self._run_single(entry)
+        self.assertEqual(run.results[0]["status"], "adapter-error")
+        self.assertFalse(run.ok)
+
+    def test_structured_error_is_adapter_error(self):
+        support.make_png(self.root / "tests/reperror.png")
+        support.make_png(self.root / "tests/reperror.oracle.png")
+        entry = support.test_entry(
+            test_id="donner-svg2/e", input_rel="tests/reperror.png", oracle_rel="tests/reperror.oracle.png"
+        )
+        run = self._run_single(entry)
+        self.assertEqual(run.results[0]["status"], "adapter-error")
+
+    def test_malformed_response_is_adapter_error(self):
+        support.make_png(self.root / "tests/malformed.png")
+        support.make_png(self.root / "tests/malformed.oracle.png")
+        entry = support.test_entry(
+            test_id="donner-svg2/mal", input_rel="tests/malformed.png", oracle_rel="tests/malformed.oracle.png"
+        )
+        run = self._run_single(entry)
+        self.assertEqual(run.results[0]["status"], "adapter-error")
+
+    def test_timeout(self):
+        support.make_png(self.root / "tests/hang.png")
+        support.make_png(self.root / "tests/hang.oracle.png")
+        entry = support.test_entry(
+            test_id="donner-svg2/h", input_rel="tests/hang.png", oracle_rel="tests/hang.oracle.png"
+        )
+        run = self._run_single(entry, timeout=0.5)
+        self.assertEqual(run.results[0]["status"], "timeout")
+        self.assertFalse(run.ok)
+
+    def test_wrong_output_dimensions_is_adapter_error(self):
+        # Input is 2x2 but the oracle declares 4x4, so the requested dimensions
+        # do not match what the (echoing) adapter produces.
+        support.make_png(self.root / "tests/dims.png", width=2, height=2)
+        support.make_png(self.root / "tests/dims.oracle.png", width=4, height=4)
+        entry = support.test_entry(
+            test_id="donner-svg2/d",
+            input_rel="tests/dims.png",
+            oracle_rel="tests/dims.oracle.png",
+            width=4,
+            height=4,
+        )
+        run = self._run_single(entry)
+        self.assertEqual(run.results[0]["status"], "adapter-error")
+        self.assertIn("dimensions", run.results[0]["diagnostics"])
+
+    def test_render_output_is_deterministic(self):
+        support.make_png(self.root / "tests/base.png")
+        support.make_png(self.root / "tests/base.oracle.png")
+        entry = support.test_entry(
+            test_id="donner-svg2/det", input_rel="tests/base.png", oracle_rel="tests/base.oracle.png"
+        )
+        sandbox_name = hashlib.sha256(b"donner-svg2/det").hexdigest()[:16]
+
+        work_a = self.root / "work_a"
+        work_b = self.root / "work_b"
+        self._run_single(entry, work_dir=work_a)
+        self._run_single(entry, work_dir=work_b)
+        output_a = (work_a / sandbox_name / "out.png").read_bytes()
+        output_b = (work_b / sandbox_name / "out.png").read_bytes()
+        self.assertEqual(output_a, output_b)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/donner_svg2_suite/adapter_protocol.py
+++ b/tools/donner_svg2_suite/adapter_protocol.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""The SVG2 suite render-adapter request/response contract.
+
+The reference runner invokes an adapter as an executable plus an argument array
+(never a shell string) and exchanges typed JSON documents:
+
+    svg-render-adapter render --request request.json --response response.json
+
+This module defines the request the runner writes, the response an adapter must
+return, and strict parsing that treats a missing, malformed, or out-of-contract
+response as an error rather than a silent pass. Runner-level statuses are held
+separately in :mod:`runner`; the adapter reports only its own outcome
+(``ok`` / ``unsupported`` / ``error``).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+
+
+# Statuses an adapter may report for its own work. The runner maps these to the
+# richer per-test result statuses.
+ADAPTER_STATUSES = frozenset({"ok", "unsupported", "error"})
+
+RENDER_FORMAT = "rgba8"
+
+
+class AdapterProtocolError(Exception):
+    """Raised when an adapter response violates the contract."""
+
+
+@dataclass(frozen=True)
+class RenderRequest:
+    """Everything an adapter needs to render one case inside its sandbox."""
+
+    operation: str
+    test_id: str
+    input: str
+    output: str
+    resource_root: str
+    font_root: str
+    processing_mode: str
+    width: int
+    height: int
+    capabilities: list[str] = field(default_factory=list)
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), indent=2, sort_keys=True)
+
+
+def render_request(
+    *,
+    test_id: str,
+    input_path: str,
+    output_path: str,
+    resource_root: str,
+    font_root: str,
+    processing_mode: str,
+    width: int,
+    height: int,
+    capabilities: list[str],
+) -> RenderRequest:
+    return RenderRequest(
+        operation="render",
+        test_id=test_id,
+        input=input_path,
+        output=output_path,
+        resource_root=resource_root,
+        font_root=font_root,
+        processing_mode=processing_mode,
+        width=width,
+        height=height,
+        capabilities=list(capabilities),
+    )
+
+
+@dataclass(frozen=True)
+class AdapterResponse:
+    status: str
+    width: int | None = None
+    height: int | None = None
+    format: str | None = None
+    diagnostics: str = ""
+    duration_ms: float | None = None
+
+
+def parse_response(text: str) -> AdapterResponse:
+    """Parse and validate an adapter response document.
+
+    Raises :class:`AdapterProtocolError` on malformed JSON, a missing or unknown
+    status, or a render success that omits its declared dimensions/format.
+    """
+
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as error:
+        raise AdapterProtocolError(f"response is not valid JSON: {error}") from error
+    if not isinstance(payload, dict):
+        raise AdapterProtocolError("response must be a JSON object")
+
+    status = payload.get("status")
+    if status not in ADAPTER_STATUSES:
+        raise AdapterProtocolError(f"invalid or missing adapter status: {status!r}")
+
+    response = AdapterResponse(
+        status=status,
+        width=payload.get("width"),
+        height=payload.get("height"),
+        format=payload.get("format"),
+        diagnostics=payload.get("diagnostics", ""),
+        duration_ms=payload.get("duration_ms"),
+    )
+
+    if status == "ok":
+        if not isinstance(response.width, int) or not isinstance(response.height, int):
+            raise AdapterProtocolError("render success must report integer width and height")
+        if response.format != RENDER_FORMAT:
+            raise AdapterProtocolError(f"render success must report format {RENDER_FORMAT!r}")
+
+    return response
+
+
+def write_response(path: str, status: str, **fields: object) -> None:
+    """Helper for adapter implementations to emit a response document."""
+
+    document: dict[str, object] = {"status": status}
+    document.update(fields)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(document, handle, indent=2, sort_keys=True)

--- a/tools/donner_svg2_suite/png_image.py
+++ b/tools/donner_svg2_suite/png_image.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Minimal 8-bit RGBA PNG codec for the reference runner's comparator.
+
+The design requires a render adapter to return an 8-bit RGBA PNG and the runner
+to compare it against the oracle PNG. To keep the pilot runner hermetic and
+dependency-free (matching the repo's stdlib-only tooling), this module encodes
+and decodes non-interlaced, 8-bit, colour-type-6 (RGBA) PNGs using only
+``zlib`` and ``struct``. It is deliberately narrow: anything outside that
+profile raises ``PngError`` rather than guessing.
+
+Donner's production adapter is expected to reuse Donner's own pixel-comparison
+implementation (design 0057, Milestone 2); this codec backs the portable
+process-adapter path and the runner's tests.
+"""
+
+from __future__ import annotations
+
+import struct
+import zlib
+
+
+_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+
+class PngError(ValueError):
+    """Raised for malformed or unsupported PNG data."""
+
+
+def _chunk(tag: bytes, data: bytes) -> bytes:
+    return struct.pack(">I", len(data)) + tag + data + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+
+
+def encode_rgba(width: int, height: int, pixels: bytes) -> bytes:
+    """Encode ``width`` x ``height`` RGBA pixels (row-major) into PNG bytes."""
+
+    if width <= 0 or height <= 0:
+        raise PngError("width and height must be positive")
+    if len(pixels) != width * height * 4:
+        raise PngError("pixel buffer size does not match dimensions")
+
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0)
+    stride = width * 4
+    raw = bytearray()
+    for y in range(height):
+        raw.append(0)  # filter type 0 (None)
+        raw += pixels[y * stride : (y + 1) * stride]
+    idat = zlib.compress(bytes(raw), 9)
+    return _SIGNATURE + _chunk(b"IHDR", ihdr) + _chunk(b"IDAT", idat) + _chunk(b"IEND", b"")
+
+
+def _unfilter(raw: bytes, width: int, height: int) -> bytes:
+    stride = width * 4
+    out = bytearray()
+    previous = bytearray(stride)
+    position = 0
+    for _ in range(height):
+        if position >= len(raw):
+            raise PngError("truncated scanline data")
+        filter_type = raw[position]
+        position += 1
+        line = bytearray(raw[position : position + stride])
+        if len(line) != stride:
+            raise PngError("truncated scanline")
+        position += stride
+        for i in range(stride):
+            left = line[i - 4] if i >= 4 else 0
+            up = previous[i]
+            up_left = previous[i - 4] if i >= 4 else 0
+            if filter_type == 0:
+                value = line[i]
+            elif filter_type == 1:
+                value = line[i] + left
+            elif filter_type == 2:
+                value = line[i] + up
+            elif filter_type == 3:
+                value = line[i] + ((left + up) >> 1)
+            elif filter_type == 4:
+                predictor = left + up - up_left
+                pa = abs(predictor - left)
+                pb = abs(predictor - up)
+                pc = abs(predictor - up_left)
+                if pa <= pb and pa <= pc:
+                    paeth = left
+                elif pb <= pc:
+                    paeth = up
+                else:
+                    paeth = up_left
+                value = line[i] + paeth
+            else:
+                raise PngError(f"unsupported filter type {filter_type}")
+            line[i] = value & 0xFF
+        out += line
+        previous = line
+    return bytes(out)
+
+
+def decode_rgba(data: bytes) -> tuple[int, int, bytes]:
+    """Decode PNG ``data`` into ``(width, height, rgba_pixels)``."""
+
+    if data[:8] != _SIGNATURE:
+        raise PngError("not a PNG file")
+    position = 8
+    width = height = None
+    idat = bytearray()
+    while position + 8 <= len(data):
+        (length,) = struct.unpack(">I", data[position : position + 4])
+        tag = data[position + 4 : position + 8]
+        chunk_data = data[position + 8 : position + 8 + length]
+        position += 12 + length
+        if tag == b"IHDR":
+            width, height, depth, color_type = struct.unpack(">IIBB", chunk_data[:10])
+            if depth != 8 or color_type != 6:
+                raise PngError("only 8-bit RGBA (color type 6) PNGs are supported")
+        elif tag == b"IDAT":
+            idat += chunk_data
+        elif tag == b"IEND":
+            break
+    if width is None or height is None:
+        raise PngError("missing IHDR")
+    raw = zlib.decompress(bytes(idat))
+    pixels = _unfilter(raw, width, height)
+    return width, height, pixels

--- a/tools/donner_svg2_suite/reference_adapter.py
+++ b/tools/donner_svg2_suite/reference_adapter.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""A deterministic reference render adapter for the SVG2 suite runner tests.
+
+This is not a real SVG renderer and, like any conforming adapter, it is a
+self-contained executable that depends only on the standard library and the
+request/response contract, not on the suite's own modules. It "renders" by
+copying its (already-rasterized) PNG input to the output, so a test controls
+pass versus comparison-fail purely by choosing the oracle pixels. Behavioural
+branches are keyed off marker substrings in the input filename so tests can
+force each status path:
+
+- ``unsupported`` (or an ``unsupported`` capability): report an unsupported skip;
+- ``crash``: exit non-zero without a response (drives adapter-error);
+- ``hang``: sleep far past any reasonable timeout (drives timeout);
+- ``malformed``: write a non-JSON response (drives adapter-error);
+- ``reperror``: report a structured adapter error; and
+- otherwise: copy the input PNG to the output and report its dimensions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import struct
+import sys
+import time
+
+
+_PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+
+def _png_dimensions(path: str) -> tuple[int, int]:
+    with open(path, "rb") as handle:
+        header = handle.read(24)
+    if header[:8] != _PNG_SIGNATURE or header[12:16] != b"IHDR":
+        raise ValueError("input is not a PNG")
+    width, height = struct.unpack(">II", header[16:24])
+    return width, height
+
+
+def _write_response(path: str, status: str, **fields: object) -> None:
+    document: dict[str, object] = {"status": status}
+    document.update(fields)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(document, handle, indent=2, sort_keys=True)
+
+
+def _run(request_path: str, response_path: str) -> int:
+    with open(request_path, "r", encoding="utf-8") as handle:
+        request = json.load(handle)
+
+    input_path = request["input"]
+    output_path = request["output"]
+    capabilities = request.get("capabilities", [])
+    marker = os.path.basename(input_path)
+
+    if "unsupported" in capabilities or "unsupported" in marker:
+        _write_response(response_path, "unsupported", diagnostics="declared capability absent")
+        return 0
+    if "crash" in marker:
+        sys.stderr.write("simulated adapter crash\n")
+        return 3
+    if "hang" in marker:
+        time.sleep(60)
+        return 0
+    if "malformed" in marker:
+        with open(response_path, "w", encoding="utf-8") as handle:
+            handle.write("{ this is not valid json")
+        return 0
+    if "reperror" in marker:
+        _write_response(response_path, "error", diagnostics="simulated internal failure")
+        return 0
+
+    try:
+        width, height = _png_dimensions(input_path)
+    except (OSError, ValueError) as error:
+        _write_response(response_path, "error", diagnostics=f"cannot read input: {error}")
+        return 0
+
+    shutil.copyfile(input_path, output_path)
+    _write_response(response_path, "ok", width=width, height=height, format="rgba8")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Reference SVG2 render adapter (test fixture).")
+    parser.add_argument("operation", choices=["render"])
+    parser.add_argument("--request", required=True)
+    parser.add_argument("--response", required=True)
+    args = parser.parse_args(argv)
+    return _run(args.request, args.response)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/donner_svg2_suite/runner.py
+++ b/tools/donner_svg2_suite/runner.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python3
+"""Reference runner for the Donner SVG2 test suite (design 0057, Milestone 2).
+
+The runner reads a corpus manifest and an optional renderer profile, stages each
+case in a per-case sandbox, invokes a render adapter as an executable plus an
+argument array (never a shell string), compares the adapter's PNG output against
+the canonical oracle, and emits one explicit status per test as JSON (result-v1)
+and JUnit.
+
+Policy precedence follows the design: locked spec facts and required
+capabilities, then corpus facts, then the renderer profile, then command-line
+selection. Command-line flags may select tests or tighten a comparison budget
+(strict audit), but may never relax one; an attempt to relax raises
+:class:`ComparisonRelaxationError`.
+
+Statuses are non-overlapping: ``pass``, ``comparison-fail``, ``unsupported``,
+``expected-fail``, ``render-only``, ``adapter-error``, ``timeout``, and
+``infrastructure-error``. Aggregate process exit status is never used to infer
+that individual cases passed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from xml.sax.saxutils import escape, quoteattr
+
+from adapter_protocol import (
+    AdapterProtocolError,
+    RenderRequest,
+    parse_response,
+    render_request,
+)
+from path_safety import UnsafePathError, read_text_capped, resolve_within_root
+import png_image
+
+
+RESULT_SCHEMA = "https://donner.graphics/svg2-suite/result-v1.schema.json"
+
+# Corpus facts define an exact-match budget. A profile may loosen it; the CLI
+# may only tighten it.
+CORPUS_EXACT_BUDGET = {"threshold": 0.0, "max_mismatched_pixels": 0}
+
+# Per-test status -> whether the case ended in an acceptable terminal state.
+# The run fails if any case is not acceptable.
+ACCEPTABLE_STATUSES = frozenset({"pass", "unsupported", "expected-fail", "render-only"})
+
+# Per-test status -> JUnit projection.
+_JUNIT_KIND = {
+    "pass": "success",
+    "render-only": "success",
+    "unsupported": "skipped",
+    "expected-fail": "skipped",
+    "comparison-fail": "failure",
+    "adapter-error": "error",
+    "timeout": "error",
+    "infrastructure-error": "error",
+}
+
+
+class ComparisonRelaxationError(Exception):
+    """Raised when a command-line flag tries to relax a comparison budget."""
+
+
+class AdapterTimeout(Exception):
+    pass
+
+
+class AdapterFailure(Exception):
+    pass
+
+
+@dataclass
+class RunResult:
+    results: list[dict] = field(default_factory=list)
+    ok: bool = True
+
+
+def resolve_comparison(profile_case: dict | None, cli_override: dict | None) -> dict:
+    """Resolve the comparison budget with precedence corpus < profile < CLI.
+
+    The CLI may only tighten (lower) a budget. Any attempt to raise the
+    threshold or the mismatched-pixel allowance is rejected.
+    """
+
+    budget = dict(CORPUS_EXACT_BUDGET)
+    if profile_case and "comparison" in profile_case:
+        budget.update(profile_case["comparison"])
+    if cli_override:
+        for key, value in cli_override.items():
+            if value > budget[key]:
+                raise ComparisonRelaxationError(
+                    f"command line may not relax {key} from {budget[key]} to {value}"
+                )
+            budget[key] = value
+    return budget
+
+
+def compare_png(actual_bytes: bytes, expected_bytes: bytes, budget: dict) -> tuple[bool, dict]:
+    """Compare two RGBA PNGs under ``budget`` and return (passed, metrics)."""
+
+    actual_width, actual_height, actual = png_image.decode_rgba(actual_bytes)
+    expected_width, expected_height, expected = png_image.decode_rgba(expected_bytes)
+    if (actual_width, actual_height) != (expected_width, expected_height):
+        return False, {
+            "reason": "dimension-mismatch",
+            "actual": [actual_width, actual_height],
+            "expected": [expected_width, expected_height],
+        }
+
+    threshold = budget["threshold"]
+    mismatched = 0
+    for i in range(0, len(expected), 4):
+        diff = max(abs(actual[i + k] - expected[i + k]) for k in range(4)) / 255.0
+        if diff > threshold:
+            mismatched += 1
+    passed = mismatched <= budget["max_mismatched_pixels"]
+    return passed, {
+        "mismatched_pixels": mismatched,
+        "max_mismatched_pixels": budget["max_mismatched_pixels"],
+        "threshold": threshold,
+    }
+
+
+def _stage_file(sandbox: Path, relative: str, source: str) -> Path:
+    destination = sandbox / relative
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, destination)
+    return destination
+
+
+def stage_case(corpus_root: Path, test: dict, sandbox: Path) -> tuple[RenderRequest, Path]:
+    """Stage one case into ``sandbox`` and return its render request and oracle.
+
+    Only manifest-declared inputs and resources are copied in, so the adapter
+    cannot reach anything undeclared. Every source path is confined to the
+    corpus root before it is read. The oracle stays in the corpus tree and is
+    read only by the runner, never handed to the adapter.
+    """
+
+    oracle = test["oracle"]
+    if oracle.get("kind") != "png":
+        raise UnsafePathError("pilot runner only executes png oracles")
+
+    sandbox.mkdir(parents=True, exist_ok=True)
+    input_source = resolve_within_root(corpus_root, test["input"])
+    input_destination = _stage_file(sandbox, test["input"], input_source)
+
+    resource_root = sandbox / "resources"
+    font_root = sandbox / "fonts"
+    resource_root.mkdir(exist_ok=True)
+    font_root.mkdir(exist_ok=True)
+    for resource in test.get("resources", []):
+        _stage_file(sandbox, resource, resolve_within_root(corpus_root, resource))
+
+    oracle_source = Path(resolve_within_root(corpus_root, oracle["path"]))
+    output = sandbox / "out.png"
+
+    request = render_request(
+        test_id=test["id"],
+        input_path=str(input_destination),
+        output_path=str(output),
+        resource_root=str(resource_root),
+        font_root=str(font_root),
+        processing_mode="static",
+        width=oracle["width"],
+        height=oracle["height"],
+        capabilities=test["capabilities"],
+    )
+    return request, oracle_source
+
+
+def invoke_adapter(adapter_argv: list[str], request: RenderRequest, sandbox: Path, timeout: float):
+    request_path = sandbox / "request.json"
+    response_path = sandbox / "response.json"
+    request_path.write_text(request.to_json(), encoding="utf-8")
+
+    argv = list(adapter_argv) + ["render", "--request", str(request_path), "--response", str(response_path)]
+    try:
+        completed = subprocess.run(argv, timeout=timeout, capture_output=True, text=True)
+    except subprocess.TimeoutExpired as error:
+        raise AdapterTimeout(f"adapter timed out after {timeout}s") from error
+
+    if completed.returncode != 0:
+        raise AdapterFailure(
+            f"adapter exited with status {completed.returncode}: {completed.stderr.strip()[:200]}"
+        )
+    if not response_path.is_file():
+        raise AdapterFailure("adapter produced no response.json")
+
+    response = parse_response(response_path.read_text(encoding="utf-8"))
+    if response.status == "error":
+        raise AdapterFailure(f"adapter reported error: {response.diagnostics}")
+    return response
+
+
+def run_case(
+    corpus_root: Path,
+    test: dict,
+    profile_case: dict | None,
+    adapter_argv: list[str],
+    work_dir: Path,
+    cli_override: dict | None,
+    timeout: float,
+) -> tuple[dict, bool]:
+    """Run one case and return (result_record, acceptable)."""
+
+    test_id = test["id"]
+    expectation = (profile_case or {}).get("expectation", "pass")
+    result: dict = {"test": test_id, "spec_requirements": test["spec_requirements"]}
+
+    if expectation == "unsupported":
+        result["status"] = "unsupported"
+        result["diagnostics"] = (profile_case or {}).get("reason", "")
+        return result, True
+
+    # Resolve the comparison budget before doing any work so a CLI relaxation
+    # aborts the whole run rather than silently affecting some cases.
+    budget = resolve_comparison(profile_case, cli_override)
+
+    sandbox = work_dir / hashlib.sha256(test_id.encode("utf-8")).hexdigest()[:16]
+    try:
+        request, oracle_source = stage_case(corpus_root, test, sandbox)
+    except UnsafePathError as error:
+        result["status"] = "infrastructure-error"
+        result["diagnostics"] = str(error)
+        return result, False
+
+    started = time.monotonic()
+    try:
+        response = invoke_adapter(adapter_argv, request, sandbox, timeout)
+    except AdapterTimeout as error:
+        result["status"] = "timeout"
+        result["diagnostics"] = str(error)
+        return result, False
+    except (AdapterFailure, AdapterProtocolError) as error:
+        result["status"] = "adapter-error"
+        result["diagnostics"] = str(error)
+        return result, False
+    result["duration_ms"] = (time.monotonic() - started) * 1000.0
+
+    if response.status == "unsupported":
+        result["status"] = "unsupported"
+        result["diagnostics"] = response.diagnostics
+        return result, True
+
+    output_path = Path(request.output)
+    if not output_path.is_file():
+        result["status"] = "adapter-error"
+        result["diagnostics"] = "adapter reported ok but wrote no output image"
+        return result, False
+    actual_bytes = output_path.read_bytes()
+    try:
+        actual_width, actual_height, _ = png_image.decode_rgba(actual_bytes)
+    except png_image.PngError as error:
+        result["status"] = "adapter-error"
+        result["diagnostics"] = f"output is not a valid RGBA PNG: {error}"
+        return result, False
+    if (actual_width, actual_height) != (request.width, request.height):
+        result["status"] = "adapter-error"
+        result["diagnostics"] = (
+            f"output dimensions {actual_width}x{actual_height} do not match "
+            f"requested {request.width}x{request.height}"
+        )
+        return result, False
+
+    if expectation == "render-only":
+        result["status"] = "render-only"
+        return result, True
+
+    passed, metrics = compare_png(actual_bytes, oracle_source.read_bytes(), budget)
+    result["comparison"] = metrics
+
+    if expectation == "expected-fail":
+        if passed:
+            result["status"] = "comparison-fail"
+            result["diagnostics"] = (
+                "expected failure unexpectedly matched the oracle; "
+                "remove or narrow the profile policy"
+            )
+            return result, False
+        result["status"] = "expected-fail"
+        return result, True
+
+    if passed:
+        result["status"] = "pass"
+        return result, True
+    result["status"] = "comparison-fail"
+    return result, False
+
+
+def run_manifest(
+    manifest_path: Path,
+    adapter_argv: list[str],
+    *,
+    profile_path: Path | None = None,
+    work_dir: Path | None = None,
+    cli_override: dict | None = None,
+    timeout: float = 30.0,
+) -> RunResult:
+    corpus_root = manifest_path.resolve().parent
+    manifest = json.loads(read_text_capped(manifest_path))
+
+    cases: dict = {}
+    if profile_path is not None:
+        cases = json.loads(read_text_capped(profile_path)).get("cases", {})
+
+    work_dir = Path(work_dir) if work_dir is not None else Path(tempfile.mkdtemp(prefix="svg2-runner-"))
+    run = RunResult()
+    for test in manifest["tests"]:
+        result, acceptable = run_case(
+            corpus_root, test, cases.get(test["id"]), adapter_argv, work_dir, cli_override, timeout
+        )
+        run.results.append(result)
+        run.ok = run.ok and acceptable
+    return run
+
+
+def _sha256_of_file(path: Path) -> str:
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def result_document(
+    run: RunResult,
+    *,
+    bundle_digest: str,
+    adapter_id: str,
+    profile_name: str,
+    baseline_formal: str,
+    dependency_lock: str,
+    editorial_delta: str | None = None,
+    adapter_capabilities: list[str] | None = None,
+    conformance_classes: list[str] | None = None,
+    processing_modes: list[str] | None = None,
+) -> dict:
+    baseline: dict = {"formal": baseline_formal, "dependency_lock": dependency_lock}
+    if editorial_delta is not None:
+        baseline["editorial_delta"] = editorial_delta
+    document: dict = {
+        "schema": RESULT_SCHEMA,
+        "bundle": {"digest": bundle_digest},
+        "adapter": {"id": adapter_id},
+        "profile": profile_name,
+        "baseline": baseline,
+        "results": run.results,
+    }
+    if adapter_capabilities is not None:
+        document["adapter"]["capabilities"] = adapter_capabilities
+    if conformance_classes is not None:
+        document["conformance_classes"] = conformance_classes
+    if processing_modes is not None:
+        document["processing_modes"] = processing_modes
+    return document
+
+
+def junit_document(run: RunResult, *, suite_name: str = "donner-svg2-suite") -> str:
+    failures = sum(1 for r in run.results if _JUNIT_KIND[r["status"]] == "failure")
+    errors = sum(1 for r in run.results if _JUNIT_KIND[r["status"]] == "error")
+    skipped = sum(1 for r in run.results if _JUNIT_KIND[r["status"]] == "skipped")
+
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        f'<testsuite name={quoteattr(suite_name)} tests="{len(run.results)}" '
+        f'failures="{failures}" errors="{errors}" skipped="{skipped}">',
+    ]
+    for result in run.results:
+        kind = _JUNIT_KIND[result["status"]]
+        name = quoteattr(result["test"])
+        message = quoteattr(f"status={result['status']}")
+        detail = escape(result.get("diagnostics", ""))
+        lines.append(f'  <testcase name={name} classname={quoteattr(suite_name)}>')
+        if kind == "skipped":
+            lines.append(f"    <skipped message={message}/>")
+        elif kind == "failure":
+            lines.append(f"    <failure message={message}>{detail}</failure>")
+        elif kind == "error":
+            lines.append(f"    <error message={message}>{detail}</error>")
+        lines.append("  </testcase>")
+    lines.append("</testsuite>")
+    return "\n".join(lines) + "\n"
+
+
+def _parse_cli_override(args: argparse.Namespace) -> dict | None:
+    override: dict = {}
+    if args.strict_audit:
+        override.update(CORPUS_EXACT_BUDGET)
+    if args.threshold is not None:
+        override["threshold"] = args.threshold
+    if args.max_mismatched_pixels is not None:
+        override["max_mismatched_pixels"] = args.max_mismatched_pixels
+    return override or None
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run an SVG2 suite corpus through a render adapter.")
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument(
+        "--adapter",
+        required=True,
+        nargs="+",
+        help="Adapter executable and its fixed leading arguments (argument array, never a shell string).",
+    )
+    parser.add_argument("--adapter-id", default=None)
+    parser.add_argument("--profile", type=Path, default=None)
+    parser.add_argument("--baseline-lock", type=Path, default=None)
+    parser.add_argument("--out-json", type=Path, default=None)
+    parser.add_argument("--out-junit", type=Path, default=None)
+    parser.add_argument("--threshold", type=float, default=None)
+    parser.add_argument("--max-mismatched-pixels", type=int, default=None)
+    parser.add_argument("--strict-audit", action="store_true")
+    parser.add_argument("--timeout", type=float, default=30.0)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        run = run_manifest(
+            args.manifest,
+            args.adapter,
+            profile_path=args.profile,
+            cli_override=_parse_cli_override(args),
+            timeout=args.timeout,
+        )
+    except ComparisonRelaxationError as error:
+        print(f"runner refused to relax a comparison budget: {error}", file=sys.stderr)
+        return 2
+
+    baseline_formal = "unknown"
+    dependency_lock = "sha256:" + "0" * 64
+    editorial_delta = None
+    if args.baseline_lock is not None:
+        lock = json.loads(args.baseline_lock.read_text(encoding="utf-8"))
+        publication = lock["formal_baseline"]["publication_date"].replace("-", "")
+        baseline_formal = f"svg2-cr-{publication}"
+        dependency_lock = _sha256_of_file(args.baseline_lock)
+        editorial_delta = lock["editorial_delta_baseline"]["revision"]
+
+    document = result_document(
+        run,
+        bundle_digest=_sha256_of_file(args.manifest),
+        adapter_id=args.adapter_id or Path(args.adapter[-1]).name,
+        profile_name=args.profile.stem if args.profile else "none",
+        baseline_formal=baseline_formal,
+        dependency_lock=dependency_lock,
+        editorial_delta=editorial_delta,
+        conformance_classes=["interpreter", "viewer"],
+        processing_modes=["static", "secure-static"],
+    )
+
+    if args.out_json is not None:
+        args.out_json.write_text(json.dumps(document, indent=2, sort_keys=True), encoding="utf-8")
+    if args.out_junit is not None:
+        args.out_junit.write_text(junit_document(run), encoding="utf-8")
+    if args.out_json is None and args.out_junit is None:
+        print(json.dumps(document, indent=2, sort_keys=True))
+
+    for result in run.results:
+        print(f"{result['status']:20} {result['test']}", file=sys.stderr)
+    return 0 if run.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/donner_svg2_suite/runner_tests.py
+++ b/tools/donner_svg2_suite/runner_tests.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Tests for the SVG2 suite reference runner."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from xml.dom import minidom
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import jsonschema_lite
+import manifest_validation
+import runner
+import suite_test_support as support
+
+
+class RunnerScenarioTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.work = self.root / "work"
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def _run(self, tests, cases=None, cli_override=None, timeout=30.0):
+        manifest_path = support.write_manifest(self.root, tests)
+        profile_path = support.write_profile(self.root, cases) if cases is not None else None
+        return runner.run_manifest(
+            manifest_path,
+            support.adapter_argv(),
+            profile_path=profile_path,
+            work_dir=self.work,
+            cli_override=cli_override,
+            timeout=timeout,
+        )
+
+    def _statuses(self, run):
+        return {result["test"]: result["status"] for result in run.results}
+
+    def test_pass_when_output_matches_oracle(self):
+        support.make_png(self.root / "tests/a.png")
+        support.make_png(self.root / "tests/a.oracle.png")
+        entry = support.test_entry(
+            test_id="donner-svg2/a", input_rel="tests/a.png", oracle_rel="tests/a.oracle.png"
+        )
+        run = self._run([entry])
+        self.assertEqual(self._statuses(run), {"donner-svg2/a": "pass"})
+        self.assertTrue(run.ok)
+
+    def test_comparison_fail_marks_run_not_ok(self):
+        support.make_png(self.root / "tests/m.png")
+        support.make_png(self.root / "tests/m.oracle.png", pixel=support.OTHER_PIXEL)
+        entry = support.test_entry(
+            test_id="donner-svg2/m", input_rel="tests/m.png", oracle_rel="tests/m.oracle.png"
+        )
+        run = self._run([entry])
+        self.assertEqual(self._statuses(run), {"donner-svg2/m": "comparison-fail"})
+        self.assertFalse(run.ok)
+
+    def test_unsupported_profile_skips_before_render(self):
+        # No input/oracle files exist; unsupported must skip before any file access.
+        entry = support.test_entry(
+            test_id="donner-svg2/u", input_rel="tests/missing.png", oracle_rel="tests/missing.oracle.png"
+        )
+        cases = {"donner-svg2/u": {"expectation": "unsupported", "reason_category": "capability", "reason": "no bidi"}}
+        run = self._run([entry], cases=cases)
+        self.assertEqual(self._statuses(run), {"donner-svg2/u": "unsupported"})
+        self.assertTrue(run.ok)
+
+    def test_expected_fail_that_fails_is_healthy(self):
+        support.make_png(self.root / "tests/ef.png")
+        support.make_png(self.root / "tests/ef.oracle.png", pixel=support.OTHER_PIXEL)
+        entry = support.test_entry(
+            test_id="donner-svg2/ef", input_rel="tests/ef.png", oracle_rel="tests/ef.oracle.png"
+        )
+        cases = {"donner-svg2/ef": {"expectation": "expected-fail", "reason_category": "gap", "reason": "known"}}
+        run = self._run([entry], cases=cases)
+        self.assertEqual(self._statuses(run), {"donner-svg2/ef": "expected-fail"})
+        self.assertTrue(run.ok)
+
+    def test_expected_fail_that_passes_fails_the_audit(self):
+        support.make_png(self.root / "tests/a.png")
+        support.make_png(self.root / "tests/a.oracle.png")
+        entry = support.test_entry(
+            test_id="donner-svg2/ef", input_rel="tests/a.png", oracle_rel="tests/a.oracle.png"
+        )
+        cases = {"donner-svg2/ef": {"expectation": "expected-fail", "reason_category": "gap", "reason": "known"}}
+        run = self._run([entry], cases=cases)
+        self.assertEqual(self._statuses(run), {"donner-svg2/ef": "comparison-fail"})
+        self.assertFalse(run.ok)
+        self.assertIn("unexpectedly", run.results[0]["diagnostics"])
+
+    def test_render_only_ignores_oracle_mismatch(self):
+        support.make_png(self.root / "tests/ro.png")
+        support.make_png(self.root / "tests/ro.oracle.png", pixel=support.OTHER_PIXEL)
+        entry = support.test_entry(
+            test_id="donner-svg2/ro", input_rel="tests/ro.png", oracle_rel="tests/ro.oracle.png"
+        )
+        cases = {"donner-svg2/ro": {"expectation": "render-only"}}
+        run = self._run([entry], cases=cases)
+        self.assertEqual(self._statuses(run), {"donner-svg2/ro": "render-only"})
+        self.assertTrue(run.ok)
+
+    def test_pass_fail_skip_are_separated(self):
+        support.make_png(self.root / "tests/p.png")
+        support.make_png(self.root / "tests/p.oracle.png")
+        support.make_png(self.root / "tests/f.png")
+        support.make_png(self.root / "tests/f.oracle.png", pixel=support.OTHER_PIXEL)
+        tests = [
+            support.test_entry(test_id="donner-svg2/p", input_rel="tests/p.png", oracle_rel="tests/p.oracle.png"),
+            support.test_entry(test_id="donner-svg2/f", input_rel="tests/f.png", oracle_rel="tests/f.oracle.png"),
+            support.test_entry(test_id="donner-svg2/s", input_rel="tests/x.png", oracle_rel="tests/x.oracle.png"),
+        ]
+        cases = {"donner-svg2/s": {"expectation": "unsupported", "reason_category": "cap", "reason": "n/a"}}
+        run = self._run(tests, cases=cases)
+        self.assertEqual(
+            self._statuses(run),
+            {"donner-svg2/p": "pass", "donner-svg2/f": "comparison-fail", "donner-svg2/s": "unsupported"},
+        )
+        self.assertFalse(run.ok)
+
+    def test_cli_may_not_relax_comparison_budget(self):
+        support.make_png(self.root / "tests/a.png")
+        support.make_png(self.root / "tests/a.oracle.png")
+        entry = support.test_entry(
+            test_id="donner-svg2/a", input_rel="tests/a.png", oracle_rel="tests/a.oracle.png"
+        )
+        with self.assertRaises(runner.ComparisonRelaxationError):
+            self._run([entry], cli_override={"threshold": 0.5, "max_mismatched_pixels": 0})
+
+    def test_resolve_comparison_precedence(self):
+        # Corpus default is exact; profile may loosen; CLI may only tighten.
+        self.assertEqual(
+            runner.resolve_comparison(None, None), {"threshold": 0.0, "max_mismatched_pixels": 0}
+        )
+        loosened = runner.resolve_comparison(
+            {"comparison": {"threshold": 0.02, "max_mismatched_pixels": 100}}, None
+        )
+        self.assertEqual(loosened, {"threshold": 0.02, "max_mismatched_pixels": 100})
+        tightened = runner.resolve_comparison(
+            {"comparison": {"threshold": 0.02, "max_mismatched_pixels": 100}},
+            {"threshold": 0.0, "max_mismatched_pixels": 0},
+        )
+        self.assertEqual(tightened, {"threshold": 0.0, "max_mismatched_pixels": 0})
+        with self.assertRaises(runner.ComparisonRelaxationError):
+            runner.resolve_comparison({"comparison": {"threshold": 0.0}}, {"threshold": 0.1})
+
+    def test_json_output_conforms_to_result_schema(self):
+        support.make_png(self.root / "tests/a.png")
+        support.make_png(self.root / "tests/a.oracle.png")
+        entry = support.test_entry(
+            test_id="donner-svg2/a", input_rel="tests/a.png", oracle_rel="tests/a.oracle.png"
+        )
+        run = self._run([entry])
+        document = runner.result_document(
+            run,
+            bundle_digest="sha256:" + "a" * 64,
+            adapter_id="reference",
+            profile_name="none",
+            baseline_formal="svg2-cr-20181004",
+            dependency_lock="sha256:" + "b" * 64,
+            conformance_classes=["interpreter"],
+            processing_modes=["static"],
+        )
+        schema = manifest_validation.load_schema("result-v1.schema.json")
+        self.assertEqual(jsonschema_lite.validate(document, schema), [])
+
+    def test_junit_output_is_wellformed(self):
+        support.make_png(self.root / "tests/a.png")
+        support.make_png(self.root / "tests/a.oracle.png")
+        entry = support.test_entry(
+            test_id="donner-svg2/a", input_rel="tests/a.png", oracle_rel="tests/a.oracle.png"
+        )
+        run = self._run([entry])
+        parsed = minidom.parseString(runner.junit_document(run))
+        self.assertEqual(len(parsed.getElementsByTagName("testcase")), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/donner_svg2_suite/suite_test_support.py
+++ b/tools/donner_svg2_suite/suite_test_support.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Shared fixtures for the runner and adapter-contract tests."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import png_image
+
+
+SOLID_PIXEL = bytes((10, 20, 30, 255))
+OTHER_PIXEL = bytes((200, 100, 50, 255))
+
+
+def adapter_argv() -> list[str]:
+    """The reference adapter as an executable-plus-argument array.
+
+    The adapter is a standalone script invoked as a separate process, mirroring
+    how a real adapter is an independent executable.
+    """
+
+    adapter = Path(__file__).resolve().with_name("reference_adapter.py")
+    return [sys.executable, str(adapter)]
+
+
+def make_png(path: Path, width: int = 2, height: int = 2, pixel: bytes = SOLID_PIXEL) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(png_image.encode_rgba(width, height, pixel * width * height))
+
+
+def test_entry(
+    *,
+    test_id: str,
+    input_rel: str,
+    oracle_rel: str,
+    width: int = 2,
+    height: int = 2,
+    capabilities: list[str] | None = None,
+    resources: list[str] | None = None,
+) -> dict:
+    entry = {
+        "id": test_id,
+        "input": input_rel,
+        "oracle": {
+            "kind": "png",
+            "path": oracle_rel,
+            "width": width,
+            "height": height,
+            "provenance": "test-fixture",
+        },
+        "assertion": "fixture assertion",
+        "spec_requirements": ["svg2-cr-20181004/painting/paint-order/req-03"],
+        "capabilities": capabilities or ["paint-order"],
+    }
+    if resources is not None:
+        entry["resources"] = resources
+    return entry
+
+
+def write_manifest(root: Path, tests: list[dict]) -> Path:
+    manifest = {
+        "schema": "https://donner.graphics/svg2-suite/corpus-v1.schema.json",
+        "corpus": "donner-svg2",
+        "revision": "0" * 40,
+        "tests": tests,
+    }
+    path = root / "manifest.json"
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+    return path
+
+
+def write_profile(root: Path, cases: dict, name: str = "test-profile") -> Path:
+    profile = {
+        "schema": "https://donner.graphics/svg2-suite/profile-v1.schema.json",
+        "profile": name,
+        "cases": cases,
+    }
+    path = root / "profile.json"
+    path.write_text(json.dumps(profile), encoding="utf-8")
+    return path


### PR DESCRIPTION
This lands Milestone 2 of the portable Donner SVG2 test suite from design 0057: the reference runner and the structured render-adapter contract. It is stacked on #876 (the schemas and manifest validation) and targets that branch; retarget to main once #876 merges. It changes nothing about the existing resvg gate.

Implementing design 0057 sections "Adapter protocol", "Composition and precedence", and "Security and Privacy":

- adapter_protocol.py defines the request the runner writes and the response an adapter returns. The runner invokes an adapter as an executable plus an argument array, never a shell string, and exchanges typed JSON. A missing, malformed, or out-of-contract response is an error, never a silent pass.
- runner.py stages each case in a per-case sandbox containing only manifest-declared inputs and resources, each confined to the corpus root before it is read; the oracle is read by the runner and never handed to the adapter. It compares the adapter's PNG output against the canonical oracle and emits one explicit status per test.
- Policy precedence is spec, then corpus facts, then the renderer profile, then command-line selection. The command line may tighten a comparison budget (strict audit) but never relax one; an attempt raises rather than silently loosening.
- png_image.py is a dependency-free 8-bit RGBA PNG codec backing the comparator, matching the repo's stdlib-only tooling.
- reference_adapter.py is a standalone, stdlib-only fixture adapter used by the tests to drive every status path.

Statuses are non-overlapping (pass, comparison-fail, unsupported, expected-fail, render-only, adapter-error, timeout, infrastructure-error) and the runner never infers per-case success from the adapter process exit code. An expected-fail case that unexpectedly matches the oracle is reported as a failure and fails the run, which is the design's stale-policy signal.

Scope notes: the comparator iterates pixels in Python, which is fine for the pilot's small images; Donner's production adapter is expected to reuse Donner's own pixel comparison per the design. The runner consumes already-validated manifests (validation is the separate manifest_validation step) but still confines every staged path defensively.

Validation:

- bazel test //tools/donner_svg2_suite:all (runner_tests and adapter_contract_tests cover profile precedence, expected-fail semantics, pass/fail/skip separation, malformed-response handling, timeout, and CLI budget relaxation refusal; the Milestone 0/1 tests also pass)
- an end-to-end runner CLI run over a small corpus: the emitted result JSON validates against result-v1 and the JUnit output is well-formed
