### PR TITLE
Harden Geode adapter acquisition: bounded retry and clean no-adapter failure

### DIFF
--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -2141,6 +2141,14 @@ RendererGeode::RendererGeode(RendererGeode&&) noexcept = default;
 RendererGeode& RendererGeode::operator=(RendererGeode&&) noexcept = default;
 
 void RendererGeode::draw(SVGDocument& document) {
+  // No-op mode: if adapter/device acquisition failed there is no GPU to
+  // render with. Return before running the driver so none of the
+  // per-element callbacks (drawPath, pushClip, pushFilterLayer, ...)
+  // dereference a null device. Matches beginFrame's existing no-op guard.
+  if (!impl_->device) {
+    return;
+  }
+
   // Wire the M2 cache-invalidation listener onto this document's
   // registry BEFORE the driver runs `RenderingContext::instantiateRenderTree`.
   // The listener must be connected when `ShapeSystem` fires its
@@ -3436,6 +3444,13 @@ void RendererGeode::setPaint(const PaintParams& paint) {
 }
 
 void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) {
+  // No-op mode guard (matches drawImage / drawText): with no device or no
+  // active frame encoder, skip cleanly instead of dereferencing a null
+  // device via getFillEncode() -> GeodeDevice::countPathEncode().
+  if (!impl_->device || !impl_->encoder) {
+    return;
+  }
+
   // M6-B detection (design doc 0030 §M6 Bullet 2): when a `<use>`
   // draws a path that was also just drawn by the previous call -
   // same source entity, same paint - this is exactly the case an

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -274,10 +274,38 @@ std::unique_ptr<GeodeDevice> GeodeDevice::CreateHeadless() {
   //    `emscripten_sleep` instead).
   wgpu::RequestAdapterOptions adapterOptions = {};
   adapterOptions.backendType = headlessBackend;
-  result->adapter_ = result->impl_->instance.requestAdapter(adapterOptions);
-  if (!result->adapter_) {
+
+  // Bounded retry around adapter acquisition, mirroring the device-init
+  // retry below (#880). Under heavy parallel load the adapter request can
+  // transiently fail at the adapter level - wgpu-native logs
+  // \"Could not get WebGPU adapter: Validation Error / No suitable adapter
+  // found\" and requestAdapter returns null - before requestDevice is even
+  // reached. This is the same driver-side race under contention; the
+  // adapter re-request after a short backoff succeeds. A permanently
+  // missing adapter (no GPU, wrong backend) simply exhausts the retries and
+  // returns nullptr, which RendererGeode handles as no-op mode. Every retry
+  // is logged so the flake stays observable in test logs.
+  constexpr int kMaxAdapterRetries = 3;
+  constexpr int kAdapterBackoffMs[kMaxAdapterRetries] = {50, 200, 800};
+  for (int attempt = 0;; ++attempt) {
+    result->adapter_ = result->impl_->instance.requestAdapter(adapterOptions);
+    if (result->adapter_) {
+      break;  // Adapter acquired.
+    }
+
     std::fprintf(stderr, "[Geode/wgpu-native] No WebGPU adapter available.\n");
-    return nullptr;
+    if (attempt >= kMaxAdapterRetries) {
+      std::fprintf(stderr,
+                   "[Geode/wgpu-native] Giving up after %d adapter-acquisition retries.\n",
+                   kMaxAdapterRetries);
+      return nullptr;
+    }
+    const int backoffMs = kAdapterBackoffMs[attempt];
+    std::fprintf(stderr,
+                 "[Geode/wgpu-native] Transient adapter-acquisition failure under parallel "
+                 "load; retrying (attempt %d of %d) after %d ms.\n",
+                 attempt + 1, kMaxAdapterRetries, backoffMs);
+    std::this_thread::sleep_for(std::chrono::milliseconds(backoffMs));
   }
 
   // Log adapter selection so it is obvious at a glance whether we landed

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -85,6 +85,14 @@ PaintParams solidFillAndStroke(const css::RGBA& fill, const css::RGBA& stroke) {
 /// RGBA pixel at (x, y) in a tightly packed snapshot bitmap.
 std::array<uint8_t, 4> pixelAt(const RendererBitmap& bitmap, int x, int y) {
   const size_t off = static_cast<size_t>(y) * bitmap.rowBytes + static_cast<size_t>(x) * 4u;
+  // Guard against an empty or undersized bitmap - e.g. a no-op-mode snapshot
+  // produced when no GPU adapter was available. Returning transparent lets the
+  // caller's pixel assertion fail cleanly instead of indexing out of bounds
+  // and crashing the whole test binary with SIGSEGV (a missing adapter must
+  // yield a clean test FAILURE, never a crash and never a silent skip).
+  if (off + 4 > bitmap.pixels.size()) {
+    return {0, 0, 0, 0};
+  }
   return {bitmap.pixels[off], bitmap.pixels[off + 1], bitmap.pixels[off + 2],
           bitmap.pixels[off + 3]};
 }
@@ -2168,6 +2176,46 @@ TEST_F(RendererGeodeTest, FilterAppliedBeforeClipPathSvgRenderingOrder) {
   auto outside = pixelAt(snap, 48, 32);
   EXPECT_THAT(outside, IsTransparent()) << "Outside the clip must be transparent - the "
                                            "filter result is clipped on composite";
+}
+
+
+// A GeodeDevice that fails to initialize (e.g. no Vulkan adapter on a GPU-less
+// worker) leaves RendererGeode in \"no-op mode\". Every rendering entry point
+// must be a clean no-op rather than dereferencing the null device. The
+// historical failure was a SIGSEGV in
+// drawPath -> Impl::getFillEncode -> GeodeDevice::countPathEncode() when the
+// resvg suite ran on a worker whose adapter acquisition failed.
+TEST_F(RendererGeodeTest, NullDeviceEntersNoOpModeWithoutCrashing) {
+  // Deterministically simulate CreateHeadless() having returned nullptr by
+  // handing the renderer a null device. Does not depend on the host GPU.
+  RendererGeode renderer(std::shared_ptr<geode::GeodeDevice>(nullptr), /*verbose=*/false);
+
+  // Low-level ops (direct callers such as the editor overlay) must no-op.
+  RenderViewport viewport;
+  viewport.size = Vector2d(kViewportSize, kViewportSize);
+  viewport.devicePixelRatio = 1.0;
+  renderer.beginFrame(viewport);
+  renderer.setPaint(solidFill(css::RGBA(255, 0, 0, 255)));
+  renderer.drawRect(Box2d({0, 0}, {kViewportSize, kViewportSize}), StrokeParams{});
+  renderer.endFrame();
+  EXPECT_TRUE(renderer.takeSnapshot().empty())
+      << "No-op mode has no rendered target, so the snapshot is empty.";
+
+  // Full document render path via draw(). The draw() guard makes this a
+  // clean no-op before the driver runs; the drawPath guard (the historical
+  // crash site drawPath -> getFillEncode -> countPathEncode) is exercised
+  // directly by the drawRect() call above, which routes through drawPath.
+  ParseWarningSink warningSink;
+  auto maybeDocument = parser::SVGParser::ParseSVG(
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+             <rect x="1" y="1" width="14" height="14" fill="red"/>
+           </svg>)svg",
+      warningSink);
+  ASSERT_FALSE(maybeDocument.hasError()) << maybeDocument.error();
+  SVGDocument document = std::move(maybeDocument).result();
+  RendererUtils::prepareDocumentForRendering(document, /*verbose=*/false, warningSink);
+  renderer.draw(document);  // Must not crash.
+  EXPECT_TRUE(renderer.takeSnapshot().empty());
 }
 
 }  // namespace


### PR DESCRIPTION
Harden the Geode WebGPU backend so a missing or transiently-unavailable GPU adapter is handled gracefully instead of crashing.

Three related changes:

First, the bounded, logged device-init retry added in #880 is extended up to adapter acquisition. Under heavy parallel load wgpu-native's `requestAdapter` can transiently return null (logging "Could not get WebGPU adapter: Validation Error / No suitable adapter found") before `requestDevice` is ever reached. This is the same driver-side race the device-init retry already absorbs, so the same discipline is applied: three attempts with 50/200/800 ms backoff, every retry logged so the flake stays observable in test logs. A permanently missing adapter still returns nullptr once the retries are exhausted.

Second, the renderer now fails cleanly when no adapter is available. When `CreateHeadless` returns null, `RendererGeode` runs in no-op mode (`impl_->device` is null). `beginFrame`, `drawImage`, and `drawText` already guarded that state, but the per-element path did not: `drawPath` then `getFillEncode` then `GeodeDevice::countPathEncode()` dereferenced the null device and crashed with a SIGSEGV. `draw()` and `drawPath()` now guard the same way, so a missing adapter produces a blank or skipped render instead of a crash.

Third, the pixel-reading test helper `pixelAt` is bounds-checked. Several existing Geode tests read a pixel from the snapshot without first asserting it is non-empty; in a no-adapter run the snapshot is a correct empty no-op bitmap, so `pixelAt` indexed a zero-length buffer and crashed the whole test binary. It now returns transparent when the offset is out of range, so those tests fail cleanly (their color assertion fails) rather than crashing. This deliberately does not skip: a missing adapter must surface as a loud test failure, never a silent skip that could mask a real GPU regression.

A deterministic regression test constructs a `RendererGeode` with a null device and exercises the low-level ops and the full `draw(document)` path, asserting no crash and an empty snapshot. It does not depend on the host GPU.

Verification: on macOS/Metal, `renderer_geode_tests` (including the new test), `renderer_geode_golden_tests`, and the 16-shard `resvg_test_suite_geode` all pass, and the goldens are unchanged since the success path is untouched. In a forced no-adapter run, `renderer_geode_tests` and `resvg_test_suite_geode` both fail cleanly with zero crashes: the three adapter retries fire, the renderer enters no-op mode, and every affected test reports a clean assertion failure.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17