### PR TITLE
fix: Keep recorded scene-batch draws bound to their resolved records

### DIFF
--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1995,16 +1995,21 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
   /// by an earlier recorded batch). Returns false when no slot is
   /// available.
   /// Choose the record slot for a scene-batch instance of `slot` WITHOUT
-  /// marking it used: the primary slot on the entity's first scene use
-  /// this frame (nullptr: the ensure uses the cached write path), or a
-  /// fresh temporary slot for same-frame repeats (the primary slot's
-  /// record is already referenced by an earlier recorded batch). Callers
-  /// mark `slot.lastSceneFrame = currentFrameIndex` only after a
-  /// successful ensure.
+  /// marking it used: the primary slot when nothing this frame references
+  /// it yet (nullptr: the ensure uses the cached write path), or a fresh
+  /// temporary slot for same-frame repeats. The primary slot is off-limits
+  /// when an earlier recorded batch references it (`lastSceneFrame`) AND
+  /// when a solo resident draw was recorded against it (`lastResidentFrame`):
+  /// buffer writes are queue-ordered ahead of every draw in the frame's
+  /// submit, so rewriting the record in scene form would retroactively
+  /// retransform the already-recorded solo draw. Callers mark
+  /// `slot.lastSceneFrame = currentFrameIndex` only after a successful
+  /// ensure.
   bool resolveSceneRecordSlot(geode::GeodeResidentSlot& slot,
                               const geode::GeodeRecordSlab::Slot*& outSlot) {
     outSlot = nullptr;
-    if (slot.lastSceneFrame == currentFrameIndex) {
+    if (slot.lastSceneFrame == currentFrameIndex ||
+        slot.lastResidentFrame == currentFrameIndex) {
       if (!slot.recordSlab) {
         return false;
       }
@@ -2278,6 +2283,22 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       deviceFromLocalTransform = Transform2d();
       syncTransform();
 
+      if (debugGeometryOverlay) {
+        // Ordered batches issue one GPU draw, so the overlay sink never
+        // sees the per-instance geometry through the draw itself. Report
+        // each instance in paint order with the packed-transform wire
+        // format the instanced path uses (encoder transform is identity
+        // here, matching the batch draw's uniform).
+        for (const PendingBatch::SceneInstance& inst : batch.sceneInstances) {
+          if (inst.encoded != nullptr) {
+            float packed[8];
+            packTransform(inst.deviceFromLocal, packed);
+            encoder->recordGeometryDebugInstance(*inst.encoded,
+                                                 std::span<const float>(packed, 8u));
+          }
+        }
+      }
+
       geode::GeoEncoder::SceneBatchBinding binding = {};
       binding.chunkBuffer = batch.sceneChunkBuffer;
       binding.recordBuffer = batch.sceneRecordBuffer;
@@ -2352,6 +2373,25 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
   /// The caller is expected to have already verified the draw is
   /// "batch-compatible" (solid paint, no stroke, has source entity,
   /// has cached fill encode, no in-flight pattern).
+  /// Start a fresh size-1 same-entity batch holding the current draw.
+  /// The caller has already flushed any previous pending batch.
+  void startSameEntitySingleton(const Registry* sourceRegistry, Entity sourceEntity,
+                                const Path& path, const css::RGBA& color, FillRule rule,
+                                const geode::EncodedPath* encoded,
+                                geode::GeodeResidentSlot* residentFillSlot) {
+    pendingBatch = PendingBatch{};
+    pendingBatch->mode = PendingBatch::Mode::SameEntity;
+    pendingBatch->sameEntityClipVersion = encoder->clipStateVersion();
+    pendingBatch->sourceRegistry = sourceRegistry;
+    pendingBatch->sourceEntity = sourceEntity;
+    pendingBatch->color = color;
+    pendingBatch->rule = rule;
+    pendingBatch->encoded = encoded;
+    pendingBatch->path = &path;
+    pendingBatch->residentFillSlot = residentFillSlot;
+    pendingBatch->deviceFromLocalTransforms.push_back(deviceFromLocalTransform);
+  }
+
   bool tryAppendOrStartBatch(const Registry* sourceRegistry, Entity sourceEntity, const Path& path,
                              const css::RGBA& color, FillRule rule,
                              const geode::EncodedPath* encoded,
@@ -2387,6 +2427,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
                                !encoder->hasActiveClipState() &&
                                !encoder->hasActiveScissor() &&
                                residentFillSlot->lastSceneFrame != currentFrameIndex &&
+                               residentFillSlot->lastResidentFrame != currentFrameIndex &&
                                resolveSceneRecordSlot(*residentFillSlot, recordSlotPtr);
     if (sceneEligible &&
         encoder->ensureResidentSceneRecord(*residentFillSlot, *encoded, color, rule,
@@ -2483,7 +2524,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
             pendingBatch->sceneChunkBuffer = chunk;
             pendingBatch->sceneRecordBuffer = recordBuf;
             pendingBatch->sceneFirstInstance = recordIndex;
-          pendingBatch->sceneFirstRecordOffset = effectiveRecordSlot.offset;
+            pendingBatch->sceneFirstRecordOffset = effectiveRecordSlot.offset;
+            pendingBatch->sceneClipVersion = clipVersion;
             appendSceneInstance(*pendingBatch,
                                 PendingBatch::SceneInstance{residentFillSlot, encoded, &path,
                                                             color, rule,
@@ -2491,7 +2533,13 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
                                                             vertexCount});
           }
         } else {
+          // The pending singleton could not take scene form: emit it solo
+          // and keep the CURRENT draw as a fresh singleton. Returning
+          // without recording the current draw would silently drop it
+          // (its ensured record is not referenced by any batch).
           flushPendingBatch();
+          startSameEntitySingleton(sourceRegistry, sourceEntity, path, color, rule, encoded,
+                                   residentFillSlot);
         }
         return true;
       }
@@ -2503,17 +2551,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
         if (pendingBatch.has_value()) {
           flushPendingBatch();
         }
-        pendingBatch = PendingBatch{};
-        pendingBatch->mode = PendingBatch::Mode::SameEntity;
-        pendingBatch->sameEntityClipVersion = clipVersion;
-        pendingBatch->sourceRegistry = sourceRegistry;
-        pendingBatch->sourceEntity = sourceEntity;
-        pendingBatch->color = color;
-        pendingBatch->rule = rule;
-        pendingBatch->encoded = encoded;
-        pendingBatch->path = &path;
-        pendingBatch->residentFillSlot = residentFillSlot;
-        pendingBatch->deviceFromLocalTransforms.push_back(deviceFromLocalTransform);
+        startSameEntitySingleton(sourceRegistry, sourceEntity, path, color, rule, encoded,
+                                 residentFillSlot);
         return true;
       }
 
@@ -2535,17 +2574,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     // Not scene-eligible: flush whatever's pending, then start a fresh
     // same-entity batch.
     flushPendingBatch();
-    pendingBatch = PendingBatch{};
-    pendingBatch->mode = PendingBatch::Mode::SameEntity;
-    pendingBatch->sameEntityClipVersion = encoder->clipStateVersion();
-    pendingBatch->sourceRegistry = sourceRegistry;
-    pendingBatch->sourceEntity = sourceEntity;
-    pendingBatch->color = color;
-    pendingBatch->rule = rule;
-    pendingBatch->encoded = encoded;
-    pendingBatch->path = &path;
-    pendingBatch->residentFillSlot = residentFillSlot;
-    pendingBatch->deviceFromLocalTransforms.push_back(deviceFromLocalTransform);
+    startSameEntitySingleton(sourceRegistry, sourceEntity, path, color, rule, encoded,
+                             residentFillSlot);
     return true;
   }
 

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1999,11 +1999,6 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
   };
   std::deque<SceneTempRecordSlot> sceneTempRecordSlots;
 
-  /// Resolve the record slot for a scene-batch instance of `slot`: the
-  /// entity's primary slot on its first scene use this frame, otherwise a
-  /// fresh temporary slot (the primary slot's record is already referenced
-  /// by an earlier recorded batch). Returns false when no slot is
-  /// available.
   /// Choose the record slot for a scene-batch instance of `slot` WITHOUT
   /// marking it used: the primary slot when nothing this frame references
   /// it yet (nullptr: the ensure uses the cached write path), or a fresh
@@ -2382,14 +2377,6 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     deviceFromLocalTransform = savedDeviceFromLocalTransform;
   }
 
-  /// Predicate: would a batchable draw with this key extend the
-  /// currently pending batch, or does it start a new one? Returns
-  /// true when the current `drawPath` call should NOT emit (because
-  /// it's been absorbed into a batch). Always returns true on a
-  /// non-empty batch state - either appends or flushes + starts new.
-  /// The caller is expected to have already verified the draw is
-  /// "batch-compatible" (solid paint, no stroke, has source entity,
-  /// has cached fill encode, no in-flight pattern).
   /// Start a fresh size-1 same-entity batch holding the current draw.
   /// The caller has already flushed any previous pending batch.
   void startSameEntitySingleton(const Registry* sourceRegistry, Entity sourceEntity,
@@ -2409,6 +2396,14 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     pendingBatch->deviceFromLocalTransforms.push_back(deviceFromLocalTransform);
   }
 
+  /// Predicate: would a batchable draw with this key extend the
+  /// currently pending batch, or does it start a new one? Returns
+  /// true when the current `drawPath` call should NOT emit (because
+  /// it's been absorbed into a batch). Always returns true on a
+  /// non-empty batch state - either appends or flushes + starts new.
+  /// The caller is expected to have already verified the draw is
+  /// "batch-compatible" (solid paint, no stroke, has source entity,
+  /// has cached fill encode, no in-flight pattern).
   bool tryAppendOrStartBatch(const Registry* sourceRegistry, Entity sourceEntity, const Path& path,
                              const css::RGBA& color, FillRule rule,
                              const geode::EncodedPath* encoded,
@@ -2582,7 +2577,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       pendingBatch->sceneChunkBuffer = chunk;
       pendingBatch->sceneRecordBuffer = recordBuf;
       pendingBatch->sceneFirstInstance = recordIndex;
-          pendingBatch->sceneFirstRecordOffset = effectiveRecordSlot.offset;
+      pendingBatch->sceneFirstRecordOffset = effectiveRecordSlot.offset;
       pendingBatch->sceneClipVersion = clipVersion;
       appendSceneInstance(*pendingBatch,
                           PendingBatch::SceneInstance{residentFillSlot, encoded, &path, color,

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1950,6 +1950,16 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       FillRule rule = FillRule::NonZero;
       Transform2d deviceFromLocal;
       uint32_t vertexCount = 0;
+      /// Record slot resolved by `resolveSceneRecordSlot` for THIS
+      /// instance: null means the slot's primary record; non-null points
+      /// into `sceneTempRecordSlots` (a deque, so the address is stable
+      /// for the rest of the frame) when the primary record was already
+      /// referenced this frame. The flush-time re-ensure MUST pass this
+      /// same slot - re-ensuring a temp-diverted instance against the
+      /// primary record would queue a buffer write that retroactively
+      /// retransforms the earlier draw that references the primary
+      /// (buffer writes execute before every draw at submit).
+      const geode::GeodeRecordSlab::Slot* recordSlotOverride = nullptr;
     };
     /// Consecutive instances. Each instance's record-slab slot index must
     /// be `firstInstanceIndex + i`, its geometry must live in the same
@@ -2310,11 +2320,18 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       const FillRule batchRule = batch.sceneInstances.front().rule;
       // Ensure each instance's geometry + batch-form record immediately
       // before the draw that consumes them, so solo flushes never observe
-      // the batch form's bytes.
+      // the batch form's bytes. Pass each instance's resolved record slot:
+      // a temp-diverted instance must re-ensure its TEMP record, never the
+      // primary (a primary write here would retroactively retransform the
+      // earlier draw that references the primary record, because all
+      // buffer writes execute before all draws at submit). For
+      // primary-slot instances the cached-record compare makes this a
+      // no-op when the record is unchanged.
       for (const PendingBatch::SceneInstance& inst : batch.sceneInstances) {
         if (inst.slot != nullptr && inst.encoded != nullptr) {
           (void)encoder->ensureResidentSceneRecord(*inst.slot, *inst.encoded, inst.color,
-                                                   inst.rule, inst.deviceFromLocal, nullptr);
+                                                   inst.rule, inst.deviceFromLocal,
+                                                   inst.recordSlotOverride);
         }
       }
       encoder->fillPathSceneBatch(batchColor, batchRule, binding);
@@ -2458,7 +2475,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
           appendSceneInstance(*pendingBatch,
                               PendingBatch::SceneInstance{residentFillSlot, encoded, &path, color,
                                                           rule, deviceFromLocalTransform,
-                                                          vertexCount});
+                                                          vertexCount, recordSlotPtr});
         } else {
           flushPendingBatch();
           pendingBatch = PendingBatch{};
@@ -2471,7 +2488,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
           appendSceneInstance(*pendingBatch,
                               PendingBatch::SceneInstance{residentFillSlot, encoded, &path, color,
                                                           rule, deviceFromLocalTransform,
-                                                          vertexCount});
+                                                          vertexCount, recordSlotPtr});
         }
         return true;
       }
@@ -2497,6 +2514,9 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
                                                first.rule, first.deviceFromLocal,
                                                firstRecordSlotPtr)) {
           first.slot->lastSceneFrame = currentFrameIndex;
+          // Carry the resolved slot on the instance so the flush-time
+          // re-ensure targets the same record this batch draws from.
+          first.recordSlotOverride = firstRecordSlotPtr;
           const geode::GeodeRecordSlab::Slot& effectiveFirstRecordSlot =
               firstRecordSlotPtr != nullptr ? *firstRecordSlotPtr : first.slot->recordSlot;
           const wgpu::Buffer firstChunk = first.slot->buffer;
@@ -2516,7 +2536,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
                                 PendingBatch::SceneInstance{residentFillSlot, encoded, &path,
                                                             color, rule,
                                                             deviceFromLocalTransform,
-                                                            vertexCount});
+                                                            vertexCount, recordSlotPtr});
           } else {
             flushPendingBatch();
             pendingBatch = PendingBatch{};
@@ -2530,7 +2550,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
                                 PendingBatch::SceneInstance{residentFillSlot, encoded, &path,
                                                             color, rule,
                                                             deviceFromLocalTransform,
-                                                            vertexCount});
+                                                            vertexCount, recordSlotPtr});
           }
         } else {
           // The pending singleton could not take scene form: emit it solo
@@ -2567,7 +2587,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       appendSceneInstance(*pendingBatch,
                           PendingBatch::SceneInstance{residentFillSlot, encoded, &path, color,
                                                       rule, deviceFromLocalTransform,
-                                                      vertexCount});
+                                                      vertexCount, recordSlotPtr});
       return true;
     }
 

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -347,6 +347,27 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
     uint64_t offset;
     uint64_t size;
   };
+  /// One shared uniform allocation for every scene-batch draw this encoder
+  /// records while the uniform bytes stay unchanged (identity mvp plus
+  /// frame-constant viewport / clip / antialias state, so in practice all
+  /// batches of a frame). Sharing keeps the batch bind-group cache key
+  /// stable across batches and frames and drops the per-batch uniform
+  /// write.
+  std::vector<uint8_t> sceneBatchUniformBytes;
+  Allocation sceneBatchUniformAlloc = {};
+
+  Allocation allocSceneBatchUniform(const Uniforms& u) {
+    const auto* bytes = reinterpret_cast<const uint8_t*>(&u);
+    if (sceneBatchUniformAlloc.buffer && sceneBatchUniformBytes.size() == sizeof(Uniforms) &&
+        std::memcmp(sceneBatchUniformBytes.data(), bytes, sizeof(Uniforms)) == 0) {
+      return sceneBatchUniformAlloc;
+    }
+    sceneBatchUniformAlloc = allocInArena(uniformArena, &u, sizeof(Uniforms),
+                                          kUniformOffsetAlignment);
+    sceneBatchUniformBytes.assign(bytes, bytes + sizeof(Uniforms));
+    return sceneBatchUniformAlloc;
+  }
+
   /// Grow `arena` so at least `size` bytes fit from offset 0: retire the
   /// current buffer (already-recorded commands keep referencing it through
   /// encoder submission) and install a pooled or fresh larger one. Returns
@@ -1962,8 +1983,7 @@ void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,
 
   Uniforms u = {};
   impl_->populateBatchUniform(u, args, Transform2d(), /*identityMvp=*/true);
-  const auto uniAlloc =
-      impl_->allocInArena(impl_->uniformArena, &u, sizeof(Uniforms), kUniformOffsetAlignment);
+  const auto uniAlloc = impl_->allocSceneBatchUniform(u);
 
   // Whole-chunk views: valid while a chunk stays under the device's
   // maxStorageBufferBindingSize (default 128 MiB); kInitialChunkBytes
@@ -2003,14 +2023,30 @@ void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,
   chunkEntry(9, 9);
   chunkEntry(10, 10);
 
-  wgpu::BindGroupDescriptor bgDesc = {};
-  bgDesc.label = wgpuLabel("GeodeSceneBatchBindGroup");
-  bgDesc.layout = impl_->pipeline->bindGroupLayout();
-  bgDesc.entryCount = 11;
-  bgDesc.entries = entries;
-  wgpu::BindGroup bindGroup =
-      impl_->transientResources.retain(impl_->device->device().createBindGroup(bgDesc));
-  impl_->device->countBindGroup();
+  GeodeDevice::SceneBatchBindGroupKey cacheKey = {};
+  cacheKey.uniformBuffer = uniAlloc.buffer;
+  cacheKey.uniformOffset = uniAlloc.offset;
+  cacheKey.uniformSize = uniAlloc.size;
+  cacheKey.chunkBuffer = binding.chunkBuffer;
+  cacheKey.chunkBytes = chunkBytes;
+  cacheKey.recordBuffer = binding.recordBuffer;
+  cacheKey.recordOffset = recordSpanStart;
+  cacheKey.recordBytes = recordSpanBytes;
+
+  wgpu::BindGroup bindGroup = impl_->device->findSceneBatchBindGroup(cacheKey);
+  if (!bindGroup) {
+    wgpu::BindGroupDescriptor bgDesc = {};
+    bgDesc.label = wgpuLabel("GeodeSceneBatchBindGroup");
+    bgDesc.layout = impl_->pipeline->bindGroupLayout();
+    bgDesc.entryCount = 11;
+    bgDesc.entries = entries;
+    wgpu::BindGroup created = impl_->device->device().createBindGroup(bgDesc);
+    impl_->device->countBindGroup();
+    bindGroup = created;
+    // The cache takes ownership of the +1 handle and keeps the bound
+    // buffers alive for the entry's lifetime.
+    impl_->device->storeSceneBatchBindGroup(cacheKey, std::move(created));
+  }
 
   // The binding covers the span of consecutive record slots starting at
   // `firstInstance`; the shader's instance_index therefore runs 0..N-1

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -1345,6 +1345,11 @@ void GeoEncoder::setBufferPool(GeodeBufferPool* pool) {
   impl_->bufferPool = pool;
 }
 
+void GeoEncoder::recordGeometryDebugInstance(const EncodedPath& encoded,
+                                             std::span<const float> instanceTransforms) {
+  impl_->recordGeometryDebugDraw(encoded, instanceTransforms);
+}
+
 void GeoEncoder::setGeometryDebugSink(GeometryDebugSink* sink, const Transform2d& rootFromTarget) {
   impl_->geometryDebugSink = sink;
   impl_->geometryDebugRootFromTarget = rootFromTarget;
@@ -1742,14 +1747,22 @@ bool GeoEncoder::Impl::ensureResidentSceneRecordImpl(GeodeResidentSlot& slot,
   //   - Scene batch (orthographic uniform): uniforms.mvp is the
   //     orthographic mapping and the record carries the caller's
   //     per-instance transform, so one uniform serves every instance.
-  Uniforms u = {};
-  populateBatchUniform(u, args, transform, /*identityMvp=*/!bakeTransform);
-  const auto* uBytes = reinterpret_cast<const uint8_t*>(&u);
-  if (slot.lastUniform.size() != sizeof(Uniforms) ||
-      std::memcmp(slot.lastUniform.data(), uBytes, sizeof(Uniforms)) != 0) {
-    device->queue().writeBuffer(slot.buffer, slot.uniform.offset, &u, sizeof(Uniforms));
-    device->countBufferWrite(sizeof(Uniforms));
-    slot.lastUniform.assign(uBytes, uBytes + sizeof(Uniforms));
+  // The slot's uniform region belongs exclusively to the solo resident
+  // draw: scene batches bind a per-batch arena uniform instead, so the
+  // scene form must not write it. Buffer writes are queue-ordered ahead
+  // of every draw in the frame's single submit, so a scene-form write
+  // after a recorded solo draw would retroactively change that draw's
+  // uniform (last write wins at submit time).
+  if (bakeTransform) {
+    Uniforms u = {};
+    populateBatchUniform(u, args, transform, /*identityMvp=*/false);
+    const auto* uBytes = reinterpret_cast<const uint8_t*>(&u);
+    if (slot.lastUniform.size() != sizeof(Uniforms) ||
+        std::memcmp(slot.lastUniform.data(), uBytes, sizeof(Uniforms)) != 0) {
+      device->queue().writeBuffer(slot.buffer, slot.uniform.offset, &u, sizeof(Uniforms));
+      device->countBufferWrite(sizeof(Uniforms));
+      slot.lastUniform.assign(uBytes, uBytes + sizeof(Uniforms));
+    }
   }
 
   InstanceRecord record = {};

--- a/donner/svg/renderer/geode/GeoEncoder.h
+++ b/donner/svg/renderer/geode/GeoEncoder.h
@@ -199,6 +199,17 @@ public:
    * renderer's final target. Pass null to disable observation. The default
    * path stores one pointer and one branch per actual Slug submission.
    */
+  /**
+   * Record one scene-batch instance's geometry into the debug-overlay sink
+   * (no-op without a sink). Ordered batches issue a single GPU draw, so the
+   * caller reports each batched instance here in paint order, passing the
+   * instance's transform in the same packed 8-float wire format instanced
+   * draws use. The encoder transform must already be identity, matching the
+   * batch draw's uniform.
+   */
+  void recordGeometryDebugInstance(const EncodedPath& encoded,
+                                   std::span<const float> instanceTransforms);
+
   void setGeometryDebugSink(GeometryDebugSink* sink,
                             const Transform2d& rootFromTarget = Transform2d());
 

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -854,6 +854,20 @@ void GeodeDevice::initSharedPipelines() {
   impl_->filterEngine = std::make_unique<GeodeFilterEngine>(*this, /*verbose=*/false);
 }
 
+wgpu::BindGroup GeodeDevice::findSceneBatchBindGroup(
+    const SceneBatchBindGroupKey& key) const {
+  const auto it = sceneBatchBindGroups_.find(key);
+  return it != sceneBatchBindGroups_.end() ? it->second.get() : wgpu::BindGroup{};
+}
+
+void GeodeDevice::storeSceneBatchBindGroup(const SceneBatchBindGroupKey& key,
+                                           wgpu::BindGroup group) {
+  if (sceneBatchBindGroups_.size() >= kSceneBatchBindGroupCacheCap) {
+    sceneBatchBindGroups_.clear();
+  }
+  sceneBatchBindGroups_[key] = ScopedWgpuHandle<wgpu::BindGroup>(std::move(group));
+}
+
 void GeodeDevice::deferDestroy(wgpu::Buffer buffer) {
   if (buffer) {
     pendingBuffers_.push_back(ScopedWgpuHandle<wgpu::Buffer>(std::move(buffer)));

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -4,7 +4,9 @@
 
 #include <atomic>
 #include <cstddef>
+#include <map>
 #include <memory>
+#include <tuple>
 #include <vector>
 #include <webgpu/webgpu.hpp>
 
@@ -241,6 +243,48 @@ public:
   [[nodiscard]] std::size_t deferredTextureDestroyCountForTesting() const {
     return pendingTextures_.size();
   }
+
+  /**
+   * Key identifying a scene-batch bind group by its exact buffer bindings:
+   * the shared batch uniform allocation, the geometry slab chunk, and the
+   * record span. The dummy texture/sampler bindings are device-owned
+   * singletons, so they never contribute to the key.
+   *
+   * Scene batches bind pooled arena and slab buffers whose identities and
+   * offsets are stable across steady-state frames, so a cached bind group
+   * keyed this way is reusable frame over frame (keeping the per-frame
+   * bind-group create count flat; the GeodePerf ceilings pin this). A
+   * cached entry holds a reference to its bind group, which in turn keeps
+   * every bound buffer alive, so a raw handle in a live key can never be
+   * recycled for a different buffer.
+   */
+  struct SceneBatchBindGroupKey {
+    WGPUBuffer uniformBuffer = nullptr;
+    uint64_t uniformOffset = 0;
+    uint64_t uniformSize = 0;
+    WGPUBuffer chunkBuffer = nullptr;
+    uint64_t chunkBytes = 0;
+    WGPUBuffer recordBuffer = nullptr;
+    uint64_t recordOffset = 0;
+    uint64_t recordBytes = 0;
+
+    friend bool operator<(const SceneBatchBindGroupKey& a, const SceneBatchBindGroupKey& b) {
+      return std::tie(a.uniformBuffer, a.uniformOffset, a.uniformSize, a.chunkBuffer, a.chunkBytes,
+                      a.recordBuffer, a.recordOffset, a.recordBytes) <
+             std::tie(b.uniformBuffer, b.uniformOffset, b.uniformSize, b.chunkBuffer, b.chunkBytes,
+                      b.recordBuffer, b.recordOffset, b.recordBytes);
+    }
+  };
+
+  /// Look up a cached scene-batch bind group. Returns a borrowed handle
+  /// (valid while the cache entry lives), or an empty handle on miss.
+  [[nodiscard]] wgpu::BindGroup findSceneBatchBindGroup(const SceneBatchBindGroupKey& key) const;
+
+  /// Store a scene-batch bind group under `key`, taking ownership of the
+  /// +1 handle. Clears the whole cache first when it reaches the cap
+  /// (recorded command buffers keep their own references, so dropping the
+  /// cache's handles mid-frame is safe).
+  void storeSceneBatchBindGroup(const SceneBatchBindGroupKey& key, wgpu::BindGroup group);
 
   /**
    * Process-unique identity for this device instance, assigned at
@@ -528,6 +572,11 @@ private:
   // alive until drainDeferredDestroys() drops them at the next frame boundary.
   std::vector<ScopedWgpuHandle<wgpu::Buffer>> pendingBuffers_;
   std::vector<ScopedWgpuHandle<wgpu::Texture>> pendingTextures_;
+
+  // Scene-batch bind groups cached across frames (see
+  // SceneBatchBindGroupKey). Bounded by kSceneBatchBindGroupCacheCap.
+  static constexpr std::size_t kSceneBatchBindGroupCacheCap = 256;
+  std::map<SceneBatchBindGroupKey, ScopedWgpuHandle<wgpu::BindGroup>> sceneBatchBindGroups_;
 };
 
 }  // namespace donner::geode

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <cinttypes>
 #include <cstdint>
 #include <cstdio>
@@ -1088,6 +1089,108 @@ TEST_F(GeodePerfTest, GpuResidence_ReUploadsWhenDeviceChanges) {
   const RendererBitmap reReferenceA = rendererA2.takeSnapshot();
   EXPECT_TRUE(bitmapsEqual(referenceA, reReferenceA))
       << "device A output changed after a device-B render round-trip";
+}
+
+// ---------------------------------------------------------------------------
+// Regression: a non-adjacent same-frame reuse of an entity must not
+// retransform the entity's EARLIER draw.
+//
+// Scenario (reachable when cross-entity record-slab batching is enabled):
+// entity A is drawn early at transform T1 and that draw's record targets
+// A's PRIMARY record slot. A is reused later in the same frame at
+// transform T2, separated from its first draw by other content, so the
+// reuse lands in a size-1 same-entity batch instead of extending an
+// instanced run. The next draw is a different batch-compatible entity,
+// which converts that singleton into a cross-entity batch; the
+// conversion diverts A to a fresh TEMPORARY record slot because A's
+// primary record is already referenced this frame.
+//
+// The bug: the batch's flush-time re-ensure ignored the diverted slot
+// and recomputed the record against A's PRIMARY slot. The recomputed
+// (T2) record differs from the primary's cached (T1) bytes, so a buffer
+// write was queued into the primary record. All buffer writes execute
+// before all draws in the frame's submit, so A's EARLIER draw rendered
+// at T2: the first instance vanished from its correct position while
+// the converting batch itself (reading the temp slot) looked fine.
+//
+// The assertions are absolute pixel checks at rect centers, so the test
+// is meaningful in both batching configurations: with cross-entity
+// batching compiled out it documents the correct output; with it
+// enabled it fails on the pre-fix code (first `<use>` instance missing
+// at (30, 30)) and passes once each instance's flush-time re-ensure
+// targets the exact record slot its batch draws from.
+// ---------------------------------------------------------------------------
+
+// Draw order (document order): A@T1, B1, A@T2, B2. All solid fills,
+// disjoint rects, no clip / stroke / gradient, so every draw is
+// batch-compatible and the two `<use>` draws are non-adjacent.
+constexpr std::string_view kNonAdjacentReuseSvg = R"SVG(
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+     viewBox="0 0 300 100">
+  <defs>
+    <rect id="a" width="40" height="40" fill="#ff0000"/>
+  </defs>
+  <use xlink:href="#a" x="10" y="10"/>
+  <rect x="60" y="10" width="40" height="40" fill="#0000ff"/>
+  <use xlink:href="#a" x="110" y="10"/>
+  <rect x="160" y="10" width="40" height="40" fill="#00cc00"/>
+</svg>
+)SVG";
+
+// Assert the RGBA bytes at (x, y). Sample points sit at rect centers,
+// 20px from every edge, so antialiasing cannot reach them and exact
+// byte equality is safe (solid fills, alpha 255).
+void expectPixel(const RendererBitmap& bmp, int x, int y, const std::array<uint8_t, 4>& expected,
+                 const char* what) {
+  ASSERT_LT(x, bmp.dimensions.x);
+  ASSERT_LT(y, bmp.dimensions.y);
+  const uint8_t* p =
+      bmp.pixels.data() + static_cast<size_t>(y) * bmp.rowBytes + static_cast<size_t>(x) * 4u;
+  EXPECT_TRUE(p[0] == expected[0] && p[1] == expected[1] && p[2] == expected[2] &&
+              p[3] == expected[3])
+      << what << " at (" << x << ", " << y << "): expected rgba(" << int(expected[0]) << ", "
+      << int(expected[1]) << ", " << int(expected[2]) << ", " << int(expected[3]) << "), got rgba("
+      << int(p[0]) << ", " << int(p[1]) << ", " << int(p[2]) << ", " << int(p[3]) << ")";
+}
+
+TEST_F(GeodePerfTest, NonAdjacentReuse_EarlierDrawKeepsItsTransform) {
+  auto device = sharedDevice();
+  ASSERT_TRUE(device) << "GeodeDevice::CreateHeadless failed";
+
+  ParseWarningSink sink = ParseWarningSink::Disabled();
+  auto parsed = parser::SVGParser::ParseSVG(kNonAdjacentReuseSvg, sink);
+  ASSERT_FALSE(parsed.hasError()) << parsed.error().reason;
+  SVGDocument document = std::move(parsed.result());
+
+  RendererGeode renderer(device);
+  // Two frames: frame 1 establishes GPU residence and record slots;
+  // frame 2 is the steady state where every draw is record-slot
+  // eligible. The hazard reproduces on both; the snapshot reads the
+  // second frame (the general case).
+  renderer.draw(document);
+  renderer.draw(document);
+  const RendererBitmap bmp = renderer.takeSnapshot();
+  ASSERT_FALSE(bmp.empty()) << "renderer produced no snapshot";
+  ASSERT_EQ(bmp.dimensions.x, 300);
+  ASSERT_EQ(bmp.dimensions.y, 100);
+
+  const std::array<uint8_t, 4> red = {255, 0, 0, 255};
+  const std::array<uint8_t, 4> blue = {0, 0, 255, 255};
+  const std::array<uint8_t, 4> green = {0, 204, 0, 255};
+  const std::array<uint8_t, 4> clear = {0, 0, 0, 0};
+
+  // The first `<use>` of #a must still render at its own position.
+  // Pre-fix, the flush-time primary-record rewrite retransformed this
+  // draw to the second `<use>`'s position and this pixel went empty.
+  expectPixel(bmp, 30, 30, red, "first <use> instance");
+  // Separating content between the two `<use>` draws.
+  expectPixel(bmp, 80, 30, blue, "separating rect");
+  // The second `<use>` of #a at its own position.
+  expectPixel(bmp, 130, 30, red, "second <use> instance");
+  // The batch-compatible entity that triggers the singleton conversion.
+  expectPixel(bmp, 180, 30, green, "converting rect");
+  // Background stays empty - nothing rendered where nothing was drawn.
+  expectPixel(bmp, 260, 80, clear, "background");
 }
 
 }  // namespace

--- a/tools/gpu_inventory/manifests/gpu_operations.json
+++ b/tools/gpu_inventory/manifests/gpu_operations.json
@@ -637,6 +637,7 @@
         "Adapter",
         "AddressMode",
         "BackendType",
+        "BindGroup",
         "Buffer",
         "BufferDescriptor",
         "BufferUsage",
@@ -674,8 +675,12 @@
       "wgpuCFunctions": [
         "wgpuDevicePoll"
       ],
+      "wgpuCTypes": [
+        "WGPUBuffer"
+      ],
       "wgpuCppTokens": [
         "Adapter",
+        "BindGroup",
         "Buffer",
         "Device",
         "Instance",


### PR DESCRIPTION
Fixes the rendering corruption that kept the scene-batching flag disabled. All buffer writes in a frame execute before any draw at submit time, so any write to resident state after a draw referencing it was recorded silently retransforms that earlier draw. Four instances of this class are fixed: eligibility checks no longer write the slot uniform that belongs to solo draws; the record resolver diverts to a temporary record slot when the primary was referenced this frame by either an earlier batch or a solo draw; a conversion fallback that silently dropped the current draw now starts a fresh singleton holding it; and batch flushes now re-ensure each instance against its resolved record slot rather than unconditionally against the primary, which previously defeated the divert for an entity reused non-adjacently and then converted into a scene batch.

With batching enabled locally, renders are pixel-identical to the disabled configuration across the full resvg corpus (1212 of 1212 comparisons, including every marker and overflow case), and dense scenes confirm the machinery's purpose: Ghostscript Tiger drops from 304 to 153 draw calls and lion from 132 to 1, with bind-group creations pinned at one by a new bind-group cache keyed on exact buffer bindings. A regression test pins the non-adjacent-reuse case with absolute pixel assertions, demonstrated failing before the fix with the exact corruption signature. The batching flag itself stays disabled in this change; enabling it ships separately with the steady-state counter gate as its acceptance bar.

Scene flushes also now report per-instance geometry to the debug overlay in paint order, and all scene batches in a frame share one arena uniform allocation. Verification: the geode renderer surface and full repository suite pass in both flag states, with the only failure being a known environment-specific case reproduced identically at the base revision.
