### PR TITLE
fix: Derive the feDropShadow shadow from its resolved input, not SourceGraphic

### DIFF
--- a/donner/svg/renderer/tests/FilterGraphExecutor_tests.cc
+++ b/donner/svg/renderer/tests/FilterGraphExecutor_tests.cc
@@ -18,6 +18,7 @@ namespace {
 using ::testing::_;
 using ::testing::AllOf;
 using ::testing::ElementsAre;
+using ::testing::ElementsAreArray;
 using ::testing::Ge;
 using ::testing::Gt;
 using ::testing::Le;
@@ -666,6 +667,177 @@ TEST(FilterGraphExecutorTest, DropShadowProducesOffsetAndBlurredCopy) {
   // The shadow center should be near (20, 20), with non-zero alpha (black shadow).
   const Pixel shadow = GetPixel(pixmap, 20, 20);
   EXPECT_THAT(shadow, Rgba(_, _, _, Gt(0)));
+}
+
+// ---------------------------------------------------------------------------
+// feDropShadow input selection
+// ---------------------------------------------------------------------------
+
+/// Fills a square of opaque white, the simplest shape whose alpha is either 255 or 0 everywhere
+/// so a shadow cast from it can be located exactly.
+void FillOpaqueSquare(tiny_skia::Pixmap& pixmap, int x, int y, int size) {
+  for (int row = y; row < y + size; ++row) {
+    for (int column = x; column < x + size; ++column) {
+      SetPixel(pixmap, column, row, Pixel{255, 255, 255, 255});
+    }
+  }
+}
+
+/// A drop shadow with no blur, so the shadow is a hard-edged copy of its input's alpha and its
+/// position can be asserted per-pixel instead of through a tolerance.
+components::filter_primitive::DropShadow SharpBlackShadow(double dx, double dy) {
+  return components::filter_primitive::DropShadow{
+      .dx = dx,
+      .dy = dy,
+      .stdDeviationX = 0.0,
+      .stdDeviationY = 0.0,
+      .floodColor = css::Color(css::RGBA(0, 0, 0, 255)),
+      .floodOpacity = 1.0,
+  };
+}
+
+// feDropShadow builds its shadow from the alpha of its own input, and an explicit `in` naming
+// an earlier result has to move the shadow with that result. A shadow cut from SourceGraphic
+// instead stays behind at the unfiltered geometry.
+TEST(FilterGraphExecutorTest, DropShadowUsesNamedInputAlphaNotSourceGraphic) {
+  auto maybePixmap = tiny_skia::Pixmap::fromSize(32, 32);
+  ASSERT_TRUE(maybePixmap.has_value());
+  tiny_skia::Pixmap pixmap = std::move(*maybePixmap);
+
+  // SourceGraphic is one opaque square covering x,y in [6, 10).
+  FillOpaqueSquare(pixmap, 6, 6, 4);
+
+  components::FilterGraph graph;
+
+  // Node 0: move the square to [18, 22) and publish it as "moved".
+  components::FilterNode offsetNode;
+  offsetNode.inputs.push_back(
+      components::FilterInput{components::FilterStandardInput::SourceGraphic});
+  offsetNode.primitive = components::filter_primitive::Offset{.dx = 12.0, .dy = 12.0};
+  offsetNode.result = RcString("moved");
+  graph.nodes.push_back(std::move(offsetNode));
+
+  // Node 1: shadow "moved", putting the shadow at [22, 26).
+  components::FilterNode shadowNode;
+  shadowNode.inputs.push_back(
+      components::FilterInput{components::FilterInput::Named{RcString("moved")}});
+  shadowNode.primitive = SharpBlackShadow(/*dx=*/4.0, /*dy=*/4.0);
+  graph.nodes.push_back(std::move(shadowNode));
+
+  ApplyFilterGraphToPixmap(pixmap, graph, Transform2d(), std::nullopt);
+
+  // The input the shadow was cut from is still merged over it.
+  EXPECT_THAT(GetPixel(pixmap, 19, 19), Rgba(255, 255, 255, 255));
+
+  // The shadow follows the named input.
+  EXPECT_THAT(GetPixel(pixmap, 23, 23), Rgba(0, 0, 0, 255));
+
+  // ... and no shadow is cast from SourceGraphic's untouched position, which is where a shadow
+  // built from SourceGraphic's alpha would have landed.
+  EXPECT_THAT(GetPixel(pixmap, 11, 11), Rgba(_, _, _, 0));
+}
+
+// The same obligation reached through the implicit input: an unspecified `in` is the preceding
+// primitive's result, so only a feDropShadow that is itself the first primitive resolves to
+// SourceGraphic.
+TEST(FilterGraphExecutorTest, DropShadowUsesPrecedingResultAlphaWhenInputIsImplicit) {
+  auto maybePixmap = tiny_skia::Pixmap::fromSize(32, 32);
+  ASSERT_TRUE(maybePixmap.has_value());
+  tiny_skia::Pixmap pixmap = std::move(*maybePixmap);
+
+  FillOpaqueSquare(pixmap, 6, 6, 4);
+
+  components::FilterGraph graph;
+
+  components::FilterNode offsetNode;
+  offsetNode.inputs.push_back(
+      components::FilterInput{components::FilterStandardInput::SourceGraphic});
+  offsetNode.primitive = components::filter_primitive::Offset{.dx = 12.0, .dy = 12.0};
+  graph.nodes.push_back(std::move(offsetNode));
+
+  components::FilterNode shadowNode;
+  shadowNode.inputs.push_back(components::FilterInput{});  // Previous.
+  shadowNode.primitive = SharpBlackShadow(/*dx=*/4.0, /*dy=*/4.0);
+  graph.nodes.push_back(std::move(shadowNode));
+
+  ApplyFilterGraphToPixmap(pixmap, graph, Transform2d(), std::nullopt);
+
+  EXPECT_THAT(GetPixel(pixmap, 19, 19), Rgba(255, 255, 255, 255));
+  EXPECT_THAT(GetPixel(pixmap, 23, 23), Rgba(0, 0, 0, 255));
+  EXPECT_THAT(GetPixel(pixmap, 11, 11), Rgba(_, _, _, 0));
+}
+
+// The default case, which the two above must not disturb: a feDropShadow with no earlier
+// primitive to chain from still cuts its shadow out of SourceGraphic.
+TEST(FilterGraphExecutorTest, DropShadowWithoutAnEarlierResultShadowsSourceGraphic) {
+  auto maybePixmap = tiny_skia::Pixmap::fromSize(32, 32);
+  ASSERT_TRUE(maybePixmap.has_value());
+  tiny_skia::Pixmap pixmap = std::move(*maybePixmap);
+
+  FillOpaqueSquare(pixmap, 6, 6, 4);
+
+  components::FilterGraph graph;
+  components::FilterNode shadowNode;
+  shadowNode.inputs.push_back(components::FilterInput{});  // Previous, which is SourceGraphic here.
+  shadowNode.primitive = SharpBlackShadow(/*dx=*/4.0, /*dy=*/4.0);
+  graph.nodes.push_back(std::move(shadowNode));
+
+  ApplyFilterGraphToPixmap(pixmap, graph, Transform2d(), std::nullopt);
+
+  EXPECT_THAT(GetPixel(pixmap, 7, 7), Rgba(255, 255, 255, 255));
+  EXPECT_THAT(GetPixel(pixmap, 11, 11), Rgba(0, 0, 0, 255));
+}
+
+// On a first primitive, an explicit `in="SourceGraphic"` and an implicit input name the same
+// buffer, so the two renders have to agree byte for byte. This is the pixel-level statement that
+// reading the node's own input left that path alone.
+TEST(FilterGraphExecutorTest, DropShadowExplicitSourceGraphicMatchesImplicitInput) {
+  const auto render = [](components::FilterInput input) {
+    auto maybePixmap = tiny_skia::Pixmap::fromSize(32, 32);
+    EXPECT_TRUE(maybePixmap.has_value());
+    tiny_skia::Pixmap pixmap = std::move(*maybePixmap);
+
+    // Partial alpha and mixed colors, so a shadow that reads the wrong channel or skips a
+    // conversion shows up rather than cancelling against a flat opaque square.
+    for (int y = 4; y < 12; ++y) {
+      for (int x = 4; x < 12; ++x) {
+        const auto alpha = static_cast<std::uint8_t>(40 + (x * 9 + y * 3) % 216);
+        const auto scale = [&](int value) {
+          return static_cast<std::uint8_t>(value * alpha / 255);
+        };
+        SetPixel(pixmap, x, y, Pixel{scale(200), scale(80), scale(30), alpha});
+      }
+    }
+
+    components::FilterGraph graph;
+    components::FilterNode shadowNode;
+    shadowNode.inputs.push_back(std::move(input));
+    shadowNode.primitive = components::filter_primitive::DropShadow{
+        .dx = 3.0,
+        .dy = 2.0,
+        .stdDeviationX = 1.5,
+        .stdDeviationY = 1.5,
+        .floodColor = css::Color(css::RGBA(20, 90, 160, 255)),
+        .floodOpacity = 0.75,
+    };
+    graph.nodes.push_back(std::move(shadowNode));
+
+    ApplyFilterGraphToPixmap(pixmap, graph, Transform2d(), std::nullopt);
+    return pixmap;
+  };
+
+  const tiny_skia::Pixmap implicitInput = render(components::FilterInput{});
+  const tiny_skia::Pixmap explicitSourceGraphic =
+      render(components::FilterInput{components::FilterStandardInput::SourceGraphic});
+
+  const auto implicitData = implicitInput.data();
+  const auto explicitData = explicitSourceGraphic.data();
+  ASSERT_EQ(implicitData.size(), explicitData.size());
+  EXPECT_THAT(std::vector<std::uint8_t>(explicitData.begin(), explicitData.end()),
+              ElementsAreArray(implicitData));
+
+  // The shadow is present, so the comparison above is not two blank pixmaps agreeing.
+  EXPECT_THAT(GetPixel(implicitInput, 13, 12), Rgba(_, _, _, Gt(0)));
 }
 
 // ---------------------------------------------------------------------------

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/FilterGraph.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/FilterGraph.cpp
@@ -697,13 +697,23 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
           } else if constexpr (std::is_same_v<T, graph_primitive::DropShadow>) {
             // Decomposed into flood + composite-in + offset + blur + merge, all run in the
             // node's own interpolation space. Only the flood color needs converting, because it
-            // is authored as premultiplied sRGB; the source alpha carries no color.
+            // is authored as premultiplied sRGB; the alpha the shadow is cut from carries no
+            // color.
             auto floodBuf = createTransparentFloat(w, h);
             floodInSpace(floodBuf, primitive.r, primitive.g, primitive.b, primitive.a,
                          nodeLinearRGB);
 
+            // The shadow is the flood color masked by the alpha of this node's own input. An
+            // unspecified input is the previous primitive's result, which is SourceGraphic only
+            // for the first primitive in the filter, so reading SourceGraphic unconditionally
+            // casts a shadow of the wrong shape everywhere else in a chain.
+            //
+            // CompositeOp::In reads nothing from its second operand but the alpha channel, and
+            // neither transfer function touches alpha, so the stored pixels serve whichever
+            // space they are tagged with and no conversion pass belongs here. The merge below
+            // still asks the input for this node's space, because that layer does carry color.
             auto compositeBuf = createTransparentFloat(w, h);
-            composite(floodBuf, getSourceAlpha()->spaceAgnostic(), compositeBuf, CompositeOp::In);
+            composite(floodBuf, input->spaceAgnostic(), compositeBuf, CompositeOp::In);
 
             auto offsetBuf = createTransparentFloat(w, h);
             filter::offset(compositeBuf, offsetBuf, primitive.dx, primitive.dy);


### PR DESCRIPTION
feDropShadow built its shadow silhouette from SourceGraphic's alpha unconditionally, ignoring the primitive's resolved input. Per the Filter Effects spec, the shadow derives from the primitive's input: the preceding primitive's result when `in` is unspecified, and SourceGraphic only when explicitly named or when the primitive is first in the chain. Any feDropShadow that was not first in a filter chain, or that named a different input, cast a wrong-shaped shadow.

The fix is one functional line in the filter graph builder: composite the flood color against the resolved input's alpha (`input->spaceAgnostic()`) instead of the source graphic's alpha.

Coverage, all in `filter_graph_executor_tests` (red before the fix, green after):

- A named-`in` case where the shadow must track the named input, not SourceGraphic.
- An implicit-input chained case: an unspecified `in` resolves to the preceding primitive's result, so only a first-position feDropShadow reads SourceGraphic.
- A first-primitive byte-identity case: explicit `in="SourceGraphic"` and an unspecified input on the first primitive name the same buffer, so existing single-primitive documents are unchanged.

The full rasterization corpus sweep is byte-identical before and after this change. That is a no-regression result, not evidence of no behavior change: the corpus happens to contain no exercised chained or named-`in` drop shadow. The real behavior change is that chained `drop-shadow()` filters now composite each shadow against the preceding result per spec; the new tests carry that coverage.

Verified at the rebased head: `filter_graph_executor_tests` green (39 cases), lint clean, clang-format 18/19 clean.
