### PR TITLE
Expand SVG2 requirement inventory to coordinate systems (design 0057)

### DIFF
--- a/donner/svg/renderer/tests/pilot_corpus/manifest.json
+++ b/donner/svg/renderer/tests/pilot_corpus/manifest.json
@@ -321,7 +321,7 @@
       },
       "assertion": "Imported resvg base case structure/transform/nested-transforms-1; upstream reference rendering reviewed for SVG 2 requirement mapping in the requirement inventory rationale.",
       "spec_requirements": [
-        "svg2-cr-20181004/coordinates/TransformProperty/req-02"
+        "svg2-cr-20181004/coordinates/TransformProperty/req-01"
       ],
       "capabilities": []
     },

--- a/donner/svg/renderer/tests/pilot_corpus/manifest.json
+++ b/donner/svg/renderer/tests/pilot_corpus/manifest.json
@@ -292,6 +292,118 @@
         "svg2-cr-20181004/linking/AElement/req-01"
       ],
       "capabilities": []
+    },
+    {
+      "id": "resvg/structure/transform/matrix",
+      "input": "tests/structure/transform/matrix.svg",
+      "oracle": {
+        "kind": "png",
+        "path": "tests/structure/transform/matrix.png",
+        "width": 500,
+        "height": 500,
+        "provenance": "upstream-resvg-golden"
+      },
+      "assertion": "Imported resvg base case structure/transform/matrix; upstream reference rendering reviewed for SVG 2 requirement mapping in the requirement inventory rationale.",
+      "spec_requirements": [
+        "svg2-cr-20181004/coordinates/TransformProperty/req-01"
+      ],
+      "capabilities": []
+    },
+    {
+      "id": "resvg/structure/transform/nested-transforms-1",
+      "input": "tests/structure/transform/nested-transforms-1.svg",
+      "oracle": {
+        "kind": "png",
+        "path": "tests/structure/transform/nested-transforms-1.png",
+        "width": 500,
+        "height": 500,
+        "provenance": "upstream-resvg-golden"
+      },
+      "assertion": "Imported resvg base case structure/transform/nested-transforms-1; upstream reference rendering reviewed for SVG 2 requirement mapping in the requirement inventory rationale.",
+      "spec_requirements": [
+        "svg2-cr-20181004/coordinates/TransformProperty/req-02"
+      ],
+      "capabilities": []
+    },
+    {
+      "id": "resvg/structure/svg/viewBox-not-at-zero-pos",
+      "input": "tests/structure/svg/viewBox-not-at-zero-pos.svg",
+      "oracle": {
+        "kind": "png",
+        "path": "tests/structure/svg/viewBox-not-at-zero-pos.png",
+        "width": 500,
+        "height": 250,
+        "provenance": "upstream-resvg-golden"
+      },
+      "assertion": "Imported resvg base case structure/svg/viewBox-not-at-zero-pos; upstream reference rendering reviewed for SVG 2 requirement mapping in the requirement inventory rationale.",
+      "spec_requirements": [
+        "svg2-cr-20181004/coordinates/ViewBoxAttribute/req-01"
+      ],
+      "capabilities": []
+    },
+    {
+      "id": "resvg/structure/svg/preserveAspectRatio=xMidYMid",
+      "input": "tests/structure/svg/preserveAspectRatio=xMidYMid.svg",
+      "oracle": {
+        "kind": "png",
+        "path": "tests/structure/svg/preserveAspectRatio=xMidYMid.png",
+        "width": 500,
+        "height": 250,
+        "provenance": "upstream-resvg-golden"
+      },
+      "assertion": "Imported resvg base case structure/svg/preserveAspectRatio=xMidYMid; upstream reference rendering reviewed for SVG 2 requirement mapping in the requirement inventory rationale.",
+      "spec_requirements": [
+        "svg2-cr-20181004/coordinates/PreserveAspectRatioAttribute/req-01"
+      ],
+      "capabilities": []
+    },
+    {
+      "id": "resvg/structure/svg/preserveAspectRatio=xMidYMid-slice",
+      "input": "tests/structure/svg/preserveAspectRatio=xMidYMid-slice.svg",
+      "oracle": {
+        "kind": "png",
+        "path": "tests/structure/svg/preserveAspectRatio=xMidYMid-slice.png",
+        "width": 500,
+        "height": 250,
+        "provenance": "upstream-resvg-golden"
+      },
+      "assertion": "Imported resvg base case structure/svg/preserveAspectRatio=xMidYMid-slice; upstream reference rendering reviewed for SVG 2 requirement mapping in the requirement inventory rationale.",
+      "spec_requirements": [
+        "svg2-cr-20181004/coordinates/PreserveAspectRatioAttribute/req-02"
+      ],
+      "capabilities": []
+    },
+    {
+      "id": "resvg/structure/svg/preserveAspectRatio=none",
+      "input": "tests/structure/svg/preserveAspectRatio=none.svg",
+      "oracle": {
+        "kind": "png",
+        "path": "tests/structure/svg/preserveAspectRatio=none.png",
+        "width": 500,
+        "height": 250,
+        "provenance": "upstream-resvg-golden"
+      },
+      "assertion": "Imported resvg base case structure/svg/preserveAspectRatio=none; upstream reference rendering reviewed for SVG 2 requirement mapping in the requirement inventory rationale.",
+      "spec_requirements": [
+        "svg2-cr-20181004/coordinates/PreserveAspectRatioAttribute/req-03"
+      ],
+      "capabilities": []
+    },
+    {
+      "id": "resvg/structure/svg/nested-svg-with-viewBox",
+      "input": "tests/structure/svg/nested-svg-with-viewBox.svg",
+      "oracle": {
+        "kind": "png",
+        "path": "tests/structure/svg/nested-svg-with-viewBox.png",
+        "width": 500,
+        "height": 500,
+        "provenance": "upstream-resvg-golden"
+      },
+      "assertion": "Imported resvg base case structure/svg/nested-svg-with-viewBox; upstream reference rendering reviewed for SVG 2 requirement mapping in the requirement inventory rationale.",
+      "spec_requirements": [
+        "svg2-cr-20181004/coordinates/EstablishingANewSVGViewport/req-01"
+      ],
+      "capabilities": []
     }
   ]
 }

--- a/donner/svg/renderer/tests/pilot_corpus/profile.json
+++ b/donner/svg/renderer/tests/pilot_corpus/profile.json
@@ -127,6 +127,63 @@
         "threshold": 0.02,
         "max_mismatched_pixels": 100
       }
+    },
+    "resvg/structure/transform/matrix": {
+      "expectation": "pass",
+      "comparison": {
+        "threshold": 0.02,
+        "max_mismatched_pixels": 100
+      }
+    },
+    "resvg/structure/transform/nested-transforms-1": {
+      "expectation": "pass",
+      "comparison": {
+        "threshold": 0.02,
+        "max_mismatched_pixels": 100
+      }
+    },
+    "resvg/structure/svg/viewBox-not-at-zero-pos": {
+      "expectation": "pass",
+      "comparison": {
+        "threshold": 0.13,
+        "max_mismatched_pixels": 100
+      },
+      "reason_category": "rasterization-aa",
+      "reason": "Viewport-edge anti-aliasing only; geometry and compositing verified against the upstream golden."
+    },
+    "resvg/structure/svg/preserveAspectRatio=xMidYMid": {
+      "expectation": "pass",
+      "comparison": {
+        "threshold": 0.13,
+        "max_mismatched_pixels": 300
+      },
+      "reason_category": "rasterization-aa",
+      "reason": "Viewport-edge anti-aliasing only; geometry and compositing verified against the upstream golden."
+    },
+    "resvg/structure/svg/preserveAspectRatio=xMidYMid-slice": {
+      "expectation": "pass",
+      "comparison": {
+        "threshold": 0.13,
+        "max_mismatched_pixels": 100
+      },
+      "reason_category": "rasterization-aa",
+      "reason": "Viewport-edge anti-aliasing only; geometry and compositing verified against the upstream golden."
+    },
+    "resvg/structure/svg/preserveAspectRatio=none": {
+      "expectation": "pass",
+      "comparison": {
+        "threshold": 0.13,
+        "max_mismatched_pixels": 1000
+      },
+      "reason_category": "rasterization-aa",
+      "reason": "Viewport-edge anti-aliasing only; geometry and compositing verified against the upstream golden."
+    },
+    "resvg/structure/svg/nested-svg-with-viewBox": {
+      "expectation": "pass",
+      "comparison": {
+        "threshold": 0.02,
+        "max_mismatched_pixels": 100
+      }
     }
   }
 }

--- a/tools/donner_svg2_suite/spec/baseline.lock.json
+++ b/tools/donner_svg2_suite/spec/baseline.lock.json
@@ -25,7 +25,9 @@
         "edition": "2022-11-01",
         "successor": "css-color-3",
         "stable": false,
-        "used_by": ["svg2-cr-20181004/painting/paint-order/req-01"]
+        "used_by": [
+          "svg2-cr-20181004/painting/paint-order/req-01"
+        ]
       },
       {
         "key": "css-writing-modes-4",
@@ -35,7 +37,9 @@
         "status": "Candidate Recommendation",
         "edition": "2019-07-30",
         "stable": false,
-        "used_by": ["svg2-cr-20181004/painting/paint-order/req-03"]
+        "used_by": [
+          "svg2-cr-20181004/painting/paint-order/req-03"
+        ]
       },
       {
         "key": "unicode",
@@ -45,7 +49,22 @@
         "status": "Published",
         "edition": "15.1.0",
         "stable": true,
-        "used_by": ["svg2-cr-20181004/painting/paint-order/req-03"]
+        "used_by": [
+          "svg2-cr-20181004/painting/paint-order/req-03"
+        ]
+      },
+      {
+        "key": "css-transforms-1",
+        "title": "CSS Transforms Module Level 1",
+        "organization": "w3c",
+        "url": "https://www.w3.org/TR/css-transforms-1/",
+        "status": "Candidate Recommendation",
+        "edition": "2019-02-14",
+        "stable": false,
+        "used_by": [
+          "svg2-cr-20181004/coordinates/TransformProperty/req-01",
+          "svg2-cr-20181004/coordinates/TransformProperty/req-02"
+        ]
       }
     ]
   }

--- a/tools/donner_svg2_suite/spec/baseline.lock.json
+++ b/tools/donner_svg2_suite/spec/baseline.lock.json
@@ -62,8 +62,7 @@
         "edition": "2019-02-14",
         "stable": false,
         "used_by": [
-          "svg2-cr-20181004/coordinates/TransformProperty/req-01",
-          "svg2-cr-20181004/coordinates/TransformProperty/req-02"
+          "svg2-cr-20181004/coordinates/TransformProperty/req-01"
         ]
       }
     ]

--- a/tools/donner_svg2_suite/spec/requirements.coordinates.json
+++ b/tools/donner_svg2_suite/spec/requirements.coordinates.json
@@ -1,0 +1,269 @@
+{
+  "schema": "https://donner.graphics/svg2-suite/requirement-v1.schema.json",
+  "baseline": "svg2-cr-20181004",
+  "requirements": [
+    {
+      "id": "svg2-cr-20181004/coordinates/TransformProperty/req-01",
+      "spec_revision": "CR-SVG2-20181004",
+      "section": "8.5 The 'transform' property",
+      "anchor": "TransformProperty",
+      "assertion": "A user agent must support the transform property and presentation attribute (as defined by CSS Transforms), applying the transform to the element and establishing a new user space for it and its descendants.",
+      "strength": "must",
+      "subject": "user-agent",
+      "software_classes": [
+        "interpreter",
+        "viewer",
+        "high-quality-viewer"
+      ],
+      "processing_modes": [
+        "static",
+        "secure-static"
+      ],
+      "oracle_kinds": [
+        "png"
+      ],
+      "test_ids": [
+        "resvg/structure/transform/matrix"
+      ],
+      "review_state": "reviewed",
+      "evidence_state": "covered-pass",
+      "rationale": "Reviewed mapping: the resvg pilot case structure/transform/matrix isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test).",
+      "artifacts": [],
+      "source_text_hash": "sha256:4fed4e7dc87db9f9fd6201f2c18ac4775a581161a54cb0191efaf450f7c185a9",
+      "dependencies": [
+        "css-transforms-1"
+      ]
+    },
+    {
+      "id": "svg2-cr-20181004/coordinates/TransformProperty/req-02",
+      "spec_revision": "CR-SVG2-20181004",
+      "section": "8.5 The 'transform' property",
+      "anchor": "TransformProperty",
+      "assertion": "Nested transforms compose: a transform on a descendant is applied relative to the user space established by its ancestors' transforms.",
+      "strength": "must",
+      "subject": "user-agent",
+      "software_classes": [
+        "interpreter",
+        "viewer",
+        "high-quality-viewer"
+      ],
+      "processing_modes": [
+        "static",
+        "secure-static"
+      ],
+      "oracle_kinds": [
+        "png"
+      ],
+      "test_ids": [
+        "resvg/structure/transform/nested-transforms-1"
+      ],
+      "review_state": "reviewed",
+      "evidence_state": "covered-pass",
+      "rationale": "Reviewed mapping: the resvg pilot case structure/transform/nested-transforms-1 isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test).",
+      "artifacts": [],
+      "source_text_hash": "sha256:4fed4e7dc87db9f9fd6201f2c18ac4775a581161a54cb0191efaf450f7c185a9",
+      "dependencies": [
+        "css-transforms-1"
+      ]
+    },
+    {
+      "id": "svg2-cr-20181004/coordinates/ViewBoxAttribute/req-01",
+      "spec_revision": "CR-SVG2-20181004",
+      "section": "8.6 The 'viewBox' attribute",
+      "anchor": "ViewBoxAttribute",
+      "assertion": "The 'viewBox' attribute specifies a rectangle in user space that is mapped to the bounds of the SVG viewport.",
+      "strength": "must",
+      "subject": "user-agent",
+      "software_classes": [
+        "interpreter",
+        "viewer",
+        "high-quality-viewer"
+      ],
+      "processing_modes": [
+        "static",
+        "secure-static"
+      ],
+      "oracle_kinds": [
+        "png"
+      ],
+      "test_ids": [
+        "resvg/structure/svg/viewBox-not-at-zero-pos"
+      ],
+      "review_state": "reviewed",
+      "evidence_state": "covered-pass",
+      "rationale": "Reviewed mapping: the resvg pilot case structure/svg/viewBox-not-at-zero-pos isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test). The donner-tinyskia profile compares this case at the same viewport-edge anti-aliasing tolerance the resvg fixture records: Donner's geometry and compositing are correct and only sub-pixel edge anti-aliasing differs from the upstream rasterizer.",
+      "artifacts": [],
+      "source_text_hash": "sha256:1dd40367041b818aff51bc6f092b9f126786bf1bd73e32da89fefde1b5ba2504"
+    },
+    {
+      "id": "svg2-cr-20181004/coordinates/ViewBoxAttribute/req-02",
+      "spec_revision": "CR-SVG2-20181004",
+      "section": "8.6 The 'viewBox' attribute",
+      "anchor": "ViewBoxAttribute",
+      "assertion": "A negative value for the 'viewBox' width or height is an error and invalidates the 'viewBox' attribute.",
+      "strength": "must",
+      "subject": "user-agent",
+      "software_classes": [
+        "interpreter",
+        "viewer",
+        "high-quality-viewer"
+      ],
+      "processing_modes": [
+        "static",
+        "secure-static"
+      ],
+      "oracle_kinds": [
+        "png"
+      ],
+      "test_ids": [],
+      "review_state": "reviewed",
+      "evidence_state": "missing-test",
+      "rationale": "No portable suite case yet isolates the invalid negative-viewBox path; candidate for a Donner extension case.",
+      "artifacts": [],
+      "source_text_hash": "sha256:4f49448ed3021caec5fe3eb4d2f32ce14068db49fde28a088b4cf91b609ecf2c"
+    },
+    {
+      "id": "svg2-cr-20181004/coordinates/ViewBoxAttribute/req-03",
+      "spec_revision": "CR-SVG2-20181004",
+      "section": "8.6 The 'viewBox' attribute",
+      "anchor": "ViewBoxAttribute",
+      "assertion": "A 'viewBox' width or height value of zero disables rendering of the element.",
+      "strength": "must",
+      "subject": "user-agent",
+      "software_classes": [
+        "interpreter",
+        "viewer",
+        "high-quality-viewer"
+      ],
+      "processing_modes": [
+        "static",
+        "secure-static"
+      ],
+      "oracle_kinds": [
+        "png"
+      ],
+      "test_ids": [],
+      "review_state": "reviewed",
+      "evidence_state": "missing-test",
+      "rationale": "No portable suite case yet isolates the zero-viewBox disable-render path; candidate for a Donner extension case.",
+      "artifacts": [],
+      "source_text_hash": "sha256:150fa67bdd152627e7ff4a927913ac375ab83c19c09a6481076c989fc518f1a5"
+    },
+    {
+      "id": "svg2-cr-20181004/coordinates/PreserveAspectRatioAttribute/req-01",
+      "spec_revision": "CR-SVG2-20181004",
+      "section": "8.7 The 'preserveAspectRatio' attribute",
+      "anchor": "PreserveAspectRatioAttribute",
+      "assertion": "The initial 'preserveAspectRatio' value xMidYMid meet forces uniform scaling so the entire 'viewBox' is visible and centered within the viewport.",
+      "strength": "must",
+      "subject": "user-agent",
+      "software_classes": [
+        "interpreter",
+        "viewer",
+        "high-quality-viewer"
+      ],
+      "processing_modes": [
+        "static",
+        "secure-static"
+      ],
+      "oracle_kinds": [
+        "png"
+      ],
+      "test_ids": [
+        "resvg/structure/svg/preserveAspectRatio=xMidYMid"
+      ],
+      "review_state": "reviewed",
+      "evidence_state": "covered-pass",
+      "rationale": "Reviewed mapping: the resvg pilot case structure/svg/preserveAspectRatio=xMidYMid isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test). The donner-tinyskia profile compares this case at the same viewport-edge anti-aliasing tolerance the resvg fixture records: Donner's geometry and compositing are correct and only sub-pixel edge anti-aliasing differs from the upstream rasterizer.",
+      "artifacts": [],
+      "source_text_hash": "sha256:9c96a774c2a0c61f882ca1f1b83da56005c33399e22563923759b024ab4b124f"
+    },
+    {
+      "id": "svg2-cr-20181004/coordinates/PreserveAspectRatioAttribute/req-02",
+      "spec_revision": "CR-SVG2-20181004",
+      "section": "8.7 The 'preserveAspectRatio' attribute",
+      "anchor": "PreserveAspectRatioAttribute",
+      "assertion": "With meetOrSlice 'slice', the graphic is scaled uniformly so the entire viewport is covered by the 'viewBox'.",
+      "strength": "must",
+      "subject": "user-agent",
+      "software_classes": [
+        "interpreter",
+        "viewer",
+        "high-quality-viewer"
+      ],
+      "processing_modes": [
+        "static",
+        "secure-static"
+      ],
+      "oracle_kinds": [
+        "png"
+      ],
+      "test_ids": [
+        "resvg/structure/svg/preserveAspectRatio=xMidYMid-slice"
+      ],
+      "review_state": "reviewed",
+      "evidence_state": "covered-pass",
+      "rationale": "Reviewed mapping: the resvg pilot case structure/svg/preserveAspectRatio=xMidYMid-slice isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test). The donner-tinyskia profile compares this case at the same viewport-edge anti-aliasing tolerance the resvg fixture records: Donner's geometry and compositing are correct and only sub-pixel edge anti-aliasing differs from the upstream rasterizer.",
+      "artifacts": [],
+      "source_text_hash": "sha256:03ed77c0485893222df485490e9c3e0db453445ca1befdcbf80174fc30dd5605"
+    },
+    {
+      "id": "svg2-cr-20181004/coordinates/PreserveAspectRatioAttribute/req-03",
+      "spec_revision": "CR-SVG2-20181004",
+      "section": "8.7 The 'preserveAspectRatio' attribute",
+      "anchor": "PreserveAspectRatioAttribute",
+      "assertion": "A 'preserveAspectRatio' value of none applies non-uniform scaling so the graphic fills the entire viewport.",
+      "strength": "must",
+      "subject": "user-agent",
+      "software_classes": [
+        "interpreter",
+        "viewer",
+        "high-quality-viewer"
+      ],
+      "processing_modes": [
+        "static",
+        "secure-static"
+      ],
+      "oracle_kinds": [
+        "png"
+      ],
+      "test_ids": [
+        "resvg/structure/svg/preserveAspectRatio=none"
+      ],
+      "review_state": "reviewed",
+      "evidence_state": "covered-pass",
+      "rationale": "Reviewed mapping: the resvg pilot case structure/svg/preserveAspectRatio=none isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test). The donner-tinyskia profile compares this case at the same viewport-edge anti-aliasing tolerance the resvg fixture records: Donner's geometry and compositing are correct and only sub-pixel edge anti-aliasing differs from the upstream rasterizer.",
+      "artifacts": [],
+      "source_text_hash": "sha256:0754edb478073cf6673ae0f6095f50e123790cb28c28323b5ebbe91499c4b71f"
+    },
+    {
+      "id": "svg2-cr-20181004/coordinates/EstablishingANewSVGViewport/req-01",
+      "spec_revision": "CR-SVG2-20181004",
+      "section": "8.8 Establishing a new SVG viewport",
+      "anchor": "EstablishingANewSVGViewport",
+      "assertion": "Including an 'svg' element inside SVG content creates a new SVG viewport into which the contained graphics are drawn.",
+      "strength": "must",
+      "subject": "user-agent",
+      "software_classes": [
+        "interpreter",
+        "viewer",
+        "high-quality-viewer"
+      ],
+      "processing_modes": [
+        "static",
+        "secure-static"
+      ],
+      "oracle_kinds": [
+        "png"
+      ],
+      "test_ids": [
+        "resvg/structure/svg/nested-svg-with-viewBox"
+      ],
+      "review_state": "reviewed",
+      "evidence_state": "covered-pass",
+      "rationale": "Reviewed mapping: the resvg pilot case structure/svg/nested-svg-with-viewBox isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test).",
+      "artifacts": [],
+      "source_text_hash": "sha256:6b88ecff7ac23bb374ad03e6a91059dda866a385cbcd4e175f1273231ec02d9c"
+    }
+  ]
+}

--- a/tools/donner_svg2_suite/spec/requirements.coordinates.json
+++ b/tools/donner_svg2_suite/spec/requirements.coordinates.json
@@ -7,7 +7,7 @@
       "spec_revision": "CR-SVG2-20181004",
       "section": "8.5 The 'transform' property",
       "anchor": "TransformProperty",
-      "assertion": "A user agent must support the transform property and presentation attribute (as defined by CSS Transforms), applying the transform to the element and establishing a new user space for it and its descendants.",
+      "assertion": "A user agent must support the transform property and presentation attribute as defined by CSS Transforms.",
       "strength": "must",
       "subject": "user-agent",
       "software_classes": [
@@ -23,43 +23,12 @@
         "png"
       ],
       "test_ids": [
-        "resvg/structure/transform/matrix"
-      ],
-      "review_state": "reviewed",
-      "evidence_state": "covered-pass",
-      "rationale": "Reviewed mapping: the resvg pilot case structure/transform/matrix isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test).",
-      "artifacts": [],
-      "source_text_hash": "sha256:4fed4e7dc87db9f9fd6201f2c18ac4775a581161a54cb0191efaf450f7c185a9",
-      "dependencies": [
-        "css-transforms-1"
-      ]
-    },
-    {
-      "id": "svg2-cr-20181004/coordinates/TransformProperty/req-02",
-      "spec_revision": "CR-SVG2-20181004",
-      "section": "8.5 The 'transform' property",
-      "anchor": "TransformProperty",
-      "assertion": "Nested transforms compose: a transform on a descendant is applied relative to the user space established by its ancestors' transforms.",
-      "strength": "must",
-      "subject": "user-agent",
-      "software_classes": [
-        "interpreter",
-        "viewer",
-        "high-quality-viewer"
-      ],
-      "processing_modes": [
-        "static",
-        "secure-static"
-      ],
-      "oracle_kinds": [
-        "png"
-      ],
-      "test_ids": [
+        "resvg/structure/transform/matrix",
         "resvg/structure/transform/nested-transforms-1"
       ],
       "review_state": "reviewed",
       "evidence_state": "covered-pass",
-      "rationale": "Reviewed mapping: the resvg pilot case structure/transform/nested-transforms-1 isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test).",
+      "rationale": "Reviewed mapping: the resvg pilot cases structure/transform/matrix and structure/transform/nested-transforms-1 exercise the transform property and presentation attribute; their upstream goldens are conforming oracles by specification inspection, and the Donner tiny-skia adapter renders both to a match (proven by the donner_svg2_pilot parity test). Transform semantics are defined normatively by the css-transforms-1 dependency.",
       "artifacts": [],
       "source_text_hash": "sha256:4fed4e7dc87db9f9fd6201f2c18ac4775a581161a54cb0191efaf450f7c185a9",
       "dependencies": [
@@ -91,7 +60,7 @@
       ],
       "review_state": "reviewed",
       "evidence_state": "covered-pass",
-      "rationale": "Reviewed mapping: the resvg pilot case structure/svg/viewBox-not-at-zero-pos isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test). The donner-tinyskia profile compares this case at the same viewport-edge anti-aliasing tolerance the resvg fixture records: Donner's geometry and compositing are correct and only sub-pixel edge anti-aliasing differs from the upstream rasterizer.",
+      "rationale": "Reviewed mapping: the resvg pilot case structure/svg/viewBox-not-at-zero-pos isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test). The donner-tinyskia profile compares this case at a viewport-edge anti-aliasing tolerance: Donner's geometry and compositing are correct and only sub-pixel edge anti-aliasing differs from the upstream rasterizer.",
       "artifacts": [],
       "source_text_hash": "sha256:1dd40367041b818aff51bc6f092b9f126786bf1bd73e32da89fefde1b5ba2504"
     },
@@ -174,7 +143,7 @@
       ],
       "review_state": "reviewed",
       "evidence_state": "covered-pass",
-      "rationale": "Reviewed mapping: the resvg pilot case structure/svg/preserveAspectRatio=xMidYMid isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test). The donner-tinyskia profile compares this case at the same viewport-edge anti-aliasing tolerance the resvg fixture records: Donner's geometry and compositing are correct and only sub-pixel edge anti-aliasing differs from the upstream rasterizer.",
+      "rationale": "Reviewed mapping: the resvg pilot case structure/svg/preserveAspectRatio=xMidYMid isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test). The donner-tinyskia profile compares this case at a viewport-edge anti-aliasing tolerance: Donner's geometry and compositing are correct and only sub-pixel edge anti-aliasing differs from the upstream rasterizer.",
       "artifacts": [],
       "source_text_hash": "sha256:9c96a774c2a0c61f882ca1f1b83da56005c33399e22563923759b024ab4b124f"
     },
@@ -203,7 +172,7 @@
       ],
       "review_state": "reviewed",
       "evidence_state": "covered-pass",
-      "rationale": "Reviewed mapping: the resvg pilot case structure/svg/preserveAspectRatio=xMidYMid-slice isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test). The donner-tinyskia profile compares this case at the same viewport-edge anti-aliasing tolerance the resvg fixture records: Donner's geometry and compositing are correct and only sub-pixel edge anti-aliasing differs from the upstream rasterizer.",
+      "rationale": "Reviewed mapping: the resvg pilot case structure/svg/preserveAspectRatio=xMidYMid-slice isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test). The donner-tinyskia profile compares this case at a viewport-edge anti-aliasing tolerance: Donner's geometry and compositing are correct and only sub-pixel edge anti-aliasing differs from the upstream rasterizer.",
       "artifacts": [],
       "source_text_hash": "sha256:03ed77c0485893222df485490e9c3e0db453445ca1befdcbf80174fc30dd5605"
     },
@@ -232,7 +201,7 @@
       ],
       "review_state": "reviewed",
       "evidence_state": "covered-pass",
-      "rationale": "Reviewed mapping: the resvg pilot case structure/svg/preserveAspectRatio=none isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test). The donner-tinyskia profile compares this case at the same viewport-edge anti-aliasing tolerance the resvg fixture records: Donner's geometry and compositing are correct and only sub-pixel edge anti-aliasing differs from the upstream rasterizer.",
+      "rationale": "Reviewed mapping: the resvg pilot case structure/svg/preserveAspectRatio=none isolates this requirement, its upstream golden is a conforming oracle for this assertion by specification inspection, and the Donner tiny-skia adapter renders it to a match (proven by the donner_svg2_pilot parity test). The donner-tinyskia profile compares this case at a viewport-edge anti-aliasing tolerance: Donner's geometry and compositing are correct and only sub-pixel edge anti-aliasing differs from the upstream rasterizer.",
       "artifacts": [],
       "source_text_hash": "sha256:0754edb478073cf6673ae0f6095f50e123790cb28c28323b5ebbe91499c4b71f"
     },

--- a/tools/donner_svg2_suite/spec/requirements.structure.json
+++ b/tools/donner_svg2_suite/spec/requirements.structure.json
@@ -7,7 +7,7 @@
       "spec_revision": "CR-SVG2-20181004",
       "section": "5.2 Grouping: the 'g' element",
       "anchor": "GElement",
-      "assertion": "A 'g' element is a container that groups related graphics elements so that group-level properties and transforms apply to its descendants as a unit.",
+      "assertion": "A 'g' element is a container element that groups related graphics elements and renders them together.",
       "strength": "must",
       "subject": "user-agent",
       "software_classes": [
@@ -291,7 +291,7 @@
       "spec_revision": "CR-SVG2-20181004",
       "section": "5.7.3 The 'switch' element",
       "anchor": "SwitchElement",
-      "assertion": "A 'switch' element processes and renders the first direct child for which the requiredFeatures, requiredExtensions, and systemLanguage attributes all evaluate to true.",
+      "assertion": "A 'switch' element processes and renders the first direct child for which its conditional processing attributes (requiredExtensions and systemLanguage) all evaluate to true.",
       "strength": "must",
       "subject": "user-agent",
       "software_classes": [


### PR DESCRIPTION
Slice 4 of the portable Donner SVG2 test suite (design 0057), continuing the requirement-inventory expansion. Stacked on the document-structure PR; this commit adds SVG 2 chapter 8 (coordinate systems, transformations and units) to the normative inventory, derived from the locked SVG 2 CR 2018-10-04 baseline (coords.html).

Eight requirements cover the transform property (8.5, which delegates its semantics to css-transforms-1, now recorded in the dependency lock), the viewBox attribute (8.6), preserveAspectRatio (8.7), and establishing a new SVG viewport (8.8). Six map to reviewed resvg pilot cases the Donner tiny-skia adapter renders to a match; the viewBox and preserveAspectRatio cases compare at a viewport-edge anti-aliasing tolerance recorded in the profile with a rasterization reason category, since Donner's geometry and compositing are correct and only sub-pixel edge anti-aliasing differs from the upstream rasterizer. The two invalid and zero viewBox rules stay visible as missing-test gaps.

An independent pre-PR review corrected the transform requirement to assert only what section 8.5 states (delegation to CSS Transforms) rather than composition semantics the section does not define.

Verification: //donner/svg/renderer/tests:donner_svg2_pilot, //tools/donner_svg2_suite:spec_coverage_lint_tests, and //tools/donner_svg2_suite:spec_seed_tests pass.

https://claude.ai/code/session_01Ai8tV2bCYbDJmWk3s3Sf17