### PR TITLE
Fix coverage under Bazel 8.7 by not mixing LLVM releases

### DIFF
--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -211,14 +211,28 @@ fi
 
 LLVM_COVERAGE_FLAGS=(
   --features=llvm_coverage_map_format
-  # Bazel's test runner copies GCOV into COVERAGE_GCOV_PATH. For LLVM lcov
-  # collection that path is used as llvm-profdata to merge profraw files.
+  # These feed the host cc autoconfiguration, which is what builds coverage on
+  # macOS. On Linux the hermetic toolchain provides its own llvm-profdata and
+  # llvm-cov, so it, not these values, merges and exports the profiles.
   --action_env=GCOV="$LLVM_PROFDATA_PATH"
   --action_env=BAZEL_LLVM_COV="$LLVM_COV_PATH"
   --action_env=BAZEL_LLVM_PROFDATA="$LLVM_PROFDATA_PATH"
-  --test_env=LLVM_COV="$LLVM_COV_PATH"
-  --test_env=LLVM_PROFDATA="$LLVM_PROFDATA_PATH"
 )
+
+# llvm-cov must come from the same LLVM release that instrumented the binaries.
+# It reads the profdata that llvm-profdata merged, and refuses any profile whose
+# format version it does not understand. On Linux the hermetic toolchain
+# (--config=latest_llvm) compiles the tests and supplies both tools, so pinning
+# the test env to the host clang's copies mixes two LLVM releases and llvm-cov
+# fails with "unsupported instrumentation profile format version", leaving an
+# LCOV report with no line data. macOS builds with the host toolchain, so there
+# the host tools are the matching ones.
+if [[ "$(uname)" == "Darwin" ]]; then
+  LLVM_COVERAGE_FLAGS+=(
+    --test_env=LLVM_COV="$LLVM_COV_PATH"
+    --test_env=LLVM_PROFDATA="$LLVM_PROFDATA_PATH"
+  )
+fi
 
 (
   cd "$WORKSPACE_ROOT"


### PR DESCRIPTION
The Coverage workflow has been red on main since the Bazel 8.7.0 bump in #725. Every LCOV record comes back with no executable line data, so `check_lcov_report.py` rejects the report after a full instrumented run.

This is the fix that #724 deferred. Bazel 8.7.0 landed once before in #650 and was rolled back the next day by #724, which pinned back to 8.6.0 and added `tools/check_lcov_report.py` so the failure would be caught rather than silently uploaded. #725 landed 8.7.0 again and that gate fired on the first main push carrying it.

## Root cause

Coverage post-processing was using two different LLVM releases. On Linux the hermetic toolchain (`--config=latest_llvm`, LLVM 21.1.6) compiles the instrumented binaries and supplies the `llvm-profdata` that merges the profraw files. `tools/coverage.sh` separately pinned `LLVM_COV` in the test env to whatever `clang` resolved to on the host. The host `llvm-cov` was then handed a profile it could not read:

```
error: failed to load coverage: '..._cc_coverage.dat.data': unsupported instrumentation profile format version
error: could not load coverage information
WARNING: There was no coverage found.
```

Every per-test `coverage.dat` was left empty, so the combined report degraded to baseline records only. That is exactly the all-zero shape the gate reported:

```
ERROR: Coverage report has no executable line data (records=727, source_files=727, DA=0, LF=0, LH=0).
```

The failure is silent in the job log because the collection error appears only in each per-test `test.log`.

## Fix

Export `LLVM_COV`/`LLVM_PROFDATA` only on macOS, where the host toolchain is the one that built the tests. On Linux the hermetic toolchain supplies both tools, so the export no longer depends on host clang. macOS behavior is unchanged.

## Verification

Measured on Linux against `//donner/base:base_tests`, DA count in the filtered report:

| | 8.6.0 | 8.7.0 |
|---|---|---|
| before | 5576 | **0** |
| after | 5576 | **5576** |

Red-then-green on 8.7.0, plus an 8.6.0 arm confirming no regression if the pin ever moves back.

## Notes for review

- A reduced repro (a single `cc_test` in a scratch workspace) does not reproduce this on either Bazel version. The hermetic toolchain is required, so the repro has to be the real repo.
- The remaining `--action_env=GCOV/BAZEL_LLVM_COV/BAZEL_LLVM_PROFDATA` values feed host cc autoconfiguration, which Linux does not use in this configuration. A build that opts out of `--config=latest_llvm` could still mix releases in the merge step; that is pre-existing and left alone here.
- Unrelated to this PR, the nightly Perf, Sanitizers, and Editor WASM workflows are also red on main. They have separate causes and are not addressed here.
