### PR TITLE
Fix the nightly sanitizer lane: attribute wgpu-native teardown leaks and stop an ASan shard timing out

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -344,6 +344,13 @@ build:asan --linkopt=-fsanitize=address,undefined
 build:asan --copt=-fno-omit-frame-pointer
 build:asan --copt=-fsanitize-address-use-after-scope
 build:asan --test_env=ASAN_SYMBOLIZER_PATH
+# LeakSanitizer scans loaded modules' globals for root pointers and symbolizes stacks against
+# loaded modules, so a driver library the Vulkan loader unloads during teardown takes both with
+# it: memory its globals still owned is reported as an unreachable leak, and every frame prints
+# as `<unknown module>`, which no suppression template can name. The Vulkan loader exposes this
+# switch for exactly that reason; it keeps ICDs and layers mapped so the reports stay
+# attributable. Test-only, and a no-op on hosts without a Vulkan loader.
+build:asan --test_env=VK_LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING=1
 # These require libubsan, which is not linked properly by bazel, so disable.
 # See https://github.com/google/oss-fuzz/issues/713
 build:asan --copt=-fno-sanitize=vptr,function

--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -244,6 +244,11 @@ donner_cc_test(
 
 donner_cc_test(
     name = "zoom_filter_repro_tests",
+    # One scenario per shard, so sharding cannot split the heaviest one further. Under ASan that
+    # shard measures 58-60 s on the hosted nightly runner, right at the 60 s ceiling the default
+    # `size = "small"` imposes, and it tips over on a slow run. Give the shard headroom explicitly
+    # rather than let an instrumented build decide the lane's colour.
+    timeout = "moderate",
     srcs = ["ZoomFilterRepro_tests.cc"],
     data = ["//:donner_splash.svg"],
     # 4 independent zoom/filter repro scenarios, ~80 s serial on the

--- a/third_party/webgpu-cpp/BUILD.bazel
+++ b/third_party/webgpu-cpp/BUILD.bazel
@@ -26,12 +26,30 @@ exports_files(["webgpu.hpp"])
 cc_library(
     name = "webgpu_cpp",
     hdrs = ["webgpu.hpp"],
+    include_prefix = "webgpu",
     # The header includes <webgpu/webgpu.h> and <webgpu/wgpu.h> directly, so
     # the wgpu-native `cc_library` must be exported as part of this target's
     # public headers, not just a link-time dep.
     strip_include_prefix = ".",
-    include_prefix = "webgpu",
-    deps = [":wgpu_native_platform"],
+    deps = [":wgpu_native_platform"] + select({
+        "@platforms//os:linux": [":wgpu_native_lsan_suppressions"],
+        "//conditions:default": [],
+    }),
+)
+
+# LeakSanitizer only runs on Linux, and the suppression is only meaningful for a binary that links
+# the prebuilt wgpu-native library, so it rides along with the wrapper every such binary depends
+# on. `alwayslink` is required: nothing references the symbol, and the sanitizer runtime's own weak
+# definition wins unless this object is force-linked into the executable.
+cc_library(
+    name = "wgpu_native_lsan_suppressions",
+    srcs = ["wgpu_native_lsan_suppressions.cc"],
+    linkstatic = True,
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    alwayslink = True,
 )
 
 # Alias the active wgpu-native archive for the current (os, cpu). Each

--- a/third_party/webgpu-cpp/wgpu_native_lsan_suppressions.cc
+++ b/third_party/webgpu-cpp/wgpu_native_lsan_suppressions.cc
@@ -1,0 +1,37 @@
+/// @file
+/// LeakSanitizer suppression scoped to the prebuilt wgpu-native shared library.
+///
+/// wgpu-native ships as an opaque prebuilt binary (`libwgpu_native.so` on Linux). Creating and
+/// then fully releasing a WebGPU instance/adapter/device leaves allocations behind inside that
+/// library, and on Linux its Vulkan backend additionally unloads the loader/ICD it loaded at
+/// runtime, which strands allocations those modules rooted in their own globals. LeakSanitizer
+/// then reports unreachable blocks against whichever test process happened to create a device,
+/// with stacks that mostly cannot be symbolized because the owning module is gone.
+///
+/// Attribution evidence: running the affected tests with `LSAN_OPTIONS=print_suppressions=1` and
+/// this single `libwgpu_native.so` template accounts for every reported byte (for example
+/// `//donner/gpu/shader:wgsl_emitter_geode_validation_tests`: 1303 allocations / 562632 bytes,
+/// exactly the unsuppressed total). Every leaked chunk's allocation stack passes through the
+/// prebuilt library. Donner's own teardown is not the cause: `GeodeDevice::~GeodeDevice` waits for
+/// submitted work and then releases queue, device, adapter, and instance.
+///
+/// Matching by module name keeps leak detection fully enabled for Donner code. It is deliberately
+/// narrower than disabling `detect_leaks` for whole packages, which is what the nightly sanitizer
+/// job previously had to do.
+///
+/// LeakSanitizer matches a suppression against the function, file, and module of every frame in an
+/// allocation stack, and rescans suppressed chunks as roots, so blocks reported as indirect leaks
+/// below a suppressed allocation are covered too.
+
+#if defined(__linux__) && !defined(__EMSCRIPTEN__)
+
+/// Default LeakSanitizer suppression list, consulted by the sanitizer runtime at leak-check time.
+/// The weak default in the runtime returns an empty list; this strong definition replaces it.
+///
+/// @return Newline-separated LeakSanitizer suppression templates.
+// NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,readability-identifier-naming)
+extern "C" const char* __lsan_default_suppressions() {
+  return "leak:libwgpu_native.so\n";
+}
+
+#endif

--- a/third_party/webgpu-cpp/wgpu_native_lsan_suppressions.cc
+++ b/third_party/webgpu-cpp/wgpu_native_lsan_suppressions.cc
@@ -20,8 +20,14 @@
 /// job previously had to do.
 ///
 /// LeakSanitizer matches a suppression against the function, file, and module of every frame in an
-/// allocation stack, and rescans suppressed chunks as roots, so blocks reported as indirect leaks
-/// below a suppressed allocation are covered too.
+/// allocation stack, so this template covers any allocation the prebuilt library made, whatever
+/// called into it.
+///
+/// It cannot cover allocations whose owning module is already unloaded when the leak check runs,
+/// because those frames have no module name to match. The Vulkan loader unloads its driver
+/// libraries during teardown and produces exactly that shape; `--config=asan` sets
+/// `VK_LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING` to keep them mapped. See the comment in
+/// `.bazelrc`.
 
 #if defined(__linux__) && !defined(__EMSCRIPTEN__)
 


### PR DESCRIPTION
The nightly Sanitizers workflow has been red since the GitHub-hosted ubuntu-24.04 runner image rolled from 20260624.560 to 20260707.563. Nine targets failed, all with the same shape of leak: a small unreachable allocation graph whose stack ends inside the prebuilt `libwgpu_native.so`, with the frames in between pointing into a module the Vulkan loader unloads before exit, so they cannot be symbolized.

None of it is Donner's. `GeodeDevice::~GeodeDevice` waits for submitted work and then releases queue, device, adapter, and instance. What is left is allocated inside the prebuilt wgpu-native binary, plus memory that the Vulkan driver libraries still owned when the loader unloaded them out from under the leak check. This lands as three commits, one per distinct cause.

Attribute wgpu-native's own leaks by module name. A strong `__lsan_default_suppressions()` matching `libwgpu_native.so`, `alwayslink`ed into every binary that links wgpu-native and nothing else, so the scope is exactly the binaries that can produce these reports, and Linux only since LeakSanitizer does not run on the other supported hosts. Evidence for the attribution: with `LSAN_OPTIONS=print_suppressions=1`, that one template accounts for the entire reported total. `//donner/gpu/shader:wgsl_emitter_geode_validation_tests` reports `562632 byte(s) leaked in 1303 allocation(s)` unsuppressed and then reports exactly `1303 / 562632 libwgpu_native.so` suppressed, with nothing left over. Leak detection stays fully enabled for Donner's own allocations in the targets that were failing, which a package-level `detect_leaks=0` would have given up.

Keep the Vulkan driver libraries mapped under ASan. That first change took the remaining reports down to `112 byte(s) leaked in 2 allocation(s)`, whose stacks have no named module at all: every intermediate frame prints as `<unknown module>`, so no template can match them. LeakSanitizer scans loaded modules' globals for root pointers and symbolizes against loaded modules, so a library unloaded before the leak check takes both away. A loader trace confirms the Vulkan loader closing every installed ICD during teardown. The loader exposes a switch for exactly this case; with `VK_LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING=1` the trace shows no `closing file=.../libvulkan_*.so` at all. Setting it in `--config=asan` rather than in one workflow keeps local ASan runs, the nightly job, and the Geode PR job consistent.

Give an ASan shard a stated timeout instead of an inherited one. With the leaks resolved, the lane's only remaining failure was `//donner/svg/renderer/tests:zoom_filter_repro_tests` timing out in 1 of 4 shards at 60.1 s. It holds four independent scenarios and shards one per shard, so sharding cannot split the heaviest one further; instrumented, that scenario measures 58 to 60 s. It passed at 58.5 s on the most recent nightly and timed out on the two runs after it, which is a budget with no headroom rather than a slow test. The budget was implicit: the target declares no `size` or `timeout`, so `donner_cc_test` filled in `size = "small"` and its 60 s ceiling. The timeout is now declared on the target with the measurement next to it. Uninstrumented runtime is unchanged; the same shard runs 9.5 s locally in the default config.

## Verification

- `Sanitizers` workflow, full run on this branch: green. ASan `Executed 724 out of 732 tests: 724 tests pass and 8 were skipped` with zero LeakSanitizer reports, the Geode carve-out step `30 of 37 pass`, UBSan `755 tests pass`. The three previously failing suites (`svg_tests_geode`, `svg_tests_text_full`, `resvg_test_suite_geode`) and the six failing renderer variants all pass.
- Red to green on Linux with the workflow's own `--config=asan`: `//donner/gpu/shader:wgsl_emitter_geode_validation_tests` fails with `562632 byte(s) leaked in 1303 allocation(s)` (exit 3) before the change and passes after it (exit 0).
- Linux `--config=geode` build of `//donner/svg/renderer/geode/...` and `//donner/gpu/shader/...`: exit 0.
- Linux default-config build of `//donner/gpu/...`, `//donner/editor/gui/...`, `//examples/...`, every package that links the wrapper: exit 0.
- macOS `--config=geode` test of `//donner/svg/renderer/geode/...` and `//donner/gpu/...`: 51 tests pass, exit 0. The `select()` is empty off Linux, so non-Linux link lines are unchanged.
- macOS default config, `//donner/svg/renderer/tests:zoom_filter_repro_tests` and `//third_party/webgpu-cpp/...`: exit 0.
- `python3 tools/cmake/gen_cmakelists.py --check`: exit 0, no CMake output change.
- `python3 build_defs/check_banned_patterns.py` on the new source: exit 0.
- `python3 tools/gpu_inventory/generate_gpu_manifests.py` after staging: no manifest diff.
- `buildifier -mode=check` on both touched BUILD files: exit 0.
