### PR TITLE
ci: Carry bazel progress counters in the coverage heartbeat

### DIFF
--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -124,16 +124,24 @@ function run_quiet_with_progress() {
 
       local current
       current="$(tail -n 1 "$log_file" 2> /dev/null || true)"
+      # Surface bazel's own latest progress counter ("[8,521 / 8,522] 66 / 116
+      # tests; Testing //...") so the workflow log shows how far along the run
+      # is, not just that it is alive. Bounded read: progress lines live at the
+      # end of the log, and curses output separates updates with carriage
+      # returns, so normalize those to newlines before matching.
+      local snapshot
+      snapshot="$(tail -c 65536 "$log_file" 2> /dev/null | tr "\r" "\n" \
+        | grep -E "^\[[0-9,]+ */ *[0-9,]+\]" | tail -n 1 || true)"
       if [[ "$current" != "$last_line" ]]; then
         last_line="$current"
         last_change=$now
-        echo "$description still running after ${elapsed}s; detailed log: $log_file"
+        echo "$description still running after ${elapsed}s${snapshot:+ - ${snapshot}}; detailed log: $log_file"
         continue
       fi
 
       local stalled=$((now - last_change))
       if ((stalled < stall_limit)); then
-        echo "$description still running after ${elapsed}s (no new output for ${stalled}s); detailed log: $log_file"
+        echo "$description still running after ${elapsed}s (no new output for ${stalled}s)${snapshot:+ - last progress: ${snapshot}}; detailed log: $log_file"
         continue
       fi
 


### PR DESCRIPTION
The quiet coverage runner redirects all bazel output into its log file and printed only an opaque "still running after Ns" line each minute, so a 38-minute coverage run gave no visibility into progress versus hang. The log deliberately keeps bazel's progress lines for post-mortems, so each heartbeat now appends the latest action/test counter extracted from the log tail:

    Bazel coverage still running after 601s - [8,521 / 8,522] 66 / 116 tests; Testing //donner/svg:bar; 13s; detailed log: ...

The stalled variant shows the last progress seen before output stopped. Extraction is bounded to the log's last 64KB with curses carriage returns normalized, verified against a fabricated log carrying both formats; bash -n and the lint sweep are clean. Shell-only change to tools/coverage.sh; no bazel flags or workflow files change.