### PR TITLE
perf: Make the selective style recompute reachable from the render path

### DIFF
--- a/docs/design_docs/0005-incremental_invalidation.md
+++ b/docs/design_docs/0005-incremental_invalidation.md
@@ -556,12 +556,18 @@ prepare that follows a single transform edit on a group; medians of five interle
 
 | Document | Before | After | Delta |
 |----------|--------|-------|-------|
-| Ghostscript_Tiger (240 paths) | 3.55 ms | 1.62 ms | -54% |
-| Synthetic, 10,003 elements with a class-selector stylesheet | 84.8 ms | 28.4 ms | -67% |
+| Ghostscript_Tiger (240 paths) | 3.44 ms | 1.62 ms | -53% |
+| Synthetic, 10,003 elements with a class-selector stylesheet | 84.2 ms | 29.0 ms | -66% |
+| The same synthetic document, plus a `g[transform] rect` rule | 88.4 ms | 91.5 ms | parity |
+
+The third row is the fallback: once a stylesheet selects on the attribute being written, the edit
+takes the whole-tree restyle and the document performs as it did before. Interleaved in the order
+above it measured 6% slower, but re-running that document with the order reversed put the two at
+91.5 ms and 91.5 ms, so the gap is measurement drift rather than a cost of the check.
 
 The first prepare of a document is unchanged, as expected: it has never been able to use the
-selective branch, because no computed styles exist yet. Measured over the same rounds, 5.11 ms
-before and 5.07 ms after for Ghostscript_Tiger, 103.8 ms before and 101.9 ms after for the
+selective branch, because no computed styles exist yet. Measured over the same rounds, 4.90 ms
+before and 4.89 ms after for Ghostscript_Tiger, 103.5 ms before and 104.0 ms after for the
 synthetic document, both within run-to-run noise.
 
 Correctness is pinned by per-mutation-class equivalence tests in
@@ -572,12 +578,27 @@ byte-identical to a freshly parsed document in the same final state, with varian
 shadow trees (`<use>`), offscreen shadow trees (clipPath, mask, pattern, marker) and an animated
 document.
 
+The transform branch of `trySetPresentationAttribute()` is the one attribute write that stays on
+the selective pass, and it needs care: the value is stored in `AttributesComponent`, which is a
+live selector input, so `[transform]`, `[transform="..."]` and combinators keyed on them can start
+or stop matching, on other elements as well as the written one. It therefore requests the
+whole-tree restyle when, and only when, a loaded stylesheet actually selects on that attribute.
+That question is answered from a per-stylesheet cache of the attribute names its selectors
+reference, computed in `StylesheetComponent::parseStylesheet()`, which every stylesheet load and
+mutation path funnels through. The cache is keyed by attribute name rather than being a single
+"uses any attribute selector" flag because the user agent stylesheet always contains one
+(`*[xml|space=preserve]`), which would set a single flag for every document and give back the
+whole win. `SVGGraphicsElement::setTransform()` writes no attribute, so the compositor's drag path
+never reaches this check at all.
+
 Remaining over-approximation, deliberately left for a follow-up: `SVGElement::setStyle()`,
-`updateStyle()`, `setClassName()`, `setId()`, `setAttribute()` and the non-transform branch of
-`trySetPresentationAttribute()` all request a whole-tree restyle. That is correct but broader than
-necessary. Attribute, class and id edits can change selector matches on unrelated elements, so
-narrowing them needs the selector dependency index listed under Non-Goals; inline `style` edits
-only feed `[style]` attribute selectors and could be narrowed sooner.
+`updateStyle()`, `setClassName()`, `setId()`, the generic-attribute path of `setAttribute()` and
+the non-transform branch of `trySetPresentationAttribute()` all request a whole-tree restyle
+unconditionally. That is correct but broader than necessary. Class, id and attribute edits can
+change selector matches on unrelated elements, so narrowing them in general needs the selector
+dependency index listed under Non-Goals; the cheaper move is to extend the per-attribute check
+above to the other presentation attributes, which would leave only genuinely selector-relevant
+writes on the whole-tree path.
 
 ### Phase 4: Selective Layout and Transform Recomputation
 

--- a/docs/design_docs/0005-incremental_invalidation.md
+++ b/docs/design_docs/0005-incremental_invalidation.md
@@ -519,9 +519,65 @@ Modify `StyleSystem` to skip clean entities.
   inheriting descendants) are recomputed in the style pass
 - [x] Correctness test: incremental style invalidation output matches a fresh full render for the
   same final DOM state
+- [x] Make the selective branch reachable from the render path (see below)
 
 At this point the style stage has a selective path, but the rest of `createComputedComponents()`
 still falls back to whole-tree recomputation once anything is dirty.
+
+#### Phase 3 was shipped switched off, and is now live
+
+The selective branch landed unreachable. `RenderingContext::ensureComputedComponents()` set
+`RenderTreeState::needsFullStyleRecompute` unconditionally immediately before calling
+`createComputedComponents()`, so `StyleSystem::computeAllStyles()` always took the whole-tree
+branch, discarded every `ComputedStyleComponent`, and recomputed the cascade for the entire
+document on any dirty entity. Only the unit tests that call `computeAllStyles()` directly ever
+exercised the selective branch.
+
+The flag was guarding a real hazard rather than being redundant. Tearing down shadow trees
+destroys the cloned entities, and repopulating a main shadow-tree instance creates fresh clones
+that each carry an empty `ComputedStyleComponent` placeholder. Nothing marks those clones dirty,
+so the selective branch would skip them, and the paint/mask/marker pass that follows dereferences
+`ComputedStyleComponent::properties` on every entity it sees.
+
+The fix marks the clones dirty where they are created, which is where the knowledge that they are
+new lives, and narrows the forced whole-tree restyle to the one case that still needs it:
+documents with active animation overrides. `applyAnimationOverrides()` writes animated
+presentation attributes directly into the cached computed styles, which is only sound while those
+styles are rebuilt from their unanimated base on every pass.
+
+Closing the selective path also exposed a gap in the invalidation hooks: removing an element
+through the document mutation API requested a full rebuild but not a full restyle, which left the
+remaining siblings' structural selector matches (`:nth-child`, `:empty`, `:first-child`, sibling
+combinators) stale. Element removal now requests the whole-tree restyle.
+
+Measured effect on the prepare phase for an incremental frame (parse, prepare once, then time the
+prepare that follows a single transform edit on a group; medians of five interleaved A/B rounds,
+`-c opt`, Linux aarch64):
+
+| Document | Before | After | Delta |
+|----------|--------|-------|-------|
+| Ghostscript_Tiger (240 paths) | 3.55 ms | 1.62 ms | -54% |
+| Synthetic, 10,003 elements with a class-selector stylesheet | 84.8 ms | 28.4 ms | -67% |
+
+The first prepare of a document is unchanged, as expected: it has never been able to use the
+selective branch, because no computed styles exist yet. Measured over the same rounds, 5.11 ms
+before and 5.07 ms after for Ghostscript_Tiger, 103.8 ms before and 101.9 ms after for the
+synthetic document, both within run-to-run noise.
+
+Correctness is pinned by per-mutation-class equivalence tests in
+`donner/svg/renderer/tests/RendererPublicApi_tests.cc`: presentation attribute, transform,
+class, inline style, text content, structural insert, structural remove (including a structural
+selector case), and `<use>` retarget edits each require the incrementally rendered document to be
+byte-identical to a freshly parsed document in the same final state, with variants covering main
+shadow trees (`<use>`), offscreen shadow trees (clipPath, mask, pattern, marker) and an animated
+document.
+
+Remaining over-approximation, deliberately left for a follow-up: `SVGElement::setStyle()`,
+`updateStyle()`, `setClassName()`, `setId()`, `setAttribute()` and the non-transform branch of
+`trySetPresentationAttribute()` all request a whole-tree restyle. That is correct but broader than
+necessary. Attribute, class and id edits can change selector matches on unrelated elements, so
+narrowing them needs the selector dependency index listed under Non-Goals; inline `style` edits
+only feed `[style]` attribute selectors and could be narrowed sooner.
 
 ### Phase 4: Selective Layout and Transform Recomputation
 

--- a/donner/css/Selector.cc
+++ b/donner/css/Selector.cc
@@ -1,6 +1,47 @@
 #include "donner/css/Selector.h"
 
+#include <algorithm>
+
 namespace donner::css {
+
+namespace {
+
+void CollectAttributeNames(const Selector& selector, std::vector<RcString>& outNames,
+                           bool& outMatchesAnyName);
+
+void CollectAttributeNames(const CompoundSelector& compound, std::vector<RcString>& outNames,
+                           bool& outMatchesAnyName) {
+  for (const CompoundSelector::Entry& entry : compound.entries) {
+    if (const auto* attributeSelector = std::get_if<AttributeSelector>(&entry)) {
+      const RcString& localName = attributeSelector->name.name.name;
+      if (localName == "*") {
+        outMatchesAnyName = true;
+      } else if (std::find(outNames.begin(), outNames.end(), localName) == outNames.end()) {
+        outNames.push_back(localName);
+      }
+    } else if (const auto* pseudoClassSelector = std::get_if<PseudoClassSelector>(&entry)) {
+      if (pseudoClassSelector->selector) {
+        CollectAttributeNames(*pseudoClassSelector->selector, outNames, outMatchesAnyName);
+      }
+    }
+  }
+}
+
+void CollectAttributeNames(const Selector& selector, std::vector<RcString>& outNames,
+                           bool& outMatchesAnyName) {
+  for (const ComplexSelector& complexSelector : selector.entries) {
+    for (const ComplexSelector::Entry& entry : complexSelector.entries) {
+      CollectAttributeNames(entry.compoundSelector, outNames, outMatchesAnyName);
+    }
+  }
+}
+
+}  // namespace
+
+void Selector::collectAttributeSelectorNames(std::vector<RcString>& outNames,
+                                             bool& outMatchesAnyName) const {
+  CollectAttributeNames(*this, outNames, outMatchesAnyName);
+}
 
 Selector::Selector() = default;
 

--- a/donner/css/Selector.h
+++ b/donner/css/Selector.h
@@ -37,6 +37,23 @@ struct Selector {
   std::vector<ComplexSelector> entries;
 
   /**
+   * Collect the attribute names referenced by every attribute selector in this selector.
+   *
+   * Recurses into functional pseudo-classes that carry their own selector list, such as `:is()`,
+   * `:not()`, `:has()` and `:nth-child(An+B of S)`, so a nested `[attr]` is not missed.
+   *
+   * Namespaces are ignored: only the local name is collected, which over-approximates
+   * `[ns|attr]` to `[attr]`. Callers use this to decide whether writing an attribute can change
+   * selector matching, where over-approximating is the safe direction.
+   *
+   * @param outNames Receives each distinct local name found, appended to any existing contents.
+   * @param outMatchesAnyName Set to true if a selector uses a wildcard local name, meaning any
+   *   attribute write can change matching. No CSS syntax produces this today; it is a fail-safe.
+   */
+  void collectAttributeSelectorNames(std::vector<RcString>& outNames,
+                                     bool& outMatchesAnyName) const;
+
+  /**
    * Get the max specificity of all ComplexSelectors in the Selector.
    */
   Specificity::ABC maxSpecificity() const {

--- a/donner/svg/SVGDocument.cc
+++ b/donner/svg/SVGDocument.cc
@@ -316,6 +316,10 @@ void MarkSubtreeReplaced(EntityHandle handle) {
 void MarkChildRemoved(EntityHandle parentHandle) {
   components::RenderTreeState& renderState = GetRenderTreeState(parentHandle);
   renderState.needsFullRebuild = true;
+  // Removing a child changes structural selector matches (:nth-child, :empty, :first-child and
+  // the sibling combinators) for the elements that remain. Per-entity dirty flags do not track
+  // those non-local dependencies, so the whole tree has to be restyled.
+  renderState.needsFullStyleRecompute = true;
 
   parentHandle.get_or_emplace<components::DirtyFlagsComponent>().mark(
       components::DirtyFlagsComponent::All);

--- a/donner/svg/SVGElement.cc
+++ b/donner/svg/SVGElement.cc
@@ -477,6 +477,16 @@ ParseResult<bool> SVGElement::trySetPresentationAttribute(std::string_view name,
 
     // Mark dirty flags based on the attribute type.
     if (actualName == "transform") {
+      // The value was just stored as an attribute above, and attributes are a live selector
+      // input: `[transform]`, `[transform="..."]` and combinators keyed on them can start or stop
+      // matching, including on elements other than this one. Per-entity dirty flags cannot
+      // express that, so it needs the whole-tree restyle - but only when a stylesheet actually
+      // selects on this attribute, which keeps the common case on the selective style pass.
+      if (components::StyleSystem().anyStylesheetUsesAttributeInSelector(*handle_.registry(),
+                                                                         name)) {
+        markNeedsFullStyleRecompute(handle_);
+      }
+
       components::LayoutSystem().invalidate(handle_);
       markDirty(handle_, components::DirtyFlagsComponent::RenderInstance);
       propagateWorldTransformDirtyToDescendants(handle_);

--- a/donner/svg/SVGGradientElement.cc
+++ b/donner/svg/SVGGradientElement.cc
@@ -3,6 +3,7 @@
 #include "donner/svg/components/layout/LayoutSystem.h"
 #include "donner/svg/components/paint/GradientComponent.h"
 #include "donner/svg/components/shadow/ComputedShadowTreeComponent.h"
+#include "donner/svg/components/shadow/ShadowTreeSystem.h"
 #include "donner/svg/renderer/RenderingContext.h"
 
 namespace donner::svg {
@@ -43,6 +44,7 @@ void SVGGradientElement::setHref(const std::optional<RcString>& value) {
   DocumentWriteAccess& access = mutation.access();
   handle_.get_or_emplace<components::GradientComponent>(access).href = value;
   // Force the shadow tree to be regenerated.
+  components::ShadowTreeSystem().teardownInstances(handle_);
   handle_.remove<components::ComputedShadowTreeComponent>(access);
 }
 

--- a/donner/svg/SVGPatternElement.cc
+++ b/donner/svg/SVGPatternElement.cc
@@ -7,6 +7,7 @@
 #include "donner/svg/components/layout/ViewBoxComponent.h"
 #include "donner/svg/components/paint/PatternComponent.h"
 #include "donner/svg/components/shadow/ComputedShadowTreeComponent.h"
+#include "donner/svg/components/shadow/ShadowTreeSystem.h"
 #include "donner/svg/components/style/DoNotInheritFillOrStrokeTag.h"
 #include "donner/svg/core/PreserveAspectRatio.h"
 #include "donner/svg/renderer/RenderingContext.h"
@@ -17,6 +18,7 @@ namespace {
 void InvalidatePattern(EntityHandle handle) {
   components::LayoutSystem().invalidate(handle);
   handle.remove<components::ComputedPatternComponent>();
+  components::ShadowTreeSystem().teardownInstances(handle);
   handle.remove<components::ComputedShadowTreeComponent>();
   components::RenderingContext(*handle.registry()).invalidateRenderTree();
 }

--- a/donner/svg/SVGUseElement.cc
+++ b/donner/svg/SVGUseElement.cc
@@ -6,6 +6,7 @@
 #include "donner/svg/components/resources/ImageComponent.h"
 #include "donner/svg/components/shadow/ComputedShadowTreeComponent.h"
 #include "donner/svg/components/shadow/ShadowTreeComponent.h"
+#include "donner/svg/components/shadow/ShadowTreeSystem.h"
 #include "donner/svg/renderer/RenderingContext.h"
 
 namespace donner::svg {
@@ -13,6 +14,7 @@ namespace {
 
 void InvalidateUse(EntityHandle handle) {
   components::LayoutSystem().invalidate(handle);
+  components::ShadowTreeSystem().teardownInstances(handle);
   handle.remove<components::ComputedShadowTreeComponent, components::ExternalUseComponent>();
   components::RenderingContext(*handle.registry()).invalidateRenderTree();
 }

--- a/donner/svg/components/StylesheetComponent.cc
+++ b/donner/svg/components/StylesheetComponent.cc
@@ -71,10 +71,7 @@ std::optional<std::size_t> StylesheetSourceMap::mapToLocalCssOffset(
 }
 
 void StylesheetComponent::parseStylesheet(const RcStringOrRef& str) {
-  text = RcString(str);
-  sourceMap = StylesheetSourceMap();
-  ParseWarningSink disabled = ParseWarningSink::Disabled();
-  stylesheet = donner::css::parser::StylesheetParser::Parse(str, disabled);
+  parseStylesheet(str, StylesheetSourceMap());
 }
 
 void StylesheetComponent::parseStylesheet(const RcStringOrRef& str,
@@ -83,6 +80,15 @@ void StylesheetComponent::parseStylesheet(const RcStringOrRef& str,
   sourceMap = std::move(newSourceMap);
   ParseWarningSink disabled = ParseWarningSink::Disabled();
   stylesheet = donner::css::parser::StylesheetParser::Parse(str, disabled);
+
+  // Every path that loads or mutates a stylesheet ends here, so recomputing the cache alongside
+  // the parse keeps it from going stale.
+  attributeSelectorNames.clear();
+  attributeSelectorMatchesAnyName = false;
+  for (const css::SelectorRule& rule : stylesheet.rules()) {
+    rule.selector.collectAttributeSelectorNames(attributeSelectorNames,
+                                                attributeSelectorMatchesAnyName);
+  }
 }
 
 }  // namespace donner::svg::components

--- a/donner/svg/components/StylesheetComponent.h
+++ b/donner/svg/components/StylesheetComponent.h
@@ -1,8 +1,10 @@
 #pragma once
 /// @file
 
+#include <algorithm>
 #include <optional>
 #include <span>
+#include <string_view>
 #include <vector>
 
 #include "donner/base/FileOffset.h"
@@ -88,10 +90,43 @@ struct StylesheetComponent {
   bool isUserAgentStylesheet = false;
 
   /**
+   * Local names of the attributes referenced by attribute selectors in \ref stylesheet, cached
+   * when the stylesheet is parsed. Used by \ref usesAttributeInSelector.
+   */
+  std::vector<RcString> attributeSelectorNames;
+
+  /**
+   * True when an attribute selector in \ref stylesheet uses a wildcard local name, so any
+   * attribute write can change selector matching. No CSS syntax produces this today.
+   */
+  bool attributeSelectorMatchesAnyName = false;
+
+  /**
    * Returns true if the \ref xml_style element has either no `type` attribute, or if it has been
    * manually set to "text/css".
    */
   bool isCssType() const { return type.empty() || type.equalsIgnoreCase("text/css"); }
+
+  /**
+   * Returns true if this stylesheet contains an attribute selector that could match an attribute
+   * with the given local name, meaning writing that attribute can change which elements the
+   * stylesheet matches.
+   *
+   * Deliberately per-name rather than a single "uses any attribute selector" flag: the user agent
+   * stylesheet always contains one (`*[xml|space=preserve]`), so a single flag would be set for
+   * every document.
+   *
+   * @param localName Attribute local name, compared case-insensitively to over-approximate.
+   */
+  bool usesAttributeInSelector(std::string_view localName) const {
+    if (attributeSelectorMatchesAnyName) {
+      return true;
+    }
+
+    return std::any_of(
+        attributeSelectorNames.begin(), attributeSelectorNames.end(),
+        [localName](const RcString& name) { return name.equalsIgnoreCase(localName); });
+  }
 
   /**
    * Parse the contents of the \ref xml_style element.

--- a/donner/svg/components/shadow/ShadowTreeSystem.cc
+++ b/donner/svg/components/shadow/ShadowTreeSystem.cc
@@ -62,6 +62,12 @@ void ShadowTreeSystem::teardown(Registry& registry, ComputedShadowTreeComponent&
   shadow.branches.clear();
 }
 
+void ShadowTreeSystem::teardownInstances(EntityHandle handle) {
+  if (auto* shadow = handle.try_get<ComputedShadowTreeComponent>()) {
+    teardown(*handle.registry(), *shadow);
+  }
+}
+
 std::optional<size_t> ShadowTreeSystem::populateInstance(EntityHandle entity,
                                                          ComputedShadowTreeComponent& shadow,
                                                          ShadowBranchType branchType,

--- a/donner/svg/components/shadow/ShadowTreeSystem.cc
+++ b/donner/svg/components/shadow/ShadowTreeSystem.cc
@@ -63,6 +63,14 @@ void ShadowTreeSystem::teardown(Registry& registry, ComputedShadowTreeComponent&
 }
 
 void ShadowTreeSystem::teardownInstances(EntityHandle handle) {
+  // TODO(jwmcglynn): This only tears down instances recorded on `handle` itself. A shadow tree
+  // whose clones are themselves shadow hosts records those nested instances on the clone
+  // entities, and destroying the clones here drops those records without destroying what they
+  // point at. The leak is bounded and unreachable in practice today because the render path
+  // clears every ComputedShadowTreeComponent through the teardown loop in
+  // `RenderingContext::ensureComputedComponents()` before rebuilding, but a caller that relies on
+  // this function alone would leak. Recursing here needs the nested entities to be reachable
+  // without a full registry scan.
   if (auto* shadow = handle.try_get<ComputedShadowTreeComponent>()) {
     teardown(*handle.registry(), *shadow);
   }

--- a/donner/svg/components/shadow/ShadowTreeSystem.h
+++ b/donner/svg/components/shadow/ShadowTreeSystem.h
@@ -60,6 +60,18 @@ public:
   void teardown(Registry& registry, ComputedShadowTreeComponent& shadow);
 
   /**
+   * Destroy every shadow tree instantiated on \p handle, if any.
+   *
+   * Call this before removing an entity's \ref ComputedShadowTreeComponent to force its shadow
+   * trees to be regenerated. Removing the component on its own orphans the cloned entities: they
+   * stay parented into the tree with nothing left recording them, so the next render instantiates
+   * a second copy that draws on top of the first.
+   *
+   * @param handle The shadow host whose instances should be destroyed.
+   */
+  void teardownInstances(EntityHandle handle);
+
+  /**
    * Create a new computed shadow tree instance, such as the shadow tree for a \ref xml_use element
    * or a \ref xml_pattern element.
    *

--- a/donner/svg/components/style/StyleSystem.cc
+++ b/donner/svg/components/style/StyleSystem.cc
@@ -417,6 +417,19 @@ void StyleSystem::computeAllStyles(Registry& registry, ParseWarningSink& warning
       renderState != nullptr && renderState->needsFullStyleRecompute;
   const bool hasDirtyEntities = !registry.view<DirtyFlagsComponent>().empty();
 
+  // Selective pass: recompute only the entities flagged dirty. This depends on a two-part
+  // invariant that mutation hooks must uphold together, because either half alone is inert:
+  //
+  //   1. The entity's cached ComputedStyleComponent must have been removed. computeStyle() is
+  //      memoized (see computePropertiesInto, which returns early once `properties` is set), so
+  //      a Style dirty flag on an entity whose cached style is still populated does nothing.
+  //   2. The entity must be flagged DirtyFlagsComponent::Style. Removing the cached style without
+  //      flagging it leaves the entity with no computed style at all, which later passes that
+  //      walk ComputedStyleComponent would then skip or dereference.
+  //
+  // Mutations whose effect is not local to specific entities (stylesheet edits, class/id/attribute
+  // writes that feed selectors, structural changes) cannot express themselves through per-entity
+  // flags at all, and must instead request RenderTreeState::needsFullStyleRecompute.
   if (hasBeenBuilt && hasDirtyEntities && !needsFullStyleRecompute) {
     for (auto entity : registry.view<DirtyFlagsComponent>()) {
       const auto& dirty = registry.get<DirtyFlagsComponent>(entity);
@@ -467,6 +480,17 @@ void StyleSystem::computeStylesFor(Registry& registry, std::span<const Entity> e
   for (Entity entity : entities) {
     computeStyle(EntityHandle(registry, entity), warningSink);
   }
+}
+
+bool StyleSystem::anyStylesheetUsesAttributeInSelector(Registry& registry,
+                                                       std::string_view localName) const {
+  for (auto view = registry.view<StylesheetComponent>(); auto stylesheetEntity : view) {
+    if (view.get<StylesheetComponent>(stylesheetEntity).usesAttributeInSelector(localName)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 void StyleSystem::invalidateComputed(EntityHandle handle) {

--- a/donner/svg/components/style/StyleSystem.h
+++ b/donner/svg/components/style/StyleSystem.h
@@ -119,6 +119,19 @@ public:
   void invalidateComputed(EntityHandle handle);
 
   /**
+   * Returns true if any stylesheet loaded into \p registry contains an attribute selector that
+   * could match an attribute with the given local name.
+   *
+   * Writing such an attribute changes selector matching, and can do so for elements other than
+   * the one written (sibling combinators, descendant selectors), which per-entity dirty flags do
+   * not track. Callers use this to decide whether an attribute write needs a whole-tree restyle.
+   *
+   * @param registry Document registry.
+   * @param localName Attribute local name that is about to be written.
+   */
+  bool anyStylesheetUsesAttributeInSelector(Registry& registry, std::string_view localName) const;
+
+  /**
    * Invalidate the full style and reparse attributes.
    *
    * @param handle Entity handle to invalidate

--- a/donner/svg/renderer/RenderingContext.cc
+++ b/donner/svg/renderer/RenderingContext.cc
@@ -1356,10 +1356,16 @@ void RenderingContext::ensureComputedComponents(ParseWarningSink& warningSink) {
   registry_.clear<RenderingInstanceComponent>();
   registry_.clear<ComputedClipPathsComponent>();
 
-  // Shadow-tree teardown recreates tree entities with fresh ComputedStyleComponent placeholders.
-  // Force StyleSystem down the full recompute path so those placeholders are populated before the
-  // later paint/mask/marker passes walk all styled entities.
-  renderState.needsFullStyleRecompute = true;
+  // Animated presentation attributes are written straight into the cached computed styles (see
+  // applyAnimationOverrides above), which is only sound while every pass rebuilds those styles
+  // from their unanimated base. Keep documents carrying animation overrides on the whole-tree
+  // restyle; every other document may use the dirty-entity style pass.
+  //
+  // Entities that the shadow-tree instantiation below creates are handled there: it flags the
+  // fresh clones dirty so the dirty-entity pass populates their placeholder styles.
+  if (!registry_.view<AnimatedValuesComponent>().empty()) {
+    renderState.needsFullStyleRecompute = true;
+  }
 
   createComputedComponents(warningSink);
 
@@ -1549,6 +1555,15 @@ void RenderingContext::createComputedComponents(ParseWarningSink& warningSink) {
           EntityHandle(registry_, entity), shadow, ShadowBranchType::Main, targetEntity.value(),
           shadowTreeComponent.mainHref().value(), warningSink);
 
+      // populateInstance() just created these entities, each carrying an empty computed-style
+      // placeholder that the passes below dereference unconditionally. No mutation hook can have
+      // flagged them, so flag them here: the style pass is allowed to visit only dirty entities.
+      if (shadow.mainBranch) {
+        for (const Entity shadowEntity : shadow.mainBranch->shadowEntities) {
+          registry_.get_or_emplace<DirtyFlagsComponent>(shadowEntity)
+              .mark(DirtyFlagsComponent::Style);
+        }
+      }
     } else if (shadowTreeComponent.mainHref()) {
       // Same-document resolution failed. Check if this is an external reference.
       const Reference ref(shadowTreeComponent.mainHref().value());

--- a/donner/svg/renderer/tests/RendererPublicApi_tests.cc
+++ b/donner/svg/renderer/tests/RendererPublicApi_tests.cc
@@ -835,6 +835,10 @@ TEST(RendererPublicApiTest, AppendChildMatchesFullRender) {
 
 /// Render `initialSource`, apply `mutate`, render again, and require the pixels to match a fresh
 /// render of `finalSource` exactly.
+///
+/// Includes an anti-vacuity control: if the mutation does not change the rendered output, the
+/// equivalence assertion would hold no matter what the incremental path did, so the caller would
+/// be testing nothing. Every case here is expected to be visible.
 void ExpectIncrementalMatchesFullRender(std::string_view initialSource,
                                         const std::function<void(SVGDocument&)>& mutate,
                                         std::string_view finalSource) {
@@ -851,6 +855,14 @@ void ExpectIncrementalMatchesFullRender(std::string_view initialSource,
   fullRenderer.draw(fullDocument);
   const RendererBitmap full = NormalizeSnapshot(fullRenderer.takeSnapshot());
   ASSERT_FALSE(full.empty());
+
+  SVGDocument initialDocument = ParseDocument(initialSource);
+  Renderer initialRenderer;
+  initialRenderer.draw(initialDocument);
+  const RendererBitmap initial = NormalizeSnapshot(initialRenderer.takeSnapshot());
+  ASSERT_FALSE(initial.empty());
+  EXPECT_NE(initial.pixels, full.pixels)
+      << "the mutation produced no visible change, so the equivalence assertion is vacuous";
 
   EXPECT_EQ(incremental.dimensions, full.dimensions);
   EXPECT_EQ(incremental.rowBytes, full.rowBytes);
@@ -898,6 +910,56 @@ TEST(RendererPublicApiTest, TransformAttributeChangeMatchesFullRender) {
         <g fill="#ff0000">
           <rect width="5" height="5" transform="translate(9, 8)" />
         </g>
+      </svg>
+    )svg");
+}
+
+TEST(RendererPublicApiTest, TransformValueChangeUpdatesAttributeSelectorMatchesFullRender) {
+  // The transform attribute is a selector input, not just layout state: changing its value
+  // changes which `[transform="..."]` rules match.
+  ExpectIncrementalMatchesFullRender(
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+        <style>rect { fill: #ff0000 } rect[transform="translate(9, 8)"] { fill: #0000ff }</style>
+        <rect id="r" width="5" height="5" transform="translate(1, 1)" />
+      </svg>
+    )svg",
+      [](SVGDocument& document) {
+        auto target = document.querySelector("#r");
+        ASSERT_TRUE(target.has_value());
+        target->setAttribute("transform", "translate(9, 8)");
+      },
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+        <style>rect { fill: #ff0000 } rect[transform="translate(9, 8)"] { fill: #0000ff }</style>
+        <rect width="5" height="5" transform="translate(9, 8)" />
+      </svg>
+    )svg");
+}
+
+TEST(RendererPublicApiTest, TransformPresenceChangeUpdatesSiblingSelectorMatchesFullRender) {
+  // The match this changes is on a *different* element than the one written: adding the attribute
+  // makes `rect[transform] + rect` start matching the sibling. The transform itself is an
+  // identity translation, so the sibling's fill is the only visible difference, which keeps the
+  // anti-vacuity control pinned on exactly the non-local effect.
+  ExpectIncrementalMatchesFullRender(
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+        <style>rect { fill: #ff0000 } rect[transform] + rect { fill: #0000ff }</style>
+        <rect id="r" width="5" height="5" />
+        <rect x="8" width="5" height="5" />
+      </svg>
+    )svg",
+      [](SVGDocument& document) {
+        auto target = document.querySelector("#r");
+        ASSERT_TRUE(target.has_value());
+        target->setAttribute("transform", "translate(0, 0)");
+      },
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+        <style>rect { fill: #ff0000 } rect[transform] + rect { fill: #0000ff }</style>
+        <rect width="5" height="5" transform="translate(0, 0)" />
+        <rect x="8" width="5" height="5" />
       </svg>
     )svg");
 }
@@ -1183,6 +1245,18 @@ TEST(RendererPublicApiTest, TransformChangeOnAnimatedDocumentMatchesFullRender) 
   fullRenderer.draw(fullDocument);
   const RendererBitmap full = NormalizeSnapshot(fullRenderer.takeSnapshot());
   ASSERT_FALSE(full.empty());
+
+  // Anti-vacuity: prove the animation override is actually applied at t=1.5. Without this the
+  // comparison would pass trivially if `<set>` never took effect, which is the whole behavior
+  // this test exists to protect.
+  SVGDocument beforeAnimationDocument = ParseDocumentWithExperimental(kFinalSource);
+  beforeAnimationDocument.setTime(0.0);
+  Renderer beforeAnimationRenderer;
+  beforeAnimationRenderer.draw(beforeAnimationDocument);
+  const RendererBitmap beforeAnimation = NormalizeSnapshot(beforeAnimationRenderer.takeSnapshot());
+  ASSERT_FALSE(beforeAnimation.empty());
+  EXPECT_NE(beforeAnimation.pixels, full.pixels)
+      << "the <set> override never applied, so the equivalence assertion is vacuous";
 
   EXPECT_EQ(incremental.dimensions, full.dimensions);
   EXPECT_EQ(incremental.pixels, full.pixels);

--- a/donner/svg/renderer/tests/RendererPublicApi_tests.cc
+++ b/donner/svg/renderer/tests/RendererPublicApi_tests.cc
@@ -3,12 +3,16 @@
 
 #include <array>
 #include <filesystem>
+#include <functional>
 #include <limits>
+#include <tuple>
 #include <vector>
 
 #include "donner/base/ParseWarningSink.h"
 #include "donner/svg/SVG.h"
 #include "donner/svg/SVGRectElement.h"
+#include "donner/svg/SVGTextElement.h"
+#include "donner/svg/SVGUseElement.h"
 #include "donner/svg/renderer/Renderer.h"
 #include "donner/svg/renderer/tests/MockRendererInterface.h"
 #include "donner/svg/renderer/tests/RendererTestBackend.h"
@@ -26,6 +30,16 @@ using ::testing::Lt;
 SVGDocument ParseDocument(std::string_view svgSource) {
   ParseWarningSink warningSink;
   ParseResult<SVGDocument> maybeDocument = parser::SVGParser::ParseSVG(svgSource, warningSink);
+  EXPECT_FALSE(maybeDocument.hasError());
+  return std::move(maybeDocument.result());
+}
+
+SVGDocument ParseDocumentWithExperimental(std::string_view svgSource) {
+  ParseWarningSink warningSink;
+  parser::SVGParser::Options options;
+  options.enableExperimental = true;
+  ParseResult<SVGDocument> maybeDocument =
+      parser::SVGParser::ParseSVG(svgSource, warningSink, options);
   EXPECT_FALSE(maybeDocument.hasError());
   return std::move(maybeDocument.result());
 }
@@ -807,6 +821,368 @@ TEST(RendererPublicApiTest, AppendChildMatchesFullRender) {
   Renderer r2;
   r2.draw(doc2);
   const RendererBitmap full = NormalizeSnapshot(r2.takeSnapshot());
+
+  EXPECT_EQ(incremental.dimensions, full.dimensions);
+  EXPECT_EQ(incremental.pixels, full.pixels);
+}
+
+// --- Mutation-class equivalence: incremental render vs. a fresh parse ---
+//
+// One test per class of DOM mutation. Each renders a document, mutates it, renders again, and
+// requires the result to be byte-identical to rendering a freshly parsed document that already
+// has the mutated state. These pin the invariant that reusing cached computed state can never
+// produce different pixels than computing everything from scratch.
+
+/// Render `initialSource`, apply `mutate`, render again, and require the pixels to match a fresh
+/// render of `finalSource` exactly.
+void ExpectIncrementalMatchesFullRender(std::string_view initialSource,
+                                        const std::function<void(SVGDocument&)>& mutate,
+                                        std::string_view finalSource) {
+  SVGDocument incrementalDocument = ParseDocument(initialSource);
+  Renderer incrementalRenderer;
+  incrementalRenderer.draw(incrementalDocument);
+  mutate(incrementalDocument);
+  incrementalRenderer.draw(incrementalDocument);
+  const RendererBitmap incremental = NormalizeSnapshot(incrementalRenderer.takeSnapshot());
+  ASSERT_FALSE(incremental.empty());
+
+  SVGDocument fullDocument = ParseDocument(finalSource);
+  Renderer fullRenderer;
+  fullRenderer.draw(fullDocument);
+  const RendererBitmap full = NormalizeSnapshot(fullRenderer.takeSnapshot());
+  ASSERT_FALSE(full.empty());
+
+  EXPECT_EQ(incremental.dimensions, full.dimensions);
+  EXPECT_EQ(incremental.rowBytes, full.rowBytes);
+  EXPECT_EQ(incremental.pixels, full.pixels);
+}
+
+TEST(RendererPublicApiTest, PresentationAttributeChangeMatchesFullRender) {
+  ExpectIncrementalMatchesFullRender(
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+        <rect id="r" x="1" y="1" width="6" height="6" fill="#ff0000" stroke="#000000" />
+      </svg>
+    )svg",
+      [](SVGDocument& document) {
+        auto target = document.querySelector("#r");
+        ASSERT_TRUE(target.has_value());
+        target->setAttribute("width", "11");
+        target->setAttribute("fill", "#00ff00");
+      },
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+        <rect x="1" y="1" width="11" height="6" fill="#00ff00" stroke="#000000" />
+      </svg>
+    )svg");
+}
+
+TEST(RendererPublicApiTest, TransformAttributeChangeMatchesFullRender) {
+  // A transform edit marks only layout/transform dirty, so this is the mutation class that
+  // reaches the dirty-entity style pass.
+  ExpectIncrementalMatchesFullRender(
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+        <g fill="#ff0000">
+          <rect id="r" width="5" height="5" transform="translate(1, 1)" />
+        </g>
+      </svg>
+    )svg",
+      [](SVGDocument& document) {
+        auto target = document.querySelector("#r");
+        ASSERT_TRUE(target.has_value());
+        target->setAttribute("transform", "translate(9, 8)");
+      },
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+        <g fill="#ff0000">
+          <rect width="5" height="5" transform="translate(9, 8)" />
+        </g>
+      </svg>
+    )svg");
+}
+
+TEST(RendererPublicApiTest, TransformChangeWithUseShadowTreeMatchesFullRender) {
+  // Shadow-tree instances are torn down and recreated on every pass, so their entities are new
+  // (and unstyled) each time even though nothing about them changed.
+  ExpectIncrementalMatchesFullRender(
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+        <defs>
+          <g id="src" fill="#ff0000" stroke="#0000ff" stroke-width="1">
+            <rect width="6" height="6" />
+            <circle cx="9" cy="3" r="3" />
+          </g>
+        </defs>
+        <use id="u" href="#src" transform="translate(1, 1)" />
+        <use href="#src" transform="translate(1, 12)" />
+      </svg>
+    )svg",
+      [](SVGDocument& document) {
+        auto target = document.querySelector("#u");
+        ASSERT_TRUE(target.has_value());
+        target->setAttribute("transform", "translate(10, 1)");
+      },
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+        <defs>
+          <g id="src" fill="#ff0000" stroke="#0000ff" stroke-width="1">
+            <rect width="6" height="6" />
+            <circle cx="9" cy="3" r="3" />
+          </g>
+        </defs>
+        <use href="#src" transform="translate(10, 1)" />
+        <use href="#src" transform="translate(1, 12)" />
+      </svg>
+    )svg");
+}
+
+TEST(RendererPublicApiTest, TransformChangeWithOffscreenShadowTreesMatchesFullRender) {
+  // clipPath, mask, pattern and marker references all instantiate offscreen shadow trees, which
+  // are likewise recreated on every pass.
+  ExpectIncrementalMatchesFullRender(
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+        <defs>
+          <clipPath id="clip"><rect width="10" height="10" /></clipPath>
+          <mask id="m"><rect width="24" height="24" fill="#ffffff" /></mask>
+          <pattern id="p" width="4" height="4" patternUnits="userSpaceOnUse">
+            <rect width="2" height="2" fill="#00ff00" />
+          </pattern>
+          <marker id="mk" markerWidth="3" markerHeight="3" refX="1" refY="1">
+            <circle cx="1" cy="1" r="1" fill="#0000ff" />
+          </marker>
+        </defs>
+        <rect id="r" width="12" height="12" fill="url(#p)" clip-path="url(#clip)" mask="url(#m)"
+              transform="translate(1, 1)" />
+        <path d="M 2 20 L 10 20 L 18 20" stroke="#000000" fill="none" marker-start="url(#mk)"
+              marker-mid="url(#mk)" marker-end="url(#mk)" />
+      </svg>
+    )svg",
+      [](SVGDocument& document) {
+        auto target = document.querySelector("#r");
+        ASSERT_TRUE(target.has_value());
+        target->setAttribute("transform", "translate(8, 6)");
+      },
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+        <defs>
+          <clipPath id="clip"><rect width="10" height="10" /></clipPath>
+          <mask id="m"><rect width="24" height="24" fill="#ffffff" /></mask>
+          <pattern id="p" width="4" height="4" patternUnits="userSpaceOnUse">
+            <rect width="2" height="2" fill="#00ff00" />
+          </pattern>
+          <marker id="mk" markerWidth="3" markerHeight="3" refX="1" refY="1">
+            <circle cx="1" cy="1" r="1" fill="#0000ff" />
+          </marker>
+        </defs>
+        <rect width="12" height="12" fill="url(#p)" clip-path="url(#clip)" mask="url(#m)"
+              transform="translate(8, 6)" />
+        <path d="M 2 20 L 10 20 L 18 20" stroke="#000000" fill="none" marker-start="url(#mk)"
+              marker-mid="url(#mk)" marker-end="url(#mk)" />
+      </svg>
+    )svg");
+}
+
+TEST(RendererPublicApiTest, ClassNameChangeMatchesFullRender) {
+  ExpectIncrementalMatchesFullRender(
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+        <style>.a { fill: #ff0000 } .b { fill: #0000ff } .b rect { stroke: #00ff00 }</style>
+        <g id="g" class="a"><rect width="10" height="10" /></g>
+      </svg>
+    )svg",
+      [](SVGDocument& document) {
+        auto target = document.querySelector("#g");
+        ASSERT_TRUE(target.has_value());
+        target->setClassName("b");
+      },
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+        <style>.a { fill: #ff0000 } .b { fill: #0000ff } .b rect { stroke: #00ff00 }</style>
+        <g class="b"><rect width="10" height="10" /></g>
+      </svg>
+    )svg");
+}
+
+TEST(RendererPublicApiTest, StyleAttributeChangeWithInheritanceMatchesFullRender) {
+  ExpectIncrementalMatchesFullRender(
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+        <g id="g" style="fill: #ff0000"><rect width="10" height="10" /></g>
+      </svg>
+    )svg",
+      [](SVGDocument& document) {
+        auto target = document.querySelector("#g");
+        ASSERT_TRUE(target.has_value());
+        target->setStyle("fill: #0000ff; opacity: 0.5");
+      },
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+        <g style="fill: #0000ff; opacity: 0.5"><rect width="10" height="10" /></g>
+      </svg>
+    )svg");
+}
+
+TEST(RendererPublicApiTest, RemoveChildMatchesFullRender) {
+  ExpectIncrementalMatchesFullRender(
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+        <rect width="6" height="6" fill="#ff0000" />
+        <rect id="r" x="8" width="6" height="6" fill="#0000ff" />
+      </svg>
+    )svg",
+      [](SVGDocument& document) {
+        auto target = document.querySelector("#r");
+        ASSERT_TRUE(target.has_value());
+        document.svgElement().removeChild(*target);
+      },
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+        <rect width="6" height="6" fill="#ff0000" />
+      </svg>
+    )svg");
+}
+
+TEST(RendererPublicApiTest, RemoveElementUpdatesStructuralSelectorsMatchesFullRender) {
+  // Removing an element changes which of its remaining siblings match structural selectors, a
+  // dependency that no per-entity dirty flag tracks.
+  ExpectIncrementalMatchesFullRender(
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+        <style>rect { fill: #ff0000 } rect:last-child { fill: #0000ff }</style>
+        <rect width="6" height="6" />
+        <rect id="r" x="8" width="6" height="6" />
+      </svg>
+    )svg",
+      [](SVGDocument& document) {
+        auto target = document.querySelector("#r");
+        ASSERT_TRUE(target.has_value());
+        std::ignore = document.removeElement(*target);
+      },
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+        <style>rect { fill: #ff0000 } rect:last-child { fill: #0000ff }</style>
+        <rect width="6" height="6" />
+      </svg>
+    )svg");
+}
+
+TEST(RendererPublicApiTest, InsertChildUpdatesStructuralSelectorsMatchesFullRender) {
+  ExpectIncrementalMatchesFullRender(
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+        <style>rect { fill: #ff0000 } rect:last-child { fill: #0000ff }</style>
+        <rect width="6" height="6" />
+      </svg>
+    )svg",
+      [](SVGDocument& document) {
+        SVGRectElement rect = SVGRectElement::Create(document);
+        rect.setAttribute("x", "8");
+        rect.setAttribute("width", "6");
+        rect.setAttribute("height", "6");
+        document.svgElement().appendChild(rect);
+      },
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+        <style>rect { fill: #ff0000 } rect:last-child { fill: #0000ff }</style>
+        <rect width="6" height="6" />
+        <rect x="8" width="6" height="6" />
+      </svg>
+    )svg");
+}
+
+TEST(RendererPublicApiTest, UseHrefRetargetMatchesFullRender) {
+  ExpectIncrementalMatchesFullRender(
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+        <defs>
+          <rect id="a" width="8" height="8" fill="#ff0000" />
+          <circle id="b" cx="4" cy="4" r="4" fill="#0000ff" />
+        </defs>
+        <use id="u" href="#a" transform="translate(2, 2)" />
+      </svg>
+    )svg",
+      [](SVGDocument& document) {
+        auto target = document.querySelector("#u");
+        ASSERT_TRUE(target.has_value());
+        target->cast<SVGUseElement>().setHref("#b");
+      },
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+        <defs>
+          <rect id="a" width="8" height="8" fill="#ff0000" />
+          <circle id="b" cx="4" cy="4" r="4" fill="#0000ff" />
+        </defs>
+        <use href="#b" transform="translate(2, 2)" />
+      </svg>
+    )svg");
+}
+
+TEST(RendererPublicApiTest, TextContentEditMatchesFullRender) {
+  if (!ActiveRendererSupportsFeature(RendererBackendFeature::Text)) {
+    GTEST_SKIP() << "Text rendering disabled in this variant (" << ActiveRendererBackendName()
+                 << "); skipping text-edit equivalence assertion.";
+  }
+
+  ExpectIncrementalMatchesFullRender(
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="64" height="32" viewBox="0 0 64 32"
+           font-size="16">
+        <text id="t" x="4" y="20">AAA</text>
+      </svg>
+    )svg",
+      [](SVGDocument& document) {
+        auto target = document.querySelector("#t");
+        ASSERT_TRUE(target.has_value());
+        target->cast<SVGTextElement>().setTextContent("BB");
+      },
+      R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="64" height="32" viewBox="0 0 64 32"
+           font-size="16">
+        <text x="4" y="20">BB</text>
+      </svg>
+    )svg");
+}
+
+TEST(RendererPublicApiTest, TransformChangeOnAnimatedDocumentMatchesFullRender) {
+  // Animation overrides are written into the cached computed styles in place, so a document with
+  // active overrides must keep producing the same pixels as a freshly parsed equivalent even when
+  // a later mutation only touches the transform.
+  constexpr std::string_view kInitialSource = R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+        <rect id="r" width="6" height="6" fill="#ff0000" transform="translate(1, 1)">
+          <set attributeName="fill" to="#0000ff" begin="1s" dur="2s" />
+        </rect>
+      </svg>
+    )svg";
+  constexpr std::string_view kFinalSource = R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+        <rect width="6" height="6" fill="#ff0000" transform="translate(8, 7)">
+          <set attributeName="fill" to="#0000ff" begin="1s" dur="2s" />
+        </rect>
+      </svg>
+    )svg";
+
+  SVGDocument incrementalDocument = ParseDocumentWithExperimental(kInitialSource);
+  incrementalDocument.setTime(1.5);
+  Renderer incrementalRenderer;
+  incrementalRenderer.draw(incrementalDocument);
+
+  auto target = incrementalDocument.querySelector("#r");
+  ASSERT_TRUE(target.has_value());
+  target->setAttribute("transform", "translate(8, 7)");
+
+  incrementalRenderer.draw(incrementalDocument);
+  const RendererBitmap incremental = NormalizeSnapshot(incrementalRenderer.takeSnapshot());
+  ASSERT_FALSE(incremental.empty());
+
+  SVGDocument fullDocument = ParseDocumentWithExperimental(kFinalSource);
+  fullDocument.setTime(1.5);
+  Renderer fullRenderer;
+  fullRenderer.draw(fullDocument);
+  const RendererBitmap full = NormalizeSnapshot(fullRenderer.takeSnapshot());
+  ASSERT_FALSE(full.empty());
 
   EXPECT_EQ(incremental.dimensions, full.dimensions);
   EXPECT_EQ(incremental.pixels, full.pixels);


### PR DESCRIPTION
The style system's selective dirty-entity recompute shipped some time ago but was unreachable: the render path unconditionally requested a whole-tree restyle on every prepare, a deliberate hold-back protecting shadow-tree repopulation, whose freshly cloned entities carry empty computed-style placeholders that no mutation hook can flag and that downstream dereferences unconditionally. The fix addresses that cause instead of the symptom: the main shadow-tree loop marks its clones style-dirty at creation, documents with active animation overrides keep the whole-tree path since overrides mutate cached styles in place, and element removal now also requests a full restyle so sibling structural selectors re-match.

A review-found regression shaped the final design: transform attribute edits take a fast path that skips restyling, but the written attribute is a live selector input, so documents selecting on it went stale non-locally. The naive gate, any stylesheet containing an attribute selector, turns out to be always true because the user-agent stylesheet itself contains one, which would have silently forfeited the entire win; the gate is therefore keyed by attribute name, collected per stylesheet at parse time with recursion through functional pseudo-classes and safe over-approximation on namespaces, and every stylesheet load funnels through the one parse entry point that rebuilds the cache. Programmatic transform setters write no attribute and keep the fast path unconditionally.

Along the way a pre-existing bug is fixed: retargeting a use, pattern, or gradient reference removed its shadow-tree component without tearing down the cloned entities, leaving orphaned copies that continued to render under the new content.

Measured after the fix: incremental prepare drops 53 percent on Ghostscript Tiger and 66 percent on a ten-thousand-element document, first-frame prepare unchanged, and a fallback document that does select on the attribute measures at parity. Twelve mutation-class byte-identity tests pin the behavior against freshly parsed documents, each guarded against vacuous passes, plus the two review probes covering attribute-selector staleness including the non-local sibling case.

Verification: full repository suite green in the default configuration, the geode configuration green apart from the known environment-specific failure attributed byte-identically against main, lint and provenance checks green.