### PR TITLE
Stabilize CI runtime boundaries

### DIFF
--- a/build_defs/BUILD.bazel
+++ b/build_defs/BUILD.bazel
@@ -41,6 +41,13 @@ py_test(
     ],
 )
 
+py_test(
+    name = "sanitizer_runtime_provenance_tests",
+    size = "small",
+    srcs = ["sanitizer_runtime_provenance_tests.py"],
+    data = [":rules.bzl"],
+)
+
 string_flag(
     name = "llvm_latest",
     build_setting_default = "0",

--- a/build_defs/rules.bzl
+++ b/build_defs/rules.bzl
@@ -37,28 +37,6 @@ def _banned_patterns_lint_test(name, srcs, hdrs, tags = [], **_kwargs):
     """
     _ = (name, srcs, hdrs, tags)  # @unused
 
-def llvm21_macos_runtime_rpath_linkopts():
-    """
-    Returns rpaths needed by LLVM 21 sanitizer runtime dylibs on macOS.
-    """
-    runtime_dir = "toolchains_llvm++llvm+llvm_toolchain_llvm/lib/clang/21/lib/darwin"
-    return select({
-        "//build_defs:llvm_latest_macos": [
-            # Add rpaths for execroot (from bazel-bin/<package> to external/).
-            # The needed depth varies with package path depth.
-            "-Wl,-rpath,@loader_path/../../../../../../external/" + runtime_dir,
-            "-Wl,-rpath,@loader_path/../../../../../../../external/" + runtime_dir,
-            "-Wl,-rpath,@loader_path/../../../../../../../../external/" + runtime_dir,
-            "-Wl,-rpath,@loader_path/../../../../../../../../../external/" + runtime_dir,
-            # Add rpaths for runfiles directory (without the external/ prefix).
-            "-Wl,-rpath,@loader_path/../../../../" + runtime_dir,
-            "-Wl,-rpath,@loader_path/../../../../../" + runtime_dir,
-            "-Wl,-rpath,@loader_path/../../../../../../" + runtime_dir,
-            "-Wl,-rpath,@loader_path/../../../../../../../" + runtime_dir,
-        ],
-        "//conditions:default": [],
-    })
-
 def libc_compat_deps():
     """
     Returns extra deps needed when linking against the hermetic LLVM toolchain
@@ -516,14 +494,10 @@ def donner_cc_binary(name, srcs = [], linkopts = [], deps = [], tags = [], **kwa
       tags: Tags.
       **kwargs: Additional arguments, matching the implementation of cc_binary.
     """
-    donner_linkopts = (
-        linkopts +
-        llvm21_macos_runtime_rpath_linkopts()
-    )
     cc_binary(
         name = name,
         srcs = srcs,
-        linkopts = donner_linkopts,
+        linkopts = linkopts,
         deps = deps + libc_compat_deps(),
         tags = tags,
         **kwargs
@@ -584,7 +558,6 @@ def donner_cc_test(
         tags = [],
         variants = None,
         opens_gpu_device = False,
-        add_llvm_macos_runtime_rpaths = True,
         **kwargs):
     """
     Create a cc_test with donner-specific defaults.
@@ -605,20 +578,15 @@ def donner_cc_test(
         device/adapter, so its geode-backed variants must be drained serially.
         Forwarded to donner_multi_transitioned_test; see there for why it is
         opt-in rather than implied by the geode backend.
-      add_llvm_macos_runtime_rpaths: Add LLVM 21 sanitizer runtime rpaths on macOS.
       **kwargs: Additional arguments, matching the implementation of cc_test.
     """
-    donner_linkopts = linkopts
-    if add_llvm_macos_runtime_rpaths:
-        donner_linkopts = donner_linkopts + llvm21_macos_runtime_rpath_linkopts()
-
     if "size" not in kwargs and "timeout" not in kwargs:
         kwargs["size"] = "small"
 
     cc_test(
         name = name,
         srcs = srcs,
-        linkopts = donner_linkopts,
+        linkopts = linkopts,
         deps = deps + libc_compat_deps() + test_crash_handler_deps(),
         tags = tags,
         **kwargs
@@ -814,7 +782,6 @@ def donner_cc_fuzzer(name, corpus, deps = [], per_input_timeout_seconds = 2, tag
 
     donner_cc_test(
         name = name + "_soak",
-        add_llvm_macos_runtime_rpaths = False,
         additional_linker_inputs = fuzzer_additional_linker_inputs,
         linkopts = fuzzer_runtime_linkopts,
         args = fuzz_time_args + [
@@ -834,7 +801,6 @@ def donner_cc_fuzzer(name, corpus, deps = [], per_input_timeout_seconds = 2, tag
 
     donner_cc_test(
         name = name,
-        add_llvm_macos_runtime_rpaths = False,
         additional_linker_inputs = fuzzer_additional_linker_inputs,
         linkopts = fuzzer_runtime_linkopts,
         args = ["$(locations %s)" % corpus_name],

--- a/build_defs/sanitizer_runtime_provenance_tests.py
+++ b/build_defs/sanitizer_runtime_provenance_tests.py
@@ -1,0 +1,41 @@
+import os
+import re
+import unittest
+from pathlib import Path
+
+
+class SanitizerRuntimeProvenanceTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        runfiles = Path(os.environ["TEST_SRCDIR"]) / os.environ["TEST_WORKSPACE"]
+        cls.rules = (runfiles / "build_defs/rules.bzl").read_text()
+
+    def function_body(self, name):
+        match = re.search(
+            rf"^def {name}\(.*?(?=^def |\Z)",
+            self.rules,
+            re.DOTALL | re.MULTILINE,
+        )
+        self.assertIsNotNone(match, f"{name} definition is missing")
+        return match.group(0)
+
+    def test_ordinary_targets_do_not_search_upstream_macos_runtimes(self):
+        self.assertNotIn("llvm21_macos_runtime_rpath_linkopts", self.rules)
+        for macro in ("donner_cc_binary", "donner_cc_test"):
+            body = self.function_body(macro)
+            self.assertNotIn("rpath", body.lower())
+            self.assertNotIn("toolchains_llvm", body)
+            self.assertNotIn("@llvm_toolchain", body)
+
+    def test_fuzzers_keep_explicit_upstream_runtime_inputs(self):
+        linkopts = self.function_body("fuzzer_linkopts")
+        linker_inputs = self.function_body("fuzzer_linker_inputs")
+        self.assertIn("libclang_rt.fuzzer_osx.a", linkopts)
+        self.assertIn(
+            "@llvm_toolchain//:linker-components-aarch64-darwin",
+            linker_inputs,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -2620,6 +2620,13 @@ TEST(EditorShellTest, FullDesktopFrameLoopPresentsShapeDragBeforeMouseUp) {
 
   EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
   ASSERT_TRUE(shell.valid());
+  std::optional<svg::SVGElement> target =
+      EditorShellTestAccess::App(shell).document().document().querySelector("#target");
+  ASSERT_THAT(target, ::testing::Optional(::testing::_));
+  // Establish the selected-layer cache before measuring the drag handoff. The contract below is
+  // same-frame rebasing of already-promoted pixels, not completion within a fixed number of
+  // back-to-back frames by the asynchronous worker that creates those pixels.
+  EditorShellTestAccess::App(shell).setSelection(*target);
   const auto runFrameWithMouse = [&](const ImVec2& mouse, bool mouseDown) {
     ImGuiIO& io = ImGui::GetIO();
     io.AddMousePosEvent(mouse.x, mouse.y);
@@ -2635,6 +2642,9 @@ TEST(EditorShellTest, FullDesktopFrameLoopPresentsShapeDragBeforeMouseUp) {
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(2));
   }
+  ASSERT_THAT(shell.layerInspectorStatusForReadback().displayedDragPreview,
+              ::testing::Optional(::testing::_))
+      << "The drag assertion requires a promoted selected-layer cache";
 
   const auto screenPoint = [&](const Vector2d& documentPoint) {
     const Vector2d screen = shell.viewportForReadback().documentToScreen(documentPoint);


### PR DESCRIPTION
Stabilizes two causal CI runtime boundaries exposed by the full candidate suite under load. This stack layer above #940 changes only build and test infrastructure.

- keeps ordinary macOS Xcode-Clang targets from resolving incompatible upstream LLVM sanitizer dylibs while preserving explicit fuzzer runtime inputs
- establishes the selected-layer cache precondition before the editor test asserts same-frame drag-pixel epoch rebasing

Validation:
- the exact candidate passed `bazel test //...` across 430 test targets
- the parent reproduced a TSAN failure only after a fuzzer materialized the incompatible runtime; the repaired target passed the same shared-output-base sequence, plus the corresponding ASan sequence
- the loaded editor regression moved from 1 failure in 100 four-way contention runs to 100 of 100 passing while retaining the original drag translation and epoch assertions
- repository lint, CMake generator validation, buildifier, shell syntax, diff checks, and privacy review passed
