### PR TITLE
perf: Compose isolated-effect layers from their cached bitmaps

### DIFF
--- a/donner/svg/compositor/CompositorController.cc
+++ b/donner/svg/compositor/CompositorController.cc
@@ -2218,7 +2218,7 @@ void CompositorController::refreshLayerMetadata() {
 
     if (registry.all_of<components::RenderingInstanceComponent>(layer.entity())) {
       const auto& instance = registry.get<components::RenderingInstanceComponent>(layer.entity());
-      layer.setFallbackReasons(detectFallbackReasons(instance));
+      layer.setFallbackReasons(detectFallbackReasons(registry, instance));
     } else {
       layer.setFallbackReasons(FallbackReason::None);
     }
@@ -2265,7 +2265,7 @@ void CompositorController::reconcileLayers(Registry& registry) {
 
     if (registry.all_of<components::RenderingInstanceComponent>(entity)) {
       const auto& instance = registry.get<components::RenderingInstanceComponent>(entity);
-      layers_.back().setFallbackReasons(detectFallbackReasons(instance));
+      layers_.back().setFallbackReasons(detectFallbackReasons(registry, instance));
     }
 
     // A layer-set change is handled by `resyncSegmentsToLayerSet`, which
@@ -2419,15 +2419,37 @@ void CompositorController::propagateFastPathDeltaToSubtree(
 }
 
 FallbackReason CompositorController::detectFallbackReasons(
-    const components::RenderingInstanceComponent& instance) {
+    Registry& registry, const components::RenderingInstanceComponent& instance) {
   FallbackReason reasons = FallbackReason::None;
 
-  // Isolated layers (opacity < 1, isolation groups) interact with the backdrop.
+  // Isolated layers (opacity < 1, isolation groups). The layer's offscreen
+  // rasterization pushes the isolated layer itself, so the cached bitmap
+  // already holds the group composited against transparency with its opacity
+  // applied, and constant opacity on a premultiplied raster commutes with
+  // source-over. The flag is informational for such layers; only a
+  // non-normal blend mode (below) genuinely needs the live backdrop.
   if (instance.isolatedLayer) {
     reasons |= FallbackReason::IsolatedLayer;
   }
 
-  // Filters may reference BackgroundImage or other backdrop-dependent inputs.
+  // A non-normal mix-blend-mode reads the backdrop at blend time, which a
+  // cached source-over blit cannot reproduce, so these layers must render
+  // directly into the composed frame in paint order. The computed style can
+  // be absent here: attribute mutation removes ComputedStyleComponent while
+  // the RenderingInstanceComponent survives until the next prepare, and
+  // promotion (and the reconcile inside renderFrame) runs before that
+  // prepare. Fail closed in that window - claim the blend bit so an unknown
+  // style direct-composes; refreshLayerMetadata re-derives the reasons from
+  // the fresh style immediately after the prepare in the same frame.
+  const auto* style = instance.styleHandle(registry).try_get<components::ComputedStyleComponent>();
+  if (style == nullptr || !style->properties.has_value() ||
+      style->properties->mixBlendMode.get().value() != MixBlendMode::Normal) {
+    reasons |= FallbackReason::BlendMode;
+  }
+
+  // Filter roots are tracked for promotion and diagnostics; the filter
+  // itself renders into the layer's cached bitmap, so the bit does not
+  // force direct compose.
   if (instance.resolvedFilter.has_value()) {
     reasons |= FallbackReason::Filter;
   }

--- a/donner/svg/compositor/CompositorController.h
+++ b/donner/svg/compositor/CompositorController.h
@@ -1172,8 +1172,10 @@ private:
   static std::pair<Entity, Entity> computeEntityRange(Registry& registry, Entity entity);
 
   /// Inspect a RenderingInstanceComponent and return which fallback reasons apply.
+  /// The registry is needed to reach the instance's computed style, which is
+  /// where mix-blend-mode lives.
   static FallbackReason detectFallbackReasons(
-      const components::RenderingInstanceComponent& instance);
+      Registry& registry, const components::RenderingInstanceComponent& instance);
 
   /// Fast-path helper: a promoted subtree layer's root just moved by a
   /// world-space delta (translation, scale, or rotation). Descendants' local

--- a/donner/svg/compositor/CompositorControllerInternal.cc
+++ b/donner/svg/compositor/CompositorControllerInternal.cc
@@ -480,9 +480,25 @@ double EstimateStaticSpanRasterizeMs(int estimatedDrawOps, int estimatedPathVerb
 }
 
 bool ShouldDirectComposeLayer(const CompositorLayer& layer) {
+  // Immediate layers re-render by explicit plan. External paint references
+  // may resolve against elements outside the promoted subtree, so their
+  // cached raster cannot be trusted across mutations. A non-normal
+  // mix-blend-mode must read the live backdrop at blend time, which a
+  // source-over blit cannot reproduce.
+  //
+  // Plain isolated layers (group opacity, isolation: isolate) are NOT in
+  // this list: their offscreen rasterization pushes the isolated layer
+  // itself, so the cached bitmap already holds the group composited against
+  // transparency with its opacity applied, and blitting that premultiplied
+  // raster source-over is exactly the group-opacity compositing model. They
+  // previously direct-composed here, which re-rendered the whole subtree
+  // (including any filters inside it) every composed frame. During a rotate
+  // or scale drag, composeLayers re-adds isolated-effect layers to the
+  // direct path so an already-rasterized payload is never resampled through
+  // a non-translation affine.
   return layer.isImmediate() ||
-         (layer.fallbackReasons() &
-          (FallbackReason::ExternalPaint | FallbackReason::IsolatedLayer)) != FallbackReason::None;
+         (layer.fallbackReasons() & (FallbackReason::ExternalPaint | FallbackReason::BlendMode)) !=
+             FallbackReason::None;
 }
 
 double ImmediateStaticSpanBudgetMs() {

--- a/donner/svg/compositor/CompositorControllerRasterize.cc
+++ b/donner/svg/compositor/CompositorControllerRasterize.cc
@@ -949,8 +949,19 @@ void CompositorController::composeLayers(const RenderViewport& viewport,
     // moves `canvasFromBitmap`. Direct-drawing that layer can reproduce its old pixels in the
     // flattened frame, so translate the retained payload below. Scale and rotation keep the
     // established direct-render path, which avoids resampling differences from transforming an
-    // already-rasterized payload.
-    const bool shouldDirectComposeLayer = ShouldDirectComposeLayer(layer);
+    // already-rasterized payload. That resampling guarantee is preserved for isolated-effect
+    // layers too: they compose from their cached bitmap when the bitmap sits at its rendered
+    // transform, but a rotate or scale drag re-renders them rather than resampling the payload
+    // through a non-translation affine.
+    // isTranslation() is true for identity, so one predicate covers both
+    // at-rest cases.
+    const bool nonTranslationTransform = !layer.canvasFromBitmap().isTranslation();
+    const bool resampleSensitiveEffect =
+        (layer.fallbackReasons() & (FallbackReason::Filter | FallbackReason::ClipPath |
+                                    FallbackReason::Mask | FallbackReason::IsolatedLayer)) !=
+        FallbackReason::None;
+    const bool shouldDirectComposeLayer =
+        ShouldDirectComposeLayer(layer) || (nonTranslationTransform && resampleSensitiveEffect);
     const bool blitRetainedTranslation = shouldDirectComposeLayer &&
                                          !layer.canvasFromBitmap().isIdentity() &&
                                          layer.canvasFromBitmap().isTranslation();

--- a/donner/svg/compositor/CompositorController_tests.cc
+++ b/donner/svg/compositor/CompositorController_tests.cc
@@ -847,6 +847,42 @@ TEST_F(CompositorControllerTest, OpacityTriggersFallback) {
             FallbackReason::None);
 }
 
+// Attribute mutation removes ComputedStyleComponent while the stale
+// RenderingInstanceComponent survives until the next prepare, and promotion
+// (plus the reconcile at the top of renderFrame) runs before that prepare.
+// Fallback detection must tolerate the absent style, and it fails closed:
+// an unknown style claims the blend bit so the layer direct-composes until
+// the post-prepare metadata refresh re-derives the truth.
+TEST_F(CompositorControllerTest, PromoteAfterAttributeMutationFailsClosedWithoutCrashing) {
+  SVGDocument document = makeDocument(R"svg(
+    <rect id="target" width="10" height="10" fill="red" opacity="0.5" />
+  )svg");
+
+  ParseWarningSink warningSink;
+  RendererUtils::prepareDocumentForRendering(document, /*verbose=*/false, warningSink);
+
+  auto target = document.querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  const Entity entity = target->unsafeEntityHandle().entity();
+
+  // Removes the computed style; the rendering instance survives.
+  target->setAttribute("opacity", "0.4");
+
+  CompositorController compositor(document, renderer_);
+  ASSERT_TRUE(compositor.promoteEntity(entity));
+  EXPECT_NE(compositor.fallbackReasonsOf(entity) & FallbackReason::BlendMode, FallbackReason::None);
+
+  // A rendered frame re-prepares the document and re-derives the real
+  // reasons: plain opacity is not a blend, so the conservative bit clears.
+  RenderViewport viewport;
+  viewport.size = Vector2d(20, 20);
+  viewport.devicePixelRatio = 1.0;
+  compositor.renderFrame(viewport);
+  EXPECT_EQ(compositor.fallbackReasonsOf(entity) & FallbackReason::BlendMode, FallbackReason::None);
+  EXPECT_NE(compositor.fallbackReasonsOf(entity) & FallbackReason::IsolatedLayer,
+            FallbackReason::None);
+}
+
 TEST_F(CompositorControllerTest, GradientFillTriggersFallback) {
   SVGDocument document = makeDocument(R"svg(
     <defs>

--- a/donner/svg/compositor/CompositorGolden_tests.cc
+++ b/donner/svg/compositor/CompositorGolden_tests.cc
@@ -1200,9 +1200,131 @@ TEST_F(CompositorGoldenTest, GaussianBlurredShapeMatchesFullRenderAfterPromotion
   // Blur produces semi-transparent edge pixels over a wide radius; the tolerance
   // here is looser than the identity-composition cases because the blur kernel
   // itself has sub-pixel variation and the unpremul round-trip may amplify it.
+  // The compose path blits the layer's cached bitmap rather than re-rendering
+  // the filter into the frame, which adds one 8-bit quantization boundary
+  // (filter output -> premultiplied bitmap -> blit), spreading off-by-one
+  // channel values across the blur skirt. Observed: about 2.8% of pixels at a
+  // channel diff of exactly 1.
   EXPECT_LE(result.maxChannelDiff, 3) << result;
-  EXPECT_LE(result.mismatchCount, result.totalPixels / 50u)  // 2%
+  EXPECT_LE(result.mismatchCount, result.totalPixels / 25u)  // 4%
       << "blurred shape should match full-render within AA tolerance: " << result;
+}
+
+// A group with opacity composes from its cached layer bitmap instead of
+// re-rendering the subtree every composed frame. The cached bitmap is correct
+// by construction: layer rasterization pushes the isolated layer itself, so
+// the bitmap holds the children composited against transparency with the
+// group opacity applied, and blitting that premultiplied raster source-over
+// is exactly the group-opacity compositing model. The overlapping children
+// make this discriminating: re-rendering them with per-child opacity instead
+// would double-darken the overlap.
+TEST_F(CompositorGoldenTest, OpacityGroupComposesFromCachedBitmapWithoutRerender) {
+  // Two dozen small overlapping rects keep the immediate-plan economics on
+  // the cached side (many draw ops, small covered area) without pulling in a
+  // filter, whose mandatory promotion hint would split the group into two
+  // layers and defeat the point of the test.
+  std::string rects;
+  for (int i = 0; i < 24; ++i) {
+    const int x = 20 + (i % 8) * 8;
+    const int y = 24 + (i / 8) * 10;
+    rects += "<rect x=\"" + std::to_string(x) + "\" y=\"" + std::to_string(y) +
+             "\" width=\"20\" height=\"16\" fill=\"" + (i % 2 == 0 ? "red" : "blue") + "\"/>";
+  }
+  // No background content: static segments stay empty, so the immediate
+  // rasterize accumulator below measures only this layer's compose behavior
+  // (cheap static spans legitimately direct-render and would otherwise
+  // contribute a few tenths of a millisecond of their own).
+  SVGDocument document = parseDocument(R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
+      <g id="target" opacity="0.6">)svg" +
+                                       rects + R"svg(</g>
+    </svg>
+  )svg");
+
+  auto target = document.querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  const Entity entity = target->unsafeEntityHandle().entity();
+
+  // No explicit promotion: the opacity group auto-promotes as a mandatory
+  // layer. An explicitly promoted entity would carry an interaction hint,
+  // which legitimately opts cheap layers into direct compose for drag
+  // latency; the steady-state document case is the one this test pins.
+  CompositorController compositor(document, renderer_);
+
+  DualPathVerifier verifier(compositor, renderer_);
+  const auto result = verifier.renderAndVerify(viewport_);
+
+  EXPECT_NE(compositor.fallbackReasonsOf(entity) & FallbackReason::IsolatedLayer,
+            FallbackReason::None);
+  EXPECT_EQ(compositor.fallbackReasonsOf(entity) & FallbackReason::BlendMode, FallbackReason::None);
+  // A zero here proves the compose blitted the cached bitmap rather than
+  // direct-rendering the subtree every composed frame.
+  EXPECT_EQ(compositor.lastRenderFrameStats().immediateRasterizeMs, 0.0);
+  EXPECT_LE(result.maxChannelDiff, 1) << result;
+
+  const auto second = verifier.renderAndVerify(viewport_);
+  EXPECT_EQ(compositor.lastRenderFrameStats().immediateRasterizeMs, 0.0);
+  EXPECT_LE(second.maxChannelDiff, 1) << second;
+}
+
+// A non-normal mix-blend-mode reads the live backdrop at blend time, which a
+// cached source-over blit cannot reproduce, so such a layer must keep
+// rendering directly into the composed frame in paint order.
+TEST_F(CompositorGoldenTest, BlendModeGroupStillComposesDirectly) {
+  SVGDocument document = parseDocument(R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
+      <rect width="200" height="100" fill="white"/>
+      <rect x="10" y="10" width="120" height="60" fill="orange"/>
+      <g id="target" style="mix-blend-mode: multiply">
+        <rect x="40" y="20" width="80" height="50" fill="skyblue"/>
+      </g>
+    </svg>
+  )svg");
+
+  auto target = document.querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  const Entity entity = target->unsafeEntityHandle().entity();
+
+  CompositorController compositor(document, renderer_);
+  ASSERT_TRUE(compositor.promoteEntity(entity));
+
+  DualPathVerifier verifier(compositor, renderer_);
+  const auto result = verifier.renderAndVerify(viewport_);
+
+  EXPECT_NE(compositor.fallbackReasonsOf(entity) & FallbackReason::BlendMode, FallbackReason::None);
+  // Direct compose accrues immediate-rasterize time; a zero would mean the
+  // blend group was blitted source-over, silently dropping the blend.
+  EXPECT_GT(compositor.lastRenderFrameStats().immediateRasterizeMs, 0.0);
+  EXPECT_TRUE(result.isExact()) << result;
+}
+
+// Changing the group's opacity re-rasterizes the layer: the opacity is baked
+// into the cached bitmap, so a stale bitmap would keep composing the old
+// value. The second verification against the full render catches that.
+TEST_F(CompositorGoldenTest, OpacityChangeRefreshesTheComposedResult) {
+  SVGDocument document = parseDocument(R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
+      <rect width="200" height="100" fill="white"/>
+      <g id="target" opacity="0.5">
+        <rect x="20" y="20" width="60" height="40" fill="red"/>
+        <rect x="50" y="30" width="60" height="40" fill="blue"/>
+      </g>
+    </svg>
+  )svg");
+
+  auto target = document.querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+
+  CompositorController compositor(document, renderer_);
+  ASSERT_TRUE(compositor.promoteEntity(target->unsafeEntityHandle().entity()));
+
+  DualPathVerifier verifier(compositor, renderer_);
+  const auto before = verifier.renderAndVerify(viewport_);
+  EXPECT_LE(before.maxChannelDiff, 1) << before;
+
+  target->setAttribute("opacity", "0.9");
+  const auto after = verifier.renderAndVerify(viewport_);
+  EXPECT_LE(after.maxChannelDiff, 1) << after;
 }
 
 // Regression variant: the blurred shape is dragged (composition transform set

--- a/donner/svg/compositor/CompositorLayer.h
+++ b/donner/svg/compositor/CompositorLayer.h
@@ -43,7 +43,12 @@ enum class FallbackReason : uint16_t {
   /// Entity has a paint server (gradient/pattern) referencing external elements.
   ExternalPaint = 1 << 5,
 
-  /// Entity establishes an isolation group (opacity < 1 composed with siblings).
+  /// Entity establishes an isolation group (opacity, filter, clip-path,
+  /// mask, blend, or isolation: isolate). Informational: the cached layer
+  /// bitmap holds the isolated result, so this bit alone does not force
+  /// direct compose (a non-normal blend mode does, via BlendMode). During a
+  /// rotate or scale drag such layers still direct-render to avoid
+  /// resampling an already-rasterized payload.
   IsolatedLayer = 1 << 6,
 };
 


### PR DESCRIPTION
Layers whose root sets the isolated-layer flag - group opacity, isolation: isolate, and equally filter, clip-path, and mask roots, which all set the same flag - previously direct-rendered their whole subtree into the composed frame every composed frame, re-running any filters each time. The cached layer bitmap was already correct: layer rasterization pushes the isolated layer itself, so the bitmap holds the subtree composited against transparency with its effects and opacity applied, and constant opacity on a premultiplied raster commutes with source-over.

The direct-compose predicate now keys on what genuinely cannot be blitted: an explicit immediate plan, an external paint reference, or a non-normal mix-blend-mode, which must read the live backdrop at blend time. The mix-blend-mode fallback bit was declared but never set; fallback detection now derives it from the instance's computed style. The computed style can be legitimately absent in the mutate-then-promote window (attribute edits remove it while the rendering instance survives until the next prepare), so detection fails closed there: the bit is claimed, the layer direct-composes for that frame, and the post-prepare metadata refresh re-derives the truth.

Two deliberate behavior notes. Rotate and scale drags of isolated-effect layers keep the established direct-render path rather than resampling an already-rasterized payload through a non-translation affine. And the blurred-shape golden, previously pixel-exact, now differs by one channel level on 2.8 percent of pixels: composing the filter output through a premultiplied bitmap adds one 8-bit quantization boundary across the blur skirt; its mismatch budget widens from 2 to 4 percent with the 3-level max-channel bound unchanged.

Measured on the real splash document (same host, three interleaved runs each way, independently reproduced by review): the post-drag settle recompose drops from 206-217 ms to 70-73 ms (-66%); cold, first drag, and steady drag are unchanged within noise. A rotation-drag probe confirms the direct-render path still engages for isolated-effect layers under non-translation transforms (immediate-rasterize time back in the baseline's class).

Four new tests: an auto-promoted opacity group composes with zero immediate-rasterize cost and matches the full render (fails with the previous predicate), a mix-blend-mode group still composes directly (fails without the new bit derivation), promotion immediately after an attribute mutation fails closed without crashing (SIGSEGV without the guard), and an opacity change refreshes the composed result. Full compositor package green in both backend configurations; the broad editor and renderer surface is green in the default configuration.
