### PR TITLE
Add link hit-testing to DonnerController

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -228,6 +228,47 @@ The output size is determined by \ref donner::svg::SVGDocument, which can either
 - \ref donner::svg::SVGDocument::setCanvasSize()
 - \ref donner::svg::SVGDocument::useAutomaticCanvasSize()
 
+### Hit testing and link interaction
+
+The \ref donner::svg::DonnerController class provides geometry-aware spatial queries on top of the
+DOM, for pointer interaction in a viewer or editor. All queries take a point in SVG canvas
+coordinates (the same space as the root `<svg>` element's viewBox) and honor `pointer-events`,
+`visibility`, `display`, paint-order, transforms, and per-shape fill/stroke geometry. They are
+independent of the active renderer.
+
+- \ref donner::svg::DonnerController::findIntersecting returns the topmost painted element at a
+  point.
+- \ref donner::svg::DonnerController::findAllIntersecting returns every painted element at a point,
+  front to back.
+- \ref donner::svg::DonnerController::hitTestLink returns the hyperlink (\ref donner::svg::SVGAElement
+  "&lt;a&gt;") at a point, if any.
+
+`hitTestLink` implements the SVG enclosing-`<a>` semantics: a point over any descendant of an `<a>`
+resolves to that link, so the whole subtree of a link is clickable. Donner never navigates; it
+returns the link target verbatim (a raw `href` such as `"#section"`, `"../other.svg"`, or an
+absolute URL) and the embedding application resolves and follows it. Because it is a stateless
+query rather than a navigation callback, the application drives it from its own pointer events and
+uses the same call for both a click (activate the link) and hover (show a pointer cursor, a hover
+highlight, or a tooltip), deciding for itself what each gesture does.
+
+```cpp
+donner::svg::DonnerController controller(document);
+
+// On a pointer move, for a hover affordance:
+if (auto link = controller.hitTestLink(cursorPosition)) {
+  setCursor(Cursor::Pointer);
+  showTooltip(link->href);  // link->linkElement is the enclosing <a>
+} else {
+  setCursor(Cursor::Default);
+  hideTooltip();
+}
+
+// On a click, to activate:
+if (auto link = controller.hitTestLink(clickPosition)) {
+  app.openUrl(link->href);  // the application resolves and navigates
+}
+```
+
 ### Using the CSS API {#UsingTheCssApi}
 
 The CSS API is used internally within the SVG library, but can be used standalone.

--- a/donner/svg/DonnerController.cc
+++ b/donner/svg/DonnerController.cc
@@ -35,4 +35,28 @@ std::vector<SVGGraphicsElement> DonnerController::findAllIntersecting(const Vect
   return results;
 }
 
+std::optional<DonnerController::LinkHit> DonnerController::hitTestLink(const Vector2d& point) {
+  std::optional<SVGGraphicsElement> hit = findIntersecting(point);
+  if (!hit) {
+    return std::nullopt;
+  }
+
+  // Enclosing-<a> semantics: a hit on any descendant of an `<a>` resolves to that `<a>`'s target.
+  // Walk the ancestor chain, starting at the hit element itself, to the nearest `<a>` that carries
+  // a link target. An `<a>` without an href is not a link and is skipped so an outer linked `<a>`
+  // can still match.
+  std::optional<SVGElement> current = *hit;
+  while (current) {
+    if (std::optional<SVGAElement> anchor = current->tryCast<SVGAElement>()) {
+      if (std::optional<RcString> href = anchor->href()) {
+        return LinkHit{*anchor, std::move(*href), *hit};
+      }
+    }
+
+    current = current->parentElement();
+  }
+
+  return std::nullopt;
+}
+
 }  // namespace donner::svg

--- a/donner/svg/DonnerController.h
+++ b/donner/svg/DonnerController.h
@@ -1,8 +1,11 @@
 #pragma once
 /// @file
 
+#include <optional>
 #include <vector>
 
+#include "donner/base/RcString.h"
+#include "donner/svg/SVGAElement.h"
 #include "donner/svg/SVGDocument.h"
 #include "donner/svg/SVGGeometryElement.h"
 #include "donner/svg/SVGGraphicsElement.h"
@@ -25,6 +28,26 @@ namespace donner::svg {
  */
 class DonnerController {
 public:
+  /**
+   * Result of a successful \ref hitTestLink query: the enclosing \ref xml_a element that was hit,
+   * its retained link target, and the concrete element under the point.
+   */
+  struct LinkHit {
+    /// The enclosing `<a>` element whose content was hit.
+    SVGAElement linkElement;
+
+    /// The raw, unresolved link target as authored on the `<a>` element (`href` / `xlink:href`),
+    /// for example `"#section"`, `"../other.svg"`, or `"https://example.com/"`. The embedding
+    /// application is responsible for resolving this reference against the document base URL and
+    /// performing any navigation; Donner returns the target verbatim and never navigates itself.
+    RcString href;
+
+    /// The concrete painted descendant actually under the point (e.g. the nested `<rect>` inside
+    /// the `<a>`). An `<a>` paints nothing of its own, so this is always a descendant of \ref
+    /// linkElement, never the `<a>` element itself.
+    SVGGraphicsElement hitElement;
+  };
+
   /**
    * Create a controller for the given document.
    *
@@ -51,6 +74,49 @@ public:
    * outside the active scope to occlude an eligible descendant.
    */
   std::vector<SVGGraphicsElement> findAllIntersecting(const Vector2d& point);
+
+  /**
+   * Finds the hyperlink (\ref xml_a) at the given point, if any, resolving the enclosing-`<a>`
+   * semantics from the SVG linking model (https://www.w3.org/TR/SVG2/linking.html#Links).
+   *
+   * The embedding application drives this query directly from its own pointer events, so the same
+   * call serves both link activation (on click / tap) and link affordances (on hover, e.g. a
+   * pointer-cursor change, hover highlight, or tooltip). Donner intentionally exposes a stateless
+   * query rather than registering navigation callbacks: it has no event loop and never navigates,
+   * so the application keeps full control over what a hover versus a click does with the returned
+   * target.
+   *
+   * Hit resolution reuses \ref findIntersecting, so it honors `pointer-events`, `visibility`,
+   * `display`, paint-order, transforms, and per-shape fill/stroke geometry, and it is independent
+   * of the active renderer (TinySkia or Geode). A point that lands on any descendant of an `<a>`
+   * resolves to that `<a>` (the nearest ancestor `<a>` with a link target), matching the SVG
+   * requirement that the whole subtree of a link is clickable. If the topmost painted element at
+   * the point is not inside any `<a>`, no link is returned even when a lower, occluded element
+   * would have been linked.
+   *
+   * The point is in SVG canvas coordinates (the same coordinate space as the root `<svg>`
+   * element's viewBox), identical to \ref findIntersecting.
+   *
+   * Resolution follows the document-tree ancestor chain, which has two consequences worth noting:
+   * a `<a>` wrapping graphics (or a whole `<text>`) resolves normally, but an inline `<a>` span
+   * nested *inside* a `<text>` resolves to that enclosing `<text>` rather than to the inline span,
+   * because text is hit-tested at text-element granularity. Content injected through `<use>` is
+   * resolved by the referenced subtree's own ancestry.
+   *
+   * ```cpp
+   * DonnerController controller(document);
+   * if (auto link = controller.hitTestLink(cursorPosition)) {
+   *   // On hover: show a pointer cursor / highlight link->linkElement.
+   *   // On click: navigate to link->href (the app resolves and follows it).
+   *   app.openUrl(link->href);
+   * }
+   * ```
+   *
+   * @param point Position in canvas coordinates.
+   * @return The enclosing link, its raw target, and the hit element, or \c std::nullopt if no link
+   *   is at the point.
+   */
+  std::optional<LinkHit> hitTestLink(const Vector2d& point);
 
 private:
   SVGDocument document_;

--- a/donner/svg/tests/BUILD.bazel
+++ b/donner/svg/tests/BUILD.bazel
@@ -43,6 +43,7 @@ donner_cc_test(
 donner_cc_test(
     name = "svg_tests",
     srcs = [
+        "DonnerController_tests.cc",
         "ElementStyle_tests.cc",
         "ElementType_tests.cc",
         "SVGAElement_tests.cc",

--- a/donner/svg/tests/DonnerController_tests.cc
+++ b/donner/svg/tests/DonnerController_tests.cc
@@ -1,0 +1,355 @@
+/**
+ * Tests for DonnerController::hitTestLink: resolving the enclosing `<a>` hyperlink at a point, for
+ * both click activation and hover affordances. Link hit-testing is DOM/geometry only, so it is
+ * exercised identically across renderer variants.
+ */
+
+#include "donner/svg/DonnerController.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "donner/base/ParseWarningSink.h"
+#include "donner/base/tests/BaseTestUtils.h"
+#include "donner/base/tests/ParseResultTestUtils.h"
+#include "donner/svg/parser/SVGParser.h"
+
+using testing::Eq;
+using testing::Optional;
+
+namespace donner::svg {
+
+class DonnerControllerTest : public ::testing::Test {
+protected:
+  SVGDocument ParseSVG(std::string_view input) {
+    ParseWarningSink parseSink;
+    auto maybeResult = parser::SVGParser::ParseSVG(input, parseSink);
+    EXPECT_THAT(maybeResult, NoParseError());
+    return std::move(maybeResult).result();
+  }
+};
+
+// --- Click activation ---
+
+/// @test A click directly on the painted child of an `<a>` resolves to that link, and reports both
+/// the enclosing `<a>` and the concrete element hit.
+TEST_F(DonnerControllerTest, ClickInsideLinkDirectChild) {
+  SVGDocument document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <a href="https://example.com/">
+        <rect id="r" x="10" y="10" width="80" height="80" fill="red"/>
+      </a>
+    </svg>
+  )");
+  DonnerController controller(document);
+
+  std::optional<DonnerController::LinkHit> link = controller.hitTestLink(Vector2d(50, 50));
+  ASSERT_TRUE(link.has_value());
+  EXPECT_THAT(link->href, Eq(RcString("https://example.com/")));
+  EXPECT_THAT(link->linkElement.href(), Optional(RcString("https://example.com/")));
+  // The concrete element under the point is the nested <rect>, not the <a> container.
+  EXPECT_THAT(link->hitElement.id(), Eq(RcString("r")));
+  EXPECT_EQ(link->hitElement, *document.querySelector("#r"));
+}
+
+/// @test A click on a shape nested several levels below an `<a>` (through a `<g>`) still resolves to
+/// the enclosing link (SVG enclosing-`<a>` semantics: the whole subtree of a link is clickable).
+TEST_F(DonnerControllerTest, ClickOnNestedDescendant) {
+  SVGDocument document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <a href="#target">
+        <g>
+          <g>
+            <circle id="c" cx="50" cy="50" r="40" fill="blue"/>
+          </g>
+        </g>
+      </a>
+    </svg>
+  )");
+  DonnerController controller(document);
+
+  std::optional<DonnerController::LinkHit> link = controller.hitTestLink(Vector2d(50, 50));
+  ASSERT_TRUE(link.has_value());
+  EXPECT_THAT(link->href, Eq(RcString("#target")));
+  EXPECT_THAT(link->hitElement.id(), Eq(RcString("c")));
+}
+
+/// @test A click on a painted element that is not inside any `<a>` returns no link.
+TEST_F(DonnerControllerTest, ClickOutsideAnyLink) {
+  SVGDocument document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <rect x="10" y="10" width="80" height="80" fill="green"/>
+    </svg>
+  )");
+  DonnerController controller(document);
+
+  EXPECT_THAT(controller.hitTestLink(Vector2d(50, 50)), Eq(std::nullopt));
+}
+
+/// @test A click on empty canvas (no painted element) returns no link.
+TEST_F(DonnerControllerTest, ClickOnEmptyArea) {
+  SVGDocument document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <a href="https://example.com/">
+        <rect x="10" y="10" width="20" height="20" fill="red"/>
+      </a>
+    </svg>
+  )");
+  DonnerController controller(document);
+
+  // (90, 90) is outside the small rect.
+  EXPECT_THAT(controller.hitTestLink(Vector2d(90, 90)), Eq(std::nullopt));
+}
+
+// --- Overlap / z-order ---
+
+/// @test When a linked shape is painted on top of another shape, the click resolves to the top
+/// link.
+TEST_F(DonnerControllerTest, OverlappingTopLinkWins) {
+  SVGDocument document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <rect x="0" y="0" width="100" height="100" fill="green"/>
+      <a href="#top">
+        <rect id="top" x="20" y="20" width="60" height="60" fill="red"/>
+      </a>
+    </svg>
+  )");
+  DonnerController controller(document);
+
+  std::optional<DonnerController::LinkHit> link = controller.hitTestLink(Vector2d(50, 50));
+  ASSERT_TRUE(link.has_value());
+  EXPECT_THAT(link->href, Eq(RcString("#top")));
+  EXPECT_THAT(link->hitElement.id(), Eq(RcString("top")));
+}
+
+/// @test An unlinked shape painted on top of a linked shape occludes the link: the topmost element
+/// wins, and since it is not inside an `<a>`, no link is returned.
+TEST_F(DonnerControllerTest, TopUnlinkedShapeOccludesLink) {
+  SVGDocument document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <a href="#below">
+        <rect x="0" y="0" width="100" height="100" fill="green"/>
+      </a>
+      <rect x="20" y="20" width="60" height="60" fill="red"/>
+    </svg>
+  )");
+  DonnerController controller(document);
+
+  // Inside the top unlinked rect: occluded, no link.
+  EXPECT_THAT(controller.hitTestLink(Vector2d(50, 50)), Eq(std::nullopt));
+  // Outside the top rect but still over the linked full-canvas rect: link resolves.
+  std::optional<DonnerController::LinkHit> edge = controller.hitTestLink(Vector2d(5, 5));
+  ASSERT_TRUE(edge.has_value());
+  EXPECT_THAT(edge->href, Eq(RcString("#below")));
+}
+
+// --- Transformed coordinates ---
+
+/// @test Link hit-testing accounts for transforms on the link subtree: the query point is in canvas
+/// coordinates, and a shape moved by a transform is hit at its transformed location.
+TEST_F(DonnerControllerTest, TransformedCoordinates) {
+  SVGDocument document = ParseSVG(R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <a href="#moved">
+        <rect id="m" x="0" y="0" width="40" height="40" transform="translate(100, 100)" fill="red"/>
+      </a>
+    </svg>
+  )svg");
+  DonnerController controller(document);
+
+  // The rect's local (0..40) box is translated to canvas (100..140).
+  EXPECT_THAT(controller.hitTestLink(Vector2d(20, 20)), Eq(std::nullopt));
+  std::optional<DonnerController::LinkHit> link = controller.hitTestLink(Vector2d(120, 120));
+  ASSERT_TRUE(link.has_value());
+  EXPECT_THAT(link->href, Eq(RcString("#moved")));
+  EXPECT_THAT(link->hitElement.id(), Eq(RcString("m")));
+}
+
+// --- href resolution: the raw target is returned verbatim; the app resolves navigation ---
+
+/// @test A fragment target is returned raw.
+TEST_F(DonnerControllerTest, HrefFragmentReturnedRaw) {
+  SVGDocument document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <a href="#section-2"><rect x="0" y="0" width="100" height="100"/></a>
+    </svg>
+  )");
+  DonnerController controller(document);
+  EXPECT_THAT(controller.hitTestLink(Vector2d(50, 50))->href, Eq(RcString("#section-2")));
+}
+
+/// @test A relative target is returned raw (Donner does not resolve it against the base URL).
+TEST_F(DonnerControllerTest, HrefRelativeReturnedRaw) {
+  SVGDocument document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <a href="../pages/other.svg"><rect x="0" y="0" width="100" height="100"/></a>
+    </svg>
+  )");
+  DonnerController controller(document);
+  EXPECT_THAT(controller.hitTestLink(Vector2d(50, 50))->href, Eq(RcString("../pages/other.svg")));
+}
+
+/// @test An absolute target is returned raw, including via the legacy `xlink:href` alias.
+TEST_F(DonnerControllerTest, HrefAbsoluteViaXlinkReturnedRaw) {
+  SVGDocument document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+         viewBox="0 0 100 100">
+      <a xlink:href="https://example.com/path?q=1"><rect x="0" y="0" width="100" height="100"/></a>
+    </svg>
+  )");
+  DonnerController controller(document);
+  EXPECT_THAT(controller.hitTestLink(Vector2d(50, 50))->href,
+              Eq(RcString("https://example.com/path?q=1")));
+}
+
+/// @test An `<a>` with no target is not a link: a hit inside it returns no link.
+TEST_F(DonnerControllerTest, LinkWithoutHrefIsNotALink) {
+  SVGDocument document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <a><rect x="0" y="0" width="100" height="100" fill="red"/></a>
+    </svg>
+  )");
+  DonnerController controller(document);
+  EXPECT_THAT(controller.hitTestLink(Vector2d(50, 50)), Eq(std::nullopt));
+}
+
+/// @test An `<a>` with an empty href (`href=""`) is not a link, matching `SVGAElement::href()`
+/// reporting no target for an empty string.
+TEST_F(DonnerControllerTest, EmptyHrefIsNotALink) {
+  SVGDocument document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <a href=""><rect x="0" y="0" width="100" height="100" fill="red"/></a>
+    </svg>
+  )");
+  DonnerController controller(document);
+  EXPECT_THAT(controller.hitTestLink(Vector2d(50, 50)), Eq(std::nullopt));
+}
+
+/// @test Nested `<a>` elements resolve to the innermost enclosing link with a target (nearest
+/// ancestor wins).
+TEST_F(DonnerControllerTest, NestedLinksResolveToInnermost) {
+  SVGDocument document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <a href="#outer">
+        <a href="#inner">
+          <rect x="0" y="0" width="100" height="100" fill="red"/>
+        </a>
+      </a>
+    </svg>
+  )");
+  DonnerController controller(document);
+  std::optional<DonnerController::LinkHit> link = controller.hitTestLink(Vector2d(50, 50));
+  ASSERT_TRUE(link.has_value());
+  EXPECT_THAT(link->href, Eq(RcString("#inner")));
+}
+
+/// @test An outer `<a>` still resolves when an inner `<a>` has no target: the walk skips the
+/// targetless inner link and climbs to the outer one.
+TEST_F(DonnerControllerTest, TargetlessInnerLinkFallsThroughToOuter) {
+  SVGDocument document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <a href="#outer">
+        <a>
+          <rect x="0" y="0" width="100" height="100" fill="red"/>
+        </a>
+      </a>
+    </svg>
+  )");
+  DonnerController controller(document);
+  std::optional<DonnerController::LinkHit> link = controller.hitTestLink(Vector2d(50, 50));
+  ASSERT_TRUE(link.has_value());
+  EXPECT_THAT(link->href, Eq(RcString("#outer")));
+}
+
+/// @test `display: none` on the linked shape removes it from the render tree, so it is not
+/// hit-tested and no link is returned.
+TEST_F(DonnerControllerTest, DisplayNoneSuppressesLink) {
+  SVGDocument document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <a href="#x">
+        <rect x="0" y="0" width="100" height="100" fill="red" display="none"/>
+      </a>
+    </svg>
+  )");
+  DonnerController controller(document);
+  EXPECT_THAT(controller.hitTestLink(Vector2d(50, 50)), Eq(std::nullopt));
+}
+
+/// @test `pointer-events: none` on the linked shape makes it non-interactive, so no link is
+/// returned even though the point is geometrically inside it.
+TEST_F(DonnerControllerTest, PointerEventsNoneSuppressesLink) {
+  SVGDocument document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <a href="#x">
+        <rect x="0" y="0" width="100" height="100" fill="red" pointer-events="none"/>
+      </a>
+    </svg>
+  )");
+  DonnerController controller(document);
+  EXPECT_THAT(controller.hitTestLink(Vector2d(50, 50)), Eq(std::nullopt));
+}
+
+// --- Hover affordances: the app drives the same query on pointer-move ---
+
+/// @test Hovering inside a link reports it (same query as click), so the app can show a pointer
+/// cursor or hover highlight.
+TEST_F(DonnerControllerTest, HoverInsideLink) {
+  SVGDocument document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <a href="https://hover.example/">
+        <rect x="10" y="10" width="80" height="80" fill="red"/>
+      </a>
+    </svg>
+  )");
+  DonnerController controller(document);
+  std::optional<DonnerController::LinkHit> hover = controller.hitTestLink(Vector2d(50, 50));
+  ASSERT_TRUE(hover.has_value());
+  EXPECT_THAT(hover->href, Eq(RcString("https://hover.example/")));
+}
+
+/// @test Hovering over a nested descendant of a link reports the enclosing link, so the whole link
+/// region shows the hover affordance.
+TEST_F(DonnerControllerTest, HoverOnNestedDescendant) {
+  SVGDocument document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <a href="#deep">
+        <g><rect id="r" x="10" y="10" width="80" height="80" fill="red"/></g>
+      </a>
+    </svg>
+  )");
+  DonnerController controller(document);
+  std::optional<DonnerController::LinkHit> hover = controller.hitTestLink(Vector2d(50, 50));
+  ASSERT_TRUE(hover.has_value());
+  EXPECT_THAT(hover->href, Eq(RcString("#deep")));
+  EXPECT_THAT(hover->hitElement.id(), Eq(RcString("r")));
+}
+
+/// @test As the pointer leaves the link's painted region, the query stops reporting the link, so
+/// the app clears the hover affordance.
+TEST_F(DonnerControllerTest, HoverLeavingLink) {
+  SVGDocument document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <a href="#l">
+        <rect x="10" y="10" width="30" height="30" fill="red"/>
+      </a>
+    </svg>
+  )");
+  DonnerController controller(document);
+  // Inside the small rect: link present.
+  ASSERT_TRUE(controller.hitTestLink(Vector2d(20, 20)).has_value());
+  // Moved outside the rect: link cleared.
+  EXPECT_THAT(controller.hitTestLink(Vector2d(80, 80)), Eq(std::nullopt));
+}
+
+/// @test Hovering over an area with no link (an unlinked shape) reports nothing.
+TEST_F(DonnerControllerTest, HoverWithNoLink) {
+  SVGDocument document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <rect x="10" y="10" width="80" height="80" fill="green"/>
+    </svg>
+  )");
+  DonnerController controller(document);
+  EXPECT_THAT(controller.hitTestLink(Vector2d(50, 50)), Eq(std::nullopt));
+}
+
+}  // namespace donner::svg


### PR DESCRIPTION
Adds a public query so an embedding application can find the SVG hyperlink at a pointer location and handle navigation itself. `DonnerController::hitTestLink(point)` returns the enclosing `<a>` element, its retained link target, and the concrete element under the point, or nothing when there is no link there.

The application drives the query directly from its own pointer events, so the same call serves both link activation on click and link affordances on hover (a pointer cursor, a hover highlight, or a tooltip). This stateless-query shape fits Donner's existing API idioms (it sits alongside `findIntersecting` / `findAllIntersecting`) rather than introducing navigation callbacks: Donner has no event loop and never navigates. It returns the `href` verbatim (for example `#section`, `../other.svg`, or an absolute URL) and the application resolves and follows it.

Hit resolution reuses the existing `findIntersecting` hit-test, so it honors `pointer-events`, `visibility`, `display`, paint-order, transforms, and per-shape fill/stroke geometry, and is independent of the active renderer (CPU or GPU). It implements SVG enclosing-`<a>` semantics by walking the document-tree ancestor chain: a hit on any descendant of an `<a>` resolves to that link, the nearest enclosing linked `<a>` wins for nested links, and an unlinked element painted on top correctly occludes a link beneath it.

Behavioral notes captured in the API docs: an `<a>` paints nothing of its own, so the reported hit element is always a descendant; and an inline `<a>` span nested inside a `<text>` resolves to the enclosing `<text>` because text is hit-tested at text-element granularity.

Testing: new unit tests in `donner/svg/tests/DonnerController_tests.cc` cover click, hover (inside, on a nested descendant, leaving the link, and with no link), nested and targetless links, z-order occlusion, transformed coordinates, `pointer-events: none` and `display: none` suppression, empty href, and raw href resolution for fragment, relative, and absolute targets. They pass across the CPU, GPU, and full-text renderer variants. The API guide gains a hit-testing-and-link-interaction section with a usage example. This is a small additive API plus tests and docs; there is no change to existing rendering behavior.
