### PR TITLE
perf: Eliminate cold-frame zero-initialization of exposed binding bytes

### DIFF
--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1031,11 +1031,17 @@ std::shared_ptr<RendererGeodeTexturePool> TexturePoolForDevice(geode::GeodeDevic
 
 }  // namespace
 
-/// Gate for ordered cross-entity batching. Disabled while the
-/// marker / scissor-clip deferred-flush interaction is unresolved; the
-/// same-entity instanced path and the solo residence flows remain
-/// active and fully verified.
-constexpr bool kEnableSceneBatching = false;
+/// Gate for ordered cross-entity batching. Enabled: the deferred flush that
+/// used to reorder a batched draw past a scissor or clip change can no longer
+/// form one, because the eligibility predicate refuses any draw taken while a
+/// clip state, a scissor, or a mask pass is active. The same-entity instanced
+/// path and the solo residence flows are unchanged and still handle
+/// everything a scene batch declines.
+///
+/// Kept as a compile-time constant rather than a runtime option so that
+/// turning it off folds the whole eligibility predicate away, leaving the
+/// record slab, its buffers and its per-entity slots entirely uncreated.
+constexpr bool kEnableSceneBatching = true;
 
 struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::FilterTextureAllocator {
   bool verbose = false;
@@ -2367,10 +2373,15 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
 
     if (batch.deviceFromLocalTransforms.size() == 1) {
       // Single draw - restore the captured transform + use the
-      // non-instanced path. Prefer the persistent-residence path
-      // so an unbatched solid fill re-uploads zero geometry on an
-      // unchanged frame (the common Lion / Tiger case: distinct source
-      // entities never batch, so almost every solid fill flushes here).
+      // non-instanced path. Prefer the persistent-residence path so an
+      // unbatched solid fill re-uploads zero geometry on an unchanged frame.
+      // A fill lands here whenever it never gained a second batch member:
+      // it was scene-ineligible (clipped, scissored, no cached encode, no
+      // residence slot, or a same-frame repeat), or it was eligible but its
+      // record slot did not extend the pending run. Differing paint does NOT
+      // land a draw here - a scene batch carries color and fill rule per
+      // instance record; only the same-entity instanced mode ends its run on
+      // a paint or fill-rule change.
       deviceFromLocalTransform = batch.deviceFromLocalTransforms.front();
       syncTransform();
       emitSolidFill(*batch.path, batch.color, batch.rule, batch.encoded, batch.residentFillSlot);
@@ -2455,26 +2466,30 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     // ordered batching and are already exact for repeated draws.
     const geode::GeodeRecordSlab::Slot* recordSlotPtr = nullptr;
     const uint64_t clipVersion = encoder->clipStateVersion();
-    // `kEnableSceneBatching` keeps ordered cross-entity batching off by
-    // default: it is a behavior-visible rendering change that is being
-    // rolled out separately from the machinery, and every gate below still
-    // has to hold before a draw can join a batch. With the flag off the
-    // predicate folds away at compile time, so no draw allocates a record
-    // slot, writes a record, or touches the record slab.
+    // `kEnableSceneBatching` is the compile-time gate for ordered
+    // cross-entity batching; with it off the whole predicate folds away, so
+    // no draw allocates a record slot, writes a record, or touches the record
+    // slab. Every gate below still has to hold before a draw can join a
+    // batch.
     //
     // The record-slab slot is allocated HERE, on the eligibility path,
     // rather than when the residence slot is created: a draw that can never
     // batch takes its paint from the uniform and binds the device's shared
     // identity record, so giving it a slot would be pure cost.
-    const bool sceneEligible = kEnableSceneBatching && residentFillSlot != nullptr &&
-                               encoded != nullptr &&
-                               !encoder->hasActiveClipState() &&
-                               !encoder->hasActiveScissor() &&
-                               residentFillSlot->lastSceneFrame != currentFrameIndex &&
-                               residentFillSlot->lastResidentFrame != currentFrameIndex &&
-                               sourceRegistry != nullptr &&
-                               ensureRecordSlot(*residentFillSlot, *sourceRegistry) &&
-                               resolveSceneRecordSlot(*residentFillSlot, recordSlotPtr);
+    //
+    // The three target-state guards (clip, scissor, mask pass) are what make
+    // deferring a draw to flush time safe: each is state the batch would
+    // observe at flush rather than at draw. Solid fills do not currently
+    // reach here during a mask pass, but the residency helpers all carry the
+    // same three-way guard, and an ordered batch is the one caller for which
+    // getting it wrong silently paints into the wrong target.
+    const bool sceneEligible =
+        kEnableSceneBatching && residentFillSlot != nullptr && encoded != nullptr &&
+        !encoder->hasActiveClipState() && !encoder->hasActiveScissor() &&
+        !encoder->hasOpenMaskPass() && residentFillSlot->lastSceneFrame != currentFrameIndex &&
+        residentFillSlot->lastResidentFrame != currentFrameIndex && sourceRegistry != nullptr &&
+        ensureRecordSlot(*residentFillSlot, *sourceRegistry) &&
+        resolveSceneRecordSlot(*residentFillSlot, recordSlotPtr);
     if (sceneEligible &&
         encoder->ensureResidentSceneRecord(*residentFillSlot, *encoded, color, rule,
                                            deviceFromLocalTransform, recordSlotPtr)) {
@@ -4563,10 +4578,10 @@ void RendererGeode::drawPath(const PathShape& path, const StrokeParams& stroke) 
                          impl_->paint.drawFillComponent;
 
   // GPU residence: a persistent per-entity fill slot, eligible for
-  // any solid fill with a cached encode. Shared by the batch size-1 flush
-  // and the direct `fillResolved` path so almost every solid fill (which
-  // never batches across distinct source entities) re-uploads zero
-  // geometry on an unchanged frame.
+  // any solid fill with a cached encode. Shared by the batch size-1 flush,
+  // the cross-entity scene batch and the direct `fillResolved` path, so a
+  // solid fill re-uploads zero geometry on an unchanged frame however it
+  // ends up being drawn.
   geode::GeodeResidentSlot* residentFill =
       (fillEncoded != nullptr && std::holds_alternative<PaintServer::Solid>(impl_->paint.fill))
           ? impl_->residentFillSlot(path.sourceEntity)

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -312,6 +312,41 @@ void copyRecordParamsToUniform(Uniforms& u, const InstanceRecord& r) {
   u.vRefsBase = r.vRefsBase;
 }
 
+/// Byte range covering a resident slot's four grid classes, which share one
+/// storage binding. Taken as the min/max over the four regions rather than
+/// assuming which one is placed first or last, so reordering the layout can
+/// never silently produce a range that omits a class or underflows.
+struct GridRegionSpan {
+  uint64_t offset = 0;
+  uint64_t size = 0;
+};
+
+GridRegionSpan gridRegionSpan(const GeodeResidentSlot& slot) {
+  const uint64_t start =
+      std::min({slot.hGrid.offset, slot.vGrid.offset, slot.hRefs.offset, slot.vRefs.offset});
+  const uint64_t end =
+      std::max({slot.hGrid.offset + slot.hGrid.size, slot.vGrid.offset + slot.vGrid.size,
+                slot.hRefs.offset + slot.hRefs.size, slot.vRefs.offset + slot.vRefs.size});
+  return {start, end - start};
+}
+
+/// Rewrite the geometry bases of a solo resident draw's uniform so they are
+/// relative to the sub-ranges its bind group actually binds, rather than to
+/// the slab chunk. Each single-class binding starts at its own region, so
+/// its base is zero; the four grid classes share one binding covering all of
+/// them, so their bases are offsets within that span.
+void writeSoloGeometryBases(Uniforms& u, const GeodeResidentSlot& slot) {
+  const GridRegionSpan grid = gridRegionSpan(slot);
+  u.bandBase = 0u;
+  u.curveBase = 0u;
+  u.vBandBase = 0u;
+  u.vCurveBase = 0u;
+  u.hGridBase = static_cast<uint32_t>((slot.hGrid.offset - grid.offset) / sizeof(uint32_t));
+  u.vGridBase = static_cast<uint32_t>((slot.vGrid.offset - grid.offset) / sizeof(uint32_t));
+  u.hRefsBase = static_cast<uint32_t>((slot.hRefs.offset - grid.offset) / sizeof(uint32_t));
+  u.vRefsBase = static_cast<uint32_t>((slot.vRefs.offset - grid.offset) / sizeof(uint32_t));
+}
+
 /// Gradient kind values shared with `shaders/slug_gradient.wgsl`.
 constexpr uint32_t kGradientKindLinear = 0u;
 constexpr uint32_t kGradientKindRadial = 1u;
@@ -483,39 +518,61 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
     }
   }
 
-  /// Ensure the arena can serve `totalBytes` of upcoming allocations from
-  /// its CURRENT buffer without growing in between. Callers that bind one
-  /// combined range across several consecutive allocations (the grid-class
-  /// span) use this so the range can never straddle two buffers: a growth
-  /// between the allocations would leave earlier ones in the retired
-  /// buffer and the combined offsets meaningless.
-  void reserveInArena(Arena& arena, uint64_t totalBytes, uint64_t alignment) {
-    const uint64_t alignedOffset = (arena.offset + alignment - 1) & ~(alignment - 1);
-    if (alignedOffset + totalBytes > arena.capacity) {
-      growArena(arena, totalBytes);
-    }
-  }
+  /// One packed grid-arena allocation holding the four dense grid classes
+  /// back to back, plus each class's element base within it.
+  struct GridSpan {
+    Allocation alloc;
+    uint32_t hGridBase = 0;
+    uint32_t vGridBase = 0;
+    uint32_t hRefsBase = 0;
+    uint32_t vRefsBase = 0;
+  };
 
-  /// Reserve the combined footprint of the four grid-class allocations
-  /// (hGrid, vGrid, hRefs, vRefs) so they land in ONE arena buffer: they
-  /// are bound as one combined range, and an arena growth between them
-  /// would strand the earlier allocations in the retired buffer and make
-  /// the combined offsets meaningless (observed as a bind-group range
-  /// overflow on encodes large enough to grow the grid arena
-  /// mid-sequence). Mirrors allocStorageOrDummy's sizing: empty classes
-  /// bind a 4-byte dummy, sizes round up to 4, each allocation starts
-  /// storage-aligned.
-  void reserveGridClassSpan(const EncodedPath& encoded) {
-    const uint64_t gridClassSizes[4] = {
-        encoded.hBandGrid.size() * sizeof(uint32_t), encoded.vBandGrid.size() * sizeof(uint32_t),
-        encoded.curveIndices.size() * sizeof(uint32_t),
-        encoded.vCurveIndices.size() * sizeof(uint32_t)};
-    uint64_t combined = 0;
-    for (uint64_t bytes : gridClassSizes) {
-      const uint64_t slot = bytes == 0 ? kStorageDummyBytes : roundUp4(bytes);
-      combined = ((combined + kStorageOffsetAlignment - 1) & ~(kStorageOffsetAlignment - 1)) + slot;
-    }
-    reserveInArena(gridArena, combined, kStorageOffsetAlignment);
+  /// Staging buffer for `allocGridSpan`, kept across draws so packing a
+  /// span does not allocate.
+  std::vector<uint32_t> gridSpanScratch;
+
+  /// Pack `hBandGrid | vBandGrid | curveIndices | vCurveIndices` into ONE
+  /// grid-arena allocation.
+  ///
+  /// The solid-fill pipeline reaches all four classes through a single
+  /// storage binding and indexes each one by element base, so inside the
+  /// allocation they only need u32 packing - not the 256-byte binding
+  /// alignment each would need as a binding of its own. Packing them also
+  /// keeps the bound range free of bytes nobody writes: WebGPU has to
+  /// zero-fill every byte a binding exposes before the first draw that
+  /// could read it, so alignment padding inside the range would turn each
+  /// cold draw into a clear of that padding.
+  ///
+  /// An empty class takes one zero element so its base stays inside the
+  /// range; the shader's band-count gates never read it. The span always
+  /// holds at least the four of them, so it clears WebGPU's one-element
+  /// minimum for the `array<u32>` binding on its own.
+  ///
+  /// The tradeoff: this copies the four class arrays into one staging
+  /// buffer, so the draw pays an O(grid bytes) CPU memcpy that four separate
+  /// allocations did not, and saves three of its four `writeBuffer` calls.
+  /// The scratch buffer is reused across draws, so the copy does not
+  /// allocate.
+  GridSpan allocGridSpan(const EncodedPath& encoded) {
+    gridSpanScratch.clear();
+    auto append = [&](const std::vector<uint32_t>& src) {
+      const uint32_t base = static_cast<uint32_t>(gridSpanScratch.size());
+      if (src.empty()) {
+        gridSpanScratch.push_back(0u);
+      } else {
+        gridSpanScratch.insert(gridSpanScratch.end(), src.begin(), src.end());
+      }
+      return base;
+    };
+    GridSpan span;
+    span.hGridBase = append(encoded.hBandGrid);
+    span.vGridBase = append(encoded.vBandGrid);
+    span.hRefsBase = append(encoded.curveIndices);
+    span.vRefsBase = append(encoded.vCurveIndices);
+    span.alloc = allocInArena(gridArena, gridSpanScratch.data(),
+                              gridSpanScratch.size() * sizeof(uint32_t), kStorageOffsetAlignment);
+    return span;
   }
 
   Allocation allocInArena(Arena& arena, const void* data, uint64_t size, uint64_t alignment) {
@@ -565,7 +622,7 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   /// `bufferWrite` (geometry only; the uniform is written separately).
   void uploadResidentGeometry(GeodeResidentSlot& slot, const EncodedPath& encoded);
 
-  /// Build + cache the twelve-entry fill bind group for `slot` (all
+  /// Build + cache the eleven-entry fill bind group for `slot` (all
   /// bindings reference `slot.buffer` sub-ranges + device dummies).
   void buildResidentBindGroup(GeodeResidentSlot& slot);
 
@@ -657,7 +714,6 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
                                                  encoded.vBands.size() * sizeof(EncodedPath::Band));
     const auto vCurvesAlloc = allocStorageOrDummy(vCurveArena, encoded.vCurves.data(),
                                                   encoded.vCurves.size() * 6u * sizeof(float));
-    reserveGridClassSpan(encoded);
     const auto hGridAlloc = allocStorageOrDummy(gridArena, encoded.hBandGrid.data(),
                                                 encoded.hBandGrid.size() * sizeof(uint32_t));
     const auto vGridAlloc = allocStorageOrDummy(gridArena, encoded.vBandGrid.data(),
@@ -1303,7 +1359,6 @@ void GeoEncoder::fillPathIntoMask(const Path& path, FillRule rule,
       impl_->vBandArena, encoded.vBands.data(), encoded.vBands.size() * sizeof(EncodedPath::Band));
   const auto vCurvesAlloc = impl_->allocStorageOrDummy(impl_->vCurveArena, encoded.vCurves.data(),
                                                        encoded.vCurves.size() * 6u * sizeof(float));
-  impl_->reserveGridClassSpan(encoded);
   const auto hGridAlloc = impl_->allocStorageOrDummy(impl_->gridArena, encoded.hBandGrid.data(),
                                                      encoded.hBandGrid.size() * sizeof(uint32_t));
   const auto vGridAlloc = impl_->allocStorageOrDummy(impl_->gridArena, encoded.vBandGrid.data(),
@@ -1668,9 +1723,10 @@ void GeoEncoder::Impl::uploadResidentGeometry(GeodeResidentSlot& slot, const Enc
     r.size = (storageDummy && bytes == 0) ? kStorageDummyBytes : roundUp4(bytes);
     cursor += r.size;
   };
-  // The four grid regions are contiguous so ONE combined storage binding
-  // (binding 10) covers them; the instance record carries element bases
-  // relative to the combined region's start.
+  // The four grid regions are placed adjacently so ONE combined storage
+  // binding (binding 10) covers them. A solo draw's uniform carries bases
+  // relative to that binding's range; a batched draw's record carries
+  // chunk-relative bases, because its binding spans the whole chunk.
   place(slot.bands, bandsBytes, kStorageOffsetAlignment, /*storageDummy=*/true);
   place(slot.curves, curvesBytes, kStorageOffsetAlignment, /*storageDummy=*/true);
   place(slot.vBands, vBandsBytes, kStorageOffsetAlignment, /*storageDummy=*/true);
@@ -1760,19 +1816,18 @@ void GeoEncoder::Impl::buildResidentBindGroup(GeodeResidentSlot& slot) {
     entries[i].size = r.size;
   };
   bufEntry(0, 0, slot.uniform);
-  // Geometry classes bind the WHOLE slab chunk (offset 0, chunk size).
-  // The record carries chunk-relative element bases, so the same cached
-  // bind group shape and record content serve both solo resident draws
-  // and cross-entity batches.
-  const uint64_t chunkBytes = buf.getSize();
-  auto chunkEntry = [&](int i, uint32_t binding) {
-    entries[i].binding = binding;
-    entries[i].buffer = buf;
-    entries[i].offset = 0;
-    entries[i].size = chunkBytes;
-  };
-  chunkEntry(1, 1);
-  chunkEntry(2, 2);
+  // Geometry classes bind this slot's own sub-ranges, not the whole slab
+  // chunk. A whole-chunk view would also cover the chunk's not-yet-written
+  // bytes, and WebGPU has to zero-fill every byte a binding exposes before
+  // the first draw that can read it: on a cold frame that turns each new
+  // slot's first draw into a clear of the chunk's unwritten remainder, which
+  // is pure cost for a draw that only ever reads its own regions. Tight
+  // ranges start every geometry class at element zero, which is what the
+  // uniform's bases say for a solo draw. Cross-entity batches read several
+  // slots through one binding and build their own whole-chunk bind group
+  // with chunk-relative bases in each instance record.
+  bufEntry(1, 1, slot.bands);
+  bufEntry(2, 2, slot.curves);
   entries[3].binding = 3;
   entries[3].textureView = device->dummyPatternTextureView();
   entries[4].binding = 4;
@@ -1793,9 +1848,16 @@ void GeoEncoder::Impl::buildResidentBindGroup(GeodeResidentSlot& slot) {
   entries[7].buffer = device->identityInstanceRecordBuffer();
   entries[7].offset = 0;
   entries[7].size = sizeof(InstanceRecord);
-  chunkEntry(8, 8);
-  chunkEntry(9, 9);
-  chunkEntry(10, 10);
+  bufEntry(8, 8, slot.vBands);
+  bufEntry(9, 9, slot.vCurves);
+  // The four grid classes share one binding, so it spans them as a single
+  // range. `uploadResidentGeometry` places them adjacently and the uniform's
+  // grid bases are relative to this range's start.
+  const GridRegionSpan grid = gridRegionSpan(slot);
+  entries[10].binding = 10;
+  entries[10].buffer = buf;
+  entries[10].offset = grid.offset;
+  entries[10].size = grid.size;
 
   wgpu::BindGroupDescriptor bgDesc = {};
   bgDesc.label = wgpuLabel("GeodeResidentBindGroup");
@@ -1878,9 +1940,10 @@ bool GeoEncoder::Impl::ensureResidentSceneRecordImpl(GeodeResidentSlot& slot,
       record, encoded, args,
       bakeTransform ? Transform2d()
                     : composeOrthographicMvp(targetWidth, targetHeight, recordTransform));
-  // Chunk-relative element offsets: solo and batch draws both bind whole
-  // slab chunks for the geometry classes, so these bases are valid in
-  // both modes.
+  // Chunk-relative element offsets, which is what a cross-entity batch
+  // needs: its one bind group spans the whole chunk so every instance can
+  // reach its own slot. A solo draw binds its own sub-ranges instead and
+  // overrides these with range-relative bases below.
   record.bandBase = static_cast<uint32_t>(slot.bands.offset / sizeof(EncodedPath::Band));
   record.curveBase = static_cast<uint32_t>(slot.curves.offset / sizeof(float));
   record.vBandBase = static_cast<uint32_t>(slot.vBands.offset / sizeof(EncodedPath::Band));
@@ -1900,6 +1963,7 @@ bool GeoEncoder::Impl::ensureResidentSceneRecordImpl(GeodeResidentSlot& slot,
     Uniforms u = {};
     populateBatchUniform(u, args, transform, /*identityMvp=*/false);
     copyRecordParamsToUniform(u, record);
+    writeSoloGeometryBases(u, slot);
     const auto* uBytes = reinterpret_cast<const uint8_t*>(&u);
     if (slot.lastUniform.size() != sizeof(Uniforms) ||
         std::memcmp(slot.lastUniform.data(), uBytes, sizeof(Uniforms)) != 0) {
@@ -2249,17 +2313,7 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args,
       impl_->vBandArena, encoded.vBands.data(), encoded.vBands.size() * sizeof(EncodedPath::Band));
   const auto vCurvesAlloc = impl_->allocStorageOrDummy(impl_->vCurveArena, encoded.vCurves.data(),
                                                        encoded.vCurves.size() * 6u * sizeof(float));
-  impl_->reserveGridClassSpan(encoded);
-  const auto hGridAlloc = impl_->allocStorageOrDummy(impl_->gridArena, encoded.hBandGrid.data(),
-                                                     encoded.hBandGrid.size() * sizeof(uint32_t));
-  const auto vGridAlloc = impl_->allocStorageOrDummy(impl_->gridArena, encoded.vBandGrid.data(),
-                                                     encoded.vBandGrid.size() * sizeof(uint32_t));
-  const auto hRefsAlloc =
-      impl_->allocStorageOrDummy(impl_->gridArena, encoded.curveIndices.data(),
-                                 encoded.curveIndices.size() * sizeof(uint32_t));
-  const auto vRefsAlloc =
-      impl_->allocStorageOrDummy(impl_->gridArena, encoded.vCurveIndices.data(),
-                                 encoded.vCurveIndices.size() * sizeof(uint32_t));
+  const auto gridSpan = impl_->allocGridSpan(encoded);
 
   // Batch-level uniform + per-instance record. The uniform is shared with
   // the resident fill path so both produce byte-identical bytes; the record
@@ -2273,14 +2327,12 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args,
   InstanceRecord record = {};
   impl_->populateInstanceRecord(record, encoded, args, Transform2d());
 
-  // The combined grid binding spans the four grid allocations; the record
-  // carries element bases relative to that span's start.
-  const uint64_t gridSpanStart =
-      std::min({hGridAlloc.offset, vGridAlloc.offset, hRefsAlloc.offset, vRefsAlloc.offset});
-  record.hGridBase = static_cast<uint32_t>((hGridAlloc.offset - gridSpanStart) / sizeof(uint32_t));
-  record.vGridBase = static_cast<uint32_t>((vGridAlloc.offset - gridSpanStart) / sizeof(uint32_t));
-  record.hRefsBase = static_cast<uint32_t>((hRefsAlloc.offset - gridSpanStart) / sizeof(uint32_t));
-  record.vRefsBase = static_cast<uint32_t>((vRefsAlloc.offset - gridSpanStart) / sizeof(uint32_t));
+  // The four grid classes live in one packed allocation; the record carries
+  // each class's element base within it.
+  record.hGridBase = gridSpan.hGridBase;
+  record.vGridBase = gridSpan.vGridBase;
+  record.hRefsBase = gridSpan.hRefsBase;
+  record.vRefsBase = gridSpan.vRefsBase;
 
   // Every instance of this draw shares one paint and one encoded path, so
   // the parameters ride in the uniform and the fragment stage reads no
@@ -2376,16 +2428,11 @@ void GeoEncoder::submitFillDraw(const FillDrawArgs& args,
   entries[9].buffer = vCurvesAlloc.buffer;
   entries[9].offset = vCurvesAlloc.offset;
   entries[9].size = vCurvesAlloc.size;
-  // One combined binding for all four grid arrays; the record's bases
-  // index into it.
-  const uint64_t gridSpanEnd = std::max({hGridAlloc.offset + hGridAlloc.size,
-                                         vGridAlloc.offset + vGridAlloc.size,
-                                         hRefsAlloc.offset + hRefsAlloc.size,
-                                         vRefsAlloc.offset + vRefsAlloc.size});
+  // One binding for all four grid arrays; the record's bases index into it.
   entries[10].binding = 10;
-  entries[10].buffer = hGridAlloc.buffer;
-  entries[10].offset = gridSpanStart;
-  entries[10].size = gridSpanEnd - gridSpanStart;
+  entries[10].buffer = gridSpan.alloc.buffer;
+  entries[10].offset = gridSpan.alloc.offset;
+  entries[10].size = gridSpan.alloc.size;
 
   wgpu::BindGroupDescriptor bgDesc = {};
   bgDesc.label = wgpuLabel("GeodeBindGroup");
@@ -2522,9 +2569,9 @@ void GeoEncoder::Impl::uploadResidentGradientGeometry(GeodeResidentGradientSlot&
     r.size = (storageDummy && bytes == 0) ? kStorageDummyBytes : roundUp4(bytes);
     cursor += r.size;
   };
-  // The four grid regions are contiguous so ONE combined storage binding
-  // (binding 10) covers them; the instance record carries element bases
-  // relative to the combined region's start.
+  // The gradient pipeline binds every class separately, so this layout only
+  // has to keep each region at its binding's required alignment. It mirrors
+  // the fill slot's order so both read the same way.
   place(slot.bands, bandsBytes, kStorageOffsetAlignment, /*storageDummy=*/true);
   place(slot.curves, curvesBytes, kStorageOffsetAlignment, /*storageDummy=*/true);
   place(slot.vBands, vBandsBytes, kStorageOffsetAlignment, /*storageDummy=*/true);

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -618,8 +618,10 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
                               const FillDrawArgs& args, const Transform2d& transform);
 
   /// (Re)upload `encoded` into `slot`'s persistent combined buffer and
-  /// reset its cached bind group. Bumps `bufferCreates` + one
-  /// `bufferWrite` (geometry only; the uniform is written separately).
+  /// reset its cached bind group. Bumps `bufferCreates` + one `bufferWrite`
+  /// covering the WHOLE slot, uniform region and trailing padding included,
+  /// so the slot leaves no byte of the slab chunk unwritten. The draw path
+  /// rewrites the uniform region right after.
   void uploadResidentGeometry(GeodeResidentSlot& slot, const EncodedPath& encoded);
 
   /// Build + cache the eleven-entry fill bind group for `slot` (all
@@ -1737,8 +1739,12 @@ void GeoEncoder::Impl::uploadResidentGeometry(GeodeResidentSlot& slot, const Enc
   place(slot.vRefs, vRefsBytes, kStorageOffsetAlignment, /*storageDummy=*/true);
   place(slot.uniform, sizeof(Uniforms), kUniformOffsetAlignment, /*storageDummy=*/false);
 
-  const uint64_t totalSize = cursor;
-  const uint64_t geometrySize = slot.uniform.offset;  // everything before the uniform.
+  // Round the slot up to the slab's allocation alignment so consecutive
+  // slots leave no unwritten hole between them: a hole inside a chunk is a
+  // byte the driver still owes a zero-fill to, and a cross-entity batch
+  // binds whole chunks, so a hole would become clear work on the frame that
+  // first binds past it.
+  const uint64_t totalSize = alignUp(cursor, kStorageOffsetAlignment);
 
   // Suballocate from the document's resident slab (one growable buffer
   // chunk set instead of a buffer per slot). The slab is installed by the
@@ -1752,14 +1758,14 @@ void GeoEncoder::Impl::uploadResidentGeometry(GeodeResidentSlot& slot, const Enc
   slot.allocationOffset = alloc.offset;
   slot.allocationSize = alloc.size;
 
-  // Assemble the geometry portion in one zero-filled staging blob so
-  // padding + dummy regions read as zero, then upload it in a single
-  // `writeBuffer` at the allocation's absolute offset. Region offsets are
-  // relative to the allocation start here and are shifted to absolute
-  // buffer offsets below. The uniform region is written separately by the
-  // draw path (so a camera/color-only change rewrites just the uniform
-  // region).
-  std::vector<uint8_t> staging(geometrySize, 0u);
+  // Assemble the whole slot in one zero-filled staging blob so padding,
+  // dummy regions, and the not-yet-written uniform all read as zero, then
+  // upload it in a single `writeBuffer` at the allocation's absolute
+  // offset. Region offsets are relative to the allocation start here and
+  // are shifted to absolute buffer offsets below. The draw path rewrites
+  // just the uniform region afterwards, so a camera/color-only change stays
+  // a small write.
+  std::vector<uint8_t> staging(totalSize, 0u);
   auto blit = [&](const GeodeResidentSlot::Region& r, const void* data, uint64_t bytes) {
     if (bytes > 0) {
       std::memcpy(staging.data() + r.offset, data, bytes);
@@ -1774,8 +1780,8 @@ void GeoEncoder::Impl::uploadResidentGeometry(GeodeResidentSlot& slot, const Enc
   blit(slot.hGrid, encoded.hBandGrid.data(), hGridBytes);
   blit(slot.vGrid, encoded.vBandGrid.data(), vGridBytes);
 
-  device->queue().writeBuffer(slot.buffer, alloc.offset, staging.data(), geometrySize);
-  device->countBufferWrite(geometrySize);
+  device->queue().writeBuffer(slot.buffer, alloc.offset, staging.data(), totalSize);
+  device->countBufferWrite(totalSize);
 
   // Regions become absolute buffer offsets for the bind groups.
   auto shift = [&](GeodeResidentSlot::Region& r) {
@@ -2582,8 +2588,9 @@ void GeoEncoder::Impl::uploadResidentGradientGeometry(GeodeResidentGradientSlot&
   place(slot.vRefs, vRefsBytes, kStorageOffsetAlignment, /*storageDummy=*/true);
   place(slot.uniform, sizeof(GradientUniforms), kUniformOffsetAlignment, /*storageDummy=*/false);
 
-  const uint64_t totalSize = cursor;
-  const uint64_t geometrySize = slot.uniform.offset;
+  // Same no-hole rounding as `uploadResidentGeometry`: gradient slots share
+  // the chunk with fill slots, so a gap here is a hole in the same chunk.
+  const uint64_t totalSize = alignUp(cursor, kStorageOffsetAlignment);
 
   // Suballocate from the document's resident slab (same contract as
   // `uploadResidentGeometry`).
@@ -2596,7 +2603,7 @@ void GeoEncoder::Impl::uploadResidentGradientGeometry(GeodeResidentGradientSlot&
   slot.allocationOffset = alloc.offset;
   slot.allocationSize = alloc.size;
 
-  std::vector<uint8_t> staging(geometrySize, 0u);
+  std::vector<uint8_t> staging(totalSize, 0u);
   auto blit = [&](const GeodeResidentGradientSlot::Region& r, const void* data, uint64_t bytes) {
     if (bytes > 0) {
       std::memcpy(staging.data() + r.offset, data, bytes);
@@ -2611,8 +2618,8 @@ void GeoEncoder::Impl::uploadResidentGradientGeometry(GeodeResidentGradientSlot&
   blit(slot.hGrid, encoded.hBandGrid.data(), hGridBytes);
   blit(slot.vGrid, encoded.vBandGrid.data(), vGridBytes);
 
-  device->queue().writeBuffer(slot.buffer, alloc.offset, staging.data(), geometrySize);
-  device->countBufferWrite(geometrySize);
+  device->queue().writeBuffer(slot.buffer, alloc.offset, staging.data(), totalSize);
+  device->countBufferWrite(totalSize);
 
   // Regions become absolute buffer offsets for the bind groups.
   auto shift = [&](GeodeResidentGradientSlot::Region& r) {

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -50,6 +50,20 @@ constexpr uint64_t kUniformOffsetAlignment = 256u;
 static_assert(kStorageOffsetAlignment % kUniformOffsetAlignment == 0,
               "resident slab allocation alignment must satisfy uniform binding alignment");
 
+// Size of the zero-filled slot bound in place of an empty storage class.
+// WebGPU rejects a zero-sized storage binding, and it also rejects a binding
+// smaller than ONE element of the WGSL array it feeds: a binding declared
+// `array<T>` must expose at least `sizeof(T)` bytes even when the shader
+// never indexes it. The widest element any of these bindings carries is the
+// 8-byte `Band` struct, so anything below 8 fails bind-group validation at
+// submit time and invalidates the whole command buffer. 16 keeps a margin
+// for a future vec4-shaped element and still fits inside the 256-byte
+// alignment padding every one of these allocations already reserves, so it
+// costs no additional bytes anywhere.
+constexpr uint64_t kStorageDummyBytes = 16u;
+static_assert(kStorageDummyBytes % sizeof(uint32_t) == 0,
+              "storage dummy must be a whole number of u32 elements");
+
 /// Layout of the per-draw uniform buffer (must match shaders/slug_fill.wgsl).
 ///
 /// WGSL struct layout requires the total size to be a multiple of the largest
@@ -498,7 +512,7 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
         encoded.vCurveIndices.size() * sizeof(uint32_t)};
     uint64_t combined = 0;
     for (uint64_t bytes : gridClassSizes) {
-      const uint64_t slot = bytes == 0 ? uint64_t{4} : roundUp4(bytes);
+      const uint64_t slot = bytes == 0 ? kStorageDummyBytes : roundUp4(bytes);
       combined = ((combined + kStorageOffsetAlignment - 1) & ~(kStorageOffsetAlignment - 1)) + slot;
     }
     reserveInArena(gridArena, combined, kStorageOffsetAlignment);
@@ -518,14 +532,14 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
 
   /// Allocate a read-only storage binding for `byteCount` bytes of `data`,
   /// rounding the size up to a multiple of 4. When `byteCount == 0` (a
-  /// degenerate axis with no vertical band data, or an empty grid) a single
-  /// zeroed 4-byte slot is bound instead, since WebGPU rejects zero-sized
-  /// storage bindings. The shader gates on the band-count uniform so it never
-  /// dereferences the dummy slot.
+  /// degenerate axis with no vertical band data, or an empty grid) a zeroed
+  /// dummy slot of `kStorageDummyBytes` is bound instead, since WebGPU
+  /// rejects zero-sized storage bindings. The shader gates on the band-count
+  /// uniform so it never dereferences the dummy slot.
   Allocation allocStorageOrDummy(Arena& arena, const void* data, uint64_t byteCount) {
     if (byteCount == 0) {
-      static const uint32_t kZero = 0u;
-      return allocInArena(arena, &kZero, sizeof(kZero), kStorageOffsetAlignment);
+      static const uint32_t kZero[kStorageDummyBytes / sizeof(uint32_t)] = {};
+      return allocInArena(arena, kZero, sizeof(kZero), kStorageOffsetAlignment);
     }
     return allocInArena(arena, data, roundUp4(byteCount), kStorageOffsetAlignment);
   }
@@ -1643,15 +1657,15 @@ void GeoEncoder::Impl::uploadResidentGeometry(GeodeResidentSlot& slot, const Enc
 
   // Lay out the combined buffer. Each storage region's offset satisfies
   // `kStorageOffsetAlignment`; the uniform region needs `kUniformOffsetAlignment`. Empty storage
-  // regions reserve a 4-byte zero-filled dummy slot (the shader's
-  // band-count gate never dereferences them), mirroring the arena
+  // regions reserve a `kStorageDummyBytes` zero-filled dummy slot (the
+  // shader's band-count gate never dereferences them), mirroring the arena
   // `allocStorageOrDummy` dummy.
   uint64_t cursor = 0;
   auto place = [&](GeodeResidentSlot::Region& r, uint64_t bytes, uint64_t alignment,
                    bool storageDummy) {
     cursor = alignUp(cursor, alignment);
     r.offset = cursor;
-    r.size = (storageDummy && bytes == 0) ? uint64_t{4} : roundUp4(bytes);
+    r.size = (storageDummy && bytes == 0) ? kStorageDummyBytes : roundUp4(bytes);
     cursor += r.size;
   };
   // The four grid regions are contiguous so ONE combined storage binding
@@ -2505,7 +2519,7 @@ void GeoEncoder::Impl::uploadResidentGradientGeometry(GeodeResidentGradientSlot&
                    bool storageDummy) {
     cursor = alignUp(cursor, alignment);
     r.offset = cursor;
-    r.size = (storageDummy && bytes == 0) ? uint64_t{4} : roundUp4(bytes);
+    r.size = (storageDummy && bytes == 0) ? kStorageDummyBytes : roundUp4(bytes);
     cursor += r.size;
   };
   // The four grid regions are contiguous so ONE combined storage binding

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -1469,6 +1469,10 @@ bool GeoEncoder::hasActiveScissor() const {
   return impl_->scissorActive;
 }
 
+bool GeoEncoder::hasOpenMaskPass() const {
+  return impl_->maskPassOpen;
+}
+
 void GeoEncoder::setLoadPreserve() {
   // No-op if a pass is already open - loadOp is a pass-construction
   // parameter and can't be changed mid-pass. The RendererGeode caller

--- a/donner/svg/renderer/geode/GeoEncoder.h
+++ b/donner/svg/renderer/geode/GeoEncoder.h
@@ -262,6 +262,13 @@ public:
   /// scissor at flush time instead of at draw time).
   bool hasActiveScissor() const;
 
+  /// True while a mask pass is open, i.e. draws are being recorded into a
+  /// mask texture through the mask pipeline rather than into the main pass.
+  /// Residency and the ordered batch gate both exclude these draws: a batch
+  /// defers to flush time, by which point the mask pass has closed and the
+  /// draw would land in the wrong target.
+  bool hasOpenMaskPass() const;
+
   /// Set the model-view transform for subsequent draw calls.
   void setTransform(const Transform2d& transform);
 

--- a/donner/svg/renderer/geode/GeodeResidentPathComponent.h
+++ b/donner/svg/renderer/geode/GeodeResidentPathComponent.h
@@ -520,7 +520,11 @@ struct GeodeResidentSlot {
   /// `GeodeResidentSlab` chunk. Region offsets are ABSOLUTE buffer
   /// offsets. Layout (each region offset satisfies the binding's
   /// alignment requirement):
-  ///   [ bands | curves | hRefs | vBands | vCurves | vRefs | hGrid | vGrid | uniform | instanceRecord ]
+  ///   [ bands | curves | vBands | vCurves | hGrid | vGrid | hRefs | vRefs | uniform ]
+  /// The four grid classes are placed adjacently on purpose: they share one
+  /// storage binding, whose range spans them. The slot is padded out to the
+  /// slab's allocation alignment so consecutive slots leave no unwritten
+  /// bytes between them.
   wgpu::Buffer buffer;
   /// Slab that owns `buffer`; null until residence is established. Held
   /// by shared_ptr so a device change (which swaps the registry's slab)
@@ -531,7 +535,7 @@ struct GeodeResidentSlot {
   uint64_t allocationOffset = 0;
   uint64_t allocationSize = 0;
 
-  /// Cached fill bind group. All fourteen bindings reference stable
+  /// Cached fill bind group. All eleven bindings reference stable
   /// objects (this slot's `buffer` sub-ranges + device-owned dummy
   /// texture/sampler/identity-instance handles), so it survives frames
   /// and encoders. Rebuilt only when the geometry buffer is
@@ -551,12 +555,14 @@ struct GeodeResidentSlot {
 
   Region bands;    ///< Horizontal band SSBO (binding 1).
   Region curves;   ///< Horizontal curve SSBO (binding 2).
-  Region hRefs;    ///< Horizontal curve-reference SSBO (binding 12).
+  // The four grid classes below share binding 10, whose range covers all of
+  // them; each one is reached through an element base in the uniform.
+  Region hRefs;    ///< Horizontal curve-reference SSBO (binding 10).
   Region vBands;   ///< Vertical band SSBO (binding 8).
   Region vCurves;  ///< Vertical curve SSBO (binding 9).
-  Region vRefs;    ///< Vertical curve-reference SSBO (binding 13).
+  Region vRefs;    ///< Vertical curve-reference SSBO (binding 10).
   Region hGrid;    ///< Horizontal band grid (binding 10).
-  Region vGrid;    ///< Vertical band grid (binding 11).
+  Region vGrid;    ///< Vertical band grid (binding 10).
   Region uniform;  ///< Batch-level uniform block (binding 0, 256-aligned).
 
   /// Document-scoped record slab slot for this entity's instance record

--- a/donner/svg/renderer/geode/GeodeResidentPathComponent.h
+++ b/donner/svg/renderer/geode/GeodeResidentPathComponent.h
@@ -539,9 +539,11 @@ struct GeodeResidentSlot {
   ScopedWgpuHandle<wgpu::BindGroup> bindGroup;
 
   /// A byte sub-range of `buffer`. `size == 0` is never bound directly -
-  /// empty SSBO regions reserve a 4-byte zero-filled slot so the shader's
-  /// band-count gate keeps them un-dereferenced (matching the per-frame
-  /// arena `allocStorageOrDummy` dummy).
+  /// empty SSBO regions reserve a zero-filled dummy slot wide enough for one
+  /// element of the WGSL array they feed, so the shader's band-count gate
+  /// keeps them un-dereferenced and the binding still passes WebGPU's
+  /// minimum-size validation (matching the per-frame arena
+  /// `allocStorageOrDummy` dummy).
   struct Region {
     uint64_t offset = 0;
     uint64_t size = 0;

--- a/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodePerf_tests.cc
@@ -210,10 +210,16 @@ TEST_F(GeodePerfTest, SimpleShapes_BaselineCeilings) {
   // arenas (vBands/vCurves/hBandGrid/vBandGrid) on top of bands/curves/vertex/
   // uniform, so first-frame arena growth costs a few more buffer creates.
   EXPECT_LE(c.bufferCreates, 12u);
-  EXPECT_LE(c.bindgroupCreates, 6u);  // Target <= #pipelines (3 today).
-  EXPECT_LE(c.textureCreates, 3u);    // Target on frame 1; 0 on repeat.
-  EXPECT_LE(c.submits, 3u);           // Target = 1.
-  EXPECT_LE(c.drawCalls, 4u);         // 3 shapes, one draw each.
+  // One group for the batch, one for the snapshot readback.
+  EXPECT_LE(c.bindgroupCreates, 2u);
+  EXPECT_LE(c.textureCreates, 3u);  // Target on frame 1; 0 on repeat.
+  EXPECT_LE(c.submits, 3u);         // Target = 1.
+  // Three unclipped solid fills of distinct entities in painter order form
+  // one ordered cross-entity batch, so the whole fixture is a single
+  // instanced draw. Each instance's record carries its own color and fill
+  // rule, so the fixture's differing paints (red / blue / green) do not
+  // split the batch.
+  EXPECT_LE(c.drawCalls, 1u);
   EXPECT_LE(c.pipelineSwitches, 2u);  // Solid pipeline bound once.
 }
 
@@ -406,22 +412,23 @@ TEST_F(GeodePerfTest, Lion_BaselineCeilings) {
   //   device dummies + texture pool: target on frame 1; 0 on repeat.
   //   draw instrumentation: drawCalls=132 (one per path),
   //                       pipelineSwitches=1 (solid pipeline only -
-  //                       all of Lion is solid-fill). `<use>` instancing
-  //                       is the knob that moves drawCalls for
-  //                       `<use>`-heavy fixtures; Lion has no `<use>`
-  //                       so this ceiling stays at 132.
+  //                       all of Lion is solid-fill).
   EXPECT_LE(c.pathEncodes, 200u);  // Target = 0.
-  // GPU residence: frame 1 now front-loads ONE persistent
-  // combined buffer per cached solid-fill path (132 for Lion) so that
-  // steady-state frames re-upload zero geometry. This trades a one-time
-  // frame-1 buffer-create spike for the steady-state win asserted in
-  // `Lion_NoDirtyPath_ZeroEncodes` (frame-2 bufferCreates == 1, the
-  // readback). Ceiling = 132 resident + readback + arena slack.
-  EXPECT_LE(c.bufferCreates, 150u);
-  EXPECT_LE(c.bindgroupCreates, 200u);   // Target <= #pipelines.
-  EXPECT_LE(c.textureCreates, 3u);       // Target on first render; 0 on repeat.
-  EXPECT_LE(c.submits, 3u);              // Target = 1.
-  EXPECT_LE(c.drawCalls, 200u);          // 132 paths, one draw each (no <use>).
+  // GPU residence packs every cached solid fill into shared slab chunks
+  // rather than a buffer per path, so frame 1 creates a handful of slab
+  // chunks, the record slab, the arenas and the readback buffer - a count
+  // set by the slab chunk size, not by the 132 paths. Steady-state frames
+  // then re-upload zero geometry (`Lion_NoDirtyPath_ZeroEncodes`).
+  EXPECT_LE(c.bufferCreates, 8u);
+  // Ordered cross-entity batching collapsed this from one bind group per
+  // draw (133) to the batch's own group plus the readback's.
+  EXPECT_LE(c.bindgroupCreates, 2u);
+  EXPECT_LE(c.textureCreates, 3u);  // Target on first render; 0 on repeat.
+  EXPECT_LE(c.submits, 3u);         // Target = 1.
+  // All 132 paths are unclipped solid fills in painter order sharing one slab
+  // chunk, so they merge into a single instanced draw. Lion has no `<use>`,
+  // so this is entirely the cross-entity path, not same-entity instancing.
+  EXPECT_LE(c.drawCalls, 1u);
   EXPECT_LE(c.pipelineSwitches, 2u);     // All-solid fixture: tracker binds solid once.
   EXPECT_EQ(c.sameSourceDrawPairs, 0u);  // No `<use>` in Lion - every draw has a unique source.
 }
@@ -642,14 +649,14 @@ TEST_F(GeodePerfTest, Lion_NoDirtyPath_ZeroEncodes) {
   // fills are GPU-resident from frame 1, so an unchanged second render
   // re-uploads zero geometry bytes and creates zero bind groups. The
   // pre-residence baseline was bufferWriteBytes=172776 across 1056 writes, and
-  // bindgroupCreates=132 (one per draw). drawCalls stays 132 - the draws
-  // still happen, they just bind cached resident buffers.
+  // bindgroupCreates=132 (one per draw). The 132 draws now merge into one
+  // ordered cross-entity batch that binds the cached resident buffers.
   EXPECT_LE(c.bufferWriteBytes, 4096u)
       << "Steady-state geometry re-upload on an unchanged second render of lion.svg: resident "
          "buffers should serve every draw.";
-  // Resident draws reuse their cached bind groups on an unchanged frame;
-  // cross-entity batching is gated off, so nothing here may create groups
-  // per draw or per batch.
+  // Resident draws reuse their cached bind groups on an unchanged frame, and
+  // a scene batch reuses the group cached under its arena / slab identities,
+  // so nothing here may create a group per draw or per batch.
   EXPECT_LE(c.bindgroupCreates, 1u)
       << "Steady-state bind-group creates: cached resident groups should serve every draw.";
 }
@@ -686,12 +693,22 @@ TEST_F(GeodePerfTest, GhostscriptTiger_NoDirtyPath_ZeroEncodes) {
   // unchanged second render re-uploads zero geometry bytes and creates
   // zero bind groups - a >99% reduction, far past the 90% acceptance
   // floor (which would be <= 147388 bytes). Both fill AND stroke slots
-  // are exercised (Tiger has strokes). drawCalls stays 304.
+  // are exercised (Tiger has strokes). The 304 draws merge down to 153:
+  // Tiger's strokes are not batch-eligible, so each one ends a run of fills.
   EXPECT_LE(c.bufferWriteBytes, 8192u)
       << "Steady-state geometry re-upload on an unchanged second render of Ghostscript_Tiger.svg. "
          "The pre-residency baseline was 1,473,888 bytes; residency should drive this to ~0.";
   EXPECT_LE(c.bindgroupCreates, 2u)
       << "Steady-state bind-group creates no longer proportional to draw calls (was 304).";
+  // Batching is not free here: the batched and solo solid fills are separate
+  // pipeline objects, so every stroke that interrupts a run of fills costs a
+  // switch back and forth. Tiger went from 1 switch (one solid pipeline for
+  // all 304 draws) to 11 as the draws collapsed to 153. That is a good trade
+  // at this ratio, but it scales with how often non-eligible draws interleave,
+  // so bound it rather than letting it track the draw count again.
+  EXPECT_LE(c.pipelineSwitches, 12u)
+      << "Pipeline alternation between the batched and solo solid fill pipelines grew: a batch "
+         "that keeps getting interrupted gives back the draw-call win.";
 }
 
 // ---------------------------------------------------------------------------

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -3022,5 +3022,59 @@ TEST_F(RendererGeodeTest, NullDeviceEntersNoOpModeWithoutCrashing) {
   EXPECT_TRUE(renderer.takeSnapshot().empty());
 }
 
+/// A fill whose subpaths are all vertical segments produces horizontal band
+/// data but an EMPTY vertical band array, so the vertical band binding falls
+/// back to the zero-filled slot every empty storage class reserves. WebGPU
+/// requires a storage binding to expose at least one element of the WGSL
+/// array it feeds, and `array<Band>` has an 8-byte stride, so a narrower
+/// dummy fails bind-group validation at submit, invalidates the whole
+/// command buffer of that frame, and takes the process down with it. The
+/// rectangle drawn alongside the degenerate path is the liveness signal: its
+/// pixels only survive if the frame actually submitted.
+///
+/// Unclipped, which takes the resident per-slot bindings.
+TEST_F(RendererGeodeTest, VerticalOnlyFillWithEmptyVerticalBandsRenders) {
+  ParseWarningSink warningSink;
+  auto maybeDocument = parser::SVGParser::ParseSVG(
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+             <rect x="0" y="0" width="64" height="64" fill="#00ff00"/>
+             <path d="M 16 8 L 16 56 M 48 8 L 48 56" fill="#0000ff"/>
+           </svg>)svg",
+      warningSink);
+  ASSERT_FALSE(maybeDocument.hasError()) << maybeDocument.error();
+  SVGDocument document = std::move(maybeDocument).result();
+
+  RendererGeode renderer = createRenderer();
+  renderer.draw(document);
+  const RendererBitmap snapshot = renderer.takeSnapshot();
+  ASSERT_FALSE(snapshot.empty());
+  EXPECT_THAT(pixelAt(snapshot, 32, 32), RgbaEq(0, 255, 0, 255))
+      << "A fill with no vertical bands must not invalidate the frame it is drawn in.";
+}
+
+/// Clipped, which takes the per-frame arena bindings instead of the resident
+/// ones. Same defect, different allocation path.
+TEST_F(RendererGeodeTest, ClippedVerticalOnlyFillWithEmptyVerticalBandsRenders) {
+  ParseWarningSink warningSink;
+  auto maybeDocument = parser::SVGParser::ParseSVG(
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+             <clipPath id="c"><rect x="0" y="0" width="64" height="64"/></clipPath>
+             <g clip-path="url(#c)">
+               <rect x="0" y="0" width="64" height="64" fill="#00ff00"/>
+               <path d="M 16 8 L 16 56 M 48 8 L 48 56" fill="#0000ff"/>
+             </g>
+           </svg>)svg",
+      warningSink);
+  ASSERT_FALSE(maybeDocument.hasError()) << maybeDocument.error();
+  SVGDocument document = std::move(maybeDocument).result();
+
+  RendererGeode renderer = createRenderer();
+  renderer.draw(document);
+  const RendererBitmap snapshot = renderer.takeSnapshot();
+  ASSERT_FALSE(snapshot.empty());
+  EXPECT_THAT(pixelAt(snapshot, 32, 32), RgbaEq(0, 255, 0, 255))
+      << "A clipped fill with no vertical bands must not invalidate the frame it is drawn in.";
+}
+
 }  // namespace
 }  // namespace donner::svg


### PR DESCRIPTION
Geode first frames pay for zero-initialization the steady state never sees: WebGPU guarantees a shader cannot read uninitialized memory, so the driver zero-fills every byte a bind group exposes that no queue write initialized. Two binding patterns left such bytes exposed, costing +10-22% on cold frames depending on scene shape. Second PR of a stack on top of the scene-batching flip.

Three commits:

- **Bind a whole array element for an empty storage class.** Empty band/curve classes reserved a 4-byte dummy region, but the shader's `array<Band>` stride is 8 bytes and the pipeline layout defers the size check to draw time, so binding an empty class aborted the process (validation error, invalid command buffer, panic in submit). This pre-exists on main for clipped draws through the arena path and became reachable on the default resident path with the rebinding below, so the fix rides first in the stack: 16-byte dummies, which fit inside alignment padding every allocation already reserves. Two red-then-green regression tests cover a vertical-only fill both unclipped (resident path) and clipped (arena path, crashes main today); each renders a companion rectangle so a failed submit is caught by pixels, not just by the absence of an abort.
- **Keep fill bindings free of bytes no draw ever writes.** The solo resident bind group binds each slot's own sub-ranges instead of the whole slab chunk (uniform bases are relative to the bound range; cross-entity batches keep the whole-chunk view with chunk-relative record bases, and the grid binding's range is computed as a min/max over the four grid regions so a layout reorder cannot silently corrupt it). The arena fill path packs the four grid classes into one allocation, collapsing four buffer writes per draw into one.
- **Leave no unwritten hole between resident slab slots.** Slots round up to the slab allocation alignment and uploads stage the whole slot including trailing padding, so no gap between consecutive slots is left for the driver to clear.

Measured on a discrete GPU (Vulkan), interleaved passes against both the pre-consolidation baseline and current main: first frames return to at-or-better-than the old baseline on all five standard scenes (worst case was text at +24%, now -11% vs that baseline; stroking +15% to -2%), and steady state improves as a side effect of the write consolidation (text -20%, poker -8%). Render hashes are identical across baseline, main, and this branch on every scene. The deliberate tradeoff: first-frame buffer-write bytes rise 2-20% by scene (about 512 bytes per resident slot, staging the uniform region plus padding) to avoid the driver's zero-fill of exposed gaps, while arena-heavy scenes write fewer times overall; steady-state bytes are unchanged.

Full geode plus gpu-inventory surface green in both invocation styles (77 targets under the geode config), goldens and resvg suite included, counter ratchets unmoved.
