### PR TITLE
perf: Resident per-glyph outline instancing for Geode text

### DIFF
--- a/donner/editor/tests/TextToOutlines_tests.cc
+++ b/donner/editor/tests/TextToOutlines_tests.cc
@@ -95,13 +95,25 @@ std::string ApplyConversion(svg::SVGDocument& document, svg::SVGElement text,
 ///
 /// Conversion must not move, restyle, or drop anything, and a real defect there
 /// shows up as hundreds or thousands of divergent pixels. It is not, however, a
-/// bit-exact identity: the GPU backend keeps a glyph's outline resident in the
-/// glyph's own coordinate space and carries the placement in the draw
-/// transform, while a converted `<path>` is encoded at its placed coordinates.
-/// Analytic coverage evaluated from those two (equally valid) spaces lands a
-/// handful of glyph-edge pixels a couple of levels apart. The per-pixel
-/// threshold is the renderer suite's standard 0.02, and NO pixel is allowed to
-/// exceed it, so the allowance covers last-bits shading and nothing else.
+/// bit-exact identity on the GPU backend, for one narrow reason: a resident
+/// glyph outline is encoded in the glyph's own coordinate space and placed by
+/// the draw transform, while a converted `<path>` is encoded at its placed
+/// coordinates. Both spaces are axis-aligned with the pixel grid and the
+/// analytic coverage is the same algorithm; what differs is float32
+/// conditioning at large versus small coordinates.
+///
+/// On THESE fixtures that was measured at up to 3/255 across 6 to 12
+/// glyph-edge pixels. That figure is not a universal bound and must not be
+/// quoted as one: elsewhere in the render corpus the same mechanism puts a
+/// handful of edge pixels a few tens of levels apart, on documents this suite
+/// does not cover.
+///
+/// The allowance is the renderer suite's standard per-pixel threshold with ZERO
+/// pixels permitted to exceed it. Read honestly, that bounds how far any single
+/// pixel may drift and puts no cap on how many pixels sit under the bound - a
+/// uniform sub-threshold shift across the whole glyph would pass. What it rules
+/// out is any pixel moving far enough to be a placement, paint, or coverage
+/// error, which is the class of defect this check exists to catch.
 tests::BitmapGoldenCompareParams OutlineConversionParams() {
   return tests::ApprovedPixelToleranceParams(/*threshold=*/0.02f, /*maxMismatchedPixels=*/0,
                                              /*includeAntiAliasing=*/true);
@@ -204,6 +216,34 @@ TEST(TextToOutlines, PixelCompareBeforeAndAfterMatches) {
 // children (x + dy line advance), the box-size data attributes, and bold
 // styling. Conversion must produce path geometry that renders pixel-identical
 // to the live text.
+// Per-glyph `rotate` is the case that most stresses the comparison above: the
+// GPU backend keeps a rotated glyph's outline resident with the rotation baked
+// in, so the resident space stays aligned with the pixel grid. Leaving the
+// rotation in the draw transform instead tilts that space, the analytic
+// coverage measures the glyph through a coarser per-axis footprint, and the
+// edges soften - this fixture's own red measured 57/255 across 582 pixels, far
+// outside what the conversion check allows. Keep a rotated document in the
+// matrix so that failure mode cannot come back unnoticed.
+TEST(TextToOutlines, ConvertsRotatedGlyphsWithoutLosingEdgeFidelity) {
+  constexpr std::string_view kRotatedSvg =
+      R"(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+<text x="20" y="120" font-family="sans-serif" font-size="48" fill="black" rotate="30">Text</text>
+</svg>)";
+  svg::SVGDocument converted = Parse(kRotatedSvg);
+  svg::SVGElement text = TextElement(converted);
+
+  ConvertTextToOutlinesResult result = convertTextToOutlines(converted, text);
+  ASSERT_TRUE(result.ok) << result.error;
+  const std::string mergedSource = ApplyConversion(converted, text, result);
+
+  svg::SVGDocument beforeFresh = Parse(kRotatedSvg);
+  svg::SVGDocument after = Parse(mergedSource);
+  const svg::RendererBitmap beforeBitmap = RenderToBitmap(beforeFresh);
+  const svg::RendererBitmap afterBitmap = RenderToBitmap(after);
+  tests::CompareBitmapToBitmap(afterBitmap, beforeBitmap, "text_to_outlines_rotated_glyphs",
+                               OutlineConversionParams());
+}
+
 TEST(TextToOutlines, ConvertsTextToolBoxTextPixelIdentical) {
   constexpr std::string_view kToolAuthoredSvg =
       R"(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">

--- a/donner/editor/tests/TextToOutlines_tests.cc
+++ b/donner/editor/tests/TextToOutlines_tests.cc
@@ -90,12 +90,30 @@ std::string ApplyConversion(svg::SVGDocument& document, svg::SVGElement text,
   return std::string(document.source());
 }
 
+/// Comparison parameters for "the same content, before and after conversion to
+/// outlines".
+///
+/// Conversion must not move, restyle, or drop anything, and a real defect there
+/// shows up as hundreds or thousands of divergent pixels. It is not, however, a
+/// bit-exact identity: the GPU backend keeps a glyph's outline resident in the
+/// glyph's own coordinate space and carries the placement in the draw
+/// transform, while a converted `<path>` is encoded at its placed coordinates.
+/// Analytic coverage evaluated from those two (equally valid) spaces lands a
+/// handful of glyph-edge pixels a couple of levels apart. The per-pixel
+/// threshold is the renderer suite's standard 0.02, and NO pixel is allowed to
+/// exceed it, so the allowance covers last-bits shading and nothing else.
+tests::BitmapGoldenCompareParams OutlineConversionParams() {
+  return tests::ApprovedPixelToleranceParams(/*threshold=*/0.02f, /*maxMismatchedPixels=*/0,
+                                             /*includeAntiAliasing=*/true);
+}
+
 /// Paint-retention matrix helper. Parses \p svg, converts its first `<text>` to
 /// outlines, applies the structural edit, and asserts the converted document
-/// renders pixel-identical to the original text. This is the load-bearing
-/// assertion for W4: whatever styling form painted the source text (presentation
-/// attribute, CSS rule, inline style, inheritance, per-tspan override, paint
-/// server, currentColor, or an opacity interaction) must survive the conversion.
+/// renders the same as the original text. This is the load-bearing assertion
+/// for paint retention: whatever styling form painted the source text
+/// (presentation attribute, CSS rule, inline style, inheritance, per-tspan
+/// override, paint server, currentColor, or an opacity interaction) must
+/// survive the conversion.
 void ExpectPaintRetained(std::string_view svg, std::string_view label) {
   svg::SVGDocument converted = Parse(svg);
   svg::SVGElement text = TextElement(converted);
@@ -110,7 +128,7 @@ void ExpectPaintRetained(std::string_view svg, std::string_view label) {
   const svg::RendererBitmap afterBitmap = RenderToBitmap(after);
 
   tests::CompareBitmapToBitmap(afterBitmap, beforeBitmap, std::string(label),
-                               tests::PixelmatchIdentityParams());
+                               OutlineConversionParams());
 }
 
 }  // namespace
@@ -179,7 +197,7 @@ TEST(TextToOutlines, PixelCompareBeforeAndAfterMatches) {
   // `CompareBitmapToBitmap` adds gtest failures and writes
   // actual_/expected_/diff_ PNGs to $TEST_UNDECLARED_OUTPUTS_DIR on mismatch.
   tests::CompareBitmapToBitmap(afterBitmap, beforeBitmap, "text_to_outlines_before_after",
-                               tests::PixelmatchIdentityParams());
+                               OutlineConversionParams());
 }
 
 // Text authored by the editor's text tool: box text with per-line <tspan>
@@ -208,7 +226,7 @@ TEST(TextToOutlines, ConvertsTextToolBoxTextPixelIdentical) {
   const svg::RendererBitmap beforeBitmap = RenderToBitmap(beforeFresh);
   const svg::RendererBitmap afterBitmap = RenderToBitmap(after);
   tests::CompareBitmapToBitmap(afterBitmap, beforeBitmap, "text_to_outlines_tool_box_text",
-                               tests::PixelmatchIdentityParams());
+                               OutlineConversionParams());
 }
 
 // Preserves fill, opacity, transform, fill-rule, stroke, and paint order: the

--- a/donner/svg/renderer/BUILD.bazel
+++ b/donner/svg/renderer/BUILD.bazel
@@ -394,6 +394,7 @@ donner_cc_library(
         # GeodeFilterEngine that were previously separate libraries
         # (see that target's comment).
         "//donner/svg/renderer/geode:geode_device",
+        "//donner/svg/renderer/geode:geode_glyph_residency",
         "//donner/svg/renderer/geode:geode_path_cache_component",
         "//donner/svg/renderer/geode:geode_resident_path_component",
         "//donner/svg/renderer/geode:geode_path_encoder",

--- a/donner/svg/renderer/PlacedTextGeometry.cc
+++ b/donner/svg/renderer/PlacedTextGeometry.cc
@@ -70,8 +70,8 @@ GlyphOutlineAndPlacement UnplacedGlyphOutline(const TextEngine& textEngine, Font
   //    when a per-glyph rotation is present the stretch axes follow the glyph,
   //    not the post-rotation frame.
   if (glyph.stretchScaleX != 1.0f || glyph.stretchScaleY != 1.0f) {
-    result.outline = TransformPath(result.outline,
-                                   Transform2d::Scale(glyph.stretchScaleX, glyph.stretchScaleY));
+    result.outline =
+        TransformPath(result.outline, Transform2d::Scale(glyph.stretchScaleX, glyph.stretchScaleY));
   }
 
   return result;

--- a/donner/svg/renderer/PlacedTextGeometry.cc
+++ b/donner/svg/renderer/PlacedTextGeometry.cc
@@ -36,8 +36,9 @@ Path TransformPath(const Path& path, const Transform2d& transform) {
 }
 
 Transform2d GlyphPlacementTransform(const TextGlyph& glyph) {
-  // Translate to the baseline origin, then rotate about it. As a composed
-  // transform this is `Rotate * Translate` (translate applied first), matching
+  // Rotate the outline about its own origin, then move it to the baseline
+  // position: `Rotate * Translate`, which applies the rotation first because a
+  // `Transform2d` product applies its LEFT operand first. Matching
   // `RendererTinySkia::drawText`.
   Transform2d glyphFromLocal = Transform2d::Translate(glyph.xPosition, glyph.yPosition);
   if (glyph.rotateDegrees != 0.0) {

--- a/donner/svg/renderer/PlacedTextGeometry.cc
+++ b/donner/svg/renderer/PlacedTextGeometry.cc
@@ -35,16 +35,34 @@ Path TransformPath(const Path& path, const Transform2d& transform) {
   return builder.build();
 }
 
-Path PlacedGlyphOutline(const TextEngine& textEngine, FontHandle font, const TextGlyph& glyph,
-                        float scale) {
+Transform2d GlyphPlacementTransform(const TextGlyph& glyph) {
+  // Translate to the baseline origin, then rotate about it. As a composed
+  // transform this is `Rotate * Translate` (translate applied first), matching
+  // `RendererTinySkia::drawText`.
+  Transform2d glyphFromLocal = Transform2d::Translate(glyph.xPosition, glyph.yPosition);
+  if (glyph.rotateDegrees != 0.0) {
+    glyphFromLocal = Transform2d::Rotate(glyph.rotateDegrees * MathConstants<double>::kPi / 180.0) *
+                     glyphFromLocal;
+  }
+  return glyphFromLocal;
+}
+
+GlyphOutlineAndPlacement UnplacedGlyphOutline(const TextEngine& textEngine, FontHandle font,
+                                              const TextGlyph& glyph, float scale) {
+  GlyphOutlineAndPlacement result;
+
+  // 3. Position. Computed even for an empty outline so the placement stays a
+  //    pure function of the glyph's position fields.
+  result.glyphFromLocal = GlyphPlacementTransform(glyph);
+
   if (glyph.glyphIndex == 0) {
-    return Path();  // `.notdef` -- caller skips.
+    return result;  // `.notdef` -- caller skips.
   }
 
   // 1. Raw outline at the glyph's effective scale.
-  Path glyphPath = textEngine.glyphOutline(font, glyph.glyphIndex, scale * glyph.fontSizeScale);
-  if (glyphPath.empty()) {
-    return glyphPath;  // No vector outline (e.g. bitmap-only) -- caller handles.
+  result.outline = textEngine.glyphOutline(font, glyph.glyphIndex, scale * glyph.fontSizeScale);
+  if (result.outline.empty()) {
+    return result;  // No vector outline (e.g. bitmap-only) -- caller handles.
   }
 
   // 2. Stretch the raw outline (lengthAdjust=spacingAndGlyphs), matching
@@ -52,20 +70,20 @@ Path PlacedGlyphOutline(const TextEngine& textEngine, FontHandle font, const Tex
   //    when a per-glyph rotation is present the stretch axes follow the glyph,
   //    not the post-rotation frame.
   if (glyph.stretchScaleX != 1.0f || glyph.stretchScaleY != 1.0f) {
-    glyphPath =
-        TransformPath(glyphPath, Transform2d::Scale(glyph.stretchScaleX, glyph.stretchScaleY));
+    result.outline = TransformPath(result.outline,
+                                   Transform2d::Scale(glyph.stretchScaleX, glyph.stretchScaleY));
   }
 
-  // 3. Position: translate to the baseline origin, then rotate about it. As a
-  //    composed transform this is `Rotate * Translate` (translate applied
-  //    first), matching `RendererTinySkia::drawText`.
-  Transform2d glyphFromLocal = Transform2d::Translate(glyph.xPosition, glyph.yPosition);
-  if (glyph.rotateDegrees != 0.0) {
-    glyphFromLocal = Transform2d::Rotate(glyph.rotateDegrees * MathConstants<double>::kPi / 180.0) *
-                     glyphFromLocal;
-  }
+  return result;
+}
 
-  return TransformPath(glyphPath, glyphFromLocal);
+Path PlacedGlyphOutline(const TextEngine& textEngine, FontHandle font, const TextGlyph& glyph,
+                        float scale) {
+  const GlyphOutlineAndPlacement unplaced = UnplacedGlyphOutline(textEngine, font, glyph, scale);
+  if (unplaced.outline.empty()) {
+    return unplaced.outline;
+  }
+  return TransformPath(unplaced.outline, unplaced.glyphFromLocal);
 }
 
 Box2d ComputeTextBounds(const TextEngine& textEngine, const std::vector<TextRun>& runs,

--- a/donner/svg/renderer/PlacedTextGeometry.cc
+++ b/donner/svg/renderer/PlacedTextGeometry.cc
@@ -36,24 +36,15 @@ Path TransformPath(const Path& path, const Transform2d& transform) {
 }
 
 Transform2d GlyphPlacementTransform(const TextGlyph& glyph) {
-  // Rotate the outline about its own origin, then move it to the baseline
-  // position: `Rotate * Translate`, which applies the rotation first because a
-  // `Transform2d` product applies its LEFT operand first. Matching
-  // `RendererTinySkia::drawText`.
-  Transform2d glyphFromLocal = Transform2d::Translate(glyph.xPosition, glyph.yPosition);
-  if (glyph.rotateDegrees != 0.0) {
-    glyphFromLocal = Transform2d::Rotate(glyph.rotateDegrees * MathConstants<double>::kPi / 180.0) *
-                     glyphFromLocal;
-  }
-  return glyphFromLocal;
+  return Transform2d::Translate(glyph.xPosition, glyph.yPosition);
 }
 
 GlyphOutlineAndPlacement UnplacedGlyphOutline(const TextEngine& textEngine, FontHandle font,
                                               const TextGlyph& glyph, float scale) {
   GlyphOutlineAndPlacement result;
 
-  // 3. Position. Computed even for an empty outline so the placement stays a
-  //    pure function of the glyph's position fields.
+  // Position. Computed even for an empty outline so the placement stays a pure
+  // function of the glyph's position fields.
   result.glyphFromLocal = GlyphPlacementTransform(glyph);
 
   if (glyph.glyphIndex == 0) {
@@ -75,16 +66,55 @@ GlyphOutlineAndPlacement UnplacedGlyphOutline(const TextEngine& textEngine, Font
         TransformPath(result.outline, Transform2d::Scale(glyph.stretchScaleX, glyph.stretchScaleY));
   }
 
+  // 3. Rotation, baked into the OUTLINE rather than left in the placement.
+  //
+  //    A renderer that keeps this outline and carries `glyphFromLocal` as a
+  //    draw transform is choosing the coordinate space its rasteriser works in.
+  //    Leaving a rotation in that transform tilts the outline's own space
+  //    against the pixel grid, and a rasteriser that evaluates coverage with
+  //    per-axis pixel footprints then measures a rotated glyph through a
+  //    coarser footprint than an upright one - visibly softer edges on
+  //    `rotate` and on `textPath`, which rotates every glyph. Baking it here
+  //    keeps that space axis-aligned, and the rotation stays part of the
+  //    glyph's identity so one angle costs one cached outline.
+  if (glyph.rotateDegrees != 0.0) {
+    result.outline = TransformPath(
+        result.outline,
+        Transform2d::Rotate(glyph.rotateDegrees * MathConstants<double>::kPi / 180.0));
+  }
+
   return result;
 }
 
 Path PlacedGlyphOutline(const TextEngine& textEngine, FontHandle font, const TextGlyph& glyph,
                         float scale) {
-  const GlyphOutlineAndPlacement unplaced = UnplacedGlyphOutline(textEngine, font, glyph, scale);
-  if (unplaced.outline.empty()) {
-    return unplaced.outline;
+  if (glyph.glyphIndex == 0) {
+    return Path();  // `.notdef` -- caller skips.
   }
-  return TransformPath(unplaced.outline, unplaced.glyphFromLocal);
+
+  // Deliberately NOT built from `UnplacedGlyphOutline`: this composes the
+  // placement into ONE affine and transforms the outline once, and the CPU
+  // backend's golden images are pinned to that exact arithmetic. Splitting it
+  // into a rotate pass and a translate pass is the same mapping but not the
+  // same rounding.
+  Path glyphPath = textEngine.glyphOutline(font, glyph.glyphIndex, scale * glyph.fontSizeScale);
+  if (glyphPath.empty()) {
+    return glyphPath;  // No vector outline (e.g. bitmap-only) -- caller handles.
+  }
+
+  if (glyph.stretchScaleX != 1.0f || glyph.stretchScaleY != 1.0f) {
+    glyphPath =
+        TransformPath(glyphPath, Transform2d::Scale(glyph.stretchScaleX, glyph.stretchScaleY));
+  }
+
+  // Translate to the baseline origin and rotate about it, as one transform.
+  Transform2d glyphFromLocal = Transform2d::Translate(glyph.xPosition, glyph.yPosition);
+  if (glyph.rotateDegrees != 0.0) {
+    glyphFromLocal = Transform2d::Rotate(glyph.rotateDegrees * MathConstants<double>::kPi / 180.0) *
+                     glyphFromLocal;
+  }
+
+  return TransformPath(glyphPath, glyphFromLocal);
 }
 
 Box2d ComputeTextBounds(const TextEngine& textEngine, const std::vector<TextRun>& runs,

--- a/donner/svg/renderer/PlacedTextGeometry.h
+++ b/donner/svg/renderer/PlacedTextGeometry.h
@@ -39,13 +39,70 @@ namespace donner::svg {
 Path TransformPath(const Path& path, const Transform2d& transform);
 
 /**
- * @brief Build the placed outline for a single glyph in document space.
+ * @brief A glyph's outline split into the part that depends only on the glyph
+ *   and the part that depends only on where the glyph sits in the run.
  *
- * Encodes tiny-skia's exact placement sequence:
+ * The two compose back into the placed outline exactly:
+ * `PlacedGlyphOutline(...) == TransformPath(outline, glyphFromLocal)`.
+ *
+ * Splitting them lets a renderer key a cache on glyph identity (font, glyph
+ * index, effective scale, stretch) and reuse one outline for every occurrence,
+ * carrying the per-occurrence placement as a transform instead of re-deriving
+ * and re-transforming the outline for each one.
+ */
+struct GlyphOutlineAndPlacement {
+  /// Raw glyph outline at the glyph's effective scale, with the lengthAdjust
+  /// stretch already baked in. Empty for `.notdef` and for glyphs with no
+  /// vector outline.
+  Path outline;
+  /// Affine placing `outline` into the text element's local space.
+  Transform2d glyphFromLocal;
+};
+
+/**
+ * @brief The affine that places a glyph's unplaced outline into the text
+ *   element's local space.
+ *
+ * Translate to the baseline origin, then rotate about it: as a composed
+ * transform `Rotate(rotateDegrees) * Translate(xPosition, yPosition)`, matching
+ * `RendererTinySkia::drawText`. Depends only on the glyph's position and
+ * rotation, so a renderer that caches outlines by glyph identity can compute
+ * this per occurrence without touching the font backend.
+ *
+ * @param glyph The positioned glyph.
+ * @return The placement transform.
+ */
+Transform2d GlyphPlacementTransform(const TextGlyph& glyph);
+
+/**
+ * @brief Build a glyph's unplaced outline and its placement transform.
+ *
+ * Encodes tiny-skia's exact placement sequence, split at the point where the
+ * glyph-identity-dependent work ends:
  *   1. `glyphOutline(font, glyph.glyphIndex, scale * glyph.fontSizeScale)`,
  *   2. stretch the **raw outline** by `Scale(stretchScaleX, stretchScaleY)`
- *      (only when either differs from 1),
- *   3. position via `Rotate(rotateDegrees) * Translate(xPosition, yPosition)`.
+ *      (only when either differs from 1)  -- these two produce `outline`,
+ *   3. `Rotate(rotateDegrees) * Translate(xPosition, yPosition)` -- this is
+ *      `glyphFromLocal`.
+ *
+ * Steps 1 and 2 depend only on (font, glyph index, `scale * fontSizeScale`,
+ * stretch); step 3 depends only on the glyph's position and rotation.
+ *
+ * @param textEngine Engine providing glyph outlines.
+ * @param font Font handle for the run.
+ * @param glyph The positioned glyph (carries position, rotation, stretch).
+ * @param scale Per-run pixel-height scale (`scaleForPixelHeight(font, sizePx)`).
+ * @return The unplaced outline plus its placement transform.
+ */
+GlyphOutlineAndPlacement UnplacedGlyphOutline(const TextEngine& textEngine, FontHandle font,
+                                              const TextGlyph& glyph, float scale);
+
+/**
+ * @brief Build the placed outline for a single glyph in document space.
+ *
+ * Equivalent to `TransformPath(o.outline, o.glyphFromLocal)` for the
+ * \ref UnplacedGlyphOutline result `o`; see that function for the exact
+ * placement sequence.
  *
  * Returns an empty path for `.notdef` (glyphIndex 0) or when the font has no
  * vector outline for the glyph (e.g. bitmap-only fonts) - callers handle those

--- a/donner/svg/renderer/PlacedTextGeometry.h
+++ b/donner/svg/renderer/PlacedTextGeometry.h
@@ -42,33 +42,37 @@ Path TransformPath(const Path& path, const Transform2d& transform);
  * @brief A glyph's outline split into the part that depends only on the glyph
  *   and the part that depends only on where the glyph sits in the run.
  *
- * The two compose back into the placed outline exactly:
- * `PlacedGlyphOutline(...) == TransformPath(outline, glyphFromLocal)`.
+ * The two compose back into the placed outline: `TransformPath(outline,
+ * glyphFromLocal)` maps to the same place `PlacedGlyphOutline` does. It is not
+ * the same arithmetic - that one composes the placement into a single affine -
+ * so the two agree as mappings, not bit for bit, whenever a rotation is
+ * present.
  *
  * Splitting them lets a renderer key a cache on glyph identity (font, glyph
- * index, effective scale, stretch) and reuse one outline for every occurrence,
- * carrying the per-occurrence placement as a transform instead of re-deriving
- * and re-transforming the outline for each one.
+ * index, effective scale, stretch, rotation) and reuse one outline for every
+ * occurrence, carrying the per-occurrence placement as a transform instead of
+ * re-deriving and re-transforming the outline for each one.
  */
 struct GlyphOutlineAndPlacement {
   /// Raw glyph outline at the glyph's effective scale, with the lengthAdjust
-  /// stretch already baked in. Empty for `.notdef` and for glyphs with no
-  /// vector outline.
+  /// stretch and the per-glyph rotation already baked in. Empty for `.notdef`
+  /// and for glyphs with no vector outline.
   Path outline;
-  /// Affine placing `outline` into the text element's local space.
+  /// Pure translation placing `outline` at its baseline position in the text
+  /// element's local space.
   Transform2d glyphFromLocal;
 };
 
 /**
- * @brief The affine that places a glyph's unplaced outline into the text
- *   element's local space.
+ * @brief The affine that places a glyph's unplaced outline at its baseline
+ *   position in the text element's local space.
  *
- * Rotate the outline about its own origin, then move it to the baseline
- * position: `Rotate(rotateDegrees) * Translate(xPosition, yPosition)`, which
- * applies the rotation first because a `Transform2d` product applies its LEFT
- * operand first. Matches `RendererTinySkia::drawText`. Depends only on the
- * glyph's position and rotation, so a renderer that caches outlines by glyph
- * identity can compute this per occurrence without touching the font backend.
+ * A pure translation to `(xPosition, yPosition)`. Per-glyph rotation is NOT
+ * here: it is baked into the outline by \ref UnplacedGlyphOutline, so a
+ * renderer that rasterises in the outline's own space keeps that space aligned
+ * with the pixel grid. Depends only on the glyph's position, so a renderer that
+ * caches outlines by glyph identity can compute this per occurrence without
+ * touching the font backend.
  *
  * @param glyph The positioned glyph.
  * @return The placement transform.
@@ -78,16 +82,17 @@ Transform2d GlyphPlacementTransform(const TextGlyph& glyph);
 /**
  * @brief Build a glyph's unplaced outline and its placement transform.
  *
- * Encodes tiny-skia's exact placement sequence, split at the point where the
+ * Encodes tiny-skia's placement inputs, split at the point where the
  * glyph-identity-dependent work ends:
  *   1. `glyphOutline(font, glyph.glyphIndex, scale * glyph.fontSizeScale)`,
  *   2. stretch the **raw outline** by `Scale(stretchScaleX, stretchScaleY)`
- *      (only when either differs from 1)  -- these two produce `outline`,
- *   3. `Rotate(rotateDegrees) * Translate(xPosition, yPosition)` -- this is
- *      `glyphFromLocal`.
+ *      (only when either differs from 1),
+ *   3. rotate by `rotateDegrees` about the glyph's own origin -- these three
+ *      produce `outline`,
+ *   4. `Translate(xPosition, yPosition)` -- this is `glyphFromLocal`.
  *
- * Steps 1 and 2 depend only on (font, glyph index, `scale * fontSizeScale`,
- * stretch); step 3 depends only on the glyph's position and rotation.
+ * Steps 1 to 3 depend only on (font, glyph index, `scale * fontSizeScale`,
+ * stretch, rotation); step 4 depends only on the glyph's position.
  *
  * @param textEngine Engine providing glyph outlines.
  * @param font Font handle for the run.
@@ -101,9 +106,12 @@ GlyphOutlineAndPlacement UnplacedGlyphOutline(const TextEngine& textEngine, Font
 /**
  * @brief Build the placed outline for a single glyph in document space.
  *
- * Equivalent to `TransformPath(o.outline, o.glyphFromLocal)` for the
- * \ref UnplacedGlyphOutline result `o`; see that function for the exact
- * placement sequence.
+ * Encodes tiny-skia's exact placement sequence: stretch the raw outline, then
+ * position it with `Rotate(rotateDegrees) * Translate(xPosition, yPosition)`
+ * composed into ONE affine and applied once. The single composition is
+ * load-bearing rather than incidental: the CPU backend's golden images are
+ * pinned to that arithmetic, so \ref UnplacedGlyphOutline's two-step form is
+ * not a drop-in substitute for it.
  *
  * Returns an empty path for `.notdef` (glyphIndex 0) or when the font has no
  * vector outline for the glyph (e.g. bitmap-only fonts) - callers handle those

--- a/donner/svg/renderer/PlacedTextGeometry.h
+++ b/donner/svg/renderer/PlacedTextGeometry.h
@@ -63,11 +63,12 @@ struct GlyphOutlineAndPlacement {
  * @brief The affine that places a glyph's unplaced outline into the text
  *   element's local space.
  *
- * Translate to the baseline origin, then rotate about it: as a composed
- * transform `Rotate(rotateDegrees) * Translate(xPosition, yPosition)`, matching
- * `RendererTinySkia::drawText`. Depends only on the glyph's position and
- * rotation, so a renderer that caches outlines by glyph identity can compute
- * this per occurrence without touching the font backend.
+ * Rotate the outline about its own origin, then move it to the baseline
+ * position: `Rotate(rotateDegrees) * Translate(xPosition, yPosition)`, which
+ * applies the rotation first because a `Transform2d` product applies its LEFT
+ * operand first. Matches `RendererTinySkia::drawText`. Depends only on the
+ * glyph's position and rotation, so a renderer that caches outlines by glyph
+ * identity can compute this per occurrence without touching the font backend.
  *
  * @param glyph The positioned glyph.
  * @return The placement transform.

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -40,6 +40,7 @@
 #include "donner/svg/renderer/geode/GeodeCallbackState.h"
 #include "donner/svg/renderer/geode/GeodeDevice.h"
 #include "donner/svg/renderer/geode/GeodeFilterEngine.h"
+#include "donner/svg/renderer/geode/GeodeGlyphResidency.h"
 #include "donner/svg/renderer/geode/GeodeImagePipeline.h"
 #include "donner/svg/renderer/geode/GeodePathCacheComponent.h"
 #include "donner/svg/renderer/geode/GeodePathEncoder.h"
@@ -1977,6 +1978,11 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       /// retransforms the earlier draw that references the primary
       /// (buffer writes execute before every draw at submit).
       const geode::GeodeRecordSlab::Slot* recordSlotOverride = nullptr;
+      /// Last-written bytes of `recordSlotOverride`, when that slot persists
+      /// across frames (per-occurrence text records). Non-null turns the
+      /// override write into a skip-when-unchanged write. Null for per-frame
+      /// temporary slots, which are always fresh and always written.
+      std::vector<uint8_t>* recordCacheOverride = nullptr;
     };
     /// Consecutive instances. Each instance's record-slab slot index must
     /// be `firstInstanceIndex + i`, its geometry must live in the same
@@ -2037,17 +2043,27 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
                               const geode::GeodeRecordSlab::Slot*& outSlot) {
     outSlot = nullptr;
     if (slot.lastSceneFrame == currentFrameIndex || slot.lastResidentFrame == currentFrameIndex) {
-      if (!slot.recordSlab) {
-        return false;
-      }
-      geode::GeodeRecordSlab::Slot tempSlot;
-      if (!slot.recordSlab->allocateSlot(*device, tempSlot)) {
-        return false;
-      }
-      sceneTempRecordSlots.push_back(SceneTempRecordSlot{tempSlot, slot.recordSlab});
-      outSlot = &sceneTempRecordSlots.back().slot;
+      outSlot = allocateTempRecordSlot(slot.recordSlab);
+      return outSlot != nullptr;
     }
     return true;
+  }
+
+  /// Allocate a record slot that lives only for this frame, retained in
+  /// `sceneTempRecordSlots` so its address stays valid until the next
+  /// `draw()` returns it to `slab`. Returns null when `slab` is absent or the
+  /// device cannot back the allocation.
+  const geode::GeodeRecordSlab::Slot* allocateTempRecordSlot(
+      const std::shared_ptr<geode::GeodeRecordSlab>& slab) {
+    if (!slab) {
+      return nullptr;
+    }
+    geode::GeodeRecordSlab::Slot tempSlot;
+    if (!slab->allocateSlot(*device, tempSlot)) {
+      return nullptr;
+    }
+    sceneTempRecordSlots.push_back(SceneTempRecordSlot{tempSlot, slab});
+    return &sceneTempRecordSlots.back().slot;
   }
 
   /// Connect (or rewire) our `on_update<ComputedPathComponent>` /
@@ -2152,6 +2168,234 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       (void)slot.recordSlab->allocateSlot(*device, slot.recordSlot);
     }
     return static_cast<bool>(slot.recordSlot.buffer);
+  }
+
+  /// Glyph-residency budget, in distinct cached outlines and in summed encode
+  /// bytes. Defaults come from `GeodeGlyphCache`; a test shrinks them to reach
+  /// eviction without building a font-sized working set.
+  size_t glyphCacheMaxEntries = geode::GeodeGlyphCache::kDefaultMaxEntries;
+  uint64_t glyphCacheMaxEncodedBytes = geode::GeodeGlyphCache::kDefaultMaxEncodedBytes;
+
+  /// Document-scoped glyph-outline residency. Mirrors `residentSlab`'s
+  /// registry-context wiring: one cache per document, replaced when a
+  /// different device renders the document, because every cached entry holds
+  /// that device's buffer and bind group.
+  std::shared_ptr<geode::GeodeGlyphCache> glyphCache(Registry& registry) {
+    auto* cachePtr = registry.ctx().find<std::shared_ptr<geode::GeodeGlyphCache>>();
+    if (cachePtr == nullptr) {
+      registry.ctx().emplace<std::shared_ptr<geode::GeodeGlyphCache>>(nullptr);
+      cachePtr = registry.ctx().find<std::shared_ptr<geode::GeodeGlyphCache>>();
+    }
+    std::shared_ptr<geode::GeodeGlyphCache>& cache = *cachePtr;
+    if (!cache || cache->owningDeviceId() != device->deviceId()) {
+      cache = std::make_shared<geode::GeodeGlyphCache>(device->deviceId());
+    }
+    // Trim to budget at the first touch of each frame, the same shape (and for
+    // the same reason) as the slabs' pending-free merge: dropping an entry
+    // returns its slab range through the deferred free list, so the range only
+    // becomes reusable at the NEXT merge, never inside a frame whose recorded
+    // draws still read it. Gating here rather than at one draw entry point
+    // covers the multi-document tile paths that never reach `draw()`.
+    device->countGlyphResidencyEvictions(cache->beginFrame(
+        currentFrameIndex, glyphCacheMaxEntries, glyphCacheMaxEncodedBytes));
+    return cache;
+  }
+
+  /// Per-occurrence record storage for one text element's glyph fills.
+  ///
+  /// `component` non-null means the element's persistent slots are in play and
+  /// `next` is the ordinal of the occurrence about to be drawn. Null means
+  /// this pass takes per-frame temporaries instead (no source entity, batching
+  /// off, or the element already drew once this frame).
+  struct TextRecordCursor {
+    geode::GeodeTextInstanceRecordComponent* component = nullptr;
+    size_t next = 0;
+  };
+
+  /// Open per-occurrence record allocation for the text element rooted at
+  /// `textRoot`.
+  TextRecordCursor beginTextRecords(Registry& registry, Entity textRoot) {
+    TextRecordCursor cursor;
+    // Records only earn their keep when a batch can read them; with ordered
+    // batching off every glyph draws solo from the uniform and a record would
+    // be pure cost.
+    if (!kEnableSceneBatching || textRoot == entt::null) {
+      return cursor;
+    }
+    EntityHandle handle(registry, textRoot);
+    if (!handle) {
+      return cursor;
+    }
+    auto& component = handle.get_or_emplace<geode::GeodeTextInstanceRecordComponent>();
+    std::shared_ptr<geode::GeodeRecordSlab> slab = recordSlab(registry);
+    if (component.recordSlab.get() != slab.get()) {
+      // Device change retired the old slab with the registry-context swap;
+      // the held slots belong to it, so drop them and start fresh.
+      component.release();
+      component.recordSlab = std::move(slab);
+    }
+    if (component.lastFrame == currentFrameIndex) {
+      // The element already drew this frame (a `<use>` of the text, a
+      // multi-document tile pass). Its slots are referenced by that draw's
+      // recorded batch, and every buffer write in a frame lands before every
+      // draw in the same submit, so rewriting them would retroactively
+      // retransform the earlier draw.
+      return cursor;
+    }
+    component.lastFrame = currentFrameIndex;
+    cursor.component = &component;
+    return cursor;
+  }
+
+  /// Take the next occurrence's record slot, growing the element's persistent
+  /// list on demand. Falls back to a per-frame temporary when there is no
+  /// persistent list. Leaves `outSlot` null when no record can be had at all,
+  /// which sends the occurrence down the solo resident draw path.
+  void nextTextRecord(TextRecordCursor& cursor, Registry& registry,
+                      const geode::GeodeRecordSlab::Slot*& outSlot,
+                      std::vector<uint8_t>*& outCache) {
+    outSlot = nullptr;
+    outCache = nullptr;
+    if (cursor.component != nullptr) {
+      auto& occurrences = cursor.component->occurrences;
+      if (cursor.next == occurrences.size() && cursor.component->recordSlab) {
+        geode::GeodeRecordSlab::Slot slot;
+        if (cursor.component->recordSlab->allocateSlot(*device, slot)) {
+          occurrences.push_back(geode::GeodeTextInstanceRecordComponent::Occurrence{slot, {}});
+        }
+      }
+      if (cursor.next < occurrences.size()) {
+        outSlot = &occurrences[cursor.next].slot;
+        outCache = &occurrences[cursor.next].lastRecord;
+        ++cursor.next;
+        return;
+      }
+    }
+    if (!kEnableSceneBatching) {
+      return;
+    }
+    outSlot = allocateTempRecordSlot(recordSlab(registry));
+  }
+
+  /// Resident CPU encode + GPU geometry for one glyph identity, creating it on
+  /// first use.
+  ///
+  /// `buildOutline` is a callable returning the glyph's unplaced `Path`; it
+  /// runs only on a miss, which is the whole point - fetching an outline from
+  /// the font backend is the cost this cache exists to pay once. An entry
+  /// whose outline comes back empty (a glyph the font has no vector outline
+  /// for) is still cached, so that miss also costs one backend call per
+  /// document rather than one per occurrence per frame.
+  template <typename BuildOutlineFn>
+  geode::GeodeGlyphResidentEntry* residentGlyphEntry(Registry& registry,
+                                                     const geode::GlyphGeometryKey& key,
+                                                     BuildOutlineFn&& buildOutline) {
+    std::shared_ptr<geode::GeodeGlyphCache> cache = glyphCache(registry);
+    geode::GeodeGlyphResidentEntry* entry = cache->find(key);
+    if (entry != nullptr) {
+      device->countGlyphResidencyHit();
+    } else {
+      Path outline = buildOutline();
+      geode::EncodedPath encoded;
+      if (!outline.empty()) {
+        device->countPathEncode();
+        encoded = geode::GeodePathEncoder::encode(outline, FillRule::NonZero);
+      }
+      entry = cache->insert(key, std::move(outline), std::move(encoded));
+      device->countGlyphResidencyUpload();
+    }
+    entry->lastUsedFrame = currentFrameIndex;
+
+    // Wire the slot to the document's current slabs, exactly like the
+    // per-entity residence getters do.
+    std::shared_ptr<geode::GeodeResidentSlab> slab = residentSlab(registry);
+    if (entry->slot.slab.get() != slab.get()) {
+      entry->slot.reset();
+    }
+    entry->slot.slab = std::move(slab);
+    std::shared_ptr<geode::GeodeRecordSlab> records = recordSlab(registry);
+    if (entry->slot.recordSlab.get() != records.get()) {
+      entry->slot.recordSlot = geode::GeodeRecordSlab::Slot{};
+      entry->slot.recordSlab = std::move(records);
+    }
+    return entry;
+  }
+
+  /// Draw one glyph occurrence over shared resident geometry.
+  ///
+  /// `recordSlot` / `recordCache` are this occurrence's own record storage.
+  /// When a record is available the occurrence joins (or opens) a batch of
+  /// consecutive records over the same slab chunk; otherwise it falls back to
+  /// a solo resident draw whose placement rides in the encoder transform. The
+  /// glyph's geometry is uploaded at most once either way.
+  void emitGlyphFill(geode::GeodeGlyphResidentEntry& entry, const css::RGBA& color,
+                     const Transform2d& deviceFromGlyph,
+                     const geode::GeodeRecordSlab::Slot* recordSlot,
+                     std::vector<uint8_t>* recordCache) {
+    if (entry.encoded.empty()) {
+      return;
+    }
+    if (tryAppendGlyphBatch(entry, color, deviceFromGlyph, recordSlot, recordCache)) {
+      return;
+    }
+    flushPendingBatch();
+    encoder->setTransform(deviceFromGlyph);
+    encoder->fillPathResident(entry.slot, entry.encoded, color, FillRule::NonZero,
+                              currentFrameIndex);
+  }
+
+  /// Append one glyph occurrence to the pending ordered batch, opening a new
+  /// one when the current batch cannot cover it. Returns false when the
+  /// occurrence cannot batch at all and the caller must draw it solo.
+  ///
+  /// Unlike the per-entity scene path this never needs the same-frame repeat
+  /// divert: the geometry is shared by construction and every occurrence
+  /// already owns a distinct record, so no record a recorded draw depends on
+  /// is ever rewritten.
+  bool tryAppendGlyphBatch(geode::GeodeGlyphResidentEntry& entry, const css::RGBA& color,
+                           const Transform2d& deviceFromGlyph,
+                           const geode::GeodeRecordSlab::Slot* recordSlot,
+                           std::vector<uint8_t>* recordCache) {
+    if (!kEnableSceneBatching || recordSlot == nullptr || encoder->hasActiveClipState() ||
+        encoder->hasActiveScissor()) {
+      return false;
+    }
+    // The ensure both establishes residence on first sight of this glyph and
+    // publishes this occurrence's record; a repeat frame writes neither.
+    if (!encoder->ensureResidentSceneRecord(entry.slot, entry.encoded, color, FillRule::NonZero,
+                                            deviceFromGlyph, recordSlot, recordCache)) {
+      return false;
+    }
+
+    const wgpu::Buffer chunk = entry.slot.buffer;
+    const uint32_t vertexCount = entry.encoded.boundingDrawVertexCount();
+    const uint64_t clipVersion = encoder->clipStateVersion();
+    const PendingBatch::SceneInstance instance{
+        &entry.slot, &entry.encoded, &entry.outline, color,      FillRule::NonZero,
+        deviceFromGlyph, vertexCount, recordSlot,    recordCache};
+
+    if (pendingBatch.has_value() && pendingBatch->mode == PendingBatch::Mode::Scene &&
+        pendingBatch->sceneChunkBuffer == chunk &&
+        pendingBatch->sceneRecordBuffer == recordSlot->buffer &&
+        pendingBatch->sceneClipVersion == clipVersion &&
+        pendingBatch->sceneFirstInstance + pendingBatch->sceneInstances.size() ==
+            recordSlot->index) {
+      pendingBatch->sceneInstances.push_back(instance);
+      pendingBatch->sceneVertexCount = std::max(pendingBatch->sceneVertexCount, vertexCount);
+      return true;
+    }
+
+    flushPendingBatch();
+    pendingBatch = PendingBatch{};
+    pendingBatch->mode = PendingBatch::Mode::Scene;
+    pendingBatch->sceneChunkBuffer = chunk;
+    pendingBatch->sceneRecordBuffer = recordSlot->buffer;
+    pendingBatch->sceneFirstInstance = recordSlot->index;
+    pendingBatch->sceneFirstRecordOffset = recordSlot->offset;
+    pendingBatch->sceneClipVersion = clipVersion;
+    pendingBatch->sceneVertexCount = vertexCount;
+    pendingBatch->sceneInstances.push_back(instance);
+    return true;
   }
 
   std::shared_ptr<geode::GeodeResidentSlab> residentSlab(Registry& registry) {
@@ -2358,8 +2602,10 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       // no-op when the record is unchanged.
       for (const PendingBatch::SceneInstance& inst : batch.sceneInstances) {
         if (inst.slot != nullptr && inst.encoded != nullptr) {
-          (void)encoder->ensureResidentSceneRecord(*inst.slot, *inst.encoded, inst.color, inst.rule,
-                                                   inst.deviceFromLocal, inst.recordSlotOverride);
+          (void)encoder->ensureResidentSceneRecord(*inst.slot, *inst.encoded, inst.color,
+                                                   inst.rule, inst.deviceFromLocal,
+                                                   inst.recordSlotOverride,
+                                                   inst.recordCacheOverride);
         }
       }
       encoder->fillPathSceneBatch(batchColor, batchRule, binding);
@@ -3261,6 +3507,24 @@ void RendererGeode::draw(SVGDocument& document) {
 
   RendererDriver driver(*this, impl_->verbose);
   driver.draw(document);
+}
+
+void RendererGeode::setGlyphResidencyBudgetForTesting(size_t maxEntries,
+                                                      uint64_t maxEncodedBytes) {
+  impl_->glyphCacheMaxEntries = maxEntries;
+  impl_->glyphCacheMaxEncodedBytes = maxEncodedBytes;
+}
+
+size_t RendererGeode::residentGlyphCountForTesting(SVGDocument& document) {
+  if (!impl_->device) {
+    return 0;
+  }
+  auto* cachePtr =
+      document.registry().ctx().find<std::shared_ptr<geode::GeodeGlyphCache>>();
+  if (cachePtr == nullptr || !*cachePtr) {
+    return 0;
+  }
+  return (*cachePtr)->size();
 }
 
 int RendererGeode::width() const {
@@ -4885,6 +5149,12 @@ void RendererGeode::drawText(Registry& registry, const components::ComputedTextC
   // encoder to use the element's deviceFromLocalTransform unchanged.
   impl_->encoder->setTransform(impl_->deviceFromLocalTransform);
 
+  // Per-occurrence record storage for this element's solid-fill glyphs. The
+  // ordinal advances across runs, so the element's persistent slots stay in
+  // one consecutive range and a batch can cover the whole element.
+  Impl::TextRecordCursor textRecords =
+      impl_->beginTextRecords(registry, params.textRootEntity);
+
   for (size_t runIndex = 0; runIndex < runs.size(); ++runIndex) {
     const auto& run = runs[runIndex];
     if (run.font == FontHandle()) {
@@ -5010,29 +5280,79 @@ void RendererGeode::drawText(Registry& registry, const components::ComputedTextC
       continue;  // Nothing to fill, stroke, or decorate.
     }
 
+    // A solid fill draws each glyph from shared resident geometry: the outline
+    // is cached once per glyph identity and the occurrence contributes only a
+    // placement transform. Gradient, pattern, and stroke paint still consume a
+    // glyph outline placed in the element's local space, so those keep
+    // building placed paths.
+    const bool residentGlyphFill = hasFill && !fillIsGradient && !usePatternFill;
+    const bool needPlacedGlyphPaths = fillIsGradient || usePatternFill || hasStrokePaint;
+
+    // Glyph occurrences of this run, in paint order. Parallel to
+    // `runGlyphPaths` when both are populated.
+    struct RunGlyphOccurrence {
+      geode::GeodeGlyphResidentEntry* entry = nullptr;
+      Transform2d glyphFromLocal;
+    };
+    std::vector<RunGlyphOccurrence> runGlyphOccurrences;
     std::vector<Path> runGlyphPaths;
-    runGlyphPaths.reserve(run.glyphs.size());
+    runGlyphOccurrences.reserve(run.glyphs.size());
+    if (needPlacedGlyphPaths) {
+      runGlyphPaths.reserve(run.glyphs.size());
+    }
     for (const auto& glyph : run.glyphs) {
       if (glyph.glyphIndex == 0) {
         continue;  // `.notdef` -- skip to match tiny-skia.
       }
 
-      // Placed outline in document space, shared with RendererTinySkia via
-      // PlacedTextGeometry so the two backends can't drift on placement (0038).
-      // This encodes tiny-skia's order (stretch the raw outline, then
-      // `Rotate * Translate`) - geode previously composed
-      // `Scale * Rotate * Translate`, which stretched in the post-rotation frame
-      // (the D4 divergence). Empty for outline-less glyphs; bitmap-only fonts
-      // were already skipped at the run level above.
-      const Path placed = PlacedGlyphOutline(textEngine, run.font, glyph, scale);
-      if (placed.empty()) {
-        continue;
+      // Outline + placement are split by PlacedTextGeometry, which both
+      // backends share so they cannot drift on placement. The split encodes
+      // tiny-skia's order: stretch the raw outline, then `Rotate * Translate`.
+      // Geode once composed `Scale * Rotate * Translate`, which stretched in
+      // the post-rotation frame and diverged from tiny-skia.
+      geode::GlyphGeometryKey key;
+      // The font handle's entity id, versioned by entt, so a font that is
+      // unloaded and a different one loaded into the same slot cannot be
+      // mistaken for the original.
+      key.fontId = static_cast<uint64_t>(static_cast<uint32_t>(run.font.entity()));
+      key.glyphIndex = static_cast<uint32_t>(glyph.glyphIndex);
+      key.outlineScale = scale * glyph.fontSizeScale;
+      key.stretchScaleX = glyph.stretchScaleX;
+      key.stretchScaleY = glyph.stretchScaleY;
+
+      geode::GeodeGlyphResidentEntry* entry =
+          impl_->residentGlyphEntry(registry, key, [&]() -> Path {
+            return UnplacedGlyphOutline(textEngine, run.font, glyph, scale).outline;
+          });
+      if (entry == nullptr || entry->outline.empty()) {
+        continue;  // No vector outline; bitmap-only fonts were skipped above.
       }
 
-      runGlyphPaths.push_back(placed);
+      const Transform2d glyphFromLocal = GlyphPlacementTransform(glyph);
+      runGlyphOccurrences.push_back(RunGlyphOccurrence{entry, glyphFromLocal});
+      if (needPlacedGlyphPaths) {
+        runGlyphPaths.push_back(TransformPath(entry->outline, glyphFromLocal));
+      }
     }
 
     const auto drawRunFill = [&]() {
+      if (residentGlyphFill) {
+        for (const RunGlyphOccurrence& occurrence : runGlyphOccurrences) {
+          const geode::GeodeRecordSlab::Slot* recordSlot = nullptr;
+          std::vector<uint8_t>* recordCache = nullptr;
+          impl_->nextTextRecord(textRecords, registry, recordSlot, recordCache);
+          impl_->emitGlyphFill(*occurrence.entry, spanFill,
+                               impl_->deviceFromLocalTransform * occurrence.glyphFromLocal,
+                               recordSlot, recordCache);
+        }
+        // Stroke, decoration, and the next run all emit straight through the
+        // encoder without flushing, so close the batch here or they would land
+        // ahead of these glyphs. The flush leaves the encoder transform at
+        // identity; restore the element's.
+        impl_->flushPendingBatch();
+        impl_->encoder->setTransform(impl_->deviceFromLocalTransform);
+        return;
+      }
       for (const Path& placed : runGlyphPaths) {
         if (fillIsGradient) {
           // Gradient fill on text: resolve the gradient against the text bbox
@@ -5048,8 +5368,6 @@ void RendererGeode::drawText(Registry& registry, const components::ComputedTextC
           impl_->encoder->fillPathPattern(
               placed, FillRule::NonZero,
               impl_->buildPatternPaint(*impl_->patternFillPaint, impl_->paint.fillOpacity));
-        } else if (hasFill) {
-          impl_->encoder->fillPath(placed, spanFill, FillRule::NonZero);
         }
       }
     };

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1246,8 +1246,27 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     encoderToConfigure.setAntialias(antialias);
   }
 
-  /// Per-renderer frame index used to age resident path-cache entries.
+  /// Frame index used to age resident cache entries and to tell "this frame
+  /// already claimed that buffer" from "an earlier, submitted frame did".
+  ///
+  /// DEVICE-scoped, not per-renderer: an offscreen renderer built from this
+  /// device renders `feImage` fragments and layer thumbnails out of the same
+  /// document while this renderer's frame is still open, and a per-renderer
+  /// counter would let those two frames alias. See
+  /// `GeodeDevice::beginFrameGeneration`.
   uint64_t currentFrameIndex = 0;
+  /// True while `currentFrameIndex` names a generation this renderer opened and
+  /// has not closed. Frames are closed at `endFrame`, at the next `beginFrame`
+  /// (a caller that abandons a frame), and at teardown.
+  bool frameGenerationOpen = false;
+
+  /// Close this renderer's open frame generation, if any.
+  void closeFrameGeneration() {
+    if (frameGenerationOpen && device) {
+      device->endFrameGeneration(currentFrameIndex);
+    }
+    frameGenerationOpen = false;
+  }
 
   /// Acquire a pooled texture matching `desc`, or create a fresh one
   /// on miss. Always increments the `textureCreates` counter on miss;
@@ -2197,7 +2216,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     // draws still read it. Gating here rather than at one draw entry point
     // covers the multi-document tile paths that never reach `draw()`.
     device->countGlyphResidencyEvictions(
-        cache->beginFrame(currentFrameIndex, glyphCacheMaxEntries, glyphCacheMaxEncodedBytes));
+        cache->beginFrame(currentFrameIndex, device->oldestOpenFrameGeneration(),
+                          glyphCacheMaxEntries, glyphCacheMaxEncodedBytes));
     return cache;
   }
 
@@ -2234,12 +2254,13 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       component.freeRecordSlots();
       component.recordSlab = std::move(slab);
     }
-    if (component.lastFrame == currentFrameIndex) {
-      // The element already drew this frame (a `<use>` of the text, a
-      // multi-document tile pass). Its slots are referenced by that draw's
-      // recorded batch, and every buffer write in a frame lands before every
-      // draw in the same submit, so rewriting them would retroactively
-      // retransform the earlier draw.
+    if (component.lastFrame >= device->oldestOpenFrameGeneration()) {
+      // Some frame that wrote these slots has not submitted: this element drew
+      // earlier in this frame (a `<use>` of the text), or an outer frame
+      // recorded its glyph batch and an offscreen pass is now rendering the
+      // same document. Every buffer write in a frame lands before every draw in
+      // the same submit, so rewriting the slots would retroactively retransform
+      // that recorded draw. Take per-frame temporaries instead.
       return cursor;
     }
     component.lastFrame = currentFrameIndex;
@@ -2382,6 +2403,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
             recordSlot->index) {
       pendingBatch->sceneInstances.push_back(instance);
       pendingBatch->sceneVertexCount = std::max(pendingBatch->sceneVertexCount, vertexCount);
+      entry.slot.lastSceneFrame = currentFrameIndex;
       return true;
     }
 
@@ -2395,6 +2417,11 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     pendingBatch->sceneClipVersion = clipVersion;
     pendingBatch->sceneVertexCount = vertexCount;
     pendingBatch->sceneInstances.push_back(instance);
+    // Claim the shared glyph slot now rather than at flush: while this batch is
+    // pending, a solo resident draw of the same glyph must already see the slot
+    // as taken, or it would publish its paint through the slot's uniform and
+    // through `lastResidentFrame` while the batch still depends on it.
+    entry.slot.lastSceneFrame = currentFrameIndex;
     return true;
   }
 
@@ -3452,6 +3479,9 @@ RendererGeode::~RendererGeode() {
   if (impl_ && impl_->device && impl_->device->counters() == &impl_->counters) {
     impl_->device->setCounters(nullptr);
   }
+  if (impl_) {
+    impl_->closeFrameGeneration();
+  }
 }
 RendererGeode::RendererGeode(RendererGeode&&) noexcept = default;
 RendererGeode& RendererGeode::operator=(RendererGeode&& other) noexcept {
@@ -3522,7 +3552,8 @@ size_t RendererGeode::residentGlyphCountForTesting(SVGDocument& document) {
     return 0;
   }
   auto* cachePtr = document.registry().ctx().find<std::shared_ptr<geode::GeodeGlyphCache>>();
-  if (cachePtr == nullptr || !*cachePtr) {
+  if (cachePtr == nullptr || !*cachePtr ||
+      (*cachePtr)->owningDeviceId() != impl_->device->deviceId()) {
     return 0;
   }
   return (*cachePtr)->size();
@@ -3570,7 +3601,16 @@ void RendererGeode::beginFrame(const RenderViewport& viewport) {
   if (impl_->texturePool) {
     impl_->texturePool->beginFrame();
   }
-  ++impl_->currentFrameIndex;
+  // A caller that abandons a frame (beginFrame without endFrame) must not leave
+  // its generation open forever, or every later eviction would be held back by
+  // it.
+  impl_->closeFrameGeneration();
+  if (impl_->device) {
+    impl_->currentFrameIndex = impl_->device->beginFrameGeneration();
+    impl_->frameGenerationOpen = true;
+  } else {
+    ++impl_->currentFrameIndex;
+  }
 
   // `<use>`-batch detection: drop the previous-draw source-entity memo so
   // cross-frame draws don't show up as "same-source runs".
@@ -3690,6 +3730,11 @@ void RendererGeode::endFrame() {
     impl_->frameCommandEncoder.reset();
     impl_->frameFinishedEncoders.clear();
   }
+
+  // The frame's work is submitted, so nothing it recorded can still be waiting
+  // to read a buffer: its generation stops holding back the caches that defer
+  // recycling until every frame that touched them has submitted.
+  impl_->closeFrameGeneration();
 
   // Now that the command buffer is submitted, it's safe to return the
   // frame's transient layer / filter / mask / snapshot textures to
@@ -5296,11 +5341,20 @@ void RendererGeode::drawText(Registry& registry, const components::ComputedTextC
     };
     std::vector<RunGlyphOccurrence> runGlyphOccurrences;
     std::vector<Path> runGlyphPaths;
-    runGlyphOccurrences.reserve(run.glyphs.size());
+    if (residentGlyphFill || needPlacedGlyphPaths) {
+      runGlyphOccurrences.reserve(run.glyphs.size());
+    }
     if (needPlacedGlyphPaths) {
       runGlyphPaths.reserve(run.glyphs.size());
     }
+    // A run can reach here with no glyph paint at all - decoration lines only -
+    // and must not then fetch, encode, and permanently cache an outline per
+    // glyph for geometry nothing draws.
+    const bool runNeedsGlyphGeometry = residentGlyphFill || needPlacedGlyphPaths;
     for (const auto& glyph : run.glyphs) {
+      if (!runNeedsGlyphGeometry) {
+        break;
+      }
       if (glyph.glyphIndex == 0) {
         continue;  // `.notdef` -- skip to match tiny-skia.
       }
@@ -5757,7 +5811,7 @@ ReadbackMapStatus MapAndWaitReadback(const std::shared_ptr<geode::GeodeDevice>& 
     std::atomic<bool> done{false};
     std::atomic<bool> ok{false};
 
-    void freeRecordSlots() {
+    void release() {
       if (references.fetch_sub(1, std::memory_order_acq_rel) == 1) {
         delete this;
       }
@@ -5770,7 +5824,7 @@ ReadbackMapStatus MapAndWaitReadback(const std::shared_ptr<geode::GeodeDevice>& 
     auto* s = static_cast<MapState*>(userdata1);
     s->ok.store(status == WGPUMapAsyncStatus_Success, std::memory_order_relaxed);
     s->done.store(true, std::memory_order_release);
-    s->freeRecordSlots();
+    s->release();
   };
   mapCb.userdata1 = mapState;
   mapCb.userdata2 = nullptr;
@@ -5846,12 +5900,12 @@ ReadbackMapStatus MapAndWaitReadback(const std::shared_ptr<geode::GeodeDevice>& 
     // reference keeps `mapState` valid even when delivery happens after this method returns.
     buffer.unmap();
     buffer.destroy();
-    mapState->freeRecordSlots();
+    mapState->release();
     return cancelled ? ReadbackMapStatus::Cancelled : ReadbackMapStatus::TimedOut;
   }
 
   const bool mapOk = mapState->ok.load(std::memory_order_acquire);
-  mapState->freeRecordSlots();
+  mapState->release();
   return mapOk ? ReadbackMapStatus::Success : ReadbackMapStatus::Failed;
 }
 

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -3509,6 +3509,10 @@ void RendererGeode::draw(SVGDocument& document) {
   driver.draw(document);
 }
 
+bool RendererGeode::sceneBatchingEnabledForTesting() {
+  return kEnableSceneBatching;
+}
+
 void RendererGeode::setGlyphResidencyBudgetForTesting(size_t maxEntries,
                                                       uint64_t maxEncodedBytes) {
   impl_->glyphCacheMaxEntries = maxEntries;

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -11,6 +11,7 @@
 #include <map>
 #include <mutex>
 #include <optional>
+#include <span>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -2616,6 +2617,10 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
                                ? batch.sceneInstances.front().slot->recordSlab.get()
                                : nullptr;
 
+      // The batched entry points read colour and fill rule from each instance's
+      // record, so these two only populate the draw-level uniform the batched
+      // shader does not consult. They come from the first instance because the
+      // uniform still has to hold something well-formed.
       const css::RGBA batchColor = batch.sceneInstances.front().color;
       const FillRule batchRule = batch.sceneInstances.front().rule;
       // Ensure each instance's geometry + batch-form record immediately
@@ -5351,10 +5356,8 @@ void RendererGeode::drawText(Registry& registry, const components::ComputedTextC
     // and must not then fetch, encode, and permanently cache an outline per
     // glyph for geometry nothing draws.
     const bool runNeedsGlyphGeometry = residentGlyphFill || needPlacedGlyphPaths;
-    for (const auto& glyph : run.glyphs) {
-      if (!runNeedsGlyphGeometry) {
-        break;
-      }
+    for (const auto& glyph : runNeedsGlyphGeometry ? std::span<const TextGlyph>(run.glyphs)
+                                                   : std::span<const TextGlyph>()) {
       if (glyph.glyphIndex == 0) {
         continue;  // `.notdef` -- skip to match tiny-skia.
       }
@@ -5373,6 +5376,7 @@ void RendererGeode::drawText(Registry& registry, const components::ComputedTextC
       key.outlineScale = scale * glyph.fontSizeScale;
       key.stretchScaleX = glyph.stretchScaleX;
       key.stretchScaleY = glyph.stretchScaleY;
+      key.rotateDegrees = glyph.rotateDegrees;
 
       geode::GeodeGlyphResidentEntry* entry =
           impl_->residentGlyphEntry(registry, key, [&]() -> Path {
@@ -5392,6 +5396,11 @@ void RendererGeode::drawText(Registry& registry, const components::ComputedTextC
     const auto drawRunFill = [&]() {
       if (residentGlyphFill) {
         for (const RunGlyphOccurrence& occurrence : runGlyphOccurrences) {
+          // The ordinal advances even for an occurrence whose encode turns out
+          // empty (a whitespace-only outline), so an element's occurrence ->
+          // slot mapping stays stable across frames. That occurrence's slot is
+          // allocated and then left alone: the emit returns before any record
+          // is written, so the slot holds nothing and no draw reads it.
           const geode::GeodeRecordSlab::Slot* recordSlot = nullptr;
           std::vector<uint8_t>* recordCache = nullptr;
           impl_->nextTextRecord(textRecords, registry, recordSlot, recordCache);

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -2196,8 +2196,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     // becomes reusable at the NEXT merge, never inside a frame whose recorded
     // draws still read it. Gating here rather than at one draw entry point
     // covers the multi-document tile paths that never reach `draw()`.
-    device->countGlyphResidencyEvictions(cache->beginFrame(
-        currentFrameIndex, glyphCacheMaxEntries, glyphCacheMaxEncodedBytes));
+    device->countGlyphResidencyEvictions(
+        cache->beginFrame(currentFrameIndex, glyphCacheMaxEntries, glyphCacheMaxEncodedBytes));
     return cache;
   }
 
@@ -2370,9 +2370,9 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     const wgpu::Buffer chunk = entry.slot.buffer;
     const uint32_t vertexCount = entry.encoded.boundingDrawVertexCount();
     const uint64_t clipVersion = encoder->clipStateVersion();
-    const PendingBatch::SceneInstance instance{
-        &entry.slot, &entry.encoded, &entry.outline, color,      FillRule::NonZero,
-        deviceFromGlyph, vertexCount, recordSlot,    recordCache};
+    const PendingBatch::SceneInstance instance{&entry.slot, &entry.encoded,    &entry.outline,
+                                               color,       FillRule::NonZero, deviceFromGlyph,
+                                               vertexCount, recordSlot,        recordCache};
 
     if (pendingBatch.has_value() && pendingBatch->mode == PendingBatch::Mode::Scene &&
         pendingBatch->sceneChunkBuffer == chunk &&
@@ -2602,9 +2602,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       // no-op when the record is unchanged.
       for (const PendingBatch::SceneInstance& inst : batch.sceneInstances) {
         if (inst.slot != nullptr && inst.encoded != nullptr) {
-          (void)encoder->ensureResidentSceneRecord(*inst.slot, *inst.encoded, inst.color,
-                                                   inst.rule, inst.deviceFromLocal,
-                                                   inst.recordSlotOverride,
+          (void)encoder->ensureResidentSceneRecord(*inst.slot, *inst.encoded, inst.color, inst.rule,
+                                                   inst.deviceFromLocal, inst.recordSlotOverride,
                                                    inst.recordCacheOverride);
         }
       }
@@ -3513,8 +3512,7 @@ bool RendererGeode::sceneBatchingEnabledForTesting() {
   return kEnableSceneBatching;
 }
 
-void RendererGeode::setGlyphResidencyBudgetForTesting(size_t maxEntries,
-                                                      uint64_t maxEncodedBytes) {
+void RendererGeode::setGlyphResidencyBudgetForTesting(size_t maxEntries, uint64_t maxEncodedBytes) {
   impl_->glyphCacheMaxEntries = maxEntries;
   impl_->glyphCacheMaxEncodedBytes = maxEncodedBytes;
 }
@@ -3523,8 +3521,7 @@ size_t RendererGeode::residentGlyphCountForTesting(SVGDocument& document) {
   if (!impl_->device) {
     return 0;
   }
-  auto* cachePtr =
-      document.registry().ctx().find<std::shared_ptr<geode::GeodeGlyphCache>>();
+  auto* cachePtr = document.registry().ctx().find<std::shared_ptr<geode::GeodeGlyphCache>>();
   if (cachePtr == nullptr || !*cachePtr) {
     return 0;
   }
@@ -5156,8 +5153,7 @@ void RendererGeode::drawText(Registry& registry, const components::ComputedTextC
   // Per-occurrence record storage for this element's solid-fill glyphs. The
   // ordinal advances across runs, so the element's persistent slots stay in
   // one consecutive range and a batch can cover the whole element.
-  Impl::TextRecordCursor textRecords =
-      impl_->beginTextRecords(registry, params.textRootEntity);
+  Impl::TextRecordCursor textRecords = impl_->beginTextRecords(registry, params.textRootEntity);
 
   for (size_t runIndex = 0; runIndex < runs.size(); ++runIndex) {
     const auto& run = runs[runIndex];

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -2231,7 +2231,7 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     if (component.recordSlab.get() != slab.get()) {
       // Device change retired the old slab with the registry-context swap;
       // the held slots belong to it, so drop them and start fresh.
-      component.release();
+      component.freeRecordSlots();
       component.recordSlab = std::move(slab);
     }
     if (component.lastFrame == currentFrameIndex) {
@@ -5341,8 +5341,12 @@ void RendererGeode::drawText(Registry& registry, const components::ComputedTextC
           const geode::GeodeRecordSlab::Slot* recordSlot = nullptr;
           std::vector<uint8_t>* recordCache = nullptr;
           impl_->nextTextRecord(textRecords, registry, recordSlot, recordCache);
+          // `Transform2d`'s product applies its left operand first, so the
+          // glyph's placement into element-local space comes first and the
+          // element's device transform second. This is the same composition
+          // `pushTransform` performs for a nested element.
           impl_->emitGlyphFill(*occurrence.entry, spanFill,
-                               impl_->deviceFromLocalTransform * occurrence.glyphFromLocal,
+                               occurrence.glyphFromLocal * impl_->deviceFromLocalTransform,
                                recordSlot, recordCache);
         }
         // Stroke, decoration, and the next run all emit straight through the
@@ -5753,7 +5757,7 @@ ReadbackMapStatus MapAndWaitReadback(const std::shared_ptr<geode::GeodeDevice>& 
     std::atomic<bool> done{false};
     std::atomic<bool> ok{false};
 
-    void release() {
+    void freeRecordSlots() {
       if (references.fetch_sub(1, std::memory_order_acq_rel) == 1) {
         delete this;
       }
@@ -5766,7 +5770,7 @@ ReadbackMapStatus MapAndWaitReadback(const std::shared_ptr<geode::GeodeDevice>& 
     auto* s = static_cast<MapState*>(userdata1);
     s->ok.store(status == WGPUMapAsyncStatus_Success, std::memory_order_relaxed);
     s->done.store(true, std::memory_order_release);
-    s->release();
+    s->freeRecordSlots();
   };
   mapCb.userdata1 = mapState;
   mapCb.userdata2 = nullptr;
@@ -5842,12 +5846,12 @@ ReadbackMapStatus MapAndWaitReadback(const std::shared_ptr<geode::GeodeDevice>& 
     // reference keeps `mapState` valid even when delivery happens after this method returns.
     buffer.unmap();
     buffer.destroy();
-    mapState->release();
+    mapState->freeRecordSlots();
     return cancelled ? ReadbackMapStatus::Cancelled : ReadbackMapStatus::TimedOut;
   }
 
   const bool mapOk = mapState->ok.load(std::memory_order_acquire);
-  mapState->release();
+  mapState->freeRecordSlots();
   return mapOk ? ReadbackMapStatus::Success : ReadbackMapStatus::Failed;
 }
 

--- a/donner/svg/renderer/RendererGeode.h
+++ b/donner/svg/renderer/RendererGeode.h
@@ -394,6 +394,18 @@ public:
   [[nodiscard]] RendererGeodeTexturePoolStats texturePoolStats() const;
 
   /**
+   * Shrink the glyph-residency budget so eviction can be exercised without
+   * building a font-sized working set.
+   *
+   * @param maxEntries Distinct cached glyph outlines to keep.
+   * @param maxEncodedBytes Summed encode bytes to keep.
+   */
+  void setGlyphResidencyBudgetForTesting(size_t maxEntries, uint64_t maxEncodedBytes);
+
+  /// Number of glyph outlines currently resident for `document`.
+  [[nodiscard]] size_t residentGlyphCountForTesting(SVGDocument& document);
+
+  /**
    * Captures the current resolved render target as a directly sampleable
    * WebGPU texture.
    *

--- a/donner/svg/renderer/RendererGeode.h
+++ b/donner/svg/renderer/RendererGeode.h
@@ -394,6 +394,16 @@ public:
   [[nodiscard]] RendererGeodeTexturePoolStats texturePoolStats() const;
 
   /**
+   * Whether cross-entity ordered batching is compiled into this build.
+   *
+   * Batching collapses many draws into one, so any assertion about draw-call
+   * counts or about the buffer traffic a batch's records replace has a
+   * different right answer in each build state. Tests read this rather than
+   * hard-coding one of them.
+   */
+  [[nodiscard]] static bool sceneBatchingEnabledForTesting();
+
+  /**
    * Shrink the glyph-residency budget so eviction can be exercised without
    * building a font-sized working set.
    *

--- a/donner/svg/renderer/geode/BUILD.bazel
+++ b/donner/svg/renderer/geode/BUILD.bazel
@@ -140,6 +140,41 @@ donner_cc_library(
     ],
 )
 
+# Header-only glyph-identity-keyed outline cache plus the persistent
+# per-occurrence text instance records that ride on top of it.
+donner_cc_library(
+    name = "geode_glyph_residency",
+    hdrs = ["GeodeGlyphResidency.h"],
+    target_compatible_with = _GEODE_ONLY,
+    visibility = ["//donner/svg/renderer:__subpackages__"],
+    deps = [
+        ":geode_device",
+        ":geode_path_encoder",
+        ":geode_resident_path_component",
+        "//donner/base",
+        "//third_party/webgpu-cpp:webgpu_cpp",
+    ],
+)
+
+donner_cc_test(
+    name = "geode_glyph_residency_tests_impl",
+    srcs = ["tests/GeodeGlyphResidency_tests.cc"],
+    target_compatible_with = _GEODE_ONLY,
+    deps = [
+        ":geode_glyph_residency",
+        "//donner/base",
+        "//donner/base:gtest_timeout_main",
+    ],
+)
+
+donner_multi_transitioned_test(
+    name = "geode_glyph_residency_tests",
+    timeout = "short",
+    testonly = 1,
+    dep = ":geode_glyph_residency_tests_impl",
+    renderer_backend = "geode",
+)
+
 donner_cc_test(
     name = "geode_path_encoder_tests",
     srcs = ["tests/GeodePathEncoder_tests.cc"],

--- a/donner/svg/renderer/geode/BUILD.bazel
+++ b/donner/svg/renderer/geode/BUILD.bazel
@@ -770,6 +770,38 @@ donner_multi_transitioned_test(
 )
 
 donner_cc_test(
+    name = "geode_glyph_instancing_tests_impl",
+    srcs = ["tests/GeodeGlyphInstancing_tests.cc"],
+    data = ["//third_party/resvg-test-suite:fonts"],
+    tags = ["exclusive-if-local"],
+    target_compatible_with = _GEODE_ONLY,
+    deps = [
+        ":geode_counters",
+        ":geode_device",
+        "//donner/base",
+        "//donner/base:base_test_utils",
+        "//donner/base:gtest_timeout_main",
+        "//donner/svg",
+        "//donner/svg/parser",
+        "//donner/svg/renderer:renderer_geode",
+        "//donner/svg/renderer:renderer_interface",
+        "//donner/svg/renderer/tests:image_comparison_test_fixture",
+    ],
+)
+
+donner_multi_transitioned_test(
+    name = "geode_glyph_instancing_tests",
+    timeout = "moderate",
+    testonly = 1,
+    dep = ":geode_glyph_instancing_tests_impl",
+    opens_gpu_device = True,
+    renderer_backend = "geode",
+    # Every assertion here is about glyph geometry; without the text backend
+    # the documents render as no-ops and the gate would see nothing.
+    text = "true",
+)
+
+donner_cc_test(
     name = "geode_embed_tests_impl",
     srcs = ["tests/GeodeEmbed_tests.cc"],
     target_compatible_with = _GEODE_ONLY,

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -655,6 +655,26 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
                                      const GeodeRecordSlab::Slot* recordSlotOverride,
                                      std::vector<uint8_t>* overrideRecordCache, bool bakeTransform);
 
+  /// Publish the solo resident draw's uniform for `slot`, skipping the write
+  /// when the bytes are unchanged. Only the solo path calls this: a scene
+  /// batch binds a per-batch arena uniform instead.
+  void publishSoloUniform(GeodeResidentSlot& slot, const FillDrawArgs& args,
+                          const InstanceRecord& record);
+
+  /// Publish `record` into the record slot backing this draw, skipping the
+  /// write when the guarding cache already holds these bytes. Which slot and
+  /// which cache apply depends on what the caller supplied:
+  ///   - no override: the slot's own record, guarded by `slot.lastRecord`.
+  ///   - override without a cache: a per-frame temporary slot (same-frame
+  ///     repeat draws). Always fresh, so always written.
+  ///   - override with a cache: a caller-owned slot whose last contents the
+  ///     caller keeps (per-occurrence text records, which persist across
+  ///     frames), guarded by that cache.
+  /// Returns false when no record buffer backs the target slot.
+  bool publishInstanceRecord(GeodeResidentSlot& slot, const InstanceRecord& record,
+                             const GeodeRecordSlab::Slot* recordSlotOverride,
+                             std::vector<uint8_t>* overrideRecordCache);
+
   /// Gradient-paint extension: (re)upload `encoded` into the
   /// gradient slot's persistent combined buffer (same eight SSBO regions,
   /// uniform region sized for `GradientUniforms`) and reset its cached
@@ -1973,50 +1993,56 @@ bool GeoEncoder::Impl::ensureResidentSceneRecordImpl(
     // of every draw in the frame's single submit, so a scene-form write
     // after a recorded solo draw would retroactively change that draw's
     // uniform (last write wins at submit time).
-    Uniforms u = {};
-    populateBatchUniform(u, args, transform, /*identityMvp=*/false);
-    copyRecordParamsToUniform(u, record);
-    writeSoloGeometryBases(u, slot);
-    const auto* uBytes = reinterpret_cast<const uint8_t*>(&u);
-    if (slot.lastUniform.size() != sizeof(Uniforms) ||
-        std::memcmp(slot.lastUniform.data(), uBytes, sizeof(Uniforms)) != 0) {
-      device->queue().writeBuffer(slot.buffer, slot.uniform.offset, &u, sizeof(Uniforms));
-      device->countBufferWrite(sizeof(Uniforms));
-      slot.lastUniform.assign(uBytes, uBytes + sizeof(Uniforms));
-    }
+    publishSoloUniform(slot, args, record);
     return true;
   }
 
-  const auto* rBytes = reinterpret_cast<const uint8_t*>(&record);
+  return publishInstanceRecord(slot, record, recordSlotOverride, overrideRecordCache);
+}
+
+void GeoEncoder::Impl::publishSoloUniform(GeodeResidentSlot& slot, const FillDrawArgs& args,
+                                          const InstanceRecord& record) {
+  Uniforms u = {};
+  populateBatchUniform(u, args, transform, /*identityMvp=*/false);
+  copyRecordParamsToUniform(u, record);
+  writeSoloGeometryBases(u, slot);
+
+  const auto* uBytes = reinterpret_cast<const uint8_t*>(&u);
+  if (slot.lastUniform.size() == sizeof(Uniforms) &&
+      std::memcmp(slot.lastUniform.data(), uBytes, sizeof(Uniforms)) == 0) {
+    return;
+  }
+
+  device->queue().writeBuffer(slot.buffer, slot.uniform.offset, &u, sizeof(Uniforms));
+  device->countBufferWrite(sizeof(Uniforms));
+  slot.lastUniform.assign(uBytes, uBytes + sizeof(Uniforms));
+}
+
+bool GeoEncoder::Impl::publishInstanceRecord(GeodeResidentSlot& slot, const InstanceRecord& record,
+                                             const GeodeRecordSlab::Slot* recordSlotOverride,
+                                             std::vector<uint8_t>* overrideRecordCache) {
   const GeodeRecordSlab::Slot& recordSlot =
       recordSlotOverride != nullptr ? *recordSlotOverride : slot.recordSlot;
   if (!recordSlot.buffer) {
     return false;
   }
-  if (recordSlotOverride != nullptr && overrideRecordCache != nullptr) {
-    // Caller-owned record slot with a caller-owned copy of its last contents
-    // (per-occurrence text records, which persist across frames). Same
-    // skip-when-unchanged contract as the slot's own primary record, just
-    // with the cache living where the slot does.
-    if (overrideRecordCache->size() != sizeof(InstanceRecord) ||
-        std::memcmp(overrideRecordCache->data(), rBytes, sizeof(InstanceRecord)) != 0) {
-      device->queue().writeBuffer(recordSlot.buffer, recordSlot.offset, &record,
-                                  sizeof(InstanceRecord));
-      device->countBufferWrite(sizeof(InstanceRecord));
-      overrideRecordCache->assign(rBytes, rBytes + sizeof(InstanceRecord));
-    }
-  } else if (recordSlotOverride != nullptr) {
-    // Per-frame temporary record slot (same-frame repeat draws): always
-    // fresh, so always written.
-    device->queue().writeBuffer(recordSlot.buffer, recordSlot.offset, &record,
-                                sizeof(InstanceRecord));
-    device->countBufferWrite(sizeof(InstanceRecord));
-  } else if (slot.lastRecord.size() != sizeof(InstanceRecord) ||
-             std::memcmp(slot.lastRecord.data(), rBytes, sizeof(InstanceRecord)) != 0) {
-    device->queue().writeBuffer(recordSlot.buffer, recordSlot.offset, &record,
-                                sizeof(InstanceRecord));
-    device->countBufferWrite(sizeof(InstanceRecord));
-    slot.lastRecord.assign(rBytes, rBytes + sizeof(InstanceRecord));
+
+  // The cache guarding this write, or null when nothing guards it. An
+  // override slot without a caller-supplied cache is a per-frame temporary
+  // (same-frame repeat draws): always fresh, so always written.
+  std::vector<uint8_t>* cache =
+      recordSlotOverride != nullptr ? overrideRecordCache : &slot.lastRecord;
+  const auto* rBytes = reinterpret_cast<const uint8_t*>(&record);
+  if (cache != nullptr && cache->size() == sizeof(InstanceRecord) &&
+      std::memcmp(cache->data(), rBytes, sizeof(InstanceRecord)) == 0) {
+    return true;
+  }
+
+  device->queue().writeBuffer(recordSlot.buffer, recordSlot.offset, &record,
+                              sizeof(InstanceRecord));
+  device->countBufferWrite(sizeof(InstanceRecord));
+  if (cache != nullptr) {
+    cache->assign(rBytes, rBytes + sizeof(InstanceRecord));
   }
   return true;
 }

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -653,8 +653,7 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   bool ensureResidentSceneRecordImpl(GeodeResidentSlot& slot, const EncodedPath& encoded,
                                      const FillDrawArgs& args, const Transform2d& recordTransform,
                                      const GeodeRecordSlab::Slot* recordSlotOverride,
-                                     std::vector<uint8_t>* overrideRecordCache,
-                                     bool bakeTransform);
+                                     std::vector<uint8_t>* overrideRecordCache, bool bakeTransform);
 
   /// Gradient-paint extension: (re)upload `encoded` into the
   /// gradient slot's persistent combined buffer (same eight SSBO regions,
@@ -1907,13 +1906,10 @@ bool GeoEncoder::Impl::submitResidentFillDraw(GeodeResidentSlot& slot, const Enc
   return true;
 }
 
-bool GeoEncoder::Impl::ensureResidentSceneRecordImpl(GeodeResidentSlot& slot,
-                                                     const EncodedPath& encoded,
-                                                     const FillDrawArgs& args,
-                                                     const Transform2d& recordTransform,
-                                                     const GeodeRecordSlab::Slot* recordSlotOverride,
-                                                     std::vector<uint8_t>* overrideRecordCache,
-                                                     bool bakeTransform) {
+bool GeoEncoder::Impl::ensureResidentSceneRecordImpl(
+    GeodeResidentSlot& slot, const EncodedPath& encoded, const FillDrawArgs& args,
+    const Transform2d& recordTransform, const GeodeRecordSlab::Slot* recordSlotOverride,
+    std::vector<uint8_t>* overrideRecordCache, bool bakeTransform) {
   // Ensure the geometry is resident and current AND owned by THIS device.
   // Component removal is the primary invalidation; the pointer + fingerprint
   // guard catches the in-place stroke-slot rebuild (which replaces the encode

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -653,6 +653,7 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
   bool ensureResidentSceneRecordImpl(GeodeResidentSlot& slot, const EncodedPath& encoded,
                                      const FillDrawArgs& args, const Transform2d& recordTransform,
                                      const GeodeRecordSlab::Slot* recordSlotOverride,
+                                     std::vector<uint8_t>* overrideRecordCache,
                                      bool bakeTransform);
 
   /// Gradient-paint extension: (re)upload `encoded` into the
@@ -1888,7 +1889,7 @@ bool GeoEncoder::Impl::submitResidentFillDraw(GeodeResidentSlot& slot, const Enc
   ensurePassOpen();
   bindSolidPipeline();
 
-  if (!ensureResidentSceneRecordImpl(slot, encoded, args, transform, nullptr,
+  if (!ensureResidentSceneRecordImpl(slot, encoded, args, transform, nullptr, nullptr,
                                      /*bakeTransform=*/true)) {
     return false;
   }
@@ -1906,10 +1907,13 @@ bool GeoEncoder::Impl::submitResidentFillDraw(GeodeResidentSlot& slot, const Enc
   return true;
 }
 
-bool GeoEncoder::Impl::ensureResidentSceneRecordImpl(
-    GeodeResidentSlot& slot, const EncodedPath& encoded, const FillDrawArgs& args,
-    const Transform2d& recordTransform, const GeodeRecordSlab::Slot* recordSlotOverride,
-    bool bakeTransform) {
+bool GeoEncoder::Impl::ensureResidentSceneRecordImpl(GeodeResidentSlot& slot,
+                                                     const EncodedPath& encoded,
+                                                     const FillDrawArgs& args,
+                                                     const Transform2d& recordTransform,
+                                                     const GeodeRecordSlab::Slot* recordSlotOverride,
+                                                     std::vector<uint8_t>* overrideRecordCache,
+                                                     bool bakeTransform) {
   // Ensure the geometry is resident and current AND owned by THIS device.
   // Component removal is the primary invalidation; the pointer + fingerprint
   // guard catches the in-place stroke-slot rebuild (which replaces the encode
@@ -1993,7 +1997,19 @@ bool GeoEncoder::Impl::ensureResidentSceneRecordImpl(
   if (!recordSlot.buffer) {
     return false;
   }
-  if (recordSlotOverride != nullptr) {
+  if (recordSlotOverride != nullptr && overrideRecordCache != nullptr) {
+    // Caller-owned record slot with a caller-owned copy of its last contents
+    // (per-occurrence text records, which persist across frames). Same
+    // skip-when-unchanged contract as the slot's own primary record, just
+    // with the cache living where the slot does.
+    if (overrideRecordCache->size() != sizeof(InstanceRecord) ||
+        std::memcmp(overrideRecordCache->data(), rBytes, sizeof(InstanceRecord)) != 0) {
+      device->queue().writeBuffer(recordSlot.buffer, recordSlot.offset, &record,
+                                  sizeof(InstanceRecord));
+      device->countBufferWrite(sizeof(InstanceRecord));
+      overrideRecordCache->assign(rBytes, rBytes + sizeof(InstanceRecord));
+    }
+  } else if (recordSlotOverride != nullptr) {
     // Per-frame temporary record slot (same-frame repeat draws): always
     // fresh, so always written.
     device->queue().writeBuffer(recordSlot.buffer, recordSlot.offset, &record,
@@ -2112,7 +2128,8 @@ void GeoEncoder::fillPathInstanced(const EncodedPath& encoded, const css::RGBA& 
 bool GeoEncoder::ensureResidentSceneRecord(GeodeResidentSlot& slot, const EncodedPath& encoded,
                                            const css::RGBA& color, FillRule rule,
                                            const Transform2d& recordTransform,
-                                           const GeodeRecordSlab::Slot* recordSlotOverride) {
+                                           const GeodeRecordSlab::Slot* recordSlotOverride,
+                                           std::vector<uint8_t>* overrideRecordCache) {
   if (encoded.empty()) {
     return false;
   }
@@ -2134,7 +2151,8 @@ bool GeoEncoder::ensureResidentSceneRecord(GeodeResidentSlot& slot, const Encode
   args.tileSize = Vector2d(1.0, 1.0);
   args.patternFromPath = Transform2d();
   return impl_->ensureResidentSceneRecordImpl(slot, encoded, args, recordTransform,
-                                              recordSlotOverride, /*bakeTransform=*/false);
+                                              recordSlotOverride, overrideRecordCache,
+                                              /*bakeTransform=*/false);
 }
 
 void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,

--- a/donner/svg/renderer/geode/GeoEncoder.h
+++ b/donner/svg/renderer/geode/GeoEncoder.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <memory>
 #include <span>
+#include <vector>
 #include <webgpu/webgpu.hpp>
 
 #include "donner/base/Box.h"
@@ -571,13 +572,21 @@ public:
    *   into the record (the batch uniform is orthographic-only).
    * @param recordSlotOverride When non-null, write the record into this
    *   slot instead of the entity's primary slot (same-frame repeat draws
-   *   need one record per draw). Always written.
+   *   need one record per draw, and per-occurrence text records live outside
+   *   the shared glyph slot entirely).
+   * @param overrideRecordCache Optional caller-owned copy of the override
+   *   slot's last contents. Supplying it turns the override write into the
+   *   same skip-when-unchanged write the primary record gets, which is what
+   *   lets a persistent per-occurrence record reach a zero-write steady
+   *   state. Null means the override slot is per-frame scratch and is always
+   *   written. Ignored when `recordSlotOverride` is null.
    * @return True when the slot is resident and current.
    */
   bool ensureResidentSceneRecord(GeodeResidentSlot& slot, const EncodedPath& encoded,
                                  const css::RGBA& color, FillRule rule,
                                  const Transform2d& recordTransform,
-                                 const GeodeRecordSlab::Slot* recordSlotOverride = nullptr);
+                                 const GeodeRecordSlab::Slot* recordSlotOverride = nullptr,
+                                 std::vector<uint8_t>* overrideRecordCache = nullptr);
 
   /// One cross-entity ordered batch: consecutive resident slots of one
   /// slab chunk plus a run of consecutive record-slab slots.

--- a/donner/svg/renderer/geode/GeodeCounters.h
+++ b/donner/svg/renderer/geode/GeodeCounters.h
@@ -116,17 +116,19 @@ struct GeodeCounters {
   /// zoomed-in curves render as visible polygons.
   uint64_t strokeOutlinePoints = 0;
 
-  /// Glyph occurrences this frame that reused an already-resident glyph
+  /// Glyph occurrences this frame that resolved to an already-cached glyph
   /// outline. A text run repeats a handful of outlines across many
   /// occurrences, so this is the direct measure of the glyph cache doing its
-  /// job: on an unchanged frame it equals the run's total rendered-glyph
-  /// count.
+  /// job: on an unchanged frame it equals the run's total non-`.notdef` glyph
+  /// count. Counted at the cache lookup, so an occurrence whose font has no
+  /// vector outline for it counts too - the lookup is what the cache saved.
   uint64_t glyphResidencyHits = 0;
 
-  /// Unique glyph outlines fetched from the font backend, encoded, and made
-  /// GPU-resident this frame. Steady-state target: `== 0` once a document's
-  /// glyph set is cached; nonzero only on the first frame, after an eviction,
-  /// or when a font/size change mints new glyph identities.
+  /// Glyph outlines fetched from the font backend and cached this frame,
+  /// including the encode and the GPU upload for the ones that have geometry.
+  /// Steady-state target: `== 0` once a document's glyph set is cached;
+  /// nonzero only on the first frame, after an eviction, or when a font or
+  /// scale change mints new glyph identities.
   uint64_t glyphResidencyUploads = 0;
 
   /// Cached glyph outlines dropped this frame to stay inside the residency

--- a/donner/svg/renderer/geode/GeodeCounters.h
+++ b/donner/svg/renderer/geode/GeodeCounters.h
@@ -116,6 +116,24 @@ struct GeodeCounters {
   /// zoomed-in curves render as visible polygons.
   uint64_t strokeOutlinePoints = 0;
 
+  /// Glyph occurrences this frame that reused an already-resident glyph
+  /// outline. A text run repeats a handful of outlines across many
+  /// occurrences, so this is the direct measure of the glyph cache doing its
+  /// job: on an unchanged frame it equals the run's total rendered-glyph
+  /// count.
+  uint64_t glyphResidencyHits = 0;
+
+  /// Unique glyph outlines fetched from the font backend, encoded, and made
+  /// GPU-resident this frame. Steady-state target: `== 0` once a document's
+  /// glyph set is cached; nonzero only on the first frame, after an eviction,
+  /// or when a font/size change mints new glyph identities.
+  uint64_t glyphResidencyUploads = 0;
+
+  /// Cached glyph outlines dropped this frame to stay inside the residency
+  /// budget. Steady-state target: `== 0`; sustained nonzero means the working
+  /// set does not fit and every frame repays the upload.
+  uint64_t glyphResidencyEvictions = 0;
+
   /// Reset all counters to zero. Called at `RendererGeode::beginFrame`.
   void reset() { *this = {}; }
 };

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -465,6 +465,18 @@ public:
   void countTextureWrite(uint64_t bytes) const {
     if (counters_) counters_->textureWriteBytes += bytes;
   }
+  /// Record one glyph occurrence served from an already-resident outline.
+  void countGlyphResidencyHit() const {
+    if (counters_) ++counters_->glyphResidencyHits;
+  }
+  /// Record one unique glyph outline encoded and made resident.
+  void countGlyphResidencyUpload() const {
+    if (counters_) ++counters_->glyphResidencyUploads;
+  }
+  /// Record `count` cached glyph outlines dropped to stay inside the budget.
+  void countGlyphResidencyEvictions(uint64_t count) const {
+    if (counters_) counters_->glyphResidencyEvictions += count;
+  }
 
   /// Shared live-resident-bytes gauge for GPU residence. Co-owned with
   /// each `GeodeResidentSlot`'s buffer so

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -2,6 +2,7 @@
 /// @file
 /// RAII wrapper around a WebGPU device - headless or host-provided.
 
+#include <algorithm>
 #include <atomic>
 #include <cstddef>
 #include <map>
@@ -465,6 +466,50 @@ public:
   void countTextureWrite(uint64_t bytes) const {
     if (counters_) counters_->textureWriteBytes += bytes;
   }
+  /**
+   * Open a frame on this device and return its generation.
+   *
+   * Generations are DEVICE-scoped and monotonic, so two renderers sharing one
+   * device cannot mint the same index. That happens routinely: an offscreen
+   * renderer built from this device renders an `feImage` fragment or a layer
+   * thumbnail from the same document while the outer renderer's frame is still
+   * open and has already recorded draws. With per-renderer counters the two
+   * frames alias, and a cache keyed on "was this touched in the current frame?"
+   * cannot tell the inner pass from the outer one - it would let the inner pass
+   * rewrite buffers the outer pass's recorded draws read, and every buffer
+   * write in a frame lands before every draw in that frame's submit.
+   *
+   * Pair with `endFrameGeneration`. A cache that must not recycle memory an
+   * unsubmitted frame still reads compares against
+   * `oldestOpenFrameGeneration()` rather than against its own index.
+   */
+  uint64_t beginFrameGeneration() {
+    const uint64_t generation = ++frameGeneration_;
+    openFrameGenerations_.push_back(generation);
+    return generation;
+  }
+
+  /// Close a generation opened by `beginFrameGeneration`. Unknown values are
+  /// ignored, so a renderer that never opened one (no-op mode) is safe.
+  void endFrameGeneration(uint64_t generation) {
+    const auto it =
+        std::find(openFrameGenerations_.begin(), openFrameGenerations_.end(), generation);
+    if (it != openFrameGenerations_.end()) {
+      openFrameGenerations_.erase(it);
+    }
+  }
+
+  /// Oldest generation whose frame has not closed yet, or `~0` when no frame is
+  /// open. Anything a generation at or after this touched may still be read by
+  /// an unsubmitted draw.
+  uint64_t oldestOpenFrameGeneration() const {
+    uint64_t oldest = ~uint64_t{0};
+    for (const uint64_t generation : openFrameGenerations_) {
+      oldest = std::min(oldest, generation);
+    }
+    return oldest;
+  }
+
   /// Record one glyph occurrence served from an already-resident outline.
   void countGlyphResidencyHit() const {
     if (counters_) ++counters_->glyphResidencyHits;
@@ -664,6 +709,13 @@ private:
 
   /// Process-unique identity assigned at construction. See `deviceId()`.
   const uint64_t deviceId_ = 0;
+
+  /// Monotonic device-scoped frame counter; see `beginFrameGeneration()`.
+  uint64_t frameGeneration_ = 0;
+  /// Generations opened but not yet closed. At most a handful are ever live
+  /// (an outer frame plus its nested offscreen passes), so a linear scan is
+  /// cheaper than any ordered container.
+  std::vector<uint64_t> openFrameGenerations_;
 
   /// Shared device-lost flag; never null. Created at construction, replaced
   /// by the host's shared state in `CreateFromExternal` when

--- a/donner/svg/renderer/geode/GeodeGlyphResidency.h
+++ b/donner/svg/renderer/geode/GeodeGlyphResidency.h
@@ -47,6 +47,13 @@ namespace donner::geode {
  * The floating-point fields are compared and hashed BITWISE, matching how they
  * reach the font backend: two scales that differ in the last bit produce
  * different outlines, so they must not share an entry.
+ *
+ * `fontId` carries the font handle's version bits, so an unloaded font whose
+ * slot is later reused cannot be mistaken for the original. It is also not
+ * stable across a style mutation that makes the document re-resolve its fonts:
+ * the re-resolved font is a new identity and its glyphs are rebuilt. That costs
+ * a rebuild on a mutating document rather than serving stale geometry, and the
+ * superseded entries age out through the residency budget.
  */
 struct GlyphGeometryKey {
   uint64_t fontId = 0;

--- a/donner/svg/renderer/geode/GeodeGlyphResidency.h
+++ b/donner/svg/renderer/geode/GeodeGlyphResidency.h
@@ -1,0 +1,352 @@
+#pragma once
+/// @file
+/// Glyph-identity-keyed CPU encode + GPU residence for Geode text rendering.
+///
+/// A text run draws the same handful of outlines over and over: the letter "e"
+/// in a paragraph is one outline placed at fifty positions. Encoding and
+/// uploading that outline once per occurrence per frame is the dominant cost of
+/// a text frame - the outline has to be fetched from the font backend,
+/// transformed into place, banded into analytic dual-ray data, and pushed to
+/// the GPU, every time.
+///
+/// This cache breaks the occurrence apart: everything that depends only on
+/// glyph identity (the outline, its encode, and its GPU residence) is kept
+/// once, and everything that depends on the occurrence (position, rotation,
+/// colour) rides in a per-occurrence instance record. A repeated glyph then
+/// costs one record instead of a re-encode plus a re-upload.
+///
+/// Lives in `donner::geode` (not `donner::svg::geode`) to match the other
+/// Geode types referenced unqualified via `geode::` inside `donner::svg`.
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <deque>
+#include <memory>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "donner/base/Path.h"
+#include "donner/svg/renderer/geode/GeodePathEncoder.h"
+#include "donner/svg/renderer/geode/GeodeResidentPathComponent.h"
+
+namespace donner::geode {
+
+/**
+ * Identity of one unique glyph outline: every input that can change the
+ * encoded geometry, and nothing that cannot.
+ *
+ * `fontId` is the font handle's opaque identifier, `outlineScale` is the
+ * effective scale handed to the font backend (the run scale times the glyph's
+ * own font-size multiplier), and the stretch factors are the `lengthAdjust`
+ * scale baked into the outline before placement. Position and rotation are
+ * deliberately absent: they are the placement transform, which rides in the
+ * per-occurrence record.
+ *
+ * The floating-point fields are compared and hashed BITWISE, matching how they
+ * reach the font backend: two scales that differ in the last bit produce
+ * different outlines, so they must not share an entry.
+ */
+struct GlyphGeometryKey {
+  uint64_t fontId = 0;
+  uint32_t glyphIndex = 0;
+  float outlineScale = 0.0f;
+  float stretchScaleX = 1.0f;
+  float stretchScaleY = 1.0f;
+
+  bool operator==(const GlyphGeometryKey& other) const {
+    return fontId == other.fontId && glyphIndex == other.glyphIndex &&
+           bits(outlineScale) == bits(other.outlineScale) &&
+           bits(stretchScaleX) == bits(other.stretchScaleX) &&
+           bits(stretchScaleY) == bits(other.stretchScaleY);
+  }
+
+  /// Raw bit pattern of a float, so `-0.0f` and NaN payloads compare and hash
+  /// as the distinct inputs they are rather than by numeric equality.
+  static uint32_t bits(float value) {
+    uint32_t out = 0;
+    std::memcpy(&out, &value, sizeof(out));
+    return out;
+  }
+};
+
+/// Hash for \ref GlyphGeometryKey. Mixes with the 64-bit splitmix finalizer so
+/// the low-entropy fields (small glyph indices, a handful of scales) still
+/// spread across buckets.
+struct GlyphGeometryKeyHash {
+  size_t operator()(const GlyphGeometryKey& key) const {
+    uint64_t h = key.fontId;
+    h = mix(h ^ key.glyphIndex);
+    h = mix(h ^ GlyphGeometryKey::bits(key.outlineScale));
+    h = mix(h ^ GlyphGeometryKey::bits(key.stretchScaleX));
+    h = mix(h ^ GlyphGeometryKey::bits(key.stretchScaleY));
+    return static_cast<size_t>(h);
+  }
+
+private:
+  static uint64_t mix(uint64_t value) {
+    value += 0x9e3779b97f4a7c15ull;
+    value = (value ^ (value >> 30)) * 0xbf58476d1ce4e5b9ull;
+    value = (value ^ (value >> 27)) * 0x94d049bb133111ebull;
+    return value ^ (value >> 31);
+  }
+};
+
+/**
+ * One unique glyph outline: the CPU outline, its analytic encode, and its GPU
+ * residence.
+ *
+ * The entry owns the outline and the encode so their addresses are stable for
+ * as long as the entry lives; `slot.encodedKey` points at `encoded`, and the
+ * pattern / gradient / stroke text paths borrow `outline` to build a placed
+ * path without going back to the font backend.
+ */
+struct GeodeGlyphResidentEntry {
+  /// Unplaced outline (stretch baked in). Empty for glyphs the font has no
+  /// vector outline for; the entry is still cached so the miss is not repaid
+  /// every frame.
+  Path outline;
+  /// Analytic dual-ray encode of `outline`. Empty when `outline` is.
+  EncodedPath encoded;
+  /// Persistent GPU residence for `encoded`.
+  GeodeResidentSlot slot;
+  /// Renderer frame index of the last occurrence that used this entry. The
+  /// eviction pass never touches an entry used in the current frame, because
+  /// this frame's recorded draws still read its geometry.
+  uint64_t lastUsedFrame = ~uint64_t{0};
+  /// Approximate CPU footprint of the encode, used as the residence budget's
+  /// unit. Slab capacity is not usable here: the slab reports whole chunks.
+  uint64_t encodedBytes = 0;
+};
+
+/**
+ * Document-scoped cache of unique glyph outlines and their GPU residence.
+ *
+ * Bound to one device exactly like `GeodeResidentSlab`: a document rendered by
+ * a second device gets a fresh cache, so no entry can hand a stale device's
+ * buffer or bind group to another device's render pass.
+ *
+ * Eviction is generation-based rather than strictly ordered: entries carry the
+ * frame index of their last use, and when the cache is over budget the oldest
+ * unused entries are dropped first. Dropping an entry destroys its
+ * `GeodeResidentSlot`, which returns the slab range through the slab's
+ * deferred free list, so the range only becomes reusable at the NEXT frame's
+ * merge - never inside the frame whose recorded draws still reference it.
+ * Entries used in the current frame are never candidates for the same reason.
+ *
+ * Not thread-safe; the renderer serializes one frame per device at a time.
+ */
+class GeodeGlyphCache {
+public:
+  /// Create an empty cache bound to `deviceId`.
+  explicit GeodeGlyphCache(uint64_t deviceId) : owningDeviceId_(deviceId) {}
+
+  GeodeGlyphCache(const GeodeGlyphCache&) = delete;
+  GeodeGlyphCache& operator=(const GeodeGlyphCache&) = delete;
+
+  /// Device this cache's residence was built on.
+  uint64_t owningDeviceId() const { return owningDeviceId_; }
+
+  /// Look up `key`, returning null on a miss. Does not mark the entry used;
+  /// the caller does that once it commits to drawing.
+  GeodeGlyphResidentEntry* find(const GlyphGeometryKey& key) {
+    auto it = entries_.find(key);
+    return it == entries_.end() ? nullptr : it->second.get();
+  }
+
+  /// Insert an entry for `key`, taking ownership of `outline` and its encode.
+  /// The returned address is stable for the entry's lifetime.
+  GeodeGlyphResidentEntry* insert(const GlyphGeometryKey& key, Path&& outline,
+                                  EncodedPath&& encoded) {
+    auto entry = std::make_unique<GeodeGlyphResidentEntry>();
+    entry->outline = std::move(outline);
+    entry->encoded = std::move(encoded);
+    entry->encodedBytes = EncodedBytes(entry->encoded);
+    encodedBytes_ += entry->encodedBytes;
+    GeodeGlyphResidentEntry* raw = entry.get();
+    entries_.emplace(key, std::move(entry));
+    return raw;
+  }
+
+  /// Number of live entries.
+  size_t size() const { return entries_.size(); }
+
+  /// Summed \ref GeodeGlyphResidentEntry::encodedBytes over live entries.
+  uint64_t encodedBytes() const { return encodedBytes_; }
+
+  /// Trim to budget at most once per frame. The frame-index guard makes the
+  /// call idempotent no matter how many times a frame touches the cache, so
+  /// the caller can put it on the accessor and cover every draw entry point.
+  /// Returns the number of entries dropped.
+  size_t beginFrame(uint64_t frameIndex, size_t maxEntries, uint64_t maxEncodedBytes) {
+    if (frameIndex == lastEvictedFrame_) {
+      return 0;
+    }
+    lastEvictedFrame_ = frameIndex;
+    return evictToBudget(frameIndex, maxEntries, maxEncodedBytes);
+  }
+
+  /// Drop entries until the cache fits the budget, oldest-unused first.
+  /// Entries whose `lastUsedFrame` equals `currentFrame` are never dropped:
+  /// this frame's already-recorded draws still read their geometry, and the
+  /// slab would hand the range to a later allocation in the same frame.
+  /// Returns the number of entries dropped.
+  size_t evictToBudget(uint64_t currentFrame, size_t maxEntries, uint64_t maxEncodedBytes) {
+    if (entries_.size() <= maxEntries && encodedBytes_ <= maxEncodedBytes) {
+      return 0;
+    }
+
+    // Gather the droppable entries and order them oldest-use-first. The cache
+    // holds one entry per distinct glyph outline, so this list stays small
+    // enough that a sort per over-budget frame is cheaper than maintaining an
+    // intrusive LRU list through every lookup.
+    std::vector<std::pair<uint64_t, const GlyphGeometryKey*>> candidates;
+    candidates.reserve(entries_.size());
+    for (const auto& [key, entry] : entries_) {
+      if (entry->lastUsedFrame != currentFrame) {
+        candidates.emplace_back(entry->lastUsedFrame, &key);
+      }
+    }
+    std::sort(candidates.begin(), candidates.end(),
+              [](const auto& a, const auto& b) { return a.first < b.first; });
+
+    size_t evicted = 0;
+    for (const auto& [unusedFrame, keyPtr] : candidates) {
+      if (entries_.size() <= maxEntries && encodedBytes_ <= maxEncodedBytes) {
+        break;
+      }
+      auto it = entries_.find(*keyPtr);
+      if (it == entries_.end()) {
+        continue;
+      }
+      encodedBytes_ -= it->second->encodedBytes;
+      entries_.erase(it);
+      ++evicted;
+    }
+    return evicted;
+  }
+
+  /// Default cap on distinct cached glyph outlines. One document at one size
+  /// in one font needs a few hundred; the cap bounds a document that animates
+  /// font-size continuously, where every frame mints new keys.
+  static constexpr size_t kDefaultMaxEntries = 1024u;
+  /// Default cap on summed encode bytes.
+  static constexpr uint64_t kDefaultMaxEncodedBytes = 8u << 20;
+
+private:
+  /// CPU size of an encode. Used as the budget unit because it tracks the GPU
+  /// residence byte-for-byte (the resident slot uploads exactly these arrays).
+  static uint64_t EncodedBytes(const EncodedPath& encoded) {
+    return encoded.bands.size() * sizeof(EncodedPath::Band) +
+           encoded.curves.size() * 6u * sizeof(float) +
+           encoded.curveIndices.size() * sizeof(uint32_t) +
+           encoded.vBands.size() * sizeof(EncodedPath::Band) +
+           encoded.vCurves.size() * 6u * sizeof(float) +
+           encoded.vCurveIndices.size() * sizeof(uint32_t) +
+           encoded.hBandGrid.size() * sizeof(uint32_t) +
+           encoded.vBandGrid.size() * sizeof(uint32_t);
+  }
+
+  uint64_t owningDeviceId_ = 0;
+  uint64_t encodedBytes_ = 0;
+  /// Frame index of the last trim; `~0` = never trimmed. See beginFrame().
+  uint64_t lastEvictedFrame_ = ~uint64_t{0};
+  std::unordered_map<GlyphGeometryKey, std::unique_ptr<GeodeGlyphResidentEntry>,
+                     GlyphGeometryKeyHash>
+      entries_;
+};
+
+/**
+ * Persistent per-occurrence instance records for one text element.
+ *
+ * Glyph geometry is shared, so the thing that has to exist once per OCCURRENCE
+ * is the record: transform, colour, and the shared outline's chunk-relative
+ * geometry bases. Handing every occurrence a fresh record slot each frame would
+ * work, but it would also write 256 bytes per glyph per frame forever, which
+ * keeps a static text frame off the zero-bytes steady state the rest of the
+ * renderer reaches.
+ *
+ * So the slots live on the text element and persist. Occurrence `i` of the
+ * element always writes slot `i`, the bytes are compared before writing, and an
+ * unchanged frame writes nothing. Slots are bump-allocated together on first
+ * use, which keeps their indices consecutive - exactly the property a batch
+ * needs to cover them with one draw.
+ *
+ * No explicit invalidation is needed when the text changes: a re-laid-out
+ * element simply produces different record bytes for the affected slots, the
+ * compare misses, and those slots are rewritten. A shorter run leaves trailing
+ * slots unused (and free for the element to grow back into); a longer one
+ * appends.
+ *
+ * `lastFrame` guards the one case the compare cannot: the SAME element drawn
+ * twice in one frame (a `<use>` of the text, a multi-document tile pass). The
+ * second pass must not rewrite records the first pass's already-recorded draw
+ * reads, because every buffer write in a frame executes before every draw in
+ * that frame's submit. The renderer diverts the repeat to per-frame temporary
+ * slots instead.
+ */
+struct GeodeTextInstanceRecordComponent {
+  /// One occurrence's record slot plus the bytes last written to it.
+  struct Occurrence {
+    GeodeRecordSlab::Slot slot;
+    std::vector<uint8_t> lastRecord;
+  };
+
+  /// Occurrence slots in paint order. Index is the occurrence's ordinal
+  /// within the element's draw, so it is stable across unchanged frames. A
+  /// deque, not a vector: a pending batch holds pointers into these entries
+  /// while later occurrences are still appending, and a reallocating growth
+  /// would leave the batch writing through dangling pointers at flush.
+  std::deque<Occurrence> occurrences;
+  /// Slab the slots were allocated from; also keeps that slab alive so a
+  /// device change cannot leave the slots pointing at a destroyed slab.
+  std::shared_ptr<GeodeRecordSlab> recordSlab;
+  /// Renderer frame index of the last draw that wrote these slots. Sentinel
+  /// `~0` means "never drawn".
+  uint64_t lastFrame = ~uint64_t{0};
+
+  GeodeTextInstanceRecordComponent() = default;
+  ~GeodeTextInstanceRecordComponent() { release(); }
+
+  GeodeTextInstanceRecordComponent(const GeodeTextInstanceRecordComponent&) = delete;
+  GeodeTextInstanceRecordComponent& operator=(const GeodeTextInstanceRecordComponent&) = delete;
+
+  GeodeTextInstanceRecordComponent(GeodeTextInstanceRecordComponent&& other) noexcept
+      : occurrences(std::move(other.occurrences)),
+        recordSlab(std::move(other.recordSlab)),
+        lastFrame(other.lastFrame) {
+    other.occurrences.clear();
+  }
+
+  GeodeTextInstanceRecordComponent& operator=(GeodeTextInstanceRecordComponent&& other) noexcept {
+    if (this != &other) {
+      // Release ours first, then take the source's slots and clear the
+      // source's view of them: entt's swap-and-pop removal move-assigns the
+      // surviving component over the removed one, and a source that kept its
+      // slots would free the SURVIVOR's records from its own destructor,
+      // handing live batch bindings to whatever allocates next.
+      release();
+      occurrences = std::move(other.occurrences);
+      recordSlab = std::move(other.recordSlab);
+      lastFrame = other.lastFrame;
+      other.occurrences.clear();
+    }
+    return *this;
+  }
+
+  /// Return every slot to the slab (deferred to the next frame's merge, like
+  /// every other record free) and drop them.
+  void release() {
+    if (recordSlab) {
+      for (const Occurrence& occurrence : occurrences) {
+        if (occurrence.slot.buffer) {
+          recordSlab->freeSlot(occurrence.slot);
+        }
+      }
+    }
+    occurrences.clear();
+  }
+};
+
+}  // namespace donner::geode

--- a/donner/svg/renderer/geode/GeodeGlyphResidency.h
+++ b/donner/svg/renderer/geode/GeodeGlyphResidency.h
@@ -39,13 +39,20 @@ namespace donner::geode {
  *
  * `fontId` is the font handle's opaque identifier, `outlineScale` is the
  * effective scale handed to the font backend (the run scale times the glyph's
- * own font-size multiplier), and the stretch factors are the `lengthAdjust`
- * scale baked into the outline before placement. Position and rotation are
- * deliberately absent: they are the placement transform, which rides in the
- * per-occurrence record.
+ * own font-size multiplier), the stretch factors are the `lengthAdjust` scale,
+ * and `rotateDegrees` is the per-glyph rotation - all four are baked into the
+ * outline before placement. Position is deliberately absent: it is the
+ * placement transform, which rides in the per-occurrence record.
  *
- * The floating-point fields are compared and hashed BITWISE, matching how they
- * reach the font backend: two scales that differ in the last bit produce
+ * Rotation belongs here rather than in the placement because a resident
+ * outline is also the space its rasteriser works in, and that space has to stay
+ * aligned with the pixel grid. The cost is one cached outline per distinct
+ * angle: a whole run rotated by one angle still collapses to one entry, and a
+ * `textPath`, which rotates every glyph differently, degrades to about one
+ * entry per glyph - which is what an uncached renderer pays anyway.
+ *
+ * The numeric fields are compared and hashed BITWISE, matching how they reach
+ * the font backend: two scales or angles that differ in the last bit produce
  * different outlines, so they must not share an entry.
  *
  * `fontId` carries the font handle's version bits, so an unloaded font whose
@@ -61,18 +68,27 @@ struct GlyphGeometryKey {
   float outlineScale = 0.0f;
   float stretchScaleX = 1.0f;
   float stretchScaleY = 1.0f;
+  double rotateDegrees = 0.0;
 
   bool operator==(const GlyphGeometryKey& other) const {
     return fontId == other.fontId && glyphIndex == other.glyphIndex &&
            bits(outlineScale) == bits(other.outlineScale) &&
            bits(stretchScaleX) == bits(other.stretchScaleX) &&
-           bits(stretchScaleY) == bits(other.stretchScaleY);
+           bits(stretchScaleY) == bits(other.stretchScaleY) &&
+           bits(rotateDegrees) == bits(other.rotateDegrees);
   }
 
   /// Raw bit pattern of a float, so `-0.0f` and NaN payloads compare and hash
   /// as the distinct inputs they are rather than by numeric equality.
   static uint32_t bits(float value) {
     uint32_t out = 0;
+    std::memcpy(&out, &value, sizeof(out));
+    return out;
+  }
+
+  /// Raw bit pattern of a double; same policy as the float overload.
+  static uint64_t bits(double value) {
+    uint64_t out = 0;
     std::memcpy(&out, &value, sizeof(out));
     return out;
   }
@@ -88,6 +104,7 @@ struct GlyphGeometryKeyHash {
     h = mix(h ^ GlyphGeometryKey::bits(key.outlineScale));
     h = mix(h ^ GlyphGeometryKey::bits(key.stretchScaleX));
     h = mix(h ^ GlyphGeometryKey::bits(key.stretchScaleY));
+    h = mix(h ^ GlyphGeometryKey::bits(key.rotateDegrees));
     return static_cast<size_t>(h);
   }
 
@@ -257,6 +274,11 @@ public:
 private:
   /// CPU size of an encode. Used as the budget unit because it tracks the GPU
   /// residence byte-for-byte (the resident slot uploads exactly these arrays).
+  ///
+  /// The entry's retained `Path outline` is NOT counted: it is CPU-only, it is
+  /// small next to the banded encode, and the entry-count cap already bounds
+  /// how many of them can be live. Add it here if the outline ever grows a
+  /// representation where that stops being true.
   static uint64_t EncodedBytes(const EncodedPath& encoded) {
     return encoded.bands.size() * sizeof(EncodedPath::Band) +
            encoded.curves.size() * 6u * sizeof(float) +

--- a/donner/svg/renderer/geode/GeodeGlyphResidency.h
+++ b/donner/svg/renderer/geode/GeodeGlyphResidency.h
@@ -307,7 +307,7 @@ struct GeodeTextInstanceRecordComponent {
   uint64_t lastFrame = ~uint64_t{0};
 
   GeodeTextInstanceRecordComponent() = default;
-  ~GeodeTextInstanceRecordComponent() { release(); }
+  ~GeodeTextInstanceRecordComponent() { freeRecordSlots(); }
 
   GeodeTextInstanceRecordComponent(const GeodeTextInstanceRecordComponent&) = delete;
   GeodeTextInstanceRecordComponent& operator=(const GeodeTextInstanceRecordComponent&) = delete;
@@ -326,7 +326,7 @@ struct GeodeTextInstanceRecordComponent {
       // surviving component over the removed one, and a source that kept its
       // slots would free the SURVIVOR's records from its own destructor,
       // handing live batch bindings to whatever allocates next.
-      release();
+      freeRecordSlots();
       occurrences = std::move(other.occurrences);
       recordSlab = std::move(other.recordSlab);
       lastFrame = other.lastFrame;
@@ -337,7 +337,7 @@ struct GeodeTextInstanceRecordComponent {
 
   /// Return every slot to the slab (deferred to the next frame's merge, like
   /// every other record free) and drop them.
-  void release() {
+  void freeRecordSlots() {
     if (recordSlab) {
       for (const Occurrence& occurrence : occurrences) {
         if (occurrence.slot.buffer) {

--- a/donner/svg/renderer/geode/GeodeGlyphResidency.h
+++ b/donner/svg/renderer/geode/GeodeGlyphResidency.h
@@ -118,10 +118,12 @@ struct GeodeGlyphResidentEntry {
   EncodedPath encoded;
   /// Persistent GPU residence for `encoded`.
   GeodeResidentSlot slot;
-  /// Renderer frame index of the last occurrence that used this entry. The
-  /// eviction pass never touches an entry used in the current frame, because
-  /// this frame's recorded draws still read its geometry.
-  uint64_t lastUsedFrame = ~uint64_t{0};
+  /// Device-scoped frame generation of the last occurrence that used this
+  /// entry. The eviction pass never drops an entry a frame that has not
+  /// submitted touched, because that frame's recorded draws still read its
+  /// geometry. Zero means "never used"; generations start at 1, so an entry
+  /// that somehow never reached a draw is evictable immediately.
+  uint64_t lastUsedFrame = 0;
   /// Approximate CPU footprint of the encode, used as the residence budget's
   /// unit. Slab capacity is not usable here: the slab reports whole chunks.
   uint64_t encodedBytes = 0;
@@ -166,14 +168,21 @@ public:
   /// The returned address is stable for the entry's lifetime.
   GeodeGlyphResidentEntry* insert(const GlyphGeometryKey& key, Path&& outline,
                                   EncodedPath&& encoded) {
-    auto entry = std::make_unique<GeodeGlyphResidentEntry>();
+    // try_emplace, not emplace: emplace constructs the node before it checks
+    // for a duplicate key and destroys it on collision, which would hand the
+    // caller a pointer into freed storage and leave the byte total crediting an
+    // entry that is not in the map.
+    auto [it, inserted] = entries_.try_emplace(key);
+    if (!inserted) {
+      return it->second.get();
+    }
+    it->second = std::make_unique<GeodeGlyphResidentEntry>();
+    GeodeGlyphResidentEntry* entry = it->second.get();
     entry->outline = std::move(outline);
     entry->encoded = std::move(encoded);
     entry->encodedBytes = EncodedBytes(entry->encoded);
     encodedBytes_ += entry->encodedBytes;
-    GeodeGlyphResidentEntry* raw = entry.get();
-    entries_.emplace(key, std::move(entry));
-    return raw;
+    return entry;
   }
 
   /// Number of live entries.
@@ -186,20 +195,24 @@ public:
   /// call idempotent no matter how many times a frame touches the cache, so
   /// the caller can put it on the accessor and cover every draw entry point.
   /// Returns the number of entries dropped.
-  size_t beginFrame(uint64_t frameIndex, size_t maxEntries, uint64_t maxEncodedBytes) {
+  size_t beginFrame(uint64_t frameIndex, uint64_t oldestOpenFrame, size_t maxEntries,
+                    uint64_t maxEncodedBytes) {
     if (frameIndex == lastEvictedFrame_) {
       return 0;
     }
     lastEvictedFrame_ = frameIndex;
-    return evictToBudget(frameIndex, maxEntries, maxEncodedBytes);
+    return evictToBudget(oldestOpenFrame, maxEntries, maxEncodedBytes);
   }
 
   /// Drop entries until the cache fits the budget, oldest-unused first.
-  /// Entries whose `lastUsedFrame` equals `currentFrame` are never dropped:
-  /// this frame's already-recorded draws still read their geometry, and the
-  /// slab would hand the range to a later allocation in the same frame.
-  /// Returns the number of entries dropped.
-  size_t evictToBudget(uint64_t currentFrame, size_t maxEntries, uint64_t maxEncodedBytes) {
+  ///
+  /// An entry last used at or after `oldestOpenFrame` is never dropped: some
+  /// frame that touched it has not submitted, its recorded draws still read
+  /// that geometry, and dropping the entry would return the slab range for a
+  /// later allocation to overwrite. `oldestOpenFrame` is device-scoped, so an
+  /// offscreen pass nested inside an outer frame cannot free the outer frame's
+  /// geometry out from under it. Returns the number of entries dropped.
+  size_t evictToBudget(uint64_t oldestOpenFrame, size_t maxEntries, uint64_t maxEncodedBytes) {
     if (entries_.size() <= maxEntries && encodedBytes_ <= maxEncodedBytes) {
       return 0;
     }
@@ -211,7 +224,7 @@ public:
     std::vector<std::pair<uint64_t, const GlyphGeometryKey*>> candidates;
     candidates.reserve(entries_.size());
     for (const auto& [key, entry] : entries_) {
-      if (entry->lastUsedFrame != currentFrame) {
+      if (entry->lastUsedFrame < oldestOpenFrame) {
         candidates.emplace_back(entry->lastUsedFrame, &key);
       }
     }
@@ -286,12 +299,16 @@ private:
  * slots unused (and free for the element to grow back into); a longer one
  * appends.
  *
- * `lastFrame` guards the one case the compare cannot: the SAME element drawn
- * twice in one frame (a `<use>` of the text, a multi-document tile pass). The
- * second pass must not rewrite records the first pass's already-recorded draw
- * reads, because every buffer write in a frame executes before every draw in
- * that frame's submit. The renderer diverts the repeat to per-frame temporary
- * slots instead.
+ * `lastFrame` guards the one case the compare cannot: the same element written
+ * twice while an earlier writer's draws are still unsubmitted - the same
+ * element drawn twice in one frame (a `<use>` of the text), or an offscreen
+ * pass rendering the same document inside an outer frame that has already
+ * recorded its glyph batch. The second writer must not rewrite those records,
+ * because every buffer write in a frame executes before every draw in that
+ * frame's submit. `lastFrame` holds a DEVICE-scoped generation
+ * (`GeodeDevice::beginFrameGeneration`) so the comparison covers renderers
+ * sharing a device, and the renderer diverts the second writer to per-frame
+ * temporary slots instead.
  */
 struct GeodeTextInstanceRecordComponent {
   /// One occurrence's record slot plus the bytes last written to it.
@@ -309,9 +326,11 @@ struct GeodeTextInstanceRecordComponent {
   /// Slab the slots were allocated from; also keeps that slab alive so a
   /// device change cannot leave the slots pointing at a destroyed slab.
   std::shared_ptr<GeodeRecordSlab> recordSlab;
-  /// Renderer frame index of the last draw that wrote these slots. Sentinel
-  /// `~0` means "never drawn".
-  uint64_t lastFrame = ~uint64_t{0};
+  /// Device-scoped frame generation of the last draw that wrote these slots.
+  /// Zero means "never written": generations start at 1, and the guard reads
+  /// this as "older than every open frame", which is what an untouched
+  /// component is.
+  uint64_t lastFrame = 0;
 
   GeodeTextInstanceRecordComponent() = default;
   ~GeodeTextInstanceRecordComponent() { freeRecordSlots(); }

--- a/donner/svg/renderer/geode/tests/GeodeCounterCorpus_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeCounterCorpus_tests.cc
@@ -169,9 +169,15 @@ struct KnownViolation {
   std::string_view reason;
   /// What has to change for this entry to be deleted.
   std::string_view tracking;
+  /// True when the scene only falls off the steady state in a build with
+  /// cross-entity ordered batching compiled out. Such a scene has its work
+  /// batched away entirely when batching is on, so the entry does not apply
+  /// there and the scene is held to the shared target instead. Delete the
+  /// qualifier (and the entry) once batching is unconditional.
+  bool onlyWithoutSceneBatching = false;
 };
 
-constexpr std::array<KnownViolation, 32> kKnownViolations = {{
+constexpr std::array<KnownViolation, 31> kKnownViolations = {{
     {
         /*scene=*/"donner_icon",
         /*violated=*/kTextureCreates | kBufferWrites | kBindgroupCreates,
@@ -438,14 +444,14 @@ constexpr std::array<KnownViolation, 32> kKnownViolations = {{
     },
     {
         /*scene=*/"simple_text_demo",
-        /*violated=*/kPathEncodes | kBufferWrites | kBindgroupCreates,
-        /*ceiling=*/{24, 0, 216, 24},
+        /*violated=*/kBufferWrites | kBindgroupCreates,
+        /*ceiling=*/{0, 0, 135, 15},
         /*reason=*/
-        "glyph outlines are re-encoded and re-uploaded every frame; placed text has no path "
-        "cache or residency",
+        "glyph outlines are resident, but without a batch to read per-occurrence records the "
+        "repeated occurrences of a glyph fall back to the per-frame arena for their uniforms",
         /*tracking=*/
-        "clears when placed glyph geometry gets the same per-entity cache and residency "
-        "shapes have",
+        "clears when cross-entity ordered batching is unconditional",
+        /*onlyWithoutSceneBatching=*/true,
     },
     {
         /*scene=*/"stroking_complex",
@@ -483,44 +489,41 @@ constexpr std::array<KnownViolation, 32> kKnownViolations = {{
     },
     {
         /*scene=*/"text_inline_size_wrap",
-        /*violated=*/kPathEncodes | kBufferWrites | kBindgroupCreates,
-        /*ceiling=*/{35, 0, 315, 35},
+        /*violated=*/kBufferWrites | kBindgroupCreates,
+        /*ceiling=*/{0, 0, 72, 8},
         /*reason=*/
-        "every wrapped glyph outline is re-encoded and re-uploaded each frame; placed text "
-        "has no path cache or residency",
+        "glyph outlines are resident, but without a batch to read per-occurrence records the "
+        "repeated occurrences of a glyph fall back to the per-frame arena for their uniforms",
         /*tracking=*/
-        "clears when placed glyph geometry gets the same per-entity cache and residency "
-        "shapes have",
-    },
-    {
-        /*scene=*/"text_nested_baseline_shift_idempotency",
-        /*violated=*/kPathEncodes | kBufferWrites,
-        /*ceiling=*/{2, 0, 18, 2},
-        /*reason=*/
-        "glyph outlines are re-encoded and re-uploaded every frame; placed text has no path "
-        "cache or residency",
-        /*tracking=*/
-        "clears when placed glyph geometry gets the same per-entity cache and residency "
-        "shapes have",
+        "clears when cross-entity ordered batching is unconditional",
+        /*onlyWithoutSceneBatching=*/true,
     },
     {
         /*scene=*/"z0rly_test6",
-        /*violated=*/kPathEncodes | kBufferWrites | kBindgroupCreates,
-        /*ceiling=*/{22, 0, 198, 22},
+        /*violated=*/kBufferWrites | kBindgroupCreates,
+        /*ceiling=*/{0, 0, 162, 18},
         /*reason=*/
-        "music-notation glyphs from an embedded font face re-encode and re-upload their "
-        "outlines every frame; placed text has no path cache or residency",
+        "music-notation glyph outlines are resident, but without a batch to read "
+        "per-occurrence records the repeated occurrences fall back to the per-frame arena "
+        "for their uniforms",
         /*tracking=*/
-        "clears when placed glyph geometry gets the same per-entity cache and residency "
-        "shapes have",
+        "clears when cross-entity ordered batching is unconditional",
+        /*onlyWithoutSceneBatching=*/true,
     },
 }};
 
 const KnownViolation* findKnownViolation(std::string_view scene) {
   for (const KnownViolation& entry : kKnownViolations) {
-    if (entry.scene == scene) {
-      return &entry;
+    if (entry.scene != scene) {
+      continue;
     }
+    if (entry.onlyWithoutSceneBatching && RendererGeode::sceneBatchingEnabledForTesting()) {
+      // The entry describes a build this is not. Falling through to the shared
+      // target is the point: with batching on the scene reaches it, and the
+      // ratchet must fail if it ever stops.
+      return nullptr;
+    }
+    return &entry;
   }
   return nullptr;
 }

--- a/donner/svg/renderer/geode/tests/GeodeCounterCorpus_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeCounterCorpus_tests.cc
@@ -169,15 +169,9 @@ struct KnownViolation {
   std::string_view reason;
   /// What has to change for this entry to be deleted.
   std::string_view tracking;
-  /// True when the scene only falls off the steady state in a build with
-  /// cross-entity ordered batching compiled out. Such a scene has its work
-  /// batched away entirely when batching is on, so the entry does not apply
-  /// there and the scene is held to the shared target instead. Delete the
-  /// qualifier (and the entry) once batching is unconditional.
-  bool onlyWithoutSceneBatching = false;
 };
 
-constexpr std::array<KnownViolation, 31> kKnownViolations = {{
+constexpr std::array<KnownViolation, 29> kKnownViolations = {{
     {
         /*scene=*/"donner_icon",
         /*violated=*/kTextureCreates | kBufferWrites | kBindgroupCreates,
@@ -443,17 +437,6 @@ constexpr std::array<KnownViolation, 31> kKnownViolations = {{
         "per source entity",
     },
     {
-        /*scene=*/"simple_text_demo",
-        /*violated=*/kBufferWrites | kBindgroupCreates,
-        /*ceiling=*/{0, 0, 135, 15},
-        /*reason=*/
-        "glyph outlines are resident, but without a batch to read per-occurrence records the "
-        "repeated occurrences of a glyph fall back to the per-frame arena for their uniforms",
-        /*tracking=*/
-        "clears when cross-entity ordered batching is unconditional",
-        /*onlyWithoutSceneBatching=*/true,
-    },
-    {
         /*scene=*/"stroking_complex",
         /*violated=*/kPathEncodes | kBufferWrites | kBindgroupCreates,
         /*ceiling=*/{8, 0, 16, 8},
@@ -488,27 +471,16 @@ constexpr std::array<KnownViolation, 31> kKnownViolations = {{
         "have",
     },
     {
-        /*scene=*/"text_inline_size_wrap",
-        /*violated=*/kBufferWrites | kBindgroupCreates,
-        /*ceiling=*/{0, 0, 72, 8},
-        /*reason=*/
-        "glyph outlines are resident, but without a batch to read per-occurrence records the "
-        "repeated occurrences of a glyph fall back to the per-frame arena for their uniforms",
-        /*tracking=*/
-        "clears when cross-entity ordered batching is unconditional",
-        /*onlyWithoutSceneBatching=*/true,
-    },
-    {
         /*scene=*/"z0rly_test6",
-        /*violated=*/kBufferWrites | kBindgroupCreates,
-        /*ceiling=*/{0, 0, 162, 18},
+        /*violated=*/kBindgroupCreates,
+        /*ceiling=*/{0, 0, 0, 22},
         /*reason=*/
-        "music-notation glyph outlines are resident, but without a batch to read "
-        "per-occurrence records the repeated occurrences fall back to the per-frame arena "
-        "for their uniforms",
+        "residency removed this scene's outline re-encodes and uniform re-uploads, but its "
+        "music-notation glyphs are drawn from many separate text elements that ordered batching "
+        "does not merge, so each draw still builds its own bind group",
         /*tracking=*/
-        "clears when cross-entity ordered batching is unconditional",
-        /*onlyWithoutSceneBatching=*/true,
+        "clears when bind groups are cached across draws that share a pipeline, or when batching "
+        "merges runs from separate text elements",
     },
 }};
 
@@ -516,12 +488,6 @@ const KnownViolation* findKnownViolation(std::string_view scene) {
   for (const KnownViolation& entry : kKnownViolations) {
     if (entry.scene != scene) {
       continue;
-    }
-    if (entry.onlyWithoutSceneBatching && RendererGeode::sceneBatchingEnabledForTesting()) {
-      // The entry describes a build this is not. Falling through to the shared
-      // target is the point: with batching on the scene reaches it, and the
-      // ratchet must fail if it ever stops.
-      return nullptr;
     }
     return &entry;
   }

--- a/donner/svg/renderer/geode/tests/GeodeGlyphInstancing_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeGlyphInstancing_tests.cc
@@ -156,10 +156,15 @@ TEST_F(GeodeGlyphInstancingTest, RepeatedGlyphsShareOneResidentOutline) {
       << "The resident second frame must draw the same coverage as the first.";
 }
 
-/// Two separate `<text>` elements are distinct source entities that share glyph
-/// outlines. They must batch together, and - the part that batching can get
-/// wrong - overlapping instances must still composite in painter order, because
-/// the batch draws them as instances of one call.
+/// Two separate `<text>` elements are distinct source entities that share one
+/// glyph outline: residency is keyed on the glyph, not on the element, so the
+/// outline is built once for both.
+///
+/// Their DRAWS do not currently share a batch - each element's fill loop closes
+/// its batch before anything else can emit, so batching collapses occurrences
+/// within an element and cross-element batching is future work. What this pins
+/// is the property batching can get wrong wherever it does apply: instances of
+/// one draw must still composite in painter order.
 TEST_F(GeodeGlyphInstancingTest, OverlappingTextElementsCompositeInPaintOrder) {
   // Both elements draw the same glyphs at the same place: opaque blue is
   // painted last, so blue must win everywhere the two overlap.
@@ -273,8 +278,6 @@ TEST_F(GeodeGlyphInstancingTest, FontSizeChangeInvalidatesResidentGlyphGeometry)
       << "The larger font must cover substantially more of the canvas; serving the cached "
          "small outline would keep the coverage the same.";
 
-  // Back to the original size: the first entry is still resident and serves it
-  // without a rebuild.
   // Returning to the original size renders the original geometry again. This
   // deliberately does not assert a cache hit: a style mutation re-resolves the
   // document's fonts, and a re-resolved font is a new identity, so the earlier
@@ -286,6 +289,107 @@ TEST_F(GeodeGlyphInstancingTest, FontSizeChangeInvalidatesResidentGlyphGeometry)
   const Frame backToSmall = render(renderer, document);
   EXPECT_EQ(nonTransparentPixels(backToSmall.bitmap), smallCovered)
       << "Returning to the original size must render the original geometry.";
+}
+
+/// Per-glyph `rotate` is part of glyph identity, so a rotated run is cached and
+/// instanced exactly like an upright one: one angle costs one outline no matter
+/// how many occurrences carry it.
+TEST_F(GeodeGlyphInstancingTest, WholeRunRotationCostsOneResidentOutlinePerAngle) {
+  SVGDocument document = parse(R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"
+           font-family="Noto Sans" font-size="32">
+        <text x="20" y="120" fill="black" rotate="30">eeee</text>
+      </svg>)svg");
+
+  RendererGeode renderer(sharedDevice());
+  const Frame first = render(renderer, document);
+  ASSERT_GT(nonTransparentPixels(first.bitmap), 0u) << "Rotated text did not render at all.";
+
+  EXPECT_EQ(first.counters.glyphResidencyUploads, 1u)
+      << "Four occurrences of one glyph at one angle must build one outline.";
+  EXPECT_EQ(renderer.residentGlyphCountForTesting(document), 1u);
+
+  const Frame second = render(renderer, document);
+  EXPECT_EQ(second.counters.glyphResidencyUploads, 0u);
+  EXPECT_EQ(second.counters.pathEncodes, 0u)
+      << "An unchanged rotated text frame must re-encode nothing.";
+  EXPECT_EQ(nonTransparentPixels(second.bitmap), nonTransparentPixels(first.bitmap));
+}
+
+/// Angle is part of the key, so glyphs that differ ONLY in rotation must not
+/// share an outline - serving one angle's geometry for another would draw the
+/// glyph tilted the wrong way.
+TEST_F(GeodeGlyphInstancingTest, DistinctRotationsTakeDistinctResidentOutlines) {
+  SVGDocument document = parse(R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"
+           font-family="Noto Sans" font-size="32">
+        <text x="20" y="120" fill="black" rotate="0 45 90">eee</text>
+      </svg>)svg");
+
+  RendererGeode renderer(sharedDevice());
+  const Frame first = render(renderer, document);
+  ASSERT_GT(nonTransparentPixels(first.bitmap), 0u) << "Rotated text did not render at all.";
+
+  EXPECT_EQ(renderer.residentGlyphCountForTesting(document), 3u)
+      << "One glyph at three angles is three glyph identities.";
+  EXPECT_EQ(first.counters.glyphResidencyUploads, 3u);
+}
+
+/// A document that keeps mutating - the editor's typing and drag loop - churns
+/// glyph identities today, because re-resolving a text element's style hands
+/// back new font handles (a `FontManager` behaviour this change does not
+/// touch). The residency must then stay BOUNDED by its budget rather than
+/// growing without limit: superseded entries have to be evicted, not stranded.
+TEST_F(GeodeGlyphInstancingTest, RepeatedMutationKeepsResidencyBounded) {
+  SVGDocument document = parse(R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+        <text id="t" x="10" y="120" font-family="Noto Sans" font-size="24"
+              fill="black">Hello</text>
+      </svg>)svg");
+
+  auto text = document.querySelector("#t");
+  ASSERT_TRUE(text.has_value());
+
+  RendererGeode renderer(sharedDevice());
+  // A budget far below what 20 rounds of unreclaimed churn would reach, so a
+  // pass means eviction is doing the work rather than the budget being roomy.
+  constexpr size_t kMaxEntries = 16u;
+  // "Hello" resolves to four distinct glyph outlines, and a frame's own new
+  // entries land AFTER that frame's trim, so the count legitimately sits above
+  // the cap until the next frame trims it. Give that one frame of headroom.
+  constexpr size_t kDistinctGlyphsPerFrame = 4u;
+  constexpr size_t kCeiling = kMaxEntries + kDistinctGlyphsPerFrame;
+  renderer.setGlyphResidencyBudgetForTesting(kMaxEntries, /*maxEncodedBytes=*/1u << 30);
+
+  uint64_t totalEvictions = 0;
+  size_t settledCount = 0;
+  for (int round = 0; round < 20; ++round) {
+    // Alternate the fill so every round is a real style mutation while the
+    // glyph geometry stays identical.
+    text->setAttribute("fill", (round % 2) == 0 ? "#101010" : "#202020");
+    const Frame frame = render(renderer, document);
+    ASSERT_GT(nonTransparentPixels(frame.bitmap), 0u)
+        << "Text stopped rendering at mutation round " << round;
+    totalEvictions += frame.counters.glyphResidencyEvictions;
+
+    const size_t resident = renderer.residentGlyphCountForTesting(document);
+    EXPECT_LE(resident, kCeiling) << "Residency exceeded its budget at mutation round " << round;
+
+    // Once the churn has filled the budget, the count must stop climbing:
+    // that, not the absolute number, is what says superseded identities are
+    // reclaimed rather than stranded.
+    if (round == 9) {
+      settledCount = resident;
+    } else if (round > 9) {
+      EXPECT_LE(resident, settledCount)
+          << "Residency grew after settling, at mutation round " << round;
+    }
+  }
+
+  EXPECT_GT(totalEvictions, 0u)
+      << "Mutation churn must be reclaimed by eviction, not accumulated. If this fails while "
+         "the ceiling assertion passes, the churn stopped happening and this test is now "
+         "measuring nothing.";
 }
 
 }  // namespace

--- a/donner/svg/renderer/geode/tests/GeodeGlyphInstancing_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeGlyphInstancing_tests.cc
@@ -151,8 +151,7 @@ TEST_F(GeodeGlyphInstancingTest, RepeatedGlyphsShareOneResidentOutline) {
       << "An unchanged frame must not re-derive any glyph outline.";
   EXPECT_EQ(second.counters.glyphResidencyHits, 4u)
       << "Every occurrence of an unchanged frame comes from residency.";
-  EXPECT_EQ(second.counters.pathEncodes, 0u)
-      << "An unchanged text frame must re-encode nothing.";
+  EXPECT_EQ(second.counters.pathEncodes, 0u) << "An unchanged text frame must re-encode nothing.";
   EXPECT_EQ(nonTransparentPixels(second.bitmap), nonTransparentPixels(first.bitmap))
       << "The resident second frame must draw the same coverage as the first.";
 }

--- a/donner/svg/renderer/geode/tests/GeodeGlyphInstancing_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeGlyphInstancing_tests.cc
@@ -1,0 +1,293 @@
+/// @file
+/// End-to-end gate for glyph-outline residency and per-occurrence instancing.
+///
+/// The unit of work these tests are about is the glyph OCCURRENCE: a letter at
+/// one position in one run. Text used to pay for every occurrence in full - the
+/// outline was fetched from the font backend, transformed into place, banded,
+/// and uploaded, once per occurrence per frame. The behaviour under test is
+/// that the expensive half of that is now paid once per unique glyph outline
+/// and retained, while the occurrence contributes only an instance record.
+///
+/// The observables are the frame counters (`glyphResidencyUploads`,
+/// `glyphResidencyHits`, `glyphResidencyEvictions`, `pathEncodes`,
+/// `drawCalls`) plus pixels, because a counter that improves while the text
+/// stops rendering is not an improvement.
+///
+/// Fonts come from the checked-in hermetic set: glyph identity is the cache
+/// key, so resolving fonts from the host would make every count here a
+/// property of the machine that ran the test.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "donner/base/ParseWarningSink.h"
+#include "donner/base/Vector2.h"
+#include "donner/base/tests/Runfiles.h"
+#include "donner/svg/SVGDocument.h"
+#include "donner/svg/parser/SVGParser.h"
+#include "donner/svg/renderer/RendererGeode.h"
+#include "donner/svg/renderer/RendererInterface.h"
+#include "donner/svg/renderer/geode/GeodeCounters.h"
+#include "donner/svg/renderer/geode/GeodeDevice.h"
+#include "donner/svg/renderer/tests/ImageComparisonTestFixture.h"
+
+namespace donner::svg {
+namespace {
+
+/// Hermetic test fonts, relative to the runfiles root.
+constexpr std::string_view kFontsRunfilesPath = "third_party/resvg-test-suite/fonts";
+
+/// Pixels with a non-zero alpha. Used as the liveness signal: every counter
+/// assertion here is paired with one so a "fix" that stops drawing the text
+/// cannot pass.
+size_t nonTransparentPixels(const RendererBitmap& bitmap) {
+  size_t count = 0;
+  for (int y = 0; y < bitmap.dimensions.y; ++y) {
+    const uint8_t* row = bitmap.pixels.data() + static_cast<size_t>(y) * bitmap.rowBytes;
+    for (int x = 0; x < bitmap.dimensions.x; ++x) {
+      if (row[x * 4 + 3] != 0) {
+        ++count;
+      }
+    }
+  }
+  return count;
+}
+
+/// Straight-alpha RGBA at (x, y).
+struct Pixel {
+  uint8_t r = 0;
+  uint8_t g = 0;
+  uint8_t b = 0;
+  uint8_t a = 0;
+};
+
+Pixel pixelAt(const RendererBitmap& bitmap, int x, int y) {
+  const size_t offset = static_cast<size_t>(y) * bitmap.rowBytes + static_cast<size_t>(x) * 4u;
+  if (offset + 4 > bitmap.pixels.size()) {
+    return Pixel{};
+  }
+  return Pixel{bitmap.pixels[offset], bitmap.pixels[offset + 1], bitmap.pixels[offset + 2],
+               bitmap.pixels[offset + 3]};
+}
+
+class GeodeGlyphInstancingTest : public ::testing::Test {
+protected:
+  /// Process-wide shared device, matching the other GPU-opening geode suites:
+  /// device creation dominates the runtime of a short test.
+  static std::shared_ptr<geode::GeodeDevice> sharedDevice() {
+    static auto device = [] {
+      return std::shared_ptr<geode::GeodeDevice>(geode::GeodeDevice::CreateHeadless());
+    }();
+    return device;
+  }
+
+  void SetUp() override {
+    ASSERT_TRUE(sharedDevice()) << "No headless GPU device; the glyph residency gate needs one.";
+    const std::filesystem::path fontsDir =
+        Runfiles::instance().Rlocation(std::string(kFontsRunfilesPath));
+    ASSERT_TRUE(std::filesystem::is_directory(fontsDir))
+        << "Hermetic test fonts not found at '" << fontsDir
+        << "'; without them glyph identity depends on the host's installed fonts.";
+  }
+
+  /// Parse `source` and point its generic font families at the hermetic set.
+  SVGDocument parse(std::string_view source, int canvasEdge = 200) {
+    ParseWarningSink sink = ParseWarningSink::Disabled();
+    auto parsed = parser::SVGParser::ParseSVG(source, sink);
+    EXPECT_FALSE(parsed.hasError()) << (parsed.hasError() ? parsed.error().reason : "");
+    SVGDocument document = std::move(parsed.result());
+    TrustDocumentFontFacesForTesting(document);
+    RegisterFontsFromDirectoryForTesting(
+        document, Runfiles::instance().Rlocation(std::string(kFontsRunfilesPath)));
+    document.setCanvasSize(canvasEdge, canvasEdge);
+    return document;
+  }
+
+  /// One rendered frame plus the counters it cost.
+  struct Frame {
+    RendererBitmap bitmap;
+    geode::GeodeCounters counters;
+  };
+
+  Frame render(RendererGeode& renderer, SVGDocument& document) {
+    Frame frame;
+    renderer.draw(document);
+    frame.counters = renderer.lastFrameTimings().counters;
+    frame.bitmap = renderer.takeSnapshot();
+    return frame;
+  }
+};
+
+/// A run repeats a handful of outlines across many occurrences. The first frame
+/// pays one upload per DISTINCT outline; every later occurrence, in that frame
+/// and in every frame after it, hits the resident entry and re-encodes nothing.
+TEST_F(GeodeGlyphInstancingTest, RepeatedGlyphsShareOneResidentOutline) {
+  // "eeee" is four occurrences of one outline, so the occurrence count and the
+  // distinct-outline count cannot be confused for each other.
+  SVGDocument document = parse(R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"
+           font-family="Noto Sans" font-size="32">
+        <text x="10" y="60" fill="black">eeee</text>
+      </svg>)svg");
+
+  RendererGeode renderer(sharedDevice());
+  const Frame first = render(renderer, document);
+  ASSERT_GT(nonTransparentPixels(first.bitmap), 0u) << "Text did not render at all.";
+
+  EXPECT_EQ(first.counters.glyphResidencyUploads, 1u)
+      << "Four occurrences of one outline must upload exactly one resident glyph.";
+  EXPECT_EQ(first.counters.glyphResidencyHits, 3u)
+      << "The second and later occurrences must come from the resident entry.";
+  EXPECT_EQ(renderer.residentGlyphCountForTesting(document), 1u);
+
+  const Frame second = render(renderer, document);
+  EXPECT_EQ(second.counters.glyphResidencyUploads, 0u)
+      << "An unchanged frame must not re-derive any glyph outline.";
+  EXPECT_EQ(second.counters.glyphResidencyHits, 4u)
+      << "Every occurrence of an unchanged frame comes from residency.";
+  EXPECT_EQ(second.counters.pathEncodes, 0u)
+      << "An unchanged text frame must re-encode nothing.";
+  EXPECT_EQ(nonTransparentPixels(second.bitmap), nonTransparentPixels(first.bitmap))
+      << "The resident second frame must draw the same coverage as the first.";
+}
+
+/// Two separate `<text>` elements are distinct source entities that share glyph
+/// outlines. They must batch together, and - the part that batching can get
+/// wrong - overlapping instances must still composite in painter order, because
+/// the batch draws them as instances of one call.
+TEST_F(GeodeGlyphInstancingTest, OverlappingTextElementsCompositeInPaintOrder) {
+  // Both elements draw the same glyphs at the same place: opaque blue is
+  // painted last, so blue must win everywhere the two overlap.
+  SVGDocument document = parse(R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"
+           font-family="Noto Sans" font-size="96">
+        <text x="10" y="120" fill="#ff0000">HH</text>
+        <text x="10" y="120" fill="#0000ff">HH</text>
+      </svg>)svg");
+
+  RendererGeode renderer(sharedDevice());
+  const Frame first = render(renderer, document);
+  const size_t covered = nonTransparentPixels(first.bitmap);
+  ASSERT_GT(covered, 0u) << "Text did not render at all.";
+
+  // One outline serves all four occurrences across the two elements.
+  EXPECT_EQ(first.counters.glyphResidencyUploads, 1u);
+  EXPECT_EQ(renderer.residentGlyphCountForTesting(document), 1u);
+
+  // Find a pixel the glyphs fully cover and check the painter-order winner.
+  bool foundOpaque = false;
+  for (int y = 0; y < first.bitmap.dimensions.y && !foundOpaque; ++y) {
+    for (int x = 0; x < first.bitmap.dimensions.x; ++x) {
+      const Pixel pixel = pixelAt(first.bitmap, x, y);
+      if (pixel.a == 255) {
+        EXPECT_LT(pixel.r, 16) << "Red shows through at (" << x << ", " << y
+                               << "); the later element must win in painter order.";
+        EXPECT_GT(pixel.b, 200) << "Blue is missing at (" << x << ", " << y << ").";
+        foundOpaque = true;
+        break;
+      }
+    }
+  }
+  EXPECT_TRUE(foundOpaque) << "No fully covered glyph pixel to check painter order against.";
+
+  const Frame second = render(renderer, document);
+  EXPECT_EQ(second.counters.glyphResidencyUploads, 0u);
+  EXPECT_EQ(second.counters.pathEncodes, 0u)
+      << "Two elements' worth of glyphs must all come from residency on an unchanged frame.";
+  EXPECT_EQ(nonTransparentPixels(second.bitmap), covered);
+
+  if (RendererGeode::sceneBatchingEnabledForTesting()) {
+    EXPECT_LT(second.counters.drawCalls, 4u)
+        << "Four glyph occurrences over one resident outline must collapse into fewer draws "
+           "than occurrences.";
+  }
+}
+
+/// Residency is budgeted. Under a budget smaller than the working set the
+/// oldest unused entries are dropped, the dropped glyphs are re-uploaded when
+/// they come back, and the text keeps rendering identically throughout.
+TEST_F(GeodeGlyphInstancingTest, EvictionUnderPressureKeepsRenderingCorrect) {
+  SVGDocument document = parse(R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"
+           font-family="Noto Sans" font-size="24">
+        <text x="10" y="60" fill="black">abcdefghij</text>
+      </svg>)svg");
+
+  RendererGeode renderer(sharedDevice());
+  const Frame unbudgeted = render(renderer, document);
+  const size_t covered = nonTransparentPixels(unbudgeted.bitmap);
+  ASSERT_GT(covered, 0u) << "Text did not render at all.";
+  ASSERT_GT(renderer.residentGlyphCountForTesting(document), 2u)
+      << "This document needs more distinct glyphs than the budget below to create pressure.";
+  EXPECT_EQ(unbudgeted.counters.glyphResidencyEvictions, 0u)
+      << "The default budget must not evict a ten-glyph document.";
+
+  renderer.setGlyphResidencyBudgetForTesting(/*maxEntries=*/2, /*maxEncodedBytes=*/1u << 30);
+
+  const Frame squeezed = render(renderer, document);
+  EXPECT_GT(squeezed.counters.glyphResidencyEvictions, 0u)
+      << "A budget below the working set must drop entries.";
+  EXPECT_GT(squeezed.counters.glyphResidencyUploads, 0u)
+      << "Glyphs dropped by the trim must be re-uploaded when they are drawn again.";
+  EXPECT_EQ(nonTransparentPixels(squeezed.bitmap), covered)
+      << "Eviction must not change what the frame draws.";
+
+  // Still correct once the budget is lifted again: the entries that survived
+  // the squeeze are still usable, not left half-released.
+  renderer.setGlyphResidencyBudgetForTesting(/*maxEntries=*/1024, /*maxEncodedBytes=*/1u << 30);
+  const Frame restored = render(renderer, document);
+  EXPECT_EQ(nonTransparentPixels(restored.bitmap), covered);
+}
+
+/// The cache key carries every parameter that changes the outline. A font-size
+/// change alters the scale the outline is built at, so it must mint new entries
+/// and draw the new size rather than serving the old geometry.
+TEST_F(GeodeGlyphInstancingTest, FontSizeChangeInvalidatesResidentGlyphGeometry) {
+  SVGDocument document = parse(R"svg(
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+        <text id="t" x="10" y="120" font-family="Noto Sans" font-size="24"
+              fill="black">HH</text>
+      </svg>)svg");
+
+  RendererGeode renderer(sharedDevice());
+  const Frame small = render(renderer, document);
+  const size_t smallCovered = nonTransparentPixels(small.bitmap);
+  ASSERT_GT(smallCovered, 0u) << "Text did not render at all.";
+  ASSERT_EQ(renderer.residentGlyphCountForTesting(document), 1u);
+
+  auto text = document.querySelector("#t");
+  ASSERT_TRUE(text.has_value());
+  text->setAttribute("font-size", "96");
+
+  const Frame large = render(renderer, document);
+  EXPECT_GT(large.counters.glyphResidencyUploads, 0u)
+      << "A scale change must build a new outline rather than reuse the old entry.";
+  EXPECT_EQ(renderer.residentGlyphCountForTesting(document), 2u)
+      << "The two sizes are distinct glyph identities and must not share an entry.";
+  EXPECT_GT(nonTransparentPixels(large.bitmap), smallCovered * 3u)
+      << "The larger font must cover substantially more of the canvas; serving the cached "
+         "small outline would keep the coverage the same.";
+
+  // Back to the original size: the first entry is still resident and serves it
+  // without a rebuild.
+  // Returning to the original size renders the original geometry again. This
+  // deliberately does not assert a cache hit: a style mutation re-resolves the
+  // document's fonts, and a re-resolved font is a new identity, so the earlier
+  // entry no longer matches. That costs a rebuild on a mutating document and
+  // the stale entries age out through the residency budget; what must never
+  // happen is the wrong geometry being served, which the coverage check below
+  // is what pins.
+  text->setAttribute("font-size", "24");
+  const Frame backToSmall = render(renderer, document);
+  EXPECT_EQ(nonTransparentPixels(backToSmall.bitmap), smallCovered)
+      << "Returning to the original size must render the original geometry.";
+}
+
+}  // namespace
+}  // namespace donner::svg

--- a/donner/svg/renderer/geode/tests/GeodeGlyphResidency_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeGlyphResidency_tests.cc
@@ -160,16 +160,13 @@ TEST(GeodeGlyphCacheTest, BeginFrameTrimsAtMostOncePerFrame) {
   InsertUsed(cache, MakeKey(/*glyphIndex=*/2), /*curveCount=*/1, /*frame=*/1);
   InsertUsed(cache, MakeKey(/*glyphIndex=*/3), /*curveCount=*/1, /*frame=*/1);
 
-  EXPECT_EQ(cache.beginFrame(/*frameIndex=*/2, /*maxEntries=*/2, /*maxEncodedBytes=*/1u << 20),
-            1u);
+  EXPECT_EQ(cache.beginFrame(/*frameIndex=*/2, /*maxEntries=*/2, /*maxEncodedBytes=*/1u << 20), 1u);
   // A second touch of the same frame must not trim again, even though the
   // renderer calls the accessor once per glyph occurrence.
-  EXPECT_EQ(cache.beginFrame(/*frameIndex=*/2, /*maxEntries=*/1, /*maxEncodedBytes=*/1u << 20),
-            0u);
+  EXPECT_EQ(cache.beginFrame(/*frameIndex=*/2, /*maxEntries=*/1, /*maxEncodedBytes=*/1u << 20), 0u);
   EXPECT_EQ(cache.size(), 2u);
 
-  EXPECT_EQ(cache.beginFrame(/*frameIndex=*/3, /*maxEntries=*/1, /*maxEncodedBytes=*/1u << 20),
-            1u);
+  EXPECT_EQ(cache.beginFrame(/*frameIndex=*/3, /*maxEntries=*/1, /*maxEncodedBytes=*/1u << 20), 1u);
   EXPECT_EQ(cache.size(), 1u);
 }
 

--- a/donner/svg/renderer/geode/tests/GeodeGlyphResidency_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeGlyphResidency_tests.cc
@@ -1,0 +1,210 @@
+/// @file
+/// Unit tests for the glyph-identity cache's key semantics and eviction
+/// policy. No GPU device is created: every entry here carries an empty
+/// resident slot, which is exactly the part of the cache that is pure
+/// bookkeeping.
+
+#include "donner/svg/renderer/geode/GeodeGlyphResidency.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "donner/base/Path.h"
+
+namespace donner::geode {
+
+namespace {
+
+GlyphGeometryKey MakeKey(uint32_t glyphIndex, float outlineScale = 0.25f) {
+  GlyphGeometryKey key;
+  key.fontId = 7u;
+  key.glyphIndex = glyphIndex;
+  key.outlineScale = outlineScale;
+  return key;
+}
+
+/// An encode whose accounted size is `curveCount * sizeof(Curve)`, so a test
+/// can hand the budget a known number of bytes without going through the
+/// encoder.
+EncodedPath MakeEncodeWithCurves(size_t curveCount) {
+  EncodedPath encoded;
+  encoded.curves.resize(curveCount);
+  return encoded;
+}
+
+/// Insert `key` and immediately mark it used in `frame`, which is what the
+/// renderer does for every occurrence it draws.
+GeodeGlyphResidentEntry* InsertUsed(GeodeGlyphCache& cache, const GlyphGeometryKey& key,
+                                    size_t curveCount, uint64_t frame) {
+  GeodeGlyphResidentEntry* entry = cache.insert(key, Path(), MakeEncodeWithCurves(curveCount));
+  entry->lastUsedFrame = frame;
+  return entry;
+}
+
+}  // namespace
+
+TEST(GeodeGlyphCacheTest, DistinctGlyphIdentitiesTakeDistinctEntries) {
+  GeodeGlyphCache cache(/*deviceId=*/1u);
+
+  GlyphGeometryKey a = MakeKey(/*glyphIndex=*/10);
+  GlyphGeometryKey b = MakeKey(/*glyphIndex=*/11);
+  GlyphGeometryKey scaled = MakeKey(/*glyphIndex=*/10, /*outlineScale=*/0.5f);
+  GlyphGeometryKey stretched = MakeKey(/*glyphIndex=*/10);
+  stretched.stretchScaleX = 2.0f;
+  GlyphGeometryKey otherFont = MakeKey(/*glyphIndex=*/10);
+  otherFont.fontId = 8u;
+
+  InsertUsed(cache, a, /*curveCount=*/1, /*frame=*/1);
+  InsertUsed(cache, b, /*curveCount=*/1, /*frame=*/1);
+  InsertUsed(cache, scaled, /*curveCount=*/1, /*frame=*/1);
+  InsertUsed(cache, stretched, /*curveCount=*/1, /*frame=*/1);
+  InsertUsed(cache, otherFont, /*curveCount=*/1, /*frame=*/1);
+
+  EXPECT_EQ(cache.size(), 5u);
+  EXPECT_NE(cache.find(a), nullptr);
+  EXPECT_NE(cache.find(scaled), nullptr);
+  EXPECT_NE(cache.find(a), cache.find(scaled));
+  EXPECT_NE(cache.find(a), cache.find(stretched));
+  EXPECT_NE(cache.find(a), cache.find(otherFont));
+}
+
+TEST(GeodeGlyphCacheTest, RepeatedLookupOfOneIdentityReusesTheSameEntry) {
+  GeodeGlyphCache cache(/*deviceId=*/1u);
+  const GlyphGeometryKey key = MakeKey(/*glyphIndex=*/42);
+
+  GeodeGlyphResidentEntry* first = InsertUsed(cache, key, /*curveCount=*/3, /*frame=*/1);
+  ASSERT_NE(first, nullptr);
+
+  EXPECT_EQ(cache.find(key), first);
+  EXPECT_EQ(cache.find(MakeKey(/*glyphIndex=*/42)), first);
+  EXPECT_EQ(cache.size(), 1u);
+}
+
+TEST(GeodeGlyphCacheTest, ScalesThatDifferInTheLastBitDoNotShareAnEntry) {
+  GeodeGlyphCache cache(/*deviceId=*/1u);
+  const float scale = 0.25f;
+  const float nudged = std::nextafter(scale, 1.0f);
+
+  InsertUsed(cache, MakeKey(/*glyphIndex=*/5, scale), /*curveCount=*/1, /*frame=*/1);
+  EXPECT_EQ(cache.find(MakeKey(/*glyphIndex=*/5, nudged)), nullptr);
+}
+
+TEST(GeodeGlyphCacheTest, MissingEntryReportsAMiss) {
+  GeodeGlyphCache cache(/*deviceId=*/1u);
+  EXPECT_EQ(cache.find(MakeKey(/*glyphIndex=*/1)), nullptr);
+  EXPECT_EQ(cache.size(), 0u);
+}
+
+TEST(GeodeGlyphCacheTest, EntryCountBudgetDropsTheLeastRecentlyUsedFirst) {
+  GeodeGlyphCache cache(/*deviceId=*/1u);
+  const GlyphGeometryKey oldest = MakeKey(/*glyphIndex=*/1);
+  const GlyphGeometryKey middle = MakeKey(/*glyphIndex=*/2);
+  const GlyphGeometryKey newest = MakeKey(/*glyphIndex=*/3);
+  InsertUsed(cache, oldest, /*curveCount=*/1, /*frame=*/1);
+  InsertUsed(cache, middle, /*curveCount=*/1, /*frame=*/2);
+  InsertUsed(cache, newest, /*curveCount=*/1, /*frame=*/3);
+
+  EXPECT_EQ(cache.evictToBudget(/*currentFrame=*/4, /*maxEntries=*/2,
+                                /*maxEncodedBytes=*/1u << 20),
+            1u);
+  EXPECT_EQ(cache.size(), 2u);
+  EXPECT_EQ(cache.find(oldest), nullptr);
+  EXPECT_NE(cache.find(middle), nullptr);
+  EXPECT_NE(cache.find(newest), nullptr);
+}
+
+TEST(GeodeGlyphCacheTest, ByteBudgetDropsEntriesUntilItFits) {
+  GeodeGlyphCache cache(/*deviceId=*/1u);
+  const uint64_t curveBytes = 6u * sizeof(float);
+  InsertUsed(cache, MakeKey(/*glyphIndex=*/1), /*curveCount=*/4, /*frame=*/1);
+  InsertUsed(cache, MakeKey(/*glyphIndex=*/2), /*curveCount=*/4, /*frame=*/2);
+  InsertUsed(cache, MakeKey(/*glyphIndex=*/3), /*curveCount=*/4, /*frame=*/3);
+  ASSERT_EQ(cache.encodedBytes(), 12u * curveBytes);
+
+  EXPECT_EQ(cache.evictToBudget(/*currentFrame=*/4, /*maxEntries=*/100,
+                                /*maxEncodedBytes=*/5u * curveBytes),
+            2u);
+  EXPECT_EQ(cache.size(), 1u);
+  EXPECT_EQ(cache.encodedBytes(), 4u * curveBytes);
+  EXPECT_NE(cache.find(MakeKey(/*glyphIndex=*/3)), nullptr);
+}
+
+TEST(GeodeGlyphCacheTest, EntriesUsedThisFrameSurviveAnOverBudgetTrim) {
+  // The frame that is drawing right now has recorded draws reading these
+  // entries' geometry, and freeing a slab range mid-frame would hand it to a
+  // later allocation in the same frame.
+  GeodeGlyphCache cache(/*deviceId=*/1u);
+  InsertUsed(cache, MakeKey(/*glyphIndex=*/1), /*curveCount=*/1, /*frame=*/9);
+  InsertUsed(cache, MakeKey(/*glyphIndex=*/2), /*curveCount=*/1, /*frame=*/9);
+  InsertUsed(cache, MakeKey(/*glyphIndex=*/3), /*curveCount=*/1, /*frame=*/9);
+
+  EXPECT_EQ(cache.evictToBudget(/*currentFrame=*/9, /*maxEntries=*/1,
+                                /*maxEncodedBytes=*/1u << 20),
+            0u);
+  EXPECT_EQ(cache.size(), 3u);
+}
+
+TEST(GeodeGlyphCacheTest, TrimIsSkippedWhenTheCacheAlreadyFits) {
+  GeodeGlyphCache cache(/*deviceId=*/1u);
+  InsertUsed(cache, MakeKey(/*glyphIndex=*/1), /*curveCount=*/1, /*frame=*/1);
+
+  EXPECT_EQ(cache.evictToBudget(/*currentFrame=*/2, /*maxEntries=*/4,
+                                /*maxEncodedBytes=*/1u << 20),
+            0u);
+  EXPECT_EQ(cache.size(), 1u);
+}
+
+TEST(GeodeGlyphCacheTest, BeginFrameTrimsAtMostOncePerFrame) {
+  GeodeGlyphCache cache(/*deviceId=*/1u);
+  InsertUsed(cache, MakeKey(/*glyphIndex=*/1), /*curveCount=*/1, /*frame=*/1);
+  InsertUsed(cache, MakeKey(/*glyphIndex=*/2), /*curveCount=*/1, /*frame=*/1);
+  InsertUsed(cache, MakeKey(/*glyphIndex=*/3), /*curveCount=*/1, /*frame=*/1);
+
+  EXPECT_EQ(cache.beginFrame(/*frameIndex=*/2, /*maxEntries=*/2, /*maxEncodedBytes=*/1u << 20),
+            1u);
+  // A second touch of the same frame must not trim again, even though the
+  // renderer calls the accessor once per glyph occurrence.
+  EXPECT_EQ(cache.beginFrame(/*frameIndex=*/2, /*maxEntries=*/1, /*maxEncodedBytes=*/1u << 20),
+            0u);
+  EXPECT_EQ(cache.size(), 2u);
+
+  EXPECT_EQ(cache.beginFrame(/*frameIndex=*/3, /*maxEntries=*/1, /*maxEncodedBytes=*/1u << 20),
+            1u);
+  EXPECT_EQ(cache.size(), 1u);
+}
+
+TEST(GeodeTextInstanceRecordComponentTest, OccurrenceAddressesSurviveGrowth) {
+  // A pending batch holds pointers into these entries while later occurrences
+  // are still appending; a reallocating container would leave the batch
+  // writing through dangling pointers at flush.
+  GeodeTextInstanceRecordComponent component;
+  component.occurrences.push_back(GeodeTextInstanceRecordComponent::Occurrence{});
+  const GeodeTextInstanceRecordComponent::Occurrence* first = &component.occurrences.front();
+
+  for (int i = 0; i < 512; ++i) {
+    component.occurrences.push_back(GeodeTextInstanceRecordComponent::Occurrence{});
+  }
+
+  EXPECT_EQ(&component.occurrences.front(), first);
+}
+
+TEST(GeodeTextInstanceRecordComponentTest, MoveLeavesTheSourceWithNoSlotsToRelease) {
+  // entt's swap-and-pop removal move-assigns the surviving component over the
+  // removed one; a source that kept its slots would free the survivor's
+  // records from its own destructor.
+  GeodeTextInstanceRecordComponent source;
+  source.occurrences.push_back(GeodeTextInstanceRecordComponent::Occurrence{});
+  source.lastFrame = 5u;
+
+  GeodeTextInstanceRecordComponent moved = std::move(source);
+  EXPECT_EQ(moved.occurrences.size(), 1u);
+  EXPECT_EQ(moved.lastFrame, 5u);
+  EXPECT_TRUE(source.occurrences.empty());
+
+  GeodeTextInstanceRecordComponent assigned;
+  assigned = std::move(moved);
+  EXPECT_EQ(assigned.occurrences.size(), 1u);
+  EXPECT_TRUE(moved.occurrences.empty());
+}
+
+}  // namespace donner::geode

--- a/donner/svg/renderer/geode/tests/GeodeGlyphResidency_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeGlyphResidency_tests.cc
@@ -104,7 +104,7 @@ TEST(GeodeGlyphCacheTest, EntryCountBudgetDropsTheLeastRecentlyUsedFirst) {
   InsertUsed(cache, middle, /*curveCount=*/1, /*frame=*/2);
   InsertUsed(cache, newest, /*curveCount=*/1, /*frame=*/3);
 
-  EXPECT_EQ(cache.evictToBudget(/*currentFrame=*/4, /*maxEntries=*/2,
+  EXPECT_EQ(cache.evictToBudget(/*oldestOpenFrame=*/4, /*maxEntries=*/2,
                                 /*maxEncodedBytes=*/1u << 20),
             1u);
   EXPECT_EQ(cache.size(), 2u);
@@ -121,7 +121,7 @@ TEST(GeodeGlyphCacheTest, ByteBudgetDropsEntriesUntilItFits) {
   InsertUsed(cache, MakeKey(/*glyphIndex=*/3), /*curveCount=*/4, /*frame=*/3);
   ASSERT_EQ(cache.encodedBytes(), 12u * curveBytes);
 
-  EXPECT_EQ(cache.evictToBudget(/*currentFrame=*/4, /*maxEntries=*/100,
+  EXPECT_EQ(cache.evictToBudget(/*oldestOpenFrame=*/4, /*maxEntries=*/100,
                                 /*maxEncodedBytes=*/5u * curveBytes),
             2u);
   EXPECT_EQ(cache.size(), 1u);
@@ -129,16 +129,16 @@ TEST(GeodeGlyphCacheTest, ByteBudgetDropsEntriesUntilItFits) {
   EXPECT_NE(cache.find(MakeKey(/*glyphIndex=*/3)), nullptr);
 }
 
-TEST(GeodeGlyphCacheTest, EntriesUsedThisFrameSurviveAnOverBudgetTrim) {
-  // The frame that is drawing right now has recorded draws reading these
-  // entries' geometry, and freeing a slab range mid-frame would hand it to a
-  // later allocation in the same frame.
+TEST(GeodeGlyphCacheTest, EntriesAnUnsubmittedFrameTouchedSurviveAnOverBudgetTrim) {
+  // A frame that touched these entries has not submitted; its recorded draws
+  // still read their geometry, so freeing the slab range would hand it to a
+  // later allocation to overwrite.
   GeodeGlyphCache cache(/*deviceId=*/1u);
   InsertUsed(cache, MakeKey(/*glyphIndex=*/1), /*curveCount=*/1, /*frame=*/9);
   InsertUsed(cache, MakeKey(/*glyphIndex=*/2), /*curveCount=*/1, /*frame=*/9);
   InsertUsed(cache, MakeKey(/*glyphIndex=*/3), /*curveCount=*/1, /*frame=*/9);
 
-  EXPECT_EQ(cache.evictToBudget(/*currentFrame=*/9, /*maxEntries=*/1,
+  EXPECT_EQ(cache.evictToBudget(/*oldestOpenFrame=*/9, /*maxEntries=*/1,
                                 /*maxEncodedBytes=*/1u << 20),
             0u);
   EXPECT_EQ(cache.size(), 3u);
@@ -148,7 +148,7 @@ TEST(GeodeGlyphCacheTest, TrimIsSkippedWhenTheCacheAlreadyFits) {
   GeodeGlyphCache cache(/*deviceId=*/1u);
   InsertUsed(cache, MakeKey(/*glyphIndex=*/1), /*curveCount=*/1, /*frame=*/1);
 
-  EXPECT_EQ(cache.evictToBudget(/*currentFrame=*/2, /*maxEntries=*/4,
+  EXPECT_EQ(cache.evictToBudget(/*oldestOpenFrame=*/2, /*maxEntries=*/4,
                                 /*maxEncodedBytes=*/1u << 20),
             0u);
   EXPECT_EQ(cache.size(), 1u);
@@ -160,13 +160,19 @@ TEST(GeodeGlyphCacheTest, BeginFrameTrimsAtMostOncePerFrame) {
   InsertUsed(cache, MakeKey(/*glyphIndex=*/2), /*curveCount=*/1, /*frame=*/1);
   InsertUsed(cache, MakeKey(/*glyphIndex=*/3), /*curveCount=*/1, /*frame=*/1);
 
-  EXPECT_EQ(cache.beginFrame(/*frameIndex=*/2, /*maxEntries=*/2, /*maxEncodedBytes=*/1u << 20), 1u);
+  EXPECT_EQ(cache.beginFrame(/*frameIndex=*/2, /*oldestOpenFrame=*/2, /*maxEntries=*/2,
+                             /*maxEncodedBytes=*/1u << 20),
+            1u);
   // A second touch of the same frame must not trim again, even though the
   // renderer calls the accessor once per glyph occurrence.
-  EXPECT_EQ(cache.beginFrame(/*frameIndex=*/2, /*maxEntries=*/1, /*maxEncodedBytes=*/1u << 20), 0u);
+  EXPECT_EQ(cache.beginFrame(/*frameIndex=*/2, /*oldestOpenFrame=*/2, /*maxEntries=*/1,
+                             /*maxEncodedBytes=*/1u << 20),
+            0u);
   EXPECT_EQ(cache.size(), 2u);
 
-  EXPECT_EQ(cache.beginFrame(/*frameIndex=*/3, /*maxEntries=*/1, /*maxEncodedBytes=*/1u << 20), 1u);
+  EXPECT_EQ(cache.beginFrame(/*frameIndex=*/3, /*oldestOpenFrame=*/3, /*maxEntries=*/1,
+                             /*maxEncodedBytes=*/1u << 20),
+            1u);
   EXPECT_EQ(cache.size(), 1u);
 }
 


### PR DESCRIPTION
Text was the Geode outlier: every glyph occurrence re-fetched its outline from the font backend, re-encoded it, and re-uploaded it every frame, so text scenes sat an order of magnitude behind every other scene class. This change makes glyph geometry resident once per unique outline and instances it per occurrence through the record machinery.

Mechanism:

- `PlacedTextGeometry` (shared with the CPU backend) now exposes the unplaced outline and the placement separately; `PlacedGlyphOutline` is reimplemented on top as a single composed affine, so the CPU backend's arithmetic and output are untouched (verified bit-identical across the full scene set including all rotated scenes).
- A document-scoped glyph cache keys on font handle id (entity-versioned), glyph index, effective outline scale, lengthAdjust stretch, and rotation, all compared bitwise. Rotation is baked into the cached outline so the placement transform is a pure translation and coverage is evaluated in axis-aligned space; rotated text renders at parity with the previous per-occurrence path (byte-zero difference on the rotated corpus scenes) while gaining residency (one angle costs one cached outline).
- Occurrences contribute 256-byte instance records; consecutive record slots collapse into one instanced draw when scene batching is on. Per-occurrence record slots persist on the text element with a byte compare, so an unchanged text frame writes zero bytes to the GPU.
- Residency is budgeted (1024 outlines / 8 MiB) with oldest-unused-first trimming at the first cache touch of a frame; frame identity is device-scoped with an open-frame window so multiple renderers sharing a device (thumbnails, feImage) cannot alias or evict each other's live entries.
- The analytic coverage algorithm in the shader is untouched; no `.wgsl` file changes.

Measured on a discrete GPU (Vulkan), interleaved passes, with scene batching on (the shipping default): simple_text_demo steady 6.5 -> 0.32 ms, text_inline_size_wrap 8.4 -> 0.31 ms, text decoration 2.9x. First frames improve 1.8-3.5x because encoding happens once per unique outline even when cold. Non-text scenes are at noise and hash-identical. One honest scoping note: the steady-state win applies to an untouched document; any attribute mutation on a text element currently re-resolves fonts and mints new glyph identities (existing font-manager behavior this change does not address), so an editing loop gets the correctness and the bounded memory but not yet the speedup.

One product-visible tolerance change, stated plainly: converting text to outlines was previously asserted bit-identical to rendered text on this backend. Encoding in glyph space (better-conditioned for float32 curves) shifts 6-12 glyph-edge pixels by up to 3/255 on the covered fixtures, and the gate moved from bit-identity to the renderer suite's standard 0.02 per-pixel threshold with zero pixels allowed to exceed it, including a rotated-glyph fixture so the gate covers the case its relaxation was justified against. The bound is per-pixel with no cap on how many pixels sit under it.

Tests: 7 GPU instancing cases (repeated-glyph residency via counters, cross-element paint order, eviction-under-pressure rendering correctness, font-size invalidation of resident geometry, rotation parity, mutation-churn boundedness), 11 CPU residency unit cases (key identity and bitwise float semantics, budget eviction ordering, unsubmitted-frame protection, container address stability), and 20 text-to-outlines cases. Full renderer, editor, and gpu-inventory surface green in both flag states; counter ratchets tightened to exact observed values for the text scenes with the batching-off entries preserved for bisect truthfulness.
