### PR TITLE
perf: Pin the donner-svg CLI to the CPU renderer backend

### DIFF
--- a/docs/donner_svg_tool.dox
+++ b/docs/donner_svg_tool.dox
@@ -13,6 +13,15 @@
  * tools/donner-svg input.svg
  * ```
  *
+ * @section DonnerSvgToolBackend Rendering backend
+ *
+ * `donner-svg` always renders with Donner's CPU (tiny-skia) backend, under
+ * every build configuration. A one-shot command-line render cannot amortize
+ * the GPU backend's fixed device and shader setup cost, so the CPU backend
+ * is strictly better for single-frame output. The GPU (Geode) backend is
+ * Donner's interactive renderer, used by long-lived surfaces such as the
+ * editor where that setup cost is paid once across many frames.
+ *
  * @section DonnerSvgToolFlags Common flags
  *
  * - `--output <png>`: Output filename (default `output.png`).

--- a/donner/svg/tool/BUILD.bazel
+++ b/donner/svg/tool/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//build_defs:package.bzl", "donner_package")
+load("//build_defs:dep_audit.bzl", "forbidden_transitive_dep_test")
 load("//build_defs:rules.bzl", "donner_cc_binary", "donner_cc_library", "donner_cc_test")
 
 alias(
@@ -40,7 +41,14 @@ donner_cc_library(
         ":donner_svg_tool_utils",
         "//donner/base:diagnostic_renderer",
         "//donner/svg",
-        "//donner/svg/renderer",
+        # The CLI renders exactly one frame per invocation, so the GPU
+        # backend's fixed device and shader setup cost can never amortize;
+        # the CPU (tiny-skia) backend is strictly faster for one-shot
+        # rendering. Depend on the CPU backend directly instead of the
+        # config-selected //donner/svg/renderer dispatcher so the CLI never
+        # links the GPU stack, under any build config. Enforced by
+        # :donner_svg_excludes_geode_audit below.
+        "//donner/svg/renderer:renderer_tiny_skia",
         "//donner/svg/renderer:terminal_image_viewer",
     ],
 )
@@ -63,6 +71,23 @@ donner_cc_test(
         ":donner_svg_tool_lib",
         "@com_google_gtest//:gtest_main",
     ],
+)
+
+# The one-shot CLI must never link the GPU (Geode) backend: a single
+# rendered frame cannot amortize GPU device and shader setup, so the CPU
+# backend is the CLI renderer under every build config, including
+# --config=geode. somepath() over the unconfigured graph is meaningful
+# here because nothing in the CLI's dep list reaches the config-selected
+# //donner/svg/renderer dispatcher (see build_defs/dep_audit.bzl).
+forbidden_transitive_dep_test(
+    name = "donner_svg_excludes_geode_audit",
+    size = "small",
+    forbidden = "//donner/svg/renderer:renderer_geode",
+    tags = [
+        "audit",
+        "deps",
+    ],
+    target = "//donner/svg/tool:donner-svg",
 )
 
 donner_package()

--- a/donner/svg/tool/DonnerSvgTool.cc
+++ b/donner/svg/tool/DonnerSvgTool.cc
@@ -31,8 +31,8 @@
 #include "donner/svg/SVGGeometryElement.h"
 #include "donner/svg/SVGPathElement.h"
 #include "donner/svg/SVGTextElement.h"
-#include "donner/svg/renderer/Renderer.h"
 #include "donner/svg/renderer/RendererInterface.h"
+#include "donner/svg/renderer/RendererTinySkia.h"
 #include "donner/svg/renderer/TerminalImageViewer.h"
 #include "donner/svg/resources/SandboxedFileResourceLoader.h"
 #include "donner/svg/tool/DonnerSvgToolUtils.h"
@@ -371,7 +371,7 @@ std::optional<Box2d> GraphicsWorldBounds(const SVGGraphicsElement& element) {
   return std::nullopt;
 }
 
-RendererBitmap CreateHighlightBitmap(SVGDocument& document, Renderer& renderer,
+RendererBitmap CreateHighlightBitmap(SVGDocument& document, RendererTinySkia& renderer,
                                      const SVGGraphicsElement& element,
                                      const SampledImageInfo& imageInfo) {
   const auto maybeSpline = element.isa<SVGGeometryElement>()
@@ -471,8 +471,8 @@ void RedrawImage(const TerminalImageView& view, int imageRows, std::ostream& out
 }
 
 /** Run mouse-driven terminal selection UI. */
-void RunInteractiveSelection(SVGDocument document, Renderer& renderer, const RendererBitmap& bitmap,
-                             std::ostream& out, std::ostream& err) {
+void RunInteractiveSelection(SVGDocument document, RendererTinySkia& renderer,
+                             const RendererBitmap& bitmap, std::ostream& out, std::ostream& err) {
   const SampledImageInfo imageInfo = RenderPreview(bitmap, /*interactive=*/true, out, err);
 
   // The status line sits directly after the image. renderSampled's last row ends with \n,
@@ -606,7 +606,12 @@ int RunDonnerSvgTool(int argc, char* argv[], std::ostream& out, std::ostream& er
   SVGDocument document = std::move(*maybeDocument);
   ApplyCanvasSize(options, &document);
 
-  Renderer renderer(options.verbose);
+  // donner-svg always renders on the CPU (tiny-skia) backend. A one-shot
+  // command-line render cannot amortize the GPU backend's fixed device and
+  // shader setup cost, so the CPU raster path is strictly faster for
+  // single-frame output. The GPU backend serves interactive, multi-frame
+  // rendering such as the editor.
+  RendererTinySkia renderer(options.verbose);
   renderer.draw(document);
 
   const bool shouldSavePng = options.outputFileSet || !options.preview;


### PR DESCRIPTION
Makes the one-shot donner-svg CLI depend on the tiny-skia CPU renderer directly instead of the config-selected renderer dispatcher, so it never links the GPU stack under any build configuration. A single rendered frame cannot amortize the GPU backend's fixed device and shader setup cost, so the CPU raster path is strictly faster for command-line output; the GPU backend remains the interactive and editor renderer.

The dependency boundary is enforced by a new forbidden_transitive_dep_test audit, mirroring the existing convention that keeps the GPU backend from linking the CPU one. Under the geode build config the CLI binary previously required the wgpu shared library and carried 332 wgpu symbols; it now carries none in any configuration. Benchmarks and test harnesses keep their multi-backend selection unchanged.

Stacked on the counter-ratchet fix so CI runs against a green base.