### PR TITLE
perf: Cache per-entity path and image conversions in the tiny-skia backend

### DIFF
--- a/donner/svg/renderer/BUILD.bazel
+++ b/donner/svg/renderer/BUILD.bazel
@@ -414,7 +414,10 @@ donner_cc_library(
 donner_perf_sensitive_cc_library(
     name = "renderer_tiny_skia",
     srcs = ["RendererTinySkia.cc"],
-    hdrs = ["RendererTinySkia.h"],
+    hdrs = [
+        "RendererTinySkia.h",
+        "RendererTinySkiaCache.h",
+    ],
     defines = select({
         ":text_enabled": ["DONNER_TEXT_ENABLED"],
         "//conditions:default": [],

--- a/donner/svg/renderer/PixelFormatUtils.cc
+++ b/donner/svg/renderer/PixelFormatUtils.cc
@@ -53,38 +53,55 @@ void PremultiplyRgbaInPlace(std::vector<std::uint8_t>& rgba) {
 
 }  // namespace
 
+void PremultiplyRgbaInto(std::span<const std::uint8_t> rgbaPixels, std::vector<std::uint8_t>& out) {
+  out.assign(rgbaPixels.begin(), rgbaPixels.end());
+  PremultiplyRgbaInPlace(out);
+}
+
 std::vector<std::uint8_t> PremultiplyRgba(std::span<const std::uint8_t> rgbaPixels) {
-  std::vector<std::uint8_t> result(rgbaPixels.begin(), rgbaPixels.end());
-  PremultiplyRgbaInPlace(result);
+  std::vector<std::uint8_t> result;
+  PremultiplyRgbaInto(rgbaPixels, result);
   return result;
 }
 
-std::vector<std::uint8_t> CopyTightRgbaRows(std::span<const std::uint8_t> rgbaPixels, int width,
-                                            int height, std::size_t rowBytes) {
+void CopyTightRgbaRowsInto(std::span<const std::uint8_t> rgbaPixels, int width, int height,
+                           std::size_t rowBytes, std::vector<std::uint8_t>& out) {
   if (!HasRgbaRows(rgbaPixels, width, height, rowBytes)) {
-    return {};
+    out.clear();
+    return;
   }
 
   const std::size_t tightRowBytes = *TightRowBytesForWidth(width);
   const std::size_t sizeHeight = static_cast<std::size_t>(height);
-  std::vector<std::uint8_t> result(tightRowBytes * sizeHeight);
+  out.resize(tightRowBytes * sizeHeight);
   if (rowBytes == tightRowBytes) {
-    std::copy_n(rgbaPixels.begin(), result.size(), result.begin());
-    return result;
+    std::copy_n(rgbaPixels.begin(), out.size(), out.begin());
+    return;
   }
 
   for (std::size_t y = 0; y < sizeHeight; ++y) {
     std::copy_n(rgbaPixels.begin() + static_cast<std::ptrdiff_t>(y * rowBytes), tightRowBytes,
-                result.begin() + static_cast<std::ptrdiff_t>(y * tightRowBytes));
+                out.begin() + static_cast<std::ptrdiff_t>(y * tightRowBytes));
   }
+}
 
+std::vector<std::uint8_t> CopyTightRgbaRows(std::span<const std::uint8_t> rgbaPixels, int width,
+                                            int height, std::size_t rowBytes) {
+  std::vector<std::uint8_t> result;
+  CopyTightRgbaRowsInto(rgbaPixels, width, height, rowBytes, result);
   return result;
+}
+
+void PremultiplyRgbaRowsInto(std::span<const std::uint8_t> rgbaPixels, int width, int height,
+                             std::size_t rowBytes, std::vector<std::uint8_t>& out) {
+  CopyTightRgbaRowsInto(rgbaPixels, width, height, rowBytes, out);
+  PremultiplyRgbaInPlace(out);
 }
 
 std::vector<std::uint8_t> PremultiplyRgbaRows(std::span<const std::uint8_t> rgbaPixels, int width,
                                               int height, std::size_t rowBytes) {
-  std::vector<std::uint8_t> result = CopyTightRgbaRows(rgbaPixels, width, height, rowBytes);
-  PremultiplyRgbaInPlace(result);
+  std::vector<std::uint8_t> result;
+  PremultiplyRgbaRowsInto(rgbaPixels, width, height, rowBytes, result);
   return result;
 }
 

--- a/donner/svg/renderer/PixelFormatUtils.h
+++ b/donner/svg/renderer/PixelFormatUtils.h
@@ -13,6 +13,12 @@
 /// Unaligned tails are ignored (matches the pre-split behavior of every
 /// caller that had its own local copy).
 ///
+/// Aliasing: the `*Into` helpers write through their `out` buffer while
+/// reading `rgbaPixels`, so the two must not overlap. Passing a span into
+/// `out`'s own storage (including `out` itself) is undefined behavior - the
+/// write can reallocate `out` and dangle the input span. Every other helper
+/// returns a fresh buffer and has no such constraint.
+///
 /// Rounding convention: integer `round-half-up` in both directions, so
 /// a round-trip premul → unpremul is bit-identical for every
 /// well-formed premul input (i.e., `r ≤ a, g ≤ a, b ≤ a`). If a caller
@@ -32,6 +38,19 @@ namespace donner::svg {
 /// @return Newly-allocated premul RGBA buffer of the same size.
 [[nodiscard]] std::vector<std::uint8_t> PremultiplyRgba(std::span<const std::uint8_t> rgbaPixels);
 
+/// Convert tightly-packed straight-alpha RGBA8 to premultiplied RGBA8, writing into a
+/// caller-owned buffer.
+///
+/// Same conversion as \ref PremultiplyRgba, but \p out's existing storage is reused when it is
+/// large enough, so a caller that converts once per frame keeps one buffer instead of allocating
+/// and freeing a new one every time.
+///
+/// \p rgbaPixels must not alias \p out; see the aliasing note at the top of this file.
+///
+/// @param rgbaPixels Straight-alpha RGBA bytes (size must be a multiple of 4).
+/// @param out Destination buffer, resized to match \p rgbaPixels.
+void PremultiplyRgbaInto(std::span<const std::uint8_t> rgbaPixels, std::vector<std::uint8_t>& out);
+
 /// Copy row-strided RGBA8 bytes into a tightly-packed RGBA8 buffer.
 ///
 /// @param rgbaPixels Source RGBA bytes.
@@ -44,6 +63,20 @@ namespace donner::svg {
                                                           int width, int height,
                                                           std::size_t rowBytes);
 
+/// Copy row-strided RGBA8 bytes into a caller-owned tightly-packed buffer.
+///
+/// Buffer-reusing form of \ref CopyTightRgbaRows. \p rgbaPixels must not alias \p out.
+/// @see PremultiplyRgbaInto
+///
+/// @param rgbaPixels Source RGBA bytes.
+/// @param width Pixel width.
+/// @param height Pixel height.
+/// @param rowBytes Bytes between source rows.
+/// @param out Destination buffer, resized to the tightly-packed size, or emptied when dimensions
+///   or row storage are invalid.
+void CopyTightRgbaRowsInto(std::span<const std::uint8_t> rgbaPixels, int width, int height,
+                           std::size_t rowBytes, std::vector<std::uint8_t>& out);
+
 /// Convert row-strided straight-alpha RGBA8 to tightly-packed premultiplied RGBA8.
 ///
 /// @param rgbaPixels Straight-alpha source RGBA bytes.
@@ -54,6 +87,21 @@ namespace donner::svg {
 /// dimensions or row storage are invalid.
 [[nodiscard]] std::vector<std::uint8_t> PremultiplyRgbaRows(
     std::span<const std::uint8_t> rgbaPixels, int width, int height, std::size_t rowBytes);
+
+/// Convert row-strided straight-alpha RGBA8 to tightly-packed premultiplied RGBA8, writing into
+/// a caller-owned buffer.
+///
+/// Buffer-reusing form of \ref PremultiplyRgbaRows. \p rgbaPixels must not alias \p out.
+/// @see PremultiplyRgbaInto
+///
+/// @param rgbaPixels Straight-alpha source RGBA bytes.
+/// @param width Pixel width.
+/// @param height Pixel height.
+/// @param rowBytes Bytes between source rows.
+/// @param out Destination buffer, resized to the tightly-packed size, or emptied when dimensions
+///   or row storage are invalid.
+void PremultiplyRgbaRowsInto(std::span<const std::uint8_t> rgbaPixels, int width, int height,
+                             std::size_t rowBytes, std::vector<std::uint8_t>& out);
 
 /// Convert tightly-packed premultiplied RGBA8 to straight-alpha RGBA8,
 /// in place. Fully-opaque pixels (alpha == 255) are unchanged;

--- a/donner/svg/renderer/RenderSnapshot.cc
+++ b/donner/svg/renderer/RenderSnapshot.cc
@@ -301,6 +301,9 @@ std::size_t CountReferenceToRegistry(const RenderCommand& command, const Registr
                         [&](const SetPaintCommand& value) {
                           return CountReferenceToRegistry(value.paint, registry);
                         },
+                        [&](const DrawImageCommand& value) {
+                          return CountReferenceToRegistry(value.params.sourceEntity, registry);
+                        },
                         [&](const DrawTextCommand& value) {
                           return CountReferenceToRegistry(value.text, registry);
                         },
@@ -538,7 +541,12 @@ void RenderSnapshotRecorder::drawEllipse(const Box2d& bounds, const StrokeParams
 }
 
 void RenderSnapshotRecorder::drawImage(const ImageResource& image, const ImageParams& params) {
-  snapshot_.impl_->commands.push_back(DrawImageCommand{image, params});
+  ImageParams snapshotParams = params;
+  // Same rule as `drawPath`: a replayed command must not carry a handle into the live document
+  // registry, so backends replaying a snapshot convert the image per draw instead of caching it
+  // on its source entity.
+  snapshotParams.sourceEntity = EntityHandle();
+  snapshot_.impl_->commands.push_back(DrawImageCommand{image, std::move(snapshotParams)});
 }
 
 void RenderSnapshotRecorder::drawText(Registry&, const components::ComputedTextComponent& text,

--- a/donner/svg/renderer/RendererDriver.cc
+++ b/donner/svg/renderer/RendererDriver.cc
@@ -927,6 +927,7 @@ std::optional<ImageParams> toImageParams(const components::RenderingInstanceComp
   ImageParams params;
   params.opacity = style.properties->opacity.get().value();
   params.targetRect = Box2d::WithSize(Vector2d(image.image->width, image.image->height));
+  params.sourceEntity = instance.dataHandle(registry);
 
   // `image-rendering: pixelated` and `crisp-edges` (plus the legacy
   // SVG 1.1 `optimizeSpeed` alias) disable bilinear filtering and use

--- a/donner/svg/renderer/RendererInterface.h
+++ b/donner/svg/renderer/RendererInterface.h
@@ -331,6 +331,12 @@ struct ImageParams {
   double opacity = 1.0;
   /// Whether to favor nearest-neighbor sampling for pixelated rendering.
   bool imageRenderingPixelated = false;
+  /// Source entity the drawn image was loaded onto. Set by the driver at the `drawImage`
+  /// call site. Backends that cache a converted form of the pixels key off this, the same
+  /// way \ref PathShape::sourceEntity keys converted geometry. A null `EntityHandle` (the
+  /// default) means "no associated entity" - non-driver callers leave it null and backends
+  /// fall back to converting per draw.
+  EntityHandle sourceEntity;
 };
 
 /**

--- a/donner/svg/renderer/RendererTinySkia.cc
+++ b/donner/svg/renderer/RendererTinySkia.cc
@@ -7,16 +7,20 @@
 #include <functional>
 #include <iostream>
 #include <optional>
+#include <span>
 #include <utility>
 #include <variant>
 #include <vector>
 
+#include "donner/base/EcsRegistry.h"
 #include "donner/base/Length.h"
 #include "donner/base/MathUtils.h"
 #include "donner/svg/components/layout/TransformComponent.h"
 #include "donner/svg/components/paint/GradientComponent.h"
 #include "donner/svg/components/paint/LinearGradientComponent.h"
 #include "donner/svg/components/paint/RadialGradientComponent.h"
+#include "donner/svg/components/resources/ImageComponent.h"
+#include "donner/svg/components/shape/ComputedPathComponent.h"
 #ifdef DONNER_FILTERS_ENABLED
 #include "donner/svg/renderer/FilterGraphExecutor.h"
 #endif
@@ -24,6 +28,7 @@
 #include "donner/svg/renderer/PixelFormatUtils.h"
 #include "donner/svg/renderer/RendererDriver.h"
 #include "donner/svg/renderer/RendererImageIO.h"
+#include "donner/svg/renderer/RendererTinySkiaCache.h"
 #ifdef DONNER_TEXT_ENABLED
 #include "donner/svg/components/text/ComputedTextGeometryComponent.h"
 #include "donner/svg/renderer/PlacedTextGeometry.h"
@@ -126,9 +131,8 @@ enum class TinyPathCloseBehavior : uint8_t {
   EndWithLine,
 };
 
-tiny_skia::Path toTinyPath(
-    const Path& spline,
-    TinyPathCloseBehavior closeBehavior = TinyPathCloseBehavior::Preserve) {
+tiny_skia::Path toTinyPath(const Path& spline,
+                           TinyPathCloseBehavior closeBehavior = TinyPathCloseBehavior::Preserve) {
   tiny_skia::PathBuilder builder(spline.commands().size(), spline.points().size());
   const auto points = spline.points();
 
@@ -173,6 +177,136 @@ tiny_skia::Path toTinyPath(
   }
 
   return builder.finish().value_or(tiny_skia::Path());
+}
+
+/// Marks a registry whose conversion-cache invalidation listeners are already connected.
+///
+/// The sentinel lives in the registry's context store, so it dies with the registry: a later
+/// registry allocated at the same address correctly misses it and gets its own listeners.
+/// Pointer identity on the registry alone could not tell those two cases apart.
+struct CacheListenersInstalled {};
+
+void OnComputedPathChanged(Registry& registry, Entity entity) {
+  // entt allows `remove` on a component the entity does not hold; it is a cheap no-op there.
+  registry.remove<components::TinySkiaPathCacheComponent>(entity);
+}
+
+void OnLoadedImageChanged(Registry& registry, Entity entity) {
+  registry.remove<components::TinySkiaImageCacheComponent>(entity);
+}
+
+/// Connects the listeners that drop a cached conversion when its source changes or goes away.
+/// Idempotent, and called before any cache entry is installed on \p registry.
+///
+/// Wiring on that first installation rather than at frame entry is sufficient, even though a
+/// backend that wires later than the render tree's rebuild would normally risk a stale entry:
+/// no cache entry on \p registry can predate the connection, because the same call path that
+/// creates the first one connects the listeners first. Every source mutation that could
+/// invalidate an entry therefore happens after the listeners are attached, including the ones
+/// a later frame's render-tree rebuild fires. A signal missed before the first entry exists has
+/// nothing to invalidate.
+///
+/// \p checkedThisFrame memoizes the last registry the caller verified, so the context-store
+/// lookup runs once per frame per document instead of once per draw. The memo is reset at every
+/// frame boundary, which is what makes it safe: a registry cannot be destroyed and a new one
+/// allocated at the same address in the middle of a frame while the caller holds entity handles
+/// into it, so unlike a persistent pointer cache the memo cannot confuse two registries. The
+/// context-store sentinel remains the authority across frames.
+void EnsureCacheInvalidationWired(Registry& registry, const Registry*& checkedThisFrame) {
+  if (checkedThisFrame == &registry) {
+    return;
+  }
+
+  checkedThisFrame = &registry;
+  if (registry.ctx().contains<CacheListenersInstalled>()) {
+    return;
+  }
+
+  registry.ctx().emplace<CacheListenersInstalled>();
+  // Materialize both cache pools here, while the registry is quiescent. The listeners below
+  // remove those components, and a removal on an entity that never held one still has to reach
+  // the pool, which would otherwise be created for the first time from inside a destruction
+  // signal. Creating it up front removes the need to reason about that at all.
+  static_cast<void>(registry.storage<components::TinySkiaPathCacheComponent>());
+  static_cast<void>(registry.storage<components::TinySkiaImageCacheComponent>());
+  registry.on_update<components::ComputedPathComponent>().connect<&OnComputedPathChanged>();
+  registry.on_destroy<components::ComputedPathComponent>().connect<&OnComputedPathChanged>();
+  registry.on_update<components::LoadedImageComponent>().connect<&OnLoadedImageChanged>();
+  registry.on_destroy<components::LoadedImageComponent>().connect<&OnLoadedImageChanged>();
+  // Leaving the connections attached across renderer destruction is intentional: these are
+  // free functions with no captured state, so they are safe to outlive any renderer, and the
+  // connections die with the registry.
+}
+
+/// Selects the cache slot that holds \p closeBehavior's conversion.
+///
+/// Written as an exhaustive switch, like the other `toTiny*` mappings in this file, rather than
+/// as a two-way ternary. A ternary silently folds any future close behavior into the `openedPath`
+/// slot, which would serve one behavior's outline for another - a wrong-pixels bug that no test
+/// of the existing two behaviors can see. Here `-Wswitch` names the missing case instead.
+std::optional<tiny_skia::Path>& cacheSlotFor(components::TinySkiaPathCacheComponent& cache,
+                                             TinyPathCloseBehavior closeBehavior) {
+  switch (closeBehavior) {
+    case TinyPathCloseBehavior::Preserve: return cache.closedPath;
+    case TinyPathCloseBehavior::EndWithLine: return cache.openedPath;
+  }
+
+  UTILS_UNREACHABLE();
+}
+
+/// Returns `shape.path` in tiny-skia form, converting it on a cache miss.
+///
+/// When the shape carries a source entity the conversion is memoized on that entity and the
+/// returned reference points into the cache component, which stays valid until the entity's
+/// geometry changes. Without a source entity (overlay drawing, test harnesses) the conversion
+/// lands in \p scratch, which the caller must keep alive for as long as it uses the result.
+const tiny_skia::Path& ResolveTinyPath(const PathShape& shape, TinyPathCloseBehavior closeBehavior,
+                                       tiny_skia::Path& scratch, const Registry*& checkedThisFrame,
+                                       RendererTinySkiaFrameCounters& counters) {
+  EntityHandle source = shape.sourceEntity;
+  if (!source) {
+    ++counters.pathConversions;
+    scratch = toTinyPath(shape.pathOrEmpty(), closeBehavior);
+    return scratch;
+  }
+
+  EnsureCacheInvalidationWired(*source.registry(), checkedThisFrame);
+  auto& cache = source.get_or_emplace<components::TinySkiaPathCacheComponent>();
+  std::optional<tiny_skia::Path>& slot = cacheSlotFor(cache, closeBehavior);
+  if (!slot.has_value()) {
+    ++counters.pathConversions;
+    slot = toTinyPath(shape.pathOrEmpty(), closeBehavior);
+  }
+  return *slot;
+}
+
+/// Returns \p image's pixels premultiplied, converting them on a cache miss.
+///
+/// Mirrors \ref ResolveTinyPath: the payload is memoized on \p source when there is one, and
+/// otherwise converted into \p scratch, which the caller must keep alive for as long as it uses
+/// the result. A cached payload whose dimensions no longer match \p image is reconverted rather
+/// than sampled at the wrong extent.
+std::span<const std::uint8_t> ResolvePremultipliedImage(const ImageResource& image,
+                                                        EntityHandle source,
+                                                        std::vector<std::uint8_t>& scratch,
+                                                        const Registry*& checkedThisFrame,
+                                                        RendererTinySkiaFrameCounters& counters) {
+  if (!source) {
+    ++counters.imagePremultiplies;
+    PremultiplyRgbaInto(image.data, scratch);
+    return scratch;
+  }
+
+  EnsureCacheInvalidationWired(*source.registry(), checkedThisFrame);
+  auto& cache = source.get_or_emplace<components::TinySkiaImageCacheComponent>();
+  if (cache.premultiplied.size() != image.data.size() || cache.width != image.width ||
+      cache.height != image.height) {
+    ++counters.imagePremultiplies;
+    PremultiplyRgbaInto(image.data, cache.premultiplied);
+    cache.width = image.width;
+    cache.height = image.height;
+  }
+  return cache.premultiplied;
 }
 
 // `transformPath` now lives in the shared (text-gated) PlacedTextGeometry header
@@ -595,7 +729,21 @@ void RendererTinySkia::beginFrame(const RenderViewport& viewport) {
   const int pixelWidth = static_cast<int>(viewport.size.x * viewport.devicePixelRatio);
   const int pixelHeight = static_cast<int>(viewport.size.y * viewport.devicePixelRatio);
 
-  frame_ = createTransparentPixmap(pixelWidth, pixelHeight);
+  // Keep the frame buffer's allocation across frames. A renderer that draws the
+  // same viewport repeatedly (editor, compositor, animation loop) otherwise
+  // releases and re-acquires the whole buffer every frame, which costs a
+  // malloc/free pair plus a first-touch page fault for every page of a
+  // multi-megabyte buffer. The clear is not an optimization target: the buffer
+  // must start transparent, so a retained buffer is explicitly zeroed and the
+  // output is identical either way.
+  const bool frameSizeUnchanged = pixelWidth > 0 && pixelHeight > 0 &&
+                                  frame_.width() == static_cast<std::uint32_t>(pixelWidth) &&
+                                  frame_.height() == static_cast<std::uint32_t>(pixelHeight);
+  if (frameSizeUnchanged) {
+    frame_.fill(tiny_skia::Color::transparent);
+  } else {
+    frame_ = createTransparentPixmap(pixelWidth, pixelHeight);
+  }
   deviceFromLocalTransform_ = Transform2d();
   deviceFromLocalTransformStack_.clear();
   currentClipMask_.reset();
@@ -603,6 +751,11 @@ void RendererTinySkia::beginFrame(const RenderViewport& viewport) {
   surfaceStack_.clear();
   patternFillPaint_.reset();
   patternStrokePaint_.reset();
+  frameCounters_ = RendererTinySkiaFrameCounters();
+  // Both the counters and the listener-wiring memo describe one frame only. Dropping the memo
+  // here is what bounds its lifetime to a frame, which is the property that makes comparing
+  // registry addresses safe; see `EnsureCacheInvalidationWired`.
+  cacheWiringCheckedRegistry_ = nullptr;
 }
 
 void RendererTinySkia::endFrame() {
@@ -615,6 +768,7 @@ void RendererTinySkia::endFrame() {
   deviceFromLocalTransformStack_.clear();
   currentClipMask_.reset();
   clipStack_.clear();
+  cacheWiringCheckedRegistry_ = nullptr;
 }
 
 void RendererTinySkia::setTransform(const Transform2d& transform) {
@@ -1063,9 +1217,6 @@ bool RendererTinySkia::beginPatternTile(const Box2d& tileRect,
   SurfaceFrame frame;
   frame.kind = SurfaceKind::PatternTile;
   frame.savedTransform = deviceFromLocalTransform_;
-  frame.savedTransformStack = deviceFromLocalTransformStack_;
-  frame.savedClipMask = currentClipMask_;
-  frame.savedClipStack = clipStack_;
   const Transform2d deviceFromPattern = targetFromPattern * frame.savedTransform;
   const std::optional<PatternTileRasterMetrics> rasterMetrics =
       ComputePatternTileRasterMetrics(tileRect, deviceFromPattern);
@@ -1080,6 +1231,16 @@ bool RendererTinySkia::beginPatternTile(const Box2d& tileRect,
   if (frame.pixmap.width() == 0 || frame.pixmap.height() == 0) {
     return false;
   }
+
+  // Hand the live clip and transform state to the frame by move. Every entry of
+  // `clipStack_` owns a surface-sized alpha mask, so copying the stack here
+  // duplicated one buffer per nesting level for every pattern tile the document
+  // draws, only to clear the originals three lines later. The moves are placed
+  // after the last early return, so a rejected tile still leaves the renderer's
+  // state exactly as it found it.
+  frame.savedTransformStack = std::move(deviceFromLocalTransformStack_);
+  frame.savedClipMask = std::move(currentClipMask_);
+  frame.savedClipStack = std::move(clipStack_);
 
   // Tile-content draws must not consume the outer element's pending pattern shaders (a shape
   // inside the tile would otherwise pick them up as its own fill/stroke and reset them).
@@ -1130,7 +1291,10 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
   }
 
   const Path& pathGeometry = path.pathOrEmpty();
-  const tiny_skia::Path tinyPath = toTinyPath(pathGeometry);
+  tiny_skia::Path uncachedPath;
+  const tiny_skia::Path& tinyPath =
+      ResolveTinyPath(path, TinyPathCloseBehavior::Preserve, uncachedPath,
+                      cacheWiringCheckedRegistry_, frameCounters_);
   const tiny_skia::Mask* mask = currentClipMask_.has_value() ? &*currentClipMask_ : nullptr;
   tiny_skia::Pixmap* fillPaintPixmap =
       !surfaceStack_.empty() && surfaceStack_.back().fillPaintPixmap.has_value()
@@ -1208,11 +1372,11 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
     // those ranges across ClosePath, filling the seam as if the stroke were solid. Replace only
     // the stroke's ClosePath commands with explicit closing lines so the dash stroker emits caps
     // at that boundary; fills and ordinary dashed/solid strokes keep their closed contours.
-    std::optional<tiny_skia::Path> openDashSeamPath;
+    tiny_skia::Path uncachedDashSeamPath;
     const tiny_skia::Path* strokePath = &tinyPath;
     if (tinyStroke.dash.has_value() && dashHasOnlyZeroLengthGaps) {
-      openDashSeamPath = toTinyPath(pathGeometry, TinyPathCloseBehavior::EndWithLine);
-      strokePath = &*openDashSeamPath;
+      strokePath = &ResolveTinyPath(path, TinyPathCloseBehavior::EndWithLine, uncachedDashSeamPath,
+                                    cacheWiringCheckedRegistry_, frameCounters_);
     }
 
     auto pixmapView = currentPixmapView();
@@ -1365,11 +1529,28 @@ void RendererTinySkia::drawImage(const ImageResource& image, const ImageParams& 
     return;
   }
 
-  std::vector<std::uint8_t> premultiplied = PremultiplyRgba(image.data);
-  auto maybePixmap = tiny_skia::Pixmap::fromVec(
-      std::move(premultiplied), tiny_skia::IntSize(static_cast<std::uint32_t>(image.width),
-                                                   static_cast<std::uint32_t>(image.height)));
-  if (!maybePixmap.has_value()) {
+  // A payload longer than its declared dimensions is malformed, and drawing its leading
+  // `width * height` pixels would present mismatched content. The check is explicit because
+  // `PixmapView::fromBytes` below accepts any buffer at least as large as the view it returns,
+  // where wrapping the pixels in an owning `Pixmap` demanded an exact length; short payloads and
+  // dimensions too large to address are still rejected by `fromBytes` itself.
+  const std::uint64_t expectedDataBytes =
+      static_cast<std::uint64_t>(image.width) * static_cast<std::uint64_t>(image.height) * 4u;
+  if (static_cast<std::uint64_t>(image.data.size()) != expectedDataBytes) {
+    return;
+  }
+
+  // `ImageResource` publishes straight alpha and tiny-skia samples premultiplied, so the
+  // conversion is unavoidable, but it does not have to recur. The pixels belong to the element's
+  // loaded image and change only when that does, so the premultiplied form is cached on the
+  // source entity and borrowed through a view; the previous code premultiplied into a fresh
+  // buffer and wrapped it in a throwaway `Pixmap` on every draw of every frame.
+  const std::span<const std::uint8_t> premultiplied = ResolvePremultipliedImage(
+      image, params.sourceEntity, pixelScratch_, cacheWiringCheckedRegistry_, frameCounters_);
+  const std::optional<tiny_skia::PixmapView> sourceView =
+      tiny_skia::PixmapView::fromBytes(premultiplied, static_cast<std::uint32_t>(image.width),
+                                       static_cast<std::uint32_t>(image.height));
+  if (!sourceView.has_value()) {
     return;
   }
 
@@ -1387,7 +1568,7 @@ void RendererTinySkia::drawImage(const ImageResource& image, const ImageParams& 
 
   const tiny_skia::Mask* mask = currentClipMask_.has_value() ? &*currentClipMask_ : nullptr;
   auto pixmapView = currentPixmapView();
-  tiny_skia::Painter::drawPixmap(pixmapView, 0, 0, maybePixmap->view(), paint,
+  tiny_skia::Painter::drawPixmap(pixmapView, 0, 0, *sourceView, paint,
                                  toTinyTransform(imageFromLocal), mask);
 }
 
@@ -1409,8 +1590,13 @@ void RendererTinySkia::drawBitmap(const RendererBitmap& bitmap, const ImageParam
   // payloads premultiply directly into the draw scratch while packing rows.
   // All cases beat the ImageResource contract, which costs an extra
   // full-buffer copy and, for premultiplied payloads, an extra unpremultiply.
+  //
+  // The two converting cases stage through `pixelScratch_` rather than a local
+  // buffer, so a caller that composes the same layer every frame reuses one
+  // allocation instead of acquiring and releasing a payload-sized buffer per
+  // draw. The scratch is only ever read back through the view built from it
+  // below, and no draw nests inside another, so one buffer serves all of them.
   std::optional<tiny_skia::PixmapView> sourceView;
-  std::vector<std::uint8_t> scratch;
   if (bitmap.alphaType == AlphaType::Premultiplied) {
     if (bitmap.rowBytes == tightRowBytes) {
       sourceView =
@@ -1418,16 +1604,17 @@ void RendererTinySkia::drawBitmap(const RendererBitmap& bitmap, const ImageParam
                                            static_cast<std::uint32_t>(bitmap.dimensions.x),
                                            static_cast<std::uint32_t>(bitmap.dimensions.y));
     } else {
-      scratch = CopyTightRgbaRows(bitmap.pixels, bitmap.dimensions.x, bitmap.dimensions.y,
-                                  bitmap.rowBytes);
-      sourceView = tiny_skia::PixmapView::fromBytes(
-          std::span<const std::uint8_t>(scratch), static_cast<std::uint32_t>(bitmap.dimensions.x),
-          static_cast<std::uint32_t>(bitmap.dimensions.y));
+      CopyTightRgbaRowsInto(bitmap.pixels, bitmap.dimensions.x, bitmap.dimensions.y,
+                            bitmap.rowBytes, pixelScratch_);
+      sourceView =
+          tiny_skia::PixmapView::fromBytes(std::span<const std::uint8_t>(pixelScratch_),
+                                           static_cast<std::uint32_t>(bitmap.dimensions.x),
+                                           static_cast<std::uint32_t>(bitmap.dimensions.y));
     }
   } else {
-    scratch = PremultiplyRgbaRows(bitmap.pixels, bitmap.dimensions.x, bitmap.dimensions.y,
-                                  bitmap.rowBytes);
-    sourceView = tiny_skia::PixmapView::fromBytes(std::span<const std::uint8_t>(scratch),
+    PremultiplyRgbaRowsInto(bitmap.pixels, bitmap.dimensions.x, bitmap.dimensions.y,
+                            bitmap.rowBytes, pixelScratch_);
+    sourceView = tiny_skia::PixmapView::fromBytes(std::span<const std::uint8_t>(pixelScratch_),
                                                   static_cast<std::uint32_t>(bitmap.dimensions.x),
                                                   static_cast<std::uint32_t>(bitmap.dimensions.y));
   }
@@ -2006,15 +2193,13 @@ RendererBitmap RendererTinySkia::takeSnapshot() const {
     return snapshot;
   }
 
-  auto maybeCopy = tiny_skia::Pixmap::fromVec(
-      std::vector<std::uint8_t>(frame_.data().begin(), frame_.data().end()), frame_.size());
-  if (!maybeCopy.has_value()) {
-    snapshot.dimensions = Vector2i::Zero();
-    snapshot.rowBytes = 0;
-    return snapshot;
-  }
-
-  snapshot.pixels = maybeCopy->release();
+  // Copy straight into the snapshot's buffer. The caller owns the returned
+  // pixels and `frame_` has to survive for the next frame, so one copy is
+  // unavoidable; staging it through a temporary `Pixmap` (build a vector,
+  // re-validate its length against a size we already own, then move the vector
+  // back out) only adds moves and a redundant check around that same copy.
+  const std::span<const std::uint8_t> framePixels = frame_.data();
+  snapshot.pixels.assign(framePixels.begin(), framePixels.end());
   // Scalar pass, measured at roughly 2 ms for a 900x900 frame. It already
   // short-circuits alpha==255 and alpha==0 pixels, so a separate "is the frame
   // opaque?" pre-scan would only add a second full read without removing work;
@@ -2260,13 +2445,20 @@ tiny_skia::Pixmap RendererTinySkia::createTransparentPixmap(int width, int heigh
     return tiny_skia::Pixmap();
   }
 
+  // `Pixmap::fromSize` hands back a zero-filled buffer, which is already the
+  // transparent-black bit pattern this function promises. An explicit
+  // `fill(transparent)` on top of that memsets every byte a second time, so it
+  // is dropped: the result is byte-identical and each surface (frame buffer,
+  // isolated layer, filter buffer plus its fill/stroke paint buffers, mask
+  // capture and content, pattern tile) pays one full-buffer write instead of
+  // two. Reusing a surface across frames is the one case that still needs an
+  // explicit clear; see `beginFrame`.
   auto maybePixmap = tiny_skia::Pixmap::fromSize(static_cast<std::uint32_t>(width),
                                                  static_cast<std::uint32_t>(height));
   if (!maybePixmap.has_value()) {
     return tiny_skia::Pixmap();
   }
 
-  maybePixmap->fill(tiny_skia::Color::transparent);
   return std::move(*maybePixmap);
 }
 

--- a/donner/svg/renderer/RendererTinySkia.h
+++ b/donner/svg/renderer/RendererTinySkia.h
@@ -1,12 +1,14 @@
 #pragma once
 /// @file
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <span>
 #include <string>
 #include <vector>
 
+#include "donner/base/EcsRegistry_fwd.h"
 #include "donner/svg/SVGDocument.h"
 #include "donner/svg/renderer/RendererInterface.h"
 #include "tiny_skia/Mask.h"
@@ -14,6 +16,30 @@
 #include "tiny_skia/Pixmap.h"
 
 namespace donner::svg {
+
+/**
+ * Per-frame counts of the conversions \ref RendererTinySkia caches.
+ *
+ * Reset at every \ref RendererTinySkia::beginFrame, so a read after a frame
+ * reports that frame's work alone. Both count only the conversion sites the
+ * caches cover, not every conversion the backend performs. Both are zero on a
+ * settled frame of an unchanged document, because every cached shape and image
+ * is served from its per-entity cache; that invariant is what keeps the caches
+ * from silently regressing into per-draw conversions, so it is pinned by a test.
+ */
+struct RendererTinySkiaFrameCounters {
+  /// `donner::Path` -> `tiny_skia::Path` conversions performed at the shape-draw call sites the
+  /// path cache covers: cache misses plus shape draws that carry no source entity to cache on.
+  /// Conversions the cache does not reach are not counted, so this is not a total for the frame;
+  /// clip-path shapes and text glyph and decoration outlines convert outside it.
+  uint64_t pathConversions = 0;
+
+  /// Straight-alpha -> premultiplied image conversions performed for `<image>` draws, the only
+  /// site the image cache covers. Layer and bitmap composites premultiply their own payloads
+  /// outside the cache and are not counted.
+  /// @see pathConversions
+  uint64_t imagePremultiplies = 0;
+};
 
 /**
  * Rendering backend using tiny-skia-cpp.
@@ -226,6 +252,12 @@ public:
   /// Returns the rendered height in pixels.
   int height() const override;
 
+  /// Conversions performed during the most recent frame.
+  /// @see RendererTinySkiaFrameCounters
+  [[nodiscard]] const RendererTinySkiaFrameCounters& frameCounters() const {
+    return frameCounters_;
+  }
+
 private:
   struct PatternPaintState {
     tiny_skia::Pixmap pixmap;
@@ -330,6 +362,28 @@ private:
   std::vector<SurfaceFrame> surfaceStack_;
   std::optional<PatternPaintState> patternFillPaint_;
   std::optional<PatternPaintState> patternStrokePaint_;
+
+  /// Staging buffer for image and bitmap payloads that have to be row-packed or premultiplied
+  /// before tiny-skia can view them. Held across draws so a repeated compose reuses one
+  /// allocation; only live for the duration of a single draw call, which never nests.
+  ///
+  /// Residency tradeoff: the buffer grows to the largest payload staged through it and is never
+  /// shrunk, so one large bitmap draw leaves a payload-sized allocation resident for the
+  /// renderer's lifetime. That is bounded by the largest single payload rather than by the
+  /// number of draws, and it buys an acquire/release pair per converting draw; a caller that
+  /// stages one outsized payload and then only small ones would need a shrink policy this
+  /// buffer deliberately does not have.
+  std::vector<std::uint8_t> pixelScratch_;
+
+  /// @see frameCounters()
+  RendererTinySkiaFrameCounters frameCounters_;
+
+  /// Registry whose conversion-cache invalidation listeners this renderer has already verified
+  /// during the current frame, so the check costs one context-store lookup per frame per
+  /// document rather than one per draw. Cleared at each frame boundary, which bounds the
+  /// comparison to a window in which no registry can be freed and reallocated at the same
+  /// address. Never dereferenced.
+  const Registry* cacheWiringCheckedRegistry_ = nullptr;
 };
 
 }  // namespace donner::svg

--- a/donner/svg/renderer/RendererTinySkiaCache.h
+++ b/donner/svg/renderer/RendererTinySkiaCache.h
@@ -1,0 +1,78 @@
+#pragma once
+/// @file
+/// Per-entity caches for the conversions \ref donner::svg::RendererTinySkia runs on the way
+/// into tiny-skia.
+///
+/// Both conversions below are pure functions of document state that does not change between
+/// frames, yet the backend re-ran them on every draw of every frame:
+///
+/// - `donner::Path` -> `tiny_skia::Path`, which allocates a verb buffer and a point buffer per
+///   shape per frame. A document with a few hundred shapes pays that several hundred times a
+///   frame for geometry that never moved.
+/// - An image's straight-alpha pixels -> premultiplied pixels, a full-buffer pass plus a
+///   full-buffer allocation for every image draw.
+///
+/// Invalidation is owned by \ref donner::svg::RendererTinySkia, which connects entt
+/// `on_update` + `on_destroy` listeners for the source component and removes the matching cache
+/// component whenever that source changes. A cached conversion that outlived its source would be
+/// a correctness bug, not a stale optimization, so the listeners are wired before the first
+/// cache entry is installed and cover both mutation and teardown. `ShapeSystem`'s
+/// content-equality gate (`emplaceComputedPathIfChanged`) keeps the path signals from firing on
+/// an unchanged re-render, so an idle frame keeps its caches intact.
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include "tiny_skia/Path.h"
+
+namespace donner::svg::components {
+
+/// Per-entity cache of a shape's `donner::Path` converted to `tiny_skia::Path`.
+///
+/// Installed lazily at the draw call sites via `get_or_emplace`, keyed by
+/// `PathShape::sourceEntity`; removed by the `ComputedPathComponent` listener when the geometry
+/// changes or the entity goes away. A null source entity (overlay drawing, test harnesses) is
+/// not cached and converts inline, exactly as before the cache existed.
+///
+/// Lives in `donner::svg::components`, alongside `ComputedPathComponent` and every other
+/// component it derives from, rather than in a backend-private namespace. (Geode's equivalent
+/// sits in `donner::geode` instead, to match the other Geode types its renderer references
+/// unqualified; the tiny-skia backend has no such namespace and already spells its component
+/// dependencies `components::`.)
+struct TinySkiaPathCacheComponent {
+  /// Conversion that preserves `ClosePath` verbs. Used by fills and by every ordinary stroke.
+  std::optional<tiny_skia::Path> closedPath;
+
+  /// Conversion that replaces each `ClosePath` with an explicit closing line. Used only by the
+  /// dash-stroke path that has to emit caps at a closed contour's seam, so it is filled in on
+  /// demand rather than alongside \ref closedPath.
+  std::optional<tiny_skia::Path> openedPath;
+};
+
+/// Per-entity cache of a `LoadedImageComponent`'s pixels converted from the straight-alpha
+/// `ImageResource` contract to the premultiplied form tiny-skia samples.
+///
+/// Installed lazily by `drawImage` via `get_or_emplace`, keyed by `ImageParams::sourceEntity`;
+/// removed by the `LoadedImageComponent` listener when the element loads different pixels or
+/// goes away. The dimensions are stored alongside the payload and rechecked on every hit, so a
+/// draw whose source no longer matches the cached buffer reconverts instead of sampling the
+/// wrong extent.
+///
+/// Residency tradeoff: the cached payload is a second full copy of the element's decoded pixels
+/// and there is no eviction, so a drawn image stays doubled in resident bytes for as long as the
+/// document holds it. That is bounded by the images the document actually draws (an undrawn or
+/// removed image holds nothing), and it buys a full-buffer conversion pass and allocation per
+/// image per frame; a document with a large enough image working set to care would need an
+/// eviction policy this cache deliberately does not have.
+/// @see TinySkiaPathCacheComponent for the namespace-placement rationale.
+struct TinySkiaImageCacheComponent {
+  /// Premultiplied RGBA8, tightly packed.
+  std::vector<std::uint8_t> premultiplied;
+  /// Width the payload was converted at, in pixels.
+  int width = 0;
+  /// Height the payload was converted at, in pixels.
+  int height = 0;
+};
+
+}  // namespace donner::svg::components

--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -187,6 +187,18 @@ donner_cc_test(
     ],
 )
 
+# Pure-CPU steady-state pins for the tiny-skia conversion caches: no GPU device, no goldens,
+# no backend dispatch (the counters are read straight off `RendererTinySkia`).
+donner_cc_test(
+    name = "renderer_tiny_skia_perf_tests",
+    srcs = ["RendererTinySkiaPerf_tests.cc"],
+    deps = [
+        "//donner/svg/renderer:renderer_tiny_skia",
+        "//donner/svg/tests:parser_test_utils",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
 donner_cc_test(
     name = "renderer_regression_tests",
     srcs = ["RendererRegression_tests.cc"],
@@ -204,6 +216,7 @@ donner_cc_test(
         ":image_comparison_test_fixture",
         "//donner/base:base_test_utils",
         "//donner/base:gtest_timeout_main",
+        "//donner/svg/tests:parser_test_utils",
     ],
 )
 

--- a/donner/svg/renderer/tests/RendererRegression_tests.cc
+++ b/donner/svg/renderer/tests/RendererRegression_tests.cc
@@ -1,9 +1,13 @@
 #include <gtest/gtest.h>
 
 #include <filesystem>
+#include <memory>
+#include <string_view>
 
 #include "donner/base/tests/Runfiles.h"
+#include "donner/svg/SVGImageElement.h"
 #include "donner/svg/renderer/tests/ImageComparisonTestFixture.h"
+#include "donner/svg/tests/ParserTestUtils.h"
 
 namespace donner::svg {
 namespace {
@@ -13,6 +17,18 @@ using Params = ImageComparisonParams;
 std::filesystem::path ResvgResourceRoot() {
   return Runfiles::instance().Rlocation("third_party/resvg-test-suite/");
 }
+
+/// A 2x2 solid red PNG as a data URI.
+constexpr std::string_view kRedImageDataUri =
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAEElEQVR4nGP4z8AARAwQCgAf7gP9i18U1AAAAABJRU5E"
+    "rkJggg==";
+
+/// A 2x2 solid blue PNG as a data URI. @see kRedImageDataUri
+constexpr std::string_view kBlueImageDataUri =
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAD0lEQVR4nGNgYPgPRmAKABf2A/1+6zfzAAAAAElFTkSu"
+    "QmCC";
 
 ImageComparisonParams GoldenParams() {
   Params params;
@@ -130,6 +146,74 @@ TEST_F(RendererRegressionTests, VectorEffectNonScalingStrokeChangesOutput) {
   ASSERT_EQ(nonScaling.pixels.size(), control.pixels.size());
   EXPECT_NE(nonScaling.pixels, control.pixels)
       << "vector-effect: non-scaling-stroke had no effect on the rendered output";
+}
+
+// The tiny-skia backend memoizes each shape's converted `tiny_skia::Path` on the shape's source
+// entity, so a geometry change has to drop that entry before the next draw reads it. The caches
+// live on the document, not on the renderer, so the control render has to come from a separately
+// parsed document that has no cache entries at all - a second renderer over the same document
+// would read the same (possibly stale) entry and agree with a wrong answer.
+TEST_F(RendererRegressionTests, PathMutationInvalidatesTinySkiaConvertedPathCache) {
+  SVGDocument document = instantiateSubtree(
+      R"(<path id="p" d="M 0 0 L 4 0 L 4 4 Z" fill="black"/>)", {}, Vector2i(16, 16));
+
+  std::unique_ptr<RendererInterface> renderer = CreateRendererInstance(RendererBackend::TinySkia);
+  ASSERT_NE(renderer, nullptr);
+  renderer->draw(document);
+  const RendererBitmap beforeMutation = renderer->takeSnapshot();
+  ASSERT_FALSE(beforeMutation.empty());
+
+  auto path = document.querySelector("#p");
+  ASSERT_TRUE(path.has_value());
+  path->setAttribute("d", "M 0 0 L 16 0 L 16 16 Z");
+
+  renderer->draw(document);
+  const RendererBitmap afterMutation = renderer->takeSnapshot();
+  ASSERT_FALSE(afterMutation.empty());
+  // Guards against a vacuous pass: if the mutation were invisible, a stale cache would be
+  // indistinguishable from a correctly invalidated one.
+  ASSERT_NE(afterMutation.pixels, beforeMutation.pixels)
+      << "the `d` mutation must change the rendering for this test to detect a stale conversion";
+
+  SVGDocument freshDocument = instantiateSubtree(
+      R"(<path id="p" d="M 0 0 L 16 0 L 16 16 Z" fill="black"/>)", {}, Vector2i(16, 16));
+  const RendererBitmap fresh = RenderDocumentWithBackend(freshDocument, RendererBackend::TinySkia);
+  ASSERT_FALSE(fresh.empty());
+  ExpectBitmapsIdentical(afterMutation, fresh, "tiny_skia_path_cache_invalidation");
+}
+
+// Same contract for the premultiplied-image cache, which is keyed by the element that loaded the
+// pixels: replacing the `href` drops the loaded image, and the cached conversion has to go with it.
+TEST_F(RendererRegressionTests, ImageHrefChangeInvalidatesTinySkiaPremultipliedImageCache) {
+  const std::string redMarkup =
+      std::string(R"(<image id="i" x="0" y="0" width="16" height="16" href=")") +
+      std::string(kRedImageDataUri) + R"(" />)";
+  const std::string blueMarkup =
+      std::string(R"(<image id="i" x="0" y="0" width="16" height="16" href=")") +
+      std::string(kBlueImageDataUri) + R"(" />)";
+
+  auto fragment = instantiateSubtreeElementAs<SVGImageElement>(redMarkup, {}, Vector2i(16, 16));
+
+  std::unique_ptr<RendererInterface> renderer = CreateRendererInstance(RendererBackend::TinySkia);
+  ASSERT_NE(renderer, nullptr);
+  renderer->draw(fragment.document);
+  const RendererBitmap beforeMutation = renderer->takeSnapshot();
+  ASSERT_FALSE(beforeMutation.empty());
+
+  fragment->setHref(RcString(kBlueImageDataUri));
+
+  renderer->draw(fragment.document);
+  const RendererBitmap afterMutation = renderer->takeSnapshot();
+  ASSERT_FALSE(afterMutation.empty());
+  ASSERT_NE(afterMutation.pixels, beforeMutation.pixels)
+      << "the `href` mutation must change the rendering for this test to detect a stale conversion";
+
+  auto freshFragment =
+      instantiateSubtreeElementAs<SVGImageElement>(blueMarkup, {}, Vector2i(16, 16));
+  const RendererBitmap fresh =
+      RenderDocumentWithBackend(freshFragment.document, RendererBackend::TinySkia);
+  ASSERT_FALSE(fresh.empty());
+  ExpectBitmapsIdentical(afterMutation, fresh, "tiny_skia_image_cache_invalidation");
 }
 
 }  // namespace

--- a/donner/svg/renderer/tests/RendererSnapshot_tests.cc
+++ b/donner/svg/renderer/tests/RendererSnapshot_tests.cc
@@ -268,6 +268,44 @@ TEST(RendererSnapshotTests, RejectedPatternTileSkipsRecordedContentAndEndCommand
   driver.draw(snapshot);
 }
 
+// A snapshot replays off the document thread, so no recorded command may hold a handle into the
+// live registry. `ImageParams` carries one at capture time (backends key a converted-pixel cache
+// off it), so the recorder has to clear it, and the reference audit has to look at it - an audit
+// that skipped `DrawImageCommand` would report zero for a snapshot that does hold a live handle.
+// No other case in this file draws an `<image>`, so this is the only coverage of either.
+TEST(RendererSnapshotTests, ImageSourceEntityIsClearedBeforeReplay) {
+  // A 2x2 solid red PNG as a data URI, so the image loads with no external resources.
+  SVGDocument document = MakeDocument(R"svg(
+    <image id="i" x="0" y="0" width="8" height="8"
+           href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAEElEQVR4nGP4z8AARAwQCgAf7gP9i18U1AAAAABJRU5ErkJggg==" />
+  )svg");
+
+  ::testing::NiceMock<MockRendererInterface> renderer;
+  RendererDriver driver(renderer);
+
+  RenderSnapshot snapshot = driver.captureRenderSnapshot(document);
+  EXPECT_EQ(snapshot.liveRegistryReferenceCountForTesting(document.registry()), 0u);
+
+  std::optional<SVGElement> maybeImage = document.querySelector("image");
+  ASSERT_TRUE(maybeImage.has_value());
+  maybeImage->remove();
+  EXPECT_EQ(snapshot.liveRegistryReferenceCountForTesting(document.registry()), 0u);
+
+  std::vector<ImageParams> replayedImageParams;
+  EXPECT_CALL(renderer, beginFrame(_)).Times(1);
+  EXPECT_CALL(renderer, endFrame()).Times(1);
+  EXPECT_CALL(renderer, drawImage(_, _))
+      .WillRepeatedly([&](const ImageResource&, const ImageParams& params) {
+        replayedImageParams.push_back(params);
+      });
+
+  driver.draw(snapshot);
+
+  ASSERT_FALSE(replayedImageParams.empty());
+  EXPECT_FALSE(static_cast<bool>(replayedImageParams.back().sourceEntity))
+      << "a replayed drawImage must not carry a handle into the live document registry";
+}
+
 TEST(RendererSnapshotTests, FeImageFragmentReferencesAreClearedBeforeReplay) {
   SVGDocument document = MakeDocument(R"svg(
     <defs>

--- a/donner/svg/renderer/tests/RendererTinySkiaPerf_tests.cc
+++ b/donner/svg/renderer/tests/RendererTinySkiaPerf_tests.cc
@@ -1,0 +1,92 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <string_view>
+
+#include "donner/svg/SVGElement.h"
+#include "donner/svg/renderer/RendererTinySkia.h"
+#include "donner/svg/tests/ParserTestUtils.h"
+
+/// @file
+/// Steady-state pins for the tiny-skia backend's per-entity conversion caches.
+///
+/// The caches exist so that re-rendering an unchanged document does not redo work that only
+/// document state can invalidate. That property is invisible in output pixels and easy to lose
+/// to an innocuous refactor (a lost cache lookup, a key that never matches, a listener that
+/// fires too eagerly), and it would show up only as a gradual frame-time regression. Counting
+/// the conversions turns it into an assertion.
+
+namespace donner::svg {
+namespace {
+
+/// A 2x2 solid red PNG as a data URI, so the image loads with no external resources.
+constexpr std::string_view kRedImageDataUri =
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAEElEQVR4nGP4z8AARAwQCgAf7gP9i18U1AAAAABJRU5E"
+    "rkJggg==";
+
+/// Several shapes plus one image, so both counters have work to do.
+std::string ShapesAndImageMarkup() {
+  return std::string(R"(<g>
+      <path id="p" d="M 0 0 L 6 0 L 6 6 Z" fill="black"/>
+      <rect x="1" y="1" width="4" height="4" fill="red"/>
+      <circle cx="8" cy="8" r="3" fill="blue"/>
+      <image id="i" x="8" y="0" width="8" height="8" href=")") +
+         std::string(kRedImageDataUri) + R"(" />
+    </g>)";
+}
+
+SVGDocument MakeDocument() {
+  return instantiateSubtree(ShapesAndImageMarkup(), {}, Vector2i(16, 16));
+}
+
+TEST(RendererTinySkiaPerfTests, SettledFrameConvertsNoPathsAndPremultipliesNoImages) {
+  SVGDocument document = MakeDocument();
+
+  RendererTinySkia renderer;
+  renderer.draw(document);
+
+  // Sanity: the first frame really does the work, so a zero on the second frame means "served
+  // from cache" rather than "this counter never moves".
+  const RendererTinySkiaFrameCounters first = renderer.frameCounters();
+  EXPECT_GT(first.pathConversions, 0u);
+  EXPECT_GT(first.imagePremultiplies, 0u);
+
+  renderer.draw(document);
+
+  const RendererTinySkiaFrameCounters second = renderer.frameCounters();
+  EXPECT_EQ(second.pathConversions, 0u)
+      << "a settled frame re-converted " << second.pathConversions
+      << " path(s); every shape should have been served from its per-entity cache";
+  EXPECT_EQ(second.imagePremultiplies, 0u)
+      << "a settled frame re-premultiplied " << second.imagePremultiplies
+      << " image(s); the payload should have been served from its per-entity cache";
+}
+
+// The other half of the contract: a cache that never refills would also report zero forever. A
+// geometry change has to put the shape back on the conversion path for exactly one frame.
+TEST(RendererTinySkiaPerfTests, MutatedPathReconvertsOnceThenSettlesAgain) {
+  SVGDocument document = MakeDocument();
+
+  RendererTinySkia renderer;
+  renderer.draw(document);
+  renderer.draw(document);
+  ASSERT_EQ(renderer.frameCounters().pathConversions, 0u);
+
+  std::optional<SVGElement> path = document.querySelector("#p");
+  ASSERT_TRUE(path.has_value());
+  path->setAttribute("d", "M 0 0 L 12 0 L 12 12 Z");
+
+  renderer.draw(document);
+  EXPECT_GT(renderer.frameCounters().pathConversions, 0u)
+      << "the mutated shape must be re-converted, not served from the pre-mutation cache";
+  // The image was untouched, so it must not be dragged along by the path invalidation.
+  EXPECT_EQ(renderer.frameCounters().imagePremultiplies, 0u);
+
+  renderer.draw(document);
+  EXPECT_EQ(renderer.frameCounters().pathConversions, 0u)
+      << "the frame after a mutation should settle back to zero conversions";
+}
+
+}  // namespace
+}  // namespace donner::svg


### PR DESCRIPTION
The tiny-skia backend re-did per-frame conversion work on every draw: each `drawPath` rebuilt the `tiny_skia::Path` from the donner `Path`, each `drawImage` re-premultiplied the decoded pixels, and several working buffers were reallocated per frame. This change caches the converted path and premultiplied image per source entity on the document registry, retains the frame buffer across frames, and reuses scratch buffers, so settled frames skip the conversions entirely.

Mechanism and correctness:

- Cache components live on the document registry keyed by the draw's source entity, so they are freed with the document and cannot leak across reloads. Invalidation is wired through `on_update`/`on_destroy` listeners on `ComputedPathComponent` (the same listener idiom the GPU backend already uses); every writer of that component reaches one of the two signals, and entity teardown sweeps all pools before an id can be recycled.
- New frame counters (`pathConversions`, `imagePremultiplies`) pin the mechanism in tests: zero on a settled frame, nonzero on the first frame, back to zero one frame after a mutation invalidates an entry. The counters are scoped to the conversion sites the caches cover.
- The `drawImage` payload length check is kept as an explicit equality pin (the pixmap view API alone would accept oversized buffers that the previous owning-pixmap construction rejected).

Measured on an aarch64 desktop, `-c opt`, one core pinned, medians of 7 interleaved passes: Ghostscript Tiger first+second frame -5.3% (first frame -7.6%), with steady-state heap allocations -16% by count and -39% by bytes on Tiger and lion. lion and the filter scene are at noise, with one document-dependent caveat stated in the commit: lion's cold frame is ~2% slower (7 of 7 passes) because per-shape cache installation costs more than a twice-drawn document recovers, while larger surfaces gain cold time from the retained frame buffer.

Output is byte-identical: a direct main-vs-branch fingerprint over every repo SVG plus the vendored resvg suite (1799 documents) matches on all 1798 renderable inputs. Full default test suite, the resvg suites, and an ASan+UBSan pass over the adapter tests are green.
