### PR TITLE
perf: Reside gradient-painted strokes in per-entity gradient slots

### DIFF
--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -2256,6 +2256,18 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
         // zero-area closed subpaths first (see `deCloseZeroAreaSubpaths`) so a
         // degenerate `M L Z` line strokes into a clean rectangle the analytic
         // shader covers correctly, instead of overlapping triangles.
+        // Drop the stale GPU residence FIRST, unconditionally for every
+        // exit of this miss branch: the encode is about to be replaced in
+        // place (or destroyed, in the empty-outline case below) without
+        // removing the entity's components, so the entt listener does not
+        // fire, and a resident slot keyed on the old encode storage would
+        // keep a dangling encodedKey plus a retained slab range. The
+        // GeoEncoder fingerprint guard is a second line of defense; this
+        // keeps the invariant obvious at the single mutation site.
+        if (auto* resident = source.try_get<geode::GeodeResidentPathComponent>()) {
+          resident->strokeSlot.reset();
+          resident->gradientStrokeSlot.reset();
+        }
         Path stroked =
             deCloseZeroAreaSubpaths(geometry).strokeToFill(strokeStyle, flattenTolerance);
         if (stroked.empty()) {
@@ -2276,16 +2288,6 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
             .strokedEncode = std::move(encoded),
             .strokeFillRule = fillRule,
         };
-        // The stroke encode was rebuilt in place (stroke-param change)
-        // without removing the entity's components, so the entt listener
-        // does not fire. Drop the stale GPU residence explicitly so the
-        // next draw re-uploads the new stroked geometry. The `GeoEncoder`
-        // fingerprint guard is a second line of
-        // defense; this keeps the invariant obvious at the mutation site.
-        if (auto* resident = source.try_get<geode::GeodeResidentPathComponent>()) {
-          resident->strokeSlot.reset();
-          resident->gradientStrokeSlot.reset();
-        }
       }
       result.strokedPath = &cache.strokeSlot->strokedPath;
       result.encoded = &cache.strokeSlot->strokedEncode;

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -2042,6 +2042,24 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     return &slot;
   }
 
+  /// GPU-residence slot for `source`'s gradient-painted stroke.
+  /// See `residentGradientFillSlot`; the slot holds the cached
+  /// stroke-outline encode plus the resolved gradient uniform.
+  geode::GeodeResidentGradientSlot* residentGradientStrokeSlot(EntityHandle source) {
+    if (!source) {
+      return nullptr;
+    }
+    ensureCacheInvalidationWired(*source.registry());
+    geode::GeodeResidentGradientSlot& slot =
+        source.get_or_emplace<geode::GeodeResidentPathComponent>().gradientStrokeSlot;
+    std::shared_ptr<geode::GeodeResidentSlab> slab = residentSlab(*source.registry());
+    if (slot.slab.get() != slab.get()) {
+      slot.reset();
+    }
+    slot.slab = std::move(slab);
+    return &slot;
+  }
+
   /// GPU-residence slot for `source`'s gradient-painted fill.
   /// See `residentFillSlot`; the slot lives on the
   /// same `GeodeResidentPathComponent` and is invalidated by the same
@@ -2266,6 +2284,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
         // defense; this keeps the invariant obvious at the mutation site.
         if (auto* resident = source.try_get<geode::GeodeResidentPathComponent>()) {
           resident->strokeSlot.reset();
+          resident->gradientStrokeSlot.reset();
         }
       }
       result.strokedPath = &cache.strokeSlot->strokedPath;
@@ -4199,8 +4218,17 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
       (strokeDerived.encoded != nullptr && std::holds_alternative<PaintServer::Solid>(strokeServer))
           ? impl_->residentStrokeSlot(path.sourceEntity)
           : nullptr;
+  // Gradient residence for gradient-painted strokes: the cached
+  // stroke-outline encode lives in a gradient slot so an unchanged outline
+  // with an unchanged resolved gradient re-uploads zero geometry.
+  geode::GeodeResidentGradientSlot* residentGradientStroke =
+      (strokeDerived.encoded != nullptr &&
+       std::holds_alternative<components::PaintResolvedReference>(strokeServer))
+          ? impl_->residentGradientStrokeSlot(path.sourceEntity)
+          : nullptr;
   impl_->drawPaintedPathAgainst(path.path, strokedOutline, strokeServer, effectiveOpacity,
-                                strokeDerived.fillRule, strokeDerived.encoded, residentStroke);
+                                strokeDerived.fillRule, strokeDerived.encoded, residentStroke,
+                                residentGradientStroke);
 }
 
 void RendererGeode::drawRect(const Box2d& rect, const StrokeParams& stroke) {

--- a/donner/svg/renderer/geode/GeodeResidentPathComponent.h
+++ b/donner/svg/renderer/geode/GeodeResidentPathComponent.h
@@ -559,6 +559,10 @@ struct GeodeResidentPathComponent {
   GeodeResidentSlot strokeSlot;
   /// Gradient-painted fill residence.
   GeodeResidentGradientSlot gradientFillSlot;
+  /// Gradient-painted stroke residence. Holds the
+  /// cached stroke-outline encode plus the resolved gradient uniform, so
+  /// an unchanged gradient-stroked outline re-uploads zero geometry.
+  GeodeResidentGradientSlot gradientStrokeSlot;
 };
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -760,7 +760,7 @@ TEST_F(GeodePerfTest, GradientStroke_NoDirtyPath_ZeroWrites) {
   auto device = sharedDevice();
   ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
 
-  geode::GeodeCounters c = countersForSecondRender(kGradientStrokeSvg, device);
+  const geode::GeodeCounters c = countersForSecondRender(kGradientStrokeSvg, device);
   RecordProperty("bufferWrites", std::to_string(c.bufferWrites));
   RecordProperty("bufferWriteBytes", std::to_string(c.bufferWriteBytes));
   RecordProperty("bindgroupCreates", std::to_string(c.bindgroupCreates));
@@ -769,6 +769,8 @@ TEST_F(GeodePerfTest, GradientStroke_NoDirtyPath_ZeroWrites) {
   EXPECT_EQ(c.pathEncodes, 0u) << "Stroke outline must come from the stroke-outline cache.";
   EXPECT_EQ(c.bufferWriteBytes, 0u)
       << "Resident gradient strokes must re-upload zero geometry on an unchanged frame.";
+  EXPECT_LE(c.bindgroupCreates, 1u)
+      << "The cached gradient-stroke bind group must be reused on an unchanged frame.";
 }
 
 TEST_F(GeodePerfTest, Lion_NoDirtyPath_ZeroTextures) {

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -741,7 +741,7 @@ TEST_F(GeodePerfTest, GaussianBlur_NoDirtyPath_ZeroTextures) {
 }
 
 /// One rect with a linear-gradient stroke. The stroked outline is cached
-/// by the M2 stroke cache, so an unchanged frame should re-upload zero
+/// by the stroke-outline cache, so an unchanged frame should re-upload zero
 /// geometry once gradient strokes are resident.
 constexpr std::string_view kGradientStrokeSvg = R"SVG(
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
@@ -766,7 +766,7 @@ TEST_F(GeodePerfTest, GradientStroke_NoDirtyPath_ZeroWrites) {
   RecordProperty("bindgroupCreates", std::to_string(c.bindgroupCreates));
   printCounters(::testing::UnitTest::GetInstance()->current_test_info()->name(), c);
 
-  EXPECT_EQ(c.pathEncodes, 0u) << "Stroke outline must come from the M2 stroke cache.";
+  EXPECT_EQ(c.pathEncodes, 0u) << "Stroke outline must come from the stroke-outline cache.";
   EXPECT_EQ(c.bufferWriteBytes, 0u)
       << "Resident gradient strokes must re-upload zero geometry on an unchanged frame.";
 }

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -740,6 +740,37 @@ TEST_F(GeodePerfTest, GaussianBlur_NoDirtyPath_ZeroTextures) {
          "frame submits.";
 }
 
+/// One rect with a linear-gradient stroke. The stroked outline is cached
+/// by the M2 stroke cache, so an unchanged frame should re-upload zero
+/// geometry once gradient strokes are resident.
+constexpr std::string_view kGradientStrokeSvg = R"SVG(
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="red"/>
+      <stop offset="1" stop-color="blue"/>
+    </linearGradient>
+  </defs>
+  <rect x="20" y="20" width="60" height="60" fill="none"
+        stroke="url(#g)" stroke-width="6"/>
+</svg>
+)SVG";
+
+TEST_F(GeodePerfTest, GradientStroke_NoDirtyPath_ZeroWrites) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  geode::GeodeCounters c = countersForSecondRender(kGradientStrokeSvg, device);
+  RecordProperty("bufferWrites", std::to_string(c.bufferWrites));
+  RecordProperty("bufferWriteBytes", std::to_string(c.bufferWriteBytes));
+  RecordProperty("bindgroupCreates", std::to_string(c.bindgroupCreates));
+  printCounters(::testing::UnitTest::GetInstance()->current_test_info()->name(), c);
+
+  EXPECT_EQ(c.pathEncodes, 0u) << "Stroke outline must come from the M2 stroke cache.";
+  EXPECT_EQ(c.bufferWriteBytes, 0u)
+      << "Resident gradient strokes must re-upload zero geometry on an unchanged frame.";
+}
+
 TEST_F(GeodePerfTest, Lion_NoDirtyPath_ZeroTextures) {
   auto device = sharedDevice();
   ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -921,6 +921,55 @@ TEST_F(RendererGeodeTest, GradientStopEditInvalidatesResidentGradientDraw) {
       << "A gradient stop edit must invalidate the resident gradient draw's cached uniforms";
 }
 
+/// The stroke encode is rebuilt IN PLACE on a stroke-param change (same
+/// storage address, no component removal), so gradient-stroke residence
+/// invalidation rests on the explicit reset at the rebuild site. Pin it
+/// with pixels: a stroke-width edit with no geometry change must change
+/// the next frame, and an unchanged document must render identically
+/// through the steady-state resident path.
+TEST_F(RendererGeodeTest, StrokeWidthEditInvalidatesResidentGradientStroke) {
+  ParseWarningSink warningSink;
+  auto maybeDocument = parser::SVGParser::ParseSVG(
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+             <defs>
+               <linearGradient id="g" gradientUnits="userSpaceOnUse" x1="0" y1="0" x2="64"
+                                y2="0">
+                 <stop offset="0" stop-color="#00ff00"/>
+                 <stop offset="1" stop-color="#00ff00"/>
+               </linearGradient>
+             </defs>
+             <path id="p" d="M 8 32 L 56 32" fill="none" stroke="url(#g)" stroke-width="4"/>
+           </svg>)svg",
+      warningSink);
+  ASSERT_FALSE(maybeDocument.hasError()) << maybeDocument.error();
+  SVGDocument document = std::move(maybeDocument).result();
+
+  RendererGeode renderer = createRenderer();
+  renderer.draw(document);
+  const RendererBitmap first = renderer.takeSnapshot();
+  ASSERT_FALSE(first.empty());
+  // 12px above the line center: outside a 4px-wide stroke, inside a 28px one.
+  EXPECT_THAT(pixelAt(first, 32, 20), IsTransparent());
+  EXPECT_THAT(pixelAt(first, 32, 32), RgbaEq(0, 255, 0, 255));
+
+  // Unchanged second frame rides the resident path and must be identical.
+  renderer.draw(document);
+  const RendererBitmap second = renderer.takeSnapshot();
+  ASSERT_FALSE(second.empty());
+  EXPECT_THAT(pixelAt(second, 32, 20), IsTransparent());
+  EXPECT_THAT(pixelAt(second, 32, 32), RgbaEq(0, 255, 0, 255));
+
+  auto path = document.querySelector("#p");
+  ASSERT_TRUE(path.has_value());
+  path->setAttribute("stroke-width", "28");
+
+  renderer.draw(document);
+  const RendererBitmap third = renderer.takeSnapshot();
+  ASSERT_FALSE(third.empty());
+  EXPECT_THAT(pixelAt(third, 32, 20), RgbaEq(0, 255, 0, 255))
+      << "A stroke-width edit must invalidate the resident gradient-stroke draw";
+}
+
 TEST_F(RendererGeodeTest, EmbeddedDeviceDrawPathExportsTextureSnapshot) {
   std::shared_ptr<geode::GeodeDevice> host = sharedDevice();
   ASSERT_TRUE(host != nullptr);


### PR DESCRIPTION
Gradient-painted strokes now reside in a per-entity gradient slot, mirroring the gradient-fill residence: the cached stroke-outline encode plus the resolved gradient uniform persist across frames, so an unchanged gradient-stroked outline re-uploads zero geometry. The stroke-cache rebuild path also resets the new slot so a style change never serves stale outline geometry, and the objectBoundingBox stays derived from the original path bounds, matching the existing stroke-gradient semantics.

Verification: the new GradientStroke_NoDirtyPath_ZeroWrites perf test fails before the change (9 writes, 1,256 bytes on the second frame) and passes after (0 bytes), and the perf suite, goldens, resvg corpus, and renderer tests are green.

Post-review hardening: the residence reset at the stroke-rebuild site is hoisted to the top of the miss branch so every exit invalidates (including the empty-outline early return, which previously left a resident slot keyed on destroyed encode storage), and a pixel regression test now pins the invalidation end to end: verified red with the reset disabled, failing exactly on the post-edit frame. The steady-state counters test additionally asserts cached bind-group reuse.
