### PR TITLE
perf: Cut SVG parse time another third via dispatch tables and single-parse attributes

### DIFF
--- a/donner/base/ChunkedString.h
+++ b/donner/base/ChunkedString.h
@@ -2,7 +2,9 @@
 
 #include <cassert>
 #include <cstddef>
+#include <optional>
 #include <ostream>
+#include <string_view>
 #include <vector>
 
 #include "donner/base/RcString.h"
@@ -204,6 +206,24 @@ public:
   }
 
   /**
+   * Return the whole string as one contiguous view, when it is stored as a single chunk.
+   *
+   * Reading characters through \ref operator[] has to locate the chunk holding each position and
+   * unwrap a variant to reach its bytes. A string usually holds exactly one chunk - extra chunks
+   * only appear once entity expansion or concatenation has spliced content together - so a loop
+   * that scans character by character can hoist this view once and index it directly instead.
+   *
+   * @return A view of the entire string, or \c std::nullopt when it spans zero or several chunks.
+   */
+  std::optional<std::string_view> singleChunkView() const UTILS_LIFETIME_BOUND {
+    if (pieces_.size() == 1) {
+      return std::string_view(pieces_[0]);
+    }
+
+    return std::nullopt;
+  }
+
+  /**
    * Return the total length of the string.
    */
   size_t size() const { return totalLength_; }
@@ -231,6 +251,11 @@ public:
    */
   char operator[](size_t pos) const {
     assert(pos < totalLength_ && "Index out of bounds");
+
+    // A single chunk covers the whole string, so the position needs no chunk search.
+    if (pieces_.size() == 1) {
+      return std::string_view(pieces_[0])[pos];
+    }
 
     size_t currentPos = 0;
     for (const auto& piece : pieces_) {

--- a/donner/base/xml/XMLNode.cc
+++ b/donner/base/xml/XMLNode.cc
@@ -419,15 +419,30 @@ std::optional<XMLAttributeSourceLocation> XMLNode::getAttributeSourceLocation(
 void XMLNode::setAttributeSourceLocation(const XMLQualifiedNameRef& name, SourceRange fullRange,
                                          SourceRange valueRange, char quote) {
   auto& attributes = handle_.get_or_emplace<AttributesComponent>();
-  if (!attributes.hasAttribute(name)) {
+
+  // Every step below - the existence check, the read of the previous anchors, the write of the new
+  // ones, and the clear on each failure path - concerns the same attribute. Resolve it once; the
+  // attribute set is not modified in between, so the slot stays valid for the whole function.
+  std::optional<AttributesComponent::AttributeSourceAnchors>* anchorSlot =
+      attributes.attributeSourceAnchorsSlot(name);
+  if (anchorSlot == nullptr) {
     return;
   }
 
   XMLSourceStore* sourceStore = GetSourceStore(handle_);
+
+  // Drop whatever anchors the attribute currently has, releasing them from the source store.
+  const auto clearAnchors = [sourceStore, anchorSlot]() {
+    if (sourceStore != nullptr && anchorSlot->has_value()) {
+      InvalidateAttributeAnchors(*sourceStore, **anchorSlot);
+    }
+    anchorSlot->reset();
+  };
+
   if (sourceStore == nullptr || !fullRange.start.offset.has_value() ||
       !fullRange.end.offset.has_value() || !valueRange.start.offset.has_value() ||
       !valueRange.end.offset.has_value()) {
-    clearAttributeSourceLocation(name);
+    clearAnchors();
     return;
   }
 
@@ -437,14 +452,14 @@ void XMLNode::setAttributeSourceLocation(const XMLQualifiedNameRef& name, Source
   const std::size_t valueEnd = *valueRange.end.offset;
   if (fullEnd < fullStart || valueEnd < valueStart || valueStart < fullStart ||
       valueEnd > fullEnd) {
-    clearAttributeSourceLocation(name);
+    clearAnchors();
     return;
   }
 
   std::optional<SourceAnchorSpan> fullSpan = sourceStore->createSpan(
       fullStart, fullEnd, SourceAnchorBias::After, SourceAnchorBias::Before);
   if (!fullSpan.has_value()) {
-    clearAttributeSourceLocation(name);
+    clearAnchors();
     return;
   }
 
@@ -452,23 +467,21 @@ void XMLNode::setAttributeSourceLocation(const XMLQualifiedNameRef& name, Source
       valueStart, valueEnd, SourceAnchorBias::Before, SourceAnchorBias::After);
   if (!valueSpan.has_value()) {
     InvalidateAnchors(*sourceStore, *fullSpan);
-    clearAttributeSourceLocation(name);
+    clearAnchors();
     return;
   }
 
-  if (std::optional<AttributesComponent::AttributeSourceAnchors> previous =
-          attributes.getAttributeSourceAnchors(name)) {
-    InvalidateAttributeAnchors(*sourceStore, *previous);
+  if (anchorSlot->has_value()) {
+    InvalidateAttributeAnchors(*sourceStore, **anchorSlot);
   }
 
-  attributes.setAttributeSourceAnchors(name,
-                                       AttributesComponent::AttributeSourceAnchors{
-                                           .fullStartAnchorId = fullSpan->start.value,
-                                           .fullEndAnchorId = fullSpan->end.value,
-                                           .valueStartAnchorId = valueSpan->start.value,
-                                           .valueEndAnchorId = valueSpan->end.value,
-                                           .quote = (quote == '\'' || quote == '"') ? quote : '"',
-                                       });
+  *anchorSlot = AttributesComponent::AttributeSourceAnchors{
+      .fullStartAnchorId = fullSpan->start.value,
+      .fullEndAnchorId = fullSpan->end.value,
+      .valueStartAnchorId = valueSpan->start.value,
+      .valueEndAnchorId = valueSpan->end.value,
+      .quote = (quote == '\'' || quote == '"') ? quote : '"',
+  };
 }
 
 void XMLNode::clearAttributeSourceLocation(const XMLQualifiedNameRef& name) {

--- a/donner/base/xml/XMLParser.cc
+++ b/donner/base/xml/XMLParser.cc
@@ -496,12 +496,49 @@ private:
     return std::nullopt;
   }
 
+  /**
+   * Character reader for a scanning loop over a ChunkedString.
+   *
+   * ChunkedString::operator[] has to find the chunk holding the requested position and unwrap a
+   * variant to reach its bytes, which a loop pays for on every character. A string that is still
+   * one chunk - the usual case, since extra chunks only appear once entity expansion has spliced
+   * content together - is read straight out of a view hoisted at construction.
+   *
+   * The reader must not outlive the string it was built from, and the string must not be modified
+   * while the reader is in use.
+   */
+  class CharScanner {
+  public:
+    /**
+     * Construct a reader over \p source.
+     *
+     * @param source String to read from; must outlive this reader and must not be modified while
+     *   the reader is in use.
+     */
+    explicit CharScanner(const ChunkedString& source UTILS_LIFETIME_BOUND)
+        : contiguous_(source.singleChunkView()), source_(source) {}
+
+    /**
+     * Return the character at \p pos.
+     *
+     * @param pos Position of the character to read; behavior is undefined if out of range.
+     */
+    char operator[](size_t pos) const {
+      return contiguous_.has_value() ? (*contiguous_)[pos] : source_[pos];
+    }
+
+  private:
+    std::optional<std::string_view> contiguous_;
+    const ChunkedString& source_;
+  };
+
   /// Skip whitespace characters
   void skipWhitespace(ChunkedString& sourceString) {
     size_t skipCount = 0;
     const size_t len = sourceString.size();
+    const CharScanner chars(sourceString);
 
-    while (skipCount < len && isWhitespace(sourceString[skipCount])) {
+    while (skipCount < len && isWhitespace(chars[skipCount])) {
       ++skipCount;
     }
 
@@ -513,8 +550,9 @@ private:
   static ChunkedString consumeMatching(ChunkedString& sourceString) {
     size_t i = 0;
     const size_t len = sourceString.size();
+    const CharScanner chars(sourceString);
 
-    while (i < len && MatchPredicate::test(sourceString[i])) {
+    while (i < len && MatchPredicate::test(chars[i])) {
       ++i;
     }
 
@@ -604,11 +642,12 @@ private:
       return sourceString.substr(0, 0);
     }
 
+    const CharScanner chars(sourceString);
     size_t i = 0;
 
     // Check NameStartChar (first character)
     {
-      const char firstByte = sourceString[0];
+      const char firstByte = chars[0];
       const uint8_t ub = static_cast<uint8_t>(firstByte);
       if (ub < 0x80) {
         // ASCII fast path
@@ -630,7 +669,7 @@ private:
 
     // Consume NameChar* (subsequent characters)
     while (i < len) {
-      const char byte = sourceString[i];
+      const char byte = chars[i];
       const uint8_t ub = static_cast<uint8_t>(byte);
       if (ub < 0x80) {
         // ASCII fast path
@@ -663,11 +702,12 @@ private:
       return sourceString.substr(0, 0);
     }
 
+    const CharScanner chars(sourceString);
     size_t i = 0;
 
     // Check NameStartChar (first character), including ':'
     {
-      const char firstByte = sourceString[0];
+      const char firstByte = chars[0];
       const uint8_t ub = static_cast<uint8_t>(firstByte);
       if (ub < 0x80) {
         if (!IsAsciiNameStartCharNoColon(firstByte) && firstByte != ':') {
@@ -685,7 +725,7 @@ private:
 
     // Consume NameChar* (subsequent characters), including ':'
     while (i < len) {
-      const char byte = sourceString[i];
+      const char byte = chars[i];
       const uint8_t ub = static_cast<uint8_t>(byte);
       if (ub < 0x80) {
         if (!IsAsciiNameCharNoColon(byte) && byte != ':') {
@@ -1094,8 +1134,9 @@ private:
     bool inInternalSubset = false;
 
     size_t i = 0;
+    const CharScanner chars(remaining_);
     while (i < remaining_.size()) {
-      char c = remaining_[i];
+      char c = chars[i];
       if (c == '\0') {
         return createParseError("Unexpected end of data, found embedded null character");
       }

--- a/donner/base/xml/XMLParser.cc
+++ b/donner/base/xml/XMLParser.cc
@@ -536,10 +536,12 @@ private:
   void skipWhitespace(ChunkedString& sourceString) {
     size_t skipCount = 0;
     const size_t len = sourceString.size();
-    const CharScanner chars(sourceString);
 
-    while (skipCount < len && isWhitespace(chars[skipCount])) {
-      ++skipCount;
+    {
+      const CharScanner chars(sourceString);
+      while (skipCount < len && isWhitespace(chars[skipCount])) {
+        ++skipCount;
+      }
     }
 
     sourceString.remove_prefix(skipCount);
@@ -550,10 +552,12 @@ private:
   static ChunkedString consumeMatching(ChunkedString& sourceString) {
     size_t i = 0;
     const size_t len = sourceString.size();
-    const CharScanner chars(sourceString);
 
-    while (i < len && MatchPredicate::test(chars[i])) {
-      ++i;
+    {
+      const CharScanner chars(sourceString);
+      while (i < len && MatchPredicate::test(chars[i])) {
+        ++i;
+      }
     }
 
     const ChunkedString result = sourceString.substr(0, i);
@@ -642,48 +646,53 @@ private:
       return sourceString.substr(0, 0);
     }
 
-    const CharScanner chars(sourceString);
     size_t i = 0;
 
-    // Check NameStartChar (first character)
+    // Scoped so the reader is gone before sourceString is modified below.
     {
-      const char firstByte = chars[0];
-      const uint8_t ub = static_cast<uint8_t>(firstByte);
-      if (ub < 0x80) {
-        // ASCII fast path
-        if (!IsAsciiNameStartCharNoColon(firstByte)) {
-          return sourceString.substr(0, 0);
-        }
-        i = 1;
-      } else {
-        // Multi-byte UTF-8
-        auto [codepoint, seqLen] = decodeCodepointAt(sourceString, 0);
-        // ':' is handled by the caller, so use IsNameStartChar but skip the ':' case
-        // (IsNameStartChar includes ':', but we exclude it here since it's ASCII and handled above)
-        if (!IsNameStartChar(codepoint)) {
-          return sourceString.substr(0, 0);
-        }
-        i = seqLen;
-      }
-    }
+      const CharScanner chars(sourceString);
 
-    // Consume NameChar* (subsequent characters)
-    while (i < len) {
-      const char byte = chars[i];
-      const uint8_t ub = static_cast<uint8_t>(byte);
-      if (ub < 0x80) {
-        // ASCII fast path
-        if (!IsAsciiNameCharNoColon(byte)) {
-          break;
+      // Check NameStartChar (first character)
+      {
+        const char firstByte = chars[0];
+        const uint8_t ub = static_cast<uint8_t>(firstByte);
+        if (ub < 0x80) {
+          // ASCII fast path
+          if (!IsAsciiNameStartCharNoColon(firstByte)) {
+            return sourceString.substr(0, 0);
+          }
+          i = 1;
+        } else {
+          // Multi-byte UTF-8
+          auto [codepoint, seqLen] = decodeCodepointAt(sourceString, 0);
+          // ':' is handled by the caller, so use IsNameStartChar but skip the ':' case
+          // (IsNameStartChar includes ':', but we exclude it here since it's ASCII and handled
+          // above)
+          if (!IsNameStartChar(codepoint)) {
+            return sourceString.substr(0, 0);
+          }
+          i = seqLen;
         }
-        ++i;
-      } else {
-        // Multi-byte UTF-8
-        auto [codepoint, seqLen] = decodeCodepointAt(sourceString, i);
-        if (!IsNameChar(codepoint)) {
-          break;
+      }
+
+      // Consume NameChar* (subsequent characters)
+      while (i < len) {
+        const char byte = chars[i];
+        const uint8_t ub = static_cast<uint8_t>(byte);
+        if (ub < 0x80) {
+          // ASCII fast path
+          if (!IsAsciiNameCharNoColon(byte)) {
+            break;
+          }
+          ++i;
+        } else {
+          // Multi-byte UTF-8
+          auto [codepoint, seqLen] = decodeCodepointAt(sourceString, i);
+          if (!IsNameChar(codepoint)) {
+            break;
+          }
+          i += seqLen;
         }
-        i += seqLen;
       }
     }
 
@@ -702,42 +711,46 @@ private:
       return sourceString.substr(0, 0);
     }
 
-    const CharScanner chars(sourceString);
     size_t i = 0;
 
-    // Check NameStartChar (first character), including ':'
+    // Scoped so the reader is gone before sourceString is modified below.
     {
-      const char firstByte = chars[0];
-      const uint8_t ub = static_cast<uint8_t>(firstByte);
-      if (ub < 0x80) {
-        if (!IsAsciiNameStartCharNoColon(firstByte) && firstByte != ':') {
-          return sourceString.substr(0, 0);
-        }
-        i = 1;
-      } else {
-        auto [codepoint, seqLen] = decodeCodepointAt(sourceString, 0);
-        if (!IsNameStartChar(codepoint)) {
-          return sourceString.substr(0, 0);
-        }
-        i = seqLen;
-      }
-    }
+      const CharScanner chars(sourceString);
 
-    // Consume NameChar* (subsequent characters), including ':'
-    while (i < len) {
-      const char byte = chars[i];
-      const uint8_t ub = static_cast<uint8_t>(byte);
-      if (ub < 0x80) {
-        if (!IsAsciiNameCharNoColon(byte) && byte != ':') {
-          break;
+      // Check NameStartChar (first character), including ':'
+      {
+        const char firstByte = chars[0];
+        const uint8_t ub = static_cast<uint8_t>(firstByte);
+        if (ub < 0x80) {
+          if (!IsAsciiNameStartCharNoColon(firstByte) && firstByte != ':') {
+            return sourceString.substr(0, 0);
+          }
+          i = 1;
+        } else {
+          auto [codepoint, seqLen] = decodeCodepointAt(sourceString, 0);
+          if (!IsNameStartChar(codepoint)) {
+            return sourceString.substr(0, 0);
+          }
+          i = seqLen;
         }
-        ++i;
-      } else {
-        auto [codepoint, seqLen] = decodeCodepointAt(sourceString, i);
-        if (!IsNameChar(codepoint)) {
-          break;
+      }
+
+      // Consume NameChar* (subsequent characters), including ':'
+      while (i < len) {
+        const char byte = chars[i];
+        const uint8_t ub = static_cast<uint8_t>(byte);
+        if (ub < 0x80) {
+          if (!IsAsciiNameCharNoColon(byte) && byte != ':') {
+            break;
+          }
+          ++i;
+        } else {
+          auto [codepoint, seqLen] = decodeCodepointAt(sourceString, i);
+          if (!IsNameChar(codepoint)) {
+            break;
+          }
+          i += seqLen;
         }
-        i += seqLen;
       }
     }
 
@@ -1134,7 +1147,7 @@ private:
     bool inInternalSubset = false;
 
     size_t i = 0;
-    const CharScanner chars(remaining_);
+    const CharScanner chars(remaining_);  // remaining_ is only read, never modified, in this loop.
     while (i < remaining_.size()) {
       char c = chars[i];
       if (c == '\0') {

--- a/donner/base/xml/components/AttributesComponent.cc
+++ b/donner/base/xml/components/AttributesComponent.cc
@@ -30,23 +30,35 @@ SmallVector<xml::XMLQualifiedNameRef, 1> AttributesComponent::findMatchingAttrib
 
 void AttributesComponent::setAttribute(Registry& registry, const xml::XMLQualifiedNameRef& name,
                                        const RcString& value) {
+  // Overwriting an existing attribute is the common case during parsing, because the XML parser
+  // stores every attribute and the SVG layer then stores the ones it recognizes a second time.
+  // That path needs none of the allocation below: the name is already owned by attrNameStorage_
+  // and already keys the attributes_ entry, so only the value changes.
+  if (const auto existingIt = attributes_.find(name); existingIt != attributes_.end()) {
+    existingIt->second.value = value;
+
+    if (isNamespaceOverride(existingIt->second.name)) {
+      // The declaration count is unchanged - this replaces a declaration rather than adding one -
+      // but the resolved value must still be republished in case it changed.
+      const Entity self = entt::to_entity(registry.storage<AttributesComponent>(), *this);
+      registry.ctx().get<xml::components::XMLNamespaceContext>().addNamespaceOverride(
+          self, existingIt->second.name, value);
+    }
+    return;
+  }
+
   xml::XMLQualifiedName nameAllocated(RcString(name.namespacePrefix), RcString(name.name));
 
   auto [xmlAttrStorageIt, _inserted] = attrNameStorage_.insert(nameAllocated);
   const xml::XMLQualifiedNameRef attrRef = *xmlAttrStorageIt;
 
-  auto [attrIt, newAttrInserted] = attributes_.emplace(attrRef, Storage(nameAllocated, value));
-  if (!newAttrInserted) {
-    attrIt->second.value = value;
-  }
+  attributes_.emplace(attrRef, Storage(nameAllocated, value));
 
   if (isNamespaceOverride(nameAllocated)) {
     // Count declarations present, not writes: overwriting an existing xmlns attribute replaces
     // the declaration rather than adding one, while removeAttribute only ever decrements once.
     // Counting writes leaves hasNamespaceOverrides() true after the last declaration is removed.
-    if (newAttrInserted) {
-      ++numNamespaceOverrides_;
-    }
+    ++numNamespaceOverrides_;
 
     const Entity self = entt::to_entity(registry.storage<AttributesComponent>(), *this);
     registry.ctx().get<xml::components::XMLNamespaceContext>().addNamespaceOverride(

--- a/donner/base/xml/components/AttributesComponent.h
+++ b/donner/base/xml/components/AttributesComponent.h
@@ -100,20 +100,6 @@ struct AttributesComponent {
   }
 
   /**
-   * Store source-anchor metadata for an existing attribute.
-   *
-   * @param name Name of the attribute to update.
-   * @param anchors Source anchors for the attribute.
-   */
-  void setAttributeSourceAnchors(const xml::XMLQualifiedNameRef& name,
-                                 AttributeSourceAnchors anchors) {
-    const auto it = attributes_.find(name);
-    if (it != attributes_.end()) {
-      it->second.sourceAnchors = anchors;
-    }
-  }
-
-  /**
    * Remove source-anchor metadata for an attribute.
    *
    * @param name Name of the attribute to clear.

--- a/donner/base/xml/components/AttributesComponent.h
+++ b/donner/base/xml/components/AttributesComponent.h
@@ -84,6 +84,22 @@ struct AttributesComponent {
   }
 
   /**
+   * Return a pointer to an attribute's source-anchor slot.
+   *
+   * For callers that check, read, and then write the anchors of one attribute, which would
+   * otherwise look the same attribute up once per step. The returned pointer is invalidated by
+   * anything that adds or removes an attribute on this component.
+   *
+   * @param name Name of the attribute to query.
+   * @return Pointer to the attribute's anchor slot, or nullptr when the attribute is not set.
+   */
+  std::optional<AttributeSourceAnchors>* attributeSourceAnchorsSlot(
+      const xml::XMLQualifiedNameRef& name) {
+    const auto it = attributes_.find(name);
+    return it != attributes_.end() ? &it->second.sourceAnchors : nullptr;
+  }
+
+  /**
    * Store source-anchor metadata for an existing attribute.
    *
    * @param name Name of the attribute to update.

--- a/donner/base/xml/components/tests/AttributesComponent_tests.cc
+++ b/donner/base/xml/components/tests/AttributesComponent_tests.cc
@@ -109,6 +109,43 @@ TEST(AttributesComponent, SetAttribute) {
   EXPECT_EQ(component.getAttribute("test"), "value3");
 }
 
+TEST(AttributesComponent, OverwriteKeepsNameIdentityAndOrder) {
+  Registry registry;
+  registry.ctx().emplace<XMLNamespaceContext>(registry);
+
+  Entity entity = registry.create();
+  AttributesComponent& component = registry.emplace<AttributesComponent>(entity);
+
+  // Insert out of sorted order, so an overwrite that re-keyed the entry would be visible in the
+  // reported order as well as in the values.
+  component.setAttribute(registry, "width", "1");
+  component.setAttribute(registry, XMLQualifiedNameRef("ns", "width"), "2");
+  component.setAttribute(registry, "height", "3");
+
+  const auto namesBefore = component.attributes();
+
+  // Overwriting takes a separate path from first insertion; it must leave the stored name, the
+  // reported order, and every other attribute untouched.
+  component.setAttribute(registry, "width", "4");
+  component.setAttribute(registry, XMLQualifiedNameRef("ns", "width"), "5");
+
+  const auto namesAfter = component.attributes();
+  ASSERT_EQ(namesBefore.size(), namesAfter.size());
+  for (size_t i = 0; i < namesBefore.size(); ++i) {
+    EXPECT_EQ(namesBefore[i], namesAfter[i]) << "at index " << i;
+  }
+
+  EXPECT_EQ(component.getAttribute("width"), "4");
+  EXPECT_EQ(component.getAttribute(XMLQualifiedNameRef("ns", "width")), "5");
+  EXPECT_EQ(component.getAttribute("height"), "3");
+
+  // The overwritten attribute is still removable, which requires the name storage to still hold
+  // the key the map entry points at.
+  component.removeAttribute(registry, "width");
+  EXPECT_FALSE(component.hasAttribute("width"));
+  EXPECT_EQ(component.getAttribute(XMLQualifiedNameRef("ns", "width")), "5");
+}
+
 TEST(AttributesComponent, RemoveAttribute) {
   Registry registry;
   registry.ctx().emplace<XMLNamespaceContext>(registry);
@@ -352,8 +389,8 @@ TEST(AttributesComponent, NamespaceCacheSurvivesUnrelatedTreeChange) {
   registry.get<TreeComponent>(keptBranch).appendChild(registry, keptLeaf);
   registry.get<TreeComponent>(root).appendChild(registry, movedBranch);
 
-  registry.get<AttributesComponent>(root).setAttribute(
-      registry, XMLQualifiedNameRef("", "xmlns"), "https://example.com/root");
+  registry.get<AttributesComponent>(root).setAttribute(registry, XMLQualifiedNameRef("", "xmlns"),
+                                                       "https://example.com/root");
 
   // Warm the cache for the branch that is about to be left alone.
   EXPECT_EQ(namespaceContext.getNamespaceUri(registry, keptLeaf, ""), "https://example.com/root");

--- a/donner/benchmarks/BUILD.bazel
+++ b/donner/benchmarks/BUILD.bazel
@@ -26,6 +26,16 @@ donner_cc_binary(
 )
 
 donner_cc_binary(
+    name = "svg_parse_perf_bench",
+    srcs = ["SvgParsePerfBench.cpp"],
+    deps = [
+        "//donner/base",
+        "//donner/svg",
+        "//donner/svg/parser",
+    ],
+)
+
+donner_cc_binary(
     name = "structured_editing_perf_bench",
     srcs = ["StructuredEditingPerfBench.cpp"],
     deps = [

--- a/donner/benchmarks/SvgParsePerfBench.cpp
+++ b/donner/benchmarks/SvgParsePerfBench.cpp
@@ -1,0 +1,149 @@
+/// @file
+/// Parse-only benchmark for the SVG parser.
+///
+/// Measures exactly the work that the cross-engine benchmark reports as
+/// `parse_ms`: a fresh \ref donner::svg::SVGDocument built from source text by
+/// \ref donner::svg::parser::SVGParser::ParseSVG, with warnings disabled, once
+/// per iteration. No renderer is constructed and no frame is drawn, so the
+/// sample is not diluted by raster or GPU work and the binary can be sampled
+/// with a profiler without the parser being buried under rendering symbols.
+///
+/// Reported time is the median across the timed iterations, which is the same
+/// statistic the cross-engine benchmark uses, so numbers from the two tools are
+/// directly comparable for the parse phase.
+///
+/// Usage:
+///   svg_parse_perf_bench [--iterations=N] [--warmup=N] [--repeat=N] FILE...
+///
+/// Each input file produces one `RESULT scene=<name> parse_ms=<median>` line
+/// per repeat, and repeats are interleaved across files so that machine drift
+/// affects every scene equally.
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "donner/base/ParseWarningSink.h"
+#include "donner/svg/SVGDocument.h"
+#include "donner/svg/parser/SVGParser.h"
+
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+double toMs(Clock::duration duration) {
+  return std::chrono::duration<double, std::milli>(duration).count();
+}
+
+double median(std::vector<double> values) {
+  if (values.empty()) {
+    return 0.0;
+  }
+  std::sort(values.begin(), values.end());
+  const std::size_t middle = values.size() / 2;
+  if (values.size() % 2 == 0) {
+    return (values[middle - 1] + values[middle]) / 2.0;
+  }
+  return values[middle];
+}
+
+std::string readFile(const std::filesystem::path& path) {
+  std::ifstream file(path, std::ios::binary);
+  if (!file) {
+    return {};
+  }
+  return std::string(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
+}
+
+struct Scene {
+  std::string name;
+  std::string source;
+};
+
+/// Parses one document, returning false if the source did not parse. Keeping the
+/// document alive until the timer stops means teardown is excluded, matching the
+/// cross-engine benchmark's parse phase.
+bool parseOnce(const std::string& source, double& elapsedMs) {
+  donner::ParseWarningSink warningSink = donner::ParseWarningSink::Disabled();
+  const auto start = Clock::now();
+  auto parsed = donner::svg::parser::SVGParser::ParseSVG(source, warningSink);
+  elapsedMs = toMs(Clock::now() - start);
+  if (parsed.hasError()) {
+    std::fprintf(stderr, "parse error: %s\n", std::string(parsed.error().reason).c_str());
+    return false;
+  }
+  // Keep the document alive past the timer so destruction is not timed, then
+  // discard it so each iteration starts from an empty registry.
+  donner::svg::SVGDocument document = std::move(parsed.result());
+  (void)document;
+  return true;
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+  int iterations = 25;
+  int warmup = 3;
+  int repeat = 1;
+  std::vector<std::string> inputs;
+
+  for (int i = 1; i < argc; ++i) {
+    const std::string_view arg(argv[i]);
+    if (arg.starts_with("--iterations=")) {
+      iterations = std::max(1, std::atoi(std::string(arg.substr(13)).c_str()));
+    } else if (arg.starts_with("--warmup=")) {
+      warmup = std::max(0, std::atoi(std::string(arg.substr(9)).c_str()));
+    } else if (arg.starts_with("--repeat=")) {
+      repeat = std::max(1, std::atoi(std::string(arg.substr(9)).c_str()));
+    } else {
+      inputs.emplace_back(arg);
+    }
+  }
+
+  if (inputs.empty()) {
+    std::fprintf(
+        stderr, "usage: svg_parse_perf_bench [--iterations=N] [--warmup=N] [--repeat=N] FILE...\n");
+    return 2;
+  }
+
+  std::vector<Scene> scenes;
+  scenes.reserve(inputs.size());
+  for (const std::string& input : inputs) {
+    const std::filesystem::path path(input);
+    std::string source = readFile(path);
+    if (source.empty()) {
+      std::fprintf(stderr, "unable to read SVG: %s\n", input.c_str());
+      return 2;
+    }
+    scenes.push_back(Scene{path.filename().string(), std::move(source)});
+  }
+
+  for (int run = 0; run < repeat; ++run) {
+    for (const Scene& scene : scenes) {
+      std::vector<double> samples;
+      samples.reserve(static_cast<std::size_t>(iterations));
+      for (int i = 0; i < warmup + iterations; ++i) {
+        double elapsedMs = 0.0;
+        if (!parseOnce(scene.source, elapsedMs)) {
+          return 1;
+        }
+        if (i >= warmup) {
+          samples.push_back(elapsedMs);
+        }
+      }
+
+      std::printf("RESULT scene=%s run=%d iterations=%d parse_ms=%.4f\n", scene.name.c_str(), run,
+                  iterations, median(samples));
+      std::fflush(stdout);
+    }
+  }
+
+  return 0;
+}

--- a/donner/benchmarks/SvgParsePerfBench.cpp
+++ b/donner/benchmarks/SvgParsePerfBench.cpp
@@ -16,8 +16,13 @@
 ///   svg_parse_perf_bench [--iterations=N] [--warmup=N] [--repeat=N] FILE...
 ///
 /// Each input file produces one `RESULT scene=<name> parse_ms=<median>` line
-/// per repeat, and repeats are interleaved across files so that machine drift
-/// affects every scene equally.
+/// per repeat. Repeats interleave at file granularity, not at iteration
+/// granularity: one repeat runs every iteration of the first file, then every
+/// iteration of the second, and so on, before the next repeat starts again from
+/// the first file. That spreads slow machine intervals across the repeats of
+/// every scene rather than concentrating them in whichever scene happened to be
+/// running, so comparing the median across repeats is meaningful. It does not
+/// make a single repeat's samples immune to a burst of machine load.
 
 #include <algorithm>
 #include <chrono>
@@ -26,6 +31,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iterator>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -54,10 +60,12 @@ double median(std::vector<double> values) {
   return values[middle];
 }
 
-std::string readFile(const std::filesystem::path& path) {
+/// Reads a whole file. Returns an empty optional when the file cannot be opened, which the caller
+/// distinguishes from a file that opened but holds nothing.
+std::optional<std::string> readFile(const std::filesystem::path& path) {
   std::ifstream file(path, std::ios::binary);
   if (!file) {
-    return {};
+    return std::nullopt;
   }
   return std::string(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
 }
@@ -117,12 +125,16 @@ int main(int argc, char* argv[]) {
   scenes.reserve(inputs.size());
   for (const std::string& input : inputs) {
     const std::filesystem::path path(input);
-    std::string source = readFile(path);
-    if (source.empty()) {
-      std::fprintf(stderr, "unable to read SVG: %s\n", input.c_str());
+    std::optional<std::string> source = readFile(path);
+    if (!source.has_value()) {
+      std::fprintf(stderr, "unable to open SVG: %s\n", input.c_str());
       return 2;
     }
-    scenes.push_back(Scene{path.filename().string(), std::move(source)});
+    if (source->empty()) {
+      std::fprintf(stderr, "SVG is empty: %s\n", input.c_str());
+      return 2;
+    }
+    scenes.push_back(Scene{path.filename().string(), std::move(source.value())});
   }
 
   for (int run = 0; run < repeat; ++run) {

--- a/donner/svg/ElementType.h
+++ b/donner/svg/ElementType.h
@@ -1,6 +1,7 @@
 #pragma once
 /// @file
 
+#include <cstddef>
 #include <cstdint>
 #include <ostream>
 
@@ -71,6 +72,16 @@ enum class ElementType : uint8_t {
   Unknown,              //!< For unknown elements.
   Use,                  //!< \ref xml_use
 };
+
+/**
+ * Number of distinct \ref ElementType values, for sizing arrays indexed by element type.
+ *
+ * Derived from \ref ElementType::Use being the last enumerator. Adding an enumerator after it
+ * requires updating this expression; callers that size a table with it should static_assert that
+ * the element types they index with fit, so the mismatch is caught at compile time rather than
+ * silently truncating the table.
+ */
+inline constexpr size_t kElementTypeCount = static_cast<size_t>(ElementType::Use) + 1;
 
 /// Ostream output operator for \ref ElementType, outputs the element name.
 std::ostream& operator<<(std::ostream& os, ElementType type);

--- a/donner/svg/SVGElement.cc
+++ b/donner/svg/SVGElement.cc
@@ -444,13 +444,17 @@ ParseResult<bool> SVGElement::trySetPresentationAttribute(std::string_view name,
   DocumentWriteAccess& access = mutation.access();
   std::string_view actualName = name;
 
+  // The element's type is read several times below, and each read is an ECS component lookup.
+  // Resolve it once; the type cannot change while this call runs.
+  const ElementType elementType = type();
+
   // gradientTransform and patternTransform are special, since they map to the
   // "transform" presentation attribute. When doing this mapping, store the XML
   // attribute with the user-visible attribute name and internally map it to
   // "transform".
-  if (((type() == ElementType::LinearGradient || type() == ElementType::RadialGradient) &&
+  if (((elementType == ElementType::LinearGradient || elementType == ElementType::RadialGradient) &&
        name == "gradientTransform") ||
-      (type() == ElementType::Pattern && name == "patternTransform")) {
+      (elementType == ElementType::Pattern && name == "patternTransform")) {
     actualName = "transform";
   }
 
@@ -467,7 +471,7 @@ ParseResult<bool> SVGElement::trySetPresentationAttribute(std::string_view name,
   if (!trySetResult.result()) {
     // Try element-specific presentation attributes (cx, cy, r, rx, ry, d, etc.).
     parser::PropertyParseFnParams params = parser::PropertyParseFnParams::CreateForAttribute(value);
-    trySetResult = parser::ParsePresentationAttribute(type(), handle_, actualName, params);
+    trySetResult = parser::ParsePresentationAttribute(elementType, handle_, actualName, params);
   }
 
   if (trySetResult.hasResult() && trySetResult.result()) {

--- a/donner/svg/SVGElement.cc
+++ b/donner/svg/SVGElement.cc
@@ -556,9 +556,13 @@ void SVGElement::setAttribute(const xml::XMLQualifiedNameRef& name, std::string_
 }
 
 std::optional<ParseDiagnostic> SVGElement::setAttributeFromXMLMutation(
-    const xml::XMLQualifiedNameRef& name, std::string_view value) {
+    const xml::XMLQualifiedNameRef& name, std::string_view value,
+    bool* consumedAsPresentationAttribute) {
   DocumentMutationBatch mutation = handle_.mutationBatch();
   DocumentWriteAccess& access = mutation.access();
+  if (consumedAsPresentationAttribute != nullptr) {
+    *consumedAsPresentationAttribute = false;
+  }
   // TODO: Namespace support for these attributes
   // First check some special cases which will never be presentation attributes.
   if (name == xml::XMLQualifiedNameRef("id")) {
@@ -587,6 +591,9 @@ std::optional<ParseDiagnostic> SVGElement::setAttributeFromXMLMutation(
   if (name.namespacePrefix.empty()) {
     auto trySetResult = trySetPresentationAttribute(name.name, value);
     const bool attributeWasSet = trySetResult.hasResult() && trySetResult.result();
+    if (consumedAsPresentationAttribute != nullptr) {
+      *consumedAsPresentationAttribute = attributeWasSet;
+    }
     if (attributeWasSet) {
       if (name.name == "transform") {
         // Source/XML transform edits are settled document changes, not active drag frames.

--- a/donner/svg/SVGElement.h
+++ b/donner/svg/SVGElement.h
@@ -779,9 +779,14 @@ protected:
    *
    * @param name Name of the attribute to set.
    * @param value New value to set.
+   * @param[out] consumedAsPresentationAttribute When non-null, set to true if the value was
+   *   recognized and applied as a presentation attribute, and false if it was stored only as a
+   *   generic XML attribute. Lets a caller that needs to know the outcome avoid repeating the
+   *   presentation-attribute parse to find out.
    */
-  std::optional<ParseDiagnostic> setAttributeFromXMLMutation(const xml::XMLQualifiedNameRef& name,
-                                                             std::string_view value);
+  std::optional<ParseDiagnostic> setAttributeFromXMLMutation(
+      const xml::XMLQualifiedNameRef& name, std::string_view value,
+      bool* consumedAsPresentationAttribute = nullptr);
 
   /**
    * Remove an attribute from an XML mutation without writing back to XML source.

--- a/donner/svg/parser/AttributeParser.cc
+++ b/donner/svg/parser/AttributeParser.cc
@@ -1,5 +1,6 @@
 #include "donner/svg/parser/AttributeParser.h"
 
+#include <array>
 #include <cctype>
 #include <entt/entity/fwd.hpp>  // entt::type_list, entt::type_list_element
 #include <limits>
@@ -2456,33 +2457,69 @@ std::optional<ParseDiagnostic> ParseAttribute<SVGTextPathElement>(SVGParserConte
   return std::nullopt;
 }
 
-template <size_t I = 0, typename... Types>
-std::optional<ParseDiagnostic> ParseAttributesForElement(SVGParserContext& context,
-                                                         SVGElement& element,
-                                                         const XMLQualifiedNameRef& name,
-                                                         std::string_view value,
-                                                         entt::type_list<Types...>) {
-  if constexpr (I != sizeof...(Types)) {
-    using ElementType = typename std::tuple_element<I, std::tuple<Types...>>::type;
+/// Signature of the per-element-type attribute handler stored in \ref kParseAttributeTable.
+using ParseAttributeFn = std::optional<ParseDiagnostic> (*)(SVGParserContext&, SVGElement&,
+                                                            const XMLQualifiedNameRef&,
+                                                            std::string_view);
 
-    if (element.type() == ElementType::Type) {
-      ElementType elementDerived = element.cast<ElementType>();
-      return ParseAttribute(context, elementDerived, name, value);
-    }
-
-    return ParseAttributesForElement<I + 1>(context, element, name, value,
-                                            entt::type_list<Types...>());
-  } else {
-    return ParseAttribute(context, element, name, value);
-  }
+/// Downcasts to \p ElementT and runs that type's attribute handler.
+template <typename ElementT>
+std::optional<ParseDiagnostic> ParseAttributeAs(SVGParserContext& context, SVGElement& element,
+                                                const XMLQualifiedNameRef& name,
+                                                std::string_view value) {
+  ElementT elementDerived = element.cast<ElementT>();
+  return ParseAttribute(context, elementDerived, name, value);
 }
+
+/// Runs the handler shared by every element type, used when no element type claims the runtime
+/// type (for example \ref ElementType::Unknown).
+std::optional<ParseDiagnostic> ParseAttributeGeneric(SVGParserContext& context, SVGElement& element,
+                                                     const XMLQualifiedNameRef& name,
+                                                     std::string_view value) {
+  return ParseAttribute(context, element, name, value);
+}
+
+/// Number of distinct \ref ElementType values; \c Use is the last enumerator.
+inline constexpr size_t kElementTypeCount = static_cast<size_t>(ElementType::Use) + 1;
+
+/**
+ * Build the \ref ElementType-indexed table of attribute handlers.
+ *
+ * Entries are filled in type-list order and an already-occupied slot is left alone, so a type
+ * appearing earlier in \ref AllSVGElements wins - the same element a linear "first type whose
+ * `Type` matches" scan would have selected. Types are left null when nothing claims them, and the
+ * caller falls back to the shared handler for those.
+ */
+template <typename... Types>
+constexpr std::array<ParseAttributeFn, kElementTypeCount> BuildParseAttributeTable(
+    entt::type_list<Types...>) {
+  std::array<ParseAttributeFn, kElementTypeCount> table = {};
+  (
+      [&table]<typename ElementT>() {
+        ParseAttributeFn& slot = table[static_cast<size_t>(ElementT::Type)];
+        if (slot == nullptr) {
+          slot = &ParseAttributeAs<ElementT>;
+        }
+      }.template operator()<Types>(),
+      ...);
+  return table;
+}
+
+/// Attribute handler for each element type, replacing a linear walk of the element type list that
+/// re-read the element's runtime type at every step.
+constexpr std::array<ParseAttributeFn, kElementTypeCount> kParseAttributeTable =
+    BuildParseAttributeTable(AllSVGElements());
 
 }  // namespace
 
 std::optional<ParseDiagnostic> AttributeParser::ParseAndSetAttribute(
     SVGParserContext& context, SVGElement& element, const XMLQualifiedNameRef& name,
     std::string_view value) noexcept {
-  return ParseAttributesForElement(context, element, name, value, AllSVGElements());
+  const size_t typeIndex = static_cast<size_t>(element.type());
+  const ParseAttributeFn parseFn =
+      typeIndex < kParseAttributeTable.size() ? kParseAttributeTable[typeIndex] : nullptr;
+  return parseFn != nullptr ? parseFn(context, element, name, value)
+                            : ParseAttributeGeneric(context, element, name, value);
 }
 
 std::optional<ParseDiagnostic> AttributeParser::ApplyParsedAttribute(

--- a/donner/svg/parser/AttributeParser.cc
+++ b/donner/svg/parser/AttributeParser.cc
@@ -407,27 +407,28 @@ void ParsePresentationAttribute(SVGParserContext& context, SVGElement& element,
                                 const XMLQualifiedNameRef& name, std::string_view value) {
   // TODO: Move this logic into SVGElement::setAttribute.
 
+  // Storing the attribute already performs the presentation-attribute parse and reports both its
+  // diagnostic and whether the value was recognized, so this asks for the outcome instead of
+  // parsing the value once here and a second time inside the store.
+  bool consumedAsPresentationAttribute = false;
+  std::optional<ParseDiagnostic> error =
+      AttributeParser::ApplyParsedAttribute(element, name, value, &consumedAsPresentationAttribute);
+
   // TODO: Detect the SVG namespace here and only parse elements in that namespace.
+  // For now, we only parse attributes that are not in a namespace.
   if (name.namespacePrefix.empty()) {
-    // For now, we only parse attributes that are not in a namespace.
-    auto result = element.trySetPresentationAttribute(name.name, value);
-    if (result.hasError()) {
-      context.addSubparserWarning(std::move(result.error()), context.parserOriginFrom(value));
-    } else if (!result.result()) {
-      if (context.options().disableUserAttributes) {
-        ParseDiagnostic err;
-        err.reason = "Unknown attribute '" + name.toString() + "' (disableUserAttributes: true)";
-        if (auto maybeLocation = context.getAttributeLocation(element, name)) {
-          err.range.start = maybeLocation->start;
-        }
-        context.addWarning(std::move(err));
-        AttributeParser::RemoveParsedAttribute(element, name);
-        return;
+    if (error.has_value()) {
+      context.addSubparserWarning(std::move(error.value()), context.parserOriginFrom(value));
+    } else if (!consumedAsPresentationAttribute && context.options().disableUserAttributes) {
+      ParseDiagnostic err;
+      err.reason = "Unknown attribute '" + name.toString() + "' (disableUserAttributes: true)";
+      if (auto maybeLocation = context.getAttributeLocation(element, name)) {
+        err.range.start = maybeLocation->start;
       }
+      context.addWarning(std::move(err));
+      AttributeParser::RemoveParsedAttribute(element, name);
     }
   }
-
-  (void)AttributeParser::ApplyParsedAttribute(element, name, value);
 }
 
 /**
@@ -2523,8 +2524,9 @@ std::optional<ParseDiagnostic> AttributeParser::ParseAndSetAttribute(
 }
 
 std::optional<ParseDiagnostic> AttributeParser::ApplyParsedAttribute(
-    SVGElement& element, const XMLQualifiedNameRef& name, std::string_view value) {
-  return element.setAttributeFromXMLMutation(name, value);
+    SVGElement& element, const XMLQualifiedNameRef& name, std::string_view value,
+    bool* consumedAsPresentationAttribute) {
+  return element.setAttributeFromXMLMutation(name, value, consumedAsPresentationAttribute);
 }
 
 void AttributeParser::RemoveParsedAttribute(SVGElement& element, const XMLQualifiedNameRef& name) {

--- a/donner/svg/parser/AttributeParser.cc
+++ b/donner/svg/parser/AttributeParser.cc
@@ -2480,16 +2480,27 @@ std::optional<ParseDiagnostic> ParseAttributeGeneric(SVGParserContext& context, 
   return ParseAttribute(context, element, name, value);
 }
 
-/// Number of distinct \ref ElementType values; \c Use is the last enumerator.
-inline constexpr size_t kElementTypeCount = static_cast<size_t>(ElementType::Use) + 1;
+/// Returns true when every element type in \p Types indexes inside a \ref kElementTypeCount-sized
+/// table. Guards the assumption \ref kElementTypeCount encodes, that \ref ElementType::Use is the
+/// last enumerator: an enumerator added after it that a real element type uses would otherwise
+/// index past the end of the dispatch table.
+template <typename... Types>
+constexpr bool AllElementTypesIndexInsideTable(entt::type_list<Types...>) {
+  return ((static_cast<size_t>(Types::Type) < kElementTypeCount) && ...);
+}
+
+static_assert(AllElementTypesIndexInsideTable(AllSVGElements()),
+              "An SVG element type's ElementType is outside the range kElementTypeCount covers. "
+              "Update kElementTypeCount in ElementType.h to match the last enumerator.");
 
 /**
  * Build the \ref ElementType-indexed table of attribute handlers.
  *
  * Entries are filled in type-list order and an already-occupied slot is left alone, so a type
  * appearing earlier in \ref AllSVGElements wins - the same element a linear "first type whose
- * `Type` matches" scan would have selected. Types are left null when nothing claims them, and the
- * caller falls back to the shared handler for those.
+ * `Type` matches" scan would have selected. Types are left null when nothing claims them (\ref
+ * ElementType::Unknown, and any enumerator no element type in the list uses), and the caller falls
+ * back to the shared handler for those.
  */
 template <typename... Types>
 constexpr std::array<ParseAttributeFn, kElementTypeCount> BuildParseAttributeTable(

--- a/donner/svg/parser/AttributeParser.h
+++ b/donner/svg/parser/AttributeParser.h
@@ -30,10 +30,13 @@ public:
    * @param element The element to set the attribute on.
    * @param name The name of the attribute, as specified in the document's XML.
    * @param value The value of the attribute.
+   * @param[out] consumedAsPresentationAttribute When non-null, set to true if the value was
+   *   recognized and applied as a presentation attribute, and false if it was stored only as a
+   *   generic XML attribute.
    */
-  static std::optional<ParseDiagnostic> ApplyParsedAttribute(SVGElement& element,
-                                                             const xml::XMLQualifiedNameRef& name,
-                                                             std::string_view value);
+  static std::optional<ParseDiagnostic> ApplyParsedAttribute(
+      SVGElement& element, const xml::XMLQualifiedNameRef& name, std::string_view value,
+      bool* consumedAsPresentationAttribute = nullptr);
 
   /**
    * Remove an XML attribute from the SVG projection without writing back to source.

--- a/donner/svg/parser/SVGParser.cc
+++ b/donner/svg/parser/SVGParser.cc
@@ -1,10 +1,13 @@
 #include "donner/svg/parser/SVGParser.h"
 
+#include <array>
 #include <ostream>
 #include <sstream>
 #include <string_view>
 #include <tuple>
+#include <utility>
 
+#include "donner/base/CompileTimeMap.h"
 #include "donner/base/ParseWarningSink.h"
 #include "donner/base/RcString.h"
 #include "donner/base/encoding/Decompress.h"
@@ -321,6 +324,10 @@ constexpr bool IsExperimental() {
   }
 }
 
+/// Signature of the per-tag element factory used to create and populate an element.
+using CreateElementFn = ParseResult<SVGElement> (*)(SVGParserContext&, const XMLNode&,
+                                                    const XMLQualifiedNameRef&);
+
 }  // namespace
 
 class SVGParserImpl {
@@ -329,6 +336,44 @@ private:
   std::optional<SVGDocument> document_;
   SVGDocumentHandle documentState_;
   SVGDocument::Settings settings_;
+
+  /// Creates an element of type \p ElementT on \p node and parses its attributes. Experimental
+  /// types fall back to an unknown element unless experimental support is enabled, matching the
+  /// behavior of the tag scan the factory table replaces. Element constructors are only reachable
+  /// from this class, which is why the factories live here.
+  template <typename ElementT>
+  static ParseResult<SVGElement> createElementAndParseAttributes(
+      SVGParserContext& context, const XMLNode& node, const XMLQualifiedNameRef& tagName) {
+    if constexpr (IsExperimental<ElementT>()) {
+      if (!context.options().enableExperimental) {
+        auto element = SVGUnknownElement::CreateOn(node.entityHandle(), tagName);
+        return ParseAttributes(context, element, node);
+      }
+    }
+
+    auto element = ElementT::CreateOn(node.entityHandle());
+    return ParseAttributes(context, element, node);
+  }
+
+  /// Builds the tag-name to factory entries for a perfect-hash lookup over the known element types.
+  template <typename... Types>
+  static constexpr auto makeElementFactoryEntries(entt::type_list<Types...>) {
+    return std::to_array<std::pair<std::string_view, CreateElementFn>>(
+        {{Types::Tag, &createElementAndParseAttributes<Types>}...});
+  }
+
+  /**
+   * Look up the element factory for an SVG tag name.
+   *
+   * Replaces a linear scan that compared the tag against every element type's tag in turn. Lookup
+   * is exact and case-sensitive, matching the `tagName.name == ElementT::Tag` comparison it
+   * replaces. The lookup table's constructor rejects duplicate keys at compile time, so two
+   * element types can never silently claim the same tag.
+   *
+   * @param tagName Tag name to look up.
+   * @return Factory for the matching element type, or nullptr when no element type claims the tag.
+   */
+  static const CreateElementFn* lookupElementFactory(std::string_view tagName);
 
 public:
   explicit SVGParserImpl(SVGParserContext& context, std::shared_ptr<Registry> registry,
@@ -351,35 +396,14 @@ public:
    */
   ParseResult<SVGElement> createElement(const XMLQualifiedNameRef& tagName, const XMLNode& node,
                                         bool isSvgNamespace) {
-    return createElement(tagName, node, isSvgNamespace, AllSVGElements());
-  }
-
-  template <size_t I = 0, typename... Types>
-  ParseResult<SVGElement> createElement(const XMLQualifiedNameRef& tagName, const XMLNode& node,
-                                        bool isSvgNamespace, entt::type_list<Types...>) {
-    if constexpr (I != sizeof...(Types)) {
-      using ElementT = std::tuple_element<I, std::tuple<Types...>>::type;
-
-      if (isSvgNamespace && tagName.name == ElementT::Tag) {
-        if constexpr (IsExperimental<ElementT>()) {
-          if (context_.options().enableExperimental) {
-            auto element = ElementT::CreateOn(node.entityHandle());
-            return ParseAttributes(context_, element, node);
-          } else {
-            auto element = SVGUnknownElement::CreateOn(node.entityHandle(), tagName);
-            return ParseAttributes(context_, element, node);
-          }
-        } else {
-          auto element = ElementT::CreateOn(node.entityHandle());
-          return ParseAttributes(context_, element, node);
-        }
+    if (isSvgNamespace) {
+      if (const CreateElementFn* createFn = lookupElementFactory(std::string_view(tagName.name))) {
+        return (*createFn)(context_, node, tagName);
       }
-
-      return createElement<I + 1>(tagName, node, isSvgNamespace, entt::type_list<Types...>());
-    } else {
-      auto element = SVGUnknownElement::CreateOn(node.entityHandle(), tagName);
-      return ParseAttributes(context_, element, node);
     }
+
+    auto element = SVGUnknownElement::CreateOn(node.entityHandle(), tagName);
+    return ParseAttributes(context_, element, node);
   }
 
   std::optional<ParseDiagnostic> walkChildren(std::optional<SVGElement> element,
@@ -489,6 +513,14 @@ public:
     return std::nullopt;
   }
 };
+
+const CreateElementFn* SVGParserImpl::lookupElementFactory(std::string_view tagName) {
+  // Defined out of line so the table is built where SVGParserImpl is a complete type; the factories
+  // it stores are private members of the class.
+  static DONNER_CONSTEXPR_MAP auto kElementFactories =
+      makeCompileTimeMap(makeElementFactoryEntries(AllSVGElements()));
+  return kElementFactories.find(tagName);
+}
 
 ParseResult<SVGDocument> SVGParser::ParseSVG(std::string_view source, ParseWarningSink& warningSink,
                                              SVGParser::Options options,

--- a/donner/svg/parser/SVGParser.cc
+++ b/donner/svg/parser/SVGParser.cc
@@ -367,8 +367,13 @@ private:
    *
    * Replaces a linear scan that compared the tag against every element type's tag in turn. Lookup
    * is exact and case-sensitive, matching the `tagName.name == ElementT::Tag` comparison it
-   * replaces. The lookup table's constructor rejects duplicate keys at compile time, so two
-   * element types can never silently claim the same tag.
+   * replaces.
+   *
+   * Two element types claiming the same tag is a build error wherever the lookup table is built as
+   * a constant expression, which is every configuration except the one that degrades the table to
+   * runtime initialization to stay inside a lower constexpr step budget. There the duplicate
+   * instead makes the map fall back to a linear scan that returns the first matching key, which is
+   * the entry the replaced scan would also have chosen.
    *
    * @param tagName Tag name to look up.
    * @return Factory for the matching element type, or nullptr when no element type claims the tag.

--- a/donner/svg/parser/details/SVGParserContext.h
+++ b/donner/svg/parser/details/SVGParserContext.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "donner/base/FileOffset.h"
 #include "donner/base/ParseDiagnostic.h"
 #include "donner/base/ParseWarningSink.h"
@@ -42,7 +44,7 @@ public:
    */
   SVGParserContext(std::string_view input UTILS_LIFETIME_BOUND, ParseWarningSink& warningSink,
                    const SVGParser::Options& options)
-      : input_(input), lineOffsets_(input), warningSink_(warningSink), options_(options) {}
+      : input_(input), warningSink_(warningSink), options_(options) {}
 
   /// Get the parser options.
   const SVGParser::Options& options() const { return options_; }
@@ -70,7 +72,7 @@ public:
     // fileOffset() computes both halves consistently; passing the line's own start offset as the
     // column instead shifts every diagnostic on line 2 or later by the length of all preceding
     // lines.
-    const FileOffset parentOffset = lineOffsets_.fileOffset(origin.startOffset);
+    const FileOffset parentOffset = lineOffsets().fileOffset(origin.startOffset);
 
     ParseDiagnostic newError = std::move(error);
     newError.range.start = newError.range.start.addParentOffset(parentOffset);
@@ -149,16 +151,32 @@ public:
    * @param offset Character index.
    * @return size_t Line number, 1-indexed.
    */
-  size_t offsetToLine(size_t offset) const { return lineOffsets_.offsetToLine(offset); }
+  size_t offsetToLine(size_t offset) const { return lineOffsets().offsetToLine(offset); }
 
   /**
    * Returns the offset of a given 1-indexed line number.
    *
    * @param line Line number, 1-indexed.
    */
-  size_t lineOffset(size_t line) const { return lineOffsets_.lineOffset(line); }
+  size_t lineOffset(size_t line) const { return lineOffsets().lineOffset(line); }
 
 private:
+  /**
+   * Return the newline table for the input string, scanning the input on first use.
+   *
+   * Scanning is deferred because a successful parse never needs line or column numbers: they are
+   * only used to place diagnostics. Building the table in the constructor charged every parse for
+   * a full pass over the source plus the vector it fills, whether or not a single warning was
+   * emitted. The table is a pure function of the (immutable) input string, so the deferred result
+   * is identical to the eager one.
+   */
+  const donner::parser::LineOffsets& lineOffsets() const {
+    if (!lineOffsets_.has_value()) {
+      lineOffsets_.emplace(input_);
+    }
+    return *lineOffsets_;
+  }
+
   SourceRange addLineInfo(SourceRange range) const {
     return SourceRange{
         addLineInfo(range.start),
@@ -179,14 +197,14 @@ private:
       return offset;
     }
 
-    return lineOffsets_.fileOffset(*offset.offset);
+    return lineOffsets().fileOffset(*offset.offset);
   }
 
   /// Original string containing the XML text, used for remapping errors.
   std::string_view input_;
 
-  /// Offsets of the start of each line in the input string.
-  donner::parser::LineOffsets lineOffsets_;
+  /// Offsets of the start of each line in the input string, computed on first use.
+  mutable std::optional<donner::parser::LineOffsets> lineOffsets_;
 
   /// Sink to collect warnings encountered during parsing.
   ParseWarningSink& warningSink_;

--- a/donner/svg/parser/tests/SVGParser_tests.cc
+++ b/donner/svg/parser/tests/SVGParser_tests.cc
@@ -262,6 +262,27 @@ TEST(SVGParser, Warning) {
               ElementsAre(ParseWarningIs(0, 13, "Failed to parse number: Unexpected character")));
 }
 
+TEST(SVGParser, InvalidPresentationAttributeWarnsOnceAndKeepsRawAttribute) {
+  const std::string_view invalidXml(
+      R"(<svg xmlns="http://www.w3.org/2000/svg">
+           <rect stroke-width="notanumber" />
+         </svg>)");
+
+  ParseWarningSink warnings;
+  auto documentResult = SVGParser::ParseSVG(invalidXml, warnings);
+  ASSERT_THAT(documentResult, NoParseError());
+
+  // Exactly one diagnostic: the presentation-attribute value is parsed once, so a failure is
+  // reported once. The position is the subparser's own, since an attribute value is not a view
+  // into the document text and cannot be mapped back to it.
+  EXPECT_THAT(warnings.warnings(),
+              ElementsAre(ParseWarningIs(1, 0, "Invalid length or percentage")));
+
+  // A value that fails to parse is still round-tripped as a raw XML attribute.
+  const SVGElement rect = documentResult.result().querySelector("rect").value();
+  EXPECT_THAT(rect.getAttribute("stroke-width"), testing::Optional(RcString("notanumber")));
+}
+
 TEST(SVGParser, InvalidXmlns) {
   const std::string_view invalidXml(R"(<svg id="svg1" viewBox="0 0 200 200" xmlns="invalid">
          </svg>)");

--- a/donner/svg/properties/PropertyRegistry.cc
+++ b/donner/svg/properties/PropertyRegistry.cc
@@ -2245,10 +2245,11 @@ bool PropertyRegistry::isPresentationAttributeInherited(std::string_view name) {
     return false;
   }
 
-  // Each property's name and cascade mode are fixed for the life of the process, so the answer is
-  // read from a table built once rather than by constructing (and destroying) a whole registry per
-  // call just to inspect that metadata. This runs once per presentation attribute that a document
-  // sets, so the per-call registry was charged to every parse.
+  // Each property's name and cascade mode are fixed for the life of the process - every property
+  // is declared with a literal name - so the answer is read from a table built once rather than by
+  // constructing (and destroying) a whole registry per call just to inspect that metadata. This
+  // runs once per presentation attribute that a document sets, so the per-call registry was
+  // charged to every parse.
   static const std::array<std::pair<std::string_view, bool>, numProperties()> kInheritedByName =
       [] {
         std::array<std::pair<std::string_view, bool>, numProperties()> table = {};

--- a/donner/svg/properties/PropertyRegistry.cc
+++ b/donner/svg/properties/PropertyRegistry.cc
@@ -5,6 +5,7 @@
 #include <span>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "donner/base/CompileTimeMap.h"
@@ -2244,17 +2245,31 @@ bool PropertyRegistry::isPresentationAttributeInherited(std::string_view name) {
     return false;
   }
 
-  PropertyRegistry registry;
-  const auto properties = registry.allProperties();
-  bool inherited = false;
+  // Each property's name and cascade mode are fixed for the life of the process, so the answer is
+  // read from a table built once rather than by constructing (and destroying) a whole registry per
+  // call just to inspect that metadata. This runs once per presentation attribute that a document
+  // sets, so the per-call registry was charged to every parse.
+  static const std::array<std::pair<std::string_view, bool>, numProperties()> kInheritedByName =
+      [] {
+        std::array<std::pair<std::string_view, bool>, numProperties()> table = {};
+        PropertyRegistry registry;
+        const auto properties = registry.allProperties();
+        forEachProperty<0, numProperties()>([&properties, &table](auto i) {
+          const auto& property = std::get<i.value>(properties);
+          using PropertyType = std::decay_t<decltype(property)>;
+          table[i.value] = {property.name, PropertyType::kCascadeMode != PropertyCascade::None};
+        });
+        return table;
+      }();
 
-  forEachProperty<0, numProperties()>([&properties, name, &inherited](auto i) {
-    const auto& property = std::get<i.value>(properties);
-    using PropertyType = std::decay_t<decltype(property)>;
-    if (property.name == name) {
-      inherited = PropertyType::kCascadeMode != PropertyCascade::None;
+  // Later entries win, matching the previous scan, which kept assigning as it walked the whole
+  // property list rather than stopping at the first name match.
+  bool inherited = false;
+  for (const auto& [propertyName, propertyInherits] : kInheritedByName) {
+    if (propertyName == name) {
+      inherited = propertyInherits;
     }
-  });
+  }
 
   return inherited;
 }


### PR DESCRIPTION
Second round of parse optimization, measured 28 to 38 percent off parse time across six benchmark documents on top of the earlier lazy-source-location and namespace-cache round, with independent review reproducing 34 and 47 percent on two additional documents. No scene regressed.

The profile drove the order. Element creation and attribute parsing now dispatch through an element-type-indexed handler table and a compile-time perfect-hash tag map instead of a linear fifty-way type walk that re-read the element type per attribute; first-in-type-list ordering, case sensitivity, and unknown-element fallback are preserved exactly, with a static assertion tying the table to the enum. Presentation attributes are parsed once instead of twice: the store previously re-parsed and discarded every value the attribute parser had already parsed, so every presentation attribute paid double CSS parsing and double invalidation. Answering whether a presentation attribute inherits no longer constructs and destroys an entire property registry per attribute. The source line table builds lazily on first diagnostic rather than eagerly per document. Attribute overwrites reuse the existing map node and name storage instead of reallocating both and discarding the new node. The XML tokenizer scans through a contiguous view with the chunk walk kept as the multi-chunk fallback, and attribute source anchors resolve once instead of three to five map lookups per attribute.

Parser behavior is byte-identical: review built both revisions with an instrumented tree dump and compared the full diagnostic list with positions, complete DOM attribute order and values, and computed styles on an adversarial document covering invalid presentation attributes, style and class interactions, foreign namespaces, geometry overlaps, and the disable-user-attributes path, all identical. A new parse-only benchmark makes future rounds measurable in isolation.

Verification: full repository suite green in both configurations, parser and XML and properties suites green, CMake mirror check green, and the position-asserting diagnostic tests pin line and column stability.