### PR TITLE
perf: Skip re-parsing unchanged path data in the shape pass

### DIFF
--- a/donner/svg/components/shape/ComputedPathComponent.h
+++ b/donner/svg/components/shape/ComputedPathComponent.h
@@ -4,6 +4,7 @@
 #include <optional>
 
 #include "donner/base/Path.h"
+#include "donner/base/RcString.h"
 
 namespace donner::svg::components {
 
@@ -24,6 +25,29 @@ struct ComputedPathComponent {
   /// path initializes components via aggregate initialization on older
   /// compilers and breaks once a non-public section is added.
   mutable std::optional<Box2d> cachedLocalBounds;
+
+  /**
+   * The path-data string that `spline` was parsed from, when the spline came from path data.
+   *
+   * `std::nullopt` for every other producer: shapes generated from numeric attributes
+   * (circle, ellipse, line, poly, rect), splines supplied directly instead of parsed, and
+   * path data whose parse reported a diagnostic.
+   *
+   * `ShapeSystem` uses this to skip re-parsing unchanged path data. Parsing is a pure function
+   * of the resolved path-data string, so while the string is unchanged the retained `spline` is
+   * byte-for-byte what a re-parse would produce, and the shape pass can return the retained
+   * component untouched. Keeping the key on the computed component rather than beside the
+   * source attribute ties its lifetime to the geometry it describes: every writer of this
+   * component either sets the key to the string it just parsed or clears it, and every
+   * invalidation removes or replaces the component, so a stale key cannot outlive the spline
+   * it belongs to.
+   *
+   * Cost: `sizeof(std::optional<RcString>)` is 40 bytes, paid by every `ComputedPathComponent`,
+   * including the numeric-attribute shapes that always leave it empty. Beyond that, path data
+   * longer than \ref RcString's inline capacity shares its buffer with the attribute value it
+   * was copied from and costs nothing more; shorter path data is held inline, so it is copied.
+   */
+  std::optional<RcString> sourcePathData;
 
   /**
    * Returns the tight fill bounds of the path in local (pre-transform) space.

--- a/donner/svg/components/shape/ShapeSystem.cc
+++ b/donner/svg/components/shape/ShapeSystem.cc
@@ -117,13 +117,28 @@ std::optional<ParseDiagnostic> ParseDFromAttributes(PathComponent& properties,
 /// signal a precise "geometry actually changed" edge - downstream
 /// caches (e.g. the Geode path-encode cache) listen on that signal and rely
 /// on it not firing for no-op regenerations.
-ComputedPathComponent& emplaceComputedPathIfChanged(EntityHandle handle, Path newPath) {
+///
+/// \p sourcePathData records the path-data string the spline was parsed from, so a later pass
+/// can recognize the spline as still current and skip the parse. Callers that did not produce
+/// the spline by parsing path data leave it unset, which clears any key a previous producer
+/// left behind - only a parse of path data may leave a key that matches a path-data string.
+ComputedPathComponent& emplaceComputedPathIfChanged(
+    EntityHandle handle, Path newPath, std::optional<RcString> sourcePathData = std::nullopt) {
   if (auto* existing = handle.try_get<ComputedPathComponent>()) {
     if (existing->spline == newPath) {
+      // Assign through the reference rather than re-emplacing, so the unchanged-geometry case
+      // still does not fire on_update<ComputedPathComponent>.
+      existing->sourcePathData = std::move(sourcePathData);
       return *existing;
     }
   }
-  return handle.emplace_or_replace<ComputedPathComponent>(std::move(newPath));
+
+  // Aggregate-initialize the component complete with its key, rather than filling the key in
+  // afterwards: `on_construct` and `on_update` listeners run inside `emplace_or_replace`, and a
+  // two-step write would let them observe a keyless component. The arguments are positional, so
+  // they track ComputedPathComponent's member order.
+  return handle.emplace_or_replace<ComputedPathComponent>(
+      std::move(newPath), /*cachedLocalBounds=*/std::nullopt, std::move(sourcePathData));
 }
 
 /**
@@ -375,15 +390,38 @@ ComputedPathComponent* ShapeSystem::createComputedShapeWithStyle(
   if (path.splineOverride) {
     return &emplaceComputedPathIfChanged(handle, path.splineOverride.value());
   } else if (actualD.isSpecified()) {
-    auto maybePath = parser::PathParser::Parse(actualD.get().value());
-    if (maybePath.hasError()) {
+    // `Property::get()` hands back a fresh optional, so this has to be a value rather than a
+    // reference into a temporary. Copying an RcString shares its buffer.
+    const RcString pathData = actualD.get().value();
+
+    // Reuse the retained spline when it was parsed from this exact string. The shape pass runs
+    // over every shape on every prepare, and re-parsing path data that has not changed is the
+    // single most expensive thing it does. `pathData` is resolved fresh here from the current
+    // presentation attribute and the current computed style, so any change to either - however
+    // it was made - produces a different string and falls through to the parse below.
+    if (ComputedPathComponent* existing = handle.try_get<ComputedPathComponent>();
+        existing && existing->sourcePathData && existing->sourcePathData.value() == pathData) {
+      return existing;
+    }
+
+    auto maybePath = parser::PathParser::Parse(pathData);
+    const bool hadDiagnostic = maybePath.hasError();
+    if (hadDiagnostic) {
       // Propagate warnings, which may be set on success too.
       warningSink.add(std::move(maybePath.error()));
     }
 
     if (maybePath.hasResult() && !maybePath.result().empty()) {
-      // Success: Return path
-      return &emplaceComputedPathIfChanged(handle, std::move(maybePath.result()));
+      // Success: Return path. Only remember the source string when the parse was clean; path
+      // data that produces a diagnostic must be re-parsed by every pass so the diagnostic keeps
+      // reaching the sink for as long as the malformed data is present.
+      std::optional<RcString> cacheKey;
+      if (!hadDiagnostic) {
+        cacheKey = pathData;
+      }
+
+      return &emplaceComputedPathIfChanged(handle, std::move(maybePath.result()),
+                                           std::move(cacheKey));
     }
   }
 

--- a/donner/svg/components/shape/tests/ShapeSystem_tests.cc
+++ b/donner/svg/components/shape/tests/ShapeSystem_tests.cc
@@ -10,6 +10,7 @@
 #include "donner/base/ParseWarningSink.h"
 #include "donner/base/tests/BaseTestUtils.h"
 #include "donner/base/tests/ParseResultTestUtils.h"
+#include "donner/svg/SVGPathElement.h"
 #include "donner/svg/components/shape/ComputedPathComponent.h"
 #include "donner/svg/components/style/StyleSystem.h"
 #include "donner/svg/parser/SVGParser.h"
@@ -634,6 +635,252 @@ TEST_F(ShapeSystemTest, PathMultipleMoveTo) {
   if (path) {
     EXPECT_FALSE(path->spline.empty());
   }
+}
+
+// --- Path data parse caching ---
+
+namespace {
+
+/// A spline that no shape in these tests produces. Writing it over a retained
+/// `ComputedPathComponent` makes it observable whether the next shape pass rewrote the component
+/// (marker gone, so the path data was parsed again) or reused it as-is (marker still present).
+Path MarkerSpline() {
+  return PathBuilder()
+      .moveTo(Vector2d(-1234.0, -5678.0))
+      .lineTo(Vector2d(-8765.0, -4321.0))
+      .build();
+}
+
+}  // namespace
+
+/**
+ * Path data is parsed once and the parse is skipped while the resolved path-data string is
+ * unchanged, so every way that string can change has to be shown to reach the parser again.
+ */
+class ShapeSystemPathCacheTest : public ShapeSystemTest {
+protected:
+  /// Run the style and shape passes again, the way a repeated render does.
+  void recomputeShapes(SVGDocument& document) {
+    StyleSystem().computeAllStyles(document.registry(), warningSink_);
+    shapeSystem.instantiateAllComputedPaths(document.registry(), warningSink_);
+  }
+
+  static ComputedPathComponent* computedPath(SVGElement element) {
+    return element.entityHandle().try_get<ComputedPathComponent>();
+  }
+
+  /// Overwrite the retained spline with \ref MarkerSpline.
+  void markComputedPath(SVGElement element) {
+    ComputedPathComponent* computed = computedPath(element);
+    ASSERT_THAT(computed, NotNull());
+    computed->spline = MarkerSpline();
+    computed->cachedLocalBounds.reset();
+  }
+
+  static bool isMarked(SVGElement element) {
+    const ComputedPathComponent* computed = computedPath(element);
+    return computed != nullptr && computed->spline == MarkerSpline();
+  }
+
+  /// The spline that `#p` gets in a document parsed from scratch, which is what a mutated
+  /// document has to converge on. Comparing against a separately parsed document is what makes
+  /// the check meaningful: the retained parse lives on the mutated document, so only a document
+  /// that never saw the mutation can show what the new value is supposed to produce.
+  Path freshSpline(std::string_view svg) {
+    SVGDocument fresh = ParseAndComputeShapes(svg);
+    std::optional<SVGElement> element = fresh.querySelector("#p");
+    EXPECT_TRUE(element.has_value());
+    if (!element) {
+      return Path();
+    }
+
+    const ComputedPathComponent* computed = computedPath(element.value());
+    EXPECT_THAT(computed, NotNull());
+    return computed ? computed->spline : Path();
+  }
+
+  ParseWarningSink warningSink_;
+};
+
+TEST_F(ShapeSystemPathCacheTest, UnchangedPathDataIsNotReparsed) {
+  auto document = ParseAndComputeShapes(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <path id="p" d="M10 10 L90 90 L90 10 Z"/>
+    </svg>
+  )");
+
+  auto element = document.querySelector("#p");
+  ASSERT_TRUE(element.has_value());
+  ASSERT_NO_FATAL_FAILURE(markComputedPath(element.value()));
+
+  recomputeShapes(document);
+
+  // Nothing changed, so the retained component has to be returned untouched instead of being
+  // rebuilt from a fresh parse of the same string.
+  EXPECT_TRUE(isMarked(element.value()));
+}
+
+TEST_F(ShapeSystemPathCacheTest, SetDReparses) {
+  constexpr std::string_view kBefore = R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <path id="p" d="M10 10 L90 90"/>
+    </svg>
+  )";
+  constexpr std::string_view kAfter = R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <path id="p" d="M20 20 L80 40 L60 80 Z"/>
+    </svg>
+  )";
+
+  const Path expected = freshSpline(kAfter);
+  ASSERT_FALSE(expected == freshSpline(kBefore));
+
+  auto document = ParseAndComputeShapes(kBefore);
+  auto element = document.querySelector("#p");
+  ASSERT_TRUE(element.has_value());
+  ASSERT_NO_FATAL_FAILURE(markComputedPath(element.value()));
+
+  element->cast<SVGPathElement>().setD(RcString("M20 20 L80 40 L60 80 Z"));
+  recomputeShapes(document);
+
+  EXPECT_FALSE(isMarked(element.value()));
+  ASSERT_THAT(computedPath(element.value()), NotNull());
+  EXPECT_TRUE(computedPath(element.value())->spline == expected);
+}
+
+TEST_F(ShapeSystemPathCacheTest, SetAttributeDReparses) {
+  constexpr std::string_view kBefore = R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <path id="p" d="M10 10 L90 90"/>
+    </svg>
+  )";
+  constexpr std::string_view kAfter = R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <path id="p" d="M30 30 L70 30 L70 70 Z"/>
+    </svg>
+  )";
+
+  const Path expected = freshSpline(kAfter);
+  ASSERT_FALSE(expected == freshSpline(kBefore));
+
+  auto document = ParseAndComputeShapes(kBefore);
+  auto element = document.querySelector("#p");
+  ASSERT_TRUE(element.has_value());
+  ASSERT_NO_FATAL_FAILURE(markComputedPath(element.value()));
+
+  element->setAttribute("d", "M30 30 L70 30 L70 70 Z");
+  recomputeShapes(document);
+
+  EXPECT_FALSE(isMarked(element.value()));
+  ASSERT_THAT(computedPath(element.value()), NotNull());
+  EXPECT_TRUE(computedPath(element.value())->spline == expected);
+}
+
+TEST_F(ShapeSystemPathCacheTest, RemoveAttributeDDropsGeometry) {
+  auto document = ParseAndComputeShapes(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <path id="p" d="M10 10 L90 90"/>
+    </svg>
+  )");
+
+  auto element = document.querySelector("#p");
+  ASSERT_TRUE(element.has_value());
+  ASSERT_NO_FATAL_FAILURE(markComputedPath(element.value()));
+
+  element->removeAttribute("d");
+  recomputeShapes(document);
+
+  // A path with no path data has no geometry at all, matching a document parsed without a `d`
+  // attribute.
+  EXPECT_THAT(computedPath(element.value()), testing::IsNull());
+}
+
+TEST_F(ShapeSystemPathCacheTest, StyleAttributeDReparses) {
+  constexpr std::string_view kBefore = R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <path id="p" d="M10 10 L90 90"/>
+    </svg>
+  )";
+  constexpr std::string_view kAfter = R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <path id="p" d="M10 10 L90 90" style="d: 'M40 40 L60 40 L60 60 Z'"/>
+    </svg>
+  )";
+
+  const Path expected = freshSpline(kAfter);
+  ASSERT_FALSE(expected == freshSpline(kBefore));
+
+  auto document = ParseAndComputeShapes(kBefore);
+  auto element = document.querySelector("#p");
+  ASSERT_TRUE(element.has_value());
+  ASSERT_NO_FATAL_FAILURE(markComputedPath(element.value()));
+
+  // A CSS `d` declaration is resolved by the shape pass itself and does not drop the computed
+  // path, so this is the mutation class the retained parse has to notice on its own rather than
+  // through an invalidation.
+  element->setStyle("d: 'M40 40 L60 40 L60 60 Z'");
+  recomputeShapes(document);
+
+  EXPECT_FALSE(isMarked(element.value()));
+  ASSERT_THAT(computedPath(element.value()), NotNull());
+  EXPECT_TRUE(computedPath(element.value())->spline == expected);
+}
+
+TEST_F(ShapeSystemPathCacheTest, SplineOverrideAndBackReparses) {
+  constexpr std::string_view kSvg = R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <path id="p" d="M10 10 L90 90"/>
+    </svg>
+  )";
+
+  const Path expected = freshSpline(kSvg);
+  const Path overrideSpline =
+      PathBuilder().moveTo(Vector2d(5.0, 5.0)).lineTo(Vector2d(25.0, 45.0)).build();
+  ASSERT_FALSE(expected == overrideSpline);
+
+  auto document = ParseAndComputeShapes(kSvg);
+  auto element = document.querySelector("#p");
+  ASSERT_TRUE(element.has_value());
+
+  element->cast<SVGPathElement>().setSpline(overrideSpline);
+  recomputeShapes(document);
+
+  ASSERT_THAT(computedPath(element.value()), NotNull());
+  EXPECT_TRUE(computedPath(element.value())->spline == overrideSpline);
+
+  // Going back to path data has to parse again: the spline that is currently retained was never
+  // produced by parsing a string, so it cannot be mistaken for a cached parse of one.
+  element->cast<SVGPathElement>().setD(RcString("M10 10 L90 90"));
+  recomputeShapes(document);
+
+  ASSERT_THAT(computedPath(element.value()), NotNull());
+  EXPECT_TRUE(computedPath(element.value())->spline == expected);
+}
+
+TEST_F(ShapeSystemPathCacheTest, MalformedPathDataReportsDiagnosticOnEveryPass) {
+  // Trailing `Q` with no coordinates: the parser returns the commands it did read plus a
+  // diagnostic, so there is a usable spline and a warning at the same time.
+  auto document = ParseSVG(R"(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+      <path id="p" d="M10 10 L90 90 Q"/>
+    </svg>
+  )");
+
+  ParseWarningSink firstSink;
+  StyleSystem().computeAllStyles(document.registry(), firstSink);
+  shapeSystem.instantiateAllComputedPaths(document.registry(), firstSink);
+  EXPECT_TRUE(firstSink.hasWarnings());
+
+  auto element = document.querySelector("#p");
+  ASSERT_TRUE(element.has_value());
+  ASSERT_THAT(computedPath(element.value()), NotNull());
+
+  // The diagnostic has to keep reaching the sink for as long as the malformed data is present,
+  // so path data that did not parse cleanly is never treated as a settled parse.
+  ParseWarningSink secondSink;
+  StyleSystem().computeAllStyles(document.registry(), secondSink);
+  shapeSystem.instantiateAllComputedPaths(document.registry(), secondSink);
+  EXPECT_TRUE(secondSink.hasWarnings());
 }
 
 }  // namespace donner::svg::components

--- a/donner/svg/renderer/benchmarks/BUILD.bazel
+++ b/donner/svg/renderer/benchmarks/BUILD.bazel
@@ -1,9 +1,25 @@
-"""Geode renderer benchmarks — per-phase timing for the WebGPU/Slug backend."""
+"""Renderer benchmarks: backend-independent document-preparation timing, plus per-phase
+timing for the Geode WebGPU/Slug backend."""
 
 load("//build_defs:package.bzl", "donner_package")
 load("//build_defs:rules.bzl", "donner_cc_binary")
 
 package(default_visibility = ["//visibility:public"])
+
+donner_cc_binary(
+    name = "shape_prepare_perf_bench",
+    testonly = 1,
+    srcs = ["ShapePreparePerfBench.cc"],
+    data = ["//donner/svg/renderer/testdata"],
+    deps = [
+        "//donner/base",
+        "//donner/base:base_test_utils",
+        "//donner/svg",
+        "//donner/svg/parser",
+        "//donner/svg/renderer",
+        "@google_benchmark//:benchmark",
+    ],
+)
 
 donner_cc_binary(
     name = "renderer_bench",

--- a/donner/svg/renderer/benchmarks/ShapePreparePerfBench.cc
+++ b/donner/svg/renderer/benchmarks/ShapePreparePerfBench.cc
@@ -1,0 +1,189 @@
+/// @file ShapePreparePerfBench.cc
+/// @brief Shape-pass and render-prepare benchmarks.
+///
+/// The shape pass re-derives every shape's geometry on every prepare, so its cost is paid on
+/// each frame in which anything at all changed, not only when geometry changed. These
+/// benchmarks isolate that pass so the cost of re-deriving unchanged geometry is measurable on
+/// its own, and pair it with a full prepare of the same document so the pass can be read as a
+/// share of the frame.
+///
+/// `<path>` geometry comes from parsing a path-data string, while `<rect>`, `<circle>`, and
+/// `<ellipse>` geometry comes from evaluating a handful of lengths, so the per-shape entries are
+/// split by shape type to keep those two costs separable.
+///
+/// Usage:
+/// ```
+/// bazel run -c opt //donner/svg/renderer/benchmarks:shape_prepare_perf_bench -- \
+///     --benchmark_min_time=0.5s
+/// ```
+
+#include <benchmark/benchmark.h>
+
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <string_view>
+
+#include "donner/base/ParseWarningSink.h"
+#include "donner/base/tests/Runfiles.h"
+#include "donner/svg/SVGDocument.h"
+#include "donner/svg/SVGElement.h"
+#include "donner/svg/components/shape/ShapeSystem.h"
+#include "donner/svg/parser/SVGParser.h"
+#include "donner/svg/renderer/RendererUtils.h"
+
+namespace {
+
+using donner::ParseWarningSink;
+using donner::Vector2i;
+using donner::svg::RendererUtils;
+using donner::svg::SVGDocument;
+using donner::svg::SVGElement;
+using donner::svg::components::ShapeSystem;
+using donner::svg::parser::SVGParser;
+
+constexpr Vector2i kCanvasSize(1024, 1024);
+
+/// Wrap `body` in an `<svg>` root large enough that nothing is clipped away.
+std::string WrapSvg(std::string_view body) {
+  std::ostringstream svg;
+  svg << R"(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">)" << body << "</svg>";
+  return svg.str();
+}
+
+/// `count` `<path>` elements, each with a distinct multi-command path-data string, modelling a
+/// generated diagram or a traced illustration.
+std::string MakePathSvg(int count) {
+  std::ostringstream body;
+  for (int i = 0; i < count; ++i) {
+    const int x = (i % 32) * 32;
+    const int y = (i / 32) % 32 * 32;
+    body << R"(<path d="M)" << x << ' ' << y << " L" << (x + 24) << ' ' << y << " C" << (x + 28)
+         << ' ' << y << ' ' << (x + 30) << ' ' << (y + 4) << ' ' << (x + 30) << ' ' << (y + 8)
+         << " L" << (x + 30) << ' ' << (y + 20) << " Q" << (x + 30) << ' ' << (y + 28) << ' '
+         << (x + 22) << ' ' << (y + 28) << " L" << x << ' ' << (y + 28) << R"( Z" fill="blue"/>)";
+  }
+  return WrapSvg(body.str());
+}
+
+/// `count` `<rect>` elements, for comparison against the same number of `<path>` elements.
+std::string MakeRectSvg(int count) {
+  std::ostringstream body;
+  for (int i = 0; i < count; ++i) {
+    body << R"(<rect x=")" << (i % 32) * 32 << R"(" y=")" << (i / 32) % 32 * 32
+         << R"(" width="30" height="28" fill="blue"/>)";
+  }
+  return WrapSvg(body.str());
+}
+
+/// `count` `<circle>` elements, for comparison against the same number of `<path>` elements.
+std::string MakeCircleSvg(int count) {
+  std::ostringstream body;
+  for (int i = 0; i < count; ++i) {
+    body << R"(<circle cx=")" << (i % 32) * 32 + 15 << R"(" cy=")" << (i / 32) % 32 * 32 + 15
+         << R"(" r="14" fill="blue"/>)";
+  }
+  return WrapSvg(body.str());
+}
+
+/// A real illustration: a few hundred filled and stroked paths with long path-data strings.
+std::string LoadTigerSvg() {
+  const std::string path =
+      donner::Runfiles::instance().Rlocation("donner/svg/renderer/testdata/Ghostscript_Tiger.svg");
+  std::ifstream file(path, std::ios::binary);
+  std::ostringstream contents;
+  contents << file.rdbuf();
+  return contents.str();
+}
+
+/// Parse `svg` and take it through one full prepare, leaving it in the state a document is in
+/// after its first frame.
+SVGDocument PreparedDocument(const std::string& svg) {
+  ParseWarningSink sink = ParseWarningSink::Disabled();
+  auto result = SVGParser::ParseSVG(svg, sink);
+  SVGDocument document = std::move(result).result();
+  document.setCanvasSize(kCanvasSize.x, kCanvasSize.y);
+  RendererUtils::prepareDocumentForRendering(document, /*verbose=*/false, sink);
+  return document;
+}
+
+/// The shape pass on its own, repeated on an already-prepared document. This is exactly what a
+/// prepare re-runs for every shape in the document on every frame that anything changed.
+void RunShapePass(benchmark::State& state, const std::string& svg) {
+  SVGDocument document = PreparedDocument(svg);
+  ParseWarningSink sink = ParseWarningSink::Disabled();
+
+  for (auto _ : state) {
+    ShapeSystem().instantiateAllComputedPaths(document.registry(), sink);
+  }
+  state.SetItemsProcessed(state.iterations());
+}
+
+/// A full prepare of an already-prepared document, with one non-inherited presentation
+/// attribute toggled first so the frame cannot take the nothing-is-dirty fast path. This models
+/// the editor's steady state, where one element changes and the whole document is re-prepared.
+void RunPrepare(benchmark::State& state, const std::string& svg) {
+  SVGDocument document = PreparedDocument(svg);
+  ParseWarningSink sink = ParseWarningSink::Disabled();
+  SVGElement root = document.svgElement();
+
+  bool toggle = false;
+  for (auto _ : state) {
+    toggle = !toggle;
+    root.setAttribute("opacity", toggle ? "1" : "0.999");
+    RendererUtils::prepareDocumentForRendering(document, /*verbose=*/false, sink);
+  }
+  state.SetItemsProcessed(state.iterations());
+}
+
+void BM_ShapePass_Paths(benchmark::State& state) {
+  RunShapePass(state, MakePathSvg(static_cast<int>(state.range(0))));
+}
+BENCHMARK(BM_ShapePass_Paths)->Arg(100)->Arg(1000)->Arg(10000);
+
+void BM_ShapePass_Rects(benchmark::State& state) {
+  RunShapePass(state, MakeRectSvg(static_cast<int>(state.range(0))));
+}
+BENCHMARK(BM_ShapePass_Rects)->Arg(100)->Arg(1000)->Arg(10000);
+
+void BM_ShapePass_Circles(benchmark::State& state) {
+  RunShapePass(state, MakeCircleSvg(static_cast<int>(state.range(0))));
+}
+BENCHMARK(BM_ShapePass_Circles)->Arg(100)->Arg(1000)->Arg(10000);
+
+void BM_ShapePass_Tiger(benchmark::State& state) {
+  RunShapePass(state, LoadTigerSvg());
+}
+BENCHMARK(BM_ShapePass_Tiger);
+
+void BM_Prepare_Paths(benchmark::State& state) {
+  RunPrepare(state, MakePathSvg(static_cast<int>(state.range(0))));
+}
+BENCHMARK(BM_Prepare_Paths)->Arg(1000)->Arg(10000);
+
+void BM_Prepare_Tiger(benchmark::State& state) {
+  RunPrepare(state, LoadTigerSvg());
+}
+BENCHMARK(BM_Prepare_Tiger);
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  // Locating this benchmark's data dependencies needs either the RUNFILES_DIR environment
+  // variable or argv[0], and the stock benchmark main forwards neither. A binary's runfiles tree
+  // always sits next to the binary, so point the lookup there when nothing else already has.
+  if (argc > 0 && std::getenv("RUNFILES_DIR") == nullptr) {
+    const std::string runfilesDir = std::string(argv[0]) + ".runfiles";
+    setenv("RUNFILES_DIR", runfilesDir.c_str(), /*overwrite=*/0);
+  }
+
+  benchmark::Initialize(&argc, argv);
+  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
+    return 1;
+  }
+
+  benchmark::RunSpecifiedBenchmarks();
+  benchmark::Shutdown();
+  return 0;
+}

--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -340,6 +340,25 @@ donner_cc_test(
 )
 
 donner_cc_test(
+    name = "shape_parse_cache_tests",
+    srcs = [
+        "ShapeParseCache_tests.cc",
+    ],
+    opens_gpu_device = True,
+    # The tiny / text_full / geode wrapper targets run automatically under
+    # `bazel test //...`.
+    variants = [
+        "tiny",
+        "text_full",
+        "geode",
+    ],
+    deps = [
+        ":renderer_test_utils",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
     name = "renderer_animation_tests",
     srcs = [
         "RendererAnimation_tests.cc",

--- a/donner/svg/renderer/tests/ShapeParseCache_tests.cc
+++ b/donner/svg/renderer/tests/ShapeParseCache_tests.cc
@@ -1,0 +1,203 @@
+/// @file
+/// Byte-identical render checks for the retained path-data parse in `ShapeSystem`.
+///
+/// The shape pass keeps the spline it parsed from a `<path>`'s resolved path-data string and
+/// skips the parse while that string is unchanged. Every way the resolved string can change has
+/// to produce exactly the pixels that a document parsed from scratch with the new value
+/// produces. Each test renders a live document once so the parse is retained, mutates it, and
+/// compares its next frame against a separately parsed document: the retained parse lives on the
+/// mutated document, so only a document that never saw the mutation can show what the new value
+/// is supposed to look like.
+///
+/// Every comparison is paired with a check that the expected pixels actually differ from the
+/// unmutated ones, so a mutation that silently did nothing cannot pass by both sides agreeing on
+/// the old picture.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+#include <string_view>
+
+#include "donner/base/Path.h"
+#include "donner/svg/SVGPathElement.h"
+#include "donner/svg/renderer/tests/RendererTestUtils.h"
+#include "donner/svg/tests/ParserTestUtils.h"
+
+namespace donner::svg {
+namespace {
+
+SVGDocument Parse(std::string_view fragment) {
+  return instantiateSubtree(fragment, parser::SVGParser::Options(), Vector2i(16, 16));
+}
+
+SVGDocument ParseAnimated(std::string_view fragment) {
+  parser::SVGParser::Options options;
+  options.enableExperimental = true;
+  return instantiateSubtree(fragment, options, Vector2i(16, 16));
+}
+
+std::string Render(SVGDocument document) {
+  return RendererTestUtils::renderToAsciiImage(document).generated;
+}
+
+/// The pixels a document parsed from scratch produces.
+std::string RenderFresh(std::string_view fragment) {
+  return Render(Parse(fragment));
+}
+
+/// Look up `#p`, which every fragment here names as the path under test.
+SVGPathElement TargetPath(SVGDocument& document) {
+  std::optional<SVGElement> element = document.querySelector("#p");
+  EXPECT_TRUE(element.has_value());
+  return element->cast<SVGPathElement>();
+}
+
+constexpr std::string_view kInitialPath =
+    R"(<path id="p" d="M2 2 L14 2 L14 6 L2 6 Z" fill="black" />)";
+
+}  // namespace
+
+TEST(ShapeParseCache, RepeatedRenderOfUnchangedDocumentIsStable) {
+  SVGDocument document = Parse(kInitialPath);
+
+  const std::string first = Render(document);
+  EXPECT_EQ(Render(document), first);
+  EXPECT_EQ(Render(document), first);
+}
+
+TEST(ShapeParseCache, SetDMatchesFreshDocument) {
+  constexpr std::string_view kAfter =
+      R"(<path id="p" d="M2 8 L14 8 L14 14 L2 14 Z" fill="black" />)";
+
+  SVGDocument document = Parse(kInitialPath);
+  const std::string before = Render(document);
+  const std::string expected = RenderFresh(kAfter);
+  ASSERT_NE(expected, before);
+
+  TargetPath(document).setD(RcString("M2 8 L14 8 L14 14 L2 14 Z"));
+
+  EXPECT_EQ(Render(document), expected);
+}
+
+TEST(ShapeParseCache, SetAttributeDMatchesFreshDocument) {
+  constexpr std::string_view kAfter =
+      R"(<path id="p" d="M6 2 L10 2 L10 14 L6 14 Z" fill="black" />)";
+
+  SVGDocument document = Parse(kInitialPath);
+  const std::string before = Render(document);
+  const std::string expected = RenderFresh(kAfter);
+  ASSERT_NE(expected, before);
+
+  TargetPath(document).setAttribute("d", "M6 2 L10 2 L10 14 L6 14 Z");
+
+  EXPECT_EQ(Render(document), expected);
+}
+
+TEST(ShapeParseCache, RemoveAttributeDMatchesFreshDocument) {
+  constexpr std::string_view kAfter = R"(<path id="p" fill="black" />)";
+
+  SVGDocument document = Parse(kInitialPath);
+  const std::string before = Render(document);
+  const std::string expected = RenderFresh(kAfter);
+  ASSERT_NE(expected, before);
+
+  TargetPath(document).removeAttribute("d");
+
+  EXPECT_EQ(Render(document), expected);
+}
+
+TEST(ShapeParseCache, StyleAttributeDMatchesFreshDocument) {
+  constexpr std::string_view kAfter =
+      R"(<path id="p" d="M2 2 L14 2 L14 6 L2 6 Z" fill="black"
+                style="d: 'M2 8 L14 8 L14 14 L2 14 Z'" />)";
+
+  SVGDocument document = Parse(kInitialPath);
+  const std::string before = Render(document);
+  const std::string expected = RenderFresh(kAfter);
+  ASSERT_NE(expected, before);
+
+  // A CSS `d` declaration does not drop the computed path, so this is the mutation class the
+  // retained parse has to notice on its own rather than through an invalidation.
+  TargetPath(document).setStyle("d: 'M2 8 L14 8 L14 14 L2 14 Z'");
+
+  EXPECT_EQ(Render(document), expected);
+}
+
+TEST(ShapeParseCache, SetSplineThenSetDMatchesFreshDocument) {
+  constexpr std::string_view kOverridden =
+      R"(<path id="p" d="M2 8 L14 8 L14 14 L2 14 Z" fill="black" />)";
+
+  SVGDocument document = Parse(kInitialPath);
+  const std::string before = Render(document);
+  const std::string overridden = RenderFresh(kOverridden);
+  ASSERT_NE(overridden, before);
+
+  TargetPath(document).setSpline(PathBuilder()
+                                     .moveTo(Vector2d(2.0, 8.0))
+                                     .lineTo(Vector2d(14.0, 8.0))
+                                     .lineTo(Vector2d(14.0, 14.0))
+                                     .lineTo(Vector2d(2.0, 14.0))
+                                     .closePath()
+                                     .build());
+  EXPECT_EQ(Render(document), overridden);
+
+  // The retained spline was supplied directly rather than parsed, so returning to the original
+  // path data must parse it again instead of matching it against a spline it never produced.
+  TargetPath(document).setD(RcString("M2 2 L14 2 L14 6 L2 6 Z"));
+  EXPECT_EQ(Render(document), before);
+}
+
+TEST(ShapeParseCache, UseShadowInstanceFollowsMutation) {
+  constexpr std::string_view kBefore = R"svg(
+    <path id="p" d="M2 2 L6 2 L6 6 L2 6 Z" fill="black" />
+    <use href="#p" transform="translate(8, 8)" />
+  )svg";
+  constexpr std::string_view kAfter = R"svg(
+    <path id="p" d="M2 2 L6 2 L6 10 L2 10 Z" fill="black" />
+    <use href="#p" transform="translate(8, 8)" />
+  )svg";
+
+  SVGDocument document = Parse(kBefore);
+  const std::string before = Render(document);
+  const std::string expected = RenderFresh(kAfter);
+  ASSERT_NE(expected, before);
+
+  // A `<use>` instance renders the referenced element's computed geometry, so a stale retained
+  // parse would show up on the original and on every instance of it.
+  TargetPath(document).setD(RcString("M2 2 L6 2 L6 10 L2 10 Z"));
+
+  EXPECT_EQ(Render(document), expected);
+}
+
+TEST(ShapeParseCache, AnimatedPathDataMatchesFreshDocumentAtEachTime) {
+  constexpr std::string_view kFragment = R"svg(
+    <path id="p" d="M2 2 L14 2 L14 6 L2 6 Z" fill="black">
+      <set attributeName="d" to="M2 8 L14 8 L14 14 L2 14 Z" begin="1s" dur="1s" />
+    </path>
+  )svg";
+
+  SVGDocument document = ParseAnimated(kFragment);
+  document.setTime(0.0);
+  const std::string atStart = Render(document);
+
+  // Before the animation begins, while it is applied, and after it reverts. Each sample of the
+  // live document has to match a document that was parsed fresh and sampled at the same time.
+  bool sawDifferentFrame = false;
+  for (const double time : {0.0, 1.5, 3.0}) {
+    document.setTime(time);
+
+    SVGDocument fresh = ParseAnimated(kFragment);
+    fresh.setTime(time);
+
+    const std::string expected = Render(fresh);
+    EXPECT_EQ(Render(document), expected) << "at time " << time;
+    sawDifferentFrame = sawDifferentFrame || expected != atStart;
+  }
+
+  // The animation has to actually move the path at one of the sampled times, otherwise the
+  // comparisons above would hold for a document that ignored it entirely.
+  EXPECT_TRUE(sawDifferentFrame);
+}
+
+}  // namespace donner::svg


### PR DESCRIPTION
The shape pass re-ran the path-data parser on every element's d string every frame and then discarded the result whenever the parsed spline matched the retained one, which at ten thousand paths is seventeen milliseconds per frame of pure re-derivation. The computed path component now records the resolved path-data string that produced its spline, and an unchanged string returns the retained geometry without parsing.

The key design makes invalidation structural rather than plumbed: the key lives on the computed component, so every existing invalidation that removes or replaces the component drops the key with it, and every producer that does not parse path data clears the key by default construction. The resolved string is a complete key because the parser has exactly one input and path geometry is viewport- and font-independent, both verified structurally in review along with probes for the path-length attribute (a stroke-time input, correctly not part of the key), producer switches through identical geometry, and CSS path data retargeted to equivalent text. Eight mutation classes are pinned by byte-identity tests against freshly parsed documents, each guarded against vacuous passes, including animated path data sampled at three times and use-element shadow instances.

Measured: the shape pass drops 3.4x at ten thousand paths and 8.8x on Ghostscript Tiger, full document preparation 15 percent and 29 percent respectively, with rect and circle passes at exact parity since their cost is not parsing (their own retention is noted as separate future work). Memory cost is forty bytes per computed path component, documented with the string-sharing behavior.

Verification: full repository suite green in the default configuration, all shape and renderer test variants green, and the known environment-specific geode failure attributed against main.