### PR TITLE
Restore static-host Wasm isolation fallback

### DIFF
--- a/.github/workflows/editor_wasm.yml
+++ b/.github/workflows/editor_wasm.yml
@@ -123,7 +123,7 @@ jobs:
         working-directory: donner/editor/wasm/tests
         run: |
           npm ci
-          npx playwright install chromium webkit
+          npx playwright install chromium firefox webkit
 
       - name: Verify renderer selector
         working-directory: donner/editor/wasm/tests
@@ -140,6 +140,47 @@ jobs:
           donner/editor/wasm/stage-compatible-package.sh \
             "${geode_dir}" "${tiny_skia_dir}" "${compatible_dir}"
           echo "compatible_dir=${compatible_dir}" >> "${GITHUB_OUTPUT}"
+
+      - name: Verify static-host isolation fallback
+        env:
+          DONNER_WASM_TEST_ISOLATION_FALLBACK: "1"
+        run: |
+          set -euo pipefail
+
+          pkg_dir="${{ steps.stage-compatible-package.outputs.compatible_dir }}"
+          server_log="${RUNNER_TEMP}/editor-wasm-isolation-fallback-server.log"
+          PYTHONUNBUFFERED=1 python3 tools/http/simple_webserver.py \
+            --no-https --no-cross-origin-isolation --host 127.0.0.1 \
+            --dir "${pkg_dir}" >"${server_log}" 2>&1 &
+          server_pid=$!
+          cleanup() {
+            kill "${server_pid}" 2>/dev/null || true
+            wait "${server_pid}" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          server_url=""
+          for _ in $(seq 1 60); do
+            server_url=$(sed -n 's/^Serving at //p' "${server_log}" | head -n1)
+            if [[ -n "${server_url}" ]]; then break; fi
+            if ! kill -0 "${server_pid}" 2>/dev/null; then
+              cat "${server_log}"
+              wait "${server_pid}" 2>/dev/null || true
+              exit 1
+            fi
+            sleep 1
+          done
+          test -n "${server_url}"
+          export DONNER_WASM_BASE_URL="${server_url}"
+
+          (
+            cd donner/editor/wasm/tests
+            npm run test:isolation-fallback
+            npx playwright test static-host-isolation.spec.ts --browser=firefox
+            npx playwright test static-host-isolation.spec.ts --browser=webkit
+          )
+          cleanup
+          trap - EXIT
 
       - name: Serve compatible package and run headed Geode suite
         env:
@@ -274,6 +315,7 @@ jobs:
             donner_icon.svg \
             editor-bootstrap.js \
             editor.css \
+            enable-threads.js \
             geode/editor.js \
             geode/editor.wasm \
             index.html \
@@ -283,7 +325,8 @@ jobs:
           test "${actual_site_files}" = "${expected_site_files}"
 
           for shared_file in \
-            backend-selector.js donner_icon.svg editor-bootstrap.js editor.css index.html; do
+            backend-selector.js donner_icon.svg editor-bootstrap.js editor.css enable-threads.js \
+            index.html; do
             cp "${site_dir}/${shared_file}" "${deploy_dir}/${shared_file}"
           done
           for backend in geode tiny_skia; do

--- a/docs/design_docs/0056-wasm_ios_runtime_compatibility.md
+++ b/docs/design_docs/0056-wasm_ios_runtime_compatibility.md
@@ -9,7 +9,8 @@
 The web editor ships one static package that selects the best available renderer at runtime. Safari
 26 and newer use the Geode WebGPU backend when WebGPU exposes an adapter. Safari 15.4 and newer
 without WebGPU fall back to the TinySkia WebGL2 backend. Both paths retain the existing pthread
-build and therefore require HTTPS plus cross-origin isolation.
+build and therefore require HTTPS plus cross-origin isolation. Header-capable hosts provide COOP and
+COEP directly; secure static hosts may establish the same policy with the packaged service worker.
 
 This design covers runtime startup and renderer selection on iPhone-class browsers. Responsive
 layout, touch-first controls, mobile toolbars, and other user-interface changes are separate work.
@@ -19,6 +20,7 @@ layout, touch-first controls, mobile toolbars, and other user-interface changes 
 - Start the editor on iOS Safari when the browser exposes `SharedArrayBuffer` and WebGL2.
 - Prefer Geode when a WebGPU adapter is available and use TinySkia otherwise.
 - Keep one immutable deployment candidate containing both reviewed renderer binaries.
+- Start on secure static hosts that cannot configure response headers.
 - Preserve the desktop editor layout and interaction model unchanged.
 - Detect capabilities instead of parsing the browser user agent.
 - Fail clearly before loading Wasm when required browser capabilities are absent.
@@ -30,7 +32,8 @@ layout, touch-first controls, mobile toolbars, and other user-interface changes 
   pthread build; Safari 15.4 adds the narrow `wasm-unsafe-eval` CSP source used by the host.
 - Replacing pthreads with a single-threaded build.
 - Making Geode run where Safari does not expose WebGPU.
-- Adding service-worker-based isolation. Hosts must send COOP and COEP directly.
+- Supporting insecure non-localhost origins.
+- Loading cross-origin subresources that do not opt into the embedder policy.
 
 ## Next Steps
 
@@ -44,7 +47,7 @@ layout, touch-first controls, mobile toolbars, and other user-interface changes 
   - [x] Move bootstrap code and CSS out of inline HTML so a strict CSP needs no inline exceptions.
 - [x] Milestone 2: Build one compatible static package.
   - [x] Add a deterministic staging tool that keeps each backend in its own directory.
-  - [x] Remove the service-worker fallback and require host-provided COOP and COEP.
+  - [x] Add a same-origin service-worker fallback for secure hosts without configurable headers.
   - [x] Include both backend binaries and their hashes in deployment provenance.
 - [x] Milestone 3: Add iOS-shaped browser verification.
   - [x] Run the combined package under Chromium with automatic Geode selection.
@@ -68,6 +71,7 @@ combines their byte-identical shared files with two immutable backend directorie
 index.html
 editor.css
 editor-bootstrap.js
+enable-threads.js
 backend-selector.js
 donner_icon.svg
 geode/editor.js
@@ -81,18 +85,23 @@ automatic mode it requests a WebGPU adapter and selects Geode only when the requ
 otherwise verifies WebGL2 and selects TinySkia. The selected glue file resolves its Wasm file
 relative to its own backend directory.
 
-The host sends `Cross-Origin-Opener-Policy: same-origin` and
-`Cross-Origin-Embedder-Policy: require-corp`. The bootstrap refuses to load either backend when
-`SharedArrayBuffer` is unavailable. Static HTML contains no inline script, inline event handler, or
-inline style, allowing a default-deny CSP with self-hosted script and style exceptions only.
+The preferred host configuration sends `Cross-Origin-Opener-Policy: same-origin` and
+`Cross-Origin-Embedder-Policy: require-corp`. When those headers are absent on a secure origin,
+`enable-threads.js` registers as a same-origin service worker, adds the same headers to successful
+responses, and reloads once it becomes active. It is a no-op when the document is already isolated.
+The bootstrap refuses to load either backend when `SharedArrayBuffer` remains unavailable. Static
+HTML contains no inline script, inline event handler, or inline style, allowing a default-deny CSP
+with self-hosted script and style exceptions only.
 
 ## Security / Privacy
 
 SVG, XML, CSS, and font inputs remain untrusted. This work does not change parser surfaces or grant
-new network access. The static host permits only GET and HEAD, serves the candidate from one origin,
-and applies a default-deny CSP. `script-src` admits same-origin scripts and `wasm-unsafe-eval`;
-`worker-src` admits same-origin and blob workers required by Emscripten pthreads. `connect-src`,
-`img-src`, and `style-src` stay same-origin or narrower.
+new network access. The service worker is packaged on and restricted to the editor origin. It
+forwards requests without caching or rewriting bodies and does not modify opaque responses. The
+static host permits only GET and HEAD, serves the candidate from one origin, and applies a
+default-deny CSP. `script-src` admits same-origin scripts and `wasm-unsafe-eval`; `worker-src` admits
+same-origin and blob workers required by Emscripten pthreads. `connect-src`, `img-src`, and
+`style-src` stay same-origin or narrower.
 
 The selector accepts only two literal backend names. Unit tests reject other values. The combined
 candidate is produced once in CI, records each file hash, and is promoted without rebuilding.
@@ -101,6 +110,10 @@ candidate is produced once in CI, records each file hash, and is promoted withou
 
 - `node --test donner/editor/wasm/tests/backend-selector.spec.mjs` enforces deterministic selection
   and unsupported-capability errors.
+- `node --test donner/editor/wasm/tests/isolation-fallback.spec.mjs` verifies registration, direct
+  header-host no-op behavior, and the service worker's COOP/COEP response policy.
+- The Editor WASM workflow serves the compatible package without host-provided isolation headers
+  and verifies the service-worker reload and runtime startup in Chromium, Firefox, and WebKit.
 - Existing Chromium suites continue to verify both Geode presentation and TinySkia pixels.
 - A Playwright WebKit project uses a real iPhone viewport and device pixel ratio to verify automatic
   TinySkia fallback and stable runtime initialization. A second DPR-1 presentation case verifies
@@ -110,6 +123,8 @@ candidate is produced once in CI, records each file hash, and is promoted withou
 
 ## Rollout Plan
 
-The combined package replaces the Geode-only deployment candidate. Rollback reactivates the prior
-reviewed candidate. Deployment proceeds only after an actual iPhone opens the internal candidate
-and confirms runtime startup; touch and layout findings are recorded for the later UI pass.
+The combined package replaces the Geode-only deployment candidate. Hosts either provide the required
+COOP/COEP headers or allow the packaged same-origin service worker to control the editor scope.
+Rollback reactivates the prior reviewed candidate. Deployment proceeds only after an actual iPhone
+opens the candidate and confirms runtime startup; touch and layout findings are recorded for the
+later UI pass.

--- a/donner/editor/wasm/BUILD.bazel
+++ b/donner/editor/wasm/BUILD.bazel
@@ -122,8 +122,9 @@ wasm_cc_binary(
 web_package(
     name = "wasm_web_package",
     srcs = [
-        "editor-bootstrap.js",
         "editor.css",
+        "editor-bootstrap.js",
+        "enable-threads.js",
         "index.html",
         "single/backend-selector.js",
         "//:donner_icon.svg",
@@ -182,8 +183,9 @@ wasm_cc_binary(
 web_package(
     name = "wasm_tiny_skia_web_package",
     srcs = [
-        "editor-bootstrap.js",
         "editor.css",
+        "editor-bootstrap.js",
+        "enable-threads.js",
         "index.html",
         "single/backend-selector.js",
         "//:donner_icon.svg",

--- a/donner/editor/wasm/enable-threads.js
+++ b/donner/editor/wasm/enable-threads.js
@@ -1,0 +1,76 @@
+// Provides cross-origin isolation on secure static hosts that cannot set response headers.
+
+if (typeof window === "undefined") {
+  self.addEventListener("install", () => self.skipWaiting());
+  self.addEventListener("activate", (event) => event.waitUntil(self.clients.claim()));
+
+  async function AddIsolationHeaders(request) {
+    const response = await fetch(request);
+    if (!response || response.status === 0) {
+      return response;
+    }
+
+    const headers = new Headers(response.headers);
+    headers.set("Cross-Origin-Opener-Policy", "same-origin");
+    headers.set("Cross-Origin-Embedder-Policy", "require-corp");
+    return new Response(response.body, {
+      headers,
+      status: response.status,
+      statusText: response.statusText,
+    });
+  }
+
+  self.addEventListener("fetch", (event) => {
+    event.respondWith(AddIsolationHeaders(event.request));
+  });
+} else {
+  const fallbackScriptUrl = document.currentScript?.src;
+  (async function() {
+    if (window.crossOriginIsolated === true) {
+      return;
+    }
+
+    if (!window.isSecureContext || !("serviceWorker" in navigator) || !fallbackScriptUrl) {
+      console.warn(
+        "COOP/COEP service worker not available on this origin. Use HTTPS or http://localhost.",
+      );
+      return;
+    }
+
+    const registration = await navigator.serviceWorker
+      .register(fallbackScriptUrl)
+      .catch((error) => console.error("COOP/COEP service worker registration failed:", error));
+    if (!registration || navigator.serviceWorker.controller) {
+      return;
+    }
+
+    let reloading = false;
+    const reload = () => {
+      if (!reloading) {
+        reloading = true;
+        window.location.reload();
+      }
+    };
+    const watchWorker = (worker) => {
+      if (!worker) {
+        return;
+      }
+      if (worker.state === "activated") {
+        reload();
+        return;
+      }
+      worker.addEventListener("statechange", () => {
+        if (worker.state === "activated") {
+          reload();
+        }
+      });
+    };
+
+    if (registration.active) {
+      reload();
+      return;
+    }
+    watchWorker(registration.installing || registration.waiting);
+    registration.addEventListener("updatefound", () => watchWorker(registration.installing));
+  })();
+}

--- a/donner/editor/wasm/enable-threads.js
+++ b/donner/editor/wasm/enable-threads.js
@@ -40,7 +40,7 @@ if (typeof window === "undefined") {
     const registration = await navigator.serviceWorker
       .register(fallbackScriptUrl)
       .catch((error) => console.error("COOP/COEP service worker registration failed:", error));
-    if (!registration || navigator.serviceWorker.controller) {
+    if (!registration) {
       return;
     }
 
@@ -51,6 +51,11 @@ if (typeof window === "undefined") {
         window.location.reload();
       }
     };
+    if (navigator.serviceWorker.controller) {
+      reload();
+      return;
+    }
+
     const watchWorker = (worker) => {
       if (!worker) {
         return;

--- a/donner/editor/wasm/index.html
+++ b/donner/editor/wasm/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="donner_icon.svg" type="image/svg+xml" />
     <link rel="stylesheet" href="editor.css" />
+    <script src="enable-threads.js"></script>
     <title>Donner SVG Editor</title>
   </head>
   <body>

--- a/donner/editor/wasm/stage-compatible-package.sh
+++ b/donner/editor/wasm/stage-compatible-package.sh
@@ -16,7 +16,7 @@ if [[ -e "$output_dir" ]]; then
   exit 1
 fi
 
-shared_files=(index.html editor-bootstrap.js editor.css donner_icon.svg)
+shared_files=(index.html editor-bootstrap.js editor.css enable-threads.js donner_icon.svg)
 backend_files=(editor.js editor.wasm)
 for file in "${shared_files[@]}"; do
   [[ -f "${geode_dir}/${file}" ]] || { echo "error: missing Geode ${file}" >&2; exit 1; }
@@ -50,6 +50,7 @@ expected_files="$(printf '%s\n' \
   ./donner_icon.svg \
   ./editor-bootstrap.js \
   ./editor.css \
+  ./enable-threads.js \
   ./geode/editor.js \
   ./geode/editor.wasm \
   ./index.html \

--- a/donner/editor/wasm/tests/isolation-fallback.spec.mjs
+++ b/donner/editor/wasm/tests/isolation-fallback.spec.mjs
@@ -9,7 +9,7 @@ async function loadFallbackSource() {
   return readFile(new URL("../enable-threads.js", import.meta.url), "utf8");
 }
 
-async function runPageFallback({ crossOriginIsolated = false } = {}) {
+async function runPageFallback({ controller = null, crossOriginIsolated = false } = {}) {
   const source = await loadFallbackSource();
   let registeredUrl = null;
   let reloads = 0;
@@ -29,7 +29,7 @@ async function runPageFallback({ crossOriginIsolated = false } = {}) {
     },
   };
   const serviceWorker = {
-    controller: null,
+    controller,
     async register(url) {
       registeredUrl = url;
       return registration;
@@ -95,6 +95,15 @@ test("isolated pages do not register the fallback", async () => {
   assert.deepEqual(result, {
     registeredUrl: null,
     reloads: 0,
+  });
+});
+
+test("newly controlled unisolated pages reload through the fallback", async () => {
+  const result = await runPageFallback({ controller: {} });
+
+  assert.deepEqual(result, {
+    registeredUrl: kFallbackScriptUrl,
+    reloads: 1,
   });
 });
 

--- a/donner/editor/wasm/tests/isolation-fallback.spec.mjs
+++ b/donner/editor/wasm/tests/isolation-fallback.spec.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import vm from "node:vm";
+
+const kFallbackScriptUrl = "https://example.test/enable-threads.js";
+
+async function loadFallbackSource() {
+  return readFile(new URL("../enable-threads.js", import.meta.url), "utf8");
+}
+
+async function runPageFallback({ crossOriginIsolated = false } = {}) {
+  const source = await loadFallbackSource();
+  let registeredUrl = null;
+  let reloads = 0;
+  const registration = {
+    active: {},
+    addEventListener() {},
+  };
+  const document = { currentScript: { src: kFallbackScriptUrl } };
+  const window = {
+    crossOriginIsolated,
+    document,
+    isSecureContext: true,
+    location: {
+      reload() {
+        reloads += 1;
+      },
+    },
+  };
+  const serviceWorker = {
+    controller: null,
+    async register(url) {
+      registeredUrl = url;
+      return registration;
+    },
+  };
+  const context = vm.createContext({
+    console,
+    document,
+    navigator: { serviceWorker },
+    window,
+  });
+
+  vm.runInContext(source, context, { filename: "enable-threads.js" });
+  await new Promise((resolve) => setImmediate(resolve));
+  return { registeredUrl, reloads };
+}
+
+async function runWorkerFallback() {
+  const source = await loadFallbackSource();
+  const listeners = new Map();
+  const context = vm.createContext({
+    console,
+    fetch: async () => new Response("editor"),
+    Headers,
+    Request,
+    Response,
+    self: {
+      addEventListener(type, listener) {
+        listeners.set(type, listener);
+      },
+      clients: { claim: async () => {} },
+      skipWaiting() {},
+    },
+  });
+
+  vm.runInContext(source, context, { filename: "enable-threads.js" });
+  const fetchListener = listeners.get("fetch");
+  assert.equal(typeof fetchListener, "function");
+
+  let responsePromise;
+  fetchListener({
+    request: new Request("https://example.test/index.html"),
+    respondWith(promise) {
+      responsePromise = promise;
+    },
+  });
+  assert.ok(responsePromise);
+  return responsePromise;
+}
+
+test("secure unisolated pages register and activate the isolation fallback", async () => {
+  const result = await runPageFallback();
+
+  assert.deepEqual(result, {
+    registeredUrl: kFallbackScriptUrl,
+    reloads: 1,
+  });
+});
+
+test("isolated pages do not register the fallback", async () => {
+  const result = await runPageFallback({ crossOriginIsolated: true });
+
+  assert.deepEqual(result, {
+    registeredUrl: null,
+    reloads: 0,
+  });
+});
+
+test("fallback responses provide the pthread isolation headers", async () => {
+  const response = await runWorkerFallback();
+
+  assert.equal(response.headers.get("Cross-Origin-Opener-Policy"), "same-origin");
+  assert.equal(response.headers.get("Cross-Origin-Embedder-Policy"), "require-corp");
+});

--- a/donner/editor/wasm/tests/package.json
+++ b/donner/editor/wasm/tests/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "test": "playwright test",
+    "test:isolation-fallback": "playwright test static-host-isolation.spec.ts",
     "test:ios": "playwright test --config=playwright.ios.config.js",
     "test:selector": "node --test backend-selector.spec.mjs isolation-fallback.spec.mjs"
   },

--- a/donner/editor/wasm/tests/package.json
+++ b/donner/editor/wasm/tests/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "test": "playwright test",
     "test:ios": "playwright test --config=playwright.ios.config.js",
-    "test:selector": "node --test backend-selector.spec.mjs"
+    "test:selector": "node --test backend-selector.spec.mjs isolation-fallback.spec.mjs"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1"

--- a/donner/editor/wasm/tests/smoke.spec.ts
+++ b/donner/editor/wasm/tests/smoke.spec.ts
@@ -4,6 +4,7 @@ import { type CanvasColorStats, type CssRegion, readCanvasColorStats } from "./c
 declare global {
   interface Window {
     __donnerBackend?: string;
+    __donnerCanStartWasm?: boolean;
     __donnerLastScrollEvent?: {
       zoomModifierHeld?: boolean;
       yoffset?: number;
@@ -172,6 +173,18 @@ async function openEditor(page: Page, options: OpenEditorOptions = {}): Promise<
   });
 
   await page.goto(url.toString(), { waitUntil: "domcontentloaded" });
+  await expect
+    .poll(async () => {
+      try {
+        return await page.evaluate(() => window.__donnerCanStartWasm === true);
+      } catch {
+        return false;
+      }
+    }, {
+      message: "expected browser capabilities to permit Wasm startup",
+      timeout: 20000,
+    })
+    .toBe(true);
   // The tiny_skia software lane renders through WebGL and does not require
   // WebGPU, so only gate the Geode lane on navigator.gpu.
   if (kBackend !== "tiny_skia") {

--- a/donner/editor/wasm/tests/static-host-isolation.spec.ts
+++ b/donner/editor/wasm/tests/static-host-isolation.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "@playwright/test";
+
+declare global {
+  interface Window {
+    __donnerCanStartWasm?: boolean;
+  }
+}
+
+const kRunFallbackTest = process.env.DONNER_WASM_TEST_ISOLATION_FALLBACK === "1";
+const kFatalRuntimePattern =
+  /Aborted|Assertion failed|RuntimeError|Pthread .* sent an error|WebAssembly runtime unavailable|Unhandled promise rejection/i;
+
+test("secure static host isolation fallback enables Wasm threads", async ({ page }) => {
+  test.skip(!kRunFallbackTest, "requires a server without COOP/COEP response headers");
+
+  const baseUrl = process.env.DONNER_WASM_BASE_URL || "http://127.0.0.1:8000";
+  const fatalMessages: string[] = [];
+  page.on("console", (message) => {
+    if (kFatalRuntimePattern.test(message.text())) {
+      fatalMessages.push(`[console:${message.type()}] ${message.text()}`);
+    }
+  });
+  page.on("pageerror", (error) => fatalMessages.push(`[pageerror] ${error.message}`));
+
+  await page.goto(baseUrl, { waitUntil: "domcontentloaded" });
+
+  await expect
+    .poll(async () => {
+      try {
+        return await page.evaluate(() => ({
+          canStartWasm: window.__donnerCanStartWasm,
+          controllerUrl: navigator.serviceWorker.controller?.scriptURL || null,
+          crossOriginIsolated,
+          hasSharedArrayBuffer: typeof SharedArrayBuffer !== "undefined",
+          isSecureContext,
+        }));
+      } catch {
+        return null;
+      }
+    }, {
+      message: "expected the service worker reload to establish cross-origin isolation",
+      timeout: 20000,
+    })
+    .toEqual({
+      canStartWasm: true,
+      controllerUrl: new URL("enable-threads.js", baseUrl).href,
+      crossOriginIsolated: true,
+      hasSharedArrayBuffer: true,
+      isSecureContext: true,
+    });
+
+  await expect(page.locator("#capability-error")).toBeHidden();
+  await expect(page.locator("canvas#canvas")).toBeVisible();
+  await expect(page.locator("#status")).toBeHidden({ timeout: 30000 });
+  await expect
+    .poll(async () => page.evaluate(() => window.__donnerBackend))
+    .toMatch(/^(geode|tiny_skia)$/);
+  await page.waitForTimeout(1000);
+  expect(fatalMessages).toEqual([]);
+});

--- a/tools/http/simple_webserver.py
+++ b/tools/http/simple_webserver.py
@@ -29,6 +29,12 @@ parser.add_argument(
 parser.add_argument("--certfile", help="path to TLS certificate PEM file")
 parser.add_argument("--keyfile", help="path to TLS private key PEM file")
 parser.add_argument(
+    "--cross-origin-isolation",
+    action=argparse.BooleanOptionalAction,
+    default=True,
+    help="send COOP/COEP response headers (default: on)",
+)
+parser.add_argument(
     "--cert-dir",
     default=os.path.join(os.path.expanduser("~"), ".cache", "donner", "dev-certs"),
     help="directory for auto-generated local certificates",
@@ -47,8 +53,9 @@ if os.path.isfile(serve_dir):
 
 class CrossOriginHandler(http.server.SimpleHTTPRequestHandler):
     def end_headers(self):
-        self.send_header("Cross-Origin-Opener-Policy", "same-origin")
-        self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
+        if args.cross_origin_isolation:
+            self.send_header("Cross-Origin-Opener-Policy", "same-origin")
+            self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
         return super().end_headers()
 
     def do_GET(self) -> None:  # noqa: N802 — overriding stdlib method name


### PR DESCRIPTION
Restores the scoped service-worker isolation fallback removed by design 0056. GitHub Pages custom domains cannot configure COOP/COEP response headers, so the secure page remained non-isolated and could not expose SharedArrayBuffer or Wasm threads.

- Register the fallback only on secure, non-isolated pages, then reload once after activation.
- Add `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` to successful same-origin responses without caching or rewriting bodies.
- Include the worker in Geode, TinySkia, combined staging, and deployment inventories.
- Exercise headerless static hosting in Chromium, Firefox, and WebKit, while preserving the direct-header no-op path.
- Update design 0056 to document both supported isolation mechanisms.

## Testing

- Selector and isolation tests: 13/13 passed.
- Geode and TinySkia Wasm package builds passed.
- Combined package inventory includes `enable-threads.js`.
- Headerless full-runtime tests passed in Chromium, Firefox, and desktop WebKit.
- CMake generation validation, dprint, buildifier, shell syntax, Python syntax, and `git diff --check` passed.
- `bazel test //...`: 756 passed, 1 failed, 102 skipped. The sole failure, `GlRnrReplayTest.ReplaysSourcePaneCharacterInput`, reproduces identically on untouched `origin/main` (expected >100 bright-green pixels; observed 0), so it is a deterministic baseline failure unrelated to this JavaScript/packaging change.