### PR TITLE
Bound untrusted SVG ingress and resource loading

### DIFF
--- a/donner/base/encoding/Decompress.cc
+++ b/donner/base/encoding/Decompress.cc
@@ -2,6 +2,10 @@
 
 #include <zlib.h>
 
+#include <algorithm>
+#include <limits>
+#include <string>
+
 namespace donner {
 
 namespace {
@@ -15,7 +19,18 @@ namespace {
  * @return \ref ParseResult with the output vector on success, or a \ref ParseDiagnostic on failure.
  */
 ParseResult<std::vector<uint8_t>> Inflate(std::string_view compressedData, int windowBits,
-                                          std::optional<size_t> outputSize) {
+                                          std::optional<size_t> outputSize,
+                                          size_t maximumOutputSize) {
+  if (compressedData.size() > std::numeric_limits<uInt>::max()) {
+    return ParseDiagnostic::Error("Compressed data exceeds zlib input limit",
+                                  FileOffset::Offset(0));
+  }
+  if (outputSize &&
+      (*outputSize > maximumOutputSize || *outputSize > std::numeric_limits<uInt>::max())) {
+    return ParseDiagnostic::Error("Requested output exceeds maximum decompressed size",
+                                  FileOffset::Offset(0));
+  }
+
   std::vector<uint8_t> output;
   if (outputSize) {
     output.resize(*outputSize);
@@ -41,10 +56,11 @@ ParseResult<std::vector<uint8_t>> Inflate(std::string_view compressedData, int w
 
     int ret = inflate(&stream, Z_FINISH);
     if (ret != Z_STREAM_END) {
+      const std::string message = stream.msg ? stream.msg : "Unknown error";
       inflateEnd(&stream);
-      return ParseDiagnostic::Error(RcString(std::string("Failed to decompress zlib data: ") +
-                                             (stream.msg ? stream.msg : "Unknown error")),
-                                    FileOffset::Offset(0));
+      return ParseDiagnostic::Error(
+          RcString(std::string("Failed to decompress zlib data: ") + message),
+          FileOffset::Offset(0));
     }
 
     if (stream.total_out != output.size()) {
@@ -56,22 +72,49 @@ ParseResult<std::vector<uint8_t>> Inflate(std::string_view compressedData, int w
     constexpr size_t kChunkSize = 16384;
     int ret = Z_OK;
     while (true) {
-      output.resize(output.size() + kChunkSize);
-      stream.next_out = reinterpret_cast<Bytef*>(output.data() + output.size() - kChunkSize);
-      stream.avail_out = kChunkSize;
+      const size_t remaining = maximumOutputSize - output.size();
+      if (remaining == 0) {
+        // zlib can require one final call to consume the gzip trailer when the output buffer was
+        // filled exactly. A one-byte probe distinguishes that from actual output beyond the cap.
+        uint8_t overflowProbe = 0;
+        stream.next_out = &overflowProbe;
+        stream.avail_out = 1;
+        ret = inflate(&stream, Z_NO_FLUSH);
+        if (ret == Z_STREAM_END && stream.avail_out == 1) {
+          break;
+        }
+
+        const std::string message = stream.msg ? stream.msg : "Unknown error";
+        const bool producedOverflowByte = stream.avail_out == 0;
+        inflateEnd(&stream);
+        if (producedOverflowByte) {
+          return ParseDiagnostic::Error("Gzip output exceeds maximum decompressed size",
+                                        FileOffset::Offset(0));
+        }
+        return ParseDiagnostic::Error(
+            RcString(std::string("Failed to decompress gzip data: ") + message),
+            FileOffset::Offset(0));
+      }
+
+      const size_t chunkSize = std::min(kChunkSize, remaining);
+      const size_t previousSize = output.size();
+      output.resize(previousSize + chunkSize);
+      stream.next_out = reinterpret_cast<Bytef*>(output.data() + previousSize);
+      stream.avail_out = static_cast<uInt>(chunkSize);
 
       ret = inflate(&stream, Z_NO_FLUSH);
+      output.resize(previousSize + chunkSize - stream.avail_out);
 
       if (ret == Z_STREAM_END) {
-        output.resize(output.size() - stream.avail_out);
         break;
       }
 
       if (ret != Z_OK) {
+        const std::string message = stream.msg ? stream.msg : "Unknown error";
         inflateEnd(&stream);
-        return ParseDiagnostic::Error(RcString(std::string("Failed to decompress gzip data: ") +
-                                               (stream.msg ? stream.msg : "Unknown error")),
-                                      FileOffset::Offset(0));
+        return ParseDiagnostic::Error(
+            RcString(std::string("Failed to decompress gzip data: ") + message),
+            FileOffset::Offset(0));
       }
     }
   }
@@ -82,7 +125,8 @@ ParseResult<std::vector<uint8_t>> Inflate(std::string_view compressedData, int w
 
 }  // namespace
 
-ParseResult<std::vector<uint8_t>> Decompress::Gzip(std::string_view compressedData) {
+ParseResult<std::vector<uint8_t>> Decompress::Gzip(std::string_view compressedData,
+                                                   size_t maximumOutputSize) {
   if (compressedData.size() < 2) {
     return ParseDiagnostic::Error("Gzip data is too short", FileOffset::Offset(0));
   }
@@ -94,12 +138,12 @@ ParseResult<std::vector<uint8_t>> Decompress::Gzip(std::string_view compressedDa
   }
 
   // 16 + MAX_WBITS enables gzip decoding.
-  return Inflate(compressedData, 16 + MAX_WBITS, std::nullopt);
+  return Inflate(compressedData, 16 + MAX_WBITS, std::nullopt, maximumOutputSize);
 }
 
 ParseResult<std::vector<uint8_t>> Decompress::Zlib(std::string_view compressedData,
                                                    size_t decompressedSize) {
-  return Inflate(compressedData, MAX_WBITS, decompressedSize);
+  return Inflate(compressedData, MAX_WBITS, decompressedSize, decompressedSize);
 }
 
 }  // namespace donner

--- a/donner/base/encoding/Decompress.h
+++ b/donner/base/encoding/Decompress.h
@@ -1,6 +1,7 @@
 #pragma once
 /// @file
 
+#include <cstddef>
 #include <cstdint>
 #include <string_view>
 #include <vector>
@@ -14,13 +15,18 @@ namespace donner {
  */
 class Decompress {
 public:
+  /// Default maximum expanded size for gzip streams accepted from untrusted inputs.
+  static constexpr size_t kDefaultMaximumOutputSize = 16 * 1024 * 1024;
+
   /**
    * Decompress gzip-compressed data.
    *
    * @param compressedData Buffer containing gzip-compressed bytes.
+   * @param maximumOutputSize Maximum number of decompressed bytes to produce.
    * @return Decompressed data on success, or a ParseDiagnostic on failure.
    */
-  static ParseResult<std::vector<uint8_t>> Gzip(std::string_view compressedData);
+  static ParseResult<std::vector<uint8_t>> Gzip(
+      std::string_view compressedData, size_t maximumOutputSize = kDefaultMaximumOutputSize);
 
   /**
    * Decompress zlib-compressed data.

--- a/donner/base/encoding/tests/Decompress_fuzzer.cc
+++ b/donner/base/encoding/tests/Decompress_fuzzer.cc
@@ -1,3 +1,5 @@
+#include <cstdlib>
+
 #include "donner/base/encoding/Decompress.h"
 
 namespace donner {
@@ -7,8 +9,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   const std::string_view strView(reinterpret_cast<const char*>(data), size);
 
   // Fuzz Gzip decompression
-  auto resultGzip = Decompress::Gzip(strView);
-  (void)resultGzip;
+  const size_t gzipLimit = size % 32;
+  auto resultGzip = Decompress::Gzip(strView, gzipLimit);
+  if (resultGzip.hasResult() && resultGzip.result().size() > gzipLimit) {
+    std::abort();
+  }
 
   // Fuzz Zlib decompression
   if (size > 0) {

--- a/donner/base/encoding/tests/Decompress_tests.cc
+++ b/donner/base/encoding/tests/Decompress_tests.cc
@@ -50,6 +50,17 @@ TEST(DecompressTest, GzipTooShort) {
   EXPECT_THAT(maybeResult, ParseErrorIs("Gzip data is too short"));
 }
 
+TEST(DecompressTest, GzipRejectsOutputLargerThanLimit) {
+  // 128 repeated 'A' bytes compressed with gzip -n.
+  const std::vector<uint8_t> compressed = {
+      0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x73, 0x74,
+      0x1c, 0x58, 0x00, 0x00, 0xde, 0x8a, 0x18, 0x04, 0x80, 0x00, 0x00, 0x00,
+  };
+  auto maybeResult = Decompress::Gzip(
+      std::string_view(reinterpret_cast<const char*>(compressed.data()), compressed.size()), 64);
+  EXPECT_THAT(maybeResult, ParseErrorIs(HasSubstr("maximum decompressed size")));
+}
+
 TEST(DecompressTest, ZlibInvalidData) {
   const std::vector<uint8_t> compressed = {0x00, 0x00};
   auto maybeResult = Decompress::Zlib(

--- a/donner/base/parser/DataUrlParser.cc
+++ b/donner/base/parser/DataUrlParser.cc
@@ -7,6 +7,15 @@
 namespace donner::parser {
 
 std::variant<DataUrlParser::Result, DataUrlParserError> DataUrlParser::Parse(std::string_view uri) {
+  return Parse(uri, Options{});
+}
+
+std::variant<DataUrlParser::Result, DataUrlParserError> DataUrlParser::Parse(
+    std::string_view uri, const Options& options) {
+  if (uri.size() > options.maximumInputSize) {
+    return DataUrlParserError::InputTooLarge;
+  }
+
   Result result;
 
   // If the URI is of format "data:image/png;base64,...", it is a data URL.

--- a/donner/base/parser/DataUrlParser.h
+++ b/donner/base/parser/DataUrlParser.h
@@ -1,6 +1,7 @@
 #pragma once
 /// @file
 
+#include <cstddef>
 #include <cstdint>
 #include <string_view>
 #include <variant>
@@ -16,12 +17,14 @@ namespace donner::parser {
  */
 enum class DataUrlParserError : uint8_t {
   InvalidDataUrl,  ///< The data URL is invalid.
+  InputTooLarge,   ///< The URI exceeds the configured input limit.
 };
 
 /// Returns a human-readable description of a \ref DataUrlParserError.
 inline std::string_view ToString(DataUrlParserError err) {
   switch (err) {
     case DataUrlParserError::InvalidDataUrl: return "Invalid data URL";
+    case DataUrlParserError::InputTooLarge: return "Data URL input too large";
   }
 
   UTILS_UNREACHABLE();
@@ -35,6 +38,14 @@ inline std::string_view ToString(DataUrlParserError err) {
  */
 class DataUrlParser {
 public:
+  /// Default maximum URI length accepted from untrusted input.
+  static constexpr size_t kDefaultMaximumInputSize = 16 * 1024 * 1024;
+
+  struct Options {
+    /// Maximum number of encoded URI bytes accepted before decoding.
+    size_t maximumInputSize = kDefaultMaximumInputSize;
+  };
+
   /**
    * Result of parsing a data URL or external URL.
    */
@@ -65,6 +76,10 @@ public:
    * valid.
    */
   static std::variant<Result, DataUrlParserError> Parse(std::string_view uri);
+
+  /// Parse with an explicit encoded-input limit.
+  static std::variant<Result, DataUrlParserError> Parse(std::string_view uri,
+                                                        const Options& options);
 };
 
 }  // namespace donner::parser

--- a/donner/base/parser/tests/DataUrlParser_fuzzer.cc
+++ b/donner/base/parser/tests/DataUrlParser_fuzzer.cc
@@ -1,4 +1,4 @@
-#include <cassert>
+#include <cstdlib>
 
 #include "donner/base/parser/DataUrlParser.h"
 
@@ -17,20 +17,23 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   if (std::holds_alternative<DataUrlParser::Result>(result)) {
     const DataUrlParser::Result& parsed = std::get<DataUrlParser::Result>(result);
     if (parsed.kind == DataUrlParser::Result::Kind::Data) {
-      assert(std::holds_alternative<std::vector<uint8_t>>(parsed.payload) &&
-             "Data URL result should carry a byte payload");
+      if (!std::holds_alternative<std::vector<uint8_t>>(parsed.payload)) {
+        std::abort();
+      }
     } else {
-      assert(std::holds_alternative<RcString>(parsed.payload) &&
-             "External URL result should carry a string payload");
+      if (!std::holds_alternative<RcString>(parsed.payload)) {
+        std::abort();
+      }
     }
   }
 
   DataUrlParser::Options limitedOptions;
   limitedOptions.maximumInputSize = size / 2;
   auto limitedResult = DataUrlParser::Parse(buffer, limitedOptions);
-  if (size > limitedOptions.maximumInputSize) {
-    assert(std::holds_alternative<DataUrlParserError>(limitedResult) &&
-           std::get<DataUrlParserError>(limitedResult) == DataUrlParserError::InputTooLarge);
+  if (size > limitedOptions.maximumInputSize &&
+      (!std::holds_alternative<DataUrlParserError>(limitedResult) ||
+       std::get<DataUrlParserError>(limitedResult) != DataUrlParserError::InputTooLarge)) {
+    std::abort();
   }
 
   return 0;

--- a/donner/base/parser/tests/DataUrlParser_fuzzer.cc
+++ b/donner/base/parser/tests/DataUrlParser_fuzzer.cc
@@ -1,3 +1,5 @@
+#include <cassert>
+
 #include "donner/base/parser/DataUrlParser.h"
 
 namespace donner::parser {
@@ -21,6 +23,14 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
       assert(std::holds_alternative<RcString>(parsed.payload) &&
              "External URL result should carry a string payload");
     }
+  }
+
+  DataUrlParser::Options limitedOptions;
+  limitedOptions.maximumInputSize = size / 2;
+  auto limitedResult = DataUrlParser::Parse(buffer, limitedOptions);
+  if (size > limitedOptions.maximumInputSize) {
+    assert(std::holds_alternative<DataUrlParserError>(limitedResult) &&
+           std::get<DataUrlParserError>(limitedResult) == DataUrlParserError::InputTooLarge);
   }
 
   return 0;

--- a/donner/base/parser/tests/DataUrlParser_tests.cc
+++ b/donner/base/parser/tests/DataUrlParser_tests.cc
@@ -18,6 +18,13 @@ TEST(DataUrlParser, Invalid) {
               VariantWith<DataUrlParserError>(Eq(DataUrlParserError::InvalidDataUrl)));
 }
 
+TEST(DataUrlParser, RejectsInputLargerThanLimit) {
+  DataUrlParser::Options options;
+  options.maximumInputSize = 3;
+  EXPECT_THAT(DataUrlParser::Parse("data:,x", options),
+              VariantWith<DataUrlParserError>(Eq(DataUrlParserError::InputTooLarge)));
+}
+
 TEST(DataUrlParser, ExternalUrl) {
   auto result = DataUrlParser::Parse("http://example.com/foo.png");
   ASSERT_TRUE(std::holds_alternative<DataUrlParser::Result>(result));

--- a/donner/base/xml/XMLParser.cc
+++ b/donner/base/xml/XMLParser.cc
@@ -1691,6 +1691,10 @@ private:
 }  // namespace
 
 ParseResult<XMLDocument> XMLParser::Parse(std::string_view str, const Options& options) {
+  if (str.size() > options.maximumInputSize) {
+    return ParseDiagnostic::Error("XML source exceeds maximum input size", FileOffset::Offset(0));
+  }
+
   XMLParserImpl parser(str, options);
   return parser.parse();
 }

--- a/donner/base/xml/XMLParser.h
+++ b/donner/base/xml/XMLParser.h
@@ -1,6 +1,7 @@
 #pragma once
 /// @file
 
+#include <cstddef>
 #include <cstdint>
 #include <string_view>
 
@@ -23,6 +24,9 @@ public:
   struct Options {
     /// Default options.
     constexpr Options() {}
+
+    /// Maximum encoded XML input bytes accepted before parsing.
+    size_t maximumInputSize = 16 * 1024 * 1024;
 
     /**
      * Parse all nodes in the XML document, including comments, the doctype node, and processing

--- a/donner/base/xml/tests/XMLParser_fuzzer.cc
+++ b/donner/base/xml/tests/XMLParser_fuzzer.cc
@@ -126,6 +126,15 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     logLimitHits(XMLParser::Parse(str, options));
   }
 
+  {
+    XMLParser::Options options;
+    options.maximumInputSize = size / 2;
+    auto limitedResult = XMLParser::Parse(str, options);
+    if (size > options.maximumInputSize && limitedResult.hasResult()) {
+      std::abort();
+    }
+  }
+
   // Exercise GetAttributeLocation - M−1 prerequisite for structured
   // editing. The inner helper previously release-asserted on malformed
   // input; this arm of the fuzzer is the regression net for that fix.

--- a/donner/base/xml/tests/XMLParser_structured_fuzzer.cc
+++ b/donner/base/xml/tests/XMLParser_structured_fuzzer.cc
@@ -10,6 +10,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <iomanip>
 #include <iostream>
 #include <string>
@@ -240,6 +241,13 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
   // 1. Construct a structured XML payload.
   const std::string xml = BuildXmlString(provider);
+
+  XMLParser::Options limitedOptions;
+  limitedOptions.maximumInputSize = xml.size() / 2;
+  auto limitedResult = XMLParser::Parse(xml, limitedOptions);
+  if (xml.size() > limitedOptions.maximumInputSize && limitedResult.hasResult()) {
+    std::abort();
+  }
 
   if (std::getenv("DUMP")) {
     // Print the generated XML for debugging purposes.

--- a/donner/base/xml/tests/XMLParser_tests.cc
+++ b/donner/base/xml/tests/XMLParser_tests.cc
@@ -24,6 +24,14 @@ using testing::Field;
 
 namespace donner::xml {
 
+TEST(XMLParserLimits, RejectsInputLargerThanLimit) {
+  XMLParser::Options options;
+  options.maximumInputSize = 3;
+  auto result = XMLParser::Parse("<a/>", options);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(std::string_view(result.error().reason), testing::HasSubstr("maximum input size"));
+}
+
 auto MutationKindIs(XMLMutation::Kind kind) {
   return Field("kind", &XMLMutation::kind, kind);
 }

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -925,9 +925,21 @@ std::optional<std::string> LoadFile(const std::string& filename) {
   if (!file) {
     return std::nullopt;
   }
-  std::ostringstream out;
-  out << file.rdbuf();
-  return std::move(out).str();
+
+  file.seekg(0, std::ios::end);
+  const std::streamsize length = file.tellg();
+  if (length < 0 ||
+      static_cast<uint64_t>(length) > svg::parser::SVGParser::kDefaultMaximumInputSize) {
+    return std::nullopt;
+  }
+
+  std::string result(static_cast<size_t>(length), '\0');
+  file.seekg(0, std::ios::beg);
+  file.read(result.data(), length);
+  if (file.bad() || file.gcount() != length) {
+    return std::nullopt;
+  }
+  return result;
 }
 
 std::string InitialDocumentSyncSource(const EditorShellOptions& options) {

--- a/donner/editor/app/EditorApp.h
+++ b/donner/editor/app/EditorApp.h
@@ -39,7 +39,7 @@ struct SourceLoadOptions {
   /// Directory used to resolve relative paths. Defaults to the current working directory.
   std::filesystem::path baseDirectory = std::filesystem::current_path();
   /// Maximum number of bytes the loader will read from a single file.
-  std::size_t maxFileBytes = 100u * 1024u * 1024u;
+  std::size_t maxFileBytes = 16u * 1024u * 1024u;
 };
 
 struct RenderSessionOptions {

--- a/donner/svg/components/layout/LayoutSystem.cc
+++ b/donner/svg/components/layout/LayoutSystem.cc
@@ -1,6 +1,8 @@
 #include "donner/svg/components/layout/LayoutSystem.h"
 
 #include <array>
+#include <cmath>
+#include <limits>
 #include <string_view>
 
 #include "donner/base/CompileTimeMap.h"
@@ -85,8 +87,20 @@ constexpr std::array<std::pair<std::string_view, SizedElementPresentationAttribu
 
 DONNER_CONSTEXPR_MAP auto kProperties = makeCompileTimeMap(kPropertyEntries);
 
-Vector2i RoundSize(Vector2f size) {
-  return Vector2i(static_cast<int>(Round(size.x)), static_cast<int>(Round(size.y)));
+int RoundDimension(double dimension) {
+  if (std::isnan(dimension)) {
+    return 0;
+  } else if (dimension >= std::numeric_limits<int>::max()) {
+    return std::numeric_limits<int>::max();
+  } else if (dimension <= std::numeric_limits<int>::min()) {
+    return std::numeric_limits<int>::min();
+  }
+
+  return static_cast<int>(Round(dimension));
+}
+
+Vector2i RoundSize(Vector2d size) {
+  return Vector2i(RoundDimension(size.x), RoundDimension(size.y));
 }
 
 PreserveAspectRatio GetPreserveAspectRatio(EntityHandle entity) {
@@ -266,11 +280,12 @@ bool LayoutSystem::overridesViewBox(EntityHandle entity) const {
 
 Vector2i LayoutSystem::calculateCanvasScaledDocumentSize(Registry& registry,
                                                          InvalidSizeBehavior behavior) const {
-  const Vector2d documentSize = calculateDocumentSize(registry);
+  const Vector2d documentSize = calculateRawDocumentSize(registry);
   const auto& ctx = registry.ctx().get<SVGDocumentContext>();
 
   std::optional<Vector2i> maybeCanvasSize = ctx.canvasSize;
-  if (documentSize.x <= 0.0 || documentSize.y <= 0.0) {
+  if (!std::isfinite(documentSize.x) || !std::isfinite(documentSize.y) || documentSize.x <= 0.0 ||
+      documentSize.y <= 0.0) {
     if (behavior == InvalidSizeBehavior::ReturnDefault) {
       return maybeCanvasSize.value_or(Vector2i(kDefaultWidth, kDefaultHeight));
     } else {
@@ -282,8 +297,10 @@ Vector2i LayoutSystem::calculateCanvasScaledDocumentSize(Registry& registry,
     if (documentSize.x <= kMaxDimension && documentSize.y <= kMaxDimension) {
       return RoundSize(documentSize);
     } else {
-      maybeCanvasSize = Vector2i(Min<int>(static_cast<int>(documentSize.x), kMaxDimension),
-                                 Min<int>(static_cast<int>(documentSize.y), kMaxDimension));
+      const auto clampDimension = [](double dimension) {
+        return dimension >= kMaxDimension ? kMaxDimension : static_cast<int>(dimension);
+      };
+      maybeCanvasSize = Vector2i(clampDimension(documentSize.x), clampDimension(documentSize.y));
     }
   }
 

--- a/donner/svg/components/layout/LayoutSystem.cc
+++ b/donner/svg/components/layout/LayoutSystem.cc
@@ -298,7 +298,7 @@ Vector2i LayoutSystem::calculateCanvasScaledDocumentSize(Registry& registry,
       return RoundSize(documentSize);
     } else {
       const auto clampDimension = [](double dimension) {
-        return dimension >= kMaxDimension ? kMaxDimension : static_cast<int>(dimension);
+        return std::min(kMaxDimension, RoundDimension(dimension));
       };
       maybeCanvasSize = Vector2i(clampDimension(documentSize.x), clampDimension(documentSize.y));
     }

--- a/donner/svg/components/layout/tests/LayoutSystem_tests.cc
+++ b/donner/svg/components/layout/tests/LayoutSystem_tests.cc
@@ -439,6 +439,18 @@ TEST_F(LayoutSystemTest, CanvasScaledDocumentSizeClampsValuesBeyondIntegerRange)
             Vector2i(8192, 4096));
 }
 
+TEST_F(LayoutSystemTest, CanvasScaledDocumentSizeRoundsFractionalAxisWhenOtherAxisClamps) {
+  auto document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9000 0.6">
+    </svg>
+  )");
+
+  auto& registry = document.registry();
+  EXPECT_EQ(layoutSystem.calculateCanvasScaledDocumentSize(
+                registry, LayoutSystem::InvalidSizeBehavior::ReturnDefault),
+            Vector2i(8192, 1));
+}
+
 // --- Intrinsic aspect ratio ---
 
 TEST_F(LayoutSystemTest, IntrinsicAspectRatioWithViewBox) {

--- a/donner/svg/components/layout/tests/LayoutSystem_tests.cc
+++ b/donner/svg/components/layout/tests/LayoutSystem_tests.cc
@@ -427,6 +427,18 @@ TEST_F(LayoutSystemTest, CanvasScaledDocumentSizeClampsLargeDocuments) {
             Vector2i(8192, 4096));
 }
 
+TEST_F(LayoutSystemTest, CanvasScaledDocumentSizeClampsValuesBeyondIntegerRange) {
+  auto document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1e300 5e299">
+    </svg>
+  )");
+
+  auto& registry = document.registry();
+  EXPECT_EQ(layoutSystem.calculateCanvasScaledDocumentSize(
+                registry, LayoutSystem::InvalidSizeBehavior::ReturnDefault),
+            Vector2i(8192, 4096));
+}
+
 // --- Intrinsic aspect ratio ---
 
 TEST_F(LayoutSystemTest, IntrinsicAspectRatioWithViewBox) {

--- a/donner/svg/components/resources/BUILD.bazel
+++ b/donner/svg/components/resources/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//build_defs:rules.bzl", "donner_cc_library")
 load("//build_defs:package.bzl", "donner_package")
+load("//build_defs:rules.bzl", "donner_cc_library")
 
 donner_cc_library(
     name = "components",
@@ -39,6 +39,7 @@ donner_cc_library(
     ],
     deps = [
         ":components",
+        "//donner/base/encoding:decompress",
         "//donner/css:core",
         "//donner/svg:svg_document_handle",
         "//donner/svg/resources:image_loader",

--- a/donner/svg/components/resources/ResourceManagerContext.cc
+++ b/donner/svg/components/resources/ResourceManagerContext.cc
@@ -45,6 +45,31 @@ private:
   ResourceLoaderInterface& loader_;
 };
 
+class BoundedResourceLoader : public ResourceLoaderInterface {
+public:
+  BoundedResourceLoader(ResourceLoaderInterface& loader, size_t& remainingAttempts,
+                        size_t& remainingResourceBytes)
+      : loader_(loader),
+        remainingAttempts_(remainingAttempts),
+        remainingResourceBytes_(remainingResourceBytes) {}
+
+  std::variant<std::vector<uint8_t>, ResourceLoaderError> fetchExternalResource(
+      std::string_view url) override {
+    if (remainingAttempts_ == 0 || remainingResourceBytes_ == 0) {
+      remainingResourceBytes_ = 0;
+      return ResourceLoaderError::TooLarge;
+    }
+
+    --remainingAttempts_;
+    return loader_.fetchExternalResource(url);
+  }
+
+private:
+  ResourceLoaderInterface& loader_;
+  size_t& remainingAttempts_;
+  size_t& remainingResourceBytes_;
+};
+
 SubDocumentCache::ParseCallback GuardSvgParseCallback(
     Registry& registry, const SubDocumentCache::ParseCallback& callback,
     size_t& remainingResourceBytes) {
@@ -62,6 +87,7 @@ SubDocumentCache::ParseCallback GuardSvgParseCallback(
           svgContent.size());
       auto maybeExpandedSvg = Decompress::Gzip(compressedSvg, expandedLimit);
       if (maybeExpandedSvg.hasError()) {
+        remainingResourceBytes = 0;
         warningSink.add(std::move(maybeExpandedSvg).error());
         return std::nullopt;
       }
@@ -91,6 +117,14 @@ ResourceManagerContext::ResourceManagerContext(Registry& registry,
                                                size_t maximumAggregateResourceSize)
     : registry_(registry), remainingResourceBytes_(maximumAggregateResourceSize) {}
 
+void ResourceManagerContext::setResourceLoader(std::unique_ptr<ResourceLoaderInterface>&& loader) {
+  failedImageUrls_.clear();
+  if (auto* cache = registry_.ctx().find<SubDocumentCache>()) {
+    cache->clearFailures();
+  }
+  loader_ = std::move(loader);
+}
+
 void ResourceManagerContext::loadResources(ParseWarningSink& warningSink) {
   // In SecureStatic mode, sub-documents are not allowed to load external resources (SVG2 §2.7.1).
   if (processingMode_ == ProcessingMode::SecureStatic ||
@@ -103,8 +137,12 @@ void ResourceManagerContext::loadResources(ParseWarningSink& warningSink) {
   NullResourceLoader nullLoader;
   WriteAccessGuardedResourceLoader guardedLoader(
       registry_, loader_ ? *loader_ : static_cast<ResourceLoaderInterface&>(nullLoader));
-  ResourceLoaderInterface& loader = loader_ ? static_cast<ResourceLoaderInterface&>(guardedLoader)
-                                            : static_cast<ResourceLoaderInterface&>(nullLoader);
+  ResourceLoaderInterface& uncappedLoader =
+      loader_ ? static_cast<ResourceLoaderInterface&>(guardedLoader)
+              : static_cast<ResourceLoaderInterface&>(nullLoader);
+  BoundedResourceLoader boundedLoader(uncappedLoader, remainingResourceFetchAttempts_,
+                                      remainingResourceBytes_);
+  ResourceLoaderInterface& loader = boundedLoader;
 
   // Only warn about a missing loader if we actually have something that
   // would need one. `data:` URLs are decoded inline in `UrlLoader::fromUri`
@@ -158,6 +196,11 @@ void ResourceManagerContext::loadResources(ParseWarningSink& warningSink) {
       continue;
     }
 
+    if (failedImageUrls_.contains(image.href)) {
+      registry_.emplace<LoadedImageComponent>(entity);
+      continue;
+    }
+
     if (auto* cache = registry_.ctx().find<SubDocumentCache>()) {
       if (auto cachedDocument = cache->get(image.href)) {
         registry_.emplace<LoadedSVGImageComponent>(entity, std::move(*cachedDocument));
@@ -174,6 +217,10 @@ void ResourceManagerContext::loadResources(ParseWarningSink& warningSink) {
       err.reason = std::string(ToString(std::get<UrlLoaderError>(imageResult)));
       warningSink.add(std::move(err));
 
+      if (failedImageUrls_.size() < kMaximumResourceFetchAttempts) {
+        failedImageUrls_.insert(image.href);
+      }
+
       // Create an empty LoadedImageComponent to prevent loading again.
       registry_.emplace<LoadedImageComponent>(entity);
     } else if (std::holds_alternative<SvgImageContent>(imageResult)) {
@@ -182,6 +229,9 @@ void ResourceManagerContext::loadResources(ParseWarningSink& warningSink) {
         ParseDiagnostic err;
         err.reason = "SVG image references require an SVG parse callback";
         warningSink.add(std::move(err));
+        if (failedImageUrls_.size() < kMaximumResourceFetchAttempts) {
+          failedImageUrls_.insert(image.href);
+        }
         registry_.emplace<LoadedImageComponent>(entity);
         continue;
       }
@@ -202,6 +252,9 @@ void ResourceManagerContext::loadResources(ParseWarningSink& warningSink) {
         registry_.emplace<LoadedSVGImageComponent>(entity, std::move(*subDoc));
       } else {
         // Parse failed - create an empty LoadedImageComponent to prevent retrying.
+        if (failedImageUrls_.size() < kMaximumResourceFetchAttempts) {
+          failedImageUrls_.insert(image.href);
+        }
         registry_.emplace<LoadedImageComponent>(entity);
       }
     } else {
@@ -277,10 +330,15 @@ std::optional<SVGDocumentHandle> ResourceManagerContext::loadExternalSVG(
   if (auto cached = cache.get(url)) {
     return cached;
   }
+  if (cache.isRejected(url)) {
+    return std::nullopt;
+  }
 
   // Fetch the file content using the same per-resource and aggregate budgets as images and fonts.
   WriteAccessGuardedResourceLoader guardedLoader(registry_, *loader_);
-  UrlLoader urlLoader(guardedLoader, UrlLoader::kDefaultMaximumResourceSize,
+  BoundedResourceLoader boundedLoader(guardedLoader, remainingResourceFetchAttempts_,
+                                      remainingResourceBytes_);
+  UrlLoader urlLoader(boundedLoader, UrlLoader::kDefaultMaximumResourceSize,
                       &remainingResourceBytes_);
   auto fetchResult = urlLoader.fromUri(url);
   if (std::holds_alternative<UrlLoaderError>(fetchResult)) {
@@ -289,6 +347,7 @@ std::optional<SVGDocumentHandle> ResourceManagerContext::loadExternalSVG(
     err.reason = std::string("Failed to load external SVG '") + std::string(url) +
                  "': " + std::string(ToString(loaderError));
     warningSink.add(std::move(err));
+    cache.rememberFailure(url);
     return std::nullopt;
   }
 
@@ -325,17 +384,28 @@ const LoadedImageComponent* ResourceManagerContext::getLoadedImageComponent(Enti
   if (!image) {
     return nullptr;
   }
+  if (failedImageUrls_.contains(image->href)) {
+    return nullptr;
+  }
 
   NullResourceLoader nullLoader;
   WriteAccessGuardedResourceLoader guardedLoader(
       registry_, loader_ ? *loader_ : static_cast<ResourceLoaderInterface&>(nullLoader));
-  ResourceLoaderInterface& loader = loader_ ? static_cast<ResourceLoaderInterface&>(guardedLoader)
-                                            : static_cast<ResourceLoaderInterface&>(nullLoader);
+  ResourceLoaderInterface& uncappedLoader =
+      loader_ ? static_cast<ResourceLoaderInterface&>(guardedLoader)
+              : static_cast<ResourceLoaderInterface&>(nullLoader);
+  BoundedResourceLoader boundedLoader(uncappedLoader, remainingResourceFetchAttempts_,
+                                      remainingResourceBytes_);
+  ResourceLoaderInterface& loader = boundedLoader;
   ImageLoader imageLoader(loader, UrlLoader::kDefaultMaximumResourceSize, &remainingResourceBytes_);
 
   auto imageResult = imageLoader.fromUri(image->href);
   if (std::holds_alternative<ImageResource>(imageResult)) {
     return &registry_.emplace<LoadedImageComponent>(entity, std::get<ImageResource>(imageResult));
+  }
+
+  if (failedImageUrls_.size() < kMaximumResourceFetchAttempts) {
+    failedImageUrls_.insert(image->href);
   }
 
   // TODO(jwm): Plumb loading error out, and handle SvgImageContent once sub-document

--- a/donner/svg/components/resources/ResourceManagerContext.cc
+++ b/donner/svg/components/resources/ResourceManagerContext.cc
@@ -1,11 +1,13 @@
 #include "donner/svg/components/resources/ResourceManagerContext.h"
 
+#include <algorithm>
 #include <memory>
 
 #include "donner/base/EcsRegistry.h"
 #include "donner/base/ParseDiagnostic.h"
 #include "donner/base/ParseWarningSink.h"
 #include "donner/base/Utils.h"
+#include "donner/base/encoding/Decompress.h"
 #include "donner/css/FontFace.h"
 #include "donner/svg/components/SVGDocumentContext.h"
 #include "donner/svg/components/resources/ImageComponent.h"
@@ -44,11 +46,31 @@ private:
 };
 
 SubDocumentCache::ParseCallback GuardSvgParseCallback(
-    Registry& registry, const SubDocumentCache::ParseCallback& callback) {
-  return [&registry, &callback](const std::vector<uint8_t>& svgContent,
-                                ParseWarningSink& warningSink) -> std::optional<SVGDocumentHandle> {
+    Registry& registry, const SubDocumentCache::ParseCallback& callback,
+    size_t& remainingResourceBytes) {
+  return [&registry, &callback, &remainingResourceBytes](
+             const std::vector<uint8_t>& svgContent,
+             ParseWarningSink& warningSink) -> std::optional<SVGDocumentHandle> {
     AssertNoDocumentWriteAccessForUserCallback(
         registry, "SVG parse callback must not run while document write access is held");
+
+    if (svgContent.size() >= 2 && svgContent[0] == 0x1f && svgContent[1] == 0x8b) {
+      const size_t expandedLimit =
+          std::min(Decompress::kDefaultMaximumOutputSize, remainingResourceBytes);
+      const std::string_view compressedSvg(
+          reinterpret_cast<const char*>(svgContent.data()),  // NOLINT, allow reinterpret_cast.
+          svgContent.size());
+      auto maybeExpandedSvg = Decompress::Gzip(compressedSvg, expandedLimit);
+      if (maybeExpandedSvg.hasError()) {
+        warningSink.add(std::move(maybeExpandedSvg).error());
+        return std::nullopt;
+      }
+
+      std::vector<uint8_t> expandedSvg = std::move(maybeExpandedSvg).result();
+      remainingResourceBytes -= expandedSvg.size();
+      return callback(expandedSvg, warningSink);
+    }
+
     return callback(svgContent, warningSink);
   };
 }
@@ -126,6 +148,13 @@ void ResourceManagerContext::loadResources(ParseWarningSink& warningSink) {
       continue;
     }
 
+    if (auto* cache = registry_.ctx().find<SubDocumentCache>()) {
+      if (auto cachedDocument = cache->get(image.href)) {
+        registry_.emplace<LoadedSVGImageComponent>(entity, std::move(*cachedDocument));
+        continue;
+      }
+    }
+
     ImageLoader imageLoader(loader, UrlLoader::kDefaultMaximumResourceSize,
                             &remainingResourceBytes_);
 
@@ -156,7 +185,7 @@ void ResourceManagerContext::loadResources(ParseWarningSink& warningSink) {
       auto& cache = registry_.ctx().get<SubDocumentCache>();
 
       SubDocumentCache::ParseCallback guardedParseCallback =
-          GuardSvgParseCallback(registry_, svgParseCallback_);
+          GuardSvgParseCallback(registry_, svgParseCallback_, remainingResourceBytes_);
       auto subDoc =
           cache.getOrParse(image.href, svgContent.data, guardedParseCallback, warningSink);
       if (subDoc) {
@@ -255,7 +284,7 @@ std::optional<SVGDocumentHandle> ResourceManagerContext::loadExternalSVG(
 
   auto& data = std::get<UrlLoader::Result>(fetchResult).data;
   SubDocumentCache::ParseCallback guardedParseCallback =
-      GuardSvgParseCallback(registry_, svgParseCallback_);
+      GuardSvgParseCallback(registry_, svgParseCallback_, remainingResourceBytes_);
   return cache.getOrParse(url, data, guardedParseCallback, warningSink);
 }
 

--- a/donner/svg/components/resources/ResourceManagerContext.cc
+++ b/donner/svg/components/resources/ResourceManagerContext.cc
@@ -55,7 +55,9 @@ SubDocumentCache::ParseCallback GuardSvgParseCallback(
 
 }  // namespace
 
-ResourceManagerContext::ResourceManagerContext(Registry& registry) : registry_(registry) {}
+ResourceManagerContext::ResourceManagerContext(Registry& registry,
+                                               size_t maximumAggregateResourceSize)
+    : registry_(registry), remainingResourceBytes_(maximumAggregateResourceSize) {}
 
 void ResourceManagerContext::loadResources(ParseWarningSink& warningSink) {
   // In SecureStatic mode, sub-documents are not allowed to load external resources (SVG2 §2.7.1).
@@ -124,7 +126,8 @@ void ResourceManagerContext::loadResources(ParseWarningSink& warningSink) {
       continue;
     }
 
-    ImageLoader imageLoader(loader);
+    ImageLoader imageLoader(loader, UrlLoader::kDefaultMaximumResourceSize,
+                            &remainingResourceBytes_);
 
     auto imageResult = imageLoader.fromUri(image.href);
     if (std::holds_alternative<UrlLoaderError>(imageResult)) {
@@ -163,14 +166,15 @@ void ResourceManagerContext::loadResources(ParseWarningSink& warningSink) {
         registry_.emplace<LoadedImageComponent>(entity);
       }
     } else {
-      registry_.emplace<LoadedImageComponent>(entity, std::get<ImageResource>(imageResult));
+      ImageResource imageResource = std::get<ImageResource>(std::move(imageResult));
+      registry_.emplace<LoadedImageComponent>(entity, std::move(imageResource));
     }
   }
 
   // Hydrate URL font sources into data sources. FontManager owns parsing and caches decoded font
   // handles on demand; ResourceManager only resolves bytes while the document resource loader is
   // available.
-  UrlLoader urlLoader(loader);
+  UrlLoader urlLoader(loader, UrlLoader::kDefaultMaximumResourceSize, &remainingResourceBytes_);
   for (const size_t fontFaceIndex : fontFaceIndexesToLoad_) {
     css::FontFace& fontFace = fontFaces_[fontFaceIndex];
     for (css::FontFaceSource& source : fontFace.sources) {
@@ -235,19 +239,21 @@ std::optional<SVGDocumentHandle> ResourceManagerContext::loadExternalSVG(
     return cached;
   }
 
-  // Fetch the file content.
+  // Fetch the file content using the same per-resource and aggregate budgets as images and fonts.
   WriteAccessGuardedResourceLoader guardedLoader(registry_, *loader_);
-  auto fetchResult = guardedLoader.fetchExternalResource(std::string_view(url));
-  if (std::holds_alternative<ResourceLoaderError>(fetchResult)) {
+  UrlLoader urlLoader(guardedLoader, UrlLoader::kDefaultMaximumResourceSize,
+                      &remainingResourceBytes_);
+  auto fetchResult = urlLoader.fromUri(url);
+  if (std::holds_alternative<UrlLoaderError>(fetchResult)) {
     ParseDiagnostic err;
-    const auto loaderError = std::get<ResourceLoaderError>(fetchResult);
-    err.reason = std::string("Failed to load external SVG '") + std::string(url) + "': " +
-                 (loaderError == ResourceLoaderError::NotFound ? "not found" : "sandbox violation");
+    const auto loaderError = std::get<UrlLoaderError>(fetchResult);
+    err.reason = std::string("Failed to load external SVG '") + std::string(url) +
+                 "': " + std::string(ToString(loaderError));
     warningSink.add(std::move(err));
     return std::nullopt;
   }
 
-  auto& data = std::get<std::vector<uint8_t>>(fetchResult);
+  auto& data = std::get<UrlLoader::Result>(fetchResult).data;
   SubDocumentCache::ParseCallback guardedParseCallback =
       GuardSvgParseCallback(registry_, svgParseCallback_);
   return cache.getOrParse(url, data, guardedParseCallback, warningSink);
@@ -286,7 +292,7 @@ const LoadedImageComponent* ResourceManagerContext::getLoadedImageComponent(Enti
       registry_, loader_ ? *loader_ : static_cast<ResourceLoaderInterface&>(nullLoader));
   ResourceLoaderInterface& loader = loader_ ? static_cast<ResourceLoaderInterface&>(guardedLoader)
                                             : static_cast<ResourceLoaderInterface&>(nullLoader);
-  ImageLoader imageLoader(loader);
+  ImageLoader imageLoader(loader, UrlLoader::kDefaultMaximumResourceSize, &remainingResourceBytes_);
 
   auto imageResult = imageLoader.fromUri(image->href);
   if (std::holds_alternative<ImageResource>(imageResult)) {

--- a/donner/svg/components/resources/ResourceManagerContext.cc
+++ b/donner/svg/components/resources/ResourceManagerContext.cc
@@ -68,6 +68,16 @@ SubDocumentCache::ParseCallback GuardSvgParseCallback(
 
       std::vector<uint8_t> expandedSvg = std::move(maybeExpandedSvg).result();
       remainingResourceBytes -= expandedSvg.size();
+
+      // The production SVG parser also recognizes gzip input. Reject another gzip layer here so
+      // the callback cannot expand bytes that were never charged to this document's aggregate
+      // resource budget.
+      if (expandedSvg.size() >= 2 && expandedSvg[0] == 0x1f && expandedSvg[1] == 0x8b) {
+        warningSink.add(ParseDiagnostic::Error("Nested gzip-compressed SVG is not supported",
+                                               FileOffset::Offset(0)));
+        return std::nullopt;
+      }
+
       return callback(expandedSvg, warningSink);
     }
 

--- a/donner/svg/components/resources/ResourceManagerContext.h
+++ b/donner/svg/components/resources/ResourceManagerContext.h
@@ -22,8 +22,12 @@ namespace donner::svg::components {
  */
 class ResourceManagerContext {
 public:
+  /// Default aggregate byte budget for raw and decoded document resources.
+  static constexpr size_t kDefaultMaximumAggregateResourceSize = 64 * 1024 * 1024;
+
   /// Constructor.
-  explicit ResourceManagerContext(Registry& registry);
+  explicit ResourceManagerContext(Registry& registry, size_t maximumAggregateResourceSize =
+                                                          kDefaultMaximumAggregateResourceSize);
 
   /**
    * Load resources such as images. Note that this doesn't issue network calls directly, but relies
@@ -121,6 +125,9 @@ private:
 
   /// Callback to parse SVG content into sub-documents (injected to avoid circular deps).
   SubDocumentCache::ParseCallback svgParseCallback_;
+
+  /// Remaining raw and decoded resource bytes available to this document.
+  mutable size_t remainingResourceBytes_;
 };
 
 }  // namespace donner::svg::components

--- a/donner/svg/components/resources/ResourceManagerContext.h
+++ b/donner/svg/components/resources/ResourceManagerContext.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <span>
+#include <unordered_set>
 #include <vector>
 
 #include "donner/base/EcsRegistry_fwd.h"
@@ -25,6 +26,9 @@ public:
   /// Default aggregate byte budget for raw and decoded document resources.
   static constexpr size_t kDefaultMaximumAggregateResourceSize = 64 * 1024 * 1024;
 
+  /// Maximum number of application resource-loader calls for one document.
+  static constexpr size_t kMaximumResourceFetchAttempts = 256;
+
   /// Constructor.
   explicit ResourceManagerContext(Registry& registry, size_t maximumAggregateResourceSize =
                                                           kDefaultMaximumAggregateResourceSize);
@@ -44,9 +48,7 @@ public:
    * @param loader Resource loader interface, which will be held until overridden. Call this API
    * again with \c nullptr to unset.
    */
-  void setResourceLoader(std::unique_ptr<ResourceLoaderInterface>&& loader) {
-    loader_ = std::move(loader);
-  }
+  void setResourceLoader(std::unique_ptr<ResourceLoaderInterface>&& loader);
 
   /**
    * Set the processing mode for this document. In secure modes (\ref ProcessingMode::SecureStatic,
@@ -128,6 +130,12 @@ private:
 
   /// Remaining raw and decoded resource bytes available to this document.
   mutable size_t remainingResourceBytes_;
+
+  /// Bounded negative cache for image fetch, parse, and decode failures.
+  mutable std::unordered_set<RcString> failedImageUrls_;
+
+  /// Remaining application fetch calls before external loading latches closed.
+  mutable size_t remainingResourceFetchAttempts_ = kMaximumResourceFetchAttempts;
 };
 
 }  // namespace donner::svg::components

--- a/donner/svg/components/resources/SubDocumentCache.cc
+++ b/donner/svg/components/resources/SubDocumentCache.cc
@@ -9,6 +9,9 @@ std::optional<SVGDocumentHandle> SubDocumentCache::getOrParse(
   if (auto it = cache_.find(resolvedUrl); it != cache_.end()) {
     return it->second;
   }
+  if (isRejected(resolvedUrl)) {
+    return std::nullopt;
+  }
 
   // Detect circular references.
   if (loading_.contains(resolvedUrl)) {
@@ -26,11 +29,32 @@ std::optional<SVGDocumentHandle> SubDocumentCache::getOrParse(
   loading_.erase(resolvedUrl);
 
   if (!maybeDocument) {
+    rememberFailure(resolvedUrl);
     return std::nullopt;
   }
 
   auto [it, inserted] = cache_.emplace(resolvedUrl, std::move(*maybeDocument));
   return it->second;
+}
+
+void SubDocumentCache::rememberFailure(const RcString& resolvedUrl) {
+  if (cache_.contains(resolvedUrl) || isRejected(resolvedUrl)) {
+    return;
+  }
+  if (rejected_.size() >= kMaximumRejectedEntries) {
+    rejectAll_ = true;
+    return;
+  }
+  rejected_.insert(resolvedUrl);
+}
+
+bool SubDocumentCache::isRejected(const RcString& resolvedUrl) const {
+  return rejectAll_ || rejected_.contains(resolvedUrl);
+}
+
+void SubDocumentCache::clearFailures() {
+  rejected_.clear();
+  rejectAll_ = false;
 }
 
 std::optional<SVGDocumentHandle> SubDocumentCache::get(const RcString& resolvedUrl) const {

--- a/donner/svg/components/resources/SubDocumentCache.h
+++ b/donner/svg/components/resources/SubDocumentCache.h
@@ -72,6 +72,15 @@ public:
    */
   std::optional<SVGDocumentHandle> get(const RcString& resolvedUrl) const;
 
+  /// Record a failed fetch or parse so the URL is not retried.
+  void rememberFailure(const RcString& resolvedUrl);
+
+  /// Return true when the URL has a negative cache entry.
+  bool isRejected(const RcString& resolvedUrl) const;
+
+  /// Clear failed-URL entries when the application replaces its resource loader.
+  void clearFailures();
+
   /// Returns true if the given URL is currently being loaded (for recursion detection).
   bool isLoading(const RcString& resolvedUrl) const;
 
@@ -79,11 +88,19 @@ public:
   size_t size() const { return cache_.size(); }
 
 private:
+  static constexpr size_t kMaximumRejectedEntries = 256;
+
   /// Cached sub-documents keyed by resolved URL.
   std::unordered_map<RcString, SVGDocumentHandle> cache_;
 
   /// URLs currently being loaded, used to detect circular references.
   std::unordered_set<RcString> loading_;
+
+  /// URLs whose fetch or parse failed.
+  std::unordered_set<RcString> rejected_;
+
+  /// True after the bounded negative cache fills, rejecting every uncached URL.
+  bool rejectAll_ = false;
 };
 
 }  // namespace donner::svg::components

--- a/donner/svg/components/resources/tests/BUILD.bazel
+++ b/donner/svg/components/resources/tests/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//build_defs:rules.bzl", "donner_cc_test")
 load("//build_defs:package.bzl", "donner_package")
+load("//build_defs:rules.bzl", "donner_cc_test")
 
 donner_cc_test(
     name = "sub_document_cache_tests",
@@ -18,6 +18,7 @@ donner_cc_test(
         "//donner/base/encoding:base64",
         "//donner/svg",
         "//donner/svg/components/resources:resource_manager_context",
+        "//donner/svg/parser",
         "@com_google_gtest//:gtest_main",
     ],
 )

--- a/donner/svg/components/resources/tests/SubDocumentCache_tests.cc
+++ b/donner/svg/components/resources/tests/SubDocumentCache_tests.cc
@@ -512,6 +512,33 @@ TEST(ResourceManagerContextAggregateBudgetTest,
   EXPECT_TRUE(warnings.hasWarnings());
 }
 
+TEST(ResourceManagerContextAggregateBudgetTest,
+     ExternalSvgzChargesSuccessfulExpansionWhenParserRejectsDocument) {
+  constexpr size_t kExactBudget = kGzipSvg.size() + kExpandedSvg.size();
+  Registry registry;
+  auto& resourceManager = registry.ctx().emplace<ResourceManagerContext>(registry, kExactBudget);
+  auto loader = std::make_unique<TestResourceLoader>();
+  loader->addFile("rejected.svgz", GzipSvgBytes());
+  resourceManager.setResourceLoader(std::move(loader));
+
+  int parseCount = 0;
+  resourceManager.setSvgParseCallback(
+      [&parseCount](const std::vector<uint8_t>& data,
+                    ParseWarningSink&) -> std::optional<SVGDocumentHandle> {
+        ++parseCount;
+        EXPECT_EQ(data, std::vector<uint8_t>(kExpandedSvg.begin(), kExpandedSvg.end()));
+        return std::nullopt;
+      });
+
+  ParseWarningSink warnings;
+  const auto result = resourceManager.loadExternalSVG("rejected.svgz", warnings);
+
+  EXPECT_FALSE(result.has_value());
+  EXPECT_EQ(parseCount, 1);
+  EXPECT_EQ(resourceManager.remainingResourceBytes_, 0u);
+  EXPECT_EQ(registry.ctx().get<SubDocumentCache>().size(), 0u);
+}
+
 TEST_F(ResourceManagerContextTest, UserCallbacksRunOutsideDocumentWriteAccess) {
   SVGDocument document;
   document.setThreadingMode(ThreadingMode::ConcurrentDom);

--- a/donner/svg/components/resources/tests/SubDocumentCache_tests.cc
+++ b/donner/svg/components/resources/tests/SubDocumentCache_tests.cc
@@ -47,6 +47,19 @@ constexpr std::string_view kTinyPngDataUrl =
     "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAEUlEQVR42mP4z8DwH4QZYAwAR8oH+"
     "Rq28akAAAAASUVORK5CYII=";
 
+// gzip-compressed "<svg xmlns='http://www.w3.org/2000/svg'></svg>"
+constexpr std::array<uint8_t, 62> kGzipSvg = {
+    0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x03, 0xb3, 0x29, 0x2e, 0x4b, 0x57, 0xa8,
+    0xc8, 0xcd, 0xc9, 0x2b, 0xb6, 0x55, 0xcf, 0x28, 0x29, 0x29, 0xb0, 0xd2, 0xd7, 0x2f, 0x2f, 0x2f,
+    0xd7, 0x2b, 0x37, 0xd6, 0xcb, 0x2f, 0x4a, 0xd7, 0x37, 0x32, 0x30, 0x30, 0xd0, 0x07, 0xaa, 0x50,
+    0xb7, 0xb3, 0x01, 0x51, 0x76, 0x00, 0xf7, 0xa3, 0x84, 0x65, 0x2e, 0x00, 0x00, 0x00};
+
+constexpr std::string_view kExpandedSvg = "<svg xmlns='http://www.w3.org/2000/svg'></svg>";
+
+std::vector<uint8_t> GzipSvgBytes() {
+  return {kGzipSvg.begin(), kGzipSvg.end()};
+}
+
 constexpr std::string_view kValidWoffBase64 =
     "d09GRk9UVE8AAAVAAAkAAAAAB0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABDRkYgAAADXAAAAdEAAAIu"
     "idw6/09TLzIAAAFAAAAARQAAAGB9nYChY21hcAAAAvwAAABMAAAA5gCvAdxoZWFkAAAA4AAAADYAAAA2"
@@ -391,6 +404,111 @@ TEST(ResourceManagerContextAggregateBudgetTest, IncludesDecodedImageBytes) {
   const auto* image = registry.try_get<LoadedImageComponent>(imageEntity);
   ASSERT_NE(image, nullptr);
   EXPECT_FALSE(image->image.has_value());
+  EXPECT_TRUE(warnings.hasWarnings());
+}
+
+TEST(ResourceManagerContextAggregateBudgetTest,
+     SvgzImageSucceedsAtExactRawAndExpandedBoundaryAndCachesWithoutRecharging) {
+  constexpr size_t kExactBudget = kGzipSvg.size() + kExpandedSvg.size();
+  Registry registry;
+  auto& resourceManager = registry.ctx().emplace<ResourceManagerContext>(registry, kExactBudget);
+
+  int fetchCount = 0;
+  auto loader = std::make_unique<TestResourceLoader>([&fetchCount]() { ++fetchCount; });
+  loader->addFile("image.svgz", GzipSvgBytes());
+  resourceManager.setResourceLoader(std::move(loader));
+
+  int parseCount = 0;
+  resourceManager.setSvgParseCallback(
+      [&parseCount](const std::vector<uint8_t>& data,
+                    ParseWarningSink&) -> std::optional<SVGDocumentHandle> {
+        ++parseCount;
+        EXPECT_EQ(data, std::vector<uint8_t>(kExpandedSvg.begin(), kExpandedSvg.end()));
+        return MakeDocumentWithCanvas(1001).handle();
+      });
+
+  const Entity firstImage = registry.create();
+  registry.emplace<ImageComponent>(firstImage, ImageComponent{RcString("image.svgz")});
+  ParseWarningSink warnings;
+  resourceManager.loadResources(warnings);
+
+  ASSERT_TRUE(registry.all_of<LoadedSVGImageComponent>(firstImage));
+  EXPECT_EQ(resourceManager.remainingResourceBytes_, 0u);
+
+  const Entity cachedImage = registry.create();
+  registry.emplace<ImageComponent>(cachedImage, ImageComponent{RcString("image.svgz")});
+  resourceManager.loadResources(warnings);
+
+  ASSERT_TRUE(registry.all_of<LoadedSVGImageComponent>(cachedImage));
+  EXPECT_EQ(registry.get<LoadedSVGImageComponent>(cachedImage).subDocument,
+            registry.get<LoadedSVGImageComponent>(firstImage).subDocument);
+  EXPECT_EQ(fetchCount, 1);
+  EXPECT_EQ(parseCount, 1);
+  EXPECT_EQ(resourceManager.remainingResourceBytes_, 0u);
+  EXPECT_FALSE(warnings.hasWarnings());
+}
+
+TEST(ResourceManagerContextAggregateBudgetTest,
+     ExternalSvgzRejectsOneByteBelowExpandedBoundaryBeforeParserCallback) {
+  constexpr size_t kBudget = kGzipSvg.size() + kExpandedSvg.size() - 1;
+  Registry registry;
+  auto& resourceManager = registry.ctx().emplace<ResourceManagerContext>(registry, kBudget);
+  auto loader = std::make_unique<TestResourceLoader>();
+  loader->addFile("external.svgz", GzipSvgBytes());
+  resourceManager.setResourceLoader(std::move(loader));
+
+  int parseCount = 0;
+  resourceManager.setSvgParseCallback(
+      [&parseCount](const std::vector<uint8_t>&,
+                    ParseWarningSink&) -> std::optional<SVGDocumentHandle> {
+        ++parseCount;
+        return MakeDocumentWithCanvas(1002).handle();
+      });
+
+  ParseWarningSink warnings;
+  const auto result = resourceManager.loadExternalSVG("external.svgz", warnings);
+
+  EXPECT_FALSE(result.has_value());
+  EXPECT_EQ(parseCount, 0);
+  EXPECT_EQ(resourceManager.remainingResourceBytes_, kExpandedSvg.size() - 1);
+  const auto& cache = registry.ctx().get<SubDocumentCache>();
+  EXPECT_EQ(cache.size(), 0u);
+  EXPECT_FALSE(cache.isLoading("external.svgz"));
+  EXPECT_FALSE(cache.get("external.svgz").has_value());
+  EXPECT_TRUE(warnings.hasWarnings());
+}
+
+TEST(ResourceManagerContextAggregateBudgetTest,
+     DistinctSvgzExpansionSharesAggregateBudgetAndPreservesFirstDocumentOnRejection) {
+  constexpr size_t kBudget = 2 * (kGzipSvg.size() + kExpandedSvg.size()) - 1;
+  Registry registry;
+  auto& resourceManager = registry.ctx().emplace<ResourceManagerContext>(registry, kBudget);
+  auto loader = std::make_unique<TestResourceLoader>();
+  loader->addFile("first.svgz", GzipSvgBytes());
+  loader->addFile("second.svgz", GzipSvgBytes());
+  resourceManager.setResourceLoader(std::move(loader));
+
+  int parseCount = 0;
+  resourceManager.setSvgParseCallback(
+      [&parseCount](const std::vector<uint8_t>& data,
+                    ParseWarningSink&) -> std::optional<SVGDocumentHandle> {
+        ++parseCount;
+        EXPECT_EQ(data, std::vector<uint8_t>(kExpandedSvg.begin(), kExpandedSvg.end()));
+        return MakeDocumentWithCanvas(1003).handle();
+      });
+
+  ParseWarningSink warnings;
+  const auto first = resourceManager.loadExternalSVG("first.svgz", warnings);
+  ASSERT_TRUE(first.has_value());
+  const auto second = resourceManager.loadExternalSVG("second.svgz", warnings);
+
+  EXPECT_FALSE(second.has_value());
+  EXPECT_EQ(parseCount, 1);
+  EXPECT_EQ(resourceManager.remainingResourceBytes_, kExpandedSvg.size() - 1);
+  const auto& cache = registry.ctx().get<SubDocumentCache>();
+  EXPECT_EQ(cache.size(), 1u);
+  EXPECT_EQ(cache.get("first.svgz"), first);
+  EXPECT_FALSE(cache.get("second.svgz").has_value());
   EXPECT_TRUE(warnings.hasWarnings());
 }
 

--- a/donner/svg/components/resources/tests/SubDocumentCache_tests.cc
+++ b/donner/svg/components/resources/tests/SubDocumentCache_tests.cc
@@ -184,6 +184,33 @@ TEST(SubDocumentCacheTest, ParseFailureReturnsNull) {
   EXPECT_EQ(cache.size(), 0u);
 }
 
+TEST(SubDocumentCacheTest, ParseFailureIsNegativeCached) {
+  SubDocumentCache cache;
+  const std::vector<uint8_t> content{'x'};
+  int parseCount = 0;
+  const auto callback = [&parseCount](const std::vector<uint8_t>&,
+                                      ParseWarningSink&) -> std::optional<SVGDocumentHandle> {
+    ++parseCount;
+    return std::nullopt;
+  };
+  ParseWarningSink warnings;
+
+  EXPECT_FALSE(cache.getOrParse("bad.svg", content, callback, warnings).has_value());
+  EXPECT_FALSE(cache.getOrParse("bad.svg", content, callback, warnings).has_value());
+  EXPECT_EQ(parseCount, 1);
+  EXPECT_TRUE(cache.isRejected("bad.svg"));
+}
+
+TEST(SubDocumentCacheTest, NegativeCacheLatchesAfterBoundedEntries) {
+  SubDocumentCache cache;
+  for (size_t index = 0; index <= 256; ++index) {
+    const std::string url = "bad-" + std::to_string(index) + ".svg";
+    cache.rememberFailure(RcString(std::string_view(url)));
+  }
+
+  EXPECT_TRUE(cache.isRejected("never-seen.svg"));
+}
+
 TEST(SubDocumentCacheTest, RecursionDetection) {
   SubDocumentCache cache;
   const std::vector<uint8_t> content{'r'};
@@ -379,6 +406,55 @@ TEST_F(ResourceManagerContextTest, LoadExternalSVGFileNotFound) {
   EXPECT_TRUE(warnings.hasWarnings());
 }
 
+TEST_F(ResourceManagerContextTest, LoadExternalSVGFileFailureIsNegativeCached) {
+  int fetchCount = 0;
+  auto loader = std::make_unique<TestResourceLoader>([&fetchCount]() { ++fetchCount; });
+  setResourceLoader(std::move(loader));
+  setSvgParseCallback(MakeDocumentCallback(703));
+
+  ParseWarningSink warnings;
+  EXPECT_FALSE(resourceManager_->loadExternalSVG("missing.svg", warnings).has_value());
+  EXPECT_FALSE(resourceManager_->loadExternalSVG("missing.svg", warnings).has_value());
+
+  EXPECT_EQ(fetchCount, 1);
+  EXPECT_TRUE(registry_.ctx().get<SubDocumentCache>().isRejected("missing.svg"));
+}
+
+TEST_F(ResourceManagerContextTest, ReplacingLoaderClearsNegativeResourceCache) {
+  setResourceLoader(std::make_unique<TestResourceLoader>());
+  setSvgParseCallback(MakeDocumentCallback(704));
+  ParseWarningSink warnings;
+  EXPECT_FALSE(resourceManager_->loadExternalSVG("later.svg", warnings).has_value());
+
+  auto replacement = std::make_unique<TestResourceLoader>();
+  replacement->addFile("later.svg", {'<', 's', 'v', 'g', '/', '>'});
+  setResourceLoader(std::move(replacement));
+
+  EXPECT_TRUE(resourceManager_->loadExternalSVG("later.svg", warnings).has_value());
+}
+
+TEST_F(ResourceManagerContextTest, FailedExternalSvgProbeDoesNotSuppressRasterImage) {
+  NullResourceLoader nullLoader;
+  UrlLoader dataUrlLoader(nullLoader);
+  auto decoded = dataUrlLoader.fromUri(kTinyPngDataUrl);
+  ASSERT_TRUE(std::holds_alternative<UrlLoader::Result>(decoded));
+
+  auto loader = std::make_unique<TestResourceLoader>();
+  loader->addFile("shared.png", std::get<UrlLoader::Result>(std::move(decoded)).data);
+  setResourceLoader(std::move(loader));
+  int parseCount = 0;
+  setSvgParseCallback(MakeProductionSvgParseCallback(parseCount));
+
+  ParseWarningSink warnings;
+  EXPECT_FALSE(resourceManager_->loadExternalSVG("shared.png", warnings).has_value());
+  const Entity image = addImage("shared.png");
+  resourceManager_->loadResources(warnings);
+
+  EXPECT_EQ(parseCount, 1);
+  ASSERT_TRUE(registry_.all_of<LoadedImageComponent>(image));
+  EXPECT_TRUE(registry_.get<LoadedImageComponent>(image).image.has_value());
+}
+
 TEST_F(ResourceManagerContextTest, LoadExternalSVGSuccess) {
   auto loader = std::make_unique<TestResourceLoader>();
   const std::vector<uint8_t> svgContent{'<', 's', 'v', 'g', '>'};
@@ -497,7 +573,7 @@ TEST(ResourceManagerContextAggregateBudgetTest,
 
   EXPECT_FALSE(result.has_value());
   EXPECT_EQ(parseCount, 0);
-  EXPECT_EQ(resourceManager.remainingResourceBytes_, kExpandedSvg.size() - 1);
+  EXPECT_EQ(resourceManager.remainingResourceBytes_, 0u);
   const auto& cache = registry.ctx().get<SubDocumentCache>();
   EXPECT_EQ(cache.size(), 0u);
   EXPECT_FALSE(cache.isLoading("external.svgz"));
@@ -531,7 +607,7 @@ TEST(ResourceManagerContextAggregateBudgetTest,
 
   EXPECT_FALSE(second.has_value());
   EXPECT_EQ(parseCount, 1);
-  EXPECT_EQ(resourceManager.remainingResourceBytes_, kExpandedSvg.size() - 1);
+  EXPECT_EQ(resourceManager.remainingResourceBytes_, 0u);
   const auto& cache = registry.ctx().get<SubDocumentCache>();
   EXPECT_EQ(cache.size(), 1u);
   EXPECT_EQ(cache.get("first.svgz"), first);
@@ -805,6 +881,64 @@ TEST_F(ResourceManagerContextTest, LoadResourcesSvgParseFailureCreatesEmptyLoade
   EXPECT_TRUE(registry_.all_of<LoadedImageComponent>(imageEntity));
   EXPECT_FALSE(registry_.all_of<LoadedSVGImageComponent>(imageEntity));
   EXPECT_TRUE(warnings.hasWarnings());
+}
+
+TEST_F(ResourceManagerContextTest, RepeatedSvgParseFailureFetchesAndParsesOnce) {
+  int fetchCount = 0;
+  auto loader = std::make_unique<TestResourceLoader>([&fetchCount]() { ++fetchCount; });
+  loader->addFile("broken.svg", {'<', 's', 'v', 'g', '/', '>'});
+  setResourceLoader(std::move(loader));
+  int parseCount = 0;
+  setSvgParseCallback([&parseCount](const std::vector<uint8_t>&,
+                                    ParseWarningSink&) -> std::optional<SVGDocumentHandle> {
+    ++parseCount;
+    return std::nullopt;
+  });
+  const Entity first = addImage("broken.svg");
+  const Entity second = addImage("broken.svg");
+
+  ParseWarningSink warnings;
+  resourceManager_->loadResources(warnings);
+
+  EXPECT_EQ(fetchCount, 1);
+  EXPECT_EQ(parseCount, 1);
+  EXPECT_TRUE(registry_.all_of<LoadedImageComponent>(first));
+  EXPECT_TRUE(registry_.all_of<LoadedImageComponent>(second));
+  EXPECT_TRUE(registry_.ctx().get<SubDocumentCache>().isRejected("broken.svg"));
+}
+
+TEST_F(ResourceManagerContextTest, ExternalFetchAttemptCapLatchesBeforeCapPlusOne) {
+  int fetchCount = 0;
+  setResourceLoader(std::make_unique<TestResourceLoader>([&fetchCount]() { ++fetchCount; }));
+  for (size_t index = 0; index <= ResourceManagerContext::kMaximumResourceFetchAttempts; ++index) {
+    addImage("missing-" + std::to_string(index) + ".png");
+  }
+
+  ParseWarningSink warnings;
+  resourceManager_->loadResources(warnings);
+
+  EXPECT_EQ(fetchCount, ResourceManagerContext::kMaximumResourceFetchAttempts);
+  EXPECT_EQ(resourceManager_->remainingResourceFetchAttempts_, 0u);
+  EXPECT_EQ(resourceManager_->remainingResourceBytes_, 0u);
+}
+
+TEST_F(ResourceManagerContextTest, SvgzExpansionFailureLatchesBeforeAnotherDistinctFetch) {
+  int fetchCount = 0;
+  auto loader = std::make_unique<TestResourceLoader>([&fetchCount]() { ++fetchCount; });
+  loader->addFile("first-broken.svgz", {0x1f, 0x8b, 0x00});
+  loader->addFile("second-broken.svgz", {0x1f, 0x8b, 0x00});
+  setResourceLoader(std::move(loader));
+  int parseCount = 0;
+  setSvgParseCallback(MakeProductionSvgParseCallback(parseCount));
+  addImage("first-broken.svgz");
+  addImage("second-broken.svgz");
+
+  ParseWarningSink warnings;
+  resourceManager_->loadResources(warnings);
+
+  EXPECT_EQ(fetchCount, 1);
+  EXPECT_EQ(parseCount, 0);
+  EXPECT_EQ(resourceManager_->remainingResourceBytes_, 0u);
 }
 
 TEST_F(ResourceManagerContextTest, AddFontFacesHydratesUrlFontSources) {

--- a/donner/svg/components/resources/tests/SubDocumentCache_tests.cc
+++ b/donner/svg/components/resources/tests/SubDocumentCache_tests.cc
@@ -13,6 +13,8 @@
 #define private public
 #include "donner/svg/components/resources/ResourceManagerContext.h"
 #undef private
+#include "donner/svg/resources/NullResourceLoader.h"
+#include "donner/svg/resources/UrlLoader.h"
 
 namespace donner::svg::components {
 namespace {
@@ -353,6 +355,43 @@ TEST_F(ResourceManagerContextTest, LoadExternalSVGSuccess) {
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(SVGDocument::CreateFromHandle(*result).canvasSize(), Vector2i(705, 705));
   EXPECT_FALSE(warnings.hasWarnings());
+}
+
+TEST(ResourceManagerContextAggregateBudgetTest, AppliesBudgetAcrossExternalSvgLoads) {
+  Registry registry;
+  auto& resourceManager = registry.ctx().emplace<ResourceManagerContext>(registry, 7);
+  auto loader = std::make_unique<TestResourceLoader>();
+  loader->addFile("first.svg", {'<', 's', 'v', 'g'});
+  loader->addFile("second.svg", {'<', 's', 'v', 'g'});
+  resourceManager.setResourceLoader(std::move(loader));
+  resourceManager.setSvgParseCallback(MakeDocumentCallback(704));
+
+  ParseWarningSink warnings;
+  EXPECT_TRUE(resourceManager.loadExternalSVG("first.svg", warnings).has_value());
+  EXPECT_FALSE(resourceManager.loadExternalSVG("second.svg", warnings).has_value());
+  EXPECT_TRUE(warnings.hasWarnings());
+}
+
+TEST(ResourceManagerContextAggregateBudgetTest, IncludesDecodedImageBytes) {
+  NullResourceLoader nullLoader;
+  UrlLoader urlLoader(nullLoader);
+  auto loaded = urlLoader.fromUri(kTinyPngDataUrl);
+  ASSERT_TRUE(std::holds_alternative<UrlLoader::Result>(loaded));
+  const size_t encodedResourceBytes = std::get<UrlLoader::Result>(loaded).data.size();
+
+  Registry registry;
+  auto& resourceManager =
+      registry.ctx().emplace<ResourceManagerContext>(registry, encodedResourceBytes);
+  const Entity imageEntity = registry.create();
+  registry.emplace<ImageComponent>(imageEntity, ImageComponent{RcString(kTinyPngDataUrl)});
+
+  ParseWarningSink warnings;
+  resourceManager.loadResources(warnings);
+
+  const auto* image = registry.try_get<LoadedImageComponent>(imageEntity);
+  ASSERT_NE(image, nullptr);
+  EXPECT_FALSE(image->image.has_value());
+  EXPECT_TRUE(warnings.hasWarnings());
 }
 
 TEST_F(ResourceManagerContextTest, UserCallbacksRunOutsideDocumentWriteAccess) {

--- a/donner/svg/components/resources/tests/SubDocumentCache_tests.cc
+++ b/donner/svg/components/resources/tests/SubDocumentCache_tests.cc
@@ -13,6 +13,7 @@
 #define private public
 #include "donner/svg/components/resources/ResourceManagerContext.h"
 #undef private
+#include "donner/svg/parser/SVGParser.h"
 #include "donner/svg/resources/NullResourceLoader.h"
 #include "donner/svg/resources/UrlLoader.h"
 
@@ -42,6 +43,23 @@ SubDocumentCache::ParseCallback MakeFailingCallback() {
   };
 }
 
+SubDocumentCache::ParseCallback MakeProductionSvgParseCallback(int& parseCount) {
+  return [&parseCount](const std::vector<uint8_t>& data,
+                       ParseWarningSink& warnings) -> std::optional<SVGDocumentHandle> {
+    ++parseCount;
+    SVGDocument::Settings settings;
+    settings.processingMode = ProcessingMode::SecureStatic;
+    const std::string_view source(reinterpret_cast<const char*>(data.data()), data.size());
+    auto result = parser::SVGParser::ParseSVG(source, warnings, parser::SVGParser::Options(),
+                                              std::move(settings));
+    if (result.hasError()) {
+      warnings.add(ParseDiagnostic(result.error()));
+      return std::nullopt;
+    }
+    return result.result().handle();
+  };
+}
+
 constexpr std::string_view kTinyPngDataUrl =
     "data:image/png;base64,"
     "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAEUlEQVR42mP4z8DwH4QZYAwAR8oH+"
@@ -55,6 +73,15 @@ constexpr std::array<uint8_t, 62> kGzipSvg = {
     0xb7, 0xb3, 0x01, 0x51, 0x76, 0x00, 0xf7, 0xa3, 0x84, 0x65, 0x2e, 0x00, 0x00, 0x00};
 
 constexpr std::string_view kExpandedSvg = "<svg xmlns='http://www.w3.org/2000/svg'></svg>";
+
+// gzip-compressed kGzipSvg. The outer layer expands to another gzip stream, not XML.
+constexpr std::array<uint8_t, 81> kNestedGzipSvg = {
+    0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x93, 0xef, 0xe6, 0x60,
+    0x00, 0x01, 0x26, 0xe6, 0xcd, 0x9a, 0x7a, 0xde, 0xe1, 0x2b, 0x4e, 0x9c, 0x3d, 0xa9,
+    0xbd, 0x2d, 0xf4, 0xbc, 0x86, 0xa6, 0xe6, 0x86, 0x4b, 0xd7, 0xf5, 0xf5, 0xf5, 0xaf,
+    0x6b, 0x9b, 0x5f, 0x3b, 0xad, 0xef, 0x75, 0xdd, 0xdc, 0xc8, 0xc0, 0xe0, 0x02, 0xfb,
+    0xaa, 0x80, 0xed, 0x9b, 0x19, 0x03, 0xcb, 0x18, 0xbe, 0x2f, 0x6e, 0x49, 0xd5, 0x03,
+    0xea, 0x02, 0x00, 0xe6, 0x0f, 0x43, 0x99, 0x3e, 0x00, 0x00, 0x00};
 
 std::vector<uint8_t> GzipSvgBytes() {
   return {kGzipSvg.begin(), kGzipSvg.end()};
@@ -537,6 +564,55 @@ TEST(ResourceManagerContextAggregateBudgetTest,
   EXPECT_EQ(parseCount, 1);
   EXPECT_EQ(resourceManager.remainingResourceBytes_, 0u);
   EXPECT_EQ(registry.ctx().get<SubDocumentCache>().size(), 0u);
+}
+
+TEST(ResourceManagerContextAggregateBudgetTest,
+     NestedSvgzRejectsBeforeProductionParserCanExpandAnUnchargedSecondLayer) {
+  constexpr size_t kBudget = kNestedGzipSvg.size() + kGzipSvg.size();
+  Registry registry;
+  auto& resourceManager = registry.ctx().emplace<ResourceManagerContext>(registry, kBudget);
+  auto loader = std::make_unique<TestResourceLoader>();
+  loader->addFile("nested.svgz",
+                  std::vector<uint8_t>(kNestedGzipSvg.begin(), kNestedGzipSvg.end()));
+  resourceManager.setResourceLoader(std::move(loader));
+
+  int parseCount = 0;
+  resourceManager.setSvgParseCallback(MakeProductionSvgParseCallback(parseCount));
+
+  ParseWarningSink warnings;
+  const auto result = resourceManager.loadExternalSVG("nested.svgz", warnings);
+
+  EXPECT_FALSE(result.has_value());
+  EXPECT_EQ(parseCount, 0);
+  EXPECT_EQ(resourceManager.remainingResourceBytes_, 0u);
+  EXPECT_EQ(registry.ctx().get<SubDocumentCache>().size(), 0u);
+  EXPECT_TRUE(warnings.hasWarnings());
+}
+
+TEST(ResourceManagerContextAggregateBudgetTest,
+     NestedSvgzImageRejectsBeforeProductionParserCanExpandAnUnchargedSecondLayer) {
+  constexpr size_t kBudget = kNestedGzipSvg.size() + kGzipSvg.size();
+  Registry registry;
+  auto& resourceManager = registry.ctx().emplace<ResourceManagerContext>(registry, kBudget);
+  auto loader = std::make_unique<TestResourceLoader>();
+  loader->addFile("nested-image.svgz",
+                  std::vector<uint8_t>(kNestedGzipSvg.begin(), kNestedGzipSvg.end()));
+  resourceManager.setResourceLoader(std::move(loader));
+
+  int parseCount = 0;
+  resourceManager.setSvgParseCallback(MakeProductionSvgParseCallback(parseCount));
+  const Entity image = registry.create();
+  registry.emplace<ImageComponent>(image, ImageComponent{RcString("nested-image.svgz")});
+
+  ParseWarningSink warnings;
+  resourceManager.loadResources(warnings);
+
+  EXPECT_EQ(parseCount, 0);
+  EXPECT_EQ(resourceManager.remainingResourceBytes_, 0u);
+  EXPECT_TRUE(registry.all_of<LoadedImageComponent>(image));
+  EXPECT_FALSE(registry.all_of<LoadedSVGImageComponent>(image));
+  EXPECT_EQ(registry.ctx().get<SubDocumentCache>().size(), 0u);
+  EXPECT_TRUE(warnings.hasWarnings());
 }
 
 TEST_F(ResourceManagerContextTest, UserCallbacksRunOutsideDocumentWriteAccess) {

--- a/donner/svg/parser/BUILD.bazel
+++ b/donner/svg/parser/BUILD.bazel
@@ -188,6 +188,7 @@ donner_cc_fuzzer(
     ],
     deps = [
         ":parser",
+        "//donner/svg/components/layout:layout_system",
     ],
 )
 

--- a/donner/svg/parser/SVGParser.cc
+++ b/donner/svg/parser/SVGParser.cc
@@ -478,6 +478,10 @@ public:
 ParseResult<SVGDocument> SVGParser::ParseSVG(std::string_view source, ParseWarningSink& warningSink,
                                              SVGParser::Options options,
                                              SVGDocument::Settings settings) noexcept {
+  if (source.size() > options.maximumInputSize) {
+    return ParseDiagnostic::Error("SVG source exceeds maximum input size", FileOffset::Offset(0));
+  }
+
   // Inject the SVG parse callback for sub-document loading, unless we're already in secure mode
   // (sub-documents cannot load their own sub-documents).
   if (!settings.svgParseCallback && settings.processingMode == ProcessingMode::DynamicInteractive) {
@@ -500,11 +504,12 @@ ParseResult<SVGDocument> SVGParser::ParseSVG(std::string_view source, ParseWarni
 
   xml::XMLParser::Options xmlOptions;
   xmlOptions.parseCustomEntities = true;
+  xmlOptions.maximumInputSize = options.maximumInputSize;
 
   std::vector<uint8_t> decompressedData;
   if (source.size() >= 2 && static_cast<unsigned char>(source[0]) == 0x1F &&
       static_cast<unsigned char>(source[1]) == 0x8B) {
-    auto maybeDecompressedData = Decompress::Gzip(source);
+    auto maybeDecompressedData = Decompress::Gzip(source, options.maximumInputSize);
     if (maybeDecompressedData.hasError()) {
       return std::move(maybeDecompressedData.error());
     }

--- a/donner/svg/parser/SVGParser.h
+++ b/donner/svg/parser/SVGParser.h
@@ -16,6 +16,9 @@ namespace donner::svg::parser {
  */
 class SVGParser {
 public:
+  /// Default maximum number of source or expanded SVG bytes accepted from untrusted input.
+  static constexpr size_t kDefaultMaximumInputSize = 16 * 1024 * 1024;
+
   /**
    * Options to modify the parsing behavior.
    */
@@ -75,6 +78,12 @@ public:
      * ```
      */
     bool parseAsInlineSVG = false;
+
+    /**
+     * Maximum source size accepted by ParseSVG. For SVGZ input the same limit applies to both the
+     * compressed and expanded forms, preventing decompression bombs.
+     */
+    size_t maximumInputSize = kDefaultMaximumInputSize;
   };
 
   /**

--- a/donner/svg/parser/tests/SVGParser_fuzzer.cc
+++ b/donner/svg/parser/tests/SVGParser_fuzzer.cc
@@ -1,3 +1,5 @@
+#include <cstdlib>
+
 #include "donner/base/ParseWarningSink.h"
 #include "donner/svg/parser/SVGParser.h"
 
@@ -14,10 +16,13 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   // Try again with options set.
   SVGParser::Options options;
   options.disableUserAttributes = false;
+  options.maximumInputSize = size / 2;
 
   ParseWarningSink disabled2 = ParseWarningSink::Disabled();
   auto result2 = SVGParser::ParseSVG(buffer, disabled2, options);
-  (void)result2;
+  if (size > options.maximumInputSize && result2.hasResult()) {
+    std::abort();
+  }
 
   return 0;
 }

--- a/donner/svg/parser/tests/SVGParser_structured_fuzzer.cc
+++ b/donner/svg/parser/tests/SVGParser_structured_fuzzer.cc
@@ -10,6 +10,7 @@
 #include "donner/base/xml/XMLNode.h"
 #include "donner/base/xml/XMLQualifiedName.h"
 #include "donner/svg/SVGElementNames.h"
+#include "donner/svg/components/layout/LayoutSystem.h"
 #include "donner/svg/parser/SVGParser.h"
 
 using namespace donner::xml;
@@ -54,6 +55,22 @@ XMLQualifiedName CreateRandomAttributeName(FuzzedDataProvider& provider) {
   } else {
     // Generate a random attribute name
     return CreateQualifiedName(provider);
+  }
+}
+
+void AddEdgeCaseSizingAttributes(XMLNode& svgElement, FuzzedDataProvider& provider) {
+  constexpr std::string_view kEdgeNumbers[] = {
+      "0", "-1", "1e-300", "1e300", "8192", "2147483648", "4294967296", "inf", "nan",
+  };
+
+  if (provider.ConsumeBool()) {
+    svgElement.setAttribute("width", provider.PickValueInArray(kEdgeNumbers));
+    svgElement.setAttribute("height", provider.PickValueInArray(kEdgeNumbers));
+  }
+  if (provider.ConsumeBool()) {
+    const std::string viewBox = "0 0 " + std::string(provider.PickValueInArray(kEdgeNumbers)) +
+                                " " + std::string(provider.PickValueInArray(kEdgeNumbers));
+    svgElement.setAttribute("viewBox", viewBox);
   }
 }
 
@@ -176,6 +193,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     // Create an SVG element
     XMLNode svgElement = XMLNode::CreateElementNode(document, "svg");
     svgElement.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+    AddEdgeCaseSizingAttributes(svgElement, provider);
     root.appendChild(svgElement);
 
     // Set the SVG element as the new root for further processing
@@ -188,7 +206,13 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   // Pass the constructed document to the SVG parser
   donner::ParseWarningSink disabled = donner::ParseWarningSink::Disabled();
   auto result = donner::svg::parser::SVGParser::ParseXMLDocument(std::move(document), disabled);
-  (void)result;  // Suppress unused variable warning
+  if (result.hasResult()) {
+    auto svgDocument = std::move(result).result();
+    donner::svg::components::LayoutSystem layoutSystem;
+    (void)layoutSystem.calculateCanvasScaledDocumentSize(
+        svgDocument.unsafeRegistry(),
+        donner::svg::components::LayoutSystem::InvalidSizeBehavior::ReturnDefault);
+  }
 
   return 0;
 }

--- a/donner/svg/parser/tests/SVGParser_tests.cc
+++ b/donner/svg/parser/tests/SVGParser_tests.cc
@@ -63,6 +63,30 @@ TEST(SVGParser, Svgz) {
   EXPECT_THAT(warnings.warnings(), ElementsAre());
 }
 
+TEST(SVGParser, RejectsInputLargerThanConfiguredLimit) {
+  SVGParser::Options options;
+  options.maximumInputSize = 64;
+
+  ParseWarningSink warnings;
+  EXPECT_THAT(SVGParser::ParseSVG(std::string(65, ' '), warnings, options),
+              ParseErrorIs(testing::HasSubstr("maximum input size")));
+}
+
+TEST(SVGParser, RejectsSvgzWhoseExpandedSizeExceedsConfiguredLimit) {
+  // 128 repeated 'A' bytes compressed with gzip -n. The compressed input is 24 bytes.
+  static const uint8_t kGzipData[] = {
+      0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x73, 0x74,
+      0x1c, 0x58, 0x00, 0x00, 0xde, 0x8a, 0x18, 0x04, 0x80, 0x00, 0x00, 0x00,
+  };
+  SVGParser::Options options;
+  options.maximumInputSize = 64;
+
+  ParseWarningSink warnings;
+  const std::string_view gzipStr(reinterpret_cast<const char*>(kGzipData), sizeof(kGzipData));
+  EXPECT_THAT(SVGParser::ParseSVG(gzipStr, warnings, options),
+              ParseErrorIs(testing::HasSubstr("maximum decompressed size")));
+}
+
 TEST(SVGParser, WithoutNamespace) {
   const std::string_view simpleXml("<svg></svg>");
 

--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -70,7 +70,7 @@ donner_cc_library(
     visibility = ["//donner/svg:__subpackages__"],
     deps = [
         ":renderer_test_backend",
-        "//donner/svg/renderer",
+        "//donner/svg/renderer:renderer_utils",
         "//donner/svg/tests:parser_test_utils",
         "@com_google_gtest//:gtest",
     ],
@@ -699,7 +699,7 @@ donner_cc_fuzzer(
     ],
     deps = [
         "//donner/svg",
-        "//donner/svg/renderer:renderer_utils",
+        "//donner/svg/renderer",
     ],
 )
 

--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -156,6 +156,7 @@ donner_cc_test(
     ],
     deps = [
         ":image_comparison_test_fixture",
+        "//donner/base:base_test_utils",
         "@com_google_gtest//:gtest_main",
     ],
 )

--- a/donner/svg/renderer/tests/ImageComparisonTestFixture.cc
+++ b/donner/svg/renderer/tests/ImageComparisonTestFixture.cc
@@ -32,6 +32,34 @@ namespace donner::svg {
 
 namespace {
 
+std::filesystem::path ResolveRunfilesResourceRoot(const std::filesystem::path& runfilesRoot,
+                                                  const std::filesystem::path& documentPath) {
+  const std::filesystem::path absoluteRoot =
+      std::filesystem::absolute(runfilesRoot).lexically_normal();
+  const std::filesystem::path absoluteDocument =
+      std::filesystem::absolute(documentPath).lexically_normal();
+  const std::filesystem::path relativeDocument = absoluteDocument.lexically_relative(absoluteRoot);
+  if (relativeDocument.empty() || relativeDocument.is_absolute()) {
+    return runfilesRoot;
+  }
+  for (const auto& component : relativeDocument) {
+    if (component == "..") {
+      return runfilesRoot;
+    }
+  }
+
+  std::error_code error;
+  std::filesystem::path resolvedRoot = std::filesystem::canonical(documentPath, error);
+  if (error) {
+    return runfilesRoot;
+  }
+  for (const auto& component : relativeDocument) {
+    static_cast<void>(component);
+    resolvedRoot = resolvedRoot.parent_path();
+  }
+  return resolvedRoot;
+}
+
 /// Load all TTF/OTF fonts from a directory and register them as @font-face rules on the document.
 /// Cache of font faces loaded from a directory, keyed by directory path.
 /// Prevents re-reading 14MB of font files for every test in a shard, which causes glibc
@@ -532,6 +560,10 @@ RendererBitmap NormalizeSnapshot(RendererBitmap snapshot) {
 
 }  // namespace
 
+std::filesystem::path ResolveRunfilesResourceRootForTesting(
+    const std::filesystem::path& runfilesRoot, const std::filesystem::path& documentPath) {
+  return ResolveRunfilesResourceRoot(runfilesRoot, documentPath);
+}
 std::optional<TerminalPreviewConfig> PreviewConfigFromEnv(const ImageComparisonParams& params) {
   if (!params.showTerminalPreview) {
     return std::nullopt;
@@ -737,7 +769,8 @@ SVGDocument ImageComparisonTestFixture::loadSVG(
   SVGDocument::Settings settings;
   if (resourceDir) {
     settings.resourceLoader = std::make_unique<SandboxedFileResourceLoader>(
-        *resourceDir, std::filesystem::path(filename));
+        ResolveRunfilesResourceRootForTesting(*resourceDir, filename),
+        std::filesystem::path(filename));
   }
 
   ParseWarningSink disabled = ParseWarningSink::Disabled();

--- a/donner/svg/renderer/tests/ImageComparisonTestFixture.h
+++ b/donner/svg/renderer/tests/ImageComparisonTestFixture.h
@@ -486,6 +486,9 @@ std::string RenderTerminalComparisonGridForTesting(
     const TerminalImageView& diff, int maxTerminalWidth, TerminalPixelMode pixelMode,
     const TerminalImageViewerConfig& viewerConfig = {});
 
+/// Maps a runfiles-tree resource root onto the canonical tree containing @p documentPath.
+std::filesystem::path ResolveRunfilesResourceRootForTesting(
+    const std::filesystem::path& runfilesRoot, const std::filesystem::path& documentPath);
 /**
  * @brief A Google Test fixture for tests that compare rendered SVG output against golden images.
  *

--- a/donner/svg/renderer/tests/ImageComparisonTestFixture_tests.cc
+++ b/donner/svg/renderer/tests/ImageComparisonTestFixture_tests.cc
@@ -3,7 +3,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <filesystem>
+#include <fstream>
 #include <string>
+
+#include "donner/base/tests/TestTempDir.h"
 
 namespace donner::svg {
 namespace {
@@ -32,6 +36,29 @@ TEST(ImageComparisonTestFixtureTests, GeodeMaxPixelsOnlyAppliesToGeodeModes) {
   EXPECT_EQ(params.effectiveMaxMismatchedPixels(ComparisonMode::TinyGolden), 150);
   EXPECT_EQ(params.effectiveMaxMismatchedPixels(ComparisonMode::GeodeGolden), 500);
   EXPECT_EQ(params.effectiveMaxMismatchedPixels(ComparisonMode::GeodeTinyParity), 500);
+}
+
+TEST(ImageComparisonTestFixtureTests, ResolvesSymlinkedRunfilesRootToCanonicalDocumentTree) {
+  const std::filesystem::path testRoot = TestTempDir() / "runfiles-resource-root";
+  const std::filesystem::path canonicalRoot = testRoot / "canonical";
+  const std::filesystem::path runfilesRoot = testRoot / "runfiles";
+  const std::filesystem::path canonicalDocument = canonicalRoot / "document.svg";
+  std::filesystem::create_directories(canonicalRoot);
+  {
+    std::ofstream file(canonicalDocument);
+    ASSERT_TRUE(file.good());
+    file << "<svg/>";
+  }
+
+  std::error_code error;
+  std::filesystem::create_directory_symlink(canonicalRoot, runfilesRoot, error);
+  if (error) {
+    GTEST_SKIP() << "Could not create test symlink: " << error.message();
+  }
+
+  EXPECT_EQ(ResolveRunfilesResourceRootForTesting(runfilesRoot, runfilesRoot / "document.svg"),
+            canonicalRoot);
+  EXPECT_EQ(ResolveRunfilesResourceRootForTesting(runfilesRoot, canonicalDocument), runfilesRoot);
 }
 
 #ifndef DONNER_TEXT_FULL

--- a/donner/svg/renderer/tests/Renderer_tests.cc
+++ b/donner/svg/renderer/tests/Renderer_tests.cc
@@ -172,7 +172,8 @@ protected:
     const std::filesystem::path resourceDir = filePath.parent_path();
 
     SVGDocument::Settings settings;
-    settings.resourceLoader = std::make_unique<SandboxedFileResourceLoader>(resourceDir, filePath);
+    settings.resourceLoader = std::make_unique<SandboxedFileResourceLoader>(
+        ResolveRunfilesResourceRootForTesting(resourceDir, filePath), filePath);
 
     ParseWarningSink disabled = ParseWarningSink::Disabled();
     auto maybeResult =

--- a/donner/svg/renderer/wasm/BUILD.bazel
+++ b/donner/svg/renderer/wasm/BUILD.bazel
@@ -44,13 +44,16 @@ _WASM_GEODE_COMPATIBLE_WITH = select({
 # Internal cc_binary that Emscripten's wasm_cc_binary transitions to WASM.
 cc_binary(
     name = "donner_wasm_bin",
-    srcs = ["wasm_bridge.cc"],
+    srcs = [
+        "WasmBridgeUtils.h",
+        "wasm_bridge.cc",
+    ],
     linkopts = [
         "-sMODULARIZE=1",
         "-sEXPORT_ES6=1",
         "-sENVIRONMENT=web",
         "-sALLOW_MEMORY_GROWTH=1",
-        "-sEXPORTED_FUNCTIONS=_donner_init,_donner_render_svg,_donner_free_pixels,_donner_get_last_error,_malloc,_free",
+        "-sEXPORTED_FUNCTIONS=_donner_init,_donner_render_svg,_donner_render_svg_len,_donner_free_pixels,_donner_get_last_error,_malloc,_free",
         # Smaller allocator than the default dlmalloc; safe with USE_PTHREADS=0.
         "-sMALLOC=emmalloc",
         "-sEXPORTED_RUNTIME_METHODS=ccall,cwrap,UTF8ToString,HEAPU8",
@@ -121,7 +124,10 @@ py_test(
 # the browser's async WebGPU implementation.
 cc_binary(
     name = "donner_wasm_geode_bin",
-    srcs = ["wasm_bridge_geode.cc"],
+    srcs = [
+        "WasmBridgeUtils.h",
+        "wasm_bridge_geode.cc",
+    ],
     additional_linker_inputs = [
         "//third_party/emdawnwebgpu:webgpu/src/library_webgpu_enum_tables.js",
         "//third_party/emdawnwebgpu:webgpu/src/library_webgpu_generated_struct_info.js",
@@ -135,7 +141,7 @@ cc_binary(
         "-sALLOW_MEMORY_GROWTH=1",
         "-sASYNCIFY=1",
         "-sASYNCIFY_STACK_SIZE=131072",
-        "-sEXPORTED_FUNCTIONS=_donner_geode_init,_donner_geode_render_svg,_donner_free_pixels,_donner_get_last_error,_malloc,_free",
+        "-sEXPORTED_FUNCTIONS=_donner_geode_init,_donner_geode_render_svg,_donner_geode_render_svg_len,_donner_free_pixels,_donner_get_last_error,_malloc,_free",
         "-sEXPORTED_RUNTIME_METHODS=ccall,cwrap,UTF8ToString,HEAPU8",
         "-sUSE_PTHREADS=0",
         "-sSTACK_SIZE=1048576",

--- a/donner/svg/renderer/wasm/WasmBridgeUtils.h
+++ b/donner/svg/renderer/wasm/WasmBridgeUtils.h
@@ -1,0 +1,50 @@
+#pragma once
+/// @file
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+
+#ifdef __EMSCRIPTEN__
+#include <emscripten/heap.h>
+#endif
+
+namespace donner::svg::wasm {
+
+/// Return whether a caller-provided byte range is contained in WebAssembly linear memory.
+inline bool IsValidInputRange(const char* data, size_t size) {
+#ifdef __EMSCRIPTEN__
+  const uintptr_t address = reinterpret_cast<uintptr_t>(data);
+  const size_t heapSize = emscripten_get_heap_size();
+  return address <= heapSize && size <= heapSize - address;
+#else
+  (void)data;
+  (void)size;
+  return true;
+#endif
+}
+
+/// Find a terminator without scanning beyond linear memory or the configured source limit.
+inline std::optional<size_t> BoundedCStringLength(const char* data, size_t maximumInputSize) {
+  size_t scanSize = maximumInputSize + 1;
+#ifdef __EMSCRIPTEN__
+  const uintptr_t address = reinterpret_cast<uintptr_t>(data);
+  const size_t heapSize = emscripten_get_heap_size();
+  if (address >= heapSize) {
+    return std::nullopt;
+  }
+  scanSize = std::min(scanSize, heapSize - address);
+#endif
+
+  if (const void* terminator = std::memchr(data, '\0', scanSize)) {
+    return static_cast<const char*>(terminator) - data;
+  }
+  if (scanSize == maximumInputSize + 1) {
+    return scanSize;
+  }
+  return std::nullopt;
+}
+
+}  // namespace donner::svg::wasm

--- a/donner/svg/renderer/wasm/render_test_driver.mjs
+++ b/donner/svg/renderer/wasm/render_test_driver.mjs
@@ -72,7 +72,7 @@ try {
   fail('module instantiation failed: ' + err.message);
 }
 
-for (const name of ['cwrap', 'HEAPU8']) {
+for (const name of ['cwrap', 'HEAPU8', '_malloc', '_free']) {
   if (Module[name] === undefined) {
     fail('runtime method/view "' + name + '" is missing from the module (glue regression?)');
   }
@@ -80,12 +80,45 @@ for (const name of ['cwrap', 'HEAPU8']) {
 
 const donnerInit = Module.cwrap('donner_init', null, []);
 const donnerRenderSvg = Module.cwrap('donner_render_svg', 'number', ['string', 'number', 'number']);
+const donnerRenderSvgLen = Module.cwrap(
+  'donner_render_svg_len',
+  'number',
+  ['number', 'number', 'number', 'number'],
+);
 const donnerFreePixels = Module.cwrap('donner_free_pixels', null, ['number']);
 const donnerGetError = Module.cwrap('donner_get_last_error', 'string', []);
 
 donnerInit();
 
-const ptr = donnerRenderSvg(SVG, width, height);
+const oversizedInput = Module._malloc(1);
+if (oversizedInput === 0) {
+  fail('could not allocate oversized-input sentinel');
+}
+Module.HEAPU8[oversizedInput] = 0;
+const oversizedResult = donnerRenderSvgLen(oversizedInput, 16 * 1024 * 1024 + 1, 1, 1);
+Module._free(oversizedInput);
+if (oversizedResult !== 0 || !donnerGetError().includes('maximum input size')) {
+  fail('length-aware API did not reject oversized SVG before reading it: ' + donnerGetError());
+}
+
+const invalidRangeResult = donnerRenderSvgLen(Module.HEAPU8.byteLength - 1, 2, 1, 1);
+if (invalidRangeResult !== 0 || !donnerGetError().includes('outside WebAssembly memory')) {
+  fail('length-aware API did not reject an out-of-bounds input range: ' + donnerGetError());
+}
+
+const oversizedPixels = donnerRenderSvg('<svg/>', 8192, 8192);
+if (oversizedPixels !== 0 || !donnerGetError().toLowerCase().includes('pixel buffer')) {
+  fail('render API did not reject an oversized pixel buffer: ' + donnerGetError());
+}
+
+const svgBytes = new TextEncoder().encode(SVG);
+const svgPtr = Module._malloc(svgBytes.byteLength);
+if (svgPtr === 0) {
+  fail('could not allocate SVG input');
+}
+Module.HEAPU8.set(svgBytes, svgPtr);
+const ptr = donnerRenderSvgLen(svgPtr, svgBytes.byteLength, width, height);
+Module._free(svgPtr);
 if (ptr === 0) {
   fail('donner_render_svg returned null: ' + donnerGetError());
 }

--- a/donner/svg/renderer/wasm/render_test_driver.mjs
+++ b/donner/svg/renderer/wasm/render_test_driver.mjs
@@ -21,20 +21,20 @@
 //   BYTES=<total>
 // Any failure prints a line beginning with "ERROR:" and exits non-zero.
 
-import { readFileSync } from 'node:fs';
-import { pathToFileURL } from 'node:url';
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 
 function fail(message) {
-  console.error('ERROR: ' + message);
+  console.error("ERROR: " + message);
   process.exit(2);
 }
 
 const [, , gluePath, wasmPath, widthArg, heightArg] = process.argv;
 if (!gluePath || !wasmPath) {
-  fail('usage: render_test_driver.mjs <glue.mjs> <module.wasm> [width] [height]');
+  fail("usage: render_test_driver.mjs <glue.mjs> <module.wasm> [width] [height]");
 }
-const width = Number.parseInt(widthArg ?? '64', 10);
-const height = Number.parseInt(heightArg ?? '64', 10);
+const width = Number.parseInt(widthArg ?? "64", 10);
+const height = Number.parseInt(heightArg ?? "64", 10);
 
 const SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
   <defs>
@@ -52,81 +52,81 @@ let wasmBinary;
 try {
   wasmBinary = readFileSync(wasmPath);
 } catch (err) {
-  fail('could not read wasm file ' + wasmPath + ': ' + err.message);
+  fail("could not read wasm file " + wasmPath + ": " + err.message);
 }
 
 let createModule;
 try {
   createModule = (await import(pathToFileURL(gluePath).href)).default;
 } catch (err) {
-  fail('could not import glue module ' + gluePath + ': ' + err.message);
+  fail("could not import glue module " + gluePath + ": " + err.message);
 }
-if (typeof createModule !== 'function') {
-  fail('glue module default export is not a factory function');
+if (typeof createModule !== "function") {
+  fail("glue module default export is not a factory function");
 }
 
 let Module;
 try {
   Module = await createModule({ wasmBinary, print: () => {}, printErr: () => {} });
 } catch (err) {
-  fail('module instantiation failed: ' + err.message);
+  fail("module instantiation failed: " + err.message);
 }
 
-for (const name of ['cwrap', 'HEAPU8', '_malloc', '_free']) {
+for (const name of ["cwrap", "HEAPU8", "_malloc", "_free"]) {
   if (Module[name] === undefined) {
-    fail('runtime method/view "' + name + '" is missing from the module (glue regression?)');
+    fail("runtime method/view \"" + name + "\" is missing from the module (glue regression?)");
   }
 }
 
-const donnerInit = Module.cwrap('donner_init', null, []);
-const donnerRenderSvg = Module.cwrap('donner_render_svg', 'number', ['string', 'number', 'number']);
+const donnerInit = Module.cwrap("donner_init", null, []);
+const donnerRenderSvg = Module.cwrap("donner_render_svg", "number", ["string", "number", "number"]);
 const donnerRenderSvgLen = Module.cwrap(
-  'donner_render_svg_len',
-  'number',
-  ['number', 'number', 'number', 'number'],
+  "donner_render_svg_len",
+  "number",
+  ["number", "number", "number", "number"],
 );
-const donnerFreePixels = Module.cwrap('donner_free_pixels', null, ['number']);
-const donnerGetError = Module.cwrap('donner_get_last_error', 'string', []);
+const donnerFreePixels = Module.cwrap("donner_free_pixels", null, ["number"]);
+const donnerGetError = Module.cwrap("donner_get_last_error", "string", []);
 
 donnerInit();
 
 const oversizedInput = Module._malloc(1);
 if (oversizedInput === 0) {
-  fail('could not allocate oversized-input sentinel');
+  fail("could not allocate oversized-input sentinel");
 }
 Module.HEAPU8[oversizedInput] = 0;
 const oversizedResult = donnerRenderSvgLen(oversizedInput, 16 * 1024 * 1024 + 1, 1, 1);
 Module._free(oversizedInput);
-if (oversizedResult !== 0 || !donnerGetError().includes('maximum input size')) {
-  fail('length-aware API did not reject oversized SVG before reading it: ' + donnerGetError());
+if (oversizedResult !== 0 || !donnerGetError().includes("maximum input size")) {
+  fail("length-aware API did not reject oversized SVG before reading it: " + donnerGetError());
 }
 
 const invalidRangeResult = donnerRenderSvgLen(Module.HEAPU8.byteLength - 1, 2, 1, 1);
-if (invalidRangeResult !== 0 || !donnerGetError().includes('outside WebAssembly memory')) {
-  fail('length-aware API did not reject an out-of-bounds input range: ' + donnerGetError());
+if (invalidRangeResult !== 0 || !donnerGetError().includes("outside WebAssembly memory")) {
+  fail("length-aware API did not reject an out-of-bounds input range: " + donnerGetError());
 }
 
-const oversizedPixels = donnerRenderSvg('<svg/>', 8192, 8192);
-if (oversizedPixels !== 0 || !donnerGetError().toLowerCase().includes('pixel buffer')) {
-  fail('render API did not reject an oversized pixel buffer: ' + donnerGetError());
+const oversizedPixels = donnerRenderSvg("<svg/>", 8192, 8192);
+if (oversizedPixels !== 0 || !donnerGetError().toLowerCase().includes("pixel buffer")) {
+  fail("render API did not reject an oversized pixel buffer: " + donnerGetError());
 }
 
 const svgBytes = new TextEncoder().encode(SVG);
 const svgPtr = Module._malloc(svgBytes.byteLength);
 if (svgPtr === 0) {
-  fail('could not allocate SVG input');
+  fail("could not allocate SVG input");
 }
 Module.HEAPU8.set(svgBytes, svgPtr);
 const ptr = donnerRenderSvgLen(svgPtr, svgBytes.byteLength, width, height);
 Module._free(svgPtr);
 if (ptr === 0) {
-  fail('donner_render_svg returned null: ' + donnerGetError());
+  fail("donner_render_svg returned null: " + donnerGetError());
 }
 
 const total = width * height * 4;
 const pixels = Module.HEAPU8.subarray(ptr, ptr + total);
 if (pixels.length !== total) {
-  fail('pixel view has wrong length: ' + pixels.length + ' != ' + total);
+  fail("pixel view has wrong length: " + pixels.length + " != " + total);
 }
 
 let hash = 0x811c9dc5;
@@ -138,6 +138,6 @@ for (let i = 0; i < pixels.length; i++) {
 }
 donnerFreePixels(ptr);
 
-console.log('HASH=' + hash.toString(16).padStart(8, '0'));
-console.log('NONZERO=' + nonZero + '/' + total);
-console.log('BYTES=' + total);
+console.log("HASH=" + hash.toString(16).padStart(8, "0"));
+console.log("NONZERO=" + nonZero + "/" + total);
+console.log("BYTES=" + total);

--- a/donner/svg/renderer/wasm/test-geode.html
+++ b/donner/svg/renderer/wasm/test-geode.html
@@ -146,7 +146,7 @@
     // Emscripten's ASYNCIFY runtime aborts with "The call to X is running
     // asynchronously. If this was intended, add the async option..."
     donnerGeodeInit      = Module.cwrap('donner_geode_init', null, [], { async: true });
-    donnerGeodeRenderSvg = Module.cwrap('donner_geode_render_svg', 'number', ['string', 'number', 'number'], { async: true });
+    donnerGeodeRenderSvg = Module.cwrap('donner_geode_render_svg_len', 'number', ['number', 'number', 'number', 'number'], { async: true });
     donnerFreePixels     = Module.cwrap('donner_free_pixels', null, ['number']);
     donnerGetError       = Module.cwrap('donner_get_last_error', 'string', []);
 
@@ -172,7 +172,33 @@
     await new Promise(r => requestAnimationFrame(() => setTimeout(r, 0)));
 
     const t0 = performance.now();
-    const ptr = await donnerGeodeRenderSvg(svgText, w, h);
+    if (svgText.length > 16 * 1024 * 1024) {
+      status.textContent = 'SVG exceeds maximum input size';
+      status.classList.add('error');
+      btn.disabled = false;
+      return;
+    }
+    const svgBytes = new TextEncoder().encode(svgText);
+    if (svgBytes.byteLength > 16 * 1024 * 1024) {
+      status.textContent = 'SVG exceeds maximum input size';
+      status.classList.add('error');
+      btn.disabled = false;
+      return;
+    }
+    const svgPtr = Module._malloc(Math.max(1, svgBytes.byteLength));
+    if (svgPtr === 0) {
+      status.textContent = 'Failed to allocate SVG input buffer';
+      status.classList.add('error');
+      btn.disabled = false;
+      return;
+    }
+    Module.HEAPU8.set(svgBytes, svgPtr);
+    let ptr;
+    try {
+      ptr = await donnerGeodeRenderSvg(svgPtr, svgBytes.byteLength, w, h);
+    } finally {
+      Module._free(svgPtr);
+    }
     const elapsed = (performance.now() - t0).toFixed(1);
 
     if (ptr === 0) {

--- a/donner/svg/renderer/wasm/test.html
+++ b/donner/svg/renderer/wasm/test.html
@@ -80,7 +80,7 @@
 
       // Wrap exported C functions.
       donnerInit       = Module.cwrap('donner_init', null, []);
-      donnerRenderSvg  = Module.cwrap('donner_render_svg', 'number', ['string', 'number', 'number']);
+      donnerRenderSvg  = Module.cwrap('donner_render_svg_len', 'number', ['number', 'number', 'number', 'number']);
       donnerFreePixels = Module.cwrap('donner_free_pixels', null, ['number']);
       donnerGetError   = Module.cwrap('donner_get_last_error', 'string', []);
 
@@ -102,7 +102,23 @@
     canvas.height = h;
 
     const t0 = performance.now();
-    const ptr = donnerRenderSvg(svgText, w, h);
+    if (svgText.length > 16 * 1024 * 1024) {
+      status.textContent = 'SVG exceeds maximum input size';
+      return;
+    }
+    const svgBytes = new TextEncoder().encode(svgText);
+    if (svgBytes.byteLength > 16 * 1024 * 1024) {
+      status.textContent = 'SVG exceeds maximum input size';
+      return;
+    }
+    const svgPtr = Module._malloc(Math.max(1, svgBytes.byteLength));
+    if (svgPtr === 0) {
+      status.textContent = 'Failed to allocate SVG input buffer';
+      return;
+    }
+    Module.HEAPU8.set(svgBytes, svgPtr);
+    const ptr = donnerRenderSvg(svgPtr, svgBytes.byteLength, w, h);
+    Module._free(svgPtr);
     const elapsed = (performance.now() - t0).toFixed(1);
 
     if (ptr === 0) {

--- a/donner/svg/renderer/wasm/wasm_bridge.cc
+++ b/donner/svg/renderer/wasm/wasm_bridge.cc
@@ -6,37 +6,32 @@
  * suitable for use from JavaScript via Emscripten's ccall/cwrap.
  */
 
+#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <string>
+#include <string_view>
 
 #include "donner/base/ParseWarningSink.h"
 #include "donner/svg/SVG.h"
 #include "donner/svg/renderer/Renderer.h"
+#include "donner/svg/renderer/wasm/WasmBridgeUtils.h"
 
 namespace {
 
 /// Stores the last error message for retrieval via donner_get_last_error().
 std::string gLastError;
 
-}  // namespace
+constexpr size_t kMaximumPixelBufferSize = 64 * 1024 * 1024;
 
-extern "C" {
-
-void donner_init() {
-  // No global initialization required; reserved for future use.
-}
-
-uint8_t* donner_render_svg(const char* svgText, int width, int height) {
+uint8_t* RenderSvg(std::string_view svgText, int width, int height) {
   using namespace donner;
   using namespace donner::svg;
   using namespace donner::svg::parser;
 
-  gLastError.clear();
-
-  if (svgText == nullptr) {
-    gLastError = "SVG text is null";
+  if (svgText.size() > SVGParser::kDefaultMaximumInputSize) {
+    gLastError = "SVG exceeds maximum input size";
     return nullptr;
   }
 
@@ -53,16 +48,14 @@ uint8_t* donner_render_svg(const char* svgText, int width, int height) {
   }
 
   const size_t area = static_cast<size_t>(width) * static_cast<size_t>(height);
-  if (area > SIZE_MAX / 4) {
-    gLastError = "Pixel buffer too large";
+  if (area > kMaximumPixelBufferSize / 4) {
+    gLastError = "Pixel buffer exceeds maximum size";
     return nullptr;
   }
   const size_t expectedBytes = area * 4;
 
-  // Parse the SVG document.
   ParseWarningSink warnings;
   ParseResult<SVGDocument> maybeDocument = SVGParser::ParseSVG(svgText, warnings);
-
   if (maybeDocument.hasError()) {
     gLastError = "Parse error: " + maybeDocument.error().reason.str();
     return nullptr;
@@ -71,16 +64,18 @@ uint8_t* donner_render_svg(const char* svgText, int width, int height) {
   SVGDocument document = std::move(maybeDocument.result());
   document.setCanvasSize(width, height);
 
-  // Render using the default backend (tiny-skia).
   Renderer renderer;
   renderer.draw(document);
 
-  // Take a snapshot to get RGBA pixel data.
   RendererBitmap bitmap = renderer.takeSnapshot();
-  if (bitmap.empty()) {
-    gLastError = "Rendering produced an empty bitmap";
+  const size_t dstRowBytes = static_cast<size_t>(width) * 4;
+  if (bitmap.empty() || bitmap.dimensions != Vector2i(width, height) ||
+      bitmap.rowBytes < dstRowBytes || bitmap.rowBytes > bitmap.pixels.size() ||
+      static_cast<size_t>(height) > bitmap.pixels.size() / bitmap.rowBytes) {
+    gLastError = "Rendering produced an invalid bitmap";
     return nullptr;
   }
+
   // NOLINTNEXTLINE: malloc is required for Emscripten interop - JS frees via donner_free_pixels.
   auto* pixels = static_cast<uint8_t*>(std::malloc(expectedBytes));
   if (pixels == nullptr) {
@@ -88,19 +83,54 @@ uint8_t* donner_render_svg(const char* svgText, int width, int height) {
     return nullptr;
   }
 
-  // Copy rows, handling potential stride differences between the renderer's
-  // rowBytes and the tightly-packed output expected by the caller.
-  const size_t dstRowBytes = static_cast<size_t>(width) * 4;
   for (int y = 0; y < height; ++y) {
     const size_t srcOffset = static_cast<size_t>(y) * bitmap.rowBytes;
     const size_t dstOffset = static_cast<size_t>(y) * dstRowBytes;
-    if (srcOffset + dstRowBytes > bitmap.pixels.size()) {
-      break;
-    }
     std::memcpy(pixels + dstOffset, bitmap.pixels.data() + srcOffset, dstRowBytes);
   }
-
   return pixels;
+}
+
+}  // namespace
+
+extern "C" {
+
+void donner_init() {
+  // No global initialization required; reserved for future use.
+}
+
+uint8_t* donner_render_svg(const char* svgText, int width, int height) {
+  gLastError.clear();
+
+  if (svgText == nullptr) {
+    gLastError = "SVG text is null";
+    return nullptr;
+  }
+
+  const auto length = donner::svg::wasm::BoundedCStringLength(
+      svgText, donner::svg::parser::SVGParser::kDefaultMaximumInputSize);
+  if (!length.has_value()) {
+    gLastError = "SVG text is outside WebAssembly memory";
+    return nullptr;
+  }
+  return RenderSvg(std::string_view(svgText, *length), width, height);
+}
+
+uint8_t* donner_render_svg_len(const char* svgText, size_t svgTextSize, int width, int height) {
+  gLastError.clear();
+  if (svgText == nullptr) {
+    gLastError = "SVG text is null";
+    return nullptr;
+  }
+  if (svgTextSize > donner::svg::parser::SVGParser::kDefaultMaximumInputSize) {
+    gLastError = "SVG exceeds maximum input size";
+    return nullptr;
+  }
+  if (!donner::svg::wasm::IsValidInputRange(svgText, svgTextSize)) {
+    gLastError = "SVG text is outside WebAssembly memory";
+    return nullptr;
+  }
+  return RenderSvg(std::string_view(svgText, svgTextSize), width, height);
 }
 
 void donner_free_pixels(uint8_t* pixels) {

--- a/donner/svg/renderer/wasm/wasm_bridge_geode.cc
+++ b/donner/svg/renderer/wasm/wasm_bridge_geode.cc
@@ -10,20 +10,25 @@
  * to the browser event loop).
  */
 
+#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <string>
+#include <string_view>
 
 #include "donner/base/ParseWarningSink.h"
 #include "donner/svg/SVG.h"
 #include "donner/svg/renderer/RendererGeode.h"
+#include "donner/svg/renderer/wasm/WasmBridgeUtils.h"
 
 namespace {
 
 /// Stores the last error message for retrieval via donner_get_last_error().
 std::string gLastError;
+
+constexpr size_t kMaximumPixelBufferSize = 64 * 1024 * 1024;
 
 }  // namespace
 
@@ -35,7 +40,8 @@ void donner_geode_init() {
   // and requires ASYNCIFY yield.
 }
 
-uint8_t* donner_geode_render_svg(const char* svgText, int width, int height) {
+uint8_t* donner_geode_render_svg_len(const char* svgText, size_t svgTextSize, int width,
+                                     int height) {
   using namespace donner;
   using namespace donner::svg;
   using namespace donner::svg::parser;
@@ -46,6 +52,14 @@ uint8_t* donner_geode_render_svg(const char* svgText, int width, int height) {
 
   if (svgText == nullptr) {
     gLastError = "SVG text is null";
+    return nullptr;
+  }
+  if (svgTextSize > SVGParser::kDefaultMaximumInputSize) {
+    gLastError = "SVG exceeds maximum input size";
+    return nullptr;
+  }
+  if (!donner::svg::wasm::IsValidInputRange(svgText, svgTextSize)) {
+    gLastError = "SVG text is outside WebAssembly memory";
     return nullptr;
   }
 
@@ -62,16 +76,17 @@ uint8_t* donner_geode_render_svg(const char* svgText, int width, int height) {
   }
 
   const size_t area = static_cast<size_t>(width) * static_cast<size_t>(height);
-  if (area > SIZE_MAX / 4) {
-    gLastError = "Pixel buffer too large";
+  if (area > kMaximumPixelBufferSize / 4) {
+    gLastError = "Pixel buffer exceeds maximum size";
     return nullptr;
   }
   const size_t expectedBytes = area * 4;
 
   // Parse the SVG document.
-  std::cerr << "[wasm] parsing SVG (" << std::strlen(svgText) << " bytes)" << std::endl;
+  std::cerr << "[wasm] parsing SVG (" << svgTextSize << " bytes)" << std::endl;
   ParseWarningSink warnings;
-  ParseResult<SVGDocument> maybeDocument = SVGParser::ParseSVG(svgText, warnings);
+  ParseResult<SVGDocument> maybeDocument =
+      SVGParser::ParseSVG(std::string_view(svgText, svgTextSize), warnings);
 
   if (maybeDocument.hasError()) {
     gLastError = "Parse error: " + maybeDocument.error().reason.str();
@@ -97,8 +112,11 @@ uint8_t* donner_geode_render_svg(const char* svgText, int width, int height) {
   RendererBitmap bitmap = renderer.takeSnapshot();
   std::cerr << "[wasm] takeSnapshot() returned; pixels.size=" << bitmap.pixels.size()
             << " rowBytes=" << bitmap.rowBytes << std::endl;
-  if (bitmap.empty()) {
-    gLastError = "Rendering produced an empty bitmap";
+  const size_t dstRowBytes = static_cast<size_t>(width) * 4;
+  if (bitmap.empty() || bitmap.dimensions != Vector2i(width, height) ||
+      bitmap.rowBytes < dstRowBytes || bitmap.rowBytes > bitmap.pixels.size() ||
+      static_cast<size_t>(height) > bitmap.pixels.size() / bitmap.rowBytes) {
+    gLastError = "Rendering produced an invalid bitmap";
     return nullptr;
   }
 
@@ -111,17 +129,28 @@ uint8_t* donner_geode_render_svg(const char* svgText, int width, int height) {
 
   // Copy rows, handling potential stride differences between the renderer's
   // rowBytes and the tightly-packed output expected by the caller.
-  const size_t dstRowBytes = static_cast<size_t>(width) * 4;
   for (int y = 0; y < height; ++y) {
     const size_t srcOffset = static_cast<size_t>(y) * bitmap.rowBytes;
     const size_t dstOffset = static_cast<size_t>(y) * dstRowBytes;
-    if (srcOffset + dstRowBytes > bitmap.pixels.size()) {
-      break;
-    }
     std::memcpy(pixels + dstOffset, bitmap.pixels.data() + srcOffset, dstRowBytes);
   }
 
   return pixels;
+}
+
+uint8_t* donner_geode_render_svg(const char* svgText, int width, int height) {
+  if (svgText == nullptr) {
+    gLastError = "SVG text is null";
+    return nullptr;
+  }
+
+  const auto length = donner::svg::wasm::BoundedCStringLength(
+      svgText, donner::svg::parser::SVGParser::kDefaultMaximumInputSize);
+  if (!length.has_value()) {
+    gLastError = "SVG text is outside WebAssembly memory";
+    return nullptr;
+  }
+  return donner_geode_render_svg_len(svgText, *length, width, height);
 }
 
 void donner_free_pixels(uint8_t* pixels) {

--- a/donner/svg/resources/BUILD.bazel
+++ b/donner/svg/resources/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//build_defs:rules.bzl", "donner_cc_fuzzer", "donner_cc_library", "donner_cc_test")
 load("//build_defs:package.bzl", "donner_package")
+load("//build_defs:rules.bzl", "donner_cc_fuzzer", "donner_cc_library", "donner_cc_test")
 
 donner_cc_library(
     name = "sandboxed_file_resource_loader",
@@ -10,6 +10,13 @@ donner_cc_library(
         ":resource_loader_interface",
         "//donner/base",
     ],
+)
+
+donner_cc_fuzzer(
+    name = "sandboxed_file_resource_loader_structured_fuzzer",
+    srcs = ["tests/SandboxedFileResourceLoader_structured_fuzzer.cc"],
+    corpus = "tests/sandboxed_file_resource_loader_structured_corpus",
+    deps = [":sandboxed_file_resource_loader"],
 )
 
 donner_cc_library(
@@ -233,6 +240,13 @@ donner_cc_test(
         "//donner/base:base_test_utils",
         "@com_google_gtest//:gtest_main",
     ],
+)
+
+donner_cc_fuzzer(
+    name = "url_loader_structured_fuzzer",
+    srcs = ["tests/UrlLoader_structured_fuzzer.cc"],
+    corpus = "tests/url_loader_structured_corpus",
+    deps = [":url_loader"],
 )
 
 donner_cc_test(

--- a/donner/svg/resources/ImageLoader.cc
+++ b/donner/svg/resources/ImageLoader.cc
@@ -2,6 +2,7 @@
 
 #include <stb/stb_image.h>
 
+#include <algorithm>
 #include <limits>
 #include <optional>
 
@@ -10,7 +11,6 @@ namespace donner::svg {
 namespace {
 
 constexpr int kMaxImageDimension = 16384;
-constexpr size_t kMaxDecodedImageBytes = 256u * 1024u * 1024u;
 
 /// Detect if file contents look like SVG (XML starting with '<') or SVGZ (gzip magic bytes).
 bool LooksLikeSvgContent(const std::vector<uint8_t>& data) {
@@ -76,7 +76,7 @@ std::optional<size_t> RgbaByteSize(int width, int height) {
   const size_t widthSize = static_cast<size_t>(width);
   const size_t heightSize = static_cast<size_t>(height);
 
-  if (widthSize > kMaxDecodedImageBytes / heightSize / kRgbaChannels) {
+  if (widthSize > std::numeric_limits<size_t>::max() / heightSize / kRgbaChannels) {
     return std::nullopt;
   }
 
@@ -84,7 +84,8 @@ std::optional<size_t> RgbaByteSize(int width, int height) {
 }
 
 std::variant<ImageResource, UrlLoaderError> LoadImage(std::string_view mimeType,
-                                                      const std::vector<uint8_t>& fileContents) {
+                                                      const std::vector<uint8_t>& fileContents,
+                                                      size_t maximumDecodedImageSize) {
   // Allow known formats and an empty mime type (stb_image will auto-detect)
   if (mimeType != "" && mimeType != "image/png" && mimeType != "image/jpeg" &&
       mimeType != "image/jpg" && mimeType != "image/gif") {
@@ -118,6 +119,9 @@ std::variant<ImageResource, UrlLoaderError> LoadImage(std::string_view mimeType,
   if (!dataSize.has_value()) {
     return UrlLoaderError::DataCorrupt;
   }
+  if (*dataSize > maximumDecodedImageSize) {
+    return UrlLoaderError::ResourceTooLarge;
+  }
 
   uint8_t* data =
       stbi_load_from_memory(reinterpret_cast<const unsigned char*>(
@@ -130,6 +134,10 @@ std::variant<ImageResource, UrlLoaderError> LoadImage(std::string_view mimeType,
   if (!loadedDataSize.has_value()) {
     stbi_image_free(data);
     return UrlLoaderError::DataCorrupt;
+  }
+  if (*loadedDataSize > maximumDecodedImageSize) {
+    stbi_image_free(data);
+    return UrlLoaderError::ResourceTooLarge;
   }
 
   ImageResource result;
@@ -159,11 +167,20 @@ ImageLoader::Result ImageLoader::fromUri(std::string_view uri) {
     return SvgImageContent{std::move(urlResult.data)};
   }
 
-  auto rasterResult = LoadImage(urlResult.mimeType, urlResult.data);
+  const size_t remainingDecodedBytes =
+      remainingResourceBytes_ != nullptr ? *remainingResourceBytes_ : maximumDecodedImageSize_;
+  const size_t decodedLimit = std::min(maximumDecodedImageSize_, remainingDecodedBytes);
+  auto rasterResult = LoadImage(urlResult.mimeType, urlResult.data, decodedLimit);
   if (std::holds_alternative<UrlLoaderError>(rasterResult)) {
     return std::get<UrlLoaderError>(rasterResult);
   }
-  return std::get<ImageResource>(std::move(rasterResult));
+
+  ImageResource result = std::get<ImageResource>(std::move(rasterResult));
+  if (remainingResourceBytes_ != nullptr) {
+    // LoadImage checked this against the current budget before asking stb_image to allocate.
+    *remainingResourceBytes_ -= result.data.size();
+  }
+  return result;
 }
 
 }  // namespace donner::svg

--- a/donner/svg/resources/ImageLoader.cc
+++ b/donner/svg/resources/ImageLoader.cc
@@ -172,7 +172,11 @@ ImageLoader::Result ImageLoader::fromUri(std::string_view uri) {
   const size_t decodedLimit = std::min(maximumDecodedImageSize_, remainingDecodedBytes);
   auto rasterResult = LoadImage(urlResult.mimeType, urlResult.data, decodedLimit);
   if (std::holds_alternative<UrlLoaderError>(rasterResult)) {
-    return std::get<UrlLoaderError>(rasterResult);
+    const UrlLoaderError error = std::get<UrlLoaderError>(rasterResult);
+    if (error == UrlLoaderError::ResourceTooLarge && remainingResourceBytes_ != nullptr) {
+      *remainingResourceBytes_ = 0;
+    }
+    return error;
   }
 
   ImageResource result = std::get<ImageResource>(std::move(rasterResult));

--- a/donner/svg/resources/ImageLoader.h
+++ b/donner/svg/resources/ImageLoader.h
@@ -22,6 +22,9 @@ struct SvgImageContent {
  */
 class ImageLoader {
 public:
+  /// Default maximum number of decoded RGBA bytes for one raster image.
+  static constexpr size_t kDefaultMaximumDecodedImageSize = 64 * 1024 * 1024;
+
   /// Result type returned by \ref fromUri. Contains either decoded raster pixels, raw SVG content,
   /// or an error.
   using Result = std::variant<ImageResource, SvgImageContent, UrlLoaderError>;
@@ -31,7 +34,13 @@ public:
    *
    * @param resourceLoader Resource loader to use for fetching external resources.
    */
-  explicit ImageLoader(ResourceLoaderInterface& resourceLoader) : urlLoader_(resourceLoader) {}
+  explicit ImageLoader(ResourceLoaderInterface& resourceLoader,
+                       size_t maximumResourceSize = UrlLoader::kDefaultMaximumResourceSize,
+                       size_t* remainingResourceBytes = nullptr,
+                       size_t maximumDecodedImageSize = kDefaultMaximumDecodedImageSize)
+      : urlLoader_(resourceLoader, maximumResourceSize, remainingResourceBytes),
+        remainingResourceBytes_(remainingResourceBytes),
+        maximumDecodedImageSize_(maximumDecodedImageSize) {}
 
   /// Destructor.
   ~ImageLoader() = default;
@@ -57,6 +66,12 @@ public:
 private:
   /// Loader used for decoding the data URL or fetching the external resources.
   UrlLoader urlLoader_;
+
+  /// Optional shared byte budget for raw and decoded resources in one document.
+  size_t* remainingResourceBytes_;
+
+  /// Maximum decoded RGBA bytes returned for one raster image.
+  size_t maximumDecodedImageSize_;
 };
 
 }  // namespace donner::svg

--- a/donner/svg/resources/ResourceLoaderInterface.h
+++ b/donner/svg/resources/ResourceLoaderInterface.h
@@ -13,7 +13,19 @@ enum class ResourceLoaderError : uint8_t {
   NotFound,          //!< File not found.
   SandboxViolation,  //!< File access violation, such as attempting to access a file outside the
                      //!< sandbox.
+  TooLarge,          //!< Resource exceeds the configured byte limit.
 };
+
+/// Convert a resource-loader error to a stable human-readable string.
+inline std::string_view ToString(ResourceLoaderError error) {
+  switch (error) {
+    case ResourceLoaderError::NotFound: return "not found";
+    case ResourceLoaderError::SandboxViolation: return "sandbox violation";
+    case ResourceLoaderError::TooLarge: return "resource too large";
+  }
+
+  return "unknown resource error";
+}
 
 /**
  * Interface for loading external resources, such as images. To load files from the local

--- a/donner/svg/resources/SandboxedFileResourceLoader.cc
+++ b/donner/svg/resources/SandboxedFileResourceLoader.cc
@@ -15,22 +15,29 @@ namespace {
 
 bool IsPathUnderRoot(const std::filesystem::path& root, const std::filesystem::path& path) {
   assert(root.is_absolute());
-  const std::filesystem::path absRoot = root.lexically_normal();
-  const std::filesystem::path absPath = std::filesystem::absolute(path).lexically_normal();
+  assert(path.is_absolute());
 
-  return absPath.string().find(absRoot.string()) == 0;
+  auto rootIt = root.begin();
+  auto pathIt = path.begin();
+  for (; rootIt != root.end() && pathIt != path.end(); ++rootIt, ++pathIt) {
+    if (*rootIt != *pathIt) {
+      return false;
+    }
+  }
+  return rootIt == root.end();
 }
 
 }  // namespace
 
 SandboxedFileResourceLoader::SandboxedFileResourceLoader(const std::filesystem::path& root,
-                                                         const std::filesystem::path& documentPath)
-    : root_(root), documentPath_(documentPath) {
+                                                         const std::filesystem::path& documentPath,
+                                                         size_t maximumResourceSize)
+    : root_(root), documentPath_(documentPath), maximumResourceSize_(maximumResourceSize) {
   UTILS_RELEASE_ASSERT_MSG(std::filesystem::is_directory(root_), "Root directory does not exist");
 
-  root_ = std::filesystem::absolute(root_);
-  documentPath_ = std::filesystem::absolute(documentPath);
-  documentPath_ = documentPath_.parent_path();
+  root_ = std::filesystem::canonical(root_);
+  documentPath_ =
+      std::filesystem::weakly_canonical(std::filesystem::absolute(documentPath)).parent_path();
 }
 
 std::variant<std::vector<uint8_t>, ResourceLoaderError>
@@ -41,31 +48,44 @@ SandboxedFileResourceLoader::fetchExternalResource(std::string_view url) {
     path = documentPath_ / path;
   }
 
+  std::error_code canonicalError;
+  path = std::filesystem::canonical(path, canonicalError);
+  if (canonicalError) {
+    return ResourceLoaderError::NotFound;
+  }
+
   if (!IsPathUnderRoot(root_, path)) {
     return ResourceLoaderError::SandboxViolation;
   }
 
-  // Validated, now read the file.
-  std::ifstream file(path, std::ios::binary);
-  if (!file.is_open() || !std::filesystem::is_regular_file(path)) {
+  std::error_code statusError;
+  if (!std::filesystem::is_regular_file(path, statusError) || statusError) {
     return ResourceLoaderError::NotFound;
   }
 
-  // Read the file into a vector.
-  file.seekg(0, std::ios::end);
+  const uintmax_t fileSize = std::filesystem::file_size(path, statusError);
+  if (statusError || fileSize > std::numeric_limits<size_t>::max()) {
+    return ResourceLoaderError::NotFound;
+  }
+  if (fileSize > maximumResourceSize_) {
+    return ResourceLoaderError::TooLarge;
+  }
+
+  // Open the canonical path rather than the attacker-controlled symlink path.
+  std::ifstream file(path, std::ios::binary);
+  if (!file.is_open()) {
+    return ResourceLoaderError::NotFound;
+  }
 
   std::vector<uint8_t> data;
-  const std::streamsize fileSize = file.tellg();
-  if (fileSize < 0 ||
-      static_cast<uint64_t>(fileSize) > static_cast<uint64_t>(std::numeric_limits<size_t>::max())) {
+  data.resize(static_cast<size_t>(fileSize));
+  file.read(reinterpret_cast<char*>(data.data()),
+            static_cast<std::streamsize>(fileSize));  // NOLINT
+  if (file.bad() || file.gcount() != static_cast<std::streamsize>(fileSize)) {
     return ResourceLoaderError::NotFound;
   }
-
-  data.resize(static_cast<size_t>(fileSize));
-  file.seekg(0, std::ios::beg);
-  file.read(reinterpret_cast<char*>(data.data()), fileSize);  // NOLINT, allow reinterpret_cast.
-  if (file.bad() || file.gcount() != fileSize) {
-    return ResourceLoaderError::NotFound;
+  if (file.peek() != std::char_traits<char>::eof()) {
+    return ResourceLoaderError::TooLarge;
   }
 
   return data;

--- a/donner/svg/resources/SandboxedFileResourceLoader.h
+++ b/donner/svg/resources/SandboxedFileResourceLoader.h
@@ -1,6 +1,7 @@
 #pragma once
 /// @file
 
+#include <cstddef>
 #include <filesystem>
 
 #include "donner/svg/resources/ResourceLoaderInterface.h"
@@ -12,6 +13,9 @@ namespace donner::svg {
  */
 class SandboxedFileResourceLoader : public ResourceLoaderInterface {
 public:
+  /// Default maximum size of one external resource.
+  static constexpr size_t kDefaultMaximumResourceSize = 16 * 1024 * 1024;
+
   /**
    * Create a new resource loader that loads files sandboxed within the given root directory.
    *
@@ -20,9 +24,11 @@ public:
    *
    * @param root Sandbox directory, loads outside of this directory will be rejected.
    * @param documentPath Path to the document being loaded, used to resolve relative paths.
+   * @param maximumResourceSize Maximum number of bytes read from one resource.
    */
   explicit SandboxedFileResourceLoader(const std::filesystem::path& root,
-                                       const std::filesystem::path& documentPath);
+                                       const std::filesystem::path& documentPath,
+                                       size_t maximumResourceSize = kDefaultMaximumResourceSize);
 
   // No copy or move.
   SandboxedFileResourceLoader(const SandboxedFileResourceLoader&) = delete;
@@ -45,6 +51,7 @@ public:
 private:
   std::filesystem::path root_;          //!< Root directory of the sandbox.
   std::filesystem::path documentPath_;  //!< Path to the document being loaded.
+  size_t maximumResourceSize_;          //!< Maximum bytes accepted from one resource.
 };
 
 }  // namespace donner::svg

--- a/donner/svg/resources/UrlLoader.cc
+++ b/donner/svg/resources/UrlLoader.cc
@@ -66,6 +66,9 @@ std::string MimeTypeFromUrl(std::string_view url) {
 bool UrlLoader::consumeResourceBytes(size_t size) {
   if (size > maximumResourceSize_ ||
       (remainingResourceBytes_ != nullptr && size > *remainingResourceBytes_)) {
+    if (remainingResourceBytes_ != nullptr) {
+      *remainingResourceBytes_ = 0;
+    }
     return false;
   }
 
@@ -76,13 +79,21 @@ bool UrlLoader::consumeResourceBytes(size_t size) {
 }
 
 std::variant<UrlLoader::Result, UrlLoaderError> UrlLoader::fromUri(std::string_view uri) {
+  if (remainingResourceBytes_ != nullptr && *remainingResourceBytes_ == 0) {
+    return UrlLoaderError::ResourceTooLarge;
+  }
+
   Result result;
 
   std::variant<DataUrlParser::Result, DataUrlParserError> maybeParsedUrl =
       DataUrlParser::Parse(uri);
 
   if (std::holds_alternative<DataUrlParserError>(maybeParsedUrl)) {
-    return MapError(std::get<DataUrlParserError>(maybeParsedUrl));
+    const UrlLoaderError error = MapError(std::get<DataUrlParserError>(maybeParsedUrl));
+    if (error == UrlLoaderError::ResourceTooLarge && remainingResourceBytes_ != nullptr) {
+      *remainingResourceBytes_ = 0;
+    }
+    return error;
   }
 
   DataUrlParser::Result& parsedUrl = std::get<DataUrlParser::Result>(maybeParsedUrl);
@@ -100,7 +111,11 @@ std::variant<UrlLoader::Result, UrlLoaderError> UrlLoader::fromUri(std::string_v
     // It's an external URL, fetch it.
     auto maybeLoadedData = resourceLoader_.fetchExternalResource(url);
     if (std::holds_alternative<ResourceLoaderError>(maybeLoadedData)) {
-      return MapError(std::get<ResourceLoaderError>(maybeLoadedData));
+      const UrlLoaderError error = MapError(std::get<ResourceLoaderError>(maybeLoadedData));
+      if (error == UrlLoaderError::ResourceTooLarge && remainingResourceBytes_ != nullptr) {
+        *remainingResourceBytes_ = 0;
+      }
+      return error;
     }
 
     result.data = std::get<std::vector<uint8_t>>(std::move(maybeLoadedData));

--- a/donner/svg/resources/UrlLoader.cc
+++ b/donner/svg/resources/UrlLoader.cc
@@ -10,14 +10,20 @@ using parser::DataUrlParserError;
 
 namespace {
 
-UrlLoaderError MapError([[maybe_unused]] ResourceLoaderError error) {
-  // Map all errors to NotFound for now.
-  return UrlLoaderError::NotFound;
+UrlLoaderError MapError(ResourceLoaderError error) {
+  switch (error) {
+    case ResourceLoaderError::TooLarge: return UrlLoaderError::ResourceTooLarge;
+    case ResourceLoaderError::NotFound:
+    case ResourceLoaderError::SandboxViolation: return UrlLoaderError::NotFound;
+  }
+
+  UTILS_UNREACHABLE();
 }
 
 UrlLoaderError MapError(DataUrlParserError error) {
   switch (error) {
     case DataUrlParserError::InvalidDataUrl: return UrlLoaderError::InvalidDataUrl;
+    case DataUrlParserError::InputTooLarge: return UrlLoaderError::ResourceTooLarge;
   }
 
   UTILS_UNREACHABLE();
@@ -57,6 +63,18 @@ std::string MimeTypeFromUrl(std::string_view url) {
 
 }  // namespace
 
+bool UrlLoader::consumeResourceBytes(size_t size) {
+  if (size > maximumResourceSize_ ||
+      (remainingResourceBytes_ != nullptr && size > *remainingResourceBytes_)) {
+    return false;
+  }
+
+  if (remainingResourceBytes_ != nullptr) {
+    *remainingResourceBytes_ -= size;
+  }
+  return true;
+}
+
 std::variant<UrlLoader::Result, UrlLoaderError> UrlLoader::fromUri(std::string_view uri) {
   Result result;
 
@@ -71,6 +89,9 @@ std::variant<UrlLoader::Result, UrlLoaderError> UrlLoader::fromUri(std::string_v
 
   if (parsedUrl.kind == DataUrlParser::Result::Kind::Data) {
     result.data = std::move(std::get<std::vector<uint8_t>>(parsedUrl.payload));
+    if (!consumeResourceBytes(result.data.size())) {
+      return UrlLoaderError::ResourceTooLarge;
+    }
     result.mimeType = parsedUrl.mimeType;
     return result;
   } else {
@@ -82,7 +103,10 @@ std::variant<UrlLoader::Result, UrlLoaderError> UrlLoader::fromUri(std::string_v
       return MapError(std::get<ResourceLoaderError>(maybeLoadedData));
     }
 
-    result.data = std::get<std::vector<uint8_t>>(maybeLoadedData);
+    result.data = std::get<std::vector<uint8_t>>(std::move(maybeLoadedData));
+    if (!consumeResourceBytes(result.data.size())) {
+      return UrlLoaderError::ResourceTooLarge;
+    }
     result.mimeType = MimeTypeFromUrl(url);
   }
 

--- a/donner/svg/resources/UrlLoader.h
+++ b/donner/svg/resources/UrlLoader.h
@@ -1,6 +1,7 @@
 #pragma once
 /// @file
 
+#include <cstddef>
 #include <string>
 
 #include "donner/base/Utils.h"
@@ -17,6 +18,7 @@ enum class UrlLoaderError : uint8_t {
                       ///< "image/png" or "image/jpeg").
   InvalidDataUrl,     ///< The data URL is invalid.
   DataCorrupt,        ///< The loaded data is corrupt and cannot be decoded.
+  ResourceTooLarge,   ///< The loaded or decoded resource exceeds the byte limit.
 };
 
 /// Converts a \ref UrlLoaderError to a human-readable string.
@@ -26,6 +28,7 @@ inline std::string_view ToString(UrlLoaderError err) {
     case UrlLoaderError::UnsupportedFormat: return "Unsupported format";
     case UrlLoaderError::InvalidDataUrl: return "Invalid data URL";
     case UrlLoaderError::DataCorrupt: return "Data corrupted";
+    case UrlLoaderError::ResourceTooLarge: return "Resource too large";
   }
 
   UTILS_UNREACHABLE();
@@ -41,6 +44,9 @@ inline std::ostream& operator<<(std::ostream& os, UrlLoaderError err) {
  */
 class UrlLoader {
 public:
+  /// Default maximum decoded or fetched resource size.
+  static constexpr size_t kDefaultMaximumResourceSize = 16 * 1024 * 1024;
+
   /**
    * Result of loading a URI or decoding a data URL.
    */
@@ -57,7 +63,12 @@ public:
    *
    * @param resourceLoader Resource loader to use for fetching external resources.
    */
-  explicit UrlLoader(ResourceLoaderInterface& resourceLoader) : resourceLoader_(resourceLoader) {}
+  explicit UrlLoader(ResourceLoaderInterface& resourceLoader,
+                     size_t maximumResourceSize = kDefaultMaximumResourceSize,
+                     size_t* remainingResourceBytes = nullptr)
+      : resourceLoader_(resourceLoader),
+        maximumResourceSize_(maximumResourceSize),
+        remainingResourceBytes_(remainingResourceBytes) {}
 
   /// Destructor.
   ~UrlLoader() = default;
@@ -78,8 +89,16 @@ public:
   std::variant<Result, UrlLoaderError> fromUri(std::string_view uri);
 
 private:
+  bool consumeResourceBytes(size_t size);
+
   /// Resource loader to use for fetching external resources.
   ResourceLoaderInterface& resourceLoader_;  // NOLINT
+
+  /// Maximum decoded or fetched bytes returned to the caller.
+  size_t maximumResourceSize_;
+
+  /// Optional shared byte budget across multiple loaders in one document.
+  size_t* remainingResourceBytes_;
 };
 
 }  // namespace donner::svg

--- a/donner/svg/resources/tests/ImageLoader_fuzzer.cc
+++ b/donner/svg/resources/tests/ImageLoader_fuzzer.cc
@@ -1,11 +1,13 @@
-#include "donner/svg/resources/ImageLoader.h"
-
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
+#include <limits>
 #include <string_view>
 #include <utility>
 #include <variant>
 #include <vector>
+
+#include "donner/svg/resources/ImageLoader.h"
 
 namespace donner::svg {
 
@@ -33,14 +35,29 @@ private:
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   std::vector<uint8_t> bytes(data, data + size);
 
-  FuzzResourceLoader loader(bytes);
-  ImageLoader imageLoader(loader);
+  size_t maximumDecodedImageSize = ImageLoader::kDefaultMaximumDecodedImageSize;
+  if (size >= 2 && (data[size - 1] & 1u) != 0) {
+    maximumDecodedImageSize = 4u * (static_cast<size_t>(data[size - 2]) + 1u);
+  }
 
-  // Use a fixed URL with a raster image extension. stb_image auto-detects the actual format
-  // from the file's magic bytes regardless of the extension hint, so this exercises PNG, JPEG,
-  // GIF, BMP, and other stb-supported decoders on arbitrary fuzz bytes.
+  FuzzResourceLoader loader(bytes);
+  const bool canAccountInput = size <= UrlLoader::kDefaultMaximumResourceSize &&
+                               size <= std::numeric_limits<size_t>::max() - maximumDecodedImageSize;
+  size_t remainingResourceBytes =
+      canAccountInput ? size + maximumDecodedImageSize : maximumDecodedImageSize;
+  ImageLoader imageLoader(loader, UrlLoader::kDefaultMaximumResourceSize, &remainingResourceBytes,
+                          maximumDecodedImageSize);
+
+  // Use a fixed URL with a raster image extension. The parser gates supported magic bytes before
+  // stb_image, so this exercises the PNG, JPEG, and GIF decoders on arbitrary fuzz bytes.
   auto result = imageLoader.fromUri("fuzz-input.png");
-  (void)result;
+  if (std::holds_alternative<ImageResource>(result)) {
+    const ImageResource& image = std::get<ImageResource>(result);
+    if (image.data.size() > maximumDecodedImageSize || !canAccountInput ||
+        remainingResourceBytes != maximumDecodedImageSize - image.data.size()) {
+      std::abort();
+    }
+  }
 
   return 0;
 }

--- a/donner/svg/resources/tests/ImageLoader_tests.cc
+++ b/donner/svg/resources/tests/ImageLoader_tests.cc
@@ -227,7 +227,7 @@ TEST(ImageLoader, ChargesRawAndDecodedBytesToSharedBudget) {
     ImageLoader imageLoader(resourceLoader, UrlLoader::kDefaultMaximumResourceSize,
                             &remainingBytes);
     ExpectImageLoaderError(imageLoader.fromUri("one-pixel.png"), UrlLoaderError::ResourceTooLarge);
-    EXPECT_EQ(remainingBytes, 3u);
+    EXPECT_EQ(remainingBytes, 0u);
   }
 
   {

--- a/donner/svg/resources/tests/ImageLoader_tests.cc
+++ b/donner/svg/resources/tests/ImageLoader_tests.cc
@@ -70,9 +70,9 @@ TEST(ImageLoader, RejectsMagiclessTgaDecodeBomb) {
   // bytes, so stb auto-detects it and its decoder iterates the full declared
   // pixel grid regardless of input size (CPU-exhaustion decode-bomb). Only
   // PNG/JPEG/GIF are supported, so this must be rejected before any decode.
-  StaticResourceLoader resourceLoader(std::vector<uint8_t>{0x00, 0x00, 0x03, 0x00, 0x00, 0x00,
-                                                           0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                                           0x40, 0x1F, 0x40, 0x1F, 0x08, 0x00});
+  StaticResourceLoader resourceLoader(std::vector<uint8_t>{0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00,
+                                                           0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x1F,
+                                                           0x40, 0x1F, 0x08, 0x00});
   ImageLoader imageLoader(resourceLoader);
 
   ImageLoader::Result result = imageLoader.fromUri("bomb");
@@ -184,7 +184,7 @@ TEST(ImageLoader, RejectsPngHeadersWithInvalidDimensions) {
   {
     StaticResourceLoader resourceLoader(PngHeaderWithDimensions(16384, 16384));
     ImageLoader imageLoader(resourceLoader);
-    ExpectImageLoaderError(imageLoader.fromUri("too-large.png"), UrlLoaderError::DataCorrupt);
+    ExpectImageLoaderError(imageLoader.fromUri("too-large.png"), UrlLoaderError::ResourceTooLarge);
   }
   {
     StaticResourceLoader resourceLoader(PngHeaderWithDimensions(0, 1));
@@ -195,6 +195,48 @@ TEST(ImageLoader, RejectsPngHeadersWithInvalidDimensions) {
     StaticResourceLoader resourceLoader(PngHeaderWithDimensions(1, 0));
     ImageLoader imageLoader(resourceLoader);
     ExpectImageLoaderError(imageLoader.fromUri("zero-height.png"), UrlLoaderError::DataCorrupt);
+  }
+}
+
+TEST(ImageLoader, RejectsDecodedImageBeforeAllocationWhenOverConfiguredLimit) {
+  const std::vector<uint8_t> png = {
+      0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48,
+      0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x04, 0x00, 0x00,
+      0x00, 0xB5, 0x1C, 0x0C, 0x02, 0x00, 0x00, 0x00, 0x0B, 0x49, 0x44, 0x41, 0x54, 0x78,
+      0xDA, 0x63, 0xFC, 0xFF, 0x1F, 0x00, 0x03, 0x03, 0x02, 0x00, 0xEF, 0xBF, 0xA7, 0xDB,
+      0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+  };
+  StaticResourceLoader resourceLoader(png);
+  ImageLoader imageLoader(resourceLoader, UrlLoader::kDefaultMaximumResourceSize, nullptr, 3);
+
+  ExpectImageLoaderError(imageLoader.fromUri("one-pixel.png"), UrlLoaderError::ResourceTooLarge);
+}
+
+TEST(ImageLoader, ChargesRawAndDecodedBytesToSharedBudget) {
+  const std::vector<uint8_t> png = {
+      0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48,
+      0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x04, 0x00, 0x00,
+      0x00, 0xB5, 0x1C, 0x0C, 0x02, 0x00, 0x00, 0x00, 0x0B, 0x49, 0x44, 0x41, 0x54, 0x78,
+      0xDA, 0x63, 0xFC, 0xFF, 0x1F, 0x00, 0x03, 0x03, 0x02, 0x00, 0xEF, 0xBF, 0xA7, 0xDB,
+      0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+  };
+
+  {
+    StaticResourceLoader resourceLoader(png);
+    size_t remainingBytes = png.size() + 3;
+    ImageLoader imageLoader(resourceLoader, UrlLoader::kDefaultMaximumResourceSize,
+                            &remainingBytes);
+    ExpectImageLoaderError(imageLoader.fromUri("one-pixel.png"), UrlLoaderError::ResourceTooLarge);
+    EXPECT_EQ(remainingBytes, 3u);
+  }
+
+  {
+    StaticResourceLoader resourceLoader(png);
+    size_t remainingBytes = png.size() + 4;
+    ImageLoader imageLoader(resourceLoader, UrlLoader::kDefaultMaximumResourceSize,
+                            &remainingBytes);
+    ASSERT_TRUE(std::holds_alternative<ImageResource>(imageLoader.fromUri("one-pixel.png")));
+    EXPECT_EQ(remainingBytes, 0u);
   }
 }
 

--- a/donner/svg/resources/tests/SandboxedFileResourceLoader_structured_fuzzer.cc
+++ b/donner/svg/resources/tests/SandboxedFileResourceLoader_structured_fuzzer.cc
@@ -1,0 +1,93 @@
+#include <fuzzer/FuzzedDataProvider.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+#include "donner/svg/resources/SandboxedFileResourceLoader.h"
+
+namespace donner::svg {
+namespace {
+
+class SandboxFixture {
+public:
+  SandboxFixture() {
+    const char* testTmpDir = std::getenv("TEST_TMPDIR");
+    const std::filesystem::path temporaryRoot =
+        testTmpDir != nullptr ? testTmpDir : std::filesystem::temp_directory_path();
+    base_ = temporaryRoot /
+            ("donner-resource-fuzzer-" + std::to_string(reinterpret_cast<std::uintptr_t>(this)));
+    root_ = base_ / "root";
+    sibling_ = base_ / "root-sibling";
+    std::filesystem::create_directories(root_ / "subdir");
+    std::filesystem::create_directories(sibling_);
+    constexpr std::array<uint8_t, 6> kInside = {'i', 'n', 's', 'i', 'd', 'e'};
+    WriteFile(root_ / "inside.bin", kInside);
+    WriteFile(root_ / "large.bin", std::vector<uint8_t>(65, 0x41));
+    WriteFile(sibling_ / "secret.bin", kSecret);
+
+    std::error_code symlinkError;
+    std::filesystem::create_directory_symlink(sibling_, root_ / "escape-link", symlinkError);
+    hasSymlink_ = !symlinkError;
+    loader_ = std::make_unique<SandboxedFileResourceLoader>(root_, root_ / "document.svg", 64);
+  }
+
+  ~SandboxFixture() {
+    std::error_code ignored;
+    std::filesystem::remove_all(base_, ignored);
+  }
+
+  ResourceLoaderInterface& loader() { return *loader_; }
+  bool hasSymlink() const { return hasSymlink_; }
+
+  static constexpr std::array<uint8_t, 6> kSecret = {0x53, 0x45, 0x43, 0x52, 0x45, 0x54};
+
+private:
+  static void WriteFile(const std::filesystem::path& path, std::span<const uint8_t> bytes) {
+    std::ofstream file(path, std::ios::binary);
+    file.write(reinterpret_cast<const char*>(bytes.data()),
+               static_cast<std::streamsize>(bytes.size()));
+  }
+
+  std::filesystem::path base_;
+  std::filesystem::path root_;
+  std::filesystem::path sibling_;
+  bool hasSymlink_ = false;
+  std::unique_ptr<SandboxedFileResourceLoader> loader_;
+};
+
+void CheckResult(const std::variant<std::vector<uint8_t>, ResourceLoaderError>& result) {
+  if (const auto* bytes = std::get_if<std::vector<uint8_t>>(&result)) {
+    if (bytes->size() > 64 || std::ranges::equal(*bytes, SandboxFixture::kSecret)) {
+      std::abort();
+    }
+  }
+}
+
+}  // namespace
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  static SandboxFixture fixture;
+  FuzzedDataProvider provider(data, size);
+
+  CheckResult(fixture.loader().fetchExternalResource("inside.bin"));
+  CheckResult(fixture.loader().fetchExternalResource("large.bin"));
+  CheckResult(fixture.loader().fetchExternalResource("../root-sibling/secret.bin"));
+  if (fixture.hasSymlink()) {
+    CheckResult(fixture.loader().fetchExternalResource("escape-link/secret.bin"));
+  }
+  CheckResult(fixture.loader().fetchExternalResource(provider.ConsumeRandomLengthString(256)));
+  return 0;
+}
+
+}  // namespace donner::svg

--- a/donner/svg/resources/tests/SandboxedFileResourceLoader_tests.cc
+++ b/donner/svg/resources/tests/SandboxedFileResourceLoader_tests.cc
@@ -79,4 +79,35 @@ TEST_F(SandboxedFileResourceLoaderTests, AccessOutsideSandbox) {
               testing::VariantWith<ResourceLoaderError>(ResourceLoaderError::SandboxViolation));
 }
 
+TEST_F(SandboxedFileResourceLoaderTests, RejectsSiblingWhoseNameSharesRootPrefix) {
+  const std::filesystem::path prefixSibling = root_.parent_path() / "root-backup";
+  std::filesystem::create_directories(prefixSibling);
+  createTestFileUnder(prefixSibling, "secret.txt");
+
+  SandboxedFileResourceLoader loader(root_, root_ / "doc.svg");
+  EXPECT_THAT(loader.fetchExternalResource((prefixSibling / "secret.txt").string()),
+              testing::VariantWith<ResourceLoaderError>(ResourceLoaderError::SandboxViolation));
+}
+
+TEST_F(SandboxedFileResourceLoaderTests, RejectsSymlinkThatEscapesRoot) {
+  createTestFileUnder(secondaryDir_, "secret.txt");
+  std::error_code error;
+  std::filesystem::create_directory_symlink(secondaryDir_, root_ / "escape", error);
+  if (error) {
+    GTEST_SKIP() << "Could not create test symlink: " << error.message();
+  }
+
+  SandboxedFileResourceLoader loader(root_, root_ / "doc.svg");
+  EXPECT_THAT(loader.fetchExternalResource("escape/secret.txt"),
+              testing::VariantWith<ResourceLoaderError>(ResourceLoaderError::SandboxViolation));
+}
+
+TEST_F(SandboxedFileResourceLoaderTests, RejectsResourceLargerThanConfiguredLimit) {
+  createTestFileUnder(root_, "test.txt");
+
+  SandboxedFileResourceLoader loader(root_, root_ / "doc.svg", 4);
+  EXPECT_THAT(loader.fetchExternalResource("test.txt"),
+              testing::VariantWith<ResourceLoaderError>(ResourceLoaderError::TooLarge));
+}
+
 }  // namespace donner::svg

--- a/donner/svg/resources/tests/UrlLoader_structured_fuzzer.cc
+++ b/donner/svg/resources/tests/UrlLoader_structured_fuzzer.cc
@@ -1,0 +1,73 @@
+#include <fuzzer/FuzzedDataProvider.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "donner/svg/resources/UrlLoader.h"
+
+namespace donner::svg {
+namespace {
+
+class PayloadResourceLoader : public ResourceLoaderInterface {
+public:
+  explicit PayloadResourceLoader(std::vector<uint8_t> payload) : payload_(std::move(payload)) {}
+
+  std::variant<std::vector<uint8_t>, ResourceLoaderError> fetchExternalResource(
+      std::string_view /*url*/) override {
+    return payload_;
+  }
+
+private:
+  std::vector<uint8_t> payload_;
+};
+
+std::string PercentEncode(std::span<const uint8_t> data) {
+  constexpr char kHex[] = "0123456789ABCDEF";
+  std::string result = "data:application/octet-stream,";
+  result.reserve(result.size() + data.size() * 3);
+  for (uint8_t byte : data) {
+    result.push_back('%');
+    result.push_back(kHex[byte >> 4]);
+    result.push_back(kHex[byte & 0x0F]);
+  }
+  return result;
+}
+
+}  // namespace
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  FuzzedDataProvider provider(data, size);
+  const size_t maximumResourceSize = provider.ConsumeIntegralInRange<size_t>(0, 128);
+  size_t remainingResourceBytes = provider.ConsumeIntegralInRange<size_t>(0, 256);
+  const std::vector<uint8_t> payload =
+      provider.ConsumeBytes<uint8_t>(provider.ConsumeIntegralInRange<size_t>(
+          0, std::min<size_t>(128, provider.remaining_bytes())));
+
+  PayloadResourceLoader resourceLoader(payload);
+  UrlLoader urlLoader(resourceLoader, maximumResourceSize, &remainingResourceBytes);
+  const std::string externalUrl = "asset/" + provider.ConsumeRandomLengthString(32);
+  const std::string dataUrl = PercentEncode(payload);
+
+  for (std::string_view uri :
+       {std::string_view(externalUrl), std::string_view(dataUrl), std::string_view(externalUrl)}) {
+    const size_t before = remainingResourceBytes;
+    auto result = urlLoader.fromUri(uri);
+    if (const auto* loaded = std::get_if<UrlLoader::Result>(&result)) {
+      if (loaded->data.size() > maximumResourceSize || loaded->data.size() > before ||
+          remainingResourceBytes != before - loaded->data.size()) {
+        std::abort();
+      }
+    } else if (remainingResourceBytes != before) {
+      std::abort();
+    }
+  }
+  return 0;
+}
+
+}  // namespace donner::svg

--- a/donner/svg/resources/tests/UrlLoader_structured_fuzzer.cc
+++ b/donner/svg/resources/tests/UrlLoader_structured_fuzzer.cc
@@ -63,8 +63,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
           remainingResourceBytes != before - loaded->data.size()) {
         std::abort();
       }
-    } else if (remainingResourceBytes != before) {
-      std::abort();
+    } else {
+      const UrlLoaderError error = std::get<UrlLoaderError>(result);
+      if ((error == UrlLoaderError::ResourceTooLarge && remainingResourceBytes != 0) ||
+          (error != UrlLoaderError::ResourceTooLarge && remainingResourceBytes != before)) {
+        std::abort();
+      }
     }
   }
   return 0;

--- a/donner/svg/resources/tests/UrlLoader_tests.cc
+++ b/donner/svg/resources/tests/UrlLoader_tests.cc
@@ -52,6 +52,7 @@ TEST(UrlLoader, UrlLoaderErrorToString) {
   EXPECT_EQ(ToString(UrlLoaderError::UnsupportedFormat), "Unsupported format");
   EXPECT_EQ(ToString(UrlLoaderError::InvalidDataUrl), "Invalid data URL");
   EXPECT_EQ(ToString(UrlLoaderError::DataCorrupt), "Data corrupted");
+  EXPECT_EQ(ToString(UrlLoaderError::ResourceTooLarge), "Resource too large");
 }
 
 /// @test that a valid file URI is correctly fetched.
@@ -84,6 +85,32 @@ TEST(UrlLoader, FetchDataUrlBase64) {
   EXPECT_THAT(result, VariantWith<UrlLoader::Result>(
                           AllOf(Field(&UrlLoader::Result::mimeType, Eq("text/plain")),
                                 Field(&UrlLoader::Result::data, ElementsAre('t', 'e', 's', 't')))));
+}
+
+TEST(UrlLoader, RejectsDecodedDataUrlLargerThanConfiguredLimit) {
+  InProcResourceLoader loader;
+  UrlLoader urlLoader(loader, 3);
+  EXPECT_THAT(urlLoader.fromUri("data:text/plain;base64,dGVzdA=="),
+              VariantWith<UrlLoaderError>(UrlLoaderError::ResourceTooLarge));
+}
+
+TEST(UrlLoader, RejectsExternalResourceLargerThanConfiguredLimit) {
+  InProcResourceLoader loader;
+  UrlLoader urlLoader(loader, 3);
+  EXPECT_THAT(urlLoader.fromUri("test.txt"),
+              VariantWith<UrlLoaderError>(UrlLoaderError::ResourceTooLarge));
+}
+
+TEST(UrlLoader, EnforcesSharedAggregateResourceBudget) {
+  InProcResourceLoader loader;
+  size_t remainingResourceBytes = 7;
+  UrlLoader urlLoader(loader, UrlLoader::kDefaultMaximumResourceSize, &remainingResourceBytes);
+
+  EXPECT_THAT(urlLoader.fromUri("test.txt"), VariantWith<UrlLoader::Result>(testing::_));
+  EXPECT_EQ(remainingResourceBytes, 3);
+  EXPECT_THAT(urlLoader.fromUri("data:text/plain;base64,dGVzdA=="),
+              VariantWith<UrlLoaderError>(UrlLoaderError::ResourceTooLarge));
+  EXPECT_EQ(remainingResourceBytes, 3);
 }
 
 /// @test that a valid URL-encoded data URL with an explicit MIME type is decoded.

--- a/donner/svg/resources/tests/UrlLoader_tests.cc
+++ b/donner/svg/resources/tests/UrlLoader_tests.cc
@@ -17,6 +17,7 @@ class InProcResourceLoader : public ResourceLoaderInterface {
 public:
   std::variant<std::vector<uint8_t>, ResourceLoaderError> fetchExternalResource(
       std::string_view url) override {
+    ++fetchCount_;
     for (const auto& knownUrl : knownUrls_) {
       if (url == knownUrl) {
         return std::vector<uint8_t>{'t', 'e', 's', 't'};
@@ -29,8 +30,20 @@ public:
   /// Add a URL that this loader will recognize and return dummy data for.
   void addKnownUrl(std::string url) { knownUrls_.push_back(std::move(url)); }
 
+  /// Number of application fetch callbacks.
+  size_t fetchCount() const { return fetchCount_; }
+
 private:
   std::vector<std::string> knownUrls_{"test.txt"};
+  size_t fetchCount_ = 0;
+};
+
+class TooLargeResourceLoader : public ResourceLoaderInterface {
+public:
+  std::variant<std::vector<uint8_t>, ResourceLoaderError> fetchExternalResource(
+      std::string_view) override {
+    return ResourceLoaderError::TooLarge;
+  }
 };
 
 /// A helper matcher that extracts the alternative T from a std::variant.
@@ -110,7 +123,31 @@ TEST(UrlLoader, EnforcesSharedAggregateResourceBudget) {
   EXPECT_EQ(remainingResourceBytes, 3);
   EXPECT_THAT(urlLoader.fromUri("data:text/plain;base64,dGVzdA=="),
               VariantWith<UrlLoaderError>(UrlLoaderError::ResourceTooLarge));
-  EXPECT_EQ(remainingResourceBytes, 3);
+  EXPECT_EQ(remainingResourceBytes, 0);
+}
+
+TEST(UrlLoader, AggregateOverageLatchesBeforeAnotherExternalFetch) {
+  InProcResourceLoader loader;
+  size_t remainingResourceBytes = 3;
+  UrlLoader urlLoader(loader, UrlLoader::kDefaultMaximumResourceSize, &remainingResourceBytes);
+
+  EXPECT_THAT(urlLoader.fromUri("test.txt"),
+              VariantWith<UrlLoaderError>(UrlLoaderError::ResourceTooLarge));
+  EXPECT_EQ(loader.fetchCount(), 1u);
+  EXPECT_EQ(remainingResourceBytes, 0u);
+  EXPECT_THAT(urlLoader.fromUri("test.txt"),
+              VariantWith<UrlLoaderError>(UrlLoaderError::ResourceTooLarge));
+  EXPECT_EQ(loader.fetchCount(), 1u);
+}
+
+TEST(UrlLoader, LoaderReportedOverageLatchesAggregateBudget) {
+  TooLargeResourceLoader loader;
+  size_t remainingResourceBytes = 10;
+  UrlLoader urlLoader(loader, UrlLoader::kDefaultMaximumResourceSize, &remainingResourceBytes);
+
+  EXPECT_THAT(urlLoader.fromUri("too-large.bin"),
+              VariantWith<UrlLoaderError>(UrlLoaderError::ResourceTooLarge));
+  EXPECT_EQ(remainingResourceBytes, 0u);
 }
 
 /// @test that a valid URL-encoded data URL with an explicit MIME type is decoded.

--- a/donner/svg/resources/tests/sandboxed_file_resource_loader_structured_corpus/paths
+++ b/donner/svg/resources/tests/sandboxed_file_resource_loader_structured_corpus/paths
@@ -1,0 +1,1 @@
+../root-sibling/secret.bin

--- a/donner/svg/resources/tests/url_loader_structured_corpus/seed
+++ b/donner/svg/resources/tests/url_loader_structured_corpus/seed
@@ -1,0 +1,1 @@
+structured-url-seed

--- a/donner/svg/tool/DonnerSvgTool.cc
+++ b/donner/svg/tool/DonnerSvgTool.cc
@@ -243,6 +243,9 @@ std::optional<std::string> ReadFile(std::string_view filename) {
   if (length <= 0) {
     return std::string();
   }
+  if (static_cast<uint64_t>(length) > parser::SVGParser::kDefaultMaximumInputSize) {
+    return std::nullopt;
+  }
 
   std::string data(static_cast<size_t>(length), '\0');
   file.read(data.data(), length);

--- a/tools/vscode_extension/README.md
+++ b/tools/vscode_extension/README.md
@@ -98,4 +98,4 @@ script-capable parser inside the webview.
 - Dark / Light / High Contrast theme support
 - Checkerboard transparency background
 - Error overlay for parse failures
-- 32 MiB file size guard
+- 16 MiB file size guard

--- a/tools/vscode_extension/src/SvgPreviewEditorProvider.ts
+++ b/tools/vscode_extension/src/SvgPreviewEditorProvider.ts
@@ -1,6 +1,9 @@
+import { Buffer } from "node:buffer";
+import { randomUUID } from "node:crypto";
+
 import * as vscode from "vscode";
 
-const MAX_FILE_SIZE = 32 * 1024 * 1024; // 32 MiB
+const MAX_FILE_SIZE = 16 * 1024 * 1024;
 
 export class SvgPreviewEditorProvider implements vscode.CustomTextEditorProvider {
   public static readonly viewType = "donner.svgPreview";
@@ -30,7 +33,7 @@ export class SvgPreviewEditorProvider implements vscode.CustomTextEditorProvider
     const sendDocument = () => {
       const text = document.getText();
       if (Buffer.byteLength(text, "utf-8") > MAX_FILE_SIZE) {
-        postMessage("error", "File too large (>32 MiB). Rendering disabled.");
+        postMessage("error", "File too large (>16 MiB). Rendering disabled.");
         return;
       }
       postMessage("initDocument", { svgText: text });
@@ -55,7 +58,7 @@ export class SvgPreviewEditorProvider implements vscode.CustomTextEditorProvider
       if (saved.uri.toString() === document.uri.toString()) {
         const text = saved.getText();
         if (Buffer.byteLength(text, "utf-8") > MAX_FILE_SIZE) {
-          postMessage("error", "File too large (>32 MiB). Rendering disabled.");
+          postMessage("error", "File too large (>16 MiB). Rendering disabled.");
           return;
         }
         postMessage("replaceDocumentSnapshot", { svgText: text });
@@ -113,5 +116,5 @@ export class SvgPreviewEditorProvider implements vscode.CustomTextEditorProvider
 }
 
 function getNonce(): string {
-  return crypto.randomUUID();
+  return randomUUID();
 }

--- a/tools/vscode_extension/tsconfig.json
+++ b/tools/vscode_extension/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "module": "ESNext",
     "target": "ES2020",
-    "lib": ["ES2020"],
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["node", "vscode"],
     "moduleResolution": "bundler",
     "outDir": "dist",
     "rootDir": ".",
@@ -14,6 +15,6 @@
     "declaration": false,
     "sourceMap": true
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "webview"]
+  "include": ["src/**/*.ts", "webview/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/tools/vscode_extension/webview/boot.ts
+++ b/tools/vscode_extension/webview/boot.ts
@@ -4,8 +4,8 @@ const vscode = acquireVsCodeApi();
 // DOM elements.
 const canvasContainer = document.getElementById("canvas-container") as HTMLDivElement;
 const canvas = document.getElementById("preview-canvas") as HTMLCanvasElement;
-const ctx = canvas.getContext("2d");
-if (!ctx) {
+const maybeCtx = canvas.getContext("2d");
+if (!maybeCtx) {
   const msg = document.createElement("p");
   msg.textContent = "Error: Unable to create canvas 2D context. The preview cannot render.";
   msg.style.color = "red";
@@ -13,6 +13,7 @@ if (!ctx) {
   canvasContainer.replaceChildren(msg);
   throw new Error("Canvas 2D context unavailable");
 }
+const ctx = maybeCtx;
 const errorOverlay = document.getElementById("error-overlay") as HTMLDivElement;
 const errorMessage = document.getElementById("error-message") as HTMLParagraphElement;
 const dirtyBadge = document.getElementById("dirty-badge") as HTMLSpanElement;
@@ -51,10 +52,13 @@ declare function acquireVsCodeApi(): {
 interface DonnerWasmModule {
   cwrap: (name: string, returnType: string | null, argTypes: string[]) => Function;
   HEAPU8: Uint8Array;
+  _malloc: (size: number) => number;
+  _free: (ptr: number) => void;
 }
 
 let wasmModule: DonnerWasmModule | null = null;
-let wasmRenderSvg: ((svgText: string, w: number, h: number) => number) | null = null;
+let wasmRenderSvg: ((svgPtr: number, byteLength: number, w: number, h: number) => number) | null =
+  null;
 let wasmFreePixels: ((ptr: number) => void) | null = null;
 let wasmGetLastError: (() => string) | null = null;
 
@@ -89,11 +93,12 @@ async function tryLoadWasm(): Promise<boolean> {
     wasmModule = await createModule();
 
     const init = wasmModule.cwrap("donner_init", null, []) as () => void;
-    wasmRenderSvg = wasmModule.cwrap("donner_render_svg", "number", [
-      "string",
+    wasmRenderSvg = wasmModule.cwrap("donner_render_svg_len", "number", [
       "number",
       "number",
-    ]) as (svgText: string, w: number, h: number) => number;
+      "number",
+      "number",
+    ]) as (svgPtr: number, byteLength: number, w: number, h: number) => number;
     wasmFreePixels = wasmModule.cwrap("donner_free_pixels", null, ["number"]) as (
       ptr: number,
     ) => void;
@@ -131,7 +136,28 @@ async function renderSvg(
     };
   }
 
-  const ptr = wasmRenderSvg(svgText, cappedWidth, cappedHeight);
+  const MAX_SVG_BYTES = 16 * 1024 * 1024;
+  if (svgText.length > MAX_SVG_BYTES) {
+    return { imageData: null, error: "SVG exceeds maximum input size" };
+  }
+
+  const svgBytes = new TextEncoder().encode(svgText);
+  if (svgBytes.byteLength > MAX_SVG_BYTES) {
+    return { imageData: null, error: "SVG exceeds maximum input size" };
+  }
+
+  const svgPtr = wasmModule._malloc(Math.max(1, svgBytes.byteLength));
+  if (svgPtr === 0) {
+    return { imageData: null, error: "Failed to allocate SVG input buffer" };
+  }
+
+  let ptr = 0;
+  try {
+    wasmModule.HEAPU8.set(svgBytes, svgPtr);
+    ptr = wasmRenderSvg(svgPtr, svgBytes.byteLength, cappedWidth, cappedHeight);
+  } finally {
+    wasmModule._free(svgPtr);
+  }
   if (ptr === 0) {
     return { imageData: null, error: wasmGetLastError() || "Unknown rendering error" };
   }


### PR DESCRIPTION
Bounds untrusted SVG ingress and document resource loading before parser, decoder, or Wasm work can amplify attacker-controlled input. This is a stack layer above #939 and intentionally excludes font decoding, reference graphs, and renderer work.

- caps compressed and expanded SVG/XML input, data URLs, and raw plus decoded document-resource bytes
- preflights raster decoded bytes against the remaining shared budget and strengthens canonical, component-aware file-sandbox containment
- charges SVGZ expansion to the shared resource budget, rejects nested compression, and latches the first aggregate overage or decompression failure
- bounds application resource callbacks and negative caches so failed, malformed, or over-budget URLs cannot trigger repeated fetch, decode, or parse work
- validates canvas and Wasm memory dimensions with checked arithmetic before allocation or typed-array construction
- keeps the editor preview and VS Code webview on the same 16 MiB input contract

Validation:
- the exact candidate passed `bazel test //...` across 434 test targets
- focused resource, loader, layout, and subdocument tests passed in default and text-full configurations
- ASan data-URL, URL-loader, SVG-parser, and subdocument corpora passed with causal cap cases
- focused unit oracles passed for repeated failed, malformed, and over-budget resource loads
- Tiny Wasm render tests and CMake generator validation passed
- extension lint and compilation, repository lint, formatting, buildifier, diff checks, and privacy review passed
