### PR TITLE
Add the donner::gpu shader IR core and WGSL-rule layout engine

### DIFF
--- a/donner/gpu/shader/BUILD.bazel
+++ b/donner/gpu/shader/BUILD.bazel
@@ -1,0 +1,28 @@
+load("//build_defs:rules.bzl", "donner_cc_library", "donner_cc_test")
+load("//build_defs:visibility.bzl", "donner_internal_visibility")
+
+# donner::gpu::shader - the typed shader IR core and WGSL-rule layout engine
+# (design doc 0053, "Donner shader IR"; change sequence packet 4).
+#
+# A typed immutable IR with a validating builder, host-shareable layout
+# computation per the WGSL specification's memory layout rules, and
+# deterministic text serialization. Scope is exactly the solid-fill pipeline
+# family; the WGSL/MSL emitters land in later packets.
+
+donner_cc_library(
+    name = "shader",
+    srcs = [
+        "IrLayout.cc",
+        "IrType.cc",
+    ],
+    hdrs = [
+        "IrLayout.h",
+        "IrType.h",
+        "ShaderError.h",
+        "ShaderResult.h",
+    ],
+    visibility = donner_internal_visibility(),
+    deps = [
+        "//donner/base",
+    ],
+)

--- a/donner/gpu/shader/BUILD.bazel
+++ b/donner/gpu/shader/BUILD.bazel
@@ -12,11 +12,17 @@ load("//build_defs:visibility.bzl", "donner_internal_visibility")
 donner_cc_library(
     name = "shader",
     srcs = [
+        "IrExpr.cc",
         "IrLayout.cc",
+        "IrModule.cc",
+        "IrSerialization.cc",
         "IrType.cc",
     ],
     hdrs = [
+        "IrExpr.h",
         "IrLayout.h",
+        "IrModule.h",
+        "IrStatement.h",
         "IrType.h",
         "ShaderError.h",
         "ShaderResult.h",

--- a/donner/gpu/shader/BUILD.bazel
+++ b/donner/gpu/shader/BUILD.bazel
@@ -32,3 +32,17 @@ donner_cc_library(
         "//donner/base",
     ],
 )
+
+donner_cc_test(
+    name = "shader_tests",
+    srcs = [
+        "tests/IrBuilder_tests.cc",
+        "tests/IrLayout_tests.cc",
+        "tests/IrSerialization_tests.cc",
+        "tests/ShaderTestUtils.h",
+    ],
+    deps = [
+        ":shader",
+        "@com_google_gtest//:gtest_main",
+    ],
+)

--- a/donner/gpu/shader/IrExpr.cc
+++ b/donner/gpu/shader/IrExpr.cc
@@ -173,6 +173,24 @@ void IrExpr::collectRefs(std::vector<RefInfo>& out) const {
   }
 }
 
+void IrExpr::collectBuiltinCalls(std::vector<BuiltinFn>& out) const {
+  if (node_->kind == Kind::CallBuiltin) {
+    out.push_back(node_->builtin);
+  }
+  for (const IrExpr& child : node_->children) {
+    child.collectBuiltinCalls(out);
+  }
+}
+
+void IrExpr::collectUserCalls(std::vector<RcString>& out) const {
+  if (node_->kind == Kind::CallUser) {
+    out.push_back(node_->name);
+  }
+  for (const IrExpr& child : node_->children) {
+    child.collectUserCalls(out);
+  }
+}
+
 std::string IrExpr::toString() const {
   const Node& node = *node_;
   switch (node.kind) {

--- a/donner/gpu/shader/IrExpr.cc
+++ b/donner/gpu/shader/IrExpr.cc
@@ -1,0 +1,722 @@
+#include "donner/gpu/shader/IrExpr.h"
+
+#include <format>
+#include <utility>
+#include <variant>
+
+namespace donner::gpu::shader {
+
+/// Internal storage for \ref IrExpr nodes.
+struct IrExpr::Node {
+  Kind kind = Kind::Literal;                                    //!< Node kind.
+  IrType type = IrType::F32();                                  //!< Result type.
+  bool mutableLvalue = false;                                   //!< Assignable access chain.
+  std::variant<bool, int32_t, uint32_t, float> literal = 0.0f;  //!< Literal payload.
+  RefKind refKind = RefKind::Let;                               //!< Ref payload.
+  RcString name;                                                //!< Ref/member/callee name.
+  UnaryOp unaryOp = UnaryOp::Neg;                               //!< Unary payload.
+  BinaryOp binaryOp = BinaryOp::Add;                            //!< Binary payload.
+  BuiltinFn builtin = BuiltinFn::Abs;                           //!< Builtin payload.
+  std::string swizzle;                                          //!< Swizzle components.
+  std::vector<IrExpr> children;                                 //!< Operands, in order.
+};
+
+namespace {
+
+/// Builds a node-backed expression.
+IrExpr MakeNode(IrExpr::Node&& node) {
+  return IrExpr(std::make_shared<const IrExpr::Node>(std::move(node)));
+}
+
+/// Formats "type" for diagnostics.
+std::string TypeName(const IrExpr& expr) {
+  return expr.type().toString();
+}
+
+/// Shared checker for same-type numeric arithmetic.
+ShaderResult<IrExpr> MakeArithmetic(BinaryOp op, const IrExpr& lhs, const IrExpr& rhs,
+                                    const RcString& label) {
+  if (!(lhs.type() == rhs.type()) || !lhs.type().isNumeric()) {
+    return ShaderError{std::format("operands must be matching numeric scalar/vector types, got "
+                                   "{} and {}",
+                                   TypeName(lhs), TypeName(rhs)),
+                       label};
+  }
+
+  IrExpr::Node node;
+  node.kind = IrExpr::Kind::Binary;
+  node.type = lhs.type();
+  node.binaryOp = op;
+  node.children = {lhs, rhs};
+  return MakeNode(std::move(node));
+}
+
+/// Shared checker for ordered comparisons (numeric scalars) and equality (any scalars).
+ShaderResult<IrExpr> MakeComparison(BinaryOp op, bool requireNumeric, const IrExpr& lhs,
+                                    const IrExpr& rhs, const RcString& label) {
+  const bool typeOk = requireNumeric ? lhs.type().isNumericScalar() : lhs.type().isScalar();
+  if (!(lhs.type() == rhs.type()) || !typeOk) {
+    return ShaderError{std::format("comparison operands must be matching {} scalar types, got "
+                                   "{} and {}",
+                                   requireNumeric ? "numeric" : "", TypeName(lhs), TypeName(rhs)),
+                       label};
+  }
+
+  IrExpr::Node node;
+  node.kind = IrExpr::Kind::Binary;
+  node.type = IrType::Bool();
+  node.binaryOp = op;
+  node.children = {lhs, rhs};
+  return MakeNode(std::move(node));
+}
+
+/// Shared checker for bool logical binary operators.
+ShaderResult<IrExpr> MakeLogical(BinaryOp op, const IrExpr& lhs, const IrExpr& rhs,
+                                 const RcString& label) {
+  if (!(lhs.type() == IrType::Bool()) || !(rhs.type() == IrType::Bool())) {
+    return ShaderError{
+        std::format("logical operands must be bool, got {} and {}", TypeName(lhs), TypeName(rhs)),
+        label};
+  }
+
+  IrExpr::Node node;
+  node.kind = IrExpr::Kind::Binary;
+  node.type = IrType::Bool();
+  node.binaryOp = op;
+  node.children = {lhs, rhs};
+  return MakeNode(std::move(node));
+}
+
+/// Formats a literal payload deterministically.
+std::string LiteralToString(const IrExpr::Node& node) {
+  if (std::holds_alternative<bool>(node.literal)) {
+    return std::get<bool>(node.literal) ? "lit_bool(true)" : "lit_bool(false)";
+  }
+  if (std::holds_alternative<int32_t>(node.literal)) {
+    return std::format("lit_i32({})", std::get<int32_t>(node.literal));
+  }
+  if (std::holds_alternative<uint32_t>(node.literal)) {
+    return std::format("lit_u32({})", std::get<uint32_t>(node.literal));
+  }
+  return std::format("lit_f32({})", std::get<float>(node.literal));
+}
+
+}  // namespace
+
+std::ostream& operator<<(std::ostream& os, BinaryOp value) {
+  switch (value) {
+    case BinaryOp::Add: return os << "add";
+    case BinaryOp::Sub: return os << "sub";
+    case BinaryOp::Mul: return os << "mul";
+    case BinaryOp::Div: return os << "div";
+    case BinaryOp::Lt: return os << "lt";
+    case BinaryOp::Le: return os << "le";
+    case BinaryOp::Gt: return os << "gt";
+    case BinaryOp::Ge: return os << "ge";
+    case BinaryOp::Eq: return os << "eq";
+    case BinaryOp::Ne: return os << "ne";
+    case BinaryOp::And: return os << "and";
+    case BinaryOp::Or: return os << "or";
+  }
+  return os << "unknown";
+}
+
+std::ostream& operator<<(std::ostream& os, BuiltinFn value) {
+  switch (value) {
+    case BuiltinFn::Abs: return os << "abs";
+    case BuiltinFn::Min: return os << "min";
+    case BuiltinFn::Max: return os << "max";
+    case BuiltinFn::Clamp: return os << "clamp";
+    case BuiltinFn::Saturate: return os << "saturate";
+    case BuiltinFn::Fract: return os << "fract";
+    case BuiltinFn::Sqrt: return os << "sqrt";
+    case BuiltinFn::Length: return os << "length";
+    case BuiltinFn::Fwidth: return os << "fwidth";
+    case BuiltinFn::Round: return os << "round";
+    case BuiltinFn::Select: return os << "select";
+    case BuiltinFn::TextureSample: return os << "textureSample";
+    case BuiltinFn::TextureLoad: return os << "textureLoad";
+    case BuiltinFn::TextureDimensions: return os << "textureDimensions";
+  }
+  return os << "unknown";
+}
+
+std::ostream& operator<<(std::ostream& os, RefKind value) {
+  switch (value) {
+    case RefKind::Param: return os << "param";
+    case RefKind::Let: return os << "let";
+    case RefKind::Var: return os << "var";
+    case RefKind::Constant: return os << "const";
+    case RefKind::Resource: return os << "resource";
+  }
+  return os << "unknown";
+}
+
+const IrType& IrExpr::type() const {
+  return node_->type;
+}
+
+IrExpr::Kind IrExpr::kind() const {
+  return node_->kind;
+}
+
+bool IrExpr::isMutableLvalue() const {
+  return node_->mutableLvalue;
+}
+
+std::string IrExpr::toString() const {
+  const Node& node = *node_;
+  switch (node.kind) {
+    case Kind::Literal: return LiteralToString(node);
+    case Kind::Ref: return std::format("ref({})", node.name.str());
+    case Kind::Unary:
+      return std::format("{}({})", node.unaryOp == UnaryOp::Neg ? "neg" : "not",
+                         node.children[0].toString());
+    case Kind::Binary: {
+      std::string result;
+      switch (node.binaryOp) {
+        case BinaryOp::Add: result = "add"; break;
+        case BinaryOp::Sub: result = "sub"; break;
+        case BinaryOp::Mul: result = "mul"; break;
+        case BinaryOp::Div: result = "div"; break;
+        case BinaryOp::Lt: result = "lt"; break;
+        case BinaryOp::Le: result = "le"; break;
+        case BinaryOp::Gt: result = "gt"; break;
+        case BinaryOp::Ge: result = "ge"; break;
+        case BinaryOp::Eq: result = "eq"; break;
+        case BinaryOp::Ne: result = "ne"; break;
+        case BinaryOp::And: result = "and"; break;
+        case BinaryOp::Or: result = "or"; break;
+      }
+      return std::format("{}({}, {})", result, node.children[0].toString(),
+                         node.children[1].toString());
+    }
+    case Kind::Member:
+      return std::format("member({}, {})", node.children[0].toString(), node.name.str());
+    case Kind::Swizzle:
+      return std::format("swizzle({}, {})", node.children[0].toString(), node.swizzle);
+    case Kind::Index:
+      return std::format("index({}, {})", node.children[0].toString(), node.children[1].toString());
+    case Kind::Construct:
+    case Kind::CallUser:
+    case Kind::CallBuiltin:
+    case Kind::Convert: {
+      std::string head;
+      if (node.kind == Kind::Construct) {
+        head = std::format("construct_{}", node.type.toString());
+      } else if (node.kind == Kind::Convert) {
+        head = std::format("convert_{}", node.type.toString());
+      } else if (node.kind == Kind::CallUser) {
+        head = std::format("call({}", node.name.str());
+      } else {
+        head = "builtin_";
+        switch (node.builtin) {
+          case BuiltinFn::Abs: head += "abs"; break;
+          case BuiltinFn::Min: head += "min"; break;
+          case BuiltinFn::Max: head += "max"; break;
+          case BuiltinFn::Clamp: head += "clamp"; break;
+          case BuiltinFn::Saturate: head += "saturate"; break;
+          case BuiltinFn::Fract: head += "fract"; break;
+          case BuiltinFn::Sqrt: head += "sqrt"; break;
+          case BuiltinFn::Length: head += "length"; break;
+          case BuiltinFn::Fwidth: head += "fwidth"; break;
+          case BuiltinFn::Round: head += "round"; break;
+          case BuiltinFn::Select: head += "select"; break;
+          case BuiltinFn::TextureSample: head += "textureSample"; break;
+          case BuiltinFn::TextureLoad: head += "textureLoad"; break;
+          case BuiltinFn::TextureDimensions: head += "textureDimensions"; break;
+        }
+      }
+
+      std::string result = node.kind == Kind::CallUser ? head : head + "(";
+      for (size_t i = 0; i < node.children.size(); ++i) {
+        if (i > 0 || node.kind == Kind::CallUser) {
+          result += ", ";
+        }
+        result += node.children[i].toString();
+      }
+      result += ")";
+      return result;
+    }
+  }
+  return "unknown";
+}
+
+IrExpr LiteralF32(float value) {
+  IrExpr::Node node;
+  node.kind = IrExpr::Kind::Literal;
+  node.type = IrType::F32();
+  node.literal = value;
+  return MakeNode(std::move(node));
+}
+
+IrExpr LiteralI32(int32_t value) {
+  IrExpr::Node node;
+  node.kind = IrExpr::Kind::Literal;
+  node.type = IrType::I32();
+  node.literal = value;
+  return MakeNode(std::move(node));
+}
+
+IrExpr LiteralU32(uint32_t value) {
+  IrExpr::Node node;
+  node.kind = IrExpr::Kind::Literal;
+  node.type = IrType::U32();
+  node.literal = value;
+  return MakeNode(std::move(node));
+}
+
+IrExpr LiteralBool(bool value) {
+  IrExpr::Node node;
+  node.kind = IrExpr::Kind::Literal;
+  node.type = IrType::Bool();
+  node.literal = value;
+  return MakeNode(std::move(node));
+}
+
+IrExpr MakeRef(RefKind kind, const RcString& name, const IrType& type) {
+  IrExpr::Node node;
+  node.kind = IrExpr::Kind::Ref;
+  node.type = type;
+  node.refKind = kind;
+  node.name = name;
+  node.mutableLvalue = kind == RefKind::Var;
+  return MakeNode(std::move(node));
+}
+
+ShaderResult<IrExpr> Add(const IrExpr& lhs, const IrExpr& rhs, const RcString& label) {
+  return MakeArithmetic(BinaryOp::Add, lhs, rhs, label);
+}
+ShaderResult<IrExpr> Sub(const IrExpr& lhs, const IrExpr& rhs, const RcString& label) {
+  return MakeArithmetic(BinaryOp::Sub, lhs, rhs, label);
+}
+
+ShaderResult<IrExpr> Mul(const IrExpr& lhs, const IrExpr& rhs, const RcString& label) {
+  const IrType& lt = lhs.type();
+  const IrType& rt = rhs.type();
+
+  // mat4x4f * vec4f and mat4x4f * mat4x4f (the vertex stage composes matrices).
+  if (lt.kind() == IrType::Kind::Matrix4x4f) {
+    if (rt == IrType::Vec4f() || rt.kind() == IrType::Kind::Matrix4x4f) {
+      IrExpr::Node node;
+      node.kind = IrExpr::Kind::Binary;
+      node.type = rt;
+      node.binaryOp = BinaryOp::Mul;
+      node.children = {lhs, rhs};
+      return MakeNode(std::move(node));
+    }
+    return ShaderError{
+        std::format("mat4x4<f32> can multiply vec4<f32> or mat4x4<f32>, got {}", rt.toString()),
+        label};
+  }
+
+  // vector * scalar and scalar * vector with matching element type.
+  const bool vectorScalar =
+      lt.isNumericVector() && rt.isNumericScalar() && lt.scalarKind() == rt.scalarKind();
+  const bool scalarVector =
+      lt.isNumericScalar() && rt.isNumericVector() && lt.scalarKind() == rt.scalarKind();
+  if (vectorScalar || scalarVector) {
+    IrExpr::Node node;
+    node.kind = IrExpr::Kind::Binary;
+    node.type = vectorScalar ? lt : rt;
+    node.binaryOp = BinaryOp::Mul;
+    node.children = {lhs, rhs};
+    return MakeNode(std::move(node));
+  }
+
+  return MakeArithmetic(BinaryOp::Mul, lhs, rhs, label);
+}
+
+ShaderResult<IrExpr> Div(const IrExpr& lhs, const IrExpr& rhs, const RcString& label) {
+  return MakeArithmetic(BinaryOp::Div, lhs, rhs, label);
+}
+
+ShaderResult<IrExpr> Lt(const IrExpr& lhs, const IrExpr& rhs, const RcString& label) {
+  return MakeComparison(BinaryOp::Lt, /*requireNumeric=*/true, lhs, rhs, label);
+}
+ShaderResult<IrExpr> Le(const IrExpr& lhs, const IrExpr& rhs, const RcString& label) {
+  return MakeComparison(BinaryOp::Le, /*requireNumeric=*/true, lhs, rhs, label);
+}
+ShaderResult<IrExpr> Gt(const IrExpr& lhs, const IrExpr& rhs, const RcString& label) {
+  return MakeComparison(BinaryOp::Gt, /*requireNumeric=*/true, lhs, rhs, label);
+}
+ShaderResult<IrExpr> Ge(const IrExpr& lhs, const IrExpr& rhs, const RcString& label) {
+  return MakeComparison(BinaryOp::Ge, /*requireNumeric=*/true, lhs, rhs, label);
+}
+ShaderResult<IrExpr> Eq(const IrExpr& lhs, const IrExpr& rhs, const RcString& label) {
+  return MakeComparison(BinaryOp::Eq, /*requireNumeric=*/false, lhs, rhs, label);
+}
+ShaderResult<IrExpr> Ne(const IrExpr& lhs, const IrExpr& rhs, const RcString& label) {
+  return MakeComparison(BinaryOp::Ne, /*requireNumeric=*/false, lhs, rhs, label);
+}
+
+ShaderResult<IrExpr> And(const IrExpr& lhs, const IrExpr& rhs, const RcString& label) {
+  return MakeLogical(BinaryOp::And, lhs, rhs, label);
+}
+ShaderResult<IrExpr> Or(const IrExpr& lhs, const IrExpr& rhs, const RcString& label) {
+  return MakeLogical(BinaryOp::Or, lhs, rhs, label);
+}
+
+ShaderResult<IrExpr> Not(const IrExpr& operand, const RcString& label) {
+  if (!(operand.type() == IrType::Bool())) {
+    return ShaderError{std::format("logical not requires bool, got {}", TypeName(operand)), label};
+  }
+  IrExpr::Node node;
+  node.kind = IrExpr::Kind::Unary;
+  node.type = IrType::Bool();
+  node.unaryOp = IrExpr::UnaryOp::Not;
+  node.children = {operand};
+  return MakeNode(std::move(node));
+}
+
+ShaderResult<IrExpr> Neg(const IrExpr& operand, const RcString& label) {
+  if (!operand.type().isNumeric() || operand.type().scalarKind() == ScalarKind::U32) {
+    return ShaderError{
+        std::format("unary minus requires f32/i32 scalar or vector, got {}", TypeName(operand)),
+        label};
+  }
+  IrExpr::Node node;
+  node.kind = IrExpr::Kind::Unary;
+  node.type = operand.type();
+  node.unaryOp = IrExpr::UnaryOp::Neg;
+  node.children = {operand};
+  return MakeNode(std::move(node));
+}
+
+ShaderResult<IrExpr> Member(const IrExpr& base, const RcString& memberName, const RcString& label) {
+  if (base.type().kind() != IrType::Kind::Struct) {
+    return ShaderError{std::format("member access requires a struct, got {}", TypeName(base)),
+                       label};
+  }
+  for (const IrType::Member& member : base.type().structMembers()) {
+    if (member.name == memberName) {
+      IrExpr::Node node;
+      node.kind = IrExpr::Kind::Member;
+      node.type = member.type;
+      node.name = memberName;
+      node.mutableLvalue = base.isMutableLvalue();
+      node.children = {base};
+      return MakeNode(std::move(node));
+    }
+  }
+  return ShaderError{std::format("struct {} has no member named {}", base.type().structName().str(),
+                                 memberName.str()),
+                     label};
+}
+
+ShaderResult<IrExpr> Swizzle(const IrExpr& base, std::string_view components,
+                             const RcString& label) {
+  if (!base.type().isVector()) {
+    return ShaderError{std::format("swizzle requires a vector, got {}", TypeName(base)), label};
+  }
+  if (components.empty() || components.size() > 4) {
+    return ShaderError{std::format("swizzle must have 1-4 components, got \"{}\"", components),
+                       label};
+  }
+  for (const char component : components) {
+    const uint32_t componentIndex = component == 'x'   ? 0
+                                    : component == 'y' ? 1
+                                    : component == 'z' ? 2
+                                    : component == 'w' ? 3
+                                                       : 4;
+    if (componentIndex >= base.type().vectorSize()) {
+      return ShaderError{
+          std::format("swizzle component '{}' is out of range for {}", component, TypeName(base)),
+          label};
+    }
+  }
+
+  const ScalarKind element = base.type().scalarKind();
+  IrExpr::Node node;
+  node.kind = IrExpr::Kind::Swizzle;
+  node.type = components.size() == 1 ? IrType::Scalar(element)
+                                     : (components.size() == 2   ? IrType::Vec2(element)
+                                        : components.size() == 3 ? IrType::Vec3(element)
+                                                                 : IrType::Vec4(element));
+  node.swizzle = std::string(components);
+  // Only a single-component swizzle of a mutable chain is assignable.
+  node.mutableLvalue = base.isMutableLvalue() && components.size() == 1;
+  node.children = {base};
+  return MakeNode(std::move(node));
+}
+
+ShaderResult<IrExpr> Index(const IrExpr& base, const IrExpr& index, const RcString& label) {
+  if (!(index.type() == IrType::I32()) && !(index.type() == IrType::U32())) {
+    return ShaderError{std::format("index must be i32 or u32, got {}", TypeName(index)), label};
+  }
+
+  const IrType& baseType = base.type();
+  if (baseType.kind() == IrType::Kind::SizedArray ||
+      baseType.kind() == IrType::Kind::RuntimeArray) {
+    IrExpr::Node node;
+    node.kind = IrExpr::Kind::Index;
+    node.type = baseType.elementType();
+    node.mutableLvalue = base.isMutableLvalue();
+    node.children = {base, index};
+    return MakeNode(std::move(node));
+  }
+  if (baseType.isVector()) {
+    IrExpr::Node node;
+    node.kind = IrExpr::Kind::Index;
+    node.type = IrType::Scalar(baseType.scalarKind());
+    node.mutableLvalue = base.isMutableLvalue();
+    node.children = {base, index};
+    return MakeNode(std::move(node));
+  }
+  return ShaderError{
+      std::format("type {} is not indexable (arrays and vectors are)", TypeName(base)), label};
+}
+
+ShaderResult<IrExpr> ConstructVector(const IrType& target, std::vector<IrExpr> args,
+                                     const RcString& label) {
+  if (!target.isVector()) {
+    return ShaderError{std::format("constructor target {} is not a vector type", target.toString()),
+                       label};
+  }
+  if (args.empty()) {
+    return ShaderError{"vector constructor requires at least one argument", label};
+  }
+
+  const ScalarKind element = target.scalarKind();
+
+  // Single scalar splat.
+  const bool isSplat = args.size() == 1 && args[0].type().isScalar();
+  uint32_t componentCount = 0;
+  for (const IrExpr& arg : args) {
+    const IrType& argType = arg.type();
+    if (argType.isScalar() && argType.scalarKind() == element) {
+      componentCount += 1;
+    } else if (argType.isVector() && argType.scalarKind() == element) {
+      componentCount += argType.vectorSize();
+    } else if (!isSplat) {
+      return ShaderError{std::format("constructor argument type {} does not match target {}",
+                                     argType.toString(), target.toString()),
+                         label};
+    }
+  }
+  if (isSplat) {
+    if (!(args[0].type().isScalar() && args[0].type().scalarKind() == element)) {
+      return ShaderError{std::format("splat argument type {} does not match target {}",
+                                     args[0].type().toString(), target.toString()),
+                         label};
+    }
+  } else if (componentCount != target.vectorSize()) {
+    return ShaderError{std::format("constructor for {} needs {} components, got {}",
+                                   target.toString(), target.vectorSize(), componentCount),
+                       label};
+  }
+
+  IrExpr::Node node;
+  node.kind = IrExpr::Kind::Construct;
+  node.type = target;
+  node.children = std::move(args);
+  return MakeNode(std::move(node));
+}
+
+ShaderResult<IrExpr> ConstructMat4x4f(std::vector<IrExpr> columns, const RcString& label) {
+  if (columns.size() != 4) {
+    return ShaderError{
+        std::format("mat4x4<f32> constructor needs 4 columns, got {}", columns.size()), label};
+  }
+  for (const IrExpr& column : columns) {
+    if (!(column.type() == IrType::Vec4f())) {
+      return ShaderError{
+          std::format("mat4x4<f32> columns must be vec4<f32>, got {}", column.type().toString()),
+          label};
+    }
+  }
+
+  IrExpr::Node node;
+  node.kind = IrExpr::Kind::Construct;
+  node.type = IrType::Mat4x4f();
+  node.children = std::move(columns);
+  return MakeNode(std::move(node));
+}
+
+ShaderResult<IrExpr> Convert(const IrType& target, const IrExpr& value, const RcString& label) {
+  const bool targetNumeric = target.isNumericScalar() || target.isNumericVector();
+  if (!targetNumeric) {
+    return ShaderError{
+        std::format("conversion target {} must be a numeric scalar or vector", target.toString()),
+        label};
+  }
+
+  const IrType& sourceType = value.type();
+  const bool scalarToScalar = target.isNumericScalar() && sourceType.isNumericScalar();
+  const bool vectorToVector = target.isNumericVector() && sourceType.isNumericVector() &&
+                              target.vectorSize() == sourceType.vectorSize();
+  const bool scalarSplat = target.isNumericVector() && sourceType.isNumericScalar();
+  if (!scalarToScalar && !vectorToVector && !scalarSplat) {
+    return ShaderError{
+        std::format("cannot convert {} to {}", sourceType.toString(), target.toString()), label};
+  }
+
+  IrExpr::Node node;
+  node.kind = IrExpr::Kind::Convert;
+  node.type = target;
+  node.children = {value};
+  return MakeNode(std::move(node));
+}
+
+namespace {
+
+/// Type-checks builtin arguments and computes the result type.
+ShaderResult<IrType> CheckBuiltin(BuiltinFn fn, std::span<const IrExpr> args,
+                                  const RcString& label) {
+  const auto argCountError = [&](size_t expected) {
+    return ShaderError{std::format("builtin expects {} arguments, got {}", expected, args.size()),
+                       label};
+  };
+
+  switch (fn) {
+    case BuiltinFn::Abs:
+      if (args.size() != 1) return argCountError(1);
+      if (!args[0].type().isNumeric()) {
+        return ShaderError{std::format("abs requires a numeric type, got {}", TypeName(args[0])),
+                           label};
+      }
+      return args[0].type();
+
+    case BuiltinFn::Min:
+    case BuiltinFn::Max:
+      if (args.size() != 2) return argCountError(2);
+      if (!(args[0].type() == args[1].type()) || !args[0].type().isNumeric()) {
+        return ShaderError{std::format("min/max require matching numeric types, got {} and {}",
+                                       TypeName(args[0]), TypeName(args[1])),
+                           label};
+      }
+      return args[0].type();
+
+    case BuiltinFn::Clamp:
+      if (args.size() != 3) return argCountError(3);
+      if (!(args[0].type() == args[1].type()) || !(args[0].type() == args[2].type()) ||
+          !args[0].type().isNumeric()) {
+        return ShaderError{
+            std::format("clamp requires three matching numeric operands, got {}, {}, {}",
+                        TypeName(args[0]), TypeName(args[1]), TypeName(args[2])),
+            label};
+      }
+      return args[0].type();
+
+    case BuiltinFn::Saturate:
+    case BuiltinFn::Fract:
+    case BuiltinFn::Sqrt:
+    case BuiltinFn::Fwidth:
+    case BuiltinFn::Round:
+      if (args.size() != 1) return argCountError(1);
+      if (!args[0].type().isFloatScalarOrVector()) {
+        return ShaderError{
+            std::format("builtin requires f32 scalar or vector, got {}", TypeName(args[0])), label};
+      }
+      return args[0].type();
+
+    case BuiltinFn::Length:
+      if (args.size() != 1) return argCountError(1);
+      if (!args[0].type().isVector() || args[0].type().scalarKind() != ScalarKind::F32) {
+        return ShaderError{std::format("length requires a float vector, got {}", TypeName(args[0])),
+                           label};
+      }
+      return IrType::F32();
+
+    case BuiltinFn::Select:
+      if (args.size() != 3) return argCountError(3);
+      if (!(args[0].type() == args[1].type())) {
+        return ShaderError{std::format("select branches must have matching types, got {} and {}",
+                                       TypeName(args[0]), TypeName(args[1])),
+                           label};
+      }
+      if (!(args[2].type() == IrType::Bool())) {
+        return ShaderError{std::format("select condition must be bool, got {}", TypeName(args[2])),
+                           label};
+      }
+      return args[0].type();
+
+    case BuiltinFn::TextureSample:
+      if (args.size() != 3) return argCountError(3);
+      if (args[0].type().kind() != IrType::Kind::Texture2dF32 ||
+          args[1].type().kind() != IrType::Kind::Sampler || !(args[2].type() == IrType::Vec2f())) {
+        return ShaderError{
+            std::format("textureSample requires (texture_2d<f32>, sampler, vec2<f32>), got "
+                        "({}, {}, {})",
+                        TypeName(args[0]), TypeName(args[1]), TypeName(args[2])),
+            label};
+      }
+      return IrType::Vec4f();
+
+    case BuiltinFn::TextureLoad:
+      if (args.size() != 3) return argCountError(3);
+      if (args[0].type().kind() != IrType::Kind::Texture2dF32 ||
+          !(args[1].type() == IrType::Vec2i()) ||
+          (!(args[2].type() == IrType::I32()) && !(args[2].type() == IrType::U32()))) {
+        return ShaderError{
+            std::format("textureLoad requires (texture_2d<f32>, vec2<i32>, i32|u32), got "
+                        "({}, {}, {})",
+                        TypeName(args[0]), TypeName(args[1]), TypeName(args[2])),
+            label};
+      }
+      return IrType::Vec4f();
+
+    case BuiltinFn::TextureDimensions:
+      if (args.size() != 1) return argCountError(1);
+      if (args[0].type().kind() != IrType::Kind::Texture2dF32) {
+        return ShaderError{
+            std::format("textureDimensions requires a texture, got {}", TypeName(args[0])), label};
+      }
+      return IrType::Vec2u();
+  }
+
+  return ShaderError{"unknown builtin", label};
+}
+
+}  // namespace
+
+ShaderResult<IrExpr> CallBuiltin(BuiltinFn fn, std::vector<IrExpr> args, const RcString& label) {
+  ShaderResult<IrType> resultType = CheckBuiltin(fn, args, label);
+  if (resultType.hasError()) {
+    return std::move(resultType).error();
+  }
+
+  IrExpr::Node node;
+  node.kind = IrExpr::Kind::CallBuiltin;
+  node.type = std::move(resultType).result();
+  node.builtin = fn;
+  node.children = std::move(args);
+  return MakeNode(std::move(node));
+}
+
+ShaderResult<IrExpr> CallBuiltinNamed(std::string_view name, std::vector<IrExpr> args,
+                                      const RcString& label) {
+  static constexpr std::pair<std::string_view, BuiltinFn> kBuiltins[] = {
+      {"abs", BuiltinFn::Abs},
+      {"min", BuiltinFn::Min},
+      {"max", BuiltinFn::Max},
+      {"clamp", BuiltinFn::Clamp},
+      {"saturate", BuiltinFn::Saturate},
+      {"fract", BuiltinFn::Fract},
+      {"sqrt", BuiltinFn::Sqrt},
+      {"length", BuiltinFn::Length},
+      {"fwidth", BuiltinFn::Fwidth},
+      {"round", BuiltinFn::Round},
+      {"select", BuiltinFn::Select},
+      {"textureSample", BuiltinFn::TextureSample},
+      {"textureLoad", BuiltinFn::TextureLoad},
+      {"textureDimensions", BuiltinFn::TextureDimensions},
+  };
+  for (const auto& [builtinName, fn] : kBuiltins) {
+    if (builtinName == name) {
+      return CallBuiltin(fn, std::move(args), label);
+    }
+  }
+  return ShaderError{std::format("unknown builtin function \"{}\"", name), label};
+}
+
+IrExpr MakeCallUser(const RcString& name, const IrType& returnType, std::vector<IrExpr> args) {
+  IrExpr::Node node;
+  node.kind = IrExpr::Kind::CallUser;
+  node.type = returnType;
+  node.name = name;
+  node.children = std::move(args);
+  return MakeNode(std::move(node));
+}
+
+}  // namespace donner::gpu::shader

--- a/donner/gpu/shader/IrExpr.cc
+++ b/donner/gpu/shader/IrExpr.cc
@@ -164,6 +164,15 @@ bool IrExpr::isMutableLvalue() const {
   return node_->mutableLvalue;
 }
 
+void IrExpr::collectRefs(std::vector<RefInfo>& out) const {
+  if (node_->kind == Kind::Ref) {
+    out.push_back(RefInfo{node_->refKind, node_->name, node_->type});
+  }
+  for (const IrExpr& child : node_->children) {
+    child.collectRefs(out);
+  }
+}
+
 std::string IrExpr::toString() const {
   const Node& node = *node_;
   switch (node.kind) {
@@ -328,6 +337,23 @@ ShaderResult<IrExpr> Mul(const IrExpr& lhs, const IrExpr& rhs, const RcString& l
 }
 
 ShaderResult<IrExpr> Div(const IrExpr& lhs, const IrExpr& rhs, const RcString& label) {
+  // vector / broadcast-scalar and broadcast-scalar / vector with matching element type; the
+  // solid-fill fragment stage needs the latter for `1.0 / fwidth(sample_pos)`.
+  const IrType& lt = lhs.type();
+  const IrType& rt = rhs.type();
+  const bool vectorScalar =
+      lt.isNumericVector() && rt.isNumericScalar() && lt.scalarKind() == rt.scalarKind();
+  const bool scalarVector =
+      lt.isNumericScalar() && rt.isNumericVector() && lt.scalarKind() == rt.scalarKind();
+  if (vectorScalar || scalarVector) {
+    IrExpr::Node node;
+    node.kind = IrExpr::Kind::Binary;
+    node.type = vectorScalar ? lt : rt;
+    node.binaryOp = BinaryOp::Div;
+    node.children = {lhs, rhs};
+    return MakeNode(std::move(node));
+  }
+
   return MakeArithmetic(BinaryOp::Div, lhs, rhs, label);
 }
 

--- a/donner/gpu/shader/IrExpr.h
+++ b/donner/gpu/shader/IrExpr.h
@@ -114,6 +114,22 @@ public:
   /// member/index/single-component-swizzle chain rooted at one.
   bool isMutableLvalue() const;
 
+  /// One name reference found inside an expression tree (see \ref collectRefs).
+  struct RefInfo {
+    RefKind kind;   //!< What the name refers to.
+    RcString name;  //!< Referenced name.
+    IrType type;    //!< Type the reference was created with.
+  };
+
+  /**
+   * Appends every name reference in this expression tree (depth-first, in operand order) to
+   * \p out. Used by the function builder to re-verify that referenced names are still in scope
+   * when an expression is recorded into a statement.
+   *
+   * @param out Destination list.
+   */
+  void collectRefs(std::vector<RefInfo>& out) const;
+
   /// Formats this expression as a deterministic prefix string, e.g. `add(ref(a), lit_f32(1))`.
   std::string toString() const;
 

--- a/donner/gpu/shader/IrExpr.h
+++ b/donner/gpu/shader/IrExpr.h
@@ -1,0 +1,291 @@
+#pragma once
+/// @file
+/// Typed, immutable expression nodes for the \c donner::gpu::shader IR.
+///
+/// Every expression is type-checked at construction: the factory functions return
+/// \ref ShaderResult and fail closed on ill-typed operands, unknown swizzles, bad constructor
+/// arity, indexing of non-indexable types, and unknown builtin functions. Expression values are
+/// cheap immutable handles; sharing a subexpression is sharing, not mutation.
+
+#include <cstdint>
+#include <memory>
+#include <ostream>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "donner/base/RcString.h"
+#include "donner/gpu/shader/IrType.h"
+#include "donner/gpu/shader/ShaderResult.h"
+
+namespace donner::gpu::shader {
+
+/// Binary operators.
+enum class BinaryOp : uint8_t {
+  Add,  //!< `+`
+  Sub,  //!< `-`
+  Mul,  //!< `*` (scalars, vectors, vector*scalar, mat4x4f*vec4f, mat4x4f*mat4x4f)
+  Div,  //!< `/`
+  Lt,   //!< `<`
+  Le,   //!< `<=`
+  Gt,   //!< `>`
+  Ge,   //!< `>=`
+  Eq,   //!< `==`
+  Ne,   //!< `!=`
+  And,  //!< `&&`
+  Or,   //!< `||`
+};
+
+/// Ostream output operator, e.g. `add`. @param os Output stream. @param value Value to output.
+std::ostream& operator<<(std::ostream& os, BinaryOp value);
+
+/// Builtin functions callable from IR (the solid-fill subset; everything else is rejected).
+enum class BuiltinFn : uint8_t {
+  Abs,                //!< `abs(x)`
+  Min,                //!< `min(a, b)`
+  Max,                //!< `max(a, b)`
+  Clamp,              //!< `clamp(x, lo, hi)`
+  Saturate,           //!< `saturate(x)`
+  Fract,              //!< `fract(x)`
+  Sqrt,               //!< `sqrt(x)`
+  Length,             //!< `length(v)`
+  Fwidth,             //!< `fwidth(x)` (fragment stage)
+  Round,              //!< `round(x)`
+  Select,             //!< `select(falseVal, trueVal, cond)`
+  TextureSample,      //!< `textureSample(texture, sampler, coords)`
+  TextureLoad,        //!< `textureLoad(texture, coords, level)`
+  TextureDimensions,  //!< `textureDimensions(texture)`
+};
+
+/// Ostream output operator, e.g. `clamp`. @param os Output stream. @param value Value to output.
+std::ostream& operator<<(std::ostream& os, BuiltinFn value);
+
+/// What a name reference refers to; determines mutability and serialization.
+enum class RefKind : uint8_t {
+  Param,     //!< Function parameter (immutable).
+  Let,       //!< Function-scope immutable binding.
+  Var,       //!< Function-scope mutable variable (assignable).
+  Constant,  //!< Module-scope constant.
+  Resource,  //!< Module-scope resource binding.
+};
+
+/// Ostream output operator, e.g. `var`. @param os Output stream. @param value Value to output.
+std::ostream& operator<<(std::ostream& os, RefKind value);
+
+/**
+ * A typed, immutable IR expression handle.
+ *
+ * Construct through the free factory functions (\ref LiteralF32, \ref Add, \ref Member,
+ * \ref CallBuiltin, ...) or through the function builder's `ref`/`addLet`/`addVar`. Every handle
+ * carries its result type; assignability is tracked so only `var`-rooted access chains can be
+ * assignment targets.
+ */
+class IrExpr {
+public:
+  /// Expression node kind.
+  enum class Kind : uint8_t {
+    Literal,      //!< Scalar literal.
+    Ref,          //!< Named reference (param/let/var/constant/resource).
+    Unary,        //!< Unary minus or logical not.
+    Binary,       //!< Binary operator.
+    Member,       //!< Struct member access.
+    Swizzle,      //!< Vector swizzle (.x, .xy, ...).
+    Index,        //!< Array or vector indexing.
+    Construct,    //!< Vector or matrix constructor.
+    Convert,      //!< Scalar/vector element type conversion.
+    CallBuiltin,  //!< Builtin function call.
+    CallUser,     //!< User-defined function call.
+  };
+
+  /// Unary operators.
+  enum class UnaryOp : uint8_t {
+    Neg,  //!< Unary minus (numeric, non-u32).
+    Not,  //!< Logical not (bool).
+  };
+
+  /// Result type of this expression.
+  const IrType& type() const;
+
+  /// Node kind.
+  Kind kind() const;
+
+  /// True if this expression is a valid assignment target: a `var` reference or a
+  /// member/index/single-component-swizzle chain rooted at one.
+  bool isMutableLvalue() const;
+
+  /// Formats this expression as a deterministic prefix string, e.g. `add(ref(a), lit_f32(1))`.
+  std::string toString() const;
+
+  /**
+   * Ostream output operator.
+   *
+   * @param os Output stream.
+   * @param expr Expression to output.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const IrExpr& expr) {
+    return os << expr.toString();
+  }
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+  // Internal node storage; public for the factory/serialization implementation only.
+  struct Node;
+  explicit IrExpr(std::shared_ptr<const Node> node) : node_(std::move(node)) {}
+  const Node& node() const { return *node_; }
+#endif  // DOXYGEN_SHOULD_SKIP_THIS
+
+private:
+  std::shared_ptr<const Node> node_;
+};
+
+/// `f32` literal. @param value Literal value.
+IrExpr LiteralF32(float value);
+/// `i32` literal. @param value Literal value.
+IrExpr LiteralI32(int32_t value);
+/// `u32` literal. @param value Literal value.
+IrExpr LiteralU32(uint32_t value);
+/// `bool` literal. @param value Literal value.
+IrExpr LiteralBool(bool value);
+
+/**
+ * Named reference; normally produced by the function/module builders, which guarantee the name
+ * exists with the given type.
+ *
+ * @param kind What the name refers to.
+ * @param name Referenced name.
+ * @param type Type of the referenced value.
+ */
+IrExpr MakeRef(RefKind kind, const RcString& name, const IrType& type);
+
+/// `lhs + rhs` for matching numeric scalar/vector types.
+/// @param lhs Left operand. @param rhs Right operand. @param label Diagnostic label.
+ShaderResult<IrExpr> Add(const IrExpr& lhs, const IrExpr& rhs, const RcString& label = "add");
+/// `lhs - rhs` for matching numeric scalar/vector types.
+/// @param lhs Left operand. @param rhs Right operand. @param label Diagnostic label.
+ShaderResult<IrExpr> Sub(const IrExpr& lhs, const IrExpr& rhs, const RcString& label = "sub");
+/**
+ * `lhs * rhs`: matching numeric scalar/vector types, vector*scalar, scalar*vector,
+ * mat4x4f*vec4f, or mat4x4f*mat4x4f (required by the solid-fill vertex stage, which composes
+ * the per-instance matrix with the MVP).
+ *
+ * @param lhs Left operand. @param rhs Right operand. @param label Diagnostic label.
+ */
+ShaderResult<IrExpr> Mul(const IrExpr& lhs, const IrExpr& rhs, const RcString& label = "mul");
+/// `lhs / rhs` for matching numeric scalar/vector types.
+/// @param lhs Left operand. @param rhs Right operand. @param label Diagnostic label.
+ShaderResult<IrExpr> Div(const IrExpr& lhs, const IrExpr& rhs, const RcString& label = "div");
+
+/// `lhs < rhs` for matching numeric scalar types; yields bool.
+/// @param lhs Left operand. @param rhs Right operand. @param label Diagnostic label.
+ShaderResult<IrExpr> Lt(const IrExpr& lhs, const IrExpr& rhs, const RcString& label = "lt");
+/// `lhs <= rhs` for matching numeric scalar types; yields bool.
+/// @param lhs Left operand. @param rhs Right operand. @param label Diagnostic label.
+ShaderResult<IrExpr> Le(const IrExpr& lhs, const IrExpr& rhs, const RcString& label = "le");
+/// `lhs > rhs` for matching numeric scalar types; yields bool.
+/// @param lhs Left operand. @param rhs Right operand. @param label Diagnostic label.
+ShaderResult<IrExpr> Gt(const IrExpr& lhs, const IrExpr& rhs, const RcString& label = "gt");
+/// `lhs >= rhs` for matching numeric scalar types; yields bool.
+/// @param lhs Left operand. @param rhs Right operand. @param label Diagnostic label.
+ShaderResult<IrExpr> Ge(const IrExpr& lhs, const IrExpr& rhs, const RcString& label = "ge");
+/// `lhs == rhs` for matching scalar types; yields bool.
+/// @param lhs Left operand. @param rhs Right operand. @param label Diagnostic label.
+ShaderResult<IrExpr> Eq(const IrExpr& lhs, const IrExpr& rhs, const RcString& label = "eq");
+/// `lhs != rhs` for matching scalar types; yields bool.
+/// @param lhs Left operand. @param rhs Right operand. @param label Diagnostic label.
+ShaderResult<IrExpr> Ne(const IrExpr& lhs, const IrExpr& rhs, const RcString& label = "ne");
+
+/// `lhs && rhs` for bools.
+/// @param lhs Left operand. @param rhs Right operand. @param label Diagnostic label.
+ShaderResult<IrExpr> And(const IrExpr& lhs, const IrExpr& rhs, const RcString& label = "and");
+/// `lhs || rhs` for bools.
+/// @param lhs Left operand. @param rhs Right operand. @param label Diagnostic label.
+ShaderResult<IrExpr> Or(const IrExpr& lhs, const IrExpr& rhs, const RcString& label = "or");
+/// `!operand` for bool.
+/// @param operand Operand. @param label Diagnostic label.
+ShaderResult<IrExpr> Not(const IrExpr& operand, const RcString& label = "not");
+/// `-operand` for f32/i32 scalars and vectors (u32 has no unary minus).
+/// @param operand Operand. @param label Diagnostic label.
+ShaderResult<IrExpr> Neg(const IrExpr& operand, const RcString& label = "neg");
+
+/// Struct member access `base.member`.
+/// @param base Struct-typed expression. @param memberName Member to access.
+/// @param label Diagnostic label.
+ShaderResult<IrExpr> Member(const IrExpr& base, const RcString& memberName,
+                            const RcString& label = "member");
+
+/// Vector swizzle `base.xy` (components from xyzw, 1-4 of them, within the vector size).
+/// @param base Vector-typed expression. @param components Swizzle string, e.g. `"xy"`.
+/// @param label Diagnostic label.
+ShaderResult<IrExpr> Swizzle(const IrExpr& base, std::string_view components,
+                             const RcString& label = "swizzle");
+
+/// Indexing `base[index]` for sized arrays, runtime arrays, and vectors, with an i32/u32 index.
+/// @param base Indexable expression. @param index Index expression. @param label Diagnostic
+/// label.
+ShaderResult<IrExpr> Index(const IrExpr& base, const IrExpr& index,
+                           const RcString& label = "index");
+
+/**
+ * Vector constructor: `vecN<T>(...)` from scalars and smaller vectors of element type T totaling
+ * exactly N components, or a single scalar splat.
+ *
+ * @param target Vector type to construct.
+ * @param args Constructor arguments.
+ * @param label Diagnostic label.
+ */
+ShaderResult<IrExpr> ConstructVector(const IrType& target, std::vector<IrExpr> args,
+                                     const RcString& label = "construct");
+
+/**
+ * Matrix constructor: `mat4x4f(c0, c1, c2, c3)` from four vec4f columns.
+ *
+ * @param columns The four column vectors.
+ * @param label Diagnostic label.
+ */
+ShaderResult<IrExpr> ConstructMat4x4f(std::vector<IrExpr> columns,
+                                      const RcString& label = "mat4x4f");
+
+/**
+ * Scalar or vector element-type conversion, e.g. `f32(x)`, `u32(x)`, `vec2i(vec2f)`. The target
+ * must be a numeric scalar or vector; vector conversions require matching component counts, and
+ * a numeric scalar argument may also convert to a vector by splat (e.g. `vec2i(0)`).
+ *
+ * @param target Conversion target type.
+ * @param value Value to convert.
+ * @param label Diagnostic label.
+ */
+ShaderResult<IrExpr> Convert(const IrType& target, const IrExpr& value,
+                             const RcString& label = "convert");
+
+/**
+ * Builtin function call by enum.
+ *
+ * @param fn Builtin to call.
+ * @param args Call arguments.
+ * @param label Diagnostic label.
+ */
+ShaderResult<IrExpr> CallBuiltin(BuiltinFn fn, std::vector<IrExpr> args,
+                                 const RcString& label = "call");
+
+/**
+ * Builtin function call by name; unknown names fail closed (only the solid-fill builtin subset
+ * exists).
+ *
+ * @param name Builtin name, e.g. `"clamp"`.
+ * @param args Call arguments.
+ * @param label Diagnostic label.
+ */
+ShaderResult<IrExpr> CallBuiltinNamed(std::string_view name, std::vector<IrExpr> args,
+                                      const RcString& label = "call");
+
+/**
+ * User-defined function call; normally produced by the function builder, which checks the
+ * signature against the module's registered functions.
+ *
+ * @param name Callee name.
+ * @param returnType Callee return type.
+ * @param args Call arguments (already checked against the signature).
+ */
+IrExpr MakeCallUser(const RcString& name, const IrType& returnType, std::vector<IrExpr> args);
+
+}  // namespace donner::gpu::shader

--- a/donner/gpu/shader/IrExpr.h
+++ b/donner/gpu/shader/IrExpr.h
@@ -130,6 +130,22 @@ public:
    */
   void collectRefs(std::vector<RefInfo>& out) const;
 
+  /**
+   * Appends every builtin function called anywhere in this expression tree to \p out. Used by
+   * the function builder to enforce stage restrictions (fragment-only builtins).
+   *
+   * @param out Destination list.
+   */
+  void collectBuiltinCalls(std::vector<BuiltinFn>& out) const;
+
+  /**
+   * Appends the name of every user function called anywhere in this expression tree to \p out.
+   * Used to propagate stage restrictions through user calls.
+   *
+   * @param out Destination list.
+   */
+  void collectUserCalls(std::vector<RcString>& out) const;
+
   /// Formats this expression as a deterministic prefix string, e.g. `add(ref(a), lit_f32(1))`.
   std::string toString() const;
 

--- a/donner/gpu/shader/IrLayout.cc
+++ b/donner/gpu/shader/IrLayout.cc
@@ -137,7 +137,15 @@ ShaderResult<StructLayout> ComputeStructLayout(const IrType& structType,
     layout.members.push_back(
         StructMemberLayout{offset, TypeLayout{memberAlign, memberLayout.result().sizeBytes}});
     layout.alignBytes = std::max(layout.alignBytes, memberAlign);
-    offset += memberLayout.result().sizeBytes;
+
+    // WGSL uniform constraint: the member following a struct-typed member S must start at least
+    // roundUp(16, SizeOf(S)) bytes after S's start, even when the follower's own alignment would
+    // let it pack into S's tail padding.
+    if (addressSpace == AddressSpace::Uniform && member.type.kind() == IrType::Kind::Struct) {
+      offset += RoundUp(16, memberLayout.result().sizeBytes);
+    } else {
+      offset += memberLayout.result().sizeBytes;
+    }
   }
 
   layout.sizeBytes = RoundUp(layout.alignBytes, offset);

--- a/donner/gpu/shader/IrLayout.cc
+++ b/donner/gpu/shader/IrLayout.cc
@@ -1,0 +1,147 @@
+#include "donner/gpu/shader/IrLayout.h"
+
+#include <algorithm>
+#include <format>
+
+namespace donner::gpu::shader {
+
+namespace {
+
+/// Rounds \p value up to the next multiple of \p alignment.
+uint32_t RoundUp(uint32_t alignment, uint32_t value) {
+  return ((value + alignment - 1) / alignment) * alignment;
+}
+
+/// Alignment of \p type as a member or array element in \p addressSpace: in uniform space,
+/// structs and arrays round their alignment up to 16 (WGSL uniform layout constraints).
+uint32_t EffectiveAlign(const IrType& type, AddressSpace addressSpace, uint32_t baseAlign) {
+  if (addressSpace == AddressSpace::Uniform &&
+      (type.kind() == IrType::Kind::Struct || type.kind() == IrType::Kind::SizedArray)) {
+    return RoundUp(16, baseAlign);
+  }
+  return baseAlign;
+}
+
+}  // namespace
+
+std::ostream& operator<<(std::ostream& os, AddressSpace value) {
+  switch (value) {
+    case AddressSpace::Uniform: return os << "uniform";
+    case AddressSpace::Storage: return os << "storage";
+  }
+  return os << "unknown";
+}
+
+ShaderResult<TypeLayout> ComputeTypeLayout(const IrType& type, AddressSpace addressSpace) {
+  switch (type.kind()) {
+    case IrType::Kind::Scalar:
+      if (type.scalarKind() == ScalarKind::Bool) {
+        return ShaderError{"bool is not host-shareable and has no layout", "layout"};
+      }
+      return TypeLayout{4, 4};
+
+    case IrType::Kind::Vector: {
+      if (type.scalarKind() == ScalarKind::Bool) {
+        return ShaderError{"vectors of bool are not host-shareable and have no layout", "layout"};
+      }
+      switch (type.vectorSize()) {
+        case 2: return TypeLayout{8, 8};
+        case 3: return TypeLayout{16, 12};
+        case 4: return TypeLayout{16, 16};
+        default: break;
+      }
+      return ShaderError{std::format("vector size {} has no layout", type.vectorSize()), "layout"};
+    }
+
+    case IrType::Kind::Matrix4x4f: return TypeLayout{16, 64};
+
+    case IrType::Kind::SizedArray: {
+      ShaderResult<TypeLayout> elementLayout = ComputeTypeLayout(type.elementType(), addressSpace);
+      if (elementLayout.hasError()) {
+        return std::move(elementLayout).error();
+      }
+      ShaderResult<uint32_t> stride = ComputeArrayStride(type, addressSpace);
+      if (stride.hasError()) {
+        return std::move(stride).error();
+      }
+      // WGSL: in the uniform address space, arrays align to roundUp(16, AlignOf(element)).
+      uint32_t align = elementLayout.result().alignBytes;
+      if (addressSpace == AddressSpace::Uniform) {
+        align = RoundUp(16, align);
+      }
+      return TypeLayout{align, type.arrayCount() * stride.result()};
+    }
+
+    case IrType::Kind::RuntimeArray:
+      return ShaderError{"runtime arrays have a stride but no fixed size; use ComputeArrayStride",
+                         "layout"};
+
+    case IrType::Kind::Struct: {
+      ShaderResult<StructLayout> structLayout = ComputeStructLayout(type, addressSpace);
+      if (structLayout.hasError()) {
+        return std::move(structLayout).error();
+      }
+      return TypeLayout{structLayout.result().alignBytes, structLayout.result().sizeBytes};
+    }
+
+    case IrType::Kind::Texture2dF32:
+    case IrType::Kind::Sampler:
+      return ShaderError{
+          std::format("{} is a resource type and has no host-shareable layout", type.toString()),
+          "layout"};
+  }
+
+  return ShaderError{"unknown type kind", "layout"};
+}
+
+ShaderResult<uint32_t> ComputeArrayStride(const IrType& arrayType, AddressSpace addressSpace) {
+  if (arrayType.kind() != IrType::Kind::SizedArray &&
+      arrayType.kind() != IrType::Kind::RuntimeArray) {
+    return ShaderError{std::format("{} is not an array type", arrayType.toString()), "arrayStride"};
+  }
+
+  ShaderResult<TypeLayout> elementLayout = ComputeTypeLayout(arrayType.elementType(), addressSpace);
+  if (elementLayout.hasError()) {
+    return std::move(elementLayout).error();
+  }
+
+  uint32_t stride = RoundUp(elementLayout.result().alignBytes, elementLayout.result().sizeBytes);
+  if (addressSpace == AddressSpace::Uniform) {
+    // WGSL uniform address space requires array element strides to be multiples of 16.
+    stride = RoundUp(16, stride);
+  }
+  return stride;
+}
+
+ShaderResult<StructLayout> ComputeStructLayout(const IrType& structType,
+                                               AddressSpace addressSpace) {
+  if (structType.kind() != IrType::Kind::Struct) {
+    return ShaderError{std::format("{} is not a struct type", structType.toString()),
+                       "structLayout"};
+  }
+
+  StructLayout layout;
+  uint32_t offset = 0;
+  for (const IrType::Member& member : structType.structMembers()) {
+    ShaderResult<TypeLayout> memberLayout = ComputeTypeLayout(member.type, addressSpace);
+    if (memberLayout.hasError()) {
+      ShaderError error = std::move(memberLayout).error();
+      error.message = std::format("struct {} member {}: {}", structType.structName().str(),
+                                  member.name.str(), error.message);
+      return error;
+    }
+
+    const uint32_t memberAlign =
+        EffectiveAlign(member.type, addressSpace, memberLayout.result().alignBytes);
+    offset = RoundUp(memberAlign, offset);
+    layout.members.push_back(
+        StructMemberLayout{offset, TypeLayout{memberAlign, memberLayout.result().sizeBytes}});
+    layout.alignBytes = std::max(layout.alignBytes, memberAlign);
+    offset += memberLayout.result().sizeBytes;
+  }
+
+  layout.sizeBytes = RoundUp(layout.alignBytes, offset);
+  return layout;
+}
+
+}  // namespace donner::gpu::shader

--- a/donner/gpu/shader/IrLayout.cc
+++ b/donner/gpu/shader/IrLayout.cc
@@ -95,6 +95,15 @@ ShaderResult<TypeLayout> ComputeTypeLayout(const IrType& type, AddressSpace addr
 }
 
 ShaderResult<uint32_t> ComputeArrayStride(const IrType& arrayType, AddressSpace addressSpace) {
+  ShaderResult<ArrayStrideInfo> info = ComputeArrayStrideInfo(arrayType, addressSpace);
+  if (info.hasError()) {
+    return std::move(info).error();
+  }
+  return info.result().strideBytes;
+}
+
+ShaderResult<ArrayStrideInfo> ComputeArrayStrideInfo(const IrType& arrayType,
+                                                     AddressSpace addressSpace) {
   if (arrayType.kind() != IrType::Kind::SizedArray &&
       arrayType.kind() != IrType::Kind::RuntimeArray) {
     return ShaderError{std::format("{} is not an array type", arrayType.toString()), "arrayStride"};
@@ -105,12 +114,16 @@ ShaderResult<uint32_t> ComputeArrayStride(const IrType& arrayType, AddressSpace 
     return std::move(elementLayout).error();
   }
 
-  uint32_t stride = RoundUp(elementLayout.result().alignBytes, elementLayout.result().sizeBytes);
+  const uint32_t naturalStride =
+      RoundUp(elementLayout.result().alignBytes, elementLayout.result().sizeBytes);
+  uint32_t stride = naturalStride;
   if (addressSpace == AddressSpace::Uniform) {
-    // WGSL uniform address space requires array element strides to be multiples of 16.
+    // WGSL uniform address space requires array element strides to be multiples of 16. Rounding
+    // (instead of rejecting) keeps natural-stride-16 arrays like slug_fill's clipPolygonPlanes
+    // array<vec4f, 4> simple; emitters must wrap padded elements when paddedFromNatural is set.
     stride = RoundUp(16, stride);
   }
-  return stride;
+  return ArrayStrideInfo{stride, stride != naturalStride};
 }
 
 ShaderResult<StructLayout> ComputeStructLayout(const IrType& structType,

--- a/donner/gpu/shader/IrLayout.h
+++ b/donner/gpu/shader/IrLayout.h
@@ -82,10 +82,47 @@ ShaderResult<TypeLayout> ComputeTypeLayout(const IrType& type, AddressSpace addr
  * roundUp(AlignOf(element), SizeOf(element)), rounded up to a multiple of 16 in the uniform
  * address space.
  *
+ * The uniform rounding is a deliberate policy choice: WGSL validation would reject a uniform
+ * array whose natural stride is not a multiple of 16 (there is no stride attribute), so this
+ * engine defines the layout as the rounded stride and \ref ComputeArrayStrideInfo reports when
+ * rounding occurred. Emitters must materialize padded element wrappers in that case (see
+ * \ref ArrayStrideInfo).
+ *
  * @param arrayType Sized or runtime array type.
  * @param addressSpace Address space the stride is computed for.
  */
 ShaderResult<uint32_t> ComputeArrayStride(const IrType& arrayType, AddressSpace addressSpace);
+
+/// Element stride of an array in an address space, plus whether uniform rules padded it.
+struct ArrayStrideInfo {
+  uint32_t strideBytes = 0;        //!< Effective element stride.
+  bool paddedFromNatural = false;  //!< True when the uniform 16-byte rule raised the natural
+                                   //!< stride. EMITTER OBLIGATION: WGSL has no stride attribute,
+                                   //!< so emitters must materialize a padded element wrapper
+                                   //!< (e.g. a struct with explicit tail padding) whenever this
+                                   //!< is set.
+
+  /// Equality operator. @param other Info to compare against.
+  bool operator==(const ArrayStrideInfo& other) const = default;
+
+  /// Ostream output operator, e.g. `stride=16 padded=true`.
+  /// @param os Output stream. @param value Info to output.
+  friend std::ostream& operator<<(std::ostream& os, const ArrayStrideInfo& value) {
+    return os << "stride=" << value.strideBytes
+              << " padded=" << (value.paddedFromNatural ? "true" : "false");
+  }
+};
+
+/**
+ * Like \ref ComputeArrayStride, additionally reporting whether the uniform 16-byte rule raised
+ * the natural stride - the flag packet 5's emitters consult to decide whether a padded element
+ * wrapper is required.
+ *
+ * @param arrayType Sized or runtime array type.
+ * @param addressSpace Address space the stride is computed for.
+ */
+ShaderResult<ArrayStrideInfo> ComputeArrayStrideInfo(const IrType& arrayType,
+                                                     AddressSpace addressSpace);
 
 /**
  * Computes the full member layout of a struct type in \p addressSpace: member offsets rounded to

--- a/donner/gpu/shader/IrLayout.h
+++ b/donner/gpu/shader/IrLayout.h
@@ -1,0 +1,100 @@
+#pragma once
+/// @file
+/// Host-shareable memory layout engine for \c donner::gpu::shader types.
+///
+/// Implements the WGSL specification's memory layout rules: scalar align/size 4/4, vec2 8/8,
+/// vec3 16/12, vec4 16/16, mat4x4f 16/64, array stride roundUp(AlignOf(elem), SizeOf(elem)),
+/// struct member offsets rounded to member alignment, struct alignment = max member alignment,
+/// struct size rounded up to the struct alignment. In the uniform address space, arrays round
+/// their element stride up to a multiple of 16, and members whose type is a struct or array
+/// round their alignment up to 16.
+///
+/// The C++ mirror structs the GPU runtime uploads (e.g. the Geode encoder's Uniforms/Band/
+/// InstanceTransform) must byte-match these computed layouts; the shader tests anchor that.
+
+#include <cstdint>
+#include <ostream>
+#include <vector>
+
+#include "donner/gpu/shader/IrType.h"
+#include "donner/gpu/shader/ShaderResult.h"
+
+namespace donner::gpu::shader {
+
+/// Address space a host-shareable layout is computed for.
+enum class AddressSpace : uint8_t {
+  Uniform,  //!< Uniform buffers; extra 16-byte rounding rules apply.
+  Storage,  //!< (Read-only) storage buffers; base layout rules.
+};
+
+/**
+ * Ostream output operator, e.g. `uniform`.
+ *
+ * @param os Output stream.
+ * @param value Value to output.
+ */
+std::ostream& operator<<(std::ostream& os, AddressSpace value);
+
+/// Alignment and size of a host-shareable type.
+struct TypeLayout {
+  uint32_t alignBytes = 0;  //!< Required alignment in bytes.
+  uint32_t sizeBytes = 0;   //!< Size in bytes (for sized types).
+
+  /// Equality operator. @param other Layout to compare against.
+  bool operator==(const TypeLayout& other) const = default;
+
+  /// Ostream output operator, e.g. `align=16 size=288`.
+  /// @param os Output stream. @param value Layout to output.
+  friend std::ostream& operator<<(std::ostream& os, const TypeLayout& value) {
+    return os << "align=" << value.alignBytes << " size=" << value.sizeBytes;
+  }
+};
+
+/// Layout of one struct member.
+struct StructMemberLayout {
+  uint32_t offsetBytes = 0;  //!< Byte offset from the start of the struct.
+  TypeLayout layout;         //!< Member type layout in the queried address space.
+
+  /// Equality operator. @param other Layout to compare against.
+  bool operator==(const StructMemberLayout& other) const = default;
+};
+
+/// Layout of a struct type: overall alignment/size plus per-member offsets in declaration order.
+struct StructLayout {
+  uint32_t alignBytes = 0;                  //!< Struct alignment.
+  uint32_t sizeBytes = 0;                   //!< Struct size, rounded up to the alignment.
+  std::vector<StructMemberLayout> members;  //!< Per-member layouts, in declaration order.
+};
+
+/**
+ * Computes alignment and size of \p type in \p addressSpace per the WGSL layout rules. Fails
+ * closed for types with no host-shareable layout: bool (and vectors of bool), textures,
+ * samplers, and runtime arrays (which have a stride but no fixed size; use
+ * \ref ComputeArrayStride).
+ *
+ * @param type Type to lay out.
+ * @param addressSpace Address space the layout is computed for.
+ */
+ShaderResult<TypeLayout> ComputeTypeLayout(const IrType& type, AddressSpace addressSpace);
+
+/**
+ * Computes the element stride of a sized or runtime array in \p addressSpace:
+ * roundUp(AlignOf(element), SizeOf(element)), rounded up to a multiple of 16 in the uniform
+ * address space.
+ *
+ * @param arrayType Sized or runtime array type.
+ * @param addressSpace Address space the stride is computed for.
+ */
+ShaderResult<uint32_t> ComputeArrayStride(const IrType& arrayType, AddressSpace addressSpace);
+
+/**
+ * Computes the full member layout of a struct type in \p addressSpace: member offsets rounded to
+ * member alignment (16-rounded for nested structs/arrays in uniform), struct alignment = max
+ * member alignment, struct size rounded up to the struct alignment.
+ *
+ * @param structType Struct type to lay out.
+ * @param addressSpace Address space the layout is computed for.
+ */
+ShaderResult<StructLayout> ComputeStructLayout(const IrType& structType, AddressSpace addressSpace);
+
+}  // namespace donner::gpu::shader

--- a/donner/gpu/shader/IrModule.cc
+++ b/donner/gpu/shader/IrModule.cc
@@ -691,9 +691,15 @@ ShaderResult<FunctionBuilder> ModuleBuilder::createFragmentEntryPoint(
     return std::move(status).error();
   }
   for (const IrParam& param : params) {
-    if (param.builtin || !param.location) {
-      return ShaderError{std::format("fragment input {} must have a location", param.name.str()),
-                         name};
+    if (param.builtin) {
+      if (*param.builtin != BuiltinInput::Position || !(param.type == IrType::Vec4f())) {
+        return ShaderError{
+            std::format("fragment builtin input {} must be position: vec4<f32>", param.name.str()),
+            name};
+      }
+    } else if (!param.location) {
+      return ShaderError{
+          std::format("fragment input {} must have a location or builtin", param.name.str()), name};
     }
   }
   bool hasColorOutput = false;

--- a/donner/gpu/shader/IrModule.cc
+++ b/donner/gpu/shader/IrModule.cc
@@ -1,0 +1,729 @@
+#include "donner/gpu/shader/IrModule.h"
+
+#include <format>
+#include <utility>
+
+namespace donner::gpu::shader {
+
+namespace {
+
+/// Builds a labeled error.
+ShaderError Err(std::string message, const RcString& label) {
+  return ShaderError{std::move(message), label};
+}
+
+/// Validates entry point IO: unique locations and allowed types (numeric scalars/vectors).
+template <typename IoList>
+ShaderStatus ValidateStageIo(const IoList& io, const RcString& label) {
+  for (size_t i = 0; i < io.size(); ++i) {
+    if (io[i].location) {
+      if (!io[i].type.isNumeric()) {
+        return Err(std::format("stage IO {} must be a numeric scalar or vector, got {}",
+                               io[i].name.str(), io[i].type.toString()),
+                   label);
+      }
+      for (size_t j = i + 1; j < io.size(); ++j) {
+        if (io[j].location && *io[j].location == *io[i].location) {
+          return Err(std::format("duplicate stage IO location {}", *io[i].location), label);
+        }
+      }
+    }
+  }
+  return OkShaderStatus();
+}
+
+}  // namespace
+
+std::ostream& operator<<(std::ostream& os, BindingKind value) {
+  switch (value) {
+    case BindingKind::UniformBuffer: return os << "uniform";
+    case BindingKind::ReadOnlyStorageBuffer: return os << "storage_read";
+    case BindingKind::SampledTexture2dF32: return os << "texture_2d<f32>";
+    case BindingKind::FilteringSampler: return os << "sampler";
+  }
+  return os << "unknown";
+}
+
+// ============================================================================
+// FunctionBuilder
+// ============================================================================
+
+FunctionBuilder::FunctionBuilder(ModuleBuilder& moduleBuilder, IrFunction&& function)
+    : moduleBuilder_(&moduleBuilder), function_(std::move(function)) {
+  for (const IrParam& param : function_.params) {
+    locals_.emplace(param.name, std::make_pair(param.type, RefKind::Param));
+  }
+}
+
+FunctionBuilder::FunctionBuilder(FunctionBuilder&& other) noexcept
+    : moduleBuilder_(std::exchange(other.moduleBuilder_, nullptr)),
+      function_(std::move(other.function_)),
+      firstError_(std::move(other.firstError_)),
+      finished_(other.finished_),
+      blockStack_(std::move(other.blockStack_)),
+      locals_(std::move(other.locals_)) {}
+
+FunctionBuilder::~FunctionBuilder() {
+  if (moduleBuilder_ != nullptr && !finished_) {
+    moduleBuilder_->functionInProgress_ = false;
+  }
+}
+
+ShaderStatus FunctionBuilder::fail(ShaderError&& error) {
+  if (!firstError_) {
+    firstError_ = std::move(error);
+  }
+  return *firstError_;
+}
+
+std::optional<ShaderError> FunctionBuilder::checkUsable() const {
+  if (firstError_) {
+    return *firstError_;
+  }
+  if (finished_) {
+    return ShaderError{"function already finished", function_.name};
+  }
+  return std::nullopt;
+}
+
+void FunctionBuilder::append(IrStmt&& statement) {
+  if (!blockStack_.empty()) {
+    blockStack_.back().statements.push_back(std::move(statement));
+  } else {
+    function_.body.push_back(std::move(statement));
+  }
+}
+
+ShaderStatus FunctionBuilder::declareName(const RcString& name, const IrType& type, RefKind kind) {
+  if (locals_.contains(name)) {
+    return fail(Err(std::format("name {} is already declared in this function", name.str()),
+                    function_.name));
+  }
+  locals_.emplace(name, std::make_pair(type, kind));
+  return OkShaderStatus();
+}
+
+bool FunctionBuilder::insideLoop() const {
+  for (const BlockFrame& frame : blockStack_) {
+    if (frame.kind == BlockFrame::Kind::ForBody) {
+      return true;
+    }
+  }
+  return false;
+}
+
+ShaderResult<IrExpr> FunctionBuilder::ref(const RcString& name) const {
+  const auto it = locals_.find(name);
+  if (it != locals_.end()) {
+    return MakeRef(it->second.second, name, it->second.first);
+  }
+  if (std::optional<IrExpr> moduleRef = moduleBuilder_->resolveModuleName(name)) {
+    return *moduleRef;
+  }
+  return ShaderError{std::format("unknown name {}", name.str()), function_.name};
+}
+
+ShaderResult<IrExpr> FunctionBuilder::addLet(const RcString& name, const IrExpr& value) {
+  if (std::optional<ShaderError> error = checkUsable()) {
+    return *error;
+  }
+  if (ShaderStatus status = declareName(name, value.type(), RefKind::Let); status.hasError()) {
+    return std::move(status).error();
+  }
+
+  IrStmt::Data data;
+  data.kind = IrStmt::Kind::Let;
+  data.name = name;
+  data.exprs = {value};
+  append(IrStmt(std::move(data)));
+  return MakeRef(RefKind::Let, name, value.type());
+}
+
+ShaderResult<IrExpr> FunctionBuilder::addVar(const RcString& name, const IrType& type,
+                                             const std::optional<IrExpr>& init) {
+  if (std::optional<ShaderError> error = checkUsable()) {
+    return *error;
+  }
+  if (!type.isPlainData()) {
+    ShaderStatus status =
+        fail(Err(std::format("var {} type {} is not plain data", name.str(), type.toString()),
+                 function_.name));
+    return std::move(status).error();
+  }
+  if (init && !(init->type() == type)) {
+    ShaderStatus status =
+        fail(Err(std::format("var {} initializer type {} does not match declared type {}",
+                             name.str(), init->type().toString(), type.toString()),
+                 function_.name));
+    return std::move(status).error();
+  }
+  if (ShaderStatus status = declareName(name, type, RefKind::Var); status.hasError()) {
+    return std::move(status).error();
+  }
+
+  IrStmt::Data data;
+  data.kind = IrStmt::Kind::Var;
+  data.name = name;
+  data.declaredType = type;
+  if (init) {
+    data.exprs = {*init};
+  }
+  append(IrStmt(std::move(data)));
+  return MakeRef(RefKind::Var, name, type);
+}
+
+ShaderStatus FunctionBuilder::assign(const IrExpr& lhs, const IrExpr& rhs) {
+  if (std::optional<ShaderError> error = checkUsable()) {
+    return *error;
+  }
+  if (!lhs.isMutableLvalue()) {
+    return fail(
+        Err("assignment target is not a mutable lvalue (only var-rooted chains are "
+            "assignable)",
+            function_.name));
+  }
+  if (!(lhs.type() == rhs.type())) {
+    return fail(Err(std::format("assignment type mismatch: {} = {}", lhs.type().toString(),
+                                rhs.type().toString()),
+                    function_.name));
+  }
+
+  IrStmt::Data data;
+  data.kind = IrStmt::Kind::Assign;
+  data.exprs = {lhs, rhs};
+  append(IrStmt(std::move(data)));
+  return OkShaderStatus();
+}
+
+ShaderStatus FunctionBuilder::beginIf(const IrExpr& condition) {
+  if (std::optional<ShaderError> error = checkUsable()) {
+    return *error;
+  }
+  if (!(condition.type() == IrType::Bool())) {
+    return fail(Err(std::format("if condition must be bool, got {}", condition.type().toString()),
+                    function_.name));
+  }
+
+  BlockFrame frame;
+  frame.kind = BlockFrame::Kind::IfThen;
+  frame.condition = condition;
+  blockStack_.push_back(std::move(frame));
+  return OkShaderStatus();
+}
+
+ShaderStatus FunctionBuilder::elseBranch() {
+  if (std::optional<ShaderError> error = checkUsable()) {
+    return *error;
+  }
+  if (blockStack_.empty() || blockStack_.back().kind != BlockFrame::Kind::IfThen) {
+    return fail(Err("elseBranch without an open if", function_.name));
+  }
+
+  BlockFrame& frame = blockStack_.back();
+  frame.kind = BlockFrame::Kind::IfElse;
+  frame.thenStatements = std::move(frame.statements);
+  frame.statements.clear();
+  return OkShaderStatus();
+}
+
+ShaderStatus FunctionBuilder::endIf() {
+  if (std::optional<ShaderError> error = checkUsable()) {
+    return *error;
+  }
+  if (blockStack_.empty() || (blockStack_.back().kind != BlockFrame::Kind::IfThen &&
+                              blockStack_.back().kind != BlockFrame::Kind::IfElse)) {
+    return fail(Err("endIf without an open if", function_.name));
+  }
+
+  BlockFrame frame = std::move(blockStack_.back());
+  blockStack_.pop_back();
+
+  IrStmt::Data data;
+  data.kind = IrStmt::Kind::If;
+  data.exprs = {*frame.condition};
+  if (frame.kind == BlockFrame::Kind::IfElse) {
+    data.body = std::move(frame.thenStatements);
+    data.elseBody = std::move(frame.statements);
+  } else {
+    data.body = std::move(frame.statements);
+  }
+  append(IrStmt(std::move(data)));
+  return OkShaderStatus();
+}
+
+ShaderResult<IrExpr> FunctionBuilder::beginFor(const RcString& name, const IrExpr& init) {
+  if (std::optional<ShaderError> error = checkUsable()) {
+    return *error;
+  }
+  if (ShaderStatus status = declareName(name, init.type(), RefKind::Var); status.hasError()) {
+    return std::move(status).error();
+  }
+
+  IrStmt::Data initData;
+  initData.kind = IrStmt::Kind::Var;
+  initData.name = name;
+  initData.declaredType = init.type();
+  initData.exprs = {init};
+
+  BlockFrame frame;
+  frame.kind = BlockFrame::Kind::ForBody;
+  frame.init = IrStmt(std::move(initData));
+  blockStack_.push_back(std::move(frame));
+  return MakeRef(RefKind::Var, name, init.type());
+}
+
+ShaderStatus FunctionBuilder::forCondition(const IrExpr& condition) {
+  if (std::optional<ShaderError> error = checkUsable()) {
+    return *error;
+  }
+  if (blockStack_.empty() || blockStack_.back().kind != BlockFrame::Kind::ForBody) {
+    return fail(Err("forCondition without an open for", function_.name));
+  }
+  if (!(condition.type() == IrType::Bool())) {
+    return fail(Err(std::format("for condition must be bool, got {}", condition.type().toString()),
+                    function_.name));
+  }
+  if (blockStack_.back().forCondition) {
+    return fail(Err("for condition already set", function_.name));
+  }
+  blockStack_.back().forCondition = condition;
+  return OkShaderStatus();
+}
+
+ShaderStatus FunctionBuilder::forContinuing(const IrExpr& lhs, const IrExpr& rhs) {
+  if (std::optional<ShaderError> error = checkUsable()) {
+    return *error;
+  }
+  if (blockStack_.empty() || blockStack_.back().kind != BlockFrame::Kind::ForBody) {
+    return fail(Err("forContinuing without an open for", function_.name));
+  }
+  if (!lhs.isMutableLvalue() || !(lhs.type() == rhs.type())) {
+    return fail(Err("for continuing must be a type-correct assignment to a mutable lvalue",
+                    function_.name));
+  }
+  if (blockStack_.back().continuing) {
+    return fail(Err("for continuing already set", function_.name));
+  }
+
+  IrStmt::Data data;
+  data.kind = IrStmt::Kind::Assign;
+  data.exprs = {lhs, rhs};
+  blockStack_.back().continuing = IrStmt(std::move(data));
+  blockStack_.back().forHeaderComplete = true;
+  return OkShaderStatus();
+}
+
+ShaderStatus FunctionBuilder::endFor() {
+  if (std::optional<ShaderError> error = checkUsable()) {
+    return *error;
+  }
+  if (blockStack_.empty() || blockStack_.back().kind != BlockFrame::Kind::ForBody) {
+    return fail(Err("endFor without an open for", function_.name));
+  }
+
+  BlockFrame frame = std::move(blockStack_.back());
+  blockStack_.pop_back();
+
+  IrStmt::Data data;
+  data.kind = IrStmt::Kind::For;
+  if (frame.forCondition) {
+    data.exprs = {*frame.forCondition};
+  }
+  data.body = std::move(frame.statements);
+  if (frame.init) {
+    data.init = std::make_shared<const IrStmt>(std::move(*frame.init));
+  }
+  if (frame.continuing) {
+    data.continuing = std::make_shared<const IrStmt>(std::move(*frame.continuing));
+  }
+  append(IrStmt(std::move(data)));
+  return OkShaderStatus();
+}
+
+ShaderStatus FunctionBuilder::breakStmt() {
+  if (std::optional<ShaderError> error = checkUsable()) {
+    return *error;
+  }
+  if (!insideLoop()) {
+    return fail(Err("break outside of a loop", function_.name));
+  }
+  IrStmt::Data data;
+  data.kind = IrStmt::Kind::Break;
+  append(IrStmt(std::move(data)));
+  return OkShaderStatus();
+}
+
+ShaderStatus FunctionBuilder::continueStmt() {
+  if (std::optional<ShaderError> error = checkUsable()) {
+    return *error;
+  }
+  if (!insideLoop()) {
+    return fail(Err("continue outside of a loop", function_.name));
+  }
+  IrStmt::Data data;
+  data.kind = IrStmt::Kind::Continue;
+  append(IrStmt(std::move(data)));
+  return OkShaderStatus();
+}
+
+ShaderStatus FunctionBuilder::returnValue(const IrExpr& value) {
+  if (std::optional<ShaderError> error = checkUsable()) {
+    return *error;
+  }
+  if (function_.stage != StageKind::None) {
+    return fail(Err("entry points return their outputs via returnOutputs", function_.name));
+  }
+  if (!function_.returnType || !(value.type() == *function_.returnType)) {
+    return fail(Err(std::format("return type mismatch: function returns {}, got {}",
+                                function_.returnType ? function_.returnType->toString() : "void",
+                                value.type().toString()),
+                    function_.name));
+  }
+
+  IrStmt::Data data;
+  data.kind = IrStmt::Kind::Return;
+  data.exprs = {value};
+  append(IrStmt(std::move(data)));
+  return OkShaderStatus();
+}
+
+ShaderStatus FunctionBuilder::returnVoid() {
+  if (std::optional<ShaderError> error = checkUsable()) {
+    return *error;
+  }
+  if (function_.stage != StageKind::None || function_.returnType) {
+    return fail(Err("returnVoid requires a void plain function", function_.name));
+  }
+  IrStmt::Data data;
+  data.kind = IrStmt::Kind::Return;
+  append(IrStmt(std::move(data)));
+  return OkShaderStatus();
+}
+
+ShaderStatus FunctionBuilder::returnOutputs(std::vector<IrExpr> outputs) {
+  if (std::optional<ShaderError> error = checkUsable()) {
+    return *error;
+  }
+  if (function_.stage == StageKind::None) {
+    return fail(Err("returnOutputs requires an entry point", function_.name));
+  }
+  if (outputs.size() != function_.outputs.size()) {
+    return fail(Err(std::format("entry point declares {} outputs, got {}", function_.outputs.size(),
+                                outputs.size()),
+                    function_.name));
+  }
+  for (size_t i = 0; i < outputs.size(); ++i) {
+    if (!(outputs[i].type() == function_.outputs[i].type)) {
+      return fail(
+          Err(std::format("output {} ({}) type mismatch: declared {}, got {}", i,
+                          function_.outputs[i].name.str(), function_.outputs[i].type.toString(),
+                          outputs[i].type().toString()),
+              function_.name));
+    }
+  }
+
+  IrStmt::Data data;
+  data.kind = IrStmt::Kind::Return;
+  data.exprs = std::move(outputs);
+  append(IrStmt(std::move(data)));
+  return OkShaderStatus();
+}
+
+ShaderStatus FunctionBuilder::discard() {
+  if (std::optional<ShaderError> error = checkUsable()) {
+    return *error;
+  }
+  if (function_.stage != StageKind::Fragment) {
+    return fail(Err("discard is only valid in fragment entry points", function_.name));
+  }
+  IrStmt::Data data;
+  data.kind = IrStmt::Kind::Discard;
+  append(IrStmt(std::move(data)));
+  return OkShaderStatus();
+}
+
+ShaderResult<IrExpr> FunctionBuilder::callFunction(const RcString& name, std::vector<IrExpr> args) {
+  if (std::optional<ShaderError> error = checkUsable()) {
+    return *error;
+  }
+  const IrFunction* callee = moduleBuilder_->findFunction(name);
+  if (callee == nullptr || callee->stage != StageKind::None) {
+    ShaderStatus status = fail(Err(std::format("unknown function {}", name.str()), function_.name));
+    return std::move(status).error();
+  }
+  if (!callee->returnType) {
+    ShaderStatus status = fail(
+        Err(std::format("function {} returns void and cannot be used as an expression", name.str()),
+            function_.name));
+    return std::move(status).error();
+  }
+  if (args.size() != callee->params.size()) {
+    ShaderStatus status = fail(Err(std::format("function {} takes {} arguments, got {}", name.str(),
+                                               callee->params.size(), args.size()),
+                                   function_.name));
+    return std::move(status).error();
+  }
+  for (size_t i = 0; i < args.size(); ++i) {
+    if (!(args[i].type() == callee->params[i].type)) {
+      ShaderStatus status = fail(
+          Err(std::format("function {} argument {} type mismatch: expected {}, got {}", name.str(),
+                          i, callee->params[i].type.toString(), args[i].type().toString()),
+              function_.name));
+      return std::move(status).error();
+    }
+  }
+
+  return MakeCallUser(name, *callee->returnType, std::move(args));
+}
+
+ShaderStatus FunctionBuilder::finish() {
+  if (firstError_) {
+    return *firstError_;
+  }
+  if (finished_) {
+    return ShaderError{"function already finished", function_.name};
+  }
+  if (!blockStack_.empty()) {
+    return fail(Err("finish with an open if/for block", function_.name));
+  }
+
+  finished_ = true;
+  moduleBuilder_->registerFunction(std::move(function_));
+  return OkShaderStatus();
+}
+
+// ============================================================================
+// ModuleBuilder
+// ============================================================================
+
+ShaderStatus ModuleBuilder::checkModuleName(const RcString& name) {
+  for (const IrConstant& constant : module_.constants_) {
+    if (constant.name == name) {
+      return ShaderError{std::format("module-scope name {} already exists", name.str()), name};
+    }
+  }
+  for (const IrBinding& binding : module_.bindings_) {
+    if (binding.name == name) {
+      return ShaderError{std::format("module-scope name {} already exists", name.str()), name};
+    }
+  }
+  for (const IrFunction& function : module_.functions_) {
+    if (function.name == name) {
+      return ShaderError{std::format("module-scope name {} already exists", name.str()), name};
+    }
+  }
+  return OkShaderStatus();
+}
+
+ShaderStatus ModuleBuilder::addConstant(const RcString& name, const IrExpr& value) {
+  if (ShaderStatus status = checkModuleName(name); status.hasError()) {
+    return status;
+  }
+  if (value.kind() != IrExpr::Kind::Literal) {
+    return ShaderError{"module-scope constants must be literals", name};
+  }
+  module_.constants_.push_back(IrConstant{name, value});
+  return OkShaderStatus();
+}
+
+ShaderStatus ModuleBuilder::addBinding(IrBinding&& binding) {
+  if (ShaderStatus status = checkModuleName(binding.name); status.hasError()) {
+    return status;
+  }
+  for (const IrBinding& existing : module_.bindings_) {
+    if (existing.group == binding.group && existing.binding == binding.binding) {
+      return ShaderError{std::format("binding (group={}, binding={}) is already in use by {}",
+                                     binding.group, binding.binding, existing.name.str()),
+                         binding.name};
+    }
+  }
+  module_.bindings_.push_back(std::move(binding));
+  return OkShaderStatus();
+}
+
+ShaderStatus ModuleBuilder::addUniformBuffer(uint32_t group, uint32_t binding, const RcString& name,
+                                             const IrType& structType) {
+  if (structType.kind() != IrType::Kind::Struct) {
+    return ShaderError{
+        std::format("uniform buffer type must be a struct, got {}", structType.toString()), name};
+  }
+  return addBinding(IrBinding{group, binding, name, BindingKind::UniformBuffer, structType});
+}
+
+ShaderStatus ModuleBuilder::addReadOnlyStorageBuffer(uint32_t group, uint32_t binding,
+                                                     const RcString& name, const IrType& type) {
+  if (type.kind() != IrType::Kind::RuntimeArray && type.kind() != IrType::Kind::Struct) {
+    return ShaderError{std::format("storage buffer type must be a runtime array or struct, got {}",
+                                   type.toString()),
+                       name};
+  }
+  return addBinding(IrBinding{group, binding, name, BindingKind::ReadOnlyStorageBuffer, type});
+}
+
+ShaderStatus ModuleBuilder::addTexture2d(uint32_t group, uint32_t binding, const RcString& name) {
+  return addBinding(
+      IrBinding{group, binding, name, BindingKind::SampledTexture2dF32, IrType::Texture2dF32()});
+}
+
+ShaderStatus ModuleBuilder::addSampler(uint32_t group, uint32_t binding, const RcString& name) {
+  return addBinding(
+      IrBinding{group, binding, name, BindingKind::FilteringSampler, IrType::SamplerType()});
+}
+
+std::optional<IrExpr> ModuleBuilder::resolveModuleName(const RcString& name) const {
+  for (const IrConstant& constant : module_.constants_) {
+    if (constant.name == name) {
+      return MakeRef(RefKind::Constant, name, constant.value.type());
+    }
+  }
+  for (const IrBinding& binding : module_.bindings_) {
+    if (binding.name == name) {
+      return MakeRef(RefKind::Resource, name, binding.type);
+    }
+  }
+  return std::nullopt;
+}
+
+const IrFunction* ModuleBuilder::findFunction(const RcString& name) const {
+  for (const IrFunction& function : module_.functions_) {
+    if (function.name == name) {
+      return &function;
+    }
+  }
+  return nullptr;
+}
+
+void ModuleBuilder::registerFunction(IrFunction&& function) {
+  module_.functions_.push_back(std::move(function));
+  functionInProgress_ = false;
+}
+
+ShaderResult<FunctionBuilder> ModuleBuilder::createFunction(
+    const RcString& name, std::vector<IrParam> params, const std::optional<IrType>& returnType) {
+  if (functionInProgress_) {
+    return ShaderError{"finish the previous function before starting a new one", name};
+  }
+  if (ShaderStatus status = checkModuleName(name); status.hasError()) {
+    return std::move(status).error();
+  }
+  for (size_t i = 0; i < params.size(); ++i) {
+    for (size_t j = i + 1; j < params.size(); ++j) {
+      if (params[j].name == params[i].name) {
+        return ShaderError{std::format("duplicate parameter name {}", params[i].name.str()), name};
+      }
+    }
+  }
+
+  IrFunction function;
+  function.name = name;
+  function.stage = StageKind::None;
+  function.params = std::move(params);
+  function.returnType = returnType;
+  functionInProgress_ = true;
+  return FunctionBuilder(*this, std::move(function));
+}
+
+ShaderResult<FunctionBuilder> ModuleBuilder::createVertexEntryPoint(
+    const RcString& name, std::vector<IrParam> params, std::vector<IrOutputMember> outputs) {
+  if (functionInProgress_) {
+    return ShaderError{"finish the previous function before starting a new one", name};
+  }
+  if (ShaderStatus status = checkModuleName(name); status.hasError()) {
+    return std::move(status).error();
+  }
+  if (ShaderStatus status = ValidateStageIo(params, name); status.hasError()) {
+    return std::move(status).error();
+  }
+  if (ShaderStatus status = ValidateStageIo(outputs, name); status.hasError()) {
+    return std::move(status).error();
+  }
+  for (const IrParam& param : params) {
+    if (param.builtin) {
+      if (*param.builtin != BuiltinInput::InstanceIndex || !(param.type == IrType::U32())) {
+        return ShaderError{
+            std::format("vertex builtin input {} must be instance_index: u32", param.name.str()),
+            name};
+      }
+    } else if (!param.location) {
+      return ShaderError{
+          std::format("vertex input {} needs a location or builtin", param.name.str()), name};
+    }
+  }
+  size_t positionCount = 0;
+  for (const IrOutputMember& output : outputs) {
+    if (output.builtin) {
+      if (*output.builtin != BuiltinOutput::Position || !(output.type == IrType::Vec4f())) {
+        return ShaderError{
+            std::format("vertex builtin output {} must be position: vec4<f32>", output.name.str()),
+            name};
+      }
+      ++positionCount;
+    } else if (!output.location) {
+      return ShaderError{
+          std::format("vertex output {} needs a location or builtin", output.name.str()), name};
+    }
+  }
+  if (positionCount != 1) {
+    return ShaderError{"vertex entry points need exactly one position builtin output", name};
+  }
+
+  IrFunction function;
+  function.name = name;
+  function.stage = StageKind::Vertex;
+  function.params = std::move(params);
+  function.outputs = std::move(outputs);
+  functionInProgress_ = true;
+  return FunctionBuilder(*this, std::move(function));
+}
+
+ShaderResult<FunctionBuilder> ModuleBuilder::createFragmentEntryPoint(
+    const RcString& name, std::vector<IrParam> params, std::vector<IrOutputMember> outputs) {
+  if (functionInProgress_) {
+    return ShaderError{"finish the previous function before starting a new one", name};
+  }
+  if (ShaderStatus status = checkModuleName(name); status.hasError()) {
+    return std::move(status).error();
+  }
+  if (ShaderStatus status = ValidateStageIo(params, name); status.hasError()) {
+    return std::move(status).error();
+  }
+  if (ShaderStatus status = ValidateStageIo(outputs, name); status.hasError()) {
+    return std::move(status).error();
+  }
+  for (const IrParam& param : params) {
+    if (param.builtin || !param.location) {
+      return ShaderError{std::format("fragment input {} must have a location", param.name.str()),
+                         name};
+    }
+  }
+  bool hasColorOutput = false;
+  for (const IrOutputMember& output : outputs) {
+    if (output.builtin || !output.location) {
+      return ShaderError{std::format("fragment output {} must have a location", output.name.str()),
+                         name};
+    }
+    if (*output.location == 0 && output.type == IrType::Vec4f()) {
+      hasColorOutput = true;
+    }
+  }
+  if (!hasColorOutput) {
+    return ShaderError{"fragment entry points need a location-0 vec4<f32> color output", name};
+  }
+
+  IrFunction function;
+  function.name = name;
+  function.stage = StageKind::Fragment;
+  function.params = std::move(params);
+  function.outputs = std::move(outputs);
+  functionInProgress_ = true;
+  return FunctionBuilder(*this, std::move(function));
+}
+
+ShaderResult<IrModule> ModuleBuilder::build() {
+  if (functionInProgress_) {
+    return ShaderError{"finish the in-progress function before building the module", "module"};
+  }
+  return std::move(module_);
+}
+
+}  // namespace donner::gpu::shader

--- a/donner/gpu/shader/IrModule.cc
+++ b/donner/gpu/shader/IrModule.cc
@@ -16,6 +16,15 @@ ShaderError Err(std::string message, const RcString& label) {
 template <typename IoList>
 ShaderStatus ValidateStageIo(const IoList& io, const RcString& label) {
   for (size_t i = 0; i < io.size(); ++i) {
+    if (io[i].builtin) {
+      for (size_t j = i + 1; j < io.size(); ++j) {
+        if (io[j].builtin && *io[j].builtin == *io[i].builtin) {
+          return Err(std::format("duplicate stage IO builtin on {} and {}", io[i].name.str(),
+                                 io[j].name.str()),
+                     label);
+        }
+      }
+    }
     if (io[i].location) {
       if (!io[i].type.isNumeric()) {
         return Err(std::format("stage IO {} must be a numeric scalar or vector, got {}",
@@ -100,6 +109,38 @@ ShaderStatus FunctionBuilder::declareName(const RcString& name, const IrType& ty
                     function_.name));
   }
   locals_.emplace(name, std::make_pair(type, kind));
+  if (!blockStack_.empty()) {
+    blockStack_.back().declaredNames.push_back(name);
+  }
+  return OkShaderStatus();
+}
+
+void FunctionBuilder::removeScopedNames(std::vector<RcString>& names) {
+  for (const RcString& name : names) {
+    locals_.erase(name);
+  }
+  names.clear();
+}
+
+ShaderStatus FunctionBuilder::verifyExprInScope(const IrExpr& expr) {
+  std::vector<IrExpr::RefInfo> refs;
+  expr.collectRefs(refs);
+  for (const IrExpr::RefInfo& ref : refs) {
+    if (ref.kind == RefKind::Constant || ref.kind == RefKind::Resource) {
+      if (!moduleBuilder_->resolveModuleName(ref.name)) {
+        return fail(
+            Err(std::format("expression references unknown module-scope name {}", ref.name.str()),
+                function_.name));
+      }
+      continue;
+    }
+    const auto it = locals_.find(ref.name);
+    if (it == locals_.end() || it->second.second != ref.kind || !(it->second.first == ref.type)) {
+      return fail(
+          Err(std::format("expression references {} which is out of scope here", ref.name.str()),
+              function_.name));
+    }
+  }
   return OkShaderStatus();
 }
 
@@ -126,6 +167,9 @@ ShaderResult<IrExpr> FunctionBuilder::ref(const RcString& name) const {
 ShaderResult<IrExpr> FunctionBuilder::addLet(const RcString& name, const IrExpr& value) {
   if (std::optional<ShaderError> error = checkUsable()) {
     return *error;
+  }
+  if (ShaderStatus status = verifyExprInScope(value); status.hasError()) {
+    return std::move(status).error();
   }
   if (ShaderStatus status = declareName(name, value.type(), RefKind::Let); status.hasError()) {
     return std::move(status).error();
@@ -157,6 +201,11 @@ ShaderResult<IrExpr> FunctionBuilder::addVar(const RcString& name, const IrType&
                  function_.name));
     return std::move(status).error();
   }
+  if (init) {
+    if (ShaderStatus status = verifyExprInScope(*init); status.hasError()) {
+      return std::move(status).error();
+    }
+  }
   if (ShaderStatus status = declareName(name, type, RefKind::Var); status.hasError()) {
     return std::move(status).error();
   }
@@ -175,6 +224,12 @@ ShaderResult<IrExpr> FunctionBuilder::addVar(const RcString& name, const IrType&
 ShaderStatus FunctionBuilder::assign(const IrExpr& lhs, const IrExpr& rhs) {
   if (std::optional<ShaderError> error = checkUsable()) {
     return *error;
+  }
+  if (ShaderStatus status = verifyExprInScope(lhs); status.hasError()) {
+    return status;
+  }
+  if (ShaderStatus status = verifyExprInScope(rhs); status.hasError()) {
+    return status;
   }
   if (!lhs.isMutableLvalue()) {
     return fail(
@@ -223,6 +278,7 @@ ShaderStatus FunctionBuilder::elseBranch() {
   frame.kind = BlockFrame::Kind::IfElse;
   frame.thenStatements = std::move(frame.statements);
   frame.statements.clear();
+  removeScopedNames(frame.declaredNames);
   return OkShaderStatus();
 }
 
@@ -237,6 +293,7 @@ ShaderStatus FunctionBuilder::endIf() {
 
   BlockFrame frame = std::move(blockStack_.back());
   blockStack_.pop_back();
+  removeScopedNames(frame.declaredNames);
 
   IrStmt::Data data;
   data.kind = IrStmt::Kind::If;
@@ -255,7 +312,7 @@ ShaderResult<IrExpr> FunctionBuilder::beginFor(const RcString& name, const IrExp
   if (std::optional<ShaderError> error = checkUsable()) {
     return *error;
   }
-  if (ShaderStatus status = declareName(name, init.type(), RefKind::Var); status.hasError()) {
+  if (ShaderStatus status = verifyExprInScope(init); status.hasError()) {
     return std::move(status).error();
   }
 
@@ -269,6 +326,13 @@ ShaderResult<IrExpr> FunctionBuilder::beginFor(const RcString& name, const IrExp
   frame.kind = BlockFrame::Kind::ForBody;
   frame.init = IrStmt(std::move(initData));
   blockStack_.push_back(std::move(frame));
+
+  // Declared after the frame is pushed so the loop variable is scoped to it and dropped at
+  // endFor.
+  if (ShaderStatus status = declareName(name, init.type(), RefKind::Var); status.hasError()) {
+    blockStack_.pop_back();
+    return std::move(status).error();
+  }
   return MakeRef(RefKind::Var, name, init.type());
 }
 
@@ -309,7 +373,6 @@ ShaderStatus FunctionBuilder::forContinuing(const IrExpr& lhs, const IrExpr& rhs
   data.kind = IrStmt::Kind::Assign;
   data.exprs = {lhs, rhs};
   blockStack_.back().continuing = IrStmt(std::move(data));
-  blockStack_.back().forHeaderComplete = true;
   return OkShaderStatus();
 }
 
@@ -323,6 +386,7 @@ ShaderStatus FunctionBuilder::endFor() {
 
   BlockFrame frame = std::move(blockStack_.back());
   blockStack_.pop_back();
+  removeScopedNames(frame.declaredNames);
 
   IrStmt::Data data;
   data.kind = IrStmt::Kind::For;
@@ -485,6 +549,15 @@ ShaderStatus FunctionBuilder::finish() {
   }
   if (!blockStack_.empty()) {
     return fail(Err("finish with an open if/for block", function_.name));
+  }
+
+  // Conservative structural check: a non-void function or entry point must end with a
+  // top-level return statement (returns inside if/for bodies do not count).
+  const bool needsReturn = function_.stage != StageKind::None || function_.returnType.has_value();
+  if (needsReturn &&
+      (function_.body.empty() || function_.body.back().kind() != IrStmt::Kind::Return)) {
+    return fail(Err("non-void functions and entry points must end with a return statement",
+                    function_.name));
   }
 
   finished_ = true;

--- a/donner/gpu/shader/IrModule.cc
+++ b/donner/gpu/shader/IrModule.cc
@@ -16,6 +16,11 @@ ShaderError Err(std::string message, const RcString& label) {
 template <typename IoList>
 ShaderStatus ValidateStageIo(const IoList& io, const RcString& label) {
   for (size_t i = 0; i < io.size(); ++i) {
+    if (io[i].builtin && io[i].location) {
+      return Err(
+          std::format("stage IO {} must not carry both a location and a builtin", io[i].name.str()),
+          label);
+    }
     if (io[i].builtin) {
       for (size_t j = i + 1; j < io.size(); ++j) {
         if (io[j].builtin && *io[j].builtin == *io[i].builtin) {
@@ -52,6 +57,60 @@ std::ostream& operator<<(std::ostream& os, BindingKind value) {
   }
   return os << "unknown";
 }
+
+namespace {
+
+/// True if \p fn takes implicit derivatives and is therefore fragment-only in WGSL.
+bool IsFragmentOnlyBuiltin(BuiltinFn fn) {
+  return fn == BuiltinFn::Fwidth || fn == BuiltinFn::TextureSample;
+}
+
+/// Recursively determines whether \p block calls a fragment-only builtin, following user calls
+/// through \p lookupFunction (callees are always finished, and therefore flagged, before their
+/// callers can reference them).
+template <typename LookupFn>
+bool BlockUsesFragmentOnlyBuiltins(const IrBlock& block, const LookupFn& lookupFunction) {
+  const auto exprUses = [&](const IrExpr& expr) {
+    std::vector<BuiltinFn> builtins;
+    expr.collectBuiltinCalls(builtins);
+    for (const BuiltinFn fn : builtins) {
+      if (IsFragmentOnlyBuiltin(fn)) {
+        return true;
+      }
+    }
+    std::vector<RcString> callees;
+    expr.collectUserCalls(callees);
+    for (const RcString& callee : callees) {
+      const IrFunction* function = lookupFunction(callee);
+      if (function != nullptr && function->usesFragmentOnlyBuiltins) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  for (const IrStmt& statement : block) {
+    const IrStmt::Data& data = statement.data();
+    for (const IrExpr& expr : data.exprs) {
+      if (exprUses(expr)) {
+        return true;
+      }
+    }
+    if (data.init && BlockUsesFragmentOnlyBuiltins({*data.init}, lookupFunction)) {
+      return true;
+    }
+    if (data.continuing && BlockUsesFragmentOnlyBuiltins({*data.continuing}, lookupFunction)) {
+      return true;
+    }
+    if (BlockUsesFragmentOnlyBuiltins(data.body, lookupFunction) ||
+        BlockUsesFragmentOnlyBuiltins(data.elseBody, lookupFunction)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
 
 // ============================================================================
 // FunctionBuilder
@@ -368,6 +427,33 @@ ShaderStatus FunctionBuilder::forContinuing(const IrExpr& lhs, const IrExpr& rhs
   if (blockStack_.back().continuing) {
     return fail(Err("for continuing already set", function_.name));
   }
+  if (ShaderStatus status = verifyExprInScope(lhs); status.hasError()) {
+    return status;
+  }
+  if (ShaderStatus status = verifyExprInScope(rhs); status.hasError()) {
+    return status;
+  }
+  // Our for-loop model closes the body block before the update expression runs, so the update
+  // may reference the loop variable and enclosing scope only, never body-block locals (unlike a
+  // raw WGSL loop/continuing, where the continuing block nests inside the body scope).
+  {
+    const BlockFrame& frame = blockStack_.back();
+    const RcString loopVarName = frame.init ? frame.init->data().name : RcString();
+    std::vector<IrExpr::RefInfo> refs;
+    lhs.collectRefs(refs);
+    rhs.collectRefs(refs);
+    for (const IrExpr::RefInfo& ref : refs) {
+      for (const RcString& bodyName : frame.declaredNames) {
+        if (ref.name == bodyName && ref.name != loopVarName) {
+          return fail(Err(
+              std::format("for continuing references body-block local {}; the update expression "
+                          "may reference the loop variable and enclosing scope only",
+                          ref.name.str()),
+              function_.name));
+        }
+      }
+    }
+  }
 
   IrStmt::Data data;
   data.kind = IrStmt::Kind::Assign;
@@ -444,6 +530,10 @@ ShaderStatus FunctionBuilder::returnValue(const IrExpr& value) {
                     function_.name));
   }
 
+  if (ShaderStatus status = verifyExprInScope(value); status.hasError()) {
+    return status;
+  }
+
   IrStmt::Data data;
   data.kind = IrStmt::Kind::Return;
   data.exprs = {value};
@@ -483,6 +573,9 @@ ShaderStatus FunctionBuilder::returnOutputs(std::vector<IrExpr> outputs) {
                           function_.outputs[i].name.str(), function_.outputs[i].type.toString(),
                           outputs[i].type().toString()),
               function_.name));
+    }
+    if (ShaderStatus status = verifyExprInScope(outputs[i]); status.hasError()) {
+      return status;
     }
   }
 
@@ -558,6 +651,20 @@ ShaderStatus FunctionBuilder::finish() {
       (function_.body.empty() || function_.body.back().kind() != IrStmt::Kind::Return)) {
     return fail(Err("non-void functions and entry points must end with a return statement",
                     function_.name));
+  }
+
+  // Stage restriction for implicit-derivative builtins: fwidth and textureSample are
+  // fragment-only in WGSL. Each function records whether its body (or any user function it
+  // calls, transitively - callees are always finished before their callers) uses one; vertex
+  // entry points with the flag fail closed. Fragment entry points and plain functions may carry
+  // the flag freely.
+  function_.usesFragmentOnlyBuiltins = BlockUsesFragmentOnlyBuiltins(
+      function_.body, [this](const RcString& name) { return moduleBuilder_->findFunction(name); });
+  if (function_.stage == StageKind::Vertex && function_.usesFragmentOnlyBuiltins) {
+    return fail(
+        Err("vertex entry points cannot use fragment-only builtins (fwidth and "
+            "textureSample take implicit derivatives)",
+            function_.name));
   }
 
   finished_ = true;

--- a/donner/gpu/shader/IrModule.h
+++ b/donner/gpu/shader/IrModule.h
@@ -51,6 +51,7 @@ enum class StageKind : uint8_t {
 /// Builtin input values available to entry point parameters.
 enum class BuiltinInput : uint8_t {
   InstanceIndex,  //!< `instance_index` (vertex stage, u32).
+  Position,       //!< Framebuffer position (fragment stage, vec4<f32>).
 };
 
 /// Builtin output values available to entry point outputs.

--- a/donner/gpu/shader/IrModule.h
+++ b/donner/gpu/shader/IrModule.h
@@ -1,0 +1,410 @@
+#pragma once
+/// @file
+/// Module model and validating builders for the \c donner::gpu::shader IR.
+///
+/// A module holds module-scope constants, resource bindings, and functions (plain functions
+/// plus vertex/fragment entry points). \c ModuleBuilder and \c FunctionBuilder validate every
+/// construction step and fail closed with \ref ShaderError on ill-typed input; a successfully
+/// built \c IrModule is immutable and serializes deterministically.
+///
+/// Compute entry points are intentionally out of scope for this packet; \c StageKind leaves the
+/// seam (a Compute enumerator would slot next to Vertex/Fragment, with workgroup-size metadata
+/// on IrFunction) for the filter-engine migration packets.
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "donner/base/RcString.h"
+#include "donner/gpu/shader/IrExpr.h"
+#include "donner/gpu/shader/IrStatement.h"
+#include "donner/gpu/shader/IrType.h"
+#include "donner/gpu/shader/ShaderResult.h"
+
+namespace donner::gpu::shader {
+
+class ModuleBuilder;
+class FunctionBuilder;
+
+/// Kind of a module-scope resource binding.
+enum class BindingKind : uint8_t {
+  UniformBuffer,          //!< `var<uniform>` with a struct type.
+  ReadOnlyStorageBuffer,  //!< `var<storage, read>` with a runtime array or struct type.
+  SampledTexture2dF32,    //!< `texture_2d<f32>`.
+  FilteringSampler,       //!< `sampler`.
+};
+
+/// Ostream output operator, e.g. `uniform`. @param os Output stream. @param value Value to
+/// output.
+std::ostream& operator<<(std::ostream& os, BindingKind value);
+
+/// Pipeline stage of a function.
+enum class StageKind : uint8_t {
+  None,      //!< Plain (non-entry-point) function.
+  Vertex,    //!< Vertex entry point.
+  Fragment,  //!< Fragment entry point.
+};
+
+/// Builtin input values available to entry point parameters.
+enum class BuiltinInput : uint8_t {
+  InstanceIndex,  //!< `instance_index` (vertex stage, u32).
+};
+
+/// Builtin output values available to entry point outputs.
+enum class BuiltinOutput : uint8_t {
+  Position,  //!< Clip-space position (vertex stage, vec4<f32>).
+};
+
+/// One module-scope constant.
+struct IrConstant {
+  RcString name;  //!< Constant name.
+  IrExpr value;   //!< Literal value (determines the type).
+};
+
+/// One module-scope resource binding.
+struct IrBinding {
+  uint32_t group = 0;                             //!< Bind group index.
+  uint32_t binding = 0;                           //!< Binding index within the group.
+  RcString name;                                  //!< Binding variable name.
+  BindingKind kind = BindingKind::UniformBuffer;  //!< Binding kind.
+  IrType type;  //!< Bound type (struct, runtime array, texture, or sampler).
+};
+
+/// One entry point parameter or plain function parameter.
+struct IrParam {
+  RcString name;                        //!< Parameter name.
+  IrType type;                          //!< Parameter type.
+  std::optional<uint32_t> location;     //!< Stage IO location (entry points).
+  std::optional<BuiltinInput> builtin;  //!< Builtin input (entry points).
+};
+
+/// One entry point output member.
+struct IrOutputMember {
+  RcString name;                         //!< Output name.
+  IrType type;                           //!< Output type.
+  std::optional<uint32_t> location;      //!< Stage IO location.
+  std::optional<BuiltinOutput> builtin;  //!< Builtin output.
+};
+
+/// One function: a plain function or an entry point.
+struct IrFunction {
+  RcString name;                        //!< Function name.
+  StageKind stage = StageKind::None;    //!< Stage kind.
+  std::vector<IrParam> params;          //!< Parameters, in order.
+  std::optional<IrType> returnType;     //!< Plain function return type (empty = void).
+  std::vector<IrOutputMember> outputs;  //!< Entry point outputs (empty for plain functions).
+  IrBlock body;                         //!< Function body.
+};
+
+/**
+ * An immutable, validated shader IR module.
+ */
+class IrModule {
+public:
+  /// Module-scope constants, in declaration order.
+  const std::vector<IrConstant>& constants() const { return constants_; }
+  /// Resource bindings, in declaration order.
+  const std::vector<IrBinding>& bindings() const { return bindings_; }
+  /// Functions (including entry points), in declaration order.
+  const std::vector<IrFunction>& functions() const { return functions_; }
+
+  /**
+   * Serializes the module to a stable, line-based text dump for golden tests and debugging.
+   * Byte-identical across runs and across semantically identical construction orderings:
+   * iteration follows declaration order and the output contains no pointers or addresses.
+   */
+  std::string serialize() const;
+
+private:
+  friend class ModuleBuilder;
+
+  IrModule() = default;
+
+  std::vector<IrConstant> constants_;
+  std::vector<IrBinding> bindings_;
+  std::vector<IrFunction> functions_;
+};
+
+/**
+ * Builds one function or entry point. Created by \c ModuleBuilder; validates scope, types,
+ * loop/stage context, and stage IO before recording statements. The first error latches: every
+ * subsequent operation and \ref finish return it, so an ill-typed build cannot silently succeed.
+ */
+class FunctionBuilder {
+public:
+  /// Move constructor; \p other becomes an inert moved-from shell.
+  /// @param other Builder to move from.
+  FunctionBuilder(FunctionBuilder&& other) noexcept;
+  FunctionBuilder(const FunctionBuilder&) = delete;
+  FunctionBuilder& operator=(const FunctionBuilder&) = delete;
+  FunctionBuilder& operator=(FunctionBuilder&&) = delete;
+  /// Destructor. Destroying an unfinished builder abandons the function, letting the module
+  /// builder start a new one (the abandoned function is not registered).
+  ~FunctionBuilder();
+
+  /**
+   * Resolves \p name to a reference expression: function parameters, lets, vars, then
+   * module-scope constants and resource bindings.
+   *
+   * @param name Name to resolve.
+   */
+  ShaderResult<IrExpr> ref(const RcString& name) const;
+
+  /**
+   * Declares `let name = value;` and returns a reference to it.
+   *
+   * @param name Binding name; must be unique within the function.
+   * @param value Initializer.
+   */
+  ShaderResult<IrExpr> addLet(const RcString& name, const IrExpr& value);
+
+  /**
+   * Declares `var name: type (= init);` and returns a (mutable) reference to it.
+   *
+   * @param name Variable name; must be unique within the function.
+   * @param type Declared type; must be plain data.
+   * @param init Optional initializer; must match \p type.
+   */
+  ShaderResult<IrExpr> addVar(const RcString& name, const IrType& type,
+                              const std::optional<IrExpr>& init = std::nullopt);
+
+  /**
+   * Records `lhs = rhs;`. \p lhs must be a mutable lvalue (a `var` or a member/index/
+   * single-component-swizzle chain rooted at one) and types must match.
+   *
+   * @param lhs Assignment target.
+   * @param rhs Value.
+   */
+  ShaderStatus assign(const IrExpr& lhs, const IrExpr& rhs);
+
+  /**
+   * Opens `if (condition) { ... }`. Statements recorded until \ref elseBranch or \ref endIf go
+   * to the then-branch.
+   *
+   * @param condition Bool condition.
+   */
+  ShaderStatus beginIf(const IrExpr& condition);
+  /// Switches the innermost open `if` to its else-branch.
+  ShaderStatus elseBranch();
+  /// Closes the innermost open `if`.
+  ShaderStatus endIf();
+
+  /**
+   * Opens `for (var name = init; ...)` and returns a reference to the loop variable. Follow
+   * with \ref forCondition and \ref forContinuing, then body statements, then \ref endFor.
+   *
+   * @param name Loop variable name; must be unique within the function.
+   * @param init Loop variable initializer.
+   */
+  ShaderResult<IrExpr> beginFor(const RcString& name, const IrExpr& init);
+  /**
+   * Sets the condition of the innermost open `for`.
+   *
+   * @param condition Bool condition.
+   */
+  ShaderStatus forCondition(const IrExpr& condition);
+  /**
+   * Sets the continuing assignment of the innermost open `for`.
+   *
+   * @param lhs Continuing assignment target (normally the loop variable).
+   * @param rhs Continuing assignment value.
+   */
+  ShaderStatus forContinuing(const IrExpr& lhs, const IrExpr& rhs);
+  /// Closes the innermost open `for`.
+  ShaderStatus endFor();
+
+  /// Records `break;` (valid inside a loop).
+  ShaderStatus breakStmt();
+  /// Records `continue;` (valid inside a loop).
+  ShaderStatus continueStmt();
+
+  /**
+   * Records `return expr;` for a plain function with a return type.
+   *
+   * @param value Return value; must match the declared return type.
+   */
+  ShaderStatus returnValue(const IrExpr& value);
+  /// Records `return;` for a void plain function.
+  ShaderStatus returnVoid();
+  /**
+   * Records the entry point return: one expression per declared output member, in order.
+   *
+   * @param outputs Output values matching the entry point's output member types.
+   */
+  ShaderStatus returnOutputs(std::vector<IrExpr> outputs);
+  /// Records `discard;` (fragment entry points only).
+  ShaderStatus discard();
+
+  /**
+   * Calls a previously finished module function.
+   *
+   * @param name Callee name.
+   * @param args Arguments; must match the callee's parameter types.
+   */
+  ShaderResult<IrExpr> callFunction(const RcString& name, std::vector<IrExpr> args);
+
+  /// Finishes the function, registering it with the module builder. Fails if any prior
+  /// operation failed or a block is still open.
+  ShaderStatus finish();
+
+private:
+  friend class ModuleBuilder;
+
+  /// Frame of the open-block stack.
+  struct BlockFrame {
+    enum class Kind : uint8_t { IfThen, IfElse, ForBody } kind = Kind::IfThen;  //!< Frame kind.
+    std::optional<IrExpr> condition;                                            //!< If condition.
+    IrBlock statements;                  //!< Statements recorded into this frame.
+    IrBlock thenStatements;              //!< Completed then-branch (IfElse frames).
+    std::optional<IrStmt> init;          //!< For-loop init.
+    std::optional<IrExpr> forCondition;  //!< For-loop condition (set via forCondition()).
+    std::optional<IrStmt> continuing;    //!< For-loop continuing.
+    bool forHeaderComplete = false;      //!< True once forContinuing() was called.
+  };
+
+  FunctionBuilder(ModuleBuilder& moduleBuilder, IrFunction&& function);
+
+  /// Latches the first error and returns it.
+  ShaderStatus fail(ShaderError&& error);
+  /// Returns the latched error or nullopt.
+  std::optional<ShaderError> checkUsable() const;
+  /// Appends to the innermost open block (or the function body).
+  void append(IrStmt&& statement);
+  /// Declares a local name, rejecting duplicates.
+  ShaderStatus declareName(const RcString& name, const IrType& type, RefKind kind);
+  /// True if any enclosing open block is a loop body.
+  bool insideLoop() const;
+
+  ModuleBuilder* moduleBuilder_;
+  IrFunction function_;
+  std::optional<ShaderError> firstError_;
+  bool finished_ = false;
+  std::vector<BlockFrame> blockStack_;
+  std::map<RcString, std::pair<IrType, RefKind>> locals_;
+};
+
+/**
+ * Builds an \ref IrModule: module-scope constants, resource bindings with (group, binding)
+ * uniqueness validation, and functions.
+ */
+class ModuleBuilder {
+public:
+  /// Constructs an empty module builder.
+  ModuleBuilder() = default;
+
+  ModuleBuilder(const ModuleBuilder&) = delete;
+  ModuleBuilder& operator=(const ModuleBuilder&) = delete;
+  ModuleBuilder(ModuleBuilder&&) = delete;
+  ModuleBuilder& operator=(ModuleBuilder&&) = delete;
+  /// Destructor.
+  ~ModuleBuilder() = default;
+
+  /**
+   * Adds a module-scope constant with a literal value (e.g. a u32 sentinel).
+   *
+   * @param name Constant name; must be unique at module scope.
+   * @param value Literal expression.
+   */
+  ShaderStatus addConstant(const RcString& name, const IrExpr& value);
+
+  /**
+   * Adds a uniform buffer binding.
+   *
+   * @param group Bind group index.
+   * @param binding Binding index; (group, binding) must be unique.
+   * @param name Binding name; must be unique at module scope.
+   * @param structType Uniform struct type.
+   */
+  ShaderStatus addUniformBuffer(uint32_t group, uint32_t binding, const RcString& name,
+                                const IrType& structType);
+
+  /**
+   * Adds a read-only storage buffer binding with a runtime array or struct type.
+   *
+   * @param group Bind group index.
+   * @param binding Binding index; (group, binding) must be unique.
+   * @param name Binding name; must be unique at module scope.
+   * @param type Runtime array or struct type.
+   */
+  ShaderStatus addReadOnlyStorageBuffer(uint32_t group, uint32_t binding, const RcString& name,
+                                        const IrType& type);
+
+  /**
+   * Adds a `texture_2d<f32>` binding.
+   *
+   * @param group Bind group index.
+   * @param binding Binding index; (group, binding) must be unique.
+   * @param name Binding name; must be unique at module scope.
+   */
+  ShaderStatus addTexture2d(uint32_t group, uint32_t binding, const RcString& name);
+
+  /**
+   * Adds a filtering sampler binding.
+   *
+   * @param group Bind group index.
+   * @param binding Binding index; (group, binding) must be unique.
+   * @param name Binding name; must be unique at module scope.
+   */
+  ShaderStatus addSampler(uint32_t group, uint32_t binding, const RcString& name);
+
+  /**
+   * Starts a plain function. Finish it with `FunctionBuilder::finish()` before starting the
+   * next function.
+   *
+   * @param name Function name; must be unique at module scope.
+   * @param params Parameters (types must be plain data or texture/sampler for helpers).
+   * @param returnType Return type, or empty for void.
+   */
+  ShaderResult<FunctionBuilder> createFunction(const RcString& name, std::vector<IrParam> params,
+                                               const std::optional<IrType>& returnType);
+
+  /**
+   * Starts a vertex entry point. Parameters may carry the `instance_index` builtin (u32) or
+   * unique locations; outputs must contain exactly one `position` builtin (vec4<f32>) plus
+   * uniquely-located outputs.
+   *
+   * @param name Entry point name; must be unique at module scope.
+   * @param params Stage inputs.
+   * @param outputs Stage outputs.
+   */
+  ShaderResult<FunctionBuilder> createVertexEntryPoint(const RcString& name,
+                                                       std::vector<IrParam> params,
+                                                       std::vector<IrOutputMember> outputs);
+
+  /**
+   * Starts a fragment entry point. Parameters must have unique locations; outputs must include
+   * a location-0 `vec4<f32>` color.
+   *
+   * @param name Entry point name; must be unique at module scope.
+   * @param params Stage inputs.
+   * @param outputs Stage outputs.
+   */
+  ShaderResult<FunctionBuilder> createFragmentEntryPoint(const RcString& name,
+                                                         std::vector<IrParam> params,
+                                                         std::vector<IrOutputMember> outputs);
+
+  /// Finalizes and returns the module. Fails if any recorded error is pending.
+  ShaderResult<IrModule> build();
+
+private:
+  friend class FunctionBuilder;
+
+  /// Resolves a module-scope name (constant or binding) to a reference expression.
+  std::optional<IrExpr> resolveModuleName(const RcString& name) const;
+  /// Looks up a finished function by name.
+  const IrFunction* findFunction(const RcString& name) const;
+  /// Validates module-scope name uniqueness.
+  ShaderStatus checkModuleName(const RcString& name);
+  /// Validates (group, binding) uniqueness and registers the binding.
+  ShaderStatus addBinding(IrBinding&& binding);
+  /// Registers a finished function (called by FunctionBuilder::finish).
+  void registerFunction(IrFunction&& function);
+
+  IrModule module_;
+  bool functionInProgress_ = false;
+};
+
+}  // namespace donner::gpu::shader

--- a/donner/gpu/shader/IrModule.h
+++ b/donner/gpu/shader/IrModule.h
@@ -258,12 +258,12 @@ private:
   struct BlockFrame {
     enum class Kind : uint8_t { IfThen, IfElse, ForBody } kind = Kind::IfThen;  //!< Frame kind.
     std::optional<IrExpr> condition;                                            //!< If condition.
-    IrBlock statements;                  //!< Statements recorded into this frame.
-    IrBlock thenStatements;              //!< Completed then-branch (IfElse frames).
-    std::optional<IrStmt> init;          //!< For-loop init.
-    std::optional<IrExpr> forCondition;  //!< For-loop condition (set via forCondition()).
-    std::optional<IrStmt> continuing;    //!< For-loop continuing.
-    bool forHeaderComplete = false;      //!< True once forContinuing() was called.
+    IrBlock statements;                   //!< Statements recorded into this frame.
+    IrBlock thenStatements;               //!< Completed then-branch (IfElse frames).
+    std::optional<IrStmt> init;           //!< For-loop init.
+    std::optional<IrExpr> forCondition;   //!< For-loop condition (set via forCondition()).
+    std::optional<IrStmt> continuing;     //!< For-loop continuing.
+    std::vector<RcString> declaredNames;  //!< Names declared in this block; dropped on close.
   };
 
   FunctionBuilder(ModuleBuilder& moduleBuilder, IrFunction&& function);
@@ -274,8 +274,13 @@ private:
   std::optional<ShaderError> checkUsable() const;
   /// Appends to the innermost open block (or the function body).
   void append(IrStmt&& statement);
-  /// Declares a local name, rejecting duplicates.
+  /// Declares a local name (scoped to the innermost open block), rejecting duplicates.
   ShaderStatus declareName(const RcString& name, const IrType& type, RefKind kind);
+  /// Drops \p names from the local scope (block exit).
+  void removeScopedNames(std::vector<RcString>& names);
+  /// Re-verifies that every name referenced by \p expr is still declared with the same type and
+  /// kind, so expressions captured inside a closed block fail closed when reused outside it.
+  ShaderStatus verifyExprInScope(const IrExpr& expr);
   /// True if any enclosing open block is a loop body.
   bool insideLoop() const;
 

--- a/donner/gpu/shader/IrModule.h
+++ b/donner/gpu/shader/IrModule.h
@@ -92,12 +92,16 @@ struct IrOutputMember {
 
 /// One function: a plain function or an entry point.
 struct IrFunction {
-  RcString name;                        //!< Function name.
-  StageKind stage = StageKind::None;    //!< Stage kind.
-  std::vector<IrParam> params;          //!< Parameters, in order.
-  std::optional<IrType> returnType;     //!< Plain function return type (empty = void).
-  std::vector<IrOutputMember> outputs;  //!< Entry point outputs (empty for plain functions).
-  IrBlock body;                         //!< Function body.
+  RcString name;                          //!< Function name.
+  StageKind stage = StageKind::None;      //!< Stage kind.
+  std::vector<IrParam> params;            //!< Parameters, in order.
+  std::optional<IrType> returnType;       //!< Plain function return type (empty = void).
+  std::vector<IrOutputMember> outputs;    //!< Entry point outputs (empty for plain functions).
+  IrBlock body;                           //!< Function body.
+  bool usesFragmentOnlyBuiltins = false;  //!< True if the body (or any user function it calls)
+                                          //!< calls an implicit-derivative builtin (fwidth,
+                                          //!< textureSample). Computed at finish(); vertex entry
+                                          //!< points with this flag are rejected.
 };
 
 /**
@@ -209,6 +213,11 @@ public:
   ShaderStatus forCondition(const IrExpr& condition);
   /**
    * Sets the continuing assignment of the innermost open `for`.
+   *
+   * The update expression may reference the loop variable and enclosing scope only, never
+   * body-block locals: this builder models `for (init; cond; update)` where the body block
+   * closes before the update runs, unlike a raw WGSL `loop`/`continuing` where the continuing
+   * block is nested inside the body scope.
    *
    * @param lhs Continuing assignment target (normally the loop variable).
    * @param rhs Continuing assignment value.

--- a/donner/gpu/shader/IrSerialization.cc
+++ b/donner/gpu/shader/IrSerialization.cc
@@ -1,0 +1,196 @@
+#include <format>
+#include <string>
+
+#include "donner/gpu/shader/IrModule.h"
+
+/// @file
+/// Deterministic text serialization of \ref donner::gpu::shader::IrModule.
+///
+/// The dump is line-based with two-space indentation, iterates strictly in declaration order,
+/// and contains no pointers or addresses, so semantically identical modules serialize
+/// byte-identically regardless of construction order or process state.
+
+namespace donner::gpu::shader {
+
+namespace {
+
+/// Appends `indent` levels of two-space indentation.
+void AppendIndent(std::string& out, int indent) {
+  for (int i = 0; i < indent; ++i) {
+    out += "  ";
+  }
+}
+
+/// Appends the full definition of a struct type, e.g. `struct Band { curveStart: u32, ... }`.
+void AppendStructDefinition(std::string& out, const IrType& type, int indent) {
+  AppendIndent(out, indent);
+  out += std::format("struct {} {{ ", type.structName().str());
+  bool first = true;
+  for (const IrType::Member& member : type.structMembers()) {
+    if (!first) {
+      out += ", ";
+    }
+    out += std::format("{}: {}", member.name.str(), member.type.toString());
+    first = false;
+  }
+  out += " }\n";
+}
+
+/// Appends struct definitions reachable from a binding type (the root struct or a runtime
+/// array's struct element).
+void AppendReachableStructs(std::string& out, const IrType& type, int indent) {
+  if (type.kind() == IrType::Kind::Struct) {
+    AppendStructDefinition(out, type, indent);
+  } else if (type.kind() == IrType::Kind::RuntimeArray &&
+             type.elementType().kind() == IrType::Kind::Struct) {
+    AppendStructDefinition(out, type.elementType(), indent);
+  }
+}
+
+/// Appends one statement (and its nested blocks) at the given indentation.
+void AppendStatement(std::string& out, const IrStmt& statement, int indent);
+
+/// Appends a statement block at the given indentation.
+void AppendBlock(std::string& out, const IrBlock& block, int indent) {
+  for (const IrStmt& statement : block) {
+    AppendStatement(out, statement, indent);
+  }
+}
+
+void AppendStatement(std::string& out, const IrStmt& statement, int indent) {
+  const IrStmt::Data& data = statement.data();
+  AppendIndent(out, indent);
+  switch (statement.kind()) {
+    case IrStmt::Kind::Let:
+      out += std::format("let {} = {}\n", data.name.str(), data.exprs[0].toString());
+      return;
+    case IrStmt::Kind::Var:
+      if (!data.exprs.empty()) {
+        out += std::format("var {}: {} = {}\n", data.name.str(), data.declaredType->toString(),
+                           data.exprs[0].toString());
+      } else {
+        out += std::format("var {}: {}\n", data.name.str(), data.declaredType->toString());
+      }
+      return;
+    case IrStmt::Kind::Assign:
+      out += std::format("assign {} = {}\n", data.exprs[0].toString(), data.exprs[1].toString());
+      return;
+    case IrStmt::Kind::If:
+      out += std::format("if {}\n", data.exprs[0].toString());
+      AppendBlock(out, data.body, indent + 1);
+      if (!data.elseBody.empty()) {
+        AppendIndent(out, indent);
+        out += "else\n";
+        AppendBlock(out, data.elseBody, indent + 1);
+      }
+      return;
+    case IrStmt::Kind::For:
+      out += "for\n";
+      if (data.init) {
+        AppendIndent(out, indent + 1);
+        out += "init:\n";
+        AppendStatement(out, *data.init, indent + 2);
+      }
+      if (!data.exprs.empty()) {
+        AppendIndent(out, indent + 1);
+        out += std::format("cond: {}\n", data.exprs[0].toString());
+      }
+      if (data.continuing) {
+        AppendIndent(out, indent + 1);
+        out += "continuing:\n";
+        AppendStatement(out, *data.continuing, indent + 2);
+      }
+      AppendIndent(out, indent + 1);
+      out += "body:\n";
+      AppendBlock(out, data.body, indent + 2);
+      return;
+    case IrStmt::Kind::Break: out += "break\n"; return;
+    case IrStmt::Kind::Continue: out += "continue\n"; return;
+    case IrStmt::Kind::Return: {
+      out += "return(";
+      for (size_t i = 0; i < data.exprs.size(); ++i) {
+        if (i > 0) {
+          out += ", ";
+        }
+        out += data.exprs[i].toString();
+      }
+      out += ")\n";
+      return;
+    }
+    case IrStmt::Kind::Discard: out += "discard\n"; return;
+  }
+}
+
+/// Appends the IO annotation suffix for a param/output, e.g. ` @location(0)`.
+template <typename Io>
+std::string IoAnnotation(const Io& io) {
+  if (io.location) {
+    return std::format(" @location({})", *io.location);
+  }
+  return "";
+}
+
+}  // namespace
+
+std::string IrModule::serialize() const {
+  std::string out = "module\n";
+
+  for (const IrConstant& constant : constants_) {
+    out += std::format("constant {}: {} = {}\n", constant.name.str(),
+                       constant.value.type().toString(), constant.value.toString());
+  }
+
+  for (const IrBinding& binding : bindings_) {
+    out += std::format("binding group={} binding={} kind=", binding.group, binding.binding);
+    switch (binding.kind) {
+      case BindingKind::UniformBuffer: out += "uniform"; break;
+      case BindingKind::ReadOnlyStorageBuffer: out += "storage_read"; break;
+      case BindingKind::SampledTexture2dF32: out += "texture_2d_f32"; break;
+      case BindingKind::FilteringSampler: out += "sampler"; break;
+    }
+    out += std::format(" {}: {}\n", binding.name.str(), binding.type.toString());
+    AppendReachableStructs(out, binding.type, 1);
+  }
+
+  for (const IrFunction& function : functions_) {
+    out += "function ";
+    out += function.name.str();
+    switch (function.stage) {
+      case StageKind::None: break;
+      case StageKind::Vertex: out += " stage=vertex"; break;
+      case StageKind::Fragment: out += " stage=fragment"; break;
+    }
+    out += "\n";
+
+    for (const IrParam& param : function.params) {
+      AppendIndent(out, 1);
+      out += std::format("param {}: {}{}", param.name.str(), param.type.toString(),
+                         IoAnnotation(param));
+      if (param.builtin) {
+        out += " @builtin(instance_index)";
+      }
+      out += "\n";
+    }
+    for (const IrOutputMember& output : function.outputs) {
+      AppendIndent(out, 1);
+      out += std::format("output {}: {}{}", output.name.str(), output.type.toString(),
+                         IoAnnotation(output));
+      if (output.builtin) {
+        out += " @builtin(position)";
+      }
+      out += "\n";
+    }
+    if (function.returnType) {
+      AppendIndent(out, 1);
+      out += std::format("returns {}\n", function.returnType->toString());
+    }
+
+    AppendIndent(out, 1);
+    out += "body:\n";
+    AppendBlock(out, function.body, 2);
+  }
+
+  return out;
+}
+
+}  // namespace donner::gpu::shader

--- a/donner/gpu/shader/IrSerialization.cc
+++ b/donner/gpu/shader/IrSerialization.cc
@@ -36,14 +36,30 @@ void AppendStructDefinition(std::string& out, const IrType& type, int indent) {
   out += " }\n";
 }
 
-/// Appends struct definitions reachable from a binding type (the root struct or a runtime
-/// array's struct element).
-void AppendReachableStructs(std::string& out, const IrType& type, int indent) {
-  if (type.kind() == IrType::Kind::Struct) {
-    AppendStructDefinition(out, type, indent);
-  } else if (type.kind() == IrType::Kind::RuntimeArray &&
-             type.elementType().kind() == IrType::Kind::Struct) {
-    AppendStructDefinition(out, type.elementType(), indent);
+/// Appends every struct definition reachable from a binding type, depth-first in declaration
+/// order (outer struct before its nested member structs), deduplicated by struct name so shared
+/// nested types print once.
+void AppendReachableStructs(std::string& out, const IrType& type, int indent,
+                            std::vector<RcString>& emittedNames) {
+  switch (type.kind()) {
+    case IrType::Kind::Struct: {
+      for (const RcString& emitted : emittedNames) {
+        if (emitted == type.structName()) {
+          return;
+        }
+      }
+      emittedNames.push_back(type.structName());
+      AppendStructDefinition(out, type, indent);
+      for (const IrType::Member& member : type.structMembers()) {
+        AppendReachableStructs(out, member.type, indent, emittedNames);
+      }
+      return;
+    }
+    case IrType::Kind::SizedArray:
+    case IrType::Kind::RuntimeArray:
+      AppendReachableStructs(out, type.elementType(), indent, emittedNames);
+      return;
+    default: return;
   }
 }
 
@@ -149,7 +165,8 @@ std::string IrModule::serialize() const {
       case BindingKind::FilteringSampler: out += "sampler"; break;
     }
     out += std::format(" {}: {}\n", binding.name.str(), binding.type.toString());
-    AppendReachableStructs(out, binding.type, 1);
+    std::vector<RcString> emittedStructNames;
+    AppendReachableStructs(out, binding.type, 1, emittedStructNames);
   }
 
   for (const IrFunction& function : functions_) {

--- a/donner/gpu/shader/IrSerialization.cc
+++ b/donner/gpu/shader/IrSerialization.cc
@@ -167,7 +167,10 @@ std::string IrModule::serialize() const {
       out += std::format("param {}: {}{}", param.name.str(), param.type.toString(),
                          IoAnnotation(param));
       if (param.builtin) {
-        out += " @builtin(instance_index)";
+        switch (*param.builtin) {
+          case BuiltinInput::InstanceIndex: out += " @builtin(instance_index)"; break;
+          case BuiltinInput::Position: out += " @builtin(position)"; break;
+        }
       }
       out += "\n";
     }

--- a/donner/gpu/shader/IrStatement.h
+++ b/donner/gpu/shader/IrStatement.h
@@ -1,0 +1,73 @@
+#pragma once
+/// @file
+/// Statement nodes for the \c donner::gpu::shader IR.
+///
+/// Statements are immutable value nodes produced by \c FunctionBuilder, which performs all
+/// scope, type, and stage validation before constructing them; the nodes themselves are plain
+/// data consumed by serialization and (in later packets) the emitters.
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "donner/base/RcString.h"
+#include "donner/gpu/shader/IrExpr.h"
+#include "donner/gpu/shader/IrType.h"
+
+namespace donner::gpu::shader {
+
+class IrStmt;
+
+/// An ordered list of statements.
+using IrBlock = std::vector<IrStmt>;
+
+/**
+ * One IR statement. Construct through \c FunctionBuilder; this class is an immutable value
+ * handle over validated statement data.
+ */
+class IrStmt {
+public:
+  /// Statement kind.
+  enum class Kind : uint8_t {
+    Let,       //!< `let name = expr;`
+    Var,       //!< `var name: type (= init);`
+    Assign,    //!< `lvalue = expr;`
+    If,        //!< `if (cond) { ... } else { ... }`
+    For,       //!< `for (init; cond; continuing) { ... }`
+    Break,     //!< `break;`
+    Continue,  //!< `continue;`
+    Return,    //!< `return;` / `return expr;` / entry point output return.
+    Discard,   //!< `discard;` (fragment stage only).
+  };
+
+  /// Internal storage; public for the builder and serialization implementation.
+  struct Data {
+    Kind kind = Kind::Break;                   //!< Statement kind.
+    RcString name;                             //!< Let/var name.
+    std::optional<IrType> declaredType;        //!< Var declared type.
+    std::vector<IrExpr> exprs;                 //!< Kind-dependent expressions: let/var init, assign
+                                               //!< (lhs, rhs), if/for condition, return values.
+    IrBlock body;                              //!< If-then / for body.
+    IrBlock elseBody;                          //!< If-else body.
+    std::shared_ptr<const IrStmt> init;        //!< For-loop init statement.
+    std::shared_ptr<const IrStmt> continuing;  //!< For-loop continuing statement.
+  };
+
+  /**
+   * Wraps validated statement data; called by the builder only.
+   *
+   * @param data Statement payload.
+   */
+  explicit IrStmt(Data&& data) : data_(std::make_shared<const Data>(std::move(data))) {}
+
+  /// Statement kind.
+  Kind kind() const { return data_->kind; }
+
+  /// Statement payload.
+  const Data& data() const { return *data_; }
+
+private:
+  std::shared_ptr<const Data> data_;
+};
+
+}  // namespace donner::gpu::shader

--- a/donner/gpu/shader/IrType.cc
+++ b/donner/gpu/shader/IrType.cc
@@ -1,0 +1,271 @@
+#include "donner/gpu/shader/IrType.h"
+
+#include <format>
+#include <utility>
+
+namespace donner::gpu::shader {
+
+/// Internal storage for \ref IrType. One node per type; children held by value (IrType handles).
+struct IrType::Node {
+  Kind kind = Kind::Scalar;             //!< Type category.
+  ScalarKind scalar = ScalarKind::F32;  //!< Scalar/vector component kind.
+  uint32_t vectorSize = 0;              //!< Vector component count (2..4).
+  std::vector<IrType> element;          //!< Array element type (0 or 1 entries).
+  uint32_t arrayCount = 0;              //!< Sized array element count.
+  RcString structName;                  //!< Struct name.
+  std::vector<Member> members;          //!< Struct members.
+};
+
+std::ostream& operator<<(std::ostream& os, ScalarKind value) {
+  switch (value) {
+    case ScalarKind::Bool: return os << "bool";
+    case ScalarKind::I32: return os << "i32";
+    case ScalarKind::U32: return os << "u32";
+    case ScalarKind::F32: return os << "f32";
+  }
+  return os << "unknown";
+}
+
+IrType IrType::MakeScalarType(ScalarKind kind) {
+  Node node;
+  node.kind = Kind::Scalar;
+  node.scalar = kind;
+  return IrType(std::make_shared<const Node>(std::move(node)));
+}
+
+IrType IrType::MakeVectorType(ScalarKind kind, uint32_t size) {
+  Node node;
+  node.kind = Kind::Vector;
+  node.scalar = kind;
+  node.vectorSize = size;
+  return IrType(std::make_shared<const Node>(std::move(node)));
+}
+
+IrType IrType::MakeSimpleType(Kind kind) {
+  Node node;
+  node.kind = kind;
+  return IrType(std::make_shared<const Node>(std::move(node)));
+}
+
+IrType IrType::Scalar(ScalarKind kind) {
+  return MakeScalarType(kind);
+}
+
+IrType IrType::Bool() {
+  return MakeScalarType(ScalarKind::Bool);
+}
+IrType IrType::I32() {
+  return MakeScalarType(ScalarKind::I32);
+}
+IrType IrType::U32() {
+  return MakeScalarType(ScalarKind::U32);
+}
+IrType IrType::F32() {
+  return MakeScalarType(ScalarKind::F32);
+}
+
+IrType IrType::Vec2(ScalarKind element) {
+  return MakeVectorType(element, 2);
+}
+IrType IrType::Vec3(ScalarKind element) {
+  return MakeVectorType(element, 3);
+}
+IrType IrType::Vec4(ScalarKind element) {
+  return MakeVectorType(element, 4);
+}
+
+IrType IrType::Mat4x4f() {
+  return MakeSimpleType(Kind::Matrix4x4f);
+}
+
+IrType IrType::Texture2dF32() {
+  return MakeSimpleType(Kind::Texture2dF32);
+}
+
+IrType IrType::SamplerType() {
+  return MakeSimpleType(Kind::Sampler);
+}
+
+ShaderResult<IrType> IrType::SizedArray(const IrType& element, uint32_t count,
+                                        const RcString& label) {
+  if (count == 0) {
+    return ShaderError{"array element count must be nonzero", label};
+  }
+  if (!element.isPlainData()) {
+    return ShaderError{
+        std::format("array element type {} is not plain data (runtime arrays, textures, and "
+                    "samplers cannot be array elements)",
+                    element.toString()),
+        label};
+  }
+
+  Node node;
+  node.kind = Kind::SizedArray;
+  node.element.push_back(element);
+  node.arrayCount = count;
+  return IrType(std::make_shared<const Node>(std::move(node)));
+}
+
+ShaderResult<IrType> IrType::RuntimeArray(const IrType& element, const RcString& label) {
+  if (!element.isPlainData()) {
+    return ShaderError{
+        std::format("runtime array element type {} is not plain data", element.toString()), label};
+  }
+
+  Node node;
+  node.kind = Kind::RuntimeArray;
+  node.element.push_back(element);
+  return IrType(std::make_shared<const Node>(std::move(node)));
+}
+
+ShaderResult<IrType> IrType::Struct(const RcString& name, std::vector<Member> members,
+                                    const RcString& label) {
+  if (members.empty()) {
+    return ShaderError{std::format("struct {} must have at least one member", name.str()), label};
+  }
+  for (size_t i = 0; i < members.size(); ++i) {
+    if (!members[i].type.isPlainData()) {
+      return ShaderError{
+          std::format("struct {} member {} has type {} which is not plain data (runtime arrays "
+                      "are only supported as storage binding roots)",
+                      name.str(), members[i].name.str(), members[i].type.toString()),
+          label};
+    }
+    for (size_t j = i + 1; j < members.size(); ++j) {
+      if (members[j].name == members[i].name) {
+        return ShaderError{std::format("struct {} has duplicate member name {}", name.str(),
+                                       members[i].name.str()),
+                           label};
+      }
+    }
+  }
+
+  Node node;
+  node.kind = Kind::Struct;
+  node.structName = name;
+  node.members = std::move(members);
+  return IrType(std::make_shared<const Node>(std::move(node)));
+}
+
+IrType::Kind IrType::kind() const {
+  return node_->kind;
+}
+
+ScalarKind IrType::scalarKind() const {
+  return node_->scalar;
+}
+
+uint32_t IrType::vectorSize() const {
+  return node_->vectorSize;
+}
+
+const IrType& IrType::elementType() const {
+  return node_->element.front();
+}
+
+uint32_t IrType::arrayCount() const {
+  return node_->arrayCount;
+}
+
+const RcString& IrType::structName() const {
+  return node_->structName;
+}
+
+std::span<const IrType::Member> IrType::structMembers() const {
+  return node_->members;
+}
+
+bool IrType::isNumericScalar() const {
+  return kind() == Kind::Scalar && node_->scalar != ScalarKind::Bool;
+}
+
+bool IrType::isNumericVector() const {
+  return kind() == Kind::Vector && node_->scalar != ScalarKind::Bool;
+}
+
+bool IrType::isFloatScalarOrVector() const {
+  return (kind() == Kind::Scalar || kind() == Kind::Vector) && node_->scalar == ScalarKind::F32;
+}
+
+bool IrType::isPlainData() const {
+  switch (kind()) {
+    case Kind::Scalar:
+    case Kind::Vector:
+    case Kind::Matrix4x4f:
+    case Kind::SizedArray:
+    case Kind::Struct: return true;
+    case Kind::RuntimeArray:
+    case Kind::Texture2dF32:
+    case Kind::Sampler: return false;
+  }
+  return false;
+}
+
+bool IrType::operator==(const IrType& other) const {
+  if (node_ == other.node_) {
+    return true;
+  }
+  if (node_->kind != other.node_->kind) {
+    return false;
+  }
+  switch (node_->kind) {
+    case Kind::Scalar: return node_->scalar == other.node_->scalar;
+    case Kind::Vector:
+      return node_->scalar == other.node_->scalar && node_->vectorSize == other.node_->vectorSize;
+    case Kind::Matrix4x4f:
+    case Kind::Texture2dF32:
+    case Kind::Sampler: return true;
+    case Kind::SizedArray:
+      return node_->arrayCount == other.node_->arrayCount &&
+             node_->element.front() == other.node_->element.front();
+    case Kind::RuntimeArray: return node_->element.front() == other.node_->element.front();
+    case Kind::Struct: {
+      if (node_->structName != other.node_->structName ||
+          node_->members.size() != other.node_->members.size()) {
+        return false;
+      }
+      for (size_t i = 0; i < node_->members.size(); ++i) {
+        if (node_->members[i].name != other.node_->members[i].name ||
+            !(node_->members[i].type == other.node_->members[i].type)) {
+          return false;
+        }
+      }
+      return true;
+    }
+  }
+  return false;
+}
+
+std::string IrType::toString() const {
+  switch (kind()) {
+    case Kind::Scalar: {
+      switch (node_->scalar) {
+        case ScalarKind::Bool: return "bool";
+        case ScalarKind::I32: return "i32";
+        case ScalarKind::U32: return "u32";
+        case ScalarKind::F32: return "f32";
+      }
+      return "unknown";
+    }
+    case Kind::Vector: {
+      std::string element;
+      switch (node_->scalar) {
+        case ScalarKind::Bool: element = "bool"; break;
+        case ScalarKind::I32: element = "i32"; break;
+        case ScalarKind::U32: element = "u32"; break;
+        case ScalarKind::F32: element = "f32"; break;
+      }
+      return std::format("vec{}<{}>", node_->vectorSize, element);
+    }
+    case Kind::Matrix4x4f: return "mat4x4<f32>";
+    case Kind::SizedArray:
+      return std::format("array<{}, {}>", node_->element.front().toString(), node_->arrayCount);
+    case Kind::RuntimeArray: return std::format("array<{}>", node_->element.front().toString());
+    case Kind::Struct: return node_->structName.str();
+    case Kind::Texture2dF32: return "texture_2d<f32>";
+    case Kind::Sampler: return "sampler";
+  }
+  return "unknown";
+}
+
+}  // namespace donner::gpu::shader

--- a/donner/gpu/shader/IrType.h
+++ b/donner/gpu/shader/IrType.h
@@ -1,0 +1,227 @@
+#pragma once
+/// @file
+/// Immutable type model for the \c donner::gpu::shader IR.
+///
+/// The type surface covers exactly what the solid-fill pipeline family requires (design 0053
+/// "Donner shader IR"): scalars, vectors, mat4x4f, sized and runtime arrays, structs, and the
+/// texture_2d<f32> / sampler resource types. Types are immutable values with deep equality, so
+/// identical types compare equal deterministically regardless of construction order.
+
+#include <cstdint>
+#include <memory>
+#include <ostream>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "donner/base/RcString.h"
+#include "donner/gpu/shader/ShaderResult.h"
+
+namespace donner::gpu::shader {
+
+/// Scalar component types.
+enum class ScalarKind : uint8_t {
+  Bool,  //!< `bool`. Not host-shareable; no layout.
+  I32,   //!< 32-bit signed integer.
+  U32,   //!< 32-bit unsigned integer.
+  F32,   //!< 32-bit float.
+};
+
+/**
+ * Ostream output operator, e.g. `f32`.
+ *
+ * @param os Output stream.
+ * @param value Value to output.
+ */
+std::ostream& operator<<(std::ostream& os, ScalarKind value);
+
+/**
+ * An immutable shader IR type with deep value equality.
+ *
+ * Construct through the static factories. Factories that can receive invalid input (arrays,
+ * structs) return \ref ShaderResult and fail closed; the fixed factories (scalars, vectors,
+ * matrix, resource types) cannot fail.
+ */
+class IrType {
+public:
+  /// Type category.
+  enum class Kind : uint8_t {
+    Scalar,        //!< bool / i32 / u32 / f32.
+    Vector,        //!< vecN<T>, N in 2..4.
+    Matrix4x4f,    //!< mat4x4f (the only matrix type in scope).
+    SizedArray,    //!< array<E, N>.
+    RuntimeArray,  //!< array<E>; storage buffer roots only.
+    Struct,        //!< Named struct with named members.
+    Texture2dF32,  //!< texture_2d<f32>.
+    Sampler,       //!< Filtering sampler.
+  };
+
+  /// One named member of a struct type; defined after the class (members hold IrType by value).
+  struct Member;
+
+  /**
+   * Scalar type of the given kind.
+   *
+   * @param kind Scalar kind.
+   */
+  static IrType Scalar(ScalarKind kind);
+
+  /// `bool` type.
+  static IrType Bool();
+  /// `i32` type.
+  static IrType I32();
+  /// `u32` type.
+  static IrType U32();
+  /// `f32` type.
+  static IrType F32();
+
+  /**
+   * `vec2<element>` type.
+   *
+   * @param element Component scalar kind.
+   */
+  static IrType Vec2(ScalarKind element);
+  /**
+   * `vec3<element>` type.
+   *
+   * @param element Component scalar kind.
+   */
+  static IrType Vec3(ScalarKind element);
+  /**
+   * `vec4<element>` type.
+   *
+   * @param element Component scalar kind.
+   */
+  static IrType Vec4(ScalarKind element);
+
+  /// `vec2<f32>` convenience factory.
+  static IrType Vec2f() { return Vec2(ScalarKind::F32); }
+  /// `vec3<f32>` convenience factory.
+  static IrType Vec3f() { return Vec3(ScalarKind::F32); }
+  /// `vec4<f32>` convenience factory.
+  static IrType Vec4f() { return Vec4(ScalarKind::F32); }
+  /// `vec2<i32>` convenience factory.
+  static IrType Vec2i() { return Vec2(ScalarKind::I32); }
+  /// `vec2<u32>` convenience factory.
+  static IrType Vec2u() { return Vec2(ScalarKind::U32); }
+
+  /// `mat4x4<f32>` type.
+  static IrType Mat4x4f();
+
+  /// `texture_2d<f32>` resource type.
+  static IrType Texture2dF32();
+  /// Filtering sampler resource type.
+  static IrType SamplerType();
+
+  /**
+   * `array<element, count>` type. Fails closed if \p count is zero or \p element is not plain
+   * data (runtime arrays, textures, and samplers cannot be array elements).
+   *
+   * @param element Element type.
+   * @param count Element count; must be nonzero.
+   * @param label Diagnostic label for errors.
+   */
+  static ShaderResult<IrType> SizedArray(const IrType& element, uint32_t count,
+                                         const RcString& label = "array");
+
+  /**
+   * `array<element>` runtime-sized type, usable only as a read-only storage buffer root. Fails
+   * closed if \p element is not plain data.
+   *
+   * @param element Element type.
+   * @param label Diagnostic label for errors.
+   */
+  static ShaderResult<IrType> RuntimeArray(const IrType& element,
+                                           const RcString& label = "runtimeArray");
+
+  /**
+   * Named struct type. Fails closed on empty member lists, duplicate member names, or member
+   * types that are not plain data (runtime arrays are only supported as storage binding roots in
+   * this packet, so they cannot be struct members).
+   *
+   * @param name Struct name.
+   * @param members Struct members in declaration order.
+   * @param label Diagnostic label for errors.
+   */
+  static ShaderResult<IrType> Struct(const RcString& name, std::vector<Member> members,
+                                     const RcString& label = "struct");
+
+  /// Type category.
+  Kind kind() const;
+
+  /// Scalar kind of a scalar or vector type. @pre `kind()` is Scalar or Vector.
+  ScalarKind scalarKind() const;
+
+  /// Component count of a vector type (2..4). @pre `kind()` is Vector.
+  uint32_t vectorSize() const;
+
+  /// Element type of a sized or runtime array. @pre `kind()` is SizedArray or RuntimeArray.
+  const IrType& elementType() const;
+
+  /// Element count of a sized array. @pre `kind()` is SizedArray.
+  uint32_t arrayCount() const;
+
+  /// Name of a struct type. @pre `kind()` is Struct.
+  const RcString& structName() const;
+
+  /// Members of a struct type. @pre `kind()` is Struct.
+  std::span<const Member> structMembers() const;
+
+  /// True for bool/i32/u32/f32.
+  bool isScalar() const { return kind() == Kind::Scalar; }
+  /// True for vecN types.
+  bool isVector() const { return kind() == Kind::Vector; }
+  /// True for i32/u32/f32 scalars.
+  bool isNumericScalar() const;
+  /// True for vectors of i32/u32/f32.
+  bool isNumericVector() const;
+  /// True for i32/u32/f32 scalars and their vectors.
+  bool isNumeric() const { return isNumericScalar() || isNumericVector(); }
+  /// True for `f32` and vectors of f32.
+  bool isFloatScalarOrVector() const;
+  /// True for types that can be stored in arrays and structs (everything except runtime arrays,
+  /// textures, and samplers).
+  bool isPlainData() const;
+
+  /**
+   * Deep structural equality.
+   *
+   * @param other Type to compare against.
+   */
+  bool operator==(const IrType& other) const;
+
+  /// Formats this type, e.g. `vec2<f32>` or `array<Band>`.
+  std::string toString() const;
+
+  /**
+   * Ostream output operator.
+   *
+   * @param os Output stream.
+   * @param type Type to output.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const IrType& type) {
+    return os << type.toString();
+  }
+
+private:
+  struct Node;
+
+  explicit IrType(std::shared_ptr<const Node> node) : node_(std::move(node)) {}
+
+  /// Builds a scalar type node. @param kind Scalar kind.
+  static IrType MakeScalarType(ScalarKind kind);
+  /// Builds a vector type node. @param kind Component kind. @param size Component count.
+  static IrType MakeVectorType(ScalarKind kind, uint32_t size);
+  /// Builds a node for a childless type category. @param kind Type category.
+  static IrType MakeSimpleType(Kind kind);
+
+  std::shared_ptr<const Node> node_;
+};
+
+/// One named member of a struct type.
+struct IrType::Member {
+  RcString name;  //!< Member name; unique within the struct.
+  IrType type;    //!< Member type.
+};
+
+}  // namespace donner::gpu::shader

--- a/donner/gpu/shader/ShaderError.h
+++ b/donner/gpu/shader/ShaderError.h
@@ -1,0 +1,56 @@
+#pragma once
+/// @file
+/// Error type returned by the \c donner::gpu::shader IR builder and layout engine.
+
+#include <ostream>
+#include <string>
+
+#include "donner/base/RcString.h"
+
+namespace donner::gpu::shader {
+
+/**
+ * An error from IR construction, validation, or layout computation.
+ *
+ * The IR builder is fail-closed: ill-typed construction returns a ShaderError, never asserts on
+ * input. Messages name the offending operand or rule; \ref nodeLabel carries a caller-supplied
+ * source-location-like label (or the node kind when the caller did not supply one) so failures
+ * localize without a rerun.
+ *
+ * This type is intentionally local to the shader IR rather than reusing \c donner::gpu::GpuError:
+ * the runtime's error taxonomy describes device/resource failures (handles, descriptors, limits),
+ * not type-checking diagnostics, and the IR does not depend on runtime headers.
+ */
+struct ShaderError {
+  std::string message;  //!< Human-readable failure reason.
+  RcString nodeLabel;   //!< Label of the node or rule that failed.
+
+  /**
+   * Equality operator.
+   *
+   * @param other Error to compare against.
+   */
+  bool operator==(const ShaderError& other) const = default;
+
+  /**
+   * Ostream output operator, outputs `<label>: <message>`.
+   *
+   * @param os Output stream.
+   * @param error Error to output.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const ShaderError& error) {
+    return os << error.nodeLabel << ": " << error.message;
+  }
+};
+
+/**
+ * gtest PrintTo support for readable failure messages.
+ *
+ * @param error Error to print.
+ * @param os Output stream.
+ */
+inline void PrintTo(const ShaderError& error, std::ostream* os) {
+  *os << error;
+}
+
+}  // namespace donner::gpu::shader

--- a/donner/gpu/shader/ShaderResult.h
+++ b/donner/gpu/shader/ShaderResult.h
@@ -1,0 +1,155 @@
+#pragma once
+/// @file
+/// Result type returned by fallible \c donner::gpu::shader APIs.
+
+#include <ostream>
+#include <type_traits>
+#include <variant>
+
+#include "donner/base/Utils.h"
+#include "donner/gpu/shader/ShaderError.h"
+
+namespace donner::gpu::shader {
+
+/**
+ * Result of a fallible shader IR operation: exactly one of a value of type \a T or a
+ * \ref ShaderError. Mirrors the accessor shape of \c donner::gpu::Result so call sites read the
+ * same across the GPU module, but carries the IR-local error type.
+ *
+ * @tparam T Result type.
+ */
+template <typename T>
+class ShaderResult {
+public:
+  static_assert(!std::is_same_v<std::remove_cvref_t<T>, ShaderError>,
+                "ShaderResult<ShaderError> is ambiguous; use ShaderStatus");
+
+  /**
+   * Construct from a successful result.
+   *
+   * @param result Result value.
+   */
+  /* implicit */ ShaderResult(T&& result) : value_(std::move(result)) {}
+
+  /**
+   * Construct from a successful result by copy.
+   *
+   * @param result Result value.
+   */
+  /* implicit */ ShaderResult(const T& result) : value_(result) {}
+
+  /**
+   * Construct from an error.
+   *
+   * @param error Error value.
+   */
+  /* implicit */ ShaderResult(ShaderError&& error) : value_(std::move(error)) {}
+
+  /**
+   * Construct from an error by copy.
+   *
+   * @param error Error value.
+   */
+  /* implicit */ ShaderResult(const ShaderError& error) : value_(error) {}
+
+  /**
+   * Returns the contained result.
+   *
+   * @pre There is a valid result, i.e. \ref hasResult() returns true.
+   */
+  T& result() & {
+    UTILS_RELEASE_ASSERT(hasResult());
+    return std::get<T>(value_);
+  }
+
+  /**
+   * Returns the contained result (move).
+   *
+   * @pre There is a valid result, i.e. \ref hasResult() returns true.
+   */
+  T&& result() && {
+    UTILS_RELEASE_ASSERT(hasResult());
+    return std::get<T>(std::move(value_));
+  }
+
+  /**
+   * Returns the contained result.
+   *
+   * @pre There is a valid result, i.e. \ref hasResult() returns true.
+   */
+  const T& result() const& {
+    UTILS_RELEASE_ASSERT(hasResult());
+    return std::get<T>(value_);
+  }
+
+  /**
+   * Returns the contained error.
+   *
+   * @pre There is a valid error, i.e. \ref hasError() returns true.
+   */
+  ShaderError& error() & {
+    UTILS_RELEASE_ASSERT(hasError());
+    return std::get<ShaderError>(value_);
+  }
+
+  /**
+   * Returns the contained error (move).
+   *
+   * @pre There is a valid error, i.e. \ref hasError() returns true.
+   */
+  ShaderError&& error() && {
+    UTILS_RELEASE_ASSERT(hasError());
+    return std::get<ShaderError>(std::move(value_));
+  }
+
+  /**
+   * Returns the contained error.
+   *
+   * @pre There is a valid error, i.e. \ref hasError() returns true.
+   */
+  const ShaderError& error() const& {
+    UTILS_RELEASE_ASSERT(hasError());
+    return std::get<ShaderError>(value_);
+  }
+
+  /// Returns true if this result contains a value.
+  bool hasResult() const noexcept { return std::holds_alternative<T>(value_); }
+
+  /// Returns true if this result contains an error.
+  bool hasError() const noexcept { return std::holds_alternative<ShaderError>(value_); }
+
+private:
+  std::variant<T, ShaderError> value_;
+};
+
+/**
+ * Status of a fallible shader IR operation with no result value. Construct success values with
+ * \ref OkShaderStatus().
+ */
+using ShaderStatus = ShaderResult<std::monostate>;
+
+/// Returns a successful \ref ShaderStatus.
+inline ShaderStatus OkShaderStatus() {
+  return ShaderStatus(std::monostate());
+}
+
+/**
+ * gtest PrintTo support for readable failure messages.
+ *
+ * @param result Result to print.
+ * @param os Output stream.
+ */
+template <typename T>
+void PrintTo(const ShaderResult<T>& result, std::ostream* os) {
+  if (result.hasError()) {
+    *os << "ShaderResult { error: " << result.error() << " }";
+  } else if constexpr (std::is_same_v<T, std::monostate>) {
+    *os << "ShaderStatus { ok }";
+  } else if constexpr (requires(std::ostream& s, const T& v) { s << v; }) {
+    *os << "ShaderResult { " << result.result() << " }";
+  } else {
+    *os << "ShaderResult { <value> }";
+  }
+}
+
+}  // namespace donner::gpu::shader

--- a/donner/gpu/shader/tests/IrBuilder_tests.cc
+++ b/donner/gpu/shader/tests/IrBuilder_tests.cc
@@ -347,6 +347,126 @@ TEST_F(FunctionBuilderTests, ForLoopWithBreakAndContinue) {
   EXPECT_THAT(function.finish(), IsShaderOk());
 }
 
+TEST_F(FunctionBuilderTests, ReturnValueRejectsOutOfScopeRefs) {
+  FunctionBuilder function = startFunction(IrType::F32());
+
+  EXPECT_THAT(function.beginIf(LiteralBool(true)), IsShaderOk());
+  const IrExpr scoped = GetShaderResultOrFail(function.addLet("x", LiteralF32(1)), LiteralF32(0));
+  EXPECT_THAT(function.endIf(), IsShaderOk());
+
+  // The handle survives its block; returning it after endIf must fail closed like addLet/assign.
+  EXPECT_THAT(function.returnValue(scoped), IsShaderError(HasSubstr("x which is out of scope")));
+}
+
+TEST(EntryPointTests, ReturnOutputsRejectsOutOfScopeRefs) {
+  ModuleBuilder builder;
+  auto fragment = builder.createFragmentEntryPoint("fsMain", {IrParam{"uv", IrType::Vec2f(), 0}},
+                                                   {IrOutputMember{"color", IrType::Vec4f(), 0}});
+  ASSERT_THAT(fragment, HasShaderResult());
+  FunctionBuilder function = std::move(fragment).result();
+
+  EXPECT_THAT(function.beginIf(LiteralBool(true)), IsShaderOk());
+  const IrExpr scoped = GetShaderResultOrFail(
+      function.addLet("tmp",
+                      GetShaderResultOrFail(ConstructVector(IrType::Vec4f(), {LiteralF32(1.0f)}),
+                                            LiteralF32(0))),
+      LiteralF32(0));
+  EXPECT_THAT(function.endIf(), IsShaderOk());
+
+  EXPECT_THAT(function.returnOutputs({scoped}),
+              IsShaderError(HasSubstr("tmp which is out of scope")));
+}
+
+TEST_F(FunctionBuilderTests, ForContinuingRejectsBodyBlockLocals) {
+  // Our for-loop model closes the body block before the update expression runs, so the
+  // continuing expression may reference the loop variable and enclosing scope only.
+  FunctionBuilder function = startFunction();
+  const IrExpr i = GetShaderResultOrFail(function.beginFor("i", LiteralU32(0)), LiteralF32(0));
+  EXPECT_THAT(function.forCondition(GetShaderResultOrFail(Lt(i, LiteralU32(4)), LiteralF32(0))),
+              IsShaderOk());
+  const IrExpr bodyLocal = GetShaderResultOrFail(
+      function.addVar("bodyLocal", IrType::U32(), LiteralU32(2)), LiteralF32(0));
+
+  EXPECT_THAT(function.forContinuing(i, GetShaderResultOrFail(Add(i, bodyLocal), LiteralF32(0))),
+              IsShaderError(HasSubstr("loop variable and enclosing scope")));
+}
+
+TEST(EntryPointTests, VertexEntryPointRejectsFwidth) {
+  // fwidth takes implicit derivatives: WGSL restricts it to the fragment stage.
+  ModuleBuilder builder;
+  auto vertex = builder.createVertexEntryPoint(
+      "vsMain", {IrParam{"pos", IrType::Vec2f(), 0}},
+      {IrOutputMember{"clip_pos", IrType::Vec4f(), std::nullopt, BuiltinOutput::Position}});
+  ASSERT_THAT(vertex, HasShaderResult());
+  FunctionBuilder function = std::move(vertex).result();
+
+  const IrExpr pos = GetShaderResultOrFail(function.ref("pos"), LiteralF32(0));
+  const IrExpr width = GetShaderResultOrFail(
+      function.addLet("width",
+                      GetShaderResultOrFail(CallBuiltin(BuiltinFn::Fwidth, {pos}), LiteralF32(0))),
+      LiteralF32(0));
+  EXPECT_THAT(
+      function.returnOutputs({GetShaderResultOrFail(
+          ConstructVector(IrType::Vec4f(), {width, LiteralF32(0), LiteralF32(1)}), LiteralF32(0))}),
+      IsShaderOk());
+
+  EXPECT_THAT(function.finish(), IsShaderError(HasSubstr("fragment-only builtin")));
+}
+
+TEST(EntryPointTests, VertexEntryPointRejectsTextureSampleTransitively) {
+  // textureSample also takes implicit derivatives, and the restriction must follow user calls:
+  // a helper that samples is rejected when reached from a vertex entry point.
+  ModuleBuilder builder;
+  EXPECT_THAT(builder.addTexture2d(0, 0, "tex"), IsShaderOk());
+  EXPECT_THAT(builder.addSampler(0, 1, "smp"), IsShaderOk());
+
+  {
+    auto helper =
+        builder.createFunction("sampleHelper", {IrParam{"uv", IrType::Vec2f()}}, IrType::Vec4f());
+    ASSERT_THAT(helper, HasShaderResult());
+    FunctionBuilder function = std::move(helper).result();
+    const IrExpr sampled = GetShaderResultOrFail(
+        CallBuiltin(BuiltinFn::TextureSample,
+                    {GetShaderResultOrFail(function.ref("tex"), LiteralF32(0)),
+                     GetShaderResultOrFail(function.ref("smp"), LiteralF32(0)),
+                     GetShaderResultOrFail(function.ref("uv"), LiteralF32(0))}),
+        LiteralF32(0));
+    EXPECT_THAT(function.returnValue(sampled), IsShaderOk());
+    EXPECT_THAT(function.finish(), IsShaderOk());
+  }
+
+  auto vertex = builder.createVertexEntryPoint(
+      "vsMain", {IrParam{"pos", IrType::Vec2f(), 0}},
+      {IrOutputMember{"clip_pos", IrType::Vec4f(), std::nullopt, BuiltinOutput::Position}});
+  ASSERT_THAT(vertex, HasShaderResult());
+  FunctionBuilder function = std::move(vertex).result();
+
+  const IrExpr sampled = GetShaderResultOrFail(
+      function.addLet(
+          "sampled",
+          GetShaderResultOrFail(
+              function.callFunction("sampleHelper",
+                                    {GetShaderResultOrFail(function.ref("pos"), LiteralF32(0))}),
+              LiteralF32(0))),
+      LiteralF32(0));
+  EXPECT_THAT(function.returnOutputs({sampled}), IsShaderOk());
+
+  EXPECT_THAT(function.finish(), IsShaderError(HasSubstr("fragment-only builtin")));
+}
+
+TEST(EntryPointTests, RejectsLocationAndBuiltinOnSameIo) {
+  ModuleBuilder builder;
+  EXPECT_THAT(builder.createVertexEntryPoint(
+                  "vsMain", {IrParam{"pos", IrType::Vec2f(), 0}},
+                  {IrOutputMember{"clip_pos", IrType::Vec4f(), 0, BuiltinOutput::Position}}),
+              IsShaderError(HasSubstr("both a location and a builtin")));
+
+  EXPECT_THAT(builder.createFragmentEntryPoint(
+                  "fsMain", {IrParam{"clip_pos", IrType::Vec4f(), 3, BuiltinInput::Position}},
+                  {IrOutputMember{"color", IrType::Vec4f(), 0}}),
+              IsShaderError(HasSubstr("both a location and a builtin")));
+}
+
 TEST_F(FunctionBuilderTests, FinishWithOpenBlockFails) {
   FunctionBuilder function = startFunction();
   EXPECT_THAT(function.beginIf(LiteralBool(true)), IsShaderOk());

--- a/donner/gpu/shader/tests/IrBuilder_tests.cc
+++ b/donner/gpu/shader/tests/IrBuilder_tests.cc
@@ -1,0 +1,461 @@
+/// @file
+/// Accept/reject tests for the validating IR builder: types, expressions, statements, module
+/// bindings, and stage rules.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <optional>
+#include <vector>
+
+#include "donner/gpu/shader/IrModule.h"
+#include "donner/gpu/shader/tests/ShaderTestUtils.h"
+
+using testing::HasSubstr;
+
+namespace donner::gpu::shader {
+namespace {
+
+IrExpr F32Val() {
+  return LiteralF32(1.0f);
+}
+IrExpr Vec2fVal() {
+  return GetShaderResultOrFail(
+      ConstructVector(IrType::Vec2f(), {LiteralF32(1.0f), LiteralF32(2.0f)}), LiteralF32(0));
+}
+IrExpr Vec4fVal() {
+  return GetShaderResultOrFail(
+      ConstructVector(IrType::Vec4f(),
+                      {LiteralF32(1.0f), LiteralF32(2.0f), LiteralF32(3.0f), LiteralF32(4.0f)}),
+      LiteralF32(0));
+}
+IrExpr Mat4Val() {
+  return GetShaderResultOrFail(ConstructMat4x4f({Vec4fVal(), Vec4fVal(), Vec4fVal(), Vec4fVal()}),
+                               LiteralF32(0));
+}
+
+// == Types ====================================================================================
+
+TEST(IrTypeTests, IdenticalTypesCompareEqual) {
+  EXPECT_TRUE(IrType::Vec2f() == IrType::Vec2(ScalarKind::F32));
+  EXPECT_FALSE(IrType::Vec2f() == IrType::Vec2i());
+  EXPECT_FALSE(IrType::Vec2f() == IrType::Vec3f());
+
+  const IrType arrayA =
+      GetShaderResultOrFail(IrType::SizedArray(IrType::Vec4f(), 4), IrType::F32());
+  const IrType arrayB =
+      GetShaderResultOrFail(IrType::SizedArray(IrType::Vec4f(), 4), IrType::F32());
+  EXPECT_TRUE(arrayA == arrayB);
+
+  const IrType structA =
+      GetShaderResultOrFail(IrType::Struct("S", {{"a", IrType::F32()}}), IrType::F32());
+  const IrType structB =
+      GetShaderResultOrFail(IrType::Struct("S", {{"a", IrType::F32()}}), IrType::F32());
+  const IrType structC =
+      GetShaderResultOrFail(IrType::Struct("S", {{"a", IrType::U32()}}), IrType::F32());
+  EXPECT_TRUE(structA == structB);
+  EXPECT_FALSE(structA == structC);
+}
+
+TEST(IrTypeTests, RejectsInvalidArraysAndStructs) {
+  EXPECT_THAT(IrType::SizedArray(IrType::F32(), 0),
+              IsShaderError(HasSubstr("count must be nonzero")));
+  EXPECT_THAT(IrType::SizedArray(IrType::Texture2dF32(), 2),
+              IsShaderError(HasSubstr("not plain data")));
+
+  const IrType runtimeArray =
+      GetShaderResultOrFail(IrType::RuntimeArray(IrType::F32()), IrType::F32());
+  EXPECT_THAT(IrType::SizedArray(runtimeArray, 2), IsShaderError(HasSubstr("not plain data")));
+
+  EXPECT_THAT(IrType::Struct("Empty", {}), IsShaderError(HasSubstr("at least one member")));
+  EXPECT_THAT(IrType::Struct("Dup", {{"a", IrType::F32()}, {"a", IrType::U32()}}),
+              IsShaderError(HasSubstr("duplicate member name a")));
+  EXPECT_THAT(IrType::Struct("Bad", {{"tex", IrType::Texture2dF32()}}),
+              IsShaderError(HasSubstr("not plain data")));
+}
+
+// == Expressions ==============================================================================
+
+TEST(IrExprTests, ArithmeticRequiresMatchingNumericTypes) {
+  EXPECT_THAT(Add(F32Val(), F32Val()), HasShaderResult());
+  EXPECT_THAT(Add(F32Val(), Vec2fVal()), IsShaderError(HasSubstr("matching numeric")));
+  EXPECT_THAT(Add(LiteralBool(true), LiteralBool(false)),
+              IsShaderError(HasSubstr("matching numeric")));
+  EXPECT_THAT(Div(LiteralU32(4), LiteralU32(2)), HasShaderResult());
+}
+
+TEST(IrExprTests, MulSupportsMatrixAndScalarVectorForms) {
+  // mat4x4f * vec4f and mat4x4f * mat4x4f (slug_fill composes the MVP with the instance matrix).
+  const IrExpr matVec = GetShaderResultOrFail(Mul(Mat4Val(), Vec4fVal()), LiteralF32(0));
+  EXPECT_TRUE(matVec.type() == IrType::Vec4f());
+  const IrExpr matMat = GetShaderResultOrFail(Mul(Mat4Val(), Mat4Val()), LiteralF32(0));
+  EXPECT_TRUE(matMat.type() == IrType::Mat4x4f());
+  EXPECT_THAT(Mul(Mat4Val(), Vec2fVal()), IsShaderError(HasSubstr("mat4x4<f32> can multiply")));
+
+  // vector * scalar and scalar * vector.
+  const IrExpr vecScalar = GetShaderResultOrFail(Mul(Vec2fVal(), F32Val()), LiteralF32(0));
+  EXPECT_TRUE(vecScalar.type() == IrType::Vec2f());
+  const IrExpr scalarVec = GetShaderResultOrFail(Mul(F32Val(), Vec2fVal()), LiteralF32(0));
+  EXPECT_TRUE(scalarVec.type() == IrType::Vec2f());
+}
+
+TEST(IrExprTests, ComparisonsAreScalarOnlyAndYieldBool) {
+  const IrExpr cmp = GetShaderResultOrFail(Lt(F32Val(), F32Val()), LiteralF32(0));
+  EXPECT_TRUE(cmp.type() == IrType::Bool());
+  EXPECT_THAT(Ge(Vec2fVal(), Vec2fVal()), IsShaderError(HasSubstr("scalar")));
+  EXPECT_THAT(Eq(LiteralBool(true), LiteralBool(false)), HasShaderResult());
+  EXPECT_THAT(Lt(LiteralBool(true), LiteralBool(false)), IsShaderError(HasSubstr("numeric")));
+}
+
+TEST(IrExprTests, LogicalOpsRequireBool) {
+  EXPECT_THAT(And(LiteralBool(true), LiteralBool(false)), HasShaderResult());
+  EXPECT_THAT(Or(LiteralBool(true), F32Val()), IsShaderError(HasSubstr("must be bool")));
+  EXPECT_THAT(Not(F32Val()), IsShaderError(HasSubstr("requires bool")));
+}
+
+TEST(IrExprTests, NegRejectsU32AndBool) {
+  EXPECT_THAT(Neg(F32Val()), HasShaderResult());
+  EXPECT_THAT(Neg(LiteralI32(-2)), HasShaderResult());
+  EXPECT_THAT(Neg(LiteralU32(1)), IsShaderError(HasSubstr("unary minus")));
+  EXPECT_THAT(Neg(LiteralBool(true)), IsShaderError(HasSubstr("unary minus")));
+}
+
+TEST(IrExprTests, SwizzleValidatesComponents) {
+  const IrExpr xy = GetShaderResultOrFail(Swizzle(Vec4fVal(), "xy"), LiteralF32(0));
+  EXPECT_TRUE(xy.type() == IrType::Vec2f());
+  const IrExpr x = GetShaderResultOrFail(Swizzle(Vec2fVal(), "x"), LiteralF32(0));
+  EXPECT_TRUE(x.type() == IrType::F32());
+
+  EXPECT_THAT(Swizzle(Vec2fVal(), "q"), IsShaderError(HasSubstr("out of range")));
+  EXPECT_THAT(Swizzle(Vec2fVal(), "xyz"), IsShaderError(HasSubstr("out of range")));
+  EXPECT_THAT(Swizzle(Vec2fVal(), ""), IsShaderError(HasSubstr("1-4 components")));
+  EXPECT_THAT(Swizzle(F32Val(), "x"), IsShaderError(HasSubstr("requires a vector")));
+}
+
+TEST(IrExprTests, MemberAccessValidatesStructMembers) {
+  const IrType structType =
+      GetShaderResultOrFail(IrType::Struct("Quad", {{"p0", IrType::Vec2f()}}), IrType::F32());
+  const IrExpr structRef = MakeRef(RefKind::Let, "q", structType);
+
+  const IrExpr member = GetShaderResultOrFail(Member(structRef, "p0"), LiteralF32(0));
+  EXPECT_TRUE(member.type() == IrType::Vec2f());
+  EXPECT_THAT(Member(structRef, "missing"), IsShaderError(HasSubstr("no member named")));
+  EXPECT_THAT(Member(F32Val(), "x"), IsShaderError(HasSubstr("requires a struct")));
+}
+
+TEST(IrExprTests, IndexValidatesBaseAndIndexTypes) {
+  const IrType runtimeArray =
+      GetShaderResultOrFail(IrType::RuntimeArray(IrType::F32()), IrType::F32());
+  const IrExpr arrayRef = MakeRef(RefKind::Resource, "curveData", runtimeArray);
+
+  const IrExpr element = GetShaderResultOrFail(Index(arrayRef, LiteralU32(3)), LiteralF32(0));
+  EXPECT_TRUE(element.type() == IrType::F32());
+
+  const IrExpr vectorElement =
+      GetShaderResultOrFail(Index(Vec4fVal(), LiteralI32(1)), LiteralF32(0));
+  EXPECT_TRUE(vectorElement.type() == IrType::F32());
+
+  EXPECT_THAT(Index(arrayRef, F32Val()), IsShaderError(HasSubstr("index must be i32 or u32")));
+  EXPECT_THAT(Index(F32Val(), LiteralU32(0)), IsShaderError(HasSubstr("not indexable")));
+}
+
+TEST(IrExprTests, ConstructorsValidateArityAndTypes) {
+  EXPECT_THAT(ConstructVector(IrType::Vec4f(), {Vec2fVal(), LiteralF32(0), LiteralF32(1)}),
+              HasShaderResult());
+  EXPECT_THAT(ConstructVector(IrType::Vec4f(), {Vec2fVal(), LiteralF32(0)}),
+              IsShaderError(HasSubstr("needs 4 components, got 3")));
+  EXPECT_THAT(ConstructVector(IrType::Vec2f(), {LiteralI32(0), LiteralI32(1)}),
+              IsShaderError(HasSubstr("does not match target")));
+
+  // Single-scalar splat, e.g. vec2i(0).
+  const IrExpr splat =
+      GetShaderResultOrFail(ConstructVector(IrType::Vec2i(), {LiteralI32(0)}), LiteralF32(0));
+  EXPECT_TRUE(splat.type() == IrType::Vec2i());
+
+  EXPECT_THAT(ConstructMat4x4f({Vec4fVal(), Vec4fVal()}),
+              IsShaderError(HasSubstr("needs 4 columns")));
+  EXPECT_THAT(ConstructMat4x4f({Vec4fVal(), Vec4fVal(), Vec4fVal(), Vec2fVal()}),
+              IsShaderError(HasSubstr("columns must be vec4<f32>")));
+}
+
+TEST(IrExprTests, ConversionsValidateShapes) {
+  EXPECT_THAT(Convert(IrType::F32(), LiteralU32(4)), HasShaderResult());
+  EXPECT_THAT(Convert(IrType::I32(), LiteralU32(4)), HasShaderResult());
+  EXPECT_THAT(Convert(IrType::Vec2i(), Vec2fVal()), HasShaderResult());
+  EXPECT_THAT(Convert(IrType::Vec2i(), LiteralI32(0)), HasShaderResult());  // Splat.
+  EXPECT_THAT(Convert(IrType::Vec4f(), Vec2fVal()), IsShaderError(HasSubstr("cannot convert")));
+  EXPECT_THAT(Convert(IrType::Bool(), F32Val()),
+              IsShaderError(HasSubstr("numeric scalar or vector")));
+}
+
+TEST(IrExprTests, BuiltinCallsTypeCheck) {
+  EXPECT_THAT(CallBuiltin(BuiltinFn::Clamp, {F32Val(), F32Val(), F32Val()}), HasShaderResult());
+  EXPECT_THAT(CallBuiltin(BuiltinFn::Clamp, {F32Val(), F32Val()}),
+              IsShaderError(HasSubstr("expects 3 arguments")));
+  EXPECT_THAT(CallBuiltin(BuiltinFn::Clamp, {F32Val(), F32Val(), LiteralU32(0)}),
+              IsShaderError(HasSubstr("matching numeric")));
+  EXPECT_THAT(CallBuiltin(BuiltinFn::Saturate, {LiteralU32(0)}),
+              IsShaderError(HasSubstr("f32 scalar or vector")));
+  EXPECT_THAT(CallBuiltin(BuiltinFn::Length, {Vec2fVal()}), HasShaderResult());
+  EXPECT_THAT(CallBuiltin(BuiltinFn::Length, {F32Val()}), IsShaderError(HasSubstr("float vector")));
+  EXPECT_THAT(CallBuiltin(BuiltinFn::Select, {F32Val(), F32Val(), LiteralBool(true)}),
+              HasShaderResult());
+  EXPECT_THAT(CallBuiltin(BuiltinFn::Select, {F32Val(), F32Val(), F32Val()}),
+              IsShaderError(HasSubstr("condition must be bool")));
+
+  const IrExpr texture = MakeRef(RefKind::Resource, "tex", IrType::Texture2dF32());
+  const IrExpr sampler = MakeRef(RefKind::Resource, "smp", IrType::SamplerType());
+  EXPECT_THAT(CallBuiltin(BuiltinFn::TextureSample, {texture, sampler, Vec2fVal()}),
+              HasShaderResult());
+  EXPECT_THAT(CallBuiltin(BuiltinFn::TextureSample, {texture, texture, Vec2fVal()}),
+              IsShaderError(HasSubstr("textureSample requires")));
+  EXPECT_THAT(CallBuiltin(BuiltinFn::TextureDimensions, {texture}), HasShaderResult());
+
+  const IrExpr dims =
+      GetShaderResultOrFail(CallBuiltin(BuiltinFn::TextureDimensions, {texture}), LiteralF32(0));
+  EXPECT_TRUE(dims.type() == IrType::Vec2u());
+}
+
+TEST(IrExprTests, UnknownBuiltinNameIsRejected) {
+  EXPECT_THAT(CallBuiltinNamed("clamp", {F32Val(), F32Val(), F32Val()}), HasShaderResult());
+  EXPECT_THAT(CallBuiltinNamed("dot", {Vec2fVal(), Vec2fVal()}),
+              IsShaderError(HasSubstr("unknown builtin function \"dot\"")));
+}
+
+// == Module and function builders =============================================================
+
+TEST(ModuleBuilderTests, RejectsDuplicateBindingsAndNames) {
+  ModuleBuilder builder;
+  EXPECT_THAT(builder.addTexture2d(0, 3, "patternTexture"), IsShaderOk());
+  EXPECT_THAT(builder.addSampler(0, 3, "patternSampler"),
+              IsShaderError(HasSubstr("(group=0, binding=3) is already in use")));
+  EXPECT_THAT(builder.addSampler(0, 4, "patternTexture"),
+              IsShaderError(HasSubstr("already exists")));
+  EXPECT_THAT(builder.addSampler(0, 4, "patternSampler"), IsShaderOk());
+}
+
+TEST(ModuleBuilderTests, ValidatesBindingTypes) {
+  ModuleBuilder builder;
+  EXPECT_THAT(builder.addUniformBuffer(0, 0, "uniforms", IrType::F32()),
+              IsShaderError(HasSubstr("must be a struct")));
+  EXPECT_THAT(builder.addReadOnlyStorageBuffer(0, 1, "data", IrType::Vec4f()),
+              IsShaderError(HasSubstr("runtime array or struct")));
+
+  const IrType runtimeArray =
+      GetShaderResultOrFail(IrType::RuntimeArray(IrType::F32()), IrType::F32());
+  EXPECT_THAT(builder.addReadOnlyStorageBuffer(0, 1, "data", runtimeArray), IsShaderOk());
+}
+
+TEST(ModuleBuilderTests, ConstantsMustBeLiterals) {
+  ModuleBuilder builder;
+  EXPECT_THAT(builder.addConstant("kNoBand", LiteralU32(0xFFFFFFFFu)), IsShaderOk());
+  EXPECT_THAT(builder.addConstant("kBad", Vec2fVal()),
+              IsShaderError(HasSubstr("must be literals")));
+}
+
+class FunctionBuilderTests : public testing::Test {
+protected:
+  /// Starts a plain void function with an f32 parameter `t` and a vec2f parameter `p`.
+  FunctionBuilder startFunction(const std::optional<IrType>& returnType = std::nullopt) {
+    auto result = builder_.createFunction(
+        "helper", {IrParam{"t", IrType::F32()}, IrParam{"p", IrType::Vec2f()}}, returnType);
+    EXPECT_THAT(result, HasShaderResult());
+    return std::move(result).result();
+  }
+
+  ModuleBuilder builder_;
+};
+
+TEST_F(FunctionBuilderTests, RefResolvesParamsAndRejectsUnknownNames) {
+  FunctionBuilder function = startFunction();
+  EXPECT_THAT(function.ref("t"), HasShaderResult());
+  EXPECT_THAT(function.ref("unknown"), IsShaderError(HasSubstr("unknown name")));
+}
+
+TEST_F(FunctionBuilderTests, DuplicateLocalNamesAreRejected) {
+  FunctionBuilder function = startFunction();
+  EXPECT_THAT(function.addLet("x", LiteralF32(1.0f)), HasShaderResult());
+  EXPECT_THAT(function.addLet("x", LiteralF32(2.0f)), IsShaderError(HasSubstr("already declared")));
+  // The duplicate declaration poisons the builder; finish returns the first error.
+  EXPECT_THAT(function.finish(), IsShaderError(HasSubstr("already declared")));
+}
+
+TEST_F(FunctionBuilderTests, AssignRequiresMutableLvalueAndMatchingTypes) {
+  FunctionBuilder function = startFunction();
+  const IrExpr let = GetShaderResultOrFail(function.addLet("x", LiteralF32(1)), LiteralF32(0));
+  const IrExpr var =
+      GetShaderResultOrFail(function.addVar("y", IrType::F32(), LiteralF32(0)), LiteralF32(0));
+
+  EXPECT_THAT(function.assign(var, LiteralF32(2)), IsShaderOk());
+  EXPECT_THAT(function.assign(let, LiteralF32(2)),
+              IsShaderError(HasSubstr("not a mutable lvalue")));
+}
+
+TEST_F(FunctionBuilderTests, AssignThroughVarChainsIncludingSwizzledComponent) {
+  FunctionBuilder function = startFunction();
+  const IrExpr vec =
+      GetShaderResultOrFail(function.addVar("v", IrType::Vec4f(), Vec4fVal()), LiteralF32(0));
+
+  const IrExpr component = GetShaderResultOrFail(Swizzle(vec, "x"), LiteralF32(0));
+  EXPECT_THAT(function.assign(component, LiteralF32(5)), IsShaderOk());
+
+  // Multi-component swizzles are not assignable.
+  const IrExpr twoComponents = GetShaderResultOrFail(Swizzle(vec, "xy"), LiteralF32(0));
+  EXPECT_THAT(function.assign(twoComponents, Vec2fVal()),
+              IsShaderError(HasSubstr("not a mutable lvalue")));
+}
+
+TEST_F(FunctionBuilderTests, VarInitializerMustMatchDeclaredType) {
+  FunctionBuilder function = startFunction();
+  EXPECT_THAT(function.addVar("v", IrType::F32(), LiteralU32(0)),
+              IsShaderError(HasSubstr("does not match declared type")));
+}
+
+TEST_F(FunctionBuilderTests, IfConditionMustBeBool) {
+  FunctionBuilder function = startFunction();
+  EXPECT_THAT(function.beginIf(LiteralF32(1)), IsShaderError(HasSubstr("must be bool")));
+}
+
+TEST_F(FunctionBuilderTests, BreakAndContinueRequireALoop) {
+  FunctionBuilder function = startFunction();
+  EXPECT_THAT(function.breakStmt(), IsShaderError(HasSubstr("outside of a loop")));
+}
+
+TEST_F(FunctionBuilderTests, ForLoopWithBreakAndContinue) {
+  FunctionBuilder function = startFunction();
+  const IrExpr i = GetShaderResultOrFail(function.beginFor("i", LiteralU32(0)), LiteralF32(0));
+  EXPECT_THAT(function.forCondition(GetShaderResultOrFail(Lt(i, LiteralU32(4)), LiteralF32(0))),
+              IsShaderOk());
+  EXPECT_THAT(
+      function.forContinuing(i, GetShaderResultOrFail(Add(i, LiteralU32(1)), LiteralF32(0))),
+      IsShaderOk());
+  EXPECT_THAT(function.continueStmt(), IsShaderOk());
+  EXPECT_THAT(function.breakStmt(), IsShaderOk());
+  EXPECT_THAT(function.endFor(), IsShaderOk());
+  EXPECT_THAT(function.finish(), IsShaderOk());
+}
+
+TEST_F(FunctionBuilderTests, FinishWithOpenBlockFails) {
+  FunctionBuilder function = startFunction();
+  EXPECT_THAT(function.beginIf(LiteralBool(true)), IsShaderOk());
+  EXPECT_THAT(function.finish(), IsShaderError(HasSubstr("open if/for block")));
+}
+
+TEST_F(FunctionBuilderTests, ReturnTypeIsChecked) {
+  FunctionBuilder function = startFunction(IrType::F32());
+  EXPECT_THAT(function.returnValue(LiteralU32(0)),
+              IsShaderError(HasSubstr("return type mismatch")));
+}
+
+TEST_F(FunctionBuilderTests, DiscardIsFragmentOnly) {
+  FunctionBuilder function = startFunction();
+  EXPECT_THAT(function.discard(), IsShaderError(HasSubstr("only valid in fragment entry points")));
+}
+
+TEST(EntryPointTests, VertexValidatesBuiltinsAndPosition) {
+  ModuleBuilder builder;
+
+  // Missing position output.
+  EXPECT_THAT(builder.createVertexEntryPoint("vsMain", {IrParam{"pos", IrType::Vec2f(), 0}},
+                                             {IrOutputMember{"uv", IrType::Vec2f(), 0}}),
+              IsShaderError(HasSubstr("exactly one position builtin")));
+
+  // Wrong builtin input type.
+  EXPECT_THAT(
+      builder.createVertexEntryPoint(
+          "vsMain",
+          {IrParam{"instance_index", IrType::F32(), std::nullopt, BuiltinInput::InstanceIndex}},
+          {IrOutputMember{"clip_pos", IrType::Vec4f(), std::nullopt, BuiltinOutput::Position}}),
+      IsShaderError(HasSubstr("instance_index: u32")));
+
+  // Duplicate input locations.
+  EXPECT_THAT(
+      builder.createVertexEntryPoint(
+          "vsMain", {IrParam{"a", IrType::Vec2f(), 0}, IrParam{"b", IrType::Vec2f(), 0}},
+          {IrOutputMember{"clip_pos", IrType::Vec4f(), std::nullopt, BuiltinOutput::Position}}),
+      IsShaderError(HasSubstr("duplicate stage IO location 0")));
+}
+
+TEST(EntryPointTests, FragmentValidatesColorOutputAndDiscard) {
+  ModuleBuilder builder;
+
+  EXPECT_THAT(builder.createFragmentEntryPoint("fsMain", {IrParam{"uv", IrType::Vec2f(), 0}},
+                                               {IrOutputMember{"color", IrType::Vec2f(), 0}}),
+              IsShaderError(HasSubstr("location-0 vec4<f32> color output")));
+
+  auto fragment = builder.createFragmentEntryPoint("fsMain", {IrParam{"uv", IrType::Vec2f(), 0}},
+                                                   {IrOutputMember{"color", IrType::Vec4f(), 0}});
+  ASSERT_THAT(fragment, HasShaderResult());
+  FunctionBuilder function = std::move(fragment).result();
+  EXPECT_THAT(function.discard(), IsShaderOk());
+  EXPECT_THAT(function.returnOutputs({Vec4fVal()}), IsShaderOk());
+  EXPECT_THAT(function.finish(), IsShaderOk());
+}
+
+TEST(EntryPointTests, ReturnOutputsTypeChecked) {
+  ModuleBuilder builder;
+  auto vertex = builder.createVertexEntryPoint(
+      "vsMain", {IrParam{"pos", IrType::Vec2f(), 0}},
+      {IrOutputMember{"clip_pos", IrType::Vec4f(), std::nullopt, BuiltinOutput::Position},
+       IrOutputMember{"sample_pos", IrType::Vec2f(), 0}});
+  ASSERT_THAT(vertex, HasShaderResult());
+  FunctionBuilder function = std::move(vertex).result();
+
+  EXPECT_THAT(function.returnOutputs({Vec4fVal()}),
+              IsShaderError(HasSubstr("declares 2 outputs, got 1")));
+}
+
+TEST(ModuleBuilderTests, CallFunctionChecksSignature) {
+  ModuleBuilder builder;
+  {
+    auto helper = builder.createFunction("scale", {IrParam{"x", IrType::F32()}}, IrType::F32());
+    ASSERT_THAT(helper, HasShaderResult());
+    FunctionBuilder function = std::move(helper).result();
+    const IrExpr x = GetShaderResultOrFail(function.ref("x"), LiteralF32(0));
+    EXPECT_THAT(function.returnValue(GetShaderResultOrFail(Mul(x, LiteralF32(2)), LiteralF32(0))),
+                IsShaderOk());
+    EXPECT_THAT(function.finish(), IsShaderOk());
+  }
+
+  // Errors poison the function builder, so each rejection uses a fresh (abandoned) builder.
+  {
+    auto caller = builder.createFunction("callerA", {}, IrType::F32());
+    ASSERT_THAT(caller, HasShaderResult());
+    FunctionBuilder function = std::move(caller).result();
+    EXPECT_THAT(function.callFunction("missing", {LiteralF32(1)}),
+                IsShaderError(HasSubstr("unknown function")));
+  }
+  {
+    auto caller = builder.createFunction("callerB", {}, IrType::F32());
+    ASSERT_THAT(caller, HasShaderResult());
+    FunctionBuilder function = std::move(caller).result();
+    EXPECT_THAT(function.callFunction("scale", {}),
+                IsShaderError(HasSubstr("takes 1 arguments, got 0")));
+    EXPECT_THAT(function.callFunction("scale", {LiteralU32(1)}),
+                IsShaderError(HasSubstr("takes 1 arguments, got 0")));  // Poisoned: first error.
+  }
+}
+
+TEST(ModuleBuilderTests, ResourceRefsResolveInsideFunctions) {
+  ModuleBuilder builder;
+  const IrType bandArray = GetShaderResultOrFail(
+      IrType::RuntimeArray(GetShaderResultOrFail(
+          IrType::Struct("Band", {{"curveStart", IrType::U32()}}), IrType::F32())),
+      IrType::F32());
+  EXPECT_THAT(builder.addReadOnlyStorageBuffer(0, 1, "bands", bandArray), IsShaderOk());
+  EXPECT_THAT(builder.addConstant("kNoBand", LiteralU32(0xFFFFFFFFu)), IsShaderOk());
+
+  auto helper = builder.createFunction("probe", {}, IrType::U32());
+  ASSERT_THAT(helper, HasShaderResult());
+  FunctionBuilder function = std::move(helper).result();
+
+  const IrExpr bands = GetShaderResultOrFail(function.ref("bands"), LiteralF32(0));
+  const IrExpr band = GetShaderResultOrFail(Index(bands, LiteralU32(0)), LiteralF32(0));
+  const IrExpr curveStart = GetShaderResultOrFail(Member(band, "curveStart"), LiteralF32(0));
+  EXPECT_THAT(function.ref("kNoBand"), HasShaderResult());
+  EXPECT_THAT(function.returnValue(curveStart), IsShaderOk());
+  EXPECT_THAT(function.finish(), IsShaderOk());
+}
+
+}  // namespace
+}  // namespace donner::gpu::shader

--- a/donner/gpu/shader/tests/IrBuilder_tests.cc
+++ b/donner/gpu/shader/tests/IrBuilder_tests.cc
@@ -37,15 +37,15 @@ IrExpr Mat4Val() {
 // == Types ====================================================================================
 
 TEST(IrTypeTests, IdenticalTypesCompareEqual) {
-  EXPECT_TRUE(IrType::Vec2f() == IrType::Vec2(ScalarKind::F32));
-  EXPECT_FALSE(IrType::Vec2f() == IrType::Vec2i());
-  EXPECT_FALSE(IrType::Vec2f() == IrType::Vec3f());
+  EXPECT_EQ(IrType::Vec2f(), IrType::Vec2(ScalarKind::F32));
+  EXPECT_NE(IrType::Vec2f(), IrType::Vec2i());
+  EXPECT_NE(IrType::Vec2f(), IrType::Vec3f());
 
   const IrType arrayA =
       GetShaderResultOrFail(IrType::SizedArray(IrType::Vec4f(), 4), IrType::F32());
   const IrType arrayB =
       GetShaderResultOrFail(IrType::SizedArray(IrType::Vec4f(), 4), IrType::F32());
-  EXPECT_TRUE(arrayA == arrayB);
+  EXPECT_EQ(arrayA, arrayB);
 
   const IrType structA =
       GetShaderResultOrFail(IrType::Struct("S", {{"a", IrType::F32()}}), IrType::F32());
@@ -53,8 +53,8 @@ TEST(IrTypeTests, IdenticalTypesCompareEqual) {
       GetShaderResultOrFail(IrType::Struct("S", {{"a", IrType::F32()}}), IrType::F32());
   const IrType structC =
       GetShaderResultOrFail(IrType::Struct("S", {{"a", IrType::U32()}}), IrType::F32());
-  EXPECT_TRUE(structA == structB);
-  EXPECT_FALSE(structA == structC);
+  EXPECT_EQ(structA, structB);
+  EXPECT_NE(structA, structC);
 }
 
 TEST(IrTypeTests, RejectsInvalidArraysAndStructs) {
@@ -87,21 +87,33 @@ TEST(IrExprTests, ArithmeticRequiresMatchingNumericTypes) {
 TEST(IrExprTests, MulSupportsMatrixAndScalarVectorForms) {
   // mat4x4f * vec4f and mat4x4f * mat4x4f (slug_fill composes the MVP with the instance matrix).
   const IrExpr matVec = GetShaderResultOrFail(Mul(Mat4Val(), Vec4fVal()), LiteralF32(0));
-  EXPECT_TRUE(matVec.type() == IrType::Vec4f());
+  EXPECT_EQ(matVec.type(), IrType::Vec4f());
   const IrExpr matMat = GetShaderResultOrFail(Mul(Mat4Val(), Mat4Val()), LiteralF32(0));
-  EXPECT_TRUE(matMat.type() == IrType::Mat4x4f());
+  EXPECT_EQ(matMat.type(), IrType::Mat4x4f());
   EXPECT_THAT(Mul(Mat4Val(), Vec2fVal()), IsShaderError(HasSubstr("mat4x4<f32> can multiply")));
 
   // vector * scalar and scalar * vector.
   const IrExpr vecScalar = GetShaderResultOrFail(Mul(Vec2fVal(), F32Val()), LiteralF32(0));
-  EXPECT_TRUE(vecScalar.type() == IrType::Vec2f());
+  EXPECT_EQ(vecScalar.type(), IrType::Vec2f());
   const IrExpr scalarVec = GetShaderResultOrFail(Mul(F32Val(), Vec2fVal()), LiteralF32(0));
-  EXPECT_TRUE(scalarVec.type() == IrType::Vec2f());
+  EXPECT_EQ(scalarVec.type(), IrType::Vec2f());
+}
+
+TEST(IrExprTests, DivSupportsVectorScalarForms) {
+  // scalar / vector broadcast: slug_fill computes 1.0 / fwidth(sample_pos) (f32 / vec2f).
+  const IrExpr scalarVec = GetShaderResultOrFail(Div(F32Val(), Vec2fVal()), LiteralF32(0));
+  EXPECT_EQ(scalarVec.type(), IrType::Vec2f());
+
+  const IrExpr vecScalar = GetShaderResultOrFail(Div(Vec2fVal(), F32Val()), LiteralF32(0));
+  EXPECT_EQ(vecScalar.type(), IrType::Vec2f());
+
+  // Element types must still match.
+  EXPECT_THAT(Div(LiteralI32(1), Vec2fVal()), IsShaderError(HasSubstr("matching numeric")));
 }
 
 TEST(IrExprTests, ComparisonsAreScalarOnlyAndYieldBool) {
   const IrExpr cmp = GetShaderResultOrFail(Lt(F32Val(), F32Val()), LiteralF32(0));
-  EXPECT_TRUE(cmp.type() == IrType::Bool());
+  EXPECT_EQ(cmp.type(), IrType::Bool());
   EXPECT_THAT(Ge(Vec2fVal(), Vec2fVal()), IsShaderError(HasSubstr("scalar")));
   EXPECT_THAT(Eq(LiteralBool(true), LiteralBool(false)), HasShaderResult());
   EXPECT_THAT(Lt(LiteralBool(true), LiteralBool(false)), IsShaderError(HasSubstr("numeric")));
@@ -122,9 +134,9 @@ TEST(IrExprTests, NegRejectsU32AndBool) {
 
 TEST(IrExprTests, SwizzleValidatesComponents) {
   const IrExpr xy = GetShaderResultOrFail(Swizzle(Vec4fVal(), "xy"), LiteralF32(0));
-  EXPECT_TRUE(xy.type() == IrType::Vec2f());
+  EXPECT_EQ(xy.type(), IrType::Vec2f());
   const IrExpr x = GetShaderResultOrFail(Swizzle(Vec2fVal(), "x"), LiteralF32(0));
-  EXPECT_TRUE(x.type() == IrType::F32());
+  EXPECT_EQ(x.type(), IrType::F32());
 
   EXPECT_THAT(Swizzle(Vec2fVal(), "q"), IsShaderError(HasSubstr("out of range")));
   EXPECT_THAT(Swizzle(Vec2fVal(), "xyz"), IsShaderError(HasSubstr("out of range")));
@@ -138,7 +150,7 @@ TEST(IrExprTests, MemberAccessValidatesStructMembers) {
   const IrExpr structRef = MakeRef(RefKind::Let, "q", structType);
 
   const IrExpr member = GetShaderResultOrFail(Member(structRef, "p0"), LiteralF32(0));
-  EXPECT_TRUE(member.type() == IrType::Vec2f());
+  EXPECT_EQ(member.type(), IrType::Vec2f());
   EXPECT_THAT(Member(structRef, "missing"), IsShaderError(HasSubstr("no member named")));
   EXPECT_THAT(Member(F32Val(), "x"), IsShaderError(HasSubstr("requires a struct")));
 }
@@ -149,11 +161,11 @@ TEST(IrExprTests, IndexValidatesBaseAndIndexTypes) {
   const IrExpr arrayRef = MakeRef(RefKind::Resource, "curveData", runtimeArray);
 
   const IrExpr element = GetShaderResultOrFail(Index(arrayRef, LiteralU32(3)), LiteralF32(0));
-  EXPECT_TRUE(element.type() == IrType::F32());
+  EXPECT_EQ(element.type(), IrType::F32());
 
   const IrExpr vectorElement =
       GetShaderResultOrFail(Index(Vec4fVal(), LiteralI32(1)), LiteralF32(0));
-  EXPECT_TRUE(vectorElement.type() == IrType::F32());
+  EXPECT_EQ(vectorElement.type(), IrType::F32());
 
   EXPECT_THAT(Index(arrayRef, F32Val()), IsShaderError(HasSubstr("index must be i32 or u32")));
   EXPECT_THAT(Index(F32Val(), LiteralU32(0)), IsShaderError(HasSubstr("not indexable")));
@@ -170,7 +182,7 @@ TEST(IrExprTests, ConstructorsValidateArityAndTypes) {
   // Single-scalar splat, e.g. vec2i(0).
   const IrExpr splat =
       GetShaderResultOrFail(ConstructVector(IrType::Vec2i(), {LiteralI32(0)}), LiteralF32(0));
-  EXPECT_TRUE(splat.type() == IrType::Vec2i());
+  EXPECT_EQ(splat.type(), IrType::Vec2i());
 
   EXPECT_THAT(ConstructMat4x4f({Vec4fVal(), Vec4fVal()}),
               IsShaderError(HasSubstr("needs 4 columns")));
@@ -213,7 +225,7 @@ TEST(IrExprTests, BuiltinCallsTypeCheck) {
 
   const IrExpr dims =
       GetShaderResultOrFail(CallBuiltin(BuiltinFn::TextureDimensions, {texture}), LiteralF32(0));
-  EXPECT_TRUE(dims.type() == IrType::Vec2u());
+  EXPECT_EQ(dims.type(), IrType::Vec2u());
 }
 
 TEST(IrExprTests, UnknownBuiltinNameIsRejected) {
@@ -350,6 +362,73 @@ TEST_F(FunctionBuilderTests, ReturnTypeIsChecked) {
 TEST_F(FunctionBuilderTests, DiscardIsFragmentOnly) {
   FunctionBuilder function = startFunction();
   EXPECT_THAT(function.discard(), IsShaderError(HasSubstr("only valid in fragment entry points")));
+}
+
+TEST_F(FunctionBuilderTests, NonVoidFunctionMustEndWithReturn) {
+  FunctionBuilder function = startFunction(IrType::F32());
+  EXPECT_THAT(function.addLet("x", LiteralF32(1)), HasShaderResult());
+
+  // The body ends with a let, not a return; if/for-nested returns would not count either.
+  EXPECT_THAT(function.finish(), IsShaderError(HasSubstr("must end with a return")));
+}
+
+TEST_F(FunctionBuilderTests, VoidFunctionNeedsNoReturn) {
+  FunctionBuilder function = startFunction();
+  EXPECT_THAT(function.addLet("x", LiteralF32(1)), HasShaderResult());
+  EXPECT_THAT(function.finish(), IsShaderOk());
+}
+
+TEST_F(FunctionBuilderTests, LoopVariableGoesOutOfScopeAtEndFor) {
+  FunctionBuilder function = startFunction();
+  const IrExpr i = GetShaderResultOrFail(function.beginFor("i", LiteralU32(0)), LiteralF32(0));
+  EXPECT_THAT(function.forCondition(GetShaderResultOrFail(Lt(i, LiteralU32(4)), LiteralF32(0))),
+              IsShaderOk());
+  EXPECT_THAT(
+      function.forContinuing(i, GetShaderResultOrFail(Add(i, LiteralU32(1)), LiteralF32(0))),
+      IsShaderOk());
+  EXPECT_THAT(function.endFor(), IsShaderOk());
+
+  // The loop variable is block-scoped: name lookup fails closed after endFor.
+  EXPECT_THAT(function.ref("i"), IsShaderError(HasSubstr("unknown name i")));
+}
+
+TEST_F(FunctionBuilderTests, StaleExprFromClosedBlockFailsClosed) {
+  FunctionBuilder function = startFunction();
+
+  EXPECT_THAT(function.beginIf(LiteralBool(true)), IsShaderOk());
+  const IrExpr scoped = GetShaderResultOrFail(function.addLet("x", LiteralF32(1)), LiteralF32(0));
+  EXPECT_THAT(function.endIf(), IsShaderOk());
+
+  // The expression handle survives the block, but recording it after endIf must fail closed.
+  EXPECT_THAT(function.addLet("y", scoped), IsShaderError(HasSubstr("x which is out of scope")));
+}
+
+TEST_F(FunctionBuilderTests, AssignToVarFromClosedBlockFailsClosed) {
+  FunctionBuilder function = startFunction();
+
+  const IrExpr i = GetShaderResultOrFail(function.beginFor("i", LiteralU32(0)), LiteralF32(0));
+  EXPECT_THAT(function.forCondition(GetShaderResultOrFail(Lt(i, LiteralU32(4)), LiteralF32(0))),
+              IsShaderOk());
+  EXPECT_THAT(
+      function.forContinuing(i, GetShaderResultOrFail(Add(i, LiteralU32(1)), LiteralF32(0))),
+      IsShaderOk());
+  const IrExpr scopedVar =
+      GetShaderResultOrFail(function.addVar("scoped", IrType::U32(), LiteralU32(0)), LiteralF32(0));
+  EXPECT_THAT(function.endFor(), IsShaderOk());
+
+  EXPECT_THAT(function.assign(scopedVar, LiteralU32(1)),
+              IsShaderError(HasSubstr("scoped which is out of scope")));
+}
+
+TEST(EntryPointTests, DuplicateBuiltinParamsAreRejected) {
+  ModuleBuilder builder;
+  EXPECT_THAT(
+      builder.createVertexEntryPoint(
+          "vsMain",
+          {IrParam{"a", IrType::U32(), std::nullopt, BuiltinInput::InstanceIndex},
+           IrParam{"b", IrType::U32(), std::nullopt, BuiltinInput::InstanceIndex}},
+          {IrOutputMember{"clip_pos", IrType::Vec4f(), std::nullopt, BuiltinOutput::Position}}),
+      IsShaderError(HasSubstr("duplicate stage IO builtin")));
 }
 
 TEST(EntryPointTests, VertexValidatesBuiltinsAndPosition) {

--- a/donner/gpu/shader/tests/IrBuilder_tests.cc
+++ b/donner/gpu/shader/tests/IrBuilder_tests.cc
@@ -392,6 +392,54 @@ TEST(EntryPointTests, FragmentValidatesColorOutputAndDiscard) {
   EXPECT_THAT(function.finish(), IsShaderOk());
 }
 
+TEST(EntryPointTests, FragmentAcceptsPositionBuiltinInput) {
+  // slug_fill's fs_main consumes @builtin(position) as pixel_center; the IR must express it.
+  ModuleBuilder builder;
+  auto fragment = builder.createFragmentEntryPoint(
+      "fsMain",
+      {IrParam{"clip_pos", IrType::Vec4f(), std::nullopt, BuiltinInput::Position},
+       IrParam{"sample_pos", IrType::Vec2f(), 0}},
+      {IrOutputMember{"color", IrType::Vec4f(), 0}});
+  ASSERT_THAT(fragment, HasShaderResult());
+  FunctionBuilder function = std::move(fragment).result();
+
+  // The builtin param resolves like any other input.
+  const IrExpr clipPos = GetShaderResultOrFail(function.ref("clip_pos"), LiteralF32(0));
+  EXPECT_EQ(clipPos.type(), IrType::Vec4f());
+  const IrExpr pixelCenter = GetShaderResultOrFail(Swizzle(clipPos, "xy"), LiteralF32(0));
+  EXPECT_EQ(pixelCenter.type(), IrType::Vec2f());
+
+  EXPECT_THAT(function.returnOutputs({Vec4fVal()}), IsShaderOk());
+  EXPECT_THAT(function.finish(), IsShaderOk());
+}
+
+TEST(EntryPointTests, FragmentPositionBuiltinMustBeVec4f) {
+  ModuleBuilder builder;
+  EXPECT_THAT(
+      builder.createFragmentEntryPoint(
+          "fsMain", {IrParam{"clip_pos", IrType::Vec2f(), std::nullopt, BuiltinInput::Position}},
+          {IrOutputMember{"color", IrType::Vec4f(), 0}}),
+      IsShaderError(HasSubstr("position: vec4<f32>")));
+}
+
+TEST(EntryPointTests, FragmentRejectsInstanceIndexBuiltin) {
+  ModuleBuilder builder;
+  EXPECT_THAT(builder.createFragmentEntryPoint("fsMain",
+                                               {IrParam{"instance_index", IrType::U32(),
+                                                        std::nullopt, BuiltinInput::InstanceIndex}},
+                                               {IrOutputMember{"color", IrType::Vec4f(), 0}}),
+              IsShaderError(HasSubstr("position")));
+}
+
+TEST(EntryPointTests, VertexRejectsPositionBuiltinInput) {
+  ModuleBuilder builder;
+  EXPECT_THAT(
+      builder.createVertexEntryPoint(
+          "vsMain", {IrParam{"clip_pos", IrType::Vec4f(), std::nullopt, BuiltinInput::Position}},
+          {IrOutputMember{"out_pos", IrType::Vec4f(), std::nullopt, BuiltinOutput::Position}}),
+      IsShaderError(HasSubstr("instance_index")));
+}
+
 TEST(EntryPointTests, ReturnOutputsTypeChecked) {
   ModuleBuilder builder;
   auto vertex = builder.createVertexEntryPoint(

--- a/donner/gpu/shader/tests/IrLayout_tests.cc
+++ b/donner/gpu/shader/tests/IrLayout_tests.cc
@@ -1,0 +1,225 @@
+/// @file
+/// WGSL layout-rule tests, including the byte-layout anchors that the GPU runtime's C++ mirror
+/// structs (Geode's Uniforms / Band / InstanceTransform) assert.
+
+#include "donner/gpu/shader/IrLayout.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "donner/gpu/shader/IrType.h"
+#include "donner/gpu/shader/tests/ShaderTestUtils.h"
+
+using testing::ElementsAre;
+using testing::Eq;
+using testing::Field;
+using testing::HasSubstr;
+
+namespace donner::gpu::shader {
+namespace {
+
+/// Matches a StructMemberLayout by offset.
+auto OffsetIs(uint32_t offset) {
+  return Field("offsetBytes", &StructMemberLayout::offsetBytes, Eq(offset));
+}
+
+TypeLayout LayoutOrFail(const IrType& type, AddressSpace addressSpace) {
+  return GetShaderResultOrFail(ComputeTypeLayout(type, addressSpace));
+}
+
+StructLayout StructLayoutOrFail(const IrType& type, AddressSpace addressSpace) {
+  ShaderResult<StructLayout> layout = ComputeStructLayout(type, addressSpace);
+  if (layout.hasError()) {
+    ADD_FAILURE() << "Expected a struct layout, got error: " << layout.error();
+    return StructLayout{};
+  }
+  return std::move(layout).result();
+}
+
+TEST(IrLayoutTests, ScalarAndVectorLayouts) {
+  EXPECT_THAT(LayoutOrFail(IrType::F32(), AddressSpace::Storage), Eq(TypeLayout{4, 4}));
+  EXPECT_THAT(LayoutOrFail(IrType::I32(), AddressSpace::Storage), Eq(TypeLayout{4, 4}));
+  EXPECT_THAT(LayoutOrFail(IrType::U32(), AddressSpace::Uniform), Eq(TypeLayout{4, 4}));
+  EXPECT_THAT(LayoutOrFail(IrType::Vec2f(), AddressSpace::Storage), Eq(TypeLayout{8, 8}));
+  EXPECT_THAT(LayoutOrFail(IrType::Vec3f(), AddressSpace::Storage), Eq(TypeLayout{16, 12}));
+  EXPECT_THAT(LayoutOrFail(IrType::Vec4f(), AddressSpace::Storage), Eq(TypeLayout{16, 16}));
+  EXPECT_THAT(LayoutOrFail(IrType::Mat4x4f(), AddressSpace::Storage), Eq(TypeLayout{16, 64}));
+}
+
+TEST(IrLayoutTests, NonHostShareableTypesHaveNoLayout) {
+  EXPECT_THAT(ComputeTypeLayout(IrType::Bool(), AddressSpace::Storage),
+              IsShaderError(HasSubstr("bool is not host-shareable")));
+  EXPECT_THAT(ComputeTypeLayout(IrType::Vec2(ScalarKind::Bool), AddressSpace::Storage),
+              IsShaderError(HasSubstr("vectors of bool")));
+  EXPECT_THAT(ComputeTypeLayout(IrType::Texture2dF32(), AddressSpace::Storage),
+              IsShaderError(HasSubstr("resource type")));
+  EXPECT_THAT(ComputeTypeLayout(IrType::SamplerType(), AddressSpace::Storage),
+              IsShaderError(HasSubstr("resource type")));
+}
+
+TEST(IrLayoutTests, Vec3PaddingInsideStruct) {
+  const IrType structType = GetShaderResultOrFail(
+      IrType::Struct("Padded", {{"a", IrType::Vec3f()}, {"b", IrType::F32()}}), IrType::F32());
+
+  const StructLayout layout = StructLayoutOrFail(structType, AddressSpace::Storage);
+  EXPECT_THAT(layout.alignBytes, Eq(16u));
+  // The f32 packs into the vec3's tail padding at offset 12; the struct rounds to 16.
+  EXPECT_THAT(layout.sizeBytes, Eq(16u));
+  EXPECT_THAT(layout.members, ElementsAre(OffsetIs(0), OffsetIs(12)));
+}
+
+TEST(IrLayoutTests, ArrayStrideStorageVsUniform) {
+  const IrType arrayF32 =
+      GetShaderResultOrFail(IrType::SizedArray(IrType::F32(), 4), IrType::F32());
+  const IrType arrayVec2 =
+      GetShaderResultOrFail(IrType::SizedArray(IrType::Vec2f(), 2), IrType::F32());
+
+  // Storage: stride = roundUp(align, size) of the element.
+  EXPECT_THAT(ComputeArrayStride(arrayF32, AddressSpace::Storage), HasShaderResult());
+  EXPECT_THAT(GetShaderResultOrFail(ComputeArrayStride(arrayF32, AddressSpace::Storage)), Eq(4u));
+  EXPECT_THAT(GetShaderResultOrFail(ComputeArrayStride(arrayVec2, AddressSpace::Storage)), Eq(8u));
+  EXPECT_THAT(LayoutOrFail(arrayF32, AddressSpace::Storage), Eq(TypeLayout{4, 16}));
+
+  // Uniform: element stride rounds up to a multiple of 16.
+  EXPECT_THAT(GetShaderResultOrFail(ComputeArrayStride(arrayF32, AddressSpace::Uniform)), Eq(16u));
+  EXPECT_THAT(GetShaderResultOrFail(ComputeArrayStride(arrayVec2, AddressSpace::Uniform)), Eq(16u));
+  EXPECT_THAT(LayoutOrFail(arrayF32, AddressSpace::Uniform), Eq(TypeLayout{16, 64}));
+}
+
+TEST(IrLayoutTests, RuntimeArrayHasStrideButNoSize) {
+  const IrType runtimeArray =
+      GetShaderResultOrFail(IrType::RuntimeArray(IrType::F32()), IrType::F32());
+
+  EXPECT_THAT(GetShaderResultOrFail(ComputeArrayStride(runtimeArray, AddressSpace::Storage)),
+              Eq(4u));
+  EXPECT_THAT(ComputeTypeLayout(runtimeArray, AddressSpace::Storage),
+              IsShaderError(HasSubstr("no fixed size")));
+}
+
+TEST(IrLayoutTests, NestedStructUniformGets16ByteAlignment) {
+  const IrType inner =
+      GetShaderResultOrFail(IrType::Struct("Inner", {{"x", IrType::F32()}}), IrType::F32());
+  const IrType outer = GetShaderResultOrFail(
+      IrType::Struct("Outer", {{"a", IrType::F32()}, {"b", inner}, {"c", IrType::F32()}}),
+      IrType::F32());
+
+  // Storage: Inner is align 4 size 4; members pack tightly.
+  const StructLayout storageLayout = StructLayoutOrFail(outer, AddressSpace::Storage);
+  EXPECT_THAT(storageLayout.members, ElementsAre(OffsetIs(0), OffsetIs(4), OffsetIs(8)));
+  EXPECT_THAT(storageLayout.sizeBytes, Eq(12u));
+
+  // Uniform: the nested struct member's alignment rounds up to 16.
+  const StructLayout uniformLayout = StructLayoutOrFail(outer, AddressSpace::Uniform);
+  EXPECT_THAT(uniformLayout.members, ElementsAre(OffsetIs(0), OffsetIs(16), OffsetIs(20)));
+  EXPECT_THAT(uniformLayout.alignBytes, Eq(16u));
+  EXPECT_THAT(uniformLayout.sizeBytes, Eq(32u));
+}
+
+// == Anchor structs ===========================================================================
+// These three struct layouts must equal the byte layouts the Geode encoder's C++ mirror structs
+// assert (GeoEncoder.cc): Uniforms == 288 bytes with the commented field offsets, Band == 32
+// bytes, InstanceTransform == 32 bytes. The types are constructed here through the IR type API
+// and laid out by the WGSL rules.
+
+/// Builds the slug_fill `Uniforms` struct via the IR type API.
+IrType MakeSlugFillUniforms() {
+  const IrType planesArray =
+      GetShaderResultOrFail(IrType::SizedArray(IrType::Vec4f(), 4), IrType::F32());
+  return GetShaderResultOrFail(
+      IrType::Struct("Uniforms",
+                     {
+                         {"mvp", IrType::Mat4x4f()},        {"patternFromPath", IrType::Mat4x4f()},
+                         {"viewport", IrType::Vec2f()},     {"tileSize", IrType::Vec2f()},
+                         {"color", IrType::Vec4f()},        {"fillRule", IrType::U32()},
+                         {"paintMode", IrType::U32()},      {"patternOpacity", IrType::F32()},
+                         {"hasClipPolygon", IrType::U32()}, {"hasClipMask", IrType::U32()},
+                         {"_pad0", IrType::U32()},          {"_pad1", IrType::U32()},
+                         {"_pad2", IrType::U32()},          {"yBase", IrType::F32()},
+                         {"hStride", IrType::F32()},        {"hBandCount", IrType::U32()},
+                         {"xBase", IrType::F32()},          {"vStride", IrType::F32()},
+                         {"vBandCount", IrType::U32()},     {"_gridPad0", IrType::U32()},
+                         {"_gridPad1", IrType::U32()},      {"clipPolygonPlanes", planesArray},
+                     }),
+      IrType::F32());
+}
+
+/// Builds the slug_fill `Band` struct via the IR type API.
+IrType MakeSlugFillBand() {
+  return GetShaderResultOrFail(IrType::Struct("Band",
+                                              {
+                                                  {"curveStart", IrType::U32()},
+                                                  {"curveCount", IrType::U32()},
+                                                  {"yMin", IrType::F32()},
+                                                  {"yMax", IrType::F32()},
+                                                  {"xMin", IrType::F32()},
+                                                  {"xMax", IrType::F32()},
+                                                  {"_pad0", IrType::F32()},
+                                                  {"_pad1", IrType::F32()},
+                                              }),
+                               IrType::F32());
+}
+
+/// Builds the slug_fill `InstanceTransform` struct via the IR type API.
+IrType MakeInstanceTransform() {
+  return GetShaderResultOrFail(
+      IrType::Struct("InstanceTransform", {{"row0", IrType::Vec4f()}, {"row1", IrType::Vec4f()}}),
+      IrType::F32());
+}
+
+TEST(IrLayoutAnchorTests, SlugFillUniformsIs288BytesWithEncoderOffsets) {
+  const StructLayout layout = StructLayoutOrFail(MakeSlugFillUniforms(), AddressSpace::Uniform);
+
+  EXPECT_THAT(layout.sizeBytes, Eq(288u));
+  EXPECT_THAT(layout.alignBytes, Eq(16u));
+  // Offsets from the C++ mirror struct comments in GeoEncoder.cc.
+  EXPECT_THAT(layout.members,
+              ElementsAre(OffsetIs(0),      // mvp
+                          OffsetIs(64),     // patternFromPath
+                          OffsetIs(128),    // viewport
+                          OffsetIs(136),    // tileSize
+                          OffsetIs(144),    // color
+                          OffsetIs(160),    // fillRule
+                          OffsetIs(164),    // paintMode
+                          OffsetIs(168),    // patternOpacity
+                          OffsetIs(172),    // hasClipPolygon
+                          OffsetIs(176),    // hasClipMask
+                          OffsetIs(180),    // _pad0
+                          OffsetIs(184),    // _pad1
+                          OffsetIs(188),    // _pad2
+                          OffsetIs(192),    // yBase
+                          OffsetIs(196),    // hStride
+                          OffsetIs(200),    // hBandCount
+                          OffsetIs(204),    // xBase
+                          OffsetIs(208),    // vStride
+                          OffsetIs(212),    // vBandCount
+                          OffsetIs(216),    // _gridPad0
+                          OffsetIs(220),    // _gridPad1
+                          OffsetIs(224)));  // clipPolygonPlanes (224 .. 288)
+}
+
+TEST(IrLayoutAnchorTests, SlugFillBandIs32Bytes) {
+  const StructLayout layout = StructLayoutOrFail(MakeSlugFillBand(), AddressSpace::Storage);
+
+  EXPECT_THAT(layout.sizeBytes, Eq(32u));
+  EXPECT_THAT(layout.alignBytes, Eq(4u));
+  EXPECT_THAT(layout.members, ElementsAre(OffsetIs(0), OffsetIs(4), OffsetIs(8), OffsetIs(12),
+                                          OffsetIs(16), OffsetIs(20), OffsetIs(24), OffsetIs(28)));
+
+  // As a storage runtime array element, the stride equals the struct size.
+  const IrType bandArray =
+      GetShaderResultOrFail(IrType::RuntimeArray(MakeSlugFillBand()), IrType::F32());
+  EXPECT_THAT(GetShaderResultOrFail(ComputeArrayStride(bandArray, AddressSpace::Storage)), Eq(32u));
+}
+
+TEST(IrLayoutAnchorTests, InstanceTransformIs32Bytes) {
+  const StructLayout layout = StructLayoutOrFail(MakeInstanceTransform(), AddressSpace::Storage);
+
+  EXPECT_THAT(layout.sizeBytes, Eq(32u));
+  EXPECT_THAT(layout.alignBytes, Eq(16u));
+  EXPECT_THAT(layout.members, ElementsAre(OffsetIs(0), OffsetIs(16)));
+}
+
+}  // namespace
+}  // namespace donner::gpu::shader

--- a/donner/gpu/shader/tests/IrLayout_tests.cc
+++ b/donner/gpu/shader/tests/IrLayout_tests.cc
@@ -82,10 +82,30 @@ TEST(IrLayoutTests, ArrayStrideStorageVsUniform) {
   EXPECT_THAT(GetShaderResultOrFail(ComputeArrayStride(arrayVec2, AddressSpace::Storage)), Eq(8u));
   EXPECT_THAT(LayoutOrFail(arrayF32, AddressSpace::Storage), Eq(TypeLayout{4, 16}));
 
-  // Uniform: element stride rounds up to a multiple of 16.
+  // Uniform: element stride rounds up to a multiple of 16. This is a deliberate policy: WGSL
+  // validation would reject the natural stride (there is no stride attribute), so the layout
+  // engine defines the rounded stride and emitters must materialize padded element wrappers
+  // when ArrayStrideInfo::paddedFromNatural is set.
   EXPECT_THAT(GetShaderResultOrFail(ComputeArrayStride(arrayF32, AddressSpace::Uniform)), Eq(16u));
   EXPECT_THAT(GetShaderResultOrFail(ComputeArrayStride(arrayVec2, AddressSpace::Uniform)), Eq(16u));
   EXPECT_THAT(LayoutOrFail(arrayF32, AddressSpace::Uniform), Eq(TypeLayout{16, 64}));
+}
+
+TEST(IrLayoutTests, ArrayStrideInfoReportsUniformPadding) {
+  const IrType arrayF32 =
+      GetShaderResultOrFail(IrType::SizedArray(IrType::F32(), 4), IrType::F32());
+  const IrType arrayVec4 =
+      GetShaderResultOrFail(IrType::SizedArray(IrType::Vec4f(), 4), IrType::F32());
+
+  // array<f32, 4> in uniform is padded (natural stride 4 -> 16); the emitter obligation flag is
+  // set so packet 5 wraps the element type.
+  EXPECT_THAT(GetShaderResultOrFail(ComputeArrayStrideInfo(arrayF32, AddressSpace::Uniform)),
+              Eq(ArrayStrideInfo{16, true}));
+  EXPECT_THAT(GetShaderResultOrFail(ComputeArrayStrideInfo(arrayF32, AddressSpace::Storage)),
+              Eq(ArrayStrideInfo{4, false}));
+  // slug_fill's clipPolygonPlanes array<vec4f, 4> has a natural stride of 16: no padding needed.
+  EXPECT_THAT(GetShaderResultOrFail(ComputeArrayStrideInfo(arrayVec4, AddressSpace::Uniform)),
+              Eq(ArrayStrideInfo{16, false}));
 }
 
 TEST(IrLayoutTests, RuntimeArrayHasStrideButNoSize) {

--- a/donner/gpu/shader/tests/IrLayout_tests.cc
+++ b/donner/gpu/shader/tests/IrLayout_tests.cc
@@ -98,7 +98,7 @@ TEST(IrLayoutTests, RuntimeArrayHasStrideButNoSize) {
               IsShaderError(HasSubstr("no fixed size")));
 }
 
-TEST(IrLayoutTests, NestedStructUniformGets16ByteAlignment) {
+TEST(IrLayoutTests, NestedStructUniformGets16ByteAlignmentAndFollowerRounding) {
   const IrType inner =
       GetShaderResultOrFail(IrType::Struct("Inner", {{"x", IrType::F32()}}), IrType::F32());
   const IrType outer = GetShaderResultOrFail(
@@ -110,9 +110,31 @@ TEST(IrLayoutTests, NestedStructUniformGets16ByteAlignment) {
   EXPECT_THAT(storageLayout.members, ElementsAre(OffsetIs(0), OffsetIs(4), OffsetIs(8)));
   EXPECT_THAT(storageLayout.sizeBytes, Eq(12u));
 
-  // Uniform: the nested struct member's alignment rounds up to 16.
+  // Uniform: the nested struct member aligns to 16 AND the member following a struct-typed
+  // member must start at least roundUp(16, SizeOf(Inner)) bytes after its start (WGSL uniform
+  // layout constraint), so c lands at 32, not 20.
   const StructLayout uniformLayout = StructLayoutOrFail(outer, AddressSpace::Uniform);
-  EXPECT_THAT(uniformLayout.members, ElementsAre(OffsetIs(0), OffsetIs(16), OffsetIs(20)));
+  EXPECT_THAT(uniformLayout.members, ElementsAre(OffsetIs(0), OffsetIs(16), OffsetIs(32)));
+  EXPECT_THAT(uniformLayout.alignBytes, Eq(16u));
+  EXPECT_THAT(uniformLayout.sizeBytes, Eq(48u));
+}
+
+TEST(IrLayoutTests, UniformFollowerOfLargerNestedStructRoundsToNext16) {
+  // Inner3 is 12 bytes (three f32, align 4): its size is not a multiple of 16, so in uniform
+  // space the follower advances by roundUp(16, 12) = 16 even though the follower itself only
+  // needs 4-byte alignment.
+  const IrType inner = GetShaderResultOrFail(
+      IrType::Struct("Inner3", {{"x", IrType::F32()}, {"y", IrType::F32()}, {"z", IrType::F32()}}),
+      IrType::F32());
+  const IrType outer = GetShaderResultOrFail(
+      IrType::Struct("Outer3", {{"a", inner}, {"b", IrType::F32()}}), IrType::F32());
+
+  const StructLayout storageLayout = StructLayoutOrFail(outer, AddressSpace::Storage);
+  EXPECT_THAT(storageLayout.members, ElementsAre(OffsetIs(0), OffsetIs(12)));
+  EXPECT_THAT(storageLayout.sizeBytes, Eq(16u));
+
+  const StructLayout uniformLayout = StructLayoutOrFail(outer, AddressSpace::Uniform);
+  EXPECT_THAT(uniformLayout.members, ElementsAre(OffsetIs(0), OffsetIs(16)));
   EXPECT_THAT(uniformLayout.alignBytes, Eq(16u));
   EXPECT_THAT(uniformLayout.sizeBytes, Eq(32u));
 }

--- a/donner/gpu/shader/tests/IrSerialization_tests.cc
+++ b/donner/gpu/shader/tests/IrSerialization_tests.cc
@@ -1,0 +1,300 @@
+/// @file
+/// Deterministic serialization tests: byte-identical repeats and an embedded golden of a
+/// representative module exercising every node kind.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "donner/gpu/shader/IrModule.h"
+#include "donner/gpu/shader/tests/ShaderTestUtils.h"
+
+using testing::HasSubstr;
+using testing::Not;
+
+namespace donner::gpu::shader {
+namespace {
+
+/// Builds a representative module exercising every node kind: a constant, all four binding
+/// kinds, a plain function (for/if/else/break/continue/index/member/swizzle/convert/builtins),
+/// and vertex + fragment entry points (construct, mat*vec, select, textureSample, discard).
+IrModule BuildRepresentativeModule() {
+  ModuleBuilder builder;
+
+  const IrType uniformsType = GetShaderResultOrFail(
+      IrType::Struct(
+          "Params",
+          {{"mvp", IrType::Mat4x4f()}, {"color", IrType::Vec4f()}, {"fillRule", IrType::U32()}}),
+      IrType::F32());
+  const IrType bandType = GetShaderResultOrFail(
+      IrType::Struct("Band", {{"curveStart", IrType::U32()}, {"curveCount", IrType::U32()}}),
+      IrType::F32());
+  const IrType bandArray = GetShaderResultOrFail(IrType::RuntimeArray(bandType), IrType::F32());
+
+  EXPECT_THAT(builder.addConstant("kNoBand", LiteralU32(0xFFFFFFFFu)), IsShaderOk());
+  EXPECT_THAT(builder.addUniformBuffer(0, 0, "params", uniformsType), IsShaderOk());
+  EXPECT_THAT(builder.addReadOnlyStorageBuffer(0, 1, "bands", bandArray), IsShaderOk());
+  EXPECT_THAT(builder.addTexture2d(0, 2, "patternTexture"), IsShaderOk());
+  EXPECT_THAT(builder.addSampler(0, 3, "patternSampler"), IsShaderOk());
+
+  // Plain function: sums curveCounts of the first `limit` bands, skipping empty entries.
+  {
+    auto result =
+        builder.createFunction("countCurves", {IrParam{"limit", IrType::U32()}}, IrType::U32());
+    EXPECT_THAT(result, HasShaderResult());
+    FunctionBuilder function = std::move(result).result();
+
+    const IrExpr limit = GetShaderResultOrFail(function.ref("limit"), LiteralF32(0));
+    const IrExpr total = GetShaderResultOrFail(
+        function.addVar("total", IrType::U32(), LiteralU32(0)), LiteralF32(0));
+    const IrExpr bands = GetShaderResultOrFail(function.ref("bands"), LiteralF32(0));
+    const IrExpr sentinel = GetShaderResultOrFail(function.ref("kNoBand"), LiteralF32(0));
+
+    const IrExpr i = GetShaderResultOrFail(function.beginFor("i", LiteralU32(0)), LiteralF32(0));
+    EXPECT_THAT(function.forCondition(GetShaderResultOrFail(Lt(i, limit), LiteralF32(0))),
+                IsShaderOk());
+    EXPECT_THAT(
+        function.forContinuing(i, GetShaderResultOrFail(Add(i, LiteralU32(1)), LiteralF32(0))),
+        IsShaderOk());
+
+    const IrExpr band = GetShaderResultOrFail(Index(bands, i), LiteralF32(0));
+    const IrExpr curveStart = GetShaderResultOrFail(Member(band, "curveStart"), LiteralF32(0));
+    EXPECT_THAT(function.beginIf(GetShaderResultOrFail(Eq(curveStart, sentinel), LiteralF32(0))),
+                IsShaderOk());
+    EXPECT_THAT(function.continueStmt(), IsShaderOk());
+    EXPECT_THAT(function.elseBranch(), IsShaderOk());
+    EXPECT_THAT(
+        function.beginIf(GetShaderResultOrFail(Gt(curveStart, LiteralU32(1000)), LiteralF32(0))),
+        IsShaderOk());
+    EXPECT_THAT(function.breakStmt(), IsShaderOk());
+    EXPECT_THAT(function.endIf(), IsShaderOk());
+    EXPECT_THAT(function.endIf(), IsShaderOk());
+
+    const IrExpr curveCount = GetShaderResultOrFail(Member(band, "curveCount"), LiteralF32(0));
+    EXPECT_THAT(
+        function.assign(total, GetShaderResultOrFail(Add(total, curveCount), LiteralF32(0))),
+        IsShaderOk());
+    EXPECT_THAT(function.endFor(), IsShaderOk());
+    EXPECT_THAT(function.returnValue(total), IsShaderOk());
+    EXPECT_THAT(function.finish(), IsShaderOk());
+  }
+
+  // Vertex entry point: instance_index builtin, mat*vec multiply, constructors, swizzle.
+  {
+    auto result = builder.createVertexEntryPoint(
+        "vsMain",
+        {IrParam{"instance_index", IrType::U32(), std::nullopt, BuiltinInput::InstanceIndex},
+         IrParam{"pos", IrType::Vec2f(), 0}},
+        {IrOutputMember{"clip_pos", IrType::Vec4f(), std::nullopt, BuiltinOutput::Position},
+         IrOutputMember{"sample_pos", IrType::Vec2f(), 0}});
+    EXPECT_THAT(result, HasShaderResult());
+    FunctionBuilder function = std::move(result).result();
+
+    const IrExpr pos = GetShaderResultOrFail(function.ref("pos"), LiteralF32(0));
+    const IrExpr params = GetShaderResultOrFail(function.ref("params"), LiteralF32(0));
+    const IrExpr mvp = GetShaderResultOrFail(Member(params, "mvp"), LiteralF32(0));
+    const IrExpr homogeneous = GetShaderResultOrFail(
+        ConstructVector(IrType::Vec4f(), {pos, LiteralF32(0), LiteralF32(1)}), LiteralF32(0));
+    const IrExpr clipPos = GetShaderResultOrFail(
+        function.addLet("clip", GetShaderResultOrFail(Mul(mvp, homogeneous), LiteralF32(0))),
+        LiteralF32(0));
+    const IrExpr samplePos = GetShaderResultOrFail(Swizzle(clipPos, "xy"), LiteralF32(0));
+    EXPECT_THAT(function.returnOutputs({clipPos, samplePos}), IsShaderOk());
+    EXPECT_THAT(function.finish(), IsShaderOk());
+  }
+
+  // Fragment entry point: user call, builtins, select, textureSample/Load/Dimensions, negation,
+  // logical ops, conversion, single-component swizzle assignment, discard.
+  {
+    auto result =
+        builder.createFragmentEntryPoint("fsMain", {IrParam{"sample_pos", IrType::Vec2f(), 0}},
+                                         {IrOutputMember{"color", IrType::Vec4f(), 0}});
+    EXPECT_THAT(result, HasShaderResult());
+    FunctionBuilder function = std::move(result).result();
+
+    const IrExpr samplePos = GetShaderResultOrFail(function.ref("sample_pos"), LiteralF32(0));
+    const IrExpr params = GetShaderResultOrFail(function.ref("params"), LiteralF32(0));
+    const IrExpr texture = GetShaderResultOrFail(function.ref("patternTexture"), LiteralF32(0));
+    const IrExpr sampler = GetShaderResultOrFail(function.ref("patternSampler"), LiteralF32(0));
+
+    const IrExpr count = GetShaderResultOrFail(
+        function.addLet("count",
+                        GetShaderResultOrFail(function.callFunction("countCurves", {LiteralU32(4)}),
+                                              LiteralF32(0))),
+        LiteralF32(0));
+
+    const IrExpr coverage = GetShaderResultOrFail(
+        function.addLet(
+            "coverage",
+            GetShaderResultOrFail(
+                CallBuiltin(
+                    BuiltinFn::Saturate,
+                    {GetShaderResultOrFail(
+                        CallBuiltin(BuiltinFn::Fract, {GetShaderResultOrFail(
+                                                          Swizzle(samplePos, "x"), LiteralF32(0))}),
+                        LiteralF32(0))}),
+                LiteralF32(0))),
+        LiteralF32(0));
+
+    // if (coverage <= 0.0 && count > 0u) { discard; }
+    const IrExpr coverageZero = GetShaderResultOrFail(Le(coverage, LiteralF32(0)), LiteralF32(0));
+    const IrExpr hasCurves = GetShaderResultOrFail(Gt(count, LiteralU32(0)), LiteralF32(0));
+    EXPECT_THAT(
+        function.beginIf(GetShaderResultOrFail(And(coverageZero, hasCurves), LiteralF32(0))),
+        IsShaderOk());
+    EXPECT_THAT(function.discard(), IsShaderOk());
+    EXPECT_THAT(function.endIf(), IsShaderOk());
+
+    // Texture path: dims = vec2i(textureDimensions(t)); texel = textureLoad(t, dims - vec2i(1), 0)
+    const IrExpr dims = GetShaderResultOrFail(
+        function.addLet(
+            "dims",
+            GetShaderResultOrFail(
+                Convert(IrType::Vec2i(),
+                        GetShaderResultOrFail(CallBuiltin(BuiltinFn::TextureDimensions, {texture}),
+                                              LiteralF32(0))),
+                LiteralF32(0))),
+        LiteralF32(0));
+    const IrExpr texel = GetShaderResultOrFail(
+        function.addLet(
+            "texel",
+            GetShaderResultOrFail(
+                CallBuiltin(BuiltinFn::TextureLoad,
+                            {texture,
+                             GetShaderResultOrFail(
+                                 Sub(dims, GetShaderResultOrFail(
+                                               ConstructVector(IrType::Vec2i(), {LiteralI32(1)}),
+                                               LiteralF32(0))),
+                                 LiteralF32(0)),
+                             LiteralI32(0)}),
+                LiteralF32(0))),
+        LiteralF32(0));
+
+    const IrExpr sampled = GetShaderResultOrFail(
+        function.addLet("sampled", GetShaderResultOrFail(CallBuiltin(BuiltinFn::TextureSample,
+                                                                     {texture, sampler, samplePos}),
+                                                         LiteralF32(0))),
+        LiteralF32(0));
+
+    // var out = select(params.color, sampled, coverage > 0.5) * coverage; out.w = -(-coverage).
+    const IrExpr paramsColor = GetShaderResultOrFail(Member(params, "color"), LiteralF32(0));
+    const IrExpr selected = GetShaderResultOrFail(
+        CallBuiltin(BuiltinFn::Select,
+                    {paramsColor, sampled,
+                     GetShaderResultOrFail(Gt(coverage, LiteralF32(0.5f)), LiteralF32(0))}),
+        LiteralF32(0));
+    const IrExpr out = GetShaderResultOrFail(
+        function.addVar("out", IrType::Vec4f(),
+                        GetShaderResultOrFail(Mul(selected, coverage), LiteralF32(0))),
+        LiteralF32(0));
+    const IrExpr outAlpha = GetShaderResultOrFail(Swizzle(out, "w"), LiteralF32(0));
+    EXPECT_THAT(
+        function.assign(
+            outAlpha, GetShaderResultOrFail(
+                          Neg(GetShaderResultOrFail(Neg(coverage), LiteralF32(0))), LiteralF32(0))),
+        IsShaderOk());
+    // Fold in the loaded texel so textureLoad participates in the result.
+    EXPECT_THAT(function.assign(out, GetShaderResultOrFail(
+                                         CallBuiltin(BuiltinFn::Max, {out, texel}), LiteralF32(0))),
+                IsShaderOk());
+
+    EXPECT_THAT(function.returnOutputs({out}), IsShaderOk());
+    EXPECT_THAT(function.finish(), IsShaderOk());
+  }
+
+  ShaderResult<IrModule> module = builder.build();
+  EXPECT_THAT(module, HasShaderResult());
+  if (module.hasError()) {
+    ModuleBuilder emptyBuilder;
+    return std::move(emptyBuilder.build()).result();
+  }
+  return std::move(module).result();
+}
+
+TEST(IrSerializationTests, IdenticalModulesSerializeByteIdentically) {
+  const IrModule first = BuildRepresentativeModule();
+  const IrModule second = BuildRepresentativeModule();
+  EXPECT_THAT(first.serialize(), testing::Eq(second.serialize()));
+}
+
+TEST(IrSerializationTests, TypesConstructedInDifferentOrderCompareEqual) {
+  // Semantically identical types built in different orders are value-equal, so modules built
+  // from them serialize identically.
+  const IrType vecFirst = IrType::Vec4f();
+  const IrType arrayA = GetShaderResultOrFail(IrType::SizedArray(vecFirst, 4), IrType::F32());
+  const IrType arrayB =
+      GetShaderResultOrFail(IrType::SizedArray(IrType::Vec4(ScalarKind::F32), 4), IrType::F32());
+  EXPECT_TRUE(arrayA == arrayB);
+  EXPECT_THAT(arrayA.toString(), testing::Eq(arrayB.toString()));
+}
+
+TEST(IrSerializationTests, SerializationContainsNoPointers) {
+  const IrModule module = BuildRepresentativeModule();
+  EXPECT_THAT(module.serialize(), testing::Not(HasSubstr("0x")));
+}
+
+TEST(IrSerializationTests, GoldenSerializationOfRepresentativeModule) {
+  const IrModule module = BuildRepresentativeModule();
+
+  // clang-format off
+  const std::string kExpected = R"(module
+constant kNoBand: u32 = lit_u32(4294967295)
+binding group=0 binding=0 kind=uniform params: Params
+  struct Params { mvp: mat4x4<f32>, color: vec4<f32>, fillRule: u32 }
+binding group=0 binding=1 kind=storage_read bands: array<Band>
+  struct Band { curveStart: u32, curveCount: u32 }
+binding group=0 binding=2 kind=texture_2d_f32 patternTexture: texture_2d<f32>
+binding group=0 binding=3 kind=sampler patternSampler: sampler
+function countCurves
+  param limit: u32
+  returns u32
+  body:
+    var total: u32 = lit_u32(0)
+    for
+      init:
+        var i: u32 = lit_u32(0)
+      cond: lt(ref(i), ref(limit))
+      continuing:
+        assign ref(i) = add(ref(i), lit_u32(1))
+      body:
+        if eq(member(index(ref(bands), ref(i)), curveStart), ref(kNoBand))
+          continue
+        else
+          if gt(member(index(ref(bands), ref(i)), curveStart), lit_u32(1000))
+            break
+        assign ref(total) = add(ref(total), member(index(ref(bands), ref(i)), curveCount))
+    return(ref(total))
+function vsMain stage=vertex
+  param instance_index: u32 @builtin(instance_index)
+  param pos: vec2<f32> @location(0)
+  output clip_pos: vec4<f32> @builtin(position)
+  output sample_pos: vec2<f32> @location(0)
+  body:
+    let clip = mul(member(ref(params), mvp), construct_vec4<f32>(ref(pos), lit_f32(0), lit_f32(1)))
+    return(ref(clip), swizzle(ref(clip), xy))
+function fsMain stage=fragment
+  param sample_pos: vec2<f32> @location(0)
+  output color: vec4<f32> @location(0)
+  body:
+    let count = call(countCurves, lit_u32(4))
+    let coverage = builtin_saturate(builtin_fract(swizzle(ref(sample_pos), x)))
+    if and(le(ref(coverage), lit_f32(0)), gt(ref(count), lit_u32(0)))
+      discard
+    let dims = convert_vec2<i32>(builtin_textureDimensions(ref(patternTexture)))
+    let texel = builtin_textureLoad(ref(patternTexture), sub(ref(dims), construct_vec2<i32>(lit_i32(1))), lit_i32(0))
+    let sampled = builtin_textureSample(ref(patternTexture), ref(patternSampler), ref(sample_pos))
+    var out: vec4<f32> = mul(builtin_select(member(ref(params), color), ref(sampled), gt(ref(coverage), lit_f32(0.5))), ref(coverage))
+    assign swizzle(ref(out), w) = neg(neg(ref(coverage)))
+    assign ref(out) = builtin_max(ref(out), ref(texel))
+    return(ref(out))
+)";
+  // clang-format on
+
+  EXPECT_THAT(module.serialize(), testing::Eq(kExpected));
+}
+
+}  // namespace
+}  // namespace donner::gpu::shader

--- a/donner/gpu/shader/tests/IrSerialization_tests.cc
+++ b/donner/gpu/shader/tests/IrSerialization_tests.cc
@@ -227,8 +227,27 @@ TEST(IrSerializationTests, TypesConstructedInDifferentOrderCompareEqual) {
   const IrType arrayA = GetShaderResultOrFail(IrType::SizedArray(vecFirst, 4), IrType::F32());
   const IrType arrayB =
       GetShaderResultOrFail(IrType::SizedArray(IrType::Vec4(ScalarKind::F32), 4), IrType::F32());
-  EXPECT_TRUE(arrayA == arrayB);
+  EXPECT_EQ(arrayA, arrayB);
   EXPECT_THAT(arrayA.toString(), testing::Eq(arrayB.toString()));
+}
+
+TEST(IrSerializationTests, NestedStructDefinitionsAreSerializedRecursively) {
+  ModuleBuilder builder;
+  const IrType inner = GetShaderResultOrFail(
+      IrType::Struct("GridParams", {{"base", IrType::F32()}, {"count", IrType::U32()}}),
+      IrType::F32());
+  const IrType outer = GetShaderResultOrFail(
+      IrType::Struct("NestedUniforms", {{"mvp", IrType::Mat4x4f()}, {"grid", inner}}),
+      IrType::F32());
+  EXPECT_THAT(builder.addUniformBuffer(0, 0, "params", outer), IsShaderOk());
+
+  ShaderResult<IrModule> module = builder.build();
+  ASSERT_THAT(module, HasShaderResult());
+
+  const std::string serialized = module.result().serialize();
+  EXPECT_THAT(serialized,
+              HasSubstr("struct NestedUniforms { mvp: mat4x4<f32>, grid: GridParams }"));
+  EXPECT_THAT(serialized, HasSubstr("struct GridParams { base: f32, count: u32 }"));
 }
 
 TEST(IrSerializationTests, SerializationContainsNoPointers) {

--- a/donner/gpu/shader/tests/ShaderTestUtils.h
+++ b/donner/gpu/shader/tests/ShaderTestUtils.h
@@ -1,0 +1,84 @@
+#pragma once
+/// @file
+/// gmock matchers and helpers for \c donner::gpu::shader tests.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <utility>
+
+#include "donner/gpu/shader/ShaderResult.h"
+
+namespace donner::gpu::shader {
+
+/**
+ * Matches a \ref ShaderResult that contains a value (no error). On mismatch prints the contained
+ * error.
+ */
+MATCHER(HasShaderResult, "has a result") {
+  if (arg.hasError()) {
+    *result_listener << "which has error: " << arg.error();
+    return false;
+  }
+  return arg.hasResult();
+}
+
+/**
+ * Matches a successful \ref ShaderStatus. On mismatch prints the contained error.
+ */
+MATCHER(IsShaderOk, "is ok") {
+  if (arg.hasError()) {
+    *result_listener << "which has error: " << arg.error();
+    return false;
+  }
+  return arg.hasResult();
+}
+
+/**
+ * Matches a \ref ShaderResult whose error message matches \p messageMatcher (string or gmock
+ * matcher). On mismatch prints the full error or the absence of one.
+ *
+ * @param messageMatcher Matcher for the error message.
+ */
+MATCHER_P(IsShaderError, messageMatcher,
+          std::string("is a ShaderError with message ") + testing::PrintToString(messageMatcher)) {
+  if (!arg.hasError()) {
+    *result_listener << "which has no error";
+    return false;
+  }
+  *result_listener << "which has error: " << arg.error();
+  return testing::ExplainMatchResult(messageMatcher, arg.error().message, result_listener);
+}
+
+/**
+ * Unwraps a \ref ShaderResult, adding a test failure and returning a default-constructed value
+ * if it holds an error.
+ *
+ * @param result Result to unwrap.
+ */
+template <typename T>
+T GetShaderResultOrFail(ShaderResult<T>&& result) {
+  if (result.hasError()) {
+    ADD_FAILURE() << "Expected a result, got error: " << result.error();
+    return T{};
+  }
+  return std::move(result).result();
+}
+
+/**
+ * Unwraps a \ref ShaderResult for non-default-constructible types (IrType, IrExpr), adding a
+ * test failure and returning \p fallback if it holds an error.
+ *
+ * @param result Result to unwrap.
+ * @param fallback Value returned (with a recorded failure) when \p result holds an error.
+ */
+template <typename T>
+T GetShaderResultOrFail(ShaderResult<T>&& result, T fallback) {
+  if (result.hasError()) {
+    ADD_FAILURE() << "Expected a result, got error: " << result.error();
+    return fallback;
+  }
+  return std::move(result).result();
+}
+
+}  // namespace donner::gpu::shader


### PR DESCRIPTION
Adds the typed shader IR core and WGSL-rule layout engine under `donner/gpu/shader/`, packet 4 of the change sequence in docs/design_docs/0053-native_gpu_hal.md (stacked on the RHI core PR). No emitters yet; those are the next packets. Nothing consumes this in production and no dependencies change.

What is in the PR:

- A typed, immutable IR scoped to exactly what the solid-fill pipeline family (`slug_fill.wgsl`) requires: scalars, vectors, `mat4x4f`, sized and runtime arrays, named structs, `texture_2d<f32>`, and samplers, with value equality and validating factory functions.
- A layout engine implementing the WGSL specification's memory layout rules per address space, including the uniform-space constraints (16-byte array strides with a `paddedFromNatural` flag documenting the emitter obligation, struct-member 16-byte alignment, and follower rounding after struct-typed members). Public APIs expose offsets, sizes, and strides for host-shareable layout metadata.
- Layout anchor tests derived from the WGSL rules that reproduce the byte layouts the existing renderer's mirror structs assert: the 288-byte solid-fill uniform block with every documented field offset, the 32-byte band record, and the 32-byte instance transform.
- `ModuleBuilder`/`FunctionBuilder` with fail-closed, type-checked-at-construction expressions and statements: binding uniqueness, stage IO validation (locations, builtins including the fragment position input), lvalue rules, block scoping (names leave scope at `endIf`/`endFor`), structural missing-return detection, and exactly the fourteen builtin functions the solid-fill family uses. Ill-typed programs return labeled `ShaderResult` errors; nothing asserts on input.
- Deterministic declaration-order text serialization of modules for golden tests; byte-identical across runs, no pointers.
- 60 model-level tests: WGSL layout corner cases (vec3 tail packing, uniform vs storage array strides, nested structs with follower rounding), builder accept/reject per rule, and serialization determinism with an embedded golden.

The library depends only on `donner/base` (no RHI runtime dependency); the compute entry point seam is documented for the later filter-engine migration packets.

Validation: `bazel test //...` green locally (865 targets, 0 failures; `shader_tests` 60/60 plus the RHI core's 118), `bazel build //donner/...` green, `gen_cmakelists.py --check` passes, zero WebGPU wrapper tokens (grep-verified), clang-format/buildifier clean. The diff passed an independent sub-agent review (two blocking findings fixed with committed red-to-green sequences: a missed WGSL uniform follower-rounding rule and the missing fragment position builtin) and a privacy sweep before opening.
