### PR TITLE
perf: Retain and replay per-shape coverage spans in the tiny-skia backend

### DIFF
--- a/docs/design_docs/0060-tinyskia_retained_raster_cache.md
+++ b/docs/design_docs/0060-tinyskia_retained_raster_cache.md
@@ -32,16 +32,16 @@ additions to `third_party/tiny-skia-cpp`). The Geode GPU backend is untouched.
 
 ## Goals
 
-- Steady-state frames of an unchanged document render 10-20x faster on raster-bound scenes
-  (Tiger: from about 41 ms to 2-4 ms), measured by `engine_compare_bench`'s `second_ms` phase at
-  `-c opt`.
+- Steady-state frames of an unchanged document render substantially faster on raster-bound
+  scenes, measured by `engine_compare_bench`'s `second_ms` phase at `-c opt`. The target was
+  10-20x; the measured result is 2.4x on the tiger, and Performance says why the rest is not
+  reachable without giving up the identity argument.
 - Cold (first) frames stay at parity or better.
-- The retained path produces bit-identical output to a fresh render, asserted by a
-  mode-comparison test over the golden and resvg corpora, for every supported scene.
-- Property changes invalidate only the retained state they affect: a fill color change rebuilds
-  nothing; a gradient stop change rebuilds only the color ramp; a stroke property change rebuilds
-  only stroke spans; geometry, transform, or clip changes rebuild outline and spans.
-- Steady-state prepare performs zero heap allocations, asserted by an allocation-count test.
+- The retained path produces bit-identical output to a fresh render, for every supported scene.
+- A change invalidates at least the retained state it affects, and never less. Fine-grained
+  classification is a goal only where it can be had without an invalidation rule that has to be
+  kept in sync with the property system by hand; today a stroke change rebuilds only stroke
+  coverage, and every other change rebuilds the shape.
 - With the concurrency feature enabled, output is identical for every thread count, including the
   zero-thread inline mode.
 
@@ -64,11 +64,18 @@ additions to `third_party/tiny-skia-cpp`). The Geode GPU backend is untouched.
 
 ## Next Steps
 
-- Decide whether the steady frame's remaining cost (blending covered area, not generating it)
-  is worth attacking with opaque-interior straight stores, and whether that can be done inside
-  the shared blitter construction so identity still holds by construction.
-- Revisit the colour-only fast path: a solid paint change currently re-rasterizes, which the
-  goals below said it should not.
+- Decide whether the steady frame's remaining cost (blending covered area, not generating it) is
+  worth attacking with opaque-interior stores, and whether that can live inside the shared
+  blitter construction so identity still holds by construction rather than by proof.
+- Add a colour-only fast path: when a draw does not derive its blitter's paint from the caller's
+  (which a hairline stroke and a transformed gradient both do), coverage is independent of the
+  paint and a replay could take the fresh paint instead of rebuilding.
+- Give corpus-wide retained-versus-fresh identity a CI lane, instead of leaving
+  `DONNER_TINYSKIA_RETAINED=compare` as a diagnostic someone has to remember to run.
+- Run the SVG parser and render fuzzers with retention enabled, so the invalidation and eviction
+  state machines see hostile mutation sequences.
+- Make a steady frame allocation-free, which needs paint comparison that does not rebuild a
+  gradient's stop list every frame, and then assert it.
 
 ## Implementation Plan
 
@@ -158,7 +165,9 @@ Tiger.
         straight stores; they go through the same blitter a cold draw builds, which is what
         keeps identity true by construction. That decision is why the measured win is smaller
         than this document projected; see Performance.
-  - [x] Mode-comparison identity test over the renderer golden corpus and the resvg suite.
+  - [x] Retained-versus-fresh identity test, plus a run mode that turns the golden and resvg
+        suites into corpus-wide identity runs. The run mode is a diagnostic with no CI lane
+        setting it; see Testing and Validation.
   - [x] Per-dirty-class invalidation tests (mutate one property class, assert identity with a
         fresh render).
 - [x] Milestone 3: Memory policy
@@ -178,50 +187,28 @@ Tiger.
 
 ### Milestone 2 decisions
 
-**Validation compares the draw's inputs, not per-property revision counters.** This document
-proposed a `RenderRevisionsComponent` extension of the 0005 dirty-flag machinery, and flagged
-the hook audit it needs as real work, with a missed hook being an under-invalidation bug. What
-landed instead needs no audit: a retained entry records the exact inputs its coverage was
-produced from (device transform, the `tiny_skia::Paint` the draw was handed, the stroke, the
-clip identity, the surface size, the fill rule, and whether the stroke opened its dash seams)
-and replays only while all of them compare equal. Paint equality is real deep equality, added
-to the tiny-skia paint and shader types for this purpose, so a gradient stop edit is caught by
-the same comparison as a colour edit with nothing to remember to mark. Geometry is the one
-input too large to compare per frame, and it is handled by dropping the whole entry from the
-resolved-path update and destroy signals, the same mechanism the Geode encode cache already
-relies on.
-
-The cost of that choice is granularity. This document's goals said a fill colour change should
-rebuild nothing and a gradient stop change should rebuild only the ramp; both now rebuild the
-shape's coverage. The conservative direction is the safe one (a rebuild is always correct,
-a missed rebuild never is), and the case the design exists for, a frame where nothing changed,
-is unaffected. A colour-only fast path is possible on top of this: when the draw does not
-derive its blitter's paint from the caller's (which a hairline stroke and a transformed
-gradient both do), the coverage is independent of the paint and a replay could take the fresh
-paint. It is listed under Next Steps rather than assumed.
-
-**Clip is a validation key, decided by mask content.** The mask reaches the blitter as pipeline
-state applied per blit, so recorded coverage does not depend on it, but this iteration keeps
-clip conservative as planned. Each clip-stack depth remembers the mask it last held; a rebuilt
-mask that compares byte-equal keeps that depth's identity, and any change issues a new one.
-Equal identities therefore mean byte-equal masks, and a shape carries only the integer. The
-comparison costs one pass over a mask per clip push, against the mask build that already costs
-the same order.
-
-**Retention covers `drawPath` only.** `drawRect` and `drawEllipse` carry no source entity, and
-the driver never emits them: they exist for replaying a recorded snapshot, which has no stable
-identity to key on. Their coverage is recorded by the same packed records anyway when a rect
-draw reaches the capture blitter through `drawPath`.
-
-**An entity drawn more than once in a frame stops retaining.** One entry cannot describe two
-draws, and shadow-tree instancing (`use`), markers, and a `paint-order` that splits fill from
-stroke all draw one data entity several times. Those entities fall back to rasterizing rather
-than re-capturing on every draw.
+**Why validation compares inputs instead of counting revisions.** The alternative is a
+per-entity revision counter bumped wherever `DirtyFlagsComponent` is marked, which needs every
+mutation site to remember to bump it and turns a missed site into an under-invalidation bug,
+where a shape keeps painting its old pixels. Comparing the draw's own inputs has no such site
+list: whatever a mutation does to the document, the next frame either builds the same transform,
+paint, stroke, clip and surface it built before, or it does not. The one input too large to
+compare, the outline, is handled by dropping the entry from a signal that already exists and is
+already load-bearing for the Geode encode cache. The cost is granularity, and Invalidation and
+validation keys states exactly how coarse.
 
 **Frame identity belongs to the document.** Entries live on the document's registry, so several
-renderers can meet the same entry. Each frame takes its identity from a counter on the
-document, which is what keeps one renderer's frame from reading as a second draw inside
-another's.
+renderers can meet the same entry, and each frame takes its identity from a counter on the
+document rather than from a renderer-local one. Otherwise two renderers would agree on frame
+numbers and each would read the other's draw as a second draw of the same shape, which is the
+signal that makes an entity stop retaining.
+
+**Known limitation: several renderers retaining one document thrash.** One entry describes one
+draw, so two renderers with different surfaces or transforms drawing the same document take
+turns re-capturing it. Output stays correct, because a key that does not match is never
+replayed; only the work is wasted. The case that matters in practice, one renderer per document,
+is unaffected, and the corpus harness deliberately keeps its reference renderer out of retention
+so it cannot perturb the retained one.
 
 ## Background
 
@@ -294,30 +281,25 @@ transiently (`AlphaRuns`); this design makes the representation durable per shap
 
 ### Retained state per shape
 
-Each retained shape node (`RetainedShapeNode`, keyed by the render-tree entity of the
-`RenderingInstanceComponent`) stores:
+Retained state lives on the entity a shape's geometry came from, as a `RetainedSpansComponent`
+holding two slots, one for the fill pass and one for the stroke pass. Each slot holds:
 
-- **Fill coverage spans**: packed runs in device space, exactly the blits the scan converter
-  emitted (`CapturedSpans`; see "Milestone 1 decisions" for the record layout). Interior rows
-  compress to a few long runs at full coverage; antialiased edges become short runs (the same
-  shape `AlphaRuns` produces today). Runs are stored in emission order, which is what replay
-  depends on; the scan converter already emits them in increasing `y`.
-- **Stroke coverage spans**: the same representation for the stroked outline, with dashing,
-  caps, and joins already baked in by the stroker/dasher at capture time.
-- **Gradient color ramp**: for gradient paints, the instantiated `tiny_skia::Shader` (the
-  product of `instantiateGradientShader`), including any stop-ramp lookup table the gradient
-  pipeline stage precomputes. If an explicit ramp LUT stage is introduced, the cold path must
-  use the identical LUT so identity holds; this is called out under Open Questions.
-- **Device-space bounding box** of the union of fill and stroke spans, used for clipped blits
-  and for bounds queries without touching span data.
-- **Fast-path flag** for axis-aligned rectangles: `drawRect` fills that go through
-  `Scan::fillRect` / `fillRectAa` retain the rect plus its edge alphas instead of spans and
-  replay via `blitRect` / `blitAntiRect`.
-- **Validation keys** described below.
+- **Coverage runs** in device space, exactly the blits the scan converter emitted
+  (`CapturedSpans`; see "Milestone 1 decisions" for the record layout). Interior rows compress
+  to a few long runs at full coverage; antialiased edges become short runs. Runs are stored in
+  emission order, which is what replay depends on.
+- **The paint the recorded draw built its blitter from**, which is not always the paint the
+  caller passed: a hairline stroke folds its coverage into the shader opacity, and a transformed
+  draw transforms the shader. Replaying with this paint is what reproduces the draw. A gradient
+  lives inside it as an instantiated shader, so no separate ramp is kept.
+- **The validation key**, described below.
 
-Span storage is per-shape `std::vector`-backed with capacity retention: invalidation resets the
-count but keeps the allocation, so a shape that oscillates between two geometries settles into
-zero-allocation rebuilds.
+Storage keeps its capacity across invalidations, so a shape that is rebuilt repeatedly settles
+into allocation-free captures.
+
+Nothing else is retained. There is no cached bounding box (nothing reads one), and axis-aligned
+rectangles need no special case: a rect draw's `blitRect` and `blitAntiRect` calls are recorded
+by the same packed records as everything else.
 
 ### Capture
 
@@ -341,90 +323,109 @@ so the cold frame renders and captures in one pass.
 A steady frame is:
 
 1. Surface clear (as `beginFrame` does today).
-2. For each visible shape in paint order: validate the node (cheap key compare), then blit its
-   fill spans and stroke spans in the shape's fill/stroke/paint-order sequence.
+2. For each visible shape in paint order: compare the validation key, then replay the fill and
+   stroke runs in the shape's fill/stroke/paint-order sequence.
 
-Replay feeds the recorded runs to the same pipeline blitter configuration the cold path uses,
-constructed from the shape's current `Paint`:
+Replay builds the blitter exactly as a direct draw with the retained paint would, and feeds the
+recorded runs to it. That is the whole of the identity argument: the same blitter receives the
+same calls in the same order, so it performs the same stores.
 
-- **Opaque interior spans** (coverage 255, opaque solid paint, source-over) are straight stores:
-  a `memset`-style row fill of the paint color. This is the dominant case on raster-bound
-  scenes.
-- **Edge spans and translucent paints** blend through the normal pipeline stages, reproducing
-  the exact root-surface store rounding of the active pipeline configuration so low-alpha edge
-  pixels keep the bytes the golden corpus depends on (0028-2 documents how observable this
-  rounding class is).
-- **Color at blit**: because spans are pure coverage, the paint color is an input to replay, not
-  to capture. A solid paint color change therefore rebuilds nothing.
-- **Clipped blits**: spans are sorted by `y`, so a clip band or tight viewport selects its span
-  sub-range by binary search on `y` rather than walking the whole array.
+- **Clip masks** are supplied at replay, not baked into coverage. Scan conversion clips to the
+  surface and the mask reaches the blitter as per-blit pipeline state, so recorded coverage is
+  mask-independent and a replay is handed whatever mask a fresh draw would get.
+- **Edge runs and translucent paints** blend through the normal pipeline stages, reproducing the
+  root-surface store rounding of the active pipeline configuration, so low-alpha edge pixels
+  keep the bytes the golden corpus depends on (0028-2 documents how observable this rounding
+  class is).
+- **No separate fast path for opaque interiors.** A `memset`-style store for full-coverage runs
+  under an opaque solid paint would be a second implementation of the blitter's arithmetic, and
+  identity would stop holding by construction and start needing to be proven. That is the main
+  reason the steady frame is faster but not as fast as this document first projected; see
+  Performance.
 
 ### Invalidation and validation keys
 
-Retained state is invalidated by property class, mirroring `DirtyFlagsComponent` categories.
-Because the compute systems clear the dirty flags before the renderer runs, each category
-increments a small per-entity revision counter when marked (a `RenderRevisionsComponent`
-extension of the 0005 machinery); retained nodes record the revisions they were built from and
-compare on validation.
+A recording is replayed only while every input the recorded coverage depended on is unchanged.
+Rather than tracking which properties were marked dirty, the renderer compares those inputs
+directly, so no mutation hook has to be audited for the result to be sound.
 
-| Change class                                  | Rebuilds                                     |
-| --------------------------------------------- | -------------------------------------------- |
-| Geometry (`Shape`), transform (`Transform` /  | Outline conversion, fill spans, stroke spans |
-| `WorldTransform`), clip chain                 |                                              |
-| Solid paint color, `fill-opacity`,            | Nothing (applied at blit)                    |
-| `stroke-opacity`, `currentColor`              |                                              |
-| Gradient stop list or stop colors             | Gradient ramp only (spans untouched)         |
-| Stroke properties (width, caps, joins, dash   | Stroke spans only (fill spans untouched)     |
-| array/offset, miter limit)                    |                                              |
-| Paint server kind change (solid to gradient,  | Paint object only; spans untouched           |
-| gradient to solid)                            |                                              |
-| Paint becomes a pattern, or shape enters a    | Node leaves retention; immediate mode        |
-| non-retained context                          |                                              |
+The key is the device transform, the `tiny_skia::Paint` the draw was handed, the stroke, the
+identity of the clip mask, the surface size, the fill rule, and whether the stroke opened its
+dash seams. Paint comparison is real deep equality over the shader, which is why a gradient
+stop edit is caught by the same comparison as a colour edit, with nothing to remember to mark.
 
-Clip participates conservatively in the first iteration: the node key includes the identity of
-the clip chain affecting the shape, and any clip change rebuilds the node's spans. Because the
-clip mask is actually applied at blit time (the pipeline blitter takes the mask), a later
-refinement can drop clip from the rebuild set; that is listed under Open Questions rather than
-assumed.
+Geometry is the one input too large to compare per frame. It is handled by dropping the entry
+entirely from the resolved-path update and destroy signals, the mechanism the Geode encode
+cache already relies on: `ShapeSystem`'s content-equality gate means those signals fire when the
+outline actually changed and stay quiet on an idle re-render.
+
+| Change class                                             | Effect on the next frame            |
+| -------------------------------------------------------- | ----------------------------------- |
+| Geometry                                                  | Entry dropped; shape re-rasterizes  |
+| Transform, clip, surface size, fill rule, dash seam       | Key mismatch; shape re-rasterizes   |
+| Any paint change, including a solid colour or a gradient stop | Key mismatch; shape re-rasterizes |
+| Stroke width, caps, joins, dash array or offset, miter    | Stroke pass re-rasterizes; fill pass replays |
+| Paint becomes a pattern, or the shape enters a non-retained context | Entry unused; immediate mode |
+
+This is coarser than the per-property table this design first proposed: a colour change
+rebuilds coverage that a colour change cannot affect. The conservative direction is the safe
+one, and the case the design exists for, a frame where nothing changed, is unaffected. A
+colour-only fast path is possible on top of this and is under Next Steps.
+
+The clip identity is conservatism, not a correctness dependency. Each clip-stack depth remembers
+the mask it last held, and a rebuilt mask that compares byte-equal keeps that depth's identity;
+any change takes a new one. Identities are renderer-local, so two renderers drawing one document
+number their clips independently, and nothing rests on that, because coverage does not depend on
+the mask and a replay is handed the mask in effect at replay time.
 
 ### Retention scope
 
-Retention initially covers shape draws (`drawPath`, `drawRect`, `drawEllipse`) with solid or
-gradient paint, emitted directly to the root surface (`surfaceStack_.empty()`). Everything else
-bypasses retention and renders through the unchanged immediate-mode code:
+Retention covers `drawPath` with solid or gradient paint, emitted directly to the root surface
+(`surfaceStack_.empty()`) for a shape that carries a source entity. `drawRect` and `drawEllipse`
+are not retained and do not need to be: the driver never emits them, they exist for replaying a
+recorded snapshot, and a snapshot has no stable identity to key on. Everything below bypasses
+retention and renders through the unchanged immediate-mode code:
 
 - Filter layers (`pushFilterLayer` content and composition).
 - Masks (`pushMask` capture and content).
 - Pattern tiles (`beginPatternTile` recording and pattern-painted shapes).
 - Isolated layers (`pushIsolatedLayer` for group opacity, mix-blend-mode, isolation).
 - Text (`drawText`) and images (`drawImage` / `drawBitmap`).
+- Draws that also paint a context-paint capture surface, which are two draws sharing one
+  outline and cannot be described by one entry.
+- Entities drawn more than once in a frame. Shadow-tree instancing (`use`), markers, and a
+  `paint-order` that splits fill from stroke all draw one data entity several times, and one
+  entry cannot describe several draws. Such an entity stops retaining rather than re-capturing
+  on every draw.
 
-Bypassed content is drawn between retained blits in paint order, so ordering semantics are
-unchanged. This split keeps the identity argument simple (retained draws replay the exact blit
-sequence; bypassed draws run the exact existing code) while covering the raster-bound scenes
-that motivate the design. Tiger is entirely within the retained set. Widening the retained set
-(for example, retaining an isolated layer's composed pixmap) is future work.
+Bypassed content is drawn between replays in paint order, so ordering semantics are unchanged.
+This split keeps the identity argument simple: retained draws replay the exact blit sequence,
+bypassed draws run the exact existing code. Tiger is entirely within the retained set. Widening
+the retained set (for example, retaining an isolated layer's composed pixmap) is future work.
 
 ### Memory policy
 
 - **Per-shape storage** keeps capacity across invalidations, as above.
-- **Per-worker scratch pools** hold the transient prepare intermediates (path conversion
-  buffers, edge lists, stroke/dash output, scanline cells), sized high-water per worker slot,
-  so steady-state prepare performs zero heap allocations once pools are warm. Slot zero belongs
-  to the caller thread and is the only slot used in single-threaded mode.
-- **Cost model**: a run is 16 bytes packed (decided in Milestone 1; see the record layout
-  there). A shape's run count is approximately (rows x interior runs per row) + (antialiased
-  edge pixels), and the analytic scan converter emits long interior runs, so the count runs
-  well below one per covered pixel: a 512x512 antialiased path measured 1650 runs, 26.4 KB.
-  Extrapolating that density, Tiger at 900x900 is on the order of a few MiB. A pathological
-  document (many thousands of small shapes) is bounded by the budget below, not by hope.
-- **Budget and eviction**: a per-document retained-memory budget (default on the order of
-  32 MiB, configurable). When exceeded, nodes are evicted coldest-first (least-recently-blitted)
-  until under budget; an evicted shape simply renders immediate-mode and may re-enter the cache
-  later. If eviction thrashes (a tracked counter crosses a threshold within a frame window),
-  retention disables for the document and the renderer reverts to today's behavior wholesale.
-- **Opt-out**: a document-level API disables retention explicitly for embedders that prefer the
-  immediate-mode memory profile.
+- **Cost model**: a run is 16 bytes packed. A shape's run count is approximately (rows x
+  interior runs per row) + (antialiased edge pixels), and the analytic scan converter emits long
+  interior runs, so the count runs well below one per covered pixel: a 512x512 antialiased path
+  measures 1650 runs, 26.4 KB. Measured on real documents, the tiger holds 3.21 MiB across 305
+  retained passes at 900x900 and the lion 501 KiB across 132.
+- **Budget and eviction**: a per-document retained-memory budget, 32 MiB by default and settable
+  on the renderer. It charges the whole of an entry, not only its coverage: the runs plus their
+  kept capacity, the two paints beside them, and the entry itself. When the budget is exceeded,
+  entries not drawn in the current frame are evicted coldest-first until the document is back
+  under it; an evicted shape rasterizes and may re-enter later. If evicting every entry from an
+  earlier frame still leaves the document over budget, its working set does not fit at all, so
+  retention turns off for the document rather than evicting and re-capturing the same shapes
+  every frame. Raising the budget lets it try again.
+- **Clip masks a renderer remembers** are not part of that budget. They are bounded instead:
+  eight depths at most, one mask per depth, dropped whenever the surface changes size. Past that
+  depth a clip takes a fresh identity per draw, so shapes under it rasterize.
+- **Opt-out**: retention is off by default and enabled per renderer. Turning it off hands back
+  everything the document was holding, since entries outlive the renderer that made them.
+- **Per-worker scratch pools** for transient prepare intermediates belong to the concurrency
+  stage and do not exist yet.
 
 ## Structured-Concurrency Prepare Stage
 
@@ -448,7 +449,7 @@ Consumers join before reading:
 
 - The blit pass joins each node immediately before blitting it (in paint order, so the caller
   naturally overlaps blitting early shapes with preparing later ones).
-- Bounds queries join the node before reading its device-space bounding box.
+- Any consumer that reads a node's prepared state joins it first.
 - Clip dependencies do not schedule concurrently: a prepare that depends on another node's clip
   output joins that dependency at submission time, on the submitting thread, rather than
   deferring the join into the worker. This keeps the dependency graph trivially acyclic at the
@@ -488,63 +489,85 @@ unchanged, and does, because the zero-thread mode is the same code path.
 
 SVG input is untrusted. This design adds no new parsing surfaces, but it adds retained state
 whose size is attacker-influenced, so the memory policy above is a security boundary, not just
-a performance knob:
+a performance knob. What the budget caps, precisely:
 
-- The per-document budget caps retained memory regardless of shape count or coordinates;
-  overflow degrades to immediate mode, never to unbounded growth. The budget/eviction paths get
-  negative tests with adversarial documents (many shapes, giant device boxes, degenerate spans).
+- Every byte a retained entry holds is charged: the recorded coverage including the capacity it
+  keeps across a rebuild, the two paints kept beside it (a gradient paint owns its stop list),
+  and the entry itself. Exceeding the budget evicts coldest-first; a working set that does not
+  fit at all disables retention for the document. Growth is bounded either way.
+- Not charged, and bounded by other means: the per-depth clip masks a renderer remembers, which
+  are capped at eight depths and dropped when the surface changes size, so a document chooses
+  neither how many it holds nor how large they are; and the entry shell of an entity that has
+  stopped retaining, which is one small component per entity, bounded like any per-entity
+  component by the document's own size.
 - Span capture stores only what the scan converter emitted for the clipped device area, so
   coordinates outside the surface cannot inflate storage beyond the surface-bounded run count.
   A capture is bound to the surface size it was recorded against and a replay onto a different
   size is refused, so a retained capture that outlives a viewport resize cannot write outside
-  the new surface (see "Milestone 1 decisions").
-- The threaded mode is compiled out by default and, when enabled, workers only run prepare on
-  data owned by the node being prepared; there is no cross-document or cross-renderer sharing.
-- Fuzzing: the existing SVG parser/render fuzzers run with retention enabled so the
-  invalidation and eviction state machines see hostile mutation sequences; a mode-flip fuzz
-  cycle (render, mutate, render, compare against fresh) doubles as a correctness oracle.
+  the new surface.
+- Retention holds no pixel data of its own: coverage carries alpha, and the paint that colors it
+  is supplied at replay, so an evicted or disabled document leaks nothing about what it drew.
+- The threaded mode does not exist yet; when it does, workers must only run prepare on data
+  owned by the node being prepared, with no cross-document or cross-renderer sharing.
 
 ## Testing and Validation
 
 Every invariant below names the CI target that enforces it, per this directory's rule that
 claimed invariants trace to CI.
 
-- **Byte identity, retained vs fresh** (the core invariant): a new
-  `//donner/svg/renderer/tests:renderer_retained_identity_tests` renders every case twice with
-  a shared corpus driver: once with a fresh renderer, once through a warmed retained cache
-  (render, then render again), and asserts byte-equal snapshots. It runs over the renderer
-  golden corpus and, on lanes where `--//donner/svg/renderer:resvg_test_suite_available=True`,
-  over the resvg suite corpus. A retained-mode configuration of the existing golden suites
-  (`renderer_tests`, `resvg_test_suite`) additionally pins retained output to the checked-in
-  goldens.
-- **Per-dirty-class invalidation**: in the same target, each property class from the
-  invalidation table is mutated in isolation (color, gradient stops, stroke width, dash array,
-  transform, geometry, clip), then the steady frame is compared byte-equal against a fresh
-  render of the mutated document. This catches both under-invalidation (stale pixels) and
-  mis-classified rebuilds.
-- **Steady-state allocations**: `renderer_retained_identity_tests` includes cases wrapping the
-  steady frame in the allocation-counting scope from
-  `donner/svg/renderer/benchmarks/AllocationTracker.h` and asserting zero prepare-path
-  allocations after warmup (the frame clear and snapshot are excluded and measured separately).
-- **Thread-count determinism**: with the concurrency config enabled, the identity test
-  parameterizes thread counts {0, 2, 8} and asserts byte-equal output across all of them. This
-  runs on a CI lane that builds with `--//donner/svg/renderer:tiny_skia_prepare_threads=true`
-  so the threaded configuration is compiled and exercised, per the rule that a green default
-  build does not verify flag-gated code.
-- **tiny-skia-level capture/replay identity**: `SpanCaptureTest.cpp`, in the port's
-  `//src/tiny_skia/tests:tiny_skia_core_tests` dual native/scalar targets, asserts
-  capture+replay equals direct painting for antialiased and aliased fills, both fill rules,
-  gradients, transforms, masks, rect fast paths, thick and hairline strokes, and dashes, and
-  specifically for low-alpha antialiased edges under the pipeline's root-surface store rounding
-  (the failure class 0028-2 documents). It also asserts that the capture pass leaves the cold
-  frame byte-identical, that a replay with a different paint matches a direct draw in that
-  paint, and that the recorded ops cover every blit method the scan converters emit. Injecting
-  a one-unit coverage error into replay fails 14 of those cases and a one-pixel rect width
-  error fails 3, with the diagnostic naming the first differing pixel.
-- **Performance**: before/after `engine_compare_bench --backend=tiny-skia` runs at `-c opt` on
-  Tiger and raster-heavy resvg-derived scenes, recording `second_ms`, `first_ms`, ALLOC
-  `phase=second`, and RSS fields. Numbers land in this doc's status updates only as measured
-  output, never estimated.
+- **Byte identity, retained vs fresh** (the core invariant):
+  `//donner/svg/renderer/tests:renderer_retained_spans_tests` renders each of its documents
+  several times both ways, once through a renderer that retains nothing and once through a
+  warmed retained cache, and asserts byte-equal snapshots frame by frame. Its documents cover
+  the retained draw kinds (fills, both fill rules, hairline and thick and dashed strokes,
+  zero-length-gap dashes, linear and radial gradients, gradient strokes) and the bypassed ones
+  (patterns, masks, isolated layers, markers, `use` instancing, `paint-order` splits), plus
+  three real documents from `donner/svg/renderer/testdata` including the tiger.
+- **Corpus-wide identity** is a diagnostic, not a CI gate. Setting
+  `DONNER_TINYSKIA_RETAINED=compare` makes the tiny-skia test backend render every document a
+  suite touches both ways and fail on the first differing byte, so
+  `renderer_tests`, `renderer_regression_tests`, `renderer_ascii_tests` and `resvg_test_suite`
+  become retained-versus-fresh identity runs over roughly three thousand documents. No CI lane
+  sets it today; it is invoked by hand with `--test_env`. Turning it into a lane is the
+  follow-up under Next Steps.
+- **Per-change-class invalidation**: `renderer_retained_spans_tests` mutates each class in
+  isolation (geometry, transform, solid paint, gradient stop, stroke width, clip, surface
+  resize), then asserts through the renderer's counters that the next frame rasterized rather
+  than replayed, and that its bytes match a fresh render of the mutated document. This catches
+  both under-invalidation (stale pixels) and a mutation that quietly does nothing.
+- **Fail-closed surface binding**: the same target makes a retained key claim a surface its
+  recording did not come from, with every other input identical by construction, and asserts
+  the recording is refused, that the refusal falls back to rasterizing rather than dropping the
+  shape, and that the frame matches a fresh render.
+- **Memory bound**: the same target pins the eviction and whole-document-fallback paths, and
+  that turning retention off hands back what the document held.
+- **Steady-state allocations**: not implemented. A steady frame still rebuilds each shape's
+  `tiny_skia::Paint` to compare it, which allocates for gradient paints, so there is no
+  zero-allocation claim to enforce. Listed under Next Steps.
+- **Fuzzing with retention enabled**: not wired. The SVG parser and render fuzzers run without
+  retention, so the invalidation and eviction state machines do not currently see fuzzer
+  mutation sequences. Listed under Next Steps.
+- **Thread-count determinism**: not applicable until the concurrency stage exists.
+- **Paint and stroke equality**: `//src/tiny_skia/tests:tiny_skia_core_tests` (dual native and
+  scalar) covers `PaintTest.cpp`, which pins reflexivity for every shader kind, field
+  sensitivity for solid, gradient and pattern paints and for strokes and dashes, and the float
+  policy in both directions (a NaN is never equal, signed zeroes are). Equality is what decides
+  whether a recording still applies, so an equality that answered wrongly would be the shortest
+  path to a stale pixel.
+- **tiny-skia-level capture/replay identity**: `SpanCaptureTest.cpp`, in the same dual targets,
+  asserts capture+replay equals direct painting for antialiased and aliased fills, both fill
+  rules, gradients, transforms, masks, rect fast paths, thick and hairline strokes, and dashes,
+  and specifically for low-alpha antialiased edges under the pipeline's root-surface store
+  rounding (the failure class 0028-2 documents). It also asserts that the capture pass leaves
+  the cold frame byte-identical, that a replay with a different paint matches a direct draw in
+  that paint, that the recorded ops cover every blit method the scan converters emit, and that
+  the storage accessors a bounded cache depends on report and release what they claim.
+  Injecting a one-unit coverage error into replay fails 14 of those cases and a one-pixel rect
+  width error fails 3, with the diagnostic naming the first differing pixel.
+- **Performance**: `engine_compare_bench --backend=tiny-skia` at `-c opt`, run with and without
+  `--retained-spans`, recording `second_ms`, `first_ms`, `mutated_ms`, the `RETAINED` line, ALLOC
+  `phase=second`, and RSS fields. Numbers land in this doc only as measured output, never
+  estimated.
 
 ## Performance
 
@@ -601,48 +624,44 @@ fast path inside the shared blitter construction, where both a cold draw and a r
 
 ### Targets
 
-- **Steady-frame target**: 10-20x on raster-bound scenes; Tiger from about 41 ms to 2-4 ms
-  `second_ms` at 900x900, `-c opt`, reference aarch64 host. The floor is the surface clear plus
-  covered-area blend cost, which is why opaque-interior straight stores matter.
-- **Cold-frame target**: parity or better. Capture adds run stores to the cold path; the
-  concurrency stage, where enabled, can make cold frames faster than today. Regression bar:
-  cold `first_ms` within noise of the pre-change baseline on the benchmark corpus. Measured at
-  the tiny-skia level, capture costs 5.1 percent on a 512x512 antialiased path fill (see
-  "Milestone 1 decisions"), which is above noise, so the cold-frame budget is a real constraint
-  rather than a free assumption. Whether that survives at the renderer level depends on how
-  much of a frame is scan conversion versus blending; Milestone 5 measures it.
-- **Measurement discipline**: all claims go through `engine_compare_bench`'s existing phases
-  (`first_ms`, `second_ms`, ALLOC per phase, RSS) so numbers are comparable across the design's
+- **Steady-frame target**: the original 10-20x is not reachable while replay goes through the
+  same blitter a cold draw builds, because what remains after coverage generation is removed is
+  the blend of that coverage. A target that can be met without giving up the identity argument
+  has to come with the fast path that makes it reachable; see Next Steps.
+- **Cold-frame target**: parity or better. Capture adds run stores to the cold path. Measured at
+  the tiny-skia level it costs 5.1 percent on a 512x512 antialiased path fill, and at the
+  renderer level 2.6 percent on the tiger and 12.9 percent on the lion, so the cold-frame budget
+  is a real constraint rather than a free assumption.
+- **Measurement discipline**: all claims go through `engine_compare_bench`'s phases (`first_ms`,
+  `second_ms`, `mutated_ms`, ALLOC per phase, RSS) so numbers are comparable across the design's
   lifetime; within-engine before/after deltas only, per the benchmark's own caveats.
 
 ## Risks and Open Questions
 
-- **Memory growth bounds.** The budget/eviction policy is designed but its default (32 MiB
-  order) is a guess until measured across the resvg corpus and editor documents. Open: should
-  the budget scale with surface area? What eviction granularity (whole node vs stroke-only)
-  pays for its complexity?
+- **Memory growth bounds.** The 32 MiB default is a guess: measured documents sit far under it
+  (3.21 MiB for the tiger), so nothing has pushed on eviction outside its tests. Open: should
+  the budget scale with surface area? Is whole-entry eviction granular enough, or is dropping a
+  stroke pass alone worth the complexity?
 - **Interaction with the frame storage convention.** Replay must reproduce the exact
   root-surface store rounding of the active pipeline configuration; 0028-2 governs that
   convention and documents how observable the low-alpha rounding class is. The capture/replay
   identity tests target this class directly and must hold across any storage-convention change,
   and any future explicit gradient ramp LUT must be shared by cold and steady paths or identity
   breaks silently.
-- **Clip-chain invalidation fan-out.** A clip path change invalidates every shape it affects;
-  for a document-root clip that is everything. Conservative rebuild is correct but makes some
-  single-property edits cost a full re-rasterization. Open: apply clip masks purely at blit
-  time (the pipeline already takes the mask per blit) so clip changes rebuild nothing, at the
-  cost of keying blits by mask identity; decide after measuring real editor clip-edit
-  frequency.
-- **Eviction heuristics.** Least-recently-blitted is simple but a zooming viewport can cycle
-  the working set. Open: protect shapes by blit frequency, or by rebuild cost, and what the
-  thrash-detection window should be.
-- **Gradient ramp representation.** Settled for now in Milestone 1: the instantiated shader is
-  retained and no quantized ramp LUT is introduced, because both paths already share one
-  resolution step. Revisit only if ramp resolution shows up in a profile, and only as a stage
-  inside that shared step.
-- **Revision-counter plumbing.** The `RenderRevisionsComponent` extension must be marked by the
-  same mutation hooks that mark `DirtyFlagsComponent`; a missed hook is an under-invalidation
-  bug. The per-dirty-class tests are the net, but the hook audit is real work.
+- **Clip-chain invalidation fan-out.** A clip change invalidates every shape under it; for a
+  document-root clip that is everything. Conservative rebuild is correct but makes some
+  single-property edits cost a full re-rasterization. Open: drop clip from the key entirely,
+  which coverage already permits, once there is a reason to trust that no future change makes
+  scan conversion consult the mask.
+- **Eviction heuristics.** Least-recently-drawn is simple but a zooming viewport can cycle the
+  working set. Open: protect shapes by draw frequency or by rebuild cost.
+- **Gradient ramp representation.** The instantiated shader is retained and no quantized ramp
+  LUT is introduced, because both paths already share one resolution step. Revisit only if ramp
+  resolution shows up in a profile, and only as a stage inside that shared step.
+- **Paint comparison is the whole invalidation story for paint.** An equality that answered
+  wrongly, on any shader field, would be the shortest path to a stale pixel. `PaintTest.cpp`
+  covers reflexivity, field sensitivity and the float policy for that reason, and any field
+  added to a shader has to be added to its comparison in the same change.
 
 ## Alternatives Considered
 

--- a/docs/design_docs/0060-tinyskia_retained_raster_cache.md
+++ b/docs/design_docs/0060-tinyskia_retained_raster_cache.md
@@ -64,8 +64,11 @@ additions to `third_party/tiny-skia-cpp`). The Geode GPU backend is untouched.
 
 ## Next Steps
 
-- Build the retained-node cache and validation keys in `RendererTinySkia` behind a runtime mode
-  flag, with the mode-comparison identity test running both modes over the golden corpus.
+- Decide whether the steady frame's remaining cost (blending covered area, not generating it)
+  is worth attacking with opaque-interior straight stores, and whether that can be done inside
+  the shared blitter construction so identity still holds by construction.
+- Revisit the colour-only fast path: a solid paint change currently re-rasterizes, which the
+  goals below said it should not.
 
 ## Implementation Plan
 
@@ -147,25 +150,78 @@ steady-state win this design targets has to come from scenes with many small and
 where coverage generation dominates and covered area does not. Milestone 5 measures that on
 Tiger.
 
-- [ ] Milestone 2: Retained node cache in `RendererTinySkia`
-  - [ ] `RetainedShapeNode` storage keyed by render-tree entity; validation keys per
-        property class.
-  - [ ] Steady-frame path: surface clear plus in-order span blits; opaque interior runs as
-        straight stores.
-  - [ ] Mode-comparison identity test over the renderer golden corpus and resvg suite.
-  - [ ] Per-dirty-class invalidation tests (mutate one property class, assert identity with a
+- [x] Milestone 2: Retained node cache in `RendererTinySkia`
+  - [x] `RetainedSpansComponent` storage keyed by the render-tree entity, with a validation key
+        compared per draw. The key is the draw's own inputs rather than per-property revision
+        counters; see "Milestone 2 decisions" below.
+  - [x] Steady-frame path: surface clear plus in-order replays. Opaque interior runs are NOT
+        straight stores; they go through the same blitter a cold draw builds, which is what
+        keeps identity true by construction. That decision is why the measured win is smaller
+        than this document projected; see Performance.
+  - [x] Mode-comparison identity test over the renderer golden corpus and the resvg suite.
+  - [x] Per-dirty-class invalidation tests (mutate one property class, assert identity with a
         fresh render).
-- [ ] Milestone 3: Memory policy
-  - [ ] Per-document span budget, eviction, whole-document fallback, and opt-out API.
-  - [ ] Memory accounting counters surfaced through the benchmark output.
+- [x] Milestone 3: Memory policy
+  - [x] Per-document byte budget, coldest-first eviction, whole-document fallback, and a
+        runtime enable/disable plus budget setter on the renderer.
+  - [x] Memory accounting surfaced through the benchmark's `RETAINED` line.
 - [ ] Milestone 4: Structured-concurrency prepare (config-gated, default off)
   - [ ] Joinable retained nodes with idempotent completion wait; zero-thread inline mode.
   - [ ] Worker pool with per-slot scratch pools; slot zero reserved for the caller thread.
   - [ ] Thread-count determinism test (identity across thread counts 0, 2, 8).
 - [ ] Milestone 5: Steady-state allocation assertions and performance validation
-  - [ ] Zero-allocation steady-prepare test.
-  - [ ] Before/after `engine_compare_bench` numbers recorded for Tiger and the resvg-derived
-        raster-heavy scenes.
+  - [ ] Zero-allocation steady-prepare test. Not met and not attempted: a steady frame still
+        rebuilds each shape's `tiny_skia::Paint` in order to compare it, which allocates for
+        gradient paints.
+  - [x] Before/after `engine_compare_bench` numbers recorded for Tiger and other raster-heavy
+        scenes; see Performance.
+
+### Milestone 2 decisions
+
+**Validation compares the draw's inputs, not per-property revision counters.** This document
+proposed a `RenderRevisionsComponent` extension of the 0005 dirty-flag machinery, and flagged
+the hook audit it needs as real work, with a missed hook being an under-invalidation bug. What
+landed instead needs no audit: a retained entry records the exact inputs its coverage was
+produced from (device transform, the `tiny_skia::Paint` the draw was handed, the stroke, the
+clip identity, the surface size, the fill rule, and whether the stroke opened its dash seams)
+and replays only while all of them compare equal. Paint equality is real deep equality, added
+to the tiny-skia paint and shader types for this purpose, so a gradient stop edit is caught by
+the same comparison as a colour edit with nothing to remember to mark. Geometry is the one
+input too large to compare per frame, and it is handled by dropping the whole entry from the
+resolved-path update and destroy signals, the same mechanism the Geode encode cache already
+relies on.
+
+The cost of that choice is granularity. This document's goals said a fill colour change should
+rebuild nothing and a gradient stop change should rebuild only the ramp; both now rebuild the
+shape's coverage. The conservative direction is the safe one (a rebuild is always correct,
+a missed rebuild never is), and the case the design exists for, a frame where nothing changed,
+is unaffected. A colour-only fast path is possible on top of this: when the draw does not
+derive its blitter's paint from the caller's (which a hairline stroke and a transformed
+gradient both do), the coverage is independent of the paint and a replay could take the fresh
+paint. It is listed under Next Steps rather than assumed.
+
+**Clip is a validation key, decided by mask content.** The mask reaches the blitter as pipeline
+state applied per blit, so recorded coverage does not depend on it, but this iteration keeps
+clip conservative as planned. Each clip-stack depth remembers the mask it last held; a rebuilt
+mask that compares byte-equal keeps that depth's identity, and any change issues a new one.
+Equal identities therefore mean byte-equal masks, and a shape carries only the integer. The
+comparison costs one pass over a mask per clip push, against the mask build that already costs
+the same order.
+
+**Retention covers `drawPath` only.** `drawRect` and `drawEllipse` carry no source entity, and
+the driver never emits them: they exist for replaying a recorded snapshot, which has no stable
+identity to key on. Their coverage is recorded by the same packed records anyway when a rect
+draw reaches the capture blitter through `drawPath`.
+
+**An entity drawn more than once in a frame stops retaining.** One entry cannot describe two
+draws, and shadow-tree instancing (`use`), markers, and a `paint-order` that splits fill from
+stroke all draw one data entity several times. Those entities fall back to rasterizing rather
+than re-capturing on every draw.
+
+**Frame identity belongs to the document.** Entries live on the document's registry, so several
+renderers can meet the same entry. Each frame takes its identity from a counter on the
+document, which is what keeps one renderer's frame from reading as a second draw inside
+another's.
 
 ## Background
 
@@ -491,6 +547,59 @@ claimed invariants trace to CI.
   output, never estimated.
 
 ## Performance
+
+### Measured, Milestone 2 and 3
+
+`engine_compare_bench --backend=tiny-skia`, `-c opt`, aarch64, one core, medians of three
+interleaved passes of five timed iterations each, retention off versus on in the same binary.
+`pixels_hash` was identical between the two modes in every run.
+
+| Scene (size)               | cold base | cold retained | steady base | steady retained | steady speedup |
+| -------------------------- | --------: | ------------: | ----------: | --------------: | -------------: |
+| Ghostscript_Tiger (900x900)|  27.47 ms |      28.19 ms |    22.03 ms |         9.27 ms |          2.38x |
+| lion (400x400)             |   3.64 ms |       4.11 ms |     3.00 ms |         1.65 ms |          1.82x |
+| Edzample_Anim3             |   6.86 ms |       7.07 ms |     5.61 ms |         5.22 ms |          1.07x |
+| z0rly_test6                |   5.11 ms |       5.19 ms |     0.56 ms |         0.53 ms |          1.07x |
+
+Capture costs 2.6 percent of the cold frame on Tiger and 12.9 percent on lion, which is the
+cold-frame budget this document set and, on lion, is at the edge of it.
+
+A frame that follows an edit, timed as a third phase (`--mutate`):
+
+| Scene             | drag base | drag retained | pan base | pan retained |
+| ----------------- | --------: | ------------: | -------: | -----------: |
+| Ghostscript_Tiger |  22.57 ms |      10.20 ms | 23.51 ms |     23.23 ms |
+| lion              |   3.40 ms |       2.02 ms |  3.13 ms |      3.29 ms |
+| Edzample_Anim3    |   6.01 ms |       5.44 ms |  5.99 ms |      5.45 ms |
+| z0rly_test6       |   4.56 ms |       4.45 ms |  4.59 ms |      4.47 ms |
+
+`drag` moves one shape, so everything else still replays; `pan` moves the outermost group, so
+every device transform changes and nothing replays. `pan` is the worst case retention can be
+put in, and it costs at most 5 percent (lion) against not retaining at all.
+
+Retained memory on a settled frame, from the benchmark's `RETAINED` line:
+
+| Scene             | retained passes | retained bytes |
+| ----------------- | --------------: | -------------: |
+| Ghostscript_Tiger |             305 |        3.21 MiB |
+| lion              |             132 |         501 KiB |
+| Edzample_Anim3    |              49 |         124 KiB |
+| z0rly_test6       |              58 |         7.2 KiB |
+
+The tiger's 3.21 MiB at 900x900 matches this document's "order of a few MiB" estimate, and
+every scene sits far under the 32 MiB default budget.
+
+**The 10-20x target was not met, and the reason is structural rather than incidental.** Tiger's
+steady frame went from 22.0 ms to 9.3 ms. What retention removes is coverage generation; what
+remains is blending that coverage into the surface, which the design's own Milestone 1
+measurement predicted (replaying a 512x512 antialiased fill cost 0.79x the cold fill, because a
+single large path spends most of its time blending). The projection of 2-4 ms assumed the
+opaque-interior straight stores that Milestone 2 deliberately did not build, because a separate
+store path for the common case is a second implementation of the blitter's arithmetic and the
+byte-identity argument would stop holding by construction. Closing that gap means putting the
+fast path inside the shared blitter construction, where both a cold draw and a replay get it.
+
+### Targets
 
 - **Steady-frame target**: 10-20x on raster-bound scenes; Tiger from about 41 ms to 2-4 ms
   `second_ms` at 900x900, `-c opt`, reference aarch64 host. The floor is the surface clear plus

--- a/docs/design_docs/0060-tinyskia_retained_raster_cache.md
+++ b/docs/design_docs/0060-tinyskia_retained_raster_cache.md
@@ -297,6 +297,11 @@ holding two slots, one for the fill pass and one for the stroke pass. Each slot 
 Storage keeps its capacity across invalidations, so a shape that is rebuilt repeatedly settles
 into allocation-free captures.
 
+The outline itself is not part of this state. A capture takes the shape's `tiny_skia::Path` from
+the per-entity conversion cache, and a replay needs no outline at all, so the two caches compose
+rather than duplicate: retention never converts a path on its own, and a shape that has to
+rasterize again after an invalidation still takes the cached conversion.
+
 Nothing else is retained. There is no cached bounding box (nothing reads one), and axis-aligned
 rectangles need no special case: a rect draw's `blitRect` and `blitAntiRect` calls are recorded
 by the same packed records as everything else.
@@ -575,32 +580,38 @@ claimed invariants trace to CI.
 
 `engine_compare_bench --backend=tiny-skia`, `-c opt`, aarch64, one core, medians of three
 interleaved passes of five timed iterations each, retention off versus on in the same binary.
-`pixels_hash` was identical between the two modes in every run.
+`pixels_hash` was identical between the two modes in every run. Both modes run with the
+per-entity path and image conversion caches, so these numbers are what retention adds on top of
+those.
 
 | Scene (size)                | cold base | cold retained | steady base | steady retained | steady speedup |
 | --------------------------- | --------: | ------------: | ----------: | --------------: | -------------: |
-| Ghostscript_Tiger (900x900) |  27.09 ms |      27.83 ms |    22.10 ms |         8.85 ms |          2.50x |
-| lion (400x400)              |   3.55 ms |       3.91 ms |     2.81 ms |         1.57 ms |          1.79x |
-| Edzample_Anim3              |   6.76 ms |       6.91 ms |     5.54 ms |         5.16 ms |          1.07x |
-| z0rly_test6                 |   4.98 ms |       5.02 ms |     0.54 ms |         0.52 ms |          1.04x |
+| Ghostscript_Tiger (900x900) |  24.10 ms |      26.51 ms |    21.21 ms |         7.67 ms |          2.77x |
+| lion (400x400)              |   3.56 ms |       3.87 ms |     2.58 ms |         1.53 ms |          1.69x |
+| Edzample_Anim3              |   6.70 ms |       6.79 ms |     5.48 ms |         5.03 ms |          1.09x |
+| z0rly_test6                 |   4.79 ms |       4.93 ms |     0.69 ms |         0.69 ms |          1.01x |
 
-Capture costs 2.7 percent of the cold frame on the tiger and 10.2 percent on the lion, which is
-the cold-frame budget this document set and, on the lion, is at the edge of it.
+Capture costs 10.0 percent of the cold frame on the tiger, 8.7 percent on the lion, and 1 to 3
+percent on the other two. That is a larger share than the capture pass costs in isolation,
+because the conversion caches took outline conversion out of both sides: the same capture work
+is now measured against a cheaper frame.
 
 A frame that follows an edit, timed as a third phase (`--mutate`):
 
 | Scene             | drag base | drag retained | pan base | pan retained |
 | ----------------- | --------: | ------------: | -------: | -----------: |
-| Ghostscript_Tiger |  22.34 ms |       9.45 ms | 22.37 ms |     24.16 ms |
-| lion              |   3.29 ms |       1.91 ms |  2.96 ms |      3.17 ms |
-| Edzample_Anim3    |   5.90 ms |       5.38 ms |  5.91 ms |      5.37 ms |
-| z0rly_test6       |   4.51 ms |       4.37 ms |  4.46 ms |      4.43 ms |
+| Ghostscript_Tiger |  22.05 ms |       9.32 ms | 22.38 ms |     23.12 ms |
+| lion              |   3.29 ms |       1.92 ms |  2.91 ms |      3.09 ms |
+| Edzample_Anim3    |   5.77 ms |       5.28 ms |  5.70 ms |      5.25 ms |
+| z0rly_test6       |   4.30 ms |       4.45 ms |  4.31 ms |      4.46 ms |
 
-`drag` moves one shape, so everything else still replays and the frame is close to a steady one.
-`pan` moves the outermost group, so every device transform changes, every key misses, and every
-shape is captured again: that is the worst case retention can be put in, and it costs 8 percent
-on the tiger and 7 percent on the lion against not retaining at all. The cost is capture on top
-of a full rasterization, plus the comparison that decided nothing could be reused.
+`drag` moves one shape, so everything else still replays and the frame is close to a settled
+one. `pan` moves the outermost group, so every device transform changes, every key misses, and
+every shape is captured again: that is the worst case retention can be put in, and it costs 3
+percent on the tiger and 6 percent on the lion against not retaining at all. The cost is capture
+on top of a full rasterization, plus the comparison that decided nothing could be reused; the
+re-rasterization itself still takes its outline from the conversion cache rather than converting
+again.
 
 Retained memory on a settled frame, from the benchmark's `RETAINED` line, which reports what the
 budget charges (coverage, the paints beside it, and the entries themselves):
@@ -616,7 +627,7 @@ The tiger's 3.41 MiB at 900x900 matches this document's "order of a few MiB" est
 scene sits far under the 32 MiB default budget.
 
 **The 10-20x target was not met, and the reason is structural rather than incidental.** The
-tiger's steady frame went from 22.1 ms to 8.9 ms. What retention removes is coverage generation;
+tiger's steady frame went from 21.2 ms to 7.7 ms. What retention removes is coverage generation;
 what remains is blending that coverage into the surface, which Milestone 1's own measurement
 predicted (replaying a 512x512 antialiased fill cost 0.79x the cold fill, because a single large
 path spends most of its time blending). The projection of 2-4 ms assumed opaque-interior stores,
@@ -633,7 +644,7 @@ construction, where both a cold draw and a replay get it.
   has to come with the fast path that makes it reachable; see Next Steps.
 - **Cold-frame target**: parity or better. Capture adds run stores to the cold path. Measured at
   the tiny-skia level it costs 5.1 percent on a 512x512 antialiased path fill, and at the
-  renderer level 2.7 percent on the tiger and 10.2 percent on the lion, so the cold-frame budget
+  renderer level 10.0 percent on the tiger and 8.7 percent on the lion, so the cold-frame budget
   is a real constraint rather than a free assumption.
 - **Measurement discipline**: all claims go through `engine_compare_bench`'s phases (`first_ms`,
   `second_ms`, `mutated_ms`, ALLOC per phase, RSS) so numbers are comparable across the design's

--- a/docs/design_docs/0060-tinyskia_retained_raster_cache.md
+++ b/docs/design_docs/0060-tinyskia_retained_raster_cache.md
@@ -409,8 +409,8 @@ the retained set (for example, retaining an isolated layer's composed pixmap) is
 - **Cost model**: a run is 16 bytes packed. A shape's run count is approximately (rows x
   interior runs per row) + (antialiased edge pixels), and the analytic scan converter emits long
   interior runs, so the count runs well below one per covered pixel: a 512x512 antialiased path
-  measures 1650 runs, 26.4 KB. Measured on real documents, the tiger holds 3.21 MiB across 305
-  retained passes at 900x900 and the lion 501 KiB across 132.
+  measures 1650 runs, 26.4 KB. Measured on real documents, the tiger holds 3.41 MiB across 305
+  retained passes at 900x900 and the lion 612 KiB across 132.
 - **Budget and eviction**: a per-document retained-memory budget, 32 MiB by default and settable
   on the renderer. It charges the whole of an entry, not only its coverage: the runs plus their
   kept capacity, the two paints beside them, and the entry itself. When the budget is exceeded,
@@ -571,56 +571,59 @@ claimed invariants trace to CI.
 
 ## Performance
 
-### Measured, Milestone 2 and 3
+### Measured
 
 `engine_compare_bench --backend=tiny-skia`, `-c opt`, aarch64, one core, medians of three
 interleaved passes of five timed iterations each, retention off versus on in the same binary.
 `pixels_hash` was identical between the two modes in every run.
 
-| Scene (size)               | cold base | cold retained | steady base | steady retained | steady speedup |
-| -------------------------- | --------: | ------------: | ----------: | --------------: | -------------: |
-| Ghostscript_Tiger (900x900)|  27.47 ms |      28.19 ms |    22.03 ms |         9.27 ms |          2.38x |
-| lion (400x400)             |   3.64 ms |       4.11 ms |     3.00 ms |         1.65 ms |          1.82x |
-| Edzample_Anim3             |   6.86 ms |       7.07 ms |     5.61 ms |         5.22 ms |          1.07x |
-| z0rly_test6                |   5.11 ms |       5.19 ms |     0.56 ms |         0.53 ms |          1.07x |
+| Scene (size)                | cold base | cold retained | steady base | steady retained | steady speedup |
+| --------------------------- | --------: | ------------: | ----------: | --------------: | -------------: |
+| Ghostscript_Tiger (900x900) |  27.09 ms |      27.83 ms |    22.10 ms |         8.85 ms |          2.50x |
+| lion (400x400)              |   3.55 ms |       3.91 ms |     2.81 ms |         1.57 ms |          1.79x |
+| Edzample_Anim3              |   6.76 ms |       6.91 ms |     5.54 ms |         5.16 ms |          1.07x |
+| z0rly_test6                 |   4.98 ms |       5.02 ms |     0.54 ms |         0.52 ms |          1.04x |
 
-Capture costs 2.6 percent of the cold frame on Tiger and 12.9 percent on lion, which is the
-cold-frame budget this document set and, on lion, is at the edge of it.
+Capture costs 2.7 percent of the cold frame on the tiger and 10.2 percent on the lion, which is
+the cold-frame budget this document set and, on the lion, is at the edge of it.
 
 A frame that follows an edit, timed as a third phase (`--mutate`):
 
 | Scene             | drag base | drag retained | pan base | pan retained |
 | ----------------- | --------: | ------------: | -------: | -----------: |
-| Ghostscript_Tiger |  22.57 ms |      10.20 ms | 23.51 ms |     23.23 ms |
-| lion              |   3.40 ms |       2.02 ms |  3.13 ms |      3.29 ms |
-| Edzample_Anim3    |   6.01 ms |       5.44 ms |  5.99 ms |      5.45 ms |
-| z0rly_test6       |   4.56 ms |       4.45 ms |  4.59 ms |      4.47 ms |
+| Ghostscript_Tiger |  22.34 ms |       9.45 ms | 22.37 ms |     24.16 ms |
+| lion              |   3.29 ms |       1.91 ms |  2.96 ms |      3.17 ms |
+| Edzample_Anim3    |   5.90 ms |       5.38 ms |  5.91 ms |      5.37 ms |
+| z0rly_test6       |   4.51 ms |       4.37 ms |  4.46 ms |      4.43 ms |
 
-`drag` moves one shape, so everything else still replays; `pan` moves the outermost group, so
-every device transform changes and nothing replays. `pan` is the worst case retention can be
-put in, and it costs at most 5 percent (lion) against not retaining at all.
+`drag` moves one shape, so everything else still replays and the frame is close to a steady one.
+`pan` moves the outermost group, so every device transform changes, every key misses, and every
+shape is captured again: that is the worst case retention can be put in, and it costs 8 percent
+on the tiger and 7 percent on the lion against not retaining at all. The cost is capture on top
+of a full rasterization, plus the comparison that decided nothing could be reused.
 
-Retained memory on a settled frame, from the benchmark's `RETAINED` line:
+Retained memory on a settled frame, from the benchmark's `RETAINED` line, which reports what the
+budget charges (coverage, the paints beside it, and the entries themselves):
 
 | Scene             | retained passes | retained bytes |
 | ----------------- | --------------: | -------------: |
-| Ghostscript_Tiger |             305 |        3.21 MiB |
-| lion              |             132 |         501 KiB |
-| Edzample_Anim3    |              49 |         124 KiB |
-| z0rly_test6       |              58 |         7.2 KiB |
+| Ghostscript_Tiger |             305 |        3.41 MiB |
+| lion              |             132 |         612 KiB |
+| Edzample_Anim3    |              49 |         166 KiB |
+| z0rly_test6       |              58 |          46 KiB |
 
-The tiger's 3.21 MiB at 900x900 matches this document's "order of a few MiB" estimate, and
-every scene sits far under the 32 MiB default budget.
+The tiger's 3.41 MiB at 900x900 matches this document's "order of a few MiB" estimate, and every
+scene sits far under the 32 MiB default budget.
 
-**The 10-20x target was not met, and the reason is structural rather than incidental.** Tiger's
-steady frame went from 22.0 ms to 9.3 ms. What retention removes is coverage generation; what
-remains is blending that coverage into the surface, which the design's own Milestone 1
-measurement predicted (replaying a 512x512 antialiased fill cost 0.79x the cold fill, because a
-single large path spends most of its time blending). The projection of 2-4 ms assumed the
-opaque-interior straight stores that Milestone 2 deliberately did not build, because a separate
-store path for the common case is a second implementation of the blitter's arithmetic and the
-byte-identity argument would stop holding by construction. Closing that gap means putting the
-fast path inside the shared blitter construction, where both a cold draw and a replay get it.
+**The 10-20x target was not met, and the reason is structural rather than incidental.** The
+tiger's steady frame went from 22.1 ms to 8.9 ms. What retention removes is coverage generation;
+what remains is blending that coverage into the surface, which Milestone 1's own measurement
+predicted (replaying a 512x512 antialiased fill cost 0.79x the cold fill, because a single large
+path spends most of its time blending). The projection of 2-4 ms assumed opaque-interior stores,
+which were deliberately not built: a separate store path for the common case is a second
+implementation of the blitter's arithmetic, and the byte-identity argument would stop holding by
+construction. Closing that gap means putting the fast path inside the shared blitter
+construction, where both a cold draw and a replay get it.
 
 ### Targets
 
@@ -630,7 +633,7 @@ fast path inside the shared blitter construction, where both a cold draw and a r
   has to come with the fast path that makes it reachable; see Next Steps.
 - **Cold-frame target**: parity or better. Capture adds run stores to the cold path. Measured at
   the tiny-skia level it costs 5.1 percent on a 512x512 antialiased path fill, and at the
-  renderer level 2.6 percent on the tiger and 12.9 percent on the lion, so the cold-frame budget
+  renderer level 2.7 percent on the tiger and 10.2 percent on the lion, so the cold-frame budget
   is a real constraint rather than a free assumption.
 - **Measurement discipline**: all claims go through `engine_compare_bench`'s phases (`first_ms`,
   `second_ms`, `mutated_ms`, ALLOC per phase, RSS) so numbers are comparable across the design's
@@ -639,7 +642,7 @@ fast path inside the shared blitter construction, where both a cold draw and a r
 ## Risks and Open Questions
 
 - **Memory growth bounds.** The 32 MiB default is a guess: measured documents sit far under it
-  (3.21 MiB for the tiger), so nothing has pushed on eviction outside its tests. Open: should
+  (3.41 MiB for the tiger), so nothing has pushed on eviction outside its tests. Open: should
   the budget scale with surface area? Is whole-entry eviction granular enough, or is dropping a
   stroke pass alone worth the complexity?
 - **Interaction with the frame storage convention.** Replay must reproduce the exact

--- a/donner/svg/renderer/BUILD.bazel
+++ b/donner/svg/renderer/BUILD.bazel
@@ -413,10 +413,14 @@ donner_cc_library(
 
 donner_perf_sensitive_cc_library(
     name = "renderer_tiny_skia",
-    srcs = ["RendererTinySkia.cc"],
+    srcs = [
+        "RendererTinySkia.cc",
+        "RetainedSpans.cc",
+    ],
     hdrs = [
         "RendererTinySkia.h",
         "RendererTinySkiaCache.h",
+        "RetainedSpans.h",
     ],
     defines = select({
         ":text_enabled": ["DONNER_TEXT_ENABLED"],
@@ -446,6 +450,7 @@ donner_perf_sensitive_cc_library(
         ":tiny_skia_deps",
         "//donner/base",
         "//donner/svg",
+        "//donner/svg/components",
     ] + select({
         ":text_enabled": [
             ":placed_text_geometry",

--- a/donner/svg/renderer/RendererTinySkia.cc
+++ b/donner/svg/renderer/RendererTinySkia.cc
@@ -496,7 +496,7 @@ bool paintBorrowsPattern(const tiny_skia::Paint& paint) {
 /// Draws one fill or stroke pass, replaying retained coverage when it still applies.
 ///
 /// @param slot Retained storage for this pass, or null to rasterize unconditionally.
-/// @param budget Document accounting to charge a new recording against. Non-null with `slot`.
+/// @param state Document state to charge a new recording against. Non-null with `slot`.
 /// @param key Inputs the recorded coverage depends on.
 /// @param pixmap Surface the pass draws onto.
 /// @param mask Clip mask in effect, applied per blit by the pipeline rather than baked into
@@ -506,7 +506,7 @@ bool paintBorrowsPattern(const tiny_skia::Paint& paint) {
 /// @param drawCapturing Performs the same draw through a capture, returning false when the
 ///   draw could not be recorded. The pixels are painted either way.
 template <typename DrawFresh, typename DrawCapturing>
-void drawRetainablePass(RetainedSpanSlot* slot, RetainedSpanBudget* budget,
+void drawRetainablePass(RetainedSpanSlot* slot, RetainedSpanDocumentState* state,
                         const RetainedSpanKey& key, tiny_skia::MutablePixmapView& pixmap,
                         const tiny_skia::Mask* mask, RetainedSpanStats& stats,
                         DrawFresh&& drawFresh, DrawCapturing&& drawCapturing) {
@@ -548,9 +548,9 @@ void drawRetainablePass(RetainedSpanSlot* slot, RetainedSpanBudget* budget,
   }
 
   const std::size_t charged = slot->capture.spans().capacityBytes();
-  budget->liveBytes = budget->liveBytes - slot->chargedBytes + charged;
+  state->liveBytes = state->liveBytes - slot->chargedBytes + charged;
   slot->chargedBytes = charged;
-  stats.liveBytes = budget->liveBytes;
+  stats.liveBytes = state->liveBytes;
 }
 
 std::optional<tiny_skia::Mask> createMaskForSize(std::uint32_t width, std::uint32_t height) {
@@ -959,16 +959,24 @@ RendererTinySkia::RetainedTarget RendererTinySkia::retainedTargetFor(
   Registry& registry = *sourceEntity.registry();
   EnsureRetainedSpanInvalidationWired(registry);
 
-  RetainedSpanBudget& budget = RetainedSpanBudgetFor(registry, retainedSpanBudgetBytes_);
-  retainedSpanStats_.documentDisabled = budget.disabled;
-  retainedSpanStats_.evictions = budget.evictions;
-  if (budget.disabled) {
+  RetainedSpanDocumentState& state = RetainedSpanStateFor(registry, retainedSpanBudgetBytes_);
+  retainedSpanStats_.documentDisabled = state.disabled;
+  retainedSpanStats_.evictions = state.evictions;
+  if (state.disabled) {
     return RetainedTarget();
   }
 
+  if (frameToken_ == 0 || frameTokenIndex_ != frameIndex_) {
+    // Take this frame's identity from the document rather than from a renderer-local counter:
+    // entries live on the document, so two renderers drawing it would otherwise agree on frame
+    // numbers and each would look to the other like a second draw of the same shape.
+    frameToken_ = ++state.frameCounter;
+    frameTokenIndex_ = frameIndex_;
+  }
+
   RetainedSpansComponent& entry = sourceEntity.get_or_emplace<RetainedSpansComponent>();
-  if (entry.drawFrame != frameIndex_) {
-    entry.drawFrame = frameIndex_;
+  if (entry.drawFrame != frameToken_) {
+    entry.drawFrame = frameToken_;
     entry.drawsThisFrame = 0;
   }
 
@@ -979,7 +987,7 @@ RendererTinySkia::RetainedTarget RendererTinySkia::retainedTargetFor(
     // can only describe one of them, and alternating between them would re-capture on every
     // draw, so this entity stops retaining.
     entry.ambiguous = true;
-    budget.liveBytes -= std::min(budget.liveBytes, entry.chargedBytes());
+    state.liveBytes -= std::min(state.liveBytes, entry.chargedBytes());
     entry.fill = RetainedSpanSlot();
     entry.stroke = RetainedSpanSlot();
   }
@@ -988,8 +996,8 @@ RendererTinySkia::RetainedTarget RendererTinySkia::retainedTargetFor(
     return RetainedTarget();
   }
 
-  entry.lastUsedFrame = frameIndex_;
-  return RetainedTarget{&entry, &budget};
+  entry.lastUsedFrame = frameToken_;
+  return RetainedTarget{&entry, &state};
 }
 
 void RendererTinySkia::pushIsolatedLayer(double opacity, MixBlendMode blendMode) {
@@ -1514,7 +1522,7 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
     RetainedSpanSlot* slot =
         (retained && !paintBorrowsPattern(*fillPaint)) ? &retained.entry->fill : nullptr;
     drawRetainablePass(
-        slot, retained.budget, key, pixmapView, mask, retainedSpanStats_,
+        slot, retained.state, key, pixmapView, mask, retainedSpanStats_,
         [&] {
           tiny_skia::Painter::fillPath(pixmapView, tinyPath(), *fillPaint,
                                        toTinyFillRule(path.fillRule),
@@ -1614,7 +1622,7 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
     RetainedSpanSlot* slot =
         (retained && !paintBorrowsPattern(*strokePaint)) ? &retained.entry->stroke : nullptr;
     drawRetainablePass(
-        slot, retained.budget, key, pixmapView, mask, retainedSpanStats_,
+        slot, retained.state, key, pixmapView, mask, retainedSpanStats_,
         [&] {
           tiny_skia::Painter::strokePath(pixmapView, strokePath(), *strokePaint, tinyStroke,
                                          toTinyTransform(deviceFromLocalTransform_), mask);
@@ -1637,10 +1645,10 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
   if (retained) {
     // Runs after both passes so the entry this draw just wrote is complete, and after the
     // pointer into it is no longer used, since evicting removes entries.
-    EvictRetainedSpansToBudget(*path.sourceEntity.registry(), frameIndex_);
-    retainedSpanStats_.liveBytes = retained.budget->liveBytes;
-    retainedSpanStats_.evictions = retained.budget->evictions;
-    retainedSpanStats_.documentDisabled = retained.budget->disabled;
+    EvictRetainedSpansToBudget(*path.sourceEntity.registry(), frameToken_);
+    retainedSpanStats_.liveBytes = retained.state->liveBytes;
+    retainedSpanStats_.evictions = retained.state->evictions;
+    retainedSpanStats_.documentDisabled = retained.state->disabled;
   }
 }
 

--- a/donner/svg/renderer/RendererTinySkia.cc
+++ b/donner/svg/renderer/RendererTinySkia.cc
@@ -548,7 +548,10 @@ void drawRetainablePass(RetainedSpanSlot* slot, RetainedSpanDocumentState* state
   }
 
   const std::size_t charged = slot->capture.spans().capacityBytes();
-  state->liveBytes = state->liveBytes - slot->chargedBytes + charged;
+  // Subtract before adding, and never below zero: the running total is maintained across
+  // several paths and an unsigned wrap here would read as a document holding gigabytes.
+  state->liveBytes -= std::min(state->liveBytes, slot->chargedBytes);
+  state->liveBytes += charged;
   slot->chargedBytes = charged;
   stats.liveBytes = state->liveBytes;
 }

--- a/donner/svg/renderer/RendererTinySkia.cc
+++ b/donner/svg/renderer/RendererTinySkia.cc
@@ -1504,10 +1504,9 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
 
   // A draw that also paints a context-paint capture surface is two draws sharing one outline,
   // which one retained entry cannot describe, so it rasterizes.
-  const RetainedTarget retained =
-      (fillPaintPixmap == nullptr && strokePaintPixmap == nullptr)
-          ? retainedTargetFor(path.sourceEntity)
-          : RetainedTarget();
+  const RetainedTarget retained = (fillPaintPixmap == nullptr && strokePaintPixmap == nullptr)
+                                      ? retainedTargetFor(path.sourceEntity)
+                                      : RetainedTarget();
 
   const bool usedPatternFill = patternFillPaint_.has_value();
   std::optional<tiny_skia::Paint> fillPaint =
@@ -1532,8 +1531,7 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
                                        toTinyTransform(deviceFromLocalTransform_), mask);
         },
         [&](tiny_skia::SpanCapture& capture) {
-          return capture.fillPath(pixmapView, tinyPath(), *fillPaint,
-                                  toTinyFillRule(path.fillRule),
+          return capture.fillPath(pixmapView, tinyPath(), *fillPaint, toTinyFillRule(path.fillRule),
                                   toTinyTransform(deviceFromLocalTransform_), mask);
         });
 

--- a/donner/svg/renderer/RendererTinySkia.cc
+++ b/donner/svg/renderer/RendererTinySkia.cc
@@ -478,6 +478,81 @@ tiny_skia::Paint makeBasePaint(bool antialias) {
   return paint;
 }
 
+bool masksEqual(const tiny_skia::Mask& lhs, const tiny_skia::Mask& rhs) {
+  const std::span<const std::uint8_t> lhsData = lhs.data();
+  const std::span<const std::uint8_t> rhsData = rhs.data();
+  return lhs.size() == rhs.size() && lhsData.size() == rhsData.size() &&
+         std::equal(lhsData.begin(), lhsData.end(), rhsData.begin());
+}
+
+/// True when a paint borrows its pixels from a pattern tile.
+///
+/// Those pixels are rebuilt per use and live outside the paint, so coverage recorded under one
+/// cannot be shown to still describe the next draw. Such a draw is left to rasterize.
+bool paintBorrowsPattern(const tiny_skia::Paint& paint) {
+  return std::holds_alternative<tiny_skia::Pattern>(paint.shader);
+}
+
+/// Draws one fill or stroke pass, replaying retained coverage when it still applies.
+///
+/// @param slot Retained storage for this pass, or null to rasterize unconditionally.
+/// @param budget Document accounting to charge a new recording against. Non-null with `slot`.
+/// @param key Inputs the recorded coverage depends on.
+/// @param pixmap Surface the pass draws onto.
+/// @param mask Clip mask in effect, applied per blit by the pipeline rather than baked into
+///   coverage, so a replay must be handed the same one a fresh draw would get.
+/// @param stats Counters describing what happened.
+/// @param drawFresh Performs the ordinary draw.
+/// @param drawCapturing Performs the same draw through a capture, returning false when the
+///   draw could not be recorded. The pixels are painted either way.
+template <typename DrawFresh, typename DrawCapturing>
+void drawRetainablePass(RetainedSpanSlot* slot, RetainedSpanBudget* budget,
+                        const RetainedSpanKey& key, tiny_skia::MutablePixmapView& pixmap,
+                        const tiny_skia::Mask* mask, RetainedSpanStats& stats,
+                        DrawFresh&& drawFresh, DrawCapturing&& drawCapturing) {
+  if (slot == nullptr) {
+    ++stats.bypassedDraws;
+    drawFresh();
+    return;
+  }
+
+  if (slot->valid && slot->key == key) {
+    if (tiny_skia::SpanCapture::replay(pixmap, slot->capture.spans(), slot->capture.paint(),
+                                       mask)) {
+      ++stats.replayedDraws;
+      return;
+    }
+
+    // The recording was refused, which the surface-size guard does for runs that were recorded
+    // against a differently sized surface. Falling through to a real draw is what keeps a
+    // refusal from turning into a missing shape.
+    ++stats.refusedReplays;
+    slot->invalidate();
+  }
+
+  if (slot->valid) {
+    ++stats.invalidatedDraws;
+    slot->invalidate();
+  }
+
+  const bool recorded = drawCapturing(slot->capture);
+  if (recorded) {
+    slot->valid = true;
+    slot->key = key;
+    ++stats.capturedDraws;
+  } else {
+    // Nothing to replay, and the draw will be just as unrecordable next frame, so give the
+    // storage back rather than charge the document for it.
+    slot->capture.release();
+    ++stats.unrecordableDraws;
+  }
+
+  const std::size_t charged = slot->capture.spans().capacityBytes();
+  budget->liveBytes = budget->liveBytes - slot->chargedBytes + charged;
+  slot->chargedBytes = charged;
+  stats.liveBytes = budget->liveBytes;
+}
+
 std::optional<tiny_skia::Mask> createMaskForSize(std::uint32_t width, std::uint32_t height) {
   return tiny_skia::Mask::fromSize(width, height);
 }
@@ -720,6 +795,13 @@ RendererTinySkia::RendererTinySkia(RendererTinySkia&&) noexcept = default;
 RendererTinySkia& RendererTinySkia::operator=(RendererTinySkia&&) noexcept = default;
 
 void RendererTinySkia::draw(SVGDocument& document) {
+  if (retainedSpansEnabled_) {
+    // Connect the geometry-invalidation listener before the driver instantiates the render
+    // tree, so a shape whose outline changed between draws drops its recording before this
+    // frame could replay it.
+    EnsureRetainedSpanInvalidationWired(document.registry());
+  }
+
   RendererDriver driver(*this, verbose_);
   driver.draw(document);
 }
@@ -756,6 +838,11 @@ void RendererTinySkia::beginFrame(const RenderViewport& viewport) {
   // here is what bounds its lifetime to a frame, which is the property that makes comparing
   // registry addresses safe; see `EnsureCacheInvalidationWired`.
   cacheWiringCheckedRegistry_ = nullptr;
+
+  ++frameIndex_;
+  retainedSpanStats_ = RetainedSpanStats();
+  clipEpoch_ = 0;
+  clipEpochStack_.clear();
 }
 
 void RendererTinySkia::endFrame() {
@@ -807,6 +894,7 @@ void RendererTinySkia::popTransform() {
 
 void RendererTinySkia::pushClip(const ResolvedClip& clip) {
   clipStack_.push_back(currentClipMask_);
+  clipEpochStack_.push_back(clipEpoch_);
 
   std::optional<tiny_skia::Mask> clipMask = buildClipMask(clip);
   if (!clipMask.has_value()) {
@@ -818,16 +906,90 @@ void RendererTinySkia::pushClip(const ResolvedClip& clip) {
   }
 
   currentClipMask_ = std::move(clipMask);
+  clipEpoch_ = assignClipEpoch();
 }
 
 void RendererTinySkia::popClip() {
   if (clipStack_.empty()) {
     currentClipMask_.reset();
+    clipEpoch_ = 0;
     return;
   }
 
   currentClipMask_ = std::move(clipStack_.back());
   clipStack_.pop_back();
+  clipEpoch_ = clipEpochStack_.back();
+  clipEpochStack_.pop_back();
+}
+
+std::uint64_t RendererTinySkia::assignClipEpoch() {
+  if (!retainedSpansEnabled_ || !currentClipMask_.has_value()) {
+    return 0;
+  }
+
+  // The depth this clip was pushed at. Comparing against the mask the same depth held last
+  // time is what makes the identity meaningful: a document's clip stack is rebuilt in the same
+  // order every frame, so an unchanged clip lands on its own previous mask and keeps its
+  // identity, while any change issues a new one.
+  const std::size_t depth = clipEpochStack_.size();
+  if (clipEpochSlots_.size() <= depth) {
+    clipEpochSlots_.resize(depth + 1);
+  }
+
+  ClipEpochSlot& slot = clipEpochSlots_[depth];
+  if (slot.epoch != 0 && slot.mask.has_value() && masksEqual(*slot.mask, *currentClipMask_)) {
+    return slot.epoch;
+  }
+
+  slot.mask = currentClipMask_;
+  slot.epoch = nextClipEpoch_++;
+  return slot.epoch;
+}
+
+RendererTinySkia::RetainedTarget RendererTinySkia::retainedTargetFor(
+    const EntityHandle& sourceEntity) {
+  // Coverage is retained only for a draw that goes straight to the root surface: a layer,
+  // mask, or pattern-tile surface is rebuilt with the thing that owns it, so a recording made
+  // against one describes a surface that no longer exists. A draw with no source entity (a
+  // replayed snapshot, an overlay, a test harness) has no identity to key on.
+  if (!retainedSpansEnabled_ || !surfaceStack_.empty() || !sourceEntity) {
+    return RetainedTarget();
+  }
+
+  Registry& registry = *sourceEntity.registry();
+  EnsureRetainedSpanInvalidationWired(registry);
+
+  RetainedSpanBudget& budget = RetainedSpanBudgetFor(registry, retainedSpanBudgetBytes_);
+  retainedSpanStats_.documentDisabled = budget.disabled;
+  retainedSpanStats_.evictions = budget.evictions;
+  if (budget.disabled) {
+    return RetainedTarget();
+  }
+
+  RetainedSpansComponent& entry = sourceEntity.get_or_emplace<RetainedSpansComponent>();
+  if (entry.drawFrame != frameIndex_) {
+    entry.drawFrame = frameIndex_;
+    entry.drawsThisFrame = 0;
+  }
+
+  ++entry.drawsThisFrame;
+  if (entry.drawsThisFrame > 1 && !entry.ambiguous) {
+    // One entity, several draws in one frame: an instanced shape drawn through a shadow tree,
+    // or a shape whose `paint-order` splits fill and stroke into separate draws. A single entry
+    // can only describe one of them, and alternating between them would re-capture on every
+    // draw, so this entity stops retaining.
+    entry.ambiguous = true;
+    budget.liveBytes -= std::min(budget.liveBytes, entry.chargedBytes());
+    entry.fill = RetainedSpanSlot();
+    entry.stroke = RetainedSpanSlot();
+  }
+
+  if (entry.ambiguous) {
+    return RetainedTarget();
+  }
+
+  entry.lastUsedFrame = frameIndex_;
+  return RetainedTarget{&entry, &budget};
 }
 
 void RendererTinySkia::pushIsolatedLayer(double opacity, MixBlendMode blendMode) {
@@ -940,8 +1102,12 @@ void RendererTinySkia::pushFilterLayer(const components::FilterGraph& filterGrap
   // The clip mask is restored in popFilterLayer and applied when compositing the filter output.
   frame.savedClipMask = std::move(currentClipMask_);
   frame.savedClipStack = std::move(clipStack_);
+  frame.savedClipEpoch = clipEpoch_;
+  frame.savedClipEpochStack = std::move(clipEpochStack_);
   currentClipMask_.reset();
   clipStack_.clear();
+  clipEpoch_ = 0;
+  clipEpochStack_.clear();
 
   surfaceStack_.push_back(std::move(frame));
 
@@ -975,6 +1141,8 @@ void RendererTinySkia::popFilterLayer() {
   // paint → filter → clip-path → mask → opacity.
   currentClipMask_ = std::move(frame.savedClipMask);
   clipStack_ = std::move(frame.savedClipStack);
+  clipEpoch_ = frame.savedClipEpoch;
+  clipEpochStack_ = std::move(frame.savedClipEpochStack);
 
   // Transform is maintained by RendererDriver via setTransform. The filter buffer offset
   // (if any) was applied in setTransform and is automatically removed when the surface is
@@ -1241,6 +1409,8 @@ bool RendererTinySkia::beginPatternTile(const Box2d& tileRect,
   frame.savedTransformStack = std::move(deviceFromLocalTransformStack_);
   frame.savedClipMask = std::move(currentClipMask_);
   frame.savedClipStack = std::move(clipStack_);
+  frame.savedClipEpoch = clipEpoch_;
+  frame.savedClipEpochStack = std::move(clipEpochStack_);
 
   // Tile-content draws must not consume the outer element's pending pattern shaders (a shape
   // inside the tile would otherwise pick them up as its own fill/stroke and reset them).
@@ -1255,6 +1425,8 @@ bool RendererTinySkia::beginPatternTile(const Box2d& tileRect,
   deviceFromLocalTransformStack_.clear();
   currentClipMask_.reset();
   clipStack_.clear();
+  clipEpoch_ = 0;
+  clipEpochStack_.clear();
   return true;
 }
 
@@ -1270,6 +1442,8 @@ void RendererTinySkia::endPatternTile(bool forStroke) {
   deviceFromLocalTransformStack_ = std::move(frame.savedTransformStack);
   currentClipMask_ = std::move(frame.savedClipMask);
   clipStack_ = std::move(frame.savedClipStack);
+  clipEpoch_ = frame.savedClipEpoch;
+  clipEpochStack_ = std::move(frame.savedClipEpochStack);
   patternFillPaint_ = std::move(frame.savedPatternFillPaint);
   patternStrokePaint_ = std::move(frame.savedPatternStrokePaint);
   PatternPaintState state{std::move(frame.pixmap), frame.targetFromPattern};
@@ -1291,10 +1465,7 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
   }
 
   const Path& pathGeometry = path.pathOrEmpty();
-  tiny_skia::Path uncachedPath;
-  const tiny_skia::Path& tinyPath =
-      ResolveTinyPath(path, TinyPathCloseBehavior::Preserve, uncachedPath,
-                      cacheWiringCheckedRegistry_, frameCounters_);
+
   const tiny_skia::Mask* mask = currentClipMask_.has_value() ? &*currentClipMask_ : nullptr;
   tiny_skia::Pixmap* fillPaintPixmap =
       !surfaceStack_.empty() && surfaceStack_.back().fillPaintPixmap.has_value()
@@ -1305,16 +1476,59 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
           ? &*surfaceStack_.back().strokePaintPixmap
           : nullptr;
 
+  // The tiny-skia outline is resolved on demand, through the per-entity conversion cache: a
+  // draw served from retained coverage needs no outline at all, and one that does need it takes
+  // the cached conversion rather than converting again. Retention never converts on its own, so
+  // the cache stays the only place a conversion happens and its per-frame count keeps meaning
+  // what it says.
+  tiny_skia::Path uncachedPath;
+  const tiny_skia::Path* resolvedPath = nullptr;
+  const auto tinyPath = [&]() -> const tiny_skia::Path& {
+    if (resolvedPath == nullptr) {
+      resolvedPath = &ResolveTinyPath(path, TinyPathCloseBehavior::Preserve, uncachedPath,
+                                      cacheWiringCheckedRegistry_, frameCounters_);
+    }
+    return *resolvedPath;
+  };
+
+  // A draw that also paints a context-paint capture surface is two draws sharing one outline,
+  // which one retained entry cannot describe, so it rasterizes.
+  const RetainedTarget retained =
+      (fillPaintPixmap == nullptr && strokePaintPixmap == nullptr)
+          ? retainedTargetFor(path.sourceEntity)
+          : RetainedTarget();
+
   const bool usedPatternFill = patternFillPaint_.has_value();
   std::optional<tiny_skia::Paint> fillPaint =
       paint_.drawFillComponent ? makeFillPaint(pathGeometry.bounds()) : std::nullopt;
   if (fillPaint) {
     auto pixmapView = currentPixmapView();
-    tiny_skia::Painter::fillPath(pixmapView, tinyPath, *fillPaint, toTinyFillRule(path.fillRule),
-                                 toTinyTransform(deviceFromLocalTransform_), mask);
+
+    RetainedSpanKey key;
+    key.deviceFromLocal = deviceFromLocalTransform_;
+    key.paint = *fillPaint;
+    key.clipEpoch = clipEpoch_;
+    key.surfaceSize = pixmapView.size();
+    key.fillRule = path.fillRule;
+
+    RetainedSpanSlot* slot =
+        (retained && !paintBorrowsPattern(*fillPaint)) ? &retained.entry->fill : nullptr;
+    drawRetainablePass(
+        slot, retained.budget, key, pixmapView, mask, retainedSpanStats_,
+        [&] {
+          tiny_skia::Painter::fillPath(pixmapView, tinyPath(), *fillPaint,
+                                       toTinyFillRule(path.fillRule),
+                                       toTinyTransform(deviceFromLocalTransform_), mask);
+        },
+        [&](tiny_skia::SpanCapture& capture) {
+          return capture.fillPath(pixmapView, tinyPath(), *fillPaint,
+                                  toTinyFillRule(path.fillRule),
+                                  toTinyTransform(deviceFromLocalTransform_), mask);
+        });
+
     if (fillPaintPixmap != nullptr) {
       auto fillPaintView = fillPaintPixmap->mutableView();
-      tiny_skia::Painter::fillPath(fillPaintView, tinyPath, *fillPaint,
+      tiny_skia::Painter::fillPath(fillPaintView, tinyPath(), *fillPaint,
                                    toTinyFillRule(path.fillRule),
                                    toTinyTransform(deviceFromLocalTransform_), mask);
     }
@@ -1372,24 +1586,61 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
     // those ranges across ClosePath, filling the seam as if the stroke were solid. Replace only
     // the stroke's ClosePath commands with explicit closing lines so the dash stroker emits caps
     // at that boundary; fills and ordinary dashed/solid strokes keep their closed contours.
+    const bool openDashSeam = tinyStroke.dash.has_value() && dashHasOnlyZeroLengthGaps;
     tiny_skia::Path uncachedDashSeamPath;
-    const tiny_skia::Path* strokePath = &tinyPath;
-    if (tinyStroke.dash.has_value() && dashHasOnlyZeroLengthGaps) {
-      strokePath = &ResolveTinyPath(path, TinyPathCloseBehavior::EndWithLine, uncachedDashSeamPath,
-                                    cacheWiringCheckedRegistry_, frameCounters_);
-    }
+    const tiny_skia::Path* resolvedDashSeamPath = nullptr;
+    const auto strokePath = [&]() -> const tiny_skia::Path& {
+      if (!openDashSeam) {
+        return tinyPath();
+      }
+      if (resolvedDashSeamPath == nullptr) {
+        resolvedDashSeamPath =
+            &ResolveTinyPath(path, TinyPathCloseBehavior::EndWithLine, uncachedDashSeamPath,
+                             cacheWiringCheckedRegistry_, frameCounters_);
+      }
+      return *resolvedDashSeamPath;
+    };
 
     auto pixmapView = currentPixmapView();
-    tiny_skia::Painter::strokePath(pixmapView, *strokePath, *strokePaint, tinyStroke,
-                                   toTinyTransform(deviceFromLocalTransform_), mask);
+
+    RetainedSpanKey key;
+    key.deviceFromLocal = deviceFromLocalTransform_;
+    key.paint = *strokePaint;
+    key.stroke = tinyStroke;
+    key.clipEpoch = clipEpoch_;
+    key.surfaceSize = pixmapView.size();
+    key.openDashSeam = openDashSeam;
+
+    RetainedSpanSlot* slot =
+        (retained && !paintBorrowsPattern(*strokePaint)) ? &retained.entry->stroke : nullptr;
+    drawRetainablePass(
+        slot, retained.budget, key, pixmapView, mask, retainedSpanStats_,
+        [&] {
+          tiny_skia::Painter::strokePath(pixmapView, strokePath(), *strokePaint, tinyStroke,
+                                         toTinyTransform(deviceFromLocalTransform_), mask);
+        },
+        [&](tiny_skia::SpanCapture& capture) {
+          return capture.strokePath(pixmapView, strokePath(), *strokePaint, tinyStroke,
+                                    toTinyTransform(deviceFromLocalTransform_), mask);
+        });
+
     if (strokePaintPixmap != nullptr) {
       auto strokePaintView = strokePaintPixmap->mutableView();
-      tiny_skia::Painter::strokePath(strokePaintView, *strokePath, *strokePaint, tinyStroke,
+      tiny_skia::Painter::strokePath(strokePaintView, strokePath(), *strokePaint, tinyStroke,
                                      toTinyTransform(deviceFromLocalTransform_), mask);
     }
     if (usedPatternStroke) {
       patternStrokePaint_.reset();
     }
+  }
+
+  if (retained) {
+    // Runs after both passes so the entry this draw just wrote is complete, and after the
+    // pointer into it is no longer used, since evicting removes entries.
+    EvictRetainedSpansToBudget(*path.sourceEntity.registry(), frameIndex_);
+    retainedSpanStats_.liveBytes = retained.budget->liveBytes;
+    retainedSpanStats_.evictions = retained.budget->evictions;
+    retainedSpanStats_.documentDisabled = retained.budget->disabled;
   }
 }
 

--- a/donner/svg/renderer/RendererTinySkia.cc
+++ b/donner/svg/renderer/RendererTinySkia.cc
@@ -496,7 +496,6 @@ bool paintBorrowsPattern(const tiny_skia::Paint& paint) {
 /// Draws one fill or stroke pass, replaying retained coverage when it still applies.
 ///
 /// @param slot Retained storage for this pass, or null to rasterize unconditionally.
-/// @param state Document state to charge a new recording against. Non-null with `slot`.
 /// @param key Inputs the recorded coverage depends on.
 /// @param pixmap Surface the pass draws onto.
 /// @param mask Clip mask in effect, applied per blit by the pipeline rather than baked into
@@ -506,10 +505,10 @@ bool paintBorrowsPattern(const tiny_skia::Paint& paint) {
 /// @param drawCapturing Performs the same draw through a capture, returning false when the
 ///   draw could not be recorded. The pixels are painted either way.
 template <typename DrawFresh, typename DrawCapturing>
-void drawRetainablePass(RetainedSpanSlot* slot, RetainedSpanDocumentState* state,
-                        const RetainedSpanKey& key, tiny_skia::MutablePixmapView& pixmap,
-                        const tiny_skia::Mask* mask, RetainedSpanStats& stats,
-                        DrawFresh&& drawFresh, DrawCapturing&& drawCapturing) {
+void drawRetainablePass(RetainedSpanSlot* slot, const RetainedSpanKey& key,
+                        tiny_skia::MutablePixmapView& pixmap, const tiny_skia::Mask* mask,
+                        RetainedSpanStats& stats, DrawFresh&& drawFresh,
+                        DrawCapturing&& drawCapturing) {
   if (slot == nullptr) {
     ++stats.bypassedDraws;
     drawFresh();
@@ -546,14 +545,6 @@ void drawRetainablePass(RetainedSpanSlot* slot, RetainedSpanDocumentState* state
     slot->capture.release();
     ++stats.unrecordableDraws;
   }
-
-  const std::size_t charged = slot->capture.spans().capacityBytes();
-  // Subtract before adding, and never below zero: the running total is maintained across
-  // several paths and an unsigned wrap here would read as a document holding gigabytes.
-  state->liveBytes -= std::min(state->liveBytes, slot->chargedBytes);
-  state->liveBytes += charged;
-  slot->chargedBytes = charged;
-  stats.liveBytes = state->liveBytes;
 }
 
 std::optional<tiny_skia::Mask> createMaskForSize(std::uint32_t width, std::uint32_t height) {
@@ -803,6 +794,11 @@ void RendererTinySkia::draw(SVGDocument& document) {
     // tree, so a shape whose outline changed between draws drops its recording before this
     // frame could replay it.
     EnsureRetainedSpanInvalidationWired(document.registry());
+  } else {
+    // Retained entries live on the document, not on the renderer that made them, so a renderer
+    // that stops retaining has to hand them back. Otherwise turning retention off leaves the
+    // document holding coverage nothing will ever replay.
+    ClearRetainedSpans(document.registry());
   }
 
   RendererDriver driver(*this, verbose_);
@@ -846,6 +842,13 @@ void RendererTinySkia::beginFrame(const RenderViewport& viewport) {
   retainedSpanStats_ = RetainedSpanStats();
   clipEpoch_ = 0;
   clipEpochStack_.clear();
+  if (frame_.size() != previousFrameSize_) {
+    // The remembered clip masks are sized for the surface they were built against, so they can
+    // never match again once it changes. Dropping them here is what keeps a resizing viewport
+    // from holding one full-surface mask per depth per size.
+    clipEpochSlots_.clear();
+    previousFrameSize_ = frame_.size();
+  }
 }
 
 void RendererTinySkia::endFrame() {
@@ -909,7 +912,9 @@ void RendererTinySkia::pushClip(const ResolvedClip& clip) {
   }
 
   currentClipMask_ = std::move(clipMask);
-  clipEpoch_ = assignClipEpoch();
+  // `clipEpochStack_` already holds the epoch this clip replaced, so the clip's own depth is
+  // one below the stack's size, and the outermost clip is depth zero.
+  clipEpoch_ = assignClipEpoch(clipEpochStack_.size() - 1);
 }
 
 void RendererTinySkia::popClip() {
@@ -925,16 +930,20 @@ void RendererTinySkia::popClip() {
   clipEpochStack_.pop_back();
 }
 
-std::uint64_t RendererTinySkia::assignClipEpoch() {
+std::uint64_t RendererTinySkia::assignClipEpoch(std::size_t depth) {
   if (!retainedSpansEnabled_ || !currentClipMask_.has_value()) {
     return 0;
   }
 
-  // The depth this clip was pushed at. Comparing against the mask the same depth held last
-  // time is what makes the identity meaningful: a document's clip stack is rebuilt in the same
-  // order every frame, so an unchanged clip lands on its own previous mask and keeps its
-  // identity, while any change issues a new one.
-  const std::size_t depth = clipEpochStack_.size();
+  // Remembering one mask per depth is what makes the identity useful: a document's clip stack
+  // is rebuilt in the same order every frame, so an unchanged clip meets its own previous mask
+  // and keeps its identity, while any change takes a new one. Past the cap the identity is
+  // fresh every time, so deeply clipped shapes rasterize rather than letting a document choose
+  // how many full-surface masks this renderer holds.
+  if (depth >= kMaxRetainedClipDepth) {
+    return nextClipEpoch_++;
+  }
+
   if (clipEpochSlots_.size() <= depth) {
     clipEpochSlots_.resize(depth + 1);
   }
@@ -990,7 +999,8 @@ RendererTinySkia::RetainedTarget RendererTinySkia::retainedTargetFor(
     // can only describe one of them, and alternating between them would re-capture on every
     // draw, so this entity stops retaining.
     entry.ambiguous = true;
-    state.liveBytes -= std::min(state.liveBytes, entry.chargedBytes());
+    state.liveBytes -= std::min(state.liveBytes, entry.chargedBytes);
+    entry.chargedBytes = 0;
     entry.fill = RetainedSpanSlot();
     entry.stroke = RetainedSpanSlot();
   }
@@ -1524,7 +1534,7 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
     RetainedSpanSlot* slot =
         (retained && !paintBorrowsPattern(*fillPaint)) ? &retained.entry->fill : nullptr;
     drawRetainablePass(
-        slot, retained.state, key, pixmapView, mask, retainedSpanStats_,
+        slot, key, pixmapView, mask, retainedSpanStats_,
         [&] {
           tiny_skia::Painter::fillPath(pixmapView, tinyPath(), *fillPaint,
                                        toTinyFillRule(path.fillRule),
@@ -1623,7 +1633,7 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
     RetainedSpanSlot* slot =
         (retained && !paintBorrowsPattern(*strokePaint)) ? &retained.entry->stroke : nullptr;
     drawRetainablePass(
-        slot, retained.state, key, pixmapView, mask, retainedSpanStats_,
+        slot, key, pixmapView, mask, retainedSpanStats_,
         [&] {
           tiny_skia::Painter::strokePath(pixmapView, strokePath(), *strokePaint, tinyStroke,
                                          toTinyTransform(deviceFromLocalTransform_), mask);
@@ -1644,8 +1654,17 @@ void RendererTinySkia::drawPath(const PathShape& path, const StrokeParams& strok
   }
 
   if (retained) {
-    // Runs after both passes so the entry this draw just wrote is complete, and after the
-    // pointer into it is no longer used, since evicting removes entries.
+    // Charge the whole entry once both passes have written it, rather than each pass its own
+    // slot: the two share the entry's own footprint, and the paints one pass keeps are only
+    // meaningful next to the coverage the other kept.
+    const std::size_t entryBytes = RetainedEntryBytes(*retained.entry);
+    // Subtract before adding, and never below zero: the running total is maintained across
+    // several paths and an unsigned wrap here would read as a document holding gigabytes.
+    retained.state->liveBytes -= std::min(retained.state->liveBytes, retained.entry->chargedBytes);
+    retained.state->liveBytes += entryBytes;
+    retained.entry->chargedBytes = entryBytes;
+
+    // Evicting removes entries, so nothing may touch `retained.entry` after this point.
     EvictRetainedSpansToBudget(*path.sourceEntity.registry(), frameToken_);
     retainedSpanStats_.liveBytes = retained.state->liveBytes;
     retainedSpanStats_.evictions = retained.state->evictions;

--- a/donner/svg/renderer/RendererTinySkia.h
+++ b/donner/svg/renderer/RendererTinySkia.h
@@ -271,7 +271,7 @@ public:
    * Sets the per-document ceiling on retained coverage.
    *
    * Exceeding it evicts the coldest shapes; a working set that does not fit at all turns
-   * retention off for that document. @see RetainedSpanBudget.
+   * retention off for that document. @see RetainedSpanDocumentState.
    *
    * @param bytes Ceiling in bytes.
    */
@@ -356,7 +356,7 @@ private:
   /// retainable.
   struct RetainedTarget {
     RetainedSpansComponent* entry = nullptr;
-    RetainedSpanBudget* budget = nullptr;
+    RetainedSpanDocumentState* state = nullptr;
 
     explicit operator bool() const { return entry != nullptr; }
   };
@@ -451,11 +451,15 @@ private:
   const Registry* cacheWiringCheckedRegistry_ = nullptr;
 
   bool retainedSpansEnabled_ = false;
-  std::size_t retainedSpanBudgetBytes_ = RetainedSpanBudget::kDefaultBudgetBytes;
+  std::size_t retainedSpanBudgetBytes_ = RetainedSpanDocumentState::kDefaultBudgetBytes;
   RetainedSpanStats retainedSpanStats_;
-  /// Counts frames so retained entries can record when they were last drawn. Starts at one so
-  /// a default-constructed entry's zero never reads as "used this frame".
+  /// Counts this renderer's frames, which is only used to notice that a new frame started.
   std::uint64_t frameIndex_ = 0;
+  /// Identity of the current frame within the document being drawn, taken from the document on
+  /// the frame's first retainable draw. Zero until then, which no entry can match.
+  std::uint64_t frameToken_ = 0;
+  /// The value of `frameIndex_` `frameToken_` was taken for.
+  std::uint64_t frameTokenIndex_ = 0;
   /// Identity of the clip mask now in effect, zero when there is none.
   std::uint64_t clipEpoch_ = 0;
   /// Next identity to issue. Starts at one so zero stays reserved for "no clip".

--- a/donner/svg/renderer/RendererTinySkia.h
+++ b/donner/svg/renderer/RendererTinySkia.h
@@ -347,13 +347,25 @@ private:
   ///
   /// A clip mask is rebuilt every frame, so object identity says nothing about whether the clip
   /// changed. Comparing the rebuilt mask against the one this depth held last time turns that
-  /// into an integer a shape can carry in its retained key: equal identities mean the two masks
-  /// compared byte-equal, because an identity is only ever issued for one comparison chain, and
-  /// no two depths share one.
+  /// into an integer a shape can carry in its retained key, and within one renderer equal
+  /// identities do mean the masks compared byte-equal, because an identity is only ever issued
+  /// for one comparison chain and no two depths share one.
+  ///
+  /// Identities are renderer-local, so two renderers drawing one document number their clips
+  /// independently and a shape retained by one can meet the other's numbering. Nothing rests on
+  /// that: a replay is handed the clip mask in effect at replay time, exactly as a fresh draw
+  /// would be, and the recorded coverage does not depend on the mask at all, because scan
+  /// conversion clips to the surface and the mask reaches the blitter as per-blit pipeline
+  /// state. The key is there to keep clip changes conservative, not to make them correct.
   struct ClipEpochSlot {
     std::optional<tiny_skia::Mask> mask;
     std::uint64_t epoch = 0;
   };
+
+  /// Clip depths past this one take a fresh identity per draw instead of a remembered mask, so
+  /// a document cannot decide how many full-surface masks a renderer holds. Deeper clips are
+  /// rare, and a shape under one rasterizes rather than replaying.
+  static constexpr std::size_t kMaxRetainedClipDepth = 8;
 
   /// Retained storage and accounting for the shape being drawn, or empty when the draw is not
   /// retainable.
@@ -389,7 +401,9 @@ private:
   /// rasterize.
   [[nodiscard]] RetainedTarget retainedTargetFor(const EntityHandle& sourceEntity);
   /// Returns the identity of the clip mask now in effect, assigning a new one if it changed.
-  [[nodiscard]] std::uint64_t assignClipEpoch();
+  ///
+  /// @param depth Position of this clip in the clip stack, outermost being zero.
+  [[nodiscard]] std::uint64_t assignClipEpoch(std::size_t depth);
 
   bool verbose_ = false;
   bool antialias_ = true;
@@ -469,6 +483,8 @@ private:
   std::uint64_t nextClipEpoch_ = 1;
   std::vector<std::uint64_t> clipEpochStack_;
   std::vector<ClipEpochSlot> clipEpochSlots_;
+  /// Surface size the remembered clip masks were built against.
+  tiny_skia::IntSize previousFrameSize_;
 };
 
 }  // namespace donner::svg

--- a/donner/svg/renderer/RendererTinySkia.h
+++ b/donner/svg/renderer/RendererTinySkia.h
@@ -1,6 +1,7 @@
 #pragma once
 /// @file
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -11,6 +12,7 @@
 #include "donner/base/EcsRegistry_fwd.h"
 #include "donner/svg/SVGDocument.h"
 #include "donner/svg/renderer/RendererInterface.h"
+#include "donner/svg/renderer/RetainedSpans.h"
 #include "tiny_skia/Mask.h"
 #include "tiny_skia/Paint.h"
 #include "tiny_skia/Pixmap.h"
@@ -246,6 +248,38 @@ public:
   /// Enables or disables anti-aliasing.
   void setAntialias(bool antialias) { antialias_ = antialias; }
 
+  /**
+   * Enables or disables retained rasterization.
+   *
+   * When enabled, each shape's coverage is recorded the first time it is rasterized and
+   * replayed on later frames for as long as every input that coverage depended on is
+   * unchanged, which turns a redraw of an unchanged document into blits. Output is
+   * byte-identical either way; the cost is the memory the recordings occupy, bounded by
+   * \ref setRetainedSpanBudgetBytes.
+   *
+   * Off by default, because a renderer that draws each document once pays the recording cost
+   * with nothing to replay it onto.
+   *
+   * @param enabled Whether to retain and replay per-shape coverage.
+   */
+  void setRetainedSpansEnabled(bool enabled) { retainedSpansEnabled_ = enabled; }
+
+  /// Returns whether retained rasterization is enabled.
+  [[nodiscard]] bool retainedSpansEnabled() const { return retainedSpansEnabled_; }
+
+  /**
+   * Sets the per-document ceiling on retained coverage.
+   *
+   * Exceeding it evicts the coldest shapes; a working set that does not fit at all turns
+   * retention off for that document. @see RetainedSpanBudget.
+   *
+   * @param bytes Ceiling in bytes.
+   */
+  void setRetainedSpanBudgetBytes(std::size_t bytes) { retainedSpanBudgetBytes_ = bytes; }
+
+  /// Returns what retained rasterization did during the most recent frame.
+  [[nodiscard]] const RetainedSpanStats& retainedSpanStats() const { return retainedSpanStats_; }
+
   /// Returns the rendered width in pixels.
   int width() const override;
 
@@ -299,6 +333,32 @@ private:
     std::optional<PatternPaintState> savedPatternFillPaint;
     /// @see savedPatternFillPaint
     std::optional<PatternPaintState> savedPatternStrokePaint;
+    /// Clip identity saved alongside `savedClipMask`, so the identity and the mask it names
+    /// are restored together.
+    std::uint64_t savedClipEpoch = 0;
+    /// @see savedClipEpoch
+    std::vector<std::uint64_t> savedClipEpochStack;
+  };
+
+  /// Last clip mask seen at one clip-stack depth, and the identity assigned to it.
+  ///
+  /// A clip mask is rebuilt every frame, so object identity says nothing about whether the clip
+  /// changed. Comparing the rebuilt mask against the one this depth held last time turns that
+  /// into an integer a shape can carry in its retained key: equal identities mean the two masks
+  /// compared byte-equal, because an identity is only ever issued for one comparison chain, and
+  /// no two depths share one.
+  struct ClipEpochSlot {
+    std::optional<tiny_skia::Mask> mask;
+    std::uint64_t epoch = 0;
+  };
+
+  /// Retained storage and accounting for the shape being drawn, or empty when the draw is not
+  /// retainable.
+  struct RetainedTarget {
+    RetainedSpansComponent* entry = nullptr;
+    RetainedSpanBudget* budget = nullptr;
+
+    explicit operator bool() const { return entry != nullptr; }
   };
 
   [[nodiscard]] tiny_skia::Pixmap& currentPixmap();
@@ -322,6 +382,11 @@ private:
   void compositePixmap(const tiny_skia::Pixmap& pixmap, double opacity,
                        MixBlendMode blendMode = MixBlendMode::Normal);
   void maybeWarnUnsupportedText();
+  /// Returns retained storage for \p sourceEntity, or an empty target when this draw must
+  /// rasterize.
+  [[nodiscard]] RetainedTarget retainedTargetFor(const EntityHandle& sourceEntity);
+  /// Returns the identity of the clip mask now in effect, assigning a new one if it changed.
+  [[nodiscard]] std::uint64_t assignClipEpoch();
 
   bool verbose_ = false;
   bool antialias_ = true;
@@ -384,6 +449,19 @@ private:
   /// comparison to a window in which no registry can be freed and reallocated at the same
   /// address. Never dereferenced.
   const Registry* cacheWiringCheckedRegistry_ = nullptr;
+
+  bool retainedSpansEnabled_ = false;
+  std::size_t retainedSpanBudgetBytes_ = RetainedSpanBudget::kDefaultBudgetBytes;
+  RetainedSpanStats retainedSpanStats_;
+  /// Counts frames so retained entries can record when they were last drawn. Starts at one so
+  /// a default-constructed entry's zero never reads as "used this frame".
+  std::uint64_t frameIndex_ = 0;
+  /// Identity of the clip mask now in effect, zero when there is none.
+  std::uint64_t clipEpoch_ = 0;
+  /// Next identity to issue. Starts at one so zero stays reserved for "no clip".
+  std::uint64_t nextClipEpoch_ = 1;
+  std::vector<std::uint64_t> clipEpochStack_;
+  std::vector<ClipEpochSlot> clipEpochSlots_;
 };
 
 }  // namespace donner::svg

--- a/donner/svg/renderer/RendererTinySkia.h
+++ b/donner/svg/renderer/RendererTinySkia.h
@@ -248,6 +248,9 @@ public:
   /// Enables or disables anti-aliasing.
   void setAntialias(bool antialias) { antialias_ = antialias; }
 
+  /// Returns whether anti-aliasing is enabled.
+  [[nodiscard]] bool antialias() const { return antialias_; }
+
   /**
    * Enables or disables retained rasterization.
    *

--- a/donner/svg/renderer/RetainedSpans.cc
+++ b/donner/svg/renderer/RetainedSpans.cc
@@ -31,8 +31,8 @@ std::size_t DropRetainedEntry(Registry& registry, Entity entity) {
   return bytes;
 }
 
-void ReleaseBytes(RetainedSpanBudget& budget, std::size_t bytes) {
-  budget.liveBytes -= std::min(budget.liveBytes, bytes);
+void ReleaseBytes(RetainedSpanDocumentState& state, std::size_t bytes) {
+  state.liveBytes -= std::min(state.liveBytes, bytes);
 }
 
 /// Drops an entity's retained coverage when its resolved path changes or goes away.
@@ -46,8 +46,8 @@ void OnComputedPathChanged(Registry& registry, Entity entity) {
     return;
   }
 
-  if (auto* budget = registry.ctx().find<RetainedSpanBudget>()) {
-    ReleaseBytes(*budget, bytes);
+  if (auto* state = registry.ctx().find<RetainedSpanDocumentState>()) {
+    ReleaseBytes(*state, bytes);
   }
 }
 
@@ -79,27 +79,28 @@ void EnsureRetainedSpanInvalidationWired(Registry& registry) {
   // component.
 }
 
-RetainedSpanBudget& RetainedSpanBudgetFor(Registry& registry, std::size_t budgetBytes) {
-  RetainedSpanBudget& budget = registry.ctx().get_or_emplace<RetainedSpanBudget>();
-  if (budget.budgetBytes != budgetBytes) {
+RetainedSpanDocumentState& RetainedSpanStateFor(Registry& registry, std::size_t budgetBytes) {
+  // `emplace` on the context returns the existing value when there is one.
+  RetainedSpanDocumentState& state = registry.ctx().emplace<RetainedSpanDocumentState>();
+  if (state.budgetBytes != budgetBytes) {
     // A new budget is a new answer to "does the working set fit", so a document that gave up
     // under the old one gets to try again.
-    budget.budgetBytes = budgetBytes;
-    budget.disabled = false;
+    state.budgetBytes = budgetBytes;
+    state.disabled = false;
   }
-  return budget;
+  return state;
 }
 
 void ClearRetainedSpans(Registry& registry) {
   registry.clear<RetainedSpansComponent>();
-  if (auto* budget = registry.ctx().find<RetainedSpanBudget>()) {
-    budget->liveBytes = 0;
+  if (auto* state = registry.ctx().find<RetainedSpanDocumentState>()) {
+    state->liveBytes = 0;
   }
 }
 
 void EvictRetainedSpansToBudget(Registry& registry, std::uint64_t currentFrame) {
-  auto* budget = registry.ctx().find<RetainedSpanBudget>();
-  if (budget == nullptr || budget->liveBytes <= budget->budgetBytes) {
+  auto* state = registry.ctx().find<RetainedSpanDocumentState>();
+  if (state == nullptr || state->liveBytes <= state->budgetBytes) {
     return;
   }
 
@@ -128,16 +129,16 @@ void EvictRetainedSpansToBudget(Registry& registry, std::uint64_t currentFrame) 
             });
 
   for (const Candidate& candidate : candidates) {
-    if (budget->liveBytes <= budget->budgetBytes) {
+    if (state->liveBytes <= state->budgetBytes) {
       return;
     }
 
     DropRetainedEntry(registry, candidate.entity);
-    ReleaseBytes(*budget, candidate.bytes);
-    ++budget->evictions;
+    ReleaseBytes(*state, candidate.bytes);
+    ++state->evictions;
   }
 
-  if (budget->liveBytes <= budget->budgetBytes) {
+  if (state->liveBytes <= state->budgetBytes) {
     return;
   }
 
@@ -145,7 +146,7 @@ void EvictRetainedSpansToBudget(Registry& registry, std::uint64_t currentFrame) 
   // any of it would evict and re-capture the same shapes every frame, which costs more than not
   // retaining at all.
   ClearRetainedSpans(registry);
-  budget->disabled = true;
+  state->disabled = true;
 }
 
 }  // namespace donner::svg

--- a/donner/svg/renderer/RetainedSpans.cc
+++ b/donner/svg/renderer/RetainedSpans.cc
@@ -115,12 +115,22 @@ void EvictRetainedSpansToBudget(Registry& registry, std::uint64_t currentFrame) 
   std::vector<Candidate> candidates;
   const auto view = registry.view<const RetainedSpansComponent>();
   candidates.reserve(view.size());
+  std::size_t held = 0;
   for (const Entity entity : view) {
     const RetainedSpansComponent& entry = view.get<const RetainedSpansComponent>(entity);
+    held += entry.chargedBytes();
     if (entry.lastUsedFrame >= currentFrame) {
       continue;
     }
     candidates.push_back(Candidate{entity, entry.lastUsedFrame, entry.chargedBytes()});
+  }
+
+  // An entity can be destroyed without this cache hearing about it, which leaves the running
+  // total above what is actually held. Recount before acting, so a document is never evicted
+  // from or disabled over memory it already gave back.
+  state->liveBytes = held;
+  if (state->liveBytes <= state->budgetBytes) {
+    return;
   }
 
   std::sort(candidates.begin(), candidates.end(),

--- a/donner/svg/renderer/RetainedSpans.cc
+++ b/donner/svg/renderer/RetainedSpans.cc
@@ -1,0 +1,151 @@
+#include "donner/svg/renderer/RetainedSpans.h"
+
+#include <algorithm>
+#include <vector>
+
+#include "donner/svg/components/shape/ComputedPathComponent.h"
+
+namespace donner::svg {
+
+namespace {
+
+/// Marks a registry as already carrying the invalidation listener. Lives in the registry's
+/// context, so it goes away with the registry: a later registry allocated at the same address
+/// correctly misses it and gets its own connection. Pointer identity alone cannot tell those
+/// two cases apart.
+struct RetainedSpanListenerInstalled {};
+
+bool TransformsEqual(const Transform2d& lhs, const Transform2d& rhs) {
+  return std::equal(std::begin(lhs.data), std::end(lhs.data), std::begin(rhs.data));
+}
+
+/// Drops an entity's retained coverage and returns the bytes it was charged.
+std::size_t DropRetainedEntry(Registry& registry, Entity entity) {
+  auto* entry = registry.try_get<RetainedSpansComponent>(entity);
+  if (entry == nullptr) {
+    return 0;
+  }
+
+  const std::size_t bytes = entry->chargedBytes();
+  registry.remove<RetainedSpansComponent>(entity);
+  return bytes;
+}
+
+void ReleaseBytes(RetainedSpanBudget& budget, std::size_t bytes) {
+  budget.liveBytes -= std::min(budget.liveBytes, bytes);
+}
+
+/// Drops an entity's retained coverage when its resolved path changes or goes away.
+///
+/// The resolved-path signals only fire when the geometry actually differs, so an idle
+/// re-render leaves retained coverage intact, and any real outline change removes it before the
+/// next draw can replay it.
+void OnComputedPathChanged(Registry& registry, Entity entity) {
+  const std::size_t bytes = DropRetainedEntry(registry, entity);
+  if (bytes == 0) {
+    return;
+  }
+
+  if (auto* budget = registry.ctx().find<RetainedSpanBudget>()) {
+    ReleaseBytes(*budget, bytes);
+  }
+}
+
+}  // namespace
+
+bool operator==(const RetainedSpanKey& lhs, const RetainedSpanKey& rhs) {
+  return TransformsEqual(lhs.deviceFromLocal, rhs.deviceFromLocal) && lhs.paint == rhs.paint &&
+         lhs.stroke == rhs.stroke && lhs.clipEpoch == rhs.clipEpoch &&
+         lhs.surfaceSize == rhs.surfaceSize && lhs.fillRule == rhs.fillRule &&
+         lhs.openDashSeam == rhs.openDashSeam;
+}
+
+void EnsureRetainedSpanInvalidationWired(Registry& registry) {
+  if (registry.ctx().contains<RetainedSpanListenerInstalled>()) {
+    return;
+  }
+
+  registry.ctx().emplace<RetainedSpanListenerInstalled>();
+  // Materialize the entry pool while the registry is quiescent. The listener below reaches it on
+  // every resolved-path change, including for entities that never retained anything, and a pool
+  // created for the first time from inside a destruction signal is a situation not worth having
+  // to reason about.
+  static_cast<void>(registry.storage<RetainedSpansComponent>());
+  registry.on_update<components::ComputedPathComponent>().connect<&OnComputedPathChanged>();
+  registry.on_destroy<components::ComputedPathComponent>().connect<&OnComputedPathChanged>();
+  // The connection outlives the renderer on purpose: the listener is a free function with no
+  // captured state, and it dies with the registry it is attached to. It shares these two
+  // signals with the conversion caches' listener; entt calls both, and each drops only its own
+  // component.
+}
+
+RetainedSpanBudget& RetainedSpanBudgetFor(Registry& registry, std::size_t budgetBytes) {
+  RetainedSpanBudget& budget = registry.ctx().get_or_emplace<RetainedSpanBudget>();
+  if (budget.budgetBytes != budgetBytes) {
+    // A new budget is a new answer to "does the working set fit", so a document that gave up
+    // under the old one gets to try again.
+    budget.budgetBytes = budgetBytes;
+    budget.disabled = false;
+  }
+  return budget;
+}
+
+void ClearRetainedSpans(Registry& registry) {
+  registry.clear<RetainedSpansComponent>();
+  if (auto* budget = registry.ctx().find<RetainedSpanBudget>()) {
+    budget->liveBytes = 0;
+  }
+}
+
+void EvictRetainedSpansToBudget(Registry& registry, std::uint64_t currentFrame) {
+  auto* budget = registry.ctx().find<RetainedSpanBudget>();
+  if (budget == nullptr || budget->liveBytes <= budget->budgetBytes) {
+    return;
+  }
+
+  // Coldest first: an entry not drawn this frame costs nothing to lose right now, while an
+  // entry drawn this frame would be re-captured immediately.
+  struct Candidate {
+    Entity entity;
+    std::uint64_t lastUsedFrame;
+    std::size_t bytes;
+  };
+
+  std::vector<Candidate> candidates;
+  const auto view = registry.view<const RetainedSpansComponent>();
+  candidates.reserve(view.size());
+  for (const Entity entity : view) {
+    const RetainedSpansComponent& entry = view.get<const RetainedSpansComponent>(entity);
+    if (entry.lastUsedFrame >= currentFrame) {
+      continue;
+    }
+    candidates.push_back(Candidate{entity, entry.lastUsedFrame, entry.chargedBytes()});
+  }
+
+  std::sort(candidates.begin(), candidates.end(),
+            [](const Candidate& lhs, const Candidate& rhs) {
+              return lhs.lastUsedFrame < rhs.lastUsedFrame;
+            });
+
+  for (const Candidate& candidate : candidates) {
+    if (budget->liveBytes <= budget->budgetBytes) {
+      return;
+    }
+
+    DropRetainedEntry(registry, candidate.entity);
+    ReleaseBytes(*budget, candidate.bytes);
+    ++budget->evictions;
+  }
+
+  if (budget->liveBytes <= budget->budgetBytes) {
+    return;
+  }
+
+  // Every remaining entry was drawn this frame, so the working set itself does not fit. Keeping
+  // any of it would evict and re-capture the same shapes every frame, which costs more than not
+  // retaining at all.
+  ClearRetainedSpans(registry);
+  budget->disabled = true;
+}
+
+}  // namespace donner::svg

--- a/donner/svg/renderer/RetainedSpans.cc
+++ b/donner/svg/renderer/RetainedSpans.cc
@@ -1,6 +1,8 @@
 #include "donner/svg/renderer/RetainedSpans.h"
 
 #include <algorithm>
+#include <type_traits>
+#include <variant>
 #include <vector>
 
 #include "donner/svg/components/shape/ComputedPathComponent.h"
@@ -26,9 +28,30 @@ std::size_t DropRetainedEntry(Registry& registry, Entity entity) {
     return 0;
   }
 
-  const std::size_t bytes = entry->chargedBytes();
+  const std::size_t bytes = entry->chargedBytes;
   registry.remove<RetainedSpansComponent>(entity);
   return bytes;
+}
+
+/// Returns the heap a paint owns beyond the object itself, which for a gradient is its stops.
+std::size_t PaintHeapBytes(const tiny_skia::Paint& paint) {
+  return std::visit(
+      [](const auto& shader) -> std::size_t {
+        using ShaderType = std::decay_t<decltype(shader)>;
+        if constexpr (std::is_same_v<ShaderType, tiny_skia::LinearGradient> ||
+                      std::is_same_v<ShaderType, tiny_skia::RadialGradient> ||
+                      std::is_same_v<ShaderType, tiny_skia::SweepGradient>) {
+          return shader.base_.stopsByteSize();
+        } else {
+          return 0;
+        }
+      },
+      paint.shader);
+}
+
+std::size_t SlotBytes(const RetainedSpanSlot& slot) {
+  return slot.capture.spans().capacityBytes() + PaintHeapBytes(slot.key.paint) +
+         PaintHeapBytes(slot.capture.paint());
 }
 
 void ReleaseBytes(RetainedSpanDocumentState& state, std::size_t bytes) {
@@ -52,6 +75,10 @@ void OnComputedPathChanged(Registry& registry, Entity entity) {
 }
 
 }  // namespace
+
+std::size_t RetainedEntryBytes(const RetainedSpansComponent& entry) {
+  return sizeof(RetainedSpansComponent) + SlotBytes(entry.fill) + SlotBytes(entry.stroke);
+}
 
 bool operator==(const RetainedSpanKey& lhs, const RetainedSpanKey& rhs) {
   return TransformsEqual(lhs.deviceFromLocal, rhs.deviceFromLocal) && lhs.paint == rhs.paint &&
@@ -92,10 +119,15 @@ RetainedSpanDocumentState& RetainedSpanStateFor(Registry& registry, std::size_t 
 }
 
 void ClearRetainedSpans(Registry& registry) {
-  registry.clear<RetainedSpansComponent>();
-  if (auto* state = registry.ctx().find<RetainedSpanDocumentState>()) {
-    state->liveBytes = 0;
+  // The document state is created by the first retainable draw, so its absence means this
+  // document never retained anything and there is nothing to walk.
+  auto* state = registry.ctx().find<RetainedSpanDocumentState>();
+  if (state == nullptr) {
+    return;
   }
+
+  registry.clear<RetainedSpansComponent>();
+  state->liveBytes = 0;
 }
 
 void EvictRetainedSpansToBudget(Registry& registry, std::uint64_t currentFrame) {
@@ -118,11 +150,11 @@ void EvictRetainedSpansToBudget(Registry& registry, std::uint64_t currentFrame) 
   std::size_t held = 0;
   for (const Entity entity : view) {
     const RetainedSpansComponent& entry = view.get<const RetainedSpansComponent>(entity);
-    held += entry.chargedBytes();
+    held += entry.chargedBytes;
     if (entry.lastUsedFrame >= currentFrame) {
       continue;
     }
-    candidates.push_back(Candidate{entity, entry.lastUsedFrame, entry.chargedBytes()});
+    candidates.push_back(Candidate{entity, entry.lastUsedFrame, entry.chargedBytes});
   }
 
   // An entity can be destroyed without this cache hearing about it, which leaves the running

--- a/donner/svg/renderer/RetainedSpans.cc
+++ b/donner/svg/renderer/RetainedSpans.cc
@@ -133,10 +133,9 @@ void EvictRetainedSpansToBudget(Registry& registry, std::uint64_t currentFrame) 
     return;
   }
 
-  std::sort(candidates.begin(), candidates.end(),
-            [](const Candidate& lhs, const Candidate& rhs) {
-              return lhs.lastUsedFrame < rhs.lastUsedFrame;
-            });
+  std::sort(candidates.begin(), candidates.end(), [](const Candidate& lhs, const Candidate& rhs) {
+    return lhs.lastUsedFrame < rhs.lastUsedFrame;
+  });
 
   for (const Candidate& candidate : candidates) {
     if (state->liveBytes <= state->budgetBytes) {

--- a/donner/svg/renderer/RetainedSpans.h
+++ b/donner/svg/renderer/RetainedSpans.h
@@ -76,9 +76,6 @@ struct RetainedSpanSlot {
   /// Whether `capture` holds a replayable recording.
   bool valid = false;
 
-  /// Bytes this slot is currently charged against the document budget.
-  std::size_t chargedBytes = 0;
-
   /// Drops the recording, keeping the allocation for the next capture.
   void invalidate() { valid = false; }
 };
@@ -113,9 +110,18 @@ struct RetainedSpansComponent {
   /// them would re-capture on every draw, so the entry stops retaining instead.
   bool ambiguous = false;
 
-  /// Bytes both slots are charged against the document budget.
-  [[nodiscard]] std::size_t chargedBytes() const { return fill.chargedBytes + stroke.chargedBytes; }
+  /// Bytes this entry is currently charged against the document budget, refreshed after every
+  /// draw that writes it. @see RetainedEntryBytes.
+  std::size_t chargedBytes = 0;
 };
+
+/// Returns everything an entry holds: recorded coverage, the paints kept beside it, and the
+/// entry itself.
+///
+/// The paints are counted because a gradient paint owns its stop list and an entry keeps two of
+/// them, so a document of many small gradient-painted shapes would otherwise grow the cache in
+/// a way the budget could not see. Recorded coverage still dominates in practice.
+[[nodiscard]] std::size_t RetainedEntryBytes(const RetainedSpansComponent& entry);
 
 /**
  * Document-wide state for retained coverage, stored in the registry context.

--- a/donner/svg/renderer/RetainedSpans.h
+++ b/donner/svg/renderer/RetainedSpans.h
@@ -1,0 +1,183 @@
+#pragma once
+/// @file
+/// Per-shape retained rasterization for the tiny-skia backend.
+///
+/// Scan conversion is the expensive half of a shape draw, and its whole pixel effect is the
+/// sequence of blit calls it makes. Recording that sequence once and replaying it on later
+/// frames turns an unchanged shape into a blit-only draw. This file owns the storage for those
+/// recordings, the key that decides whether a recording still describes the draw the renderer
+/// is about to make, and the memory bound on how much a document may keep.
+///
+/// The correctness rule is one-directional: a recording may be discarded for any reason, but it
+/// may only be replayed when every input the recorded coverage depended on is unchanged. Keys
+/// therefore compare conservatively (bitwise float equality, patterns never equal), and every
+/// input that is re-supplied at replay rather than baked into the coverage (the paint the draw
+/// built its blitter from, the clip mask) is either part of the key or reproduced exactly.
+
+#include <cstdint>
+#include <optional>
+
+#include "donner/base/EcsRegistry.h"
+#include "donner/base/FillRule.h"
+#include "donner/base/Transform.h"
+#include "tiny_skia/Geom.h"
+#include "tiny_skia/Paint.h"
+#include "tiny_skia/SpanCapture.h"
+#include "tiny_skia/Stroke.h"
+
+namespace donner::svg {
+
+/// Everything a captured blit sequence depends on, besides the shape's geometry.
+///
+/// Geometry is deliberately absent: it is tracked by removing a shape's whole retained entry
+/// when its resolved path changes, which costs nothing per frame, rather than by re-comparing
+/// point arrays on every draw. Everything else is small enough to compare directly, so the
+/// renderer never has to reason about which mutation hooks mark which property.
+struct RetainedSpanKey {
+  /// Local-to-device transform the coverage was scan converted with.
+  Transform2d deviceFromLocal;
+
+  /// Paint the draw was handed. The coverage itself carries no color, but the paint decides
+  /// antialiasing, and a draw may derive its blitter's paint from this one (a hairline stroke
+  /// folds its coverage into the shader opacity, and a transformed draw transforms the
+  /// shader), so a replay is only sound while this input is unchanged.
+  tiny_skia::Paint paint;
+
+  /// Stroke configuration, unused by a fill pass.
+  tiny_skia::Stroke stroke;
+
+  /// Identity of the clip mask in effect, or zero for no clip. @see RendererTinySkia's clip
+  /// epoch assignment: equal epochs mean byte-equal masks.
+  std::uint64_t clipEpoch = 0;
+
+  /// Surface the coverage was recorded against. Recorded runs are device-space rectangles that
+  /// nothing re-clips, so a differently sized surface cannot receive them.
+  tiny_skia::IntSize surfaceSize;
+
+  /// Fill rule, unused by a stroke pass.
+  FillRule fillRule = FillRule::NonZero;
+
+  /// Whether the stroke pass replaced closed contours with explicit closing lines, which the
+  /// zero-length-gap dash case does and which changes the outline the stroker expands.
+  bool openDashSeam = false;
+
+  friend bool operator==(const RetainedSpanKey& lhs, const RetainedSpanKey& rhs);
+};
+
+/// One retained fill or stroke pass of one shape.
+struct RetainedSpanSlot {
+  /// Recorded coverage, plus the paint the recorded draw built its blitter from. Kept across
+  /// invalidations so a shape that is rebuilt repeatedly settles into allocation-free captures.
+  tiny_skia::SpanCapture capture;
+
+  /// Inputs `capture` was recorded under. Only meaningful while `valid` is true.
+  RetainedSpanKey key;
+
+  /// Whether `capture` holds a replayable recording.
+  bool valid = false;
+
+  /// Bytes this slot is currently charged against the document budget.
+  std::size_t chargedBytes = 0;
+
+  /// Drops the recording, keeping the allocation for the next capture.
+  void invalidate() { valid = false; }
+};
+
+/**
+ * Retained rasterization output for one shape, attached to the entity its geometry came from.
+ *
+ * Removal is the invalidation mechanism for geometry: `RendererTinySkia` listens on the
+ * resolved-path update and destroy signals and drops this component, so a shape whose outline
+ * changed cannot replay stale coverage. Everything else is decided by comparing
+ * \ref RetainedSpanKey at draw time.
+ *
+ * @ingroup ecs_components
+ */
+struct RetainedSpansComponent {
+  RetainedSpanSlot fill;    ///< Retained fill pass.
+  RetainedSpanSlot stroke;  ///< Retained stroke pass.
+
+  /// Frame index of the most recent draw that read or wrote this entry, used to evict the
+  /// coldest entries first when a document exceeds its budget.
+  std::uint64_t lastUsedFrame = 0;
+
+  /// Frame index this entry last counted a draw in, paired with \ref drawsThisFrame.
+  std::uint64_t drawFrame = 0;
+
+  /// Draws this entry has seen within `drawFrame`.
+  std::uint32_t drawsThisFrame = 0;
+
+  /// Set when one entity is drawn more than once in a single frame, which happens when a
+  /// shape is instanced through a shadow tree or split into separate fill and stroke passes by
+  /// `paint-order`. One entry cannot describe several draws at once, and alternating between
+  /// them would re-capture on every draw, so the entry stops retaining instead.
+  bool ambiguous = false;
+
+  /// Bytes both slots are charged against the document budget.
+  [[nodiscard]] std::size_t chargedBytes() const {
+    return fill.chargedBytes + stroke.chargedBytes;
+  }
+};
+
+/**
+ * Document-wide accounting for retained coverage, stored in the registry context.
+ *
+ * Retained coverage is attacker-influenced: a document chooses how many shapes exist and how
+ * much coverage each produces. The budget here is what keeps that bounded. Exceeding it evicts
+ * the coldest entries, and a working set that does not fit at all turns retention off for the
+ * document rather than growing without limit.
+ */
+struct RetainedSpanBudget {
+  /// Default budget. Sized so a full-viewport document of a few hundred shapes fits while a
+  /// pathological one cannot grow unbounded.
+  static constexpr std::size_t kDefaultBudgetBytes = 32u * 1024u * 1024u;
+
+  /// Bytes currently held by every retained entry in this document.
+  std::size_t liveBytes = 0;
+
+  /// Ceiling on `liveBytes`.
+  std::size_t budgetBytes = kDefaultBudgetBytes;
+
+  /// Set when the working set did not fit the budget, which turns retention off for this
+  /// document until it is reset. Falling back wholesale is cheaper and more predictable than
+  /// re-capturing the same shapes every frame.
+  bool disabled = false;
+
+  /// Entries evicted to stay under budget, across the document's lifetime.
+  std::uint64_t evictions = 0;
+};
+
+/// Counters describing what a renderer's retained coverage did, for tests and benchmarks.
+struct RetainedSpanStats {
+  std::uint64_t replayedDraws = 0;   ///< Draws served from retained coverage.
+  std::uint64_t capturedDraws = 0;   ///< Draws that rasterized and recorded their coverage.
+  std::uint64_t invalidatedDraws = 0;  ///< Captures that replaced a recording whose key changed.
+  std::uint64_t bypassedDraws = 0;   ///< Draws retention did not apply to.
+  /// Draws whose recording was refused at replay, which then rasterized instead. A refusal is
+  /// the surface-size guard doing its job, never a dropped shape.
+  std::uint64_t refusedReplays = 0;
+  /// Draws that could not be recorded (a tiled surface, or a blit the packed record cannot
+  /// hold). The pixels are painted regardless.
+  std::uint64_t unrecordableDraws = 0;
+  std::size_t liveBytes = 0;    ///< Bytes retained by the document at the end of the frame.
+  std::uint64_t evictions = 0;  ///< Entries evicted to stay under budget.
+  bool documentDisabled = false;  ///< Whether the document fell back to immediate mode.
+};
+
+/// Connects the resolved-path invalidation listener to `registry`, once per registry.
+void EnsureRetainedSpanInvalidationWired(Registry& registry);
+
+/// Returns the document's retained-coverage accounting, creating it if needed.
+RetainedSpanBudget& RetainedSpanBudgetFor(Registry& registry, std::size_t budgetBytes);
+
+/// Drops every retained entry in `registry` and resets its accounting.
+void ClearRetainedSpans(Registry& registry);
+
+/// Evicts the coldest entries until the document is under budget.
+///
+/// Entries last used before `currentFrame` go first. When dropping all of those still leaves
+/// the document over budget, its working set does not fit, so retention is disabled for the
+/// document and everything is dropped.
+void EvictRetainedSpansToBudget(Registry& registry, std::uint64_t currentFrame);
+
+}  // namespace donner::svg

--- a/donner/svg/renderer/RetainedSpans.h
+++ b/donner/svg/renderer/RetainedSpans.h
@@ -120,14 +120,18 @@ struct RetainedSpansComponent {
 };
 
 /**
- * Document-wide accounting for retained coverage, stored in the registry context.
+ * Document-wide state for retained coverage, stored in the registry context.
  *
  * Retained coverage is attacker-influenced: a document chooses how many shapes exist and how
  * much coverage each produces. The budget here is what keeps that bounded. Exceeding it evicts
  * the coldest entries, and a working set that does not fit at all turns retention off for the
  * document rather than growing without limit.
+ *
+ * It also issues frame identities, because retained entries belong to the document rather than
+ * to any one renderer: several renderers can draw one document, and each of their frames needs
+ * an identity the others cannot collide with.
  */
-struct RetainedSpanBudget {
+struct RetainedSpanDocumentState {
   /// Default budget. Sized so a full-viewport document of a few hundred shapes fits while a
   /// pathological one cannot grow unbounded.
   static constexpr std::size_t kDefaultBudgetBytes = 32u * 1024u * 1024u;
@@ -145,6 +149,11 @@ struct RetainedSpanBudget {
 
   /// Entries evicted to stay under budget, across the document's lifetime.
   std::uint64_t evictions = 0;
+
+  /// Issues frame identities. Every frame of every renderer drawing this document takes the
+  /// next value, so "already drawn in this frame" cannot be confused with "drawn by another
+  /// renderer".
+  std::uint64_t frameCounter = 0;
 };
 
 /// Counters describing what a renderer's retained coverage did, for tests and benchmarks.
@@ -167,8 +176,8 @@ struct RetainedSpanStats {
 /// Connects the resolved-path invalidation listener to `registry`, once per registry.
 void EnsureRetainedSpanInvalidationWired(Registry& registry);
 
-/// Returns the document's retained-coverage accounting, creating it if needed.
-RetainedSpanBudget& RetainedSpanBudgetFor(Registry& registry, std::size_t budgetBytes);
+/// Returns the document's retained-coverage state, creating it if needed.
+RetainedSpanDocumentState& RetainedSpanStateFor(Registry& registry, std::size_t budgetBytes);
 
 /// Drops every retained entry in `registry` and resets its accounting.
 void ClearRetainedSpans(Registry& registry);

--- a/donner/svg/renderer/RetainedSpans.h
+++ b/donner/svg/renderer/RetainedSpans.h
@@ -114,9 +114,7 @@ struct RetainedSpansComponent {
   bool ambiguous = false;
 
   /// Bytes both slots are charged against the document budget.
-  [[nodiscard]] std::size_t chargedBytes() const {
-    return fill.chargedBytes + stroke.chargedBytes;
-  }
+  [[nodiscard]] std::size_t chargedBytes() const { return fill.chargedBytes + stroke.chargedBytes; }
 };
 
 /**
@@ -162,18 +160,18 @@ struct RetainedSpanDocumentState {
 /// Draw kinds retention does not reach at all (text, images, layer composites) are not counted
 /// here at all, not even as bypassed.
 struct RetainedSpanStats {
-  std::uint64_t replayedDraws = 0;   ///< Passes served from retained coverage.
-  std::uint64_t capturedDraws = 0;   ///< Passes that rasterized and recorded their coverage.
+  std::uint64_t replayedDraws = 0;     ///< Passes served from retained coverage.
+  std::uint64_t capturedDraws = 0;     ///< Passes that rasterized and recorded their coverage.
   std::uint64_t invalidatedDraws = 0;  ///< Captures that replaced a recording whose key changed.
-  std::uint64_t bypassedDraws = 0;   ///< Passes retention did not apply to.
+  std::uint64_t bypassedDraws = 0;     ///< Passes retention did not apply to.
   /// Draws whose recording was refused at replay, which then rasterized instead. A refusal is
   /// the surface-size guard doing its job, never a dropped shape.
   std::uint64_t refusedReplays = 0;
   /// Draws that could not be recorded (a tiled surface, or a blit the packed record cannot
   /// hold). The pixels are painted regardless.
   std::uint64_t unrecordableDraws = 0;
-  std::size_t liveBytes = 0;    ///< Bytes retained by the document at the end of the frame.
-  std::uint64_t evictions = 0;  ///< Entries evicted to stay under budget.
+  std::size_t liveBytes = 0;      ///< Bytes retained by the document at the end of the frame.
+  std::uint64_t evictions = 0;    ///< Entries evicted to stay under budget.
   bool documentDisabled = false;  ///< Whether the document fell back to immediate mode.
 };
 

--- a/donner/svg/renderer/RetainedSpans.h
+++ b/donner/svg/renderer/RetainedSpans.h
@@ -157,11 +157,15 @@ struct RetainedSpanDocumentState {
 };
 
 /// Counters describing what a renderer's retained coverage did, for tests and benchmarks.
+///
+/// Counts are per fill or stroke pass of a shape draw, and cover the frame most recently drawn.
+/// Draw kinds retention does not reach at all (text, images, layer composites) are not counted
+/// here at all, not even as bypassed.
 struct RetainedSpanStats {
-  std::uint64_t replayedDraws = 0;   ///< Draws served from retained coverage.
-  std::uint64_t capturedDraws = 0;   ///< Draws that rasterized and recorded their coverage.
+  std::uint64_t replayedDraws = 0;   ///< Passes served from retained coverage.
+  std::uint64_t capturedDraws = 0;   ///< Passes that rasterized and recorded their coverage.
   std::uint64_t invalidatedDraws = 0;  ///< Captures that replaced a recording whose key changed.
-  std::uint64_t bypassedDraws = 0;   ///< Draws retention did not apply to.
+  std::uint64_t bypassedDraws = 0;   ///< Passes retention did not apply to.
   /// Draws whose recording was refused at replay, which then rasterized instead. A refusal is
   /// the surface-size guard doing its job, never a dropped shape.
   std::uint64_t refusedReplays = 0;

--- a/donner/svg/renderer/benchmarks/EngineCompareBench.cc
+++ b/donner/svg/renderer/benchmarks/EngineCompareBench.cc
@@ -245,7 +245,17 @@ bool applyMutation(donner::svg::SVGDocument& document, const std::string& mode, 
     return false;
   }
 
-  target->setAttribute("transform", toggled ? "translate(1, 0)" : "translate(0, 0)");
+  // Prepend rather than replace: the element may already carry the transform that places the
+  // whole drawing, and overwriting it would change how much of the surface the frame covers,
+  // which is the very thing being timed.
+  const std::optional<donner::RcString> original = target->getAttribute("transform");
+  std::string value = toggled ? "translate(1, 0)" : "translate(0, 0)";
+  if (original.has_value()) {
+    value += " ";
+    value += std::string_view(*original);
+  }
+
+  target->setAttribute("transform", value);
   return true;
 }
 

--- a/donner/svg/renderer/benchmarks/EngineCompareBench.cc
+++ b/donner/svg/renderer/benchmarks/EngineCompareBench.cc
@@ -221,9 +221,14 @@ donner::svg::RendererBitmap renderSettled(Renderer& renderer, donner::svg::SVGDo
 /// transform of everything under it, so nothing about the previous frame's rasterization still
 /// applies. Between them they bracket what an edit can cost.
 ///
+/// Every iteration parses the document again, so the edit is applied once to a document that
+/// has never seen it. Alternating between an edit and an edit-back would leave half the timed
+/// frames identical to the settled frame that precedes them, and the median would report a
+/// blend of the two rather than the cost of a change.
+///
 /// @return false when the document has no element the mode applies to, in which case no
 ///   mutated frame is timed.
-bool applyMutation(donner::svg::SVGDocument& document, const std::string& mode, bool toggled) {
+bool applyMutation(donner::svg::SVGDocument& document, const std::string& mode) {
   if (mode.empty()) {
     return false;
   }
@@ -249,7 +254,7 @@ bool applyMutation(donner::svg::SVGDocument& document, const std::string& mode, 
   // whole drawing, and overwriting it would change how much of the surface the frame covers,
   // which is the very thing being timed.
   const std::optional<donner::RcString> original = target->getAttribute("transform");
-  std::string value = toggled ? "translate(1, 0)" : "translate(0, 0)";
+  std::string value = "translate(1, 0)";
   if (original.has_value()) {
     value += " ";
     value += std::string_view(*original);
@@ -289,7 +294,7 @@ bool runTimedLoop(const Config& config, const std::string& source, MakeRenderer 
 
     double mutatedFrameMs = 0.0;
     bool mutated = false;
-    if (applyMutation(document, config.mutate, (i % 2) == 0)) {
+    if (applyMutation(document, config.mutate)) {
       start = Clock::now();
       const donner::svg::RendererBitmap mutatedBitmap = renderSettled(renderer, document);
       mutatedFrameMs = toMs(Clock::now() - start);

--- a/donner/svg/renderer/benchmarks/EngineCompareBench.cc
+++ b/donner/svg/renderer/benchmarks/EngineCompareBench.cc
@@ -404,23 +404,21 @@ int main(int argc, char* argv[]) {
   std::vector<double> mutatedFrameTimes;
   donner::svg::RendererBitmap finalBitmap;
   if (geodeMode) {
-    if (!runTimedLoop(config, source,
-                      [&sharedDevice] {
-                        return donner::svg::RendererGeode(sharedDevice, /*verbose=*/false);
-                      },
-                      parseTimes, firstFrameTimes, secondFrameTimes, mutatedFrameTimes,
-                      finalBitmap)) {
+    if (!runTimedLoop(
+            config, source,
+            [&sharedDevice] { return donner::svg::RendererGeode(sharedDevice, /*verbose=*/false); },
+            parseTimes, firstFrameTimes, secondFrameTimes, mutatedFrameTimes, finalBitmap)) {
       return 1;
     }
   } else {
-    if (!runTimedLoop(config, source,
-                      [&config] {
-                        donner::svg::RendererTinySkia renderer(/*verbose=*/false);
-                        renderer.setRetainedSpansEnabled(config.retainedSpans);
-                        return renderer;
-                      },
-                      parseTimes, firstFrameTimes, secondFrameTimes, mutatedFrameTimes,
-                      finalBitmap)) {
+    if (!runTimedLoop(
+            config, source,
+            [&config] {
+              donner::svg::RendererTinySkia renderer(/*verbose=*/false);
+              renderer.setRetainedSpansEnabled(config.retainedSpans);
+              return renderer;
+            },
+            parseTimes, firstFrameTimes, secondFrameTimes, mutatedFrameTimes, finalBitmap)) {
       return 1;
     }
   }
@@ -437,13 +435,14 @@ int main(int argc, char* argv[]) {
       return 1;
     }
   } else {
-    if (!runAllocationPass(source,
-                           [&config] {
-                             donner::svg::RendererTinySkia renderer(/*verbose=*/false);
-                             renderer.setRetainedSpansEnabled(config.retainedSpans);
-                             return renderer;
-                           },
-                           parseAllocations, firstAllocations, secondAllocations)) {
+    if (!runAllocationPass(
+            source,
+            [&config] {
+              donner::svg::RendererTinySkia renderer(/*verbose=*/false);
+              renderer.setRetainedSpansEnabled(config.retainedSpans);
+              return renderer;
+            },
+            parseAllocations, firstAllocations, secondAllocations)) {
       return 1;
     }
   }
@@ -461,13 +460,11 @@ int main(int argc, char* argv[]) {
   std::printf(
       "RESULT engine=%.*s setup_ms=%.3f parse_ms=%.3f first_ms=%.3f second_ms=%.3f "
       "mutated_ms=%.3f "
-      "width=%d height=%d rss_before_kb=%" PRIu64 " rss_setup_kb=%" PRIu64
-      " peak_rss_kb=%" PRIu64 " rss_supported=%d pixels_hash=%016" PRIx64
-      " nonzero_bytes=%" PRIu64 "\n",
+      "width=%d height=%d rss_before_kb=%" PRIu64 " rss_setup_kb=%" PRIu64 " peak_rss_kb=%" PRIu64
+      " rss_supported=%d pixels_hash=%016" PRIx64 " nonzero_bytes=%" PRIu64 "\n",
       static_cast<int>(engineName.size()), engineName.data(), setupMs, median(parseTimes),
       median(firstFrameTimes), median(secondFrameTimes), median(mutatedFrameTimes),
-      finalBitmap.dimensions.x,
-      finalBitmap.dimensions.y, static_cast<std::uint64_t>(rssBeforeKb),
+      finalBitmap.dimensions.x, finalBitmap.dimensions.y, static_cast<std::uint64_t>(rssBeforeKb),
       static_cast<std::uint64_t>(rssAfterSetupKb), static_cast<std::uint64_t>(peakRssKb),
       kRssSupported ? 1 : 0, fingerprint.hash, fingerprint.nonzeroBytes);
   if (!geodeMode && config.retainedSpans) {
@@ -481,19 +478,18 @@ int main(int argc, char* argv[]) {
       const donner::svg::RetainedSpanStats coldStats = retainedRenderer.retainedSpanStats();
       retainedRenderer.draw(retainedDocument);
       const donner::svg::RetainedSpanStats steadyStats = retainedRenderer.retainedSpanStats();
-      std::printf("RETAINED engine=%.*s cold_captured=%" PRIu64 " cold_bypassed=%" PRIu64
-                  " steady_replayed=%" PRIu64 " steady_captured=%" PRIu64
-                  " steady_bypassed=%" PRIu64 " live_bytes=%" PRIu64 " evictions=%" PRIu64
-                  " disabled=%d\n",
-                  static_cast<int>(engineName.size()), engineName.data(),
-                  static_cast<std::uint64_t>(coldStats.capturedDraws),
-                  static_cast<std::uint64_t>(coldStats.bypassedDraws),
-                  static_cast<std::uint64_t>(steadyStats.replayedDraws),
-                  static_cast<std::uint64_t>(steadyStats.capturedDraws),
-                  static_cast<std::uint64_t>(steadyStats.bypassedDraws),
-                  static_cast<std::uint64_t>(steadyStats.liveBytes),
-                  static_cast<std::uint64_t>(steadyStats.evictions),
-                  steadyStats.documentDisabled ? 1 : 0);
+      std::printf(
+          "RETAINED engine=%.*s cold_captured=%" PRIu64 " cold_bypassed=%" PRIu64
+          " steady_replayed=%" PRIu64 " steady_captured=%" PRIu64 " steady_bypassed=%" PRIu64
+          " live_bytes=%" PRIu64 " evictions=%" PRIu64 " disabled=%d\n",
+          static_cast<int>(engineName.size()), engineName.data(),
+          static_cast<std::uint64_t>(coldStats.capturedDraws),
+          static_cast<std::uint64_t>(coldStats.bypassedDraws),
+          static_cast<std::uint64_t>(steadyStats.replayedDraws),
+          static_cast<std::uint64_t>(steadyStats.capturedDraws),
+          static_cast<std::uint64_t>(steadyStats.bypassedDraws),
+          static_cast<std::uint64_t>(steadyStats.liveBytes),
+          static_cast<std::uint64_t>(steadyStats.evictions), steadyStats.documentDisabled ? 1 : 0);
     }
   }
 

--- a/donner/svg/renderer/benchmarks/EngineCompareBench.cc
+++ b/donner/svg/renderer/benchmarks/EngineCompareBench.cc
@@ -61,6 +61,13 @@ struct Config {
   std::string input;
   std::string outputPng;
   std::string backend = "geode";
+  /// Retain and replay per-shape coverage (tiny-skia only). Off by default so the reported
+  /// numbers keep meaning the same thing unless the run asks for the retained mode.
+  bool retainedSpans = false;
+  /// Optional third timed frame that follows a document edit, so a run can report what a frame
+  /// costs when something changed rather than only what a settled frame costs. Empty disables
+  /// it; "drag" moves one shape; "pan" moves the whole drawing.
+  std::string mutate;
 };
 
 double toMs(Clock::duration duration) {
@@ -91,6 +98,10 @@ Config parseArgs(int argc, char* argv[]) {
       config.outputPng = arg.substr(9);
     } else if (arg.starts_with("--backend=")) {
       config.backend = arg.substr(10);
+    } else if (arg == "--retained-spans") {
+      config.retainedSpans = true;
+    } else if (arg.starts_with("--mutate=")) {
+      config.mutate = arg.substr(9);
     } else if (config.input.empty()) {
       config.input = arg;
     }
@@ -203,12 +214,47 @@ donner::svg::RendererBitmap renderSettled(Renderer& renderer, donner::svg::SVGDo
   return renderer.takeSnapshot();
 }
 
+/// Edits one element's transform, so the frame after it is a frame where something moved.
+///
+/// "drag" moves a single shape, which is what an editor does while dragging one object: nearly
+/// every shape is unchanged. "pan" moves the outermost group, which changes the device
+/// transform of everything under it, so nothing about the previous frame's rasterization still
+/// applies. Between them they bracket what an edit can cost.
+///
+/// @return false when the document has no element the mode applies to, in which case no
+///   mutated frame is timed.
+bool applyMutation(donner::svg::SVGDocument& document, const std::string& mode, bool toggled) {
+  if (mode.empty()) {
+    return false;
+  }
+
+  std::optional<donner::svg::SVGElement> target;
+  if (mode == "pan") {
+    target = document.querySelector("g");
+  }
+  if (!target.has_value()) {
+    for (const char* selector : {"path", "rect", "circle", "ellipse", "polygon", "g"}) {
+      target = document.querySelector(selector);
+      if (target.has_value()) {
+        break;
+      }
+    }
+  }
+
+  if (!target.has_value()) {
+    return false;
+  }
+
+  target->setAttribute("transform", toggled ? "translate(1, 0)" : "translate(0, 0)");
+  return true;
+}
+
 /// Timed first/second-frame loop. `makeRenderer` constructs a fresh renderer
 /// per iteration, mirroring per-document renderer lifetime in production.
 template <typename MakeRenderer>
 bool runTimedLoop(const Config& config, const std::string& source, MakeRenderer makeRenderer,
                   std::vector<double>& parseTimes, std::vector<double>& firstFrameTimes,
-                  std::vector<double>& secondFrameTimes,
+                  std::vector<double>& secondFrameTimes, std::vector<double>& mutatedFrameTimes,
                   donner::svg::RendererBitmap& finalBitmap) {
   const int total = config.warmup + config.iterations;
   for (int i = 0; i < total; ++i) {
@@ -231,10 +277,26 @@ bool runTimedLoop(const Config& config, const std::string& source, MakeRenderer 
       return false;
     }
 
+    double mutatedFrameMs = 0.0;
+    bool mutated = false;
+    if (applyMutation(document, config.mutate, (i % 2) == 0)) {
+      start = Clock::now();
+      const donner::svg::RendererBitmap mutatedBitmap = renderSettled(renderer, document);
+      mutatedFrameMs = toMs(Clock::now() - start);
+      if (mutatedBitmap.empty()) {
+        std::fprintf(stderr, "renderer returned an empty bitmap\n");
+        return false;
+      }
+      mutated = true;
+    }
+
     if (i >= config.warmup) {
       parseTimes.push_back(parseMs);
       firstFrameTimes.push_back(firstFrameMs);
       secondFrameTimes.push_back(secondFrameMs);
+      if (mutated) {
+        mutatedFrameTimes.push_back(mutatedFrameMs);
+      }
       finalBitmap = std::move(secondBitmap);
     }
   }
@@ -288,7 +350,7 @@ int main(int argc, char* argv[]) {
   if (config.input.empty()) {
     std::fprintf(stderr,
                  "usage: engine_compare_bench [--backend=geode|tiny-skia] [--iterations=N] "
-                 "[--warmup=N] [--output=FILE] SVG\n");
+                 "[--warmup=N] [--output=FILE] [--retained-spans] [--mutate=drag|pan] SVG\n");
     return 2;
   }
   if (config.backend != "geode" && config.backend != "tiny-skia") {
@@ -329,19 +391,26 @@ int main(int argc, char* argv[]) {
   std::vector<double> parseTimes;
   std::vector<double> firstFrameTimes;
   std::vector<double> secondFrameTimes;
+  std::vector<double> mutatedFrameTimes;
   donner::svg::RendererBitmap finalBitmap;
   if (geodeMode) {
     if (!runTimedLoop(config, source,
                       [&sharedDevice] {
                         return donner::svg::RendererGeode(sharedDevice, /*verbose=*/false);
                       },
-                      parseTimes, firstFrameTimes, secondFrameTimes, finalBitmap)) {
+                      parseTimes, firstFrameTimes, secondFrameTimes, mutatedFrameTimes,
+                      finalBitmap)) {
       return 1;
     }
   } else {
     if (!runTimedLoop(config, source,
-                      [] { return donner::svg::RendererTinySkia(/*verbose=*/false); },
-                      parseTimes, firstFrameTimes, secondFrameTimes, finalBitmap)) {
+                      [&config] {
+                        donner::svg::RendererTinySkia renderer(/*verbose=*/false);
+                        renderer.setRetainedSpansEnabled(config.retainedSpans);
+                        return renderer;
+                      },
+                      parseTimes, firstFrameTimes, secondFrameTimes, mutatedFrameTimes,
+                      finalBitmap)) {
       return 1;
     }
   }
@@ -358,7 +427,12 @@ int main(int argc, char* argv[]) {
       return 1;
     }
   } else {
-    if (!runAllocationPass(source, [] { return donner::svg::RendererTinySkia(/*verbose=*/false); },
+    if (!runAllocationPass(source,
+                           [&config] {
+                             donner::svg::RendererTinySkia renderer(/*verbose=*/false);
+                             renderer.setRetainedSpansEnabled(config.retainedSpans);
+                             return renderer;
+                           },
                            parseAllocations, firstAllocations, secondAllocations)) {
       return 1;
     }
@@ -376,14 +450,43 @@ int main(int argc, char* argv[]) {
   const BitmapFingerprint fingerprint = fingerprintBitmap(finalBitmap);
   std::printf(
       "RESULT engine=%.*s setup_ms=%.3f parse_ms=%.3f first_ms=%.3f second_ms=%.3f "
+      "mutated_ms=%.3f "
       "width=%d height=%d rss_before_kb=%" PRIu64 " rss_setup_kb=%" PRIu64
       " peak_rss_kb=%" PRIu64 " rss_supported=%d pixels_hash=%016" PRIx64
       " nonzero_bytes=%" PRIu64 "\n",
       static_cast<int>(engineName.size()), engineName.data(), setupMs, median(parseTimes),
-      median(firstFrameTimes), median(secondFrameTimes), finalBitmap.dimensions.x,
+      median(firstFrameTimes), median(secondFrameTimes), median(mutatedFrameTimes),
+      finalBitmap.dimensions.x,
       finalBitmap.dimensions.y, static_cast<std::uint64_t>(rssBeforeKb),
       static_cast<std::uint64_t>(rssAfterSetupKb), static_cast<std::uint64_t>(peakRssKb),
       kRssSupported ? 1 : 0, fingerprint.hash, fingerprint.nonzeroBytes);
+  if (!geodeMode && config.retainedSpans) {
+    // Untimed pass whose only job is to report what the retained mode held and did on a
+    // settled frame, so the memory the mode costs is measured rather than estimated.
+    donner::svg::SVGDocument retainedDocument;
+    if (parseDocument(source, retainedDocument)) {
+      donner::svg::RendererTinySkia retainedRenderer(/*verbose=*/false);
+      retainedRenderer.setRetainedSpansEnabled(true);
+      retainedRenderer.draw(retainedDocument);
+      const donner::svg::RetainedSpanStats coldStats = retainedRenderer.retainedSpanStats();
+      retainedRenderer.draw(retainedDocument);
+      const donner::svg::RetainedSpanStats steadyStats = retainedRenderer.retainedSpanStats();
+      std::printf("RETAINED engine=%.*s cold_captured=%" PRIu64 " cold_bypassed=%" PRIu64
+                  " steady_replayed=%" PRIu64 " steady_captured=%" PRIu64
+                  " steady_bypassed=%" PRIu64 " live_bytes=%" PRIu64 " evictions=%" PRIu64
+                  " disabled=%d\n",
+                  static_cast<int>(engineName.size()), engineName.data(),
+                  static_cast<std::uint64_t>(coldStats.capturedDraws),
+                  static_cast<std::uint64_t>(coldStats.bypassedDraws),
+                  static_cast<std::uint64_t>(steadyStats.replayedDraws),
+                  static_cast<std::uint64_t>(steadyStats.capturedDraws),
+                  static_cast<std::uint64_t>(steadyStats.bypassedDraws),
+                  static_cast<std::uint64_t>(steadyStats.liveBytes),
+                  static_cast<std::uint64_t>(steadyStats.evictions),
+                  steadyStats.documentDisabled ? 1 : 0);
+    }
+  }
+
   printAllocation(engineName, "setup", setupAllocations);
   printAllocation(engineName, "parse", parseAllocations);
   printAllocation(engineName, "first", firstAllocations);

--- a/donner/svg/renderer/tests/BUILD.bazel
+++ b/donner/svg/renderer/tests/BUILD.bazel
@@ -240,6 +240,21 @@ donner_cc_test(
 )
 
 donner_cc_test(
+    name = "renderer_retained_spans_tests",
+    size = "medium",
+    srcs = ["RendererRetainedSpans_tests.cc"],
+    data = [
+        "//donner/svg/renderer/testdata",
+    ],
+    deps = [
+        "//donner/svg/parser",
+        "//donner/svg/renderer:renderer_tiny_skia",
+        "//donner/svg/tests:parser_test_utils",
+        "@com_google_gtest//:gtest_main",
+    ],
+)
+
+donner_cc_test(
     name = "renderer_tests",
     srcs = [
         "RendererAscii_tests.cc",

--- a/donner/svg/renderer/tests/RendererRetainedSpans_tests.cc
+++ b/donner/svg/renderer/tests/RendererRetainedSpans_tests.cc
@@ -1,0 +1,617 @@
+/// @file
+/// Behavior of the tiny-skia backend's retained rasterization.
+///
+/// Two properties are load-bearing and both are asserted directly rather than inferred. First,
+/// a retained frame is byte-identical to the frame a renderer that never retained anything
+/// would have produced, checked frame by frame over documents covering the retained draw kinds
+/// and the bypassed ones. Second, replay only happens when it is sound: every class of change
+/// that could alter a shape's pixels is mutated in isolation and the frame after it must be
+/// produced by rasterizing, which the counters make observable.
+
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "donner/svg/parser/SVGParser.h"
+#include "donner/svg/renderer/RendererTinySkia.h"
+#include "donner/svg/tests/ParserTestUtils.h"
+
+namespace donner::svg {
+namespace {
+
+SVGDocument parseDocument(std::string_view svg) {
+  ParseWarningSink warningSink;
+  auto parsed = parser::SVGParser::ParseSVG(svg, warningSink);
+  EXPECT_FALSE(parsed.hasError()) << parsed.error();
+  return std::move(parsed).result();
+}
+
+/// Wraps a fragment in a fixed-size document, so a test can describe only the shapes it cares
+/// about.
+SVGDocument parseFragment(std::string_view fragment, int width = 96, int height = 96) {
+  std::ostringstream svg;
+  svg << "<svg xmlns=\"http://www.w3.org/2000/svg\" "
+      << "xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"" << width << "\" height=\""
+      << height << "\">" << fragment << "</svg>";
+  return parseDocument(svg.str());
+}
+
+/// Renders `document` `frames` times through one renderer and returns every frame.
+std::vector<RendererBitmap> renderFrames(SVGDocument& document, int frames, bool retained) {
+  RendererTinySkia renderer;
+  renderer.setRetainedSpansEnabled(retained);
+
+  std::vector<RendererBitmap> bitmaps;
+  bitmaps.reserve(static_cast<std::size_t>(frames));
+  for (int i = 0; i < frames; ++i) {
+    renderer.draw(document);
+    bitmaps.push_back(renderer.takeSnapshot());
+  }
+  return bitmaps;
+}
+
+::testing::AssertionResult BitmapsEqual(const RendererBitmap& lhs, const RendererBitmap& rhs) {
+  if (lhs.dimensions != rhs.dimensions || lhs.rowBytes != rhs.rowBytes) {
+    return ::testing::AssertionFailure()
+           << "dimensions differ: " << lhs.dimensions << " (row " << lhs.rowBytes << ") vs "
+           << rhs.dimensions << " (row " << rhs.rowBytes << ")";
+  }
+  if (lhs.pixels.size() != rhs.pixels.size()) {
+    return ::testing::AssertionFailure()
+           << "pixel buffer sizes differ: " << lhs.pixels.size() << " vs " << rhs.pixels.size();
+  }
+
+  for (std::size_t i = 0; i < lhs.pixels.size(); ++i) {
+    if (lhs.pixels[i] != rhs.pixels[i]) {
+      const std::size_t pixel = i / 4;
+      const int x = static_cast<int>(pixel % static_cast<std::size_t>(lhs.dimensions.x));
+      const int y = static_cast<int>(pixel / static_cast<std::size_t>(lhs.dimensions.x));
+      return ::testing::AssertionFailure()
+             << "first difference at pixel (" << x << ", " << y << ") channel " << (i % 4) << ": "
+             << static_cast<int>(lhs.pixels[i]) << " vs " << static_cast<int>(rhs.pixels[i]);
+    }
+  }
+  return ::testing::AssertionSuccess();
+}
+
+/// Renders the same document with and without retention and compares every frame.
+void ExpectRetainedFramesMatchFresh(SVGDocument& document, int frames = 3) {
+  const std::vector<RendererBitmap> fresh = renderFrames(document, frames, /*retained=*/false);
+  const std::vector<RendererBitmap> retained = renderFrames(document, frames, /*retained=*/true);
+  ASSERT_EQ(fresh.size(), retained.size());
+  for (std::size_t i = 0; i < fresh.size(); ++i) {
+    EXPECT_TRUE(BitmapsEqual(fresh[i], retained[i])) << "frame " << i;
+  }
+}
+
+/// Renders `document` once through a fresh renderer, which is the reference every retained
+/// frame is measured against.
+RendererBitmap renderFresh(SVGDocument& document) {
+  RendererTinySkia renderer;
+  renderer.draw(document);
+  return renderer.takeSnapshot();
+}
+
+std::string readTestFile(const char* path) {
+  std::ifstream file(path, std::ios::binary);
+  EXPECT_TRUE(file.good()) << "unable to open " << path;
+  return std::string(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
+}
+
+constexpr std::string_view kShapes = R"svg(
+    <rect x="4" y="4" width="40" height="30" fill="#ff0000"/>
+    <circle cx="70" cy="20" r="16" fill="#00a000" stroke="#000080" stroke-width="3"/>
+    <path d="M 8 50 L 50 90 L 8 90 Z" fill="#3040ff" fill-opacity="0.6"/>
+    <path d="M 55 55 C 70 45, 90 70, 60 88" fill="none" stroke="#804000" stroke-width="5"/>
+  )svg";
+
+}  // namespace
+
+TEST(RendererRetainedSpans, UnchangedFrameReplaysInsteadOfRasterizing) {
+  SVGDocument document = parseFragment(kShapes);
+
+  RendererTinySkia renderer;
+  renderer.setRetainedSpansEnabled(true);
+
+  renderer.draw(document);
+  const RendererBitmap first = renderer.takeSnapshot();
+  const RetainedSpanStats afterFirst = renderer.retainedSpanStats();
+  EXPECT_GT(afterFirst.capturedDraws, 0u);
+  EXPECT_EQ(afterFirst.replayedDraws, 0u);
+
+  renderer.draw(document);
+  const RendererBitmap second = renderer.takeSnapshot();
+  const RetainedSpanStats afterSecond = renderer.retainedSpanStats();
+
+  EXPECT_EQ(afterSecond.replayedDraws, afterFirst.capturedDraws)
+      << "every draw captured on the first frame must replay on an unchanged second frame";
+  EXPECT_EQ(afterSecond.capturedDraws, 0u) << "an unchanged frame must not rasterize anything";
+  EXPECT_EQ(afterSecond.invalidatedDraws, 0u);
+  EXPECT_EQ(afterSecond.refusedReplays, 0u);
+  EXPECT_TRUE(BitmapsEqual(first, second));
+  EXPECT_GT(afterSecond.liveBytes, 0u);
+}
+
+TEST(RendererRetainedSpans, RetentionIsOffByDefault) {
+  SVGDocument document = parseFragment(kShapes);
+
+  RendererTinySkia renderer;
+  EXPECT_FALSE(renderer.retainedSpansEnabled());
+
+  renderer.draw(document);
+  renderer.draw(document);
+  const RetainedSpanStats stats = renderer.retainedSpanStats();
+  EXPECT_EQ(stats.capturedDraws, 0u);
+  EXPECT_EQ(stats.replayedDraws, 0u);
+  EXPECT_EQ(stats.liveBytes, 0u);
+}
+
+/// The frame-by-frame A/B: every one of these documents renders identically with and without
+/// retention, on the capture frame and on every replay frame after it.
+TEST(RendererRetainedSpans, FramesAreByteIdenticalToFreshRendering) {
+  struct Case {
+    const char* name;
+    std::string_view fragment;
+  };
+
+  const Case cases[] = {
+      {"shapes", kShapes},
+      {"even_odd_fill",
+       R"svg(<path d="M 10 10 H 80 V 80 H 10 Z M 30 30 H 60 V 60 H 30 Z" fill-rule="evenodd"
+            fill="#204080"/>)svg"},
+      {"hairline_stroke",
+       R"svg(<path d="M 5 5 L 90 90" fill="none" stroke="#000000" stroke-width="0.2"/>)svg"},
+      {"dashed_stroke",
+       R"svg(<path d="M 5 40 H 90" fill="none" stroke="#c00000" stroke-width="6"
+            stroke-dasharray="9 4" stroke-dashoffset="2"/>)svg"},
+      {"zero_gap_dash",
+       R"svg(<rect x="10" y="10" width="60" height="60" fill="none" stroke="#008080"
+            stroke-width="4" stroke-dasharray="8 0"/>)svg"},
+      {"round_join_stroke",
+       R"svg(<path d="M 10 80 L 45 10 L 80 80" fill="none" stroke="#602080" stroke-width="12"
+            stroke-linejoin="round" stroke-linecap="round"/>)svg"},
+      {"linear_gradient",
+       R"svg(<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0" stop-color="#ff0000"/><stop offset="1" stop-color="#0000ff"/>
+          </linearGradient></defs>
+          <rect x="5" y="5" width="86" height="86" fill="url(#g)"/>)svg"},
+      {"radial_gradient",
+       R"svg(<defs><radialGradient id="g" cx="0.4" cy="0.4" r="0.6">
+            <stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#004000"/>
+          </radialGradient></defs>
+          <circle cx="48" cy="48" r="40" fill="url(#g)"/>)svg"},
+      {"gradient_stroke",
+       R"svg(<defs><linearGradient id="g"><stop offset="0" stop-color="#ff8000"/>
+            <stop offset="1" stop-color="#0080ff"/></linearGradient></defs>
+          <path d="M 10 48 H 86" fill="none" stroke="url(#g)" stroke-width="14"/>)svg"},
+      {"clipped_shapes",
+       R"svg(<defs><clipPath id="c"><circle cx="48" cy="48" r="30"/></clipPath></defs>
+          <g clip-path="url(#c)"><rect x="0" y="0" width="96" height="96" fill="#802020"/>
+          <path d="M 0 96 L 96 0 L 96 96 Z" fill="#208020"/></g>)svg"},
+      {"nested_clips",
+       R"svg(<defs><clipPath id="a"><rect x="10" y="10" width="70" height="70"/></clipPath>
+          <clipPath id="b"><circle cx="48" cy="48" r="28"/></clipPath></defs>
+          <g clip-path="url(#a)"><g clip-path="url(#b)">
+            <rect x="0" y="0" width="96" height="96" fill="#3060c0"/></g></g>)svg"},
+      {"group_opacity",
+       R"svg(<g opacity="0.5"><rect x="10" y="10" width="50" height="50" fill="#ff0000"/>
+          <rect x="30" y="30" width="50" height="50" fill="#0000ff"/></g>)svg"},
+      {"nested_transforms",
+       R"svg(<g transform="translate(20 10) rotate(15)"><g transform="scale(1.4)">
+          <rect x="0" y="0" width="30" height="30" fill="#008040"/></g></g>)svg"},
+      {"pattern_fill",
+       R"svg(<defs><pattern id="p" width="12" height="12" patternUnits="userSpaceOnUse">
+            <rect width="6" height="6" fill="#c04000"/>
+          </pattern></defs>
+          <rect x="5" y="5" width="86" height="86" fill="url(#p)"/>)svg"},
+      {"instanced_use",
+       R"svg(<defs><path id="s" d="M 0 0 H 30 V 30 H 0 Z" fill="#a02060"/></defs>
+          <use xlink:href="#s" x="5" y="5"/><use xlink:href="#s" x="50" y="50"/>)svg"},
+      {"paint_order",
+       R"svg(<path d="M 20 20 H 76 V 76 H 20 Z" fill="#ffd000" stroke="#202020" stroke-width="10"
+            paint-order="stroke fill"/>)svg"},
+      {"mask",
+       R"svg(<defs><mask id="m"><rect x="0" y="0" width="96" height="48" fill="#ffffff"/></mask>
+          </defs><rect x="0" y="0" width="96" height="96" fill="#0040ff" mask="url(#m)"/>)svg"},
+      {"markers",
+       R"svg(<defs><marker id="m" markerWidth="6" markerHeight="6" refX="3" refY="3">
+            <circle cx="3" cy="3" r="3" fill="#c00060"/></marker></defs>
+          <path d="M 10 10 L 50 50 L 86 20" fill="none" stroke="#202020" stroke-width="2"
+            marker-start="url(#m)" marker-mid="url(#m)" marker-end="url(#m)"/>)svg"},
+      {"empty_document", R"svg(<g/>)svg"},
+  };
+
+  for (const Case& testCase : cases) {
+    SCOPED_TRACE(testCase.name);
+    SVGDocument document = parseFragment(testCase.fragment);
+    ExpectRetainedFramesMatchFresh(document, /*frames=*/4);
+  }
+}
+
+TEST(RendererRetainedSpans, RealDocumentFramesAreByteIdenticalToFreshRendering) {
+  const char* paths[] = {
+      "donner/svg/renderer/testdata/Ghostscript_Tiger.svg",
+      "donner/svg/renderer/testdata/ellipse1.svg",
+      "donner/svg/renderer/testdata/a-fill-rule-001.svg",
+  };
+
+  for (const char* path : paths) {
+    SCOPED_TRACE(path);
+    const std::string source = readTestFile(path);
+    ASSERT_FALSE(source.empty());
+    SVGDocument document = parseDocument(source);
+    ExpectRetainedFramesMatchFresh(document, /*frames=*/3);
+  }
+}
+
+TEST(RendererRetainedSpans, TigerSteadyFrameReplaysEveryDraw) {
+  const std::string source = readTestFile("donner/svg/renderer/testdata/Ghostscript_Tiger.svg");
+  ASSERT_FALSE(source.empty());
+  SVGDocument document = parseDocument(source);
+
+  RendererTinySkia renderer;
+  renderer.setRetainedSpansEnabled(true);
+  renderer.draw(document);
+  const RetainedSpanStats afterFirst = renderer.retainedSpanStats();
+  ASSERT_GT(afterFirst.capturedDraws, 100u) << "the tiger is hundreds of filled and stroked paths";
+  EXPECT_EQ(afterFirst.bypassedDraws, 0u) << "every tiger draw is a retainable root-surface draw";
+
+  renderer.draw(document);
+  const RetainedSpanStats afterSecond = renderer.retainedSpanStats();
+  EXPECT_EQ(afterSecond.capturedDraws, 0u);
+  EXPECT_EQ(afterSecond.replayedDraws, afterFirst.capturedDraws);
+}
+
+namespace {
+
+/// Renders two settled frames with retention on, applies `mutate`, then renders one more.
+///
+/// The returned stats describe that third frame, which is where an invalidation has to show up
+/// as rasterization. The bitmap is compared against a renderer that never retained anything, so
+/// the test fails both when a change is missed (stale pixels) and when it is applied wrongly.
+struct MutationResult {
+  RetainedSpanStats stats;
+  RendererBitmap retained;
+  RendererBitmap fresh;
+};
+
+template <typename MutateFn>
+MutationResult renderThroughMutation(SVGDocument& document, MutateFn&& mutate) {
+  RendererTinySkia renderer;
+  renderer.setRetainedSpansEnabled(true);
+  renderer.draw(document);
+  renderer.draw(document);
+  EXPECT_GT(renderer.retainedSpanStats().replayedDraws, 0u)
+      << "the mutation test needs a populated cache to invalidate";
+
+  mutate();
+
+  renderer.draw(document);
+  MutationResult result;
+  result.stats = renderer.retainedSpanStats();
+  result.retained = renderer.takeSnapshot();
+  result.fresh = renderFresh(document);
+  return result;
+}
+
+void ExpectRasterizedAndCorrect(const MutationResult& result) {
+  EXPECT_GT(result.stats.capturedDraws, 0u)
+      << "the changed shape must rasterize instead of replaying retained coverage";
+  EXPECT_TRUE(BitmapsEqual(result.fresh, result.retained));
+}
+
+}  // namespace
+
+TEST(RendererRetainedSpans, GeometryEditFallsBackToRasterizing) {
+  SVGDocument document = parseFragment(
+      R"svg(<path id="p" d="M 10 10 H 70 V 70 H 10 Z" fill="#20a020"/>)svg");
+  auto path = document.querySelector("#p");
+  ASSERT_TRUE(path.has_value());
+
+  const MutationResult result = renderThroughMutation(
+      document, [&] { path->setAttribute("d", "M 20 20 H 86 V 86 H 20 Z"); });
+  ExpectRasterizedAndCorrect(result);
+  EXPECT_EQ(result.stats.invalidatedDraws, 0u)
+      << "a geometry change drops the whole entry, so the redraw is a fresh capture rather "
+         "than a key mismatch";
+}
+
+TEST(RendererRetainedSpans, TransformChangeFallsBackToRasterizing) {
+  SVGDocument document =
+      parseFragment(R"svg(<rect id="r" x="10" y="10" width="40" height="40" fill="#a02020"/>)svg");
+  auto rect = document.querySelector("#r");
+  ASSERT_TRUE(rect.has_value());
+
+  const MutationResult result = renderThroughMutation(
+      document, [&] { rect->setAttribute("transform", "translate(20, 15)"); });
+  ExpectRasterizedAndCorrect(result);
+  EXPECT_GT(result.stats.invalidatedDraws, 0u)
+      << "the geometry is unchanged, so the transform must be caught by the retained key";
+}
+
+TEST(RendererRetainedSpans, SolidPaintChangeFallsBackToRasterizing) {
+  SVGDocument document =
+      parseFragment(R"svg(<rect id="r" x="10" y="10" width="60" height="60" fill="#a02020"/>)svg");
+  auto rect = document.querySelector("#r");
+  ASSERT_TRUE(rect.has_value());
+
+  const MutationResult result =
+      renderThroughMutation(document, [&] { rect->setAttribute("fill", "#2020a0"); });
+  ExpectRasterizedAndCorrect(result);
+  EXPECT_GT(result.stats.invalidatedDraws, 0u);
+}
+
+TEST(RendererRetainedSpans, GradientStopChangeFallsBackToRasterizing) {
+  SVGDocument document = parseFragment(
+      R"svg(<defs><linearGradient id="g"><stop id="s0" offset="0" stop-color="#ff0000"/>
+           <stop id="s1" offset="1" stop-color="#0000ff"/></linearGradient></defs>
+         <rect x="5" y="5" width="86" height="86" fill="url(#g)"/>)svg");
+  auto stop0 = document.querySelector("#s0");
+  ASSERT_TRUE(stop0.has_value());
+
+  const MutationResult result =
+      renderThroughMutation(document, [&] { stop0->setAttribute("stop-color", "#00ff00"); });
+  ExpectRasterizedAndCorrect(result);
+  EXPECT_GT(result.stats.invalidatedDraws, 0u)
+      << "a stop edit changes no geometry, so only the retained key's paint comparison can "
+         "catch it";
+}
+
+TEST(RendererRetainedSpans, StrokeWidthChangeFallsBackToRasterizing) {
+  SVGDocument document = parseFragment(
+      R"svg(<path id="p" d="M 10 48 H 86" fill="none" stroke="#202080" stroke-width="4"/>)svg");
+  auto path = document.querySelector("#p");
+  ASSERT_TRUE(path.has_value());
+
+  const MutationResult result =
+      renderThroughMutation(document, [&] { path->setAttribute("stroke-width", "20"); });
+  ExpectRasterizedAndCorrect(result);
+  EXPECT_GT(result.stats.invalidatedDraws, 0u);
+}
+
+TEST(RendererRetainedSpans, ClipChangeFallsBackToRasterizing) {
+  SVGDocument document = parseFragment(
+      R"svg(<defs><clipPath id="c"><rect id="cr" x="0" y="0" width="48" height="96"/></clipPath>
+          </defs>
+         <rect x="0" y="0" width="96" height="96" fill="#206080" clip-path="url(#c)"/>)svg");
+  auto clipRect = document.querySelector("#cr");
+  ASSERT_TRUE(clipRect.has_value());
+
+  const MutationResult result =
+      renderThroughMutation(document, [&] { clipRect->setAttribute("width", "80"); });
+  ExpectRasterizedAndCorrect(result);
+  EXPECT_GT(result.stats.invalidatedDraws, 0u)
+      << "the clipped shape's own geometry and paint are unchanged, so the clip identity in the "
+         "retained key is what has to notice";
+}
+
+TEST(RendererRetainedSpans, SurfaceResizeFallsBackToRasterizing) {
+  SVGDocument document =
+      parseFragment(R"svg(<rect x="10" y="10" width="60" height="60" fill="#804020"/>)svg");
+
+  RendererTinySkia renderer;
+  renderer.setRetainedSpansEnabled(true);
+  renderer.draw(document);
+  renderer.draw(document);
+  ASSERT_GT(renderer.retainedSpanStats().replayedDraws, 0u);
+
+  document.setCanvasSize(140, 140);
+  renderer.draw(document);
+  const RetainedSpanStats stats = renderer.retainedSpanStats();
+  const RendererBitmap resized = renderer.takeSnapshot();
+
+  EXPECT_GT(stats.capturedDraws, 0u);
+  EXPECT_EQ(resized.dimensions, Vector2i(140, 140));
+  EXPECT_TRUE(BitmapsEqual(renderFresh(document), resized));
+}
+
+/// The surface binding is a memory-safety boundary, not bookkeeping: recorded runs are
+/// device-space rectangles that nothing re-clips, so replaying them onto a smaller surface
+/// reaches the blitter with an origin past the buffer. The retained key normally notices a
+/// resize before the guard is reached, so this test drives the renderer's draw interface
+/// directly, keeping every other input identical across two differently sized frames, and then
+/// makes the key claim the recording came from the second frame's surface. The guard underneath
+/// has to refuse anyway, and refusing has to draw the shape rather than drop it.
+TEST(RendererRetainedSpans, ReplayRefusesRunsRecordedAgainstAnotherSurface) {
+  SVGDocument document =
+      parseFragment(R"svg(<rect id="r" x="10" y="10" width="60" height="60" fill="#3070c0"/>)svg");
+  auto rect = document.querySelector("#r");
+  ASSERT_TRUE(rect.has_value());
+  const EntityHandle handle = rect->unsafeEntityHandle();
+
+  const Path geometry = PathBuilder()
+                            .moveTo(Vector2d(10, 10))
+                            .lineTo(Vector2d(70, 10))
+                            .lineTo(Vector2d(70, 70))
+                            .lineTo(Vector2d(10, 70))
+                            .closePath()
+                            .build();
+  PathShape shape;
+  shape.path = &geometry;
+  shape.sourceEntity = handle;
+
+  PaintParams paint;
+  paint.fill = PaintServer::Solid(css::Color(css::RGBA(0x30, 0x70, 0xC0, 0xFF)));
+  paint.stroke = PaintServer::None();
+
+  const auto drawOneFrame = [&](RendererTinySkia& renderer, int size) {
+    RenderViewport viewport;
+    viewport.size = Vector2d(size, size);
+    renderer.beginFrame(viewport);
+    renderer.setTransform(Transform2d());
+    renderer.setPaint(paint);
+    renderer.drawPath(shape, StrokeParams());
+    renderer.endFrame();
+  };
+
+  RendererTinySkia renderer;
+  renderer.setRetainedSpansEnabled(true);
+  drawOneFrame(renderer, 140);
+  ASSERT_EQ(renderer.retainedSpanStats().capturedDraws, 1u);
+
+  Registry& registry = document.registry();
+  ASSERT_TRUE(registry.all_of<RetainedSpansComponent>(handle.entity()));
+  RetainedSpansComponent& retained = registry.get<RetainedSpansComponent>(handle.entity());
+  ASSERT_TRUE(retained.fill.valid);
+  // Everything else about the next frame's draw is identical by construction, so claiming the
+  // recording came from that frame's surface leaves the recording itself as the only thing
+  // standing between a 140-wide run and a 60-wide buffer.
+  retained.fill.key.surfaceSize = tiny_skia::IntSize(60, 60);
+
+  drawOneFrame(renderer, 60);
+  const RetainedSpanStats stats = renderer.retainedSpanStats();
+  const RendererBitmap shrunk = renderer.takeSnapshot();
+
+  EXPECT_EQ(stats.refusedReplays, 1u) << "the surface-size guard must refuse the stale runs";
+  EXPECT_EQ(stats.capturedDraws, 1u) << "a refusal must fall back to rasterizing, not to nothing";
+  EXPECT_EQ(shrunk.dimensions, Vector2i(60, 60));
+
+  // The refused frame must look exactly like the same draw on a renderer that never retained
+  // anything, which is what proves the fallback painted the shape.
+  RendererTinySkia reference;
+  drawOneFrame(reference, 60);
+  EXPECT_TRUE(BitmapsEqual(reference.takeSnapshot(), shrunk));
+}
+
+TEST(RendererRetainedSpans, InstancedShapeStopsRetaining) {
+  SVGDocument document = parseFragment(
+      R"svg(<defs><path id="s" d="M 0 0 H 30 V 30 H 0 Z" fill="#a02060"/></defs>
+         <use xlink:href="#s" x="5" y="5"/><use xlink:href="#s" x="50" y="50"/>)svg");
+
+  RendererTinySkia renderer;
+  renderer.setRetainedSpansEnabled(true);
+  renderer.draw(document);
+  renderer.draw(document);
+  renderer.draw(document);
+  const RetainedSpanStats stats = renderer.retainedSpanStats();
+
+  EXPECT_GT(stats.bypassedDraws, 0u)
+      << "one entity drawn twice in a frame cannot be described by one retained entry";
+  EXPECT_TRUE(BitmapsEqual(renderFresh(document), renderer.takeSnapshot()));
+}
+
+TEST(RendererRetainedSpans, PatternPaintIsNotRetained) {
+  SVGDocument document = parseFragment(
+      R"svg(<defs><pattern id="p" width="12" height="12" patternUnits="userSpaceOnUse">
+           <rect width="6" height="6" fill="#c04000"/></pattern></defs>
+         <rect x="5" y="5" width="86" height="86" fill="url(#p)"/>)svg");
+
+  RendererTinySkia renderer;
+  renderer.setRetainedSpansEnabled(true);
+  renderer.draw(document);
+  renderer.draw(document);
+  const RetainedSpanStats stats = renderer.retainedSpanStats();
+
+  EXPECT_EQ(stats.replayedDraws, 0u)
+      << "a pattern's pixels live outside the paint, so its coverage is never replayed";
+  EXPECT_TRUE(BitmapsEqual(renderFresh(document), renderer.takeSnapshot()));
+}
+
+TEST(RendererRetainedSpans, BudgetEvictsColdestEntries) {
+  SVGDocument document = parseFragment(kShapes);
+
+  RendererTinySkia renderer;
+  renderer.setRetainedSpansEnabled(true);
+  renderer.draw(document);
+  const std::size_t settledBytes = renderer.retainedSpanStats().liveBytes;
+  ASSERT_GT(settledBytes, 0u);
+
+  // A budget under what one frame needs cannot hold the working set, so the document gives up
+  // rather than evict and re-capture the same shapes every frame.
+  RendererTinySkia bounded;
+  bounded.setRetainedSpansEnabled(true);
+  bounded.setRetainedSpanBudgetBytes(settledBytes / 4);
+  bounded.draw(document);
+  bounded.draw(document);
+  const RetainedSpanStats stats = bounded.retainedSpanStats();
+
+  EXPECT_TRUE(stats.documentDisabled)
+      << "a working set that does not fit the budget must turn retention off for the document"
+      << " (settled " << settledBytes << " bytes, budget " << (settledBytes / 4) << ", live "
+      << stats.liveBytes << ", evictions " << stats.evictions << ", captured "
+      << stats.capturedDraws << ", replayed " << stats.replayedDraws << ", bypassed "
+      << stats.bypassedDraws << ")";
+  EXPECT_LE(stats.liveBytes, settledBytes / 4);
+  EXPECT_TRUE(BitmapsEqual(renderFresh(document), bounded.takeSnapshot()));
+}
+
+TEST(RendererRetainedSpans, BudgetRaiseLetsTheDocumentRetainAgain) {
+  SVGDocument document = parseFragment(kShapes);
+
+  RendererTinySkia renderer;
+  renderer.setRetainedSpansEnabled(true);
+  renderer.setRetainedSpanBudgetBytes(64);
+  renderer.draw(document);
+  renderer.draw(document);
+  ASSERT_TRUE(renderer.retainedSpanStats().documentDisabled);
+
+  renderer.setRetainedSpanBudgetBytes(RetainedSpanDocumentState::kDefaultBudgetBytes);
+  renderer.draw(document);
+  renderer.draw(document);
+  const RetainedSpanStats stats = renderer.retainedSpanStats();
+
+  EXPECT_FALSE(stats.documentDisabled);
+  EXPECT_GT(stats.replayedDraws, 0u);
+  EXPECT_TRUE(BitmapsEqual(renderFresh(document), renderer.takeSnapshot()));
+}
+
+TEST(RendererRetainedSpans, EvictedShapeRendersFromRasterization) {
+  // Two documents' worth of shapes in one, with a budget that holds most but not all of them,
+  // so eviction runs without the working set being hopeless.
+  SVGDocument document = parseFragment(kShapes);
+
+  RendererTinySkia measure;
+  measure.setRetainedSpansEnabled(true);
+  measure.draw(document);
+  const std::size_t settledBytes = measure.retainedSpanStats().liveBytes;
+  ASSERT_GT(settledBytes, 0u);
+
+  RendererTinySkia renderer;
+  renderer.setRetainedSpansEnabled(true);
+  renderer.draw(document);
+  // Shrinking the budget after the entries exist evicts the ones not drawn in the frame that
+  // notices, which is every entry from an earlier frame.
+  renderer.setRetainedSpanBudgetBytes(settledBytes / 2);
+  renderer.draw(document);
+  const RetainedSpanStats stats = renderer.retainedSpanStats();
+
+  EXPECT_TRUE(stats.evictions > 0u || stats.documentDisabled)
+      << "settled " << settledBytes << " bytes, budget " << (settledBytes / 2) << ", live "
+      << stats.liveBytes << ", captured " << stats.capturedDraws << ", replayed "
+      << stats.replayedDraws << ", bypassed " << stats.bypassedDraws;
+  EXPECT_TRUE(BitmapsEqual(renderFresh(document), renderer.takeSnapshot()));
+}
+
+TEST(RendererRetainedSpans, AnimatedDocumentStaysCorrectAcrossTimeSamples) {
+  parser::SVGParser::Options options;
+  options.enableExperimental = true;
+  SVGDocument document = instantiateSubtree(
+      R"svg(<rect x="0" y="0" width="4" height="16" fill="black">
+           <animate attributeName="width" from="4" to="12" begin="0s" dur="2s" fill="freeze"/>
+         </rect>)svg",
+      options, Vector2i(16, 16));
+
+  RendererTinySkia renderer;
+  renderer.setRetainedSpansEnabled(true);
+
+  for (const double time : {0.0, 0.5, 1.0, 1.0, 3.0}) {
+    SCOPED_TRACE(time);
+    document.setTime(time);
+    renderer.draw(document);
+    const RendererBitmap retained = renderer.takeSnapshot();
+
+    SVGDocument reference = instantiateSubtree(
+        R"svg(<rect x="0" y="0" width="4" height="16" fill="black">
+             <animate attributeName="width" from="4" to="12" begin="0s" dur="2s" fill="freeze"/>
+           </rect>)svg",
+        options, Vector2i(16, 16));
+    reference.setTime(time);
+    EXPECT_TRUE(BitmapsEqual(renderFresh(reference), retained));
+  }
+}
+
+}  // namespace donner::svg

--- a/donner/svg/renderer/tests/RendererRetainedSpans_tests.cc
+++ b/donner/svg/renderer/tests/RendererRetainedSpans_tests.cc
@@ -586,6 +586,53 @@ TEST(RendererRetainedSpans, EvictedShapeRendersFromRasterization) {
   EXPECT_TRUE(BitmapsEqual(renderFresh(document), renderer.takeSnapshot()));
 }
 
+TEST(RendererRetainedSpans, TurningRetentionOffHandsBackWhatTheDocumentHeld) {
+  SVGDocument document = parseFragment(kShapes);
+
+  RendererTinySkia renderer;
+  renderer.setRetainedSpansEnabled(true);
+  renderer.draw(document);
+  ASSERT_GT(renderer.retainedSpanStats().liveBytes, 0u);
+  ASSERT_FALSE(document.registry().view<RetainedSpansComponent>().empty());
+
+  renderer.setRetainedSpansEnabled(false);
+  renderer.draw(document);
+
+  EXPECT_TRUE(document.registry().view<RetainedSpansComponent>().empty())
+      << "entries live on the document, so a renderer that stops retaining has to hand them "
+         "back rather than leave them for nothing to replay";
+  const auto* state = document.registry().ctx().find<RetainedSpanDocumentState>();
+  ASSERT_NE(state, nullptr);
+  EXPECT_EQ(state->liveBytes, 0u);
+  EXPECT_TRUE(BitmapsEqual(renderFresh(document), renderer.takeSnapshot()));
+}
+
+TEST(RendererRetainedSpans, RetainedBytesCountThePaintsKeptBesideTheCoverage) {
+  SVGDocument document = parseFragment(
+      R"svg(<defs><linearGradient id="g">
+             <stop offset="0" stop-color="#ff0000"/>
+             <stop offset="0.5" stop-color="#00ff00"/>
+             <stop offset="1" stop-color="#0000ff"/>
+           </linearGradient></defs>
+          <rect id="r" x="5" y="5" width="86" height="86" fill="url(#g)"/>)svg");
+  auto rect = document.querySelector("#r");
+  ASSERT_TRUE(rect.has_value());
+
+  RendererTinySkia renderer;
+  renderer.setRetainedSpansEnabled(true);
+  renderer.draw(document);
+
+  const RetainedSpansComponent& entry =
+      document.registry().get<RetainedSpansComponent>(rect->unsafeEntityHandle().entity());
+  ASSERT_TRUE(entry.fill.valid);
+
+  const std::size_t coverageBytes = entry.fill.capture.spans().capacityBytes();
+  EXPECT_GT(RetainedEntryBytes(entry), coverageBytes + sizeof(RetainedSpansComponent))
+      << "a gradient paint owns its stop list, and the entry keeps two paints, so the budget "
+         "has to see more than the recorded coverage";
+  EXPECT_EQ(entry.chargedBytes, RetainedEntryBytes(entry));
+}
+
 TEST(RendererRetainedSpans, AnimatedDocumentStaysCorrectAcrossTimeSamples) {
   parser::SVGParser::Options options;
   options.enableExperimental = true;

--- a/donner/svg/renderer/tests/RendererRetainedSpans_tests.cc
+++ b/donner/svg/renderer/tests/RendererRetainedSpans_tests.cc
@@ -307,13 +307,13 @@ void ExpectRasterizedAndCorrect(const MutationResult& result) {
 }  // namespace
 
 TEST(RendererRetainedSpans, GeometryEditFallsBackToRasterizing) {
-  SVGDocument document = parseFragment(
-      R"svg(<path id="p" d="M 10 10 H 70 V 70 H 10 Z" fill="#20a020"/>)svg");
+  SVGDocument document =
+      parseFragment(R"svg(<path id="p" d="M 10 10 H 70 V 70 H 10 Z" fill="#20a020"/>)svg");
   auto path = document.querySelector("#p");
   ASSERT_TRUE(path.has_value());
 
-  const MutationResult result = renderThroughMutation(
-      document, [&] { path->setAttribute("d", "M 20 20 H 86 V 86 H 20 Z"); });
+  const MutationResult result =
+      renderThroughMutation(document, [&] { path->setAttribute("d", "M 20 20 H 86 V 86 H 20 Z"); });
   ExpectRasterizedAndCorrect(result);
   EXPECT_EQ(result.stats.invalidatedDraws, 0u)
       << "a geometry change drops the whole entry, so the redraw is a fresh capture rather "

--- a/donner/svg/renderer/tests/RendererRetainedSpans_tests.cc
+++ b/donner/svg/renderer/tests/RendererRetainedSpans_tests.cc
@@ -633,6 +633,99 @@ TEST(RendererRetainedSpans, RetainedBytesCountThePaintsKeptBesideTheCoverage) {
   EXPECT_EQ(entry.chargedBytes, RetainedEntryBytes(entry));
 }
 
+// Retention and the per-entity conversion caches sit on the same draw and the same entities, so
+// what each does to the other's observable behavior is pinned here rather than assumed.
+
+namespace {
+
+/// A 2x2 solid red PNG as a data URI, so the image loads with no external resources.
+constexpr std::string_view kRedImageDataUri =
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAEElEQVR4nGP4z8AARAwQCgAf7gP9i18U1AAAAABJRU5E"
+    "rkJggg==";
+
+SVGDocument shapesAndImageDocument() {
+  return parseFragment(std::string(R"svg(<path id="p" d="M 8 8 L 60 8 L 60 60 Z" fill="black"/>
+         <rect x="10" y="10" width="30" height="30" fill="red"/>
+         <circle cx="70" cy="70" r="16" fill="blue"/>
+         <image id="i" x="60" y="0" width="30" height="30" href=")svg") +
+                       std::string(kRedImageDataUri) + R"svg(" />)svg");
+}
+
+}  // namespace
+
+TEST(RendererRetainedSpans, SettledFrameConvertsNothingWithRetentionEnabled) {
+  SVGDocument document = shapesAndImageDocument();
+
+  RendererTinySkia renderer;
+  renderer.setRetainedSpansEnabled(true);
+  renderer.draw(document);
+
+  EXPECT_GT(renderer.frameCounters().pathConversions, 0u)
+      << "the capture frame rasterizes, so it needs the outlines and converts them once";
+  EXPECT_GT(renderer.frameCounters().imagePremultiplies, 0u);
+  EXPECT_GT(renderer.retainedSpanStats().capturedDraws, 0u);
+
+  renderer.draw(document);
+
+  EXPECT_EQ(renderer.frameCounters().pathConversions, 0u)
+      << "a replayed frame needs no outline at all, so retention must not reach the conversion "
+         "cache and must not convert on its own";
+  EXPECT_EQ(renderer.frameCounters().imagePremultiplies, 0u)
+      << "images bypass retention, so their cache has to keep serving them";
+  EXPECT_GT(renderer.retainedSpanStats().replayedDraws, 0u);
+  EXPECT_TRUE(BitmapsEqual(renderFresh(document), renderer.takeSnapshot()));
+}
+
+TEST(RendererRetainedSpans, RecaptureTakesTheCachedOutlineInsteadOfConvertingAgain) {
+  SVGDocument document =
+      parseFragment(R"svg(<rect id="r" x="10" y="10" width="40" height="40" fill="#a02020"/>)svg");
+  auto rect = document.querySelector("#r");
+  ASSERT_TRUE(rect.has_value());
+
+  RendererTinySkia renderer;
+  renderer.setRetainedSpansEnabled(true);
+  renderer.draw(document);
+  renderer.draw(document);
+  ASSERT_EQ(renderer.frameCounters().pathConversions, 0u);
+
+  // A transform change invalidates the recording but not the outline, which is the case where
+  // the two caches have to compose: the shape rasterizes again and takes its outline from the
+  // conversion cache rather than converting a second time.
+  rect->setAttribute("transform", "translate(12, 9)");
+  renderer.draw(document);
+
+  EXPECT_GT(renderer.retainedSpanStats().capturedDraws, 0u);
+  EXPECT_EQ(renderer.frameCounters().pathConversions, 0u)
+      << "re-rasterizing must not bypass the conversion cache";
+  EXPECT_TRUE(BitmapsEqual(renderFresh(document), renderer.takeSnapshot()));
+}
+
+TEST(RendererRetainedSpans, GeometryEditDropsBothCachesForTheSameEntity) {
+  SVGDocument document =
+      parseFragment(R"svg(<path id="p" d="M 10 10 H 70 V 70 H 10 Z" fill="#20a020"/>)svg");
+  auto path = document.querySelector("#p");
+  ASSERT_TRUE(path.has_value());
+
+  RendererTinySkia renderer;
+  renderer.setRetainedSpansEnabled(true);
+  renderer.draw(document);
+  renderer.draw(document);
+  ASSERT_EQ(renderer.frameCounters().pathConversions, 0u);
+  ASSERT_GT(renderer.retainedSpanStats().replayedDraws, 0u);
+
+  path->setAttribute("d", "M 20 20 H 86 V 86 H 20 Z");
+  renderer.draw(document);
+
+  // Both caches listen on the resolved-path signals. Both listeners have to run: one converting
+  // the new outline, the other refusing to replay coverage of the old one.
+  EXPECT_GT(renderer.frameCounters().pathConversions, 0u)
+      << "the conversion cache kept the pre-edit outline";
+  EXPECT_GT(renderer.retainedSpanStats().capturedDraws, 0u)
+      << "the retained cache kept the pre-edit coverage";
+  EXPECT_TRUE(BitmapsEqual(renderFresh(document), renderer.takeSnapshot()));
+}
+
 TEST(RendererRetainedSpans, AnimatedDocumentStaysCorrectAcrossTimeSamples) {
   parser::SVGParser::Options options;
   options.enableExperimental = true;

--- a/donner/svg/renderer/tests/RendererTestBackendTinySkia.cc
+++ b/donner/svg/renderer/tests/RendererTestBackendTinySkia.cc
@@ -1,9 +1,89 @@
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <string_view>
+
 #include "donner/svg/renderer/RendererTinySkia.h"
 #include "donner/svg/renderer/tests/RendererTestBackend.h"
 
 namespace donner::svg {
 
 namespace {
+
+/// How the environment asked retained rasterization to be exercised.
+///
+/// A suite that draws each document once only exercises the recording half of retained
+/// rasterization, so the mode is selected per run rather than compiled in:
+///
+/// - `off`: the default. One frame, no retention.
+/// - `replay` (`DONNER_TINYSKIA_RETAINED=1`): draw a second frame through the warmed cache and
+///   return that one, so the whole corpus is checked against its goldens with replayed
+///   coverage.
+/// - `compare` (`DONNER_TINYSKIA_RETAINED=compare`): additionally render the same document on a
+///   renderer that retains nothing and fail unless the two frames are byte-equal, which turns
+///   every corpus document into a retained-versus-fresh identity case.
+enum class RetainedMode { Off, Replay, Compare };
+
+RetainedMode RequestedRetainedMode() {
+  static const RetainedMode mode = [] {
+    const char* value = std::getenv("DONNER_TINYSKIA_RETAINED");
+    if (value == nullptr) {
+      return RetainedMode::Off;
+    }
+
+    const std::string_view text(value);
+    if (text == "compare") {
+      return RetainedMode::Compare;
+    }
+    return text == "1" ? RetainedMode::Replay : RetainedMode::Off;
+  }();
+  return mode;
+}
+
+/// Reports the first differing byte, so a corpus-wide failure names a pixel instead of a file.
+void ExpectBitmapsEqual(const RendererBitmap& fresh, const RendererBitmap& retained) {
+  ASSERT_EQ(fresh.dimensions, retained.dimensions);
+  ASSERT_EQ(fresh.rowBytes, retained.rowBytes);
+  ASSERT_EQ(fresh.pixels.size(), retained.pixels.size());
+
+  for (std::size_t i = 0; i < fresh.pixels.size(); ++i) {
+    if (fresh.pixels[i] != retained.pixels[i]) {
+      const std::size_t pixel = i / 4;
+      const int x = static_cast<int>(pixel % static_cast<std::size_t>(fresh.dimensions.x));
+      const int y = static_cast<int>(pixel / static_cast<std::size_t>(fresh.dimensions.x));
+      FAIL() << "retained rendering differs from fresh rendering at pixel (" << x << ", " << y
+             << ") channel " << (i % 4) << ": " << static_cast<int>(fresh.pixels[i]) << " vs "
+             << static_cast<int>(retained.pixels[i]);
+    }
+  }
+}
+
+/// Draws `document` and returns the frame the current mode is meant to check.
+RendererBitmap RenderSettled(RendererTinySkia& renderer, SVGDocument& document) {
+  const RetainedMode mode = RequestedRetainedMode();
+  if (mode == RetainedMode::Off) {
+    renderer.draw(document);
+    return renderer.takeSnapshot();
+  }
+
+  RendererBitmap fresh;
+  if (mode == RetainedMode::Compare) {
+    RendererTinySkia freshRenderer;
+    freshRenderer.setAntialias(renderer.antialias());
+    freshRenderer.draw(document);
+    fresh = freshRenderer.takeSnapshot();
+  }
+
+  renderer.setRetainedSpansEnabled(true);
+  renderer.draw(document);
+  renderer.draw(document);
+  RendererBitmap retained = renderer.takeSnapshot();
+
+  if (mode == RetainedMode::Compare) {
+    ExpectBitmapsEqual(fresh, retained);
+  }
+  return retained;
+}
 
 bool TinySkiaSupportsFeature(RendererBackendFeature feature) {
   switch (feature) {
@@ -29,20 +109,20 @@ bool TinySkiaSupportsFeature(RendererBackendFeature feature) {
 }
 
 std::unique_ptr<RendererInterface> TinySkiaCreateInstance(bool verbose) {
-  return std::make_unique<RendererTinySkia>(verbose);
+  auto renderer = std::make_unique<RendererTinySkia>(verbose);
+  renderer->setRetainedSpansEnabled(RequestedRetainedMode() != RetainedMode::Off);
+  return renderer;
 }
 
 RendererBitmap TinySkiaRender(SVGDocument& document, bool verbose) {
   RendererTinySkia renderer(verbose);
-  renderer.draw(document);
-  return renderer.takeSnapshot();
+  return RenderSettled(renderer, document);
 }
 
 RendererBitmap TinySkiaRenderForAscii(SVGDocument& document) {
   RendererTinySkia renderer;
   renderer.setAntialias(false);
-  renderer.draw(document);
-  return renderer.takeSnapshot();
+  return RenderSettled(renderer, document);
 }
 
 }  // namespace

--- a/third_party/tiny-skia-cpp/src/tiny_skia/Paint.h
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/Paint.h
@@ -38,6 +38,15 @@ struct Paint {
 
   /// Returns true if the shader is a solid color.
   [[nodiscard]] bool isSolidColor() const { return std::holds_alternative<Color>(shader); }
+
+  /// Two paints compare equal when a draw with either would build the same blitter.
+  ///
+  /// This is what lets a caller keep work derived from a paint and decide later whether it
+  /// still applies. Equality is conservative in both directions that matter: a pattern shader
+  /// never compares equal, because its pixels are borrowed and can change underneath it, and
+  /// float members compare bitwise, so a paint that only looks the same is reported as
+  /// different rather than the other way around.
+  friend bool operator==(const Paint&, const Paint&) = default;
 };
 
 }  // namespace tiny_skia

--- a/third_party/tiny-skia-cpp/src/tiny_skia/Paint.h
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/Paint.h
@@ -42,10 +42,14 @@ struct Paint {
   /// Two paints compare equal when a draw with either would build the same blitter.
   ///
   /// This is what lets a caller keep work derived from a paint and decide later whether it
-  /// still applies. Equality is conservative in both directions that matter: a pattern shader
-  /// never compares equal, because its pixels are borrowed and can change underneath it, and
-  /// float members compare bitwise, so a paint that only looks the same is reported as
-  /// different rather than the other way around.
+  /// still applies. Floats compare with IEEE semantics, which deviates from "same value" in
+  /// two ways and both fail toward reporting a difference: a paint holding a NaN is never
+  /// equal even to itself, so such a paint is simply never reused, and positive and negative
+  /// zero compare equal, which is sound because the two produce the same pixels everywhere the
+  /// pipeline consumes them.
+  ///
+  /// A pattern shader compares its pixel view by address, so equality means the two paints
+  /// read the same buffer, not that the buffer still holds the same image. @see Pattern.
   friend bool operator==(const Paint&, const Paint&) = default;
 };
 

--- a/third_party/tiny-skia-cpp/src/tiny_skia/Pixmap.h
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/Pixmap.h
@@ -49,6 +49,12 @@ class PixmapView {
   /// Clones a rectangular region into a new Pixmap.
   [[nodiscard]] std::optional<Pixmap> cloneRect(const IntRect& rect) const;
 
+  /// Two views compare equal when they name the same bytes: the same address, the same length,
+  /// and the same dimensions. This is view identity, not image equality. Views onto two buffers
+  /// holding identical pixels are not equal, and one view stays equal to itself after the bytes
+  /// it points at are overwritten, because a view does not own them.
+  friend bool operator==(const PixmapView&, const PixmapView&) = default;
+
  private:
   friend class Pixmap;
 

--- a/third_party/tiny-skia-cpp/src/tiny_skia/SpanCapture.h
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/SpanCapture.h
@@ -119,6 +119,17 @@ class CapturedSpans {
   /// Returns the bytes the recorded runs occupy, excluding unused vector capacity.
   [[nodiscard]] std::size_t byteSize() const { return spans_.size() * sizeof(CapturedSpan); }
 
+  /// Returns the bytes actually held, including capacity kept across a clear.
+  ///
+  /// A cache that bounds how much coverage it retains has to charge itself for what it is
+  /// holding, not for what it is currently using, because clearing runs keeps the allocation.
+  [[nodiscard]] std::size_t capacityBytes() const {
+    return spans_.capacity() * sizeof(CapturedSpan);
+  }
+
+  /// Releases unused capacity, so a cache can return memory it charged itself for.
+  void shrinkToFit() { spans_.shrink_to_fit(); }
+
   /// Returns false when a blit call carried a value the packed record cannot hold. The
   /// recorded runs are then incomplete and must not be replayed.
   [[nodiscard]] bool valid() const { return !overflowed_; }
@@ -202,6 +213,16 @@ class SpanCapture {
 
   /// The runs the last successful capture recorded, in device space.
   [[nodiscard]] const CapturedSpans& spans() const { return spans_; }
+
+  /// Drops the recorded runs and gives their storage back.
+  ///
+  /// Capturing again normally keeps the allocation, which is what makes a repeatedly rebuilt
+  /// shape allocation-free. A caller that has decided not to capture this draw again wants the
+  /// opposite, so it can stop paying for storage it will not use.
+  void release() {
+    spans_.clear();
+    spans_.shrinkToFit();
+  }
 
   /// The paint the last successful capture's draw built its blitter from.
   ///

--- a/third_party/tiny-skia-cpp/src/tiny_skia/Stroke.h
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/Stroke.h
@@ -44,7 +44,9 @@ struct Stroke {
 
   /// Two strokes compare equal when they expand an outline the same way, which is what lets a
   /// caller keep work derived from a stroke and decide later whether it still applies. Floats
-  /// compare bitwise, so the answer is never "equal" for inputs that merely look alike.
+  /// compare with IEEE semantics: a NaN width is never equal even to itself, so such a stroke
+  /// is never reused, and positive and negative zero compare equal, which the stroker cannot
+  /// distinguish either.
   friend bool operator==(const Stroke&, const Stroke&) = default;
 };
 

--- a/third_party/tiny-skia-cpp/src/tiny_skia/Stroke.h
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/Stroke.h
@@ -30,6 +30,8 @@ struct StrokeDash {
   /// Creates a validated dash. Returns nullopt if the array is invalid.
   [[nodiscard]] static std::optional<StrokeDash> create(std::vector<float> dashArray,
                                                         float dashOffset);
+
+  friend bool operator==(const StrokeDash&, const StrokeDash&) = default;
 };
 
 /// Stroke properties for Painter::strokePath.
@@ -39,6 +41,11 @@ struct Stroke {
   LineCap lineCap = LineCap::Butt;     ///< Endpoint cap style.
   LineJoin lineJoin = LineJoin::Miter;  ///< Corner join style.
   std::optional<StrokeDash> dash;       ///< Optional dash pattern.
+
+  /// Two strokes compare equal when they expand an outline the same way, which is what lets a
+  /// caller keep work derived from a stroke and decide later whether it still applies. Floats
+  /// compare bitwise, so the answer is never "equal" for inputs that merely look alike.
+  friend bool operator==(const Stroke&, const Stroke&) = default;
 };
 
 }  // namespace tiny_skia

--- a/third_party/tiny-skia-cpp/src/tiny_skia/shaders/Gradient.h
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/shaders/Gradient.h
@@ -24,6 +24,8 @@ struct GradientStop {
   static GradientStop create(float position, Color color) {
     return GradientStop{NormalizedF32::newClamped(position), color};
   }
+
+  friend bool operator==(const GradientStop&, const GradientStop&) = default;
 };
 
 /// @internal
@@ -51,6 +53,12 @@ class Gradient {
                                              ColorSpace cs) const;
 
   void applyOpacity(float opacity);
+
+  /// Two gradients compare equal when every value the pipeline stages read from them is
+  /// equal, which is what lets a caller decide that a shader it built earlier still describes
+  /// the paint it wants now. Floats compare bitwise-exactly, so an equal result means the
+  /// stages are built from identical inputs, and an unequal one is at worst a missed reuse.
+  friend bool operator==(const Gradient&, const Gradient&) = default;
 
   Transform transform;
 

--- a/third_party/tiny-skia-cpp/src/tiny_skia/shaders/Gradient.h
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/shaders/Gradient.h
@@ -3,7 +3,9 @@
 /// @file shaders/Gradient.h
 /// @brief Base gradient data and gradient stop type.
 
+#include <cstddef>
 #include <functional>
+#include <span>
 #include <vector>
 
 #include "tiny_skia/Color.h"
@@ -54,10 +56,21 @@ class Gradient {
 
   void applyOpacity(float opacity);
 
-  /// Two gradients compare equal when every value the pipeline stages read from them is
-  /// equal, which is what lets a caller decide that a shader it built earlier still describes
-  /// the paint it wants now. Floats compare bitwise-exactly, so an equal result means the
-  /// stages are built from identical inputs, and an unequal one is at worst a missed reuse.
+  /// Returns the color stops, in the order the pipeline stages read them.
+  [[nodiscard]] std::span<const GradientStop> stops() const { return stops_; }
+
+  /// Returns the bytes the stop list occupies, for a caller that bounds how much gradient
+  /// state it keeps.
+  [[nodiscard]] std::size_t stopsByteSize() const {
+    return stops_.size() * sizeof(GradientStop);
+  }
+
+  /// Two gradients compare equal when every value the pipeline stages read from them is equal,
+  /// which is what lets a caller decide that a shader it built earlier still describes the
+  /// paint it wants now. Floats compare with IEEE semantics: a stop or transform holding a NaN
+  /// is never equal even to itself, so such a gradient is never reused, and positive and
+  /// negative zero compare equal, which the stages cannot distinguish either. An unequal
+  /// result is at worst a missed reuse.
   friend bool operator==(const Gradient&, const Gradient&) = default;
 
   Transform transform;

--- a/third_party/tiny-skia-cpp/src/tiny_skia/shaders/Gradient.h
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/shaders/Gradient.h
@@ -61,9 +61,7 @@ class Gradient {
 
   /// Returns the bytes the stop list occupies, for a caller that bounds how much gradient
   /// state it keeps.
-  [[nodiscard]] std::size_t stopsByteSize() const {
-    return stops_.size() * sizeof(GradientStop);
-  }
+  [[nodiscard]] std::size_t stopsByteSize() const { return stops_.size() * sizeof(GradientStop); }
 
   /// Two gradients compare equal when every value the pipeline stages read from them is equal,
   /// which is what lets a caller decide that a shader it built earlier still describes the

--- a/third_party/tiny-skia-cpp/src/tiny_skia/shaders/LinearGradient.h
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/shaders/LinearGradient.h
@@ -30,6 +30,9 @@ class LinearGradient {
   /// @internal
   [[nodiscard]] bool pushStages(ColorSpace cs, pipeline::RasterPipelineBuilder& p) const;
 
+  /// Equal when the underlying gradient data is equal. @see Gradient's operator==.
+  friend bool operator==(const LinearGradient&, const LinearGradient&) = default;
+
   /// @internal
   Gradient base_;
 };

--- a/third_party/tiny-skia-cpp/src/tiny_skia/shaders/Pattern.h
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/shaders/Pattern.h
@@ -51,15 +51,14 @@ class Pattern {
   /// @internal
   [[nodiscard]] bool pushStages(ColorSpace cs, pipeline::RasterPipelineBuilder& p) const;
 
-  /// Never equal, deliberately.
+  /// Equal when every field describing the tiling is equal, including the view, which
+  /// compares by address rather than by content.
   ///
-  /// A pattern borrows its pixels through a view, so two patterns that describe the same
-  /// tile today can describe different pixels a moment later without either object changing.
-  /// Equality exists so a caller can ask "is this the same paint I saw before, such that work
-  /// derived from it is still valid", and for a borrowed-pixel shader the honest answer is
-  /// always no. Reporting equal would let a caller reuse output built from pixels that have
-  /// since been overwritten.
-  friend bool operator==(const Pattern&, const Pattern&) { return false; }
+  /// A pattern does not own its pixels, so equality says the two patterns read the same
+  /// buffer, not that the buffer still holds the same image. A caller that keeps work derived
+  /// from a pattern has to know whether anything can have overwritten those pixels since; this
+  /// comparison cannot tell it that.
+  friend bool operator==(const Pattern&, const Pattern&) = default;
 
   /// @internal
   PixmapView pixmap_;

--- a/third_party/tiny-skia-cpp/src/tiny_skia/shaders/Pattern.h
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/shaders/Pattern.h
@@ -51,6 +51,16 @@ class Pattern {
   /// @internal
   [[nodiscard]] bool pushStages(ColorSpace cs, pipeline::RasterPipelineBuilder& p) const;
 
+  /// Never equal, deliberately.
+  ///
+  /// A pattern borrows its pixels through a view, so two patterns that describe the same
+  /// tile today can describe different pixels a moment later without either object changing.
+  /// Equality exists so a caller can ask "is this the same paint I saw before, such that work
+  /// derived from it is still valid", and for a borrowed-pixel shader the honest answer is
+  /// always no. Reporting equal would let a caller reuse output built from pixels that have
+  /// since been overwritten.
+  friend bool operator==(const Pattern&, const Pattern&) { return false; }
+
   /// @internal
   PixmapView pixmap_;
   /// @internal

--- a/third_party/tiny-skia-cpp/src/tiny_skia/shaders/RadialGradient.h
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/shaders/RadialGradient.h
@@ -18,6 +18,8 @@ struct FocalData {
   float focalX = 0.0f;
   bool isSwapped = false;
 
+  friend bool operator==(const FocalData&, const FocalData&) = default;
+
   [[nodiscard]] bool isFocalOnCircle() const;
   [[nodiscard]] bool isWellBehaved() const;
   [[nodiscard]] bool isNativelyFocal() const;
@@ -29,11 +31,15 @@ struct FocalData {
 struct RadialType {
   float radius1 = 0.0f;
   float radius2 = 0.0f;
+
+  friend bool operator==(const RadialType&, const RadialType&) = default;
 };
 
 /// @internal
 struct StripType {
   float scaledR0 = 0.0f;
+
+  friend bool operator==(const StripType&, const StripType&) = default;
 };
 
 /// @internal
@@ -58,6 +64,10 @@ class RadialGradient {
 
   /// @internal
   [[nodiscard]] bool pushStages(ColorSpace cs, pipeline::RasterPipelineBuilder& p) const;
+
+  /// Equal when the gradient data and the resolved conical configuration are equal.
+  /// @see Gradient's operator==.
+  friend bool operator==(const RadialGradient&, const RadialGradient&) = default;
 
   /// @internal
   Gradient base_;

--- a/third_party/tiny-skia-cpp/src/tiny_skia/shaders/SweepGradient.h
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/shaders/SweepGradient.h
@@ -32,6 +32,9 @@ class SweepGradient {
   /// @internal
   [[nodiscard]] bool pushStages(ColorSpace cs, pipeline::RasterPipelineBuilder& p) const;
 
+  /// Equal when the gradient data and the sweep angles are equal. @see Gradient's operator==.
+  friend bool operator==(const SweepGradient&, const SweepGradient&) = default;
+
   /// @internal
   Gradient base_;
 

--- a/third_party/tiny-skia-cpp/src/tiny_skia/tests/BUILD.bazel
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/tests/BUILD.bazel
@@ -22,6 +22,7 @@ tiny_skia_dual_mode_cc_test(
         "LineClipperTest.cpp",
         "MaskTest.cpp",
         "MathTest.cpp",
+        "PaintTest.cpp",
         "PainterTest.cpp",
         "PathGeometryTest.cpp",
         "PathTest.cpp",

--- a/third_party/tiny-skia-cpp/src/tiny_skia/tests/PaintTest.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/tests/PaintTest.cpp
@@ -1,0 +1,292 @@
+#include "tiny_skia/Paint.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <utility>
+#include <vector>
+
+#include "tiny_skia/Color.h"
+#include "tiny_skia/Geom.h"
+#include "tiny_skia/Pixmap.h"
+#include "tiny_skia/Stroke.h"
+#include "tiny_skia/Transform.h"
+#include "tiny_skia/shaders/Shaders.h"
+
+namespace {
+
+using tiny_skia::Color;
+using tiny_skia::FilterQuality;
+using tiny_skia::GradientStop;
+using tiny_skia::IntSize;
+using tiny_skia::LinearGradient;
+using tiny_skia::Paint;
+using tiny_skia::Pattern;
+using tiny_skia::Pixmap;
+using tiny_skia::Point;
+using tiny_skia::RadialGradient;
+using tiny_skia::SpreadMode;
+using tiny_skia::Stroke;
+using tiny_skia::StrokeDash;
+using tiny_skia::Transform;
+
+std::vector<GradientStop> twoStops(Color first, Color second) {
+  return {GradientStop::create(0.0f, first), GradientStop::create(1.0f, second)};
+}
+
+LinearGradient makeLinearGradient(std::vector<GradientStop> stops,
+                                  Transform transform = Transform::identity()) {
+  auto shader = LinearGradient::create(Point::fromXY(0.0f, 0.0f), Point::fromXY(8.0f, 8.0f),
+                                       std::move(stops), SpreadMode::Pad, transform);
+  EXPECT_TRUE(shader.has_value());
+  EXPECT_TRUE(std::holds_alternative<LinearGradient>(*shader));
+  return std::get<LinearGradient>(std::move(*shader));
+}
+
+RadialGradient makeRadialGradient(float radius) {
+  auto shader = RadialGradient::create(Point::fromXY(4.0f, 4.0f), 0.0f, Point::fromXY(4.0f, 4.0f),
+                                       radius, twoStops(Color::black, Color::white),
+                                       SpreadMode::Pad, Transform::identity());
+  EXPECT_TRUE(shader.has_value());
+  EXPECT_TRUE(std::holds_alternative<RadialGradient>(*shader));
+  return std::get<RadialGradient>(std::move(*shader));
+}
+
+Pixmap makePixmap(std::uint8_t fill) {
+  const auto size = IntSize::fromWH(2, 2);
+  EXPECT_TRUE(size.has_value());
+  auto pixmap = Pixmap::fromVec(std::vector<std::uint8_t>(16, fill), *size);
+  EXPECT_TRUE(pixmap.has_value());
+  return std::move(*pixmap);
+}
+
+// A paint is only useful as an equality key if it is equal to itself, so every shader kind is
+// checked for that before anything else.
+
+TEST(PaintEquality, PaintIsEqualToItself) {
+  Paint solid;
+  solid.setColorRgba8(10, 20, 30, 40);
+  EXPECT_EQ(solid, solid);
+
+  Paint linear;
+  linear.shader = makeLinearGradient(twoStops(Color::black, Color::white));
+  EXPECT_EQ(linear, linear);
+
+  Paint radial;
+  radial.shader = makeRadialGradient(4.0f);
+  EXPECT_EQ(radial, radial);
+
+  const Pixmap pixmap = makePixmap(0x40);
+  Paint pattern;
+  pattern.shader = Pattern(pixmap.view(), SpreadMode::Repeat, FilterQuality::Nearest, 1.0f,
+                           Transform::identity());
+  EXPECT_EQ(pattern, pattern)
+      << "a pattern paint that is not equal to itself would make every paint holding one "
+         "unusable as a key, including in containers that assume reflexivity";
+}
+
+TEST(PaintEquality, SolidColorPaintsCompareByEveryField) {
+  Paint base;
+  base.setColorRgba8(10, 20, 30, 40);
+
+  Paint same;
+  same.setColorRgba8(10, 20, 30, 40);
+  EXPECT_EQ(base, same);
+
+  Paint otherColor;
+  otherColor.setColorRgba8(10, 20, 31, 40);
+  EXPECT_NE(base, otherColor);
+
+  Paint otherAlias = same;
+  otherAlias.antiAlias = !otherAlias.antiAlias;
+  EXPECT_NE(base, otherAlias);
+
+  Paint otherBlend = same;
+  otherBlend.blendMode = tiny_skia::BlendMode::Multiply;
+  EXPECT_NE(base, otherBlend);
+
+  Paint otherColorspace = same;
+  otherColorspace.colorspace = tiny_skia::ColorSpace::SimpleSRGB;
+  EXPECT_NE(base, otherColorspace);
+
+  Paint otherPipeline = same;
+  otherPipeline.forceHqPipeline = !otherPipeline.forceHqPipeline;
+  EXPECT_NE(base, otherPipeline);
+}
+
+TEST(PaintEquality, ShaderKindIsPartOfEquality) {
+  Paint solid;
+  solid.setColor(Color::black);
+
+  Paint gradient;
+  gradient.shader = makeLinearGradient(twoStops(Color::black, Color::black));
+
+  EXPECT_NE(solid, gradient);
+}
+
+TEST(PaintEquality, GradientsCompareByStopsAndTransform) {
+  Paint base;
+  base.shader = makeLinearGradient(twoStops(Color::black, Color::white));
+
+  Paint same;
+  same.shader = makeLinearGradient(twoStops(Color::black, Color::white));
+  EXPECT_EQ(base, same) << "two gradients built from the same inputs describe the same paint";
+
+  Paint otherStopColor;
+  otherStopColor.shader =
+      makeLinearGradient(twoStops(Color::black, Color::fromRgba8(0, 255, 0, 255)));
+  EXPECT_NE(base, otherStopColor);
+
+  Paint otherStopPosition;
+  otherStopPosition.shader = makeLinearGradient(
+      {GradientStop::create(0.25f, Color::black), GradientStop::create(1.0f, Color::white)});
+  EXPECT_NE(base, otherStopPosition);
+
+  Paint otherStopCount;
+  otherStopCount.shader = makeLinearGradient({GradientStop::create(0.0f, Color::black),
+                                              GradientStop::create(0.5f, Color::black),
+                                              GradientStop::create(1.0f, Color::white)});
+  EXPECT_NE(base, otherStopCount);
+
+  Paint otherTransform;
+  otherTransform.shader = makeLinearGradient(twoStops(Color::black, Color::white),
+                                             Transform::fromTranslate(1.0f, 0.0f));
+  EXPECT_NE(base, otherTransform);
+}
+
+TEST(PaintEquality, RadialGradientsCompareByResolvedConfiguration) {
+  Paint base;
+  base.shader = makeRadialGradient(4.0f);
+
+  Paint same;
+  same.shader = makeRadialGradient(4.0f);
+  EXPECT_EQ(base, same);
+
+  Paint otherRadius;
+  otherRadius.shader = makeRadialGradient(6.0f);
+  EXPECT_NE(base, otherRadius);
+}
+
+TEST(PaintEquality, GradientStopsAreReportedForAccounting) {
+  const LinearGradient gradient = makeLinearGradient(twoStops(Color::black, Color::white));
+  EXPECT_EQ(gradient.base_.stops().size(), 2u);
+  EXPECT_EQ(gradient.base_.stopsByteSize(), 2u * sizeof(GradientStop));
+}
+
+TEST(PaintEquality, PatternsCompareByEveryTilingField) {
+  const Pixmap pixmap = makePixmap(0x40);
+  const Pixmap otherPixmap = makePixmap(0x40);
+
+  const auto makePattern = [&](const Pixmap& source, SpreadMode spread, FilterQuality quality,
+                               float opacity, Transform transform) {
+    Paint paint;
+    paint.shader = Pattern(source.view(), spread, quality, opacity, transform);
+    return paint;
+  };
+
+  const Paint base = makePattern(pixmap, SpreadMode::Repeat, FilterQuality::Nearest, 1.0f,
+                                 Transform::identity());
+  EXPECT_EQ(base, makePattern(pixmap, SpreadMode::Repeat, FilterQuality::Nearest, 1.0f,
+                              Transform::identity()));
+
+  EXPECT_NE(base, makePattern(pixmap, SpreadMode::Pad, FilterQuality::Nearest, 1.0f,
+                              Transform::identity()));
+  EXPECT_NE(base, makePattern(pixmap, SpreadMode::Repeat, FilterQuality::Bilinear, 1.0f,
+                              Transform::identity()));
+  EXPECT_NE(base, makePattern(pixmap, SpreadMode::Repeat, FilterQuality::Nearest, 0.5f,
+                              Transform::identity()));
+  EXPECT_NE(base, makePattern(pixmap, SpreadMode::Repeat, FilterQuality::Nearest, 1.0f,
+                              Transform::fromTranslate(1.0f, 0.0f)));
+  EXPECT_NE(base, makePattern(otherPixmap, SpreadMode::Repeat, FilterQuality::Nearest, 1.0f,
+                              Transform::identity()))
+      << "a pattern view names an address, so two buffers holding identical pixels are two "
+         "different patterns";
+}
+
+// The float policy: IEEE comparison, whose two deviations from "same value" both fail toward
+// reporting a difference rather than a false match.
+
+TEST(PaintEquality, PaintHoldingNaNIsNeverEqual) {
+  // Gradient construction rejects a non-finite transform, so the NaN is written afterwards:
+  // the point is what equality does when one reaches a paint, not how one gets there.
+  LinearGradient gradient = makeLinearGradient(twoStops(Color::black, Color::white));
+  gradient.base_.transform = Transform::fromRow(std::nanf(""), 0.0f, 0.0f, 1.0f, 0.0f, 0.0f);
+
+  Paint paint;
+  paint.shader = std::move(gradient);
+
+  EXPECT_NE(paint, paint) << "IEEE comparison never reports a NaN as equal, so such a paint is "
+                             "simply never reused, which is the safe direction";
+}
+
+TEST(PaintEquality, SignedZeroesCompareEqual) {
+  Paint positiveZero;
+  positiveZero.shader = makeLinearGradient(twoStops(Color::black, Color::white),
+                                           Transform::fromTranslate(0.0f, 0.0f));
+
+  Paint negativeZero;
+  negativeZero.shader = makeLinearGradient(twoStops(Color::black, Color::white),
+                                           Transform::fromTranslate(-0.0f, -0.0f));
+
+  EXPECT_EQ(positiveZero, negativeZero)
+      << "the two translate by the same amount, so treating them as one paint cannot change a "
+         "pixel";
+}
+
+TEST(StrokeEquality, StrokesCompareByEveryField) {
+  Stroke base;
+  base.width = 2.0f;
+  base.miterLimit = 4.0f;
+  base.lineCap = tiny_skia::LineCap::Butt;
+  base.lineJoin = tiny_skia::LineJoin::Miter;
+  EXPECT_EQ(base, base);
+
+  Stroke same = base;
+  EXPECT_EQ(base, same);
+
+  Stroke otherWidth = base;
+  otherWidth.width = 2.5f;
+  EXPECT_NE(base, otherWidth);
+
+  Stroke otherMiter = base;
+  otherMiter.miterLimit = 8.0f;
+  EXPECT_NE(base, otherMiter);
+
+  Stroke otherCap = base;
+  otherCap.lineCap = tiny_skia::LineCap::Round;
+  EXPECT_NE(base, otherCap);
+
+  Stroke otherJoin = base;
+  otherJoin.lineJoin = tiny_skia::LineJoin::Bevel;
+  EXPECT_NE(base, otherJoin);
+}
+
+TEST(StrokeEquality, DashPatternsCompareByArrayAndOffset) {
+  Stroke base;
+  base.dash = StrokeDash::create({4.0f, 2.0f}, 0.0f);
+  ASSERT_TRUE(base.dash.has_value());
+
+  Stroke same;
+  same.dash = StrokeDash::create({4.0f, 2.0f}, 0.0f);
+  EXPECT_EQ(base, same);
+
+  Stroke otherArray;
+  otherArray.dash = StrokeDash::create({4.0f, 3.0f}, 0.0f);
+  EXPECT_NE(base, otherArray);
+
+  Stroke otherOffset;
+  otherOffset.dash = StrokeDash::create({4.0f, 2.0f}, 1.0f);
+  EXPECT_NE(base, otherOffset);
+
+  Stroke undashed;
+  EXPECT_NE(base, undashed);
+}
+
+TEST(StrokeEquality, StrokeHoldingNaNIsNeverEqual) {
+  Stroke paint;
+  paint.width = std::nanf("");
+  EXPECT_NE(paint, paint);
+}
+
+}  // namespace

--- a/third_party/tiny-skia-cpp/src/tiny_skia/tests/SpanCaptureTest.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/tests/SpanCaptureTest.cpp
@@ -874,4 +874,73 @@ TEST(SpanCaptureTest, FullyTransparentPaintStillRecordsCoverage) {
   EXPECT_TRUE(pixmapsEqual(directPixmap, replayPixmap));
 }
 
+// A cache that bounds how much coverage it keeps has to be able to ask what a recording costs
+// and to hand the storage back, so those three accessors are pinned directly.
+
+TEST(SpanCaptureTest, ReportsWhatItHoldsIncludingCapacityKeptAcrossAClear) {
+  const auto path = makeCurvedPath(static_cast<float>(kDim));
+  auto pixmap = makePixmap();
+  auto view = pixmap.mutableView();
+
+  SpanCapture recorded;
+  ASSERT_TRUE(recorded.fillPath(view, path, makeSolidPaint(220, 30, 90, 255), FillRule::Winding,
+                                Transform::identity()));
+
+  const CapturedSpans& spans = recorded.spans();
+  EXPECT_GT(spans.size(), 0u);
+  EXPECT_EQ(spans.byteSize(), spans.size() * sizeof(CapturedSpan));
+  EXPECT_GE(spans.capacityBytes(), spans.byteSize())
+      << "capacity is what the recording actually holds, so it can never be under what it uses";
+
+  const std::size_t heldWhileRecorded = spans.capacityBytes();
+
+  // Capturing a smaller shape reuses the allocation, which is what makes a repeatedly rebuilt
+  // shape allocation-free. The used bytes fall; the held bytes do not.
+  const auto smallPath = makeCurvedPath(static_cast<float>(kDim) / 4.0f);
+  ASSERT_TRUE(recorded.fillPath(view, smallPath, makeSolidPaint(220, 30, 90, 255),
+                                FillRule::Winding, Transform::identity()));
+  EXPECT_LT(recorded.spans().byteSize(), heldWhileRecorded);
+  EXPECT_EQ(recorded.spans().capacityBytes(), heldWhileRecorded);
+}
+
+TEST(SpanCaptureTest, ReleaseDropsTheRunsAndTheirStorage) {
+  const auto path = makeCurvedPath(static_cast<float>(kDim));
+  auto pixmap = makePixmap();
+  auto view = pixmap.mutableView();
+
+  SpanCapture recorded;
+  ASSERT_TRUE(recorded.fillPath(view, path, makeSolidPaint(220, 30, 90, 255), FillRule::Winding,
+                                Transform::identity()));
+  ASSERT_GT(recorded.spans().capacityBytes(), 0u);
+
+  recorded.release();
+  EXPECT_TRUE(recorded.spans().empty());
+  EXPECT_EQ(recorded.spans().byteSize(), 0u);
+  EXPECT_EQ(recorded.spans().capacityBytes(), 0u)
+      << "release exists so a caller that will not replay a recording stops paying for it";
+}
+
+TEST(SpanCaptureTest, ShrinkToFitReturnsUnusedCapacity) {
+  const auto path = makeCurvedPath(static_cast<float>(kDim));
+  auto pixmap = makePixmap();
+  auto view = pixmap.mutableView();
+
+  SpanCapture recorded;
+  ASSERT_TRUE(recorded.fillPath(view, path, makeSolidPaint(220, 30, 90, 255), FillRule::Winding,
+                                Transform::identity()));
+
+  // Work on a copy: clearing it keeps the allocation, which is exactly the unused capacity
+  // shrinking is meant to return.
+  CapturedSpans spans = recorded.spans();
+  const std::size_t heldWhileRecorded = spans.capacityBytes();
+  ASSERT_GT(heldWhileRecorded, 0u);
+
+  spans.clear();
+  EXPECT_TRUE(spans.empty());
+  EXPECT_EQ(spans.capacityBytes(), heldWhileRecorded) << "clearing keeps the allocation";
+
+  spans.shrinkToFit();
+  EXPECT_EQ(spans.capacityBytes(), 0u);
+}
+
 }  // namespace


### PR DESCRIPTION
The tiny-skia backend re-rasterizes every shape every frame even when nothing about the shape changed. This change retains each shape's rasterized coverage spans across frames and replays them instead, cutting steady-state frame time on static and mostly-static documents.

Mechanism:

- A retained-spans component lives on the document registry keyed by the draw's source entity, holding the captured coverage spans plus the draw's actual inputs (device transform, paint via new deep equality on the vendored `tiny_skia::Paint`, stroke, clip identity, surface size, fill rule, dash-seam flag). Replay happens only while every input compares equal; anything else re-rasterizes and re-captures. Geometry changes invalidate through `on_update`/`on_destroy` listeners on the computed path component, the same mechanism the GPU backend's encode cache uses.
- Coverage is mask-independent by construction (the scan converter never sees the mask; it is re-applied at replay), so group opacity, blend modes, masks, isolation, and filters all push a surface and structurally cannot reach a retained draw. Pattern paints bypass retention (borrowed pixels).
- Replay refuses spans recorded against a different surface geometry (an independent size check below the key comparison), entities drawn more than once per frame stop retaining, and frame identity comes from the document so multiple renderers cannot cross-read.
- Memory is budgeted per document (default 32 MiB) charging spans, retained paints, and the component itself; eviction is coldest-first, and a working set that cannot fit disables retention for the document instead of thrashing. Clip-mask identity slots are capped and dropped on resize. Disabling retention hands all retained state back.
- Off by default behind a runtime flag on the renderer.

Measured (aarch64 desktop, `-c opt`, medians of interleaved passes, byte-identical pixel hashes in every run): Ghostscript Tiger steady 22.1 -> 8.9 ms (2.50x), lion 2.8 -> 1.6 ms (1.79x), smaller scenes 1.04-1.07x. A one-shape drag on Tiger goes 22.3 -> 9.5 ms because the untouched shapes replay. Honest costs: cold-frame capture overhead is +2.7% (Tiger) to +10.2% (lion), and the worst case, a pan where every transform changes and nothing replays, is +8% (capture plus the comparison that decided nothing could be reused). Retained memory on Tiger is 3.4 MiB.

Correctness evidence: byte-identity is enforced by `renderer_retained_spans_tests` (per-invalidation-class red-then-green cases, replay-hit counter assertions, surface-mismatch fail-closed, eviction, multi-draw bypass) plus a hand-invoked compare mode (`DONNER_TINYSKIA_RETAINED=compare`) that renders every corpus document both ways and fails on the first differing byte, green over the full resvg suites. ASan+UBSan clean including compare mode. The vendored tiny-skia equality operators ship with their own tests in the subtree (reflexivity per shader kind, field sensitivity, IEEE float policy stated and asserted).

The retained-raster design doc is updated in the same change to describe what shipped, name the real CI target for the identity invariant, and record what is deliberately not built yet (opaque-interior straight stores, which is most of the remaining gap to the design's original steady-state target; steady-frame zero-allocation; fuzzer integration).
