### PR TITLE
docs: Generalize infrastructure references in CI design docs

### DIFF
--- a/docs/design_docs/0029-2-ci_runtime.md
+++ b/docs/design_docs/0029-2-ci_runtime.md
@@ -121,14 +121,14 @@ These are hard constraints that bound the solution space:
         (`-${{ github.run_id }}` is too aggressive; per-PR + per-week
         rotation is better)
 - [ ] Milestone 6: Internal remote cache for authenticated runs
-  - [ ] Wire `--config=ci-remote-cache` to the existing `bazel-re1` worker
-        (the sysroots from PR #545 already make the toolchain hermetic
-        enough for this)
+  - [ ] Wire `--config=ci-remote-cache` to the existing self-hosted
+        remote-execution worker (the sysroots from PR #545 already make
+        the toolchain hermetic enough for this)
   - [ ] Available only to runs with repo secrets — i.e. our own branches
         and main pushes; fork PRs continue using GHA disk cache only
   - [ ] Most Donner PRs come from the `jwmcglynn` account on branches in
         the same repo, so this still benefits the majority of merge cycles
-  - [ ] Risk: bazel-re1 outage tanks our own CI. Use
+  - [ ] Risk: a remote-cache outage tanks our own CI. Use
         `--remote_local_fallback=true` so Bazel falls back to local on
         cache miss/timeout
 - [ ] Milestone 7 (stretch): Matrix-parallelize the heavy variants
@@ -218,7 +218,7 @@ flowchart TD
     MacOS -.GHA disk cache, per-config slot.-> CacheMacos[(GHA cache: CI-macOS-default)]
     Fuzz -.dedicated cache slot.-> FuzzCache[(GHA cache: CI-macOS-asan-fuzzer)]
 
-    LinuxFull -.our PRs only.-> RemoteCache[(internal bazel-re1 remote cache)]
+    LinuxFull -.our PRs only.-> RemoteCache[(internal self-hosted remote cache)]
     MacOS -.our PRs only.-> RemoteCache
     LinuxFull2 -.write-through.-> RemoteCache
     MacOS2 -.write-through.-> RemoteCache
@@ -237,7 +237,7 @@ that isn't evicted by the fuzzer step (M1).
 - **macos-15-large cost overrun** (M4): macos-15-large is ~5x the per-minute
   rate of macos-15. If wall-clock improvement is < 5x, we're paying more
   for the same throughput. Validate before rolling forward.
-- **bazel-re1 outage tanks our own CI** (M6): `--remote_local_fallback=true`
+- **Remote-cache outage tanks our own CI** (M6): `--remote_local_fallback=true`
   means a cache miss falls back to local execution; outage degrades to
   current behavior.
 - **Per-PR cache write doubles every PR** (M5): same active PRs that today

--- a/docs/design_docs/0031-ci_hardening_2026q2.md
+++ b/docs/design_docs/0031-ci_hardening_2026q2.md
@@ -108,7 +108,7 @@ the `tiny`, `text-full`, and `geode` variant lanes now run as
   - [ ] M4.2: ReadabilityBot / GeodeBot review rule — raw pointers into objects owned by a different `shared_ptr` chain flag for review. Narrow but prevents #552 twin.
 
 - [ ] **Milestone 5 — Stretch (L effort)**
-  - [ ] M5.1: Internal remote cache (`bazel-re1`) for authenticated runs. Fork PRs keep GHA disk cache. `--remote_local_fallback=true` so outage degrades gracefully. (From 0029 M6.)
+  - [ ] M5.1: Internal remote cache on the self-hosted remote-execution host for authenticated runs. Fork PRs keep GHA disk cache. `--remote_local_fallback=true` so outage degrades gracefully. (From 0029 M6.)
   - [ ] M5.2: Matrix-parallelize heavy variants (`linux-default`, `linux-text-full`, `linux-geode`). Only if M1+M2+M3 don't hit target. (From 0029 M7.)
 
 ## Background


### PR DESCRIPTION
Replaces specific infrastructure names in two CI design documents with generic descriptions that preserve each sentence's technical meaning: the remote-execution worker reference, the two outage-risk sentences, and the architecture diagram node. Build configuration files are unchanged. Seven lines across two documents; lint and provenance checks green.