### PR TITLE
perf: Add cross-engine benchmark with TinySkia mode and fix band boundary coverage

### DIFF
--- a/docs/design_docs/0030-geode_performance.md
+++ b/docs/design_docs/0030-geode_performance.md
@@ -429,6 +429,23 @@ algorithm.
         `drawCalls` so regressions in detection vs. batching can
         be triaged independently.
 - [ ] Milestone 7: Opportunistic cleanups.
+  - [x] Keep band-selection and band-fill scratch storage on the stack.
+    `kMaxBands` already bounds these arrays at 256 entries, so the
+    encoder now initializes only the active prefix and reuses the
+    count array as its write cursor. On allocation-instrumented first
+    frames this removes 6,010 allocation calls for Ghostscript Tiger
+    (55,914 -> 49,904, -10.8%) and 2,194 for Lion
+    (14,885 -> 12,691, -14.7%) without a measurable encode-time
+    regression.
+  - [x] Keep curve maxima inclusive when assigning band references. An
+    exclusive maximum dropped a curve from the following cell when its
+    endpoint landed exactly on an internal band boundary, producing a
+    deterministic two-pixel hole in the Donner Splash Sunburst thumbnail.
+    The focused encoder test now requires boundary-ending curves in both
+    adjacent cells.
+  - [x] Pin TinySkia-only golden tests to `RendererTinySkia`. The showcase
+    golden previously used the build-selected `Renderer` facade, so a Geode
+    test configuration compared GPU output to a TinySkia image.
   - [ ] GPU-side `takeSnapshot` unpremultiply (`RendererGeode.cc:2322-2353`)
     via a one-dispatch compute kernel writing into a CopySrc buffer;
     drops the CPU divide-per-pixel loop.

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -1083,7 +1083,7 @@ donner_cc_test(
         "//donner/editor/tools:showcase_asset_generator",
         "//donner/svg",
         "//donner/svg/parser",
-        "//donner/svg/renderer",
+        "//donner/svg/renderer:renderer_tiny_skia",
         "@com_google_gtest//:gtest_main",
     ],
 )

--- a/donner/editor/tests/ShowcaseAssetFixture_tests.cc
+++ b/donner/editor/tests/ShowcaseAssetFixture_tests.cc
@@ -20,7 +20,7 @@
 #include "donner/svg/SVGDocument.h"
 #include "donner/svg/SVGSVGElement.h"
 #include "donner/svg/parser/SVGParser.h"
-#include "donner/svg/renderer/Renderer.h"
+#include "donner/svg/renderer/RendererTinySkia.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -107,7 +107,7 @@ TEST(ShowcaseAssetFixture, GeneratesOutlinedOverlayShowcaseOnDemand) {
   // Render through the deterministic CPU facade as the final end-to-end gate.
   constexpr Vector2i kRenderSize(223, 128);
   document.setCanvasSize(kRenderSize.x, kRenderSize.y);
-  Renderer renderer;
+  RendererTinySkia renderer;
   renderer.draw(document);
   const RendererBitmap bitmap = renderer.takeSnapshot();
   ASSERT_FALSE(bitmap.empty()) << "generated showcase produced no renderer snapshot";
@@ -137,7 +137,7 @@ TEST(ShowcaseAssetFixture, GeneratedBadgeAndOverlayMatchGolden) {
   SVGDocument document = std::move(result).result();
   constexpr Vector2i kRenderSize(223, 128);
   document.setCanvasSize(kRenderSize.x, kRenderSize.y);
-  Renderer renderer;
+  RendererTinySkia renderer;
   renderer.draw(document);
   const RendererBitmap bitmap = renderer.takeSnapshot();
   editor::tests::CompareBitmapToGolden(bitmap, kShowcaseGoldenPath, "generated_showcase_tiny_skia",

--- a/donner/svg/renderer/benchmarks/AllocationTracker.h
+++ b/donner/svg/renderer/benchmarks/AllocationTracker.h
@@ -1,0 +1,185 @@
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <new>
+
+namespace donner::benchmarks::allocations {
+
+struct Snapshot {
+  std::uint64_t allocationCalls = 0;
+  std::uint64_t allocationBytes = 0;
+  std::uint64_t freeCalls = 0;
+};
+
+inline std::atomic<bool> gEnabled = false;
+inline std::atomic<std::uint64_t> gAllocationCalls = 0;
+inline std::atomic<std::uint64_t> gAllocationBytes = 0;
+inline std::atomic<std::uint64_t> gFreeCalls = 0;
+
+inline void recordAllocation(std::size_t size) noexcept {
+  if (gEnabled.load(std::memory_order_relaxed)) {
+    gAllocationCalls.fetch_add(1, std::memory_order_relaxed);
+    gAllocationBytes.fetch_add(size, std::memory_order_relaxed);
+  }
+}
+
+inline void recordFree() noexcept {
+  if (gEnabled.load(std::memory_order_relaxed)) {
+    gFreeCalls.fetch_add(1, std::memory_order_relaxed);
+  }
+}
+
+class Scope {
+public:
+  Scope() {
+    gAllocationCalls.store(0, std::memory_order_relaxed);
+    gAllocationBytes.store(0, std::memory_order_relaxed);
+    gFreeCalls.store(0, std::memory_order_relaxed);
+    gEnabled.store(true, std::memory_order_release);
+  }
+
+  Scope(const Scope&) = delete;
+  Scope& operator=(const Scope&) = delete;
+
+  ~Scope() { stop(); }
+
+  Snapshot stop() {
+    if (!stopped_) {
+      gEnabled.store(false, std::memory_order_release);
+      snapshot_ = {gAllocationCalls.load(std::memory_order_relaxed),
+                   gAllocationBytes.load(std::memory_order_relaxed),
+                   gFreeCalls.load(std::memory_order_relaxed)};
+      stopped_ = true;
+    }
+    return snapshot_;
+  }
+
+private:
+  bool stopped_ = false;
+  Snapshot snapshot_;
+};
+
+inline void* allocate(std::size_t size) noexcept {
+  void* result = std::malloc(size == 0 ? 1 : size);
+  if (result) {
+    recordAllocation(size);
+  }
+  return result;
+}
+
+inline void* allocateAligned(std::size_t size, std::size_t alignment) noexcept {
+  void* result = nullptr;
+  if (posix_memalign(&result, alignment, size == 0 ? 1 : size) != 0) {
+    return nullptr;
+  }
+  recordAllocation(size);
+  return result;
+}
+
+inline void deallocate(void* ptr) noexcept {
+  if (ptr) {
+    recordFree();
+  }
+  std::free(ptr);
+}
+
+}  // namespace donner::benchmarks::allocations
+
+void* operator new(std::size_t size) {
+  if (void* ptr = donner::benchmarks::allocations::allocate(size)) {
+    return ptr;
+  }
+  std::abort();
+}
+
+void* operator new[](std::size_t size) {
+  if (void* ptr = donner::benchmarks::allocations::allocate(size)) {
+    return ptr;
+  }
+  std::abort();
+}
+
+void* operator new(std::size_t size, const std::nothrow_t&) noexcept {
+  return donner::benchmarks::allocations::allocate(size);
+}
+
+void* operator new[](std::size_t size, const std::nothrow_t&) noexcept {
+  return donner::benchmarks::allocations::allocate(size);
+}
+
+void* operator new(std::size_t size, std::align_val_t alignment) {
+  if (void* ptr = donner::benchmarks::allocations::allocateAligned(
+          size, static_cast<std::size_t>(alignment))) {
+    return ptr;
+  }
+  std::abort();
+}
+
+void* operator new[](std::size_t size, std::align_val_t alignment) {
+  if (void* ptr = donner::benchmarks::allocations::allocateAligned(
+          size, static_cast<std::size_t>(alignment))) {
+    return ptr;
+  }
+  std::abort();
+}
+
+void* operator new(std::size_t size, std::align_val_t alignment, const std::nothrow_t&) noexcept {
+  return donner::benchmarks::allocations::allocateAligned(size,
+                                                          static_cast<std::size_t>(alignment));
+}
+
+void* operator new[](std::size_t size, std::align_val_t alignment, const std::nothrow_t&) noexcept {
+  return donner::benchmarks::allocations::allocateAligned(size,
+                                                          static_cast<std::size_t>(alignment));
+}
+
+void operator delete(void* ptr) noexcept {
+  donner::benchmarks::allocations::deallocate(ptr);
+}
+
+void operator delete[](void* ptr) noexcept {
+  donner::benchmarks::allocations::deallocate(ptr);
+}
+
+void operator delete(void* ptr, std::size_t) noexcept {
+  donner::benchmarks::allocations::deallocate(ptr);
+}
+
+void operator delete[](void* ptr, std::size_t) noexcept {
+  donner::benchmarks::allocations::deallocate(ptr);
+}
+
+void operator delete(void* ptr, const std::nothrow_t&) noexcept {
+  donner::benchmarks::allocations::deallocate(ptr);
+}
+
+void operator delete[](void* ptr, const std::nothrow_t&) noexcept {
+  donner::benchmarks::allocations::deallocate(ptr);
+}
+
+void operator delete(void* ptr, std::align_val_t) noexcept {
+  donner::benchmarks::allocations::deallocate(ptr);
+}
+
+void operator delete[](void* ptr, std::align_val_t) noexcept {
+  donner::benchmarks::allocations::deallocate(ptr);
+}
+
+void operator delete(void* ptr, std::size_t, std::align_val_t) noexcept {
+  donner::benchmarks::allocations::deallocate(ptr);
+}
+
+void operator delete[](void* ptr, std::size_t, std::align_val_t) noexcept {
+  donner::benchmarks::allocations::deallocate(ptr);
+}
+
+void operator delete(void* ptr, std::align_val_t, const std::nothrow_t&) noexcept {
+  donner::benchmarks::allocations::deallocate(ptr);
+}
+
+void operator delete[](void* ptr, std::align_val_t, const std::nothrow_t&) noexcept {
+  donner::benchmarks::allocations::deallocate(ptr);
+}

--- a/donner/svg/renderer/benchmarks/BUILD.bazel
+++ b/donner/svg/renderer/benchmarks/BUILD.bazel
@@ -41,6 +41,11 @@ donner_cc_binary(
         "//donner/svg/parser",
         "//donner/svg/renderer:renderer_geode",
         "//donner/svg/renderer:renderer_image_io",
+        # In-tree TinySkia CPU backend for the --backend=tiny-skia comparison
+        # mode. The benchmark links both backends directly (like the parity
+        # test binary), which the geode_excludes_tiny_skia_audit permits:
+        # it only forbids a path from :renderer_geode to :renderer_tiny_skia.
+        "//donner/svg/renderer:renderer_tiny_skia",
         "//donner/svg/renderer/geode:geode_device",
     ],
 )

--- a/donner/svg/renderer/benchmarks/BUILD.bazel
+++ b/donner/svg/renderer/benchmarks/BUILD.bazel
@@ -1,7 +1,7 @@
 """Geode renderer benchmarks — per-phase timing for the WebGPU/Slug backend."""
 
-load("//build_defs:rules.bzl", "donner_cc_binary")
 load("//build_defs:package.bzl", "donner_package")
+load("//build_defs:rules.bzl", "donner_cc_binary")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -20,6 +20,27 @@ donner_cc_binary(
         "//donner/svg",
         "//donner/svg/parser",
         "//donner/svg/renderer:renderer_geode",
+        "//donner/svg/renderer/geode:geode_device",
+    ],
+)
+
+donner_cc_binary(
+    name = "engine_compare_bench",
+    srcs = [
+        "AllocationTracker.h",
+        "EngineCompareBench.cc",
+    ],
+    data = ["testdata/simple_setup.svg"],
+    target_compatible_with = select({
+        "//donner/svg/renderer/geode:geode_enabled": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = [
+        "//donner/base",
+        "//donner/svg",
+        "//donner/svg/parser",
+        "//donner/svg/renderer:renderer_geode",
+        "//donner/svg/renderer:renderer_image_io",
         "//donner/svg/renderer/geode:geode_device",
     ],
 )

--- a/donner/svg/renderer/benchmarks/EngineCompareBench.cc
+++ b/donner/svg/renderer/benchmarks/EngineCompareBench.cc
@@ -1,5 +1,7 @@
 /// @file
-/// Cross-engine benchmark adapter for Donner's Geode renderer.
+/// Cross-engine benchmark adapter for Donner's Geode renderer, with an
+/// optional in-tree TinySkia CPU-backend mode for direct GPU-vs-CPU
+/// comparison of Donner's own backends.
 ///
 /// The adapter intentionally measures a newly parsed document's first frame and an unchanged
 /// second frame separately. Parse and frame allocation telemetry is collected in dedicated
@@ -23,6 +25,7 @@
 #include "donner/svg/parser/SVGParser.h"
 #include "donner/svg/renderer/RendererGeode.h"
 #include "donner/svg/renderer/RendererImageIO.h"
+#include "donner/svg/renderer/RendererTinySkia.h"
 #include "donner/svg/renderer/benchmarks/AllocationTracker.h"
 #include "donner/svg/renderer/geode/GeodeDevice.h"
 
@@ -36,6 +39,7 @@ struct Config {
   int warmup = 2;
   std::string input;
   std::string outputPng;
+  std::string backend = "geode";
 };
 
 double toMs(Clock::duration duration) {
@@ -64,6 +68,8 @@ Config parseArgs(int argc, char* argv[]) {
       config.warmup = std::max(0, std::atoi(arg.substr(9).data()));
     } else if (arg.starts_with("--output=")) {
       config.outputPng = arg.substr(9);
+    } else if (arg.starts_with("--backend=")) {
+      config.backend = arg.substr(10);
     } else if (config.input.empty()) {
       config.input = arg;
     }
@@ -105,16 +111,82 @@ bool parseDocument(std::string_view source, donner::svg::SVGDocument& document) 
   return true;
 }
 
-donner::svg::RendererBitmap renderSettled(donner::svg::RendererGeode& renderer,
-                                          donner::svg::SVGDocument& document) {
+template <typename Renderer>
+donner::svg::RendererBitmap renderSettled(Renderer& renderer, donner::svg::SVGDocument& document) {
   renderer.draw(document);
   return renderer.takeSnapshot();
 }
 
-void printAllocation(std::string_view phase, const AllocationSnapshot& snapshot) {
-  std::printf("ALLOC engine=Donner phase=%.*s calls=%llu bytes=%llu frees=%llu\n",
-              static_cast<int>(phase.size()), phase.data(),
-              static_cast<unsigned long long>(snapshot.allocationCalls),
+/// Timed first/second-frame loop. `makeRenderer` constructs a fresh renderer
+/// per iteration, mirroring per-document renderer lifetime in production.
+template <typename MakeRenderer>
+bool runTimedLoop(const Config& config, const std::string& source, MakeRenderer makeRenderer,
+                  std::vector<double>& parseTimes, std::vector<double>& firstFrameTimes,
+                  std::vector<double>& secondFrameTimes,
+                  donner::svg::RendererBitmap& finalBitmap) {
+  const int total = config.warmup + config.iterations;
+  for (int i = 0; i < total; ++i) {
+    donner::svg::SVGDocument document;
+    auto start = Clock::now();
+    if (!parseDocument(source, document)) {
+      return false;
+    }
+    const double parseMs = toMs(Clock::now() - start);
+
+    auto renderer = makeRenderer();
+    start = Clock::now();
+    donner::svg::RendererBitmap firstBitmap = renderSettled(renderer, document);
+    const double firstFrameMs = toMs(Clock::now() - start);
+    start = Clock::now();
+    donner::svg::RendererBitmap secondBitmap = renderSettled(renderer, document);
+    const double secondFrameMs = toMs(Clock::now() - start);
+    if (firstBitmap.empty() || secondBitmap.empty()) {
+      std::fprintf(stderr, "renderer returned an empty bitmap\n");
+      return false;
+    }
+
+    if (i >= config.warmup) {
+      parseTimes.push_back(parseMs);
+      firstFrameTimes.push_back(firstFrameMs);
+      secondFrameTimes.push_back(secondFrameMs);
+      finalBitmap = std::move(secondBitmap);
+    }
+  }
+  return true;
+}
+
+/// Untimed allocation pass: parse once, then first and second settled render
+/// under allocation scopes.
+template <typename MakeRenderer>
+bool runAllocationPass(const std::string& source, MakeRenderer makeRenderer,
+                       AllocationSnapshot& parseAllocations, AllocationSnapshot& firstAllocations,
+                       AllocationSnapshot& secondAllocations) {
+  donner::svg::SVGDocument allocationDocument;
+  donner::benchmarks::allocations::Scope parseAllocationScope;
+  if (!parseDocument(source, allocationDocument)) {
+    return false;
+  }
+  parseAllocations = parseAllocationScope.stop();
+
+  auto allocationRenderer = makeRenderer();
+  donner::benchmarks::allocations::Scope firstAllocationScope;
+  auto firstAllocationBitmap = renderSettled(allocationRenderer, allocationDocument);
+  firstAllocations = firstAllocationScope.stop();
+  donner::benchmarks::allocations::Scope secondAllocationScope;
+  auto secondAllocationBitmap = renderSettled(allocationRenderer, allocationDocument);
+  secondAllocations = secondAllocationScope.stop();
+  if (firstAllocationBitmap.empty() || secondAllocationBitmap.empty()) {
+    std::fprintf(stderr, "renderer returned an empty bitmap\n");
+    return false;
+  }
+  return true;
+}
+
+void printAllocation(std::string_view engine, std::string_view phase,
+                     const AllocationSnapshot& snapshot) {
+  std::printf("ALLOC engine=%.*s phase=%.*s calls=%llu bytes=%llu frees=%llu\n",
+              static_cast<int>(engine.size()), engine.data(), static_cast<int>(phase.size()),
+              phase.data(), static_cast<unsigned long long>(snapshot.allocationCalls),
               static_cast<unsigned long long>(snapshot.allocationBytes),
               static_cast<unsigned long long>(snapshot.freeCalls));
 }
@@ -125,9 +197,17 @@ int main(int argc, char* argv[]) {
   const Config config = parseArgs(argc, argv);
   if (config.input.empty()) {
     std::fprintf(stderr,
-                 "usage: engine_compare_bench [--iterations=N] [--warmup=N] [--output=FILE] SVG\n");
+                 "usage: engine_compare_bench [--backend=geode|tiny-skia] [--iterations=N] "
+                 "[--warmup=N] [--output=FILE] SVG\n");
     return 2;
   }
+  if (config.backend != "geode" && config.backend != "tiny-skia") {
+    std::fprintf(stderr, "unknown backend: %s (expected geode or tiny-skia)\n",
+                 config.backend.c_str());
+    return 2;
+  }
+  const bool geodeMode = config.backend == "geode";
+  const std::string_view engineName = geodeMode ? "Donner" : "TinySkia";
 
   const std::string source = readFile(config.input);
   if (source.empty()) {
@@ -135,67 +215,63 @@ int main(int argc, char* argv[]) {
     return 2;
   }
 
+  // One-time setup, measured separately: Geode initializes a GPU device;
+  // TinySkia constructs its renderer (no GPU). Setup does not recur per frame.
   const std::uint64_t rssBeforeKb = readProcStatusKb("VmRSS:");
   const auto setupStart = Clock::now();
   donner::benchmarks::allocations::Scope setupAllocationScope;
-  auto device = donner::geode::GeodeDevice::CreateHeadless();
+  std::shared_ptr<donner::geode::GeodeDevice> sharedDevice;
+  if (geodeMode) {
+    auto device = donner::geode::GeodeDevice::CreateHeadless();
+    if (!device) {
+      std::fprintf(stderr, "unable to create Geode device\n");
+      return 1;
+    }
+    sharedDevice = std::shared_ptr<donner::geode::GeodeDevice>(std::move(device));
+  } else {
+    donner::svg::RendererTinySkia setupRenderer(/*verbose=*/false);
+    (void)setupRenderer;
+  }
   const AllocationSnapshot setupAllocations = setupAllocationScope.stop();
   const double setupMs = toMs(Clock::now() - setupStart);
-  if (!device) {
-    std::fprintf(stderr, "unable to create Geode device\n");
-    return 1;
-  }
-  auto sharedDevice = std::shared_ptr<donner::geode::GeodeDevice>(std::move(device));
   const std::uint64_t rssAfterSetupKb = readProcStatusKb("VmRSS:");
 
   std::vector<double> parseTimes;
   std::vector<double> firstFrameTimes;
   std::vector<double> secondFrameTimes;
   donner::svg::RendererBitmap finalBitmap;
-  const int total = config.warmup + config.iterations;
-  for (int i = 0; i < total; ++i) {
-    donner::svg::SVGDocument document;
-    auto start = Clock::now();
-    if (!parseDocument(source, document)) {
+  if (geodeMode) {
+    if (!runTimedLoop(config, source,
+                      [&sharedDevice] {
+                        return donner::svg::RendererGeode(sharedDevice, /*verbose=*/false);
+                      },
+                      parseTimes, firstFrameTimes, secondFrameTimes, finalBitmap)) {
       return 1;
     }
-    const double parseMs = toMs(Clock::now() - start);
-
-    donner::svg::RendererGeode renderer(sharedDevice, /*verbose=*/false);
-    start = Clock::now();
-    donner::svg::RendererBitmap firstBitmap = renderSettled(renderer, document);
-    const double firstFrameMs = toMs(Clock::now() - start);
-    start = Clock::now();
-    donner::svg::RendererBitmap secondBitmap = renderSettled(renderer, document);
-    const double secondFrameMs = toMs(Clock::now() - start);
-    if (firstBitmap.empty() || secondBitmap.empty()) {
-      std::fprintf(stderr, "renderer returned an empty bitmap\n");
+  } else {
+    if (!runTimedLoop(config, source,
+                      [] { return donner::svg::RendererTinySkia(/*verbose=*/false); },
+                      parseTimes, firstFrameTimes, secondFrameTimes, finalBitmap)) {
       return 1;
-    }
-
-    if (i >= config.warmup) {
-      parseTimes.push_back(parseMs);
-      firstFrameTimes.push_back(firstFrameMs);
-      secondFrameTimes.push_back(secondFrameMs);
-      finalBitmap = std::move(secondBitmap);
     }
   }
 
-  donner::svg::SVGDocument allocationDocument;
-  donner::benchmarks::allocations::Scope parseAllocationScope;
-  if (!parseDocument(source, allocationDocument)) {
-    return 1;
-  }
-  const AllocationSnapshot parseAllocations = parseAllocationScope.stop();
-  donner::svg::RendererGeode allocationRenderer(sharedDevice, /*verbose=*/false);
-  donner::benchmarks::allocations::Scope firstAllocationScope;
-  auto firstAllocationBitmap = renderSettled(allocationRenderer, allocationDocument);
-  const AllocationSnapshot firstAllocations = firstAllocationScope.stop();
-  donner::benchmarks::allocations::Scope secondAllocationScope;
-  auto secondAllocationBitmap = renderSettled(allocationRenderer, allocationDocument);
-  const AllocationSnapshot secondAllocations = secondAllocationScope.stop();
-  if (firstAllocationBitmap.empty() || secondAllocationBitmap.empty()) {
-    return 1;
+  AllocationSnapshot parseAllocations;
+  AllocationSnapshot firstAllocations;
+  AllocationSnapshot secondAllocations;
+  if (geodeMode) {
+    if (!runAllocationPass(source,
+                           [&sharedDevice] {
+                             return donner::svg::RendererGeode(sharedDevice, /*verbose=*/false);
+                           },
+                           parseAllocations, firstAllocations, secondAllocations)) {
+      return 1;
+    }
+  } else {
+    if (!runAllocationPass(source, [] { return donner::svg::RendererTinySkia(/*verbose=*/false); },
+                           parseAllocations, firstAllocations, secondAllocations)) {
+      return 1;
+    }
   }
 
   if (!config.outputPng.empty() &&
@@ -208,15 +284,15 @@ int main(int argc, char* argv[]) {
 
   const std::uint64_t peakRssKb = readProcStatusKb("VmHWM:");
   std::printf(
-      "RESULT engine=Donner setup_ms=%.3f parse_ms=%.3f first_ms=%.3f second_ms=%.3f "
+      "RESULT engine=%.*s setup_ms=%.3f parse_ms=%.3f first_ms=%.3f second_ms=%.3f "
       "width=%d height=%d rss_before_kb=%llu rss_setup_kb=%llu peak_rss_kb=%llu\n",
-      setupMs, median(parseTimes), median(firstFrameTimes), median(secondFrameTimes),
-      finalBitmap.dimensions.x, finalBitmap.dimensions.y,
-      static_cast<unsigned long long>(rssBeforeKb),
+      static_cast<int>(engineName.size()), engineName.data(), setupMs, median(parseTimes),
+      median(firstFrameTimes), median(secondFrameTimes), finalBitmap.dimensions.x,
+      finalBitmap.dimensions.y, static_cast<unsigned long long>(rssBeforeKb),
       static_cast<unsigned long long>(rssAfterSetupKb), static_cast<unsigned long long>(peakRssKb));
-  printAllocation("setup", setupAllocations);
-  printAllocation("parse", parseAllocations);
-  printAllocation("first", firstAllocations);
-  printAllocation("second", secondAllocations);
+  printAllocation(engineName, "setup", setupAllocations);
+  printAllocation(engineName, "parse", parseAllocations);
+  printAllocation(engineName, "first", firstAllocations);
+  printAllocation(engineName, "second", secondAllocations);
   return 0;
 }

--- a/donner/svg/renderer/benchmarks/EngineCompareBench.cc
+++ b/donner/svg/renderer/benchmarks/EngineCompareBench.cc
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cinttypes>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -90,8 +91,8 @@ std::uint64_t readProcStatusKb(std::string_view field) {
   std::string line;
   while (std::getline(status, line)) {
     if (line.starts_with(field)) {
-      unsigned long long value = 0;
-      if (std::sscanf(line.c_str() + field.size(), "%llu", &value) == 1) {
+      std::uint64_t value = 0;
+      if (std::sscanf(line.c_str() + field.size(), "%" PRIu64, &value) == 1) {
         return static_cast<std::uint64_t>(value);
       }
       return 0;
@@ -184,11 +185,12 @@ bool runAllocationPass(const std::string& source, MakeRenderer makeRenderer,
 
 void printAllocation(std::string_view engine, std::string_view phase,
                      const AllocationSnapshot& snapshot) {
-  std::printf("ALLOC engine=%.*s phase=%.*s calls=%llu bytes=%llu frees=%llu\n",
+  std::printf("ALLOC engine=%.*s phase=%.*s calls=%" PRIu64 " bytes=%" PRIu64
+              " frees=%" PRIu64 "\n",
               static_cast<int>(engine.size()), engine.data(), static_cast<int>(phase.size()),
-              phase.data(), static_cast<unsigned long long>(snapshot.allocationCalls),
-              static_cast<unsigned long long>(snapshot.allocationBytes),
-              static_cast<unsigned long long>(snapshot.freeCalls));
+              phase.data(), static_cast<std::uint64_t>(snapshot.allocationCalls),
+              static_cast<std::uint64_t>(snapshot.allocationBytes),
+              static_cast<std::uint64_t>(snapshot.freeCalls));
 }
 
 }  // namespace
@@ -285,11 +287,12 @@ int main(int argc, char* argv[]) {
   const std::uint64_t peakRssKb = readProcStatusKb("VmHWM:");
   std::printf(
       "RESULT engine=%.*s setup_ms=%.3f parse_ms=%.3f first_ms=%.3f second_ms=%.3f "
-      "width=%d height=%d rss_before_kb=%llu rss_setup_kb=%llu peak_rss_kb=%llu\n",
+      "width=%d height=%d rss_before_kb=%" PRIu64 " rss_setup_kb=%" PRIu64
+      " peak_rss_kb=%" PRIu64 "\n",
       static_cast<int>(engineName.size()), engineName.data(), setupMs, median(parseTimes),
       median(firstFrameTimes), median(secondFrameTimes), finalBitmap.dimensions.x,
-      finalBitmap.dimensions.y, static_cast<unsigned long long>(rssBeforeKb),
-      static_cast<unsigned long long>(rssAfterSetupKb), static_cast<unsigned long long>(peakRssKb));
+      finalBitmap.dimensions.y, static_cast<std::uint64_t>(rssBeforeKb),
+      static_cast<std::uint64_t>(rssAfterSetupKb), static_cast<std::uint64_t>(peakRssKb));
   printAllocation(engineName, "setup", setupAllocations);
   printAllocation(engineName, "parse", parseAllocations);
   printAllocation(engineName, "first", firstAllocations);

--- a/donner/svg/renderer/benchmarks/EngineCompareBench.cc
+++ b/donner/svg/renderer/benchmarks/EngineCompareBench.cc
@@ -1,0 +1,222 @@
+/// @file
+/// Cross-engine benchmark adapter for Donner's Geode renderer.
+///
+/// The adapter intentionally measures a newly parsed document's first frame and an unchanged
+/// second frame separately. Parse and frame allocation telemetry is collected in dedicated
+/// untimed passes so the atomic counters do not distort those wall-clock samples.
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "donner/base/ParseWarningSink.h"
+#include "donner/svg/SVGDocument.h"
+#include "donner/svg/parser/SVGParser.h"
+#include "donner/svg/renderer/RendererGeode.h"
+#include "donner/svg/renderer/RendererImageIO.h"
+#include "donner/svg/renderer/benchmarks/AllocationTracker.h"
+#include "donner/svg/renderer/geode/GeodeDevice.h"
+
+namespace {
+
+using Clock = std::chrono::steady_clock;
+using AllocationSnapshot = donner::benchmarks::allocations::Snapshot;
+
+struct Config {
+  int iterations = 10;
+  int warmup = 2;
+  std::string input;
+  std::string outputPng;
+};
+
+double toMs(Clock::duration duration) {
+  return std::chrono::duration<double, std::milli>(duration).count();
+}
+
+double median(std::vector<double> values) {
+  if (values.empty()) {
+    return 0.0;
+  }
+  std::sort(values.begin(), values.end());
+  const std::size_t middle = values.size() / 2;
+  if (values.size() % 2 == 0) {
+    return (values[middle - 1] + values[middle]) / 2.0;
+  }
+  return values[middle];
+}
+
+Config parseArgs(int argc, char* argv[]) {
+  Config config;
+  for (int i = 1; i < argc; ++i) {
+    const std::string_view arg(argv[i]);
+    if (arg.starts_with("--iterations=")) {
+      config.iterations = std::max(1, std::atoi(arg.substr(13).data()));
+    } else if (arg.starts_with("--warmup=")) {
+      config.warmup = std::max(0, std::atoi(arg.substr(9).data()));
+    } else if (arg.starts_with("--output=")) {
+      config.outputPng = arg.substr(9);
+    } else if (config.input.empty()) {
+      config.input = arg;
+    }
+  }
+  return config;
+}
+
+std::string readFile(const std::filesystem::path& path) {
+  std::ifstream file(path, std::ios::binary);
+  if (!file) {
+    return {};
+  }
+  return std::string(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
+}
+
+std::uint64_t readProcStatusKb(std::string_view field) {
+  std::ifstream status("/proc/self/status");
+  std::string line;
+  while (std::getline(status, line)) {
+    if (line.starts_with(field)) {
+      unsigned long long value = 0;
+      if (std::sscanf(line.c_str() + field.size(), "%llu", &value) == 1) {
+        return static_cast<std::uint64_t>(value);
+      }
+      return 0;
+    }
+  }
+  return 0;
+}
+
+bool parseDocument(std::string_view source, donner::svg::SVGDocument& document) {
+  donner::ParseWarningSink warningSink = donner::ParseWarningSink::Disabled();
+  auto parsed = donner::svg::parser::SVGParser::ParseSVG(source, warningSink);
+  if (parsed.hasError()) {
+    std::fprintf(stderr, "parse error: %s\n", std::string(parsed.error().reason).c_str());
+    return false;
+  }
+  document = std::move(parsed.result());
+  return true;
+}
+
+donner::svg::RendererBitmap renderSettled(donner::svg::RendererGeode& renderer,
+                                          donner::svg::SVGDocument& document) {
+  renderer.draw(document);
+  return renderer.takeSnapshot();
+}
+
+void printAllocation(std::string_view phase, const AllocationSnapshot& snapshot) {
+  std::printf("ALLOC engine=Donner phase=%.*s calls=%llu bytes=%llu frees=%llu\n",
+              static_cast<int>(phase.size()), phase.data(),
+              static_cast<unsigned long long>(snapshot.allocationCalls),
+              static_cast<unsigned long long>(snapshot.allocationBytes),
+              static_cast<unsigned long long>(snapshot.freeCalls));
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+  const Config config = parseArgs(argc, argv);
+  if (config.input.empty()) {
+    std::fprintf(stderr,
+                 "usage: engine_compare_bench [--iterations=N] [--warmup=N] [--output=FILE] SVG\n");
+    return 2;
+  }
+
+  const std::string source = readFile(config.input);
+  if (source.empty()) {
+    std::fprintf(stderr, "unable to read SVG: %s\n", config.input.c_str());
+    return 2;
+  }
+
+  const std::uint64_t rssBeforeKb = readProcStatusKb("VmRSS:");
+  const auto setupStart = Clock::now();
+  donner::benchmarks::allocations::Scope setupAllocationScope;
+  auto device = donner::geode::GeodeDevice::CreateHeadless();
+  const AllocationSnapshot setupAllocations = setupAllocationScope.stop();
+  const double setupMs = toMs(Clock::now() - setupStart);
+  if (!device) {
+    std::fprintf(stderr, "unable to create Geode device\n");
+    return 1;
+  }
+  auto sharedDevice = std::shared_ptr<donner::geode::GeodeDevice>(std::move(device));
+  const std::uint64_t rssAfterSetupKb = readProcStatusKb("VmRSS:");
+
+  std::vector<double> parseTimes;
+  std::vector<double> firstFrameTimes;
+  std::vector<double> secondFrameTimes;
+  donner::svg::RendererBitmap finalBitmap;
+  const int total = config.warmup + config.iterations;
+  for (int i = 0; i < total; ++i) {
+    donner::svg::SVGDocument document;
+    auto start = Clock::now();
+    if (!parseDocument(source, document)) {
+      return 1;
+    }
+    const double parseMs = toMs(Clock::now() - start);
+
+    donner::svg::RendererGeode renderer(sharedDevice, /*verbose=*/false);
+    start = Clock::now();
+    donner::svg::RendererBitmap firstBitmap = renderSettled(renderer, document);
+    const double firstFrameMs = toMs(Clock::now() - start);
+    start = Clock::now();
+    donner::svg::RendererBitmap secondBitmap = renderSettled(renderer, document);
+    const double secondFrameMs = toMs(Clock::now() - start);
+    if (firstBitmap.empty() || secondBitmap.empty()) {
+      std::fprintf(stderr, "renderer returned an empty bitmap\n");
+      return 1;
+    }
+
+    if (i >= config.warmup) {
+      parseTimes.push_back(parseMs);
+      firstFrameTimes.push_back(firstFrameMs);
+      secondFrameTimes.push_back(secondFrameMs);
+      finalBitmap = std::move(secondBitmap);
+    }
+  }
+
+  donner::svg::SVGDocument allocationDocument;
+  donner::benchmarks::allocations::Scope parseAllocationScope;
+  if (!parseDocument(source, allocationDocument)) {
+    return 1;
+  }
+  const AllocationSnapshot parseAllocations = parseAllocationScope.stop();
+  donner::svg::RendererGeode allocationRenderer(sharedDevice, /*verbose=*/false);
+  donner::benchmarks::allocations::Scope firstAllocationScope;
+  auto firstAllocationBitmap = renderSettled(allocationRenderer, allocationDocument);
+  const AllocationSnapshot firstAllocations = firstAllocationScope.stop();
+  donner::benchmarks::allocations::Scope secondAllocationScope;
+  auto secondAllocationBitmap = renderSettled(allocationRenderer, allocationDocument);
+  const AllocationSnapshot secondAllocations = secondAllocationScope.stop();
+  if (firstAllocationBitmap.empty() || secondAllocationBitmap.empty()) {
+    return 1;
+  }
+
+  if (!config.outputPng.empty() &&
+      !donner::svg::RendererImageIO::writeRgbaPixelsToPngFile(
+          config.outputPng.c_str(), finalBitmap.pixels, finalBitmap.dimensions.x,
+          finalBitmap.dimensions.y, finalBitmap.rowBytes / 4)) {
+    std::fprintf(stderr, "unable to write PNG: %s\n", config.outputPng.c_str());
+    return 1;
+  }
+
+  const std::uint64_t peakRssKb = readProcStatusKb("VmHWM:");
+  std::printf(
+      "RESULT engine=Donner setup_ms=%.3f parse_ms=%.3f first_ms=%.3f second_ms=%.3f "
+      "width=%d height=%d rss_before_kb=%llu rss_setup_kb=%llu peak_rss_kb=%llu\n",
+      setupMs, median(parseTimes), median(firstFrameTimes), median(secondFrameTimes),
+      finalBitmap.dimensions.x, finalBitmap.dimensions.y,
+      static_cast<unsigned long long>(rssBeforeKb),
+      static_cast<unsigned long long>(rssAfterSetupKb), static_cast<unsigned long long>(peakRssKb));
+  printAllocation("setup", setupAllocations);
+  printAllocation("parse", parseAllocations);
+  printAllocation("first", firstAllocations);
+  printAllocation("second", secondAllocations);
+  return 0;
+}

--- a/donner/svg/renderer/benchmarks/EngineCompareBench.cc
+++ b/donner/svg/renderer/benchmarks/EngineCompareBench.cc
@@ -6,6 +6,22 @@
 /// The adapter intentionally measures a newly parsed document's first frame and an unchanged
 /// second frame separately. Parse and frame allocation telemetry is collected in dedicated
 /// untimed passes so the atomic counters do not distort those wall-clock samples.
+///
+/// Interpretation caveats, so the output is not over-read:
+/// - ALLOC lines count only C++ `operator new`/`delete`. Geode's per-frame
+///   work bottoms out in wgpu-native (Rust), whose allocations go through the
+///   Rust global allocator and are invisible here, while TinySkia's C++ port
+///   is fully counted. Within-engine before/after deltas are valid;
+///   cross-engine ALLOC comparison is not.
+/// - second_ms compares structurally different work: Geode replays resident
+///   GPU geometry, TinySkia re-rasterizes every path. That asymmetry is the
+///   production shape being measured, not an apples-to-apples raster loop.
+/// - RESULT carries a pixels_hash + nonzero_bytes fingerprint of the final
+///   frame. The two backends are not expected to match bit-exactly, so the
+///   fingerprint is not a cross-engine comparator; compare it across runs of
+///   the SAME engine and scene so a regression that silently renders a stale
+///   or empty frame shows up as a hash flip or nonzero collapse instead of a
+///   fake speedup.
 
 #include <algorithm>
 #include <chrono>
@@ -20,6 +36,10 @@
 #include <string>
 #include <string_view>
 #include <vector>
+
+#if defined(__APPLE__)
+#include <mach/mach.h>
+#endif
 
 #include "donner/base/ParseWarningSink.h"
 #include "donner/svg/SVGDocument.h"
@@ -99,6 +119,71 @@ std::uint64_t readProcStatusKb(std::string_view field) {
     }
   }
   return 0;
+}
+
+/// Whether the RSS numbers on this platform are real measurements. Echoed
+/// into RESULT as rss_supported so a 0 KB reading on an unsupported platform
+/// is never mistaken for a measurement.
+constexpr bool kRssSupported =
+#if defined(__linux__) || defined(__APPLE__)
+    true;
+#else
+    false;
+#endif
+
+/// Current resident set size in KiB (0 where unsupported).
+std::uint64_t readCurrentRssKb() {
+#if defined(__APPLE__)
+  mach_task_basic_info info = {};
+  mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
+  if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO, reinterpret_cast<task_info_t>(&info),
+                &count) != KERN_SUCCESS) {
+    return 0;
+  }
+  return static_cast<std::uint64_t>(info.resident_size) / 1024u;
+#else
+  return readProcStatusKb("VmRSS:");
+#endif
+}
+
+/// Peak resident set size in KiB (0 where unsupported).
+std::uint64_t readPeakRssKb() {
+#if defined(__APPLE__)
+  mach_task_basic_info info = {};
+  mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
+  if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO, reinterpret_cast<task_info_t>(&info),
+                &count) != KERN_SUCCESS) {
+    return 0;
+  }
+  return static_cast<std::uint64_t>(info.resident_size_max) / 1024u;
+#else
+  return readProcStatusKb("VmHWM:");
+#endif
+}
+
+/// Order-sensitive FNV-1a over the bitmap's pixel rows, plus a count of
+/// nonzero bytes. See the file header for how to read these fields.
+struct BitmapFingerprint {
+  std::uint64_t hash = 0;
+  std::uint64_t nonzeroBytes = 0;
+};
+
+BitmapFingerprint fingerprintBitmap(const donner::svg::RendererBitmap& bitmap) {
+  BitmapFingerprint fp;
+  std::uint64_t hash = 14695981039346656037ull;
+  const std::uint8_t* base = bitmap.pixels.data();
+  const std::size_t rowStride = bitmap.rowBytes;
+  const std::size_t rowBytes = static_cast<std::size_t>(bitmap.dimensions.x) * 4u;
+  for (int y = 0; y < bitmap.dimensions.y; ++y) {
+    const std::uint8_t* row = base + static_cast<std::size_t>(y) * rowStride;
+    for (std::size_t i = 0; i < rowBytes; ++i) {
+      hash ^= row[i];
+      hash *= 1099511628211ull;
+      fp.nonzeroBytes += row[i] != 0u ? 1u : 0u;
+    }
+  }
+  fp.hash = hash;
+  return fp;
 }
 
 bool parseDocument(std::string_view source, donner::svg::SVGDocument& document) {
@@ -185,8 +270,11 @@ bool runAllocationPass(const std::string& source, MakeRenderer makeRenderer,
 
 void printAllocation(std::string_view engine, std::string_view phase,
                      const AllocationSnapshot& snapshot) {
+  // scope=cpp_heap_only: only C++ operator new/delete are counted, so
+  // wgpu-native's Rust-side allocations are invisible; do not compare these
+  // numbers across engines (see the file header).
   std::printf("ALLOC engine=%.*s phase=%.*s calls=%" PRIu64 " bytes=%" PRIu64
-              " frees=%" PRIu64 "\n",
+              " frees=%" PRIu64 " scope=cpp_heap_only\n",
               static_cast<int>(engine.size()), engine.data(), static_cast<int>(phase.size()),
               phase.data(), static_cast<std::uint64_t>(snapshot.allocationCalls),
               static_cast<std::uint64_t>(snapshot.allocationBytes),
@@ -219,7 +307,7 @@ int main(int argc, char* argv[]) {
 
   // One-time setup, measured separately: Geode initializes a GPU device;
   // TinySkia constructs its renderer (no GPU). Setup does not recur per frame.
-  const std::uint64_t rssBeforeKb = readProcStatusKb("VmRSS:");
+  const std::uint64_t rssBeforeKb = readCurrentRssKb();
   const auto setupStart = Clock::now();
   donner::benchmarks::allocations::Scope setupAllocationScope;
   std::shared_ptr<donner::geode::GeodeDevice> sharedDevice;
@@ -236,7 +324,7 @@ int main(int argc, char* argv[]) {
   }
   const AllocationSnapshot setupAllocations = setupAllocationScope.stop();
   const double setupMs = toMs(Clock::now() - setupStart);
-  const std::uint64_t rssAfterSetupKb = readProcStatusKb("VmRSS:");
+  const std::uint64_t rssAfterSetupKb = readCurrentRssKb();
 
   std::vector<double> parseTimes;
   std::vector<double> firstFrameTimes;
@@ -284,15 +372,18 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  const std::uint64_t peakRssKb = readProcStatusKb("VmHWM:");
+  const std::uint64_t peakRssKb = readPeakRssKb();
+  const BitmapFingerprint fingerprint = fingerprintBitmap(finalBitmap);
   std::printf(
       "RESULT engine=%.*s setup_ms=%.3f parse_ms=%.3f first_ms=%.3f second_ms=%.3f "
       "width=%d height=%d rss_before_kb=%" PRIu64 " rss_setup_kb=%" PRIu64
-      " peak_rss_kb=%" PRIu64 "\n",
+      " peak_rss_kb=%" PRIu64 " rss_supported=%d pixels_hash=%016" PRIx64
+      " nonzero_bytes=%" PRIu64 "\n",
       static_cast<int>(engineName.size()), engineName.data(), setupMs, median(parseTimes),
       median(firstFrameTimes), median(secondFrameTimes), finalBitmap.dimensions.x,
       finalBitmap.dimensions.y, static_cast<std::uint64_t>(rssBeforeKb),
-      static_cast<std::uint64_t>(rssAfterSetupKb), static_cast<std::uint64_t>(peakRssKb));
+      static_cast<std::uint64_t>(rssAfterSetupKb), static_cast<std::uint64_t>(peakRssKb),
+      kRssSupported ? 1 : 0, fingerprint.hash, fingerprint.nonzeroBytes);
   printAllocation(engineName, "setup", setupAllocations);
   printAllocation(engineName, "parse", parseAllocations);
   printAllocation(engineName, "first", firstAllocations);

--- a/donner/svg/renderer/benchmarks/testdata/simple_setup.svg
+++ b/donner/svg/renderer/benchmarks/testdata/simple_setup.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <rect x="20" y="20" width="160" height="160" rx="16" fill="#2f80ed"/>
+  <circle cx="100" cy="100" r="48" fill="#f2c94c"/>
+</svg>

--- a/donner/svg/renderer/geode/GeodePathEncoder.cc
+++ b/donner/svg/renderer/geode/GeodePathEncoder.cc
@@ -172,9 +172,20 @@ std::optional<BandSpan> curveBandSpan(const CurveRange& range, const Box2d& boun
   const float lo = byY ? range.yMin : range.xMin;
   const float hi = byY ? range.yMax : range.xMax;
 
-  const int first = std::clamp(static_cast<int>(std::floor((lo - spanBase) / bandStride)), 0,
+  // The fragment shader recomputes this same quotient in f32, where WGSL
+  // division may err by ~2.5 ULP, so a sample within a few ULP of a band
+  // boundary can index the adjacent cell relative to this exact CPU
+  // binning. Pad the span by a boundary-proximity epsilon in quotient
+  // space, in both directions. Over-inclusion is cost-only: the shader
+  // re-filters every referenced curve by exact axis ownership, so an extra
+  // band reference can never change pixels, while a missing one leaves a
+  // coverage hole.
+  constexpr float kBandQuotientPad = 1e-3f;
+  const float qLo = (lo - spanBase) / bandStride;
+  const float qHi = (hi - spanBase) / bandStride;
+  const int first = std::clamp(static_cast<int>(std::floor(qLo - kBandQuotientPad)), 0,
                                static_cast<int>(bandCount) - 1);
-  const int last = std::clamp(static_cast<int>(std::floor((hi - spanBase) / bandStride)), first,
+  const int last = std::clamp(static_cast<int>(std::floor(qHi + kBandQuotientPad)), first,
                               static_cast<int>(bandCount) - 1);
   return BandSpan{static_cast<uint16_t>(first), static_cast<uint16_t>(last)};
 }
@@ -565,6 +576,8 @@ void bandCurves(const std::vector<CurveWithRange>& allCurves, const Box2d& bound
                 std::vector<EncodedPath::Curve>& outCurves, std::vector<uint32_t>& outCurveIndices,
                 uint16_t bandCount, std::vector<uint32_t>& outGrid,
                 EncodedPath::AxisStats& outStats) {
+  // The fixed-size count/scratch arrays below index up to bandCount.
+  UTILS_RELEASE_ASSERT(bandCount <= kMaxBands);
   // Dense cell → band-slot map (kNoBand for empty cells). Sized to the full grid even when
   // some cells are empty, so the fragment shader can index it directly by position.
   outGrid.assign(bandCount, EncodedPath::kNoBand);

--- a/donner/svg/renderer/geode/GeodePathEncoder.cc
+++ b/donner/svg/renderer/geode/GeodePathEncoder.cc
@@ -1,6 +1,7 @@
 #include "donner/svg/renderer/geode/GeodePathEncoder.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <limits>
 #include <numeric>
@@ -170,18 +171,19 @@ std::optional<BandSpan> curveBandSpan(const CurveRange& range, const Box2d& boun
   const float bandStride = span / static_cast<float>(bandCount);
   const float lo = byY ? range.yMin : range.xMin;
   const float hi = byY ? range.yMax : range.xMax;
-  const float hiExclusive = std::nextafter(hi, -std::numeric_limits<float>::infinity());
 
   const int first = std::clamp(static_cast<int>(std::floor((lo - spanBase) / bandStride)), 0,
                                static_cast<int>(bandCount) - 1);
-  const int last = std::clamp(static_cast<int>(std::floor((hiExclusive - spanBase) / bandStride)),
-                              first, static_cast<int>(bandCount) - 1);
+  const int last = std::clamp(static_cast<int>(std::floor((hi - spanBase) / bandStride)), first,
+                              static_cast<int>(bandCount) - 1);
   return BandSpan{static_cast<uint16_t>(first), static_cast<uint16_t>(last)};
 }
 
 BandMetrics evaluateBandCount(const std::vector<CurveWithRange>& curves, const Box2d& bounds,
                               BandAxis axis, uint16_t bandCount) {
-  std::vector<int32_t> countDeltas(static_cast<size_t>(bandCount) + 1u, 0);
+  UTILS_RELEASE_ASSERT(bandCount <= kMaxBands);
+  std::array<int32_t, static_cast<size_t>(kMaxBands) + 1u> countDeltas;
+  std::fill_n(countDeltas.begin(), static_cast<size_t>(bandCount) + 1u, 0);
   for (const CurveWithRange& curve : curves) {
     const std::optional<BandSpan> span = curveBandSpan(curve.range, bounds, axis, bandCount);
     if (!span) {
@@ -194,8 +196,8 @@ BandMetrics evaluateBandCount(const std::vector<CurveWithRange>& curves, const B
   }
 
   BandMetrics metrics;
-  std::vector<uint32_t> nonemptyCounts;
-  nonemptyCounts.reserve(bandCount);
+  std::array<uint32_t, kMaxBands> nonemptyCounts;
+  size_t nonemptyCount = 0u;
   int32_t runningCount = 0;
   for (uint16_t band = 0; band < bandCount; ++band) {
     runningCount += countDeltas[band];
@@ -203,12 +205,12 @@ BandMetrics evaluateBandCount(const std::vector<CurveWithRange>& curves, const B
     metrics.totalReferences += count;
     metrics.maxCurves = std::max(metrics.maxCurves, count);
     if (count != 0u) {
-      nonemptyCounts.push_back(count);
+      nonemptyCounts[nonemptyCount++] = count;
     }
   }
-  if (!nonemptyCounts.empty()) {
-    std::sort(nonemptyCounts.begin(), nonemptyCounts.end());
-    const size_t p95Index = (nonemptyCounts.size() * 95u + 99u) / 100u - 1u;
+  if (nonemptyCount != 0u) {
+    std::sort(nonemptyCounts.begin(), nonemptyCounts.begin() + nonemptyCount);
+    const size_t p95Index = (nonemptyCount * 95u + 99u) / 100u - 1u;
     metrics.p95Curves = nonemptyCounts[p95Index];
   }
   return metrics;
@@ -597,7 +599,8 @@ void bandCurves(const std::vector<CurveWithRange>& allCurves, const Box2d& bound
 
   // Build the compact row offsets directly. This avoids one heap allocation per band while
   // preserving the globally sorted reference order inside every row.
-  std::vector<uint32_t> bandCounts(bandCount, 0u);
+  std::array<uint32_t, kMaxBands> bandCounts;
+  std::fill_n(bandCounts.begin(), bandCount, 0u);
   for (const CurveWithRange& curve : allCurves) {
     const std::optional<BandSpan> curveSpan = curveBandSpan(curve.range, bounds, axis, bandCount);
     if (!curveSpan) {
@@ -608,11 +611,12 @@ void bandCurves(const std::vector<CurveWithRange>& allCurves, const Box2d& bound
     }
   }
 
+  const size_t bandBase = outBands.size();
   outBands.reserve(outBands.size() + bandCount);
   const size_t referenceBase = outCurveIndices.size();
   uint64_t totalReferences = 0u;
-  std::vector<uint32_t> nonemptyCounts;
-  nonemptyCounts.reserve(bandCount);
+  std::array<uint32_t, kMaxBands> nonemptyCounts;
+  size_t nonemptyCount = 0u;
 
   for (uint16_t b = 0; b < bandCount; ++b) {
     const uint32_t count = bandCounts[b];
@@ -629,17 +633,16 @@ void bandCurves(const std::vector<CurveWithRange>& allCurves, const Box2d& bound
     outBands.push_back(
         {static_cast<uint32_t>(referenceBase + totalReferences), static_cast<uint32_t>(count)});
     totalReferences += count;
-    nonemptyCounts.push_back(count);
+    nonemptyCounts[nonemptyCount++] = count;
   }
 
   UTILS_RELEASE_ASSERT_MSG(totalReferences <= std::numeric_limits<size_t>::max() - referenceBase,
                            "Geode path band references overflow addressable storage");
   outCurveIndices.resize(referenceBase + static_cast<size_t>(totalReferences));
-  std::vector<uint32_t> writeOffsets(bandCount, 0u);
   for (uint16_t b = 0; b < bandCount; ++b) {
     const uint32_t slot = outGrid[b];
     if (slot != EncodedPath::kNoBand) {
-      writeOffsets[b] = outBands[slot].curveStart;
+      bandCounts[b] = outBands[slot].curveStart;
     }
   }
   for (size_t ci : sortedCurveIndices) {
@@ -649,21 +652,21 @@ void bandCurves(const std::vector<CurveWithRange>& allCurves, const Box2d& bound
       continue;
     }
     for (uint16_t band = curveSpan->first; band <= curveSpan->last; ++band) {
-      outCurveIndices[writeOffsets[band]++] = canonicalBase + static_cast<uint32_t>(ci);
+      outCurveIndices[bandCounts[band]++] = canonicalBase + static_cast<uint32_t>(ci);
     }
   }
 
-  std::sort(nonemptyCounts.begin(), nonemptyCounts.end());
+  std::sort(nonemptyCounts.begin(), nonemptyCounts.begin() + nonemptyCount);
   outStats.canonicalCurveCount = static_cast<uint32_t>(allCurves.size());
   outStats.curveReferenceCount = static_cast<uint32_t>(totalReferences);
   outStats.gridBandCount = bandCount;
-  outStats.nonemptyBandCount = static_cast<uint32_t>(outBands.size());
-  if (!nonemptyCounts.empty()) {
-    outStats.maxCurvesPerBand = nonemptyCounts.back();
-    const size_t p95Index = (nonemptyCounts.size() * 95u + 99u) / 100u - 1u;
+  outStats.nonemptyBandCount = static_cast<uint32_t>(outBands.size() - bandBase);
+  if (nonemptyCount != 0u) {
+    outStats.maxCurvesPerBand = nonemptyCounts[nonemptyCount - 1u];
+    const size_t p95Index = (nonemptyCount * 95u + 99u) / 100u - 1u;
     outStats.p95CurvesPerBand = nonemptyCounts[p95Index];
     outStats.meanCurvesPerBand =
-        static_cast<double>(totalReferences) / static_cast<double>(nonemptyCounts.size());
+        static_cast<double>(totalReferences) / static_cast<double>(nonemptyCount);
   }
 }
 

--- a/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
@@ -216,7 +216,13 @@ TEST(GeodePathEncoder, CurveEndingOnBandBoundaryIsReferencedByFollowingBand) {
     const float curveMax = std::max({curve.p0y, curve.p1y, curve.p2y});
     const float gridPosition = (curveMax - encoded.yBase) / encoded.hStride;
     const float roundedPosition = std::round(gridPosition);
-    if (std::abs(gridPosition - roundedPosition) > 1e-6f || roundedPosition <= 0.0f ||
+    // Select curves ending ON or NEAR a boundary. The 1e-4 tolerance is
+    // deliberately inside the encoder's quotient-space pad (kBandQuotientPad,
+    // 1e-3, in GeodePathEncoder.cc), which guarantees any such curve is
+    // referenced from BOTH adjacent cells; a wider tolerance than the pad
+    // would assert more than the encoder provides and fail on a
+    // legitimately-binned curve.
+    if (std::abs(gridPosition - roundedPosition) > 1e-4f || roundedPosition <= 0.0f ||
         roundedPosition >= static_cast<float>(encoded.hBandCount)) {
       continue;
     }

--- a/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePathEncoder_tests.cc
@@ -199,6 +199,42 @@ TEST(GeodePathEncoder, ChoosesBandCountFromCurveDistribution) {
       << "A compact path with many separated curve clusters needs more than one band";
 }
 
+TEST(GeodePathEncoder, CurveEndingOnBandBoundaryIsReferencedByFollowingBand) {
+  PathBuilder builder;
+  for (int i = 0; i < 16; ++i) {
+    const double y = static_cast<double>(i);
+    builder.addRect(Box2d({0, y}, {10, y + 1.0}));
+  }
+
+  const EncodedPath encoded = GeodePathEncoder::encode(builder.build(), FillRule::NonZero);
+  ASSERT_FALSE(encoded.empty());
+  ASSERT_GT(encoded.hBandCount, 1u);
+
+  bool foundBoundaryEndingCurve = false;
+  for (uint32_t curveIndex = 0; curveIndex < encoded.curves.size(); ++curveIndex) {
+    const EncodedPath::Curve& curve = encoded.curves[curveIndex];
+    const float curveMax = std::max({curve.p0y, curve.p1y, curve.p2y});
+    const float gridPosition = (curveMax - encoded.yBase) / encoded.hStride;
+    const float roundedPosition = std::round(gridPosition);
+    if (std::abs(gridPosition - roundedPosition) > 1e-6f || roundedPosition <= 0.0f ||
+        roundedPosition >= static_cast<float>(encoded.hBandCount)) {
+      continue;
+    }
+
+    foundBoundaryEndingCurve = true;
+    const uint32_t cell = static_cast<uint32_t>(roundedPosition);
+    const uint32_t slot = encoded.hBandGrid[cell];
+    ASSERT_NE(slot, EncodedPath::kNoBand);
+    ASSERT_LT(slot, encoded.bands.size());
+    const EncodedPath::Band& band = encoded.bands[slot];
+    const auto first = encoded.curveIndices.begin() + band.curveStart;
+    const auto last = first + band.curveCount;
+    EXPECT_NE(std::find(first, last, curveIndex), last)
+        << "A curve touching a band boundary must be visible from both adjacent cells";
+  }
+  EXPECT_TRUE(foundBoundaryEndingCurve) << "Fixture must exercise an internal band boundary";
+}
+
 TEST(GeodePathEncoder, StoresEachCurveOnceInsteadOfDuplicatingItAcrossBands) {
   const Path path = PathBuilder()
                         .moveTo(Vector2d(0, 0))


### PR DESCRIPTION
Adds engine_compare_bench, a cross-engine SVG performance probe that separates device setup, parse, first settled frame, and unchanged second frame with allocation and RSS telemetry, plus a --backend=tiny-skia mode that runs Donner's in-tree CPU renderer through the same passes for a direct GPU-vs-CPU comparison. Also fixes a two-pixel Sunburst hole where a curve ending exactly on a band boundary was omitted from the following cell, and moves bounded band-selection scratch to the stack.

Verification: focused encoder, perf, and golden tests plus the full Geode repository gate at this layer's head, all green. The benchmark links both backends directly like the parity test binary, which the geode_excludes_tiny_skia_audit permits.

Post-review hardening: the CPU band binning is padded by a quotient-space epsilon in both directions so relaxed-precision GPU division cannot re-open the boundary hole on near-boundary endpoints (extra references are cost-only; the shader re-filters by exact axis ownership), the band-count bound the fixed-size scratch arrays rely on is release-asserted, and the benchmark now reports a per-run pixel fingerprint (FNV-1a plus nonzero byte count) so a stale or empty frame cannot masquerade as a speedup, measures RSS on macOS via task_info with an explicit rss_supported flag, and labels ALLOC lines cpp_heap_only because wgpu-native's Rust-side allocations are invisible to the operator-new tracker.
