### PR TITLE
Fix Doxygen element navigation and search

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -54,7 +54,7 @@ PROJECT_NUMBER         = $(DONNER_VERSION)
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "SVG editor and embeddable C++20 engine."
+PROJECT_BRIEF          = "SVG editor and embeddable C&#8288;+&#8288;+&#8288;20 engine."
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55
@@ -1751,7 +1751,7 @@ ENUM_VALUES_PER_LINE   = 1
 # Minimum value: 0, maximum value: 1500, default value: 250.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-TREEVIEW_WIDTH         = 250
+TREEVIEW_WIDTH         = 335
 
 # If the EXT_LINKS_IN_WINDOW option is set to YES, doxygen will open links to
 # external symbols imported via tag files in a separate window.

--- a/tools/support/doxygen_css.css
+++ b/tools/support/doxygen_css.css
@@ -23,6 +23,12 @@
   text-align: center;
 }
 
+/* Long specification URLs must remain readable in the narrow content column
+ * immediately above the mobile-navigation breakpoint. */
+.contents a[href^="http"] {
+  overflow-wrap: anywhere;
+}
+
 /* Doxygen's stock outline forces long headings onto one unbroken line. Keep
  * the rail useful at desktop widths where it is visible. */
 #page-nav ul.page-outline li {
@@ -34,6 +40,39 @@
   display: block;
   line-height: 1.35;
   padding: 0.35em 0.5em;
+}
+
+/* The branded header is five title lines high. Reserve one additional row for
+ * Doxygen's client-side search without moving page content downward. */
+@media screen and (min-width: 768px) {
+  html {
+    --top-height: calc(
+      var(--title-font-size) * 5 + 2 * var(--spacing-medium) + var(--searchbar-height) +
+        var(--spacing-small)
+    );
+  }
+
+  #main-nav {
+    box-sizing: border-box;
+    float: none;
+    height: calc(var(--searchbar-height) + var(--spacing-small));
+    padding: 0 var(--spacing-medium) var(--spacing-small);
+  }
+
+  #main-menu {
+    height: var(--searchbar-height);
+  }
+
+  #main-menu > li:last-child {
+    display: flex;
+    float: none !important;
+    height: var(--searchbar-height);
+    margin: 0;
+  }
+
+  #doc-content {
+    padding-top: 40px;
+  }
 }
 
 /* The fixed navigation rail already consumes substantial laptop width.  Drop

--- a/tools/support/doxygen_layout.xml
+++ b/tools/support/doxygen_layout.xml
@@ -26,15 +26,116 @@
         <tab type="user" title="API Overview" url="DonnerAPI.html"/>
         <tab type="user" title="CSS" url="CssArchitecture.html"/>
         <tab type="usergroup" title="SVG Element Reference" url="SvgElementReference.html">
-          <tab type="user" title="Structural" url="elements_structural.html"/>
-          <tab type="user" title="Basic Shapes" url="elements_basic_shapes.html"/>
-          <tab type="user" title="Text" url="elements_text.html"/>
-          <tab type="user" title="Painting" url="elements_painting.html"/>
-          <tab type="user" title="Masking and Clipping"
-               url="elements_masking_clipping.html"/>
-          <tab type="user" title="Filters" url="elements_filters.html"/>
-          <tab type="user" title="Media and Styling" url="elements_media_and_style.html"/>
-          <tab type="user" title="Animation" url="elements_animation.html"/>
+          <!-- XML and Doxygen each decode one entity layer before navtree.js
+               inserts labels as HTML. Keep both layers so angle brackets render
+               as text instead of disappearing as custom HTML elements. -->
+          <tab type="usergroup" title="Structural" url="elements_structural.html">
+            <tab type="user" title="&amp;amp;lt;svg&amp;amp;gt;" url="xml_svg.html"/>
+            <tab type="user" title="&amp;amp;lt;a&amp;amp;gt;" url="xml_a.html"/>
+            <tab type="user" title="&amp;amp;lt;g&amp;amp;gt;" url="xml_g.html"/>
+            <tab type="user" title="&amp;amp;lt;defs&amp;amp;gt;" url="xml_defs.html"/>
+            <tab type="user" title="&amp;amp;lt;use&amp;amp;gt;" url="xml_use.html"/>
+            <tab type="user" title="&amp;amp;lt;switch&amp;amp;gt;" url="xml_switch.html"/>
+            <tab type="user" title="&amp;amp;lt;symbol&amp;amp;gt;" url="xml_symbol.html"/>
+            <tab type="user" title="&amp;amp;lt;title&amp;amp;gt;" url="xml_title.html"/>
+            <tab type="user" title="&amp;amp;lt;desc&amp;amp;gt;" url="xml_desc.html"/>
+            <tab type="user" title="&amp;amp;lt;metadata&amp;amp;gt;" url="xml_metadata.html"/>
+          </tab>
+
+          <tab type="usergroup" title="Basic Shapes" url="elements_basic_shapes.html">
+            <tab type="user" title="&amp;amp;lt;circle&amp;amp;gt;" url="xml_circle.html"/>
+            <tab type="user" title="&amp;amp;lt;ellipse&amp;amp;gt;" url="xml_ellipse.html"/>
+            <tab type="user" title="&amp;amp;lt;line&amp;amp;gt;" url="xml_line.html"/>
+            <tab type="user" title="&amp;amp;lt;path&amp;amp;gt;" url="xml_path.html"/>
+            <tab type="user" title="&amp;amp;lt;polygon&amp;amp;gt;" url="xml_polygon.html"/>
+            <tab type="user" title="&amp;amp;lt;polyline&amp;amp;gt;" url="xml_polyline.html"/>
+            <tab type="user" title="&amp;amp;lt;rect&amp;amp;gt;" url="xml_rect.html"/>
+          </tab>
+
+          <tab type="usergroup" title="Text" url="elements_text.html">
+            <tab type="user" title="&amp;amp;lt;text&amp;amp;gt;" url="xml_text.html"/>
+            <tab type="user" title="&amp;amp;lt;tspan&amp;amp;gt;" url="xml_tspan.html"/>
+            <tab type="user" title="&amp;amp;lt;textPath&amp;amp;gt;" url="xml_textPath.html"/>
+          </tab>
+
+          <tab type="usergroup" title="Painting" url="elements_painting.html">
+            <tab type="user" title="&amp;amp;lt;linearGradient&amp;amp;gt;" url="xml_linearGradient.html"/>
+            <tab type="user" title="&amp;amp;lt;radialGradient&amp;amp;gt;" url="xml_radialGradient.html"/>
+            <tab type="user" title="&amp;amp;lt;pattern&amp;amp;gt;" url="xml_pattern.html"/>
+            <tab type="user" title="&amp;amp;lt;stop&amp;amp;gt;" url="xml_stop.html"/>
+            <tab type="user" title="&amp;amp;lt;marker&amp;amp;gt;" url="xml_marker.html"/>
+          </tab>
+
+          <tab type="usergroup" title="Masking and Clipping"
+               url="elements_masking_clipping.html">
+            <tab type="user" title="&amp;amp;lt;mask&amp;amp;gt;" url="xml_mask.html"/>
+            <tab type="user" title="&amp;amp;lt;clipPath&amp;amp;gt;" url="xml_clipPath.html"/>
+          </tab>
+
+          <tab type="usergroup" title="Filters" url="elements_filters.html">
+            <tab type="user" title="&amp;amp;lt;filter&amp;amp;gt;" url="xml_filter.html"/>
+
+            <tab type="usergroup" title="Blur, Shadow, and Geometry"
+                 url="elements_filters.html#blur-shadow-and-geometry">
+              <tab type="user" title="&amp;amp;lt;feGaussianBlur&amp;amp;gt;" url="xml_feGaussianBlur.html"/>
+              <tab type="user" title="&amp;amp;lt;feDropShadow&amp;amp;gt;" url="xml_feDropShadow.html"/>
+              <tab type="user" title="&amp;amp;lt;feOffset&amp;amp;gt;" url="xml_feOffset.html"/>
+              <tab type="user" title="&amp;amp;lt;feMorphology&amp;amp;gt;" url="xml_feMorphology.html"/>
+              <tab type="user" title="&amp;amp;lt;feDisplacementMap&amp;amp;gt;" url="xml_feDisplacementMap.html"/>
+              <tab type="user" title="&amp;amp;lt;feTile&amp;amp;gt;" url="xml_feTile.html"/>
+            </tab>
+
+            <tab type="usergroup" title="Color and Component Transforms"
+                 url="elements_filters.html#color-and-component-transforms">
+              <tab type="user" title="&amp;amp;lt;feColorMatrix&amp;amp;gt;" url="xml_feColorMatrix.html"/>
+              <tab type="usergroup" title="&amp;amp;lt;feComponentTransfer&amp;amp;gt;"
+                   url="xml_feComponentTransfer.html">
+                <tab type="user" title="&amp;amp;lt;feFuncR&amp;amp;gt;" url="xml_feFuncR.html"/>
+                <tab type="user" title="&amp;amp;lt;feFuncG&amp;amp;gt;" url="xml_feFuncG.html"/>
+                <tab type="user" title="&amp;amp;lt;feFuncB&amp;amp;gt;" url="xml_feFuncB.html"/>
+                <tab type="user" title="&amp;amp;lt;feFuncA&amp;amp;gt;" url="xml_feFuncA.html"/>
+              </tab>
+            </tab>
+
+            <tab type="usergroup" title="Compositing and Merging"
+                 url="elements_filters.html#compositing-and-merging">
+              <tab type="user" title="&amp;amp;lt;feBlend&amp;amp;gt;" url="xml_feBlend.html"/>
+              <tab type="user" title="&amp;amp;lt;feComposite&amp;amp;gt;" url="xml_feComposite.html"/>
+              <tab type="usergroup" title="&amp;amp;lt;feMerge&amp;amp;gt;" url="xml_feMerge.html">
+                <tab type="user" title="&amp;amp;lt;feMergeNode&amp;amp;gt;" url="xml_feMergeNode.html"/>
+              </tab>
+            </tab>
+
+            <tab type="usergroup" title="Sources"
+                 url="elements_filters.html#sources-flood-image-turbulence-convolution">
+              <tab type="user" title="&amp;amp;lt;feFlood&amp;amp;gt;" url="xml_feFlood.html"/>
+              <tab type="user" title="&amp;amp;lt;feImage&amp;amp;gt;" url="xml_feImage.html"/>
+              <tab type="user" title="&amp;amp;lt;feTurbulence&amp;amp;gt;" url="xml_feTurbulence.html"/>
+              <tab type="user" title="&amp;amp;lt;feConvolveMatrix&amp;amp;gt;" url="xml_feConvolveMatrix.html"/>
+            </tab>
+
+            <tab type="usergroup" title="Lighting" url="elements_filters.html#lighting">
+              <tab type="user" title="&amp;amp;lt;feDiffuseLighting&amp;amp;gt;" url="xml_feDiffuseLighting.html"/>
+              <tab type="user" title="&amp;amp;lt;feSpecularLighting&amp;amp;gt;"
+                   url="xml_feSpecularLighting.html"/>
+              <tab type="user" title="&amp;amp;lt;feDistantLight&amp;amp;gt;" url="xml_feDistantLight.html"/>
+              <tab type="user" title="&amp;amp;lt;fePointLight&amp;amp;gt;" url="xml_fePointLight.html"/>
+              <tab type="user" title="&amp;amp;lt;feSpotLight&amp;amp;gt;" url="xml_feSpotLight.html"/>
+            </tab>
+          </tab>
+
+          <tab type="usergroup" title="Media and Styling"
+               url="elements_media_and_style.html">
+            <tab type="user" title="&amp;amp;lt;image&amp;amp;gt;" url="xml_image.html"/>
+            <tab type="user" title="&amp;amp;lt;style&amp;amp;gt;" url="xml_style.html"/>
+          </tab>
+
+          <tab type="usergroup" title="Animation" url="elements_animation.html">
+            <tab type="user" title="&amp;amp;lt;animate&amp;amp;gt;" url="xml_animate.html"/>
+            <tab type="user" title="&amp;amp;lt;animateTransform&amp;amp;gt;" url="xml_animateTransform.html"/>
+            <tab type="user" title="&amp;amp;lt;set&amp;amp;gt;" url="xml_set.html"/>
+          </tab>
+
           <tab type="user" title="Symbol Usage" url="SymbolElementUsage.html"/>
         </tab>
       </tab>


### PR DESCRIPTION
This follow-up makes the generated Doxygen site searchable and keeps every SVG element page attached to the curated sidebar.

## Changes

- Nest all 58 SVG element pages under their element families in the explicit Doxygen layout.
- Preserve element angle brackets through XML, Doxygen, and nav-tree HTML rendering.
- Expose the existing client-side Doxygen search index beneath the branded header.
- Keep `C++20` together when the project brief wraps.
- Wrap long specification URLs in the narrow desktop content column.

## Verification

- `tools/doxygen.sh` (Doxygen 1.15.0, exit 0)
- 58 source element pages, 58 generated pages, 58 readable nav labels, and 58 curated nav paths
- Search returns both `<linearGradient>` and `SVGLinearGradientElement`, with one search widget
- Browser inspection at 767, 768, 1280, and 2048 px, including a deeply nested filter page
- `tools/llm-bazel-wrap.sh test //...` (410 passed, 15 platform skips)
- `tools/lint.sh`
- `python3 tools/cmake/gen_cmakelists.py --check`
- `dprint check`, `xmllint --noout`, and `git diff --check`

The repository-wide Doxygen warning count remains the parent's 898 legacy diagnostics; this layer adds no warnings.

Stacked on #936.
