### PR TITLE
gpu: resource lifetime and submission model (design 0053 packet 3)

### DIFF
--- a/donner/gpu/BUILD.bazel
+++ b/donner/gpu/BUILD.bazel
@@ -4,10 +4,11 @@ load("//build_defs:package.bzl", "donner_package")
 
 # donner::gpu - the Donner-owned GPU runtime (design doc 0053).
 #
-# Packet 2 of the design's change sequence: typed immutable descriptors, explicit Result/Status
-# errors, move-only generation-checked handles, fail-closed validation shared by every backend,
-# and the deterministic recording backend. Platform backends and the shader IR land in later
-# packets; production rendering stays on the existing Geode path until then.
+# Packets 2 and 3 of the design's change sequence: typed immutable descriptors, explicit
+# Result/Status errors, move-only RAII generation-checked handles, deferred destruction by
+# submission serial, submit-time re-validation of recorded commands, fail-closed validation
+# shared by every backend, and the deterministic recording backend. Production rendering stays
+# on the existing Geode path until the migration packets.
 
 donner_cc_library(
     name = "gpu",
@@ -46,6 +47,7 @@ donner_cc_test(
         "tests/HandleLifetime_tests.cc",
         "tests/Handles_tests.cc",
         "tests/RecordingDevice_tests.cc",
+        "tests/ResourceLifetime_tests.cc",
     ],
     deps = [
         ":gpu",

--- a/donner/gpu/CommandEncoder.cc
+++ b/donner/gpu/CommandEncoder.cc
@@ -94,7 +94,7 @@ Result<RenderPassEncoder*> CommandEncoder::beginRenderPass(const RenderPassDescr
   Extent2d passExtent;
   std::vector<TextureFormat> attachmentFormats;
   attachmentFormats.reserve(descriptor.colorAttachments.size());
-  std::vector<Device::ResourceIdentity> seenViews;
+  std::vector<ResourceIdentity> seenViews;
   seenViews.reserve(descriptor.colorAttachments.size());
   for (size_t i = 0; i < descriptor.colorAttachments.size(); ++i) {
     const RenderPassColorAttachment& attachment = descriptor.colorAttachments[i];
@@ -104,9 +104,8 @@ Result<RenderPassEncoder*> CommandEncoder::beginRenderPass(const RenderPassDescr
       return fail(std::move(viewRecord).error()).error();
     }
 
-    const Device::ResourceIdentity viewIdentity{attachment.view.slotIndex(),
-                                                attachment.view.generation()};
-    for (const Device::ResourceIdentity& seenView : seenViews) {
+    const ResourceIdentity viewIdentity{attachment.view.slotIndex(), attachment.view.generation()};
+    for (const ResourceIdentity& seenView : seenViews) {
       if (seenView == viewIdentity) {
         return fail(Err(GpuErrorType::InvalidDescriptor,
                         std::format("beginRenderPass: attachment {} view \"{}\" appears in "
@@ -210,7 +209,8 @@ Status CommandEncoder::passSetPipeline(const RenderPipeline& pipeline) {
 
   currentPipeline_ = BoundPipeline{record.result()->descriptor.vertex.buffers,
                                    record.result()->bindGroupLayoutIds};
-  commands_.push_back(SetPipelineCommand{pipeline.slotIndex()});
+  commands_.push_back(
+      SetPipelineCommand{ResourceIdentity{pipeline.slotIndex(), pipeline.generation()}});
   return OkStatus();
 }
 
@@ -260,7 +260,8 @@ Status CommandEncoder::passSetBindGroup(uint32_t index, const BindGroup& bindGro
   }
 
   boundBindGroups_[index] = BoundBindGroup{bindGroup.slotIndex(), record.result()->layoutIdentity};
-  commands_.push_back(SetBindGroupCommand{index, bindGroup.slotIndex()});
+  commands_.push_back(
+      SetBindGroupCommand{index, ResourceIdentity{bindGroup.slotIndex(), bindGroup.generation()}});
   return OkStatus();
 }
 
@@ -292,7 +293,8 @@ Status CommandEncoder::passSetVertexBuffer(uint32_t slot, const Buffer& buffer,
 
   boundVertexBuffers_[slot] =
       BoundVertexBuffer{buffer.slotIndex(), record.result()->descriptor.byteSize - offsetBytes};
-  commands_.push_back(SetVertexBufferCommand{slot, buffer.slotIndex(), offsetBytes});
+  commands_.push_back(SetVertexBufferCommand{
+      slot, ResourceIdentity{buffer.slotIndex(), buffer.generation()}, offsetBytes});
   return OkStatus();
 }
 
@@ -451,7 +453,9 @@ Status CommandEncoder::copyTextureToBuffer(const TexelCopyTextureInfo& source,
   }
 
   commands_.push_back(CopyTextureToBufferCommand{
-      source.texture.slotIndex(), destination.slotIndex(), destinationLayout, copySize});
+      ResourceIdentity{source.texture.slotIndex(), source.texture.generation()},
+      ResourceIdentity{destination.slotIndex(), destination.generation()}, destinationLayout,
+      copySize});
   return OkStatus();
 }
 

--- a/donner/gpu/CommandEncoder.cc
+++ b/donner/gpu/CommandEncoder.cc
@@ -228,9 +228,19 @@ Status CommandEncoder::passSetBindGroup(uint32_t index, const BindGroup& bindGro
     return fail(std::move(record).error());
   }
 
-  // Re-resolve every resource the group references: a buffer, texture view (and its texture),
-  // or sampler destroyed after createBindGroup - including slot reuse - must fail closed here
-  // instead of reaching a backend.
+  // Re-resolve everything the group references: the layout it was created against (backends
+  // read it at encode time) plus every entry buffer, texture view (and its texture), and
+  // sampler. A dependency destroyed after createBindGroup - including slot reuse - must fail
+  // closed here instead of reaching a backend.
+  const Device::BindGroupLayoutRecord* layoutRecord = device_->bindGroupLayouts_.find(
+      record.result()->layoutIdentity.slotIndex, record.result()->layoutIdentity.generation);
+  if (layoutRecord == nullptr) {
+    return fail(Err(GpuErrorType::InvalidHandle,
+                    std::format("setBindGroup: bind group \"{}\" is stale; the layout it was "
+                                "created against was destroyed (layout slot {})",
+                                record.result()->descriptor.label.str(),
+                                record.result()->layoutIdentity.slotIndex)));
+  }
   for (const BindGroupEntry& entry : record.result()->descriptor.entries) {
     if (const BufferBinding* bufferBinding = std::get_if<BufferBinding>(&entry.resource)) {
       auto bufferRecord =

--- a/donner/gpu/CommandEncoder.cc
+++ b/donner/gpu/CommandEncoder.cc
@@ -242,36 +242,43 @@ Status CommandEncoder::passSetBindGroup(uint32_t index, const BindGroup& bindGro
                                 record.result()->layoutIdentity.slotIndex)));
   }
   for (const BindGroupEntry& entry : record.result()->descriptor.entries) {
-    if (const BufferBinding* bufferBinding = std::get_if<BufferBinding>(&entry.resource)) {
-      auto bufferRecord =
-          device_->resolve(device_->buffers_, bufferBinding->buffer, BufferTag::kName);
-      if (bufferRecord.hasError()) {
-        return fail(std::move(bufferRecord).error());
-      }
-    } else if (const TextureViewBinding* viewBinding =
-                   std::get_if<TextureViewBinding>(&entry.resource)) {
-      auto viewRecord =
-          device_->resolve(device_->textureViews_, viewBinding->view, TextureViewTag::kName);
-      if (viewRecord.hasError()) {
-        return fail(std::move(viewRecord).error());
-      }
-      auto viewedTexture = device_->resolveViewedTexture(*viewRecord.result());
-      if (viewedTexture.hasError()) {
-        return fail(std::move(viewedTexture).error());
-      }
-    } else if (const SamplerBinding* samplerBinding =
-                   std::get_if<SamplerBinding>(&entry.resource)) {
-      auto samplerRecord =
-          device_->resolve(device_->samplers_, samplerBinding->sampler, SamplerTag::kName);
-      if (samplerRecord.hasError()) {
-        return fail(std::move(samplerRecord).error());
-      }
+    const Status entryStatus = revalidateBindGroupEntry(entry);
+    if (entryStatus.hasError()) {
+      return entryStatus;
     }
   }
 
   boundBindGroups_[index] = BoundBindGroup{bindGroup.slotIndex(), record.result()->layoutIdentity};
   commands_.push_back(
       SetBindGroupCommand{index, ResourceIdentity{bindGroup.slotIndex(), bindGroup.generation()}});
+  return OkStatus();
+}
+
+Status CommandEncoder::revalidateBindGroupEntry(const BindGroupEntry& entry) {
+  if (const BufferBinding* bufferBinding = std::get_if<BufferBinding>(&entry.resource)) {
+    auto bufferRecord =
+        device_->resolve(device_->buffers_, bufferBinding->buffer, BufferTag::kName);
+    if (bufferRecord.hasError()) {
+      return fail(std::move(bufferRecord).error());
+    }
+  } else if (const TextureViewBinding* viewBinding =
+                 std::get_if<TextureViewBinding>(&entry.resource)) {
+    auto viewRecord =
+        device_->resolve(device_->textureViews_, viewBinding->view, TextureViewTag::kName);
+    if (viewRecord.hasError()) {
+      return fail(std::move(viewRecord).error());
+    }
+    auto viewedTexture = device_->resolveViewedTexture(*viewRecord.result());
+    if (viewedTexture.hasError()) {
+      return fail(std::move(viewedTexture).error());
+    }
+  } else if (const SamplerBinding* samplerBinding = std::get_if<SamplerBinding>(&entry.resource)) {
+    auto samplerRecord =
+        device_->resolve(device_->samplers_, samplerBinding->sampler, SamplerTag::kName);
+    if (samplerRecord.hasError()) {
+      return fail(std::move(samplerRecord).error());
+    }
+  }
   return OkStatus();
 }
 

--- a/donner/gpu/CommandEncoder.h
+++ b/donner/gpu/CommandEncoder.h
@@ -114,10 +114,8 @@ private:
  * error. Obtain encoders via `Device::createCommandEncoder`; the encoder must not outlive its
  * device.
  *
- * Known gap: destroying a resource that a recorded-but-unsubmitted command buffer references is
- * not yet validated; commands are checked at recording time only. Deferred-destruction
- * validation arrives with the resource-lifetime and submission packet (design 0053 change
- * sequence step 3).
+ * Commands record full (slot, generation) resource identities, and `Device::submit` re-validates
+ * every one, so destroying a resource between recording and submission fails closed at submit.
  */
 class CommandEncoder {
 public:
@@ -171,8 +169,8 @@ private:
 
   /// Draw-time validation state for the active pipeline.
   struct BoundPipeline {
-    std::vector<VertexBufferLayout> vertexBuffers;             //!< Declared vertex layouts.
-    std::vector<Device::ResourceIdentity> bindGroupLayoutIds;  //!< Required group layouts.
+    std::vector<VertexBufferLayout> vertexBuffers;     //!< Declared vertex layouts.
+    std::vector<ResourceIdentity> bindGroupLayoutIds;  //!< Required group layouts.
   };
   /// Draw-time validation state for one bound vertex buffer slot.
   struct BoundVertexBuffer {
@@ -181,8 +179,8 @@ private:
   };
   /// Draw-time validation state for one bound bind group index.
   struct BoundBindGroup {
-    uint32_t bindGroupSlot = 0;               //!< Bind group slot index.
-    Device::ResourceIdentity layoutIdentity;  //!< Layout the group was created against.
+    uint32_t bindGroupSlot = 0;       //!< Bind group slot index.
+    ResourceIdentity layoutIdentity;  //!< Layout the group was created against.
   };
 
   /// Latches \p error (first error wins, poisoning the encoder) and returns the latched error.

--- a/donner/gpu/CommandEncoder.h
+++ b/donner/gpu/CommandEncoder.h
@@ -191,6 +191,11 @@ private:
   /// @param requireActivePass True for render pass operations.
   std::optional<GpuError> checkRecordable(bool requireActivePass);
 
+  /// Re-resolves the resource one bind group entry references, failing closed when it was
+  /// destroyed after the group was created.
+  /// @param entry Entry to re-resolve.
+  Status revalidateBindGroupEntry(const BindGroupEntry& entry);
+
   // RenderPassEncoder forwards to these.
   Status passSetPipeline(const RenderPipeline& pipeline);
   Status passSetBindGroup(uint32_t index, const BindGroup& bindGroup);

--- a/donner/gpu/Commands.h
+++ b/donner/gpu/Commands.h
@@ -2,39 +2,43 @@
 /// @file
 /// Validated command value types recorded by \c donner::gpu::CommandEncoder.
 ///
-/// Commands store only validated Donner value objects and slot-based resource identifiers, never
+/// Commands store only validated Donner value objects and slot-based resource identities, never
 /// raw pointers or native handles (design 0053 "Command model"), so recorded streams serialize
-/// deterministically and contain no process state.
+/// deterministically and contain no process state. Each referenced resource is stored as a
+/// \ref ResourceIdentity (slot plus generation): `Device::submit` re-validates every identity, so
+/// a resource destroyed between recording and submission fails closed instead of reaching a
+/// backend.
 
 #include <cstdint>
 #include <variant>
 
 #include "donner/gpu/Descriptors.h"
+#include "donner/gpu/Handles.h"
 
 namespace donner::gpu {
 
 /// Recorded `beginRenderPass`. Attachment references inside the descriptor are validated before
-/// recording.
+/// recording and re-validated at submission.
 struct BeginRenderPassCommand {
   RenderPassDescriptor descriptor;  //!< Validated pass descriptor.
 };
 
 /// Recorded `setPipeline`.
 struct SetPipelineCommand {
-  uint32_t pipelineSlot = 0;  //!< Render pipeline slot index.
+  ResourceIdentity pipelineId;  //!< Render pipeline identity.
 };
 
 /// Recorded `setBindGroup`.
 struct SetBindGroupCommand {
-  uint32_t index = 0;          //!< Bind group index.
-  uint32_t bindGroupSlot = 0;  //!< Bind group slot index.
+  uint32_t index = 0;            //!< Bind group index.
+  ResourceIdentity bindGroupId;  //!< Bind group identity.
 };
 
 /// Recorded `setVertexBuffer`.
 struct SetVertexBufferCommand {
-  uint32_t slot = 0;         //!< Vertex buffer slot index in the pipeline layout.
-  uint32_t bufferSlot = 0;   //!< Buffer slot index.
-  uint64_t offsetBytes = 0;  //!< Byte offset of the first element.
+  uint32_t slot = 0;          //!< Vertex buffer slot index in the pipeline layout.
+  ResourceIdentity bufferId;  //!< Buffer identity.
+  uint64_t offsetBytes = 0;   //!< Byte offset of the first element.
 };
 
 /// Recorded `setScissorRect`.
@@ -68,8 +72,8 @@ struct EndRenderPassCommand {};
 
 /// Recorded `copyTextureToBuffer` (readback staging copy).
 struct CopyTextureToBufferCommand {
-  uint32_t textureSlot = 0;      //!< Source texture slot index.
-  uint32_t bufferSlot = 0;       //!< Destination buffer slot index.
+  ResourceIdentity textureId;    //!< Source texture identity.
+  ResourceIdentity bufferId;     //!< Destination buffer identity.
   TexelCopyBufferLayout layout;  //!< Destination row layout.
   Extent2d copySize;             //!< Copy extent in texels.
 };

--- a/donner/gpu/Device.cc
+++ b/donner/gpu/Device.cc
@@ -966,8 +966,16 @@ Result<std::vector<Device::SubmissionUse>> Device::validateSubmissionResources(
             if (groupRecord.hasError()) {
               return std::move(groupRecord).error();
             }
-            // Re-validate every resource the group references so a destroyed entry resource
-            // fails closed even though the group object itself is alive.
+            // Re-validate everything the group references so a destroyed dependency fails
+            // closed even though the group object itself is alive: the layout the group was
+            // created against (backends read it at encode time) and every entry resource.
+            auto layoutRecord = check(
+                bindGroupLayouts_, groupRecord.result()->layoutIdentity,
+                ResourceKind::BindGroupLayout, BindGroupLayoutTag::kName,
+                std::format("bind group \"{}\"", groupRecord.result()->descriptor.label.str()));
+            if (layoutRecord.hasError()) {
+              return std::move(layoutRecord).error();
+            }
             for (const BindGroupEntry& entry : groupRecord.result()->descriptor.entries) {
               const std::string context =
                   std::format("bind group \"{}\" entry binding {}",

--- a/donner/gpu/Device.cc
+++ b/donner/gpu/Device.cc
@@ -284,26 +284,149 @@ uint64_t Device::NextDeviceId() {
   return counter.fetch_add(1, std::memory_order_relaxed);
 }
 
-Device::Device() : deviceId_(NextDeviceId()) {}
+Device::Device() : deviceId_(NextDeviceId()), aliveToken_(std::make_shared<Device*>(this)) {}
 
-Device::~Device() = default;
+Device::~Device() {
+  // Expire the device-alive token first: handles destroyed after this point release nothing.
+  // Deferred backend releases still pending are dropped with the device - backend destructors
+  // own the teardown of any remaining backend state (waiting for in-flight submissions first
+  // where the backend executes asynchronously).
+  aliveToken_.reset();
+}
 
 template <typename Tag, typename Record>
 Handle<Tag> Device::allocateHandle(details::SlotTable<Record>& table, Record&& record) {
   const uint32_t slotIndex = table.allocate(std::move(record));
-  return Handle<Tag>::CreateForBackend(slotIndex, table.generationOf(slotIndex), deviceId_);
+  return Handle<Tag>::CreateForBackend(slotIndex, table.generationOf(slotIndex), deviceId_,
+                                       aliveToken_);
+}
+
+void Device::recycleRetiredSlot(ResourceKind kind, uint32_t slotIndex) {
+  switch (kind) {
+    case ResourceKind::Buffer:
+      onDestroyResource(BufferTag::kName, slotIndex);
+      buffers_.recycle(slotIndex);
+      return;
+    case ResourceKind::Texture:
+      onDestroyResource(TextureTag::kName, slotIndex);
+      textures_.recycle(slotIndex);
+      return;
+    case ResourceKind::TextureView:
+      onDestroyResource(TextureViewTag::kName, slotIndex);
+      textureViews_.recycle(slotIndex);
+      return;
+    case ResourceKind::Sampler:
+      onDestroyResource(SamplerTag::kName, slotIndex);
+      samplers_.recycle(slotIndex);
+      return;
+    case ResourceKind::BindGroupLayout:
+      onDestroyResource(BindGroupLayoutTag::kName, slotIndex);
+      bindGroupLayouts_.recycle(slotIndex);
+      return;
+    case ResourceKind::BindGroup:
+      onDestroyResource(BindGroupTag::kName, slotIndex);
+      bindGroups_.recycle(slotIndex);
+      return;
+    case ResourceKind::PipelineLayout:
+      onDestroyResource(PipelineLayoutTag::kName, slotIndex);
+      pipelineLayouts_.recycle(slotIndex);
+      return;
+    case ResourceKind::ShaderModule:
+      onDestroyResource(ShaderModuleTag::kName, slotIndex);
+      shaderModules_.recycle(slotIndex);
+      return;
+    case ResourceKind::RenderPipeline:
+      onDestroyResource(RenderPipelineTag::kName, slotIndex);
+      renderPipelines_.recycle(slotIndex);
+      return;
+  }
+}
+
+void Device::retireResource(ResourceKind kind, uint32_t slotIndex, uint64_t lastUseSerial) {
+  if (lastUseSerial <= completedSerial()) {
+    recycleRetiredSlot(kind, slotIndex);
+  } else {
+    pendingDestroys_.push_back(PendingDestroy{lastUseSerial, kind, slotIndex});
+  }
+}
+
+void Device::poll() {
+  const uint64_t completed = completedSerial();
+  size_t writeIndex = 0;
+  for (const PendingDestroy& pending : pendingDestroys_) {
+    if (pending.readySerial <= completed) {
+      recycleRetiredSlot(pending.kind, pending.slotIndex);
+    } else {
+      pendingDestroys_[writeIndex++] = pending;
+    }
+  }
+  pendingDestroys_.resize(writeIndex);
 }
 
 template <typename Record, typename Tag>
-Status Device::destroyResource(details::SlotTable<Record>& table, const Handle<Tag>& handle) {
-  auto resolved = resolve(table, handle, Tag::kName);
+Status Device::destroyResource(details::SlotTable<Record>& table, Handle<Tag>&& handle,
+                               ResourceKind kind) {
+  // Take ownership so the caller's handle is null afterwards. On any early return the local's
+  // RAII release runs: a stale no-op after a successful retire below, an actual release on the
+  // owning device when the handle belongs to a different device.
+  const Handle<Tag> consumed = std::move(handle);
+  poll();
+  auto resolved = resolve(table, consumed, Tag::kName);
   if (resolved.hasError()) {
     return std::move(resolved).error();
   }
-  table.release(handle.slotIndex());
-  onDestroyResource(Tag::kName, handle.slotIndex());
+  const uint32_t slotIndex = consumed.slotIndex();
+  const uint64_t lastUseSerial = table.lastUseOf(slotIndex);
+  table.retire(slotIndex);
+  retireResource(kind, slotIndex, lastUseSerial);
   return OkStatus();
 }
+
+template <typename Record>
+void Device::releaseFromRaii(details::SlotTable<Record>& table, uint32_t slotIndex,
+                             uint32_t generation, ResourceKind kind) {
+  if (table.find(slotIndex, generation) == nullptr) {
+    return;  // Already destroyed explicitly (or consumed); RAII release is a no-op.
+  }
+  const uint64_t lastUseSerial = table.lastUseOf(slotIndex);
+  table.retire(slotIndex);
+  retireResource(kind, slotIndex, lastUseSerial);
+}
+
+namespace details {
+
+/// Defines the RAII release hook for one handle tag.
+#define DONNER_GPU_DEFINE_RAII_RELEASE(TagType, tableMember, kindValue)                           \
+  template <>                                                                                     \
+  void ReleaseHandleFromRaii<TagType>(Device & device, uint32_t slotIndex, uint32_t generation) { \
+    device.releaseFromRaii(device.tableMember, slotIndex, generation,                             \
+                           Device::ResourceKind::kindValue);                                      \
+  }
+
+DONNER_GPU_DEFINE_RAII_RELEASE(BufferTag, buffers_, Buffer)
+DONNER_GPU_DEFINE_RAII_RELEASE(TextureTag, textures_, Texture)
+DONNER_GPU_DEFINE_RAII_RELEASE(TextureViewTag, textureViews_, TextureView)
+DONNER_GPU_DEFINE_RAII_RELEASE(SamplerTag, samplers_, Sampler)
+DONNER_GPU_DEFINE_RAII_RELEASE(BindGroupLayoutTag, bindGroupLayouts_, BindGroupLayout)
+DONNER_GPU_DEFINE_RAII_RELEASE(BindGroupTag, bindGroups_, BindGroup)
+DONNER_GPU_DEFINE_RAII_RELEASE(PipelineLayoutTag, pipelineLayouts_, PipelineLayout)
+DONNER_GPU_DEFINE_RAII_RELEASE(ShaderModuleTag, shaderModules_, ShaderModule)
+DONNER_GPU_DEFINE_RAII_RELEASE(RenderPipelineTag, renderPipelines_, RenderPipeline)
+
+#undef DONNER_GPU_DEFINE_RAII_RELEASE
+
+/// Command buffers have no backend object until submission, so a dropped unsubmitted command
+/// buffer releases its recorded commands immediately with no backend notification.
+template <>
+void ReleaseHandleFromRaii<CommandBufferTag>(Device& device, uint32_t slotIndex,
+                                             uint32_t generation) {
+  if (device.commandBuffers_.find(slotIndex, generation) == nullptr) {
+    return;  // Already submitted (consumed); nothing to release.
+  }
+  device.commandBuffers_.release(slotIndex);
+}
+
+}  // namespace details
 
 Result<Buffer> Device::createBuffer(const BufferDescriptor& descriptor) {
   if (Status status = ValidateBufferDescriptor(descriptor); status.hasError()) {
@@ -642,40 +765,45 @@ Result<RenderPipeline> Device::createRenderPipeline(const RenderPipelineDescript
   return handle;
 }
 
-Status Device::destroyBuffer(const Buffer& buffer) {
-  return destroyResource(buffers_, buffer);
+// Each destroy* consumes the handle: destroyResource retires the identity (so the RAII release
+// of the moved-in parameter is a stale no-op), and on validation failure the dropped parameter's
+// RAII release still runs against the handle's own device, so nothing leaks.
+
+Status Device::destroyBuffer(Buffer&& buffer) {
+  return destroyResource(buffers_, std::move(buffer), ResourceKind::Buffer);
 }
 
-Status Device::destroyTexture(const Texture& texture) {
-  return destroyResource(textures_, texture);
+Status Device::destroyTexture(Texture&& texture) {
+  return destroyResource(textures_, std::move(texture), ResourceKind::Texture);
 }
 
-Status Device::destroyTextureView(const TextureView& textureView) {
-  return destroyResource(textureViews_, textureView);
+Status Device::destroyTextureView(TextureView&& textureView) {
+  return destroyResource(textureViews_, std::move(textureView), ResourceKind::TextureView);
 }
 
-Status Device::destroySampler(const Sampler& sampler) {
-  return destroyResource(samplers_, sampler);
+Status Device::destroySampler(Sampler&& sampler) {
+  return destroyResource(samplers_, std::move(sampler), ResourceKind::Sampler);
 }
 
-Status Device::destroyBindGroupLayout(const BindGroupLayout& bindGroupLayout) {
-  return destroyResource(bindGroupLayouts_, bindGroupLayout);
+Status Device::destroyBindGroupLayout(BindGroupLayout&& bindGroupLayout) {
+  return destroyResource(bindGroupLayouts_, std::move(bindGroupLayout),
+                         ResourceKind::BindGroupLayout);
 }
 
-Status Device::destroyBindGroup(const BindGroup& bindGroup) {
-  return destroyResource(bindGroups_, bindGroup);
+Status Device::destroyBindGroup(BindGroup&& bindGroup) {
+  return destroyResource(bindGroups_, std::move(bindGroup), ResourceKind::BindGroup);
 }
 
-Status Device::destroyPipelineLayout(const PipelineLayout& pipelineLayout) {
-  return destroyResource(pipelineLayouts_, pipelineLayout);
+Status Device::destroyPipelineLayout(PipelineLayout&& pipelineLayout) {
+  return destroyResource(pipelineLayouts_, std::move(pipelineLayout), ResourceKind::PipelineLayout);
 }
 
-Status Device::destroyShaderModule(const ShaderModule& shaderModule) {
-  return destroyResource(shaderModules_, shaderModule);
+Status Device::destroyShaderModule(ShaderModule&& shaderModule) {
+  return destroyResource(shaderModules_, std::move(shaderModule), ResourceKind::ShaderModule);
 }
 
-Status Device::destroyRenderPipeline(const RenderPipeline& renderPipeline) {
-  return destroyResource(renderPipelines_, renderPipeline);
+Status Device::destroyRenderPipeline(RenderPipeline&& renderPipeline) {
+  return destroyResource(renderPipelines_, std::move(renderPipeline), ResourceKind::RenderPipeline);
 }
 
 Result<std::unique_ptr<CommandEncoder>> Device::createCommandEncoder() {
@@ -739,6 +867,8 @@ Status Device::writeTexture(const Texture& texture, std::span<const uint8_t> dat
 }
 
 Result<uint64_t> Device::submit(CommandBuffer commandBuffer) {
+  poll();
+
   auto record = resolve(commandBuffers_, commandBuffer, CommandBufferTag::kName);
   if (record.hasError()) {
     return std::move(record).error();
@@ -750,14 +880,182 @@ Result<uint64_t> Device::submit(CommandBuffer commandBuffer) {
       std::move(commandBuffers_.findMutable(slotIndex, commandBuffer.generation())->commands);
   commandBuffers_.release(slotIndex);
 
+  // Re-validate every recorded resource identity: a resource destroyed between recording and
+  // submission fails closed here, before the backend sees the commands.
+  Result<std::vector<SubmissionUse>> uses = validateSubmissionResources(commands);
+  if (uses.hasError()) {
+    return std::move(uses).error();
+  }
+
   // Advance the serial only after the backend accepts the submission: a failed submit must not
-  // burn a serial, or completion waiters would treat the failed work as finished.
+  // burn a serial, or completion waiters would treat the failed work as finished. Resources are
+  // marked in-use only for accepted submissions for the same reason.
   const uint64_t serial = lastSubmittedSerial_ + 1;
   if (Status status = onSubmit(serial, slotIndex, commands); status.hasError()) {
     return std::move(status).error();
   }
   lastSubmittedSerial_ = serial;
+  markSubmissionUses(uses.result(), serial);
   return serial;
+}
+
+Result<std::vector<Device::SubmissionUse>> Device::validateSubmissionResources(
+    std::span<const Command> commands) const {
+  std::vector<SubmissionUse> uses;
+
+  // Resolves one recorded identity against its table, failing closed when it is stale.
+  const auto check = [&uses]<typename Record>(const details::SlotTable<Record>& table,
+                                              const ResourceIdentity& identity, ResourceKind kind,
+                                              std::string_view resourceName,
+                                              std::string_view context) -> Result<const Record*> {
+    const Record* record = table.find(identity.slotIndex, identity.generation);
+    if (record == nullptr) {
+      return GpuError{GpuErrorType::InvalidHandle,
+                      std::format("submit: {} references destroyed {} (slot {})", context,
+                                  resourceName, identity.slotIndex)};
+    }
+    uses.push_back(SubmissionUse{kind, identity.slotIndex});
+    return record;
+  };
+
+  // Resolves a texture view plus the texture behind it (a view of a destroyed texture must fail
+  // even if the view itself is alive).
+  const auto checkViewAndTexture = [this, &check](const ResourceIdentity& viewIdentity,
+                                                  std::string_view context) -> Status {
+    auto viewRecord = check(textureViews_, viewIdentity, ResourceKind::TextureView,
+                            TextureViewTag::kName, context);
+    if (viewRecord.hasError()) {
+      return std::move(viewRecord).error();
+    }
+    auto textureRecord = check(textures_, viewRecord.result()->textureIdentity,
+                               ResourceKind::Texture, TextureTag::kName, context);
+    if (textureRecord.hasError()) {
+      return std::move(textureRecord).error();
+    }
+    return OkStatus();
+  };
+
+  for (const Command& command : commands) {
+    Status status = std::visit(
+        [&](const auto& typedCommand) -> Status {
+          using CommandType = std::remove_cvref_t<decltype(typedCommand)>;
+
+          if constexpr (std::is_same_v<CommandType, BeginRenderPassCommand>) {
+            for (const RenderPassColorAttachment& attachment :
+                 typedCommand.descriptor.colorAttachments) {
+              const ResourceIdentity viewIdentity{attachment.view.slotIndex(),
+                                                  attachment.view.generation()};
+              if (Status attachmentStatus =
+                      checkViewAndTexture(viewIdentity, "render pass attachment");
+                  attachmentStatus.hasError()) {
+                return attachmentStatus;
+              }
+            }
+            return OkStatus();
+          } else if constexpr (std::is_same_v<CommandType, SetPipelineCommand>) {
+            auto pipelineRecord =
+                check(renderPipelines_, typedCommand.pipelineId, ResourceKind::RenderPipeline,
+                      RenderPipelineTag::kName, "recorded setPipeline");
+            if (pipelineRecord.hasError()) {
+              return std::move(pipelineRecord).error();
+            }
+            return OkStatus();
+          } else if constexpr (std::is_same_v<CommandType, SetBindGroupCommand>) {
+            auto groupRecord = check(bindGroups_, typedCommand.bindGroupId, ResourceKind::BindGroup,
+                                     BindGroupTag::kName, "recorded setBindGroup");
+            if (groupRecord.hasError()) {
+              return std::move(groupRecord).error();
+            }
+            // Re-validate every resource the group references so a destroyed entry resource
+            // fails closed even though the group object itself is alive.
+            for (const BindGroupEntry& entry : groupRecord.result()->descriptor.entries) {
+              const std::string context =
+                  std::format("bind group \"{}\" entry binding {}",
+                              groupRecord.result()->descriptor.label.str(), entry.binding);
+              if (const BufferBinding* bufferBinding =
+                      std::get_if<BufferBinding>(&entry.resource)) {
+                const ResourceIdentity bufferIdentity{bufferBinding->buffer.slotIndex(),
+                                                      bufferBinding->buffer.generation()};
+                auto bufferRecord = check(buffers_, bufferIdentity, ResourceKind::Buffer,
+                                          BufferTag::kName, context);
+                if (bufferRecord.hasError()) {
+                  return std::move(bufferRecord).error();
+                }
+              } else if (const TextureViewBinding* viewBinding =
+                             std::get_if<TextureViewBinding>(&entry.resource)) {
+                const ResourceIdentity viewIdentity{viewBinding->view.slotIndex(),
+                                                    viewBinding->view.generation()};
+                if (Status entryStatus = checkViewAndTexture(viewIdentity, context);
+                    entryStatus.hasError()) {
+                  return entryStatus;
+                }
+              } else if (const SamplerBinding* samplerBinding =
+                             std::get_if<SamplerBinding>(&entry.resource)) {
+                const ResourceIdentity samplerIdentity{samplerBinding->sampler.slotIndex(),
+                                                       samplerBinding->sampler.generation()};
+                auto samplerRecord = check(samplers_, samplerIdentity, ResourceKind::Sampler,
+                                           SamplerTag::kName, context);
+                if (samplerRecord.hasError()) {
+                  return std::move(samplerRecord).error();
+                }
+              }
+            }
+            return OkStatus();
+          } else if constexpr (std::is_same_v<CommandType, SetVertexBufferCommand>) {
+            auto bufferRecord = check(buffers_, typedCommand.bufferId, ResourceKind::Buffer,
+                                      BufferTag::kName, "recorded setVertexBuffer");
+            if (bufferRecord.hasError()) {
+              return std::move(bufferRecord).error();
+            }
+            return OkStatus();
+          } else if constexpr (std::is_same_v<CommandType, CopyTextureToBufferCommand>) {
+            auto textureRecord = check(textures_, typedCommand.textureId, ResourceKind::Texture,
+                                       TextureTag::kName, "recorded copyTextureToBuffer");
+            if (textureRecord.hasError()) {
+              return std::move(textureRecord).error();
+            }
+            auto bufferRecord = check(buffers_, typedCommand.bufferId, ResourceKind::Buffer,
+                                      BufferTag::kName, "recorded copyTextureToBuffer");
+            if (bufferRecord.hasError()) {
+              return std::move(bufferRecord).error();
+            }
+            return OkStatus();
+          } else {
+            return OkStatus();
+          }
+        },
+        command);
+    if (status.hasError()) {
+      return std::move(status).error();
+    }
+  }
+  return uses;
+}
+
+void Device::markSubmissionUses(std::span<const SubmissionUse> uses, uint64_t submissionSerial) {
+  for (const SubmissionUse& use : uses) {
+    switch (use.kind) {
+      case ResourceKind::Buffer: buffers_.markUsed(use.slotIndex, submissionSerial); break;
+      case ResourceKind::Texture: textures_.markUsed(use.slotIndex, submissionSerial); break;
+      case ResourceKind::TextureView:
+        textureViews_.markUsed(use.slotIndex, submissionSerial);
+        break;
+      case ResourceKind::Sampler: samplers_.markUsed(use.slotIndex, submissionSerial); break;
+      case ResourceKind::BindGroupLayout:
+        bindGroupLayouts_.markUsed(use.slotIndex, submissionSerial);
+        break;
+      case ResourceKind::BindGroup: bindGroups_.markUsed(use.slotIndex, submissionSerial); break;
+      case ResourceKind::PipelineLayout:
+        pipelineLayouts_.markUsed(use.slotIndex, submissionSerial);
+        break;
+      case ResourceKind::ShaderModule:
+        shaderModules_.markUsed(use.slotIndex, submissionSerial);
+        break;
+      case ResourceKind::RenderPipeline:
+        renderPipelines_.markUsed(use.slotIndex, submissionSerial);
+        break;
+    }
+  }
 }
 
 Status Device::validateBufferHandleForBackend(const Buffer& buffer) const {

--- a/donner/gpu/Device.cc
+++ b/donner/gpu/Device.cc
@@ -899,140 +899,154 @@ Result<uint64_t> Device::submit(CommandBuffer commandBuffer) {
   return serial;
 }
 
+template <typename Record>
+Result<const Record*> Device::checkSubmissionResource(const details::SlotTable<Record>& table,
+                                                      const ResourceIdentity& identity,
+                                                      ResourceKind kind,
+                                                      std::string_view resourceName,
+                                                      std::string_view context,
+                                                      std::vector<SubmissionUse>& uses) const {
+  const Record* record = table.find(identity.slotIndex, identity.generation);
+  if (record == nullptr) {
+    return GpuError{GpuErrorType::InvalidHandle,
+                    std::format("submit: {} references destroyed {} (slot {})", context,
+                                resourceName, identity.slotIndex)};
+  }
+  uses.push_back(SubmissionUse{kind, identity.slotIndex});
+  return record;
+}
+
+Status Device::checkSubmissionTextureView(const ResourceIdentity& viewIdentity,
+                                          std::string_view context,
+                                          std::vector<SubmissionUse>& uses) const {
+  auto viewRecord = checkSubmissionResource(textureViews_, viewIdentity, ResourceKind::TextureView,
+                                            TextureViewTag::kName, context, uses);
+  if (viewRecord.hasError()) {
+    return std::move(viewRecord).error();
+  }
+  auto textureRecord =
+      checkSubmissionResource(textures_, viewRecord.result()->textureIdentity,
+                              ResourceKind::Texture, TextureTag::kName, context, uses);
+  if (textureRecord.hasError()) {
+    return std::move(textureRecord).error();
+  }
+  return OkStatus();
+}
+
+Status Device::checkSubmissionRenderPass(const RenderPassDescriptor& descriptor,
+                                         std::vector<SubmissionUse>& uses) const {
+  for (const RenderPassColorAttachment& attachment : descriptor.colorAttachments) {
+    const ResourceIdentity viewIdentity{attachment.view.slotIndex(), attachment.view.generation()};
+    if (Status attachmentStatus =
+            checkSubmissionTextureView(viewIdentity, "render pass attachment", uses);
+        attachmentStatus.hasError()) {
+      return attachmentStatus;
+    }
+  }
+  return OkStatus();
+}
+
+Status Device::checkSubmissionBindGroup(const ResourceIdentity& groupIdentity,
+                                        std::vector<SubmissionUse>& uses) const {
+  auto groupRecord = checkSubmissionResource(bindGroups_, groupIdentity, ResourceKind::BindGroup,
+                                             BindGroupTag::kName, "recorded setBindGroup", uses);
+  if (groupRecord.hasError()) {
+    return std::move(groupRecord).error();
+  }
+  auto layoutRecord = checkSubmissionResource(
+      bindGroupLayouts_, groupRecord.result()->layoutIdentity, ResourceKind::BindGroupLayout,
+      BindGroupLayoutTag::kName,
+      std::format("bind group \"{}\"", groupRecord.result()->descriptor.label.str()), uses);
+  if (layoutRecord.hasError()) {
+    return std::move(layoutRecord).error();
+  }
+  for (const BindGroupEntry& entry : groupRecord.result()->descriptor.entries) {
+    const std::string context =
+        std::format("bind group \"{}\" entry binding {}",
+                    groupRecord.result()->descriptor.label.str(), entry.binding);
+    if (const BufferBinding* bufferBinding = std::get_if<BufferBinding>(&entry.resource)) {
+      const ResourceIdentity bufferIdentity{bufferBinding->buffer.slotIndex(),
+                                            bufferBinding->buffer.generation()};
+      auto bufferRecord = checkSubmissionResource(buffers_, bufferIdentity, ResourceKind::Buffer,
+                                                  BufferTag::kName, context, uses);
+      if (bufferRecord.hasError()) {
+        return std::move(bufferRecord).error();
+      }
+    } else if (const TextureViewBinding* viewBinding =
+                   std::get_if<TextureViewBinding>(&entry.resource)) {
+      const ResourceIdentity viewIdentity{viewBinding->view.slotIndex(),
+                                          viewBinding->view.generation()};
+      if (Status entryStatus = checkSubmissionTextureView(viewIdentity, context, uses);
+          entryStatus.hasError()) {
+        return entryStatus;
+      }
+    } else if (const SamplerBinding* samplerBinding =
+                   std::get_if<SamplerBinding>(&entry.resource)) {
+      const ResourceIdentity samplerIdentity{samplerBinding->sampler.slotIndex(),
+                                             samplerBinding->sampler.generation()};
+      auto samplerRecord = checkSubmissionResource(
+          samplers_, samplerIdentity, ResourceKind::Sampler, SamplerTag::kName, context, uses);
+      if (samplerRecord.hasError()) {
+        return std::move(samplerRecord).error();
+      }
+    }
+  }
+  return OkStatus();
+}
+
+Status Device::checkSubmissionCommand(const Command& command,
+                                      std::vector<SubmissionUse>& uses) const {
+  return std::visit(
+      [&](const auto& typedCommand) -> Status {
+        using CommandType = std::remove_cvref_t<decltype(typedCommand)>;
+
+        if constexpr (std::is_same_v<CommandType, BeginRenderPassCommand>) {
+          return checkSubmissionRenderPass(typedCommand.descriptor, uses);
+        } else if constexpr (std::is_same_v<CommandType, SetPipelineCommand>) {
+          auto pipelineRecord = checkSubmissionResource(
+              renderPipelines_, typedCommand.pipelineId, ResourceKind::RenderPipeline,
+              RenderPipelineTag::kName, "recorded setPipeline", uses);
+          if (pipelineRecord.hasError()) {
+            return std::move(pipelineRecord).error();
+          }
+          return OkStatus();
+        } else if constexpr (std::is_same_v<CommandType, SetBindGroupCommand>) {
+          return checkSubmissionBindGroup(typedCommand.bindGroupId, uses);
+        } else if constexpr (std::is_same_v<CommandType, SetVertexBufferCommand>) {
+          auto bufferRecord =
+              checkSubmissionResource(buffers_, typedCommand.bufferId, ResourceKind::Buffer,
+                                      BufferTag::kName, "recorded setVertexBuffer", uses);
+          if (bufferRecord.hasError()) {
+            return std::move(bufferRecord).error();
+          }
+          return OkStatus();
+        } else if constexpr (std::is_same_v<CommandType, CopyTextureToBufferCommand>) {
+          auto textureRecord =
+              checkSubmissionResource(textures_, typedCommand.textureId, ResourceKind::Texture,
+                                      TextureTag::kName, "recorded copyTextureToBuffer", uses);
+          if (textureRecord.hasError()) {
+            return std::move(textureRecord).error();
+          }
+          auto bufferRecord =
+              checkSubmissionResource(buffers_, typedCommand.bufferId, ResourceKind::Buffer,
+                                      BufferTag::kName, "recorded copyTextureToBuffer", uses);
+          if (bufferRecord.hasError()) {
+            return std::move(bufferRecord).error();
+          }
+          return OkStatus();
+        } else {
+          return OkStatus();
+        }
+      },
+      command);
+}
+
 Result<std::vector<Device::SubmissionUse>> Device::validateSubmissionResources(
     std::span<const Command> commands) const {
   std::vector<SubmissionUse> uses;
 
-  // Resolves one recorded identity against its table, failing closed when it is stale.
-  const auto check = [&uses]<typename Record>(const details::SlotTable<Record>& table,
-                                              const ResourceIdentity& identity, ResourceKind kind,
-                                              std::string_view resourceName,
-                                              std::string_view context) -> Result<const Record*> {
-    const Record* record = table.find(identity.slotIndex, identity.generation);
-    if (record == nullptr) {
-      return GpuError{GpuErrorType::InvalidHandle,
-                      std::format("submit: {} references destroyed {} (slot {})", context,
-                                  resourceName, identity.slotIndex)};
-    }
-    uses.push_back(SubmissionUse{kind, identity.slotIndex});
-    return record;
-  };
-
-  // Resolves a texture view plus the texture behind it (a view of a destroyed texture must fail
-  // even if the view itself is alive).
-  const auto checkViewAndTexture = [this, &check](const ResourceIdentity& viewIdentity,
-                                                  std::string_view context) -> Status {
-    auto viewRecord = check(textureViews_, viewIdentity, ResourceKind::TextureView,
-                            TextureViewTag::kName, context);
-    if (viewRecord.hasError()) {
-      return std::move(viewRecord).error();
-    }
-    auto textureRecord = check(textures_, viewRecord.result()->textureIdentity,
-                               ResourceKind::Texture, TextureTag::kName, context);
-    if (textureRecord.hasError()) {
-      return std::move(textureRecord).error();
-    }
-    return OkStatus();
-  };
-
   for (const Command& command : commands) {
-    Status status = std::visit(
-        [&](const auto& typedCommand) -> Status {
-          using CommandType = std::remove_cvref_t<decltype(typedCommand)>;
-
-          if constexpr (std::is_same_v<CommandType, BeginRenderPassCommand>) {
-            for (const RenderPassColorAttachment& attachment :
-                 typedCommand.descriptor.colorAttachments) {
-              const ResourceIdentity viewIdentity{attachment.view.slotIndex(),
-                                                  attachment.view.generation()};
-              if (Status attachmentStatus =
-                      checkViewAndTexture(viewIdentity, "render pass attachment");
-                  attachmentStatus.hasError()) {
-                return attachmentStatus;
-              }
-            }
-            return OkStatus();
-          } else if constexpr (std::is_same_v<CommandType, SetPipelineCommand>) {
-            auto pipelineRecord =
-                check(renderPipelines_, typedCommand.pipelineId, ResourceKind::RenderPipeline,
-                      RenderPipelineTag::kName, "recorded setPipeline");
-            if (pipelineRecord.hasError()) {
-              return std::move(pipelineRecord).error();
-            }
-            return OkStatus();
-          } else if constexpr (std::is_same_v<CommandType, SetBindGroupCommand>) {
-            auto groupRecord = check(bindGroups_, typedCommand.bindGroupId, ResourceKind::BindGroup,
-                                     BindGroupTag::kName, "recorded setBindGroup");
-            if (groupRecord.hasError()) {
-              return std::move(groupRecord).error();
-            }
-            // Re-validate everything the group references so a destroyed dependency fails
-            // closed even though the group object itself is alive: the layout the group was
-            // created against (backends read it at encode time) and every entry resource.
-            auto layoutRecord = check(
-                bindGroupLayouts_, groupRecord.result()->layoutIdentity,
-                ResourceKind::BindGroupLayout, BindGroupLayoutTag::kName,
-                std::format("bind group \"{}\"", groupRecord.result()->descriptor.label.str()));
-            if (layoutRecord.hasError()) {
-              return std::move(layoutRecord).error();
-            }
-            for (const BindGroupEntry& entry : groupRecord.result()->descriptor.entries) {
-              const std::string context =
-                  std::format("bind group \"{}\" entry binding {}",
-                              groupRecord.result()->descriptor.label.str(), entry.binding);
-              if (const BufferBinding* bufferBinding =
-                      std::get_if<BufferBinding>(&entry.resource)) {
-                const ResourceIdentity bufferIdentity{bufferBinding->buffer.slotIndex(),
-                                                      bufferBinding->buffer.generation()};
-                auto bufferRecord = check(buffers_, bufferIdentity, ResourceKind::Buffer,
-                                          BufferTag::kName, context);
-                if (bufferRecord.hasError()) {
-                  return std::move(bufferRecord).error();
-                }
-              } else if (const TextureViewBinding* viewBinding =
-                             std::get_if<TextureViewBinding>(&entry.resource)) {
-                const ResourceIdentity viewIdentity{viewBinding->view.slotIndex(),
-                                                    viewBinding->view.generation()};
-                if (Status entryStatus = checkViewAndTexture(viewIdentity, context);
-                    entryStatus.hasError()) {
-                  return entryStatus;
-                }
-              } else if (const SamplerBinding* samplerBinding =
-                             std::get_if<SamplerBinding>(&entry.resource)) {
-                const ResourceIdentity samplerIdentity{samplerBinding->sampler.slotIndex(),
-                                                       samplerBinding->sampler.generation()};
-                auto samplerRecord = check(samplers_, samplerIdentity, ResourceKind::Sampler,
-                                           SamplerTag::kName, context);
-                if (samplerRecord.hasError()) {
-                  return std::move(samplerRecord).error();
-                }
-              }
-            }
-            return OkStatus();
-          } else if constexpr (std::is_same_v<CommandType, SetVertexBufferCommand>) {
-            auto bufferRecord = check(buffers_, typedCommand.bufferId, ResourceKind::Buffer,
-                                      BufferTag::kName, "recorded setVertexBuffer");
-            if (bufferRecord.hasError()) {
-              return std::move(bufferRecord).error();
-            }
-            return OkStatus();
-          } else if constexpr (std::is_same_v<CommandType, CopyTextureToBufferCommand>) {
-            auto textureRecord = check(textures_, typedCommand.textureId, ResourceKind::Texture,
-                                       TextureTag::kName, "recorded copyTextureToBuffer");
-            if (textureRecord.hasError()) {
-              return std::move(textureRecord).error();
-            }
-            auto bufferRecord = check(buffers_, typedCommand.bufferId, ResourceKind::Buffer,
-                                      BufferTag::kName, "recorded copyTextureToBuffer");
-            if (bufferRecord.hasError()) {
-              return std::move(bufferRecord).error();
-            }
-            return OkStatus();
-          } else {
-            return OkStatus();
-          }
-        },
-        command);
+    Status status = checkSubmissionCommand(command, uses);
     if (status.hasError()) {
       return std::move(status).error();
     }

--- a/donner/gpu/Device.h
+++ b/donner/gpu/Device.h
@@ -49,7 +49,8 @@ public:
       return slotIndex;
     }
 
-    slots_.push_back(Slot{1, true, 0, std::move(record)});
+    slots_.push_back(
+        Slot{.generation = 1, .alive = true, .lastUseSerial = 0, .record = std::move(record)});
     return static_cast<uint32_t>(slots_.size() - 1);
   }
 
@@ -193,6 +194,12 @@ Result<uint64_t> ValidateTexelCopyInternal(const TexelCopyBufferLayout& layout,
  * but the backend object is kept alive - and its slot is not reused - until every submission
  * referencing it has completed (\ref completedSerial). Deferred backend releases are processed by
  * \ref poll and opportunistically by `destroy*` and \ref submit.
+ *
+ * Two resource kinds are intentionally exempt from submission pinning because commands never
+ * reference them: \ref PipelineLayout and \ref ShaderModule are consumed at pipeline creation
+ * only, so destroying one releases its backend object immediately. Backends must snapshot or
+ * retain whatever they need from them when the pipeline is created (Metal's compiled pipeline
+ * state retains its functions; the Vulkan backend must do the equivalent when it lands).
  *
  * Thread affinity: a Device and everything created from it must be used from one thread at a
  * time, matching the async-renderer worker ownership model.

--- a/donner/gpu/Device.h
+++ b/donner/gpu/Device.h
@@ -44,11 +44,12 @@ public:
       freeList_.pop_back();
       Slot& slot = slots_[slotIndex];
       slot.alive = true;
+      slot.lastUseSerial = 0;
       slot.record = std::move(record);
       return slotIndex;
     }
 
-    slots_.push_back(Slot{1, true, std::move(record)});
+    slots_.push_back(Slot{1, true, 0, std::move(record)});
     return static_cast<uint32_t>(slots_.size() - 1);
   }
 
@@ -88,24 +89,63 @@ public:
   uint32_t generationOf(uint32_t slotIndex) const { return slots_[slotIndex].generation; }
 
   /**
-   * Releases the record at \p slotIndex: marks the slot dead, bumps its generation so remaining
-   * identifiers fail closed, and queues the slot for reuse.
+   * Releases the record at \p slotIndex immediately: \ref retire plus \ref recycle. Used when the
+   * resource was never visible to submissions (creation rollback, command buffer consumption).
    *
    * @param slotIndex Slot index; must refer to an alive slot.
    */
   void release(uint32_t slotIndex) {
+    retire(slotIndex);
+    recycle(slotIndex);
+  }
+
+  /**
+   * Retires the record at \p slotIndex: marks the slot dead and bumps its generation so remaining
+   * identifiers fail closed, but does NOT queue the slot for reuse. The caller must \ref recycle
+   * the slot once the backend object is safe to destroy; until then, no new resource can occupy
+   * the slot, so in-flight backend state cannot be aliased.
+   *
+   * @param slotIndex Slot index; must refer to an alive slot.
+   */
+  void retire(uint32_t slotIndex) {
     Slot& slot = slots_[slotIndex];
     slot.alive = false;
     slot.record.reset();
     ++slot.generation;
-    freeList_.push_back(slotIndex);
   }
+
+  /**
+   * Queues a retired slot for reuse. Called after the backend object is destroyed.
+   *
+   * @param slotIndex Slot index; must refer to a retired slot.
+   */
+  void recycle(uint32_t slotIndex) { freeList_.push_back(slotIndex); }
+
+  /**
+   * Records that the resource at \p slotIndex is referenced by the submission with
+   * \p submissionSerial. Serials increase monotonically, so the stored value is the last use.
+   *
+   * @param slotIndex Slot index; must refer to an alive slot.
+   * @param submissionSerial Serial of the submission referencing the resource.
+   */
+  void markUsed(uint32_t slotIndex, uint64_t submissionSerial) {
+    slots_[slotIndex].lastUseSerial = submissionSerial;
+  }
+
+  /**
+   * Serial of the last submission referencing \p slotIndex (0 if never submitted). Valid for
+   * retired slots too: retiring preserves the last use so deferred destruction can key on it.
+   *
+   * @param slotIndex Slot index; must be in range.
+   */
+  uint64_t lastUseOf(uint32_t slotIndex) const { return slots_[slotIndex].lastUseSerial; }
 
 private:
   /// One slot: generation counter plus the stored record while alive.
   struct Slot {
-    uint32_t generation = 1;       //!< Bumped on release; a handle matches only its generation.
+    uint32_t generation = 1;       //!< Bumped on retire; a handle matches only its generation.
     bool alive = false;            //!< True while the slot holds a live resource.
+    uint64_t lastUseSerial = 0;    //!< Serial of the last submission referencing this slot.
     std::optional<Record> record;  //!< Stored record; empty while dead.
   };
 
@@ -145,16 +185,23 @@ Result<uint64_t> ValidateTexelCopyInternal(const TexelCopyBufferLayout& layout,
  * (\ref GpuErrorType::DeviceMismatch) and slot generation (\ref GpuErrorType::InvalidHandle), so
  * destroyed or foreign handles fail before reaching a backend.
  *
- * Lifetime: resources are freed by explicit `destroy*` calls; device teardown frees everything
- * that remains (handles are not RAII in this packet, see Handles.h). Handles must not be used
- * after their device is destroyed.
+ * Lifetime (design 0053 "Core types and ownership"): handles are move-only RAII - dropping a live
+ * handle releases the resource, an explicit `destroy*(std::move(handle))` call releases it early
+ * and reports errors, and device teardown frees everything that remains. A handle that outlives
+ * its device releases nothing (its device-alive token has expired). Destruction is deferred by
+ * submission serial: destroying a resource makes its handles and references stale immediately,
+ * but the backend object is kept alive - and its slot is not reused - until every submission
+ * referencing it has completed (\ref completedSerial). Deferred backend releases are processed by
+ * \ref poll and opportunistically by `destroy*` and \ref submit.
  *
  * Thread affinity: a Device and everything created from it must be used from one thread at a
  * time, matching the async-renderer worker ownership model.
  */
 class Device {
 public:
-  /// Destructor; frees all remaining resources.
+  /// Destructor; expires the device-alive token (so handles that outlive the device release
+  /// nothing) and frees all remaining resources. Backends that submit asynchronously must wait
+  /// for in-flight submissions in their own destructor before backend state is torn down.
   virtual ~Device();
 
   Device(const Device&) = delete;
@@ -238,33 +285,36 @@ public:
    */
   Result<RenderPipeline> createRenderPipeline(const RenderPipelineDescriptor& descriptor);
 
-  /// Destroys a buffer; the handle and all references to it become stale.
-  /// @param buffer Handle to destroy.
-  Status destroyBuffer(const Buffer& buffer);
-  /// Destroys a texture; the handle and all references to it become stale.
-  /// @param texture Handle to destroy.
-  Status destroyTexture(const Texture& texture);
-  /// Destroys a texture view; the handle and all references to it become stale.
+  // The destroy* methods consume the handle: on success it becomes stale immediately (along with
+  // all references to it) while the backend object is deferred until in-flight submissions
+  // complete; on failure the handle is still consumed, and if it named a live resource of a
+  // DIFFERENT device, that resource is released through RAII on its owning device (the error is
+  // still reported). Either way the caller's handle is null afterwards, so explicit destroy plus
+  // RAII can never double-free.
+
+  /// Destroys a buffer (see the destroy contract above). @param buffer Handle to destroy.
+  Status destroyBuffer(Buffer&& buffer);
+  /// Destroys a texture (see the destroy contract above). @param texture Handle to destroy.
+  Status destroyTexture(Texture&& texture);
+  /// Destroys a texture view (see the destroy contract above).
   /// @param textureView Handle to destroy.
-  Status destroyTextureView(const TextureView& textureView);
-  /// Destroys a sampler; the handle and all references to it become stale.
-  /// @param sampler Handle to destroy.
-  Status destroySampler(const Sampler& sampler);
-  /// Destroys a bind group layout; the handle and all references to it become stale.
+  Status destroyTextureView(TextureView&& textureView);
+  /// Destroys a sampler (see the destroy contract above). @param sampler Handle to destroy.
+  Status destroySampler(Sampler&& sampler);
+  /// Destroys a bind group layout (see the destroy contract above).
   /// @param bindGroupLayout Handle to destroy.
-  Status destroyBindGroupLayout(const BindGroupLayout& bindGroupLayout);
-  /// Destroys a bind group; the handle and all references to it become stale.
-  /// @param bindGroup Handle to destroy.
-  Status destroyBindGroup(const BindGroup& bindGroup);
-  /// Destroys a pipeline layout; the handle and all references to it become stale.
+  Status destroyBindGroupLayout(BindGroupLayout&& bindGroupLayout);
+  /// Destroys a bind group (see the destroy contract above). @param bindGroup Handle to destroy.
+  Status destroyBindGroup(BindGroup&& bindGroup);
+  /// Destroys a pipeline layout (see the destroy contract above).
   /// @param pipelineLayout Handle to destroy.
-  Status destroyPipelineLayout(const PipelineLayout& pipelineLayout);
-  /// Destroys a shader module; the handle and all references to it become stale.
+  Status destroyPipelineLayout(PipelineLayout&& pipelineLayout);
+  /// Destroys a shader module (see the destroy contract above).
   /// @param shaderModule Handle to destroy.
-  Status destroyShaderModule(const ShaderModule& shaderModule);
-  /// Destroys a render pipeline; the handle and all references to it become stale.
+  Status destroyShaderModule(ShaderModule&& shaderModule);
+  /// Destroys a render pipeline (see the destroy contract above).
   /// @param renderPipeline Handle to destroy.
-  Status destroyRenderPipeline(const RenderPipeline& renderPipeline);
+  Status destroyRenderPipeline(RenderPipeline&& renderPipeline);
 
   /// Creates a command encoder recording against this device. The encoder must not outlive the
   /// device.
@@ -296,16 +346,27 @@ public:
 
   /**
    * Submits a finished command buffer, consuming it, and returns the assigned submission serial.
-   * Serials start at 1 and increase by 1 per submission; a submission rejected by the backend
-   * does not consume a serial.
+   * Serials start at 1 and increase by 1 per submission; a submission rejected here or by the
+   * backend does not consume a serial.
    *
-   * Known gap: commands are validated at recording time, so destroying a resource between
-   * recording and submit is not yet detected here. Deferred-destruction validation arrives with
-   * the resource-lifetime and submission packet (design 0053 change sequence step 3).
+   * Every resource a recorded command references - including bind-group entry resources and the
+   * textures behind attachment and entry views - is re-validated against its recorded
+   * (slot, generation) identity, so a resource destroyed between recording and submission fails
+   * closed with \ref GpuErrorType::InvalidHandle instead of reaching a backend. On success those
+   * resources are marked in-use by the new serial, which defers their backend destruction until
+   * the submission completes.
    *
    * @param commandBuffer Command buffer to submit; consumed even on failure.
    */
   Result<uint64_t> submit(CommandBuffer commandBuffer);
+
+  /**
+   * Processes deferred destructions: releases the backend object of every destroyed resource
+   * whose last referencing submission has completed (\ref completedSerial), and recycles its
+   * slot. Called opportunistically by `destroy*` and \ref submit; call it directly after waiting
+   * for completion to reclaim resources promptly.
+   */
+  void poll();
 
   /// Serial assigned to the most recent submission (0 if none yet).
   uint64_t lastSubmittedSerial() const { return lastSubmittedSerial_; }
@@ -397,15 +458,6 @@ private:
   struct TextureRecord {
     TextureDescriptor descriptor;  //!< Creation descriptor.
   };
-  /// Identity of a resource at a point in time: slot plus generation, so slot reuse cannot alias
-  /// two different resources.
-  struct ResourceIdentity {
-    uint32_t slotIndex = 0;   //!< Resource slot index.
-    uint32_t generation = 0;  //!< Slot generation at capture time.
-
-    /// Equality operator. @param other Identity to compare against.
-    bool operator==(const ResourceIdentity& other) const = default;
-  };
   /// Validated per-view state. Consumers re-resolve the viewed texture through
   /// \ref resolveViewedTexture on every use, so a view cannot outlive its texture unnoticed.
   struct TextureViewRecord {
@@ -466,15 +518,82 @@ private:
    */
   Result<const TextureRecord*> resolveViewedTexture(const TextureViewRecord& viewRecord) const;
 
+  /// Resource kinds with deferrable backend destruction, indexing the destroy dispatch in
+  /// \ref recycleRetiredSlot.
+  enum class ResourceKind : uint8_t {
+    Buffer,
+    Texture,
+    TextureView,
+    Sampler,
+    BindGroupLayout,
+    BindGroup,
+    PipelineLayout,
+    ShaderModule,
+    RenderPipeline,
+  };
+
+  /// A destroyed resource whose backend object is awaiting submission completion.
+  struct PendingDestroy {
+    uint64_t readySerial = 0;  //!< Backend destruction is safe once completedSerial() >= this.
+    ResourceKind kind = ResourceKind::Buffer;  //!< Resource kind, for table dispatch.
+    uint32_t slotIndex = 0;                    //!< Retired slot index.
+  };
+
   /// Allocates a slot in \p table and mints a handle carrying this device's identity.
   /// @param table Destination table. @param record Validated record to store.
   template <typename Tag, typename Record>
   Handle<Tag> allocateHandle(details::SlotTable<Record>& table, Record&& record);
 
-  /// Shared implementation of the `destroy*` methods.
+  /// Shared implementation of the `destroy*` methods: consumes the handle, retires the slot
+  /// immediately, and defers the backend release until in-flight submissions complete.
   /// @param table Table for the handle's resource type. @param handle Handle to destroy.
+  /// @param kind Resource kind for deferred dispatch.
   template <typename Record, typename Tag>
-  Status destroyResource(details::SlotTable<Record>& table, const Handle<Tag>& handle);
+  Status destroyResource(details::SlotTable<Record>& table, Handle<Tag>&& handle,
+                         ResourceKind kind);
+
+  /// Releases the backend object of a retired slot and recycles the slot for reuse.
+  /// @param kind Resource kind. @param slotIndex Retired slot index.
+  void recycleRetiredSlot(ResourceKind kind, uint32_t slotIndex);
+
+  /// Retires a resolved resource: defers the backend release if the resource is referenced by an
+  /// incomplete submission, otherwise releases it immediately.
+  /// @param kind Resource kind. @param slotIndex Slot index. @param lastUseSerial Serial of the
+  /// last submission referencing the resource.
+  void retireResource(ResourceKind kind, uint32_t slotIndex, uint64_t lastUseSerial);
+
+  /// RAII destructor path: destroys the resource identified by (\p slotIndex, \p generation) in
+  /// \p table if it is still alive; a silent no-op when the identity is stale.
+  /// @param table Table for the resource type. @param slotIndex Slot index.
+  /// @param generation Generation the handle carried. @param kind Resource kind.
+  template <typename Record>
+  void releaseFromRaii(details::SlotTable<Record>& table, uint32_t slotIndex, uint32_t generation,
+                       ResourceKind kind);
+
+  template <typename Tag>
+  friend void details::ReleaseHandleFromRaii(Device& device, uint32_t slotIndex,
+                                             uint32_t generation);
+
+  /// One resource referenced by a submission, collected during validation and marked in-use
+  /// after the backend accepts the submission.
+  struct SubmissionUse {
+    ResourceKind kind = ResourceKind::Buffer;  //!< Resource kind, for table dispatch.
+    uint32_t slotIndex = 0;                    //!< Resource slot index.
+  };
+
+  /// Validates every resource identity referenced by \p commands - including transitive
+  /// bind-group entry resources and the textures behind attachment and entry views - and returns
+  /// the referenced resources. A destroyed reference fails closed with
+  /// \ref GpuErrorType::InvalidHandle.
+  /// @param commands Recorded commands.
+  Result<std::vector<SubmissionUse>> validateSubmissionResources(
+      std::span<const Command> commands) const;
+
+  /// Marks every collected resource as used by \p submissionSerial, deferring its backend
+  /// destruction until that submission completes.
+  /// @param uses Resources collected by \ref validateSubmissionResources.
+  /// @param submissionSerial Serial assigned to the accepted submission.
+  void markSubmissionUses(std::span<const SubmissionUse> uses, uint64_t submissionSerial);
 
   /// Registers a finished command stream from an encoder and returns its handle.
   /// @param commands Validated commands in recording order.
@@ -485,6 +604,14 @@ private:
 
   uint64_t deviceId_ = 0;
   uint64_t lastSubmittedSerial_ = 0;
+
+  /// Device-alive token shared with every minted handle: `~Device` releases it, so a handle
+  /// destroyed after its device skips the RAII release.
+  std::shared_ptr<Device*> aliveToken_;
+
+  /// Destroyed resources awaiting backend release, in destruction order (drained FIFO by
+  /// \ref poll so backend release order is deterministic).
+  std::vector<PendingDestroy> pendingDestroys_;
 
   details::SlotTable<BufferRecord> buffers_;
   details::SlotTable<TextureRecord> textures_;

--- a/donner/gpu/Device.h
+++ b/donner/gpu/Device.h
@@ -596,6 +596,48 @@ private:
   Result<std::vector<SubmissionUse>> validateSubmissionResources(
       std::span<const Command> commands) const;
 
+  /// Resolves one recorded identity against \p table and records it in \p uses, failing closed
+  /// with \ref GpuErrorType::InvalidHandle when the slot has been destroyed or reused.
+  /// @param table Table owning the resource kind.
+  /// @param identity Recorded slot and generation.
+  /// @param kind Resource kind stored in \p uses for later table dispatch.
+  /// @param resourceName Resource kind name, for the error message.
+  /// @param context Description of what referenced the resource, for the error message.
+  /// @param uses Accumulator of resources referenced by the submission.
+  template <typename Record>
+  Result<const Record*> checkSubmissionResource(const details::SlotTable<Record>& table,
+                                                const ResourceIdentity& identity, ResourceKind kind,
+                                                std::string_view resourceName,
+                                                std::string_view context,
+                                                std::vector<SubmissionUse>& uses) const;
+
+  /// Resolves a recorded texture view plus the texture behind it: a view of a destroyed texture
+  /// must fail even while the view itself is alive.
+  /// @param viewIdentity Recorded view slot and generation.
+  /// @param context Description of what referenced the view, for the error message.
+  /// @param uses Accumulator of resources referenced by the submission.
+  Status checkSubmissionTextureView(const ResourceIdentity& viewIdentity, std::string_view context,
+                                    std::vector<SubmissionUse>& uses) const;
+
+  /// Resolves every attachment view of a recorded render pass.
+  /// @param descriptor Recorded render pass descriptor.
+  /// @param uses Accumulator of resources referenced by the submission.
+  Status checkSubmissionRenderPass(const RenderPassDescriptor& descriptor,
+                                   std::vector<SubmissionUse>& uses) const;
+
+  /// Resolves a recorded bind group, the layout it was created against, and every resource its
+  /// entries reference, so a destroyed dependency fails closed even though the group object
+  /// itself is alive.
+  /// @param groupIdentity Recorded bind group slot and generation.
+  /// @param uses Accumulator of resources referenced by the submission.
+  Status checkSubmissionBindGroup(const ResourceIdentity& groupIdentity,
+                                  std::vector<SubmissionUse>& uses) const;
+
+  /// Resolves every resource one recorded command references.
+  /// @param command Recorded command.
+  /// @param uses Accumulator of resources referenced by the submission.
+  Status checkSubmissionCommand(const Command& command, std::vector<SubmissionUse>& uses) const;
+
   /// Marks every collected resource as used by \p submissionSerial, deferring its backend
   /// destruction until that submission completes.
   /// @param uses Resources collected by \ref validateSubmissionResources.

--- a/donner/gpu/Handles.h
+++ b/donner/gpu/Handles.h
@@ -1,21 +1,54 @@
 #pragma once
 /// @file
-/// Move-only, generation-checked resource handles for \c donner::gpu.
+/// Move-only RAII, generation-checked resource handles for \c donner::gpu.
 ///
-/// Handles are NOT RAII in this packet: resources are freed by an explicit
-/// `Device::destroy*(handle)` call, and device teardown frees everything that remains. RAII
-/// ownership wrappers arrive with the resource-lifetime packet (design 0053 change sequence
-/// step 3, "Resource lifetime and submission model"). Dropping a handle without destroying the
-/// resource does not dangle or leak beyond the device's lifetime; the resource simply stays alive
-/// until device teardown.
+/// Destroying a live handle releases its resource through the owning device (design 0053 "Core
+/// types and ownership"). Teardown ordering is safe in every direction: an explicit
+/// `Device::destroy*(std::move(handle))` call makes the RAII release a no-op, and a handle
+/// destroyed after its device holds an expired device-alive token, so the release is skipped
+/// (device teardown already freed everything that remained). Backend objects referenced by
+/// in-flight submissions are additionally kept alive by the device's deferred-destruction queue,
+/// so an RAII release never destroys a backend object the GPU is still using.
 
 #include <cstdint>
+#include <memory>
 #include <ostream>
 
 namespace donner::gpu {
 
+class Device;
+
 /**
- * Move-only handle to a device resource.
+ * Identity of a resource at a point in time: slot plus generation, so slot reuse cannot alias
+ * two different resources. Recorded commands and dependent-resource records store identities and
+ * re-validate them on every use.
+ */
+struct ResourceIdentity {
+  uint32_t slotIndex = 0;   //!< Resource slot index.
+  uint32_t generation = 0;  //!< Slot generation at capture time.
+
+  /// Equality operator. @param other Identity to compare against.
+  bool operator==(const ResourceIdentity& other) const = default;
+};
+
+namespace details {
+
+/**
+ * Releases the resource identified by (\p slotIndex, \p generation) on \p device if it is still
+ * alive; silently a no-op when the identity is already stale (e.g. the resource was destroyed
+ * explicitly). Called by `~Handle` only; specialized per tag in Device.cc.
+ *
+ * @param device Owning device.
+ * @param slotIndex Resource slot index.
+ * @param generation Slot generation the handle carries.
+ */
+template <typename Tag>
+void ReleaseHandleFromRaii(Device& device, uint32_t slotIndex, uint32_t generation);
+
+}  // namespace details
+
+/**
+ * Move-only RAII handle to a device resource.
  *
  * A handle carries a (slot, generation) pair plus the identity of the owning device. The device
  * validates all three on every use, so a null handle, a stale handle (the resource was destroyed,
@@ -23,7 +56,9 @@ namespace donner::gpu {
  * \ref GpuErrorType::InvalidHandle / \ref GpuErrorType::DeviceMismatch instead of reaching a
  * backend. Validation runs in release builds too.
  *
- * A default-constructed or moved-from handle is null (\ref isValid() returns false).
+ * Destroying a live handle releases the resource through the owning device (see the file comment
+ * for the teardown-ordering contract). A default-constructed or moved-from handle is null
+ * (\ref isValid() returns false) and releases nothing.
  *
  * @tparam Tag Tag type identifying the resource type; provides `Tag::kName` for diagnostics.
  */
@@ -33,8 +68,8 @@ public:
   /// Constructs a null handle.
   Handle() = default;
 
-  /// Destructor. Intentionally does not free the resource (see file comment).
-  ~Handle() = default;
+  /// Destructor; releases the resource if this handle still owns it and the device is alive.
+  ~Handle() { releaseIfOwned(); }
 
   Handle(const Handle&) = delete;
   Handle& operator=(const Handle&) = delete;
@@ -45,20 +80,26 @@ public:
    * @param other Handle to move from.
    */
   Handle(Handle&& other) noexcept
-      : slotIndex_(other.slotIndex_), generation_(other.generation_), deviceId_(other.deviceId_) {
+      : slotIndex_(other.slotIndex_),
+        generation_(other.generation_),
+        deviceId_(other.deviceId_),
+        deviceAlive_(std::move(other.deviceAlive_)) {
     other.resetToNull();
   }
 
   /**
-   * Move assignment; \p other becomes null.
+   * Move assignment; releases the currently owned resource (if any), then takes ownership from
+   * \p other, which becomes null.
    *
    * @param other Handle to move from.
    */
   Handle& operator=(Handle&& other) noexcept {
     if (this != &other) {
+      releaseIfOwned();
       slotIndex_ = other.slotIndex_;
       generation_ = other.generation_;
       deviceId_ = other.deviceId_;
+      deviceAlive_ = std::move(other.deviceAlive_);
       other.resetToNull();
     }
     return *this;
@@ -84,12 +125,17 @@ public:
    * @param slotIndex Resource table slot index.
    * @param generation Slot generation at creation time; must be nonzero.
    * @param deviceId Identity of the owning device.
+   * @param deviceAlive Device-alive token (see `Device`); when empty, the handle is inert - its
+   *   destructor never self-releases. `Device` always supplies the token; the empty default
+   *   exists for handle-shape unit tests that have no device.
    */
-  static Handle CreateForBackend(uint32_t slotIndex, uint32_t generation, uint64_t deviceId) {
+  static Handle CreateForBackend(uint32_t slotIndex, uint32_t generation, uint64_t deviceId,
+                                 std::weak_ptr<Device*> deviceAlive = {}) {
     Handle handle;
     handle.slotIndex_ = slotIndex;
     handle.generation_ = generation;
     handle.deviceId_ = deviceId;
+    handle.deviceAlive_ = std::move(deviceAlive);
     return handle;
   }
 
@@ -101,15 +147,26 @@ public:
   friend bool operator==(const Handle& handle, std::nullptr_t) { return !handle.isValid(); }
 
 private:
+  void releaseIfOwned() {
+    if (generation_ == 0) {
+      return;
+    }
+    if (std::shared_ptr<Device*> device = deviceAlive_.lock()) {
+      details::ReleaseHandleFromRaii<Tag>(**device, slotIndex_, generation_);
+    }
+  }
+
   void resetToNull() {
     slotIndex_ = 0;
     generation_ = 0;
     deviceId_ = 0;
+    deviceAlive_.reset();
   }
 
   uint32_t slotIndex_ = 0;
   uint32_t generation_ = 0;
   uint64_t deviceId_ = 0;
+  std::weak_ptr<Device*> deviceAlive_;
 };
 
 /**

--- a/donner/gpu/RecordingDevice.cc
+++ b/donner/gpu/RecordingDevice.cc
@@ -110,15 +110,15 @@ struct CommandSerializer {
     os << "]";
   }
   void operator()(const SetPipelineCommand& command) {
-    os << "setPipeline " << RefId(RenderPipelineTag::kName, command.pipelineSlot);
+    os << "setPipeline " << RefId(RenderPipelineTag::kName, command.pipelineId.slotIndex);
   }
   void operator()(const SetBindGroupCommand& command) {
     os << "setBindGroup index=" << command.index
-       << " bindGroup=" << RefId(BindGroupTag::kName, command.bindGroupSlot);
+       << " bindGroup=" << RefId(BindGroupTag::kName, command.bindGroupId.slotIndex);
   }
   void operator()(const SetVertexBufferCommand& command) {
     os << "setVertexBuffer slot=" << command.slot
-       << " buffer=" << RefId(BufferTag::kName, command.bufferSlot)
+       << " buffer=" << RefId(BufferTag::kName, command.bufferId.slotIndex)
        << " offsetBytes=" << command.offsetBytes;
   }
   void operator()(const SetScissorRectCommand& command) {
@@ -137,8 +137,8 @@ struct CommandSerializer {
   }
   void operator()(const EndRenderPassCommand&) { os << "endRenderPass"; }
   void operator()(const CopyTextureToBufferCommand& command) {
-    os << "copyTextureToBuffer texture=" << RefId(TextureTag::kName, command.textureSlot)
-       << " buffer=" << RefId(BufferTag::kName, command.bufferSlot)
+    os << "copyTextureToBuffer texture=" << RefId(TextureTag::kName, command.textureId.slotIndex)
+       << " buffer=" << RefId(BufferTag::kName, command.bufferId.slotIndex)
        << " offsetBytes=" << command.layout.offsetBytes
        << " bytesPerRow=" << command.layout.bytesPerRow
        << " rowsPerImage=" << command.layout.rowsPerImage << " copySize=" << command.copySize;

--- a/donner/gpu/metal/MetalDevice.mm
+++ b/donner/gpu/metal/MetalDevice.mm
@@ -235,7 +235,16 @@ std::unique_ptr<MetalDevice> MetalDevice::Create() {
 
 MetalDevice::MetalDevice() : impl_(std::make_unique<Impl>()) {}
 
-MetalDevice::~MetalDevice() = default;
+MetalDevice::~MetalDevice() {
+  // Wait for in-flight submissions so deferred destructions drain before Impl teardown releases
+  // the remaining Metal objects. On timeout (a hung submission) teardown proceeds anyway: Metal
+  // itself retains every resource referenced by a committed command buffer until it completes,
+  // so releasing our references cannot free memory the GPU is still using.
+  if (lastSubmittedSerial() > completedSerial()) {
+    waitForSerial(lastSubmittedSerial(), /*timeoutSeconds=*/5.0);
+  }
+  poll();
+}
 
 uint64_t MetalDevice::completedSerial() const {
   return impl_->completionState->completedSerial.load(std::memory_order_acquire);
@@ -485,8 +494,8 @@ Status MetalDevice::onCreateRenderPipeline(uint32_t slotIndex,
   }
 
   SetSlot(impl_->renderPipelines, slotIndex,
-          std::optional<Impl::RenderPipelineRecord>(Impl::RenderPipelineRecord{
-              pipelineState, descriptor.topology, descriptor.cullMode}));
+          std::optional<Impl::RenderPipelineRecord>(
+              Impl::RenderPipelineRecord{pipelineState, descriptor.topology, descriptor.cullMode}));
   return OkStatus();
 }
 
@@ -605,18 +614,18 @@ Status MetalDevice::onSubmit(uint64_t submissionSerial, uint32_t commandBufferSl
       }
     } else if (const auto* setPipeline = std::get_if<SetPipelineCommand>(&command)) {
       const Impl::RenderPipelineRecord* pipeline =
-          FindRecord(impl_->renderPipelines, setPipeline->pipelineSlot);
+          FindRecord(impl_->renderPipelines, setPipeline->pipelineId.slotIndex);
       if (renderEncoder == nil || pipeline == nullptr || pipeline->state == nil) {
         return failEncoding(GpuError{GpuErrorType::InvalidState,
                                      std::format("setPipeline: pipeline slot {} is not encodable",
-                                                 setPipeline->pipelineSlot)});
+                                                 setPipeline->pipelineId.slotIndex)});
       }
       [renderEncoder setRenderPipelineState:pipeline->state];
       // Cull mode is encoder state in Metal; apply the pipeline's recorded mode at bind time.
       // Behavioral coverage requires winding-controlled geometry, which arrives with the Geode
       // pipeline migration packets; the solid-fill slice always uses CullMode::None.
-      [renderEncoder setCullMode:(pipeline->cullMode == CullMode::Back ? MTLCullModeBack
-                                                                       : MTLCullModeNone)];
+      [renderEncoder
+          setCullMode:(pipeline->cullMode == CullMode::Back ? MTLCullModeBack : MTLCullModeNone)];
       currentTopology = pipeline->topology;
     } else if (const auto* setBindGroup = std::get_if<SetBindGroupCommand>(&command)) {
       if (setBindGroup->index != 0) {
@@ -625,7 +634,7 @@ Status MetalDevice::onSubmit(uint64_t submissionSerial, uint32_t commandBufferSl
                      "the Metal backend maps bind group 0 only in this slice (MslBindingMap.h)"});
       }
       const Impl::BindGroupRecord* bindGroup =
-          FindRecord(impl_->bindGroups, setBindGroup->bindGroupSlot);
+          FindRecord(impl_->bindGroups, setBindGroup->bindGroupId.slotIndex);
       const BindGroupLayoutDescriptor* layout =
           bindGroup != nullptr ? FindRecord(impl_->bindGroupLayouts, bindGroup->layoutSlot)
                                : nullptr;
@@ -633,7 +642,7 @@ Status MetalDevice::onSubmit(uint64_t submissionSerial, uint32_t commandBufferSl
         return failEncoding(
             GpuError{GpuErrorType::InvalidState,
                      std::format("setBindGroup: bind group slot {} is not encodable",
-                                 setBindGroup->bindGroupSlot)});
+                                 setBindGroup->bindGroupId.slotIndex)});
       }
 
       Status bindStatus = OkStatus();
@@ -724,11 +733,11 @@ Status MetalDevice::onSubmit(uint64_t submissionSerial, uint32_t commandBufferSl
             GpuError{GpuErrorType::Unsupported,
                      "the Metal backend supports vertex buffer slot 0 only in this slice"});
       }
-      id<MTLBuffer> buffer = GetSlot(impl_->buffers, setVertexBuffer->bufferSlot);
+      id<MTLBuffer> buffer = GetSlot(impl_->buffers, setVertexBuffer->bufferId.slotIndex);
       if (renderEncoder == nil || buffer == nil) {
         return failEncoding(GpuError{GpuErrorType::InvalidState,
                                      std::format("setVertexBuffer: buffer slot {} is not encodable",
-                                                 setVertexBuffer->bufferSlot)});
+                                                 setVertexBuffer->bufferId.slotIndex)});
       }
       [renderEncoder setVertexBuffer:buffer
                               offset:setVertexBuffer->offsetBytes
@@ -768,8 +777,8 @@ Status MetalDevice::onSubmit(uint64_t submissionSerial, uint32_t commandBufferSl
         return failEncoding(
             GpuError{GpuErrorType::InvalidState, "copyTextureToBuffer inside a render pass"});
       }
-      id<MTLTexture> texture = GetSlot(impl_->textures, copy->textureSlot);
-      id<MTLBuffer> buffer = GetSlot(impl_->buffers, copy->bufferSlot);
+      id<MTLTexture> texture = GetSlot(impl_->textures, copy->textureId.slotIndex);
+      id<MTLBuffer> buffer = GetSlot(impl_->buffers, copy->bufferId.slotIndex);
       if (texture == nil || buffer == nil) {
         return GpuError{GpuErrorType::InvalidState,
                         "copyTextureToBuffer: source texture or destination buffer is missing"};

--- a/donner/gpu/metal/MetalDevice.mm
+++ b/donner/gpu/metal/MetalDevice.mm
@@ -197,7 +197,10 @@ struct MetalDevice::Impl {
   /// A bind group plus the layout slot it was created against (for per-binding visibility).
   struct BindGroupRecord {
     BindGroupDescriptor descriptor;  //!< Validated creation descriptor (entries).
-    uint32_t layoutSlot = 0;         //!< Slot of the bind group layout.
+    /// Snapshot of the layout the group was created against, taken at creation time. Layouts
+    /// are immutable value descriptors, so the copy stays correct even if the layout object is
+    /// destroyed and its slot recycled; encode never looks the layout up by slot.
+    BindGroupLayoutDescriptor layout;
   };
 
   /// A compiled render pipeline plus the encoder state every draw through it uses (cull mode
@@ -370,9 +373,17 @@ Status MetalDevice::onCreateBindGroupLayout(uint32_t slotIndex,
 }
 
 Status MetalDevice::onCreateBindGroup(uint32_t slotIndex, const BindGroupDescriptor& descriptor) {
+  // The base class validated the layout reference before this hook, so the slot lookup cannot
+  // miss; the descriptor is snapshotted into the record (see Impl::BindGroupRecord::layout).
+  const BindGroupLayoutDescriptor* layout =
+      FindRecord(impl_->bindGroupLayouts, descriptor.layout.slotIndex());
+  if (layout == nullptr) {
+    return GpuError{GpuErrorType::InvalidState,
+                    std::format("bind group layout slot {} has no Metal-side descriptor",
+                                descriptor.layout.slotIndex())};
+  }
   SetSlot(impl_->bindGroups, slotIndex,
-          std::optional<Impl::BindGroupRecord>(
-              Impl::BindGroupRecord{descriptor, descriptor.layout.slotIndex()}));
+          std::optional<Impl::BindGroupRecord>(Impl::BindGroupRecord{descriptor, *layout}));
   return OkStatus();
 }
 
@@ -635,15 +646,13 @@ Status MetalDevice::onSubmit(uint64_t submissionSerial, uint32_t commandBufferSl
       }
       const Impl::BindGroupRecord* bindGroup =
           FindRecord(impl_->bindGroups, setBindGroup->bindGroupId.slotIndex);
-      const BindGroupLayoutDescriptor* layout =
-          bindGroup != nullptr ? FindRecord(impl_->bindGroupLayouts, bindGroup->layoutSlot)
-                               : nullptr;
-      if (renderEncoder == nil || bindGroup == nullptr || layout == nullptr) {
+      if (renderEncoder == nil || bindGroup == nullptr) {
         return failEncoding(
             GpuError{GpuErrorType::InvalidState,
                      std::format("setBindGroup: bind group slot {} is not encodable",
                                  setBindGroup->bindGroupId.slotIndex)});
       }
+      const BindGroupLayoutDescriptor* layout = &bindGroup->layout;
 
       Status bindStatus = OkStatus();
       for (const BindGroupEntry& entry : bindGroup->descriptor.entries) {

--- a/donner/gpu/metal/tests/MetalSolidFill_tests.cc
+++ b/donner/gpu/metal/tests/MetalSolidFill_tests.cc
@@ -230,16 +230,22 @@ TEST_F(MetalSolidFillTest, ReadBackBufferRejectsStaleHandleAfterSlotReuse) {
   Buffer original = unwrap(device_->createBuffer(BufferDescriptor{
                                "original", 16, BufferUsage::CopyDst | BufferUsage::MapRead}),
                            "createBuffer original");
-  const Status destroyStatus = device_->destroyBuffer(original);
+  const uint32_t originalSlot = original.slotIndex();
+  const uint32_t originalGeneration = original.generation();
+  const uint64_t deviceId = original.deviceId();
+  const Status destroyStatus = device_->destroyBuffer(std::move(original));
   ASSERT_FALSE(destroyStatus.hasError()) << destroyStatus.error();
 
   Buffer replacement = unwrap(device_->createBuffer(BufferDescriptor{
                                   "replacement", 16, BufferUsage::CopyDst | BufferUsage::MapRead}),
                               "createBuffer replacement");
-  ASSERT_EQ(replacement.slotIndex(), original.slotIndex());
-  ASSERT_NE(replacement.generation(), original.generation());
+  ASSERT_EQ(replacement.slotIndex(), originalSlot);
+  ASSERT_NE(replacement.generation(), originalGeneration);
 
-  Result<std::vector<uint8_t>> stale = device_->readBackBuffer(original);
+  // Forge a handle carrying the retired generation (destroy consumed the real handle), proving
+  // the readback helper checks generation, not just slot.
+  const Buffer staleHandle = Buffer::CreateForBackend(originalSlot, originalGeneration, deviceId);
+  Result<std::vector<uint8_t>> stale = device_->readBackBuffer(staleHandle);
   ASSERT_TRUE(stale.hasError()) << "stale readback unexpectedly succeeded";
   EXPECT_EQ(stale.error().type, GpuErrorType::InvalidHandle) << stale.error();
 }

--- a/donner/gpu/tests/CommandEncoder_tests.cc
+++ b/donner/gpu/tests/CommandEncoder_tests.cc
@@ -282,7 +282,7 @@ TEST_F(CommandEncoderTests, CopyTextureToBufferRejectsMissingCopySrc) {
 }
 
 TEST_F(CommandEncoderTests, BeginRenderPassRejectsStaleView) {
-  ASSERT_THAT(device_.destroyTextureView(targetView_), IsOk());
+  ASSERT_THAT(device_.destroyTextureView(std::move(targetView_)), IsOk());
   EXPECT_THAT(encoder_->beginRenderPass(passDescriptor()), IsGpuError(GpuErrorType::InvalidHandle));
 }
 
@@ -299,7 +299,7 @@ TEST_F(CommandEncoderTests, BeginRenderPassRejectsNonRenderableView) {
 }
 
 TEST_F(CommandEncoderTests, SetBindGroupRejectsDestroyedBuffer) {
-  ASSERT_THAT(device_.destroyBuffer(uniformBuffer_), IsOk());
+  ASSERT_THAT(device_.destroyBuffer(std::move(uniformBuffer_)), IsOk());
 
   RenderPassEncoder* pass = beginPass();
   EXPECT_THAT(pass->setBindGroup(0, bindGroup_),
@@ -307,12 +307,13 @@ TEST_F(CommandEncoderTests, SetBindGroupRejectsDestroyedBuffer) {
 }
 
 TEST_F(CommandEncoderTests, SetBindGroupRejectsBufferSlotReuse) {
-  ASSERT_THAT(device_.destroyBuffer(uniformBuffer_), IsOk());
+  const uint32_t uniformSlot = uniformBuffer_.slotIndex();
+  ASSERT_THAT(device_.destroyBuffer(std::move(uniformBuffer_)), IsOk());
 
   // The replacement reuses the freed buffer slot; the group's stale reference must not alias it.
   const Buffer replacement = GetResultOrFail(device_.createBuffer(
       BufferDescriptor{"replacement", 16, BufferUsage::Uniform | BufferUsage::CopyDst}));
-  ASSERT_THAT(replacement.slotIndex(), Eq(uniformBuffer_.slotIndex()));
+  ASSERT_THAT(replacement.slotIndex(), Eq(uniformSlot));
 
   RenderPassEncoder* pass = beginPass();
   EXPECT_THAT(pass->setBindGroup(0, bindGroup_),
@@ -348,7 +349,7 @@ protected:
 };
 
 TEST_F(SetBindGroupTextureTests, RejectsDestroyedTextureView) {
-  ASSERT_THAT(device_.destroyTextureView(sampledView_), IsOk());
+  ASSERT_THAT(device_.destroyTextureView(std::move(sampledView_)), IsOk());
 
   RenderPassEncoder* pass = beginPass();
   EXPECT_THAT(pass->setBindGroup(1, textureGroup_),
@@ -356,7 +357,7 @@ TEST_F(SetBindGroupTextureTests, RejectsDestroyedTextureView) {
 }
 
 TEST_F(SetBindGroupTextureTests, RejectsDestroyedUnderlyingTexture) {
-  ASSERT_THAT(device_.destroyTexture(sampledTexture_), IsOk());
+  ASSERT_THAT(device_.destroyTexture(std::move(sampledTexture_)), IsOk());
 
   RenderPassEncoder* pass = beginPass();
   EXPECT_THAT(
@@ -365,7 +366,7 @@ TEST_F(SetBindGroupTextureTests, RejectsDestroyedUnderlyingTexture) {
 }
 
 TEST_F(SetBindGroupTextureTests, RejectsDestroyedSampler) {
-  ASSERT_THAT(device_.destroySampler(sampler_), IsOk());
+  ASSERT_THAT(device_.destroySampler(std::move(sampler_)), IsOk());
 
   RenderPassEncoder* pass = beginPass();
   EXPECT_THAT(pass->setBindGroup(1, textureGroup_),

--- a/donner/gpu/tests/DeviceValidation_tests.cc
+++ b/donner/gpu/tests/DeviceValidation_tests.cc
@@ -220,11 +220,11 @@ TEST_F(DeviceValidationTests, CreatePipelineLayoutRejectsTooManyGroups) {
 }
 
 TEST_F(DeviceValidationTests, CreatePipelineLayoutRejectsStaleLayout) {
-  const BindGroupLayout layout =
-      GetResultOrFail(device_.createBindGroupLayout(BindGroupLayoutDescriptor{
-          "uniforms", {BindGroupLayoutEntry{0, ShaderStage::Vertex, BindingType::UniformBuffer}}}));
-  EXPECT_THAT(device_.destroyBindGroupLayout(layout), IsOk());
-  EXPECT_THAT(device_.createPipelineLayout(PipelineLayoutDescriptor{"stale", {layout}}),
+  BindGroupLayout layout = GetResultOrFail(device_.createBindGroupLayout(BindGroupLayoutDescriptor{
+      "uniforms", {BindGroupLayoutEntry{0, ShaderStage::Vertex, BindingType::UniformBuffer}}}));
+  const BindGroupLayoutRef staleRef(layout);
+  EXPECT_THAT(device_.destroyBindGroupLayout(std::move(layout)), IsOk());
+  EXPECT_THAT(device_.createPipelineLayout(PipelineLayoutDescriptor{"stale", {staleRef}}),
               IsGpuError(GpuErrorType::InvalidHandle));
 }
 
@@ -467,9 +467,10 @@ TEST_F(RenderPipelineValidationTests, RejectsMultisample) {
 }
 
 TEST_F(RenderPipelineValidationTests, RejectsStaleLayout) {
-  EXPECT_THAT(device_.destroyPipelineLayout(layout_), IsOk());
-  EXPECT_THAT(device_.createRenderPipeline(validDescriptor()),
-              IsGpuError(GpuErrorType::InvalidHandle));
+  // Build the descriptor first so it holds a genuinely stale layout reference.
+  const RenderPipelineDescriptor descriptor = validDescriptor();
+  EXPECT_THAT(device_.destroyPipelineLayout(std::move(layout_)), IsOk());
+  EXPECT_THAT(device_.createRenderPipeline(descriptor), IsGpuError(GpuErrorType::InvalidHandle));
 }
 
 // == writeBuffer ==============================================================================

--- a/donner/gpu/tests/HandleLifetime_tests.cc
+++ b/donner/gpu/tests/HandleLifetime_tests.cc
@@ -1,6 +1,6 @@
 /// @file
-/// Handle lifetime tests: destroy-then-use, stale generations after slot reuse, cross-device
-/// handles, and moved-from handles.
+/// Handle lifetime tests: RAII release, explicit destroy, stale references after slot reuse,
+/// cross-device handles, moved-from handles, and device-teardown ordering.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -14,7 +14,9 @@
 #include "donner/gpu/tests/GpuTestUtils.h"
 
 using testing::Eq;
+using testing::HasSubstr;
 using testing::Ne;
+using testing::Not;
 
 namespace donner::gpu {
 namespace {
@@ -34,34 +36,93 @@ protected:
   RecordingDevice device_;
 };
 
-TEST_F(HandleLifetimeTests, DestroyThenUseFailsClosed) {
-  const Buffer buffer = createBuffer("victim");
-  EXPECT_THAT(device_.destroyBuffer(buffer), IsOk());
+TEST_F(HandleLifetimeTests, DestroyConsumesHandleAndUseFailsClosed) {
+  Buffer buffer = createBuffer("victim");
+  EXPECT_THAT(device_.destroyBuffer(std::move(buffer)), IsOk());
 
+  // The consumed handle is null; both use and re-destroy fail closed.
+  EXPECT_EQ(buffer, nullptr);  // NOLINT(bugprone-use-after-move): consumed state is the API.
   EXPECT_THAT(writeTo(buffer), IsGpuError(GpuErrorType::InvalidHandle));
-  EXPECT_THAT(device_.destroyBuffer(buffer), IsGpuError(GpuErrorType::InvalidHandle));
+  EXPECT_THAT(device_.destroyBuffer(std::move(buffer)), IsGpuError(GpuErrorType::InvalidHandle));
 }
 
-TEST_F(HandleLifetimeTests, StaleGenerationAfterSlotReuseFailsClosed) {
-  const Buffer first = createBuffer("first");
-  EXPECT_THAT(device_.destroyBuffer(first), IsOk());
+TEST_F(HandleLifetimeTests, DroppingHandleReleasesResource) {
+  {
+    const Buffer buffer = createBuffer("raii");
+    EXPECT_THAT(device_.serialize(), Not(HasSubstr("destroy buffer#0")));
+  }
+  EXPECT_THAT(device_.serialize(), HasSubstr("destroy buffer#0"));
+}
 
-  // The freed slot is reused with a bumped generation; the stale handle must not alias it.
+TEST_F(HandleLifetimeTests, ExplicitDestroyThenRaiiDoesNotDoubleDestroy) {
+  {
+    Buffer buffer = createBuffer("once");
+    EXPECT_THAT(device_.destroyBuffer(std::move(buffer)), IsOk());
+  }
+
+  // Exactly one destroy line: the RAII release of the consumed handle is a no-op.
+  const std::string capture = device_.serialize();
+  const size_t first = capture.find("destroy buffer#0");
+  ASSERT_THAT(first, Ne(std::string::npos));
+  EXPECT_THAT(capture.find("destroy buffer#0", first + 1), Eq(std::string::npos));
+}
+
+TEST_F(HandleLifetimeTests, MoveAssignReleasesPreviouslyOwnedResource) {
+  Buffer target = createBuffer("first");
+  Buffer replacement = createBuffer("second");
+
+  target = std::move(replacement);
+
+  // The first buffer (slot 0) was released by the assignment; the second is still alive.
+  EXPECT_THAT(device_.serialize(), HasSubstr("destroy buffer#0"));
+  EXPECT_THAT(device_.serialize(), Not(HasSubstr("destroy buffer#1")));
+  EXPECT_THAT(writeTo(target), IsOk());
+}
+
+TEST_F(HandleLifetimeTests, HandleOutlivingDeviceReleasesNothing) {
+  auto device = std::make_unique<RecordingDevice>();
+  Buffer survivor = GetResultOrFail(device->createBuffer(
+      BufferDescriptor{"survivor", 16, BufferUsage::Uniform | BufferUsage::CopyDst}));
+
+  // Destroying the device first must leave the outstanding handle inert: its destructor runs
+  // after this line and must not touch the destroyed device (ASAN would catch a violation).
+  device.reset();
+}
+
+TEST_F(HandleLifetimeTests, StaleReferenceAfterSlotReuseFailsClosed) {
+  Buffer first = createBuffer("first");
+  const uint32_t firstSlot = first.slotIndex();
+  const uint32_t firstGeneration = first.generation();
+  const BindGroupLayout layout =
+      GetResultOrFail(device_.createBindGroupLayout(BindGroupLayoutDescriptor{
+          "uniforms", {BindGroupLayoutEntry{0, ShaderStage::Vertex, BindingType::UniformBuffer}}}));
+
+  // Capture a non-owning reference, then destroy the buffer and reuse its slot.
+  const BufferRef staleRef(first);
+  EXPECT_THAT(device_.destroyBuffer(std::move(first)), IsOk());
   const Buffer second = createBuffer("second");
-  ASSERT_THAT(second.slotIndex(), Eq(first.slotIndex()));
-  ASSERT_THAT(second.generation(), Ne(first.generation()));
+  ASSERT_THAT(second.slotIndex(), Eq(firstSlot));
+  ASSERT_THAT(second.generation(), Ne(firstGeneration));
 
-  EXPECT_THAT(writeTo(first), IsGpuError(GpuErrorType::InvalidHandle));
+  // The stale reference must not alias the slot's new occupant.
+  EXPECT_THAT(device_.createBindGroup(BindGroupDescriptor{
+                  "stale", layout, {BindGroupEntry{0, BufferBinding{staleRef, 0, 16}}}}),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidHandle, HasSubstr("stale")));
   EXPECT_THAT(writeTo(second), IsOk());
 }
 
 TEST_F(HandleLifetimeTests, ForeignDeviceHandleFailsClosed) {
   RecordingDevice otherDevice;
-  const Buffer foreign = GetResultOrFail(otherDevice.createBuffer(
+  Buffer foreign = GetResultOrFail(otherDevice.createBuffer(
       BufferDescriptor{"foreign", 16, BufferUsage::Uniform | BufferUsage::CopyDst}));
 
   EXPECT_THAT(writeTo(foreign), IsGpuError(GpuErrorType::DeviceMismatch));
-  EXPECT_THAT(device_.destroyBuffer(foreign), IsGpuError(GpuErrorType::DeviceMismatch));
+
+  // destroy on the wrong device reports the mismatch; the consumed handle still releases the
+  // resource on its OWNING device (no leak), which the other device's capture records.
+  EXPECT_THAT(device_.destroyBuffer(std::move(foreign)), IsGpuError(GpuErrorType::DeviceMismatch));
+  EXPECT_THAT(otherDevice.serialize(), HasSubstr("destroy buffer#0"));
+  EXPECT_THAT(device_.serialize(), Not(HasSubstr("destroy")));
 }
 
 TEST_F(HandleLifetimeTests, MovedFromHandleIsNullAndFailsClosed) {
@@ -71,24 +132,27 @@ TEST_F(HandleLifetimeTests, MovedFromHandleIsNullAndFailsClosed) {
   EXPECT_EQ(original, nullptr);  // NOLINT(bugprone-use-after-move): moved-from state is the API.
   EXPECT_THAT(writeTo(original), IsGpuError(GpuErrorType::InvalidHandle));
   EXPECT_THAT(writeTo(moved), IsOk());
+
+  // The move transferred ownership: no destroy has been recorded yet.
+  EXPECT_THAT(device_.serialize(), Not(HasSubstr("destroy")));
 }
 
 TEST_F(HandleLifetimeTests, PassAttachmentOfDestroyedTextureRejects) {
-  const Texture texture = GetResultOrFail(device_.createTexture(TextureDescriptor{
+  Texture texture = GetResultOrFail(device_.createTexture(TextureDescriptor{
       "target", Extent2d{4, 4}, TextureFormat::RGBA8Unorm, TextureUsage::RenderAttachment}));
   const TextureView view =
       GetResultOrFail(device_.createTextureView(texture, TextureViewDescriptor{"targetView"}));
-  ASSERT_THAT(device_.destroyTexture(texture), IsOk());
+  ASSERT_THAT(device_.destroyTexture(std::move(texture)), IsOk());
 
   std::unique_ptr<CommandEncoder> encoder = GetResultOrFail(device_.createCommandEncoder());
-  EXPECT_THAT(encoder->beginRenderPass(RenderPassDescriptor{
-                  "pass", {RenderPassColorAttachment{view, LoadOp::Clear, StoreOp::Store}}}),
-              IsGpuErrorWithMessage(GpuErrorType::InvalidHandle,
-                                    testing::HasSubstr("texture was destroyed")));
+  EXPECT_THAT(
+      encoder->beginRenderPass(RenderPassDescriptor{
+          "pass", {RenderPassColorAttachment{view, LoadOp::Clear, StoreOp::Store}}}),
+      IsGpuErrorWithMessage(GpuErrorType::InvalidHandle, HasSubstr("texture was destroyed")));
 }
 
 TEST_F(HandleLifetimeTests, SampledBindingOfDestroyedTextureRejects) {
-  const Texture texture = GetResultOrFail(device_.createTexture(TextureDescriptor{
+  Texture texture = GetResultOrFail(device_.createTexture(TextureDescriptor{
       "image", Extent2d{4, 4}, TextureFormat::RGBA8Unorm, TextureUsage::Sampled}));
   const TextureView view =
       GetResultOrFail(device_.createTextureView(texture, TextureViewDescriptor{"imageView"}));
@@ -96,48 +160,55 @@ TEST_F(HandleLifetimeTests, SampledBindingOfDestroyedTextureRejects) {
       GetResultOrFail(device_.createBindGroupLayout(BindGroupLayoutDescriptor{
           "texture",
           {BindGroupLayoutEntry{0, ShaderStage::Fragment, BindingType::SampledTexture2dFloat}}}));
-  ASSERT_THAT(device_.destroyTexture(texture), IsOk());
+  ASSERT_THAT(device_.destroyTexture(std::move(texture)), IsOk());
 
-  EXPECT_THAT(device_.createBindGroup(BindGroupDescriptor{
-                  "group", layout, {BindGroupEntry{0, TextureViewBinding{view}}}}),
-              IsGpuErrorWithMessage(GpuErrorType::InvalidHandle,
-                                    testing::HasSubstr("texture was destroyed")));
+  EXPECT_THAT(
+      device_.createBindGroup(
+          BindGroupDescriptor{"group", layout, {BindGroupEntry{0, TextureViewBinding{view}}}}),
+      IsGpuErrorWithMessage(GpuErrorType::InvalidHandle, HasSubstr("texture was destroyed")));
 }
 
 TEST_F(HandleLifetimeTests, StaleViewAfterTextureSlotReuseRejects) {
-  const Texture original = GetResultOrFail(device_.createTexture(TextureDescriptor{
+  Texture original = GetResultOrFail(device_.createTexture(TextureDescriptor{
       "original", Extent2d{4, 4}, TextureFormat::RGBA8Unorm, TextureUsage::RenderAttachment}));
+  const uint32_t originalSlot = original.slotIndex();
+  const uint32_t originalGeneration = original.generation();
   const TextureView staleView =
       GetResultOrFail(device_.createTextureView(original, TextureViewDescriptor{"staleView"}));
-  ASSERT_THAT(device_.destroyTexture(original), IsOk());
+  ASSERT_THAT(device_.destroyTexture(std::move(original)), IsOk());
 
   // The replacement reuses the freed texture slot; the stale view must not alias it.
   const Texture replacement = GetResultOrFail(device_.createTexture(TextureDescriptor{
       "replacement", Extent2d{8, 8}, TextureFormat::RGBA8Unorm, TextureUsage::RenderAttachment}));
-  ASSERT_THAT(replacement.slotIndex(), Eq(original.slotIndex()));
-  ASSERT_THAT(replacement.generation(), Ne(original.generation()));
+  ASSERT_THAT(replacement.slotIndex(), Eq(originalSlot));
+  ASSERT_THAT(replacement.generation(), Ne(originalGeneration));
 
   std::unique_ptr<CommandEncoder> encoder = GetResultOrFail(device_.createCommandEncoder());
-  EXPECT_THAT(encoder->beginRenderPass(RenderPassDescriptor{
-                  "pass", {RenderPassColorAttachment{staleView, LoadOp::Clear, StoreOp::Store}}}),
-              IsGpuErrorWithMessage(GpuErrorType::InvalidHandle,
-                                    testing::HasSubstr("texture was destroyed")));
+  EXPECT_THAT(
+      encoder->beginRenderPass(RenderPassDescriptor{
+          "pass", {RenderPassColorAttachment{staleView, LoadOp::Clear, StoreOp::Store}}}),
+      IsGpuErrorWithMessage(GpuErrorType::InvalidHandle, HasSubstr("texture was destroyed")));
 }
 
 TEST_F(HandleLifetimeTests, DestroyIsSharedAcrossResourceTypes) {
-  const Texture texture = GetResultOrFail(device_.createTexture(TextureDescriptor{
+  Texture texture = GetResultOrFail(device_.createTexture(TextureDescriptor{
       "target", Extent2d{4, 4}, TextureFormat::RGBA8Unorm, TextureUsage::RenderAttachment}));
-  const TextureView view =
+  TextureView view =
       GetResultOrFail(device_.createTextureView(texture, TextureViewDescriptor{"view"}));
-  const Sampler sampler = GetResultOrFail(device_.createSampler(SamplerDescriptor{"sampler"}));
+  Sampler sampler = GetResultOrFail(device_.createSampler(SamplerDescriptor{"sampler"}));
 
-  EXPECT_THAT(device_.destroyTextureView(view), IsOk());
-  EXPECT_THAT(device_.destroyTextureView(view), IsGpuError(GpuErrorType::InvalidHandle));
-  EXPECT_THAT(device_.destroyTexture(texture), IsOk());
-  EXPECT_THAT(device_.destroySampler(sampler), IsOk());
+  EXPECT_THAT(device_.destroyTextureView(std::move(view)), IsOk());
+  EXPECT_THAT(device_.destroyTextureView(std::move(view)),  // NOLINT(bugprone-use-after-move)
+              IsGpuError(GpuErrorType::InvalidHandle));
+  EXPECT_THAT(device_.destroySampler(std::move(sampler)), IsOk());
 
   // A view of a destroyed texture cannot be created either.
-  EXPECT_THAT(device_.createTextureView(texture, TextureViewDescriptor{"lateView"}),
+  const uint32_t textureSlot = texture.slotIndex();
+  const uint32_t textureGeneration = texture.generation();
+  const uint64_t deviceId = texture.deviceId();
+  EXPECT_THAT(device_.destroyTexture(std::move(texture)), IsOk());
+  const Texture staleTexture = Texture::CreateForBackend(textureSlot, textureGeneration, deviceId);
+  EXPECT_THAT(device_.createTextureView(staleTexture, TextureViewDescriptor{"lateView"}),
               IsGpuError(GpuErrorType::InvalidHandle));
 }
 

--- a/donner/gpu/tests/HandleLifetime_tests.cc
+++ b/donner/gpu/tests/HandleLifetime_tests.cc
@@ -63,8 +63,8 @@ TEST_F(HandleLifetimeTests, ExplicitDestroyThenRaiiDoesNotDoubleDestroy) {
   // Exactly one destroy line: the RAII release of the consumed handle is a no-op.
   const std::string capture = device_.serialize();
   const size_t first = capture.find("destroy buffer#0");
-  ASSERT_THAT(first, Ne(std::string::npos));
-  EXPECT_THAT(capture.find("destroy buffer#0", first + 1), Eq(std::string::npos));
+  ASSERT_THAT(first, Ne(std::string::npos)) << "no destroy recorded; capture:\n" << capture;
+  EXPECT_THAT(capture.substr(first + 1), Not(HasSubstr("destroy buffer#0")));
 }
 
 TEST_F(HandleLifetimeTests, MoveAssignReleasesPreviouslyOwnedResource) {

--- a/donner/gpu/tests/Handles_tests.cc
+++ b/donner/gpu/tests/Handles_tests.cc
@@ -21,6 +21,14 @@ TEST(HandlesTests, DefaultConstructedIsNull) {
   EXPECT_THAT(buffer.deviceId(), Eq(0u));
 }
 
+TEST(HandlesTests, HandleWithoutDeviceAliveTokenIsInert) {
+  // CreateForBackend without a device-alive token mints an inert handle: destroying it must not
+  // dereference the (nonexistent) device. Simply exiting this scope is the assertion; ASAN
+  // catches a violation.
+  const Buffer buffer = Buffer::CreateForBackend(1, 1, 42);
+  EXPECT_TRUE(buffer.isValid());
+}
+
 TEST(HandlesTests, CreateForBackendIsValid) {
   const Buffer buffer = Buffer::CreateForBackend(3, 2, 77);
   EXPECT_TRUE(buffer.isValid());

--- a/donner/gpu/tests/RecordingDevice_tests.cc
+++ b/donner/gpu/tests/RecordingDevice_tests.cc
@@ -67,7 +67,8 @@ protected:
 };
 
 /// Records the representative solid-fill stream: every resource creation, queue write, a full
-/// render pass, a readback copy, a destroy, and a submission.
+/// render pass, a readback copy, a destroy, and a submission, followed by the RAII teardown of
+/// every remaining handle in reverse declaration order as the locals go out of scope.
 void RecordRepresentativeStream(RecordingDevice& device) {
   const Texture target = GetResultOrFail(device.createTexture(
       TextureDescriptor{"target", Extent2d{4, 4}, TextureFormat::RGBA8Unorm,
@@ -87,7 +88,7 @@ void RecordRepresentativeStream(RecordingDevice& device) {
       BufferDescriptor{"uniforms", 16, BufferUsage::Uniform | BufferUsage::CopyDst}));
   const Buffer readbackBuffer = GetResultOrFail(device.createBuffer(
       BufferDescriptor{"readback", 1024, BufferUsage::CopyDst | BufferUsage::MapRead}));
-  const Buffer scratchBuffer =
+  Buffer scratchBuffer =
       GetResultOrFail(device.createBuffer(BufferDescriptor{"scratch", 8, BufferUsage::CopySrc}));
 
   const BindGroupLayout bindGroupLayout =
@@ -126,7 +127,7 @@ void RecordRepresentativeStream(RecordingDevice& device) {
   EXPECT_THAT(device.writeTexture(image, MakeBytes(3 * 256 + 16), TexelCopyBufferLayout{0, 256, 4},
                                   Extent2d{4, 4}),
               IsOk());
-  EXPECT_THAT(device.destroyBuffer(scratchBuffer), IsOk());
+  EXPECT_THAT(device.destroyBuffer(std::move(scratchBuffer)), IsOk());
 
   std::unique_ptr<CommandEncoder> encoder = GetResultOrFail(device.createCommandEncoder());
   RenderPassEncoder* pass = GetResultOrFail(encoder->beginRenderPass(RenderPassDescriptor{
@@ -239,6 +240,18 @@ submit serial=1 commandBuffer#0 commandCount=9
   draw vertexCount=6 instanceCount=1 firstVertex=0 firstInstance=0
   endRenderPass
   copyTextureToBuffer texture=texture#0 buffer=buffer#2 offsetBytes=0 bytesPerRow=256 rowsPerImage=4 copySize=4x4
+destroy renderPipeline#0
+destroy shaderModule#0
+destroy bindGroup#0
+destroy pipelineLayout#0
+destroy bindGroupLayout#0
+destroy buffer#2
+destroy buffer#1
+destroy buffer#0
+destroy sampler#0
+destroy texture#1
+destroy textureView#0
+destroy texture#0
 )";
   // clang-format on
 

--- a/donner/gpu/tests/ResourceLifetime_tests.cc
+++ b/donner/gpu/tests/ResourceLifetime_tests.cc
@@ -299,6 +299,37 @@ TEST_F(SubmitStalenessTests, DestroyedBindGroupRejectsSubmit) {
               IsGpuErrorWithMessage(GpuErrorType::InvalidHandle, HasSubstr("destroyed bindGroup")));
 }
 
+TEST_F(SubmitStalenessTests, DestroyedBindGroupLayoutRejectsSubmit) {
+  CommandBuffer commands = recordScene();
+  // The bind group stays alive; only the layout it was created against dies. The layout is a
+  // transitive dependency of the group (backends read it at encode time), so submission must
+  // fail closed.
+  ASSERT_THAT(device_.destroyBindGroupLayout(std::move(bindGroupLayout_)), IsOk());
+  EXPECT_THAT(device_.submit(std::move(commands)),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidHandle,
+                                    AllOf(HasSubstr("bind group \"solidUniforms\""),
+                                          HasSubstr("destroyed bindGroupLayout"))));
+}
+
+TEST_F(SubmitStalenessTests, RecycledBindGroupLayoutSlotRejectsSubmit) {
+  CommandBuffer commands = recordScene();
+  const uint32_t layoutSlot = bindGroupLayout_.slotIndex();
+  ASSERT_THAT(device_.destroyBindGroupLayout(std::move(bindGroupLayout_)), IsOk());
+
+  // A different layout reuses the freed slot; the group's recorded layout identity must not
+  // alias it (the replacement's entries would misbind stages at encode time).
+  const BindGroupLayout replacement =
+      GetResultOrFail(device_.createBindGroupLayout(BindGroupLayoutDescriptor{
+          "replacementLayout",
+          {BindGroupLayoutEntry{5, ShaderStage::Fragment, BindingType::FilteringSampler}}}));
+  ASSERT_THAT(replacement.slotIndex(), Eq(layoutSlot));
+
+  EXPECT_THAT(device_.submit(std::move(commands)),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidHandle,
+                                    AllOf(HasSubstr("bind group \"solidUniforms\""),
+                                          HasSubstr("destroyed bindGroupLayout"))));
+}
+
 TEST_F(SubmitStalenessTests, DestroyedBindGroupEntryBufferRejectsSubmit) {
   CommandBuffer commands = recordScene();
   // The bind group itself stays alive; only the buffer one of its entries references dies.

--- a/donner/gpu/tests/ResourceLifetime_tests.cc
+++ b/donner/gpu/tests/ResourceLifetime_tests.cc
@@ -1,0 +1,400 @@
+/// @file
+/// Resource lifetime and submission model tests: deferred destruction by submission serial, slot
+/// retirement while work is in flight, and submit-time re-validation of recorded command
+/// resources (design 0053 "Core types and ownership", "Command model").
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "donner/gpu/CommandEncoder.h"
+#include "donner/gpu/Device.h"
+#include "donner/gpu/RecordingDevice.h"
+#include "donner/gpu/tests/GpuTestUtils.h"
+
+using testing::AllOf;
+using testing::ElementsAre;
+using testing::Eq;
+using testing::HasSubstr;
+using testing::IsEmpty;
+using testing::Ne;
+
+namespace donner::gpu {
+namespace {
+
+/**
+ * Test backend whose completion serial is advanced manually, modeling a GPU that executes
+ * submissions asynchronously. Records every backend release in order so tests can assert exactly
+ * when deferred destruction reaches the backend.
+ */
+class ManualCompletionDevice final : public Device {
+public:
+  /// Marks every submission up to \p serial as executed by the fake GPU.
+  /// @param serial Serial to complete through.
+  void completeUpTo(uint64_t serial) { completedSerial_ = serial; }
+
+  /// Serial of the most recent manually completed submission.
+  uint64_t completedSerial() const override { return completedSerial_; }
+
+  /// Backend releases observed, as `<name>#<slot>` strings in release order.
+  const std::vector<std::string>& backendReleases() const { return backendReleases_; }
+
+protected:
+  Status onCreateBuffer(uint32_t, const BufferDescriptor&) override { return OkStatus(); }
+  Status onCreateTexture(uint32_t, const TextureDescriptor&) override { return OkStatus(); }
+  Status onCreateTextureView(uint32_t, uint32_t, const TextureViewDescriptor&) override {
+    return OkStatus();
+  }
+  Status onCreateSampler(uint32_t, const SamplerDescriptor&) override { return OkStatus(); }
+  Status onCreateBindGroupLayout(uint32_t, const BindGroupLayoutDescriptor&) override {
+    return OkStatus();
+  }
+  Status onCreateBindGroup(uint32_t, const BindGroupDescriptor&) override { return OkStatus(); }
+  Status onCreatePipelineLayout(uint32_t, const PipelineLayoutDescriptor&) override {
+    return OkStatus();
+  }
+  Status onCreateShaderModule(uint32_t, const ShaderModuleDescriptor&) override {
+    return OkStatus();
+  }
+  Status onCreateRenderPipeline(uint32_t, const RenderPipelineDescriptor&) override {
+    return OkStatus();
+  }
+  void onDestroyResource(std::string_view resourceName, uint32_t slotIndex) override {
+    backendReleases_.push_back(std::string(resourceName) + "#" + std::to_string(slotIndex));
+  }
+  Status onWriteBuffer(uint32_t, uint64_t, std::span<const uint8_t>) override { return OkStatus(); }
+  Status onWriteTexture(uint32_t, std::span<const uint8_t>, const TexelCopyBufferLayout&,
+                        const Extent2d&) override {
+    return OkStatus();
+  }
+  Status onSubmit(uint64_t, uint32_t, std::span<const Command>) override { return OkStatus(); }
+
+private:
+  uint64_t completedSerial_ = 0;
+  std::vector<std::string> backendReleases_;
+};
+
+/// Deferred-destruction tests: a readback copy keeps its source texture and destination buffer
+/// referenced by an in-flight submission.
+class DeferredDestructionTests : public testing::Test {
+protected:
+  Texture createSourceTexture() {
+    return GetResultOrFail(device_.createTexture(TextureDescriptor{
+        "source", Extent2d{4, 4}, TextureFormat::RGBA8Unorm, TextureUsage::CopySrc}));
+  }
+
+  Buffer createReadbackBuffer() {
+    return GetResultOrFail(device_.createBuffer(
+        BufferDescriptor{"readback", 1024, BufferUsage::CopyDst | BufferUsage::MapRead}));
+  }
+
+  /// Submits one copy from \p texture to \p buffer and returns the submission serial.
+  uint64_t submitCopy(const Texture& texture, const Buffer& buffer) {
+    std::unique_ptr<CommandEncoder> encoder = GetResultOrFail(device_.createCommandEncoder());
+    Status copyStatus = encoder->copyTextureToBuffer(
+        TexelCopyTextureInfo{texture}, buffer, TexelCopyBufferLayout{0, 256, 4}, Extent2d{4, 4});
+    EXPECT_THAT(copyStatus, IsOk());
+    CommandBuffer commands = GetResultOrFail(encoder->finish());
+    return GetResultOrFail(device_.submit(std::move(commands)));
+  }
+
+  ManualCompletionDevice device_;
+};
+
+TEST_F(DeferredDestructionTests, DestroyOfUnsubmittedResourceReleasesImmediately) {
+  Buffer buffer = createReadbackBuffer();
+  const uint32_t slot = buffer.slotIndex();
+  EXPECT_THAT(device_.destroyBuffer(std::move(buffer)), IsOk());
+  EXPECT_THAT(device_.backendReleases(), ElementsAre("buffer#" + std::to_string(slot)));
+}
+
+TEST_F(DeferredDestructionTests, DestroyWhileInFlightDefersBackendRelease) {
+  Texture texture = createSourceTexture();
+  Buffer buffer = createReadbackBuffer();
+  const uint32_t bufferSlot = buffer.slotIndex();
+  const uint64_t serial = submitCopy(texture, buffer);
+
+  // The destroy retires the handle immediately but must not release the backend object while
+  // the submission is incomplete - not even through an explicit poll.
+  EXPECT_THAT(device_.destroyBuffer(std::move(buffer)), IsOk());
+  device_.poll();
+  EXPECT_THAT(device_.backendReleases(), IsEmpty());
+
+  // The retired slot must not be reused while the backend object is still alive.
+  const Buffer unrelated = createReadbackBuffer();
+  EXPECT_THAT(unrelated.slotIndex(), Ne(bufferSlot));
+
+  // Completion plus poll releases the backend object and recycles the slot.
+  device_.completeUpTo(serial);
+  device_.poll();
+  EXPECT_THAT(device_.backendReleases(), ElementsAre("buffer#" + std::to_string(bufferSlot)));
+  const Buffer recycled = createReadbackBuffer();
+  EXPECT_THAT(recycled.slotIndex(), Eq(bufferSlot));
+}
+
+TEST_F(DeferredDestructionTests, DestroyAfterCompletionReleasesImmediately) {
+  Texture texture = createSourceTexture();
+  Buffer buffer = createReadbackBuffer();
+  const uint32_t bufferSlot = buffer.slotIndex();
+  const uint64_t serial = submitCopy(texture, buffer);
+
+  device_.completeUpTo(serial);
+  EXPECT_THAT(device_.destroyBuffer(std::move(buffer)), IsOk());
+  EXPECT_THAT(device_.backendReleases(), ElementsAre("buffer#" + std::to_string(bufferSlot)));
+}
+
+TEST_F(DeferredDestructionTests, RaiiDropWhileInFlightAlsoDefers) {
+  Texture texture = createSourceTexture();
+  uint64_t serial = 0;
+  uint32_t bufferSlot = 0;
+  {
+    const Buffer buffer = createReadbackBuffer();
+    bufferSlot = buffer.slotIndex();
+    serial = submitCopy(texture, buffer);
+  }
+
+  // The RAII release at scope exit deferred: the backend object survives until completion.
+  EXPECT_THAT(device_.backendReleases(), IsEmpty());
+  device_.completeUpTo(serial);
+  device_.poll();
+  EXPECT_THAT(device_.backendReleases(), ElementsAre("buffer#" + std::to_string(bufferSlot)));
+}
+
+TEST_F(DeferredDestructionTests, BothCopyOperandsDeferAndReleaseInDestructionOrder) {
+  Texture texture = createSourceTexture();
+  Buffer buffer = createReadbackBuffer();
+  const std::string textureId = "texture#" + std::to_string(texture.slotIndex());
+  const std::string bufferId = "buffer#" + std::to_string(buffer.slotIndex());
+  const uint64_t serial = submitCopy(texture, buffer);
+
+  EXPECT_THAT(device_.destroyTexture(std::move(texture)), IsOk());
+  EXPECT_THAT(device_.destroyBuffer(std::move(buffer)), IsOk());
+  EXPECT_THAT(device_.backendReleases(), IsEmpty());
+
+  device_.completeUpTo(serial);
+  device_.poll();
+  EXPECT_THAT(device_.backendReleases(), ElementsAre(textureId, bufferId));
+}
+
+TEST_F(DeferredDestructionTests, LaterSubmissionExtendsDeferral) {
+  Texture texture = createSourceTexture();
+  Buffer buffer = createReadbackBuffer();
+  const uint32_t bufferSlot = buffer.slotIndex();
+  const uint64_t firstSerial = submitCopy(texture, buffer);
+  const uint64_t secondSerial = submitCopy(texture, buffer);
+  ASSERT_THAT(secondSerial, Eq(firstSerial + 1));
+
+  EXPECT_THAT(device_.destroyBuffer(std::move(buffer)), IsOk());
+
+  // Completing only the first submission is not enough: the second still references the buffer.
+  device_.completeUpTo(firstSerial);
+  device_.poll();
+  EXPECT_THAT(device_.backendReleases(), IsEmpty());
+
+  device_.completeUpTo(secondSerial);
+  device_.poll();
+  EXPECT_THAT(device_.backendReleases(), ElementsAre("buffer#" + std::to_string(bufferSlot)));
+}
+
+/// Submit-time staleness tests: the full solid-fill scene is recorded, then one resource is
+/// destroyed between finish() and submit(). Submission must fail closed naming the resource.
+class SubmitStalenessTests : public testing::Test {
+protected:
+  void SetUp() override {
+    target_ = GetResultOrFail(device_.createTexture(
+        TextureDescriptor{"target", Extent2d{4, 4}, TextureFormat::RGBA8Unorm,
+                          TextureUsage::RenderAttachment | TextureUsage::CopySrc}));
+    targetView_ =
+        GetResultOrFail(device_.createTextureView(target_, TextureViewDescriptor{"targetView"}));
+    vertexBuffer_ = GetResultOrFail(device_.createBuffer(
+        BufferDescriptor{"vertices", 48, BufferUsage::Vertex | BufferUsage::CopyDst}));
+    uniformBuffer_ = GetResultOrFail(device_.createBuffer(
+        BufferDescriptor{"uniforms", 16, BufferUsage::Uniform | BufferUsage::CopyDst}));
+    readbackBuffer_ = GetResultOrFail(device_.createBuffer(
+        BufferDescriptor{"readback", 1024, BufferUsage::CopyDst | BufferUsage::MapRead}));
+
+    bindGroupLayout_ = GetResultOrFail(device_.createBindGroupLayout(BindGroupLayoutDescriptor{
+        "uniforms",
+        {BindGroupLayoutEntry{0, ShaderStage::Vertex | ShaderStage::Fragment,
+                              BindingType::UniformBuffer}}}));
+    pipelineLayout_ = GetResultOrFail(
+        device_.createPipelineLayout(PipelineLayoutDescriptor{"solidLayout", {bindGroupLayout_}}));
+    bindGroup_ = GetResultOrFail(device_.createBindGroup(
+        BindGroupDescriptor{"solidUniforms",
+                            bindGroupLayout_,
+                            {BindGroupEntry{0, BufferBinding{uniformBuffer_, 0, 16}}}}));
+    shader_ = GetResultOrFail(device_.createShaderModule(ShaderModuleDescriptor{
+        "solidFill", "@vertex fn vsMain() {}\n@fragment fn fsMain() {}", ShaderSourceKind::Wgsl}));
+    pipeline_ = GetResultOrFail(device_.createRenderPipeline(RenderPipelineDescriptor{
+        "solid", pipelineLayout_,
+        VertexState{
+            shader_,
+            "vsMain",
+            {VertexBufferLayout{
+                8, VertexStepMode::Vertex, {VertexAttribute{VertexFormat::Float32x2, 0, 0}}}}},
+        FragmentState{shader_, "fsMain", {ColorTargetState{TextureFormat::RGBA8Unorm}}}}));
+  }
+
+  /// Records the full pass plus readback copy and returns the finished command buffer.
+  CommandBuffer recordScene() {
+    std::unique_ptr<CommandEncoder> encoder = GetResultOrFail(device_.createCommandEncoder());
+    RenderPassEncoder* pass = GetResultOrFail(encoder->beginRenderPass(RenderPassDescriptor{
+        "mainPass",
+        {RenderPassColorAttachment{targetView_, LoadOp::Clear, StoreOp::Store, {0, 0, 0.5, 1}}}}));
+    EXPECT_THAT(pass->setPipeline(pipeline_), IsOk());
+    EXPECT_THAT(pass->setBindGroup(0, bindGroup_), IsOk());
+    EXPECT_THAT(pass->setVertexBuffer(0, vertexBuffer_), IsOk());
+    EXPECT_THAT(pass->draw(6), IsOk());
+    EXPECT_THAT(pass->end(), IsOk());
+    EXPECT_THAT(encoder->copyTextureToBuffer(TexelCopyTextureInfo{target_}, readbackBuffer_,
+                                             TexelCopyBufferLayout{0, 256, 4}, Extent2d{4, 4}),
+                IsOk());
+    return GetResultOrFail(encoder->finish());
+  }
+
+  RecordingDevice device_;
+  Texture target_;
+  TextureView targetView_;
+  Buffer vertexBuffer_;
+  Buffer uniformBuffer_;
+  Buffer readbackBuffer_;
+  BindGroupLayout bindGroupLayout_;
+  PipelineLayout pipelineLayout_;
+  BindGroup bindGroup_;
+  ShaderModule shader_;
+  RenderPipeline pipeline_;
+};
+
+TEST_F(SubmitStalenessTests, IntactSceneSubmits) {
+  CommandBuffer commands = recordScene();
+  EXPECT_THAT(device_.submit(std::move(commands)), HasResult());
+}
+
+TEST_F(SubmitStalenessTests, DestroyedVertexBufferRejectsSubmit) {
+  CommandBuffer commands = recordScene();
+  ASSERT_THAT(device_.destroyBuffer(std::move(vertexBuffer_)), IsOk());
+  EXPECT_THAT(
+      device_.submit(std::move(commands)),
+      IsGpuErrorWithMessage(GpuErrorType::InvalidHandle,
+                            AllOf(HasSubstr("setVertexBuffer"), HasSubstr("destroyed buffer"))));
+}
+
+TEST_F(SubmitStalenessTests, DestroyedPipelineRejectsSubmit) {
+  CommandBuffer commands = recordScene();
+  ASSERT_THAT(device_.destroyRenderPipeline(std::move(pipeline_)), IsOk());
+  EXPECT_THAT(
+      device_.submit(std::move(commands)),
+      IsGpuErrorWithMessage(GpuErrorType::InvalidHandle, HasSubstr("destroyed renderPipeline")));
+}
+
+TEST_F(SubmitStalenessTests, DestroyedBindGroupRejectsSubmit) {
+  CommandBuffer commands = recordScene();
+  ASSERT_THAT(device_.destroyBindGroup(std::move(bindGroup_)), IsOk());
+  EXPECT_THAT(device_.submit(std::move(commands)),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidHandle, HasSubstr("destroyed bindGroup")));
+}
+
+TEST_F(SubmitStalenessTests, DestroyedBindGroupEntryBufferRejectsSubmit) {
+  CommandBuffer commands = recordScene();
+  // The bind group itself stays alive; only the buffer one of its entries references dies.
+  ASSERT_THAT(device_.destroyBuffer(std::move(uniformBuffer_)), IsOk());
+  EXPECT_THAT(device_.submit(std::move(commands)),
+              IsGpuErrorWithMessage(
+                  GpuErrorType::InvalidHandle,
+                  AllOf(HasSubstr("bind group \"solidUniforms\""), HasSubstr("destroyed buffer"))));
+}
+
+TEST_F(SubmitStalenessTests, DestroyedAttachmentViewRejectsSubmit) {
+  CommandBuffer commands = recordScene();
+  ASSERT_THAT(device_.destroyTextureView(std::move(targetView_)), IsOk());
+  EXPECT_THAT(device_.submit(std::move(commands)),
+              IsGpuErrorWithMessage(
+                  GpuErrorType::InvalidHandle,
+                  AllOf(HasSubstr("render pass attachment"), HasSubstr("destroyed textureView"))));
+}
+
+TEST_F(SubmitStalenessTests, DestroyedAttachmentTextureRejectsSubmit) {
+  CommandBuffer commands = recordScene();
+  // The view stays alive; the texture behind it dies. The copy source also dies with it, but
+  // the attachment walk hits the identity first - either way the submit must fail closed.
+  ASSERT_THAT(device_.destroyTexture(std::move(target_)), IsOk());
+  EXPECT_THAT(device_.submit(std::move(commands)),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidHandle, HasSubstr("destroyed texture")));
+}
+
+TEST_F(SubmitStalenessTests, DestroyedCopyDestinationRejectsSubmit) {
+  CommandBuffer commands = recordScene();
+  ASSERT_THAT(device_.destroyBuffer(std::move(readbackBuffer_)), IsOk());
+  EXPECT_THAT(
+      device_.submit(std::move(commands)),
+      IsGpuErrorWithMessage(GpuErrorType::InvalidHandle, AllOf(HasSubstr("copyTextureToBuffer"),
+                                                               HasSubstr("destroyed buffer"))));
+}
+
+TEST_F(SubmitStalenessTests, RejectedSubmitDoesNotBurnSerial) {
+  CommandBuffer staleCommands = recordScene();
+  ASSERT_THAT(device_.destroyBuffer(std::move(vertexBuffer_)), IsOk());
+  ASSERT_THAT(device_.submit(std::move(staleCommands)), IsGpuError(GpuErrorType::InvalidHandle));
+  EXPECT_THAT(device_.lastSubmittedSerial(), Eq(uint64_t{0}));
+
+  // A subsequent valid submission takes serial 1: rejected submissions consume no serial.
+  vertexBuffer_ = GetResultOrFail(device_.createBuffer(
+      BufferDescriptor{"vertices2", 48, BufferUsage::Vertex | BufferUsage::CopyDst}));
+  CommandBuffer freshCommands = recordScene();
+  EXPECT_THAT(GetResultOrFail(device_.submit(std::move(freshCommands))), Eq(uint64_t{1}));
+}
+
+TEST_F(SubmitStalenessTests, DestroyedSamplerEntryRejectsSubmit) {
+  // A second scene with a sampled-texture bind group, so the sampler entry branch is covered.
+  Texture sampled = GetResultOrFail(device_.createTexture(TextureDescriptor{
+      "sampled", Extent2d{4, 4}, TextureFormat::RGBA8Unorm, TextureUsage::Sampled}));
+  const TextureView sampledView =
+      GetResultOrFail(device_.createTextureView(sampled, TextureViewDescriptor{"sampledView"}));
+  Sampler sampler = GetResultOrFail(device_.createSampler(SamplerDescriptor{"linear"}));
+  const BindGroupLayout textureLayout =
+      GetResultOrFail(device_.createBindGroupLayout(BindGroupLayoutDescriptor{
+          "textureBindings",
+          {BindGroupLayoutEntry{0, ShaderStage::Fragment, BindingType::SampledTexture2dFloat},
+           BindGroupLayoutEntry{1, ShaderStage::Fragment, BindingType::FilteringSampler}}}));
+  const PipelineLayout texturePipelineLayout = GetResultOrFail(
+      device_.createPipelineLayout(PipelineLayoutDescriptor{"textureLayout", {textureLayout}}));
+  const BindGroup textureGroup = GetResultOrFail(device_.createBindGroup(
+      BindGroupDescriptor{"textureGroup",
+                          textureLayout,
+                          {BindGroupEntry{0, TextureViewBinding{sampledView}},
+                           BindGroupEntry{1, SamplerBinding{sampler}}}}));
+  const RenderPipeline texturePipeline =
+      GetResultOrFail(device_.createRenderPipeline(RenderPipelineDescriptor{
+          "textured", texturePipelineLayout,
+          VertexState{
+              shader_,
+              "vsMain",
+              {VertexBufferLayout{
+                  8, VertexStepMode::Vertex, {VertexAttribute{VertexFormat::Float32x2, 0, 0}}}}},
+          FragmentState{shader_, "fsMain", {ColorTargetState{TextureFormat::RGBA8Unorm}}}}));
+
+  std::unique_ptr<CommandEncoder> encoder = GetResultOrFail(device_.createCommandEncoder());
+  RenderPassEncoder* pass = GetResultOrFail(encoder->beginRenderPass(RenderPassDescriptor{
+      "texturedPass",
+      {RenderPassColorAttachment{targetView_, LoadOp::Clear, StoreOp::Store, {0, 0, 0, 1}}}}));
+  ASSERT_THAT(pass->setPipeline(texturePipeline), IsOk());
+  ASSERT_THAT(pass->setBindGroup(0, textureGroup), IsOk());
+  ASSERT_THAT(pass->setVertexBuffer(0, vertexBuffer_), IsOk());
+  ASSERT_THAT(pass->draw(3), IsOk());
+  ASSERT_THAT(pass->end(), IsOk());
+  CommandBuffer commands = GetResultOrFail(encoder->finish());
+
+  ASSERT_THAT(device_.destroySampler(std::move(sampler)), IsOk());
+  EXPECT_THAT(device_.submit(std::move(commands)),
+              IsGpuErrorWithMessage(
+                  GpuErrorType::InvalidHandle,
+                  AllOf(HasSubstr("bind group \"textureGroup\""), HasSubstr("destroyed sampler"))));
+}
+
+}  // namespace
+}  // namespace donner::gpu

--- a/donner/gpu/tests/ResourceLifetime_tests.cc
+++ b/donner/gpu/tests/ResourceLifetime_tests.cc
@@ -23,6 +23,7 @@ using testing::Eq;
 using testing::HasSubstr;
 using testing::IsEmpty;
 using testing::Ne;
+using testing::Not;
 
 namespace donner::gpu {
 namespace {
@@ -378,6 +379,43 @@ TEST_F(SubmitStalenessTests, RejectedSubmitDoesNotBurnSerial) {
       BufferDescriptor{"vertices2", 48, BufferUsage::Vertex | BufferUsage::CopyDst}));
   CommandBuffer freshCommands = recordScene();
   EXPECT_THAT(GetResultOrFail(device_.submit(std::move(freshCommands))), Eq(uint64_t{1}));
+}
+
+TEST_F(SubmitStalenessTests, DroppedCommandBufferReleasesSlotWithoutBackendNotification) {
+  uint32_t droppedSlot = 0;
+  {
+    const CommandBuffer dropped = recordScene();
+    droppedSlot = dropped.slotIndex();
+  }
+
+  // The RAII release freed the slot (the next finished buffer reuses it) and command buffers
+  // have no backend object, so no destroy line was recorded.
+  const CommandBuffer next = recordScene();
+  EXPECT_THAT(next.slotIndex(), Eq(droppedSlot));
+  EXPECT_THAT(device_.serialize(), Not(HasSubstr("destroy commandBuffer")));
+}
+
+TEST_F(SubmitStalenessTests, DoubleSubmitFailsClosed) {
+  CommandBuffer commands = recordScene();
+  ASSERT_THAT(device_.submit(std::move(commands)), HasResult());
+
+  // The first submit consumed the handle; the second sees a null handle.
+  EXPECT_THAT(device_.submit(std::move(commands)),  // NOLINT(bugprone-use-after-move)
+              IsGpuErrorWithMessage(GpuErrorType::InvalidHandle, HasSubstr("null")));
+}
+
+TEST_F(SubmitStalenessTests, ForgedConsumedCommandBufferIsStale) {
+  CommandBuffer commands = recordScene();
+  const uint32_t slot = commands.slotIndex();
+  const uint32_t generation = commands.generation();
+  const uint64_t deviceId = commands.deviceId();
+  ASSERT_THAT(device_.submit(std::move(commands)), HasResult());
+
+  // A forged handle carrying the consumed generation must resolve as stale, not alias a later
+  // command buffer occupying the slot.
+  CommandBuffer forged = CommandBuffer::CreateForBackend(slot, generation, deviceId);
+  EXPECT_THAT(device_.submit(std::move(forged)),
+              IsGpuErrorWithMessage(GpuErrorType::InvalidHandle, HasSubstr("stale")));
 }
 
 TEST_F(SubmitStalenessTests, DestroyedSamplerEntryRejectsSubmit) {


### PR DESCRIPTION
Packet 3 of the design 0053 change sequence: the resource lifetime and submission model for `donner::gpu`, closing the two lifetime gaps documented in packet 2 (#902).

- **RAII handles.** `Handle<Tag>` is now move-only RAII: dropping a live handle releases its resource through the owning device, and the `destroy*` methods consume the handle (`Handle&&`), so explicit destroy plus RAII can never double-free. Handles carry a device-alive token; a handle destroyed after its device tears down is an inert no-op, making teardown safe in every order.
- **Deferred destruction by submission serial.** Destroying a resource retires its identity immediately (stale handles, references, and recorded commands all fail closed), but the backend object is kept alive - and its slot is not reused - until every submission referencing it has completed. Deferred releases drain through `Device::poll()` and opportunistically on `destroy*`/`submit`. `MetalDevice` waits for in-flight serials in its destructor before releasing backend state.
- **Submit-time staleness validation.** Recorded commands now carry full `(slot, generation)` resource identities, and `Device::submit` re-validates every referenced resource - including transitive bind-group entries, the bind group's layout, and the textures behind attachment and entry views - before the backend sees the commands, then pins each one's last-use serial. `PipelineLayout` and `ShaderModule` are documented as intentionally exempt (consumed at pipeline creation only).

An independent review of the candidate diff found one blocking hole - the bind group's layout was not re-validated or pinned, and the Metal backend looked it up by slot without a generation check, so a recycled layout slot could silently misbind stages. The branch carries a red-to-green sequence for it: failing tests first, then the three-layer fix (submit validation pins the layout identity, the encoder re-checks it at record time, and Metal snapshots the immutable layout descriptor at bind-group creation).

Testing: `bazel test //...` green locally (876 targets, 0 failures; 103 skipped are the usual fuzzer/manual/gated lanes), including the Metal solid-fill vertical slice at 0 px difference against the frozen baseline. New coverage: RAII/teardown-ordering tests in `HandleLifetime_tests`, and a new `ResourceLifetime_tests` suite with a manual-completion test device for deferred-destruction timing plus submit-staleness tests for every referenced resource kind. `gen_cmakelists.py --check` and the GPU inventory manifests are clean.
