### PR TITLE
Add the donner::gpu RHI core: descriptors, validation, and recording backend

### DIFF
--- a/build_defs/check_banned_patterns.py
+++ b/build_defs/check_banned_patterns.py
@@ -141,6 +141,11 @@ _RULES: List[_Rule] = [
         # construct test fixtures that compile pipelines for shader-only
         # validation; they're exempt because the test binary's wgpu::Device
         # goes away at process exit, not during the test run.
+        # donner/gpu/** is the Donner-owned GPU runtime (design 0053):
+        # `donner::gpu::Device::createRenderPipeline` is that runtime's own validated API, not a
+        # wgpu-native pipeline constructor, and its recording backend never touches a driver.
+        # Pipeline ownership rules for the new runtime are enforced by its Device API and model
+        # tests.
         exempt_path_prefixes=(
             "donner/svg/renderer/geode/GeodePipeline.cc",
             "donner/svg/renderer/geode/GeodeImagePipeline.cc",
@@ -148,6 +153,7 @@ _RULES: List[_Rule] = [
             "donner/svg/renderer/geode/GeodeCheckerboardPipeline.cc",
             "donner/svg/renderer/geode/tests/GeoEncoder_tests.cc",
             "donner/svg/renderer/geode/tests/GeodeShaders_tests.cc",
+            "donner/gpu/",
         ),
     ),
     _Rule(

--- a/donner/gpu/BUILD.bazel
+++ b/donner/gpu/BUILD.bazel
@@ -1,0 +1,30 @@
+load("//build_defs:rules.bzl", "donner_cc_library", "donner_cc_test")
+load("//build_defs:visibility.bzl", "donner_internal_visibility")
+
+# donner::gpu - the Donner-owned GPU runtime (design doc 0053).
+#
+# Packet 2 of the design's change sequence: typed immutable descriptors, explicit Result/Status
+# errors, move-only generation-checked handles, fail-closed validation shared by every backend,
+# and the deterministic recording backend. Platform backends and the shader IR land in later
+# packets; production rendering stays on the existing Geode path until then.
+
+donner_cc_library(
+    name = "gpu",
+    srcs = [
+        "Descriptors.cc",
+        "GpuError.cc",
+    ],
+    hdrs = [
+        "CheckedArithmetic.h",
+        "Commands.h",
+        "Descriptors.h",
+        "GpuError.h",
+        "GpuLimits.h",
+        "GpuResult.h",
+        "Handles.h",
+    ],
+    visibility = donner_internal_visibility(),
+    deps = [
+        "//donner/base",
+    ],
+)

--- a/donner/gpu/BUILD.bazel
+++ b/donner/gpu/BUILD.bazel
@@ -11,17 +11,23 @@ load("//build_defs:visibility.bzl", "donner_internal_visibility")
 donner_cc_library(
     name = "gpu",
     srcs = [
+        "CommandEncoder.cc",
         "Descriptors.cc",
+        "Device.cc",
         "GpuError.cc",
+        "RecordingDevice.cc",
     ],
     hdrs = [
         "CheckedArithmetic.h",
+        "CommandEncoder.h",
         "Commands.h",
         "Descriptors.h",
+        "Device.h",
         "GpuError.h",
         "GpuLimits.h",
         "GpuResult.h",
         "Handles.h",
+        "RecordingDevice.h",
     ],
     visibility = donner_internal_visibility(),
     deps = [

--- a/donner/gpu/BUILD.bazel
+++ b/donner/gpu/BUILD.bazel
@@ -34,3 +34,20 @@ donner_cc_library(
         "//donner/base",
     ],
 )
+
+donner_cc_test(
+    name = "gpu_tests",
+    srcs = [
+        "tests/CommandEncoder_tests.cc",
+        "tests/DeviceValidation_tests.cc",
+        "tests/GpuResult_tests.cc",
+        "tests/GpuTestUtils.h",
+        "tests/HandleLifetime_tests.cc",
+        "tests/Handles_tests.cc",
+        "tests/RecordingDevice_tests.cc",
+    ],
+    deps = [
+        ":gpu",
+        "@com_google_gtest//:gtest_main",
+    ],
+)

--- a/donner/gpu/CheckedArithmetic.h
+++ b/donner/gpu/CheckedArithmetic.h
@@ -1,0 +1,44 @@
+#pragma once
+/// @file
+/// Overflow-checked integer arithmetic for GPU byte-size and extent math.
+
+#include <cstdint>
+#include <optional>
+
+namespace donner::gpu {
+
+/**
+ * Overflow-checked addition of unsigned 64-bit sizes.
+ *
+ * All byte-size and extent arithmetic in the GPU runtime is checked (design
+ * 0053 "Security and Reliability"): untrusted SVG content controls geometry
+ * volume and image sizes, so silent wraparound must be impossible.
+ *
+ * @param a First operand.
+ * @param b Second operand.
+ * @return The sum, or \c std::nullopt on overflow.
+ */
+inline std::optional<uint64_t> CheckedAdd(uint64_t a, uint64_t b) {
+  uint64_t result = 0;
+  if (__builtin_add_overflow(a, b, &result)) {
+    return std::nullopt;
+  }
+  return result;
+}
+
+/**
+ * Overflow-checked multiplication of unsigned 64-bit sizes.
+ *
+ * @param a First operand.
+ * @param b Second operand.
+ * @return The product, or \c std::nullopt on overflow.
+ */
+inline std::optional<uint64_t> CheckedMul(uint64_t a, uint64_t b) {
+  uint64_t result = 0;
+  if (__builtin_mul_overflow(a, b, &result)) {
+    return std::nullopt;
+  }
+  return result;
+}
+
+}  // namespace donner::gpu

--- a/donner/gpu/CommandEncoder.cc
+++ b/donner/gpu/CommandEncoder.cc
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <format>
 #include <utility>
+#include <vector>
 
 #include "donner/gpu/CheckedArithmetic.h"
 
@@ -90,6 +91,8 @@ Result<RenderPassEncoder*> CommandEncoder::beginRenderPass(const RenderPassDescr
   }
 
   Extent2d passExtent;
+  std::vector<Device::ResourceIdentity> seenViews;
+  seenViews.reserve(descriptor.colorAttachments.size());
   for (size_t i = 0; i < descriptor.colorAttachments.size(); ++i) {
     const RenderPassColorAttachment& attachment = descriptor.colorAttachments[i];
     auto viewRecord =
@@ -97,7 +100,29 @@ Result<RenderPassEncoder*> CommandEncoder::beginRenderPass(const RenderPassDescr
     if (viewRecord.hasError()) {
       return fail(std::move(viewRecord).error()).error();
     }
-    if (!HasAllFlags(viewRecord.result()->textureUsage, TextureUsage::RenderAttachment)) {
+
+    const Device::ResourceIdentity viewIdentity{attachment.view.slotIndex(),
+                                                attachment.view.generation()};
+    for (const Device::ResourceIdentity& seenView : seenViews) {
+      if (seenView == viewIdentity) {
+        return fail(Err(GpuErrorType::InvalidDescriptor,
+                        std::format("beginRenderPass: attachment {} view \"{}\" appears in "
+                                    "multiple color attachments of the same pass",
+                                    i, viewRecord.result()->descriptor.label.str())))
+            .error();
+      }
+    }
+    seenViews.push_back(viewIdentity);
+
+    // Re-resolve the viewed texture so a view of a destroyed (or slot-reused) texture fails
+    // closed here instead of aliasing another texture.
+    auto viewedTexture = device_->resolveViewedTexture(*viewRecord.result());
+    if (viewedTexture.hasError()) {
+      return fail(std::move(viewedTexture).error()).error();
+    }
+    const TextureDescriptor& textureDescriptor = viewedTexture.result()->descriptor;
+
+    if (!HasAllFlags(textureDescriptor.usage, TextureUsage::RenderAttachment)) {
       return fail(Err(GpuErrorType::UsageMismatch,
                       std::format("beginRenderPass: attachment {} view \"{}\" lacks the "
                                   "RenderAttachment usage",
@@ -112,14 +137,13 @@ Result<RenderPassEncoder*> CommandEncoder::beginRenderPass(const RenderPassDescr
       }
     }
     if (i == 0) {
-      passExtent = viewRecord.result()->textureSize;
-    } else if (!(viewRecord.result()->textureSize == passExtent)) {
+      passExtent = textureDescriptor.size;
+    } else if (!(textureDescriptor.size == passExtent)) {
       return fail(Err(GpuErrorType::InvalidDescriptor,
                       std::format("beginRenderPass: attachment {} extent {}x{} differs from "
                                   "attachment 0 extent {}x{}",
-                                  i, viewRecord.result()->textureSize.width,
-                                  viewRecord.result()->textureSize.height, passExtent.width,
-                                  passExtent.height)))
+                                  i, textureDescriptor.size.width, textureDescriptor.size.height,
+                                  passExtent.width, passExtent.height)))
           .error();
     }
   }

--- a/donner/gpu/CommandEncoder.cc
+++ b/donner/gpu/CommandEncoder.cc
@@ -1,0 +1,376 @@
+#include "donner/gpu/CommandEncoder.h"
+
+#include <cmath>
+#include <format>
+#include <utility>
+
+#include "donner/gpu/CheckedArithmetic.h"
+
+namespace donner::gpu {
+
+namespace {
+
+/// Builds a \ref GpuError with the given category and message.
+GpuError Err(GpuErrorType type, std::string message) {
+  return GpuError{type, std::move(message)};
+}
+
+}  // namespace
+
+Status RenderPassEncoder::setPipeline(const RenderPipeline& pipeline) {
+  return encoder_->passSetPipeline(pipeline);
+}
+
+Status RenderPassEncoder::setBindGroup(uint32_t index, const BindGroup& bindGroup) {
+  return encoder_->passSetBindGroup(index, bindGroup);
+}
+
+Status RenderPassEncoder::setVertexBuffer(uint32_t slot, const Buffer& buffer,
+                                          uint64_t offsetBytes) {
+  return encoder_->passSetVertexBuffer(slot, buffer, offsetBytes);
+}
+
+Status RenderPassEncoder::setScissorRect(uint32_t x, uint32_t y, uint32_t width, uint32_t height) {
+  return encoder_->passSetScissorRect(x, y, width, height);
+}
+
+Status RenderPassEncoder::setViewport(float x, float y, float width, float height, float minDepth,
+                                      float maxDepth) {
+  return encoder_->passSetViewport(x, y, width, height, minDepth, maxDepth);
+}
+
+Status RenderPassEncoder::draw(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex,
+                               uint32_t firstInstance) {
+  return encoder_->passDraw(vertexCount, instanceCount, firstVertex, firstInstance);
+}
+
+Status RenderPassEncoder::end() {
+  return encoder_->passEnd();
+}
+
+Status CommandEncoder::fail(GpuError&& error) {
+  if (!firstError_) {
+    firstError_ = std::move(error);
+  }
+  return *firstError_;
+}
+
+std::optional<GpuError> CommandEncoder::checkRecordable(bool requireActivePass) {
+  if (firstError_) {
+    return *firstError_;
+  }
+  if (finished_) {
+    return Err(GpuErrorType::InvalidState, "encoder already finished");
+  }
+  if (requireActivePass && !inRenderPass_) {
+    return Err(GpuErrorType::InvalidState, "no render pass is active");
+  }
+  return std::nullopt;
+}
+
+Result<RenderPassEncoder*> CommandEncoder::beginRenderPass(const RenderPassDescriptor& descriptor) {
+  if (std::optional<GpuError> error = checkRecordable(/*requireActivePass=*/false)) {
+    return fail(std::move(*error)).error();
+  }
+  if (inRenderPass_) {
+    return fail(Err(GpuErrorType::InvalidState, "beginRenderPass: a render pass is already active"))
+        .error();
+  }
+  if (descriptor.colorAttachments.empty()) {
+    return fail(Err(GpuErrorType::InvalidDescriptor,
+                    "RenderPassDescriptor.colorAttachments is empty"))
+        .error();
+  }
+  if (descriptor.colorAttachments.size() > kMaxColorAttachments) {
+    return fail(Err(GpuErrorType::LimitExceeded,
+                    std::format("RenderPassDescriptor has {} color attachments, exceeding "
+                                "kMaxColorAttachments {}",
+                                descriptor.colorAttachments.size(), kMaxColorAttachments)))
+        .error();
+  }
+
+  Extent2d passExtent;
+  for (size_t i = 0; i < descriptor.colorAttachments.size(); ++i) {
+    const RenderPassColorAttachment& attachment = descriptor.colorAttachments[i];
+    auto viewRecord =
+        device_->resolve(device_->textureViews_, attachment.view, TextureViewTag::kName);
+    if (viewRecord.hasError()) {
+      return fail(std::move(viewRecord).error()).error();
+    }
+    if (!HasAllFlags(viewRecord.result()->textureUsage, TextureUsage::RenderAttachment)) {
+      return fail(Err(GpuErrorType::UsageMismatch,
+                      std::format("beginRenderPass: attachment {} view \"{}\" lacks the "
+                                  "RenderAttachment usage",
+                                  i, viewRecord.result()->descriptor.label.str())))
+          .error();
+    }
+    for (double channel : attachment.clearColor) {
+      if (!std::isfinite(channel)) {
+        return fail(Err(GpuErrorType::InvalidDescriptor,
+                        std::format("beginRenderPass: attachment {} clearColor is not finite", i)))
+            .error();
+      }
+    }
+    if (i == 0) {
+      passExtent = viewRecord.result()->textureSize;
+    } else if (!(viewRecord.result()->textureSize == passExtent)) {
+      return fail(Err(GpuErrorType::InvalidDescriptor,
+                      std::format("beginRenderPass: attachment {} extent {}x{} differs from "
+                                  "attachment 0 extent {}x{}",
+                                  i, viewRecord.result()->textureSize.width,
+                                  viewRecord.result()->textureSize.height, passExtent.width,
+                                  passExtent.height)))
+          .error();
+    }
+  }
+
+  inRenderPass_ = true;
+  passExtent_ = passExtent;
+  currentPipeline_.reset();
+  boundVertexBuffers_.fill(std::nullopt);
+  boundBindGroups_.fill(std::nullopt);
+  commands_.push_back(BeginRenderPassCommand{descriptor});
+  return &passEncoder_;
+}
+
+Status CommandEncoder::passSetPipeline(const RenderPipeline& pipeline) {
+  if (std::optional<GpuError> error = checkRecordable(/*requireActivePass=*/true)) {
+    return fail(std::move(*error));
+  }
+  auto record = device_->resolve(device_->renderPipelines_, pipeline, RenderPipelineTag::kName);
+  if (record.hasError()) {
+    return fail(std::move(record).error());
+  }
+
+  currentPipeline_ = BoundPipeline{record.result()->descriptor.vertex.buffers,
+                                   record.result()->bindGroupLayoutIds};
+  commands_.push_back(SetPipelineCommand{pipeline.slotIndex()});
+  return OkStatus();
+}
+
+Status CommandEncoder::passSetBindGroup(uint32_t index, const BindGroup& bindGroup) {
+  if (std::optional<GpuError> error = checkRecordable(/*requireActivePass=*/true)) {
+    return fail(std::move(*error));
+  }
+  if (index >= kMaxBindGroups) {
+    return fail(Err(
+        GpuErrorType::LimitExceeded,
+        std::format("setBindGroup: index {} exceeds kMaxBindGroups {}", index, kMaxBindGroups)));
+  }
+  auto record = device_->resolve(device_->bindGroups_, bindGroup, BindGroupTag::kName);
+  if (record.hasError()) {
+    return fail(std::move(record).error());
+  }
+
+  boundBindGroups_[index] = BoundBindGroup{bindGroup.slotIndex(), record.result()->layoutIdentity};
+  commands_.push_back(SetBindGroupCommand{index, bindGroup.slotIndex()});
+  return OkStatus();
+}
+
+Status CommandEncoder::passSetVertexBuffer(uint32_t slot, const Buffer& buffer,
+                                           uint64_t offsetBytes) {
+  if (std::optional<GpuError> error = checkRecordable(/*requireActivePass=*/true)) {
+    return fail(std::move(*error));
+  }
+  if (slot >= kMaxVertexBuffers) {
+    return fail(Err(GpuErrorType::LimitExceeded,
+                    std::format("setVertexBuffer: slot {} exceeds kMaxVertexBuffers {}", slot,
+                                kMaxVertexBuffers)));
+  }
+  auto record = device_->resolve(device_->buffers_, buffer, BufferTag::kName);
+  if (record.hasError()) {
+    return fail(std::move(record).error());
+  }
+  if (!HasAllFlags(record.result()->descriptor.usage, BufferUsage::Vertex)) {
+    return fail(Err(GpuErrorType::UsageMismatch,
+                    std::format("setVertexBuffer: buffer \"{}\" lacks the Vertex usage",
+                                record.result()->descriptor.label.str())));
+  }
+  if (offsetBytes > record.result()->descriptor.byteSize) {
+    return fail(Err(GpuErrorType::OutOfBounds,
+                    std::format("setVertexBuffer: offsetBytes {} exceeds buffer \"{}\" size {}",
+                                offsetBytes, record.result()->descriptor.label.str(),
+                                record.result()->descriptor.byteSize)));
+  }
+
+  boundVertexBuffers_[slot] =
+      BoundVertexBuffer{buffer.slotIndex(), record.result()->descriptor.byteSize - offsetBytes};
+  commands_.push_back(SetVertexBufferCommand{slot, buffer.slotIndex(), offsetBytes});
+  return OkStatus();
+}
+
+Status CommandEncoder::passSetScissorRect(uint32_t x, uint32_t y, uint32_t width, uint32_t height) {
+  if (std::optional<GpuError> error = checkRecordable(/*requireActivePass=*/true)) {
+    return fail(std::move(*error));
+  }
+  const std::optional<uint64_t> right = CheckedAdd(x, width);
+  const std::optional<uint64_t> bottom = CheckedAdd(y, height);
+  if (!right || *right > passExtent_.width || !bottom || *bottom > passExtent_.height) {
+    return fail(Err(GpuErrorType::OutOfBounds,
+                    std::format("setScissorRect: rect x={} y={} width={} height={} exceeds pass "
+                                "extent {}x{}",
+                                x, y, width, height, passExtent_.width, passExtent_.height)));
+  }
+
+  commands_.push_back(SetScissorRectCommand{x, y, width, height});
+  return OkStatus();
+}
+
+Status CommandEncoder::passSetViewport(float x, float y, float width, float height, float minDepth,
+                                       float maxDepth) {
+  if (std::optional<GpuError> error = checkRecordable(/*requireActivePass=*/true)) {
+    return fail(std::move(*error));
+  }
+  const bool allFinite = std::isfinite(x) && std::isfinite(y) && std::isfinite(width) &&
+                         std::isfinite(height) && std::isfinite(minDepth) &&
+                         std::isfinite(maxDepth);
+  if (!allFinite || width <= 0 || height <= 0 || minDepth < 0 || maxDepth > 1 ||
+      minDepth > maxDepth) {
+    return fail(Err(GpuErrorType::InvalidDescriptor,
+                    std::format("setViewport: invalid viewport x={} y={} width={} height={} "
+                                "minDepth={} maxDepth={}",
+                                x, y, width, height, minDepth, maxDepth)));
+  }
+
+  commands_.push_back(SetViewportCommand{x, y, width, height, minDepth, maxDepth});
+  return OkStatus();
+}
+
+Status CommandEncoder::passDraw(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex,
+                                uint32_t firstInstance) {
+  if (std::optional<GpuError> error = checkRecordable(/*requireActivePass=*/true)) {
+    return fail(std::move(*error));
+  }
+  if (!currentPipeline_) {
+    return fail(Err(GpuErrorType::InvalidState, "draw: no pipeline is set"));
+  }
+
+  for (size_t slot = 0; slot < currentPipeline_->vertexBuffers.size(); ++slot) {
+    const VertexBufferLayout& layout = currentPipeline_->vertexBuffers[slot];
+    if (!boundVertexBuffers_[slot]) {
+      return fail(Err(GpuErrorType::InvalidState,
+                      std::format("draw: the pipeline requires a vertex buffer at slot {} but "
+                                  "none is bound",
+                                  slot)));
+    }
+    const bool perVertex = layout.stepMode == VertexStepMode::Vertex;
+    const uint64_t first = perVertex ? firstVertex : firstInstance;
+    const uint64_t count = perVertex ? vertexCount : instanceCount;
+    const std::optional<uint64_t> lastElement = CheckedAdd(first, count);
+    const std::optional<uint64_t> bytesNeeded =
+        lastElement ? CheckedMul(*lastElement, layout.strideBytes) : std::nullopt;
+    if (!bytesNeeded || *bytesNeeded > boundVertexBuffers_[slot]->bytesAvailable) {
+      return fail(
+          Err(GpuErrorType::OutOfBounds,
+              std::format("draw: {} range [{}, {}) with strideBytes {} overflows the "
+                          "vertex buffer bound at slot {} ({} bytes available)",
+                          perVertex ? "vertex" : "instance", first, lastElement ? *lastElement : 0,
+                          layout.strideBytes, slot, boundVertexBuffers_[slot]->bytesAvailable)));
+    }
+  }
+
+  for (size_t index = 0; index < currentPipeline_->bindGroupLayoutIds.size(); ++index) {
+    if (!boundBindGroups_[index]) {
+      return fail(Err(GpuErrorType::InvalidState,
+                      std::format("draw: the pipeline layout requires a bind group at index {} "
+                                  "but none is bound",
+                                  index)));
+    }
+    if (!(boundBindGroups_[index]->layoutIdentity == currentPipeline_->bindGroupLayoutIds[index])) {
+      return fail(Err(GpuErrorType::InvalidState,
+                      std::format("draw: the bind group at index {} was created against a "
+                                  "different layout than the pipeline expects",
+                                  index)));
+    }
+  }
+
+  commands_.push_back(DrawCommand{vertexCount, instanceCount, firstVertex, firstInstance});
+  return OkStatus();
+}
+
+Status CommandEncoder::passEnd() {
+  if (std::optional<GpuError> error = checkRecordable(/*requireActivePass=*/true)) {
+    return fail(std::move(*error));
+  }
+
+  inRenderPass_ = false;
+  currentPipeline_.reset();
+  boundVertexBuffers_.fill(std::nullopt);
+  boundBindGroups_.fill(std::nullopt);
+  commands_.push_back(EndRenderPassCommand{});
+  return OkStatus();
+}
+
+Status CommandEncoder::copyTextureToBuffer(const TexelCopyTextureInfo& source,
+                                           const Buffer& destination,
+                                           const TexelCopyBufferLayout& destinationLayout,
+                                           const Extent2d& copySize) {
+  if (std::optional<GpuError> error = checkRecordable(/*requireActivePass=*/false)) {
+    return fail(std::move(*error));
+  }
+  if (inRenderPass_) {
+    return fail(
+        Err(GpuErrorType::InvalidState, "copyTextureToBuffer: not allowed inside a render pass"));
+  }
+  auto textureRecord = device_->resolve(device_->textures_, source.texture, TextureTag::kName);
+  if (textureRecord.hasError()) {
+    return fail(std::move(textureRecord).error());
+  }
+  auto bufferRecord = device_->resolve(device_->buffers_, destination, BufferTag::kName);
+  if (bufferRecord.hasError()) {
+    return fail(std::move(bufferRecord).error());
+  }
+  const TextureDescriptor& textureDescriptor = textureRecord.result()->descriptor;
+  const BufferDescriptor& bufferDescriptor = bufferRecord.result()->descriptor;
+  if (!HasAllFlags(textureDescriptor.usage, TextureUsage::CopySrc)) {
+    return fail(Err(GpuErrorType::UsageMismatch,
+                    std::format("copyTextureToBuffer: texture \"{}\" lacks the CopySrc usage",
+                                textureDescriptor.label.str())));
+  }
+  if (!HasAllFlags(bufferDescriptor.usage, BufferUsage::CopyDst)) {
+    return fail(Err(GpuErrorType::UsageMismatch,
+                    std::format("copyTextureToBuffer: buffer \"{}\" lacks the CopyDst usage",
+                                bufferDescriptor.label.str())));
+  }
+  if (copySize.width > textureDescriptor.size.width ||
+      copySize.height > textureDescriptor.size.height) {
+    return fail(
+        Err(GpuErrorType::OutOfBounds,
+            std::format("copyTextureToBuffer: copy size {}x{} exceeds texture \"{}\" size {}x{}",
+                        copySize.width, copySize.height, textureDescriptor.label.str(),
+                        textureDescriptor.size.width, textureDescriptor.size.height)));
+  }
+  Result<uint64_t> requiredEnd = ValidateTexelCopyInternal(
+      destinationLayout, copySize, textureDescriptor.format, "copyTextureToBuffer");
+  if (requiredEnd.hasError()) {
+    return fail(std::move(requiredEnd).error());
+  }
+  if (requiredEnd.result() > bufferDescriptor.byteSize) {
+    return fail(Err(GpuErrorType::OutOfBounds,
+                    std::format("copyTextureToBuffer: layout requires {} bytes but buffer \"{}\" "
+                                "has {} bytes",
+                                requiredEnd.result(), bufferDescriptor.label.str(),
+                                bufferDescriptor.byteSize)));
+  }
+
+  commands_.push_back(CopyTextureToBufferCommand{
+      source.texture.slotIndex(), destination.slotIndex(), destinationLayout, copySize});
+  return OkStatus();
+}
+
+Result<CommandBuffer> CommandEncoder::finish() {
+  if (firstError_) {
+    return *firstError_;
+  }
+  if (finished_) {
+    return Err(GpuErrorType::InvalidState, "finish: encoder already finished");
+  }
+  if (inRenderPass_) {
+    return fail(Err(GpuErrorType::InvalidState, "finish: a render pass is still active")).error();
+  }
+
+  finished_ = true;
+  return device_->registerCommandBuffer(std::move(commands_));
+}
+
+}  // namespace donner::gpu

--- a/donner/gpu/CommandEncoder.cc
+++ b/donner/gpu/CommandEncoder.cc
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <format>
+#include <sstream>
 #include <utility>
 #include <vector>
 
@@ -91,6 +92,8 @@ Result<RenderPassEncoder*> CommandEncoder::beginRenderPass(const RenderPassDescr
   }
 
   Extent2d passExtent;
+  std::vector<TextureFormat> attachmentFormats;
+  attachmentFormats.reserve(descriptor.colorAttachments.size());
   std::vector<Device::ResourceIdentity> seenViews;
   seenViews.reserve(descriptor.colorAttachments.size());
   for (size_t i = 0; i < descriptor.colorAttachments.size(); ++i) {
@@ -114,6 +117,19 @@ Result<RenderPassEncoder*> CommandEncoder::beginRenderPass(const RenderPassDescr
     }
     seenViews.push_back(viewIdentity);
 
+    if (!IsKnownEnumValue(attachment.loadOp)) {
+      return fail(Err(GpuErrorType::InvalidDescriptor,
+                      std::format("beginRenderPass: attachment {} has an unknown loadOp value {}",
+                                  i, static_cast<uint32_t>(attachment.loadOp))))
+          .error();
+    }
+    if (!IsKnownEnumValue(attachment.storeOp)) {
+      return fail(Err(GpuErrorType::InvalidDescriptor,
+                      std::format("beginRenderPass: attachment {} has an unknown storeOp value {}",
+                                  i, static_cast<uint32_t>(attachment.storeOp))))
+          .error();
+    }
+
     // Re-resolve the viewed texture so a view of a destroyed (or slot-reused) texture fails
     // closed here instead of aliasing another texture.
     auto viewedTexture = device_->resolveViewedTexture(*viewRecord.result());
@@ -121,6 +137,7 @@ Result<RenderPassEncoder*> CommandEncoder::beginRenderPass(const RenderPassDescr
       return fail(std::move(viewedTexture).error()).error();
     }
     const TextureDescriptor& textureDescriptor = viewedTexture.result()->descriptor;
+    attachmentFormats.push_back(textureDescriptor.format);
 
     if (!HasAllFlags(textureDescriptor.usage, TextureUsage::RenderAttachment)) {
       return fail(Err(GpuErrorType::UsageMismatch,
@@ -150,6 +167,7 @@ Result<RenderPassEncoder*> CommandEncoder::beginRenderPass(const RenderPassDescr
 
   inRenderPass_ = true;
   passExtent_ = passExtent;
+  passAttachmentFormats_ = std::move(attachmentFormats);
   currentPipeline_.reset();
   boundVertexBuffers_.fill(std::nullopt);
   boundBindGroups_.fill(std::nullopt);
@@ -164,6 +182,30 @@ Status CommandEncoder::passSetPipeline(const RenderPipeline& pipeline) {
   auto record = device_->resolve(device_->renderPipelines_, pipeline, RenderPipelineTag::kName);
   if (record.hasError()) {
     return fail(std::move(record).error());
+  }
+
+  // The pipeline's color targets must match the active pass's attachments in count and
+  // per-index format. InvalidState (not UsageMismatch) by convention: like the draw-time bind
+  // group / pipeline layout check, this is an incompatibility between a valid object and the
+  // encoder's current state, whereas UsageMismatch is reserved for resources missing a usage
+  // flag.
+  const std::vector<ColorTargetState>& targets = record.result()->descriptor.fragment.targets;
+  if (targets.size() != passAttachmentFormats_.size()) {
+    return fail(
+        Err(GpuErrorType::InvalidState,
+            std::format("setPipeline: pipeline declares {} color targets but the pass has {} "
+                        "attachments",
+                        targets.size(), passAttachmentFormats_.size())));
+  }
+  for (size_t i = 0; i < targets.size(); ++i) {
+    if (targets[i].format != passAttachmentFormats_[i]) {
+      std::ostringstream formats;
+      formats << targets[i].format << " vs " << passAttachmentFormats_[i];
+      return fail(Err(GpuErrorType::InvalidState,
+                      std::format("setPipeline: color target {} format does not match the pass "
+                                  "attachment format ({})",
+                                  i, formats.str())));
+    }
   }
 
   currentPipeline_ = BoundPipeline{record.result()->descriptor.vertex.buffers,
@@ -184,6 +226,37 @@ Status CommandEncoder::passSetBindGroup(uint32_t index, const BindGroup& bindGro
   auto record = device_->resolve(device_->bindGroups_, bindGroup, BindGroupTag::kName);
   if (record.hasError()) {
     return fail(std::move(record).error());
+  }
+
+  // Re-resolve every resource the group references: a buffer, texture view (and its texture),
+  // or sampler destroyed after createBindGroup - including slot reuse - must fail closed here
+  // instead of reaching a backend.
+  for (const BindGroupEntry& entry : record.result()->descriptor.entries) {
+    if (const BufferBinding* bufferBinding = std::get_if<BufferBinding>(&entry.resource)) {
+      auto bufferRecord =
+          device_->resolve(device_->buffers_, bufferBinding->buffer, BufferTag::kName);
+      if (bufferRecord.hasError()) {
+        return fail(std::move(bufferRecord).error());
+      }
+    } else if (const TextureViewBinding* viewBinding =
+                   std::get_if<TextureViewBinding>(&entry.resource)) {
+      auto viewRecord =
+          device_->resolve(device_->textureViews_, viewBinding->view, TextureViewTag::kName);
+      if (viewRecord.hasError()) {
+        return fail(std::move(viewRecord).error());
+      }
+      auto viewedTexture = device_->resolveViewedTexture(*viewRecord.result());
+      if (viewedTexture.hasError()) {
+        return fail(std::move(viewedTexture).error());
+      }
+    } else if (const SamplerBinding* samplerBinding =
+                   std::get_if<SamplerBinding>(&entry.resource)) {
+      auto samplerRecord =
+          device_->resolve(device_->samplers_, samplerBinding->sampler, SamplerTag::kName);
+      if (samplerRecord.hasError()) {
+        return fail(std::move(samplerRecord).error());
+      }
+    }
   }
 
   boundBindGroups_[index] = BoundBindGroup{bindGroup.slotIndex(), record.result()->layoutIdentity};

--- a/donner/gpu/CommandEncoder.h
+++ b/donner/gpu/CommandEncoder.h
@@ -166,8 +166,8 @@ private:
 
   /// Draw-time validation state for the active pipeline.
   struct BoundPipeline {
-    std::vector<VertexBufferLayout> vertexBuffers;           //!< Declared vertex layouts.
-    std::vector<Device::LayoutIdentity> bindGroupLayoutIds;  //!< Required group layouts.
+    std::vector<VertexBufferLayout> vertexBuffers;             //!< Declared vertex layouts.
+    std::vector<Device::ResourceIdentity> bindGroupLayoutIds;  //!< Required group layouts.
   };
   /// Draw-time validation state for one bound vertex buffer slot.
   struct BoundVertexBuffer {
@@ -176,8 +176,8 @@ private:
   };
   /// Draw-time validation state for one bound bind group index.
   struct BoundBindGroup {
-    uint32_t bindGroupSlot = 0;             //!< Bind group slot index.
-    Device::LayoutIdentity layoutIdentity;  //!< Layout the group was created against.
+    uint32_t bindGroupSlot = 0;               //!< Bind group slot index.
+    Device::ResourceIdentity layoutIdentity;  //!< Layout the group was created against.
   };
 
   /// Latches \p error (first error wins, poisoning the encoder) and returns the latched error.

--- a/donner/gpu/CommandEncoder.h
+++ b/donner/gpu/CommandEncoder.h
@@ -1,0 +1,215 @@
+#pragma once
+/// @file
+/// \c donner::gpu::CommandEncoder and \c donner::gpu::RenderPassEncoder - fail-closed command
+/// recording.
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include "donner/gpu/Commands.h"
+#include "donner/gpu/Device.h"
+#include "donner/gpu/GpuLimits.h"
+#include "donner/gpu/GpuResult.h"
+
+namespace donner::gpu {
+
+class CommandEncoder;
+
+/**
+ * Encodes commands inside an active render pass. Obtained from
+ * \ref CommandEncoder::beginRenderPass; owned by the encoder and valid until the encoder is
+ * destroyed (operations after \ref end fail with \ref GpuErrorType::InvalidState).
+ */
+class RenderPassEncoder {
+public:
+  RenderPassEncoder(const RenderPassEncoder&) = delete;
+  RenderPassEncoder& operator=(const RenderPassEncoder&) = delete;
+  RenderPassEncoder(RenderPassEncoder&&) = delete;
+  RenderPassEncoder& operator=(RenderPassEncoder&&) = delete;
+
+  /**
+   * Sets the active render pipeline.
+   *
+   * @param pipeline Pipeline to bind; must be a live handle of the encoder's device.
+   */
+  Status setPipeline(const RenderPipeline& pipeline);
+
+  /**
+   * Binds \p bindGroup at \p index. Compatibility with the active pipeline's layout is checked
+   * at \ref draw time, so bind groups may be set before the pipeline.
+   *
+   * @param index Bind group index; must be below \ref kMaxBindGroups.
+   * @param bindGroup Bind group to bind; must be a live handle of the encoder's device.
+   */
+  Status setBindGroup(uint32_t index, const BindGroup& bindGroup);
+
+  /**
+   * Binds \p buffer as the vertex buffer for \p slot.
+   *
+   * @param slot Vertex buffer slot; must be below \ref kMaxVertexBuffers.
+   * @param buffer Buffer to bind; needs \ref BufferUsage::Vertex.
+   * @param offsetBytes Byte offset of the first element; must be within the buffer.
+   */
+  Status setVertexBuffer(uint32_t slot, const Buffer& buffer, uint64_t offsetBytes = 0);
+
+  /**
+   * Sets the scissor rectangle. The rectangle must fit inside the pass attachment extent.
+   *
+   * @param x Left edge in pixels.
+   * @param y Top edge in pixels.
+   * @param width Width in pixels.
+   * @param height Height in pixels.
+   */
+  Status setScissorRect(uint32_t x, uint32_t y, uint32_t width, uint32_t height);
+
+  /**
+   * Sets the viewport. All values must be finite, with positive extent and
+   * `0 <= minDepth <= maxDepth <= 1`.
+   *
+   * @param x Left edge in pixels.
+   * @param y Top edge in pixels.
+   * @param width Width in pixels.
+   * @param height Height in pixels.
+   * @param minDepth Minimum depth of the viewport range.
+   * @param maxDepth Maximum depth of the viewport range.
+   */
+  Status setViewport(float x, float y, float width, float height, float minDepth, float maxDepth);
+
+  /**
+   * Records a draw. Fails closed unless a pipeline is set, every vertex buffer slot the pipeline
+   * declares is bound with enough bytes for the drawn range (checked arithmetic), and every bind
+   * group index the pipeline layout declares holds a bind group created against the same layout.
+   *
+   * @param vertexCount Number of vertices.
+   * @param instanceCount Number of instances.
+   * @param firstVertex First vertex index.
+   * @param firstInstance First instance index.
+   */
+  Status draw(uint32_t vertexCount, uint32_t instanceCount = 1, uint32_t firstVertex = 0,
+              uint32_t firstInstance = 0);
+
+  /// Ends the render pass. Further pass operations fail with
+  /// \ref GpuErrorType::InvalidState until a new pass begins.
+  Status end();
+
+private:
+  friend class CommandEncoder;
+
+  /// Constructs the pass encoder owned by \p encoder.
+  /// @param encoder Owning command encoder.
+  explicit RenderPassEncoder(CommandEncoder& encoder) : encoder_(&encoder) {}
+
+  CommandEncoder* encoder_;
+};
+
+/**
+ * Records and validates GPU commands for one command buffer (design 0053 "Command model").
+ *
+ * The encoder is a fail-closed state machine: every operation validates handle liveness, device
+ * identity, usage flags, bounds, and pass state before recording. The first error latches and
+ * poisons the encoder - every subsequent operation, including \ref finish, returns that first
+ * error - so a failure cannot be silently skipped and the root cause is always the reported
+ * error. Obtain encoders via `Device::createCommandEncoder`; the encoder must not outlive its
+ * device.
+ */
+class CommandEncoder {
+public:
+  CommandEncoder(const CommandEncoder&) = delete;
+  CommandEncoder& operator=(const CommandEncoder&) = delete;
+  CommandEncoder(CommandEncoder&&) = delete;
+  CommandEncoder& operator=(CommandEncoder&&) = delete;
+  /// Destructor. Discards recorded commands unless \ref finish transferred them.
+  ~CommandEncoder() = default;
+
+  /**
+   * Begins a render pass and returns its pass encoder. Fails with
+   * \ref GpuErrorType::InvalidState if a pass is already active. Attachment views must be live,
+   * share one extent, and their textures need \ref TextureUsage::RenderAttachment.
+   *
+   * The returned pointer is owned by this encoder and remains valid until the encoder is
+   * destroyed.
+   *
+   * @param descriptor Validated render pass descriptor.
+   */
+  Result<RenderPassEncoder*> beginRenderPass(const RenderPassDescriptor& descriptor);
+
+  /**
+   * Records a texture-to-buffer copy (readback staging). Not allowed inside a render pass.
+   * \p destinationLayout must be 256-aligned and cover \p copySize, \p copySize must fit in the
+   * source texture, and the described rows must fit in \p destination (checked arithmetic).
+   *
+   * @param source Source texture; needs \ref TextureUsage::CopySrc.
+   * @param destination Destination buffer; needs \ref BufferUsage::CopyDst.
+   * @param destinationLayout Row layout in the destination buffer.
+   * @param copySize Copy extent in texels.
+   */
+  Status copyTextureToBuffer(const TexelCopyTextureInfo& source, const Buffer& destination,
+                             const TexelCopyBufferLayout& destinationLayout,
+                             const Extent2d& copySize);
+
+  /**
+   * Finishes recording and registers the command buffer with the device. Fails with the first
+   * recorded error if any operation failed, or with \ref GpuErrorType::InvalidState if a pass is
+   * still active or the encoder already finished.
+   */
+  Result<CommandBuffer> finish();
+
+private:
+  friend class Device;
+  friend class RenderPassEncoder;
+
+  /// Constructs an encoder recording against \p device.
+  /// @param device Owning device; must outlive the encoder.
+  explicit CommandEncoder(Device& device) : device_(&device), passEncoder_(*this) {}
+
+  /// Draw-time validation state for the active pipeline.
+  struct BoundPipeline {
+    std::vector<VertexBufferLayout> vertexBuffers;           //!< Declared vertex layouts.
+    std::vector<Device::LayoutIdentity> bindGroupLayoutIds;  //!< Required group layouts.
+  };
+  /// Draw-time validation state for one bound vertex buffer slot.
+  struct BoundVertexBuffer {
+    uint32_t bufferSlot = 0;      //!< Buffer slot index.
+    uint64_t bytesAvailable = 0;  //!< Bytes from the bound offset to the end of the buffer.
+  };
+  /// Draw-time validation state for one bound bind group index.
+  struct BoundBindGroup {
+    uint32_t bindGroupSlot = 0;             //!< Bind group slot index.
+    Device::LayoutIdentity layoutIdentity;  //!< Layout the group was created against.
+  };
+
+  /// Latches \p error (first error wins, poisoning the encoder) and returns the latched error.
+  /// @param error Error to latch.
+  Status fail(GpuError&& error);
+
+  /// Returns the poisoned/finished-state error common to all operations, if any.
+  /// @param requireActivePass True for render pass operations.
+  std::optional<GpuError> checkRecordable(bool requireActivePass);
+
+  // RenderPassEncoder forwards to these.
+  Status passSetPipeline(const RenderPipeline& pipeline);
+  Status passSetBindGroup(uint32_t index, const BindGroup& bindGroup);
+  Status passSetVertexBuffer(uint32_t slot, const Buffer& buffer, uint64_t offsetBytes);
+  Status passSetScissorRect(uint32_t x, uint32_t y, uint32_t width, uint32_t height);
+  Status passSetViewport(float x, float y, float width, float height, float minDepth,
+                         float maxDepth);
+  Status passDraw(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex,
+                  uint32_t firstInstance);
+  Status passEnd();
+
+  Device* device_;
+  RenderPassEncoder passEncoder_;
+  std::vector<Command> commands_;
+  std::optional<GpuError> firstError_;
+  bool inRenderPass_ = false;
+  bool finished_ = false;
+
+  Extent2d passExtent_;
+  std::optional<BoundPipeline> currentPipeline_;
+  std::array<std::optional<BoundVertexBuffer>, kMaxVertexBuffers> boundVertexBuffers_;
+  std::array<std::optional<BoundBindGroup>, kMaxBindGroups> boundBindGroups_;
+};
+
+}  // namespace donner::gpu

--- a/donner/gpu/CommandEncoder.h
+++ b/donner/gpu/CommandEncoder.h
@@ -113,6 +113,11 @@ private:
  * error - so a failure cannot be silently skipped and the root cause is always the reported
  * error. Obtain encoders via `Device::createCommandEncoder`; the encoder must not outlive its
  * device.
+ *
+ * Known gap: destroying a resource that a recorded-but-unsubmitted command buffer references is
+ * not yet validated; commands are checked at recording time only. Deferred-destruction
+ * validation arrives with the resource-lifetime and submission packet (design 0053 change
+ * sequence step 3).
  */
 class CommandEncoder {
 public:

--- a/donner/gpu/CommandEncoder.h
+++ b/donner/gpu/CommandEncoder.h
@@ -212,6 +212,7 @@ private:
   bool finished_ = false;
 
   Extent2d passExtent_;
+  std::vector<TextureFormat> passAttachmentFormats_;
   std::optional<BoundPipeline> currentPipeline_;
   std::array<std::optional<BoundVertexBuffer>, kMaxVertexBuffers> boundVertexBuffers_;
   std::array<std::optional<BoundBindGroup>, kMaxBindGroups> boundBindGroups_;

--- a/donner/gpu/Commands.h
+++ b/donner/gpu/Commands.h
@@ -1,0 +1,82 @@
+#pragma once
+/// @file
+/// Validated command value types recorded by \c donner::gpu::CommandEncoder.
+///
+/// Commands store only validated Donner value objects and slot-based resource identifiers, never
+/// raw pointers or native handles (design 0053 "Command model"), so recorded streams serialize
+/// deterministically and contain no process state.
+
+#include <cstdint>
+#include <variant>
+
+#include "donner/gpu/Descriptors.h"
+
+namespace donner::gpu {
+
+/// Recorded `beginRenderPass`. Attachment references inside the descriptor are validated before
+/// recording.
+struct BeginRenderPassCommand {
+  RenderPassDescriptor descriptor;  //!< Validated pass descriptor.
+};
+
+/// Recorded `setPipeline`.
+struct SetPipelineCommand {
+  uint32_t pipelineSlot = 0;  //!< Render pipeline slot index.
+};
+
+/// Recorded `setBindGroup`.
+struct SetBindGroupCommand {
+  uint32_t index = 0;          //!< Bind group index.
+  uint32_t bindGroupSlot = 0;  //!< Bind group slot index.
+};
+
+/// Recorded `setVertexBuffer`.
+struct SetVertexBufferCommand {
+  uint32_t slot = 0;         //!< Vertex buffer slot index in the pipeline layout.
+  uint32_t bufferSlot = 0;   //!< Buffer slot index.
+  uint64_t offsetBytes = 0;  //!< Byte offset of the first element.
+};
+
+/// Recorded `setScissorRect`.
+struct SetScissorRectCommand {
+  uint32_t x = 0;       //!< Left edge in pixels.
+  uint32_t y = 0;       //!< Top edge in pixels.
+  uint32_t width = 0;   //!< Width in pixels.
+  uint32_t height = 0;  //!< Height in pixels.
+};
+
+/// Recorded `setViewport`.
+struct SetViewportCommand {
+  float x = 0;         //!< Left edge in pixels.
+  float y = 0;         //!< Top edge in pixels.
+  float width = 0;     //!< Width in pixels.
+  float height = 0;    //!< Height in pixels.
+  float minDepth = 0;  //!< Minimum depth of the viewport range.
+  float maxDepth = 1;  //!< Maximum depth of the viewport range.
+};
+
+/// Recorded `draw`.
+struct DrawCommand {
+  uint32_t vertexCount = 0;    //!< Number of vertices.
+  uint32_t instanceCount = 1;  //!< Number of instances.
+  uint32_t firstVertex = 0;    //!< First vertex index.
+  uint32_t firstInstance = 0;  //!< First instance index.
+};
+
+/// Recorded render pass end.
+struct EndRenderPassCommand {};
+
+/// Recorded `copyTextureToBuffer` (readback staging copy).
+struct CopyTextureToBufferCommand {
+  uint32_t textureSlot = 0;      //!< Source texture slot index.
+  uint32_t bufferSlot = 0;       //!< Destination buffer slot index.
+  TexelCopyBufferLayout layout;  //!< Destination row layout.
+  Extent2d copySize;             //!< Copy extent in texels.
+};
+
+/// One recorded command.
+using Command = std::variant<BeginRenderPassCommand, SetPipelineCommand, SetBindGroupCommand,
+                             SetVertexBufferCommand, SetScissorRectCommand, SetViewportCommand,
+                             DrawCommand, EndRenderPassCommand, CopyTextureToBufferCommand>;
+
+}  // namespace donner::gpu

--- a/donner/gpu/Descriptors.cc
+++ b/donner/gpu/Descriptors.cc
@@ -1,0 +1,201 @@
+#include "donner/gpu/Descriptors.h"
+
+#include <initializer_list>
+#include <string_view>
+
+namespace donner::gpu {
+
+namespace {
+
+/// One (flag, name) pair for bitmask serialization.
+struct FlagName {
+  uint32_t flag;          //!< Flag bit value.
+  std::string_view name;  //!< Flag name.
+};
+
+/// Outputs set flags joined by `|`, or `None` if no flags are set. Flags print in ascending bit
+/// order so output is deterministic.
+std::ostream& OutputFlags(std::ostream& os, uint32_t value,
+                          std::initializer_list<FlagName> flagNames) {
+  if (value == 0) {
+    return os << "None";
+  }
+
+  bool first = true;
+  for (const FlagName& flagName : flagNames) {
+    if ((value & flagName.flag) == flagName.flag) {
+      if (!first) {
+        os << "|";
+      }
+      os << flagName.name;
+      first = false;
+    }
+  }
+  return os;
+}
+
+}  // namespace
+
+std::ostream& operator<<(std::ostream& os, TextureFormat value) {
+  switch (value) {
+    case TextureFormat::RGBA8Unorm: return os << "RGBA8Unorm";
+    case TextureFormat::BGRA8Unorm: return os << "BGRA8Unorm";
+    case TextureFormat::R8Unorm: return os << "R8Unorm";
+  }
+  return os << "Unknown";
+}
+
+std::ostream& operator<<(std::ostream& os, TextureUsage value) {
+  return OutputFlags(os, static_cast<uint32_t>(value),
+                     {{static_cast<uint32_t>(TextureUsage::RenderAttachment), "RenderAttachment"},
+                      {static_cast<uint32_t>(TextureUsage::Sampled), "Sampled"},
+                      {static_cast<uint32_t>(TextureUsage::CopySrc), "CopySrc"},
+                      {static_cast<uint32_t>(TextureUsage::CopyDst), "CopyDst"}});
+}
+
+std::ostream& operator<<(std::ostream& os, BufferUsage value) {
+  return OutputFlags(os, static_cast<uint32_t>(value),
+                     {{static_cast<uint32_t>(BufferUsage::Vertex), "Vertex"},
+                      {static_cast<uint32_t>(BufferUsage::Index), "Index"},
+                      {static_cast<uint32_t>(BufferUsage::Uniform), "Uniform"},
+                      {static_cast<uint32_t>(BufferUsage::Storage), "Storage"},
+                      {static_cast<uint32_t>(BufferUsage::CopySrc), "CopySrc"},
+                      {static_cast<uint32_t>(BufferUsage::CopyDst), "CopyDst"},
+                      {static_cast<uint32_t>(BufferUsage::MapRead), "MapRead"}});
+}
+
+std::ostream& operator<<(std::ostream& os, ShaderStage value) {
+  return OutputFlags(os, static_cast<uint32_t>(value),
+                     {{static_cast<uint32_t>(ShaderStage::Vertex), "Vertex"},
+                      {static_cast<uint32_t>(ShaderStage::Fragment), "Fragment"},
+                      {static_cast<uint32_t>(ShaderStage::Compute), "Compute"}});
+}
+
+std::ostream& operator<<(std::ostream& os, ColorWriteMask value) {
+  return OutputFlags(os, static_cast<uint32_t>(value),
+                     {{static_cast<uint32_t>(ColorWriteMask::Red), "Red"},
+                      {static_cast<uint32_t>(ColorWriteMask::Green), "Green"},
+                      {static_cast<uint32_t>(ColorWriteMask::Blue), "Blue"},
+                      {static_cast<uint32_t>(ColorWriteMask::Alpha), "Alpha"}});
+}
+
+std::ostream& operator<<(std::ostream& os, FilterMode value) {
+  switch (value) {
+    case FilterMode::Nearest: return os << "Nearest";
+    case FilterMode::Linear: return os << "Linear";
+  }
+  return os << "Unknown";
+}
+
+std::ostream& operator<<(std::ostream& os, AddressMode value) {
+  switch (value) {
+    case AddressMode::ClampToEdge: return os << "ClampToEdge";
+    case AddressMode::Repeat: return os << "Repeat";
+  }
+  return os << "Unknown";
+}
+
+std::ostream& operator<<(std::ostream& os, VertexFormat value) {
+  switch (value) {
+    case VertexFormat::Float32x2: return os << "Float32x2";
+    case VertexFormat::Float32x4: return os << "Float32x4";
+    case VertexFormat::Uint32: return os << "Uint32";
+  }
+  return os << "Unknown";
+}
+
+std::ostream& operator<<(std::ostream& os, VertexStepMode value) {
+  switch (value) {
+    case VertexStepMode::Vertex: return os << "Vertex";
+    case VertexStepMode::Instance: return os << "Instance";
+  }
+  return os << "Unknown";
+}
+
+std::ostream& operator<<(std::ostream& os, PrimitiveTopology value) {
+  switch (value) {
+    case PrimitiveTopology::TriangleList: return os << "TriangleList";
+    case PrimitiveTopology::TriangleStrip: return os << "TriangleStrip";
+  }
+  return os << "Unknown";
+}
+
+std::ostream& operator<<(std::ostream& os, CullMode value) {
+  switch (value) {
+    case CullMode::None: return os << "None";
+    case CullMode::Back: return os << "Back";
+  }
+  return os << "Unknown";
+}
+
+std::ostream& operator<<(std::ostream& os, BlendFactor value) {
+  switch (value) {
+    case BlendFactor::Zero: return os << "Zero";
+    case BlendFactor::One: return os << "One";
+    case BlendFactor::SrcAlpha: return os << "SrcAlpha";
+    case BlendFactor::OneMinusSrcAlpha: return os << "OneMinusSrcAlpha";
+  }
+  return os << "Unknown";
+}
+
+std::ostream& operator<<(std::ostream& os, BlendOperation value) {
+  switch (value) {
+    case BlendOperation::Add: return os << "Add";
+    case BlendOperation::Max: return os << "Max";
+  }
+  return os << "Unknown";
+}
+
+std::ostream& operator<<(std::ostream& os, BindingType value) {
+  switch (value) {
+    case BindingType::UniformBuffer: return os << "UniformBuffer";
+    case BindingType::ReadOnlyStorageBuffer: return os << "ReadOnlyStorageBuffer";
+    case BindingType::SampledTexture2dFloat: return os << "SampledTexture2dFloat";
+    case BindingType::FilteringSampler: return os << "FilteringSampler";
+  }
+  return os << "Unknown";
+}
+
+std::ostream& operator<<(std::ostream& os, LoadOp value) {
+  switch (value) {
+    case LoadOp::Clear: return os << "Clear";
+    case LoadOp::Load: return os << "Load";
+  }
+  return os << "Unknown";
+}
+
+std::ostream& operator<<(std::ostream& os, StoreOp value) {
+  switch (value) {
+    case StoreOp::Store: return os << "Store";
+    case StoreOp::Discard: return os << "Discard";
+  }
+  return os << "Unknown";
+}
+
+std::ostream& operator<<(std::ostream& os, ShaderSourceKind value) {
+  switch (value) {
+    case ShaderSourceKind::Wgsl: return os << "Wgsl";
+    case ShaderSourceKind::Msl: return os << "Msl";
+  }
+  return os << "Unknown";
+}
+
+uint32_t TextureFormatBytesPerTexel(TextureFormat format) {
+  switch (format) {
+    case TextureFormat::RGBA8Unorm:
+    case TextureFormat::BGRA8Unorm: return 4;
+    case TextureFormat::R8Unorm: return 1;
+  }
+  return 0;
+}
+
+uint32_t VertexFormatByteSize(VertexFormat format) {
+  switch (format) {
+    case VertexFormat::Float32x2: return 8;
+    case VertexFormat::Float32x4: return 16;
+    case VertexFormat::Uint32: return 4;
+  }
+  return 0;
+}
+
+}  // namespace donner::gpu

--- a/donner/gpu/Descriptors.cc
+++ b/donner/gpu/Descriptors.cc
@@ -180,6 +180,141 @@ std::ostream& operator<<(std::ostream& os, ShaderSourceKind value) {
   return os << "Unknown";
 }
 
+bool IsKnownEnumValue(TextureFormat value) {
+  switch (value) {
+    case TextureFormat::RGBA8Unorm:
+    case TextureFormat::BGRA8Unorm:
+    case TextureFormat::R8Unorm: return true;
+  }
+  return false;
+}
+
+bool IsKnownEnumValue(FilterMode value) {
+  switch (value) {
+    case FilterMode::Nearest:
+    case FilterMode::Linear: return true;
+  }
+  return false;
+}
+
+bool IsKnownEnumValue(AddressMode value) {
+  switch (value) {
+    case AddressMode::ClampToEdge:
+    case AddressMode::Repeat: return true;
+  }
+  return false;
+}
+
+bool IsKnownEnumValue(VertexFormat value) {
+  switch (value) {
+    case VertexFormat::Float32x2:
+    case VertexFormat::Float32x4:
+    case VertexFormat::Uint32: return true;
+  }
+  return false;
+}
+
+bool IsKnownEnumValue(VertexStepMode value) {
+  switch (value) {
+    case VertexStepMode::Vertex:
+    case VertexStepMode::Instance: return true;
+  }
+  return false;
+}
+
+bool IsKnownEnumValue(PrimitiveTopology value) {
+  switch (value) {
+    case PrimitiveTopology::TriangleList:
+    case PrimitiveTopology::TriangleStrip: return true;
+  }
+  return false;
+}
+
+bool IsKnownEnumValue(CullMode value) {
+  switch (value) {
+    case CullMode::None:
+    case CullMode::Back: return true;
+  }
+  return false;
+}
+
+bool IsKnownEnumValue(BlendFactor value) {
+  switch (value) {
+    case BlendFactor::Zero:
+    case BlendFactor::One:
+    case BlendFactor::SrcAlpha:
+    case BlendFactor::OneMinusSrcAlpha: return true;
+  }
+  return false;
+}
+
+bool IsKnownEnumValue(BlendOperation value) {
+  switch (value) {
+    case BlendOperation::Add:
+    case BlendOperation::Max: return true;
+  }
+  return false;
+}
+
+bool IsKnownEnumValue(BindingType value) {
+  switch (value) {
+    case BindingType::UniformBuffer:
+    case BindingType::ReadOnlyStorageBuffer:
+    case BindingType::SampledTexture2dFloat:
+    case BindingType::FilteringSampler: return true;
+  }
+  return false;
+}
+
+bool IsKnownEnumValue(LoadOp value) {
+  switch (value) {
+    case LoadOp::Clear:
+    case LoadOp::Load: return true;
+  }
+  return false;
+}
+
+bool IsKnownEnumValue(StoreOp value) {
+  switch (value) {
+    case StoreOp::Store:
+    case StoreOp::Discard: return true;
+  }
+  return false;
+}
+
+bool IsKnownEnumValue(ShaderSourceKind value) {
+  switch (value) {
+    case ShaderSourceKind::Wgsl:
+    case ShaderSourceKind::Msl: return true;
+  }
+  return false;
+}
+
+bool IsValidBitmask(TextureUsage value) {
+  constexpr uint32_t kAllBits =
+      static_cast<uint32_t>(TextureUsage::RenderAttachment | TextureUsage::Sampled |
+                            TextureUsage::CopySrc | TextureUsage::CopyDst);
+  return (static_cast<uint32_t>(value) & ~kAllBits) == 0;
+}
+
+bool IsValidBitmask(BufferUsage value) {
+  constexpr uint32_t kAllBits = static_cast<uint32_t>(
+      BufferUsage::Vertex | BufferUsage::Index | BufferUsage::Uniform | BufferUsage::Storage |
+      BufferUsage::CopySrc | BufferUsage::CopyDst | BufferUsage::MapRead);
+  return (static_cast<uint32_t>(value) & ~kAllBits) == 0;
+}
+
+bool IsValidBitmask(ShaderStage value) {
+  constexpr uint32_t kAllBits =
+      static_cast<uint32_t>(ShaderStage::Vertex | ShaderStage::Fragment | ShaderStage::Compute);
+  return (static_cast<uint32_t>(value) & ~kAllBits) == 0;
+}
+
+bool IsValidBitmask(ColorWriteMask value) {
+  constexpr uint32_t kAllBits = static_cast<uint32_t>(ColorWriteMask::All);
+  return (static_cast<uint32_t>(value) & ~kAllBits) == 0;
+}
+
 uint32_t TextureFormatBytesPerTexel(TextureFormat format) {
   switch (format) {
     case TextureFormat::RGBA8Unorm:

--- a/donner/gpu/Descriptors.h
+++ b/donner/gpu/Descriptors.h
@@ -292,7 +292,9 @@ struct TextureDescriptor {
   Extent2d size;                                     //!< Extent in texels. Must be nonzero.
   TextureFormat format = TextureFormat::RGBA8Unorm;  //!< Texel format.
   TextureUsage usage = TextureUsage::None;           //!< Usage flags. Must not be empty.
-  uint32_t sampleCount = 1;  //!< Samples per texel. Only 1 is supported; coverage is analytic.
+  uint32_t sampleCount = 1;  //!< Samples per texel. Only 1 is accepted today; multisampled
+                             //!< attachments plus a resolve-target story arrive with the Geode
+                             //!< pipeline migration packets.
 };
 
 /// Descriptor for `Device::createTextureView`. Views cover the whole texture.
@@ -392,7 +394,8 @@ struct RenderPipelineDescriptor {
   FragmentState fragment;                                        //!< Fragment stage.
   PrimitiveTopology topology = PrimitiveTopology::TriangleList;  //!< Primitive topology.
   CullMode cullMode = CullMode::None;                            //!< Face culling mode.
-  uint32_t multisampleCount = 1;  //!< Samples per pixel. Only 1 is supported.
+  uint32_t multisampleCount = 1;  //!< Samples per pixel. Only 1 is accepted today; multisample
+                                  //!< support arrives with the Geode pipeline migration packets.
 };
 
 /// One color attachment of a \ref RenderPassDescriptor.
@@ -421,10 +424,11 @@ struct TexelCopyTextureInfo {
  *
  * \ref bytesPerRow must be a multiple of \ref donner::gpu::kTexelRowPitchAlignment (256): that is
  * the strictest row-pitch alignment across the native APIs this runtime targets, so enforcing it
- * uniformly keeps recorded copies portable to every backend without repacking.
+ * uniformly keeps recorded copies portable to every backend without repacking. For the same
+ * portability reason, \ref offsetBytes must be aligned to the copied format's texel size.
  */
 struct TexelCopyBufferLayout {
-  uint64_t offsetBytes = 0;   //!< Byte offset of the first texel row.
+  uint64_t offsetBytes = 0;   //!< Byte offset of the first texel row. Must be texel-size aligned.
   uint32_t bytesPerRow = 0;   //!< Bytes between row starts. Must be 256-aligned and cover a row.
   uint32_t rowsPerImage = 0;  //!< Rows allotted to the image. Must cover the copy height.
 };

--- a/donner/gpu/Descriptors.h
+++ b/donner/gpu/Descriptors.h
@@ -1,0 +1,463 @@
+#pragma once
+/// @file
+/// Typed immutable descriptors for \c donner::gpu resource creation.
+///
+/// The enum and descriptor surface is intentionally narrow: it covers the operations Geode's
+/// rendering and the editor actually use (design 0053 "Command model"), not a general GPU API.
+/// Descriptors are plain value types, immutable by convention; all validation happens in
+/// \ref donner::gpu::Device operations, which fail closed on malformed input.
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <ostream>
+#include <type_traits>
+#include <variant>
+#include <vector>
+
+#include "donner/base/RcString.h"
+#include "donner/gpu/Handles.h"
+
+namespace donner::gpu {
+
+/**
+ * Marks an enum as a bitmask, enabling `operator|`, `operator&`, `operator|=`, and
+ * \ref HasAllFlags. Specialize to \c std::true_type for each bitmask enum.
+ *
+ * @tparam T Enum type.
+ */
+template <typename T>
+struct IsBitmaskEnum : std::false_type {};
+
+/// Concept satisfied by enums marked with \ref IsBitmaskEnum.
+template <typename T>
+concept BitmaskEnum = IsBitmaskEnum<T>::value;
+
+/**
+ * Bitwise-or for bitmask enums.
+ *
+ * @param lhs First operand.
+ * @param rhs Second operand.
+ */
+template <BitmaskEnum T>
+constexpr T operator|(T lhs, T rhs) {
+  return static_cast<T>(static_cast<uint32_t>(lhs) | static_cast<uint32_t>(rhs));
+}
+
+/**
+ * Bitwise-and for bitmask enums.
+ *
+ * @param lhs First operand.
+ * @param rhs Second operand.
+ */
+template <BitmaskEnum T>
+constexpr T operator&(T lhs, T rhs) {
+  return static_cast<T>(static_cast<uint32_t>(lhs) & static_cast<uint32_t>(rhs));
+}
+
+/**
+ * Bitwise-or-assign for bitmask enums.
+ *
+ * @param lhs Value to update.
+ * @param rhs Flags to add.
+ */
+template <BitmaskEnum T>
+constexpr T& operator|=(T& lhs, T rhs) {
+  lhs = lhs | rhs;
+  return lhs;
+}
+
+/**
+ * Returns true if \p value contains every flag in \p flags.
+ *
+ * @param value Flags to test.
+ * @param flags Required flags.
+ */
+template <BitmaskEnum T>
+constexpr bool HasAllFlags(T value, T flags) {
+  return (value & flags) == flags;
+}
+
+/// Texture formats used by Donner render targets, masks, and image uploads.
+enum class TextureFormat : uint8_t {
+  RGBA8Unorm,  //!< 8-bit RGBA, unsigned normalized. Default render target format.
+  BGRA8Unorm,  //!< 8-bit BGRA, unsigned normalized. Editor surface format.
+  R8Unorm,     //!< 8-bit single channel. Coverage / clip-mask textures.
+};
+
+/// Texture usage flags. Combinable with `|`.
+enum class TextureUsage : uint32_t {
+  None = 0,                   //!< No usage; invalid for creation.
+  RenderAttachment = 1 << 0,  //!< Color attachment of a render pass.
+  Sampled = 1 << 1,           //!< Sampled in a shader.
+  CopySrc = 1 << 2,           //!< Source of copy operations (readback).
+  CopyDst = 1 << 3,           //!< Destination of copies and queue writes.
+};
+
+/// Buffer usage flags. Combinable with `|`.
+enum class BufferUsage : uint32_t {
+  None = 0,          //!< No usage; invalid for creation.
+  Vertex = 1 << 0,   //!< Bound as a vertex buffer.
+  Index = 1 << 1,    //!< Bound as an index buffer.
+  Uniform = 1 << 2,  //!< Bound as a uniform buffer.
+  Storage = 1 << 3,  //!< Bound as a read-only storage buffer.
+  CopySrc = 1 << 4,  //!< Source of copy operations.
+  CopyDst = 1 << 5,  //!< Destination of copies and queue writes.
+  MapRead = 1 << 6,  //!< Host-readable after readback.
+};
+
+/// Shader stage visibility flags for bindings. Combinable with `|`.
+enum class ShaderStage : uint32_t {
+  None = 0,           //!< No stage; invalid for bind group layout entries.
+  Vertex = 1 << 0,    //!< Visible to the vertex stage.
+  Fragment = 1 << 1,  //!< Visible to the fragment stage.
+  Compute = 1 << 2,   //!< Visible to the compute stage.
+};
+
+/// Per-channel color write mask for a color target. Combinable with `|`.
+enum class ColorWriteMask : uint32_t {
+  None = 0,                          //!< Write no channels.
+  Red = 1 << 0,                      //!< Write the red channel.
+  Green = 1 << 1,                    //!< Write the green channel.
+  Blue = 1 << 2,                     //!< Write the blue channel.
+  Alpha = 1 << 3,                    //!< Write the alpha channel.
+  All = Red | Green | Blue | Alpha,  //!< Write all channels.
+};
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+template <>
+struct IsBitmaskEnum<TextureUsage> : std::true_type {};
+template <>
+struct IsBitmaskEnum<BufferUsage> : std::true_type {};
+template <>
+struct IsBitmaskEnum<ShaderStage> : std::true_type {};
+template <>
+struct IsBitmaskEnum<ColorWriteMask> : std::true_type {};
+#endif  // DOXYGEN_SHOULD_SKIP_THIS
+
+/// Sampler minification/magnification filter.
+enum class FilterMode : uint8_t {
+  Nearest,  //!< Nearest-texel sampling.
+  Linear,   //!< Bilinear sampling.
+};
+
+/// Sampler texture addressing mode.
+enum class AddressMode : uint8_t {
+  ClampToEdge,  //!< Clamp coordinates to the edge texel.
+  Repeat,       //!< Wrap coordinates (pattern tiling).
+};
+
+/// Vertex attribute formats used by Donner pipelines.
+enum class VertexFormat : uint8_t {
+  Float32x2,  //!< Two 32-bit floats (8 bytes).
+  Float32x4,  //!< Four 32-bit floats (16 bytes).
+  Uint32,     //!< One 32-bit unsigned integer (4 bytes).
+};
+
+/// Rate at which a vertex buffer is stepped through during a draw.
+enum class VertexStepMode : uint8_t {
+  Vertex,    //!< Advance per vertex.
+  Instance,  //!< Advance per instance.
+};
+
+/// Primitive topology for render pipelines.
+enum class PrimitiveTopology : uint8_t {
+  TriangleList,   //!< Separate triangles.
+  TriangleStrip,  //!< Triangle strip.
+};
+
+/// Face culling mode for render pipelines.
+enum class CullMode : uint8_t {
+  None,  //!< No culling; Donner geometry has no guaranteed winding.
+  Back,  //!< Cull back faces.
+};
+
+/// Blend factors used by Donner pipelines (premultiplied-alpha compositing).
+enum class BlendFactor : uint8_t {
+  Zero,              //!< Factor 0.
+  One,               //!< Factor 1.
+  SrcAlpha,          //!< Factor (source alpha).
+  OneMinusSrcAlpha,  //!< Factor (1 - source alpha).
+};
+
+/// Blend operations used by Donner pipelines.
+enum class BlendOperation : uint8_t {
+  Add,  //!< Component-wise addition (premultiplied source-over).
+  Max,  //!< Component-wise maximum (coverage / clip-mask union).
+};
+
+/// Type of resource a bind group layout entry expects.
+enum class BindingType : uint8_t {
+  UniformBuffer,          //!< Uniform buffer binding.
+  ReadOnlyStorageBuffer,  //!< Read-only storage buffer binding.
+  SampledTexture2dFloat,  //!< Sampled 2D float texture binding.
+  FilteringSampler,       //!< Filtering sampler binding.
+};
+
+/// Load operation for a render pass color attachment.
+enum class LoadOp : uint8_t {
+  Clear,  //!< Clear to the attachment's clear color.
+  Load,   //!< Preserve existing contents.
+};
+
+/// Store operation for a render pass color attachment.
+enum class StoreOp : uint8_t {
+  Store,    //!< Write results back to the texture.
+  Discard,  //!< Discard results (transient attachments).
+};
+
+/// Shader source language of a \ref ShaderModuleDescriptor.
+enum class ShaderSourceKind : uint8_t {
+  Wgsl,  //!< WGSL text.
+  Msl,   //!< Metal Shading Language text.
+};
+
+/// Ostream output operator. @param os Output stream. @param value Value to output.
+std::ostream& operator<<(std::ostream& os, TextureFormat value);
+/// Ostream output operator, e.g. `RenderAttachment|CopySrc`, or `None` when no flags are set.
+/// @param os Output stream. @param value Value to output.
+std::ostream& operator<<(std::ostream& os, TextureUsage value);
+/// Ostream output operator, e.g. `Vertex|CopyDst`, or `None` when no flags are set.
+/// @param os Output stream. @param value Value to output.
+std::ostream& operator<<(std::ostream& os, BufferUsage value);
+/// Ostream output operator, e.g. `Vertex|Fragment`, or `None` when no flags are set.
+/// @param os Output stream. @param value Value to output.
+std::ostream& operator<<(std::ostream& os, ShaderStage value);
+/// Ostream output operator, e.g. `Red|Green|Blue|Alpha`, or `None` when no flags are set.
+/// @param os Output stream. @param value Value to output.
+std::ostream& operator<<(std::ostream& os, ColorWriteMask value);
+/// Ostream output operator. @param os Output stream. @param value Value to output.
+std::ostream& operator<<(std::ostream& os, FilterMode value);
+/// Ostream output operator. @param os Output stream. @param value Value to output.
+std::ostream& operator<<(std::ostream& os, AddressMode value);
+/// Ostream output operator. @param os Output stream. @param value Value to output.
+std::ostream& operator<<(std::ostream& os, VertexFormat value);
+/// Ostream output operator. @param os Output stream. @param value Value to output.
+std::ostream& operator<<(std::ostream& os, VertexStepMode value);
+/// Ostream output operator. @param os Output stream. @param value Value to output.
+std::ostream& operator<<(std::ostream& os, PrimitiveTopology value);
+/// Ostream output operator. @param os Output stream. @param value Value to output.
+std::ostream& operator<<(std::ostream& os, CullMode value);
+/// Ostream output operator. @param os Output stream. @param value Value to output.
+std::ostream& operator<<(std::ostream& os, BlendFactor value);
+/// Ostream output operator. @param os Output stream. @param value Value to output.
+std::ostream& operator<<(std::ostream& os, BlendOperation value);
+/// Ostream output operator. @param os Output stream. @param value Value to output.
+std::ostream& operator<<(std::ostream& os, BindingType value);
+/// Ostream output operator. @param os Output stream. @param value Value to output.
+std::ostream& operator<<(std::ostream& os, LoadOp value);
+/// Ostream output operator. @param os Output stream. @param value Value to output.
+std::ostream& operator<<(std::ostream& os, StoreOp value);
+/// Ostream output operator. @param os Output stream. @param value Value to output.
+std::ostream& operator<<(std::ostream& os, ShaderSourceKind value);
+
+/**
+ * Bytes per texel for a \ref TextureFormat.
+ *
+ * @param format Texture format.
+ */
+uint32_t TextureFormatBytesPerTexel(TextureFormat format);
+
+/**
+ * Byte size of a \ref VertexFormat.
+ *
+ * @param format Vertex attribute format.
+ */
+uint32_t VertexFormatByteSize(VertexFormat format);
+
+/// A 2D extent in texels.
+struct Extent2d {
+  uint32_t width = 0;   //!< Width in texels.
+  uint32_t height = 0;  //!< Height in texels.
+
+  /// Equality operator. @param other Extent to compare against.
+  bool operator==(const Extent2d& other) const = default;
+
+  /// Ostream output operator, e.g. `4x4`. @param os Output stream. @param value Extent to output.
+  friend std::ostream& operator<<(std::ostream& os, const Extent2d& value) {
+    return os << value.width << "x" << value.height;
+  }
+};
+
+/// Descriptor for `Device::createBuffer`.
+struct BufferDescriptor {
+  RcString label;                         //!< Debug label; also appears in recordings.
+  uint64_t byteSize = 0;                  //!< Size in bytes. Must be nonzero and within limits.
+  BufferUsage usage = BufferUsage::None;  //!< Usage flags. Must not be empty.
+};
+
+/// Descriptor for `Device::createTexture`. All Donner textures are 2D, single-mip.
+struct TextureDescriptor {
+  RcString label;                                    //!< Debug label.
+  Extent2d size;                                     //!< Extent in texels. Must be nonzero.
+  TextureFormat format = TextureFormat::RGBA8Unorm;  //!< Texel format.
+  TextureUsage usage = TextureUsage::None;           //!< Usage flags. Must not be empty.
+  uint32_t sampleCount = 1;  //!< Samples per texel. Only 1 is supported; coverage is analytic.
+};
+
+/// Descriptor for `Device::createTextureView`. Views cover the whole texture.
+struct TextureViewDescriptor {
+  RcString label;  //!< Debug label.
+};
+
+/// Descriptor for `Device::createSampler`.
+struct SamplerDescriptor {
+  RcString label;                                       //!< Debug label.
+  FilterMode magFilter = FilterMode::Nearest;           //!< Magnification filter.
+  FilterMode minFilter = FilterMode::Nearest;           //!< Minification filter.
+  AddressMode addressModeU = AddressMode::ClampToEdge;  //!< U-coordinate addressing.
+  AddressMode addressModeV = AddressMode::ClampToEdge;  //!< V-coordinate addressing.
+};
+
+/// One entry of a \ref BindGroupLayoutDescriptor.
+struct BindGroupLayoutEntry {
+  uint32_t binding = 0;                           //!< Shader binding index.
+  ShaderStage visibility = ShaderStage::None;     //!< Stages that may access the binding.
+  BindingType type = BindingType::UniformBuffer;  //!< Kind of resource bound.
+};
+
+/// Descriptor for `Device::createBindGroupLayout`.
+struct BindGroupLayoutDescriptor {
+  RcString label;                             //!< Debug label.
+  std::vector<BindGroupLayoutEntry> entries;  //!< Entries; binding indices must be unique.
+};
+
+/// Descriptor for `Device::createPipelineLayout`.
+struct PipelineLayoutDescriptor {
+  RcString label;                                    //!< Debug label.
+  std::vector<BindGroupLayoutRef> bindGroupLayouts;  //!< Bind group layouts, by group index.
+};
+
+/// Descriptor for `Device::createShaderModule`. Source is trusted generated build output, never
+/// runtime input from documents.
+struct ShaderModuleDescriptor {
+  RcString label;                                        //!< Debug label.
+  RcString sourceText;                                   //!< Shader source text. Must be nonempty.
+  ShaderSourceKind sourceKind = ShaderSourceKind::Wgsl;  //!< Source language.
+};
+
+/// One vertex attribute within a \ref VertexBufferLayout.
+struct VertexAttribute {
+  VertexFormat format = VertexFormat::Float32x2;  //!< Attribute format.
+  uint32_t offsetBytes = 0;                       //!< Byte offset within one element.
+  uint32_t shaderLocation = 0;                    //!< Location index in the shader.
+};
+
+/// Layout of one vertex buffer slot of a render pipeline.
+struct VertexBufferLayout {
+  uint32_t strideBytes = 0;  //!< Bytes per element. Must fit all attributes.
+  VertexStepMode stepMode = VertexStepMode::Vertex;  //!< Step rate.
+  std::vector<VertexAttribute> attributes;           //!< Attributes; locations must be unique.
+};
+
+/// One blend term (color or alpha) of a \ref BlendState.
+struct BlendComponent {
+  BlendFactor srcFactor = BlendFactor::One;        //!< Source factor.
+  BlendFactor dstFactor = BlendFactor::Zero;       //!< Destination factor.
+  BlendOperation operation = BlendOperation::Add;  //!< Blend operation.
+};
+
+/// Blend state for one color target.
+struct BlendState {
+  BlendComponent color;  //!< RGB blend term.
+  BlendComponent alpha;  //!< Alpha blend term.
+};
+
+/// One color target of a render pipeline's fragment stage.
+struct ColorTargetState {
+  TextureFormat format = TextureFormat::RGBA8Unorm;  //!< Attachment format.
+  std::optional<BlendState> blend;                   //!< Blend state; disabled if empty.
+  ColorWriteMask writeMask = ColorWriteMask::All;    //!< Channels written.
+};
+
+/// Vertex stage of a \ref RenderPipelineDescriptor.
+struct VertexState {
+  ShaderModuleRef module;                   //!< Shader module containing the entry point.
+  RcString entryPoint;                      //!< Entry point name. Must be nonempty.
+  std::vector<VertexBufferLayout> buffers;  //!< Vertex buffer layouts, by slot.
+};
+
+/// Fragment stage of a \ref RenderPipelineDescriptor.
+struct FragmentState {
+  ShaderModuleRef module;                 //!< Shader module containing the entry point.
+  RcString entryPoint;                    //!< Entry point name. Must be nonempty.
+  std::vector<ColorTargetState> targets;  //!< Color targets. Must be nonempty.
+};
+
+/// Descriptor for `Device::createRenderPipeline`.
+struct RenderPipelineDescriptor {
+  RcString label;                                                //!< Debug label.
+  PipelineLayoutRef layout;                                      //!< Pipeline layout.
+  VertexState vertex;                                            //!< Vertex stage.
+  FragmentState fragment;                                        //!< Fragment stage.
+  PrimitiveTopology topology = PrimitiveTopology::TriangleList;  //!< Primitive topology.
+  CullMode cullMode = CullMode::None;                            //!< Face culling mode.
+  uint32_t multisampleCount = 1;  //!< Samples per pixel. Only 1 is supported.
+};
+
+/// One color attachment of a \ref RenderPassDescriptor.
+struct RenderPassColorAttachment {
+  TextureViewRef view;                    //!< Attachment view. Texture needs
+                                          //!< \ref TextureUsage::RenderAttachment.
+  LoadOp loadOp = LoadOp::Clear;          //!< Load operation.
+  StoreOp storeOp = StoreOp::Store;       //!< Store operation.
+  std::array<double, 4> clearColor = {};  //!< Premultiplied RGBA clear color (loadOp Clear).
+};
+
+/// Descriptor for `CommandEncoder::beginRenderPass`.
+struct RenderPassDescriptor {
+  RcString label;                                           //!< Pass debug label.
+  std::vector<RenderPassColorAttachment> colorAttachments;  //!< Attachments. Must be nonempty and
+                                                            //!< share one extent.
+};
+
+/// Source texture of a texture-to-buffer copy. Copies start at texel (0, 0).
+struct TexelCopyTextureInfo {
+  TextureRef texture;  //!< Source texture. Needs \ref TextureUsage::CopySrc.
+};
+
+/**
+ * Byte layout of texel rows in buffer or host memory for copy operations.
+ *
+ * \ref bytesPerRow must be a multiple of \ref donner::gpu::kTexelRowPitchAlignment (256): that is
+ * the strictest row-pitch alignment across the native APIs this runtime targets, so enforcing it
+ * uniformly keeps recorded copies portable to every backend without repacking.
+ */
+struct TexelCopyBufferLayout {
+  uint64_t offsetBytes = 0;   //!< Byte offset of the first texel row.
+  uint32_t bytesPerRow = 0;   //!< Bytes between row starts. Must be 256-aligned and cover a row.
+  uint32_t rowsPerImage = 0;  //!< Rows allotted to the image. Must cover the copy height.
+};
+
+/// A buffer range bound through a bind group.
+struct BufferBinding {
+  BufferRef buffer;          //!< Bound buffer.
+  uint64_t offsetBytes = 0;  //!< Byte offset of the bound range.
+  uint64_t sizeBytes = 0;    //!< Byte size of the bound range. Must be nonzero.
+};
+
+/// A texture view bound through a bind group.
+struct TextureViewBinding {
+  TextureViewRef view;  //!< Bound view. Texture needs \ref TextureUsage::Sampled.
+};
+
+/// A sampler bound through a bind group.
+struct SamplerBinding {
+  SamplerRef sampler;  //!< Bound sampler.
+};
+
+/// One entry of a \ref BindGroupDescriptor. The resource alternative must match the
+/// \ref BindingType of the layout entry with the same binding index.
+struct BindGroupEntry {
+  uint32_t binding = 0;  //!< Shader binding index.
+  std::variant<BufferBinding, TextureViewBinding, SamplerBinding> resource;  //!< Bound resource.
+};
+
+/// Descriptor for `Device::createBindGroup`.
+struct BindGroupDescriptor {
+  RcString label;                       //!< Debug label.
+  BindGroupLayoutRef layout;            //!< Layout the entries must match exactly.
+  std::vector<BindGroupEntry> entries;  //!< One entry per layout binding.
+};
+
+}  // namespace donner::gpu

--- a/donner/gpu/Descriptors.h
+++ b/donner/gpu/Descriptors.h
@@ -251,6 +251,46 @@ std::ostream& operator<<(std::ostream& os, StoreOp value);
 /// Ostream output operator. @param os Output stream. @param value Value to output.
 std::ostream& operator<<(std::ostream& os, ShaderSourceKind value);
 
+/// Returns true if \p value is a known enumerator. Every enum arriving through a descriptor is
+/// checked with these overloads so out-of-range casts fail closed with
+/// \ref GpuErrorType::InvalidDescriptor instead of flowing into layout or copy math.
+/// @param value Value to check.
+bool IsKnownEnumValue(TextureFormat value);
+/// Returns true if \p value is a known enumerator. @param value Value to check.
+bool IsKnownEnumValue(FilterMode value);
+/// Returns true if \p value is a known enumerator. @param value Value to check.
+bool IsKnownEnumValue(AddressMode value);
+/// Returns true if \p value is a known enumerator. @param value Value to check.
+bool IsKnownEnumValue(VertexFormat value);
+/// Returns true if \p value is a known enumerator. @param value Value to check.
+bool IsKnownEnumValue(VertexStepMode value);
+/// Returns true if \p value is a known enumerator. @param value Value to check.
+bool IsKnownEnumValue(PrimitiveTopology value);
+/// Returns true if \p value is a known enumerator. @param value Value to check.
+bool IsKnownEnumValue(CullMode value);
+/// Returns true if \p value is a known enumerator. @param value Value to check.
+bool IsKnownEnumValue(BlendFactor value);
+/// Returns true if \p value is a known enumerator. @param value Value to check.
+bool IsKnownEnumValue(BlendOperation value);
+/// Returns true if \p value is a known enumerator. @param value Value to check.
+bool IsKnownEnumValue(BindingType value);
+/// Returns true if \p value is a known enumerator. @param value Value to check.
+bool IsKnownEnumValue(LoadOp value);
+/// Returns true if \p value is a known enumerator. @param value Value to check.
+bool IsKnownEnumValue(StoreOp value);
+/// Returns true if \p value is a known enumerator. @param value Value to check.
+bool IsKnownEnumValue(ShaderSourceKind value);
+
+/// Returns true if \p value contains only known flag bits (an empty mask is bit-valid; emptiness
+/// is validated separately where required). @param value Bitmask to check.
+bool IsValidBitmask(TextureUsage value);
+/// Returns true if \p value contains only known flag bits. @param value Bitmask to check.
+bool IsValidBitmask(BufferUsage value);
+/// Returns true if \p value contains only known flag bits. @param value Bitmask to check.
+bool IsValidBitmask(ShaderStage value);
+/// Returns true if \p value contains only known flag bits. @param value Bitmask to check.
+bool IsValidBitmask(ColorWriteMask value);
+
 /**
  * Bytes per texel for a \ref TextureFormat.
  *

--- a/donner/gpu/Device.cc
+++ b/donner/gpu/Device.cc
@@ -239,6 +239,20 @@ Result<Texture> Device::createTexture(const TextureDescriptor& descriptor) {
   return handle;
 }
 
+Result<const Device::TextureRecord*> Device::resolveViewedTexture(
+    const TextureViewRecord& viewRecord) const {
+  const TextureRecord* record =
+      textures_.find(viewRecord.textureIdentity.slotIndex, viewRecord.textureIdentity.generation);
+  if (record == nullptr) {
+    return Err(
+        GpuErrorType::InvalidHandle,
+        std::format("textureView \"{}\" is stale; the view's texture was destroyed "
+                    "(texture slot {})",
+                    viewRecord.descriptor.label.str(), viewRecord.textureIdentity.slotIndex));
+  }
+  return record;
+}
+
 Result<TextureView> Device::createTextureView(const Texture& texture,
                                               const TextureViewDescriptor& descriptor) {
   auto textureRecord = resolve(textures_, texture, TextureTag::kName);
@@ -246,9 +260,7 @@ Result<TextureView> Device::createTextureView(const Texture& texture,
     return std::move(textureRecord).error();
   }
 
-  TextureViewRecord record{
-      descriptor, texture.slotIndex(), textureRecord.result()->descriptor.format,
-      textureRecord.result()->descriptor.size, textureRecord.result()->descriptor.usage};
+  TextureViewRecord record{descriptor, ResourceIdentity{texture.slotIndex(), texture.generation()}};
   TextureView handle = allocateHandle<TextureViewTag>(textureViews_, std::move(record));
   if (Status status = onCreateTextureView(handle.slotIndex(), texture.slotIndex(), descriptor);
       status.hasError()) {
@@ -367,7 +379,11 @@ Result<BindGroup> Device::createBindGroup(const BindGroupDescriptor& descriptor)
         if (viewRecord.hasError()) {
           return std::move(viewRecord).error();
         }
-        if (!HasAllFlags(viewRecord.result()->textureUsage, TextureUsage::Sampled)) {
+        auto viewedTexture = resolveViewedTexture(*viewRecord.result());
+        if (viewedTexture.hasError()) {
+          return std::move(viewedTexture).error();
+        }
+        if (!HasAllFlags(viewedTexture.result()->descriptor.usage, TextureUsage::Sampled)) {
           return Err(GpuErrorType::UsageMismatch,
                      std::format("BindGroupEntry binding {}: texture view \"{}\" lacks the "
                                  "Sampled usage",
@@ -393,7 +409,7 @@ Result<BindGroup> Device::createBindGroup(const BindGroupDescriptor& descriptor)
   }
 
   BindGroupRecord record{
-      descriptor, LayoutIdentity{descriptor.layout.slotIndex(), descriptor.layout.generation()}};
+      descriptor, ResourceIdentity{descriptor.layout.slotIndex(), descriptor.layout.generation()}};
   BindGroup handle = allocateHandle<BindGroupTag>(bindGroups_, std::move(record));
   if (Status status = onCreateBindGroup(handle.slotIndex(), descriptor); status.hasError()) {
     bindGroups_.release(handle.slotIndex());
@@ -410,14 +426,14 @@ Result<PipelineLayout> Device::createPipelineLayout(const PipelineLayoutDescript
                            descriptor.bindGroupLayouts.size(), kMaxBindGroups));
   }
 
-  std::vector<LayoutIdentity> layoutIds;
+  std::vector<ResourceIdentity> layoutIds;
   layoutIds.reserve(descriptor.bindGroupLayouts.size());
   for (const BindGroupLayoutRef& layoutRef : descriptor.bindGroupLayouts) {
     auto layoutRecord = resolve(bindGroupLayouts_, layoutRef, BindGroupLayoutTag::kName);
     if (layoutRecord.hasError()) {
       return std::move(layoutRecord).error();
     }
-    layoutIds.push_back(LayoutIdentity{layoutRef.slotIndex(), layoutRef.generation()});
+    layoutIds.push_back(ResourceIdentity{layoutRef.slotIndex(), layoutRef.generation()});
   }
 
   PipelineLayout handle = allocateHandle<PipelineLayoutTag>(
@@ -601,10 +617,13 @@ Result<uint64_t> Device::submit(CommandBuffer commandBuffer) {
       std::move(commandBuffers_.findMutable(slotIndex, commandBuffer.generation())->commands);
   commandBuffers_.release(slotIndex);
 
-  const uint64_t serial = ++lastSubmittedSerial_;
+  // Advance the serial only after the backend accepts the submission: a failed submit must not
+  // burn a serial, or completion waiters would treat the failed work as finished.
+  const uint64_t serial = lastSubmittedSerial_ + 1;
   if (Status status = onSubmit(serial, slotIndex, commands); status.hasError()) {
     return std::move(status).error();
   }
+  lastSubmittedSerial_ = serial;
   return serial;
 }
 

--- a/donner/gpu/Device.cc
+++ b/donner/gpu/Device.cc
@@ -1,0 +1,616 @@
+#include "donner/gpu/Device.h"
+
+#include <atomic>
+#include <cmath>
+#include <format>
+#include <memory>
+#include <utility>
+
+#include "donner/gpu/CheckedArithmetic.h"
+#include "donner/gpu/CommandEncoder.h"
+#include "donner/gpu/GpuLimits.h"
+
+namespace donner::gpu {
+
+namespace {
+
+/// Builds a \ref GpuError with the given category and message.
+GpuError Err(GpuErrorType type, std::string message) {
+  return GpuError{type, std::move(message)};
+}
+
+/// Validates a \ref BufferDescriptor.
+Status ValidateBufferDescriptor(const BufferDescriptor& descriptor) {
+  if (descriptor.byteSize == 0) {
+    return Err(GpuErrorType::InvalidDescriptor, "BufferDescriptor.byteSize is 0");
+  }
+  if (descriptor.byteSize > kMaxBufferByteSize) {
+    return Err(GpuErrorType::LimitExceeded,
+               std::format("BufferDescriptor.byteSize {} exceeds kMaxBufferByteSize {}",
+                           descriptor.byteSize, kMaxBufferByteSize));
+  }
+  if (descriptor.usage == BufferUsage::None) {
+    return Err(GpuErrorType::InvalidDescriptor, "BufferDescriptor.usage is empty");
+  }
+  return OkStatus();
+}
+
+/// Validates a \ref TextureDescriptor.
+Status ValidateTextureDescriptor(const TextureDescriptor& descriptor) {
+  if (descriptor.size.width == 0 || descriptor.size.height == 0) {
+    return Err(GpuErrorType::InvalidDescriptor,
+               std::format("TextureDescriptor.size {}x{} has a zero dimension",
+                           descriptor.size.width, descriptor.size.height));
+  }
+  if (descriptor.size.width > kMaxTextureDimension ||
+      descriptor.size.height > kMaxTextureDimension) {
+    return Err(GpuErrorType::LimitExceeded,
+               std::format("TextureDescriptor.size {}x{} exceeds kMaxTextureDimension {}",
+                           descriptor.size.width, descriptor.size.height, kMaxTextureDimension));
+  }
+  if (descriptor.usage == TextureUsage::None) {
+    return Err(GpuErrorType::InvalidDescriptor, "TextureDescriptor.usage is empty");
+  }
+  if (descriptor.sampleCount != 1) {
+    return Err(GpuErrorType::Unsupported,
+               std::format("TextureDescriptor.sampleCount {} is not supported; only 1 sample per "
+                           "texel is available",
+                           descriptor.sampleCount));
+  }
+  return OkStatus();
+}
+
+/// Validates a \ref BindGroupLayoutDescriptor.
+Status ValidateBindGroupLayoutDescriptor(const BindGroupLayoutDescriptor& descriptor) {
+  if (descriptor.entries.empty()) {
+    return Err(GpuErrorType::InvalidDescriptor, "BindGroupLayoutDescriptor.entries is empty");
+  }
+  if (descriptor.entries.size() > kMaxBindings) {
+    return Err(GpuErrorType::LimitExceeded,
+               std::format("BindGroupLayoutDescriptor has {} entries, exceeding kMaxBindings {}",
+                           descriptor.entries.size(), kMaxBindings));
+  }
+  for (size_t i = 0; i < descriptor.entries.size(); ++i) {
+    const BindGroupLayoutEntry& entry = descriptor.entries[i];
+    if (entry.binding >= kMaxBindings) {
+      return Err(GpuErrorType::LimitExceeded,
+                 std::format("BindGroupLayoutEntry.binding {} exceeds kMaxBindings {}",
+                             entry.binding, kMaxBindings));
+    }
+    if (entry.visibility == ShaderStage::None) {
+      return Err(
+          GpuErrorType::InvalidDescriptor,
+          std::format("BindGroupLayoutEntry binding {} has empty visibility", entry.binding));
+    }
+    for (size_t j = i + 1; j < descriptor.entries.size(); ++j) {
+      if (descriptor.entries[j].binding == entry.binding) {
+        return Err(
+            GpuErrorType::InvalidDescriptor,
+            std::format("BindGroupLayoutDescriptor has duplicate binding index {}", entry.binding));
+      }
+    }
+  }
+  return OkStatus();
+}
+
+/// Validates the vertex buffer layouts of a \ref RenderPipelineDescriptor.
+Status ValidateVertexBufferLayouts(const std::vector<VertexBufferLayout>& buffers) {
+  if (buffers.size() > kMaxVertexBuffers) {
+    return Err(GpuErrorType::LimitExceeded,
+               std::format("RenderPipelineDescriptor has {} vertex buffers, exceeding "
+                           "kMaxVertexBuffers {}",
+                           buffers.size(), kMaxVertexBuffers));
+  }
+
+  for (size_t bufferIndex = 0; bufferIndex < buffers.size(); ++bufferIndex) {
+    const VertexBufferLayout& layout = buffers[bufferIndex];
+    if (layout.strideBytes == 0) {
+      return Err(GpuErrorType::InvalidDescriptor,
+                 std::format("VertexBufferLayout {} has strideBytes 0", bufferIndex));
+    }
+    if (layout.attributes.empty()) {
+      return Err(GpuErrorType::InvalidDescriptor,
+                 std::format("VertexBufferLayout {} has no attributes", bufferIndex));
+    }
+    for (const VertexAttribute& attribute : layout.attributes) {
+      const std::optional<uint64_t> attributeEnd =
+          CheckedAdd(attribute.offsetBytes, VertexFormatByteSize(attribute.format));
+      if (!attributeEnd || *attributeEnd > layout.strideBytes) {
+        return Err(GpuErrorType::InvalidDescriptor,
+                   std::format("VertexAttribute at shaderLocation {} (offsetBytes {}, {}) "
+                               "overflows strideBytes {}",
+                               attribute.shaderLocation, attribute.offsetBytes,
+                               VertexFormatByteSize(attribute.format), layout.strideBytes));
+      }
+    }
+  }
+
+  for (size_t bufferIndex = 0; bufferIndex < buffers.size(); ++bufferIndex) {
+    for (const VertexAttribute& attribute : buffers[bufferIndex].attributes) {
+      for (size_t otherIndex = 0; otherIndex < buffers.size(); ++otherIndex) {
+        for (const VertexAttribute& other : buffers[otherIndex].attributes) {
+          if (&attribute != &other && attribute.shaderLocation == other.shaderLocation) {
+            return Err(GpuErrorType::InvalidDescriptor,
+                       std::format("RenderPipelineDescriptor has duplicate vertex shaderLocation "
+                                   "{}",
+                                   attribute.shaderLocation));
+          }
+        }
+      }
+    }
+  }
+  return OkStatus();
+}
+
+}  // namespace
+
+Result<uint64_t> ValidateTexelCopyInternal(const TexelCopyBufferLayout& layout,
+                                           const Extent2d& copySize, TextureFormat format,
+                                           std::string_view context) {
+  if (copySize.width == 0 || copySize.height == 0) {
+    return Err(GpuErrorType::InvalidDescriptor,
+               std::format("{}: copy size {}x{} has a zero dimension", context, copySize.width,
+                           copySize.height));
+  }
+  const std::optional<uint64_t> rowBytes =
+      CheckedMul(copySize.width, TextureFormatBytesPerTexel(format));
+  if (!rowBytes) {
+    return Err(GpuErrorType::OutOfBounds, std::format("{}: row byte size overflows", context));
+  }
+  if (layout.bytesPerRow % kTexelRowPitchAlignment != 0) {
+    return Err(GpuErrorType::InvalidDescriptor,
+               std::format("{}: bytesPerRow {} is not a multiple of {}", context,
+                           layout.bytesPerRow, kTexelRowPitchAlignment));
+  }
+  if (layout.bytesPerRow < *rowBytes) {
+    return Err(GpuErrorType::InvalidDescriptor,
+               std::format("{}: bytesPerRow {} does not cover one row of {} bytes", context,
+                           layout.bytesPerRow, *rowBytes));
+  }
+  if (layout.rowsPerImage < copySize.height) {
+    return Err(GpuErrorType::InvalidDescriptor,
+               std::format("{}: rowsPerImage {} does not cover {} rows", context,
+                           layout.rowsPerImage, copySize.height));
+  }
+
+  const std::optional<uint64_t> interiorBytes =
+      CheckedMul(static_cast<uint64_t>(copySize.height) - 1, layout.bytesPerRow);
+  const std::optional<uint64_t> imageBytes =
+      interiorBytes ? CheckedAdd(*interiorBytes, *rowBytes) : std::nullopt;
+  const std::optional<uint64_t> endByte =
+      imageBytes ? CheckedAdd(layout.offsetBytes, *imageBytes) : std::nullopt;
+  if (!endByte) {
+    return Err(GpuErrorType::OutOfBounds,
+               std::format("{}: byte range (offsetBytes {} + rows) overflows", context,
+                           layout.offsetBytes));
+  }
+  return *endByte;
+}
+
+uint64_t Device::NextDeviceId() {
+  static std::atomic<uint64_t> counter{1};
+  return counter.fetch_add(1, std::memory_order_relaxed);
+}
+
+Device::Device() : deviceId_(NextDeviceId()) {}
+
+Device::~Device() = default;
+
+template <typename Tag, typename Record>
+Handle<Tag> Device::allocateHandle(details::SlotTable<Record>& table, Record&& record) {
+  const uint32_t slotIndex = table.allocate(std::move(record));
+  return Handle<Tag>::CreateForBackend(slotIndex, table.generationOf(slotIndex), deviceId_);
+}
+
+template <typename Record, typename Tag>
+Status Device::destroyResource(details::SlotTable<Record>& table, const Handle<Tag>& handle) {
+  auto resolved = resolve(table, handle, Tag::kName);
+  if (resolved.hasError()) {
+    return std::move(resolved).error();
+  }
+  table.release(handle.slotIndex());
+  onDestroyResource(Tag::kName, handle.slotIndex());
+  return OkStatus();
+}
+
+Result<Buffer> Device::createBuffer(const BufferDescriptor& descriptor) {
+  if (Status status = ValidateBufferDescriptor(descriptor); status.hasError()) {
+    return std::move(status).error();
+  }
+
+  Buffer handle = allocateHandle<BufferTag>(buffers_, BufferRecord{descriptor});
+  if (Status status = onCreateBuffer(handle.slotIndex(), descriptor); status.hasError()) {
+    buffers_.release(handle.slotIndex());
+    return std::move(status).error();
+  }
+  return handle;
+}
+
+Result<Texture> Device::createTexture(const TextureDescriptor& descriptor) {
+  if (Status status = ValidateTextureDescriptor(descriptor); status.hasError()) {
+    return std::move(status).error();
+  }
+
+  Texture handle = allocateHandle<TextureTag>(textures_, TextureRecord{descriptor});
+  if (Status status = onCreateTexture(handle.slotIndex(), descriptor); status.hasError()) {
+    textures_.release(handle.slotIndex());
+    return std::move(status).error();
+  }
+  return handle;
+}
+
+Result<TextureView> Device::createTextureView(const Texture& texture,
+                                              const TextureViewDescriptor& descriptor) {
+  auto textureRecord = resolve(textures_, texture, TextureTag::kName);
+  if (textureRecord.hasError()) {
+    return std::move(textureRecord).error();
+  }
+
+  TextureViewRecord record{
+      descriptor, texture.slotIndex(), textureRecord.result()->descriptor.format,
+      textureRecord.result()->descriptor.size, textureRecord.result()->descriptor.usage};
+  TextureView handle = allocateHandle<TextureViewTag>(textureViews_, std::move(record));
+  if (Status status = onCreateTextureView(handle.slotIndex(), texture.slotIndex(), descriptor);
+      status.hasError()) {
+    textureViews_.release(handle.slotIndex());
+    return std::move(status).error();
+  }
+  return handle;
+}
+
+Result<Sampler> Device::createSampler(const SamplerDescriptor& descriptor) {
+  Sampler handle = allocateHandle<SamplerTag>(samplers_, SamplerRecord{descriptor});
+  if (Status status = onCreateSampler(handle.slotIndex(), descriptor); status.hasError()) {
+    samplers_.release(handle.slotIndex());
+    return std::move(status).error();
+  }
+  return handle;
+}
+
+Result<BindGroupLayout> Device::createBindGroupLayout(const BindGroupLayoutDescriptor& descriptor) {
+  if (Status status = ValidateBindGroupLayoutDescriptor(descriptor); status.hasError()) {
+    return std::move(status).error();
+  }
+
+  BindGroupLayout handle =
+      allocateHandle<BindGroupLayoutTag>(bindGroupLayouts_, BindGroupLayoutRecord{descriptor});
+  if (Status status = onCreateBindGroupLayout(handle.slotIndex(), descriptor); status.hasError()) {
+    bindGroupLayouts_.release(handle.slotIndex());
+    return std::move(status).error();
+  }
+  return handle;
+}
+
+Result<BindGroup> Device::createBindGroup(const BindGroupDescriptor& descriptor) {
+  auto layoutRecord = resolve(bindGroupLayouts_, descriptor.layout, BindGroupLayoutTag::kName);
+  if (layoutRecord.hasError()) {
+    return std::move(layoutRecord).error();
+  }
+
+  const std::vector<BindGroupLayoutEntry>& layoutEntries =
+      layoutRecord.result()->descriptor.entries;
+  if (descriptor.entries.size() != layoutEntries.size()) {
+    return Err(GpuErrorType::InvalidDescriptor,
+               std::format("BindGroupDescriptor has {} entries but the layout requires {}",
+                           descriptor.entries.size(), layoutEntries.size()));
+  }
+
+  for (const BindGroupLayoutEntry& layoutEntry : layoutEntries) {
+    const BindGroupEntry* match = nullptr;
+    for (const BindGroupEntry& entry : descriptor.entries) {
+      if (entry.binding == layoutEntry.binding) {
+        if (match != nullptr) {
+          return Err(GpuErrorType::InvalidDescriptor,
+                     std::format("BindGroupDescriptor has duplicate entries for binding {}",
+                                 layoutEntry.binding));
+        }
+        match = &entry;
+      }
+    }
+    if (match == nullptr) {
+      return Err(GpuErrorType::InvalidDescriptor,
+                 std::format("BindGroupDescriptor is missing an entry for layout binding {}",
+                             layoutEntry.binding));
+    }
+
+    switch (layoutEntry.type) {
+      case BindingType::UniformBuffer:
+      case BindingType::ReadOnlyStorageBuffer: {
+        const BufferBinding* bufferBinding = std::get_if<BufferBinding>(&match->resource);
+        if (bufferBinding == nullptr) {
+          return Err(GpuErrorType::InvalidDescriptor,
+                     std::format("BindGroupEntry binding {} must bind a buffer to match the "
+                                 "layout type {}",
+                                 match->binding,
+                                 layoutEntry.type == BindingType::UniformBuffer
+                                     ? "UniformBuffer"
+                                     : "ReadOnlyStorageBuffer"));
+        }
+        auto bufferRecord = resolve(buffers_, bufferBinding->buffer, BufferTag::kName);
+        if (bufferRecord.hasError()) {
+          return std::move(bufferRecord).error();
+        }
+        const bool isUniform = layoutEntry.type == BindingType::UniformBuffer;
+        const BufferUsage requiredUsage = isUniform ? BufferUsage::Uniform : BufferUsage::Storage;
+        if (!HasAllFlags(bufferRecord.result()->descriptor.usage, requiredUsage)) {
+          return Err(GpuErrorType::UsageMismatch,
+                     std::format("BindGroupEntry binding {}: buffer \"{}\" lacks the {} usage",
+                                 match->binding, bufferRecord.result()->descriptor.label.str(),
+                                 isUniform ? "Uniform" : "Storage"));
+        }
+        if (bufferBinding->sizeBytes == 0) {
+          return Err(GpuErrorType::InvalidDescriptor,
+                     std::format("BindGroupEntry binding {}: sizeBytes is 0", match->binding));
+        }
+        const std::optional<uint64_t> bindingEnd =
+            CheckedAdd(bufferBinding->offsetBytes, bufferBinding->sizeBytes);
+        if (!bindingEnd || *bindingEnd > bufferRecord.result()->descriptor.byteSize) {
+          return Err(
+              GpuErrorType::OutOfBounds,
+              std::format("BindGroupEntry binding {}: range offsetBytes={} sizeBytes={} "
+                          "does not fit in buffer \"{}\" of {} bytes",
+                          match->binding, bufferBinding->offsetBytes, bufferBinding->sizeBytes,
+                          bufferRecord.result()->descriptor.label.str(),
+                          bufferRecord.result()->descriptor.byteSize));
+        }
+        break;
+      }
+      case BindingType::SampledTexture2dFloat: {
+        const TextureViewBinding* viewBinding = std::get_if<TextureViewBinding>(&match->resource);
+        if (viewBinding == nullptr) {
+          return Err(GpuErrorType::InvalidDescriptor,
+                     std::format("BindGroupEntry binding {} must bind a texture view to match "
+                                 "the layout type SampledTexture2dFloat",
+                                 match->binding));
+        }
+        auto viewRecord = resolve(textureViews_, viewBinding->view, TextureViewTag::kName);
+        if (viewRecord.hasError()) {
+          return std::move(viewRecord).error();
+        }
+        if (!HasAllFlags(viewRecord.result()->textureUsage, TextureUsage::Sampled)) {
+          return Err(GpuErrorType::UsageMismatch,
+                     std::format("BindGroupEntry binding {}: texture view \"{}\" lacks the "
+                                 "Sampled usage",
+                                 match->binding, viewRecord.result()->descriptor.label.str()));
+        }
+        break;
+      }
+      case BindingType::FilteringSampler: {
+        const SamplerBinding* samplerBinding = std::get_if<SamplerBinding>(&match->resource);
+        if (samplerBinding == nullptr) {
+          return Err(GpuErrorType::InvalidDescriptor,
+                     std::format("BindGroupEntry binding {} must bind a sampler to match the "
+                                 "layout type FilteringSampler",
+                                 match->binding));
+        }
+        auto samplerRecord = resolve(samplers_, samplerBinding->sampler, SamplerTag::kName);
+        if (samplerRecord.hasError()) {
+          return std::move(samplerRecord).error();
+        }
+        break;
+      }
+    }
+  }
+
+  BindGroupRecord record{
+      descriptor, LayoutIdentity{descriptor.layout.slotIndex(), descriptor.layout.generation()}};
+  BindGroup handle = allocateHandle<BindGroupTag>(bindGroups_, std::move(record));
+  if (Status status = onCreateBindGroup(handle.slotIndex(), descriptor); status.hasError()) {
+    bindGroups_.release(handle.slotIndex());
+    return std::move(status).error();
+  }
+  return handle;
+}
+
+Result<PipelineLayout> Device::createPipelineLayout(const PipelineLayoutDescriptor& descriptor) {
+  if (descriptor.bindGroupLayouts.size() > kMaxBindGroups) {
+    return Err(GpuErrorType::LimitExceeded,
+               std::format("PipelineLayoutDescriptor has {} bind group layouts, exceeding "
+                           "kMaxBindGroups {}",
+                           descriptor.bindGroupLayouts.size(), kMaxBindGroups));
+  }
+
+  std::vector<LayoutIdentity> layoutIds;
+  layoutIds.reserve(descriptor.bindGroupLayouts.size());
+  for (const BindGroupLayoutRef& layoutRef : descriptor.bindGroupLayouts) {
+    auto layoutRecord = resolve(bindGroupLayouts_, layoutRef, BindGroupLayoutTag::kName);
+    if (layoutRecord.hasError()) {
+      return std::move(layoutRecord).error();
+    }
+    layoutIds.push_back(LayoutIdentity{layoutRef.slotIndex(), layoutRef.generation()});
+  }
+
+  PipelineLayout handle = allocateHandle<PipelineLayoutTag>(
+      pipelineLayouts_, PipelineLayoutRecord{descriptor, std::move(layoutIds)});
+  if (Status status = onCreatePipelineLayout(handle.slotIndex(), descriptor); status.hasError()) {
+    pipelineLayouts_.release(handle.slotIndex());
+    return std::move(status).error();
+  }
+  return handle;
+}
+
+Result<ShaderModule> Device::createShaderModule(const ShaderModuleDescriptor& descriptor) {
+  if (descriptor.sourceText.empty()) {
+    return Err(GpuErrorType::InvalidDescriptor, "ShaderModuleDescriptor.sourceText is empty");
+  }
+
+  ShaderModule handle =
+      allocateHandle<ShaderModuleTag>(shaderModules_, ShaderModuleRecord{descriptor});
+  if (Status status = onCreateShaderModule(handle.slotIndex(), descriptor); status.hasError()) {
+    shaderModules_.release(handle.slotIndex());
+    return std::move(status).error();
+  }
+  return handle;
+}
+
+Result<RenderPipeline> Device::createRenderPipeline(const RenderPipelineDescriptor& descriptor) {
+  auto layoutRecord = resolve(pipelineLayouts_, descriptor.layout, PipelineLayoutTag::kName);
+  if (layoutRecord.hasError()) {
+    return std::move(layoutRecord).error();
+  }
+  auto vertexModule = resolve(shaderModules_, descriptor.vertex.module, ShaderModuleTag::kName);
+  if (vertexModule.hasError()) {
+    return std::move(vertexModule).error();
+  }
+  auto fragmentModule = resolve(shaderModules_, descriptor.fragment.module, ShaderModuleTag::kName);
+  if (fragmentModule.hasError()) {
+    return std::move(fragmentModule).error();
+  }
+  if (descriptor.vertex.entryPoint.empty()) {
+    return Err(GpuErrorType::InvalidDescriptor,
+               "RenderPipelineDescriptor.vertex.entryPoint is empty");
+  }
+  if (descriptor.fragment.entryPoint.empty()) {
+    return Err(GpuErrorType::InvalidDescriptor,
+               "RenderPipelineDescriptor.fragment.entryPoint is empty");
+  }
+  if (Status status = ValidateVertexBufferLayouts(descriptor.vertex.buffers); status.hasError()) {
+    return std::move(status).error();
+  }
+  if (descriptor.fragment.targets.empty()) {
+    return Err(GpuErrorType::InvalidDescriptor,
+               "RenderPipelineDescriptor.fragment.targets is empty");
+  }
+  if (descriptor.fragment.targets.size() > kMaxColorAttachments) {
+    return Err(GpuErrorType::LimitExceeded,
+               std::format("RenderPipelineDescriptor has {} color targets, exceeding "
+                           "kMaxColorAttachments {}",
+                           descriptor.fragment.targets.size(), kMaxColorAttachments));
+  }
+  if (descriptor.multisampleCount != 1) {
+    return Err(GpuErrorType::Unsupported,
+               std::format("RenderPipelineDescriptor.multisampleCount {} is not supported; only "
+                           "1 sample per pixel is available",
+                           descriptor.multisampleCount));
+  }
+
+  RenderPipelineRecord record{descriptor, layoutRecord.result()->bindGroupLayoutIds};
+  RenderPipeline handle = allocateHandle<RenderPipelineTag>(renderPipelines_, std::move(record));
+  if (Status status = onCreateRenderPipeline(handle.slotIndex(), descriptor); status.hasError()) {
+    renderPipelines_.release(handle.slotIndex());
+    return std::move(status).error();
+  }
+  return handle;
+}
+
+Status Device::destroyBuffer(const Buffer& buffer) {
+  return destroyResource(buffers_, buffer);
+}
+
+Status Device::destroyTexture(const Texture& texture) {
+  return destroyResource(textures_, texture);
+}
+
+Status Device::destroyTextureView(const TextureView& textureView) {
+  return destroyResource(textureViews_, textureView);
+}
+
+Status Device::destroySampler(const Sampler& sampler) {
+  return destroyResource(samplers_, sampler);
+}
+
+Status Device::destroyBindGroupLayout(const BindGroupLayout& bindGroupLayout) {
+  return destroyResource(bindGroupLayouts_, bindGroupLayout);
+}
+
+Status Device::destroyBindGroup(const BindGroup& bindGroup) {
+  return destroyResource(bindGroups_, bindGroup);
+}
+
+Status Device::destroyPipelineLayout(const PipelineLayout& pipelineLayout) {
+  return destroyResource(pipelineLayouts_, pipelineLayout);
+}
+
+Status Device::destroyShaderModule(const ShaderModule& shaderModule) {
+  return destroyResource(shaderModules_, shaderModule);
+}
+
+Status Device::destroyRenderPipeline(const RenderPipeline& renderPipeline) {
+  return destroyResource(renderPipelines_, renderPipeline);
+}
+
+Result<std::unique_ptr<CommandEncoder>> Device::createCommandEncoder() {
+  return std::unique_ptr<CommandEncoder>(new CommandEncoder(*this));
+}
+
+Status Device::writeBuffer(const Buffer& buffer, uint64_t offsetBytes,
+                           std::span<const uint8_t> data) {
+  auto record = resolve(buffers_, buffer, BufferTag::kName);
+  if (record.hasError()) {
+    return std::move(record).error();
+  }
+  if (!HasAllFlags(record.result()->descriptor.usage, BufferUsage::CopyDst)) {
+    return Err(GpuErrorType::UsageMismatch,
+               std::format("writeBuffer: buffer \"{}\" lacks the CopyDst usage",
+                           record.result()->descriptor.label.str()));
+  }
+  const std::optional<uint64_t> endByte = CheckedAdd(offsetBytes, data.size());
+  if (!endByte || *endByte > record.result()->descriptor.byteSize) {
+    return Err(GpuErrorType::OutOfBounds,
+               std::format("writeBuffer: range offsetBytes={} byteCount={} does not fit in "
+                           "buffer \"{}\" of {} bytes",
+                           offsetBytes, data.size(), record.result()->descriptor.label.str(),
+                           record.result()->descriptor.byteSize));
+  }
+
+  return onWriteBuffer(buffer.slotIndex(), offsetBytes, data);
+}
+
+Status Device::writeTexture(const Texture& texture, std::span<const uint8_t> data,
+                            const TexelCopyBufferLayout& dataLayout, const Extent2d& writeSize) {
+  auto record = resolve(textures_, texture, TextureTag::kName);
+  if (record.hasError()) {
+    return std::move(record).error();
+  }
+  const TextureDescriptor& textureDescriptor = record.result()->descriptor;
+  if (!HasAllFlags(textureDescriptor.usage, TextureUsage::CopyDst)) {
+    return Err(GpuErrorType::UsageMismatch,
+               std::format("writeTexture: texture \"{}\" lacks the CopyDst usage",
+                           textureDescriptor.label.str()));
+  }
+  if (writeSize.width > textureDescriptor.size.width ||
+      writeSize.height > textureDescriptor.size.height) {
+    return Err(GpuErrorType::OutOfBounds,
+               std::format("writeTexture: write size {}x{} exceeds texture \"{}\" size {}x{}",
+                           writeSize.width, writeSize.height, textureDescriptor.label.str(),
+                           textureDescriptor.size.width, textureDescriptor.size.height));
+  }
+  Result<uint64_t> requiredEnd =
+      ValidateTexelCopyInternal(dataLayout, writeSize, textureDescriptor.format, "writeTexture");
+  if (requiredEnd.hasError()) {
+    return std::move(requiredEnd).error();
+  }
+  if (requiredEnd.result() > data.size()) {
+    return Err(GpuErrorType::OutOfBounds,
+               std::format("writeTexture: layout requires {} bytes but data has {} bytes",
+                           requiredEnd.result(), data.size()));
+  }
+
+  return onWriteTexture(texture.slotIndex(), data, dataLayout, writeSize);
+}
+
+Result<uint64_t> Device::submit(CommandBuffer commandBuffer) {
+  auto record = resolve(commandBuffers_, commandBuffer, CommandBufferTag::kName);
+  if (record.hasError()) {
+    return std::move(record).error();
+  }
+
+  // Take ownership of the commands and consume the command buffer slot: submission is one-shot.
+  const uint32_t slotIndex = commandBuffer.slotIndex();
+  std::vector<Command> commands =
+      std::move(commandBuffers_.findMutable(slotIndex, commandBuffer.generation())->commands);
+  commandBuffers_.release(slotIndex);
+
+  const uint64_t serial = ++lastSubmittedSerial_;
+  if (Status status = onSubmit(serial, slotIndex, commands); status.hasError()) {
+    return std::move(status).error();
+  }
+  return serial;
+}
+
+CommandBuffer Device::registerCommandBuffer(std::vector<Command>&& commands) {
+  return allocateHandle<CommandBufferTag>(commandBuffers_,
+                                          CommandBufferRecord{std::move(commands)});
+}
+
+}  // namespace donner::gpu

--- a/donner/gpu/Device.cc
+++ b/donner/gpu/Device.cc
@@ -102,6 +102,17 @@ Status ValidateVertexBufferLayouts(const std::vector<VertexBufferLayout>& buffer
                            buffers.size(), kMaxVertexBuffers));
   }
 
+  size_t totalAttributes = 0;
+  for (const VertexBufferLayout& layout : buffers) {
+    totalAttributes += layout.attributes.size();
+  }
+  if (totalAttributes > kMaxVertexAttributes) {
+    return Err(GpuErrorType::LimitExceeded,
+               std::format("RenderPipelineDescriptor has {} vertex attributes, exceeding "
+                           "kMaxVertexAttributes {}",
+                           totalAttributes, kMaxVertexAttributes));
+  }
+
   for (size_t bufferIndex = 0; bufferIndex < buffers.size(); ++bufferIndex) {
     const VertexBufferLayout& layout = buffers[bufferIndex];
     if (layout.strideBytes == 0) {
@@ -113,6 +124,11 @@ Status ValidateVertexBufferLayouts(const std::vector<VertexBufferLayout>& buffer
                  std::format("VertexBufferLayout {} has no attributes", bufferIndex));
     }
     for (const VertexAttribute& attribute : layout.attributes) {
+      if (attribute.shaderLocation >= kMaxVertexAttributes) {
+        return Err(GpuErrorType::LimitExceeded,
+                   std::format("VertexAttribute shaderLocation {} exceeds kMaxVertexAttributes {}",
+                               attribute.shaderLocation, kMaxVertexAttributes));
+      }
       const std::optional<uint64_t> attributeEnd =
           CheckedAdd(attribute.offsetBytes, VertexFormatByteSize(attribute.format));
       if (!attributeEnd || *attributeEnd > layout.strideBytes) {
@@ -161,6 +177,13 @@ Result<uint64_t> ValidateTexelCopyInternal(const TexelCopyBufferLayout& layout,
     return Err(GpuErrorType::InvalidDescriptor,
                std::format("{}: bytesPerRow {} is not a multiple of {}", context,
                            layout.bytesPerRow, kTexelRowPitchAlignment));
+  }
+  // Texel-size offset alignment is a portability rule like the 256-byte row pitch: every native
+  // API this runtime targets requires copy offsets aligned to the texel block size.
+  if (layout.offsetBytes % TextureFormatBytesPerTexel(format) != 0) {
+    return Err(GpuErrorType::InvalidDescriptor,
+               std::format("{}: offsetBytes {} is not aligned to the {}-byte texel size", context,
+                           layout.offsetBytes, TextureFormatBytesPerTexel(format)));
   }
   if (layout.bytesPerRow < *rowBytes) {
     return Err(GpuErrorType::InvalidDescriptor,

--- a/donner/gpu/Device.cc
+++ b/donner/gpu/Device.cc
@@ -19,6 +19,29 @@ GpuError Err(GpuErrorType type, std::string message) {
   return GpuError{type, std::move(message)};
 }
 
+/// Rejects out-of-range enum values arriving through descriptors (central check so unknown
+/// values cannot flow into layout or copy math).
+template <typename EnumT>
+Status CheckEnum(EnumT value, std::string_view fieldName) {
+  if (!IsKnownEnumValue(value)) {
+    return Err(
+        GpuErrorType::InvalidDescriptor,
+        std::format("{} has unknown enum value {}", fieldName, static_cast<uint32_t>(value)));
+  }
+  return OkStatus();
+}
+
+/// Rejects bitmasks containing unknown flag bits.
+template <typename MaskT>
+Status CheckBitmask(MaskT value, std::string_view fieldName) {
+  if (!IsValidBitmask(value)) {
+    return Err(GpuErrorType::InvalidDescriptor,
+               std::format("{} has unknown flag bits (value {})", fieldName,
+                           static_cast<uint32_t>(value)));
+  }
+  return OkStatus();
+}
+
 /// Validates a \ref BufferDescriptor.
 Status ValidateBufferDescriptor(const BufferDescriptor& descriptor) {
   if (descriptor.byteSize == 0) {
@@ -29,14 +52,45 @@ Status ValidateBufferDescriptor(const BufferDescriptor& descriptor) {
                std::format("BufferDescriptor.byteSize {} exceeds kMaxBufferByteSize {}",
                            descriptor.byteSize, kMaxBufferByteSize));
   }
+  if (Status status = CheckBitmask(descriptor.usage, "BufferDescriptor.usage"); status.hasError()) {
+    return status;
+  }
   if (descriptor.usage == BufferUsage::None) {
     return Err(GpuErrorType::InvalidDescriptor, "BufferDescriptor.usage is empty");
   }
   return OkStatus();
 }
 
+/// Validates a \ref SamplerDescriptor.
+Status ValidateSamplerDescriptor(const SamplerDescriptor& descriptor) {
+  if (Status status = CheckEnum(descriptor.magFilter, "SamplerDescriptor.magFilter");
+      status.hasError()) {
+    return status;
+  }
+  if (Status status = CheckEnum(descriptor.minFilter, "SamplerDescriptor.minFilter");
+      status.hasError()) {
+    return status;
+  }
+  if (Status status = CheckEnum(descriptor.addressModeU, "SamplerDescriptor.addressModeU");
+      status.hasError()) {
+    return status;
+  }
+  if (Status status = CheckEnum(descriptor.addressModeV, "SamplerDescriptor.addressModeV");
+      status.hasError()) {
+    return status;
+  }
+  return OkStatus();
+}
+
 /// Validates a \ref TextureDescriptor.
 Status ValidateTextureDescriptor(const TextureDescriptor& descriptor) {
+  if (Status status = CheckEnum(descriptor.format, "TextureDescriptor.format"); status.hasError()) {
+    return status;
+  }
+  if (Status status = CheckBitmask(descriptor.usage, "TextureDescriptor.usage");
+      status.hasError()) {
+    return status;
+  }
   if (descriptor.size.width == 0 || descriptor.size.height == 0) {
     return Err(GpuErrorType::InvalidDescriptor,
                std::format("TextureDescriptor.size {}x{} has a zero dimension",
@@ -77,6 +131,13 @@ Status ValidateBindGroupLayoutDescriptor(const BindGroupLayoutDescriptor& descri
                  std::format("BindGroupLayoutEntry.binding {} exceeds kMaxBindings {}",
                              entry.binding, kMaxBindings));
     }
+    if (Status status = CheckBitmask(entry.visibility, "BindGroupLayoutEntry.visibility");
+        status.hasError()) {
+      return status;
+    }
+    if (Status status = CheckEnum(entry.type, "BindGroupLayoutEntry.type"); status.hasError()) {
+      return status;
+    }
     if (entry.visibility == ShaderStage::None) {
       return Err(
           GpuErrorType::InvalidDescriptor,
@@ -115,6 +176,10 @@ Status ValidateVertexBufferLayouts(const std::vector<VertexBufferLayout>& buffer
 
   for (size_t bufferIndex = 0; bufferIndex < buffers.size(); ++bufferIndex) {
     const VertexBufferLayout& layout = buffers[bufferIndex];
+    if (Status status = CheckEnum(layout.stepMode, "VertexBufferLayout.stepMode");
+        status.hasError()) {
+      return status;
+    }
     if (layout.strideBytes == 0) {
       return Err(GpuErrorType::InvalidDescriptor,
                  std::format("VertexBufferLayout {} has strideBytes 0", bufferIndex));
@@ -124,6 +189,10 @@ Status ValidateVertexBufferLayouts(const std::vector<VertexBufferLayout>& buffer
                  std::format("VertexBufferLayout {} has no attributes", bufferIndex));
     }
     for (const VertexAttribute& attribute : layout.attributes) {
+      if (Status status = CheckEnum(attribute.format, "VertexAttribute.format");
+          status.hasError()) {
+        return status;
+      }
       if (attribute.shaderLocation >= kMaxVertexAttributes) {
         return Err(GpuErrorType::LimitExceeded,
                    std::format("VertexAttribute shaderLocation {} exceeds kMaxVertexAttributes {}",
@@ -294,6 +363,10 @@ Result<TextureView> Device::createTextureView(const Texture& texture,
 }
 
 Result<Sampler> Device::createSampler(const SamplerDescriptor& descriptor) {
+  if (Status status = ValidateSamplerDescriptor(descriptor); status.hasError()) {
+    return std::move(status).error();
+  }
+
   Sampler handle = allocateHandle<SamplerTag>(samplers_, SamplerRecord{descriptor});
   if (Status status = onCreateSampler(handle.slotIndex(), descriptor); status.hasError()) {
     samplers_.release(handle.slotIndex());
@@ -469,6 +542,10 @@ Result<PipelineLayout> Device::createPipelineLayout(const PipelineLayoutDescript
 }
 
 Result<ShaderModule> Device::createShaderModule(const ShaderModuleDescriptor& descriptor) {
+  if (Status status = CheckEnum(descriptor.sourceKind, "ShaderModuleDescriptor.sourceKind");
+      status.hasError()) {
+    return std::move(status).error();
+  }
   if (descriptor.sourceText.empty()) {
     return Err(GpuErrorType::InvalidDescriptor, "ShaderModuleDescriptor.sourceText is empty");
   }
@@ -515,6 +592,39 @@ Result<RenderPipeline> Device::createRenderPipeline(const RenderPipelineDescript
                std::format("RenderPipelineDescriptor has {} color targets, exceeding "
                            "kMaxColorAttachments {}",
                            descriptor.fragment.targets.size(), kMaxColorAttachments));
+  }
+  for (const ColorTargetState& target : descriptor.fragment.targets) {
+    if (Status status = CheckEnum(target.format, "ColorTargetState.format"); status.hasError()) {
+      return std::move(status).error();
+    }
+    if (Status status = CheckBitmask(target.writeMask, "ColorTargetState.writeMask");
+        status.hasError()) {
+      return std::move(status).error();
+    }
+    if (target.blend) {
+      for (const BlendComponent& component : {target.blend->color, target.blend->alpha}) {
+        if (Status status = CheckEnum(component.srcFactor, "BlendComponent.srcFactor");
+            status.hasError()) {
+          return std::move(status).error();
+        }
+        if (Status status = CheckEnum(component.dstFactor, "BlendComponent.dstFactor");
+            status.hasError()) {
+          return std::move(status).error();
+        }
+        if (Status status = CheckEnum(component.operation, "BlendComponent.operation");
+            status.hasError()) {
+          return std::move(status).error();
+        }
+      }
+    }
+  }
+  if (Status status = CheckEnum(descriptor.topology, "RenderPipelineDescriptor.topology");
+      status.hasError()) {
+    return std::move(status).error();
+  }
+  if (Status status = CheckEnum(descriptor.cullMode, "RenderPipelineDescriptor.cullMode");
+      status.hasError()) {
+    return std::move(status).error();
   }
   if (descriptor.multisampleCount != 1) {
     return Err(GpuErrorType::Unsupported,

--- a/donner/gpu/Device.h
+++ b/donner/gpu/Device.h
@@ -296,7 +296,12 @@ public:
 
   /**
    * Submits a finished command buffer, consuming it, and returns the assigned submission serial.
-   * Serials start at 1 and increase by 1 per submission.
+   * Serials start at 1 and increase by 1 per submission; a submission rejected by the backend
+   * does not consume a serial.
+   *
+   * Known gap: commands are validated at recording time, so destroying a resource between
+   * recording and submit is not yet detected here. Deferred-destruction validation arrives with
+   * the resource-lifetime and submission packet (design 0053 change sequence step 3).
    *
    * @param commandBuffer Command buffer to submit; consumed even on failure.
    */

--- a/donner/gpu/Device.h
+++ b/donner/gpu/Device.h
@@ -383,14 +383,20 @@ private:
   struct TextureRecord {
     TextureDescriptor descriptor;  //!< Creation descriptor.
   };
-  /// Validated per-view state, including a snapshot of the viewed texture's properties used by
-  /// render pass and bind group validation.
+  /// Identity of a resource at a point in time: slot plus generation, so slot reuse cannot alias
+  /// two different resources.
+  struct ResourceIdentity {
+    uint32_t slotIndex = 0;   //!< Resource slot index.
+    uint32_t generation = 0;  //!< Slot generation at capture time.
+
+    /// Equality operator. @param other Identity to compare against.
+    bool operator==(const ResourceIdentity& other) const = default;
+  };
+  /// Validated per-view state. Consumers re-resolve the viewed texture through
+  /// \ref resolveViewedTexture on every use, so a view cannot outlive its texture unnoticed.
   struct TextureViewRecord {
-    TextureViewDescriptor descriptor;                         //!< Creation descriptor.
-    uint32_t textureSlot = 0;                                 //!< Slot of the viewed texture.
-    TextureFormat textureFormat = TextureFormat::RGBA8Unorm;  //!< Viewed texture format.
-    Extent2d textureSize;                                     //!< Viewed texture extent.
-    TextureUsage textureUsage = TextureUsage::None;           //!< Viewed texture usage.
+    TextureViewDescriptor descriptor;  //!< Creation descriptor.
+    ResourceIdentity textureIdentity;  //!< Identity of the viewed texture.
   };
   /// Validated per-sampler state.
   struct SamplerRecord {
@@ -400,24 +406,15 @@ private:
   struct BindGroupLayoutRecord {
     BindGroupLayoutDescriptor descriptor;  //!< Creation descriptor.
   };
-  /// Identity of a bind group layout at a point in time: slot plus generation, so slot reuse
-  /// cannot alias two different layouts.
-  struct LayoutIdentity {
-    uint32_t slotIndex = 0;   //!< Layout slot index.
-    uint32_t generation = 0;  //!< Layout generation at capture time.
-
-    /// Equality operator. @param other Identity to compare against.
-    bool operator==(const LayoutIdentity& other) const = default;
-  };
   /// Validated per-bind-group state.
   struct BindGroupRecord {
-    BindGroupDescriptor descriptor;  //!< Creation descriptor.
-    LayoutIdentity layoutIdentity;   //!< Identity of the layout this group was created against.
+    BindGroupDescriptor descriptor;   //!< Creation descriptor.
+    ResourceIdentity layoutIdentity;  //!< Identity of the layout this group was created against.
   };
   /// Validated per-pipeline-layout state.
   struct PipelineLayoutRecord {
-    PipelineLayoutDescriptor descriptor;             //!< Creation descriptor.
-    std::vector<LayoutIdentity> bindGroupLayoutIds;  //!< Layout identities, by group index.
+    PipelineLayoutDescriptor descriptor;               //!< Creation descriptor.
+    std::vector<ResourceIdentity> bindGroupLayoutIds;  //!< Layout identities, by group index.
   };
   /// Validated per-shader-module state.
   struct ShaderModuleRecord {
@@ -425,8 +422,8 @@ private:
   };
   /// Validated per-pipeline state used for draw-time compatibility checks.
   struct RenderPipelineRecord {
-    RenderPipelineDescriptor descriptor;             //!< Creation descriptor.
-    std::vector<LayoutIdentity> bindGroupLayoutIds;  //!< Pipeline layout's group identities.
+    RenderPipelineDescriptor descriptor;               //!< Creation descriptor.
+    std::vector<ResourceIdentity> bindGroupLayoutIds;  //!< Pipeline layout's group identities.
   };
   /// A finished, not-yet-submitted command buffer.
   struct CommandBufferRecord {
@@ -445,6 +442,15 @@ private:
   template <typename Record, typename HandleLike>
   Result<const Record*> resolve(const details::SlotTable<Record>& table,
                                 const HandleLike& handleLike, std::string_view resourceName) const;
+
+  /**
+   * Re-resolves the texture a view was created against. Returns
+   * \ref GpuErrorType::InvalidHandle if the texture was destroyed, including when its slot was
+   * reused by a newer texture, so stale views can never alias another texture.
+   *
+   * @param viewRecord Resolved record of the view being consumed.
+   */
+  Result<const TextureRecord*> resolveViewedTexture(const TextureViewRecord& viewRecord) const;
 
   /// Allocates a slot in \p table and mints a handle carrying this device's identity.
   /// @param table Destination table. @param record Validated record to store.

--- a/donner/gpu/Device.h
+++ b/donner/gpu/Device.h
@@ -1,0 +1,504 @@
+#pragma once
+/// @file
+/// \c donner::gpu::Device - the abstract GPU device with shared fail-closed validation.
+
+#include <cstdint>
+#include <format>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "donner/gpu/Commands.h"
+#include "donner/gpu/Descriptors.h"
+#include "donner/gpu/GpuResult.h"
+#include "donner/gpu/Handles.h"
+
+namespace donner::gpu {
+
+class CommandEncoder;
+
+namespace details {
+
+/**
+ * Generation-checked slot storage for one resource type.
+ *
+ * Slots are reused through a free list; every release bumps the slot's generation so stale
+ * handles referencing the previous occupant fail validation.
+ *
+ * @tparam Record Validated per-resource record stored in each slot.
+ */
+template <typename Record>
+class SlotTable {
+public:
+  /**
+   * Stores \p record in a free slot (reusing released slots first) and returns its index.
+   *
+   * @param record Record to store.
+   */
+  uint32_t allocate(Record&& record) {
+    if (!freeList_.empty()) {
+      const uint32_t slotIndex = freeList_.back();
+      freeList_.pop_back();
+      Slot& slot = slots_[slotIndex];
+      slot.alive = true;
+      slot.record = std::move(record);
+      return slotIndex;
+    }
+
+    slots_.push_back(Slot{1, true, std::move(record)});
+    return static_cast<uint32_t>(slots_.size() - 1);
+  }
+
+  /**
+   * Returns the record at \p slotIndex if it is alive and \p generation is current, otherwise
+   * nullptr.
+   *
+   * @param slotIndex Slot index.
+   * @param generation Generation the caller's handle carries.
+   */
+  const Record* find(uint32_t slotIndex, uint32_t generation) const {
+    if (slotIndex >= slots_.size()) {
+      return nullptr;
+    }
+    const Slot& slot = slots_[slotIndex];
+    if (!slot.alive || slot.generation != generation) {
+      return nullptr;
+    }
+    return &slot.record.value();
+  }
+
+  /**
+   * Mutable variant of \ref find, for consuming stored state (e.g. submitting a command buffer).
+   *
+   * @param slotIndex Slot index.
+   * @param generation Generation the caller's handle carries.
+   */
+  Record* findMutable(uint32_t slotIndex, uint32_t generation) {
+    return const_cast<Record*>(std::as_const(*this).find(slotIndex, generation));
+  }
+
+  /**
+   * Current generation of \p slotIndex.
+   *
+   * @param slotIndex Slot index; must be in range.
+   */
+  uint32_t generationOf(uint32_t slotIndex) const { return slots_[slotIndex].generation; }
+
+  /**
+   * Releases the record at \p slotIndex: marks the slot dead, bumps its generation so remaining
+   * identifiers fail closed, and queues the slot for reuse.
+   *
+   * @param slotIndex Slot index; must refer to an alive slot.
+   */
+  void release(uint32_t slotIndex) {
+    Slot& slot = slots_[slotIndex];
+    slot.alive = false;
+    slot.record.reset();
+    ++slot.generation;
+    freeList_.push_back(slotIndex);
+  }
+
+private:
+  /// One slot: generation counter plus the stored record while alive.
+  struct Slot {
+    uint32_t generation = 1;       //!< Bumped on release; a handle matches only its generation.
+    bool alive = false;            //!< True while the slot holds a live resource.
+    std::optional<Record> record;  //!< Stored record; empty while dead.
+  };
+
+  std::vector<Slot> slots_;
+  std::vector<uint32_t> freeList_;
+};
+
+}  // namespace details
+
+/**
+ * Internal: validates a texel copy layout against a copy extent and format, and returns the
+ * exclusive end byte offset the copy requires in the buffer or host memory it describes. Shared
+ * by `Device::writeTexture` and `CommandEncoder::copyTextureToBuffer`; not part of the public
+ * API.
+ *
+ * @param layout Row layout to validate (256-aligned `bytesPerRow` covering one row, and
+ *   `rowsPerImage` covering the copy height).
+ * @param copySize Copy extent in texels.
+ * @param format Texel format of the texture side of the copy.
+ * @param context Operation name for diagnostics.
+ */
+Result<uint64_t> ValidateTexelCopyInternal(const TexelCopyBufferLayout& layout,
+                                           const Extent2d& copySize, TextureFormat format,
+                                           std::string_view context);
+
+/**
+ * Abstract GPU device: resource creation, queue writes, and submission with shared fail-closed
+ * validation (design 0053 "Proposed Architecture", "Validation layer").
+ *
+ * The public API is non-virtual and validates every descriptor, handle, and byte range before
+ * delegating to protected `on*` virtuals (template-method pattern), so every backend - the
+ * deterministic \ref RecordingDevice today, platform backends in later packets - inherits
+ * identical fail-closed behavior. Validation runs in release builds too: invalid input returns
+ * a \ref GpuError, never asserts.
+ *
+ * Enforced limits are documented in GpuLimits.h. Handle validation checks device identity
+ * (\ref GpuErrorType::DeviceMismatch) and slot generation (\ref GpuErrorType::InvalidHandle), so
+ * destroyed or foreign handles fail before reaching a backend.
+ *
+ * Lifetime: resources are freed by explicit `destroy*` calls; device teardown frees everything
+ * that remains (handles are not RAII in this packet, see Handles.h). Handles must not be used
+ * after their device is destroyed.
+ *
+ * Thread affinity: a Device and everything created from it must be used from one thread at a
+ * time, matching the async-renderer worker ownership model.
+ */
+class Device {
+public:
+  /// Destructor; frees all remaining resources.
+  virtual ~Device();
+
+  Device(const Device&) = delete;
+  Device& operator=(const Device&) = delete;
+  Device(Device&&) = delete;
+  Device& operator=(Device&&) = delete;
+
+  /// Process-unique identity of this device (starts at 1, never reused). Baked into every handle
+  /// for cross-device validation.
+  uint64_t deviceId() const { return deviceId_; }
+
+  /**
+   * Creates a buffer. Fails closed on zero or oversized `byteSize` or empty usage.
+   *
+   * @param descriptor Validated buffer descriptor.
+   */
+  Result<Buffer> createBuffer(const BufferDescriptor& descriptor);
+
+  /**
+   * Creates a 2D texture. Fails closed on zero or oversized extents, empty usage, or
+   * `sampleCount != 1`.
+   *
+   * @param descriptor Validated texture descriptor.
+   */
+  Result<Texture> createTexture(const TextureDescriptor& descriptor);
+
+  /**
+   * Creates a view of \p texture covering the whole texture.
+   *
+   * @param texture Texture to view; must be a live handle of this device.
+   * @param descriptor Validated view descriptor.
+   */
+  Result<TextureView> createTextureView(const Texture& texture,
+                                        const TextureViewDescriptor& descriptor);
+
+  /**
+   * Creates a sampler.
+   *
+   * @param descriptor Validated sampler descriptor.
+   */
+  Result<Sampler> createSampler(const SamplerDescriptor& descriptor);
+
+  /**
+   * Creates a bind group layout. Fails closed on duplicate binding indices, out-of-limit binding
+   * counts or indices, or empty per-entry visibility.
+   *
+   * @param descriptor Validated layout descriptor.
+   */
+  Result<BindGroupLayout> createBindGroupLayout(const BindGroupLayoutDescriptor& descriptor);
+
+  /**
+   * Creates a bind group. Fails closed unless every layout binding is matched by exactly one
+   * entry whose resource is live, belongs to this device, matches the layout's
+   * \ref BindingType, and carries the usage that binding type requires.
+   *
+   * @param descriptor Validated bind group descriptor.
+   */
+  Result<BindGroup> createBindGroup(const BindGroupDescriptor& descriptor);
+
+  /**
+   * Creates a pipeline layout. Fails closed on out-of-limit group counts or invalid layout
+   * references.
+   *
+   * @param descriptor Validated pipeline layout descriptor.
+   */
+  Result<PipelineLayout> createPipelineLayout(const PipelineLayoutDescriptor& descriptor);
+
+  /**
+   * Creates a shader module from trusted generated source. Fails closed on empty source text.
+   *
+   * @param descriptor Validated shader module descriptor.
+   */
+  Result<ShaderModule> createShaderModule(const ShaderModuleDescriptor& descriptor);
+
+  /**
+   * Creates a render pipeline. Fails closed on invalid layout/module references, empty entry
+   * points, vertex attributes that overflow their stride, duplicate shader locations, empty or
+   * out-of-limit target lists, or `multisampleCount != 1`.
+   *
+   * @param descriptor Validated pipeline descriptor.
+   */
+  Result<RenderPipeline> createRenderPipeline(const RenderPipelineDescriptor& descriptor);
+
+  /// Destroys a buffer; the handle and all references to it become stale.
+  /// @param buffer Handle to destroy.
+  Status destroyBuffer(const Buffer& buffer);
+  /// Destroys a texture; the handle and all references to it become stale.
+  /// @param texture Handle to destroy.
+  Status destroyTexture(const Texture& texture);
+  /// Destroys a texture view; the handle and all references to it become stale.
+  /// @param textureView Handle to destroy.
+  Status destroyTextureView(const TextureView& textureView);
+  /// Destroys a sampler; the handle and all references to it become stale.
+  /// @param sampler Handle to destroy.
+  Status destroySampler(const Sampler& sampler);
+  /// Destroys a bind group layout; the handle and all references to it become stale.
+  /// @param bindGroupLayout Handle to destroy.
+  Status destroyBindGroupLayout(const BindGroupLayout& bindGroupLayout);
+  /// Destroys a bind group; the handle and all references to it become stale.
+  /// @param bindGroup Handle to destroy.
+  Status destroyBindGroup(const BindGroup& bindGroup);
+  /// Destroys a pipeline layout; the handle and all references to it become stale.
+  /// @param pipelineLayout Handle to destroy.
+  Status destroyPipelineLayout(const PipelineLayout& pipelineLayout);
+  /// Destroys a shader module; the handle and all references to it become stale.
+  /// @param shaderModule Handle to destroy.
+  Status destroyShaderModule(const ShaderModule& shaderModule);
+  /// Destroys a render pipeline; the handle and all references to it become stale.
+  /// @param renderPipeline Handle to destroy.
+  Status destroyRenderPipeline(const RenderPipeline& renderPipeline);
+
+  /// Creates a command encoder recording against this device. The encoder must not outlive the
+  /// device.
+  Result<std::unique_ptr<CommandEncoder>> createCommandEncoder();
+
+  /**
+   * Writes \p data into \p buffer at \p offsetBytes. Fails closed if the range does not fit
+   * (checked arithmetic) or the buffer lacks \ref BufferUsage::CopyDst.
+   *
+   * @param buffer Destination buffer.
+   * @param offsetBytes Destination byte offset.
+   * @param data Payload bytes.
+   */
+  Status writeBuffer(const Buffer& buffer, uint64_t offsetBytes, std::span<const uint8_t> data);
+
+  /**
+   * Writes texel rows from \p data into \p texture starting at texel (0, 0). Fails closed unless
+   * the texture has \ref TextureUsage::CopyDst, \p dataLayout is 256-aligned and covers
+   * \p writeSize, \p writeSize fits in the texture, and the described rows fit inside \p data
+   * (checked arithmetic).
+   *
+   * @param texture Destination texture.
+   * @param data Payload bytes laid out per \p dataLayout.
+   * @param dataLayout Row layout of \p data.
+   * @param writeSize Extent to write in texels.
+   */
+  Status writeTexture(const Texture& texture, std::span<const uint8_t> data,
+                      const TexelCopyBufferLayout& dataLayout, const Extent2d& writeSize);
+
+  /**
+   * Submits a finished command buffer, consuming it, and returns the assigned submission serial.
+   * Serials start at 1 and increase by 1 per submission.
+   *
+   * @param commandBuffer Command buffer to submit; consumed even on failure.
+   */
+  Result<uint64_t> submit(CommandBuffer commandBuffer);
+
+  /// Serial assigned to the most recent submission (0 if none yet).
+  uint64_t lastSubmittedSerial() const { return lastSubmittedSerial_; }
+
+  /// Serial of the most recent submission the backend has finished executing (0 if none). The
+  /// recording backend completes instantly, so this equals \ref lastSubmittedSerial there.
+  virtual uint64_t completedSerial() const = 0;
+
+protected:
+  /// Constructor for backends; assigns the process-unique device identity.
+  Device();
+
+  /// Backend hook: a buffer passed validation and occupies \p slotIndex.
+  /// @param slotIndex Slot index of the new resource. @param descriptor Validated descriptor.
+  virtual Status onCreateBuffer(uint32_t slotIndex, const BufferDescriptor& descriptor) = 0;
+  /// Backend hook: a texture passed validation and occupies \p slotIndex.
+  /// @param slotIndex Slot index of the new resource. @param descriptor Validated descriptor.
+  virtual Status onCreateTexture(uint32_t slotIndex, const TextureDescriptor& descriptor) = 0;
+  /// Backend hook: a texture view passed validation and occupies \p slotIndex.
+  /// @param slotIndex Slot index of the new resource.
+  /// @param textureSlotIndex Slot index of the viewed texture.
+  /// @param descriptor Validated descriptor.
+  virtual Status onCreateTextureView(uint32_t slotIndex, uint32_t textureSlotIndex,
+                                     const TextureViewDescriptor& descriptor) = 0;
+  /// Backend hook: a sampler passed validation and occupies \p slotIndex.
+  /// @param slotIndex Slot index of the new resource. @param descriptor Validated descriptor.
+  virtual Status onCreateSampler(uint32_t slotIndex, const SamplerDescriptor& descriptor) = 0;
+  /// Backend hook: a bind group layout passed validation and occupies \p slotIndex.
+  /// @param slotIndex Slot index of the new resource. @param descriptor Validated descriptor.
+  virtual Status onCreateBindGroupLayout(uint32_t slotIndex,
+                                         const BindGroupLayoutDescriptor& descriptor) = 0;
+  /// Backend hook: a bind group passed validation and occupies \p slotIndex.
+  /// @param slotIndex Slot index of the new resource. @param descriptor Validated descriptor.
+  virtual Status onCreateBindGroup(uint32_t slotIndex, const BindGroupDescriptor& descriptor) = 0;
+  /// Backend hook: a pipeline layout passed validation and occupies \p slotIndex.
+  /// @param slotIndex Slot index of the new resource. @param descriptor Validated descriptor.
+  virtual Status onCreatePipelineLayout(uint32_t slotIndex,
+                                        const PipelineLayoutDescriptor& descriptor) = 0;
+  /// Backend hook: a shader module passed validation and occupies \p slotIndex.
+  /// @param slotIndex Slot index of the new resource. @param descriptor Validated descriptor.
+  virtual Status onCreateShaderModule(uint32_t slotIndex,
+                                      const ShaderModuleDescriptor& descriptor) = 0;
+  /// Backend hook: a render pipeline passed validation and occupies \p slotIndex.
+  /// @param slotIndex Slot index of the new resource. @param descriptor Validated descriptor.
+  virtual Status onCreateRenderPipeline(uint32_t slotIndex,
+                                        const RenderPipelineDescriptor& descriptor) = 0;
+
+  /// Backend hook: a validated resource was destroyed.
+  /// @param resourceName Resource type name, e.g. `"buffer"`.
+  /// @param slotIndex Slot index of the destroyed resource.
+  virtual void onDestroyResource(std::string_view resourceName, uint32_t slotIndex) = 0;
+
+  /// Backend hook: a validated buffer write.
+  /// @param slotIndex Destination buffer slot. @param offsetBytes Destination byte offset.
+  /// @param data Payload bytes.
+  virtual Status onWriteBuffer(uint32_t slotIndex, uint64_t offsetBytes,
+                               std::span<const uint8_t> data) = 0;
+  /// Backend hook: a validated texture write.
+  /// @param slotIndex Destination texture slot. @param data Payload bytes.
+  /// @param dataLayout Row layout of \p data. @param writeSize Extent written in texels.
+  virtual Status onWriteTexture(uint32_t slotIndex, std::span<const uint8_t> data,
+                                const TexelCopyBufferLayout& dataLayout,
+                                const Extent2d& writeSize) = 0;
+
+  /// Backend hook: a validated command buffer was submitted.
+  /// @param submissionSerial Serial assigned to this submission.
+  /// @param commandBufferSlotIndex Slot the command buffer occupied before being consumed.
+  /// @param commands Validated commands, in recording order.
+  virtual Status onSubmit(uint64_t submissionSerial, uint32_t commandBufferSlotIndex,
+                          std::span<const Command> commands) = 0;
+
+private:
+  friend class CommandEncoder;
+
+  /// Validated per-buffer state.
+  struct BufferRecord {
+    BufferDescriptor descriptor;  //!< Creation descriptor.
+  };
+  /// Validated per-texture state.
+  struct TextureRecord {
+    TextureDescriptor descriptor;  //!< Creation descriptor.
+  };
+  /// Validated per-view state, including a snapshot of the viewed texture's properties used by
+  /// render pass and bind group validation.
+  struct TextureViewRecord {
+    TextureViewDescriptor descriptor;                         //!< Creation descriptor.
+    uint32_t textureSlot = 0;                                 //!< Slot of the viewed texture.
+    TextureFormat textureFormat = TextureFormat::RGBA8Unorm;  //!< Viewed texture format.
+    Extent2d textureSize;                                     //!< Viewed texture extent.
+    TextureUsage textureUsage = TextureUsage::None;           //!< Viewed texture usage.
+  };
+  /// Validated per-sampler state.
+  struct SamplerRecord {
+    SamplerDescriptor descriptor;  //!< Creation descriptor.
+  };
+  /// Validated per-layout state.
+  struct BindGroupLayoutRecord {
+    BindGroupLayoutDescriptor descriptor;  //!< Creation descriptor.
+  };
+  /// Identity of a bind group layout at a point in time: slot plus generation, so slot reuse
+  /// cannot alias two different layouts.
+  struct LayoutIdentity {
+    uint32_t slotIndex = 0;   //!< Layout slot index.
+    uint32_t generation = 0;  //!< Layout generation at capture time.
+
+    /// Equality operator. @param other Identity to compare against.
+    bool operator==(const LayoutIdentity& other) const = default;
+  };
+  /// Validated per-bind-group state.
+  struct BindGroupRecord {
+    BindGroupDescriptor descriptor;  //!< Creation descriptor.
+    LayoutIdentity layoutIdentity;   //!< Identity of the layout this group was created against.
+  };
+  /// Validated per-pipeline-layout state.
+  struct PipelineLayoutRecord {
+    PipelineLayoutDescriptor descriptor;             //!< Creation descriptor.
+    std::vector<LayoutIdentity> bindGroupLayoutIds;  //!< Layout identities, by group index.
+  };
+  /// Validated per-shader-module state.
+  struct ShaderModuleRecord {
+    ShaderModuleDescriptor descriptor;  //!< Creation descriptor.
+  };
+  /// Validated per-pipeline state used for draw-time compatibility checks.
+  struct RenderPipelineRecord {
+    RenderPipelineDescriptor descriptor;             //!< Creation descriptor.
+    std::vector<LayoutIdentity> bindGroupLayoutIds;  //!< Pipeline layout's group identities.
+  };
+  /// A finished, not-yet-submitted command buffer.
+  struct CommandBufferRecord {
+    std::vector<Command> commands;  //!< Validated commands in recording order.
+  };
+
+  /**
+   * Resolves a handle or handle reference against \p table: null handles and stale generations
+   * return \ref GpuErrorType::InvalidHandle, foreign devices return
+   * \ref GpuErrorType::DeviceMismatch.
+   *
+   * @param table Table for the handle's resource type.
+   * @param handleLike Handle or \ref HandleRef to resolve.
+   * @param resourceName Resource type name for diagnostics.
+   */
+  template <typename Record, typename HandleLike>
+  Result<const Record*> resolve(const details::SlotTable<Record>& table,
+                                const HandleLike& handleLike, std::string_view resourceName) const;
+
+  /// Allocates a slot in \p table and mints a handle carrying this device's identity.
+  /// @param table Destination table. @param record Validated record to store.
+  template <typename Tag, typename Record>
+  Handle<Tag> allocateHandle(details::SlotTable<Record>& table, Record&& record);
+
+  /// Shared implementation of the `destroy*` methods.
+  /// @param table Table for the handle's resource type. @param handle Handle to destroy.
+  template <typename Record, typename Tag>
+  Status destroyResource(details::SlotTable<Record>& table, const Handle<Tag>& handle);
+
+  /// Registers a finished command stream from an encoder and returns its handle.
+  /// @param commands Validated commands in recording order.
+  CommandBuffer registerCommandBuffer(std::vector<Command>&& commands);
+
+  /// Returns the next process-unique device id.
+  static uint64_t NextDeviceId();
+
+  uint64_t deviceId_ = 0;
+  uint64_t lastSubmittedSerial_ = 0;
+
+  details::SlotTable<BufferRecord> buffers_;
+  details::SlotTable<TextureRecord> textures_;
+  details::SlotTable<TextureViewRecord> textureViews_;
+  details::SlotTable<SamplerRecord> samplers_;
+  details::SlotTable<BindGroupLayoutRecord> bindGroupLayouts_;
+  details::SlotTable<BindGroupRecord> bindGroups_;
+  details::SlotTable<PipelineLayoutRecord> pipelineLayouts_;
+  details::SlotTable<ShaderModuleRecord> shaderModules_;
+  details::SlotTable<RenderPipelineRecord> renderPipelines_;
+  details::SlotTable<CommandBufferRecord> commandBuffers_;
+};
+
+template <typename Record, typename HandleLike>
+Result<const Record*> Device::resolve(const details::SlotTable<Record>& table,
+                                      const HandleLike& handleLike,
+                                      std::string_view resourceName) const {
+  if (!handleLike.isValid()) {
+    return GpuError{
+        GpuErrorType::InvalidHandle,
+        std::format("{} handle is null (default-constructed or moved-from)", resourceName)};
+  }
+  if (handleLike.deviceId() != deviceId_) {
+    return GpuError{GpuErrorType::DeviceMismatch,
+                    std::format("{} handle belongs to device {} but was used with device {}",
+                                resourceName, handleLike.deviceId(), deviceId_)};
+  }
+  const Record* record = table.find(handleLike.slotIndex(), handleLike.generation());
+  if (record == nullptr) {
+    return GpuError{GpuErrorType::InvalidHandle,
+                    std::format("{} handle (slot {}) is stale; the resource was destroyed",
+                                resourceName, handleLike.slotIndex())};
+  }
+  return record;
+}
+
+}  // namespace donner::gpu

--- a/donner/gpu/GpuError.cc
+++ b/donner/gpu/GpuError.cc
@@ -1,0 +1,35 @@
+#include "donner/gpu/GpuError.h"
+
+namespace donner::gpu {
+
+std::string_view GpuError::TypeToString(GpuErrorType type) {
+  switch (type) {
+    case GpuErrorType::InvalidDescriptor: return "InvalidDescriptor";
+    case GpuErrorType::InvalidHandle: return "InvalidHandle";
+    case GpuErrorType::DeviceMismatch: return "DeviceMismatch";
+    case GpuErrorType::UsageMismatch: return "UsageMismatch";
+    case GpuErrorType::OutOfBounds: return "OutOfBounds";
+    case GpuErrorType::LimitExceeded: return "LimitExceeded";
+    case GpuErrorType::InvalidState: return "InvalidState";
+    case GpuErrorType::Unsupported: return "Unsupported";
+  }
+
+  return "Unknown";
+}
+
+std::ostream& operator<<(std::ostream& os, GpuErrorType value) {
+  return os << GpuError::TypeToString(value);
+}
+
+std::string GpuError::toString() const {
+  std::string result(TypeToString(type));
+  result += ": ";
+  result += message;
+  return result;
+}
+
+std::ostream& operator<<(std::ostream& os, const GpuError& error) {
+  return os << error.type << ": " << error.message;
+}
+
+}  // namespace donner::gpu

--- a/donner/gpu/GpuError.h
+++ b/donner/gpu/GpuError.h
@@ -1,0 +1,83 @@
+#pragma once
+/// @file
+/// Explicit error types returned by \c donner::gpu APIs.
+
+#include <cstdint>
+#include <ostream>
+#include <string>
+#include <string_view>
+
+namespace donner::gpu {
+
+/**
+ * Category of a GPU runtime error.
+ *
+ * Every invalid descriptor, handle, or state transition fails closed by returning one of these
+ * categories wrapped in a \ref GpuError, in release builds too. Asserts are reserved for
+ * programmer invariants inside the runtime; invalid input never aborts.
+ */
+enum class GpuErrorType : uint8_t {
+  InvalidDescriptor,  //!< A descriptor field is malformed (zero size, bad range, misalignment).
+  InvalidHandle,      //!< A handle is null, destroyed, or has a stale generation.
+  DeviceMismatch,     //!< A handle created by one device was used on another device.
+  UsageMismatch,      //!< A resource lacks the usage flag required by the operation.
+  OutOfBounds,        //!< An offset, size, or copy region exceeds the resource bounds.
+  LimitExceeded,      //!< A count or dimension exceeds a documented device limit.
+  InvalidState,       //!< An operation was issued in an invalid state (encoder state machine).
+  Unsupported,        //!< The requested feature is not supported by this runtime.
+};
+
+/**
+ * Ostream output operator for \ref GpuErrorType, e.g. `InvalidDescriptor`.
+ *
+ * @param os Output stream.
+ * @param value Error type to output.
+ */
+std::ostream& operator<<(std::ostream& os, GpuErrorType value);
+
+/**
+ * An explicit error result from a \c donner::gpu operation, carrying the error category and a
+ * human-readable message that names the offending field or state so a failing test localizes the
+ * bug without a rerun.
+ */
+struct GpuError {
+  GpuErrorType type = GpuErrorType::InvalidDescriptor;  //!< Error category.
+  std::string message;                                  //!< Human-readable failure reason.
+
+  /**
+   * Returns the name of an error type, e.g. `"InvalidDescriptor"`.
+   *
+   * @param type Error type to format.
+   */
+  static std::string_view TypeToString(GpuErrorType type);
+
+  /// Formats this error as `<type>: <message>`.
+  std::string toString() const;
+
+  /**
+   * Equality operator.
+   *
+   * @param other Error to compare against.
+   */
+  bool operator==(const GpuError& other) const = default;
+
+  /**
+   * Ostream output operator, outputs `<type>: <message>`.
+   *
+   * @param os Output stream.
+   * @param error Error to output.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const GpuError& error);
+};
+
+/**
+ * gtest PrintTo support for readable test failure messages.
+ *
+ * @param error Error to print.
+ * @param os Output stream.
+ */
+inline void PrintTo(const GpuError& error, std::ostream* os) {
+  *os << error;
+}
+
+}  // namespace donner::gpu

--- a/donner/gpu/GpuLimits.h
+++ b/donner/gpu/GpuLimits.h
@@ -1,0 +1,39 @@
+#pragma once
+/// @file
+/// Documented validation limits enforced by \c donner::gpu::Device.
+///
+/// Limits exist so that untrusted SVG-derived dimensions (geometry volume, image sizes,
+/// render-target extents) fail deterministically with \ref GpuErrorType::LimitExceeded instead of
+/// exhausting a driver (design 0053 "Security and Reliability").
+
+#include <cstdint>
+
+namespace donner::gpu {
+
+/// Maximum texture width or height in texels.
+inline constexpr uint32_t kMaxTextureDimension = 16384;
+
+/// Maximum buffer size in bytes (1 GiB).
+inline constexpr uint64_t kMaxBufferByteSize = uint64_t(1) << 30;
+
+/// Maximum number of entries in one bind group layout, and the exclusive upper bound for binding
+/// indices.
+inline constexpr uint32_t kMaxBindings = 32;
+
+/// Maximum number of bind groups in a pipeline layout, and the exclusive upper bound for
+/// `setBindGroup` indices.
+inline constexpr uint32_t kMaxBindGroups = 4;
+
+/// Maximum number of vertex buffer layouts in a render pipeline, and the exclusive upper bound
+/// for `setVertexBuffer` slots.
+inline constexpr uint32_t kMaxVertexBuffers = 8;
+
+/// Maximum number of color attachments in a render pass or render pipeline.
+inline constexpr uint32_t kMaxColorAttachments = 4;
+
+/// Required alignment of \ref TexelCopyBufferLayout::bytesPerRow. 256 is the strictest row-pitch
+/// alignment across the native APIs this runtime targets, so enforcing it uniformly keeps copies
+/// portable without per-backend repacking.
+inline constexpr uint32_t kTexelRowPitchAlignment = 256;
+
+}  // namespace donner::gpu

--- a/donner/gpu/GpuLimits.h
+++ b/donner/gpu/GpuLimits.h
@@ -28,12 +28,18 @@ inline constexpr uint32_t kMaxBindGroups = 4;
 /// for `setVertexBuffer` slots.
 inline constexpr uint32_t kMaxVertexBuffers = 8;
 
+/// Maximum total vertex attributes in a render pipeline, and the exclusive upper bound for
+/// attribute shader locations. 16 is the strictest common cap across the native APIs this
+/// runtime targets (well below Metal's 31 per-stage limit).
+inline constexpr uint32_t kMaxVertexAttributes = 16;
+
 /// Maximum number of color attachments in a render pass or render pipeline.
 inline constexpr uint32_t kMaxColorAttachments = 4;
 
 /// Required alignment of \ref TexelCopyBufferLayout::bytesPerRow. 256 is the strictest row-pitch
 /// alignment across the native APIs this runtime targets, so enforcing it uniformly keeps copies
-/// portable without per-backend repacking.
+/// portable without per-backend repacking. The same portability reasoning requires
+/// `TexelCopyBufferLayout::offsetBytes` to be aligned to the copied format's texel size.
 inline constexpr uint32_t kTexelRowPitchAlignment = 256;
 
 }  // namespace donner::gpu

--- a/donner/gpu/GpuResult.h
+++ b/donner/gpu/GpuResult.h
@@ -1,0 +1,158 @@
+#pragma once
+/// @file
+/// Result type returned by fallible \c donner::gpu APIs.
+
+#include <ostream>
+#include <type_traits>
+#include <variant>
+
+#include "donner/base/Utils.h"
+#include "donner/gpu/GpuError.h"
+
+namespace donner::gpu {
+
+/**
+ * Result of a fallible GPU operation: exactly one of a value of type \a T or a \ref GpuError.
+ *
+ * The GPU runtime uses no exceptions; this is the only failure channel. The accessor shape
+ * (\ref hasResult / \ref result / \ref error) mirrors \ref donner::ParseResult so call sites read
+ * the same across the codebase, but unlike ParseResult a GPU operation never returns a partial
+ * result together with an error.
+ *
+ * @tparam T Result type.
+ */
+template <typename T>
+class Result {
+public:
+  static_assert(!std::is_same_v<std::remove_cvref_t<T>, GpuError>,
+                "Result<GpuError> is ambiguous; use Status for void-returning operations");
+
+  /**
+   * Construct from a successful result.
+   *
+   * @param result Result value.
+   */
+  /* implicit */ Result(T&& result) : value_(std::move(result)) {}
+
+  /**
+   * Construct from a successful result by copy.
+   *
+   * @param result Result value.
+   */
+  /* implicit */ Result(const T& result) : value_(result) {}
+
+  /**
+   * Construct from an error.
+   *
+   * @param error Error value.
+   */
+  /* implicit */ Result(GpuError&& error) : value_(std::move(error)) {}
+
+  /**
+   * Construct from an error by copy.
+   *
+   * @param error Error value.
+   */
+  /* implicit */ Result(const GpuError& error) : value_(error) {}
+
+  /**
+   * Returns the contained result.
+   *
+   * @pre There is a valid result, i.e. \ref hasResult() returns true.
+   */
+  T& result() & {
+    UTILS_RELEASE_ASSERT(hasResult());
+    return std::get<T>(value_);
+  }
+
+  /**
+   * Returns the contained result (move).
+   *
+   * @pre There is a valid result, i.e. \ref hasResult() returns true.
+   */
+  T&& result() && {
+    UTILS_RELEASE_ASSERT(hasResult());
+    return std::get<T>(std::move(value_));
+  }
+
+  /**
+   * Returns the contained result.
+   *
+   * @pre There is a valid result, i.e. \ref hasResult() returns true.
+   */
+  const T& result() const& {
+    UTILS_RELEASE_ASSERT(hasResult());
+    return std::get<T>(value_);
+  }
+
+  /**
+   * Returns the contained error.
+   *
+   * @pre There is a valid error, i.e. \ref hasError() returns true.
+   */
+  GpuError& error() & {
+    UTILS_RELEASE_ASSERT(hasError());
+    return std::get<GpuError>(value_);
+  }
+
+  /**
+   * Returns the contained error (move).
+   *
+   * @pre There is a valid error, i.e. \ref hasError() returns true.
+   */
+  GpuError&& error() && {
+    UTILS_RELEASE_ASSERT(hasError());
+    return std::get<GpuError>(std::move(value_));
+  }
+
+  /**
+   * Returns the contained error.
+   *
+   * @pre There is a valid error, i.e. \ref hasError() returns true.
+   */
+  const GpuError& error() const& {
+    UTILS_RELEASE_ASSERT(hasError());
+    return std::get<GpuError>(value_);
+  }
+
+  /// Returns true if this Result contains a value.
+  bool hasResult() const noexcept { return std::holds_alternative<T>(value_); }
+
+  /// Returns true if this Result contains an error.
+  bool hasError() const noexcept { return std::holds_alternative<GpuError>(value_); }
+
+private:
+  std::variant<T, GpuError> value_;
+};
+
+/**
+ * Status of a fallible GPU operation with no result value: either success (a \c std::monostate
+ * result) or a \ref GpuError. Construct success values with \ref OkStatus().
+ */
+using Status = Result<std::monostate>;
+
+/// Returns a successful \ref Status.
+inline Status OkStatus() {
+  return Status(std::monostate());
+}
+
+/**
+ * gtest PrintTo support for readable test failure messages.
+ *
+ * @param result Result to print.
+ * @param os Output stream.
+ */
+template <typename T>
+void PrintTo(const Result<T>& result, std::ostream* os) {
+  if (result.hasError()) {
+    *os << "Result { error: " << result.error() << " }";
+  } else if constexpr (std::is_same_v<T, std::monostate>) {
+    *os << "Status { ok }";
+  } else if constexpr (requires(std::ostream& s, const T& v) { s << v; }) {
+    *os << "Result { " << result.result() << " }";
+  } else {
+    *os << "Result { <value> }";
+  }
+}
+
+}  // namespace donner::gpu

--- a/donner/gpu/Handles.h
+++ b/donner/gpu/Handles.h
@@ -1,0 +1,257 @@
+#pragma once
+/// @file
+/// Move-only, generation-checked resource handles for \c donner::gpu.
+///
+/// Handles are NOT RAII in this packet: resources are freed by an explicit
+/// `Device::destroy*(handle)` call, and device teardown frees everything that remains. RAII
+/// ownership wrappers arrive with the resource-lifetime packet (design 0053 change sequence
+/// step 3, "Resource lifetime and submission model"). Dropping a handle without destroying the
+/// resource does not dangle or leak beyond the device's lifetime; the resource simply stays alive
+/// until device teardown.
+
+#include <cstdint>
+#include <ostream>
+
+namespace donner::gpu {
+
+/**
+ * Move-only handle to a device resource.
+ *
+ * A handle carries a (slot, generation) pair plus the identity of the owning device. The device
+ * validates all three on every use, so a null handle, a stale handle (the resource was destroyed,
+ * possibly with its slot reused), or a handle from a different device fails closed with
+ * \ref GpuErrorType::InvalidHandle / \ref GpuErrorType::DeviceMismatch instead of reaching a
+ * backend. Validation runs in release builds too.
+ *
+ * A default-constructed or moved-from handle is null (\ref isValid() returns false).
+ *
+ * @tparam Tag Tag type identifying the resource type; provides `Tag::kName` for diagnostics.
+ */
+template <typename Tag>
+class Handle {
+public:
+  /// Constructs a null handle.
+  Handle() = default;
+
+  /// Destructor. Intentionally does not free the resource (see file comment).
+  ~Handle() = default;
+
+  Handle(const Handle&) = delete;
+  Handle& operator=(const Handle&) = delete;
+
+  /**
+   * Move constructor; \p other becomes null.
+   *
+   * @param other Handle to move from.
+   */
+  Handle(Handle&& other) noexcept
+      : slotIndex_(other.slotIndex_), generation_(other.generation_), deviceId_(other.deviceId_) {
+    other.resetToNull();
+  }
+
+  /**
+   * Move assignment; \p other becomes null.
+   *
+   * @param other Handle to move from.
+   */
+  Handle& operator=(Handle&& other) noexcept {
+    if (this != &other) {
+      slotIndex_ = other.slotIndex_;
+      generation_ = other.generation_;
+      deviceId_ = other.deviceId_;
+      other.resetToNull();
+    }
+    return *this;
+  }
+
+  /// Returns true if this handle is non-null. The device generation check is authoritative for
+  /// whether the resource is still alive.
+  bool isValid() const { return generation_ != 0; }
+
+  /// Resource table slot index, for backend use.
+  uint32_t slotIndex() const { return slotIndex_; }
+
+  /// Slot generation at creation time, for backend use. Zero for null handles.
+  uint32_t generation() const { return generation_; }
+
+  /// Identity of the owning device (see `Device::deviceId()`), for backend use. Zero for null
+  /// handles.
+  uint64_t deviceId() const { return deviceId_; }
+
+  /**
+   * Mints a live handle; called by device backends only.
+   *
+   * @param slotIndex Resource table slot index.
+   * @param generation Slot generation at creation time; must be nonzero.
+   * @param deviceId Identity of the owning device.
+   */
+  static Handle CreateForBackend(uint32_t slotIndex, uint32_t generation, uint64_t deviceId) {
+    Handle handle;
+    handle.slotIndex_ = slotIndex;
+    handle.generation_ = generation;
+    handle.deviceId_ = deviceId;
+    return handle;
+  }
+
+  /**
+   * Compares against null: true if the handle is null.
+   *
+   * @param handle Handle to test.
+   */
+  friend bool operator==(const Handle& handle, std::nullptr_t) { return !handle.isValid(); }
+
+private:
+  void resetToNull() {
+    slotIndex_ = 0;
+    generation_ = 0;
+    deviceId_ = 0;
+  }
+
+  uint32_t slotIndex_ = 0;
+  uint32_t generation_ = 0;
+  uint64_t deviceId_ = 0;
+};
+
+/**
+ * Copyable non-owning reference to a \ref Handle, used inside descriptor structs.
+ *
+ * Handles are move-only, so descriptors reference them through this identity-only view instead.
+ * The device re-validates slot, generation, and device identity when the descriptor is consumed,
+ * so a stale or foreign reference fails closed exactly like a stale or foreign handle.
+ *
+ * @tparam Tag Tag type identifying the resource type.
+ */
+template <typename Tag>
+class HandleRef {
+public:
+  /// Constructs a null reference.
+  HandleRef() = default;
+
+  /**
+   * Implicitly references \p handle. The reference does not keep the resource alive.
+   *
+   * @param handle Handle to reference.
+   */
+  /* implicit */ HandleRef(const Handle<Tag>& handle)
+      : slotIndex_(handle.slotIndex()),
+        generation_(handle.generation()),
+        deviceId_(handle.deviceId()) {}
+
+  /// Returns true if this reference is non-null.
+  bool isValid() const { return generation_ != 0; }
+
+  /// Resource table slot index, for backend use.
+  uint32_t slotIndex() const { return slotIndex_; }
+
+  /// Slot generation at creation time, for backend use. Zero for null references.
+  uint32_t generation() const { return generation_; }
+
+  /// Identity of the owning device, for backend use. Zero for null references.
+  uint64_t deviceId() const { return deviceId_; }
+
+  /**
+   * Compares against null: true if the reference is null.
+   *
+   * @param ref Reference to test.
+   */
+  friend bool operator==(const HandleRef& ref, std::nullptr_t) { return !ref.isValid(); }
+
+private:
+  uint32_t slotIndex_ = 0;
+  uint32_t generation_ = 0;
+  uint64_t deviceId_ = 0;
+};
+
+/// Tag for \ref Buffer handles.
+struct BufferTag {
+  static constexpr const char* kName = "buffer";  //!< Resource name for diagnostics.
+};
+/// Tag for \ref Texture handles.
+struct TextureTag {
+  static constexpr const char* kName = "texture";  //!< Resource name for diagnostics.
+};
+/// Tag for \ref TextureView handles.
+struct TextureViewTag {
+  static constexpr const char* kName = "textureView";  //!< Resource name for diagnostics.
+};
+/// Tag for \ref Sampler handles.
+struct SamplerTag {
+  static constexpr const char* kName = "sampler";  //!< Resource name for diagnostics.
+};
+/// Tag for \ref BindGroupLayout handles.
+struct BindGroupLayoutTag {
+  static constexpr const char* kName = "bindGroupLayout";  //!< Resource name for diagnostics.
+};
+/// Tag for \ref BindGroup handles.
+struct BindGroupTag {
+  static constexpr const char* kName = "bindGroup";  //!< Resource name for diagnostics.
+};
+/// Tag for \ref PipelineLayout handles.
+struct PipelineLayoutTag {
+  static constexpr const char* kName = "pipelineLayout";  //!< Resource name for diagnostics.
+};
+/// Tag for \ref ShaderModule handles.
+struct ShaderModuleTag {
+  static constexpr const char* kName = "shaderModule";  //!< Resource name for diagnostics.
+};
+/// Tag for \ref RenderPipeline handles.
+struct RenderPipelineTag {
+  static constexpr const char* kName = "renderPipeline";  //!< Resource name for diagnostics.
+};
+/// Tag for \ref CommandBuffer handles.
+struct CommandBufferTag {
+  static constexpr const char* kName = "commandBuffer";  //!< Resource name for diagnostics.
+};
+
+using Buffer = Handle<BufferTag>;                    //!< Buffer handle.
+using Texture = Handle<TextureTag>;                  //!< Texture handle.
+using TextureView = Handle<TextureViewTag>;          //!< Texture view handle.
+using Sampler = Handle<SamplerTag>;                  //!< Sampler handle.
+using BindGroupLayout = Handle<BindGroupLayoutTag>;  //!< Bind group layout handle.
+using BindGroup = Handle<BindGroupTag>;              //!< Bind group handle.
+using PipelineLayout = Handle<PipelineLayoutTag>;    //!< Pipeline layout handle.
+using ShaderModule = Handle<ShaderModuleTag>;        //!< Shader module handle.
+using RenderPipeline = Handle<RenderPipelineTag>;    //!< Render pipeline handle.
+using CommandBuffer = Handle<CommandBufferTag>;      //!< Finished command buffer handle.
+
+using BufferRef = HandleRef<BufferTag>;                    //!< Buffer reference.
+using TextureRef = HandleRef<TextureTag>;                  //!< Texture reference.
+using TextureViewRef = HandleRef<TextureViewTag>;          //!< Texture view reference.
+using SamplerRef = HandleRef<SamplerTag>;                  //!< Sampler reference.
+using BindGroupLayoutRef = HandleRef<BindGroupLayoutTag>;  //!< Bind group layout reference.
+using BindGroupRef = HandleRef<BindGroupTag>;              //!< Bind group reference.
+using PipelineLayoutRef = HandleRef<PipelineLayoutTag>;    //!< Pipeline layout reference.
+using ShaderModuleRef = HandleRef<ShaderModuleTag>;        //!< Shader module reference.
+using RenderPipelineRef = HandleRef<RenderPipelineTag>;    //!< Render pipeline reference.
+
+/**
+ * gtest PrintTo support: prints `<name>#<slot>@<generation>` or `<name>(null)`.
+ *
+ * @param handle Handle to print.
+ * @param os Output stream.
+ */
+template <typename Tag>
+void PrintTo(const Handle<Tag>& handle, std::ostream* os) {
+  if (handle.isValid()) {
+    *os << Tag::kName << "#" << handle.slotIndex() << "@" << handle.generation();
+  } else {
+    *os << Tag::kName << "(null)";
+  }
+}
+
+/**
+ * gtest PrintTo support: prints `<name>#<slot>@<generation>` or `<name>(null)`.
+ *
+ * @param ref Reference to print.
+ * @param os Output stream.
+ */
+template <typename Tag>
+void PrintTo(const HandleRef<Tag>& ref, std::ostream* os) {
+  if (ref.isValid()) {
+    *os << Tag::kName << "#" << ref.slotIndex() << "@" << ref.generation();
+  } else {
+    *os << Tag::kName << "(null)";
+  }
+}
+
+}  // namespace donner::gpu

--- a/donner/gpu/RecordingDevice.cc
+++ b/donner/gpu/RecordingDevice.cc
@@ -1,8 +1,7 @@
 #include "donner/gpu/RecordingDevice.h"
 
-#include <cctype>
-#include <cstdio>
 #include <format>
+#include <locale>
 #include <sstream>
 #include <string_view>
 
@@ -10,28 +9,34 @@ namespace donner::gpu {
 
 namespace {
 
-/// Formats a double deterministically (no locale dependence beyond the C locale, fixed
-/// precision).
-std::string FormatDouble(double value) {
-  char buffer[32];
-  std::snprintf(buffer, sizeof(buffer), "%.9g", value);
-  return buffer;
+/// Creates a serialization stream imbued with the classic "C" locale, so captured numbers are
+/// byte-identical regardless of the process's global locale (no digit grouping).
+std::ostringstream MakeLineStream() {
+  std::ostringstream os;
+  os.imbue(std::locale::classic());
+  return os;
 }
 
-/// Quotes and escapes a label: `"`, `\`, and non-printable bytes are escaped so labels cannot
-/// break the line-based format.
+/// Formats a double deterministically: std::format's shortest round-trip representation is
+/// locale-independent, unlike printf-family formatting which follows LC_NUMERIC.
+std::string FormatDouble(double value) {
+  return std::format("{}", value);
+}
+
+/// Quotes and escapes a label: `"`, `\`, and bytes outside the printable ASCII range are escaped
+/// so labels cannot break the line-based format. The explicit range test avoids the
+/// locale-dependent std::isprint.
 std::string QuoteLabel(std::string_view label) {
   std::string result = "\"";
   for (const char ch : label) {
+    const unsigned char byte = static_cast<unsigned char>(ch);
     if (ch == '"' || ch == '\\') {
       result += '\\';
       result += ch;
-    } else if (std::isprint(static_cast<unsigned char>(ch)) != 0) {
+    } else if (byte >= 0x20 && byte < 0x7F) {
       result += ch;
     } else {
-      char buffer[8];
-      std::snprintf(buffer, sizeof(buffer), "\\x%02x", static_cast<unsigned char>(ch));
-      result += buffer;
+      result += std::format("\\x{:02x}", byte);
     }
   }
   result += '"';
@@ -51,17 +56,7 @@ std::string HashBytes(std::span<const uint8_t> data) {
 
 /// Formats a slot-based resource identifier, e.g. `buffer#0`.
 std::string RefId(std::string_view resourceName, uint32_t slotIndex) {
-  std::ostringstream os;
-  os << resourceName << "#" << slotIndex;
-  return os.str();
-}
-
-/// Streams an enum or other `operator<<`-printable value to a string.
-template <typename T>
-std::string ToString(const T& value) {
-  std::ostringstream os;
-  os << value;
-  return os.str();
+  return std::format("{}#{}", resourceName, slotIndex);
 }
 
 /// Serializes the vertex buffer layout list of a pipeline descriptor.
@@ -162,7 +157,7 @@ std::string RecordingDevice::serialize() const {
 }
 
 Status RecordingDevice::onCreateBuffer(uint32_t slotIndex, const BufferDescriptor& descriptor) {
-  std::ostringstream os;
+  std::ostringstream os = MakeLineStream();
   os << "createBuffer " << RefId(BufferTag::kName, slotIndex)
      << " label=" << QuoteLabel(descriptor.label) << " byteSize=" << descriptor.byteSize
      << " usage=" << descriptor.usage;
@@ -171,7 +166,7 @@ Status RecordingDevice::onCreateBuffer(uint32_t slotIndex, const BufferDescripto
 }
 
 Status RecordingDevice::onCreateTexture(uint32_t slotIndex, const TextureDescriptor& descriptor) {
-  std::ostringstream os;
+  std::ostringstream os = MakeLineStream();
   os << "createTexture " << RefId(TextureTag::kName, slotIndex)
      << " label=" << QuoteLabel(descriptor.label) << " size=" << descriptor.size
      << " format=" << descriptor.format << " usage=" << descriptor.usage
@@ -182,7 +177,7 @@ Status RecordingDevice::onCreateTexture(uint32_t slotIndex, const TextureDescrip
 
 Status RecordingDevice::onCreateTextureView(uint32_t slotIndex, uint32_t textureSlotIndex,
                                             const TextureViewDescriptor& descriptor) {
-  std::ostringstream os;
+  std::ostringstream os = MakeLineStream();
   os << "createTextureView " << RefId(TextureViewTag::kName, slotIndex)
      << " label=" << QuoteLabel(descriptor.label)
      << " texture=" << RefId(TextureTag::kName, textureSlotIndex);
@@ -191,7 +186,7 @@ Status RecordingDevice::onCreateTextureView(uint32_t slotIndex, uint32_t texture
 }
 
 Status RecordingDevice::onCreateSampler(uint32_t slotIndex, const SamplerDescriptor& descriptor) {
-  std::ostringstream os;
+  std::ostringstream os = MakeLineStream();
   os << "createSampler " << RefId(SamplerTag::kName, slotIndex)
      << " label=" << QuoteLabel(descriptor.label) << " magFilter=" << descriptor.magFilter
      << " minFilter=" << descriptor.minFilter << " addressModeU=" << descriptor.addressModeU
@@ -202,7 +197,7 @@ Status RecordingDevice::onCreateSampler(uint32_t slotIndex, const SamplerDescrip
 
 Status RecordingDevice::onCreateBindGroupLayout(uint32_t slotIndex,
                                                 const BindGroupLayoutDescriptor& descriptor) {
-  std::ostringstream os;
+  std::ostringstream os = MakeLineStream();
   os << "createBindGroupLayout " << RefId(BindGroupLayoutTag::kName, slotIndex)
      << " label=" << QuoteLabel(descriptor.label) << " entries=[";
   for (size_t i = 0; i < descriptor.entries.size(); ++i) {
@@ -220,7 +215,7 @@ Status RecordingDevice::onCreateBindGroupLayout(uint32_t slotIndex,
 
 Status RecordingDevice::onCreateBindGroup(uint32_t slotIndex,
                                           const BindGroupDescriptor& descriptor) {
-  std::ostringstream os;
+  std::ostringstream os = MakeLineStream();
   os << "createBindGroup " << RefId(BindGroupTag::kName, slotIndex)
      << " label=" << QuoteLabel(descriptor.label)
      << " layout=" << RefId(BindGroupLayoutTag::kName, descriptor.layout.slotIndex())
@@ -251,7 +246,7 @@ Status RecordingDevice::onCreateBindGroup(uint32_t slotIndex,
 
 Status RecordingDevice::onCreatePipelineLayout(uint32_t slotIndex,
                                                const PipelineLayoutDescriptor& descriptor) {
-  std::ostringstream os;
+  std::ostringstream os = MakeLineStream();
   os << "createPipelineLayout " << RefId(PipelineLayoutTag::kName, slotIndex)
      << " label=" << QuoteLabel(descriptor.label) << " bindGroupLayouts=[";
   for (size_t i = 0; i < descriptor.bindGroupLayouts.size(); ++i) {
@@ -268,7 +263,7 @@ Status RecordingDevice::onCreatePipelineLayout(uint32_t slotIndex,
 Status RecordingDevice::onCreateShaderModule(uint32_t slotIndex,
                                              const ShaderModuleDescriptor& descriptor) {
   const std::string_view source(descriptor.sourceText);
-  std::ostringstream os;
+  std::ostringstream os = MakeLineStream();
   os << "createShaderModule " << RefId(ShaderModuleTag::kName, slotIndex)
      << " label=" << QuoteLabel(descriptor.label) << " sourceKind=" << descriptor.sourceKind
      << " sourceBytes=" << source.size() << " sourceHash="
@@ -280,7 +275,7 @@ Status RecordingDevice::onCreateShaderModule(uint32_t slotIndex,
 
 Status RecordingDevice::onCreateRenderPipeline(uint32_t slotIndex,
                                                const RenderPipelineDescriptor& descriptor) {
-  std::ostringstream os;
+  std::ostringstream os = MakeLineStream();
   os << "createRenderPipeline " << RefId(RenderPipelineTag::kName, slotIndex)
      << " label=" << QuoteLabel(descriptor.label)
      << " layout=" << RefId(PipelineLayoutTag::kName, descriptor.layout.slotIndex());
@@ -324,7 +319,7 @@ void RecordingDevice::onDestroyResource(std::string_view resourceName, uint32_t 
 
 Status RecordingDevice::onWriteBuffer(uint32_t slotIndex, uint64_t offsetBytes,
                                       std::span<const uint8_t> data) {
-  std::ostringstream os;
+  std::ostringstream os = MakeLineStream();
   os << "writeBuffer " << RefId(BufferTag::kName, slotIndex) << " offsetBytes=" << offsetBytes
      << " byteCount=" << data.size() << " dataHash=" << HashBytes(data);
   lines_.push_back(os.str());
@@ -334,7 +329,7 @@ Status RecordingDevice::onWriteBuffer(uint32_t slotIndex, uint64_t offsetBytes,
 Status RecordingDevice::onWriteTexture(uint32_t slotIndex, std::span<const uint8_t> data,
                                        const TexelCopyBufferLayout& dataLayout,
                                        const Extent2d& writeSize) {
-  std::ostringstream os;
+  std::ostringstream os = MakeLineStream();
   os << "writeTexture " << RefId(TextureTag::kName, slotIndex)
      << " offsetBytes=" << dataLayout.offsetBytes << " bytesPerRow=" << dataLayout.bytesPerRow
      << " rowsPerImage=" << dataLayout.rowsPerImage << " writeSize=" << writeSize
@@ -345,14 +340,14 @@ Status RecordingDevice::onWriteTexture(uint32_t slotIndex, std::span<const uint8
 
 Status RecordingDevice::onSubmit(uint64_t submissionSerial, uint32_t commandBufferSlotIndex,
                                  std::span<const Command> commands) {
-  std::ostringstream os;
+  std::ostringstream os = MakeLineStream();
   os << "submit serial=" << submissionSerial << " "
      << RefId(CommandBufferTag::kName, commandBufferSlotIndex)
      << " commandCount=" << commands.size();
   lines_.push_back(os.str());
 
   for (const Command& command : commands) {
-    std::ostringstream commandStream;
+    std::ostringstream commandStream = MakeLineStream();
     commandStream << "  ";
     std::visit(CommandSerializer{commandStream}, command);
     lines_.push_back(commandStream.str());

--- a/donner/gpu/RecordingDevice.cc
+++ b/donner/gpu/RecordingDevice.cc
@@ -1,0 +1,363 @@
+#include "donner/gpu/RecordingDevice.h"
+
+#include <cctype>
+#include <cstdio>
+#include <format>
+#include <sstream>
+#include <string_view>
+
+namespace donner::gpu {
+
+namespace {
+
+/// Formats a double deterministically (no locale dependence beyond the C locale, fixed
+/// precision).
+std::string FormatDouble(double value) {
+  char buffer[32];
+  std::snprintf(buffer, sizeof(buffer), "%.9g", value);
+  return buffer;
+}
+
+/// Quotes and escapes a label: `"`, `\`, and non-printable bytes are escaped so labels cannot
+/// break the line-based format.
+std::string QuoteLabel(std::string_view label) {
+  std::string result = "\"";
+  for (const char ch : label) {
+    if (ch == '"' || ch == '\\') {
+      result += '\\';
+      result += ch;
+    } else if (std::isprint(static_cast<unsigned char>(ch)) != 0) {
+      result += ch;
+    } else {
+      char buffer[8];
+      std::snprintf(buffer, sizeof(buffer), "\\x%02x", static_cast<unsigned char>(ch));
+      result += buffer;
+    }
+  }
+  result += '"';
+  return result;
+}
+
+/// FNV-1a 64-bit hash of a byte payload, formatted as 16 hex digits. Content-sensitive but
+/// compact, so recordings stay deterministic without dumping payload bytes.
+std::string HashBytes(std::span<const uint8_t> data) {
+  uint64_t hash = 14695981039346656037ull;
+  for (const uint8_t byte : data) {
+    hash ^= byte;
+    hash *= 1099511628211ull;
+  }
+  return std::format("{:016x}", hash);
+}
+
+/// Formats a slot-based resource identifier, e.g. `buffer#0`.
+std::string RefId(std::string_view resourceName, uint32_t slotIndex) {
+  std::ostringstream os;
+  os << resourceName << "#" << slotIndex;
+  return os.str();
+}
+
+/// Streams an enum or other `operator<<`-printable value to a string.
+template <typename T>
+std::string ToString(const T& value) {
+  std::ostringstream os;
+  os << value;
+  return os.str();
+}
+
+/// Serializes the vertex buffer layout list of a pipeline descriptor.
+void AppendVertexBufferLayouts(std::ostringstream& os,
+                               const std::vector<VertexBufferLayout>& buffers) {
+  os << "buffers=[";
+  for (size_t i = 0; i < buffers.size(); ++i) {
+    if (i > 0) {
+      os << " ";
+    }
+    const VertexBufferLayout& layout = buffers[i];
+    os << "{strideBytes=" << layout.strideBytes << " stepMode=" << layout.stepMode
+       << " attributes=[";
+    for (size_t j = 0; j < layout.attributes.size(); ++j) {
+      if (j > 0) {
+        os << " ";
+      }
+      const VertexAttribute& attribute = layout.attributes[j];
+      os << "{format=" << attribute.format << " offsetBytes=" << attribute.offsetBytes
+         << " shaderLocation=" << attribute.shaderLocation << "}";
+    }
+    os << "]}";
+  }
+  os << "]";
+}
+
+/// Serializes a blend component, e.g. `{srcFactor=One dstFactor=OneMinusSrcAlpha operation=Add}`.
+void AppendBlendComponent(std::ostringstream& os, const BlendComponent& component) {
+  os << "{srcFactor=" << component.srcFactor << " dstFactor=" << component.dstFactor
+     << " operation=" << component.operation << "}";
+}
+
+/// Serializes one recorded command as a single line (no indentation or newline).
+struct CommandSerializer {
+  std::ostringstream& os;  //!< Destination stream.
+
+  void operator()(const BeginRenderPassCommand& command) {
+    os << "beginRenderPass label=" << QuoteLabel(command.descriptor.label) << " colorAttachments=[";
+    const std::vector<RenderPassColorAttachment>& attachments = command.descriptor.colorAttachments;
+    for (size_t i = 0; i < attachments.size(); ++i) {
+      if (i > 0) {
+        os << " ";
+      }
+      const RenderPassColorAttachment& attachment = attachments[i];
+      os << "{view=" << RefId(TextureViewTag::kName, attachment.view.slotIndex())
+         << " loadOp=" << attachment.loadOp << " storeOp=" << attachment.storeOp << " clearColor=("
+         << FormatDouble(attachment.clearColor[0]) << " " << FormatDouble(attachment.clearColor[1])
+         << " " << FormatDouble(attachment.clearColor[2]) << " "
+         << FormatDouble(attachment.clearColor[3]) << ")}";
+    }
+    os << "]";
+  }
+  void operator()(const SetPipelineCommand& command) {
+    os << "setPipeline " << RefId(RenderPipelineTag::kName, command.pipelineSlot);
+  }
+  void operator()(const SetBindGroupCommand& command) {
+    os << "setBindGroup index=" << command.index
+       << " bindGroup=" << RefId(BindGroupTag::kName, command.bindGroupSlot);
+  }
+  void operator()(const SetVertexBufferCommand& command) {
+    os << "setVertexBuffer slot=" << command.slot
+       << " buffer=" << RefId(BufferTag::kName, command.bufferSlot)
+       << " offsetBytes=" << command.offsetBytes;
+  }
+  void operator()(const SetScissorRectCommand& command) {
+    os << "setScissorRect x=" << command.x << " y=" << command.y << " width=" << command.width
+       << " height=" << command.height;
+  }
+  void operator()(const SetViewportCommand& command) {
+    os << "setViewport x=" << FormatDouble(command.x) << " y=" << FormatDouble(command.y)
+       << " width=" << FormatDouble(command.width) << " height=" << FormatDouble(command.height)
+       << " minDepth=" << FormatDouble(command.minDepth)
+       << " maxDepth=" << FormatDouble(command.maxDepth);
+  }
+  void operator()(const DrawCommand& command) {
+    os << "draw vertexCount=" << command.vertexCount << " instanceCount=" << command.instanceCount
+       << " firstVertex=" << command.firstVertex << " firstInstance=" << command.firstInstance;
+  }
+  void operator()(const EndRenderPassCommand&) { os << "endRenderPass"; }
+  void operator()(const CopyTextureToBufferCommand& command) {
+    os << "copyTextureToBuffer texture=" << RefId(TextureTag::kName, command.textureSlot)
+       << " buffer=" << RefId(BufferTag::kName, command.bufferSlot)
+       << " offsetBytes=" << command.layout.offsetBytes
+       << " bytesPerRow=" << command.layout.bytesPerRow
+       << " rowsPerImage=" << command.layout.rowsPerImage << " copySize=" << command.copySize;
+  }
+};
+
+}  // namespace
+
+std::string RecordingDevice::serialize() const {
+  std::string result;
+  for (const std::string& line : lines_) {
+    result += line;
+    result += '\n';
+  }
+  return result;
+}
+
+Status RecordingDevice::onCreateBuffer(uint32_t slotIndex, const BufferDescriptor& descriptor) {
+  std::ostringstream os;
+  os << "createBuffer " << RefId(BufferTag::kName, slotIndex)
+     << " label=" << QuoteLabel(descriptor.label) << " byteSize=" << descriptor.byteSize
+     << " usage=" << descriptor.usage;
+  lines_.push_back(os.str());
+  return OkStatus();
+}
+
+Status RecordingDevice::onCreateTexture(uint32_t slotIndex, const TextureDescriptor& descriptor) {
+  std::ostringstream os;
+  os << "createTexture " << RefId(TextureTag::kName, slotIndex)
+     << " label=" << QuoteLabel(descriptor.label) << " size=" << descriptor.size
+     << " format=" << descriptor.format << " usage=" << descriptor.usage
+     << " sampleCount=" << descriptor.sampleCount;
+  lines_.push_back(os.str());
+  return OkStatus();
+}
+
+Status RecordingDevice::onCreateTextureView(uint32_t slotIndex, uint32_t textureSlotIndex,
+                                            const TextureViewDescriptor& descriptor) {
+  std::ostringstream os;
+  os << "createTextureView " << RefId(TextureViewTag::kName, slotIndex)
+     << " label=" << QuoteLabel(descriptor.label)
+     << " texture=" << RefId(TextureTag::kName, textureSlotIndex);
+  lines_.push_back(os.str());
+  return OkStatus();
+}
+
+Status RecordingDevice::onCreateSampler(uint32_t slotIndex, const SamplerDescriptor& descriptor) {
+  std::ostringstream os;
+  os << "createSampler " << RefId(SamplerTag::kName, slotIndex)
+     << " label=" << QuoteLabel(descriptor.label) << " magFilter=" << descriptor.magFilter
+     << " minFilter=" << descriptor.minFilter << " addressModeU=" << descriptor.addressModeU
+     << " addressModeV=" << descriptor.addressModeV;
+  lines_.push_back(os.str());
+  return OkStatus();
+}
+
+Status RecordingDevice::onCreateBindGroupLayout(uint32_t slotIndex,
+                                                const BindGroupLayoutDescriptor& descriptor) {
+  std::ostringstream os;
+  os << "createBindGroupLayout " << RefId(BindGroupLayoutTag::kName, slotIndex)
+     << " label=" << QuoteLabel(descriptor.label) << " entries=[";
+  for (size_t i = 0; i < descriptor.entries.size(); ++i) {
+    if (i > 0) {
+      os << " ";
+    }
+    const BindGroupLayoutEntry& entry = descriptor.entries[i];
+    os << "{binding=" << entry.binding << " visibility=" << entry.visibility
+       << " type=" << entry.type << "}";
+  }
+  os << "]";
+  lines_.push_back(os.str());
+  return OkStatus();
+}
+
+Status RecordingDevice::onCreateBindGroup(uint32_t slotIndex,
+                                          const BindGroupDescriptor& descriptor) {
+  std::ostringstream os;
+  os << "createBindGroup " << RefId(BindGroupTag::kName, slotIndex)
+     << " label=" << QuoteLabel(descriptor.label)
+     << " layout=" << RefId(BindGroupLayoutTag::kName, descriptor.layout.slotIndex())
+     << " entries=[";
+  for (size_t i = 0; i < descriptor.entries.size(); ++i) {
+    if (i > 0) {
+      os << " ";
+    }
+    const BindGroupEntry& entry = descriptor.entries[i];
+    os << "{binding=" << entry.binding << " ";
+    if (const BufferBinding* bufferBinding = std::get_if<BufferBinding>(&entry.resource)) {
+      os << "buffer=" << RefId(BufferTag::kName, bufferBinding->buffer.slotIndex())
+         << " offsetBytes=" << bufferBinding->offsetBytes
+         << " sizeBytes=" << bufferBinding->sizeBytes;
+    } else if (const TextureViewBinding* viewBinding =
+                   std::get_if<TextureViewBinding>(&entry.resource)) {
+      os << "textureView=" << RefId(TextureViewTag::kName, viewBinding->view.slotIndex());
+    } else if (const SamplerBinding* samplerBinding =
+                   std::get_if<SamplerBinding>(&entry.resource)) {
+      os << "sampler=" << RefId(SamplerTag::kName, samplerBinding->sampler.slotIndex());
+    }
+    os << "}";
+  }
+  os << "]";
+  lines_.push_back(os.str());
+  return OkStatus();
+}
+
+Status RecordingDevice::onCreatePipelineLayout(uint32_t slotIndex,
+                                               const PipelineLayoutDescriptor& descriptor) {
+  std::ostringstream os;
+  os << "createPipelineLayout " << RefId(PipelineLayoutTag::kName, slotIndex)
+     << " label=" << QuoteLabel(descriptor.label) << " bindGroupLayouts=[";
+  for (size_t i = 0; i < descriptor.bindGroupLayouts.size(); ++i) {
+    if (i > 0) {
+      os << " ";
+    }
+    os << RefId(BindGroupLayoutTag::kName, descriptor.bindGroupLayouts[i].slotIndex());
+  }
+  os << "]";
+  lines_.push_back(os.str());
+  return OkStatus();
+}
+
+Status RecordingDevice::onCreateShaderModule(uint32_t slotIndex,
+                                             const ShaderModuleDescriptor& descriptor) {
+  const std::string_view source(descriptor.sourceText);
+  std::ostringstream os;
+  os << "createShaderModule " << RefId(ShaderModuleTag::kName, slotIndex)
+     << " label=" << QuoteLabel(descriptor.label) << " sourceKind=" << descriptor.sourceKind
+     << " sourceBytes=" << source.size() << " sourceHash="
+     << HashBytes(std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(source.data()),
+                                           source.size()));
+  lines_.push_back(os.str());
+  return OkStatus();
+}
+
+Status RecordingDevice::onCreateRenderPipeline(uint32_t slotIndex,
+                                               const RenderPipelineDescriptor& descriptor) {
+  std::ostringstream os;
+  os << "createRenderPipeline " << RefId(RenderPipelineTag::kName, slotIndex)
+     << " label=" << QuoteLabel(descriptor.label)
+     << " layout=" << RefId(PipelineLayoutTag::kName, descriptor.layout.slotIndex());
+
+  os << " vertex={module=" << RefId(ShaderModuleTag::kName, descriptor.vertex.module.slotIndex())
+     << " entryPoint=" << QuoteLabel(descriptor.vertex.entryPoint) << " ";
+  AppendVertexBufferLayouts(os, descriptor.vertex.buffers);
+  os << "}";
+
+  os << " fragment={module="
+     << RefId(ShaderModuleTag::kName, descriptor.fragment.module.slotIndex())
+     << " entryPoint=" << QuoteLabel(descriptor.fragment.entryPoint) << " targets=[";
+  for (size_t i = 0; i < descriptor.fragment.targets.size(); ++i) {
+    if (i > 0) {
+      os << " ";
+    }
+    const ColorTargetState& target = descriptor.fragment.targets[i];
+    os << "{format=" << target.format << " blend=";
+    if (target.blend) {
+      os << "{color=";
+      AppendBlendComponent(os, target.blend->color);
+      os << " alpha=";
+      AppendBlendComponent(os, target.blend->alpha);
+      os << "}";
+    } else {
+      os << "none";
+    }
+    os << " writeMask=" << target.writeMask << "}";
+  }
+  os << "]}";
+
+  os << " topology=" << descriptor.topology << " cullMode=" << descriptor.cullMode
+     << " multisampleCount=" << descriptor.multisampleCount;
+  lines_.push_back(os.str());
+  return OkStatus();
+}
+
+void RecordingDevice::onDestroyResource(std::string_view resourceName, uint32_t slotIndex) {
+  lines_.push_back("destroy " + RefId(resourceName, slotIndex));
+}
+
+Status RecordingDevice::onWriteBuffer(uint32_t slotIndex, uint64_t offsetBytes,
+                                      std::span<const uint8_t> data) {
+  std::ostringstream os;
+  os << "writeBuffer " << RefId(BufferTag::kName, slotIndex) << " offsetBytes=" << offsetBytes
+     << " byteCount=" << data.size() << " dataHash=" << HashBytes(data);
+  lines_.push_back(os.str());
+  return OkStatus();
+}
+
+Status RecordingDevice::onWriteTexture(uint32_t slotIndex, std::span<const uint8_t> data,
+                                       const TexelCopyBufferLayout& dataLayout,
+                                       const Extent2d& writeSize) {
+  std::ostringstream os;
+  os << "writeTexture " << RefId(TextureTag::kName, slotIndex)
+     << " offsetBytes=" << dataLayout.offsetBytes << " bytesPerRow=" << dataLayout.bytesPerRow
+     << " rowsPerImage=" << dataLayout.rowsPerImage << " writeSize=" << writeSize
+     << " byteCount=" << data.size() << " dataHash=" << HashBytes(data);
+  lines_.push_back(os.str());
+  return OkStatus();
+}
+
+Status RecordingDevice::onSubmit(uint64_t submissionSerial, uint32_t commandBufferSlotIndex,
+                                 std::span<const Command> commands) {
+  std::ostringstream os;
+  os << "submit serial=" << submissionSerial << " "
+     << RefId(CommandBufferTag::kName, commandBufferSlotIndex)
+     << " commandCount=" << commands.size();
+  lines_.push_back(os.str());
+
+  for (const Command& command : commands) {
+    std::ostringstream commandStream;
+    commandStream << "  ";
+    std::visit(CommandSerializer{commandStream}, command);
+    lines_.push_back(commandStream.str());
+  }
+  return OkStatus();
+}
+
+}  // namespace donner::gpu

--- a/donner/gpu/RecordingDevice.h
+++ b/donner/gpu/RecordingDevice.h
@@ -1,0 +1,70 @@
+#pragma once
+/// @file
+/// \c donner::gpu::RecordingDevice - the deterministic recording backend.
+
+#include <string>
+#include <vector>
+
+#include "donner/gpu/Device.h"
+
+namespace donner::gpu {
+
+/**
+ * Deterministic recording backend (design 0053 "Proposed Architecture", "Testing Strategy").
+ *
+ * Inherits every fail-closed validation check from \ref Device and records each validated
+ * operation as a line of text. \ref serialize returns the capture: repeated identical operation
+ * streams serialize byte-identically, resources are identified by stable slot-based ids like
+ * `buffer#0` (never pointers or process state), descriptor fields are dumped in full with fixed
+ * formatting, and data payloads appear as byte counts plus a content hash.
+ *
+ * Submission completes instantly: \ref completedSerial always equals
+ * \ref Device::lastSubmittedSerial.
+ */
+class RecordingDevice final : public Device {
+public:
+  /// Constructs an empty recording device.
+  RecordingDevice() = default;
+
+  /// Destructor.
+  ~RecordingDevice() override = default;
+
+  /**
+   * Returns the deterministic line-based text capture of every recorded operation, in order.
+   * Creation, write, and destroy operations appear as one line each; submissions appear as a
+   * `submit` line followed by one indented line per command.
+   */
+  std::string serialize() const;
+
+  /// Serial of the most recent submission; recording completes instantly.
+  uint64_t completedSerial() const override { return lastSubmittedSerial(); }
+
+protected:
+  Status onCreateBuffer(uint32_t slotIndex, const BufferDescriptor& descriptor) override;
+  Status onCreateTexture(uint32_t slotIndex, const TextureDescriptor& descriptor) override;
+  Status onCreateTextureView(uint32_t slotIndex, uint32_t textureSlotIndex,
+                             const TextureViewDescriptor& descriptor) override;
+  Status onCreateSampler(uint32_t slotIndex, const SamplerDescriptor& descriptor) override;
+  Status onCreateBindGroupLayout(uint32_t slotIndex,
+                                 const BindGroupLayoutDescriptor& descriptor) override;
+  Status onCreateBindGroup(uint32_t slotIndex, const BindGroupDescriptor& descriptor) override;
+  Status onCreatePipelineLayout(uint32_t slotIndex,
+                                const PipelineLayoutDescriptor& descriptor) override;
+  Status onCreateShaderModule(uint32_t slotIndex,
+                              const ShaderModuleDescriptor& descriptor) override;
+  Status onCreateRenderPipeline(uint32_t slotIndex,
+                                const RenderPipelineDescriptor& descriptor) override;
+  void onDestroyResource(std::string_view resourceName, uint32_t slotIndex) override;
+  Status onWriteBuffer(uint32_t slotIndex, uint64_t offsetBytes,
+                       std::span<const uint8_t> data) override;
+  Status onWriteTexture(uint32_t slotIndex, std::span<const uint8_t> data,
+                        const TexelCopyBufferLayout& dataLayout,
+                        const Extent2d& writeSize) override;
+  Status onSubmit(uint64_t submissionSerial, uint32_t commandBufferSlotIndex,
+                  std::span<const Command> commands) override;
+
+private:
+  std::vector<std::string> lines_;
+};
+
+}  // namespace donner::gpu

--- a/donner/gpu/tests/CommandEncoder_tests.cc
+++ b/donner/gpu/tests/CommandEncoder_tests.cc
@@ -298,6 +298,22 @@ TEST_F(CommandEncoderTests, BeginRenderPassRejectsNonRenderableView) {
       IsGpuErrorWithMessage(GpuErrorType::UsageMismatch, HasSubstr("RenderAttachment")));
 }
 
+TEST_F(CommandEncoderTests, DuplicateAttachmentViewFails) {
+  EXPECT_THAT(encoder_->beginRenderPass(RenderPassDescriptor{
+                  "duplicatePass",
+                  {RenderPassColorAttachment{targetView_, LoadOp::Clear, StoreOp::Store},
+                   RenderPassColorAttachment{targetView_, LoadOp::Load, StoreOp::Store}}}),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor,
+                                    HasSubstr("multiple color attachments")));
+}
+
+TEST_F(CommandEncoderTests, CopyTextureToBufferRejectsMisalignedOffset) {
+  EXPECT_THAT(encoder_->copyTextureToBuffer(TexelCopyTextureInfo{target_}, readbackBuffer_,
+                                            TexelCopyBufferLayout{2, 256, 4}, Extent2d{4, 4}),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor,
+                                    HasSubstr("not aligned to the 4-byte texel size")));
+}
+
 TEST_F(CommandEncoderTests, SubmitNullCommandBufferFails) {
   EXPECT_THAT(device_.submit(CommandBuffer()), IsGpuError(GpuErrorType::InvalidHandle));
 }

--- a/donner/gpu/tests/CommandEncoder_tests.cc
+++ b/donner/gpu/tests/CommandEncoder_tests.cc
@@ -298,6 +298,110 @@ TEST_F(CommandEncoderTests, BeginRenderPassRejectsNonRenderableView) {
       IsGpuErrorWithMessage(GpuErrorType::UsageMismatch, HasSubstr("RenderAttachment")));
 }
 
+TEST_F(CommandEncoderTests, SetBindGroupRejectsDestroyedBuffer) {
+  ASSERT_THAT(device_.destroyBuffer(uniformBuffer_), IsOk());
+
+  RenderPassEncoder* pass = beginPass();
+  EXPECT_THAT(pass->setBindGroup(0, bindGroup_),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidHandle, HasSubstr("stale")));
+}
+
+TEST_F(CommandEncoderTests, SetBindGroupRejectsBufferSlotReuse) {
+  ASSERT_THAT(device_.destroyBuffer(uniformBuffer_), IsOk());
+
+  // The replacement reuses the freed buffer slot; the group's stale reference must not alias it.
+  const Buffer replacement = GetResultOrFail(device_.createBuffer(
+      BufferDescriptor{"replacement", 16, BufferUsage::Uniform | BufferUsage::CopyDst}));
+  ASSERT_THAT(replacement.slotIndex(), Eq(uniformBuffer_.slotIndex()));
+
+  RenderPassEncoder* pass = beginPass();
+  EXPECT_THAT(pass->setBindGroup(0, bindGroup_),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidHandle, HasSubstr("stale")));
+}
+
+class SetBindGroupTextureTests : public CommandEncoderTests {
+protected:
+  void SetUp() override {
+    CommandEncoderTests::SetUp();
+
+    sampledTexture_ = GetResultOrFail(device_.createTexture(TextureDescriptor{
+        "sampled", Extent2d{4, 4}, TextureFormat::RGBA8Unorm, TextureUsage::Sampled}));
+    sampledView_ = GetResultOrFail(
+        device_.createTextureView(sampledTexture_, TextureViewDescriptor{"sampledView"}));
+    sampler_ = GetResultOrFail(device_.createSampler(SamplerDescriptor{"linear"}));
+    textureLayout_ = GetResultOrFail(device_.createBindGroupLayout(BindGroupLayoutDescriptor{
+        "textureBindings",
+        {BindGroupLayoutEntry{0, ShaderStage::Fragment, BindingType::SampledTexture2dFloat},
+         BindGroupLayoutEntry{1, ShaderStage::Fragment, BindingType::FilteringSampler}}}));
+    textureGroup_ = GetResultOrFail(device_.createBindGroup(
+        BindGroupDescriptor{"textureGroup",
+                            textureLayout_,
+                            {BindGroupEntry{0, TextureViewBinding{sampledView_}},
+                             BindGroupEntry{1, SamplerBinding{sampler_}}}}));
+  }
+
+  Texture sampledTexture_;
+  TextureView sampledView_;
+  Sampler sampler_;
+  BindGroupLayout textureLayout_;
+  BindGroup textureGroup_;
+};
+
+TEST_F(SetBindGroupTextureTests, RejectsDestroyedTextureView) {
+  ASSERT_THAT(device_.destroyTextureView(sampledView_), IsOk());
+
+  RenderPassEncoder* pass = beginPass();
+  EXPECT_THAT(pass->setBindGroup(1, textureGroup_),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidHandle, HasSubstr("stale")));
+}
+
+TEST_F(SetBindGroupTextureTests, RejectsDestroyedUnderlyingTexture) {
+  ASSERT_THAT(device_.destroyTexture(sampledTexture_), IsOk());
+
+  RenderPassEncoder* pass = beginPass();
+  EXPECT_THAT(
+      pass->setBindGroup(1, textureGroup_),
+      IsGpuErrorWithMessage(GpuErrorType::InvalidHandle, HasSubstr("texture was destroyed")));
+}
+
+TEST_F(SetBindGroupTextureTests, RejectsDestroyedSampler) {
+  ASSERT_THAT(device_.destroySampler(sampler_), IsOk());
+
+  RenderPassEncoder* pass = beginPass();
+  EXPECT_THAT(pass->setBindGroup(1, textureGroup_),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidHandle, HasSubstr("stale")));
+}
+
+TEST_F(CommandEncoderTests, SetPipelineRejectsMismatchedTargetFormat) {
+  // A pipeline whose color target is RGBA8 cannot be used in a BGRA8 pass.
+  const Texture bgraTarget = GetResultOrFail(device_.createTexture(TextureDescriptor{
+      "bgraTarget", Extent2d{4, 4}, TextureFormat::BGRA8Unorm, TextureUsage::RenderAttachment}));
+  const TextureView bgraView =
+      GetResultOrFail(device_.createTextureView(bgraTarget, TextureViewDescriptor{"bgraView"}));
+
+  RenderPassEncoder* pass = GetResultOrFail(encoder_->beginRenderPass(RenderPassDescriptor{
+      "bgraPass", {RenderPassColorAttachment{bgraView, LoadOp::Clear, StoreOp::Store}}}));
+  ASSERT_NE(pass, nullptr);
+  EXPECT_THAT(pass->setPipeline(pipeline_),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidState, HasSubstr("format")));
+}
+
+TEST_F(CommandEncoderTests, SetPipelineRejectsAttachmentCountMismatch) {
+  // The pass has two attachments but the pipeline declares one color target.
+  const Texture second = GetResultOrFail(device_.createTexture(TextureDescriptor{
+      "second", Extent2d{4, 4}, TextureFormat::RGBA8Unorm, TextureUsage::RenderAttachment}));
+  const TextureView secondView =
+      GetResultOrFail(device_.createTextureView(second, TextureViewDescriptor{"secondView"}));
+
+  RenderPassEncoder* pass = GetResultOrFail(encoder_->beginRenderPass(RenderPassDescriptor{
+      "twoAttachmentPass",
+      {RenderPassColorAttachment{targetView_, LoadOp::Clear, StoreOp::Store},
+       RenderPassColorAttachment{secondView, LoadOp::Clear, StoreOp::Store}}}));
+  ASSERT_NE(pass, nullptr);
+  EXPECT_THAT(pass->setPipeline(pipeline_),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidState, HasSubstr("color target")));
+}
+
 TEST_F(CommandEncoderTests, DuplicateAttachmentViewFails) {
   EXPECT_THAT(encoder_->beginRenderPass(RenderPassDescriptor{
                   "duplicatePass",

--- a/donner/gpu/tests/CommandEncoder_tests.cc
+++ b/donner/gpu/tests/CommandEncoder_tests.cc
@@ -1,0 +1,306 @@
+/// @file
+/// Encoder state machine tests: pass lifecycle, draw prerequisites, error poisoning, and copy
+/// validation.
+
+#include "donner/gpu/CommandEncoder.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <utility>
+
+#include "donner/gpu/RecordingDevice.h"
+#include "donner/gpu/tests/GpuTestUtils.h"
+
+using testing::Eq;
+using testing::HasSubstr;
+
+namespace donner::gpu {
+namespace {
+
+/// Creates the solid-fill scene used by the encoder tests: a render target with view, vertex and
+/// uniform buffers, a readback buffer, and a pipeline with one uniform bind group.
+class CommandEncoderTests : public testing::Test {
+protected:
+  void SetUp() override {
+    target_ = GetResultOrFail(device_.createTexture(
+        TextureDescriptor{"target", Extent2d{4, 4}, TextureFormat::RGBA8Unorm,
+                          TextureUsage::RenderAttachment | TextureUsage::CopySrc}));
+    targetView_ =
+        GetResultOrFail(device_.createTextureView(target_, TextureViewDescriptor{"targetView"}));
+    vertexBuffer_ = GetResultOrFail(device_.createBuffer(
+        BufferDescriptor{"vertices", 48, BufferUsage::Vertex | BufferUsage::CopyDst}));
+    uniformBuffer_ = GetResultOrFail(device_.createBuffer(
+        BufferDescriptor{"uniforms", 16, BufferUsage::Uniform | BufferUsage::CopyDst}));
+    readbackBuffer_ = GetResultOrFail(device_.createBuffer(
+        BufferDescriptor{"readback", 1024, BufferUsage::CopyDst | BufferUsage::MapRead}));
+
+    bindGroupLayout_ = GetResultOrFail(device_.createBindGroupLayout(BindGroupLayoutDescriptor{
+        "uniforms",
+        {BindGroupLayoutEntry{0, ShaderStage::Vertex | ShaderStage::Fragment,
+                              BindingType::UniformBuffer}}}));
+    pipelineLayout_ = GetResultOrFail(
+        device_.createPipelineLayout(PipelineLayoutDescriptor{"solidLayout", {bindGroupLayout_}}));
+    bindGroup_ = GetResultOrFail(device_.createBindGroup(
+        BindGroupDescriptor{"solidUniforms",
+                            bindGroupLayout_,
+                            {BindGroupEntry{0, BufferBinding{uniformBuffer_, 0, 16}}}}));
+    shader_ = GetResultOrFail(device_.createShaderModule(ShaderModuleDescriptor{
+        "solidFill", "@vertex fn vsMain() {}\n@fragment fn fsMain() {}", ShaderSourceKind::Wgsl}));
+    pipeline_ = GetResultOrFail(device_.createRenderPipeline(solidPipelineDescriptor()));
+
+    encoder_ = GetResultOrFail(device_.createCommandEncoder());
+  }
+
+  RenderPipelineDescriptor solidPipelineDescriptor() const {
+    return RenderPipelineDescriptor{
+        "solid", pipelineLayout_,
+        VertexState{
+            shader_,
+            "vsMain",
+            {VertexBufferLayout{
+                8, VertexStepMode::Vertex, {VertexAttribute{VertexFormat::Float32x2, 0, 0}}}}},
+        FragmentState{shader_,
+                      "fsMain",
+                      {ColorTargetState{
+                          TextureFormat::RGBA8Unorm,
+                          BlendState{BlendComponent{BlendFactor::One, BlendFactor::OneMinusSrcAlpha,
+                                                    BlendOperation::Add},
+                                     BlendComponent{BlendFactor::One, BlendFactor::OneMinusSrcAlpha,
+                                                    BlendOperation::Add}}}}}};
+  }
+
+  RenderPassDescriptor passDescriptor() const {
+    return RenderPassDescriptor{
+        "mainPass",
+        {RenderPassColorAttachment{targetView_, LoadOp::Clear, StoreOp::Store, {0, 0, 0.5, 1}}}};
+  }
+
+  /// Begins the standard pass, failing the test if it cannot begin.
+  RenderPassEncoder* beginPass() {
+    return GetResultOrFail(encoder_->beginRenderPass(passDescriptor()));
+  }
+
+  RecordingDevice device_;
+  Texture target_;
+  TextureView targetView_;
+  Buffer vertexBuffer_;
+  Buffer uniformBuffer_;
+  Buffer readbackBuffer_;
+  BindGroupLayout bindGroupLayout_;
+  PipelineLayout pipelineLayout_;
+  BindGroup bindGroup_;
+  ShaderModule shader_;
+  RenderPipeline pipeline_;
+  std::unique_ptr<CommandEncoder> encoder_;
+};
+
+TEST_F(CommandEncoderTests, FullPassEncodesAndSubmits) {
+  RenderPassEncoder* pass = beginPass();
+  ASSERT_NE(pass, nullptr);
+
+  EXPECT_THAT(pass->setPipeline(pipeline_), IsOk());
+  EXPECT_THAT(pass->setBindGroup(0, bindGroup_), IsOk());
+  EXPECT_THAT(pass->setVertexBuffer(0, vertexBuffer_), IsOk());
+  EXPECT_THAT(pass->setScissorRect(0, 0, 4, 4), IsOk());
+  EXPECT_THAT(pass->setViewport(0, 0, 4, 4, 0, 1), IsOk());
+  EXPECT_THAT(pass->draw(6), IsOk());
+  EXPECT_THAT(pass->end(), IsOk());
+  EXPECT_THAT(encoder_->copyTextureToBuffer(TexelCopyTextureInfo{target_}, readbackBuffer_,
+                                            TexelCopyBufferLayout{0, 256, 4}, Extent2d{4, 4}),
+              IsOk());
+
+  auto finished = encoder_->finish();
+  ASSERT_THAT(finished, HasResult());
+  EXPECT_THAT(device_.submit(std::move(finished).result()), HasResult());
+}
+
+TEST_F(CommandEncoderTests, DrawBeforeSetPipelineFails) {
+  RenderPassEncoder* pass = beginPass();
+  EXPECT_THAT(pass->draw(3),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidState, HasSubstr("no pipeline is set")));
+}
+
+TEST_F(CommandEncoderTests, BeginRenderPassTwiceFails) {
+  beginPass();
+  EXPECT_THAT(encoder_->beginRenderPass(passDescriptor()),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidState, HasSubstr("already active")));
+}
+
+TEST_F(CommandEncoderTests, PassOpsAfterEndFail) {
+  RenderPassEncoder* pass = beginPass();
+  EXPECT_THAT(pass->end(), IsOk());
+  EXPECT_THAT(
+      pass->setPipeline(pipeline_),
+      IsGpuErrorWithMessage(GpuErrorType::InvalidState, HasSubstr("no render pass is active")));
+}
+
+TEST_F(CommandEncoderTests, SecondPassAfterEndIsAllowed) {
+  RenderPassEncoder* pass = beginPass();
+  ASSERT_THAT(pass->end(), IsOk());
+
+  // The state error above poisons nothing: ending then beginning a new pass is valid.
+  EXPECT_THAT(encoder_->beginRenderPass(passDescriptor()), HasResult());
+}
+
+TEST_F(CommandEncoderTests, FinishWithOpenPassFails) {
+  beginPass();
+  EXPECT_THAT(encoder_->finish(),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidState, HasSubstr("still active")));
+}
+
+TEST_F(CommandEncoderTests, ErrorPoisonsEncoderAndFinishReturnsFirstError) {
+  RenderPassEncoder* pass = beginPass();
+
+  // First error: a null buffer handle.
+  const Status firstError = pass->setVertexBuffer(0, Buffer());
+  ASSERT_THAT(firstError, IsGpuError(GpuErrorType::InvalidHandle));
+
+  // Subsequent operations and finish all return the first error, not new ones.
+  EXPECT_THAT(pass->draw(3),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidHandle, Eq(firstError.error().message)));
+  EXPECT_THAT(encoder_->finish(),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidHandle, Eq(firstError.error().message)));
+}
+
+TEST_F(CommandEncoderTests, FinishTwiceFails) {
+  ASSERT_THAT(encoder_->finish(), HasResult());
+  EXPECT_THAT(encoder_->finish(),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidState, HasSubstr("already finished")));
+}
+
+TEST_F(CommandEncoderTests, OpsAfterFinishFail) {
+  ASSERT_THAT(encoder_->finish(), HasResult());
+  EXPECT_THAT(encoder_->beginRenderPass(passDescriptor()), IsGpuError(GpuErrorType::InvalidState));
+}
+
+TEST_F(CommandEncoderTests, DrawWithoutVertexBufferFails) {
+  RenderPassEncoder* pass = beginPass();
+  ASSERT_THAT(pass->setPipeline(pipeline_), IsOk());
+  ASSERT_THAT(pass->setBindGroup(0, bindGroup_), IsOk());
+
+  EXPECT_THAT(pass->draw(3), IsGpuErrorWithMessage(GpuErrorType::InvalidState,
+                                                   HasSubstr("vertex buffer at slot 0")));
+}
+
+TEST_F(CommandEncoderTests, DrawWithoutBindGroupFails) {
+  RenderPassEncoder* pass = beginPass();
+  ASSERT_THAT(pass->setPipeline(pipeline_), IsOk());
+  ASSERT_THAT(pass->setVertexBuffer(0, vertexBuffer_), IsOk());
+
+  EXPECT_THAT(pass->draw(3), IsGpuErrorWithMessage(GpuErrorType::InvalidState,
+                                                   HasSubstr("bind group at index 0")));
+}
+
+TEST_F(CommandEncoderTests, DrawWithIncompatibleBindGroupFails) {
+  // A bind group created against a different (structurally identical) layout is incompatible.
+  const BindGroupLayout otherLayout =
+      GetResultOrFail(device_.createBindGroupLayout(BindGroupLayoutDescriptor{
+          "otherUniforms",
+          {BindGroupLayoutEntry{0, ShaderStage::Vertex | ShaderStage::Fragment,
+                                BindingType::UniformBuffer}}}));
+  const BindGroup otherGroup = GetResultOrFail(device_.createBindGroup(BindGroupDescriptor{
+      "otherGroup", otherLayout, {BindGroupEntry{0, BufferBinding{uniformBuffer_, 0, 16}}}}));
+
+  RenderPassEncoder* pass = beginPass();
+  ASSERT_THAT(pass->setPipeline(pipeline_), IsOk());
+  ASSERT_THAT(pass->setVertexBuffer(0, vertexBuffer_), IsOk());
+  ASSERT_THAT(pass->setBindGroup(0, otherGroup), IsOk());
+
+  EXPECT_THAT(pass->draw(3),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidState, HasSubstr("different layout")));
+}
+
+TEST_F(CommandEncoderTests, DrawVertexRangeBeyondBufferFails) {
+  RenderPassEncoder* pass = beginPass();
+  ASSERT_THAT(pass->setPipeline(pipeline_), IsOk());
+  ASSERT_THAT(pass->setBindGroup(0, bindGroup_), IsOk());
+  ASSERT_THAT(pass->setVertexBuffer(0, vertexBuffer_), IsOk());
+
+  // The 48-byte buffer holds 6 vertices with stride 8; drawing 7 overflows.
+  EXPECT_THAT(pass->draw(7), IsGpuError(GpuErrorType::OutOfBounds));
+}
+
+TEST_F(CommandEncoderTests, SetVertexBufferRejectsNonVertexUsage) {
+  RenderPassEncoder* pass = beginPass();
+  EXPECT_THAT(pass->setVertexBuffer(0, uniformBuffer_),
+              IsGpuErrorWithMessage(GpuErrorType::UsageMismatch, HasSubstr("Vertex usage")));
+}
+
+TEST_F(CommandEncoderTests, SetVertexBufferRejectsOutOfLimitSlot) {
+  RenderPassEncoder* pass = beginPass();
+  EXPECT_THAT(pass->setVertexBuffer(kMaxVertexBuffers, vertexBuffer_),
+              IsGpuError(GpuErrorType::LimitExceeded));
+}
+
+TEST_F(CommandEncoderTests, SetBindGroupRejectsOutOfLimitIndex) {
+  RenderPassEncoder* pass = beginPass();
+  EXPECT_THAT(pass->setBindGroup(kMaxBindGroups, bindGroup_),
+              IsGpuError(GpuErrorType::LimitExceeded));
+}
+
+TEST_F(CommandEncoderTests, ScissorRectBeyondAttachmentFails) {
+  RenderPassEncoder* pass = beginPass();
+  EXPECT_THAT(pass->setScissorRect(2, 0, 4, 4), IsGpuError(GpuErrorType::OutOfBounds));
+}
+
+TEST_F(CommandEncoderTests, ViewportWithInvalidDepthRangeFails) {
+  RenderPassEncoder* pass = beginPass();
+  EXPECT_THAT(pass->setViewport(0, 0, 4, 4, /*minDepth=*/0.75f, /*maxDepth=*/0.25f),
+              IsGpuError(GpuErrorType::InvalidDescriptor));
+}
+
+TEST_F(CommandEncoderTests, CopyTextureToBufferDuringPassFails) {
+  beginPass();
+  EXPECT_THAT(encoder_->copyTextureToBuffer(TexelCopyTextureInfo{target_}, readbackBuffer_,
+                                            TexelCopyBufferLayout{0, 256, 4}, Extent2d{4, 4}),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidState, HasSubstr("inside a render pass")));
+}
+
+TEST_F(CommandEncoderTests, CopyTextureToBufferRejectsMisalignedBytesPerRow) {
+  EXPECT_THAT(
+      encoder_->copyTextureToBuffer(TexelCopyTextureInfo{target_}, readbackBuffer_,
+                                    TexelCopyBufferLayout{0, 100, 4}, Extent2d{4, 4}),
+      IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor, HasSubstr("not a multiple of 256")));
+}
+
+TEST_F(CommandEncoderTests, CopyTextureToBufferRejectsBufferTooSmall) {
+  const Buffer tiny = GetResultOrFail(device_.createBuffer(
+      BufferDescriptor{"tiny", 64, BufferUsage::CopyDst | BufferUsage::MapRead}));
+  EXPECT_THAT(encoder_->copyTextureToBuffer(TexelCopyTextureInfo{target_}, tiny,
+                                            TexelCopyBufferLayout{0, 256, 4}, Extent2d{4, 4}),
+              IsGpuError(GpuErrorType::OutOfBounds));
+}
+
+TEST_F(CommandEncoderTests, CopyTextureToBufferRejectsMissingCopySrc) {
+  const Texture noCopySrc = GetResultOrFail(device_.createTexture(TextureDescriptor{
+      "noCopySrc", Extent2d{4, 4}, TextureFormat::RGBA8Unorm, TextureUsage::RenderAttachment}));
+  EXPECT_THAT(encoder_->copyTextureToBuffer(TexelCopyTextureInfo{noCopySrc}, readbackBuffer_,
+                                            TexelCopyBufferLayout{0, 256, 4}, Extent2d{4, 4}),
+              IsGpuErrorWithMessage(GpuErrorType::UsageMismatch, HasSubstr("CopySrc")));
+}
+
+TEST_F(CommandEncoderTests, BeginRenderPassRejectsStaleView) {
+  ASSERT_THAT(device_.destroyTextureView(targetView_), IsOk());
+  EXPECT_THAT(encoder_->beginRenderPass(passDescriptor()), IsGpuError(GpuErrorType::InvalidHandle));
+}
+
+TEST_F(CommandEncoderTests, BeginRenderPassRejectsNonRenderableView) {
+  const Texture sampledOnly = GetResultOrFail(device_.createTexture(TextureDescriptor{
+      "sampledOnly", Extent2d{4, 4}, TextureFormat::RGBA8Unorm, TextureUsage::Sampled}));
+  const TextureView sampledView =
+      GetResultOrFail(device_.createTextureView(sampledOnly, TextureViewDescriptor{"view"}));
+
+  EXPECT_THAT(
+      encoder_->beginRenderPass(RenderPassDescriptor{
+          "badPass", {RenderPassColorAttachment{sampledView, LoadOp::Clear, StoreOp::Store}}}),
+      IsGpuErrorWithMessage(GpuErrorType::UsageMismatch, HasSubstr("RenderAttachment")));
+}
+
+TEST_F(CommandEncoderTests, SubmitNullCommandBufferFails) {
+  EXPECT_THAT(device_.submit(CommandBuffer()), IsGpuError(GpuErrorType::InvalidHandle));
+}
+
+}  // namespace
+}  // namespace donner::gpu

--- a/donner/gpu/tests/DeviceValidation_tests.cc
+++ b/donner/gpu/tests/DeviceValidation_tests.cc
@@ -92,6 +92,53 @@ TEST_F(DeviceValidationTests, CreateTextureRejectsMultisample) {
               IsGpuErrorWithMessage(GpuErrorType::Unsupported, HasSubstr("sampleCount 4")));
 }
 
+TEST_F(DeviceValidationTests, CreateTextureRejectsUnknownFormat) {
+  // An out-of-range format enum must fail closed instead of flowing into copy-size math
+  // (TextureFormatBytesPerTexel returns 0 for unknown formats).
+  EXPECT_THAT(device_.createTexture(TextureDescriptor{
+                  "bogus", Extent2d{4, 4}, static_cast<TextureFormat>(255), TextureUsage::Sampled}),
+              IsGpuError(GpuErrorType::InvalidDescriptor));
+}
+
+TEST_F(DeviceValidationTests, RejectsUnknownUsageBits) {
+  EXPECT_THAT(device_.createBuffer(
+                  BufferDescriptor{"bogus", 16, static_cast<BufferUsage>((1u << 30) | 1u)}),
+              IsGpuError(GpuErrorType::InvalidDescriptor));
+  EXPECT_THAT(
+      device_.createTexture(TextureDescriptor{"bogus", Extent2d{4, 4}, TextureFormat::RGBA8Unorm,
+                                              static_cast<TextureUsage>(1u << 29)}),
+      IsGpuError(GpuErrorType::InvalidDescriptor));
+}
+
+TEST_F(DeviceValidationTests, CreateSamplerRejectsUnknownEnums) {
+  EXPECT_THAT(device_.createSampler(SamplerDescriptor{"bogus", static_cast<FilterMode>(7),
+                                                      FilterMode::Nearest, AddressMode::ClampToEdge,
+                                                      AddressMode::ClampToEdge}),
+              IsGpuError(GpuErrorType::InvalidDescriptor));
+  EXPECT_THAT(device_.createSampler(
+                  SamplerDescriptor{"bogus", FilterMode::Nearest, FilterMode::Nearest,
+                                    static_cast<AddressMode>(9), AddressMode::ClampToEdge}),
+              IsGpuError(GpuErrorType::InvalidDescriptor));
+}
+
+TEST_F(DeviceValidationTests, CreateBindGroupLayoutRejectsUnknownEnums) {
+  EXPECT_THAT(
+      device_.createBindGroupLayout(BindGroupLayoutDescriptor{
+          "bogus", {BindGroupLayoutEntry{0, ShaderStage::Vertex, static_cast<BindingType>(200)}}}),
+      IsGpuError(GpuErrorType::InvalidDescriptor));
+  EXPECT_THAT(device_.createBindGroupLayout(BindGroupLayoutDescriptor{
+                  "bogus",
+                  {BindGroupLayoutEntry{0, static_cast<ShaderStage>(1u << 20),
+                                        BindingType::UniformBuffer}}}),
+              IsGpuError(GpuErrorType::InvalidDescriptor));
+}
+
+TEST_F(DeviceValidationTests, CreateShaderModuleRejectsUnknownSourceKind) {
+  EXPECT_THAT(device_.createShaderModule(ShaderModuleDescriptor{"bogus", "@vertex fn vsMain() {}",
+                                                                static_cast<ShaderSourceKind>(9)}),
+              IsGpuError(GpuErrorType::InvalidDescriptor));
+}
+
 // == createTextureView ========================================================================
 
 TEST_F(DeviceValidationTests, CreateTextureViewAcceptsLiveTexture) {
@@ -364,6 +411,53 @@ TEST_F(RenderPipelineValidationTests, RejectsOutOfRangeShaderLocation) {
   descriptor.vertex.buffers[0].attributes[0].shaderLocation = kMaxVertexAttributes;
   EXPECT_THAT(device_.createRenderPipeline(descriptor),
               IsGpuErrorWithMessage(GpuErrorType::LimitExceeded, HasSubstr("shaderLocation 16")));
+}
+
+TEST_F(RenderPipelineValidationTests, RejectsUnknownEnums) {
+  {
+    RenderPipelineDescriptor descriptor = validDescriptor();
+    descriptor.vertex.buffers[0].attributes[0].format = static_cast<VertexFormat>(77);
+    EXPECT_THAT(device_.createRenderPipeline(descriptor),
+                IsGpuError(GpuErrorType::InvalidDescriptor));
+  }
+  {
+    RenderPipelineDescriptor descriptor = validDescriptor();
+    descriptor.fragment.targets[0].format = static_cast<TextureFormat>(255);
+    EXPECT_THAT(device_.createRenderPipeline(descriptor),
+                IsGpuError(GpuErrorType::InvalidDescriptor));
+  }
+  {
+    RenderPipelineDescriptor descriptor = validDescriptor();
+    descriptor.fragment.targets[0].blend = BlendState{
+        BlendComponent{static_cast<BlendFactor>(99), BlendFactor::One, BlendOperation::Add},
+        BlendComponent{}};
+    EXPECT_THAT(device_.createRenderPipeline(descriptor),
+                IsGpuError(GpuErrorType::InvalidDescriptor));
+  }
+  {
+    RenderPipelineDescriptor descriptor = validDescriptor();
+    descriptor.fragment.targets[0].writeMask = static_cast<ColorWriteMask>(1u << 8);
+    EXPECT_THAT(device_.createRenderPipeline(descriptor),
+                IsGpuError(GpuErrorType::InvalidDescriptor));
+  }
+  {
+    RenderPipelineDescriptor descriptor = validDescriptor();
+    descriptor.topology = static_cast<PrimitiveTopology>(9);
+    EXPECT_THAT(device_.createRenderPipeline(descriptor),
+                IsGpuError(GpuErrorType::InvalidDescriptor));
+  }
+  {
+    RenderPipelineDescriptor descriptor = validDescriptor();
+    descriptor.cullMode = static_cast<CullMode>(9);
+    EXPECT_THAT(device_.createRenderPipeline(descriptor),
+                IsGpuError(GpuErrorType::InvalidDescriptor));
+  }
+  {
+    RenderPipelineDescriptor descriptor = validDescriptor();
+    descriptor.vertex.buffers[0].stepMode = static_cast<VertexStepMode>(9);
+    EXPECT_THAT(device_.createRenderPipeline(descriptor),
+                IsGpuError(GpuErrorType::InvalidDescriptor));
+  }
 }
 
 TEST_F(RenderPipelineValidationTests, RejectsMultisample) {

--- a/donner/gpu/tests/DeviceValidation_tests.cc
+++ b/donner/gpu/tests/DeviceValidation_tests.cc
@@ -346,6 +346,26 @@ TEST_F(RenderPipelineValidationTests, RejectsEmptyTargets) {
       IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor, HasSubstr("targets is empty")));
 }
 
+TEST_F(RenderPipelineValidationTests, RejectsTooManyVertexAttributes) {
+  RenderPipelineDescriptor descriptor = validDescriptor();
+  VertexBufferLayout& layout = descriptor.vertex.buffers[0];
+  layout.strideBytes = (kMaxVertexAttributes + 1) * 8;
+  layout.attributes.clear();
+  for (uint32_t i = 0; i < kMaxVertexAttributes + 1; ++i) {
+    layout.attributes.push_back(VertexAttribute{VertexFormat::Float32x2, i * 8, i});
+  }
+  EXPECT_THAT(
+      device_.createRenderPipeline(descriptor),
+      IsGpuErrorWithMessage(GpuErrorType::LimitExceeded, HasSubstr("kMaxVertexAttributes")));
+}
+
+TEST_F(RenderPipelineValidationTests, RejectsOutOfRangeShaderLocation) {
+  RenderPipelineDescriptor descriptor = validDescriptor();
+  descriptor.vertex.buffers[0].attributes[0].shaderLocation = kMaxVertexAttributes;
+  EXPECT_THAT(device_.createRenderPipeline(descriptor),
+              IsGpuErrorWithMessage(GpuErrorType::LimitExceeded, HasSubstr("shaderLocation 16")));
+}
+
 TEST_F(RenderPipelineValidationTests, RejectsMultisample) {
   RenderPipelineDescriptor descriptor = validDescriptor();
   descriptor.multisampleCount = 4;
@@ -420,6 +440,14 @@ TEST_F(WriteTextureTests, RejectsBytesPerRowSmallerThanRow) {
       device_.writeTexture(wide, MakeBytes(1024), TexelCopyBufferLayout{0, 256, 2},
                            Extent2d{128, 2}),
       IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor, HasSubstr("does not cover one row")));
+}
+
+TEST_F(WriteTextureTests, RejectsOffsetNotAlignedToTexelSize) {
+  // RGBA8 texels are 4 bytes; an offset of 2 is not texel-aligned.
+  EXPECT_THAT(device_.writeTexture(texture_, MakeBytes(kPaddedByteCount + 2),
+                                   TexelCopyBufferLayout{2, 256, 4}, Extent2d{4, 4}),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor,
+                                    HasSubstr("not aligned to the 4-byte texel size")));
 }
 
 TEST_F(WriteTextureTests, RejectsDataTooSmall) {

--- a/donner/gpu/tests/DeviceValidation_tests.cc
+++ b/donner/gpu/tests/DeviceValidation_tests.cc
@@ -1,0 +1,452 @@
+/// @file
+/// Accept/reject tests for every \ref donner::gpu::Device descriptor validator.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "donner/gpu/GpuLimits.h"
+#include "donner/gpu/RecordingDevice.h"
+#include "donner/gpu/tests/GpuTestUtils.h"
+
+using testing::HasSubstr;
+
+namespace donner::gpu {
+namespace {
+
+std::vector<uint8_t> MakeBytes(size_t count) {
+  std::vector<uint8_t> bytes(count);
+  for (size_t i = 0; i < count; ++i) {
+    bytes[i] = static_cast<uint8_t>(i & 0xFF);
+  }
+  return bytes;
+}
+
+class DeviceValidationTests : public testing::Test {
+protected:
+  Buffer createUniformBuffer(uint64_t byteSize = 16) {
+    return GetResultOrFail(device_.createBuffer(
+        BufferDescriptor{"uniform", byteSize, BufferUsage::Uniform | BufferUsage::CopyDst}));
+  }
+
+  RecordingDevice device_;
+};
+
+// == createBuffer =============================================================================
+
+TEST_F(DeviceValidationTests, CreateBufferAcceptsValidDescriptor) {
+  EXPECT_THAT(device_.createBuffer(BufferDescriptor{"vertices", 48, BufferUsage::Vertex}),
+              HasResult());
+}
+
+TEST_F(DeviceValidationTests, CreateBufferRejectsZeroSize) {
+  EXPECT_THAT(device_.createBuffer(BufferDescriptor{"empty", 0, BufferUsage::Vertex}),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor, HasSubstr("byteSize is 0")));
+}
+
+TEST_F(DeviceValidationTests, CreateBufferRejectsEmptyUsage) {
+  EXPECT_THAT(device_.createBuffer(BufferDescriptor{"unusable", 16, BufferUsage::None}),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor, HasSubstr("usage is empty")));
+}
+
+TEST_F(DeviceValidationTests, CreateBufferRejectsOversizedBuffer) {
+  EXPECT_THAT(
+      device_.createBuffer(BufferDescriptor{"huge", kMaxBufferByteSize + 1, BufferUsage::Vertex}),
+      IsGpuError(GpuErrorType::LimitExceeded));
+}
+
+// == createTexture ============================================================================
+
+TEST_F(DeviceValidationTests, CreateTextureAcceptsValidDescriptor) {
+  EXPECT_THAT(
+      device_.createTexture(TextureDescriptor{"target", Extent2d{16, 16}, TextureFormat::RGBA8Unorm,
+                                              TextureUsage::RenderAttachment}),
+      HasResult());
+}
+
+TEST_F(DeviceValidationTests, CreateTextureRejectsZeroDimension) {
+  EXPECT_THAT(device_.createTexture(TextureDescriptor{
+                  "flat", Extent2d{16, 0}, TextureFormat::RGBA8Unorm, TextureUsage::Sampled}),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor, HasSubstr("zero dimension")));
+}
+
+TEST_F(DeviceValidationTests, CreateTextureRejectsOversizedDimension) {
+  EXPECT_THAT(
+      device_.createTexture(TextureDescriptor{"vast", Extent2d{kMaxTextureDimension + 1, 4},
+                                              TextureFormat::RGBA8Unorm, TextureUsage::Sampled}),
+      IsGpuError(GpuErrorType::LimitExceeded));
+}
+
+TEST_F(DeviceValidationTests, CreateTextureRejectsEmptyUsage) {
+  EXPECT_THAT(device_.createTexture(TextureDescriptor{
+                  "unusable", Extent2d{4, 4}, TextureFormat::RGBA8Unorm, TextureUsage::None}),
+              IsGpuError(GpuErrorType::InvalidDescriptor));
+}
+
+TEST_F(DeviceValidationTests, CreateTextureRejectsMultisample) {
+  EXPECT_THAT(device_.createTexture(TextureDescriptor{
+                  "msaa", Extent2d{4, 4}, TextureFormat::RGBA8Unorm, TextureUsage::RenderAttachment,
+                  /*sampleCount=*/4}),
+              IsGpuErrorWithMessage(GpuErrorType::Unsupported, HasSubstr("sampleCount 4")));
+}
+
+// == createTextureView ========================================================================
+
+TEST_F(DeviceValidationTests, CreateTextureViewAcceptsLiveTexture) {
+  const Texture texture = GetResultOrFail(device_.createTexture(TextureDescriptor{
+      "target", Extent2d{4, 4}, TextureFormat::RGBA8Unorm, TextureUsage::RenderAttachment}));
+  EXPECT_THAT(device_.createTextureView(texture, TextureViewDescriptor{"view"}), HasResult());
+}
+
+TEST_F(DeviceValidationTests, CreateTextureViewRejectsNullTexture) {
+  EXPECT_THAT(device_.createTextureView(Texture(), TextureViewDescriptor{"view"}),
+              IsGpuError(GpuErrorType::InvalidHandle));
+}
+
+// == createBindGroupLayout ====================================================================
+
+TEST_F(DeviceValidationTests, CreateBindGroupLayoutAcceptsValidDescriptor) {
+  EXPECT_THAT(device_.createBindGroupLayout(BindGroupLayoutDescriptor{
+                  "uniforms",
+                  {BindGroupLayoutEntry{0, ShaderStage::Vertex | ShaderStage::Fragment,
+                                        BindingType::UniformBuffer}}}),
+              HasResult());
+}
+
+TEST_F(DeviceValidationTests, CreateBindGroupLayoutRejectsEmptyEntries) {
+  EXPECT_THAT(device_.createBindGroupLayout(BindGroupLayoutDescriptor{"empty", {}}),
+              IsGpuError(GpuErrorType::InvalidDescriptor));
+}
+
+TEST_F(DeviceValidationTests, CreateBindGroupLayoutRejectsDuplicateBindings) {
+  EXPECT_THAT(
+      device_.createBindGroupLayout(BindGroupLayoutDescriptor{
+          "duplicate",
+          {BindGroupLayoutEntry{1, ShaderStage::Fragment, BindingType::UniformBuffer},
+           BindGroupLayoutEntry{1, ShaderStage::Fragment, BindingType::FilteringSampler}}}),
+      IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor, HasSubstr("duplicate binding")));
+}
+
+TEST_F(DeviceValidationTests, CreateBindGroupLayoutRejectsTooManyBindings) {
+  std::vector<BindGroupLayoutEntry> entries;
+  for (uint32_t i = 0; i < kMaxBindings + 1; ++i) {
+    entries.push_back(BindGroupLayoutEntry{i, ShaderStage::Fragment, BindingType::UniformBuffer});
+  }
+  EXPECT_THAT(device_.createBindGroupLayout(BindGroupLayoutDescriptor{"many", entries}),
+              IsGpuError(GpuErrorType::LimitExceeded));
+}
+
+TEST_F(DeviceValidationTests, CreateBindGroupLayoutRejectsOutOfRangeBindingIndex) {
+  EXPECT_THAT(
+      device_.createBindGroupLayout(BindGroupLayoutDescriptor{
+          "outOfRange",
+          {BindGroupLayoutEntry{kMaxBindings, ShaderStage::Fragment, BindingType::UniformBuffer}}}),
+      IsGpuError(GpuErrorType::LimitExceeded));
+}
+
+TEST_F(DeviceValidationTests, CreateBindGroupLayoutRejectsEmptyVisibility) {
+  EXPECT_THAT(
+      device_.createBindGroupLayout(BindGroupLayoutDescriptor{
+          "invisible", {BindGroupLayoutEntry{0, ShaderStage::None, BindingType::UniformBuffer}}}),
+      IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor, HasSubstr("empty visibility")));
+}
+
+// == createPipelineLayout =====================================================================
+
+TEST_F(DeviceValidationTests, CreatePipelineLayoutAcceptsValidDescriptor) {
+  const BindGroupLayout layout =
+      GetResultOrFail(device_.createBindGroupLayout(BindGroupLayoutDescriptor{
+          "uniforms", {BindGroupLayoutEntry{0, ShaderStage::Vertex, BindingType::UniformBuffer}}}));
+  EXPECT_THAT(device_.createPipelineLayout(PipelineLayoutDescriptor{"layout", {layout}}),
+              HasResult());
+}
+
+TEST_F(DeviceValidationTests, CreatePipelineLayoutRejectsTooManyGroups) {
+  const BindGroupLayout layout =
+      GetResultOrFail(device_.createBindGroupLayout(BindGroupLayoutDescriptor{
+          "uniforms", {BindGroupLayoutEntry{0, ShaderStage::Vertex, BindingType::UniformBuffer}}}));
+  const std::vector<BindGroupLayoutRef> groups(kMaxBindGroups + 1, BindGroupLayoutRef(layout));
+  EXPECT_THAT(device_.createPipelineLayout(PipelineLayoutDescriptor{"many", groups}),
+              IsGpuError(GpuErrorType::LimitExceeded));
+}
+
+TEST_F(DeviceValidationTests, CreatePipelineLayoutRejectsStaleLayout) {
+  const BindGroupLayout layout =
+      GetResultOrFail(device_.createBindGroupLayout(BindGroupLayoutDescriptor{
+          "uniforms", {BindGroupLayoutEntry{0, ShaderStage::Vertex, BindingType::UniformBuffer}}}));
+  EXPECT_THAT(device_.destroyBindGroupLayout(layout), IsOk());
+  EXPECT_THAT(device_.createPipelineLayout(PipelineLayoutDescriptor{"stale", {layout}}),
+              IsGpuError(GpuErrorType::InvalidHandle));
+}
+
+// == createShaderModule =======================================================================
+
+TEST_F(DeviceValidationTests, CreateShaderModuleAcceptsValidDescriptor) {
+  EXPECT_THAT(device_.createShaderModule(ShaderModuleDescriptor{"solid", "@vertex fn vsMain() {}",
+                                                                ShaderSourceKind::Wgsl}),
+              HasResult());
+}
+
+TEST_F(DeviceValidationTests, CreateShaderModuleRejectsEmptySource) {
+  EXPECT_THAT(
+      device_.createShaderModule(ShaderModuleDescriptor{"empty", ""}),
+      IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor, HasSubstr("sourceText is empty")));
+}
+
+// == createBindGroup ==========================================================================
+
+class BindGroupValidationTests : public DeviceValidationTests {
+protected:
+  void SetUp() override {
+    uniformLayout_ = GetResultOrFail(device_.createBindGroupLayout(BindGroupLayoutDescriptor{
+        "uniforms", {BindGroupLayoutEntry{0, ShaderStage::Vertex, BindingType::UniformBuffer}}}));
+  }
+
+  BindGroupLayout uniformLayout_;
+};
+
+TEST_F(BindGroupValidationTests, AcceptsMatchingEntries) {
+  const Buffer uniform = createUniformBuffer();
+  EXPECT_THAT(device_.createBindGroup(BindGroupDescriptor{
+                  "group", uniformLayout_, {BindGroupEntry{0, BufferBinding{uniform, 0, 16}}}}),
+              HasResult());
+}
+
+TEST_F(BindGroupValidationTests, RejectsNullBufferHandle) {
+  EXPECT_THAT(device_.createBindGroup(BindGroupDescriptor{
+                  "group", uniformLayout_, {BindGroupEntry{0, BufferBinding{BufferRef(), 0, 16}}}}),
+              IsGpuError(GpuErrorType::InvalidHandle));
+}
+
+TEST_F(BindGroupValidationTests, RejectsBindingTypeMismatch) {
+  const Sampler sampler = GetResultOrFail(device_.createSampler(SamplerDescriptor{"sampler"}));
+  EXPECT_THAT(
+      device_.createBindGroup(BindGroupDescriptor{
+          "group", uniformLayout_, {BindGroupEntry{0, SamplerBinding{sampler}}}}),
+      IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor, HasSubstr("must bind a buffer")));
+}
+
+TEST_F(BindGroupValidationTests, RejectsMissingBinding) {
+  const Buffer uniform = createUniformBuffer();
+  EXPECT_THAT(device_.createBindGroup(BindGroupDescriptor{
+                  "group", uniformLayout_, {BindGroupEntry{7, BufferBinding{uniform, 0, 16}}}}),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor,
+                                    HasSubstr("missing an entry for layout binding 0")));
+}
+
+TEST_F(BindGroupValidationTests, RejectsEntryCountMismatch) {
+  const Buffer uniform = createUniformBuffer();
+  EXPECT_THAT(
+      device_.createBindGroup(
+          BindGroupDescriptor{"group",
+                              uniformLayout_,
+                              {BindGroupEntry{0, BufferBinding{uniform, 0, 8}},
+                               BindGroupEntry{1, BufferBinding{uniform, 8, 8}}}}),
+      IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor, HasSubstr("layout requires 1")));
+}
+
+TEST_F(BindGroupValidationTests, RejectsBufferWithoutUniformUsage) {
+  const Buffer vertexOnly =
+      GetResultOrFail(device_.createBuffer(BufferDescriptor{"vertices", 16, BufferUsage::Vertex}));
+  EXPECT_THAT(device_.createBindGroup(BindGroupDescriptor{
+                  "group", uniformLayout_, {BindGroupEntry{0, BufferBinding{vertexOnly, 0, 16}}}}),
+              IsGpuErrorWithMessage(GpuErrorType::UsageMismatch, HasSubstr("Uniform usage")));
+}
+
+TEST_F(BindGroupValidationTests, RejectsOutOfBoundsBufferRange) {
+  const Buffer uniform = createUniformBuffer(/*byteSize=*/16);
+  EXPECT_THAT(device_.createBindGroup(BindGroupDescriptor{
+                  "group", uniformLayout_, {BindGroupEntry{0, BufferBinding{uniform, 8, 16}}}}),
+              IsGpuError(GpuErrorType::OutOfBounds));
+}
+
+TEST_F(BindGroupValidationTests, RejectsZeroSizeBufferRange) {
+  const Buffer uniform = createUniformBuffer();
+  EXPECT_THAT(device_.createBindGroup(BindGroupDescriptor{
+                  "group", uniformLayout_, {BindGroupEntry{0, BufferBinding{uniform, 0, 0}}}}),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor, HasSubstr("sizeBytes is 0")));
+}
+
+TEST_F(BindGroupValidationTests, RejectsTextureViewWithoutSampledUsage) {
+  const BindGroupLayout textureLayout =
+      GetResultOrFail(device_.createBindGroupLayout(BindGroupLayoutDescriptor{
+          "texture",
+          {BindGroupLayoutEntry{0, ShaderStage::Fragment, BindingType::SampledTexture2dFloat}}}));
+  const Texture texture = GetResultOrFail(device_.createTexture(TextureDescriptor{
+      "target", Extent2d{4, 4}, TextureFormat::RGBA8Unorm, TextureUsage::RenderAttachment}));
+  const TextureView view =
+      GetResultOrFail(device_.createTextureView(texture, TextureViewDescriptor{"view"}));
+
+  EXPECT_THAT(device_.createBindGroup(BindGroupDescriptor{
+                  "group", textureLayout, {BindGroupEntry{0, TextureViewBinding{view}}}}),
+              IsGpuErrorWithMessage(GpuErrorType::UsageMismatch, HasSubstr("Sampled usage")));
+}
+
+// == createRenderPipeline =====================================================================
+
+class RenderPipelineValidationTests : public DeviceValidationTests {
+protected:
+  void SetUp() override {
+    layout_ = GetResultOrFail(device_.createPipelineLayout(PipelineLayoutDescriptor{"empty", {}}));
+    shader_ = GetResultOrFail(device_.createShaderModule(
+        ShaderModuleDescriptor{"solid", "@vertex fn vsMain() {}", ShaderSourceKind::Wgsl}));
+  }
+
+  RenderPipelineDescriptor validDescriptor() const {
+    return RenderPipelineDescriptor{
+        "solid", layout_,
+        VertexState{
+            shader_,
+            "vsMain",
+            {VertexBufferLayout{
+                8, VertexStepMode::Vertex, {VertexAttribute{VertexFormat::Float32x2, 0, 0}}}}},
+        FragmentState{shader_, "fsMain", {ColorTargetState{TextureFormat::RGBA8Unorm}}}};
+  }
+
+  PipelineLayout layout_;
+  ShaderModule shader_;
+};
+
+TEST_F(RenderPipelineValidationTests, AcceptsValidDescriptor) {
+  EXPECT_THAT(device_.createRenderPipeline(validDescriptor()), HasResult());
+}
+
+TEST_F(RenderPipelineValidationTests, RejectsAttributeBeyondStride) {
+  RenderPipelineDescriptor descriptor = validDescriptor();
+  descriptor.vertex.buffers[0].attributes[0].offsetBytes = 4;  // 4 + 8 > stride 8.
+  EXPECT_THAT(
+      device_.createRenderPipeline(descriptor),
+      IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor, HasSubstr("overflows strideBytes 8")));
+}
+
+TEST_F(RenderPipelineValidationTests, RejectsDuplicateShaderLocations) {
+  RenderPipelineDescriptor descriptor = validDescriptor();
+  descriptor.vertex.buffers[0].strideBytes = 16;
+  descriptor.vertex.buffers[0].attributes.push_back(VertexAttribute{VertexFormat::Float32x2, 8, 0});
+  EXPECT_THAT(device_.createRenderPipeline(descriptor),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor,
+                                    HasSubstr("duplicate vertex shaderLocation 0")));
+}
+
+TEST_F(RenderPipelineValidationTests, RejectsEmptyVertexEntryPoint) {
+  RenderPipelineDescriptor descriptor = validDescriptor();
+  descriptor.vertex.entryPoint = "";
+  EXPECT_THAT(device_.createRenderPipeline(descriptor),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor,
+                                    HasSubstr("vertex.entryPoint is empty")));
+}
+
+TEST_F(RenderPipelineValidationTests, RejectsEmptyTargets) {
+  RenderPipelineDescriptor descriptor = validDescriptor();
+  descriptor.fragment.targets.clear();
+  EXPECT_THAT(
+      device_.createRenderPipeline(descriptor),
+      IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor, HasSubstr("targets is empty")));
+}
+
+TEST_F(RenderPipelineValidationTests, RejectsMultisample) {
+  RenderPipelineDescriptor descriptor = validDescriptor();
+  descriptor.multisampleCount = 4;
+  EXPECT_THAT(device_.createRenderPipeline(descriptor), IsGpuError(GpuErrorType::Unsupported));
+}
+
+TEST_F(RenderPipelineValidationTests, RejectsStaleLayout) {
+  EXPECT_THAT(device_.destroyPipelineLayout(layout_), IsOk());
+  EXPECT_THAT(device_.createRenderPipeline(validDescriptor()),
+              IsGpuError(GpuErrorType::InvalidHandle));
+}
+
+// == writeBuffer ==============================================================================
+
+TEST_F(DeviceValidationTests, WriteBufferAcceptsInBoundsWrite) {
+  const Buffer buffer = createUniformBuffer(/*byteSize=*/16);
+  EXPECT_THAT(device_.writeBuffer(buffer, 8, MakeBytes(8)), IsOk());
+}
+
+TEST_F(DeviceValidationTests, WriteBufferRejectsOutOfBoundsWrite) {
+  const Buffer buffer = createUniformBuffer(/*byteSize=*/16);
+  EXPECT_THAT(device_.writeBuffer(buffer, 8, MakeBytes(16)), IsGpuError(GpuErrorType::OutOfBounds));
+}
+
+TEST_F(DeviceValidationTests, WriteBufferRejectsOffsetOverflow) {
+  const Buffer buffer = createUniformBuffer(/*byteSize=*/16);
+  EXPECT_THAT(device_.writeBuffer(buffer, UINT64_MAX, MakeBytes(8)),
+              IsGpuError(GpuErrorType::OutOfBounds));
+}
+
+TEST_F(DeviceValidationTests, WriteBufferRejectsMissingCopyDstUsage) {
+  const Buffer buffer =
+      GetResultOrFail(device_.createBuffer(BufferDescriptor{"vertices", 16, BufferUsage::Vertex}));
+  EXPECT_THAT(device_.writeBuffer(buffer, 0, MakeBytes(8)),
+              IsGpuErrorWithMessage(GpuErrorType::UsageMismatch, HasSubstr("CopyDst")));
+}
+
+// == writeTexture =============================================================================
+
+class WriteTextureTests : public DeviceValidationTests {
+protected:
+  void SetUp() override {
+    texture_ = GetResultOrFail(
+        device_.createTexture(TextureDescriptor{"image", Extent2d{4, 4}, TextureFormat::RGBA8Unorm,
+                                                TextureUsage::Sampled | TextureUsage::CopyDst}));
+  }
+
+  /// 4x4 RGBA rows padded to the 256-byte row pitch: 3 * 256 + 16 bytes.
+  static constexpr size_t kPaddedByteCount = 3 * 256 + 16;
+
+  Texture texture_;
+};
+
+TEST_F(WriteTextureTests, AcceptsAlignedFullWrite) {
+  EXPECT_THAT(device_.writeTexture(texture_, MakeBytes(kPaddedByteCount),
+                                   TexelCopyBufferLayout{0, 256, 4}, Extent2d{4, 4}),
+              IsOk());
+}
+
+TEST_F(WriteTextureTests, RejectsMisalignedBytesPerRow) {
+  EXPECT_THAT(
+      device_.writeTexture(texture_, MakeBytes(kPaddedByteCount), TexelCopyBufferLayout{0, 128, 4},
+                           Extent2d{4, 4}),
+      IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor, HasSubstr("not a multiple of 256")));
+}
+
+TEST_F(WriteTextureTests, RejectsBytesPerRowSmallerThanRow) {
+  const Texture wide = GetResultOrFail(device_.createTexture(TextureDescriptor{
+      "wide", Extent2d{128, 2}, TextureFormat::RGBA8Unorm, TextureUsage::CopyDst}));
+  // One row of 128 RGBA texels is 512 bytes; 256 is aligned but does not cover it.
+  EXPECT_THAT(
+      device_.writeTexture(wide, MakeBytes(1024), TexelCopyBufferLayout{0, 256, 2},
+                           Extent2d{128, 2}),
+      IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor, HasSubstr("does not cover one row")));
+}
+
+TEST_F(WriteTextureTests, RejectsDataTooSmall) {
+  EXPECT_THAT(device_.writeTexture(texture_, MakeBytes(kPaddedByteCount - 1),
+                                   TexelCopyBufferLayout{0, 256, 4}, Extent2d{4, 4}),
+              IsGpuError(GpuErrorType::OutOfBounds));
+}
+
+TEST_F(WriteTextureTests, RejectsWriteSizeBeyondTexture) {
+  EXPECT_THAT(device_.writeTexture(texture_, MakeBytes(8 * 256), TexelCopyBufferLayout{0, 256, 8},
+                                   Extent2d{4, 8}),
+              IsGpuError(GpuErrorType::OutOfBounds));
+}
+
+TEST_F(WriteTextureTests, RejectsRowsPerImageBelowHeight) {
+  EXPECT_THAT(device_.writeTexture(texture_, MakeBytes(kPaddedByteCount),
+                                   TexelCopyBufferLayout{0, 256, 2}, Extent2d{4, 4}),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidDescriptor, HasSubstr("rowsPerImage 2")));
+}
+
+TEST_F(WriteTextureTests, RejectsMissingCopyDstUsage) {
+  const Texture sampledOnly = GetResultOrFail(device_.createTexture(TextureDescriptor{
+      "sampledOnly", Extent2d{4, 4}, TextureFormat::RGBA8Unorm, TextureUsage::Sampled}));
+  EXPECT_THAT(device_.writeTexture(sampledOnly, MakeBytes(kPaddedByteCount),
+                                   TexelCopyBufferLayout{0, 256, 4}, Extent2d{4, 4}),
+              IsGpuErrorWithMessage(GpuErrorType::UsageMismatch, HasSubstr("CopyDst")));
+}
+
+}  // namespace
+}  // namespace donner::gpu

--- a/donner/gpu/tests/GpuResult_tests.cc
+++ b/donner/gpu/tests/GpuResult_tests.cc
@@ -1,0 +1,66 @@
+/// @file
+/// Tests for \ref donner::gpu::Result and \ref donner::gpu::Status.
+
+#include "donner/gpu/GpuResult.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+#include "donner/gpu/tests/GpuTestUtils.h"
+
+using testing::Eq;
+using testing::HasSubstr;
+
+namespace donner::gpu {
+
+TEST(GpuResultTests, HoldsValue) {
+  const Result<int> result(42);
+  EXPECT_THAT(result, HasResult());
+  EXPECT_THAT(result.result(), Eq(42));
+  EXPECT_FALSE(result.hasError());
+}
+
+TEST(GpuResultTests, HoldsError) {
+  const Result<int> result(GpuError{GpuErrorType::OutOfBounds, "offset 4 exceeds size 2"});
+  EXPECT_THAT(result, IsGpuError(GpuErrorType::OutOfBounds));
+  EXPECT_THAT(result,
+              IsGpuErrorWithMessage(GpuErrorType::OutOfBounds, HasSubstr("offset 4 exceeds")));
+  EXPECT_FALSE(result.hasResult());
+}
+
+TEST(GpuResultTests, SupportsMoveOnlyValues) {
+  Result<std::unique_ptr<int>> result(std::make_unique<int>(7));
+  ASSERT_THAT(result, HasResult());
+
+  const std::unique_ptr<int> value = std::move(result).result();
+  EXPECT_THAT(*value, Eq(7));
+}
+
+TEST(GpuResultTests, StatusOkAndError) {
+  EXPECT_THAT(OkStatus(), IsOk());
+
+  const Status errorStatus(GpuError{GpuErrorType::InvalidState, "no render pass is active"});
+  EXPECT_THAT(errorStatus, IsGpuError(GpuErrorType::InvalidState));
+}
+
+TEST(GpuResultTests, PrintToIsDiagnosable) {
+  const Result<int> value(3);
+  EXPECT_THAT(testing::PrintToString(value), HasSubstr("3"));
+
+  const Result<int> error(GpuError{GpuErrorType::LimitExceeded, "too many bindings"});
+  EXPECT_THAT(testing::PrintToString(error), HasSubstr("LimitExceeded: too many bindings"));
+
+  EXPECT_THAT(testing::PrintToString(OkStatus()), HasSubstr("ok"));
+}
+
+TEST(GpuErrorTests, ToStringAndEquality) {
+  const GpuError error{GpuErrorType::DeviceMismatch, "handle belongs to device 1"};
+  EXPECT_THAT(error.toString(), Eq("DeviceMismatch: handle belongs to device 1"));
+  EXPECT_THAT(error, Eq(GpuError{GpuErrorType::DeviceMismatch, "handle belongs to device 1"}));
+  EXPECT_THAT(GpuError::TypeToString(GpuErrorType::Unsupported), Eq("Unsupported"));
+}
+
+}  // namespace donner::gpu

--- a/donner/gpu/tests/GpuTestUtils.h
+++ b/donner/gpu/tests/GpuTestUtils.h
@@ -1,0 +1,103 @@
+#pragma once
+/// @file
+/// gmock matchers and fixtures for \c donner::gpu model tests.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <utility>
+
+#include "donner/gpu/GpuResult.h"
+
+namespace donner::gpu {
+
+/**
+ * Matches a \ref Result that contains a value (no error). On mismatch prints the contained
+ * error.
+ */
+MATCHER(HasResult, "has a result") {
+  if (arg.hasError()) {
+    *result_listener << "which has error: " << arg.error();
+    return false;
+  }
+  return arg.hasResult();
+}
+
+/**
+ * Matches a successful \ref Status. On mismatch prints the contained error.
+ */
+MATCHER(IsOk, "is ok") {
+  if (arg.hasError()) {
+    *result_listener << "which has error: " << arg.error();
+    return false;
+  }
+  return arg.hasResult();
+}
+
+/**
+ * Matches a \ref Result or \ref GpuError whose error type equals \p expectedType. On mismatch
+ * prints the full error (type and message) or the absence of one.
+ *
+ * @param expectedType Expected \ref GpuErrorType.
+ */
+MATCHER_P(IsGpuError, expectedType,
+          std::string("is a GpuError of type ") + testing::PrintToString(expectedType)) {
+  using ArgType = std::remove_cvref_t<decltype(arg)>;
+
+  if constexpr (std::is_same_v<ArgType, GpuError>) {
+    *result_listener << "which is: " << arg;
+    return arg.type == expectedType;
+  } else {
+    if (!arg.hasError()) {
+      *result_listener << "which has no error";
+      return false;
+    }
+    *result_listener << "which has error: " << arg.error();
+    return arg.error().type == expectedType;
+  }
+}
+
+/**
+ * Matches a \ref Result or \ref GpuError whose error type equals \p expectedType and whose
+ * message matches \p messageMatcher (string or gmock matcher).
+ *
+ * @param expectedType Expected \ref GpuErrorType.
+ * @param messageMatcher Matcher for the error message.
+ */
+MATCHER_P2(IsGpuErrorWithMessage, expectedType, messageMatcher,
+           std::string("is a GpuError of type ") + testing::PrintToString(expectedType) +
+               " with message " + testing::PrintToString(messageMatcher)) {
+  using ArgType = std::remove_cvref_t<decltype(arg)>;
+
+  const GpuError* error = nullptr;
+  if constexpr (std::is_same_v<ArgType, GpuError>) {
+    error = &arg;
+  } else {
+    if (!arg.hasError()) {
+      *result_listener << "which has no error";
+      return false;
+    }
+    error = &arg.error();
+  }
+
+  *result_listener << "which is: " << *error;
+  return error->type == expectedType &&
+         testing::ExplainMatchResult(messageMatcher, error->message, result_listener);
+}
+
+/**
+ * Unwraps a \ref Result, adding a test failure and returning a default-constructed value if it
+ * holds an error.
+ *
+ * @param result Result to unwrap.
+ */
+template <typename T>
+T GetResultOrFail(Result<T>&& result) {
+  if (result.hasError()) {
+    ADD_FAILURE() << "Expected a result, got error: " << result.error();
+    return T{};
+  }
+  return std::move(result).result();
+}
+
+}  // namespace donner::gpu

--- a/donner/gpu/tests/HandleLifetime_tests.cc
+++ b/donner/gpu/tests/HandleLifetime_tests.cc
@@ -1,0 +1,92 @@
+/// @file
+/// Handle lifetime tests: destroy-then-use, stale generations after slot reuse, cross-device
+/// handles, and moved-from handles.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <utility>
+#include <vector>
+
+#include "donner/gpu/RecordingDevice.h"
+#include "donner/gpu/tests/GpuTestUtils.h"
+
+using testing::Eq;
+using testing::Ne;
+
+namespace donner::gpu {
+namespace {
+
+class HandleLifetimeTests : public testing::Test {
+protected:
+  Buffer createBuffer(const char* label) {
+    return GetResultOrFail(device_.createBuffer(
+        BufferDescriptor{label, 16, BufferUsage::Uniform | BufferUsage::CopyDst}));
+  }
+
+  Status writeTo(const Buffer& buffer) {
+    const std::vector<uint8_t> bytes(4, 0xAB);
+    return device_.writeBuffer(buffer, 0, bytes);
+  }
+
+  RecordingDevice device_;
+};
+
+TEST_F(HandleLifetimeTests, DestroyThenUseFailsClosed) {
+  const Buffer buffer = createBuffer("victim");
+  EXPECT_THAT(device_.destroyBuffer(buffer), IsOk());
+
+  EXPECT_THAT(writeTo(buffer), IsGpuError(GpuErrorType::InvalidHandle));
+  EXPECT_THAT(device_.destroyBuffer(buffer), IsGpuError(GpuErrorType::InvalidHandle));
+}
+
+TEST_F(HandleLifetimeTests, StaleGenerationAfterSlotReuseFailsClosed) {
+  const Buffer first = createBuffer("first");
+  EXPECT_THAT(device_.destroyBuffer(first), IsOk());
+
+  // The freed slot is reused with a bumped generation; the stale handle must not alias it.
+  const Buffer second = createBuffer("second");
+  ASSERT_THAT(second.slotIndex(), Eq(first.slotIndex()));
+  ASSERT_THAT(second.generation(), Ne(first.generation()));
+
+  EXPECT_THAT(writeTo(first), IsGpuError(GpuErrorType::InvalidHandle));
+  EXPECT_THAT(writeTo(second), IsOk());
+}
+
+TEST_F(HandleLifetimeTests, ForeignDeviceHandleFailsClosed) {
+  RecordingDevice otherDevice;
+  const Buffer foreign = GetResultOrFail(otherDevice.createBuffer(
+      BufferDescriptor{"foreign", 16, BufferUsage::Uniform | BufferUsage::CopyDst}));
+
+  EXPECT_THAT(writeTo(foreign), IsGpuError(GpuErrorType::DeviceMismatch));
+  EXPECT_THAT(device_.destroyBuffer(foreign), IsGpuError(GpuErrorType::DeviceMismatch));
+}
+
+TEST_F(HandleLifetimeTests, MovedFromHandleIsNullAndFailsClosed) {
+  Buffer original = createBuffer("moved");
+  const Buffer moved = std::move(original);
+
+  EXPECT_EQ(original, nullptr);  // NOLINT(bugprone-use-after-move): moved-from state is the API.
+  EXPECT_THAT(writeTo(original), IsGpuError(GpuErrorType::InvalidHandle));
+  EXPECT_THAT(writeTo(moved), IsOk());
+}
+
+TEST_F(HandleLifetimeTests, DestroyIsSharedAcrossResourceTypes) {
+  const Texture texture = GetResultOrFail(device_.createTexture(TextureDescriptor{
+      "target", Extent2d{4, 4}, TextureFormat::RGBA8Unorm, TextureUsage::RenderAttachment}));
+  const TextureView view =
+      GetResultOrFail(device_.createTextureView(texture, TextureViewDescriptor{"view"}));
+  const Sampler sampler = GetResultOrFail(device_.createSampler(SamplerDescriptor{"sampler"}));
+
+  EXPECT_THAT(device_.destroyTextureView(view), IsOk());
+  EXPECT_THAT(device_.destroyTextureView(view), IsGpuError(GpuErrorType::InvalidHandle));
+  EXPECT_THAT(device_.destroyTexture(texture), IsOk());
+  EXPECT_THAT(device_.destroySampler(sampler), IsOk());
+
+  // A view of a destroyed texture cannot be created either.
+  EXPECT_THAT(device_.createTextureView(texture, TextureViewDescriptor{"lateView"}),
+              IsGpuError(GpuErrorType::InvalidHandle));
+}
+
+}  // namespace
+}  // namespace donner::gpu

--- a/donner/gpu/tests/HandleLifetime_tests.cc
+++ b/donner/gpu/tests/HandleLifetime_tests.cc
@@ -5,9 +5,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <memory>
 #include <utility>
 #include <vector>
 
+#include "donner/gpu/CommandEncoder.h"
 #include "donner/gpu/RecordingDevice.h"
 #include "donner/gpu/tests/GpuTestUtils.h"
 
@@ -69,6 +71,57 @@ TEST_F(HandleLifetimeTests, MovedFromHandleIsNullAndFailsClosed) {
   EXPECT_EQ(original, nullptr);  // NOLINT(bugprone-use-after-move): moved-from state is the API.
   EXPECT_THAT(writeTo(original), IsGpuError(GpuErrorType::InvalidHandle));
   EXPECT_THAT(writeTo(moved), IsOk());
+}
+
+TEST_F(HandleLifetimeTests, PassAttachmentOfDestroyedTextureRejects) {
+  const Texture texture = GetResultOrFail(device_.createTexture(TextureDescriptor{
+      "target", Extent2d{4, 4}, TextureFormat::RGBA8Unorm, TextureUsage::RenderAttachment}));
+  const TextureView view =
+      GetResultOrFail(device_.createTextureView(texture, TextureViewDescriptor{"targetView"}));
+  ASSERT_THAT(device_.destroyTexture(texture), IsOk());
+
+  std::unique_ptr<CommandEncoder> encoder = GetResultOrFail(device_.createCommandEncoder());
+  EXPECT_THAT(encoder->beginRenderPass(RenderPassDescriptor{
+                  "pass", {RenderPassColorAttachment{view, LoadOp::Clear, StoreOp::Store}}}),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidHandle,
+                                    testing::HasSubstr("texture was destroyed")));
+}
+
+TEST_F(HandleLifetimeTests, SampledBindingOfDestroyedTextureRejects) {
+  const Texture texture = GetResultOrFail(device_.createTexture(TextureDescriptor{
+      "image", Extent2d{4, 4}, TextureFormat::RGBA8Unorm, TextureUsage::Sampled}));
+  const TextureView view =
+      GetResultOrFail(device_.createTextureView(texture, TextureViewDescriptor{"imageView"}));
+  const BindGroupLayout layout =
+      GetResultOrFail(device_.createBindGroupLayout(BindGroupLayoutDescriptor{
+          "texture",
+          {BindGroupLayoutEntry{0, ShaderStage::Fragment, BindingType::SampledTexture2dFloat}}}));
+  ASSERT_THAT(device_.destroyTexture(texture), IsOk());
+
+  EXPECT_THAT(device_.createBindGroup(BindGroupDescriptor{
+                  "group", layout, {BindGroupEntry{0, TextureViewBinding{view}}}}),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidHandle,
+                                    testing::HasSubstr("texture was destroyed")));
+}
+
+TEST_F(HandleLifetimeTests, StaleViewAfterTextureSlotReuseRejects) {
+  const Texture original = GetResultOrFail(device_.createTexture(TextureDescriptor{
+      "original", Extent2d{4, 4}, TextureFormat::RGBA8Unorm, TextureUsage::RenderAttachment}));
+  const TextureView staleView =
+      GetResultOrFail(device_.createTextureView(original, TextureViewDescriptor{"staleView"}));
+  ASSERT_THAT(device_.destroyTexture(original), IsOk());
+
+  // The replacement reuses the freed texture slot; the stale view must not alias it.
+  const Texture replacement = GetResultOrFail(device_.createTexture(TextureDescriptor{
+      "replacement", Extent2d{8, 8}, TextureFormat::RGBA8Unorm, TextureUsage::RenderAttachment}));
+  ASSERT_THAT(replacement.slotIndex(), Eq(original.slotIndex()));
+  ASSERT_THAT(replacement.generation(), Ne(original.generation()));
+
+  std::unique_ptr<CommandEncoder> encoder = GetResultOrFail(device_.createCommandEncoder());
+  EXPECT_THAT(encoder->beginRenderPass(RenderPassDescriptor{
+                  "pass", {RenderPassColorAttachment{staleView, LoadOp::Clear, StoreOp::Store}}}),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidHandle,
+                                    testing::HasSubstr("texture was destroyed")));
 }
 
 TEST_F(HandleLifetimeTests, DestroyIsSharedAcrossResourceTypes) {

--- a/donner/gpu/tests/Handles_tests.cc
+++ b/donner/gpu/tests/Handles_tests.cc
@@ -1,0 +1,72 @@
+/// @file
+/// Tests for \ref donner::gpu::Handle and \ref donner::gpu::HandleRef.
+
+#include "donner/gpu/Handles.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <utility>
+
+using testing::Eq;
+using testing::HasSubstr;
+
+namespace donner::gpu {
+
+TEST(HandlesTests, DefaultConstructedIsNull) {
+  const Buffer buffer;
+  EXPECT_FALSE(buffer.isValid());
+  EXPECT_EQ(buffer, nullptr);
+  EXPECT_THAT(buffer.generation(), Eq(0u));
+  EXPECT_THAT(buffer.deviceId(), Eq(0u));
+}
+
+TEST(HandlesTests, CreateForBackendIsValid) {
+  const Buffer buffer = Buffer::CreateForBackend(3, 2, 77);
+  EXPECT_TRUE(buffer.isValid());
+  EXPECT_NE(buffer, nullptr);
+  EXPECT_THAT(buffer.slotIndex(), Eq(3u));
+  EXPECT_THAT(buffer.generation(), Eq(2u));
+  EXPECT_THAT(buffer.deviceId(), Eq(77u));
+}
+
+TEST(HandlesTests, MoveConstructionTransfersAndNullsSource) {
+  Buffer original = Buffer::CreateForBackend(1, 5, 9);
+  const Buffer moved(std::move(original));
+
+  EXPECT_THAT(moved.slotIndex(), Eq(1u));
+  EXPECT_THAT(moved.generation(), Eq(5u));
+  EXPECT_THAT(moved.deviceId(), Eq(9u));
+  EXPECT_EQ(original, nullptr);  // NOLINT(bugprone-use-after-move): moved-from state is the API.
+}
+
+TEST(HandlesTests, MoveAssignmentTransfersAndNullsSource) {
+  Buffer original = Buffer::CreateForBackend(4, 6, 2);
+  Buffer target;
+  target = std::move(original);
+
+  EXPECT_THAT(target.slotIndex(), Eq(4u));
+  EXPECT_THAT(target.generation(), Eq(6u));
+  EXPECT_EQ(original, nullptr);  // NOLINT(bugprone-use-after-move): moved-from state is the API.
+}
+
+TEST(HandlesTests, HandleRefCapturesIdentity) {
+  const Texture texture = Texture::CreateForBackend(2, 3, 4);
+  const TextureRef ref = texture;
+
+  EXPECT_TRUE(ref.isValid());
+  EXPECT_THAT(ref.slotIndex(), Eq(texture.slotIndex()));
+  EXPECT_THAT(ref.generation(), Eq(texture.generation()));
+  EXPECT_THAT(ref.deviceId(), Eq(texture.deviceId()));
+
+  const TextureRef nullRef;
+  EXPECT_EQ(nullRef, nullptr);
+}
+
+TEST(HandlesTests, PrintToNamesResource) {
+  EXPECT_THAT(testing::PrintToString(Buffer::CreateForBackend(0, 1, 1)), HasSubstr("buffer#0@1"));
+  EXPECT_THAT(testing::PrintToString(Buffer()), HasSubstr("buffer(null)"));
+  EXPECT_THAT(testing::PrintToString(TextureViewRef()), HasSubstr("textureView(null)"));
+}
+
+}  // namespace donner::gpu

--- a/donner/gpu/tests/RecordingDevice_tests.cc
+++ b/donner/gpu/tests/RecordingDevice_tests.cc
@@ -29,6 +29,43 @@ std::vector<uint8_t> MakeBytes(size_t count) {
   return bytes;
 }
 
+/// Backend fake whose submissions always fail, proving that a rejected submission does not
+/// consume a serial.
+class FailingSubmitDevice : public Device {
+public:
+  uint64_t completedSerial() const override { return lastSubmittedSerial(); }
+
+protected:
+  Status onCreateBuffer(uint32_t, const BufferDescriptor&) override { return OkStatus(); }
+  Status onCreateTexture(uint32_t, const TextureDescriptor&) override { return OkStatus(); }
+  Status onCreateTextureView(uint32_t, uint32_t, const TextureViewDescriptor&) override {
+    return OkStatus();
+  }
+  Status onCreateSampler(uint32_t, const SamplerDescriptor&) override { return OkStatus(); }
+  Status onCreateBindGroupLayout(uint32_t, const BindGroupLayoutDescriptor&) override {
+    return OkStatus();
+  }
+  Status onCreateBindGroup(uint32_t, const BindGroupDescriptor&) override { return OkStatus(); }
+  Status onCreatePipelineLayout(uint32_t, const PipelineLayoutDescriptor&) override {
+    return OkStatus();
+  }
+  Status onCreateShaderModule(uint32_t, const ShaderModuleDescriptor&) override {
+    return OkStatus();
+  }
+  Status onCreateRenderPipeline(uint32_t, const RenderPipelineDescriptor&) override {
+    return OkStatus();
+  }
+  void onDestroyResource(std::string_view, uint32_t) override {}
+  Status onWriteBuffer(uint32_t, uint64_t, std::span<const uint8_t>) override { return OkStatus(); }
+  Status onWriteTexture(uint32_t, std::span<const uint8_t>, const TexelCopyBufferLayout&,
+                        const Extent2d&) override {
+    return OkStatus();
+  }
+  Status onSubmit(uint64_t, uint32_t, std::span<const Command>) override {
+    return GpuError{GpuErrorType::InvalidState, "backend rejected the submission"};
+  }
+};
+
 /// Records the representative solid-fill stream: every resource creation, queue write, a full
 /// render pass, a readback copy, a destroy, and a submission.
 void RecordRepresentativeStream(RecordingDevice& device) {
@@ -131,6 +168,22 @@ TEST(RecordingDeviceTests, SubmissionSerialsStrictlyIncreaseAndComplete) {
     EXPECT_THAT(device.lastSubmittedSerial(), Eq(previousSerial));
     EXPECT_THAT(device.completedSerial(), Eq(previousSerial));
   }
+}
+
+TEST(RecordingDeviceTests, FailedBackendSubmitDoesNotBurnSerial) {
+  FailingSubmitDevice device;
+  std::unique_ptr<CommandEncoder> encoder = GetResultOrFail(device.createCommandEncoder());
+  auto commandBuffer = encoder->finish();
+  ASSERT_THAT(commandBuffer, HasResult());
+
+  EXPECT_THAT(device.submit(std::move(commandBuffer).result()),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidState,
+                                    HasSubstr("backend rejected the submission")));
+
+  // The rejected submission must not consume a serial: completion waiters would otherwise treat
+  // the failed work as finished.
+  EXPECT_THAT(device.lastSubmittedSerial(), Eq(0u));
+  EXPECT_THAT(device.completedSerial(), Eq(0u));
 }
 
 TEST(RecordingDeviceTests, IdenticalStreamsSerializeByteIdentically) {

--- a/donner/gpu/tests/RecordingDevice_tests.cc
+++ b/donner/gpu/tests/RecordingDevice_tests.cc
@@ -1,0 +1,203 @@
+/// @file
+/// Recording backend tests: submission serials, deterministic serialization, and the golden
+/// capture of a representative command stream.
+
+#include "donner/gpu/RecordingDevice.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "donner/gpu/CommandEncoder.h"
+#include "donner/gpu/tests/GpuTestUtils.h"
+
+using testing::Eq;
+using testing::HasSubstr;
+
+namespace donner::gpu {
+namespace {
+
+std::vector<uint8_t> MakeBytes(size_t count) {
+  std::vector<uint8_t> bytes(count);
+  for (size_t i = 0; i < count; ++i) {
+    bytes[i] = static_cast<uint8_t>(i & 0xFF);
+  }
+  return bytes;
+}
+
+/// Records the representative solid-fill stream: every resource creation, queue write, a full
+/// render pass, a readback copy, a destroy, and a submission.
+void RecordRepresentativeStream(RecordingDevice& device) {
+  const Texture target = GetResultOrFail(device.createTexture(
+      TextureDescriptor{"target", Extent2d{4, 4}, TextureFormat::RGBA8Unorm,
+                        TextureUsage::RenderAttachment | TextureUsage::CopySrc}));
+  const TextureView targetView =
+      GetResultOrFail(device.createTextureView(target, TextureViewDescriptor{"targetView"}));
+  const Texture image = GetResultOrFail(
+      device.createTexture(TextureDescriptor{"image", Extent2d{4, 4}, TextureFormat::RGBA8Unorm,
+                                             TextureUsage::Sampled | TextureUsage::CopyDst}));
+  const Sampler linearSampler [[maybe_unused]] = GetResultOrFail(
+      device.createSampler(SamplerDescriptor{"linearClamp", FilterMode::Linear, FilterMode::Linear,
+                                             AddressMode::ClampToEdge, AddressMode::ClampToEdge}));
+
+  const Buffer vertexBuffer = GetResultOrFail(device.createBuffer(
+      BufferDescriptor{"vertices", 48, BufferUsage::Vertex | BufferUsage::CopyDst}));
+  const Buffer uniformBuffer = GetResultOrFail(device.createBuffer(
+      BufferDescriptor{"uniforms", 16, BufferUsage::Uniform | BufferUsage::CopyDst}));
+  const Buffer readbackBuffer = GetResultOrFail(device.createBuffer(
+      BufferDescriptor{"readback", 1024, BufferUsage::CopyDst | BufferUsage::MapRead}));
+  const Buffer scratchBuffer =
+      GetResultOrFail(device.createBuffer(BufferDescriptor{"scratch", 8, BufferUsage::CopySrc}));
+
+  const BindGroupLayout bindGroupLayout =
+      GetResultOrFail(device.createBindGroupLayout(BindGroupLayoutDescriptor{
+          "solidBindings",
+          {BindGroupLayoutEntry{0, ShaderStage::Vertex | ShaderStage::Fragment,
+                                BindingType::UniformBuffer}}}));
+  const PipelineLayout pipelineLayout = GetResultOrFail(
+      device.createPipelineLayout(PipelineLayoutDescriptor{"solidLayout", {bindGroupLayout}}));
+  const BindGroup bindGroup = GetResultOrFail(device.createBindGroup(BindGroupDescriptor{
+      "solidUniforms", bindGroupLayout, {BindGroupEntry{0, BufferBinding{uniformBuffer, 0, 16}}}}));
+  const ShaderModule shader = GetResultOrFail(device.createShaderModule(ShaderModuleDescriptor{
+      "solidFill", "@vertex fn vsMain() {}\n@fragment fn fsMain() {}", ShaderSourceKind::Wgsl}));
+
+  const RenderPipeline pipeline =
+      GetResultOrFail(device.createRenderPipeline(RenderPipelineDescriptor{
+          "solid", pipelineLayout,
+          VertexState{
+              shader,
+              "vsMain",
+              {VertexBufferLayout{
+                  8, VertexStepMode::Vertex, {VertexAttribute{VertexFormat::Float32x2, 0, 0}}}}},
+          FragmentState{
+              shader,
+              "fsMain",
+              {ColorTargetState{
+                  TextureFormat::RGBA8Unorm,
+                  BlendState{BlendComponent{BlendFactor::One, BlendFactor::OneMinusSrcAlpha,
+                                            BlendOperation::Add},
+                             BlendComponent{BlendFactor::One, BlendFactor::OneMinusSrcAlpha,
+                                            BlendOperation::Add}}}}},
+          PrimitiveTopology::TriangleList, CullMode::None}));
+
+  EXPECT_THAT(device.writeBuffer(vertexBuffer, 0, MakeBytes(48)), IsOk());
+  EXPECT_THAT(device.writeBuffer(uniformBuffer, 0, MakeBytes(16)), IsOk());
+  EXPECT_THAT(device.writeTexture(image, MakeBytes(3 * 256 + 16), TexelCopyBufferLayout{0, 256, 4},
+                                  Extent2d{4, 4}),
+              IsOk());
+  EXPECT_THAT(device.destroyBuffer(scratchBuffer), IsOk());
+
+  std::unique_ptr<CommandEncoder> encoder = GetResultOrFail(device.createCommandEncoder());
+  RenderPassEncoder* pass = GetResultOrFail(encoder->beginRenderPass(RenderPassDescriptor{
+      "mainPass",
+      {RenderPassColorAttachment{targetView, LoadOp::Clear, StoreOp::Store, {0, 0, 0.5, 1}}}}));
+  ASSERT_NE(pass, nullptr);
+  EXPECT_THAT(pass->setPipeline(pipeline), IsOk());
+  EXPECT_THAT(pass->setBindGroup(0, bindGroup), IsOk());
+  EXPECT_THAT(pass->setVertexBuffer(0, vertexBuffer), IsOk());
+  EXPECT_THAT(pass->setScissorRect(0, 0, 4, 4), IsOk());
+  EXPECT_THAT(pass->setViewport(0, 0, 4, 4, 0, 1), IsOk());
+  EXPECT_THAT(pass->draw(6), IsOk());
+  EXPECT_THAT(pass->end(), IsOk());
+  EXPECT_THAT(encoder->copyTextureToBuffer(TexelCopyTextureInfo{target}, readbackBuffer,
+                                           TexelCopyBufferLayout{0, 256, 4}, Extent2d{4, 4}),
+              IsOk());
+
+  auto commandBuffer = encoder->finish();
+  ASSERT_THAT(commandBuffer, HasResult());
+  EXPECT_THAT(device.submit(std::move(commandBuffer).result()), HasResult());
+}
+
+TEST(RecordingDeviceTests, SubmissionSerialsStrictlyIncreaseAndComplete) {
+  RecordingDevice device;
+  EXPECT_THAT(device.lastSubmittedSerial(), Eq(0u));
+  EXPECT_THAT(device.completedSerial(), Eq(0u));
+
+  uint64_t previousSerial = 0;
+  for (int i = 0; i < 3; ++i) {
+    std::unique_ptr<CommandEncoder> encoder = GetResultOrFail(device.createCommandEncoder());
+    auto commandBuffer = encoder->finish();
+    ASSERT_THAT(commandBuffer, HasResult());
+
+    auto serial = device.submit(std::move(commandBuffer).result());
+    ASSERT_THAT(serial, HasResult());
+    EXPECT_THAT(serial.result(), Eq(previousSerial + 1));
+    previousSerial = serial.result();
+
+    EXPECT_THAT(device.lastSubmittedSerial(), Eq(previousSerial));
+    EXPECT_THAT(device.completedSerial(), Eq(previousSerial));
+  }
+}
+
+TEST(RecordingDeviceTests, IdenticalStreamsSerializeByteIdentically) {
+  RecordingDevice first;
+  RecordingDevice second;
+  RecordRepresentativeStream(first);
+  RecordRepresentativeStream(second);
+
+  EXPECT_THAT(first.serialize(), Eq(second.serialize()));
+}
+
+TEST(RecordingDeviceTests, RepeatedStreamOnOneDeviceAppendsIdenticalCapture) {
+  RecordingDevice device;
+  RecordRepresentativeStream(device);
+  const std::string once = device.serialize();
+
+  // Serials and slots keep advancing, so run a fresh device to compare the repeat.
+  RecordingDevice repeatDevice;
+  RecordRepresentativeStream(repeatDevice);
+  EXPECT_THAT(repeatDevice.serialize(), Eq(once));
+}
+
+TEST(RecordingDeviceTests, GoldenSerializationOfRepresentativeStream) {
+  RecordingDevice device;
+  RecordRepresentativeStream(device);
+
+  // clang-format off
+  const std::string kExpected =
+      R"(createTexture texture#0 label="target" size=4x4 format=RGBA8Unorm usage=RenderAttachment|CopySrc sampleCount=1
+createTextureView textureView#0 label="targetView" texture=texture#0
+createTexture texture#1 label="image" size=4x4 format=RGBA8Unorm usage=Sampled|CopyDst sampleCount=1
+createSampler sampler#0 label="linearClamp" magFilter=Linear minFilter=Linear addressModeU=ClampToEdge addressModeV=ClampToEdge
+createBuffer buffer#0 label="vertices" byteSize=48 usage=Vertex|CopyDst
+createBuffer buffer#1 label="uniforms" byteSize=16 usage=Uniform|CopyDst
+createBuffer buffer#2 label="readback" byteSize=1024 usage=CopyDst|MapRead
+createBuffer buffer#3 label="scratch" byteSize=8 usage=CopySrc
+createBindGroupLayout bindGroupLayout#0 label="solidBindings" entries=[{binding=0 visibility=Vertex|Fragment type=UniformBuffer}]
+createPipelineLayout pipelineLayout#0 label="solidLayout" bindGroupLayouts=[bindGroupLayout#0]
+createBindGroup bindGroup#0 label="solidUniforms" layout=bindGroupLayout#0 entries=[{binding=0 buffer=buffer#1 offsetBytes=0 sizeBytes=16}]
+createShaderModule shaderModule#0 label="solidFill" sourceKind=Wgsl sourceBytes=47 sourceHash=b5b881c1bdd08531
+createRenderPipeline renderPipeline#0 label="solid" layout=pipelineLayout#0 vertex={module=shaderModule#0 entryPoint="vsMain" buffers=[{strideBytes=8 stepMode=Vertex attributes=[{format=Float32x2 offsetBytes=0 shaderLocation=0}]}]} fragment={module=shaderModule#0 entryPoint="fsMain" targets=[{format=RGBA8Unorm blend={color={srcFactor=One dstFactor=OneMinusSrcAlpha operation=Add} alpha={srcFactor=One dstFactor=OneMinusSrcAlpha operation=Add}} writeMask=Red|Green|Blue|Alpha}]} topology=TriangleList cullMode=None multisampleCount=1
+writeBuffer buffer#0 offsetBytes=0 byteCount=48 dataHash=dd7a5e9540df1b95
+writeBuffer buffer#1 offsetBytes=0 byteCount=16 dataHash=7c84dc9477851775
+writeTexture texture#1 offsetBytes=0 bytesPerRow=256 rowsPerImage=4 writeSize=4x4 byteCount=784 dataHash=aaaef608c2729075
+destroy buffer#3
+submit serial=1 commandBuffer#0 commandCount=9
+  beginRenderPass label="mainPass" colorAttachments=[{view=textureView#0 loadOp=Clear storeOp=Store clearColor=(0 0 0.5 1)}]
+  setPipeline renderPipeline#0
+  setBindGroup index=0 bindGroup=bindGroup#0
+  setVertexBuffer slot=0 buffer=buffer#0 offsetBytes=0
+  setScissorRect x=0 y=0 width=4 height=4
+  setViewport x=0 y=0 width=4 height=4 minDepth=0 maxDepth=1
+  draw vertexCount=6 instanceCount=1 firstVertex=0 firstInstance=0
+  endRenderPass
+  copyTextureToBuffer texture=texture#0 buffer=buffer#2 offsetBytes=0 bytesPerRow=256 rowsPerImage=4 copySize=4x4
+)";
+  // clang-format on
+
+  EXPECT_THAT(device.serialize(), Eq(kExpected));
+}
+
+TEST(RecordingDeviceTests, SerializationContainsNoPointers) {
+  RecordingDevice device;
+  RecordRepresentativeStream(device);
+
+  EXPECT_THAT(device.serialize(), Not(HasSubstr("0x")));
+}
+
+}  // namespace
+}  // namespace donner::gpu


### PR DESCRIPTION
Introduces the `donner::gpu` RHI core, packet 2 of the change sequence in docs/design_docs/0053-native_gpu_hal.md. This is the narrow Donner-owned GPU interface the design replaces the current WebGPU dependency with; nothing consumes it in production yet (the design's migration plan moves Geode call sites behind it in later packets, then deletes the old path), and no dependencies change.

What is in the PR, all under `donner/gpu/`:

- Typed immutable value descriptors and enums scoped to the operations in the packet 1 inventory manifests: buffers, textures, texture views, samplers, bind group layouts, bind groups (variant-based entries), pipeline layouts, shader modules, render pipelines (vertex layouts, premultiplied source-over and max blend states, color write masks), render passes, and texel copy layouts with a documented 256-byte row-pitch rule.
- Explicit error results: `Result<T>` over `std::variant<T, GpuError>` with an 8-category `GpuErrorType` taxonomy; no exceptions anywhere.
- Move-only generation-checked handles (`Handle<Tag>` carrying slot, generation, and device identity) for all ten resource types, plus copyable `HandleRef` for embedding in descriptors, re-validated on consumption so stale references fail closed.
- An abstract `Device` backend seam: the public API is non-virtual, performs all validation (checked arithmetic, documented limits, handle generation and device identity, binding-vs-layout compatibility, copy bounds), and only then delegates to protected virtuals. Invalid input returns errors in release builds; asserts are reserved for programmer invariants.
- A fail-closed `CommandEncoder`/`RenderPassEncoder` state machine with first-error latching: any recording error poisons the encoder and `finish()` returns the first error.
- A deterministic `RecordingDevice` backend that stores validated value objects and serializes the command stream as line-based text with slot-based identifiers, fixed float formatting, and payload hashes; identical streams serialize byte-identically. This feeds the deterministic replay and debugger tooling the design calls for.
- 105 model-level tests (gmock matchers throughout): per-validator accept/reject cases, handle lifetime (use-after-destroy, stale generation after slot reuse, cross-device use, moved-from), encoder state machine, submission serial monotonicity, and byte-identical serialization including an embedded golden of a representative solid-fill command stream.

One change outside `donner/gpu/`: the banned-patterns lint's `.createRenderPipeline` rule (which guards the old runtime's pipeline-leak footgun) gains a scoped `donner/gpu/` exemption, since `Device::createRenderPipeline` is this module's own API and the recording backend never touches a driver.

Validation: `bazel test //...` green locally (862 targets, 0 failures; the new `gpu_tests` suite is 105/105), `bazel build //donner/...` green, `python3 tools/cmake/gen_cmakelists.py --check` passes, zero WebGPU wrapper tokens under `donner/gpu/` (grep-verified), clang-format and banned-patterns clean. The diff passed an independent sub-agent review (one blocking finding, a texture-view liveness bypass, was fixed with a committed red-to-green regression sequence; seven smaller findings were also addressed) and a privacy sweep before opening.
