### PR TITLE
perf: Move snapshot unpremultiplication to the GPU and cut map-wait polling latency

### DIFF
--- a/donner/editor/wasm/BUILD.bazel
+++ b/donner/editor/wasm/BUILD.bazel
@@ -305,6 +305,14 @@ py_test(
         # whole-app worker the default: wasm 11,124,823 raw / 4,443,900 gzip,
         # js 168,939 raw / 47,708 gzip, package 11,335,146 raw. A gate with
         # megabytes of slack does not catch the regression it exists for.
+        #
+        # Geode perf stack retune: the GPU-side snapshot readback adds
+        # deliberate renderer code to the editor package, and the emscripten
+        # glue grows with it. Measured at this layer: js 170,862 raw /
+        # 48,316 gzip (main measured 48,284 gzip, 16 bytes under the old
+        # budget, so the gate could no longer absorb intended growth).
+        # Budget keeps about 1 percent headroom over the final stack
+        # measurement of 48,319 gzip.
         "--max-wasm-raw-bytes",
         "11240000",
         "--max-wasm-gzip-bytes",
@@ -316,7 +324,7 @@ py_test(
         "--max-js-raw-bytes",
         "171000",
         "--max-js-gzip-bytes",
-        "48300",
+        "48800",
         "--max-total-raw-bytes",
         "11450000",
         "--expected-js-property",

--- a/donner/editor/wasm/BUILD.bazel
+++ b/donner/editor/wasm/BUILD.bazel
@@ -311,8 +311,11 @@ py_test(
         # glue grows with it. Measured at this layer: js 170,862 raw /
         # 48,316 gzip (main measured 48,284 gzip, 16 bytes under the old
         # budget, so the gate could no longer absorb intended growth).
-        # Budget keeps about 1 percent headroom over the final stack
-        # measurement of 48,319 gzip.
+        # Budgets keep about 1 percent headroom over the measured values
+        # for BOTH the gzip and raw js gates: retuning only the gzip gate
+        # would leave the raw gate at 138 bytes of headroom over the
+        # measured 170,862 raw, making it the one that flips red on the
+        # next incidental change.
         "--max-wasm-raw-bytes",
         "11240000",
         "--max-wasm-gzip-bytes",
@@ -322,7 +325,7 @@ py_test(
         "--max-wasm-data-segments",
         "64",
         "--max-js-raw-bytes",
-        "171000",
+        "172500",
         "--max-js-gzip-bytes",
         "48800",
         "--max-total-raw-bytes",

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -4859,10 +4859,13 @@ ReadbackMapStatus MapAndWaitReadback(const std::shared_ptr<geode::GeodeDevice>& 
 #endif
     // Never ask wgpu-native to block until the GPU map completes: a low-priority thumbnail must
     // observe a superseding main-document request promptly. Native polling is
-    // non-blocking and gets a short sleep to avoid spinning.
+    // non-blocking and gets a short sleep to avoid spinning. The 100 us sleep
+    // bounds the snapshot latency floor without the 1 ms quanta that used to
+    // dominate small-fixture readbacks; the poll itself processes the map
+    // completion callback as soon as the GPU delivers it.
     device->pollSuspending(false);
 #ifndef __EMSCRIPTEN__
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    std::this_thread::sleep_for(std::chrono::microseconds(100));
 #endif
   }
   device->recordReadback(usedTimedWaitAny, pollIter);

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -294,10 +294,12 @@ double computeBlurPadding(const components::FilterGraph& filterGraph) {
 }
 
 /// WebGPU requires bytesPerRow alignment to 256 when copying textures to
-/// buffers. This rounds the unpadded row width up to the next 256 boundary.
+/// buffers. Delegates to the shared helper so the renderer's map-range math
+/// can never diverge from the readback-buffer sizing in GeodeDevice: a
+/// mapped-range request larger than the buffer returns null rather than
+/// raising a validation error.
 constexpr uint32_t alignBytesPerRow(uint32_t unpadded) {
-  constexpr uint32_t kAlign = 256u;
-  return (unpadded + kAlign - 1u) & ~(kAlign - 1u);
+  return geode::AlignReadbackBytesPerRow(unpadded);
 }
 
 /// Convert an SVG stroke-linecap enum to the donner::LineCap used by
@@ -4774,8 +4776,13 @@ namespace {
 enum class ReadbackMapStatus {
   /// The map completed successfully; the buffer is mapped and owned by the caller until unmap().
   Success,
-  /// A cancellation request or the deadline fired; the buffer was unmapped and destroyed.
+  /// A cancellation request fired; the buffer was unmapped and destroyed.
   Cancelled,
+  /// The 10-second deadline expired with no map completion; the buffer was
+  /// unmapped and destroyed. Distinct from Cancelled so a caller can avoid
+  /// starting a second full-deadline wait against a device that just proved
+  /// unresponsive.
+  TimedOut,
   /// The map completed with a non-success status.
   Failed,
 };
@@ -4821,11 +4828,16 @@ ReadbackMapStatus MapAndWaitReadback(const std::shared_ptr<geode::GeodeDevice>& 
       buffer.mapAsync(wgpu::MapMode::Read, 0, mapSize, mapCb);
   int pollIter = 0;
   bool cancelled = false;
+  bool timedOut = false;
   bool usedTimedWaitAny = false;
   const auto readbackDeadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
   while (!mapState->done.load(std::memory_order_acquire)) {
-    if ((shouldCancel && shouldCancel()) || std::chrono::steady_clock::now() >= readbackDeadline) {
+    if (shouldCancel && shouldCancel()) {
       cancelled = true;
+      break;
+    }
+    if (std::chrono::steady_clock::now() >= readbackDeadline) {
+      timedOut = true;
       break;
     }
     ++pollIter;
@@ -4869,13 +4881,13 @@ ReadbackMapStatus MapAndWaitReadback(const std::shared_ptr<geode::GeodeDevice>& 
 #endif
   }
   device->recordReadback(usedTimedWaitAny, pollIter);
-  if (cancelled) {
+  if (cancelled || timedOut) {
     // Cancelling a pending map schedules its callback with an aborted status. The callback's
     // reference keeps `mapState` valid even when delivery happens after this method returns.
     buffer.unmap();
     buffer.destroy();
     mapState->release();
-    return ReadbackMapStatus::Cancelled;
+    return cancelled ? ReadbackMapStatus::Cancelled : ReadbackMapStatus::TimedOut;
   }
 
   const bool mapOk = mapState->ok.load(std::memory_order_acquire);
@@ -4896,8 +4908,10 @@ ReadbackMapStatus MapAndWaitReadback(const std::shared_ptr<geode::GeodeDevice>& 
 RendererBitmap ReadGeodeTextureSnapshotGpu(const std::shared_ptr<geode::GeodeDevice>& device,
                                            const wgpu::Texture& texture, uint32_t width,
                                            uint32_t height,
-                                           const std::function<bool()>& shouldCancel) {
+                                           const std::function<bool()>& shouldCancel,
+                                           bool& outTimedOut) {
   RendererBitmap bitmap;
+  outTimedOut = false;
   const geode::GeodeSnapshotReadbackPipeline& readbackPipeline =
       device->snapshotReadbackPipeline();
   if (!readbackPipeline.valid()) {
@@ -4906,7 +4920,7 @@ RendererBitmap ReadGeodeTextureSnapshotGpu(const std::shared_ptr<geode::GeodeDev
 
   // Pooled staging texture + readback buffer, keyed by size. Repeat snapshots
   // at the same dimensions reuse the entry, so steady-state readback
-  // allocates nothing (design doc 0030 Milestone 4.2).
+  // allocates nothing.
   geode::SnapshotReadbackResources resources =
       device->acquireSnapshotReadbackResources(width, height);
   if (resources.empty()) {
@@ -4957,16 +4971,26 @@ RendererBitmap ReadGeodeTextureSnapshotGpu(const std::shared_ptr<geode::GeodeDev
   device->queue().submit(1, &cmd.get());
   device->countSubmit();
 
-  if (MapAndWaitReadback(device, resources.readback.get(), mapSize, shouldCancel) !=
-      ReadbackMapStatus::Success) {
-    // Cancelled or failed: the helper already unmapped and destroyed the
-    // readback buffer, so the entry cannot be pooled. Fall back to the CPU
-    // copy path below, which re-checks cancellation before doing any work.
+  const ReadbackMapStatus mapStatus =
+      MapAndWaitReadback(device, resources.readback.get(), mapSize, shouldCancel);
+  if (mapStatus != ReadbackMapStatus::Success) {
+    // Cancelled, timed out, or failed: the helper already unmapped and
+    // destroyed the readback buffer, so the entry cannot be pooled. The
+    // caller uses outTimedOut to avoid a second full-deadline wait against
+    // an unresponsive device.
+    outTimedOut = mapStatus == ReadbackMapStatus::TimedOut;
     return bitmap;
   }
 
   const uint8_t* mapped = static_cast<const uint8_t*>(
       resources.readback.get().getConstMappedRange(0, mapSize));
+  if (mapped == nullptr) {
+    // A mapped-range/buffer-size mismatch returns null instead of raising a
+    // validation error. Unmap and drop the entry (do not pool a buffer whose
+    // sizing math disagreed with ours) and let the CPU path take over.
+    resources.readback.get().unmap();
+    return bitmap;
+  }
 
   // The staging texture already holds straight-alpha RGBA, so the CPU only
   // strips row padding.
@@ -5010,20 +5034,29 @@ static RendererBitmap ReadGeodeTextureSnapshot(const std::shared_ptr<geode::Geod
   // GPU unpremultiply path: premultiplied RGBA8Unorm render targets only. The
   // compute shader produces straight RGBA regardless of the texture's memory
   // layout, but BGRA targets keep the proven CPU path for now.
+  // Gate on the texture's REAL format as well as the caller-declared one:
+  // the compute pass binds a view that inherits the texture's actual format,
+  // so an sRGB surface declared as RGBA8Unorm would be silently linearized
+  // by textureLoad and re-quantized into wrong bytes with no validation
+  // error, where the CPU copy path degrades only to a channel-order bug.
   if (sourceAlphaType == AlphaType::Premultiplied &&
-      format == wgpu::TextureFormat::RGBA8Unorm &&
+      format == wgpu::TextureFormat::RGBA8Unorm && texture.getFormat() == format &&
       (static_cast<WGPUTextureUsage>(texture.getUsage()) &
        static_cast<WGPUTextureUsage>(wgpu::TextureUsage::TextureBinding)) != 0u) {
+    bool gpuTimedOut = false;
     RendererBitmap gpuBitmap =
-        ReadGeodeTextureSnapshotGpu(device, texture, width, height, shouldCancel);
+        ReadGeodeTextureSnapshotGpu(device, texture, width, height, shouldCancel, gpuTimedOut);
     if (!gpuBitmap.empty()) {
       return gpuBitmap;
     }
-    // The GPU path returned empty: either the map was cancelled or it failed.
-    // A cancellation must return here so a superseding request is not delayed
-    // by a second GPU round-trip; only a genuine failure falls back to the
-    // CPU copy path below.
-    if (shouldCancel && shouldCancel()) {
+    // The GPU path returned empty: cancelled, timed out, or failed. A
+    // cancellation must return here so a superseding request is not delayed
+    // by a second GPU round-trip. A timeout must also return: the device
+    // just spent the full deadline not delivering a map, and the CPU copy
+    // path would begin another full-deadline wait against the same
+    // unresponsive device, turning a 10 s stall into 20 s. Only a genuine
+    // map failure falls back to the CPU copy path below.
+    if ((shouldCancel && shouldCancel()) || gpuTimedOut) {
       return bitmap;
     }
   }
@@ -5062,6 +5095,12 @@ static RendererBitmap ReadGeodeTextureSnapshot(const std::shared_ptr<geode::Geod
 
   const uint8_t* mapped =
       static_cast<const uint8_t*>(readback.get().getConstMappedRange(0, bd.size));
+  if (mapped == nullptr) {
+    // Size mismatch between the map request and the buffer returns null
+    // rather than raising a validation error; never memcpy from it.
+    readback.get().unmap();
+    return bitmap;
+  }
 
   // Strip row padding and unpremultiply alpha so the consumer gets a tightly
   // packed *straight-alpha* RGBA buffer. `GeoEncoder::fillPath` premultiplies

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstdio>
+#include <cstring>
 #include <iostream>
 #include <map>
 #include <mutex>
@@ -4760,51 +4761,33 @@ RendererBitmap RendererGeode::takeSnapshot() const {
 // bitmap. Shared by the live renderer target and detached texture snapshots.
 // `sourceAlphaType` describes the texels: render targets store premultiplied alpha and are
 // divided back out, while a snapshot wrapping a straight-alpha host upload is copied as-is.
-static RendererBitmap ReadGeodeTextureSnapshot(const std::shared_ptr<geode::GeodeDevice>& device,
-                                               const wgpu::Texture& texture, Vector2i dimensions,
-                                               wgpu::TextureFormat format,
-                                               AlphaType sourceAlphaType,
-                                               const std::function<bool()>& shouldCancel) {
-  RendererBitmap bitmap;
-  // Close the traversal-to-snapshot race before allocating a readback buffer or submitting any GPU
-  // work. A main-document request may arrive immediately after the thumbnail finishes drawing.
-  if (shouldCancel && shouldCancel()) {
-    return bitmap;
-  }
-  if (!device || !texture || dimensions.x <= 0 || dimensions.y <= 0) {
-    return bitmap;
-  }
+//
+// Premultiplied RGBA8Unorm targets take the GPU path: a compute pass
+// unpremultiplies the target into a straight-alpha RGBA8 staging texture,
+// which is then copied into a map-readable buffer and packed out. The GPU
+// path output is byte-identical to the CPU reference loop below. Everything
+// else (BGRA targets, straight-alpha host uploads, unbindable textures) uses
+// the CPU copy path.
+namespace {
 
-  const uint32_t width = static_cast<uint32_t>(dimensions.x);
-  const uint32_t height = static_cast<uint32_t>(dimensions.y);
-  const uint32_t bytesPerRow = alignBytesPerRow(width * 4u);
+/// Outcome of a completed readback map wait.
+enum class ReadbackMapStatus {
+  /// The map completed successfully; the buffer is mapped and owned by the caller until unmap().
+  Success,
+  /// A cancellation request or the deadline fired; the buffer was unmapped and destroyed.
+  Cancelled,
+  /// The map completed with a non-success status.
+  Failed,
+};
 
-  // Allocate readback buffer.
-  wgpu::BufferDescriptor bd = {};
-  bd.label = wgpuLabel("RendererGeodeReadback");
-  bd.size = static_cast<uint64_t>(bytesPerRow) * static_cast<uint64_t>(height);
-  bd.usage = wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::MapRead;
-  geode::ScopedWgpuHandle<wgpu::Buffer> readback(device->device().createBuffer(bd));
-  device->countBuffer();
-
-  // Copy texture → readback buffer.
-  geode::ScopedWgpuHandle<wgpu::CommandEncoder> enc(device->device().createCommandEncoder());
-  wgpu::TexelCopyTextureInfo src = {};
-  src.texture = texture;
-  src.mipLevel = 0;
-  src.origin = {0, 0, 0};
-  wgpu::TexelCopyBufferInfo dst = {};
-  dst.buffer = readback.get();
-  dst.layout.bytesPerRow = bytesPerRow;
-  dst.layout.rowsPerImage = height;
-  wgpu::Extent3D copySize = {width, height, 1};
-  enc.get().copyTextureToBuffer(src, dst, copySize);
-
-  geode::ScopedWgpuHandle<wgpu::CommandBuffer> cmd(enc.get().finish());
-  device->queue().submit(1, &cmd.get());
-  device->countSubmit();
-
-  // Map for read. `BufferMapCallbackInfo` takes raw userdata rather than a std::function, and a
+/// Map `buffer` for read and wait for the GPU to deliver it. On cancellation,
+/// timeout, or map failure the buffer is unmapped and destroyed and a
+/// non-success status is returned. Readback poll statistics are recorded on
+/// the device regardless of the outcome.
+ReadbackMapStatus MapAndWaitReadback(const std::shared_ptr<geode::GeodeDevice>& device,
+                                     const wgpu::Buffer& buffer, uint64_t mapSize,
+                                     const std::function<bool()>& shouldCancel) {
+  // `BufferMapCallbackInfo` takes raw userdata rather than a std::function, and a
   // cancellation may return before WebGPU delivers that callback. Keep its payload alive
   // independently of this stack frame: one reference belongs to this caller, the other to the
   // callback. The state intentionally owns no WebGPU handles, so its final release is safe even
@@ -4832,7 +4815,10 @@ static RendererBitmap ReadGeodeTextureSnapshot(const std::shared_ptr<geode::Geod
   mapCb.userdata1 = mapState;
   mapCb.userdata2 = nullptr;
   mapCb.mode = wgpu::CallbackMode::AllowSpontaneous;
-  const wgpu::Future mapFuture = readback.get().mapAsync(wgpu::MapMode::Read, 0, bd.size, mapCb);
+  // Emscripten-only: the browser timed-wait path below consumes `mapFuture`;
+  // native builds finish without touching it.
+  [[maybe_unused]] const wgpu::Future mapFuture =
+      buffer.mapAsync(wgpu::MapMode::Read, 0, mapSize, mapCb);
   int pollIter = 0;
   bool cancelled = false;
   bool usedTimedWaitAny = false;
@@ -4883,15 +4869,191 @@ static RendererBitmap ReadGeodeTextureSnapshot(const std::shared_ptr<geode::Geod
   if (cancelled) {
     // Cancelling a pending map schedules its callback with an aborted status. The callback's
     // reference keeps `mapState` valid even when delivery happens after this method returns.
-    readback.get().unmap();
-    readback.get().destroy();
+    buffer.unmap();
+    buffer.destroy();
     mapState->release();
-    return bitmap;
+    return ReadbackMapStatus::Cancelled;
   }
 
   const bool mapOk = mapState->ok.load(std::memory_order_acquire);
   mapState->release();
-  if (!mapOk) {
+  return mapOk ? ReadbackMapStatus::Success : ReadbackMapStatus::Failed;
+}
+
+/// GPU-side snapshot readback for premultiplied RGBA8Unorm render targets: a
+/// compute pass unpremultiplies the target into a straight-alpha RGBA8
+/// staging texture, which is then copied into a map-readable buffer. The
+/// output bytes are identical to the CPU reference loop in
+/// ReadGeodeTextureSnapshot. Returns an empty bitmap on any failure so the
+/// caller can fall back to the CPU copy path.
+///
+/// wgpu-native forbids combining MAP_READ with STORAGE on a single buffer, so
+/// the compute output cannot be mapped directly; the staging-texture copy is
+/// the standard readback shape.
+RendererBitmap ReadGeodeTextureSnapshotGpu(const std::shared_ptr<geode::GeodeDevice>& device,
+                                           const wgpu::Texture& texture, uint32_t width,
+                                           uint32_t height,
+                                           const std::function<bool()>& shouldCancel) {
+  RendererBitmap bitmap;
+  const geode::GeodeSnapshotReadbackPipeline& readbackPipeline =
+      device->snapshotReadbackPipeline();
+  if (!readbackPipeline.valid()) {
+    return bitmap;
+  }
+
+  // Pooled staging texture + readback buffer, keyed by size. Repeat snapshots
+  // at the same dimensions reuse the entry, so steady-state readback
+  // allocates nothing (design doc 0030 Milestone 4.2).
+  geode::SnapshotReadbackResources resources =
+      device->acquireSnapshotReadbackResources(width, height);
+  if (resources.empty()) {
+    return bitmap;
+  }
+  const uint32_t bytesPerRow = alignBytesPerRow(width * 4u);
+  const uint64_t mapSize = static_cast<uint64_t>(bytesPerRow) * static_cast<uint64_t>(height);
+
+  geode::ScopedWgpuHandle<wgpu::TextureView> inputView(texture.createView());
+  wgpu::BindGroupEntry bgEntries[2] = {};
+  bgEntries[0].binding = 0;
+  bgEntries[0].textureView = inputView.get();
+  bgEntries[1].binding = 1;
+  bgEntries[1].textureView = resources.stagingView.get();
+  wgpu::BindGroupDescriptor bgDesc = {};
+  bgDesc.label = wgpuLabel("RendererGeodeReadbackBG");
+  bgDesc.layout = readbackPipeline.bindGroupLayout();
+  bgDesc.entryCount = 2;
+  bgDesc.entries = bgEntries;
+  geode::ScopedWgpuHandle<wgpu::BindGroup> bindGroup(device->device().createBindGroup(bgDesc));
+  device->countBindGroup();
+
+  // Record the unpremultiply compute pass and the staging-texture copy into
+  // one command buffer, then submit it on the device queue.
+  geode::ScopedWgpuHandle<wgpu::CommandEncoder> enc(device->device().createCommandEncoder());
+  wgpu::ComputePassDescriptor passDesc = {};
+  passDesc.label = wgpuLabel("RendererGeodeReadbackPass");
+  geode::ScopedWgpuHandle<wgpu::ComputePassEncoder> pass(enc.get().beginComputePass(passDesc));
+  pass.get().setPipeline(readbackPipeline.pipeline());
+  pass.get().setBindGroup(0, bindGroup.get(), 0, nullptr);
+  pass.get().dispatchWorkgroups((width + 7) / 8, (height + 7) / 8, 1);
+  pass.get().end();
+  pass.reset();
+
+  wgpu::TexelCopyTextureInfo src = {};
+  src.texture = resources.staging.get();
+  src.mipLevel = 0;
+  src.origin = {0, 0, 0};
+  wgpu::TexelCopyBufferInfo dst = {};
+  dst.buffer = resources.readback.get();
+  dst.layout.bytesPerRow = bytesPerRow;
+  dst.layout.rowsPerImage = height;
+  wgpu::Extent3D copySize = {width, height, 1};
+  enc.get().copyTextureToBuffer(src, dst, copySize);
+
+  geode::ScopedWgpuHandle<wgpu::CommandBuffer> cmd(enc.get().finish());
+  enc.reset();
+  device->queue().submit(1, &cmd.get());
+  device->countSubmit();
+
+  if (MapAndWaitReadback(device, resources.readback.get(), mapSize, shouldCancel) !=
+      ReadbackMapStatus::Success) {
+    // Cancelled or failed: the helper already unmapped and destroyed the
+    // readback buffer, so the entry cannot be pooled. Fall back to the CPU
+    // copy path below, which re-checks cancellation before doing any work.
+    return bitmap;
+  }
+
+  const uint8_t* mapped = static_cast<const uint8_t*>(
+      resources.readback.get().getConstMappedRange(0, mapSize));
+
+  // The staging texture already holds straight-alpha RGBA, so the CPU only
+  // strips row padding.
+  bitmap.dimensions = Vector2i(static_cast<int>(width), static_cast<int>(height));
+  bitmap.rowBytes = static_cast<size_t>(width) * 4u;
+  bitmap.alphaType = AlphaType::Unpremultiplied;
+  bitmap.pixels.resize(bitmap.rowBytes * height);
+  for (uint32_t y = 0; y < height; ++y) {
+    if (shouldCancel && shouldCancel()) {
+      resources.readback.get().unmap();
+      return {};
+    }
+    std::memcpy(bitmap.pixels.data() + static_cast<size_t>(y) * bitmap.rowBytes,
+                mapped + static_cast<size_t>(y) * bytesPerRow, bitmap.rowBytes);
+  }
+  resources.readback.get().unmap();
+  device->releaseSnapshotReadbackResources(std::move(resources));
+  return bitmap;
+}
+
+}  // namespace
+
+static RendererBitmap ReadGeodeTextureSnapshot(const std::shared_ptr<geode::GeodeDevice>& device,
+                                               const wgpu::Texture& texture, Vector2i dimensions,
+                                               wgpu::TextureFormat format,
+                                               AlphaType sourceAlphaType,
+                                               const std::function<bool()>& shouldCancel) {
+  RendererBitmap bitmap;
+  // Close the traversal-to-snapshot race before allocating a readback buffer or submitting any GPU
+  // work. A main-document request may arrive immediately after the thumbnail finishes drawing.
+  if (shouldCancel && shouldCancel()) {
+    return bitmap;
+  }
+  if (!device || !texture || dimensions.x <= 0 || dimensions.y <= 0) {
+    return bitmap;
+  }
+
+  const uint32_t width = static_cast<uint32_t>(dimensions.x);
+  const uint32_t height = static_cast<uint32_t>(dimensions.y);
+
+  // GPU unpremultiply path: premultiplied RGBA8Unorm render targets only. The
+  // compute shader produces straight RGBA regardless of the texture's memory
+  // layout, but BGRA targets keep the proven CPU path for now.
+  if (sourceAlphaType == AlphaType::Premultiplied &&
+      format == wgpu::TextureFormat::RGBA8Unorm &&
+      (static_cast<WGPUTextureUsage>(texture.getUsage()) &
+       static_cast<WGPUTextureUsage>(wgpu::TextureUsage::TextureBinding)) != 0u) {
+    RendererBitmap gpuBitmap =
+        ReadGeodeTextureSnapshotGpu(device, texture, width, height, shouldCancel);
+    if (!gpuBitmap.empty()) {
+      return gpuBitmap;
+    }
+    // The GPU path returned empty: either the map was cancelled or it failed.
+    // A cancellation must return here so a superseding request is not delayed
+    // by a second GPU round-trip; only a genuine failure falls back to the
+    // CPU copy path below.
+    if (shouldCancel && shouldCancel()) {
+      return bitmap;
+    }
+  }
+
+  const uint32_t bytesPerRow = alignBytesPerRow(width * 4u);
+
+  // Allocate readback buffer.
+  wgpu::BufferDescriptor bd = {};
+  bd.label = wgpuLabel("RendererGeodeReadback");
+  bd.size = static_cast<uint64_t>(bytesPerRow) * static_cast<uint64_t>(height);
+  bd.usage = wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::MapRead;
+  geode::ScopedWgpuHandle<wgpu::Buffer> readback(device->device().createBuffer(bd));
+  device->countBuffer();
+
+  // Copy texture → readback buffer.
+  geode::ScopedWgpuHandle<wgpu::CommandEncoder> enc(device->device().createCommandEncoder());
+  wgpu::TexelCopyTextureInfo src = {};
+  src.texture = texture;
+  src.mipLevel = 0;
+  src.origin = {0, 0, 0};
+  wgpu::TexelCopyBufferInfo dst = {};
+  dst.buffer = readback.get();
+  dst.layout.bytesPerRow = bytesPerRow;
+  dst.layout.rowsPerImage = height;
+  wgpu::Extent3D copySize = {width, height, 1};
+  enc.get().copyTextureToBuffer(src, dst, copySize);
+
+  geode::ScopedWgpuHandle<wgpu::CommandBuffer> cmd(enc.get().finish());
+  device->queue().submit(1, &cmd.get());
+  device->countSubmit();
+
+  if (MapAndWaitReadback(device, readback.get(), bd.size, shouldCancel) !=
+      ReadbackMapStatus::Success) {
     return bitmap;
   }
 

--- a/donner/svg/renderer/benchmarks/RendererBench.cc
+++ b/donner/svg/renderer/benchmarks/RendererBench.cc
@@ -118,6 +118,9 @@ struct Sample {
   double drawMs = 0.0;
   double snapshotMs = 0.0;
   double settledMs = 0.0;
+  double retainedDrawMs = 0.0;
+  double retainedSnapshotMs = 0.0;
+  double retainedSettledMs = 0.0;
   double gpuRenderPassMs = 0.0;
   double gpuTotalMs = 0.0;
 };
@@ -189,6 +192,9 @@ struct PhaseStats {
   Stats draw;
   Stats snapshot;
   Stats settled;
+  Stats retainedDraw;
+  Stats retainedSnapshot;
+  Stats retainedSettled;
   Stats gpuRenderPass;
   Stats gpuTotal;
 };
@@ -236,16 +242,33 @@ PhaseStats benchmarkWorkload(const Workload& workload, donner::svg::RendererGeod
     s.settledMs = toMs(t1 - settledStart);
     (void)bitmap;  // Discard - we only care about timing.
 
+    // -- Retained second draw on the same document (unchanged eligible scene) --
+    const auto retainedStart = Clock::now();
+    t0 = retainedStart;
+    renderer.draw(doc);
+    t1 = Clock::now();
+    s.retainedDrawMs = toMs(t1 - t0);
+    t0 = Clock::now();
+    bitmap = renderer.takeSnapshot();
+    t1 = Clock::now();
+    s.retainedSnapshotMs = toMs(t1 - t0);
+    s.retainedSettledMs = toMs(t1 - retainedStart);
+    (void)bitmap;
+
     samples.push_back(s);
   }
 
   // Discard warmup samples.
-  std::vector<double> parseVals, drawVals, snapVals, settledVals, gpuRpVals, gpuTotVals;
+  std::vector<double> parseVals, drawVals, snapVals, settledVals, retainedDrawVals,
+      retainedSnapVals, retainedSettledVals, gpuRpVals, gpuTotVals;
   const auto reserve = static_cast<size_t>(cfg.iterations);
   parseVals.reserve(reserve);
   drawVals.reserve(reserve);
   snapVals.reserve(reserve);
   settledVals.reserve(reserve);
+  retainedDrawVals.reserve(reserve);
+  retainedSnapVals.reserve(reserve);
+  retainedSettledVals.reserve(reserve);
   gpuRpVals.reserve(reserve);
   gpuTotVals.reserve(reserve);
 
@@ -255,12 +278,22 @@ PhaseStats benchmarkWorkload(const Workload& workload, donner::svg::RendererGeod
     drawVals.push_back(s.drawMs);
     snapVals.push_back(s.snapshotMs);
     settledVals.push_back(s.settledMs);
+    retainedDrawVals.push_back(s.retainedDrawMs);
+    retainedSnapVals.push_back(s.retainedSnapshotMs);
+    retainedSettledVals.push_back(s.retainedSettledMs);
     gpuRpVals.push_back(s.gpuRenderPassMs);
     gpuTotVals.push_back(s.gpuTotalMs);
   }
 
-  return {computeStats(parseVals),   computeStats(drawVals),  computeStats(snapVals),
-          computeStats(settledVals), computeStats(gpuRpVals), computeStats(gpuTotVals)};
+  return {computeStats(parseVals),
+          computeStats(drawVals),
+          computeStats(snapVals),
+          computeStats(settledVals),
+          computeStats(retainedDrawVals),
+          computeStats(retainedSnapVals),
+          computeStats(retainedSettledVals),
+          computeStats(gpuRpVals),
+          computeStats(gpuTotVals)};
 }
 
 void printPhase(const char* label, const Stats& stats) {
@@ -329,15 +362,24 @@ int main(int argc, char* argv[]) {
   for (const auto& workload : workloads) {
     std::printf("SVG: %s (%zu bytes)\n", workload.name.c_str(), workload.source.size());
 
+    // Reset readback stats so each workload reports its own snapshot wait.
+    (void)renderer.consumeReadbackStats();
+
     PhaseStats ps = benchmarkWorkload(workload, renderer, cfg);
     printPhase("Parse:", ps.parse);
     printPhase("Draw:", ps.draw);
     printPhase("Snapshot:", ps.snapshot);
     printPhase("Settled:", ps.settled);
+    printPhase("Ret-Draw:", ps.retainedDraw);
+    printPhase("Ret-Snap:", ps.retainedSnapshot);
+    printPhase("Ret-Settled:", ps.retainedSettled);
     if (sharedDevice->supportsTimestamps()) {
       printPhase("GPU-RP:", ps.gpuRenderPass);
       printPhase("GPU-Tot:", ps.gpuTotal);
     }
+    const donner::svg::RendererReadbackStats readbackStats = renderer.consumeReadbackStats();
+    std::printf("  %-10s count=%d polls=%d timedWaitAny=%s\n", "Readback:", readbackStats.count,
+                readbackStats.pollIterations, readbackStats.usedTimedWaitAny ? "yes" : "no");
     std::printf("\n");
 
     if (ps.draw.median > 0.0) {

--- a/donner/svg/renderer/geode/BUILD.bazel
+++ b/donner/svg/renderer/geode/BUILD.bazel
@@ -474,6 +474,17 @@ embed_resources(
     visibility = ["//donner/svg/renderer:__subpackages__"],
 )
 
+# Snapshot readback: GPU-side unpremultiply of a render target into a
+# straight-alpha RGBA8 staging texture, then copied into the readback buffer.
+embed_resources(
+    name = "snapshot_unpremultiply_wgsl",
+    header_output = "embed_resources/SnapshotUnpremultiplyWgsl.h",
+    resources = {
+        "kSnapshotUnpremultiplyWgsl": "shaders/snapshot_unpremultiply.wgsl",
+    },
+    visibility = ["//donner/svg/renderer:__subpackages__"],
+)
+
 donner_cc_library(
     name = "geode_shaders",
     srcs = ["GeodeShaders.cc"],
@@ -505,6 +516,7 @@ donner_cc_library(
         ":slug_fill_wgsl",
         ":slug_gradient_wgsl",
         ":slug_mask_wgsl",
+        ":snapshot_unpremultiply_wgsl",
         "//third_party/webgpu-cpp:webgpu_cpp",
     ],
 )
@@ -649,6 +661,31 @@ donner_multi_transitioned_test(
     size = "small",
     testonly = 1,
     dep = ":geode_embed_tests_impl",
+    opens_gpu_device = True,
+    renderer_backend = "geode",
+)
+
+# GPU-side snapshot unpremultiplication: byte parity between the compute
+# readback path and the CPU copy reference path.
+donner_cc_test(
+    name = "geode_snapshot_readback_tests_impl",
+    srcs = ["tests/GeodeSnapshotReadback_tests.cc"],
+    target_compatible_with = _GEODE_ONLY,
+    deps = [
+        ":geode_device",
+        ":geode_wgpu_util",
+        "//donner/base",
+        "//donner/base:gtest_timeout_main",
+        "//donner/svg/renderer:renderer_geode",
+        "//donner/svg/renderer:renderer_interface",
+    ],
+)
+
+donner_multi_transitioned_test(
+    name = "geode_snapshot_readback_tests",
+    size = "small",
+    testonly = 1,
+    dep = ":geode_snapshot_readback_tests_impl",
     opens_gpu_device = True,
     renderer_backend = "geode",
 )

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -12,6 +12,8 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <map>
+#include <mutex>
 #include <string_view>
 #include <thread>
 
@@ -217,6 +219,14 @@ struct GeodeDevice::Impl {
   /// Built lazily on first `maskPipeline()` access - see the header.
   std::unique_ptr<GeodeMaskPipeline> maskPipeline;
   std::unique_ptr<GeodeFilterEngine> filterEngine;
+  /// Built lazily on first `snapshotReadbackPipeline()` access - see the header.
+  std::unique_ptr<GeodeSnapshotReadbackPipeline> snapshotReadbackPipeline;
+
+  /// Size-keyed free pool of GPU snapshot readback resources (staging texture,
+  /// view, and map-readable buffer). One entry per (width, height) so repeat
+  /// snapshots at the same dimensions allocate nothing (design doc 0030 M4.2).
+  std::mutex snapshotReadbackPoolMutex;
+  std::map<std::pair<uint32_t, uint32_t>, SnapshotReadbackResources> snapshotReadbackPool;
 };
 
 namespace {
@@ -570,6 +580,74 @@ GeodeMaskPipeline& GeodeDevice::maskPipeline() const {
 }
 GeodeFilterEngine& GeodeDevice::filterEngine() const {
   return *impl_->filterEngine;
+}
+GeodeSnapshotReadbackPipeline& GeodeDevice::snapshotReadbackPipeline() const {
+  if (!impl_->snapshotReadbackPipeline) {
+    // Lazy: only snapshot readback consumes this pipeline, so renderers that
+    // never call takeSnapshot() avoid the compile cost.
+    impl_->snapshotReadbackPipeline = std::make_unique<GeodeSnapshotReadbackPipeline>(device_);
+  }
+  return *impl_->snapshotReadbackPipeline;
+}
+
+SnapshotReadbackResources GeodeDevice::acquireSnapshotReadbackResources(uint32_t width,
+                                                                        uint32_t height) {
+  const std::pair<uint32_t, uint32_t> key(width, height);
+  {
+    std::lock_guard<std::mutex> lock(impl_->snapshotReadbackPoolMutex);
+    auto it = impl_->snapshotReadbackPool.find(key);
+    if (it != impl_->snapshotReadbackPool.end()) {
+      SnapshotReadbackResources result = std::move(it->second);
+      impl_->snapshotReadbackPool.erase(it);
+      return result;
+    }
+  }
+
+  // First use at this size: allocate the staging texture, its view, and the
+  // map-readable readback buffer. Bytes-per-row must be 256-aligned per the
+  // WebGPU texture-to-buffer copy rules.
+  SnapshotReadbackResources resources;
+  resources.width = width;
+  resources.height = height;
+
+  wgpu::TextureDescriptor td = {};
+  td.label = wgpuLabel("RendererGeodeReadbackStaging");
+  td.size = {width, height, 1};
+  td.format = wgpu::TextureFormat::RGBA8Unorm;
+  td.usage = wgpu::TextureUsage::StorageBinding | wgpu::TextureUsage::CopySrc;
+  td.mipLevelCount = 1;
+  td.sampleCount = 1;
+  td.dimension = wgpu::TextureDimension::_2D;
+  resources.staging.reset(device_.createTexture(td));
+  if (resources.staging) {
+    resources.stagingView.reset(resources.staging.get().createView());
+    countTexture();
+  }
+
+  const uint32_t bytesPerRow = (width * 4u + 255u) & ~255u;
+  wgpu::BufferDescriptor bd = {};
+  bd.label = wgpuLabel("RendererGeodeReadback");
+  bd.size = static_cast<uint64_t>(bytesPerRow) * static_cast<uint64_t>(height);
+  bd.usage = wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::MapRead;
+  resources.readback.reset(device_.createBuffer(bd));
+  if (resources.readback) {
+    countBuffer();
+  }
+
+  if (resources.empty()) {
+    // Partial allocation failure: release what was created without pooling it.
+    resources = SnapshotReadbackResources{};
+  }
+  return resources;
+}
+
+void GeodeDevice::releaseSnapshotReadbackResources(SnapshotReadbackResources resources) {
+  if (resources.empty()) {
+    return;
+  }
+  const std::pair<uint32_t, uint32_t> key(resources.width, resources.height);
+  std::lock_guard<std::mutex> lock(impl_->snapshotReadbackPoolMutex);
+  impl_->snapshotReadbackPool.insert_or_assign(key, std::move(resources));
 }
 const wgpu::Instance& GeodeDevice::instance() const {
   return impl_->instance;

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -182,6 +182,11 @@ struct GeodeDevice::Impl {
     DestroyResourceBacking(dummyPatternTexture);
     DestroyResourceBacking(dummyClipMaskTexture);
     DestroyResourceBacking(identityInstanceTransformBuffer);
+    for (auto& [unusedKey, entry] : snapshotReadbackPool) {
+      (void)unusedKey;
+      DestroyResourceBacking(entry.resources.staging);
+      DestroyResourceBacking(entry.resources.readback);
+    }
   }
 
   wgpu::Instance instance;
@@ -224,10 +229,31 @@ struct GeodeDevice::Impl {
 
   /// Size-keyed free pool of GPU snapshot readback resources (staging texture,
   /// view, and map-readable buffer). One entry per (width, height) so repeat
-  /// snapshots at the same dimensions allocate nothing (design doc 0030 M4.2).
+  /// snapshots at the same dimensions allocate nothing. Bounded: entries
+  /// carry a last-use tick, and the least-recently-used entry is destroyed
+  /// when a release would exceed kMaxSnapshotReadbackPoolEntries, so a
+  /// size-churning caller (a window resize walks hundreds of canvas sizes)
+  /// cannot accumulate retained staging memory for the device's lifetime.
+  struct SnapshotReadbackPoolEntry {
+    SnapshotReadbackResources resources;
+    uint64_t lastUsedTick = 0;
+  };
   std::mutex snapshotReadbackPoolMutex;
-  std::map<std::pair<uint32_t, uint32_t>, SnapshotReadbackResources> snapshotReadbackPool;
+  std::map<std::pair<uint32_t, uint32_t>, SnapshotReadbackPoolEntry> snapshotReadbackPool;
+  uint64_t snapshotReadbackPoolTick = 0;
+
+  /// Guards the lazy snapshotReadbackPipeline construction: the device is
+  /// documented as shareable between the main thread and the async-render
+  /// worker, and both can take a first snapshot concurrently. A plain
+  /// null-check would let both construct, and the second assignment would
+  /// destroy the pipeline the first thread already holds a reference to.
+  std::once_flag snapshotReadbackPipelineOnce;
 };
+
+/// Distinct snapshot sizes retained by the readback pool: covers the main
+/// canvas, the async-render worker, and thumbnail/icon sizes without letting
+/// a resize sweep pin one entry per intermediate size.
+constexpr size_t kMaxSnapshotReadbackPoolEntries = 4;
 
 namespace {
 /// Monotonic source for `GeodeDevice::deviceId()`. Never reused, starts at 1
@@ -582,11 +608,12 @@ GeodeFilterEngine& GeodeDevice::filterEngine() const {
   return *impl_->filterEngine;
 }
 GeodeSnapshotReadbackPipeline& GeodeDevice::snapshotReadbackPipeline() const {
-  if (!impl_->snapshotReadbackPipeline) {
-    // Lazy: only snapshot readback consumes this pipeline, so renderers that
-    // never call takeSnapshot() avoid the compile cost.
+  // Lazy: only snapshot readback consumes this pipeline, so renderers that
+  // never call takeSnapshot() avoid the compile cost. call_once, not a plain
+  // null-check: see Impl::snapshotReadbackPipelineOnce.
+  std::call_once(impl_->snapshotReadbackPipelineOnce, [this] {
     impl_->snapshotReadbackPipeline = std::make_unique<GeodeSnapshotReadbackPipeline>(device_);
-  }
+  });
   return *impl_->snapshotReadbackPipeline;
 }
 
@@ -597,7 +624,7 @@ SnapshotReadbackResources GeodeDevice::acquireSnapshotReadbackResources(uint32_t
     std::lock_guard<std::mutex> lock(impl_->snapshotReadbackPoolMutex);
     auto it = impl_->snapshotReadbackPool.find(key);
     if (it != impl_->snapshotReadbackPool.end()) {
-      SnapshotReadbackResources result = std::move(it->second);
+      SnapshotReadbackResources result = std::move(it->second.resources);
       impl_->snapshotReadbackPool.erase(it);
       return result;
     }
@@ -624,7 +651,7 @@ SnapshotReadbackResources GeodeDevice::acquireSnapshotReadbackResources(uint32_t
     countTexture();
   }
 
-  const uint32_t bytesPerRow = (width * 4u + 255u) & ~255u;
+  const uint32_t bytesPerRow = AlignReadbackBytesPerRow(width * 4u);
   wgpu::BufferDescriptor bd = {};
   bd.label = wgpuLabel("RendererGeodeReadback");
   bd.size = static_cast<uint64_t>(bytesPerRow) * static_cast<uint64_t>(height);
@@ -647,7 +674,26 @@ void GeodeDevice::releaseSnapshotReadbackResources(SnapshotReadbackResources res
   }
   const std::pair<uint32_t, uint32_t> key(resources.width, resources.height);
   std::lock_guard<std::mutex> lock(impl_->snapshotReadbackPoolMutex);
-  impl_->snapshotReadbackPool.insert_or_assign(key, std::move(resources));
+  Impl::SnapshotReadbackPoolEntry entry;
+  entry.resources = std::move(resources);
+  entry.lastUsedTick = ++impl_->snapshotReadbackPoolTick;
+  impl_->snapshotReadbackPool.insert_or_assign(key, std::move(entry));
+
+  while (impl_->snapshotReadbackPool.size() > kMaxSnapshotReadbackPoolEntries) {
+    auto lruIt = impl_->snapshotReadbackPool.begin();
+    for (auto it = std::next(impl_->snapshotReadbackPool.begin());
+         it != impl_->snapshotReadbackPool.end(); ++it) {
+      if (it->second.lastUsedTick < lruIt->second.lastUsedTick) {
+        lruIt = it;
+      }
+    }
+    // Pooled entries are idle by construction (release happens only after
+    // the readback unmaps), so their backings can be destroyed eagerly
+    // instead of deferred to a frame boundary.
+    DestroyResourceBacking(lruIt->second.resources.staging);
+    DestroyResourceBacking(lruIt->second.resources.readback);
+    impl_->snapshotReadbackPool.erase(lruIt);
+  }
 }
 const wgpu::Instance& GeodeDevice::instance() const {
   return impl_->instance;

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -13,6 +13,15 @@
 
 namespace donner::geode {
 
+/// 256-align a tightly packed row-byte count per the WebGPU
+/// texture-to-buffer copy rules. Shared by the device's readback-buffer
+/// sizing and the renderer's map-range math; the two MUST agree, because a
+/// mapped-range request larger than the buffer returns null rather than
+/// raising an error.
+constexpr uint32_t AlignReadbackBytesPerRow(uint32_t rowBytes) {
+  return (rowBytes + 255u) & ~255u;
+}
+
 // Forward declarations - GeodeDevice exposes accessors for the pipeline
 // objects it owns (see "Shared render / compute pipelines" section below).
 // The full class definitions live in their own headers; including them
@@ -30,8 +39,10 @@ class GeodeSnapshotReadbackPipeline;
  * Move-only resource set for one GPU snapshot unpremultiply readback: a
  * straight-alpha staging texture, its view, and a map-readable readback
  * buffer. Acquired from and returned to the per-device pool keyed by size,
- * so repeat snapshots at the same dimensions allocate nothing (design doc
- * 0030 Milestone 4.2 pooling).
+ * so repeat snapshots at the same dimensions allocate nothing. The pool is
+ * bounded with least-recently-used eviction, so a caller walking many
+ * distinct sizes (for example a window resize) cannot pin unbounded staging
+ * memory for the device's lifetime.
  */
 struct SnapshotReadbackResources {
   /// Staging texture the compute pass writes the unpremultiplied result into.
@@ -424,15 +435,16 @@ public:
   /// GPU filter-graph executor. Owns ~15 compute pipelines for SVG
   /// filter primitives.
   GeodeFilterEngine& filterEngine() const;
-  /// Snapshot-unpremultiply compute pipeline. Built lazily on first access so
-  /// consumers that never read back a snapshot avoid the compile cost.
+  /// Snapshot-unpremultiply compute pipeline. Built lazily (thread-safe,
+  /// once-only) on first access so consumers that never read back a snapshot
+  /// avoid the compile cost.
   GeodeSnapshotReadbackPipeline& snapshotReadbackPipeline() const;
 
   /**
    * Acquire the pooled readback resource set for a GPU snapshot readback at
    * the given size, allocating it on first use. Repeated snapshots at the
    * same dimensions reuse the pooled entry, so steady-state snapshot readback
-   * allocates nothing (design doc 0030 Milestone 4.2 pooling).
+   * allocates nothing.
    *
    * The caller owns the returned set until `releaseSnapshotReadbackResources`
    * returns it to the pool, or until the set is destroyed unpooled. An empty
@@ -445,6 +457,11 @@ public:
    * `acquireSnapshotReadbackResources` to the device pool for reuse. The
    * returned set must be unmapped. Do not call this after the readback map
    * was cancelled and the buffer destroyed; drop the set instead.
+   *
+   * The pool holds at most a small fixed number of size buckets; when a
+   * release would exceed that, the least-recently-used entry's backing
+   * resources are destroyed (pooled entries are idle, so eager destroy is
+   * safe).
    */
   void releaseSnapshotReadbackResources(SnapshotReadbackResources resources);
   /// Framebuffer checkerboard underlay pipeline used by the editor's direct

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -24,6 +24,30 @@ class GeodeGradientPipeline;
 class GeodeImagePipeline;
 class GeodeMaskPipeline;
 class GeodeFilterEngine;
+class GeodeSnapshotReadbackPipeline;
+
+/**
+ * Move-only resource set for one GPU snapshot unpremultiply readback: a
+ * straight-alpha staging texture, its view, and a map-readable readback
+ * buffer. Acquired from and returned to the per-device pool keyed by size,
+ * so repeat snapshots at the same dimensions allocate nothing (design doc
+ * 0030 Milestone 4.2 pooling).
+ */
+struct SnapshotReadbackResources {
+  /// Staging texture the compute pass writes the unpremultiplied result into.
+  ScopedWgpuHandle<wgpu::Texture> staging;
+  /// View of `staging`, kept with the pooled entry so it is created once.
+  ScopedWgpuHandle<wgpu::TextureView> stagingView;
+  /// Map-readable buffer the staging texture is copied into.
+  ScopedWgpuHandle<wgpu::Buffer> readback;
+  /// Pool key: staging texture width in pixels.
+  uint32_t width = 0;
+  /// Pool key: staging texture height in pixels.
+  uint32_t height = 0;
+
+  /// True when any required handle is missing; an empty set cannot be used.
+  [[nodiscard]] bool empty() const { return !staging || !stagingView || !readback; }
+};
 
 /**
  * Configuration for embedding Geode into a host application that already owns a
@@ -400,6 +424,29 @@ public:
   /// GPU filter-graph executor. Owns ~15 compute pipelines for SVG
   /// filter primitives.
   GeodeFilterEngine& filterEngine() const;
+  /// Snapshot-unpremultiply compute pipeline. Built lazily on first access so
+  /// consumers that never read back a snapshot avoid the compile cost.
+  GeodeSnapshotReadbackPipeline& snapshotReadbackPipeline() const;
+
+  /**
+   * Acquire the pooled readback resource set for a GPU snapshot readback at
+   * the given size, allocating it on first use. Repeated snapshots at the
+   * same dimensions reuse the pooled entry, so steady-state snapshot readback
+   * allocates nothing (design doc 0030 Milestone 4.2 pooling).
+   *
+   * The caller owns the returned set until `releaseSnapshotReadbackResources`
+   * returns it to the pool, or until the set is destroyed unpooled. An empty
+   * set means allocation failed.
+   */
+  SnapshotReadbackResources acquireSnapshotReadbackResources(uint32_t width, uint32_t height);
+
+  /**
+   * Return a readback resource set acquired from
+   * `acquireSnapshotReadbackResources` to the device pool for reuse. The
+   * returned set must be unmapped. Do not call this after the readback map
+   * was cancelled and the buffer destroyed; drop the set instead.
+   */
+  void releaseSnapshotReadbackResources(SnapshotReadbackResources resources);
   /// Framebuffer checkerboard underlay pipeline used by the editor's direct
   /// presentation path. Built lazily on first access - only the editor draws
   /// it, so headless/WASM consumers never pay the compile cost.

--- a/donner/svg/renderer/geode/GeodePipeline.cc
+++ b/donner/svg/renderer/geode/GeodePipeline.cc
@@ -350,4 +350,48 @@ GeodeMaskPipeline::GeodeMaskPipeline(const wgpu::Device& device) {
   pipeline_.reset(device.createRenderPipeline(rpDesc));
 }
 
+// ============================================================================
+// GeodeSnapshotReadbackPipeline
+// ============================================================================
+
+GeodeSnapshotReadbackPipeline::GeodeSnapshotReadbackPipeline(const wgpu::Device& device) {
+  // Two bindings: the premultiplied render target (sampled via textureLoad)
+  // and the straight-alpha RGBA8 staging storage texture.
+  wgpu::BindGroupLayoutEntry entries[2] = {};
+
+  entries[0].binding = 0;
+  entries[0].visibility = wgpu::ShaderStage::Compute;
+  entries[0].texture.sampleType = wgpu::TextureSampleType::Float;
+  entries[0].texture.viewDimension = wgpu::TextureViewDimension::_2D;
+  entries[0].texture.multisampled = false;
+
+  entries[1].binding = 1;
+  entries[1].visibility = wgpu::ShaderStage::Compute;
+  entries[1].storageTexture.access = wgpu::StorageTextureAccess::WriteOnly;
+  entries[1].storageTexture.format = wgpu::TextureFormat::RGBA8Unorm;
+  entries[1].storageTexture.viewDimension = wgpu::TextureViewDimension::_2D;
+
+  wgpu::BindGroupLayoutDescriptor bglDesc = {};
+  bglDesc.label = wgpuLabel("GeodeSnapshotReadbackBGL");
+  bglDesc.entryCount = 2;
+  bglDesc.entries = entries;
+  bindGroupLayout_.reset(device.createBindGroupLayout(bglDesc));
+
+  wgpu::PipelineLayoutDescriptor plDesc = {};
+  plDesc.label = wgpuLabel("GeodeSnapshotReadbackPL");
+  plDesc.bindGroupLayoutCount = 1;
+  WGPUBindGroupLayout layouts[1] = {bindGroupLayout_.get()};
+  plDesc.bindGroupLayouts = layouts;
+  ScopedWgpuHandle<wgpu::PipelineLayout> pipelineLayout(device.createPipelineLayout(plDesc));
+
+  ScopedWgpuHandle<wgpu::ShaderModule> shader(createSnapshotUnpremultiplyShader(device));
+
+  wgpu::ComputePipelineDescriptor cpDesc = {};
+  cpDesc.label = wgpuLabel("GeodeSnapshotReadback");
+  cpDesc.layout = pipelineLayout.get();
+  cpDesc.compute.module = shader.get();
+  cpDesc.compute.entryPoint = wgpuLabel("main");
+  pipeline_.reset(device.createComputePipeline(cpDesc));
+}
+
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodePipeline.h
+++ b/donner/svg/renderer/geode/GeodePipeline.h
@@ -154,4 +154,43 @@ private:
   ScopedWgpuHandle<wgpu::RenderPipeline> pipeline_;
 };
 
+/**
+ * Compute pipeline for GPU-side snapshot unpremultiplication.
+ *
+ * Reads a premultiplied-alpha render target (binding 0, `texture_2d<f32>`)
+ * and writes straight-alpha RGBA8 into the storage texture at binding 1
+ * (`rgba8unorm`, write-only). Owned lazily by `GeodeDevice` so every
+ * snapshot sharing the device reuses one compiled pipeline (issue #575:
+ * wgpu-native retains compiled pipelines).
+ *
+ * The stored bytes replicate the CPU round-half-up reference formula in
+ * `RendererGeode::ReadGeodeTextureSnapshot` exactly, so snapshots produced
+ * through this pipeline are byte-identical to the CPU readback path.
+ */
+class GeodeSnapshotReadbackPipeline {
+public:
+  /**
+   * Create the snapshot-unpremultiply compute pipeline for the given device.
+   */
+  explicit GeodeSnapshotReadbackPipeline(const wgpu::Device& device);
+
+  ~GeodeSnapshotReadbackPipeline() = default;
+  GeodeSnapshotReadbackPipeline(const GeodeSnapshotReadbackPipeline&) = delete;
+  GeodeSnapshotReadbackPipeline& operator=(const GeodeSnapshotReadbackPipeline&) = delete;
+  GeodeSnapshotReadbackPipeline(GeodeSnapshotReadbackPipeline&&) noexcept = default;
+  GeodeSnapshotReadbackPipeline& operator=(GeodeSnapshotReadbackPipeline&&) noexcept = default;
+
+  /// True when the bind group layout and compute pipeline compiled.
+  bool valid() const { return static_cast<bool>(pipeline_) && static_cast<bool>(bindGroupLayout_); }
+
+  /// The compiled compute pipeline.
+  const wgpu::ComputePipeline& pipeline() const { return pipeline_.get(); }
+  /// The bind group layout used by the pipeline.
+  const wgpu::BindGroupLayout& bindGroupLayout() const { return bindGroupLayout_.get(); }
+
+private:
+  ScopedWgpuHandle<wgpu::BindGroupLayout> bindGroupLayout_;
+  ScopedWgpuHandle<wgpu::ComputePipeline> pipeline_;
+};
+
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodeShaders.cc
+++ b/donner/svg/renderer/geode/GeodeShaders.cc
@@ -24,6 +24,7 @@
 #include "embed_resources/SlugFillWgsl.h"
 #include "embed_resources/SlugGradientWgsl.h"
 #include "embed_resources/SlugMaskWgsl.h"
+#include "embed_resources/SnapshotUnpremultiplyWgsl.h"
 
 namespace donner::geode {
 
@@ -180,6 +181,12 @@ wgpu::ShaderModule createFilterColorSpaceConvertShader(const wgpu::Device& devic
   return createShaderFromWgsl(device, "FilterColorSpaceConvert",
                               donner::embedded::kFilterColorSpaceConvertWgsl.data(),
                               donner::embedded::kFilterColorSpaceConvertWgsl.size());
+}
+
+wgpu::ShaderModule createSnapshotUnpremultiplyShader(const wgpu::Device& device) {
+  return createShaderFromWgsl(device, "SnapshotUnpremultiply",
+                              donner::embedded::kSnapshotUnpremultiplyWgsl.data(),
+                              donner::embedded::kSnapshotUnpremultiplyWgsl.size());
 }
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodeShaders.h
+++ b/donner/svg/renderer/geode/GeodeShaders.h
@@ -424,4 +424,23 @@ wgpu::ShaderModule createFilterSubregionClipShader(const wgpu::Device& device);
  */
 wgpu::ShaderModule createFilterColorSpaceConvertShader(const wgpu::Device& device);
 
+/**
+ * Compile the snapshot-unpremultiply compute shader for the given device.
+ *
+ * The WGSL source is embedded at build time from
+ * `shaders/snapshot_unpremultiply.wgsl` via the `embed_resources()` Bazel
+ * rule. The shader reads a premultiplied-alpha render target and writes
+ * straight-alpha RGBA8 into a storage texture, replacing the CPU per-pixel
+ * unpremultiply loop in `RendererGeode` snapshot readback. The stored bytes
+ * replicate the CPU round-half-up formula exactly.
+ *
+ * Bind group layout:
+ * - `@group(0) @binding(0) var input_tex: texture_2d<f32>;`
+ * - `@group(0) @binding(1) var output_tex: texture_storage_2d<rgba8unorm, write>;`
+ *
+ * @return A valid shader module on success, or an empty module if compilation
+ *   failed (errors go to the device's uncaptured error callback).
+ */
+wgpu::ShaderModule createSnapshotUnpremultiplyShader(const wgpu::Device& device);
+
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/shaders/snapshot_unpremultiply.wgsl
+++ b/donner/svg/renderer/geode/shaders/snapshot_unpremultiply.wgsl
@@ -24,7 +24,11 @@
 
 @compute @workgroup_size(8, 8)
 fn main(@builtin(global_invocation_id) gid: vec3u) {
-  let size = textureDimensions(input_tex);
+  // Clamp to BOTH textures: the staging output is pooled, so if a caller ever
+  // dispatched with mismatched sizes, writing only the input-covered region
+  // would silently leave stale pixels from a previous snapshot in the rest of
+  // the pooled texture instead of raising a validation error.
+  let size = min(textureDimensions(input_tex), textureDimensions(output_tex));
   if (any(gid.xy >= size)) {
     return;
   }

--- a/donner/svg/renderer/geode/shaders/snapshot_unpremultiply.wgsl
+++ b/donner/svg/renderer/geode/shaders/snapshot_unpremultiply.wgsl
@@ -1,0 +1,53 @@
+// Geode snapshot readback: unpremultiply a render target on the GPU.
+//
+// Reads the premultiplied-alpha render target and writes straight-alpha RGBA8
+// into a storage texture, replacing the CPU per-pixel unpremultiply loop in
+// RendererGeode::ReadGeodeTextureSnapshot. The caller then copies the storage
+// texture into a map-readable buffer.
+//
+// The integer arithmetic replicates the CPU reference formula byte-for-byte:
+//
+//   a == 0   -> (0, 0, 0, 0)
+//   a != 0   -> min(255, (premul * 255 + a/2) / a)   (round-half-up)
+//
+// The recovered 8-bit channels are the unorm texel bytes, so the stored
+// output matches the CPU path exactly; see the sourceAlphaType handling in
+// RendererGeode.cc.
+//
+// Bind group:
+// - binding(0) input_tex: texture_2d<f32> - premultiplied render target.
+// - binding(1) output_tex: texture_storage_2d<rgba8unorm, write> - straight
+//   RGBA8 staging texture, then copied into the readback buffer.
+
+@group(0) @binding(0) var input_tex: texture_2d<f32>;
+@group(0) @binding(1) var output_tex: texture_storage_2d<rgba8unorm, write>;
+
+@compute @workgroup_size(8, 8)
+fn main(@builtin(global_invocation_id) gid: vec3u) {
+  let size = textureDimensions(input_tex);
+  if (any(gid.xy >= size)) {
+    return;
+  }
+
+  let premul = textureLoad(input_tex, vec2i(gid.xy), 0);
+
+  // Recover the stored 8-bit channels from the normalized unorm floats.
+  let r8 = u32(round(premul.r * 255.0));
+  let g8 = u32(round(premul.g * 255.0));
+  let b8 = u32(round(premul.b * 255.0));
+  let a8 = u32(round(premul.a * 255.0));
+
+  var sr = 0u;
+  var sg = 0u;
+  var sb = 0u;
+  if (a8 != 0u) {
+    let half = a8 >> 1u;
+    sr = min(255u, (r8 * 255u + half) / a8);
+    sg = min(255u, (g8 * 255u + half) / a8);
+    sb = min(255u, (b8 * 255u + half) / a8);
+  }
+
+  // Normalized floats round back to the same bytes on unorm storage.
+  textureStore(output_tex, vec2i(gid.xy),
+               vec4f(f32(sr) / 255.0, f32(sg) / 255.0, f32(sb) / 255.0, f32(a8) / 255.0));
+}

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -416,8 +416,11 @@ TEST_F(GeodePerfTest, UseHeavy_BaselineCeilings) {
   EXPECT_EQ(c.drawCalls, 1u);
   // And a single bind group covers all eight - per-instance
   // transforms ride in a storage-buffer binding (binding 7), while
-  // the other seven entries are stable across the batch.
-  EXPECT_EQ(c.bindgroupCreates, 1u);
+  // the other seven entries are stable across the batch. The second
+  // bind group is the GPU-side snapshot readback (one per snapshot;
+  // the input texture view changes per render target, so it cannot
+  // be pooled like the staging texture and readback buffer).
+  EXPECT_EQ(c.bindgroupCreates, 2u);
   // Seven adjacent-same-source pairs detected at `drawPath` entry
   // (BEFORE batching collapses them). This is the "opportunity"
   // counter - kept as a separate signal from `drawCalls` (the

--- a/donner/svg/renderer/geode/tests/GeodeShaders_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeShaders_tests.cc
@@ -64,4 +64,12 @@ TEST(GeodeShaders, FilterTileCompiles) {
   ASSERT_TRUE(static_cast<bool>(module)) << "feTile shader failed to compile";
 }
 
+TEST(GeodeShaders, SnapshotUnpremultiplyCompiles) {
+  auto geodeDevice = GeodeDevice::CreateHeadless();
+  ASSERT_NE(geodeDevice, nullptr);
+
+  wgpu::ShaderModule module = createSnapshotUnpremultiplyShader(geodeDevice->device());
+  ASSERT_TRUE(static_cast<bool>(module)) << "snapshot unpremultiply shader failed to compile";
+}
+
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/tests/GeodeSnapshotReadback_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeSnapshotReadback_tests.cc
@@ -1,0 +1,127 @@
+/// @file
+/// Byte-parity tests for GPU-side snapshot unpremultiplication.
+///
+/// The GPU readback path (compute unpremultiply into a straight-alpha staging
+/// texture, then a texture-to-buffer copy) must produce byte-identical output
+/// to the CPU copy path. Each path is forced by controlling texture usage
+/// flags: the GPU path requires TextureBinding, the CPU path requires CopySrc.
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <utility>
+
+#include "donner/svg/renderer/RendererGeode.h"
+#include "donner/svg/renderer/RendererInterface.h"
+#include "donner/svg/renderer/geode/GeodeDevice.h"
+#include "donner/svg/renderer/geode/GeodePipeline.h"
+#include "donner/svg/renderer/geode/GeodeWgpuUtil.h"  // IWYU pragma: keep - provides wgpuLabel
+
+namespace donner::svg {
+
+using ::donner::geode::wgpuLabel;
+
+namespace {
+
+constexpr uint32_t kWidth = 8;
+constexpr uint32_t kHeight = 4;
+
+/// Premultiplied RGBA test pixels covering every CPU unpremultiply branch:
+/// a == 0 with nonzero RGB, a == 255, odd and even partial alpha with
+/// nontrivial round-half-up behavior.
+const std::array<uint8_t, kWidth * kHeight * 4>& premultipliedTestPixels() {
+  static const std::array<uint8_t, kWidth * kHeight * 4> pixels = [] {
+    std::array<uint8_t, kWidth * kHeight * 4> p = {};
+    auto set = [&p](uint32_t x, uint32_t y, uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
+      const size_t off = (static_cast<size_t>(y) * kWidth + x) * 4u;
+      p[off + 0] = r;
+      p[off + 1] = g;
+      p[off + 2] = b;
+      p[off + 3] = a;
+    };
+    // Row 0: fully transparent with nonzero premultiplied RGB (must zero out).
+    set(0, 0, 255, 128, 64, 0);
+    set(1, 0, 17, 9, 3, 0);
+    // Row 1: fully opaque (straight copy).
+    set(1, 1, 200, 100, 50, 255);
+    set(2, 1, 3, 240, 255, 255);
+    // Row 2: odd partial alpha, round-half-up cases.
+    set(2, 2, 2, 1, 1, 3);
+    set(3, 2, 200, 128, 64, 128);
+    set(4, 2, 7, 6, 5, 7);
+    // Row 3: even partial alpha and a == 1 edge case.
+    set(4, 3, 77, 33, 11, 64);
+    set(5, 3, 255, 255, 255, 1);
+    return p;
+  }();
+  return pixels;
+}
+
+/// Create a texture with the given usage flags and upload the test pixels.
+wgpu::Texture createTestTexture(const wgpu::Device& device, wgpu::TextureUsage usage) {
+  wgpu::TextureDescriptor desc = {};
+  desc.label = wgpuLabel("SnapshotReadbackParity");
+  desc.size = {kWidth, kHeight, 1};
+  desc.format = wgpu::TextureFormat::RGBA8Unorm;
+  desc.usage = usage | wgpu::TextureUsage::CopyDst;
+  desc.mipLevelCount = 1;
+  desc.sampleCount = 1;
+  desc.dimension = wgpu::TextureDimension::_2D;
+  wgpu::Texture texture = device.createTexture(desc);
+
+  wgpu::TexelCopyTextureInfo destination = {};
+  destination.texture = texture;
+  wgpu::TexelCopyBufferLayout dataLayout = {};
+  dataLayout.bytesPerRow = kWidth * 4u;
+  dataLayout.rowsPerImage = kHeight;
+  wgpu::Extent3D writeSize = {kWidth, kHeight, 1};
+  device.getQueue().writeTexture(destination, premultipliedTestPixels().data(),
+                                 premultipliedTestPixels().size(), dataLayout, writeSize);
+  return texture;
+}
+
+class GeodeSnapshotReadbackTest : public ::testing::Test {
+protected:
+  static std::shared_ptr<geode::GeodeDevice> sharedDevice() {
+    static auto device = [] {
+      return std::shared_ptr<geode::GeodeDevice>(geode::GeodeDevice::CreateHeadless());
+    }();
+    return device;
+  }
+};
+
+/// The GPU unpremultiply path (TextureBinding, no CopySrc) and the CPU copy
+/// path (CopySrc, no TextureBinding) must produce byte-identical straight-alpha
+/// output for the same premultiplied input. The usage flags force each path:
+/// the GPU path cannot run without TextureBinding, and the CPU copy cannot run
+/// without CopySrc, so a mismatch between the two bitmaps cannot be hidden by
+/// silent path fallback.
+TEST_F(GeodeSnapshotReadbackTest, GpuAndCpuPathsAreByteIdentical) {
+  auto device = sharedDevice();
+  ASSERT_NE(device, nullptr);
+  ASSERT_TRUE(device->snapshotReadbackPipeline().valid());
+
+  wgpu::Texture gpuTex = createTestTexture(device->device(), wgpu::TextureUsage::TextureBinding);
+  wgpu::Texture cpuTex = createTestTexture(device->device(), wgpu::TextureUsage::CopySrc);
+
+  const Vector2i dimensions(static_cast<int>(kWidth), static_cast<int>(kHeight));
+  RendererGeodeTextureSnapshot gpuSnapshot(device, std::move(gpuTex), dimensions,
+                                           wgpu::TextureFormat::RGBA8Unorm);
+  RendererGeodeTextureSnapshot cpuSnapshot(device, std::move(cpuTex), dimensions,
+                                           wgpu::TextureFormat::RGBA8Unorm);
+
+  RendererBitmap gpuBitmap = gpuSnapshot.takeSnapshot();
+  ASSERT_FALSE(gpuBitmap.empty());
+  RendererBitmap cpuBitmap = cpuSnapshot.takeSnapshot();
+  ASSERT_FALSE(cpuBitmap.empty());
+
+  EXPECT_EQ(gpuBitmap.dimensions, dimensions);
+  EXPECT_EQ(gpuBitmap.alphaType, AlphaType::Unpremultiplied);
+  EXPECT_EQ(gpuBitmap.pixels, cpuBitmap.pixels)
+      << "GPU unpremultiply output differs from the CPU reference path";
+}
+
+}  // namespace
+}  // namespace donner::svg

--- a/tools/gpu_inventory/manifests/gpu_operations.json
+++ b/tools/gpu_inventory/manifests/gpu_operations.json
@@ -354,17 +354,22 @@
     },
     "donner/svg/renderer/RendererGeode.cc": {
       "operations": [
+        "beginComputePass",
         "copyTextureToBuffer",
         "copyTextureToTexture",
+        "createBindGroup",
         "createBuffer",
         "createCommandEncoder",
         "createTexture",
         "createView",
         "destroy",
+        "dispatchWorkgroups",
         "draw",
         "finish",
         "getConstMappedRange",
         "mapAsync",
+        "setBindGroup",
+        "setPipeline",
         "submit",
         "unmap"
       ],
@@ -377,9 +382,13 @@
         "WGPUMapAsyncStatus_Success",
         "WGPUStringView",
         "WGPUTextureFormat",
-        "WGPUTextureFormat_BGRA8Unorm"
+        "WGPUTextureFormat_BGRA8Unorm",
+        "WGPUTextureUsage"
       ],
       "wgpuCppTokens": [
+        "BindGroup",
+        "BindGroupDescriptor",
+        "BindGroupEntry",
         "Buffer",
         "BufferDescriptor",
         "BufferMapCallbackInfo",
@@ -388,6 +397,8 @@
         "CommandBuffer",
         "CommandEncoder",
         "CommandEncoderDescriptor",
+        "ComputePassDescriptor",
+        "ComputePassEncoder",
         "Default",
         "Device",
         "Extent3D",
@@ -582,7 +593,8 @@
         "wgpuAdapterInfoFreeMembers",
         "wgpuCreateInstance",
         "wgpuForceFallbackAdapterRequested",
-        "wgpuInstanceRequestAdapter"
+        "wgpuInstanceRequestAdapter",
+        "wgpuLabel"
       ],
       "wgpuCTypes": [
         "WGPUAdapterInfo",
@@ -804,6 +816,7 @@
     "donner/svg/renderer/geode/GeodePipeline.cc": {
       "operations": [
         "createBindGroupLayout",
+        "createComputePipeline",
         "createPipelineLayout",
         "createRenderPipeline"
       ],
@@ -822,6 +835,7 @@
         "BufferBindingType",
         "ColorTargetState",
         "ColorWriteMask",
+        "ComputePipelineDescriptor",
         "CullMode",
         "Device",
         "FragmentState",
@@ -832,6 +846,7 @@
         "SamplerBindingType",
         "ShaderModule",
         "ShaderStage",
+        "StorageTextureAccess",
         "TextureFormat",
         "TextureSampleType",
         "TextureViewDimension"
@@ -840,6 +855,7 @@
     "donner/svg/renderer/geode/GeodePipeline.h": {
       "wgpuCppTokens": [
         "BindGroupLayout",
+        "ComputePipeline",
         "Device",
         "RenderPipeline",
         "TextureFormat"
@@ -1062,6 +1078,27 @@
     "donner/svg/renderer/geode/tests/GeodeShaders_tests.cc": {
       "wgpuCppTokens": [
         "ShaderModule"
+      ]
+    },
+    "donner/svg/renderer/geode/tests/GeodeSnapshotReadback_tests.cc": {
+      "operations": [
+        "createTexture",
+        "getQueue",
+        "writeTexture"
+      ],
+      "wgpuCFunctions": [
+        "wgpuLabel"
+      ],
+      "wgpuCppTokens": [
+        "Device",
+        "Extent3D",
+        "TexelCopyBufferLayout",
+        "TexelCopyTextureInfo",
+        "Texture",
+        "TextureDescriptor",
+        "TextureDimension",
+        "TextureFormat",
+        "TextureUsage"
       ]
     },
     "donner/svg/renderer/tests/RendererGeodeGolden_tests.cc": {

--- a/tools/gpu_inventory/manifests/shader_features.json
+++ b/tools/gpu_inventory/manifests/shader_features.json
@@ -1751,6 +1751,49 @@
         "Uniforms",
         "VertexOutput"
       ]
+    },
+    "donner/svg/renderer/geode/shaders/snapshot_unpremultiply.wgsl": {
+      "bindings": [
+        {
+          "binding": 0,
+          "group": 0,
+          "name": "input_tex",
+          "type": "texture_2d<f32>"
+        },
+        {
+          "binding": 1,
+          "group": 0,
+          "name": "output_tex",
+          "type": "texture_storage_2d<rgba8unorm, write>"
+        }
+      ],
+      "builtins": [
+        "global_invocation_id"
+      ],
+      "entryPoints": [
+        {
+          "name": "main",
+          "stage": "compute",
+          "workgroupSize": [
+            "8",
+            "8"
+          ]
+        }
+      ],
+      "features": [
+        "for",
+        "if",
+        "let",
+        "loop",
+        "min",
+        "return",
+        "round",
+        "textureDimensions",
+        "textureLoad",
+        "textureStore",
+        "var"
+      ],
+      "structs": []
     }
   }
 }


### PR DESCRIPTION
Snapshot readback now runs a compute pass (snapshot_unpremultiply) that converts the premultiplied render target to straight-alpha RGBA8 in a pooled staging texture, so the CPU only strips row padding; the shader replicates the CPU round-half-up formula byte-for-byte and a usage-flag-forced parity test pins byte equality against the CPU path. The native map wait polls with a 100 us sleep instead of 1 ms, cutting the latency floor without changing cancellation semantics. RendererBench gains retained second-draw, snapshot, and settled phases plus readback poll stats.

Verification: parity, perf, interruptible-snapshot, golden, and resvg corpus tests plus the full Geode repository gate at this layer's head, all green. The editor package size test budgets are retuned with measured evidence: js 170,862 raw / 48,316 gzip at this layer (main measured 48,284 gzip, 16 bytes under the old budget), and the retuned budget keeps about 1 percent headroom over the final stack measurement of 48,319 gzip.

Post-review hardening: the per-size snapshot readback pool is bounded with least-recently-used eviction (a window resize previously retained one staging texture and readback buffer per distinct canvas size for the device lifetime), the lazily built readback pipeline constructs under call_once per the documented cross-thread snapshot contract, a readback that exhausts the 10 second deadline reports TimedOut and skips the CPU fallback instead of starting a second full-deadline wait, the GPU path additionally gates on the texture's actual format, both mapped-range reads are null-checked and share one row-alignment helper with the pool sizing, the unpremultiply dispatch clamps to both texture sizes, and the js raw budget is retuned to match the gzip retune's headroom.
