### PR TITLE
Expand SVG2 requirement inventory to document structure (design 0057)

### DIFF
--- a/donner/svg/renderer/tests/pilot_corpus/manifest.json
+++ b/donner/svg/renderer/tests/pilot_corpus/manifest.json
@@ -163,6 +163,135 @@
       "resources": [
         "fonts/NotoSans-Regular.ttf"
       ]
+    },
+    {
+      "id": "resvg/structure/g/deeply-nested-groups",
+      "input": "tests/structure/g/deeply-nested-groups.svg",
+      "oracle": {
+        "kind": "png",
+        "path": "tests/structure/g/deeply-nested-groups.png",
+        "width": 500,
+        "height": 500,
+        "provenance": "upstream-resvg-golden"
+      },
+      "assertion": "Imported resvg base case structure/g/deeply-nested-groups; upstream reference rendering reviewed for SVG 2 requirement mapping in the requirement inventory rationale.",
+      "spec_requirements": [
+        "svg2-cr-20181004/structure/GElement/req-01"
+      ],
+      "capabilities": []
+    },
+    {
+      "id": "resvg/structure/defs/ignore-shapes-inside-defs",
+      "input": "tests/structure/defs/ignore-shapes-inside-defs.svg",
+      "oracle": {
+        "kind": "png",
+        "path": "tests/structure/defs/ignore-shapes-inside-defs.png",
+        "width": 500,
+        "height": 500,
+        "provenance": "upstream-resvg-golden"
+      },
+      "assertion": "Imported resvg base case structure/defs/ignore-shapes-inside-defs; upstream reference rendering reviewed for SVG 2 requirement mapping in the requirement inventory rationale.",
+      "spec_requirements": [
+        "svg2-cr-20181004/structure/DefsElement/req-01"
+      ],
+      "capabilities": []
+    },
+    {
+      "id": "resvg/structure/use/from-defs",
+      "input": "tests/structure/use/from-defs.svg",
+      "oracle": {
+        "kind": "png",
+        "path": "tests/structure/use/from-defs.png",
+        "width": 500,
+        "height": 500,
+        "provenance": "upstream-resvg-golden"
+      },
+      "assertion": "Imported resvg base case structure/use/from-defs; upstream reference rendering reviewed for SVG 2 requirement mapping in the requirement inventory rationale.",
+      "spec_requirements": [
+        "svg2-cr-20181004/structure/UseElement/req-01"
+      ],
+      "capabilities": []
+    },
+    {
+      "id": "resvg/structure/symbol/with-viewBox-and-custom-use-size",
+      "input": "tests/structure/symbol/with-viewBox-and-custom-use-size.svg",
+      "oracle": {
+        "kind": "png",
+        "path": "tests/structure/symbol/with-viewBox-and-custom-use-size.png",
+        "width": 500,
+        "height": 500,
+        "provenance": "upstream-resvg-golden"
+      },
+      "assertion": "Imported resvg base case structure/symbol/with-viewBox-and-custom-use-size; upstream reference rendering reviewed for SVG 2 requirement mapping in the requirement inventory rationale.",
+      "spec_requirements": [
+        "svg2-cr-20181004/structure/UseLayout/req-02"
+      ],
+      "capabilities": []
+    },
+    {
+      "id": "resvg/structure/symbol/unused-symbol",
+      "input": "tests/structure/symbol/unused-symbol.svg",
+      "oracle": {
+        "kind": "png",
+        "path": "tests/structure/symbol/unused-symbol.png",
+        "width": 500,
+        "height": 500,
+        "provenance": "upstream-resvg-golden"
+      },
+      "assertion": "Imported resvg base case structure/symbol/unused-symbol; upstream reference rendering reviewed for SVG 2 requirement mapping in the requirement inventory rationale.",
+      "spec_requirements": [
+        "svg2-cr-20181004/structure/SymbolElement/req-01",
+        "svg2-cr-20181004/structure/SymbolElement/req-02"
+      ],
+      "capabilities": []
+    },
+    {
+      "id": "resvg/structure/symbol/simple-case",
+      "input": "tests/structure/symbol/simple-case.svg",
+      "oracle": {
+        "kind": "png",
+        "path": "tests/structure/symbol/simple-case.png",
+        "width": 500,
+        "height": 500,
+        "provenance": "upstream-resvg-golden"
+      },
+      "assertion": "Imported resvg base case structure/symbol/simple-case; upstream reference rendering reviewed for SVG 2 requirement mapping in the requirement inventory rationale.",
+      "spec_requirements": [
+        "svg2-cr-20181004/structure/SymbolElement/req-03"
+      ],
+      "capabilities": []
+    },
+    {
+      "id": "resvg/structure/switch/simple-case",
+      "input": "tests/structure/switch/simple-case.svg",
+      "oracle": {
+        "kind": "png",
+        "path": "tests/structure/switch/simple-case.png",
+        "width": 500,
+        "height": 500,
+        "provenance": "upstream-resvg-golden"
+      },
+      "assertion": "Imported resvg base case structure/switch/simple-case; upstream reference rendering reviewed for SVG 2 requirement mapping in the requirement inventory rationale.",
+      "spec_requirements": [
+        "svg2-cr-20181004/structure/SwitchElement/req-01"
+      ],
+      "capabilities": []
+    },
+    {
+      "id": "resvg/structure/a/on-shape",
+      "input": "tests/structure/a/on-shape.svg",
+      "oracle": {
+        "kind": "png",
+        "path": "tests/structure/a/on-shape.png",
+        "width": 500,
+        "height": 500,
+        "provenance": "upstream-resvg-golden"
+      },
+      "assertion": "Imported resvg base case structure/a/on-shape; upstream reference rendering reviewed for SVG 2 requirement mapping in the requirement inventory rationale.",
+      "spec_requirements": [
+        "svg2-cr-20181004/linking/AElement/req-01"
+      ],
+      "capabilities": []
     }
   ]
 }

--- a/donner/svg/renderer/tests/pilot_corpus/profile.json
+++ b/donner/svg/renderer/tests/pilot_corpus/profile.json
@@ -4,43 +4,129 @@
   "cases": {
     "resvg/shapes/rect/simple-case": {
       "expectation": "pass",
-      "comparison": {"threshold": 0.02, "max_mismatched_pixels": 100}
+      "comparison": {
+        "threshold": 0.02,
+        "max_mismatched_pixels": 100
+      }
     },
     "resvg/shapes/circle/simple-case": {
       "expectation": "pass",
-      "comparison": {"threshold": 0.02, "max_mismatched_pixels": 100}
+      "comparison": {
+        "threshold": 0.02,
+        "max_mismatched_pixels": 100
+      }
     },
     "resvg/shapes/ellipse/simple-case": {
       "expectation": "pass",
-      "comparison": {"threshold": 0.02, "max_mismatched_pixels": 100}
+      "comparison": {
+        "threshold": 0.02,
+        "max_mismatched_pixels": 100
+      }
     },
     "resvg/shapes/polygon/simple-case": {
       "expectation": "pass",
-      "comparison": {"threshold": 0.02, "max_mismatched_pixels": 100}
+      "comparison": {
+        "threshold": 0.02,
+        "max_mismatched_pixels": 100
+      }
     },
     "resvg/shapes/polyline/simple-case": {
       "expectation": "pass",
-      "comparison": {"threshold": 0.02, "max_mismatched_pixels": 100}
+      "comparison": {
+        "threshold": 0.02,
+        "max_mismatched_pixels": 100
+      }
     },
     "resvg/painting/fill/named-color": {
       "expectation": "pass",
-      "comparison": {"threshold": 0.02, "max_mismatched_pixels": 100}
+      "comparison": {
+        "threshold": 0.02,
+        "max_mismatched_pixels": 100
+      }
     },
     "resvg/painting/fill-opacity/50percent": {
       "expectation": "pass",
-      "comparison": {"threshold": 0.02, "max_mismatched_pixels": 100}
+      "comparison": {
+        "threshold": 0.02,
+        "max_mismatched_pixels": 100
+      }
     },
     "resvg/painting/color/simple-case": {
       "expectation": "pass",
-      "comparison": {"threshold": 0.02, "max_mismatched_pixels": 100}
+      "comparison": {
+        "threshold": 0.02,
+        "max_mismatched_pixels": 100
+      }
     },
     "resvg/painting/fill-rule/evenodd": {
       "expectation": "pass",
-      "comparison": {"threshold": 0.02, "max_mismatched_pixels": 100}
+      "comparison": {
+        "threshold": 0.02,
+        "max_mismatched_pixels": 100
+      }
     },
     "resvg/text/text/simple-case": {
       "expectation": "pass",
-      "comparison": {"threshold": 0.02, "max_mismatched_pixels": 100}
+      "comparison": {
+        "threshold": 0.02,
+        "max_mismatched_pixels": 100
+      }
+    },
+    "resvg/structure/g/deeply-nested-groups": {
+      "expectation": "pass",
+      "comparison": {
+        "threshold": 0.02,
+        "max_mismatched_pixels": 100
+      }
+    },
+    "resvg/structure/defs/ignore-shapes-inside-defs": {
+      "expectation": "pass",
+      "comparison": {
+        "threshold": 0.02,
+        "max_mismatched_pixels": 100
+      }
+    },
+    "resvg/structure/use/from-defs": {
+      "expectation": "pass",
+      "comparison": {
+        "threshold": 0.02,
+        "max_mismatched_pixels": 100
+      }
+    },
+    "resvg/structure/symbol/with-viewBox-and-custom-use-size": {
+      "expectation": "pass",
+      "comparison": {
+        "threshold": 0.02,
+        "max_mismatched_pixels": 100
+      }
+    },
+    "resvg/structure/symbol/unused-symbol": {
+      "expectation": "pass",
+      "comparison": {
+        "threshold": 0.02,
+        "max_mismatched_pixels": 100
+      }
+    },
+    "resvg/structure/symbol/simple-case": {
+      "expectation": "pass",
+      "comparison": {
+        "threshold": 0.02,
+        "max_mismatched_pixels": 100
+      }
+    },
+    "resvg/structure/switch/simple-case": {
+      "expectation": "pass",
+      "comparison": {
+        "threshold": 0.02,
+        "max_mismatched_pixels": 100
+      }
+    },
+    "resvg/structure/a/on-shape": {
+      "expectation": "pass",
+      "comparison": {
+        "threshold": 0.02,
+        "max_mismatched_pixels": 100
+      }
     }
   }
 }

--- a/tools/donner_svg2_suite/spec/requirements.structure.json
+++ b/tools/donner_svg2_suite/spec/requirements.structure.json
@@ -7,7 +7,7 @@
       "spec_revision": "CR-SVG2-20181004",
       "section": "5.2 Grouping: the 'g' element",
       "anchor": "GElement",
-      "assertion": "A 'g' element is a container that groups related graphics elements so that group-level properties and transforms apply to its descendants as a unit.",
+      "assertion": "A 'g' element is a container element that groups related graphics elements and renders them together.",
       "strength": "must",
       "subject": "user-agent",
       "software_classes": [
@@ -291,7 +291,7 @@
       "spec_revision": "CR-SVG2-20181004",
       "section": "5.7.3 The 'switch' element",
       "anchor": "SwitchElement",
-      "assertion": "A 'switch' element processes and renders the first direct child for which the requiredFeatures, requiredExtensions, and systemLanguage attributes all evaluate to true.",
+      "assertion": "A 'switch' element processes and renders the first direct child for which its conditional processing attributes (requiredExtensions and systemLanguage) all evaluate to true.",
       "strength": "must",
       "subject": "user-agent",
       "software_classes": [

--- a/tools/donner_svg2_suite/spec/requirements.structure.json
+++ b/tools/donner_svg2_suite/spec/requirements.structure.json
@@ -1,0 +1,375 @@
+{
+  "schema": "https://donner.graphics/svg2-suite/requirement-v1.schema.json",
+  "baseline": "svg2-cr-20181004",
+  "requirements": [
+    {
+      "id": "svg2-cr-20181004/structure/GElement/req-01",
+      "spec_revision": "CR-SVG2-20181004",
+      "section": "5.2 Grouping: the 'g' element",
+      "anchor": "GElement",
+      "assertion": "A 'g' element is a container that groups related graphics elements so that group-level properties and transforms apply to its descendants as a unit.",
+      "strength": "must",
+      "subject": "user-agent",
+      "software_classes": [
+        "interpreter",
+        "viewer",
+        "high-quality-viewer"
+      ],
+      "processing_modes": [
+        "static",
+        "secure-static"
+      ],
+      "oracle_kinds": [
+        "png"
+      ],
+      "test_ids": [
+        "resvg/structure/g/deeply-nested-groups"
+      ],
+      "review_state": "reviewed",
+      "evidence_state": "covered-pass",
+      "rationale": "Reviewed mapping: the resvg pilot case structure/g/deeply-nested-groups isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test).",
+      "artifacts": [],
+      "source_text_hash": "sha256:3227627c6befada4949ddc6f4ecc517ca9ac3fa1f838b0ac3a711f49119b335c"
+    },
+    {
+      "id": "svg2-cr-20181004/structure/DefsElement/req-01",
+      "spec_revision": "CR-SVG2-20181004",
+      "section": "5.4 Defining content for reuse, and the 'defs' element",
+      "anchor": "DefsElement",
+      "assertion": "Descendants of a 'defs' element are not rendered directly; the user agent style sheet forces display:none on 'defs' with importance over any other rule.",
+      "strength": "must",
+      "subject": "user-agent",
+      "software_classes": [
+        "interpreter",
+        "viewer",
+        "high-quality-viewer"
+      ],
+      "processing_modes": [
+        "static",
+        "secure-static"
+      ],
+      "oracle_kinds": [
+        "png"
+      ],
+      "test_ids": [
+        "resvg/structure/defs/ignore-shapes-inside-defs"
+      ],
+      "review_state": "reviewed",
+      "evidence_state": "covered-pass",
+      "rationale": "Reviewed mapping: the resvg pilot case structure/defs/ignore-shapes-inside-defs isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test).",
+      "artifacts": [],
+      "source_text_hash": "sha256:9c7f14af666d534b85e5eb28c86c6f5732c3bb1cb24268643812686e0cc08469"
+    },
+    {
+      "id": "svg2-cr-20181004/structure/UseElement/req-01",
+      "spec_revision": "CR-SVG2-20181004",
+      "section": "5.6 The 'use' element",
+      "anchor": "UseElement",
+      "assertion": "A 'use' element references another element and renders a copy of it in place of the 'use' element in the document.",
+      "strength": "must",
+      "subject": "user-agent",
+      "software_classes": [
+        "interpreter",
+        "viewer",
+        "high-quality-viewer"
+      ],
+      "processing_modes": [
+        "static",
+        "secure-static"
+      ],
+      "oracle_kinds": [
+        "png"
+      ],
+      "test_ids": [
+        "resvg/structure/use/from-defs"
+      ],
+      "review_state": "reviewed",
+      "evidence_state": "covered-pass",
+      "rationale": "Reviewed mapping: the resvg pilot case structure/use/from-defs isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test).",
+      "artifacts": [],
+      "source_text_hash": "sha256:2977ef24efb216c629ee055ea8dbe61e6ccebfe78d6be94cb7bf7434b9962e0f"
+    },
+    {
+      "id": "svg2-cr-20181004/structure/UseShadowTree/req-01",
+      "spec_revision": "CR-SVG2-20181004",
+      "section": "5.6 The 'use' element",
+      "anchor": "UseShadowTree",
+      "assertion": "If a 'use' element's referenced element is neither an SVG element nor an HTML element that may be included in an SVG container, the reference is invalid and the 'use' element is in error.",
+      "strength": "must",
+      "subject": "user-agent",
+      "software_classes": [
+        "interpreter",
+        "viewer",
+        "high-quality-viewer"
+      ],
+      "processing_modes": [
+        "static",
+        "secure-static"
+      ],
+      "oracle_kinds": [
+        "png"
+      ],
+      "test_ids": [],
+      "review_state": "reviewed",
+      "evidence_state": "missing-test",
+      "rationale": "No portable suite case yet isolates the invalid-target error path; candidate for a Donner extension case.",
+      "artifacts": [],
+      "source_text_hash": "sha256:4bf4ef60c62e81fe014e450978f38b8e490e03f46db51ed37ad914c28ed19270"
+    },
+    {
+      "id": "svg2-cr-20181004/structure/UseShadowTree/req-02",
+      "spec_revision": "CR-SVG2-20181004",
+      "section": "5.6 The 'use' element",
+      "anchor": "UseShadowTree",
+      "assertion": "A 'use' element that references a (shadow-including) ancestor of itself is an invalid circular reference and the 'use' element is in error.",
+      "strength": "must",
+      "subject": "user-agent",
+      "software_classes": [
+        "interpreter",
+        "viewer",
+        "high-quality-viewer"
+      ],
+      "processing_modes": [
+        "static",
+        "secure-static"
+      ],
+      "oracle_kinds": [
+        "png"
+      ],
+      "test_ids": [],
+      "review_state": "reviewed",
+      "evidence_state": "missing-test",
+      "rationale": "Donner exercises circular-use error handling in unit fixtures (testdata/svg2-e-use-*.svg) but no portable suite case is mapped yet; candidate for a Donner extension case.",
+      "artifacts": [],
+      "source_text_hash": "sha256:3c8608b92552216eff6d58a69b50848b4acc27ead501408ca431062e1804b7b6"
+    },
+    {
+      "id": "svg2-cr-20181004/structure/UseLayout/req-01",
+      "spec_revision": "CR-SVG2-20181004",
+      "section": "5.6 The 'use' element",
+      "anchor": "UseLayout",
+      "assertion": "A negative value for the width or height of a 'use' element is an illegal value.",
+      "strength": "must",
+      "subject": "user-agent",
+      "software_classes": [
+        "interpreter",
+        "viewer",
+        "high-quality-viewer"
+      ],
+      "processing_modes": [
+        "static",
+        "secure-static"
+      ],
+      "oracle_kinds": [
+        "png"
+      ],
+      "test_ids": [],
+      "review_state": "reviewed",
+      "evidence_state": "missing-test",
+      "rationale": "No portable suite case yet isolates negative use width/height; candidate for a Donner extension case.",
+      "artifacts": [],
+      "source_text_hash": "sha256:0b5dbf8a12d4a3cc8fcdd3a4e4a4b98b68373e20a66290a36f8b73ed627b988c"
+    },
+    {
+      "id": "svg2-cr-20181004/structure/UseLayout/req-02",
+      "spec_revision": "CR-SVG2-20181004",
+      "section": "5.6 The 'use' element",
+      "anchor": "UseLayout",
+      "assertion": "The width and height properties on a 'use' element override the corresponding properties of a referenced 'svg' or 'symbol' element.",
+      "strength": "must",
+      "subject": "user-agent",
+      "software_classes": [
+        "interpreter",
+        "viewer",
+        "high-quality-viewer"
+      ],
+      "processing_modes": [
+        "static",
+        "secure-static"
+      ],
+      "oracle_kinds": [
+        "png"
+      ],
+      "test_ids": [
+        "resvg/structure/symbol/with-viewBox-and-custom-use-size"
+      ],
+      "review_state": "reviewed",
+      "evidence_state": "covered-pass",
+      "rationale": "Reviewed mapping: the resvg pilot case structure/symbol/with-viewBox-and-custom-use-size isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test).",
+      "artifacts": [],
+      "source_text_hash": "sha256:87ce91aebd50918ab9794685fba499c517775eded8cc67136e2f58233f257234"
+    },
+    {
+      "id": "svg2-cr-20181004/structure/SymbolElement/req-01",
+      "spec_revision": "CR-SVG2-20181004",
+      "section": "5.5 The 'symbol' element",
+      "anchor": "SymbolElement",
+      "assertion": "A 'symbol' element must never be rendered directly; it is rendered only when referenced by a 'use' element.",
+      "strength": "must",
+      "subject": "user-agent",
+      "software_classes": [
+        "interpreter",
+        "viewer",
+        "high-quality-viewer"
+      ],
+      "processing_modes": [
+        "static",
+        "secure-static"
+      ],
+      "oracle_kinds": [
+        "png"
+      ],
+      "test_ids": [
+        "resvg/structure/symbol/unused-symbol"
+      ],
+      "review_state": "reviewed",
+      "evidence_state": "covered-pass",
+      "rationale": "Reviewed mapping: the resvg pilot case structure/symbol/unused-symbol isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test).",
+      "artifacts": [],
+      "source_text_hash": "sha256:c09d5dc814c43c91abbe2ba96f45b187518a53b50d0aa70abe1b5483f2765b9c"
+    },
+    {
+      "id": "svg2-cr-20181004/structure/SymbolElement/req-02",
+      "spec_revision": "CR-SVG2-20181004",
+      "section": "5.5 The 'symbol' element",
+      "anchor": "SymbolElement",
+      "assertion": "The user agent must set display:none on the 'symbol' element via the user agent style sheet, with importance over any other rule.",
+      "strength": "must",
+      "subject": "user-agent",
+      "software_classes": [
+        "interpreter",
+        "viewer",
+        "high-quality-viewer"
+      ],
+      "processing_modes": [
+        "static",
+        "secure-static"
+      ],
+      "oracle_kinds": [
+        "png"
+      ],
+      "test_ids": [
+        "resvg/structure/symbol/unused-symbol"
+      ],
+      "review_state": "reviewed",
+      "evidence_state": "covered-pass",
+      "rationale": "Reviewed mapping: the resvg pilot case structure/symbol/unused-symbol isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test).",
+      "artifacts": [],
+      "source_text_hash": "sha256:084a3f2df6bfc2f4de298f6be72d7da520e02611ea20e235c25d81e31c7e1b09"
+    },
+    {
+      "id": "svg2-cr-20181004/structure/SymbolElement/req-03",
+      "spec_revision": "CR-SVG2-20181004",
+      "section": "5.5 The 'symbol' element",
+      "anchor": "SymbolElement",
+      "assertion": "When referenced by a 'use' element, a 'symbol' element's content is instantiated and rendered.",
+      "strength": "must",
+      "subject": "user-agent",
+      "software_classes": [
+        "interpreter",
+        "viewer",
+        "high-quality-viewer"
+      ],
+      "processing_modes": [
+        "static",
+        "secure-static"
+      ],
+      "oracle_kinds": [
+        "png"
+      ],
+      "test_ids": [
+        "resvg/structure/symbol/simple-case"
+      ],
+      "review_state": "reviewed",
+      "evidence_state": "covered-pass",
+      "rationale": "Reviewed mapping: the resvg pilot case structure/symbol/simple-case isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test).",
+      "artifacts": [],
+      "source_text_hash": "sha256:c09d5dc814c43c91abbe2ba96f45b187518a53b50d0aa70abe1b5483f2765b9c"
+    },
+    {
+      "id": "svg2-cr-20181004/structure/SwitchElement/req-01",
+      "spec_revision": "CR-SVG2-20181004",
+      "section": "5.7.3 The 'switch' element",
+      "anchor": "SwitchElement",
+      "assertion": "A 'switch' element processes and renders the first direct child for which the requiredFeatures, requiredExtensions, and systemLanguage attributes all evaluate to true.",
+      "strength": "must",
+      "subject": "user-agent",
+      "software_classes": [
+        "interpreter",
+        "viewer",
+        "high-quality-viewer"
+      ],
+      "processing_modes": [
+        "static",
+        "secure-static"
+      ],
+      "oracle_kinds": [
+        "png"
+      ],
+      "test_ids": [
+        "resvg/structure/switch/simple-case"
+      ],
+      "review_state": "reviewed",
+      "evidence_state": "covered-pass",
+      "rationale": "Reviewed mapping: the resvg pilot case structure/switch/simple-case isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test).",
+      "artifacts": [],
+      "source_text_hash": "sha256:bac83ab16ad99a6461f86f5d2d182c3437366520da95125896205d93e0acd82f"
+    },
+    {
+      "id": "svg2-cr-20181004/linking/AElement/req-01",
+      "spec_revision": "CR-SVG2-20181004",
+      "section": "16.2 Links out of SVG content: the 'a' element",
+      "anchor": "AElement",
+      "assertion": "An 'a' element is a container that renders its child content and may contain any element its parent may contain, except another 'a' element.",
+      "strength": "must",
+      "subject": "user-agent",
+      "software_classes": [
+        "interpreter",
+        "viewer",
+        "high-quality-viewer"
+      ],
+      "processing_modes": [
+        "static",
+        "secure-static"
+      ],
+      "oracle_kinds": [
+        "png"
+      ],
+      "test_ids": [
+        "resvg/structure/a/on-shape"
+      ],
+      "review_state": "reviewed",
+      "evidence_state": "covered-pass",
+      "rationale": "Reviewed mapping: the resvg pilot case structure/a/on-shape isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test).",
+      "artifacts": [],
+      "source_text_hash": "sha256:49e43e08d744780450546494131213081b3dc1c9997112c7d39215036b4cf7be"
+    },
+    {
+      "id": "svg2-cr-20181004/linking/AElement/req-02",
+      "spec_revision": "CR-SVG2-20181004",
+      "section": "16.2 Links out of SVG content: the 'a' element",
+      "anchor": "AElement",
+      "assertion": "A nested 'a' element (a link within a link) has its href ignored and is treated as inactive, but is still rendered as a generic container element.",
+      "strength": "must",
+      "subject": "user-agent",
+      "software_classes": [
+        "interpreter",
+        "viewer",
+        "high-quality-viewer"
+      ],
+      "processing_modes": [
+        "static",
+        "secure-static"
+      ],
+      "oracle_kinds": [
+        "png"
+      ],
+      "test_ids": [],
+      "review_state": "reviewed",
+      "evidence_state": "missing-test",
+      "rationale": "No portable suite case yet isolates nested-link container rendering; candidate for a Donner extension case.",
+      "artifacts": [],
+      "source_text_hash": "sha256:97d2b9b83dc9f50c4f3be001c2611eaba9ec0ab75c9885951bcca71987d1d968"
+    }
+  ]
+}

--- a/tools/donner_svg2_suite/spec_coverage_lint_tests.py
+++ b/tools/donner_svg2_suite/spec_coverage_lint_tests.py
@@ -101,9 +101,20 @@ class ShippedGraphTest(unittest.TestCase):
             gaps = json.loads((out / "gaps.json").read_text())
             summary = gaps["summary"]
             # Passing evidence is exactly the covered-pass mappings; every other
-            # testable state remains a visible gap.
+            # testable state remains a visible gap. Assert the partition invariant
+            # and that the passing tally counts only covered-pass requirements
+            # (derived from the committed inventories, so adding chapters does not
+            # churn a hardcoded snapshot).
             self.assertEqual(summary["covered_pass"] + summary["gaps"] + summary["not_applicable"], summary["total"])
-            self.assertEqual(summary["covered_pass"], 14)
+            expected_pass = 0
+            expected_total = 0
+            for path in sorted(SPEC_DIR.glob("requirements.*.json")):
+                for req in json.loads(path.read_text())["requirements"]:
+                    expected_total += 1
+                    if req["evidence_state"] == "covered-pass":
+                        expected_pass += 1
+            self.assertEqual(summary["covered_pass"], expected_pass)
+            self.assertEqual(summary["total"], expected_total)
             self.assertGreaterEqual(summary["total"], 35)
             self.assertTrue((out / "requirements.json").is_file())
             self.assertTrue((out / "coverage.json").is_file())


### PR DESCRIPTION
This is slice 4 of the portable Donner SVG2 test suite (design 0057, docs/design_docs/0057-donner_svg2_test_suite.md), the measurement-instrument expansion. It grows the normative requirement inventory beyond shapes and painting into the SVG 2 document structure and linking elements, derived from the locked SVG 2 CR 2018-10-04 baseline (struct.html and linking.html).

Thirteen requirements are added for the g, defs, use, symbol, switch, and a elements. Nine map to reviewed resvg pilot cases that the Donner tiny-skia adapter renders to a match (added to the pilot corpus and profile, verified by the donner_svg2_pilot parity test); the four use and a error-path edge cases stay visible as missing-test gaps, per the design's rule that missing requirements remain gaps rather than exclusions. Each requirement records a verbatim-sentence source hash so a wording change forces re-review, following the Full Normative Compliance Audit section of the design.

The spec_coverage_lint graph stays consistent and the coverage lint unit test now derives its expected passing tally from the committed inventories instead of a hardcoded snapshot. A second, independent review corrected two assertions to match the SVG 2 baseline (switch no longer names the removed requiredFeatures attribute; g is narrowed to the container-grouping fact its oracle proves).

Verification: //donner/svg/renderer/tests:donner_svg2_pilot, //tools/donner_svg2_suite:spec_coverage_lint_tests, and //tools/donner_svg2_suite:manifest_validation_tests all pass.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17