### PR TITLE
docs: Add Lottie playback to the v1.0 roadmap

### DIFF
--- a/docs/ProjectRoadmap.md
+++ b/docs/ProjectRoadmap.md
@@ -169,6 +169,10 @@ Focus: interactive editing, conformance, parser hardening, and ecosystem integra
 
 - Phases 1–9: timing model, interpolation engine, sandwich composition, attribute targeting,
   `<animate>`, `<animateTransform>`, `<animateMotion>`, `<set>`, event-based timing.
+- [ ] **Lottie playback (probable)** -- Play back Lottie animations (the JSON-based After
+      Effects export format, `.json`/`.lottie`) on top of the same animation timeline
+      machinery. Lottie is the dominant interchange format for production vector animation,
+      and runtimes such as ThorVG and dotLottie demonstrate the demand.
 
 ### Composited Rendering
 


### PR DESCRIPTION
Adds Lottie playback to the v1.0 milestone's SVG Animation section as a probable item: playing back the JSON-based After Effects export format on top of the same animation timeline machinery. Lottie is the dominant interchange format for production vector animation, and runtimes such as ThorVG and dotLottie demonstrate the demand.

Stacked on the counter-ratchet fix so CI runs against a green base; retargets to main automatically when that merges.