### PR TITLE
docs: Reference NanoSVG, Vello, and Apache Batik as related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,5 +223,8 @@ See the [CMake Documentation](https://jwmcglynn.github.io/donner/BuildingDonner.
 
 - C++ | **[LunaSVG](https://github.com/sammycage/lunasvg)**: A lightweight library with an embedded renderer, suitable for embedded applications
 - C++ | **[ThorVG](https://github.com/thorvg/thorvg)**: A production vector graphics engine with software, OpenGL/ES, and WebGPU backends and Lottie support; targets SVG Tiny 1.2 rather than full SVG, so it is not as fully featured an SVG renderer as Donner or resvg
+- C | **[NanoSVG](https://github.com/memononen/nanosvg)**: A minimal single-header SVG parser and rasterizer, widely embedded where footprint matters; supports a small subset of SVG
 - Rust | **[librsvg](https://gitlab.gnome.org/GNOME/librsvg)**: Provides a simple way to render SVGs one-shot, does not provide a DOM or animation
 - Rust | **[resvg](https://github.com/RazrFalcon/resvg)**: Library that focuses on correctness, safety, and portability for static SVGs
+- Rust | **[Vello](https://github.com/linebender/vello)**: A GPU compute-centric 2D renderer from the Linebender ecosystem; renders SVG through companion crates rather than natively
+- Java | **[Apache Batik](https://xmlgraphics.apache.org/batik/)**: A full dynamic SVG implementation with DOM, scripting, and declarative animation; the closest reference for browser-style dynamic SVG outside a browser engine


### PR DESCRIPTION
Extends the Other Libraries section with three more related projects, each with the same honest one-line treatment as the existing entries: NanoSVG (minimal single-header C parser and rasterizer for footprint-sensitive embedding), Vello (GPU compute-centric 2D renderer from the Linebender ecosystem, SVG via companion crates), and Apache Batik (full dynamic SVG with DOM, scripting, and declarative animation, the closest reference for browser-style dynamic SVG outside a browser engine). Groups stay language-clustered and alphabetical within each group.

Note: the self-hosted CI lanes are currently red on main from a counter-ratchet interaction between two merged optimizations (fix in flight in a separate branch); this docs-only change should be re-checked once that lands.