### PR TITLE
Generate the resvg base corpus manifest (design 0057, Milestone 3)

### DIFF
--- a/tools/donner_svg2_suite/BUILD.bazel
+++ b/tools/donner_svg2_suite/BUILD.bazel
@@ -126,3 +126,30 @@ py_test(
     ],
     data = ["reference_adapter.py"],
 )
+
+# Milestone 3: package the resvg base layer. Generates a corpus-v1 manifest
+# from the pinned, unmodified upstream tree at //third_party/resvg-test-suite.
+
+py_binary(
+    name = "resvg_base_manifest",
+    srcs = ["resvg_base_manifest.py"],
+    main = "resvg_base_manifest.py",
+    visibility = ["//visibility:public"],
+)
+
+py_test(
+    name = "resvg_base_manifest_tests",
+    srcs = [
+        "jsonschema_lite.py",
+        "manifest_validation.py",
+        "path_safety.py",
+        "resvg_base_manifest.py",
+        "resvg_base_manifest_tests.py",
+    ],
+    data = [
+        ":schemas",
+        "//third_party/resvg-test-suite:LICENSE",
+        "//third_party/resvg-test-suite:tests",
+    ],
+    deps = ["@rules_python//python/runfiles"],
+)

--- a/tools/donner_svg2_suite/manifest_validation.py
+++ b/tools/donner_svg2_suite/manifest_validation.py
@@ -141,15 +141,24 @@ def validate_manifest(
     manifest_path: Path,
     schema_dir: Path | None = None,
     known_requirements: set[str] | None = None,
+    corpus_root: Path | None = None,
 ) -> list[str]:
     """Validate the manifest at ``manifest_path`` and return error strings.
 
     An empty list means the manifest is valid. Structural errors are reported on
     their own; when the shape is broken, the deeper filesystem checks are
     skipped because they assume a well-formed manifest.
+
+    By default, referenced paths (``tests/...``, ``resources/...``, ...) are
+    resolved relative to the manifest file's own parent directory. Passing an
+    explicit ``corpus_root`` overrides that and resolves referenced paths
+    against a different directory instead. This lets a manifest that was
+    generated into its own location (for example a temporary file produced by
+    a generator tool) be validated against the actual corpus tree it
+    describes, without copying or symlinking that tree next to the manifest.
     """
 
-    corpus_root = manifest_path.resolve().parent
+    resolved_root = Path(corpus_root) if corpus_root is not None else manifest_path.resolve().parent
     try:
         raw = read_text_capped(manifest_path)
     except (OSError, UnsafePathError) as error:
@@ -174,14 +183,14 @@ def validate_manifest(
             errors.append(f"duplicate test id: {test_id!r}")
         seen_ids.add(test_id)
 
-        _check_referenced_path(corpus_root, test["input"], INPUT_ROOTS, "input", errors)
+        _check_referenced_path(resolved_root, test["input"], INPUT_ROOTS, "input", errors)
 
         oracle = test["oracle"]
         if oracle.get("kind") == "png":
-            _check_referenced_path(corpus_root, oracle["path"], INPUT_ROOTS, "oracle", errors)
+            _check_referenced_path(resolved_root, oracle["path"], INPUT_ROOTS, "oracle", errors)
 
         for resource in test.get("resources", []):
-            _check_referenced_path(corpus_root, resource, RESOURCE_ROOTS, "resource", errors)
+            _check_referenced_path(resolved_root, resource, RESOURCE_ROOTS, "resource", errors)
 
         if known_requirements is not None:
             for requirement in test["spec_requirements"]:
@@ -192,7 +201,7 @@ def validate_manifest(
 
     integrity = manifest.get("integrity")
     if isinstance(integrity, dict):
-        _check_integrity(corpus_root, integrity, errors)
+        _check_integrity(resolved_root, integrity, errors)
 
     return errors
 

--- a/tools/donner_svg2_suite/resvg_base_manifest.py
+++ b/tools/donner_svg2_suite/resvg_base_manifest.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Generate a corpus-v1 manifest for the vendored resvg-test-suite base layer.
+
+Design 0057 (Milestone 3, "Package the resvg base layer") requires the resvg
+base corpus to be described by a *generated* manifest rather than a hand
+maintained one: the manifest is a derived fact about the pinned upstream tree,
+not new source truth. This tool walks the vendored tree under
+``third_party/resvg-test-suite`` (see that directory's ``BUILD.bazel`` for the
+pinned commit and MIT license) and emits:
+
+- a corpus-v1 manifest (``manifest.json``) with one test entry per
+  ``tests/<category>/<feature>/<name>.svg`` that has a sibling
+  ``<name>.png``, plus a sha256 integrity map over every referenced file; and
+- optional bundle metadata (``bundle.json``) recording the upstream source
+  repository, pinned revision, license, and manifest digest, per the design's
+  "Versioning and Distribution" section.
+
+Every imported case gets an empty ``spec_requirements`` list: base import is
+unmapped until the requirement audit and oracle-review campaign (design 0057,
+"Oracle governance": imported corpus membership is not sufficient
+provenance). Upstream bytes are only read here, never modified, moved, or
+copied.
+
+Generation is deterministic: tests are sorted by id, the integrity map is
+sorted by path (``json.dumps(..., sort_keys=True)`` handles this), and the
+manifest is serialized with sorted keys and fixed indentation, so running this
+tool twice against an unchanged tree produces byte-identical output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import struct
+import sys
+from pathlib import Path
+from typing import Any
+
+CORPUS_NAME = "resvg"
+CORPUS_SCHEMA_URL = "https://donner.graphics/svg2-suite/corpus-v1.schema.json"
+DEFAULT_RESVG_ROOT = Path("third_party/resvg-test-suite")
+
+# Pinned upstream commit documented in third_party/resvg-test-suite/BUILD.bazel.
+# detect_revision() parses that file for the authoritative value; this is only
+# the fallback used if the header cannot be found or parsed.
+DEFAULT_REVISION = "d8e064337faf01bc5a9579187a56dbdbe3eacc72"
+UPSTREAM_REPOSITORY = "https://github.com/linebender/resvg-test-suite"
+UPSTREAM_LICENSE_ID = "MIT"
+UPSTREAM_LICENSE_FILE = "LICENSE"
+
+_REVISION_RE = re.compile(r"\bcommit\s+([0-9a-f]{40})\b")
+_PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+# Top-level tests/ category -> derived capability tokens. Anything not listed
+# here gets no capability tokens; this is a minimal, honest derivation, not a
+# full capability taxonomy.
+_CATEGORY_CAPABILITIES = {
+    "filters": ["filter-effects"],
+    "text": ["text"],
+}
+
+
+class ManifestGenerationError(ValueError):
+    """Raised when the vendored tree cannot be walked into a valid manifest."""
+
+
+def read_png_dimensions(path: Path) -> tuple[int, int]:
+    """Read ``(width, height)`` from a PNG file's IHDR chunk.
+
+    This only inspects the fixed 8-byte signature and the first chunk header
+    plus the leading width/height fields of IHDR; it never decodes pixel
+    data, so it has no dependency on the suite's PNG codec and does not
+    assume any particular color type or bit depth.
+    """
+
+    with open(path, "rb") as handle:
+        header = handle.read(8 + 8 + 8)  # signature + chunk length/tag + IHDR width/height
+    if len(header) < 24 or header[:8] != _PNG_SIGNATURE:
+        raise ManifestGenerationError(f"not a PNG file: {path}")
+    tag = header[12:16]
+    if tag != b"IHDR":
+        raise ManifestGenerationError(f"expected IHDR as the first chunk: {path}")
+    width, height = struct.unpack(">II", header[16:24])
+    return width, height
+
+
+def detect_revision(resvg_root: Path, override: str | None) -> str:
+    """Return the pinned upstream revision, preferring the BUILD.bazel header."""
+
+    if override:
+        return override
+    build_file = resvg_root / "BUILD.bazel"
+    if build_file.is_file():
+        text = build_file.read_text(encoding="utf-8")
+        match = _REVISION_RE.search(text)
+        if match:
+            return match.group(1)
+    return DEFAULT_REVISION
+
+
+def _capabilities_for_category(category: str) -> list[str]:
+    return list(_CATEGORY_CAPABILITIES.get(category, []))
+
+
+def discover_cases(resvg_root: Path) -> list[tuple[Path, Path]]:
+    """Return every ``(svg_path, png_path)`` pair with both files present.
+
+    Sorted by the svg path's corpus-relative form so downstream iteration is
+    deterministic even before the final id-sort of the manifest's test list.
+    """
+
+    tests_root = resvg_root / "tests"
+    if not tests_root.is_dir():
+        raise ManifestGenerationError(f"no tests/ directory under resvg root: {resvg_root}")
+
+    cases: list[tuple[Path, Path]] = []
+    for svg_path in tests_root.rglob("*.svg"):
+        png_path = svg_path.with_suffix(".png")
+        if png_path.is_file():
+            cases.append((svg_path, png_path))
+
+    cases.sort(key=lambda pair: pair[0].relative_to(resvg_root).as_posix())
+    return cases
+
+
+def _hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def build_manifest(resvg_root: Path, revision: str | None = None) -> dict[str, Any]:
+    """Walk ``resvg_root`` and build a corpus-v1 manifest dict for it."""
+
+    resolved_revision = detect_revision(resvg_root, revision)
+    cases = discover_cases(resvg_root)
+
+    tests: list[dict[str, Any]] = []
+    integrity: dict[str, str] = {}
+
+    for svg_path, png_path in cases:
+        svg_relative = svg_path.relative_to(resvg_root).as_posix()
+        png_relative = png_path.relative_to(resvg_root).as_posix()
+        relative_to_tests = svg_path.relative_to(resvg_root / "tests")
+        test_id_suffix = relative_to_tests.with_suffix("").as_posix()
+        category = relative_to_tests.parts[0]
+        width, height = read_png_dimensions(png_path)
+
+        tests.append(
+            {
+                "id": f"{CORPUS_NAME}/{test_id_suffix}",
+                "input": svg_relative,
+                "oracle": {
+                    "kind": "png",
+                    "path": png_relative,
+                    "width": width,
+                    "height": height,
+                    "provenance": "upstream-resvg-golden",
+                },
+                "assertion": (
+                    f"Imported resvg base case {relative_to_tests.as_posix()}; "
+                    "upstream reference rendering (unreviewed for SVG 2 "
+                    "requirement mapping)."
+                ),
+                "spec_requirements": [],
+                "capabilities": _capabilities_for_category(category),
+            }
+        )
+        integrity[svg_relative] = _hash_file(svg_path)
+        integrity[png_relative] = _hash_file(png_path)
+
+    tests.sort(key=lambda test: test["id"])
+
+    return {
+        "schema": CORPUS_SCHEMA_URL,
+        "corpus": CORPUS_NAME,
+        "revision": resolved_revision,
+        "integrity": integrity,
+        "tests": tests,
+    }
+
+
+def render_manifest(manifest: dict[str, Any]) -> str:
+    """Serialize ``manifest`` deterministically, with a trailing newline."""
+
+    return json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+
+
+def build_bundle(manifest: dict[str, Any], manifest_text: str) -> dict[str, Any]:
+    """Build the bundle metadata dict (design "Versioning and Distribution")."""
+
+    manifest_sha256 = hashlib.sha256(manifest_text.encode("utf-8")).hexdigest()
+    return {
+        "corpus": manifest["corpus"],
+        "source": {
+            "repository": UPSTREAM_REPOSITORY,
+            "revision": manifest["revision"],
+        },
+        "license": {
+            "id": UPSTREAM_LICENSE_ID,
+            "file": UPSTREAM_LICENSE_FILE,
+        },
+        "schema": "corpus-v1",
+        "manifest_sha256": f"sha256:{manifest_sha256}",
+        "test_count": len(manifest["tests"]),
+    }
+
+
+def render_bundle(bundle: dict[str, Any]) -> str:
+    return json.dumps(bundle, indent=2, sort_keys=True) + "\n"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a corpus-v1 manifest for the vendored resvg-test-suite."
+    )
+    parser.add_argument(
+        "--resvg-root",
+        type=Path,
+        default=DEFAULT_RESVG_ROOT,
+        help="Root of the vendored resvg-test-suite tree (default: third_party/resvg-test-suite)",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Write the manifest JSON here (default: stdout)",
+    )
+    parser.add_argument(
+        "--revision",
+        type=str,
+        default=None,
+        help="Override the detected upstream revision instead of parsing BUILD.bazel",
+    )
+    parser.add_argument(
+        "--bundle-out",
+        type=Path,
+        default=None,
+        help="Also write bundle.json metadata (source, license, manifest digest) here",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    manifest = build_manifest(args.resvg_root, args.revision)
+    manifest_text = render_manifest(manifest)
+
+    if args.out is not None:
+        args.out.write_text(manifest_text, encoding="utf-8")
+    else:
+        sys.stdout.write(manifest_text)
+
+    if args.bundle_out is not None:
+        bundle = build_bundle(manifest, manifest_text)
+        args.bundle_out.write_text(render_bundle(bundle), encoding="utf-8")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/donner_svg2_suite/resvg_base_manifest_tests.py
+++ b/tools/donner_svg2_suite/resvg_base_manifest_tests.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Tests for resvg_base_manifest.
+
+Generates the resvg base manifest from the real vendored tree
+(``third_party/resvg-test-suite``) and validates it with the slice-1
+validator, over the actual files on disk (not fixtures), and proves the
+generator is deterministic.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from python.runfiles import runfiles
+
+import manifest_validation
+import resvg_base_manifest
+
+
+def _find_resvg_root() -> Path:
+    """Locate the physical, non-symlinked vendored resvg-test-suite directory.
+
+    Bazel's runfiles tree for a vendored (non-generated) source file is a
+    symlink pointing at the real file in the workspace; path_safety rejects
+    symlink path components (by design: a symlink is an escape vector), so
+    validating a generated manifest directly against the runfiles-tree path
+    would fail every single referenced file. Resolving through the runfiles
+    indirection once here, via the LICENSE file that
+    third_party/resvg-test-suite/BUILD.bazel already exports, yields the real
+    on-disk directory: an ordinary directory of ordinary files with no
+    symlinks in it, which is what the manifest actually describes.
+    """
+
+    r = runfiles.Create()
+    anchor = r.Rlocation("donner/third_party/resvg-test-suite/LICENSE")
+    if not anchor:
+        raise RuntimeError(
+            "could not locate third_party/resvg-test-suite/LICENSE in runfiles; "
+            "is //third_party/resvg-test-suite:LICENSE in this test's data?"
+        )
+    return Path(os.path.realpath(anchor)).parent
+
+
+class ResvgBaseManifestTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.resvg_root = _find_resvg_root()
+        cls.manifest = resvg_base_manifest.build_manifest(cls.resvg_root)
+
+    def test_generated_manifest_validates_against_vendored_tree(self):
+        manifest_text = resvg_base_manifest.render_manifest(self.manifest)
+        with tempfile.TemporaryDirectory() as tmp:
+            # The manifest is written somewhere that is *not* inside the
+            # vendored tree, to exercise the corpus_root override rather than
+            # the manifest-path-parent default.
+            manifest_path = Path(tmp) / "generated-manifest.json"
+            manifest_path.write_text(manifest_text, encoding="utf-8")
+            errors = manifest_validation.validate_manifest(
+                manifest_path, corpus_root=self.resvg_root
+            )
+        self.assertEqual(errors, [], errors)
+
+    def test_generation_is_deterministic(self):
+        first = resvg_base_manifest.render_manifest(
+            resvg_base_manifest.build_manifest(self.resvg_root)
+        )
+        second = resvg_base_manifest.render_manifest(
+            resvg_base_manifest.build_manifest(self.resvg_root)
+        )
+        self.assertEqual(first, second)
+
+    def test_every_id_is_namespaced_under_resvg(self):
+        for test in self.manifest["tests"]:
+            self.assertTrue(test["id"].startswith("resvg/"), test["id"])
+
+    def test_test_count_exceeds_expected_floor(self):
+        self.assertGreater(len(self.manifest["tests"]), 1000)
+
+    def test_known_case_is_present(self):
+        ids = {test["id"] for test in self.manifest["tests"]}
+        self.assertIn("resvg/shapes/rect/simple-case", ids)
+
+    def test_integrity_map_is_nonempty_and_covers_inputs_and_oracles(self):
+        integrity = self.manifest["integrity"]
+        self.assertGreater(len(integrity), 0)
+        for test in self.manifest["tests"]:
+            self.assertIn(test["input"], integrity)
+            self.assertIn(test["oracle"]["path"], integrity)
+
+    def test_bundle_metadata(self):
+        manifest_text = resvg_base_manifest.render_manifest(self.manifest)
+        bundle = resvg_base_manifest.build_bundle(self.manifest, manifest_text)
+        self.assertEqual(bundle["source"]["revision"], resvg_base_manifest.DEFAULT_REVISION)
+        self.assertEqual(bundle["source"]["revision"], self.manifest["revision"])
+        self.assertEqual(bundle["license"]["id"], "MIT")
+        self.assertEqual(bundle["license"]["file"], "LICENSE")
+        self.assertTrue(bundle["manifest_sha256"].startswith("sha256:"))
+        self.assertEqual(bundle["test_count"], len(self.manifest["tests"]))
+
+    def test_bundle_metadata_round_trips_through_json(self):
+        manifest_text = resvg_base_manifest.render_manifest(self.manifest)
+        bundle = resvg_base_manifest.build_bundle(self.manifest, manifest_text)
+        rendered = resvg_base_manifest.render_bundle(bundle)
+        reparsed = json.loads(rendered)
+        self.assertEqual(reparsed, bundle)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/donner_svg2_suite/schemas/corpus-v1.schema.json
+++ b/tools/donner_svg2_suite/schemas/corpus-v1.schema.json
@@ -42,8 +42,8 @@
       "properties": {
         "id": {
           "type": "string",
-          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*/[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*$",
-          "description": "Globally namespaced stable id, for example 'donner-svg2/painting/paint-order/tspan-boundary'."
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*/[A-Za-z0-9._=#-]+(?:/[A-Za-z0-9._=#-]+)*$",
+          "description": "Globally namespaced stable id, for example 'donner-svg2/painting/paint-order/tspan-boundary'. '=' and '#' are allowed in path segments because imported resvg base cases carry those characters in upstream filenames (for example 'filters/feColorMatrix/type=matrix')."
         },
         "input": {
           "$ref": "#/$defs/relpath"
@@ -57,7 +57,8 @@
         },
         "spec_requirements": {
           "type": "array",
-          "minItems": 1,
+          "minItems": 0,
+          "description": "Requirement links, when reviewed. Base-imported corpus cases (design 0057, 'Oracle governance': imported corpus membership is not sufficient provenance) carry an empty array until their assertion, applicability, and oracle are reviewed and mapped; the future spec_coverage_lint enforces mapping completeness, not this schema.",
           "items": {
             "$ref": "#/$defs/requirementId"
           }


### PR DESCRIPTION
This lands the Milestone 3 seed from design 0057 ("Package the resvg base layer"): a generator that walks the pinned, unmodified upstream resvg-test-suite tree and emits a corpus-v1 manifest, plus a test that validates the generated manifest with the slice-1 validator and proves generation is deterministic. It changes nothing about the existing resvg gate and does not touch third_party/resvg-test-suite.

What this adds, under tools/donner_svg2_suite/:

- resvg_base_manifest.py: walks third_party/resvg-test-suite for every tests/<category>/<feature>/<name>.svg with a sibling <name>.png, and emits a corpus-v1 manifest (schema 0057 "Corpus manifest" section) with one test entry per case: id namespaced resvg/..., input and oracle paths, oracle width/height read from the PNG's own IHDR chunk (not assumed), an honest generic assertion, an empty spec_requirements list, and capabilities derived minimally from the top-level category (filters -> filter-effects, text -> text). It also builds a sha256 integrity map over every referenced file, and optional bundle.json metadata recording the upstream source repository, pinned revision, MIT license, and manifest digest, matching the design's "Versioning and Distribution" requirement to include upstream license, source revision, and file hashes.
- resvg_base_manifest_tests.py: generates the manifest from the real vendored tree (located through Bazel runfiles) and validates it with manifest_validation.validate_manifest over the actual files on disk, asserts generation is deterministic across two runs, and checks bundle metadata.
- A small manifest_validation.py addition: validate_manifest gains an optional corpus_root parameter (default None, preserving current behavior) so a manifest generated into its own location (a temp file here) can be validated against the actual corpus tree it describes, instead of assuming the manifest's own parent directory is the corpus root.
- A schema evolution in corpus-v1.schema.json for two real upstream filename patterns: several resvg cases use = and # in filenames (for example filters/feColorMatrix/type=matrix.svg and painting/color/#RRGGBB.svg), so the test id pattern now allows those characters in each path segment. Also relaxes spec_requirements from minItems 1 to minItems 0, since base-imported cases are unmapped until the requirement-audit and oracle-review campaign (design 0057 "Oracle governance": imported corpus membership is not sufficient provenance); the key stays required, and mapping completeness is left to the future spec_coverage_lint rather than this schema. Both changes are additive and backward compatible: every manifest that validated before still validates.

Determinism: tests are sorted by id and the manifest is serialized with json.dumps(..., indent=2, sort_keys=True), so generating the manifest twice from an unchanged tree produces byte-identical output; resvg_base_manifest_tests.py asserts this directly, and I also confirmed it by hand (diff -q on two successive CLI runs).

Validator-in-test note: the test resolves the vendored tree's real on-disk directory (via runfiles, then realpath) rather than the runfiles-tree path directly, because Bazel's runfiles entries for vendored source files are symlinks and path_safety.py intentionally rejects symlink path components as an escape vector. Validating against the real directory lets the test exercise schema, id-pattern, path-safety, and integrity-hash checks against the actual ~1679 upstream files rather than a fixture subset.

Upstream bytes are untouched: this only reads third_party/resvg-test-suite; nothing under it is copied, moved, edited, or committed.

Validation:
- bazel test //tools/donner_svg2_suite:resvg_base_manifest_tests
- bazel test //tools/donner_svg2_suite:manifest_validation_tests //tools/donner_svg2_suite:spec_seed_tests //tools/donner_svg2_suite:security_tests //tools/donner_svg2_suite:runner_tests //tools/donner_svg2_suite:adapter_contract_tests
- generator run by hand over the vendored tree; eyeballed manifest entries and bundle.json

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
