### PR TITLE
perf: Suballocate resident geometry from a document-scoped slab

### DIFF
--- a/donner/editor/wasm/BUILD.bazel
+++ b/donner/editor/wasm/BUILD.bazel
@@ -322,8 +322,13 @@ py_test(
         # would leave the raw gate at 138 bytes of headroom over the
         # measured 170,862 raw, making it the one that flips red on the
         # next incidental change.
+        #
+        # Geode perf stack retune: the resident-slab packet adds deliberate
+        # renderer code to the editor package. Measured at this layer:
+        # wasm 11,243,015 raw and package 11,455,433 raw. Budgets keep about
+        # 1 percent headroom over the measured values.
         "--max-wasm-raw-bytes",
-        "11240000",
+        "11360000",
         "--max-wasm-gzip-bytes",
         "4490000",
         "--max-wasm-function-body-bytes",
@@ -335,7 +340,7 @@ py_test(
         "--max-js-gzip-bytes",
         "48800",
         "--max-total-raw-bytes",
-        "11565000",
+        "11570000",
         "--expected-js-property",
         "__donnerLastScrollEvent",
         # SHIP BLOCKER, tracked with the deferred WebKit decision: the WebGPU diagnostic

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1983,12 +1983,41 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
   /// 2). Returns null for a null source (editor/overlay draws stay on the
   /// arena path). The slot lives on a `GeodeResidentPathComponent` beside
   /// the M2 encode cache and is invalidated by the same listener.
+  /// Document-scoped resident slab: one growable chunk-set per registry,
+  /// bound to the current device. The slab is swapped when the document is
+  /// rendered by a different device, and freed with the registry.
+  /// Returns the registry's resident slab, shared so slots can keep the
+  /// old slab alive across a device change.
+  std::shared_ptr<geode::GeodeResidentSlab> residentSlab(Registry& registry) {
+    auto* slabPtr = registry.ctx().find<std::shared_ptr<geode::GeodeResidentSlab>>();
+    if (slabPtr == nullptr) {
+      registry.ctx().emplace<std::shared_ptr<geode::GeodeResidentSlab>>(nullptr);
+      slabPtr = registry.ctx().find<std::shared_ptr<geode::GeodeResidentSlab>>();
+    }
+    std::shared_ptr<geode::GeodeResidentSlab>& slab = *slabPtr;
+    if (!slab || slab->owningDeviceId() != device->deviceId()) {
+      slab = std::make_shared<geode::GeodeResidentSlab>(device->deviceId());
+    }
+    return slab;
+  }
+
   geode::GeodeResidentSlot* residentFillSlot(EntityHandle source) {
     if (!source) {
       return nullptr;
     }
     ensureCacheInvalidationWired(*source.registry());
-    return &source.get_or_emplace<geode::GeodeResidentPathComponent>().fillSlot;
+    geode::GeodeResidentSlot& slot =
+        source.get_or_emplace<geode::GeodeResidentPathComponent>().fillSlot;
+    std::shared_ptr<geode::GeodeResidentSlab> slab = residentSlab(*source.registry());
+    if (slot.slab.get() != slab.get()) {
+      // The registry's slab changed (device change): the slot's borrowed
+      // buffer may reference a released chunk, so its residence is stale
+      // and must re-upload from the new slab. reset() keeps the old slab
+      // reference alive via this slot until the swap below.
+      slot.reset();
+    }
+    slot.slab = std::move(slab);
+    return &slot;
   }
 
   /// GPU-residence slot for `source`'s stroke encode. See `residentFillSlot`.
@@ -1997,7 +2026,14 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       return nullptr;
     }
     ensureCacheInvalidationWired(*source.registry());
-    return &source.get_or_emplace<geode::GeodeResidentPathComponent>().strokeSlot;
+    geode::GeodeResidentSlot& slot =
+        source.get_or_emplace<geode::GeodeResidentPathComponent>().strokeSlot;
+    std::shared_ptr<geode::GeodeResidentSlab> slab = residentSlab(*source.registry());
+    if (slot.slab.get() != slab.get()) {
+      slot.reset();
+    }
+    slot.slab = std::move(slab);
+    return &slot;
   }
 
   /// GPU-residence slot for `source`'s gradient-painted fill (design doc
@@ -2009,7 +2045,14 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       return nullptr;
     }
     ensureCacheInvalidationWired(*source.registry());
-    return &source.get_or_emplace<geode::GeodeResidentPathComponent>().gradientFillSlot;
+    geode::GeodeResidentGradientSlot& slot =
+        source.get_or_emplace<geode::GeodeResidentPathComponent>().gradientFillSlot;
+    std::shared_ptr<geode::GeodeResidentSlab> slab = residentSlab(*source.registry());
+    if (slot.slab.get() != slab.get()) {
+      slot.reset();
+    }
+    slot.slab = std::move(slab);
+    return &slot;
   }
 
   /// Emit a solid fill, preferring the persistent-residence path when a
@@ -2707,6 +2750,11 @@ void RendererGeode::draw(SVGDocument& document) {
   // change between draws would silently leave a stale encode in
   // `GeodePathCacheComponent`.
   impl_->ensureCacheInvalidationWired(document.registry());
+
+  // Merge the previous frame's freed slab ranges before any draw records
+  // against this frame's command buffer (a range freed this frame is never
+  // reused this frame; see GeodeResidentSlab::beginFrame).
+  impl_->residentSlab(document.registry())->beginFrame();
 
   RendererDriver driver(*this, impl_->verbose);
   driver.draw(document);

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1998,6 +1998,13 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     if (!slab || slab->owningDeviceId() != device->deviceId()) {
       slab = std::make_shared<geode::GeodeResidentSlab>(device->deviceId());
     }
+    // Merge the previous frame's freed ranges, at most once per frame (the
+    // slab gates on the index). Gating here rather than at one draw entry
+    // point covers every path that can record resident draws, including
+    // multi-document tile frames that bypass draw(), and keeps a repeated
+    // draw() of the same document within one frame from prematurely
+    // recycling ranges its own recorded draws still reference.
+    slab->beginFrame(currentFrameIndex);
     return slab;
   }
 
@@ -2751,10 +2758,9 @@ void RendererGeode::draw(SVGDocument& document) {
   // `GeodePathCacheComponent`.
   impl_->ensureCacheInvalidationWired(document.registry());
 
-  // Merge the previous frame's freed slab ranges before any draw records
-  // against this frame's command buffer (a range freed this frame is never
-  // reused this frame; see GeodeResidentSlab::beginFrame).
-  impl_->residentSlab(document.registry())->beginFrame();
+  // Freed slab ranges merge lazily inside residentSlab(), gated to once
+  // per frame, so every resident-slot access (this draw, tile frames,
+  // repeated draws) shares one merge point; see GeodeResidentSlab::beginFrame.
 
   RendererDriver driver(*this, impl_->verbose);
   driver.draw(document);

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -41,6 +41,14 @@ constexpr uint64_t kStorageOffsetAlignment = 256u;
 // Uniform buffer bind-group offset: same 256-byte default across
 // wgpu-native backends (`minUniformBufferOffsetAlignment`).
 constexpr uint64_t kUniformOffsetAlignment = 256u;
+// The resident slab allocates slot ranges aligned only to
+// kStorageOffsetAlignment, while the region layout inside a slot uses the
+// per-region constant; absolute offsets stay valid for uniform bindings
+// only while the slab's allocation alignment also satisfies the uniform
+// alignment. Pin the coupling so a future divergence fails at compile time
+// instead of as a device-dependent binding validation error.
+static_assert(kStorageOffsetAlignment % kUniformOffsetAlignment == 0,
+              "resident slab allocation alignment must satisfy uniform binding alignment");
 
 /// Layout of the per-draw uniform buffer (must match shaders/slug_fill.wgsl).
 ///

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -397,7 +397,7 @@ struct GeoEncoder::Impl {
   /// uniform only if it changed, reuse the cached bind group, and record
   /// the draw. Steady-state (unchanged) frame: zero writes, zero bind
   /// group creates.
-  void submitResidentFillDraw(GeodeResidentSlot& slot, const EncodedPath& encoded,
+  bool submitResidentFillDraw(GeodeResidentSlot& slot, const EncodedPath& encoded,
                               const FillDrawArgs& args);
 
   /// Wave-2 extension for gradient paints: (re)upload `encoded` into the
@@ -415,7 +415,7 @@ struct GeoEncoder::Impl {
   /// gradient uniform when it changed, reuse the cached bind group, and
   /// record the draw. Steady-state (unchanged) frame: zero writes, zero
   /// bind group creates.
-  void submitResidentGradientDraw(GeodeResidentGradientSlot& slot, const EncodedPath& encoded,
+  bool submitResidentGradientDraw(GeodeResidentGradientSlot& slot, const EncodedPath& encoded,
                                   GradientUniforms& u);
 
   /// Fill the common prefix of a gradient uniform (mvp, viewport, stops,
@@ -1401,17 +1401,25 @@ void GeoEncoder::Impl::uploadResidentGeometry(GeodeResidentSlot& slot, const Enc
   const uint64_t totalSize = cursor;
   const uint64_t geometrySize = slot.uniform.offset;  // everything before the uniform.
 
-  wgpu::BufferDescriptor desc = {};
-  desc.label = wgpuLabel("GeodeResidentPath");
-  desc.size = totalSize;
-  desc.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::Uniform | wgpu::BufferUsage::CopyDst;
-  slot.buffer.reset(device->device().createBuffer(desc));
-  device->countBuffer();
+  // Suballocate from the document's resident slab (one growable buffer
+  // chunk set instead of a buffer per slot). The slab is installed by the
+  // renderer at slot creation and belongs to this device.
+  GeodeResidentSlab::Allocation alloc;
+  if (slot.slab == nullptr || slot.slab->owningDeviceId() != device->deviceId() ||
+      !slot.slab->allocate(*device, totalSize, kStorageOffsetAlignment, alloc)) {
+    return;
+  }
+  slot.buffer = alloc.buffer;
+  slot.allocationOffset = alloc.offset;
+  slot.allocationSize = alloc.size;
 
   // Assemble the geometry portion in one zero-filled staging blob so
   // padding + dummy regions read as zero, then upload it in a single
-  // `writeBuffer`. The uniform region is written separately by the draw
-  // path (so a camera/color-only change rewrites just the uniform region).
+  // `writeBuffer` at the allocation's absolute offset. Region offsets are
+  // relative to the allocation start here and are shifted to absolute
+  // buffer offsets below. The uniform region is written separately by the
+  // draw path (so a camera/color-only change rewrites just the uniform
+  // region).
   std::vector<uint8_t> staging(geometrySize, 0u);
   auto blit = [&](const GeodeResidentSlot::Region& r, const void* data, uint64_t bytes) {
     if (bytes > 0) {
@@ -1427,16 +1435,28 @@ void GeoEncoder::Impl::uploadResidentGeometry(GeodeResidentSlot& slot, const Enc
   blit(slot.hGrid, encoded.hBandGrid.data(), hGridBytes);
   blit(slot.vGrid, encoded.vBandGrid.data(), vGridBytes);
 
-  device->queue().writeBuffer(slot.buffer.get(), 0, staging.data(), geometrySize);
+  device->queue().writeBuffer(slot.buffer, alloc.offset, staging.data(), geometrySize);
   device->countBufferWrite(geometrySize);
+
+  // Regions become absolute buffer offsets for the bind groups.
+  auto shift = [&](GeodeResidentSlot::Region& r) {
+    if (r.size != 0) {
+      r.offset += alloc.offset;
+    }
+  };
+  shift(slot.bands);
+  shift(slot.curves);
+  shift(slot.hRefs);
+  shift(slot.vBands);
+  shift(slot.vCurves);
+  shift(slot.vRefs);
+  shift(slot.hGrid);
+  shift(slot.vGrid);
+  shift(slot.uniform);
 
   slot.vertexCount = encoded.boundingDrawVertexCount();
   slot.resident = true;
   slot.lastUniform.clear();  // Force the first uniform write below.
-
-  slot.liveBytesGauge = device->residentBytesGauge();
-  slot.accountedBytes = static_cast<int64_t>(totalSize);
-  slot.liveBytesGauge->fetch_add(slot.accountedBytes, std::memory_order_relaxed);
 
   // Stamp the current device's identity so a later render by a different
   // device re-uploads instead of binding this device's buffer / bind group
@@ -1446,7 +1466,7 @@ void GeoEncoder::Impl::uploadResidentGeometry(GeodeResidentSlot& slot, const Enc
 
 void GeoEncoder::Impl::buildResidentBindGroup(GeodeResidentSlot& slot) {
   const wgpu::Device& dev = device->device();
-  const wgpu::Buffer& buf = slot.buffer.get();
+  const wgpu::Buffer& buf = slot.buffer;
 
   wgpu::BindGroupEntry entries[14] = {};
   auto bufEntry = [&](int i, uint32_t binding, const GeodeResidentSlot::Region& r) {
@@ -1489,8 +1509,8 @@ void GeoEncoder::Impl::buildResidentBindGroup(GeodeResidentSlot& slot) {
   device->countBindGroup();
 }
 
-void GeoEncoder::Impl::submitResidentFillDraw(GeodeResidentSlot& slot, const EncodedPath& encoded,
-                                              const FillDrawArgs& args) {
+bool GeoEncoder::Impl::submitResidentFillDraw(GeodeResidentSlot& slot, const EncodedPath& encoded,
+                                               const FillDrawArgs& args) {
   ensurePassOpen();
   bindSolidPipeline();
 
@@ -1510,6 +1530,14 @@ void GeoEncoder::Impl::submitResidentFillDraw(GeodeResidentSlot& slot, const Enc
     slot.encodedFingerprint = fingerprint;
   }
 
+  // The upload can fail (no slab, a device mismatch that the caller has
+  // not re-wired yet, or a chunk allocation failure). Route the draw
+  // through the wave-1 arena path so it stays bit-exact and never touches
+  // an empty buffer.
+  if (!slot.resident || !slot.buffer) {
+    return false;
+  }
+
   // Rewrite the uniform only when it actually changed. A static
   // re-render (same viewport, same paint) produces byte-identical
   // uniforms, so this write is skipped entirely and the frame emits zero
@@ -1519,7 +1547,7 @@ void GeoEncoder::Impl::submitResidentFillDraw(GeodeResidentSlot& slot, const Enc
   const auto* uBytes = reinterpret_cast<const uint8_t*>(&u);
   if (slot.lastUniform.size() != sizeof(Uniforms) ||
       std::memcmp(slot.lastUniform.data(), uBytes, sizeof(Uniforms)) != 0) {
-    device->queue().writeBuffer(slot.buffer.get(), slot.uniform.offset, &u, sizeof(Uniforms));
+    device->queue().writeBuffer(slot.buffer, slot.uniform.offset, &u, sizeof(Uniforms));
     device->countBufferWrite(sizeof(Uniforms));
     slot.lastUniform.assign(uBytes, uBytes + sizeof(Uniforms));
   }
@@ -1532,6 +1560,7 @@ void GeoEncoder::Impl::submitResidentFillDraw(GeodeResidentSlot& slot, const Enc
   pass.get().setBindGroup(0, slot.bindGroup.get(), 0, nullptr);
   pass.get().draw(slot.vertexCount, 1, 0, 0);
   device->countDraw();
+  return true;
 }
 
 void GeoEncoder::fillPathResident(GeodeResidentSlot& slot, const EncodedPath& encoded,
@@ -1580,7 +1609,9 @@ void GeoEncoder::fillPathResident(GeodeResidentSlot& slot, const EncodedPath& en
     return;
   }
   slot.lastResidentFrame = frameId;
-  impl_->submitResidentFillDraw(slot, encoded, args);
+  if (!impl_->submitResidentFillDraw(slot, encoded, args)) {
+    submitFillDraw(args);
+  }
 }
 
 void GeoEncoder::fillPathInstanced(const EncodedPath& encoded, const css::RGBA& color,
@@ -1936,12 +1967,16 @@ void GeoEncoder::Impl::uploadResidentGradientGeometry(GeodeResidentGradientSlot&
   const uint64_t totalSize = cursor;
   const uint64_t geometrySize = slot.uniform.offset;
 
-  wgpu::BufferDescriptor desc = {};
-  desc.label = wgpuLabel("GeodeResidentGradientPath");
-  desc.size = totalSize;
-  desc.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::Uniform | wgpu::BufferUsage::CopyDst;
-  slot.buffer.reset(device->device().createBuffer(desc));
-  device->countBuffer();
+  // Suballocate from the document's resident slab (same contract as
+  // `uploadResidentGeometry`).
+  GeodeResidentSlab::Allocation alloc;
+  if (slot.slab == nullptr || slot.slab->owningDeviceId() != device->deviceId() ||
+      !slot.slab->allocate(*device, totalSize, kStorageOffsetAlignment, alloc)) {
+    return;
+  }
+  slot.buffer = alloc.buffer;
+  slot.allocationOffset = alloc.offset;
+  slot.allocationSize = alloc.size;
 
   std::vector<uint8_t> staging(geometrySize, 0u);
   auto blit = [&](const GeodeResidentGradientSlot::Region& r, const void* data, uint64_t bytes) {
@@ -1958,22 +1993,34 @@ void GeoEncoder::Impl::uploadResidentGradientGeometry(GeodeResidentGradientSlot&
   blit(slot.hGrid, encoded.hBandGrid.data(), hGridBytes);
   blit(slot.vGrid, encoded.vBandGrid.data(), vGridBytes);
 
-  device->queue().writeBuffer(slot.buffer.get(), 0, staging.data(), geometrySize);
+  device->queue().writeBuffer(slot.buffer, alloc.offset, staging.data(), geometrySize);
   device->countBufferWrite(geometrySize);
+
+  // Regions become absolute buffer offsets for the bind groups.
+  auto shift = [&](GeodeResidentGradientSlot::Region& r) {
+    if (r.size != 0) {
+      r.offset += alloc.offset;
+    }
+  };
+  shift(slot.bands);
+  shift(slot.curves);
+  shift(slot.hRefs);
+  shift(slot.vBands);
+  shift(slot.vCurves);
+  shift(slot.vRefs);
+  shift(slot.hGrid);
+  shift(slot.vGrid);
+  shift(slot.uniform);
 
   slot.vertexCount = encoded.boundingDrawVertexCount();
   slot.resident = true;
   slot.lastUniform.clear();  // Force the first uniform write below.
-
-  slot.liveBytesGauge = device->residentBytesGauge();
-  slot.accountedBytes = static_cast<int64_t>(totalSize);
-  slot.liveBytesGauge->fetch_add(slot.accountedBytes, std::memory_order_relaxed);
   slot.owningDeviceId = device->deviceId();
 }
 
 void GeoEncoder::Impl::buildResidentGradientBindGroup(GeodeResidentGradientSlot& slot) {
   const wgpu::Device& dev = device->device();
-  const wgpu::Buffer& buf = slot.buffer.get();
+  const wgpu::Buffer& buf = slot.buffer;
 
   // Eleven bindings mirroring `submitGradientDraw`, with the clip-mask
   // texture/sampler slots bound to the device-owned dummies. Residence is
@@ -2009,8 +2056,9 @@ void GeoEncoder::Impl::buildResidentGradientBindGroup(GeodeResidentGradientSlot&
   device->countBindGroup();
 }
 
-void GeoEncoder::Impl::submitResidentGradientDraw(GeodeResidentGradientSlot& slot,
-                                                  const EncodedPath& encoded, GradientUniforms& u) {
+bool GeoEncoder::Impl::submitResidentGradientDraw(GeodeResidentGradientSlot& slot,
+                                                   const EncodedPath& encoded,
+                                                   GradientUniforms& u) {
   // The grid parameters and the bounding polygon are derived from the
   // encode, not the paint; fill them exactly like the arena path so a
   // draw that flips between the two stays byte-identical.
@@ -2036,13 +2084,18 @@ void GeoEncoder::Impl::submitResidentGradientDraw(GeodeResidentGradientSlot& slo
     slot.encodedFingerprint = fingerprint;
   }
 
+  // Upload failure: report it so the caller routes the draw through the
+  // wave-1 arena path.
+  if (!slot.resident || !slot.buffer) {
+    return false;
+  }
+
   // Rewrite the gradient uniform only when it actually changed, mirroring
   // the fill path. A static re-render produces byte-identical uniforms.
   const auto* uBytes = reinterpret_cast<const uint8_t*>(&u);
   if (slot.lastUniform.size() != sizeof(GradientUniforms) ||
       std::memcmp(slot.lastUniform.data(), uBytes, sizeof(GradientUniforms)) != 0) {
-    device->queue().writeBuffer(slot.buffer.get(), slot.uniform.offset, &u,
-                                sizeof(GradientUniforms));
+    device->queue().writeBuffer(slot.buffer, slot.uniform.offset, &u, sizeof(GradientUniforms));
     device->countBufferWrite(sizeof(GradientUniforms));
     slot.lastUniform.assign(uBytes, uBytes + sizeof(GradientUniforms));
   }
@@ -2055,6 +2108,7 @@ void GeoEncoder::Impl::submitResidentGradientDraw(GeodeResidentGradientSlot& slo
   pass.get().setBindGroup(0, slot.bindGroup.get(), 0, nullptr);
   pass.get().draw(slot.vertexCount, 1, 0, 0);
   device->countDraw();
+  return true;
 }
 
 void GeoEncoder::fillPathLinearGradient(const Path& path, const LinearGradientParams& params,
@@ -2132,7 +2186,9 @@ void GeoEncoder::fillPathLinearGradientResident(GeodeResidentGradientSlot& slot,
     return;
   }
   slot.lastResidentFrame = frameId;
-  impl_->submitResidentGradientDraw(slot, encoded, u);
+  if (!impl_->submitResidentGradientDraw(slot, encoded, u)) {
+    impl_->submitGradientArenaFallback(u, encoded);
+  }
 }
 
 void GeoEncoder::fillPathRadialGradientResident(GeodeResidentGradientSlot& slot,
@@ -2157,7 +2213,9 @@ void GeoEncoder::fillPathRadialGradientResident(GeodeResidentGradientSlot& slot,
     return;
   }
   slot.lastResidentFrame = frameId;
-  impl_->submitResidentGradientDraw(slot, encoded, u);
+  if (!impl_->submitResidentGradientDraw(slot, encoded, u)) {
+    impl_->submitGradientArenaFallback(u, encoded);
+  }
 }
 
 void GeoEncoder::blitFullTarget(const wgpu::Texture& src, double opacity) {

--- a/donner/svg/renderer/geode/GeodeResidentPathComponent.h
+++ b/donner/svg/renderer/geode/GeodeResidentPathComponent.h
@@ -35,20 +35,23 @@ namespace donner::geode {
 class GeodeDevice;
 
 /**
- * Document-scoped suballocation slab for GPU residence (design doc 0030
- * wave 2 follow-up, Phase 2 scene data).
+ * Document-scoped suballocation slab for GPU residence.
  *
- * Wave 2 gave every cached path its own combined GPU buffer, so a
- * first frame allocated one buffer per resident slot (Lion: 133). The slab
- * replaces those with sub-ranges of a small number of growable chunk
- * buffers owned by the document's registry context, cutting first-frame
- * `bufferCreates` to one chunk per growth step (1 to 2 for typical
- * documents).
+ * Per-slot residence previously gave every cached path its own combined GPU
+ * buffer, so a first frame allocated one buffer per resident slot (Lion:
+ * 133). The slab replaces those with sub-ranges of a small number of
+ * growable chunk buffers owned by the document's registry context, cutting
+ * first-frame `bufferCreates` to one chunk per growth step (1 to 2 for
+ * typical documents).
  *
  * Allocations are bump-placed and returned through a first-fit free list,
  * so a geometry edit that re-uploads a slot reuses the freed range. Each
  * chunk's bytes are accounted in the device's live-resident-bytes gauge on
- * creation and released when the slab is destroyed with its registry.
+ * creation and released when the slab is destroyed with its registry. Note
+ * the gauge therefore reports slab CAPACITY, not live payload bytes: it
+ * grows when a chunk is created and never shrinks on slot reset, which is
+ * the right shape for leak detection but over-reads against the previous
+ * per-slot accounting.
  *
  * The slab is bound to one device (`GeodeDevice::deviceId()`): a document
  * rendered by a second device gets a fresh slab, and the old chunks are
@@ -85,13 +88,28 @@ public:
   uint64_t owningDeviceId() const { return owningDeviceId_; }
 
   /// Merge the previous frame's freed ranges into the reusable free list.
-  /// The renderer calls this once per frame (from `RendererGeode::draw`)
-  /// BEFORE any draws are recorded. Freed ranges must NOT be reused within
-  /// the frame that freed them: a re-upload that reuses its own just-freed
-  /// range would overwrite the geometry before the already-recorded draws
-  /// of the same frame read it (the resident slots hold one buffer range
-  /// per slot, not one buffer per draw).
-  void beginFrame() {
+  /// Gated on `frameIndex` (the renderer's frame counter) so the merge runs
+  /// at most once per frame no matter how many times the renderer touches
+  /// the slab: the accessor calls this on every slot lookup, which covers
+  /// every draw entry point (full-document draws and multi-document
+  /// tile/thumbnail frames alike) without trusting any single call site.
+  ///
+  /// Freed ranges must NOT be reused within the frame that freed them: a
+  /// re-upload that reuses its own just-freed range would overwrite the
+  /// geometry before the already-recorded draws of the same frame read it
+  /// (the resident slots hold one buffer range per slot, not one buffer per
+  /// draw). Merging at the first touch of frame N is safe because ranges
+  /// pending at that point were freed no later than frame N-1, whose
+  /// command buffer was submitted at its endFrame; a second renderer on the
+  /// same device has its own frame counter, and a stale-index skip only
+  /// defers the merge (the safe direction). Frames on one device are
+  /// serialized by contract, so no merge can run under another renderer's
+  /// unsubmitted frame.
+  void beginFrame(uint64_t frameIndex) {
+    if (frameIndex == lastMergedFrame_) {
+      return;
+    }
+    lastMergedFrame_ = frameIndex;
     for (const FreeRange& range : pendingFrees_) {
       auto it = freeRanges_.begin();
       while (it != freeRanges_.end() &&
@@ -230,6 +248,9 @@ private:
   };
 
   uint64_t owningDeviceId_ = 0;
+  /// Frame index of the last pending-free merge; ~0 = never merged. See
+  /// beginFrame().
+  uint64_t lastMergedFrame_ = ~uint64_t{0};
   std::vector<Chunk> chunks_;
   std::vector<FreeRange> freeRanges_;
   std::vector<FreeRange> pendingFrees_;

--- a/donner/svg/renderer/geode/GeodeResidentPathComponent.h
+++ b/donner/svg/renderer/geode/GeodeResidentPathComponent.h
@@ -54,6 +54,10 @@ class GeodeDevice;
  * rendered by a second device gets a fresh slab, and the old chunks are
  * released without touching the old device's objects (WebGPU retains any
  * still-referenced buffers through submitted command buffers).
+ *
+ * Not thread-safe: allocate/free/beginFrame mutate the free list and bump
+ * cursors without locking. The renderer serializes one frame per device at
+ * a time, so a document's slab is only touched from one thread.
  */
 class GeodeResidentSlab {
 public:

--- a/donner/svg/renderer/geode/GeodeResidentPathComponent.h
+++ b/donner/svg/renderer/geode/GeodeResidentPathComponent.h
@@ -32,6 +32,207 @@
 
 namespace donner::geode {
 
+class GeodeDevice;
+
+/**
+ * Document-scoped suballocation slab for GPU residence (design doc 0030
+ * wave 2 follow-up, Phase 2 scene data).
+ *
+ * Wave 2 gave every cached path its own combined GPU buffer, so a
+ * first frame allocated one buffer per resident slot (Lion: 133). The slab
+ * replaces those with sub-ranges of a small number of growable chunk
+ * buffers owned by the document's registry context, cutting first-frame
+ * `bufferCreates` to one chunk per growth step (1 to 2 for typical
+ * documents).
+ *
+ * Allocations are bump-placed and returned through a first-fit free list,
+ * so a geometry edit that re-uploads a slot reuses the freed range. Each
+ * chunk's bytes are accounted in the device's live-resident-bytes gauge on
+ * creation and released when the slab is destroyed with its registry.
+ *
+ * The slab is bound to one device (`GeodeDevice::deviceId()`): a document
+ * rendered by a second device gets a fresh slab, and the old chunks are
+ * released without touching the old device's objects (WebGPU retains any
+ * still-referenced buffers through submitted command buffers).
+ */
+class GeodeResidentSlab {
+public:
+  /// One sub-range of a slab chunk.
+  struct Allocation {
+    wgpu::Buffer buffer;  // Borrowed handle; owned by the slab chunk.
+    uint64_t offset = 0;
+    uint64_t size = 0;
+  };
+
+  /// Create an empty slab bound to `deviceId` (usually the current
+  /// renderer's device). Chunks are allocated lazily on first use.
+  explicit GeodeResidentSlab(uint64_t deviceId) : owningDeviceId_(deviceId) {}
+
+  ~GeodeResidentSlab() {
+    if (gauge_ && accountedBytes_ != 0) {
+      gauge_->fetch_sub(accountedBytes_, std::memory_order_relaxed);
+    }
+  }
+
+  GeodeResidentSlab(const GeodeResidentSlab&) = delete;
+  GeodeResidentSlab& operator=(const GeodeResidentSlab&) = delete;
+
+  /// Device this slab's chunks were created on.
+  uint64_t owningDeviceId() const { return owningDeviceId_; }
+
+  /// Merge the previous frame's freed ranges into the reusable free list.
+  /// The renderer calls this once per frame (from `RendererGeode::draw`)
+  /// BEFORE any draws are recorded. Freed ranges must NOT be reused within
+  /// the frame that freed them: a re-upload that reuses its own just-freed
+  /// range would overwrite the geometry before the already-recorded draws
+  /// of the same frame read it (the resident slots hold one buffer range
+  /// per slot, not one buffer per draw).
+  void beginFrame() {
+    for (const FreeRange& range : pendingFrees_) {
+      auto it = freeRanges_.begin();
+      while (it != freeRanges_.end() &&
+             (it->chunk < range.chunk || (it->chunk == range.chunk && it->offset < range.offset))) {
+        ++it;
+      }
+      bool merged = false;
+      if (it != freeRanges_.end() && it->chunk == range.chunk &&
+          it->offset == range.offset + range.size) {
+        it->offset = range.offset;
+        it->size += range.size;
+        merged = true;
+      }
+      if (it != freeRanges_.begin()) {
+        auto prev = std::prev(it);
+        if (prev->chunk == range.chunk && prev->offset + prev->size == range.offset) {
+          if (merged) {
+            prev->size += it->size;
+            freeRanges_.erase(it);
+          } else {
+            prev->size += range.size;
+          }
+          continue;
+        }
+      }
+      if (!merged) {
+        freeRanges_.insert(it, range);
+      }
+    }
+    pendingFrees_.clear();
+  }
+
+  /// Bump- or free-list-allocate `size` bytes aligned to `alignment`.
+  /// Creates a new chunk (and counts it) when nothing fits. Returns false
+  /// when the device cannot create a buffer.
+  bool allocate(GeodeDevice& device, uint64_t size, uint64_t alignment, Allocation& out) {
+    if (size == 0) {
+      return false;
+    }
+
+    // First-fit from the free list (ranges carry their chunk index and
+    // stay sorted by chunk then offset).
+    for (auto it = freeRanges_.begin(); it != freeRanges_.end(); ++it) {
+      const uint64_t start = alignUp(it->offset, alignment);
+      if (start + size <= it->offset + it->size) {
+        out.buffer = chunks_[it->chunk].buffer.get();
+        out.offset = start;
+        out.size = size;
+        if (start == it->offset) {
+          it->offset += size;
+          it->size -= size;
+          if (it->size == 0) {
+            freeRanges_.erase(it);
+          }
+        } else {
+          const uint64_t tail = (it->offset + it->size) - (start + size);
+          it->size = start - it->offset;
+          if (tail > 0) {
+            freeRanges_.insert(std::next(it), FreeRange{it->chunk, start + size, tail});
+          }
+        }
+        return true;
+      }
+    }
+
+    // Bump-allocate from the newest chunk, growing when it does not fit.
+    if (chunks_.empty() || alignUp(chunks_.back().cursor, alignment) + size > chunks_.back().size) {
+      uint64_t newSize = chunks_.empty() ? kInitialChunkBytes : chunks_.back().size * 2u;
+      while (newSize < alignUp(size, alignment)) {
+        newSize *= 2u;
+      }
+      wgpu::BufferDescriptor desc = {};
+      desc.label = wgpuLabel("GeodeResidentSlab");
+      desc.size = newSize;
+      desc.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::Uniform |
+                   wgpu::BufferUsage::CopyDst;
+      Chunk chunk;
+      chunk.buffer.reset(device.device().createBuffer(desc));
+      if (!chunk.buffer) {
+        return false;
+      }
+      device.countBuffer();
+      chunk.size = newSize;
+      chunks_.push_back(std::move(chunk));
+      if (!gauge_) {
+        gauge_ = device.residentBytesGauge();
+      }
+      gauge_->fetch_add(static_cast<int64_t>(newSize), std::memory_order_relaxed);
+      accountedBytes_ += static_cast<int64_t>(newSize);
+    }
+
+    Chunk& chunk = chunks_.back();
+    out.buffer = chunk.buffer.get();
+    out.offset = alignUp(chunk.cursor, alignment);
+    out.size = size;
+    chunk.cursor = out.offset + size;
+    return true;
+  }
+
+  /// Return an allocation for reuse at the NEXT frame boundary. The
+  /// range is not reusable within the current frame: see beginFrame().
+  void free(const Allocation& alloc) {
+    if (alloc.size == 0) {
+      return;
+    }
+    // Locate the owning chunk.
+    size_t chunkIndex = 0;
+    for (; chunkIndex < chunks_.size(); ++chunkIndex) {
+      if (chunks_[chunkIndex].buffer.get() == alloc.buffer) {
+        break;
+      }
+    }
+    if (chunkIndex == chunks_.size()) {
+      return;  // Stale allocation (chunk no longer live); ignore.
+    }
+    pendingFrees_.push_back(FreeRange{chunkIndex, alloc.offset, alloc.size});
+  }
+
+private:
+  static constexpr uint64_t kInitialChunkBytes = 1u << 20;  // 1 MiB.
+
+  static uint64_t alignUp(uint64_t value, uint64_t alignment) {
+    return (value + alignment - 1u) & ~(alignment - 1u);
+  }
+
+  struct Chunk {
+    ScopedWgpuHandle<wgpu::Buffer> buffer;
+    uint64_t size = 0;
+    uint64_t cursor = 0;
+  };
+
+  struct FreeRange {
+    uint64_t chunk = 0;
+    uint64_t offset = 0;
+    uint64_t size = 0;
+  };
+
+  uint64_t owningDeviceId_ = 0;
+  std::vector<Chunk> chunks_;
+  std::vector<FreeRange> freeRanges_;
+  std::vector<FreeRange> pendingFrees_;
+  std::shared_ptr<std::atomic<int64_t>> gauge_;
+  int64_t accountedBytes_ = 0;
+};
+
 /// GPU-resident geometry for one cached `EncodedPath` (a fill slot or a
 /// stroke slot). Owns a single combined-usage GPU buffer that holds the
 /// path's eight analytic dual-ray SSBO regions and per-draw uniform block, plus the cached fill
@@ -43,10 +244,20 @@ namespace donner::geode {
 /// Move-only (owns wgpu handles). Default-constructed slots are empty;
 /// `GeoEncoder::fillPathResident` populates them lazily.
 struct GeodeResidentSlot {
-  /// Combined Storage|Uniform|CopyDst buffer. Layout (each region
-  /// offset satisfies the binding's alignment requirement):
+  /// Combined Storage|Uniform|CopyDst buffer, borrowed from the owning
+  /// `GeodeResidentSlab` chunk. Region offsets are ABSOLUTE buffer
+  /// offsets. Layout (each region offset satisfies the binding's
+  /// alignment requirement):
   ///   [ bands | curves | hRefs | vBands | vCurves | vRefs | hGrid | vGrid | uniform ]
-  ScopedWgpuHandle<wgpu::Buffer> buffer;
+  wgpu::Buffer buffer;
+  /// Slab that owns `buffer`; null until residence is established. Held
+  /// by shared_ptr so a device change (which swaps the registry's slab)
+  /// cannot leave a slot referencing a destroyed slab: old slots keep the
+  /// old slab alive until their own reset drops the reference.
+  std::shared_ptr<GeodeResidentSlab> slab;
+  /// Whole-slot allocation inside the slab, returned via `free` on reset.
+  uint64_t allocationOffset = 0;
+  uint64_t allocationSize = 0;
 
   /// Cached fill bind group. All fourteen bindings reference stable
   /// objects (this slot's `buffer` sub-ranges + device-owned dummy
@@ -116,12 +327,6 @@ struct GeodeResidentSlot {
   /// only this 368-byte region and keeps the cached bind group.
   std::vector<uint8_t> lastUniform;
 
-  /// Live-resident-bytes gauge, co-owned with `GeodeDevice` so the
-  /// accounting is lifetime-safe even if the owning document outlives the
-  /// device. Incremented on residence, decremented on reset/destroy.
-  std::shared_ptr<std::atomic<int64_t>> liveBytesGauge;
-  int64_t accountedBytes = 0;
-
   GeodeResidentSlot() = default;
   ~GeodeResidentSlot() { reset(); }
 
@@ -131,7 +336,13 @@ struct GeodeResidentSlot {
   GeodeResidentSlot& operator=(GeodeResidentSlot&& other) noexcept {
     if (this != &other) {
       reset();
-      buffer = std::move(other.buffer);
+      buffer = other.buffer;
+      other.buffer = wgpu::Buffer();
+      slab = std::move(other.slab);
+      allocationOffset = other.allocationOffset;
+      allocationSize = other.allocationSize;
+      other.allocationOffset = 0;
+      other.allocationSize = 0;
       bindGroup = std::move(other.bindGroup);
       bands = other.bands;
       curves = other.curves;
@@ -149,9 +360,6 @@ struct GeodeResidentSlot {
       encodedFingerprint = other.encodedFingerprint;
       owningDeviceId = other.owningDeviceId;
       lastUniform = std::move(other.lastUniform);
-      liveBytesGauge = std::move(other.liveBytesGauge);
-      accountedBytes = other.accountedBytes;
-      other.accountedBytes = 0;
       other.resident = false;
       other.encodedKey = nullptr;
       other.owningDeviceId = 0;
@@ -159,20 +367,27 @@ struct GeodeResidentSlot {
     return *this;
   }
 
-  /// Release the GPU buffer + bind group handles and settle the live-bytes
-  /// gauge. Safe to call on an empty slot. A geometry mutation can remove
-  /// this component after a draw has referenced the buffer but before the
+  /// Return the slab allocation and drop the bind group + borrowed handle.
+  /// Safe to call on an empty slot. A geometry mutation can remove this
+  /// component after a draw has referenced the buffer but before the
   /// frame's command encoder is submitted. Do not call `Buffer::destroy()`
   /// here: WebGPU makes that buffer unusable immediately, invalidating the
-  /// already-recorded draw. Releasing our handles is sufficient because the
-  /// command encoder keeps the referenced resources alive until it is done.
+  /// already-recorded draw. Releasing our references is sufficient because
+  /// the command encoder keeps the referenced resources alive until it is
+  /// done.
   void reset() {
-    if (accountedBytes != 0 && liveBytesGauge) {
-      liveBytesGauge->fetch_sub(accountedBytes, std::memory_order_relaxed);
+    if (slab && allocationSize != 0) {
+      GeodeResidentSlab::Allocation alloc{buffer, allocationOffset, allocationSize};
+      slab->free(alloc);
     }
-    accountedBytes = 0;
+    // The slab pointer itself is intentionally kept: it outlives any one
+    // residence (it is owned by the registry context), and the re-upload
+    // path needs it right after reset(). `residentFillSlot` refreshes it
+    // when the document crosses devices.
+    allocationOffset = 0;
+    allocationSize = 0;
+    buffer = wgpu::Buffer();
     bindGroup.reset();
-    buffer.reset();
     resident = false;
     encodedKey = nullptr;
     encodedFingerprint = 0;
@@ -192,11 +407,19 @@ struct GeodeResidentSlot {
 /// shader's clip flags must stay zero for the cached bind group to remain
 /// stable), exactly like the solid-fill residence gate.
 struct GeodeResidentGradientSlot {
-  /// Combined Storage|Uniform|CopyDst buffer. Region layout matches
-  /// \ref GeodeResidentSlot: [ bands | curves | hRefs | vBands | vCurves |
-  /// vRefs | hGrid | vGrid | uniform ], with the uniform region sized for
-  /// `GradientUniforms` (672 bytes).
-  ScopedWgpuHandle<wgpu::Buffer> buffer;
+  /// Combined Storage|Uniform|CopyDst buffer, borrowed from the owning
+  /// `GeodeResidentSlab` chunk; region offsets are ABSOLUTE buffer
+  /// offsets. Region layout matches \ref GeodeResidentSlot, with the
+  /// uniform region sized for `GradientUniforms` (672 bytes).
+  wgpu::Buffer buffer;
+  /// Slab that owns `buffer`; null until residence is established. Held
+  /// by shared_ptr so a device change (which swaps the registry's slab)
+  /// cannot leave a slot referencing a destroyed slab: old slots keep the
+  /// old slab alive until their own reset drops the reference.
+  std::shared_ptr<GeodeResidentSlab> slab;
+  /// Whole-slot allocation inside the slab, returned via `free` on reset.
+  uint64_t allocationOffset = 0;
+  uint64_t allocationSize = 0;
 
   /// Cached 11-binding gradient bind group. All bindings reference stable
   /// objects (this slot's buffer sub-ranges + device-owned dummy
@@ -240,10 +463,6 @@ struct GeodeResidentGradientSlot {
   /// Bytes last written to the uniform region; unchanged draws skip the write.
   std::vector<uint8_t> lastUniform;
 
-  /// Live-resident-bytes gauge, co-owned with `GeodeDevice`.
-  std::shared_ptr<std::atomic<int64_t>> liveBytesGauge;
-  int64_t accountedBytes = 0;
-
   GeodeResidentGradientSlot() = default;
   ~GeodeResidentGradientSlot() { reset(); }
 
@@ -253,7 +472,13 @@ struct GeodeResidentGradientSlot {
   GeodeResidentGradientSlot& operator=(GeodeResidentGradientSlot&& other) noexcept {
     if (this != &other) {
       reset();
-      buffer = std::move(other.buffer);
+      buffer = other.buffer;
+      other.buffer = wgpu::Buffer();
+      slab = std::move(other.slab);
+      allocationOffset = other.allocationOffset;
+      allocationSize = other.allocationSize;
+      other.allocationOffset = 0;
+      other.allocationSize = 0;
       bindGroup = std::move(other.bindGroup);
       bands = other.bands;
       curves = other.curves;
@@ -271,9 +496,6 @@ struct GeodeResidentGradientSlot {
       encodedFingerprint = other.encodedFingerprint;
       owningDeviceId = other.owningDeviceId;
       lastUniform = std::move(other.lastUniform);
-      liveBytesGauge = std::move(other.liveBytesGauge);
-      accountedBytes = other.accountedBytes;
-      other.accountedBytes = 0;
       other.resident = false;
       other.encodedKey = nullptr;
       other.owningDeviceId = 0;
@@ -281,15 +503,21 @@ struct GeodeResidentGradientSlot {
     return *this;
   }
 
-  /// Release the GPU handles and settle the live-bytes gauge. Never calls
-  /// `Buffer::destroy()`; see GeodeResidentSlot::reset.
+  /// Return the slab allocation and drop the bind group + borrowed handle.
+  /// Never calls `Buffer::destroy()`; see GeodeResidentSlot::reset.
   void reset() {
-    if (accountedBytes != 0 && liveBytesGauge) {
-      liveBytesGauge->fetch_sub(accountedBytes, std::memory_order_relaxed);
+    if (slab && allocationSize != 0) {
+      GeodeResidentSlab::Allocation alloc{buffer, allocationOffset, allocationSize};
+      slab->free(alloc);
     }
-    accountedBytes = 0;
+    // The slab pointer itself is intentionally kept: it outlives any one
+    // residence (it is owned by the registry context), and the re-upload
+    // path needs it right after reset(). `residentFillSlot` refreshes it
+    // when the document crosses devices.
+    allocationOffset = 0;
+    allocationSize = 0;
+    buffer = wgpu::Buffer();
     bindGroup.reset();
-    buffer.reset();
     resident = false;
     encodedKey = nullptr;
     encodedFingerprint = 0;

--- a/tools/gpu_inventory/manifests/gpu_operations.json
+++ b/tools/gpu_inventory/manifests/gpu_operations.json
@@ -862,9 +862,17 @@
       ]
     },
     "donner/svg/renderer/geode/GeodeResidentPathComponent.h": {
+      "operations": [
+        "createBuffer"
+      ],
+      "wgpuCFunctions": [
+        "wgpuLabel"
+      ],
       "wgpuCppTokens": [
         "BindGroup",
-        "Buffer"
+        "Buffer",
+        "BufferDescriptor",
+        "BufferUsage"
       ]
     },
     "donner/svg/renderer/geode/GeodeShaders.cc": {


### PR DESCRIPTION
Replaces one combined GPU buffer per resident slot with sub-ranges of a per-registry growable chunk slab with a first-fit free list, cutting first-frame buffer creates from 133 to 2 on lion.svg while frame 2 stays at zero creates, zero bind groups, and zero writes. Freed ranges defer to the next frame so a re-upload never reuses a range the current frame's recorded draws still read; a device change swaps the registry slab and resets any slot whose slab changed. Chunk bytes are accounted in the live-resident-bytes gauge.

Verification: GpuResidence teardown, steady, and cross-device tests, structured-editing stress, goldens, and the full Geode repository gate at this layer's head, all green. The editor package size test budgets are retuned with measured evidence: wasm 11,243,015 raw and package 11,455,433 raw at this layer, with about 1 percent headroom over the measured values.

Post-review hardening: pending-free merges are gated on the renderer frame counter inside the slab accessor, so a repeated draw of one document within a frame cannot prematurely recycle ranges its recorded draws still reference, and multi-document tile frames (which bypass draw()) now merge too; a static_assert pins the coupling between the slab allocation alignment and the uniform binding alignment; and the live-resident-bytes gauge's capacity semantics (chunk capacity, not live payload) are documented.
