### PR TITLE
Restore affine editor-control final-frame captures

### DIFF
--- a/donner/editor/EditorShellPresentation.cc
+++ b/donner/editor/EditorShellPresentation.cc
@@ -102,24 +102,6 @@ Box2d FramebufferBoxFromScreenBox(const Box2d& screenBox, double devicePixelRati
   return Box2d(screenBox.topLeft * devicePixelRatio, screenBox.bottomRight * devicePixelRatio);
 }
 
-std::optional<Transform2d> FramebufferFromTextureTransform(const PresentedTileQuad& tileQuad,
-                                                           const Vector2i& textureSizePx) {
-  if (textureSizePx.x <= 0 || textureSizePx.y <= 0) {
-    return std::nullopt;
-  }
-
-  const Vector2d sourceSize(static_cast<double>(textureSizePx.x),
-                            static_cast<double>(textureSizePx.y));
-  Transform2d framebufferFromTexture(Transform2d::uninitialized);
-  framebufferFromTexture.data[0] = (tileQuad.topRight.x - tileQuad.topLeft.x) / sourceSize.x;
-  framebufferFromTexture.data[1] = (tileQuad.topRight.y - tileQuad.topLeft.y) / sourceSize.x;
-  framebufferFromTexture.data[2] = (tileQuad.bottomLeft.x - tileQuad.topLeft.x) / sourceSize.y;
-  framebufferFromTexture.data[3] = (tileQuad.bottomLeft.y - tileQuad.topLeft.y) / sourceSize.y;
-  framebufferFromTexture.data[4] = tileQuad.topLeft.x;
-  framebufferFromTexture.data[5] = tileQuad.topLeft.y;
-  return framebufferFromTexture;
-}
-
 }  // namespace
 
 FrameCostBreakdown::DirectPresentation DrawDocumentPresentationToFramebuffer(
@@ -188,7 +170,7 @@ FrameCostBreakdown::DirectPresentation DrawDocumentPresentationToFramebuffer(
 
     const Vector2i textureSizePx = tile.textureSnapshot->dimensions();
     const std::optional<Transform2d> framebufferFromTexture =
-        FramebufferFromTextureTransform(*tileQuad, textureSizePx);
+        ComputePresentedOutputFromTextureTransform(*tileQuad, textureSizePx);
     if (!framebufferFromTexture.has_value()) {
       return false;
     }

--- a/donner/editor/PresentedFrameComposer.cc
+++ b/donner/editor/PresentedFrameComposer.cc
@@ -150,6 +150,27 @@ std::optional<PresentedTileQuad> ComputePresentedTileQuad(
   return quad;
 }
 
+std::optional<Transform2d> ComputePresentedOutputFromTextureTransform(
+    const PresentedTileQuad& tileQuad, const Vector2i& textureSizePx) {
+  if (!IsValidQuad(tileQuad) || textureSizePx.x <= 0 || textureSizePx.y <= 0) {
+    return std::nullopt;
+  }
+
+  const Vector2d sourceSize(static_cast<double>(textureSizePx.x),
+                            static_cast<double>(textureSizePx.y));
+  Transform2d outputFromTexture(Transform2d::uninitialized);
+  outputFromTexture.data[0] = (tileQuad.topRight.x - tileQuad.topLeft.x) / sourceSize.x;
+  outputFromTexture.data[1] = (tileQuad.topRight.y - tileQuad.topLeft.y) / sourceSize.x;
+  outputFromTexture.data[2] = (tileQuad.bottomLeft.x - tileQuad.topLeft.x) / sourceSize.y;
+  outputFromTexture.data[3] = (tileQuad.bottomLeft.y - tileQuad.topLeft.y) / sourceSize.y;
+  outputFromTexture.data[4] = tileQuad.topLeft.x;
+  outputFromTexture.data[5] = tileQuad.topLeft.y;
+  if (!IsFinite(outputFromTexture)) {
+    return std::nullopt;
+  }
+  return outputFromTexture;
+}
+
 std::optional<PresentedTileRect> ComputePresentedTileRect(
     const PresentedFrameTileGeometry& tile, const Transform2d& outputFromCanvasTransform,
     const std::optional<PresentedDragBaseline>& dragBaseline) {

--- a/donner/editor/PresentedFrameComposer.h
+++ b/donner/editor/PresentedFrameComposer.h
@@ -118,6 +118,17 @@ struct PresentedPixelRect {
     const std::optional<PresentedDragBaseline>& dragBaseline);
 
 /**
+ * Recover the affine transform that maps source texture pixels onto a presented tile quad.
+ *
+ * @param tileQuad Presented output-space tile corners.
+ * @param textureSizePx Source texture dimensions in pixels.
+ * @return Transform from texture pixels to output coordinates, or `std::nullopt` for invalid
+ *   inputs.
+ */
+[[nodiscard]] std::optional<Transform2d> ComputePresentedOutputFromTextureTransform(
+    const PresentedTileQuad& tileQuad, const Vector2i& textureSizePx);
+
+/**
  * Compute the output-space rectangle for a presented tile.
  *
  * @param tile Geometry for the tile being presented.

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -15,7 +15,10 @@ donner_cc_library(
     hdrs = ["BitmapGoldenCompare.h"],
     # //donner/gpu: the Metal vertical slice test (design 0053) uses the one
     # blessed pixelmatch comparator for its frozen-baseline comparison.
-    visibility = ["//donner/gpu/metal/tests:__pkg__"],
+    visibility = [
+        "//donner/gpu/metal/tests:__pkg__",
+        "//tools/mcp-servers/editor-control:__pkg__",
+    ],
     deps = [
         "//donner/svg/renderer:renderer_image_io",
         "//donner/svg/renderer:renderer_interface",

--- a/tools/mcp-servers/editor-control/BUILD.bazel
+++ b/tools/mcp-servers/editor-control/BUILD.bazel
@@ -91,6 +91,8 @@ donner_cc_test(
         ":editor_control_session",
         "//donner/base:base_test_utils",
         "//donner/editor/repro:repro_file",
+        "//donner/editor/tests:bitmap_golden_compare",
+        "//donner/svg/renderer",
         "@com_google_gtest//:gtest",
         "@com_google_gtest//:gtest_main",
         "@nlohmann_json//:json",

--- a/tools/mcp-servers/editor-control/EditorControlSession.h
+++ b/tools/mcp-servers/editor-control/EditorControlSession.h
@@ -144,6 +144,8 @@ private:
                                            std::string* error);
   [[nodiscard]] nlohmann::json sourceStateJson() const;
 
+public:
+  /// CPU mirror of the editor's tile presentation cache, exposed for focused composition tests.
   class HeadlessTextureCache {
   public:
     void reset();
@@ -167,6 +169,7 @@ private:
     std::vector<DisplayTileView> tiles_;
   };
 
+private:
   [[nodiscard]] bool renderCurrentFrame(std::vector<CapturedRenderResult>* results,
                                         std::string* error);
   [[nodiscard]] std::optional<svg::RendererBitmap> composeDisplayFrameBitmap(

--- a/tools/mcp-servers/editor-control/EditorControlSession.h
+++ b/tools/mcp-servers/editor-control/EditorControlSession.h
@@ -114,6 +114,7 @@ public:
   struct CapturedRenderResult {
     RenderResult renderResult;
     DisplayFrameSnapshot displayFrame;
+    std::optional<svg::RendererBitmap> presentedBitmap;
   };
 
 private:

--- a/tools/mcp-servers/editor-control/EditorControlSessionInternal.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSessionInternal.cc
@@ -128,17 +128,18 @@ std::optional<std::string> EncodeBitmapPngBase64(const svg::RendererBitmap& bitm
   return Base64Encode(png);
 }
 
-json RenderResultJson(const RenderResult& result, ToolCallResult* out,
-                      const EditorControlSession::CaptureOptions& capture,
+json RenderResultJson(const RenderResult& result, const svg::RendererBitmap* presentedBitmap,
+                      ToolCallResult* out, const EditorControlSession::CaptureOptions& capture,
                       std::string_view imagePrefix) {
+  const svg::RendererBitmap& finalBitmap = presentedBitmap ? *presentedBitmap : result.bitmap;
   json resultJson{
       {"version", result.version},
       {"worker_ms", result.workerMs},
-      {"bitmap", BitmapSummary(result.bitmap)},
+      {"bitmap", BitmapSummary(finalBitmap)},
   };
 
   if (capture.includeFinalFrame) {
-    AttachBitmapImage(out, std::string(imagePrefix) + "/final_frame", result.bitmap,
+    AttachBitmapImage(out, std::string(imagePrefix) + "/final_frame", finalBitmap,
                       capture.embedPngBase64, &resultJson["bitmap"]);
   }
 
@@ -187,7 +188,10 @@ json CapturedRenderResultJson(const EditorControlSession::CapturedRenderResult& 
                               ToolCallResult* out,
                               const EditorControlSession::CaptureOptions& capture,
                               std::string_view imagePrefix) {
-  json resultJson = RenderResultJson(captured.renderResult, out, capture, imagePrefix);
+  const svg::RendererBitmap* presentedBitmap =
+      captured.presentedBitmap.has_value() ? &*captured.presentedBitmap : nullptr;
+  json resultJson =
+      RenderResultJson(captured.renderResult, presentedBitmap, out, capture, imagePrefix);
   resultJson["display_preview"] = DisplayFrameJson(captured.displayFrame);
   return resultJson;
 }

--- a/tools/mcp-servers/editor-control/EditorControlSessionRender.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSessionRender.cc
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
-#include <limits>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -99,75 +98,6 @@ json DirtyFlagsToJson(std::uint16_t flags) {
     }
   }
   return out;
-}
-
-std::uint8_t PremultiplyChannel(std::uint8_t channel, std::uint8_t alpha,
-                                svg::AlphaType alphaType) {
-  if (alphaType == svg::AlphaType::Premultiplied) {
-    return channel;
-  }
-  return static_cast<std::uint8_t>((static_cast<int>(channel) * static_cast<int>(alpha) + 127) /
-                                   255);
-}
-
-std::uint8_t BlendChannel(std::uint8_t src, std::uint8_t dst, std::uint8_t srcAlpha) {
-  const int invAlpha = 255 - static_cast<int>(srcAlpha);
-  return static_cast<std::uint8_t>(
-      std::min(255, static_cast<int>(src) + (static_cast<int>(dst) * invAlpha + 127) / 255));
-}
-
-void BlendBitmapOver(svg::RendererBitmap* destination, const svg::RendererBitmap& source,
-                     int targetX, int targetY, int targetWidth, int targetHeight) {
-  if (destination == nullptr || destination->empty() || source.empty() || targetWidth <= 0 ||
-      targetHeight <= 0) {
-    return;
-  }
-
-  const std::size_t sourceRowBytes =
-      source.rowBytes > 0 ? source.rowBytes : static_cast<std::size_t>(source.dimensions.x) * 4;
-  const std::size_t destinationRowBytes = destination->rowBytes;
-  for (int y = 0; y < targetHeight; ++y) {
-    const int dy = targetY + y;
-    if (dy < 0 || dy >= destination->dimensions.y) {
-      continue;
-    }
-    const int sy =
-        std::clamp(static_cast<int>((static_cast<int64_t>(y) * source.dimensions.y) / targetHeight),
-                   0, source.dimensions.y - 1);
-    for (int x = 0; x < targetWidth; ++x) {
-      const int dx = targetX + x;
-      if (dx < 0 || dx >= destination->dimensions.x) {
-        continue;
-      }
-      const int sx = std::clamp(
-          static_cast<int>((static_cast<int64_t>(x) * source.dimensions.x) / targetWidth), 0,
-          source.dimensions.x - 1);
-      const std::size_t sourceIndex =
-          static_cast<std::size_t>(sy) * sourceRowBytes + static_cast<std::size_t>(sx) * 4;
-      const std::size_t destinationIndex =
-          static_cast<std::size_t>(dy) * destinationRowBytes + static_cast<std::size_t>(dx) * 4;
-      if (sourceIndex + 3 >= source.pixels.size() ||
-          destinationIndex + 3 >= destination->pixels.size()) {
-        continue;
-      }
-
-      const std::uint8_t srcAlpha = source.pixels[sourceIndex + 3];
-      const std::uint8_t srcRed =
-          PremultiplyChannel(source.pixels[sourceIndex], srcAlpha, source.alphaType);
-      const std::uint8_t srcGreen =
-          PremultiplyChannel(source.pixels[sourceIndex + 1], srcAlpha, source.alphaType);
-      const std::uint8_t srcBlue =
-          PremultiplyChannel(source.pixels[sourceIndex + 2], srcAlpha, source.alphaType);
-      destination->pixels[destinationIndex] =
-          BlendChannel(srcRed, destination->pixels[destinationIndex], srcAlpha);
-      destination->pixels[destinationIndex + 1] =
-          BlendChannel(srcGreen, destination->pixels[destinationIndex + 1], srcAlpha);
-      destination->pixels[destinationIndex + 2] =
-          BlendChannel(srcBlue, destination->pixels[destinationIndex + 2], srcAlpha);
-      destination->pixels[destinationIndex + 3] =
-          BlendChannel(srcAlpha, destination->pixels[destinationIndex + 3], srcAlpha);
-    }
-  }
 }
 
 std::string CompositeTileKindName(
@@ -306,11 +236,11 @@ std::optional<svg::RendererBitmap> EditorControlSession::HeadlessTextureCache::c
     return std::nullopt;
   }
 
-  svg::RendererBitmap composed;
-  composed.dimensions = canvasSize;
-  composed.rowBytes = static_cast<std::size_t>(canvasSize.x) * 4;
-  composed.alphaType = svg::AlphaType::Premultiplied;
-  composed.pixels.resize(static_cast<std::size_t>(canvasSize.y) * composed.rowBytes, 0);
+  svg::Renderer renderer;
+  renderer.beginFrame(svg::RenderViewport{
+      .size = Vector2d(static_cast<double>(canvasSize.x), static_cast<double>(canvasSize.y)),
+      .devicePixelRatio = 1.0,
+  });
 
   const double pixelsPerDocX = static_cast<double>(canvasSize.x) / viewBox.size().x;
   const double pixelsPerDocY = static_cast<double>(canvasSize.y) / viewBox.size().y;
@@ -325,22 +255,29 @@ std::optional<svg::RendererBitmap> EditorControlSession::HeadlessTextureCache::c
       continue;
     }
 
-    const std::optional<PresentedTileRect> tileRect = ComputePresentedTileRect(
+    const std::optional<PresentedTileQuad> tileQuad = ComputePresentedTileQuad(
         PresentedGeometryFromDisplayTile(tile), canvasPixelsFromCanvasTransform, dragBaseline);
-    if (!tileRect.has_value()) {
+    if (!tileQuad.has_value()) {
       continue;
     }
-    const std::optional<PresentedPixelRect> pixelRect =
-        RoundPresentedTileRectToPixelRect(*tileRect);
-    if (!pixelRect.has_value()) {
+    const svg::RendererBitmap& bitmap = tileIt->second.bitmap;
+    const std::optional<Transform2d> canvasPixelsFromTexture =
+        ComputePresentedOutputFromTextureTransform(*tileQuad, bitmap.dimensions);
+    if (!canvasPixelsFromTexture.has_value()) {
       continue;
     }
 
-    BlendBitmapOver(&composed, tileIt->second.bitmap, pixelRect->x, pixelRect->y, pixelRect->width,
-                    pixelRect->height);
+    renderer.setTransform(*canvasPixelsFromTexture);
+    renderer.drawBitmap(
+        bitmap, svg::ImageParams{
+                    .targetRect =
+                        Box2d(Vector2d::Zero(), Vector2d(static_cast<double>(bitmap.dimensions.x),
+                                                         static_cast<double>(bitmap.dimensions.y))),
+                });
   }
 
-  return composed;
+  renderer.endFrame();
+  return renderer.takeSnapshot();
 }
 
 ToolCallResult EditorControlSession::renderFrameTool(const json& arguments) {

--- a/tools/mcp-servers/editor-control/EditorControlSessionRender.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSessionRender.cc
@@ -559,9 +559,11 @@ bool EditorControlSession::renderCurrentFrame(std::vector<CapturedRenderResult>*
   while (std::chrono::steady_clock::now() < deadline) {
     if (auto result = asyncRenderer_.pollResult(); result.has_value()) {
       DisplayFrameSnapshot displayFrame = recordDisplayFrame(*result);
+      std::optional<svg::RendererBitmap> presentedBitmap = composeDisplayFrameBitmap(displayFrame);
       results->push_back(CapturedRenderResult{
           .renderResult = std::move(*result),
           .displayFrame = std::move(displayFrame),
+          .presentedBitmap = std::move(presentedBitmap),
       });
       // A completed render can leave a deferred first-frame cache warmup queued on the
       // worker. That warmup traverses the document from the worker thread, while the next

--- a/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
@@ -1,9 +1,12 @@
 #include "tools/mcp-servers/editor-control/EditorControlSession.h"
 
+#include <algorithm>
+#include <array>
 #include <cstdint>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <initializer_list>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -12,6 +15,8 @@
 
 #include "donner/base/tests/TestTempDir.h"
 #include "donner/editor/repro/ReproFile.h"
+#include "donner/editor/tests/BitmapGoldenCompare.h"
+#include "donner/svg/renderer/Renderer.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "nlohmann/json.hpp"
@@ -821,6 +826,109 @@ TEST(EditorControlSessionTest, TransformSelectorRotatesThroughHandleAndExposesAf
   EXPECT_NEAR(center.y, 30.0, 1e-6);
   EXPECT_NEAR(topRight.x, 40.0, 1e-6);
   EXPECT_NEAR(topRight.y, 40.0, 1e-6);
+}
+
+TEST(EditorControlSessionTest, HeadlessTileCompositionPreservesAffinePlacementAndAlpha) {
+  const auto makeBitmap = [](Vector2i dimensions, std::size_t rowBytes,
+                             std::initializer_list<std::array<std::uint8_t, 4>> pixels) {
+    svg::RendererBitmap bitmap;
+    bitmap.dimensions = dimensions;
+    bitmap.rowBytes = rowBytes;
+    bitmap.alphaType = svg::AlphaType::Unpremultiplied;
+    bitmap.pixels.resize(static_cast<std::size_t>(dimensions.y) * rowBytes, 0xa5u);
+    auto pixel = pixels.begin();
+    for (int y = 0; y < dimensions.y; ++y) {
+      for (int x = 0; x < dimensions.x; ++x, ++pixel) {
+        const std::size_t offset =
+            static_cast<std::size_t>(y) * rowBytes + static_cast<std::size_t>(x) * 4u;
+        std::copy(pixel->begin(), pixel->end(), bitmap.pixels.begin() + offset);
+      }
+    }
+    return bitmap;
+  };
+
+  const svg::RendererBitmap rotatedBitmap =
+      makeBitmap(Vector2i(2, 3), 12u,
+                 {std::array<std::uint8_t, 4>{255u, 0u, 0u, 255u},
+                  std::array<std::uint8_t, 4>{0u, 0u, 255u, 128u},
+                  std::array<std::uint8_t, 4>{255u, 255u, 0u, 255u},
+                  std::array<std::uint8_t, 4>{0u, 255u, 255u, 192u},
+                  std::array<std::uint8_t, 4>{255u, 0u, 255u, 64u},
+                  std::array<std::uint8_t, 4>{0u, 0u, 0u, 255u}});
+  const svg::RendererBitmap overlappingBitmap =
+      makeBitmap(Vector2i(2, 2), 8u,
+                 {std::array<std::uint8_t, 4>{255u, 128u, 0u, 128u},
+                  std::array<std::uint8_t, 4>{64u, 0u, 128u, 255u},
+                  std::array<std::uint8_t, 4>{0u, 255u, 0u, 96u},
+                  std::array<std::uint8_t, 4>{255u, 255u, 255u, 192u}});
+
+  Transform2d documentFromRotatedTexture(Transform2d::uninitialized);
+  documentFromRotatedTexture.data[0] = 0.0;
+  documentFromRotatedTexture.data[1] = 1.0;
+  documentFromRotatedTexture.data[2] = -1.0;
+  documentFromRotatedTexture.data[3] = 0.0;
+  documentFromRotatedTexture.data[4] = 3.0;
+  documentFromRotatedTexture.data[5] = 0.0;
+
+  RenderResult::CompositedPreview preview;
+  preview.tiles = {
+      RenderResult::CompositedTile{
+          .id = "rotated",
+          .generation = 1u,
+          .bitmap = rotatedBitmap,
+          .bitmapDimsPx = rotatedBitmap.dimensions,
+          .rasterCanvasSize = Vector2i(8, 8),
+          .canvasOffsetDoc = Vector2d(1.0, 1.0),
+          .bitmapDimsDoc = Vector2d(2.0, 3.0),
+          .documentFromCachedDocument = documentFromRotatedTexture,
+      },
+      RenderResult::CompositedTile{
+          .id = "overlap",
+          .generation = 1u,
+          .bitmap = overlappingBitmap,
+          .bitmapDimsPx = overlappingBitmap.dimensions,
+          .rasterCanvasSize = Vector2i(8, 8),
+          .canvasOffsetDoc = Vector2d(0.0, 2.0),
+          .bitmapDimsDoc = Vector2d(2.0, 2.0),
+      },
+  };
+
+  EditorControlSession::HeadlessTextureCache cache;
+  cache.uploadComposited(preview);
+  EditorControlSession::DisplayFrameSnapshot display{
+      .path = "tiles",
+      .hasCachedTiles = true,
+      .tiles = cache.tiles(),
+  };
+  const std::optional<svg::RendererBitmap> actual =
+      cache.composeDisplayFrame(display, Box2d::FromXYWH(0.0, 0.0, 8.0, 8.0), Vector2i(8, 8));
+  ASSERT_TRUE(actual.has_value());
+
+  svg::Renderer reference;
+  reference.beginFrame(svg::RenderViewport{
+      .size = Vector2d(8.0, 8.0),
+      .devicePixelRatio = 1.0,
+  });
+  Transform2d outputFromRotatedTexture(Transform2d::uninitialized);
+  outputFromRotatedTexture.data[0] = 0.0;
+  outputFromRotatedTexture.data[1] = 1.0;
+  outputFromRotatedTexture.data[2] = -1.0;
+  outputFromRotatedTexture.data[3] = 0.0;
+  outputFromRotatedTexture.data[4] = 2.0;
+  outputFromRotatedTexture.data[5] = 1.0;
+  reference.setTransform(outputFromRotatedTexture);
+  reference.drawBitmap(rotatedBitmap, svg::ImageParams{
+                                          .targetRect = Box2d::FromXYWH(0.0, 0.0, 2.0, 3.0),
+                                      });
+  reference.setTransform(Transform2d::Translate(0.0, 2.0));
+  reference.drawBitmap(overlappingBitmap, svg::ImageParams{
+                                              .targetRect = Box2d::FromXYWH(0.0, 0.0, 2.0, 2.0),
+                                          });
+  reference.endFrame();
+  const svg::RendererBitmap expected = reference.takeSnapshot();
+
+  tests::CompareBitmapToBitmap(*actual, expected, "headless_affine_tile_composition",
+                               tests::PixelmatchIdentityParams());
 }
 
 TEST(EditorControlSessionTest, SplashOThenRDragKeepsStableSplitLayerPaintOrder) {

--- a/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
@@ -805,7 +805,7 @@ TEST(EditorControlSessionTest, TransformSelectorRotatesThroughHandleAndExposesAf
                                                         {"delta_y", 48.0},
                                                         {"frames", 2},
                                                         {"release", false},
-                                                        {"include_final_frame", false}});
+                                                        {"include_final_frame", true}});
   ASSERT_TRUE(rotate.body.value("ok", false)) << rotate.body.dump(2);
   EXPECT_EQ(rotate.body.value("gesture_kind", ""), "rotate");
   EXPECT_EQ(rotate.body.value("corner", ""), "top_right");
@@ -826,6 +826,14 @@ TEST(EditorControlSessionTest, TransformSelectorRotatesThroughHandleAndExposesAf
   EXPECT_NEAR(center.y, 30.0, 1e-6);
   EXPECT_NEAR(topRight.x, 40.0, 1e-6);
   EXPECT_NEAR(topRight.y, 40.0, 1e-6);
+
+  ASSERT_TRUE(lastFrame["stages"].is_array()) << lastFrame.dump(2);
+  ASSERT_FALSE(lastFrame["stages"].empty()) << lastFrame.dump(2);
+  const json& finalBitmap = lastFrame["stages"].back()["bitmap"];
+  ASSERT_TRUE(finalBitmap["dimensions"].is_object()) << finalBitmap.dump(2);
+  EXPECT_GT(finalBitmap["dimensions"].value("x", 0), 0) << finalBitmap.dump(2);
+  EXPECT_GT(finalBitmap["dimensions"].value("y", 0), 0) << finalBitmap.dump(2);
+  EXPECT_TRUE(finalBitmap.value("png_attached", false)) << finalBitmap.dump(2);
 }
 
 TEST(EditorControlSessionTest, HeadlessTileCompositionPreservesAffinePlacementAndAlpha) {


### PR DESCRIPTION
Editor-control final-frame captures now preserve the same affine tile placement as the editor.

- Replace the private axis-aligned pixel scaler with Donner's renderer-backed bitmap composition.
- Share the production texture-to-output transform between framebuffer and headless presentation.
- Preserve padded rows, alpha blending, clipping, paint order, rotation, and shear.
- Add strict pixel-identity coverage and an end-to-end rotated final-frame assertion.

## Verification

- `bazel test //tools/mcp-servers/editor-control:editor_control_session_tests --test_output=errors`
- Cumulative prerequisite stack: `bazel test //donner/editor/tests:presented_frame_composer_tests --test_output=errors`
- Cumulative presentation stack on PR #1000: `bazel test //... --test_output=errors`
- Cumulative prerequisite stack: `python3 tools/cmake/gen_cmakelists.py --check`
