### PR TITLE
perf: Pool image-blit uniforms into the encoder scratch arena

### DIFF
--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -2042,6 +2042,24 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     return &slot;
   }
 
+  /// GPU-residence slot for `source`'s gradient-painted stroke.
+  /// See `residentGradientFillSlot`; the slot holds the cached
+  /// stroke-outline encode plus the resolved gradient uniform.
+  geode::GeodeResidentGradientSlot* residentGradientStrokeSlot(EntityHandle source) {
+    if (!source) {
+      return nullptr;
+    }
+    ensureCacheInvalidationWired(*source.registry());
+    geode::GeodeResidentGradientSlot& slot =
+        source.get_or_emplace<geode::GeodeResidentPathComponent>().gradientStrokeSlot;
+    std::shared_ptr<geode::GeodeResidentSlab> slab = residentSlab(*source.registry());
+    if (slot.slab.get() != slab.get()) {
+      slot.reset();
+    }
+    slot.slab = std::move(slab);
+    return &slot;
+  }
+
   /// GPU-residence slot for `source`'s gradient-painted fill.
   /// See `residentFillSlot`; the slot lives on the
   /// same `GeodeResidentPathComponent` and is invalidated by the same
@@ -2238,6 +2256,18 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
         // zero-area closed subpaths first (see `deCloseZeroAreaSubpaths`) so a
         // degenerate `M L Z` line strokes into a clean rectangle the analytic
         // shader covers correctly, instead of overlapping triangles.
+        // Drop the stale GPU residence FIRST, unconditionally for every
+        // exit of this miss branch: the encode is about to be replaced in
+        // place (or destroyed, in the empty-outline case below) without
+        // removing the entity's components, so the entt listener does not
+        // fire, and a resident slot keyed on the old encode storage would
+        // keep a dangling encodedKey plus a retained slab range. The
+        // GeoEncoder fingerprint guard is a second line of defense; this
+        // keeps the invariant obvious at the single mutation site.
+        if (auto* resident = source.try_get<geode::GeodeResidentPathComponent>()) {
+          resident->strokeSlot.reset();
+          resident->gradientStrokeSlot.reset();
+        }
         Path stroked =
             deCloseZeroAreaSubpaths(geometry).strokeToFill(strokeStyle, flattenTolerance);
         if (stroked.empty()) {
@@ -2258,15 +2288,6 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
             .strokedEncode = std::move(encoded),
             .strokeFillRule = fillRule,
         };
-        // The stroke encode was rebuilt in place (stroke-param change)
-        // without removing the entity's components, so the entt listener
-        // does not fire. Drop the stale GPU residence explicitly so the
-        // next draw re-uploads the new stroked geometry. The `GeoEncoder`
-        // fingerprint guard is a second line of
-        // defense; this keeps the invariant obvious at the mutation site.
-        if (auto* resident = source.try_get<geode::GeodeResidentPathComponent>()) {
-          resident->strokeSlot.reset();
-        }
       }
       result.strokedPath = &cache.strokeSlot->strokedPath;
       result.encoded = &cache.strokeSlot->strokedEncode;
@@ -4199,8 +4220,17 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
       (strokeDerived.encoded != nullptr && std::holds_alternative<PaintServer::Solid>(strokeServer))
           ? impl_->residentStrokeSlot(path.sourceEntity)
           : nullptr;
+  // Gradient residence for gradient-painted strokes: the cached
+  // stroke-outline encode lives in a gradient slot so an unchanged outline
+  // with an unchanged resolved gradient re-uploads zero geometry.
+  geode::GeodeResidentGradientSlot* residentGradientStroke =
+      (strokeDerived.encoded != nullptr &&
+       std::holds_alternative<components::PaintResolvedReference>(strokeServer))
+          ? impl_->residentGradientStrokeSlot(path.sourceEntity)
+          : nullptr;
   impl_->drawPaintedPathAgainst(path.path, strokedOutline, strokeServer, effectiveOpacity,
-                                strokeDerived.fillRule, strokeDerived.encoded, residentStroke);
+                                strokeDerived.fillRule, strokeDerived.encoded, residentStroke,
+                                residentGradientStroke);
 }
 
 void RendererGeode::drawRect(const Box2d& rect, const StrokeParams& stroke) {

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -227,11 +227,21 @@ constexpr uint32_t kGradientKindRadial = 1u;
 
 }  // namespace
 
-struct GeoEncoder::Impl {
+struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   GeodeDevice* device;
   const GeodePipeline* pipeline;
   const GeodeGradientPipeline* gradientPipeline;
   const GeodeImagePipeline* imagePipeline;
+
+  /// Pooled blit-uniform scratch: bump-allocate image-blit uniforms from
+  /// the encoder's uniform arena instead of creating one buffer per blit.
+  /// Consecutive image draws and layer composites share one growing
+  /// buffer; a buffer is only created when the arena grows.
+  GeodeTextureEncoder::UniformAllocation allocate(const void* data, uint64_t size,
+                                                  uint64_t alignment) override {
+    const Allocation alloc = allocInArena(uniformArena, data, size, alignment);
+    return {alloc.buffer, alloc.offset, alloc.size};
+  }
 
   /// Per-encoder growable GPU buffer used as a bump-allocation arena
   /// for per-draw data (vertex / band / curve). Replaces the per-fill
@@ -2261,7 +2271,7 @@ void GeoEncoder::blitFullTarget(const wgpu::Texture& src, double opacity) {
 
   GeodeTextureEncoder::drawTexturedQuad(*impl_->device, *impl_->imagePipeline, impl_->pass.get(),
                                         src, mvp, impl_->targetWidth, impl_->targetHeight, qp,
-                                        impl_->transientResources);
+                                        impl_->transientResources, impl_.get());
 }
 
 void GeoEncoder::blitFullTargetMasked(const wgpu::Texture& content, const wgpu::Texture& mask,
@@ -2302,7 +2312,7 @@ void GeoEncoder::blitFullTargetMasked(const wgpu::Texture& content, const wgpu::
 
   GeodeTextureEncoder::drawTexturedQuad(*impl_->device, *impl_->imagePipeline, impl_->pass.get(),
                                         content, mvp, impl_->targetWidth, impl_->targetHeight, qp,
-                                        impl_->transientResources);
+                                        impl_->transientResources, impl_.get());
 }
 
 void GeoEncoder::blitFullTargetBlended(const wgpu::Texture& layer, const wgpu::Texture& dstSnapshot,
@@ -2345,7 +2355,7 @@ void GeoEncoder::blitFullTargetBlended(const wgpu::Texture& layer, const wgpu::T
 
   GeodeTextureEncoder::drawTexturedQuad(*impl_->device, *impl_->imagePipeline, impl_->pass.get(),
                                         layer, mvp, impl_->targetWidth, impl_->targetHeight, qp,
-                                        impl_->transientResources);
+                                        impl_->transientResources, impl_.get());
 }
 
 void GeoEncoder::drawImage(const svg::ImageResource& image, const Box2d& destRect, double opacity,
@@ -2398,7 +2408,7 @@ void GeoEncoder::drawImage(const svg::ImageResource& image, const Box2d& destRec
 
   GeodeTextureEncoder::drawTexturedQuad(*impl_->device, *impl_->imagePipeline, impl_->pass.get(),
                                         texture, mvp, impl_->targetWidth, impl_->targetHeight, qp,
-                                        impl_->transientResources);
+                                        impl_->transientResources, impl_.get());
 }
 
 void GeoEncoder::drawTexture(const wgpu::Texture& texture, const Box2d& destRect,
@@ -2429,7 +2439,7 @@ void GeoEncoder::drawTexture(const wgpu::Texture& texture, const Box2d& destRect
 
   GeodeTextureEncoder::drawTexturedQuad(*impl_->device, *impl_->imagePipeline, impl_->pass.get(),
                                         texture, mvp, impl_->targetWidth, impl_->targetHeight, qp,
-                                        impl_->transientResources);
+                                        impl_->transientResources, impl_.get());
 }
 
 void GeoEncoder::finish() {

--- a/donner/svg/renderer/geode/GeodeResidentPathComponent.h
+++ b/donner/svg/renderer/geode/GeodeResidentPathComponent.h
@@ -559,6 +559,10 @@ struct GeodeResidentPathComponent {
   GeodeResidentSlot strokeSlot;
   /// Gradient-painted fill residence.
   GeodeResidentGradientSlot gradientFillSlot;
+  /// Gradient-painted stroke residence. Holds the
+  /// cached stroke-outline encode plus the resolved gradient uniform, so
+  /// an unchanged gradient-stroked outline re-uploads zero geometry.
+  GeodeResidentGradientSlot gradientStrokeSlot;
 };
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodeTextureEncoder.cc
+++ b/donner/svg/renderer/geode/GeodeTextureEncoder.cc
@@ -117,7 +117,8 @@ void GeodeTextureEncoder::drawTexturedQuad(GeodeDevice& device, const GeodeImage
                                            const wgpu::Texture& texture, const float mvp[16],
                                            uint32_t targetWidth, uint32_t targetHeight,
                                            const QuadParams& params,
-                                           ScopedWgpuResourceArena& resourceArena) {
+                                           ScopedWgpuResourceArena& resourceArena,
+                                           UniformScratch* scratch) {
   if (!texture) {
     return;
   }
@@ -149,14 +150,28 @@ void GeodeTextureEncoder::drawTexturedQuad(GeodeDevice& device, const GeodeImage
   u.blendMode = params.blendMode;
   u.hasClipMask = params.clipMaskView ? 1u : 0u;
 
-  wgpu::BufferDescriptor uniDesc = {};
-  uniDesc.label = wgpuLabel("GeodeImageBlitUniforms");
-  uniDesc.size = sizeof(Uniforms);
-  uniDesc.usage = wgpu::BufferUsage::Uniform | wgpu::BufferUsage::CopyDst;
-  wgpu::Buffer uniBuf = resourceArena.retain(dev.createBuffer(uniDesc));
-  device.countBuffer();
-  queue.writeBuffer(uniBuf, 0, &u, sizeof(Uniforms));
-  device.countBufferWrite(sizeof(Uniforms));
+  // Pooled callers bump-allocate from their per-frame scratch arena;
+  // standalone callers keep the legacy one-buffer-per-blit path.
+  wgpu::Buffer uniBuf;
+  uint64_t uniOffset = 0;
+  uint64_t uniSize = sizeof(Uniforms);
+  if (scratch != nullptr) {
+    constexpr uint64_t kUniformOffsetAlignment = 256u;
+    const UniformAllocation alloc =
+        scratch->allocate(&u, sizeof(Uniforms), kUniformOffsetAlignment);
+    uniBuf = alloc.buffer;
+    uniOffset = alloc.offset;
+    uniSize = alloc.size;
+  } else {
+    wgpu::BufferDescriptor uniDesc = {};
+    uniDesc.label = wgpuLabel("GeodeImageBlitUniforms");
+    uniDesc.size = sizeof(Uniforms);
+    uniDesc.usage = wgpu::BufferUsage::Uniform | wgpu::BufferUsage::CopyDst;
+    uniBuf = resourceArena.retain(dev.createBuffer(uniDesc));
+    device.countBuffer();
+    queue.writeBuffer(uniBuf, 0, &u, sizeof(Uniforms));
+    device.countBufferWrite(sizeof(Uniforms));
+  }
 
   // Pick sampler based on requested filter mode.
   const wgpu::Sampler& sampler =
@@ -176,7 +191,8 @@ void GeodeTextureEncoder::drawTexturedQuad(GeodeDevice& device, const GeodeImage
   wgpu::BindGroupEntry entries[7] = {};
   entries[0].binding = 0;
   entries[0].buffer = uniBuf;
-  entries[0].size = sizeof(Uniforms);
+  entries[0].offset = uniOffset;
+  entries[0].size = uniSize;
   entries[1].binding = 1;
   entries[1].sampler = sampler;
   entries[2].binding = 2;

--- a/donner/svg/renderer/geode/GeodeTextureEncoder.cc
+++ b/donner/svg/renderer/geode/GeodeTextureEncoder.cc
@@ -156,7 +156,7 @@ void GeodeTextureEncoder::drawTexturedQuad(GeodeDevice& device, const GeodeImage
   uint64_t uniOffset = 0;
   uint64_t uniSize = sizeof(Uniforms);
   if (scratch != nullptr) {
-    constexpr uint64_t kUniformOffsetAlignment = 256u;
+    constexpr uint64_t kUniformOffsetAlignment = GeodeTextureEncoder::kUniformOffsetAlignment;
     const UniformAllocation alloc =
         scratch->allocate(&u, sizeof(Uniforms), kUniformOffsetAlignment);
     uniBuf = alloc.buffer;

--- a/donner/svg/renderer/geode/GeodeTextureEncoder.h
+++ b/donner/svg/renderer/geode/GeodeTextureEncoder.h
@@ -57,6 +57,29 @@ public:
   static wgpu::Texture uploadRgba8Texture(GeodeDevice& device, const uint8_t* rgbaPixels,
                                           uint32_t width, uint32_t height);
 
+  /// Borrowed uniform-buffer range for one blit uniform upload.
+  struct UniformAllocation {
+    wgpu::Buffer buffer;
+    uint64_t offset = 0;
+    uint64_t size = 0;
+  };
+
+  /**
+   * Interface for callers that pool blit uniform uploads into a per-frame
+   * scratch arena instead of creating one uniform buffer per blit.
+   * `GeoEncoder` implements this over its per-encoder uniform arena, so
+   * consecutive image blits and layer composites share one growing buffer
+   * (the buffer itself is only created when the arena grows).
+   */
+  class UniformScratch {
+  public:
+    virtual ~UniformScratch() = default;
+
+    /// Copy `size` bytes of uniform data into the scratch arena and return
+    /// the borrowed (buffer, offset, size) range for the bind group.
+    virtual UniformAllocation allocate(const void* data, uint64_t size, uint64_t alignment) = 0;
+  };
+
   /// Filtering mode for `drawTexturedQuad`.
   enum class Filter : uint8_t {
     /// Bilinear filtering. Default for SVG `image-rendering: auto`.
@@ -133,16 +156,20 @@ public:
    *   - Provide an MVP matrix built the same way as `GeoEncoder::Impl::buildMvp`
    *     (target-pixel → clip space, composed with the model-view transform).
    *
-   * Allocates fresh GPU resources (uniform buffer + bind group) per call and
-   * retains them in `resourceArena` until the caller finishes the enclosing
-   * command encoder.
+   * Allocates a bind group per call (retained in `resourceArena` until the
+   * caller finishes the enclosing command encoder). The uniform upload
+   * either goes into `scratch` when provided (one buffer create on arena
+   * growth instead of one per blit) or into a fresh per-blit buffer on the
+   * legacy path.
    *
    * @param resourceArena Scoped owner for WebGPU handles created by the draw.
+   * @param scratch Optional pooled uniform scratch (see `UniformScratch`).
    */
   static void drawTexturedQuad(GeodeDevice& device, const GeodeImagePipeline& pipeline,
                                const wgpu::RenderPassEncoder& pass, const wgpu::Texture& texture,
                                const float mvp[16], uint32_t targetWidth, uint32_t targetHeight,
-                               const QuadParams& params, ScopedWgpuResourceArena& resourceArena);
+                               const QuadParams& params, ScopedWgpuResourceArena& resourceArena,
+                               UniformScratch* scratch = nullptr);
 };
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodeTextureEncoder.h
+++ b/donner/svg/renderer/geode/GeodeTextureEncoder.h
@@ -57,7 +57,17 @@ public:
   static wgpu::Texture uploadRgba8Texture(GeodeDevice& device, const uint8_t* rgbaPixels,
                                           uint32_t width, uint32_t height);
 
-  /// Borrowed uniform-buffer range for one blit uniform upload.
+  /// Uniform-buffer binding offset alignment shared by the blit path and
+  /// any UniformScratch implementation. 256 is the WebGPU default
+  /// minUniformBufferOffsetAlignment; implementations that ever query a
+  /// device limit instead must keep this constant in sync or blits fail
+  /// binding validation on devices with a larger limit.
+  static constexpr uint64_t kUniformOffsetAlignment = 256u;
+
+  /// Borrowed uniform-buffer range for one blit uniform upload. The
+  /// `buffer` field is a raw non-owning handle: the provider keeps it
+  /// alive (see UniformScratch's contract below); holders must not retain
+  /// the allocation beyond the current frame.
   struct UniformAllocation {
     wgpu::Buffer buffer;
     uint64_t offset = 0;
@@ -70,6 +80,15 @@ public:
    * `GeoEncoder` implements this over its per-encoder uniform arena, so
    * consecutive image blits and layer composites share one growing buffer
    * (the buffer itself is only created when the arena grows).
+   *
+   * Implementation contract (GeoEncoder's arena satisfies all four):
+   * - The returned buffer carries the Uniform buffer-usage flag.
+   * - The buffer outlives every command buffer recorded against it in the
+   *   current frame (retire-then-release, never destroy mid-frame).
+   * - The range `[offset, offset + size)` is never rewritten for the rest
+   *   of the frame once returned.
+   * - `offset` honors the requested alignment (at least
+   *   kUniformOffsetAlignment for blit uniforms).
    */
   class UniformScratch {
   public:

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -324,6 +324,45 @@ TEST_F(GeodePerfTest, GaussianBlur_UsesSingleFrameSubmission) {
 // testdata deps).
 // ---------------------------------------------------------------------------
 
+TEST_F(GeodePerfTest, MultiImageBlit_PoolsCompositeUniforms) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  // Three `drawImage` blits in one frame. Each blit previously created its
+  // own 160-byte uniform buffer; pooled blits should bump-allocate from the
+  // encoder's per-frame uniform scratch instead, so the only buffer create
+  // left is the scratch arena's first growth.
+  RendererGeode renderer(device);
+  RenderViewport viewport;
+  viewport.size = Vector2d(80.0, 32.0);
+  viewport.devicePixelRatio = 1.0;
+  renderer.beginFrame(viewport);
+
+  ImageResource image;
+  image.width = 2;
+  image.height = 2;
+  image.data = {255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 0, 255};
+
+  ImageParams params;
+  params.targetRect = Box2d({8.0, 8.0}, {24.0, 24.0});
+  params.opacity = 1.0;
+
+  renderer.drawImage(image, params);
+  params.targetRect = Box2d({32.0, 8.0}, {48.0, 24.0});
+  renderer.drawImage(image, params);
+  params.targetRect = Box2d({56.0, 8.0}, {72.0, 24.0});
+  renderer.drawImage(image, params);
+  renderer.endFrame();
+
+  const geode::GeodeCounters c = renderer.lastFrameTimings().counters;
+  RecordProperty("bufferCreates", std::to_string(c.bufferCreates));
+  printCounters(::testing::UnitTest::GetInstance()->current_test_info()->name(), c);
+
+  EXPECT_LE(c.bufferCreates, 2u)
+      << "Three image blits should pool their uniform uploads into the encoder scratch arena "
+         "instead of creating one uniform buffer per blit.";
+}
+
 TEST_F(GeodePerfTest, Lion_BaselineCeilings) {
   auto device = sharedDevice();
   ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -740,6 +740,39 @@ TEST_F(GeodePerfTest, GaussianBlur_NoDirtyPath_ZeroTextures) {
          "frame submits.";
 }
 
+/// One rect with a linear-gradient stroke. The stroked outline is cached
+/// by the stroke-outline cache, so an unchanged frame should re-upload zero
+/// geometry once gradient strokes are resident.
+constexpr std::string_view kGradientStrokeSvg = R"SVG(
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="red"/>
+      <stop offset="1" stop-color="blue"/>
+    </linearGradient>
+  </defs>
+  <rect x="20" y="20" width="60" height="60" fill="none"
+        stroke="url(#g)" stroke-width="6"/>
+</svg>
+)SVG";
+
+TEST_F(GeodePerfTest, GradientStroke_NoDirtyPath_ZeroWrites) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  const geode::GeodeCounters c = countersForSecondRender(kGradientStrokeSvg, device);
+  RecordProperty("bufferWrites", std::to_string(c.bufferWrites));
+  RecordProperty("bufferWriteBytes", std::to_string(c.bufferWriteBytes));
+  RecordProperty("bindgroupCreates", std::to_string(c.bindgroupCreates));
+  printCounters(::testing::UnitTest::GetInstance()->current_test_info()->name(), c);
+
+  EXPECT_EQ(c.pathEncodes, 0u) << "Stroke outline must come from the stroke-outline cache.";
+  EXPECT_EQ(c.bufferWriteBytes, 0u)
+      << "Resident gradient strokes must re-upload zero geometry on an unchanged frame.";
+  EXPECT_LE(c.bindgroupCreates, 1u)
+      << "The cached gradient-stroke bind group must be reused on an unchanged frame.";
+}
+
 TEST_F(GeodePerfTest, Lion_NoDirtyPath_ZeroTextures) {
   auto device = sharedDevice();
   ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -274,6 +274,50 @@ constexpr std::string_view kHugeRadiusMorphologySvg = R"SVG(
 </svg>
 )SVG";
 
+// ---------------------------------------------------------------------------
+// Fixture: image blits - drawImage uniform pooling.
+// ---------------------------------------------------------------------------
+
+TEST_F(GeodePerfTest, MultiImageBlit_PoolsCompositeUniforms) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  // Three `drawImage` blits in one frame. Each blit previously created its
+  // own 160-byte uniform buffer; pooled blits should bump-allocate from the
+  // encoder's per-frame uniform scratch instead, so the only buffer create
+  // left is the scratch arena's first growth.
+  RendererGeode renderer(device);
+  RenderViewport viewport;
+  viewport.size = Vector2d(80.0, 32.0);
+  viewport.devicePixelRatio = 1.0;
+  renderer.beginFrame(viewport);
+
+  ImageResource image;
+  image.width = 2;
+  image.height = 2;
+  image.data = {255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 0, 255};
+
+  ImageParams params;
+  params.targetRect = Box2d({8.0, 8.0}, {24.0, 24.0});
+  params.opacity = 1.0;
+
+  renderer.drawImage(image, params);
+  params.targetRect = Box2d({32.0, 8.0}, {48.0, 24.0});
+  renderer.drawImage(image, params);
+  params.targetRect = Box2d({56.0, 8.0}, {72.0, 24.0});
+  renderer.drawImage(image, params);
+  renderer.endFrame();
+
+  const geode::GeodeCounters c = renderer.lastFrameTimings().counters;
+  RecordProperty("bufferCreates", std::to_string(c.bufferCreates));
+  printCounters(::testing::UnitTest::GetInstance()->current_test_info()->name(), c);
+
+  EXPECT_LE(c.bufferCreates, 1u)
+      << "Three image blits should pool their uniform uploads into the encoder scratch arena "
+         "(one create for the arena's first growth) instead of creating one uniform buffer per "
+         "blit.";
+}
+
 TEST_F(GeodePerfTest, MorphologyHugeRadius_ChunksFilterCommandBuffers) {
   auto device = sharedDevice();
   ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
@@ -318,50 +362,12 @@ TEST_F(GeodePerfTest, GaussianBlur_UsesSingleFrameSubmission) {
          "shared frame submission plus the snapshot submission.";
 }
 
+
 // ---------------------------------------------------------------------------
-// Fixture: lion.svg - the workhorse SVG used across Donner's test suites.
-// Skipped gracefully if the file isn't bundled (e.g. unit test run without
+// Fixture: lion.svg - the workhorse SVG used across Donner test suites.
+// Skipped gracefully if the file is not bundled (e.g. unit test run without
 // testdata deps).
 // ---------------------------------------------------------------------------
-
-TEST_F(GeodePerfTest, MultiImageBlit_PoolsCompositeUniforms) {
-  auto device = sharedDevice();
-  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
-
-  // Three `drawImage` blits in one frame. Each blit previously created its
-  // own 160-byte uniform buffer; pooled blits should bump-allocate from the
-  // encoder's per-frame uniform scratch instead, so the only buffer create
-  // left is the scratch arena's first growth.
-  RendererGeode renderer(device);
-  RenderViewport viewport;
-  viewport.size = Vector2d(80.0, 32.0);
-  viewport.devicePixelRatio = 1.0;
-  renderer.beginFrame(viewport);
-
-  ImageResource image;
-  image.width = 2;
-  image.height = 2;
-  image.data = {255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 0, 255};
-
-  ImageParams params;
-  params.targetRect = Box2d({8.0, 8.0}, {24.0, 24.0});
-  params.opacity = 1.0;
-
-  renderer.drawImage(image, params);
-  params.targetRect = Box2d({32.0, 8.0}, {48.0, 24.0});
-  renderer.drawImage(image, params);
-  params.targetRect = Box2d({56.0, 8.0}, {72.0, 24.0});
-  renderer.drawImage(image, params);
-  renderer.endFrame();
-
-  const geode::GeodeCounters c = renderer.lastFrameTimings().counters;
-  RecordProperty("bufferCreates", std::to_string(c.bufferCreates));
-  printCounters(::testing::UnitTest::GetInstance()->current_test_info()->name(), c);
-
-  EXPECT_LE(c.bufferCreates, 2u)
-      << "Three image blits should pool their uniform uploads into the encoder scratch arena "
-         "instead of creating one uniform buffer per blit.";
-}
 
 TEST_F(GeodePerfTest, Lion_BaselineCeilings) {
   auto device = sharedDevice();

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -921,6 +921,55 @@ TEST_F(RendererGeodeTest, GradientStopEditInvalidatesResidentGradientDraw) {
       << "A gradient stop edit must invalidate the resident gradient draw's cached uniforms";
 }
 
+/// The stroke encode is rebuilt IN PLACE on a stroke-param change (same
+/// storage address, no component removal), so gradient-stroke residence
+/// invalidation rests on the explicit reset at the rebuild site. Pin it
+/// with pixels: a stroke-width edit with no geometry change must change
+/// the next frame, and an unchanged document must render identically
+/// through the steady-state resident path.
+TEST_F(RendererGeodeTest, StrokeWidthEditInvalidatesResidentGradientStroke) {
+  ParseWarningSink warningSink;
+  auto maybeDocument = parser::SVGParser::ParseSVG(
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+             <defs>
+               <linearGradient id="g" gradientUnits="userSpaceOnUse" x1="0" y1="0" x2="64"
+                                y2="0">
+                 <stop offset="0" stop-color="#00ff00"/>
+                 <stop offset="1" stop-color="#00ff00"/>
+               </linearGradient>
+             </defs>
+             <path id="p" d="M 8 32 L 56 32" fill="none" stroke="url(#g)" stroke-width="4"/>
+           </svg>)svg",
+      warningSink);
+  ASSERT_FALSE(maybeDocument.hasError()) << maybeDocument.error();
+  SVGDocument document = std::move(maybeDocument).result();
+
+  RendererGeode renderer = createRenderer();
+  renderer.draw(document);
+  const RendererBitmap first = renderer.takeSnapshot();
+  ASSERT_FALSE(first.empty());
+  // 12px above the line center: outside a 4px-wide stroke, inside a 28px one.
+  EXPECT_THAT(pixelAt(first, 32, 20), IsTransparent());
+  EXPECT_THAT(pixelAt(first, 32, 32), RgbaEq(0, 255, 0, 255));
+
+  // Unchanged second frame rides the resident path and must be identical.
+  renderer.draw(document);
+  const RendererBitmap second = renderer.takeSnapshot();
+  ASSERT_FALSE(second.empty());
+  EXPECT_THAT(pixelAt(second, 32, 20), IsTransparent());
+  EXPECT_THAT(pixelAt(second, 32, 32), RgbaEq(0, 255, 0, 255));
+
+  auto path = document.querySelector("#p");
+  ASSERT_TRUE(path.has_value());
+  path->setAttribute("stroke-width", "28");
+
+  renderer.draw(document);
+  const RendererBitmap third = renderer.takeSnapshot();
+  ASSERT_FALSE(third.empty());
+  EXPECT_THAT(pixelAt(third, 32, 20), RgbaEq(0, 255, 0, 255))
+      << "A stroke-width edit must invalidate the resident gradient-stroke draw";
+}
+
 TEST_F(RendererGeodeTest, EmbeddedDeviceDrawPathExportsTextureSnapshot) {
   std::shared_ptr<geode::GeodeDevice> host = sharedDevice();
   ASSERT_TRUE(host != nullptr);

--- a/tools/gpu_inventory/manifests/gpu_operations.json
+++ b/tools/gpu_inventory/manifests/gpu_operations.json
@@ -939,6 +939,7 @@
     },
     "donner/svg/renderer/geode/GeodeTextureEncoder.h": {
       "wgpuCppTokens": [
+        "Buffer",
         "Device",
         "Queue",
         "RenderPassEncoder",


### PR DESCRIPTION
Image blits and layer composites pool their uniform uploads into the encoder's per-frame scratch arena instead of creating one uniform buffer per blit. A UniformScratch interface lets callers supply their own allocation; GeoEncoder implements it over its uniform arena, so three consecutive drawImage calls create one buffer (the arena's first growth) instead of three, with identical pixels.

Verification: the new MultiImageBlit_PoolsCompositeUniforms perf test fails before the change (3 buffer creates) and passes after (1), and the perf suite, goldens, resvg corpus, and renderer tests are green.

Post-review hardening: the blit path's 256-byte uniform offset alignment is now one shared constant on GeodeTextureEncoder instead of an independent re-declaration, the UniformScratch interface documents the four-part implementation contract its raw non-owning buffer handle relies on (usage flags, frame lifetime, no rewrite, alignment), and the pooling test is tightened to the measured single arena growth under its own fixture banner.
