### PR TITLE
fix: Resolve unspecified filter in2 inputs to the preceding result in both executors

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -50,6 +50,12 @@ See the [Project Roadmap](docs/ProjectRoadmap.md) and
 
 ### Fixes and Internals
 
+- **Filter graph `in2` default.** A filter-graph node that leaves a two-input primitive's second
+  input unpopulated (`feComposite`, `feBlend`, `feDisplacementMap`) now resolves it to the previous
+  primitive's result on both the tiny-skia and Geode backends, per the Filter Effects defaulting
+  rule, instead of the source graphic or the node's own first input. Parsed SVG documents are
+  unaffected because the attribute layer always populates both inputs; this is a behavior change
+  for embedders that build a `FilterGraph` directly.
 - **Filter subregion clipping hardening (security)** — fixed two heap-buffer-overflows in the
   tiny-skia filter pipeline (`applySubregionClipping` and `ClipFilterOutputToRegion`) where the
   kept-rect origin was clamped only at the low end; both axes are now clamped to the output bounds.

--- a/donner/svg/components/filter/FilterGraph.h
+++ b/donner/svg/components/filter/FilterGraph.h
@@ -356,8 +356,15 @@ using FilterPrimitive =
  * operation, and writes to an output buffer.
  */
 struct FilterNode {
-  FilterPrimitive primitive;        ///< The filter primitive operation.
-  std::vector<FilterInput> inputs;  ///< Input(s) to this primitive.
+  FilterPrimitive primitive;  ///< The filter primitive operation.
+
+  /// Input(s) to this primitive. A slot this list leaves unpopulated resolves exactly like an
+  /// unspecified `in`/`in2` attribute: to the previous primitive's result, and to SourceGraphic
+  /// only when the node is the first primitive in the graph. A Composite, Blend, or
+  /// DisplacementMap node built with a single input therefore reads the previous result as its
+  /// second input, never the source graphic.
+  std::vector<FilterInput> inputs;
+
   std::optional<RcString> result;   ///< Named output (for `result` attribute).
   std::optional<Lengthd> x;         ///< Primitive subregion X.
   std::optional<Lengthd> y;         ///< Primitive subregion Y.

--- a/donner/svg/components/filter/tests/FilterSystem_tests.cc
+++ b/donner/svg/components/filter/tests/FilterSystem_tests.cc
@@ -7,6 +7,10 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <string>
+#include <string_view>
+#include <variant>
+
 #include "donner/base/ParseWarningSink.h"
 #include "donner/base/tests/BaseTestUtils.h"
 #include "donner/base/tests/ParseResultTestUtils.h"
@@ -816,6 +820,43 @@ TEST_F(FilterSystemTest, FilterCustomAttributes) {
   ASSERT_THAT(computed, NotNull());
   EXPECT_EQ(computed->filterUnits, FilterUnits::ObjectBoundingBox);
   EXPECT_EQ(computed->primitiveUnits, PrimitiveUnits::UserSpaceOnUse);
+}
+
+// --- `in2` defaulting ---
+
+// Every primitive with an `in2` attribute defaults it the same way `in` defaults: to the
+// preceding primitive's result, which is SourceGraphic only for the first primitive in the
+// filter. The graph carries that as a second input holding Previous, so an executor never has to
+// guess what an absent second input meant.
+TEST_F(FilterSystemTest, UnspecifiedIn2IsThePreviousResult) {
+  for (const std::string_view primitive :
+       {"<feComposite in=\"SourceGraphic\" operator=\"in\"/>",
+        "<feBlend in=\"SourceGraphic\" mode=\"multiply\"/>",
+        "<feDisplacementMap in=\"SourceGraphic\" scale=\"4\"/>"}) {
+    SCOPED_TRACE(primitive);
+
+    auto document = ParseAndComputeFilters(std::string(R"(
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+        <defs>
+          <filter id="f">
+            <feFlood flood-color="red"/>
+            )") + std::string(primitive) + R"(
+          </filter>
+        </defs>
+      </svg>
+    )");
+
+    auto element = document.querySelector("#f");
+    ASSERT_TRUE(element.has_value());
+    auto* computed = element->entityHandle().try_get<ComputedFilterComponent>();
+    ASSERT_THAT(computed, NotNull());
+    ASSERT_THAT(computed->filterGraph.nodes, SizeIs(2));
+
+    const FilterNode& node = computed->filterGraph.nodes[1];
+    ASSERT_THAT(node.inputs, SizeIs(2));
+    EXPECT_TRUE(std::holds_alternative<FilterStandardInput>(node.inputs[0].value));
+    EXPECT_TRUE(std::holds_alternative<FilterInput::Previous>(node.inputs[1].value));
+  }
 }
 
 }  // namespace donner::svg::components

--- a/donner/svg/renderer/geode/GeodeFilterEngine.cc
+++ b/donner/svg/renderer/geode/GeodeFilterEngine.cc
@@ -860,6 +860,31 @@ FilterResourceCache::UniformSlot writeUniformSlot(FilterResourceCache& cache, Ge
   return slot;
 }
 
+/// The number of inputs a primitive reads through the filter attribute surface. feComposite,
+/// feBlend and feDisplacementMap each take a second input (`in2`); feMerge is variadic and reads
+/// exactly the list it was built with, and every other primitive reads at most one input. The cap
+/// of two is deliberate rather than a lower bound: those primitives never sample a third input, so
+/// an extra entry a caller appends must not widen the node's subregion either.
+size_t filterInputSlotCount(const svg::components::FilterNode& node) {
+  using namespace svg::components;
+  if (std::holds_alternative<filter_primitive::Composite>(node.primitive) ||
+      std::holds_alternative<filter_primitive::Blend>(node.primitive) ||
+      std::holds_alternative<filter_primitive::DisplacementMap>(node.primitive)) {
+    return 2;
+  }
+  return node.inputs.size();
+}
+
+/// The input in slot @p index, or the default for a slot the graph left empty. A slot the graph
+/// never populated is an unspecified `in`/`in2` attribute, and both resolve the same way: to the
+/// preceding primitive's result, which is SourceGraphic only when this node is the first
+/// primitive in the filter. Falling back to the node's own first input instead would silently
+/// composite, blend, or displace a buffer against itself.
+svg::components::FilterInput filterInputOrDefault(const svg::components::FilterNode& node,
+                                                  size_t index) {
+  return index < node.inputs.size() ? node.inputs[index] : svg::components::FilterInput{};
+}
+
 /// Resolve an input reference to a texture.
 wgpu::Texture resolveInput(const svg::components::FilterInput& input,
                            const std::unordered_map<std::string, wgpu::Texture>& namedBuffers,
@@ -1616,6 +1641,11 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
     const bool hasExplicitSubregion = node.x.has_value() || node.y.has_value() ||
                                       node.width.has_value() || node.height.has_value();
 
+    // The slot count and not the populated list: a two-input primitive with nothing filled in
+    // still reads two defaulted inputs, so its bounds come from those defaults rather than from
+    // the whole filter region.
+    const size_t slots = filterInputSlotCount(node);
+
     Box2d nodeSubregion = filterRegionSubregion;
     if (hasExplicitSubregion) {
       const double ux =
@@ -1634,10 +1664,13 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
                                   : filterRegion.height();
       nodeSubregion = boxIntersect(Box2d(Vector2d(ux, uy), Vector2d(ux + uw, uy + uh)),
                                    filterRegionSubregion);
-    } else if (!isSourceGenerator && !node.inputs.empty()) {
-      Box2d inputBounds = resolveInputSubregion(node.inputs[0]);
-      for (size_t i = 1; i < node.inputs.size(); ++i) {
-        inputBounds = Box2d::Union(inputBounds, resolveInputSubregion(node.inputs[i]));
+    } else if (!isSourceGenerator && slots > 0) {
+      // Walk every slot the primitive reads, so a defaulted `in2` contributes its subregion
+      // the same way an explicit one would.
+      Box2d inputBounds = resolveInputSubregion(filterInputOrDefault(node, 0));
+      for (size_t i = 1; i < slots; ++i) {
+        inputBounds =
+            Box2d::Union(inputBounds, resolveInputSubregion(filterInputOrDefault(node, i)));
       }
       if (const auto* blur = std::get_if<filter_primitive::GaussianBlur>(&node.primitive)) {
         const double expandX =
@@ -1684,11 +1717,9 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
     bool clipMergedIntoBlur = false;
 
     // Resolve the primary input texture for this node.
-    wgpu::Texture inputTex = currentBuffer;
-    if (!node.inputs.empty()) {
-      inputTex = resolveInput(node.inputs[0], namedBuffers, currentBuffer, sourceGraphic,
-                              sourceAlpha ? &*sourceAlpha : nullptr);
-    }
+    wgpu::Texture inputTex =
+        resolveInput(filterInputOrDefault(node, 0), namedBuffers, currentBuffer, sourceGraphic,
+                     sourceAlpha ? &*sourceAlpha : nullptr);
 
     // Dispatch based on primitive type.
     wgpu::Texture outputTex;
@@ -1778,11 +1809,9 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
                              sourceAlpha ? &*sourceAlpha : nullptr, nodeLinearRGB);
     } else if (const auto* composite = std::get_if<filter_primitive::Composite>(&node.primitive)) {
       // Resolve second input (in2/backdrop).
-      wgpu::Texture in2Tex = inputTex;
-      if (node.inputs.size() >= 2) {
-        in2Tex = resolveInput(node.inputs[1], namedBuffers, currentBuffer, sourceGraphic,
-                              sourceAlpha ? &*sourceAlpha : nullptr);
-      }
+      wgpu::Texture in2Tex =
+          resolveInput(filterInputOrDefault(node, 1), namedBuffers, currentBuffer, sourceGraphic,
+                       sourceAlpha ? &*sourceAlpha : nullptr);
       // Per SVG spec, feComposite operates in the filter's color-interpolation-
       // filters space (linearRGB by default). The arithmetic operator in
       // particular evaluates k1..k4 against the channel values, so the result
@@ -1802,11 +1831,9 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
       }
     } else if (const auto* blend = std::get_if<filter_primitive::Blend>(&node.primitive)) {
       // Resolve second input (in2/backdrop).
-      wgpu::Texture in2Tex = inputTex;
-      if (node.inputs.size() >= 2) {
-        in2Tex = resolveInput(node.inputs[1], namedBuffers, currentBuffer, sourceGraphic,
-                              sourceAlpha ? &*sourceAlpha : nullptr);
-      }
+      wgpu::Texture in2Tex =
+          resolveInput(filterInputOrDefault(node, 1), namedBuffers, currentBuffer, sourceGraphic,
+                       sourceAlpha ? &*sourceAlpha : nullptr);
       // Per SVG spec, feBlend operates in the filter's color-interpolation-filters
       // space (linearRGB by default). Match tiny-skia by wrapping the blend with
       // sRGB↔linear conversion when the node resolves to linearRGB.
@@ -1902,11 +1929,10 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
         outputTex = applyColorSpaceConversion(arena, outputTex, /*srgbToLinear=*/false);
       }
     } else if (const auto* disp = std::get_if<filter_primitive::DisplacementMap>(&node.primitive)) {
-      wgpu::Texture in2Tex = inputTex;
-      if (node.inputs.size() >= 2) {
-        in2Tex = resolveInput(node.inputs[1], namedBuffers, currentBuffer, sourceGraphic,
-                              sourceAlpha ? &*sourceAlpha : nullptr);
-      }
+      // Resolve second input (in2), the displacement map.
+      wgpu::Texture in2Tex =
+          resolveInput(filterInputOrDefault(node, 1), namedBuffers, currentBuffer, sourceGraphic,
+                       sourceAlpha ? &*sourceAlpha : nullptr);
       // For objectBoundingBox, scale through sqrt(bboxW * bboxH) per the spec.
       double pixelScale = std::abs(disp->scale);
       if (isOBB) {
@@ -1931,8 +1957,10 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
       }
     } else if (const auto* diffuse =
                    std::get_if<filter_primitive::DiffuseLighting>(&node.primitive)) {
-      const Box2d lightingInputSubregion =
-          node.inputs.empty() ? filterRegionSubregion : resolveInputSubregion(node.inputs[0]);
+      // Bounds for the buffer this pass actually reads: an unpopulated input slot resolves to
+      // the previous primitive's result, so its subregion has to follow that buffer rather than
+      // widening to the whole filter region.
+      const Box2d lightingInputSubregion = resolveInputSubregion(filterInputOrDefault(node, 0));
       const bool nodeLinearRGB =
           node.colorInterpolationFilters.value_or(graph.colorInterpolationFilters) !=
           svg::ColorInterpolationFilters::SRGB;
@@ -1940,8 +1968,10 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
                                        lightingInputSubregion, nodeLinearRGB);
     } else if (const auto* specular =
                    std::get_if<filter_primitive::SpecularLighting>(&node.primitive)) {
-      const Box2d lightingInputSubregion =
-          node.inputs.empty() ? filterRegionSubregion : resolveInputSubregion(node.inputs[0]);
+      // Bounds for the buffer this pass actually reads: an unpopulated input slot resolves to
+      // the previous primitive's result, so its subregion has to follow that buffer rather than
+      // widening to the whole filter region.
+      const Box2d lightingInputSubregion = resolveInputSubregion(filterInputOrDefault(node, 0));
       const bool nodeLinearRGB =
           node.colorInterpolationFilters.value_or(graph.colorInterpolationFilters) !=
           svg::ColorInterpolationFilters::SRGB;
@@ -1977,10 +2007,10 @@ wgpu::Texture GeodeFilterEngine::execute(const svg::components::FilterGraph& gra
                              deviceFromFilter, imagePlacementRegion);
     } else if (std::holds_alternative<filter_primitive::Tile>(node.primitive)) {
       // FE1 §9.20: feTile repeats the INPUT primitive's subregion to fill
-      // feTile's own subregion. Default to the filter region only when there
-      // is no explicit input.
-      const Box2d tileSourceSubregion =
-          node.inputs.empty() ? filterRegionSubregion : resolveInputSubregion(node.inputs[0]);
+      // feTile's own subregion. An unpopulated input slot resolves to the
+      // previous primitive's result, the same buffer the tile is read from, so
+      // the source bounds follow it instead of widening to the filter region.
+      const Box2d tileSourceSubregion = resolveInputSubregion(filterInputOrDefault(node, 0));
       // An empty/inverted input subregion (topLeft > bottomRight, e.g. a flood
       // whose explicit x/y/w/h lies entirely outside the filter region) must
       // produce transparent output. transformBox() normalizes (min/max) the

--- a/donner/svg/renderer/tests/FilterGraphExecutor_tests.cc
+++ b/donner/svg/renderer/tests/FilterGraphExecutor_tests.cc
@@ -841,6 +841,365 @@ TEST(FilterGraphExecutorTest, DropShadowExplicitSourceGraphicMatchesImplicitInpu
 }
 
 // ---------------------------------------------------------------------------
+// Two-input primitive `in2` resolution
+// ---------------------------------------------------------------------------
+
+/// Fills a block of mixed colors and partial alpha, so a two-input primitive that reads the wrong
+/// buffer or skips a color-space conversion shows up rather than cancelling against a flat opaque
+/// square.
+void FillMixedAlphaBlock(tiny_skia::Pixmap& pixmap) {
+  for (int y = 4; y < 12; ++y) {
+    for (int x = 4; x < 12; ++x) {
+      const auto alpha = static_cast<std::uint8_t>(40 + (x * 9 + y * 3) % 216);
+      const auto scale = [&](int value) { return static_cast<std::uint8_t>(value * alpha / 255); };
+      SetPixel(pixmap, x, y, Pixel{scale(200), scale(80), scale(30), alpha});
+    }
+  }
+}
+
+/// Asserts two renders agree byte for byte. Used by the first-primitive cases, where an
+/// unspecified `in2` and an explicit `in2="SourceGraphic"` name the same buffer.
+void ExpectPixmapsEqual(const tiny_skia::Pixmap& lhs, const tiny_skia::Pixmap& rhs) {
+  const auto lhsData = lhs.data();
+  const auto rhsData = rhs.data();
+  ASSERT_EQ(lhsData.size(), rhsData.size());
+  EXPECT_THAT(std::vector<std::uint8_t>(rhsData.begin(), rhsData.end()), ElementsAreArray(lhsData));
+}
+
+/// A 16x16 pixmap holding one opaque white square covering x,y in [2, 10).
+tiny_skia::Pixmap MakeSquarePixmap() {
+  auto maybePixmap = tiny_skia::Pixmap::fromSize(16, 16);
+  EXPECT_TRUE(maybePixmap.has_value());
+  tiny_skia::Pixmap pixmap = std::move(*maybePixmap);
+  FillOpaqueSquare(pixmap, 2, 2, 8);
+  return pixmap;
+}
+
+/// An feOffset that shifts SourceGraphic right by six pixels, so the moved copy overlaps the
+/// original only in x = [8, 10). A second input taken from the preceding result and one taken
+/// from SourceGraphic therefore mask different pixels.
+components::FilterNode MakeMovedSquareNode() {
+  components::FilterNode node;
+  node.inputs.push_back(components::FilterInput{components::FilterStandardInput::SourceGraphic});
+  node.primitive = components::filter_primitive::Offset{.dx = 6.0, .dy = 0.0};
+  return node;
+}
+
+// An unspecified `in2` resolves the same way an unspecified `in` does: to the preceding
+// primitive's result, and to SourceGraphic only when the primitive is first in the filter. The
+// mask here is therefore the moved square, not the unfiltered element the filter started from.
+TEST(FilterGraphExecutorTest, CompositeImplicitIn2UsesPrecedingResult) {
+  tiny_skia::Pixmap pixmap = MakeSquarePixmap();
+
+  components::FilterGraph graph;
+  graph.nodes.push_back(MakeMovedSquareNode());
+
+  components::FilterNode compositeNode;
+  compositeNode.inputs.push_back(
+      components::FilterInput{components::FilterStandardInput::SourceGraphic});
+  // No second input at all, which is how an unspecified `in2` reaches the executor.
+  compositeNode.primitive = components::filter_primitive::Composite{
+      .op = components::filter_primitive::Composite::Operator::In,
+  };
+  graph.nodes.push_back(std::move(compositeNode));
+
+  ApplyFilterGraphToPixmap(pixmap, graph, Transform2d(), std::nullopt);
+
+  // The overlap of the source square with the moved square survives.
+  EXPECT_THAT(GetPixel(pixmap, 9, 4), Rgba(255, 255, 255, 255));
+
+  // The rest of the source square is masked away. Masking against SourceGraphic would have kept
+  // it, because a square is fully inside itself.
+  EXPECT_THAT(GetPixel(pixmap, 3, 4), Rgba(_, _, _, 0));
+
+  // `operator="in"` keeps nothing outside the first input either way.
+  EXPECT_THAT(GetPixel(pixmap, 12, 4), Rgba(_, _, _, 0));
+}
+
+// An explicit `in2` still names its own buffer. Pointing a chained feComposite back at
+// SourceGraphic keeps the whole source square, which is exactly what the implicit case must not
+// do, so the two tests together pin the default rather than a hardcoded choice.
+TEST(FilterGraphExecutorTest, CompositeExplicitIn2NamesItsOwnInput) {
+  tiny_skia::Pixmap pixmap = MakeSquarePixmap();
+
+  components::FilterGraph graph;
+  graph.nodes.push_back(MakeMovedSquareNode());
+
+  components::FilterNode compositeNode;
+  compositeNode.inputs.push_back(
+      components::FilterInput{components::FilterStandardInput::SourceGraphic});
+  compositeNode.inputs.push_back(
+      components::FilterInput{components::FilterStandardInput::SourceGraphic});
+  compositeNode.primitive = components::filter_primitive::Composite{
+      .op = components::filter_primitive::Composite::Operator::In,
+  };
+  graph.nodes.push_back(std::move(compositeNode));
+
+  ApplyFilterGraphToPixmap(pixmap, graph, Transform2d(), std::nullopt);
+
+  EXPECT_THAT(GetPixel(pixmap, 3, 4), Rgba(255, 255, 255, 255));
+  EXPECT_THAT(GetPixel(pixmap, 9, 4), Rgba(255, 255, 255, 255));
+  EXPECT_THAT(GetPixel(pixmap, 12, 4), Rgba(_, _, _, 0));
+}
+
+// On a first primitive there is no preceding result, so an unspecified `in2` and an explicit
+// `in2="SourceGraphic"` name the same buffer and the two renders have to agree byte for byte.
+// This is the pixel-level statement that single-primitive filters are unaffected.
+TEST(FilterGraphExecutorTest, CompositeFirstPrimitiveImplicitIn2MatchesSourceGraphic) {
+  const auto render = [](bool explicitIn2) {
+    auto maybePixmap = tiny_skia::Pixmap::fromSize(16, 16);
+    EXPECT_TRUE(maybePixmap.has_value());
+    tiny_skia::Pixmap pixmap = std::move(*maybePixmap);
+    FillMixedAlphaBlock(pixmap);
+
+    components::FilterGraph graph;
+    components::FilterNode node;
+    node.inputs.push_back(components::FilterInput{components::FilterStandardInput::SourceGraphic});
+    if (explicitIn2) {
+      node.inputs.push_back(
+          components::FilterInput{components::FilterStandardInput::SourceGraphic});
+    }
+    // Arithmetic mixes both inputs channel by channel, so a wrong second buffer cannot hide
+    // behind a Porter-Duff operator that happens to ignore it.
+    node.primitive = components::filter_primitive::Composite{
+        .op = components::filter_primitive::Composite::Operator::Arithmetic,
+        .k1 = 0.5,
+        .k2 = 0.25,
+        .k3 = 0.25,
+        .k4 = 0.0,
+    };
+    graph.nodes.push_back(std::move(node));
+
+    ApplyFilterGraphToPixmap(pixmap, graph, Transform2d(), std::nullopt);
+    return pixmap;
+  };
+
+  const tiny_skia::Pixmap implicitIn2 = render(false);
+  const tiny_skia::Pixmap explicitIn2 = render(true);
+  ExpectPixmapsEqual(implicitIn2, explicitIn2);
+
+  // The composite produced something, so the comparison is not two blank pixmaps agreeing.
+  EXPECT_THAT(GetPixel(implicitIn2, 8, 8), Rgba(_, _, _, Gt(0)));
+}
+
+// feBlend's `in2` is the backdrop, and it defaults the same way: the preceding flood, not the
+// white source graphic.
+TEST(FilterGraphExecutorTest, BlendImplicitIn2UsesPrecedingResult) {
+  auto maybePixmap = tiny_skia::Pixmap::fromSize(16, 16);
+  ASSERT_TRUE(maybePixmap.has_value());
+  tiny_skia::Pixmap pixmap = std::move(*maybePixmap);
+  FillOpaqueSquare(pixmap, 0, 0, 16);
+
+  components::FilterGraph graph;
+  // sRGB keeps `multiply` a plain per-channel product of the authored values.
+  graph.colorInterpolationFilters = ColorInterpolationFilters::SRGB;
+
+  components::FilterNode floodNode;
+  floodNode.inputs.push_back(components::FilterInput{});
+  floodNode.primitive = components::filter_primitive::Flood{
+      .floodColor = css::Color(css::RGBA(128, 128, 128, 255)),
+      .floodOpacity = 1.0,
+  };
+  graph.nodes.push_back(std::move(floodNode));
+
+  components::FilterNode blendNode;
+  blendNode.inputs.push_back(
+      components::FilterInput{components::FilterStandardInput::SourceGraphic});
+  // No second input at all, which is how an unspecified `in2` reaches the executor.
+  blendNode.primitive = components::filter_primitive::Blend{
+      .mode = components::filter_primitive::Blend::Mode::Multiply,
+  };
+  graph.nodes.push_back(std::move(blendNode));
+
+  ApplyFilterGraphToPixmap(pixmap, graph, Transform2d(), std::nullopt);
+
+  // White multiplied by the 50% gray flood. Blending against SourceGraphic would have multiplied
+  // white by white and left the pixmap at 255.
+  EXPECT_THAT(GetPixel(pixmap, 8, 8),
+              Rgba(ChannelNear(128, 2), ChannelNear(128, 2), ChannelNear(128, 2), 255));
+}
+
+// The explicit counterpart: naming SourceGraphic as the backdrop multiplies white by white and
+// leaves the pixmap untouched, so the default above is a default and not a rewrite.
+TEST(FilterGraphExecutorTest, BlendExplicitIn2NamesItsOwnInput) {
+  auto maybePixmap = tiny_skia::Pixmap::fromSize(16, 16);
+  ASSERT_TRUE(maybePixmap.has_value());
+  tiny_skia::Pixmap pixmap = std::move(*maybePixmap);
+  FillOpaqueSquare(pixmap, 0, 0, 16);
+
+  components::FilterGraph graph;
+  graph.colorInterpolationFilters = ColorInterpolationFilters::SRGB;
+
+  components::FilterNode floodNode;
+  floodNode.inputs.push_back(components::FilterInput{});
+  floodNode.primitive = components::filter_primitive::Flood{
+      .floodColor = css::Color(css::RGBA(128, 128, 128, 255)),
+      .floodOpacity = 1.0,
+  };
+  graph.nodes.push_back(std::move(floodNode));
+
+  components::FilterNode blendNode;
+  blendNode.inputs.push_back(
+      components::FilterInput{components::FilterStandardInput::SourceGraphic});
+  blendNode.inputs.push_back(
+      components::FilterInput{components::FilterStandardInput::SourceGraphic});
+  blendNode.primitive = components::filter_primitive::Blend{
+      .mode = components::filter_primitive::Blend::Mode::Multiply,
+  };
+  graph.nodes.push_back(std::move(blendNode));
+
+  ApplyFilterGraphToPixmap(pixmap, graph, Transform2d(), std::nullopt);
+
+  EXPECT_THAT(GetPixel(pixmap, 8, 8), Rgba(255, 255, 255, 255));
+}
+
+// The first-primitive identity for feBlend: with nothing before it, the implicit backdrop is
+// SourceGraphic, so naming it explicitly has to render the same bytes.
+TEST(FilterGraphExecutorTest, BlendFirstPrimitiveImplicitIn2MatchesSourceGraphic) {
+  const auto render = [](bool explicitIn2) {
+    auto maybePixmap = tiny_skia::Pixmap::fromSize(16, 16);
+    EXPECT_TRUE(maybePixmap.has_value());
+    tiny_skia::Pixmap pixmap = std::move(*maybePixmap);
+    FillMixedAlphaBlock(pixmap);
+
+    components::FilterGraph graph;
+    components::FilterNode node;
+    node.inputs.push_back(components::FilterInput{components::FilterStandardInput::SourceGraphic});
+    if (explicitIn2) {
+      node.inputs.push_back(
+          components::FilterInput{components::FilterStandardInput::SourceGraphic});
+    }
+    node.primitive = components::filter_primitive::Blend{
+        .mode = components::filter_primitive::Blend::Mode::Multiply,
+    };
+    graph.nodes.push_back(std::move(node));
+
+    ApplyFilterGraphToPixmap(pixmap, graph, Transform2d(), std::nullopt);
+    return pixmap;
+  };
+
+  const tiny_skia::Pixmap implicitIn2 = render(false);
+  const tiny_skia::Pixmap explicitIn2 = render(true);
+  ExpectPixmapsEqual(implicitIn2, explicitIn2);
+
+  EXPECT_THAT(GetPixel(implicitIn2, 8, 8), Rgba(_, _, _, Gt(0)));
+}
+
+// feDisplacementMap's `in2` is the displacement map itself, so the default decides where every
+// output pixel is sampled from. An opaque flood displaces the whole image by a constant; the
+// source graphic's own alpha would displace the square and its surroundings in opposite
+// directions.
+TEST(FilterGraphExecutorTest, DisplacementMapImplicitIn2UsesPrecedingResult) {
+  auto maybePixmap = tiny_skia::Pixmap::fromSize(16, 16);
+  ASSERT_TRUE(maybePixmap.has_value());
+  tiny_skia::Pixmap pixmap = std::move(*maybePixmap);
+  FillOpaqueSquare(pixmap, 4, 4, 4);
+
+  components::FilterGraph graph;
+
+  components::FilterNode floodNode;
+  floodNode.inputs.push_back(components::FilterInput{});
+  floodNode.primitive = components::filter_primitive::Flood{
+      .floodColor = css::Color(css::RGBA(255, 255, 255, 255)),
+      .floodOpacity = 1.0,
+  };
+  graph.nodes.push_back(std::move(floodNode));
+
+  components::FilterNode displaceNode;
+  displaceNode.inputs.push_back(
+      components::FilterInput{components::FilterStandardInput::SourceGraphic});
+  // No second input at all, which is how an unspecified `in2` reaches the executor.
+  displaceNode.primitive = components::filter_primitive::DisplacementMap{
+      .scale = 8.0,
+      .xChannelSelector = components::filter_primitive::DisplacementMap::Channel::A,
+      .yChannelSelector = components::filter_primitive::DisplacementMap::Channel::A,
+  };
+  graph.nodes.push_back(std::move(displaceNode));
+
+  ApplyFilterGraphToPixmap(pixmap, graph, Transform2d(), std::nullopt);
+
+  // Alpha is 1 everywhere in the flood, so every pixel samples 8 * (1 - 0.5) = 4 pixels down and
+  // to the right: the square moves from [4, 8) to [0, 4).
+  EXPECT_THAT(GetPixel(pixmap, 2, 2), Rgba(255, 255, 255, 255));
+
+  // Displacing by SourceGraphic's own alpha instead would have sent the pixels outside the
+  // square the other way and landed a copy of the square at [8, 12).
+  EXPECT_THAT(GetPixel(pixmap, 10, 10), Rgba(_, _, _, 0));
+}
+
+// The explicit counterpart, which is also the pre-default behavior: naming SourceGraphic as the
+// displacement map splits the image, because its alpha is 1 inside the square and 0 outside.
+TEST(FilterGraphExecutorTest, DisplacementMapExplicitIn2NamesItsOwnInput) {
+  auto maybePixmap = tiny_skia::Pixmap::fromSize(16, 16);
+  ASSERT_TRUE(maybePixmap.has_value());
+  tiny_skia::Pixmap pixmap = std::move(*maybePixmap);
+  FillOpaqueSquare(pixmap, 4, 4, 4);
+
+  components::FilterGraph graph;
+
+  components::FilterNode floodNode;
+  floodNode.inputs.push_back(components::FilterInput{});
+  floodNode.primitive = components::filter_primitive::Flood{
+      .floodColor = css::Color(css::RGBA(255, 255, 255, 255)),
+      .floodOpacity = 1.0,
+  };
+  graph.nodes.push_back(std::move(floodNode));
+
+  components::FilterNode displaceNode;
+  displaceNode.inputs.push_back(
+      components::FilterInput{components::FilterStandardInput::SourceGraphic});
+  displaceNode.inputs.push_back(
+      components::FilterInput{components::FilterStandardInput::SourceGraphic});
+  displaceNode.primitive = components::filter_primitive::DisplacementMap{
+      .scale = 8.0,
+      .xChannelSelector = components::filter_primitive::DisplacementMap::Channel::A,
+      .yChannelSelector = components::filter_primitive::DisplacementMap::Channel::A,
+  };
+  graph.nodes.push_back(std::move(displaceNode));
+
+  ApplyFilterGraphToPixmap(pixmap, graph, Transform2d(), std::nullopt);
+
+  // Alpha 0 outside the square sends those pixels 4 up and to the left, so [8, 12) samples the
+  // square at [4, 8).
+  EXPECT_THAT(GetPixel(pixmap, 10, 10), Rgba(255, 255, 255, 255));
+  EXPECT_THAT(GetPixel(pixmap, 2, 2), Rgba(_, _, _, 0));
+}
+
+// The first-primitive identity for feDisplacementMap: the implicit map is SourceGraphic when
+// nothing precedes the primitive, so both spellings render the same bytes.
+TEST(FilterGraphExecutorTest, DisplacementMapFirstPrimitiveImplicitIn2MatchesSourceGraphic) {
+  const auto render = [](bool explicitIn2) {
+    auto maybePixmap = tiny_skia::Pixmap::fromSize(16, 16);
+    EXPECT_TRUE(maybePixmap.has_value());
+    tiny_skia::Pixmap pixmap = std::move(*maybePixmap);
+    FillMixedAlphaBlock(pixmap);
+
+    components::FilterGraph graph;
+    components::FilterNode node;
+    node.inputs.push_back(components::FilterInput{components::FilterStandardInput::SourceGraphic});
+    if (explicitIn2) {
+      node.inputs.push_back(
+          components::FilterInput{components::FilterStandardInput::SourceGraphic});
+    }
+    node.primitive = components::filter_primitive::DisplacementMap{
+        .scale = 6.0,
+        .xChannelSelector = components::filter_primitive::DisplacementMap::Channel::R,
+        .yChannelSelector = components::filter_primitive::DisplacementMap::Channel::A,
+    };
+    graph.nodes.push_back(std::move(node));
+
+    ApplyFilterGraphToPixmap(pixmap, graph, Transform2d(), std::nullopt);
+    return pixmap;
+  };
+
+  const tiny_skia::Pixmap implicitIn2 = render(false);
+  const tiny_skia::Pixmap explicitIn2 = render(true);
+  ExpectPixmapsEqual(implicitIn2, explicitIn2);
+
+  EXPECT_THAT(GetPixel(implicitIn2, 6, 6), Rgba(_, _, _, Gt(0)));
+}
+
+// ---------------------------------------------------------------------------
 // Error / edge cases
 // ---------------------------------------------------------------------------
 

--- a/donner/svg/renderer/tests/RendererGeode_tests.cc
+++ b/donner/svg/renderer/tests/RendererGeode_tests.cc
@@ -2411,6 +2411,65 @@ TEST_F(RendererGeodeTest, FilterCompositeInOperator) {
       << "feComposite operator=in should mask red by green alpha";
 }
 
+/// feComposite with no `in2`: an unspecified `in2` resolves the same way an unspecified `in`
+/// does, to the preceding primitive's result. Falling back to the node's own first input would
+/// mask red by its own opaque alpha and leave the result fully opaque instead.
+TEST_F(RendererGeodeTest, FilterCompositeImplicitIn2UsesPrecedingResult) {
+  RendererGeode renderer = createRenderer();
+  beginFrame(renderer);
+
+  components::FilterGraph graph;
+
+  // Node 0: opaque red flood -> result="red".
+  {
+    components::FilterNode node;
+    components::filter_primitive::Flood f;
+    f.floodColor = css::Color(css::RGBA(255, 0, 0, 255));
+    f.floodOpacity = 1.0;
+    node.primitive = f;
+    node.result = RcString("red");
+    graph.nodes.push_back(node);
+  }
+
+  // Node 1: 50% alpha green flood, deliberately unnamed so it is reachable only as the previous
+  // result.
+  {
+    components::FilterNode node;
+    components::filter_primitive::Flood f;
+    f.floodColor = css::Color(css::RGBA(0, 255, 0, 255));
+    f.floodOpacity = 0.5;
+    node.primitive = f;
+    graph.nodes.push_back(node);
+  }
+
+  // Node 2: feComposite in="red" operator=in, with no in2 at all.
+  {
+    components::FilterNode node;
+    components::filter_primitive::Composite comp;
+    comp.op = components::filter_primitive::Composite::Operator::In;
+    node.primitive = comp;
+    node.inputs.push_back(components::FilterInput::Named{RcString("red")});
+    graph.nodes.push_back(node);
+  }
+
+  renderer.pushFilterLayer(graph, Box2d({0, 0}, {kViewportSize, kViewportSize}));
+  renderer.setPaint(solidFill(css::RGBA(0, 0, 255, 255)));
+  renderer.setTransform(Transform2d());
+  renderer.drawRect(Box2d({0, 0}, {kViewportSize, kViewportSize}), StrokeParams{});
+  renderer.popFilterLayer();
+  renderer.endFrame();
+
+  RendererBitmap snap = renderer.takeSnapshot();
+  ASSERT_FALSE(snap.empty());
+
+  // in1 premul = (255,0,0,255); the defaulted in2 is the green flood, premul alpha 128.
+  // operator=in: result = in1 * in2.a ~= (128,0,0,128), which takeSnapshot unpremultiplies to
+  // (255,0,0,128). Reading the first input as in2 would have left alpha at 255.
+  auto center = pixelAt(snap, 32, 32);
+  EXPECT_THAT(center, Rgba(Near(255, 3), testing::Eq(0), testing::Eq(0), Near(128, 3)))
+      << "an unspecified in2 should mask red by the preceding flood's alpha";
+}
+
 /// feComposite defaults to operator=over.
 TEST_F(RendererGeodeTest, FilterCompositeOverDefault) {
   RendererGeode renderer = createRenderer();

--- a/third_party/tiny-skia-cpp/README.md
+++ b/third_party/tiny-skia-cpp/README.md
@@ -202,6 +202,11 @@ auto pixmap = Pixmap::fromSize(256, 256).value();
 executeFilterGraph(pixmap, graph);  // Result written back to pixmap.
 ```
 
+Inputs default the way the SVG attributes do: a slot a node leaves unpopulated resolves to the
+previous primitive's result, and to `SourceGraphic` only for the first node. A `Composite`,
+`Blend`, or `DisplacementMap` node built with one input therefore reads the previous result as its
+second input.
+
 ### Supported primitives
 
 | Primitive | SVG element | Description |

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/FilterGraph.cpp
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/FilterGraph.cpp
@@ -304,6 +304,29 @@ class SpacedPixmap {
   std::optional<FloatPixmap> converted_;
 };
 
+/// The number of inputs a primitive reads through the filter attribute surface. feComposite,
+/// feBlend and feDisplacementMap each take a second input (`in2`); feMerge is variadic and reads
+/// exactly the list it was built with, and every other primitive reads at most one input. The cap
+/// of two is deliberate rather than a lower bound: those primitives never sample a third input, so
+/// an extra entry a caller appends must not widen the node's subregion either.
+std::size_t inputSlotCount(const GraphNode& node) {
+  if (std::holds_alternative<graph_primitive::Composite>(node.primitive) ||
+      std::holds_alternative<graph_primitive::Blend>(node.primitive) ||
+      std::holds_alternative<graph_primitive::DisplacementMap>(node.primitive)) {
+    return 2;
+  }
+  return node.inputs.size();
+}
+
+/// The input in slot @p index, or the default for a slot the graph left empty. A slot the caller
+/// never populated is an unspecified `in`/`in2` attribute, and both resolve the same way: to the
+/// preceding primitive's result, which is SourceGraphic only when this node is the first
+/// primitive in the filter. Substituting SourceGraphic directly would reach past the chain to the
+/// unfiltered element every time a two-input primitive omitted `in2`.
+NodeInput inputOrDefault(const GraphNode& node, std::size_t index) {
+  return index < node.inputs.size() ? node.inputs[index] : NodeInput();
+}
+
 }  // namespace
 
 bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
@@ -463,13 +486,18 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
       return Box::fromPixelRect(*node.subregion).intersect(filterRegionBox);
     }
 
-    if (node.inputs.empty() || isSourceGenerator) {
+    // Walk every slot the primitive reads, so a defaulted `in2` contributes its subregion the
+    // same way an explicit one would. The test is the slot count and not the populated list: a
+    // two-input primitive with nothing filled in still reads two defaulted inputs, so its bounds
+    // come from those defaults rather than from the whole filter region.
+    const std::size_t slots = inputSlotCount(node);
+    if (slots == 0 || isSourceGenerator) {
       return filterRegionBox;
     }
 
-    Box inputBounds = resolveInputSubregion(node.inputs[0]);
-    for (std::size_t i = 1; i < node.inputs.size(); ++i) {
-      inputBounds = inputBounds.unite(resolveInputSubregion(node.inputs[i]));
+    Box inputBounds = resolveInputSubregion(inputOrDefault(node, 0));
+    for (std::size_t i = 1; i < slots; ++i) {
+      inputBounds = inputBounds.unite(resolveInputSubregion(inputOrDefault(node, i)));
     }
 
     return std::visit(
@@ -509,7 +537,7 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
     // Each buffer knows its own color space, so a node asks its inputs for the space it works in
     // and tags its result with that same space. `in()` is a no-op whenever the producer already
     // agreed with this node, which is the common case.
-    SpacedPixmap* input = node.inputs.empty() ? source : resolveInput(node.inputs[0]);
+    SpacedPixmap* input = resolveInput(inputOrDefault(node, 0));
 
     std::optional<NodeOutput> output;
 
@@ -536,7 +564,7 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
             output = input->describe(std::move(fpOut));
 
           } else if constexpr (std::is_same_v<T, graph_primitive::Composite>) {
-            SpacedPixmap* input2 = node.inputs.size() > 1 ? resolveInput(node.inputs[1]) : source;
+            SpacedPixmap* input2 = resolveInput(inputOrDefault(node, 1));
             const FloatPixmap& in1 = input->in(nodeLinearRGB);
             const FloatPixmap& in2 = input2->in(nodeLinearRGB);
             auto fpOut = createTransparentFloat(w, h);
@@ -545,7 +573,7 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
             output = NodeOutput{std::move(fpOut), nodeLinearRGB};
 
           } else if constexpr (std::is_same_v<T, graph_primitive::Blend>) {
-            SpacedPixmap* input2 = node.inputs.size() > 1 ? resolveInput(node.inputs[1]) : source;
+            SpacedPixmap* input2 = resolveInput(inputOrDefault(node, 1));
             const FloatPixmap& in1 = input->in(nodeLinearRGB);
             const FloatPixmap& in2 = input2->in(nodeLinearRGB);
             auto fpOut = createTransparentFloat(w, h);
@@ -635,8 +663,7 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
           } else if constexpr (std::is_same_v<T, graph_primitive::Tile>) {
             // Pure pixel mover, so the result stays in the input's space with no conversion.
             auto fpOut = createTransparentFloat(w, h);
-            const Box inputSubregion = node.inputs.empty() ? previousOutputSubregion
-                                                           : resolveInputSubregion(node.inputs[0]);
+            const Box inputSubregion = resolveInputSubregion(inputOrDefault(node, 0));
             const int tileX = std::max(0, static_cast<int>(std::floor(inputSubregion.x0)));
             const int tileY = std::max(0, static_cast<int>(std::floor(inputSubregion.y0)));
             const int tileR = std::min(w, static_cast<int>(std::ceil(inputSubregion.x1)));
@@ -655,7 +682,7 @@ bool executeFilterGraph(Pixmap& sourceGraphic, const FilterGraph& graph) {
             output = NodeOutput{std::move(fp), nodeLinearRGB};
 
           } else if constexpr (std::is_same_v<T, graph_primitive::DisplacementMap>) {
-            SpacedPixmap* input2 = node.inputs.size() > 1 ? resolveInput(node.inputs[1]) : source;
+            SpacedPixmap* input2 = resolveInput(inputOrDefault(node, 1));
             const FloatPixmap& in1 = input->in(nodeLinearRGB);
             const FloatPixmap& in2 = input2->in(nodeLinearRGB);
             auto fpOut = createTransparentFloat(w, h);

--- a/third_party/tiny-skia-cpp/src/tiny_skia/filter/FilterGraph.h
+++ b/third_party/tiny-skia-cpp/src/tiny_skia/filter/FilterGraph.h
@@ -231,8 +231,15 @@ struct AffineTransform {
 
 /// A single node in the filter graph.
 struct GraphNode {
-  GraphPrimitive primitive;            ///< The filter operation.
-  std::vector<NodeInput> inputs;       ///< Input reference(s).
+  GraphPrimitive primitive;  ///< The filter operation.
+
+  /// Input reference(s). A slot this list leaves unpopulated resolves exactly like an unspecified
+  /// `in`/`in2` attribute: to the previous primitive's result, and to SourceGraphic only when the
+  /// node is the first primitive in the graph. A Composite, Blend, or DisplacementMap node built
+  /// with a single input therefore reads the previous result as its second input, never the
+  /// source graphic.
+  std::vector<NodeInput> inputs;
+
   std::optional<std::string> result;   ///< Named output (for `result` attribute).
   std::optional<PixelRect> subregion;  ///< Pixel-space primitive subregion (AABB, for clipping).
 


### PR DESCRIPTION
The two-input filter primitives (feComposite, feBlend, feDisplacementMap) resolved a missing `in2` incorrectly in both graph executors, and the executors also disagreed with each other: the CPU executor fell back to SourceGraphic, and the GPU executor fell back to the node's own first input, compositing a buffer against itself. Per SVG 1.1 section 15 and Filter Effects 1, `in2` takes the same values and the same defaulting rule as `in`: an unspecified input references the previous primitive's result, and SourceGraphic only for the first primitive. The SVG attribute layer was already spec-correct; this fixes the executors underneath it and locks the attribute-layer default with a test.

Scope of the change:

- Both executors resolve an unpopulated `in2` slot (and the CPU executor's unpopulated primary input, previously a divergence from the GPU executor) to the previous primitive's result, which resolves to SourceGraphic on a first primitive by construction.
- Subregion computation now follows the buffers the primitive actually reads: every read slot participates in the union (previously only populated slots did, so a defaulted input's bounds were omitted), the three GPU lighting/tile sites that claimed the full filter region while reading the previous result now derive bounds from that resolved input, and a zero-input two-input primitive takes the union of its defaulted slots instead of short-circuiting to the full region. The slot-count cap of two is deliberate and documented: extra entries a caller appends are never sampled and no longer widen the subregion.
- The defaulting contract is documented where direct graph builders read it (`GraphNode::inputs`, `FilterNode::inputs`, and the vendored library's README beside its construction example), and the release notes carry the embedder-facing behavior change.

Tests: eleven red-then-green cases. Three implicit-`in2` executor cases (each observed failing before the fix, e.g. a composite mask keeping full alpha instead of masking to the preceding result), three explicit-`in2` guards proving the default is a default rather than a rewrite, three first-primitive identity cases, one GPU case (alpha 255 instead of 128 with the fix reverted, on the real adapter), and one attribute-layer lock-in.

Rendered documents are unaffected, and provably rather than luckily: the attribute layer unconditionally populates both slots for all three primitives, so no parsed SVG reaches the changed defaults. The full corpus (1679 suite files plus six auxiliary SVGs, 1685 renders per side) is sha256-identical against main. The behavior change is real only for embedders that build a filter graph directly, which the vendored library's documentation teaches; that is exactly the audience the new documentation addresses.
