### PR TITLE
Editor: stabilize welcome startup and layer thumbnail smoke check

### DIFF
--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -3556,7 +3556,6 @@ void EditorShell::renderSamplePicker(const ImVec2& paneOrigin, const ImVec2& con
   ImGui::SetCursorPosY(contentRegion.y < 560.0f ? 8.0f : 32.0f);
   ImGui::BeginChild("##sample_picker_content", ImVec2(contentWidth, 0.0f), ImGuiChildFlags_None,
                     ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoSavedSettings);
-  ensureSampleThumbnails();
   const SamplePickerThumbnailProvider thumbnailProvider =
       [this](const EditorSample&, std::size_t index) -> SamplePickerThumbnail {
     if (index >= sampleThumbnailBitmaps_.size() || !sampleThumbnailBitmaps_[index].has_value()) {
@@ -5483,6 +5482,12 @@ void EditorShell::revealSourceRange(SourceByteRange byteRange) {
     textEditor_.flashSourceRange(byteRange);
   }
   window_.wakeEventLoop();
+}
+
+void EditorShell::prepareFrame() {
+  if (showSamplePicker_) {
+    ensureSampleThumbnails();
+  }
 }
 
 void EditorShell::runFrame() {

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -238,6 +238,8 @@ public:
   ~EditorShell();
 
   [[nodiscard]] bool valid() const { return valid_; }
+  /// Perform bounded work that may yield and must run before ImGui::NewFrame().
+  void prepareFrame();
   void runFrame();
 
   /// Font catalog (embedded Google Fonts + macOS system fonts) backing document font resolution

--- a/donner/editor/main.cc
+++ b/donner/editor/main.cc
@@ -74,6 +74,10 @@ void RunEditorFrame(donner::editor::gui::EditorWindow& window, donner::editor::E
     }
   }
   {
+    ZoneScopedN("shell.prepareFrame");
+    shell.prepareFrame();
+  }
+  {
     ZoneScopedN("beginFrame");
     window.beginFrame();
   }

--- a/donner/editor/main.cc
+++ b/donner/editor/main.cc
@@ -96,17 +96,28 @@ void RunEditorFrame(donner::editor::gui::EditorWindow& window, donner::editor::E
 struct WasmEditorLoopState {
   std::unique_ptr<donner::editor::gui::EditorWindow> window;
   std::unique_ptr<donner::editor::EditorShell> shell;
+  bool frameActive = false;
 };
 
 void RunWasmEditorFrame(void* userdata) {
   auto* state = static_cast<WasmEditorLoopState*>(userdata);
+  // Synchronous browser calls proxied from the pthread can let WebKit service
+  // another requestAnimationFrame callback before the suspended frame resumes.
+  // A nested frame would call ImGui::NewFrame() twice without an intervening
+  // Render() and recurse until the JS stack overflows. Drop that callback; the
+  // active frame will finish and the browser will schedule the next one.
+  if (state->frameActive) {
+    return;
+  }
   if (state->window->shouldClose()) {
     emscripten_cancel_main_loop();
     delete state;
     return;
   }
 
+  state->frameActive = true;
   RunEditorFrame(*state->window, *state->shell);
+  state->frameActive = false;
 }
 #endif
 

--- a/donner/editor/repro/GlRnrReplay.cc
+++ b/donner/editor/repro/GlRnrReplay.cc
@@ -610,6 +610,7 @@ bool RunGlRnrReplay(const GlRnrReplayOptions& options, GlRnrReplayResult* result
 
     const std::uint64_t holdPollCountBefore = replayRenderer.replayResultHoldPollCountForTesting();
     window.pollEvents();
+    shell.prepareFrame();
     window.beginFrameWithInput(options.driveDocumentSpaceInput ? NonCanvasInputFromFrame(frame)
                                                                : InputFromFrame(frame));
     if (frame.viewport.has_value()) {

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -3798,7 +3798,7 @@ TEST(EditorShellTest, ShapeClipboardRejectsMalformedAndPastesIntoSelectedGroup) 
   EXPECT_LT(pastedOffset, groupCloseOffset);
 }
 
-TEST(EditorShellTest, SamplePickerRenderGeneratesThumbnailsAcrossFrames) {
+TEST(EditorShellTest, SamplePickerPreparationGeneratesThumbnailsOutsideImGuiFrame) {
   gui::EditorWindow window = MakeHiddenWindow();
   if (!window.valid()) {
     GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
@@ -3810,14 +3810,22 @@ TEST(EditorShellTest, SamplePickerRenderGeneratesThumbnailsAcrossFrames) {
   const std::size_t sampleCount = GetEditorSampleCatalog().size();
   ASSERT_GT(sampleCount, 0u);
 
-  // Showing the picker routes runFrame through renderSamplePicker(), which lazily
-  // rasterizes one thumbnail per frame via ensureSampleThumbnails().
+  // Thumbnail rasterization is bounded to one sample per pre-frame preparation.
+  // The ImGui frame only uploads and presents completed bitmaps.
   EditorShellTestAccess::SetShowSamplePicker(shell, true);
   EXPECT_EQ(EditorShellTestAccess::SampleThumbnailCursor(shell), 0u);
 
-  // Generation advances at most one sample per frame, so drive enough frames to
-  // let the cursor walk the whole catalog and leave headroom for the final pass.
+  // Rendering the picker without preparation must not rasterize inside the active
+  // ImGui frame.
+  window.beginFrame();
+  shell.runFrame();
+  window.endFrame();
+  EXPECT_EQ(EditorShellTestAccess::SampleThumbnailCursor(shell), 0u);
+
+  // Generation advances at most one sample per preparation, so drive enough
+  // frames to let the cursor walk the whole catalog.
   for (std::size_t frame = 0; frame < sampleCount + 3u; ++frame) {
+    shell.prepareFrame();
     window.beginFrame();
     shell.runFrame();
     window.endFrame();
@@ -3835,6 +3843,7 @@ TEST(EditorShellTest, SamplePickerRenderGeneratesThumbnailsAcrossFrames) {
 
   // Re-running frames past the end of the catalog is idempotent: the cursor stays
   // clamped and no additional thumbnails are produced.
+  shell.prepareFrame();
   window.beginFrame();
   shell.runFrame();
   window.endFrame();

--- a/donner/editor/wasm/tests/smoke.spec.ts
+++ b/donner/editor/wasm/tests/smoke.spec.ts
@@ -27,6 +27,7 @@ const kFatalRuntimePattern =
   /Aborted|Assertion failed|RuntimeError|Pthread .* sent an error|getJsObject|No available adapters|WebGPU on Linux requires|WebGPU adapter (?:request )?(?:failed|unavailable)/i;
 const kSourcePaneWidth = 560;
 const kRightPaneWidth = 420;
+const kWelcomeContentMaxWidth = 920;
 
 // Which renderer backend the served package was built with. The Geode/WebGPU
 // lane publishes window.__donnerWgpuReadbackStats (its swapchain pixels never
@@ -206,6 +207,32 @@ async function openEditor(page: Page, options: OpenEditorOptions = {}): Promise<
   return fatalMessages;
 }
 
+async function dismissWelcomePicker(page: Page) {
+  const canvas = page.locator("canvas#canvas");
+  const bounds = await canvas.boundingBox();
+  expect(bounds).not.toBeNull();
+  if (bounds === null) {
+    return;
+  }
+
+  const contentWidth = Math.min(kWelcomeContentMaxWidth, bounds.width - 32);
+  const contentLeft = (bounds.width - contentWidth) * 0.5;
+  const inputPrimePosition = {
+    x: contentLeft + contentWidth - 100,
+    y: 75,
+  };
+  const dismissPosition = {
+    x: contentLeft + contentWidth - 30,
+    y: 75,
+  };
+  // emscripten-glfw consumes mouse transitions on rendered frames. Prime the
+  // canvas in inert header space before activating the dismiss button.
+  await canvas.click({ position: inputPrimePosition });
+  await page.waitForTimeout(100);
+  await canvas.click({ position: dismissPosition });
+  await page.waitForTimeout(100);
+}
+
 test("wasm editor starts without runtime abort", async ({ page }) => {
   const fatalMessages = await openEditor(page);
 
@@ -266,15 +293,26 @@ test("wasm editor renders colored document pixels", async ({ page }) => {
 
 test("wasm editor renders layer panel thumbnails", async ({ page }) => {
   const fatalMessages = await openEditor(page);
-  await expect
-    .poll(async () => {
-      const stats = await readLayerPreviewColorStats(page);
-      return stats.coloredPixels > 100 && stats.maxChannel > 80;
-    }, {
-      message: "expected colored thumbnail pixels in the Layers panel preview column",
-      timeout: 20000,
-    })
-    .toBe(true);
+  await dismissWelcomePicker(page);
+  try {
+    await expect
+      .poll(async () => {
+        const stats = await readLayerPreviewColorStats(page);
+        return stats.coloredPixels > 100 && stats.maxChannel > 80;
+      }, {
+        message: "expected colored thumbnail pixels in the Layers panel preview column",
+        timeout: 20000,
+      })
+      .toBe(true);
+  } catch (error) {
+    const stats = await readLayerPreviewColorStats(page);
+    console.log(`layer-preview-stats=${JSON.stringify(stats)}`);
+    await test.info().attach("layer-preview-stats", {
+      body: JSON.stringify(stats, null, 2),
+      contentType: "application/json",
+    });
+    throw error;
+  }
 
   expect(fatalMessages).toEqual([]);
 });

--- a/donner/editor/wasm/tests/static-host-isolation.spec.ts
+++ b/donner/editor/wasm/tests/static-host-isolation.spec.ts
@@ -12,6 +12,10 @@ const kFatalRuntimePattern =
 
 test("secure static host isolation fallback enables Wasm threads", async ({ page }) => {
   test.skip(!kRunFallbackTest, "requires a server without COOP/COEP response headers");
+  // A cold browser may need both a service-worker activation reload and a
+  // separate pthread Wasm startup, whose existing phase deadlines exceed the
+  // suite's 30-second default when combined.
+  test.setTimeout(60_000);
 
   const baseUrl = process.env.DONNER_WASM_BASE_URL || "http://127.0.0.1:8000";
   const fatalMessages: string[] = [];

--- a/donner/svg/renderer/RenderingContext.cc
+++ b/donner/svg/renderer/RenderingContext.cc
@@ -428,17 +428,20 @@ public:
     }
   }
 
-  /**
-   * Traverse a tree, instantiating each entity in the tree.
-   *
-   * @param treeEntity Current entity in the tree or shadow tree.
-   * @param lastRenderedEntityIfSubtree Optional, entity of the last rendered element if this is a
-   *   subtree.
-   * @return The last rendered entity.
-   */
+  struct PreparedTraversalNode {
+    Entity styleEntity = entt::null;
+    bool traverseChildren = false;
+    bool selectSwitchChild = false;
+    int layerDepth = 0;
+    std::optional<ContextPaintServers> savedContextPaintServers;
+  };
+
+  /// Instantiate one tree entity and retain only the state needed while its
+  /// children are traversed. Keeping this large operation out of the recursive
+  /// DFS bounds native/WASM call-frame usage on browsers with small stacks.
   // TODO(jwmcglynn): Since 'stroke' and 'fill' may reference the same tree, we need to create two
   // instances of it in the render tree.
-  void traverseTree(Entity treeEntity, Entity* lastRenderedEntityIfSubtree = nullptr) {
+  std::optional<PreparedTraversalNode> prepareTraversalNode(Entity treeEntity) {
     const auto* shadowEntityComponent = registry_.try_get<ShadowEntityComponent>(treeEntity);
     const Entity styleEntity = treeEntity;
     const EntityHandle dataHandle(
@@ -450,7 +453,7 @@ public:
     const bool isShape = dataHandle.all_of<ComputedPathComponent>();
 
     if (!dataHandle.all_of<ElementTypeComponent>()) {
-      return;
+      return std::nullopt;
     }
 
     // Conditional-processing attributes (requiredExtensions, systemLanguage) disable rendering of
@@ -459,7 +462,7 @@ public:
     // intentionally not affected, matching resvg.
     if (const auto* conditional = dataHandle.try_get<ConditionalProcessingComponent>();
         conditional && !EvaluateConditionalProcessing(*conditional, userLanguages_)) {
-      return;
+      return std::nullopt;
     }
 
     // ShadowOnlyChildren elements (e.g., <mask>, <pattern>) don't render content in the light
@@ -470,7 +473,7 @@ public:
 
     if (const auto* behavior = dataHandle.try_get<RenderingBehaviorComponent>()) {
       if (behavior->behavior == RenderingBehavior::Nonrenderable && !ignoreNonrenderable_) {
-        return;
+        return std::nullopt;
       } else if (behavior->behavior == RenderingBehavior::NoTraverseChildren) {
         traverseChildren = false;
       } else if (behavior->behavior == RenderingBehavior::ShadowOnlyChildren) {
@@ -485,7 +488,7 @@ public:
     const auto& properties = styleComponent.properties.value();
 
     if (properties.display.get().value() == Display::None) {
-      return;
+      return std::nullopt;
     }
 
     bool isEmpty = false;
@@ -501,7 +504,7 @@ public:
     }
 
     if (isEmpty) {
-      return;
+      return std::nullopt;
     }
 
     if (auto maybeClipRect = LayoutSystem().clipRect(EntityHandle(registry_, treeEntity))) {
@@ -694,9 +697,31 @@ public:
 
     lastRenderedEntity_ = styleEntity;
 
-    if (traverseChildren) {
+    return PreparedTraversalNode{
+        .styleEntity = styleEntity,
+        .traverseChildren = traverseChildren,
+        .selectSwitchChild = dataHandle.get<ElementTypeComponent>().type() == ElementType::Switch,
+        .layerDepth = layerDepth,
+        .savedContextPaintServers = std::move(savedContextPaintServers),
+    };
+  }
+
+  /**
+   * Traverse a tree, instantiating each entity in the tree.
+   *
+   * @param treeEntity Current entity in the tree or shadow tree.
+   * @param lastRenderedEntityIfSubtree Optional, entity of the last rendered element if this is a
+   *   subtree.
+   */
+  void traverseTree(Entity treeEntity, Entity* lastRenderedEntityIfSubtree = nullptr) {
+    std::optional<PreparedTraversalNode> prepared = prepareTraversalNode(treeEntity);
+    if (!prepared.has_value()) {
+      return;
+    }
+
+    if (prepared->traverseChildren) {
       const auto& tree = registry_.get<donner::components::TreeComponent>(treeEntity);
-      if (dataHandle.get<ElementTypeComponent>().type() == ElementType::Switch) {
+      if (prepared->selectSwitchChild) {
         // <switch> renders only the first direct child whose conditional-processing attributes
         // all evaluate to true.
         if (const Entity selectedChild = selectSwitchChild(tree); selectedChild != entt::null) {
@@ -710,12 +735,13 @@ public:
       }
     }
 
-    if (layerDepth > 0) {
-      instance.subtreeInfo = SubtreeInfo{styleEntity, lastRenderedEntity_, layerDepth};
+    if (prepared->layerDepth > 0) {
+      registry_.get<RenderingInstanceComponent>(prepared->styleEntity).subtreeInfo =
+          SubtreeInfo{prepared->styleEntity, lastRenderedEntity_, prepared->layerDepth};
     }
 
-    if (savedContextPaintServers) {
-      contextPaintServers_ = savedContextPaintServers.value();
+    if (prepared->savedContextPaintServers) {
+      contextPaintServers_ = std::move(prepared->savedContextPaintServers).value();
     }
 
     if (lastRenderedEntityIfSubtree) {


### PR DESCRIPTION
Stabilizes Editor WASM welcome startup and updates the layer-thumbnail smoke check for the canvas-rendered picker.

## Summary

- rasterize one sample thumbnail in a bounded pre-frame phase before `ImGui::NewFrame()`
- keep production and replay frame lifecycles aligned, with a regression test proving picker rendering no longer performs thumbnail rasterization inside ImGui
- dismiss the welcome picker before sampling the Layers panel in the browser smoke test
- attach native layer-preview pixel statistics when the browser assertion fails
- reject reentrant WebKit animation-frame callbacks while an Editor WASM frame is suspended in a proxied browser call
- move per-node render-tree preparation out of the recursive traversal frame to avoid WebKit WASM stack exhaustion without changing traversal order or semantics
- give the static-host fallback test an aggregate budget that covers its existing isolation and cold-start phase deadlines

## Testing

- `//donner/editor/tests:editor_shell_tests`
- focused sample-picker lifecycle regression
- `//donner/svg/renderer/tests:renderer_driver_tests`
- switch-element focused SVG tests
- CMake graph validation
- Geode and TinySkia Editor WASM package builds
- CI-shaped iPhone WebKit TinySkia fallback and document-pixel tests
- static-host isolation fallback in Chromium, Firefox, and WebKit
- Geode focused layer-thumbnail test, 3 concurrent repetitions
- TinySkia focused layer-thumbnail test, 3 concurrent repetitions
- complete TinySkia Editor WASM smoke suite