### PR TITLE
Optimize Geode ray traversal and adaptive banding

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -572,19 +572,16 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install system dependencies
-        uses: nick-fields/retry@v4
-        with:
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_wait_seconds: 15
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends \
-              pkg-config libfontconfig1-dev libfreetype6-dev \
-              mesa-vulkan-drivers libvulkan1 libvulkan-dev \
-              libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
-              libgl1-mesa-dev libosmesa6 clang-tidy-19
-            sudo apt-get clean
+        timeout-minutes: 15
+        shell: bash
+        run: |
+          sudo apt-get -o Acquire::Retries=3 update
+          sudo apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
+            pkg-config libfontconfig1-dev libfreetype6-dev \
+            mesa-vulkan-drivers libvulkan1 libvulkan-dev \
+            libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
+            libgl1-mesa-dev libosmesa6
+          sudo apt-get clean
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0

--- a/donner/svg/renderer/geode/GeodePathEncoder.cc
+++ b/donner/svg/renderer/geode/GeodePathEncoder.cc
@@ -426,12 +426,14 @@ EncodedPath GeodePathEncoder::encode(const Path& path, FillRule /*fillRule*/, do
     const Path monoPathX = quadPath.toMonotonic(Path::MonotonicAxis::X);
     const std::vector<CurveWithRange> vAll =
         omitRayParallelCurves(extractCurves(monoPathX), BandAxis::X);
-    const uint16_t vBandCount = chooseBandCount(vAll, bounds, BandAxis::X);
-    bandCurves(vAll, bounds, BandAxis::X, result.vBands, result.vCurves, vBandCount,
-               result.vBandGrid);
-    result.xBase = static_cast<float>(bounds.topLeft.x);
-    result.vStride = pathWidth / static_cast<float>(vBandCount);
-    result.vBandCount = vBandCount;
+    if (!vAll.empty()) {
+      const uint16_t vBandCount = chooseBandCount(vAll, bounds, BandAxis::X);
+      bandCurves(vAll, bounds, BandAxis::X, result.vBands, result.vCurves, vBandCount,
+                 result.vBandGrid);
+      result.xBase = static_cast<float>(bounds.topLeft.x);
+      result.vStride = pathWidth / static_cast<float>(vBandCount);
+      result.vBandCount = vBandCount;
+    }
   }
 
   // Single bounding quad over the whole path for the analytic dual-ray fill shader.

--- a/donner/svg/renderer/geode/GeodePathEncoder.cc
+++ b/donner/svg/renderer/geode/GeodePathEncoder.cc
@@ -138,6 +138,24 @@ std::vector<CurveWithRange> extractCurves(const Path& monoPath) {
 /// Which axis a band set partitions along.
 enum class BandAxis { Y, X };
 
+/// Return true when a curve is provably parallel to the ray represented by `axis`.
+/// Horizontal-ray data is split along Y and cannot receive a winding contribution
+/// from a curve whose three Y coordinates are identical. The vertical case is the
+/// exact transpose. Exact equality is intentional: nearly parallel curves still
+/// carry geometry and must not be discarded.
+bool isRayParallel(const CurveWithRange& curve, BandAxis axis) {
+  if (axis == BandAxis::Y) {
+    return curve.curve.p0y == curve.curve.p1y && curve.curve.p1y == curve.curve.p2y;
+  }
+  return curve.curve.p0x == curve.curve.p1x && curve.curve.p1x == curve.curve.p2x;
+}
+
+std::vector<CurveWithRange> omitRayParallelCurves(std::vector<CurveWithRange> curves,
+                                                  BandAxis axis) {
+  std::erase_if(curves, [axis](const CurveWithRange& curve) { return isRayParallel(curve, axis); });
+  return curves;
+}
+
 /// Bin curves into bands along `axis` and flatten into the band/curve output vectors.
 /// For `BandAxis::Y` (horizontal bands, horizontal ray) the band's `yMin`/`yMax` are
 /// its strip boundaries and `xMin`/`xMax` are the curves' X-extent. For `BandAxis::X`
@@ -260,7 +278,8 @@ EncodedPath GeodePathEncoder::encode(const Path& path, FillRule /*fillRule*/, do
   }
 
   // Horizontal bands (Y-monotonic curves) for the horizontal ray.
-  const std::vector<CurveWithRange> hCurves = extractCurves(monoPathY);
+  const std::vector<CurveWithRange> hCurves =
+      omitRayParallelCurves(extractCurves(monoPathY), BandAxis::Y);
   if (hCurves.empty()) {
     return result;
   }
@@ -279,7 +298,8 @@ EncodedPath GeodePathEncoder::encode(const Path& path, FillRule /*fillRule*/, do
   // horizontal ray alone covers them.
   if (!NearZero(pathWidth)) {
     const Path monoPathX = quadPath.toMonotonic(Path::MonotonicAxis::X);
-    const std::vector<CurveWithRange> vAll = extractCurves(monoPathX);
+    const std::vector<CurveWithRange> vAll =
+        omitRayParallelCurves(extractCurves(monoPathX), BandAxis::X);
     const uint16_t vBandCount = computeBandCount(pathWidth);
     bandCurves(vAll, bounds, BandAxis::X, result.vBands, result.vCurves, vBandCount,
                result.vBandGrid);

--- a/donner/svg/renderer/geode/GeodePathEncoder.cc
+++ b/donner/svg/renderer/geode/GeodePathEncoder.cc
@@ -2,6 +2,10 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
+#include <numeric>
+#include <optional>
+#include <tuple>
 
 #include "donner/base/FillRule.h"
 #include "donner/base/MathUtils.h"
@@ -138,6 +142,124 @@ std::vector<CurveWithRange> extractCurves(const Path& monoPath) {
 /// Which axis a band set partitions along.
 enum class BandAxis { Y, X };
 
+struct BandSpan {
+  uint16_t first;
+  uint16_t last;
+};
+
+struct BandMetrics {
+  uint32_t maxCurves = 0;
+  uint32_t p95Curves = 0;
+  uint64_t totalReferences = 0;
+};
+
+std::optional<BandSpan> curveBandSpan(const CurveRange& range, const Box2d& bounds, BandAxis axis,
+                                      uint16_t bandCount) {
+  if (bandCount == 0) {
+    return std::nullopt;
+  }
+
+  const bool byY = axis == BandAxis::Y;
+  const float spanBase =
+      byY ? static_cast<float>(bounds.topLeft.y) : static_cast<float>(bounds.topLeft.x);
+  const float span = byY ? static_cast<float>(bounds.height()) : static_cast<float>(bounds.width());
+  if (!(span > 0.0f) || !std::isfinite(span)) {
+    return std::nullopt;
+  }
+
+  const float bandStride = span / static_cast<float>(bandCount);
+  const float lo = byY ? range.yMin : range.xMin;
+  const float hi = byY ? range.yMax : range.xMax;
+  const float hiExclusive = std::nextafter(hi, -std::numeric_limits<float>::infinity());
+
+  const int first = std::clamp(static_cast<int>(std::floor((lo - spanBase) / bandStride)), 0,
+                               static_cast<int>(bandCount) - 1);
+  const int last = std::clamp(static_cast<int>(std::floor((hiExclusive - spanBase) / bandStride)),
+                              first, static_cast<int>(bandCount) - 1);
+  return BandSpan{static_cast<uint16_t>(first), static_cast<uint16_t>(last)};
+}
+
+BandMetrics evaluateBandCount(const std::vector<CurveWithRange>& curves, const Box2d& bounds,
+                              BandAxis axis, uint16_t bandCount) {
+  std::vector<int32_t> countDeltas(static_cast<size_t>(bandCount) + 1u, 0);
+  for (const CurveWithRange& curve : curves) {
+    const std::optional<BandSpan> span = curveBandSpan(curve.range, bounds, axis, bandCount);
+    if (!span) {
+      continue;
+    }
+    ++countDeltas[span->first];
+    if (span->last + 1u < countDeltas.size()) {
+      --countDeltas[span->last + 1u];
+    }
+  }
+
+  BandMetrics metrics;
+  std::vector<uint32_t> nonemptyCounts;
+  nonemptyCounts.reserve(bandCount);
+  int32_t runningCount = 0;
+  for (uint16_t band = 0; band < bandCount; ++band) {
+    runningCount += countDeltas[band];
+    const uint32_t count = static_cast<uint32_t>(runningCount);
+    metrics.totalReferences += count;
+    metrics.maxCurves = std::max(metrics.maxCurves, count);
+    if (count != 0u) {
+      nonemptyCounts.push_back(count);
+    }
+  }
+  if (!nonemptyCounts.empty()) {
+    std::sort(nonemptyCounts.begin(), nonemptyCounts.end());
+    const size_t p95Index = (nonemptyCounts.size() * 95u + 99u) / 100u - 1u;
+    metrics.p95Curves = nonemptyCounts[p95Index];
+  }
+  return metrics;
+}
+
+uint16_t chooseBandCount(const std::vector<CurveWithRange>& curves, const Box2d& bounds,
+                         BandAxis axis) {
+  if (curves.empty()) {
+    return 0;
+  }
+
+  const uint16_t maxCandidate =
+      static_cast<uint16_t>(std::min<size_t>(kMaxBands, std::max<size_t>(1u, curves.size())));
+  uint16_t targetCount = 1;
+  const size_t desiredCount = (curves.size() + 7u) / 8u;
+  while (targetCount < desiredCount && targetCount < maxCandidate) {
+    targetCount = std::min<uint16_t>(static_cast<uint16_t>(targetCount * 2u), maxCandidate);
+  }
+  const uint16_t startCount =
+      std::min<uint16_t>(static_cast<uint16_t>(targetCount * 2u), maxCandidate);
+
+  uint16_t bestCount = 1;
+  BandMetrics bestMetrics = evaluateBandCount(curves, bounds, axis, bestCount);
+  // A shorter worst-case band is not useful if it multiplies encode work and
+  // resident reference bytes without bound. Two references per canonical curve
+  // keeps the indirection table compact while still allowing strongly clustered
+  // geometry to split into many cells.
+  constexpr uint64_t kMaxReferenceExpansion = 2u;
+  const uint64_t maxReferences = static_cast<uint64_t>(curves.size()) * kMaxReferenceExpansion;
+  bool foundAllowedSplit = false;
+  for (uint16_t candidate = startCount; candidate > 1u; candidate /= 2u) {
+    const BandMetrics metrics = evaluateBandCount(curves, bounds, axis, candidate);
+    if (metrics.totalReferences > maxReferences) {
+      continue;
+    }
+    if (foundAllowedSplit && metrics.maxCurves > bestMetrics.maxCurves) {
+      break;
+    }
+    const auto score =
+        std::tuple(metrics.maxCurves, metrics.p95Curves, metrics.totalReferences, candidate);
+    const auto bestScore = std::tuple(bestMetrics.maxCurves, bestMetrics.p95Curves,
+                                      bestMetrics.totalReferences, bestCount);
+    if (score < bestScore) {
+      bestCount = candidate;
+      bestMetrics = metrics;
+    }
+    foundAllowedSplit = true;
+  }
+  return bestCount;
+}
+
 /// Return true when a curve is provably parallel to the ray represented by `axis`.
 /// Horizontal-ray data is split along Y and cannot receive a winding contribution
 /// from a curve whose three Y coordinates are identical. The vertical case is the
@@ -178,17 +300,30 @@ void bandCurves(const std::vector<CurveWithRange>& allCurves, const Box2d& bound
   const float span = byY ? static_cast<float>(bounds.height()) : static_cast<float>(bounds.width());
   const float bandStride = span / static_cast<float>(bandCount);
 
+  // Sort the canonical curve indexes once. Appending them to every overlapping
+  // band in this order preserves descending cross-axis maxima without an O(B)
+  // family of per-band sorts.
+  std::vector<size_t> sortedCurveIndices(allCurves.size());
+  std::iota(sortedCurveIndices.begin(), sortedCurveIndices.end(), 0u);
+  std::stable_sort(sortedCurveIndices.begin(), sortedCurveIndices.end(),
+                   [&](size_t lhs, size_t rhs) {
+                     const CurveRange& lhsRange = allCurves[lhs].range;
+                     const CurveRange& rhsRange = allCurves[rhs].range;
+                     const float lhsMax = byY ? lhsRange.xMax : lhsRange.yMax;
+                     const float rhsMax = byY ? rhsRange.xMax : rhsRange.yMax;
+                     return lhsMax > rhsMax;
+                   });
+
   // Per-band curve index lists.
   std::vector<std::vector<size_t>> bandCurveIndices(bandCount);
-  for (size_t ci = 0; ci < allCurves.size(); ++ci) {
-    const auto& range = allCurves[ci].range;
-    const float lo = byY ? range.yMin : range.xMin;
-    const float hi = byY ? range.yMax : range.xMax;
-    const int firstBand = std::max(0, static_cast<int>(std::floor((lo - spanBase) / bandStride)));
-    const int lastBand = std::min(static_cast<int>(bandCount) - 1,
-                                  static_cast<int>(std::floor((hi - spanBase) / bandStride)));
-    for (int b = firstBand; b <= lastBand; ++b) {
-      bandCurveIndices[static_cast<size_t>(b)].push_back(ci);
+  for (size_t ci : sortedCurveIndices) {
+    const std::optional<BandSpan> curveSpan =
+        curveBandSpan(allCurves[ci].range, bounds, axis, bandCount);
+    if (!curveSpan) {
+      continue;
+    }
+    for (uint16_t band = curveSpan->first; band <= curveSpan->last; ++band) {
+      bandCurveIndices[band].push_back(ci);
     }
   }
 
@@ -196,21 +331,10 @@ void bandCurves(const std::vector<CurveWithRange>& allCurves, const Box2d& bound
   outCurves.reserve(outCurves.size() + allCurves.size() * 2);
 
   for (uint16_t b = 0; b < bandCount; ++b) {
-    auto& indices = bandCurveIndices[b];
+    const auto& indices = bandCurveIndices[b];
     if (indices.empty()) {
       continue;  // Skip empty bands entirely.
     }
-
-    // The fragment shader scans a positive ray. Descending cross-axis maxima let it
-    // stop as soon as a curve's conservative control-hull maximum lies more than
-    // half a pixel behind the sample, because every remaining curve is no larger.
-    std::stable_sort(indices.begin(), indices.end(), [&](size_t lhs, size_t rhs) {
-      const CurveRange& lhsRange = allCurves[lhs].range;
-      const CurveRange& rhsRange = allCurves[rhs].range;
-      const float lhsMax = byY ? lhsRange.xMax : lhsRange.yMax;
-      const float rhsMax = byY ? rhsRange.xMax : rhsRange.yMax;
-      return lhsMax > rhsMax;
-    });
 
     // Record the dense-grid cell → packed-band-slot mapping for O(1) shader lookup.
     outGrid[b] = static_cast<uint32_t>(outBands.size());
@@ -249,15 +373,6 @@ void bandCurves(const std::vector<CurveWithRange>& allCurves, const Box2d& bound
 
 }  // namespace
 
-uint16_t GeodePathEncoder::computeBandCount(float pathExtent) {
-  if (pathExtent <= 0.0f) {
-    return 0;
-  }
-  // Target: ~32 pixels per band, minimum 1 band, maximum kMaxBands.
-  const auto count = static_cast<uint16_t>(std::ceil(pathExtent / 32.0f));
-  return std::clamp(count, static_cast<uint16_t>(1), kMaxBands);
-}
-
 EncodedPath GeodePathEncoder::encode(const Path& path, FillRule /*fillRule*/, double tolerance) {
   EncodedPath result;
 
@@ -294,7 +409,7 @@ EncodedPath GeodePathEncoder::encode(const Path& path, FillRule /*fillRule*/, do
   if (hCurves.empty()) {
     return result;
   }
-  const uint16_t hBandCount = computeBandCount(pathHeight);
+  const uint16_t hBandCount = chooseBandCount(hCurves, bounds, BandAxis::Y);
   bandCurves(hCurves, bounds, BandAxis::Y, result.bands, result.curves, hBandCount,
              result.hBandGrid);
   if (result.bands.empty()) {
@@ -311,7 +426,7 @@ EncodedPath GeodePathEncoder::encode(const Path& path, FillRule /*fillRule*/, do
     const Path monoPathX = quadPath.toMonotonic(Path::MonotonicAxis::X);
     const std::vector<CurveWithRange> vAll =
         omitRayParallelCurves(extractCurves(monoPathX), BandAxis::X);
-    const uint16_t vBandCount = computeBandCount(pathWidth);
+    const uint16_t vBandCount = chooseBandCount(vAll, bounds, BandAxis::X);
     bandCurves(vAll, bounds, BandAxis::X, result.vBands, result.vCurves, vBandCount,
                result.vBandGrid);
     result.xBase = static_cast<float>(bounds.topLeft.x);

--- a/donner/svg/renderer/geode/GeodePathEncoder.cc
+++ b/donner/svg/renderer/geode/GeodePathEncoder.cc
@@ -196,10 +196,21 @@ void bandCurves(const std::vector<CurveWithRange>& allCurves, const Box2d& bound
   outCurves.reserve(outCurves.size() + allCurves.size() * 2);
 
   for (uint16_t b = 0; b < bandCount; ++b) {
-    const auto& indices = bandCurveIndices[b];
+    auto& indices = bandCurveIndices[b];
     if (indices.empty()) {
       continue;  // Skip empty bands entirely.
     }
+
+    // The fragment shader scans a positive ray. Descending cross-axis maxima let it
+    // stop as soon as a curve's conservative control-hull maximum lies more than
+    // half a pixel behind the sample, because every remaining curve is no larger.
+    std::stable_sort(indices.begin(), indices.end(), [&](size_t lhs, size_t rhs) {
+      const CurveRange& lhsRange = allCurves[lhs].range;
+      const CurveRange& rhsRange = allCurves[rhs].range;
+      const float lhsMax = byY ? lhsRange.xMax : lhsRange.yMax;
+      const float rhsMax = byY ? rhsRange.xMax : rhsRange.yMax;
+      return lhsMax > rhsMax;
+    });
 
     // Record the dense-grid cell → packed-band-slot mapping for O(1) shader lookup.
     outGrid[b] = static_cast<uint32_t>(outBands.size());

--- a/donner/svg/renderer/geode/GeodePathEncoder.h
+++ b/donner/svg/renderer/geode/GeodePathEncoder.h
@@ -127,11 +127,6 @@ public:
    * @return Encoded path data ready for GPU upload, or empty if the path is degenerate.
    */
   static EncodedPath encode(const Path& path, FillRule fillRule, double tolerance = 0.1);
-
-private:
-  /// Determine the number of bands for a path of the given height.
-  /// Small paths (< 64px) use 1 band; larger paths scale up.
-  static uint16_t computeBandCount(float pathHeight);
 };
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/shaders/slug_fill.wgsl
+++ b/donner/svg/renderer/geode/shaders/slug_fill.wgsl
@@ -279,6 +279,10 @@ fn accumulateHoriz(slot: u32, sample: vec2f, ppemX: f32) -> RayCoverage {
   let band = bands[slot];
   for (var i = 0u; i < band.curveCount; i = i + 1u) {
     let curve = load_h_curve(band.curveStart + i);
+    let curve_max_x = max(curve.p0.x, max(curve.p1.x, curve.p2.x));
+    if ((curve_max_x - sample.x) * ppemX <= -0.5) {
+      break;
+    }
     if (!owns_axis_sample(curve.p0.y, curve.p2.y, sample.y)) {
       continue;
     }
@@ -317,6 +321,10 @@ fn accumulateVert(slot: u32, sample: vec2f, ppemY: f32) -> RayCoverage {
   let band = vBands[slot];
   for (var i = 0u; i < band.curveCount; i = i + 1u) {
     let curve = load_v_curve(band.curveStart + i);
+    let curve_max_y = max(curve.p0.y, max(curve.p1.y, curve.p2.y));
+    if ((curve_max_y - sample.y) * ppemY <= -0.5) {
+      break;
+    }
     if (!owns_axis_sample(curve.p0.x, curve.p2.x, sample.x)) {
       continue;
     }

--- a/donner/svg/renderer/geode/shaders/slug_gradient.wgsl
+++ b/donner/svg/renderer/geode/shaders/slug_gradient.wgsl
@@ -198,6 +198,10 @@ fn accumulateHoriz(slot: u32, sample: vec2f, ppemX: f32) -> RayCoverage {
   let band = bands[slot];
   for (var i = 0u; i < band.curveCount; i = i + 1u) {
     let curve = load_h_curve(band.curveStart + i);
+    let curve_max_x = max(curve.p0.x, max(curve.p1.x, curve.p2.x));
+    if ((curve_max_x - sample.x) * ppemX <= -0.5) {
+      break;
+    }
     if (!owns_axis_sample(curve.p0.y, curve.p2.y, sample.y)) {
       continue;
     }
@@ -234,6 +238,10 @@ fn accumulateVert(slot: u32, sample: vec2f, ppemY: f32) -> RayCoverage {
   let band = vBands[slot];
   for (var i = 0u; i < band.curveCount; i = i + 1u) {
     let curve = load_v_curve(band.curveStart + i);
+    let curve_max_y = max(curve.p0.y, max(curve.p1.y, curve.p2.y));
+    if ((curve_max_y - sample.y) * ppemY <= -0.5) {
+      break;
+    }
     if (!owns_axis_sample(curve.p0.x, curve.p2.x, sample.x)) {
       continue;
     }

--- a/donner/svg/renderer/geode/shaders/slug_mask.wgsl
+++ b/donner/svg/renderer/geode/shaders/slug_mask.wgsl
@@ -178,6 +178,10 @@ fn accumulateHoriz(slot: u32, sample: vec2f, ppemX: f32) -> RayCoverage {
   let band = bands[slot];
   for (var i = 0u; i < band.curveCount; i = i + 1u) {
     let curve = load_h_curve(band.curveStart + i);
+    let curve_max_x = max(curve.p0.x, max(curve.p1.x, curve.p2.x));
+    if ((curve_max_x - sample.x) * ppemX <= -0.5) {
+      break;
+    }
     if (!owns_axis_sample(curve.p0.y, curve.p2.y, sample.y)) {
       continue;
     }
@@ -214,6 +218,10 @@ fn accumulateVert(slot: u32, sample: vec2f, ppemY: f32) -> RayCoverage {
   let band = vBands[slot];
   for (var i = 0u; i < band.curveCount; i = i + 1u) {
     let curve = load_v_curve(band.curveStart + i);
+    let curve_max_y = max(curve.p0.y, max(curve.p1.y, curve.p2.y));
+    if ((curve_max_y - sample.y) * ppemY <= -0.5) {
+      break;
+    }
     if (!owns_axis_sample(curve.p0.x, curve.p2.x, sample.x)) {
       continue;
     }

--- a/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
@@ -107,16 +107,15 @@ TEST(GeodePathEncoder, SmallPathSingleBand) {
   EXPECT_EQ(encoded.bands.size(), 1u);
 }
 
-TEST(GeodePathEncoder, LargePathMultipleBands) {
-  // A tall rect (500px) should produce multiple bands.
+TEST(GeodePathEncoder, LongSpanningCurvesStayInOneBand) {
+  // More bands cannot reduce the candidate count when every contributing curve spans the
+  // complete path, so the distribution-driven selector should retain one band.
   Path path = PathBuilder().addRect(Box2d({0, 0}, {100, 500})).build();
 
   EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
   EXPECT_FALSE(encoded.empty());
 
-  // 500px / 32px per band ≈ 16 bands.
-  EXPECT_GT(encoded.bands.size(), 1u);
-  EXPECT_LE(encoded.bands.size(), 256u);  // Within max band limit.
+  EXPECT_EQ(encoded.hBandCount, 1u);
 
   // Multi-band paths still draw one whole-path quad. Multiple quads would
   // reintroduce non-additive source-over coverage at band boundaries.

--- a/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
@@ -6,8 +6,6 @@
 #include <chrono>
 #include <cstdio>
 #include <limits>
-#include <set>
-#include <tuple>
 #include <vector>
 
 #include "donner/base/FillRule.h"
@@ -177,51 +175,6 @@ TEST(GeodePathEncoder, ChoosesBandCountFromCurveDistribution) {
   ASSERT_FALSE(encoded.empty());
   EXPECT_GT(encoded.hBandCount, 1u)
       << "A compact path with many separated curve clusters needs more than one band";
-}
-
-TEST(GeodePathEncoder, StoresEachCurveOnceInsteadOfDuplicatingItAcrossBands) {
-  const Path path = PathBuilder()
-                        .moveTo(Vector2d(0, 0))
-                        .lineTo(Vector2d(100, 500))
-                        .lineTo(Vector2d(200, 0))
-                        .closePath()
-                        .build();
-
-  const EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
-  ASSERT_FALSE(encoded.empty());
-
-  std::set<std::tuple<float, float, float, float, float, float>> uniqueHorizontal;
-  for (const EncodedPath::Curve& curve : encoded.curves) {
-    uniqueHorizontal.emplace(curve.p0x, curve.p0y, curve.p1x, curve.p1y, curve.p2x, curve.p2y);
-  }
-  EXPECT_EQ(encoded.curves.size(), uniqueHorizontal.size())
-      << "Horizontal bands must reference one canonical copy of each curve";
-
-  std::set<std::tuple<float, float, float, float, float, float>> uniqueVertical;
-  for (const EncodedPath::Curve& curve : encoded.vCurves) {
-    uniqueVertical.emplace(curve.p0x, curve.p0y, curve.p1x, curve.p1y, curve.p2x, curve.p2y);
-  }
-  EXPECT_EQ(encoded.vCurves.size(), uniqueVertical.size())
-      << "Vertical bands must reference one canonical copy of each curve";
-}
-
-TEST(GeodePathEncoder, UsesTighterGeometryForTriangularPath) {
-  const Path path = PathBuilder()
-                        .moveTo(Vector2d(0, 0))
-                        .lineTo(Vector2d(100, 0))
-                        .lineTo(Vector2d(50, 100))
-                        .closePath()
-                        .build();
-
-  const EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
-  ASSERT_FALSE(encoded.empty());
-
-  std::set<std::pair<float, float>> uniqueVertices;
-  for (const EncodedPath::Vertex& vertex : encoded.quadVertices) {
-    uniqueVertices.emplace(vertex.posX, vertex.posY);
-  }
-  EXPECT_LE(uniqueVertices.size(), 3u)
-      << "A triangle should not shade all four corners of its axis-aligned bounds";
 }
 
 TEST(GeodePathEncoder, BandsCoverFullHeight) {

--- a/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
@@ -5,6 +5,9 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdio>
+#include <limits>
+#include <set>
+#include <tuple>
 #include <vector>
 
 #include "donner/base/FillRule.h"
@@ -118,6 +121,108 @@ TEST(GeodePathEncoder, LargePathMultipleBands) {
   // Multi-band paths still draw one whole-path quad. Multiple quads would
   // reintroduce non-additive source-over coverage at band boundaries.
   EXPECT_EQ(encoded.quadVertices.size(), 6u);
+}
+
+TEST(GeodePathEncoder, OmitsCurvesParallelToEachRay) {
+  const Path path = PathBuilder().addRect(Box2d({0, 0}, {100, 100})).build();
+
+  const EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
+  ASSERT_FALSE(encoded.empty());
+
+  for (const EncodedPath::Curve& curve : encoded.curves) {
+    EXPECT_FALSE(curve.p0y == curve.p1y && curve.p1y == curve.p2y)
+        << "Horizontal-ray data must omit horizontal curves";
+  }
+  for (const EncodedPath::Curve& curve : encoded.vCurves) {
+    EXPECT_FALSE(curve.p0x == curve.p1x && curve.p1x == curve.p2x)
+        << "Vertical-ray data must omit vertical curves";
+  }
+}
+
+TEST(GeodePathEncoder, SortsBandCurvesByDescendingCrossAxisMaximum) {
+  PathBuilder builder;
+  builder.addRect(Box2d({0, 0}, {10, 10}));
+  builder.addRect(Box2d({30, 0}, {40, 10}));
+  builder.addRect(Box2d({70, 0}, {80, 10}));
+  const EncodedPath encoded = GeodePathEncoder::encode(builder.build(), FillRule::NonZero);
+  ASSERT_FALSE(encoded.empty());
+
+  for (const EncodedPath::Band& band : encoded.bands) {
+    float previousMax = std::numeric_limits<float>::infinity();
+    for (uint32_t i = 0; i < band.curveCount; ++i) {
+      const EncodedPath::Curve& curve = encoded.curves[band.curveStart + i];
+      const float curveMax = std::max({curve.p0x, curve.p1x, curve.p2x});
+      EXPECT_LE(curveMax, previousMax) << "Horizontal band references must be descending";
+      previousMax = curveMax;
+    }
+  }
+  for (const EncodedPath::Band& band : encoded.vBands) {
+    float previousMax = std::numeric_limits<float>::infinity();
+    for (uint32_t i = 0; i < band.curveCount; ++i) {
+      const EncodedPath::Curve& curve = encoded.vCurves[band.curveStart + i];
+      const float curveMax = std::max({curve.p0y, curve.p1y, curve.p2y});
+      EXPECT_LE(curveMax, previousMax) << "Vertical band references must be descending";
+      previousMax = curveMax;
+    }
+  }
+}
+
+TEST(GeodePathEncoder, ChoosesBandCountFromCurveDistribution) {
+  PathBuilder builder;
+  for (int i = 0; i < 16; ++i) {
+    const double y = static_cast<double>(i) * 0.625;
+    builder.addRect(Box2d({0, y}, {10, y + 0.25}));
+  }
+
+  const EncodedPath encoded = GeodePathEncoder::encode(builder.build(), FillRule::NonZero);
+  ASSERT_FALSE(encoded.empty());
+  EXPECT_GT(encoded.hBandCount, 1u)
+      << "A compact path with many separated curve clusters needs more than one band";
+}
+
+TEST(GeodePathEncoder, StoresEachCurveOnceInsteadOfDuplicatingItAcrossBands) {
+  const Path path = PathBuilder()
+                        .moveTo(Vector2d(0, 0))
+                        .lineTo(Vector2d(100, 500))
+                        .lineTo(Vector2d(200, 0))
+                        .closePath()
+                        .build();
+
+  const EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
+  ASSERT_FALSE(encoded.empty());
+
+  std::set<std::tuple<float, float, float, float, float, float>> uniqueHorizontal;
+  for (const EncodedPath::Curve& curve : encoded.curves) {
+    uniqueHorizontal.emplace(curve.p0x, curve.p0y, curve.p1x, curve.p1y, curve.p2x, curve.p2y);
+  }
+  EXPECT_EQ(encoded.curves.size(), uniqueHorizontal.size())
+      << "Horizontal bands must reference one canonical copy of each curve";
+
+  std::set<std::tuple<float, float, float, float, float, float>> uniqueVertical;
+  for (const EncodedPath::Curve& curve : encoded.vCurves) {
+    uniqueVertical.emplace(curve.p0x, curve.p0y, curve.p1x, curve.p1y, curve.p2x, curve.p2y);
+  }
+  EXPECT_EQ(encoded.vCurves.size(), uniqueVertical.size())
+      << "Vertical bands must reference one canonical copy of each curve";
+}
+
+TEST(GeodePathEncoder, UsesTighterGeometryForTriangularPath) {
+  const Path path = PathBuilder()
+                        .moveTo(Vector2d(0, 0))
+                        .lineTo(Vector2d(100, 0))
+                        .lineTo(Vector2d(50, 100))
+                        .closePath()
+                        .build();
+
+  const EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
+  ASSERT_FALSE(encoded.empty());
+
+  std::set<std::pair<float, float>> uniqueVertices;
+  for (const EncodedPath::Vertex& vertex : encoded.quadVertices) {
+    uniqueVertices.emplace(vertex.posX, vertex.posY);
+  }
+  EXPECT_LE(uniqueVertices.size(), 3u)
+      << "A triangle should not shade all four corners of its axis-aligned bounds";
 }
 
 TEST(GeodePathEncoder, BandsCoverFullHeight) {

--- a/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <cstdio>
 #include <limits>
 #include <vector>
@@ -508,6 +509,23 @@ TEST(GeodePathEncoder, MultipleOpenSubpathsEachGetClosed) {
   EncodedPath openEncoded = GeodePathEncoder::encode(twoLinesOpen, FillRule::NonZero);
   EncodedPath closedEncoded = GeodePathEncoder::encode(twoLinesClosed, FillRule::NonZero);
   EXPECT_EQ(openEncoded.curves.size(), closedEncoded.curves.size());
+}
+
+TEST(GeodePathEncoder, RayParallelAxisLeavesFiniteEmptyBandMetadata) {
+  const Path path = PathBuilder()
+                        .moveTo(Vector2d(0, 0))
+                        .lineTo(Vector2d(0, 10))
+                        .moveTo(Vector2d(10, 0))
+                        .lineTo(Vector2d(10, 10))
+                        .build();
+
+  const EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
+  ASSERT_FALSE(encoded.empty());
+  EXPECT_TRUE(encoded.vBands.empty());
+  EXPECT_TRUE(encoded.vCurves.empty());
+  EXPECT_EQ(encoded.vBandCount, 0u);
+  EXPECT_EQ(encoded.vStride, 0.0f);
+  EXPECT_TRUE(std::isfinite(encoded.vStride));
 }
 
 }  // namespace donner::geode

--- a/tools/ci_runtime_workflow_tests.py
+++ b/tools/ci_runtime_workflow_tests.py
@@ -89,6 +89,18 @@ class CiRuntimeWorkflowTest(unittest.TestCase):
                 job = self._job_body(job_name)
                 self.assertEqual(1, job.count("--test_tag_filters=-manual,-perf"))
 
+    def test_linker_canary_uses_bounded_native_apt_retries(self):
+        """The hosted canary must not ask an unprivileged action to kill apt."""
+        job = self._job_body("linker-canary")
+        install = job.split("- name: Install system dependencies", 1)[1].split(
+            "- name: Setup Bazel", 1
+        )[0]
+
+        self.assertNotIn("nick-fields/retry", install)
+        self.assertIn("timeout-minutes: 15", install)
+        self.assertEqual(2, install.count("Acquire::Retries=3"))
+        self.assertNotIn("clang-tidy", install)
+
     def test_heartbeat_cleanup_is_prompt_without_ps(self):
         """A finished command cannot leave the heartbeat sleeper holding the pipe."""
         job = self._job_body("linux-self-hosted")

--- a/tools/gpu_inventory/manifests/shader_features.json
+++ b/tools/gpu_inventory/manifests/shader_features.json
@@ -1432,6 +1432,7 @@
       "features": [
         "abs",
         "array",
+        "break",
         "clamp",
         "const",
         "continue",
@@ -1550,6 +1551,7 @@
       "features": [
         "abs",
         "array",
+        "break",
         "clamp",
         "const",
         "continue",
@@ -1666,6 +1668,7 @@
       "features": [
         "abs",
         "array",
+        "break",
         "clamp",
         "const",
         "continue",


### PR DESCRIPTION
This is the second of four dependency-ordered Geode optimization changes. It reduces analytic-ray work before changing the renderer's curve storage format.

## Changes

- omits curves that are parallel to each analytic ray
- sorts band curves by descending cross-axis maximum for a conservative half-pixel early-out
- chooses horizontal and vertical band counts from the observed curve distribution
- handles empty ray axes explicitly and adds focused encoder coverage

## Validation

- Exact layer head: focused Geode encoder, path encoder, shader, renderer, golden, and 16-shard resvg suites passed, 9 of 9 targets
- Exact cumulative stack head: repository-wide Geode configuration passed 868 tests with 8 declared platform skips using the deterministic software Vulkan adapter
- Exact editor goldens remain unchanged in this layer

## Security review

This layer changes bounded CPU encoding and read-only GPU traversal only. It adds no external interfaces, dependencies, persistence, or privileges. Cumulative secret and publication-scope scans are clean.

Stack: 2 of 4. Depends on the Geode editor and runtime stabilization PR; the next PR introduces canonical curve storage.
