### PR TITLE
Route geode GPU tests to a GPU remote-execution worker via exec_properties

### DIFF
--- a/build_defs/rules.bzl
+++ b/build_defs/rules.bzl
@@ -354,6 +354,8 @@ def donner_variant_cc_test(name, dep, variants = None, named_variants = None, **
                 variant_kwargs["args"] = v["args"]
             if "shard_count" in v:
                 variant_kwargs["shard_count"] = v["shard_count"]
+            if "exec_properties" in v:
+                variant_kwargs["exec_properties"] = v["exec_properties"]
 
             donner_multi_transitioned_test(
                 name = target_name,

--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -457,6 +457,9 @@ donner_multi_transitioned_test(
     testonly = 1,
     dep = ":renderer_geode_golden_tests_impl",
     renderer_backend = "geode",
+    # Route the GPU test action to a remote-execution worker advertising a
+    # hardware GPU. Ignored for local / non-remote execution.
+    exec_properties = {"gpu": "arc"},
 )
 
 donner_cc_test(
@@ -502,6 +505,7 @@ donner_multi_transitioned_test(
     testonly = 1,
     dep = ":renderer_geode_tests_impl",
     renderer_backend = "geode",
+    exec_properties = {"gpu": "arc"},
 )
 
 donner_cc_test(
@@ -629,6 +633,9 @@ donner_variant_cc_test(
             "text_full": "false",
             "args": ["--gtest_filter=-*_TinyGolden"],
             "shard_count": 16,
+            # Route only this GPU variant to a remote-execution worker that
+            # advertises a hardware GPU. Ignored for local / non-remote runs.
+            "exec_properties": {"gpu": "arc"},
         },
     ],
     # Hundreds of independent image comparisons per variant. Unsharded, the


### PR DESCRIPTION
Route the Geode GPU test lane to a dedicated GPU remote-execution worker.

This tags the three Geode GPU test targets (renderer_geode_tests, renderer_geode_golden_tests, and the geode variant of resvg_test_suite) with `exec_properties = {"gpu": "arc"}`. On remote execution the scheduler then routes only those test actions to a worker that advertises `gpu = arc` (a host with a real GPU), while compiles and the CPU-variant tests keep running on the general workers. A small per-variant `exec_properties` passthrough is added to `donner_variant_cc_test`, mirroring the existing `args` and `shard_count` per-variant overrides; the CPU variants are untouched.

`exec_properties` only influence remote-execution placement. Local and Metal runs ignore them, so off-remote behavior is unchanged: the Geode unit suite, the Geode golden suite, and the 16-shard geode resvg suite all pass on macOS/Metal.

DO NOT MERGE YET. This change is inert and unsafe to land until a remote-execution worker advertising `gpu = arc` is live and joined to the scheduler. Until then, tagging these tests with `gpu = arc` leaves the geode test actions with no matching worker on remote execution, so any remote run of them (including CI that routes through remote execution) would fail to schedule. Hold this PR until the GPU worker is up, then land it.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17
