### PR TITLE
Deduplicate Geode curves with compact band references

### DIFF
--- a/donner/editor/tests/EditorApp_tests.cc
+++ b/donner/editor/tests/EditorApp_tests.cc
@@ -1389,6 +1389,20 @@ TEST(EditorAppTest, PathOperationConvertsDocumentResultThroughRootViewBox) {
   EXPECT_FALSE(spline->isInside({35, 25}));
 }
 
+TEST(EditorAppTest, HitTestFindsDonnerLetterAtSolidStem) {
+  const std::optional<std::string> splashSource = ReadDonnerSplash();
+  if (!splashSource.has_value()) {
+    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
+  }
+
+  EditorApp app;
+  ASSERT_TRUE(app.loadFromString(*splashSource));
+
+  const std::optional<svg::SVGGraphicsElement> hit = app.hitTest(Vector2d(281.0, 395.0));
+  ASSERT_TRUE(hit.has_value());
+  EXPECT_EQ(hit->id(), "Donner_D");
+}
+
 TEST(EditorAppTest, PathOperationsHandleOverlappingDonnerLetters) {
   const std::optional<std::string> splashSource = ReadDonnerSplash();
   if (!splashSource.has_value()) {

--- a/donner/editor/wasm/tests/browser-presentation-regression.spec.ts
+++ b/donner/editor/wasm/tests/browser-presentation-regression.spec.ts
@@ -997,10 +997,22 @@ test("Firefox never exposes the checkerboard while dragging a Splash letter", as
 
   // One selected element is not yet proof that it is the RIGHT element: a press
   // that misses the letter and lands on the artboard behind it also reports
-  // one. The letter window held no outline pixels before the press, so an
-  // outline in it now, hugging the letter's own left edge, is the selection
-  // this drag is about to move.
-  const pressFrame = await captureSplashDragFrame(page, documentRegion, letterWindow, "press");
+  // one. Nor does the completed prewarm render prove its selection chrome has
+  // reached the browser composite: the overlay refresh is an idle follow-up
+  // after that worker result. Wait on the actual visible outline, bounded. A
+  // genuinely wrong selection still never puts an outline in the letter
+  // corridor and fails below with the final full-document capture attached.
+  let pressFrame = await captureSplashDragFrame(page, documentRegion, letterWindow, "press");
+  const pressOutlineDeadline = Date.now() + scaledMs(750);
+  while (pressFrame.outline === null && Date.now() < pressOutlineDeadline) {
+    await waitForBrowserComposite(page);
+    pressFrame = await captureSplashDragFrame(
+      page,
+      documentRegion,
+      letterWindow,
+      "press outline",
+    );
+  }
   expect(pressFrame.letter, "the press lost the Splash letter").not.toBeNull();
   if (pressFrame.outline === null) {
     // The letter window is a corridor a few dozen pixels wide, so "no outline

--- a/donner/gpu/metal/tests/MetalSolidFill_tests.cc
+++ b/donner/gpu/metal/tests/MetalSolidFill_tests.cc
@@ -192,7 +192,7 @@ protected:
     const Status writeStatus = device_->writeBuffer(
         buffer, 0, std::span<const uint8_t>(static_cast<const uint8_t*>(data), byteCount));
     EXPECT_FALSE(writeStatus.hasError()) << writeStatus.error();
-    return SizedBuffer{buffer, byteCount};
+    return SizedBuffer{std::move(buffer), byteCount};
   }
 
   std::unique_ptr<MetalDevice> device_;

--- a/donner/gpu/metal/tests/MetalSolidFill_tests.cc
+++ b/donner/gpu/metal/tests/MetalSolidFill_tests.cc
@@ -4,10 +4,11 @@
 /// and compares pixels against the frozen baseline captured from the current production
 /// renderer.
 ///
-/// The geometry, uniforms, and draw sequence mirror the production encoder's fillPath data flow
-/// exactly: GeodePathEncoder banding, the same clip-space MVP construction (pixel -> clip with
-/// the Y flip for a top-left origin), premultiplied colors, an identity per-instance transform
-/// at binding 7, and 1x1 dummy pattern/clip textures at bindings 3..6.
+/// The geometry, uniforms, and draw sequence follow the production encoder's fillPath data flow:
+/// GeodePathEncoder banding, the same clip-space MVP construction (pixel -> clip with the Y flip
+/// for a top-left origin), premultiplied colors, an identity per-instance transform at binding 7,
+/// and 1x1 dummy pattern/clip textures at bindings 3..6. The compact canonical curve references
+/// are expanded for the shader IR's current contiguous-curve input layout.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -16,6 +17,7 @@
 #include <cstring>
 #include <memory>
 #include <optional>
+#include <span>
 #include <utility>
 #include <vector>
 
@@ -95,16 +97,64 @@ void BuildIdentity(float* out16) {
   out16[0] = out16[5] = out16[10] = out16[15] = 1.0f;
 }
 
+/// Legacy band layout consumed by BuildSolidFillModule. The generic shader IR intentionally
+/// remains on contiguous per-band curves while Geode's production shaders use compact references.
+struct LegacyBand {
+  uint32_t curveStart;
+  uint32_t curveCount;
+  float yMin = 0.0f;
+  float yMax = 0.0f;
+  float xMin = 0.0f;
+  float xMax = 0.0f;
+  float pad0 = 0.0f;
+  float pad1 = 0.0f;
+};
+static_assert(sizeof(LegacyBand) == 32, "LegacyBand must match the shader IR layout");
+
+struct LegacyAxis {
+  std::vector<LegacyBand> bands;
+  std::vector<EncodedPath::Curve> curves;
+};
+
+/// Expands compact per-band curve references into the contiguous layout consumed by the current
+/// generic solid-fill shader IR. Returns false for a malformed reference range or index.
+bool ExpandLegacyAxis(std::span<const EncodedPath::Band> bands,
+                      std::span<const uint32_t> curveIndices,
+                      std::span<const EncodedPath::Curve> canonicalCurves, LegacyAxis& result) {
+  for (const EncodedPath::Band& band : bands) {
+    if (band.curveStart > curveIndices.size() ||
+        band.curveCount > curveIndices.size() - band.curveStart) {
+      return false;
+    }
+
+    LegacyBand legacyBand{static_cast<uint32_t>(result.curves.size()), band.curveCount};
+    for (uint32_t i = 0; i < band.curveCount; ++i) {
+      const uint32_t curveIndex = curveIndices[band.curveStart + i];
+      if (curveIndex >= canonicalCurves.size()) {
+        return false;
+      }
+      result.curves.push_back(canonicalCurves[curveIndex]);
+    }
+    result.bands.push_back(legacyBand);
+  }
+  return true;
+}
+
+struct SizedBuffer {
+  Buffer buffer;
+  uint64_t sizeBytes = 0;
+};
+
 /// One path's GPU resources.
 struct PathDraw {
   Buffer vertexBuffer;       //!< Quad vertices (6 x 20 bytes).
   Buffer uniformBuffer;      //!< 288-byte Uniforms.
-  Buffer bands;              //!< Horizontal bands (or 4-byte dummy).
-  Buffer curves;             //!< Horizontal curves (or dummy).
-  Buffer vBands;             //!< Vertical bands (or dummy).
-  Buffer vCurves;            //!< Vertical curves (or dummy).
-  Buffer hGrid;              //!< Horizontal band grid (or dummy).
-  Buffer vGrid;              //!< Vertical band grid (or dummy).
+  SizedBuffer bands;         //!< Horizontal bands (or one zero band).
+  SizedBuffer curves;        //!< Horizontal curves (or 4-byte dummy).
+  SizedBuffer vBands;        //!< Vertical bands (or one zero band).
+  SizedBuffer vCurves;       //!< Vertical curves (or 4-byte dummy).
+  SizedBuffer hGrid;         //!< Horizontal band grid (or 4-byte dummy).
+  SizedBuffer vGrid;         //!< Vertical band grid (or 4-byte dummy).
   BindGroup bindGroup;       //!< The 12-entry solid-fill bind group.
   uint32_t vertexCount = 0;  //!< Draw vertex count.
 };
@@ -127,14 +177,14 @@ protected:
     return std::move(result).result();
   }
 
-  /// Creates a storage buffer holding \p bytes (or a 4-byte zero dummy when empty), mirroring
-  /// the production encoder's empty-region dummies (the shader's band-count gates never
-  /// dereference them).
-  Buffer storageBuffer(const char* label, const void* data, size_t byteCount) {
-    const uint32_t dummy = 0;
+  /// Creates a storage buffer holding \p bytes. Empty buffers receive a zero-filled dummy large
+  /// enough for one shader element so Metal validation can prove every runtime-array binding.
+  SizedBuffer storageBuffer(const char* label, const void* data, size_t byteCount,
+                            size_t emptyByteCount = sizeof(uint32_t)) {
+    const std::array<uint8_t, sizeof(LegacyBand)> dummy = {};
     if (byteCount == 0) {
-      data = &dummy;
-      byteCount = sizeof(dummy);
+      data = dummy.data();
+      byteCount = emptyByteCount;
     }
     Buffer buffer = unwrap(device_->createBuffer(BufferDescriptor{
                                label, byteCount, BufferUsage::Storage | BufferUsage::CopyDst}),
@@ -142,7 +192,7 @@ protected:
     const Status writeStatus = device_->writeBuffer(
         buffer, 0, std::span<const uint8_t>(static_cast<const uint8_t*>(data), byteCount));
     EXPECT_FALSE(writeStatus.hasError()) << writeStatus.error();
-    return buffer;
+    return SizedBuffer{buffer, byteCount};
   }
 
   std::unique_ptr<MetalDevice> device_;
@@ -260,7 +310,7 @@ TEST_F(MetalSolidFillTest, MatchesFrozenBaseline) {
     float row0[4] = {1.0f, 0.0f, 0.0f, 0.0f};
     float row1[4] = {0.0f, 1.0f, 0.0f, 0.0f};
   } identityTransform;
-  Buffer instanceTransforms =
+  SizedBuffer instanceTransforms =
       storageBuffer("instanceTransforms", &identityTransform, sizeof(identityTransform));
 
   // ----- Per-path geometry, uniforms, and bind groups (the production fillPath data flow) ----
@@ -269,6 +319,11 @@ TEST_F(MetalSolidFillTest, MatchesFrozenBaseline) {
   for (const BaselinePathSpec& spec : BaselineScenePaths()) {
     const EncodedPath encoded = geode::GeodePathEncoder::encode(spec.path, spec.rule);
     ASSERT_FALSE(encoded.quadVertices.empty());
+
+    LegacyAxis horizontal;
+    LegacyAxis vertical;
+    ASSERT_TRUE(ExpandLegacyAxis(encoded.bands, encoded.curveIndices, encoded.curves, horizontal));
+    ASSERT_TRUE(ExpandLegacyAxis(encoded.vBands, encoded.vCurveIndices, encoded.vCurves, vertical));
 
     PathDraw draw;
     draw.vertexCount = static_cast<uint32_t>(encoded.quadVertices.size());
@@ -283,14 +338,14 @@ TEST_F(MetalSolidFillTest, MatchesFrozenBaseline) {
                                  encoded.quadVertices.size() * sizeof(EncodedPath::Vertex)));
     ASSERT_FALSE(vertexWrite.hasError()) << vertexWrite.error();
 
-    draw.bands = storageBuffer("bands", encoded.bands.data(),
-                               encoded.bands.size() * sizeof(EncodedPath::Band));
-    draw.curves = storageBuffer("curves", encoded.curves.data(),
-                                encoded.curves.size() * sizeof(EncodedPath::Curve));
-    draw.vBands = storageBuffer("vBands", encoded.vBands.data(),
-                                encoded.vBands.size() * sizeof(EncodedPath::Band));
-    draw.vCurves = storageBuffer("vCurves", encoded.vCurves.data(),
-                                 encoded.vCurves.size() * sizeof(EncodedPath::Curve));
+    draw.bands = storageBuffer("bands", horizontal.bands.data(),
+                               horizontal.bands.size() * sizeof(LegacyBand), sizeof(LegacyBand));
+    draw.curves = storageBuffer("curves", horizontal.curves.data(),
+                                horizontal.curves.size() * sizeof(EncodedPath::Curve));
+    draw.vBands = storageBuffer("vBands", vertical.bands.data(),
+                                vertical.bands.size() * sizeof(LegacyBand), sizeof(LegacyBand));
+    draw.vCurves = storageBuffer("vCurves", vertical.curves.data(),
+                                 vertical.curves.size() * sizeof(EncodedPath::Curve));
     draw.hGrid = storageBuffer("hBandGrid", encoded.hBandGrid.data(),
                                encoded.hBandGrid.size() * sizeof(uint32_t));
     draw.vGrid = storageBuffer("vBandGrid", encoded.vBandGrid.data(),
@@ -330,17 +385,18 @@ TEST_F(MetalSolidFillTest, MatchesFrozenBaseline) {
 
     std::vector<BindGroupEntry> entries;
     entries.push_back({0, BufferBinding{draw.uniformBuffer, 0, sizeof(Uniforms)}});
-    entries.push_back({1, BufferBinding{draw.bands, 0, 4}});
-    entries.push_back({2, BufferBinding{draw.curves, 0, 4}});
+    entries.push_back({1, BufferBinding{draw.bands.buffer, 0, draw.bands.sizeBytes}});
+    entries.push_back({2, BufferBinding{draw.curves.buffer, 0, draw.curves.sizeBytes}});
     entries.push_back({3, TextureViewBinding{dummyView}});
     entries.push_back({4, SamplerBinding{dummySampler}});
     entries.push_back({5, TextureViewBinding{dummyView}});
     entries.push_back({6, SamplerBinding{dummySampler}});
-    entries.push_back({7, BufferBinding{instanceTransforms, 0, sizeof(identityTransform)}});
-    entries.push_back({8, BufferBinding{draw.vBands, 0, 4}});
-    entries.push_back({9, BufferBinding{draw.vCurves, 0, 4}});
-    entries.push_back({10, BufferBinding{draw.hGrid, 0, 4}});
-    entries.push_back({11, BufferBinding{draw.vGrid, 0, 4}});
+    entries.push_back(
+        {7, BufferBinding{instanceTransforms.buffer, 0, instanceTransforms.sizeBytes}});
+    entries.push_back({8, BufferBinding{draw.vBands.buffer, 0, draw.vBands.sizeBytes}});
+    entries.push_back({9, BufferBinding{draw.vCurves.buffer, 0, draw.vCurves.sizeBytes}});
+    entries.push_back({10, BufferBinding{draw.hGrid.buffer, 0, draw.hGrid.sizeBytes}});
+    entries.push_back({11, BufferBinding{draw.vGrid.buffer, 0, draw.vGrid.sizeBytes}});
     draw.bindGroup = unwrap(device_->createBindGroup(BindGroupDescriptor{
                                 "solidFillGroup", bindGroupLayout, std::move(entries)}),
                             "createBindGroup");

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -237,8 +237,8 @@ struct GeoEncoder::Impl {
   Arena bandArena;
   Arena curveArena;
   Arena uniformArena;
-  /// Analytic dual-ray fill (0041 §8): vertical band/curve SSBOs and the dense
-  /// H/V band-grid lookup tables. Bound at bindings 8-11 of the fill pipeline.
+  /// Analytic dual-ray fill (0041 §8): vertical band/curve SSBOs, dense H/V band-grid lookup
+  /// tables, and compact curve references. Bound at bindings 8-13 of the fill pipeline.
   Arena vBandArena;
   Arena vCurveArena;
   Arena hGridArena;
@@ -389,15 +389,17 @@ struct GeoEncoder::Impl {
     uint64_t h = e.quadVertices.size();
     h = h * 1000003u + e.bands.size();
     h = h * 1000003u + e.curves.size();
+    h = h * 1000003u + e.curveIndices.size();
     h = h * 1000003u + e.vBands.size();
     h = h * 1000003u + e.vCurves.size();
+    h = h * 1000003u + e.vCurveIndices.size();
     h = h * 1000003u + e.hBandGrid.size();
     h = h * 1000003u + e.vBandGrid.size();
     return h;
   }
 
   /// Upload the analytic dual-ray buffers + grid params for a gradient draw,
-  /// build the 9-binding bind group, and record the single-quad draw. Shared
+  /// build the 11-binding bind group, and record the single-quad draw. Shared
   /// by the linear and radial gradient paths (0041 §8). `u` is filled in by the
   /// caller except for the grid params, which this writes from `encoded`.
   void submitGradientDraw(GradientUniforms& u, const EncodedPath& encoded) {
@@ -426,11 +428,15 @@ struct GeoEncoder::Impl {
                                                 encoded.hBandGrid.size() * sizeof(uint32_t));
     const auto vGridAlloc = allocStorageOrDummy(vGridArena, encoded.vBandGrid.data(),
                                                 encoded.vBandGrid.size() * sizeof(uint32_t));
+    const auto hRefsAlloc = allocStorageOrDummy(hGridArena, encoded.curveIndices.data(),
+                                                encoded.curveIndices.size() * sizeof(uint32_t));
+    const auto vRefsAlloc = allocStorageOrDummy(vGridArena, encoded.vCurveIndices.data(),
+                                                encoded.vCurveIndices.size() * sizeof(uint32_t));
 
     const auto uniAlloc =
         allocInArena(uniformArena, &u, sizeof(GradientUniforms), kUniformOffsetAlignment);
 
-    wgpu::BindGroupEntry entries[9] = {};
+    wgpu::BindGroupEntry entries[11] = {};
     entries[0].binding = 0;
     entries[0].buffer = *uniAlloc.buffer;
     entries[0].offset = uniAlloc.offset;
@@ -463,11 +469,19 @@ struct GeoEncoder::Impl {
     entries[8].buffer = *vGridAlloc.buffer;
     entries[8].offset = vGridAlloc.offset;
     entries[8].size = vGridAlloc.size;
+    entries[9].binding = 9;
+    entries[9].buffer = *hRefsAlloc.buffer;
+    entries[9].offset = hRefsAlloc.offset;
+    entries[9].size = hRefsAlloc.size;
+    entries[10].binding = 10;
+    entries[10].buffer = *vRefsAlloc.buffer;
+    entries[10].offset = vRefsAlloc.offset;
+    entries[10].size = vRefsAlloc.size;
 
     wgpu::BindGroupDescriptor bgDesc = {};
     bgDesc.label = wgpuLabel("GeodeGradientBindGroup");
     bgDesc.layout = gradientPipeline->bindGroupLayout();
-    bgDesc.entryCount = 9;
+    bgDesc.entryCount = 11;
     bgDesc.entries = entries;
     wgpu::BindGroup bindGroup = transientResources.retain(dev.createBindGroup(bgDesc));
     device->countBindGroup();
@@ -1039,6 +1053,12 @@ void GeoEncoder::fillPathIntoMask(const Path& path, FillRule rule,
                                                      encoded.hBandGrid.size() * sizeof(uint32_t));
   const auto vGridAlloc = impl_->allocStorageOrDummy(impl_->vGridArena, encoded.vBandGrid.data(),
                                                      encoded.vBandGrid.size() * sizeof(uint32_t));
+  const auto hRefsAlloc =
+      impl_->allocStorageOrDummy(impl_->hGridArena, encoded.curveIndices.data(),
+                                 encoded.curveIndices.size() * sizeof(uint32_t));
+  const auto vRefsAlloc =
+      impl_->allocStorageOrDummy(impl_->vGridArena, encoded.vCurveIndices.data(),
+                                 encoded.vCurveIndices.size() * sizeof(uint32_t));
 
   // Mask uniforms - mvp, viewport, fillRule, hasClipMask, grid params. The
   // `hasClipMask` field gates whether the fragment shader intersects with the
@@ -1076,7 +1096,7 @@ void GeoEncoder::fillPathIntoMask(const Path& path, FillRule rule,
   const auto uniAlloc =
       impl_->allocInArena(impl_->uniformArena, &u, sizeof(MaskUniforms), kUniformOffsetAlignment);
 
-  wgpu::BindGroupEntry entries[9] = {};
+  wgpu::BindGroupEntry entries[11] = {};
   entries[0].binding = 0;
   entries[0].buffer = *uniAlloc.buffer;
   entries[0].offset = uniAlloc.offset;
@@ -1109,11 +1129,19 @@ void GeoEncoder::fillPathIntoMask(const Path& path, FillRule rule,
   entries[8].buffer = *vGridAlloc.buffer;
   entries[8].offset = vGridAlloc.offset;
   entries[8].size = vGridAlloc.size;
+  entries[9].binding = 9;
+  entries[9].buffer = *hRefsAlloc.buffer;
+  entries[9].offset = hRefsAlloc.offset;
+  entries[9].size = hRefsAlloc.size;
+  entries[10].binding = 10;
+  entries[10].buffer = *vRefsAlloc.buffer;
+  entries[10].offset = vRefsAlloc.offset;
+  entries[10].size = vRefsAlloc.size;
 
   wgpu::BindGroupDescriptor bgDesc = {};
   bgDesc.label = wgpuLabel("GeodeMaskBindGroup");
   bgDesc.layout = impl_->maskPipelineOwned->bindGroupLayout();
-  bgDesc.entryCount = 9;
+  bgDesc.entryCount = 11;
   bgDesc.entries = entries;
   wgpu::BindGroup bindGroup = impl_->transientResources.retain(dev.createBindGroup(bgDesc));
   impl_->device->countBindGroup();
@@ -1293,8 +1321,10 @@ void GeoEncoder::Impl::uploadResidentGeometry(GeodeResidentSlot& slot, const Enc
   const uint64_t vBytes = encoded.quadVertices.size() * sizeof(EncodedPath::Vertex);
   const uint64_t bandsBytes = encoded.bands.size() * sizeof(EncodedPath::Band);
   const uint64_t curvesBytes = encoded.curves.size() * 6u * sizeof(float);
+  const uint64_t hRefsBytes = encoded.curveIndices.size() * sizeof(uint32_t);
   const uint64_t vBandsBytes = encoded.vBands.size() * sizeof(EncodedPath::Band);
   const uint64_t vCurvesBytes = encoded.vCurves.size() * 6u * sizeof(float);
+  const uint64_t vRefsBytes = encoded.vCurveIndices.size() * sizeof(uint32_t);
   const uint64_t hGridBytes = encoded.hBandGrid.size() * sizeof(uint32_t);
   const uint64_t vGridBytes = encoded.vBandGrid.size() * sizeof(uint32_t);
 
@@ -1315,8 +1345,10 @@ void GeoEncoder::Impl::uploadResidentGeometry(GeodeResidentSlot& slot, const Enc
   place(slot.vertex, vBytes, kVertexOffsetAlignment, /*storageDummy=*/false);
   place(slot.bands, bandsBytes, kStorageOffsetAlignment, /*storageDummy=*/true);
   place(slot.curves, curvesBytes, kStorageOffsetAlignment, /*storageDummy=*/true);
+  place(slot.hRefs, hRefsBytes, kStorageOffsetAlignment, /*storageDummy=*/true);
   place(slot.vBands, vBandsBytes, kStorageOffsetAlignment, /*storageDummy=*/true);
   place(slot.vCurves, vCurvesBytes, kStorageOffsetAlignment, /*storageDummy=*/true);
+  place(slot.vRefs, vRefsBytes, kStorageOffsetAlignment, /*storageDummy=*/true);
   place(slot.hGrid, hGridBytes, kStorageOffsetAlignment, /*storageDummy=*/true);
   place(slot.vGrid, vGridBytes, kStorageOffsetAlignment, /*storageDummy=*/true);
   place(slot.uniform, sizeof(Uniforms), kUniformOffsetAlignment, /*storageDummy=*/false);
@@ -1345,8 +1377,10 @@ void GeoEncoder::Impl::uploadResidentGeometry(GeodeResidentSlot& slot, const Enc
   blit(slot.vertex, encoded.quadVertices.data(), vBytes);
   blit(slot.bands, encoded.bands.data(), bandsBytes);
   blit(slot.curves, encoded.curves.data(), curvesBytes);
+  blit(slot.hRefs, encoded.curveIndices.data(), hRefsBytes);
   blit(slot.vBands, encoded.vBands.data(), vBandsBytes);
   blit(slot.vCurves, encoded.vCurves.data(), vCurvesBytes);
+  blit(slot.vRefs, encoded.vCurveIndices.data(), vRefsBytes);
   blit(slot.hGrid, encoded.hBandGrid.data(), hGridBytes);
   blit(slot.vGrid, encoded.vBandGrid.data(), vGridBytes);
 
@@ -1371,7 +1405,7 @@ void GeoEncoder::Impl::buildResidentBindGroup(GeodeResidentSlot& slot) {
   const wgpu::Device& dev = device->device();
   const wgpu::Buffer& buf = slot.buffer.get();
 
-  wgpu::BindGroupEntry entries[12] = {};
+  wgpu::BindGroupEntry entries[14] = {};
   auto bufEntry = [&](int i, uint32_t binding, const GeodeResidentSlot::Region& r) {
     entries[i].binding = binding;
     entries[i].buffer = buf;
@@ -1400,11 +1434,13 @@ void GeoEncoder::Impl::buildResidentBindGroup(GeodeResidentSlot& slot) {
   bufEntry(9, 9, slot.vCurves);
   bufEntry(10, 10, slot.hGrid);
   bufEntry(11, 11, slot.vGrid);
+  bufEntry(12, 12, slot.hRefs);
+  bufEntry(13, 13, slot.vRefs);
 
   wgpu::BindGroupDescriptor bgDesc = {};
   bgDesc.label = wgpuLabel("GeodeResidentBindGroup");
   bgDesc.layout = pipeline->bindGroupLayout();
-  bgDesc.entryCount = 12;
+  bgDesc.entryCount = 14;
   bgDesc.entries = entries;
   slot.bindGroup.reset(dev.createBindGroup(bgDesc));
   device->countBindGroup();
@@ -1636,6 +1672,12 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args,
                                                      encoded.hBandGrid.size() * sizeof(uint32_t));
   const auto vGridAlloc = impl_->allocStorageOrDummy(impl_->vGridArena, encoded.vBandGrid.data(),
                                                      encoded.vBandGrid.size() * sizeof(uint32_t));
+  const auto hRefsAlloc =
+      impl_->allocStorageOrDummy(impl_->hGridArena, encoded.curveIndices.data(),
+                                 encoded.curveIndices.size() * sizeof(uint32_t));
+  const auto vRefsAlloc =
+      impl_->allocStorageOrDummy(impl_->vGridArena, encoded.vCurveIndices.data(),
+                                 encoded.vCurveIndices.size() * sizeof(uint32_t));
 
   // Uniform buffer - still per-draw today; Milestone 1.f lifts it into
   // a ring buffer with dynamic offsets. `populateFillUniform` is shared
@@ -1646,11 +1688,11 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args,
   const auto uniAlloc =
       impl_->allocInArena(impl_->uniformArena, &u, sizeof(Uniforms), kUniformOffsetAlignment);
 
-  // 3. Bind group - twelve entries: uniforms, H bands SSBO, H curves SSBO,
+  // 3. Bind group - fourteen entries: uniforms, H bands SSBO, H curves SSBO,
   // pattern texture, pattern sampler, clip-mask texture, clip-mask sampler,
   // per-instance transforms SSBO, V bands SSBO, V curves SSBO, H band grid,
-  // V band grid.
-  wgpu::BindGroupEntry entries[12] = {};
+  // V band grid, H curve references, V curve references.
+  wgpu::BindGroupEntry entries[14] = {};
   entries[0].binding = 0;
   entries[0].buffer = *uniAlloc.buffer;
   entries[0].offset = uniAlloc.offset;
@@ -1700,11 +1742,19 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args,
   entries[11].buffer = *vGridAlloc.buffer;
   entries[11].offset = vGridAlloc.offset;
   entries[11].size = vGridAlloc.size;
+  entries[12].binding = 12;
+  entries[12].buffer = *hRefsAlloc.buffer;
+  entries[12].offset = hRefsAlloc.offset;
+  entries[12].size = hRefsAlloc.size;
+  entries[13].binding = 13;
+  entries[13].buffer = *vRefsAlloc.buffer;
+  entries[13].offset = vRefsAlloc.offset;
+  entries[13].size = vRefsAlloc.size;
 
   wgpu::BindGroupDescriptor bgDesc = {};
   bgDesc.label = wgpuLabel("GeodeBindGroup");
   bgDesc.layout = impl_->pipeline->bindGroupLayout();
-  bgDesc.entryCount = 12;
+  bgDesc.entryCount = 14;
   bgDesc.entries = entries;
   wgpu::BindGroup bindGroup = impl_->transientResources.retain(dev.createBindGroup(bgDesc));
   impl_->device->countBindGroup();

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -294,9 +294,11 @@ struct GeoEncoder::Impl {
   /// Allocate `size` bytes in `arena` at an offset aligned to
   /// `alignment`, growing if necessary. Writes `size` bytes of `data`
   /// into the buffer via `queue.writeBuffer`. Returns the
-  /// (buffer, offset) pair the draw should bind.
+  /// (buffer, offset) pair the draw should bind. The returned handle is a
+  /// value snapshot so a later growth of the same arena cannot retarget an
+  /// earlier allocation to the replacement buffer.
   struct Allocation {
-    const wgpu::Buffer* buffer;
+    wgpu::Buffer buffer;
     uint64_t offset;
     uint64_t size;
   };
@@ -339,7 +341,7 @@ struct GeoEncoder::Impl {
     device->queue().writeBuffer(arena.buffer.get(), alignedOffset, data, size);
     device->countBufferWrite(size);
     arena.offset = alignedOffset + size;
-    return {&arena.buffer.get(), alignedOffset, size};
+    return {arena.buffer.get(), alignedOffset, size};
   }
 
   /// Allocate a read-only storage binding for `byteCount` bytes of `data`,
@@ -438,15 +440,15 @@ struct GeoEncoder::Impl {
 
     wgpu::BindGroupEntry entries[11] = {};
     entries[0].binding = 0;
-    entries[0].buffer = *uniAlloc.buffer;
+    entries[0].buffer = uniAlloc.buffer;
     entries[0].offset = uniAlloc.offset;
     entries[0].size = uniAlloc.size;
     entries[1].binding = 1;
-    entries[1].buffer = *bandsAlloc.buffer;
+    entries[1].buffer = bandsAlloc.buffer;
     entries[1].offset = bandsAlloc.offset;
     entries[1].size = bandsAlloc.size;
     entries[2].binding = 2;
-    entries[2].buffer = *curvesAlloc.buffer;
+    entries[2].buffer = curvesAlloc.buffer;
     entries[2].offset = curvesAlloc.offset;
     entries[2].size = curvesAlloc.size;
     entries[3].binding = 3;
@@ -454,27 +456,27 @@ struct GeoEncoder::Impl {
     entries[4].binding = 4;
     entries[4].sampler = device->dummyClipMaskSampler();
     entries[5].binding = 5;
-    entries[5].buffer = *vBandsAlloc.buffer;
+    entries[5].buffer = vBandsAlloc.buffer;
     entries[5].offset = vBandsAlloc.offset;
     entries[5].size = vBandsAlloc.size;
     entries[6].binding = 6;
-    entries[6].buffer = *vCurvesAlloc.buffer;
+    entries[6].buffer = vCurvesAlloc.buffer;
     entries[6].offset = vCurvesAlloc.offset;
     entries[6].size = vCurvesAlloc.size;
     entries[7].binding = 7;
-    entries[7].buffer = *hGridAlloc.buffer;
+    entries[7].buffer = hGridAlloc.buffer;
     entries[7].offset = hGridAlloc.offset;
     entries[7].size = hGridAlloc.size;
     entries[8].binding = 8;
-    entries[8].buffer = *vGridAlloc.buffer;
+    entries[8].buffer = vGridAlloc.buffer;
     entries[8].offset = vGridAlloc.offset;
     entries[8].size = vGridAlloc.size;
     entries[9].binding = 9;
-    entries[9].buffer = *hRefsAlloc.buffer;
+    entries[9].buffer = hRefsAlloc.buffer;
     entries[9].offset = hRefsAlloc.offset;
     entries[9].size = hRefsAlloc.size;
     entries[10].binding = 10;
-    entries[10].buffer = *vRefsAlloc.buffer;
+    entries[10].buffer = vRefsAlloc.buffer;
     entries[10].offset = vRefsAlloc.offset;
     entries[10].size = vRefsAlloc.size;
 
@@ -487,7 +489,7 @@ struct GeoEncoder::Impl {
     device->countBindGroup();
 
     recordGeometryDebugDraw(encoded);
-    pass.get().setVertexBuffer(0, *vbAlloc.buffer, vbAlloc.offset, vbAlloc.size);
+    pass.get().setVertexBuffer(0, vbAlloc.buffer, vbAlloc.offset, vbAlloc.size);
     pass.get().setBindGroup(0, bindGroup, 0, nullptr);
     pass.get().draw(static_cast<uint32_t>(encoded.quadVertices.size()), 1, 0, 0);
     device->countDraw();
@@ -1098,15 +1100,15 @@ void GeoEncoder::fillPathIntoMask(const Path& path, FillRule rule,
 
   wgpu::BindGroupEntry entries[11] = {};
   entries[0].binding = 0;
-  entries[0].buffer = *uniAlloc.buffer;
+  entries[0].buffer = uniAlloc.buffer;
   entries[0].offset = uniAlloc.offset;
   entries[0].size = uniAlloc.size;
   entries[1].binding = 1;
-  entries[1].buffer = *bandsAlloc.buffer;
+  entries[1].buffer = bandsAlloc.buffer;
   entries[1].offset = bandsAlloc.offset;
   entries[1].size = bandsAlloc.size;
   entries[2].binding = 2;
-  entries[2].buffer = *curvesAlloc.buffer;
+  entries[2].buffer = curvesAlloc.buffer;
   entries[2].offset = curvesAlloc.offset;
   entries[2].size = curvesAlloc.size;
   entries[3].binding = 3;
@@ -1114,27 +1116,27 @@ void GeoEncoder::fillPathIntoMask(const Path& path, FillRule rule,
   entries[4].binding = 4;
   entries[4].sampler = impl_->device->dummyClipMaskSampler();
   entries[5].binding = 5;
-  entries[5].buffer = *vBandsAlloc.buffer;
+  entries[5].buffer = vBandsAlloc.buffer;
   entries[5].offset = vBandsAlloc.offset;
   entries[5].size = vBandsAlloc.size;
   entries[6].binding = 6;
-  entries[6].buffer = *vCurvesAlloc.buffer;
+  entries[6].buffer = vCurvesAlloc.buffer;
   entries[6].offset = vCurvesAlloc.offset;
   entries[6].size = vCurvesAlloc.size;
   entries[7].binding = 7;
-  entries[7].buffer = *hGridAlloc.buffer;
+  entries[7].buffer = hGridAlloc.buffer;
   entries[7].offset = hGridAlloc.offset;
   entries[7].size = hGridAlloc.size;
   entries[8].binding = 8;
-  entries[8].buffer = *vGridAlloc.buffer;
+  entries[8].buffer = vGridAlloc.buffer;
   entries[8].offset = vGridAlloc.offset;
   entries[8].size = vGridAlloc.size;
   entries[9].binding = 9;
-  entries[9].buffer = *hRefsAlloc.buffer;
+  entries[9].buffer = hRefsAlloc.buffer;
   entries[9].offset = hRefsAlloc.offset;
   entries[9].size = hRefsAlloc.size;
   entries[10].binding = 10;
-  entries[10].buffer = *vRefsAlloc.buffer;
+  entries[10].buffer = vRefsAlloc.buffer;
   entries[10].offset = vRefsAlloc.offset;
   entries[10].size = vRefsAlloc.size;
 
@@ -1147,7 +1149,7 @@ void GeoEncoder::fillPathIntoMask(const Path& path, FillRule rule,
   impl_->device->countBindGroup();
 
   impl_->recordGeometryDebugDraw(encoded);
-  impl_->maskPass.get().setVertexBuffer(0, *vbAlloc.buffer, vbAlloc.offset, vbAlloc.size);
+  impl_->maskPass.get().setVertexBuffer(0, vbAlloc.buffer, vbAlloc.offset, vbAlloc.size);
   impl_->maskPass.get().setBindGroup(0, bindGroup, 0, nullptr);
   impl_->maskPass.get().draw(static_cast<uint32_t>(encoded.quadVertices.size()), 1, 0, 0);
   impl_->device->countDraw();
@@ -1579,7 +1581,7 @@ void GeoEncoder::fillPathInstanced(const EncodedPath& encoded, const css::RGBA& 
   args.tileSize = Vector2d(1.0, 1.0);
   args.patternFromPath = Transform2d();
 
-  args.instanceTransformsBuffer = itAlloc.buffer;
+  args.instanceTransformsBuffer = &itAlloc.buffer;
   args.instanceTransformsOffset = itAlloc.offset;
   args.instanceTransformsSize = itAlloc.size;
   args.instanceCount = instanceCount;
@@ -1694,15 +1696,15 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args,
   // V band grid, H curve references, V curve references.
   wgpu::BindGroupEntry entries[14] = {};
   entries[0].binding = 0;
-  entries[0].buffer = *uniAlloc.buffer;
+  entries[0].buffer = uniAlloc.buffer;
   entries[0].offset = uniAlloc.offset;
   entries[0].size = uniAlloc.size;
   entries[1].binding = 1;
-  entries[1].buffer = *bandsAlloc.buffer;
+  entries[1].buffer = bandsAlloc.buffer;
   entries[1].offset = bandsAlloc.offset;
   entries[1].size = bandsAlloc.size;
   entries[2].binding = 2;
-  entries[2].buffer = *curvesAlloc.buffer;
+  entries[2].buffer = curvesAlloc.buffer;
   entries[2].offset = curvesAlloc.offset;
   entries[2].size = curvesAlloc.size;
   entries[3].binding = 3;
@@ -1727,27 +1729,27 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args,
     entries[7].size = 32u;
   }
   entries[8].binding = 8;
-  entries[8].buffer = *vBandsAlloc.buffer;
+  entries[8].buffer = vBandsAlloc.buffer;
   entries[8].offset = vBandsAlloc.offset;
   entries[8].size = vBandsAlloc.size;
   entries[9].binding = 9;
-  entries[9].buffer = *vCurvesAlloc.buffer;
+  entries[9].buffer = vCurvesAlloc.buffer;
   entries[9].offset = vCurvesAlloc.offset;
   entries[9].size = vCurvesAlloc.size;
   entries[10].binding = 10;
-  entries[10].buffer = *hGridAlloc.buffer;
+  entries[10].buffer = hGridAlloc.buffer;
   entries[10].offset = hGridAlloc.offset;
   entries[10].size = hGridAlloc.size;
   entries[11].binding = 11;
-  entries[11].buffer = *vGridAlloc.buffer;
+  entries[11].buffer = vGridAlloc.buffer;
   entries[11].offset = vGridAlloc.offset;
   entries[11].size = vGridAlloc.size;
   entries[12].binding = 12;
-  entries[12].buffer = *hRefsAlloc.buffer;
+  entries[12].buffer = hRefsAlloc.buffer;
   entries[12].offset = hRefsAlloc.offset;
   entries[12].size = hRefsAlloc.size;
   entries[13].binding = 13;
-  entries[13].buffer = *vRefsAlloc.buffer;
+  entries[13].buffer = vRefsAlloc.buffer;
   entries[13].offset = vRefsAlloc.offset;
   entries[13].size = vRefsAlloc.size;
 
@@ -1761,7 +1763,7 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args,
 
   // 4. Record the draw call - one quad (6 vertices) per path.
   impl_->recordGeometryDebugDraw(encoded, instanceTransforms);
-  impl_->pass.get().setVertexBuffer(0, *vbAlloc.buffer, vbAlloc.offset, vbAlloc.size);
+  impl_->pass.get().setVertexBuffer(0, vbAlloc.buffer, vbAlloc.offset, vbAlloc.size);
   impl_->pass.get().setBindGroup(0, bindGroup, 0, nullptr);
   impl_->pass.get().draw(static_cast<uint32_t>(encoded.quadVertices.size()), args.instanceCount, 0,
                          0);

--- a/donner/svg/renderer/geode/GeodePathEncoder.cc
+++ b/donner/svg/renderer/geode/GeodePathEncoder.cc
@@ -285,8 +285,9 @@ std::vector<CurveWithRange> omitRayParallelCurves(std::vector<CurveWithRange> cu
 /// boundaries and `yMin`/`yMax` are the curves' Y-extent.
 void bandCurves(const std::vector<CurveWithRange>& allCurves, const Box2d& bounds, BandAxis axis,
                 std::vector<EncodedPath::Band>& outBands,
-                std::vector<EncodedPath::Curve>& outCurves, uint16_t bandCount,
-                std::vector<uint32_t>& outGrid) {
+                std::vector<EncodedPath::Curve>& outCurves, std::vector<uint32_t>& outCurveIndices,
+                uint16_t bandCount, std::vector<uint32_t>& outGrid,
+                EncodedPath::AxisStats& outStats) {
   // Dense cell → band-slot map (kNoBand for empty cells). Sized to the full grid even when
   // some cells are empty, so the fragment shader can index it directly by position.
   outGrid.assign(bandCount, EncodedPath::kNoBand);
@@ -294,11 +295,14 @@ void bandCurves(const std::vector<CurveWithRange>& allCurves, const Box2d& bound
     return;
   }
 
+  UTILS_RELEASE_ASSERT_MSG(allCurves.size() <= std::numeric_limits<uint32_t>::max(),
+                           "Geode path has too many canonical curves for 32-bit references");
+  outCurves.reserve(outCurves.size() + allCurves.size());
+  for (const CurveWithRange& curve : allCurves) {
+    outCurves.push_back(curve.curve);
+  }
+
   const bool byY = (axis == BandAxis::Y);
-  const float spanBase =
-      byY ? static_cast<float>(bounds.topLeft.y) : static_cast<float>(bounds.topLeft.x);
-  const float span = byY ? static_cast<float>(bounds.height()) : static_cast<float>(bounds.width());
-  const float bandStride = span / static_cast<float>(bandCount);
 
   // Sort the canonical curve indexes once. Appending them to every overlapping
   // band in this order preserves descending cross-axis maxima without an O(B)
@@ -328,7 +332,7 @@ void bandCurves(const std::vector<CurveWithRange>& allCurves, const Box2d& bound
   }
 
   outBands.reserve(outBands.size() + bandCount);
-  outCurves.reserve(outCurves.size() + allCurves.size() * 2);
+  outCurveIndices.reserve(outCurveIndices.size() + allCurves.size() * 2u);
 
   for (uint16_t b = 0; b < bandCount; ++b) {
     const auto& indices = bandCurveIndices[b];
@@ -340,34 +344,29 @@ void bandCurves(const std::vector<CurveWithRange>& allCurves, const Box2d& bound
     outGrid[b] = static_cast<uint32_t>(outBands.size());
 
     EncodedPath::Band band = {};
-    band.curveStart = static_cast<uint32_t>(outCurves.size());
+    UTILS_RELEASE_ASSERT_MSG(outCurveIndices.size() <= std::numeric_limits<uint32_t>::max(),
+                             "Geode path has too many band references for 32-bit offsets");
+    UTILS_RELEASE_ASSERT_MSG(
+        indices.size() <= std::numeric_limits<uint32_t>::max() - outCurveIndices.size(),
+        "Geode path band references overflow 32-bit storage");
+    band.curveStart = static_cast<uint32_t>(outCurveIndices.size());
     band.curveCount = static_cast<uint32_t>(indices.size());
-
-    const float stripLo = spanBase + static_cast<float>(b) * bandStride;
-    const float stripHi = spanBase + static_cast<float>(b + 1) * bandStride;
-
-    // Cross-axis extent of curves in this band.
-    float crossMin = std::numeric_limits<float>::max();
-    float crossMax = std::numeric_limits<float>::lowest();
     for (size_t ci : indices) {
-      const auto& curve = allCurves[ci];
-      outCurves.push_back(curve.curve);
-      crossMin = std::min(crossMin, byY ? curve.range.xMin : curve.range.yMin);
-      crossMax = std::max(crossMax, byY ? curve.range.xMax : curve.range.yMax);
-    }
-
-    if (byY) {
-      band.yMin = stripLo;
-      band.yMax = stripHi;
-      band.xMin = crossMin;
-      band.xMax = crossMax;
-    } else {
-      band.xMin = stripLo;
-      band.xMax = stripHi;
-      band.yMin = crossMin;
-      band.yMax = crossMax;
+      outCurveIndices.push_back(static_cast<uint32_t>(ci));
     }
     outBands.push_back(band);
+  }
+
+  const BandMetrics metrics = evaluateBandCount(allCurves, bounds, axis, bandCount);
+  outStats.canonicalCurveCount = static_cast<uint32_t>(allCurves.size());
+  outStats.curveReferenceCount = static_cast<uint32_t>(outCurveIndices.size());
+  outStats.gridBandCount = bandCount;
+  outStats.nonemptyBandCount = static_cast<uint32_t>(outBands.size());
+  outStats.maxCurvesPerBand = metrics.maxCurves;
+  outStats.p95CurvesPerBand = metrics.p95Curves;
+  if (!outBands.empty()) {
+    outStats.meanCurvesPerBand =
+        static_cast<double>(outCurveIndices.size()) / static_cast<double>(outBands.size());
   }
 }
 
@@ -396,6 +395,9 @@ EncodedPath GeodePathEncoder::encode(const Path& path, FillRule /*fillRule*/, do
     return result;
   }
   result.pathBounds = bounds;
+  result.stats.aabbArea = bounds.width() * bounds.height();
+  result.stats.boundingGeometryArea = result.stats.aabbArea;
+  result.stats.boundingGeometryVertexCount = 4u;
 
   const float pathHeight = static_cast<float>(bounds.height());
   const float pathWidth = static_cast<float>(bounds.width());
@@ -404,14 +406,16 @@ EncodedPath GeodePathEncoder::encode(const Path& path, FillRule /*fillRule*/, do
   }
 
   // Horizontal bands (Y-monotonic curves) for the horizontal ray.
-  const std::vector<CurveWithRange> hCurves =
-      omitRayParallelCurves(extractCurves(monoPathY), BandAxis::Y);
+  const std::vector<CurveWithRange> hAll = extractCurves(monoPathY);
+  const std::vector<CurveWithRange> hCurves = omitRayParallelCurves(hAll, BandAxis::Y);
+  result.stats.horizontal.omittedParallelCurves =
+      static_cast<uint32_t>(hAll.size() - hCurves.size());
   if (hCurves.empty()) {
     return result;
   }
   const uint16_t hBandCount = chooseBandCount(hCurves, bounds, BandAxis::Y);
-  bandCurves(hCurves, bounds, BandAxis::Y, result.bands, result.curves, hBandCount,
-             result.hBandGrid);
+  bandCurves(hCurves, bounds, BandAxis::Y, result.bands, result.curves, result.curveIndices,
+             hBandCount, result.hBandGrid, result.stats.horizontal);
   if (result.bands.empty()) {
     return result;
   }
@@ -424,12 +428,14 @@ EncodedPath GeodePathEncoder::encode(const Path& path, FillRule /*fillRule*/, do
   // horizontal ray alone covers them.
   if (!NearZero(pathWidth)) {
     const Path monoPathX = quadPath.toMonotonic(Path::MonotonicAxis::X);
-    const std::vector<CurveWithRange> vAll =
-        omitRayParallelCurves(extractCurves(monoPathX), BandAxis::X);
+    const std::vector<CurveWithRange> vExtracted = extractCurves(monoPathX);
+    const std::vector<CurveWithRange> vAll = omitRayParallelCurves(vExtracted, BandAxis::X);
+    result.stats.vertical.omittedParallelCurves =
+        static_cast<uint32_t>(vExtracted.size() - vAll.size());
     if (!vAll.empty()) {
       const uint16_t vBandCount = chooseBandCount(vAll, bounds, BandAxis::X);
-      bandCurves(vAll, bounds, BandAxis::X, result.vBands, result.vCurves, vBandCount,
-                 result.vBandGrid);
+      bandCurves(vAll, bounds, BandAxis::X, result.vBands, result.vCurves, result.vCurveIndices,
+                 vBandCount, result.vBandGrid, result.stats.vertical);
       result.xBase = static_cast<float>(bounds.topLeft.x);
       result.vStride = pathWidth / static_cast<float>(vBandCount);
       result.vBandCount = vBandCount;

--- a/donner/svg/renderer/geode/GeodePathEncoder.h
+++ b/donner/svg/renderer/geode/GeodePathEncoder.h
@@ -23,9 +23,9 @@ namespace donner::geode {
  * filled path. It is produced by GeodePathEncoder::encode() and consumed by the GPU pipeline.
  *
  * The data is organized as:
- * - **Curves**: Quadratic Bézier control points (3 × Vector2f per curve), packed contiguously.
- * - **Bands**: Horizontal slices through the path. Each band references a contiguous range of
- *   curves and has a bounding quad for rasterization.
+ * - **Curves**: Canonical quadratic Bézier control points (3 × Vector2f per curve).
+ * - **Curve references**: Compact per-band indexes into the canonical curve arrays.
+ * - **Bands**: Compact offset/count pairs into the curve-reference arrays.
  * - **quadVertices**: A single bounding quad over the whole path (6 vertices = 2 triangles),
  *   with position, outward normal, and band index attributes for the vertex shader.
  */
@@ -37,23 +37,33 @@ struct EncodedPath {
     float p2x, p2y;  ///< End point.
   };
 
-  /// Metadata for one horizontal band.
-  ///
-  /// Layout matches the WGSL `Band` struct in shaders/slug_fill.wgsl exactly
-  /// (8 × 4 bytes = 32 bytes per band). Two trailing pad fields are required
-  /// because storage buffer struct stride must be 16-byte aligned, and
-  /// without them WGSL would round the struct to 32 bytes anyway.
+  /// Compact metadata for one band. Layout matches the WGSL `Band` struct exactly.
   struct Band {
-    uint32_t curveStart;  ///< Index of the first curve in this band's curve range.
-    uint32_t curveCount;  ///< Number of curves intersecting this band.
-    float yMin;           ///< Bottom edge of the band (in path space).
-    float yMax;           ///< Top edge of the band (in path space).
-    float xMin;           ///< Left extent of curves in this band.
-    float xMax;           ///< Right extent of curves in this band.
-    float _pad0;          ///< Padding to match WGSL stride.
-    float _pad1;          ///< Padding to match WGSL stride.
+    uint32_t curveStart;  ///< First entry in the axis's curve-reference array.
+    uint32_t curveCount;  ///< Number of curve references in the band.
   };
-  static_assert(sizeof(Band) == 32, "Band struct must match WGSL layout");
+  static_assert(sizeof(Band) == 8, "Band struct must match WGSL layout");
+
+  /// Per-axis encode statistics retained with the path for diagnostics and perf tests.
+  struct AxisStats {
+    uint32_t canonicalCurveCount = 0;    ///< Curves stored exactly once for this ray.
+    uint32_t curveReferenceCount = 0;    ///< Total indexes across all bands.
+    uint32_t omittedParallelCurves = 0;  ///< Curves proven parallel to this ray.
+    uint32_t gridBandCount = 0;          ///< Dense band-grid cells.
+    uint32_t nonemptyBandCount = 0;      ///< Packed nonempty band records.
+    uint32_t maxCurvesPerBand = 0;       ///< Worst packed-band reference count.
+    uint32_t p95CurvesPerBand = 0;       ///< 95th percentile nonempty-band count.
+    double meanCurvesPerBand = 0.0;      ///< Mean references per nonempty band.
+  };
+
+  /// Output-neutral instrumentation for the CPU encoding result.
+  struct EncodingStats {
+    AxisStats horizontal;
+    AxisStats vertical;
+    double aabbArea = 0.0;
+    double boundingGeometryArea = 0.0;
+    uint32_t boundingGeometryVertexCount = 0;
+  };
 
   /// Vertex for the path bounding quad (input to the Slug vertex shader).
   struct Vertex {
@@ -62,9 +72,10 @@ struct EncodedPath {
     uint32_t bandIndex;      ///< Which band this vertex belongs to (unused by the dual-ray fill).
   };
 
-  std::vector<Curve> curves;  ///< Horizontal (Y-monotonic) curves, sorted by band.
-  std::vector<Band> bands;    ///< Horizontal band metadata (Y-strips), for the horizontal ray.
-  Box2d pathBounds;           ///< Axis-aligned bounding box of the path.
+  std::vector<Curve> curves;           ///< Canonical horizontal (Y-monotonic) curves.
+  std::vector<uint32_t> curveIndices;  ///< Per-band references into `curves`.
+  std::vector<Band> bands;  ///< Horizontal band metadata (Y-strips), for the horizontal ray.
+  Box2d pathBounds;         ///< Axis-aligned bounding box of the path.
 
   /// Single bounding quad (6 verts) over the whole path, for the analytic dual-ray fill
   /// shader (0041 §8.1). One quad per path means each pixel is rasterized by exactly one
@@ -74,12 +85,11 @@ struct EncodedPath {
   std::vector<Vertex> quadVertices;
 
   /// Vertical (X-monotonic) curve + band data, for the Slug **vertical ray** used by the
-  /// dual-ray analytic coverage. These mirror `curves`/`bands`
-  /// but are split at X-extrema and binned into vertical (X-strip) bands. For a vertical
-  /// `Band` the field semantics are transposed: `xMin`/`xMax` are the band's X-strip
-  /// boundaries and `yMin`/`yMax` are the Y-extent of the curves in the band.
-  std::vector<Curve> vCurves;  ///< X-monotonic curves, sorted by vertical band.
-  std::vector<Band> vBands;    ///< Vertical band metadata (X-strips), for the vertical ray.
+  /// dual-ray analytic coverage. These mirror `curves`/`bands`, but are split at X-extrema and
+  /// binned into vertical (X-strip) bands.
+  std::vector<Curve> vCurves;           ///< Canonical X-monotonic curves.
+  std::vector<uint32_t> vCurveIndices;  ///< Per-band references into `vCurves`.
+  std::vector<Band> vBands;  ///< Vertical band metadata (X-strips), for the vertical ray.
 
   /// Sentinel for a grid cell with no band (no curves overlap that strip).
   static constexpr uint32_t kNoBand = 0xFFFFFFFFu;
@@ -99,6 +109,8 @@ struct EncodedPath {
   float xBase = 0.0f;               ///< Left edge of the vertical band grid (path space).
   float vStride = 0.0f;             ///< Width of each vertical band cell (path space).
   uint32_t vBandCount = 0;          ///< Number of vertical band cells.
+
+  EncodingStats stats;  ///< Encode diagnostics; does not affect rendering.
 
   /// Returns true if the encoded path has no bands (empty or degenerate path).
   bool empty() const { return bands.empty(); }

--- a/donner/svg/renderer/geode/GeodePipeline.cc
+++ b/donner/svg/renderer/geode/GeodePipeline.cc
@@ -8,7 +8,7 @@ namespace donner::geode {
 GeodePipeline::GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat colorFormat)
     : colorFormat_(colorFormat) {
   // ----- Bind group layout -----
-  // Eight bindings: uniforms, bands SSBO, curves SSBO, pattern texture,
+  // Fourteen bindings: uniforms, bands SSBO, curves SSBO, pattern texture,
   // pattern sampler, clip-mask texture, clip-mask sampler, and
   // (Milestone 6 Bullet 2) per-instance transforms SSBO. The pattern
   // texture/sampler are only sampled when paintMode == "pattern" and
@@ -19,7 +19,7 @@ GeodePipeline::GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat col
   // identity buffer (`GeodeDevice::identityInstanceTransformBuffer`)
   // for single-draw fills, a full per-instance array for
   // `fillPathInstanced`.
-  wgpu::BindGroupLayoutEntry entries[12] = {};
+  wgpu::BindGroupLayoutEntry entries[14] = {};
 
   entries[0].binding = 0;
   entries[0].visibility = wgpu::ShaderStage::Vertex | wgpu::ShaderStage::Fragment;
@@ -64,7 +64,8 @@ GeodePipeline::GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat col
   entries[7].buffer.minBindingSize = 0;
 
   // Analytic dual-ray fill (0041 §8): vertical bands SSBO, vertical curves
-  // SSBO, horizontal band grid, vertical band grid. All fragment-read-only.
+  // SSBO, horizontal band grid, vertical band grid, and compact references
+  // into each canonical curve array. All fragment-read-only.
   entries[8].binding = 8;
   entries[8].visibility = wgpu::ShaderStage::Fragment;
   entries[8].buffer.type = wgpu::BufferBindingType::ReadOnlyStorage;
@@ -85,9 +86,16 @@ GeodePipeline::GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat col
   entries[11].buffer.type = wgpu::BufferBindingType::ReadOnlyStorage;
   entries[11].buffer.minBindingSize = 0;
 
+  for (int i = 12; i <= 13; ++i) {
+    entries[i].binding = static_cast<uint32_t>(i);
+    entries[i].visibility = wgpu::ShaderStage::Fragment;
+    entries[i].buffer.type = wgpu::BufferBindingType::ReadOnlyStorage;
+    entries[i].buffer.minBindingSize = 0;
+  }
+
   wgpu::BindGroupLayoutDescriptor bglDesc = {};
   bglDesc.label = wgpuLabel("GeodeSlugFillBGL");
-  bglDesc.entryCount = 12;
+  bglDesc.entryCount = 14;
   bglDesc.entries = entries;
   bindGroupLayout_.reset(device.createBindGroupLayout(bglDesc));
 
@@ -172,12 +180,12 @@ GeodePipeline::GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat col
 GeodeGradientPipeline::GeodeGradientPipeline(const wgpu::Device& device,
                                              wgpu::TextureFormat colorFormat)
     : colorFormat_(colorFormat) {
-  // Nine bindings - uniforms, H bands SSBO, H curves SSBO, clip-mask texture,
+  // Eleven bindings - uniforms, H bands SSBO, H curves SSBO, clip-mask texture,
   // clip-mask sampler, and (analytic dual-ray, 0041 §8) V bands SSBO, V curves
   // SSBO, H band grid, V band grid. The clip-mask bindings always carry
   // something valid; when `hasClipMask == 0` a 1x1 dummy texture is bound and
   // the shader skips the sample work.
-  wgpu::BindGroupLayoutEntry entries[9] = {};
+  wgpu::BindGroupLayoutEntry entries[11] = {};
 
   entries[0].binding = 0;
   entries[0].visibility = wgpu::ShaderStage::Vertex | wgpu::ShaderStage::Fragment;
@@ -206,7 +214,7 @@ GeodeGradientPipeline::GeodeGradientPipeline(const wgpu::Device& device,
   entries[4].sampler.type = wgpu::SamplerBindingType::Filtering;
 
   // Analytic dual-ray (0041 §8): vertical bands/curves + dense band grids.
-  for (int i = 5; i <= 8; ++i) {
+  for (int i = 5; i <= 10; ++i) {
     entries[i].binding = static_cast<uint32_t>(i);
     entries[i].visibility = wgpu::ShaderStage::Fragment;
     entries[i].buffer.type = wgpu::BufferBindingType::ReadOnlyStorage;
@@ -215,7 +223,7 @@ GeodeGradientPipeline::GeodeGradientPipeline(const wgpu::Device& device,
 
   wgpu::BindGroupLayoutDescriptor bglDesc = {};
   bglDesc.label = wgpuLabel("GeodeSlugGradientBGL");
-  bglDesc.entryCount = 9;
+  bglDesc.entryCount = 11;
   bglDesc.entries = entries;
   bindGroupLayout_.reset(device.createBindGroupLayout(bglDesc));
 
@@ -291,11 +299,11 @@ GeodeGradientPipeline::GeodeGradientPipeline(const wgpu::Device& device,
 // ============================================================================
 
 GeodeMaskPipeline::GeodeMaskPipeline(const wgpu::Device& device) {
-  // Nine bindings - uniforms, H bands SSBO, H curves SSBO, nested clip mask
+  // Eleven bindings - uniforms, H bands SSBO, H curves SSBO, nested clip mask
   // texture, nested clip mask sampler, and (analytic dual-ray, 0041 §8) V bands
   // SSBO, V curves SSBO, H band grid, V band grid. The clip-mask slot is always
   // bound; a 1x1 dummy is used when `uniforms.hasClipMask == 0`.
-  wgpu::BindGroupLayoutEntry entries[9] = {};
+  wgpu::BindGroupLayoutEntry entries[11] = {};
 
   entries[0].binding = 0;
   entries[0].visibility = wgpu::ShaderStage::Vertex | wgpu::ShaderStage::Fragment;
@@ -323,7 +331,7 @@ GeodeMaskPipeline::GeodeMaskPipeline(const wgpu::Device& device) {
   entries[4].sampler.type = wgpu::SamplerBindingType::Filtering;
 
   // Analytic dual-ray (0041 §8): vertical bands/curves + dense band grids.
-  for (int i = 5; i <= 8; ++i) {
+  for (int i = 5; i <= 10; ++i) {
     entries[i].binding = static_cast<uint32_t>(i);
     entries[i].visibility = wgpu::ShaderStage::Fragment;
     entries[i].buffer.type = wgpu::BufferBindingType::ReadOnlyStorage;
@@ -332,7 +340,7 @@ GeodeMaskPipeline::GeodeMaskPipeline(const wgpu::Device& device) {
 
   wgpu::BindGroupLayoutDescriptor bglDesc = {};
   bglDesc.label = wgpuLabel("GeodeSlugMaskBGL");
-  bglDesc.entryCount = 9;
+  bglDesc.entryCount = 11;
   bglDesc.entries = entries;
   bindGroupLayout_.reset(device.createBindGroupLayout(bglDesc));
 

--- a/donner/svg/renderer/geode/GeodePipeline.h
+++ b/donner/svg/renderer/geode/GeodePipeline.h
@@ -24,6 +24,12 @@ namespace donner::geode {
  * - binding 3: pattern tile texture (2D, Float sampleType) - sampled only
  *   when paintMode == 1. A 1x1 dummy texture is bound in solid-fill draws.
  * - binding 4: pattern sampler (Filtering) - paired with binding 3.
+ * - binding 5: nested clip-mask texture.
+ * - binding 6: nested clip-mask sampler.
+ * - binding 7: per-instance transforms.
+ * - bindings 8 and 9: vertical Band[] and canonical curve data.
+ * - bindings 10 and 11: horizontal and vertical dense band grids.
+ * - bindings 12 and 13: horizontal and vertical curve-reference indexes.
  *
  * The vertex buffer layout is:
  * - location 0: vec2f position (offset 0)
@@ -119,6 +125,9 @@ private:
  * - binding 0: uniform buffer (mvp, viewport, fillRule).
  * - binding 1: storage buffer (read-only) - Band[].
  * - binding 2: storage buffer (read-only) - curve data (flat f32[]).
+ * - bindings 5 and 6: vertical Band[] and canonical curve data.
+ * - bindings 7 and 8: horizontal and vertical dense band grids.
+ * - bindings 9 and 10: horizontal and vertical curve-reference indexes.
  *
  * No texture / sampler bindings - the mask pipeline doesn't read from
  * any texture input. Multiple paths belonging to a single clip layer

--- a/donner/svg/renderer/geode/GeodeResidentPathComponent.h
+++ b/donner/svg/renderer/geode/GeodeResidentPathComponent.h
@@ -34,7 +34,7 @@ namespace donner::geode {
 
 /// GPU-resident geometry for one cached `EncodedPath` (a fill slot or a
 /// stroke slot). Owns a single combined-usage GPU buffer that holds the
-/// path's vertex quad, the six analytic dual-ray SSBO regions, and the
+/// path's vertex quad, the eight analytic dual-ray SSBO regions, and the
 /// per-draw uniform block, plus the cached fill bind group. The buffer
 /// and bind group are built once by `GeoEncoder` on first residence and
 /// reused every subsequent unchanged frame.
@@ -44,10 +44,11 @@ namespace donner::geode {
 struct GeodeResidentSlot {
   /// Combined Vertex|Storage|Uniform|CopyDst buffer. Layout (each region
   /// offset satisfies the binding's alignment requirement):
-  ///   [ vertex quad | bands | curves | vBands | vCurves | hGrid | vGrid | uniform ]
+  ///   [ vertex quad | bands | curves | hRefs | vBands | vCurves | vRefs |
+  ///     hGrid | vGrid | uniform ]
   ScopedWgpuHandle<wgpu::Buffer> buffer;
 
-  /// Cached fill bind group. All twelve bindings reference stable
+  /// Cached fill bind group. All fourteen bindings reference stable
   /// objects (this slot's `buffer` sub-ranges + device-owned dummy
   /// texture/sampler/identity-instance handles), so it survives frames
   /// and encoders. Rebuilt only when the geometry buffer is
@@ -66,8 +67,10 @@ struct GeodeResidentSlot {
   Region vertex;   ///< Vertex quad range (4-byte aligned offset).
   Region bands;    ///< Horizontal band SSBO (binding 1).
   Region curves;   ///< Horizontal curve SSBO (binding 2).
+  Region hRefs;    ///< Horizontal curve-reference SSBO (binding 12).
   Region vBands;   ///< Vertical band SSBO (binding 8).
   Region vCurves;  ///< Vertical curve SSBO (binding 9).
+  Region vRefs;    ///< Vertical curve-reference SSBO (binding 13).
   Region hGrid;    ///< Horizontal band grid (binding 10).
   Region vGrid;    ///< Vertical band grid (binding 11).
   Region uniform;  ///< Per-draw uniform block (binding 0, 256-aligned).
@@ -134,8 +137,10 @@ struct GeodeResidentSlot {
       vertex = other.vertex;
       bands = other.bands;
       curves = other.curves;
+      hRefs = other.hRefs;
       vBands = other.vBands;
       vCurves = other.vCurves;
+      vRefs = other.vRefs;
       hGrid = other.hGrid;
       vGrid = other.vGrid;
       uniform = other.uniform;

--- a/donner/svg/renderer/geode/shaders/slug_fill.wgsl
+++ b/donner/svg/renderer/geode/shaders/slug_fill.wgsl
@@ -74,19 +74,10 @@ struct Uniforms {
 // Storage buffers
 // ============================================================================
 
-// Per-band metadata. With the dense-grid lookup the band's strip extents come
-// from the grid params, so only (curveStart, curveCount) are meaningful; the
-// remaining fields are retained for layout compatibility with the encoder's
-// `EncodedPath::Band` (32 bytes).
+// Compact per-band offset/count into the axis's curve-reference array.
 struct Band {
   curveStart: u32,
   curveCount: u32,
-  yMin: f32,
-  yMax: f32,
-  xMin: f32,
-  xMax: f32,
-  _pad0: f32,
-  _pad1: f32,
 };
 
 // Horizontal bands + curves (for the horizontal ray).
@@ -115,6 +106,8 @@ struct InstanceTransform {
 @group(0) @binding(9) var<storage, read> vCurveData: array<f32>;
 @group(0) @binding(10) var<storage, read> hBandGrid: array<u32>;
 @group(0) @binding(11) var<storage, read> vBandGrid: array<u32>;
+@group(0) @binding(12) var<storage, read> hCurveIndices: array<u32>;
+@group(0) @binding(13) var<storage, read> vCurveIndices: array<u32>;
 
 // Sentinel for an empty grid cell (must match EncodedPath::kNoBand).
 const kNoBand: u32 = 0xFFFFFFFFu;
@@ -278,7 +271,7 @@ fn accumulateHoriz(slot: u32, sample: vec2f, ppemX: f32) -> RayCoverage {
   }
   let band = bands[slot];
   for (var i = 0u; i < band.curveCount; i = i + 1u) {
-    let curve = load_h_curve(band.curveStart + i);
+    let curve = load_h_curve(hCurveIndices[band.curveStart + i]);
     let curve_max_x = max(curve.p0.x, max(curve.p1.x, curve.p2.x));
     if ((curve_max_x - sample.x) * ppemX <= -0.5) {
       break;
@@ -320,7 +313,7 @@ fn accumulateVert(slot: u32, sample: vec2f, ppemY: f32) -> RayCoverage {
   }
   let band = vBands[slot];
   for (var i = 0u; i < band.curveCount; i = i + 1u) {
-    let curve = load_v_curve(band.curveStart + i);
+    let curve = load_v_curve(vCurveIndices[band.curveStart + i]);
     let curve_max_y = max(curve.p0.y, max(curve.p1.y, curve.p2.y));
     if ((curve_max_y - sample.y) * ppemY <= -0.5) {
       break;

--- a/donner/svg/renderer/geode/shaders/slug_gradient.wgsl
+++ b/donner/svg/renderer/geode/shaders/slug_gradient.wgsl
@@ -54,12 +54,6 @@ struct GradientUniforms {
 struct Band {
   curveStart: u32,
   curveCount: u32,
-  yMin: f32,
-  yMax: f32,
-  xMin: f32,
-  xMax: f32,
-  _pad0: f32,
-  _pad1: f32,
 };
 
 @group(0) @binding(1) var<storage, read> bands: array<Band>;
@@ -71,6 +65,8 @@ struct Band {
 @group(0) @binding(6) var<storage, read> vCurveData: array<f32>;
 @group(0) @binding(7) var<storage, read> hBandGrid: array<u32>;
 @group(0) @binding(8) var<storage, read> vBandGrid: array<u32>;
+@group(0) @binding(9) var<storage, read> hCurveIndices: array<u32>;
+@group(0) @binding(10) var<storage, read> vCurveIndices: array<u32>;
 
 const kNoBand: u32 = 0xFFFFFFFFu;
 
@@ -197,7 +193,7 @@ fn accumulateHoriz(slot: u32, sample: vec2f, ppemX: f32) -> RayCoverage {
   }
   let band = bands[slot];
   for (var i = 0u; i < band.curveCount; i = i + 1u) {
-    let curve = load_h_curve(band.curveStart + i);
+    let curve = load_h_curve(hCurveIndices[band.curveStart + i]);
     let curve_max_x = max(curve.p0.x, max(curve.p1.x, curve.p2.x));
     if ((curve_max_x - sample.x) * ppemX <= -0.5) {
       break;
@@ -237,7 +233,7 @@ fn accumulateVert(slot: u32, sample: vec2f, ppemY: f32) -> RayCoverage {
   }
   let band = vBands[slot];
   for (var i = 0u; i < band.curveCount; i = i + 1u) {
-    let curve = load_v_curve(band.curveStart + i);
+    let curve = load_v_curve(vCurveIndices[band.curveStart + i]);
     let curve_max_y = max(curve.p0.y, max(curve.p1.y, curve.p2.y));
     if ((curve_max_y - sample.y) * ppemY <= -0.5) {
       break;

--- a/donner/svg/renderer/geode/shaders/slug_mask.wgsl
+++ b/donner/svg/renderer/geode/shaders/slug_mask.wgsl
@@ -35,12 +35,6 @@ struct Uniforms {
 struct Band {
   curveStart: u32,
   curveCount: u32,
-  yMin: f32,
-  yMax: f32,
-  xMin: f32,
-  xMax: f32,
-  _pad0: f32,
-  _pad1: f32,
 };
 
 @group(0) @binding(1) var<storage, read> bands: array<Band>;
@@ -51,6 +45,8 @@ struct Band {
 @group(0) @binding(6) var<storage, read> vCurveData: array<f32>;
 @group(0) @binding(7) var<storage, read> hBandGrid: array<u32>;
 @group(0) @binding(8) var<storage, read> vBandGrid: array<u32>;
+@group(0) @binding(9) var<storage, read> hCurveIndices: array<u32>;
+@group(0) @binding(10) var<storage, read> vCurveIndices: array<u32>;
 
 const kNoBand: u32 = 0xFFFFFFFFu;
 
@@ -177,7 +173,7 @@ fn accumulateHoriz(slot: u32, sample: vec2f, ppemX: f32) -> RayCoverage {
   }
   let band = bands[slot];
   for (var i = 0u; i < band.curveCount; i = i + 1u) {
-    let curve = load_h_curve(band.curveStart + i);
+    let curve = load_h_curve(hCurveIndices[band.curveStart + i]);
     let curve_max_x = max(curve.p0.x, max(curve.p1.x, curve.p2.x));
     if ((curve_max_x - sample.x) * ppemX <= -0.5) {
       break;
@@ -217,7 +213,7 @@ fn accumulateVert(slot: u32, sample: vec2f, ppemY: f32) -> RayCoverage {
   }
   let band = vBands[slot];
   for (var i = 0u; i < band.curveCount; i = i + 1u) {
-    let curve = load_v_curve(band.curveStart + i);
+    let curve = load_v_curve(vCurveIndices[band.curveStart + i]);
     let curve_max_y = max(curve.p0.y, max(curve.p1.y, curve.p2.y));
     if ((curve_max_y - sample.y) * ppemY <= -0.5) {
       break;

--- a/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
@@ -184,6 +184,22 @@ TEST_F(GeoEncoderTest, FillRect) {
   EXPECT_THAT(corner, RgbaEq(0, 0, 0, 255)) << "Corner should be clear black";
 }
 
+TEST_F(GeoEncoderTest, ArenaGrowthKeepsEarlierGridBinding) {
+  PathBuilder builder;
+  for (int i = 0; i < 8500; ++i) {
+    builder.addRect(Box2d({31, 31}, {33, 33}));
+  }
+  const Path path = builder.build();
+
+  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+  encoder.clear(css::RGBA(0, 0, 0, 255));
+  encoder.fillPath(path, css::RGBA(255, 0, 0, 255), FillRule::NonZero);
+  encoder.finish();
+
+  const auto pixels = readback();
+  EXPECT_THAT(pixelAt(pixels, 32, 32), RgbaEq(255, 0, 0, 255));
+}
+
 /// Fill a triangle. Verify center inside, far corners outside.
 TEST_F(GeoEncoderTest, FillTriangle) {
   Path path = PathBuilder()

--- a/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
@@ -46,17 +46,20 @@ TEST(GeodePathEncoder, EncodeTimingProbe) {
     const auto start = std::chrono::steady_clock::now();
     const EncodedPath iterEncoded = GeodePathEncoder::encode(path, FillRule::NonZero);
     const auto end = std::chrono::steady_clock::now();
-    sink += iterEncoded.curves.size() + iterEncoded.quadVertices.size();
+    sink += iterEncoded.curves.size() + iterEncoded.curveIndices.size() +
+            iterEncoded.vCurves.size() + iterEncoded.vCurveIndices.size() +
+            iterEncoded.quadVertices.size();
     samplesUs.push_back(std::chrono::duration<double, std::micro>(end - start).count());
   }
   std::sort(samplesUs.begin(), samplesUs.end());
   const EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
   std::fprintf(stderr,
                "[GeodePathEncoder] EncodeTimingProbe median=%.1fus p90=%.1fus (bands=%zu "
-               "vBands=%zu curves=%zu vCurves=%zu sink=%zu)\n",
+               "vBands=%zu curves=%zu refs=%zu vCurves=%zu vRefs=%zu sink=%zu)\n",
                samplesUs[samplesUs.size() / 2], samplesUs[(samplesUs.size() * 9) / 10],
                encoded.bands.size(), encoded.vBands.size(), encoded.curves.size(),
-               encoded.vCurves.size(), sink);
+               encoded.curveIndices.size(), encoded.vCurves.size(), encoded.vCurveIndices.size(),
+               sink);
   EXPECT_FALSE(encoded.empty());
 }
 
@@ -148,7 +151,9 @@ TEST(GeodePathEncoder, SortsBandCurvesByDescendingCrossAxisMaximum) {
   for (const EncodedPath::Band& band : encoded.bands) {
     float previousMax = std::numeric_limits<float>::infinity();
     for (uint32_t i = 0; i < band.curveCount; ++i) {
-      const EncodedPath::Curve& curve = encoded.curves[band.curveStart + i];
+      const uint32_t curveIndex = encoded.curveIndices[band.curveStart + i];
+      ASSERT_LT(curveIndex, encoded.curves.size());
+      const EncodedPath::Curve& curve = encoded.curves[curveIndex];
       const float curveMax = std::max({curve.p0x, curve.p1x, curve.p2x});
       EXPECT_LE(curveMax, previousMax) << "Horizontal band references must be descending";
       previousMax = curveMax;
@@ -157,7 +162,9 @@ TEST(GeodePathEncoder, SortsBandCurvesByDescendingCrossAxisMaximum) {
   for (const EncodedPath::Band& band : encoded.vBands) {
     float previousMax = std::numeric_limits<float>::infinity();
     for (uint32_t i = 0; i < band.curveCount; ++i) {
-      const EncodedPath::Curve& curve = encoded.vCurves[band.curveStart + i];
+      const uint32_t curveIndex = encoded.vCurveIndices[band.curveStart + i];
+      ASSERT_LT(curveIndex, encoded.vCurves.size());
+      const EncodedPath::Curve& curve = encoded.vCurves[curveIndex];
       const float curveMax = std::max({curve.p0y, curve.p1y, curve.p2y});
       EXPECT_LE(curveMax, previousMax) << "Vertical band references must be descending";
       previousMax = curveMax;
@@ -184,11 +191,9 @@ TEST(GeodePathEncoder, BandsCoverFullHeight) {
   EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
   EXPECT_FALSE(encoded.empty());
 
-  // First band should start at or before the path's top.
-  EXPECT_LE(encoded.bands.front().yMin, encoded.pathBounds.topLeft.y + 0.01f);
-
-  // Last band should end at or after the path's bottom.
-  EXPECT_GE(encoded.bands.back().yMax, encoded.pathBounds.bottomRight.y - 0.01f);
+  EXPECT_NEAR(encoded.yBase, encoded.pathBounds.topLeft.y, 0.01f);
+  EXPECT_NEAR(encoded.yBase + encoded.hStride * static_cast<float>(encoded.hBandCount),
+              encoded.pathBounds.bottomRight.y, 0.01f);
 }
 
 TEST(GeodePathEncoder, CurvesPerBandNonEmpty) {
@@ -203,8 +208,8 @@ TEST(GeodePathEncoder, CurvesPerBandNonEmpty) {
 
   for (const auto& band : encoded.bands) {
     EXPECT_GT(band.curveCount, 0u) << "Non-empty band should have curves";
-    EXPECT_LE(band.curveStart + band.curveCount, encoded.curves.size())
-        << "Curve range should be within bounds";
+    EXPECT_LE(band.curveStart + band.curveCount, encoded.curveIndices.size())
+        << "Curve-reference range should be within bounds";
   }
 }
 
@@ -345,9 +350,10 @@ TEST(GeodePathEncoder, VerticalBandsConsistentWinding) {
   EXPECT_FALSE(encoded.vBands.empty()) << "Vertical bands must be populated for the vertical ray";
   EXPECT_FALSE(encoded.vCurves.empty());
 
-  // Vertical bands partition the bounds width.
-  EXPECT_LE(encoded.vBands.front().xMin, encoded.pathBounds.topLeft.x + 0.01);
-  EXPECT_GE(encoded.vBands.back().xMax, encoded.pathBounds.bottomRight.x - 0.01);
+  // The vertical grid partitions the bounds width.
+  EXPECT_NEAR(encoded.xBase, encoded.pathBounds.topLeft.x, 0.01);
+  EXPECT_NEAR(encoded.xBase + encoded.vStride * static_cast<float>(encoded.vBandCount),
+              encoded.pathBounds.bottomRight.x, 0.01);
 
   // Sample a grid over the bounding box; the two rays must agree on inside/outside.
   const auto& b = encoded.pathBounds;
@@ -412,9 +418,8 @@ TEST(GeodePathEncoder, BandGridResolvesToCoveringBand) {
       continue;
     }
     ASSERT_LT(slot, encoded.bands.size());
-    const float expectedYMin = encoded.yBase + static_cast<float>(cell) * encoded.hStride;
-    EXPECT_NEAR(encoded.bands[slot].yMin, expectedYMin, 0.01f)
-        << "Grid cell " << cell << " should map to the band covering its Y-strip";
+    EXPECT_LE(encoded.bands[slot].curveStart + encoded.bands[slot].curveCount,
+              encoded.curveIndices.size());
   }
   for (uint32_t cell = 0; cell < encoded.vBandCount; ++cell) {
     const uint32_t slot = encoded.vBandGrid[cell];
@@ -422,8 +427,8 @@ TEST(GeodePathEncoder, BandGridResolvesToCoveringBand) {
       continue;
     }
     ASSERT_LT(slot, encoded.vBands.size());
-    const float expectedXMin = encoded.xBase + static_cast<float>(cell) * encoded.vStride;
-    EXPECT_NEAR(encoded.vBands[slot].xMin, expectedXMin, 0.01f);
+    EXPECT_LE(encoded.vBands[slot].curveStart + encoded.vBands[slot].curveCount,
+              encoded.vCurveIndices.size());
   }
 }
 
@@ -440,10 +445,7 @@ TEST(GeodePathEncoder, BandGridResolvesToCoveringBand) {
 //
 // Strategy: compare the encoded output of an open path against the same
 // path with an explicit closePath(). They should produce identical band
-// curve counts and identical bounds. `encoded.curves` is band-flattened
-// (each curve is duplicated per band it spans), so an equality assertion
-// on the size implicitly verifies the total number of source segments
-// and their band coverage matches.
+// curve counts, reference counts, and identical bounds.
 TEST(GeodePathEncoder, OpenSubpathGetsImplicitClose) {
   // Triangle as three LineTos with no closePath() vs. the same with
   // closePath(). The implicit-close logic in the encoder should make
@@ -464,6 +466,7 @@ TEST(GeodePathEncoder, OpenSubpathGetsImplicitClose) {
   EXPECT_FALSE(openEncoded.empty());
   EXPECT_FALSE(closedEncoded.empty());
   EXPECT_EQ(openEncoded.curves.size(), closedEncoded.curves.size());
+  EXPECT_EQ(openEncoded.curveIndices.size(), closedEncoded.curveIndices.size());
   EXPECT_EQ(openEncoded.bands.size(), closedEncoded.bands.size());
 
   // A straight line (the geometry resvg's `a-stroke-linecap-001` feeds to
@@ -475,7 +478,7 @@ TEST(GeodePathEncoder, OpenSubpathGetsImplicitClose) {
   EXPECT_FALSE(encoded.empty());
   // There must be an even number of forward+return segments per band
   // (one LineTo forward, one implicit close back). `curves.size()` is
-  // band-flattened, so for an N-band span we expect 2*N band curves.
+  // stored canonically, so the forward and return segments form a pair.
   EXPECT_EQ(encoded.curves.size() % 2u, 0u);
 }
 
@@ -509,6 +512,26 @@ TEST(GeodePathEncoder, MultipleOpenSubpathsEachGetClosed) {
   EncodedPath openEncoded = GeodePathEncoder::encode(twoLinesOpen, FillRule::NonZero);
   EncodedPath closedEncoded = GeodePathEncoder::encode(twoLinesClosed, FillRule::NonZero);
   EXPECT_EQ(openEncoded.curves.size(), closedEncoded.curves.size());
+  EXPECT_EQ(openEncoded.curveIndices.size(), closedEncoded.curveIndices.size());
+}
+
+TEST(GeodePathEncoder, RecordsOutputNeutralEncodingStatistics) {
+  PathBuilder builder;
+  builder.addRect(Box2d({0, 0}, {100, 10}));
+  builder.addRect(Box2d({0, 20}, {100, 30}));
+  const EncodedPath encoded = GeodePathEncoder::encode(builder.build(), FillRule::NonZero);
+  ASSERT_FALSE(encoded.empty());
+
+  EXPECT_EQ(encoded.stats.horizontal.canonicalCurveCount, encoded.curves.size());
+  EXPECT_EQ(encoded.stats.horizontal.curveReferenceCount, encoded.curveIndices.size());
+  EXPECT_EQ(encoded.stats.horizontal.gridBandCount, encoded.hBandCount);
+  EXPECT_EQ(encoded.stats.horizontal.nonemptyBandCount, encoded.bands.size());
+  EXPECT_GT(encoded.stats.horizontal.omittedParallelCurves, 0u);
+  EXPECT_GT(encoded.stats.horizontal.maxCurvesPerBand, 0u);
+  EXPECT_GT(encoded.stats.horizontal.p95CurvesPerBand, 0u);
+  EXPECT_GT(encoded.stats.horizontal.meanCurvesPerBand, 0.0);
+  EXPECT_DOUBLE_EQ(encoded.stats.aabbArea,
+                   encoded.pathBounds.width() * encoded.pathBounds.height());
 }
 
 TEST(GeodePathEncoder, RayParallelAxisLeavesFiniteEmptyBandMetadata) {

--- a/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
@@ -7,6 +7,8 @@
 #include <cmath>
 #include <cstdio>
 #include <limits>
+#include <set>
+#include <tuple>
 #include <vector>
 
 #include "donner/base/FillRule.h"
@@ -183,6 +185,32 @@ TEST(GeodePathEncoder, ChoosesBandCountFromCurveDistribution) {
   ASSERT_FALSE(encoded.empty());
   EXPECT_GT(encoded.hBandCount, 1u)
       << "A compact path with many separated curve clusters needs more than one band";
+}
+
+TEST(GeodePathEncoder, StoresEachCurveOnceInsteadOfDuplicatingItAcrossBands) {
+  const Path path = PathBuilder()
+                        .moveTo(Vector2d(0, 0))
+                        .lineTo(Vector2d(100, 500))
+                        .lineTo(Vector2d(200, 0))
+                        .closePath()
+                        .build();
+
+  const EncodedPath encoded = GeodePathEncoder::encode(path, FillRule::NonZero);
+  ASSERT_FALSE(encoded.empty());
+
+  std::set<std::tuple<float, float, float, float, float, float>> uniqueHorizontal;
+  for (const EncodedPath::Curve& curve : encoded.curves) {
+    uniqueHorizontal.emplace(curve.p0x, curve.p0y, curve.p1x, curve.p1y, curve.p2x, curve.p2y);
+  }
+  EXPECT_EQ(encoded.curves.size(), uniqueHorizontal.size())
+      << "Horizontal bands must reference one canonical copy of each curve";
+
+  std::set<std::tuple<float, float, float, float, float, float>> uniqueVertical;
+  for (const EncodedPath::Curve& curve : encoded.vCurves) {
+    uniqueVertical.emplace(curve.p0x, curve.p0y, curve.p1x, curve.p1y, curve.p2x, curve.p2y);
+  }
+  EXPECT_EQ(encoded.vCurves.size(), uniqueVertical.size())
+      << "Vertical bands must reference one canonical copy of each curve";
 }
 
 TEST(GeodePathEncoder, BandsCoverFullHeight) {

--- a/tools/gpu_inventory/manifests/shader_features.json
+++ b/tools/gpu_inventory/manifests/shader_features.json
@@ -1413,6 +1413,20 @@
           "group": 0,
           "name": "vBandGrid",
           "type": "array<u32>"
+        },
+        {
+          "addressSpace": "storage, read",
+          "binding": 12,
+          "group": 0,
+          "name": "hCurveIndices",
+          "type": "array<u32>"
+        },
+        {
+          "addressSpace": "storage, read",
+          "binding": 13,
+          "group": 0,
+          "name": "vCurveIndices",
+          "type": "array<u32>"
         }
       ],
       "builtins": [
@@ -1533,6 +1547,20 @@
           "group": 0,
           "name": "vBandGrid",
           "type": "array<u32>"
+        },
+        {
+          "addressSpace": "storage, read",
+          "binding": 9,
+          "group": 0,
+          "name": "hCurveIndices",
+          "type": "array<u32>"
+        },
+        {
+          "addressSpace": "storage, read",
+          "binding": 10,
+          "group": 0,
+          "name": "vCurveIndices",
+          "type": "array<u32>"
         }
       ],
       "builtins": [
@@ -1649,6 +1677,20 @@
           "binding": 8,
           "group": 0,
           "name": "vBandGrid",
+          "type": "array<u32>"
+        },
+        {
+          "addressSpace": "storage, read",
+          "binding": 9,
+          "group": 0,
+          "name": "hCurveIndices",
+          "type": "array<u32>"
+        },
+        {
+          "addressSpace": "storage, read",
+          "binding": 10,
+          "group": 0,
+          "name": "vCurveIndices",
           "type": "array<u32>"
         }
       ],

--- a/tools/gpu_inventory/manifests_integrity_tests.py
+++ b/tools/gpu_inventory/manifests_integrity_tests.py
@@ -60,7 +60,12 @@ class ShaderFeaturesManifestTest(unittest.TestCase):
         shader = self.manifest["shaders"]["donner/svg/renderer/geode/shaders/slug_fill.wgsl"]
         stages = sorted(e["stage"] for e in shader["entryPoints"])
         self.assertEqual(stages, ["fragment", "vertex"])
-        self.assertEqual(len(shader["bindings"]), 12)
+        self.assertEqual(len(shader["bindings"]), 14)
+        bindings = {entry["binding"]: entry["name"] for entry in shader["bindings"]}
+        self.assertEqual(
+            {binding: bindings[binding] for binding in (12, 13)},
+            {12: "hCurveIndices", 13: "vCurveIndices"},
+        )
 
     def test_every_shader_has_an_entry_point(self):
         for name, shader in self.manifest["shaders"].items():


### PR DESCRIPTION
This is the third of four dependency-ordered Geode optimization changes. It stores each Geode curve once and lets bands reference canonical curve arrays through compact indexes.

## Changes

- replaces per-band curve duplication with canonical horizontal and vertical curve arrays
- adds compact `uint32_t` reference buffers and updates resident resources, bind groups, and shaders
- preserves sorted traversal and dense band-grid lookup semantics
- keeps arena allocation handles stable across growth and adds reference-storage regression coverage

## Validation

- Exact layer head: focused encoder, shader, resident-resource, performance, debug-overlay, embed, renderer, golden, and 16-shard resvg suites passed, 13 of 13 targets
- Exact cumulative stack head: repository-wide Geode configuration passed 868 tests with 8 declared platform skips using the deterministic software Vulkan adapter
- Exact editor goldens remain unchanged in this layer

## Security review

Buffer counts, indexes, and ranges are covered by encoder and shader-facing tests. The layer adds no external interfaces, dependencies, persistence, or privileges. Cumulative secret and publication-scope scans are clean.

Stack: 3 of 4. Depends on the ray traversal and band-selection PR; the final PR tightens raster bounds.
