### PR TITLE
fix: Keep selection chrome presented across the overlay version-gate catch-up window

### DIFF
--- a/docs/design_docs/0044-2-editor_fluid_canvas_rendering.md
+++ b/docs/design_docs/0044-2-editor_fluid_canvas_rendering.md
@@ -438,15 +438,35 @@ That callback points `RendererGeode` at the current swapchain texture, preserves
 framebuffer contents, pushes a framebuffer-space clip rect for the artboard, and calls
 `OverlayRenderer::drawChromeFromSnapshot`.
 
-The overlay is rebuilt every frame from the current viewport and current interaction state. It is
-not retained behind the async document-content version gate and it is not reprojected from a cached
-overlay texture during pan, zoom, drag, or transform handles. This keeps the chrome aligned with the
-content even when the document tiles are still refining.
+The overlay is rebuilt every frame from the current viewport and current interaction state, and it
+is never reprojected from a cached overlay texture during pan, zoom, drag, or transform handles.
+This keeps the chrome aligned with the content even when the document tiles are still refining.
+
+The async document-content version gate holds back the recapture, not the snapshot. A
+non-transforming edit that puts the live document ahead of the presented pixels has no
+presenter-side projection that could make chrome captured from the new DOM line up with the older
+pixels, so the capture waits for the worker to catch up. But the chrome pass itself exists only for
+frames a snapshot is held for, so releasing the snapshot across that window would present document
+pixels with no chrome over them at all: the selection outline, bounds, and handles would blink out
+until the worker caught up, which is a dropout rather than a stale frame. The snapshot is therefore
+retained across the catch-up window and only the recapture is deferred. The cost is a geometry lead
+of at most one render, the same bargain the pen live preview already makes deliberately in the
+other direction.
+
+A changed chrome subject is the one difference the gate may not hold. Chrome that outlines elements
+which are no longer selected or hovered is wrong rather than early, and no later frame will
+recapture for it while the gate holds, so those frames recapture immediately: deselecting captures
+empty chrome instead of leaving a stale outline behind.
 
 The path overlay has an iron lockstep rule: it must represent the same transform as the document
 tiles actually presented underneath it in that frame. If a high-zoom or worker-busy frame cannot
 present a fresh drag-target tile yet, the overlay must be projected back to the presented content
 transform instead of displaying a newer transform over stale pixels.
+
+The retained snapshot above does not weaken that rule, because the rule is about transform. Held
+chrome is re-pointed at the presented transform at draw time, so it never puts a newer transform
+over older pixels. Only geometry, which no reprojection can reconcile, is allowed to lead, and only
+by the single render it takes the gate to release.
 
 Large selections use LOD:
 
@@ -457,9 +477,12 @@ Large selections use LOD:
 | >32 elements or "select all" | combined bounds + handles + count                           | visible outlines after interaction settles          |
 | Group with many descendants  | group bounds first                                          | descendant outlines only when zoomed in and visible |
 
-`SelectionChromeSnapshot` is a per-frame transfer object, not a retained cache. It should keep
-capture and draw separate so we can count work, cull before draw, and choose large-selection LOD,
-but it should be discarded after the current overlay has been drawn or uploaded.
+`SelectionChromeSnapshot` keeps capture and draw separate so we can count work, cull before draw,
+and choose large-selection LOD. It is held for as long as there is chrome to draw rather than
+discarded after each draw, because the chrome pass is installed only for frames a snapshot is held
+for. It is still not a cache that outlives its subject: a capture is redone whenever the viewport,
+the interaction state, or the chrome subject changes, and the held geometry is re-pointed at the
+presented transform every time it is drawn.
 
 ### Source-Pane Ropes
 

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -4007,9 +4007,8 @@ void EditorShell::installFramebufferUnderlayPlan(
 #endif
 }
 
-void EditorShell::installImmediateChromePlan(
-    [[maybe_unused]] std::optional<ImmediateChromePlan> plan) {
-  immediateChromePlanInstalled_ = plan.has_value();
+void EditorShell::installImmediateChromePlan(std::optional<ImmediateChromePlan> plan) {
+  immediateChromePlanProduced_ = plan.has_value();
 #ifdef DONNER_EDITOR_WGPU
   if (!plan.has_value() || directOverlayRenderer_ == nullptr) {
     window_.setWgpuDirectRenderCallback({});

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -4009,6 +4009,7 @@ void EditorShell::installFramebufferUnderlayPlan(
 
 void EditorShell::installImmediateChromePlan(
     [[maybe_unused]] std::optional<ImmediateChromePlan> plan) {
+  immediateChromePlanInstalled_ = plan.has_value();
 #ifdef DONNER_EDITOR_WGPU
   if (!plan.has_value() || directOverlayRenderer_ == nullptr) {
     window_.setWgpuDirectRenderCallback({});
@@ -4171,10 +4172,19 @@ void EditorShell::renderRenderPanePresentation(
   if (documentPresenter_->presentUnderlay(std::move(underlayPlan)) && underlayPresentsTiles) {
     documentPresentedDirectly = true;
   }
-  // Chrome is drawn immediately, every frame, into the same framebuffer the
-  // tiles just landed in, with the transform those tiles were placed with.
-  // Nothing caches it, so it cannot lag the document, and nothing re-scales
-  // it, so handles cannot grow with zoom.
+  // Chrome is drawn immediately, into the same framebuffer the tiles just
+  // landed in, with the transform those tiles were placed with. Nothing caches
+  // it, so it cannot lag the document, and nothing re-scales it, so handles
+  // cannot grow with zoom.
+  //
+  // Every frame that draws chrome at all has to build a plan for it. Installing
+  // no plan detaches the direct-render callback, so a frame that skipped one
+  // presents the document underlay with no chrome pass over it - a dropout, not
+  // a stale frame. That is why the coordinator holds its chrome snapshot for as
+  // long as there is chrome to draw and holds back only the recapture; the two
+  // frames below that legitimately carry no chrome are the content-only capture
+  // (which is defined as document pixels without editor chrome) and the sample
+  // picker (which covers the canvas).
   std::optional<ImmediateChromePlan> chromePlan;
   if (!contentOnlyCaptureThisFrame_ && !showSamplePicker_ &&
       renderCoordinator_.immediateOverlaySnapshot().has_value()) {

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -708,6 +708,12 @@ private:
   FrameCostBreakdown::DirectPresentation lastDirectPresentationCost_;
   /// Wall time the last immediate chrome pass spent drawing, in milliseconds.
   double lastImmediateChromeDrawMs_ = 0.0;
+  /// Whether the most recently installed plan carries a chrome pass.
+  ///
+  /// False means the presented frame is document pixels with no chrome drawn over them, which is
+  /// correct only for a frame that has no chrome to draw. Any other false is the selection outline
+  /// dropping out for a frame, so this is the invariant the presentation tests assert on.
+  bool immediateChromePlanInstalled_ = false;
   bool treeSelectionOriginatedInTree_ = false;
   bool sourceSelectionOriginatedInText_ = false;
   bool sourceFocusOriginatedInStyle_ = false;

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -708,12 +708,17 @@ private:
   FrameCostBreakdown::DirectPresentation lastDirectPresentationCost_;
   /// Wall time the last immediate chrome pass spent drawing, in milliseconds.
   double lastImmediateChromeDrawMs_ = 0.0;
-  /// Whether the most recently installed plan carries a chrome pass.
+  /// Whether a chrome plan was produced for the most recent frame.
   ///
-  /// False means the presented frame is document pixels with no chrome drawn over them, which is
-  /// correct only for a frame that has no chrome to draw. Any other false is the selection outline
-  /// dropping out for a frame, so this is the invariant the presentation tests assert on.
-  bool immediateChromePlanInstalled_ = false;
+  /// This records the coordinator-side half of the chrome pass: the shell had a selection chrome
+  /// snapshot to draw and handed a plan down for it. It is not a claim that a pass was installed or
+  /// that anything was drawn, because whether the plan reaches a draw also depends on the build
+  /// configuration and on a direct overlay renderer existing.
+  ///
+  /// False means the frame had no chrome to draw at all, which is correct only for the content-only
+  /// capture and the sample picker. Any other false is the selection outline dropping out for a
+  /// frame, so this is the invariant the presentation tests assert on.
+  bool immediateChromePlanProduced_ = false;
   bool treeSelectionOriginatedInTree_ = false;
   bool sourceSelectionOriginatedInText_ = false;
   bool sourceFocusOriginatedInStyle_ = false;

--- a/donner/editor/RenderCoordinator.cc
+++ b/donner/editor/RenderCoordinator.cc
@@ -531,6 +531,11 @@ void RenderCoordinator::setLockedRejectionFlash(
   lockedRejectionFlash_ = std::move(flash);
 }
 
+bool RenderCoordinator::chromeSubjectDiffersFromSnapshot(const EditorApp& app) const {
+  return app.selectedElements() != lastOverlaySelectionVec_ ||
+         sourceHoverElements_ != lastOverlaySourceHoverVec_;
+}
+
 void RenderCoordinator::refreshSelectionBoundsCache(EditorApp& app) {
   if (!app.hasDocument()) {
     selectionBoundsCache_ = SelectionBoundsCache{};
@@ -590,9 +595,7 @@ bool RenderCoordinator::rasterizeOverlayForCurrentSelection(
         });
   }
   const bool overlayGeometryDiffers =
-      overlaySelection != lastOverlaySelectionVec_ ||
-      sourceHoverElements_ != lastOverlaySourceHoverVec_ ||
-      currentPenLiveSpline != lastOverlayPenLiveSpline_ ||
+      chromeSubjectDiffersFromSnapshot(app) || currentPenLiveSpline != lastOverlayPenLiveSpline_ ||
       marqueeRectDoc != lastOverlayMarqueeRectDoc_ ||
       currentOverlayRasterSize != lastOverlayRasterSize_ || !lastOverlayScreenRect_.has_value() ||
       currentOverlayScreenRect != *lastOverlayScreenRect_ ||
@@ -762,19 +765,31 @@ bool RenderCoordinator::rasterizeOverlayForPresentation(
                                          representedDragPreview.has_value() ||
                                          activeBoundsPreview.has_value();
   const std::uint64_t currentVersion = app.document().currentFrameVersion();
-  // Non-transforming geometry edits usually have no presenter-side projection that can make live
-  // chrome line up with older document pixels. Live-geometry tools are the exception (the caller
-  // passes `allowLiveGeometryOverlay`): active PenTool editing, where the selected path is itself
-  // the live interaction surface, and active TextTool sessions, where every keystroke flushes the
-  // DOM ahead of the async renderer and the caret/frame chrome comes from the live post-flush DOM.
-  // For those the chrome must keep tracking the live document; resetting the snapshot here would
-  // blink the caret/selection chrome off for the whole typing or drafting burst.
+  // Hold the overlay RECAPTURE back while the live document runs ahead of the presented pixels: a
+  // non-transforming geometry edit has no presenter-side projection that could make chrome captured
+  // from the new DOM line up with the older pixels on screen. Live-geometry tools are the exception
+  // the caller names with `allowLiveGeometryOverlay` - active PenTool editing, where the selected
+  // path is itself the live interaction surface, and active TextTool sessions, where every
+  // keystroke flushes the DOM ahead of the async renderer and the caret/frame chrome comes from the
+  // live post-flush DOM. For those the chrome must keep tracking the live document, or it blinks
+  // off for the whole typing or drafting burst.
+  //
+  // Only the recapture is held back, never the snapshot itself. The presenter installs its chrome
+  // pass only for frames this coordinator is holding a snapshot for, so releasing the snapshot here
+  // would present document pixels with no chrome pass over them at all: the selection outline,
+  // bounds and handles blink out until the worker catches up. Retaining it costs at most a
+  // one-render lead over the presented pixels - the conservative half of the choice the
+  // live-geometry tools above already make deliberately - and the retained geometry is re-pointed
+  // at the transform those pixels landed in before it is drawn.
+  //
+  // The chrome subject is the one difference no lead can excuse: an outline around elements that
+  // are no longer selected or hovered is wrong rather than early, and no recapture is coming while
+  // this gate holds. Recapture for those frames instead, so the chrome names the right elements -
+  // deselecting captures empty chrome, which is what draws nothing.
   if (displayedDocVersion_ != 0u && currentVersion > displayedDocVersion_ &&
-      !hasPresentationProjection && !allowLiveGeometryOverlay) {
+      !hasPresentationProjection && !allowLiveGeometryOverlay &&
+      !chromeSubjectDiffersFromSnapshot(app)) {
     ++overlayVersionGateSuppressionTotal_;
-    if (immediateOverlaySnapshot_.has_value() && lastOverlayVersion_ > displayedDocVersion_) {
-      immediateOverlaySnapshot_.reset();
-    }
 
     FrameCostBreakdown::Overlay overlayCost;
     overlayCost.canvasSize = OverlayRasterSizeForViewport(viewport);

--- a/donner/editor/RenderCoordinator.h
+++ b/donner/editor/RenderCoordinator.h
@@ -355,6 +355,19 @@ private:
   [[nodiscard]] Entity selectedCompositedEntity(EditorApp& app) const;
   [[nodiscard]] std::vector<Entity> selectedCompositedExtraEntities(EditorApp& app,
                                                                     Entity primaryEntity) const;
+  /**
+   * True when the elements \ref immediateOverlaySnapshot draws chrome for are no longer the
+   * elements the editor would draw chrome for now.
+   *
+   * This is about *what* the chrome annotates, not where it sits: the selection and the transient
+   * source-hover set are the only inputs that decide which elements get an outline, so a snapshot
+   * captured for a different set annotates elements that are no longer selected or hovered. That
+   * is the one difference the overlay refresh may never skip, because a snapshot describing the
+   * wrong elements is worse than one that trails the live geometry by a frame.
+   *
+   * @param app Editor application state holding the live selection.
+   */
+  [[nodiscard]] bool chromeSubjectDiffersFromSnapshot(const EditorApp& app) const;
 
   struct RenderWorkerBundle {
     explicit RenderWorkerBundle(

--- a/donner/editor/RenderCoordinator.h
+++ b/donner/editor/RenderCoordinator.h
@@ -359,11 +359,15 @@ private:
    * True when the elements \ref immediateOverlaySnapshot draws chrome for are no longer the
    * elements the editor would draw chrome for now.
    *
-   * This is about *what* the chrome annotates, not where it sits: the selection and the transient
-   * source-hover set are the only inputs that decide which elements get an outline, so a snapshot
-   * captured for a different set annotates elements that are no longer selected or hovered. That
-   * is the one difference the overlay refresh may never skip, because a snapshot describing the
-   * wrong elements is worse than one that trails the live geometry by a frame.
+   * This is about *what* the chrome annotates, not where it sits: a snapshot captured for a
+   * different selection or source-hover set annotates elements that are no longer selected or
+   * hovered. That is the one difference the overlay refresh may never skip, because a snapshot
+   * describing the wrong elements is worse than one that trails the live geometry by a frame.
+   *
+   * Selection and source hover are not the whole chrome subject. A locked-rejection flash outlines
+   * an element that is not selected, and a marquee rect is chrome that annotates no element at all.
+   * Both are short-lived interaction state that already keeps the overlay refreshing every frame on
+   * its own, so they are compared with the rest of the per-frame geometry instead of here.
    *
    * @param app Editor application state holding the live selection.
    */

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -986,8 +986,8 @@ public:
     return shell.renderCoordinator_.selectionBoundsCache().displayedBoundsDoc.size();
   }
 
-  static bool ImmediateChromePlanInstalled(const EditorShell& shell) {
-    return shell.immediateChromePlanInstalled_;
+  static bool ImmediateChromePlanProduced(const EditorShell& shell) {
+    return shell.immediateChromePlanProduced_;
   }
 
   static std::size_t SelectionChromePathCount(const EditorShell& shell) {
@@ -1908,7 +1908,7 @@ TEST(EditorShellTest, SelectionChromePresentsOnFramesTheOverlayVersionGateSuppre
 
   const std::uint64_t presentedVersion = RunFramesUntilChromeLeadsPresentedDocument(window, shell);
   ASSERT_GT(presentedVersion, 0u) << "The gate only engages once a render has been presented.";
-  ASSERT_TRUE(EditorShellTestAccess::ImmediateChromePlanInstalled(shell));
+  ASSERT_TRUE(EditorShellTestAccess::ImmediateChromePlanProduced(shell));
   ASSERT_EQ(EditorShellTestAccess::ImmediateOverlayDocumentVersion(shell),
             std::optional<std::uint64_t>(app.document().currentFrameVersion()));
   ASSERT_GT(app.document().currentFrameVersion(), presentedVersion)
@@ -1929,7 +1929,7 @@ TEST(EditorShellTest, SelectionChromePresentsOnFramesTheOverlayVersionGateSuppre
       << "Withheld results should have kept the presented version pinned across the frame.";
   ASSERT_GT(EditorShellTestAccess::OverlayVersionGateSuppressions(shell), suppressionsBeforeFrame)
       << "This frame must actually be one the version gate suppressed, or it proves nothing.";
-  EXPECT_TRUE(EditorShellTestAccess::ImmediateChromePlanInstalled(shell))
+  EXPECT_TRUE(EditorShellTestAccess::ImmediateChromePlanProduced(shell))
       << "A suppressed overlay refresh must not take the chrome pass with it: without a plan the "
          "frame presents document pixels with no chrome drawn over them, and the selection "
          "outline, bounds and handles blink out until the worker catches up.";
@@ -1962,6 +1962,8 @@ TEST(EditorShellTest, DeselectingDropsChromeOnFramesTheOverlayVersionGateSuppres
                                                .tool = "select",
                                            });
   app.clearSelection();
+  ASSERT_GT(app.document().currentFrameVersion(), presentedVersion)
+      << "The Pen frame must leave the chrome captured ahead of the presented pixels.";
   const std::uint64_t suppressionsBeforeFrame =
       EditorShellTestAccess::OverlayVersionGateSuppressions(shell);
   RunShellFrame(window, shell);

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -986,6 +986,32 @@ public:
     return shell.renderCoordinator_.selectionBoundsCache().displayedBoundsDoc.size();
   }
 
+  static bool ImmediateChromePlanInstalled(const EditorShell& shell) {
+    return shell.immediateChromePlanInstalled_;
+  }
+
+  static std::size_t SelectionChromePathCount(const EditorShell& shell) {
+    const std::optional<SelectionChromeSnapshot>& snapshot =
+        shell.renderCoordinator_.immediateOverlaySnapshot();
+    return snapshot.has_value() ? snapshot->paths.size() : 0u;
+  }
+
+  static std::uint64_t DisplayedDocVersion(const EditorShell& shell) {
+    return shell.renderCoordinator_.displayedDocVersion();
+  }
+
+  static std::optional<std::uint64_t> ImmediateOverlayDocumentVersion(const EditorShell& shell) {
+    return shell.renderCoordinator_.immediateOverlayDocumentVersionForDiagnostics();
+  }
+
+  static std::uint64_t OverlayVersionGateSuppressions(const EditorShell& shell) {
+    return shell.renderCoordinator_.overlayVersionGateSuppressionTotalForDiagnostics();
+  }
+
+  static void HoldRenderResultsForPolls(EditorShell& shell, int polls) {
+    shell.renderCoordinator_.asyncRenderer().setReplayResultHoldFramesForTesting(polls);
+  }
+
   static std::vector<svg::SVGElement> ReferenceHighlightElements(const EditorShell& shell) {
     return shell.referenceHighlightElements();
   }
@@ -1355,17 +1381,56 @@ public:
   }
 };
 
+void RunShellFrame(gui::EditorWindow& window, EditorShell& shell) {
+  window.beginFrame();
+  shell.runFrame();
+  window.endFrame();
+}
+
 void RunFramesUntilDisplayedSelectionBounds(gui::EditorWindow& window, EditorShell& shell) {
   for (int attempt = 0; attempt < 40; ++attempt) {
-    window.beginFrame();
-    shell.runFrame();
-    window.endFrame();
+    RunShellFrame(window, shell);
     if (EditorShellTestAccess::DisplayedSelectionBoundsCount(shell) > 0u) {
       return;
     }
 
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
   }
+}
+
+/// Drive the frames that leave the editor holding selection chrome captured against a document
+/// version the presented pixels have not caught up to.
+///
+/// That state is what the overlay version gate is written for, and reaching it takes two things
+/// the editor only does together: a live-geometry tool (the Pen tool here) captures chrome from
+/// the post-flush DOM instead of waiting for the raster, and the worker has not published that
+/// version yet. Results are withheld from every later poll so the presented version stays pinned
+/// where the initial settle left it, making the gate's engagement a property of the sequence
+/// rather than of how fast the worker happens to be.
+///
+/// @param window Hidden window driving the frames.
+/// @param shell Editor shell under test, with its target already selected.
+/// @return Document version the presented pixels are pinned at.
+std::uint64_t RunFramesUntilChromeLeadsPresentedDocument(gui::EditorWindow& window,
+                                                         EditorShell& shell) {
+  RunFramesUntilDisplayedSelectionBounds(window, shell);
+  EditorShellTestAccess::HoldRenderResultsForPolls(shell, 64);
+
+  const std::uint64_t presentedVersion = EditorShellTestAccess::DisplayedDocVersion(shell);
+  EditorShellTestAccess::ApplyReplayAction(shell,
+                                           repro::ReproAction{
+                                               .kind = repro::ReproAction::Kind::SetActiveTool,
+                                               .tool = "pen",
+                                           });
+  EditorShellTestAccess::ApplyReplayAction(shell,
+                                           repro::ReproAction{
+                                               .kind = repro::ReproAction::Kind::SetStyleProperty,
+                                               .propertyName = "fill",
+                                               .propertyValue = "#010203",
+                                           });
+  (void)EditorShellTestAccess::App(shell).flushFrame();
+  RunShellFrame(window, shell);
+  return presentedVersion;
 }
 
 bool WaitForStyleSourceDecorations(EditorShell& shell) {
@@ -1826,6 +1891,88 @@ TEST(EditorShellTest, ReplayActionsSwitchToolsAndIgnoreUnknownToolNames) {
                                                .kind = repro::ReproAction::Kind::CommitPenPath,
                                            });
   EXPECT_TRUE(EditorShellTestAccess::ActiveToolIsSelect(shell));
+}
+
+TEST(EditorShellTest, SelectionChromePresentsOnFramesTheOverlayVersionGateSuppresses) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg));
+  ASSERT_TRUE(shell.valid());
+  EditorApp& app = EditorShellTestAccess::App(shell);
+  auto target = app.document().document().querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  app.setSelection(*target);
+
+  const std::uint64_t presentedVersion = RunFramesUntilChromeLeadsPresentedDocument(window, shell);
+  ASSERT_GT(presentedVersion, 0u) << "The gate only engages once a render has been presented.";
+  ASSERT_TRUE(EditorShellTestAccess::ImmediateChromePlanInstalled(shell));
+  ASSERT_EQ(EditorShellTestAccess::ImmediateOverlayDocumentVersion(shell),
+            std::optional<std::uint64_t>(app.document().currentFrameVersion()));
+  ASSERT_GT(app.document().currentFrameVersion(), presentedVersion)
+      << "The Pen frame must leave the chrome captured ahead of the presented pixels.";
+
+  // Leaving the Pen tool takes away the live-geometry allowance, and there is no drag projection
+  // to reconcile chrome with older pixels, so the next frame is one the gate suppresses.
+  EditorShellTestAccess::ApplyReplayAction(shell,
+                                           repro::ReproAction{
+                                               .kind = repro::ReproAction::Kind::SetActiveTool,
+                                               .tool = "select",
+                                           });
+  const std::uint64_t suppressionsBeforeFrame =
+      EditorShellTestAccess::OverlayVersionGateSuppressions(shell);
+  RunShellFrame(window, shell);
+
+  ASSERT_EQ(EditorShellTestAccess::DisplayedDocVersion(shell), presentedVersion)
+      << "Withheld results should have kept the presented version pinned across the frame.";
+  ASSERT_GT(EditorShellTestAccess::OverlayVersionGateSuppressions(shell), suppressionsBeforeFrame)
+      << "This frame must actually be one the version gate suppressed, or it proves nothing.";
+  EXPECT_TRUE(EditorShellTestAccess::ImmediateChromePlanInstalled(shell))
+      << "A suppressed overlay refresh must not take the chrome pass with it: without a plan the "
+         "frame presents document pixels with no chrome drawn over them, and the selection "
+         "outline, bounds and handles blink out until the worker catches up.";
+  EXPECT_EQ(EditorShellTestAccess::SelectionChromePathCount(shell), 1u)
+      << "The retained chrome should still outline the selected element.";
+}
+
+TEST(EditorShellTest, DeselectingDropsChromeOnFramesTheOverlayVersionGateSuppresses) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg));
+  ASSERT_TRUE(shell.valid());
+  EditorApp& app = EditorShellTestAccess::App(shell);
+  auto target = app.document().document().querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  app.setSelection(*target);
+
+  const std::uint64_t presentedVersion = RunFramesUntilChromeLeadsPresentedDocument(window, shell);
+  ASSERT_GT(presentedVersion, 0u);
+  ASSERT_EQ(EditorShellTestAccess::SelectionChromePathCount(shell), 1u);
+
+  // Deselecting under the same suppressed-refresh conditions. Retained chrome may trail the live
+  // geometry, but it may never outline an element that is no longer selected.
+  EditorShellTestAccess::ApplyReplayAction(shell,
+                                           repro::ReproAction{
+                                               .kind = repro::ReproAction::Kind::SetActiveTool,
+                                               .tool = "select",
+                                           });
+  app.clearSelection();
+  const std::uint64_t suppressionsBeforeFrame =
+      EditorShellTestAccess::OverlayVersionGateSuppressions(shell);
+  RunShellFrame(window, shell);
+
+  ASSERT_EQ(EditorShellTestAccess::DisplayedDocVersion(shell), presentedVersion);
+  EXPECT_EQ(EditorShellTestAccess::OverlayVersionGateSuppressions(shell), suppressionsBeforeFrame)
+      << "A changed chrome subject must recapture instead of suppressing, because no later frame "
+         "will recapture for it while the presented document stays behind.";
+  EXPECT_EQ(EditorShellTestAccess::SelectionChromePathCount(shell), 0u)
+      << "Chrome captured for the old selection must not survive the deselect just because the "
+         "overlay refresh is otherwise suppressed.";
 }
 
 TEST(EditorShellTest, ReplayActionSelectCommitsDraftPenPath) {

--- a/donner/editor/tests/GlRnrReplay_tests.cc
+++ b/donner/editor/tests/GlRnrReplay_tests.cc
@@ -2787,11 +2787,13 @@ TEST(GlRnrReplayTest, TextToolLivePointerClickOpensSessionAndTypes) {
 // collapses and later recovers is the per-keystroke flicker this reproduces.
 //
 // Observed failure mode (2026-07-06, Geode presentation): the text pixels
-// hold steady, but the cyan chrome collapses to zero for the entire typing
-// burst because `RenderCoordinator::rasterizeOverlayForPresentation` resets
-// the immediate overlay snapshot whenever the flushed document version is
-// ahead of the displayed version with no drag projection - and fast typing
-// keeps the document perpetually ahead of the async renderer.
+// held steady, but the cyan chrome collapsed to zero for the entire typing
+// burst, because at that time
+// `RenderCoordinator::rasterizeOverlayForPresentation` reset the immediate
+// overlay snapshot whenever the flushed document version was ahead of the
+// displayed version with no drag projection - and fast typing keeps the
+// document perpetually ahead of the async renderer. That reset is gone: the
+// coordinator holds the snapshot and defers only the recapture.
 TEST(GlRnrReplayTest, TypingIntoTextKeepsTextPixelsPresentEveryFrame) {
   if (!UsesGeodePresentation()) {
     GTEST_SKIP() << "Chrome pixels require the Geode direct presentation path.";

--- a/donner/editor/wasm/tests/browser-presentation-regression.spec.ts
+++ b/donner/editor/wasm/tests/browser-presentation-regression.spec.ts
@@ -916,15 +916,16 @@ test("Firefox keeps the dragged shape and its selection outline in every drag fr
       .toBeNull();
     // "No teal" has two very different causes and the pixels cannot tell them
     // apart: the chrome draw ran and its pixels missed this probe window, or no
-    // chrome was drawn at all. The second is reachable without any rendering
-    // fault - the immediate-chrome plan is only installed for frames where the
-    // render coordinator is holding a selection-chrome snapshot, so a frame that
-    // lands between overlay rebuilds presents the document underlay with no
-    // chrome pass over it. The app already publishes which case it was in
-    // `selectionChromeSnapshotPresent`, so read it here rather than leaving the
-    // next failure to guess. Read only on the failing path: this test asserts on
-    // per-frame drag timing, and a probe that costs a round trip per frame
-    // changes the thing it is measuring.
+    // chrome was drawn at all. The second means the render coordinator was not
+    // holding a selection-chrome snapshot for that frame, which is what the
+    // immediate-chrome plan - and with it the whole chrome pass - is installed
+    // from. The coordinator holds that snapshot for as long as there is chrome
+    // to draw and holds back only the recapture, so a frame without one is a
+    // defect rather than ordinary timing between overlay rebuilds. The app
+    // publishes which case it was in `selectionChromeSnapshotPresent`, so read
+    // it here rather than leaving the next failure to guess. Read only on the
+    // failing path: this test asserts on per-frame drag timing, and a probe that
+    // costs a round trip per frame changes the thing it is measuring.
     if (geometry?.teal === null || geometry?.teal === undefined) {
       const chromeState = await page
         .evaluate(() => ({


### PR DESCRIPTION
When the async overlay version gate suppressed recapture (the presented document running behind the current edit version), the render coordinator also reset the retained selection-chrome snapshot, so selection chrome blinked off for the frames of the catch-up window. This was visible as a selection-outline dropout for a frame or more after a non-transforming edit.

The fix holds back only the recapture, not the snapshot:

- The version gate now defers recapture while retaining the existing snapshot, so chrome keeps drawing across the catch-up window. Held chrome is re-pointed at the presented transform at draw time, so transform lockstep is preserved. The accepted cost is a bounded one-render geometry lead after a non-transforming edit, the same bargain the pen live preview already makes; the worst case (a full drag translation mismatch) is structurally unreachable because the drag preview path keeps its own presentation projection through post-release settle.
- A changed chrome subject still recaptures immediately via a new `chromeSubjectDiffersFromSnapshot` check, so deselecting drops chrome on the same frame instead of leaving stale outlines under the gate.
- `immediateChromePlanProduced_` records that a chrome plan was produced for the frame, giving tests a coordinator-side invariant to police.

Tests (EditorShell, run in both default and geode configs): two red-then-green cases pinned to each half of the fix. One proves chrome presents on frames the version gate suppresses recapture for (fails if the old reset is restored); the other proves deselect still drops chrome on those same frames and asserts the version-lead precondition held (fails if the subject check is removed). Both pin the presented version with poll-count holds rather than wall-clock waits. The full pixel-counting replay suite (32 cases) stays green, including the typing and drag lockstep invariants.

The fluid-canvas rendering design doc is updated in the same change to record the retention decision; it previously specified that the snapshot was not retained behind this gate, which is exactly what this change makes the mechanism.
