### PR TITLE
perf: Enable ordered cross-entity scene batching by default

### DIFF
--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1031,11 +1031,17 @@ std::shared_ptr<RendererGeodeTexturePool> TexturePoolForDevice(geode::GeodeDevic
 
 }  // namespace
 
-/// Gate for ordered cross-entity batching. Disabled while the
-/// marker / scissor-clip deferred-flush interaction is unresolved; the
-/// same-entity instanced path and the solo residence flows remain
-/// active and fully verified.
-constexpr bool kEnableSceneBatching = false;
+/// Gate for ordered cross-entity batching. Enabled: the deferred flush that
+/// used to reorder a batched draw past a scissor or clip change can no longer
+/// form one, because the eligibility predicate refuses any draw taken while a
+/// clip state, a scissor, or a mask pass is active. The same-entity instanced
+/// path and the solo residence flows are unchanged and still handle
+/// everything a scene batch declines.
+///
+/// Kept as a compile-time constant rather than a runtime option so that
+/// turning it off folds the whole eligibility predicate away, leaving the
+/// record slab, its buffers and its per-entity slots entirely uncreated.
+constexpr bool kEnableSceneBatching = true;
 
 struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::FilterTextureAllocator {
   bool verbose = false;
@@ -2367,10 +2373,15 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
 
     if (batch.deviceFromLocalTransforms.size() == 1) {
       // Single draw - restore the captured transform + use the
-      // non-instanced path. Prefer the persistent-residence path
-      // so an unbatched solid fill re-uploads zero geometry on an
-      // unchanged frame (the common Lion / Tiger case: distinct source
-      // entities never batch, so almost every solid fill flushes here).
+      // non-instanced path. Prefer the persistent-residence path so an
+      // unbatched solid fill re-uploads zero geometry on an unchanged frame.
+      // A fill lands here whenever it never gained a second batch member:
+      // it was scene-ineligible (clipped, scissored, no cached encode, no
+      // residence slot, or a same-frame repeat), or it was eligible but its
+      // record slot did not extend the pending run. Differing paint does NOT
+      // land a draw here - a scene batch carries color and fill rule per
+      // instance record; only the same-entity instanced mode ends its run on
+      // a paint or fill-rule change.
       deviceFromLocalTransform = batch.deviceFromLocalTransforms.front();
       syncTransform();
       emitSolidFill(*batch.path, batch.color, batch.rule, batch.encoded, batch.residentFillSlot);
@@ -2455,26 +2466,30 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     // ordered batching and are already exact for repeated draws.
     const geode::GeodeRecordSlab::Slot* recordSlotPtr = nullptr;
     const uint64_t clipVersion = encoder->clipStateVersion();
-    // `kEnableSceneBatching` keeps ordered cross-entity batching off by
-    // default: it is a behavior-visible rendering change that is being
-    // rolled out separately from the machinery, and every gate below still
-    // has to hold before a draw can join a batch. With the flag off the
-    // predicate folds away at compile time, so no draw allocates a record
-    // slot, writes a record, or touches the record slab.
+    // `kEnableSceneBatching` is the compile-time gate for ordered
+    // cross-entity batching; with it off the whole predicate folds away, so
+    // no draw allocates a record slot, writes a record, or touches the record
+    // slab. Every gate below still has to hold before a draw can join a
+    // batch.
     //
     // The record-slab slot is allocated HERE, on the eligibility path,
     // rather than when the residence slot is created: a draw that can never
     // batch takes its paint from the uniform and binds the device's shared
     // identity record, so giving it a slot would be pure cost.
-    const bool sceneEligible = kEnableSceneBatching && residentFillSlot != nullptr &&
-                               encoded != nullptr &&
-                               !encoder->hasActiveClipState() &&
-                               !encoder->hasActiveScissor() &&
-                               residentFillSlot->lastSceneFrame != currentFrameIndex &&
-                               residentFillSlot->lastResidentFrame != currentFrameIndex &&
-                               sourceRegistry != nullptr &&
-                               ensureRecordSlot(*residentFillSlot, *sourceRegistry) &&
-                               resolveSceneRecordSlot(*residentFillSlot, recordSlotPtr);
+    //
+    // The three target-state guards (clip, scissor, mask pass) are what make
+    // deferring a draw to flush time safe: each is state the batch would
+    // observe at flush rather than at draw. Solid fills do not currently
+    // reach here during a mask pass, but the residency helpers all carry the
+    // same three-way guard, and an ordered batch is the one caller for which
+    // getting it wrong silently paints into the wrong target.
+    const bool sceneEligible =
+        kEnableSceneBatching && residentFillSlot != nullptr && encoded != nullptr &&
+        !encoder->hasActiveClipState() && !encoder->hasActiveScissor() &&
+        !encoder->hasOpenMaskPass() && residentFillSlot->lastSceneFrame != currentFrameIndex &&
+        residentFillSlot->lastResidentFrame != currentFrameIndex && sourceRegistry != nullptr &&
+        ensureRecordSlot(*residentFillSlot, *sourceRegistry) &&
+        resolveSceneRecordSlot(*residentFillSlot, recordSlotPtr);
     if (sceneEligible &&
         encoder->ensureResidentSceneRecord(*residentFillSlot, *encoded, color, rule,
                                            deviceFromLocalTransform, recordSlotPtr)) {
@@ -4563,10 +4578,10 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
                          impl_->paint.drawFillComponent;
 
   // GPU residence: a persistent per-entity fill slot, eligible for
-  // any solid fill with a cached encode. Shared by the batch size-1 flush
-  // and the direct `fillResolved` path so almost every solid fill (which
-  // never batches across distinct source entities) re-uploads zero
-  // geometry on an unchanged frame.
+  // any solid fill with a cached encode. Shared by the batch size-1 flush,
+  // the cross-entity scene batch and the direct `fillResolved` path, so a
+  // solid fill re-uploads zero geometry on an unchanged frame however it
+  // ends up being drawn.
   geode::GeodeResidentSlot* residentFill =
       (fillEncoded != nullptr && std::holds_alternative<PaintServer::Solid>(impl_->paint.fill))
           ? impl_->residentFillSlot(path.sourceEntity)

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -1469,6 +1469,10 @@ bool GeoEncoder::hasActiveScissor() const {
   return impl_->scissorActive;
 }
 
+bool GeoEncoder::hasOpenMaskPass() const {
+  return impl_->maskPassOpen;
+}
+
 void GeoEncoder::setLoadPreserve() {
   // No-op if a pass is already open - loadOp is a pass-construction
   // parameter and can't be changed mid-pass. The RendererGeode caller

--- a/donner/svg/renderer/geode/GeoEncoder.h
+++ b/donner/svg/renderer/geode/GeoEncoder.h
@@ -262,6 +262,13 @@ public:
   /// scissor at flush time instead of at draw time).
   bool hasActiveScissor() const;
 
+  /// True while a mask pass is open, i.e. draws are being recorded into a
+  /// mask texture through the mask pipeline rather than into the main pass.
+  /// Residency and the ordered batch gate both exclude these draws: a batch
+  /// defers to flush time, by which point the mask pass has closed and the
+  /// draw would land in the wrong target.
+  bool hasOpenMaskPass() const;
+
   /// Set the model-view transform for subsequent draw calls.
   void setTransform(const Transform2d& transform);
 

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -210,10 +210,16 @@ TEST_F(GeodePerfTest, SimpleShapes_BaselineCeilings) {
   // arenas (vBands/vCurves/hBandGrid/vBandGrid) on top of bands/curves/vertex/
   // uniform, so first-frame arena growth costs a few more buffer creates.
   EXPECT_LE(c.bufferCreates, 12u);
-  EXPECT_LE(c.bindgroupCreates, 6u);  // Target <= #pipelines (3 today).
-  EXPECT_LE(c.textureCreates, 3u);    // Target on frame 1; 0 on repeat.
-  EXPECT_LE(c.submits, 3u);           // Target = 1.
-  EXPECT_LE(c.drawCalls, 4u);         // 3 shapes, one draw each.
+  // One group for the batch, one for the snapshot readback.
+  EXPECT_LE(c.bindgroupCreates, 2u);
+  EXPECT_LE(c.textureCreates, 3u);  // Target on frame 1; 0 on repeat.
+  EXPECT_LE(c.submits, 3u);         // Target = 1.
+  // Three unclipped solid fills of distinct entities in painter order form
+  // one ordered cross-entity batch, so the whole fixture is a single
+  // instanced draw. Each instance's record carries its own color and fill
+  // rule, so the fixture's differing paints (red / blue / green) do not
+  // split the batch.
+  EXPECT_LE(c.drawCalls, 1u);
   EXPECT_LE(c.pipelineSwitches, 2u);  // Solid pipeline bound once.
 }
 
@@ -406,22 +412,23 @@ TEST_F(GeodePerfTest, Lion_BaselineCeilings) {
   //   device dummies + texture pool: target on frame 1; 0 on repeat.
   //   draw instrumentation: drawCalls=132 (one per path),
   //                       pipelineSwitches=1 (solid pipeline only -
-  //                       all of Lion is solid-fill). `<use>` instancing
-  //                       is the knob that moves drawCalls for
-  //                       `<use>`-heavy fixtures; Lion has no `<use>`
-  //                       so this ceiling stays at 132.
+  //                       all of Lion is solid-fill).
   EXPECT_LE(c.pathEncodes, 200u);  // Target = 0.
-  // GPU residence: frame 1 now front-loads ONE persistent
-  // combined buffer per cached solid-fill path (132 for Lion) so that
-  // steady-state frames re-upload zero geometry. This trades a one-time
-  // frame-1 buffer-create spike for the steady-state win asserted in
-  // `Lion_NoDirtyPath_ZeroEncodes` (frame-2 bufferCreates == 1, the
-  // readback). Ceiling = 132 resident + readback + arena slack.
-  EXPECT_LE(c.bufferCreates, 150u);
-  EXPECT_LE(c.bindgroupCreates, 200u);   // Target <= #pipelines.
-  EXPECT_LE(c.textureCreates, 3u);       // Target on first render; 0 on repeat.
-  EXPECT_LE(c.submits, 3u);              // Target = 1.
-  EXPECT_LE(c.drawCalls, 200u);          // 132 paths, one draw each (no <use>).
+  // GPU residence packs every cached solid fill into shared slab chunks
+  // rather than a buffer per path, so frame 1 creates a handful of slab
+  // chunks, the record slab, the arenas and the readback buffer - a count
+  // set by the slab chunk size, not by the 132 paths. Steady-state frames
+  // then re-upload zero geometry (`Lion_NoDirtyPath_ZeroEncodes`).
+  EXPECT_LE(c.bufferCreates, 8u);
+  // Ordered cross-entity batching collapsed this from one bind group per
+  // draw (133) to the batch's own group plus the readback's.
+  EXPECT_LE(c.bindgroupCreates, 2u);
+  EXPECT_LE(c.textureCreates, 3u);  // Target on first render; 0 on repeat.
+  EXPECT_LE(c.submits, 3u);         // Target = 1.
+  // All 132 paths are unclipped solid fills in painter order sharing one slab
+  // chunk, so they merge into a single instanced draw. Lion has no `<use>`,
+  // so this is entirely the cross-entity path, not same-entity instancing.
+  EXPECT_LE(c.drawCalls, 1u);
   EXPECT_LE(c.pipelineSwitches, 2u);     // All-solid fixture: tracker binds solid once.
   EXPECT_EQ(c.sameSourceDrawPairs, 0u);  // No `<use>` in Lion - every draw has a unique source.
 }
@@ -642,14 +649,14 @@ TEST_F(GeodePerfTest, Lion_NoDirtyPath_ZeroEncodes) {
   // fills are GPU-resident from frame 1, so an unchanged second render
   // re-uploads zero geometry bytes and creates zero bind groups. The
   // pre-residence baseline was bufferWriteBytes=172776 across 1056 writes, and
-  // bindgroupCreates=132 (one per draw). drawCalls stays 132 - the draws
-  // still happen, they just bind cached resident buffers.
+  // bindgroupCreates=132 (one per draw). The 132 draws now merge into one
+  // ordered cross-entity batch that binds the cached resident buffers.
   EXPECT_LE(c.bufferWriteBytes, 4096u)
       << "Steady-state geometry re-upload on an unchanged second render of lion.svg: resident "
          "buffers should serve every draw.";
-  // Resident draws reuse their cached bind groups on an unchanged frame;
-  // cross-entity batching is gated off, so nothing here may create groups
-  // per draw or per batch.
+  // Resident draws reuse their cached bind groups on an unchanged frame, and
+  // a scene batch reuses the group cached under its arena / slab identities,
+  // so nothing here may create a group per draw or per batch.
   EXPECT_LE(c.bindgroupCreates, 1u)
       << "Steady-state bind-group creates: cached resident groups should serve every draw.";
 }
@@ -686,12 +693,22 @@ TEST_F(GeodePerfTest, GhostscriptTiger_NoDirtyPath_ZeroEncodes) {
   // unchanged second render re-uploads zero geometry bytes and creates
   // zero bind groups - a >99% reduction, far past the 90% acceptance
   // floor (which would be <= 147388 bytes). Both fill AND stroke slots
-  // are exercised (Tiger has strokes). drawCalls stays 304.
+  // are exercised (Tiger has strokes). The 304 draws merge down to 153:
+  // Tiger's strokes are not batch-eligible, so each one ends a run of fills.
   EXPECT_LE(c.bufferWriteBytes, 8192u)
       << "Steady-state geometry re-upload on an unchanged second render of Ghostscript_Tiger.svg. "
          "The pre-residency baseline was 1,473,888 bytes; residency should drive this to ~0.";
   EXPECT_LE(c.bindgroupCreates, 2u)
       << "Steady-state bind-group creates no longer proportional to draw calls (was 304).";
+  // Batching is not free here: the batched and solo solid fills are separate
+  // pipeline objects, so every stroke that interrupts a run of fills costs a
+  // switch back and forth. Tiger went from 1 switch (one solid pipeline for
+  // all 304 draws) to 11 as the draws collapsed to 153. That is a good trade
+  // at this ratio, but it scales with how often non-eligible draws interleave,
+  // so bound it rather than letting it track the draw count again.
+  EXPECT_LE(c.pipelineSwitches, 12u)
+      << "Pipeline alternation between the batched and solo solid fill pipelines grew: a batch "
+         "that keeps getting interrupted gives back the draw-call win.";
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Ordered cross-entity scene batching has been compile-time gated off while its machinery landed and stabilized. This flips `kEnableSceneBatching` on by default and retightens the perf ceilings the flip moves. First PR of a stack; the follow-up rebinds fill bindings to eliminate cold-frame zero-initialization cost.

The flip itself is the constant plus comment corrections; the batching machinery (record-sourced shader entry points, per-instance color and fill rule, write-after-record protection, same-frame repeat diversion) is already on main. One small guard is added alongside the flip: the scene-eligibility predicate now also declines while a mask pass is open, matching every sibling residency guard; not reachable today, but the flip is what would make the omission live.

Acceptance, measured on a discrete GPU (Vulkan), 44 interleaved passes plus focused 20-pass campaigns on the two scenes nearest the noise band: no scene loses beyond noise across 14 scenes, render hashes identical in all cases. lion steady-state draw improves about 56% (132 draws collapse to 1), Ghostscript Tiger about 15% (304 to 153 draws), with mid-size scenes between 3 and 17%. Steady-state buffer writes on batchable scenes are zero.

Ceilings: four perf-test ceilings tighten to exact observed values (SimpleShapes bind groups 6 to 2, draws 4 to 1; Lion bind groups 200 to 2, draws 200 to 1), a stale buffer-creation rationale is rewritten to the actual slab mechanism and its ceiling tightened 150 to 8, and a new `pipelineSwitches` ceiling documents and bounds the one cost batching adds (solo and batched solid fills are distinct pipelines, so interleaved non-eligible draws pay a switch each way; Tiger went 1 to 11 switches while its draws halved). The counter corpus needs zero changes: its gate measures the second frame, where every draw is already served from cached resident state, so batching regroups draws into fewer GPU calls without moving any gated counter; verified byte-identical across all 82 corpus scenes in both flag states, and again byte-identical on the software-rasterizer adapter CI uses.

Full geode surface green in both invocation styles (157 targets), golden and resvg suites included, manifest freshness clean with no regeneration.
