### PR TITLE
ci: queue self-hosted RE jobs with a FIFO turnstile instead of an evicting concurrency group

### DIFF
--- a/.github/actions/re-turnstile/action.yml
+++ b/.github/actions/re-turnstile/action.yml
@@ -1,0 +1,155 @@
+name: Remote-execution turnstile
+description: >-
+  Serialize a self-hosted job on the shared remote-execution backend without
+  losing runs. Waits (FIFO, oldest run first) until this job's lane is free,
+  then returns so the build can proceed. Replaces a GitHub concurrency group,
+  which caps the queue at one pending run and cancels any older pending run
+  when a third concurrent run arrives. This turnstile instead holds each run
+  until its turn, so N concurrent runs all execute in submission order and
+  none are cancelled. Read-only: it lists this repository's own workflow runs
+  via the Actions API and mutates nothing.
+
+inputs:
+  lane:
+    description: >-
+      Job name to serialize on. All runs whose job of this name is active
+      form one FIFO queue; only the oldest proceeds at a time.
+    required: true
+  token:
+    description: Token with actions:read on this repository (github.token).
+    required: true
+  timeout-minutes:
+    description: >-
+      Safety cap. If the wait exceeds this, the turnstile proceeds anyway
+      (fail-open) rather than blocking. Keep below the job timeout, with room
+      left for a full build after the wait.
+    required: false
+    default: "150"
+  poll-seconds:
+    description: Base seconds between polls (a small random jitter is added).
+    required: false
+    default: "30"
+
+runs:
+  using: composite
+  steps:
+    - name: Wait for remote-execution turnstile
+      shell: bash
+      env:
+        TURNSTILE_LANE: ${{ inputs.lane }}
+        TURNSTILE_TOKEN: ${{ inputs.token }}
+        TURNSTILE_TIMEOUT_MINUTES: ${{ inputs.timeout-minutes }}
+        TURNSTILE_POLL_SECONDS: ${{ inputs.poll-seconds }}
+      run: |
+        set -uo pipefail
+
+        api="${GITHUB_API_URL:-https://api.github.com}"
+        repo="${GITHUB_REPOSITORY}"
+        run_id="${GITHUB_RUN_ID}"
+        lane="${TURNSTILE_LANE}"
+        poll="${TURNSTILE_POLL_SECONDS}"
+        deadline=$(( $(date +%s) + TURNSTILE_TIMEOUT_MINUTES * 60 ))
+
+        # GET a paginated-safe single page (100 is plenty; the runner pool
+        # bounds how many self-hosted runs can be concurrently active).
+        gh_get() {
+          curl --silent --show-error --fail-with-body \
+            --max-time 30 \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${TURNSTILE_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "$1" 2>/dev/null
+        }
+
+        # Identify this run: its ordering key (run_number) and workflow id.
+        me_json=""
+        for attempt in 1 2 3; do
+          me_json=$(gh_get "${api}/repos/${repo}/actions/runs/${run_id}") && break
+          echo "turnstile: could not read own run (attempt ${attempt}); retrying"
+          sleep 5
+        done
+        if [[ -z "${me_json}" ]]; then
+          echo "turnstile: Actions API unavailable; proceeding without serialization (fail-open)"
+          exit 0
+        fi
+        my_number=$(printf '%s' "${me_json}" | jq -r '.run_number')
+        workflow_id=$(printf '%s' "${me_json}" | jq -r '.workflow_id')
+        if [[ -z "${my_number}" || "${my_number}" == "null" || -z "${workflow_id}" || "${workflow_id}" == "null" ]]; then
+          echo "turnstile: could not determine run ordering; proceeding (fail-open)"
+          exit 0
+        fi
+        echo "turnstile: lane='${lane}' this run #${my_number} (workflow ${workflow_id})"
+
+        # A run is "ahead" of us if it is older (smaller run_number) and its
+        # lane job is not yet in a terminal state. A still-initializing older
+        # run whose lane job has not appeared yet also counts as ahead so we
+        # never jump its place (strict FIFO, no two-at-once race). Because the
+        # order is a strict total order on run_number, the oldest run is never
+        # ahead of anyone: no cycles, no deadlock, no starvation.
+        while true; do
+          ahead_desc=""
+          list_failed=0
+          # Enumerate older, still-active runs of this workflow, oldest first,
+          # and break on the first one still holding the lane (that alone is
+          # enough to keep waiting). Filter status server-side (queued +
+          # in_progress) so an old active run is never missed behind >100 newer
+          # runs; active runs of one workflow never exceed a page in practice.
+          older_active=$(
+            for status in in_progress queued; do
+              p=$(gh_get "${api}/repos/${repo}/actions/workflows/${workflow_id}/runs?status=${status}&per_page=100") || true
+              if [[ -z "${p}" ]]; then
+                echo "LIST_FAILED"
+                continue
+              fi
+              printf '%s' "${p}" | jq -r --argjson mine "${my_number}" \
+                '.workflow_runs[] | select(.run_number < $mine) | "\(.id)\t\(.run_number)"'
+            done
+          )
+          if printf '%s\n' "${older_active}" | grep -q '^LIST_FAILED$'; then
+            list_failed=1
+          fi
+          while IFS=$'\t' read -r other_id other_number; do
+            [[ -z "${other_id}" || "${other_id}" == "LIST_FAILED" ]] && continue
+            [[ "${other_id}" == "${run_id}" ]] && continue
+            jobs=$(gh_get "${api}/repos/${repo}/actions/runs/${other_id}/jobs?per_page=100") || true
+            if [[ -z "${jobs}" ]]; then
+              # Cannot inspect this older active run; be conservative and treat
+              # it as ahead so we do not race past it.
+              ahead_desc="#${other_number} (jobs unavailable)"
+              break
+            fi
+            lane_state=$(printf '%s' "${jobs}" \
+              | jq -r --arg lane "${lane}" \
+                  'first(.jobs[] | select(.name == $lane) | .status) // "absent"')
+            case "${lane_state}" in
+              queued|in_progress|absent)
+                # queued/in_progress: lane job active. absent: older run still
+                # initializing and has not yet created (or skipped) its lane job.
+                ahead_desc="#${other_number} (lane ${lane_state})"
+                break
+                ;;
+              *)
+                # terminal (completed/skipped/cancelled): not blocking
+                ;;
+            esac
+          done < <(printf '%s\n' "${older_active}" | grep -v '^LIST_FAILED$' | sort -t$'\t' -k2 -n)
+
+          if [[ -n "${ahead_desc}" ]]; then
+            :
+          elif [[ "${list_failed}" -eq 1 ]]; then
+            echo "turnstile: Actions API list failed; proceeding (fail-open)"
+            exit 0
+          else
+            echo "turnstile: clear, proceeding"
+            exit 0
+          fi
+
+          now=$(date +%s)
+          if (( now >= deadline )); then
+            echo "turnstile: safety timeout reached while waiting behind ${ahead_desc}; proceeding (fail-open)"
+            exit 0
+          fi
+          jitter=$(( RANDOM % 5 ))
+          echo "turnstile: waiting behind run ${ahead_desc}; re-checking in $(( poll + jitter ))s"
+          sleep $(( poll + jitter ))
+        done

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -49,6 +49,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  actions: read
 
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.workflow, github.event.pull_request.number) || format('push-{0}-{1}', github.workflow, github.run_id) }}
@@ -648,23 +649,31 @@ jobs:
     # here instead of hosted Ubuntu. Large-change PRs (over the changed-file
     # cap) stay on the hosted coverage lane.
     if: ${{ needs.determine-targets.outputs.use_self_hosted_linux == 'true' && needs.determine-targets.outputs.large_change != 'true' && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && (needs.determine-targets.outputs.fallback == 'false' || needs.determine-targets.outputs.fallback_reason == 'coverage_smoke' || needs.determine-targets.outputs.fallback_reason == 'full_test_label'))) }}
-    # Coverage healthy median is ~21 min, so bound this SLA lane at 60 min for
-    # buffer: RE degradation fast-fails (no local fallback, below) instead of
-    # the CPU-capped 2-3 h local re-run that produced the 3.3 h tail.
-    timeout-minutes: 60
+    # Coverage healthy median is ~21 min. This budget now also covers the
+    # re-turnstile queue wait (the job clock runs while the turnstile step
+    # waits its FIFO turn), so it is sized to hold a realistic multi-PR burst
+    # (turnstile cap 150 min below, plus a full build) rather than fail open.
+    # RE-degradation fast-fail is unchanged and lives at the Bazel layer (no
+    # local fallback + --remote_timeout=60s below), so a dead/degraded backend
+    # still fails in about a minute regardless of this backstop; the CPU-capped
+    # 2-3 h local re-run cannot recur because local fallback is disabled.
+    timeout-minutes: 210
     # Admission control on the shared remote-execution backend. Two concurrent
     # instrumented coverage builds were the measured failure that hit the
     # timeout: both self-hosted lanes execute on a shared remote-execution
     # backend that an interactive development host also uses with priority, so
     # two-plus concurrent instrumented builds oversubscribe it and crawl into
-    # the timeout (measured). This group serializes coverage-self-hosted across
-    # all of the operator's in-flight PRs so at most one instrumented coverage
-    # build runs at a time; the CI linux-self-hosted lane uses a separate group.
-    # cancel-in-progress: false never kills a running build (a superseded push
-    # to the SAME PR is already cancelled by the workflow-level group).
-    concurrency:
-      group: donner-selfhosted-coverage-re
-      cancel-in-progress: false
+    # the timeout (measured). Serialization is enforced by the re-turnstile
+    # step below (first step of this job), NOT by a GitHub concurrency group.
+    # A concurrency group caps the queue at one pending run and cancels any
+    # older pending run when a third concurrent run arrives, so a parallel-PR
+    # burst (and every post-merge main coverage run competing for the same
+    # group) drops pending runs and self-clogs. The turnstile instead holds
+    # each run until its turn, FIFO, so N concurrent runs all execute in
+    # submission order and none are cancelled, while still keeping at most one
+    # instrumented coverage build on the backend at a time. The sibling CI
+    # linux-self-hosted lane serializes on its own turnstile lane, so a Linux
+    # build and a coverage build may overlap but two coverage builds never do.
     env:
       # RE-availability SLA: do NOT fall back to local execution when remote
       # execution is unavailable or degraded. A CPU-capped self-hosted runner
@@ -679,9 +688,25 @@ jobs:
       DONNER_COVERAGE_BAZEL_FLAGS: "--remote_local_fallback=false --incompatible_remote_local_fallback_for_remote_cache=false --remote_timeout=60s"
 
     steps:
+      # Checkout first so the local ./.github/actions/re-turnstile action is
+      # present. Checkout does no remote-execution work, so gating the
+      # RE-heavy Bazel steps (below) on the turnstile is what matters.
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+
+      # Serialize instrumented coverage builds on the shared remote-execution
+      # backend without dropping runs. Holds this run (FIFO) until its lane is
+      # free, replacing the old evicting concurrency group. Read-only.
+      - name: Remote-execution turnstile
+        uses: ./.github/actions/re-turnstile
+        with:
+          lane: coverage-self-hosted
+          token: ${{ github.token }}
+          # Below the job's 210 min timeout with room for a full build after
+          # the wait. Beyond this depth the turnstile fails open (bounded
+          # oversubscription, never an evicted/lost run).
+          timeout-minutes: "150"
 
       - name: Sync Bazel toolchain
         # Keep this in sync with CI's self-hosted Linux cleanup (main.yml).

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read
+  actions: read
 
 # Retry policy: network-sensitive steps (checkout, apt install, bazel fetch)
 # are retried to survive transient GitHub/registry outages. Build/test steps
@@ -623,26 +624,30 @@ jobs:
     runs-on: [self-hosted, linux, arm64]
     needs: [gatekeeper, determine-targets]
     if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') && needs.gatekeeper.outputs.use_self_hosted_linux == 'true' && needs.determine-targets.outputs.large_change != 'true' }}
-    # RE-availability SLA lane. A healthy affected-target run is ~21 min; bound
-    # it at 60 min for buffer while a wedged/degraded RE endpoint still
-    # fast-fails instead of silently tailing for hours.
-    timeout-minutes: 60
+    # RE-availability SLA lane. A healthy affected-target run is ~21 min. This
+    # budget now also covers the re-turnstile queue wait (the job clock runs
+    # while the turnstile step waits its FIFO turn), so it is sized to hold a
+    # realistic multi-PR burst (turnstile cap 150 min below, plus a full build)
+    # rather than fail open. RE-degradation fast-fail is unchanged and lives at
+    # the Bazel layer (no local fallback + --remote_timeout=60s below), so a
+    # wedged/degraded backend still fails in about a minute regardless of this
+    # backstop.
+    timeout-minutes: 210
     # Admission control on the shared remote-execution backend. Both self-hosted
     # lanes execute on a shared remote-execution backend that an interactive
     # development host also uses with priority; two-plus concurrent operator PRs
-    # oversubscribe it and crawl into the 60 min timeout (measured). This
-    # per-lane group serializes linux-self-hosted across all of the operator's
-    # in-flight PRs so at most one runs at a time; the sibling
-    # coverage-self-hosted lane has its own group, so a Linux build and a
-    # coverage build may overlap but two of the same heavy lane never do.
-    # Bounding CI's demand on the backend also protects the interactive host's
-    # latency. cancel-in-progress: false never kills a running build (a
-    # superseded push to the SAME PR is already cancelled by the workflow-level
-    # concurrency group). This job-level group composes with the workflow-level
-    # group and with the centralized routing (it is gate-agnostic).
-    concurrency:
-      group: donner-selfhosted-linux-re
-      cancel-in-progress: false
+    # oversubscribe it and crawl into the 60 min timeout (measured).
+    # Serialization is enforced by the re-turnstile step below (after checkout),
+    # NOT by a GitHub concurrency group. A concurrency group caps the queue at
+    # one pending run and cancels any older pending run when a third concurrent
+    # run arrives, so a parallel-PR burst (and every post-merge main run
+    # competing for the same group) drops pending runs. The turnstile instead
+    # holds each run until its turn, FIFO, so N concurrent runs all execute in
+    # submission order and none are cancelled, while keeping at most one Linux
+    # build on the backend at a time. Bounding CI's demand on the backend also
+    # protects the interactive host's latency. The sibling coverage-self-hosted
+    # lane serializes on its own turnstile lane, so a Linux build and a coverage
+    # build may overlap but two of the same heavy lane never do.
     env:
       # The runner host may add the LAN Bazel cache from its home rc. Use that
       # acceleration when healthy, but do NOT fall back to local execution when
@@ -669,10 +674,26 @@ jobs:
       DIAG_BUILD_FLAGS: "--remote_download_outputs=minimal"
       DIAG_TEST_FLAGS: "--remote_download_outputs=minimal --remote_download_regex=.*(test\\.log|test\\.xml|outputs\\.zip)$"
     steps:
+      # Checkout first so the local ./.github/actions/re-turnstile action is
+      # present. Checkout does no remote-execution work, so gating the
+      # RE-heavy Bazel steps (below) on the turnstile is what matters.
       - name: Checkout
         uses: actions/checkout@v7
         with:
           persist-credentials: false
+
+      # Serialize this Linux self-hosted build on the shared remote-execution
+      # backend without dropping runs. Holds this run (FIFO) until its lane is
+      # free, replacing the old evicting concurrency group. Read-only.
+      - name: Remote-execution turnstile
+        uses: ./.github/actions/re-turnstile
+        with:
+          lane: linux-self-hosted
+          token: ${{ github.token }}
+          # Below the job's 210 min timeout with room for a full build after
+          # the wait. Beyond this depth the turnstile fails open (bounded
+          # oversubscription, never an evicted/lost run).
+          timeout-minutes: "150"
 
       - name: Record target selection
         shell: bash


### PR DESCRIPTION
Serialize the two self-hosted CI lanes on the shared remote-execution backend with an in-workflow FIFO turnstile instead of a GitHub concurrency group, so concurrent runs queue instead of being cancelled.

The `coverage-self-hosted` job (`coverage.yml`) and the `linux-self-hosted` job (`main.yml`) each run instrumented or affected-target Bazel builds against a single shared remote-execution backend, and each must run at most one build of its lane at a time or the backend oversubscribes and the jobs crawl into their 60-minute timeout. Until now that limit was enforced with a job-level `concurrency:` group and `cancel-in-progress: false`.

That mechanism drops runs. GitHub native concurrency holds at most one running plus one pending run per group, and when a third concurrent run arrives it cancels the older pending run (it appears as `cancelled` with 0 steps). With several pull requests open at once, and because every push to `main` also starts one of these jobs and competes for the same group, bursts and merges continuously evict each other's pending runs, and the queue has to be drained and re-run by hand.

This replaces each evicting group with a first-party, in-workflow FIFO turnstile.

- A new local composite action, `./.github/actions/re-turnstile`, runs as the first remote-execution step of each self-hosted job (right after checkout, which does no backend work). It waits, oldest run first, until no older run of the same workflow still holds that lane's job, then returns so the build proceeds.
- Ordering is a strict total order on `run_number`, so the oldest run never waits: no cycles, no deadlock, no starvation. N concurrent runs all execute in submission order and none are cancelled.
- The two lanes use independent turnstile keys (their own job names), so a Linux build and a coverage build may overlap, but two builds of the same lane never do. This preserves the previous per-lane serialization exactly.
- Post-merge `main` runs and pull-request runs now share one FIFO queue and coexist without evicting each other, so a merge no longer clogs pull-request CI.

The action is read-only: it lists this repository's own workflow runs and jobs through the Actions REST API with the ambient `github.token` and mutates nothing. It needs `actions: read`, which is granted at the workflow level in both files; no write scope, no lock branch, no external state, and no third-party action. On any API error, rate limit, or the safety timeout, it fails open and proceeds rather than blocking, so a transient API problem can at worst briefly reduce serialization, never wedge a run.

No other job and neither workflow-level per-PR concurrency group is changed.

Verification: `actionlint` and `shellcheck` are clean; the wait and ordering logic was unit-checked against mock API payloads (older-run selection, active-status filtering, and lane-state extraction including the absent / still-initializing case); and concurrent self-hosted runs were triggered to confirm all execute with none cancelled at 0 steps.
