### PR TITLE
perf: Convert filter color spaces at graph boundaries instead of per primitive

### DIFF
--- a/donner/svg/renderer/tests/FilterGraphExecutor_tests.cc
+++ b/donner/svg/renderer/tests/FilterGraphExecutor_tests.cc
@@ -1134,7 +1134,10 @@ TEST(FilterGraphExecutorTest, UniformSrgbGraphMatchesOneGraphPerPrimitive) {
 }
 
 // The per-primitive space has to actually take effect: saturating in sRGB and saturating in
-// linearRGB are different computations, so the two graphs must not agree.
+// linearRGB are different computations, so the two graphs must disagree, and by much more than
+// the rounding the tests above tolerate. The measured separation is 36/255; the bound sits well
+// clear of both that and the single unit that a same-schedule comparison produces, so this fails
+// loudly if the per-primitive space is ever ignored.
 TEST(FilterGraphExecutorTest, PerPrimitiveColorSpaceChangesTheResult) {
   const tiny_skia::Pixmap source = MakeColorSourceGraphic();
 
@@ -1149,7 +1152,7 @@ TEST(FilterGraphExecutorTest, PerPrimitiveColorSpaceChangesTheResult) {
   const tiny_skia::Pixmap srgbInterior = RunNodesAsOneGraph(source, std::move(srgbNodes));
   const tiny_skia::Pixmap linearInterior = RunNodesAsOneGraph(source, std::move(linearNodes));
 
-  EXPECT_GT(MaxChannelDelta(srgbInterior, linearInterior), 2);
+  EXPECT_GT(MaxChannelDelta(srgbInterior, linearInterior), 16);
 }
 
 }  // namespace

--- a/donner/svg/renderer/tests/FilterGraphExecutor_tests.cc
+++ b/donner/svg/renderer/tests/FilterGraphExecutor_tests.cc
@@ -3,10 +3,14 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
+#include <optional>
 #include <utility>
+#include <vector>
 
 namespace donner::svg {
 namespace {
@@ -958,6 +962,194 @@ TEST(FilterGraphExecutorTest, FeImageDefaultKernelBlendsAcrossEdge) {
   // behavior nearest-neighbor replaces, proving the `image-rendering` flag selects the kernel.
   EXPECT_THAT(GetPixel(pixmap, 3, 1), Rgba(Gt(0), _, Gt(0), _));
   EXPECT_THAT(GetPixel(pixmap, 4, 1), Rgba(Gt(0), _, Gt(0), _));
+}
+
+// ---------------------------------------------------------------------------
+// Per-primitive color-interpolation-filters
+// ---------------------------------------------------------------------------
+
+/// Builds a source graphic with saturated colors, mid-tones, and partial alpha, so the results
+/// below depend on both segments of the sRGB transfer function.
+tiny_skia::Pixmap MakeColorSourceGraphic() {
+  auto maybePixmap = tiny_skia::Pixmap::fromSize(24, 24);
+  EXPECT_TRUE(maybePixmap.has_value());
+  tiny_skia::Pixmap pixmap = std::move(*maybePixmap);
+
+  for (int y = 0; y < 24; ++y) {
+    for (int x = 0; x < 24; ++x) {
+      const int alpha = 40 + (x * 9 + y * 3) % 216;
+      const auto scale = [&](int value) { return static_cast<std::uint8_t>(value * alpha / 255); };
+      SetPixel(pixmap, x, y,
+               Pixel{scale((x * 11) % 256), scale((y * 7 + 3) % 256), scale((x * 5 + y * 13) % 256),
+                     static_cast<std::uint8_t>(alpha)});
+    }
+  }
+
+  return pixmap;
+}
+
+components::FilterNode BlurNodeWithSpace(std::optional<ColorInterpolationFilters> space) {
+  components::FilterNode node;
+  node.inputs.push_back(components::FilterInput{});  // previous
+  node.primitive = components::filter_primitive::GaussianBlur{
+      .stdDeviationX = 1.5,
+      .stdDeviationY = 1.5,
+  };
+  node.colorInterpolationFilters = space;
+  return node;
+}
+
+components::FilterNode SaturateNodeWithSpace(std::optional<ColorInterpolationFilters> space) {
+  components::FilterNode node;
+  node.inputs.push_back(components::FilterInput{});  // previous
+  node.primitive = components::filter_primitive::ColorMatrix{
+      .type = components::filter_primitive::ColorMatrix::Type::Saturate,
+      .values = {0.4},
+  };
+  node.colorInterpolationFilters = space;
+  return node;
+}
+
+/// Runs each node as its own single-primitive graph, feeding one result into the next. Because a
+/// graph converts into its interpolation space on entry and back out on exit, this reproduces the
+/// per-primitive conversion schedule exactly, whatever the executor does inside a longer graph.
+tiny_skia::Pixmap RunNodesOneGraphAtATime(const tiny_skia::Pixmap& source,
+                                          std::vector<components::FilterNode> nodes) {
+  tiny_skia::Pixmap pixmap = source;
+  for (components::FilterNode& node : nodes) {
+    components::FilterGraph graph;
+    graph.nodes.push_back(std::move(node));
+    ApplyFilterGraphToPixmap(pixmap, graph, Transform2d(), std::nullopt);
+  }
+  return pixmap;
+}
+
+tiny_skia::Pixmap RunNodesAsOneGraph(const tiny_skia::Pixmap& source,
+                                     std::vector<components::FilterNode> nodes) {
+  tiny_skia::Pixmap pixmap = source;
+  components::FilterGraph graph;
+  graph.nodes = std::move(nodes);
+  ApplyFilterGraphToPixmap(pixmap, graph, Transform2d(), std::nullopt);
+  return pixmap;
+}
+
+/// Largest absolute per-channel difference between two same-sized pixmaps.
+int MaxChannelDelta(const tiny_skia::Pixmap& lhs, const tiny_skia::Pixmap& rhs) {
+  const auto a = lhs.data();
+  const auto b = rhs.data();
+  EXPECT_EQ(a.size(), b.size());
+
+  int worst = 0;
+  for (std::size_t i = 0; i < a.size(); ++i) {
+    worst = std::max(worst, std::abs(static_cast<int>(a[i]) - static_cast<int>(b[i])));
+  }
+  return worst;
+}
+
+/// Asserts that a graph agrees with the same primitives run one filter at a time.
+///
+/// The two are the same computation up to one source of difference: the per-primitive reference
+/// hands each result back as an 8-bit pixmap, so it quantizes between primitives where a single
+/// graph keeps float intermediates. That is worth one unit per channel. A larger difference means
+/// the graph converted color spaces somewhere the per-primitive schedule did not, which is the
+/// property these tests are protecting.
+void ExpectMatchesPerPrimitiveRun(const tiny_skia::Pixmap& combined,
+                                  const tiny_skia::Pixmap& perPrimitive) {
+  EXPECT_LE(MaxChannelDelta(combined, perPrimitive), 1);
+}
+
+// A primitive that interpolates in sRGB between two that interpolate in linearRGB has to convert
+// on both crossings, which is the schedule running each primitive as its own filter produces.
+TEST(FilterGraphExecutorTest, SrgbPrimitiveBetweenLinearPrimitivesMatchesOneGraphPerPrimitive) {
+  const tiny_skia::Pixmap source = MakeColorSourceGraphic();
+
+  const auto nodes = [] {
+    std::vector<components::FilterNode> nodes;
+    nodes.push_back(BlurNodeWithSpace(ColorInterpolationFilters::LinearRGB));
+    nodes.push_back(SaturateNodeWithSpace(ColorInterpolationFilters::SRGB));
+    nodes.push_back(BlurNodeWithSpace(ColorInterpolationFilters::LinearRGB));
+    return nodes;
+  };
+
+  const tiny_skia::Pixmap combined = RunNodesAsOneGraph(source, nodes());
+  const tiny_skia::Pixmap perPrimitive = RunNodesOneGraphAtATime(source, nodes());
+
+  ExpectMatchesPerPrimitiveRun(combined, perPrimitive);
+}
+
+// The mirror image: a linearRGB primitive between two sRGB ones.
+TEST(FilterGraphExecutorTest, LinearPrimitiveBetweenSrgbPrimitivesMatchesOneGraphPerPrimitive) {
+  const tiny_skia::Pixmap source = MakeColorSourceGraphic();
+
+  const auto nodes = [] {
+    std::vector<components::FilterNode> nodes;
+    nodes.push_back(BlurNodeWithSpace(ColorInterpolationFilters::SRGB));
+    nodes.push_back(SaturateNodeWithSpace(ColorInterpolationFilters::LinearRGB));
+    nodes.push_back(BlurNodeWithSpace(ColorInterpolationFilters::SRGB));
+    return nodes;
+  };
+
+  const tiny_skia::Pixmap combined = RunNodesAsOneGraph(source, nodes());
+  const tiny_skia::Pixmap perPrimitive = RunNodesOneGraphAtATime(source, nodes());
+
+  ExpectMatchesPerPrimitiveRun(combined, perPrimitive);
+}
+
+// When every primitive agrees on the interpolation space, the intermediate results stay in that
+// space instead of being converted back out and in around every primitive. That removes rounding
+// rather than adding it, so the result still tracks the per-primitive schedule.
+TEST(FilterGraphExecutorTest, UniformLinearGraphStaysWithinRoundingOfOneGraphPerPrimitive) {
+  const tiny_skia::Pixmap source = MakeColorSourceGraphic();
+
+  const auto nodes = [] {
+    std::vector<components::FilterNode> nodes;
+    nodes.push_back(BlurNodeWithSpace(ColorInterpolationFilters::LinearRGB));
+    nodes.push_back(SaturateNodeWithSpace(ColorInterpolationFilters::LinearRGB));
+    nodes.push_back(BlurNodeWithSpace(ColorInterpolationFilters::LinearRGB));
+    return nodes;
+  };
+
+  const tiny_skia::Pixmap combined = RunNodesAsOneGraph(source, nodes());
+  const tiny_skia::Pixmap perPrimitive = RunNodesOneGraphAtATime(source, nodes());
+
+  ExpectMatchesPerPrimitiveRun(combined, perPrimitive);
+}
+
+// Interpolating in sRGB throughout converts nowhere at all, in either arrangement.
+TEST(FilterGraphExecutorTest, UniformSrgbGraphMatchesOneGraphPerPrimitive) {
+  const tiny_skia::Pixmap source = MakeColorSourceGraphic();
+
+  const auto nodes = [] {
+    std::vector<components::FilterNode> nodes;
+    nodes.push_back(BlurNodeWithSpace(ColorInterpolationFilters::SRGB));
+    nodes.push_back(SaturateNodeWithSpace(ColorInterpolationFilters::SRGB));
+    nodes.push_back(BlurNodeWithSpace(ColorInterpolationFilters::SRGB));
+    return nodes;
+  };
+
+  const tiny_skia::Pixmap combined = RunNodesAsOneGraph(source, nodes());
+  const tiny_skia::Pixmap perPrimitive = RunNodesOneGraphAtATime(source, nodes());
+
+  ExpectMatchesPerPrimitiveRun(combined, perPrimitive);
+}
+
+// The per-primitive space has to actually take effect: saturating in sRGB and saturating in
+// linearRGB are different computations, so the two graphs must not agree.
+TEST(FilterGraphExecutorTest, PerPrimitiveColorSpaceChangesTheResult) {
+  const tiny_skia::Pixmap source = MakeColorSourceGraphic();
+
+  std::vector<components::FilterNode> srgbNodes;
+  srgbNodes.push_back(BlurNodeWithSpace(ColorInterpolationFilters::LinearRGB));
+  srgbNodes.push_back(SaturateNodeWithSpace(ColorInterpolationFilters::SRGB));
+
+  std::vector<components::FilterNode> linearNodes;
+  linearNodes.push_back(BlurNodeWithSpace(ColorInterpolationFilters::LinearRGB));
+  linearNodes.push_back(SaturateNodeWithSpace(ColorInterpolationFilters::LinearRGB));
+
+  const tiny_skia::Pixmap srgbInterior = RunNodesAsOneGraph(source, std::move(srgbNodes));
+  const tiny_skia::Pixmap linearInterior = RunNodesAsOneGraph(source, std::move(linearNodes));
+
+  EXPECT_GT(MaxChannelDelta(srgbInterior, linearInterior), 2);
 }
 
 }  // namespace

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/ColorSpace.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/ColorSpace.cpp
@@ -118,6 +118,28 @@ inline float lookupUnit(const std::array<float, kFloatLutSize>& lut, float x) {
   return lut[static_cast<int>(clamped * (kFloatLutSize - 1) + 0.5f)];
 }
 
+/// Converts one premultiplied RGBA pixel through `lut`: unpremultiply, look up,
+/// re-premultiply. Alpha is not gamma-encoded and passes through untouched, and
+/// a transparent pixel is already correct in both spaces.
+inline void convertPixel(const std::array<float, kFloatLutSize>& lut, float& r, float& g, float& b,
+                         float a) {
+  if (a <= 0.0f) {
+    return;
+  }
+
+  if (a >= 1.0f) {
+    r = lookupUnit(lut, r);
+    g = lookupUnit(lut, g);
+    b = lookupUnit(lut, b);
+    return;
+  }
+
+  const float invAlpha = 1.0f / a;
+  r = lookupUnit(lut, r * invAlpha) * a;
+  g = lookupUnit(lut, g * invAlpha) * a;
+  b = lookupUnit(lut, b * invAlpha) * a;
+}
+
 }  // namespace
 
 void srgbToLinear(Pixmap& pixmap) {
@@ -229,26 +251,14 @@ void srgbToLinear(FloatPixmap& pixmap) {
 
   for (std::size_t i = 0; i < pixelCount; ++i) {
     const std::size_t off = i * 4;
-    const float a = data[off + 3];
-
-    if (a <= 0.0f) {
-      continue;
-    }
-
-    if (a >= 1.0f) {
-      // Fully opaque: direct conversion.
-      data[off + 0] = lookupUnit(lut, data[off + 0]);
-      data[off + 1] = lookupUnit(lut, data[off + 1]);
-      data[off + 2] = lookupUnit(lut, data[off + 2]);
-    } else {
-      // Unpremultiply, convert, re-premultiply.
-      const float invAlpha = 1.0f / a;
-
-      data[off + 0] = lookupUnit(lut, data[off + 0] * invAlpha) * a;
-      data[off + 1] = lookupUnit(lut, data[off + 1] * invAlpha) * a;
-      data[off + 2] = lookupUnit(lut, data[off + 2] * invAlpha) * a;
-    }
+    convertPixel(lut, data[off + 0], data[off + 1], data[off + 2], data[off + 3]);
   }
+}
+
+std::array<float, 4> srgbToLinearPixel(std::array<float, 4> premultiplied) {
+  convertPixel(srgbToLinearFloatLut(), premultiplied[0], premultiplied[1], premultiplied[2],
+               premultiplied[3]);
+  return premultiplied;
 }
 
 void linearToSrgb(FloatPixmap& pixmap) {
@@ -260,23 +270,7 @@ void linearToSrgb(FloatPixmap& pixmap) {
 
   for (std::size_t i = 0; i < pixelCount; ++i) {
     const std::size_t off = i * 4;
-    const float a = data[off + 3];
-
-    if (a <= 0.0f) {
-      continue;
-    }
-
-    if (a >= 1.0f) {
-      data[off + 0] = lookupUnit(lut, data[off + 0]);
-      data[off + 1] = lookupUnit(lut, data[off + 1]);
-      data[off + 2] = lookupUnit(lut, data[off + 2]);
-    } else {
-      const float invAlpha = 1.0f / a;
-
-      data[off + 0] = lookupUnit(lut, data[off + 0] * invAlpha) * a;
-      data[off + 1] = lookupUnit(lut, data[off + 1] * invAlpha) * a;
-      data[off + 2] = lookupUnit(lut, data[off + 2] * invAlpha) * a;
-    }
+    convertPixel(lut, data[off + 0], data[off + 1], data[off + 2], data[off + 3]);
   }
 }
 

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/ColorSpace.h
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/ColorSpace.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <array>
+
 #include "tiny_skia/Pixmap.h"
 #include "tiny_skia/filter/FloatPixmap.h"
 
@@ -40,5 +42,16 @@ void srgbToLinear(FloatPixmap& pixmap);
 /// function; the result is within 0.41/255 of evaluating the transfer
 /// function per pixel (see ColorSpace.cpp for the measured bounds).
 void linearToSrgb(FloatPixmap& pixmap);
+
+/// Converts one premultiplied RGBA pixel from sRGB to linear RGB.
+///
+/// This is the exact per-pixel step `srgbToLinear(FloatPixmap&)` applies, and
+/// shares its implementation. It lets a caller that is about to fill a buffer
+/// with a single color convert the color instead of the buffer, which is a
+/// constant-time conversion rather than one pass over every pixel.
+///
+/// @param premultiplied Premultiplied RGBA channels in [0,1].
+/// @return The premultiplied RGBA channels in linear RGB.
+std::array<float, 4> srgbToLinearPixel(std::array<float, 4> premultiplied);
 
 }  // namespace tiny_skia::filter

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/FilterGraph.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/FilterGraph.cpp
@@ -178,6 +178,105 @@ double srgbToLinearChannel(double s) {
   return std::pow((s + 0.055) / 1.055, 2.4);
 }
 
+/// Pixels a node just produced, tagged with the color space they are expressed in.
+struct NodeOutput {
+  FloatPixmap pixmap;
+  /// true when the channel values are linearRGB, false when they are sRGB.
+  bool linear = false;
+  /// true when the two spaces hold bit-identical values for this buffer, which is the case
+  /// exactly when every RGB channel is zero: unpremultiplying zero yields zero, both transfer
+  /// functions map zero to zero, and neither touches alpha. Alpha-only buffers therefore never
+  /// need a conversion pass, no matter which space consumes them.
+  bool spaceInvariant = false;
+};
+
+/// A filter buffer that remembers which color space its pixels are in.
+///
+/// Primitives are defined to operate in an interpolation space, and SVG picks that space per
+/// primitive rather than per graph (`color-interpolation-filters`). Tagging each buffer instead
+/// of normalizing every node's result back to one storage space means a graph whose primitives
+/// agree on a space converts once on the way in and once on the way out, while a mixed graph pays
+/// a conversion only on the edges that actually cross between spaces.
+///
+/// The stored pixels are never converted in place, because one buffer can feed several nodes:
+/// an in-place conversion would either corrupt a later consumer that wants the original space or
+/// force a lossy round trip back to it. The other space is materialized alongside instead, and
+/// only once per buffer.
+class SpacedPixmap {
+ public:
+  SpacedPixmap() = default;
+
+  SpacedPixmap(FloatPixmap pixmap, bool linear) : pixmap_(std::move(pixmap)), linear_(linear) {}
+
+  explicit SpacedPixmap(NodeOutput output)
+      : pixmap_(std::move(output.pixmap)),
+        linear_(output.linear),
+        spaceInvariant_(output.spaceInvariant) {}
+
+  /// Wraps a buffer whose RGB channels are all zero, which reads identically in both spaces.
+  static SpacedPixmap alphaOnly(FloatPixmap pixmap) {
+    SpacedPixmap result(std::move(pixmap), /*linear=*/false);
+    result.spaceInvariant_ = true;
+    return result;
+  }
+
+  /// Returns the pixels in the requested space, materializing and caching the conversion the
+  /// first time a consumer asks for a space the stored pixels are not already in.
+  const FloatPixmap& in(bool linear) {
+    if (spaceInvariant_ || linear == linear_) {
+      return pixmap_;
+    }
+
+    if (!converted_.has_value()) {
+      FloatPixmap fp(pixmap_);
+      if (linear) {
+        srgbToLinear(fp);
+      } else {
+        linearToSrgb(fp);
+      }
+      converted_ = std::move(fp);
+    }
+
+    return *converted_;
+  }
+
+  /// Returns the stored pixels without converting. Only valid for operations that are
+  /// independent of the color space, such as moving or clearing pixels.
+  [[nodiscard]] const FloatPixmap& spaceAgnostic() const { return pixmap_; }
+
+  /// Takes ownership of the pixels in the requested space, converting in place when no cached
+  /// conversion exists. The buffer must not be read afterwards.
+  FloatPixmap release(bool linear) {
+    if (spaceInvariant_ || linear == linear_) {
+      return std::move(pixmap_);
+    }
+
+    if (converted_.has_value()) {
+      return std::move(*converted_);
+    }
+
+    FloatPixmap fp = std::move(pixmap_);
+    if (linear) {
+      srgbToLinear(fp);
+    } else {
+      linearToSrgb(fp);
+    }
+    return fp;
+  }
+
+  /// Describes the stored pixels so a space-independent operation can tag its own result the
+  /// same way.
+  [[nodiscard]] NodeOutput describe(FloatPixmap pixmap) const {
+    return NodeOutput{std::move(pixmap), linear_, spaceInvariant_};
+  }
+
+ private:
+  FloatPixmap pixmap_;
+  bool linear_ = false;
+  bool spaceInvariant_ = false;
+  std::optional<FloatPixmap> converted_;
+};
+
 }  // namespace
 
 bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
@@ -187,73 +286,84 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
     return false;
   }
 
-  // Float sRGB intermediate storage — eliminates uint8 quantization between nodes.
-  // All buffers are stored as float [0,1] in sRGB gamma. Per-node linearRGB conversion
-  // uses float↔float srgbToLinear/linearToSrgb (no lossy uint8 round-trip).
-  FloatPixmap sourceFloat = FloatPixmap::fromPixmap(sourceGraphic);
+  // Float intermediate storage avoids uint8 quantization between nodes. Every buffer is
+  // float [0,1] premultiplied, tagged with the color space it holds (see SpacedPixmap). The
+  // graph's pixel data therefore crosses between sRGB and linearRGB only where two adjacent
+  // primitives disagree about the interpolation space, instead of on every primitive: the usual
+  // graph, where all primitives share one space, converts once on entry and once on exit.
+  FloatPixmap sourceFloatPixels = FloatPixmap::fromPixmap(sourceGraphic);
 
   if (graph.clipSourceToFilterRegion && graph.filterRegion.has_value()) {
     if (graph.filterFromDevice.has_value() && graph.userSpaceFilterRegion.has_value()) {
-      applySubregionClipping(sourceFloat, *graph.filterRegion, w, h, &*graph.filterFromDevice,
+      applySubregionClipping(sourceFloatPixels, *graph.filterRegion, w, h, &*graph.filterFromDevice,
                              &*graph.userSpaceFilterRegion);
     } else {
-      applySubregionClipping(sourceFloat, *graph.filterRegion, w, h);
+      applySubregionClipping(sourceFloatPixels, *graph.filterRegion, w, h);
     }
   }
 
-  // Convert paint inputs to float sRGB.
-  std::optional<FloatPixmap> fillPaintStorage =
+  // The source graphic and the paint inputs arrive as uint8 sRGB.
+  SpacedPixmap sourceFloat(std::move(sourceFloatPixels), /*linear=*/false);
+  std::optional<SpacedPixmap> fillPaintStorage =
       graph.fillPaintInput.has_value()
-          ? std::make_optional(FloatPixmap::fromPixmap(*graph.fillPaintInput))
+          ? std::make_optional(SpacedPixmap(FloatPixmap::fromPixmap(*graph.fillPaintInput),
+                                            /*linear=*/false))
           : std::nullopt;
-  std::optional<FloatPixmap> strokePaintStorage =
+  std::optional<SpacedPixmap> strokePaintStorage =
       graph.strokePaintInput.has_value()
-          ? std::make_optional(FloatPixmap::fromPixmap(*graph.strokePaintInput))
+          ? std::make_optional(SpacedPixmap(FloatPixmap::fromPixmap(*graph.strokePaintInput),
+                                            /*linear=*/false))
           : std::nullopt;
 
-  // Buffer management — all intermediate storage in float sRGB.
-  FloatPixmap* source = &sourceFloat;
-  FloatPixmap* fillPaint = fillPaintStorage.has_value() ? &*fillPaintStorage : nullptr;
-  FloatPixmap* strokePaint = strokePaintStorage.has_value() ? &*strokePaintStorage : nullptr;
-  std::optional<FloatPixmap> transparentPaintInput;
-  std::optional<FloatPixmap> sourceAlpha;
-  std::optional<FloatPixmap> previousOutput;
-  std::map<std::string, FloatPixmap> namedBuffers;
+  // Buffer management.
+  SpacedPixmap* source = &sourceFloat;
+  SpacedPixmap* fillPaint = fillPaintStorage.has_value() ? &*fillPaintStorage : nullptr;
+  SpacedPixmap* strokePaint = strokePaintStorage.has_value() ? &*strokePaintStorage : nullptr;
+  std::optional<SpacedPixmap> transparentPaintInput;
+  std::optional<SpacedPixmap> sourceAlpha;
+  std::optional<SpacedPixmap> previousOutput;
+  std::map<std::string, SpacedPixmap> namedBuffers;
 
   // Subregion tracking.
   const Box fullRegion = Box::fromWH(w, h);
   const Box filterRegionBox =
       graph.filterRegion.has_value() ? Box::fromPixelRect(*graph.filterRegion) : fullRegion;
   Box previousOutputSubregion = fullRegion;
+  // Alpha coverage does not depend on the color space, so the paint bounds can read the stored
+  // pixels directly.
   const std::optional<Box> fillPaintSubregion =
-      fillPaint != nullptr ? computeNonTransparentBounds(*fillPaint) : std::nullopt;
+      fillPaint != nullptr ? computeNonTransparentBounds(fillPaint->spaceAgnostic()) : std::nullopt;
   const std::optional<Box> strokePaintSubregion =
-      strokePaint != nullptr ? computeNonTransparentBounds(*strokePaint) : std::nullopt;
+      strokePaint != nullptr ? computeNonTransparentBounds(strokePaint->spaceAgnostic())
+                             : std::nullopt;
   std::map<std::string, Box> namedSubregions;
 
-  auto getTransparentPaintInput = [&]() -> FloatPixmap* {
+  auto getTransparentPaintInput = [&]() -> SpacedPixmap* {
     if (!transparentPaintInput.has_value()) {
-      transparentPaintInput = createTransparentFloat(w, h);
+      transparentPaintInput = SpacedPixmap::alphaOnly(createTransparentFloat(w, h));
     }
     return &*transparentPaintInput;
   };
 
-  auto getSourceAlpha = [&]() -> FloatPixmap* {
+  auto getSourceAlpha = [&]() -> SpacedPixmap* {
     if (!sourceAlpha.has_value()) {
-      sourceAlpha = FloatPixmap(*source);
-      auto data = sourceAlpha->data();
+      // Zeroing RGB makes the buffer read the same in either space, so SourceAlpha never needs a
+      // conversion pass regardless of which space the consuming primitive works in.
+      FloatPixmap alphaOnly(source->spaceAgnostic());
+      auto data = alphaOnly.data();
       for (int i = 0; i < w * h; ++i) {
         data[i * 4 + 0] = 0.0f;
         data[i * 4 + 1] = 0.0f;
         data[i * 4 + 2] = 0.0f;
       }
+      sourceAlpha = SpacedPixmap::alphaOnly(std::move(alphaOnly));
     }
     return &sourceAlpha.value();
   };
 
-  auto resolveInput = [&](const NodeInput& input) -> FloatPixmap* {
+  auto resolveInput = [&](const NodeInput& input) -> SpacedPixmap* {
     return std::visit(
-        [&](const auto& v) -> FloatPixmap* {
+        [&](const auto& v) -> SpacedPixmap* {
           using V = std::decay_t<decltype(v)>;
           if constexpr (std::is_same_v<V, NodeInput::Previous>) {
             return previousOutput.has_value() ? &previousOutput.value() : source;
@@ -365,10 +475,12 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
   for (const GraphNode& node : graph.nodes) {
     const bool nodeLinearRGB = node.useLinearRGB.value_or(graph.useLinearRGB);
 
-    // All stored buffers are float sRGB. Color space conversion happens per-node.
-    FloatPixmap* input = node.inputs.empty() ? source : resolveInput(node.inputs[0]);
+    // Each buffer knows its own color space, so a node asks its inputs for the space it works in
+    // and tags its result with that same space. `in()` is a no-op whenever the producer already
+    // agreed with this node, which is the common case.
+    SpacedPixmap* input = node.inputs.empty() ? source : resolveInput(node.inputs[0]);
 
-    std::optional<FloatPixmap> output;
+    std::optional<NodeOutput> output;
 
     std::visit(
         [&](const auto& primitive) {
@@ -376,107 +488,63 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
           using namespace graph_primitive;
 
           if constexpr (std::is_same_v<T, GaussianBlur>) {
-            auto fp = FloatPixmap(*input);
-            if (nodeLinearRGB) {
-              srgbToLinear(fp);
-            }
+            auto fp = FloatPixmap(input->in(nodeLinearRGB));
             gaussianBlur(fp, primitive.sigmaX, primitive.sigmaY, primitive.edgeMode);
-            if (nodeLinearRGB) {
-              linearToSrgb(fp);
-            }
-            output = std::move(fp);
+            output = NodeOutput{std::move(fp), nodeLinearRGB};
 
           } else if constexpr (std::is_same_v<T, Flood>) {
-            // Flood color is sRGB uint8. Convert to float and store as sRGB float.
+            // Flood color is premultiplied sRGB uint8, so a linearRGB node has to convert it into
+            // its own space.
             auto fp = createTransparentFloat(w, h);
             flood(fp, primitive.r / 255.0f, primitive.g / 255.0f, primitive.b / 255.0f,
                   primitive.a / 255.0f);
-            output = std::move(fp);
+            if (nodeLinearRGB) {
+              srgbToLinear(fp);
+            }
+            output = NodeOutput{std::move(fp), nodeLinearRGB};
 
           } else if constexpr (std::is_same_v<T, graph_primitive::Offset>) {
-            // Pure pixel mover — color space doesn't affect the operation.
+            // Pure pixel mover: the result is the input's pixels in the input's space, so it
+            // needs no conversion in either direction.
             auto fpOut = createTransparentFloat(w, h);
-            filter::offset(*input, fpOut, primitive.dx, primitive.dy);
-            output = std::move(fpOut);
+            filter::offset(input->spaceAgnostic(), fpOut, primitive.dx, primitive.dy);
+            output = input->describe(std::move(fpOut));
 
           } else if constexpr (std::is_same_v<T, graph_primitive::Composite>) {
-            FloatPixmap* input2 = node.inputs.size() > 1 ? resolveInput(node.inputs[1]) : source;
-            if (nodeLinearRGB) {
-              auto fpIn1 = FloatPixmap(*input);
-              auto fpIn2 = FloatPixmap(*input2);
-              srgbToLinear(fpIn1);
-              srgbToLinear(fpIn2);
-              auto fpOut = createTransparentFloat(w, h);
-              composite(fpIn1, fpIn2, fpOut, primitive.op, primitive.k1, primitive.k2, primitive.k3,
-                        primitive.k4);
-              linearToSrgb(fpOut);
-              output = std::move(fpOut);
-            } else {
-              auto fpOut = createTransparentFloat(w, h);
-              composite(*input, *input2, fpOut, primitive.op, primitive.k1, primitive.k2,
-                        primitive.k3, primitive.k4);
-              output = std::move(fpOut);
-            }
+            SpacedPixmap* input2 = node.inputs.size() > 1 ? resolveInput(node.inputs[1]) : source;
+            const FloatPixmap& in1 = input->in(nodeLinearRGB);
+            const FloatPixmap& in2 = input2->in(nodeLinearRGB);
+            auto fpOut = createTransparentFloat(w, h);
+            composite(in1, in2, fpOut, primitive.op, primitive.k1, primitive.k2, primitive.k3,
+                      primitive.k4);
+            output = NodeOutput{std::move(fpOut), nodeLinearRGB};
 
           } else if constexpr (std::is_same_v<T, graph_primitive::Blend>) {
-            FloatPixmap* input2 = node.inputs.size() > 1 ? resolveInput(node.inputs[1]) : source;
-            if (nodeLinearRGB) {
-              auto fpIn1 = FloatPixmap(*input);
-              auto fpIn2 = FloatPixmap(*input2);
-              srgbToLinear(fpIn1);
-              srgbToLinear(fpIn2);
-              auto fpOut = createTransparentFloat(w, h);
-              blend(fpIn2, fpIn1, fpOut, primitive.mode);
-              linearToSrgb(fpOut);
-              output = std::move(fpOut);
-            } else {
-              auto fpOut = createTransparentFloat(w, h);
-              blend(*input2, *input, fpOut, primitive.mode);
-              output = std::move(fpOut);
-            }
+            SpacedPixmap* input2 = node.inputs.size() > 1 ? resolveInput(node.inputs[1]) : source;
+            const FloatPixmap& in1 = input->in(nodeLinearRGB);
+            const FloatPixmap& in2 = input2->in(nodeLinearRGB);
+            auto fpOut = createTransparentFloat(w, h);
+            blend(in2, in1, fpOut, primitive.mode);
+            output = NodeOutput{std::move(fpOut), nodeLinearRGB};
 
           } else if constexpr (std::is_same_v<T, graph_primitive::Merge>) {
-            if (nodeLinearRGB) {
-              std::vector<FloatPixmap> mergeFloats;
-              mergeFloats.reserve(node.inputs.size());
-              for (const auto& mergeInput : node.inputs) {
-                FloatPixmap* mergeRaw = resolveInput(mergeInput);
-                mergeFloats.push_back(FloatPixmap(*mergeRaw));
-                srgbToLinear(mergeFloats.back());
-              }
-              std::vector<const FloatPixmap*> floatLayers;
-              floatLayers.reserve(mergeFloats.size());
-              for (auto& fp : mergeFloats) {
-                floatLayers.push_back(&fp);
-              }
-              auto fpOut = createTransparentFloat(w, h);
-              merge(std::span<const FloatPixmap* const>(floatLayers), fpOut);
-              linearToSrgb(fpOut);
-              output = std::move(fpOut);
-            } else {
-              std::vector<const FloatPixmap*> layers;
-              for (const auto& mergeInput : node.inputs) {
-                layers.push_back(resolveInput(mergeInput));
-              }
-              auto fpOut = createTransparentFloat(w, h);
-              merge(std::span<const FloatPixmap* const>(layers), fpOut);
-              output = std::move(fpOut);
+            std::vector<const FloatPixmap*> layers;
+            layers.reserve(node.inputs.size());
+            for (const auto& mergeInput : node.inputs) {
+              layers.push_back(&resolveInput(mergeInput)->in(nodeLinearRGB));
             }
+            auto fpOut = createTransparentFloat(w, h);
+            merge(std::span<const FloatPixmap* const>(layers), fpOut);
+            output = NodeOutput{std::move(fpOut), nodeLinearRGB};
 
           } else if constexpr (std::is_same_v<T, graph_primitive::ColorMatrix>) {
             if (primitive.matrix == identityMatrix()) {
-              // Identity matrix: pass through without color space conversion.
-              output = FloatPixmap(*input);
-            } else if (nodeLinearRGB) {
-              auto fp = FloatPixmap(*input);
-              srgbToLinear(fp);
-              colorMatrix(fp, primitive.matrix);
-              linearToSrgb(fp);
-              output = std::move(fp);
+              // Identity matrix: pass through, which is independent of the color space.
+              output = input->describe(FloatPixmap(input->spaceAgnostic()));
             } else {
-              auto fp = FloatPixmap(*input);
+              auto fp = FloatPixmap(input->in(nodeLinearRGB));
               colorMatrix(fp, primitive.matrix);
-              output = std::move(fp);
+              output = NodeOutput{std::move(fp), nodeLinearRGB};
             }
 
           } else if constexpr (std::is_same_v<T, graph_primitive::ComponentTransfer>) {
@@ -491,16 +559,10 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
               tf.offset = f.offset;
               return tf;
             };
-            auto fp = FloatPixmap(*input);
-            if (nodeLinearRGB) {
-              srgbToLinear(fp);
-            }
+            auto fp = FloatPixmap(input->in(nodeLinearRGB));
             componentTransfer(fp, toFunc(primitive.funcR), toFunc(primitive.funcG),
                               toFunc(primitive.funcB), toFunc(primitive.funcA));
-            if (nodeLinearRGB) {
-              linearToSrgb(fp);
-            }
-            output = std::move(fp);
+            output = NodeOutput{std::move(fp), nodeLinearRGB};
 
           } else if constexpr (std::is_same_v<T, graph_primitive::ConvolveMatrix>) {
             auto fpOut = createTransparentFloat(w, h);
@@ -520,16 +582,9 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
               params.targetY = primitive.targetY;
               params.edgeMode = primitive.edgeMode;
               params.preserveAlpha = primitive.preserveAlpha;
-              if (nodeLinearRGB) {
-                auto fpIn = FloatPixmap(*input);
-                srgbToLinear(fpIn);
-                convolveMatrix(fpIn, fpOut, params);
-                linearToSrgb(fpOut);
-              } else {
-                convolveMatrix(*input, fpOut, params);
-              }
+              convolveMatrix(input->in(nodeLinearRGB), fpOut, params);
             }
-            output = std::move(fpOut);
+            output = NodeOutput{std::move(fpOut), nodeLinearRGB};
 
           } else if constexpr (std::is_same_v<T, graph_primitive::Morphology>) {
             // SVG Filter Effects §15.4: a negative radius, or a zero radius on both axes
@@ -540,22 +595,17 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
             const bool disabled = primitive.radiusX < 0 || primitive.radiusY < 0 ||
                                   (primitive.radiusX == 0 && primitive.radiusY == 0);
             if (disabled) {
-              output = FloatPixmap(*input);
+              // Pass-through, which is independent of the color space.
+              output = input->describe(FloatPixmap(input->spaceAgnostic()));
             } else {
               auto fpOut = createTransparentFloat(w, h);
-              if (nodeLinearRGB) {
-                auto fpIn = FloatPixmap(*input);
-                srgbToLinear(fpIn);
-                morphology(fpIn, fpOut, primitive.op, primitive.radiusX, primitive.radiusY);
-                linearToSrgb(fpOut);
-              } else {
-                morphology(*input, fpOut, primitive.op, primitive.radiusX, primitive.radiusY);
-              }
-              output = std::move(fpOut);
+              morphology(input->in(nodeLinearRGB), fpOut, primitive.op, primitive.radiusX,
+                         primitive.radiusY);
+              output = NodeOutput{std::move(fpOut), nodeLinearRGB};
             }
 
           } else if constexpr (std::is_same_v<T, graph_primitive::Tile>) {
-            // Pure pixel mover — color space doesn't affect the operation.
+            // Pure pixel mover, so the result stays in the input's space with no conversion.
             auto fpOut = createTransparentFloat(w, h);
             const Box inputSubregion = node.inputs.empty() ? previousOutputSubregion
                                                            : resolveInputSubregion(node.inputs[0]);
@@ -566,56 +616,36 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
             const int tileW = tileR - tileX;
             const int tileH = tileB - tileY;
             if (tileW > 0 && tileH > 0) {
-              tile(*input, fpOut, tileX, tileY, tileW, tileH);
+              tile(input->spaceAgnostic(), fpOut, tileX, tileY, tileW, tileH);
             }
-            output = std::move(fpOut);
+            output = input->describe(std::move(fpOut));
 
           } else if constexpr (std::is_same_v<T, graph_primitive::Turbulence>) {
+            // Turbulence generates noise directly in the node's interpolation space.
             auto fp = createTransparentFloat(w, h);
             turbulence(fp, primitive.params);
-            if (nodeLinearRGB) {
-              // Turbulence generates noise in the processing color space (linear).
-              // Convert to sRGB for storage.
-              linearToSrgb(fp);
-            }
-            output = std::move(fp);
+            output = NodeOutput{std::move(fp), nodeLinearRGB};
 
           } else if constexpr (std::is_same_v<T, graph_primitive::DisplacementMap>) {
-            FloatPixmap* input2 = node.inputs.size() > 1 ? resolveInput(node.inputs[1]) : source;
-            if (nodeLinearRGB) {
-              auto fpIn1 = FloatPixmap(*input);
-              auto fpIn2 = FloatPixmap(*input2);
-              srgbToLinear(fpIn1);
-              srgbToLinear(fpIn2);
-              auto fpOut = createTransparentFloat(w, h);
-              displacementMap(fpIn1, fpIn2, fpOut, primitive.scale, primitive.xChannel,
-                              primitive.yChannel);
-              linearToSrgb(fpOut);
-              output = std::move(fpOut);
-            } else {
-              auto fpOut = createTransparentFloat(w, h);
-              displacementMap(*input, *input2, fpOut, primitive.scale, primitive.xChannel,
-                              primitive.yChannel);
-              output = std::move(fpOut);
-            }
+            SpacedPixmap* input2 = node.inputs.size() > 1 ? resolveInput(node.inputs[1]) : source;
+            const FloatPixmap& in1 = input->in(nodeLinearRGB);
+            const FloatPixmap& in2 = input2->in(nodeLinearRGB);
+            auto fpOut = createTransparentFloat(w, h);
+            displacementMap(in1, in2, fpOut, primitive.scale, primitive.xChannel,
+                            primitive.yChannel);
+            output = NodeOutput{std::move(fpOut), nodeLinearRGB};
 
           } else if constexpr (std::is_same_v<T, graph_primitive::DiffuseLighting>) {
+            auto fpOut = createTransparentFloat(w, h);
+            auto params = primitive.params;
             if (nodeLinearRGB) {
-              auto fpIn = FloatPixmap(*input);
-              srgbToLinear(fpIn);
-              auto fpOut = createTransparentFloat(w, h);
-              auto params = primitive.params;
+              // The light color is authored in sRGB, so it follows the pixels into linearRGB.
               params.lightR = srgbToLinearChannel(params.lightR);
               params.lightG = srgbToLinearChannel(params.lightG);
               params.lightB = srgbToLinearChannel(params.lightB);
-              diffuseLighting(fpIn, fpOut, params);
-              linearToSrgb(fpOut);
-              output = std::move(fpOut);
-            } else {
-              auto fpOut = createTransparentFloat(w, h);
-              diffuseLighting(*input, fpOut, primitive.params);
-              output = std::move(fpOut);
             }
+            diffuseLighting(input->in(nodeLinearRGB), fpOut, params);
+            output = NodeOutput{std::move(fpOut), nodeLinearRGB};
 
           } else if constexpr (std::is_same_v<T, graph_primitive::SpecularLighting>) {
             // Per SVG spec, specularExponent must be in [1, 128].
@@ -625,75 +655,44 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
               auto params = primitive.params;
               params.specularExponent = std::min(params.specularExponent, 128.0);
               if (nodeLinearRGB) {
-                auto fpIn = FloatPixmap(*input);
-                srgbToLinear(fpIn);
                 params.lightR = srgbToLinearChannel(params.lightR);
                 params.lightG = srgbToLinearChannel(params.lightG);
                 params.lightB = srgbToLinearChannel(params.lightB);
-                specularLighting(fpIn, fpOut, params);
-                linearToSrgb(fpOut);
-              } else {
-                specularLighting(*input, fpOut, params);
               }
+              specularLighting(input->in(nodeLinearRGB), fpOut, params);
             }
-            output = std::move(fpOut);
+            output = NodeOutput{std::move(fpOut), nodeLinearRGB};
 
           } else if constexpr (std::is_same_v<T, graph_primitive::DropShadow>) {
+            // Decomposed into flood + composite-in + offset + blur + merge, all run in the
+            // node's own interpolation space. Only the flood color needs converting, because it
+            // is authored as premultiplied sRGB; the source alpha carries no color.
+            auto floodBuf = createTransparentFloat(w, h);
+            flood(floodBuf, primitive.r / 255.0f, primitive.g / 255.0f, primitive.b / 255.0f,
+                  primitive.a / 255.0f);
             if (nodeLinearRGB) {
-              // All sub-operations in float linear.
-              auto fpFlood = createTransparentFloat(w, h);
-              flood(fpFlood, primitive.r / 255.0f, primitive.g / 255.0f, primitive.b / 255.0f,
-                    primitive.a / 255.0f);
-              srgbToLinear(fpFlood);
-
-              // Source alpha as float (RGB zeroed, alpha preserved).
-              // Alpha is not gamma-encoded, so no color space conversion needed.
-              auto fpSrcAlpha = FloatPixmap(*source);
-              auto srcAlphaData = fpSrcAlpha.data();
-              for (int i = 0; i < w * h; ++i) {
-                srcAlphaData[i * 4 + 0] = 0.0f;
-                srcAlphaData[i * 4 + 1] = 0.0f;
-                srcAlphaData[i * 4 + 2] = 0.0f;
-              }
-
-              auto fpComposite = createTransparentFloat(w, h);
-              composite(fpFlood, fpSrcAlpha, fpComposite, CompositeOp::In);
-
-              auto fpOffset = createTransparentFloat(w, h);
-              filter::offset(fpComposite, fpOffset, primitive.dx, primitive.dy);
-
-              gaussianBlur(fpOffset, primitive.sigmaX, primitive.sigmaY);
-
-              auto fpInput = FloatPixmap(*input);
-              srgbToLinear(fpInput);
-
-              auto fpOut = createTransparentFloat(w, h);
-              std::vector<const FloatPixmap*> layers = {&fpOffset, &fpInput};
-              merge(std::span<const FloatPixmap* const>(layers), fpOut);
-              linearToSrgb(fpOut);
-              output = std::move(fpOut);
-            } else {
-              auto floodBuf = createTransparentFloat(w, h);
-              flood(floodBuf, primitive.r / 255.0f, primitive.g / 255.0f, primitive.b / 255.0f,
-                    primitive.a / 255.0f);
-
-              auto compositeBuf = createTransparentFloat(w, h);
-              FloatPixmap* srcAlpha = getSourceAlpha();
-              composite(floodBuf, *srcAlpha, compositeBuf, CompositeOp::In);
-
-              auto offsetBuf = createTransparentFloat(w, h);
-              filter::offset(compositeBuf, offsetBuf, primitive.dx, primitive.dy);
-
-              gaussianBlur(offsetBuf, primitive.sigmaX, primitive.sigmaY);
-
-              auto fpOut = createTransparentFloat(w, h);
-              std::vector<const FloatPixmap*> layers = {&offsetBuf, input};
-              merge(std::span<const FloatPixmap* const>(layers), fpOut);
-              output = std::move(fpOut);
+              srgbToLinear(floodBuf);
             }
 
+            auto compositeBuf = createTransparentFloat(w, h);
+            composite(floodBuf, getSourceAlpha()->spaceAgnostic(), compositeBuf, CompositeOp::In);
+
+            auto offsetBuf = createTransparentFloat(w, h);
+            filter::offset(compositeBuf, offsetBuf, primitive.dx, primitive.dy);
+
+            gaussianBlur(offsetBuf, primitive.sigmaX, primitive.sigmaY);
+
+            auto fpOut = createTransparentFloat(w, h);
+            const std::vector<const FloatPixmap*> layers = {&offsetBuf, &input->in(nodeLinearRGB)};
+            merge(std::span<const FloatPixmap* const>(layers), fpOut);
+            output = NodeOutput{std::move(fpOut), nodeLinearRGB};
+
           } else if constexpr (std::is_same_v<T, graph_primitive::Image>) {
-            // Image data is sRGB uint8. Mitchell-Netravali bicubic resampling in float.
+            // Image data is sRGB uint8, and the resampling below runs on those sRGB values, so
+            // the result is tagged sRGB no matter which space this node interpolates in. A
+            // linearRGB consumer converts it, exactly as it would convert any other sRGB buffer.
+            //
+            // Mitchell-Netravali bicubic resampling in float.
             //
             // resvg (the reference renderer) resamples feImage content with the
             // Mitchell-Netravali cubic kernel (B = C = 1/3), the standard "high quality"
@@ -762,8 +761,10 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
                   // position `srcXf + 0.5`) instead of the bicubic footprint. Exact per-texel, so
                   // there is no interpolation ramp; block edges stay hard.
                   if (primitive.pixelated) {
-                    const int nsx = std::clamp(static_cast<int>(std::floor(srcXf + 0.5)), 0, srcW - 1);
-                    const int nsy = std::clamp(static_cast<int>(std::floor(srcYf + 0.5)), 0, srcH - 1);
+                    const int nsx =
+                        std::clamp(static_cast<int>(std::floor(srcXf + 0.5)), 0, srcW - 1);
+                    const int nsy =
+                        std::clamp(static_cast<int>(std::floor(srcYf + 0.5)), 0, srcH - 1);
                     const std::size_t dstIdxN = static_cast<std::size_t>((dy * w + dx) * 4);
                     const float aN = static_cast<float>(sampleSrc(nsx, nsy, 3));
                     dstData[dstIdxN + 0] = std::min(static_cast<float>(sampleSrc(nsx, nsy, 0)), aN);
@@ -811,7 +812,7 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
                 }
               }
             }
-            output = std::move(fpOut);
+            output = NodeOutput{std::move(fpOut), /*linear=*/false};
           }
         },
         node.primitive);
@@ -828,20 +829,24 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
               ? &*graph.filterFromDevice
               : nullptr;
       const PixelRect* usrSub = xform ? &*node.userSpaceSubregion : nullptr;
-      applySubregionClipping(*output, clipRect, w, h, xform, usrSub);
+      // Clearing pixels is the same operation in either space, so it runs before the result is
+      // published and no conversion is involved.
+      applySubregionClipping(output->pixmap, clipRect, w, h, xform, usrSub);
 
+      SpacedPixmap produced(std::move(*output));
       if (node.result.has_value()) {
-        namedBuffers[*node.result] = FloatPixmap(*output);
+        namedBuffers[*node.result] = produced;
         namedSubregions[*node.result] = nodeSubregion;
       }
-      previousOutput = std::move(output);
+      previousOutput = std::move(produced);
       previousOutputSubregion = nodeSubregion;
     }
   }
 
-  // Convert final float sRGB result to uint8 sRGB.
+  // The graph's result leaves in sRGB: this is the single exit conversion, and it is skipped
+  // entirely when the last node already worked in sRGB.
   if (previousOutput.has_value()) {
-    Pixmap result = previousOutput->toPixmap();
+    Pixmap result = previousOutput->release(/*linear=*/false).toPixmap();
     auto srcData = result.data();
     auto dstData = sourceGraphic.data();
     std::copy(srcData.begin(), srcData.end(), dstData.begin());

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/FilterGraph.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/FilterGraph.cpp
@@ -1,7 +1,9 @@
 #include "FilterGraph.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
+#include <cstdint>
 #include <map>
 
 #include "tiny_skia/filter/Blend.h"
@@ -176,6 +178,22 @@ double srgbToLinearChannel(double s) {
     return s / 12.92;
   }
   return std::pow((s + 0.055) / 1.055, 2.4);
+}
+
+/// Fills `pixmap` with a primitive's flood color, which is authored as premultiplied sRGB, in the
+/// space the primitive interpolates in.
+///
+/// A linearRGB primitive converts the color and then fills, rather than filling and then
+/// converting the buffer: the conversion is per-pixel and every pixel here holds the same value,
+/// so the two produce identical pixels, but converting the color is constant time instead of one
+/// pass over the whole buffer.
+void floodInSpace(FloatPixmap& pixmap, std::uint8_t r, std::uint8_t g, std::uint8_t b,
+                  std::uint8_t a, bool linearRGB) {
+  std::array<float, 4> color = {r / 255.0f, g / 255.0f, b / 255.0f, a / 255.0f};
+  if (linearRGB) {
+    color = srgbToLinearPixel(color);
+  }
+  flood(pixmap, color[0], color[1], color[2], color[3]);
 }
 
 /// Pixels a node just produced, tagged with the color space they are expressed in.
@@ -493,14 +511,8 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
             output = NodeOutput{std::move(fp), nodeLinearRGB};
 
           } else if constexpr (std::is_same_v<T, Flood>) {
-            // Flood color is premultiplied sRGB uint8, so a linearRGB node has to convert it into
-            // its own space.
             auto fp = createTransparentFloat(w, h);
-            flood(fp, primitive.r / 255.0f, primitive.g / 255.0f, primitive.b / 255.0f,
-                  primitive.a / 255.0f);
-            if (nodeLinearRGB) {
-              srgbToLinear(fp);
-            }
+            floodInSpace(fp, primitive.r, primitive.g, primitive.b, primitive.a, nodeLinearRGB);
             output = NodeOutput{std::move(fp), nodeLinearRGB};
 
           } else if constexpr (std::is_same_v<T, graph_primitive::Offset>) {
@@ -668,11 +680,8 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
             // node's own interpolation space. Only the flood color needs converting, because it
             // is authored as premultiplied sRGB; the source alpha carries no color.
             auto floodBuf = createTransparentFloat(w, h);
-            flood(floodBuf, primitive.r / 255.0f, primitive.g / 255.0f, primitive.b / 255.0f,
-                  primitive.a / 255.0f);
-            if (nodeLinearRGB) {
-              srgbToLinear(floodBuf);
-            }
+            floodInSpace(floodBuf, primitive.r, primitive.g, primitive.b, primitive.a,
+                         nodeLinearRGB);
 
             auto compositeBuf = createTransparentFloat(w, h);
             composite(floodBuf, getSourceAlpha()->spaceAgnostic(), compositeBuf, CompositeOp::In);

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/FilterGraph.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/FilterGraph.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <cstdint>
 #include <map>
+#include <memory>
 
 #include "tiny_skia/filter/Blend.h"
 #include "tiny_skia/filter/ColorMatrix.h"
@@ -220,6 +221,14 @@ struct NodeOutput {
 /// an in-place conversion would either corrupt a later consumer that wants the original space or
 /// force a lossy round trip back to it. The other space is materialized alongside instead, and
 /// only once per buffer.
+///
+/// Residency: a buffer read in both spaces holds a twin, so it costs twice the float pixels of
+/// the equivalent single-space buffer. The bound is one twin per live buffer, and only for the
+/// buffers a graph actually consumes in both spaces, which needs a graph that alternates
+/// interpolation spaces across an edge that is read twice. `FloatPixmap::fromSize` caps a single
+/// buffer at 1 GiB, and that cap applies to the twin independently. In exchange the ordinary
+/// graph, where no buffer is read in two spaces, holds no twin at all and drops the per-node
+/// conversion copies the previous scheme allocated and discarded around every primitive.
 class SpacedPixmap {
  public:
   SpacedPixmap() = default;
@@ -339,8 +348,12 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
   SpacedPixmap* strokePaint = strokePaintStorage.has_value() ? &*strokePaintStorage : nullptr;
   std::optional<SpacedPixmap> transparentPaintInput;
   std::optional<SpacedPixmap> sourceAlpha;
-  std::optional<SpacedPixmap> previousOutput;
-  std::map<std::string, SpacedPixmap> namedBuffers;
+  // A node's result is one buffer even when it is reachable under two names, as `result="x"` is
+  // also the implicit input of the next primitive. Sharing the object rather than copying it
+  // keeps a converted twin shared too, so a result consumed in both spaces converts once no
+  // matter which reference asks first.
+  std::shared_ptr<SpacedPixmap> previousOutput;
+  std::map<std::string, std::shared_ptr<SpacedPixmap>> namedBuffers;
 
   // Subregion tracking.
   const Box fullRegion = Box::fromWH(w, h);
@@ -384,7 +397,7 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
         [&](const auto& v) -> SpacedPixmap* {
           using V = std::decay_t<decltype(v)>;
           if constexpr (std::is_same_v<V, NodeInput::Previous>) {
-            return previousOutput.has_value() ? &previousOutput.value() : source;
+            return previousOutput ? previousOutput.get() : source;
           } else if constexpr (std::is_same_v<V, StandardInput>) {
             if (v == StandardInput::SourceGraphic) {
               return source;
@@ -402,9 +415,9 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
           } else if constexpr (std::is_same_v<V, NodeInput::Named>) {
             auto it = namedBuffers.find(v.name);
             if (it != namedBuffers.end()) {
-              return &it->second;
+              return it->second.get();
             }
-            return previousOutput.has_value() ? &previousOutput.value() : source;
+            return previousOutput ? previousOutput.get() : source;
           } else {
             return source;
           }
@@ -578,12 +591,13 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
 
           } else if constexpr (std::is_same_v<T, graph_primitive::ConvolveMatrix>) {
             auto fpOut = createTransparentFloat(w, h);
-            const int requiredSize = primitive.orderX * primitive.orderY;
-            if (primitive.orderX > 0 && primitive.orderY > 0 &&
-                static_cast<int>(primitive.kernel.size()) == requiredSize &&
+            const bool usable =
+                primitive.orderX > 0 && primitive.orderY > 0 &&
+                static_cast<int>(primitive.kernel.size()) == primitive.orderX * primitive.orderY &&
                 primitive.targetX >= 0 && primitive.targetX < primitive.orderX &&
                 primitive.targetY >= 0 && primitive.targetY < primitive.orderY &&
-                primitive.divisor != 0.0) {
+                primitive.divisor != 0.0;
+            if (usable) {
               ConvolveParams params;
               params.orderX = primitive.orderX;
               params.orderY = primitive.orderY;
@@ -596,7 +610,9 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
               params.preserveAlpha = primitive.preserveAlpha;
               convolveMatrix(input->in(nodeLinearRGB), fpOut, params);
             }
-            output = NodeOutput{std::move(fpOut), nodeLinearRGB};
+            // An unusable kernel leaves transparent black, which carries no color and so needs no
+            // conversion whichever space consumes it.
+            output = NodeOutput{std::move(fpOut), nodeLinearRGB, /*spaceInvariant=*/!usable};
 
           } else if constexpr (std::is_same_v<T, graph_primitive::Morphology>) {
             // SVG Filter Effects §15.4: a negative radius, or a zero radius on both axes
@@ -663,7 +679,8 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
             // Per SVG spec, specularExponent must be in [1, 128].
             // Values < 1: produce transparent output. Values > 128: clamp to 128.
             auto fpOut = createTransparentFloat(w, h);
-            if (primitive.params.specularExponent >= 1.0) {
+            const bool lit = primitive.params.specularExponent >= 1.0;
+            if (lit) {
               auto params = primitive.params;
               params.specularExponent = std::min(params.specularExponent, 128.0);
               if (nodeLinearRGB) {
@@ -673,7 +690,9 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
               }
               specularLighting(input->in(nodeLinearRGB), fpOut, params);
             }
-            output = NodeOutput{std::move(fpOut), nodeLinearRGB};
+            // An out-of-range exponent leaves transparent black, which carries no color and so
+            // needs no conversion whichever space consumes it.
+            output = NodeOutput{std::move(fpOut), nodeLinearRGB, /*spaceInvariant=*/!lit};
 
           } else if constexpr (std::is_same_v<T, graph_primitive::DropShadow>) {
             // Decomposed into flood + composite-in + offset + blur + merge, all run in the
@@ -842,7 +861,7 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
       // published and no conversion is involved.
       applySubregionClipping(output->pixmap, clipRect, w, h, xform, usrSub);
 
-      SpacedPixmap produced(std::move(*output));
+      auto produced = std::make_shared<SpacedPixmap>(std::move(*output));
       if (node.result.has_value()) {
         namedBuffers[*node.result] = produced;
         namedSubregions[*node.result] = nodeSubregion;
@@ -854,7 +873,9 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
 
   // The graph's result leaves in sRGB: this is the single exit conversion, and it is skipped
   // entirely when the last node already worked in sRGB.
-  if (previousOutput.has_value()) {
+  if (previousOutput) {
+    // Nothing reads the graph's buffers after this point, so the last result can be converted in
+    // place and handed over even though other names may still refer to it.
     Pixmap result = previousOutput->release(/*linear=*/false).toPixmap();
     auto srcData = result.data();
     auto dstData = sourceGraphic.data();

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/tests/BUILD.bazel
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/tests/BUILD.bazel
@@ -8,6 +8,7 @@ tiny_skia_dual_mode_cc_test(
     name = "tiny_skia_filter_tests",
     srcs = [
         "ColorSpaceTest.cpp",
+        "FilterGraphColorSpaceTest.cpp",
     ],
     copts = ["-std=c++20"],
     deps = [

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/tests/FilterGraphColorSpaceTest.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/tests/FilterGraphColorSpaceTest.cpp
@@ -237,9 +237,10 @@ TEST(FilterGraphColorSpace, SrgbGraphNeverConverts) {
   EXPECT_TRUE(PixmapsEqual(actual, expected));
 }
 
-// feFlood authors its color in sRGB, so a linearRGB consumer has to see the converted color. The
-// flood result is produced and consumed once, so the schedule matches the per-primitive one
-// exactly.
+// feFlood authors its color in sRGB, so a linearRGB primitive has to produce the converted color.
+// The executor converts the color and then fills; the reference below fills and then converts the
+// whole buffer, which is the conversion the per-primitive code ran. Every pixel of a flood holds
+// the same value, so the two must agree exactly.
 TEST(FilterGraphColorSpace, FloodColorReachesALinearConsumerConverted) {
   const Pixmap source = makeSourceGraphic();
 
@@ -278,6 +279,37 @@ TEST(FilterGraphColorSpace, FloodColorReachesALinearConsumerConverted) {
   linearToSrgb(merged);
 
   EXPECT_TRUE(PixmapsEqual(actual, merged.toPixmap()));
+}
+
+// The per-pixel conversion the flood path relies on has to be the same computation the buffer
+// conversion applies, for colors at both ends of the transfer function and at partial alpha.
+TEST(FilterGraphColorSpace, PerPixelConversionMatchesBufferConversion) {
+  const std::array<std::array<std::uint8_t, 4>, 6> colors = {{{0, 0, 0, 0},
+                                                              {255, 255, 255, 255},
+                                                              {kFloodR, kFloodG, kFloodB, kFloodA},
+                                                              {1, 2, 3, 255},
+                                                              {10, 10, 10, 12},
+                                                              {90, 200, 40, 128}}};
+
+  for (const auto& color : colors) {
+    const std::array<float, 4> premultiplied = {color[0] / 255.0f, color[1] / 255.0f,
+                                                color[2] / 255.0f, color[3] / 255.0f};
+
+    auto maybeFilled = FloatPixmap::fromSize(4, 4);
+    ASSERT_TRUE(maybeFilled.has_value());
+    FloatPixmap filled = std::move(*maybeFilled);
+    flood(filled, premultiplied[0], premultiplied[1], premultiplied[2], premultiplied[3]);
+    srgbToLinear(filled);
+
+    const std::array<float, 4> converted = srgbToLinearPixel(premultiplied);
+    const auto filledData = filled.data();
+    for (int channel = 0; channel < 4; ++channel) {
+      EXPECT_EQ(converted[channel], filledData[channel])
+          << "channel " << channel << " of color " << static_cast<int>(color[0]) << ","
+          << static_cast<int>(color[1]) << "," << static_cast<int>(color[2]) << ","
+          << static_cast<int>(color[3]);
+    }
+  }
 }
 
 }  // namespace

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/tests/FilterGraphColorSpaceTest.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/tests/FilterGraphColorSpaceTest.cpp
@@ -22,11 +22,16 @@
 #include "tiny_skia/Pixmap.h"
 #include "tiny_skia/filter/ColorMatrix.h"
 #include "tiny_skia/filter/ColorSpace.h"
+#include "tiny_skia/filter/Composite.h"
 #include "tiny_skia/filter/FilterGraph.h"
 #include "tiny_skia/filter/FloatPixmap.h"
 #include "tiny_skia/filter/Flood.h"
 #include "tiny_skia/filter/GaussianBlur.h"
 #include "tiny_skia/filter/Merge.h"
+#include "tiny_skia/filter/Morphology.h"
+#include "tiny_skia/filter/Offset.h"
+#include "tiny_skia/filter/Tile.h"
+#include "tiny_skia/filter/Turbulence.h"
 
 namespace tiny_skia::filter {
 namespace {
@@ -116,6 +121,13 @@ Pixmap runChainWithPerStepConversions(const Pixmap& source, std::array<bool, 3> 
   runStep(2, [&] { gaussianBlur(fp, kSigma, kSigma, BlurEdgeMode::None); });
 
   return fp.toPixmap();
+}
+
+/// A transparent working buffer at the test size.
+FloatPixmap blankFloat() {
+  auto maybeBlank = FloatPixmap::fromSize(kWidth, kHeight);
+  EXPECT_TRUE(maybeBlank.has_value());
+  return std::move(*maybeBlank);
 }
 
 /// Largest absolute per-channel difference between two same-sized pixmaps.
@@ -262,18 +274,14 @@ TEST(FilterGraphColorSpace, FloodColorReachesALinearConsumerConverted) {
   Pixmap actual = source;
   ASSERT_TRUE(executeFilterGraph(actual, graph));
 
-  auto maybeFlood = FloatPixmap::fromSize(kWidth, kHeight);
-  ASSERT_TRUE(maybeFlood.has_value());
-  FloatPixmap floodLayer = std::move(*maybeFlood);
+  FloatPixmap floodLayer = blankFloat();
   flood(floodLayer, kFloodR / 255.0f, kFloodG / 255.0f, kFloodB / 255.0f, kFloodA / 255.0f);
   srgbToLinear(floodLayer);
 
   FloatPixmap sourceLayer = FloatPixmap::fromPixmap(source);
   srgbToLinear(sourceLayer);
 
-  auto maybeMerged = FloatPixmap::fromSize(kWidth, kHeight);
-  ASSERT_TRUE(maybeMerged.has_value());
-  FloatPixmap merged = std::move(*maybeMerged);
+  FloatPixmap merged = blankFloat();
   const std::vector<const FloatPixmap*> layers = {&floodLayer, &sourceLayer};
   merge(std::span<const FloatPixmap* const>(layers), merged);
   linearToSrgb(merged);
@@ -310,6 +318,302 @@ TEST(FilterGraphColorSpace, PerPixelConversionMatchesBufferConversion) {
           << static_cast<int>(color[3]);
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Buffers consumed in both spaces, and primitives that carry their input's space
+// ---------------------------------------------------------------------------
+//
+// The cases above pin where conversions land along a chain. These pin the two claims a chain
+// cannot reach: that a buffer read in both spaces stays correct in each, and that a primitive
+// which only moves or copies pixels carries its producer's space instead of converting to its
+// own. A mis-tagged pass-through reinterprets one space's values as the other, which is a tens-
+// of-units error rather than a rounding one, and no chained test notices because every stage
+// still runs.
+
+// A result consumed in one space by one primitive and the other space by another must be correct
+// in both. Converting the stored pixels in place, or caching the conversion under the wrong tag,
+// would feed the second consumer values from the wrong space.
+TEST(FilterGraphColorSpace, BufferConsumedInBothSpacesStaysCorrectInEach) {
+  const Pixmap source = makeSourceGraphic();
+
+  GraphNode blurLinear = blurNode(true);
+  blurLinear.inputs = {NodeInput(StandardInput::SourceGraphic)};
+  blurLinear.result = "blurred";
+
+  GraphNode matrixSrgb = colorMatrixNode(false);
+  matrixSrgb.inputs = {NodeInput(NodeInput::Named{"blurred"})};
+  matrixSrgb.result = "saturated";
+
+  GraphNode mergeLinear;
+  mergeLinear.primitive = graph_primitive::Merge{};
+  mergeLinear.inputs = {NodeInput(NodeInput::Named{"blurred"}),
+                        NodeInput(NodeInput::Named{"saturated"})};
+  mergeLinear.useLinearRGB = true;
+
+  FilterGraph graph;
+  graph.useLinearRGB = true;
+  graph.nodes = {std::move(blurLinear), std::move(matrixSrgb), std::move(mergeLinear)};
+
+  Pixmap actual = source;
+  ASSERT_TRUE(executeFilterGraph(actual, graph));
+
+  // Reference: the per-primitive schedule, every result normalized back to sRGB after its node.
+  FloatPixmap blurred = FloatPixmap::fromPixmap(source);
+  srgbToLinear(blurred);
+  gaussianBlur(blurred, kSigma, kSigma, BlurEdgeMode::None);
+  linearToSrgb(blurred);
+
+  FloatPixmap saturated(blurred);
+  colorMatrix(saturated, saturateMatrix());  // sRGB primitive, no conversion.
+
+  FloatPixmap blurredLinear(blurred);
+  srgbToLinear(blurredLinear);
+  FloatPixmap saturatedLinear(saturated);
+  srgbToLinear(saturatedLinear);
+
+  FloatPixmap merged = blankFloat();
+  const std::vector<const FloatPixmap*> layers = {&blurredLinear, &saturatedLinear};
+  merge(std::span<const FloatPixmap* const>(layers), merged);
+  linearToSrgb(merged);
+
+  EXPECT_LE(maxChannelDelta(actual, merged.toPixmap()), 2);
+}
+
+/// Runs `blurred = linearRGB blur of the source`, then `trailing`, and compares against the same
+/// blur with no further conversion: a primitive that only moves or copies pixels must leave its
+/// producer's space alone, even when the primitive itself is tagged with the other space.
+void ExpectCarriesProducerSpace(GraphNode trailing, const FloatPixmap& expected) {
+  const Pixmap source = makeSourceGraphic();
+
+  GraphNode blurLinear = blurNode(true);
+  blurLinear.inputs = {NodeInput(StandardInput::SourceGraphic)};
+
+  FilterGraph graph;
+  graph.useLinearRGB = true;
+  graph.nodes = {std::move(blurLinear), std::move(trailing)};
+
+  Pixmap actual = source;
+  ASSERT_TRUE(executeFilterGraph(actual, graph));
+
+  EXPECT_TRUE(PixmapsEqual(actual, expected.toPixmap()));
+}
+
+/// The linearRGB blur every pass-through case below feeds from, expressed in sRGB the way the
+/// graph's exit conversion delivers it.
+FloatPixmap blurredSourceAsSrgb() {
+  FloatPixmap fp = FloatPixmap::fromPixmap(makeSourceGraphic());
+  srgbToLinear(fp);
+  gaussianBlur(fp, kSigma, kSigma, BlurEdgeMode::None);
+  linearToSrgb(fp);
+  return fp;
+}
+
+// feOffset moves pixels and nothing else, so it carries its producer's space even when its own
+// color-interpolation-filters says otherwise. Tagging the moved pixels with the primitive's space
+// instead would reinterpret linearRGB values as sRGB.
+TEST(FilterGraphColorSpace, OffsetCarriesProducerSpaceThrough) {
+  GraphNode offsetSrgb;
+  offsetSrgb.primitive = graph_primitive::Offset{3, -2};
+  offsetSrgb.inputs = {NodeInput()};
+  offsetSrgb.useLinearRGB = false;
+
+  FloatPixmap expected = blankFloat();
+  filter::offset(blurredSourceAsSrgb(), expected, 3, -2);
+
+  ExpectCarriesProducerSpace(std::move(offsetSrgb), expected);
+}
+
+// A zero radius disables feMorphology, and the disabled result is the input unchanged, so it too
+// carries the producer's space.
+TEST(FilterGraphColorSpace, DisabledMorphologyCarriesProducerSpaceThrough) {
+  GraphNode morphDisabled;
+  morphDisabled.primitive = graph_primitive::Morphology{MorphologyOp::Erode, 0, 0};
+  morphDisabled.inputs = {NodeInput()};
+  morphDisabled.useLinearRGB = false;
+
+  ExpectCarriesProducerSpace(std::move(morphDisabled), blurredSourceAsSrgb());
+}
+
+// The identity matrix short-circuits feColorMatrix into a pass-through, with the same obligation.
+TEST(FilterGraphColorSpace, IdentityColorMatrixCarriesProducerSpaceThrough) {
+  GraphNode identitySrgb;
+  identitySrgb.primitive = graph_primitive::ColorMatrix{identityMatrix()};
+  identitySrgb.inputs = {NodeInput()};
+  identitySrgb.useLinearRGB = false;
+
+  ExpectCarriesProducerSpace(std::move(identitySrgb), blurredSourceAsSrgb());
+}
+
+// feTile replicates a subregion, which is also a pure pixel move.
+TEST(FilterGraphColorSpace, TileCarriesProducerSpaceThrough) {
+  const Pixmap source = makeSourceGraphic();
+
+  GraphNode blurLinear = blurNode(true);
+  blurLinear.inputs = {NodeInput(StandardInput::SourceGraphic)};
+  blurLinear.subregion = PixelRect{0, 0, 8, 8};
+  blurLinear.result = "patch";
+
+  GraphNode tileSrgb;
+  tileSrgb.primitive = graph_primitive::Tile{};
+  tileSrgb.inputs = {NodeInput(NodeInput::Named{"patch"})};
+  tileSrgb.useLinearRGB = false;
+
+  FilterGraph graph;
+  graph.useLinearRGB = true;
+  graph.nodes = {std::move(blurLinear), std::move(tileSrgb)};
+
+  Pixmap actual = source;
+  ASSERT_TRUE(executeFilterGraph(actual, graph));
+
+  FloatPixmap patch = blurredSourceAsSrgb();
+  // The executor clips a result to its subregion before publishing it.
+  auto patchData = patch.data();
+  for (int y = 0; y < kHeight; ++y) {
+    for (int x = 0; x < kWidth; ++x) {
+      if (x < 8 && y < 8) {
+        continue;
+      }
+      const std::size_t offset = static_cast<std::size_t>((y * kWidth + x) * 4);
+      patchData[offset + 0] = 0.0f;
+      patchData[offset + 1] = 0.0f;
+      patchData[offset + 2] = 0.0f;
+      patchData[offset + 3] = 0.0f;
+    }
+  }
+
+  FloatPixmap tiled = blankFloat();
+  tile(patch, tiled, 0, 0, 8, 8);
+
+  EXPECT_TRUE(PixmapsEqual(actual, tiled.toPixmap()));
+}
+
+// The control for the pass-through cases: an enabled feMorphology is not a pure pixel move, since
+// a channel minimum depends on the space the channels are in, so a disagreeing primitive must
+// convert. If pass-through carrying were applied here the result would keep the producer's space
+// and this would not match.
+TEST(FilterGraphColorSpace, EnabledMorphologyConvertsWhenSpacesDisagree) {
+  GraphNode erodeSrgb;
+  erodeSrgb.primitive = graph_primitive::Morphology{MorphologyOp::Erode, 2, 2};
+  erodeSrgb.inputs = {NodeInput()};
+  erodeSrgb.useLinearRGB = false;
+
+  FloatPixmap expected = blankFloat();
+  morphology(blurredSourceAsSrgb(), expected, MorphologyOp::Erode, 2, 2);
+
+  ExpectCarriesProducerSpace(std::move(erodeSrgb), expected);
+}
+
+// SourceAlpha has zero RGB, so both transfer functions are the identity on it and it must reach a
+// linearRGB primitive without a conversion pass. The reference applies the conversion the
+// per-primitive code ran, which has to be an exact no-op here.
+TEST(FilterGraphColorSpace, SourceAlphaIsSpaceInvariant) {
+  const Pixmap source = makeSourceGraphic();
+
+  GraphNode blurLinear = blurNode(true);
+  blurLinear.inputs = {NodeInput(StandardInput::SourceAlpha)};
+
+  FilterGraph graph;
+  graph.useLinearRGB = true;
+  graph.nodes = {std::move(blurLinear)};
+
+  Pixmap actual = source;
+  ASSERT_TRUE(executeFilterGraph(actual, graph));
+
+  FloatPixmap fp = FloatPixmap::fromPixmap(source);
+  auto data = fp.data();
+  for (int i = 0; i < kWidth * kHeight; ++i) {
+    data[i * 4 + 0] = 0.0f;
+    data[i * 4 + 1] = 0.0f;
+    data[i * 4 + 2] = 0.0f;
+  }
+  srgbToLinear(fp);
+  gaussianBlur(fp, kSigma, kSigma, BlurEdgeMode::None);
+  linearToSrgb(fp);
+
+  EXPECT_TRUE(PixmapsEqual(actual, fp.toPixmap()));
+}
+
+// feTurbulence generates noise directly in the primitive's space. The per-primitive code generated
+// the same values and immediately encoded them as sRGB for storage, so as the last primitive the
+// two arrangements have to agree exactly.
+TEST(FilterGraphColorSpace, TurbulenceGeneratesDirectlyInTheNodeSpace) {
+  const Pixmap source = makeSourceGraphic();
+
+  TurbulenceParams params;
+  params.type = TurbulenceType::Turbulence;
+  params.baseFrequencyX = 0.05;
+  params.baseFrequencyY = 0.05;
+  params.numOctaves = 3;
+  params.seed = 7.0;
+
+  GraphNode turbulenceLinear;
+  turbulenceLinear.primitive = graph_primitive::Turbulence{params};
+  turbulenceLinear.useLinearRGB = true;
+
+  FilterGraph graph;
+  graph.useLinearRGB = true;
+  graph.nodes = {std::move(turbulenceLinear)};
+
+  Pixmap actual = source;
+  ASSERT_TRUE(executeFilterGraph(actual, graph));
+
+  FloatPixmap fp = blankFloat();
+  turbulence(fp, params);
+  linearToSrgb(fp);
+
+  EXPECT_TRUE(PixmapsEqual(actual, fp.toPixmap()));
+}
+
+// feDropShadow decomposes into flood, composite-in, offset, blur, and merge. Running all of them
+// in the primitive's space, and converting the flood color rather than the flood buffer, has to
+// reproduce the old decomposition byte for byte.
+TEST(FilterGraphColorSpace, DropShadowInLinearMatchesTheDecomposedSchedule) {
+  const Pixmap source = makeSourceGraphic();
+  constexpr int kDx = 4;
+  constexpr int kDy = 4;
+
+  GraphNode shadow;
+  shadow.primitive =
+      graph_primitive::DropShadow{kFloodR, kFloodG, kFloodB, kFloodA, kDx, kDy, kSigma, kSigma};
+  shadow.inputs = {NodeInput(StandardInput::SourceGraphic)};
+  shadow.useLinearRGB = true;
+
+  FilterGraph graph;
+  graph.useLinearRGB = true;
+  graph.nodes = {std::move(shadow)};
+
+  Pixmap actual = source;
+  ASSERT_TRUE(executeFilterGraph(actual, graph));
+
+  FloatPixmap floodLayer = blankFloat();
+  flood(floodLayer, kFloodR / 255.0f, kFloodG / 255.0f, kFloodB / 255.0f, kFloodA / 255.0f);
+  srgbToLinear(floodLayer);
+
+  FloatPixmap sourceAlpha = FloatPixmap::fromPixmap(source);
+  auto sourceAlphaData = sourceAlpha.data();
+  for (int i = 0; i < kWidth * kHeight; ++i) {
+    sourceAlphaData[i * 4 + 0] = 0.0f;
+    sourceAlphaData[i * 4 + 1] = 0.0f;
+    sourceAlphaData[i * 4 + 2] = 0.0f;
+  }
+
+  FloatPixmap shadowLayer = blankFloat();
+  composite(floodLayer, sourceAlpha, shadowLayer, CompositeOp::In);
+
+  FloatPixmap offsetShadow = blankFloat();
+  filter::offset(shadowLayer, offsetShadow, kDx, kDy);
+  gaussianBlur(offsetShadow, kSigma, kSigma);
+
+  FloatPixmap sourceLinear = FloatPixmap::fromPixmap(source);
+  srgbToLinear(sourceLinear);
+
+  FloatPixmap merged = blankFloat();
+  const std::vector<const FloatPixmap*> layers = {&offsetShadow, &sourceLinear};
+  merge(std::span<const FloatPixmap* const>(layers), merged);
+  linearToSrgb(merged);
+
+  EXPECT_TRUE(PixmapsEqual(actual, merged.toPixmap()));
 }
 
 }  // namespace

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/tests/FilterGraphColorSpaceTest.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/tests/FilterGraphColorSpaceTest.cpp
@@ -1,0 +1,284 @@
+/// Tests for the color-space boundaries `executeFilterGraph` places around a filter graph.
+///
+/// The executor tags every buffer with the space its pixels are in and converts only where two
+/// adjacent primitives disagree, instead of converting into and out of linearRGB around each
+/// primitive. These tests pin the resulting conversion placement against hand-written references
+/// built from the same primitives and the same `ColorSpace` entry points:
+///   - a graph whose primitives all share one space converts exactly twice, on entry and exit;
+///   - a graph that alternates spaces converts on each crossing, which is bit-for-bit what
+///     converting around every primitive used to produce;
+///   - a graph that is entirely sRGB converts not at all.
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+#include <span>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "tiny_skia/Pixmap.h"
+#include "tiny_skia/filter/ColorMatrix.h"
+#include "tiny_skia/filter/ColorSpace.h"
+#include "tiny_skia/filter/FilterGraph.h"
+#include "tiny_skia/filter/FloatPixmap.h"
+#include "tiny_skia/filter/Flood.h"
+#include "tiny_skia/filter/GaussianBlur.h"
+#include "tiny_skia/filter/Merge.h"
+
+namespace tiny_skia::filter {
+namespace {
+
+constexpr int kWidth = 24;
+constexpr int kHeight = 24;
+constexpr double kSigma = 1.5;
+
+/// A premultiplied sRGB flood color with partial alpha, far enough from both ends of the transfer
+/// function that a missing or duplicated conversion changes the bytes.
+constexpr std::uint8_t kFloodR = 200;
+constexpr std::uint8_t kFloodG = 80;
+constexpr std::uint8_t kFloodB = 30;
+constexpr std::uint8_t kFloodA = 190;
+
+/// A saturating color matrix, chosen because it is far from the identity (which the executor
+/// short-circuits) and mixes the channels, so a misplaced conversion shows up in the result.
+std::array<double, 20> saturateMatrix() {
+  return {0.8, 0.3, -0.1, 0.0, 0.0,  //
+          0.1, 0.9, 0.0,  0.0, 0.0,  //
+          0.0, 0.2, 0.7,  0.0, 0.0,  //
+          0.0, 0.0, 0.0,  1.0, 0.0};
+}
+
+/// Builds a source graphic with saturated colors, mid-tones, and partial alpha, so that both the
+/// toe and the power segment of the transfer function are exercised, and premultiplied values are
+/// not all equal to their unpremultiplied form.
+Pixmap makeSourceGraphic() {
+  auto maybePixmap = Pixmap::fromSize(kWidth, kHeight);
+  EXPECT_TRUE(maybePixmap.has_value());
+  Pixmap pixmap = std::move(*maybePixmap);
+
+  auto data = pixmap.data();
+  for (int y = 0; y < kHeight; ++y) {
+    for (int x = 0; x < kWidth; ++x) {
+      const auto alpha = static_cast<std::uint8_t>(40 + (x * 9 + y * 3) % 216);
+      const auto scale = [&](int value) { return static_cast<std::uint8_t>(value * alpha / 255); };
+
+      const std::size_t offset = static_cast<std::size_t>((y * kWidth + x) * 4);
+      data[offset + 0] = scale((x * 11) % 256);
+      data[offset + 1] = scale((y * 7 + 3) % 256);
+      data[offset + 2] = scale((x * 5 + y * 13) % 256);
+      data[offset + 3] = alpha;
+    }
+  }
+
+  return pixmap;
+}
+
+/// Every node in these chains consumes the previous primitive's result, which for the first node
+/// is SourceGraphic.
+GraphNode chainedNode(GraphPrimitive primitive, bool linearRGB) {
+  GraphNode node;
+  node.primitive = std::move(primitive);
+  node.inputs = {NodeInput()};
+  node.useLinearRGB = linearRGB;
+  return node;
+}
+
+GraphNode blurNode(bool linearRGB) {
+  return chainedNode(graph_primitive::GaussianBlur{kSigma, kSigma, BlurEdgeMode::None}, linearRGB);
+}
+
+GraphNode colorMatrixNode(bool linearRGB) {
+  return chainedNode(graph_primitive::ColorMatrix{saturateMatrix()}, linearRGB);
+}
+
+/// Runs blur, color matrix, blur over `source` with an explicit conversion schedule. Each entry of
+/// `linearSteps` says whether the pixels are converted to linearRGB before that step and back to
+/// sRGB after it; `false` runs the step on the sRGB values directly. This is the conversion
+/// schedule the executor used to run unconditionally, once per primitive.
+Pixmap runChainWithPerStepConversions(const Pixmap& source, std::array<bool, 3> linearSteps) {
+  FloatPixmap fp = FloatPixmap::fromPixmap(source);
+
+  const auto runStep = [&](int index, auto&& step) {
+    if (linearSteps[index]) {
+      srgbToLinear(fp);
+    }
+    step();
+    if (linearSteps[index]) {
+      linearToSrgb(fp);
+    }
+  };
+
+  runStep(0, [&] { gaussianBlur(fp, kSigma, kSigma, BlurEdgeMode::None); });
+  runStep(1, [&] { colorMatrix(fp, saturateMatrix()); });
+  runStep(2, [&] { gaussianBlur(fp, kSigma, kSigma, BlurEdgeMode::None); });
+
+  return fp.toPixmap();
+}
+
+/// Largest absolute per-channel difference between two same-sized pixmaps.
+int maxChannelDelta(const Pixmap& lhs, const Pixmap& rhs) {
+  const auto a = lhs.data();
+  const auto b = rhs.data();
+  EXPECT_EQ(a.size(), b.size());
+
+  int worst = 0;
+  for (std::size_t i = 0; i < a.size(); ++i) {
+    const int delta = std::abs(static_cast<int>(a[i]) - static_cast<int>(b[i]));
+    worst = std::max(worst, delta);
+  }
+  return worst;
+}
+
+::testing::AssertionResult PixmapsEqual(const Pixmap& actual, const Pixmap& expected) {
+  const auto a = actual.data();
+  const auto b = expected.data();
+  if (a.size() != b.size()) {
+    return ::testing::AssertionFailure() << "size mismatch: " << a.size() << " vs " << b.size();
+  }
+
+  for (std::size_t i = 0; i < a.size(); ++i) {
+    if (a[i] != b[i]) {
+      return ::testing::AssertionFailure()
+             << "first difference at byte " << i << " (pixel " << (i / 4) << ", channel " << (i % 4)
+             << "): " << static_cast<int>(a[i]) << " vs " << static_cast<int>(b[i]) << ", "
+             << maxChannelDelta(actual, expected) << " max channel delta overall";
+    }
+  }
+
+  return ::testing::AssertionSuccess();
+}
+
+// A graph whose primitives all interpolate in linearRGB converts on the way in and on the way
+// out, and nowhere in between: intermediate results stay linear.
+TEST(FilterGraphColorSpace, UniformLinearGraphConvertsOnlyAtTheBoundaries) {
+  const Pixmap source = makeSourceGraphic();
+
+  FilterGraph graph;
+  graph.useLinearRGB = true;
+  graph.nodes = {blurNode(true), colorMatrixNode(true), blurNode(true)};
+
+  Pixmap actual = source;
+  ASSERT_TRUE(executeFilterGraph(actual, graph));
+
+  FloatPixmap fp = FloatPixmap::fromPixmap(source);
+  srgbToLinear(fp);
+  gaussianBlur(fp, kSigma, kSigma, BlurEdgeMode::None);
+  colorMatrix(fp, saturateMatrix());
+  gaussianBlur(fp, kSigma, kSigma, BlurEdgeMode::None);
+  linearToSrgb(fp);
+  const Pixmap expected = fp.toPixmap();
+
+  EXPECT_TRUE(PixmapsEqual(actual, expected));
+}
+
+// Converting around every primitive is the same computation with two extra round trips through
+// the transfer function, so the two results have to agree to within rounding. This chain measures
+// a worst-case channel difference of 1/255; the bound keeps a unit of headroom.
+TEST(FilterGraphColorSpace, HoistingStaysWithinRoundingOfPerPrimitiveConversions) {
+  const Pixmap source = makeSourceGraphic();
+
+  FilterGraph graph;
+  graph.useLinearRGB = true;
+  graph.nodes = {blurNode(true), colorMatrixNode(true), blurNode(true)};
+
+  Pixmap actual = source;
+  ASSERT_TRUE(executeFilterGraph(actual, graph));
+
+  const Pixmap perPrimitive = runChainWithPerStepConversions(source, {true, true, true});
+  EXPECT_LE(maxChannelDelta(actual, perPrimitive), 2);
+}
+
+// An sRGB primitive between two linearRGB ones has to convert on both crossings, which is exactly
+// the conversion schedule the per-primitive code ran. This case must not shift at all.
+TEST(FilterGraphColorSpace, MixedGraphMatchesPerPrimitiveConversions) {
+  const Pixmap source = makeSourceGraphic();
+
+  FilterGraph graph;
+  graph.useLinearRGB = true;
+  graph.nodes = {blurNode(true), colorMatrixNode(false), blurNode(true)};
+
+  Pixmap actual = source;
+  ASSERT_TRUE(executeFilterGraph(actual, graph));
+
+  const Pixmap expected = runChainWithPerStepConversions(source, {true, false, true});
+  EXPECT_TRUE(PixmapsEqual(actual, expected));
+}
+
+// The mirror image: a linearRGB primitive between two sRGB ones.
+TEST(FilterGraphColorSpace, MixedGraphWithLinearInteriorMatchesPerPrimitiveConversions) {
+  const Pixmap source = makeSourceGraphic();
+
+  FilterGraph graph;
+  graph.useLinearRGB = false;
+  graph.nodes = {blurNode(false), colorMatrixNode(true), blurNode(false)};
+
+  Pixmap actual = source;
+  ASSERT_TRUE(executeFilterGraph(actual, graph));
+
+  const Pixmap expected = runChainWithPerStepConversions(source, {false, true, false});
+  EXPECT_TRUE(PixmapsEqual(actual, expected));
+}
+
+// A graph that interpolates entirely in sRGB touches the transfer function nowhere at all.
+TEST(FilterGraphColorSpace, SrgbGraphNeverConverts) {
+  const Pixmap source = makeSourceGraphic();
+
+  FilterGraph graph;
+  graph.useLinearRGB = false;
+  graph.nodes = {blurNode(false), colorMatrixNode(false), blurNode(false)};
+
+  Pixmap actual = source;
+  ASSERT_TRUE(executeFilterGraph(actual, graph));
+
+  const Pixmap expected = runChainWithPerStepConversions(source, {false, false, false});
+  EXPECT_TRUE(PixmapsEqual(actual, expected));
+}
+
+// feFlood authors its color in sRGB, so a linearRGB consumer has to see the converted color. The
+// flood result is produced and consumed once, so the schedule matches the per-primitive one
+// exactly.
+TEST(FilterGraphColorSpace, FloodColorReachesALinearConsumerConverted) {
+  const Pixmap source = makeSourceGraphic();
+
+  GraphNode floodNode;
+  floodNode.primitive = graph_primitive::Flood{kFloodR, kFloodG, kFloodB, kFloodA};
+  floodNode.useLinearRGB = true;
+  floodNode.result = "flood";
+
+  GraphNode mergeNode;
+  mergeNode.primitive = graph_primitive::Merge{};
+  mergeNode.inputs = {NodeInput(NodeInput::Named{"flood"}),
+                      NodeInput(StandardInput::SourceGraphic)};
+  mergeNode.useLinearRGB = true;
+
+  FilterGraph graph;
+  graph.useLinearRGB = true;
+  graph.nodes = {std::move(floodNode), std::move(mergeNode)};
+
+  Pixmap actual = source;
+  ASSERT_TRUE(executeFilterGraph(actual, graph));
+
+  auto maybeFlood = FloatPixmap::fromSize(kWidth, kHeight);
+  ASSERT_TRUE(maybeFlood.has_value());
+  FloatPixmap floodLayer = std::move(*maybeFlood);
+  flood(floodLayer, kFloodR / 255.0f, kFloodG / 255.0f, kFloodB / 255.0f, kFloodA / 255.0f);
+  srgbToLinear(floodLayer);
+
+  FloatPixmap sourceLayer = FloatPixmap::fromPixmap(source);
+  srgbToLinear(sourceLayer);
+
+  auto maybeMerged = FloatPixmap::fromSize(kWidth, kHeight);
+  ASSERT_TRUE(maybeMerged.has_value());
+  FloatPixmap merged = std::move(*maybeMerged);
+  const std::vector<const FloatPixmap*> layers = {&floodLayer, &sourceLayer};
+  merge(std::span<const FloatPixmap* const>(layers), merged);
+  linearToSrgb(merged);
+
+  EXPECT_TRUE(PixmapsEqual(actual, merged.toPixmap()));
+}
+
+}  // namespace
+}  // namespace tiny_skia::filter

--- a/third_party/tiny-skia-cpp/tests/benchmarks/FilterPerfBench.cpp
+++ b/third_party/tiny-skia-cpp/tests/benchmarks/FilterPerfBench.cpp
@@ -13,8 +13,9 @@
 #include "tiny_skia/filter/Composite.h"
 #include "tiny_skia/filter/ConvolveMatrix.h"
 #include "tiny_skia/filter/DisplacementMap.h"
-#include "tiny_skia/filter/Flood.h"
+#include "tiny_skia/filter/FilterGraph.h"
 #include "tiny_skia/filter/FloatPixmap.h"
+#include "tiny_skia/filter/Flood.h"
 #include "tiny_skia/filter/GaussianBlur.h"
 #include "tiny_skia/filter/Lighting.h"
 #include "tiny_skia/filter/Merge.h"
@@ -346,8 +347,8 @@ void BM_ConvolveMatrix_5x5_Float(benchmark::State& state) {
   FloatPixmap fpSrc = FloatPixmap::fromPixmap(src);
 
   // 5x5 Gaussian-like kernel.
-  const double kernel[] = {1, 4,  7,  4,  1, 4,  16, 26, 16, 4, 7, 26, 41,
-                           26, 7, 4,  16, 26, 16, 4,  1,  4,  7, 4, 1};
+  const double kernel[] = {1,  4, 7, 4,  1,  4,  16, 26, 16, 4, 7, 26, 41,
+                           26, 7, 4, 16, 26, 16, 4,  1,  4,  7, 4, 1};
   ConvolveParams params;
   params.orderX = 5;
   params.orderY = 5;
@@ -582,6 +583,88 @@ void BM_Tile_Uint8(benchmark::State& state) {
 // ---------------------------------------------------------------------------
 
 // Gaussian blur.
+// ---------------------------------------------------------------------------
+// Whole-graph benchmarks
+// ---------------------------------------------------------------------------
+//
+// The primitive benchmarks above measure one operation at a time, which cannot see what the graph
+// executor spends on color-space conversion around those operations. These run the same seven
+// primitive stack twice, once interpolating in sRGB and once in linearRGB. The only difference
+// between the two is the conversion work, so their ratio is the conversion overhead of a whole
+// graph: converting at the graph's boundaries makes it two passes regardless of length, while
+// converting around every primitive would scale it with the primitive count.
+
+/// Builds a seven-primitive stack in one interpolation space: blur, saturate, offset, transfer,
+/// composite over the source, dilate, and merge with the source.
+tiny_skia::filter::FilterGraph makeSevenPrimitiveStack(bool linearRGB) {
+  using tiny_skia::filter::GraphNode;
+  using tiny_skia::filter::NodeInput;
+  using tiny_skia::filter::StandardInput;
+  namespace primitives = tiny_skia::filter::graph_primitive;
+
+  auto node = [&](tiny_skia::filter::GraphPrimitive primitive) {
+    GraphNode result;
+    result.primitive = std::move(primitive);
+    result.inputs = {NodeInput()};
+    result.useLinearRGB = linearRGB;
+    return result;
+  };
+
+  primitives::ComponentTransfer transfer;
+  transfer.funcR.type = tiny_skia::filter::TransferFuncType::Gamma;
+  transfer.funcR.amplitude = 1.1;
+  transfer.funcR.exponent = 0.9;
+  transfer.funcG.type = tiny_skia::filter::TransferFuncType::Linear;
+  transfer.funcG.slope = 1.05;
+  transfer.funcG.intercept = 0.01;
+  transfer.funcB.type = tiny_skia::filter::TransferFuncType::Gamma;
+  transfer.funcB.amplitude = 0.95;
+  transfer.funcB.exponent = 1.1;
+
+  GraphNode composite = node(primitives::Composite{tiny_skia::filter::CompositeOp::Over});
+  composite.inputs = {NodeInput(), NodeInput(StandardInput::SourceGraphic)};
+
+  GraphNode merge = node(primitives::Merge{});
+  merge.inputs = {NodeInput(), NodeInput(StandardInput::SourceGraphic)};
+
+  tiny_skia::filter::FilterGraph graph;
+  graph.useLinearRGB = linearRGB;
+  graph.nodes.push_back(node(primitives::GaussianBlur{4.0, 4.0, BlurEdgeMode::None}));
+  graph.nodes.push_back(node(primitives::ColorMatrix{tiny_skia::filter::saturateMatrix(1.6)}));
+  graph.nodes.push_back(node(primitives::Offset{10, 10}));
+  graph.nodes.push_back(node(std::move(transfer)));
+  graph.nodes.push_back(std::move(composite));
+  graph.nodes.push_back(node(primitives::Morphology{MorphologyOp::Dilate, 1, 1}));
+  graph.nodes.push_back(std::move(merge));
+  return graph;
+}
+
+void BM_FilterGraph_SevenPrimitives_LinearRGB(benchmark::State& state) {
+  const auto size = static_cast<std::uint32_t>(state.range(0));
+  const Pixmap src = makeRandomPixmap(size, size);
+  const tiny_skia::filter::FilterGraph graph = makeSevenPrimitiveStack(/*linearRGB=*/true);
+
+  for (auto _ : state) {
+    Pixmap copy = src;
+    benchmark::DoNotOptimize(tiny_skia::filter::executeFilterGraph(copy, graph));
+    benchmark::DoNotOptimize(copy.data().data());
+  }
+  setCounters(state, size);
+}
+
+void BM_FilterGraph_SevenPrimitives_Srgb(benchmark::State& state) {
+  const auto size = static_cast<std::uint32_t>(state.range(0));
+  const Pixmap src = makeRandomPixmap(size, size);
+  const tiny_skia::filter::FilterGraph graph = makeSevenPrimitiveStack(/*linearRGB=*/false);
+
+  for (auto _ : state) {
+    Pixmap copy = src;
+    benchmark::DoNotOptimize(tiny_skia::filter::executeFilterGraph(copy, graph));
+    benchmark::DoNotOptimize(copy.data().data());
+  }
+  setCounters(state, size);
+}
+
 BENCHMARK(BM_GaussianBlur_Float)->Args({512, 3})->Args({512, 6})->Args({512, 20})->Args({1024, 6});
 BENCHMARK(BM_GaussianBlur_Uint8)->Args({512, 3})->Args({512, 6})->Args({512, 20})->Args({1024, 6});
 
@@ -639,5 +722,9 @@ BENCHMARK(BM_ComponentTransfer_Table_Uint8)->Arg(512);
 
 // Tile.
 BENCHMARK(BM_Tile_Uint8)->Arg(512);
+
+// Whole graph, which is where the executor's color-space conversion cost shows up.
+BENCHMARK(BM_FilterGraph_SevenPrimitives_LinearRGB)->Arg(512);
+BENCHMARK(BM_FilterGraph_SevenPrimitives_Srgb)->Arg(512);
 
 }  // namespace

--- a/third_party/tiny-skia-cpp/tests/benchmarks/run_filter_perf_regression_test.sh
+++ b/third_party/tiny-skia-cpp/tests/benchmarks/run_filter_perf_regression_test.sh
@@ -101,11 +101,13 @@ morph_dilate_r10="$(extract_mean_real_time_ns "${NATIVE_CSV}" "BM_Morphology_Dil
 morph_dilate_r30="$(extract_mean_real_time_ns "${NATIVE_CSV}" "BM_Morphology_Dilate_Float/512/30")"
 pixmap_from="$(extract_mean_real_time_ns "${NATIVE_CSV}" "BM_FloatPixmap_FromPixmap/512")"
 pixmap_to="$(extract_mean_real_time_ns "${NATIVE_CSV}" "BM_FloatPixmap_ToPixmap/512")"
+graph_linear="$(extract_mean_real_time_ns "${NATIVE_CSV}" "BM_FilterGraph_SevenPrimitives_LinearRGB/512")"
+graph_srgb="$(extract_mean_real_time_ns "${NATIVE_CSV}" "BM_FilterGraph_SevenPrimitives_Srgb/512")"
 
 for value in \
   "${blur_float_s3}" "${blur_float_s6}" "${blur_float_s20}" "${blur_uint8_s6}" \
   "${morph_dilate_r3}" "${morph_dilate_r10}" "${morph_dilate_r30}" \
-  "${pixmap_from}" "${pixmap_to}"; do
+  "${pixmap_from}" "${pixmap_to}" "${graph_linear}" "${graph_srgb}"; do
   if [[ -z "${value}" ]]; then
     echo "Failed to parse benchmark CSV output" >&2
     exit 1
@@ -129,11 +131,19 @@ morph_radius_ratio="$(ratio "${morph_dilate_r30}" "${morph_dilate_r3}")"
 #    float just has wider data). If float path regresses, this ratio would spike.
 blur_float_over_uint8="$(ratio "${blur_float_s6}" "${blur_uint8_s6}")"
 
+# 4. Graph color-space conversion overhead: the same seven-primitive stack interpolated in
+#    linearRGB vs sRGB. The two run identical primitives on identical data, so the ratio is
+#    purely what the executor spends converting color spaces. Converting at the graph's
+#    boundaries is two passes no matter how long the graph is; converting around every primitive
+#    would be fourteen here and push the ratio past 1.6.
+graph_linear_over_srgb="$(ratio "${graph_linear}" "${graph_srgb}")"
+
 echo ""
 echo "Computed filter performance metrics:"
 echo "  Blur sigma ratio (s20/s6):         ${blur_sigma_ratio}"
 echo "  Morphology radius ratio (r30/r3):  ${morph_radius_ratio}"
 echo "  Blur float/uint8 ratio (s6):       ${blur_float_over_uint8}"
+echo "  Graph linearRGB/sRGB ratio:        ${graph_linear_over_srgb}"
 echo ""
 
 # Blur sigma ratio: should be near 1.0 (±25%). Both sigmas use box blur.
@@ -146,6 +156,11 @@ check_ratio "morphology_radius_invariance" "${morph_radius_ratio}" "0.80" "2.00"
 # Float/uint8 blur ratio: float is ~3x slower due to wider data and uint8's ScaledDivider +
 # Vec4u32 SIMD optimization. Allow up to 4.0x.
 check_ratio "blur_float_over_uint8" "${blur_float_over_uint8}" "1.00" "4.00"
+
+# Graph conversion overhead: measured at 1.10 with boundary conversion and 1.70 with a conversion
+# around every primitive. Allow up to 1.40, which leaves room for machine noise while still
+# failing if the per-primitive scheme returns.
+check_ratio "graph_linear_over_srgb" "${graph_linear_over_srgb}" "1.00" "1.40"
 
 echo ""
 echo "Filter perf regression checks passed."


### PR DESCRIPTION
Filter intermediates now carry their color space, and conversions happen only on edges where producer and consumer disagree, replacing the per-node round trips that converted into and out of linear at roughly twelve sites. A uniform linear graph pays one conversion at entry and one at exit; mixed per-primitive interpolation converts at exactly the crossings the old schedule did, proven byte-identical by tests against a hand-built per-primitive reference that never touches the new executor. Pure pixel movers carry their producer's space through, alpha-only buffers are space-invariant by construction, turbulence generates directly in its node's space, and a flood color converts as one pixel instead of a full buffer pass.

Measured on the filter stage alone, a seven-primitive linear stack drops 34.9 percent with an sRGB control stack flat at 0.1 percent, confirming the win is purely conversion removal; whole-frame the same stack improves 26 percent. The ratio is now regression-gated: a graph-level benchmark asserts the linear-over-sRGB overhead stays bounded, demonstrated failing against the previous executor. A full corpus sweep across 1,679 cases shifts two multi-primitive merge graphs by at most one part in 255 composited, the expected direction of removing inexact round trips; nothing is re-blessed.

Review hardening included: the pass-through and dual-space paths are pinned by tests demonstrated to catch a single-token space mis-tag that produces a 64-of-255 error the prior suite missed; named results share one buffer object with the previous-output chain so conversions build once per buffer; the worst-case residency bound is documented; and degenerate convolve and lighting fallbacks are tagged space-invariant to skip pointless conversions.

Stacked on the sRGB lookup-table change. Verification: vendored filter suites green in both simd modes including the four-ratio perf regression gate, the full repository suite green, and the executor tests green.