### PR TITLE
ci: Fix the coverage workflow startup failure (template length cap)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -254,7 +254,7 @@ jobs:
 
             # Non-PR events (main pushes) always run: that baseline is what
             # lets PR-side fallbacks be skipped at all.
-            if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            if [[ "$EVENT_NAME" != "pull_request" ]]; then
               echo true
               return
             fi
@@ -306,7 +306,7 @@ jobs:
             } > "$diagnostics_dir/summary.txt"
           }
 
-          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
             echo "Non-PR event; using full coverage target set."
             emit_targets true non_pr "$FULL_COVERAGE_TARGETS"
             exit 0


### PR DESCRIPTION
The coverage workflow has startup-failed on every push since its target-selection script last grew: GitHub evaluates a run block containing any inline expression as a single template, templates are capped at 21000 characters, and the script now measures ~25800. The failure presents as a run named by the workflow file path with zero jobs and the message "(Line: 169, Col: 14): Exceeded max expression length 21000", created even for branch pushes because filter evaluation never happens.

The two inline `${{ github.event_name }}` reads inside the script duplicate the `EVENT_NAME` env var the same step already defines. Switching them to the env var leaves the block expression-free, which lifts the template cap entirely (no expression means no template evaluation) and also removes the last direct interpolation of workflow context into that shell script.

Two-line change, no behavior difference: the env var carries the identical value. The pull_request coverage lanes on this PR are themselves the verification that the workflow parses again.