### PR TITLE
ci: Tolerate empty test selections without masking real failures

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -581,9 +581,18 @@ jobs:
               # happened. Ask bazel which affected targets are tests, so
               # test_suite expansion and rule kinds this workflow does not
               # enumerate are handled by definition rather than by a name
-              # heuristic. Fail closed: a query failure keeps the coverage run.
+              # heuristic, and subtract the tags the coverage command itself
+              # filters out (--test_tag_filters=-fuzz_target,-lint in .bazelrc),
+              # because a subset whose only tests carry those tags leaves the
+              # coverage run with the very empty test set this gate exists to
+              # keep it out of. `attr` matches its pattern against the string
+              # form of the tag LIST ("[fuzz_target, manual]"), not against
+              # each element, so the tag names are bracketed by the list
+              # punctuation rather than anchored with ^$. Fail closed: a query
+              # failure keeps the coverage run.
               test_query_file="$work_dir/affected-tests-query.txt"
-              printf 'tests(%s)\n' "$resolved_expr" > "$test_query_file"
+              printf 'tests(%s) except attr("tags", "[\[ ](fuzz_target|lint)[,\]]", tests(%s))\n' \
+                "$resolved_expr" "$resolved_expr" > "$test_query_file"
               affected_tests_file="$work_dir/affected-tests.txt"
               if ( cd "$head_dir" && bazelisk query --query_file="$test_query_file" \
                   --keep_going ) > "$affected_tests_file" 2> "$diagnostics_dir/test-query.log"; then

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,6 +39,14 @@ name: Coverage
 # strength: shared C++ sources always impact their host cc_library/cc_test
 # owners too, which classify as instrumentable. Future readers:
 # do not silently re-add a full instrumented PR coverage run.
+#
+# And the same shape one step further in: a genuine incremental subset that
+# holds instrumentable code but no TEST target at all has nothing to measure
+# either, because coverage data comes only from tests that run. `bazel coverage`
+# reports an empty test set as an error and writes no report, so the lane would
+# die on the "report was not generated" guard. Bazel itself is asked which of
+# the affected targets are tests (fallback_reason == no_test_targets), and that
+# detection fails closed too: a query failure runs coverage as before.
 on:
   push:
     branches: [main]
@@ -506,12 +514,12 @@ jobs:
           # alias in the set with its actual; an alias that cannot be resolved
           # stays an `alias` kind and the classifier treats it as instrumentable
           # (fail closed).
+          # The alias-resolved affected set, shared by the kind query below and
+          # by the test-presence query after it. Keep it single-quoted: `$a` is
+          # a bazel query variable, not a shell one.
+          resolved_expr="$(printf 'let a = set(%s) in ($a - kind("^alias rule$", $a)) + labels("actual", kind("^alias rule$", $a))' "$(tr '\n' ' ' < "$work_dir/affected.txt")")"
           kind_query_file="$work_dir/affected-query.txt"
-          {
-            printf 'let a = set('
-            tr '\n' ' ' < "$work_dir/affected.txt"
-            printf ') in ($a - kind("^alias rule$", $a)) + labels("actual", kind("^alias rule$", $a))\n'
-          } > "$kind_query_file"
+          printf '%s\n' "$resolved_expr" > "$kind_query_file"
           label_kind_file="$work_dir/affected-label-kind.txt"
           if ( cd "$head_dir" && bazelisk query --query_file="$kind_query_file" \
               --output label_kind --keep_going ) > "$label_kind_file" 2> "$diagnostics_dir/kind-query.log"; then
@@ -563,6 +571,32 @@ jobs:
                 fi
               fi
               echo "Affected subset includes instrumentable C/C++ targets; running coverage."
+
+              # Test-presence gate. Instrumentable code is not enough: coverage
+              # data comes only from tests that RUN, so a subset holding a
+              # library or tool whose test reverse dependencies are not in the
+              # set has nothing to measure. `bazel coverage` reports that empty
+              # test set as an error and writes no report, so the lane dies on
+              # the "report was not generated" guard rather than saying what
+              # happened. Ask bazel which affected targets are tests, so
+              # test_suite expansion and rule kinds this workflow does not
+              # enumerate are handled by definition rather than by a name
+              # heuristic. Fail closed: a query failure keeps the coverage run.
+              test_query_file="$work_dir/affected-tests-query.txt"
+              printf 'tests(%s)\n' "$resolved_expr" > "$test_query_file"
+              affected_tests_file="$work_dir/affected-tests.txt"
+              if ( cd "$head_dir" && bazelisk query --query_file="$test_query_file" \
+                  --keep_going ) > "$affected_tests_file" 2> "$diagnostics_dir/test-query.log"; then
+                cp "$affected_tests_file" "$diagnostics_dir/affected-tests.txt"
+                if [[ ! -s "$affected_tests_file" ]]; then
+                  echo "Affected subset contains no test targets; skipping PR coverage."
+                  emit_targets true no_test_targets ""
+                  exit 0
+                fi
+              else
+                echo "Test-presence query failed; running coverage on affected subset (guard intact)."
+                cat "$diagnostics_dir/test-query.log" || true
+              fi
             else
               echo "Instrumentability classifier errored; running coverage on affected subset (guard intact)."
             fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -640,11 +640,11 @@ jobs:
   # Replaces `linux` for trusted operator PRs and main pushes (extra arch
   # coverage + homelab cache). Renovate and non-operator runs stay hosted.
   # The NixOS host pre-provisions the toolchain (fontconfig, freetype, mesa,
-  # vulkan, X11, clang-tidy) and writes bazel-cache1 over LAN gRPC, so there
-  # is no apt/setup-bazel step. The runner intentionally has no host GPU
-  # device passthrough; Mesa llvmpipe/lavapipe provide the same software
-  # rendering path used by GitHub-hosted Linux so this lane runs the same test
-  # surface instead of excluding graphics targets.
+  # vulkan, X11, clang-tidy) and writes to a shared LAN Bazel cache over
+  # gRPC, so there is no apt/setup-bazel step. The runner intentionally has
+  # no host GPU device passthrough; Mesa llvmpipe/lavapipe provide the same
+  # software rendering path used by GitHub-hosted Linux so this lane runs the
+  # same test surface instead of excluding graphics targets.
   linux-self-hosted:
     runs-on: [self-hosted, linux, arm64]
     needs: [gatekeeper, determine-targets, linux-self-hosted-turnstile]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -544,7 +544,11 @@ jobs:
           else
             echo "${{ needs.determine-targets.outputs.affected }}"
           fi)
-          bazelisk test --config=ci --test_output=errors \
+          # A change-based selection can legitimately contain zero test
+          # targets (docs, tooling, a vendored subtree tested from its own
+          # workspace), which `bazel test` reports as exit 4. The wrapper
+          # maps only that status to success; every other failure still fails.
+          tools/ci_bazel_test.sh bazelisk test --config=ci --test_output=errors \
             --test_tag_filters=-manual,-perf \
             $TARGETS
 
@@ -947,7 +951,7 @@ jobs:
           else
             echo "${{ needs.determine-targets.outputs.affected }}"
           fi)
-          "$DIAG_DIR/run_bazel_with_heartbeat.sh" "$DIAG_DIR/test/console.log" \
+          tools/ci_bazel_test.sh "$DIAG_DIR/run_bazel_with_heartbeat.sh" "$DIAG_DIR/test/console.log" \
             bazelisk test --config=ci --config=latest_llvm --test_output=errors \
             $BAZEL_SELF_HOSTED_REMOTE_FALLBACK_FLAGS \
             $DIAG_TEST_FLAGS \
@@ -1061,7 +1065,7 @@ jobs:
           else
             echo "${{ needs.determine-targets.outputs.affected }}"
           fi)
-          bazelisk test --config=ci --test_output=errors \
+          tools/ci_bazel_test.sh bazelisk test --config=ci --test_output=errors \
             --test_tag_filters=-manual,-perf \
             $BAZEL_MACOS_BUILD_FLAGS $BAZEL_MACOS_TEST_FLAGS $TARGETS
         # Deterministic fuzzer corpus replay remains in this Bazel suite. Sanitizer-backed mutation
@@ -1152,7 +1156,7 @@ jobs:
           else
             echo "${{ needs.determine-targets.outputs.affected }}"
           fi)
-          bazelisk --nohome_rc test --config=ci --test_output=errors \
+          tools/ci_bazel_test.sh bazelisk --nohome_rc test --config=ci --test_output=errors \
             --test_tag_filters=-manual,-perf \
             $BAZEL_MACOS_BUILD_FLAGS $BAZEL_MACOS_TEST_FLAGS $TARGETS
         # Deterministic fuzzer corpus replay remains in this Bazel suite. Sanitizer-backed mutation

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -544,6 +544,17 @@ jobs:
           else
             echo "${{ needs.determine-targets.outputs.affected }}"
           fi)
+          # An empty selection is a defect in the target derivation, not a
+          # change with nothing to test. With no patterns, bazel falls back to
+          # its default target pattern (the working directory's package, which
+          # holds no tests here), so the step would build something nobody
+          # selected and then report that empty test set as success.
+          # Unreachable today because the deriving job widens an empty result
+          # to //..., and cheap to keep unreachable.
+          if [[ -z "${TARGETS// /}" ]]; then
+            echo "::error::Empty target selection reached the test step."
+            exit 1
+          fi
           # A change-based selection can legitimately contain zero test
           # targets (docs, tooling, a vendored subtree tested from its own
           # workspace), which `bazel test` reports as exit 4. The wrapper
@@ -951,6 +962,10 @@ jobs:
           else
             echo "${{ needs.determine-targets.outputs.affected }}"
           fi)
+          if [[ -z "${TARGETS// /}" ]]; then
+            echo "::error::Empty target selection reached the test step."
+            exit 1
+          fi
           tools/ci_bazel_test.sh "$DIAG_DIR/run_bazel_with_heartbeat.sh" "$DIAG_DIR/test/console.log" \
             bazelisk test --config=ci --config=latest_llvm --test_output=errors \
             $BAZEL_SELF_HOSTED_REMOTE_FALLBACK_FLAGS \
@@ -1065,6 +1080,10 @@ jobs:
           else
             echo "${{ needs.determine-targets.outputs.affected }}"
           fi)
+          if [[ -z "${TARGETS// /}" ]]; then
+            echo "::error::Empty target selection reached the test step."
+            exit 1
+          fi
           tools/ci_bazel_test.sh bazelisk test --config=ci --test_output=errors \
             --test_tag_filters=-manual,-perf \
             $BAZEL_MACOS_BUILD_FLAGS $BAZEL_MACOS_TEST_FLAGS $TARGETS
@@ -1156,6 +1175,10 @@ jobs:
           else
             echo "${{ needs.determine-targets.outputs.affected }}"
           fi)
+          if [[ -z "${TARGETS// /}" ]]; then
+            echo "::error::Empty target selection reached the test step."
+            exit 1
+          fi
           tools/ci_bazel_test.sh bazelisk --nohome_rc test --config=ci --test_output=errors \
             --test_tag_filters=-manual,-perf \
             $BAZEL_MACOS_BUILD_FLAGS $BAZEL_MACOS_TEST_FLAGS $TARGETS

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -113,6 +113,14 @@ py_test(
 )
 
 py_test(
+    name = "ci_bazel_test_tests",
+    size = "small",
+    srcs = ["ci_bazel_test_tests.py"],
+    data = ["ci_bazel_test.sh"],
+    deps = ["@rules_python//python/runfiles"],
+)
+
+py_test(
     name = "ci_runtime_workflow_tests",
     size = "small",
     srcs = ["ci_runtime_workflow_tests.py"],

--- a/tools/ci_bazel_test.sh
+++ b/tools/ci_bazel_test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# ci_bazel_test.sh - run a bazel test command, tolerating an empty test set.
+#
+# Change-based CI lanes build and test only the targets a diff impacts. That
+# selection can legitimately contain zero TEST targets: a docs filegroup, a
+# tool-only change, or a diff confined to a vendored subtree whose own tests are
+# run from that subtree's workspace rather than from this one. `bazel test`
+# treats an empty test set as an error and exits 4 with "No test targets were
+# found, yet testing was requested", so a change with nothing to test turns the
+# lane red with a failure no rerun can clear and no edit to the change can fix.
+#
+# Bazel reserves exit code 4 for exactly that condition, and reports it only
+# after the requested targets were built successfully. Mapping it to success
+# therefore cannot hide a build break (exit 1), a failing or flaky test
+# (exit 3), a bad command line (exit 2), or an internal/environment error (the
+# 3x codes): every other status is passed through unchanged, so the step still
+# fails on all of them.
+#
+# An empty selection produced by BROKEN selection tooling never reaches this
+# wrapper. The job that derives the target set aborts on any tooling error, and
+# a selection that legitimately comes back empty is widened to the full target
+# set before the lanes run, so the only thing this wrapper can observe is a
+# non-empty, deliberately produced selection that happens to contain no tests.
+#
+# Usage:
+#   tools/ci_bazel_test.sh bazel test --config=ci //pkg:target ...
+#   tools/ci_bazel_test.sh <wrapper> <wrapper args...> bazel test ...
+#
+# The second form exists because some lanes run bazel under a logging wrapper.
+# Any intermediate wrapper must propagate bazel's exit status verbatim.
+
+set -uo pipefail
+
+# Bazel's NO_TESTS_FOUND: "Build successful but no tests were found even though
+# testing was requested."
+readonly kNoTestsFoundExitCode=4
+
+if [[ $# -eq 0 ]]; then
+  echo "ci_bazel_test.sh: expected a command to run" >&2
+  exit 2
+fi
+
+"$@"
+status=$?
+
+if [[ "${status}" -eq "${kNoTestsFoundExitCode}" ]]; then
+  echo "::notice::No test targets in the selected target set; the selection built successfully and there was nothing to test."
+  echo "ci_bazel_test.sh: tolerating exit ${kNoTestsFoundExitCode} (no test targets) from: $*"
+  exit 0
+fi
+
+exit "${status}"

--- a/tools/ci_bazel_test.sh
+++ b/tools/ci_bazel_test.sh
@@ -17,11 +17,16 @@
 # 3x codes): every other status is passed through unchanged, so the step still
 # fails on all of them.
 #
-# An empty selection produced by BROKEN selection tooling never reaches this
-# wrapper. The job that derives the target set aborts on any tooling error, and
-# a selection that legitimately comes back empty is widened to the full target
-# set before the lanes run, so the only thing this wrapper can observe is a
-# non-empty, deliberately produced selection that happens to contain no tests.
+# An empty selection produced by FAILING selection tooling cannot reach this
+# wrapper: the job that derives the target set aborts on any tooling error, so
+# its lanes never run at all, and a selection that legitimately comes back
+# empty is widened to the full target set first. Callers reject an empty
+# pattern list themselves before invoking this script.
+#
+# What this wrapper cannot see is selection tooling that SUCCEEDS while being
+# wrong: an under-inclusive set that omits tests the change should have run
+# looks exactly like a set that genuinely has none. That residual belongs to
+# the derivation step and its own tests, not here.
 #
 # Usage:
 #   tools/ci_bazel_test.sh bazel test --config=ci //pkg:target ...

--- a/tools/ci_bazel_test_tests.py
+++ b/tools/ci_bazel_test_tests.py
@@ -1,0 +1,170 @@
+"""Pins the exit-code contract of the CI bazel-test wrapper.
+
+The wrapper exists so a change-based lane whose selected target set contains no
+test targets reports success instead of bazel's exit 4. The property that makes
+that safe is narrowness: exit 4 (and only exit 4) becomes success, so a build
+break, a failing test, or a bad command line still fails the lane. These tests
+hold that line by driving the wrapper with a stand-in command whose exit status
+the test chooses, which needs no bazel and no workspace.
+"""
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+from python.runfiles import runfiles
+
+# Bazel's exit status for "Build successful but no tests were found even though
+# testing was requested".
+NO_TESTS_FOUND_EXIT_CODE = 4
+
+NOTICE_PREFIX = "::notice::"
+
+
+class CiBazelTestWrapperTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        resolver = runfiles.Create()
+        cls.script = resolver.Rlocation("donner/tools/ci_bazel_test.sh")
+        assert cls.script is not None, "ci_bazel_test.sh not found in runfiles"
+        assert os.path.exists(cls.script), cls.script
+
+    def _fake_command(self, directory, exit_code):
+        """Write a stand-in command that echoes its arguments and exits.
+
+        Args:
+            directory: Directory to write the command into.
+            exit_code: Status the command exits with.
+
+        Returns:
+            Path to the executable stand-in command.
+        """
+        command = Path(directory) / "fake_bazel.sh"
+        command.write_text(
+            "#!/usr/bin/env bash\n"
+            'echo "fake-bazel-stdout: $*"\n'
+            'echo "fake-bazel-stderr" >&2\n'
+            f"exit {exit_code}\n",
+            encoding="utf-8",
+        )
+        command.chmod(0o755)
+        return command
+
+    def _passthrough_wrapper(self, directory):
+        """Write a wrapper that runs its arguments and propagates their status.
+
+        Mirrors the logging wrapper a self-hosted lane runs bazel under, so the
+        composed invocation is covered and not just the direct one.
+        """
+        wrapper = Path(directory) / "passthrough.sh"
+        wrapper.write_text(
+            "#!/usr/bin/env bash\nset -uo pipefail\n\"$@\"\nexit $?\n",
+            encoding="utf-8",
+        )
+        wrapper.chmod(0o755)
+        return wrapper
+
+    def _run(self, args):
+        return subprocess.run(
+            [self.script, *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+    def _run_fake(self, exit_code, args=("test", "//pkg:target"), compose=False):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            command = self._fake_command(temp_dir, exit_code)
+            argv = [str(command), *args]
+            if compose:
+                argv = [str(self._passthrough_wrapper(temp_dir)), *argv]
+            return self._run(argv)
+
+    def test_script_parses(self):
+        """A syntax regression must not wait for a CI lane to surface."""
+        result = subprocess.run(
+            ["bash", "-n", self.script],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+
+    def test_empty_test_selection_reports_success_with_a_notice(self):
+        """Exit 4 means "nothing to test", which is not a defect in the change."""
+        result = self._run_fake(NO_TESTS_FOUND_EXIT_CODE)
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn(NOTICE_PREFIX, result.stdout)
+        self.assertIn("No test targets", result.stdout)
+
+    def test_empty_test_selection_is_tolerated_through_a_logging_wrapper(self):
+        """Lanes that run bazel under a wrapper get the same treatment."""
+        result = self._run_fake(NO_TESTS_FOUND_EXIT_CODE, compose=True)
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn(NOTICE_PREFIX, result.stdout)
+
+    def test_success_is_passed_through_without_a_notice(self):
+        """An ordinary green run must look exactly like an unwrapped one."""
+        result = self._run_fake(0)
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertNotIn(NOTICE_PREFIX, result.stdout)
+
+    def test_build_failure_still_fails(self):
+        """Exit 1 (build error) must keep failing the lane."""
+        result = self._run_fake(1)
+
+        self.assertEqual(1, result.returncode)
+        self.assertNotIn(NOTICE_PREFIX, result.stdout)
+
+    def test_command_line_error_still_fails(self):
+        """Exit 2 (bad command line) must keep failing the lane."""
+        result = self._run_fake(2)
+
+        self.assertEqual(2, result.returncode)
+        self.assertNotIn(NOTICE_PREFIX, result.stdout)
+
+    def test_failing_test_still_fails(self):
+        """Exit 3 (tests ran and failed) must keep failing the lane."""
+        result = self._run_fake(3)
+
+        self.assertEqual(3, result.returncode)
+        self.assertNotIn(NOTICE_PREFIX, result.stdout)
+
+    def test_failing_test_still_fails_through_a_logging_wrapper(self):
+        """The composed form must not soften a real test failure either."""
+        result = self._run_fake(3, compose=True)
+
+        self.assertEqual(3, result.returncode)
+        self.assertNotIn(NOTICE_PREFIX, result.stdout)
+
+    def test_environment_failures_still_fail(self):
+        """Bazel's internal/environment statuses are passed through unchanged."""
+        for exit_code in (36, 37, 38):
+            with self.subTest(exit_code=exit_code):
+                result = self._run_fake(exit_code)
+                self.assertEqual(exit_code, result.returncode)
+                self.assertNotIn(NOTICE_PREFIX, result.stdout)
+
+    def test_arguments_and_output_are_passed_through(self):
+        """The wrapper must be transparent to the command it runs."""
+        result = self._run_fake(0, args=("test", "--config=ci", "//pkg:target"))
+
+        self.assertIn("fake-bazel-stdout: test --config=ci //pkg:target", result.stdout)
+        self.assertIn("fake-bazel-stderr", result.stderr)
+
+    def test_missing_command_is_a_usage_error(self):
+        """An empty command line is a workflow bug, not an empty test set."""
+        result = self._run([])
+
+        self.assertEqual(2, result.returncode)
+        self.assertNotIn(NOTICE_PREFIX, result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ci_runtime_workflow_tests.py
+++ b/tools/ci_runtime_workflow_tests.py
@@ -37,6 +37,14 @@ class CiRuntimeWorkflowTest(unittest.TestCase):
         end = re.search(r"^  [A-Za-z0-9_-]+:\s*$", rest, re.MULTILINE)
         return rest[: end.start()] if end else rest
 
+    def _step_body(self, job, step_name):
+        """Return one step's body from a job, stopping at the next step."""
+        marker = "      - name: %s\n" % step_name
+        self.assertIn(marker, job, "step %s not found" % step_name)
+        rest = job.split(marker, 1)[1]
+        end = re.search(r"^      - name: ", rest, re.MULTILINE)
+        return rest[: end.start()] if end else rest
+
     def _heartbeat_script(self):
         match = re.search(
             r"cat > \"\$DIAG_DIR/run_bazel_with_heartbeat\.sh\" <<'EOF'\n"
@@ -91,6 +99,35 @@ class CiRuntimeWorkflowTest(unittest.TestCase):
             with self.subTest(job=job_name):
                 job = self._job_body(job_name)
                 self.assertEqual(1, job.count("--test_tag_filters=-manual,-perf"))
+
+    def test_selected_target_lanes_tolerate_an_empty_test_selection(self):
+        """A selection with no test targets must not fail the change-based lanes.
+
+        `bazel test` exits 4 ("No test targets were found, yet testing was
+        requested") when the target patterns it is given contain no tests. A
+        change-based lane can hand it exactly that -- a docs filegroup, a
+        tool-only change, a diff confined to a vendored subtree tested from its
+        own workspace -- and the resulting red is unfixable by rerunning or by
+        editing the change. The wrapper turns only that one status into success.
+        """
+        for job_name in ("linux", "linux-self-hosted", "macos", "macos-self-hosted"):
+            with self.subTest(job=job_name):
+                step = self._step_body(self._job_body(job_name), "Test")
+                self.assertIn("tools/ci_bazel_test.sh", step)
+
+    def test_fixed_target_lanes_do_not_tolerate_an_empty_test_selection(self):
+        """A hardcoded target list that yields no tests is a real defect.
+
+        The Geode editor lanes name their tests literally, so an empty test set
+        there means a target was renamed or deleted out from under the lane.
+        That must stay red rather than inherit the change-based lanes' notice.
+        """
+        for job_name in ("macos", "macos-self-hosted"):
+            with self.subTest(job=job_name):
+                step = self._step_body(
+                    self._job_body(job_name), "Test (Geode editor lane)"
+                )
+                self.assertNotIn("tools/ci_bazel_test.sh", step)
 
     def test_linker_canary_uses_bounded_native_apt_retries(self):
         """The hosted canary must not ask an unprivileged action to kill apt."""

--- a/tools/ci_runtime_workflow_tests.py
+++ b/tools/ci_runtime_workflow_tests.py
@@ -37,6 +37,12 @@ class CiRuntimeWorkflowTest(unittest.TestCase):
         end = re.search(r"^  [A-Za-z0-9_-]+:\s*$", rest, re.MULTILINE)
         return rest[: end.start()] if end else rest
 
+    def _steps(self, workflow):
+        """Every (step name, step body) pair in a workflow, in file order."""
+        for part in re.split(r"^      - name: ", workflow, flags=re.MULTILINE)[1:]:
+            name, _, body = part.partition("\n")
+            yield name.strip(), body
+
     def _step_body(self, job, step_name):
         """Return one step's body from a job, stopping at the next step."""
         marker = "      - name: %s\n" % step_name
@@ -100,20 +106,48 @@ class CiRuntimeWorkflowTest(unittest.TestCase):
                 job = self._job_body(job_name)
                 self.assertEqual(1, job.count("--test_tag_filters=-manual,-perf"))
 
-    def test_selected_target_lanes_tolerate_an_empty_test_selection(self):
-        """A selection with no test targets must not fail the change-based lanes.
+    def test_every_change_based_test_step_handles_an_empty_selection(self):
+        """A selection with no test targets must not fail a change-based lane.
 
         `bazel test` exits 4 ("No test targets were found, yet testing was
         requested") when the target patterns it is given contain no tests. A
         change-based lane can hand it exactly that -- a docs filegroup, a
         tool-only change, a diff confined to a vendored subtree tested from its
         own workspace -- and the resulting red is unfixable by rerunning or by
-        editing the change. The wrapper turns only that one status into success.
+        editing the change. The wrapper turns only that one status into success,
+        while an empty pattern list (a derivation defect, not an empty test set)
+        still fails hard.
+
+        The lanes are DISCOVERED, not listed: any step that tests the derived
+        target set is covered by this, including one added after this was
+        written.
         """
-        for job_name in ("linux", "linux-self-hosted", "macos", "macos-self-hosted"):
-            with self.subTest(job=job_name):
-                step = self._step_body(self._job_body(job_name), "Test")
-                self.assertIn("tools/ci_bazel_test.sh", step)
+        covered = []
+        for name, body in self._steps(self.main):
+            if "outputs.affected" not in body:
+                continue
+            if not re.search(r"bazelisk(?:\s+--\S+)*\s+test\b", body):
+                continue
+            covered.append(name)
+            self.assertIn(
+                "tools/ci_bazel_test.sh",
+                body,
+                "step %r tests the derived target set without tolerating an "
+                "empty test selection" % name,
+            )
+            self.assertIn(
+                'if [[ -z "${TARGETS// /}" ]]; then',
+                body,
+                "step %r tests the derived target set without rejecting an "
+                "empty target list" % name,
+            )
+        self.assertGreaterEqual(
+            len(covered),
+            4,
+            "step discovery matched %r, which is fewer lanes than exist; the "
+            "match is stale and this test is no longer checking anything"
+            % (covered,),
+        )
 
     def test_fixed_target_lanes_do_not_tolerate_an_empty_test_selection(self):
         """A hardcoded target list that yields no tests is a real defect.

--- a/tools/coverage_lane_routing_tests.py
+++ b/tools/coverage_lane_routing_tests.py
@@ -43,6 +43,10 @@ _PR_SKIP_REASONS = frozenset(
         # A genuine subset containing nothing instrumentable. There is no
         # coverage to measure, and running anyway trips the empty-report guard.
         "no_instrumentable_targets",
+        # A genuine subset with instrumentable code but no test target to
+        # produce profile data from. `bazel coverage` treats an empty test set
+        # as an error, so running anyway is a guaranteed red with no report.
+        "no_test_targets",
     }
 )
 


### PR DESCRIPTION
Change-based CI lanes failed with bazel exit code 4 when diff-based target selection produced zero test targets, the shape any vendored-module-only change produces since those tests run in their own workspace. A small wrapper now maps exactly that outcome to success with a printed notice: exit 4 is only reachable after a successful build with an empty test set, verified empirically against real bazel including the case where an analysis failure prints the same message but exits 1, so no real failure can be swallowed. Every other exit code passes through, pinned by an eleven-case contract test and demonstrated against live failing, passing, and build-broken target sets.

The residual risks are guarded rather than assumed away: each wrapped step rejects an empty target list outright before bazel runs (otherwise bazel's default pattern would silently green the lane against the test-free root package), the fixed-target lanes deliberately stay unwrapped so a renamed target still fails loudly, and workflow-shape tests discover every change-based test step dynamically and assert both the wrapper and the guard, so a newly added lane is covered automatically; all of it was mutation-verified. The coverage lane gets the sibling fix one layer deeper: a test-presence gate that resolves aliases and models the coverage run's own tag filters (bazel's attribute query matches the stringified tag list, a gotcha now documented in the workflow), routing genuinely test-free selections through the existing skip convention while query failures fail closed into running coverage.

One note for readers of this PR's checks: because it touches workflow files, selection escalates to the full-repository fallback, so this run does not exercise the empty-selection path itself; the contract tests, workflow-shape tests, and the recorded manual invocations are the evidence. Also includes a small comment generalization in the workflow file.