### PR TITLE
perf: Add wasm SIMD128 and SSE2 branches to the NEON-only tiny-skia filter files

### DIFF
--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/BUILD.bazel
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/BUILD.bazel
@@ -41,6 +41,7 @@ tiny_skia_cc_library(
         "SimdVec.h",
         "Tile.h",
         "Turbulence.h",
+        "TurbulenceKernel.h",
     ],
     include_prefix = "tiny_skia/filter",
     strip_include_prefix = ".",

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/ColorMatrix.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/ColorMatrix.cpp
@@ -4,11 +4,173 @@
 #include <cmath>
 #include <cstddef>
 
-#if defined(TINYSKIA_CFG_IF_SIMD_NATIVE) && (defined(__ARM_NEON) || defined(__ARM_NEON__))
-#include <arm_neon.h>
-#endif
+// Selects the ISA branch below and pulls in the matching intrinsics header.
+#include "tiny_skia/filter/SimdVec.h"
 
 namespace tiny_skia::filter {
+
+namespace {
+
+/// The 5x4 color matrix rearranged into one vector per input component, so the
+/// per-pixel work multiplies and accumulates all four output channels at once.
+///
+/// Built once per `colorMatrix()` call; `apply()` runs per pixel.
+///
+/// The wasm128, SSE2, and scalar branches all evaluate the same products and
+/// sums in the same left-to-right order, so their results are bit-identical.
+/// The NEON branch is not: it fuses each multiply and add into a single
+/// rounding step and accumulates the translation column first, which can differ
+/// by one unit in the last place. That predates the other branches and changing
+/// it would move rendered output on ARM.
+class ColorMatrixColumns {
+ public:
+#if defined(TINY_SKIA_SIMD_NEON)
+  explicit ColorMatrixColumns(const float (&m)[20]) {
+    // Each column holds one input component's coefficients across all four
+    // outputs.
+    const float32x4_t colR = {m[0], m[5], m[10], m[15]};
+    const float32x4_t colG = {m[1], m[6], m[11], m[16]};
+    const float32x4_t colB = {m[2], m[7], m[12], m[17]};
+    const float32x4_t colA = {m[3], m[8], m[13], m[18]};
+    const float32x4_t col1 = {m[4], m[9], m[14], m[19]};
+    colR_ = colR;
+    colG_ = colG;
+    colB_ = colB;
+    colA_ = colA;
+    col1_ = col1;
+  }
+
+  void apply(float r, float g, float b, float pa, float* out) const {
+    // result = col_1 + col_r*r + col_g*g + col_b*b + col_a*pa
+    float32x4_t result = col1_;
+    result = vfmaq_n_f32(result, colR_, r);
+    result = vfmaq_n_f32(result, colG_, g);
+    result = vfmaq_n_f32(result, colB_, b);
+    result = vfmaq_n_f32(result, colA_, pa);
+
+    // Clamp all channels to [0, 1].
+    result = vmaxq_f32(result, vdupq_n_f32(0.0f));
+    result = vminq_f32(result, vdupq_n_f32(1.0f));
+
+    // Extract the new alpha and premultiply RGB by it.
+    const float ca = vgetq_lane_f32(result, 3);
+    vst1q_f32(out, vmulq_n_f32(result, ca));
+    out[3] = ca;
+  }
+
+ private:
+  float32x4_t colR_;
+  float32x4_t colG_;
+  float32x4_t colB_;
+  float32x4_t colA_;
+  float32x4_t col1_;
+
+#elif defined(TINY_SKIA_SIMD_WASM_SIMD128)
+  explicit ColorMatrixColumns(const float (&m)[20])
+      : colR_(wasm_f32x4_make(m[0], m[5], m[10], m[15])),
+        colG_(wasm_f32x4_make(m[1], m[6], m[11], m[16])),
+        colB_(wasm_f32x4_make(m[2], m[7], m[12], m[17])),
+        colA_(wasm_f32x4_make(m[3], m[8], m[13], m[18])),
+        col1_(wasm_f32x4_make(m[4], m[9], m[14], m[19])) {}
+
+  void apply(float r, float g, float b, float pa, float* out) const {
+    // Accumulated in the scalar fallback's order with a separate multiply and
+    // add per term. wasm128 has no fused multiply-add outside relaxed SIMD, so
+    // each lane rounds exactly where the scalar expression rounds.
+    v128_t acc = wasm_f32x4_mul(colR_, wasm_f32x4_splat(r));
+    acc = wasm_f32x4_add(acc, wasm_f32x4_mul(colG_, wasm_f32x4_splat(g)));
+    acc = wasm_f32x4_add(acc, wasm_f32x4_mul(colB_, wasm_f32x4_splat(b)));
+    acc = wasm_f32x4_add(acc, wasm_f32x4_mul(colA_, wasm_f32x4_splat(pa)));
+    acc = wasm_f32x4_add(acc, col1_);
+
+    // pmin and pmax are plain lane selects, pmin(x, y) = y < x ? y : x and
+    // pmax(x, y) = x < y ? y : x, so this operand order evaluates
+    // std::clamp's `v < lo ? lo : (hi < v ? hi : v)` exactly. The IEEE
+    // f32x4.min/max would order the operands the other way round.
+    const v128_t clamped =
+        wasm_f32x4_pmin(wasm_f32x4_pmax(acc, wasm_f32x4_splat(0.0f)), wasm_f32x4_splat(1.0f));
+
+    // The scalar fallback clamps the premultiplied channels a second time.
+    // That clamp is an identity here: both factors are already in [0, 1] (or
+    // NaN, which every clamp passes through), so their product is too.
+    const float ca = wasm_f32x4_extract_lane(clamped, 3);
+    wasm_v128_store(out, wasm_f32x4_mul(clamped, wasm_f32x4_splat(ca)));
+    out[3] = ca;
+  }
+
+ private:
+  v128_t colR_;
+  v128_t colG_;
+  v128_t colB_;
+  v128_t colA_;
+  v128_t col1_;
+
+#elif defined(TINY_SKIA_SIMD_SSE2)
+  explicit ColorMatrixColumns(const float (&m)[20])
+      : colR_(_mm_setr_ps(m[0], m[5], m[10], m[15])),
+        colG_(_mm_setr_ps(m[1], m[6], m[11], m[16])),
+        colB_(_mm_setr_ps(m[2], m[7], m[12], m[17])),
+        colA_(_mm_setr_ps(m[3], m[8], m[13], m[18])),
+        col1_(_mm_setr_ps(m[4], m[9], m[14], m[19])) {}
+
+  void apply(float r, float g, float b, float pa, float* out) const {
+    // Accumulated in the scalar fallback's order with a separate multiply and
+    // add per term, so each lane rounds exactly where the scalar expression
+    // rounds. The library builds with -ffp-contract=off, so the compiler does
+    // not fuse these into FMAs either.
+    __m128 acc = _mm_mul_ps(colR_, _mm_set1_ps(r));
+    acc = _mm_add_ps(acc, _mm_mul_ps(colG_, _mm_set1_ps(g)));
+    acc = _mm_add_ps(acc, _mm_mul_ps(colB_, _mm_set1_ps(b)));
+    acc = _mm_add_ps(acc, _mm_mul_ps(colA_, _mm_set1_ps(pa)));
+    acc = _mm_add_ps(acc, col1_);
+
+    // _mm_max_ps(a, b) selects `a > b ? a : b` and _mm_min_ps(a, b) selects
+    // `a < b ? a : b`, so naming the bound first evaluates std::clamp's
+    // `v < lo ? lo : (hi < v ? hi : v)` exactly.
+    const __m128 clamped = _mm_min_ps(_mm_set1_ps(1.0f), _mm_max_ps(_mm_setzero_ps(), acc));
+
+    // As in the wasm128 branch, the scalar fallback's second clamp of the
+    // premultiplied channels is an identity and is dropped.
+    const float ca = _mm_cvtss_f32(_mm_shuffle_ps(clamped, clamped, _MM_SHUFFLE(3, 3, 3, 3)));
+    _mm_storeu_ps(out, _mm_mul_ps(clamped, _mm_set1_ps(ca)));
+    out[3] = ca;
+  }
+
+ private:
+  __m128 colR_;
+  __m128 colG_;
+  __m128 colB_;
+  __m128 colA_;
+  __m128 col1_;
+
+#else
+  explicit ColorMatrixColumns(const float (&m)[20]) {
+    for (int j = 0; j < 20; ++j) {
+      m_[j] = m[j];
+    }
+  }
+
+  void apply(float r, float g, float b, float pa, float* out) const {
+    // Apply the 5x4 matrix.
+    const float nr = m_[0] * r + m_[1] * g + m_[2] * b + m_[3] * pa + m_[4];
+    const float ng = m_[5] * r + m_[6] * g + m_[7] * b + m_[8] * pa + m_[9];
+    const float nb = m_[10] * r + m_[11] * g + m_[12] * b + m_[13] * pa + m_[14];
+    const float na = m_[15] * r + m_[16] * g + m_[17] * b + m_[18] * pa + m_[19];
+
+    // Clamp and re-premultiply.
+    const float ca = std::clamp(na, 0.0f, 1.0f);
+    out[0] = std::clamp(std::clamp(nr, 0.0f, 1.0f) * ca, 0.0f, 1.0f);
+    out[1] = std::clamp(std::clamp(ng, 0.0f, 1.0f) * ca, 0.0f, 1.0f);
+    out[2] = std::clamp(std::clamp(nb, 0.0f, 1.0f) * ca, 0.0f, 1.0f);
+    out[3] = ca;
+  }
+
+ private:
+  float m_[20];
+#endif
+};
+
+}  // namespace
 
 void colorMatrix(Pixmap& pixmap, const std::array<double, 20>& matrix) {
   auto data = pixmap.data();
@@ -84,97 +246,29 @@ void colorMatrix(FloatPixmap& pixmap, const std::array<double, 20>& matrix) {
     m[j] = static_cast<float>(matrix[j]);
   }
 
-#if defined(TINYSKIA_CFG_IF_SIMD_NATIVE) && (defined(__ARM_NEON) || defined(__ARM_NEON__))
-  // Transpose the 5x4 matrix into column vectors for NEON vectorized multiply.
-  // Each column contains the coefficients for one input component across all 4 outputs.
-  const float32x4_t col_r = {m[0], m[5], m[10], m[15]};   // R coefficients
-  const float32x4_t col_g = {m[1], m[6], m[11], m[16]};   // G coefficients
-  const float32x4_t col_b = {m[2], m[7], m[12], m[17]};   // B coefficients
-  const float32x4_t col_a = {m[3], m[8], m[13], m[18]};   // A coefficients
-  const float32x4_t col_1 = {m[4], m[9], m[14], m[19]};   // Translation
-  const float32x4_t zero = vdupq_n_f32(0.0f);
-  const float32x4_t one = vdupq_n_f32(1.0f);
+  const ColorMatrixColumns columns(m);
 
   for (std::size_t i = 0; i < pixelCount; ++i) {
-    const std::size_t offset = i * 4;
-    const float pa = ptr[offset + 3];
+    float* px = ptr + i * 4;
+    const float pa = px[3];
 
     if (pa == 0.0f) {
+      // Fully transparent: only the translation column can produce output.
       const float ca = std::clamp(m[19], 0.0f, 1.0f);
       if (ca == 0.0f) {
         continue;
       }
-      ptr[offset + 0] = std::clamp(m[4] * ca, 0.0f, 1.0f);
-      ptr[offset + 1] = std::clamp(m[9] * ca, 0.0f, 1.0f);
-      ptr[offset + 2] = std::clamp(m[14] * ca, 0.0f, 1.0f);
-      ptr[offset + 3] = ca;
+      px[0] = std::clamp(m[4] * ca, 0.0f, 1.0f);
+      px[1] = std::clamp(m[9] * ca, 0.0f, 1.0f);
+      px[2] = std::clamp(m[14] * ca, 0.0f, 1.0f);
+      px[3] = ca;
       continue;
     }
 
-    // Unpremultiply.
+    // Unpremultiply, then apply the matrix, clamp, and re-premultiply.
     const float invAlpha = 1.0f / pa;
-    const float r = ptr[offset + 0] * invAlpha;
-    const float g = ptr[offset + 1] * invAlpha;
-    const float b = ptr[offset + 2] * invAlpha;
-
-    // Matrix multiply: result = r*col_r + g*col_g + b*col_b + pa*col_a + col_1
-    float32x4_t result = col_1;
-    result = vfmaq_n_f32(result, col_r, r);
-    result = vfmaq_n_f32(result, col_g, g);
-    result = vfmaq_n_f32(result, col_b, b);
-    result = vfmaq_n_f32(result, col_a, pa);
-
-    // Clamp all channels to [0, 1].
-    result = vmaxq_f32(result, zero);
-    result = vminq_f32(result, one);
-
-    // Extract new alpha and premultiply RGB.
-    const float ca = vgetq_lane_f32(result, 3);
-    const float32x4_t premul = vmulq_n_f32(result, ca);
-
-    // Store premultiplied RGB and clamped alpha.
-    ptr[offset + 0] = vgetq_lane_f32(premul, 0);
-    ptr[offset + 1] = vgetq_lane_f32(premul, 1);
-    ptr[offset + 2] = vgetq_lane_f32(premul, 2);
-    ptr[offset + 3] = ca;
+    columns.apply(px[0] * invAlpha, px[1] * invAlpha, px[2] * invAlpha, pa, px);
   }
-#else
-  for (std::size_t i = 0; i < pixelCount; ++i) {
-    const std::size_t offset = i * 4;
-    const float pa = ptr[offset + 3];
-
-    if (pa == 0.0f) {
-      const float ca = std::clamp(m[19], 0.0f, 1.0f);
-      if (ca == 0.0f) {
-        continue;
-      }
-      ptr[offset + 0] = std::clamp(m[4] * ca, 0.0f, 1.0f);
-      ptr[offset + 1] = std::clamp(m[9] * ca, 0.0f, 1.0f);
-      ptr[offset + 2] = std::clamp(m[14] * ca, 0.0f, 1.0f);
-      ptr[offset + 3] = ca;
-      continue;
-    }
-
-    // Unpremultiply.
-    const float invAlpha = 1.0f / pa;
-    const float r = ptr[offset + 0] * invAlpha;
-    const float g = ptr[offset + 1] * invAlpha;
-    const float b = ptr[offset + 2] * invAlpha;
-
-    // Apply 5x4 matrix.
-    const float nr = m[0] * r + m[1] * g + m[2] * b + m[3] * pa + m[4];
-    const float ng = m[5] * r + m[6] * g + m[7] * b + m[8] * pa + m[9];
-    const float nb = m[10] * r + m[11] * g + m[12] * b + m[13] * pa + m[14];
-    const float na = m[15] * r + m[16] * g + m[17] * b + m[18] * pa + m[19];
-
-    // Clamp and re-premultiply.
-    const float ca = std::clamp(na, 0.0f, 1.0f);
-    ptr[offset + 0] = std::clamp(std::clamp(nr, 0.0f, 1.0f) * ca, 0.0f, 1.0f);
-    ptr[offset + 1] = std::clamp(std::clamp(ng, 0.0f, 1.0f) * ca, 0.0f, 1.0f);
-    ptr[offset + 2] = std::clamp(std::clamp(nb, 0.0f, 1.0f) * ca, 0.0f, 1.0f);
-    ptr[offset + 3] = ca;
-  }
-#endif
 }
 
 std::array<double, 20> saturateMatrix(double s) {

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/FloatPixmap.h
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/FloatPixmap.h
@@ -186,7 +186,8 @@ class FloatPixmap {
 
       // Truncation toward zero is what the scalar cast to uint8 does. The
       // conversion's saturation only applies to inputs the clamp already
-      // removed.
+      // removed, and its one remaining special case is NaN, which the clamp
+      // passes through and this conversion maps to zero.
       const v128_t u0 = wasm_u32x4_trunc_sat_f32x4(c0);
       const v128_t u1 = wasm_u32x4_trunc_sat_f32x4(c1);
       const v128_t u2 = wasm_u32x4_trunc_sat_f32x4(c2);
@@ -223,8 +224,12 @@ class FloatPixmap {
       const __m128i u2 = _mm_cvttps_epi32(c2);
       const __m128i u3 = _mm_cvttps_epi32(c3);
 
-      // Narrow 32->16->8. Every lane is already in [0, 255], so the saturating
-      // packs never actually saturate.
+      // Narrow 32->16->8. A lane that came from a finite value is already in
+      // [0, 255] and both packs leave it alone. A NaN lane is the one case that
+      // does saturate, and it has to: the clamp passes NaN through, the
+      // conversion turns it into INT_MIN, the signed pack clamps that to
+      // -32768, and the unsigned pack clamps that to 0. That is the same byte
+      // the wasm128 branch's saturating conversion produces for NaN.
       const __m128i lo = _mm_packs_epi32(u0, u1);
       const __m128i hi = _mm_packs_epi32(u2, u3);
       _mm_storeu_si128(reinterpret_cast<__m128i*>(&bytes[i]), _mm_packus_epi16(lo, hi));

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/FloatPixmap.h
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/FloatPixmap.h
@@ -14,11 +14,9 @@
 #include <span>
 #include <vector>
 
-#if defined(TINYSKIA_CFG_IF_SIMD_NATIVE) && (defined(__ARM_NEON) || defined(__ARM_NEON__))
-#include <arm_neon.h>
-#endif
-
 #include "tiny_skia/Pixmap.h"
+// Selects the ISA branch below and pulls in the matching intrinsics header.
+#include "tiny_skia/filter/SimdVec.h"
 
 namespace tiny_skia::filter {
 
@@ -54,7 +52,7 @@ class FloatPixmap {
     const std::size_t count = src.size();
     std::vector<float> data(count);
     std::size_t i = 0;
-#if defined(TINYSKIA_CFG_IF_SIMD_NATIVE) && (defined(__ARM_NEON) || defined(__ARM_NEON__))
+#if defined(TINY_SKIA_SIMD_NEON)
     const float32x4_t scale = vdupq_n_f32(1.0f / 255.0f);
     // Process 16 bytes (4 RGBA pixels) at a time.
     for (; i + 16 <= count; i += 16) {
@@ -75,6 +73,54 @@ class FloatPixmap {
       vst1q_f32(&data[i + 8], vmulq_f32(vcvtq_f32_u32(u2), scale));
       vst1q_f32(&data[i + 12], vmulq_f32(vcvtq_f32_u32(u3), scale));
     }
+#elif defined(TINY_SKIA_SIMD_WASM_SIMD128)
+    // Divides instead of multiplying by the reciprocal of 255. 1/255 is not
+    // exactly representable, and the rounded reciprocal disagrees with the
+    // divide in the last place for 126 of the 256 byte values, so only the
+    // divide reproduces the scalar tail below bit for bit. The NEON branch
+    // above multiplies; that predates this branch and changing it would move
+    // rendered output on ARM.
+    const v128_t scale = wasm_f32x4_splat(255.0f);
+    // Process 16 bytes (4 RGBA pixels) at a time.
+    for (; i + 16 <= count; i += 16) {
+      const v128_t bytes = wasm_v128_load(&src[i]);
+      // Widen 8->16->32 and convert to float.
+      const v128_t lo16 = wasm_u16x8_extend_low_u8x16(bytes);
+      const v128_t hi16 = wasm_u16x8_extend_high_u8x16(bytes);
+
+      const v128_t f0 = wasm_f32x4_convert_u32x4(wasm_u32x4_extend_low_u16x8(lo16));
+      const v128_t f1 = wasm_f32x4_convert_u32x4(wasm_u32x4_extend_high_u16x8(lo16));
+      const v128_t f2 = wasm_f32x4_convert_u32x4(wasm_u32x4_extend_low_u16x8(hi16));
+      const v128_t f3 = wasm_f32x4_convert_u32x4(wasm_u32x4_extend_high_u16x8(hi16));
+
+      wasm_v128_store(&data[i + 0], wasm_f32x4_div(f0, scale));
+      wasm_v128_store(&data[i + 4], wasm_f32x4_div(f1, scale));
+      wasm_v128_store(&data[i + 8], wasm_f32x4_div(f2, scale));
+      wasm_v128_store(&data[i + 12], wasm_f32x4_div(f3, scale));
+    }
+#elif defined(TINY_SKIA_SIMD_SSE2)
+    // Divides for the same reason as the wasm128 branch above: the rounded
+    // reciprocal of 255 is not bit-exact against the scalar tail.
+    const __m128 scale = _mm_set1_ps(255.0f);
+    const __m128i zero = _mm_setzero_si128();
+    // Process 16 bytes (4 RGBA pixels) at a time.
+    for (; i + 16 <= count; i += 16) {
+      const __m128i bytes = _mm_loadu_si128(reinterpret_cast<const __m128i*>(&src[i]));
+      // Widen 8->16->32 by interleaving with zero, then convert to float. Every
+      // lane is at most 255, so the signed 32-bit conversion is exact.
+      const __m128i lo16 = _mm_unpacklo_epi8(bytes, zero);
+      const __m128i hi16 = _mm_unpackhi_epi8(bytes, zero);
+
+      const __m128 f0 = _mm_cvtepi32_ps(_mm_unpacklo_epi16(lo16, zero));
+      const __m128 f1 = _mm_cvtepi32_ps(_mm_unpackhi_epi16(lo16, zero));
+      const __m128 f2 = _mm_cvtepi32_ps(_mm_unpacklo_epi16(hi16, zero));
+      const __m128 f3 = _mm_cvtepi32_ps(_mm_unpackhi_epi16(hi16, zero));
+
+      _mm_storeu_ps(&data[i + 0], _mm_div_ps(f0, scale));
+      _mm_storeu_ps(&data[i + 4], _mm_div_ps(f1, scale));
+      _mm_storeu_ps(&data[i + 8], _mm_div_ps(f2, scale));
+      _mm_storeu_ps(&data[i + 12], _mm_div_ps(f3, scale));
+    }
 #endif
     for (; i < count; ++i) {
       data[i] = src[i] / 255.0f;
@@ -87,7 +133,7 @@ class FloatPixmap {
     const std::size_t count = data_.size();
     std::vector<std::uint8_t> bytes(count);
     std::size_t i = 0;
-#if defined(TINYSKIA_CFG_IF_SIMD_NATIVE) && (defined(__ARM_NEON) || defined(__ARM_NEON__))
+#if defined(TINY_SKIA_SIMD_NEON)
     const float32x4_t scale = vdupq_n_f32(255.0f);
     const float32x4_t half = vdupq_n_f32(0.5f);
     // Process 16 floats (4 RGBA pixels) at a time.
@@ -114,6 +160,74 @@ class FloatPixmap {
       const uint8x8_t b0 = vmovn_u16(lo);
       const uint8x8_t b1 = vmovn_u16(hi);
       vst1q_u8(&bytes[i], vcombine_u8(b0, b1));
+    }
+#elif defined(TINY_SKIA_SIMD_WASM_SIMD128)
+    const v128_t scale = wasm_f32x4_splat(255.0f);
+    const v128_t half = wasm_f32x4_splat(0.5f);
+    const v128_t zero = wasm_f32x4_splat(0.0f);
+    // Process 16 floats (4 RGBA pixels) at a time.
+    for (; i + 16 <= count; i += 16) {
+      // Multiply by 255 and add 0.5 for rounding, as two separately rounded
+      // operations: wasm128 has no fused multiply-add outside relaxed SIMD, so
+      // this rounds exactly where the scalar tail rounds.
+      const v128_t f0 = wasm_f32x4_add(wasm_f32x4_mul(wasm_v128_load(&data_[i + 0]), scale), half);
+      const v128_t f1 = wasm_f32x4_add(wasm_f32x4_mul(wasm_v128_load(&data_[i + 4]), scale), half);
+      const v128_t f2 = wasm_f32x4_add(wasm_f32x4_mul(wasm_v128_load(&data_[i + 8]), scale), half);
+      const v128_t f3 = wasm_f32x4_add(wasm_f32x4_mul(wasm_v128_load(&data_[i + 12]), scale), half);
+
+      // pmin and pmax are plain lane selects, pmin(x, y) = y < x ? y : x and
+      // pmax(x, y) = x < y ? y : x, so this operand order evaluates
+      // std::clamp's `v < lo ? lo : (hi < v ? hi : v)` exactly. The IEEE
+      // f32x4.min/max would order the operands the other way round.
+      const v128_t c0 = wasm_f32x4_pmin(wasm_f32x4_pmax(f0, zero), scale);
+      const v128_t c1 = wasm_f32x4_pmin(wasm_f32x4_pmax(f1, zero), scale);
+      const v128_t c2 = wasm_f32x4_pmin(wasm_f32x4_pmax(f2, zero), scale);
+      const v128_t c3 = wasm_f32x4_pmin(wasm_f32x4_pmax(f3, zero), scale);
+
+      // Truncation toward zero is what the scalar cast to uint8 does. The
+      // conversion's saturation only applies to inputs the clamp already
+      // removed.
+      const v128_t u0 = wasm_u32x4_trunc_sat_f32x4(c0);
+      const v128_t u1 = wasm_u32x4_trunc_sat_f32x4(c1);
+      const v128_t u2 = wasm_u32x4_trunc_sat_f32x4(c2);
+      const v128_t u3 = wasm_u32x4_trunc_sat_f32x4(c3);
+
+      // Narrow 32->16->8. Every lane is already in [0, 255], so the signed
+      // saturating narrows never actually saturate.
+      const v128_t lo = wasm_i16x8_narrow_i32x4(u0, u1);
+      const v128_t hi = wasm_i16x8_narrow_i32x4(u2, u3);
+      wasm_v128_store(&bytes[i], wasm_u8x16_narrow_i16x8(lo, hi));
+    }
+#elif defined(TINY_SKIA_SIMD_SSE2)
+    const __m128 scale = _mm_set1_ps(255.0f);
+    const __m128 half = _mm_set1_ps(0.5f);
+    const __m128 zero = _mm_setzero_ps();
+    // Process 16 floats (4 RGBA pixels) at a time.
+    for (; i + 16 <= count; i += 16) {
+      const __m128 f0 = _mm_add_ps(_mm_mul_ps(_mm_loadu_ps(&data_[i + 0]), scale), half);
+      const __m128 f1 = _mm_add_ps(_mm_mul_ps(_mm_loadu_ps(&data_[i + 4]), scale), half);
+      const __m128 f2 = _mm_add_ps(_mm_mul_ps(_mm_loadu_ps(&data_[i + 8]), scale), half);
+      const __m128 f3 = _mm_add_ps(_mm_mul_ps(_mm_loadu_ps(&data_[i + 12]), scale), half);
+
+      // _mm_max_ps(a, b) selects `a > b ? a : b` and _mm_min_ps(a, b) selects
+      // `a < b ? a : b`, so naming the bound first evaluates std::clamp's
+      // `v < lo ? lo : (hi < v ? hi : v)` exactly.
+      const __m128 c0 = _mm_min_ps(scale, _mm_max_ps(zero, f0));
+      const __m128 c1 = _mm_min_ps(scale, _mm_max_ps(zero, f1));
+      const __m128 c2 = _mm_min_ps(scale, _mm_max_ps(zero, f2));
+      const __m128 c3 = _mm_min_ps(scale, _mm_max_ps(zero, f3));
+
+      // Truncates toward zero, like the scalar cast to uint8.
+      const __m128i u0 = _mm_cvttps_epi32(c0);
+      const __m128i u1 = _mm_cvttps_epi32(c1);
+      const __m128i u2 = _mm_cvttps_epi32(c2);
+      const __m128i u3 = _mm_cvttps_epi32(c3);
+
+      // Narrow 32->16->8. Every lane is already in [0, 255], so the saturating
+      // packs never actually saturate.
+      const __m128i lo = _mm_packs_epi32(u0, u1);
+      const __m128i hi = _mm_packs_epi32(u2, u3);
+      _mm_storeu_si128(reinterpret_cast<__m128i*>(&bytes[i]), _mm_packus_epi16(lo, hi));
     }
 #endif
     for (; i < count; ++i) {

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/Merge.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/Merge.cpp
@@ -213,3 +213,5 @@ void merge(std::span<const FloatPixmap* const> layers, FloatPixmap& dst) {
 }
 
 }  // namespace tiny_skia::filter
+
+#undef TINY_SKIA_FILTER_MERGE_VECTOR

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/Merge.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/Merge.cpp
@@ -5,11 +5,152 @@
 #include <cstdint>
 #include <cstring>
 
-#if defined(TINYSKIA_CFG_IF_SIMD_NATIVE) && defined(__ARM_NEON)
-#include <arm_neon.h>
-#endif
+// Selects the ISA branch below and pulls in the matching intrinsics header.
+#include "tiny_skia/filter/SimdVec.h"
 
 namespace tiny_skia::filter {
+
+namespace {
+
+/// Skia's div255: (v + 128 + ((v + 128) >> 8)) >> 8, exact for v <= 255*255.
+std::uint32_t div255(std::uint32_t v) { return (v + 128 + ((v + 128) >> 8)) >> 8; }
+
+/// Source-Over of one 8-bit pixel: dst = src + div255(dst * (255 - srcAlpha)),
+/// saturated at 255.
+///
+/// Used directly by the scalar path and as the vector paths' tail, so both
+/// produce the same bytes for a partial group of pixels.
+void mergePixel(std::uint8_t* out, const std::uint8_t* src) {
+  const std::uint32_t sa = src[3];
+  if (sa == 0) {
+    return;
+  }
+  if (sa == 255) {
+    std::memcpy(out, src, 4);
+    return;
+  }
+
+  const std::uint32_t invSa = 255 - sa;
+  for (std::size_t channel = 0; channel < 4; ++channel) {
+    out[channel] = static_cast<std::uint8_t>(
+        std::min(255u, static_cast<std::uint32_t>(src[channel]) +
+                           div255(static_cast<std::uint32_t>(out[channel]) * invSa)));
+  }
+}
+
+#if defined(TINY_SKIA_SIMD_NEON) || defined(TINY_SKIA_SIMD_WASM_SIMD128) || \
+    defined(TINY_SKIA_SIMD_SSE2)
+#define TINY_SKIA_FILTER_MERGE_VECTOR 1
+
+/// Source-Over of four consecutive 8-bit pixels (16 bytes).
+///
+/// Every branch evaluates the general formula for all four pixels, without
+/// `mergePixel`'s two shortcuts. Both shortcuts are identities of the general
+/// formula on premultiplied input: at srcAlpha 255 the `dst * 0` term vanishes,
+/// and at srcAlpha 0 the term is `div255(dst * 255) == dst` while a
+/// premultiplied source with zero alpha has zero color. Every intermediate
+/// stays in 16-bit range (255 * 255 + 128 + 254 = 65407), and the final
+/// saturating narrow reproduces `std::min(255u, ...)` because the sum of two
+/// values at most 255 is never negative when read as signed.
+void mergeFourPixels(std::uint8_t* out, const std::uint8_t* src) {
+#if defined(TINY_SKIA_SIMD_NEON)
+  const uint8x16_t srcPx = vld1q_u8(src);
+  const uint8x16_t dstPx = vld1q_u8(out);
+
+  // Widen src and dst to 16-bit for arithmetic.
+  // srcPx layout: [R0 G0 B0 A0 R1 G1 B1 A1 R2 G2 B2 A2 R3 G3 B3 A3]
+  const uint16x8_t srcW0 = vmovl_u8(vget_low_u8(srcPx));
+  const uint16x8_t srcW1 = vmovl_u8(vget_high_u8(srcPx));
+  const uint16x8_t dstW0 = vmovl_u8(vget_low_u8(dstPx));
+  const uint16x8_t dstW1 = vmovl_u8(vget_high_u8(dstPx));
+
+  // Broadcast 255 - srcAlpha across each pixel's four lanes.
+  const uint16x8_t invA0 = vdupq_n_u16(255 - vgetq_lane_u16(srcW0, 3));
+  const uint16x8_t invA1 = vdupq_n_u16(255 - vgetq_lane_u16(srcW0, 7));
+  const uint16x8_t invA2 = vdupq_n_u16(255 - vgetq_lane_u16(srcW1, 3));
+  const uint16x8_t invA3 = vdupq_n_u16(255 - vgetq_lane_u16(srcW1, 7));
+  const uint16x8_t invAlphaLo = vcombine_u16(vget_low_u16(invA0), vget_low_u16(invA1));
+  const uint16x8_t invAlphaHi = vcombine_u16(vget_low_u16(invA2), vget_low_u16(invA3));
+
+  // div255(dst * invAlpha).
+  uint16x8_t t0 = vaddq_u16(vmulq_u16(dstW0, invAlphaLo), vdupq_n_u16(128));
+  uint16x8_t t1 = vaddq_u16(vmulq_u16(dstW1, invAlphaHi), vdupq_n_u16(128));
+  t0 = vshrq_n_u16(vaddq_u16(t0, vshrq_n_u16(t0, 8)), 8);
+  t1 = vshrq_n_u16(vaddq_u16(t1, vshrq_n_u16(t1, 8)), 8);
+
+  // result = src + div255(dst * invAlpha), narrowed back to uint8 saturating.
+  const uint8x8_t resLo = vqmovn_u16(vaddq_u16(srcW0, t0));
+  const uint8x8_t resHi = vqmovn_u16(vaddq_u16(srcW1, t1));
+  vst1q_u8(out, vcombine_u8(resLo, resHi));
+
+#elif defined(TINY_SKIA_SIMD_WASM_SIMD128)
+  const v128_t srcPx = wasm_v128_load(src);
+  const v128_t dstPx = wasm_v128_load(out);
+
+  // Broadcast each pixel's alpha byte over its own four bytes, then subtract
+  // from 255 in byte lanes: 255 - alpha never underflows.
+  const v128_t alphaBytes =
+      wasm_i8x16_shuffle(srcPx, srcPx, 3, 3, 3, 3, 7, 7, 7, 7, 11, 11, 11, 11, 15, 15, 15, 15);
+  const v128_t invAlphaBytes = wasm_i8x16_sub(wasm_u8x16_splat(255), alphaBytes);
+
+  // Widen src, dst, and the inverse alphas to 16-bit for arithmetic.
+  const v128_t srcW0 = wasm_u16x8_extend_low_u8x16(srcPx);
+  const v128_t srcW1 = wasm_u16x8_extend_high_u8x16(srcPx);
+  const v128_t dstW0 = wasm_u16x8_extend_low_u8x16(dstPx);
+  const v128_t dstW1 = wasm_u16x8_extend_high_u8x16(dstPx);
+  const v128_t invAlphaLo = wasm_u16x8_extend_low_u8x16(invAlphaBytes);
+  const v128_t invAlphaHi = wasm_u16x8_extend_high_u8x16(invAlphaBytes);
+
+  // div255(dst * invAlpha). The shifts must be logical, so they use the u16
+  // form; the adds and the multiply are bit-identical either way.
+  v128_t t0 = wasm_i16x8_add(wasm_i16x8_mul(dstW0, invAlphaLo), wasm_i16x8_splat(128));
+  v128_t t1 = wasm_i16x8_add(wasm_i16x8_mul(dstW1, invAlphaHi), wasm_i16x8_splat(128));
+  t0 = wasm_u16x8_shr(wasm_i16x8_add(t0, wasm_u16x8_shr(t0, 8)), 8);
+  t1 = wasm_u16x8_shr(wasm_i16x8_add(t1, wasm_u16x8_shr(t1, 8)), 8);
+
+  // result = src + div255(dst * invAlpha), narrowed back to uint8 saturating.
+  const v128_t res0 = wasm_i16x8_add(srcW0, t0);
+  const v128_t res1 = wasm_i16x8_add(srcW1, t1);
+  wasm_v128_store(out, wasm_u8x16_narrow_i16x8(res0, res1));
+
+#elif defined(TINY_SKIA_SIMD_SSE2)
+  const __m128i zero = _mm_setzero_si128();
+  const __m128i srcPx = _mm_loadu_si128(reinterpret_cast<const __m128i*>(src));
+  const __m128i dstPx = _mm_loadu_si128(reinterpret_cast<const __m128i*>(out));
+
+  // Widen src and dst to 16-bit for arithmetic.
+  const __m128i srcW0 = _mm_unpacklo_epi8(srcPx, zero);
+  const __m128i srcW1 = _mm_unpackhi_epi8(srcPx, zero);
+  const __m128i dstW0 = _mm_unpacklo_epi8(dstPx, zero);
+  const __m128i dstW1 = _mm_unpackhi_epi8(dstPx, zero);
+
+  // Broadcast each pixel's alpha (lane 3 of its half) over that pixel's four
+  // lanes, then subtract from 255. SSE2 has no byte shuffle, so this uses the
+  // 16-bit half shuffles, which are exactly the right granularity here.
+  const __m128i alphaW0 = _mm_shufflehi_epi16(_mm_shufflelo_epi16(srcW0, _MM_SHUFFLE(3, 3, 3, 3)),
+                                              _MM_SHUFFLE(3, 3, 3, 3));
+  const __m128i alphaW1 = _mm_shufflehi_epi16(_mm_shufflelo_epi16(srcW1, _MM_SHUFFLE(3, 3, 3, 3)),
+                                              _MM_SHUFFLE(3, 3, 3, 3));
+  const __m128i full = _mm_set1_epi16(255);
+  const __m128i invAlphaLo = _mm_sub_epi16(full, alphaW0);
+  const __m128i invAlphaHi = _mm_sub_epi16(full, alphaW1);
+
+  // div255(dst * invAlpha). The shifts must be logical, hence _mm_srli_epi16.
+  const __m128i round = _mm_set1_epi16(128);
+  __m128i t0 = _mm_add_epi16(_mm_mullo_epi16(dstW0, invAlphaLo), round);
+  __m128i t1 = _mm_add_epi16(_mm_mullo_epi16(dstW1, invAlphaHi), round);
+  t0 = _mm_srli_epi16(_mm_add_epi16(t0, _mm_srli_epi16(t0, 8)), 8);
+  t1 = _mm_srli_epi16(_mm_add_epi16(t1, _mm_srli_epi16(t1, 8)), 8);
+
+  // result = src + div255(dst * invAlpha), narrowed back to uint8 saturating.
+  const __m128i res0 = _mm_add_epi16(srcW0, t0);
+  const __m128i res1 = _mm_add_epi16(srcW1, t1);
+  _mm_storeu_si128(reinterpret_cast<__m128i*>(out), _mm_packus_epi16(res0, res1));
+#endif
+}
+#endif
+
+}  // namespace
 
 void merge(std::span<const Pixmap* const> layers, Pixmap& dst) {
   auto out = dst.data();
@@ -25,109 +166,19 @@ void merge(std::span<const Pixmap* const> layers, Pixmap& dst) {
     const auto src = layer->data();
     const std::size_t byteCount = std::min(src.size(), out.size());
     const std::size_t pixelCount = byteCount / 4;
-
-#if defined(TINYSKIA_CFG_IF_SIMD_NATIVE) && defined(__ARM_NEON)
-    // Process 4 pixels (16 bytes) at a time with NEON.
     std::size_t i = 0;
-    const std::size_t simdCount = pixelCount & ~3u;
 
-    for (; i < simdCount; i += 4) {
-      const std::size_t off = i * 4;
-
-      // Load 4 pixels (16 bytes) from src and dst.
-      uint8x16_t srcPx = vld1q_u8(&src[off]);
-      uint8x16_t dstPx = vld1q_u8(&out[off]);
-
-      // Extract alpha channel from each of the 4 source pixels.
-      // srcPx layout: [R0 G0 B0 A0 R1 G1 B1 A1 R2 G2 B2 A2 R3 G3 B3 A3]
-      // We need A0, A1, A2, A3 -> broadcast each to its pixel's 4 lanes.
-
-      // Widen src and dst to 16-bit for arithmetic.
-      uint8x8_t srcLo = vget_low_u8(srcPx);
-      uint8x8_t srcHi = vget_high_u8(srcPx);
-      uint8x8_t dstLo = vget_low_u8(dstPx);
-      uint8x8_t dstHi = vget_high_u8(dstPx);
-
-      uint16x8_t srcW0 = vmovl_u8(srcLo);
-      uint16x8_t srcW1 = vmovl_u8(srcHi);
-      uint16x8_t dstW0 = vmovl_u8(dstLo);
-      uint16x8_t dstW1 = vmovl_u8(dstHi);
-
-      // Extract and broadcast alpha for each pixel.
-      // Pixel 0: alpha at index 3, Pixel 1: alpha at index 7, etc.
-      uint16_t a0 = vgetq_lane_u16(srcW0, 3);
-      uint16_t a1 = vgetq_lane_u16(srcW0, 7);
-      uint16_t a2 = vgetq_lane_u16(srcW1, 3);
-      uint16_t a3 = vgetq_lane_u16(srcW1, 7);
-
-      // Build invAlpha vector: 255 - srcAlpha, broadcast per pixel.
-      uint16x8_t invA0 = vdupq_n_u16(255 - a0);
-      uint16x8_t invA1 = vdupq_n_u16(255 - a1);
-      uint16x8_t invA2 = vdupq_n_u16(255 - a2);
-      uint16x8_t invA3 = vdupq_n_u16(255 - a3);
-
-      // Combine invAlpha for the 4 pixels into two uint16x8 vectors.
-      // Pixels 0-1 interleaved in invAlphaLo, pixels 2-3 in invAlphaHi.
-      uint16x4_t invALo0 = vget_low_u16(invA0);
-      uint16x4_t invALo1 = vget_low_u16(invA1);
-      uint16x4_t invAHi0 = vget_low_u16(invA2);
-      uint16x4_t invAHi1 = vget_low_u16(invA3);
-      uint16x8_t invAlphaLo = vcombine_u16(invALo0, invALo1);
-      uint16x8_t invAlphaHi = vcombine_u16(invAHi0, invAHi1);
-
-      // dst * invAlpha: 16-bit multiply.
-      uint16x8_t prod0 = vmulq_u16(dstW0, invAlphaLo);
-      uint16x8_t prod1 = vmulq_u16(dstW1, invAlphaHi);
-
-      // div255: (v + 128 + ((v + 128) >> 8)) >> 8
-      uint16x8_t t0 = vaddq_u16(prod0, vdupq_n_u16(128));
-      uint16x8_t t1 = vaddq_u16(prod1, vdupq_n_u16(128));
-      t0 = vshrq_n_u16(vaddq_u16(t0, vshrq_n_u16(t0, 8)), 8);
-      t1 = vshrq_n_u16(vaddq_u16(t1, vshrq_n_u16(t1, 8)), 8);
-
-      // result = src + div255(dst * invAlpha).
-      uint16x8_t res0 = vaddq_u16(srcW0, t0);
-      uint16x8_t res1 = vaddq_u16(srcW1, t1);
-
-      // Narrow back to uint8, saturating.
-      uint8x8_t resLo = vqmovn_u16(res0);
-      uint8x8_t resHi = vqmovn_u16(res1);
-      uint8x16_t result = vcombine_u8(resLo, resHi);
-
-      vst1q_u8(&out[off], result);
+#if defined(TINY_SKIA_FILTER_MERGE_VECTOR)
+    // Process 4 pixels (16 bytes) at a time.
+    const std::size_t vectorCount = pixelCount & ~std::size_t{3};
+    for (; i < vectorCount; i += 4) {
+      mergeFourPixels(&out[i * 4], &src[i * 4]);
     }
-
-    // Handle remaining pixels (0-3).
-    for (; i < pixelCount; ++i) {
-      const std::size_t off = i * 4;
-#else
-    for (std::size_t i = 0; i < pixelCount; ++i) {
-      const std::size_t off = i * 4;
 #endif
-      const std::uint32_t sa = src[off + 3];
-      if (sa == 0) {
-        continue;
-      }
-      if (sa == 255) {
-        std::memcpy(&out[off], &src[off], 4);
-        continue;
-      }
-      const std::uint32_t invSa = 255 - sa;
-      auto div255 = [](std::uint32_t v) -> std::uint8_t {
-        return static_cast<std::uint8_t>((v + 128 + ((v + 128) >> 8)) >> 8);
-      };
-      out[off + 0] = static_cast<std::uint8_t>(
-          std::min(255u, static_cast<std::uint32_t>(src[off + 0]) +
-                             div255(static_cast<std::uint32_t>(out[off + 0]) * invSa)));
-      out[off + 1] = static_cast<std::uint8_t>(
-          std::min(255u, static_cast<std::uint32_t>(src[off + 1]) +
-                             div255(static_cast<std::uint32_t>(out[off + 1]) * invSa)));
-      out[off + 2] = static_cast<std::uint8_t>(
-          std::min(255u, static_cast<std::uint32_t>(src[off + 2]) +
-                             div255(static_cast<std::uint32_t>(out[off + 2]) * invSa)));
-      out[off + 3] = static_cast<std::uint8_t>(
-          std::min(255u, static_cast<std::uint32_t>(src[off + 3]) +
-                             div255(static_cast<std::uint32_t>(out[off + 3]) * invSa)));
+
+    // Handle the remaining pixels one at a time.
+    for (; i < pixelCount; ++i) {
+      mergePixel(&out[i * 4], &src[i * 4]);
     }
   }
 }

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/Turbulence.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/Turbulence.cpp
@@ -10,9 +10,7 @@
 #include <cstring>
 #include <utility>
 
-#if defined(TINYSKIA_CFG_IF_SIMD_NATIVE) && (defined(__ARM_NEON) || defined(__ARM_NEON__))
-#include <arm_neon.h>
-#endif
+#include "tiny_skia/filter/TurbulenceKernel.h"
 
 namespace tiny_skia::filter {
 
@@ -153,7 +151,7 @@ public:
     }
   }
 
-  // Float-precision 4-channel noise with NEON vectorization.
+  // Float-precision 4-channel noise, vectorized by `turbulenceBlend4`.
   // Uses SOA gradient tables for cache-friendly 4-channel SIMD loads.
   void noise2_4ch_f(float x, float y, const StitchInfo* stitch, float out[4]) const {
     float t = x + static_cast<float>(kPerlinN);
@@ -190,46 +188,11 @@ public:
     const float sx = sCurveF(rx0);
     const float sy = sCurveF(ry0);
 
-#if defined(TINYSKIA_CFG_IF_SIMD_NATIVE) && (defined(__ARM_NEON) || defined(__ARM_NEON__))
     // Load 4-channel gradient vectors from SOA tables (contiguous float[4]).
-    const float32x4_t gx00 = vld1q_f32(gradX4_[b00]);
-    const float32x4_t gy00 = vld1q_f32(gradY4_[b00]);
-    const float32x4_t gx10 = vld1q_f32(gradX4_[b10]);
-    const float32x4_t gy10 = vld1q_f32(gradY4_[b10]);
-    const float32x4_t gx01 = vld1q_f32(gradX4_[b01]);
-    const float32x4_t gy01 = vld1q_f32(gradY4_[b01]);
-    const float32x4_t gx11 = vld1q_f32(gradX4_[b11]);
-    const float32x4_t gy11 = vld1q_f32(gradY4_[b11]);
-
-    // 4 dot products: dot = gx * rx + gy * ry
-    const float32x4_t d00 = vfmaq_n_f32(vmulq_n_f32(gx00, rx0), gy00, ry0);
-    const float32x4_t d10 = vfmaq_n_f32(vmulq_n_f32(gx10, rx1), gy10, ry0);
-    const float32x4_t d01 = vfmaq_n_f32(vmulq_n_f32(gx01, rx0), gy01, ry1);
-    const float32x4_t d11 = vfmaq_n_f32(vmulq_n_f32(gx11, rx1), gy11, ry1);
-
-    // Bilinear interpolation: lerp(sx, d00, d10) then lerp(sy, a, b)
-    const float32x4_t sx_v = vdupq_n_f32(sx);
-    const float32x4_t a = vfmaq_f32(d00, sx_v, vsubq_f32(d10, d00));
-    const float32x4_t b = vfmaq_f32(d01, sx_v, vsubq_f32(d11, d01));
-
-    const float32x4_t sy_v = vdupq_n_f32(sy);
-    const float32x4_t result = vfmaq_f32(a, sy_v, vsubq_f32(b, a));
-
-    vst1q_f32(out, result);
-#else
-    // Scalar float fallback.
-    for (int ch = 0; ch < 4; ++ch) {
-      float u = gradX4_[b00][ch] * rx0 + gradY4_[b00][ch] * ry0;
-      float v = gradX4_[b10][ch] * rx1 + gradY4_[b10][ch] * ry0;
-      const float af = u + sx * (v - u);
-
-      u = gradX4_[b01][ch] * rx0 + gradY4_[b01][ch] * ry1;
-      v = gradX4_[b11][ch] * rx1 + gradY4_[b11][ch] * ry1;
-      const float bf = u + sx * (v - u);
-
-      out[ch] = af + sy * (bf - af);
-    }
-#endif
+    const TurbulenceCorners corners{gradX4_[b00], gradY4_[b00], gradX4_[b10], gradY4_[b10],
+                                    gradX4_[b01], gradY4_[b01], gradX4_[b11], gradY4_[b11]};
+    const TurbulenceWeights weights{rx0, rx1, ry0, ry1, sx, sy};
+    turbulenceBlend4(corners, weights, out);
   }
 
 private:
@@ -287,7 +250,7 @@ private:
       }
     }
 
-    // Build SOA float gradient tables for NEON-vectorized 4-channel access.
+    // Build SOA float gradient tables for vectorized 4-channel access.
     // gradX4_[idx] = {ch0_x, ch1_x, ch2_x, ch3_x} as float.
     constexpr int kTableSize = kBLen + kBLenPlus2;
     for (int idx = 0; idx < kTableSize; ++idx) {
@@ -316,7 +279,7 @@ private:
 
   int latticeSelector_[kBLen + kBLenPlus2] = {};
   double gradient_[4][kBLen + kBLenPlus2][2] = {};
-  // SOA float gradient tables: gradX4_[idx][ch], gradY4_[idx][ch] for NEON 4-channel loads.
+  // SOA float gradient tables: gradX4_[idx][ch], gradY4_[idx][ch] for 4-channel loads.
   alignas(16) float gradX4_[kBLen + kBLenPlus2][4] = {};
   alignas(16) float gradY4_[kBLen + kBLenPlus2][4] = {};
 };

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/TurbulenceKernel.h
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/TurbulenceKernel.h
@@ -1,0 +1,153 @@
+#pragma once
+
+/// @file TurbulenceKernel.h
+/// @brief The four-channel Perlin lattice blend behind the float feTurbulence path.
+///
+/// Kept separate from `Turbulence.cpp` so the vectorized blend can be
+/// cross-validated against a scalar reference directly, without reconstructing
+/// the generator's permutation and gradient tables.
+
+// Selects the ISA branch below and pulls in the matching intrinsics header.
+#include "tiny_skia/filter/SimdVec.h"
+
+namespace tiny_skia::filter {
+
+/// The four lattice corners' gradient components in structure-of-arrays form:
+/// each pointer addresses one corner's four channel values (R, G, B, A), so a
+/// single 4-lane load covers every channel of that corner.
+///
+/// Corners are named by their lattice cell coordinates, so `01` is x = 0, y = 1.
+struct TurbulenceCorners {
+  const float* gradientX00;
+  const float* gradientY00;
+  const float* gradientX10;
+  const float* gradientY10;
+  const float* gradientX01;
+  const float* gradientY01;
+  const float* gradientX11;
+  const float* gradientY11;
+};
+
+/// The sample's position inside the lattice cell, and the s-curve interpolation
+/// weights derived from it.
+struct TurbulenceWeights {
+  float rx0;  ///< Fractional x offset from the x = 0 lattice line.
+  float rx1;  ///< rx0 - 1, the offset from the x = 1 lattice line.
+  float ry0;  ///< Fractional y offset from the y = 0 lattice line.
+  float ry1;  ///< ry0 - 1, the offset from the y = 1 lattice line.
+  float sx;   ///< s-curve weight for the interpolation along x.
+  float sy;   ///< s-curve weight for the interpolation along y.
+};
+
+/// Evaluates one Perlin lattice cell for all four channels at once, writing
+/// R, G, B, A to `out`.
+///
+/// Per channel this is the usual bilinear blend of four gradient dot products:
+///
+///     u      = gradientX00 * rx0 + gradientY00 * ry0
+///     v      = gradientX10 * rx1 + gradientY10 * ry0
+///     top    = u + sx * (v - u)
+///     u      = gradientX01 * rx0 + gradientY01 * ry1
+///     v      = gradientX11 * rx1 + gradientY11 * ry1
+///     bottom = u + sx * (v - u)
+///     out    = top + sy * (bottom - top)
+///
+/// The wasm128, SSE2, and scalar branches issue exactly those multiplies,
+/// adds, and subtracts in exactly that order, so every lane agrees bit for bit.
+/// The NEON branch fuses each multiply and add into one rounding step, which
+/// can differ by one unit in the last place; that predates the other branches
+/// and changing it would move rendered output on ARM.
+inline void turbulenceBlend4(const TurbulenceCorners& corners, const TurbulenceWeights& weights,
+                             float out[4]) {
+#if defined(TINY_SKIA_SIMD_NEON)
+  const float32x4_t gx00 = vld1q_f32(corners.gradientX00);
+  const float32x4_t gy00 = vld1q_f32(corners.gradientY00);
+  const float32x4_t gx10 = vld1q_f32(corners.gradientX10);
+  const float32x4_t gy10 = vld1q_f32(corners.gradientY10);
+  const float32x4_t gx01 = vld1q_f32(corners.gradientX01);
+  const float32x4_t gy01 = vld1q_f32(corners.gradientY01);
+  const float32x4_t gx11 = vld1q_f32(corners.gradientX11);
+  const float32x4_t gy11 = vld1q_f32(corners.gradientY11);
+
+  // 4 dot products: dot = gx * rx + gy * ry
+  const float32x4_t d00 = vfmaq_n_f32(vmulq_n_f32(gx00, weights.rx0), gy00, weights.ry0);
+  const float32x4_t d10 = vfmaq_n_f32(vmulq_n_f32(gx10, weights.rx1), gy10, weights.ry0);
+  const float32x4_t d01 = vfmaq_n_f32(vmulq_n_f32(gx01, weights.rx0), gy01, weights.ry1);
+  const float32x4_t d11 = vfmaq_n_f32(vmulq_n_f32(gx11, weights.rx1), gy11, weights.ry1);
+
+  // Bilinear interpolation: lerp along x, then along y.
+  const float32x4_t sx = vdupq_n_f32(weights.sx);
+  const float32x4_t top = vfmaq_f32(d00, sx, vsubq_f32(d10, d00));
+  const float32x4_t bottom = vfmaq_f32(d01, sx, vsubq_f32(d11, d01));
+
+  const float32x4_t sy = vdupq_n_f32(weights.sy);
+  vst1q_f32(out, vfmaq_f32(top, sy, vsubq_f32(bottom, top)));
+
+#elif defined(TINY_SKIA_SIMD_WASM_SIMD128)
+  const v128_t rx0 = wasm_f32x4_splat(weights.rx0);
+  const v128_t rx1 = wasm_f32x4_splat(weights.rx1);
+  const v128_t ry0 = wasm_f32x4_splat(weights.ry0);
+  const v128_t ry1 = wasm_f32x4_splat(weights.ry1);
+
+  // 4 dot products: dot = gx * rx + gy * ry. wasm128 has no fused
+  // multiply-add outside relaxed SIMD, so each product rounds before the add,
+  // exactly like the scalar branch.
+  const v128_t d00 = wasm_f32x4_add(wasm_f32x4_mul(wasm_v128_load(corners.gradientX00), rx0),
+                                    wasm_f32x4_mul(wasm_v128_load(corners.gradientY00), ry0));
+  const v128_t d10 = wasm_f32x4_add(wasm_f32x4_mul(wasm_v128_load(corners.gradientX10), rx1),
+                                    wasm_f32x4_mul(wasm_v128_load(corners.gradientY10), ry0));
+  const v128_t d01 = wasm_f32x4_add(wasm_f32x4_mul(wasm_v128_load(corners.gradientX01), rx0),
+                                    wasm_f32x4_mul(wasm_v128_load(corners.gradientY01), ry1));
+  const v128_t d11 = wasm_f32x4_add(wasm_f32x4_mul(wasm_v128_load(corners.gradientX11), rx1),
+                                    wasm_f32x4_mul(wasm_v128_load(corners.gradientY11), ry1));
+
+  // Bilinear interpolation: lerp along x, then along y.
+  const v128_t sx = wasm_f32x4_splat(weights.sx);
+  const v128_t top = wasm_f32x4_add(d00, wasm_f32x4_mul(sx, wasm_f32x4_sub(d10, d00)));
+  const v128_t bottom = wasm_f32x4_add(d01, wasm_f32x4_mul(sx, wasm_f32x4_sub(d11, d01)));
+
+  const v128_t sy = wasm_f32x4_splat(weights.sy);
+  wasm_v128_store(out, wasm_f32x4_add(top, wasm_f32x4_mul(sy, wasm_f32x4_sub(bottom, top))));
+
+#elif defined(TINY_SKIA_SIMD_SSE2)
+  const __m128 rx0 = _mm_set1_ps(weights.rx0);
+  const __m128 rx1 = _mm_set1_ps(weights.rx1);
+  const __m128 ry0 = _mm_set1_ps(weights.ry0);
+  const __m128 ry1 = _mm_set1_ps(weights.ry1);
+
+  // 4 dot products: dot = gx * rx + gy * ry. The library builds with
+  // -ffp-contract=off, so the multiply and add stay separately rounded, exactly
+  // like the scalar branch.
+  const __m128 d00 = _mm_add_ps(_mm_mul_ps(_mm_loadu_ps(corners.gradientX00), rx0),
+                                _mm_mul_ps(_mm_loadu_ps(corners.gradientY00), ry0));
+  const __m128 d10 = _mm_add_ps(_mm_mul_ps(_mm_loadu_ps(corners.gradientX10), rx1),
+                                _mm_mul_ps(_mm_loadu_ps(corners.gradientY10), ry0));
+  const __m128 d01 = _mm_add_ps(_mm_mul_ps(_mm_loadu_ps(corners.gradientX01), rx0),
+                                _mm_mul_ps(_mm_loadu_ps(corners.gradientY01), ry1));
+  const __m128 d11 = _mm_add_ps(_mm_mul_ps(_mm_loadu_ps(corners.gradientX11), rx1),
+                                _mm_mul_ps(_mm_loadu_ps(corners.gradientY11), ry1));
+
+  // Bilinear interpolation: lerp along x, then along y.
+  const __m128 sx = _mm_set1_ps(weights.sx);
+  const __m128 top = _mm_add_ps(d00, _mm_mul_ps(sx, _mm_sub_ps(d10, d00)));
+  const __m128 bottom = _mm_add_ps(d01, _mm_mul_ps(sx, _mm_sub_ps(d11, d01)));
+
+  const __m128 sy = _mm_set1_ps(weights.sy);
+  _mm_storeu_ps(out, _mm_add_ps(top, _mm_mul_ps(sy, _mm_sub_ps(bottom, top))));
+
+#else
+  for (int ch = 0; ch < 4; ++ch) {
+    float u = corners.gradientX00[ch] * weights.rx0 + corners.gradientY00[ch] * weights.ry0;
+    float v = corners.gradientX10[ch] * weights.rx1 + corners.gradientY10[ch] * weights.ry0;
+    const float top = u + weights.sx * (v - u);
+
+    u = corners.gradientX01[ch] * weights.rx0 + corners.gradientY01[ch] * weights.ry1;
+    v = corners.gradientX11[ch] * weights.rx1 + corners.gradientY11[ch] * weights.ry1;
+    const float bottom = u + weights.sx * (v - u);
+
+    out[ch] = top + weights.sy * (bottom - top);
+  }
+#endif
+}
+
+}  // namespace tiny_skia::filter

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/tests/BUILD.bazel
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/tests/BUILD.bazel
@@ -9,6 +9,7 @@ tiny_skia_dual_mode_cc_test(
     srcs = [
         "ColorSpaceTest.cpp",
         "FilterGraphColorSpaceTest.cpp",
+        "FilterSimdParityTest.cpp",
         "SimdVecTest.cpp",
     ],
     # -ffp-contract=off matches the library so the reference expressions in the

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/tests/FilterSimdParityTest.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/tests/FilterSimdParityTest.cpp
@@ -1,0 +1,485 @@
+/// Cross-validation of the filter primitives' vector branches against the
+/// scalar arithmetic they replace.
+///
+/// Every expectation here is a longhand scalar reference written out in the
+/// test, so the same assertions run against the vector branch in native mode
+/// and against the fallback in scalar mode.
+
+#include <array>
+#include <bit>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "tiny_skia/Pixmap.h"
+#include "tiny_skia/filter/ColorMatrix.h"
+#include "tiny_skia/filter/FloatPixmap.h"
+#include "tiny_skia/filter/Merge.h"
+#include "tiny_skia/filter/SimdVec.h"
+#include "tiny_skia/filter/Turbulence.h"
+#include "tiny_skia/filter/TurbulenceKernel.h"
+
+namespace tiny_skia::filter {
+namespace {
+
+using ::testing::ElementsAreArray;
+
+// Whether the compiled branch evaluates the float expressions with exactly the
+// scalar fallback's operations in the scalar fallback's order.
+//
+// The wasm128 and SSE2 branches are written to, and the scalar fallback
+// trivially is. NEON is not: it fuses the multiply and add in the color-matrix
+// and turbulence products, accumulates the color matrix's translation column
+// first, and converts bytes to floats by multiplying by the rounded reciprocal
+// of 255 rather than dividing (1/255 is not representable, and the two
+// disagree in the last place for 126 of the 256 byte values). Those
+// divergences are at most one unit in the last place, they predate this suite,
+// and changing them would move rendered output on ARM, so the bitwise
+// expectations are scoped to the branches that promise them.
+#if defined(TINY_SKIA_SIMD_NEON)
+constexpr bool kExactScalarParity = false;
+#else
+constexpr bool kExactScalarParity = true;
+#endif
+
+/// Compares one float against its scalar reference.
+///
+/// Where the compiled branch promises bit-for-bit parity this compares the bit
+/// patterns, so a single changed rounding fails.
+///
+/// Otherwise `tolerance` bounds the documented NEON divergence. It is an
+/// absolute bound stated against the magnitudes entering the expression, not a
+/// relative bound on the result: fusing a multiply and add moves the result by
+/// at most one rounding of the largest intermediate, and these expressions
+/// routinely cancel down to a result thousands of times smaller than their
+/// terms, where a relative comparison would reject a correct one-unit
+/// difference.
+void expectFloatMatches(float actual, float expected, float tolerance) {
+  if (kExactScalarParity) {
+    EXPECT_EQ(std::bit_cast<std::uint32_t>(actual), std::bit_cast<std::uint32_t>(expected))
+        << "actual=" << actual << " expected=" << expected;
+  } else {
+    EXPECT_NEAR(actual, expected, tolerance);
+  }
+}
+
+/// Bound for expressions over inputs in [0, 1]: one rounding of 1.0 is about
+/// 1.2e-7, so this leaves room for a handful of them.
+constexpr float kUnitRangeTolerance = 1.0e-6f;
+
+/// A deterministic byte sequence with no repeating structure that could hide a
+/// lane-ordering mistake.
+std::uint8_t sampleByte(std::size_t index) {
+  return static_cast<std::uint8_t>((index * 37u + (index * index) / 3u) & 0xFFu);
+}
+
+// ---------------------------------------------------------------------------
+// FloatPixmap conversions
+// ---------------------------------------------------------------------------
+
+Pixmap makePixmap(std::uint32_t width, std::uint32_t height, std::size_t seed) {
+  std::vector<std::uint8_t> bytes(static_cast<std::size_t>(width) * height * 4);
+  for (std::size_t i = 0; i < bytes.size(); ++i) {
+    bytes[i] = sampleByte(i + seed);
+  }
+
+  return *Pixmap::fromVec(std::move(bytes), IntSize::fromWH(width, height).value());
+}
+
+TEST(FloatPixmapConversionTest, FromPixmapMatchesScalarDivide) {
+  // Widths are chosen so the byte count leaves each possible remainder after
+  // the 16-byte vector step: 4 pixels is exactly one step, and 5, 6, and 7
+  // leave 4, 8, and 12 bytes for the tail.
+  for (std::uint32_t width : {1u, 2u, 3u, 4u, 5u, 6u, 7u, 16u}) {
+    SCOPED_TRACE(testing::Message() << "width=" << width);
+
+    const Pixmap source = makePixmap(width, 3, width * 13u);
+    const FloatPixmap converted = FloatPixmap::fromPixmap(source);
+
+    const auto src = source.data();
+    const auto out = converted.data();
+    ASSERT_EQ(out.size(), src.size());
+    for (std::size_t i = 0; i < src.size(); ++i) {
+      SCOPED_TRACE(testing::Message() << "i=" << i << " byte=" << int{src[i]});
+      // The scalar conversion divides. Multiplying by the rounded reciprocal of
+      // 255 instead lands one unit in the last place away for most byte values,
+      // which is what this bitwise comparison is here to catch.
+      expectFloatMatches(out[i], src[i] / 255.0f, kUnitRangeTolerance);
+    }
+  }
+}
+
+TEST(FloatPixmapConversionTest, FromPixmapCoversEveryByteValue) {
+  std::vector<std::uint8_t> bytes(256);
+  for (std::size_t i = 0; i < bytes.size(); ++i) {
+    bytes[i] = static_cast<std::uint8_t>(i);
+  }
+
+  const Pixmap source = *Pixmap::fromVec(std::move(bytes), IntSize::fromWH(8, 8).value());
+  const FloatPixmap converted = FloatPixmap::fromPixmap(source);
+
+  const auto src = source.data();
+  const auto out = converted.data();
+  for (std::size_t i = 0; i < src.size(); ++i) {
+    SCOPED_TRACE(testing::Message() << "byte=" << int{src[i]});
+    expectFloatMatches(out[i], src[i] / 255.0f, kUnitRangeTolerance);
+  }
+}
+
+TEST(FloatPixmapConversionTest, ToPixmapMatchesScalarClampAndTruncate) {
+  // Values below zero and above one exercise both clamp arms; the rest sit on
+  // and beside the rounding boundaries the +0.5 truncation turns over.
+  static const std::array<float, 12> kValues = {
+      -1.0f, -0.5f,         -0.0f,           0.0f, 1.0f / 512.0f, 1.0f / 510.0f,
+      0.5f,  1.0f / 255.0f, 254.0f / 255.0f, 1.0f, 1.5f,          2.0f};
+
+  // 7 pixels is 28 floats: one full 16-float vector step plus a 12-float tail.
+  FloatPixmap pixmap = *FloatPixmap::fromSize(7, 1);
+  auto data = pixmap.data();
+  for (std::size_t i = 0; i < data.size(); ++i) {
+    data[i] = kValues[i % kValues.size()];
+  }
+
+  const Pixmap converted = pixmap.toPixmap();
+  const auto out = converted.data();
+  ASSERT_EQ(out.size(), data.size());
+  for (std::size_t i = 0; i < data.size(); ++i) {
+    SCOPED_TRACE(testing::Message() << "i=" << i << " value=" << data[i]);
+    const float scaled = data[i] * 255.0f + 0.5f;
+    const float clamped = scaled < 0.0f ? 0.0f : (255.0f < scaled ? 255.0f : scaled);
+    EXPECT_EQ(int{out[i]}, int{static_cast<std::uint8_t>(clamped)});
+  }
+}
+
+TEST(FloatPixmapConversionTest, RoundTripPreservesEveryByteValue) {
+  std::vector<std::uint8_t> bytes(256);
+  for (std::size_t i = 0; i < bytes.size(); ++i) {
+    bytes[i] = static_cast<std::uint8_t>(i);
+  }
+
+  const Pixmap source = *Pixmap::fromVec(bytes, IntSize::fromWH(8, 8).value());
+  const Pixmap roundTripped = FloatPixmap::fromPixmap(source).toPixmap();
+  EXPECT_THAT(roundTripped.data(), ElementsAreArray(bytes));
+}
+
+// ---------------------------------------------------------------------------
+// ColorMatrix (float)
+// ---------------------------------------------------------------------------
+
+/// Longhand scalar reference for one premultiplied float pixel: unpremultiply,
+/// apply the 5x4 matrix left to right, clamp, then re-premultiply.
+std::array<float, 4> referenceColorMatrixPixel(const std::array<float, 4>& pixel,
+                                               const std::array<double, 20>& matrix) {
+  float m[20];
+  for (int j = 0; j < 20; ++j) {
+    m[j] = static_cast<float>(matrix[j]);
+  }
+
+  const auto clamp01 = [](float v) { return v < 0.0f ? 0.0f : (v > 1.0f ? 1.0f : v); };
+
+  const float pa = pixel[3];
+  if (pa == 0.0f) {
+    const float ca = clamp01(m[19]);
+    if (ca == 0.0f) {
+      return pixel;
+    }
+    return {clamp01(m[4] * ca), clamp01(m[9] * ca), clamp01(m[14] * ca), ca};
+  }
+
+  const float invAlpha = 1.0f / pa;
+  const float r = pixel[0] * invAlpha;
+  const float g = pixel[1] * invAlpha;
+  const float b = pixel[2] * invAlpha;
+
+  const float nr = m[0] * r + m[1] * g + m[2] * b + m[3] * pa + m[4];
+  const float ng = m[5] * r + m[6] * g + m[7] * b + m[8] * pa + m[9];
+  const float nb = m[10] * r + m[11] * g + m[12] * b + m[13] * pa + m[14];
+  const float na = m[15] * r + m[16] * g + m[17] * b + m[18] * pa + m[19];
+
+  const float ca = clamp01(na);
+  return {clamp01(clamp01(nr) * ca), clamp01(clamp01(ng) * ca), clamp01(clamp01(nb) * ca), ca};
+}
+
+/// Premultiplied sample pixels: every color channel stays at or below alpha, as
+/// a premultiplied buffer guarantees.
+const std::array<std::array<float, 4>, 8>& colorMatrixSamplePixels() {
+  static const std::array<std::array<float, 4>, 8> kPixels = {{
+      {{0.0f, 0.0f, 0.0f, 0.0f}},
+      {{0.0f, 0.0f, 0.0f, 1.0f}},
+      {{1.0f, 1.0f, 1.0f, 1.0f}},
+      {{0.25f, 0.5f, 0.75f, 1.0f}},
+      {{0.1f, 0.05f, 0.02f, 0.125f}},
+      {{0.5f, 0.0f, 0.5f, 0.5f}},
+      {{0.003921569f, 0.0f, 0.0f, 0.003921569f}},
+      {{0.9f, 0.3f, 0.6f, 0.95f}},
+  }};
+  return kPixels;
+}
+
+const std::array<std::array<double, 20>, 5>& colorMatrixSampleMatrices() {
+  // clang-format off
+  static const std::array<std::array<double, 20>, 5> kMatrices = {{
+      identityMatrix(),
+      saturateMatrix(0.3),
+      hueRotateMatrix(45.0),
+      luminanceToAlphaMatrix(),
+      // Deliberately extreme: negative and greater-than-one coefficients plus
+      // translations, so both clamp arms are reached on every channel.
+      {{ 1.7, -0.4,  0.2, 0.0,  0.3,
+        -0.6,  1.2,  0.5, 0.1, -0.2,
+         0.3,  0.3,  1.4, 0.0,  0.25,
+         0.2, -0.1,  0.4, 0.9, -0.15}},
+  }};
+  // clang-format on
+  return kMatrices;
+}
+
+TEST(ColorMatrixFloatTest, MatchesScalarReferencePerPixel) {
+  for (std::size_t matrixIndex = 0; matrixIndex < colorMatrixSampleMatrices().size();
+       ++matrixIndex) {
+    SCOPED_TRACE(testing::Message() << "matrix=" << matrixIndex);
+    const std::array<double, 20>& matrix = colorMatrixSampleMatrices()[matrixIndex];
+
+    const auto& pixels = colorMatrixSamplePixels();
+    FloatPixmap pixmap = *FloatPixmap::fromSize(static_cast<std::uint32_t>(pixels.size()), 1);
+    auto data = pixmap.data();
+    for (std::size_t i = 0; i < pixels.size(); ++i) {
+      for (std::size_t channel = 0; channel < 4; ++channel) {
+        data[i * 4 + channel] = pixels[i][channel];
+      }
+    }
+
+    colorMatrix(pixmap, matrix);
+
+    for (std::size_t i = 0; i < pixels.size(); ++i) {
+      const std::array<float, 4> expected = referenceColorMatrixPixel(pixels[i], matrix);
+      for (std::size_t channel = 0; channel < 4; ++channel) {
+        SCOPED_TRACE(testing::Message() << "pixel=" << i << " channel=" << channel);
+        expectFloatMatches(data[i * 4 + channel], expected[channel], kUnitRangeTolerance);
+      }
+    }
+  }
+}
+
+TEST(ColorMatrixFloatTest, TranslationOnlyMatrixReachesTransparentPixels) {
+  // A fully transparent pixel takes the scalar shortcut in every branch, so
+  // this pins the shortcut rather than the vector arithmetic.
+  const std::array<double, 20> matrix = {0, 0, 0, 0, 0.75,  //
+                                         0, 0, 0, 0, 0.25,  //
+                                         0, 0, 0, 0, 1.5,   //
+                                         0, 0, 0, 0, 0.5};
+
+  const std::array<float, 4> transparent = {0.0f, 0.0f, 0.0f, 0.0f};
+  FloatPixmap pixmap = *FloatPixmap::fromSize(1, 1);
+  colorMatrix(pixmap, matrix);
+
+  const std::array<float, 4> expected = referenceColorMatrixPixel(transparent, matrix);
+  for (std::size_t channel = 0; channel < 4; ++channel) {
+    SCOPED_TRACE(testing::Message() << "channel=" << channel);
+    expectFloatMatches(pixmap.data()[channel], expected[channel], kUnitRangeTolerance);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Merge (uint8)
+// ---------------------------------------------------------------------------
+
+/// Longhand scalar Source Over reference for the 8-bit merge.
+std::vector<std::uint8_t> referenceMerge(const std::vector<std::vector<std::uint8_t>>& layers,
+                                         std::size_t byteCount) {
+  std::vector<std::uint8_t> out(byteCount, 0);
+
+  for (const std::vector<std::uint8_t>& layer : layers) {
+    for (std::size_t off = 0; off + 4 <= byteCount; off += 4) {
+      const std::uint32_t sa = layer[off + 3];
+      if (sa == 0) {
+        continue;
+      }
+      if (sa == 255) {
+        for (std::size_t channel = 0; channel < 4; ++channel) {
+          out[off + channel] = layer[off + channel];
+        }
+        continue;
+      }
+
+      const std::uint32_t invSa = 255 - sa;
+      for (std::size_t channel = 0; channel < 4; ++channel) {
+        const std::uint32_t product = std::uint32_t{out[off + channel]} * invSa;
+        const std::uint32_t scaled = (product + 128 + ((product + 128) >> 8)) >> 8;
+        const std::uint32_t sum = std::uint32_t{layer[off + channel]} + scaled;
+        out[off + channel] = static_cast<std::uint8_t>(sum < 255u ? sum : 255u);
+      }
+    }
+  }
+
+  return out;
+}
+
+/// Builds a premultiplied layer: every color channel stays at or below alpha,
+/// which is what the vector path's dropped `srcAlpha == 0` shortcut relies on.
+std::vector<std::uint8_t> makeLayerBytes(std::size_t pixelCount, std::size_t seed) {
+  std::vector<std::uint8_t> bytes(pixelCount * 4);
+  for (std::size_t pixel = 0; pixel < pixelCount; ++pixel) {
+    const std::uint8_t alpha = sampleByte(pixel * 5 + seed);
+    for (std::size_t channel = 0; channel < 3; ++channel) {
+      const std::uint8_t raw = sampleByte(pixel * 4 + channel + seed * 7);
+      bytes[pixel * 4 + channel] = static_cast<std::uint8_t>(raw <= alpha ? raw : alpha);
+    }
+    bytes[pixel * 4 + 3] = alpha;
+  }
+
+  return bytes;
+}
+
+TEST(MergeUint8Test, MatchesScalarReferenceAcrossVectorStepAndTail) {
+  // Pixel counts sweep the 4-pixel vector step and every tail remainder.
+  for (std::size_t pixelCount = 1; pixelCount <= 11; ++pixelCount) {
+    SCOPED_TRACE(testing::Message() << "pixelCount=" << pixelCount);
+
+    const std::vector<std::vector<std::uint8_t>> layerBytes = {makeLayerBytes(pixelCount, 1),
+                                                               makeLayerBytes(pixelCount, 29),
+                                                               makeLayerBytes(pixelCount, 71)};
+
+    const IntSize size = IntSize::fromWH(static_cast<std::uint32_t>(pixelCount), 1).value();
+    std::vector<Pixmap> pixmaps;
+    for (const std::vector<std::uint8_t>& bytes : layerBytes) {
+      pixmaps.push_back(*Pixmap::fromVec(bytes, size));
+    }
+
+    std::vector<const Pixmap*> layers;
+    for (const Pixmap& pixmap : pixmaps) {
+      layers.push_back(&pixmap);
+    }
+
+    Pixmap dst = *Pixmap::fromSize(static_cast<std::uint32_t>(pixelCount), 1);
+    merge(std::span<const Pixmap* const>(layers), dst);
+
+    EXPECT_THAT(dst.data(), ElementsAreArray(referenceMerge(layerBytes, pixelCount * 4)));
+  }
+}
+
+TEST(MergeUint8Test, SaturatesAndRoundsAtTheExtremes) {
+  // Opaque white under a nearly transparent white saturates the sum, and the
+  // low alphas land on div255 rounding boundaries. Four pixels is exactly one
+  // vector step, so this runs entirely through the vector path where present.
+  const std::vector<std::uint8_t> bottom = {255, 255, 255, 255, 128, 128, 128, 128,
+                                            1,   1,   1,   1,   254, 254, 254, 254};
+  const std::vector<std::uint8_t> top = {1, 1, 1, 1, 255, 255, 255, 255,
+                                         2, 2, 2, 2, 128, 0,   64,  128};
+
+  const IntSize size = IntSize::fromWH(4, 1).value();
+  const Pixmap bottomPixmap = *Pixmap::fromVec(bottom, size);
+  const Pixmap topPixmap = *Pixmap::fromVec(top, size);
+  const std::array<const Pixmap*, 2> layers = {&bottomPixmap, &topPixmap};
+
+  Pixmap dst = *Pixmap::fromSize(4, 1);
+  merge(std::span<const Pixmap* const>(layers), dst);
+
+  EXPECT_THAT(dst.data(), ElementsAreArray(referenceMerge({bottom, top}, bottom.size())));
+}
+
+// ---------------------------------------------------------------------------
+// Turbulence lattice blend
+// ---------------------------------------------------------------------------
+
+using Gradient = std::array<float, 4>;
+
+/// Longhand scalar reference for `turbulenceBlend4`, one channel at a time.
+Gradient referenceTurbulenceBlend(const TurbulenceCorners& corners,
+                                  const TurbulenceWeights& weights) {
+  Gradient out{};
+  for (std::size_t ch = 0; ch < 4; ++ch) {
+    float u = corners.gradientX00[ch] * weights.rx0 + corners.gradientY00[ch] * weights.ry0;
+    float v = corners.gradientX10[ch] * weights.rx1 + corners.gradientY10[ch] * weights.ry0;
+    const float top = u + weights.sx * (v - u);
+
+    u = corners.gradientX01[ch] * weights.rx0 + corners.gradientY01[ch] * weights.ry1;
+    v = corners.gradientX11[ch] * weights.rx1 + corners.gradientY11[ch] * weights.ry1;
+    const float bottom = u + weights.sx * (v - u);
+
+    out[ch] = top + weights.sy * (bottom - top);
+  }
+
+  return out;
+}
+
+TEST(TurbulenceBlendTest, MatchesScalarReference) {
+  // Gradient components are unit-length pairs in the generator, so every value
+  // here is in [-1, 1]; the deliberately asymmetric per-corner and per-channel
+  // values make any corner or lane mix-up visible.
+  alignas(16) static const std::array<Gradient, 8> kGradients = {{
+      {{1.0f, -1.0f, 0.5f, -0.25f}},
+      {{-0.125f, 0.75f, -0.875f, 0.0f}},
+      {{0.3125f, 0.0625f, -0.5f, 1.0f}},
+      {{-1.0f, -0.5f, 0.25f, 0.125f}},
+      {{0.9375f, -0.03125f, 0.6875f, -0.4375f}},
+      {{-0.75f, 0.5f, 0.0f, -0.9375f}},
+      {{0.15625f, -0.84375f, 0.34375f, 0.71875f}},
+      {{-0.28125f, 0.96875f, -0.65625f, 0.09375f}},
+  }};
+
+  const TurbulenceCorners corners{kGradients[0].data(), kGradients[1].data(), kGradients[2].data(),
+                                  kGradients[3].data(), kGradients[4].data(), kGradients[5].data(),
+                                  kGradients[6].data(), kGradients[7].data()};
+
+  // rx1 is rx0 - 1 and sx is the s-curve of rx0, exactly as the caller derives
+  // them, so these are the shapes the kernel actually sees.
+  for (float rx0 : {0.0f, 0.125f, 0.5f, 0.75f, 0.999f}) {
+    for (float ry0 : {0.0f, 0.25f, 0.5f, 0.875f}) {
+      SCOPED_TRACE(testing::Message() << "rx0=" << rx0 << " ry0=" << ry0);
+
+      const TurbulenceWeights weights{rx0,
+                                      rx0 - 1.0f,
+                                      ry0,
+                                      ry0 - 1.0f,
+                                      rx0 * rx0 * (3.0f - 2.0f * rx0),
+                                      ry0 * ry0 * (3.0f - 2.0f * ry0)};
+
+      Gradient actual{};
+      turbulenceBlend4(corners, weights, actual.data());
+      const Gradient expected = referenceTurbulenceBlend(corners, weights);
+
+      for (std::size_t ch = 0; ch < 4; ++ch) {
+        SCOPED_TRACE(testing::Message() << "channel=" << ch);
+        expectFloatMatches(actual[ch], expected[ch], kUnitRangeTolerance);
+      }
+    }
+  }
+}
+
+TEST(TurbulenceBlendTest, IsWiredIntoTheFloatGeneratorConsistentlyWithTheDoublePath) {
+  // The float generator and the uint8 generator share the same permutation and
+  // gradient tables and differ only in precision, so their outputs agree to
+  // within 8-bit quantization. A corner or channel mix-up inside the vector
+  // kernel would move the noise field far outside that band, which is what
+  // this covers that the kernel-level test cannot.
+  TurbulenceParams params;
+  params.type = TurbulenceType::Turbulence;
+  params.baseFrequencyX = 0.2;
+  params.baseFrequencyY = 0.15;
+  params.numOctaves = 2;
+  params.seed = 7.0;
+
+  Pixmap bytePixmap = *Pixmap::fromSize(9, 5);
+  turbulence(bytePixmap, params);
+
+  FloatPixmap floatPixmap = *FloatPixmap::fromSize(9, 5);
+  turbulence(floatPixmap, params);
+
+  const auto byteData = bytePixmap.data();
+  const auto floatData = floatPixmap.data();
+  ASSERT_EQ(byteData.size(), floatData.size());
+  for (std::size_t i = 0; i < byteData.size(); ++i) {
+    SCOPED_TRACE(testing::Message() << "i=" << i);
+    // Two byte steps covers the double-to-float drift plus the uint8 path's own
+    // rounding of the premultiply.
+    EXPECT_NEAR(floatData[i] * 255.0f, static_cast<float>(byteData[i]), 2.0f);
+  }
+}
+
+}  // namespace
+}  // namespace tiny_skia::filter

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/tests/FilterSimdParityTest.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/tests/FilterSimdParityTest.cpp
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <span>
 #include <vector>
 
@@ -45,6 +46,22 @@ constexpr bool kExactScalarParity = false;
 #else
 constexpr bool kExactScalarParity = true;
 #endif
+
+// Whether `FloatPixmap::toPixmap` runs its vector conversion. The scalar
+// fallback casts the clamped float straight to uint8, and that cast is
+// undefined behaviour for the NaN input the clamp passes through, so the
+// expectations that feed a NaN through the conversion are scoped to the
+// branches that define an answer for it.
+#if defined(TINY_SKIA_SIMD_NEON) || defined(TINY_SKIA_SIMD_WASM_SIMD128) || \
+    defined(TINY_SKIA_SIMD_SSE2)
+constexpr bool kVectorToPixmap = true;
+#else
+constexpr bool kVectorToPixmap = false;
+#endif
+
+/// A quiet NaN, built from its bit pattern so no expression in the test has to
+/// produce one.
+float quietNan() { return std::bit_cast<float>(std::uint32_t{0x7fc00000}); }
 
 /// Compares one float against its scalar reference.
 ///
@@ -150,6 +167,52 @@ TEST(FloatPixmapConversionTest, ToPixmapMatchesScalarClampAndTruncate) {
   for (std::size_t i = 0; i < data.size(); ++i) {
     SCOPED_TRACE(testing::Message() << "i=" << i << " value=" << data[i]);
     const float scaled = data[i] * 255.0f + 0.5f;
+    const float clamped = scaled < 0.0f ? 0.0f : (255.0f < scaled ? 255.0f : scaled);
+    EXPECT_EQ(int{out[i]}, int{static_cast<std::uint8_t>(clamped)});
+  }
+}
+
+TEST(FloatPixmapConversionTest, ToPixmapMapsNanLanesToZeroBytes) {
+  if (!kVectorToPixmap) {
+    GTEST_SKIP() << "the scalar fallback's cast of a NaN float to uint8 is undefined behaviour";
+  }
+
+  // The clamp in the vector conversion is a nested selection, so a NaN lane
+  // falls through both comparisons unchanged, exactly as `std::clamp` does.
+  // Each conversion then turns that NaN into a zero byte: the wasm128
+  // saturating conversion defines NaN as zero, and the x86 conversion produces
+  // INT_MIN, which the signed pack clamps to -32768 and the unsigned pack
+  // clamps to 0. A clamp whose operands were the other way round would select
+  // the bound the scalar formula rejects and store 255 instead, so this is the
+  // expectation that holds that operand order in place.
+  const float nan = quietNan();
+
+  // Four pixels is exactly one 16-float vector step, so no lane reaches the
+  // scalar tail. A NaN sits in a different position in each group of four so a
+  // lane mix-up cannot hide one.
+  static const std::array<float, 16> kValues = {nan,   0.0f,  1.0f,  0.5f,    //
+                                                0.25f, nan,   0.75f, 1.0f,    //
+                                                2.0f,  -1.0f, nan,   0.125f,  //
+                                                1.0f,  0.5f,  0.0f,  nan};
+
+  FloatPixmap pixmap = *FloatPixmap::fromSize(4, 1);
+  auto data = pixmap.data();
+  ASSERT_EQ(data.size(), kValues.size());
+  for (std::size_t i = 0; i < data.size(); ++i) {
+    data[i] = kValues[i];
+  }
+
+  const Pixmap converted = pixmap.toPixmap();
+  const auto out = converted.data();
+  ASSERT_EQ(out.size(), kValues.size());
+  for (std::size_t i = 0; i < kValues.size(); ++i) {
+    SCOPED_TRACE(testing::Message() << "i=" << i << " value=" << kValues[i]);
+    if (std::isnan(kValues[i])) {
+      EXPECT_EQ(int{out[i]}, 0);
+      continue;
+    }
+
+    const float scaled = kValues[i] * 255.0f + 0.5f;
     const float clamped = scaled < 0.0f ? 0.0f : (255.0f < scaled ? 255.0f : scaled);
     EXPECT_EQ(int{out[i]}, int{static_cast<std::uint8_t>(clamped)});
   }
@@ -281,6 +344,37 @@ TEST(ColorMatrixFloatTest, TranslationOnlyMatrixReachesTransparentPixels) {
   for (std::size_t channel = 0; channel < 4; ++channel) {
     SCOPED_TRACE(testing::Message() << "channel=" << channel);
     expectFloatMatches(pixmap.data()[channel], expected[channel], kUnitRangeTolerance);
+  }
+}
+
+TEST(ColorMatrixFloatTest, DenormalAlphaProducesNanThatTheClampPassesThrough) {
+  // This is how NaN reaches the clamp in ordinary use. A premultiplied pixel
+  // whose alpha is denormal makes the unpremultiply's reciprocal overflow to
+  // infinity, and a zero color channel times that infinity is NaN, which then
+  // spreads across every product and sum in the matrix.
+  //
+  // Every branch's clamp is a nested selection, so the NaN falls through both
+  // comparisons and survives, exactly as `std::clamp` leaves it. A clamp whose
+  // operands were the other way round would select a bound instead and store 0
+  // or 1, so this is the expectation that holds that operand order in place.
+  FloatPixmap pixmap = *FloatPixmap::fromSize(1, 1);
+  auto data = pixmap.data();
+  data[0] = 0.0f;
+  data[1] = 0.0f;
+  data[2] = 0.0f;
+  data[3] = std::numeric_limits<float>::denorm_min();
+
+  // Guards the premise: a platform that computed a finite reciprocal here would
+  // never reach the clamp with a NaN and would make the expectations below
+  // vacuous.
+  ASSERT_TRUE(std::isinf(1.0f / data[3]));
+
+  colorMatrix(pixmap, identityMatrix());
+
+  const auto out = pixmap.data();
+  for (std::size_t channel = 0; channel < 4; ++channel) {
+    SCOPED_TRACE(testing::Message() << "channel=" << channel);
+    EXPECT_TRUE(std::isnan(out[channel])) << "value=" << out[channel];
   }
 }
 


### PR DESCRIPTION
Four tiny-skia filter files carried NEON-only SIMD branches, so wasm and x86 builds fell back to scalar loops in ColorMatrix, Merge, Turbulence, and the FloatPixmap byte conversions. This change adds wasm SIMD128 and SSE2 branches to all four, routed through the shared ISA dispatch header, with bit-exact scalar parity as the acceptance bar.

Correctness notes carried in the code:

- Float-to-byte conversion uses true division on the new branches: `x/255.0f` differs from `x*(1.0f/255.0f)` for 126 of 256 byte values, so the reciprocal shortcut is NEON-only where it was already the shipped behavior.
- ColorMatrix accumulates in the exact scalar left-to-right association on the new branches; the dropped redundant clamp is proven an identity (both factors in [0,1], round-to-nearest of a real <= 1 cannot exceed 1.0f, NaN passes through identically).
- Merge's u16 arithmetic bound (`255*255 + 128 + 254 = 65407 < 2^16`) makes the saturating narrows reduce to `min(255, x)` with no wraparound.
- The Turbulence interpolation kernel is extracted into a shared header (`TurbulenceKernel.h`) used identically by all branches; the NEON code is instruction-for-instruction unchanged.
- Clamp operand order (`pmin`/`pmax`, `MINPS`/`MAXPS`) is chosen to reproduce `std::clamp` bit-for-bit including NaN, and that invariant is now pinned by tests: a denormal premultiplied alpha produces `0 * inf = NaN` in production, and new cases assert NaN propagation through the clamp and the NaN-lane-to-byte-0 conversion path. Flipping either operand order fails these tests on both SSE2 and wasm.

Verification: the dual-mode parity suite (`FilterSimdParityTest`, bitwise compare against the scalar reference) passes natively on aarch64/NEON and x86-64/SSE2 and, compiled with `-msimd128`, under node on actual wasm SIMD128. Full-corpus golden rendering runs on both aarch64 and x86-64 desktops are byte-identical to main. Sanitizer (ASan+UBSan) runs are clean on both ISAs.

Note on CI coverage: the vendored tiny-skia subtree has its own bazel workspace and its tests are not executed by this repository's CI (the subtree is in `.bazelignore`); CI does compile the library, including the wasm lane, so a broken intrinsic would fail the build, but the parity suite itself was run manually on all three ISAs as described above. No performance numbers are claimed here; filter throughput is tracked separately by the benchmark tables.
