### PR TITLE
perf: Borrow the computed path in draw calls instead of copying per frame

### DIFF
--- a/.claude/skills/donner-rendering-pipeline/SKILL.md
+++ b/.claude/skills/donner-rendering-pipeline/SKILL.md
@@ -154,6 +154,12 @@ Full doc comment: `donner/svg/renderer/RendererInterface.h` (~line 235). Verifie
 - `PathShape.sourceEntity` is the per-entity path-cache key (set by the driver in
   `RendererDriver::traverseRange`; Geode keys `GeodePathCacheComponent` off it). Leaving it null
   is legal but disables caching.
+- `PathShape.path` is a BORROWED `const Path*`, never an owner. It must point at storage that
+  outlives the `drawPath` call; the driver points it straight at `ComputedPathComponent::spline`
+  so a steady frame allocates nothing per drawable. Copying it back into a `Path` member is a
+  regression, not a simplification. Anything that keeps geometry past the call owns its own copy
+  instead: `RenderSnapshot`'s `DrawPathCommand`, and `ResolvedClip::clipPaths`, which use the
+  separate owning `ClipPathShape`.
 - `RenderingInstanceComponent::worldFromEntityTransform` maps entity-local to canvas coordinates;
   the driver composes it with its surface transform. Every `Transform2d` you add must be named
   `destFromSource` (project-wide hard rule — direction encoded in the name, not a comment).

--- a/.claude/skills/donner-rendering-pipeline/SKILL.md
+++ b/.claude/skills/donner-rendering-pipeline/SKILL.md
@@ -137,7 +137,9 @@ apply as-is.
 
 ## 4. RendererInterface contract cheat sheet
 
-Full doc comment: `donner/svg/renderer/RendererInterface.h` (~line 235). Verified rules:
+Full doc comment: the `class RendererInterface` declaration in
+`donner/svg/renderer/RendererInterface.h` (~line 384; grep the class name rather than trusting
+the number). Verified rules:
 
 - Frame lifecycle: `draw()` → `beginFrame(viewport)` → drawing calls → `endFrame()`.
 - `pushTransform`/`popTransform`, `pushClip`/`popClip`, `pushIsolatedLayer`/`popIsolatedLayer`
@@ -160,6 +162,16 @@ Full doc comment: `donner/svg/renderer/RendererInterface.h` (~line 235). Verifie
   regression, not a simplification. Anything that keeps geometry past the call owns its own copy
   instead: `RenderSnapshot`'s `DrawPathCommand`, and `ResolvedClip::clipPaths`, which use the
   separate owning `ClipPathShape`.
+- The real precondition on that borrow is **no `ComputedPathComponent` is ERASED between the
+  borrow and its last use**, which is stronger than "the pointer is not dangling". Component
+  storage is paged, so emplacing components never relocates existing ones, but erase is
+  swap-and-pop: the storage's last element moves into the freed slot, and every outstanding
+  pointer into that slot silently starts naming a DIFFERENT entity's geometry. The frame then
+  renders the wrong shape with no crash, and neither ASAN nor a sanitizer lane will catch it.
+  Today every removal site (DOM attribute mutation on shape elements, `ShapeSystem`
+  recomputation, `RenderingContext` animation-override application) runs outside draw
+  traversal. If you ever add an erase inside traversal, or retain a borrow across a phase
+  boundary, that invariant is what you broke.
 - `RenderingInstanceComponent::worldFromEntityTransform` maps entity-local to canvas coordinates;
   the driver composes it with its surface transform. Every `Transform2d` you add must be named
   `destFromSource` (project-wide hard rule — direction encoded in the name, not a comment).

--- a/docs/design_docs/0023-editor_sandbox.md
+++ b/docs/design_docs/0023-editor_sandbox.md
@@ -361,6 +361,12 @@ Three properties of the existing interface make this work:
    deep-copy constructor explicitly
    ([RendererInterface.h:109-127](../../donner/svg/renderer/RendererInterface.h))
    because the driver already needs it. That deep copy is the serializer.
+
+   **No longer accurate for `PathShape`.** `PathShape::path` is now a borrowed
+   `const Path*` into the source document, not an owned `Path`, so a future
+   marshaller cannot copy the struct: it must materialize an owned `Path` at
+   decode time and point the view at that storage. Clip paths kept value
+   semantics under the separate owning `ClipPathShape` type.
 3. **Driver is already separated from backend.** `RendererDriver` consumes
    an `SVGDocument` and emits calls into a `RendererInterface&`. It doesn't
    know what backend is on the other side. Swapping a real backend for a

--- a/donner/editor/OverlayRenderer.cc
+++ b/donner/editor/OverlayRenderer.cc
@@ -939,11 +939,7 @@ void OverlayRenderer::drawChromeFromSnapshot(svg::RendererInterface& renderer,
     paint.strokeParams.strokeWidth = preview.strokeWidthDoc;
     renderer.setPaint(paint);
     renderer.setTransform(snapshot.canvasFromDoc);
-    svg::PathShape shape;
-    shape.path = preview.pathDoc;
-    shape.fillRule = preview.fillRule;
-    shape.parentFromEntity = Transform2d();
-    renderer.drawPath(shape, paint.strokeParams);
+    renderer.drawPath(svg::PathShape{&preview.pathDoc, preview.fillRule}, paint.strokeParams);
   }
 
   if (!snapshot.textSelectionQuadsDoc.empty()) {
@@ -951,10 +947,8 @@ void OverlayRenderer::drawChromeFromSnapshot(svg::RendererInterface& renderer,
     renderer.setPaint(selectionFill);
     renderer.setTransform(snapshot.canvasFromDoc);
     for (const std::array<Vector2d, 4>& corners : snapshot.textSelectionQuadsDoc) {
-      svg::PathShape shape;
-      shape.path = PathForCorners(corners);
-      shape.parentFromEntity = Transform2d();
-      renderer.drawPath(shape, selectionFill.strokeParams);
+      const Path quad = PathForCorners(corners);
+      renderer.drawPath(svg::PathShape{&quad}, selectionFill.strokeParams);
     }
   }
 
@@ -971,10 +965,8 @@ void OverlayRenderer::drawChromeFromSnapshot(svg::RendererInterface& renderer,
       PathBuilder builder;
       builder.moveTo(baseline.startDoc);
       builder.lineTo(baseline.endDoc);
-      svg::PathShape shape;
-      shape.path = builder.build();
-      shape.parentFromEntity = Transform2d();
-      renderer.drawPath(shape, baselinePaint.strokeParams);
+      const Path baselinePath = builder.build();
+      renderer.drawPath(svg::PathShape{&baselinePath}, baselinePaint.strokeParams);
     }
   }
 
@@ -984,10 +976,7 @@ void OverlayRenderer::drawChromeFromSnapshot(svg::RendererInterface& renderer,
     renderer.setPaint(hoverShapePaint);
     renderer.setTransform(snapshot.canvasFromDoc);
     for (const auto& item : snapshot.hoverPaths) {
-      svg::PathShape shape;
-      shape.path = item.pathDoc;
-      shape.parentFromEntity = Transform2d();
-      renderer.drawPath(shape, hoverShapePaint.strokeParams);
+      renderer.drawPath(svg::PathShape{&item.pathDoc}, hoverShapePaint.strokeParams);
     }
   } else if (!snapshot.hoverAabbsDoc.empty()) {
     const svg::PaintParams hoverBoundsPaint =
@@ -1012,10 +1001,7 @@ void OverlayRenderer::drawChromeFromSnapshot(svg::RendererInterface& renderer,
       const svg::PaintParams& paint =
           item.displayNone ? displayNoneSelectionStrokePaint : selectionStrokePaint;
       renderer.setPaint(paint);
-      svg::PathShape shape;
-      shape.path = item.pathDoc;
-      shape.parentFromEntity = Transform2d();
-      renderer.drawPath(shape, paint.strokeParams);
+      renderer.drawPath(svg::PathShape{&item.pathDoc}, paint.strokeParams);
     }
   }
 
@@ -1027,10 +1013,7 @@ void OverlayRenderer::drawChromeFromSnapshot(svg::RendererInterface& renderer,
         MakePathControlLinePaint(drawScale.selectionStrokeWidthWorld);
     renderer.setPaint(previewPaint);
     renderer.setTransform(snapshot.canvasFromDoc);
-    svg::PathShape shape;
-    shape.path = *snapshot.penPreviewSegmentDoc;
-    shape.parentFromEntity = Transform2d();
-    renderer.drawPath(shape, previewPaint.strokeParams);
+    renderer.drawPath(svg::PathShape{&*snapshot.penPreviewSegmentDoc}, previewPaint.strokeParams);
   }
   if (snapshot.penCloseAffordanceDoc.has_value()) {
     const svg::PaintParams affordancePaint = MakeHandlePaint(drawScale.selectionStrokeWidthWorld);
@@ -1063,10 +1046,8 @@ void OverlayRenderer::drawChromeFromSnapshot(svg::RendererInterface& renderer,
       PathBuilder builder;
       builder.moveTo(preview.baselineStartDoc);
       builder.lineTo(preview.baselineEndDoc);
-      svg::PathShape shape;
-      shape.path = builder.build();
-      shape.parentFromEntity = Transform2d();
-      renderer.drawPath(shape, baselinePaint.strokeParams);
+      const Path baselinePath = builder.build();
+      renderer.drawPath(svg::PathShape{&baselinePath}, baselinePaint.strokeParams);
     }
 
     const svg::PaintParams ibeamPaint =
@@ -1083,10 +1064,8 @@ void OverlayRenderer::drawChromeFromSnapshot(svg::RendererInterface& renderer,
       builder.lineTo(preview.ibeamTopDoc + Vector2d(serifHalf, 0.0));
       builder.moveTo(preview.ibeamBottomDoc - Vector2d(serifHalf, 0.0));
       builder.lineTo(preview.ibeamBottomDoc + Vector2d(serifHalf, 0.0));
-      svg::PathShape shape;
-      shape.path = builder.build();
-      shape.parentFromEntity = Transform2d();
-      renderer.drawPath(shape, ibeamPaint.strokeParams);
+      const Path ibeamPath = builder.build();
+      renderer.drawPath(svg::PathShape{&ibeamPath}, ibeamPaint.strokeParams);
     }
   }
 
@@ -1102,10 +1081,8 @@ void OverlayRenderer::drawChromeFromSnapshot(svg::RendererInterface& renderer,
     const svg::PaintParams framePaint =
         MakeSelectionStrokePaint(drawScale.selectionStrokeWidthWorld, frameOpacity);
     renderer.setPaint(framePaint);
-    svg::PathShape frameShape;
-    frameShape.path = PathForCorners(*snapshot.textFrameCornersDoc);
-    frameShape.parentFromEntity = Transform2d();
-    renderer.drawPath(frameShape, framePaint.strokeParams);
+    const Path framePath = PathForCorners(*snapshot.textFrameCornersDoc);
+    renderer.drawPath(svg::PathShape{&framePath}, framePaint.strokeParams);
 
     // Use the select tool's handle-box helper directly. Deriving this size
     // from stroke width double-counted device scale on high-density displays.
@@ -1125,10 +1102,8 @@ void OverlayRenderer::drawChromeFromSnapshot(svg::RendererInterface& renderer,
     PathBuilder caretBuilder;
     caretBuilder.moveTo(snapshot.textCaretDoc->topDoc);
     caretBuilder.lineTo(snapshot.textCaretDoc->bottomDoc);
-    svg::PathShape caretShape;
-    caretShape.path = caretBuilder.build();
-    caretShape.parentFromEntity = Transform2d();
-    renderer.drawPath(caretShape, caretPaint.strokeParams);
+    const Path caretPath = caretBuilder.build();
+    renderer.drawPath(svg::PathShape{&caretPath}, caretPaint.strokeParams);
   }
 
   if (!snapshot.pathControlLinesDoc.empty()) {
@@ -1140,10 +1115,8 @@ void OverlayRenderer::drawChromeFromSnapshot(svg::RendererInterface& renderer,
       PathBuilder builder;
       builder.moveTo(line.anchorDoc);
       builder.lineTo(line.controlDoc);
-      svg::PathShape shape;
-      shape.path = builder.build();
-      shape.parentFromEntity = Transform2d();
-      renderer.drawPath(shape, pathControlLinePaint.strokeParams);
+      const Path controlLinePath = builder.build();
+      renderer.drawPath(svg::PathShape{&controlLinePath}, pathControlLinePaint.strokeParams);
     }
   }
 
@@ -1177,10 +1150,8 @@ void OverlayRenderer::drawChromeFromSnapshot(svg::RendererInterface& renderer,
   if (snapshot.orientedBoundsDoc.has_value()) {
     renderer.setPaint(selectionStrokePaint);
     renderer.setTransform(snapshot.canvasFromDoc);
-    svg::PathShape shape;
-    shape.path = PathForCorners(snapshot.orientedBoundsDoc->cornersDoc);
-    shape.parentFromEntity = Transform2d();
-    renderer.drawPath(shape, selectionStrokePaint.strokeParams);
+    const Path boundsPath = PathForCorners(snapshot.orientedBoundsDoc->cornersDoc);
+    renderer.drawPath(svg::PathShape{&boundsPath}, selectionStrokePaint.strokeParams);
   } else if (!snapshot.aabbsDoc.empty()) {
     renderer.setPaint(selectionStrokePaint);
     renderer.setTransform(snapshot.canvasFromDoc);
@@ -1231,10 +1202,8 @@ void OverlayRenderer::drawChromeFromSnapshot(svg::RendererInterface& renderer,
         MakeLockedFlashStrokePaint(lockedFlashStrokeWidthWorld, snapshot.lockedFlash->intensity);
     renderer.setPaint(lockedFlashPaint);
     renderer.setTransform(snapshot.canvasFromDoc);
-    svg::PathShape shape;
-    shape.path = snapshot.lockedFlash->pathDoc;
-    shape.parentFromEntity = Transform2d();
-    renderer.drawPath(shape, lockedFlashPaint.strokeParams);
+    renderer.drawPath(svg::PathShape{&snapshot.lockedFlash->pathDoc},
+                      lockedFlashPaint.strokeParams);
   }
 }
 

--- a/donner/editor/wasm/tests/browser-presentation-regression.spec.ts
+++ b/donner/editor/wasm/tests/browser-presentation-regression.spec.ts
@@ -470,25 +470,49 @@ async function openBasicShapes(page: Page): Promise<{
   // the sample picker on screen. On a loaded runner that gap spans several
   // captures. Wait for the pixels every caller is about to measure: the Basic
   // Shapes blue rounded rectangle inside the render pane.
-  await expect
-    .poll(
-      async () => {
-        const shot = await page.screenshot({ clip: documentClip });
-        const bounds = readEditorPixelBoundsFromPng(shot, "basic-blue", documentClip, {
-          minX: 0,
-          minY: 0,
-          maxX: documentClip.width,
-          maxY: documentClip.height,
-        });
-        return bounds === null ? 0 : bounds.pixels;
-      },
-      {
-        message: "expected the presented render pane to show the Basic Shapes blue rectangle",
-        timeout: scaledMs(5_000),
-        intervals: [16, 25, 50, 100],
-      },
-    )
-    .toBeGreaterThan(0);
+  // Last pixel count the probe measured, reported below on both paths.
+  let lastBluePixels = -1;
+  try {
+    await expect
+      .poll(
+        async () => {
+          const shot = await page.screenshot({ clip: documentClip });
+          const bounds = readEditorPixelBoundsFromPng(shot, "basic-blue", documentClip, {
+            minX: 0,
+            minY: 0,
+            maxX: documentClip.width,
+            maxY: documentClip.height,
+          });
+          lastBluePixels = bounds === null ? 0 : bounds.pixels;
+          return lastBluePixels;
+        },
+        {
+          message: "expected the presented render pane to show the Basic Shapes blue rectangle",
+          timeout: scaledMs(5_000),
+          intervals: [16, 25, 50, 100],
+        },
+      )
+      .toBeGreaterThan(0);
+  } finally {
+    // "No blue" covers three unrelated faults: the worker never produced a
+    // result, a result arrived that no app frame carried, or a frame was
+    // presented whose pixels this probe window missed. Publish the app's own
+    // counters so the next failure names which one happened instead of only
+    // reporting that blue was absent. The read is best-effort: when the whole
+    // test times out the page is already being torn down, and a rejection
+    // here must not replace the real failure.
+    const presentationState = await page
+      .evaluate(() => ({
+        worker: window.__donnerWorkerStats,
+        frames: window.__donnerMainLoopRenderedFrames || 0,
+        workerBusy: window.__donnerInteractionStats?.workerBusy,
+        activeSample: window.__donnerActiveSampleStats,
+      }))
+      .catch((error: unknown) => ({ unavailable: String(error) }));
+    console.log(
+      `open-basic-shapes bluePixels=${lastBluePixels} state=${JSON.stringify(presentationState)}`,
+    );
+  }
 
   return { canvasBounds, documentClip };
 }

--- a/donner/editor/wasm/tests/smoke.spec.ts
+++ b/donner/editor/wasm/tests/smoke.spec.ts
@@ -881,6 +881,18 @@ for (
       presentedMs?: number;
     } = {};
     let completedWorkerStats: Window["__donnerWorkerStats"] | undefined;
+    // Last observation the poll made, reported on both the passing and the
+    // failing path. Three different faults share this wait's failure message -
+    // the sample never activated, the worker never returned a result, or a
+    // result landed that no app frame carried - and only the raw observation
+    // separates them. `workerBusy` is the one that says whether a render is
+    // still in flight (a stalled renderer) or was never started.
+    let lastPresentationState: {
+      activeSample: Window["__donnerActiveSampleStats"];
+      frames: number;
+      worker: Window["__donnerWorkerStats"];
+      workerBusy: boolean | undefined;
+    } | undefined;
     // Presentation is now one canvas frame: the sample is on screen once the
     // document render lands AND the app thread has drawn a frame carrying it.
     // `presentedMs` is read on the page clock at that observation.
@@ -889,7 +901,9 @@ for (
         activeSample: window.__donnerActiveSampleStats,
         frames: window.__donnerMainLoopRenderedFrames || 0,
         worker: window.__donnerWorkerStats,
+        workerBusy: window.__donnerInteractionStats?.workerBusy,
       }));
+      lastPresentationState = state;
       if (state.activeSample?.sampleId === sample.id) {
         phaseTimings.activatedMs = state.activeSample.activatedAtMs - clickStartedAt;
       }
@@ -929,7 +943,7 @@ for (
       console.log(
         `carousel-presentation sample=${sample.id} timings=${JSON.stringify(phaseTimings)} worker=${
           JSON.stringify(completedWorkerStats)
-        }`,
+        } last=${JSON.stringify(lastPresentationState)}`,
       );
     }
     expect(phaseTimings.presentedMs).toBeDefined();

--- a/donner/svg/renderer/RenderSnapshot.cc
+++ b/donner/svg/renderer/RenderSnapshot.cc
@@ -80,8 +80,12 @@ struct SetPaintCommand {
   PaintParams paint;
 };
 
+/// Recorded `drawPath`. A snapshot outlives the document it was captured from, so unlike the
+/// borrowed `PathShape` handed to the renderer this owns its geometry; replay hands a
+/// `PathShape` pointing back at that owned copy.
 struct DrawPathCommand {
-  PathShape path;
+  Path path;
+  FillRule fillRule = FillRule::NonZero;
   StrokeParams stroke;
 };
 
@@ -168,9 +172,6 @@ public:
   }
 
   ResolvedClip mapClip(ResolvedClip clip) {
-    for (PathShape& path : clip.clipPaths) {
-      path.sourceEntity = EntityHandle();
-    }
     if (clip.mask.has_value()) {
       clip.mask = mapMask(*clip.mask);
     }
@@ -272,9 +273,8 @@ std::size_t CountReferenceToRegistry(const components::ResolvedMask& mask,
 
 std::size_t CountReferenceToRegistry(const ResolvedClip& clip, const Registry& registry) {
   std::size_t count = 0;
-  for (const PathShape& path : clip.clipPaths) {
-    count += CountReferenceToRegistry(path.sourceEntity, registry);
-  }
+  // Clip paths hold no entity handle at all (see `ClipPathShape`), so only the mask chain
+  // can reference the registry.
   if (clip.mask.has_value()) {
     count += CountReferenceToRegistry(*clip.mask, registry);
   }
@@ -300,9 +300,6 @@ std::size_t CountReferenceToRegistry(const RenderCommand& command, const Registr
                         },
                         [&](const SetPaintCommand& value) {
                           return CountReferenceToRegistry(value.paint, registry);
-                        },
-                        [&](const DrawPathCommand& value) {
-                          return CountReferenceToRegistry(value.path.sourceEntity, registry);
                         },
                         [&](const DrawTextCommand& value) {
                           return CountReferenceToRegistry(value.text, registry);
@@ -339,7 +336,9 @@ void ReplayCommand(const RenderCommand& command, RendererInterface& renderer,
           },
           [&](const EndPatternTileCommand& value) { renderer.endPatternTile(value.forStroke); },
           [&](const SetPaintCommand& value) { renderer.setPaint(value.paint); },
-          [&](const DrawPathCommand& value) { renderer.drawPath(value.path, value.stroke); },
+          [&](const DrawPathCommand& value) {
+            renderer.drawPath(PathShape{&value.path, value.fillRule}, value.stroke);
+          },
           [&](const DrawRectCommand& value) { renderer.drawRect(value.rect, value.stroke); },
           [&](const DrawEllipseCommand& value) {
             renderer.drawEllipse(value.bounds, value.stroke);
@@ -525,9 +524,9 @@ void RenderSnapshotRecorder::setPaint(const PaintParams& paint) {
 }
 
 void RenderSnapshotRecorder::drawPath(const PathShape& path, const StrokeParams& stroke) {
-  PathShape snapshotPath = path;
-  snapshotPath.sourceEntity = EntityHandle();
-  snapshot_.impl_->commands.push_back(DrawPathCommand{std::move(snapshotPath), stroke});
+  // Deliberate copy: the recorded command has to own geometry that stays valid after the
+  // source registry is gone. The source entity is dropped for the same reason.
+  snapshot_.impl_->commands.push_back(DrawPathCommand{path.pathOrEmpty(), path.fillRule, stroke});
 }
 
 void RenderSnapshotRecorder::drawRect(const Box2d& rect, const StrokeParams& stroke) {

--- a/donner/svg/renderer/RendererDriver.cc
+++ b/donner/svg/renderer/RendererDriver.cc
@@ -366,10 +366,17 @@ void resolvePerSpanStyles(Registry& registry, components::ComputedTextComponent&
   }
 }
 
-PathShape toPathShape(EntityHandle sourceEntity, const components::ComputedPathComponent& path,
+/// Build the borrowed path view handed to `RendererInterface::drawPath`.
+///
+/// `shape.path` points straight at `path.spline`, so this costs no allocation no matter how
+/// large the geometry is. The returned view is only valid while \p path is: every caller
+/// uses it within the draw call that produced it, and the component lives on the registry
+/// for the whole frame.
+PathShape toPathShape(EntityHandle sourceEntity,
+                      const components::ComputedPathComponent& path UTILS_LIFETIME_BOUND,
                       const components::ComputedStyleComponent& style) {
   PathShape shape;
-  shape.path = path.spline;
+  shape.path = &path.spline;
   shape.fillRule = style.properties->fillRule.get().value();
   shape.sourceEntity = sourceEntity;
   return shape;
@@ -473,7 +480,7 @@ ResolvedClip toResolvedClip(const components::RenderingInstanceComponent& instan
 
     clip.clipPaths.reserve(clipPaths->clipPaths.size());
     for (const auto& path : clipPaths->clipPaths) {
-      PathShape shape;
+      ClipPathShape shape;
       shape.path = path.path;
       shape.fillRule = path.clipRule == ClipRule::NonZero ? FillRule::NonZero : FillRule::EvenOdd;
       shape.parentFromEntity = path.parentFromEntity;
@@ -489,7 +496,7 @@ ResolvedClip toResolvedClip(const components::RenderingInstanceComponent& instan
   }
 
   // The computed clip rule is inherited if undefined on the clip path itself.
-  for (PathShape& path : clip.clipPaths) {
+  for (ClipPathShape& path : clip.clipPaths) {
     if (path.fillRule == FillRule::NonZero &&
         style.properties->clipRule.get().value() == ClipRule::EvenOdd) {
       path.fillRule = FillRule::EvenOdd;

--- a/donner/svg/renderer/RendererDriver.cc
+++ b/donner/svg/renderer/RendererDriver.cc
@@ -15,6 +15,7 @@
 #include "donner/base/ParseDiagnostic.h"
 #include "donner/base/ParseWarningSink.h"
 #include "donner/base/RelativeLengthMetrics.h"
+#include "donner/base/Utils.h"
 #include "donner/base/xml/components/TreeComponent.h"
 #include "donner/svg/components/AttachedIdLookup.h"
 #include "donner/svg/components/ComputedClipPathsComponent.h"
@@ -369,9 +370,21 @@ void resolvePerSpanStyles(Registry& registry, components::ComputedTextComponent&
 /// Build the borrowed path view handed to `RendererInterface::drawPath`.
 ///
 /// `shape.path` points straight at `path.spline`, so this costs no allocation no matter how
-/// large the geometry is. The returned view is only valid while \p path is: every caller
-/// uses it within the draw call that produced it, and the component lives on the registry
-/// for the whole frame.
+/// large the geometry is.
+///
+/// The borrow is valid only while \p path keeps its current address AND keeps naming this
+/// entity's geometry. Both hold during traversal, but for different reasons, and the second
+/// is the subtle one. Component storage is paged, so emplacing more `ComputedPathComponent`s
+/// never relocates the existing ones. ERASING one is swap-and-pop: the storage moves its last
+/// element into the freed slot. So an erase during traversal would leave every outstanding
+/// borrow pointing at valid memory that now holds a DIFFERENT entity's spline. The frame
+/// would render the wrong shape, with no crash and nothing for ASAN to catch. The invariant
+/// we rely on is therefore "no `ComputedPathComponent` is erased between the borrow and its
+/// last use", and it holds because every site that removes one runs outside draw traversal:
+/// DOM attribute mutation on the shape elements, shape recomputation in `ShapeSystem`, and
+/// animation-override application in `RenderingContext`. Note that `emplace_or_replace`
+/// during recomputation is fine on its own - it rewrites the component in place - so the
+/// hazard is specifically erasure, not update.
 PathShape toPathShape(EntityHandle sourceEntity,
                       const components::ComputedPathComponent& path UTILS_LIFETIME_BOUND,
                       const components::ComputedStyleComponent& style) {

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1926,10 +1926,12 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     css::RGBA color;
     FillRule rule = FillRule::NonZero;
     const geode::EncodedPath* encoded = nullptr;
-    /// Reference to the source Path. Caller guarantees lifetime -
-    /// the Path is stored on `ComputedPathComponent` (pinned by
-    /// `GeodePathCacheComponent`'s cache invariant for the frame's
-    /// lifetime).
+    /// Borrowed source geometry, read only by the size-1 flush when it falls back to the
+    /// arena `fillPath`. A batch is only started for a draw with a non-null `sourceEntity`,
+    /// and for those the driver points `PathShape::path` at the entity's
+    /// `ComputedPathComponent::spline` - registry-owned storage that outlives the flush.
+    /// Draws whose geometry lives on the caller's stack (`drawRect`, `drawEllipse`, overlay
+    /// chrome) have no source entity and never reach here.
     const Path* path = nullptr;
     /// `deviceFromLocalTransform` captured at each `drawPath`. On flush, the
     /// outer encoder transform is set to identity and these are
@@ -2404,6 +2406,9 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
   /// The caller is expected to have already verified the draw is
   /// "batch-compatible" (solid paint, no stroke, has source entity,
   /// has cached fill encode, no in-flight pattern).
+  ///
+  /// \p path is retained until the batch flushes, so it must be storage that outlives this
+  /// call - see `PendingBatch::path`.
   bool tryAppendOrStartBatch(const Registry* sourceRegistry, Entity sourceEntity, const Path& path,
                              const css::RGBA& color, FillRule rule,
                              const geode::EncodedPath* encoded,
@@ -3566,7 +3571,7 @@ void RendererGeode::pushClip(const ResolvedClip& clip) {
 
       impl_->encoder->beginMaskPass(maskTexture);
       for (size_t s = it->begin; s < it->end; ++s) {
-        const PathShape& shape = clip.clipPaths[s];
+        const ClipPathShape& shape = clip.clipPaths[s];
         const Transform2d composed =
             clip.clipPathUnitsTransform * shape.parentFromEntity * savedDeviceFromLocalTransform;
         impl_->encoder->setTransform(composed);
@@ -4485,11 +4490,17 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   }
   impl_->lastDrawSourceEntity = path.sourceEntity.entity();
 
+  // `PathShape` borrows its geometry; resolve it once here. `pathOrEmpty` substitutes a
+  // shared empty path for a null pointer, and that substitute has static storage, so the
+  // reference stays valid for as long as a driver-supplied path would (this matters for the
+  // pending batch, which retains the address past the end of this call).
+  const Path& drawPathGeometry = path.pathOrEmpty();
+
   // Path-encode cache lookup for the fill. Null `sourceEntity` (editor
   // overlay, test-harness direct draws) returns nullptr and `GeoEncoder`
   // falls back to the inline encode path.
   const geode::EncodedPath* fillEncoded =
-      impl_->getFillEncode(path.sourceEntity, path.path, path.fillRule);
+      impl_->getFillEncode(path.sourceEntity, drawPathGeometry, path.fillRule);
 
   // Try to append to a pending `<use>`-batch. Preconditions:
   //  - Source entity valid (non-null handle).
@@ -4536,7 +4547,7 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
     const css::RGBA color = solid.color.resolve(impl_->paint.currentColor.rgba(),
                                                 static_cast<float>(impl_->paint.fillOpacity));
     impl_->tryAppendOrStartBatch(path.sourceEntity.registry(), path.sourceEntity.entity(),
-                                 path.path, color, path.fillRule, fillEncoded, residentFill);
+                                 drawPathGeometry, color, path.fillRule, fillEncoded, residentFill);
     return;
   }
 
@@ -4547,7 +4558,7 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   // the fill on stroke-only passes so Geode reorders rather than double-paints.
   // Both default to true, so this is a no-op for ordinary fill-then-stroke draws.
   if (impl_->paint.drawFillComponent) {
-    impl_->fillResolved(path.path, path.fillRule, fillEncoded, residentFill,
+    impl_->fillResolved(drawPathGeometry, path.fillRule, fillEncoded, residentFill,
                         residentGradientFill);
   }
 
@@ -4591,7 +4602,7 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
   // by `StrokeStyle` equality. A cache hit skips all three computations.
   const StrokeStyle strokeStyle = toStrokeStyle(stroke);
   const Impl::StrokeDerived strokeDerived =
-      impl_->getStrokeDerived(path.sourceEntity, path.path, strokeStyle);
+      impl_->getStrokeDerived(path.sourceEntity, drawPathGeometry, strokeStyle);
   if (!strokeDerived.strokedPath) {
     return;
   }
@@ -4633,21 +4644,19 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
        std::holds_alternative<components::PaintResolvedReference>(strokeServer))
           ? impl_->residentGradientStrokeSlot(path.sourceEntity)
           : nullptr;
-  impl_->drawPaintedPathAgainst(path.path, strokedOutline, strokeServer, effectiveOpacity,
+  impl_->drawPaintedPathAgainst(drawPathGeometry, strokedOutline, strokeServer, effectiveOpacity,
                                 strokeDerived.fillRule, strokeDerived.encoded, residentStroke,
                                 residentGradientStroke);
 }
 
 void RendererGeode::drawRect(const Box2d& rect, const StrokeParams& stroke) {
-  Path path = PathBuilder().addRect(rect).build();
-  PathShape shape{std::move(path), FillRule::NonZero, Transform2d(), 0};
-  drawPath(shape, stroke);
+  const Path path = PathBuilder().addRect(rect).build();
+  drawPath(PathShape{&path, FillRule::NonZero}, stroke);
 }
 
 void RendererGeode::drawEllipse(const Box2d& bounds, const StrokeParams& stroke) {
-  Path path = PathBuilder().addEllipse(bounds).build();
-  PathShape shape{std::move(path), FillRule::NonZero, Transform2d(), 0};
-  drawPath(shape, stroke);
+  const Path path = PathBuilder().addEllipse(bounds).build();
+  drawPath(PathShape{&path, FillRule::NonZero}, stroke);
 }
 
 void RendererGeode::drawImage(const ImageResource& image, const ImageParams& params) {

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1927,11 +1927,20 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     FillRule rule = FillRule::NonZero;
     const geode::EncodedPath* encoded = nullptr;
     /// Borrowed source geometry, read only by the size-1 flush when it falls back to the
-    /// arena `fillPath`. A batch is only started for a draw with a non-null `sourceEntity`,
-    /// and for those the driver points `PathShape::path` at the entity's
-    /// `ComputedPathComponent::spline` - registry-owned storage that outlives the flush.
-    /// Draws whose geometry lives on the caller's stack (`drawRect`, `drawEllipse`, overlay
-    /// chrome) have no source entity and never reach here.
+    /// arena `fillPath`. This is the one place a `PathShape`'s pointer outlives the
+    /// `drawPath` call that delivered it, so it carries the strictest precondition in this
+    /// file.
+    ///
+    /// A batch is only started for a draw with a non-null `sourceEntity`, and for those the
+    /// driver points `PathShape::path` at the entity's `ComputedPathComponent::spline`. That
+    /// address is stable while the component exists (component storage is paged, so emplacing
+    /// other components never relocates it), but erasing that component would swap the
+    /// storage's last element into the slot and silently repoint us at another entity's
+    /// geometry - wrong pixels, no crash, invisible to ASAN. What makes the retention safe is
+    /// that nothing erases a `ComputedPathComponent` between the borrow and the flush: every
+    /// removal site runs outside draw traversal, and a flush always happens within the frame
+    /// that started the batch. Draws whose geometry lives on the caller's stack (`drawRect`,
+    /// `drawEllipse`, overlay chrome) have no source entity and never reach here.
     const Path* path = nullptr;
     /// `deviceFromLocalTransform` captured at each `drawPath`. On flush, the
     /// outer encoder transform is set to identity and these are
@@ -3243,6 +3252,11 @@ void RendererGeode::beginFrame(const RenderViewport& viewport) {
   // `<use>`-batch detection: drop the previous-draw source-entity memo so
   // cross-frame draws don't show up as "same-source runs".
   impl_->lastDrawSourceEntity = entt::null;
+
+  // Drop any batch the previous frame left pending. `endFrame` normally flushes it, but an
+  // early-out that skips the flush must not carry a borrowed `ComputedPathComponent` pointer
+  // into a frame that may no longer have that component.
+  impl_->pendingBatch.reset();
 
   // Reset counters regardless of device state.
   impl_->counters.reset();

--- a/donner/svg/renderer/RendererInterface.h
+++ b/donner/svg/renderer/RendererInterface.h
@@ -198,9 +198,45 @@ private:
 };
 
 /**
- * Represents a resolved path along with its fill rule, transform, and layer index for boolean ops.
+ * A path to draw, along with its fill rule and the entity it came from.
+ *
+ * This is a borrowed view, not an owner: `path` points at geometry the caller keeps alive.
+ * Draw calls take it by const reference and must not retain it past the call unless the
+ * backend has separately established that the pointee outlives the retention (see
+ * `RendererGeode`'s deferred fill batch, which only retains geometry owned by a
+ * `ComputedPathComponent`).
+ *
+ * Passing a borrowed path instead of a copy is what keeps a steady-state frame free of
+ * per-drawable path allocations: the driver hands every backend a pointer straight at the
+ * entity's resolved geometry.
  */
 struct PathShape {
+  /// Geometry to draw. Non-owning: the pointee must outlive the draw call. Null is treated
+  /// as an empty path so a default-constructed `PathShape` draws nothing.
+  const Path* path = nullptr;
+  FillRule fillRule = FillRule::NonZero;
+  /// Source entity this path was derived from. Set by the driver at the `drawPath` call
+  /// site (`RendererDriver::traverseRange`). Backends that cache per-entity state key
+  /// off this (see `GeodePathCacheComponent`). A null `EntityHandle` (the default) means
+  /// "no associated entity" - non-driver callers (overlay drawing, test harnesses) leave
+  /// it null and backends fall back to the un-cached path.
+  EntityHandle sourceEntity;
+
+  /// Geometry to draw, with a null `path` reading as the empty path.
+  [[nodiscard]] const Path& pathOrEmpty() const UTILS_LIFETIME_BOUND {
+    static const Path kEmpty;
+    return path != nullptr ? *path : kEmpty;
+  }
+};
+
+/**
+ * One resolved clip-path shape, owned by the \ref ResolvedClip that holds it.
+ *
+ * Unlike \ref PathShape this owns its geometry: a `ResolvedClip` is copied into render
+ * snapshots that outlive the document registry, so it cannot borrow from the source
+ * `ComputedClipPathsComponent`.
+ */
+struct ClipPathShape {
   Path path;
   FillRule fillRule = FillRule::NonZero;
   /// Transform from clip path child to the clip path's coordinate system.
@@ -208,12 +244,6 @@ struct PathShape {
   /// Layer index for boolean combination: paths on the same layer are unioned, layers are
   /// intersected.
   int layer = 0;
-  /// Source entity this path was derived from. Set by the driver at the `drawPath` call
-  /// site (`RendererDriver::traverseRange`). Backends that cache per-entity state key
-  /// off this (see `GeodePathCacheComponent`). A null `EntityHandle` (the default) means
-  /// "no associated entity" - non-driver callers (overlay drawing, test harnesses) leave
-  /// it null and backends fall back to the un-cached path.
-  EntityHandle sourceEntity;
 };
 
 /**
@@ -244,8 +274,8 @@ struct PaintParams {
  * Clip stack entry combining rectangles, paths, and optional masks.
  */
 struct ResolvedClip {
-  std::optional<Box2d> clipRect;     ///< Optional axis-aligned clip rectangle.
-  std::vector<PathShape> clipPaths;  ///< Ordered list of clip path shapes to intersect.
+  std::optional<Box2d> clipRect;         ///< Optional axis-aligned clip rectangle.
+  std::vector<ClipPathShape> clipPaths;  ///< Ordered list of clip path shapes to intersect.
   /// Transform applied to all clip paths (e.g., objectBoundingBox unit mapping).
   Transform2d clipPathUnitsTransform;  ///< Transform applied to the clip path coordinate system.
   std::optional<components::ResolvedMask> mask;  ///< Optional resolved mask reference.

--- a/donner/svg/renderer/RendererInterface.h
+++ b/donner/svg/renderer/RendererInterface.h
@@ -201,18 +201,27 @@ private:
  * A path to draw, along with its fill rule and the entity it came from.
  *
  * This is a borrowed view, not an owner: `path` points at geometry the caller keeps alive.
- * Draw calls take it by const reference and must not retain it past the call unless the
- * backend has separately established that the pointee outlives the retention (see
- * `RendererGeode`'s deferred fill batch, which only retains geometry owned by a
- * `ComputedPathComponent`).
+ * Draw calls take it by const reference and must not retain it past the call, unless the
+ * backend has separately established that the pointee stays valid and stays the same
+ * geometry for as long as it is retained.
+ *
+ * When the geometry lives on a component, "stays valid" is stricter than it looks. Component
+ * storage is paged, so inserting other components never moves an existing one, but ERASING
+ * one is swap-and-pop: the last element is moved into the erased slot. A pointer into a
+ * component that is erased while borrowed therefore does not dangle into freed memory, it
+ * silently starts naming a different entity's geometry. That renders the wrong shape with no
+ * crash, and neither ASAN nor a sanitizer build will flag it. The precondition for any borrow
+ * held across statements is therefore: no component of that type is erased between the borrow
+ * and its last use. Draw traversal satisfies this because every removal site runs outside it.
  *
  * Passing a borrowed path instead of a copy is what keeps a steady-state frame free of
  * per-drawable path allocations: the driver hands every backend a pointer straight at the
  * entity's resolved geometry.
  */
 struct PathShape {
-  /// Geometry to draw. Non-owning: the pointee must outlive the draw call. Null is treated
-  /// as an empty path so a default-constructed `PathShape` draws nothing.
+  /// Geometry to draw. Non-owning: the pointee must outlive the draw call, and must not be
+  /// erased from its storage while borrowed (see the note above this struct). Null is
+  /// treated as an empty path so a default-constructed `PathShape` draws nothing.
   const Path* path = nullptr;
   FillRule fillRule = FillRule::NonZero;
   /// Source entity this path was derived from. Set by the driver at the `drawPath` call
@@ -222,8 +231,10 @@ struct PathShape {
   /// it null and backends fall back to the un-cached path.
   EntityHandle sourceEntity;
 
-  /// Geometry to draw, with a null `path` reading as the empty path.
-  [[nodiscard]] const Path& pathOrEmpty() const UTILS_LIFETIME_BOUND {
+  /// Geometry to draw, with a null `path` reading as the empty path. The returned reference
+  /// is not bound to this `PathShape`: it names either the pointee or a shared empty path
+  /// with static storage, so it stays valid after the view itself goes away.
+  [[nodiscard]] const Path& pathOrEmpty() const {
     static const Path kEmpty;
     return path != nullptr ? *path : kEmpty;
   }

--- a/donner/svg/renderer/RendererTinySkia.cc
+++ b/donner/svg/renderer/RendererTinySkia.cc
@@ -1129,7 +1129,8 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
     return;
   }
 
-  const tiny_skia::Path tinyPath = toTinyPath(path.path);
+  const Path& pathGeometry = path.pathOrEmpty();
+  const tiny_skia::Path tinyPath = toTinyPath(pathGeometry);
   const tiny_skia::Mask* mask = currentClipMask_.has_value() ? &*currentClipMask_ : nullptr;
   tiny_skia::Pixmap* fillPaintPixmap =
       !surfaceStack_.empty() && surfaceStack_.back().fillPaintPixmap.has_value()
@@ -1142,7 +1143,7 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
 
   const bool usedPatternFill = patternFillPaint_.has_value();
   std::optional<tiny_skia::Paint> fillPaint =
-      paint_.drawFillComponent ? makeFillPaint(path.path.bounds()) : std::nullopt;
+      paint_.drawFillComponent ? makeFillPaint(pathGeometry.bounds()) : std::nullopt;
   if (fillPaint) {
     auto pixmapView = currentPixmapView();
     tiny_skia::Painter::fillPath(pixmapView, tinyPath, *fillPaint, toTinyFillRule(path.fillRule),
@@ -1161,7 +1162,7 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
   StrokeParams adjustedStroke = stroke;
   if (!adjustedStroke.dashArray.empty() && adjustedStroke.pathLength > 0.0 &&
       !NearZero(adjustedStroke.pathLength)) {
-    const double actualLength = path.path.pathLength();
+    const double actualLength = pathGeometry.pathLength();
     const double dashUnitsScale = actualLength / adjustedStroke.pathLength;
     for (double& dash : adjustedStroke.dashArray) {
       dash *= dashUnitsScale;
@@ -1171,7 +1172,7 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
 
   const bool usedPatternStroke = patternStrokePaint_.has_value();
   std::optional<tiny_skia::Paint> strokePaint =
-      paint_.drawStrokeComponent ? makeStrokePaint(path.path.bounds(), adjustedStroke)
+      paint_.drawStrokeComponent ? makeStrokePaint(pathGeometry.bounds(), adjustedStroke)
                                  : std::nullopt;
   if (strokePaint) {
     tiny_skia::Stroke tinyStroke;
@@ -1210,7 +1211,7 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
     std::optional<tiny_skia::Path> openDashSeamPath;
     const tiny_skia::Path* strokePath = &tinyPath;
     if (tinyStroke.dash.has_value() && dashHasOnlyZeroLengthGaps) {
-      openDashSeamPath = toTinyPath(path.path, TinyPathCloseBehavior::EndWithLine);
+      openDashSeamPath = toTinyPath(pathGeometry, TinyPathCloseBehavior::EndWithLine);
       strokePath = &*openDashSeamPath;
     }
 
@@ -2091,7 +2092,7 @@ std::optional<tiny_skia::Mask> RendererTinySkia::buildClipMask(const ResolvedCli
     }
   }
 
-  const auto renderShapeMask = [&](const PathShape& shape) -> std::optional<tiny_skia::Mask> {
+  const auto renderShapeMask = [&](const ClipPathShape& shape) -> std::optional<tiny_skia::Mask> {
     std::optional<tiny_skia::Mask> shapeMask = createMask();
     if (!shapeMask.has_value()) {
       return std::nullopt;
@@ -2127,7 +2128,7 @@ std::optional<tiny_skia::Mask> RendererTinySkia::buildClipMask(const ResolvedCli
         [&](int layer) -> std::optional<tiny_skia::Mask> {
       std::optional<tiny_skia::Mask> layerMask;
       while (index >= 0 && clip.clipPaths[static_cast<std::size_t>(index)].layer == layer) {
-        const PathShape& shape = clip.clipPaths[static_cast<std::size_t>(index)];
+        const ClipPathShape& shape = clip.clipPaths[static_cast<std::size_t>(index)];
         std::optional<tiny_skia::Mask> shapeMask = renderShapeMask(shape);
         --index;
 

--- a/donner/svg/renderer/tests/RendererDriver_tests.cc
+++ b/donner/svg/renderer/tests/RendererDriver_tests.cc
@@ -7,6 +7,7 @@
 #include <array>
 #include <cmath>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "donner/base/xml/components/TreeComponent.h"
@@ -134,18 +135,22 @@ TEST_F(RendererDriverTest, BeginsAndEndsFrameAroundTraversal) {
 
 /// `PathShape` borrows the geometry it draws. Copying it instead would allocate twice per
 /// drawable per frame, which is pure waste on a steady frame where nothing changed, so pin
-/// the pointer identity: every path handed to the backend must be the entity's own resolved
-/// spline, not a copy of it.
+/// the pointer identity: each drawn path must be the spline of the entity that same
+/// `PathShape` names in `sourceEntity`.
+///
+/// Checking correspondence rather than "is one of the live splines" matters, because the
+/// weaker check would still pass if the driver handed every draw the same wrong (but live)
+/// component. That is exactly the failure mode an erase-during-traversal would produce.
 TEST_F(RendererDriverTest, DrawPathBorrowsTheEntitySplineInsteadOfCopyingIt) {
   SVGDocument document = makeDocument(R"svg(
     <rect width="8" height="6" fill="red" />
     <circle cx="4" cy="4" r="2" fill="blue" />
   )svg");
 
-  std::vector<const Path*> drawnPaths;
+  std::vector<std::pair<Entity, const Path*>> drawnPaths;
   EXPECT_CALL(renderer, drawPath(_, _))
       .WillRepeatedly([&drawnPaths](const PathShape& path, const StrokeParams&) {
-        drawnPaths.push_back(path.path);
+        drawnPaths.emplace_back(path.sourceEntity.entity(), path.path);
       });
 
   driver.draw(document);
@@ -153,15 +158,18 @@ TEST_F(RendererDriverTest, DrawPathBorrowsTheEntitySplineInsteadOfCopyingIt) {
   ASSERT_FALSE(drawnPaths.empty());
 
   Registry& registry = document.registry();
-  std::vector<const Path*> resolvedSplines;
-  for (const Entity entity : registry.view<components::ComputedPathComponent>()) {
-    resolvedSplines.push_back(&registry.get<components::ComputedPathComponent>(entity).spline);
-  }
-
-  for (const Path* drawn : drawnPaths) {
-    EXPECT_THAT(resolvedSplines, testing::Contains(drawn))
-        << "drawPath received a path that is not an entity's ComputedPathComponent::spline, "
-           "which means the driver copied the geometry";
+  for (const auto& [sourceEntity, drawn] : drawnPaths) {
+    // Compared with `!=` rather than ASSERT_NE: gtest's comparison helper would instantiate
+    // its printer over `entt::null_t`, which does not survive template instantiation here.
+    ASSERT_TRUE(sourceEntity != entt::null)
+        << "the driver should always name the entity a shape draw came from";
+    const auto* computedPath = registry.try_get<components::ComputedPathComponent>(sourceEntity);
+    ASSERT_NE(computedPath, nullptr)
+        << "sourceEntity should still own the ComputedPathComponent the draw was built from";
+    EXPECT_EQ(drawn, &computedPath->spline)
+        << "drawPath must borrow the source entity's own spline; a different address means "
+           "the driver copied the geometry, and a different entity's address means the "
+           "borrow was repointed";
   }
 }
 

--- a/donner/svg/renderer/tests/RendererDriver_tests.cc
+++ b/donner/svg/renderer/tests/RendererDriver_tests.cc
@@ -19,6 +19,7 @@
 #include "donner/svg/components/layout/SizedElementComponent.h"
 #include "donner/svg/components/layout/ViewBoxComponent.h"
 #include "donner/svg/components/resources/ImageComponent.h"
+#include "donner/svg/components/shape/ComputedPathComponent.h"
 #include "donner/svg/components/style/ComputedStyleComponent.h"
 #include "donner/svg/components/text/TextComponent.h"
 #include "donner/svg/core/PreserveAspectRatio.h"
@@ -52,7 +53,7 @@ MATCHER(IsIdentityTransform, "identity transform") {
 }
 
 MATCHER_P(PathCommandsAre, expected, "path commands match") {
-  const auto& commands = arg.path.commands();
+  const auto commands = arg.pathOrEmpty().commands();
   if (commands.size() != expected.size()) {
     return false;
   }
@@ -129,6 +130,39 @@ TEST_F(RendererDriverTest, BeginsAndEndsFrameAroundTraversal) {
   const RendererBitmap bitmap = driver.takeSnapshot();
   EXPECT_FALSE(bitmap.empty());
   EXPECT_THAT(bitmap.dimensions, Eq(Vector2i(16, 16)));
+}
+
+/// `PathShape` borrows the geometry it draws. Copying it instead would allocate twice per
+/// drawable per frame, which is pure waste on a steady frame where nothing changed, so pin
+/// the pointer identity: every path handed to the backend must be the entity's own resolved
+/// spline, not a copy of it.
+TEST_F(RendererDriverTest, DrawPathBorrowsTheEntitySplineInsteadOfCopyingIt) {
+  SVGDocument document = makeDocument(R"svg(
+    <rect width="8" height="6" fill="red" />
+    <circle cx="4" cy="4" r="2" fill="blue" />
+  )svg");
+
+  std::vector<const Path*> drawnPaths;
+  EXPECT_CALL(renderer, drawPath(_, _))
+      .WillRepeatedly([&drawnPaths](const PathShape& path, const StrokeParams&) {
+        drawnPaths.push_back(path.path);
+      });
+
+  driver.draw(document);
+
+  ASSERT_FALSE(drawnPaths.empty());
+
+  Registry& registry = document.registry();
+  std::vector<const Path*> resolvedSplines;
+  for (const Entity entity : registry.view<components::ComputedPathComponent>()) {
+    resolvedSplines.push_back(&registry.get<components::ComputedPathComponent>(entity).spline);
+  }
+
+  for (const Path* drawn : drawnPaths) {
+    EXPECT_THAT(resolvedSplines, testing::Contains(drawn))
+        << "drawPath received a path that is not an entity's ComputedPathComponent::spline, "
+           "which means the driver copied the geometry";
+  }
 }
 
 TEST_F(RendererDriverTest, ConcurrentDomDrawReplaysBackendCallbacksOutsideWriteAccess) {

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -1102,8 +1102,9 @@ TEST_F(RendererGeodeTest, DrawPathWithSolidFill) {
   renderer.setPaint(solidFill(css::RGBA(255, 0, 0, 255)));
   renderer.setTransform(Transform2d());
 
+  const Path path = PathBuilder().addRect(Box2d({16, 16}, {48, 48})).build();
   PathShape shape;
-  shape.path = PathBuilder().addRect(Box2d({16, 16}, {48, 48})).build();
+  shape.path = &path;
   shape.fillRule = FillRule::NonZero;
   renderer.drawPath(shape, StrokeParams{});
 
@@ -1167,8 +1168,9 @@ TEST_F(RendererGeodeTest, PushPopTransform) {
   // Draw a small rect at (8,8)-(16,16) in path space, but with a translate
   // pushed so it lands at (24,24)-(32,32) in pixel space.
   renderer.pushTransform(Transform2d::Translate(Vector2d(16, 16)));
+  const Path path = PathBuilder().addRect(Box2d({8, 8}, {16, 16})).build();
   PathShape shape;
-  shape.path = PathBuilder().addRect(Box2d({8, 8}, {16, 16})).build();
+  shape.path = &path;
   shape.fillRule = FillRule::NonZero;
   renderer.drawPath(shape, StrokeParams{});
   renderer.popTransform();
@@ -1196,8 +1198,9 @@ TEST_F(RendererGeodeTest, StrokeRectOutline) {
   stroke.lineCap = StrokeLinecap::Butt;
   stroke.lineJoin = StrokeLinejoin::Miter;
 
+  const Path path = PathBuilder().addRect(Box2d({16, 16}, {48, 48})).build();
   PathShape shape;
-  shape.path = PathBuilder().addRect(Box2d({16, 16}, {48, 48})).build();
+  shape.path = &path;
   shape.fillRule = FillRule::NonZero;
   renderer.drawPath(shape, stroke);
 
@@ -1232,15 +1235,16 @@ TEST_F(RendererGeodeTest, StrokeSharedVertexDoesNotExtendVertically) {
   stroke.strokeWidth = 1.0;
   stroke.lineJoin = StrokeLinejoin::Miter;
 
+  const Path path = PathBuilder()
+                        .moveTo({50, 85})
+                        .lineTo({65, 135})
+                        .lineTo({150, 135})
+                        .lineTo({150, 85})
+                        .quadTo({100, 45}, {50, 85})
+                        .closePath()
+                        .build();
   PathShape shape;
-  shape.path = PathBuilder()
-                   .moveTo({50, 85})
-                   .lineTo({65, 135})
-                   .lineTo({150, 135})
-                   .lineTo({150, 85})
-                   .quadTo({100, 45}, {50, 85})
-                   .closePath()
-                   .build();
+  shape.path = &path;
   shape.fillRule = FillRule::NonZero;
   renderer.drawPath(shape, stroke);
   renderer.endFrame();
@@ -1263,8 +1267,9 @@ TEST_F(RendererGeodeTest, OversizedDashArrayPreservesSolidStrokeFallback) {
   stroke.strokeWidth = 4.0;
   stroke.dashArray.assign(257, 1.0);
 
+  const Path path = PathBuilder().addRect(Box2d({16, 16}, {48, 48})).build();
   PathShape shape;
-  shape.path = PathBuilder().addRect(Box2d({16, 16}, {48, 48})).build();
+  shape.path = &path;
   shape.fillRule = FillRule::NonZero;
   renderer.drawPath(shape, stroke);
 
@@ -1303,8 +1308,9 @@ TEST_F(RendererGeodeTest, OversizedDashArrayPreservesSolidStrokeFallback) {
 TEST_F(RendererGeodeTest, StrokeFlatteningTracksDeviceScaleWithoutASourceEntity) {
   RendererGeode renderer = createRenderer();
 
+  const Path path = PathBuilder().addCircle(Vector2d(32.0, 32.0), 12.0).build();
   PathShape shape;
-  shape.path = PathBuilder().addCircle(Vector2d(32.0, 32.0), 12.0).build();
+  shape.path = &path;
   shape.fillRule = FillRule::NonZero;
 
   StrokeParams stroke;
@@ -1419,8 +1425,9 @@ TEST_F(RendererGeodeTest, FillAndStrokeRect) {
   StrokeParams stroke;
   stroke.strokeWidth = 4.0;
 
+  const Path path = PathBuilder().addRect(Box2d({16, 16}, {48, 48})).build();
   PathShape shape;
-  shape.path = PathBuilder().addRect(Box2d({16, 16}, {48, 48})).build();
+  shape.path = &path;
   shape.fillRule = FillRule::NonZero;
   renderer.drawPath(shape, stroke);
 
@@ -1480,8 +1487,9 @@ TEST_F(RendererGeodeTest, StrokeBeforeBeginFrameIsNoOp) {
   StrokeParams stroke;
   stroke.strokeWidth = 4.0;
 
+  const Path path = PathBuilder().addRect(Box2d({16, 16}, {48, 48})).build();
   PathShape shape;
-  shape.path = PathBuilder().addRect(Box2d({16, 16}, {48, 48})).build();
+  shape.path = &path;
   shape.fillRule = FillRule::NonZero;
   // Before the fix, this call crashes with a null pointer dereference.
   renderer.drawPath(shape, stroke);
@@ -1497,8 +1505,9 @@ TEST_F(RendererGeodeTest, ZeroWidthStrokeIsNoOp) {
   StrokeParams stroke;
   stroke.strokeWidth = 0.0;  // Must skip stroke path entirely.
 
+  const Path path = PathBuilder().addRect(Box2d({16, 16}, {48, 48})).build();
   PathShape shape;
-  shape.path = PathBuilder().addRect(Box2d({16, 16}, {48, 48})).build();
+  shape.path = &path;
   shape.fillRule = FillRule::NonZero;
   renderer.drawPath(shape, stroke);
 
@@ -1707,7 +1716,7 @@ TEST_F(RendererGeodeTest, PathClipMaskClipsSolidFillToLeftHalf) {
   beginFrame(renderer);
 
   ResolvedClip clip;
-  PathShape clipShape;
+  ClipPathShape clipShape;
   clipShape.fillRule = FillRule::NonZero;
   clipShape.path = PathBuilder()
                        .moveTo(Vector2d(0.0, 0.0))
@@ -1740,7 +1749,7 @@ TEST_F(RendererGeodeTest, PathClipMaskClipsIsolatedLayerComposite) {
   beginFrame(renderer);
 
   ResolvedClip clip;
-  PathShape clipShape;
+  ClipPathShape clipShape;
   clipShape.fillRule = FillRule::NonZero;
   clipShape.path = PathBuilder()
                        .moveTo(Vector2d(0.0, 0.0))
@@ -1775,7 +1784,7 @@ TEST_F(RendererGeodeTest, PathClipMaskClipsIsolatedLayerCompositeForTriangle) {
   beginFrame(renderer);
 
   ResolvedClip clip;
-  PathShape clipShape;
+  ClipPathShape clipShape;
   clipShape.fillRule = FillRule::NonZero;
   clipShape.path = PathBuilder()
                        .moveTo(Vector2d(32.0, 0.0))
@@ -1809,7 +1818,7 @@ TEST_F(RendererGeodeTest, PathClipMaskClipsFilterLayerCompositeForTriangle) {
   beginFrame(renderer);
 
   ResolvedClip clip;
-  PathShape clipShape;
+  ClipPathShape clipShape;
   clipShape.fillRule = FillRule::NonZero;
   clipShape.path = PathBuilder()
                        .moveTo(Vector2d(32.0, 0.0))
@@ -2893,7 +2902,7 @@ TEST_F(RendererGeodeTest, FilterAppliedBeforeClipPathSvgRenderingOrder) {
   // through the path-clip-mask code path (the same one resvg with-clip-path
   // exercises).
   ResolvedClip clip;
-  PathShape clipShape;
+  ClipPathShape clipShape;
   clipShape.fillRule = FillRule::NonZero;
   clipShape.path = PathBuilder()
                        .moveTo(Vector2d(0.0, 0.0))

--- a/donner/svg/renderer/tests/RendererPublicApi_tests.cc
+++ b/donner/svg/renderer/tests/RendererPublicApi_tests.cc
@@ -467,7 +467,8 @@ TEST(RendererPublicApiTest, FacadeForwardsFrameStateAndPrimitiveCalls) {
   builder.lineTo(Vector2d(8.0, 1.0));
   builder.lineTo(Vector2d(8.0, 8.0));
   builder.closePath();
-  renderer.drawPath(PathShape{.path = builder.build()}, StrokeParams{});
+  const Path path = builder.build();
+  renderer.drawPath(PathShape{.path = &path}, StrokeParams{});
   renderer.drawRect(Box2d::FromXYWH(2.0, 2.0, 4.0, 5.0), StrokeParams{});
   renderer.drawEllipse(Box2d::FromXYWH(6.0, 2.0, 5.0, 4.0), StrokeParams{});
 


### PR DESCRIPTION
Deletes the per-frame Path deep copy in the renderer driver: PathShape::path becomes a non-owning pointer borrowing the entity's computed spline, removing two heap allocations and a geometry copy per drawable per frame (exactly 264 allocations and 56,128 bytes per frame on the lion fixture, in both backends, with bit-identical pixel hashes). Consumers that genuinely need ownership got it explicitly: snapshot draw commands own their Path, and clip paths moved to a dedicated owning ClipPathShape type since snapshots deep-copy resolved clips; PathShape sheds the clip-only fields along the way.

The borrow's precondition is documented at every site in its true form: no computed-path component may be erased between borrow and last use (paged component storage keeps insertions pointer-stable; erase is swap-and-pop and would silently relocate another entity's geometry under the pointer). Every current removal site runs outside draw traversal, and the Geode batcher's stored path pointer now names registry-owned geometry, closing a latent window where a clip-masked batchable fill flushing at size one could read a dead stack local. A regression test asserts per-draw pointer correspondence with the drawn entity's own spline, and the batch state resets at frame start so no registry pointer can survive across frames.

Verification: full repository suite green in both default and geode configurations, the editor wasm package size gate green, lint and design-doc provenance checks green. Wall-clock deltas are below the measurement noise floor on the benchmark host; the allocation-count reduction is the deterministic evidence.
