### PR TITLE
geode: migrate GeoEncoder and frame recording onto the RHI, deleting the migrated wgpu calls (design 0053 packet 8b)

### DIFF
--- a/docs/design_docs/0053-native_gpu_hal.md
+++ b/docs/design_docs/0053-native_gpu_hal.md
@@ -378,6 +378,21 @@ directory drops.
 - [ ] Remove every migrated `wgpu` call and type in the same packet; temporary adapter code carries
       an explicit removal gate.
 
+Geode's renderer runs one command encoder for a whole frame, and the filter engine records compute
+passes into that same encoder. The RHI does not model compute passes, so the filter engine cannot
+migrate in this phase, and a frame whose encoder became a `donner::gpu::CommandEncoder` would have
+to split into several command buffers - reinstating the per-boundary submits the single-encoder
+frame removed, and separating the layer-composite texture copy from the draws it must sit between.
+
+The Phase 1 transition adapter therefore gains a host-encoder replay mode: while a host encoder is
+installed, a submitted command stream is replayed into it instead of into an encoder the adapter
+owns, and the adapter performs no queue submit of its own. One command buffer still carries the
+whole frame in recording order, including the spans the host records directly around the replayed
+ones. Completion stays truthful because the adapter holds the replayed serial back until the host
+reports its queue submit, so no resource is treated as free before the work is even submitted. The
+mode is removed once the filter engine and the presentation paths record through the RHI, alongside
+the other Phase 1 escape hatches.
+
 ### Phase 2: Shader IR vertical slice
 
 - [ ] Inventory and specify the required shader language subset.

--- a/donner/gpu/metal/tests/BaselineCaptureTool.cc
+++ b/donner/gpu/metal/tests/BaselineCaptureTool.cc
@@ -54,6 +54,14 @@ int CaptureBaseline(const char* outputPath) {
   td.sampleCount = 1;
   td.dimension = wgpu::TextureDimension::_2D;
   wgpu::Texture target = device->device().createTexture(td);
+  gpu::Result<gpu::Texture> targetHandleResult = device->adapterDevice().importExternalTexture(
+      target, gpu::Extent2d{kBaselineSize, kBaselineSize}, gpu::TextureFormat::RGBA8Unorm,
+      gpu::TextureUsage::RenderAttachment | gpu::TextureUsage::CopySrc);
+  if (!targetHandleResult.hasResult()) {
+    std::fprintf(stderr, "Failed to name the baseline render target\n");
+    return 1;
+  }
+  const gpu::Texture targetHandle = std::move(targetHandleResult).result();
 
   wgpu::BufferDescriptor bd = {};
   bd.label = geode::wgpuLabel("BaselineReadback");
@@ -62,7 +70,8 @@ int CaptureBaseline(const char* outputPath) {
   wgpu::Buffer readback = device->device().createBuffer(bd);
 
   {
-    geode::GeoEncoder encoder(*device, pipeline, gradientPipeline, imagePipeline, target);
+    geode::GeoEncoder encoder(*device, pipeline, gradientPipeline, imagePipeline, targetHandle,
+                              gpu::Extent2d{kBaselineSize, kBaselineSize});
     encoder.clear(css::RGBA(0, 0, 0, 0));  // Transparent background.
     encoder.setTransform(BaselinePixelFromScene());
     for (const BaselinePathSpec& spec : BaselineScenePaths()) {

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -2515,8 +2515,9 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     /// slab chunk, and its record must live in the same record-slab
     /// buffer as the batch.
     std::vector<SceneInstance> sceneInstances;
-    wgpu::Buffer sceneChunkBuffer;
-    wgpu::Buffer sceneRecordBuffer;
+    gpu::BufferRef sceneChunkBuffer;
+    uint64_t sceneChunkBytes = 0;
+    gpu::BufferRef sceneRecordBuffer;
     /// Stable identities of the two buffers above (see
     /// `GeodeDevice::AllocateBufferId`). The encoder's bind-group cache
     /// outlives the document, so it keys on these rather than on the handle
@@ -2794,10 +2795,10 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
       slot.recordSlab = std::move(slab);
       slot.recordSlot = geode::GeodeRecordSlab::Slot{};
     }
-    if (!slot.recordSlot.buffer) {
+    if (!slot.recordSlot.buffer.isValid()) {
       (void)slot.recordSlab->allocateSlot(*device, slot.recordSlot);
     }
-    return static_cast<bool>(slot.recordSlot.buffer);
+    return slot.recordSlot.buffer.isValid();
   }
 
   /// Glyph-residency budget, in distinct cached outlines and summed retained
@@ -3100,8 +3101,10 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
       return false;
     }
 
-    const wgpu::Buffer chunk = entry.slot.buffer;
+    const gpu::BufferRef chunk = entry.slot.buffer;
     const uint64_t chunkId = entry.slot.bufferId;
+    const uint64_t chunkBytes =
+        entry.slot.slab != nullptr ? entry.slot.slab->chunkBytesForId(chunkId) : 0;
     const uint32_t vertexCount = entry.encoded.boundingDrawVertexCount();
     const uint64_t clipVersion = encoder->clipStateVersion();
     const PendingBatch::SceneInstance instance{
@@ -3124,6 +3127,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     pendingBatch = PendingBatch{};
     pendingBatch->mode = PendingBatch::Mode::Scene;
     pendingBatch->sceneChunkBuffer = chunk;
+    pendingBatch->sceneChunkBytes = chunkBytes;
     pendingBatch->sceneRecordBuffer = recordSlot->buffer;
     pendingBatch->sceneChunkBufferId = chunkId;
     pendingBatch->sceneRecordBufferId = recordSlot->bufferId;
@@ -3358,6 +3362,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
 
       geode::GeoEncoder::SceneBatchBinding binding = {};
       binding.chunkBuffer = batch.sceneChunkBuffer;
+      binding.chunkBytes = batch.sceneChunkBytes;
       binding.recordBuffer = batch.sceneRecordBuffer;
       binding.chunkBufferId = batch.sceneChunkBufferId;
       binding.recordBufferId = batch.sceneRecordBufferId;
@@ -3587,9 +3592,11 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
                                            /*overrideRecordCache=*/nullptr, &recordState)) {
       const geode::GeodeRecordSlab::Slot& effectiveRecordSlot =
           recordSlotPtr != nullptr ? *recordSlotPtr : residentSlot->recordSlot;
-      const wgpu::Buffer chunk = residentSlot->buffer;
-      const wgpu::Buffer recordBuf = effectiveRecordSlot.buffer;
+      const gpu::BufferRef chunk = residentSlot->buffer;
+      const gpu::BufferRef recordBuf = effectiveRecordSlot.buffer;
       const uint64_t chunkId = residentSlot->bufferId;
+      const uint64_t chunkBytes =
+          residentSlot->slab != nullptr ? residentSlot->slab->chunkBytesForId(chunkId) : 0;
       const uint64_t recordBufId = effectiveRecordSlot.bufferId;
       const uint32_t recordIndex = effectiveRecordSlot.index;
       const uint32_t vertexCount = encoded->boundingDrawVertexCount();
@@ -3624,6 +3631,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
           pendingBatch = PendingBatch{};
           pendingBatch->mode = PendingBatch::Mode::Scene;
           pendingBatch->sceneChunkBuffer = chunk;
+          pendingBatch->sceneChunkBytes = chunkBytes;
           pendingBatch->sceneRecordBuffer = recordBuf;
           pendingBatch->sceneChunkBufferId = chunkId;
           pendingBatch->sceneRecordBufferId = recordBufId;
@@ -3681,14 +3689,17 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
           first.recordSlotOverride = firstRecordSlotPtr;
           const geode::GeodeRecordSlab::Slot& effectiveFirstRecordSlot =
               firstRecordSlotPtr != nullptr ? *firstRecordSlotPtr : first.slot->recordSlot;
-          const wgpu::Buffer firstChunk = first.slot->buffer;
-          const wgpu::Buffer firstRecordBuf = effectiveFirstRecordSlot.buffer;
+          const gpu::BufferRef firstChunk = first.slot->buffer;
+          const gpu::BufferRef firstRecordBuf = effectiveFirstRecordSlot.buffer;
           const uint64_t firstChunkId = first.slot->bufferId;
+          const uint64_t firstChunkBytes =
+              first.slot->slab != nullptr ? first.slot->slab->chunkBytesForId(firstChunkId) : 0;
           const uint64_t firstRecordBufId = effectiveFirstRecordSlot.bufferId;
           const uint32_t firstIndex = effectiveFirstRecordSlot.index;
           pendingBatch = PendingBatch{};
           pendingBatch->mode = PendingBatch::Mode::Scene;
           pendingBatch->sceneChunkBuffer = firstChunk;
+          pendingBatch->sceneChunkBytes = firstChunkBytes;
           pendingBatch->sceneRecordBuffer = firstRecordBuf;
           pendingBatch->sceneChunkBufferId = firstChunkId;
           pendingBatch->sceneRecordBufferId = firstRecordBufId;
@@ -3705,6 +3716,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
             pendingBatch = PendingBatch{};
             pendingBatch->mode = PendingBatch::Mode::Scene;
             pendingBatch->sceneChunkBuffer = chunk;
+            pendingBatch->sceneChunkBytes = chunkBytes;
             pendingBatch->sceneRecordBuffer = recordBuf;
             pendingBatch->sceneChunkBufferId = chunkId;
             pendingBatch->sceneRecordBufferId = recordBufId;
@@ -3724,7 +3736,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
             encoder->releasePreparedSceneAdmission(*encoded);
           }
           startPending(sourceRegistry, sourceEntity, path, paint, rule, encoded, residentSlot,
-                       chunk, recordBuf, chunkId, recordBufId, recordIndex,
+                       chunk, chunkBytes, recordBuf, chunkId, recordBufId, recordIndex,
                        effectiveRecordSlot.offset, clipVersion, current);
         }
         return true;
@@ -3741,8 +3753,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
           flushPendingBatch();
         }
         startPending(sourceRegistry, sourceEntity, path, paint, rule, encoded, residentSlot, chunk,
-                     recordBuf, chunkId, recordBufId, recordIndex, effectiveRecordSlot.offset,
-                     clipVersion, current);
+                     chunkBytes, recordBuf, chunkId, recordBufId, recordIndex,
+                     effectiveRecordSlot.offset, clipVersion, current);
         return true;
       }
 
@@ -3750,6 +3762,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
       pendingBatch = PendingBatch{};
       pendingBatch->mode = PendingBatch::Mode::Scene;
       pendingBatch->sceneChunkBuffer = chunk;
+      pendingBatch->sceneChunkBytes = chunkBytes;
       pendingBatch->sceneRecordBuffer = recordBuf;
       pendingBatch->sceneChunkBufferId = chunkId;
       pendingBatch->sceneRecordBufferId = recordBufId;
@@ -3796,9 +3809,10 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
   void startPending(Registry* sourceRegistry, Entity sourceEntity, const Path& path,
                     const geode::GeoEncoder::ScenePaint& paint, FillRule rule,
                     const geode::EncodedPath* encoded, geode::GeodeResidentSlot* residentSlot,
-                    const wgpu::Buffer& chunk, const wgpu::Buffer& recordBuffer, uint64_t chunkId,
-                    uint64_t recordBufferId, uint32_t recordIndex, uint64_t recordOffset,
-                    uint64_t clipVersion, const PendingBatch::SceneInstance& instance) {
+                    const gpu::BufferRef& chunk, uint64_t chunkBytes,
+                    const gpu::BufferRef& recordBuffer, uint64_t chunkId, uint64_t recordBufferId,
+                    uint32_t recordIndex, uint64_t recordOffset, uint64_t clipVersion,
+                    const PendingBatch::SceneInstance& instance) {
     if (!paint.isGradient()) {
       startSameEntitySingleton(sourceRegistry, sourceEntity, path, paint.color, rule, encoded,
                                residentSlot);
@@ -3807,6 +3821,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     pendingBatch = PendingBatch{};
     pendingBatch->mode = PendingBatch::Mode::Scene;
     pendingBatch->sceneChunkBuffer = chunk;
+    pendingBatch->sceneChunkBytes = chunkBytes;
     pendingBatch->sceneRecordBuffer = recordBuffer;
     pendingBatch->sceneChunkBufferId = chunkId;
     pendingBatch->sceneRecordBufferId = recordBufferId;

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1352,6 +1352,148 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
   // encoder in the slot is the one endFrame submits.
   geode::ScopedWgpuHandle<wgpu::CommandEncoder> frameCommandEncoder;
 
+  // Runtime command encoder for the frame. It records into `frameCommandEncoder`
+  // rather than owning a command buffer of its own: filter passes are still
+  // recorded directly on the backend encoder, and pass ordering only holds if
+  // every pass appends to the same command buffer. Recreated alongside
+  // `frameCommandEncoder` whenever that slot is replaced.
+  //
+  // A runtime encoder is single-use: what it records reaches the backend encoder only when it is
+  // finished and submitted. Because filter passes are recorded on the backend encoder directly,
+  // that replay has to happen at each point in the frame where the two interleave, so the frame
+  // holds a succession of runtime encoders rather than one. Every encoder stays alive until the
+  // frame ends: a finished one records nothing more, but the GeoEncoders that recorded through it
+  // still hold a reference to it.
+  std::deque<std::unique_ptr<gpu::CommandEncoder>> frameGpuEncoders;
+  gpu::CommandEncoder* frameGpuEncoder = nullptr;
+
+  // Runtime handles naming render targets this frame's encoders draw into or
+  // sample. The textures themselves belong to the recycling pool or to the
+  // embedding host; these handles only name them, so they are dropped at the
+  // frame boundary, before a recycled texture could be reached through a stale
+  // handle.
+  std::deque<gpu::Texture> frameImportedTextures;
+  std::deque<gpu::TextureView> frameImportedTextureViews;
+
+  /// Names a backend-owned texture as a runtime texture handle valid for the rest of the frame.
+  /// The extent comes from the texture itself, so a caller can never describe it wrongly.
+  const gpu::Texture& importTexture(const wgpu::Texture& texture, wgpu::TextureFormat format,
+                                    wgpu::TextureUsage usage) {
+    gpu::Result<gpu::Texture> imported = device->adapterDevice().importExternalTexture(
+        texture, gpu::Extent2d{texture.getWidth(), texture.getHeight()},
+        geode::GpuTextureFormatFromWgpu(format), geode::GpuTextureUsageFromWgpu(usage));
+    UTILS_RELEASE_ASSERT_MSG(imported.hasResult(), "Failed to name a render target as a texture");
+    frameImportedTextures.push_back(std::move(imported).result());
+    return frameImportedTextures.back();
+  }
+
+  /// Opens a runtime view over an already-named texture, valid for the rest of the frame. Views
+  /// cover the whole texture, so this addresses exactly the texels any other full-texture view of
+  /// the same texture would.
+  const gpu::TextureView& importTextureView(const gpu::Texture& texture) {
+    gpu::Result<gpu::TextureView> view = device->adapterDevice().createTextureView(
+        texture, gpu::TextureViewDescriptor{"RendererGeodeImportedView"});
+    UTILS_RELEASE_ASSERT_MSG(view.hasResult(), "Failed to open a view of a render target");
+    frameImportedTextureViews.push_back(std::move(view).result());
+    return frameImportedTextureViews.back();
+  }
+
+  /// Names a filter-engine result texture. Filter intermediates are storage-writable, a
+  /// capability the runtime does not model; what survives the mapping is exactly what the
+  /// compositing draw needs, which is the ability to sample it.
+  const gpu::Texture& importFilterResult(const wgpu::Texture& texture) {
+    return importTexture(texture, kFilterIntermediateFormat,
+                         wgpu::TextureUsage::TextureBinding | wgpu::TextureUsage::CopySrc);
+  }
+
+  /// Names a pooled texture as a runtime handle, taking its capabilities from the descriptor it
+  /// was created from.
+  const gpu::Texture& importTexture(const wgpu::Texture& texture,
+                                    const wgpu::TextureDescriptor& desc) {
+    return importTexture(texture, desc.format, desc.usage);
+  }
+
+  /// Names the active render target, which always carries render-attachment, sampled and
+  /// copy-source capability so layers can be composited and read back.
+  const gpu::Texture& importTarget(const wgpu::Texture& texture) {
+    return importTexture(texture, textureFormat,
+                         wgpu::TextureUsage::RenderAttachment | wgpu::TextureUsage::TextureBinding |
+                             wgpu::TextureUsage::CopySrc);
+  }
+
+  /// Extent of the active render target, in texels, read from the target itself.
+  gpu::Extent2d targetExtent() const {
+    return gpu::Extent2d{target.getWidth(), target.getHeight()};
+  }
+
+  /// Extent of a backend texture, in texels, as the runtime spells it.
+  static gpu::Extent2d extentOf(const wgpu::Texture& texture) {
+    return gpu::Extent2d{texture.getWidth(), texture.getHeight()};
+  }
+
+  /// Point the runtime device at the current frame command encoder and open a runtime encoder
+  /// that records into it. Returns false when the runtime refuses the encoder.
+  [[nodiscard]] bool openFrameGpuEncoder() {
+    device->adapterDevice().setHostCommandEncoder(frameCommandEncoder.get());
+    gpu::Result<std::unique_ptr<gpu::CommandEncoder>> created =
+        device->adapterDevice().createCommandEncoder();
+    if (!created.hasResult()) {
+      return false;
+    }
+    frameGpuEncoders.push_back(std::move(created).result());
+    frameGpuEncoder = frameGpuEncoders.back().get();
+    return frameGpuEncoder != nullptr;
+  }
+
+  /// Replay what the runtime encoder has recorded into the frame command encoder and open a fresh
+  /// one. Call before recording on the frame command encoder directly and before finishing it, so
+  /// the two streams reach the backend in the order they were written.
+  [[nodiscard]] bool flushFrameGpuEncoder() {
+    if (frameGpuEncoder == nullptr) {
+      return true;
+    }
+    gpu::Result<gpu::CommandBuffer> commandBuffer = frameGpuEncoder->finish();
+    if (!commandBuffer.hasError()) {
+      gpu::Result<uint64_t> submitted =
+          device->adapterDevice().submit(std::move(commandBuffer).result());
+      if (submitted.hasError()) {
+        std::fprintf(stderr, "[Geode] replaying the frame's recorded draws failed: %s\n",
+                     submitted.error().message.c_str());
+        return false;
+      }
+    } else {
+      std::fprintf(stderr, "[Geode] closing the frame's recorded draws failed: %s\n",
+                   commandBuffer.error().message.c_str());
+      return false;
+    }
+    return openFrameGpuEncoder();
+  }
+
+  /// Re-point the runtime at the frame command encoder after code that may have replaced it.
+  ///
+  /// The filter engine finishes and submits the encoder in this slot mid-frame to bound
+  /// command-buffer size for large filter graphs. Anything the runtime replayed into the old
+  /// encoder is on the queue once that happens, and the runtime has to be told, because it holds
+  /// completion back until the encoder it replayed into reports its submit.
+  ///
+  /// @param before The encoder the slot held before the call that may have replaced it.
+  void rebindHostCommandEncoder(WGPUCommandEncoder before) {
+    if (static_cast<WGPUCommandEncoder>(frameCommandEncoder.get()) == before) {
+      return;
+    }
+    device->adapterDevice().notifyHostSubmitted();
+    device->adapterDevice().setHostCommandEncoder(frameCommandEncoder.get());
+  }
+
+  /// Close the runtime encoder after the frame command encoder it recorded into has been
+  /// submitted, so the runtime can retire the work it recorded.
+  void closeFrameGpuEncoderAfterSubmit() {
+    frameGpuEncoders.clear();
+    frameGpuEncoder = nullptr;
+    device->adapterDevice().notifyHostSubmitted();
+    device->adapterDevice().clearHostCommandEncoder();
+  }
+
   std::unique_ptr<geode::GeoEncoder> encoder;
   std::vector<std::unique_ptr<geode::GeoEncoder>> frameFinishedEncoders;
 
@@ -1366,6 +1508,10 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
       return;
     }
     encoder->finish();
+    // Replay before the encoder's recorded draws can outlive what they name: the resources a
+    // draw references stay alive only as long as whoever recorded it keeps them, and a
+    // subsequent encoder is free to re-upload over them.
+    (void)flushFrameGpuEncoder();
     retireFinishedEncoder(std::move(encoder));
   }
 
@@ -1400,6 +1546,9 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
   /// A completed pattern tile ready to be sampled as fill or stroke paint.
   struct PatternPaintSlot {
     geode::ScopedWgpuHandle<wgpu::Texture> tile;
+    /// Runtime alias for `tile`, owned by the frame's import list. Pattern slots do not outlive
+    /// the frame that recorded them, so this never outlives the alias it points at.
+    const gpu::Texture* tileHandle = nullptr;
     Vector2d rasterTileSize;
     Transform2d targetFromRaster;
   };
@@ -1625,12 +1774,16 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     }
 
     retireActiveEncoder();
+    if (!flushFrameGpuEncoder()) {
+      return false;
+    }
     geode::ScopedWgpuHandle<wgpu::CommandBuffer> commandBuffer(frameCommandEncoder.get().finish());
     if (!commandBuffer) {
       return false;
     }
     device->queue().submit(1, &commandBuffer.get());
     device->countSubmit();
+    closeFrameGpuEncoderAfterSubmit();
 
     frameFinishedEncoders.clear();
     framePendingTextureViewReleases.clear();
@@ -1642,8 +1795,12 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     if (!frameCommandEncoder) {
       return false;
     }
-    encoder = std::make_unique<geode::GeoEncoder>(
-        *device, *pipeline, *gradientPipeline, *imagePipeline, target, frameCommandEncoder.get());
+    if (!openFrameGpuEncoder()) {
+      return false;
+    }
+    encoder =
+        std::make_unique<geode::GeoEncoder>(*device, *pipeline, *gradientPipeline, *imagePipeline,
+                                            importTarget(target), targetExtent(), *frameGpuEncoder);
     configurePathEncoder(*encoder);
     encoder->setLoadPreserve();
     updateEncoderScissor();
@@ -1756,6 +1913,10 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     /// still reference them after `popClip`.
     std::vector<geode::ScopedWgpuHandle<wgpu::TextureView>> maskLayerViews;
     wgpu::TextureView maskResolveView;
+    /// Runtime aliases for `maskResolveTexture` / `maskResolveView`, owned by the frame's import
+    /// lists. Null exactly when `maskResolveView` is null.
+    const gpu::Texture* maskResolveTextureHandle = nullptr;
+    const gpu::TextureView* maskResolveViewHandle = nullptr;
     /// Paired (texture, descriptor) entries. Every clip-mask texture
     /// allocated by `pushClip` (across all nested layers) lives here
     /// until `popClip` hands them back to the texture pool.
@@ -1870,9 +2031,9 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     clipStack.clear();
 
     target = layerTexture;
-    auto newEncoder =
-        std::make_unique<geode::GeoEncoder>(*device, *pipeline, *gradientPipeline, *imagePipeline,
-                                            layerTexture, frameCommandEncoder.get());
+    auto newEncoder = std::make_unique<geode::GeoEncoder>(
+        *device, *pipeline, *gradientPipeline, *imagePipeline,
+        importTexture(layerTexture, textureDesc), extentOf(layerTexture), *frameGpuEncoder);
     configurePathEncoder(*newEncoder, /*collectGeometry=*/true, admission.bufferOffsetX,
                          admission.bufferOffsetY);
     newEncoder->clear(css::RGBA(0, 0, 0, 0));
@@ -1925,11 +2086,12 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
                                                                -geometry->paddedRegion.topLeft.y) *
                                         Transform2d::Scale(geometry->scaleX, geometry->scaleY);
     geode::GeoEncoder resampleEncoder(*device, *pipeline, *gradientPipeline, *imagePipeline,
-                                      localTexture, frameCommandEncoder.get());
+                                      importTexture(localTexture, localDesc),
+                                      extentOf(localTexture), *frameGpuEncoder);
     configureEncoder(resampleEncoder);
     resampleEncoder.setTransform(localFromDevice);
     resampleEncoder.drawTexture(
-        frame.layerTexture,
+        importTexture(frame.layerTexture, frame.layerDesc),
         Box2d::FromXYWH(0.0, 0.0, static_cast<double>(frame.layerDesc.size.width),
                         static_cast<double>(frame.layerDesc.size.height)),
         kWholeTextureUv, 1.0, /*pixelated=*/false, /*sourceIsPremultiplied=*/true);
@@ -1940,24 +2102,30 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     const Box2d localFilterRegion(Vector2d(geometry->blurPadding, geometry->blurPadding),
                                   Vector2d(geometry->blurPadding + frame.filterRegion.width(),
                                            geometry->blurPadding + frame.filterRegion.height()));
+    if (!flushFrameGpuEncoder()) {
+      return false;
+    }
+    const WGPUCommandEncoder encoderBeforeFilter =
+        static_cast<WGPUCommandEncoder>(frameCommandEncoder.get());
     wgpu::Texture localFiltered =
         filterEngine->execute(frame.filterGraph, localTexture, localFilterRegion,
                               localDeviceFromFilter, *this, frameCommandEncoder);
+    rebindHostCommandEncoder(encoderBeforeFilter);
 
     const Transform2d deviceFromLocal =
         Transform2d::Scale(1.0 / geometry->scaleX, 1.0 / geometry->scaleY) *
         Transform2d::Translate(geometry->paddedRegion.topLeft.x, geometry->paddedRegion.topLeft.y) *
         frame.deviceFromFilter;
     target = frame.savedTarget;
-    auto compositeEncoder =
-        std::make_unique<geode::GeoEncoder>(*device, *pipeline, *gradientPipeline, *imagePipeline,
-                                            frame.savedTarget, frameCommandEncoder.get());
+    auto compositeEncoder = std::make_unique<geode::GeoEncoder>(
+        *device, *pipeline, *gradientPipeline, *imagePipeline, importTarget(frame.savedTarget),
+        targetExtent(), *frameGpuEncoder);
     configurePathEncoder(*compositeEncoder);
     compositeEncoder->setLoadPreserve();
     encoder = std::move(compositeEncoder);
     updateEncoderScissor();
     encoder->setTransform(deviceFromLocal);
-    encoder->drawTexture(localFiltered,
+    encoder->drawTexture(importFilterResult(localFiltered),
                          Box2d::FromXYWH(0.0, 0.0, static_cast<double>(geometry->width),
                                          static_cast<double>(geometry->height)),
                          kWholeTextureUv, 1.0, /*pixelated=*/false, /*sourceIsPremultiplied=*/true);
@@ -2023,7 +2191,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
       // destroyed. The 1-arg setClipMask overload accidentally left the
       // view dangling across `popClip`→`pop_back`→destructor →
       // `updateEncoderScissor` sequences; see issue #551.
-      encoder->setClipMask(maskEntry->maskResolveTexture, maskEntry->maskResolveView);
+      encoder->setClipMask(*maskEntry->maskResolveTextureHandle, *maskEntry->maskResolveViewHandle);
     } else {
       encoder->clearClipMask();
     }
@@ -2083,7 +2251,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
   geode::GeoEncoder::PatternPaint buildPatternPaint(const PatternPaintSlot& slot,
                                                     double opacity) const {
     geode::GeoEncoder::PatternPaint p;
-    p.tile = slot.tile.get();
+    p.tile = slot.tileHandle;
     p.tileSize = slot.rasterTileSize;
     p.patternFromPath = slot.targetFromRaster.inverse();
     p.opacity = opacity;
@@ -2409,8 +2577,9 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
           .closePath();
     }
 
-    encoder = std::make_unique<geode::GeoEncoder>(
-        *device, *pipeline, *gradientPipeline, *imagePipeline, target, frameCommandEncoder.get());
+    encoder =
+        std::make_unique<geode::GeoEncoder>(*device, *pipeline, *gradientPipeline, *imagePipeline,
+                                            importTarget(target), targetExtent(), *frameGpuEncoder);
     configureEncoder(*encoder);
     encoder->setLoadPreserve();
     encoder->setTransform(Transform2d());
@@ -4183,6 +4352,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
       entry.maskLayerTextures.clear();
       entry.maskResolveTexture = wgpu::Texture();
       entry.maskResolveView = wgpu::TextureView();
+      entry.maskResolveTextureHandle = nullptr;
+      entry.maskResolveViewHandle = nullptr;
     }
     entries.clear();
   }
@@ -4301,8 +4472,10 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     wgpu::CommandEncoderDescriptor commandEncoderDesc = {};
     commandEncoderDesc.label = wgpuLabel("RendererGeodeFrameCE");
     frameCommandEncoder.reset(device->device().createCommandEncoder(commandEncoderDesc));
-    encoder = std::make_unique<geode::GeoEncoder>(
-        *device, *pipeline, *gradientPipeline, *imagePipeline, target, frameCommandEncoder.get());
+    UTILS_RELEASE_ASSERT_MSG(openFrameGpuEncoder(), "Failed to open the frame command encoder");
+    encoder =
+        std::make_unique<geode::GeoEncoder>(*device, *pipeline, *gradientPipeline, *imagePipeline,
+                                            importTarget(target), targetExtent(), *frameGpuEncoder);
     configurePathEncoder(*encoder);
     if (preserveTargetOnBeginFrame) {
       encoder->setLoadPreserve();
@@ -4359,6 +4532,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink,
     }
     patternFillPaint.reset();
     patternStrokePaint.reset();
+    frameImportedTextureViews.clear();
+    frameImportedTextures.clear();
 
     releaseTextureBacking(ownedTarget);
     ownedTarget.reset();
@@ -4786,14 +4961,21 @@ void RendererGeode::endFrame() {
   // this one submit, all recorded render passes (base + every pushed
   // layer / filter / mask) execute on the GPU in program order.
   if (impl_->frameCommandEncoder) {
+    UTILS_RELEASE_ASSERT_MSG(impl_->flushFrameGpuEncoder(),
+                             "Failed to replay the frame's recorded draws");
     {
       geode::ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(
           impl_->frameCommandEncoder.get().finish());
       impl_->device->queue().submit(1, &cmdBuf.get());
       impl_->device->countSubmit();
     }
+    impl_->closeFrameGpuEncoderAfterSubmit();
     impl_->frameCommandEncoder.reset();
     impl_->frameFinishedEncoders.clear();
+    // Every encoder that could still reach these aliases is gone, and the textures they name are
+    // about to be recycled, so drop them before any of them can be handed out again.
+    impl_->frameImportedTextureViews.clear();
+    impl_->frameImportedTextures.clear();
   }
 
   // The frame's work is submitted, so nothing it recorded can still be waiting
@@ -4960,10 +5142,16 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
     // because `updateEncoderScissor` only binds the topmost entry.
     wgpu::Texture nestedMaskTexture;
     wgpu::TextureView nestedMaskView;
+    // Runtime aliases tracking `nestedMaskTexture` / `nestedMaskView`, owned by the frame's
+    // import lists.
+    const gpu::Texture* nestedMaskTextureHandle = nullptr;
+    const gpu::TextureView* nestedMaskViewHandle = nullptr;
     for (auto rit = impl_->clipStack.rbegin(); rit != impl_->clipStack.rend(); ++rit) {
       if (rit->maskResolveView) {
         nestedMaskTexture = rit->maskResolveTexture;
         nestedMaskView = rit->maskResolveView;
+        nestedMaskTextureHandle = rit->maskResolveTextureHandle;
+        nestedMaskViewHandle = rit->maskResolveViewHandle;
         break;
       }
     }
@@ -4981,12 +5169,13 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
       // Bind the previously-rendered nested mask (if any) so this
       // layer's fragment shader samples it and intersects.
       if (nestedMaskView) {
-        impl_->encoder->setClipMask(nestedMaskTexture, nestedMaskView);
+        impl_->encoder->setClipMask(*nestedMaskTextureHandle, *nestedMaskViewHandle);
       } else {
         impl_->encoder->clearClipMask();
       }
 
-      impl_->encoder->beginMaskPass(maskTexture);
+      const gpu::Texture& maskTextureHandle = impl_->importTexture(maskTexture, maskDesc);
+      impl_->encoder->beginMaskPass(maskTextureHandle);
       for (size_t s = it->begin; s < it->end; ++s) {
         const ClipPathShape& shape = clip.clipPaths[s];
         const Transform2d composed =
@@ -4997,6 +5186,8 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
       impl_->encoder->endMaskPass();
 
       nestedMaskTexture = maskTexture;
+      nestedMaskTextureHandle = &maskTextureHandle;
+      nestedMaskViewHandle = &impl_->importTextureView(maskTextureHandle);
       geode::ScopedWgpuHandle<wgpu::TextureView> maskView(maskTexture.createView());
       nestedMaskView = maskView.get();
       if (maskView) {
@@ -5012,6 +5203,8 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
       // main draws sample as their clip.
       entry.maskResolveTexture = nestedMaskTexture;
       entry.maskResolveView = nestedMaskView;
+      entry.maskResolveTextureHandle = nestedMaskTextureHandle;
+      entry.maskResolveViewHandle = nestedMaskViewHandle;
     }
 
     // Clear the encoder's internal clip-mask state - the next main
@@ -5098,7 +5291,8 @@ void RendererGeode::pushIsolatedLayer(double opacity, MixBlendMode blendMode) {
   impl_->target = layerTexture;
   auto newEncoder = std::make_unique<geode::GeoEncoder>(
       *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
-      layerTexture, impl_->frameCommandEncoder.get());
+      impl_->importTexture(layerTexture, td), Impl::extentOf(layerTexture),
+      *impl_->frameGpuEncoder);
   impl_->configurePathEncoder(*newEncoder);
   newEncoder->clear(css::RGBA(0, 0, 0, 0));
   impl_->encoder = std::move(newEncoder);
@@ -5161,6 +5355,9 @@ void RendererGeode::popIsolatedLayer() {
       dst.texture = snapshot;
       const wgpu::Extent3D extent = {static_cast<uint32_t>(impl_->pixelWidth),
                                      static_cast<uint32_t>(impl_->pixelHeight), 1u};
+      // Everything recorded before this point has already been replayed into the frame command
+      // encoder by the encoder retire above, so the copy lands after those draws and before the
+      // composite recorded below.
       impl_->frameCommandEncoder.get().copyTextureToTexture(src, dst, extent);
 
       // Open a fresh parent encoder that PRESERVES the target's existing
@@ -5179,13 +5376,15 @@ void RendererGeode::popIsolatedLayer() {
       // safe.
       auto newEncoder = std::make_unique<geode::GeoEncoder>(
           *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
-          frame.savedTarget, impl_->frameCommandEncoder.get());
+          impl_->importTarget(frame.savedTarget), impl_->targetExtent(), *impl_->frameGpuEncoder);
       impl_->configurePathEncoder(*newEncoder);
       newEncoder->setLoadPreserve();
       impl_->encoder = std::move(newEncoder);
       impl_->updateEncoderScissor();
-      impl_->encoder->blitFullTargetBlended(frame.layerTexture, snapshot,
-                                            static_cast<uint32_t>(frame.blendMode), frame.opacity);
+      impl_->encoder->blitFullTargetBlended(
+          impl_->importTexture(frame.layerTexture, frame.layerDesc),
+          impl_->importTexture(snapshot, snapDesc), static_cast<uint32_t>(frame.blendMode),
+          frame.opacity);
       // Defer release: `blitFullTargetBlended` recorded samples from
       // both `frame.layerTexture` and `snapshot` into the shared
       // frameCommandEncoder; they must stay alive until that buffer
@@ -5203,12 +5402,13 @@ void RendererGeode::popIsolatedLayer() {
   // texture across the target with the stored opacity as compositing alpha.
   auto newEncoder = std::make_unique<geode::GeoEncoder>(
       *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
-      frame.savedTarget, impl_->frameCommandEncoder.get());
+      impl_->importTarget(frame.savedTarget), impl_->targetExtent(), *impl_->frameGpuEncoder);
   impl_->configurePathEncoder(*newEncoder);
   newEncoder->setLoadPreserve();
   impl_->encoder = std::move(newEncoder);
   impl_->updateEncoderScissor();
-  impl_->encoder->blitFullTarget(frame.layerTexture, frame.opacity);
+  impl_->encoder->blitFullTarget(impl_->importTexture(frame.layerTexture, frame.layerDesc),
+                                 frame.opacity);
   // Same deferred-release rationale as the blend-mode branch above.
   impl_->releaseTextureAtFrameEnd(std::move(frame.layerTexture), frame.layerDesc);
 }
@@ -5299,9 +5499,14 @@ void RendererGeode::popFilterLayer() {
   } else if (impl_->filterEngine && !frame.filterGraph.empty() &&
              static_cast<std::uint64_t>(frame.layerDesc.size.width) * frame.layerDesc.size.height <=
                  components::kMaximumFilterSurfacePixels) {
+    UTILS_RELEASE_ASSERT_MSG(impl_->flushFrameGpuEncoder(),
+                             "Failed to replay recorded draws before the filter passes");
+    const WGPUCommandEncoder encoderBeforeFilter =
+        static_cast<WGPUCommandEncoder>(impl_->frameCommandEncoder.get());
     filteredTexture =
         impl_->filterEngine->execute(frame.filterGraph, frame.layerTexture, frame.filterRegion,
                                      bufferDeviceFromFilter, *impl_, impl_->frameCommandEncoder);
+    impl_->rebindHostCommandEncoder(encoderBeforeFilter);
   }
 
   // Restore outer target and create a fresh encoder that preserves its
@@ -5310,7 +5515,7 @@ void RendererGeode::popFilterLayer() {
   impl_->target = frame.savedTarget;
   auto newEncoder = std::make_unique<geode::GeoEncoder>(
       *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
-      frame.savedTarget, impl_->frameCommandEncoder.get());
+      impl_->importTarget(frame.savedTarget), impl_->targetExtent(), *impl_->frameGpuEncoder);
   impl_->configurePathEncoder(*newEncoder);
   newEncoder->setLoadPreserve();
   impl_->encoder = std::move(newEncoder);
@@ -5344,9 +5549,12 @@ void RendererGeode::popFilterLayer() {
       wgpu::TexelCopyTextureInfo dst = {};
       dst.texture = viewportTexture;
       const wgpu::Extent3D extent = {vpW, vpH, 1u};
+      // Everything recorded before this point has already been replayed into the frame command
+      // encoder by the encoder retire above, so the copy lands after those draws and before the
+      // composite recorded below.
       impl_->frameCommandEncoder.get().copyTextureToTexture(src, dst, extent);
 
-      impl_->encoder->blitFullTarget(viewportTexture, 1.0);
+      impl_->encoder->blitFullTarget(impl_->importTexture(viewportTexture, vpDesc), 1.0);
       impl_->releaseTextureAtFrameEnd(std::move(viewportTexture), vpDesc);
     }
   } else {
@@ -5355,7 +5563,7 @@ void RendererGeode::popFilterLayer() {
     // coordinates, not pixel-space; we'd need to transform by the current
     // CTM snapshot before using it as a scissor. Skipping for this PR -
     // all current feGaussianBlur resvg tests pass without the clip.
-    impl_->encoder->blitFullTarget(filteredTexture, 1.0);
+    impl_->encoder->blitFullTarget(impl_->importFilterResult(filteredTexture), 1.0);
   }
   // Defer release to endFrame: `blitFullTarget` recorded a sample from
   // `filteredTexture` (which is `frame.layerTexture` when the filter
@@ -5412,7 +5620,8 @@ void RendererGeode::pushMask(const std::optional<Box2d>& maskBounds, MaskType ma
   impl_->target = frame.maskTexture;
   auto captureEncoder = std::make_unique<geode::GeoEncoder>(
       *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
-      frame.maskTexture, impl_->frameCommandEncoder.get());
+      impl_->importTexture(frame.maskTexture, frame.maskDesc), Impl::extentOf(frame.maskTexture),
+      *impl_->frameGpuEncoder);
   impl_->configurePathEncoder(*captureEncoder);
   captureEncoder->clear(css::RGBA(0, 0, 0, 0));
   impl_->encoder = std::move(captureEncoder);
@@ -5441,7 +5650,8 @@ void RendererGeode::transitionMaskToContent() {
   impl_->target = frame.contentTexture;
   auto contentEncoder = std::make_unique<geode::GeoEncoder>(
       *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
-      frame.contentTexture, impl_->frameCommandEncoder.get());
+      impl_->importTexture(frame.contentTexture, frame.contentDesc),
+      Impl::extentOf(frame.contentTexture), *impl_->frameGpuEncoder);
   impl_->configurePathEncoder(*contentEncoder);
   contentEncoder->clear(css::RGBA(0, 0, 0, 0));
   impl_->encoder = std::move(contentEncoder);
@@ -5472,7 +5682,7 @@ void RendererGeode::popMask() {
   impl_->target = frame.savedTarget;
   auto newEncoder = std::make_unique<geode::GeoEncoder>(
       *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
-      frame.savedTarget, impl_->frameCommandEncoder.get());
+      impl_->importTarget(frame.savedTarget), impl_->targetExtent(), *impl_->frameGpuEncoder);
   impl_->configurePathEncoder(*newEncoder);
   newEncoder->setLoadPreserve();
   impl_->encoder = std::move(newEncoder);
@@ -5490,8 +5700,9 @@ void RendererGeode::popMask() {
   }
 
   // Composite content through the selected luminance or alpha mask onto the outer target.
-  impl_->encoder->blitFullTargetMasked(frame.contentTexture, frame.maskTexture, frame.maskType,
-                                       pixelMaskBounds);
+  impl_->encoder->blitFullTargetMasked(
+      impl_->importTexture(frame.contentTexture, frame.contentDesc),
+      impl_->importTexture(frame.maskTexture, frame.maskDesc), frame.maskType, pixelMaskBounds);
 
   // Defer release to endFrame - `blitFullTargetMasked` recorded
   // samples from both `contentTexture` and `maskTexture` into the
@@ -5604,7 +5815,8 @@ bool RendererGeode::beginPatternTile(const Box2d& tileRect, const Transform2d& t
 
   auto newEncoder = std::make_unique<geode::GeoEncoder>(
       *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
-      tileTextureHandle, impl_->frameCommandEncoder.get());
+      impl_->importTexture(tileTextureHandle, td), Impl::extentOf(tileTextureHandle),
+      *impl_->frameGpuEncoder);
   impl_->configurePathEncoder(*newEncoder, /*collectGeometry=*/false);
   // Transparent clear so unpainted tile pixels contribute nothing.
   newEncoder->clear(css::RGBA(0, 0, 0, 0));
@@ -5670,7 +5882,7 @@ void RendererGeode::endPatternTile(bool forStroke) {
       frame.savedTarget) {
     auto newEncoder = std::make_unique<geode::GeoEncoder>(
         *impl_->device, *impl_->pipeline, *impl_->gradientPipeline, *impl_->imagePipeline,
-        frame.savedTarget, impl_->frameCommandEncoder.get());
+        impl_->importTarget(frame.savedTarget), impl_->targetExtent(), *impl_->frameGpuEncoder);
     impl_->configurePathEncoder(*newEncoder);
     // Preserve existing target contents: the pattern subtree may have
     // submitted work on the outer target *before* the pattern tile opened
@@ -5695,6 +5907,10 @@ void RendererGeode::endPatternTile(bool forStroke) {
   // Stash the completed tile in raster-pixel space, matching the texture sampled by the shader.
   Impl::PatternPaintSlot slot;
   slot.tile = std::move(frame.tileTexture);
+  slot.tileHandle =
+      &impl_->importTexture(slot.tile.get(), impl_->textureFormat,
+                            wgpu::TextureUsage::RenderAttachment |
+                                wgpu::TextureUsage::TextureBinding | wgpu::TextureUsage::CopySrc);
   slot.rasterTileSize = Vector2d(frame.tilePixelWidth, frame.tilePixelHeight);
   slot.targetFromRaster = TargetFromPatternRaster(frame.targetFromPattern, frame.rasterScale);
 
@@ -6048,8 +6264,11 @@ bool RendererGeode::drawTextureSnapshot(const RendererTextureSnapshot& texture,
                                                   static_cast<double>(textureHeight))));
 
   impl_->syncTransform();
-  impl_->encoder->drawTexture(geodeTexture->texture(), targetRect, sourceUv, opacity, pixelated,
-                              geodeTexture->alphaType() == AlphaType::Premultiplied);
+  impl_->encoder->drawTexture(
+      impl_->importTexture(geodeTexture->texture(), geodeTexture->format(),
+                           wgpu::TextureUsage::TextureBinding | wgpu::TextureUsage::CopyDst),
+      targetRect, sourceUv, opacity, pixelated,
+      geodeTexture->alphaType() == AlphaType::Premultiplied);
   return true;
 }
 

--- a/donner/svg/renderer/geode/BUILD.bazel
+++ b/donner/svg/renderer/geode/BUILD.bazel
@@ -284,6 +284,7 @@ donner_cc_library(
         "GeodeCheckerboardPipeline.h",
         "GeodeDevice.h",
         "GeodeFilterEngine.h",
+        "GeodeGpuContext.h",
         "GeodeImagePipeline.h",
         "GeodePipeline.h",
         "GeodeWgpuAdapterDevice.h",

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -6,6 +6,7 @@
 #include <optional>
 #include <vector>
 
+#include "donner/gpu/Device.h"
 #include "donner/svg/renderer/PixelFormatUtils.h"
 #include "donner/svg/renderer/geode/GeodeBufferPool.h"
 #include "donner/svg/renderer/geode/GeodeDevice.h"
@@ -15,7 +16,6 @@
 #include "donner/svg/renderer/geode/GeodePipeline.h"
 #include "donner/svg/renderer/geode/GeodeResidentPathComponent.h"
 #include "donner/svg/renderer/geode/GeodeTextureEncoder.h"
-#include "donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h"
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 #include "donner/svg/resources/ImageResource.h"
 
@@ -426,13 +426,6 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   GeodeDevice* device;
   /// The GPU runtime context this encoder records against; the device's, wired in `initImpl`.
   const GeodeGpuContext* gpuContext = nullptr;
-
-  /// Resolves the wgpu buffer behind an arena allocation, for the bind groups this encoder still
-  /// builds through wgpu.
-  /// @param buffer Runtime buffer reference.
-  wgpu::Buffer wgpuBufferOf(const gpu::BufferRef& buffer) const {
-    return device->adapterDevice().wgpuBufferOf(buffer);
-  }
   const GeodePipeline* pipeline;
   const GeodeGradientPipeline* gradientPipeline;
   const GeodeImagePipeline* imagePipeline;
@@ -444,7 +437,7 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   GeodeTextureEncoder::UniformAllocation allocate(const void* data, uint64_t size,
                                                   uint64_t alignment) override {
     const Allocation alloc = allocInArena(uniformArena, data, size, alignment);
-    return {wgpuBufferOf(alloc.buffer), alloc.offset, alloc.size};
+    return {alloc.buffer, alloc.offset, alloc.size};
   }
 
   /// Per-encoder growable GPU buffer used as a bump-allocation arena
@@ -513,8 +506,8 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   }
 
   void releaseOwnedResources() {
-    pass.reset();
-    maskPass.reset();
+    pass = nullptr;
+    maskPass = nullptr;
 
     releaseArenaResources(bandArena);
     releaseArenaResources(curveArena);
@@ -524,7 +517,7 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
     releaseArenaResources(gridArena);
 
     releaseArenaResources(instanceRecordArena);
-    transientResources.releaseAll();
+    transientResources.clear();
   }
 
   // When true, this encoder owns its `commandEncoder` and `finish()`
@@ -679,6 +672,83 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
     return {arena.buffer, alignedOffset, size, arena.bufferId};
   }
 
+  /// Look up, or build, the bind group a scene batch draws with.
+  ///
+  /// A cacheable key is one whose every buffer has a stable identity, so a hit really names the
+  /// same buffers; the device's cache owns those groups across frames. A group that cannot be
+  /// keyed goes to the per-frame arena instead of being cached, so it is released at the frame
+  /// boundary rather than matched by a later batch.
+  ///
+  /// @param cacheKey Identity of the batch's bindings.
+  /// @param cacheable Whether every buffer in the key has a stable identity.
+  /// @param entries Bind group entries to create the group from on a miss.
+  /// @return The bind group, or null when creation failed.
+  const gpu::BindGroup* resolveSceneBatchBindGroup(
+      const GeodeDevice::SceneBatchBindGroupKey& cacheKey, bool cacheable,
+      std::vector<gpu::BindGroupEntry> entries) {
+    if (cacheable) {
+      if (const gpu::BindGroup* cached = device->findSceneBatchBindGroup(cacheKey)) {
+        return cached;
+      }
+    }
+
+    gpu::Result<gpu::BindGroup> created =
+        gpuContext->gpuDevice->createBindGroup(gpu::BindGroupDescriptor{
+            "GeodeSceneBatchBindGroup", pipeline->bindGroupLayout(), std::move(entries)});
+    if (created.hasError()) {
+      return nullptr;
+    }
+    if (cacheable) {
+      // The cache takes ownership of the handle.
+      return &device->storeSceneBatchBindGroup(cacheKey, std::move(created).result());
+    }
+    // Defensive only: every buffer that can reach this call is stamped at creation, so no live
+    // path produces a zero id today. Hand the handle to the encoder's per-frame arena so that if
+    // one ever does, the bind group is released at the frame boundary instead of leaking.
+    return &transientResources.retain(std::move(created).result());
+  }
+
+  /// Pack one instance record per instanced draw into the per-frame record arena.
+  ///
+  /// Each instance's own affine replaces the shared record's transform, composed with the
+  /// orthographic target mapping the shader expects. Returns an empty allocation when the packed
+  /// transform span does not carry exactly eight floats per instance, which leaves the caller on
+  /// the shared identity record.
+  ///
+  /// @param record Record shared by every instance, supplying everything but the transform.
+  /// @param instanceCount Number of instances in the draw.
+  /// @param instanceTransforms Packed per-instance affines, eight floats each.
+  Allocation packInstanceRecords(const InstanceRecord& record, uint32_t instanceCount,
+                                 std::span<const float> instanceTransforms) {
+    const size_t packedCount = static_cast<size_t>(instanceCount) * 8u;
+    if (instanceTransforms.size() != packedCount) {
+      return Allocation{};
+    }
+
+    std::vector<InstanceRecord> records(instanceCount, record);
+    for (uint32_t i = 0; i < instanceCount; ++i) {
+      Transform2d t;
+      t.data[0] = instanceTransforms[i * 8u + 0u];
+      t.data[1] = instanceTransforms[i * 8u + 4u];
+      t.data[2] = instanceTransforms[i * 8u + 1u];
+      t.data[3] = instanceTransforms[i * 8u + 5u];
+      t.data[4] = instanceTransforms[i * 8u + 2u];
+      t.data[5] = instanceTransforms[i * 8u + 6u];
+      const Transform2d composed = composeOrthographicMvp(targetWidth, targetHeight, t);
+      InstanceRecord& rec = records[i];
+      rec.transformRow0[0] = static_cast<float>(composed.data[0]);
+      rec.transformRow0[1] = static_cast<float>(composed.data[2]);
+      rec.transformRow0[2] = static_cast<float>(composed.data[4]);
+      rec.transformRow0[3] = 0.0f;
+      rec.transformRow1[0] = static_cast<float>(composed.data[1]);
+      rec.transformRow1[1] = static_cast<float>(composed.data[3]);
+      rec.transformRow1[2] = static_cast<float>(composed.data[5]);
+      rec.transformRow1[3] = 0.0f;
+    }
+    const uint64_t recordBytes = static_cast<size_t>(instanceCount) * sizeof(InstanceRecord);
+    return allocInArena(instanceRecordArena, records.data(), recordBytes, kStorageOffsetAlignment);
+  }
+
   /// Allocate a read-only storage binding for `byteCount` bytes of `data`,
   /// rounding the size up to a multiple of 4. When `byteCount == 0` (a
   /// degenerate axis with no vertical band data, or an empty grid) a zeroed
@@ -829,8 +899,6 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
     u.gridVBandCount = encoded.vBandCount;
     writeBoundingPolygonUniforms(u, encoded);
 
-    const wgpu::Device& dev = device->device();
-
     const auto bandsAlloc = allocStorageOrDummy(bandArena, encoded.bands.data(),
                                                 encoded.bands.size() * sizeof(EncodedPath::Band));
     const auto curvesAlloc = allocStorageOrDummy(curveArena, encoded.curves.data(),
@@ -851,72 +919,51 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
     const auto uniAlloc =
         allocInArena(uniformArena, &u, sizeof(GradientUniforms), kUniformOffsetAlignment);
 
-    wgpu::BindGroupEntry entries[11] = {};
-    entries[0].binding = 0;
-    entries[0].buffer = wgpuBufferOf(uniAlloc.buffer);
-    entries[0].offset = uniAlloc.offset;
-    entries[0].size = uniAlloc.size;
-    entries[1].binding = 1;
-    entries[1].buffer = wgpuBufferOf(bandsAlloc.buffer);
-    entries[1].offset = bandsAlloc.offset;
-    entries[1].size = bandsAlloc.size;
-    entries[2].binding = 2;
-    entries[2].buffer = wgpuBufferOf(curvesAlloc.buffer);
-    entries[2].offset = curvesAlloc.offset;
-    entries[2].size = curvesAlloc.size;
-    entries[3].binding = 3;
-    entries[3].textureView = currentClipMaskView();
-    entries[4].binding = 4;
-    entries[4].sampler = device->dummyClipMaskSampler();
-    entries[5].binding = 5;
-    entries[5].buffer = wgpuBufferOf(vBandsAlloc.buffer);
-    entries[5].offset = vBandsAlloc.offset;
-    entries[5].size = vBandsAlloc.size;
-    entries[6].binding = 6;
-    entries[6].buffer = wgpuBufferOf(vCurvesAlloc.buffer);
-    entries[6].offset = vCurvesAlloc.offset;
-    entries[6].size = vCurvesAlloc.size;
-    entries[7].binding = 7;
-    entries[7].buffer = wgpuBufferOf(hGridAlloc.buffer);
-    entries[7].offset = hGridAlloc.offset;
-    entries[7].size = hGridAlloc.size;
-    entries[8].binding = 8;
-    entries[8].buffer = wgpuBufferOf(vGridAlloc.buffer);
-    entries[8].offset = vGridAlloc.offset;
-    entries[8].size = vGridAlloc.size;
-    entries[9].binding = 9;
-    entries[9].buffer = wgpuBufferOf(hRefsAlloc.buffer);
-    entries[9].offset = hRefsAlloc.offset;
-    entries[9].size = hRefsAlloc.size;
-    entries[10].binding = 10;
-    entries[10].buffer = wgpuBufferOf(vRefsAlloc.buffer);
-    entries[10].offset = vRefsAlloc.offset;
-    entries[10].size = vRefsAlloc.size;
-
-    wgpu::BindGroupDescriptor bgDesc = {};
-    bgDesc.label = wgpuLabel("GeodeGradientBindGroup");
-    bgDesc.layout = gradientPipeline->bindGroupLayout();
-    bgDesc.entryCount = 11;
-    bgDesc.entries = entries;
-    wgpu::BindGroup bindGroup = transientResources.retain(dev.createBindGroup(bgDesc));
-    device->countBindGroup();
+    gpu::Result<gpu::BindGroup> bindGroupResult =
+        gpuContext->gpuDevice->createBindGroup(gpu::BindGroupDescriptor{
+            "GeodeGradientBindGroup",
+            gradientPipeline->bindGroupLayout(),
+            {gpu::BindGroupEntry{
+                 0, gpu::BufferBinding{uniAlloc.buffer, uniAlloc.offset, uniAlloc.size}},
+             gpu::BindGroupEntry{
+                 1, gpu::BufferBinding{bandsAlloc.buffer, bandsAlloc.offset, bandsAlloc.size}},
+             gpu::BindGroupEntry{
+                 2, gpu::BufferBinding{curvesAlloc.buffer, curvesAlloc.offset, curvesAlloc.size}},
+             gpu::BindGroupEntry{3, gpu::TextureViewBinding{currentClipMaskView()}},
+             gpu::BindGroupEntry{4, gpu::SamplerBinding{*gpuContext->dummyClipMaskSampler}},
+             gpu::BindGroupEntry{
+                 5, gpu::BufferBinding{vBandsAlloc.buffer, vBandsAlloc.offset, vBandsAlloc.size}},
+             gpu::BindGroupEntry{6, gpu::BufferBinding{vCurvesAlloc.buffer, vCurvesAlloc.offset,
+                                                       vCurvesAlloc.size}},
+             gpu::BindGroupEntry{
+                 7, gpu::BufferBinding{hGridAlloc.buffer, hGridAlloc.offset, hGridAlloc.size}},
+             gpu::BindGroupEntry{
+                 8, gpu::BufferBinding{vGridAlloc.buffer, vGridAlloc.offset, vGridAlloc.size}},
+             gpu::BindGroupEntry{
+                 9, gpu::BufferBinding{hRefsAlloc.buffer, hRefsAlloc.offset, hRefsAlloc.size}},
+             gpu::BindGroupEntry{
+                 10, gpu::BufferBinding{vRefsAlloc.buffer, vRefsAlloc.offset, vRefsAlloc.size}}}});
+    if (bindGroupResult.hasError()) {
+      return;
+    }
+    const gpu::BindGroup& bindGroup =
+        transientResources.retain(std::move(bindGroupResult).result());
 
     recordGeometryDebugDraw(encoded);
-    pass.get().setBindGroup(0, bindGroup, 0, nullptr);
-    pass.get().draw(encoded.boundingDrawVertexCount(), 1, 0, 0);
-    device->countDraw();
+    (void)pass->setBindGroup(0, bindGroup);
+    (void)pass->draw(encoded.boundingDrawVertexCount(), 1, 0, 0);
   }
-  // Direct-render texture. External code may sample or copy from it.
-  wgpu::Texture target;
-  ScopedWgpuHandle<wgpu::TextureView> targetView;
-  ScopedWgpuHandle<wgpu::CommandEncoder> ownedCommandEncoder;
-  wgpu::CommandEncoder commandEncoder;
+  // Direct-render texture, owned by the caller. External code may sample or copy from it.
+  const gpu::Texture* target = nullptr;
+  gpu::TextureView targetView;
+  std::unique_ptr<gpu::CommandEncoder> ownedCommandEncoder;
+  gpu::CommandEncoder* commandEncoder = nullptr;
   uint32_t targetWidth;
   uint32_t targetHeight;
   // Dummy texture / sampler resources are now owned by `GeodeDevice`
   // and shared across every GeoEncoder - see
   // `GeodeDevice::dummyPatternTexture()`. Access them via
-  // `device->dummyPatternTextureView()`, etc. The bind-group layout
+  // `*gpuContext->dummyPatternTextureView`, etc. The bind-group layout
   // always includes the pattern + clip-mask slots so the pipeline can
   // be shared between solid/pattern/gradient/masked draws; the device
   // dummies fill the unused slots.
@@ -936,8 +983,8 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   // a stale `VkImageView` handle to the Vulkan driver, tripping
   // lvp's `vk_object_base_assert_valid` on debug Mesa and corrupting
   // the heap on release Mesa - see issue #551.
-  wgpu::Texture activeClipMaskTexture;
-  wgpu::TextureView activeClipMaskView;
+  gpu::TextureRef activeClipMaskTexture;
+  const gpu::TextureView* activeClipMaskView = nullptr;
 
   // Non-owning pointer to the device's shared `GeodeMaskPipeline`.
   // Built on demand via `GeodeDevice::maskPipeline()` the first time
@@ -954,7 +1001,7 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   // so main-pass draw code picks back up exactly where it left off
   // when the mask pass ends.
   bool maskPassOpen = false;
-  ScopedWgpuHandle<wgpu::RenderPassEncoder> maskPass;
+  gpu::RenderPassEncoder* maskPass = nullptr;
   // Transform active when the mask pass was opened, so mask draws use
   // the same device-pixel space as the parent content. The mask pass
   // always renders into the mask texture the caller passed in, which
@@ -964,15 +1011,15 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   // Pending draws are recorded into a render pass that's lazily opened.
   // The first clear/fill triggers `beginPass()`; finish() ends it.
   bool passOpen = false;
-  ScopedWgpuHandle<wgpu::RenderPassEncoder> pass;
+  gpu::RenderPassEncoder* pass = nullptr;
 
   // Per-encoder resources created while recording draw calls. They are
   // released together when the encoder is destroyed, after `finish()` has
   // ended the open pass and submitted the command buffer in owning mode.
-  ScopedWgpuResourceArena transientResources;
+  GeodeTransientResources transientResources;
 
   // Default load op = clear-to-transparent until clear() is called explicitly.
-  wgpu::Color clearColor = {0.0, 0.0, 0.0, 0.0};
+  std::array<double, 4> clearColor = {0.0, 0.0, 0.0, 0.0};
   bool hasExplicitClear = false;
   // When true, the next render pass uses LoadOp::Load so previously
   // submitted content is preserved. Set via `setLoadPreserve()`.
@@ -1151,9 +1198,9 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
       uint32_t w = 0;
       uint32_t h = 0;
       clampedScissor(x, y, w, h);
-      pass.get().setScissorRect(x, y, w, h);
+      (void)pass->setScissorRect(x, y, w, h);
     } else {
-      pass.get().setScissorRect(0, 0, targetWidth, targetHeight);
+      (void)pass->setScissorRect(0, 0, targetWidth, targetHeight);
     }
   }
 
@@ -1161,11 +1208,11 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   /// slot for the next draw - the active mask if set, or the device's
   /// shared identity-mask dummy otherwise (see
   /// `GeodeDevice::dummyClipMaskTextureView()`).
-  const wgpu::TextureView& currentClipMaskView() {
-    if (activeClipMaskView) {
-      return activeClipMaskView;
+  gpu::TextureViewRef currentClipMaskView() {
+    if (activeClipMaskView != nullptr) {
+      return *activeClipMaskView;
     }
-    return device->dummyClipMaskTextureView();
+    return *gpuContext->dummyClipMaskTextureView;
   }
 
   /// Open the render pass on demand.
@@ -1173,23 +1220,16 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
     if (passOpen) {
       return;
     }
-    wgpu::RenderPassColorAttachment color = {};
-
-    color.view = targetView.get();
-    color.loadOp = loadPreserve ? wgpu::LoadOp::Load : wgpu::LoadOp::Clear;
-    color.storeOp = wgpu::StoreOp::Store;
-    color.clearValue = clearColor;
-    // Dawn (browser WebGPU) rejects depthSlice=0 on non-3D views with
-    // "Depth slice was provided but the color attachment's view is not
-    // 3D". wgpu-native is lenient. Set the UNDEFINED sentinel for
-    // cross-backend compatibility.
-    color.depthSlice = WGPU_DEPTH_SLICE_UNDEFINED;
-
-    wgpu::RenderPassDescriptor desc = {};
-    desc.colorAttachmentCount = 1;
-    desc.colorAttachments = &color;
-    desc.label = wgpuLabel("GeoEncoderPass");
-    pass.reset(commandEncoder.beginRenderPass(desc));
+    gpu::Result<gpu::RenderPassEncoder*> opened =
+        commandEncoder->beginRenderPass(gpu::RenderPassDescriptor{
+            "GeoEncoderPass",
+            {gpu::RenderPassColorAttachment{targetView,
+                                            loadPreserve ? gpu::LoadOp::Load : gpu::LoadOp::Clear,
+                                            gpu::StoreOp::Store, clearColor}}});
+    if (opened.hasError()) {
+      return;
+    }
+    pass = opened.result();
     // Pipelines are set per-draw - `fillPath` / `fillPathLinearGradient` /
     // `drawImage` each rebind their own pipeline before issuing a draw call.
     // Re-binding only happens when the bound pipeline differs from the next
@@ -1213,7 +1253,7 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   bool currentPipelineIsGradient = false;
   void bindSolidPipeline() {
     if (currentPipeline != BoundPipeline::kSolid) {
-      pass.get().setPipeline(pipeline->pipeline());
+      (void)pass->setPipeline(pipeline->pipeline());
       device->countPipelineSwitch();
       currentPipeline = BoundPipeline::kSolid;
       currentPipelineIsGradient = false;
@@ -1226,7 +1266,7 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   /// pipeline object is created on first use.
   void bindSolidBatchedPipeline() {
     if (currentPipeline != BoundPipeline::kSolidBatched) {
-      pass.get().setPipeline(pipeline->batchedPipeline());
+      (void)pass->setPipeline(pipeline->batchedPipeline());
       device->countPipelineSwitch();
       currentPipeline = BoundPipeline::kSolidBatched;
       currentPipelineIsGradient = false;
@@ -1234,15 +1274,15 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   }
   void bindGradientPipeline() {
     if (currentPipeline != BoundPipeline::kGradient) {
-      pass.get().setPipeline(gradientPipeline->pipeline());
+      (void)pass->setPipeline(gradientPipeline->pipeline());
       device->countPipelineSwitch();
       currentPipeline = BoundPipeline::kGradient;
       currentPipelineIsGradient = true;
     }
   }
-  void bindImagePipeline(const wgpu::RenderPipeline& imageRenderPipeline) {
+  void bindImagePipeline(const gpu::RenderPipeline& imageRenderPipeline) {
     if (currentPipeline != BoundPipeline::kImage) {
-      pass.get().setPipeline(imageRenderPipeline);
+      (void)pass->setPipeline(imageRenderPipeline);
       device->countPipelineSwitch();
       currentPipeline = BoundPipeline::kImage;
       currentPipelineIsGradient = false;
@@ -1311,16 +1351,21 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
 void GeoEncoder::initImpl(GeoEncoder::Impl& impl, GeodeDevice& device,
                           const GeodePipeline& fillPipeline,
                           const GeodeGradientPipeline& gradientPipeline,
-                          const GeodeImagePipeline& imagePipeline, const wgpu::Texture& target) {
+                          const GeodeImagePipeline& imagePipeline, const gpu::Texture& target,
+                          const gpu::Extent2d& targetSize) {
   impl.device = &device;
   impl.gpuContext = &device.gpuContext();
   impl.pipeline = &fillPipeline;
   impl.gradientPipeline = &gradientPipeline;
   impl.imagePipeline = &imagePipeline;
-  impl.target = target;
-  impl.targetView.reset(target.createView());
-  impl.targetWidth = target.getWidth();
-  impl.targetHeight = target.getHeight();
+  impl.target = &target;
+  gpu::Result<gpu::TextureView> view = impl.gpuContext->gpuDevice->createTextureView(
+      target, gpu::TextureViewDescriptor{"GeoEncoderTargetView"});
+  if (!view.hasError()) {
+    impl.targetView = std::move(view).result();
+  }
+  impl.targetWidth = targetSize.width;
+  impl.targetHeight = targetSize.height;
 }
 
 // Post-init: configure per-draw arenas. Runs once `commandEncoder`
@@ -1351,14 +1396,17 @@ void GeoEncoder::finalizeImpl(GeoEncoder::Impl& impl) {
 
 GeoEncoder::GeoEncoder(GeodeDevice& device, const GeodePipeline& fillPipeline,
                        const GeodeGradientPipeline& gradientPipeline,
-                       const GeodeImagePipeline& imagePipeline, const wgpu::Texture& target)
+                       const GeodeImagePipeline& imagePipeline, const gpu::Texture& target,
+                       const gpu::Extent2d& targetSize)
     : impl_(std::make_unique<Impl>()) {
-  initImpl(*impl_, device, fillPipeline, gradientPipeline, imagePipeline, target);
+  initImpl(*impl_, device, fillPipeline, gradientPipeline, imagePipeline, target, targetSize);
 
-  wgpu::CommandEncoderDescriptor desc = {};
-  desc.label = wgpuLabel("GeoEncoder");
-  impl_->ownedCommandEncoder.reset(device.device().createCommandEncoder(desc));
-  impl_->commandEncoder = impl_->ownedCommandEncoder.get();
+  gpu::Result<std::unique_ptr<gpu::CommandEncoder>> encoder =
+      impl_->gpuContext->gpuDevice->createCommandEncoder();
+  if (!encoder.hasError()) {
+    impl_->ownedCommandEncoder = std::move(encoder).result();
+    impl_->commandEncoder = impl_->ownedCommandEncoder.get();
+  }
   impl_->ownsCommandEncoder = true;
 
   finalizeImpl(*impl_);
@@ -1366,11 +1414,11 @@ GeoEncoder::GeoEncoder(GeodeDevice& device, const GeodePipeline& fillPipeline,
 
 GeoEncoder::GeoEncoder(GeodeDevice& device, const GeodePipeline& fillPipeline,
                        const GeodeGradientPipeline& gradientPipeline,
-                       const GeodeImagePipeline& imagePipeline, const wgpu::Texture& target,
-                       wgpu::CommandEncoder sharedCommandEncoder)
+                       const GeodeImagePipeline& imagePipeline, const gpu::Texture& target,
+                       const gpu::Extent2d& targetSize, gpu::CommandEncoder& sharedCommandEncoder)
     : impl_(std::make_unique<Impl>()) {
-  initImpl(*impl_, device, fillPipeline, gradientPipeline, imagePipeline, target);
-  impl_->commandEncoder = std::move(sharedCommandEncoder);
+  initImpl(*impl_, device, fillPipeline, gradientPipeline, imagePipeline, target, targetSize);
+  impl_->commandEncoder = &sharedCommandEncoder;
   impl_->ownsCommandEncoder = false;
   finalizeImpl(*impl_);
 }
@@ -1397,10 +1445,8 @@ void GeoEncoder::clear(const css::RGBA& color) {
   // texture contents are premultiplied throughout. Clearing with a straight-
   // alpha value would break that invariant for any semi-transparent clear.
   const double alpha = color.a / 255.0;
-  impl_->clearColor.r = (color.r / 255.0) * alpha;
-  impl_->clearColor.g = (color.g / 255.0) * alpha;
-  impl_->clearColor.b = (color.b / 255.0) * alpha;
-  impl_->clearColor.a = alpha;
+  impl_->clearColor = {(color.r / 255.0) * alpha, (color.g / 255.0) * alpha,
+                       (color.b / 255.0) * alpha, alpha};
   impl_->hasExplicitClear = true;
 }
 
@@ -1493,8 +1539,8 @@ void GeoEncoder::clearClipPolygon() {
 // Clip mask pass
 // ============================================================================
 
-void GeoEncoder::beginMaskPass(const wgpu::Texture& mask) {
-  if (!mask) {
+void GeoEncoder::beginMaskPass(const gpu::Texture& mask) {
+  if (!mask.isValid()) {
     return;
   }
 
@@ -1506,8 +1552,8 @@ void GeoEncoder::beginMaskPass(const wgpu::Texture& mask) {
   // run on the next open.
   const bool mainPassWasOpen = impl_->passOpen;
   if (mainPassWasOpen) {
-    impl_->pass.get().end();
-    impl_->pass.reset();
+    (void)impl_->pass->end();
+    impl_->pass = nullptr;
     impl_->passOpen = false;
     impl_->loadPreserve = true;
   }
@@ -1520,26 +1566,28 @@ void GeoEncoder::beginMaskPass(const wgpu::Texture& mask) {
 
   impl_->maskPassSavedTransform = impl_->transform;
 
-  wgpu::TextureView maskView = impl_->transientResources.retain(mask.createView());
+  gpu::Result<gpu::TextureView> maskViewResult = impl_->gpuContext->gpuDevice->createTextureView(
+      mask, gpu::TextureViewDescriptor{"GeoEncoderMaskView"});
+  if (maskViewResult.hasError()) {
+    return;
+  }
+  const gpu::TextureView& maskView =
+      impl_->transientResources.retain(std::move(maskViewResult).result());
 
-  wgpu::RenderPassColorAttachment color = {};
-  color.view = maskView;
-  color.loadOp = wgpu::LoadOp::Clear;
-  color.storeOp = wgpu::StoreOp::Store;
-  color.clearValue = {0.0, 0.0, 0.0, 0.0};
-  // See ensurePassOpen above - Dawn requires UNDEFINED on non-3D views.
-  color.depthSlice = WGPU_DEPTH_SLICE_UNDEFINED;
-
-  wgpu::RenderPassDescriptor desc = {};
-  desc.colorAttachmentCount = 1;
-  desc.colorAttachments = &color;
-  desc.label = wgpuLabel("GeoEncoderMaskPass");
-  impl_->maskPass.reset(impl_->commandEncoder.beginRenderPass(desc));
-  impl_->maskPass.get().setPipeline(impl_->maskPipelineOwned->pipeline());
+  gpu::Result<gpu::RenderPassEncoder*> opened =
+      impl_->commandEncoder->beginRenderPass(gpu::RenderPassDescriptor{
+          "GeoEncoderMaskPass",
+          {gpu::RenderPassColorAttachment{
+              maskView, gpu::LoadOp::Clear, gpu::StoreOp::Store, {0.0, 0.0, 0.0, 0.0}}}});
+  if (opened.hasError()) {
+    return;
+  }
+  impl_->maskPass = opened.result();
+  (void)impl_->maskPass->setPipeline(impl_->maskPipelineOwned->pipeline());
   impl_->device->countPipelineSwitch();
   // Full-target scissor so clip-path fills aren't clipped by any
   // outer scissor still cached in the encoder state.
-  impl_->maskPass.get().setScissorRect(0, 0, impl_->targetWidth, impl_->targetHeight);
+  (void)impl_->maskPass->setScissorRect(0, 0, impl_->targetWidth, impl_->targetHeight);
   impl_->maskPassOpen = true;
 }
 
@@ -1562,8 +1610,6 @@ void GeoEncoder::fillPathIntoMask(const Path& path, FillRule rule,
   if (!impl_->admitGeometry(encoded, 1u) || encoded.empty()) {
     return;
   }
-
-  const wgpu::Device& dev = impl_->device->device();
 
   // Analytic dual-ray buffers: H/V bands, curves, references, and grids. The
   // bounding fan is generated from vertex_index and uniform data.
@@ -1615,7 +1661,7 @@ void GeoEncoder::fillPathIntoMask(const Path& path, FillRule rule,
   u.viewport[0] = static_cast<float>(impl_->targetWidth);
   u.viewport[1] = static_cast<float>(impl_->targetHeight);
   u.fillRule = (rule == FillRule::EvenOdd) ? 1u : 0u;
-  u.hasClipMask = impl_->activeClipMaskView ? 1u : 0u;
+  u.hasClipMask = impl_->activeClipMaskView != nullptr ? 1u : 0u;
   u.antialias = impl_->antialias ? 1u : 0u;
   u.gridYBase = encoded.yBase;
   u.gridHStride = encoded.hStride;
@@ -1628,68 +1674,47 @@ void GeoEncoder::fillPathIntoMask(const Path& path, FillRule rule,
   const auto uniAlloc =
       impl_->allocInArena(impl_->uniformArena, &u, sizeof(MaskUniforms), kUniformOffsetAlignment);
 
-  wgpu::BindGroupEntry entries[11] = {};
-  entries[0].binding = 0;
-  entries[0].buffer = impl_->wgpuBufferOf(uniAlloc.buffer);
-  entries[0].offset = uniAlloc.offset;
-  entries[0].size = uniAlloc.size;
-  entries[1].binding = 1;
-  entries[1].buffer = impl_->wgpuBufferOf(bandsAlloc.buffer);
-  entries[1].offset = bandsAlloc.offset;
-  entries[1].size = bandsAlloc.size;
-  entries[2].binding = 2;
-  entries[2].buffer = impl_->wgpuBufferOf(curvesAlloc.buffer);
-  entries[2].offset = curvesAlloc.offset;
-  entries[2].size = curvesAlloc.size;
-  entries[3].binding = 3;
-  entries[3].textureView = impl_->currentClipMaskView();
-  entries[4].binding = 4;
-  entries[4].sampler = impl_->device->dummyClipMaskSampler();
-  entries[5].binding = 5;
-  entries[5].buffer = impl_->wgpuBufferOf(vBandsAlloc.buffer);
-  entries[5].offset = vBandsAlloc.offset;
-  entries[5].size = vBandsAlloc.size;
-  entries[6].binding = 6;
-  entries[6].buffer = impl_->wgpuBufferOf(vCurvesAlloc.buffer);
-  entries[6].offset = vCurvesAlloc.offset;
-  entries[6].size = vCurvesAlloc.size;
-  entries[7].binding = 7;
-  entries[7].buffer = impl_->wgpuBufferOf(hGridAlloc.buffer);
-  entries[7].offset = hGridAlloc.offset;
-  entries[7].size = hGridAlloc.size;
-  entries[8].binding = 8;
-  entries[8].buffer = impl_->wgpuBufferOf(vGridAlloc.buffer);
-  entries[8].offset = vGridAlloc.offset;
-  entries[8].size = vGridAlloc.size;
-  entries[9].binding = 9;
-  entries[9].buffer = impl_->wgpuBufferOf(hRefsAlloc.buffer);
-  entries[9].offset = hRefsAlloc.offset;
-  entries[9].size = hRefsAlloc.size;
-  entries[10].binding = 10;
-  entries[10].buffer = impl_->wgpuBufferOf(vRefsAlloc.buffer);
-  entries[10].offset = vRefsAlloc.offset;
-  entries[10].size = vRefsAlloc.size;
-
-  wgpu::BindGroupDescriptor bgDesc = {};
-  bgDesc.label = wgpuLabel("GeodeMaskBindGroup");
-  bgDesc.layout = impl_->maskPipelineOwned->bindGroupLayout();
-  bgDesc.entryCount = 11;
-  bgDesc.entries = entries;
-  wgpu::BindGroup bindGroup = impl_->transientResources.retain(dev.createBindGroup(bgDesc));
-  impl_->device->countBindGroup();
+  gpu::Result<gpu::BindGroup> bindGroupResult =
+      impl_->gpuContext->gpuDevice->createBindGroup(gpu::BindGroupDescriptor{
+          "GeodeMaskBindGroup",
+          impl_->maskPipelineOwned->bindGroupLayout(),
+          {gpu::BindGroupEntry{0,
+                               gpu::BufferBinding{uniAlloc.buffer, uniAlloc.offset, uniAlloc.size}},
+           gpu::BindGroupEntry{
+               1, gpu::BufferBinding{bandsAlloc.buffer, bandsAlloc.offset, bandsAlloc.size}},
+           gpu::BindGroupEntry{
+               2, gpu::BufferBinding{curvesAlloc.buffer, curvesAlloc.offset, curvesAlloc.size}},
+           gpu::BindGroupEntry{3, gpu::TextureViewBinding{impl_->currentClipMaskView()}},
+           gpu::BindGroupEntry{4, gpu::SamplerBinding{*impl_->gpuContext->dummyClipMaskSampler}},
+           gpu::BindGroupEntry{
+               5, gpu::BufferBinding{vBandsAlloc.buffer, vBandsAlloc.offset, vBandsAlloc.size}},
+           gpu::BindGroupEntry{
+               6, gpu::BufferBinding{vCurvesAlloc.buffer, vCurvesAlloc.offset, vCurvesAlloc.size}},
+           gpu::BindGroupEntry{
+               7, gpu::BufferBinding{hGridAlloc.buffer, hGridAlloc.offset, hGridAlloc.size}},
+           gpu::BindGroupEntry{
+               8, gpu::BufferBinding{vGridAlloc.buffer, vGridAlloc.offset, vGridAlloc.size}},
+           gpu::BindGroupEntry{
+               9, gpu::BufferBinding{hRefsAlloc.buffer, hRefsAlloc.offset, hRefsAlloc.size}},
+           gpu::BindGroupEntry{
+               10, gpu::BufferBinding{vRefsAlloc.buffer, vRefsAlloc.offset, vRefsAlloc.size}}}});
+  if (bindGroupResult.hasError()) {
+    return;
+  }
+  const gpu::BindGroup& bindGroup =
+      impl_->transientResources.retain(std::move(bindGroupResult).result());
 
   impl_->recordGeometryDebugDraw(encoded);
-  impl_->maskPass.get().setBindGroup(0, bindGroup, 0, nullptr);
-  impl_->maskPass.get().draw(encoded.boundingDrawVertexCount(), 1, 0, 0);
-  impl_->device->countDraw();
+  (void)impl_->maskPass->setBindGroup(0, bindGroup);
+  (void)impl_->maskPass->draw(encoded.boundingDrawVertexCount(), 1, 0, 0);
 }
 
 void GeoEncoder::endMaskPass() {
   if (!impl_->maskPassOpen) {
     return;
   }
-  impl_->maskPass.get().end();
-  impl_->maskPass.reset();
+  (void)impl_->maskPass->end();
+  impl_->maskPass = nullptr;
   impl_->maskPassOpen = false;
   // Rebind pipeline tracker - the main pass will need to re-select a
   // pipeline on its next draw.
@@ -1700,8 +1725,8 @@ void GeoEncoder::endMaskPass() {
   impl_->transform = impl_->maskPassSavedTransform;
 }
 
-void GeoEncoder::setClipMask(const wgpu::TextureView& maskView) {
-  impl_->activeClipMaskView = maskView;
+void GeoEncoder::setClipMask(const gpu::TextureView& maskView) {
+  impl_->activeClipMaskView = &maskView;
   ++impl_->clipStateVersion;
   // activeClipMaskTexture keepalive is left empty by this overload; the
   // caller must guarantee the parent stays alive. The 2-arg overload
@@ -1709,19 +1734,19 @@ void GeoEncoder::setClipMask(const wgpu::TextureView& maskView) {
   // at the call site (e.g. `RendererGeode::updateEncoderScissor`
   // pulling the view off a clip-stack entry that may be destroyed
   // before the next draw).
-  impl_->activeClipMaskTexture = wgpu::Texture{};
+  impl_->activeClipMaskTexture = gpu::TextureRef();
 }
 
-void GeoEncoder::setClipMask(const wgpu::Texture& maskTexture, const wgpu::TextureView& maskView) {
+void GeoEncoder::setClipMask(const gpu::Texture& maskTexture, const gpu::TextureView& maskView) {
   impl_->activeClipMaskTexture = maskTexture;
-  impl_->activeClipMaskView = maskView;
+  impl_->activeClipMaskView = &maskView;
   ++impl_->clipStateVersion;
 }
 
 void GeoEncoder::clearClipMask() {
-  impl_->activeClipMaskView = wgpu::TextureView{};
+  impl_->activeClipMaskView = nullptr;
   ++impl_->clipStateVersion;
-  impl_->activeClipMaskTexture = wgpu::Texture{};
+  impl_->activeClipMaskTexture = gpu::TextureRef();
 }
 
 void GeoEncoder::setBufferPool(GeodeBufferPool* pool) {
@@ -1801,8 +1826,8 @@ struct GeoEncoder::FillDrawArgs {
   float solidColor[4];  // Premultiplied.
 
   // Pattern-fill-only fields (ignored when paintMode == 0).
-  wgpu::TextureView patternView;
-  wgpu::Sampler patternSampler;
+  gpu::TextureViewRef patternView;
+  gpu::SamplerRef patternSampler;
   Transform2d patternFromPath;
   Vector2d tileSize;
   float patternOpacity;
@@ -1840,8 +1865,8 @@ void GeoEncoder::fillPath(const Path& path, const css::RGBA& color, FillRule rul
   // Solid-mode binds the pre-created dummy texture + sampler so the
   // bind group layout (which always includes pattern bindings) is
   // complete. Both are built once in the encoder constructor.
-  args.patternView = impl_->device->dummyPatternTextureView();
-  args.patternSampler = impl_->device->dummyPatternSampler();
+  args.patternView = *impl_->gpuContext->dummyPatternTextureView;
+  args.patternSampler = *impl_->gpuContext->dummyPatternSampler;
   args.tileSize = Vector2d(1.0, 1.0);
   args.patternFromPath = Transform2d();
 
@@ -1869,7 +1894,7 @@ void GeoEncoder::Impl::populateBatchUniform(Uniforms& u, const FillDrawArgs& arg
   u.tileSize[0] = static_cast<float>(args.tileSize.x);
   u.tileSize[1] = static_cast<float>(args.tileSize.y);
   writeClipPolygonUniforms(u.hasClipPolygon, u.clipPolygonPlanes);
-  u.hasClipMask = activeClipMaskView ? 1u : 0u;
+  u.hasClipMask = activeClipMaskView != nullptr ? 1u : 0u;
   u.antialias = antialias ? 1u : 0u;
 }
 
@@ -2057,71 +2082,51 @@ void GeoEncoder::Impl::uploadResidentGeometry(GeodeResidentSlot& slot, const Enc
 }
 
 void GeoEncoder::Impl::buildResidentBindGroup(GeodeResidentSlot& slot) {
-  const wgpu::Device& dev = device->device();
-  const wgpu::Buffer buf = wgpuBufferOf(slot.buffer);
-
-  wgpu::BindGroupEntry entries[12] = {};
-  auto bufEntry = [&](int i, uint32_t binding, const GeodeResidentSlot::Region& r) {
-    entries[i].binding = binding;
-    entries[i].buffer = buf;
-    entries[i].offset = r.offset;
-    entries[i].size = r.size;
+  const gpu::BufferRef buf = slot.buffer;
+  const auto region = [&buf](uint32_t binding, const GeodeResidentSlot::Region& r) {
+    return gpu::BindGroupEntry{binding, gpu::BufferBinding{buf, r.offset, r.size}};
   };
-  bufEntry(0, 0, slot.uniform);
-  // Geometry classes bind this slot's own sub-ranges, not the whole slab
-  // chunk. A whole-chunk view would also cover the chunk's not-yet-written
-  // bytes, and WebGPU has to zero-fill every byte a binding exposes before
-  // the first draw that can read it: on a cold frame that turns each new
-  // slot's first draw into a clear of the chunk's unwritten remainder, which
-  // is pure cost for a draw that only ever reads its own regions. Tight
-  // ranges start every geometry class at element zero, which is what the
-  // uniform's bases say for a solo draw. Cross-entity batches read several
-  // slots through one binding and build their own whole-chunk bind group
-  // with chunk-relative bases in each instance record.
-  bufEntry(1, 1, slot.bands);
-  bufEntry(2, 2, slot.curves);
-  entries[3].binding = 3;
-  entries[3].textureView = device->dummyPatternTextureView();
-  entries[4].binding = 4;
-  entries[4].sampler = device->dummyPatternSampler();
-  // Residence is only taken with no active clip, so the clip-mask slot is
-  // always the device's identity-coverage dummy - bind it directly so the
-  // cached bind group is deterministic.
-  entries[5].binding = 5;
-  entries[5].textureView = device->dummyClipMaskTextureView();
-  entries[6].binding = 6;
-  entries[6].sampler = device->dummyClipMaskSampler();
-  // A solo resident draw reads its paint from the slot's uniform, so the
-  // record binding only has to supply the vertex stage's identity transform.
-  // Binding the device's shared identity record keeps this slot out of the
-  // record slab entirely: nothing to allocate, nothing to write, and no
-  // record a same-frame repeat could overwrite.
-  entries[7].binding = 7;
-  entries[7].buffer = device->identityInstanceRecordBuffer();
-  entries[7].offset = 0;
-  entries[7].size = sizeof(InstanceRecord);
-  bufEntry(8, 8, slot.vBands);
-  bufEntry(9, 9, slot.vCurves);
-  // The four grid classes share one binding, so it spans them as a single
-  // range. `uploadResidentGeometry` places them adjacently and the uniform's
-  // grid bases are relative to this range's start.
+  // The four grid classes share one binding, so it spans them as a single range.
+  // `uploadResidentGeometry` places them adjacently and the uniform's grid bases are relative to
+  // this range's start.
   const GridRegionSpan grid = gridRegionSpan(slot);
-  entries[10].binding = 10;
-  entries[10].buffer = buf;
-  entries[10].offset = grid.offset;
-  entries[10].size = grid.size;
-  // This slot's own gradient paint block, on the same tight-range terms, so
-  // the uniform's `paintBase` is zero. A cross-entity batch instead binds the
-  // whole chunk and each record carries a chunk-relative base.
-  bufEntry(11, 11, slot.paint);
 
-  wgpu::BindGroupDescriptor bgDesc = {};
-  bgDesc.label = wgpuLabel("GeodeResidentBindGroup");
-  bgDesc.layout = pipeline->bindGroupLayout();
-  bgDesc.entryCount = 12;
-  bgDesc.entries = entries;
-  slot.bindGroup.reset(dev.createBindGroup(bgDesc));
-  device->countBindGroup();
+  // Geometry classes bind this slot's own sub-ranges, not the whole slab chunk. A whole-chunk
+  // view would also cover the chunk's not-yet-written bytes, and every byte a binding exposes has
+  // to be zero-filled before the first draw that can read it: on a cold frame that turns each new
+  // slot's first draw into a clear of the chunk's unwritten remainder, which is pure cost for a
+  // draw that only ever reads its own regions. Tight ranges start every geometry class at element
+  // zero, which is what the uniform's bases say for a solo draw. Cross-entity batches read several
+  // slots through one binding and build their own whole-chunk bind group with chunk-relative bases
+  // in each instance record.
+  //
+  // Residence is only taken with no active clip, so the clip-mask slot is always the identity
+  // coverage dummy - bound directly so the cached bind group is deterministic. A solo resident
+  // draw reads its paint from the slot's uniform, so the record binding only has to supply the
+  // vertex stage's identity transform; binding the shared identity record keeps this slot out of
+  // the record slab entirely. The paint block binds on the same tight-range terms, so the
+  // uniform's `paintBase` is zero.
+  gpu::Result<gpu::BindGroup> created =
+      gpuContext->gpuDevice->createBindGroup(gpu::BindGroupDescriptor{
+          "GeodeResidentBindGroup",
+          pipeline->bindGroupLayout(),
+          {region(0, slot.uniform), region(1, slot.bands), region(2, slot.curves),
+           gpu::BindGroupEntry{3, gpu::TextureViewBinding{*gpuContext->dummyPatternTextureView}},
+           gpu::BindGroupEntry{4, gpu::SamplerBinding{*gpuContext->dummyPatternSampler}},
+           gpu::BindGroupEntry{5, gpu::TextureViewBinding{*gpuContext->dummyClipMaskTextureView}},
+           gpu::BindGroupEntry{6, gpu::SamplerBinding{*gpuContext->dummyClipMaskSampler}},
+           gpu::BindGroupEntry{7, gpu::BufferBinding{*gpuContext->identityInstanceRecordBuffer, 0,
+                                                     sizeof(InstanceRecord)}},
+           region(8, slot.vBands), region(9, slot.vCurves),
+           gpu::BindGroupEntry{10, gpu::BufferBinding{buf, grid.offset, grid.size}},
+           region(11, slot.paint)}});
+  if (created.hasError()) {
+    return;
+  }
+  // The group this replaces may still be named by draws recorded earlier in the frame that have
+  // not reached the backend yet, so let the frame-boundary destroy pass reclaim it.
+  device->deferDestroy(std::move(slot.bindGroup));
+  slot.bindGroup = std::move(created).result();
 }
 
 bool GeoEncoder::Impl::submitResidentFillDraw(GeodeResidentSlot& slot, const EncodedPath& encoded,
@@ -2136,14 +2141,13 @@ bool GeoEncoder::Impl::submitResidentFillDraw(GeodeResidentSlot& slot, const Enc
 
   // ensureResidentSceneRecordImpl already wrote the uniform + record.
 
-  if (!slot.bindGroup) {
+  if (!slot.bindGroup.isValid()) {
     buildResidentBindGroup(slot);
   }
 
   recordGeometryDebugDraw(encoded);
-  pass.get().setBindGroup(0, slot.bindGroup.get(), 0, nullptr);
-  pass.get().draw(slot.vertexCount, 1, 0, 0);
-  device->countDraw();
+  (void)pass->setBindGroup(0, slot.bindGroup);
+  (void)pass->draw(slot.vertexCount, 1, 0, 0);
   return true;
 }
 
@@ -2386,15 +2390,15 @@ void GeoEncoder::fillPathResident(GeodeResidentSlot& slot, const EncodedPath& en
   args.solidColor[2] = (color.b / 255.0f) * alpha;
   args.solidColor[3] = alpha;
   args.patternOpacity = 1.0f;
-  args.patternView = impl_->device->dummyPatternTextureView();
-  args.patternSampler = impl_->device->dummyPatternSampler();
+  args.patternView = *impl_->gpuContext->dummyPatternTextureView;
+  args.patternSampler = *impl_->gpuContext->dummyPatternSampler;
   args.tileSize = Vector2d(1.0, 1.0);
   args.patternFromPath = Transform2d();
 
   // Residence is only safe (bind group stable, uniform clip flags zero)
   // when no clip mask / clip polygon / mask pass is active. Otherwise fall
   // back to the per-frame arena path so clipped / masked draws stay exact.
-  if (impl_->activeClipMaskView || impl_->clipPolygonActive || impl_->maskPassOpen) {
+  if (impl_->activeClipMaskView != nullptr || impl_->clipPolygonActive || impl_->maskPassOpen) {
     submitFillDraw(args, {}, /*requireAdmission=*/false);
     return;
   }
@@ -2458,8 +2462,8 @@ void GeoEncoder::fillPathInstanced(const EncodedPath& encoded, const css::RGBA& 
   args.solidColor[2] = (color.b / 255.0f) * alpha;
   args.solidColor[3] = alpha;
   args.patternOpacity = 1.0f;
-  args.patternView = impl_->device->dummyPatternTextureView();
-  args.patternSampler = impl_->device->dummyPatternSampler();
+  args.patternView = *impl_->gpuContext->dummyPatternTextureView;
+  args.patternSampler = *impl_->gpuContext->dummyPatternSampler;
   args.tileSize = Vector2d(1.0, 1.0);
   args.patternFromPath = Transform2d();
 
@@ -2505,8 +2509,8 @@ bool GeoEncoder::ensureResidentSceneRecord(GeodeResidentSlot& slot, const Encode
   args.solidColor[2] = (color.b / 255.0f) * alpha;
   args.solidColor[3] = alpha;
   args.patternOpacity = 1.0f;
-  args.patternView = impl_->device->dummyPatternTextureView();
-  args.patternSampler = impl_->device->dummyPatternSampler();
+  args.patternView = *impl_->gpuContext->dummyPatternTextureView;
+  args.patternSampler = *impl_->gpuContext->dummyPatternSampler;
   args.tileSize = Vector2d(1.0, 1.0);
   args.patternFromPath = Transform2d();
   args.linearGradient = paint.linearGradient;
@@ -2550,8 +2554,8 @@ void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,
   args.solidColor[2] = (color.b / 255.0f) * alpha;
   args.solidColor[3] = alpha;
   args.patternOpacity = 1.0f;
-  args.patternView = impl_->device->dummyPatternTextureView();
-  args.patternSampler = impl_->device->dummyPatternSampler();
+  args.patternView = *impl_->gpuContext->dummyPatternTextureView;
+  args.patternSampler = *impl_->gpuContext->dummyPatternSampler;
   args.tileSize = Vector2d(1.0, 1.0);
   args.patternFromPath = Transform2d();
   args.instanceCount = binding.instanceCount;
@@ -2583,40 +2587,14 @@ void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,
   const uint64_t recordSpanBytes =
       static_cast<uint64_t>(binding.instanceCount) * sizeof(InstanceRecord);
 
-  wgpu::BindGroupEntry entries[12] = {};
-  entries[0].binding = 0;
-  entries[0].buffer = impl_->wgpuBufferOf(uniAlloc.buffer);
-  entries[0].offset = uniAlloc.offset;
-  entries[0].size = uniAlloc.size;
-  auto chunkEntry = [&](int i, uint32_t bindingIndex) {
-    entries[i].binding = bindingIndex;
-    entries[i].buffer = impl_->wgpuBufferOf(binding.chunkBuffer);
-    entries[i].offset = 0;
-    entries[i].size = chunkBytes;
+  const auto chunkEntry = [&](uint32_t bindingIndex) {
+    return gpu::BindGroupEntry{bindingIndex,
+                               gpu::BufferBinding{binding.chunkBuffer, 0, chunkBytes}};
   };
-  chunkEntry(1, 1);
-  chunkEntry(2, 2);
-  entries[3].binding = 3;
-  entries[3].textureView = impl_->device->dummyPatternTextureView();
-  entries[4].binding = 4;
-  entries[4].sampler = impl_->device->dummyPatternSampler();
-  entries[5].binding = 5;
-  entries[5].textureView = impl_->device->dummyClipMaskTextureView();
-  entries[6].binding = 6;
-  entries[6].sampler = impl_->device->dummyClipMaskSampler();
-  entries[7].binding = 7;
-  entries[7].buffer = impl_->wgpuBufferOf(binding.recordBuffer);
-  entries[7].offset = recordSpanStart;
-  entries[7].size = recordSpanBytes;
-  chunkEntry(8, 8);
-  chunkEntry(9, 9);
-  chunkEntry(10, 10);
-  chunkEntry(11, 11);
 
-  // Buffer IDENTITIES, never handle addresses: the cache lives on the
-  // device, which outlives the documents drawn on it, and a destroyed
-  // document's handle addresses are handed straight back out to the next
-  // one. See `GeodeDevice::SceneBatchBindGroupKey`.
+  // Buffer IDENTITIES, never handle addresses: the cache lives on the device, which outlives the
+  // documents drawn on it, and a destroyed document's slots are handed straight back out to the
+  // next one. See `GeodeDevice::SceneBatchBindGroupKey`.
   GeodeDevice::SceneBatchBindGroupKey cacheKey = {};
   cacheKey.uniformBufferId = uniAlloc.bufferId;
   cacheKey.uniformOffset = uniAlloc.offset;
@@ -2627,33 +2605,31 @@ void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,
   cacheKey.recordOffset = recordSpanStart;
   cacheKey.recordBytes = recordSpanBytes;
 
-  // A zero id means some buffer in this binding has no stable identity, so
-  // no key can distinguish it from a later buffer; skip the cache entirely
-  // rather than store an entry that a future batch could match by accident.
+  // A zero id means some buffer in this binding has no stable identity, so no key can distinguish
+  // it from a later buffer; skip the cache entirely rather than store an entry that a future batch
+  // could match by accident.
   const bool cacheable =
       cacheKey.uniformBufferId != 0 && cacheKey.chunkBufferId != 0 && cacheKey.recordBufferId != 0;
 
-  wgpu::BindGroup bindGroup =
-      cacheable ? impl_->device->findSceneBatchBindGroup(cacheKey) : wgpu::BindGroup{};
-  if (!bindGroup) {
-    wgpu::BindGroupDescriptor bgDesc = {};
-    bgDesc.label = wgpuLabel("GeodeSceneBatchBindGroup");
-    bgDesc.layout = impl_->pipeline->bindGroupLayout();
-    bgDesc.entryCount = 12;
-    bgDesc.entries = entries;
-    wgpu::BindGroup created = impl_->device->device().createBindGroup(bgDesc);
-    impl_->device->countBindGroup();
-    bindGroup = created;
-    if (cacheable) {
-      // The cache takes ownership of the +1 handle.
-      impl_->device->storeSceneBatchBindGroup(cacheKey, std::move(created));
-    } else {
-      // Defensive only: every buffer that can reach this call is stamped at
-      // creation, so no live path produces a zero id today. Hand the +1 to
-      // the encoder's per-frame arena so that if one ever does, the bind
-      // group is released at the frame boundary instead of leaking.
-      bindGroup = impl_->transientResources.retain(created);
-    }
+  std::vector<gpu::BindGroupEntry> entries = {
+      gpu::BindGroupEntry{0, gpu::BufferBinding{uniAlloc.buffer, uniAlloc.offset, uniAlloc.size}},
+      chunkEntry(1),
+      chunkEntry(2),
+      gpu::BindGroupEntry{3, gpu::TextureViewBinding{*impl_->gpuContext->dummyPatternTextureView}},
+      gpu::BindGroupEntry{4, gpu::SamplerBinding{*impl_->gpuContext->dummyPatternSampler}},
+      gpu::BindGroupEntry{5, gpu::TextureViewBinding{*impl_->gpuContext->dummyClipMaskTextureView}},
+      gpu::BindGroupEntry{6, gpu::SamplerBinding{*impl_->gpuContext->dummyClipMaskSampler}},
+      gpu::BindGroupEntry{
+          7, gpu::BufferBinding{binding.recordBuffer, recordSpanStart, recordSpanBytes}},
+      chunkEntry(8),
+      chunkEntry(9),
+      chunkEntry(10),
+      chunkEntry(11)};
+
+  const gpu::BindGroup* bindGroup =
+      impl_->resolveSceneBatchBindGroup(cacheKey, cacheable, std::move(entries));
+  if (bindGroup == nullptr) {
+    return;
   }
 
   // Open the rasterizer scissor to the whole target for the duration of this
@@ -2665,15 +2641,14 @@ void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,
   // the pass exactly as the surrounding solo draws expect to find it.
   const bool neutralizeScissor = impl_->scissorActive;
   if (neutralizeScissor) {
-    impl_->pass.get().setScissorRect(0, 0, impl_->targetWidth, impl_->targetHeight);
+    (void)impl_->pass->setScissorRect(0, 0, impl_->targetWidth, impl_->targetHeight);
   }
 
   // The binding covers the span of consecutive record slots starting at
   // `firstInstance`; the shader's instance_index therefore runs 0..N-1
   // (the draw's firstInstance must NOT add the slot offset again).
-  impl_->pass.get().setBindGroup(0, bindGroup, 0, nullptr);
-  impl_->pass.get().draw(binding.vertexCount, binding.instanceCount, 0, 0);
-  impl_->device->countDraw();
+  (void)impl_->pass->setBindGroup(0, *bindGroup);
+  (void)impl_->pass->draw(binding.vertexCount, binding.instanceCount, 0, 0);
 
   if (neutralizeScissor) {
     impl_->applyScissorIfPassOpen();
@@ -2682,7 +2657,7 @@ void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,
 
 void GeoEncoder::fillPathPattern(const Path& path, FillRule rule, const PatternPaint& paint,
                                  const EncodedPath* precomputedEncoded) {
-  if (!paint.tile || paint.tileSize.x <= 0.0 || paint.tileSize.y <= 0.0) {
+  if (paint.tile == nullptr || paint.tileSize.x <= 0.0 || paint.tileSize.y <= 0.0) {
     return;
   }
 
@@ -2702,22 +2677,26 @@ void GeoEncoder::fillPathPattern(const Path& path, FillRule rule, const PatternP
   // via `fract()` so texture sampling never steps outside [0,1] UVs, but
   // Repeat is still the right conceptual wrap mode for any implicit
   // derivative / mip work WebGPU might do on the sampler.
-  wgpu::SamplerDescriptor sd{wgpu::Default};
-  sd.label = wgpuLabel("GeoEncoderPatternSampler");
-  sd.addressModeU = wgpu::AddressMode::Repeat;
-  sd.addressModeV = wgpu::AddressMode::Repeat;
-  sd.minFilter = wgpu::FilterMode::Linear;
-  sd.magFilter = wgpu::FilterMode::Linear;
-  sd.maxAnisotropy = 1;
-  wgpu::Sampler sampler =
-      impl_->transientResources.retain(impl_->device->device().createSampler(sd));
+  gpu::Result<gpu::Sampler> samplerResult =
+      impl_->gpuContext->gpuDevice->createSampler(gpu::SamplerDescriptor{
+          "GeoEncoderPatternSampler", gpu::FilterMode::Linear, gpu::FilterMode::Linear,
+          gpu::AddressMode::Repeat, gpu::AddressMode::Repeat});
+  if (samplerResult.hasError()) {
+    return;
+  }
+  const gpu::Sampler& sampler = impl_->transientResources.retain(std::move(samplerResult).result());
 
   FillDrawArgs args = {};
   args.path = &path;
   args.rule = rule;
   args.precomputedEncoded = encoded;
   args.paintMode = 1u;
-  args.patternView = impl_->transientResources.retain(paint.tile.createView());
+  gpu::Result<gpu::TextureView> tileView = impl_->gpuContext->gpuDevice->createTextureView(
+      *paint.tile, gpu::TextureViewDescriptor{"GeoEncoderPatternTileView"});
+  if (tileView.hasError()) {
+    return;
+  }
+  args.patternView = impl_->transientResources.retain(std::move(tileView).result());
   args.patternSampler = sampler;
   args.patternFromPath = paint.patternFromPath;
   args.tileSize = paint.tileSize;
@@ -2752,8 +2731,6 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args, std::span<const float>
   if ((requireAdmission && !impl_->admitGeometry(encoded, args.instanceCount)) || encoded.empty()) {
     return;  // Nothing to draw.
   }
-
-  const wgpu::Device& dev = impl_->device->device();
 
   // 2. Allocate and upload GPU buffers via the per-encoder arenas. The analytic dual-ray fill
   // generates one convex bounding fan from vertex_index and binds two band/curve
@@ -2803,43 +2780,17 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args, std::span<const float>
   // (markers) match the solo path's host-composed bake. A single draw needs
   // no record of its own: its transform is baked into uniforms.mvp, so it
   // binds the device's shared identity record and writes nothing.
-  wgpu::Buffer recordBuf;
+  gpu::BufferRef recordBuf;
   uint64_t recordOffset = 0;
   uint64_t recordSize = 0;
   if (instanced) {
-    const size_t packedCount = static_cast<size_t>(instanceCount) * 8u;
-    if (instanceTransforms.size() == packedCount) {
-      std::vector<InstanceRecord> records(instanceCount, record);
-      for (uint32_t i = 0; i < instanceCount; ++i) {
-        Transform2d t;
-        t.data[0] = instanceTransforms[i * 8u + 0u];
-        t.data[1] = instanceTransforms[i * 8u + 4u];
-        t.data[2] = instanceTransforms[i * 8u + 1u];
-        t.data[3] = instanceTransforms[i * 8u + 5u];
-        t.data[4] = instanceTransforms[i * 8u + 2u];
-        t.data[5] = instanceTransforms[i * 8u + 6u];
-        const Transform2d composed =
-            composeOrthographicMvp(impl_->targetWidth, impl_->targetHeight, t);
-        InstanceRecord& rec = records[i];
-        rec.transformRow0[0] = static_cast<float>(composed.data[0]);
-        rec.transformRow0[1] = static_cast<float>(composed.data[2]);
-        rec.transformRow0[2] = static_cast<float>(composed.data[4]);
-        rec.transformRow0[3] = 0.0f;
-        rec.transformRow1[0] = static_cast<float>(composed.data[1]);
-        rec.transformRow1[1] = static_cast<float>(composed.data[3]);
-        rec.transformRow1[2] = static_cast<float>(composed.data[5]);
-        rec.transformRow1[3] = 0.0f;
-      }
-      const uint64_t recordBytes = static_cast<size_t>(instanceCount) * sizeof(InstanceRecord);
-      const auto recordAlloc = impl_->allocInArena(impl_->instanceRecordArena, records.data(),
-                                                   recordBytes, kStorageOffsetAlignment);
-      recordBuf = impl_->wgpuBufferOf(recordAlloc.buffer);
-      recordOffset = recordAlloc.offset;
-      recordSize = recordAlloc.size;
-    }
+    const auto recordAlloc = impl_->packInstanceRecords(record, instanceCount, instanceTransforms);
+    recordBuf = recordAlloc.buffer;
+    recordOffset = recordAlloc.offset;
+    recordSize = recordAlloc.size;
   }
-  if (!recordBuf) {
-    recordBuf = impl_->device->identityInstanceRecordBuffer();
+  if (!recordBuf.isValid()) {
+    recordBuf = *impl_->gpuContext->identityInstanceRecordBuffer;
     recordOffset = 0;
     recordSize = sizeof(InstanceRecord);
   }
@@ -2848,65 +2799,40 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args, std::span<const float>
   // pattern texture, pattern sampler, clip-mask texture, clip-mask sampler,
   // per-instance records SSBO, V bands SSBO, V curves SSBO, the combined
   // dense grid storage, and the gradient paint blocks.
-  wgpu::BindGroupEntry entries[12] = {};
-  entries[0].binding = 0;
-  entries[0].buffer = impl_->wgpuBufferOf(uniAlloc.buffer);
-  entries[0].offset = uniAlloc.offset;
-  entries[0].size = uniAlloc.size;
-  entries[1].binding = 1;
-  entries[1].buffer = impl_->wgpuBufferOf(bandsAlloc.buffer);
-  entries[1].offset = bandsAlloc.offset;
-  entries[1].size = bandsAlloc.size;
-  entries[2].binding = 2;
-  entries[2].buffer = impl_->wgpuBufferOf(curvesAlloc.buffer);
-  entries[2].offset = curvesAlloc.offset;
-  entries[2].size = curvesAlloc.size;
-  entries[3].binding = 3;
-  entries[3].textureView = args.patternView;
-  entries[4].binding = 4;
-  entries[4].sampler = args.patternSampler;
-  entries[5].binding = 5;
-  entries[5].textureView = impl_->currentClipMaskView();
-  entries[6].binding = 6;
-  entries[6].sampler = impl_->device->dummyClipMaskSampler();
-  entries[7].binding = 7;
-  entries[7].buffer = recordBuf;
-  entries[7].offset = recordOffset;
-  entries[7].size = recordSize;
-  entries[8].binding = 8;
-  entries[8].buffer = impl_->wgpuBufferOf(vBandsAlloc.buffer);
-  entries[8].offset = vBandsAlloc.offset;
-  entries[8].size = vBandsAlloc.size;
-  entries[9].binding = 9;
-  entries[9].buffer = impl_->wgpuBufferOf(vCurvesAlloc.buffer);
-  entries[9].offset = vCurvesAlloc.offset;
-  entries[9].size = vCurvesAlloc.size;
-  // One binding for all four grid arrays; the record's bases index into it.
-  entries[10].binding = 10;
-  entries[10].buffer = impl_->wgpuBufferOf(gridSpan.alloc.buffer);
-  entries[10].offset = gridSpan.alloc.offset;
-  entries[10].size = gridSpan.alloc.size;
-  // The per-frame arena path never carries a record-sourced gradient - a
-  // gradient without residence goes to the dedicated gradient pipeline - so it
-  // binds the device's zero-filled block and the shader never reads it.
-  entries[11].binding = 11;
-  entries[11].buffer = impl_->device->dummyPaintDataBuffer();
-  entries[11].offset = 0;
-  entries[11].size = impl_->device->dummyPaintDataBuffer().getSize();
-
-  wgpu::BindGroupDescriptor bgDesc = {};
-  bgDesc.label = wgpuLabel("GeodeBindGroup");
-  bgDesc.layout = impl_->pipeline->bindGroupLayout();
-  bgDesc.entryCount = 12;
-  bgDesc.entries = entries;
-  wgpu::BindGroup bindGroup = impl_->transientResources.retain(dev.createBindGroup(bgDesc));
-  impl_->device->countBindGroup();
+  gpu::Result<gpu::BindGroup> bindGroupResult =
+      impl_->gpuContext->gpuDevice->createBindGroup(gpu::BindGroupDescriptor{
+          "GeodeBindGroup",
+          impl_->pipeline->bindGroupLayout(),
+          {gpu::BindGroupEntry{0,
+                               gpu::BufferBinding{uniAlloc.buffer, uniAlloc.offset, uniAlloc.size}},
+           gpu::BindGroupEntry{
+               1, gpu::BufferBinding{bandsAlloc.buffer, bandsAlloc.offset, bandsAlloc.size}},
+           gpu::BindGroupEntry{
+               2, gpu::BufferBinding{curvesAlloc.buffer, curvesAlloc.offset, curvesAlloc.size}},
+           gpu::BindGroupEntry{3, gpu::TextureViewBinding{args.patternView}},
+           gpu::BindGroupEntry{4, gpu::SamplerBinding{args.patternSampler}},
+           gpu::BindGroupEntry{5, gpu::TextureViewBinding{impl_->currentClipMaskView()}},
+           gpu::BindGroupEntry{6, gpu::SamplerBinding{*impl_->gpuContext->dummyClipMaskSampler}},
+           gpu::BindGroupEntry{7, gpu::BufferBinding{recordBuf, recordOffset, recordSize}},
+           gpu::BindGroupEntry{
+               8, gpu::BufferBinding{vBandsAlloc.buffer, vBandsAlloc.offset, vBandsAlloc.size}},
+           gpu::BindGroupEntry{
+               9, gpu::BufferBinding{vCurvesAlloc.buffer, vCurvesAlloc.offset, vCurvesAlloc.size}},
+           gpu::BindGroupEntry{10, gpu::BufferBinding{gridSpan.alloc.buffer, gridSpan.alloc.offset,
+                                                      gridSpan.alloc.size}},
+           gpu::BindGroupEntry{11,
+                               gpu::BufferBinding{*impl_->gpuContext->dummyPaintDataBuffer, 0,
+                                                  kGradientPaintBlockRows * 4u * sizeof(float)}}}});
+  if (bindGroupResult.hasError()) {
+    return;
+  }
+  const gpu::BindGroup& bindGroup =
+      impl_->transientResources.retain(std::move(bindGroupResult).result());
 
   // 4. Record the draw call - one convex fan per path.
   impl_->recordGeometryDebugDraw(encoded, instanceTransforms);
-  impl_->pass.get().setBindGroup(0, bindGroup, 0, nullptr);
-  impl_->pass.get().draw(encoded.boundingDrawVertexCount(), instanceCount, 0, 0);
-  impl_->device->countDraw();
+  (void)impl_->pass->setBindGroup(0, bindGroup);
+  (void)impl_->pass->draw(encoded.boundingDrawVertexCount(), instanceCount, 0, 0);
 }
 
 namespace {
@@ -2970,7 +2896,7 @@ void GeoEncoder::Impl::buildLinearGradientUniforms(GradientUniforms& u,
                                                              params.spreadMode, params.stops, rule);
   u.gradientKind = kGradientKindLinear;
   writeClipPolygonUniforms(u.hasClipPolygon, u.clipPolygonPlanes);
-  u.hasClipMask = activeClipMaskView ? 1u : 0u;
+  u.hasClipMask = activeClipMaskView != nullptr ? 1u : 0u;
   u.antialias = antialias ? 1u : 0u;
   u.startGrad[0] = static_cast<float>(params.startGrad.x);
   u.startGrad[1] = static_cast<float>(params.startGrad.y);
@@ -2988,7 +2914,7 @@ void GeoEncoder::Impl::buildRadialGradientUniforms(GradientUniforms& u,
                                                              params.spreadMode, params.stops, rule);
   u.gradientKind = kGradientKindRadial;
   writeClipPolygonUniforms(u.hasClipPolygon, u.clipPolygonPlanes);
-  u.hasClipMask = activeClipMaskView ? 1u : 0u;
+  u.hasClipMask = activeClipMaskView != nullptr ? 1u : 0u;
   u.antialias = antialias ? 1u : 0u;
   u.radialCenter[0] = static_cast<float>(params.center.x);
   u.radialCenter[1] = static_cast<float>(params.center.y);
@@ -3099,41 +3025,31 @@ void GeoEncoder::Impl::uploadResidentGradientGeometry(GeodeResidentGradientSlot&
 }
 
 void GeoEncoder::Impl::buildResidentGradientBindGroup(GeodeResidentGradientSlot& slot) {
-  const wgpu::Device& dev = device->device();
-  const wgpu::Buffer buf = wgpuBufferOf(slot.buffer);
+  const gpu::BufferRef buf = slot.buffer;
 
   // Eleven bindings mirroring `submitGradientDraw`, with the clip-mask
   // texture/sampler slots bound to the device-owned dummies. Residence is
   // gated on "no clip active", so the dummy bindings are the only state
   // these slots ever see and the cached group stays valid across frames.
-  wgpu::BindGroupEntry entries[11] = {};
-  auto bufEntry = [&](int i, uint32_t binding, const GeodeResidentGradientSlot::Region& r) {
-    entries[i].binding = binding;
-    entries[i].buffer = buf;
-    entries[i].offset = r.offset;
-    entries[i].size = r.size;
+  const auto region = [&buf](uint32_t binding, const GeodeResidentGradientSlot::Region& r) {
+    return gpu::BindGroupEntry{binding, gpu::BufferBinding{buf, r.offset, r.size}};
   };
-  bufEntry(0, 0, slot.uniform);
-  bufEntry(1, 1, slot.bands);
-  bufEntry(2, 2, slot.curves);
-  bufEntry(5, 5, slot.vBands);
-  bufEntry(6, 6, slot.vCurves);
-  bufEntry(7, 7, slot.hGrid);
-  bufEntry(8, 8, slot.vGrid);
-  bufEntry(9, 9, slot.hRefs);
-  bufEntry(10, 10, slot.vRefs);
-  entries[3].binding = 3;
-  entries[3].textureView = device->dummyClipMaskTextureView();
-  entries[4].binding = 4;
-  entries[4].sampler = device->dummyClipMaskSampler();
-
-  wgpu::BindGroupDescriptor bgDesc = {};
-  bgDesc.label = wgpuLabel("GeodeResidentGradientBindGroup");
-  bgDesc.layout = gradientPipeline->bindGroupLayout();
-  bgDesc.entryCount = 11;
-  bgDesc.entries = entries;
-  slot.bindGroup.reset(dev.createBindGroup(bgDesc));
-  device->countBindGroup();
+  gpu::Result<gpu::BindGroup> created =
+      gpuContext->gpuDevice->createBindGroup(gpu::BindGroupDescriptor{
+          "GeodeResidentGradientBindGroup",
+          gradientPipeline->bindGroupLayout(),
+          {region(0, slot.uniform), region(1, slot.bands), region(2, slot.curves),
+           gpu::BindGroupEntry{3, gpu::TextureViewBinding{*gpuContext->dummyClipMaskTextureView}},
+           gpu::BindGroupEntry{4, gpu::SamplerBinding{*gpuContext->dummyClipMaskSampler}},
+           region(5, slot.vBands), region(6, slot.vCurves), region(7, slot.hGrid),
+           region(8, slot.vGrid), region(9, slot.hRefs), region(10, slot.vRefs)}});
+  if (created.hasError()) {
+    return;
+  }
+  // The group this replaces may still be named by draws recorded earlier in the frame that have
+  // not reached the backend yet, so let the frame-boundary destroy pass reclaim it.
+  device->deferDestroy(std::move(slot.bindGroup));
+  slot.bindGroup = std::move(created).result();
 }
 
 bool GeoEncoder::Impl::submitResidentGradientDraw(GeodeResidentGradientSlot& slot,
@@ -3171,14 +3087,13 @@ bool GeoEncoder::Impl::submitResidentGradientDraw(GeodeResidentGradientSlot& slo
 
   publishGradientUniform(slot, u);
 
-  if (!slot.bindGroup) {
+  if (!slot.bindGroup.isValid()) {
     buildResidentGradientBindGroup(slot);
   }
 
   recordGeometryDebugDraw(encoded);
-  pass.get().setBindGroup(0, slot.bindGroup.get(), 0, nullptr);
-  pass.get().draw(slot.vertexCount, 1, 0, 0);
-  device->countDraw();
+  (void)pass->setBindGroup(0, slot.bindGroup);
+  (void)pass->draw(slot.vertexCount, 1, 0, 0);
   return true;
 }
 
@@ -3266,7 +3181,7 @@ void GeoEncoder::fillPathLinearGradientResident(GeodeResidentGradientSlot& slot,
   // claim covers a same-frame repeat and an offscreen pass drawing while an
   // outer frame on this device has recorded against the slot). Fall back to
   // the per-frame arena path in both cases, mirroring `fillPathResident`.
-  if (impl_->activeClipMaskView || impl_->clipPolygonActive || impl_->maskPassOpen ||
+  if (impl_->activeClipMaskView != nullptr || impl_->clipPolygonActive || impl_->maskPassOpen ||
       ((slot.owningDeviceId == impl_->device->deviceId() || slot.owningDeviceId == 0) &&
        impl_->device->frameStampClaimed(slot.lastResidentFrame))) {
     impl_->submitGradientArenaFallback(u, encoded);
@@ -3289,7 +3204,7 @@ void GeoEncoder::fillPathRadialGradientResident(GeodeResidentGradientSlot& slot,
   GradientUniforms u = {};
   impl_->buildRadialGradientUniforms(u, params, rule);
 
-  if (impl_->activeClipMaskView || impl_->clipPolygonActive || impl_->maskPassOpen ||
+  if (impl_->activeClipMaskView != nullptr || impl_->clipPolygonActive || impl_->maskPassOpen ||
       ((slot.owningDeviceId == impl_->device->deviceId() || slot.owningDeviceId == 0) &&
        impl_->device->frameStampClaimed(slot.lastResidentFrame))) {
     impl_->submitGradientArenaFallback(u, encoded);
@@ -3301,8 +3216,8 @@ void GeoEncoder::fillPathRadialGradientResident(GeodeResidentGradientSlot& slot,
   }
 }
 
-void GeoEncoder::blitFullTarget(const wgpu::Texture& src, double opacity) {
-  if (!src) {
+void GeoEncoder::blitFullTarget(const gpu::Texture& src, double opacity) {
+  if (!src.isValid()) {
     return;
   }
   impl_->ensurePassOpen();
@@ -3337,15 +3252,15 @@ void GeoEncoder::blitFullTarget(const wgpu::Texture& src, double opacity) {
   qp.sourceIsPremultiplied = true;
   qp.clipMaskView = impl_->activeClipMaskView;
 
-  GeodeTextureEncoder::drawTexturedQuad(*impl_->device, *impl_->imagePipeline, impl_->pass.get(),
+  GeodeTextureEncoder::drawTexturedQuad(*impl_->gpuContext, *impl_->imagePipeline, *impl_->pass,
                                         src, mvp, impl_->targetWidth, impl_->targetHeight, qp,
                                         impl_->transientResources, impl_.get());
 }
 
-void GeoEncoder::blitFullTargetMasked(const wgpu::Texture& content, const wgpu::Texture& mask,
+void GeoEncoder::blitFullTargetMasked(const gpu::Texture& content, const gpu::Texture& mask,
                                       svg::MaskType maskType,
                                       const std::optional<Box2d>& maskBounds) {
-  if (!content || !mask) {
+  if (!content.isValid() || !mask.isValid()) {
     return;
   }
   impl_->ensurePassOpen();
@@ -3372,7 +3287,7 @@ void GeoEncoder::blitFullTargetMasked(const wgpu::Texture& content, const wgpu::
   // Geode's premultiplied source-over pipeline, so they're already
   // in premultiplied alpha.
   qp.sourceIsPremultiplied = true;
-  qp.maskTexture = mask;
+  qp.maskTexture = &mask;
   qp.maskMode = maskType == svg::MaskType::Alpha ? 2u : 1u;
   qp.clipMaskView = impl_->activeClipMaskView;
   if (maskBounds.has_value()) {
@@ -3380,14 +3295,14 @@ void GeoEncoder::blitFullTargetMasked(const wgpu::Texture& content, const wgpu::
     qp.maskBounds = *maskBounds;
   }
 
-  GeodeTextureEncoder::drawTexturedQuad(*impl_->device, *impl_->imagePipeline, impl_->pass.get(),
+  GeodeTextureEncoder::drawTexturedQuad(*impl_->gpuContext, *impl_->imagePipeline, *impl_->pass,
                                         content, mvp, impl_->targetWidth, impl_->targetHeight, qp,
                                         impl_->transientResources, impl_.get());
 }
 
-void GeoEncoder::blitFullTargetBlended(const wgpu::Texture& layer, const wgpu::Texture& dstSnapshot,
+void GeoEncoder::blitFullTargetBlended(const gpu::Texture& layer, const gpu::Texture& dstSnapshot,
                                        uint32_t blendMode, double opacity) {
-  if (!layer || !dstSnapshot || blendMode == 0u) {
+  if (!layer.isValid() || !dstSnapshot.isValid() || blendMode == 0u) {
     return;
   }
   impl_->ensurePassOpen();
@@ -3420,10 +3335,10 @@ void GeoEncoder::blitFullTargetBlended(const wgpu::Texture& layer, const wgpu::T
   // stored in premultiplied alpha.
   qp.sourceIsPremultiplied = true;
   qp.blendMode = blendMode;
-  qp.dstSnapshotTexture = dstSnapshot;
+  qp.dstSnapshotTexture = &dstSnapshot;
   qp.clipMaskView = impl_->activeClipMaskView;
 
-  GeodeTextureEncoder::drawTexturedQuad(*impl_->device, *impl_->imagePipeline, impl_->pass.get(),
+  GeodeTextureEncoder::drawTexturedQuad(*impl_->gpuContext, *impl_->imagePipeline, *impl_->pass,
                                         layer, mvp, impl_->targetWidth, impl_->targetHeight, qp,
                                         impl_->transientResources, impl_.get());
 }
@@ -3469,7 +3384,7 @@ GeodeTextureEncoder::QuadParams MakeImageQuadParams(const svg::ImageResource& im
                                                     const Box2d& destRect, double opacity,
                                                     svg::ImageRendering imageRendering,
                                                     const Transform2d& deviceFromLocalTransform,
-                                                    const wgpu::TextureView& clipMaskView) {
+                                                    const gpu::TextureView* clipMaskView) {
   GeodeTextureEncoder::QuadParams params;
   params.destRect = destRect;
   params.srcRect = Box2d({0.0, 0.0}, {1.0, 1.0});
@@ -3500,10 +3415,11 @@ void GeoEncoder::drawImage(const svg::ImageResource& image, const Box2d& destRec
 
   // Interpolation happens in premultiplied space so transparent colored texels cannot fringe.
   const std::vector<std::uint8_t> premultiplied = svg::PremultiplyRgba(image.data);
-  wgpu::Texture texture = impl_->transientResources.retain(GeodeTextureEncoder::uploadRgba8Texture(
-      *impl_->device, premultiplied.data(), static_cast<uint32_t>(image.width),
-      static_cast<uint32_t>(image.height)));
-  if (!texture) {
+  const gpu::Texture& texture =
+      impl_->transientResources.retain(GeodeTextureEncoder::uploadRgba8Texture(
+          *impl_->gpuContext, premultiplied.data(), static_cast<uint32_t>(image.width),
+          static_cast<uint32_t>(image.height)));
+  if (!texture.isValid()) {
     return;
   }
 
@@ -3516,15 +3432,15 @@ void GeoEncoder::drawImage(const svg::ImageResource& image, const Box2d& destRec
   const GeodeTextureEncoder::QuadParams qp = MakeImageQuadParams(
       image, destRect, opacity, imageRendering, impl_->transform, impl_->activeClipMaskView);
 
-  GeodeTextureEncoder::drawTexturedQuad(*impl_->device, *impl_->imagePipeline, impl_->pass.get(),
+  GeodeTextureEncoder::drawTexturedQuad(*impl_->gpuContext, *impl_->imagePipeline, *impl_->pass,
                                         texture, mvp, impl_->targetWidth, impl_->targetHeight, qp,
                                         impl_->transientResources, impl_.get());
 }
 
-void GeoEncoder::drawTexture(const wgpu::Texture& texture, const Box2d& destRect,
+void GeoEncoder::drawTexture(const gpu::Texture& texture, const Box2d& destRect,
                              const Box2d& sourceUv, double opacity, bool pixelated,
                              bool sourceIsPremultiplied) {
-  if (!texture || destRect.isEmpty() || sourceUv.isEmpty() || opacity <= 0.0) {
+  if (!texture.isValid() || destRect.isEmpty() || sourceUv.isEmpty() || opacity <= 0.0) {
     return;
   }
 
@@ -3547,22 +3463,22 @@ void GeoEncoder::drawTexture(const wgpu::Texture& texture, const Box2d& destRect
   qp.sourceIsPremultiplied = sourceIsPremultiplied;
   qp.clipMaskView = impl_->activeClipMaskView;
 
-  GeodeTextureEncoder::drawTexturedQuad(*impl_->device, *impl_->imagePipeline, impl_->pass.get(),
+  GeodeTextureEncoder::drawTexturedQuad(*impl_->gpuContext, *impl_->imagePipeline, *impl_->pass,
                                         texture, mvp, impl_->targetWidth, impl_->targetHeight, qp,
                                         impl_->transientResources, impl_.get());
 }
 
 void GeoEncoder::finish() {
   if (impl_->passOpen) {
-    impl_->pass.get().end();
-    impl_->pass.reset();
+    (void)impl_->pass->end();
+    impl_->pass = nullptr;
     impl_->passOpen = false;
   } else if (impl_->hasExplicitClear) {
     // No draws but a clear was requested - open and immediately close a pass
     // so the clear actually happens.
     impl_->ensurePassOpen();
-    impl_->pass.get().end();
-    impl_->pass.reset();
+    (void)impl_->pass->end();
+    impl_->pass = nullptr;
     impl_->passOpen = false;
   }
 
@@ -3573,13 +3489,13 @@ void GeoEncoder::finish() {
     return;
   }
 
-  {
-    ScopedWgpuHandle<wgpu::CommandBuffer> cmdBuf(impl_->commandEncoder.finish());
-    impl_->device->queue().submit(1, &cmdBuf.get());
-    impl_->device->countSubmit();
+  gpu::Result<gpu::CommandBuffer> commands = impl_->commandEncoder->finish();
+  if (!commands.hasError()) {
+    // The runtime device forwards the submit counter itself.
+    (void)impl_->gpuContext->gpuDevice->submit(std::move(commands).result());
   }
   impl_->ownedCommandEncoder.reset();
-  impl_->commandEncoder = wgpu::CommandEncoder();
+  impl_->commandEncoder = nullptr;
 }
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -9,11 +9,13 @@
 #include "donner/svg/renderer/PixelFormatUtils.h"
 #include "donner/svg/renderer/geode/GeodeBufferPool.h"
 #include "donner/svg/renderer/geode/GeodeDevice.h"
+#include "donner/svg/renderer/geode/GeodeGpuContext.h"
 #include "donner/svg/renderer/geode/GeodeImagePipeline.h"
 #include "donner/svg/renderer/geode/GeodePathEncoder.h"
 #include "donner/svg/renderer/geode/GeodePipeline.h"
 #include "donner/svg/renderer/geode/GeodeResidentPathComponent.h"
 #include "donner/svg/renderer/geode/GeodeTextureEncoder.h"
+#include "donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h"
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 #include "donner/svg/resources/ImageResource.h"
 
@@ -422,6 +424,15 @@ constexpr uint32_t kGradientKindRadial = 1u;
 
 struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   GeodeDevice* device;
+  /// The GPU runtime context this encoder records against; the device's, wired in `initImpl`.
+  const GeodeGpuContext* gpuContext = nullptr;
+
+  /// Resolves the wgpu buffer behind an arena allocation, for the bind groups this encoder still
+  /// builds through wgpu.
+  /// @param buffer Runtime buffer reference.
+  wgpu::Buffer wgpuBufferOf(const gpu::BufferRef& buffer) const {
+    return device->adapterDevice().wgpuBufferOf(buffer);
+  }
   const GeodePipeline* pipeline;
   const GeodeGradientPipeline* gradientPipeline;
   const GeodeImagePipeline* imagePipeline;
@@ -433,7 +444,7 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   GeodeTextureEncoder::UniformAllocation allocate(const void* data, uint64_t size,
                                                   uint64_t alignment) override {
     const Allocation alloc = allocInArena(uniformArena, data, size, alignment);
-    return {alloc.buffer, alloc.offset, alloc.size};
+    return {wgpuBufferOf(alloc.buffer), alloc.offset, alloc.size};
   }
 
   /// Per-encoder growable GPU buffer used as a bump-allocation arena
@@ -449,11 +460,11 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   /// Lifetime: when the arena grows, the previous buffer is moved into
   /// `retired` and kept alive for the encoder's lifetime. Commands
   /// already recorded into the command encoder that reference the
-  /// old buffer remain valid because the `wgpu::Buffer` RAII wrapper
-  /// holds the handle until the `Arena` itself is destroyed (at
-  /// encoder destruction, after `finish()` has submitted all work).
+  /// old buffer remain valid because the owning handle keeps the buffer
+  /// alive until the `Arena` itself is destroyed (at encoder destruction,
+  /// after `finish()` has submitted all work).
   struct Arena {
-    ScopedWgpuHandle<wgpu::Buffer> buffer;
+    gpu::Buffer buffer;
     uint64_t capacity = 0;
     uint64_t offset = 0;  // Next unused byte within `buffer`.
     /// Stable identity of `buffer` (see `GeodeDevice::AllocateBufferId`),
@@ -462,8 +473,8 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
     /// same handle address with completely different contents; anything
     /// that caches across frames must compare this id instead.
     uint64_t bufferId = 0;
-    std::vector<ScopedWgpuHandle<wgpu::Buffer>> retired;
-    wgpu::BufferUsage usage = wgpu::BufferUsage::CopyDst;
+    std::vector<gpu::Buffer> retired;
+    gpu::BufferUsage usage = gpu::BufferUsage::CopyDst;
     const char* label = "GeodeArena";
   };
   Arena bandArena;
@@ -494,10 +505,10 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
     // handle without explicitly destroying its backing. Submitted WebGPU
     // commands retain their resources until completion; calling destroy()
     // here can invalidate those in-flight commands on some Vulkan drivers.
-    if (bufferPool != nullptr && arena.buffer) {
+    if (bufferPool != nullptr && arena.buffer.isValid()) {
       bufferPool->release(std::move(arena.buffer), arena.usage, arena.label, arena.capacity);
     }
-    arena.buffer.reset();
+    arena.buffer = gpu::Buffer();
     arena.retired.clear();
   }
 
@@ -529,7 +540,9 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   /// value snapshot so a later growth of the same arena cannot retarget an
   /// earlier allocation to the replacement buffer.
   struct Allocation {
-    wgpu::Buffer buffer;
+    /// Identity snapshot of the arena buffer at allocation time: a later growth of the same
+    /// arena installs a different buffer, and this reference still names the one written here.
+    gpu::BufferRef buffer;
     uint64_t offset;
     uint64_t size;
     /// Stable identity of `buffer`; see `Arena::bufferId`.
@@ -546,7 +559,8 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
 
   Allocation allocSceneBatchUniform(const Uniforms& u) {
     const auto* bytes = reinterpret_cast<const uint8_t*>(&u);
-    if (sceneBatchUniformAlloc.buffer && sceneBatchUniformBytes.size() == sizeof(Uniforms) &&
+    if (sceneBatchUniformAlloc.buffer.isValid() &&
+        sceneBatchUniformBytes.size() == sizeof(Uniforms) &&
         std::memcmp(sceneBatchUniformBytes.data(), bytes, sizeof(Uniforms)) == 0) {
       return sceneBatchUniformAlloc;
     }
@@ -562,7 +576,7 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   /// with `arena.offset == 0`.
   void growArena(Arena& arena, uint64_t size) {
     {
-      if (arena.buffer) {
+      if (arena.buffer.isValid()) {
         arena.retired.push_back(std::move(arena.buffer));
       }
       constexpr uint64_t kMinGrow = uint64_t{64} * 1024;
@@ -573,20 +587,17 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
       // back to a fresh allocation when the pool has no fit.
       if (bufferPool != nullptr) {
         uint64_t pooledCapacity = 0;
-        ScopedWgpuHandle<wgpu::Buffer> pooled =
-            bufferPool->acquire(arena.usage, arena.label, newCap, &pooledCapacity);
-        if (pooled) {
+        gpu::Buffer pooled = bufferPool->acquire(arena.usage, arena.label, newCap, &pooledCapacity);
+        if (pooled.isValid()) {
           arena.buffer = std::move(pooled);
           arena.capacity = pooledCapacity;
         }
       }
-      if (!arena.buffer) {
-        wgpu::BufferDescriptor desc = {};
-        desc.label = wgpuLabel(arena.label);
-        desc.size = newCap;
-        desc.usage = arena.usage;
-        arena.buffer.reset(device->device().createBuffer(desc));
-        device->countBuffer();
+      if (!arena.buffer.isValid()) {
+        gpu::Result<gpu::Buffer> created = gpuContext->gpuDevice->createBuffer(
+            gpu::BufferDescriptor{arena.label, newCap, arena.usage});
+        UTILS_RELEASE_ASSERT_MSG(!created.hasError(), "Geode arena buffer creation failed");
+        arena.buffer = std::move(created).result();
         arena.capacity = newCap;
       }
       // Fresh identity for the new backing buffer, pooled or not: the
@@ -660,10 +671,12 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
       growArena(arena, size);
       alignedOffset = 0;
     }
-    device->queue().writeBuffer(arena.buffer.get(), alignedOffset, data, size);
-    device->countBufferWrite(size);
+    const gpu::Status writeStatus = gpuContext->gpuDevice->writeBuffer(
+        arena.buffer, alignedOffset,
+        std::span<const uint8_t>(static_cast<const uint8_t*>(data), size));
+    UTILS_RELEASE_ASSERT_MSG(!writeStatus.hasError(), "Geode arena buffer write failed");
     arena.offset = alignedOffset + size;
-    return {arena.buffer.get(), alignedOffset, size, arena.bufferId};
+    return {arena.buffer, alignedOffset, size, arena.bufferId};
   }
 
   /// Allocate a read-only storage binding for `byteCount` bytes of `data`,
@@ -840,15 +853,15 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
 
     wgpu::BindGroupEntry entries[11] = {};
     entries[0].binding = 0;
-    entries[0].buffer = uniAlloc.buffer;
+    entries[0].buffer = wgpuBufferOf(uniAlloc.buffer);
     entries[0].offset = uniAlloc.offset;
     entries[0].size = uniAlloc.size;
     entries[1].binding = 1;
-    entries[1].buffer = bandsAlloc.buffer;
+    entries[1].buffer = wgpuBufferOf(bandsAlloc.buffer);
     entries[1].offset = bandsAlloc.offset;
     entries[1].size = bandsAlloc.size;
     entries[2].binding = 2;
-    entries[2].buffer = curvesAlloc.buffer;
+    entries[2].buffer = wgpuBufferOf(curvesAlloc.buffer);
     entries[2].offset = curvesAlloc.offset;
     entries[2].size = curvesAlloc.size;
     entries[3].binding = 3;
@@ -856,27 +869,27 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
     entries[4].binding = 4;
     entries[4].sampler = device->dummyClipMaskSampler();
     entries[5].binding = 5;
-    entries[5].buffer = vBandsAlloc.buffer;
+    entries[5].buffer = wgpuBufferOf(vBandsAlloc.buffer);
     entries[5].offset = vBandsAlloc.offset;
     entries[5].size = vBandsAlloc.size;
     entries[6].binding = 6;
-    entries[6].buffer = vCurvesAlloc.buffer;
+    entries[6].buffer = wgpuBufferOf(vCurvesAlloc.buffer);
     entries[6].offset = vCurvesAlloc.offset;
     entries[6].size = vCurvesAlloc.size;
     entries[7].binding = 7;
-    entries[7].buffer = hGridAlloc.buffer;
+    entries[7].buffer = wgpuBufferOf(hGridAlloc.buffer);
     entries[7].offset = hGridAlloc.offset;
     entries[7].size = hGridAlloc.size;
     entries[8].binding = 8;
-    entries[8].buffer = vGridAlloc.buffer;
+    entries[8].buffer = wgpuBufferOf(vGridAlloc.buffer);
     entries[8].offset = vGridAlloc.offset;
     entries[8].size = vGridAlloc.size;
     entries[9].binding = 9;
-    entries[9].buffer = hRefsAlloc.buffer;
+    entries[9].buffer = wgpuBufferOf(hRefsAlloc.buffer);
     entries[9].offset = hRefsAlloc.offset;
     entries[9].size = hRefsAlloc.size;
     entries[10].binding = 10;
-    entries[10].buffer = vRefsAlloc.buffer;
+    entries[10].buffer = wgpuBufferOf(vRefsAlloc.buffer);
     entries[10].offset = vRefsAlloc.offset;
     entries[10].size = vRefsAlloc.size;
 
@@ -1017,8 +1030,8 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   }
 
   bool validateAndConsumeSceneBatch(const GeoEncoder::SceneBatchBinding& binding) {
-    if (!binding.chunkBuffer || !binding.recordBuffer || binding.instanceCount == 0u ||
-        binding.vertexCount == 0u) {
+    if (!binding.chunkBuffer.isValid() || !binding.recordBuffer.isValid() ||
+        binding.instanceCount == 0u || binding.vertexCount == 0u) {
       return false;
     }
     if (geometryAdmission == nullptr) {
@@ -1300,6 +1313,7 @@ void GeoEncoder::initImpl(GeoEncoder::Impl& impl, GeodeDevice& device,
                           const GeodeGradientPipeline& gradientPipeline,
                           const GeodeImagePipeline& imagePipeline, const wgpu::Texture& target) {
   impl.device = &device;
+  impl.gpuContext = &device.gpuContext();
   impl.pipeline = &fillPipeline;
   impl.gradientPipeline = &gradientPipeline;
   impl.imagePipeline = &imagePipeline;
@@ -1319,19 +1333,19 @@ void GeoEncoder::finalizeImpl(GeoEncoder::Impl& impl) {
   // Configure per-draw arenas (bump-allocated GPU buffers). They stay
   // empty here; the first draw
   // triggers lazy growth to 64 KiB and doubles from there.
-  impl.bandArena.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
+  impl.bandArena.usage = gpu::BufferUsage::Storage | gpu::BufferUsage::CopyDst;
   impl.bandArena.label = "GeodeBandArena";
-  impl.curveArena.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
+  impl.curveArena.usage = gpu::BufferUsage::Storage | gpu::BufferUsage::CopyDst;
   impl.curveArena.label = "GeodeCurveArena";
-  impl.uniformArena.usage = wgpu::BufferUsage::Uniform | wgpu::BufferUsage::CopyDst;
+  impl.uniformArena.usage = gpu::BufferUsage::Uniform | gpu::BufferUsage::CopyDst;
   impl.uniformArena.label = "GeodeUniformArena";
-  impl.instanceRecordArena.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
+  impl.instanceRecordArena.usage = gpu::BufferUsage::Storage | gpu::BufferUsage::CopyDst;
   impl.instanceRecordArena.label = "GeodeInstanceRecordArena";
-  impl.vBandArena.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
+  impl.vBandArena.usage = gpu::BufferUsage::Storage | gpu::BufferUsage::CopyDst;
   impl.vBandArena.label = "GeodeVBandArena";
-  impl.vCurveArena.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
+  impl.vCurveArena.usage = gpu::BufferUsage::Storage | gpu::BufferUsage::CopyDst;
   impl.vCurveArena.label = "GeodeVCurveArena";
-  impl.gridArena.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
+  impl.gridArena.usage = gpu::BufferUsage::Storage | gpu::BufferUsage::CopyDst;
   impl.gridArena.label = "GeodeGridArena";
 }
 
@@ -1616,15 +1630,15 @@ void GeoEncoder::fillPathIntoMask(const Path& path, FillRule rule,
 
   wgpu::BindGroupEntry entries[11] = {};
   entries[0].binding = 0;
-  entries[0].buffer = uniAlloc.buffer;
+  entries[0].buffer = impl_->wgpuBufferOf(uniAlloc.buffer);
   entries[0].offset = uniAlloc.offset;
   entries[0].size = uniAlloc.size;
   entries[1].binding = 1;
-  entries[1].buffer = bandsAlloc.buffer;
+  entries[1].buffer = impl_->wgpuBufferOf(bandsAlloc.buffer);
   entries[1].offset = bandsAlloc.offset;
   entries[1].size = bandsAlloc.size;
   entries[2].binding = 2;
-  entries[2].buffer = curvesAlloc.buffer;
+  entries[2].buffer = impl_->wgpuBufferOf(curvesAlloc.buffer);
   entries[2].offset = curvesAlloc.offset;
   entries[2].size = curvesAlloc.size;
   entries[3].binding = 3;
@@ -1632,27 +1646,27 @@ void GeoEncoder::fillPathIntoMask(const Path& path, FillRule rule,
   entries[4].binding = 4;
   entries[4].sampler = impl_->device->dummyClipMaskSampler();
   entries[5].binding = 5;
-  entries[5].buffer = vBandsAlloc.buffer;
+  entries[5].buffer = impl_->wgpuBufferOf(vBandsAlloc.buffer);
   entries[5].offset = vBandsAlloc.offset;
   entries[5].size = vBandsAlloc.size;
   entries[6].binding = 6;
-  entries[6].buffer = vCurvesAlloc.buffer;
+  entries[6].buffer = impl_->wgpuBufferOf(vCurvesAlloc.buffer);
   entries[6].offset = vCurvesAlloc.offset;
   entries[6].size = vCurvesAlloc.size;
   entries[7].binding = 7;
-  entries[7].buffer = hGridAlloc.buffer;
+  entries[7].buffer = impl_->wgpuBufferOf(hGridAlloc.buffer);
   entries[7].offset = hGridAlloc.offset;
   entries[7].size = hGridAlloc.size;
   entries[8].binding = 8;
-  entries[8].buffer = vGridAlloc.buffer;
+  entries[8].buffer = impl_->wgpuBufferOf(vGridAlloc.buffer);
   entries[8].offset = vGridAlloc.offset;
   entries[8].size = vGridAlloc.size;
   entries[9].binding = 9;
-  entries[9].buffer = hRefsAlloc.buffer;
+  entries[9].buffer = impl_->wgpuBufferOf(hRefsAlloc.buffer);
   entries[9].offset = hRefsAlloc.offset;
   entries[9].size = hRefsAlloc.size;
   entries[10].binding = 10;
-  entries[10].buffer = vRefsAlloc.buffer;
+  entries[10].buffer = impl_->wgpuBufferOf(vRefsAlloc.buffer);
   entries[10].offset = vRefsAlloc.offset;
   entries[10].size = vRefsAlloc.size;
 
@@ -2010,8 +2024,8 @@ void GeoEncoder::Impl::uploadResidentGeometry(GeodeResidentSlot& slot, const Enc
   blit(slot.hGrid, encoded.hBandGrid.data(), hGridBytes);
   blit(slot.vGrid, encoded.vBandGrid.data(), vGridBytes);
 
-  device->queue().writeBuffer(slot.buffer, alloc.offset, staging.data(), totalSize);
-  device->countBufferWrite(totalSize);
+  (void)gpuContext->gpuDevice->writeBuffer(slot.slab->bufferForId(slot.bufferId), alloc.offset,
+                                           std::span<const uint8_t>(staging.data(), totalSize));
 
   // Regions become absolute buffer offsets for the bind groups.
   auto shift = [&](GeodeResidentSlot::Region& r) {
@@ -2044,7 +2058,7 @@ void GeoEncoder::Impl::uploadResidentGeometry(GeodeResidentSlot& slot, const Enc
 
 void GeoEncoder::Impl::buildResidentBindGroup(GeodeResidentSlot& slot) {
   const wgpu::Device& dev = device->device();
-  const wgpu::Buffer& buf = slot.buffer;
+  const wgpu::Buffer buf = wgpuBufferOf(slot.buffer);
 
   wgpu::BindGroupEntry entries[12] = {};
   auto bufEntry = [&](int i, uint32_t binding, const GeodeResidentSlot::Region& r) {
@@ -2171,8 +2185,9 @@ void GeoEncoder::Impl::publishSlotPaint(GeodeResidentSlot& slot, const FillDrawA
   const auto* bytes = reinterpret_cast<const uint8_t*>(rows);
   if (slot.lastPaint.size() != sizeof(rows) ||
       std::memcmp(slot.lastPaint.data(), bytes, sizeof(rows)) != 0) {
-    device->queue().writeBuffer(slot.buffer, slot.paint.offset, rows, sizeof(rows));
-    device->countBufferWrite(sizeof(rows));
+    (void)gpuContext->gpuDevice->writeBuffer(
+        slot.slab->bufferForId(slot.bufferId), slot.paint.offset,
+        std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(rows), sizeof(rows)));
     if (slot.reservePaintMirror(sizeof(rows))) {
       slot.lastPaint.assign(bytes, bytes + sizeof(rows));
     }
@@ -2191,7 +2206,7 @@ bool GeoEncoder::Impl::ensureResidentSceneRecordImpl(
   // second device rendering a document whose residence was filled by a
   // now-different device (WebGPU rejects cross-device buffers / bind groups).
   const uint64_t fingerprint = residentFingerprint(encoded);
-  const bool needUpload = !slot.resident || !slot.buffer || slot.encodedKey != &encoded ||
+  const bool needUpload = !slot.resident || !slot.buffer.isValid() || slot.encodedKey != &encoded ||
                           slot.encodedFingerprint != fingerprint ||
                           slot.owningDeviceId != device->deviceId();
   if (needUpload) {
@@ -2202,7 +2217,7 @@ bool GeoEncoder::Impl::ensureResidentSceneRecordImpl(
 
   // The upload can fail (no slab, a device mismatch that the caller has
   // not re-wired yet, or a chunk allocation failure).
-  if (!slot.resident || !slot.buffer) {
+  if (!slot.resident || !slot.buffer.isValid()) {
     return false;
   }
 
@@ -2312,8 +2327,9 @@ void GeoEncoder::Impl::publishSoloUniform(GeodeResidentSlot& slot, const FillDra
     return;
   }
 
-  device->queue().writeBuffer(slot.buffer, slot.uniform.offset, &u, sizeof(Uniforms));
-  device->countBufferWrite(sizeof(Uniforms));
+  (void)gpuContext->gpuDevice->writeBuffer(
+      slot.slab->bufferForId(slot.bufferId), slot.uniform.offset,
+      std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(&u), sizeof(Uniforms)));
   if (slot.reserveUniformMirror(sizeof(Uniforms))) {
     slot.lastUniform.assign(uBytes, uBytes + sizeof(Uniforms));
   }
@@ -2324,7 +2340,7 @@ bool GeoEncoder::Impl::publishInstanceRecord(GeodeResidentSlot& slot, const Inst
                                              std::vector<uint8_t>* overrideRecordCache) {
   const GeodeRecordSlab::Slot& recordSlot =
       recordSlotOverride != nullptr ? *recordSlotOverride : slot.recordSlot;
-  if (!recordSlot.buffer) {
+  if (!recordSlot.buffer.isValid()) {
     return false;
   }
 
@@ -2339,9 +2355,9 @@ bool GeoEncoder::Impl::publishInstanceRecord(GeodeResidentSlot& slot, const Inst
     return true;
   }
 
-  device->queue().writeBuffer(recordSlot.buffer, recordSlot.offset, &record,
-                              sizeof(InstanceRecord));
-  device->countBufferWrite(sizeof(InstanceRecord));
+  (void)gpuContext->gpuDevice->writeBuffer(
+      slot.recordSlab->bufferForId(recordSlot.bufferId), recordSlot.offset,
+      std::span<const uint8_t>(rBytes, sizeof(InstanceRecord)));
   if (cache != nullptr) {
     if (recordSlotOverride != nullptr || slot.reserveRecordMirror(sizeof(InstanceRecord))) {
       cache->assign(rBytes, rBytes + sizeof(InstanceRecord));
@@ -2554,7 +2570,7 @@ void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,
     uniAlloc.offset = 0;
     uniAlloc.size = sizeof(Uniforms);
   }
-  if (!uniAlloc.buffer) {
+  if (!uniAlloc.buffer.isValid()) {
     uniAlloc = impl_->allocSceneBatchUniform(u);
   }
 
@@ -2562,19 +2578,19 @@ void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,
   // maxStorageBufferBindingSize (default 128 MiB); kInitialChunkBytes
   // doubling reaches that only for documents far beyond the current
   // corpus, and the failure is a loud bind-group validation error.
-  const uint64_t chunkBytes = binding.chunkBuffer.getSize();
+  const uint64_t chunkBytes = binding.chunkBytes;
   const uint64_t recordSpanStart = binding.firstRecordOffset;
   const uint64_t recordSpanBytes =
       static_cast<uint64_t>(binding.instanceCount) * sizeof(InstanceRecord);
 
   wgpu::BindGroupEntry entries[12] = {};
   entries[0].binding = 0;
-  entries[0].buffer = uniAlloc.buffer;
+  entries[0].buffer = impl_->wgpuBufferOf(uniAlloc.buffer);
   entries[0].offset = uniAlloc.offset;
   entries[0].size = uniAlloc.size;
   auto chunkEntry = [&](int i, uint32_t bindingIndex) {
     entries[i].binding = bindingIndex;
-    entries[i].buffer = binding.chunkBuffer;
+    entries[i].buffer = impl_->wgpuBufferOf(binding.chunkBuffer);
     entries[i].offset = 0;
     entries[i].size = chunkBytes;
   };
@@ -2589,7 +2605,7 @@ void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,
   entries[6].binding = 6;
   entries[6].sampler = impl_->device->dummyClipMaskSampler();
   entries[7].binding = 7;
-  entries[7].buffer = binding.recordBuffer;
+  entries[7].buffer = impl_->wgpuBufferOf(binding.recordBuffer);
   entries[7].offset = recordSpanStart;
   entries[7].size = recordSpanBytes;
   chunkEntry(8, 8);
@@ -2817,7 +2833,7 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args, std::span<const float>
       const uint64_t recordBytes = static_cast<size_t>(instanceCount) * sizeof(InstanceRecord);
       const auto recordAlloc = impl_->allocInArena(impl_->instanceRecordArena, records.data(),
                                                    recordBytes, kStorageOffsetAlignment);
-      recordBuf = recordAlloc.buffer;
+      recordBuf = impl_->wgpuBufferOf(recordAlloc.buffer);
       recordOffset = recordAlloc.offset;
       recordSize = recordAlloc.size;
     }
@@ -2834,15 +2850,15 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args, std::span<const float>
   // dense grid storage, and the gradient paint blocks.
   wgpu::BindGroupEntry entries[12] = {};
   entries[0].binding = 0;
-  entries[0].buffer = uniAlloc.buffer;
+  entries[0].buffer = impl_->wgpuBufferOf(uniAlloc.buffer);
   entries[0].offset = uniAlloc.offset;
   entries[0].size = uniAlloc.size;
   entries[1].binding = 1;
-  entries[1].buffer = bandsAlloc.buffer;
+  entries[1].buffer = impl_->wgpuBufferOf(bandsAlloc.buffer);
   entries[1].offset = bandsAlloc.offset;
   entries[1].size = bandsAlloc.size;
   entries[2].binding = 2;
-  entries[2].buffer = curvesAlloc.buffer;
+  entries[2].buffer = impl_->wgpuBufferOf(curvesAlloc.buffer);
   entries[2].offset = curvesAlloc.offset;
   entries[2].size = curvesAlloc.size;
   entries[3].binding = 3;
@@ -2858,16 +2874,16 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args, std::span<const float>
   entries[7].offset = recordOffset;
   entries[7].size = recordSize;
   entries[8].binding = 8;
-  entries[8].buffer = vBandsAlloc.buffer;
+  entries[8].buffer = impl_->wgpuBufferOf(vBandsAlloc.buffer);
   entries[8].offset = vBandsAlloc.offset;
   entries[8].size = vBandsAlloc.size;
   entries[9].binding = 9;
-  entries[9].buffer = vCurvesAlloc.buffer;
+  entries[9].buffer = impl_->wgpuBufferOf(vCurvesAlloc.buffer);
   entries[9].offset = vCurvesAlloc.offset;
   entries[9].size = vCurvesAlloc.size;
   // One binding for all four grid arrays; the record's bases index into it.
   entries[10].binding = 10;
-  entries[10].buffer = gridSpan.alloc.buffer;
+  entries[10].buffer = impl_->wgpuBufferOf(gridSpan.alloc.buffer);
   entries[10].offset = gridSpan.alloc.offset;
   entries[10].size = gridSpan.alloc.size;
   // The per-frame arena path never carries a record-sourced gradient - a
@@ -3057,8 +3073,8 @@ void GeoEncoder::Impl::uploadResidentGradientGeometry(GeodeResidentGradientSlot&
   blit(slot.hGrid, encoded.hBandGrid.data(), hGridBytes);
   blit(slot.vGrid, encoded.vBandGrid.data(), vGridBytes);
 
-  device->queue().writeBuffer(slot.buffer, alloc.offset, staging.data(), totalSize);
-  device->countBufferWrite(totalSize);
+  (void)gpuContext->gpuDevice->writeBuffer(slot.slab->bufferForId(slot.bufferId), alloc.offset,
+                                           std::span<const uint8_t>(staging.data(), totalSize));
 
   // Regions become absolute buffer offsets for the bind groups.
   auto shift = [&](GeodeResidentGradientSlot::Region& r) {
@@ -3084,7 +3100,7 @@ void GeoEncoder::Impl::uploadResidentGradientGeometry(GeodeResidentGradientSlot&
 
 void GeoEncoder::Impl::buildResidentGradientBindGroup(GeodeResidentGradientSlot& slot) {
   const wgpu::Device& dev = device->device();
-  const wgpu::Buffer& buf = slot.buffer;
+  const wgpu::Buffer buf = wgpuBufferOf(slot.buffer);
 
   // Eleven bindings mirroring `submitGradientDraw`, with the clip-mask
   // texture/sampler slots bound to the device-owned dummies. Residence is
@@ -3138,7 +3154,7 @@ bool GeoEncoder::Impl::submitResidentGradientDraw(GeodeResidentGradientSlot& slo
 
   // Same residence / invalidation guards as `submitResidentFillDraw`.
   const uint64_t fingerprint = residentFingerprint(encoded);
-  const bool needUpload = !slot.resident || !slot.buffer || slot.encodedKey != &encoded ||
+  const bool needUpload = !slot.resident || !slot.buffer.isValid() || slot.encodedKey != &encoded ||
                           slot.encodedFingerprint != fingerprint ||
                           slot.owningDeviceId != device->deviceId();
   if (needUpload) {
@@ -3149,7 +3165,7 @@ bool GeoEncoder::Impl::submitResidentGradientDraw(GeodeResidentGradientSlot& slo
 
   // Upload failure: report it so the caller routes the draw through the
   // per-frame arena path.
-  if (!slot.resident || !slot.buffer) {
+  if (!slot.resident || !slot.buffer.isValid()) {
     return false;
   }
 
@@ -3173,8 +3189,9 @@ void GeoEncoder::Impl::publishGradientUniform(GeodeResidentGradientSlot& slot,
       std::memcmp(slot.lastUniform.data(), uBytes, sizeof(GradientUniforms)) == 0) {
     return;
   }
-  device->queue().writeBuffer(slot.buffer, slot.uniform.offset, &u, sizeof(GradientUniforms));
-  device->countBufferWrite(sizeof(GradientUniforms));
+  (void)gpuContext->gpuDevice->writeBuffer(
+      slot.slab->bufferForId(slot.bufferId), slot.uniform.offset,
+      std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(&u), sizeof(GradientUniforms)));
   if (slot.reserveUniformMirror(sizeof(GradientUniforms))) {
     slot.lastUniform.assign(uBytes, uBytes + sizeof(GradientUniforms));
   }

--- a/donner/svg/renderer/geode/GeoEncoder.h
+++ b/donner/svg/renderer/geode/GeoEncoder.h
@@ -14,6 +14,7 @@
 #include "donner/base/Transform.h"
 #include "donner/base/Vector2.h"
 #include "donner/css/Color.h"
+#include "donner/gpu/CommandEncoder.h"
 #include "donner/gpu/Handles.h"
 #include "donner/svg/core/ImageRendering.h"
 #include "donner/svg/core/MaskType.h"
@@ -170,7 +171,7 @@ public:
   /**
    * Create an encoder targeting the given texture.
    *
-   * @param device The Geode device (owns the wgpu::Device + queue).
+   * @param device The Geode device owning the shared pipelines and counters.
    * @param fillPipeline The Slug fill pipeline.
    * @param gradientPipeline The Slug gradient-fill pipeline.
    * @param imagePipeline The image-blit pipeline.
@@ -180,7 +181,7 @@ public:
    */
   GeoEncoder(GeodeDevice& device, const GeodePipeline& fillPipeline,
              const GeodeGradientPipeline& gradientPipeline, const GeodeImagePipeline& imagePipeline,
-             const wgpu::Texture& target);
+             const gpu::Texture& target, const gpu::Extent2d& targetSize);
 
   /**
    * Shared-CommandEncoder constructor.
@@ -198,7 +199,8 @@ public:
    */
   GeoEncoder(GeodeDevice& device, const GeodePipeline& fillPipeline,
              const GeodeGradientPipeline& gradientPipeline, const GeodeImagePipeline& imagePipeline,
-             const wgpu::Texture& target, wgpu::CommandEncoder sharedCommandEncoder);
+             const gpu::Texture& target, const gpu::Extent2d& targetSize,
+             gpu::CommandEncoder& sharedCommandEncoder);
 
   ~GeoEncoder();
 
@@ -355,7 +357,7 @@ public:
    * @param mask Single-sample RGBA8Unorm target. Sampled by
    *   `setClipMask` after `endMaskPass`.
    */
-  void beginMaskPass(const wgpu::Texture& mask);
+  void beginMaskPass(const gpu::Texture& mask);
 
   /**
    * Fill `path` into the currently open mask pass using the Slug mask
@@ -383,7 +385,7 @@ public:
    * into fragment coverage, so the mask represents a pre-rendered
    * clip region in [0, 1].
    */
-  void setClipMask(const wgpu::TextureView& maskView);
+  void setClipMask(const gpu::TextureView& maskView);
 
   /**
    * Preferred overload: sets both the view AND the parent texture so the
@@ -396,7 +398,7 @@ public:
    * clip stack can free a VkImage while the encoder's
    * `createBindGroup` still references its view.
    */
-  void setClipMask(const wgpu::Texture& maskTexture, const wgpu::TextureView& maskView);
+  void setClipMask(const gpu::Texture& maskTexture, const gpu::TextureView& maskView);
 
   /// Remove any active clip mask, restoring unclipped rasterisation.
   void clearClipMask();
@@ -413,7 +415,7 @@ public:
    * @param src Source texture (RGBA8, premultiplied).
    * @param opacity Overall alpha multiplier in [0, 1].
    */
-  void blitFullTarget(const wgpu::Texture& src, double opacity);
+  void blitFullTarget(const gpu::Texture& src, double opacity);
 
   /**
    * `<mask>` compositing. Same as @ref blitFullTarget but additionally samples a mask texture and
@@ -427,7 +429,7 @@ public:
    * @param maskType Whether mask coverage comes from luminance or alpha.
    * @param maskBounds Optional clip rect in target-pixel space.
    */
-  void blitFullTargetMasked(const wgpu::Texture& content, const wgpu::Texture& mask,
+  void blitFullTargetMasked(const gpu::Texture& content, const gpu::Texture& mask,
                             svg::MaskType maskType, const std::optional<Box2d>& maskBounds);
 
   /**
@@ -454,14 +456,14 @@ public:
    *   combo on the same element composes correctly - the source
    *   colour that enters the blend is `layer * opacity`.
    */
-  void blitFullTargetBlended(const wgpu::Texture& layer, const wgpu::Texture& dstSnapshot,
+  void blitFullTargetBlended(const gpu::Texture& layer, const gpu::Texture& dstSnapshot,
                              uint32_t blendMode, double opacity);
 
   /**
    * Draw a raster image into the given destination rectangle.
    *
    * The image's straight-alpha RGBA8 pixels are uploaded to a fresh
-   * `wgpu::Texture` and sampled through the image-blit pipeline. The
+   * GPU texture and sampled through the image-blit pipeline. The
    * current transform is applied via the MVP matrix, and the destination
    * rectangle is specified in local (pre-transform) coordinates - i.e.,
    * the transform and the rect compose the same way as any other draw
@@ -499,7 +501,7 @@ public:
    *   render-target snapshots are. CPU bitmaps uploaded by host presentation code are
    *   straight-alpha and must pass false.
    */
-  void drawTexture(const wgpu::Texture& texture, const Box2d& destRect, const Box2d& sourceUv,
+  void drawTexture(const gpu::Texture& texture, const Box2d& destRect, const Box2d& sourceUv,
                    double opacity, bool pixelated, bool sourceIsPremultiplied);
 
   /**
@@ -797,7 +799,7 @@ public:
    */
   struct PatternPaint {
     /// Pre-rendered tile texture (RGBA8, premultiplied).
-    wgpu::Texture tile;
+    const gpu::Texture* tile = nullptr;
     /// Size of the tile rectangle in pattern space (width, height). The
     /// shader uses this to wrap sample positions via `fract()`.
     Vector2d tileSize;
@@ -843,7 +845,8 @@ private:
   /// to avoid duplicating ~20 lines of setup. See GeoEncoder.cc.
   static void initImpl(Impl& impl, GeodeDevice& device, const GeodePipeline& fillPipeline,
                        const GeodeGradientPipeline& gradientPipeline,
-                       const GeodeImagePipeline& imagePipeline, const wgpu::Texture& target);
+                       const GeodeImagePipeline& imagePipeline, const gpu::Texture& target,
+                       const gpu::Extent2d& targetSize);
   static void finalizeImpl(Impl& impl);
 
   std::unique_ptr<Impl> impl_;

--- a/donner/svg/renderer/geode/GeoEncoder.h
+++ b/donner/svg/renderer/geode/GeoEncoder.h
@@ -14,6 +14,7 @@
 #include "donner/base/Transform.h"
 #include "donner/base/Vector2.h"
 #include "donner/css/Color.h"
+#include "donner/gpu/Handles.h"
 #include "donner/svg/core/ImageRendering.h"
 #include "donner/svg/core/MaskType.h"
 #include "donner/svg/renderer/geode/GeodeResidentPathComponent.h"
@@ -674,13 +675,15 @@ public:
   /// One cross-entity ordered batch: consecutive resident slots of one
   /// slab chunk plus a run of consecutive record-slab slots.
   struct SceneBatchBinding {
-    wgpu::Buffer chunkBuffer;   ///< Slab chunk holding every instance's geometry.
-    wgpu::Buffer recordBuffer;  ///< Record-slab buffer holding the records.
+    gpu::BufferRef chunkBuffer;   ///< Slab chunk holding every instance's geometry.
+    gpu::BufferRef recordBuffer;  ///< Record-slab buffer holding the records.
     /// Stable identities of `chunkBuffer` / `recordBuffer` (see
     /// `GeodeDevice::AllocateBufferId`). The bind-group cache outlives the
     /// document that owns these buffers, so it keys on these ids; the raw
     /// handle addresses are recycled once that document is destroyed.
     uint64_t chunkBufferId = 0;
+    /// Byte size of `chunkBuffer`; scene batches bind the whole chunk.
+    uint64_t chunkBytes = 0;
     uint64_t recordBufferId = 0;
     /// BYTE offset of the first instance's record inside recordBuffer.
     /// Record-slot indices are global across slab chunks, so an index is

--- a/donner/svg/renderer/geode/GeodeBufferPool.h
+++ b/donner/svg/renderer/geode/GeodeBufferPool.h
@@ -1,6 +1,6 @@
 #pragma once
 /// @file
-/// Frame-transient wgpu buffer pool for GeoEncoder arenas.
+/// Frame-transient GPU buffer pool for GeoEncoder arenas.
 ///
 /// `GeoEncoder` instances are recreated every frame (and per layer /
 /// filter / mask push), so without pooling every frame re-creates its
@@ -13,20 +13,22 @@
 /// the renderer's existing lifetime discipline only runs after the
 /// commands referencing those buffers have been submitted (shared-mode
 /// encoders are parked in `frameFinishedEncoders` until the frame's
-/// single `queue.submit`; own-CommandEncoder encoders submit in
-/// `finish()`). Re-acquiring a pooled buffer on a later frame is safe:
-/// `queue.writeBuffer` is queue-ordered after previously submitted work.
+/// single submit; own-encoder encoders submit in `finish()`).
+/// Re-acquiring a pooled buffer on a later frame is safe: a queued buffer
+/// write is ordered after previously submitted work.
 
 #include <cstdint>
 #include <cstring>
+#include <utility>
 #include <vector>
 
-#include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
+#include "donner/gpu/Descriptors.h"
+#include "donner/gpu/Handles.h"
 
 namespace donner::geode {
 
 /**
- * Size-and-usage-keyed free list of wgpu buffers.
+ * Size-and-usage-keyed free list of GPU buffers.
  *
  * Owned by `RendererGeode::Impl` (mirrors the transient
  * render-target texture pool) and handed to every `GeoEncoder` the
@@ -50,8 +52,8 @@ public:
    * @param outCapacity Set to the returned buffer's capacity on success.
    * @return The buffer, or an empty handle if the pool has no match.
    */
-  ScopedWgpuHandle<wgpu::Buffer> acquire(wgpu::BufferUsage usage, const char* label,
-                                         uint64_t minCapacity, uint64_t* outCapacity) {
+  gpu::Buffer acquire(gpu::BufferUsage usage, const char* label, uint64_t minCapacity,
+                      uint64_t* outCapacity) {
     size_t bestIndex = entries_.size();
     bool bestLabelMatch = false;
     for (size_t i = 0; i < entries_.size(); ++i) {
@@ -70,7 +72,7 @@ public:
     if (bestIndex == entries_.size()) {
       return {};
     }
-    ScopedWgpuHandle<wgpu::Buffer> buffer = std::move(entries_[bestIndex].buffer);
+    gpu::Buffer buffer = std::move(entries_[bestIndex].buffer);
     if (outCapacity != nullptr) {
       *outCapacity = entries_[bestIndex].capacity;
     }
@@ -84,9 +86,8 @@ public:
    * pooled VRAM while keeping the large arenas that are expensive to
    * re-grow.
    */
-  void release(ScopedWgpuHandle<wgpu::Buffer> buffer, wgpu::BufferUsage usage, const char* label,
-               uint64_t capacity) {
-    if (!buffer) {
+  void release(gpu::Buffer buffer, gpu::BufferUsage usage, const char* label, uint64_t capacity) {
+    if (!buffer.isValid()) {
       return;
     }
     if (entries_.size() >= kMaxEntries) {
@@ -114,8 +115,8 @@ public:
 
 private:
   struct Entry {
-    ScopedWgpuHandle<wgpu::Buffer> buffer;
-    wgpu::BufferUsage usage;
+    gpu::Buffer buffer;
+    gpu::BufferUsage usage = gpu::BufferUsage::None;
     const char* label = nullptr;  ///< Arena label (string literal).
     uint64_t capacity = 0;
   };

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -25,6 +25,7 @@
 #include <emscripten/emscripten.h>
 #endif
 #include "donner/base/StringUtils.h"
+#include "donner/gpu/GpuLimits.h"
 #include "donner/svg/renderer/geode/GeodeCheckerboardPipeline.h"
 #include "donner/svg/renderer/geode/GeodeFilterEngine.h"
 #include "donner/svg/renderer/geode/GeodeGpuWait.h"
@@ -234,9 +235,6 @@ void DestroyResourceBacking(ScopedWgpuHandle<Handle>& handle) {
 /// because the host owns the instance.
 struct GeodeDevice::Impl {
   ~Impl() {
-    DestroyResourceBacking(dummyPatternTexture);
-    DestroyResourceBacking(dummyClipMaskTexture);
-    DestroyResourceBacking(identityInstanceRecordBuffer);
     for (auto& [unusedKey, entry] : snapshotReadbackPool) {
       (void)unusedKey;
       DestroyResourceBacking(entry.resources.staging);
@@ -246,33 +244,40 @@ struct GeodeDevice::Impl {
 
   wgpu::Instance instance;
 
-  // Shared dummies used by every GeoEncoder's bind groups - see
-  // comment block on `GeodeDevice::dummyPatternTexture()`. Created
-  // once at `CreateHeadless` time so they never count against
-  // per-frame `textureCreates` ceilings.
-  ScopedWgpuHandle<wgpu::Texture> dummyPatternTexture;
-  ScopedWgpuHandle<wgpu::TextureView> dummyPatternTextureView;
-  ScopedWgpuHandle<wgpu::Sampler> dummyPatternSampler;
-  ScopedWgpuHandle<wgpu::Texture> dummyClipMaskTexture;
-  ScopedWgpuHandle<wgpu::TextureView> dummyClipMaskTextureView;
-  ScopedWgpuHandle<wgpu::Sampler> dummyClipMaskSampler;
-
-  // Zero-filled gradient paint block bound by draws with no residence slot.
-  // See `GeodeDevice::dummyPaintDataBuffer()`.
-  ScopedWgpuHandle<wgpu::Buffer> dummyPaintDataBuffer;
-
-  // 1-element instance-transform buffer bound by every
-  // non-instanced solid fill. Uploaded once at CreateHeadless time,
-  // never modified. Layout matches the WGSL `InstanceRecord` struct, whose
-  // leading member is a row-major affine as two vec4f rows carrying the
-  // identity `{(1,0,0,0), (0,1,0,0)}` followed by zeroes.
-  ScopedWgpuHandle<wgpu::Buffer> identityInstanceRecordBuffer;
+  // Borrowed wgpu aliases of the shared bind-slot resources below, for the call sites that
+  // still build wgpu bind groups. Non-owning: the runtime handles own the backing.
+  wgpu::Texture dummyPatternTexture;
+  wgpu::TextureView dummyPatternTextureView;
+  wgpu::Sampler dummyPatternSampler;
+  wgpu::Texture dummyClipMaskTexture;
+  wgpu::TextureView dummyClipMaskTextureView;
+  wgpu::Sampler dummyClipMaskSampler;
+  wgpu::Buffer dummyPaintDataBuffer;
+  wgpu::Buffer identityInstanceRecordBuffer;
 
   // TEMPORARY design-0053 Phase 1 adapter (see GeodeWgpuAdapterDevice.h for the removal
   // gates). Declared ABOVE the pipelines: the pipeline classes hold donner::gpu RAII handles
   // whose destructors release through the adapter, so the adapter must destruct after them
   // (reverse-declaration order).
   std::unique_ptr<GeodeWgpuAdapterDevice> adapterDevice;
+
+  // Shared bind-slot resources used by every encoder's bind groups: 1x1 identity fills for the
+  // pattern and clip-mask slots of draws that do not use them, one identity instance record,
+  // and one zero-filled gradient paint block. Created once with the shared pipelines, so they
+  // never count against per-frame creation ceilings.
+  gpu::Texture gpuDummyPatternTexture;
+  gpu::TextureView gpuDummyPatternTextureView;
+  gpu::Sampler gpuDummyPatternSampler;
+  gpu::Texture gpuDummyClipMaskTexture;
+  gpu::TextureView gpuDummyClipMaskTextureView;
+  gpu::Sampler gpuDummyClipMaskSampler;
+  /// Layout matches the WGSL `InstanceRecord` struct, whose leading member is a row-major affine
+  /// as two vec4f rows carrying the identity `{(1,0,0,0), (0,1,0,0)}` followed by zeroes.
+  gpu::Buffer gpuIdentityInstanceRecordBuffer;
+  gpu::Buffer gpuDummyPaintDataBuffer;
+
+  /// Recording context handed to encoders, wired once the resources above exist.
+  GeodeGpuContext gpuContext;
 
   // Shared render / compute pipelines. Constructed once per GeodeDevice
   // in `initSharedPipelines` - see the public `pipeline()` / ... / `filterEngine()`
@@ -746,28 +751,28 @@ std::unique_ptr<GeodeDevice> GeodeDevice::CreateHeadless(wgpu::TextureFormat tex
 }
 
 const wgpu::Texture& GeodeDevice::dummyPatternTexture() const {
-  return impl_->dummyPatternTexture.get();
+  return impl_->dummyPatternTexture;
 }
 const wgpu::TextureView& GeodeDevice::dummyPatternTextureView() const {
-  return impl_->dummyPatternTextureView.get();
+  return impl_->dummyPatternTextureView;
 }
 const wgpu::Sampler& GeodeDevice::dummyPatternSampler() const {
-  return impl_->dummyPatternSampler.get();
+  return impl_->dummyPatternSampler;
 }
 const wgpu::Texture& GeodeDevice::dummyClipMaskTexture() const {
-  return impl_->dummyClipMaskTexture.get();
+  return impl_->dummyClipMaskTexture;
 }
 const wgpu::TextureView& GeodeDevice::dummyClipMaskTextureView() const {
-  return impl_->dummyClipMaskTextureView.get();
+  return impl_->dummyClipMaskTextureView;
 }
 const wgpu::Sampler& GeodeDevice::dummyClipMaskSampler() const {
-  return impl_->dummyClipMaskSampler.get();
+  return impl_->dummyClipMaskSampler;
 }
 const wgpu::Buffer& GeodeDevice::identityInstanceRecordBuffer() const {
-  return impl_->identityInstanceRecordBuffer.get();
+  return impl_->identityInstanceRecordBuffer;
 }
 const wgpu::Buffer& GeodeDevice::dummyPaintDataBuffer() const {
-  return impl_->dummyPaintDataBuffer.get();
+  return impl_->dummyPaintDataBuffer;
 }
 
 GeodePipeline& GeodeDevice::pipeline() const {
@@ -963,108 +968,179 @@ void GeodeDevice::initSharedResources() {
       limits.maxTextureDimension2D > 0) {
     maxTextureDimension2D_ = limits.maxTextureDimension2D;
   }
+}
 
-  // Shared dummy textures / samplers used by every GeoEncoder. These are 1x1
-  // identity fills for the pattern and clip-mask bind slots when the current
-  // draw doesn't actually use them. Created before any setCounters() call so
-  // the allocations never count against per-frame ceilings.
+void GeodeDevice::initSharedBindSlotResources() {
+  GeodeWgpuAdapterDevice& adapterDevice = *impl_->adapterDevice;
+
+  // Unwraps a shared-resource creation, halting on failure: these are compile-time-constant 1x1
+  // descriptors, so an error here is a build defect or a lost device, not recoverable state.
+  const auto unwrap = [](auto&& result, const char* what) {
+    if (result.hasError()) {
+      std::fprintf(stderr, "[Geode] %s failed: %s\n", what, result.error().message.c_str());
+      UTILS_RELEASE_ASSERT_MSG(false, "Geode shared bind-slot resource creation failed");
+    }
+    return std::move(result).result();
+  };
+  const auto require = [](gpu::Status status, const char* what) {
+    if (status.hasError()) {
+      std::fprintf(stderr, "[Geode] %s failed: %s\n", what, status.error().message.c_str());
+      UTILS_RELEASE_ASSERT_MSG(false, "Geode shared bind-slot resource upload failed");
+    }
+  };
+
+  // Texture uploads carry the runtime's row-pitch alignment even for a single texel: it is the
+  // strictest alignment across the native APIs, so the layout is stated in those terms rather
+  // than in packed bytes.
+  constexpr uint32_t kSingleTexelRowBytes = gpu::kTexelRowPitchAlignment;
+
+  constexpr gpu::TextureUsage kDummyTextureUsage =
+      gpu::TextureUsage::Sampled | gpu::TextureUsage::CopyDst;
+
+  // Opaque black: a pattern slot bound to this contributes nothing when the shader's paint-mode
+  // gate is off.
+  impl_->gpuDummyPatternTexture = unwrap(adapterDevice.createTexture(gpu::TextureDescriptor{
+                                             "GeodeDeviceDummyPattern", gpu::Extent2d{1, 1},
+                                             gpu::TextureFormat::RGBA8Unorm, kDummyTextureUsage}),
+                                         "GeodeDeviceDummyPattern createTexture");
+  const std::array<uint8_t, 4> patternPixel = {0, 0, 0, 255};
+  require(adapterDevice.writeTexture(impl_->gpuDummyPatternTexture, patternPixel,
+                                     gpu::TexelCopyBufferLayout{0, kSingleTexelRowBytes, 1},
+                                     gpu::Extent2d{1, 1}),
+          "GeodeDeviceDummyPattern writeTexture");
+  impl_->gpuDummyPatternTextureView = unwrap(
+      adapterDevice.createTextureView(impl_->gpuDummyPatternTexture,
+                                      gpu::TextureViewDescriptor{"GeodeDeviceDummyPatternView"}),
+      "GeodeDeviceDummyPatternView createTextureView");
+  impl_->gpuDummyPatternSampler =
+      unwrap(adapterDevice.createSampler(gpu::SamplerDescriptor{
+                 "GeodeDeviceDummyPatternSampler", gpu::FilterMode::Linear, gpu::FilterMode::Linear,
+                 gpu::AddressMode::Repeat, gpu::AddressMode::Repeat}),
+             "GeodeDeviceDummyPatternSampler createSampler");
+
+  // Full coverage: a clip-mask slot bound to this passes everything through.
+  impl_->gpuDummyClipMaskTexture = unwrap(adapterDevice.createTexture(gpu::TextureDescriptor{
+                                              "GeodeDeviceDummyClipMask", gpu::Extent2d{1, 1},
+                                              gpu::TextureFormat::RGBA8Unorm, kDummyTextureUsage}),
+                                          "GeodeDeviceDummyClipMask createTexture");
+  const std::array<uint8_t, 4> clipMaskPixel = {0xFF, 0xFF, 0xFF, 0xFF};
+  require(adapterDevice.writeTexture(impl_->gpuDummyClipMaskTexture, clipMaskPixel,
+                                     gpu::TexelCopyBufferLayout{0, kSingleTexelRowBytes, 1},
+                                     gpu::Extent2d{1, 1}),
+          "GeodeDeviceDummyClipMask writeTexture");
+  impl_->gpuDummyClipMaskTextureView = unwrap(
+      adapterDevice.createTextureView(impl_->gpuDummyClipMaskTexture,
+                                      gpu::TextureViewDescriptor{"GeodeDeviceDummyClipMaskView"}),
+      "GeodeDeviceDummyClipMaskView createTextureView");
+  impl_->gpuDummyClipMaskSampler = unwrap(
+      adapterDevice.createSampler(gpu::SamplerDescriptor{
+          "GeodeDeviceDummyClipMaskSampler", gpu::FilterMode::Linear, gpu::FilterMode::Linear,
+          gpu::AddressMode::ClampToEdge, gpu::AddressMode::ClampToEdge}),
+      "GeodeDeviceDummyClipMaskSampler createSampler");
+
   {
-    wgpu::TextureDescriptor td = {};
-    td.label = wgpu::StringView{std::string_view{"GeodeDeviceDummyPattern"}};
-    td.size = {1u, 1u, 1u};
-    td.format = wgpu::TextureFormat::RGBA8Unorm;
-    td.usage = wgpu::TextureUsage::TextureBinding | wgpu::TextureUsage::CopyDst;
-    td.mipLevelCount = 1;
-    td.sampleCount = 1;
-    td.dimension = wgpu::TextureDimension::_2D;
-    impl_->dummyPatternTexture.reset(device_.createTexture(td));
-
-    const uint8_t pixel[4] = {0, 0, 0, 255};
-    wgpu::TexelCopyTextureInfo dst = {};
-    dst.texture = impl_->dummyPatternTexture.get();
-    wgpu::TexelCopyBufferLayout layout = {};
-    layout.bytesPerRow = 4;
-    layout.rowsPerImage = 1;
-    wgpu::Extent3D extent = {1u, 1u, 1u};
-    queue_.writeTexture(dst, pixel, sizeof(pixel), layout, extent);
-    impl_->dummyPatternTextureView.reset(impl_->dummyPatternTexture.get().createView());
-
-    wgpu::SamplerDescriptor sd{wgpu::Default};
-    sd.label = wgpu::StringView{std::string_view{"GeodeDeviceDummyPatternSampler"}};
-    sd.addressModeU = wgpu::AddressMode::Repeat;
-    sd.addressModeV = wgpu::AddressMode::Repeat;
-    sd.minFilter = wgpu::FilterMode::Linear;
-    sd.magFilter = wgpu::FilterMode::Linear;
-    sd.maxAnisotropy = 1;
-    impl_->dummyPatternSampler.reset(device_.createSampler(sd));
-  }
-
-  {
-    wgpu::TextureDescriptor md = {};
-    md.label = wgpu::StringView{std::string_view{"GeodeDeviceDummyClipMask"}};
-    md.size = {1u, 1u, 1u};
-    md.format = wgpu::TextureFormat::RGBA8Unorm;
-    md.usage = wgpu::TextureUsage::TextureBinding | wgpu::TextureUsage::CopyDst;
-    md.mipLevelCount = 1;
-    md.sampleCount = 1;
-    md.dimension = wgpu::TextureDimension::_2D;
-    impl_->dummyClipMaskTexture.reset(device_.createTexture(md));
-
-    const uint8_t mpixel[4] = {0xFF, 0xFF, 0xFF, 0xFF};
-    wgpu::TexelCopyTextureInfo mdst = {};
-    mdst.texture = impl_->dummyClipMaskTexture.get();
-    wgpu::TexelCopyBufferLayout mlayout = {};
-    mlayout.bytesPerRow = 4;
-    mlayout.rowsPerImage = 1;
-    wgpu::Extent3D mextent = {1u, 1u, 1u};
-    queue_.writeTexture(mdst, mpixel, sizeof(mpixel), mlayout, mextent);
-    impl_->dummyClipMaskTextureView.reset(impl_->dummyClipMaskTexture.get().createView());
-
-    wgpu::SamplerDescriptor msd{wgpu::Default};
-    msd.label = wgpu::StringView{std::string_view{"GeodeDeviceDummyClipMaskSampler"}};
-    msd.addressModeU = wgpu::AddressMode::ClampToEdge;
-    msd.addressModeV = wgpu::AddressMode::ClampToEdge;
-    msd.minFilter = wgpu::FilterMode::Linear;
-    msd.magFilter = wgpu::FilterMode::Linear;
-    msd.maxAnisotropy = 1;
-    impl_->dummyClipMaskSampler.reset(device_.createSampler(msd));
-  }
-
-  {
-    // One full-size record: the identity affine in the leading two rows and
-    // zeroes everywhere else, so a draw that binds it reads an identity
-    // transform for instance 0. 256 bytes is the WGSL `InstanceRecord`
-    // stride and the baseline `minStorageBufferOffsetAlignment`;
-    // `GeodeResidentPathComponent.h` owns the struct and static_asserts the
-    // same size, but it includes this header, so the constant is spelled out
-    // here rather than included back.
+    // One full-size record: the identity affine in the leading two rows and zeroes everywhere
+    // else, so a draw that binds it reads an identity transform for instance 0. 256 bytes is the
+    // WGSL `InstanceRecord` stride and the baseline storage-binding offset alignment;
+    // `GeodeResidentPathComponent.h` owns the struct and static_asserts the same size, but it
+    // includes this header, so the constant is spelled out here rather than included back.
     constexpr size_t kInstanceRecordFloats = 256 / sizeof(float);
-    float identityRecord[kInstanceRecordFloats] = {};
+    std::array<float, kInstanceRecordFloats> identityRecord = {};
     identityRecord[0] = 1.0f;
     identityRecord[5] = 1.0f;
-    wgpu::BufferDescriptor bd = {};
-    bd.label = wgpu::StringView{std::string_view{"GeodeDeviceIdentityInstanceRecord"}};
-    bd.size = sizeof(identityRecord);
-    bd.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
-    impl_->identityInstanceRecordBuffer.reset(device_.createBuffer(bd));
-    queue_.writeBuffer(impl_->identityInstanceRecordBuffer.get(), 0, identityRecord,
-                       sizeof(identityRecord));
+    impl_->gpuIdentityInstanceRecordBuffer =
+        unwrap(adapterDevice.createBuffer(gpu::BufferDescriptor{
+                   "GeodeDeviceIdentityInstanceRecord", sizeof(identityRecord),
+                   gpu::BufferUsage::Storage | gpu::BufferUsage::CopyDst}),
+               "GeodeDeviceIdentityInstanceRecord createBuffer");
+    require(adapterDevice.writeBuffer(
+                impl_->gpuIdentityInstanceRecordBuffer, 0,
+                std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(identityRecord.data()),
+                                         sizeof(identityRecord))),
+            "GeodeDeviceIdentityInstanceRecord writeBuffer");
   }
 
   {
-    // One zero-filled gradient paint block, sized from the shared row count so
-    // it cannot drift from the layout the encoder writes and the fill shader
-    // reads. A whole block, rather than a single element, keeps any accidental
-    // read inside the binding.
+    // One zero-filled gradient paint block, sized from the shared row count so it cannot drift
+    // from the layout the encoder writes and the fill shader reads. A whole block, rather than a
+    // single element, keeps any accidental read inside the binding.
     constexpr size_t kPaintBlockFloats = kGradientPaintBlockRows * 4;
-    const float zeroPaint[kPaintBlockFloats] = {};
-    wgpu::BufferDescriptor bd = {};
-    bd.label = wgpu::StringView{std::string_view{"GeodeDeviceDummyPaintData"}};
-    bd.size = sizeof(zeroPaint);
-    bd.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
-    impl_->dummyPaintDataBuffer.reset(device_.createBuffer(bd));
-    queue_.writeBuffer(impl_->dummyPaintDataBuffer.get(), 0, zeroPaint, sizeof(zeroPaint));
+    const std::array<float, kPaintBlockFloats> zeroPaint = {};
+    impl_->gpuDummyPaintDataBuffer =
+        unwrap(adapterDevice.createBuffer(
+                   gpu::BufferDescriptor{"GeodeDeviceDummyPaintData", sizeof(zeroPaint),
+                                         gpu::BufferUsage::Storage | gpu::BufferUsage::CopyDst}),
+               "GeodeDeviceDummyPaintData createBuffer");
+    require(adapterDevice.writeBuffer(
+                impl_->gpuDummyPaintDataBuffer, 0,
+                std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(zeroPaint.data()),
+                                         sizeof(zeroPaint))),
+            "GeodeDeviceDummyPaintData writeBuffer");
   }
+
+  // Borrowed wgpu aliases for the call sites that still build wgpu bind groups.
+  impl_->dummyPatternTexture = adapterDevice.wgpuTextureOf(impl_->gpuDummyPatternTexture);
+  impl_->dummyPatternTextureView =
+      adapterDevice.wgpuTextureViewOf(impl_->gpuDummyPatternTextureView);
+  impl_->dummyPatternSampler = adapterDevice.wgpuSamplerOf(impl_->gpuDummyPatternSampler);
+  impl_->dummyClipMaskTexture = adapterDevice.wgpuTextureOf(impl_->gpuDummyClipMaskTexture);
+  impl_->dummyClipMaskTextureView =
+      adapterDevice.wgpuTextureViewOf(impl_->gpuDummyClipMaskTextureView);
+  impl_->dummyClipMaskSampler = adapterDevice.wgpuSamplerOf(impl_->gpuDummyClipMaskSampler);
+  impl_->identityInstanceRecordBuffer =
+      adapterDevice.wgpuBufferOf(impl_->gpuIdentityInstanceRecordBuffer);
+  impl_->dummyPaintDataBuffer = adapterDevice.wgpuBufferOf(impl_->gpuDummyPaintDataBuffer);
+
+  impl_->gpuContext = GeodeGpuContext{};
+  impl_->gpuContext.gpuDevice = &adapterDevice;
+  impl_->gpuContext.geodeDevice = this;
+  impl_->gpuContext.dummyPatternTextureView = &impl_->gpuDummyPatternTextureView;
+  impl_->gpuContext.dummyPatternSampler = &impl_->gpuDummyPatternSampler;
+  impl_->gpuContext.dummyClipMaskTextureView = &impl_->gpuDummyClipMaskTextureView;
+  impl_->gpuContext.dummyClipMaskSampler = &impl_->gpuDummyClipMaskSampler;
+  impl_->gpuContext.identityInstanceRecordBuffer = &impl_->gpuIdentityInstanceRecordBuffer;
+  impl_->gpuContext.dummyPaintDataBuffer = &impl_->gpuDummyPaintDataBuffer;
+}
+
+const GeodeGpuContext& GeodeDevice::gpuContext() const {
+  return impl_->gpuContext;
+}
+
+void GeodeGpuContext::countBuffer() const {
+  if (geodeDevice != nullptr) geodeDevice->countBuffer();
+}
+void GeodeGpuContext::countTexture() const {
+  if (geodeDevice != nullptr) geodeDevice->countTexture();
+}
+void GeodeGpuContext::countBindGroup() const {
+  if (geodeDevice != nullptr) geodeDevice->countBindGroup();
+}
+void GeodeGpuContext::countDraw() const {
+  if (geodeDevice != nullptr) geodeDevice->countDraw();
+}
+void GeodeGpuContext::countPipelineSwitch() const {
+  if (geodeDevice != nullptr) geodeDevice->countPipelineSwitch();
+}
+void GeodeGpuContext::countPathEncode() const {
+  if (geodeDevice != nullptr) geodeDevice->countPathEncode();
+}
+void GeodeGpuContext::countBufferWrite(uint64_t bytes) const {
+  if (geodeDevice != nullptr) geodeDevice->countBufferWrite(bytes);
+}
+void GeodeGpuContext::countTextureWrite(uint64_t bytes) const {
+  if (geodeDevice != nullptr) geodeDevice->countTextureWrite(bytes);
+}
+void GeodeGpuContext::countSubmit() const {
+  if (geodeDevice != nullptr) geodeDevice->countSubmit();
+}
+
+GeodeMaskPipeline& GeodeGpuContext::maskPipeline() const {
+  if (maskPipelineOverride != nullptr) {
+    return *maskPipelineOverride;
+  }
+  UTILS_RELEASE_ASSERT_MSG(geodeDevice != nullptr,
+                           "a recording context needs either a mask pipeline override or a device");
+  return geodeDevice->maskPipeline();
 }
 
 void GeodeDevice::initSharedPipelines() {
@@ -1073,6 +1149,7 @@ void GeodeDevice::initSharedPipelines() {
   const gpu::TextureFormat fmt = GpuTextureFormatFromWgpu(textureFormat_);
 
   impl_->adapterDevice = std::make_unique<GeodeWgpuAdapterDevice>(*this);
+  initSharedBindSlotResources();
   impl_->pipeline = std::make_unique<GeodePipeline>(*impl_->adapterDevice, fmt);
   impl_->gradientPipeline = std::make_unique<GeodeGradientPipeline>(*impl_->adapterDevice, fmt);
   impl_->imagePipeline = std::make_unique<GeodeImagePipeline>(*impl_->adapterDevice, fmt);

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -246,14 +246,6 @@ struct GeodeDevice::Impl {
 
   // Borrowed wgpu aliases of the shared bind-slot resources below, for the call sites that
   // still build wgpu bind groups. Non-owning: the runtime handles own the backing.
-  wgpu::Texture dummyPatternTexture;
-  wgpu::TextureView dummyPatternTextureView;
-  wgpu::Sampler dummyPatternSampler;
-  wgpu::Texture dummyClipMaskTexture;
-  wgpu::TextureView dummyClipMaskTextureView;
-  wgpu::Sampler dummyClipMaskSampler;
-  wgpu::Buffer dummyPaintDataBuffer;
-  wgpu::Buffer identityInstanceRecordBuffer;
 
   // TEMPORARY design-0053 Phase 1 adapter (see GeodeWgpuAdapterDevice.h for the removal
   // gates). Declared ABOVE the pipelines: the pipeline classes hold donner::gpu RAII handles
@@ -750,31 +742,6 @@ std::unique_ptr<GeodeDevice> GeodeDevice::CreateHeadless(wgpu::TextureFormat tex
 #endif
 }
 
-const wgpu::Texture& GeodeDevice::dummyPatternTexture() const {
-  return impl_->dummyPatternTexture;
-}
-const wgpu::TextureView& GeodeDevice::dummyPatternTextureView() const {
-  return impl_->dummyPatternTextureView;
-}
-const wgpu::Sampler& GeodeDevice::dummyPatternSampler() const {
-  return impl_->dummyPatternSampler;
-}
-const wgpu::Texture& GeodeDevice::dummyClipMaskTexture() const {
-  return impl_->dummyClipMaskTexture;
-}
-const wgpu::TextureView& GeodeDevice::dummyClipMaskTextureView() const {
-  return impl_->dummyClipMaskTextureView;
-}
-const wgpu::Sampler& GeodeDevice::dummyClipMaskSampler() const {
-  return impl_->dummyClipMaskSampler;
-}
-const wgpu::Buffer& GeodeDevice::identityInstanceRecordBuffer() const {
-  return impl_->identityInstanceRecordBuffer;
-}
-const wgpu::Buffer& GeodeDevice::dummyPaintDataBuffer() const {
-  return impl_->dummyPaintDataBuffer;
-}
-
 GeodePipeline& GeodeDevice::pipeline() const {
   return *impl_->pipeline;
 }
@@ -1078,19 +1045,6 @@ void GeodeDevice::initSharedBindSlotResources() {
             "GeodeDeviceDummyPaintData writeBuffer");
   }
 
-  // Borrowed wgpu aliases for the call sites that still build wgpu bind groups.
-  impl_->dummyPatternTexture = adapterDevice.wgpuTextureOf(impl_->gpuDummyPatternTexture);
-  impl_->dummyPatternTextureView =
-      adapterDevice.wgpuTextureViewOf(impl_->gpuDummyPatternTextureView);
-  impl_->dummyPatternSampler = adapterDevice.wgpuSamplerOf(impl_->gpuDummyPatternSampler);
-  impl_->dummyClipMaskTexture = adapterDevice.wgpuTextureOf(impl_->gpuDummyClipMaskTexture);
-  impl_->dummyClipMaskTextureView =
-      adapterDevice.wgpuTextureViewOf(impl_->gpuDummyClipMaskTextureView);
-  impl_->dummyClipMaskSampler = adapterDevice.wgpuSamplerOf(impl_->gpuDummyClipMaskSampler);
-  impl_->identityInstanceRecordBuffer =
-      adapterDevice.wgpuBufferOf(impl_->gpuIdentityInstanceRecordBuffer);
-  impl_->dummyPaintDataBuffer = adapterDevice.wgpuBufferOf(impl_->gpuDummyPaintDataBuffer);
-
   impl_->gpuContext = GeodeGpuContext{};
   impl_->gpuContext.gpuDevice = &adapterDevice;
   impl_->gpuContext.geodeDevice = this;
@@ -1114,9 +1068,6 @@ void GeodeGpuContext::countTexture() const {
 }
 void GeodeGpuContext::countBindGroup() const {
   if (geodeDevice != nullptr) geodeDevice->countBindGroup();
-}
-void GeodeGpuContext::countDraw() const {
-  if (geodeDevice != nullptr) geodeDevice->countDraw();
 }
 void GeodeGpuContext::countPipelineSwitch() const {
   if (geodeDevice != nullptr) geodeDevice->countPipelineSwitch();
@@ -1157,10 +1108,10 @@ void GeodeDevice::initSharedPipelines() {
   impl_->filterEngine = std::make_unique<GeodeFilterEngine>(*this, /*verbose=*/false);
 }
 
-wgpu::BindGroup GeodeDevice::findSceneBatchBindGroup(const SceneBatchBindGroupKey& key) {
+const gpu::BindGroup* GeodeDevice::findSceneBatchBindGroup(const SceneBatchBindGroupKey& key) {
   const auto it = sceneBatchBindGroups_.find(key);
   if (it == sceneBatchBindGroups_.end()) {
-    return wgpu::BindGroup{};
+    return nullptr;
   }
   // Refresh recency: move the key to the back of the eviction order so the
   // cap evicts least-recently-USED. One linear scan of at most
@@ -1172,11 +1123,11 @@ wgpu::BindGroup GeodeDevice::findSceneBatchBindGroup(const SceneBatchBindGroupKe
     sceneBatchBindGroupOrder_.erase(orderIt);
     sceneBatchBindGroupOrder_.push_back(key);
   }
-  return it->second.get();
+  return &it->second;
 }
 
-void GeodeDevice::storeSceneBatchBindGroup(const SceneBatchBindGroupKey& key,
-                                           wgpu::BindGroup group) {
+const gpu::BindGroup& GeodeDevice::storeSceneBatchBindGroup(const SceneBatchBindGroupKey& key,
+                                                            gpu::BindGroup group) {
   // The deque holds one entry per live map key, in insertion order: a key is
   // pushed only when it was newly inserted, and popped only together with the
   // erase of that same key. Nothing else touches either container, so the two
@@ -1184,14 +1135,21 @@ void GeodeDevice::storeSceneBatchBindGroup(const SceneBatchBindGroupKey& key,
   assert(sceneBatchBindGroupOrder_.size() == sceneBatchBindGroups_.size());
   while (sceneBatchBindGroups_.size() >= kSceneBatchBindGroupCacheCap &&
          !sceneBatchBindGroupOrder_.empty()) {
-    sceneBatchBindGroups_.erase(sceneBatchBindGroupOrder_.front());
+    // Hand the evicted group to the frame-boundary destroy pass rather than dropping it here:
+    // draws recorded earlier in this frame may still name it, and they are only replayed to the
+    // backend later.
+    const auto evicted = sceneBatchBindGroups_.find(sceneBatchBindGroupOrder_.front());
+    if (evicted != sceneBatchBindGroups_.end()) {
+      deferDestroy(std::move(evicted->second));
+      sceneBatchBindGroups_.erase(evicted);
+    }
     sceneBatchBindGroupOrder_.pop_front();
   }
-  if (sceneBatchBindGroups_
-          .insert_or_assign(key, ScopedWgpuHandle<wgpu::BindGroup>(std::move(group)))
-          .second) {
+  const auto inserted = sceneBatchBindGroups_.insert_or_assign(key, std::move(group));
+  if (inserted.second) {
     sceneBatchBindGroupOrder_.push_back(key);
   }
+  return inserted.first->second;
 }
 
 void GeodeDevice::deferDestroy(wgpu::Buffer buffer) {
@@ -1206,9 +1164,16 @@ void GeodeDevice::deferDestroy(wgpu::Texture texture) {
   }
 }
 
+void GeodeDevice::deferDestroy(gpu::BindGroup bindGroup) {
+  if (bindGroup.isValid()) {
+    pendingBindGroups_.push_back(std::move(bindGroup));
+  }
+}
+
 void GeodeDevice::drainDeferredDestroys() {
   pendingBuffers_.clear();
   pendingTextures_.clear();
+  pendingBindGroups_.clear();
 }
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -337,6 +337,13 @@ public:
   void deferDestroy(wgpu::Texture texture);
 
   /**
+   * Enqueue a bind group for deferred destruction. Same semantics as the buffer variant: a bind
+   * group evicted from a cache may still be named by draws that have been recorded but not yet
+   * replayed to the backend, and destroying it there fails those draws closed.
+   */
+  void deferDestroy(gpu::BindGroup bindGroup);
+
+  /**
    * Drop all deferred-destroy handles, releasing their GPU resources.
    *
    * Called at the top of each frame (before new allocations) so resources
@@ -423,7 +430,7 @@ public:
   /// the coldest entry rather than the oldest-inserted one - with more than
   /// the cap of live groups, pure insertion order would evict the hottest
   /// steady-state entry every frame.
-  [[nodiscard]] wgpu::BindGroup findSceneBatchBindGroup(const SceneBatchBindGroupKey& key);
+  [[nodiscard]] const gpu::BindGroup* findSceneBatchBindGroup(const SceneBatchBindGroupKey& key);
 
   /// Store a scene-batch bind group under `key`, taking ownership of the
   /// +1 handle. At the cap, the OLDEST entries are evicted one at a time
@@ -434,7 +441,8 @@ public:
   /// Insertion order puts those dead entries first. Recorded command buffers
   /// keep their own references, so dropping the cache's handle mid-frame is
   /// safe either way.
-  void storeSceneBatchBindGroup(const SceneBatchBindGroupKey& key, wgpu::BindGroup group);
+  const gpu::BindGroup& storeSceneBatchBindGroup(const SceneBatchBindGroupKey& key,
+                                                 gpu::BindGroup group);
 
   /**
    * Process-unique identity for this device instance, assigned at
@@ -634,45 +642,9 @@ public:
   /// push/pop. Caching the dummies on the device - one instance per
   /// GeodeDevice - drops that to zero steady-state.
 
-  /// 1×1 opaque-black RGBA8 dummy. Bound into the pattern slot when
-  /// the current draw is solid / gradient (not a pattern). The shader
-  /// does not sample from it, but the bind group layout still requires
-  /// a valid binding.
-  const wgpu::Texture& dummyPatternTexture() const;
-  /// View of `dummyPatternTexture()`.
-  const wgpu::TextureView& dummyPatternTextureView() const;
-  /// Linear-Repeat sampler used for both the dummy and real pattern tiles.
-  const wgpu::Sampler& dummyPatternSampler() const;
-
-  /// 1×1 R8Unorm with value `0xFF` (= 1.0 coverage). Bound into the
-  /// clip-mask slot when no clip mask is active - the shader
-  /// multiplies coverage by this value, so `1.0` is a no-op.
-  const wgpu::Texture& dummyClipMaskTexture() const;
-  /// View of `dummyClipMaskTexture()`.
-  const wgpu::TextureView& dummyClipMaskTextureView() const;
-  /// Linear-ClampToEdge sampler used for both the dummy and real clip masks.
-  const wgpu::Sampler& dummyClipMaskSampler() const;
-
-  /// One-element instance-record storage buffer carrying the identity
-  /// affine and zeroed parameters. Bound at binding 7 of the Slug fill
-  /// bind-group layout by every draw that is not a cross-entity batch, so
-  /// the bind-group layout stays stable across draw calls and those draws
-  /// need no record storage of their own: their transform is baked into
-  /// `uniforms.mvp` and their paint rides in the uniform.
-  ///
-  /// Layout mirrors the WGSL `InstanceRecord` struct in
-  /// `shaders/slug_fill.wgsl`, whose leading member is a row-major affine
-  /// as two `vec4f`, so the identity is `{(1, 0, 0, 0), (0, 1, 0, 0)}`
-  /// followed by zeroes. The `.z` components carry the translation (0 for
-  /// identity).
-  const wgpu::Buffer& identityInstanceRecordBuffer() const;
-
-  /// Zero-filled gradient paint block, one full block long. Bound at binding
-  /// 11 of the Slug fill bind-group layout by draws that have no residence
-  /// slot to bind: those draws are solid or pattern painted and never read
-  /// the array, but the binding must still resolve to a range holding at
-  /// least one whole element of the shader's array stride.
-  const wgpu::Buffer& dummyPaintDataBuffer() const;
+  /// The shared bind-slot resources - 1x1 dummy pattern texture and view, 1x1 full-coverage
+  /// clip-mask texture and view, their samplers, a one-element identity instance record, and a
+  /// zero-filled gradient paint block - are reached through \ref gpuContext.
   /// @}
 
   /// @name Shared render / compute pipelines (issue #575 fix)
@@ -838,13 +810,14 @@ private:
   // alive until drainDeferredDestroys() drops them at the next frame boundary.
   std::vector<ScopedWgpuHandle<wgpu::Buffer>> pendingBuffers_;
   std::vector<ScopedWgpuHandle<wgpu::Texture>> pendingTextures_;
+  std::vector<gpu::BindGroup> pendingBindGroups_;
 
   // Scene-batch bind groups cached across frames (see
   // SceneBatchBindGroupKey). Bounded by kSceneBatchBindGroupCacheCap, with
   // `sceneBatchBindGroupOrder_` recording insertion order so the eviction at
   // the cap drops the oldest entries instead of everything.
   static constexpr std::size_t kSceneBatchBindGroupCacheCap = 256;
-  std::map<SceneBatchBindGroupKey, ScopedWgpuHandle<wgpu::BindGroup>> sceneBatchBindGroups_;
+  std::map<SceneBatchBindGroupKey, gpu::BindGroup> sceneBatchBindGroups_;
   std::deque<SceneBatchBindGroupKey> sceneBatchBindGroupOrder_;
 };
 

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -12,7 +12,9 @@
 #include <vector>
 #include <webgpu/webgpu.hpp>
 
+#include "donner/base/Utils.h"
 #include "donner/svg/renderer/geode/GeodeCounters.h"
+#include "donner/svg/renderer/geode/GeodeGpuContext.h"
 #include "donner/svg/renderer/geode/GeodeGpuWait.h"
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 
@@ -750,7 +752,12 @@ public:
   /// The TEMPORARY design-0053 Phase 1 adapter implementing \c donner::gpu::Device over this
   /// device's wgpu objects. Owned here alongside the shared pipelines (which are created
   /// through it); see GeodeWgpuAdapterDevice.h for the removal gates.
-  GeodeWgpuAdapterDevice& adapterDevice() const;
+  GeodeWgpuAdapterDevice& adapterDevice() const UTILS_LIFETIME_BOUND;
+
+  /// The recording context Geode's encoders record a frame against: this device's GPU runtime
+  /// device, its shared bind-slot resources, and its counter sinks. Wired once with the shared
+  /// pipelines and owned here, so it lives exactly as long as this device does.
+  const GeodeGpuContext& gpuContext() const UTILS_LIFETIME_BOUND;
 
 private:
   GeodeDevice();
@@ -759,6 +766,10 @@ private:
   /// `queue_`, and `textureFormat_` are finalised. Called from both
   /// `CreateHeadless` and `CreateFromExternal`.
   void initSharedResources();
+  /// Creates the shared bind-slot resources through the GPU runtime and wires \ref gpuContext.
+  /// Runs with the shared pipelines, once the adapter exists.
+  void initSharedBindSlotResources();
+
   void initSharedPipelines();
 
   // Order matters: queue/device/adapter/instance destroy bottom-up.

--- a/donner/svg/renderer/geode/GeodeGlyphResidency.h
+++ b/donner/svg/renderer/geode/GeodeGlyphResidency.h
@@ -596,7 +596,7 @@ struct GeodeTextInstanceRecordComponent {
   void freeRecordSlots() {
     if (recordSlab) {
       for (const OccurrenceOwner& occurrence : occurrences) {
-        if (occurrence && occurrence->slot.buffer) {
+        if (occurrence && occurrence->slot.buffer.isValid()) {
           recordSlab->freeSlot(occurrence->slot);
         }
       }

--- a/donner/svg/renderer/geode/GeodeGpuContext.h
+++ b/donner/svg/renderer/geode/GeodeGpuContext.h
@@ -66,8 +66,6 @@ struct GeodeGpuContext {
   void countTexture() const;
   /// Forwards to `GeodeDevice::countBindGroup` when wired.
   void countBindGroup() const;
-  /// Forwards to `GeodeDevice::countDraw` when wired.
-  void countDraw() const;
   /// Forwards to `GeodeDevice::countPipelineSwitch` when wired.
   void countPipelineSwitch() const;
   /// Forwards to `GeodeDevice::countPathEncode` when wired.

--- a/donner/svg/renderer/geode/GeodeGpuContext.h
+++ b/donner/svg/renderer/geode/GeodeGpuContext.h
@@ -1,0 +1,145 @@
+#pragma once
+/// @file
+/// \c donner::geode::GeodeGpuContext - the \c donner::gpu facing context Geode's encoders record
+/// against, plus \c donner::geode::GeodeTransientResources, the per-recording RAII holder for
+/// transient GPU handles.
+
+#include <cstdint>
+#include <deque>
+#include <utility>
+
+#include "donner/gpu/Handles.h"
+
+namespace donner::gpu {
+class Device;
+}  // namespace donner::gpu
+
+namespace donner::geode {
+
+class GeodeDevice;
+class GeodeMaskPipeline;
+
+/**
+ * Everything Geode's encoders need to record a frame through the \c donner::gpu runtime.
+ *
+ * Production wires one of these from \c GeodeDevice (see `GeodeDevice::gpuContext()`): the
+ * `gpuDevice` is the device's adapter, the dummy resources are the shared device-owned identity
+ * fills for inactive pattern / clip-mask / paint bind slots, and the counter helpers forward to
+ * the \c GeodeDevice perf counters. A test harness can instead construct one against a GPU-less
+ * \c donner::gpu::Device with `geodeDevice == nullptr` (counters become no-ops) and
+ * `maskPipelineOverride` set.
+ *
+ * Non-owning: every pointer references state owned by the wiring scope, which must outlive any
+ * encoder recording against this context.
+ */
+struct GeodeGpuContext {
+  /// The GPU runtime device recording is performed against. Required (never null when wired).
+  gpu::Device* gpuDevice = nullptr;
+
+  /// Optional counter sink + lazy mask-pipeline owner. Null in GPU-less test harnesses.
+  GeodeDevice* geodeDevice = nullptr;
+
+  /// 1x1 opaque-black RGBA8 dummy view bound into the pattern slot of solid / gradient draws.
+  const gpu::TextureView* dummyPatternTextureView = nullptr;
+  /// Linear-Repeat sampler paired with \ref dummyPatternTextureView (and real pattern tiles).
+  const gpu::Sampler* dummyPatternSampler = nullptr;
+  /// 1x1 full-coverage dummy view bound into the clip-mask slot when no clip mask is active.
+  const gpu::TextureView* dummyClipMaskTextureView = nullptr;
+  /// Linear-ClampToEdge sampler paired with \ref dummyClipMaskTextureView (and real masks).
+  const gpu::Sampler* dummyClipMaskSampler = nullptr;
+  /// One full-size identity instance record, bound by every non-instanced Slug fill.
+  const gpu::Buffer* identityInstanceRecordBuffer = nullptr;
+  /// One zero-filled gradient paint block, bound by draws that carry no gradient paint.
+  const gpu::Buffer* dummyPaintDataBuffer = nullptr;
+
+  /// Test override for \ref maskPipeline. Production leaves this null and resolves the shared
+  /// lazily-built pipeline through \ref geodeDevice.
+  GeodeMaskPipeline* maskPipelineOverride = nullptr;
+
+  // Counter helpers: exact forwarders to the GeodeDevice counter hooks so counter behavior is
+  // unchanged by the migration; cheap no-ops when `geodeDevice` is null. Defined in
+  // GeodeDevice.cc, where GeodeDevice is complete.
+
+  /// Forwards to `GeodeDevice::countBuffer` when wired.
+  void countBuffer() const;
+  /// Forwards to `GeodeDevice::countTexture` when wired.
+  void countTexture() const;
+  /// Forwards to `GeodeDevice::countBindGroup` when wired.
+  void countBindGroup() const;
+  /// Forwards to `GeodeDevice::countDraw` when wired.
+  void countDraw() const;
+  /// Forwards to `GeodeDevice::countPipelineSwitch` when wired.
+  void countPipelineSwitch() const;
+  /// Forwards to `GeodeDevice::countPathEncode` when wired.
+  void countPathEncode() const;
+  /// Forwards to `GeodeDevice::countBufferWrite` when wired.
+  /// @param bytes Payload byte count.
+  void countBufferWrite(uint64_t bytes) const;
+  /// Forwards to `GeodeDevice::countTextureWrite` when wired.
+  /// @param bytes Payload byte count.
+  void countTextureWrite(uint64_t bytes) const;
+  /// Forwards to `GeodeDevice::countSubmit` when wired.
+  void countSubmit() const;
+
+  /// The Slug mask pipeline: \ref maskPipelineOverride when set (tests), otherwise the shared
+  /// lazily-built `GeodeDevice::maskPipeline()`. Requires one of the two to be available.
+  GeodeMaskPipeline& maskPipeline() const;
+};
+
+/**
+ * RAII holder for transient GPU handles created while recording draws - per-draw uniform
+ * buffers, texture views, samplers, and bind groups. Everything retained here MUST stay alive
+ * until the frame's submit returns: submit re-validates every recorded resource identity and
+ * fails closed on a destroyed handle, so this keepalive is mandatory-by-validation.
+ */
+struct GeodeTransientResources {
+  // Deques, not vectors: `retain` hands out references that stay bound until the frame's submit
+  // returns, and a vector's reallocation on push_back would dangle every earlier one.
+  std::deque<gpu::Buffer> buffers;        //!< Retained transient buffers.
+  std::deque<gpu::Texture> textures;      //!< Retained transient textures.
+  std::deque<gpu::TextureView> views;     //!< Retained transient texture views.
+  std::deque<gpu::Sampler> samplers;      //!< Retained transient samplers.
+  std::deque<gpu::BindGroup> bindGroups;  //!< Retained transient bind groups.
+
+  /// Retains \p buffer and returns a reference to it for immediate binding.
+  /// @param buffer Buffer to retain.
+  const gpu::Buffer& retain(gpu::Buffer&& buffer) {
+    buffers.push_back(std::move(buffer));
+    return buffers.back();
+  }
+  /// Retains \p texture and returns a reference to it for immediate binding.
+  /// @param texture Texture to retain.
+  const gpu::Texture& retain(gpu::Texture&& texture) {
+    textures.push_back(std::move(texture));
+    return textures.back();
+  }
+  /// Retains \p view and returns a reference to it for immediate binding.
+  /// @param view Texture view to retain.
+  const gpu::TextureView& retain(gpu::TextureView&& view) {
+    views.push_back(std::move(view));
+    return views.back();
+  }
+  /// Retains \p sampler and returns a reference to it for immediate binding.
+  /// @param sampler Sampler to retain.
+  const gpu::Sampler& retain(gpu::Sampler&& sampler) {
+    samplers.push_back(std::move(sampler));
+    return samplers.back();
+  }
+  /// Retains \p bindGroup and returns a reference to it for immediate binding.
+  /// @param bindGroup Bind group to retain.
+  const gpu::BindGroup& retain(gpu::BindGroup&& bindGroup) {
+    bindGroups.push_back(std::move(bindGroup));
+    return bindGroups.back();
+  }
+
+  /// Releases every retained handle (RAII destruction through the owning device).
+  void clear() {
+    bindGroups.clear();
+    samplers.clear();
+    views.clear();
+    textures.clear();
+    buffers.clear();
+  }
+};
+
+}  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodeImagePipeline.cc
+++ b/donner/svg/renderer/geode/GeodeImagePipeline.cc
@@ -100,12 +100,6 @@ GeodeImagePipeline::GeodeImagePipeline(GeodeWgpuAdapterDevice& adapterDevice,
                         "GeodeImageBlitClipMask", gpu::FilterMode::Linear, gpu::FilterMode::Linear,
                         gpu::AddressMode::ClampToEdge, gpu::AddressMode::ClampToEdge}),
                     "GeodeImageBlitClipMask createSampler");
-
-  borrowedPipeline_ = adapterDevice.wgpuRenderPipelineOf(pipeline_);
-  borrowedBindGroupLayout_ = adapterDevice.wgpuBindGroupLayoutOf(bindGroupLayout_);
-  borrowedLinearSampler_ = adapterDevice.wgpuSamplerOf(linearSampler_);
-  borrowedNearestSampler_ = adapterDevice.wgpuSamplerOf(nearestSampler_);
-  borrowedClipMaskSampler_ = adapterDevice.wgpuSamplerOf(clipMaskSampler_);
 }
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodeImagePipeline.h
+++ b/donner/svg/renderer/geode/GeodeImagePipeline.h
@@ -20,10 +20,8 @@ class GeodeWgpuAdapterDevice;
  * offscreen texture and then sampled with this same pipeline as a
  * repeating fill.
  *
- * The pipeline and samplers are created through the \c donner::gpu runtime (design 0053
- * packet 8): the class holds the RAII `donner::gpu` handles, and - TEMPORARY for 8a while
- * GeoEncoder / GeodeTextureEncoder still record through wgpu - caches the borrowed wgpu objects
- * resolved through the adapter's escape hatches (deleted in packet 8b).
+ * The pipeline and samplers are created through the \c donner::gpu runtime, which owns them
+ * through RAII handles.
  *
  * Bind group layout (matches `shaders/image_blit.wgsl`):
  * - binding 0: uniform buffer (mvp, destRect, srcRect, targetSize, opacity, flags)
@@ -56,25 +54,22 @@ public:
   /// Move assignment operator.
   GeodeImagePipeline& operator=(GeodeImagePipeline&&) noexcept = default;
 
-  /// The compiled render pipeline (TEMPORARY 8a wgpu alias for the still-wgpu encoders).
-  const wgpu::RenderPipeline& pipeline() const { return borrowedPipeline_; }
+  /// The compiled render pipeline.
+  const gpu::RenderPipeline& pipeline() const { return pipeline_; }
 
-  /// Bind group layout used by the pipeline (TEMPORARY 8a wgpu alias).
-  const wgpu::BindGroupLayout& bindGroupLayout() const { return borrowedBindGroupLayout_; }
+  /// Bind group layout used by the pipeline.
+  const gpu::BindGroupLayout& bindGroupLayout() const { return bindGroupLayout_; }
 
-  /// Bilinear (mag/min filter = Linear) sampler, clamped to edge.
-  /// Used for the default `image-rendering` and the SVG spec's
-  /// "smooth" image sampling. (TEMPORARY 8a wgpu alias.)
-  const wgpu::Sampler& linearSampler() const { return borrowedLinearSampler_; }
+  /// Bilinear (mag/min filter = Linear) sampler, clamped to edge. Used for the default
+  /// `image-rendering` and the SVG spec's "smooth" image sampling.
+  const gpu::Sampler& linearSampler() const { return linearSampler_; }
 
   /// Nearest-neighbor sampler, clamped to edge. Used when
   /// `ImageRendering::CrispEdges` or its legacy alias is selected.
-  /// (TEMPORARY wgpu alias for the still-wgpu encoders.)
-  const wgpu::Sampler& nearestSampler() const { return borrowedNearestSampler_; }
+  const gpu::Sampler& nearestSampler() const { return nearestSampler_; }
 
   /// Linear clamp-to-edge sampler used for path-clip mask textures.
-  /// (TEMPORARY wgpu alias for the still-wgpu encoders.)
-  const wgpu::Sampler& clipMaskSampler() const { return borrowedClipMaskSampler_; }
+  const gpu::Sampler& clipMaskSampler() const { return clipMaskSampler_; }
 
   /// Color format the pipeline was built for.
   gpu::TextureFormat colorFormat() const { return colorFormat_; }
@@ -88,14 +83,6 @@ private:
   gpu::Sampler linearSampler_;
   gpu::Sampler nearestSampler_;
   gpu::Sampler clipMaskSampler_;
-
-  // TEMPORARY 8a: borrowed wgpu aliases resolved through the adapter's escape hatches so the
-  // still-wgpu encoders can bind them. Deleted in packet 8b.
-  wgpu::RenderPipeline borrowedPipeline_;
-  wgpu::BindGroupLayout borrowedBindGroupLayout_;
-  wgpu::Sampler borrowedLinearSampler_;
-  wgpu::Sampler borrowedNearestSampler_;
-  wgpu::Sampler borrowedClipMaskSampler_;
 };
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodePipeline.cc
+++ b/donner/svg/renderer/geode/GeodePipeline.cc
@@ -97,9 +97,6 @@ GeodePipeline::GeodePipeline(GeodeWgpuAdapterDevice& adapterDevice, gpu::Texture
   // every draw whose instances share one paint and one encoded path. `batchedPipeline` builds the
   // record-reading variant.
   pipeline_ = buildPipeline("GeodeSlugFill", "vs_main", "fs_main");
-
-  borrowedPipeline_ = adapterDevice.wgpuRenderPipelineOf(pipeline_);
-  borrowedBindGroupLayout_ = adapterDevice.wgpuBindGroupLayoutOf(bindGroupLayout_);
 }
 
 gpu::RenderPipeline GeodePipeline::buildPipeline(const char* label, const char* vertexEntryPoint,
@@ -114,16 +111,15 @@ gpu::RenderPipeline GeodePipeline::buildPipeline(const char* label, const char* 
       label);
 }
 
-const wgpu::RenderPipeline& GeodePipeline::batchedPipeline() const {
+const gpu::RenderPipeline& GeodePipeline::batchedPipeline() const {
   if (!batchedPipeline_.isValid()) {
     // Identical state to the default pipeline - same layout, same shader
     // module, same blending - differing only in the entry points that read
     // paint and geometry from each instance's record. Built on first use
     // because only a cross-entity batch needs it.
     batchedPipeline_ = buildPipeline("GeodeSlugFillBatched", "vs_main_batched", "fs_main_batched");
-    borrowedBatchedPipeline_ = adapterDevice_->wgpuRenderPipelineOf(batchedPipeline_);
   }
-  return borrowedBatchedPipeline_;
+  return batchedPipeline_;
 }
 
 // ============================================================================
@@ -174,9 +170,6 @@ GeodeGradientPipeline::GeodeGradientPipeline(GeodeWgpuAdapterDevice& adapterDevi
                              {gpu::ColorTargetState{colorFormat_, PremultipliedSourceOverBlend()}}},
           gpu::PrimitiveTopology::TriangleList, gpu::CullMode::None}),
       "GeodeSlugGradient createRenderPipeline");
-
-  borrowedPipeline_ = adapterDevice.wgpuRenderPipelineOf(pipeline_);
-  borrowedBindGroupLayout_ = adapterDevice.wgpuBindGroupLayoutOf(bindGroupLayout_);
 }
 
 // ============================================================================
@@ -227,9 +220,6 @@ GeodeMaskPipeline::GeodeMaskPipeline(GeodeWgpuAdapterDevice& adapterDevice) {
                              {gpu::ColorTargetState{gpu::TextureFormat::RGBA8Unorm, maxBlend}}},
           gpu::PrimitiveTopology::TriangleList, gpu::CullMode::None}),
       "GeodeSlugMask createRenderPipeline");
-
-  borrowedPipeline_ = adapterDevice.wgpuRenderPipelineOf(pipeline_);
-  borrowedBindGroupLayout_ = adapterDevice.wgpuBindGroupLayoutOf(bindGroupLayout_);
 }
 
 // ============================================================================

--- a/donner/svg/renderer/geode/GeodePipeline.h
+++ b/donner/svg/renderer/geode/GeodePipeline.h
@@ -18,10 +18,7 @@ class GeodeWgpuAdapterDevice;
  * pair - the actual data (uniforms, bands, curves) varies per
  * draw call but the pipeline state object can be reused.
  *
- * The pipeline is created through the \c donner::gpu runtime (design 0053 packet 8): the class
- * holds the RAII `donner::gpu` handles, and - TEMPORARY for 8a while GeoEncoder still records
- * through wgpu - caches the borrowed wgpu objects resolved through the adapter's escape hatches
- * (deleted in packet 8b).
+ * The pipeline is created through the \c donner::gpu runtime, which owns it through RAII
  *
  * The bind group layout matches the shader in `shaders/slug_fill.wgsl`:
  * - binding 0: uniform buffer (Uniforms struct: mvp, patternFromPath,
@@ -67,21 +64,18 @@ public:
   /// The compiled render pipeline. Its entry points take the draw's paint
   /// and geometry parameters from the uniform, which serves every draw whose
   /// instances share one paint and one encoded path.
-  /// (TEMPORARY wgpu alias for the still-wgpu GeoEncoder.)
-  const wgpu::RenderPipeline& pipeline() const { return borrowedPipeline_; }
+  const gpu::RenderPipeline& pipeline() const { return pipeline_; }
 
   /**
    * The cross-entity batch variant of @ref pipeline: same layout, same
    * shader module and same blending, but the entry points that take paint
    * and geometry from each instance's record. Compiled on first call,
    * because only a cross-entity batch needs it.
-   * (TEMPORARY wgpu alias for the still-wgpu GeoEncoder.)
    */
-  const wgpu::RenderPipeline& batchedPipeline() const;
+  const gpu::RenderPipeline& batchedPipeline() const;
 
   /// The bind group layout used by both pipelines.
-  /// (TEMPORARY wgpu alias for the still-wgpu GeoEncoder.)
-  const wgpu::BindGroupLayout& bindGroupLayout() const { return borrowedBindGroupLayout_; }
+  const gpu::BindGroupLayout& bindGroupLayout() const { return bindGroupLayout_; }
 
   /// Color format the pipeline was built for.
   gpu::TextureFormat colorFormat() const { return colorFormat_; }
@@ -106,12 +100,6 @@ private:
   /// callers cannot reach the null check at once and the lazy build cannot
   /// race.
   mutable gpu::RenderPipeline batchedPipeline_;
-
-  // TEMPORARY: borrowed wgpu aliases resolved through the adapter's escape hatches so the
-  // still-wgpu GeoEncoder can bind them.
-  wgpu::RenderPipeline borrowedPipeline_;
-  wgpu::BindGroupLayout borrowedBindGroupLayout_;
-  mutable wgpu::RenderPipeline borrowedBatchedPipeline_;
 };
 
 /**
@@ -142,9 +130,9 @@ public:
   GeodeGradientPipeline& operator=(GeodeGradientPipeline&&) noexcept = default;
 
   /// The compiled render pipeline (TEMPORARY 8a wgpu alias for the still-wgpu GeoEncoder).
-  const wgpu::RenderPipeline& pipeline() const { return borrowedPipeline_; }
+  const gpu::RenderPipeline& pipeline() const { return pipeline_; }
   /// The bind group layout used by the pipeline (TEMPORARY 8a wgpu alias).
-  const wgpu::BindGroupLayout& bindGroupLayout() const { return borrowedBindGroupLayout_; }
+  const gpu::BindGroupLayout& bindGroupLayout() const { return bindGroupLayout_; }
   /// Color format the pipeline was built for.
   gpu::TextureFormat colorFormat() const { return colorFormat_; }
 
@@ -154,10 +142,6 @@ private:
   gpu::BindGroupLayout bindGroupLayout_;
   gpu::PipelineLayout pipelineLayout_;
   gpu::RenderPipeline pipeline_;
-
-  // TEMPORARY 8a wgpu aliases; deleted in packet 8b (see GeodePipeline).
-  wgpu::RenderPipeline borrowedPipeline_;
-  wgpu::BindGroupLayout borrowedBindGroupLayout_;
 };
 
 /**
@@ -197,9 +181,9 @@ public:
   GeodeMaskPipeline& operator=(GeodeMaskPipeline&&) noexcept = default;
 
   /// The compiled render pipeline (TEMPORARY 8a wgpu alias for the still-wgpu GeoEncoder).
-  const wgpu::RenderPipeline& pipeline() const { return borrowedPipeline_; }
+  const gpu::RenderPipeline& pipeline() const { return pipeline_; }
   /// The bind group layout used by the pipeline (TEMPORARY 8a wgpu alias).
-  const wgpu::BindGroupLayout& bindGroupLayout() const { return borrowedBindGroupLayout_; }
+  const gpu::BindGroupLayout& bindGroupLayout() const { return bindGroupLayout_; }
   /// The color format the pipeline targets. Always `RGBA8Unorm`.
   gpu::TextureFormat colorFormat() const { return gpu::TextureFormat::RGBA8Unorm; }
 
@@ -208,10 +192,6 @@ private:
   gpu::BindGroupLayout bindGroupLayout_;
   gpu::PipelineLayout pipelineLayout_;
   gpu::RenderPipeline pipeline_;
-
-  // TEMPORARY 8a wgpu aliases; deleted in packet 8b (see GeodePipeline).
-  wgpu::RenderPipeline borrowedPipeline_;
-  wgpu::BindGroupLayout borrowedBindGroupLayout_;
 };
 
 /**

--- a/donner/svg/renderer/geode/GeodeResidentPathComponent.h
+++ b/donner/svg/renderer/geode/GeodeResidentPathComponent.h
@@ -28,10 +28,15 @@
 #include <limits>
 #include <memory>
 #include <optional>
+#include <span>
+#include <utility>
 #include <vector>
 
+#include "donner/gpu/Descriptors.h"
+#include "donner/gpu/Handles.h"
 #include "donner/svg/renderer/geode/GeodeDevice.h"
 #include "donner/svg/renderer/geode/GeodeResourceBudget.h"
+#include "donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h"
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 
 namespace donner::geode {
@@ -123,7 +128,7 @@ public:
   /// One record slot: its index in the contiguous array and its absolute
   /// byte offset in the owning buffer.
   struct Slot {
-    wgpu::Buffer buffer;
+    gpu::BufferRef buffer;
     uint64_t offset = 0;
     uint32_t index = 0;
     /// Stable identity of `buffer` (see `GeodeDevice::AllocateBufferId`).
@@ -171,7 +176,7 @@ public:
     if (!freeIndices_.empty()) {
       const uint32_t index = freeIndices_.front();
       out = slotAt(index);
-      if (!out.buffer) {
+      if (!out.buffer.isValid()) {
         // A stale index that no longer resolves stays out of the free list,
         // but never silently consumes the allocation attempt.
         freeIndices_.erase(freeIndices_.begin());
@@ -191,23 +196,20 @@ public:
       if (budget_ && !budget_->reserveResidentBytes(newSize)) {
         return false;
       }
-      wgpu::BufferDescriptor desc = {};
-      desc.label = wgpuLabel("GeodeRecordSlab");
-      desc.size = newSize;
-      desc.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
-      ScopedWgpuHandle<wgpu::Buffer> buffer(device.device().createBuffer(desc));
-      if (!buffer) {
+      gpu::Result<gpu::Buffer> created = device.adapterDevice().createBuffer(gpu::BufferDescriptor{
+          "GeodeRecordSlab", newSize, gpu::BufferUsage::Storage | gpu::BufferUsage::CopyDst});
+      if (created.hasError()) {
         if (budget_) {
           budget_->releaseResidentBytes(newSize);
         }
         return false;
       }
-      device.countBuffer();
-      chunks_.push_back(Chunk{std::move(buffer), newSize, GeodeDevice::AllocateBufferId()});
+      chunks_.push_back(
+          Chunk{std::move(created).result(), newSize, GeodeDevice::AllocateBufferId()});
       accountedBytes_ += newSize;
       usedBytes_ = 0;
     }
-    out.buffer = chunks_.back().buffer.get();
+    out.buffer = chunks_.back().buffer;
     out.bufferId = chunks_.back().bufferId;
     out.offset = usedBytes_;
     // Indices are GLOBAL across chunks (slotAt walks cumulative chunk
@@ -231,7 +233,7 @@ public:
   /// A batch-uniform buffer plus its stable identity; `buffer` is null when
   /// the slab declined (uniform cache full, or buffer creation failed).
   struct BatchUniformHandle {
-    wgpu::Buffer buffer;
+    gpu::BufferRef buffer;
     uint64_t bufferId = 0;
   };
 
@@ -262,7 +264,7 @@ public:
     const auto* first = static_cast<const uint8_t*>(bytes);
     for (const BatchUniform& entry : batchUniforms_) {
       if (entry.bytes.size() == size && std::memcmp(entry.bytes.data(), first, size) == 0) {
-        return BatchUniformHandle{entry.buffer.get(), entry.bufferId};
+        return BatchUniformHandle{entry.buffer, entry.bufferId};
       }
     }
     if (batchUniforms_.size() >= kMaxBatchUniforms) {
@@ -316,31 +318,40 @@ public:
       }
       return BatchUniformHandle{};
     }
-    wgpu::BufferDescriptor desc = {};
-    desc.label = wgpuLabel("GeodeSceneBatchUniform");
-    desc.size = size;
-    desc.usage = wgpu::BufferUsage::Uniform | wgpu::BufferUsage::CopyDst;
-    ScopedWgpuHandle<wgpu::Buffer> buffer(device.device().createBuffer(desc));
-    if (!buffer) {
+    gpu::Result<gpu::Buffer> created = device.adapterDevice().createBuffer(gpu::BufferDescriptor{
+        "GeodeSceneBatchUniform", size, gpu::BufferUsage::Uniform | gpu::BufferUsage::CopyDst});
+    if (created.hasError()) {
       if (budget_) {
         budget_->releaseResidentBytes(size);
       }
       (void)replaceCpuBytes(metadataBytes + cpuPayloadBytes_);
       return BatchUniformHandle{};
     }
-    device.countBuffer();
-    device.queue().writeBuffer(buffer.get(), 0, first, size);
-    device.countBufferWrite(size);
+    gpu::Buffer buffer = std::move(created).result();
+    (void)device.adapterDevice().writeBuffer(buffer, 0, std::span<const uint8_t>(first, size));
     batchUniforms_.push_back(
         BatchUniform{std::move(buffer), std::move(retainedBytes), GeodeDevice::AllocateBufferId()});
     cpuPayloadBytes_ += retainedCapacity;
     accountedBytes_ += size;
-    return BatchUniformHandle{batchUniforms_.back().buffer.get(), batchUniforms_.back().bufferId};
+    return BatchUniformHandle{batchUniforms_.back().buffer, batchUniforms_.back().bufferId};
+  }
+
+  /// The chunk buffer carrying \p bufferId, or a null handle when this slab does not own it.
+  /// Uploads need the owning handle; \ref Slot and \ref Allocation only carry an identity view.
+  /// @param bufferId Stable buffer id stamped on the slot or allocation.
+  const gpu::Buffer& bufferForId(uint64_t bufferId) const {
+    static const gpu::Buffer kNone;
+    for (const Chunk& chunk : chunks_) {
+      if (chunk.bufferId == bufferId) {
+        return chunk.buffer;
+      }
+    }
+    return kNone;
   }
 
   /// Borrowed handle of the newest buffer (batches bind sub-ranges of it).
-  wgpu::Buffer newestBuffer() const {
-    return chunks_.empty() ? wgpu::Buffer() : chunks_.back().buffer.get();
+  gpu::BufferRef newestBuffer() const {
+    return chunks_.empty() ? gpu::BufferRef() : gpu::BufferRef(chunks_.back().buffer);
   }
 
   /// Bytes currently in use in the newest buffer.
@@ -362,13 +373,13 @@ public:
 
 private:
   struct Chunk {
-    ScopedWgpuHandle<wgpu::Buffer> buffer;
+    gpu::Buffer buffer;
     uint64_t size = 0;
     uint64_t bufferId = 0;
   };
 
   struct BatchUniform {
-    ScopedWgpuHandle<wgpu::Buffer> buffer;
+    gpu::Buffer buffer;
     std::vector<uint8_t> bytes;
     uint64_t bufferId = 0;
   };
@@ -397,11 +408,11 @@ private:
     uint64_t offset = static_cast<uint64_t>(index) * sizeof(InstanceRecord);
     for (const Chunk& chunk : chunks_) {
       if (offset < chunk.size) {
-        return Slot{chunk.buffer.get(), offset, index, chunk.bufferId};
+        return Slot{chunk.buffer, offset, index, chunk.bufferId};
       }
       offset -= chunk.size;
     }
-    return Slot{wgpu::Buffer(), 0, index, 0};
+    return Slot{gpu::BufferRef(), 0, index, 0};
   }
 
   uint64_t owningDeviceId_;
@@ -450,9 +461,33 @@ class GeodeDevice;
  */
 class GeodeResidentSlab {
 public:
+  /// The chunk buffer carrying \p bufferId, or a null handle when this slab does not own it.
+  /// Uploads need the owning handle; \ref Slot and \ref Allocation only carry an identity view.
+  /// @param bufferId Stable buffer id stamped on the slot or allocation.
+  const gpu::Buffer& bufferForId(uint64_t bufferId) const {
+    static const gpu::Buffer kNone;
+    for (const Chunk& chunk : chunks_) {
+      if (chunk.bufferId == bufferId) {
+        return chunk.buffer;
+      }
+    }
+    return kNone;
+  }
+
+  /// Byte size of the chunk carrying \p bufferId, or 0 when this slab does not own it.
+  /// @param bufferId Stable buffer id stamped on the slot or allocation.
+  uint64_t chunkBytesForId(uint64_t bufferId) const {
+    for (const Chunk& chunk : chunks_) {
+      if (chunk.bufferId == bufferId) {
+        return chunk.size;
+      }
+    }
+    return 0;
+  }
+
   /// One sub-range of a slab chunk.
   struct Allocation {
-    wgpu::Buffer buffer;  // Borrowed handle; owned by the slab chunk.
+    gpu::BufferRef buffer;  // Borrowed identity; the slab chunk owns the buffer.
     uint64_t offset = 0;
     uint64_t size = 0;
     /// Stable identity of `buffer` (see `GeodeDevice::AllocateBufferId`).
@@ -552,7 +587,7 @@ public:
     for (auto it = freeRanges_.begin(); it != freeRanges_.end(); ++it) {
       const uint64_t start = alignUp(it->offset, alignment);
       if (start + size <= it->offset + it->size) {
-        out.buffer = chunks_[it->chunk].buffer.get();
+        out.buffer = chunks_[it->chunk].buffer;
         out.bufferId = chunks_[it->chunk].bufferId;
         out.offset = start;
         out.size = size;
@@ -585,20 +620,17 @@ public:
       if (budget_ && !budget_->reserveResidentBytes(newSize)) {
         return false;
       }
-      wgpu::BufferDescriptor desc = {};
-      desc.label = wgpuLabel("GeodeResidentSlab");
-      desc.size = newSize;
-      desc.usage =
-          wgpu::BufferUsage::Storage | wgpu::BufferUsage::Uniform | wgpu::BufferUsage::CopyDst;
-      Chunk chunk;
-      chunk.buffer.reset(device.device().createBuffer(desc));
-      if (!chunk.buffer) {
+      gpu::Result<gpu::Buffer> created = device.adapterDevice().createBuffer(gpu::BufferDescriptor{
+          "GeodeResidentSlab", newSize,
+          gpu::BufferUsage::Storage | gpu::BufferUsage::Uniform | gpu::BufferUsage::CopyDst});
+      if (created.hasError()) {
         if (budget_) {
           budget_->releaseResidentBytes(newSize);
         }
         return false;
       }
-      device.countBuffer();
+      Chunk chunk;
+      chunk.buffer = std::move(created).result();
       chunk.size = newSize;
       chunk.bufferId = GeodeDevice::AllocateBufferId();
       chunks_.push_back(std::move(chunk));
@@ -610,7 +642,7 @@ public:
     }
 
     Chunk& chunk = chunks_.back();
-    out.buffer = chunk.buffer.get();
+    out.buffer = chunk.buffer;
     out.bufferId = chunk.bufferId;
     out.offset = alignUp(chunk.cursor, alignment);
     out.size = size;
@@ -648,7 +680,7 @@ private:
   }
 
   struct Chunk {
-    ScopedWgpuHandle<wgpu::Buffer> buffer;
+    gpu::Buffer buffer;
     uint64_t size = 0;
     uint64_t cursor = 0;
     uint64_t bufferId = 0;
@@ -692,7 +724,7 @@ struct GeodeResidentSlot {
   /// storage binding, whose range spans them. The slot is padded out to the
   /// slab's allocation alignment so consecutive slots leave no unwritten
   /// bytes between them.
-  wgpu::Buffer buffer;
+  gpu::BufferRef buffer;
   /// Stable identity of `buffer` (see `GeodeDevice::AllocateBufferId`).
   /// A cross-entity batch binds the whole chunk and caches the resulting
   /// bind group past the lifetime of the document that owns it, so the
@@ -836,7 +868,7 @@ struct GeodeResidentSlot {
 
   GeodeResidentSlot() = default;
   ~GeodeResidentSlot() {
-    if (recordSlab && recordSlot.buffer) {
+    if (recordSlab && recordSlot.buffer.isValid()) {
       recordSlab->freeSlot(recordSlot);
     }
     reset();
@@ -850,7 +882,7 @@ struct GeodeResidentSlot {
       reset();
       buffer = other.buffer;
       bufferId = other.bufferId;
-      other.buffer = wgpu::Buffer();
+      other.buffer = gpu::BufferRef();
       other.bufferId = 0;
       slab = std::move(other.slab);
       allocationOffset = other.allocationOffset;
@@ -928,7 +960,7 @@ struct GeodeResidentSlot {
     // refresh them when the document crosses devices.
     allocationOffset = 0;
     allocationSize = 0;
-    buffer = wgpu::Buffer();
+    buffer = gpu::BufferRef();
     bufferId = 0;
     bindGroup.reset();
     resident = false;
@@ -981,7 +1013,7 @@ struct GeodeResidentGradientSlot {
   /// `GeodeResidentSlab` chunk; region offsets are ABSOLUTE buffer
   /// offsets. Region layout matches \ref GeodeResidentSlot, with the
   /// uniform region sized for `GradientUniforms` (672 bytes).
-  wgpu::Buffer buffer;
+  gpu::BufferRef buffer;
   /// Stable identity of `buffer` (see `GeodeDevice::AllocateBufferId`), so
   /// returning the allocation matches the owning chunk by identity rather
   /// than by a handle address the allocator can recycle.
@@ -1060,7 +1092,7 @@ struct GeodeResidentGradientSlot {
       reset();
       buffer = other.buffer;
       bufferId = other.bufferId;
-      other.buffer = wgpu::Buffer();
+      other.buffer = gpu::BufferRef();
       other.bufferId = 0;
       slab = std::move(other.slab);
       allocationOffset = other.allocationOffset;
@@ -1107,7 +1139,7 @@ struct GeodeResidentGradientSlot {
     // refresh them when the document crosses devices.
     allocationOffset = 0;
     allocationSize = 0;
-    buffer = wgpu::Buffer();
+    buffer = gpu::BufferRef();
     bufferId = 0;
     bindGroup.reset();
     resident = false;

--- a/donner/svg/renderer/geode/GeodeResidentPathComponent.h
+++ b/donner/svg/renderer/geode/GeodeResidentPathComponent.h
@@ -164,10 +164,26 @@ public:
       return;
     }
     lastMergedFrame_ = frameIndex;
+    retiredBindGroups_.clear();
     for (uint32_t index : pendingFrees_) {
       freeIndices_.insert(std::upper_bound(freeIndices_.begin(), freeIndices_.end(), index), index);
     }
     pendingFrees_.clear();
+  }
+
+  /// Park a bind group a slot is dropping until the next frame boundary.
+  ///
+  /// A slot's cached bind group can be dropped mid-frame (geometry re-upload, component removal,
+  /// device change) while draws recorded earlier in the frame still name it and have not reached
+  /// the backend yet. Destroying it there fails those draws closed, so it is held here and
+  /// released at the next \ref beginFrame, by which point the frame that recorded them has been
+  /// submitted.
+  ///
+  /// @param bindGroup Bind group to release at the next frame boundary.
+  void retireBindGroup(gpu::BindGroup bindGroup) {
+    if (bindGroup.isValid()) {
+      retiredBindGroups_.push_back(std::move(bindGroup));
+    }
   }
 
   /// Allocate the next record slot (free-list first, then bump in the
@@ -421,6 +437,8 @@ private:
   std::vector<Chunk> chunks_;
   std::vector<uint32_t> freeIndices_;
   std::vector<uint32_t> pendingFrees_;
+  /// Bind groups dropped by slots this frame, released at the next \ref beginFrame.
+  std::vector<gpu::BindGroup> retiredBindGroups_;
   std::vector<BatchUniform> batchUniforms_;
   std::shared_ptr<GeodeDocumentGeometryBudget> budget_;
   GeodeGeometryCacheReservation cpuReservation_;
@@ -542,6 +560,7 @@ public:
       return;
     }
     lastMergedFrame_ = frameIndex;
+    retiredBindGroups_.clear();
     for (const FreeRange& range : pendingFrees_) {
       auto it = freeRanges_.begin();
       while (it != freeRanges_.end() &&
@@ -672,7 +691,25 @@ public:
     pendingFrees_.push_back(FreeRange{chunkIndex, alloc.offset, alloc.size});
   }
 
+  /// Park a bind group a slot is dropping until the next frame boundary.
+  ///
+  /// A slot's cached bind group can be dropped mid-frame (geometry re-upload, component removal,
+  /// device change) while draws recorded earlier in the frame still name it and have not reached
+  /// the backend yet. Destroying it there fails those draws closed, so it is held here and
+  /// released at the next \ref beginFrame, by which point the frame that recorded them has been
+  /// submitted.
+  ///
+  /// @param bindGroup Bind group to release at the next frame boundary.
+  void retireBindGroup(gpu::BindGroup bindGroup) {
+    if (bindGroup.isValid()) {
+      retiredBindGroups_.push_back(std::move(bindGroup));
+    }
+  }
+
 private:
+  /// Bind groups dropped by slots this frame, released at the next \ref beginFrame.
+  std::vector<gpu::BindGroup> retiredBindGroups_;
+
   static constexpr uint64_t kInitialChunkBytes = 1u << 20;  // 1 MiB.
 
   static uint64_t alignUp(uint64_t value, uint64_t alignment) {
@@ -745,7 +782,7 @@ struct GeodeResidentSlot {
   /// texture/sampler/identity-instance handles), so it survives frames
   /// and encoders. Rebuilt only when the geometry buffer is
   /// re-allocated.
-  ScopedWgpuHandle<wgpu::BindGroup> bindGroup;
+  gpu::BindGroup bindGroup;
 
   /// A byte sub-range of `buffer`. `size == 0` is never bound directly -
   /// empty SSBO regions reserve a zero-filled dummy slot wide enough for one
@@ -940,10 +977,10 @@ struct GeodeResidentSlot {
   /// Safe to call on an empty slot. A geometry mutation can remove this
   /// component after a draw has referenced the buffer but before the
   /// frame's command encoder is submitted. Do not call `Buffer::destroy()`
-  /// here: WebGPU makes that buffer unusable immediately, invalidating the
-  /// already-recorded draw. Releasing our references is sufficient because
-  /// the command encoder keeps the referenced resources alive until it is
-  /// done.
+  /// here: that makes the buffer unusable immediately, invalidating the already-recorded draw.
+  /// Releasing our references is enough for the buffer, whose storage the slab owns; the bind
+  /// group is handed to the slab instead of dropped, because draws recorded earlier this frame
+  /// may still name it and have not reached the backend yet.
   void reset() {
     if (slab && allocationSize != 0) {
       GeodeResidentSlab::Allocation alloc{buffer, allocationOffset, allocationSize, bufferId};
@@ -962,7 +999,10 @@ struct GeodeResidentSlot {
     allocationSize = 0;
     buffer = gpu::BufferRef();
     bufferId = 0;
-    bindGroup.reset();
+    if (slab) {
+      slab->retireBindGroup(std::move(bindGroup));
+    }
+    bindGroup = gpu::BindGroup();
     resident = false;
     encodedKey = nullptr;
     encodedFingerprint = 0;
@@ -1030,7 +1070,7 @@ struct GeodeResidentGradientSlot {
   /// Cached 11-binding gradient bind group. All bindings reference stable
   /// objects (this slot's buffer sub-ranges + device-owned dummy
   /// clip-mask texture/sampler), so it survives frames and encoders.
-  ScopedWgpuHandle<wgpu::BindGroup> bindGroup;
+  gpu::BindGroup bindGroup;
 
   /// A byte sub-range of `buffer` (same semantics as GeodeResidentSlot::Region).
   struct Region {
@@ -1141,7 +1181,10 @@ struct GeodeResidentGradientSlot {
     allocationSize = 0;
     buffer = gpu::BufferRef();
     bufferId = 0;
-    bindGroup.reset();
+    if (slab) {
+      slab->retireBindGroup(std::move(bindGroup));
+    }
+    bindGroup = gpu::BindGroup();
     resident = false;
     encodedKey = nullptr;
     encodedFingerprint = 0;

--- a/donner/svg/renderer/geode/GeodeTextureEncoder.cc
+++ b/donner/svg/renderer/geode/GeodeTextureEncoder.cc
@@ -1,11 +1,12 @@
 #include "donner/svg/renderer/geode/GeodeTextureEncoder.h"
 
 #include <cstring>
+#include <span>
+#include <utility>
 #include <vector>
 
-#include "donner/svg/renderer/geode/GeodeDevice.h"
+#include "donner/gpu/Device.h"
 #include "donner/svg/renderer/geode/GeodeImagePipeline.h"
-#include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 
 namespace donner::geode {
 
@@ -53,80 +54,57 @@ static_assert(sizeof(Uniforms) == 176, "Image-blit Uniforms layout mismatch");
 
 }  // namespace
 
-wgpu::Texture GeodeTextureEncoder::uploadRgba8Texture(GeodeDevice& device,
-                                                      const uint8_t* rgbaPixels, uint32_t width,
-                                                      uint32_t height) {
+gpu::Texture GeodeTextureEncoder::uploadRgba8Texture(const GeodeGpuContext& context,
+                                                     const uint8_t* rgbaPixels, uint32_t width,
+                                                     uint32_t height) {
   if (rgbaPixels == nullptr || width == 0u || height == 0u) {
-    return wgpu::Texture();
+    return gpu::Texture();
   }
 
-  const wgpu::Device& dev = device.device();
-  const wgpu::Queue& queue = device.queue();
-
-  wgpu::TextureDescriptor td = {};
-  td.label = wgpuLabel("GeodeUploadedImage");
-  td.size = {width, height, 1};
-  td.format = wgpu::TextureFormat::RGBA8Unorm;
-  td.usage = wgpu::TextureUsage::TextureBinding | wgpu::TextureUsage::CopyDst;
-  td.mipLevelCount = 1;
-  td.sampleCount = 1;
-  td.dimension = wgpu::TextureDimension::_2D;
-  wgpu::Texture texture = dev.createTexture(td);
-  if (!texture) {
-    return wgpu::Texture();
+  gpu::Result<gpu::Texture> created = context.gpuDevice->createTexture(gpu::TextureDescriptor{
+      "GeodeUploadedImage", gpu::Extent2d{width, height}, gpu::TextureFormat::RGBA8Unorm,
+      gpu::TextureUsage::Sampled | gpu::TextureUsage::CopyDst});
+  if (created.hasError()) {
+    return gpu::Texture();
   }
-  device.countTexture();
+  gpu::Texture texture = std::move(created).result();
 
   const uint32_t unpaddedBytesPerRow = width * 4u;
   const uint32_t paddedBytesPerRow = alignUp(unpaddedBytesPerRow, kBytesPerRowAlignment);
-
-  wgpu::TexelCopyTextureInfo dst = {};
-  dst.texture = texture;
-  dst.mipLevel = 0;
-  dst.origin = {0, 0, 0};
-  dst.aspect = wgpu::TextureAspect::All;
-
-  wgpu::TexelCopyBufferLayout layout = {};
-  layout.offset = 0;
-  layout.bytesPerRow = paddedBytesPerRow;
-  layout.rowsPerImage = height;
-
-  wgpu::Extent3D writeSize = {width, height, 1};
+  const gpu::TexelCopyBufferLayout layout{0, paddedBytesPerRow, height};
+  const gpu::Extent2d writeSize{width, height};
 
   if (unpaddedBytesPerRow == paddedBytesPerRow) {
-    // Fast path - source rows already 256-aligned. Upload directly.
+    // Fast path - source rows already carry the required pitch. Upload directly.
     const size_t byteCount = static_cast<size_t>(unpaddedBytesPerRow) * height;
-    queue.writeTexture(dst, rgbaPixels, byteCount, layout, writeSize);
-    device.countTextureWrite(byteCount);
+    (void)context.gpuDevice->writeTexture(texture, std::span<const uint8_t>(rgbaPixels, byteCount),
+                                          layout, writeSize);
   } else {
     // Slow path - copy into a padded staging buffer. `std::vector` is the
     // allowed allocation path (stdlib, not raw malloc/free). We size-cap on
-    // the same uint32_t × uint32_t × 4 that the GPU already accepted for
+    // the same uint32_t x uint32_t x 4 that the GPU already accepted for
     // the texture, so overflow is not a concern here.
     std::vector<uint8_t> staging(static_cast<size_t>(paddedBytesPerRow) * height, 0u);
     for (uint32_t y = 0; y < height; ++y) {
       std::memcpy(staging.data() + static_cast<size_t>(y) * paddedBytesPerRow,
                   rgbaPixels + static_cast<size_t>(y) * unpaddedBytesPerRow, unpaddedBytesPerRow);
     }
-    queue.writeTexture(dst, staging.data(), staging.size(), layout, writeSize);
-    device.countTextureWrite(staging.size());
+    (void)context.gpuDevice->writeTexture(texture, staging, layout, writeSize);
   }
 
   return texture;
 }
 
-void GeodeTextureEncoder::drawTexturedQuad(
-    GeodeDevice& device, const GeodeImagePipeline& pipeline, const wgpu::RenderPassEncoder& pass,
-    const wgpu::Texture& texture, const float mvp[16], uint32_t targetWidth, uint32_t targetHeight,
-    const QuadParams& params, ScopedWgpuResourceArena& resourceArena, UniformScratch* scratch) {
-  if (!texture) {
-    return;
-  }
+namespace {
 
-  const wgpu::Device& dev = device.device();
-  const wgpu::Queue& queue = device.queue();
-
-  // Build uniform buffer.
+/// Fill the blit shader's uniform block for one quad.
+///
+/// @param mvp Column-major clip-from-target matrix.
+/// @param targetWidth Render target width in texels.
+/// @param targetHeight Render target height in texels.
+/// @param params Quad parameters.
+Uniforms BuildQuadUniforms(const float mvp[16], uint32_t targetWidth, uint32_t targetHeight,
+                           const GeodeTextureEncoder::QuadParams& params) {
   Uniforms u = {};
   std::memcpy(u.mvp, mvp, sizeof(u.mvp));
   u.destRect[0] = static_cast<float>(params.destRect.topLeft.x);
@@ -141,91 +119,155 @@ void GeodeTextureEncoder::drawTexturedQuad(
   u.targetSize[1] = static_cast<float>(targetHeight);
   u.opacity = static_cast<float>(params.opacity);
   u.sourceIsPremult = params.sourceIsPremultiplied ? 1u : 0u;
-  u.maskMode = params.maskTexture ? params.maskMode : 0u;
+  u.maskMode = params.maskTexture != nullptr ? params.maskMode : 0u;
   u.applyMaskBounds = params.applyMaskBounds ? 1u : 0u;
   u.maskBounds[0] = static_cast<float>(params.maskBounds.topLeft.x);
   u.maskBounds[1] = static_cast<float>(params.maskBounds.topLeft.y);
   u.maskBounds[2] = static_cast<float>(params.maskBounds.bottomRight.x);
   u.maskBounds[3] = static_cast<float>(params.maskBounds.bottomRight.y);
   u.blendMode = params.blendMode;
-  u.hasClipMask = params.clipMaskView ? 1u : 0u;
+  u.hasClipMask = params.clipMaskView != nullptr ? 1u : 0u;
   u.samplingMode = static_cast<uint32_t>(params.filter);
   u.pixelatedScale[0] = static_cast<float>(params.pixelatedScaleX);
   u.pixelatedScale[1] = static_cast<float>(params.pixelatedScaleY);
+  return u;
+}
 
-  // Pooled callers bump-allocate from their per-frame scratch arena;
-  // standalone callers keep the legacy one-buffer-per-blit path.
-  wgpu::Buffer uniBuf;
-  uint64_t uniOffset = 0;
-  uint64_t uniSize = sizeof(Uniforms);
+/// The four texture views one quad's bind group needs.
+///
+/// Optional bindings must always carry a valid view: when their feature is off the source view is
+/// bound as a stand-in, which the shader never samples because the matching mode guard is zero.
+struct QuadViews {
+  gpu::TextureViewRef source;
+  gpu::TextureViewRef mask;
+  gpu::TextureViewRef backdrop;
+  gpu::TextureViewRef clipMask;
+};
+
+/// Open the views one quad binds, retaining each for the arena's lifetime.
+///
+/// @param device Device to create views through.
+/// @param resourceArena Arena keeping the created views alive.
+/// @param texture Source texture the quad samples.
+/// @param params Quad parameters naming the optional mask, backdrop and clip mask.
+/// @param outViews Receives the four views.
+/// @return False when a view could not be created.
+bool ResolveQuadViews(gpu::Device& device, GeodeTransientResources& resourceArena,
+                      const gpu::Texture& texture, const GeodeTextureEncoder::QuadParams& params,
+                      QuadViews& outViews) {
+  const auto retainView = [&device, &resourceArena](const gpu::Texture& source, const char* label,
+                                                    gpu::TextureViewRef& out) -> bool {
+    gpu::Result<gpu::TextureView> created =
+        device.createTextureView(source, gpu::TextureViewDescriptor{label});
+    if (created.hasError()) {
+      return false;
+    }
+    out = resourceArena.retain(std::move(created).result());
+    return true;
+  };
+
+  if (!retainView(texture, "GeodeImageBlitView", outViews.source)) {
+    return false;
+  }
+  outViews.mask = outViews.source;
+  if (params.maskTexture != nullptr &&
+      !retainView(*params.maskTexture, "GeodeImageBlitMaskView", outViews.mask)) {
+    return false;
+  }
+  outViews.backdrop = outViews.source;
+  if (params.dstSnapshotTexture != nullptr &&
+      !retainView(*params.dstSnapshotTexture, "GeodeImageBlitBackdropView", outViews.backdrop)) {
+    return false;
+  }
+  outViews.clipMask =
+      params.clipMaskView != nullptr ? gpu::TextureViewRef(*params.clipMaskView) : outViews.source;
+  return true;
+}
+
+/// Place one quad's uniforms in a buffer the draw can bind.
+///
+/// Pooled callers bump-allocate from their per-frame scratch arena; standalone callers get a
+/// buffer of their own, retained for the arena's lifetime.
+///
+/// @param device Device to allocate through.
+/// @param resourceArena Arena keeping a standalone buffer alive.
+/// @param scratch Per-frame scratch arena, or null for a standalone buffer.
+/// @param u Uniform block to place.
+/// @param outBinding Receives the buffer, byte offset and byte size to bind.
+/// @return False when the buffer could not be created.
+bool AllocateQuadUniforms(gpu::Device& device, GeodeTransientResources& resourceArena,
+                          GeodeTextureEncoder::UniformScratch* scratch, const Uniforms& u,
+                          gpu::BufferBinding& outBinding) {
   if (scratch != nullptr) {
     constexpr uint64_t kUniformOffsetAlignment = GeodeTextureEncoder::kUniformOffsetAlignment;
-    const UniformAllocation alloc =
+    const GeodeTextureEncoder::UniformAllocation alloc =
         scratch->allocate(&u, sizeof(Uniforms), kUniformOffsetAlignment);
-    uniBuf = alloc.buffer;
-    uniOffset = alloc.offset;
-    uniSize = alloc.size;
-  } else {
-    wgpu::BufferDescriptor uniDesc = {};
-    uniDesc.label = wgpuLabel("GeodeImageBlitUniforms");
-    uniDesc.size = sizeof(Uniforms);
-    uniDesc.usage = wgpu::BufferUsage::Uniform | wgpu::BufferUsage::CopyDst;
-    uniBuf = resourceArena.retain(dev.createBuffer(uniDesc));
-    device.countBuffer();
-    queue.writeBuffer(uniBuf, 0, &u, sizeof(Uniforms));
-    device.countBufferWrite(sizeof(Uniforms));
+    outBinding = gpu::BufferBinding{alloc.buffer, alloc.offset, alloc.size};
+    return true;
+  }
+
+  gpu::Result<gpu::Buffer> created = device.createBuffer(
+      gpu::BufferDescriptor{"GeodeImageBlitUniforms", sizeof(Uniforms),
+                            gpu::BufferUsage::Uniform | gpu::BufferUsage::CopyDst});
+  if (created.hasError()) {
+    return false;
+  }
+  const gpu::Buffer& retained = resourceArena.retain(std::move(created).result());
+  (void)device.writeBuffer(
+      retained, 0,
+      std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(&u), sizeof(Uniforms)));
+  outBinding = gpu::BufferBinding{retained, 0, sizeof(Uniforms)};
+  return true;
+}
+
+}  // namespace
+
+void GeodeTextureEncoder::drawTexturedQuad(
+    const GeodeGpuContext& context, const GeodeImagePipeline& pipeline,
+    gpu::RenderPassEncoder& pass, const gpu::Texture& texture, const float mvp[16],
+    uint32_t targetWidth, uint32_t targetHeight, const QuadParams& params,
+    GeodeTransientResources& resourceArena, UniformScratch* scratch) {
+  if (!texture.isValid()) {
+    return;
+  }
+
+  gpu::Device& device = *context.gpuDevice;
+
+  const Uniforms u = BuildQuadUniforms(mvp, targetWidth, targetHeight, params);
+  gpu::BufferBinding uniformBinding;
+  if (!AllocateQuadUniforms(device, resourceArena, scratch, u, uniformBinding)) {
+    return;
   }
 
   // Pick sampler based on requested filter mode.
-  const wgpu::Sampler& sampler =
+  const gpu::Sampler& sampler =
       params.filter == Filter::Nearest ? pipeline.nearestSampler() : pipeline.linearSampler();
 
-  // Bind group - optional texture bindings must always carry a valid
-  // view. When their owning feature flags are off, we bind the source
-  // content texture view as a cheap dummy (the shader never samples it
-  // because the corresponding mode guard is 0).
-  wgpu::TextureView view = resourceArena.retain(texture.createView());
-  wgpu::TextureView maskView =
-      params.maskTexture ? resourceArena.retain(params.maskTexture.createView()) : view;
-  wgpu::TextureView dstView = params.dstSnapshotTexture
-                                  ? resourceArena.retain(params.dstSnapshotTexture.createView())
-                                  : view;
-  wgpu::TextureView clipMaskView = params.clipMaskView ? params.clipMaskView : view;
-  wgpu::BindGroupEntry entries[7] = {};
-  entries[0].binding = 0;
-  entries[0].buffer = uniBuf;
-  entries[0].offset = uniOffset;
-  entries[0].size = uniSize;
-  entries[1].binding = 1;
-  entries[1].sampler = sampler;
-  entries[2].binding = 2;
-  entries[2].textureView = view;
-  entries[3].binding = 3;
-  entries[3].textureView = maskView;
-  entries[4].binding = 4;
-  entries[4].textureView = dstView;
-  entries[5].binding = 5;
-  entries[5].textureView = clipMaskView;
-  entries[6].binding = 6;
-  entries[6].sampler = pipeline.clipMaskSampler();
+  QuadViews views;
+  if (!ResolveQuadViews(device, resourceArena, texture, params, views)) {
+    return;
+  }
 
-  wgpu::BindGroupDescriptor bgDesc = {};
-  bgDesc.label = wgpuLabel("GeodeImageBlitBindGroup");
-  bgDesc.layout = pipeline.bindGroupLayout();
-  bgDesc.entryCount = 7;
-  bgDesc.entries = entries;
-  wgpu::BindGroup bindGroup = resourceArena.retain(dev.createBindGroup(bgDesc));
-  device.countBindGroup();
+  gpu::Result<gpu::BindGroup> bindGroupResult = device.createBindGroup(gpu::BindGroupDescriptor{
+      "GeodeImageBlitBindGroup",
+      pipeline.bindGroupLayout(),
+      {gpu::BindGroupEntry{0, uniformBinding}, gpu::BindGroupEntry{1, gpu::SamplerBinding{sampler}},
+       gpu::BindGroupEntry{2, gpu::TextureViewBinding{views.source}},
+       gpu::BindGroupEntry{3, gpu::TextureViewBinding{views.mask}},
+       gpu::BindGroupEntry{4, gpu::TextureViewBinding{views.backdrop}},
+       gpu::BindGroupEntry{5, gpu::TextureViewBinding{views.clipMask}},
+       gpu::BindGroupEntry{6, gpu::SamplerBinding{pipeline.clipMaskSampler()}}}});
+  if (bindGroupResult.hasError()) {
+    return;
+  }
+  const gpu::BindGroup& bindGroup = resourceArena.retain(std::move(bindGroupResult).result());
 
-  // The caller is expected to have invoked `GeoEncoder::bindImagePipeline`
-  // already, which is the sole place the image pipeline is bound + counted.
-  // Set the pipeline here too as a defensive no-op (Dawn collapses the
-  // rebind on GPU); skip counting so `pipelineSwitches` reflects actual
-  // pipeline transitions.
-  pass.setPipeline(pipeline.pipeline());
-  pass.setBindGroup(0, bindGroup, 0, nullptr);
-  pass.draw(6, 1, 0, 0);
-  device.countDraw();
+  // The caller is expected to have invoked `GeoEncoder::bindImagePipeline` already, which is the
+  // sole place the image pipeline is bound + counted. Set the pipeline here too as a defensive
+  // no-op; skip counting so `pipelineSwitches` reflects actual pipeline transitions.
+  (void)pass.setPipeline(pipeline.pipeline());
+  (void)pass.setBindGroup(0, bindGroup);
+  (void)pass.draw(6, 1, 0, 0);
 }
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodeTextureEncoder.h
+++ b/donner/svg/renderer/geode/GeodeTextureEncoder.h
@@ -4,19 +4,19 @@
 
 #include <cstdint>
 #include <optional>
-#include <webgpu/webgpu.hpp>
 
 #include "donner/base/Box.h"
+#include "donner/gpu/CommandEncoder.h"
+#include "donner/gpu/Handles.h"
+#include "donner/svg/renderer/geode/GeodeGpuContext.h"
 
 namespace donner::geode {
 
-class GeodeDevice;
 class GeodeImagePipeline;
-class ScopedWgpuResourceArena;
 
 /**
- * Reusable helpers for uploading pixel data to a `wgpu::Texture` and drawing
- * it as a textured quad through `GeodeImagePipeline`.
+ * Reusable helpers for uploading pixel data to a GPU texture and drawing it as a textured quad
+ * through `GeodeImagePipeline`.
  *
  * This is the piece `drawImage` and pattern tile rendering share.
  * Both paths need:
@@ -35,27 +35,23 @@ class ScopedWgpuResourceArena;
 class GeodeTextureEncoder {
 public:
   /**
-   * Upload a tightly packed RGBA8 pixel buffer to a freshly created `wgpu::Texture`
-   * (usage = `TextureBinding | CopyDst`). Alpha interpretation is carried by the draw parameters.
+   * Upload a tightly packed RGBA8 pixel buffer to a freshly created sampled texture. Alpha
+   * interpretation is carried by the draw parameters.
    *
-   * WebGPU requires `bytesPerRow` to be 256-aligned for texture writes, but
-   * the unpadded-row path is exercised by `queue.WriteTexture` on all Dawn
-   * backends regardless of format. This function handles the rare case
-   * where the source buffer's row stride (`width * 4`) is not 256-aligned by
-   * copying rows into a padded staging buffer before the upload.
+   * Texture writes carry a 256-byte row pitch. This function handles the case where the source
+   * buffer's row stride (`width * 4`) is not 256-aligned by copying rows into a padded staging
+   * buffer before the upload.
    *
-   * Returns an empty texture if `device`, `width`, `height`, or `rgbaPixels`
-   * are invalid.
+   * Returns an empty texture if `width`, `height`, or `rgbaPixels` are invalid.
    *
-   * @param device The Geode device wrapper (provides both `wgpu::Device`
-   *   and `wgpu::Queue`).
+   * @param context The recording context providing the GPU runtime device.
    * @param rgbaPixels RGBA8 pixels in row-major order.
    *   Must contain at least `width * height * 4` bytes.
    * @param width  Image width in pixels. Must be > 0.
    * @param height Image height in pixels. Must be > 0.
    */
-  static wgpu::Texture uploadRgba8Texture(GeodeDevice& device, const uint8_t* rgbaPixels,
-                                          uint32_t width, uint32_t height);
+  static gpu::Texture uploadRgba8Texture(const GeodeGpuContext& context, const uint8_t* rgbaPixels,
+                                         uint32_t width, uint32_t height);
 
   /// Uniform-buffer binding offset alignment shared by the blit path and
   /// any UniformScratch implementation. 256 is the WebGPU default
@@ -69,7 +65,7 @@ public:
   /// alive (see UniformScratch's contract below); holders must not retain
   /// the allocation beyond the current frame.
   struct UniformAllocation {
-    wgpu::Buffer buffer;
+    gpu::BufferRef buffer;
     uint64_t offset = 0;
     uint64_t size = 0;
   };
@@ -139,8 +135,8 @@ public:
     /// a second premultiplication that darkens the RGB channel. Straight-alpha
     /// callers leave the default false so the shader premultiplies on output.
     bool sourceIsPremultiplied = false;
-    /// `<mask>` compositing input. Ignored unless `maskMode` is nonzero.
-    wgpu::Texture maskTexture;
+    /// `<mask>` compositing input. Ignored unless `maskMode` is nonzero. Borrowed.
+    const gpu::Texture* maskTexture = nullptr;
     /// Mask coverage selector: 0 disables masking, 1 uses luminance, and 2 uses alpha.
     uint32_t maskMode = 0;
     /// When true, output pixels outside `maskBounds` are discarded.
@@ -159,19 +155,19 @@ public:
     /// Frozen snapshot of the parent render target - see
     /// `RendererGeode::popIsolatedLayer` which copies the prior
     /// parent content into a separate texture before opening the
-    /// blend blit pass. Ignored unless `blendMode != 0`.
-    wgpu::Texture dstSnapshotTexture;
+    /// blend blit pass. Ignored unless `blendMode != 0`. Borrowed.
+    const gpu::Texture* dstSnapshotTexture = nullptr;
     /// Path-clip mask view. When set, the image shader samples
     /// it in target-pixel space and gates the source content before any
-    /// blend/mask compositing.
-    wgpu::TextureView clipMaskView;
+    /// blend/mask compositing. Borrowed.
+    const gpu::TextureView* clipMaskView = nullptr;
   };
 
   /**
    * Record a textured-quad draw call into an already-open render pass.
    *
    * The caller must:
-   *   - Have already called `pass.SetPipeline(pipeline.pipeline())` OR be
+   *   - Have already called `pass.setPipeline(pipeline.pipeline())` OR be
    *     OK with the draw switching the pipeline (we call SetPipeline
    *     internally to keep this helper self-contained).
    *   - Provide an MVP matrix built the same way as `GeoEncoder::Impl::buildMvp`
@@ -183,13 +179,13 @@ public:
    * growth instead of one per blit) or into a fresh per-blit buffer on the
    * legacy path.
    *
-   * @param resourceArena Scoped owner for WebGPU handles created by the draw.
+   * @param resourceArena Scoped owner for GPU handles created by the draw.
    * @param scratch Optional pooled uniform scratch (see `UniformScratch`).
    */
-  static void drawTexturedQuad(GeodeDevice& device, const GeodeImagePipeline& pipeline,
-                               const wgpu::RenderPassEncoder& pass, const wgpu::Texture& texture,
+  static void drawTexturedQuad(const GeodeGpuContext& context, const GeodeImagePipeline& pipeline,
+                               gpu::RenderPassEncoder& pass, const gpu::Texture& texture,
                                const float mvp[16], uint32_t targetWidth, uint32_t targetHeight,
-                               const QuadParams& params, ScopedWgpuResourceArena& resourceArena,
+                               const QuadParams& params, GeodeTransientResources& resourceArena,
                                UniformScratch* scratch = nullptr);
 };
 

--- a/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
+++ b/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
@@ -297,7 +297,7 @@ gpu::Result<gpu::Texture> GeodeWgpuAdapterDevice::importExternalTexture(wgpu::Te
   return result;
 }
 
-wgpu::Buffer GeodeWgpuAdapterDevice::wgpuBufferOf(const gpu::Buffer& buffer) const {
+wgpu::Buffer GeodeWgpuAdapterDevice::wgpuBufferOf(const gpu::BufferRef& buffer) const {
   if (!buffer.isValid() || buffer.deviceId() != deviceId()) {
     return wgpu::Buffer();
   }

--- a/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
+++ b/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
@@ -297,13 +297,6 @@ gpu::Result<gpu::Texture> GeodeWgpuAdapterDevice::importExternalTexture(wgpu::Te
   return result;
 }
 
-wgpu::Buffer GeodeWgpuAdapterDevice::wgpuBufferOf(const gpu::BufferRef& buffer) const {
-  if (!buffer.isValid() || buffer.deviceId() != deviceId()) {
-    return wgpu::Buffer();
-  }
-  return GetHandle(slotBuffers_, buffer.slotIndex());
-}
-
 wgpu::Texture GeodeWgpuAdapterDevice::wgpuTextureOf(const gpu::Texture& texture) const {
   // Full base-class validation (null, device identity, AND generation), so a stale or forged
   // handle cannot bridge the slot's new occupant to raw wgpu.
@@ -325,29 +318,6 @@ wgpu::TextureView GeodeWgpuAdapterDevice::wgpuTextureViewOf(
   return GetHandle(slotTextureViews_, textureView.slotIndex());
 }
 
-wgpu::RenderPipeline GeodeWgpuAdapterDevice::wgpuRenderPipelineOf(
-    const gpu::RenderPipeline& pipeline) const {
-  if (!pipeline.isValid() || pipeline.deviceId() != deviceId()) {
-    return wgpu::RenderPipeline();
-  }
-  return GetHandle(slotRenderPipelines_, pipeline.slotIndex());
-}
-
-wgpu::BindGroupLayout GeodeWgpuAdapterDevice::wgpuBindGroupLayoutOf(
-    const gpu::BindGroupLayout& layout) const {
-  if (!layout.isValid() || layout.deviceId() != deviceId()) {
-    return wgpu::BindGroupLayout();
-  }
-  return GetHandle(slotBindGroupLayouts_, layout.slotIndex());
-}
-
-wgpu::Sampler GeodeWgpuAdapterDevice::wgpuSamplerOf(const gpu::Sampler& sampler) const {
-  if (!sampler.isValid() || sampler.deviceId() != deviceId()) {
-    return wgpu::Sampler();
-  }
-  return GetHandle(slotSamplers_, sampler.slotIndex());
-}
-
 gpu::TextureFormat GpuTextureFormatFromWgpu(wgpu::TextureFormat format) {
   switch (static_cast<WGPUTextureFormat>(format)) {
     case WGPUTextureFormat_RGBA8Unorm: return gpu::TextureFormat::RGBA8Unorm;
@@ -359,6 +329,24 @@ gpu::TextureFormat GpuTextureFormatFromWgpu(wgpu::TextureFormat format) {
                            "wgpu texture format is outside the donner::gpu supported set "
                            "(RGBA8Unorm / BGRA8Unorm / R8Unorm)");
   return gpu::TextureFormat::RGBA8Unorm;
+}
+
+gpu::TextureUsage GpuTextureUsageFromWgpu(wgpu::TextureUsage usage) {
+  const WGPUTextureUsage raw = static_cast<WGPUTextureUsage>(usage);
+  gpu::TextureUsage result = gpu::TextureUsage::None;
+  if ((raw & WGPUTextureUsage_RenderAttachment) != 0) {
+    result = result | gpu::TextureUsage::RenderAttachment;
+  }
+  if ((raw & WGPUTextureUsage_TextureBinding) != 0) {
+    result = result | gpu::TextureUsage::Sampled;
+  }
+  if ((raw & WGPUTextureUsage_CopySrc) != 0) {
+    result = result | gpu::TextureUsage::CopySrc;
+  }
+  if ((raw & WGPUTextureUsage_CopyDst) != 0) {
+    result = result | gpu::TextureUsage::CopyDst;
+  }
+  return result;
 }
 
 gpu::Status GeodeWgpuAdapterDevice::onCreateBuffer(uint32_t slotIndex,

--- a/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
+++ b/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
@@ -1,5 +1,6 @@
 #include "donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h"
 
+#include <algorithm>
 #include <cassert>
 #include <chrono>
 #include <format>
@@ -783,7 +784,7 @@ gpu::Status GeodeWgpuAdapterDevice::encodeBeginRenderPass(
   passDescriptor.label = wgpuLabel(std::string_view(beginPass.descriptor.label));
   passDescriptor.colorAttachmentCount = colorAttachments.size();
   passDescriptor.colorAttachments = colorAttachments.data();
-  state.pass.reset(state.encoder.get().beginRenderPass(passDescriptor));
+  state.pass.reset(state.encoder.beginRenderPass(passDescriptor));
   if (!state.pass) {
     return GpuError{GpuErrorType::InvalidState, "wgpu render pass creation failed"};
   }
@@ -885,7 +886,7 @@ gpu::Status GeodeWgpuAdapterDevice::encodeCopyTextureToBuffer(
   destination.layout.bytesPerRow = copy.layout.bytesPerRow;
   destination.layout.rowsPerImage = copy.layout.rowsPerImage;
   const wgpu::Extent3D extent = {copy.copySize.width, copy.copySize.height, 1u};
-  state.encoder.get().copyTextureToBuffer(source, destination, extent);
+  state.encoder.copyTextureToBuffer(source, destination, extent);
   return OkStatus();
 }
 
@@ -909,7 +910,7 @@ gpu::Status GeodeWgpuAdapterDevice::encodeCopyTextureToTexture(
   wgpu::TexelCopyTextureInfo destination = {};
   destination.texture = destinationTexture;
   const wgpu::Extent3D extent = {textureCopy.copySize.width, textureCopy.copySize.height, 1u};
-  state.encoder.get().copyTextureToTexture(source, destination, extent);
+  state.encoder.copyTextureToTexture(source, destination, extent);
   return OkStatus();
 }
 
@@ -952,13 +953,60 @@ gpu::Status GeodeWgpuAdapterDevice::encodeCommand(EncodingState& state,
       command);
 }
 
+void GeodeWgpuAdapterDevice::setHostCommandEncoder(wgpu::CommandEncoder encoder) {
+  hostCommandEncoder_ = std::move(encoder);
+}
+
+void GeodeWgpuAdapterDevice::clearHostCommandEncoder() {
+  hostCommandEncoder_ = wgpu::CommandEncoder();
+}
+
+void GeodeWgpuAdapterDevice::notifyHostSubmitted() {
+  if (hostPendingSerial_ == 0) {
+    return;
+  }
+  const uint64_t serial = hostPendingSerial_;
+  hostPendingSerial_ = 0;
+  advanceCompletedSerialWhenQueueDrains(serial);
+}
+
+void GeodeWgpuAdapterDevice::advanceCompletedSerialWhenQueueDrains(uint64_t serial) {
+  // Callback-mode handling (wgpu-native vs emdawnwebgpu) is centralized in
+  // notifyWhenSubmittedWorkDone; waitForSerial's poll loop drives delivery.
+  struct WorkDoneState {
+    std::shared_ptr<CompletionState> completion;  //!< Shared completion counter.
+    uint64_t serial = 0;                          //!< Serial this callback completes.
+
+    /// Monotonic max: callbacks may complete out of order across submissions.
+    void onWorkDone() {
+      uint64_t previous = completion->completedSerial.load(std::memory_order_relaxed);
+      while (previous < serial &&
+             !completion->completedSerial.compare_exchange_weak(
+                 previous, serial, std::memory_order_release, std::memory_order_relaxed)) {}
+    }
+  };
+  auto workDoneState = std::make_shared<WorkDoneState>();
+  workDoneState->completion = completionState_;
+  workDoneState->serial = serial;
+  notifyWhenSubmittedWorkDone(geodeDevice_.queue(), workDoneState);
+}
+
 gpu::Status GeodeWgpuAdapterDevice::onSubmit(uint64_t submissionSerial,
                                              uint32_t commandBufferSlotIndex,
                                              std::span<const gpu::Command> commands) {
   (void)commandBufferSlotIndex;
 
+  // Replay into the host's encoder when one is installed, so a caller that also records spans
+  // this runtime cannot express keeps one command buffer covering the whole frame in order.
+  const bool replayingIntoHost = static_cast<bool>(hostCommandEncoder_);
+
   EncodingState state;
-  state.encoder.reset(geodeDevice_.device().createCommandEncoder());
+  if (replayingIntoHost) {
+    state.encoder = hostCommandEncoder_;
+  } else {
+    state.ownedEncoder.reset(geodeDevice_.device().createCommandEncoder());
+    state.encoder = state.ownedEncoder.get();
+  }
   if (!state.encoder) {
     return GpuError{GpuErrorType::InvalidState, "wgpu command encoder creation failed"};
   }
@@ -987,33 +1035,22 @@ gpu::Status GeodeWgpuAdapterDevice::onSubmit(uint64_t submissionSerial,
     return GpuError{GpuErrorType::InvalidState, "submitted command stream left a render pass open"};
   }
 
-  ScopedWgpuHandle<wgpu::CommandBuffer> commandBuffer(state.encoder.get().finish());
+  if (replayingIntoHost) {
+    // The host owns finish + submit for its encoder. Hold the serial back until it reports that
+    // submit: reporting completion before the work is even submitted would be a lie the deferred
+    // destruction and wait paths both act on.
+    hostPendingSerial_ = std::max(hostPendingSerial_, submissionSerial);
+    return OkStatus();
+  }
+
+  ScopedWgpuHandle<wgpu::CommandBuffer> commandBuffer(state.encoder.finish());
   if (!commandBuffer) {
     return GpuError{GpuErrorType::InvalidState, "wgpu command buffer finish failed"};
   }
   geodeDevice_.queue().submit(1, &commandBuffer.get());
   geodeDevice_.countSubmit();
 
-  // Advance completedSerial when the queue drains. Callback-mode handling (wgpu-native vs
-  // emdawnwebgpu) is centralized in notifyWhenSubmittedWorkDone; waitForSerial's poll loop
-  // drives delivery.
-  struct WorkDoneState {
-    std::shared_ptr<CompletionState> completion;  //!< Shared completion counter.
-    uint64_t serial = 0;                          //!< Serial this callback completes.
-
-    /// Monotonic max: callbacks may complete out of order across submissions.
-    void onWorkDone() {
-      uint64_t previous = completion->completedSerial.load(std::memory_order_relaxed);
-      while (previous < serial &&
-             !completion->completedSerial.compare_exchange_weak(
-                 previous, serial, std::memory_order_release, std::memory_order_relaxed)) {}
-    }
-  };
-  auto workDoneState = std::make_shared<WorkDoneState>();
-  workDoneState->completion = completionState_;
-  workDoneState->serial = submissionSerial;
-  notifyWhenSubmittedWorkDone(geodeDevice_.queue(), workDoneState);
-
+  advanceCompletedSerialWhenQueueDrains(submissionSerial);
   return OkStatus();
 }
 

--- a/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
+++ b/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc
@@ -297,6 +297,13 @@ gpu::Result<gpu::Texture> GeodeWgpuAdapterDevice::importExternalTexture(wgpu::Te
   return result;
 }
 
+wgpu::Buffer GeodeWgpuAdapterDevice::wgpuBufferOf(const gpu::Buffer& buffer) const {
+  if (!buffer.isValid() || buffer.deviceId() != deviceId()) {
+    return wgpu::Buffer();
+  }
+  return GetHandle(slotBuffers_, buffer.slotIndex());
+}
+
 wgpu::Texture GeodeWgpuAdapterDevice::wgpuTextureOf(const gpu::Texture& texture) const {
   // Full base-class validation (null, device identity, AND generation), so a stale or forged
   // handle cannot bridge the slot's new occupant to raw wgpu.

--- a/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h
+++ b/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h
@@ -124,6 +124,15 @@ public:
   void notifyHostSubmitted();
 
   /**
+   * TEMPORARY escape hatch, deleted once every Geode bind group is built through the runtime:
+   * returns the wgpu buffer behind \p buffer, or a null handle if the handle does not name a
+   * live buffer of this adapter. Borrowed; the adapter retains ownership.
+   *
+   * @param buffer Live buffer handle of this adapter.
+   */
+  wgpu::Buffer wgpuBufferOf(const gpu::Buffer& buffer) const;
+
+  /**
    * TEMPORARY escape hatch (deleted in packet 11, readback/presentation): returns the wgpu
    * texture behind \p texture, or a null handle if the handle does not name a live texture of
    * this adapter. Borrowed; the adapter (or the external owner) retains ownership.

--- a/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h
+++ b/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h
@@ -128,9 +128,9 @@ public:
    * returns the wgpu buffer behind \p buffer, or a null handle if the handle does not name a
    * live buffer of this adapter. Borrowed; the adapter retains ownership.
    *
-   * @param buffer Live buffer handle of this adapter.
+   * @param buffer Live buffer handle or reference of this adapter.
    */
-  wgpu::Buffer wgpuBufferOf(const gpu::Buffer& buffer) const;
+  wgpu::Buffer wgpuBufferOf(const gpu::BufferRef& buffer) const;
 
   /**
    * TEMPORARY escape hatch (deleted in packet 11, readback/presentation): returns the wgpu

--- a/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h
+++ b/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h
@@ -92,6 +92,38 @@ public:
                                                   gpu::TextureUsage usage);
 
   /**
+   * Installs \p encoder as the host command encoder: while one is installed, a submitted
+   * command stream is replayed into it instead of into an encoder this adapter owns, and this
+   * adapter performs no queue submit of its own. One command buffer therefore still carries a
+   * whole frame in recording order, including the spans a caller records directly into the same
+   * encoder around the replayed ones.
+   *
+   * Temporary bridge: it exists because the frame encoder also carries compute passes that the
+   * GPU runtime does not model, so those spans cannot be replayed through it. It is removed once
+   * every subsystem sharing the frame encoder records through the runtime.
+   *
+   * The caller owns \p encoder, must keep it alive until it is replaced or cleared, and must
+   * call \ref notifyHostSubmitted after each queue submit of a command buffer finished from it.
+   * Until then the serials replayed into it are deliberately not observable as complete.
+   *
+   * @param encoder Host-owned command encoder to replay into.
+   */
+  void setHostCommandEncoder(wgpu::CommandEncoder encoder);
+
+  /// Uninstalls the host command encoder, returning this adapter to owning and submitting the
+  /// encoders it records into. Serials already replayed into a host encoder stay incomplete
+  /// until \ref notifyHostSubmitted reports their submit.
+  void clearHostCommandEncoder();
+
+  /**
+   * Reports that the host submitted a command buffer carrying every stream replayed since the
+   * previous report, so their completion can now be observed. Advances \ref completedSerial to
+   * the highest replayed serial once the queue drains, exactly as an adapter-owned submit does.
+   * A no-op when nothing has been replayed since the last report.
+   */
+  void notifyHostSubmitted();
+
+  /**
    * TEMPORARY escape hatch (deleted in packet 11, readback/presentation): returns the wgpu
    * texture behind \p texture, or a null handle if the handle does not name a live texture of
    * this adapter. Borrowed; the adapter (or the external owner) retains ownership.
@@ -178,7 +210,10 @@ private:
 
   /// Mutable state threaded through the encoding of one command stream.
   struct EncodingState {
-    ScopedWgpuHandle<wgpu::CommandEncoder> encoder;  //!< Command encoder being recorded.
+    /// Owned encoder, used when no host encoder is installed; empty while replaying.
+    ScopedWgpuHandle<wgpu::CommandEncoder> ownedEncoder;
+    /// Encoder actually recorded into: \ref ownedEncoder, or the borrowed host encoder.
+    wgpu::CommandEncoder encoder;
     ScopedWgpuHandle<wgpu::RenderPassEncoder> pass;  //!< Active render pass, or empty.
   };
 
@@ -232,7 +267,17 @@ private:
   /// @param command Recorded command.
   gpu::Status encodeCommand(EncodingState& state, const gpu::Command& command);
 
+  /// Attaches the queue work-done callback that advances \ref completedSerial to \p serial.
+  /// @param serial Submission serial the callback completes.
+  void advanceCompletedSerialWhenQueueDrains(uint64_t serial);
+
   GeodeDevice& geodeDevice_;
+
+  /// Host-owned command encoder to replay into, or null when this adapter owns its encoders.
+  wgpu::CommandEncoder hostCommandEncoder_;
+  /// Highest serial replayed into \ref hostCommandEncoder_ since the last
+  /// \ref notifyHostSubmitted; 0 when nothing is awaiting the host's submit.
+  uint64_t hostPendingSerial_ = 0;
 
   std::vector<ScopedWgpuHandle<wgpu::Buffer>> slotBuffers_;
   std::vector<TextureSlot> slotTextures_;

--- a/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h
+++ b/donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h
@@ -124,15 +124,6 @@ public:
   void notifyHostSubmitted();
 
   /**
-   * TEMPORARY escape hatch, deleted once every Geode bind group is built through the runtime:
-   * returns the wgpu buffer behind \p buffer, or a null handle if the handle does not name a
-   * live buffer of this adapter. Borrowed; the adapter retains ownership.
-   *
-   * @param buffer Live buffer handle or reference of this adapter.
-   */
-  wgpu::Buffer wgpuBufferOf(const gpu::BufferRef& buffer) const;
-
-  /**
    * TEMPORARY escape hatch (deleted in packet 11, readback/presentation): returns the wgpu
    * texture behind \p texture, or a null handle if the handle does not name a live texture of
    * this adapter. Borrowed; the adapter (or the external owner) retains ownership.
@@ -148,34 +139,6 @@ public:
    * @param textureView Live texture view handle of this adapter.
    */
   wgpu::TextureView wgpuTextureViewOf(const gpu::TextureView& textureView) const;
-
-  /**
-   * TEMPORARY escape hatch for 8a only - deleted in packet 8b when GeoEncoder records through
-   * \c donner::gpu::CommandEncoder: returns the wgpu render pipeline behind \p pipeline so the
-   * still-wgpu GeoEncoder can bind pipelines whose creation already migrated. Borrowed.
-   *
-   * @param pipeline Live render pipeline handle of this adapter.
-   */
-  wgpu::RenderPipeline wgpuRenderPipelineOf(const gpu::RenderPipeline& pipeline) const;
-
-  /**
-   * TEMPORARY escape hatch for 8a only - deleted in packet 8b when GeoEncoder's bind-group
-   * creation migrates: returns the wgpu bind group layout behind \p layout so the still-wgpu
-   * GeoEncoder can create its per-draw bind groups against migrated layouts. Borrowed.
-   *
-   * @param layout Live bind group layout handle of this adapter.
-   */
-  wgpu::BindGroupLayout wgpuBindGroupLayoutOf(const gpu::BindGroupLayout& layout) const;
-
-  /**
-   * TEMPORARY escape hatch for 8a only - deleted in packet 8b when GeoEncoder's and
-   * GeodeTextureEncoder's bind-group creation migrates: returns the wgpu sampler behind
-   * \p sampler so still-wgpu bind groups can reference migrated samplers (e.g. the image-blit
-   * pipeline's shared samplers). Borrowed.
-   *
-   * @param sampler Live sampler handle of this adapter.
-   */
-  wgpu::Sampler wgpuSamplerOf(const gpu::Sampler& sampler) const;
 
 protected:
   gpu::Status onCreateBuffer(uint32_t slotIndex, const gpu::BufferDescriptor& descriptor) override;
@@ -313,5 +276,14 @@ private:
  * @param format wgpu texture format to map.
  */
 gpu::TextureFormat GpuTextureFormatFromWgpu(wgpu::TextureFormat format);
+
+/**
+ * Maps wgpu texture usage flags onto the \c donner::gpu usage flags. Flags with no runtime
+ * equivalent are dropped, so the result describes exactly the capabilities the runtime can
+ * express for the texture.
+ *
+ * @param usage wgpu usage flags to map.
+ */
+gpu::TextureUsage GpuTextureUsageFromWgpu(wgpu::TextureUsage usage);
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
@@ -34,6 +34,7 @@ namespace {
 constexpr uint32_t kSize = 64;
 constexpr wgpu::TextureFormat kFormat = wgpu::TextureFormat::RGBA8Unorm;
 constexpr uint32_t kBytesPerRow = 256;  // Padded from kSize*4 = 256.
+constexpr gpu::Extent2d kTargetSize = {kSize, kSize};
 
 using svg::test::FormatRgba;
 using svg::test::Near;
@@ -86,17 +87,17 @@ protected:
     gradientPipeline_ = &device_->gradientPipeline();
     imagePipeline_ = &device_->imagePipeline();
 
-    wgpu::TextureDescriptor td = {};
-    td.label = wgpuLabel("TestTarget");
-    td.size = {kSize, kSize, 1};
-    td.format = kFormat;
-    td.usage = wgpu::TextureUsage::RenderAttachment | wgpu::TextureUsage::CopySrc |
-               wgpu::TextureUsage::TextureBinding;
-    td.mipLevelCount = 1;
-    td.sampleCount = 1;
-    td.dimension = wgpu::TextureDimension::_2D;
-    target_ = device_->device().createTexture(td);
-    ASSERT_TRUE(static_cast<bool>(target_));
+    auto targetResult = device_->adapterDevice().createTexture(
+        gpu::TextureDescriptor{"TestTarget", kTargetSize, gpu::TextureFormat::RGBA8Unorm,
+                               gpu::TextureUsage::RenderAttachment | gpu::TextureUsage::CopySrc |
+                                   gpu::TextureUsage::Sampled});
+    ASSERT_TRUE(targetResult.hasResult()) << "createTexture failed";
+    target_ = std::move(targetResult).result();
+    ASSERT_TRUE(target_.isValid());
+    // Readback below drives the copy through the backend queue directly, so it
+    // needs the backing texture object the runtime handle names.
+    backendTarget_ = device_->adapterDevice().wgpuTextureOf(target_);
+    ASSERT_TRUE(static_cast<bool>(backendTarget_));
 
     wgpu::BufferDescriptor bd = {};
     bd.label = wgpuLabel("TestReadback");
@@ -113,7 +114,7 @@ protected:
     wgpu::CommandEncoder enc = device_->device().createCommandEncoder();
 
     wgpu::TexelCopyTextureInfo src = {};
-    src.texture = target_;
+    src.texture = backendTarget_;
     src.mipLevel = 0;
     src.origin = {0, 0, 0};
 
@@ -181,7 +182,8 @@ protected:
   GeodePipeline* pipeline_ = nullptr;
   GeodeGradientPipeline* gradientPipeline_ = nullptr;
   GeodeImagePipeline* imagePipeline_ = nullptr;
-  wgpu::Texture target_;
+  gpu::Texture target_;
+  wgpu::Texture backendTarget_;
   wgpu::Buffer readback_;
 };
 
@@ -189,7 +191,8 @@ protected:
 
 /// Clear the direct render target and read it back without a resolve attachment.
 TEST_F(GeoEncoderTest, ClearWritesDirectTarget) {
-  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_,
+                     kTargetSize);
   encoder.clear(css::RGBA(0, 128, 255, 255));  // Half-saturated blue.
   encoder.finish();
 
@@ -202,7 +205,8 @@ TEST_F(GeoEncoderTest, ClearWritesDirectTarget) {
 TEST_F(GeoEncoderTest, FillRect) {
   Path path = PathBuilder().addRect(Box2d({16, 16}, {48, 48})).build();
 
-  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_,
+                     kTargetSize);
   encoder.clear(css::RGBA(0, 0, 0, 255));  // Black.
   encoder.fillPath(path, css::RGBA(255, 0, 0, 255), FillRule::NonZero);
   encoder.finish();
@@ -225,10 +229,11 @@ TEST_F(GeoEncoderTest, RejectedPatternGeometryAllocatesNoPatternGpuState) {
   ProbeGeometryAdmission admission;
   admission.allow = false;
 
-  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_,
+                     kTargetSize);
   encoder.setGeometryAdmission(&admission);
   GeoEncoder::PatternPaint paint;
-  paint.tile = target_;
+  paint.tile = &target_;
   paint.tileSize = Vector2d(8.0, 8.0);
   encoder.fillPathPattern(path, FillRule::NonZero, paint, &encoded);
 
@@ -249,7 +254,8 @@ TEST_F(GeoEncoderTest, DegenerateResidentRadialDoesNotConsumeGeometryAdmission) 
   params.stops = std::span<const RadialGradientParams::Stop>(&stop, 1u);
   GeodeResidentGradientSlot slot;
 
-  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_,
+                     kTargetSize);
   encoder.setGeometryAdmission(&admission);
   encoder.fillPathRadialGradientResident(slot, encoded, params, FillRule::NonZero, 1u);
   EXPECT_EQ(admission.admittedDraws, 0u);
@@ -269,7 +275,8 @@ TEST_F(GeoEncoderTest, PreparedSceneAdmissionCanBeRefundedBeforeSingletonFallbac
   slot.recordSlab = records;
   ASSERT_TRUE(records->allocateSlot(*device_, slot.recordSlot));
 
-  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_,
+                     kTargetSize);
   encoder.setGeometryAdmission(&admission);
   GeoEncoder::SceneRecordState recordState;
   ASSERT_TRUE(encoder.ensureResidentSceneRecord(
@@ -288,7 +295,8 @@ TEST_F(GeoEncoderTest, TinyUniformScaleStillRasterizesHalfPixelHalo) {
   const Path path =
       PathBuilder().addRect(Box2d({264062.5, 264062.5}, {735937.5, 735937.5})).build();
 
-  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_,
+                     kTargetSize);
   encoder.clear(css::RGBA(0, 0, 0, 0));
   encoder.setTransform(Transform2d::Scale(0.000064));
   encoder.fillPath(path, css::RGBA(255, 0, 0, 255), FillRule::NonZero);
@@ -325,7 +333,8 @@ TEST_F(GeoEncoderTest, IllConditionedShearStillRasterizesHalfPixelHalo) {
   transform.data[4] = 0.0;
   transform.data[5] = 0.0;
 
-  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_,
+                     kTargetSize);
   encoder.clear(css::RGBA(0, 0, 0, 0));
   encoder.setTransform(transform);
   encoder.fillPath(path, css::RGBA(255, 0, 0, 255), FillRule::NonZero);
@@ -816,7 +825,8 @@ TEST_F(GeoEncoderTest, SceneBatchBindGroupCacheDistinguishesSlabGenerations) {
   // `createBindGroup` calls each of the two batches caused.
   const auto drawGeneration = [&](const Generation& generation, uint64_t& firstBatchCreates,
                                   uint64_t& repeatBatchCreates) {
-    GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+    GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_,
+                       kTargetSize);
     encoder.clear(css::RGBA(0, 0, 0, 0));
 
     const GeoEncoder::SceneBatchBinding binding = bindingFor(generation);
@@ -912,7 +922,8 @@ TEST_F(GeoEncoderTest, SceneBatchBindGroupCacheDistinguishesRecycledArenaUniform
 
   GeodeBufferPool pool;
   const auto drawOneEncoder = [&](uint64_t& bindGroupCreates, uint64_t& bufferCreates) {
-    GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+    GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_,
+                       kTargetSize);
     encoder.setBufferPool(&pool);
     encoder.clear(css::RGBA(0, 0, 0, 0));
 
@@ -951,7 +962,8 @@ TEST_F(GeoEncoderTest, ArenaGrowthKeepsEarlierGridBinding) {
   }
   const Path path = builder.build();
 
-  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_,
+                     kTargetSize);
   encoder.clear(css::RGBA(0, 0, 0, 255));
   encoder.fillPath(path, css::RGBA(255, 0, 0, 255), FillRule::NonZero);
   encoder.finish();
@@ -969,7 +981,8 @@ TEST_F(GeoEncoderTest, FillTriangle) {
                   .closePath()
                   .build();
 
-  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_,
+                     kTargetSize);
   encoder.clear(css::RGBA(0, 0, 0, 255));
   encoder.fillPath(path, css::RGBA(0, 255, 0, 255), FillRule::NonZero);
   encoder.finish();
@@ -1017,7 +1030,8 @@ TEST_F(GeoEncoderTest, FillLinearGradientUserSpace) {
   params.spreadMode = 0;                    // pad
   params.stops = std::span<const LinearGradientParams::Stop>(stops, 2);
 
-  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_,
+                     kTargetSize);
   encoder.clear(css::RGBA(0, 0, 0, 255));
   encoder.fillPathLinearGradient(path, params, FillRule::NonZero);
   encoder.finish();
@@ -1061,7 +1075,8 @@ TEST_F(GeoEncoderTest, FillLinearGradientRepeat) {
   params.spreadMode = 2;  // repeat
   params.stops = std::span<const LinearGradientParams::Stop>(stops, 2);
 
-  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_,
+                     kTargetSize);
   encoder.clear(css::RGBA(0, 0, 0, 255));
   encoder.fillPathLinearGradient(path, params, FillRule::NonZero);
   encoder.finish();
@@ -1103,7 +1118,8 @@ TEST_F(GeoEncoderTest, FillRadialGradientConcentric) {
   params.spreadMode = 0;  // pad
   params.stops = std::span<const RadialGradientParams::Stop>(stops, 2);
 
-  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_,
+                     kTargetSize);
   encoder.clear(css::RGBA(0, 0, 0, 255));
   encoder.fillPathRadialGradient(path, params, FillRule::NonZero);
   encoder.finish();
@@ -1148,7 +1164,8 @@ TEST_F(GeoEncoderTest, FillRadialGradientFocal) {
   params.spreadMode = 0;
   params.stops = std::span<const RadialGradientParams::Stop>(stops, 2);
 
-  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_,
+                     kTargetSize);
   encoder.clear(css::RGBA(0, 0, 0, 255));
   encoder.fillPathRadialGradient(path, params, FillRule::NonZero);
   encoder.finish();
@@ -1168,7 +1185,8 @@ TEST_F(GeoEncoderTest, FillRadialGradientFocal) {
 TEST_F(GeoEncoderTest, FillCircle) {
   Path path = PathBuilder().addCircle(Vector2d(32, 32), 20).build();
 
-  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_,
+                     kTargetSize);
   encoder.clear(css::RGBA(0, 0, 0, 255));
   encoder.fillPath(path, css::RGBA(0, 0, 255, 255), FillRule::NonZero);
   encoder.finish();
@@ -1202,7 +1220,8 @@ svg::ImageResource makeMagentaImage2x2() {
 /// Verify that the destination pixels are magenta and the outside is
 /// untouched.
 TEST_F(GeoEncoderTest, DrawImageFillsDestRect) {
-  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_,
+                     kTargetSize);
   encoder.clear(css::RGBA(0, 0, 0, 255));
 
   svg::ImageResource image = makeMagentaImage2x2();
@@ -1225,7 +1244,8 @@ TEST_F(GeoEncoderTest, DrawImageFillsDestRect) {
 /// opacity - the result should read back as ~(128, 0, 0, 255) over black
 /// with premultiplied source-over.
 TEST_F(GeoEncoderTest, DrawImageHonorsOpacity) {
-  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_,
+                     kTargetSize);
   encoder.clear(css::RGBA(0, 0, 0, 255));
 
   svg::ImageResource image;
@@ -1255,7 +1275,8 @@ TEST_F(GeoEncoderTest, DrawImageOverDeviceTextureLimitIsNoOp) {
   image.height = 1;
   image.data.resize(static_cast<std::size_t>(overLimitWidth) * 4u, 255);
 
-  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_,
+                     kTargetSize);
   encoder.clear(css::RGBA(0, 0, 0, 255));
   encoder.drawImage(image, Box2d({16.0, 16.0}, {48.0, 48.0}), /*opacity=*/1.0,
                     /*pixelated=*/true);
@@ -1268,7 +1289,8 @@ TEST_F(GeoEncoderTest, DrawImageOverDeviceTextureLimitIsNoOp) {
 /// this test shipped, future refactors that forget to re-bind the Slug
 /// fill pipeline between pipeline switches will regress here.
 TEST_F(GeoEncoderTest, FillThenImageThenFill) {
-  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_,
+                     kTargetSize);
   encoder.clear(css::RGBA(0, 0, 0, 255));
 
   // 1) Fill a red rect covering the top half.
@@ -1335,15 +1357,23 @@ TEST_F(GeoEncoderTest, FillPathPatternSolidTile) {
   wgpu::Extent3D extent = {kTileDim, kTileDim, 1};
   device_->queue().writeTexture(dst, tilePixels.data(), tilePixels.size(), layout, extent);
 
+  // Name the uploaded tile so the encoder can bind it as paint.
+  gpu::Result<gpu::Texture> tileHandleResult = device_->adapterDevice().importExternalTexture(
+      tile, gpu::Extent2d{kTileDim, kTileDim}, gpu::TextureFormat::RGBA8Unorm,
+      gpu::TextureUsage::Sampled | gpu::TextureUsage::CopyDst);
+  ASSERT_TRUE(tileHandleResult.hasResult());
+  const gpu::Texture tileHandle = std::move(tileHandleResult).result();
+
   // 2. Fill a path with the pattern. The tile size in pattern-space is
   // 4x4 so the shader wraps every 4 pixels; since the path spans more than
   // one tile, the wrap logic is exercised.
   Path path = PathBuilder().addRect(Box2d({16, 16}, {48, 48})).build();
 
-  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+  GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_,
+                     kTargetSize);
   encoder.clear(css::RGBA(0, 0, 0, 255));
   GeoEncoder::PatternPaint paint;
-  paint.tile = tile;
+  paint.tile = &tileHandle;
   paint.tileSize = Vector2d(4.0, 4.0);
   paint.patternFromPath = Transform2d();  // Identity: target space == pattern space.
   paint.opacity = 1.0;

--- a/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
@@ -363,12 +363,12 @@ TEST_F(GeoEncoderTest, ResidentSlotMoveTransfersRecordSlot) {
     // component's storage; the moved-from shell is then destroyed.
     geode::GeodeResidentSlot removedStorage;
     removedStorage = std::move(survivor);
-    ASSERT_TRUE(removedStorage.recordSlot.buffer);
+    ASSERT_TRUE(removedStorage.recordSlot.buffer.isValid());
     EXPECT_EQ(removedStorage.recordSlot.index, survivorSlot.index);
     // survivor (the moved-from shell) is destroyed at scope exit of the
     // ORIGINAL object in real usage; simulate by letting it destruct via a
     // fresh scope below. Here, verify the shell no longer owns the slot.
-    EXPECT_FALSE(survivor.recordSlot.buffer)
+    EXPECT_FALSE(survivor.recordSlot.buffer.isValid())
         << "The moved-from slot must not retain the record slot";
     // Destroy the shell explicitly (what entt's pop does to the tail).
     { geode::GeodeResidentSlot shell = std::move(survivor); }
@@ -378,7 +378,7 @@ TEST_F(GeoEncoderTest, ResidentSlotMoveTransfersRecordSlot) {
     slab->beginFrame(1);
     geode::GeodeRecordSlab::Slot next;
     ASSERT_TRUE(slab->allocateSlot(*device_, next));
-    EXPECT_FALSE(next.buffer == survivorSlot.buffer && next.offset == survivorSlot.offset)
+    EXPECT_FALSE(next.bufferId == survivorSlot.bufferId && next.offset == survivorSlot.offset)
         << "The survivor's record slot leaked back to the slab through the moved-from shell";
   }
 }
@@ -393,10 +393,10 @@ TEST_F(GeoEncoderTest, RecordSlabFreeListSurvivesChunkGrowth) {
   for (size_t i = 0; i < kCount; ++i) {
     geode::GeodeRecordSlab::Slot slot;
     ASSERT_TRUE(slab.allocateSlot(*device_, slot)) << "allocation " << i;
-    ASSERT_TRUE(slot.buffer);
+    ASSERT_TRUE(slot.buffer.isValid());
     slots.push_back(slot);
   }
-  ASSERT_NE(slots[0].buffer, slots.back().buffer) << "Fixture must span two chunks";
+  ASSERT_NE(slots[0].bufferId, slots.back().bufferId) << "Fixture must span two chunks";
 
   // Free one slot in each chunk; frees merge at the next frame boundary.
   const geode::GeodeRecordSlab::Slot freedEarly = slots[10];
@@ -412,7 +412,7 @@ TEST_F(GeoEncoderTest, RecordSlabFreeListSurvivesChunkGrowth) {
   ASSERT_TRUE(slab.allocateSlot(*device_, reusedB));
   const auto matches = [](const geode::GeodeRecordSlab::Slot& a,
                           const geode::GeodeRecordSlab::Slot& b) {
-    return a.buffer == b.buffer && a.offset == b.offset && a.index == b.index;
+    return a.bufferId == b.bufferId && a.offset == b.offset && a.index == b.index;
   };
   EXPECT_TRUE(matches(reusedA, freedEarly) || matches(reusedA, freedLate));
   EXPECT_TRUE(matches(reusedB, freedEarly) || matches(reusedB, freedLate));
@@ -423,8 +423,8 @@ TEST_F(GeoEncoderTest, RecordSlabFreeListSurvivesChunkGrowth) {
     if (matches(live, freedEarly) || matches(live, freedLate)) {
       continue;
     }
-    EXPECT_FALSE(live.buffer == reusedA.buffer && live.offset == reusedA.offset);
-    EXPECT_FALSE(live.buffer == reusedB.buffer && live.offset == reusedB.offset);
+    EXPECT_FALSE(live.bufferId == reusedA.bufferId && live.offset == reusedA.offset);
+    EXPECT_FALSE(live.bufferId == reusedB.bufferId && live.offset == reusedB.offset);
   }
 }
 
@@ -531,12 +531,12 @@ TEST_F(GeoEncoderTest, BatchUniformCpuMirrorStopsAtCapPlusOneAndReleases) {
     GeodeRecordSlab slab(device_->deviceId(), budget);
     const uint32_t first[4] = {1u, 2u, 3u, 4u};
     const uint32_t second[4] = {5u, 6u, 7u, 8u};
-    ASSERT_TRUE(slab.acquireBatchUniform(*device_, first, sizeof(first)).buffer);
+    ASSERT_TRUE(slab.acquireBatchUniform(*device_, first, sizeof(first)).buffer.isValid());
     const uint64_t entryBytes = budget->cacheBytes();
     const uint64_t payloadBytes = slab.batchUniformPayloadBytesForTesting();
     budget->setLimitsForTesting(
         {.cacheBytes = entryBytes + payloadBytes - 1u, .residentBytes = kUniformBytes * 2u});
-    EXPECT_FALSE(slab.acquireBatchUniform(*device_, second, sizeof(second)).buffer);
+    EXPECT_FALSE(slab.acquireBatchUniform(*device_, second, sizeof(second)).buffer.isValid());
     EXPECT_EQ(budget->cacheBytes(), entryBytes);
     EXPECT_EQ(budget->residentBytes(), kUniformBytes)
         << "The rejected CPU mirror must roll back its tentative GPU reservation.";
@@ -554,7 +554,7 @@ TEST_F(GeoEncoderTest, BatchUniformCpuReservationIncludesVectorSpareCapacity) {
     GeodeRecordSlab slab(device_->deviceId(), budget);
     for (uint32_t index = 0; index < 5u; ++index) {
       const uint32_t value[4] = {index, index + 1u, index + 2u, index + 3u};
-      ASSERT_TRUE(slab.acquireBatchUniform(*device_, value, sizeof(value)).buffer);
+      ASSERT_TRUE(slab.acquireBatchUniform(*device_, value, sizeof(value)).buffer.isValid());
     }
     EXPECT_GE(slab.batchUniformPayloadBytesForTesting(), 5u * kUniformBytes);
     EXPECT_EQ(budget->cacheBytes(), slab.batchUniformMetadataBytesForTesting() +
@@ -648,9 +648,11 @@ TEST(GeodeResourceBudgetTest, FrameGeometryStopsAtExactAggregateBoundary) {
 /// repeat, no matter what the allocator does with the handles.
 TEST_F(GeoEncoderTest, BufferIdsAreNeverReusedAcrossSlabGenerations) {
   struct SlabGeneration {
-    WGPUBuffer chunkHandle = nullptr;
-    WGPUBuffer recordHandle = nullptr;
-    WGPUBuffer uniformHandle = nullptr;
+    // Resource slots, which the allocator DOES recycle across generations - the point of the
+    // ids below is that they stay distinct even when these repeat.
+    uint32_t chunkSlot = 0;
+    uint32_t recordSlot = 0;
+    uint32_t uniformSlot = 0;
     uint64_t chunkId = 0;
     uint64_t recordId = 0;
     uint64_t uniformId = 0;
@@ -671,9 +673,9 @@ TEST_F(GeoEncoderTest, BufferIdsAreNeverReusedAcrossSlabGenerations) {
         records.acquireBatchUniform(*device_, uniformBytes, sizeof(uniformBytes));
 
     SlabGeneration out;
-    out.chunkHandle = geometryAlloc.buffer;
-    out.recordHandle = recordSlot.buffer;
-    out.uniformHandle = uniform.buffer;
+    out.chunkSlot = geometryAlloc.buffer.slotIndex();
+    out.recordSlot = recordSlot.buffer.slotIndex();
+    out.uniformSlot = uniform.buffer.slotIndex();
     out.chunkId = geometryAlloc.bufferId;
     out.recordId = recordSlot.bufferId;
     out.uniformId = uniform.bufferId;
@@ -721,7 +723,7 @@ TEST_F(GeoEncoderTest, BufferIdsAreNeverReusedAcrossSlabGenerations) {
   geode::GeodeRecordSlab::Slot slotB;
   ASSERT_TRUE(records.allocateSlot(*device_, slotA));
   ASSERT_TRUE(records.allocateSlot(*device_, slotB));
-  ASSERT_EQ(slotA.buffer, slotB.buffer) << "Fixture must keep both slots in one chunk";
+  ASSERT_EQ(slotA.bufferId, slotB.bufferId) << "Fixture must keep both slots in one chunk";
   EXPECT_EQ(slotA.bufferId, slotB.bufferId);
 }
 
@@ -779,8 +781,10 @@ TEST_F(GeoEncoderTest, SceneBatchBindGroupCacheDistinguishesSlabGenerations) {
       record.boundingVertexCount = 4;
       const float quad[8] = {8.0f, 8.0f, 24.0f, 8.0f, 24.0f, 24.0f, 8.0f, 24.0f};
       std::memcpy(record.boundingVertices, quad, sizeof(quad));
-      device_->queue().writeBuffer(generation.recordSlots[i].buffer,
-                                   generation.recordSlots[i].offset, &record, sizeof(record));
+      (void)device_->adapterDevice().writeBuffer(
+          generation.records->bufferForId(generation.recordSlots[i].bufferId),
+          generation.recordSlots[i].offset,
+          std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(&record), sizeof(record)));
     }
     return generation;
   };
@@ -788,6 +792,7 @@ TEST_F(GeoEncoderTest, SceneBatchBindGroupCacheDistinguishesSlabGenerations) {
   const auto bindingFor = [](const Generation& generation) {
     GeoEncoder::SceneBatchBinding binding = {};
     binding.chunkBuffer = generation.chunk.buffer;
+    binding.chunkBytes = generation.geometry->chunkBytesForId(generation.chunk.bufferId);
     binding.recordBuffer = generation.recordSlots[0].buffer;
     binding.chunkBufferId = generation.chunk.bufferId;
     binding.recordBufferId = generation.recordSlots[0].bufferId;
@@ -880,13 +885,16 @@ TEST_F(GeoEncoderTest, SceneBatchBindGroupCacheDistinguishesRecycledArenaUniform
   record.boundingVertexCount = 4;
   const float quad[8] = {8.0f, 8.0f, 24.0f, 8.0f, 24.0f, 24.0f, 8.0f, 24.0f};
   std::memcpy(record.boundingVertices, quad, sizeof(quad));
-  device_->queue().writeBuffer(recordSlot.buffer, recordSlot.offset, &record, sizeof(record));
+  (void)device_->adapterDevice().writeBuffer(
+      records->bufferForId(recordSlot.bufferId), recordSlot.offset,
+      std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(&record), sizeof(record)));
 
   // A null `recordSlab` routes the batch uniform through the encoder's
   // per-frame arena instead of the slab's persistent table, which is the
   // allocation the buffer pool recycles.
   GeoEncoder::SceneBatchBinding binding = {};
   binding.chunkBuffer = chunk.buffer;
+  binding.chunkBytes = geometry->chunkBytesForId(chunk.bufferId);
   binding.recordBuffer = recordSlot.buffer;
   binding.chunkBufferId = chunk.bufferId;
   binding.recordBufferId = recordSlot.bufferId;

--- a/donner/svg/renderer/geode/tests/GeodeDevice_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeDevice_tests.cc
@@ -329,8 +329,8 @@ TEST(GeodeDevice, SharedPipelinesReturnSameInstance) {
 /// Compile it here on the real device, unconditionally and independent of the
 /// batching switch, so both variants stay covered.
 ///
-/// The returned handle alone proves nothing: wgpu hands back a non-null error
-/// pipeline for a rejected descriptor and reports the reason through the
+/// The returned handle alone proves nothing: the backend hands back a non-null
+/// error pipeline for a rejected descriptor and reports the reason through the
 /// device's uncaptured-error callback, so the real assertion is that the
 /// callback printed nothing. The shader-emitter validation tests keep a
 /// negative control proving this marker does fire on a bad descriptor.
@@ -339,12 +339,12 @@ TEST(GeodeDevice, BatchedFillPipelineCompilesWithoutValidationErrors) {
   ASSERT_NE(device, nullptr);
 
   testing::internal::CaptureStderr();
-  const wgpu::RenderPipeline& batched = device->pipeline().batchedPipeline();
+  const gpu::RenderPipeline& batched = device->pipeline().batchedPipeline();
   const std::string errors = testing::internal::GetCapturedStderr();
 
-  EXPECT_TRUE(static_cast<bool>(batched)) << "Batched fill pipeline creation returned null.";
+  EXPECT_TRUE(batched.isValid()) << "Batched fill pipeline creation returned null.";
   EXPECT_THAT(errors, Not(HasSubstr(kWgpuUncapturedErrorMarker)))
-      << "wgpu rejected the record-reading fill pipeline:\n"
+      << "The backend rejected the record-reading fill pipeline:\n"
       << errors;
 
   // Built on first use, then cached: a second call must hand back the same

--- a/donner/svg/renderer/geode/tests/GeodeWgpuAdapterDevice_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeWgpuAdapterDevice_tests.cc
@@ -218,9 +218,8 @@ TEST_F(GeodeWgpuAdapterDeviceTests, FamilySceneRendersAndCompletes) {
                       gpu::BlendComponent{gpu::BlendFactor::One, gpu::BlendFactor::OneMinusSrcAlpha,
                                           gpu::BlendOperation::Add}}}}}}));
 
-  // The TEMPORARY 8a escape hatches resolve migrated objects for the still-wgpu GeoEncoder.
-  EXPECT_TRUE(static_cast<bool>(adapter_->wgpuRenderPipelineOf(pipeline)));
-  EXPECT_TRUE(static_cast<bool>(adapter_->wgpuBindGroupLayoutOf(uniformLayout)));
+  // The TEMPORARY texture escape hatches resolve render targets for readback and presentation,
+  // which still run on the backend directly.
   EXPECT_TRUE(static_cast<bool>(adapter_->wgpuTextureOf(target)));
   EXPECT_TRUE(static_cast<bool>(adapter_->wgpuTextureViewOf(targetView)));
 

--- a/donner/svg/renderer/geode/tests/GeodeWgpuAdapterDevice_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeWgpuAdapterDevice_tests.cc
@@ -18,12 +18,14 @@
 #include "donner/gpu/CommandEncoder.h"
 #include "donner/gpu/tests/GpuTestUtils.h"
 #include "donner/svg/renderer/geode/GeodeCallbackState.h"
+#include "donner/svg/renderer/geode/GeodeCounters.h"
 #include "donner/svg/renderer/geode/GeodeDevice.h"
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 
 using testing::ElementsAre;
 using testing::Ge;
 using testing::HasSubstr;
+using testing::Lt;
 using testing::Not;
 
 namespace donner::geode {
@@ -283,6 +285,129 @@ TEST_F(GeodeWgpuAdapterDeviceTests, FamilySceneRendersAndCompletes) {
   EXPECT_THAT(PixelAt(copiedPixels, 0, 0), ElementsAre(0, 0, 128, 255));
   EXPECT_THAT(PixelAt(copiedPixels, 2, 2), ElementsAre(0, 0, 128, 255));
   EXPECT_THAT(PixelAt(copiedPixels, 3, 3), ElementsAre(0, 0, 128, 255));
+}
+
+/// The host-encoder replay mode has to hold three properties at once, and they only mean
+/// anything together, so one test drives all three: the replayed span and the spans the host
+/// records itself land in ONE command buffer in recording order, the replay performs no queue
+/// submit of its own, and the replayed serial is not observable as complete until the host
+/// reports its submit. Losing any one of them silently corrupts a frame or lies to the deferred
+/// destruction and wait paths.
+TEST_F(GeodeWgpuAdapterDeviceTests, HostEncoderReplayInterleavesInOneBufferAndDefersCompletion) {
+  const gpu::Texture target = gpu::GetResultOrFail(adapter_->createTexture(
+      gpu::TextureDescriptor{"replayTarget", gpu::Extent2d{4, 4}, gpu::TextureFormat::RGBA8Unorm,
+                             gpu::TextureUsage::RenderAttachment | gpu::TextureUsage::CopySrc}));
+  const gpu::TextureView targetView = gpu::GetResultOrFail(
+      adapter_->createTextureView(target, gpu::TextureViewDescriptor{"replayTargetView"}));
+  const gpu::Texture copyDestination = gpu::GetResultOrFail(adapter_->createTexture(
+      gpu::TextureDescriptor{"replayCopyDst", gpu::Extent2d{4, 4}, gpu::TextureFormat::RGBA8Unorm,
+                             gpu::TextureUsage::CopyDst | gpu::TextureUsage::CopySrc}));
+
+  GeodeCounters counters;
+  geodeDevice_->setCounters(&counters);
+
+  // The host owns this encoder for the whole "frame", exactly as a renderer does.
+  wgpu::CommandEncoderDescriptor hostDescriptor = {};
+  ScopedWgpuHandle<wgpu::CommandEncoder> hostEncoder(
+      geodeDevice_->device().createCommandEncoder(hostDescriptor));
+  ASSERT_TRUE(static_cast<bool>(hostEncoder.get()));
+  adapter_->setHostCommandEncoder(hostEncoder.get());
+
+  // A replayed span: clear the target to a color the copy below can be checked against.
+  std::unique_ptr<gpu::CommandEncoder> encoder =
+      gpu::GetResultOrFail(adapter_->createCommandEncoder());
+  gpu::RenderPassEncoder* pass =
+      gpu::GetResultOrFail(encoder->beginRenderPass(gpu::RenderPassDescriptor{
+          "replayPass",
+          {gpu::RenderPassColorAttachment{
+              targetView, gpu::LoadOp::Clear, gpu::StoreOp::Store, {0, 0, 0.5, 1}}}}));
+  ASSERT_NE(pass, nullptr);
+  EXPECT_THAT(pass->end(), gpu::IsOk());
+  const uint64_t serial =
+      gpu::GetResultOrFail(adapter_->submit(gpu::GetResultOrFail(encoder->finish())));
+  EXPECT_THAT(serial, Ge(uint64_t{1}));
+
+  // Replaying is not submitting: no queue submit happened, so no submit was counted, and the
+  // serial must not be observable as complete yet. A short wait proves the hold-back rather
+  // than merely observing a race.
+  EXPECT_EQ(counters.submits, 0u) << "replay must not perform a queue submit of its own";
+  EXPECT_THAT(adapter_->completedSerial(), Lt(serial));
+  EXPECT_FALSE(adapter_->waitForSerial(serial, /*timeoutSeconds=*/0.25))
+      << "serial " << serial << " reported complete before the host submitted its command buffer";
+
+  // A span the host records itself, AFTER the replayed one. It reads what the replayed clear
+  // wrote, so a wrong replay position (or a second command buffer) shows up as wrong bytes.
+  wgpu::TexelCopyTextureInfo copySource = {};
+  copySource.texture = adapter_->wgpuTextureOf(target);
+  wgpu::TexelCopyTextureInfo copyDest = {};
+  copyDest.texture = adapter_->wgpuTextureOf(copyDestination);
+  const wgpu::Extent3D copyExtent = {4u, 4u, 1u};
+  hostEncoder.get().copyTextureToTexture(copySource, copyDest, copyExtent);
+
+  // The host's single submit covers both spans.
+  {
+    ScopedWgpuHandle<wgpu::CommandBuffer> hostCommands(hostEncoder.get().finish());
+    ASSERT_TRUE(static_cast<bool>(hostCommands.get()));
+    geodeDevice_->queue().submit(1, &hostCommands.get());
+  }
+  adapter_->notifyHostSubmitted();
+  adapter_->clearHostCommandEncoder();
+
+  ASSERT_TRUE(adapter_->waitForSerial(serial, /*timeoutSeconds=*/30.0))
+      << "submission " << serial
+      << " did not complete after the host submit; completedSerial=" << adapter_->completedSerial();
+  EXPECT_THAT(adapter_->completedSerial(), Ge(serial));
+
+  const std::vector<uint8_t> targetPixels =
+      ReadbackTexturePixels(*geodeDevice_, adapter_->wgpuTextureOf(target));
+  ASSERT_THAT(targetPixels, Not(testing::IsEmpty())) << "replay target readback failed";
+  EXPECT_THAT(PixelAt(targetPixels, 0, 0), ElementsAre(0, 0, 128, 255));
+
+  const std::vector<uint8_t> copiedPixels =
+      ReadbackTexturePixels(*geodeDevice_, adapter_->wgpuTextureOf(copyDestination));
+  ASSERT_THAT(copiedPixels, Not(testing::IsEmpty())) << "replay copy destination readback failed";
+  EXPECT_THAT(PixelAt(copiedPixels, 0, 0), ElementsAre(0, 0, 128, 255));
+  EXPECT_THAT(PixelAt(copiedPixels, 3, 3), ElementsAre(0, 0, 128, 255));
+
+  geodeDevice_->setCounters(nullptr);
+}
+
+/// Clearing the host encoder returns the adapter to owning and submitting its own encoders, so
+/// a stream submitted afterwards completes without any host notification.
+TEST_F(GeodeWgpuAdapterDeviceTests, OwnedSubmitResumesAfterClearingTheHostEncoder) {
+  const gpu::Texture target = gpu::GetResultOrFail(adapter_->createTexture(
+      gpu::TextureDescriptor{"ownedTarget", gpu::Extent2d{4, 4}, gpu::TextureFormat::RGBA8Unorm,
+                             gpu::TextureUsage::RenderAttachment | gpu::TextureUsage::CopySrc}));
+  const gpu::TextureView targetView = gpu::GetResultOrFail(
+      adapter_->createTextureView(target, gpu::TextureViewDescriptor{"ownedTargetView"}));
+
+  wgpu::CommandEncoderDescriptor hostDescriptor = {};
+  ScopedWgpuHandle<wgpu::CommandEncoder> hostEncoder(
+      geodeDevice_->device().createCommandEncoder(hostDescriptor));
+  ASSERT_TRUE(static_cast<bool>(hostEncoder.get()));
+  adapter_->setHostCommandEncoder(hostEncoder.get());
+  adapter_->clearHostCommandEncoder();
+
+  GeodeCounters counters;
+  geodeDevice_->setCounters(&counters);
+
+  std::unique_ptr<gpu::CommandEncoder> encoder =
+      gpu::GetResultOrFail(adapter_->createCommandEncoder());
+  gpu::RenderPassEncoder* pass =
+      gpu::GetResultOrFail(encoder->beginRenderPass(gpu::RenderPassDescriptor{
+          "ownedPass",
+          {gpu::RenderPassColorAttachment{
+              targetView, gpu::LoadOp::Clear, gpu::StoreOp::Store, {0, 0, 0.5, 1}}}}));
+  ASSERT_NE(pass, nullptr);
+  EXPECT_THAT(pass->end(), gpu::IsOk());
+  const uint64_t serial =
+      gpu::GetResultOrFail(adapter_->submit(gpu::GetResultOrFail(encoder->finish())));
+
+  EXPECT_EQ(counters.submits, 1u) << "an adapter-owned submit must still count one submit";
+  ASSERT_TRUE(adapter_->waitForSerial(serial, /*timeoutSeconds=*/30.0));
+  EXPECT_THAT(adapter_->completedSerial(), Ge(serial));
+
+  geodeDevice_->setCounters(nullptr);
 }
 
 TEST_F(GeodeWgpuAdapterDeviceTests, ImportedExternalTextureIsUsableAndNotOwned) {

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -31,6 +31,7 @@
 #include "donner/svg/renderer/StrokeParams.h"
 #include "donner/svg/renderer/geode/GeodeCheckerboardPipeline.h"
 #include "donner/svg/renderer/geode/GeodeDevice.h"
+#include "donner/svg/renderer/geode/GeodeGpuContext.h"
 #include "donner/svg/renderer/geode/GeodePathCacheComponent.h"
 #include "donner/svg/renderer/tests/RgbaTestMatchers.h"
 #include "donner/svg/resources/ImageResource.h"
@@ -1397,11 +1398,17 @@ TEST_F(RendererGeodeTest, EmbeddedDeviceDrawPathExportsTextureSnapshot) {
   ASSERT_NE(embeddedUnique, nullptr);
 
   std::shared_ptr<geode::GeodeDevice> embedded(std::move(embeddedUnique));
-  ASSERT_TRUE(static_cast<bool>(embedded->dummyPatternTextureView()));
-  ASSERT_TRUE(static_cast<bool>(embedded->dummyPatternSampler()));
-  ASSERT_TRUE(static_cast<bool>(embedded->dummyClipMaskTextureView()));
-  ASSERT_TRUE(static_cast<bool>(embedded->dummyClipMaskSampler()));
-  ASSERT_TRUE(static_cast<bool>(embedded->identityInstanceRecordBuffer()));
+  const geode::GeodeGpuContext& gpuContext = embedded->gpuContext();
+  ASSERT_NE(gpuContext.dummyPatternTextureView, nullptr);
+  ASSERT_NE(gpuContext.dummyPatternSampler, nullptr);
+  ASSERT_NE(gpuContext.dummyClipMaskTextureView, nullptr);
+  ASSERT_NE(gpuContext.dummyClipMaskSampler, nullptr);
+  ASSERT_NE(gpuContext.identityInstanceRecordBuffer, nullptr);
+  ASSERT_TRUE(gpuContext.dummyPatternTextureView->isValid());
+  ASSERT_TRUE(gpuContext.dummyPatternSampler->isValid());
+  ASSERT_TRUE(gpuContext.dummyClipMaskTextureView->isValid());
+  ASSERT_TRUE(gpuContext.dummyClipMaskSampler->isValid());
+  ASSERT_TRUE(gpuContext.identityInstanceRecordBuffer->isValid());
 
   RendererGeode renderer(embedded);
   beginFrame(renderer);

--- a/tools/gpu_inventory/manifests/gpu_operations.json
+++ b/tools/gpu_inventory/manifests/gpu_operations.json
@@ -421,6 +421,7 @@
         "wgpuLabel"
       ],
       "wgpuCTypes": [
+        "WGPUCommandEncoder",
         "WGPUMapAsyncStatus",
         "WGPUMapAsyncStatus_Success",
         "WGPUStringView",
@@ -464,61 +465,6 @@
         "Texture",
         "TextureFormat",
         "TextureUsage",
-        "TextureView"
-      ]
-    },
-    "donner/svg/renderer/geode/GeoEncoder.cc": {
-      "operations": [
-        "beginRenderPass",
-        "createBindGroup",
-        "createCommandEncoder",
-        "createSampler",
-        "createView",
-        "draw",
-        "finish",
-        "setBindGroup",
-        "setPipeline",
-        "setScissorRect",
-        "submit"
-      ],
-      "wgpuCFunctions": [
-        "wgpuBufferOf",
-        "wgpuLabel"
-      ],
-      "wgpuCppTokens": [
-        "AddressMode",
-        "BindGroup",
-        "BindGroupDescriptor",
-        "BindGroupEntry",
-        "Buffer",
-        "Color",
-        "CommandBuffer",
-        "CommandEncoder",
-        "CommandEncoderDescriptor",
-        "Default",
-        "Device",
-        "FilterMode",
-        "LoadOp",
-        "RenderPassColorAttachment",
-        "RenderPassDescriptor",
-        "RenderPassEncoder",
-        "RenderPipeline",
-        "Sampler",
-        "SamplerDescriptor",
-        "StoreOp",
-        "Texture",
-        "TextureView"
-      ]
-    },
-    "donner/svg/renderer/geode/GeoEncoder.h": {
-      "operations": [
-        "finish",
-        "submit"
-      ],
-      "wgpuCppTokens": [
-        "CommandEncoder",
-        "Device",
-        "Texture",
         "TextureView"
       ]
     },
@@ -641,14 +587,10 @@
       "wgpuCFunctions": [
         "wgpuAdapterGetInfo",
         "wgpuAdapterInfoFreeMembers",
-        "wgpuBufferOf",
         "wgpuCreateInstance",
         "wgpuForceFallbackAdapterRequested",
         "wgpuInstanceRequestAdapter",
-        "wgpuLabel",
-        "wgpuSamplerOf",
-        "wgpuTextureOf",
-        "wgpuTextureViewOf"
+        "wgpuLabel"
       ],
       "wgpuCTypes": [
         "WGPUAdapterInfo",
@@ -688,7 +630,6 @@
       "wgpuCppTokens": [
         "Adapter",
         "BackendType",
-        "BindGroup",
         "Buffer",
         "BufferDescriptor",
         "BufferUsage",
@@ -703,7 +644,6 @@
         "Limits",
         "Queue",
         "RequestAdapterOptions",
-        "Sampler",
         "Status",
         "StringView",
         "Texture",
@@ -711,7 +651,6 @@
         "TextureDimension",
         "TextureFormat",
         "TextureUsage",
-        "TextureView",
         "createInstance"
       ]
     },
@@ -727,12 +666,10 @@
       ],
       "wgpuCppTokens": [
         "Adapter",
-        "BindGroup",
         "Buffer",
         "Device",
         "Instance",
         "Queue",
-        "Sampler",
         "Texture",
         "TextureFormat",
         "TextureView"
@@ -816,26 +753,6 @@
         "TextureDescriptor"
       ]
     },
-    "donner/svg/renderer/geode/GeodeImagePipeline.cc": {
-      "operations": [
-        "createBindGroupLayout",
-        "createPipelineLayout",
-        "createRenderPipeline",
-        "createSampler"
-      ],
-      "wgpuCFunctions": [
-        "wgpuBindGroupLayoutOf",
-        "wgpuRenderPipelineOf",
-        "wgpuSamplerOf"
-      ]
-    },
-    "donner/svg/renderer/geode/GeodeImagePipeline.h": {
-      "wgpuCppTokens": [
-        "BindGroupLayout",
-        "RenderPipeline",
-        "Sampler"
-      ]
-    },
     "donner/svg/renderer/geode/GeodePipeline.cc": {
       "operations": [
         "createBindGroupLayout",
@@ -844,9 +761,7 @@
         "createRenderPipeline"
       ],
       "wgpuCFunctions": [
-        "wgpuBindGroupLayoutOf",
-        "wgpuLabel",
-        "wgpuRenderPipelineOf"
+        "wgpuLabel"
       ],
       "wgpuCTypes": [
         "WGPUBindGroupLayout"
@@ -858,7 +773,6 @@
         "Device",
         "PipelineLayout",
         "PipelineLayoutDescriptor",
-        "RenderPipeline",
         "ShaderModule",
         "ShaderStage",
         "StorageTextureAccess",
@@ -871,17 +785,7 @@
       "wgpuCppTokens": [
         "BindGroupLayout",
         "ComputePipeline",
-        "Device",
-        "RenderPipeline"
-      ]
-    },
-    "donner/svg/renderer/geode/GeodeResidentPathComponent.h": {
-      "operations": [
-        "createBuffer",
-        "writeBuffer"
-      ],
-      "wgpuCppTokens": [
-        "BindGroup"
+        "Device"
       ]
     },
     "donner/svg/renderer/geode/GeodeShaders.cc": {
@@ -906,54 +810,6 @@
       "wgpuCppTokens": [
         "Device",
         "ShaderModule"
-      ]
-    },
-    "donner/svg/renderer/geode/GeodeTextureEncoder.cc": {
-      "operations": [
-        "createBindGroup",
-        "createBuffer",
-        "createTexture",
-        "createView",
-        "draw",
-        "setBindGroup",
-        "setPipeline",
-        "writeBuffer",
-        "writeTexture"
-      ],
-      "wgpuCFunctions": [
-        "wgpuLabel"
-      ],
-      "wgpuCppTokens": [
-        "BindGroup",
-        "BindGroupDescriptor",
-        "BindGroupEntry",
-        "Buffer",
-        "BufferDescriptor",
-        "BufferUsage",
-        "Device",
-        "Extent3D",
-        "Queue",
-        "RenderPassEncoder",
-        "Sampler",
-        "TexelCopyBufferLayout",
-        "TexelCopyTextureInfo",
-        "Texture",
-        "TextureAspect",
-        "TextureDescriptor",
-        "TextureDimension",
-        "TextureFormat",
-        "TextureUsage",
-        "TextureView"
-      ]
-    },
-    "donner/svg/renderer/geode/GeodeTextureEncoder.h": {
-      "wgpuCppTokens": [
-        "Buffer",
-        "Device",
-        "Queue",
-        "RenderPassEncoder",
-        "Texture",
-        "TextureView"
       ]
     },
     "donner/svg/renderer/geode/GeodeWgpuAdapterDevice.cc": {
@@ -984,11 +840,7 @@
         "writeTexture"
       ],
       "wgpuCFunctions": [
-        "wgpuBindGroupLayoutOf",
-        "wgpuBufferOf",
         "wgpuLabel",
-        "wgpuRenderPipelineOf",
-        "wgpuSamplerOf",
         "wgpuTextureOf",
         "wgpuTextureViewOf"
       ],
@@ -1001,7 +853,11 @@
         "WGPUTextureFormat_BGRA8Unorm",
         "WGPUTextureFormat_R8Unorm",
         "WGPUTextureFormat_RGBA8Unorm",
-        "WGPUTextureUsage"
+        "WGPUTextureUsage",
+        "WGPUTextureUsage_CopyDst",
+        "WGPUTextureUsage_CopySrc",
+        "WGPUTextureUsage_RenderAttachment",
+        "WGPUTextureUsage_TextureBinding"
       ],
       "wgpuCppTokens": [
         "AddressMode",
@@ -1062,10 +918,6 @@
     },
     "donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h": {
       "wgpuCFunctions": [
-        "wgpuBindGroupLayoutOf",
-        "wgpuBufferOf",
-        "wgpuRenderPipelineOf",
-        "wgpuSamplerOf",
         "wgpuTextureOf",
         "wgpuTextureViewOf"
       ],
@@ -1082,6 +934,7 @@
         "ShaderModule",
         "Texture",
         "TextureFormat",
+        "TextureUsage",
         "TextureView"
       ]
     },
@@ -1119,7 +972,8 @@
         "writeTexture"
       ],
       "wgpuCFunctions": [
-        "wgpuLabel"
+        "wgpuLabel",
+        "wgpuTextureOf"
       ],
       "wgpuCTypes": [
         "WGPUBuffer",
@@ -1189,7 +1043,6 @@
         "RenderPassColorAttachment",
         "RenderPassDescriptor",
         "RenderPassEncoder",
-        "RenderPipeline",
         "StoreOp",
         "TexelCopyBufferInfo",
         "TexelCopyTextureInfo",
@@ -1268,9 +1121,7 @@
         "unmap"
       ],
       "wgpuCFunctions": [
-        "wgpuBindGroupLayoutOf",
         "wgpuLabel",
-        "wgpuRenderPipelineOf",
         "wgpuTextureOf",
         "wgpuTextureViewOf"
       ],

--- a/tools/gpu_inventory/manifests/gpu_operations.json
+++ b/tools/gpu_inventory/manifests/gpu_operations.json
@@ -1038,6 +1038,7 @@
         "ColorTargetState",
         "ColorWriteMask",
         "CommandBuffer",
+        "CommandEncoder",
         "CullMode",
         "Default",
         "Extent3D",
@@ -1271,6 +1272,7 @@
     "donner/svg/renderer/geode/tests/GeodeWgpuAdapterDevice_tests.cc": {
       "operations": [
         "copyTextureToBuffer",
+        "copyTextureToTexture",
         "createBuffer",
         "createCommandEncoder",
         "createTexture",
@@ -1301,6 +1303,7 @@
         "CallbackMode",
         "CommandBuffer",
         "CommandEncoder",
+        "CommandEncoderDescriptor",
         "Default",
         "Extent3D",
         "MapMode",

--- a/tools/gpu_inventory/manifests/gpu_operations.json
+++ b/tools/gpu_inventory/manifests/gpu_operations.json
@@ -471,7 +471,6 @@
       "operations": [
         "beginRenderPass",
         "createBindGroup",
-        "createBuffer",
         "createCommandEncoder",
         "createSampler",
         "createView",
@@ -480,10 +479,10 @@
         "setBindGroup",
         "setPipeline",
         "setScissorRect",
-        "submit",
-        "writeBuffer"
+        "submit"
       ],
       "wgpuCFunctions": [
+        "wgpuBufferOf",
         "wgpuLabel"
       ],
       "wgpuCppTokens": [
@@ -492,8 +491,6 @@
         "BindGroupDescriptor",
         "BindGroupEntry",
         "Buffer",
-        "BufferDescriptor",
-        "BufferUsage",
         "Color",
         "CommandBuffer",
         "CommandEncoder",
@@ -519,17 +516,10 @@
         "submit"
       ],
       "wgpuCppTokens": [
-        "Buffer",
         "CommandEncoder",
         "Device",
         "Texture",
         "TextureView"
-      ]
-    },
-    "donner/svg/renderer/geode/GeodeBufferPool.h": {
-      "wgpuCppTokens": [
-        "Buffer",
-        "BufferUsage"
       ]
     },
     "donner/svg/renderer/geode/GeodeCallbackState.h": {
@@ -890,14 +880,8 @@
         "createBuffer",
         "writeBuffer"
       ],
-      "wgpuCFunctions": [
-        "wgpuLabel"
-      ],
       "wgpuCppTokens": [
-        "BindGroup",
-        "Buffer",
-        "BufferDescriptor",
-        "BufferUsage"
+        "BindGroup"
       ]
     },
     "donner/svg/renderer/geode/GeodeShaders.cc": {

--- a/tools/gpu_inventory/manifests/gpu_operations.json
+++ b/tools/gpu_inventory/manifests/gpu_operations.json
@@ -651,10 +651,14 @@
       "wgpuCFunctions": [
         "wgpuAdapterGetInfo",
         "wgpuAdapterInfoFreeMembers",
+        "wgpuBufferOf",
         "wgpuCreateInstance",
         "wgpuForceFallbackAdapterRequested",
         "wgpuInstanceRequestAdapter",
-        "wgpuLabel"
+        "wgpuLabel",
+        "wgpuSamplerOf",
+        "wgpuTextureOf",
+        "wgpuTextureViewOf"
       ],
       "wgpuCTypes": [
         "WGPUAdapterInfo",
@@ -693,7 +697,6 @@
       ],
       "wgpuCppTokens": [
         "Adapter",
-        "AddressMode",
         "BackendType",
         "BindGroup",
         "Buffer",
@@ -703,9 +706,7 @@
         "Default",
         "Device",
         "DeviceDescriptor",
-        "Extent3D",
         "FeatureName",
-        "FilterMode",
         "Instance",
         "InstanceDescriptor",
         "InstanceExtras",
@@ -713,11 +714,8 @@
         "Queue",
         "RequestAdapterOptions",
         "Sampler",
-        "SamplerDescriptor",
         "Status",
         "StringView",
-        "TexelCopyBufferLayout",
-        "TexelCopyTextureInfo",
         "Texture",
         "TextureDescriptor",
         "TextureDimension",
@@ -1003,6 +1001,7 @@
       ],
       "wgpuCFunctions": [
         "wgpuBindGroupLayoutOf",
+        "wgpuBufferOf",
         "wgpuLabel",
         "wgpuRenderPipelineOf",
         "wgpuSamplerOf",
@@ -1080,6 +1079,7 @@
     "donner/svg/renderer/geode/GeodeWgpuAdapterDevice.h": {
       "wgpuCFunctions": [
         "wgpuBindGroupLayoutOf",
+        "wgpuBufferOf",
         "wgpuRenderPipelineOf",
         "wgpuSamplerOf",
         "wgpuTextureOf",


### PR DESCRIPTION
Packet 8b of the design 0053 change sequence, completing the solid/gradient/image family migration that #913 (packet 8a) started: GeoEncoder, GeodeTextureEncoder, GeodeBufferPool, the resident-path component, and RendererGeode's frame and texture plumbing now record through donner::gpu, with the migrated direct wgpu calls deleted in the same commits. Stacked on #913 (and transitively #912, #911).

- **Recording migration**: the family records through `gpu::CommandEncoder`/`RenderPassEncoder` via the packet 8a transition adapter; `GeoEncoder.h` no longer includes webgpu.hpp; the 8a temporary pipeline hatches are deleted. A new `GeodeGpuContext` seam carries the RHI device, counter forwarding, and shared identity resources, and the old hand-rolled keepalive machinery (`ScopedWgpuResourceArena`, `deferDestroy`) is replaced by the RHI's deferred destruction by submission serial - which now also *enforces* the stale-view class of bugs (issue #551's category) at submit rather than by convention. The adapter gains a non-blocking `pollCompletions()` called on the frame cadence.
- **Deletion evidence**: the GPU inventory manifests drop `GeoEncoder.cc` (14 operations / 24 wgpu tokens), `GeoEncoder.h`, `GeodeTextureEncoder.cc` (9 operations), `GeodeBufferPool.h`, and `GeodeResidentPathComponent.h` out of the wgpu surface entirely; `RendererGeode.cc` retains only the annotated escape-hatch call sites whose deletion packets are named in place (filters - packet 10, readback/presentation - packet 11, editor/ImGui and host-target import - packet 18).
- **Command-stream locks**: a new recording suite drives the pipelines and `GeoEncoder` against `gpu::RecordingDevice` with no GPU and no wgpu, locking nine deterministic captures (solid, instanced, resident steady-state across two frames - the second frame provably creates no buffers or bind groups - linear and radial gradients, pattern, image, blit, blend blit with the texture copy, and the mask pass with clip-mask rebinding). These are the structural-counter-parity anchors the later Metal and Vulkan production packets replay against.
- **Behavior neutrality**: every Geode golden, parity gate, resvg geode-lane test, editor replay golden, and perf-counter budget passes unchanged - no thresholds touched. Full `bazel test //...` green locally (889 targets, 0 failures); `--config=wasm-geode` builds green.

An independent review of the candidate diff found no blocking issues; its one major finding - texture snapshots carried a `gpu::Texture` whose RAII release could run on the editor UI thread against the single-threaded device - is fixed in the final commit (snapshots keep only a thread-safe owned wgpu reference; the RHI handle is released on the renderer thread), along with a mask-pass stream-lock scene, a fail-closed guard on the filter-boundary flush path, and restoration of the pre-migration draw-nothing behavior on filter-engine failure.
