### PR TITLE
docs: Reference ThorVG as a related project

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,5 +222,6 @@ See the [CMake Documentation](https://jwmcglynn.github.io/donner/BuildingDonner.
 ## Other Libraries
 
 - C++ | **[LunaSVG](https://github.com/sammycage/lunasvg)**: A lightweight library with an embedded renderer, suitable for embedded applications
+- C++ | **[ThorVG](https://github.com/thorvg/thorvg)**: A production vector graphics engine with software, OpenGL/ES, and WebGPU backends and Lottie support; targets SVG Tiny 1.2 rather than full SVG, so it is not as fully featured an SVG renderer as Donner or resvg
 - Rust | **[librsvg](https://gitlab.gnome.org/GNOME/librsvg)**: Provides a simple way to render SVGs one-shot, does not provide a DOM or animation
 - Rust | **[resvg](https://github.com/RazrFalcon/resvg)**: Library that focuses on correctness, safety, and portability for static SVGs


### PR DESCRIPTION
Adds ThorVG to the Other Libraries section of the README as a related project: a production C++ vector graphics engine with software, OpenGL/ES, and WebGPU backends and Lottie support. The entry notes its SVG Tiny 1.2 target, since it is not as fully featured an SVG renderer as Donner or resvg, keeping the comparison honest in both directions. Entry formatting matches the existing list style, and the C++ group stays alphabetical.