### PR TITLE
fix: Keep non-batched fills on resident uniforms, sourcing instance records only for batched draws

### DIFF
--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -2119,8 +2119,16 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     return slab;
   }
 
-  /// Ensure `slot` has a record-slab slot on the current device's slab.
-  void ensureRecordSlot(geode::GeodeResidentSlot& slot, Registry& registry) {
+  /// Ensure `slot` has a record-slab slot on the current device's slab, and
+  /// report whether it now has one.
+  ///
+  /// Only a draw that can join a cross-entity batch needs a record: every
+  /// other draw takes its paint from the uniform and binds the device's
+  /// shared identity record. Allocating from here rather than from the
+  /// residence getters keeps the slab (and its buffer creations, its
+  /// per-entity slots and its deferred frees) entirely out of a document
+  /// that never batches.
+  bool ensureRecordSlot(geode::GeodeResidentSlot& slot, Registry& registry) {
     std::shared_ptr<geode::GeodeRecordSlab> slab = recordSlab(registry);
     if (slot.recordSlab.get() != slab.get()) {
       // Device change: the old slab is retired with the registry-context
@@ -2132,6 +2140,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     if (!slot.recordSlot.buffer) {
       (void)slot.recordSlab->allocateSlot(*device, slot.recordSlot);
     }
+    return static_cast<bool>(slot.recordSlot.buffer);
   }
 
   std::shared_ptr<geode::GeodeResidentSlab> residentSlab(Registry& registry) {
@@ -2170,7 +2179,6 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       slot.reset();
     }
     slot.slab = std::move(slab);
-    ensureRecordSlot(slot, *source.registry());
     return &slot;
   }
 
@@ -2187,7 +2195,6 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       slot.reset();
     }
     slot.slab = std::move(slab);
-    ensureRecordSlot(slot, *source.registry());
     return &slot;
   }
 
@@ -2418,7 +2425,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
   ///
   /// \p path is retained until the batch flushes, so it must be storage that outlives this
   /// call - see `PendingBatch::path`.
-  bool tryAppendOrStartBatch(const Registry* sourceRegistry, Entity sourceEntity, const Path& path,
+  bool tryAppendOrStartBatch(Registry* sourceRegistry, Entity sourceEntity, const Path& path,
                              const css::RGBA& color, FillRule rule,
                              const geode::EncodedPath* encoded,
                              geode::GeodeResidentSlot* residentFillSlot) {
@@ -2443,17 +2450,25 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     // ordered batching and are already exact for repeated draws.
     const geode::GeodeRecordSlab::Slot* recordSlotPtr = nullptr;
     const uint64_t clipVersion = encoder->clipStateVersion();
-    // Ordered cross-entity batching is gated off while the marker /
-    // scissor-clip edge cases are resolved (markers show one-pixel AA-tip
-    // diffs when batched draws defer past a scissor change):
-    // the machinery below stays in place for the follow-up.
+    // `kEnableSceneBatching` keeps ordered cross-entity batching off by
+    // default: it is a behavior-visible rendering change that is being
+    // rolled out separately from the machinery, and every gate below still
+    // has to hold before a draw can join a batch. With the flag off the
+    // predicate folds away at compile time, so no draw allocates a record
+    // slot, writes a record, or touches the record slab.
+    //
+    // The record-slab slot is allocated HERE, on the eligibility path,
+    // rather than when the residence slot is created: a draw that can never
+    // batch takes its paint from the uniform and binds the device's shared
+    // identity record, so giving it a slot would be pure cost.
     const bool sceneEligible = kEnableSceneBatching && residentFillSlot != nullptr &&
                                encoded != nullptr &&
-                               residentFillSlot->recordSlot.buffer &&
                                !encoder->hasActiveClipState() &&
                                !encoder->hasActiveScissor() &&
                                residentFillSlot->lastSceneFrame != currentFrameIndex &&
                                residentFillSlot->lastResidentFrame != currentFrameIndex &&
+                               sourceRegistry != nullptr &&
+                               ensureRecordSlot(*residentFillSlot, *sourceRegistry) &&
                                resolveSceneRecordSlot(*residentFillSlot, recordSlotPtr);
     if (sceneEligible &&
         encoder->ensureResidentSceneRecord(*residentFillSlot, *encoded, color, rule,

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -2536,10 +2536,10 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
         // first scene use this frame, or a fresh temporary slot when it
         // was already batched earlier this frame (its primary record is
         // referenced by that earlier batch and must not be overwritten).
-        // The pending singleton reached the batcher without being scene
-        // eligible itself, so its slot may still be holding a record slot
-        // from a slab this device does not own (another device rendered the
-        // document in between). Re-ensure before resolving.
+        // The singleton reached the batcher without being scene eligible
+        // itself, so it may still hold a slot from a slab this device does
+        // not own (another device rendered the document in between): ensure
+        // it against the current slab before resolving.
         const geode::GeodeRecordSlab::Slot* firstRecordSlotPtr = nullptr;
         if (first.slot != nullptr && first.encoded != nullptr &&
             pendingBatch->sourceRegistry != nullptr &&

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -2328,6 +2328,11 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       binding.firstRecordOffset = batch.sceneFirstRecordOffset;
       binding.instanceCount = static_cast<uint32_t>(batch.sceneInstances.size());
       binding.vertexCount = batch.sceneVertexCount;
+      // Every instance's record lives in this batch's record buffer, so the
+      // first instance's slab owns the batch uniform too.
+      binding.recordSlab = batch.sceneInstances.front().slot != nullptr
+                               ? batch.sceneInstances.front().slot->recordSlab.get()
+                               : nullptr;
 
       const css::RGBA batchColor = batch.sceneInstances.front().color;
       const FillRule batchRule = batch.sceneInstances.front().rule;

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1921,7 +1921,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     /// document (the icon-atlas pass) has to compare this too - otherwise a
     /// second document's identically-numbered entity extends the first
     /// document's batch and is drawn with the first document's geometry.
-    const Registry* sourceRegistry = nullptr;
+    Registry* sourceRegistry = nullptr;
     Entity sourceEntity = entt::null;
     css::RGBA color;
     FillRule rule = FillRule::NonZero;
@@ -2402,7 +2402,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
 
   /// Start a fresh size-1 same-entity batch holding the current draw.
   /// The caller has already flushed any previous pending batch.
-  void startSameEntitySingleton(const Registry* sourceRegistry, Entity sourceEntity,
+  void startSameEntitySingleton(Registry* sourceRegistry, Entity sourceEntity,
                                 const Path& path, const css::RGBA& color, FillRule rule,
                                 const geode::EncodedPath* encoded,
                                 geode::GeodeResidentSlot* residentFillSlot) {
@@ -2536,8 +2536,14 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
         // first scene use this frame, or a fresh temporary slot when it
         // was already batched earlier this frame (its primary record is
         // referenced by that earlier batch and must not be overwritten).
+        // The pending singleton reached the batcher without being scene
+        // eligible itself, so its slot may still be holding a record slot
+        // from a slab this device does not own (another device rendered the
+        // document in between). Re-ensure before resolving.
         const geode::GeodeRecordSlab::Slot* firstRecordSlotPtr = nullptr;
-        if (first.slot != nullptr && first.encoded != nullptr && first.slot->recordSlot.buffer &&
+        if (first.slot != nullptr && first.encoded != nullptr &&
+            pendingBatch->sourceRegistry != nullptr &&
+            ensureRecordSlot(*first.slot, *pendingBatch->sourceRegistry) &&
             resolveSceneRecordSlot(*first.slot, firstRecordSlotPtr) &&
             encoder->ensureResidentSceneRecord(*first.slot, *first.encoded, first.color,
                                                first.rule, first.deviceFromLocal,

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <iterator>
 #include <vector>
 
 #include "donner/svg/renderer/geode/GeodeBufferPool.h"
@@ -81,8 +82,38 @@ struct alignas(16) Uniforms {
   // batch-uniform rather than per-instance. Stored as `vec4f[4]`
   // (vec4 = xyz + pad) so the WGSL side reads `array<vec4f, 4>` directly.
   float clipPolygonPlanes[16];  // 160 .. 224 (4 edges × vec4)
+
+  // Draw-level copy of the per-instance paint / geometry parameters. Every
+  // draw whose instances share one paint and one encoded path reads these
+  // instead of a record, so it binds the device's shared identity record and
+  // writes no record storage at all. `copyRecordParamsToUniform` fills them
+  // from the record the same draw would have written, so the two forms stay
+  // bit-identical by construction.
+  float color[4];                // 224 .. 240 - premultiplied
+  uint32_t fillRule;             // 240 .. 244
+  uint32_t paintMode;            // 244 .. 248
+  float patternOpacity;          // 248 .. 252
+  uint32_t _pad2;                // 252 .. 256
+  float gridYBase;               // 256 .. 260
+  float gridHStride;             // 260 .. 264
+  uint32_t gridHBandCount;       // 264 .. 268
+  float gridXBase;               // 268 .. 272
+  float gridVStride;             // 272 .. 276
+  uint32_t gridVBandCount;       // 276 .. 280
+  uint32_t boundingVertexCount;  // 280 .. 284
+  uint32_t _gridPad0;            // 284 .. 288
+  uint32_t bandBase;             // 288 .. 292
+  uint32_t curveBase;            // 292 .. 296
+  uint32_t vBandBase;            // 296 .. 300
+  uint32_t vCurveBase;           // 300 .. 304
+  uint32_t hGridBase;            // 304 .. 308
+  uint32_t vGridBase;            // 308 .. 312
+  uint32_t hRefsBase;            // 312 .. 316
+  uint32_t vRefsBase;            // 316 .. 320
+  // Two path-space vec2 vertices per vec4, up to eight vertices.
+  float boundingVertices[16];  // 320 .. 384
 };
-static_assert(sizeof(Uniforms) == 224, "Uniforms struct layout mismatch");
+static_assert(sizeof(Uniforms) == 384, "Uniforms struct layout mismatch");
 
 /// Write the 4x4 identity matrix in column-major order.
 void writeIdentityMvp(float* out16) {
@@ -232,6 +263,39 @@ void writeBoundingPolygonUniforms(UniformT& uniforms, const EncodedPath& encoded
     uniforms.boundingVertices[i * 2u] = encoded.boundingVertices[i].x;
     uniforms.boundingVertices[i * 2u + 1u] = encoded.boundingVertices[i].y;
   }
+}
+
+/// Mirror a record's paint / geometry parameters into the draw-level
+/// uniform. Called for every draw whose instances share one paint and one
+/// encoded path, which is every draw except a cross-entity batch: the
+/// shader's shared-paint entry points read the uniform copy and the draw
+/// binds no record of its own.
+void copyRecordParamsToUniform(Uniforms& u, const InstanceRecord& r) {
+  u.color[0] = r.color[0];
+  u.color[1] = r.color[1];
+  u.color[2] = r.color[2];
+  u.color[3] = r.color[3];
+  u.fillRule = r.fillRule;
+  u.paintMode = r.paintMode;
+  u.patternOpacity = r.patternOpacity;
+  u.gridYBase = r.gridYBase;
+  u.gridHStride = r.gridHStride;
+  u.gridHBandCount = r.gridHBandCount;
+  u.gridXBase = r.gridXBase;
+  u.gridVStride = r.gridVStride;
+  u.gridVBandCount = r.gridVBandCount;
+  u.boundingVertexCount = r.boundingVertexCount;
+  for (size_t i = 0; i < std::size(u.boundingVertices); ++i) {
+    u.boundingVertices[i] = r.boundingVertices[i];
+  }
+  u.bandBase = r.bandBase;
+  u.curveBase = r.curveBase;
+  u.vBandBase = r.vBandBase;
+  u.vCurveBase = r.vCurveBase;
+  u.hGridBase = r.hGridBase;
+  u.vGridBase = r.vGridBase;
+  u.hRefsBase = r.hRefsBase;
+  u.vRefsBase = r.vRefsBase;
 }
 
 /// Gradient kind values shared with `shaders/slug_gradient.wgsl`.
@@ -854,7 +918,7 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
 
   /// Track which pipeline is currently bound so we can emit `SetPipeline`
   /// only when it actually changes.
-  enum class BoundPipeline { kNone, kSolid, kGradient, kImage };
+  enum class BoundPipeline { kNone, kSolid, kSolidBatched, kGradient, kImage };
   BoundPipeline currentPipeline = BoundPipeline::kNone;
   // Kept for backward compat with the gradient binding flag - see
   // bindGradientPipeline below.
@@ -864,6 +928,19 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
       pass.get().setPipeline(pipeline->pipeline());
       device->countPipelineSwitch();
       currentPipeline = BoundPipeline::kSolid;
+      currentPipelineIsGradient = false;
+    }
+  }
+  /// Bind the cross-entity batch variant of the solid-fill pipeline: same
+  /// bind-group layout and same shader module, but the entry points that
+  /// read paint and geometry from each instance's record instead of from
+  /// the draw-level uniform. Only a cross-entity batch needs it, so the
+  /// pipeline object is created on first use.
+  void bindSolidBatchedPipeline() {
+    if (currentPipeline != BoundPipeline::kSolidBatched) {
+      pass.get().setPipeline(pipeline->batchedPipeline(device->device()));
+      device->countPipelineSwitch();
+      currentPipeline = BoundPipeline::kSolidBatched;
       currentPipelineIsGradient = false;
     }
   }
@@ -1689,9 +1766,14 @@ void GeoEncoder::Impl::buildResidentBindGroup(GeodeResidentSlot& slot) {
   entries[5].textureView = device->dummyClipMaskTextureView();
   entries[6].binding = 6;
   entries[6].sampler = device->dummyClipMaskSampler();
+  // A solo resident draw reads its paint from the slot's uniform, so the
+  // record binding only has to supply the vertex stage's identity transform.
+  // Binding the device's shared identity record keeps this slot out of the
+  // record slab entirely: nothing to allocate, nothing to write, and no
+  // record a same-frame repeat could overwrite.
   entries[7].binding = 7;
-  entries[7].buffer = slot.recordSlot.buffer;
-  entries[7].offset = slot.recordSlot.offset;
+  entries[7].buffer = device->identityInstanceRecordBuffer();
+  entries[7].offset = 0;
   entries[7].size = sizeof(InstanceRecord);
   chunkEntry(8, 8);
   chunkEntry(9, 9);
@@ -1757,35 +1839,22 @@ bool GeoEncoder::Impl::ensureResidentSceneRecordImpl(GeodeResidentSlot& slot,
     return false;
   }
 
-  // Rewrite the batch uniform and the instance record only when they
-  // actually changed. A static re-render (same viewport, same paint)
-  // produces byte-identical bytes, so both writes are skipped entirely
-  // and the frame emits zero buffer writes. Two forms exist:
-  //   - Solo (bakeTransform): uniforms.mvp carries the full
-  //     deviceFromLocal transform (double precision on the host, exactly
-  //     like the per-frame arena path) and the record's transform stays
-  //     identity.
-  //   - Scene batch (orthographic uniform): uniforms.mvp is the
-  //     orthographic mapping and the record carries the caller's
-  //     per-instance transform, so one uniform serves every instance.
-  // The slot's uniform region belongs exclusively to the solo resident
-  // draw: scene batches bind a per-batch arena uniform instead, so the
-  // scene form must not write it. Buffer writes are queue-ordered ahead
-  // of every draw in the frame's single submit, so a scene-form write
-  // after a recorded solo draw would retroactively change that draw's
-  // uniform (last write wins at submit time).
-  if (bakeTransform) {
-    Uniforms u = {};
-    populateBatchUniform(u, args, transform, /*identityMvp=*/false);
-    const auto* uBytes = reinterpret_cast<const uint8_t*>(&u);
-    if (slot.lastUniform.size() != sizeof(Uniforms) ||
-        std::memcmp(slot.lastUniform.data(), uBytes, sizeof(Uniforms)) != 0) {
-      device->queue().writeBuffer(slot.buffer, slot.uniform.offset, &u, sizeof(Uniforms));
-      device->countBufferWrite(sizeof(Uniforms));
-      slot.lastUniform.assign(uBytes, uBytes + sizeof(Uniforms));
-    }
-  }
-
+  // The parameters are always computed in record form, so the solo and the
+  // batch draw stay bit-identical by construction; only where they are
+  // published differs.
+  //   - Solo (bakeTransform): uniforms.mvp carries the full deviceFromLocal
+  //     transform (double precision on the host, exactly like the per-frame
+  //     arena path) and the parameters are mirrored into the slot's uniform.
+  //     No record is written and none is allocated: the draw binds the
+  //     device's shared identity record and reads its paint from the
+  //     uniform, so a same-frame repeat of this entity can never overwrite
+  //     an already-recorded draw's parameters.
+  //   - Scene batch (orthographic uniform): uniforms.mvp is the orthographic
+  //     mapping and the record carries the caller's per-instance transform,
+  //     so one uniform serves every instance and the parameters must live
+  //     per instance.
+  // Either way the write is skipped when the bytes are unchanged, so a
+  // static re-render emits zero buffer writes.
   InstanceRecord record = {};
   populateInstanceRecord(
       record, encoded, args,
@@ -1802,6 +1871,27 @@ bool GeoEncoder::Impl::ensureResidentSceneRecordImpl(GeodeResidentSlot& slot,
   record.vGridBase = static_cast<uint32_t>(slot.vGrid.offset / sizeof(uint32_t));
   record.hRefsBase = static_cast<uint32_t>(slot.hRefs.offset / sizeof(uint32_t));
   record.vRefsBase = static_cast<uint32_t>(slot.vRefs.offset / sizeof(uint32_t));
+
+  if (bakeTransform) {
+    // The slot's uniform region belongs exclusively to the solo resident
+    // draw: scene batches bind a per-batch arena uniform instead, so the
+    // scene form must not write it. Buffer writes are queue-ordered ahead
+    // of every draw in the frame's single submit, so a scene-form write
+    // after a recorded solo draw would retroactively change that draw's
+    // uniform (last write wins at submit time).
+    Uniforms u = {};
+    populateBatchUniform(u, args, transform, /*identityMvp=*/false);
+    copyRecordParamsToUniform(u, record);
+    const auto* uBytes = reinterpret_cast<const uint8_t*>(&u);
+    if (slot.lastUniform.size() != sizeof(Uniforms) ||
+        std::memcmp(slot.lastUniform.data(), uBytes, sizeof(Uniforms)) != 0) {
+      device->queue().writeBuffer(slot.buffer, slot.uniform.offset, &u, sizeof(Uniforms));
+      device->countBufferWrite(sizeof(Uniforms));
+      slot.lastUniform.assign(uBytes, uBytes + sizeof(Uniforms));
+    }
+    return true;
+  }
+
   const auto* rBytes = reinterpret_cast<const uint8_t*>(&record);
   const GeodeRecordSlab::Slot& recordSlot =
       recordSlotOverride != nullptr ? *recordSlotOverride : slot.recordSlot;
@@ -1866,15 +1956,13 @@ void GeoEncoder::fillPathResident(GeodeResidentSlot& slot, const EncodedPath& en
   // from a DIFFERENT device that previously rendered this document is not a
   // same-frame repeat and must re-upload (submitResidentFillDraw re-uploads
   // on the device-id mismatch) rather than fall back.
-  // owningDeviceId == 0 also gates: an in-place stroke rebuild resets the
-  // slot mid-frame (clearing the device id) while lastResidentFrame
-  // survives, and the slot keeps its persistent record slot across
-  // re-uploads. Without this, every rebuilt repeat re-enters the resident
-  // path and rewrites the ONE record that all previously recorded draws of
-  // this slot read at submit time (last write wins: repeated styled <use>
-  // strokes all rendered the final style). A never-drawn slot also has id
-  // 0 but its lastResidentFrame sentinel can never equal a real frameId.
-  if ((slot.owningDeviceId == impl_->device->deviceId() || slot.owningDeviceId == 0) &&
+  // A repeat whose slot was re-uploaded mid-frame (an in-place stroke
+  // rebuild clears the device id) is NOT gated here: the re-upload took a
+  // fresh slab range with its own uniform region, and a solo resident draw
+  // publishes its paint through that uniform rather than through a shared
+  // per-entity record, so the earlier recorded draw of this slot keeps its
+  // own parameters at submit time.
+  if (slot.owningDeviceId == impl_->device->deviceId() &&
       (slot.lastResidentFrame == frameId || slot.lastSceneFrame == frameId)) {
     submitFillDraw(args);
     return;
@@ -1961,7 +2049,7 @@ void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,
     return;
   }
   impl_->ensurePassOpen();
-  impl_->bindSolidPipeline();
+  impl_->bindSolidBatchedPipeline();
 
   // Batch-level uniform: orthographic mapping only (the caller set the
   // encoder transform to identity). Pattern/clip fields use the device
@@ -2165,16 +2253,22 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args,
   record.hRefsBase = static_cast<uint32_t>((hRefsAlloc.offset - gridSpanStart) / sizeof(uint32_t));
   record.vRefsBase = static_cast<uint32_t>((vRefsAlloc.offset - gridSpanStart) / sizeof(uint32_t));
 
+  // Every instance of this draw shares one paint and one encoded path, so
+  // the parameters ride in the uniform and the fragment stage reads no
+  // record at all.
+  copyRecordParamsToUniform(u, record);
+
   const auto uniAlloc =
       impl_->allocInArena(impl_->uniformArena, &u, sizeof(Uniforms), kUniformOffsetAlignment);
 
-  // One record for single draws; the instanced path copies the base record
-  // and overwrites each copy's transform so every instance still shares the
-  // same geometry bases computed above. Instanced records carry the
-  // HOST-COMPOSED orthographic transform (double precision), and the
-  // uniform mvp becomes the identity matrix, so the vertex stage's
-  // float32 multiply is exact and rotated instances (markers) match the
-  // solo path's host-composed bake.
+  // The instanced path copies the base record and overwrites each copy's
+  // transform so every instance still shares the geometry bases computed
+  // above. Instanced records carry the HOST-COMPOSED orthographic transform
+  // (double precision), and the uniform mvp becomes the identity matrix, so
+  // the vertex stage's float32 multiply is exact and rotated instances
+  // (markers) match the solo path's host-composed bake. A single draw needs
+  // no record of its own: its transform is baked into uniforms.mvp, so it
+  // binds the device's shared identity record and writes nothing.
   wgpu::Buffer recordBuf;
   uint64_t recordOffset = 0;
   uint64_t recordSize = 0;
@@ -2211,12 +2305,9 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args,
     }
   }
   if (!recordBuf) {
-    const auto recordAlloc =
-        impl_->allocInArena(impl_->instanceRecordArena, &record, sizeof(InstanceRecord),
-                            kStorageOffsetAlignment);
-    recordBuf = recordAlloc.buffer;
-    recordOffset = recordAlloc.offset;
-    recordSize = recordAlloc.size;
+    recordBuf = impl_->device->identityInstanceRecordBuffer();
+    recordOffset = 0;
+    recordSize = sizeof(InstanceRecord);
   }
 
   // 3. Bind group - eleven entries: uniforms, H bands SSBO, H curves SSBO,

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -2069,9 +2069,20 @@ void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,
   args.patternFromPath = Transform2d();
   args.instanceCount = binding.instanceCount;
 
+  // Batch uniforms are frame-constant, so they live in the document's
+  // record slab and a steady frame rewrites nothing. The per-frame arena is
+  // the fallback when no slab is supplied or its cache is full.
   Uniforms u = {};
   impl_->populateBatchUniform(u, args, Transform2d(), /*identityMvp=*/true);
-  const auto uniAlloc = impl_->allocSceneBatchUniform(u);
+  Impl::Allocation uniAlloc = {};
+  if (binding.recordSlab != nullptr) {
+    uniAlloc.buffer = binding.recordSlab->acquireBatchUniform(*impl_->device, &u, sizeof(Uniforms));
+    uniAlloc.offset = 0;
+    uniAlloc.size = sizeof(Uniforms);
+  }
+  if (!uniAlloc.buffer) {
+    uniAlloc = impl_->allocSceneBatchUniform(u);
+  }
 
   // Whole-chunk views: valid while a chunk stays under the device's
   // maxStorageBufferBindingSize (default 128 MiB); kInitialChunkBytes

--- a/donner/svg/renderer/geode/GeoEncoder.h
+++ b/donner/svg/renderer/geode/GeoEncoder.h
@@ -586,6 +586,10 @@ public:
     uint64_t firstRecordOffset = 0;
     uint32_t instanceCount = 1;
     uint32_t vertexCount = 0;   ///< Max fan vertex count over the instances.
+    /// Record slab the instances' records live in. Supplies the persistent
+    /// batch-uniform buffer so a steady frame writes nothing; null falls
+    /// back to the encoder's per-frame uniform arena.
+    GeodeRecordSlab* recordSlab = nullptr;
   };
 
   /**

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -185,9 +185,9 @@ struct GeodeDevice::Impl {
 
   // 1-element instance-transform buffer bound by every
   // non-instanced solid fill. Uploaded once at CreateHeadless time,
-  // never modified. Layout matches the WGSL `InstanceTransform`
-  // struct: two vec4f rows carrying the identity affine
-  // `{(1,0,0,0), (0,1,0,0)}`.
+  // never modified. Layout matches the WGSL `InstanceRecord` struct, whose
+  // leading member is a row-major affine as two vec4f rows carrying the
+  // identity `{(1,0,0,0), (0,1,0,0)}` followed by zeroes.
   ScopedWgpuHandle<wgpu::Buffer> identityInstanceRecordBuffer;
 
   // Shared render / compute pipelines. Constructed once per GeodeDevice
@@ -876,14 +876,13 @@ void GeodeDevice::initSharedResources() {
   }
 
   {
-    // One full-size record: the identity affine in the leading two rows,
-    // zeroes everywhere else. Sized to the WGSL `InstanceRecord` stride so
-    // it satisfies the binding's minimum size, and so a draw that binds it
-    // reads an identity transform for instance 0.
-    // 256 bytes: the WGSL `InstanceRecord` stride, which is also the
-    // baseline `minStorageBufferOffsetAlignment`. `GeodeResidentPathComponent.h`
-    // owns the struct and static_asserts the same size, but it includes this
-    // header, so the constant is spelled out here rather than included back.
+    // One full-size record: the identity affine in the leading two rows and
+    // zeroes everywhere else, so a draw that binds it reads an identity
+    // transform for instance 0. 256 bytes is the WGSL `InstanceRecord`
+    // stride and the baseline `minStorageBufferOffsetAlignment`;
+    // `GeodeResidentPathComponent.h` owns the struct and static_asserts the
+    // same size, but it includes this header, so the constant is spelled out
+    // here rather than included back.
     constexpr size_t kInstanceRecordFloats = 256 / sizeof(float);
     float identityRecord[kInstanceRecordFloats] = {};
     identityRecord[0] = 1.0f;

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -162,7 +162,7 @@ struct GeodeDevice::Impl {
   ~Impl() {
     DestroyResourceBacking(dummyPatternTexture);
     DestroyResourceBacking(dummyClipMaskTexture);
-    DestroyResourceBacking(identityInstanceTransformBuffer);
+    DestroyResourceBacking(identityInstanceRecordBuffer);
     for (auto& [unusedKey, entry] : snapshotReadbackPool) {
       (void)unusedKey;
       DestroyResourceBacking(entry.resources.staging);
@@ -188,7 +188,7 @@ struct GeodeDevice::Impl {
   // never modified. Layout matches the WGSL `InstanceTransform`
   // struct: two vec4f rows carrying the identity affine
   // `{(1,0,0,0), (0,1,0,0)}`.
-  ScopedWgpuHandle<wgpu::Buffer> identityInstanceTransformBuffer;
+  ScopedWgpuHandle<wgpu::Buffer> identityInstanceRecordBuffer;
 
   // Shared render / compute pipelines. Constructed once per GeodeDevice
   // in `initSharedPipelines` - see the public `pipeline()` / ... / `filterEngine()`
@@ -622,8 +622,8 @@ const wgpu::TextureView& GeodeDevice::dummyClipMaskTextureView() const {
 const wgpu::Sampler& GeodeDevice::dummyClipMaskSampler() const {
   return impl_->dummyClipMaskSampler.get();
 }
-const wgpu::Buffer& GeodeDevice::identityInstanceTransformBuffer() const {
-  return impl_->identityInstanceTransformBuffer.get();
+const wgpu::Buffer& GeodeDevice::identityInstanceRecordBuffer() const {
+  return impl_->identityInstanceRecordBuffer.get();
 }
 
 GeodePipeline& GeodeDevice::pipeline() const {
@@ -876,15 +876,25 @@ void GeodeDevice::initSharedResources() {
   }
 
   {
-    const float identity[8] = {
-        1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f,
-    };
+    // One full-size record: the identity affine in the leading two rows,
+    // zeroes everywhere else. Sized to the WGSL `InstanceRecord` stride so
+    // it satisfies the binding's minimum size, and so a draw that binds it
+    // reads an identity transform for instance 0.
+    // 256 bytes: the WGSL `InstanceRecord` stride, which is also the
+    // baseline `minStorageBufferOffsetAlignment`. `GeodeResidentPathComponent.h`
+    // owns the struct and static_asserts the same size, but it includes this
+    // header, so the constant is spelled out here rather than included back.
+    constexpr size_t kInstanceRecordFloats = 256 / sizeof(float);
+    float identityRecord[kInstanceRecordFloats] = {};
+    identityRecord[0] = 1.0f;
+    identityRecord[5] = 1.0f;
     wgpu::BufferDescriptor bd = {};
-    bd.label = wgpu::StringView{std::string_view{"GeodeDeviceIdentityInstanceTransform"}};
-    bd.size = sizeof(identity);
+    bd.label = wgpu::StringView{std::string_view{"GeodeDeviceIdentityInstanceRecord"}};
+    bd.size = sizeof(identityRecord);
     bd.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopyDst;
-    impl_->identityInstanceTransformBuffer.reset(device_.createBuffer(bd));
-    queue_.writeBuffer(impl_->identityInstanceTransformBuffer.get(), 0, identity, sizeof(identity));
+    impl_->identityInstanceRecordBuffer.reset(device_.createBuffer(bd));
+    queue_.writeBuffer(impl_->identityInstanceRecordBuffer.get(), 0, identityRecord,
+                       sizeof(identityRecord));
   }
 }
 

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -503,17 +503,19 @@ public:
   /// Linear-ClampToEdge sampler used for both the dummy and real clip masks.
   const wgpu::Sampler& dummyClipMaskSampler() const;
 
-  /// One-element instance-transform storage buffer carrying the identity
-  /// affine. Bound at binding 7 of the Slug fill bind-group layout by
-  /// every non-instanced solid fill so the bind-group layout stays
-  /// stable across draw calls regardless of whether `fillPathInstanced`
-  /// is in play.
+  /// One-element instance-record storage buffer carrying the identity
+  /// affine and zeroed parameters. Bound at binding 7 of the Slug fill
+  /// bind-group layout by every draw that is not a cross-entity batch, so
+  /// the bind-group layout stays stable across draw calls and those draws
+  /// need no record storage of their own: their transform is baked into
+  /// `uniforms.mvp` and their paint rides in the uniform.
   ///
-  /// Layout mirrors the WGSL `InstanceTransform` struct in
-  /// `shaders/slug_fill.wgsl`: two `vec4f` per entry, row-major affine,
-  /// so the identity is `{(1, 0, 0, 0), (0, 1, 0, 0)}`. The `.z`
-  /// components carry the translation (0 for identity).
-  const wgpu::Buffer& identityInstanceTransformBuffer() const;
+  /// Layout mirrors the WGSL `InstanceRecord` struct in
+  /// `shaders/slug_fill.wgsl`, whose leading member is a row-major affine
+  /// as two `vec4f`, so the identity is `{(1, 0, 0, 0), (0, 1, 0, 0)}`
+  /// followed by zeroes. The `.z` components carry the translation (0 for
+  /// identity).
+  const wgpu::Buffer& identityInstanceRecordBuffer() const;
   /// @}
 
   /// @name Shared render / compute pipelines (issue #575 fix)

--- a/donner/svg/renderer/geode/GeodePipeline.cc
+++ b/donner/svg/renderer/geode/GeodePipeline.cc
@@ -102,62 +102,21 @@ GeodePipeline::GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat col
   WGPUBindGroupLayout layouts[1] = {bindGroupLayout_.get()};
   plDesc.bindGroupLayouts = layouts;
   pipelineLayout_.reset(device.createPipelineLayout(plDesc));
-  ScopedWgpuHandle<wgpu::PipelineLayout>& pipelineLayout = pipelineLayout_;
 
   // ----- Shader module -----
   shader_.reset(createSlugFillShader(device));
-  ScopedWgpuHandle<wgpu::ShaderModule>& shader = shader_;
-
-  // ----- Fragment / blending -----
-  wgpu::BlendState blend = {};
-  // Standard premultiplied-alpha source-over blending.
-  blend.color.srcFactor = wgpu::BlendFactor::One;
-  blend.color.dstFactor = wgpu::BlendFactor::OneMinusSrcAlpha;
-  blend.color.operation = wgpu::BlendOperation::Add;
-  blend.alpha.srcFactor = wgpu::BlendFactor::One;
-  blend.alpha.dstFactor = wgpu::BlendFactor::OneMinusSrcAlpha;
-  blend.alpha.operation = wgpu::BlendOperation::Add;
-
-  wgpu::ColorTargetState colorTarget = {};
-  colorTarget.format = colorFormat_;
-  colorTarget.blend = &blend;
-  colorTarget.writeMask = wgpu::ColorWriteMask::All;
-
-  wgpu::FragmentState fragmentState = {};
-  fragmentState.module = shader.get();
-  fragmentState.entryPoint = wgpuLabel("fs_main");
-  fragmentState.targetCount = 1;
-  fragmentState.targets = &colorTarget;
 
   // ----- Render pipeline -----
-  wgpu::RenderPipelineDescriptor rpDesc = {};
-  rpDesc.label = wgpuLabel("GeodeSlugFill");
-  rpDesc.layout = pipelineLayout.get();
-
-  rpDesc.vertex.module = shader.get();
-  rpDesc.vertex.entryPoint = wgpuLabel("vs_main");
-  rpDesc.vertex.bufferCount = 0;
-  rpDesc.vertex.buffers = nullptr;
-
-  rpDesc.primitive.topology = wgpu::PrimitiveTopology::TriangleList;
-  rpDesc.primitive.cullMode = wgpu::CullMode::None;
-
-  rpDesc.fragment = &fragmentState;
-  rpDesc.multisample.count = 1;
-  rpDesc.multisample.mask = 0xFFFFFFFF;
-
-  pipeline_.reset(device.createRenderPipeline(rpDesc));
+  // The default entry points take the draw's paint and geometry from the
+  // uniform, which serves every draw whose instances share one paint and one
+  // encoded path. `batchedPipeline` builds the record-reading variant.
+  pipeline_.reset(buildPipeline(device, "GeodeSlugFill", "vs_main", "fs_main"));
 }
 
-const wgpu::RenderPipeline& GeodePipeline::batchedPipeline(const wgpu::Device& device) const {
-  if (batchedPipeline_) {
-    return batchedPipeline_.get();
-  }
-
-  // Identical state to the default pipeline - same layout, same shader
-  // module, same blending - differing only in the entry points that read
-  // paint and geometry from each instance's record. Built on first use
-  // because only a cross-entity batch needs it.
+wgpu::RenderPipeline GeodePipeline::buildPipeline(const wgpu::Device& device, const char* label,
+                                                  const char* vertexEntryPoint,
+                                                  const char* fragmentEntryPoint) const {
+  // Standard premultiplied-alpha source-over blending.
   wgpu::BlendState blend = {};
   blend.color.srcFactor = wgpu::BlendFactor::One;
   blend.color.dstFactor = wgpu::BlendFactor::OneMinusSrcAlpha;
@@ -173,16 +132,16 @@ const wgpu::RenderPipeline& GeodePipeline::batchedPipeline(const wgpu::Device& d
 
   wgpu::FragmentState fragmentState = {};
   fragmentState.module = shader_.get();
-  fragmentState.entryPoint = wgpuLabel("fs_main_batched");
+  fragmentState.entryPoint = wgpuLabel(fragmentEntryPoint);
   fragmentState.targetCount = 1;
   fragmentState.targets = &colorTarget;
 
   wgpu::RenderPipelineDescriptor rpDesc = {};
-  rpDesc.label = wgpuLabel("GeodeSlugFillBatched");
+  rpDesc.label = wgpuLabel(label);
   rpDesc.layout = pipelineLayout_.get();
 
   rpDesc.vertex.module = shader_.get();
-  rpDesc.vertex.entryPoint = wgpuLabel("vs_main_batched");
+  rpDesc.vertex.entryPoint = wgpuLabel(vertexEntryPoint);
   rpDesc.vertex.bufferCount = 0;
   rpDesc.vertex.buffers = nullptr;
 
@@ -193,7 +152,18 @@ const wgpu::RenderPipeline& GeodePipeline::batchedPipeline(const wgpu::Device& d
   rpDesc.multisample.count = 1;
   rpDesc.multisample.mask = 0xFFFFFFFF;
 
-  batchedPipeline_.reset(device.createRenderPipeline(rpDesc));
+  return device.createRenderPipeline(rpDesc);
+}
+
+const wgpu::RenderPipeline& GeodePipeline::batchedPipeline(const wgpu::Device& device) const {
+  if (!batchedPipeline_) {
+    // Identical state to the default pipeline - same layout, same shader
+    // module, same blending - differing only in the entry points that read
+    // paint and geometry from each instance's record. Built on first use
+    // because only a cross-entity batch needs it.
+    batchedPipeline_.reset(
+        buildPipeline(device, "GeodeSlugFillBatched", "vs_main_batched", "fs_main_batched"));
+  }
   return batchedPipeline_.get();
 }
 

--- a/donner/svg/renderer/geode/GeodePipeline.cc
+++ b/donner/svg/renderer/geode/GeodePipeline.cc
@@ -101,10 +101,12 @@ GeodePipeline::GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat col
   plDesc.bindGroupLayoutCount = 1;
   WGPUBindGroupLayout layouts[1] = {bindGroupLayout_.get()};
   plDesc.bindGroupLayouts = layouts;
-  ScopedWgpuHandle<wgpu::PipelineLayout> pipelineLayout(device.createPipelineLayout(plDesc));
+  pipelineLayout_.reset(device.createPipelineLayout(plDesc));
+  ScopedWgpuHandle<wgpu::PipelineLayout>& pipelineLayout = pipelineLayout_;
 
   // ----- Shader module -----
-  ScopedWgpuHandle<wgpu::ShaderModule> shader(createSlugFillShader(device));
+  shader_.reset(createSlugFillShader(device));
+  ScopedWgpuHandle<wgpu::ShaderModule>& shader = shader_;
 
   // ----- Fragment / blending -----
   wgpu::BlendState blend = {};
@@ -145,6 +147,54 @@ GeodePipeline::GeodePipeline(const wgpu::Device& device, wgpu::TextureFormat col
   rpDesc.multisample.mask = 0xFFFFFFFF;
 
   pipeline_.reset(device.createRenderPipeline(rpDesc));
+}
+
+const wgpu::RenderPipeline& GeodePipeline::batchedPipeline(const wgpu::Device& device) const {
+  if (batchedPipeline_) {
+    return batchedPipeline_.get();
+  }
+
+  // Identical state to the default pipeline - same layout, same shader
+  // module, same blending - differing only in the entry points that read
+  // paint and geometry from each instance's record. Built on first use
+  // because only a cross-entity batch needs it.
+  wgpu::BlendState blend = {};
+  blend.color.srcFactor = wgpu::BlendFactor::One;
+  blend.color.dstFactor = wgpu::BlendFactor::OneMinusSrcAlpha;
+  blend.color.operation = wgpu::BlendOperation::Add;
+  blend.alpha.srcFactor = wgpu::BlendFactor::One;
+  blend.alpha.dstFactor = wgpu::BlendFactor::OneMinusSrcAlpha;
+  blend.alpha.operation = wgpu::BlendOperation::Add;
+
+  wgpu::ColorTargetState colorTarget = {};
+  colorTarget.format = colorFormat_;
+  colorTarget.blend = &blend;
+  colorTarget.writeMask = wgpu::ColorWriteMask::All;
+
+  wgpu::FragmentState fragmentState = {};
+  fragmentState.module = shader_.get();
+  fragmentState.entryPoint = wgpuLabel("fs_main_batched");
+  fragmentState.targetCount = 1;
+  fragmentState.targets = &colorTarget;
+
+  wgpu::RenderPipelineDescriptor rpDesc = {};
+  rpDesc.label = wgpuLabel("GeodeSlugFillBatched");
+  rpDesc.layout = pipelineLayout_.get();
+
+  rpDesc.vertex.module = shader_.get();
+  rpDesc.vertex.entryPoint = wgpuLabel("vs_main_batched");
+  rpDesc.vertex.bufferCount = 0;
+  rpDesc.vertex.buffers = nullptr;
+
+  rpDesc.primitive.topology = wgpu::PrimitiveTopology::TriangleList;
+  rpDesc.primitive.cullMode = wgpu::CullMode::None;
+
+  rpDesc.fragment = &fragmentState;
+  rpDesc.multisample.count = 1;
+  rpDesc.multisample.mask = 0xFFFFFFFF;
+
+  batchedPipeline_.reset(device.createRenderPipeline(rpDesc));
+  return batchedPipeline_.get();
 }
 
 // ============================================================================

--- a/donner/svg/renderer/geode/GeodePipeline.h
+++ b/donner/svg/renderer/geode/GeodePipeline.h
@@ -90,7 +90,11 @@ private:
   ScopedWgpuHandle<wgpu::PipelineLayout> pipelineLayout_;
   ScopedWgpuHandle<wgpu::ShaderModule> shader_;
   ScopedWgpuHandle<wgpu::RenderPipeline> pipeline_;
-  /// Lazily compiled by @ref batchedPipeline.
+  /// Lazily compiled by @ref batchedPipeline. The `mutable` build is
+  /// deliberately unsynchronized: a device's pipelines are only ever used
+  /// from the single thread that owns rendering for that device, so two
+  /// callers cannot reach the null check at once and the lazy build cannot
+  /// race.
   mutable ScopedWgpuHandle<wgpu::RenderPipeline> batchedPipeline_;
 };
 

--- a/donner/svg/renderer/geode/GeodePipeline.h
+++ b/donner/svg/renderer/geode/GeodePipeline.h
@@ -17,8 +17,9 @@ namespace donner::geode {
  * draw call but the pipeline state object can be reused.
  *
  * The bind group layout matches the shader in `shaders/slug_fill.wgsl`:
- * - binding 0: uniform buffer (Uniforms struct: mvp, patternFromPath, viewport,
- *   tileSize, color, fillRule, paintMode, patternOpacity)
+ * - binding 0: uniform buffer (Uniforms struct: mvp, patternFromPath,
+ *   viewport, tileSize, clip state, and the draw-level copy of the paint /
+ *   geometry parameters)
  * - binding 1: storage buffer (read-only) - Band[]
  * - binding 2: storage buffer (read-only) - curve data (flat f32[])
  * - binding 3: pattern tile texture (2D, Float sampleType) - sampled only
@@ -26,10 +27,12 @@ namespace donner::geode {
  * - binding 4: pattern sampler (Filtering) - paired with binding 3.
  * - binding 5: nested clip-mask texture.
  * - binding 6: nested clip-mask sampler.
- * - binding 7: per-instance transforms.
+ * - binding 7: per-instance records. Only a cross-entity batch reads more
+ *   than the transform here; every other draw binds the device's shared
+ *   identity record.
  * - bindings 8 and 9: vertical Band[] and canonical curve data.
- * - bindings 10 and 11: horizontal and vertical dense band grids.
- * - bindings 12 and 13: horizontal and vertical curve-reference indexes.
+ * - binding 10: the four dense grid arrays in one combined storage range,
+ *   indexed through the per-draw or per-instance element bases.
  *
  * The pipeline has no vertex buffer. Its shader expands the uniform bounding polygon into a
  * triangle fan from `vertex_index` and applies the half-pixel AA halo in device space.
@@ -75,6 +78,13 @@ public:
   wgpu::TextureFormat colorFormat() const { return colorFormat_; }
 
 private:
+  /// Compile one variant of the Slug fill pipeline. Both variants share the
+  /// layout, the shader module and the blend state; only the entry points
+  /// differ.
+  wgpu::RenderPipeline buildPipeline(const wgpu::Device& device, const char* label,
+                                     const char* vertexEntryPoint,
+                                     const char* fragmentEntryPoint) const;
+
   wgpu::TextureFormat colorFormat_;
   ScopedWgpuHandle<wgpu::BindGroupLayout> bindGroupLayout_;
   ScopedWgpuHandle<wgpu::PipelineLayout> pipelineLayout_;

--- a/donner/svg/renderer/geode/GeodePipeline.h
+++ b/donner/svg/renderer/geode/GeodePipeline.h
@@ -53,10 +53,22 @@ public:
   /// Move assignment operator.
   GeodePipeline& operator=(GeodePipeline&&) noexcept = default;
 
-  /// The compiled render pipeline.
+  /// The compiled render pipeline. Its entry points take the draw's paint
+  /// and geometry parameters from the uniform, which serves every draw whose
+  /// instances share one paint and one encoded path.
   const wgpu::RenderPipeline& pipeline() const { return pipeline_.get(); }
 
-  /// The bind group layout used by the pipeline.
+  /**
+   * The cross-entity batch variant of @ref pipeline: same layout, same
+   * shader module and same blending, but the entry points that take paint
+   * and geometry from each instance's record. Compiled on first call,
+   * because only a cross-entity batch needs it.
+   *
+   * @param device The WebGPU device this pipeline was created for.
+   */
+  const wgpu::RenderPipeline& batchedPipeline(const wgpu::Device& device) const;
+
+  /// The bind group layout used by both pipelines.
   const wgpu::BindGroupLayout& bindGroupLayout() const { return bindGroupLayout_.get(); }
 
   /// Color format the pipeline was built for.
@@ -65,7 +77,11 @@ public:
 private:
   wgpu::TextureFormat colorFormat_;
   ScopedWgpuHandle<wgpu::BindGroupLayout> bindGroupLayout_;
+  ScopedWgpuHandle<wgpu::PipelineLayout> pipelineLayout_;
+  ScopedWgpuHandle<wgpu::ShaderModule> shader_;
   ScopedWgpuHandle<wgpu::RenderPipeline> pipeline_;
+  /// Lazily compiled by @ref batchedPipeline.
+  mutable ScopedWgpuHandle<wgpu::RenderPipeline> batchedPipeline_;
 };
 
 /**

--- a/donner/svg/renderer/geode/GeodeResidentPathComponent.h
+++ b/donner/svg/renderer/geode/GeodeResidentPathComponent.h
@@ -24,6 +24,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <vector>
 
@@ -181,6 +182,47 @@ public:
   /// recorded batch draws still read.
   void freeSlot(const Slot& slot) { pendingFrees_.push_back(slot.index); }
 
+  /**
+   * Persistent buffer holding one distinct scene-batch uniform value.
+   *
+   * A batch uniform is frame-constant (identity mvp plus the frame's
+   * viewport / clip / antialias state), so a steady frame finds its entry
+   * and writes nothing at all - the per-frame arena would rewrite it every
+   * frame because the arena's bytes do not survive.
+   *
+   * Entries are keyed by their exact bytes and are never rewritten, so a
+   * differing value (a second render-target size within one frame) takes a
+   * new entry and a batch already recorded this frame keeps reading its own
+   * bytes at submit time. Returns a null handle once `kMaxBatchUniforms`
+   * distinct values are live, and the caller falls back to its per-frame
+   * arena.
+   */
+  wgpu::Buffer acquireBatchUniform(GeodeDevice& device, const void* bytes, uint64_t size) {
+    const auto* first = static_cast<const uint8_t*>(bytes);
+    for (const BatchUniform& entry : batchUniforms_) {
+      if (entry.bytes.size() == size && std::memcmp(entry.bytes.data(), first, size) == 0) {
+        return entry.buffer.get();
+      }
+    }
+    if (batchUniforms_.size() >= kMaxBatchUniforms) {
+      return wgpu::Buffer();
+    }
+    wgpu::BufferDescriptor desc = {};
+    desc.label = wgpuLabel("GeodeSceneBatchUniform");
+    desc.size = size;
+    desc.usage = wgpu::BufferUsage::Uniform | wgpu::BufferUsage::CopyDst;
+    ScopedWgpuHandle<wgpu::Buffer> buffer(device.device().createBuffer(desc));
+    if (!buffer) {
+      return wgpu::Buffer();
+    }
+    device.countBuffer();
+    device.queue().writeBuffer(buffer.get(), 0, first, size);
+    device.countBufferWrite(size);
+    batchUniforms_.push_back(
+        BatchUniform{std::move(buffer), std::vector<uint8_t>(first, first + size)});
+    return batchUniforms_.back().buffer.get();
+  }
+
   /// Borrowed handle of the newest buffer (batches bind sub-ranges of it).
   wgpu::Buffer newestBuffer() const {
     return chunks_.empty() ? wgpu::Buffer() : chunks_.back().buffer.get();
@@ -204,7 +246,17 @@ private:
     uint64_t size = 0;
   };
 
+  struct BatchUniform {
+    ScopedWgpuHandle<wgpu::Buffer> buffer;
+    std::vector<uint8_t> bytes;
+  };
+
   static constexpr uint64_t kInitialRecordSlabBytes = 262144u;
+  /// Distinct live scene-batch uniform values before the caller falls back
+  /// to its per-frame arena. One value covers a document rendered at one
+  /// size; the cap bounds a pathological caller that varies the uniform per
+  /// batch.
+  static constexpr size_t kMaxBatchUniforms = 8u;
 
   Slot slotAt(uint32_t index) const {
     // Slots are never moved; walk the chunk sizes to find the owner.
@@ -224,6 +276,7 @@ private:
   std::vector<Chunk> chunks_;
   std::vector<uint32_t> freeIndices_;
   std::vector<uint32_t> pendingFrees_;
+  std::vector<BatchUniform> batchUniforms_;
 };
 
 class GeodeDevice;

--- a/donner/svg/renderer/geode/shaders/slug_fill.wgsl
+++ b/donner/svg/renderer/geode/shaders/slug_fill.wgsl
@@ -48,6 +48,34 @@ struct Uniforms {
   // Four inward-facing half-planes in viewport-pixel space, one per polygon
   // edge. `plane.xyz = (nx, ny, c)` with `nx*x + ny*y + c >= 0` inside.
   clipPolygonPlanes: array<vec4f, 4>,
+  // Draw-level copy of the paint / geometry parameters below. Every draw
+  // whose instances share ONE paint and ONE encoded path - a single fill, a
+  // repeated `<use>` of the same entity - reads these instead of a
+  // per-instance record, so it needs no record storage at all. Only a
+  // cross-entity batch, whose instances differ in paint and geometry, reads
+  // them per instance (the `_batched` entry points).
+  color: vec4f,
+  fillRule: u32,
+  paintMode: u32,
+  patternOpacity: f32,
+  _pad2: u32,
+  yBase: f32,
+  hStride: f32,
+  hBandCount: u32,
+  xBase: f32,
+  vStride: f32,
+  vBandCount: u32,
+  boundingVertexCount: u32,
+  _gridPad0: u32,
+  bandBase: u32,
+  curveBase: u32,
+  vBandBase: u32,
+  vCurveBase: u32,
+  hGridBase: u32,
+  vGridBase: u32,
+  hRefsBase: u32,
+  vRefsBase: u32,
+  boundingVertices: array<vec4f, 4>,
 };
 
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
@@ -74,10 +102,12 @@ struct Band {
 @group(0) @binding(5) var clipMaskTexture: texture_2d<f32>;
 @group(0) @binding(6) var clipMaskSampler: sampler;
 
-// Per-instance record (vertex + fragment stages). One record per draw or
-// batched instance; the fragment stage reads its instance's record through
-// a flat instance-id varying so overlapping batched instances still blend
-// in painter (instance) order.
+// Per-instance record (vertex + fragment stages). A cross-entity batch
+// binds one record per instance and reads all of it through the `_batched`
+// entry points, so overlapping instances blend in painter (instance) order.
+// Every other draw only reads `transform` here (in the vertex stage) and
+// takes the rest from the uniform, so it can bind the device's shared
+// identity record and write no record storage at all.
 struct InstanceTransform {
   row0: vec4f,
   row1: vec4f,
@@ -170,8 +200,16 @@ struct VertexOutput {
   @location(1) @interpolate(flat) instance_id: u32,
 };
 
-fn load_bounding_vertex(rec: InstanceRecord, index: u32) -> vec2f {
-  let pair = rec.boundingVertices[index / 2u];
+// Bounding polygon of the path this vertex belongs to. Built once per
+// vertex from either the uniform or the instance's record, so the dilation
+// helpers below are written once and serve both entry points.
+struct ShapeParams {
+  boundingVertexCount: u32,
+  boundingVertices: array<vec4f, 4>,
+};
+
+fn load_bounding_vertex(shape: ShapeParams, index: u32) -> vec2f {
+  let pair = shape.boundingVertices[index / 2u];
   return select(pair.xy, pair.zw, (index & 1u) != 0u);
 }
 
@@ -232,16 +270,16 @@ fn conservative_path_aabb_expansion(axes: mat2x2f) -> f32 {
   return select(0.0, expansion, expansion > 0.0 && expansion < 1e30);
 }
 
-fn needs_device_aabb_fallback(rec: InstanceRecord, axes: mat2x2f) -> bool {
+fn needs_device_aabb_fallback(shape: ShapeParams, axes: mat2x2f) -> bool {
   if (!axes_are_well_conditioned(axes)) {
     return false;
   }
   let orientation = select(-1.0, 1.0, axes_determinant(axes) > 0.0);
-  for (var i = 0u; i < rec.boundingVertexCount; i = i + 1u) {
+  for (var i = 0u; i < shape.boundingVertexCount; i = i + 1u) {
     let previous = load_bounding_vertex(
-      rec, (i + rec.boundingVertexCount - 1u) % rec.boundingVertexCount);
-    let position = load_bounding_vertex(rec, i);
-    let next = load_bounding_vertex(rec, (i + 1u) % rec.boundingVertexCount);
+      shape, (i + shape.boundingVertexCount - 1u) % shape.boundingVertexCount);
+    let position = load_bounding_vertex(shape, i);
+    let next = load_bounding_vertex(shape, (i + 1u) % shape.boundingVertexCount);
     let incoming = axes * (position - previous);
     let outgoing = axes * (next - position);
     let incoming_length = length(incoming);
@@ -266,14 +304,14 @@ fn needs_device_aabb_fallback(rec: InstanceRecord, axes: mat2x2f) -> bool {
   return false;
 }
 
-fn load_device_aabb_vertex(rec: InstanceRecord, effective_mvp: mat4x4f, axes: mat2x2f,
+fn load_device_aabb_vertex(shape: ShapeParams, effective_mvp: mat4x4f, axes: mat2x2f,
                            polygon_index: u32) -> vec2f {
   let pixel_scale = vec2f(uniforms.viewport.x * 0.5, -uniforms.viewport.y * 0.5);
   let origin_pixel = (effective_mvp * vec4f(0.0, 0.0, 0.0, 1.0)).xy * pixel_scale;
   var pixel_min = vec2f(1e30, 1e30);
   var pixel_max = vec2f(-1e30, -1e30);
-  for (var i = 0u; i < rec.boundingVertexCount; i = i + 1u) {
-    let pixel = origin_pixel + axes * load_bounding_vertex(rec, i);
+  for (var i = 0u; i < shape.boundingVertexCount; i = i + 1u) {
+    let pixel = origin_pixel + axes * load_bounding_vertex(shape, i);
     pixel_min = min(pixel_min, pixel);
     pixel_max = max(pixel_max, pixel);
   }
@@ -284,11 +322,11 @@ fn load_device_aabb_vertex(rec: InstanceRecord, effective_mvp: mat4x4f, axes: ma
   return path_from_pixel_delta(axes, pixel_corner - origin_pixel);
 }
 
-fn load_path_aabb_vertex(rec: InstanceRecord, expansion: f32, polygon_index: u32) -> vec2f {
+fn load_path_aabb_vertex(shape: ShapeParams, expansion: f32, polygon_index: u32) -> vec2f {
   var path_min = vec2f(1e30, 1e30);
   var path_max = vec2f(-1e30, -1e30);
-  for (var i = 0u; i < rec.boundingVertexCount; i = i + 1u) {
-    let position = load_bounding_vertex(rec, i);
+  for (var i = 0u; i < shape.boundingVertexCount; i = i + 1u) {
+    let position = load_bounding_vertex(shape, i);
     path_min = min(path_min, position);
     path_max = max(path_max, position);
   }
@@ -298,13 +336,13 @@ fn load_path_aabb_vertex(rec: InstanceRecord, expansion: f32, polygon_index: u32
                select(path_max.y + expansion, path_min.y - expansion, lower));
 }
 
-fn dilated_bounding_vertex(rec: InstanceRecord, axes: mat2x2f, polygon_index: u32) -> vec2f {
-  let count = rec.boundingVertexCount;
+fn dilated_bounding_vertex(shape: ShapeParams, axes: mat2x2f, polygon_index: u32) -> vec2f {
+  let count = shape.boundingVertexCount;
   let previous_index = (polygon_index + count - 1u) % count;
   let next_index = (polygon_index + 1u) % count;
-  let previous = load_bounding_vertex(rec, previous_index);
-  let position = load_bounding_vertex(rec, polygon_index);
-  let next = load_bounding_vertex(rec, next_index);
+  let previous = load_bounding_vertex(shape, previous_index);
+  let position = load_bounding_vertex(shape, polygon_index);
+  let next = load_bounding_vertex(shape, next_index);
 
   // Work in viewport pixels, including WebGPU's Y flip. Intersect the two adjacent edge
   // half-planes after moving each outward by half a pixel, then map that miter back to path
@@ -323,33 +361,30 @@ fn dilated_bounding_vertex(rec: InstanceRecord, axes: mat2x2f, polygon_index: u3
   return position + path_from_pixel_delta(axes, pixel_delta);
 }
 
-fn effective_bounding_vertex(rec: InstanceRecord, effective_mvp: mat4x4f,
+fn effective_bounding_vertex(shape: ShapeParams, effective_mvp: mat4x4f,
                              vertex_index: u32) -> vec2f {
   let axes = pixel_axes(effective_mvp);
   let path_aabb_expansion = conservative_path_aabb_expansion(axes);
   let use_path_aabb = !axes_are_well_conditioned(axes) && path_aabb_expansion > 0.0;
-  let use_device_aabb = needs_device_aabb_fallback(rec, axes);
+  let use_device_aabb = needs_device_aabb_fallback(shape, axes);
   let use_aabb = use_path_aabb || use_device_aabb;
-  let effective_count = select(rec.boundingVertexCount, 4u, use_aabb);
+  let effective_count = select(shape.boundingVertexCount, 4u, use_aabb);
   let triangle = vertex_index / 3u;
   var polygon_index = 0u;
   if (triangle < effective_count - 2u) {
     polygon_index = fan_polygon_index(vertex_index);
   }
   if (use_path_aabb) {
-    return load_path_aabb_vertex(rec, path_aabb_expansion, polygon_index);
+    return load_path_aabb_vertex(shape, path_aabb_expansion, polygon_index);
   }
   if (use_device_aabb) {
-    return load_device_aabb_vertex(rec, effective_mvp, axes, polygon_index);
+    return load_device_aabb_vertex(shape, effective_mvp, axes, polygon_index);
   }
-  return dilated_bounding_vertex(rec, axes, polygon_index);
+  return dilated_bounding_vertex(shape, axes, polygon_index);
 }
 
-@vertex
-fn vs_main(@builtin(vertex_index) vertex_index: u32,
-           @builtin(instance_index) instance_index: u32) -> VertexOutput {
-  let rec = instances[instance_index];
-  let xf = rec.transform;
+fn emit_vertex(shape: ShapeParams, xf: InstanceTransform, vertex_index: u32,
+               instance_index: u32) -> VertexOutput {
   let instance_mat = mat4x4f(
     vec4f(xf.row0.x, xf.row1.x, 0.0, 0.0),
     vec4f(xf.row0.y, xf.row1.y, 0.0, 0.0),
@@ -358,13 +393,38 @@ fn vs_main(@builtin(vertex_index) vertex_index: u32,
   );
   let effective_mvp = uniforms.mvp * instance_mat;
 
-  let dilated = effective_bounding_vertex(rec, effective_mvp, vertex_index);
+  let dilated = effective_bounding_vertex(shape, effective_mvp, vertex_index);
 
   var out: VertexOutput;
   out.clip_pos = effective_mvp * vec4f(dilated, 0.0, 1.0);
   out.sample_pos = dilated;
   out.instance_id = instance_index;
   return out;
+}
+
+/// Shared-geometry entry point: every instance draws the same encoded path,
+/// so the bounding polygon comes from the uniform and only the per-instance
+/// transform is read from the record. A single fill binds the device's
+/// identity record here and reads nothing else from binding 7.
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_index: u32,
+           @builtin(instance_index) instance_index: u32) -> VertexOutput {
+  var shape: ShapeParams;
+  shape.boundingVertexCount = uniforms.boundingVertexCount;
+  shape.boundingVertices = uniforms.boundingVertices;
+  return emit_vertex(shape, instances[instance_index].transform, vertex_index, instance_index);
+}
+
+/// Cross-entity batch entry point: each instance draws a DIFFERENT encoded
+/// path, so both the bounding polygon and the transform come from its record.
+@vertex
+fn vs_main_batched(@builtin(vertex_index) vertex_index: u32,
+                   @builtin(instance_index) instance_index: u32) -> VertexOutput {
+  let rec = instances[instance_index];
+  var shape: ShapeParams;
+  shape.boundingVertexCount = rec.boundingVertexCount;
+  shape.boundingVertices = rec.boundingVertices;
+  return emit_vertex(shape, rec.transform, vertex_index, instance_index);
 }
 
 // ============================================================================
@@ -377,8 +437,33 @@ struct Quadratic {
   p2: vec2f,
 };
 
-fn load_h_curve(rec: InstanceRecord, index: u32) -> Quadratic {
-  let base = rec.curveBase + index * 6u;
+// Paint and geometry parameters of the path this fragment belongs to. Built
+// once per fragment from either the uniform or the instance's record, so the
+// coverage and shading code below is written once and serves both entry
+// points.
+struct PaintParams {
+  color: vec4f,
+  fillRule: u32,
+  paintMode: u32,
+  patternOpacity: f32,
+  yBase: f32,
+  hStride: f32,
+  hBandCount: u32,
+  xBase: f32,
+  vStride: f32,
+  vBandCount: u32,
+  bandBase: u32,
+  curveBase: u32,
+  vBandBase: u32,
+  vCurveBase: u32,
+  hGridBase: u32,
+  vGridBase: u32,
+  hRefsBase: u32,
+  vRefsBase: u32,
+};
+
+fn load_h_curve(paint: PaintParams, index: u32) -> Quadratic {
+  let base = paint.curveBase + index * 6u;
   var q: Quadratic;
   q.p0 = vec2f(curveData[base + 0u], curveData[base + 1u]);
   q.p1 = vec2f(curveData[base + 2u], curveData[base + 3u]);
@@ -386,8 +471,8 @@ fn load_h_curve(rec: InstanceRecord, index: u32) -> Quadratic {
   return q;
 }
 
-fn load_v_curve(rec: InstanceRecord, index: u32) -> Quadratic {
-  let base = rec.vCurveBase + index * 6u;
+fn load_v_curve(paint: PaintParams, index: u32) -> Quadratic {
+  let base = paint.vCurveBase + index * 6u;
   var q: Quadratic;
   q.p0 = vec2f(vCurveData[base + 0u], vCurveData[base + 1u]);
   q.p1 = vec2f(vCurveData[base + 2u], vCurveData[base + 3u]);
@@ -467,7 +552,7 @@ fn owns_axis_sample(start: f32, end: f32, sample: f32) -> bool {
   return sample >= lo && sample < hi;
 }
 
-fn accumulateHoriz(rec: InstanceRecord, slot: u32, sample: vec2f, ppemX: f32) -> RayCoverage {
+fn accumulateHoriz(paint: PaintParams, slot: u32, sample: vec2f, ppemX: f32) -> RayCoverage {
   var result: RayCoverage;
   result.cov = 0.0;
   result.wgt = 0.0;
@@ -475,9 +560,9 @@ fn accumulateHoriz(rec: InstanceRecord, slot: u32, sample: vec2f, ppemX: f32) ->
   if (slot == kNoBand) {
     return result;
   }
-  let band = bands[rec.bandBase + slot];
+  let band = bands[paint.bandBase + slot];
   for (var i = 0u; i < band.curveCount; i = i + 1u) {
-    let curve = load_h_curve(rec, gridData[rec.hRefsBase + band.curveStart + i]);
+    let curve = load_h_curve(paint, gridData[paint.hRefsBase + band.curveStart + i]);
     let curve_max_x = max(curve.p0.x, max(curve.p1.x, curve.p2.x));
     if ((curve_max_x - sample.x) * ppemX <= -0.5) {
       break;
@@ -509,7 +594,7 @@ fn accumulateHoriz(rec: InstanceRecord, slot: u32, sample: vec2f, ppemX: f32) ->
   return result;
 }
 
-fn accumulateVert(rec: InstanceRecord, slot: u32, sample: vec2f, ppemY: f32) -> RayCoverage {
+fn accumulateVert(paint: PaintParams, slot: u32, sample: vec2f, ppemY: f32) -> RayCoverage {
   var result: RayCoverage;
   result.cov = 0.0;
   result.wgt = 0.0;
@@ -517,9 +602,9 @@ fn accumulateVert(rec: InstanceRecord, slot: u32, sample: vec2f, ppemY: f32) -> 
   if (slot == kNoBand) {
     return result;
   }
-  let band = vBands[rec.vBandBase + slot];
+  let band = vBands[paint.vBandBase + slot];
   for (var i = 0u; i < band.curveCount; i = i + 1u) {
-    let curve = load_v_curve(rec, gridData[rec.vRefsBase + band.curveStart + i]);
+    let curve = load_v_curve(paint, gridData[paint.vRefsBase + band.curveStart + i]);
     let curve_max_y = max(curve.p0.y, max(curve.p1.y, curve.p2.y));
     if ((curve_max_y - sample.y) * ppemY <= -0.5) {
       break;
@@ -587,9 +672,7 @@ struct FragOutput {
   @location(0) color: vec4f,
 };
 
-@fragment
-fn fs_main(in: VertexOutput) -> FragOutput {
-  let rec = instances[in.instance_id];
+fn shade(paint: PaintParams, in: VertexOutput) -> FragOutput {
   let pixel_center = in.clip_pos.xy;
 
   // Path-units per pixel, per axis. `sample_pos` is a linear function of the
@@ -601,22 +684,22 @@ fn fs_main(in: VertexOutput) -> FragOutput {
   hCov.cov = 0.0;
   hCov.wgt = 0.0;
   hCov.winding = 0.0;
-  if (rec.hBandCount > 0u) {
-    let hi = clamp(i32((in.sample_pos.y - rec.yBase) / rec.hStride),
-                   0, i32(rec.hBandCount) - 1);
-    let slot = gridData[rec.hGridBase + u32(hi)];
-    hCov = accumulateHoriz(rec, slot, in.sample_pos, ppem.x);
+  if (paint.hBandCount > 0u) {
+    let hi = clamp(i32((in.sample_pos.y - paint.yBase) / paint.hStride),
+                   0, i32(paint.hBandCount) - 1);
+    let slot = gridData[paint.hGridBase + u32(hi)];
+    hCov = accumulateHoriz(paint, slot, in.sample_pos, ppem.x);
   }
 
   var vCov: RayCoverage;
   vCov.cov = 0.0;
   vCov.wgt = 0.0;
   vCov.winding = 0.0;
-  if (rec.vBandCount > 0u) {
-    let vj = clamp(i32((in.sample_pos.x - rec.xBase) / rec.vStride),
-                   0, i32(rec.vBandCount) - 1);
-    let slot = gridData[rec.vGridBase + u32(vj)];
-    vCov = accumulateVert(rec, slot, in.sample_pos, ppem.y);
+  if (paint.vBandCount > 0u) {
+    let vj = clamp(i32((in.sample_pos.x - paint.xBase) / paint.vStride),
+                   0, i32(paint.vBandCount) - 1);
+    let slot = gridData[paint.vGridBase + u32(vj)];
+    vCov = accumulateVert(paint, slot, in.sample_pos, ppem.y);
   }
 
   var coverage = calc_coverage(hCov, vCov);
@@ -626,12 +709,12 @@ fn fs_main(in: VertexOutput) -> FragOutput {
   // value - a hole has combined coverage ≈ 2, which the wave maps to 0).
   if (uniforms.antialias == 0u) {
     let winding = u32(abs(hCov.winding));
-    if (rec.fillRule == 0u) {
+    if (paint.fillRule == 0u) {
       coverage = select(0.0, 1.0, winding != 0u);
     } else {
       coverage = f32(winding & 1u);
     }
-  } else if (rec.fillRule == 0u) {
+  } else if (paint.fillRule == 0u) {
     coverage = saturate(coverage);
   } else {
     coverage = 1.0 - abs(1.0 - fract(coverage * 0.5) * 2.0);
@@ -655,9 +738,9 @@ fn fs_main(in: VertexOutput) -> FragOutput {
 
   var out: FragOutput;
 
-  if (rec.paintMode == 0u) {
-    // `rec.color` is premultiplied; scale all channels by coverage.
-    out.color = rec.color * coverage;
+  if (paint.paintMode == 0u) {
+    // `paint.color` is premultiplied; scale all channels by coverage.
+    out.color = paint.color * coverage;
     return out;
   }
 
@@ -668,14 +751,69 @@ fn fs_main(in: VertexOutput) -> FragOutput {
     fract(patternPos.y / uniforms.tileSize.y) * uniforms.tileSize.y,
   );
   let uv = wrapped / uniforms.tileSize;
-  // textureSampleLevel, not textureSample: paintMode now lives in the
-  // per-instance record, so the solid-color early return above is
+  // textureSampleLevel, not textureSample: the batched entry point reads
+  // paintMode per instance, so the solid-color early return above is
   // non-uniform control flow and WGSL forbids implicit-derivative sampling
   // past it (browser compilers reject the module; native validation does
   // not). Pattern textures are created with a single mip level, so sampling
   // level 0 explicitly is an exact behavioral match.
   var sampled = textureSampleLevel(patternTexture, patternSampler, uv, 0.0);
-  sampled = sampled * rec.patternOpacity * coverage;
+  sampled = sampled * paint.patternOpacity * coverage;
   out.color = sampled;
   return out;
+}
+
+/// Shared-paint entry point: every instance of this draw carries the same
+/// paint and the same encoded path, so the parameters come from the uniform
+/// and the fragment stage never touches binding 7.
+@fragment
+fn fs_main(in: VertexOutput) -> FragOutput {
+  var paint: PaintParams;
+  paint.color = uniforms.color;
+  paint.fillRule = uniforms.fillRule;
+  paint.paintMode = uniforms.paintMode;
+  paint.patternOpacity = uniforms.patternOpacity;
+  paint.yBase = uniforms.yBase;
+  paint.hStride = uniforms.hStride;
+  paint.hBandCount = uniforms.hBandCount;
+  paint.xBase = uniforms.xBase;
+  paint.vStride = uniforms.vStride;
+  paint.vBandCount = uniforms.vBandCount;
+  paint.bandBase = uniforms.bandBase;
+  paint.curveBase = uniforms.curveBase;
+  paint.vBandBase = uniforms.vBandBase;
+  paint.vCurveBase = uniforms.vCurveBase;
+  paint.hGridBase = uniforms.hGridBase;
+  paint.vGridBase = uniforms.vGridBase;
+  paint.hRefsBase = uniforms.hRefsBase;
+  paint.vRefsBase = uniforms.vRefsBase;
+  return shade(paint, in);
+}
+
+/// Cross-entity batch entry point: each instance carries its own paint and
+/// its own geometry, read through the flat instance-id varying so
+/// overlapping instances still blend in painter (instance) order.
+@fragment
+fn fs_main_batched(in: VertexOutput) -> FragOutput {
+  let rec = instances[in.instance_id];
+  var paint: PaintParams;
+  paint.color = rec.color;
+  paint.fillRule = rec.fillRule;
+  paint.paintMode = rec.paintMode;
+  paint.patternOpacity = rec.patternOpacity;
+  paint.yBase = rec.yBase;
+  paint.hStride = rec.hStride;
+  paint.hBandCount = rec.hBandCount;
+  paint.xBase = rec.xBase;
+  paint.vStride = rec.vStride;
+  paint.vBandCount = rec.vBandCount;
+  paint.bandBase = rec.bandBase;
+  paint.curveBase = rec.curveBase;
+  paint.vBandBase = rec.vBandBase;
+  paint.vCurveBase = rec.vCurveBase;
+  paint.hGridBase = rec.hGridBase;
+  paint.vGridBase = rec.vGridBase;
+  paint.hRefsBase = rec.hRefsBase;
+  paint.vRefsBase = rec.vRefsBase;
+  return shade(paint, in);
 }

--- a/donner/svg/renderer/geode/tests/GeodeCounterCorpus_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeCounterCorpus_tests.cc
@@ -261,7 +261,7 @@ constexpr std::array<KnownViolation, 32> kKnownViolations = {{
     {
         /*scene=*/"geode_pattern_checker",
         /*violated=*/kTextureCreates | kBufferWrites,
-        /*ceiling=*/{0, 1, 10, 1},
+        /*ceiling=*/{0, 1, 9, 1},
         /*reason=*/
         "the pattern tile is re-rendered into a freshly allocated texture every frame and "
         "the tiled fill draws through the per-frame arena",
@@ -271,7 +271,7 @@ constexpr std::array<KnownViolation, 32> kKnownViolations = {{
     {
         /*scene=*/"geode_pattern_nonrect",
         /*violated=*/kTextureCreates | kBufferWrites,
-        /*ceiling=*/{0, 1, 10, 1},
+        /*ceiling=*/{0, 1, 9, 1},
         /*reason=*/
         "the pattern tile is re-rendered into a freshly allocated texture every frame and "
         "the tiled fill draws through the per-frame arena",
@@ -281,7 +281,7 @@ constexpr std::array<KnownViolation, 32> kKnownViolations = {{
     {
         /*scene=*/"geode_pattern_offset",
         /*violated=*/kTextureCreates | kBufferWrites,
-        /*ceiling=*/{0, 1, 10, 1},
+        /*ceiling=*/{0, 1, 9, 1},
         /*reason=*/
         "the pattern tile is re-rendered into a freshly allocated texture every frame and "
         "the tiled fill draws through the per-frame arena",
@@ -291,7 +291,7 @@ constexpr std::array<KnownViolation, 32> kKnownViolations = {{
     {
         /*scene=*/"geode_pattern_solid",
         /*violated=*/kTextureCreates | kBufferWrites,
-        /*ceiling=*/{0, 1, 10, 1},
+        /*ceiling=*/{0, 1, 9, 1},
         /*reason=*/
         "the pattern tile is re-rendered into a freshly allocated texture every frame and "
         "the tiled fill draws through the per-frame arena",
@@ -301,7 +301,7 @@ constexpr std::array<KnownViolation, 32> kKnownViolations = {{
     {
         /*scene=*/"geode_text_decoration_underline",
         /*violated=*/kPathEncodes | kBufferWrites,
-        /*ceiling=*/{5, 0, 50, 5},
+        /*ceiling=*/{5, 0, 45, 5},
         /*reason=*/
         "glyph and decoration outlines are re-encoded and re-uploaded every frame; placed "
         "text has no path cache or residency",
@@ -312,7 +312,7 @@ constexpr std::array<KnownViolation, 32> kKnownViolations = {{
     {
         /*scene=*/"geode_text_pattern_fill",
         /*violated=*/kPathEncodes | kTextureCreates | kBufferWrites,
-        /*ceiling=*/{4, 1, 40, 4},
+        /*ceiling=*/{4, 1, 36, 4},
         /*reason=*/
         "glyph outlines re-encode every frame and the pattern tile behind them is "
         "re-rendered into a fresh texture",
@@ -323,7 +323,7 @@ constexpr std::array<KnownViolation, 32> kKnownViolations = {{
     {
         /*scene=*/"geode_text_span_gradient_over_pattern",
         /*violated=*/kPathEncodes | kTextureCreates | kBufferWrites,
-        /*ceiling=*/{3, 1, 29, 3},
+        /*ceiling=*/{3, 1, 27, 3},
         /*reason=*/
         "glyph outlines re-encode every frame and the pattern tile behind them is "
         "re-rendered into a fresh texture",
@@ -334,7 +334,7 @@ constexpr std::array<KnownViolation, 32> kKnownViolations = {{
     {
         /*scene=*/"geode_text_span_gradient_over_pattern_stroke",
         /*violated=*/kPathEncodes | kTextureCreates | kBufferWrites,
-        /*ceiling=*/{3, 1, 29, 3},
+        /*ceiling=*/{3, 1, 27, 3},
         /*reason=*/
         "glyph outlines re-encode every frame and the pattern tile behind them is "
         "re-rendered into a fresh texture",
@@ -364,7 +364,7 @@ constexpr std::array<KnownViolation, 32> kKnownViolations = {{
     {
         /*scene=*/"image_external_svg_par",
         /*violated=*/kBufferWrites,
-        /*ceiling=*/{0, 0, 40, 4},
+        /*ceiling=*/{0, 0, 36, 4},
         /*reason=*/
         "the same external SVG is drawn by two image elements at different sizes; one size "
         "stays resident and the other re-uploads its geometry every frame (the single-image "
@@ -376,7 +376,7 @@ constexpr std::array<KnownViolation, 32> kKnownViolations = {{
     {
         /*scene=*/"image_external_svg_viewbox",
         /*violated=*/kBufferWrites,
-        /*ceiling=*/{0, 0, 40, 4},
+        /*ceiling=*/{0, 0, 36, 4},
         /*reason=*/
         "the same external SVG is drawn by two image elements at different sizes; one size "
         "stays resident and the other re-uploads its geometry every frame (the single-image "
@@ -388,7 +388,7 @@ constexpr std::array<KnownViolation, 32> kKnownViolations = {{
     {
         /*scene=*/"marker",
         /*violated=*/kBufferWrites | kBindgroupCreates,
-        /*ceiling=*/{0, 0, 460, 46},
+        /*ceiling=*/{0, 0, 414, 46},
         /*reason=*/
         "every drawn marker instance re-uploads its geometry through the per-frame arena and "
         "builds its own bind group",
@@ -397,7 +397,7 @@ constexpr std::array<KnownViolation, 32> kKnownViolations = {{
     {
         /*scene=*/"marker_segments",
         /*violated=*/kTextureCreates | kBufferWrites | kBindgroupCreates,
-        /*ceiling=*/{0, 7, 223, 43},
+        /*ceiling=*/{0, 7, 203, 43},
         /*reason=*/
         "every drawn marker instance re-uploads its geometry and allocates clip scratch "
         "textures each frame",
@@ -408,7 +408,7 @@ constexpr std::array<KnownViolation, 32> kKnownViolations = {{
     {
         /*scene=*/"marker_spec_example",
         /*violated=*/kBufferWrites | kBindgroupCreates,
-        /*ceiling=*/{0, 0, 101, 20},
+        /*ceiling=*/{0, 0, 92, 20},
         /*reason=*/
         "every drawn marker instance re-uploads its geometry through the per-frame arena and "
         "builds its own bind group",
@@ -417,7 +417,7 @@ constexpr std::array<KnownViolation, 32> kKnownViolations = {{
     {
         /*scene=*/"nested_svg_aspectratio",
         /*violated=*/kPathEncodes | kBufferWrites | kBindgroupCreates,
-        /*ceiling=*/{208, 0, 2886, 290},
+        /*ceiling=*/{208, 0, 2582, 290},
         /*reason=*/
         "nested viewports carrying text and use instances re-encode and re-upload the whole "
         "subtree every frame",
@@ -428,7 +428,7 @@ constexpr std::array<KnownViolation, 32> kKnownViolations = {{
     {
         /*scene=*/"poker_chips",
         /*violated=*/kPathEncodes | kBufferWrites | kBindgroupCreates,
-        /*ceiling=*/{12, 0, 193, 20},
+        /*ceiling=*/{12, 0, 96, 20},
         /*reason=*/
         "use instances share one source path with differing stroke styles, so the per-entity "
         "stroke cache thrashes and re-encodes every instance",
@@ -439,7 +439,7 @@ constexpr std::array<KnownViolation, 32> kKnownViolations = {{
     {
         /*scene=*/"simple_text_demo",
         /*violated=*/kPathEncodes | kBufferWrites | kBindgroupCreates,
-        /*ceiling=*/{24, 0, 240, 24},
+        /*ceiling=*/{24, 0, 216, 24},
         /*reason=*/
         "glyph outlines are re-encoded and re-uploaded every frame; placed text has no path "
         "cache or residency",
@@ -450,7 +450,7 @@ constexpr std::array<KnownViolation, 32> kKnownViolations = {{
     {
         /*scene=*/"stroking_complex",
         /*violated=*/kPathEncodes | kBufferWrites | kBindgroupCreates,
-        /*ceiling=*/{8, 0, 73, 8},
+        /*ceiling=*/{8, 0, 16, 8},
         /*reason=*/
         "eight use instances share one source path with differing stroke styles (width, "
         "dash, opacity), so the per-entity stroke cache thrashes and re-encodes each "
@@ -462,7 +462,7 @@ constexpr std::array<KnownViolation, 32> kKnownViolations = {{
     {
         /*scene=*/"svg2_e_use_003",
         /*violated=*/kBufferWrites,
-        /*ceiling=*/{0, 0, 10, 1},
+        /*ceiling=*/{0, 0, 9, 1},
         /*reason=*/
         "the stroke outline of a styled use instance draws through the per-frame arena "
         "instead of a resident buffer",
@@ -473,7 +473,7 @@ constexpr std::array<KnownViolation, 32> kKnownViolations = {{
     {
         /*scene=*/"svg2_e_use_004",
         /*violated=*/kBufferWrites,
-        /*ceiling=*/{0, 0, 10, 1},
+        /*ceiling=*/{0, 0, 9, 1},
         /*reason=*/
         "the stroke outline of a styled use instance draws through the per-frame arena "
         "instead of a resident buffer",
@@ -484,7 +484,7 @@ constexpr std::array<KnownViolation, 32> kKnownViolations = {{
     {
         /*scene=*/"text_inline_size_wrap",
         /*violated=*/kPathEncodes | kBufferWrites | kBindgroupCreates,
-        /*ceiling=*/{35, 0, 350, 35},
+        /*ceiling=*/{35, 0, 315, 35},
         /*reason=*/
         "every wrapped glyph outline is re-encoded and re-uploaded each frame; placed text "
         "has no path cache or residency",
@@ -495,7 +495,7 @@ constexpr std::array<KnownViolation, 32> kKnownViolations = {{
     {
         /*scene=*/"text_nested_baseline_shift_idempotency",
         /*violated=*/kPathEncodes | kBufferWrites,
-        /*ceiling=*/{2, 0, 20, 2},
+        /*ceiling=*/{2, 0, 18, 2},
         /*reason=*/
         "glyph outlines are re-encoded and re-uploaded every frame; placed text has no path "
         "cache or residency",
@@ -506,7 +506,7 @@ constexpr std::array<KnownViolation, 32> kKnownViolations = {{
     {
         /*scene=*/"z0rly_test6",
         /*violated=*/kPathEncodes | kBufferWrites | kBindgroupCreates,
-        /*ceiling=*/{22, 0, 220, 22},
+        /*ceiling=*/{22, 0, 198, 22},
         /*reason=*/
         "music-notation glyphs from an embedded font face re-encode and re-upload their "
         "outlines every frame; placed text has no path cache or residency",

--- a/donner/svg/renderer/geode/tests/GeodeDevice_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeDevice_tests.cc
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <string_view>
 
 #include "donner/svg/renderer/geode/GeodeCallbackState.h"
@@ -21,6 +22,13 @@
 namespace donner::geode {
 
 using svg::test::RgbaEq;
+using testing::HasSubstr;
+using testing::Not;
+
+/// Marker that `GeodeDevice`'s uncaptured-error callback prints when wgpu
+/// rejects a descriptor. wgpu still returns a non-null handle in that case, so
+/// tests that need to know a resource was actually accepted watch for this.
+constexpr const char* kWgpuUncapturedErrorMarker = "Uncaptured error";
 
 TEST(GeodeCallbackState, CallbackOwnsStateAfterCallerReturns) {
   struct State {};
@@ -300,6 +308,37 @@ TEST(GeodeDevice, SharedPipelinesReturnSameInstance) {
   // `maskPipeline()` is lazy - two calls must still return the same
   // instance (first call constructs, second call returns cached).
   EXPECT_EQ(&device->maskPipeline(), &device->maskPipeline());
+}
+
+/// The record-reading variant of the fill pipeline is compiled lazily, and
+/// only a cross-entity batch ever asks for it. A build that leaves scene
+/// batching switched off therefore never constructs it, so a renamed shader
+/// entry point, or a bind group layout the batched entry points no longer
+/// match, would pass every test and only fail once batching is enabled.
+/// Compile it here on the real device, unconditionally and independent of the
+/// batching switch, so both variants stay covered.
+///
+/// The returned handle alone proves nothing: wgpu hands back a non-null error
+/// pipeline for a rejected descriptor and reports the reason through the
+/// device's uncaptured-error callback, so the real assertion is that the
+/// callback printed nothing. The shader-emitter validation tests keep a
+/// negative control proving this marker does fire on a bad descriptor.
+TEST(GeodeDevice, BatchedFillPipelineCompilesWithoutValidationErrors) {
+  auto device = GeodeDevice::CreateHeadless();
+  ASSERT_NE(device, nullptr);
+
+  testing::internal::CaptureStderr();
+  const wgpu::RenderPipeline& batched = device->pipeline().batchedPipeline(device->device());
+  const std::string errors = testing::internal::GetCapturedStderr();
+
+  EXPECT_TRUE(static_cast<bool>(batched)) << "Batched fill pipeline creation returned null.";
+  EXPECT_THAT(errors, Not(HasSubstr(kWgpuUncapturedErrorMarker)))
+      << "wgpu rejected the record-reading fill pipeline:\n"
+      << errors;
+
+  // Built on first use, then cached: a second call must hand back the same
+  // pipeline rather than recompiling it.
+  EXPECT_EQ(&device->pipeline().batchedPipeline(device->device()), &batched);
 }
 
 /// Regression test for issue #575: texture / buffer allocation

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -1050,7 +1050,7 @@ TEST_F(RendererGeodeTest, EmbeddedDeviceDrawPathExportsTextureSnapshot) {
   ASSERT_TRUE(static_cast<bool>(embedded->dummyPatternSampler()));
   ASSERT_TRUE(static_cast<bool>(embedded->dummyClipMaskTextureView()));
   ASSERT_TRUE(static_cast<bool>(embedded->dummyClipMaskSampler()));
-  ASSERT_TRUE(static_cast<bool>(embedded->identityInstanceTransformBuffer()));
+  ASSERT_TRUE(static_cast<bool>(embedded->identityInstanceRecordBuffer()));
 
   RendererGeode renderer(embedded);
   beginFrame(renderer);

--- a/tools/gpu_inventory/manifests/gpu_operations.json
+++ b/tools/gpu_inventory/manifests/gpu_operations.json
@@ -848,6 +848,7 @@
         "PipelineLayout",
         "PipelineLayoutDescriptor",
         "PrimitiveTopology",
+        "RenderPipeline",
         "RenderPipelineDescriptor",
         "SamplerBindingType",
         "ShaderModule",
@@ -863,13 +864,16 @@
         "BindGroupLayout",
         "ComputePipeline",
         "Device",
+        "PipelineLayout",
         "RenderPipeline",
+        "ShaderModule",
         "TextureFormat"
       ]
     },
     "donner/svg/renderer/geode/GeodeResidentPathComponent.h": {
       "operations": [
-        "createBuffer"
+        "createBuffer",
+        "writeBuffer"
       ],
       "wgpuCFunctions": [
         "wgpuLabel"

--- a/tools/gpu_inventory/manifests/gpu_operations.json
+++ b/tools/gpu_inventory/manifests/gpu_operations.json
@@ -1057,6 +1057,7 @@
         "RenderPassColorAttachment",
         "RenderPassDescriptor",
         "RenderPassEncoder",
+        "RenderPipeline",
         "StoreOp",
         "TexelCopyBufferInfo",
         "TexelCopyTextureInfo",

--- a/tools/gpu_inventory/manifests/shader_features.json
+++ b/tools/gpu_inventory/manifests/shader_features.json
@@ -1404,7 +1404,15 @@
           "stage": "fragment"
         },
         {
+          "name": "fs_main_batched",
+          "stage": "fragment"
+        },
+        {
           "name": "vs_main",
+          "stage": "vertex"
+        },
+        {
+          "name": "vs_main_batched",
           "stage": "vertex"
         }
       ],
@@ -1443,8 +1451,10 @@
         "FragOutput",
         "InstanceRecord",
         "InstanceTransform",
+        "PaintParams",
         "Quadratic",
         "RayCoverage",
+        "ShapeParams",
         "Uniforms",
         "VertexOutput"
       ]

--- a/tools/gpu_inventory/manifests_integrity_tests.py
+++ b/tools/gpu_inventory/manifests_integrity_tests.py
@@ -58,8 +58,19 @@ class ShaderFeaturesManifestTest(unittest.TestCase):
 
     def test_solid_fill_shader_shape(self):
         shader = self.manifest["shaders"]["donner/svg/renderer/geode/shaders/slug_fill.wgsl"]
-        stages = sorted(e["stage"] for e in shader["entryPoints"])
-        self.assertEqual(stages, ["fragment", "vertex"])
+        # Two entry-point pairs: the default ones take the draw's paint and
+        # geometry from the uniform, the `_batched` ones take them from each
+        # instance record. Both pairs share one bind-group layout.
+        entries = sorted((e["stage"], e["name"]) for e in shader["entryPoints"])
+        self.assertEqual(
+            entries,
+            [
+                ("fragment", "fs_main"),
+                ("fragment", "fs_main_batched"),
+                ("vertex", "vs_main"),
+                ("vertex", "vs_main_batched"),
+            ],
+        )
         # The instance-record consolidation folded the per-draw uniform
         # bindings into the record SSBO plus a combined grid binding, so the
         # solid-fill shader declares 11 bindings.


### PR DESCRIPTION
The instance-record change in #954 widened the same-frame residence gate for fill draws, which threw repeated stroke and `<use>` draws off residency onto the per-frame arena (about 10 buffer writes per draw instead of 2). On stroke-heavy scenes that costs +50-100% steady-state draw time on main today.

This restores resident-uniform sourcing for solo draws while keeping record sourcing for batched draws:

- `slug_fill.wgsl` gains dual entry points: `vs_main`/`fs_main` source shape and paint parameters from the per-slot uniform (solo path), `vs_main_batched`/`fs_main_batched` source them from instance records (batch path). Both pairs feed the same shared vertex and shading bodies, and `copyRecordParamsToUniform` mirrors the parameters bit-identically, so the two paths shade identically.
- An immutable identity instance-record buffer satisfies the record binding on the solo pipeline variant.
- Record-slot maintenance is gated on scene-batch eligibility, so draws that can never batch (clips, scissors, non-resident fills) no longer pay record upkeep, and the solo path never rewrites a shared per-entity record mid-frame. This removes the write-after-record hazard at its source: within a submit, all buffer writes execute before all draws, so a record rewritten after a draw was recorded would retroactively corrupt that draw.
- The scene-batch header uniform lives in the record slab keyed by bytes and is written exactly once at creation, never rewritten.
- 22 counter-ratchet ceilings are retightened to the restored values, with observed counts landing exactly on the new ceilings.
- A new unconditional test compiles the batched (record-sourced) pipeline variant on a real device and asserts the uncaptured-error callback stayed silent, so the lazily-built variant stays covered even in builds that never enable batching. A bare non-null assertion would be vacuous: wgpu returns a non-null error pipeline for a rejected descriptor.

Measured on a discrete GPU (Vulkan): with scene batching off (the default), steady-state returns to the pre-#954 baseline everywhere; stroking_complex draw median goes from 2.2-2.5 ms on current main to 0.98-1.01 ms with buffer writes 73 -> 16, and other stroke/use-heavy scenes recover similarly, with lion and Tiger unchanged within noise. With scene batching on, no scene loses: lion -58%, Ghostscript Tiger -21.6%, render hashes identical, zero steady-state buffer writes. The full geode suite is green in both flag states, and the benchmark deltas were independently reproduced on the same hardware.
