### PR TITLE
fix: Bound every native GPU wait and surface device loss

### DIFF
--- a/donner/editor/gui/BUILD.bazel
+++ b/donner/editor/gui/BUILD.bazel
@@ -84,6 +84,7 @@ donner_cc_library(
     ] + select({
         "//donner/editor:wasm_geode_enabled": [
             "//donner/svg/renderer/geode:geode_device",
+            "//donner/svg/renderer/geode:geode_gpu_wait",
             "//donner/svg/renderer/geode:geode_wgpu_util",
             "//third_party/emscripten-glfw",
             "//third_party/webgpu-cpp:webgpu_cpp",
@@ -92,6 +93,7 @@ donner_cc_library(
         "//donner/svg/renderer:renderer_backend_geode": [
             ":editor_wgpu_surface",
             "//donner/svg/renderer/geode:geode_device",
+            "//donner/svg/renderer/geode:geode_gpu_wait",
             "//donner/svg/renderer/geode:geode_wgpu_util",
             "//third_party/webgpu-cpp:webgpu_cpp",
             "@glfw",

--- a/donner/editor/gui/EditorWindow.cc
+++ b/donner/editor/gui/EditorWindow.cc
@@ -52,6 +52,7 @@ extern "C" {
 #endif
 #include "donner/svg/renderer/geode/GeodeCallbackState.h"
 #include "donner/svg/renderer/geode/GeodeDevice.h"
+#include "donner/svg/renderer/geode/GeodeGpuWait.h"
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 #endif
 
@@ -117,6 +118,29 @@ void OnEditorWgpuUncapturedError(WGPUDevice const* /*device*/, WGPUErrorType typ
   std::fprintf(stderr, "[Editor/WGPU] Uncaptured error (type=%d): %.*s\n", static_cast<int>(type),
                static_cast<int>(message.length), message.data ? message.data : "");
 }
+
+#ifndef __EMSCRIPTEN__
+/// Device-lost callback for the editor's WebGPU device. `userdata1` carries a
+/// retained shared reference to the lost-state flag that both Geode device
+/// wrappers built on this device observe, so a driver-reported loss and a
+/// bounded GPU wait timing out inside Geode converge on the same detectable
+/// condition. Fires at most once per device; a spontaneous delivery can
+/// outlive the EditorWindow, hence the retained shared state.
+void OnEditorWgpuDeviceLost(WGPUDevice const* /*device*/, WGPUDeviceLostReason reason,
+                            WGPUStringView message, void* userdata1, void* /*userdata2*/) {
+  const std::shared_ptr<donner::geode::GeodeDeviceLostState> state =
+      donner::geode::takeWgpuCallbackState<donner::geode::GeodeDeviceLostState>(userdata1);
+  if (reason == WGPUDeviceLostReason_Destroyed || reason == WGPUDeviceLostReason_InstanceDropped) {
+    // Expected teardown paths, not a driver failure.
+    return;
+  }
+  std::fprintf(stderr, "[Editor/WGPU] Device lost (reason=%d): %.*s\n", static_cast<int>(reason),
+               static_cast<int>(message.length), message.data ? message.data : "");
+  if (state) {
+    state->lost.store(true, std::memory_order_release);
+  }
+}
+#endif
 
 wgpu::Instance CreateEditorWgpuInstance() {
 #ifdef __EMSCRIPTEN__
@@ -275,11 +299,17 @@ void CopySurfaceTextureToReadbackBuffer(const wgpu::Texture& texture, const wgpu
   encoder.copyTextureToBuffer(src, dst, copySize);
 }
 
-bool MapReadbackBuffer(const wgpu::Device& device, const wgpu::Buffer& buffer, uint64_t size) {
-  // AllowSpontaneous + a bounded poll-yield loop: a timed waitAny cannot
-  // complete on the browser main thread, and the poll bailout means the
-  // callback can fire after this frame returns, so the state must be
-  // heap-retained until the callback consumes it.
+bool MapReadbackBuffer(const wgpu::Device& device, const wgpu::Buffer& buffer, uint64_t size,
+                       const std::shared_ptr<donner::geode::GeodeDevice>& geodeDevice) {
+  if (geodeDevice && geodeDevice->isDeviceLost()) {
+    // A lost device will never deliver the map; fail fast instead of
+    // spending another full wait bound on the editor thread.
+    return false;
+  }
+  // AllowSpontaneous + a bounded poll loop: a timed waitAny cannot complete
+  // on the browser main thread, and the wait bailing out means the callback
+  // can fire after this frame returns, so the state must be heap-retained
+  // until the callback consumes it.
   struct MapState {
     std::atomic<bool> done = false;
     std::atomic<bool> ok = false;
@@ -299,6 +329,9 @@ bool MapReadbackBuffer(const wgpu::Device& device, const wgpu::Buffer& buffer, u
   mapCb.mode = wgpu::CallbackMode::AllowSpontaneous;
   buffer.mapAsync(wgpu::MapMode::Read, 0, size, mapCb);
 
+#ifdef __EMSCRIPTEN__
+  // Browser: `poll` yields the thread for one browser task, so the loop is
+  // already bounded in time by the iteration cap.
   int pollCount = 0;
   while (!mapState->done.load(std::memory_order_acquire)) {
     device.poll(true, nullptr);
@@ -307,7 +340,23 @@ bool MapReadbackBuffer(const wgpu::Device& device, const wgpu::Buffer& buffer, u
       break;
     }
   }
-  return mapState->ok.load(std::memory_order_relaxed);
+#else
+  // Native: never ask the driver to block until the map completes; a hung
+  // driver would wedge the editor thread forever (worst case in
+  // uninterruptible kernel sleep). Poll non-blocking with a deadline and
+  // declare the device lost when the deadline expires.
+  const donner::geode::GpuWaitResult waitResult = donner::geode::BoundedGpuWait(
+      [&] {
+        device.poll(false, nullptr);
+        return mapState->done.load(std::memory_order_acquire);
+      },
+      donner::geode::kDefaultGpuWaitTimeout);
+  if (waitResult != donner::geode::GpuWaitResult::Complete && geodeDevice) {
+    geodeDevice->markDeviceLost("editor surface readback map did not complete within the bound");
+  }
+#endif
+  return mapState->done.load(std::memory_order_acquire) &&
+         mapState->ok.load(std::memory_order_relaxed);
 }
 #endif
 
@@ -894,6 +943,13 @@ struct EditorWindow::WgpuState {
   wgpu::CompositeAlphaMode alphaMode = wgpu::CompositeAlphaMode::Auto;
   std::shared_ptr<geode::GeodeDevice> geodeDevice;
   std::shared_ptr<geode::GeodeDevice> framebufferGeodeDevice;
+  /// Shared device-lost flag observed by both Geode wrappers above. On
+  /// native builds the WebGPU device-lost callback sets it, and bounded GPU
+  /// waits inside Geode set it on timeout, so both loss paths surface as one
+  /// condition. Created before the device so the callback can be registered
+  /// on the device descriptor.
+  std::shared_ptr<geode::GeodeDeviceLostState> deviceLostState =
+      std::make_shared<geode::GeodeDeviceLostState>();
 #ifdef __EMSCRIPTEN__
   std::shared_ptr<std::atomic_bool> smokeReadbackInFlight =
       std::make_shared<std::atomic_bool>(false);
@@ -1069,6 +1125,16 @@ EditorWindow::EditorWindow(EditorWindowOptions options) : options_(std::move(opt
   deviceDesc.uncapturedErrorCallbackInfo.callback = OnEditorWgpuUncapturedError;
   deviceDesc.uncapturedErrorCallbackInfo.userdata1 = nullptr;
   deviceDesc.uncapturedErrorCallbackInfo.userdata2 = nullptr;
+#ifndef __EMSCRIPTEN__
+  // Route driver-reported device loss into the shared lost flag that the
+  // Geode wrappers below observe, so a real loss and a bounded-wait timeout
+  // converge on the same detectable condition.
+  deviceDesc.deviceLostCallbackInfo.mode = wgpu::CallbackMode::AllowSpontaneous;
+  deviceDesc.deviceLostCallbackInfo.callback = OnEditorWgpuDeviceLost;
+  deviceDesc.deviceLostCallbackInfo.userdata1 =
+      geode::retainWgpuCallbackState(wgpuState_->deviceLostState);
+  deviceDesc.deviceLostCallbackInfo.userdata2 = nullptr;
+#endif
   wgpuState_->device = wgpuState_->adapter.requestDevice(deviceDesc);
   if (!wgpuState_->device) {
     std::fprintf(stderr, "EditorWindow: failed to create WebGPU device\n");
@@ -1163,6 +1229,10 @@ EditorWindow::EditorWindow(EditorWindowOptions options) : options_(std::move(opt
   embedConfig.adapter = wgpuState_->adapter;
 #endif
   embedConfig.textureFormat = wgpuState_->surfaceFormat;
+  // Both Geode wrappers share the editor's lost flag (the framebuffer config
+  // below is copied from this one), so a loss observed by either wrapper or
+  // by the device-lost callback is visible everywhere.
+  embedConfig.lostState = wgpuState_->deviceLostState;
   wgpuState_->geodeDevice = geode::GeodeDevice::CreateFromExternal(embedConfig);
   if (wgpuState_->geodeDevice == nullptr) {
     std::fprintf(stderr, "EditorWindow: GeodeDevice::CreateFromExternal failed\n");
@@ -1878,7 +1948,8 @@ void EditorWindow::endFrameImpl(svg::RendererBitmap* readback) {
     timing.readbackMs += ElapsedMs(readbackStart);
   }
   if (targetReadback != nullptr && readbackBuffer &&
-      MapReadbackBuffer(wgpuState_->device, readbackBuffer.get(), readbackBufferSize)) {
+      MapReadbackBuffer(wgpuState_->device, readbackBuffer.get(), readbackBufferSize,
+                        wgpuState_->framebufferGeodeDevice)) {
     const auto readbackStart = std::chrono::steady_clock::now();
     const uint8_t* mapped = static_cast<const uint8_t*>(
         readbackBuffer.get().getConstMappedRange(0, readbackBufferSize));

--- a/donner/editor/wasm/tests/wgpu-readback-contract.spec.mjs
+++ b/donner/editor/wasm/tests/wgpu-readback-contract.spec.mjs
@@ -169,7 +169,21 @@ test("worker WebGPU startup keeps its browser Promise bridge private and single-
     /#ifndef __EMSCRIPTEN__([\s\S]*?)#endif/,
   );
   assert.ok(emscriptenBranch, "expected native-only submitted-work wait");
-  assert.match(emscriptenBranch[1], /WaitForSubmittedWork/);
+  assert.match(
+    emscriptenBranch[1],
+    /waitForQueueIdle/,
+    "native teardown must drain through the bounded queue-idle wait",
+  );
+  assert.doesNotMatch(
+    geodeDeviceSource,
+    /WaitForSubmittedWork/,
+    "the unbounded submitted-work wait stays deleted; teardown drains are bounded",
+  );
+  assert.doesNotMatch(
+    deviceDestructor[1],
+    /poll\(true/,
+    "teardown must never block inside the driver without a deadline",
+  );
 });
 
 test("worker WebGPU startup enables event-driven timed readback waits", () => {

--- a/donner/gpu/metal/tests/BUILD.bazel
+++ b/donner/gpu/metal/tests/BUILD.bazel
@@ -31,6 +31,7 @@ donner_cc_binary(
         "//donner/svg/renderer:renderer_image_io",
         "//donner/svg/renderer/geode:geo_encoder",
         "//donner/svg/renderer/geode:geode_device",
+        "//donner/svg/renderer/geode:geode_gpu_wait",
         "//donner/svg/renderer/geode:geode_wgpu_util",
         "//third_party/webgpu-cpp:webgpu_cpp",
     ],

--- a/donner/gpu/metal/tests/BaselineCaptureTool.cc
+++ b/donner/gpu/metal/tests/BaselineCaptureTool.cc
@@ -17,6 +17,7 @@
 #include "donner/svg/renderer/geode/GeoEncoder.h"
 #include "donner/svg/renderer/geode/GeodeCallbackState.h"
 #include "donner/svg/renderer/geode/GeodeDevice.h"
+#include "donner/svg/renderer/geode/GeodeGpuWait.h"
 #include "donner/svg/renderer/geode/GeodeImagePipeline.h"
 #include "donner/svg/renderer/geode/GeodePipeline.h"
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
@@ -96,8 +97,15 @@ int CaptureBaseline(const char* outputPath) {
   mapCb.userdata1 = geode::retainWgpuCallbackState(mapState);
   mapCb.userdata2 = nullptr;
   readback.mapAsync(wgpu::MapMode::Read, 0, kBytesPerRow * kBaselineSize, mapCb);
-  while (!mapState->done.load(std::memory_order_acquire)) {
-    device->device().poll(true, nullptr);
+  const geode::GpuWaitResult waitResult = geode::BoundedGpuWait(
+      [&] {
+        device->device().poll(false, nullptr);
+        return mapState->done.load(std::memory_order_acquire);
+      },
+      geode::kDefaultGpuWaitTimeout);
+  if (waitResult != geode::GpuWaitResult::Complete) {
+    std::fprintf(stderr, "Readback buffer map wait timed out\n");
+    return 1;
   }
   if (!mapState->ok.load(std::memory_order_relaxed)) {
     std::fprintf(stderr, "Readback buffer map failed\n");

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -5018,13 +5018,14 @@ ReadbackMapStatus MapAndWaitReadback(const std::shared_ptr<geode::GeodeDevice>& 
 #endif
     // Never ask wgpu-native to block until the GPU map completes: a low-priority thumbnail must
     // observe a superseding main-document request promptly. Native polling is
-    // non-blocking and gets a short sleep to avoid spinning. The 100 us sleep
-    // bounds the snapshot latency floor without the 1 ms quanta that used to
-    // dominate small-fixture readbacks; the poll itself processes the map
-    // completion callback as soon as the GPU delivers it.
+    // non-blocking and gets a short sleep to avoid spinning. The
+    // kGpuWaitPollInterval (100 us) sleep bounds the snapshot latency floor
+    // without the 1 ms quanta that used to dominate small-fixture readbacks;
+    // the poll itself processes the map completion callback as soon as the
+    // GPU delivers it.
     device->pollSuspending(false);
 #ifndef __EMSCRIPTEN__
-    std::this_thread::sleep_for(std::chrono::microseconds(100));
+    std::this_thread::sleep_for(geode::kGpuWaitPollInterval);
 #endif
   }
   device->recordReadback(usedTimedWaitAny, pollIter);

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -2494,7 +2494,10 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     frameFinishedEncoders.clear();
 
     if (device && device->device()) {
-      device->pollSuspending(true);
+      // Bounded drain before releasing frame resources; skips (and stays
+      // skipped) once the device is lost so renderer teardown never blocks
+      // on a hung driver.
+      device->waitForQueueIdle();
     }
 
     framePendingTextureViewReleases.clear();
@@ -2541,7 +2544,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     if (device) {
       device->drainDeferredDestroys();
       if (device->device()) {
-        device->pollSuspending(true);
+        // Bounded; a no-op when the device is already lost.
+        device->waitForQueueIdle();
       }
     }
   }
@@ -4912,11 +4916,14 @@ enum class ReadbackMapStatus {
   Success,
   /// A cancellation request fired; the buffer was unmapped and destroyed.
   Cancelled,
-  /// The 10-second deadline expired with no map completion; the buffer was
-  /// unmapped and destroyed. Distinct from Cancelled so a caller can avoid
-  /// starting a second full-deadline wait against a device that just proved
-  /// unresponsive.
+  /// The readback deadline expired with no map completion; the buffer was
+  /// unmapped and destroyed and the device was declared lost. Distinct from
+  /// Cancelled so a caller can avoid starting a second full-deadline wait
+  /// against a device that just proved unresponsive.
   TimedOut,
+  /// The device was already declared lost before the map was requested; no
+  /// GPU wait was performed.
+  DeviceLost,
   /// The map completed with a non-success status.
   Failed,
 };
@@ -4928,6 +4935,12 @@ enum class ReadbackMapStatus {
 ReadbackMapStatus MapAndWaitReadback(const std::shared_ptr<geode::GeodeDevice>& device,
                                      const wgpu::Buffer& buffer, uint64_t mapSize,
                                      const std::function<bool()>& shouldCancel) {
+  if (device->isDeviceLost()) {
+    // A lost device will never deliver the map. Fail fast so a caller does
+    // not spend another full readback deadline against a hung driver; the
+    // caller drops the buffer without pooling it.
+    return ReadbackMapStatus::DeviceLost;
+  }
   // `BufferMapCallbackInfo` takes raw userdata rather than a std::function, and a
   // cancellation may return before WebGPU delivers that callback. Keep its payload alive
   // independently of this stack frame: one reference belongs to this caller, the other to the
@@ -4964,7 +4977,7 @@ ReadbackMapStatus MapAndWaitReadback(const std::shared_ptr<geode::GeodeDevice>& 
   bool cancelled = false;
   bool timedOut = false;
   bool usedTimedWaitAny = false;
-  const auto readbackDeadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+  const auto readbackDeadline = std::chrono::steady_clock::now() + geode::kReadbackMapTimeout;
   while (!mapState->done.load(std::memory_order_acquire)) {
     if (shouldCancel && shouldCancel()) {
       cancelled = true;
@@ -5016,6 +5029,12 @@ ReadbackMapStatus MapAndWaitReadback(const std::shared_ptr<geode::GeodeDevice>& 
   }
   device->recordReadback(usedTimedWaitAny, pollIter);
   if (cancelled || timedOut) {
+    if (timedOut) {
+      // A full readback deadline with no map delivery is the observable
+      // signature of a hung device. Declare the loss so later waits on this
+      // device fail fast and teardown skips GPU waits entirely.
+      device->markDeviceLost("snapshot readback map did not complete within the readback deadline");
+    }
     // Cancelling a pending map schedules its callback with an aborted status. The callback's
     // reference keeps `mapState` valid even when delivery happens after this method returns.
     buffer.unmap();
@@ -5108,11 +5127,13 @@ RendererBitmap ReadGeodeTextureSnapshotGpu(const std::shared_ptr<geode::GeodeDev
   const ReadbackMapStatus mapStatus =
       MapAndWaitReadback(device, resources.readback.get(), mapSize, shouldCancel);
   if (mapStatus != ReadbackMapStatus::Success) {
-    // Cancelled, timed out, or failed: the helper already unmapped and
-    // destroyed the readback buffer, so the entry cannot be pooled. The
-    // caller uses outTimedOut to avoid a second full-deadline wait against
-    // an unresponsive device.
-    outTimedOut = mapStatus == ReadbackMapStatus::TimedOut;
+    // Cancelled, timed out, lost, or failed: on cancellation and timeout the
+    // helper already unmapped and destroyed the readback buffer, and on a
+    // lost device the map was never requested; either way the entry cannot
+    // be pooled. The caller uses outTimedOut to avoid a second full-deadline
+    // wait against an unresponsive device.
+    outTimedOut =
+        mapStatus == ReadbackMapStatus::TimedOut || mapStatus == ReadbackMapStatus::DeviceLost;
     return bitmap;
   }
 
@@ -5307,6 +5328,10 @@ RendererBitmap RendererGeode::takeSnapshotInterruptibly(
   return ReadGeodeTextureSnapshot(impl_->device, impl_->target,
                                   Vector2i(impl_->pixelWidth, impl_->pixelHeight),
                                   impl_->textureFormat, AlphaType::Premultiplied, shouldCancel);
+}
+
+bool RendererGeode::deviceLost() const {
+  return impl_->device && impl_->device->isDeviceLost();
 }
 
 RendererReadbackStats RendererGeode::consumeReadbackStats() {

--- a/donner/svg/renderer/RendererGeode.h
+++ b/donner/svg/renderer/RendererGeode.h
@@ -326,6 +326,22 @@ public:
   [[nodiscard]] RendererReadbackStats consumeReadbackStats() override;
 
   /**
+   * True once the GPU device backing this renderer has been declared lost,
+   * either by a driver-reported WebGPU device-lost callback or by a bounded
+   * GPU wait exceeding its deadline (for example a snapshot readback map that
+   * never completed). The condition is sticky.
+   *
+   * Once lost: draw calls may produce no usable output, snapshots return
+   * empty bitmaps promptly instead of waiting out the readback deadline, and
+   * destroying this renderer and its `GeodeDevice` performs no further GPU
+   * waits (GPU resources are deliberately leaked rather than risking a
+   * blocking call into a hung driver). Callers should treat a lost device as
+   * fatal for this renderer instance: destroy it and recreate the renderer,
+   * or fall back to a CPU backend.
+   */
+  [[nodiscard]] bool deviceLost() const;
+
+  /**
    * Enable or disable GPU timestamp capture. No-op today; reserved for
    * future work. When wired up, this
    * will drive the `renderPassNs` / `totalGpuNs` fields of

--- a/donner/svg/renderer/geode/BUILD.bazel
+++ b/donner/svg/renderer/geode/BUILD.bazel
@@ -76,6 +76,31 @@ donner_cc_library(
     visibility = ["//donner/svg/renderer:__subpackages__"],
 )
 
+# Bounded CPU-side waits on GPU progress plus the shared device-lost flag.
+# Pure chrono/functional code with no WebGPU dependency, so the timeout
+# policy is unit-testable without a GPU and builds regardless of the
+# enable_geode flag. Every native CPU-blocks-on-GPU wait in the Geode stack
+# routes through this library so the policy lives in one place.
+donner_cc_library(
+    name = "geode_gpu_wait",
+    srcs = ["GeodeGpuWait.cc"],
+    hdrs = ["GeodeGpuWait.h"],
+    visibility = [
+        "//donner/editor/gui:__pkg__",
+        "//donner/gpu:__subpackages__",
+        "//donner/svg/renderer:__subpackages__",
+    ],
+)
+
+donner_cc_test(
+    name = "geode_gpu_wait_tests",
+    srcs = ["tests/GeodeGpuWait_tests.cc"],
+    deps = [
+        ":geode_gpu_wait",
+        "//donner/base:gtest_timeout_main",
+    ],
+)
+
 # Header-only device-aware curve-flattening tolerance for stroke outlines.
 # Pure transform math with no WebGPU dependency, so it builds (and is tested)
 # regardless of the enable_geode flag.
@@ -204,6 +229,7 @@ donner_cc_library(
     ],
     deps = [
         ":geode_counters",
+        ":geode_gpu_wait",
         ":geode_shaders",
         ":geode_wgpu_util",
         "//donner/base",
@@ -219,6 +245,7 @@ donner_cc_test(
     target_compatible_with = _GEODE_ONLY,
     deps = [
         ":geode_device",
+        ":geode_gpu_wait",
         ":geode_wgpu_util",
         "//donner/base",
         "//donner/base:gtest_timeout_main",
@@ -594,6 +621,7 @@ donner_cc_test(
     deps = [
         ":geo_encoder",
         ":geode_device",
+        ":geode_gpu_wait",
         ":geode_wgpu_util",
         "//donner/base",
         "//donner/base:gtest_timeout_main",

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -287,6 +287,13 @@ GeodeDevice::~GeodeDevice() {
     // Deliberate leak: destroying or releasing the root handles of a hung
     // device can block inside the driver with no bound. Abandon them; the
     // process has already lost GPU rendering on this device.
+    //
+    // Post-loss teardown is wait-free, not driver-free: drainDeferredDestroys
+    // and the Impl reset above still issued release/destroy calls into the
+    // client library for pooled textures, buffers, and pipelines. Those are
+    // refcount drops and deferred-destroy marks that do not wait on GPU
+    // completion; only the root-handle destroy/release below, which can
+    // trigger a blocking device drain, is skipped.
     return;
   }
 

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -25,6 +25,7 @@
 #include "donner/svg/renderer/geode/GeodeCallbackState.h"
 #include "donner/svg/renderer/geode/GeodeCheckerboardPipeline.h"
 #include "donner/svg/renderer/geode/GeodeFilterEngine.h"
+#include "donner/svg/renderer/geode/GeodeGpuWait.h"
 #include "donner/svg/renderer/geode/GeodeImagePipeline.h"
 #include "donner/svg/renderer/geode/GeodePipeline.h"
 
@@ -61,14 +62,26 @@ void OnUncapturedError(WGPUDevice const* /*device*/, WGPUErrorType type, WGPUStr
                message.data ? message.data : "");
 }
 
+/// Device-lost callback wired onto headless devices. Fires at most once per
+/// device; `userdata1` carries a retained shared reference to the device's
+/// `GeodeDeviceLostState` so a spontaneous callback can outlive the
+/// `GeodeDevice` that registered it. A driver-reported loss sets the same
+/// flag that bounded-wait timeouts set, so both failure modes surface as one
+/// detectable device-lost condition.
 void OnDeviceLost(WGPUDevice const* /*device*/, WGPUDeviceLostReason reason, WGPUStringView message,
-                  void* /*userdata1*/, void* /*userdata2*/) {
+                  void* userdata1, void* /*userdata2*/) {
+  const std::shared_ptr<GeodeDeviceLostState> state =
+      takeWgpuCallbackState<GeodeDeviceLostState>(userdata1);
   if (reason == WGPUDeviceLostReason_Destroyed || reason == WGPUDeviceLostReason_InstanceDropped) {
+    // Expected teardown paths, not a driver failure.
     return;
   }
   std::fprintf(stderr, "[Geode/wgpu-native] Device lost (reason=%d): %.*s\n",
                static_cast<int>(reason), static_cast<int>(message.length),
                message.data ? message.data : "");
+  if (state) {
+    state->lost.store(true, std::memory_order_release);
+  }
 }
 
 wgpu::BackendType RequestedHeadlessBackend() {
@@ -129,38 +142,6 @@ wgpu::Instance CreateHeadlessInstance(wgpu::BackendType backendType) {
     return wgpu::createInstance(instanceDesc);
   }
   return wgpu::createInstance();
-}
-#endif
-
-#ifndef __EMSCRIPTEN__
-void WaitForSubmittedWork(const wgpu::Device& device, const wgpu::Queue& queue) {
-  if (!device || !queue) {
-    return;
-  }
-
-  struct WorkDoneState {
-    std::atomic<bool> done = false;
-  };
-  auto state = std::make_shared<WorkDoneState>();
-
-  wgpu::QueueWorkDoneCallbackInfo callbackInfo{wgpu::Default};
-  callbackInfo.mode = wgpu::CallbackMode::AllowSpontaneous;
-  callbackInfo.callback = [](WGPUQueueWorkDoneStatus /*status*/, void* userdata1,
-                             void* /*userdata2*/) {
-    const std::shared_ptr<WorkDoneState> state = takeWgpuCallbackState<WorkDoneState>(userdata1);
-    state->done.store(true, std::memory_order_release);
-  };
-  callbackInfo.userdata1 = retainWgpuCallbackState(state);
-  callbackInfo.userdata2 = nullptr;
-
-  queue.onSubmittedWorkDone(callbackInfo);
-  // Teardown drain, not a frame-path wait, but it can still unwind the wasm
-  // stack; attribute it so an unexpectedly long shutdown is visible.
-  const ScopedSuspendPoint suspend(SuspendKind::Startup);
-  for (int pollIter = 0; !state->done.load(std::memory_order_acquire) && pollIter < 2000;
-       ++pollIter) {
-    device.poll(true, nullptr);
-  }
 }
 #endif
 
@@ -263,14 +244,22 @@ std::atomic<uint64_t> g_nextDeviceId{0};
 
 GeodeDevice::GeodeDevice()
     : impl_(std::make_unique<Impl>()),
-      deviceId_(g_nextDeviceId.fetch_add(1, std::memory_order_relaxed) + 1) {}
+      deviceId_(g_nextDeviceId.fetch_add(1, std::memory_order_relaxed) + 1),
+      lostState_(std::make_shared<GeodeDeviceLostState>()) {}
 
 GeodeDevice::~GeodeDevice() {
   // Release all resources that were created from the device before releasing the
   // root queue/device/adapter/instance handles. `webgpu.hpp` handles are raw
   // wrappers: their destructors do not release native references.
+  //
+  // Every teardown wait is bounded. Once the device is lost (driver-reported
+  // or a wait deadline expired), all further GPU waits are skipped: waiting
+  // on a hung driver can block forever, in the worst case in uninterruptible
+  // kernel sleep, and a leak is strictly better than a hung thread.
 #ifndef __EMSCRIPTEN__
-  WaitForSubmittedWork(device_, queue_);
+  if (device_ && queue_) {
+    waitForQueueIdle();
+  }
 #endif
   wgpu::Instance instance;
   if (!external_ && impl_) {
@@ -281,8 +270,9 @@ GeodeDevice::~GeodeDevice() {
   impl_.reset();
   if (device_) {
 #ifndef __EMSCRIPTEN__
-    device_.poll(true, nullptr);
-    WaitForSubmittedWork(device_, queue_);
+    // Second drain after the pipelines and pooled resources released above;
+    // returns immediately if the first wait already declared the device lost.
+    waitForQueueIdle();
 #endif
   }
 
@@ -290,6 +280,13 @@ GeodeDevice::~GeodeDevice() {
     queue_ = wgpu::Queue();
     device_ = wgpu::Device();
     adapter_ = wgpu::Adapter();
+    return;
+  }
+
+  if (isDeviceLost()) {
+    // Deliberate leak: destroying or releasing the root handles of a hung
+    // device can block inside the driver with no bound. Abandon them; the
+    // process has already lost GPU rendering on this device.
     return;
   }
 
@@ -302,9 +299,40 @@ GeodeDevice::~GeodeDevice() {
   ReleaseWgpuHandle(instance);
 }
 
-void GeodeDevice::pollSuspending(bool wait) const {
+bool GeodeDevice::pollSuspending(bool wait) const {
   const ScopedSuspendPoint suspend(SuspendKind::DeviceWait);
-  device_.poll(wait, nullptr);
+  return device_.poll(wait, nullptr);
+}
+
+void GeodeDevice::markDeviceLost(const char* reason) const {
+  if (!lostState_->lost.exchange(true, std::memory_order_acq_rel)) {
+    std::fprintf(stderr, "[Geode] Device declared lost: %s\n", reason ? reason : "(no reason)");
+  }
+}
+
+GpuWaitResult GeodeDevice::waitForQueueIdle(std::chrono::milliseconds timeout) const {
+  if (isDeviceLost()) {
+    return GpuWaitResult::DeviceLost;
+  }
+  if (!device_) {
+    return GpuWaitResult::Complete;
+  }
+#ifdef __EMSCRIPTEN__
+  // emdawnwebgpu's poll yields the Asyncify thread for one browser task and
+  // its return value does not report queue-idle, so a drain loop keyed on it
+  // could spin for the full timeout every call. Keep the single poll-yield
+  // this path always performed; browser device hangs surface through the
+  // readback map deadline instead.
+  (void)timeout;
+  pollSuspending(true);
+  return GpuWaitResult::Complete;
+#else
+  const GpuWaitResult result = BoundedGpuWait([this] { return pollSuspending(false); }, timeout);
+  if (result == GpuWaitResult::TimedOut) {
+    markDeviceLost("GPU queue did not go idle within the bounded wait deadline");
+  }
+  return result;
+#endif
 }
 
 void GeodeDevice::recordReadback(bool usedTimedWaitAny, int pollIterations) {
@@ -506,7 +534,6 @@ std::unique_ptr<GeodeDevice> GeodeDevice::CreateHeadless(wgpu::TextureFormat tex
   deviceDesc.label = wgpu::StringView{std::string_view{"GeodeDevice"}};
   deviceDesc.deviceLostCallbackInfo.mode = wgpu::CallbackMode::AllowSpontaneous;
   deviceDesc.deviceLostCallbackInfo.callback = OnDeviceLost;
-  deviceDesc.deviceLostCallbackInfo.userdata1 = nullptr;
   deviceDesc.deviceLostCallbackInfo.userdata2 = nullptr;
   deviceDesc.uncapturedErrorCallbackInfo.callback = OnUncapturedError;
   deviceDesc.uncapturedErrorCallbackInfo.userdata1 = nullptr;
@@ -531,6 +558,12 @@ std::unique_ptr<GeodeDevice> GeodeDevice::CreateHeadless(wgpu::TextureFormat tex
   constexpr int kMaxDeviceInitRetries = 3;
   constexpr int kDeviceInitBackoffMs[kMaxDeviceInitRetries] = {50, 200, 800};
   for (int attempt = 0;; ++attempt) {
+    // A fresh retained lost-state reference per attempt: each successfully
+    // created device eventually consumes its userdata exactly once via
+    // OnDeviceLost (including the Destroyed-at-teardown delivery). An attempt
+    // that returns a null device strands at most one small retained block,
+    // bounded by the retry count.
+    deviceDesc.deviceLostCallbackInfo.userdata1 = retainWgpuCallbackState(result->lostState_);
     result->device_ = result->adapter_.requestDevice(deviceDesc);
     if (result->device_) {
       break;  // Device created successfully.
@@ -727,6 +760,12 @@ std::unique_ptr<GeodeDevice> GeodeDevice::CreateFromExternal(const GeodeEmbedCon
 
   auto result = std::unique_ptr<GeodeDevice>(new GeodeDevice());
   result->external_ = true;
+  if (config.lostState) {
+    // Share the host's device-lost flag so a loss reported through the
+    // host's device-lost callback and a bounded-wait timeout inside Geode
+    // surface as the same isDeviceLost() condition.
+    result->lostState_ = config.lostState;
+  }
   result->device_ = config.device;
   result->queue_ = config.queue;
   result->textureFormat_ = config.textureFormat;

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -219,6 +219,18 @@ public:
    * the device is marked lost (see \ref markDeviceLost) and later waits on
    * this device return immediately.
    *
+   * Completion condition: the wait observes "queue empty", not "the work
+   * submitted before this call completed". With a concurrent submitter on
+   * the same underlying queue (on native, the async-render thread and the
+   * editor framebuffer wrapper share one WebGPU queue), a healthy but
+   * continuously saturated queue could in principle be non-empty at every
+   * poll sample for the whole timeout and be falsely declared lost. This is
+   * accepted: real submit cadences leave idle gaps many orders of magnitude
+   * wider than the 100 us sampling interval, the exposure is bounded by the
+   * generous timeout, and a false positive degrades to the detection path
+   * (renderer reports device loss and tears down wait-free) rather than a
+   * hang or crash.
+   *
    * Under Emscripten this performs the pre-existing single poll-yield
    * instead of a bounded drain loop: emdawnwebgpu's poll return value does
    * not report queue-idle, and browser device hangs surface through the

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -9,6 +9,7 @@
 #include <webgpu/webgpu.hpp>
 
 #include "donner/svg/renderer/geode/GeodeCounters.h"
+#include "donner/svg/renderer/geode/GeodeGpuWait.h"
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
 
 namespace donner::geode {
@@ -99,6 +100,14 @@ struct GeodeEmbedConfig {
   /// Optional adapter handle. Preserved for hosts that need to query the
   /// adapter associated with the external device.
   wgpu::Adapter adapter;
+
+  /// Optional shared device-lost flag. Hosts that install their own WebGPU
+  /// device-lost callback should have that callback set this flag and pass
+  /// the same state here, so a driver-reported loss on the host device and a
+  /// bounded-wait timeout inside Geode converge on the same
+  /// `GeodeDevice::isDeviceLost()` condition. When null, the GeodeDevice
+  /// creates a private flag that only bounded-wait timeouts can set.
+  std::shared_ptr<GeodeDeviceLostState> lostState;
 };
 
 /**
@@ -156,7 +165,13 @@ public:
   /// sharing by asserting this count stays flat across repeated operations.
   static int headlessCreationCountForTesting();
 
-  /// Destructor releases the device and all GPU resources.
+  /// Destructor releases the device and all GPU resources. All teardown
+  /// waits are bounded; if the device has been declared lost (see
+  /// \ref isDeviceLost) the destructor performs no GPU waits at all and
+  /// deliberately leaks the root WebGPU handles (queue, device, adapter,
+  /// instance) rather than risking a blocking call into a hung driver. The
+  /// leak is bounded to one device's worth of driver objects per loss, and a
+  /// lost device is a process-fatal condition for GPU rendering anyway.
   ~GeodeDevice();
 
   // Non-copyable, non-movable. The device owns pipelines and a filter
@@ -183,7 +198,52 @@ public:
   /// frame time, so it has to be attributable. Route every poll through here rather than calling
   /// `device().poll` directly; the probe is a pair of clock reads on native builds, where `poll`
   /// does not suspend at all.
-  void pollSuspending(bool wait) const;
+  ///
+  /// Prefer @p wait = false: a waiting poll can block inside a hung driver
+  /// with no bound. Callers that need to wait for the queue to drain should
+  /// use \ref waitForQueueIdle, which is bounded and reports a hang as a
+  /// device-lost condition.
+  ///
+  /// @return True when the device reports its queue empty (wgpu-native's
+  ///   `wgpuDevicePoll` return value; unspecified under Emscripten, where the
+  ///   poll is a browser-task yield).
+  bool pollSuspending(bool wait) const;
+
+  /**
+   * Wait, bounded, for all submitted GPU work to complete.
+   *
+   * Replaces unbounded `poll(wait=true)` loops: the wait is a non-blocking
+   * poll at \ref kGpuWaitPollInterval cadence with a deadline, so a hung
+   * driver costs at most @p timeout instead of blocking the calling thread
+   * forever (in the worst case in uninterruptible kernel sleep). On timeout
+   * the device is marked lost (see \ref markDeviceLost) and later waits on
+   * this device return immediately.
+   *
+   * Under Emscripten this performs the pre-existing single poll-yield
+   * instead of a bounded drain loop: emdawnwebgpu's poll return value does
+   * not report queue-idle, and browser device hangs surface through the
+   * readback map deadline and the browser's own device-loss reporting.
+   *
+   * @param timeout Wait budget; defaults to the shared generous bound.
+   * @return `Complete` when the queue drained, `TimedOut` when the deadline
+   *   expired (the device is now marked lost), `DeviceLost` when the device
+   *   was already lost and no wait was performed.
+   */
+  GpuWaitResult waitForQueueIdle(std::chrono::milliseconds timeout = kDefaultGpuWaitTimeout) const;
+
+  /// True once this device has been declared lost, either by the WebGPU
+  /// device-lost callback (driver-reported) or by a bounded GPU wait
+  /// exceeding its deadline. Sticky: never resets. Once lost, rendering
+  /// output is undefined, snapshots return empty bitmaps promptly, and
+  /// teardown skips all GPU waits.
+  bool isDeviceLost() const { return lostState_->lost.load(std::memory_order_acquire); }
+
+  /// Declare this device lost. Idempotent; the first call logs @p reason.
+  /// Called from bounded waits on timeout, and available to embedders whose
+  /// own device-lost signal is not shared via `GeodeEmbedConfig::lostState`.
+  /// Const because observers treat the flag as shared diagnostic state and
+  /// waits that discover a hang run through const accessors.
+  void markDeviceLost(const char* reason) const;
 
   /// Instance that created the headless device. Null for externally-owned devices.
   const wgpu::Instance& instance() const;
@@ -505,6 +565,13 @@ private:
 
   /// Process-unique identity assigned at construction. See `deviceId()`.
   const uint64_t deviceId_ = 0;
+
+  /// Shared device-lost flag; never null. Created at construction, replaced
+  /// by the host's shared state in `CreateFromExternal` when
+  /// `GeodeEmbedConfig::lostState` is provided, and retained by the WebGPU
+  /// device-lost callback in headless mode (callbacks can outlive this
+  /// object, hence shared ownership).
+  std::shared_ptr<GeodeDeviceLostState> lostState_;
 
   GeodeCounters* counters_ = nullptr;
 

--- a/donner/svg/renderer/geode/GeodeFilterEngine.cc
+++ b/donner/svg/renderer/geode/GeodeFilterEngine.cc
@@ -113,8 +113,14 @@ struct FilterResourceArena {
     // force the submitted work to complete before recording continues. The
     // in-buffer path (no chunking) relies on WebGPU's implicit inter-pass
     // barriers and needs no wait.
+    //
+    // The wait is bounded: a driver hang here would otherwise block the
+    // rendering thread forever mid-frame. On timeout the device is declared
+    // lost and recording continues without the barrier; output for the
+    // frame is undefined, but the caller can observe the loss and tear the
+    // renderer down without further blocking.
     if (device_.isVulkan()) {
-      device_.pollSuspending(true);
+      device_.waitForQueueIdle();
     }
     wgpu::CommandEncoderDescriptor desc = {};
     desc.label = wgpuLabel("GeodeFilterChunkCE");

--- a/donner/svg/renderer/geode/GeodeGpuWait.cc
+++ b/donner/svg/renderer/geode/GeodeGpuWait.cc
@@ -1,0 +1,36 @@
+#include "donner/svg/renderer/geode/GeodeGpuWait.h"
+
+#include <thread>
+
+namespace donner::geode {
+
+GpuWaitResult BoundedGpuWait(const std::function<bool()>& pollOnce,
+                             std::chrono::milliseconds timeout,
+                             std::chrono::microseconds pollInterval,
+                             const GpuWaitTestHooks& testHooks) {
+  const auto now = [&testHooks]() {
+    return testHooks.now ? testHooks.now() : std::chrono::steady_clock::now();
+  };
+  const auto sleep = [&testHooks](std::chrono::microseconds duration) {
+    if (testHooks.sleep) {
+      testHooks.sleep(duration);
+    } else {
+      std::this_thread::sleep_for(duration);
+    }
+  };
+
+  const std::chrono::steady_clock::time_point deadline = now() + timeout;
+  for (;;) {
+    if (pollOnce()) {
+      return GpuWaitResult::Complete;
+    }
+    if (now() >= deadline) {
+      return GpuWaitResult::TimedOut;
+    }
+    if (pollInterval.count() > 0) {
+      sleep(pollInterval);
+    }
+  }
+}
+
+}  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodeGpuWait.h
+++ b/donner/svg/renderer/geode/GeodeGpuWait.h
@@ -1,0 +1,100 @@
+#pragma once
+/// @file
+/// Bounded CPU-side waits on GPU progress, and the shared device-lost flag.
+///
+/// A hung GPU driver can leave a fence or buffer-map wait blocked forever, in
+/// the worst case in uninterruptible kernel sleep. Donner cannot fix drivers,
+/// but no thread the application relies on may block unboundedly on the GPU:
+/// a hung device must surface as a detectable device-lost condition instead
+/// of a hung process. Every native CPU-blocks-on-GPU wait in the Geode stack
+/// routes through this header so the timeout policy lives in exactly one
+/// place.
+///
+/// This header is deliberately WebGPU-free (chrono + functional only) so the
+/// wait loop can be unit tested without a GPU via the injectable clock and
+/// sleep hooks.
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+
+namespace donner::geode {
+
+/// Outcome of a bounded GPU wait.
+enum class GpuWaitResult {
+  /// The awaited condition was observed before the deadline.
+  Complete,
+  /// The deadline expired without the condition being observed. Callers
+  /// treat this as evidence of a hung device and declare the device lost.
+  TimedOut,
+  /// The device was already marked lost; no wait was performed.
+  DeviceLost,
+};
+
+/// Default bound for waits that previously blocked without limit (teardown
+/// drains, inter-submit serialization, editor readback maps). Generous: a
+/// healthy device completes these in microseconds to milliseconds, so the
+/// bound only trips when the driver has effectively hung.
+inline constexpr std::chrono::milliseconds kDefaultGpuWaitTimeout{5000};
+
+/// Bound for snapshot readback map waits. Matches the long-standing readback
+/// deadline: snapshot consumers tolerate up to 10 seconds under heavily
+/// loaded parallel test runs before declaring the device unresponsive.
+inline constexpr std::chrono::milliseconds kReadbackMapTimeout{10000};
+
+/// Poll cadence for non-blocking wait loops. The 100 us cadence bounds
+/// completion-detection latency without measurable CPU cost; the snapshot
+/// readback path was tuned to this cadence and the perf ceilings assume it.
+inline constexpr std::chrono::microseconds kGpuWaitPollInterval{100};
+
+/// Test seams for \ref BoundedGpuWait. Production callers pass none; tests
+/// inject a fake clock and a sleep recorder so timeout behavior is verified
+/// deterministically and without real sleeping.
+struct GpuWaitTestHooks {
+  /// Clock override. Defaults to `std::chrono::steady_clock::now`.
+  std::function<std::chrono::steady_clock::time_point()> now;
+  /// Sleep override. Defaults to `std::this_thread::sleep_for`.
+  std::function<void(std::chrono::microseconds)> sleep;
+};
+
+/// Shared device-lost flag.
+///
+/// Set exactly once, from either direction, so a driver-reported device-loss
+/// callback and a bounded wait exceeding its deadline converge on one
+/// observable condition:
+/// - the WebGPU device-lost callback stores `true` when the driver reports a
+///   real loss, and
+/// - `GeodeDevice::markDeviceLost` stores `true` when a bounded GPU wait
+///   times out.
+///
+/// Held via `shared_ptr` by every party that needs to observe or publish the
+/// flag (the `GeodeDevice`, a host embedder's device-lost callback), because
+/// WebGPU callbacks can outlive the object that registered them.
+struct GeodeDeviceLostState {
+  /// True once the device has been declared lost. Never reset.
+  std::atomic<bool> lost{false};
+};
+
+/**
+ * Repeatedly invoke @p pollOnce until it returns true or @p timeout expires.
+ *
+ * @p pollOnce must be non-blocking: one device poll (or callback-flag check)
+ * that returns true when the awaited condition has been observed. The loop
+ * never blocks inside the driver, so a hung device costs at most @p timeout
+ * plus one @p pollInterval instead of hanging the calling thread forever.
+ *
+ * The happy path costs one @p pollOnce call and one clock read, so wrapping
+ * an already-complete wait adds no measurable overhead.
+ *
+ * @param pollOnce Non-blocking poll; returns true when the wait is over.
+ * @param timeout Total time budget for the wait.
+ * @param pollInterval Sleep between polls while the condition is pending.
+ * @param testHooks Optional clock/sleep overrides for deterministic tests.
+ * @return `Complete` if @p pollOnce returned true, `TimedOut` otherwise.
+ */
+GpuWaitResult BoundedGpuWait(const std::function<bool()>& pollOnce,
+                             std::chrono::milliseconds timeout,
+                             std::chrono::microseconds pollInterval = kGpuWaitPollInterval,
+                             const GpuWaitTestHooks& testHooks = {});
+
+}  // namespace donner::geode

--- a/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
@@ -15,6 +15,7 @@
 #include "donner/css/Color.h"
 #include "donner/svg/renderer/geode/GeodeCallbackState.h"
 #include "donner/svg/renderer/geode/GeodeDevice.h"
+#include "donner/svg/renderer/geode/GeodeGpuWait.h"
 #include "donner/svg/renderer/geode/GeodeImagePipeline.h"
 #include "donner/svg/renderer/geode/GeodePipeline.h"
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"
@@ -100,8 +101,9 @@ protected:
     device_->queue().submit(1, &cmd);
 
     // Map readback buffer. wgpu-native's `mapAsync` only exposes the
-    // callback-info form; plumb the done flag through `userdata1` and spin
-    // on `device.poll(true, nullptr)` which drains pending callbacks.
+    // callback-info form; plumb the done flag through `userdata1` and poll
+    // non-blocking under a bounded wait, which drains pending callbacks
+    // without risking an unbounded block inside a hung driver.
     struct MapState {
       std::atomic<bool> done = false;
       std::atomic<bool> ok = false;
@@ -117,9 +119,13 @@ protected:
     mapCb.userdata1 = retainWgpuCallbackState(mapState);
     mapCb.userdata2 = nullptr;
     readback_.mapAsync(wgpu::MapMode::Read, 0, kBytesPerRow * kSize, mapCb);
-    while (!mapState->done.load(std::memory_order_acquire)) {
-      device_->device().poll(true, nullptr);
-    }
+    const GpuWaitResult waitResult = BoundedGpuWait(
+        [&] {
+          device_->device().poll(false, nullptr);
+          return mapState->done.load(std::memory_order_acquire);
+        },
+        kDefaultGpuWaitTimeout);
+    EXPECT_EQ(waitResult, GpuWaitResult::Complete) << "buffer map wait timed out";
     EXPECT_TRUE(mapState->ok.load(std::memory_order_relaxed)) << "buffer map failed";
 
     const uint8_t* mapped =

--- a/donner/svg/renderer/geode/tests/GeodeDevice_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeDevice_tests.cc
@@ -5,11 +5,13 @@
 
 #include <array>
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <string_view>
 
 #include "donner/svg/renderer/geode/GeodeCallbackState.h"
+#include "donner/svg/renderer/geode/GeodeGpuWait.h"
 #include "donner/svg/renderer/geode/GeodeFilterEngine.h"
 #include "donner/svg/renderer/geode/GeodeImagePipeline.h"
 #include "donner/svg/renderer/geode/GeodePipeline.h"
@@ -169,9 +171,13 @@ TEST(GeodeDevice, CanExecuteClearAndReadback) {
   mapCb.userdata2 = nullptr;
   readback.mapAsync(wgpu::MapMode::Read, 0, kBufferSize, mapCb);
 
-  while (!mapState->done.load(std::memory_order_acquire)) {
-    device.poll(true, nullptr);
-  }
+  const GpuWaitResult waitResult = BoundedGpuWait(
+      [&] {
+        device.poll(false, nullptr);
+        return mapState->done.load(std::memory_order_acquire);
+      },
+      kDefaultGpuWaitTimeout);
+  ASSERT_EQ(waitResult, GpuWaitResult::Complete) << "buffer map wait timed out";
   EXPECT_TRUE(mapState->ok.load(std::memory_order_relaxed)) << "buffer map failed";
 
   const uint8_t* pixels = static_cast<const uint8_t*>(readback.getConstMappedRange(0, kBufferSize));
@@ -315,6 +321,99 @@ TEST(GeodeDevice, LifetimeCountersReflectCountHelpers) {
   }
   EXPECT_EQ(device->lifetimeTextureCreates(), beforeTex + 10);
   EXPECT_EQ(device->lifetimeBufferCreates(), beforeBuf + 10);
+}
+
+/// The device-lost flag is observable, sticky, and logged once.
+TEST(GeodeDeviceLost, MarkDeviceLostIsSticky) {
+  auto device = GeodeDevice::CreateHeadless();
+  ASSERT_NE(device, nullptr);
+
+  EXPECT_FALSE(device->isDeviceLost());
+  device->markDeviceLost("test-injected loss");
+  EXPECT_TRUE(device->isDeviceLost());
+  device->markDeviceLost("second call must be a no-op");
+  EXPECT_TRUE(device->isDeviceLost());
+}
+
+/// A wait against a lost device must fail fast without polling the device:
+/// the generous default timeout is seconds, so a fast return proves the
+/// short-circuit rather than a lucky quick drain.
+TEST(GeodeDeviceLost, WaitForQueueIdleFastFailsOnLostDevice) {
+  auto device = GeodeDevice::CreateHeadless();
+  ASSERT_NE(device, nullptr);
+
+  device->markDeviceLost("test-injected loss");
+  const auto start = std::chrono::steady_clock::now();
+  const GpuWaitResult result = device->waitForQueueIdle();
+  const auto elapsed = std::chrono::steady_clock::now() - start;
+
+  EXPECT_EQ(result, GpuWaitResult::DeviceLost);
+  EXPECT_LT(elapsed, std::chrono::seconds(1))
+      << "lost-device wait must return immediately, not spend the timeout";
+}
+
+/// On a healthy device the bounded drain completes.
+TEST(GeodeDeviceLost, WaitForQueueIdleCompletesOnHealthyDevice) {
+  auto device = GeodeDevice::CreateHeadless();
+  ASSERT_NE(device, nullptr);
+
+  // Submit a trivial command buffer so the wait has real work to drain.
+  wgpu::CommandEncoder encoder = device->device().createCommandEncoder();
+  wgpu::CommandBuffer cmd = encoder.finish();
+  device->queue().submit(1, &cmd);
+
+  EXPECT_EQ(device->waitForQueueIdle(), GpuWaitResult::Complete);
+}
+
+/// Teardown after a declared loss must complete without blocking on the GPU.
+/// With submitted work still notionally in flight and the loss flag set, the
+/// destructor must skip its queue drains; finishing well under the default
+/// wait bound proves no bounded wait ran, and finishing at all proves no
+/// unbounded wait ran.
+TEST(GeodeDeviceLost, TeardownAfterLossSkipsGpuWaits) {
+  auto device = GeodeDevice::CreateHeadless();
+  ASSERT_NE(device, nullptr);
+
+  wgpu::CommandEncoder encoder = device->device().createCommandEncoder();
+  wgpu::CommandBuffer cmd = encoder.finish();
+  device->queue().submit(1, &cmd);
+  device->markDeviceLost("test-injected loss before teardown");
+
+  const auto start = std::chrono::steady_clock::now();
+  device.reset();
+  const auto elapsed = std::chrono::steady_clock::now() - start;
+  EXPECT_LT(elapsed, std::chrono::seconds(1))
+      << "post-loss teardown must not run bounded GPU waits";
+}
+
+/// An embedder-shared lost flag (GeodeEmbedConfig::lostState) is observed by
+/// the wrapper, and a loss marked through the wrapper is visible to the
+/// embedder: the flag converges both directions.
+TEST(GeodeDeviceLost, ExternalConfigSharesLostState) {
+  auto headless = GeodeDevice::CreateHeadless();
+  ASSERT_NE(headless, nullptr);
+
+  auto lostState = std::make_shared<GeodeDeviceLostState>();
+  GeodeEmbedConfig config;
+  config.device = headless->device();
+  config.queue = headless->queue();
+  config.lostState = lostState;
+  auto external = GeodeDevice::CreateFromExternal(config);
+  ASSERT_NE(external, nullptr);
+
+  EXPECT_FALSE(external->isDeviceLost());
+  lostState->lost.store(true, std::memory_order_release);
+  EXPECT_TRUE(external->isDeviceLost());
+
+  // Reset the shared flag and mark through the wrapper instead.
+  lostState->lost.store(false, std::memory_order_release);
+  external->markDeviceLost("wrapper-marked loss");
+  EXPECT_TRUE(lostState->lost.load(std::memory_order_acquire));
+
+  // The external wrapper's destructor must skip GPU waits (the flag is
+  // set); destroy it before the headless owner so the underlying device
+  // outlives the wrapper.
+  external.reset();
 }
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/tests/GeodeDevice_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeDevice_tests.cc
@@ -11,8 +11,8 @@
 #include <string_view>
 
 #include "donner/svg/renderer/geode/GeodeCallbackState.h"
-#include "donner/svg/renderer/geode/GeodeGpuWait.h"
 #include "donner/svg/renderer/geode/GeodeFilterEngine.h"
+#include "donner/svg/renderer/geode/GeodeGpuWait.h"
 #include "donner/svg/renderer/geode/GeodeImagePipeline.h"
 #include "donner/svg/renderer/geode/GeodePipeline.h"
 #include "donner/svg/renderer/geode/GeodeWgpuUtil.h"

--- a/donner/svg/renderer/geode/tests/GeodeGpuWait_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeGpuWait_tests.cc
@@ -1,0 +1,139 @@
+/// @file
+/// Tests for \ref donner::geode::BoundedGpuWait.
+///
+/// All timing is driven through the injectable clock/sleep hooks: no test
+/// here performs a real sleep, and a stalled wait is simulated by a poll that
+/// never observes completion. A true red-run against the previous unbounded
+/// behavior is impossible by construction (an unbounded wait on a stalled
+/// poll never returns, so the test process would hang forever instead of
+/// failing); the bounded contract is pinned here instead.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <vector>
+
+#include "donner/svg/renderer/geode/GeodeGpuWait.h"
+
+namespace donner::geode {
+namespace {
+
+using namespace std::chrono_literals;
+
+/// Deterministic fake time source: `now` returns the accumulated fake time,
+/// and `sleep` advances it. A wait loop under these hooks makes progress only
+/// through its own sleep calls, so poll counts and elapsed fake time are
+/// exact.
+struct FakeClock {
+  std::chrono::steady_clock::time_point current{};
+  std::vector<std::chrono::microseconds> sleeps;
+
+  GpuWaitTestHooks hooks() {
+    GpuWaitTestHooks result;
+    result.now = [this] { return current; };
+    result.sleep = [this](std::chrono::microseconds duration) {
+      sleeps.push_back(duration);
+      current += duration;
+    };
+    return result;
+  }
+};
+
+TEST(BoundedGpuWait, CompletesImmediatelyWithoutSleeping) {
+  FakeClock clock;
+  int pollCount = 0;
+  const GpuWaitResult result = BoundedGpuWait(
+      [&pollCount] {
+        ++pollCount;
+        return true;
+      },
+      5000ms, 100us, clock.hooks());
+
+  EXPECT_EQ(result, GpuWaitResult::Complete);
+  EXPECT_EQ(pollCount, 1);
+  EXPECT_TRUE(clock.sleeps.empty());
+}
+
+TEST(BoundedGpuWait, CompletesAfterSeveralPolls) {
+  FakeClock clock;
+  int pollCount = 0;
+  const GpuWaitResult result = BoundedGpuWait(
+      [&pollCount] {
+        ++pollCount;
+        return pollCount >= 5;
+      },
+      5000ms, 100us, clock.hooks());
+
+  EXPECT_EQ(result, GpuWaitResult::Complete);
+  EXPECT_EQ(pollCount, 5);
+  // One sleep between each pending poll and the next.
+  EXPECT_EQ(clock.sleeps.size(), 4u);
+  for (const auto& duration : clock.sleeps) {
+    EXPECT_EQ(duration, 100us);
+  }
+}
+
+TEST(BoundedGpuWait, StalledPollTimesOutAtTheDeadline) {
+  FakeClock clock;
+  int pollCount = 0;
+  const GpuWaitResult result = BoundedGpuWait(
+      [&pollCount] {
+        ++pollCount;
+        return false;  // Simulated hung device: completion is never observed.
+      },
+      10ms, 100us, clock.hooks());
+
+  EXPECT_EQ(result, GpuWaitResult::TimedOut);
+  // 10 ms budget at a 100 us cadence: exactly 100 sleeps, and the poll after
+  // the deadline-crossing sleep is the last one. Exact counts pin that the
+  // loop neither spins without sleeping nor overshoots the deadline by more
+  // than one interval.
+  EXPECT_EQ(clock.sleeps.size(), 100u);
+  EXPECT_EQ(pollCount, 101);
+  EXPECT_EQ(clock.current.time_since_epoch(), std::chrono::microseconds(10'000));
+}
+
+TEST(BoundedGpuWait, ZeroTimeoutPollsOnceThenTimesOut) {
+  FakeClock clock;
+  int pollCount = 0;
+  const GpuWaitResult result = BoundedGpuWait(
+      [&pollCount] {
+        ++pollCount;
+        return false;
+      },
+      0ms, 100us, clock.hooks());
+
+  EXPECT_EQ(result, GpuWaitResult::TimedOut);
+  // Even a zero budget gives the condition one poll (a completed wait must
+  // never be reported as a timeout), but sleeps nothing.
+  EXPECT_EQ(pollCount, 1);
+  EXPECT_TRUE(clock.sleeps.empty());
+}
+
+TEST(BoundedGpuWait, ZeroPollIntervalDoesNotSleep) {
+  FakeClock clock;
+  int pollCount = 0;
+  // A zero interval must not call the sleep hook at all (busy-poll mode used
+  // by tests); the deadline still bounds the loop because the fake clock is
+  // advanced manually here through `now`.
+  GpuWaitTestHooks hooks = clock.hooks();
+  hooks.now = [&clock, &pollCount] {
+    // Advance fake time 1 ms per deadline check so the loop terminates.
+    clock.current += 1ms;
+    (void)pollCount;
+    return clock.current;
+  };
+  const GpuWaitResult result = BoundedGpuWait(
+      [&pollCount] {
+        ++pollCount;
+        return false;
+      },
+      5ms, 0us, hooks);
+
+  EXPECT_EQ(result, GpuWaitResult::TimedOut);
+  EXPECT_TRUE(clock.sleeps.empty());
+  EXPECT_GE(pollCount, 1);
+}
+
+}  // namespace
+}  // namespace donner::geode

--- a/donner/svg/renderer/geode/tests/GeodeGpuWait_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeGpuWait_tests.cc
@@ -8,12 +8,12 @@
 /// poll never returns, so the test process would hang forever instead of
 /// failing); the bounded contract is pinned here instead.
 
+#include "donner/svg/renderer/geode/GeodeGpuWait.h"
+
 #include <gtest/gtest.h>
 
 #include <chrono>
 #include <vector>
-
-#include "donner/svg/renderer/geode/GeodeGpuWait.h"
 
 namespace donner::geode {
 namespace {

--- a/donner/svg/renderer/geode/tests/GeodeSnapshotReadback_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeSnapshotReadback_tests.cc
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <utility>
@@ -121,6 +122,45 @@ TEST_F(GeodeSnapshotReadbackTest, GpuAndCpuPathsAreByteIdentical) {
   EXPECT_EQ(gpuBitmap.alphaType, AlphaType::Unpremultiplied);
   EXPECT_EQ(gpuBitmap.pixels, cpuBitmap.pixels)
       << "GPU unpremultiply output differs from the CPU reference path";
+}
+
+/// A snapshot against a lost device must return an empty bitmap promptly
+/// instead of spending the full readback deadline waiting for a map that a
+/// hung driver will never deliver. A fresh (non-shared) device is used so the
+/// injected loss cannot poison the suite's shared device.
+TEST_F(GeodeSnapshotReadbackTest, SnapshotOnLostDeviceFailsFast) {
+  std::shared_ptr<geode::GeodeDevice> device(geode::GeodeDevice::CreateHeadless());
+  ASSERT_NE(device, nullptr);
+
+  wgpu::Texture texture = createTestTexture(
+      device->device(), wgpu::TextureUsage::TextureBinding | wgpu::TextureUsage::CopySrc);
+  const Vector2i dimensions(static_cast<int>(kWidth), static_cast<int>(kHeight));
+  RendererGeodeTextureSnapshot snapshot(device, std::move(texture), dimensions,
+                                        wgpu::TextureFormat::RGBA8Unorm);
+
+  device->markDeviceLost("test-injected loss");
+
+  const auto start = std::chrono::steady_clock::now();
+  const RendererBitmap bitmap = snapshot.takeSnapshot();
+  const auto elapsed = std::chrono::steady_clock::now() - start;
+
+  EXPECT_TRUE(bitmap.empty());
+  // Well under the 10 second readback deadline: the map wait must fail fast
+  // on the lost flag rather than waiting it out.
+  EXPECT_LT(elapsed, std::chrono::seconds(2));
+}
+
+/// RendererGeode surfaces the device-lost condition of its backing device.
+TEST_F(GeodeSnapshotReadbackTest, RendererGeodeReportsDeviceLost) {
+  std::shared_ptr<geode::GeodeDevice> device(geode::GeodeDevice::CreateHeadless());
+  ASSERT_NE(device, nullptr);
+
+  RendererGeode renderer(device);
+  EXPECT_FALSE(renderer.deviceLost());
+  device->markDeviceLost("test-injected loss");
+  EXPECT_TRUE(renderer.deviceLost());
+  // Renderer teardown after the declared loss must not block; the test
+  // completing at all (under the suite timeout) pins that.
 }
 
 }  // namespace

--- a/tools/gpu_inventory/manifests/editor_integration.json
+++ b/tools/gpu_inventory/manifests/editor_integration.json
@@ -189,6 +189,9 @@
       ],
       "wgpuCTypes": [
         "WGPUDevice",
+        "WGPUDeviceLostReason",
+        "WGPUDeviceLostReason_Destroyed",
+        "WGPUDeviceLostReason_InstanceDropped",
         "WGPUEmscriptenSurfaceSourceCanvasHTMLSelector",
         "WGPUErrorType",
         "WGPUInstanceFeatureName",

--- a/tools/gpu_inventory/manifests/gpu_operations.json
+++ b/tools/gpu_inventory/manifests/gpu_operations.json
@@ -152,6 +152,9 @@
       ],
       "wgpuCTypes": [
         "WGPUDevice",
+        "WGPUDeviceLostReason",
+        "WGPUDeviceLostReason_Destroyed",
+        "WGPUDeviceLostReason_InstanceDropped",
         "WGPUEmscriptenSurfaceSourceCanvasHTMLSelector",
         "WGPUErrorType",
         "WGPUInstanceFeatureName",
@@ -581,7 +584,6 @@
         "destroy",
         "getQueue",
         "hasFeature",
-        "onSubmittedWorkDone",
         "poll",
         "requestAdapter",
         "requestDevice",
@@ -628,7 +630,6 @@
         "WGPUInstanceDescriptor",
         "WGPUInstanceFeatureName",
         "WGPUInstanceFeatureName_TimedWaitAny",
-        "WGPUQueueWorkDoneStatus",
         "WGPUStatus_Success",
         "WGPUStringView"
       ],
@@ -650,7 +651,6 @@
         "InstanceDescriptor",
         "InstanceExtras",
         "Queue",
-        "QueueWorkDoneCallbackInfo",
         "RequestAdapterOptions",
         "Sampler",
         "SamplerDescriptor",


### PR DESCRIPTION
Makes the Geode renderer robust against GPU driver hangs. A hung driver could previously leave the renderer blocked forever: an audit of the full stack found infinite waits at device teardown, renderer teardown, the Vulkan filter-chunk barrier (a frame-path wait), the editor main thread's framebuffer readback, a capture tool, and two test helpers, several of them looping on a device poll that blocks unboundedly in the native fence wait.

Every native wait now goes through a small shared helper with a single policy: a non-blocking poll loop with a generous configurable timeout (5 seconds default, the snapshot readback keeps its existing 10 second deadline and its tuned 100 microsecond cadence unchanged). A timeout marks the device lost through a sticky atomic flag; the driver's own device-lost callback converges on the same flag, so driver-reported loss and observed stalls surface as one renderer-level error condition. Snapshots fast-fail on a lost device, and teardown after a declared loss is wait-free: the root device handles are deliberately leaked rather than risking a blocking drain, a bounded leak being strictly better than a blocked thread, with in-flight map callbacks heap-retaining their state so a late-completing GPU cannot touch freed memory.

Detection only by design: nothing switches backends or rebuilds devices here. The embedder decides how to respond to the loss signal; browser-side device.lost subscription and rebuild-on-loss are follow-up work, and the browser code paths are behavior-preserved in this change.

Fault-injection tests pin the wait policy under an injectable clock (exact poll and sleep counts, no real sleeps), and GPU-backed tests assert fast-fail budgets for waits, snapshots, and post-loss teardown. Verified: the geode renderer surface and full repository suite pass in both configurations with the only failure being the pre-existing counter-ratchet entries already fixed on main, attributed against the parent revision; GPU inventory manifests regenerated with freshness and integrity checks green.
