### PR TITLE
feat: Make GPU wait timeouts and device loss self-identifying in worker diagnostics

### DIFF
--- a/donner/editor/AsyncRenderer.cc
+++ b/donner/editor/AsyncRenderer.cc
@@ -334,7 +334,6 @@ void AsyncRenderer::shutdown() {
   }
 }
 
-
 void AsyncRenderer::noteGpuWaitOutcome(const svg::RendererReadbackStats& readbackStats) {
   if (!readbackStats.deviceLost) {
     return;

--- a/donner/editor/AsyncRenderer.cc
+++ b/donner/editor/AsyncRenderer.cc
@@ -335,6 +335,26 @@ void AsyncRenderer::shutdown() {
 }
 
 
+void AsyncRenderer::noteGpuWaitOutcome(const svg::RendererReadbackStats& readbackStats) {
+  if (!readbackStats.deviceLost) {
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (gpuWaitFailure_.deviceLost &&
+      gpuWaitFailure_.timedOutWaitSite == readbackStats.timedOutWaitSite &&
+      gpuWaitFailure_.timedOutWaitMs == readbackStats.timedOutWaitMs) {
+    // Device loss is sticky, so every later frame re-reports it. Leave the
+    // generation alone for a repeat so a reader publishes each distinct
+    // failure once instead of on every poll.
+    return;
+  }
+  gpuWaitFailure_.deviceLost = true;
+  gpuWaitFailure_.timedOutWaitSite = readbackStats.timedOutWaitSite;
+  gpuWaitFailure_.timedOutWaitMs = readbackStats.timedOutWaitMs;
+  ++gpuWaitFailure_.generation;
+}
+
 void AsyncRenderer::notePublishedCompositedPreview(
     const std::optional<RenderResult::CompositedPreview>& compositedPreview) {
   if (!compositedPreview.has_value() || !compositedPreview->valid()) {
@@ -1296,6 +1316,12 @@ void AsyncRenderer::workerLoop() {
     if (!renderCompleted) {
       // Release document access before taking `mutex_` to avoid a lock-order inversion.
       releaseDocumentAccess();
+      // An abandoned iteration still observed whatever the backend device did.
+      // A bounded GPU wait that burns its deadline declares the device lost
+      // and then ends the frame with nothing to present, so this is the only
+      // place that failure can be recorded: the completed-frame stats below
+      // are never reached.
+      noteGpuWaitOutcome(requestRenderer.consumeReadbackStats());
       cancelledRenderCount_.fetch_add(1, std::memory_order_release);
       std::function<void()> wake;
       bool notifyStateChange = false;
@@ -1363,6 +1389,10 @@ void AsyncRenderer::workerLoop() {
     workerTiming.readbackCount = readbackStats.count;
     workerTiming.readbackPollIterations = readbackStats.pollIterations;
     workerTiming.usedTimedWaitAny = readbackStats.usedTimedWaitAny;
+    workerTiming.deviceLost = readbackStats.deviceLost;
+    workerTiming.timedOutWaitSite = readbackStats.timedOutWaitSite;
+    workerTiming.timedOutWaitMs = readbackStats.timedOutWaitMs;
+    noteGpuWaitOutcome(readbackStats);
     if (!compositedPreview.has_value() && (!bitmap.empty() || fullCanvasTexture != nullptr)) {
       const Entity previewEntity =
           request.dragPreview.has_value() ? request.dragPreview->entity : request.selectedEntity;

--- a/donner/editor/AsyncRenderer.h
+++ b/donner/editor/AsyncRenderer.h
@@ -711,6 +711,13 @@ public:
     return gpuWaitFailure_;
   }
 
+  /// Fold one render attempt's device-health stats into the failure record, as
+  /// the worker does at the end of every iteration. Tests use this to pin the
+  /// record's deduplication without hanging a real GPU.
+  void noteGpuWaitOutcomeForTesting(const svg::RendererReadbackStats& readbackStats) {
+    noteGpuWaitOutcome(readbackStats);
+  }
+
   /// Snapshot of the compositor's per-layer diagnostic rows. Captured under
   /// the worker mutex at every Done transition;
   /// the UI thread copies the cached vector out under the lock. Empty

--- a/donner/editor/AsyncRenderer.h
+++ b/donner/editor/AsyncRenderer.h
@@ -272,6 +272,13 @@ struct RenderResult {
     int readbackPollIterations = 0;
     /// True when browser readbacks used the event-driven timed WaitAny path.
     bool usedTimedWaitAny = false;
+    /// True when the worker's backend device has been declared lost, either by
+    /// the driver or by a bounded GPU wait exceeding its deadline.
+    bool deviceLost = false;
+    /// Which bounded GPU wait declared that loss, when a deadline did.
+    svg::GpuWaitTimeoutSite timedOutWaitSite = svg::GpuWaitTimeoutSite::None;
+    /// Wall time that wait spent before giving up, in milliseconds.
+    int timedOutWaitMs = 0;
   };
 
   /// One composite tile from the worker's `CompositorController::
@@ -676,6 +683,34 @@ public:
     return lastCompositorRenderFrameStats_;
   }
 
+  /// Device-health outcome the render worker observed, independent of any
+  /// frame it produced.
+  ///
+  /// A bounded GPU wait that burns its deadline declares the device lost and
+  /// ends the worker iteration with nothing to hand over, so the per-frame
+  /// diagnostics a result carries are never published. That makes the most
+  /// severe renderer failure the only one that leaves no trace in the frame
+  /// stats. The worker records the outcome here instead, so a poller can
+  /// report it without a frame ever landing.
+  struct GpuWaitFailure {
+    /// True once the worker's backend device has been declared lost. Sticky.
+    bool deviceLost = false;
+    /// Which bounded GPU wait declared that loss, when a deadline did.
+    svg::GpuWaitTimeoutSite timedOutWaitSite = svg::GpuWaitTimeoutSite::None;
+    /// Wall time that wait spent before giving up, in milliseconds.
+    int timedOutWaitMs = 0;
+    /// Bumped whenever the record above changes. A poller compares it against
+    /// what it last reported so a sticky loss is reported once rather than on
+    /// every frame.
+    std::uint64_t generation = 0;
+  };
+
+  /// Snapshot of the worker's GPU-wait failure record. UI-thread safe.
+  [[nodiscard]] GpuWaitFailure gpuWaitFailure() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return gpuWaitFailure_;
+  }
+
   /// Snapshot of the compositor's per-layer diagnostic rows. Captured under
   /// the worker mutex at every Done transition;
   /// the UI thread copies the cached vector out under the lock. Empty
@@ -856,6 +891,12 @@ private:
   void notePublishedCompositedPreview(
       const std::optional<RenderResult::CompositedPreview>& compositedPreview);
 
+  /// Fold one render attempt's backend device-health stats into
+  /// `gpuWaitFailure_`, bumping its generation only when the outcome changes.
+  /// Called from the worker thread; takes `mutex_`, so the caller must have
+  /// released document access first.
+  void noteGpuWaitOutcome(const svg::RendererReadbackStats& readbackStats);
+
   /// Counter of worker-side `resetAllLayers()` invocations. Document-generation
   /// changes and supported geometry-overlay state transitions increment it;
   /// ordinary frame-version changes do not.
@@ -888,6 +929,10 @@ private:
 
   /// Most recent compositor render-cost split captured at the Done transition.
   svg::compositor::CompositorController::RenderFrameStats lastCompositorRenderFrameStats_;
+
+  /// Worker device-health record; see `GpuWaitFailure`. Written by the worker
+  /// and read by the UI thread, both under `mutex_`.
+  GpuWaitFailure gpuWaitFailure_;
 
   /// Most recent per-layer diagnostic snapshot, captured under `mutex_`
   /// at every Done transition. UI-thread reads this via

--- a/donner/editor/RenderCoordinator.cc
+++ b/donner/editor/RenderCoordinator.cc
@@ -34,6 +34,7 @@ const char* GpuWaitTimeoutSiteName(svg::GpuWaitTimeoutSite site) {
     case svg::GpuWaitTimeoutSite::None: return "none";
     case svg::GpuWaitTimeoutSite::ReadbackMap: return "readback-map";
     case svg::GpuWaitTimeoutSite::QueueIdle: return "queue-idle";
+    case svg::GpuWaitTimeoutSite::Unknown: return "unknown";
   }
   return "unknown";
 }
@@ -120,6 +121,13 @@ void PublishWorkerGpuWaitFailure(bool deviceLost, const char* timedOutWaitSiteNa
       {
         const previous = window['__donnerWorkerStats'];
         const stats = previous ? Object.assign({}, previous) : ({'completedResults' : 0});
+        // Every published stats object starts without 'presentedAtMs'; the
+        // frame that consumes a result stamps it exactly once, and probes pair
+        // the two timestamps to measure the handoff. Carrying the previous
+        // object's stamp forward would date this publish to a frame that
+        // presented something else. Absent is also the more useful answer
+        // here: this publish is the one that never presented.
+        delete stats['presentedAtMs'];
         stats['deviceLost'] = $0 > 0;
         stats['gpuWaitTimeoutSite'] = UTF8ToString($1);
         stats['gpuWaitTimeoutMs'] = $2;

--- a/donner/editor/RenderCoordinator.cc
+++ b/donner/editor/RenderCoordinator.cc
@@ -26,45 +26,55 @@ namespace donner::editor {
 namespace {
 
 #ifdef __EMSCRIPTEN__
+/// Stable wire name for a published GPU wait site. These strings are what the
+/// browser test harness prints, so a failing run names the wait that hung
+/// instead of an opaque number.
+const char* GpuWaitTimeoutSiteName(svg::GpuWaitTimeoutSite site) {
+  switch (site) {
+    case svg::GpuWaitTimeoutSite::None: return "none";
+    case svg::GpuWaitTimeoutSite::ReadbackMap: return "readback-map";
+    case svg::GpuWaitTimeoutSite::QueueIdle: return "queue-idle";
+  }
+  return "unknown";
+}
+
 // Proxied to the browser main thread: the render pthread has no `window`.
-// The 24 values ride one heap buffer because EM_ASM argument substitution
-// stops at $15; the buffer is static because the async proxy reads it after
-// this function returns, and the publisher is single-threaded per process.
-void PublishWorkerTimingStats(double workerMs, double queueWaitMs, double dequeueToStartMs,
-                              double setupMs, double renderFrameMs, double buildPreviewMs,
-                              double finalSnapshotMs, double diagnosticsMs, double pollDelayMs,
-                              double wakeToPollMs, double firstFrameDrawMs,
-                              double firstFramePlanningMs, double firstFrameWarmupMs,
-                              double immediateRasterizeMs, double cachedRasterizeMs,
-                              int immediateTileCount, int cachedTileCount,
-                              int offscreenCreateCount, int offscreenRecycleCount,
-                              int offscreenCreateTotal, int offscreenRecycleTotal,
-                              int readbackCount, int readbackPollIterations, int usedTimedWaitAny) {
-  static double buffer[24];
-  const double values[24] = {workerMs,
-                             queueWaitMs,
-                             dequeueToStartMs,
-                             setupMs,
-                             renderFrameMs,
-                             buildPreviewMs,
-                             finalSnapshotMs,
-                             diagnosticsMs,
-                             pollDelayMs,
-                             wakeToPollMs,
-                             firstFrameDrawMs,
-                             firstFramePlanningMs,
-                             firstFrameWarmupMs,
-                             immediateRasterizeMs,
-                             cachedRasterizeMs,
-                             static_cast<double>(immediateTileCount),
-                             static_cast<double>(cachedTileCount),
-                             static_cast<double>(offscreenCreateCount),
-                             static_cast<double>(offscreenRecycleCount),
-                             static_cast<double>(offscreenCreateTotal),
-                             static_cast<double>(offscreenRecycleTotal),
-                             static_cast<double>(readbackCount),
-                             static_cast<double>(readbackPollIterations),
-                             usedTimedWaitAny ? 1.0 : 0.0};
+// The numeric values ride one heap buffer because EM_ASM argument
+// substitution stops at $15; the buffer is static because the async proxy
+// reads it after this function returns, and the publisher is single-threaded
+// per process. The wait-site name rides a separate argument as a pointer to a
+// string literal, which has static storage and so outlives the proxy hop too.
+void PublishWorkerTimingStats(
+    double workerMs, const RenderResult::WorkerTimingBreakdown& timing,
+    const svg::compositor::CompositorController::RenderFrameStats& compositorStats) {
+  constexpr std::size_t kValueCount = 26;
+  static double buffer[kValueCount];
+  const double values[kValueCount] = {workerMs,
+                                      timing.queueWaitMs,
+                                      timing.dequeueToStartMs,
+                                      timing.setupMs,
+                                      timing.renderFrameMs,
+                                      timing.buildPreviewMs,
+                                      timing.finalSnapshotMs,
+                                      timing.diagnosticsMs,
+                                      timing.pollDelayMs,
+                                      timing.wakeToPollMs,
+                                      compositorStats.firstFrameDrawMs,
+                                      compositorStats.firstFramePlanningMs,
+                                      compositorStats.firstFrameWarmupMs,
+                                      compositorStats.immediateRasterizeMs,
+                                      compositorStats.cachedRasterizeMs,
+                                      static_cast<double>(compositorStats.immediateTileCount),
+                                      static_cast<double>(compositorStats.cachedTileCount),
+                                      static_cast<double>(compositorStats.offscreenCreateCount),
+                                      static_cast<double>(compositorStats.offscreenRecycleCount),
+                                      static_cast<double>(compositorStats.offscreenCreateTotal),
+                                      static_cast<double>(compositorStats.offscreenRecycleTotal),
+                                      static_cast<double>(timing.readbackCount),
+                                      static_cast<double>(timing.readbackPollIterations),
+                                      timing.usedTimedWaitAny ? 1.0 : 0.0,
+                                      timing.deviceLost ? 1.0 : 0.0,
+                                      static_cast<double>(timing.timedOutWaitMs)};
   std::copy(std::begin(values), std::end(values), std::begin(buffer));
   MAIN_THREAD_ASYNC_EM_ASM(
       {
@@ -87,9 +97,37 @@ void PublishWorkerTimingStats(double workerMs, double queueWaitMs, double dequeu
           stats[names[index]] = heap[b + index];
         }
         stats['readbackWaitStrategy'] = heap[b + 23] ? 'timed-wait-any' : 'device-poll';
+        stats['deviceLost'] = heap[b + 24] > 0;
+        stats['gpuWaitTimeoutSite'] = UTF8ToString($1);
+        stats['gpuWaitTimeoutMs'] = heap[b + 25];
+        stats['publishReason'] = 'render-result';
         window['__donnerWorkerStats'] = stats;
       },
-      buffer);
+      buffer, GpuWaitTimeoutSiteName(timing.timedOutWaitSite));
+}
+
+// Publish a GPU-wait failure that produced no frame.
+//
+// A bounded GPU wait that burns its deadline declares the device lost and
+// ends the worker iteration with nothing to present, so the stats object
+// above is never written and the failure reads as silence to anything polling
+// the page. Merge the failure onto whatever was last published, creating the
+// object when nothing ever completed, and leave `completedResults` alone: that
+// counter orders presentation samples and must keep counting frames only.
+void PublishWorkerGpuWaitFailure(bool deviceLost, const char* timedOutWaitSiteName,
+                                 int timedOutWaitMs) {
+  MAIN_THREAD_ASYNC_EM_ASM(
+      {
+        const previous = window['__donnerWorkerStats'];
+        const stats = previous ? Object.assign({}, previous) : ({'completedResults' : 0});
+        stats['deviceLost'] = $0 > 0;
+        stats['gpuWaitTimeoutSite'] = UTF8ToString($1);
+        stats['gpuWaitTimeoutMs'] = $2;
+        stats['publishedAtMs'] = performance.now();
+        stats['publishReason'] = 'gpu-wait-failure';
+        window['__donnerWorkerStats'] = stats;
+      },
+      deviceLost ? 1 : 0, timedOutWaitSiteName, timedOutWaitMs);
 }
 #endif
 
@@ -811,26 +849,31 @@ void RenderCoordinator::pollRenderResult(EditorApp& app, const ViewportState& vi
   ZoneScopedN("RenderCoordinator::pollRenderResult");
   const ScopedHeapDelta pollHeapDelta(MemoryStage::AppPollResult);
   auto resultOpt = renderWorker_.asyncRenderer.pollResult();
+#ifdef __EMSCRIPTEN__
+  // Report a GPU-wait failure whether or not a frame landed. The completed
+  // frame below carries the same fields, so consume the generation either way
+  // and only publish separately when there is no frame to carry them.
+  {
+    const AsyncRenderer::GpuWaitFailure gpuWaitFailure =
+        renderWorker_.asyncRenderer.gpuWaitFailure();
+    if (gpuWaitFailure.generation != publishedGpuWaitGeneration_) {
+      publishedGpuWaitGeneration_ = gpuWaitFailure.generation;
+      if (!resultOpt.has_value()) {
+        PublishWorkerGpuWaitFailure(gpuWaitFailure.deviceLost,
+                                    GpuWaitTimeoutSiteName(gpuWaitFailure.timedOutWaitSite),
+                                    gpuWaitFailure.timedOutWaitMs);
+      }
+    }
+  }
+#endif
   if (!resultOpt.has_value()) {
     return;
   }
 
   const auto& result = *resultOpt;
 #ifdef __EMSCRIPTEN__
-  const auto compositorStats = renderWorker_.asyncRenderer.compositorRenderFrameStats();
-  PublishWorkerTimingStats(
-      result.workerMs, result.workerTiming.queueWaitMs, result.workerTiming.dequeueToStartMs,
-      result.workerTiming.setupMs, result.workerTiming.renderFrameMs,
-      result.workerTiming.buildPreviewMs, result.workerTiming.finalSnapshotMs,
-      result.workerTiming.diagnosticsMs, result.workerTiming.pollDelayMs,
-      result.workerTiming.wakeToPollMs, compositorStats.firstFrameDrawMs,
-      compositorStats.firstFramePlanningMs, compositorStats.firstFrameWarmupMs,
-      compositorStats.immediateRasterizeMs, compositorStats.cachedRasterizeMs,
-      compositorStats.immediateTileCount, compositorStats.cachedTileCount,
-      compositorStats.offscreenCreateCount, compositorStats.offscreenRecycleCount,
-      compositorStats.offscreenCreateTotal, compositorStats.offscreenRecycleTotal,
-      result.workerTiming.readbackCount, result.workerTiming.readbackPollIterations,
-      result.workerTiming.usedTimedWaitAny ? 1 : 0);
+  PublishWorkerTimingStats(result.workerMs, result.workerTiming,
+                           renderWorker_.asyncRenderer.compositorRenderFrameStats());
 #endif
   lastFrameCostBreakdown_.compositedRender =
       CompositedRenderCostFromStats(renderWorker_.asyncRenderer.compositorRenderFrameStats());

--- a/donner/editor/RenderCoordinator.cc
+++ b/donner/editor/RenderCoordinator.cc
@@ -871,12 +871,11 @@ void RenderCoordinator::pollRenderResult(EditorApp& app, const ViewportState& vi
   }
 
   const auto& result = *resultOpt;
+  const auto compositorStats = renderWorker_.asyncRenderer.compositorRenderFrameStats();
 #ifdef __EMSCRIPTEN__
-  PublishWorkerTimingStats(result.workerMs, result.workerTiming,
-                           renderWorker_.asyncRenderer.compositorRenderFrameStats());
+  PublishWorkerTimingStats(result.workerMs, result.workerTiming, compositorStats);
 #endif
-  lastFrameCostBreakdown_.compositedRender =
-      CompositedRenderCostFromStats(renderWorker_.asyncRenderer.compositorRenderFrameStats());
+  lastFrameCostBreakdown_.compositedRender = CompositedRenderCostFromStats(compositorStats);
   // Forward the worker-measured presentation latency to the frame history so
   // `RenderFrameGraph` can overlay async worker time on the UI frame graph.
   // The frame history's latest slot corresponds to the current UI frame

--- a/donner/editor/RenderCoordinator.h
+++ b/donner/editor/RenderCoordinator.h
@@ -474,6 +474,12 @@ private:
   std::uint64_t documentCanvasCommitTotal_ = 0;
   /// Cumulative overview-infill requests; see `overviewInfillRenderTotal`.
   std::uint64_t overviewInfillRenderTotal_ = 0;
+#ifdef __EMSCRIPTEN__
+  /// Generation of the last worker GPU-wait failure reported to the page.
+  /// Device loss is sticky, so publishing is edge-triggered on this rather
+  /// than repeated every frame for the rest of the session.
+  std::uint64_t publishedGpuWaitGeneration_ = 0;
+#endif
 };
 
 }  // namespace donner::editor

--- a/donner/editor/gui/EditorWindow.cc
+++ b/donner/editor/gui/EditorWindow.cc
@@ -345,6 +345,7 @@ bool MapReadbackBuffer(const wgpu::Device& device, const wgpu::Buffer& buffer, u
   // driver would wedge the editor thread forever (worst case in
   // uninterruptible kernel sleep). Poll non-blocking with a deadline and
   // declare the device lost when the deadline expires.
+  const auto surfaceWaitStart = std::chrono::steady_clock::now();
   const donner::geode::GpuWaitResult waitResult = donner::geode::BoundedGpuWait(
       [&] {
         device.poll(false, nullptr);
@@ -352,7 +353,11 @@ bool MapReadbackBuffer(const wgpu::Device& device, const wgpu::Buffer& buffer, u
       },
       donner::geode::kDefaultGpuWaitTimeout);
   if (waitResult != donner::geode::GpuWaitResult::Complete && geodeDevice) {
-    geodeDevice->markDeviceLost("editor surface readback map did not complete within the bound");
+    geodeDevice->markDeviceLostAfterWaitTimeout(
+        donner::geode::GpuWaitSite::ReadbackMap,
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
+                                                              surfaceWaitStart),
+        "editor surface readback map did not complete within the bound");
   }
 #endif
   return mapState->done.load(std::memory_order_acquire) &&

--- a/donner/editor/tests/AsyncRenderer_tests.cc
+++ b/donner/editor/tests/AsyncRenderer_tests.cc
@@ -359,6 +359,46 @@ TEST(AsyncRendererTest, GeometryOverlayForcesFlatFrameThenRepromotesSelectionWhe
   EXPECT_EQ(asyncRenderer.compositorResetCountForTesting(), resetCountAfterEnable + 1u);
 }
 
+/// The worker's GPU-wait failure record is read by an edge-triggered
+/// publisher, so its generation is the whole contract: device loss is sticky
+/// and every later frame re-reports it, and a generation that moved each time
+/// would republish the same failure for the rest of the session.
+TEST(AsyncRendererGpuWaitFailureTest, RepeatedIdenticalLossBumpsTheGenerationOnce) {
+  AsyncRenderer asyncRenderer(AsyncRendererStartMode::Deferred);
+
+  EXPECT_FALSE(asyncRenderer.gpuWaitFailure().deviceLost);
+  EXPECT_EQ(asyncRenderer.gpuWaitFailure().generation, 0u);
+
+  asyncRenderer.noteGpuWaitOutcomeForTesting(svg::RendererReadbackStats{});
+  EXPECT_EQ(asyncRenderer.gpuWaitFailure().generation, 0u)
+      << "a healthy frame must not manufacture a failure to publish";
+
+  svg::RendererReadbackStats lost;
+  lost.deviceLost = true;
+  lost.timedOutWaitSite = svg::GpuWaitTimeoutSite::ReadbackMap;
+  lost.timedOutWaitMs = 10000;
+  asyncRenderer.noteGpuWaitOutcomeForTesting(lost);
+
+  const AsyncRenderer::GpuWaitFailure declared = asyncRenderer.gpuWaitFailure();
+  EXPECT_TRUE(declared.deviceLost);
+  EXPECT_EQ(declared.timedOutWaitSite, svg::GpuWaitTimeoutSite::ReadbackMap);
+  EXPECT_EQ(declared.timedOutWaitMs, 10000);
+  EXPECT_EQ(declared.generation, 1u);
+
+  for (int frame = 0; frame < 5; ++frame) {
+    asyncRenderer.noteGpuWaitOutcomeForTesting(lost);
+  }
+  EXPECT_EQ(asyncRenderer.gpuWaitFailure().generation, 1u)
+      << "the same sticky loss must be reported once, not once per frame";
+
+  // A different outcome is a different failure and has to reach the page.
+  svg::RendererReadbackStats escalated = lost;
+  escalated.timedOutWaitSite = svg::GpuWaitTimeoutSite::QueueIdle;
+  asyncRenderer.noteGpuWaitOutcomeForTesting(escalated);
+  EXPECT_EQ(asyncRenderer.gpuWaitFailure().generation, 2u);
+  EXPECT_EQ(asyncRenderer.gpuWaitFailure().timedOutWaitSite, svg::GpuWaitTimeoutSite::QueueIdle);
+}
+
 TEST(AsyncRendererTest, DeferredStartQueuesWorkAndStartsExactlyOnce) {
   svg::SVGDocument document = svg::instantiateSubtree(
       R"svg(<rect id="rect" x="1" y="1" width="8" height="8" fill="blue" />)svg");

--- a/donner/editor/wasm/tests/browser-presentation-regression.spec.ts
+++ b/donner/editor/wasm/tests/browser-presentation-regression.spec.ts
@@ -35,6 +35,17 @@ declare global {
       offscreenCreateTotal?: number;
       offscreenRecycleCount?: number;
       offscreenRecycleTotal?: number;
+      // Device health, published onto the same object as the frame counter.
+      // A frame that never lands leaves the counter flat and says nothing
+      // else; these say whether the renderer stopped and which bounded GPU
+      // wait stopped it. Optional because a build older than the publisher,
+      // or a page where the worker never published at all, has neither.
+      deviceLost?: boolean;
+      gpuWaitTimeoutSite?: string;
+      gpuWaitTimeoutMs?: number;
+      publishReason?: string;
+      publishedAtMs?: number;
+      presentedAtMs?: number;
     };
     __donnerInteractionStats?: {
       dragging: boolean;
@@ -386,6 +397,66 @@ async function readDocumentPresentationState(page: Page): Promise<DocumentPresen
   }));
 }
 
+// The worker's device health, published alongside the frame counter every
+// gate in this file waits on.
+interface WorkerHealth {
+  completedResults: number;
+  deviceLost: boolean;
+  gpuWaitTimeoutSite: string;
+  gpuWaitTimeoutMs: number;
+  publishReason: string;
+}
+
+// `unpublished` and -1 distinguish "the worker never published stats at all"
+// from "the worker published and reports a healthy device". Those are very
+// different failures and the counter alone reports both as a flat zero.
+async function readWorkerHealth(page: Page): Promise<WorkerHealth> {
+  return page.evaluate(() => ({
+    completedResults: window.__donnerWorkerStats?.completedResults ?? 0,
+    deviceLost: window.__donnerWorkerStats?.deviceLost ?? false,
+    gpuWaitTimeoutSite: window.__donnerWorkerStats?.gpuWaitTimeoutSite ?? "unpublished",
+    gpuWaitTimeoutMs: window.__donnerWorkerStats?.gpuWaitTimeoutMs ?? -1,
+    publishReason: window.__donnerWorkerStats?.publishReason ?? "unpublished",
+  }));
+}
+
+/**
+ * Wait for the worker's completed-frame count to satisfy `reached`.
+ *
+ * Every render gate in this file waits on that counter, and a counter that
+ * never moves reports only "still <n>" - which is what the hardest failure
+ * looks like too: a bounded GPU wait burning its deadline stops the worker
+ * publishing entirely, and on a loaded runner that is indistinguishable from
+ * slow. Polling the whole health snapshot instead of the bare number puts the
+ * device-lost flag, the wait that timed out and its elapsed time into the
+ * value the assertion prints, so a failing run names the cause without a
+ * rerun. Waiting behavior is unchanged; only what the failure says changes.
+ *
+ * The matcher is deliberately `toEqual(objectContaining(...))` and not
+ * `toMatchObject`: the latter prints only the keys it was asked to match, so
+ * the health fields would never reach the log and this helper would be pure
+ * overhead. Verified by running both against a failing poll.
+ */
+async function expectWorkerResultsToReach(
+  page: Page,
+  reached: (completedResults: number) => boolean,
+  options: { message: string; timeout: number },
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const health = await readWorkerHealth(page);
+        return { ...health, reached: reached(health.completedResults) };
+      },
+      {
+        message: options.message,
+        timeout: options.timeout,
+        intervals: [16, 25, 50, 100],
+      },
+    )
+    .toEqual(expect.objectContaining({ reached: true }));
+}
+
 // What a drag press is supposed to have accomplished, read as one snapshot: the
 // shape is selected and its single prewarm render has landed. Reading both
 // together is what makes the failure diagnosable - a press the busy worker
@@ -554,13 +625,11 @@ async function openBasicShapes(page: Page): Promise<{
   );
   await page.mouse.click(canvasBounds.x + canvasBounds.width * 0.5, canvasBounds.y + 282);
   await expect(editorCanvas).toHaveAttribute("data-active-sample-id", "basic-shapes");
-  await expect
-    .poll(() => page.evaluate(() => window.__donnerWorkerStats?.completedResults || 0), {
-      message: "Basic Shapes must have its own document render before capture",
-      timeout: scaledMs(5_000),
-      intervals: [16, 25, 50, 100],
-    })
-    .toBeGreaterThan(beforeSampleResults);
+  await expectWorkerResultsToReach(
+    page,
+    (completedResults) => completedResults > beforeSampleResults,
+    { message: "Basic Shapes must have its own document render before capture", timeout: scaledMs(5_000) },
+  );
   await waitForBrowserComposite(page);
 
   const documentClip = {
@@ -769,13 +838,11 @@ test("Geode Wasm View overlays render tile metadata and sparse Slug triangle edg
     () => window.__donnerWorkerStats?.completedResults || 0,
   );
   await setViewOverlayState(page, canvasBounds.x, 155, "compositorTileOverlay", true);
-  await expect
-    .poll(() => page.evaluate(() => window.__donnerWorkerStats?.completedResults || 0), {
-      message: "Compositor Tile Overlay must rasterize a fresh document render",
-      timeout: scaledMs(2_000),
-      intervals: [16, 25, 50, 100],
-    })
-    .toBeGreaterThan(beforeCompositorResults);
+  await expectWorkerResultsToReach(
+    page,
+    (completedResults) => completedResults > beforeCompositorResults,
+    { message: "Compositor Tile Overlay must rasterize a fresh document render", timeout: scaledMs(2_000) },
+  );
   await waitForBrowserComposite(page);
   const compositorOverlay = await page.screenshot({ clip: documentClip });
   await test.info().attach("compositor-tile-overlay", {
@@ -851,13 +918,11 @@ test("Geode Wasm View overlays render tile metadata and sparse Slug triangle edg
     () => window.__donnerWorkerStats?.completedResults || 0,
   );
   await setViewOverlayState(page, canvasBounds.x, 176, "geometryDebugOverlay", true);
-  await expect
-    .poll(() => page.evaluate(() => window.__donnerWorkerStats?.completedResults || 0), {
-      message: "Geometry Debug Overlay must schedule a freshly rasterized document render",
-      timeout: scaledMs(2_000),
-      intervals: [16, 25, 50, 100],
-    })
-    .toBeGreaterThan(beforeGeometryResults);
+  await expectWorkerResultsToReach(
+    page,
+    (completedResults) => completedResults > beforeGeometryResults,
+    { message: "Geometry Debug Overlay must schedule a freshly rasterized document render", timeout: scaledMs(2_000) },
+  );
   await waitForBrowserComposite(page);
   const geometryOverlay = await page.screenshot({ clip: documentClip });
   await test.info().attach("geometry-debug-overlay", {
@@ -932,9 +997,14 @@ test("Firefox keeps the dragged shape and its selection outline in every drag fr
   const beforeSample = await page.evaluate(() => window.__donnerWorkerStats?.completedResults || 0);
   await page.mouse.click(editorBounds.x + editorBounds.width * 0.5, editorBounds.y + 282);
   await expect(editorCanvas).toHaveAttribute("data-active-sample-id", "basic-shapes");
-  await expect
-    .poll(() => page.evaluate(() => window.__donnerWorkerStats?.completedResults || 0))
-    .toBeGreaterThan(beforeSample);
+  await expectWorkerResultsToReach(
+    page,
+    (completedResults) => completedResults > beforeSample,
+    {
+      message: "expected Basic Shapes to render before the drag",
+      timeout: scaledMs(5_000),
+    },
+  );
 
   await expect
     .poll(() => readElementColorStats(editorCanvas).then((stats) => stats.coloredPixels), {
@@ -1081,13 +1151,11 @@ test("Firefox keeps the dragged shape and its selection outline in every drag fr
     samples[0]?.renderedFrames || 0,
   );
   // The release commits the moved geometry with exactly one document render.
-  await expect
-    .poll(async () => page.evaluate(() => window.__donnerWorkerStats?.completedResults || 0), {
-      message: "expected the pointer release to commit exactly one document render",
-      timeout: scaledMs(2_000),
-      intervals: [16, 25, 50, 100],
-    })
-    .toBe(resultsDuringDrag + 1);
+  await expectWorkerResultsToReach(
+    page,
+    (completedResults) => completedResults === resultsDuringDrag + 1,
+    { message: "expected the pointer release to commit exactly one document render", timeout: scaledMs(2_000) },
+  );
   const centerX = (bounds: PixelBounds) => (bounds.minX + bounds.maxX) * 0.5;
   const centerY = (bounds: PixelBounds) => (bounds.minY + bounds.maxY) * 0.5;
   for (const sample of samples) {
@@ -1404,13 +1472,11 @@ test("Firefox never exposes the checkerboard while dragging a Splash letter", as
   ).toBeLessThanOrEqual(2);
 
   // The release commits the moved letter with exactly one document render.
-  await expect
-    .poll(async () => page.evaluate(() => window.__donnerWorkerStats?.completedResults || 0), {
-      message: "expected the pointer release to commit exactly one Splash document render",
-      timeout: scaledMs(2_000),
-      intervals: [16, 25, 50, 100],
-    })
-    .toBe(resultsDuringDrag + 1);
+  await expectWorkerResultsToReach(
+    page,
+    (completedResults) => completedResults === resultsDuringDrag + 1,
+    { message: "expected the pointer release to commit exactly one Splash document render", timeout: scaledMs(2_000) },
+  );
   expect(failures).toEqual([]);
 });
 
@@ -1429,13 +1495,11 @@ test("WebKit Geode survives a burst of drag wakeups without fatal errors", async
   const beforeSample = await page.evaluate(() => window.__donnerWorkerStats?.completedResults || 0);
   await page.mouse.click(editorBounds.x + editorBounds.width * 0.5, editorBounds.y + 282);
   await expect(editorCanvas).toHaveAttribute("data-active-sample-id", "basic-shapes");
-  await expect
-    .poll(() => page.evaluate(() => window.__donnerWorkerStats?.completedResults || 0), {
-      message: "expected Basic Shapes to finish presenting before the WebKit drag burst",
-      timeout: scaledMs(2_000),
-      intervals: [16, 25, 50, 100],
-    })
-    .toBeGreaterThan(beforeSample);
+  await expectWorkerResultsToReach(
+    page,
+    (completedResults) => completedResults > beforeSample,
+    { message: "expected Basic Shapes to finish presenting before the WebKit drag burst", timeout: scaledMs(2_000) },
+  );
 
   const dragStart = {
     x: editorBounds.x + kBlueRectOffset.x,
@@ -1451,13 +1515,11 @@ test("WebKit Geode survives a burst of drag wakeups without fatal errors", async
     }
   }
   await page.mouse.up();
-  await expect
-    .poll(() => page.evaluate(() => window.__donnerWorkerStats?.completedResults || 0), {
-      message: "expected WebKit to complete a render after the drag wakeup burst",
-      timeout: scaledMs(2_000),
-      intervals: [16, 25, 50, 100],
-    })
-    .toBeGreaterThan(beforeDrag);
+  await expectWorkerResultsToReach(
+    page,
+    (completedResults) => completedResults > beforeDrag,
+    { message: "expected WebKit to complete a render after the drag wakeup burst", timeout: scaledMs(2_000) },
+  );
   expect(failures).toEqual([]);
 });
 
@@ -1524,13 +1586,11 @@ async function openDonnerSplash(page: Page): Promise<{
   );
   await page.mouse.click(editorBounds.x + editorBounds.width * 0.24, editorBounds.y + 282);
   await expect(editorCanvas).toHaveAttribute("data-active-sample-id", "donner-splash");
-  await expect
-    .poll(() => page.evaluate(() => window.__donnerWorkerStats?.completedResults || 0), {
-      message: "Donner Splash must produce a document render",
-      timeout: scaledMs(5_000),
-      intervals: [16, 25, 50, 100],
-    })
-    .toBeGreaterThan(beforeSampleResults);
+  await expectWorkerResultsToReach(
+    page,
+    (completedResults) => completedResults > beforeSampleResults,
+    { message: "Donner Splash must produce a document render", timeout: scaledMs(5_000) },
+  );
   return { editorBounds };
 }
 

--- a/donner/editor/wasm/tests/smoke.spec.ts
+++ b/donner/editor/wasm/tests/smoke.spec.ts
@@ -46,6 +46,10 @@ declare global {
       readbackCount: number;
       readbackPollIterations: number;
       readbackWaitStrategy: string;
+      deviceLost: boolean;
+      gpuWaitTimeoutSite: string;
+      gpuWaitTimeoutMs: number;
+      publishReason: string;
     };
     __donnerActiveSampleStats?: {
       sampleId: string;
@@ -1487,6 +1491,17 @@ test("Geode WASM selects through the overlay with one prewarm render and no recu
   expect(workerStats?.readbackCount).toBe(0);
   expect(workerStats?.readbackPollIterations).toBe(0);
   expect(["timed-wait-any", "device-poll"]).toContain(workerStats?.readbackWaitStrategy);
+  // A run that presented frames must say so explicitly rather than by the
+  // absence of a failure field. A hung GPU wait publishes the same object with
+  // `deviceLost` set and the wait named, so a rare stall prints a line that
+  // identifies itself instead of leaving the stats undefined.
+  expect(
+    workerStats?.deviceLost,
+    `worker device was declared lost: ${JSON.stringify(workerStats)}`,
+  ).toBe(false);
+  expect(workerStats?.gpuWaitTimeoutSite).toBe("none");
+  expect(workerStats?.gpuWaitTimeoutMs).toBe(0);
+  expect(workerStats?.publishReason).toBe("render-result");
   console.log(`wasm-worker-stats=${JSON.stringify(workerStats)}`);
   expect(fatalMessages).toEqual([]);
 });

--- a/donner/editor/wasm/tests/smoke.spec.ts
+++ b/donner/editor/wasm/tests/smoke.spec.ts
@@ -22,6 +22,11 @@ declare global {
       count?: number;
     };
     __donnerPinchWheelDeltaPerLnScale?: number;
+    // Shape of a completed frame's publish. A publish that reports a GPU wait
+    // failure carries only `completedResults` and the health fields below, so
+    // the timing fields are optional in principle; they are declared required
+    // because every assertion in this file reads them from a frame that
+    // landed, and loosening them would push a null check into each one.
     __donnerWorkerStats?: {
       completedResults: number;
       publishedAtMs: number;
@@ -46,6 +51,8 @@ declare global {
       readbackCount: number;
       readbackPollIterations: number;
       readbackWaitStrategy: string;
+      // Present on every publish, including one that reports a GPU wait
+      // failure with no frame behind it.
       deviceLost: boolean;
       gpuWaitTimeoutSite: string;
       gpuWaitTimeoutMs: number;

--- a/donner/editor/wasm/tests/wgpu-readback-contract.spec.mjs
+++ b/donner/editor/wasm/tests/wgpu-readback-contract.spec.mjs
@@ -210,7 +210,7 @@ test("a GPU wait failure publishes worker stats even though no frame completed",
   );
   assert.ok(poll, "expected the UI-thread result poll");
   const failureCall = poll[0].indexOf("PublishWorkerGpuWaitFailure(");
-  const earlyReturn = poll[0].indexOf("if (!resultOpt.has_value()) {");
+  const earlyReturn = poll[0].indexOf("if (!resultOpt.has_value()) {\n    return;");
   assert.ok(failureCall >= 0, "the poll must report a GPU wait failure");
   assert.ok(
     failureCall < earlyReturn,

--- a/donner/editor/wasm/tests/wgpu-readback-contract.spec.mjs
+++ b/donner/editor/wasm/tests/wgpu-readback-contract.spec.mjs
@@ -162,6 +162,82 @@ test("pre-map diagnostic setup failures use the same bounded completion policy",
   assert.doesNotMatch(source, /struct AsyncSmokeReadbackRetry/);
 });
 
+test("worker stats carry the GPU wait outcome that ended the frame", () => {
+  const publisher = renderCoordinatorSource.match(
+    /void PublishWorkerTimingStats\([\s\S]*?\n\}/,
+  );
+  assert.ok(publisher, "expected the completed-frame worker stats publisher");
+  assert.match(publisher[0], /stats\['deviceLost'\]/);
+  assert.match(publisher[0], /stats\['gpuWaitTimeoutSite'\] = UTF8ToString/);
+  assert.match(publisher[0], /stats\['gpuWaitTimeoutMs'\]/);
+  assert.match(publisher[0], /stats\['publishReason'\] = 'render-result'/);
+
+  // The site names are what a failing run prints, so they are part of the
+  // contract rather than an implementation detail.
+  assert.match(renderCoordinatorSource, /GpuWaitTimeoutSite::None: return "none"/);
+  assert.match(renderCoordinatorSource, /GpuWaitTimeoutSite::ReadbackMap: return "readback-map"/);
+  assert.match(renderCoordinatorSource, /GpuWaitTimeoutSite::QueueIdle: return "queue-idle"/);
+
+  // clang-format splits a bare `!==` into `!= =`; the publishers must not
+  // depend on an operator that a formatting pass can silently corrupt.
+  assert.doesNotMatch(renderCoordinatorSource, /!\s*=\s+=/);
+});
+
+test("a GPU wait failure publishes worker stats even though no frame completed", () => {
+  const failurePublisher = renderCoordinatorSource.match(
+    /void PublishWorkerGpuWaitFailure\([\s\S]*?\n\}/,
+  );
+  assert.ok(failurePublisher, "expected a publisher for frames that never completed");
+  assert.match(
+    failurePublisher[0],
+    /window\['__donnerWorkerStats'\] = stats/,
+    "the failure path must write the same stats object the harness reads",
+  );
+  assert.match(failurePublisher[0], /stats\['publishReason'\] = 'gpu-wait-failure'/);
+  assert.match(
+    failurePublisher[0],
+    /previous \? Object\.assign\(\{\}, previous\) : \(\{'completedResults' : 0\}\)/,
+    "a failure before any frame landed must still create the stats object",
+  );
+  assert.doesNotMatch(
+    failurePublisher[0],
+    /'completedResults' : previous/,
+    "the completed-frame counter orders presentation samples and must count frames only",
+  );
+
+  const poll = renderCoordinatorSource.match(
+    /void RenderCoordinator::pollRenderResult\([\s\S]*?\n  const auto& result = \*resultOpt;/,
+  );
+  assert.ok(poll, "expected the UI-thread result poll");
+  const failureCall = poll[0].indexOf("PublishWorkerGpuWaitFailure(");
+  const earlyReturn = poll[0].indexOf("if (!resultOpt.has_value()) {");
+  assert.ok(failureCall >= 0, "the poll must report a GPU wait failure");
+  assert.ok(
+    failureCall < earlyReturn,
+    "the failure report must happen before the no-result early return",
+  );
+  assert.match(poll[0], /gpuWaitFailure\.generation != publishedGpuWaitGeneration_/);
+});
+
+test("the render worker records a GPU wait failure on the abandoned-frame path", () => {
+  const abandoned = workerRendererSource.match(
+    /if \(!renderCompleted\) \{[\s\S]*?cancelledRenderCount_\.fetch_add/,
+  );
+  assert.ok(abandoned, "expected the worker's abandoned-iteration path");
+  assert.match(abandoned[0], /noteGpuWaitOutcome\(requestRenderer\.consumeReadbackStats\(\)\)/);
+
+  assert.match(
+    workerRendererHeader,
+    /struct GpuWaitFailure \{[\s\S]*?bool deviceLost[\s\S]*?timedOutWaitSite[\s\S]*?timedOutWaitMs[\s\S]*?generation/,
+    "the worker's failure record must carry the flag, the wait site, and the elapsed wait",
+  );
+  assert.match(
+    workerRendererHeader,
+    /bool deviceLost = false;[\s\S]*?svg::GpuWaitTimeoutSite timedOutWaitSite[\s\S]*?int timedOutWaitMs/,
+    "the per-frame timing breakdown must carry the same three fields",
+  );
+});
+
 test("worker WebGPU startup keeps its browser Promise bridge private and single-purpose", () => {
   assert.doesNotMatch(geodeDeviceHeader, /CreateHeadlessAsync/);
   assert.doesNotMatch(geodeDeviceHeader, /donnerGeodeCompleteHeadlessImport/);

--- a/donner/editor/wasm/tests/wgpu-readback-contract.spec.mjs
+++ b/donner/editor/wasm/tests/wgpu-readback-contract.spec.mjs
@@ -216,7 +216,7 @@ test("a GPU wait failure publishes worker stats even though no frame completed",
   );
 
   const poll = renderCoordinatorSource.match(
-    /void RenderCoordinator::pollRenderResult\([\s\S]*?\n  const auto& result = \*resultOpt;/,
+    /void RenderCoordinator::pollRenderResult\([\s\S]*?\n {2}const auto& result = \*resultOpt;/,
   );
   assert.ok(poll, "expected the UI-thread result poll");
   const failureCall = poll[0].indexOf("PublishWorkerGpuWaitFailure(");

--- a/donner/editor/wasm/tests/wgpu-readback-contract.spec.mjs
+++ b/donner/editor/wasm/tests/wgpu-readback-contract.spec.mjs
@@ -23,6 +23,10 @@ const rotateCursorSource = await readFile(
   new URL("../../RotateCursorSet.cc", import.meta.url),
   "utf8",
 );
+const presentationRegressionSource = await readFile(
+  new URL("./browser-presentation-regression.spec.ts", import.meta.url),
+  "utf8",
+);
 const geodeDeviceSource = await readFile(
   new URL("../../../svg/renderer/geode/GeodeDevice.cc", import.meta.url),
   "utf8",
@@ -204,6 +208,12 @@ test("a GPU wait failure publishes worker stats even though no frame completed",
     /'completedResults' : previous/,
     "the completed-frame counter orders presentation samples and must count frames only",
   );
+  assert.match(
+    failurePublisher[0],
+    /delete stats\['presentedAtMs'\]/,
+    "a merged publish must not inherit the previous object's presentation stamp; "
+      + "the editor stamps it once per fresh stats object and probes pair the two timestamps",
+  );
 
   const poll = renderCoordinatorSource.match(
     /void RenderCoordinator::pollRenderResult\([\s\S]*?\n  const auto& result = \*resultOpt;/,
@@ -235,6 +245,36 @@ test("the render worker records a GPU wait failure on the abandoned-frame path",
     workerRendererHeader,
     /bool deviceLost = false;[\s\S]*?svg::GpuWaitTimeoutSite timedOutWaitSite[\s\S]*?int timedOutWaitMs/,
     "the per-frame timing breakdown must carry the same three fields",
+  );
+});
+
+test("the presentation regression gates print the worker health they wait on", () => {
+  const helper = presentationRegressionSource.match(
+    /async function expectWorkerResultsToReach\([\s\S]*?\n\}/,
+  );
+  assert.ok(helper, "expected one shared render gate for the presentation suite");
+  assert.match(helper[0], /readWorkerHealth\(page\)/);
+  // Playwright prints the whole received value for `toEqual`, but only the
+  // keys it was asked to match for `toMatchObject`. With the latter the health
+  // fields never reach the log and the helper is pure overhead, so the matcher
+  // is part of the contract rather than a style choice.
+  assert.match(helper[0], /\.toEqual\(expect\.objectContaining\(\{ reached: true \}\)\)/);
+  assert.doesNotMatch(helper[0], /toMatchObject/);
+
+  const health = presentationRegressionSource.match(
+    /async function readWorkerHealth\([\s\S]*?\n\}/,
+  );
+  assert.ok(health, "expected a worker health snapshot helper");
+  for (const field of ["deviceLost", "gpuWaitTimeoutSite", "gpuWaitTimeoutMs", "publishReason"]) {
+    assert.match(health[0], new RegExp(`${field}:`), `health snapshot must carry ${field}`);
+  }
+
+  // Every render gate in the suite has to go through the helper: one that
+  // still polls the bare counter is exactly the gate that reports nothing when
+  // the worker stops publishing.
+  assert.doesNotMatch(
+    presentationRegressionSource,
+    /\.poll\((?:async )?\(\) => page\.evaluate\(\(\) => window\.__donnerWorkerStats\?\.completedResults/,
   );
 });
 

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -5828,16 +5828,21 @@ bool RendererGeode::deviceLost() const {
 namespace {
 
 /// Translate the Geode wait vocabulary into the backend-neutral one the
-/// renderer interface publishes. Kept as an explicit switch so adding a wait
-/// site to either enum fails the build here rather than silently reporting
-/// the wrong hang.
+/// renderer interface publishes.
+///
+/// A new enumerator on either side is only a -Wswitch warning here, not a
+/// build error, so the fallthrough must not resolve to `None`: `None` is
+/// published as "the driver declared this loss, no deadline expired", and a
+/// wait site quietly wearing that label points a report at the wrong
+/// subsystem. Report it as `Unknown` instead, which reads as itself in the
+/// published diagnostics.
 GpuWaitTimeoutSite NeutralWaitSite(geode::GpuWaitSite site) {
   switch (site) {
     case geode::GpuWaitSite::None: return GpuWaitTimeoutSite::None;
     case geode::GpuWaitSite::ReadbackMap: return GpuWaitTimeoutSite::ReadbackMap;
     case geode::GpuWaitSite::QueueIdle: return GpuWaitTimeoutSite::QueueIdle;
   }
-  return GpuWaitTimeoutSite::None;
+  return GpuWaitTimeoutSite::Unknown;
 }
 
 }  // namespace

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -5461,7 +5461,8 @@ ReadbackMapStatus MapAndWaitReadback(const std::shared_ptr<geode::GeodeDevice>& 
   bool cancelled = false;
   bool timedOut = false;
   bool usedTimedWaitAny = false;
-  const auto readbackDeadline = std::chrono::steady_clock::now() + geode::kReadbackMapTimeout;
+  const auto readbackWaitStart = std::chrono::steady_clock::now();
+  const auto readbackDeadline = readbackWaitStart + geode::kReadbackMapTimeout;
   while (!mapState->done.load(std::memory_order_acquire)) {
     if (shouldCancel && shouldCancel()) {
       cancelled = true;
@@ -5517,8 +5518,14 @@ ReadbackMapStatus MapAndWaitReadback(const std::shared_ptr<geode::GeodeDevice>& 
     if (timedOut) {
       // A full readback deadline with no map delivery is the observable
       // signature of a hung device. Declare the loss so later waits on this
-      // device fail fast and teardown skips GPU waits entirely.
-      device->markDeviceLost("snapshot readback map did not complete within the readback deadline");
+      // device fail fast and teardown skips GPU waits entirely, and record the
+      // site and the measured wait so a consumer reading only the stats can
+      // tell this hang from a queue-drain hang.
+      device->markDeviceLostAfterWaitTimeout(
+          geode::GpuWaitSite::ReadbackMap,
+          std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
+                                                                readbackWaitStart),
+          "snapshot readback map did not complete within the readback deadline");
     }
     // Cancelling a pending map schedules its callback with an aborted status. The callback's
     // reference keeps `mapState` valid even when delivery happens after this method returns.
@@ -5818,6 +5825,23 @@ bool RendererGeode::deviceLost() const {
   return impl_->device && impl_->device->isDeviceLost();
 }
 
+namespace {
+
+/// Translate the Geode wait vocabulary into the backend-neutral one the
+/// renderer interface publishes. Kept as an explicit switch so adding a wait
+/// site to either enum fails the build here rather than silently reporting
+/// the wrong hang.
+GpuWaitTimeoutSite NeutralWaitSite(geode::GpuWaitSite site) {
+  switch (site) {
+    case geode::GpuWaitSite::None: return GpuWaitTimeoutSite::None;
+    case geode::GpuWaitSite::ReadbackMap: return GpuWaitTimeoutSite::ReadbackMap;
+    case geode::GpuWaitSite::QueueIdle: return GpuWaitTimeoutSite::QueueIdle;
+  }
+  return GpuWaitTimeoutSite::None;
+}
+
+}  // namespace
+
 RendererReadbackStats RendererGeode::consumeReadbackStats() {
   if (!impl_->device) {
     return {};
@@ -5827,6 +5851,9 @@ RendererReadbackStats RendererGeode::consumeReadbackStats() {
       .count = stats.count,
       .pollIterations = stats.pollIterations,
       .usedTimedWaitAny = stats.usedTimedWaitAny,
+      .deviceLost = stats.deviceLost,
+      .timedOutWaitSite = NeutralWaitSite(stats.timedOutWaitSite),
+      .timedOutWaitMs = stats.timedOutWaitMs,
   };
 }
 

--- a/donner/svg/renderer/RendererInterface.h
+++ b/donner/svg/renderer/RendererInterface.h
@@ -87,12 +87,18 @@ struct RendererBitmap {
  */
 enum class GpuWaitTimeoutSite : uint8_t {
   /// No bounded wait has timed out. A device reported lost with this site was
-  /// reported by the driver, not by a deadline.
+  /// reported by the driver, not by a deadline. This is a positive claim, so
+  /// never use it as a fallback for a site that could not be translated - see
+  /// \ref Unknown.
   None,
   /// A buffer-map wait for GPU-to-CPU readback.
   ReadbackMap,
   /// A wait for the GPU queue to drain.
   QueueIdle,
+  /// A backend wait this build cannot name. Reported rather than folded into
+  /// \ref None so a report never claims the driver declared a loss that one of
+  /// the backend's own deadlines actually did.
+  Unknown,
 };
 
 /**

--- a/donner/svg/renderer/RendererInterface.h
+++ b/donner/svg/renderer/RendererInterface.h
@@ -77,13 +77,42 @@ struct RendererBitmap {
 };
 
 /**
+ * Bounded CPU-blocks-on-GPU wait that exceeded its deadline and caused a
+ * renderer backend to declare its device lost.
+ *
+ * Backend-neutral mirror of the GPU backend's own wait vocabulary, so a
+ * consumer of \ref RendererReadbackStats can distinguish the two very
+ * different hangs without depending on a graphics API. Backends that never
+ * block on the GPU always report \ref None.
+ */
+enum class GpuWaitTimeoutSite : uint8_t {
+  /// No bounded wait has timed out. A device reported lost with this site was
+  /// reported by the driver, not by a deadline.
+  None,
+  /// A buffer-map wait for GPU-to-CPU readback.
+  ReadbackMap,
+  /// A wait for the GPU queue to drain.
+  QueueIdle,
+};
+
+/**
  * Aggregate diagnostics for CPU readbacks completed by a renderer and any
- * offscreen instances that share its backend device.
+ * offscreen instances that share its backend device, plus the device-health
+ * outcome those readbacks observed.
  */
 struct RendererReadbackStats {
   int count = 0;
   int pollIterations = 0;
   bool usedTimedWaitAny = false;
+  /// True once the backend device has been declared lost. Sticky: a device
+  /// that hangs never recovers, and a caller whose frame produced nothing has
+  /// no other evidence to report.
+  bool deviceLost = false;
+  /// Which bounded wait declared that loss, when a deadline did.
+  GpuWaitTimeoutSite timedOutWaitSite = GpuWaitTimeoutSite::None;
+  /// Wall time that wait spent before giving up, in milliseconds. Zero while
+  /// \ref timedOutWaitSite is \ref GpuWaitTimeoutSite::None.
+  int timedOutWaitMs = 0;
 };
 
 /// Backend type for \ref RendererTextureSnapshot payloads.

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -80,7 +80,10 @@ void OnDeviceLost(WGPUDevice const* /*device*/, WGPUDeviceLostReason reason, WGP
                static_cast<int>(reason), static_cast<int>(message.length),
                message.data ? message.data : "");
   if (state) {
-    state->lost.store(true, std::memory_order_release);
+    // Route through the shared declarer rather than storing the flag: it is
+    // what leaves `timedOutSite` empty, which is how a report tells a
+    // driver-reported loss from one a bounded wait's deadline discovered.
+    DeclareDeviceLost(*state);
   }
 }
 
@@ -319,28 +322,28 @@ bool GeodeDevice::pollSuspending(bool wait) const {
   return device_.poll(wait, nullptr);
 }
 
+namespace {
+
+/// Log the cause of a device loss. Called only by the declaring caller, so the
+/// line appears exactly once per device.
+void LogDeclaredDeviceLoss(const char* reason) {
+  std::fprintf(stderr, "[Geode] Device declared lost: %s\n", reason ? reason : "(no reason)");
+}
+
+}  // namespace
+
 void GeodeDevice::markDeviceLost(const char* reason) const {
-  if (!lostState_->lost.exchange(true, std::memory_order_acq_rel)) {
-    std::fprintf(stderr, "[Geode] Device declared lost: %s\n", reason ? reason : "(no reason)");
+  if (DeclareDeviceLost(*lostState_)) {
+    LogDeclaredDeviceLoss(reason);
   }
 }
 
 void GeodeDevice::markDeviceLostAfterWaitTimeout(GpuWaitSite site,
                                                  std::chrono::milliseconds elapsed,
                                                  const char* reason) const {
-  if (lostState_->lost.load(std::memory_order_acquire)) {
-    // Keep the first attribution. Once the device is hung, every later
-    // bounded wait against it expires too, and overwriting would replace the
-    // wait that found the hang with one that merely inherited it.
-    return;
+  if (DeclareDeviceLostAfterWaitTimeout(*lostState_, site, elapsed)) {
+    LogDeclaredDeviceLoss(reason);
   }
-  // Publish the attribution before the flag so an observer that sees `lost`
-  // also sees a populated site. Two waits expiring at once can both pass the
-  // check above and race here; either store is a real timeout attribution, so
-  // the race is benign and `markDeviceLost` still logs exactly once.
-  lostState_->timedOutSite.store(site, std::memory_order_relaxed);
-  lostState_->timedOutElapsedMs.store(static_cast<int>(elapsed.count()), std::memory_order_relaxed);
-  markDeviceLost(reason);
 }
 
 GpuWaitResult GeodeDevice::waitForQueueIdle(std::chrono::milliseconds timeout) const {
@@ -360,9 +363,16 @@ GpuWaitResult GeodeDevice::waitForQueueIdle(std::chrono::milliseconds timeout) c
   pollSuspending(true);
   return GpuWaitResult::Complete;
 #else
+  const auto queueWaitStart = std::chrono::steady_clock::now();
   const GpuWaitResult result = BoundedGpuWait([this] { return pollSuspending(false); }, timeout);
   if (result == GpuWaitResult::TimedOut) {
-    markDeviceLostAfterWaitTimeout(GpuWaitSite::QueueIdle, timeout,
+    // Report the wait that actually ran, not the budget it was given: the
+    // budget is a constant the reader already knows, while the measurement
+    // says whether the deadline was reached on schedule or the loop itself
+    // overran under load.
+    markDeviceLostAfterWaitTimeout(GpuWaitSite::QueueIdle,
+                                   std::chrono::duration_cast<std::chrono::milliseconds>(
+                                       std::chrono::steady_clock::now() - queueWaitStart),
                                    "GPU queue did not go idle within the bounded wait deadline");
   }
   return result;
@@ -386,7 +396,9 @@ GeodeDevice::ReadbackStats GeodeDevice::consumeReadbackStats() {
       // clearing it here would let the very next stats read claim the device
       // is healthy while rendering stays dead.
       .deviceLost = isDeviceLost(),
-      .timedOutWaitSite = lostState_->timedOutSite.load(std::memory_order_relaxed),
+      // Acquire on the site pairs with its release store, so a non-empty site
+      // guarantees the elapsed time written before it is visible too.
+      .timedOutWaitSite = lostState_->timedOutSite.load(std::memory_order_acquire),
       .timedOutWaitMs = lostState_->timedOutElapsedMs.load(std::memory_order_relaxed),
   };
 }

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -339,8 +339,7 @@ void GeodeDevice::markDeviceLostAfterWaitTimeout(GpuWaitSite site,
   // check above and race here; either store is a real timeout attribution, so
   // the race is benign and `markDeviceLost` still logs exactly once.
   lostState_->timedOutSite.store(site, std::memory_order_relaxed);
-  lostState_->timedOutElapsedMs.store(static_cast<int>(elapsed.count()),
-                                      std::memory_order_relaxed);
+  lostState_->timedOutElapsedMs.store(static_cast<int>(elapsed.count()), std::memory_order_relaxed);
   markDeviceLost(reason);
 }
 
@@ -363,9 +362,8 @@ GpuWaitResult GeodeDevice::waitForQueueIdle(std::chrono::milliseconds timeout) c
 #else
   const GpuWaitResult result = BoundedGpuWait([this] { return pollSuspending(false); }, timeout);
   if (result == GpuWaitResult::TimedOut) {
-    markDeviceLostAfterWaitTimeout(
-        GpuWaitSite::QueueIdle, timeout,
-        "GPU queue did not go idle within the bounded wait deadline");
+    markDeviceLostAfterWaitTimeout(GpuWaitSite::QueueIdle, timeout,
+                                   "GPU queue did not go idle within the bounded wait deadline");
   }
   return result;
 #endif

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -325,6 +325,25 @@ void GeodeDevice::markDeviceLost(const char* reason) const {
   }
 }
 
+void GeodeDevice::markDeviceLostAfterWaitTimeout(GpuWaitSite site,
+                                                 std::chrono::milliseconds elapsed,
+                                                 const char* reason) const {
+  if (lostState_->lost.load(std::memory_order_acquire)) {
+    // Keep the first attribution. Once the device is hung, every later
+    // bounded wait against it expires too, and overwriting would replace the
+    // wait that found the hang with one that merely inherited it.
+    return;
+  }
+  // Publish the attribution before the flag so an observer that sees `lost`
+  // also sees a populated site. Two waits expiring at once can both pass the
+  // check above and race here; either store is a real timeout attribution, so
+  // the race is benign and `markDeviceLost` still logs exactly once.
+  lostState_->timedOutSite.store(site, std::memory_order_relaxed);
+  lostState_->timedOutElapsedMs.store(static_cast<int>(elapsed.count()),
+                                      std::memory_order_relaxed);
+  markDeviceLost(reason);
+}
+
 GpuWaitResult GeodeDevice::waitForQueueIdle(std::chrono::milliseconds timeout) const {
   if (isDeviceLost()) {
     return GpuWaitResult::DeviceLost;
@@ -344,7 +363,9 @@ GpuWaitResult GeodeDevice::waitForQueueIdle(std::chrono::milliseconds timeout) c
 #else
   const GpuWaitResult result = BoundedGpuWait([this] { return pollSuspending(false); }, timeout);
   if (result == GpuWaitResult::TimedOut) {
-    markDeviceLost("GPU queue did not go idle within the bounded wait deadline");
+    markDeviceLostAfterWaitTimeout(
+        GpuWaitSite::QueueIdle, timeout,
+        "GPU queue did not go idle within the bounded wait deadline");
   }
   return result;
 #endif
@@ -363,6 +384,12 @@ GeodeDevice::ReadbackStats GeodeDevice::consumeReadbackStats() {
       .count = readbackCount_.exchange(0, std::memory_order_relaxed),
       .pollIterations = readbackPollIterations_.exchange(0, std::memory_order_relaxed),
       .usedTimedWaitAny = readbackUsedTimedWaitAny_.exchange(false, std::memory_order_relaxed),
+      // Device loss is reported, not consumed: it is sticky on the device, so
+      // clearing it here would let the very next stats read claim the device
+      // is healthy while rendering stays dead.
+      .deviceLost = isDeviceLost(),
+      .timedOutWaitSite = lostState_->timedOutSite.load(std::memory_order_relaxed),
+      .timedOutWaitMs = lostState_->timedOutElapsedMs.load(std::memory_order_relaxed),
   };
 }
 

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -265,9 +265,10 @@ public:
    *
    * Prefer this over \ref markDeviceLost at every deadline: the attribution is
    * what turns "rendering stopped" into a diagnosable report, and it is only
-   * available at the wait site. Loss stays sticky, and the FIRST attribution
-   * wins: once a device hangs, every later bounded wait against it also times
-   * out, and those are consequences rather than the cause.
+   * available at the wait site. Loss stays sticky, and only the call that
+   * declares it records an attribution; see
+   * \ref DeclareDeviceLostAfterWaitTimeout for why that rule is what keeps a
+   * driver-reported loss from being relabelled as a wait timeout.
    *
    * @param site Which bounded wait expired.
    * @param elapsed Wall time that wait spent before giving up.

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -259,6 +259,23 @@ public:
   /// waits that discover a hang run through const accessors.
   void markDeviceLost(const char* reason) const;
 
+  /**
+   * Declare this device lost because a bounded wait exceeded its deadline,
+   * recording which wait it was and how long it actually ran.
+   *
+   * Prefer this over \ref markDeviceLost at every deadline: the attribution is
+   * what turns "rendering stopped" into a diagnosable report, and it is only
+   * available at the wait site. Loss stays sticky, and the FIRST attribution
+   * wins: once a device hangs, every later bounded wait against it also times
+   * out, and those are consequences rather than the cause.
+   *
+   * @param site Which bounded wait expired.
+   * @param elapsed Wall time that wait spent before giving up.
+   * @param reason Human-readable cause, logged once like \ref markDeviceLost.
+   */
+  void markDeviceLostAfterWaitTimeout(GpuWaitSite site, std::chrono::milliseconds elapsed,
+                                      const char* reason) const;
+
   /// Instance that created the headless device. Null for externally-owned devices.
   const wgpu::Instance& instance() const;
 
@@ -269,6 +286,14 @@ public:
     int count = 0;
     int pollIterations = 0;
     bool usedTimedWaitAny = false;
+    /// True once this device has been declared lost. Sticky, so every later
+    /// consume keeps reporting it: a frame that never rendered has no other
+    /// evidence to carry.
+    bool deviceLost = false;
+    /// Bounded wait that declared that loss, or `None`.
+    GpuWaitSite timedOutWaitSite = GpuWaitSite::None;
+    /// Wall time that wait spent before giving up, in milliseconds.
+    int timedOutWaitMs = 0;
   };
 
   /// Record one completed CPU readback from a renderer sharing this device.

--- a/donner/svg/renderer/geode/GeodeGpuWait.cc
+++ b/donner/svg/renderer/geode/GeodeGpuWait.cc
@@ -4,6 +4,26 @@
 
 namespace donner::geode {
 
+bool DeclareDeviceLost(GeodeDeviceLostState& state) {
+  return !state.lost.exchange(true, std::memory_order_acq_rel);
+}
+
+bool DeclareDeviceLostAfterWaitTimeout(GeodeDeviceLostState& state, GpuWaitSite site,
+                                       std::chrono::milliseconds elapsed) {
+  if (!DeclareDeviceLost(state)) {
+    return false;
+  }
+  // Winning the transition makes this call the only writer of the
+  // attribution, so the stores below race with nothing. Publish the elapsed
+  // time first and the site last: `timedOutSite` is what a reader tests, so
+  // releasing it last is what makes the pair observable together.
+  state.timedOutElapsedMs.store(static_cast<int>(elapsed.count()), std::memory_order_relaxed);
+  GpuWaitSite unattributed = GpuWaitSite::None;
+  state.timedOutSite.compare_exchange_strong(unattributed, site, std::memory_order_release,
+                                             std::memory_order_relaxed);
+  return true;
+}
+
 GpuWaitResult BoundedGpuWait(const std::function<bool()>& pollOnce,
                              std::chrono::milliseconds timeout,
                              std::chrono::microseconds pollInterval,

--- a/donner/svg/renderer/geode/GeodeGpuWait.h
+++ b/donner/svg/renderer/geode/GeodeGpuWait.h
@@ -90,16 +90,63 @@ enum class GpuWaitSite : std::uint8_t {
 /// flag (the `GeodeDevice`, a host embedder's device-lost callback), because
 /// WebGPU callbacks can outlive the object that registered them.
 struct GeodeDeviceLostState {
-  /// True once the device has been declared lost. Never reset.
+  /// True once the device has been declared lost. Never reset. Publish it
+  /// only through \ref DeclareDeviceLost or
+  /// \ref DeclareDeviceLostAfterWaitTimeout, never by storing directly: the
+  /// declaring call is what decides the attribution below, and a direct store
+  /// silently opts out of that decision.
   std::atomic<bool> lost{false};
   /// Bounded wait that declared the loss, or `None` when the driver reported
-  /// it. Written just before the first `lost` store, so an observer that sees
-  /// the flag also sees the attribution that explains it.
+  /// it. Only the call that wins the `lost` transition writes this, so an
+  /// empty site is a positive statement ("no deadline expired first"), not an
+  /// unwritten field.
+  ///
+  /// Written just after `lost`, so a reader sampling between the two sees a
+  /// lost device with an empty site for the width of two stores. That reads
+  /// as a driver-reported loss, which is wrong but self-correcting: the site
+  /// settles immediately and the next sample carries it. Consumers that
+  /// publish this pair should therefore key on its value changing rather than
+  /// latching the first sample they see.
   std::atomic<GpuWaitSite> timedOutSite{GpuWaitSite::None};
   /// Wall time the timed-out wait spent before giving up, in milliseconds.
-  /// Zero while `timedOutSite` is `None`.
+  /// Written before `timedOutSite`, which publishes it, so a reader that sees
+  /// a site also sees that site's elapsed time. Zero while `timedOutSite` is
+  /// `None`.
   std::atomic<int> timedOutElapsedMs{0};
 };
+
+/**
+ * Declare @p state lost with no wait to attribute it to.
+ *
+ * For losses the driver reports: there is no deadline behind them, so
+ * `timedOutSite` stays `None` and says exactly that.
+ *
+ * @return True when this call performed the false-to-true transition, so a
+ *   caller can log the cause exactly once.
+ */
+bool DeclareDeviceLost(GeodeDeviceLostState& state);
+
+/**
+ * Declare @p state lost because a bounded wait at @p site exceeded its
+ * deadline after @p elapsed.
+ *
+ * The attribution is written only when this call is the one that declares the
+ * loss. Two other writers reach the same flag and neither may claim the site:
+ * a later bounded wait, which expires because the device is ALREADY hung (a
+ * consequence of the loss, never its cause), and the driver's device-lost
+ * callback, which has no wait to name. Deriving the claim from the flag's own
+ * transition covers both without a check-then-set window - reading the flag
+ * and then storing the site would let a driver-reported loss landing in
+ * between be relabelled as a wait timeout, which is the one misattribution an
+ * empty site exists to rule out.
+ *
+ * @param state Shared device-lost record.
+ * @param site Which bounded wait expired.
+ * @param elapsed Wall time that wait spent before giving up.
+ * @return True when this call performed the false-to-true transition.
+ */
+bool DeclareDeviceLostAfterWaitTimeout(GeodeDeviceLostState& state, GpuWaitSite site,
+                                       std::chrono::milliseconds elapsed);
 
 /**
  * Repeatedly invoke @p pollOnce until it returns true or @p timeout expires.

--- a/donner/svg/renderer/geode/GeodeGpuWait.h
+++ b/donner/svg/renderer/geode/GeodeGpuWait.h
@@ -16,6 +16,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <functional>
 
 namespace donner::geode {
@@ -57,6 +58,24 @@ struct GpuWaitTestHooks {
   std::function<void(std::chrono::microseconds)> sleep;
 };
 
+/// Which bounded wait exceeded its deadline and declared the device lost.
+///
+/// A hung device costs the full timeout wherever it is first waited on, and
+/// the two waits have very different budgets and callers, so "the device was
+/// declared lost" is not actionable on its own: a readback-map timeout points
+/// at buffer-map delivery, a queue-drain timeout points at submitted work
+/// never retiring. Recording which one tripped keeps that distinction in the
+/// diagnostics a failure report is assembled from.
+enum class GpuWaitSite : std::uint8_t {
+  /// No bounded wait has timed out. A device lost with this site was reported
+  /// by the driver's device-lost callback, not by a deadline.
+  None,
+  /// A buffer-map wait for GPU-to-CPU readback (snapshot or surface capture).
+  ReadbackMap,
+  /// A wait for the GPU queue to drain (teardown, inter-submit serialization).
+  QueueIdle,
+};
+
 /// Shared device-lost flag.
 ///
 /// Set exactly once, from either direction, so a driver-reported device-loss
@@ -73,6 +92,13 @@ struct GpuWaitTestHooks {
 struct GeodeDeviceLostState {
   /// True once the device has been declared lost. Never reset.
   std::atomic<bool> lost{false};
+  /// Bounded wait that declared the loss, or `None` when the driver reported
+  /// it. Written just before the first `lost` store, so an observer that sees
+  /// the flag also sees the attribution that explains it.
+  std::atomic<GpuWaitSite> timedOutSite{GpuWaitSite::None};
+  /// Wall time the timed-out wait spent before giving up, in milliseconds.
+  /// Zero while `timedOutSite` is `None`.
+  std::atomic<int> timedOutElapsedMs{0};
 };
 
 /**

--- a/donner/svg/renderer/geode/tests/GeodeDevice_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeDevice_tests.cc
@@ -374,6 +374,81 @@ TEST(GeodeDeviceLost, MarkDeviceLostIsSticky) {
   EXPECT_TRUE(device->isDeviceLost());
 }
 
+/// A timeout-declared loss carries the attribution that makes it diagnosable:
+/// which bounded wait expired and how long it actually ran.
+TEST(GeodeDeviceLost, WaitTimeoutRecordsSiteAndElapsed) {
+  auto device = GeodeDevice::CreateHeadless();
+  ASSERT_NE(device, nullptr);
+
+  const GeodeDevice::ReadbackStats healthy = device->consumeReadbackStats();
+  EXPECT_FALSE(healthy.deviceLost);
+  EXPECT_EQ(healthy.timedOutWaitSite, GpuWaitSite::None);
+  EXPECT_EQ(healthy.timedOutWaitMs, 0);
+
+  device->markDeviceLostAfterWaitTimeout(GpuWaitSite::ReadbackMap, kReadbackMapTimeout,
+                                         "test-injected readback map stall");
+
+  EXPECT_TRUE(device->isDeviceLost());
+  const GeodeDevice::ReadbackStats afterTimeout = device->consumeReadbackStats();
+  EXPECT_TRUE(afterTimeout.deviceLost);
+  EXPECT_EQ(afterTimeout.timedOutWaitSite, GpuWaitSite::ReadbackMap);
+  EXPECT_EQ(afterTimeout.timedOutWaitMs, static_cast<int>(kReadbackMapTimeout.count()));
+}
+
+/// Once a device hangs, every later bounded wait against it expires too. Those
+/// are consequences, so the first attribution has to survive them or the
+/// report names whichever wait happened to run last.
+TEST(GeodeDeviceLost, FirstWaitTimeoutAttributionWins) {
+  auto device = GeodeDevice::CreateHeadless();
+  ASSERT_NE(device, nullptr);
+
+  device->markDeviceLostAfterWaitTimeout(GpuWaitSite::ReadbackMap, kReadbackMapTimeout,
+                                         "test-injected readback map stall");
+  device->markDeviceLostAfterWaitTimeout(GpuWaitSite::QueueIdle, kDefaultGpuWaitTimeout,
+                                         "test-injected follow-on queue drain stall");
+
+  const GeodeDevice::ReadbackStats stats = device->consumeReadbackStats();
+  EXPECT_EQ(stats.timedOutWaitSite, GpuWaitSite::ReadbackMap);
+  EXPECT_EQ(stats.timedOutWaitMs, static_cast<int>(kReadbackMapTimeout.count()));
+}
+
+/// A driver-reported loss has no wait to attribute it to, and must not borrow
+/// one: an empty site is how a report distinguishes "the driver told us" from
+/// "one of our deadlines expired".
+TEST(GeodeDeviceLost, DriverReportedLossHasNoWaitAttribution) {
+  auto device = GeodeDevice::CreateHeadless();
+  ASSERT_NE(device, nullptr);
+
+  device->markDeviceLost("test-injected driver-reported loss");
+
+  const GeodeDevice::ReadbackStats stats = device->consumeReadbackStats();
+  EXPECT_TRUE(stats.deviceLost);
+  EXPECT_EQ(stats.timedOutWaitSite, GpuWaitSite::None);
+  EXPECT_EQ(stats.timedOutWaitMs, 0);
+}
+
+/// The readback counters reset on every consume. The device-health fields must
+/// not, or the frame after the failure would report a healthy device while
+/// rendering stays dead.
+TEST(GeodeDeviceLost, ReadbackStatsReportLossWithoutConsumingIt) {
+  auto device = GeodeDevice::CreateHeadless();
+  ASSERT_NE(device, nullptr);
+
+  device->recordReadback(/*usedTimedWaitAny=*/true, /*pollIterations=*/7);
+  device->markDeviceLostAfterWaitTimeout(GpuWaitSite::QueueIdle, kDefaultGpuWaitTimeout,
+                                         "test-injected queue drain stall");
+
+  const GeodeDevice::ReadbackStats first = device->consumeReadbackStats();
+  EXPECT_EQ(first.count, 1);
+  EXPECT_EQ(first.pollIterations, 7);
+
+  const GeodeDevice::ReadbackStats second = device->consumeReadbackStats();
+  EXPECT_EQ(second.count, 0) << "readback counters must still be consumed";
+  EXPECT_TRUE(second.deviceLost);
+  EXPECT_EQ(second.timedOutWaitSite, GpuWaitSite::QueueIdle);
+  EXPECT_EQ(second.timedOutWaitMs, static_cast<int>(kDefaultGpuWaitTimeout.count()));
+}
+
 /// A wait against a lost device must fail fast without polling the device:
 /// the generous default timeout is seconds, so a fast return proves the
 /// short-circuit rather than a lucky quick drain.

--- a/donner/svg/renderer/geode/tests/GeodeGpuWait_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeGpuWait_tests.cc
@@ -12,7 +12,9 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <chrono>
+#include <thread>
 #include <vector>
 
 namespace donner::geode {
@@ -121,27 +123,73 @@ TEST(GeodeDeviceLostState, StartsWithNoTimeoutAttribution) {
   EXPECT_EQ(state.timedOutElapsedMs.load(), 0);
 }
 
-/// A stalled wait must hand its caller both a `TimedOut` result and an elapsed
-/// time worth reporting. Without the elapsed measurement a diagnostic consumer
-/// could only echo the configured budget back, which would be indistinguishable
-/// from a wait that never ran.
-TEST(BoundedGpuWait, StalledWaitYieldsAnElapsedTimeWorthRecording) {
-  FakeClock clock;
-  const auto waitStart = clock.current;
-  const GpuWaitResult result = BoundedGpuWait([] { return false; }, 10ms, 100us, clock.hooks());
-  const auto elapsed =
-      std::chrono::duration_cast<std::chrono::milliseconds>(clock.current - waitStart);
-
-  ASSERT_EQ(result, GpuWaitResult::TimedOut);
-
-  // Record it the way a device does when a bounded wait expires.
+/// Only the declaring call records an attribution, so a wait that expires
+/// against an already-hung device reports nothing new: it inherited the hang
+/// rather than finding it.
+TEST(GeodeDeviceLostState, OnlyTheDeclaringWaitRecordsAnAttribution) {
   GeodeDeviceLostState state;
-  state.timedOutSite.store(GpuWaitSite::ReadbackMap);
-  state.timedOutElapsedMs.store(static_cast<int>(elapsed.count()));
-  state.lost.store(true);
 
+  EXPECT_TRUE(DeclareDeviceLostAfterWaitTimeout(state, GpuWaitSite::ReadbackMap, 10000ms));
+  EXPECT_FALSE(DeclareDeviceLostAfterWaitTimeout(state, GpuWaitSite::QueueIdle, 5000ms));
+
+  EXPECT_TRUE(state.lost.load());
   EXPECT_EQ(state.timedOutSite.load(), GpuWaitSite::ReadbackMap);
-  EXPECT_EQ(state.timedOutElapsedMs.load(), 10);
+  EXPECT_EQ(state.timedOutElapsedMs.load(), 10000);
+}
+
+/// A driver-reported loss leaves the attribution empty, and a wait that
+/// expires afterwards must not fill it in: an empty site is the only way a
+/// report can say the driver declared the loss.
+TEST(GeodeDeviceLostState, ADriverLossKeepsTheAttributionEmpty) {
+  GeodeDeviceLostState state;
+
+  EXPECT_TRUE(DeclareDeviceLost(state));
+  EXPECT_FALSE(DeclareDeviceLostAfterWaitTimeout(state, GpuWaitSite::ReadbackMap, 10000ms));
+
+  EXPECT_EQ(state.timedOutSite.load(), GpuWaitSite::None);
+  EXPECT_EQ(state.timedOutElapsedMs.load(), 0);
+}
+
+/// The two declaring paths run on different threads (the driver's device-lost
+/// callback is spontaneous; bounded waits expire on whichever thread is
+/// waiting), so they race for real. Whoever wins the flag owns the
+/// attribution, and the loser must leave it alone - a check-then-set that
+/// reads the flag and then stores the site lets a driver loss landing in the
+/// gap be relabelled as a wait timeout, which this pins against by asserting
+/// the attribution always agrees with the reported winner.
+TEST(GeodeDeviceLostState, ConcurrentDriverLossAndWaitTimeoutAgreeOnOneAttribution) {
+  constexpr int kTrials = 1000;
+  for (int trial = 0; trial < kTrials; ++trial) {
+    GeodeDeviceLostState state;
+    std::atomic<bool> go{false};
+    bool driverDeclared = false;
+    bool waitDeclared = false;
+
+    std::thread driver([&] {
+      while (!go.load(std::memory_order_acquire)) {}
+      driverDeclared = DeclareDeviceLost(state);
+    });
+    std::thread waiter([&] {
+      while (!go.load(std::memory_order_acquire)) {}
+      waitDeclared = DeclareDeviceLostAfterWaitTimeout(state, GpuWaitSite::ReadbackMap, 10000ms);
+    });
+    go.store(true, std::memory_order_release);
+    driver.join();
+    waiter.join();
+
+    ASSERT_TRUE(state.lost.load());
+    ASSERT_NE(driverDeclared, waitDeclared) << "exactly one caller may declare the loss";
+    if (driverDeclared) {
+      ASSERT_EQ(state.timedOutSite.load(), GpuWaitSite::None)
+          << "a driver-reported loss was relabelled as a wait timeout (trial " << trial << ")";
+      ASSERT_EQ(state.timedOutElapsedMs.load(), 0);
+    } else {
+      ASSERT_EQ(state.timedOutSite.load(), GpuWaitSite::ReadbackMap)
+          << "the declaring wait lost its attribution (trial " << trial << ")";
+      ASSERT_EQ(state.timedOutElapsedMs.load(), 10000)
+          << "the site was published without its elapsed time (trial " << trial << ")";
+    }
+  }
 }
 
 TEST(BoundedGpuWait, ZeroPollIntervalDoesNotSleep) {

--- a/donner/svg/renderer/geode/tests/GeodeGpuWait_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeGpuWait_tests.cc
@@ -110,6 +110,40 @@ TEST(BoundedGpuWait, ZeroTimeoutPollsOnceThenTimesOut) {
   EXPECT_TRUE(clock.sleeps.empty());
 }
 
+/// A device-lost record starts with no timeout attribution, so "lost with no
+/// site" is a meaningful state: it says the driver reported the loss rather
+/// than a deadline discovering it.
+TEST(GeodeDeviceLostState, StartsWithNoTimeoutAttribution) {
+  const GeodeDeviceLostState state;
+
+  EXPECT_FALSE(state.lost.load());
+  EXPECT_EQ(state.timedOutSite.load(), GpuWaitSite::None);
+  EXPECT_EQ(state.timedOutElapsedMs.load(), 0);
+}
+
+/// A stalled wait must hand its caller both a `TimedOut` result and an elapsed
+/// time worth reporting. Without the elapsed measurement a diagnostic consumer
+/// could only echo the configured budget back, which would be indistinguishable
+/// from a wait that never ran.
+TEST(BoundedGpuWait, StalledWaitYieldsAnElapsedTimeWorthRecording) {
+  FakeClock clock;
+  const auto waitStart = clock.current;
+  const GpuWaitResult result = BoundedGpuWait([] { return false; }, 10ms, 100us, clock.hooks());
+  const auto elapsed =
+      std::chrono::duration_cast<std::chrono::milliseconds>(clock.current - waitStart);
+
+  ASSERT_EQ(result, GpuWaitResult::TimedOut);
+
+  // Record it the way a device does when a bounded wait expires.
+  GeodeDeviceLostState state;
+  state.timedOutSite.store(GpuWaitSite::ReadbackMap);
+  state.timedOutElapsedMs.store(static_cast<int>(elapsed.count()));
+  state.lost.store(true);
+
+  EXPECT_EQ(state.timedOutSite.load(), GpuWaitSite::ReadbackMap);
+  EXPECT_EQ(state.timedOutElapsedMs.load(), 10);
+}
+
 TEST(BoundedGpuWait, ZeroPollIntervalDoesNotSleep) {
   FakeClock clock;
   int pollCount = 0;

--- a/donner/svg/renderer/geode/tests/GeodeSnapshotReadback_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeSnapshotReadback_tests.cc
@@ -184,8 +184,7 @@ TEST_F(GeodeSnapshotReadbackTest, ReadbackStatsCarryWaitTimeoutAttribution) {
   const RendererReadbackStats afterTimeout = renderer.consumeReadbackStats();
   EXPECT_TRUE(afterTimeout.deviceLost);
   EXPECT_EQ(afterTimeout.timedOutWaitSite, GpuWaitTimeoutSite::ReadbackMap);
-  EXPECT_EQ(afterTimeout.timedOutWaitMs,
-            static_cast<int>(geode::kReadbackMapTimeout.count()));
+  EXPECT_EQ(afterTimeout.timedOutWaitMs, static_cast<int>(geode::kReadbackMapTimeout.count()));
 
   const RendererReadbackStats laterFrame = renderer.consumeReadbackStats();
   EXPECT_TRUE(laterFrame.deviceLost);

--- a/donner/svg/renderer/geode/tests/GeodeSnapshotReadback_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeodeSnapshotReadback_tests.cc
@@ -163,5 +163,52 @@ TEST_F(GeodeSnapshotReadbackTest, RendererGeodeReportsDeviceLost) {
   // completing at all (under the suite timeout) pins that.
 }
 
+/// The renderer's readback stats are the only channel a frame that produced
+/// nothing has left, so they must carry the device-lost outcome and the
+/// attribution of the bounded wait that declared it, translated into the
+/// backend-neutral vocabulary.
+TEST_F(GeodeSnapshotReadbackTest, ReadbackStatsCarryWaitTimeoutAttribution) {
+  std::shared_ptr<geode::GeodeDevice> device(geode::GeodeDevice::CreateHeadless());
+  ASSERT_NE(device, nullptr);
+
+  RendererGeode renderer(device);
+  const RendererReadbackStats healthy = renderer.consumeReadbackStats();
+  EXPECT_FALSE(healthy.deviceLost);
+  EXPECT_EQ(healthy.timedOutWaitSite, GpuWaitTimeoutSite::None);
+  EXPECT_EQ(healthy.timedOutWaitMs, 0);
+
+  device->markDeviceLostAfterWaitTimeout(geode::GpuWaitSite::ReadbackMap,
+                                         geode::kReadbackMapTimeout,
+                                         "test-injected readback map stall");
+
+  const RendererReadbackStats afterTimeout = renderer.consumeReadbackStats();
+  EXPECT_TRUE(afterTimeout.deviceLost);
+  EXPECT_EQ(afterTimeout.timedOutWaitSite, GpuWaitTimeoutSite::ReadbackMap);
+  EXPECT_EQ(afterTimeout.timedOutWaitMs,
+            static_cast<int>(geode::kReadbackMapTimeout.count()));
+
+  const RendererReadbackStats laterFrame = renderer.consumeReadbackStats();
+  EXPECT_TRUE(laterFrame.deviceLost);
+  EXPECT_EQ(laterFrame.timedOutWaitSite, GpuWaitTimeoutSite::ReadbackMap);
+}
+
+/// A queue-drain stall must be reported as a different wait than a readback
+/// map stall. The two have different budgets and different callers, so a
+/// report that collapsed them would point at the wrong subsystem.
+TEST_F(GeodeSnapshotReadbackTest, QueueIdleTimeoutIsReportedAsItsOwnWaitSite) {
+  std::shared_ptr<geode::GeodeDevice> device(geode::GeodeDevice::CreateHeadless());
+  ASSERT_NE(device, nullptr);
+
+  RendererGeode renderer(device);
+  device->markDeviceLostAfterWaitTimeout(geode::GpuWaitSite::QueueIdle,
+                                         geode::kDefaultGpuWaitTimeout,
+                                         "test-injected queue drain stall");
+
+  const RendererReadbackStats stats = renderer.consumeReadbackStats();
+  EXPECT_TRUE(stats.deviceLost);
+  EXPECT_EQ(stats.timedOutWaitSite, GpuWaitTimeoutSite::QueueIdle);
+  EXPECT_EQ(stats.timedOutWaitMs, static_cast<int>(geode::kDefaultGpuWaitTimeout.count()));
+}
+
 }  // namespace
 }  // namespace donner::svg


### PR DESCRIPTION
A rare browser-lane failure presents as the wasm render worker publishing nothing for 12+ seconds on a document it renders in ~250ms, with the worker stats object entirely absent afterward - undiagnosable from CI logs. The suspected mechanism is a stalled GPU readback map burning its bounded timeout and declaring device loss past the harness poll window. This change makes that outcome self-identifying, with no change to any wait's duration, retry, or failure handling (detection and surfacing only, per the renderer's GPU robustness scope).

What it adds:

- The worker stats object gains `deviceLost`, `gpuWaitTimeoutSite` (`none` / `readback-map` / `queue-idle` / `unknown`), `gpuWaitTimeoutMs` (measured elapsed, not the configured budget), and `publishReason` (`render-result` / `gpu-wait-failure`), and the stats are published even when no frame ever completes. A failure publish clears `presentedAtMs`, preserving the documented fresh-stats invariant the presentation-time pairing relies on.
- Device-loss attribution has a single authority: both declaring paths (driver-reported loss and deadline-declared timeout) route through one compare-exchange transition, so a driver-reported loss can never be relabelled as a wait timeout by a racing deadline. A 1000-trial concurrency test pins this and fails against the previous check-then-set.
- The bounded-wait sites all report measured elapsed time; an unmapped wait site publishes as `unknown` rather than masquerading as a driver-reported loss.
- The browser presentation suite's worker-readiness gates go through one helper whose assertion prints the full received health object on failure (matcher choice pinned by a test - the terser matcher provably printed only the matched key, which would have defeated the purpose), so the next occurrence of the flake prints one line that decides between a stalled readback, a lost device, and a worker that genuinely published nothing.

Tests: attribution, first-attribution-wins under a 1000-trial race, driver-loss site neutrality, sticky loss reported-not-consumed, the failure publisher's position before the early poll return, the abandoned-frame path, generation dedup (repeated identical loss publishes once), and the fresh-stats deletion - each verified to fail under the corresponding sabotage. Full geode device/wait/readback targets green on a real discrete GPU, node worker lane 27/27, wasm package builds with the new publishers confirmed present in the emitted module, and the browser lane's outcome set is byte-identical to main on the same host.
