### PR TITLE
perf: Resolve XML line numbers lazily and cache in-scope namespaces per element

### DIFF
--- a/donner/base/xml/XMLNode.cc
+++ b/donner/base/xml/XMLNode.cc
@@ -170,6 +170,18 @@ void UpdateSourceAnchorSpan(EntityHandle handle, SourceOffsetComponent& offset) 
   }
 }
 
+/// Attach line and column numbers to a node offset recorded by the parser. The parser stores
+/// plain byte offsets because resolving line numbers for every node costs more than the rest of
+/// the parse; node offsets are the ones surfaced in diagnostics, so they are resolved on read.
+std::optional<FileOffset> AddLineInfo(std::optional<FileOffset> offset,
+                                      XMLSourceStore* sourceStore) {
+  if (sourceStore == nullptr || !offset.has_value()) {
+    return offset;
+  }
+
+  return sourceStore->resolveLineInfo(*offset);
+}
+
 std::optional<FileOffset> ResolveStartOffset(const SourceOffsetComponent& offset,
                                              XMLSourceStore* sourceStore) {
   if (sourceStore != nullptr && offset.anchorSpan.has_value() &&
@@ -182,7 +194,7 @@ std::optional<FileOffset> ResolveStartOffset(const SourceOffsetComponent& offset
     return FileOffset::Offset(*resolved);
   }
 
-  return offset.startOffset;
+  return AddLineInfo(offset.startOffset, sourceStore);
 }
 
 std::optional<FileOffset> ResolveEndOffset(const SourceOffsetComponent& offset,
@@ -197,7 +209,7 @@ std::optional<FileOffset> ResolveEndOffset(const SourceOffsetComponent& offset,
     return FileOffset::Offset(*resolved);
   }
 
-  return offset.endOffset;
+  return AddLineInfo(offset.endOffset, sourceStore);
 }
 
 }  // namespace

--- a/donner/base/xml/XMLParser.cc
+++ b/donner/base/xml/XMLParser.cc
@@ -298,7 +298,17 @@ public:
     return ch == '\t' || ch == ' ' || ch == '\n' || ch == '\r';
   }
 
-  FileOffset currentOffset(ChunkedString& sourceString, int index) const {
+  /**
+   * Return the byte offset of \p sourceString within the original source text.
+   *
+   * This is deliberately cheap: it resolves a pointer difference and never computes line or
+   * column numbers. Line information is only needed when a diagnostic is emitted, see \ref
+   * resolveLineInfo.
+   *
+   * @param sourceString Cursor into the source text.
+   * @param index Character index relative to the cursor.
+   */
+  FileOffset currentOffset(ChunkedString& sourceString, int index = 0) const {
     if (sourceString.empty()) {
       return FileOffset::Offset(str_.size());
     }
@@ -340,7 +350,7 @@ public:
         break;
       }
 
-      const FileOffset startOffset = currentOffsetWithLineNumber(remaining_);
+      const FileOffset startOffset = currentOffset(remaining_);
 
       if (tryConsume(remaining_, "<")) {
         auto maybeNode = parseNode(startOffset);
@@ -411,7 +421,11 @@ public:
 
       const ParsedAttribute& attribute = maybeAttribute.result().value();
       if (attribute.name == name) {
-        return attribute.fullRange;
+        // This range is relative to the element text this instance was constructed with, and the
+        // caller shifts it back into the full document with FileOffset::addParentOffset, which
+        // needs both sides to carry line information to combine them correctly.
+        return SourceRange{resolveLineInfo(attribute.fullRange.start),
+                           resolveLineInfo(attribute.fullRange.end)};
       }
     }
 
@@ -419,7 +433,9 @@ public:
   }
 
 private:
-  parser::LineOffsets lineOffsets() {
+  /// Line table for the source text, scanned on first use. A document that parses without
+  /// emitting any diagnostic never pays for it.
+  const parser::LineOffsets& lineOffsets() {
     if (!lineOffsets_) {
       lineOffsets_.emplace(str_);
     }
@@ -427,20 +443,27 @@ private:
     return lineOffsets_.value();
   }
 
-  FileOffset currentOffsetWithLineNumber(ChunkedString& sourceString, int relativeOffset = 0) {
-    FileOffset current = currentOffset(sourceString, relativeOffset);
-    if (!current.offset) {
-      return current;
+  /**
+   * Attach line and column information to a byte offset.
+   *
+   * Offsets recorded on the parsed tree stay as plain byte offsets, since resolving line and
+   * column numbers for every node and attribute costs more than the whole rest of the parse for
+   * documents that never emit a diagnostic. Call this at the point a diagnostic is created.
+   *
+   * @param offset Byte offset to resolve, or an unresolved offset which is returned unchanged.
+   */
+  FileOffset resolveLineInfo(FileOffset offset) {
+    if (!offset.offset) {
+      return offset;
     }
 
-    const size_t offset = current.offset.value();
-    return lineOffsets().fileOffset(offset);
+    return lineOffsets().fileOffset(offset.offset.value());
   }
 
   ParseDiagnostic createParseError(std::string_view reason,
                                    std::optional<FileOffset> location = std::nullopt) {
     return ParseDiagnostic::Error(RcString(reason),
-                                  location.value_or(currentOffsetWithLineNumber(remaining_)));
+                                  resolveLineInfo(location.value_or(currentOffset(remaining_))));
   }
 
   [[nodiscard]] std::optional<ParseDiagnostic> recordEntitySubstitution(
@@ -717,21 +740,22 @@ private:
     // Then numeric entities: '&#' prefix
     else if (tryConsume(sourceString, "&#")) {
       const bool hex = tryConsume(sourceString, "x");
-      const FileOffset digitsOffset = currentOffsetWithLineNumber(sourceString);
+      const FileOffset digitsOffset = currentOffset(sourceString);
 
       // Grab all digits
       const RcString digits = consumeMatching<DigitsPredicate>(sourceString).toSingleRcString();
       if (digits.empty()) {
         return ParseDiagnostic::Error("Invalid numeric entity syntax (missing digits)",
-                                      entityOffset);
+                                      resolveLineInfo(entityOffset));
       }
 
       auto parseRes = hex ? IntegerParser::ParseHex(digits) : IntegerParser::Parse(digits);
       if (parseRes.hasError()) {
         ParseDiagnostic err = parseRes.error();
         if (digitsOffset.offset) {
-          err.range.start = err.range.start.addParentOffset(digitsOffset);
-          err.range.end = err.range.end.addParentOffset(digitsOffset);
+          const FileOffset parentOffset = resolveLineInfo(digitsOffset);
+          err.range.start = err.range.start.addParentOffset(parentOffset);
+          err.range.end = err.range.end.addParentOffset(parentOffset);
         } else {
           // For recursive entity expansions, source information is lost.
           // TODO: Find a way to retain this information.
@@ -746,7 +770,7 @@ private:
       // We must see a trailing ';'
       if (!tryConsume(sourceString, ";")) {
         return ParseDiagnostic::Error("Numeric character entity missing closing ';'",
-                                      currentOffsetWithLineNumber(sourceString));
+                                      resolveLineInfo(currentOffset(sourceString)));
       }
 
       // Validate and append
@@ -799,7 +823,7 @@ private:
       // Otherwise, next char must be the expected entity prefix, '&' or '%'.
       assert(nextChar == kEntityPrefix[0]);
 
-      const FileOffset entityOffset = currentOffsetWithLineNumber(sourceString);
+      const FileOffset entityOffset = currentOffset(sourceString);
 
       // 2. Try built-in or numeric
       auto parseResult = tryParseBuiltInOrNumericEntity(entityOffset, sourceString, decodedText);
@@ -1002,7 +1026,7 @@ private:
       return createParseError("XML declaration missing closing '?>'");
     }
 
-    const FileOffset endOffset = currentOffsetWithLineNumber(remaining_);
+    const FileOffset endOffset = currentOffset(remaining_);
     declaration.setSourceEndOffset(endOffset);
     declaration.setOpeningTagLocation(SourceRange{startOffset, endOffset});
     return declaration;
@@ -1010,7 +1034,7 @@ private:
 
   // Parse XML comment (<!--...)
   ParseResult<std::optional<XMLNode>> parseComment(FileOffset startOffset) {
-    const FileOffset valueStartOffset = currentOffsetWithLineNumber(remaining_);
+    const FileOffset valueStartOffset = currentOffset(remaining_);
     const auto maybeComment = consumeContentsUntilEndString("-->");
     if (!maybeComment) {
       return createParseError("Comment node does not end with '-->'");
@@ -1025,7 +1049,7 @@ private:
       }
       XMLNode commentNode = XMLNode::CreateCommentNode(document_, commentStr.toSingleRcString());
       commentNode.setSourceStartOffset(startOffset);
-      const FileOffset endOffset = currentOffsetWithLineNumber(remaining_);
+      const FileOffset endOffset = currentOffset(remaining_);
       commentNode.setSourceEndOffset(endOffset);
       if (std::optional<SourceRange> openingRange = MakeTrimmedRange(startOffset, endOffset, 0, 3);
           openingRange.has_value() && openingRange->start.offset.has_value() &&
@@ -1061,7 +1085,7 @@ private:
    * detect `<!ENTITY>` declarations in the internal subset and record them.
    */
   ParseResult<std::optional<XMLNode>> parseDoctype(FileOffset startOffset) {
-    const FileOffset valueStartOffset = currentOffsetWithLineNumber(remaining_);
+    const FileOffset valueStartOffset = currentOffset(remaining_);
 
     // We read until the first '>' at nesting level 0, while also handling the internal subset
     // `[...]`
@@ -1130,7 +1154,7 @@ private:
       }
       XMLNode docNode = XMLNode::CreateDocTypeNode(document_, doctypeStr.toSingleRcString());
       docNode.setSourceStartOffset(startOffset);
-      const FileOffset endOffset = currentOffsetWithLineNumber(remaining_);
+      const FileOffset endOffset = currentOffset(remaining_);
       docNode.setSourceEndOffset(endOffset);
       docNode.setOpeningTagLocation(SourceRange{startOffset, endOffset});
       if (std::optional<SourceRange> valueRange =
@@ -1153,7 +1177,7 @@ private:
 
     // Skip whitespace after the PI name.
     skipWhitespace(remaining_);
-    const FileOffset valueStartOffset = currentOffsetWithLineNumber(remaining_);
+    const FileOffset valueStartOffset = currentOffset(remaining_);
 
     // Consume contents until finding a '?>'
     const auto maybePiValue = consumeContentsUntilEndString("?>");
@@ -1170,7 +1194,7 @@ private:
       XMLNode pi = XMLNode::CreateProcessingInstructionNode(document_, piName.toSingleRcString(),
                                                             piValue.toSingleRcString());
       pi.setSourceStartOffset(startOffset);
-      const FileOffset endOffset = currentOffsetWithLineNumber(remaining_);
+      const FileOffset endOffset = currentOffset(remaining_);
       pi.setSourceEndOffset(endOffset);
       pi.setOpeningTagLocation(SourceRange{startOffset, endOffset});
       if (std::optional<SourceRange> valueRange =
@@ -1187,7 +1211,7 @@ private:
    * Read raw text (PCDATA) until `<` or `\0`
    */
   std::optional<ParseDiagnostic> parseAndAppendData(XMLNode& node) {
-    const FileOffset startOffset = currentOffsetWithLineNumber(remaining_);
+    const FileOffset startOffset = currentOffset(remaining_);
 
     // Expand all entities in the current text chunk
     auto maybeData = consumePCDataOnce();
@@ -1203,7 +1227,7 @@ private:
       // Create new data node
       XMLNode data = XMLNode::CreateDataNode(document_, dataStrAllocated);
       data.setSourceStartOffset(startOffset);
-      const FileOffset endOffset = currentOffsetWithLineNumber(remaining_);
+      const FileOffset endOffset = currentOffset(remaining_);
       data.setSourceEndOffset(endOffset);
       data.setValueLocation(SourceRange{startOffset, endOffset});
       node.appendChild(data);
@@ -1234,7 +1258,7 @@ private:
 
     XMLNode cdata = XMLNode::CreateCDataNode(document_, cdataStr.toSingleRcString());
     cdata.setSourceStartOffset(startOffset);
-    const FileOffset endOffset = currentOffsetWithLineNumber(remaining_);
+    const FileOffset endOffset = currentOffset(remaining_);
     cdata.setSourceEndOffset(endOffset);
     if (std::optional<SourceRange> openingRange = MakeTrimmedRange(startOffset, endOffset, 0, 3);
         openingRange.has_value() && openingRange->start.offset.has_value() &&
@@ -1388,7 +1412,7 @@ private:
     // Determine ending type
     if (tryConsume(remaining_, ">")) {
       element.setOpeningTagLocation(
-          SourceRange{startOffset, currentOffsetWithLineNumber(remaining_)});
+          SourceRange{startOffset, currentOffset(remaining_)});
       // Enter the element - bump nesting depth before recursing, restore on exit.
       if (nestingDepth_ >= maxNestingDepth_) {
         return createParseError("Maximum element nesting depth exceeded", startOffset);
@@ -1403,12 +1427,12 @@ private:
     } else if (tryConsume(remaining_, "/>")) {
       // Self-closing tag
       element.setOpeningTagLocation(
-          SourceRange{startOffset, currentOffsetWithLineNumber(remaining_)});
+          SourceRange{startOffset, currentOffset(remaining_)});
     } else {
       return createParseError("Node not closed with '>' or '/>'");
     }
 
-    element.setSourceEndOffset(currentOffsetWithLineNumber(remaining_));
+    element.setSourceEndOffset(currentOffset(remaining_));
     return element;
   }
 
@@ -1525,8 +1549,8 @@ private:
         }
 
         if (tryConsume(remaining_, "</")) {  // Node closing
-          const FileOffset closingTagOpenStart = currentOffsetWithLineNumber(contentsStart);
-          const FileOffset closingTagStart = currentOffsetWithLineNumber(remaining_);
+          const FileOffset closingTagOpenStart = currentOffset(contentsStart);
+          const FileOffset closingTagStart = currentOffset(remaining_);
 
           auto maybeClosingName = consumeQualifiedName();
           if (maybeClosingName.hasError()) {
@@ -1546,10 +1570,10 @@ private:
           }
 
           node.setClosingTagLocation(
-              SourceRange{closingTagOpenStart, currentOffsetWithLineNumber(remaining_)});
+              SourceRange{closingTagOpenStart, currentOffset(remaining_)});
           return std::nullopt;  // Node closed, finished parsing contents
         } else {
-          FileOffset startOffset = currentOffsetWithLineNumber(remaining_);
+          FileOffset startOffset = currentOffset(remaining_);
 
           // Child node
           remaining_.remove_prefix(1);  // Skip '<'
@@ -1581,7 +1605,7 @@ private:
    * @returns nullopt if none found.
    */
   ParseResult<std::optional<ParsedAttribute>> parseNextAttribute() {
-    const FileOffset attributeStartOffset = currentOffsetWithLineNumber(remaining_);
+    const FileOffset attributeStartOffset = currentOffset(remaining_);
     {
       const char nextCh = peek(remaining_).value_or('\0');
       const uint8_t ub = static_cast<uint8_t>(nextCh);
@@ -1622,7 +1646,7 @@ private:
 
     const char quote = maybeQuote.value();
     remaining_.remove_prefix(1);
-    const FileOffset valueStartOffset = currentOffsetWithLineNumber(remaining_);
+    const FileOffset valueStartOffset = currentOffset(remaining_);
 
     // Extract attribute value and expand char refs in it
     auto maybeValue = quote == '\'' ? consumeAttributeExpandEntities<'\''>()
@@ -1630,7 +1654,7 @@ private:
     if (maybeValue.hasError()) {
       return std::move(maybeValue.error());
     }
-    const FileOffset valueEndOffset = currentOffsetWithLineNumber(remaining_);
+    const FileOffset valueEndOffset = currentOffset(remaining_);
 
     // Make sure that end quote is present
     if (!tryConsume(remaining_, std::string_view(&quote, 1))) {
@@ -1640,7 +1664,7 @@ private:
         return createParseError("Attribute value not closed with '\"'");
       }
     }
-    const FileOffset attributeEndOffset = currentOffsetWithLineNumber(remaining_);
+    const FileOffset attributeEndOffset = currentOffset(remaining_);
 
     ParsedAttribute result{
         .name = name,
@@ -1659,7 +1683,7 @@ private:
     uint64_t attributeCount = 0;
     // For all attributes
     while (true) {
-      const FileOffset beforeAttribute = currentOffsetWithLineNumber(remaining_);
+      const FileOffset beforeAttribute = currentOffset(remaining_);
       ParseResult<std::optional<ParsedAttribute>> maybeAttribute = parseNextAttribute();
       if (maybeAttribute.hasError()) {
         return std::move(maybeAttribute.error());

--- a/donner/base/xml/XMLSourceStore.cc
+++ b/donner/base/xml/XMLSourceStore.cc
@@ -211,6 +211,19 @@ std::optional<XMLSourceDelta> XMLSourceStore::replace(std::size_t offset, std::s
   };
 }
 
+FileOffset XMLSourceStore::resolveLineInfo(FileOffset offset) const {
+  if (!offset.offset.has_value()) {
+    return offset;
+  }
+
+  if (!lineOffsets_.has_value() || lineOffsetsVersion_ != sourceVersion_) {
+    lineOffsets_.emplace(std::string_view(source_));
+    lineOffsetsVersion_ = sourceVersion_;
+  }
+
+  return lineOffsets_->fileOffset(offset.offset.value());
+}
+
 bool XMLSourceStore::isBoundary(std::size_t offset) const {
   if (offset > source_.size()) {
     return false;

--- a/donner/base/xml/XMLSourceStore.h
+++ b/donner/base/xml/XMLSourceStore.h
@@ -9,7 +9,9 @@
 #include <string_view>
 #include <vector>
 
+#include "donner/base/FileOffset.h"
 #include "donner/base/Utils.h"
+#include "donner/base/parser/LineOffsets.h"
 
 namespace donner::xml {
 
@@ -150,6 +152,19 @@ public:
   [[nodiscard]] std::optional<XMLSourceDelta> replace(std::size_t offset, std::size_t length,
                                                       std::string_view replacement);
 
+  /**
+   * Attach line and column information to a byte offset into the current source.
+   *
+   * The line table is scanned on first use and reused until the source changes, so parsing a
+   * document that never needs a line number never pays for it. Building it mutates state behind
+   * a const method, so this must not run concurrently with another access to the same store:
+   * the document access lock admits any number of simultaneous readers, and nothing today
+   * resolves line numbers from more than one of them at a time.
+   *
+   * @param offset Byte offset, or an unresolved offset which is returned unchanged.
+   */
+  [[nodiscard]] FileOffset resolveLineInfo(FileOffset offset) const;
+
 private:
   struct Anchor {
     std::size_t offset = 0;
@@ -165,6 +180,11 @@ private:
   std::string source_;
   std::uint64_t sourceVersion_ = 0;
   std::vector<Anchor> anchors_;
+
+  /// Line table for \ref source_, built on demand by \ref resolveLineInfo.
+  mutable std::optional<donner::parser::LineOffsets> lineOffsets_;
+  /// Value of \ref sourceVersion_ that \ref lineOffsets_ was built from.
+  mutable std::uint64_t lineOffsetsVersion_ = 0;
 };
 
 }  // namespace donner::xml

--- a/donner/base/xml/components/AttributesComponent.cc
+++ b/donner/base/xml/components/AttributesComponent.cc
@@ -41,7 +41,12 @@ void AttributesComponent::setAttribute(Registry& registry, const xml::XMLQualifi
   }
 
   if (isNamespaceOverride(nameAllocated)) {
-    ++numNamespaceOverrides_;
+    // Count declarations present, not writes: overwriting an existing xmlns attribute replaces
+    // the declaration rather than adding one, while removeAttribute only ever decrements once.
+    // Counting writes leaves hasNamespaceOverrides() true after the last declaration is removed.
+    if (newAttrInserted) {
+      ++numNamespaceOverrides_;
+    }
 
     const Entity self = entt::to_entity(registry.storage<AttributesComponent>(), *this);
     registry.ctx().get<xml::components::XMLNamespaceContext>().addNamespaceOverride(

--- a/donner/base/xml/components/TreeComponent.cc
+++ b/donner/base/xml/components/TreeComponent.cc
@@ -3,8 +3,19 @@
 #include <entt/entity/helper.hpp>  // entt::to_entity (2-arg overload)
 
 #include "donner/base/Utils.h"
+#include "donner/base/xml/components/XMLNamespaceContext.h"
 
 namespace donner::components {
+
+namespace {
+
+/// Notify the document's namespace state that \p entity moved, since which namespace
+/// declarations apply to a node depends on its ancestors.
+void NotifyTreeChanged(Registry& registry, Entity entity) {
+  xml::components::XMLNamespaceContext::InvalidateScopesForTreeChange(registry, entity);
+}
+
+}  // namespace
 
 void TreeComponent::insertBefore(Registry& registry, Entity newNode, Entity referenceNode) {
   UTILS_RELEASE_ASSERT_MSG(newNode != entt::null, "newNode is null");
@@ -52,6 +63,7 @@ void TreeComponent::insertBefore(Registry& registry, Entity newNode, Entity refe
   }
 
   newTree.parent_ = self;
+  NotifyTreeChanged(registry, newNode);
 }
 
 void TreeComponent::appendChild(Registry& registry, Entity child) {
@@ -78,6 +90,7 @@ void TreeComponent::appendChild(Registry& registry, Entity child) {
   }
 
   lastChild_ = child;
+  NotifyTreeChanged(registry, child);
 }
 
 void TreeComponent::replaceChild(Registry& registry, Entity newChild, Entity oldChild) {
@@ -133,6 +146,8 @@ void TreeComponent::remove(Registry& registry) {
     parent_ = entt::null;
     previousSibling_ = entt::null;
     nextSibling_ = entt::null;
+
+    NotifyTreeChanged(registry, self);
   }
 }
 

--- a/donner/base/xml/components/XMLNamespaceContext.h
+++ b/donner/base/xml/components/XMLNamespaceContext.h
@@ -1,7 +1,15 @@
 #pragma once
 /// @file
 
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
 #include <map>
+#include <memory>
+#include <optional>
+#include <type_traits>
+#include <unordered_map>
 
 #include "donner/base/EcsRegistry.h"
 #include "donner/base/RcString.h"
@@ -47,29 +55,14 @@ public:
    * @param uri Namespace URI to use for the prefix.
    */
   void addNamespaceOverride(Entity entity, const XMLQualifiedName& name, const RcString& uri) {
-    // Map the name to a prefix (either xmlns for prefix="" or xmlns:prefix)
-    std::optional<RcString> prefix;
-    if (name.namespacePrefix.empty() && name.name == "xmlns") {
-      // Default namespace declaration
-      prefix = "";
-    } else if (name.namespacePrefix == "xmlns") {
-      // Namespace declaration with prefix
-      prefix = name.name;
-    }
-
+    const std::optional<RcString> prefix = ToNamespacePrefix(name);
     assert(prefix.has_value() && "Not a namespace declaration attribute");
-
-    // Remove existing entries with this entity and prefix
-    auto range = namespaceEntries_.equal_range(prefix.value());
-    for (auto it = range.first; it != range.second;) {
-      if (it->second.entity == entity) {
-        it = namespaceEntries_.erase(it);
-      } else {
-        ++it;
-      }
+    if (!prefix.has_value()) {
+      return;
     }
 
-    namespaceEntries_.emplace(prefix.value(), NamespaceEntry{entity, uri});
+    declarations_[entity].insert_or_assign(prefix.value(), uri);
+    invalidateScopes();
   }
 
   /**
@@ -79,31 +72,29 @@ public:
    * @param name Namespace attribute to remove.
    */
   void removeNamespaceOverride(Entity entity, const XMLQualifiedName& name) {
-    // Map the name to a prefix (either xmlns by itself, or xmlns:prefix)
-    std::optional<RcString> prefix;
-    if (name.namespacePrefix.empty() && name.name == "xmlns") {
-      // Default namespace declaration
-      prefix = "";
-    } else if (name.namespacePrefix == "xmlns") {
-      // Namespace declaration with prefix
-      prefix = name.name;
+    const std::optional<RcString> prefix = ToNamespacePrefix(name);
+    assert(prefix.has_value() && "Not a namespace declaration attribute");
+    if (!prefix.has_value()) {
+      return;
     }
 
-    assert(prefix.has_value() && "Not a namespace declaration attribute");
-
-    // Remove existing entries with this entity and prefix
-    auto range = namespaceEntries_.equal_range(prefix.value());
-    for (auto it = range.first; it != range.second;) {
-      if (it->second.entity == entity) {
-        it = namespaceEntries_.erase(it);
-      } else {
-        ++it;
+    const auto it = declarations_.find(entity);
+    if (it != declarations_.end()) {
+      it->second.erase(prefix.value());
+      if (it->second.empty()) {
+        declarations_.erase(it);
       }
     }
+
+    invalidateScopes();
   }
 
   /**
    * Get the URI for the given namespace prefix.
+   *
+   * Resolved scopes are cached, so the first lookup below an element pays for the ancestor walk
+   * and later ones are a map lookup. Like the rest of the document's read paths that populate
+   * state on demand, this must not run concurrently with another access to the same document.
    *
    * @param registry Registry to use for the lookup.
    * @param entity Entity to get the namespace URI for.
@@ -112,69 +103,208 @@ public:
    */
   std::optional<RcString> getNamespaceUri(Registry& registry, Entity entity,
                                           const RcString& prefix) const {
-    // Get a list of parents for the entity.
-    SmallVector<Entity, 8> parents = getParents(registry, entity);
+    const ScopeMap& scope = *resolveScope(registry, entity);
 
-    // Find entries in the multimap with the given prefix
-    auto range = namespaceEntries_.equal_range(prefix);
-    if (range.first == namespaceEntries_.end()) {
+    const auto it = scope.find(prefix);
+    if (it == scope.end()) {
       return std::nullopt;
     }
 
-    // Search for the prefix in the parents (from nearest to furthest ancestor)
-    for (Entity parent : parents) {
-      if (const auto* attributes =
-              registry.try_get<donner::components::AttributesComponent>(parent);
-          attributes && attributes->hasNamespaceOverrides()) {
-        // Check for namespace entries with the given prefix and parent entity
-        for (auto it = range.first; it != range.second; ++it) {
-          if (it->second.entity == parent) {
-            return it->second.uri;
-          }
-        }
-      }
+    return it->second;
+  }
+
+  /**
+   * Drop cached namespace scopes for a subtree that was just attached or detached.
+   *
+   * An element's in-scope namespaces come from its ancestors, so re-parenting a node can change
+   * which declarations apply to it and to everything below it, and nothing else. Registries
+   * without an \ref XMLNamespaceContext are ignored.
+   *
+   * @param registry Registry whose tree changed.
+   * @param entity Root of the subtree that moved.
+   */
+  static void InvalidateScopesForTreeChange(Registry& registry, Entity entity) {
+    if (registry.ctx().contains<XMLNamespaceContext>()) {
+      registry.ctx().get<XMLNamespaceContext>().invalidateSubtreeScopes(registry, entity);
+    }
+  }
+
+  /// Number of entities whose scope has been computed from their ancestors, which only happens
+  /// when the entity has no cached scope. Lets a test tell a cache hit from a recomputation.
+  [[nodiscard]] std::uint64_t scopeResolutionCountForTesting() const {
+    return scopeResolutionCount_;
+  }
+
+private:
+  /// Namespace declarations made by a single element, mapping prefix to URI. The default
+  /// namespace (`xmlns="..."`) uses an empty prefix.
+  using DeclarationMap = std::map<RcString, RcString>;
+
+  /// Every prefix in scope for an element: its own declarations layered over its ancestors'.
+  using ScopeMap = DeclarationMap;
+
+  /// Hash for an \c Entity key, which is a scoped enum over an integer id.
+  struct EntityHash {
+    std::size_t operator()(Entity entity) const {
+      return std::hash<std::underlying_type_t<Entity>>{}(
+          static_cast<std::underlying_type_t<Entity>>(entity));
+    }
+  };
+
+  /// Map the `xmlns` or `xmlns:prefix` attribute name to the prefix it declares, or
+  /// `std::nullopt` if the name is not a namespace declaration.
+  static std::optional<RcString> ToNamespacePrefix(const XMLQualifiedName& name) {
+    if (name.namespacePrefix.empty() && name.name == "xmlns") {
+      // Default namespace declaration
+      return RcString("");
+    } else if (name.namespacePrefix == "xmlns") {
+      // Namespace declaration with prefix
+      return name.name;
     }
 
     return std::nullopt;
   }
 
-private:
-  SmallVector<Entity, 8> getParents(Registry& registry, Entity entity) const {
-    SmallVector<Entity, 8> result;
-    while (entity != entt::null) {
-      result.push_back(entity);
-      if (const auto* tree = registry.try_get<donner::components::TreeComponent>(entity)) {
-        entity = tree->parent();
-      } else {
-        entity = entt::null;
-      }
-    }
-    return result;
+  /// The scope used by elements with no namespace declarations anywhere above them.
+  static const std::shared_ptr<const ScopeMap>& EmptyScope() {
+    static const std::shared_ptr<const ScopeMap> kEmpty = std::make_shared<const ScopeMap>();
+    return kEmpty;
   }
 
-  /// Called when an entity is destroyed.
-  void onEntityDestroy(Registry& registry, Entity entity) {
-    const auto& attributes = registry.get<donner::components::AttributesComponent>(entity);
-    if (attributes.hasNamespaceOverrides()) {
-      // Remove all entries with this entity.
-      for (auto it = namespaceEntries_.begin(); it != namespaceEntries_.end();) {
-        if (it->second.entity == entity) {
-          it = namespaceEntries_.erase(it);
-        } else {
-          ++it;
+  /**
+   * Return every prefix in scope for \p entity, computing and caching it if needed.
+   *
+   * Resolving walks up to the nearest ancestor that already has a cached scope and then extends
+   * it downwards, so a document costs one ancestor walk in total rather than one per lookup.
+   *
+   * @param registry Registry to use for the lookup.
+   * @param entity Entity to resolve the scope for.
+   */
+  const std::shared_ptr<const ScopeMap>& resolveScope(Registry& registry, Entity entity) const {
+    if (entity == entt::null) {
+      return EmptyScope();
+    }
+
+    // Walk up until we reach a cached scope or run out of ancestors.
+    SmallVector<Entity, 8> pending;
+    const std::shared_ptr<const ScopeMap>* nearestCached = &EmptyScope();
+
+    Entity current = entity;
+    while (current != entt::null) {
+      const auto it = scopeCache_.find(current);
+      if (it != scopeCache_.end()) {
+        nearestCached = &it->second;
+        break;
+      }
+
+      pending.push_back(current);
+      if (const auto* tree = registry.try_get<donner::components::TreeComponent>(current)) {
+        current = tree->parent();
+      } else {
+        current = entt::null;
+      }
+    }
+
+    // Extend that scope back down towards `entity`, caching each level on the way.
+    std::shared_ptr<const ScopeMap> scope = *nearestCached;
+    for (size_t i = pending.size(); i > 0; --i) {
+      const Entity pendingEntity = pending[i - 1];
+      scope = extendScope(registry, pendingEntity, std::move(scope));
+      scopeCache_.insert_or_assign(pendingEntity, scope);
+      ++scopeResolutionCount_;
+    }
+
+    // `entity` is either the deepest entry just cached, or was already cached.
+    const auto it = scopeCache_.find(entity);
+    return it != scopeCache_.end() ? it->second : *nearestCached;
+  }
+
+  /**
+   * Layer \p entity's own namespace declarations over \p parentScope.
+   *
+   * Elements that declare nothing share the parent's scope instead of copying it, so a document
+   * that declares `xmlns` only on the root holds a single map.
+   *
+   * @param registry Registry to use for the lookup.
+   * @param entity Entity whose declarations are applied.
+   * @param parentScope Scope inherited from the entity's ancestors.
+   */
+  std::shared_ptr<const ScopeMap> extendScope(Registry& registry, Entity entity,
+                                              std::shared_ptr<const ScopeMap> parentScope) const {
+    const auto* attributes = registry.try_get<donner::components::AttributesComponent>(entity);
+    if (attributes == nullptr || !attributes->hasNamespaceOverrides()) {
+      return parentScope;
+    }
+
+    const auto it = declarations_.find(entity);
+    if (it == declarations_.end() || it->second.empty()) {
+      return parentScope;
+    }
+
+    auto extended = std::make_shared<ScopeMap>(*parentScope);
+    for (const auto& [prefix, uri] : it->second) {
+      extended->insert_or_assign(prefix, uri);
+    }
+
+    return extended;
+  }
+
+  /// Drop all cached scopes, after a declaration change that may apply anywhere below the
+  /// declaring element.
+  void invalidateScopes() { scopeCache_.clear(); }
+
+  /// Drop cached scopes for \p entity and everything below it.
+  void invalidateSubtreeScopes(Registry& registry, Entity entity) {
+    if (scopeCache_.empty()) {
+      return;
+    }
+
+    SmallVector<Entity, 16> stack;
+    stack.push_back(entity);
+
+    while (!stack.empty()) {
+      const Entity current = stack.back();
+      stack.pop_back();
+      scopeCache_.erase(current);
+
+      if (const auto* tree = registry.try_get<donner::components::TreeComponent>(current)) {
+        for (Entity child = tree->firstChild(); child != entt::null;) {
+          stack.push_back(child);
+          child = registry.get<donner::components::TreeComponent>(child).nextSibling();
         }
       }
     }
   }
 
-  /// Entry storing the entity and URI for a given namespace override.
-  struct NamespaceEntry {
-    Entity entity;  ///< Entity that has the namespace override.
-    RcString uri;   ///< URI for the namespace.
-  };
+  /// Called when an entity is destroyed.
+  void onEntityDestroy(Registry& registry, Entity entity) {
+    scopeCache_.erase(entity);
 
-  /// Mapping from ID to entity.
-  std::multimap<RcString, NamespaceEntry> namespaceEntries_;
+    const auto& attributes = registry.get<donner::components::AttributesComponent>(entity);
+    if (attributes.hasNamespaceOverrides()) {
+      declarations_.erase(entity);
+      invalidateScopes();
+    }
+  }
+
+  /// Namespace declarations made by each element that has any.
+  std::unordered_map<Entity, DeclarationMap, EntityHash> declarations_;
+
+  /**
+   * Resolved scopes, rebuilt on demand after any declaration or tree-structure change.
+   *
+   * Entries are keyed by entity and evicted three ways: a tree change drops the moved subtree, a
+   * declaration change drops everything, and destroying an entity's AttributesComponent drops
+   * that entity. The last one does not cover an ancestor that never had an AttributesComponent
+   * (it is only added on first attribute access), so such an entry can outlive its entity. That
+   * is safe rather than merely unlikely: removing a node from the tree already drops its
+   * subtree, and entt bumps an entity's version when the id is released, so a recycled id is a
+   * different key and can never hit a stale entry.
+   */
+  mutable std::unordered_map<Entity, std::shared_ptr<const ScopeMap>, EntityHash> scopeCache_;
+
+  /// Counts entities whose scope was computed rather than read from \ref scopeCache_.
+  mutable std::uint64_t scopeResolutionCount_ = 0;
 };
 
 }  // namespace donner::xml::components

--- a/donner/base/xml/components/tests/AttributesComponent_tests.cc
+++ b/donner/base/xml/components/tests/AttributesComponent_tests.cc
@@ -268,6 +268,39 @@ TEST(AttributesComponent, NamespaceAfterReparenting) {
               testing::Eq(std::nullopt));
 }
 
+TEST(AttributesComponent, NamespaceOverrideCountedPerDeclarationNotPerWrite) {
+  Registry registry;
+  auto& namespaceContext = registry.ctx().emplace<XMLNamespaceContext>(registry);
+
+  Entity parent = registry.create();
+  AttributesComponent& parentAttributes = registry.emplace<AttributesComponent>(parent);
+
+  Entity child = registry.create();
+  AttributesComponent& childAttributes = registry.emplace<AttributesComponent>(child);
+
+  {
+    auto& parentTree = registry.emplace<TreeComponent>(parent, "parent");
+    registry.emplace<TreeComponent>(child, "child");
+    parentTree.appendChild(registry, child);
+  }
+
+  parentAttributes.setAttribute(registry, XMLQualifiedNameRef("", "xmlns"),
+                                "https://example.com/parent");
+
+  // Writing the same declaration twice is still one declaration.
+  childAttributes.setAttribute(registry, XMLQualifiedNameRef("", "xmlns"),
+                               "https://example.com/child");
+  childAttributes.setAttribute(registry, XMLQualifiedNameRef("", "xmlns"),
+                               "https://example.com/child2");
+  EXPECT_TRUE(childAttributes.hasNamespaceOverrides());
+  EXPECT_EQ(namespaceContext.getNamespaceUri(registry, child, ""), "https://example.com/child2");
+
+  // Removing it leaves the element with no declarations, so the parent's applies again.
+  childAttributes.removeAttribute(registry, XMLQualifiedNameRef("", "xmlns"));
+  EXPECT_FALSE(childAttributes.hasNamespaceOverrides());
+  EXPECT_EQ(namespaceContext.getNamespaceUri(registry, child, ""), "https://example.com/parent");
+}
+
 TEST(AttributesComponent, NamespaceAfterInsertBefore) {
   Registry registry;
   auto& namespaceContext = registry.ctx().emplace<XMLNamespaceContext>(registry);

--- a/donner/base/xml/components/tests/AttributesComponent_tests.cc
+++ b/donner/base/xml/components/tests/AttributesComponent_tests.cc
@@ -3,6 +3,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cstdint>
+
 #include "donner/base/xml/XMLQualifiedName.h"
 #include "donner/base/xml/components/TreeComponent.h"
 #include "donner/base/xml/components/XMLNamespaceContext.h"
@@ -222,6 +224,124 @@ TEST(AttributesComponent, NamespaceEntityDelete) {
   // Destroy the entity and check the parent
   registry.destroy(child);
   EXPECT_EQ(namespaceContext.getNamespaceUri(registry, parent, ""), "https://example.com");
+}
+
+TEST(AttributesComponent, NamespaceAfterReparenting) {
+  Registry registry;
+  auto& namespaceContext = registry.ctx().emplace<XMLNamespaceContext>(registry);
+
+  const auto createNode = [&registry](const char* tagName) {
+    const Entity entity = registry.create();
+    registry.emplace<AttributesComponent>(entity);
+    registry.emplace<TreeComponent>(entity, tagName);
+    return entity;
+  };
+
+  const Entity firstParent = createNode("first");
+  const Entity secondParent = createNode("second");
+  const Entity child = createNode("child");
+  const Entity grandchild = createNode("grandchild");
+
+  registry.get<TreeComponent>(child).appendChild(registry, grandchild);
+  registry.get<TreeComponent>(firstParent).appendChild(registry, child);
+
+  registry.get<AttributesComponent>(firstParent)
+      .setAttribute(registry, XMLQualifiedNameRef("", "xmlns"), "https://example.com/first");
+  registry.get<AttributesComponent>(secondParent)
+      .setAttribute(registry, XMLQualifiedNameRef("", "xmlns"), "https://example.com/second");
+
+  EXPECT_EQ(namespaceContext.getNamespaceUri(registry, child, ""), "https://example.com/first");
+  EXPECT_EQ(namespaceContext.getNamespaceUri(registry, grandchild, ""),
+            "https://example.com/first");
+
+  // Moving the child moves the whole subtree into the second parent's namespace scope, so a
+  // resolution cached under the first parent must not survive the move.
+  registry.get<TreeComponent>(secondParent).appendChild(registry, child);
+  EXPECT_EQ(namespaceContext.getNamespaceUri(registry, child, ""), "https://example.com/second");
+  EXPECT_EQ(namespaceContext.getNamespaceUri(registry, grandchild, ""),
+            "https://example.com/second");
+
+  // Detaching leaves the subtree with no declaration in scope at all.
+  registry.get<TreeComponent>(child).remove(registry);
+  EXPECT_THAT(namespaceContext.getNamespaceUri(registry, child, ""), testing::Eq(std::nullopt));
+  EXPECT_THAT(namespaceContext.getNamespaceUri(registry, grandchild, ""),
+              testing::Eq(std::nullopt));
+}
+
+TEST(AttributesComponent, NamespaceAfterInsertBefore) {
+  Registry registry;
+  auto& namespaceContext = registry.ctx().emplace<XMLNamespaceContext>(registry);
+
+  const auto createNode = [&registry](const char* tagName) {
+    const Entity entity = registry.create();
+    registry.emplace<AttributesComponent>(entity);
+    registry.emplace<TreeComponent>(entity, tagName);
+    return entity;
+  };
+
+  const Entity firstParent = createNode("first");
+  const Entity secondParent = createNode("second");
+  const Entity moved = createNode("moved");
+  const Entity reference = createNode("reference");
+
+  registry.get<TreeComponent>(firstParent).appendChild(registry, moved);
+  registry.get<TreeComponent>(secondParent).appendChild(registry, reference);
+
+  registry.get<AttributesComponent>(firstParent)
+      .setAttribute(registry, XMLQualifiedNameRef("", "xmlns"), "https://example.com/first");
+  registry.get<AttributesComponent>(secondParent)
+      .setAttribute(registry, XMLQualifiedNameRef("", "xmlns"), "https://example.com/second");
+
+  EXPECT_EQ(namespaceContext.getNamespaceUri(registry, moved, ""), "https://example.com/first");
+
+  registry.get<TreeComponent>(secondParent).insertBefore(registry, moved, reference);
+  EXPECT_EQ(namespaceContext.getNamespaceUri(registry, moved, ""), "https://example.com/second");
+}
+
+TEST(AttributesComponent, NamespaceCacheSurvivesUnrelatedTreeChange) {
+  Registry registry;
+  auto& namespaceContext = registry.ctx().emplace<XMLNamespaceContext>(registry);
+
+  const auto createNode = [&registry](const char* tagName) {
+    const Entity entity = registry.create();
+    registry.emplace<AttributesComponent>(entity);
+    registry.emplace<TreeComponent>(entity, tagName);
+    return entity;
+  };
+
+  const Entity root = createNode("root");
+  const Entity keptBranch = createNode("kept");
+  const Entity keptLeaf = createNode("keptLeaf");
+  const Entity movedBranch = createNode("moved");
+  const Entity otherParent = createNode("other");
+
+  registry.get<TreeComponent>(root).appendChild(registry, keptBranch);
+  registry.get<TreeComponent>(keptBranch).appendChild(registry, keptLeaf);
+  registry.get<TreeComponent>(root).appendChild(registry, movedBranch);
+
+  registry.get<AttributesComponent>(root).setAttribute(
+      registry, XMLQualifiedNameRef("", "xmlns"), "https://example.com/root");
+
+  // Warm the cache for the branch that is about to be left alone.
+  EXPECT_EQ(namespaceContext.getNamespaceUri(registry, keptLeaf, ""), "https://example.com/root");
+  const std::uint64_t warmed = namespaceContext.scopeResolutionCountForTesting();
+  EXPECT_GT(warmed, 0u);
+
+  // A cached lookup must not recompute anything.
+  EXPECT_EQ(namespaceContext.getNamespaceUri(registry, keptLeaf, ""), "https://example.com/root");
+  EXPECT_EQ(namespaceContext.scopeResolutionCountForTesting(), warmed);
+
+  // Moving an unrelated sibling must not throw away the cached branch. Blanket invalidation
+  // would still answer correctly here, but it would recompute, which is what costs parse time
+  // when a document has a text node between every element.
+  registry.get<TreeComponent>(otherParent).appendChild(registry, movedBranch);
+  EXPECT_EQ(namespaceContext.getNamespaceUri(registry, keptLeaf, ""), "https://example.com/root");
+  EXPECT_EQ(namespaceContext.scopeResolutionCountForTesting(), warmed);
+
+  // The moved subtree itself does have to be recomputed.
+  EXPECT_THAT(namespaceContext.getNamespaceUri(registry, movedBranch, ""),
+              testing::Eq(std::nullopt));
+  EXPECT_GT(namespaceContext.scopeResolutionCountForTesting(), warmed);
 }
 
 }  // namespace donner::components

--- a/donner/svg/parser/BUILD.bazel
+++ b/donner/svg/parser/BUILD.bazel
@@ -118,12 +118,13 @@ donner_cc_test(
         "tests/PointsListParser_tests.cc",
         "tests/PreserveAspectRatioParser_tests.cc",
         "tests/SVGParser_tests.cc",
+        "tests/SVGParserContext_tests.cc",
         "tests/SetElement_tests.cc",
         "tests/TransformParser_tests.cc",
         "tests/ViewBoxParser_tests.cc",
     ],
-    # Variant lanes (doc 0031 M2.3): tiny / text_full / geode
-    # wrappers run automatically under `bazel test //...`.
+    # Variant lanes: the tiny / text_full / geode wrappers run automatically under
+    # `bazel test //...`.
     variants = [
         "tiny",
         "text_full",
@@ -132,6 +133,7 @@ donner_cc_test(
     deps = [
         ":parser",
         ":parser_core",
+        ":parser_details",
         "//donner/base:base_test_utils",
         "//donner/css/parser",
         "//donner/svg/components/animation:animation_system",

--- a/donner/svg/parser/SVGParser.cc
+++ b/donner/svg/parser/SVGParser.cc
@@ -339,15 +339,28 @@ public:
 
   std::optional<SVGDocument> document() const { return document_; }
 
+  /**
+   * Create the SVG element matching \p tagName on \p node, or an unknown element if no type
+   * matches.
+   *
+   * @param tagName Qualified tag name to match against the known element types.
+   * @param node XML node to create the element on.
+   * @param isSvgNamespace Whether the tag name's prefix resolves to the SVG namespace. Resolved
+   *   once by the caller rather than once per candidate type, since it is the same answer for
+   *   every candidate.
+   */
+  ParseResult<SVGElement> createElement(const XMLQualifiedNameRef& tagName, const XMLNode& node,
+                                        bool isSvgNamespace) {
+    return createElement(tagName, node, isSvgNamespace, AllSVGElements());
+  }
+
   template <size_t I = 0, typename... Types>
   ParseResult<SVGElement> createElement(const XMLQualifiedNameRef& tagName, const XMLNode& node,
-                                        entt::type_list<Types...>) {
+                                        bool isSvgNamespace, entt::type_list<Types...>) {
     if constexpr (I != sizeof...(Types)) {
       using ElementT = std::tuple_element<I, std::tuple<Types...>>::type;
 
-      // TODO: A faster way to lookup Uris
-      if (node.getNamespaceUri(tagName.namespacePrefix) == "http://www.w3.org/2000/svg" &&
-          tagName.name == ElementT::Tag) {
+      if (isSvgNamespace && tagName.name == ElementT::Tag) {
         if constexpr (IsExperimental<ElementT>()) {
           if (context_.options().enableExperimental) {
             auto element = ElementT::CreateOn(node.entityHandle());
@@ -362,7 +375,7 @@ public:
         }
       }
 
-      return createElement<I + 1>(tagName, node, entt::type_list<Types...>());
+      return createElement<I + 1>(tagName, node, isSvgNamespace, entt::type_list<Types...>());
     } else {
       auto element = SVGUnknownElement::CreateOn(node.entityHandle(), tagName);
       return ParseAttributes(context_, element, node);
@@ -408,7 +421,9 @@ public:
           continue;
         }
 
-        auto maybeNewElement = createElement(child->tagName(), child.value(), AllSVGElements());
+        // The namespace check above already resolved this tag name's prefix.
+        auto maybeNewElement =
+            createElement(child->tagName(), child.value(), /*isSvgNamespace=*/true);
         if (maybeNewElement.hasError()) {
           return std::move(maybeNewElement.error());
         }

--- a/donner/svg/parser/details/SVGParserContext.h
+++ b/donner/svg/parser/details/SVGParserContext.h
@@ -66,9 +66,11 @@ public:
    * @return ParseDiagnostic Remapped error.
    */
   ParseDiagnostic fromSubparser(ParseDiagnostic&& error, ParserOrigin origin) {
-    const size_t line = lineOffsets_.offsetToLine(origin.startOffset);
-    const FileOffset parentOffset = FileOffset::OffsetWithLineInfo(
-        origin.startOffset, FileOffset::LineInfo{line, lineOffsets_.lineOffset(line)});
+    // LineInfo::offsetOnLine is a column within its line, not a byte offset into the file.
+    // fileOffset() computes both halves consistently; passing the line's own start offset as the
+    // column instead shifts every diagnostic on line 2 or later by the length of all preceding
+    // lines.
+    const FileOffset parentOffset = lineOffsets_.fileOffset(origin.startOffset);
 
     ParseDiagnostic newError = std::move(error);
     newError.range.start = newError.range.start.addParentOffset(parentOffset);

--- a/donner/svg/parser/tests/SVGParserContext_tests.cc
+++ b/donner/svg/parser/tests/SVGParserContext_tests.cc
@@ -1,0 +1,81 @@
+/**
+ * Tests for SVGParserContext: verifies that diagnostics produced by subparsers are remapped back
+ * into the coordinates of the original SVG source.
+ */
+
+#include "donner/svg/parser/details/SVGParserContext.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string_view>
+
+#include "donner/base/FileOffset.h"
+#include "donner/base/ParseDiagnostic.h"
+#include "donner/base/ParseWarningSink.h"
+#include "donner/base/tests/ParseResultTestUtils.h"
+
+namespace donner::svg::parser {
+
+namespace {
+
+/// Three lines, so that line starts (0, 4, 9) are distinct from column offsets.
+constexpr std::string_view kInput = "aaa\nbbbb\ncccccc";
+
+/// Build a diagnostic at \p offset within a subparser's own input, with no line information,
+/// which is what a subparser that only sees its own substring produces.
+ParseDiagnostic SubparserError(size_t offset) {
+  ParseDiagnostic error;
+  error.reason = "subparser failure";
+  error.range.start = FileOffset::Offset(offset);
+  error.range.end = FileOffset::Offset(offset);
+  return error;
+}
+
+}  // namespace
+
+TEST(SVGParserContext, FromSubparserReportsColumnWithinLine) {
+  ParseWarningSink warnings;
+  SVGParser::Options options;
+  SVGParserContext context(kInput, warnings, options);
+
+  // Offset 11 is on line 3, column 2. A subparser error three characters into its input is
+  // therefore at line 3, column 5, not at column 9 (the byte offset where line 3 starts).
+  const ParseDiagnostic remapped =
+      context.fromSubparser(SubparserError(3), ParserOrigin::StartOffset(11));
+
+  EXPECT_THAT(remapped.range.start, ParseErrorPos(3, 5));
+  EXPECT_EQ(remapped.range.start.offset, 14u);
+}
+
+TEST(SVGParserContext, FromSubparserOnFirstLine) {
+  ParseWarningSink warnings;
+  SVGParser::Options options;
+  SVGParserContext context(kInput, warnings, options);
+
+  const ParseDiagnostic remapped =
+      context.fromSubparser(SubparserError(2), ParserOrigin::StartOffset(1));
+
+  EXPECT_THAT(remapped.range.start, ParseErrorPos(1, 3));
+  EXPECT_EQ(remapped.range.start.offset, 3u);
+}
+
+TEST(SVGParserContext, FromSubparserWithMultiLineSubparserError) {
+  ParseWarningSink warnings;
+  SVGParser::Options options;
+  SVGParserContext context(kInput, warnings, options);
+
+  // A subparser error on the subparser's own second line lands on the line after the origin's,
+  // and keeps the subparser's own column.
+  ParseDiagnostic error;
+  error.reason = "subparser failure";
+  error.range.start = FileOffset::OffsetWithLineInfo(6, FileOffset::LineInfo{2, 1});
+  error.range.end = error.range.start;
+
+  const ParseDiagnostic remapped =
+      context.fromSubparser(std::move(error), ParserOrigin::StartOffset(11));
+
+  EXPECT_THAT(remapped.range.start, ParseErrorPos(4, 1));
+}
+
+}  // namespace donner::svg::parser


### PR DESCRIPTION
Cuts SVG parse time roughly 35 percent on real documents (Ghostscript Tiger 15.3 to 9.8 ms, lion 3.3 to 2.2 ms, measured interleaved against the parent revision) by fixing the two dominant parse hotspots.

Source line numbers resolve lazily: the parser previously returned its newline-offset table BY VALUE roughly nine times per element, copying the whole vector each call, and computed line and column eagerly for every node and attribute. Offsets are now stored bare and resolved to line and column only at diagnostic construction, through a version-invalidated line table on the source store. Diagnostics are byte-identical: every parse error and warning path carries the same line and column values as before, pinned by the existing position-asserting tests, and node location getters return the same values through the lazy path.

Namespace resolution caches per element: resolving a name walked the ancestor chain per attribute, and the element-creation type walk repeated that resolution roughly one hundred times per element. Declarations now live in a per-entity map with shared resolved scopes (an element declaring nothing shares its parent's map), one ancestor walk per document, copy-on-write on declaration, whole-cache invalidation on declaration changes, and subtree-scoped invalidation on tree moves so the parser's whitespace stripping keeps the cache warm. Semantics are exact (nearest declaring ancestor wins, self shadows, empty URI stays a declaration), pinned by reparenting tests including a resolution-count guard that fails if subtree invalidation regresses to blanket clearing.

Two pre-existing parser bugs found during review are fixed with red-then-green tests: subparser diagnostics reported the line's absolute start offset as their column (now computed consistently from the origin offset), and repeated writes to the same xmlns attribute inflated the namespace-override count so removal left the element claiming overrides it no longer had.

Verification: full repository suite green in both default and geode configurations, parser and XML suites green, lint and CMake mirror checks green.
