### PR TITLE
Retry transient Geode device init under parallel load

### DIFF
--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -8,9 +8,11 @@
 #include "donner/svg/renderer/geode/GeodeDevice.h"
 
 #include <atomic>
+#include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <string_view>
+#include <thread>
 
 #include "donner/base/StringUtils.h"
 #include "donner/svg/renderer/geode/GeodeCheckerboardPipeline.h"
@@ -351,10 +353,43 @@ std::unique_ptr<GeodeDevice> GeodeDevice::CreateHeadless() {
   deviceDesc.uncapturedErrorCallbackInfo.userdata1 = nullptr;
   deviceDesc.uncapturedErrorCallbackInfo.userdata2 = nullptr;
 
-  result->device_ = result->adapter_.requestDevice(deviceDesc);
-  if (!result->device_) {
+  // Bounded retry around device creation only.
+  //
+  // Under heavy parallel load the Intel Arc (ANV) Vulkan driver
+  // intermittently fails device initialization with a transient
+  // "Validation Error" (empirically around 1 in 80 device creations). This
+  // is a driver-side device-init race under contention, not a
+  // deterministic capability problem: the adapter was acquired
+  // successfully just above, and re-requesting the device after a short
+  // backoff succeeds. Retry a bounded number of times with exponential
+  // backoff, logging every retry so the flake stays observable in test
+  // logs rather than being silently absorbed.
+  //
+  // Only a null device return from requestDevice is retried. The
+  // deterministic failures (null instance, no adapter for the requested
+  // backend) already returned above and are never retried; a device lost
+  // after successful creation is out of scope here.
+  constexpr int kMaxDeviceInitRetries = 3;
+  constexpr int kDeviceInitBackoffMs[kMaxDeviceInitRetries] = {50, 200, 800};
+  for (int attempt = 0;; ++attempt) {
+    result->device_ = result->adapter_.requestDevice(deviceDesc);
+    if (result->device_) {
+      break;  // Device created successfully.
+    }
+
     std::fprintf(stderr, "[Geode/wgpu-native] Failed to create device.\n");
-    return nullptr;
+    if (attempt >= kMaxDeviceInitRetries) {
+      std::fprintf(stderr,
+                   "[Geode/wgpu-native] Giving up after %d device-creation retries.\n",
+                   kMaxDeviceInitRetries);
+      return nullptr;
+    }
+    const int backoffMs = kDeviceInitBackoffMs[attempt];
+    std::fprintf(stderr,
+                 "[Geode/wgpu-native] Transient device-init failure under parallel "
+                 "load; retrying (attempt %d of %d) after %d ms.\n",
+                 attempt + 1, kMaxDeviceInitRetries, backoffMs);
+    std::this_thread::sleep_for(std::chrono::milliseconds(backoffMs));
   }
 
   // 4. Grab the default queue.


### PR DESCRIPTION
Fixes a rare transient GeodeDevice creation failure on Intel Arc (ANV) Vulkan by adding a bounded, logged retry around headless device acquisition.

## Problem

Under heavy parallel test load on an Intel Arc A380 (Mesa ANV, Vulkan), roughly 1 in 80 test processes failed inside `GeodeDevice::CreateHeadless` with a transient "Could not get WebGPU device: Validation Error", occasionally crashing shortly afterwards. This is a driver-side device-initialization race under contention, not a rendering bug and not a deterministic capability failure: the adapter is acquired successfully, and the original investigation observed that rerunning the failed process immediately succeeds.

## Fix

- In `GeodeDevice::CreateHeadless`, wrap `adapter.requestDevice` in a bounded retry: up to 3 retries with 50/200/800 ms exponential backoff.
- Every retry attempt is logged to stderr so the flake stays observable in test logs; it is never silently absorbed.
- Only a null device return during creation is retried. The deterministic failures (null instance, no adapter available for the requested backend) return before the loop and are never retried. A device lost after successful creation is out of scope for this change.
- The change is local to headless device creation. Adapter selection, rendering paths, the filter engine, and the compositor are untouched.
- Backends that create the device on the first attempt run the loop exactly once, so behavior there is unchanged; the success path adds zero latency and the all-attempts-fail path adds a bounded 1050 ms before failing as before.

## Verification

- macOS / Metal: `bazel test --config=geode //donner/svg/renderer/geode/... //donner/svg/renderer/tests:renderer_geode_golden_tests` passes 33/33, and no retry log lines appear in any of the 33 test logs, confirming Metal behavior is unchanged.
- Linux / Intel Arc A380 (ANV): 240 test process invocations of the device-creation test (`--runs_per_test=240`, 8-way parallel) plus 778 direct test-binary invocations from 4 concurrent load generators, all with `VK_ICD_FILENAMES` pointing at the Intel ICD: 1018 device-creation processes under up to 12-way concurrency, zero terminal device-creation failures, zero test failures. The full geode + golden suites also pass on the Arc under the same induced load (33/33).
- Linux / lavapipe (llvmpipe software Vulkan): device tests and golden tests pass once with the lavapipe ICD; no retry log lines, so the software path is unaffected.

No retry log lines appeared in any of these runs: the historical 1-in-80 failure did not reproduce under this induced load (at that rate, about 13 failures would be expected in 1018 creations), so the runs demonstrate no regression and bound the current recurrence rate well below the historical one rather than exercising the retry branch itself. The retry is a bounded safety net: if the race recurs under CI load, the attempt logging keeps it observable while preventing spurious process failures.
