### PR TITLE
Route trusted CI runs to self-hosted Linux

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -81,8 +81,6 @@ jobs:
       runs_coverage: ${{ steps.determine.outputs.runs_coverage }}
       targets: ${{ steps.determine.outputs.targets }}
       target_count: ${{ steps.determine.outputs.target_count }}
-      large_change: ${{ steps.determine.outputs.large_change }}
-      changed_file_count: ${{ steps.determine.outputs.changed_file_count }}
       use_self_hosted_linux: ${{ steps.determine.outputs.use_self_hosted_linux }}
     steps:
       - name: Checkout
@@ -162,9 +160,6 @@ jobs:
           SELFHOSTED_LINUX_RUNNER: ${{ vars.SELFHOSTED_LINUX_RUNNER }}
         run: |
           set -euo pipefail
-          SELF_HOSTED_MAX_CHANGED_FILES=75
-          large_change=false
-          changed_file_count=0
 
           diagnostics_dir="$RUNNER_TEMP/coverage-target-selection"
           mkdir -p "$diagnostics_dir"
@@ -291,8 +286,6 @@ jobs:
               echo "targets=$targets"
               echo "target_count=$count"
               echo "runs_coverage=$runs"
-              echo "large_change=$large_change"
-              echo "changed_file_count=$changed_file_count"
             } >> "$GITHUB_OUTPUT"
 
             {
@@ -300,8 +293,6 @@ jobs:
               echo "fallback_reason=$reason"
               echo "target_count=$count"
               echo "runs_coverage=$runs"
-              echo "large_change=$large_change"
-              echo "changed_file_count=$changed_file_count"
               echo
               echo "$targets" | tr ' ' '\n'
             } > "$diagnostics_dir/summary.txt"
@@ -345,11 +336,6 @@ jobs:
           fi
           changed_files="$(git diff --name-only "$diff_base" "$HEAD_SHA")"
           printf "%s\n" "$changed_files" > "$diagnostics_dir/changed-files.txt"
-          changed_file_count="$(printf '%s\n' "$changed_files" | sed '/^$/d' | wc -l | tr -d ' ')"
-          if (( changed_file_count > SELF_HOSTED_MAX_CHANGED_FILES )); then
-            large_change=true
-            echo "Large PR (${changed_file_count} changed files) exceeds self-hosted coverage cap (${SELF_HOSTED_MAX_CHANGED_FILES}); using hosted coverage lane."
-          fi
 
           if [[ -z "$changed_files" ]]; then
             echo "No changed files detected; using full coverage target set."
@@ -631,14 +617,13 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     needs: determine-targets
-    # Hosted PR coverage fallback (large-change PRs, untrusted actors,
-    # self-hosted unavailable, or ci:full-test fanout). On PRs it runs ONLY when
-    # the target set is a genuine incremental subset (fallback == false =>
-    # bazel_diff), the cheap smoke subset, or an explicit ci:full-test opt-in. A
-    # full //... fallback on a PR (infra change, bazel-diff failure, empty diff)
-    # is SKIPPED here -- the main-push baseline covers those lines under the
-    # 15-minute PR budget.
-    if: ${{ (needs.determine-targets.outputs.use_self_hosted_linux != 'true' || needs.determine-targets.outputs.large_change == 'true') && needs.determine-targets.outputs.runs_coverage == 'true' }}
+    # Hosted PR coverage fallback for untrusted actors, self-hosted
+    # unavailability, or ci:full-test fanout. On PRs it runs ONLY when the target
+    # set is a genuine incremental subset (fallback == false => bazel_diff), the
+    # cheap smoke subset, or an explicit ci:full-test opt-in. A full //... fallback
+    # on a PR (infra change, bazel-diff failure, empty diff) is SKIPPED here -- the
+    # main-push baseline covers those lines under the 15-minute PR budget.
+    if: ${{ needs.determine-targets.outputs.use_self_hosted_linux != 'true' && needs.determine-targets.outputs.runs_coverage == 'true' }}
 
     steps:
       - uses: actions/checkout@v7
@@ -742,7 +727,7 @@ jobs:
   coverage-self-hosted-turnstile:
     runs-on: ubuntu-24.04
     needs: determine-targets
-    if: ${{ needs.determine-targets.outputs.use_self_hosted_linux == 'true' && needs.determine-targets.outputs.large_change != 'true' && needs.determine-targets.outputs.runs_coverage == 'true' }}
+    if: ${{ needs.determine-targets.outputs.use_self_hosted_linux == 'true' && needs.determine-targets.outputs.runs_coverage == 'true' }}
     timeout-minutes: 165
     steps:
       - name: Checkout turnstile action
@@ -762,9 +747,8 @@ jobs:
     needs: [determine-targets, coverage-self-hosted-turnstile]
     # here on PRs, plus explicit ci:full-test opt-ins. A full //... fallback is
     # skipped on PRs (main-push baseline covers it). Trusted main pushes run
-    # here instead of hosted Ubuntu. Large-change PRs (over the changed-file
-    # cap) stay on the hosted coverage lane.
-    if: ${{ needs.determine-targets.outputs.use_self_hosted_linux == 'true' && needs.determine-targets.outputs.large_change != 'true' && needs.determine-targets.outputs.runs_coverage == 'true' }}
+    # here instead of hosted Ubuntu.
+    if: ${{ needs.determine-targets.outputs.use_self_hosted_linux == 'true' && needs.determine-targets.outputs.runs_coverage == 'true' }}
     # Coverage healthy median is ~21 min. This budget starts only after the
     # hosted turnstile admits this job, so queued work does not consume it or
     # occupy the constrained self-hosted runner pool.
@@ -896,8 +880,8 @@ jobs:
     needs: [determine-targets, coverage-self-hosted]
     runs-on: ubuntu-24.04
     # Mirrors coverage-self-hosted's gate so the upload skips whenever the
-    # self-hosted coverage job skips or fails (large-change and full-fallback
-    # PRs produce no artifact).
+    # self-hosted coverage job skips or fails (full-fallback PRs produce no
+    # artifact).
     if: ${{ needs.coverage-self-hosted.result == 'success' }}
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -233,8 +233,6 @@ jobs:
       fallback: ${{ steps.determine.outputs.fallback }}
       affected: ${{ steps.determine.outputs.affected }}
       full_test: ${{ steps.determine.outputs.full_test }}
-      large_change: ${{ steps.determine.outputs.large_change }}
-      changed_file_count: ${{ steps.determine.outputs.changed_file_count }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -311,15 +309,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          SELF_HOSTED_MAX_CHANGED_FILES=75
 
           if [[ "${{ github.event_name }}" != "pull_request" ]]; then
             echo "Non-PR event; keeping full //... coverage."
             echo "fallback=true" >> "$GITHUB_OUTPUT"
             echo "affected=" >> "$GITHUB_OUTPUT"
             echo "full_test=false" >> "$GITHUB_OUTPUT"
-            echo "large_change=false" >> "$GITHUB_OUTPUT"
-            echo "changed_file_count=0" >> "$GITHUB_OUTPUT"
 
             if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
               cached="$HOME/.cache/bazel-diff-base-hashes/${{ github.sha }}.json"
@@ -345,8 +340,6 @@ jobs:
             echo "fallback=true" >> "$GITHUB_OUTPUT"
             echo "affected=" >> "$GITHUB_OUTPUT"
             echo "full_test=false" >> "$GITHUB_OUTPUT"
-            echo "large_change=false" >> "$GITHUB_OUTPUT"
-            echo "changed_file_count=0" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -355,8 +348,6 @@ jobs:
             echo "fallback=true" >> "$GITHUB_OUTPUT"
             echo "affected=" >> "$GITHUB_OUTPUT"
             echo "full_test=true" >> "$GITHUB_OUTPUT"
-            echo "large_change=false" >> "$GITHUB_OUTPUT"
-            echo "changed_file_count=0" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -377,14 +368,6 @@ jobs:
             diff_base="$BASE_SHA"
           fi
           changed_files="$(git diff --name-only "$diff_base" "$HEAD_SHA")"
-          changed_file_count="$(printf '%s\n' "$changed_files" | sed '/^$/d' | wc -l | tr -d ' ')"
-          large_change=false
-          if (( changed_file_count > SELF_HOSTED_MAX_CHANGED_FILES )); then
-            large_change=true
-            echo "Large PR (${changed_file_count} changed files) exceeds self-hosted routing cap (${SELF_HOSTED_MAX_CHANGED_FILES}); using hosted Linux lane."
-          fi
-          echo "large_change=$large_change" >> "$GITHUB_OUTPUT"
-          echo "changed_file_count=$changed_file_count" >> "$GITHUB_OUTPUT"
 
           if [[ -z "$changed_files" ]]; then
             echo "No changed files detected; falling back to //...."
@@ -502,13 +485,11 @@ jobs:
           echo "affected=$affected" >> "$GITHUB_OUTPUT"
 
   linux:
-    # GitHub-hosted x86_64 baseline. Suppressed for small operator PRs when the
-    # self-hosted ARM64 lane is active (see gate comment above), but broad PRs
-    # stay hosted so a self-hosted SLA timeout cannot leave the only
-    # required Linux path canceled.
+    # GitHub-hosted x86_64 baseline. Suppressed when the trusted self-hosted
+    # ARM64 lane is active (see gate comment above).
     runs-on: ubuntu-24.04
     needs: [gatekeeper, determine-targets]
-    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') && (needs.gatekeeper.outputs.use_self_hosted_linux != 'true' || needs.determine-targets.outputs.large_change == 'true') }}
+    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') && needs.gatekeeper.outputs.use_self_hosted_linux != 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -574,7 +555,7 @@ jobs:
 
   # Non-lld linker canary, split into its own always-on hosted job so it runs
   # regardless of Linux runner routing. The hosted `linux` lane is suppressed
-  # for small operator PRs when self-hosted routing is active, and the
+  # when self-hosted routing is active, and the
   # self-hosted lane's hermetic LLVM toolchain ships lld (not gold), so the gold
   # canary has no home there. Keeping it on a dedicated ubuntu-24.04 job runs it
   # on the runner that actually has gold and preserves coverage on every
@@ -638,7 +619,7 @@ jobs:
   linux-self-hosted-turnstile:
     runs-on: ubuntu-24.04
     needs: [gatekeeper, determine-targets]
-    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') && needs.gatekeeper.outputs.use_self_hosted_linux == 'true' && needs.determine-targets.outputs.large_change != 'true' }}
+    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') && needs.gatekeeper.outputs.use_self_hosted_linux == 'true' }}
     timeout-minutes: 165
     steps:
       - name: Checkout turnstile action
@@ -656,7 +637,6 @@ jobs:
   # Operator's ARM64 Linux runs on the operator's self-hosted runner.
   # Replaces `linux` for trusted operator PRs and main pushes (extra arch
   # coverage + homelab cache). Renovate and non-operator runs stay hosted.
-  # Large-change PRs (over the changed-file cap) stay on hosted Linux.
   # The NixOS host pre-provisions the toolchain (fontconfig, freetype, mesa,
   # vulkan, X11, clang-tidy) and writes bazel-cache1 over LAN gRPC, so there
   # is no apt/setup-bazel step. The runner intentionally has no host GPU
@@ -666,7 +646,7 @@ jobs:
   linux-self-hosted:
     runs-on: [self-hosted, linux, arm64]
     needs: [gatekeeper, determine-targets, linux-self-hosted-turnstile]
-    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') && needs.gatekeeper.outputs.use_self_hosted_linux == 'true' && needs.determine-targets.outputs.large_change != 'true' }}
+    if: ${{ needs.gatekeeper.outputs.is_duplicate_push != 'true' && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && (github.event_name != 'pull_request' || needs.gatekeeper.outputs.docs_only != 'true') && needs.gatekeeper.outputs.use_self_hosted_linux == 'true' }}
     # RE-availability SLA lane. A healthy affected-target run is ~21 min. This
     # budget applies only after the hosted turnstile admits this job. It retains
     # ample room for an unusually slow build without making the admission wait

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -133,6 +133,17 @@ py_test(
 )
 
 py_test(
+    name = "ci_runner_routing_tests",
+    size = "small",
+    srcs = ["ci_runner_routing_tests.py"],
+    data = [
+        "//:.github/workflows/coverage.yml",
+        "//:.github/workflows/main.yml",
+    ],
+    deps = ["@rules_python//python/runfiles"],
+)
+
+py_test(
     name = "remote_cache_config_tests",
     size = "small",
     srcs = ["remote_cache_config_tests.py"],

--- a/tools/ci_runner_routing_tests.py
+++ b/tools/ci_runner_routing_tests.py
@@ -1,0 +1,56 @@
+"""Pins trusted CI routing to the configured self-hosted runner for each OS."""
+
+import re
+import unittest
+
+from python.runfiles import runfiles
+
+
+def _workflow_text(path):
+    resolver = runfiles.Create()
+    resolved = resolver.Rlocation("donner/%s" % path)
+    with open(resolved, encoding="utf-8") as handle:
+        return handle.read()
+
+
+class CiRunnerRoutingTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = _workflow_text(".github/workflows/main.yml")
+        cls.coverage_text = _workflow_text(".github/workflows/coverage.yml")
+
+    def _job_body(self, job):
+        marker = "\n  %s:\n" % job
+        self.assertIn(marker, self.text, "job %s not found" % job)
+        rest = self.text.split(marker, 1)[1]
+        end = re.search(r"^  [A-Za-z0-9_-]+:\s*$", rest, re.MULTILINE)
+        return rest[: end.start()] if end else rest
+
+    def test_change_size_does_not_override_trusted_runner_routing(self):
+        """A trusted run follows the runner gate regardless of changed-file count."""
+        self.assertNotIn("SELF_HOSTED_MAX_CHANGED_FILES", self.text)
+        self.assertNotIn("outputs.large_change", self.text)
+        self.assertNotIn("changed_file_count", self.text)
+        self.assertNotIn("SELF_HOSTED_MAX_CHANGED_FILES", self.coverage_text)
+        self.assertNotIn("outputs.large_change", self.coverage_text)
+        self.assertNotIn("changed_file_count", self.coverage_text)
+
+    def test_linux_jobs_are_selected_only_by_the_trusted_runner_gate(self):
+        hosted = self._job_body("linux")
+        turnstile = self._job_body("linux-self-hosted-turnstile")
+        self_hosted = self._job_body("linux-self-hosted")
+
+        self.assertIn("outputs.use_self_hosted_linux != 'true'", hosted)
+        self.assertIn("outputs.use_self_hosted_linux == 'true'", turnstile)
+        self.assertIn("outputs.use_self_hosted_linux == 'true'", self_hosted)
+
+    def test_macos_jobs_are_selected_only_by_the_trusted_runner_gate(self):
+        hosted = self._job_body("macos")
+        self_hosted = self._job_body("macos-self-hosted")
+
+        self.assertIn("outputs.use_self_hosted_macos != 'true'", hosted)
+        self.assertIn("outputs.use_self_hosted_macos == 'true'", self_hosted)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/coverage_lane_routing_tests.py
+++ b/tools/coverage_lane_routing_tests.py
@@ -145,11 +145,9 @@ class CoverageLaneRoutingTest(unittest.TestCase):
     def test_every_coverage_job_gates_on_runs_coverage(self):
         """All three lanes, including the hosted one.
 
-        `build` is the hosted lane, and it is not a fallback nobody exercises:
-        it is what carries coverage for every PR over the changed-file cap,
-        which is exactly when the self-hosted lane and its turnstile skip. If it
-        ever stopped consuming `runs_coverage`, a large-change PR would land in
-        the same shape the routing fix removed - all lanes skipped, run green.
+        `build` is the hosted lane used when trusted self-hosted routing is not
+        available. It must consume the same coverage decision as the two
+        self-hosted jobs so every selected lane measures the same target set.
         """
         for job in ("build", "coverage-self-hosted", "coverage-self-hosted-turnstile"):
             self.assertIn(
@@ -158,18 +156,19 @@ class CoverageLaneRoutingTest(unittest.TestCase):
                 "job %s does not gate on the single routing output" % job,
             )
 
-    def test_large_change_routes_to_the_hosted_lane_rather_than_nowhere(self):
-        """The cap moves coverage between lanes; it must never cancel it.
+    def test_runner_gate_selects_exactly_one_coverage_lane(self):
+        """The trusted-runner gate, not change size, selects the coverage lane.
 
-        `large_change` sends a PR to the hosted lane instead of the constrained
-        self-hosted one. The two gates have to be exact complements on that
-        flag, or a large-change PR falls through both and reports green having
-        measured nothing.
+        Hosted and self-hosted conditions must remain exact complements so a
+        coverage decision cannot fall through both lane families.
         """
         hosted = self._job_body("build")
-        self.assertIn("outputs.large_change == 'true'", hosted)
+        self.assertIn("outputs.use_self_hosted_linux != 'true'", hosted)
         for job in ("coverage-self-hosted", "coverage-self-hosted-turnstile"):
-            self.assertIn("outputs.large_change != 'true'", self._job_body(job))
+            self.assertIn(
+                "outputs.use_self_hosted_linux == 'true'",
+                self._job_body(job),
+            )
 
     def test_build_defs_and_bazelrc_do_not_escalate_to_a_full_fallback(self):
         """The regression itself.


### PR DESCRIPTION
Trusted runs now follow the configured self-hosted Linux gate regardless of changed-file count.

- remove the 75-file hosted-runner override from CI and Coverage
- preserve hosted routing for untrusted and Renovate runs
- pin mutually exclusive hosted and self-hosted lane selection with regression tests

## Verification

- Focused cumulative stack tests with an isolated output base: `//tools:ci_runtime_workflow_tests`, `//tools:ci_runner_routing_tests`, `//tools:coverage_lane_routing_tests`, and `//tools:coverage_variant_trim_tests`.
- `actionlint -shellcheck= .github/workflows/main.yml .github/workflows/coverage.yml`
- `dprint check .github/workflows/main.yml .github/workflows/coverage.yml tools/ci_runtime_workflow_tests.py tools/ci_runner_routing_tests.py tools/coverage_lane_routing_tests.py`
- `buildifier -mode=check BUILD.bazel tools/BUILD.bazel`
- `git diff --check repair-main-ci-runtime...HEAD`
- `git diff --check origin/main...HEAD`
