### PR TITLE
Add shared New Document actions

### DIFF
--- a/donner/editor/AsyncRenderer.cc
+++ b/donner/editor/AsyncRenderer.cc
@@ -209,6 +209,7 @@ SampleThumbnailRenderResult RenderSampleThumbnail(
     SampleThumbnailRenderRequest request, svg::RendererInterface& renderer,
     const svg::compositor::CancellationToken& cancellation, std::chrono::milliseconds delay) {
   SampleThumbnailRenderResult result{
+      .kind = request.kind,
       .key = request.key,
       .outcome = SampleThumbnailRenderOutcome::RenderError,
   };
@@ -736,6 +737,7 @@ void AsyncRenderer::workerLoop() {
 
       SampleThumbnailRenderResult result;
       if (offscreenRenderer == nullptr) {
+        result.kind = sampleThumbnailStorage->kind;
         result.key = sampleThumbnailStorage->key;
         result.outcome = SampleThumbnailRenderOutcome::RendererUnavailable;
       } else {

--- a/donner/editor/AsyncRenderer.h
+++ b/donner/editor/AsyncRenderer.h
@@ -379,8 +379,15 @@ enum class SampleThumbnailRenderOutcome : std::uint8_t {
   RendererUnavailable,
 };
 
+/// Consumer of one bounded low-priority SVG preview render.
+enum class AuxiliaryPreviewKind : std::uint8_t {
+  Sample,
+  FontFamily,
+};
+
 /// One SVG source queued for bounded, low-priority rendering on the existing render worker.
 struct SampleThumbnailRenderRequest {
+  AuxiliaryPreviewKind kind = AuxiliaryPreviewKind::Sample;
   /// Caller-defined key copied into the result (the sample-catalog index in `EditorShell`).
   std::uint64_t key = 0;
   /// Complete SVG source. The request owns its copy until the worker finishes parsing it.
@@ -396,6 +403,7 @@ struct SampleThumbnailRenderRequest {
 
 /// CPU bitmap returned by one asynchronous sample-thumbnail attempt.
 struct SampleThumbnailRenderResult {
+  AuxiliaryPreviewKind kind = AuxiliaryPreviewKind::Sample;
   std::uint64_t key = 0;
   SampleThumbnailRenderOutcome outcome = SampleThumbnailRenderOutcome::RenderError;
   svg::RendererBitmap bitmap;

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -1005,6 +1005,9 @@ std::string InitialDocumentSyncSource(const EditorShellOptions& options) {
   return LoadFile(options.svgPath).value_or("");
 }
 
+constexpr std::string_view kNewDocumentSvg =
+    R"svg(<svg xmlns="http://www.w3.org/2000/svg" width="640" height="400" viewBox="0 0 640 400"/>)svg";
+
 std::string CanonicalizeForTextEditor(std::string_view source) {
   std::string result(source);
   if (!result.empty() && result.back() == '\n') {
@@ -1806,7 +1809,7 @@ void EditorShell::maybeLogFrameMissTelemetry(const FrameCostBreakdown& frameCost
 }
 
 bool EditorShell::tryOpenPath(std::string_view path, std::string* error) {
-  cancelPendingSampleLoad();
+  cancelPendingDocumentReplacement();
   auto contents = LoadFile(std::string(path));
   if (!contents.has_value()) {
     *error = "Could not open file.";
@@ -1840,56 +1843,70 @@ bool EditorShell::tryLoadSource(std::string_view source, std::optional<std::stri
   return true;
 }
 
-void EditorShell::queuePendingSampleLoad(std::string sampleId) {
-  pendingSampleLoadId_ = std::move(sampleId);
-  pendingSampleLoadNeedsConfirmation_ = false;
-  pendingSampleLoadDiscardConfirmed_ = false;
-  // The selected sample supersedes the current document frame. Start cancellation in the click
-  // frame so the next UI frame can claim the DOM as soon as SVG traversal reaches a safe point.
+void EditorShell::requestNewDocument() {
+  queuePendingDocumentReplacement(PendingDocumentReplacementKind::NewDocument);
+  showSamplePicker_ = true;
+  processPendingDocumentReplacement();
+  window_.wakeEventLoop();
+}
+
+void EditorShell::queuePendingDocumentReplacement(PendingDocumentReplacementKind kind,
+                                                  std::string sampleId) {
+  pendingDocumentReplacement_ = PendingDocumentReplacement{
+      .kind = kind,
+      .sampleId = std::move(sampleId),
+      .pickerWasVisible = showSamplePicker_,
+  };
+  // A replacement supersedes the current document frame. Start cancellation in the request frame
+  // so the next UI frame can claim the DOM as soon as SVG traversal reaches a safe point.
   cancelSampleThumbnailGeneration();
   renderCoordinator_.asyncRenderer().cancelInFlight();
 }
 
-void EditorShell::cancelPendingSampleLoad() {
-  pendingSampleLoadId_.clear();
-  pendingSampleLoadNeedsConfirmation_ = false;
-  pendingSampleLoadDiscardConfirmed_ = false;
+void EditorShell::queuePendingSampleLoad(std::string sampleId) {
+  queuePendingDocumentReplacement(PendingDocumentReplacementKind::Sample, std::move(sampleId));
 }
 
-void EditorShell::confirmPendingSampleLoadDiscard() {
-  if (pendingSampleLoadId_.empty()) {
+void EditorShell::cancelPendingDocumentReplacement() {
+  pendingDocumentReplacement_.reset();
+}
+
+void EditorShell::confirmPendingDocumentReplacementDiscard() {
+  if (!pendingDocumentReplacement_.has_value()) {
     return;
   }
-  pendingSampleLoadNeedsConfirmation_ = false;
-  pendingSampleLoadDiscardConfirmed_ = true;
+  pendingDocumentReplacement_->needsConfirmation = false;
+  pendingDocumentReplacement_->discardConfirmed = true;
   window_.wakeEventLoop();
 }
 
-void EditorShell::processPendingSampleLoad() {
-  if (pendingSampleLoadId_.empty()) {
+void EditorShell::processPendingDocumentReplacement() {
+  if (!pendingDocumentReplacement_.has_value()) {
     return;
   }
   const bool hasDocument = app_.hasDocument();
   std::optional<svg::DocumentWriteAccess> documentAccess =
       hasDocument ? app_.document().document().tryWriteAccess() : std::nullopt;
   const bool documentWriteAvailable = !hasDocument || documentAccess.has_value();
-  if (!internal::PendingDocumentReplacementCanProcess(!pendingSampleLoadId_.empty(),
+  if (!internal::PendingDocumentReplacementCanProcess(pendingDocumentReplacement_.has_value(),
                                                       documentWriteAvailable,
                                                       app_.document().hasPendingMutations())) {
     return;
   }
 
-  if (!pendingSampleLoadDiscardConfirmed_ && (app_.isDirty() || textEditor_.isTextChanged())) {
-    pendingSampleLoadNeedsConfirmation_ = true;
+  if (!pendingDocumentReplacement_->discardConfirmed &&
+      (app_.isDirty() || textEditor_.isTextChanged())) {
+    pendingDocumentReplacement_->needsConfirmation = true;
     showSamplePicker_ = true;
     return;
   }
 
-  const std::string sampleId = std::exchange(pendingSampleLoadId_, {});
-  pendingSampleLoadNeedsConfirmation_ = false;
-  pendingSampleLoadDiscardConfirmed_ = false;
-  const EditorSample* sample = FindEditorSample(sampleId);
-  if (sample == nullptr) {
+  PendingDocumentReplacement replacement = std::move(*pendingDocumentReplacement_);
+  pendingDocumentReplacement_.reset();
+  const EditorSample* sample = replacement.kind == PendingDocumentReplacementKind::Sample
+                                   ? FindEditorSample(replacement.sampleId)
+                                   : nullptr;
+  if (replacement.kind == PendingDocumentReplacementKind::Sample && sample == nullptr) {
     showSamplePicker_ = true;
     return;
   }
@@ -1903,20 +1920,22 @@ void EditorShell::processPendingSampleLoad() {
   // dropped instead of landing over the replacement document.
   renderCoordinator_.asyncRenderer().cancelInFlight();
   std::string error;
-  if (tryLoadSource(sample->source, std::nullopt, &error)) {
-    activeSampleId_ = sampleId;
+  const std::string_view source = sample != nullptr ? sample->source : kNewDocumentSvg;
+  if (tryLoadSource(source, std::nullopt, &error)) {
+    activeSampleId_ = sample != nullptr ? replacement.sampleId : std::string();
 #ifdef __EMSCRIPTEN__
     PublishActiveSampleId(activeSampleId_.c_str());
 #endif
-    samplePresentationPending_ = true;
-    showSamplePicker_ = true;
-    // The picker click runs after the render pane has already laid out this frame. Defer the first
-    // sample request until the next frame has fitted the new intrinsic viewBox.
-    requestRenderAtEndOfFrame_ = false;
+    if (sample != nullptr) {
+      samplePresentationPending_ = true;
+      showSamplePicker_ = true;
+      // The picker click runs after the render pane has already laid out this frame. Defer the
+      // first sample request until the next frame has fitted the new intrinsic viewBox.
+      requestRenderAtEndOfFrame_ = false;
+    }
   } else {
     showSamplePicker_ = true;
-    std::fprintf(stderr, "[editor] failed to load built-in sample %s: %s\n", sampleId.c_str(),
-                 error.c_str());
+    std::fprintf(stderr, "[editor] failed to create replacement document: %s\n", error.c_str());
   }
 }
 
@@ -2118,7 +2137,7 @@ void EditorShell::requestRevert() {
     return;
   }
 
-  cancelPendingSampleLoad();
+  cancelPendingDocumentReplacement();
 
   const std::string source(app_.cleanSourceText());
   if (!app_.revertToCleanSource()) {
@@ -2223,9 +2242,12 @@ void EditorShell::applyMenuActions(const MenuBarActions& menuActions) {
   if (menuActions.openAbout) {
     dialogPresenter_.requestAbout();
   }
+  if (menuActions.newDocument) {
+    requestNewDocument();
+  }
   if (menuActions.openFile) {
     cancelSampleThumbnailGeneration();
-    cancelPendingSampleLoad();
+    cancelPendingDocumentReplacement();
     dialogPresenter_.requestOpenFile(app_.currentFilePath());
   }
   if (menuActions.openSamples) {
@@ -2402,6 +2424,10 @@ void EditorShell::handleGlobalShortcuts() {
 
   if (!anyPopupOpen && cmd && !shift && ImGui::IsKeyPressed(ImGuiKey_O, /*repeat=*/false)) {
     dialogPresenter_.requestOpenFile(app_.currentFilePath());
+  }
+
+  if (!anyPopupOpen && cmd && !shift && ImGui::IsKeyPressed(ImGuiKey_N, /*repeat=*/false)) {
+    requestNewDocument();
   }
 
   if (!anyPopupOpen && cmd && !shift && ImGui::IsKeyPressed(ImGuiKey_Q, /*repeat=*/false)) {
@@ -4479,20 +4505,29 @@ void EditorShell::renderSamplePicker(const ImVec2& paneOrigin, const ImVec2& con
       SamplePickerState{.visible = true, .selectedSampleId = activeSampleId_}, thumbnailProvider);
   ImGui::EndChild();
 
-  if (pendingSampleLoadNeedsConfirmation_) {
+  if (pendingDocumentReplacement_.has_value() && pendingDocumentReplacement_->needsConfirmation) {
+    const bool creatingNewDocument =
+        pendingDocumentReplacement_->kind == PendingDocumentReplacementKind::NewDocument;
     if (!ImGui::IsPopupOpen("Discard changes?")) {
       ImGui::OpenPopup("Discard changes?");
     }
     if (ImGui::BeginPopupModal("Discard changes?", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
-      ImGui::TextUnformatted("Loading a sample replaces the current document.");
+      ImGui::TextUnformatted(creatingNewDocument
+                                 ? "Creating a new document replaces the current document."
+                                 : "Loading a sample replaces the current document.");
       ImGui::Spacing();
       if (ImGui::Button("Cancel", ImVec2(112.0f, 40.0f))) {
-        cancelPendingSampleLoad();
+        const bool restorePicker = pendingDocumentReplacement_->pickerWasVisible;
+        cancelPendingDocumentReplacement();
+        if (!restorePicker && !welcomePlaceholderActive_) {
+          showSamplePicker_ = false;
+        }
         ImGui::CloseCurrentPopup();
       }
       ImGui::SameLine();
-      if (ImGui::Button("Discard & Load", ImVec2(148.0f, 40.0f))) {
-        confirmPendingSampleLoadDiscard();
+      const char* confirmLabel = creatingNewDocument ? "Discard & Create" : "Discard & Load";
+      if (ImGui::Button(confirmLabel, ImVec2(148.0f, 40.0f))) {
+        confirmPendingDocumentReplacementDiscard();
         ImGui::CloseCurrentPopup();
       }
       ImGui::EndPopup();
@@ -4504,7 +4539,7 @@ void EditorShell::renderSamplePicker(const ImVec2& paneOrigin, const ImVec2& con
 
   if (actions.dismiss) {
     cancelSampleThumbnailGeneration();
-    cancelPendingSampleLoad();
+    cancelPendingDocumentReplacement();
     if (welcomePlaceholderActive_) {
       queuePendingSampleLoad("donner-splash");
     } else {
@@ -4513,7 +4548,7 @@ void EditorShell::renderSamplePicker(const ImVec2& paneOrigin, const ImVec2& con
   }
   if (actions.openFile) {
     cancelSampleThumbnailGeneration();
-    cancelPendingSampleLoad();
+    cancelPendingDocumentReplacement();
     if (!welcomePlaceholderActive_) {
       showSamplePicker_ = false;
     }
@@ -4538,10 +4573,13 @@ void EditorShell::renderSamplePicker(const ImVec2& paneOrigin, const ImVec2& con
     ImGui::SetClipboardText(kSamplePickerGitHubUrl.data());
 #endif
   }
+  if (actions.newDocument) {
+    requestNewDocument();
+  }
   if (actions.loadSample) {
     queuePendingSampleLoad(actions.sampleId);
     // Start a clean, idle replacement after this frame's document UI work has already finished.
-    processPendingSampleLoad();
+    processPendingDocumentReplacement();
     window_.wakeEventLoop();
   }
 }
@@ -4843,7 +4881,7 @@ void EditorShell::renderCompactTopBar() {
 
   ImGui::SetCursorPos(ImVec2(controlsX, 4.0f));
   if (button("##compact_open", CompactIcon::Open, "Open or sample", true, false)) {
-    pendingSampleLoadId_.clear();
+    cancelPendingDocumentReplacement();
     compactPanelVisible_ = false;
     showSamplePicker_ = true;
     window_.wakeEventLoop();
@@ -6863,7 +6901,7 @@ void EditorShell::runFrame() {
       requestRenderAtEndOfFrame_ = !showSamplePicker_ || samplePresentationPending_;
     }
   }
-  processPendingSampleLoad();
+  processPendingDocumentReplacement();
   const bool documentUiSnapshotRendererBusy = renderCoordinator_.asyncRenderer().isBusy();
   cachedCanvasHasSelectableElements_ = internal::ResolveCachedDocumentBoolForFrame(
       documentUiSnapshotRendererBusy, cachedCanvasHasSelectableElements_,

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -415,6 +415,8 @@ constexpr std::string_view kEditorUiRegularFontName = "Donner UI Regular";
 constexpr std::string_view kEditorUiBoldFontName = "Donner UI Bold";
 constexpr std::string_view kEditorCodeFontName = "Donner Code";
 constexpr std::string_view kEditorCodeSymbolFontName = "Donner Code Symbols";
+constexpr int kFontPreviewWidth = 196;
+constexpr int kFontPreviewHeight = 24;
 
 void SetImGuiFontConfigName(ImFontConfig& config, std::string_view name) {
   const std::size_t size = std::min(name.size(), sizeof(config.Name) - 1u);
@@ -435,6 +437,38 @@ ImFont* FindImGuiFontByConfigName(const ImFontAtlas& atlas, std::string_view nam
     }
   }
   return nullptr;
+}
+
+std::string EscapeXmlText(std::string_view text) {
+  std::string escaped;
+  escaped.reserve(text.size());
+  for (char c : text) {
+    switch (c) {
+      case '&': escaped += "&amp;"; break;
+      case '<': escaped += "&lt;"; break;
+      case '>': escaped += "&gt;"; break;
+      case '"': escaped += "&quot;"; break;
+      case '\'': escaped += "&apos;"; break;
+      default: escaped.push_back(c); break;
+    }
+  }
+  return escaped;
+}
+
+std::string FontPreviewSvg(std::string_view family) {
+  const std::string escaped = EscapeXmlText(family);
+  return "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 196 24\">"
+         "<text x=\"1\" y=\"18\" font-family=\"" +
+         escaped + "\" font-size=\"16\" fill=\"#fff\">" + escaped + "</text></svg>";
+}
+
+std::uint64_t FontPreviewKey(std::string_view family) {
+  std::uint64_t hash = 14695981039346656037ULL;
+  for (unsigned char c : family) {
+    hash ^= static_cast<unsigned char>(std::tolower(c));
+    hash *= 1099511628211ULL;
+  }
+  return hash;
 }
 
 bool ResourceDiagnosticsEnabled() {
@@ -1093,6 +1127,7 @@ EditorShell::EditorShell(gui::EditorWindow& window, EditorShellOptions options)
       textures_(window.geodeDevice()),
       thumbnailTextures_(window.geodeDevice()),
       sampleThumbnailTextures_(window.geodeDevice()),
+      fontPreviewTextures_(window.geodeDevice()),
       toolbarIconTextures_(window.geodeDevice()),
       layerThumbnailRenderer_(window.geodeDevice()),
       fontCatalog_(),
@@ -2716,30 +2751,13 @@ FormatBarState EditorShell::computeFormatBarState() {
     ReadTextFormatState(selection.front(), &state);
   }
 
-  // The family picker lists the real font catalog (embedded curated Google
-  // Fonts, then macOS system fonts), grouped Embedded-then-System as
-  // `FontCatalog::families()` orders them. A menu entry previews in its own
-  // face only where the editor already has that face loaded as an ImGui font:
-  // the default UI face (Roboto) and the code face (Fira Code). Other families
-  // render their label in the default UI font, and the free-text box still
-  // round-trips any family the catalog lacks. Building preview faces for
-  // arbitrary catalog entries from `fontCatalog().loadFace()` bytes would need
-  // a mid-session ImGui atlas rebuild, out of scope for this bar.
-  ImFont* const regularFace =
-      ImGui::GetIO().Fonts->Fonts.empty() ? nullptr : ImGui::GetIO().Fonts->Fonts[0];
+  // Preview bitmaps are generated lazily by the existing low-priority render
+  // worker. This keeps the 180-plus desktop System group out of startup and
+  // avoids mutating ImGui's atlas after its backend texture has been uploaded.
   state.boldToggleFont = uiFontBold_;
-  state.families = BuildFormatBarFamilies(fontCatalog().families(),
-                                          [&](const svg::FontFamilyInfo& info) -> ImFont* {
-                                            if (StringUtils::Equals<StringComparison::IgnoreCase>(
-                                                    info.family, std::string_view("Roboto"))) {
-                                              return regularFace;
-                                            }
-                                            if (StringUtils::Equals<StringComparison::IgnoreCase>(
-                                                    info.family, std::string_view("Fira Code"))) {
-                                              return codeFont_;
-                                            }
-                                            return nullptr;
-                                          });
+  state.families = BuildFormatBarFamilies(
+      fontCatalog().families(),
+      [&](const svg::FontFamilyInfo& info) { return fontPreviewForFamily(info.family); });
   return state;
 }
 
@@ -4229,6 +4247,7 @@ void EditorShell::renderRenderPanePresentation(
                                                 static_cast<float>(formatBarRect->topLeft.y)),
                                          static_cast<float>(formatBarRect->width()));
       applyFormatBarActions(formatBarState, actions);
+      requestFontPreviews(actions.requestFontPreviews);
     }
     renderCanvasZoomControl();
     if (adaptiveUiLayout_.showCanvasScrollbars) {
@@ -4272,18 +4291,28 @@ void EditorShell::ensureSampleThumbnails() {
 
   if (std::optional<SampleThumbnailRenderResult> result =
           asyncRenderer.pollSampleThumbnailResult()) {
-    const std::size_t index = static_cast<std::size_t>(result->key);
-    if (index < samples.size()) {
+    if (result->kind == AuxiliaryPreviewKind::FontFamily && fontPreviewInFlight_.has_value() &&
+        result->key == FontPreviewKey(*fontPreviewInFlight_)) {
       if (result->outcome == SampleThumbnailRenderOutcome::Rendered && !result->bitmap.empty()) {
-        sampleThumbnailBitmaps_[index] = std::move(result->bitmap);
+        fontPreviewBitmaps_.insert_or_assign(*fontPreviewInFlight_, std::move(result->bitmap));
+      } else if (result->outcome != SampleThumbnailRenderOutcome::Cancelled) {
+        fontPreviewBitmaps_.insert_or_assign(*fontPreviewInFlight_, std::nullopt);
       }
-      if (result->outcome != SampleThumbnailRenderOutcome::Cancelled &&
-          index == sampleThumbnailGenerationCursor_) {
-        ++sampleThumbnailGenerationCursor_;
+      fontPreviewInFlight_.reset();
+    } else if (result->kind == AuxiliaryPreviewKind::Sample) {
+      const std::size_t index = static_cast<std::size_t>(result->key);
+      if (index < samples.size()) {
+        if (result->outcome == SampleThumbnailRenderOutcome::Rendered && !result->bitmap.empty()) {
+          sampleThumbnailBitmaps_[index] = std::move(result->bitmap);
+        }
+        if (result->outcome != SampleThumbnailRenderOutcome::Cancelled &&
+            index == sampleThumbnailGenerationCursor_) {
+          ++sampleThumbnailGenerationCursor_;
+        }
       }
-    }
-    if (sampleThumbnailInFlightIndex_ == index) {
-      sampleThumbnailInFlightIndex_.reset();
+      if (sampleThumbnailInFlightIndex_ == index) {
+        sampleThumbnailInFlightIndex_.reset();
+      }
     }
   }
 
@@ -4327,6 +4356,84 @@ void EditorShell::cancelSampleThumbnailGeneration() {
   renderCoordinator_.asyncRenderer().cancelSampleThumbnailWork();
   sampleThumbnailInFlightIndex_.reset();
   sampleThumbnailRetryPending_ = false;
+  if (fontPreviewInFlight_.has_value()) {
+    pendingFontPreviews_.push_front(std::move(*fontPreviewInFlight_));
+    fontPreviewInFlight_.reset();
+  }
+}
+
+void EditorShell::requestFontPreviews(const std::vector<std::string>& families) {
+  bool queued = false;
+  for (const std::string& family : families) {
+    if (!fontCatalog_.hasFamily(family) || fontPreviewBitmaps_.contains(family) ||
+        fontPreviewInFlight_ == family ||
+        std::ranges::find(pendingFontPreviews_, family) != pendingFontPreviews_.end()) {
+      continue;
+    }
+    pendingFontPreviews_.push_back(family);
+    queued = true;
+  }
+  if (queued) {
+    window_.wakeEventLoop();
+  }
+}
+
+void EditorShell::advanceFontPreviewGeneration() {
+  AsyncRenderer& asyncRenderer = renderCoordinator_.asyncRenderer();
+  if (std::optional<SampleThumbnailRenderResult> result =
+          asyncRenderer.pollSampleThumbnailResult()) {
+    if (result->kind == AuxiliaryPreviewKind::FontFamily && fontPreviewInFlight_.has_value() &&
+        result->key == FontPreviewKey(*fontPreviewInFlight_)) {
+      if (result->outcome == SampleThumbnailRenderOutcome::Rendered && !result->bitmap.empty()) {
+        fontPreviewBitmaps_.insert_or_assign(*fontPreviewInFlight_, std::move(result->bitmap));
+      } else if (result->outcome != SampleThumbnailRenderOutcome::Cancelled) {
+        // Remember terminal failures so an unsupported face does not spin the
+        // event loop every time its row becomes visible.
+        fontPreviewBitmaps_.insert_or_assign(*fontPreviewInFlight_, std::nullopt);
+      }
+    }
+    fontPreviewInFlight_.reset();
+  }
+
+  if (fontPreviewInFlight_.has_value() || pendingFontPreviews_.empty() || asyncRenderer.isBusy()) {
+    return;
+  }
+
+  std::string family = std::move(pendingFontPreviews_.front());
+  pendingFontPreviews_.pop_front();
+  const double displayScale = window_.displayScale();
+  SampleThumbnailRenderRequest request{
+      .kind = AuxiliaryPreviewKind::FontFamily,
+      .key = FontPreviewKey(family),
+      .source = FontPreviewSvg(family),
+      .dimensions =
+          Vector2i(std::max(1, static_cast<int>(std::ceil(kFontPreviewWidth * displayScale))),
+                   std::max(1, static_cast<int>(std::ceil(kFontPreviewHeight * displayScale)))),
+  };
+#ifndef __EMSCRIPTEN__
+  request.nativeRenderer = &renderCoordinator_.renderer();
+#endif
+  if (asyncRenderer.requestSampleThumbnail(std::move(request))) {
+    fontPreviewInFlight_ = std::move(family);
+  } else {
+    pendingFontPreviews_.push_front(std::move(family));
+  }
+}
+
+FormatBarFontPreview EditorShell::fontPreviewForFamily(std::string_view family) {
+  const auto it = fontPreviewBitmaps_.find(std::string(family));
+  if (it == fontPreviewBitmaps_.end() || !it->second.has_value()) {
+    return {};
+  }
+  const GlTextureCache::ThumbnailTextureView uploaded =
+      fontPreviewTextures_.uploadThumbnail(FontPreviewKey(family), *it->second);
+  return FormatBarFontPreview{
+      .texture = static_cast<std::uint64_t>(uploaded.texture),
+      .uvMaxX = static_cast<float>(uploaded.uvBottomRight.x),
+      .uvMaxY = static_cast<float>(uploaded.uvBottomRight.y),
+      .width = static_cast<float>(kFontPreviewWidth),
+      .height = static_cast<float>(kFontPreviewHeight),
+  };
 }
 
 void EditorShell::renderSamplePicker(const ImVec2& paneOrigin, const ImVec2& contentRegion) {
@@ -6687,6 +6794,9 @@ void EditorShell::runFrame() {
   contentOnlyCaptureForNextFrame_ = false;
   textures_.advancePresentationFrame();
   compositorDebugPanel_.advancePresentationFrame();
+  if (!showSamplePicker_) {
+    advanceFontPreviewGeneration();
+  }
   snapshotReproFrame();
   const float frameDeltaMs = ImGui::GetIO().DeltaTime * 1000.0f;
   interactionController_.noteFrameDelta(frameDeltaMs);

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -313,12 +313,28 @@ private:
     Redo,
   };
 
+  enum class PendingDocumentReplacementKind : std::uint8_t {
+    NewDocument,
+    Sample,
+  };
+
+  struct PendingDocumentReplacement {
+    PendingDocumentReplacementKind kind = PendingDocumentReplacementKind::NewDocument;
+    std::string sampleId;
+    bool pickerWasVisible = false;
+    bool needsConfirmation = false;
+    bool discardConfirmed = false;
+  };
+
   bool tryOpenPath(std::string_view path, std::string* error);
   bool tryLoadSource(std::string_view source, std::optional<std::string> path, std::string* error);
+  void requestNewDocument();
+  void queuePendingDocumentReplacement(PendingDocumentReplacementKind kind,
+                                       std::string sampleId = {});
   void queuePendingSampleLoad(std::string sampleId);
-  void cancelPendingSampleLoad();
-  void confirmPendingSampleLoadDiscard();
-  void processPendingSampleLoad();
+  void cancelPendingDocumentReplacement();
+  void confirmPendingDocumentReplacementDiscard();
+  void processPendingDocumentReplacement();
   /// Apply Group or Ungroup only while the render worker releases DOM ownership.
   bool tryApplyGroupOperation(bool ungroup);
   bool trySavePath(std::string_view path, std::string* error);
@@ -766,9 +782,7 @@ private:
   /// presentation. This prevents the startup placeholder surface from becoming user-visible.
   bool samplePresentationPending_ = false;
   std::string activeSampleId_;
-  std::string pendingSampleLoadId_;
-  bool pendingSampleLoadNeedsConfirmation_ = false;
-  bool pendingSampleLoadDiscardConfirmed_ = false;
+  std::optional<PendingDocumentReplacement> pendingDocumentReplacement_;
   /// Current compact sheet state. Desktop keeps the source/sidebar preferences
   /// above intact so switching profiles does not rewrite user layout choices.
   bool compactPanelVisible_ = false;

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -9,6 +9,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 #include "donner/editor/CanvasScrollbars.h"
@@ -442,6 +443,9 @@ private:
   void renderSidebars();
   void ensureSampleThumbnails();
   void cancelSampleThumbnailGeneration();
+  void requestFontPreviews(const std::vector<std::string>& families);
+  void advanceFontPreviewGeneration();
+  [[nodiscard]] FormatBarFontPreview fontPreviewForFamily(std::string_view family);
   void renderSamplePicker(const ImVec2& paneOrigin, const ImVec2& contentRegion);
   void renderSourcePaneSplitter(float windowWidth, float paneOriginY, float paneHeight,
                                 float sourcePaneWidth);
@@ -560,6 +564,9 @@ private:
   /// Dedicated cache for the bounded welcome catalog. It is intentionally
   /// separate from row thumbnails, whose retention sweep follows live layers.
   GlTextureCache sampleThumbnailTextures_;
+  /// Lazily rendered family-name previews. Only visible dropdown rows enter
+  /// this dedicated cache, so desktop system-font enumeration stays cheap.
+  GlTextureCache fontPreviewTextures_;
   /// Toolbar tool-icon texture cache. Holds the Donner-rendered white-mask
   /// bitmaps for the palette icons, keyed by a stable per-icon id. Never
   /// retention-swept (unlike `thumbnailTextures_`), so the four icons upload
@@ -579,6 +586,9 @@ private:
   /// still initializing. Nothing else wakes the on-demand loop for that, so the
   /// picker arms its own short idle retry. @see nextIdleWakeSeconds
   bool sampleThumbnailRetryPending_ = false;
+  std::unordered_map<std::string, std::optional<svg::RendererBitmap>> fontPreviewBitmaps_;
+  std::deque<std::string> pendingFontPreviews_;
+  std::optional<std::string> fontPreviewInFlight_;
   /// Embedded + system font catalog. It is declared before the render coordinator so it outlives
   /// every worker-side FontManager and offscreen renderer during reverse-order destruction.
   svg::FontCatalog fontCatalog_;

--- a/donner/editor/MenuBarPresenter.cc
+++ b/donner/editor/MenuBarPresenter.cc
@@ -15,6 +15,7 @@ void ApplyMenuBarCommand(bool activated, MenuBarCommand command, const MenuBarSt
 
   switch (command) {
     case MenuBarCommand::OpenAbout: actions->openAbout = true; return;
+    case MenuBarCommand::NewDocument: return;
     case MenuBarCommand::OpenFile: actions->openFile = true; return;
     case MenuBarCommand::OpenSamples: actions->openSamples = true; return;
     case MenuBarCommand::SaveFile: actions->saveFile = true; return;

--- a/donner/editor/MenuBarPresenter.cc
+++ b/donner/editor/MenuBarPresenter.cc
@@ -15,7 +15,7 @@ void ApplyMenuBarCommand(bool activated, MenuBarCommand command, const MenuBarSt
 
   switch (command) {
     case MenuBarCommand::OpenAbout: actions->openAbout = true; return;
-    case MenuBarCommand::NewDocument: return;
+    case MenuBarCommand::NewDocument: actions->newDocument = true; return;
     case MenuBarCommand::OpenFile: actions->openFile = true; return;
     case MenuBarCommand::OpenSamples: actions->openSamples = true; return;
     case MenuBarCommand::SaveFile: actions->saveFile = true; return;
@@ -133,6 +133,8 @@ MenuBarActions MenuBarPresenter::render(const MenuBarState& state, ImFont* boldM
   ImGui::SameLine(0.0f, theme.space4);
 
   if (ImGui::BeginMenu("File")) {
+    ApplyMenuBarCommand(ImGui::MenuItem("New", "Cmd+N"), MenuBarCommand::NewDocument, state,
+                        &actions);
     ApplyMenuBarCommand(ImGui::MenuItem("Open...", "Cmd+O"), MenuBarCommand::OpenFile, state,
                         &actions);
     ApplyMenuBarCommand(ImGui::MenuItem("Open Sample..."), MenuBarCommand::OpenSamples, state,

--- a/donner/editor/MenuBarPresenter.h
+++ b/donner/editor/MenuBarPresenter.h
@@ -58,6 +58,7 @@ struct MenuBarState {
 
 struct MenuBarActions {
   bool openAbout = false;
+  bool newDocument = false;
   bool openFile = false;
   bool openSamples = false;
   bool saveFile = false;
@@ -110,6 +111,7 @@ struct MenuBarActions {
 /// Semantic command emitted by a top-level menu item.
 enum class MenuBarCommand {
   OpenAbout,
+  NewDocument,
   OpenFile,
   OpenSamples,
   SaveFile,

--- a/donner/editor/SamplePickerPresenter.cc
+++ b/donner/editor/SamplePickerPresenter.cc
@@ -141,7 +141,7 @@ void ApplySamplePickerCommand(bool activated, SamplePickerCommand command,
 
   switch (command) {
     case SamplePickerCommand::Dismiss: actions->dismiss = true; return;
-    case SamplePickerCommand::NewDocument: return;
+    case SamplePickerCommand::NewDocument: actions->newDocument = true; return;
     case SamplePickerCommand::OpenFile: actions->openFile = true; return;
     case SamplePickerCommand::LoadSample:
       if (FindEditorSample(sampleId) != nullptr) {
@@ -178,13 +178,23 @@ SamplePickerActions SamplePickerPresenter::render(
   ImGui::TextWrapped("Edit SVG graphics and source together.");
   ImGui::Dummy(ImVec2(0.0f, kHeadingSpacing));
 
+  const float newWidth =
+      std::max(132.0f, ImGui::CalcTextSize("New Document").x + 2.0f * theme.space4);
   const float openWidth = std::max(112.0f, ImGui::CalcTextSize("Open SVG").x + 2.0f * theme.space4);
+  const float githubWidth =
+      std::max(128.0f, ImGui::CalcTextSize(kGitHubActionLabel.data()).x + 2.0f * theme.space4);
+  if (ImGui::Button("New Document", ImVec2(newWidth, kSamplePickerMinTouchTarget))) {
+    ApplySamplePickerCommand(true, SamplePickerCommand::NewDocument, {}, &actions);
+  }
+  if (newWidth + theme.space2 + openWidth <= availableWidth) {
+    ImGui::SameLine(0.0f, theme.space2);
+  }
   if (ImGui::Button("Open SVG", ImVec2(openWidth, kSamplePickerMinTouchTarget))) {
     ApplySamplePickerCommand(true, SamplePickerCommand::OpenFile, {}, &actions);
   }
-  ImGui::SameLine(0.0f, theme.space2);
-  const float githubWidth =
-      std::max(128.0f, ImGui::CalcTextSize(kGitHubActionLabel.data()).x + 2.0f * theme.space4);
+  if (newWidth + openWidth + githubWidth + 2.0f * theme.space2 <= availableWidth) {
+    ImGui::SameLine(0.0f, theme.space2);
+  }
   if (ImGui::Button(kGitHubActionLabel.data(), ImVec2(githubWidth, kSamplePickerMinTouchTarget))) {
     ApplySamplePickerCommand(true, SamplePickerCommand::OpenGitHub, {}, &actions);
   }

--- a/donner/editor/SamplePickerPresenter.cc
+++ b/donner/editor/SamplePickerPresenter.cc
@@ -141,6 +141,7 @@ void ApplySamplePickerCommand(bool activated, SamplePickerCommand command,
 
   switch (command) {
     case SamplePickerCommand::Dismiss: actions->dismiss = true; return;
+    case SamplePickerCommand::NewDocument: return;
     case SamplePickerCommand::OpenFile: actions->openFile = true; return;
     case SamplePickerCommand::LoadSample:
       if (FindEditorSample(sampleId) != nullptr) {

--- a/donner/editor/SamplePickerPresenter.h
+++ b/donner/editor/SamplePickerPresenter.h
@@ -57,6 +57,7 @@ struct SamplePickerState {
 /// Edge-triggered requests emitted by one rendered picker frame.
 struct SamplePickerActions {
   bool dismiss = false;
+  bool newDocument = false;
   bool openFile = false;
   bool loadSample = false;
   std::string sampleId;
@@ -76,6 +77,7 @@ using SamplePickerThumbnailProvider =
 
 enum class SamplePickerCommand {
   Dismiss,
+  NewDocument,
   OpenFile,
   LoadSample,
   OpenGitHub,

--- a/donner/editor/TextFormatBarPresenter.cc
+++ b/donner/editor/TextFormatBarPresenter.cc
@@ -130,7 +130,7 @@ bool ApplyFormatBarActionsToSelection(const FormatBarActions& actions, const For
 
 std::vector<FormatBarFontFamily> BuildFormatBarFamilies(
     const std::vector<svg::FontFamilyInfo>& catalogFamilies,
-    const std::function<ImFont*(const svg::FontFamilyInfo&)>& previewForFamily) {
+    const std::function<FormatBarFontPreview(const svg::FontFamilyInfo&)>& previewForFamily) {
   std::vector<FormatBarFontFamily> families;
   families.reserve(catalogFamilies.size());
   // Preserve the catalog's ordering (Embedded group first, then System, sorted
@@ -139,7 +139,7 @@ std::vector<FormatBarFontFamily> BuildFormatBarFamilies(
   for (const svg::FontFamilyInfo& info : catalogFamilies) {
     families.push_back(FormatBarFontFamily{
         .name = info.family,
-        .previewFont = previewForFamily ? previewForFamily(info) : nullptr,
+        .preview = previewForFamily ? previewForFamily(info) : FormatBarFontPreview{},
         .source = info.source,
     });
   }
@@ -222,14 +222,32 @@ FormatBarActions TextFormatBarPresenter::render(const FormatBarState& state, con
           shownGroup = family.source;
         }
         const bool selected = family.name == state.fontFamily;
-        // Preview each family in its own face where the editor has one loaded.
-        if (family.previewFont != nullptr) {
-          ImGui::PushFont(family.previewFont);
+        ImGui::PushID(family.name.c_str());
+        const float rowHeight = std::max(ImGui::GetTextLineHeight(), family.preview.height);
+        const bool chosen = ImGui::Selectable("##font_family", selected, ImGuiSelectableFlags_None,
+                                              ImVec2(0.0f, rowHeight));
+        const ImVec2 rowMin = ImGui::GetItemRectMin();
+        const ImVec2 rowMax = ImGui::GetItemRectMax();
+        if (family.preview.available()) {
+          const float renderedWidth = std::min(family.preview.width, rowMax.x - rowMin.x);
+          const float renderedHeight = std::min(family.preview.height, rowMax.y - rowMin.y);
+          const ImVec2 previewMin(rowMin.x,
+                                  rowMin.y + (rowMax.y - rowMin.y - renderedHeight) * 0.5f);
+          const ImVec2 previewMax(previewMin.x + renderedWidth, previewMin.y + renderedHeight);
+          ImGui::GetWindowDrawList()->AddImage(static_cast<ImTextureID>(family.preview.texture),
+                                               previewMin, previewMax, ImVec2(0.0f, 0.0f),
+                                               ImVec2(family.preview.uvMaxX, family.preview.uvMaxY),
+                                               ImGui::GetColorU32(ImGuiCol_Text));
+        } else {
+          ImGui::GetWindowDrawList()->AddText(
+              ImVec2(rowMin.x,
+                     rowMin.y + (rowMax.y - rowMin.y - ImGui::GetTextLineHeight()) * 0.5f),
+              ImGui::GetColorU32(ImGuiCol_Text), family.name.c_str());
+          if (ImGui::IsItemVisible()) {
+            actions.requestFontPreviews.push_back(family.name);
+          }
         }
-        const bool chosen = ImGui::Selectable(family.name.c_str(), selected);
-        if (family.previewFont != nullptr) {
-          ImGui::PopFont();
-        }
+        ImGui::PopID();
         if (chosen) {
           actions.setFontFamily = true;
           actions.fontFamily = family.name;

--- a/donner/editor/TextFormatBarPresenter.h
+++ b/donner/editor/TextFormatBarPresenter.h
@@ -18,6 +18,7 @@
 /// bar is a second surface over those commands, not a new styling pipeline.
 
 #include <array>
+#include <cstdint>
 #include <functional>
 #include <string>
 #include <vector>
@@ -32,29 +33,47 @@ namespace donner::editor {
 
 class EditorApp;
 
+/// Donner-rendered family-name preview uploaded for one dropdown row.
+struct FormatBarFontPreview {
+  /// Backend texture handle represented without importing ImGui into this header.
+  std::uint64_t texture = 0;
+  /// Bottom-right UV for texture allocations larger than the preview payload.
+  float uvMaxX = 1.0f;
+  float uvMaxY = 1.0f;
+  /// Logical row size used when the raster payload was produced.
+  float width = 0.0f;
+  float height = 0.0f;
+
+  [[nodiscard]] bool available() const { return texture != 0 && width > 0.0f && height > 0.0f; }
+};
+
 /// One selectable font family in the format bar's family picker.
 struct FormatBarFontFamily {
   /// CSS family name written to the document (e.g. "Roboto", "sans-serif").
   std::string name;
-  /// Face used to preview this family's menu entry, or null to fall back to the
-  /// default UI font. Lets each family render in its own face when the editor
-  /// has it loaded (the embedded Roboto and Fira Code faces today).
-  ImFont* previewFont = nullptr;
+  /// Donner-rendered label in this family's own face. An unavailable preview
+  /// falls back to UI text while the bounded worker request is in flight.
+  FormatBarFontPreview preview;
   /// Origin of this family in the catalog. The picker lists the Embedded group
   /// before the System group and shows a header at each group boundary.
   svg::FontSource source = svg::FontSource::Embedded;
 };
 
-/// Build the picker's family list from a catalog listing (see
-/// `FontCatalog::families()`, which already orders Embedded before System and
-/// sorts within each group). Each entry keeps its CSS family name and source;
-/// `previewFont` is filled from @p previewForFamily for families the editor has
-/// a loaded face for, and left null otherwise (the entry then renders in the
-/// default UI font). Families the catalog lacks are still reachable through the
-/// bar's free-text box, so this list is additive, not a whitelist.
+/**
+ * Build the picker's family list from a catalog listing.
+ *
+ * `FontCatalog::families()` already orders Embedded before System and sorts within each group.
+ * Each entry keeps its CSS family name and source; `preview` is filled for families already
+ * rendered by the bounded preview worker. Families the catalog lacks remain reachable through the
+ * free-text box, so this list is additive rather than a whitelist.
+ *
+ * @param catalogFamilies Ordered font families available to the picker.
+ * @param previewForFamily Returns a rendered preview when one is ready for a family.
+ * @return Picker entries preserving catalog order, source, and available previews.
+ */
 [[nodiscard]] std::vector<FormatBarFontFamily> BuildFormatBarFamilies(
     const std::vector<svg::FontFamilyInfo>& catalogFamilies,
-    const std::function<ImFont*(const svg::FontFamilyInfo&)>& previewForFamily);
+    const std::function<FormatBarFontPreview(const svg::FontFamilyInfo&)>& previewForFamily);
 
 /// Snapshot of the current text formatting context, driving the bar's controls.
 ///
@@ -96,6 +115,8 @@ struct FormatBarActions {
   bool toggleBold = false;
   bool toggleItalic = false;
   bool toggleUnderline = false;
+  /// Visible dropdown rows whose family-name previews are not cached yet.
+  std::vector<std::string> requestFontPreviews;
 };
 
 /// Common font-size presets offered by the size combo (document units).

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -876,18 +876,43 @@ public:
     shell.showSamplePicker_ = true;
   }
 
-  static void ProcessPendingSampleLoad(EditorShell& shell) { shell.processPendingSampleLoad(); }
+  static void ProcessPendingSampleLoad(EditorShell& shell) {
+    shell.processPendingDocumentReplacement();
+  }
 
   static std::string_view PendingSampleLoad(const EditorShell& shell) {
-    return shell.pendingSampleLoadId_;
+    if (!shell.pendingDocumentReplacement_.has_value() ||
+        shell.pendingDocumentReplacement_->kind !=
+            EditorShell::PendingDocumentReplacementKind::Sample) {
+      return {};
+    }
+    return shell.pendingDocumentReplacement_->sampleId;
   }
 
   static bool PendingSampleLoadNeedsConfirmation(const EditorShell& shell) {
-    return shell.pendingSampleLoadNeedsConfirmation_;
+    return shell.pendingDocumentReplacement_.has_value() &&
+           shell.pendingDocumentReplacement_->kind ==
+               EditorShell::PendingDocumentReplacementKind::Sample &&
+           shell.pendingDocumentReplacement_->needsConfirmation;
+  }
+
+  static bool PendingNewDocumentNeedsConfirmation(const EditorShell& shell) {
+    return shell.pendingDocumentReplacement_.has_value() &&
+           shell.pendingDocumentReplacement_->kind ==
+               EditorShell::PendingDocumentReplacementKind::NewDocument &&
+           shell.pendingDocumentReplacement_->needsConfirmation;
+  }
+
+  static void ConfirmPendingDocumentReplacementDiscard(EditorShell& shell) {
+    shell.confirmPendingDocumentReplacementDiscard();
+  }
+
+  static void ProcessPendingDocumentReplacement(EditorShell& shell) {
+    shell.processPendingDocumentReplacement();
   }
 
   static void ConfirmPendingSampleLoadDiscard(EditorShell& shell) {
-    shell.confirmPendingSampleLoadDiscard();
+    shell.confirmPendingDocumentReplacementDiscard();
   }
 
   static void RequestSave(EditorShell& shell) { shell.requestSave(); }
@@ -4070,6 +4095,21 @@ TEST(EditorShellTest, GlobalShortcutsRouteFileDialogsSaveAndQuit) {
   EXPECT_NE(glfwWindowShouldClose(window.rawHandle()), 0);
 }
 
+TEST(EditorShellTest, GlobalNewDocumentShortcutUsesTheSharedReplacementCommand) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+
+  DriveGlobalShortcut(shell, {ImGuiKey_N}, /*ctrl=*/true);
+
+  EXPECT_FALSE(EditorShellTestAccess::App(shell).currentFilePath().has_value());
+  EXPECT_FALSE(EditorShellTestAccess::App(shell).document().document().querySelector("#target"));
+}
+
 TEST(EditorShellTest, GlobalShortcutsRouteCanvasSelectionAndShapeClipboard) {
   gui::EditorWindow window = MakeHiddenWindow();
   if (!window.valid()) {
@@ -4332,6 +4372,31 @@ TEST(EditorShellTest, NewDocumentMenuActionReplacesTheCurrentFileWithAnUntitledC
   EXPECT_NE(EditorShellTestAccess::Source(shell).getText().find("viewBox=\"0 0 640 400\""),
             std::string::npos);
   EXPECT_FALSE(EditorShellTestAccess::App(shell).isDirty());
+}
+
+TEST(EditorShellTest, NewDocumentWaitsForDirtyDocumentDiscardConfirmation) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+  EditorShellTestAccess::Source(shell).setText("<svg>unsaved edits</svg>");
+  EditorShellTestAccess::App(shell).markDirty();
+
+  MenuBarActions actions;
+  actions.newDocument = true;
+  EditorShellTestAccess::ApplyMenuActions(shell, actions);
+
+  EXPECT_TRUE(EditorShellTestAccess::PendingNewDocumentNeedsConfirmation(shell));
+  EXPECT_TRUE(EditorShellTestAccess::App(shell).document().document().querySelector("#target"));
+
+  EditorShellTestAccess::ConfirmPendingDocumentReplacementDiscard(shell);
+  EditorShellTestAccess::ProcessPendingDocumentReplacement(shell);
+  EXPECT_FALSE(EditorShellTestAccess::PendingNewDocumentNeedsConfirmation(shell));
+  EXPECT_FALSE(EditorShellTestAccess::App(shell).document().document().querySelector("#target"));
+  EXPECT_FALSE(EditorShellTestAccess::App(shell).currentFilePath().has_value());
 }
 
 TEST(EditorShellTest, ShapeClipboardCopyCutAndPasteUseCanvasSelection) {
@@ -4679,7 +4744,7 @@ TEST(EditorShellTest, SamplePickerRendersDiscardConfirmationForDirtyDocument) {
   EditorShellTestAccess::QueueSampleLoad(shell, "basic-shapes");
   EXPECT_TRUE(EditorShellTestAccess::ShowSamplePicker(shell));
 
-  // Driving frames runs processPendingSampleLoad(), which flags the load as
+  // Driving frames processes the pending replacement, which flags the load as
   // needing confirmation, and renderSamplePicker() then draws the modal. The
   // pending load and picker both survive because nothing has confirmed yet.
   for (int frame = 0; frame < 3; ++frame) {

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -812,6 +812,22 @@ public:
   static TextEditor& Source(EditorShell& shell) { return shell.textEditor_; }
   static const TextEditor& Source(const EditorShell& shell) { return shell.textEditor_; }
 
+  static void RequestFontPreviews(EditorShell& shell, std::vector<std::string> families) {
+    shell.requestFontPreviews(families);
+  }
+
+  static void AdvanceFontPreviewGeneration(EditorShell& shell) {
+    shell.advanceFontPreviewGeneration();
+  }
+
+  static FormatBarFontPreview FontPreviewForFamily(EditorShell& shell, std::string_view family) {
+    return shell.fontPreviewForFamily(family);
+  }
+
+  static std::size_t CachedFontPreviewCount(const EditorShell& shell) {
+    return shell.fontPreviewBitmaps_.size();
+  }
+
   static bool TryOpenPath(EditorShell& shell, std::string_view path, std::string* error) {
     return shell.tryOpenPath(path, error);
   }
@@ -3183,6 +3199,32 @@ TEST(EditorShellTest, ShellGeometryHelpersClampToViewportAndSelectionCache) {
       ImVec2(844.0f, 390.0f - compactLandscape.topBarHeight));
   EXPECT_LE(compactPalette.bottomRight.x, compactLandscape.panelX);
   EXPECT_FLOAT_EQ(compactPalette.width(), 156.0f);
+}
+
+TEST(EditorShellTest, TextFormatBarLazilyRendersCatalogFamilyInItsOwnFace) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(R"(<svg xmlns="http://www.w3.org/2000/svg"/>)"));
+  ASSERT_TRUE(shell.valid());
+  EXPECT_EQ(EditorShellTestAccess::CachedFontPreviewCount(shell), 0u)
+      << "Constructing the editor must not eagerly materialize the desktop font catalog";
+
+  EditorShellTestAccess::RequestFontPreviews(shell, {"Bebas Neue"});
+  FormatBarFontPreview preview;
+  for (int attempt = 0; attempt < 500 && !preview.available(); ++attempt) {
+    EditorShellTestAccess::AdvanceFontPreviewGeneration(shell);
+    preview = EditorShellTestAccess::FontPreviewForFamily(shell, "Bebas Neue");
+    if (!preview.available()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+  }
+  EXPECT_TRUE(preview.available());
+  EXPECT_EQ(EditorShellTestAccess::CachedFontPreviewCount(shell), 1u);
+  EXPECT_EQ(preview.width, 196.0f);
+  EXPECT_EQ(preview.height, 24.0f);
 }
 
 TEST(EditorShellTest, PrivateUiRenderHelpersCoverPaneToolbarAndPanelStates) {

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -4314,6 +4314,26 @@ TEST(EditorShellTest, MenuActionsRouteDialogAndExportRequestsWithoutCurrentPath)
   EXPECT_TRUE(shell.valid());
 }
 
+TEST(EditorShellTest, NewDocumentMenuActionReplacesTheCurrentFileWithAnUntitledCanvas) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kInitialSvg, "initial.svg"));
+  ASSERT_TRUE(shell.valid());
+
+  MenuBarActions actions;
+  actions.newDocument = true;
+  EditorShellTestAccess::ApplyMenuActions(shell, actions);
+
+  EXPECT_FALSE(EditorShellTestAccess::App(shell).currentFilePath().has_value());
+  EXPECT_FALSE(EditorShellTestAccess::App(shell).document().document().querySelector("#target"));
+  EXPECT_NE(EditorShellTestAccess::Source(shell).getText().find("viewBox=\"0 0 640 400\""),
+            std::string::npos);
+  EXPECT_FALSE(EditorShellTestAccess::App(shell).isDirty());
+}
+
 TEST(EditorShellTest, ShapeClipboardCopyCutAndPasteUseCanvasSelection) {
   gui::EditorWindow window = MakeHiddenWindow();
   if (!window.valid()) {

--- a/donner/editor/tests/MenuBarPresenter_tests.cc
+++ b/donner/editor/tests/MenuBarPresenter_tests.cc
@@ -204,6 +204,10 @@ TEST(MenuBarPresenterActionsTest, ApplyMenuBarCommandMapsSimpleCommandsToActions
   EXPECT_TRUE(actions.openAbout);
 
   actions = MenuBarActions{};
+  ApplyMenuBarCommand(true, MenuBarCommand::NewDocument, state, &actions);
+  EXPECT_TRUE(actions.newDocument);
+
+  actions = MenuBarActions{};
   ApplyMenuBarCommand(true, MenuBarCommand::OpenFile, state, &actions);
   EXPECT_TRUE(actions.openFile);
 

--- a/donner/editor/tests/SamplePickerPresenter_tests.cc
+++ b/donner/editor/tests/SamplePickerPresenter_tests.cc
@@ -82,6 +82,10 @@ TEST(SamplePickerPresenter, CommandsProduceSemanticActions) {
   EXPECT_TRUE(actions.dismiss);
 
   actions = SamplePickerActions{};
+  ApplySamplePickerCommand(true, SamplePickerCommand::NewDocument, {}, &actions);
+  EXPECT_TRUE(actions.newDocument);
+
+  actions = SamplePickerActions{};
   ApplySamplePickerCommand(true, SamplePickerCommand::OpenFile, {}, &actions);
   EXPECT_TRUE(actions.openFile);
 

--- a/donner/editor/tests/SamplePickerPresenter_tests.cc
+++ b/donner/editor/tests/SamplePickerPresenter_tests.cc
@@ -126,13 +126,14 @@ TEST(SamplePickerPresenter, CommandsIgnoreEmptySampleAndNullAccumulator) {
 
 /// True when no action flag is set on @p actions.
 bool NoActions(const SamplePickerActions& actions) {
-  return !actions.dismiss && !actions.openFile && !actions.loadSample && !actions.openGitHub &&
-         actions.sampleId.empty();
+  return !actions.dismiss && !actions.newDocument && !actions.openFile && !actions.loadSample &&
+         !actions.openGitHub && actions.sampleId.empty();
 }
 
 /// Accumulate every edge-triggered flag from @p frame into @p merged.
 void MergeActions(SamplePickerActions& merged, const SamplePickerActions& frame) {
   merged.dismiss = merged.dismiss || frame.dismiss;
+  merged.newDocument = merged.newDocument || frame.newDocument;
   merged.openFile = merged.openFile || frame.openFile;
   merged.loadSample = merged.loadSample || frame.loadSample;
   merged.openGitHub = merged.openGitHub || frame.openGitHub;
@@ -272,31 +273,41 @@ TEST_F(SamplePickerPresenterImGuiTest, ClickingDismissButtonEmitsDismiss) {
   EXPECT_TRUE(dismissed.dismiss) << "Dismiss button not found along the top-right edge";
 }
 
-TEST_F(SamplePickerPresenterImGuiTest, ClickingActionButtonsEmitsOpenFileAndOpenGitHub) {
+TEST_F(SamplePickerPresenterImGuiTest, ClickingActionButtonsEmitsNewOpenFileAndOpenGitHub) {
   const SamplePickerState state;
   constexpr float kHostWidth = 1024.0f;
 
   Frame(state, {}, kHostWidth);
 
-  // The "Open SVG" button hugs the left content edge below the heading text;
+  // The action row hugs the left content edge below the heading text;
   // its vertical position depends on font metrics, so probe downward.
-  float openRowY = -1.0f;
+  float actionRowY = -1.0f;
   for (float y = 56.0f; y <= 400.0f; y += 6.0f) {
     const SamplePickerActions actions = Click(state, {}, kHostWidth, ImVec2(60.0f, y));
     EXPECT_FALSE(actions.dismiss);
     EXPECT_FALSE(actions.loadSample);
-    if (actions.openFile) {
-      openRowY = y;
+    if (actions.newDocument) {
+      actionRowY = y;
       break;
     }
   }
-  ASSERT_GT(openRowY, 0.0f) << "Open SVG button not found along the left edge";
+  ASSERT_GT(actionRowY, 0.0f) << "New Document button not found along the left edge";
 
-  // The GitHub action sits on the same row, right of the 112px-wide Open SVG
-  // button (8px gap).
+  bool openedFile = false;
+  for (float x = 140.0f; x <= 300.0f; x += 12.0f) {
+    const SamplePickerActions actions = Click(state, {}, kHostWidth, ImVec2(x, actionRowY));
+    EXPECT_FALSE(actions.dismiss);
+    EXPECT_FALSE(actions.loadSample);
+    if (actions.openFile) {
+      openedFile = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(openedFile) << "Open SVG action not found after New Document";
+
   bool openedGitHub = false;
-  for (float x = 132.0f; x <= 300.0f; x += 12.0f) {
-    const SamplePickerActions actions = Click(state, {}, kHostWidth, ImVec2(x, openRowY));
+  for (float x = 260.0f; x <= 520.0f; x += 12.0f) {
+    const SamplePickerActions actions = Click(state, {}, kHostWidth, ImVec2(x, actionRowY));
     EXPECT_FALSE(actions.dismiss);
     EXPECT_FALSE(actions.loadSample);
     if (actions.openGitHub) {

--- a/donner/editor/tests/TextFormatBarPresenter_tests.cc
+++ b/donner/editor/tests/TextFormatBarPresenter_tests.cc
@@ -288,10 +288,16 @@ TEST(TextFormatBarPresenterActionsTest, NoActionsQueueNoMutation) {
 // ---------------------------------------------------------------------------
 
 TEST(TextFormatBarPresenterActionsTest, BuildFormatBarFamiliesGroupsEmbeddedThenSystem) {
-  // Distinct sentinel pointers stand in for loaded ImGui faces; the builder only
-  // stores them, never dereferences them.
-  ImFont* const robotoFace = reinterpret_cast<ImFont*>(0x10);
-  ImFont* const codeFace = reinterpret_cast<ImFont*>(0x20);
+  const FormatBarFontPreview robotoPreview{
+      .texture = 0x10,
+      .width = 100.0f,
+      .height = 20.0f,
+  };
+  const FormatBarFontPreview codePreview{
+      .texture = 0x20,
+      .width = 100.0f,
+      .height = 20.0f,
+  };
 
   // Mirror FontCatalog::families(): the Embedded group first, then System, each
   // already sorted within its group.
@@ -302,14 +308,14 @@ TEST(TextFormatBarPresenterActionsTest, BuildFormatBarFamiliesGroupsEmbeddedThen
   };
 
   const std::vector<FormatBarFontFamily> built =
-      BuildFormatBarFamilies(catalog, [&](const svg::FontFamilyInfo& info) -> ImFont* {
+      BuildFormatBarFamilies(catalog, [&](const svg::FontFamilyInfo& info) {
         if (info.family == "Roboto") {
-          return robotoFace;
+          return robotoPreview;
         }
         if (info.family == "Fira Code") {
-          return codeFace;
+          return codePreview;
         }
-        return nullptr;
+        return FormatBarFontPreview{};
       });
 
   ASSERT_EQ(built.size(), 3u);
@@ -317,14 +323,14 @@ TEST(TextFormatBarPresenterActionsTest, BuildFormatBarFamiliesGroupsEmbeddedThen
   // the right rows.
   EXPECT_EQ(built[0].name, "Fira Code");
   EXPECT_EQ(built[0].source, svg::FontSource::Embedded);
-  EXPECT_EQ(built[0].previewFont, codeFace);
+  EXPECT_EQ(built[0].preview.texture, codePreview.texture);
   EXPECT_EQ(built[1].name, "Roboto");
   EXPECT_EQ(built[1].source, svg::FontSource::Embedded);
-  EXPECT_EQ(built[1].previewFont, robotoFace);
+  EXPECT_EQ(built[1].preview.texture, robotoPreview.texture);
   EXPECT_EQ(built[2].name, "Helvetica");
   EXPECT_EQ(built[2].source, svg::FontSource::System);
   // A System family with no loaded face previews in the default UI font (null).
-  EXPECT_EQ(built[2].previewFont, nullptr);
+  EXPECT_FALSE(built[2].preview.available());
 }
 
 TEST(TextFormatBarPresenterActionsTest, BuildFormatBarFamiliesToleratesNullPreviewResolver) {
@@ -334,7 +340,7 @@ TEST(TextFormatBarPresenterActionsTest, BuildFormatBarFamiliesToleratesNullPrevi
   const std::vector<FormatBarFontFamily> built = BuildFormatBarFamilies(catalog, {});
   ASSERT_EQ(built.size(), 1u);
   EXPECT_EQ(built[0].name, "Roboto");
-  EXPECT_EQ(built[0].previewFont, nullptr);
+  EXPECT_FALSE(built[0].preview.available());
 }
 
 // ---------------------------------------------------------------------------
@@ -399,7 +405,10 @@ TEST_F(TextFormatBarPresenterTest, VisibleBarRendersControlsWithoutImplicitActio
   state.hasFontSize = true;
   state.bold = true;
   state.boldToggleFont = face;
-  state.families = {FormatBarFontFamily{"Roboto", face}, FormatBarFontFamily{"serif", nullptr}};
+  state.families = {
+      FormatBarFontFamily{.name = "Roboto"},
+      FormatBarFontFamily{.name = "serif"},
+  };
 
   // Two frames: the first seeds internal buffers, the second exercises the
   // steady state. Neither involves user input, so no actions should fire.
@@ -429,6 +438,9 @@ void MergeActions(FormatBarActions& merged, const FormatBarActions& frame) {
   merged.toggleBold = merged.toggleBold || frame.toggleBold;
   merged.toggleItalic = merged.toggleItalic || frame.toggleItalic;
   merged.toggleUnderline = merged.toggleUnderline || frame.toggleUnderline;
+  merged.requestFontPreviews.insert(merged.requestFontPreviews.end(),
+                                    frame.requestFontPreviews.begin(),
+                                    frame.requestFontPreviews.end());
 }
 
 class TextFormatBarPresenterInputTest : public ::testing::Test {
@@ -469,9 +481,9 @@ protected:
     // Two Embedded families followed by one System family: the picker prints
     // one header per group and no header between same-group rows.
     state.families = {
-        FormatBarFontFamily{"Roboto", face, svg::FontSource::Embedded},
-        FormatBarFontFamily{"Fira Code", face, svg::FontSource::Embedded},
-        FormatBarFontFamily{"Zilla Slab", nullptr, svg::FontSource::System},
+        FormatBarFontFamily{.name = "Roboto", .source = svg::FontSource::Embedded},
+        FormatBarFontFamily{.name = "Fira Code", .source = svg::FontSource::Embedded},
+        FormatBarFontFamily{.name = "Zilla Slab", .source = svg::FontSource::System},
     };
     return state;
   }
@@ -614,6 +626,16 @@ TEST_F(TextFormatBarPresenterInputTest, ControlsRemainClickableAfterCanvasTakesF
 
   const FormatBarActions actions = ClickOverCanvas(state, ToggleCenter(BoldLeft()));
   EXPECT_TRUE(actions.toggleBold);
+}
+
+TEST_F(TextFormatBarPresenterInputTest, OpenFamilyMenuRequestsVisibleMissingPreviews) {
+  const FormatBarState state = MakeState();
+  Frame(state);
+  OpenComboPopup(state, ToggleCenter(FamilyArrowLeft()));
+
+  const FormatBarActions actions = Frame(state);
+  EXPECT_EQ(actions.requestFontPreviews,
+            (std::vector<std::string>{"Roboto", "Fira Code", "Zilla Slab"}));
 }
 
 TEST_F(TextFormatBarPresenterInputTest, DraggingSizeControlCommitsNewFontSize) {

--- a/donner/svg/BUILD.bazel
+++ b/donner/svg/BUILD.bazel
@@ -176,6 +176,7 @@ donner_cc_library(
         ":svg_document_handle",
         "//donner/svg/components",
         "//donner/svg/components/animation:components",
+        "//donner/svg/components/text:text_invalidation",
         "//donner/svg/core",
         "//donner/svg/parser:parser_core",
         "//donner/svg/properties",

--- a/donner/svg/SVGDocument.cc
+++ b/donner/svg/SVGDocument.cc
@@ -26,8 +26,8 @@
 #include "donner/svg/components/paint/ClipPathComponent.h"
 #include "donner/svg/components/resources/ResourceManagerContext.h"
 #include "donner/svg/components/style/ComputedStyleComponent.h"
-#include "donner/svg/components/text/ComputedTextGeometryComponent.h"
 #include "donner/svg/components/text/TextComponent.h"
+#include "donner/svg/components/text/TextInvalidation.h"
 #include "donner/svg/components/text/TextPositioningComponent.h"
 #include "donner/svg/components/text/TextRootComponent.h"
 #include "donner/svg/renderer/RenderingContext.h"
@@ -50,27 +50,6 @@ SourceRange MutationRange(std::string_view source, const xml::XMLMutation& mutat
 
   return mutation.node.getNodeLocation().value_or(
       SourceRange{FileOffset::Offset(0), FileOffset::Offset(0)});
-}
-
-void InvalidateTextGeometry(EntityHandle handle) {
-  Registry& registry = *handle.registry();
-  Entity current = handle.entity();
-  while (current != entt::null) {
-    if (registry.any_of<components::TextRootComponent>(current)) {
-      registry.remove<components::ComputedTextGeometryComponent>(current);
-      registry.get_or_emplace<components::DirtyFlagsComponent>(current).mark(
-          components::DirtyFlagsComponent::TextGeometry |
-          components::DirtyFlagsComponent::RenderInstance);
-      return;
-    }
-
-    const auto* tree = registry.try_get<donner::components::TreeComponent>(current);
-    if (tree == nullptr) {
-      return;
-    }
-
-    current = tree->parent();
-  }
 }
 
 std::optional<EntityHandle> TextElementHandleForNodeValueMutation(
@@ -116,7 +95,7 @@ std::optional<ParseDiagnostic> ApplyNodeValueChanged(std::string_view source,
     text.text = *mutation.value;
     text.textChunks.clear();
     text.textChunks.emplace_back(*mutation.value);
-    InvalidateTextGeometry(*targetHandle);
+    (void)components::InvalidateTextLayout(*targetHandle);
     return std::nullopt;
   }
 

--- a/donner/svg/SVGElement.cc
+++ b/donner/svg/SVGElement.cc
@@ -24,6 +24,8 @@
 #include "donner/svg/components/style/ComputedStyleComponent.h"
 #include "donner/svg/components/style/StyleComponent.h"
 #include "donner/svg/components/style/StyleSystem.h"
+#include "donner/svg/components/text/TextInvalidation.h"
+#include "donner/svg/components/text/TextRootComponent.h"
 #include "donner/svg/properties/PresentationAttributeParsing.h"
 
 namespace donner::svg {
@@ -33,6 +35,19 @@ namespace {
 /// Mark an entity with dirty flags for incremental invalidation.
 void markDirty(EntityHandle handle, uint16_t flags) {
   handle.get_or_emplace<components::DirtyFlagsComponent>().mark(flags);
+}
+
+/**
+ * Mark a style-cascade change on \p handle, plus any \p extraFlags.
+ *
+ * Text layout is memoized per text root in \ref components::ComputedTextGeometryComponent and both
+ * renderers draw straight out of it, so a style change inside a text subtree has to drop it. The
+ * font properties (`font-family`, `font-size`, `font-weight`, `letter-spacing`, ...) are exactly
+ * the ones an editor writes, and without this every one of them is a silent no-op.
+ */
+void markStyleCascadeDirty(EntityHandle handle, uint16_t extraFlags = 0) {
+  markDirty(handle, components::DirtyFlagsComponent::StyleCascade | extraFlags);
+  (void)components::InvalidateTextLayout(handle);
 }
 
 void invalidateComputedStyle(EntityHandle handle) {
@@ -53,7 +68,7 @@ void markNeedsFullStyleRecompute(EntityHandle handle) {
 
 void markConditionalProcessingChanged(EntityHandle handle) {
   markNeedsFullStyleRecompute(handle);
-  markDirty(handle, components::DirtyFlagsComponent::StyleCascade);
+  markStyleCascadeDirty(handle);
 }
 
 void invalidateComputedStyleForDescendants(EntityHandle handle) {
@@ -77,6 +92,11 @@ void propagateStyleDirtyToDescendants(EntityHandle handle) {
           markDirty(desc, components::DirtyFlagsComponent::Style |
                               components::DirtyFlagsComponent::Paint |
                               components::DirtyFlagsComponent::RenderInstance);
+          // The font properties inherit, so a style change on an ancestor restyles every text
+          // root beneath it. Match on the root itself to keep this O(1) per descendant.
+          if (desc.all_of<components::TextRootComponent>()) {
+            (void)components::InvalidateTextLayout(desc);
+          }
         });
   }
 }
@@ -402,7 +422,7 @@ void SVGElement::setClassName(std::string_view name) {
   markNeedsFullStyleRecompute(handle_);
   invalidateComputedStyle(handle_);
   invalidateComputedStyleForDescendants(handle_);
-  markDirty(handle_, components::DirtyFlagsComponent::StyleCascade);
+  markStyleCascadeDirty(handle_);
   propagateStyleDirtyToDescendants(handle_);
 }
 
@@ -418,7 +438,7 @@ void SVGElement::setStyle(std::string_view style) {
   markNeedsFullStyleRecompute(handle_);
   invalidateComputedStyleForDescendants(handle_);
 
-  markDirty(handle_, components::DirtyFlagsComponent::StyleCascade);
+  markStyleCascadeDirty(handle_);
   propagateStyleDirtyToDescendants(handle_);
 }
 
@@ -434,7 +454,7 @@ void SVGElement::updateStyle(std::string_view style) {
   invalidateComputedStyle(handle_);
   invalidateComputedStyleForDescendants(handle_);
 
-  markDirty(handle_, components::DirtyFlagsComponent::StyleCascade);
+  markStyleCascadeDirty(handle_);
   propagateStyleDirtyToDescendants(handle_);
 }
 
@@ -499,8 +519,7 @@ ParseResult<bool> SVGElement::trySetPresentationAttribute(std::string_view name,
       // (cx, cy, r, d, etc.), mark style cascade + shape dirty.
       markNeedsFullStyleRecompute(handle_);
       invalidateComputedStyle(handle_);
-      markDirty(handle_, components::DirtyFlagsComponent::StyleCascade |
-                             components::DirtyFlagsComponent::Shape);
+      markStyleCascadeDirty(handle_, components::DirtyFlagsComponent::Shape);
       if (PropertyRegistry::isPresentationAttributeInherited(actualName)) {
         invalidateComputedStyleForDescendants(handle_);
         propagateStyleDirtyToDescendants(handle_);

--- a/donner/svg/SVGTextContentElement.cc
+++ b/donner/svg/SVGTextContentElement.cc
@@ -2,11 +2,8 @@
 
 #include "donner/base/ParseWarningSink.h"
 #include "donner/base/Vector2.h"
-#include "donner/base/xml/components/TreeComponent.h"
-#include "donner/svg/components/DirtyFlagsComponent.h"
-#include "donner/svg/components/text/ComputedTextGeometryComponent.h"
 #include "donner/svg/components/text/TextComponent.h"
-#include "donner/svg/components/text/TextRootComponent.h"
+#include "donner/svg/components/text/TextInvalidation.h"
 #include "donner/svg/text/TextEngine.h"
 
 namespace donner::svg {
@@ -36,23 +33,7 @@ SVGTextContentElement::SVGTextContentElement(EntityHandle handle) : SVGGraphicsE
 
 void SVGTextContentElement::invalidateTextGeometry() {
   [[maybe_unused]] DocumentWriteAccess access = handle_.writeAccess();
-  // Walk up to the text root and remove cached text layout.
-  Registry& registry = *handle_.registry();
-  Entity current = handle_.entity();
-  while (current != entt::null) {
-    if (registry.any_of<components::TextRootComponent>(current)) {
-      registry.remove<components::ComputedTextGeometryComponent>(current);
-      registry.get_or_emplace<components::DirtyFlagsComponent>(current).mark(
-          components::DirtyFlagsComponent::TextGeometry |
-          components::DirtyFlagsComponent::RenderInstance);
-      return;
-    }
-    const auto* tree = registry.try_get<donner::components::TreeComponent>(current);
-    if (!tree) {
-      break;
-    }
-    current = tree->parent();
-  }
+  (void)components::InvalidateTextLayout(handle_);
 }
 
 std::vector<Path> SVGTextContentElement::computedGlyphPaths() const {

--- a/donner/svg/components/text/BUILD.bazel
+++ b/donner/svg/components/text/BUILD.bazel
@@ -23,6 +23,25 @@ cc_library(
 )
 
 cc_library(
+    name = "text_invalidation",
+    srcs = [
+        "TextInvalidation.cc",
+    ],
+    hdrs = [
+        "TextInvalidation.h",
+    ],
+    visibility = [
+        "//donner/svg:__subpackages__",
+    ],
+    deps = [
+        ":components",
+        "//donner/base",
+        "//donner/base/xml/components",
+        "//donner/svg/components:components_core",
+    ],
+)
+
+cc_library(
     name = "text_positioning_presentation",
     srcs = [
         "TextPositioningPresentation.cc",
@@ -35,6 +54,7 @@ cc_library(
     ],
     deps = [
         ":components",
+        ":text_invalidation",
         "//donner/base",
         "//donner/base/xml/components",
         "//donner/svg/components:components_core",

--- a/donner/svg/components/text/TextInvalidation.cc
+++ b/donner/svg/components/text/TextInvalidation.cc
@@ -1,0 +1,37 @@
+#include "donner/svg/components/text/TextInvalidation.h"
+
+#include "donner/base/xml/components/TreeComponent.h"
+#include "donner/svg/components/DirtyFlagsComponent.h"
+#include "donner/svg/components/text/ComputedTextGeometryComponent.h"
+#include "donner/svg/components/text/TextRootComponent.h"
+
+namespace donner::svg::components {
+
+Entity InvalidateTextLayout(EntityHandle handle) {
+  Registry& registry = *handle.registry();
+  // Documents without any text at all are the common case; skip the ancestor walk entirely.
+  if (registry.storage<TextRootComponent>().empty()) {
+    return entt::null;
+  }
+
+  Entity current = handle.entity();
+  while (current != entt::null) {
+    if (registry.all_of<TextRootComponent>(current)) {
+      registry.remove<ComputedTextGeometryComponent>(current);
+      registry.get_or_emplace<DirtyFlagsComponent>(current).mark(
+          DirtyFlagsComponent::TextGeometry | DirtyFlagsComponent::RenderInstance);
+      return current;
+    }
+
+    const auto* tree = registry.try_get<donner::components::TreeComponent>(current);
+    if (!tree) {
+      break;
+    }
+
+    current = tree->parent();
+  }
+
+  return entt::null;
+}
+
+}  // namespace donner::svg::components

--- a/donner/svg/components/text/TextInvalidation.h
+++ b/donner/svg/components/text/TextInvalidation.h
@@ -1,0 +1,25 @@
+#pragma once
+/// @file
+
+#include "donner/base/EcsRegistry.h"
+
+namespace donner::svg::components {
+
+/**
+ * Drop the cached text layout of the text root enclosing \p handle.
+ *
+ * \ref ComputedTextGeometryComponent is a memoized layout derived from the text root's computed
+ * style, text content, and positioning attributes. Both renderers draw straight out of it, so any
+ * mutation that can change one of those inputs must drop it or the old glyphs keep rendering.
+ *
+ * Walks up from \p handle until it finds the \ref TextRootComponent, so it is safe to call with a
+ * `<tspan>`, `<textPath>`, or the `<text>` root itself. Calling it on an entity outside any text
+ * subtree is a no-op.
+ *
+ * @param handle Element whose enclosing text root should be invalidated.
+ * @return The text root entity that was invalidated, or `entt::null` if \p handle is not inside a
+ *   text subtree.
+ */
+Entity InvalidateTextLayout(EntityHandle handle);
+
+}  // namespace donner::svg::components

--- a/donner/svg/components/text/TextPositioningPresentation.cc
+++ b/donner/svg/components/text/TextPositioningPresentation.cc
@@ -4,12 +4,9 @@
 
 #include "donner/base/parser/LengthParser.h"
 #include "donner/base/parser/NumberParser.h"
-#include "donner/base/xml/components/TreeComponent.h"
-#include "donner/svg/components/DirtyFlagsComponent.h"
 #include "donner/svg/components/text/ComputedTextComponent.h"
-#include "donner/svg/components/text/ComputedTextGeometryComponent.h"
+#include "donner/svg/components/text/TextInvalidation.h"
 #include "donner/svg/components/text/TextPositioningComponent.h"
-#include "donner/svg/components/text/TextRootComponent.h"
 #include "donner/svg/parser/ListParser.h"
 
 namespace donner::svg::components {
@@ -63,24 +60,12 @@ std::optional<SmallVector<double, 1>> ParseRotateList(std::string_view value) {
   return list;
 }
 
-/// Invalidate the enclosing text root's cached layout, mirroring
-/// `SVGTextContentElement::invalidateTextGeometry()`.
+/// Invalidate the enclosing text root's cached layout. Positioning attributes also feed
+/// \ref ComputedTextComponent (per-character x/y/dx/dy/rotate lists), so that is dropped too.
 void InvalidateTextRootLayout(EntityHandle handle) {
-  Registry& registry = *handle.registry();
-  Entity current = handle.entity();
-  while (current != entt::null) {
-    if (registry.any_of<TextRootComponent>(current)) {
-      registry.remove<ComputedTextGeometryComponent>(current);
-      registry.remove<ComputedTextComponent>(current);
-      registry.get_or_emplace<DirtyFlagsComponent>(current).mark(
-          DirtyFlagsComponent::TextGeometry | DirtyFlagsComponent::RenderInstance);
-      return;
-    }
-    const auto* tree = registry.try_get<donner::components::TreeComponent>(current);
-    if (!tree) {
-      break;
-    }
-    current = tree->parent();
+  const Entity textRoot = InvalidateTextLayout(handle);
+  if (textRoot != entt::null) {
+    handle.registry()->remove<ComputedTextComponent>(textRoot);
   }
 }
 

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1985,6 +1985,12 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     std::vector<SceneInstance> sceneInstances;
     wgpu::Buffer sceneChunkBuffer;
     wgpu::Buffer sceneRecordBuffer;
+    /// Stable identities of the two buffers above (see
+    /// `GeodeDevice::AllocateBufferId`). The encoder's bind-group cache
+    /// outlives the document, so it keys on these rather than on the handle
+    /// addresses, which are recycled once the document is destroyed.
+    uint64_t sceneChunkBufferId = 0;
+    uint64_t sceneRecordBufferId = 0;
     uint32_t sceneFirstInstance = 0;
     /// Byte offset of the first instance's record inside sceneRecordBuffer
     /// (indices are global across slab chunks; offsets are per-buffer).
@@ -2331,6 +2337,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       geode::GeoEncoder::SceneBatchBinding binding = {};
       binding.chunkBuffer = batch.sceneChunkBuffer;
       binding.recordBuffer = batch.sceneRecordBuffer;
+      binding.chunkBufferId = batch.sceneChunkBufferId;
+      binding.recordBufferId = batch.sceneRecordBufferId;
       binding.firstRecordOffset = batch.sceneFirstRecordOffset;
       binding.instanceCount = static_cast<uint32_t>(batch.sceneInstances.size());
       binding.vertexCount = batch.sceneVertexCount;
@@ -2497,6 +2505,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
           recordSlotPtr != nullptr ? *recordSlotPtr : residentFillSlot->recordSlot;
       const wgpu::Buffer chunk = residentFillSlot->buffer;
       const wgpu::Buffer recordBuf = effectiveRecordSlot.buffer;
+      const uint64_t chunkId = residentFillSlot->bufferId;
+      const uint64_t recordBufId = effectiveRecordSlot.bufferId;
       const uint32_t recordIndex = effectiveRecordSlot.index;
       const uint32_t vertexCount = encoded->boundingDrawVertexCount();
 
@@ -2511,8 +2521,11 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       };
 
       if (pendingBatch.has_value() && pendingBatch->mode == PendingBatch::Mode::Scene) {
-        if (pendingBatch->sceneChunkBuffer == chunk &&
-            pendingBatch->sceneRecordBuffer == recordBuf &&
+        // Buffer identities, not handles: the two are interchangeable inside
+        // one frame, but comparing ids keeps every "is this the same buffer?"
+        // question in this file answered the same way.
+        if (pendingBatch->sceneChunkBufferId == chunkId &&
+            pendingBatch->sceneRecordBufferId == recordBufId &&
             pendingBatch->sceneClipVersion == clipVersion &&
             pendingBatch->sceneFirstInstance + pendingBatch->sceneInstances.size() ==
                 recordIndex) {
@@ -2526,6 +2539,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
           pendingBatch->mode = PendingBatch::Mode::Scene;
           pendingBatch->sceneChunkBuffer = chunk;
           pendingBatch->sceneRecordBuffer = recordBuf;
+          pendingBatch->sceneChunkBufferId = chunkId;
+          pendingBatch->sceneRecordBufferId = recordBufId;
           pendingBatch->sceneFirstInstance = recordIndex;
           pendingBatch->sceneFirstRecordOffset = effectiveRecordSlot.offset;
           pendingBatch->sceneClipVersion = clipVersion;
@@ -2571,17 +2586,22 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
               firstRecordSlotPtr != nullptr ? *firstRecordSlotPtr : first.slot->recordSlot;
           const wgpu::Buffer firstChunk = first.slot->buffer;
           const wgpu::Buffer firstRecordBuf = effectiveFirstRecordSlot.buffer;
+          const uint64_t firstChunkId = first.slot->bufferId;
+          const uint64_t firstRecordBufId = effectiveFirstRecordSlot.bufferId;
           const uint32_t firstIndex = effectiveFirstRecordSlot.index;
           pendingBatch = PendingBatch{};
           pendingBatch->mode = PendingBatch::Mode::Scene;
           pendingBatch->sceneChunkBuffer = firstChunk;
           pendingBatch->sceneRecordBuffer = firstRecordBuf;
+          pendingBatch->sceneChunkBufferId = firstChunkId;
+          pendingBatch->sceneRecordBufferId = firstRecordBufId;
           pendingBatch->sceneFirstInstance = firstIndex;
           pendingBatch->sceneFirstRecordOffset = effectiveFirstRecordSlot.offset;
           pendingBatch->sceneClipVersion = clipVersion;
           pendingBatch->sceneVertexCount = first.vertexCount;
           pendingBatch->sceneInstances.push_back(first);
-          if (firstChunk == chunk && firstRecordBuf == recordBuf && firstIndex + 1 == recordIndex) {
+          if (firstChunkId == chunkId && firstRecordBufId == recordBufId &&
+              firstIndex + 1 == recordIndex) {
             appendSceneInstance(*pendingBatch,
                                 PendingBatch::SceneInstance{residentFillSlot, encoded, &path,
                                                             color, rule,
@@ -2593,6 +2613,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
             pendingBatch->mode = PendingBatch::Mode::Scene;
             pendingBatch->sceneChunkBuffer = chunk;
             pendingBatch->sceneRecordBuffer = recordBuf;
+            pendingBatch->sceneChunkBufferId = chunkId;
+            pendingBatch->sceneRecordBufferId = recordBufId;
             pendingBatch->sceneFirstInstance = recordIndex;
             pendingBatch->sceneFirstRecordOffset = effectiveRecordSlot.offset;
             pendingBatch->sceneClipVersion = clipVersion;
@@ -2631,6 +2653,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       pendingBatch->mode = PendingBatch::Mode::Scene;
       pendingBatch->sceneChunkBuffer = chunk;
       pendingBatch->sceneRecordBuffer = recordBuf;
+      pendingBatch->sceneChunkBufferId = chunkId;
+      pendingBatch->sceneRecordBufferId = recordBufId;
       pendingBatch->sceneFirstInstance = recordIndex;
       pendingBatch->sceneFirstRecordOffset = effectiveRecordSlot.offset;
       pendingBatch->sceneClipVersion = clipVersion;

--- a/donner/svg/renderer/geode/BUILD.bazel
+++ b/donner/svg/renderer/geode/BUILD.bazel
@@ -131,6 +131,10 @@ donner_cc_library(
     target_compatible_with = _GEODE_ONLY,
     visibility = ["//donner/svg/renderer:__subpackages__"],
     deps = [
+        # The slabs stamp every buffer they create with
+        # `GeodeDevice::AllocateBufferId`, which is defined out of line, so
+        # this is a link dependency and not just an include.
+        ":geode_device",
         ":geode_wgpu_util",
         "//third_party/webgpu-cpp:webgpu_cpp",
     ],

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -389,6 +389,12 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
     ScopedWgpuHandle<wgpu::Buffer> buffer;
     uint64_t capacity = 0;
     uint64_t offset = 0;  // Next unused byte within `buffer`.
+    /// Stable identity of `buffer` (see `GeodeDevice::AllocateBufferId`),
+    /// re-stamped on every growth. Arena buffers are recycled through the
+    /// device's buffer pool, so two arenas at different times can hold the
+    /// same handle address with completely different contents; anything
+    /// that caches across frames must compare this id instead.
+    uint64_t bufferId = 0;
     std::vector<ScopedWgpuHandle<wgpu::Buffer>> retired;
     wgpu::BufferUsage usage = wgpu::BufferUsage::CopyDst;
     const char* label = "GeodeArena";
@@ -459,6 +465,8 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
     wgpu::Buffer buffer;
     uint64_t offset;
     uint64_t size;
+    /// Stable identity of `buffer`; see `Arena::bufferId`.
+    uint64_t bufferId = 0;
   };
   /// One shared uniform allocation for every scene-batch draw this encoder
   /// records while the uniform bytes stay unchanged (identity mvp plus
@@ -514,6 +522,10 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
         device->countBuffer();
         arena.capacity = newCap;
       }
+      // Fresh identity for the new backing buffer, pooled or not: the
+      // contents restart at offset 0 and share nothing with the retired
+      // buffer, even when the pool hands back the same handle address.
+      arena.bufferId = GeodeDevice::AllocateBufferId();
       arena.offset = 0;
     }
   }
@@ -584,7 +596,7 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
     device->queue().writeBuffer(arena.buffer.get(), alignedOffset, data, size);
     device->countBufferWrite(size);
     arena.offset = alignedOffset + size;
-    return {arena.buffer.get(), alignedOffset, size};
+    return {arena.buffer.get(), alignedOffset, size, arena.bufferId};
   }
 
   /// Allocate a read-only storage binding for `byteCount` bytes of `data`,
@@ -1755,6 +1767,7 @@ void GeoEncoder::Impl::uploadResidentGeometry(GeodeResidentSlot& slot, const Enc
     return;
   }
   slot.buffer = alloc.buffer;
+  slot.bufferId = alloc.bufferId;
   slot.allocationOffset = alloc.offset;
   slot.allocationSize = alloc.size;
 
@@ -2164,7 +2177,10 @@ void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,
   impl_->populateBatchUniform(u, args, Transform2d(), /*identityMvp=*/true);
   Impl::Allocation uniAlloc = {};
   if (binding.recordSlab != nullptr) {
-    uniAlloc.buffer = binding.recordSlab->acquireBatchUniform(*impl_->device, &u, sizeof(Uniforms));
+    const GeodeRecordSlab::BatchUniformHandle uniform =
+        binding.recordSlab->acquireBatchUniform(*impl_->device, &u, sizeof(Uniforms));
+    uniAlloc.buffer = uniform.buffer;
+    uniAlloc.bufferId = uniform.bufferId;
     uniAlloc.offset = 0;
     uniAlloc.size = sizeof(Uniforms);
   }
@@ -2210,17 +2226,28 @@ void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,
   chunkEntry(9, 9);
   chunkEntry(10, 10);
 
+  // Buffer IDENTITIES, never handle addresses: the cache lives on the
+  // device, which outlives the documents drawn on it, and a destroyed
+  // document's handle addresses are handed straight back out to the next
+  // one. See `GeodeDevice::SceneBatchBindGroupKey`.
   GeodeDevice::SceneBatchBindGroupKey cacheKey = {};
-  cacheKey.uniformBuffer = uniAlloc.buffer;
+  cacheKey.uniformBufferId = uniAlloc.bufferId;
   cacheKey.uniformOffset = uniAlloc.offset;
   cacheKey.uniformSize = uniAlloc.size;
-  cacheKey.chunkBuffer = binding.chunkBuffer;
+  cacheKey.chunkBufferId = binding.chunkBufferId;
   cacheKey.chunkBytes = chunkBytes;
-  cacheKey.recordBuffer = binding.recordBuffer;
+  cacheKey.recordBufferId = binding.recordBufferId;
   cacheKey.recordOffset = recordSpanStart;
   cacheKey.recordBytes = recordSpanBytes;
 
-  wgpu::BindGroup bindGroup = impl_->device->findSceneBatchBindGroup(cacheKey);
+  // A zero id means some buffer in this binding has no stable identity, so
+  // no key can distinguish it from a later buffer; skip the cache entirely
+  // rather than store an entry that a future batch could match by accident.
+  const bool cacheable =
+      cacheKey.uniformBufferId != 0 && cacheKey.chunkBufferId != 0 && cacheKey.recordBufferId != 0;
+
+  wgpu::BindGroup bindGroup =
+      cacheable ? impl_->device->findSceneBatchBindGroup(cacheKey) : wgpu::BindGroup{};
   if (!bindGroup) {
     wgpu::BindGroupDescriptor bgDesc = {};
     bgDesc.label = wgpuLabel("GeodeSceneBatchBindGroup");
@@ -2230,9 +2257,16 @@ void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,
     wgpu::BindGroup created = impl_->device->device().createBindGroup(bgDesc);
     impl_->device->countBindGroup();
     bindGroup = created;
-    // The cache takes ownership of the +1 handle and keeps the bound
-    // buffers alive for the entry's lifetime.
-    impl_->device->storeSceneBatchBindGroup(cacheKey, std::move(created));
+    if (cacheable) {
+      // The cache takes ownership of the +1 handle.
+      impl_->device->storeSceneBatchBindGroup(cacheKey, std::move(created));
+    } else {
+      // Defensive only: every buffer that can reach this call is stamped at
+      // creation, so no live path produces a zero id today. Hand the +1 to
+      // the encoder's per-frame arena so that if one ever does, the bind
+      // group is released at the frame boundary instead of leaking.
+      bindGroup = impl_->transientResources.retain(created);
+    }
   }
 
   // The binding covers the span of consecutive record slots starting at
@@ -2600,6 +2634,7 @@ void GeoEncoder::Impl::uploadResidentGradientGeometry(GeodeResidentGradientSlot&
     return;
   }
   slot.buffer = alloc.buffer;
+  slot.bufferId = alloc.bufferId;
   slot.allocationOffset = alloc.offset;
   slot.allocationSize = alloc.size;
 

--- a/donner/svg/renderer/geode/GeoEncoder.h
+++ b/donner/svg/renderer/geode/GeoEncoder.h
@@ -586,6 +586,12 @@ public:
   struct SceneBatchBinding {
     wgpu::Buffer chunkBuffer;   ///< Slab chunk holding every instance's geometry.
     wgpu::Buffer recordBuffer;  ///< Record-slab buffer holding the records.
+    /// Stable identities of `chunkBuffer` / `recordBuffer` (see
+    /// `GeodeDevice::AllocateBufferId`). The bind-group cache outlives the
+    /// document that owns these buffers, so it keys on these ids; the raw
+    /// handle addresses are recycled once that document is destroyed.
+    uint64_t chunkBufferId = 0;
+    uint64_t recordBufferId = 0;
     /// BYTE offset of the first instance's record inside recordBuffer.
     /// Record-slot indices are global across slab chunks, so an index is
     /// not a byte offset once the slab has grown; the caller passes the

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -240,7 +240,15 @@ namespace {
 /// Monotonic source for `GeodeDevice::deviceId()`. Never reused, starts at 1
 /// (0 is the "no device" sentinel on a `GeodeResidentSlot`).
 std::atomic<uint64_t> g_nextDeviceId{0};
+
+/// Monotonic source for `GeodeDevice::AllocateBufferId()`. Never reused,
+/// starts at 1 (0 is the "no buffer" sentinel).
+std::atomic<uint64_t> g_nextBufferId{0};
 }  // namespace
+
+uint64_t GeodeDevice::AllocateBufferId() {
+  return g_nextBufferId.fetch_add(1, std::memory_order_relaxed) + 1;
+}
 
 GeodeDevice::GeodeDevice()
     : impl_(std::make_unique<Impl>()),

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -325,28 +325,57 @@ public:
    * Scene batches bind pooled arena and slab buffers whose identities and
    * offsets are stable across steady-state frames, so a cached bind group
    * keyed this way is reusable frame over frame (keeping the per-frame
-   * bind-group create count flat; the GeodePerf ceilings pin this). A
-   * cached entry holds a reference to its bind group, which in turn keeps
-   * every bound buffer alive, so a raw handle in a live key can never be
-   * recycled for a different buffer.
+   * bind-group create count flat; the GeodePerf ceilings pin this).
+   *
+   * Buffers are identified by the process-unique ids handed out by
+   * `AllocateBufferId()`, NOT by their `WGPUBuffer` handle addresses. A
+   * cached bind group keeps the buffer's GPU-side resource alive inside
+   * WebGPU, but it does NOT keep the caller's handle object alive: when the
+   * document that owned a slab chunk is destroyed, its handles are released
+   * and their addresses become available to the allocator again. A device
+   * outlives the documents drawn on it (renderers lease devices from a
+   * small idle pool), so a later document's freshly created buffer can land
+   * on a recycled address and - with identical chunk sizes and record
+   * offsets, the norm for small documents - compare EQUAL to an entry left
+   * behind by the dead one. The lookup would then hand back the previous
+   * document's bind group and the batch would draw that document's records
+   * and geometry, which shows up as whole shapes rendered at another
+   * document's transform.
    */
   struct SceneBatchBindGroupKey {
-    WGPUBuffer uniformBuffer = nullptr;
+    uint64_t uniformBufferId = 0;
     uint64_t uniformOffset = 0;
     uint64_t uniformSize = 0;
-    WGPUBuffer chunkBuffer = nullptr;
+    uint64_t chunkBufferId = 0;
     uint64_t chunkBytes = 0;
-    WGPUBuffer recordBuffer = nullptr;
+    uint64_t recordBufferId = 0;
     uint64_t recordOffset = 0;
     uint64_t recordBytes = 0;
 
     friend bool operator<(const SceneBatchBindGroupKey& a, const SceneBatchBindGroupKey& b) {
-      return std::tie(a.uniformBuffer, a.uniformOffset, a.uniformSize, a.chunkBuffer, a.chunkBytes,
-                      a.recordBuffer, a.recordOffset, a.recordBytes) <
-             std::tie(b.uniformBuffer, b.uniformOffset, b.uniformSize, b.chunkBuffer, b.chunkBytes,
-                      b.recordBuffer, b.recordOffset, b.recordBytes);
+      return std::tie(a.uniformBufferId, a.uniformOffset, a.uniformSize, a.chunkBufferId,
+                      a.chunkBytes, a.recordBufferId, a.recordOffset, a.recordBytes) <
+             std::tie(b.uniformBufferId, b.uniformOffset, b.uniformSize, b.chunkBufferId,
+                      b.chunkBytes, b.recordBufferId, b.recordOffset, b.recordBytes);
     }
   };
+
+  /**
+   * Allocate a process-unique identity for a GPU buffer handle, from a
+   * monotonic counter that starts at 1 and is never reused.
+   *
+   * Anything that outlives a buffer and still has to answer "is this the
+   * same buffer I saw before?" must compare these ids rather than
+   * `WGPUBuffer` handle addresses. Releasing the last handle reference frees
+   * the handle object even while WebGPU keeps the underlying resource alive
+   * for bind groups and recorded commands that already reference it, so a
+   * later allocation can reuse the address and make two unrelated buffers
+   * indistinguishable. `deviceId()` exists for the same reason one level up.
+   *
+   * `0` is reserved for "no buffer", so a default-constructed id never
+   * matches a real one.
+   */
+  [[nodiscard]] static uint64_t AllocateBufferId();
 
   /// Look up a cached scene-batch bind group. Returns a borrowed handle
   /// (valid while the cache entry lives), or an empty handle on miss.

--- a/donner/svg/renderer/geode/GeodeResidentPathComponent.h
+++ b/donner/svg/renderer/geode/GeodeResidentPathComponent.h
@@ -104,6 +104,10 @@ public:
     wgpu::Buffer buffer;
     uint64_t offset = 0;
     uint32_t index = 0;
+    /// Stable identity of `buffer` (see `GeodeDevice::AllocateBufferId`).
+    /// Anything that caches keyed on this slot must compare the id: the
+    /// handle address is recycled once the owning slab is destroyed.
+    uint64_t bufferId = 0;
   };
 
   explicit GeodeRecordSlab(uint64_t deviceId) : owningDeviceId_(deviceId) {}
@@ -159,10 +163,11 @@ public:
         return false;
       }
       device.countBuffer();
-      chunks_.push_back(Chunk{std::move(buffer), newSize});
+      chunks_.push_back(Chunk{std::move(buffer), newSize, GeodeDevice::AllocateBufferId()});
       usedBytes_ = 0;
     }
     out.buffer = chunks_.back().buffer.get();
+    out.bufferId = chunks_.back().bufferId;
     out.offset = usedBytes_;
     // Indices are GLOBAL across chunks (slotAt walks cumulative chunk
     // capacities): a per-chunk index would collide with the previous
@@ -182,6 +187,13 @@ public:
   /// recorded batch draws still read.
   void freeSlot(const Slot& slot) { pendingFrees_.push_back(slot.index); }
 
+  /// A batch-uniform buffer plus its stable identity; `buffer` is null when
+  /// the slab declined (uniform cache full, or buffer creation failed).
+  struct BatchUniformHandle {
+    wgpu::Buffer buffer;
+    uint64_t bufferId = 0;
+  };
+
   /**
    * Persistent buffer holding one distinct scene-batch uniform value.
    *
@@ -197,15 +209,15 @@ public:
    * distinct values are live, and the caller falls back to its per-frame
    * arena.
    */
-  wgpu::Buffer acquireBatchUniform(GeodeDevice& device, const void* bytes, uint64_t size) {
+  BatchUniformHandle acquireBatchUniform(GeodeDevice& device, const void* bytes, uint64_t size) {
     const auto* first = static_cast<const uint8_t*>(bytes);
     for (const BatchUniform& entry : batchUniforms_) {
       if (entry.bytes.size() == size && std::memcmp(entry.bytes.data(), first, size) == 0) {
-        return entry.buffer.get();
+        return BatchUniformHandle{entry.buffer.get(), entry.bufferId};
       }
     }
     if (batchUniforms_.size() >= kMaxBatchUniforms) {
-      return wgpu::Buffer();
+      return BatchUniformHandle{};
     }
     wgpu::BufferDescriptor desc = {};
     desc.label = wgpuLabel("GeodeSceneBatchUniform");
@@ -213,14 +225,15 @@ public:
     desc.usage = wgpu::BufferUsage::Uniform | wgpu::BufferUsage::CopyDst;
     ScopedWgpuHandle<wgpu::Buffer> buffer(device.device().createBuffer(desc));
     if (!buffer) {
-      return wgpu::Buffer();
+      return BatchUniformHandle{};
     }
     device.countBuffer();
     device.queue().writeBuffer(buffer.get(), 0, first, size);
     device.countBufferWrite(size);
-    batchUniforms_.push_back(
-        BatchUniform{std::move(buffer), std::vector<uint8_t>(first, first + size)});
-    return batchUniforms_.back().buffer.get();
+    batchUniforms_.push_back(BatchUniform{std::move(buffer),
+                                          std::vector<uint8_t>(first, first + size),
+                                          GeodeDevice::AllocateBufferId()});
+    return BatchUniformHandle{batchUniforms_.back().buffer.get(), batchUniforms_.back().bufferId};
   }
 
   /// Borrowed handle of the newest buffer (batches bind sub-ranges of it).
@@ -244,11 +257,13 @@ private:
   struct Chunk {
     ScopedWgpuHandle<wgpu::Buffer> buffer;
     uint64_t size = 0;
+    uint64_t bufferId = 0;
   };
 
   struct BatchUniform {
     ScopedWgpuHandle<wgpu::Buffer> buffer;
     std::vector<uint8_t> bytes;
+    uint64_t bufferId = 0;
   };
 
   static constexpr uint64_t kInitialRecordSlabBytes = 262144u;
@@ -263,11 +278,11 @@ private:
     uint64_t offset = static_cast<uint64_t>(index) * sizeof(InstanceRecord);
     for (const Chunk& chunk : chunks_) {
       if (offset < chunk.size) {
-        return Slot{chunk.buffer.get(), offset, index};
+        return Slot{chunk.buffer.get(), offset, index, chunk.bufferId};
       }
       offset -= chunk.size;
     }
-    return Slot{wgpu::Buffer(), 0, index};
+    return Slot{wgpu::Buffer(), 0, index, 0};
   }
 
   uint64_t owningDeviceId_;
@@ -316,6 +331,10 @@ public:
     wgpu::Buffer buffer;  // Borrowed handle; owned by the slab chunk.
     uint64_t offset = 0;
     uint64_t size = 0;
+    /// Stable identity of `buffer` (see `GeodeDevice::AllocateBufferId`).
+    /// Only allocation results carry it; `free` matches on the handle,
+    /// which is unambiguous while the slab that owns the chunk is alive.
+    uint64_t bufferId = 0;
   };
 
   /// Create an empty slab bound to `deviceId` (usually the current
@@ -403,6 +422,7 @@ public:
       const uint64_t start = alignUp(it->offset, alignment);
       if (start + size <= it->offset + it->size) {
         out.buffer = chunks_[it->chunk].buffer.get();
+        out.bufferId = chunks_[it->chunk].bufferId;
         out.offset = start;
         out.size = size;
         if (start == it->offset) {
@@ -440,6 +460,7 @@ public:
       }
       device.countBuffer();
       chunk.size = newSize;
+      chunk.bufferId = GeodeDevice::AllocateBufferId();
       chunks_.push_back(std::move(chunk));
       if (!gauge_) {
         gauge_ = device.residentBytesGauge();
@@ -450,6 +471,7 @@ public:
 
     Chunk& chunk = chunks_.back();
     out.buffer = chunk.buffer.get();
+    out.bufferId = chunk.bufferId;
     out.offset = alignUp(chunk.cursor, alignment);
     out.size = size;
     chunk.cursor = out.offset + size;
@@ -462,10 +484,13 @@ public:
     if (alloc.size == 0) {
       return;
     }
-    // Locate the owning chunk.
+    // Locate the owning chunk by identity rather than by handle address, so
+    // the match means "the chunk this range was carved out of" and cannot be
+    // confused by a recycled handle. A default-constructed allocation carries
+    // id 0 and matches nothing, since ids start at 1.
     size_t chunkIndex = 0;
     for (; chunkIndex < chunks_.size(); ++chunkIndex) {
-      if (chunks_[chunkIndex].buffer.get() == alloc.buffer) {
+      if (chunks_[chunkIndex].bufferId == alloc.bufferId) {
         break;
       }
     }
@@ -486,6 +511,7 @@ private:
     ScopedWgpuHandle<wgpu::Buffer> buffer;
     uint64_t size = 0;
     uint64_t cursor = 0;
+    uint64_t bufferId = 0;
   };
 
   struct FreeRange {
@@ -526,6 +552,12 @@ struct GeodeResidentSlot {
   /// slab's allocation alignment so consecutive slots leave no unwritten
   /// bytes between them.
   wgpu::Buffer buffer;
+  /// Stable identity of `buffer` (see `GeodeDevice::AllocateBufferId`).
+  /// A cross-entity batch binds the whole chunk and caches the resulting
+  /// bind group past the lifetime of the document that owns it, so the
+  /// cache key has to name the chunk by this id rather than by the handle
+  /// address, which the allocator recycles once the slab is destroyed.
+  uint64_t bufferId = 0;
   /// Slab that owns `buffer`; null until residence is established. Held
   /// by shared_ptr so a device change (which swaps the registry's slab)
   /// cannot leave a slot referencing a destroyed slab: old slots keep the
@@ -643,7 +675,9 @@ struct GeodeResidentSlot {
     if (this != &other) {
       reset();
       buffer = other.buffer;
+      bufferId = other.bufferId;
       other.buffer = wgpu::Buffer();
+      other.bufferId = 0;
       slab = std::move(other.slab);
       allocationOffset = other.allocationOffset;
       allocationSize = other.allocationSize;
@@ -693,7 +727,7 @@ struct GeodeResidentSlot {
   /// done.
   void reset() {
     if (slab && allocationSize != 0) {
-      GeodeResidentSlab::Allocation alloc{buffer, allocationOffset, allocationSize};
+      GeodeResidentSlab::Allocation alloc{buffer, allocationOffset, allocationSize, bufferId};
       slab->free(alloc);
     }
     // The record slot survives geometry re-uploads: its painter-ordered
@@ -708,6 +742,7 @@ struct GeodeResidentSlot {
     allocationOffset = 0;
     allocationSize = 0;
     buffer = wgpu::Buffer();
+    bufferId = 0;
     bindGroup.reset();
     resident = false;
     encodedKey = nullptr;
@@ -734,6 +769,10 @@ struct GeodeResidentGradientSlot {
   /// offsets. Region layout matches \ref GeodeResidentSlot, with the
   /// uniform region sized for `GradientUniforms` (672 bytes).
   wgpu::Buffer buffer;
+  /// Stable identity of `buffer` (see `GeodeDevice::AllocateBufferId`), so
+  /// returning the allocation matches the owning chunk by identity rather
+  /// than by a handle address the allocator can recycle.
+  uint64_t bufferId = 0;
   /// Slab that owns `buffer`; null until residence is established. Held
   /// by shared_ptr so a device change (which swaps the registry's slab)
   /// cannot leave a slot referencing a destroyed slab: old slots keep the
@@ -795,7 +834,9 @@ struct GeodeResidentGradientSlot {
     if (this != &other) {
       reset();
       buffer = other.buffer;
+      bufferId = other.bufferId;
       other.buffer = wgpu::Buffer();
+      other.bufferId = 0;
       slab = std::move(other.slab);
       allocationOffset = other.allocationOffset;
       allocationSize = other.allocationSize;
@@ -829,7 +870,7 @@ struct GeodeResidentGradientSlot {
   /// Never calls `Buffer::destroy()`; see GeodeResidentSlot::reset.
   void reset() {
     if (slab && allocationSize != 0) {
-      GeodeResidentSlab::Allocation alloc{buffer, allocationOffset, allocationSize};
+      GeodeResidentSlab::Allocation alloc{buffer, allocationOffset, allocationSize, bufferId};
       slab->free(alloc);
     }
     // The slab pointers themselves are intentionally kept: they outlive
@@ -839,6 +880,7 @@ struct GeodeResidentGradientSlot {
     allocationOffset = 0;
     allocationSize = 0;
     buffer = wgpu::Buffer();
+    bufferId = 0;
     bindGroup.reset();
     resident = false;
     encodedKey = nullptr;

--- a/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
@@ -6,6 +6,7 @@
 #include <array>
 #include <atomic>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <vector>
 
@@ -13,6 +14,7 @@
 #include "donner/base/Path.h"
 #include "donner/base/Transform.h"
 #include "donner/css/Color.h"
+#include "donner/svg/renderer/geode/GeodeBufferPool.h"
 #include "donner/svg/renderer/geode/GeodeCallbackState.h"
 #include "donner/svg/renderer/geode/GeodeDevice.h"
 #include "donner/svg/renderer/geode/GeodeGpuWait.h"
@@ -332,6 +334,308 @@ TEST_F(GeoEncoderTest, RecordSlabFreeListSurvivesChunkGrowth) {
     EXPECT_FALSE(live.buffer == reusedA.buffer && live.offset == reusedA.offset);
     EXPECT_FALSE(live.buffer == reusedB.buffer && live.offset == reusedB.offset);
   }
+}
+
+/// The scene-batch bind-group cache lives on the device, which outlives the
+/// documents drawn through it (renderers lease devices from an idle pool).
+/// A destroyed document's slabs release their buffer handles, and those
+/// addresses go straight back to the allocator, so a later document's
+/// buffers can land on them. Small documents make that collision easy -
+/// same chunk size, record offset 0, same record-span byte count - so a key
+/// built from handle addresses could compare EQUAL across two unrelated
+/// documents and the lookup would return the dead document's bind group,
+/// drawing its records and geometry instead. Buffer ids must therefore never
+/// repeat, no matter what the allocator does with the handles.
+TEST_F(GeoEncoderTest, BufferIdsAreNeverReusedAcrossSlabGenerations) {
+  struct SlabGeneration {
+    WGPUBuffer chunkHandle = nullptr;
+    WGPUBuffer recordHandle = nullptr;
+    WGPUBuffer uniformHandle = nullptr;
+    uint64_t chunkId = 0;
+    uint64_t recordId = 0;
+    uint64_t uniformId = 0;
+  };
+
+  // One document's worth of slabs, destroyed before returning: exactly the
+  // lifetime a rendered-and-closed document has.
+  const auto renderOneDocument = [this]() {
+    geode::GeodeResidentSlab geometry(device_->deviceId());
+    geode::GeodeRecordSlab records(device_->deviceId());
+
+    geode::GeodeResidentSlab::Allocation geometryAlloc;
+    EXPECT_TRUE(geometry.allocate(*device_, 4096, 256, geometryAlloc));
+    geode::GeodeRecordSlab::Slot recordSlot;
+    EXPECT_TRUE(records.allocateSlot(*device_, recordSlot));
+    const uint32_t uniformBytes[4] = {1u, 2u, 3u, 4u};
+    const geode::GeodeRecordSlab::BatchUniformHandle uniform =
+        records.acquireBatchUniform(*device_, uniformBytes, sizeof(uniformBytes));
+
+    SlabGeneration out;
+    out.chunkHandle = geometryAlloc.buffer;
+    out.recordHandle = recordSlot.buffer;
+    out.uniformHandle = uniform.buffer;
+    out.chunkId = geometryAlloc.bufferId;
+    out.recordId = recordSlot.bufferId;
+    out.uniformId = uniform.bufferId;
+    return out;
+  };
+
+  const SlabGeneration first = renderOneDocument();
+  const SlabGeneration second = renderOneDocument();
+
+  // 0 is the "no buffer" sentinel and must never be handed out.
+  EXPECT_NE(first.chunkId, 0u);
+  EXPECT_NE(first.recordId, 0u);
+  EXPECT_NE(first.uniformId, 0u);
+
+  EXPECT_NE(first.chunkId, second.chunkId);
+  EXPECT_NE(first.recordId, second.recordId);
+  EXPECT_NE(first.uniformId, second.uniformId);
+
+  // Two keys that agree on every size and offset - the shape two small
+  // documents rendered back to back produce - must stay distinct. Under the
+  // map's ordering, "distinct" means one sorts before the other.
+  const auto makeKey = [](const SlabGeneration& generation) {
+    geode::GeodeDevice::SceneBatchBindGroupKey key;
+    key.uniformBufferId = generation.uniformId;
+    key.uniformOffset = 0;
+    key.uniformSize = sizeof(geode::InstanceRecord);
+    key.chunkBufferId = generation.chunkId;
+    key.chunkBytes = 1u << 20;
+    key.recordBufferId = generation.recordId;
+    key.recordOffset = 0;
+    key.recordBytes = 2 * sizeof(geode::InstanceRecord);
+    return key;
+  };
+  const geode::GeodeDevice::SceneBatchBindGroupKey firstKey = makeKey(first);
+  const geode::GeodeDevice::SceneBatchBindGroupKey secondKey = makeKey(second);
+  EXPECT_TRUE(firstKey < secondKey || secondKey < firstKey)
+      << "Two documents' scene-batch keys collided; the second document would "
+         "draw the first's records and geometry";
+
+  // Within one slab generation the ids DO have to be stable, or the cache
+  // would miss every frame and the batched draw would rebuild its bind group
+  // each time.
+  geode::GeodeRecordSlab records(device_->deviceId());
+  geode::GeodeRecordSlab::Slot slotA;
+  geode::GeodeRecordSlab::Slot slotB;
+  ASSERT_TRUE(records.allocateSlot(*device_, slotA));
+  ASSERT_TRUE(records.allocateSlot(*device_, slotB));
+  ASSERT_EQ(slotA.buffer, slotB.buffer) << "Fixture must keep both slots in one chunk";
+  EXPECT_EQ(slotA.bufferId, slotB.bufferId);
+}
+
+/// End-to-end guard on the scene-batch bind-group cache lookup itself.
+///
+/// `BufferIdsAreNeverReusedAcrossSlabGenerations` pins the ids, but nothing
+/// forces `fillPathSceneBatch` to actually build its key out of them: keying
+/// on the `WGPUBuffer` handle addresses instead still passes every other test
+/// in this suite, every golden, and the whole resvg suite on any machine
+/// whose allocator happens not to recycle the handles. That is precisely the
+/// hole the original defect lived in, so the cache lookup gets its own
+/// assertion.
+///
+/// Two slab generations model two documents rendered through one pooled
+/// device, shaped so their bindings agree on everything the key can see -
+/// same chunk size, record offset 0, same record-span byte count, same
+/// uniform bytes. The first generation is fully destroyed before the second
+/// allocates, which is what frees the handle addresses for reuse. Every
+/// generation's first batch must MISS (one `createBindGroup`), because it
+/// binds different buffers; an immediate repeat within a generation must HIT
+/// (zero), because it binds the same ones.
+TEST_F(GeoEncoderTest, SceneBatchBindGroupCacheDistinguishesSlabGenerations) {
+  // One document's slabs, plus the two record slots its batch draws.
+  struct Generation {
+    std::shared_ptr<geode::GeodeResidentSlab> geometry;
+    std::shared_ptr<geode::GeodeRecordSlab> records;
+    geode::GeodeResidentSlab::Allocation chunk;
+    geode::GeodeRecordSlab::Slot recordSlots[2];
+  };
+
+  constexpr uint32_t kInstanceCount = 2;
+
+  const auto makeGeneration = [this]() {
+    Generation generation;
+    generation.geometry = std::make_shared<geode::GeodeResidentSlab>(device_->deviceId());
+    generation.records = std::make_shared<geode::GeodeRecordSlab>(device_->deviceId());
+    // 4 KiB of geometry is enough to own a chunk; the chunk's SIZE is what
+    // the key sees, and the slab's initial chunk is the same for every
+    // generation.
+    EXPECT_TRUE(generation.geometry->allocate(*device_, 4096, 256, generation.chunk));
+    for (uint32_t i = 0; i < kInstanceCount; ++i) {
+      EXPECT_TRUE(generation.records->allocateSlot(*device_, generation.recordSlots[i]));
+    }
+
+    // Populate the records so the batch is a real draw rather than a draw
+    // over uninitialized storage. Identity transform, a small quad bounding
+    // polygon, and zero band counts, so the shader's band-count gates stop
+    // before dereferencing the (empty) geometry chunk.
+    for (uint32_t i = 0; i < kInstanceCount; ++i) {
+      geode::InstanceRecord record = {};
+      record.transformRow0[0] = 1.0f;
+      record.transformRow1[1] = 1.0f;
+      record.color[1] = 0.5f;
+      record.color[3] = 1.0f;
+      record.boundingVertexCount = 4;
+      const float quad[8] = {8.0f, 8.0f, 24.0f, 8.0f, 24.0f, 24.0f, 8.0f, 24.0f};
+      std::memcpy(record.boundingVertices, quad, sizeof(quad));
+      device_->queue().writeBuffer(generation.recordSlots[i].buffer,
+                                   generation.recordSlots[i].offset, &record,
+                                   sizeof(record));
+    }
+    return generation;
+  };
+
+  const auto bindingFor = [](const Generation& generation) {
+    GeoEncoder::SceneBatchBinding binding = {};
+    binding.chunkBuffer = generation.chunk.buffer;
+    binding.recordBuffer = generation.recordSlots[0].buffer;
+    binding.chunkBufferId = generation.chunk.bufferId;
+    binding.recordBufferId = generation.recordSlots[0].bufferId;
+    binding.firstRecordOffset = generation.recordSlots[0].offset;
+    binding.instanceCount = kInstanceCount;
+    binding.vertexCount = 6;
+    binding.recordSlab = generation.records.get();
+    return binding;
+  };
+
+  geode::GeodeCounters counters;
+  device_->setCounters(&counters);
+  // The device is shared process-wide by this fixture, so the counters must
+  // come back off however this test exits.
+  struct CounterScope {
+    geode::GeodeDevice* device;
+    ~CounterScope() { device->setCounters(nullptr); }
+  } counterScope{device_.get()};
+
+  // Draw one generation's batch twice through a fresh encoder, and report the
+  // `createBindGroup` calls each of the two batches caused.
+  const auto drawGeneration = [&](const Generation& generation, uint64_t& firstBatchCreates,
+                                  uint64_t& repeatBatchCreates) {
+    GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+    encoder.clear(css::RGBA(0, 0, 0, 0));
+
+    const GeoEncoder::SceneBatchBinding binding = bindingFor(generation);
+    const uint64_t beforeFirst = counters.bindgroupCreates;
+    encoder.fillPathSceneBatch(css::RGBA(0, 128, 0, 255), FillRule::NonZero, binding);
+    firstBatchCreates = counters.bindgroupCreates - beforeFirst;
+
+    const uint64_t beforeRepeat = counters.bindgroupCreates;
+    encoder.fillPathSceneBatch(css::RGBA(0, 128, 0, 255), FillRule::NonZero, binding);
+    repeatBatchCreates = counters.bindgroupCreates - beforeRepeat;
+
+    encoder.finish();
+  };
+
+  // Several generations, because a handle address only becomes reusable once
+  // its owner is gone: one round is a single roll of the allocator's dice,
+  // and a key built from addresses has to survive every one of them.
+  constexpr int kGenerations = 8;
+  for (int round = 0; round < kGenerations; ++round) {
+    uint64_t firstBatchCreates = 0;
+    uint64_t repeatBatchCreates = 0;
+    {
+      const Generation generation = makeGeneration();
+      drawGeneration(generation, firstBatchCreates, repeatBatchCreates);
+    }
+    // The generation (and its buffers) are released here, before the next
+    // round allocates.
+
+    EXPECT_EQ(firstBatchCreates, 1u)
+        << "Round " << round
+        << ": this generation's batch binds buffers no earlier generation owned, so its "
+           "bind-group lookup must miss. A hit means the cache matched a dead generation's "
+           "entry and this batch drew the previous generation's records and geometry.";
+    EXPECT_EQ(repeatBatchCreates, 0u)
+        << "Round " << round
+        << ": repeating the identical batch must reuse the cached bind group.";
+  }
+}
+
+/// Companion to the slab-generation test above, and the half of the guard
+/// that does not depend on the allocator at all.
+///
+/// The encoder's bump arenas hand their buffers back to a `GeodeBufferPool`
+/// when they are destroyed, and the next encoder reacquires the very same
+/// buffer. So two batches drawn through two encoders over ONE generation of
+/// slabs agree on every byte a bind-group key can see - same chunk, same
+/// record span, same arena buffer at the same offset and size - and differ
+/// only in the arena's identity, which is re-stamped on every growth because
+/// the recycled buffer's contents start over. The second batch must still
+/// miss. `bufferCreates == 0` on the second batch is what proves the pool
+/// really did hand back the same buffer, so this test cannot quietly stop
+/// testing anything.
+TEST_F(GeoEncoderTest, SceneBatchBindGroupCacheDistinguishesRecycledArenaUniforms) {
+  auto geometry = std::make_shared<geode::GeodeResidentSlab>(device_->deviceId());
+  auto records = std::make_shared<geode::GeodeRecordSlab>(device_->deviceId());
+
+  geode::GeodeResidentSlab::Allocation chunk;
+  ASSERT_TRUE(geometry->allocate(*device_, 4096, 256, chunk));
+  geode::GeodeRecordSlab::Slot recordSlot;
+  ASSERT_TRUE(records->allocateSlot(*device_, recordSlot));
+
+  geode::InstanceRecord record = {};
+  record.transformRow0[0] = 1.0f;
+  record.transformRow1[1] = 1.0f;
+  record.color[1] = 0.5f;
+  record.color[3] = 1.0f;
+  record.boundingVertexCount = 4;
+  const float quad[8] = {8.0f, 8.0f, 24.0f, 8.0f, 24.0f, 24.0f, 8.0f, 24.0f};
+  std::memcpy(record.boundingVertices, quad, sizeof(quad));
+  device_->queue().writeBuffer(recordSlot.buffer, recordSlot.offset, &record, sizeof(record));
+
+  // A null `recordSlab` routes the batch uniform through the encoder's
+  // per-frame arena instead of the slab's persistent table, which is the
+  // allocation the buffer pool recycles.
+  GeoEncoder::SceneBatchBinding binding = {};
+  binding.chunkBuffer = chunk.buffer;
+  binding.recordBuffer = recordSlot.buffer;
+  binding.chunkBufferId = chunk.bufferId;
+  binding.recordBufferId = recordSlot.bufferId;
+  binding.firstRecordOffset = recordSlot.offset;
+  binding.instanceCount = 1;
+  binding.vertexCount = 6;
+  binding.recordSlab = nullptr;
+
+  geode::GeodeCounters counters;
+  device_->setCounters(&counters);
+  struct CounterScope {
+    geode::GeodeDevice* device;
+    ~CounterScope() { device->setCounters(nullptr); }
+  } counterScope{device_.get()};
+
+  GeodeBufferPool pool;
+  const auto drawOneEncoder = [&](uint64_t& bindGroupCreates, uint64_t& bufferCreates) {
+    GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+    encoder.setBufferPool(&pool);
+    encoder.clear(css::RGBA(0, 0, 0, 0));
+
+    const uint64_t bindGroupsBefore = counters.bindgroupCreates;
+    const uint64_t buffersBefore = counters.bufferCreates;
+    encoder.fillPathSceneBatch(css::RGBA(0, 128, 0, 255), FillRule::NonZero, binding);
+    bindGroupCreates = counters.bindgroupCreates - bindGroupsBefore;
+    bufferCreates = counters.bufferCreates - buffersBefore;
+
+    encoder.finish();
+    // The encoder is destroyed here, releasing its arena buffer into `pool`.
+  };
+
+  uint64_t firstBindGroups = 0;
+  uint64_t firstBuffers = 0;
+  drawOneEncoder(firstBindGroups, firstBuffers);
+  EXPECT_EQ(firstBindGroups, 1u);
+  ASSERT_GE(firstBuffers, 1u) << "The first batch must grow the uniform arena";
+
+  uint64_t secondBindGroups = 0;
+  uint64_t secondBuffers = 0;
+  drawOneEncoder(secondBindGroups, secondBuffers);
+  ASSERT_EQ(secondBuffers, 0u)
+      << "Fixture precondition: the second encoder must reacquire the first encoder's arena "
+         "buffer from the pool, otherwise this test is not exercising a recycled buffer";
+  EXPECT_EQ(secondBindGroups, 1u)
+      << "The recycled arena buffer holds a different uniform allocation than the one the "
+         "cached bind group was built over, so the lookup must miss. A hit means the key is "
+         "built from the buffer's handle rather than its identity.";
 }
 
 TEST_F(GeoEncoderTest, ArenaGrowthKeepsEarlierGridBinding) {

--- a/donner/svg/resources/BUILD.bazel
+++ b/donner/svg/resources/BUILD.bazel
@@ -110,6 +110,7 @@ donner_cc_library(
         "//donner/editor:__subpackages__",
         "//donner/svg:__subpackages__",
     ],
+    deps = ["//donner/svg/core"],
 )
 
 donner_cc_library(
@@ -123,6 +124,7 @@ donner_cc_library(
     visibility = [
         "//donner/editor:__subpackages__",
         "//donner/svg:__subpackages__",
+        "//tools/mcp-servers/editor-control:__pkg__",
     ],
     deps = [
         ":font_catalog_types",
@@ -171,6 +173,7 @@ donner_cc_library(
     visibility = [
         "//donner/editor:__subpackages__",
         "//donner/svg:__subpackages__",
+        "//tools/mcp-servers/editor-control:__pkg__",
     ],
     deps = [
         ":font_catalog_types",
@@ -202,6 +205,7 @@ donner_cc_test(
         ":font_catalog_types",
         ":font_manager",
         "//donner/base/fonts:sfnt_utils",
+        "//donner/svg/core",
         "//third_party/public-sans",
         "@com_google_gtest//:gtest_main",
         "@stb//:truetype",
@@ -221,6 +225,8 @@ donner_cc_test(
     deps = [
         ":font_catalog",
         ":font_catalog_types",
+        ":font_manager",
+        "//donner/svg/core",
         "@com_google_gtest//:gtest_main",
     ],
 )

--- a/donner/svg/resources/EmbeddedFontProvider.cc
+++ b/donner/svg/resources/EmbeddedFontProvider.cc
@@ -35,7 +35,8 @@ std::vector<FontFamilyInfo> EmbeddedFontProvider::families() const {
   std::vector<FontFamilyInfo> result;
   result.reserve(entries().size());
   for (const EmbeddedEntry& entry : entries()) {
-    result.push_back(FontFamilyInfo{std::string(entry.family), FontSource::Embedded, entry.category});
+    result.push_back(
+        FontFamilyInfo{std::string(entry.family), FontSource::Embedded, entry.category});
   }
   std::sort(result.begin(), result.end(),
             [](const FontFamilyInfo& a, const FontFamilyInfo& b) { return a.family < b.family; });
@@ -51,7 +52,8 @@ bool EmbeddedFontProvider::hasFamily(std::string_view family) const {
   return false;
 }
 
-std::vector<uint8_t> EmbeddedFontProvider::loadFamilyData(std::string_view family) const {
+std::vector<uint8_t> EmbeddedFontProvider::loadFamilyData(
+    std::string_view family, const FontFaceRequest& /*request*/) const {
   for (const EmbeddedEntry& entry : entries()) {
     if (StringUtils::Equals<StringComparison::IgnoreCase>(entry.family, family)) {
       return std::vector<uint8_t>(entry.data.begin(), entry.data.end());

--- a/donner/svg/resources/EmbeddedFontProvider.h
+++ b/donner/svg/resources/EmbeddedFontProvider.h
@@ -11,6 +11,11 @@ namespace donner::svg {
  * The family table is generated from `third_party/google_fonts/fonts.bzl` (see the
  * `DONNER_GF_ENTRY` x-macro include), so it always matches the fetched-and-embedded bytes. All
  * families report \ref FontSource::Embedded.
+ *
+ * Each family is a single file, so \ref loadFamilyData ignores the requested face: ten of the
+ * twelve curated families are variable fonts whose `wght` axis neither text backend instances, and
+ * the other two ship only a regular face. Bold and italic therefore render upright and regular for
+ * embedded families.
  */
 class EmbeddedFontProvider : public FontFamilyProvider {
 public:
@@ -18,7 +23,8 @@ public:
 
   std::vector<FontFamilyInfo> families() const override;
   bool hasFamily(std::string_view family) const override;
-  std::vector<uint8_t> loadFamilyData(std::string_view family) const override;
+  std::vector<uint8_t> loadFamilyData(std::string_view family,
+                                      const FontFaceRequest& request) const override;
 };
 
 }  // namespace donner::svg

--- a/donner/svg/resources/FontCatalog.cc
+++ b/donner/svg/resources/FontCatalog.cc
@@ -57,10 +57,11 @@ bool FontCatalog::hasFamily(std::string_view family) const {
   return false;
 }
 
-std::vector<uint8_t> FontCatalog::loadFamilyData(std::string_view family) const {
+std::vector<uint8_t> FontCatalog::loadFamilyData(std::string_view family,
+                                                 const FontFaceRequest& request) const {
   for (const auto& provider : providers_) {
     if (provider->hasFamily(family)) {
-      std::vector<uint8_t> data = provider->loadFamilyData(family);
+      std::vector<uint8_t> data = provider->loadFamilyData(family, request);
       if (!data.empty()) {
         return data;
       }

--- a/donner/svg/resources/FontCatalog.h
+++ b/donner/svg/resources/FontCatalog.h
@@ -14,8 +14,8 @@ namespace donner::svg {
  *
  * A default-constructed catalog contains an embedded provider (curated Google Fonts) followed by a
  * system provider (CoreText on macOS; a no-op stub elsewhere). Providers are consulted in order, so
- * resolution and `loadFace()` prefer **Embedded** families over **System** families, and `families()`
- * lists the Embedded group before the System group.
+ * resolution and `loadFace()` prefer **Embedded** families over **System** families, and
+ * `families()` lists the Embedded group before the System group.
  *
  * The catalog implements \ref FontFamilyProvider, so it can be installed directly on a \ref
  * FontManager (via `setFontProvider()` or `SetDefaultFontProvider()`).
@@ -61,15 +61,19 @@ public:
   std::optional<FontFamilyInfo> find(std::string_view family) const;
 
   /// Raw sfnt bytes for \p family from the first provider that has it (Embedded before System).
-  std::vector<uint8_t> loadFamilyData(std::string_view family) const override;
+  std::vector<uint8_t> loadFamilyData(std::string_view family,
+                                      const FontFaceRequest& request) const override;
 
   // Picker conveniences:
 
   /// Families from a single source (Embedded or System), sorted by name.
   std::vector<FontFamilyInfo> familiesBySource(FontSource source) const;
 
-  /// Alias for `loadFamilyData()`, named for the picker's preview use.
-  std::vector<uint8_t> loadFace(std::string_view family) const { return loadFamilyData(family); }
+  /// Alias for `loadFamilyData()`, named for the picker's preview use. Previews show the family's
+  /// default face, so this asks for the regular upright one.
+  std::vector<uint8_t> loadFace(std::string_view family) const {
+    return loadFamilyData(family, FontFaceRequest{});
+  }
 
 private:
   std::vector<std::unique_ptr<FontFamilyProvider>> providers_;

--- a/donner/svg/resources/FontCatalogTypes.h
+++ b/donner/svg/resources/FontCatalogTypes.h
@@ -2,9 +2,13 @@
 /// @file
 
 #include <cstdint>
+#include <ostream>
 #include <string>
 #include <string_view>
 #include <vector>
+
+#include "donner/svg/core/FontStretch.h"
+#include "donner/svg/core/FontStyle.h"
 
 namespace donner::svg {
 
@@ -35,8 +39,8 @@ enum class FontCategory {
 
 /// One entry in the font catalog: a family name plus how it was discovered and classified.
 struct FontFamilyInfo {
-  std::string family;                          //!< Display name and CSS `font-family` match key.
-  FontSource source = FontSource::Embedded;    //!< Origin (embedded vs system).
+  std::string family;                             //!< Display name and CSS `font-family` match key.
+  FontSource source = FontSource::Embedded;       //!< Origin (embedded vs system).
   FontCategory category = FontCategory::Unknown;  //!< Best-effort style bucket.
 
   /// Equality (used by tests).
@@ -44,6 +48,30 @@ struct FontFamilyInfo {
     return family == other.family && source == other.source && category == other.category;
   }
 };
+
+/**
+ * Which face inside a family a `font-family` lookup wants, taken from the element's computed CSS
+ * font properties.
+ *
+ * A family is a *set* of faces, not one file: "Helvetica" covers Regular, Bold, Oblique, and Bold
+ * Oblique. Providers must honour this or `font-weight: bold` silently renders as regular.
+ *
+ * @see https://www.w3.org/TR/css-fonts-4/#font-matching-algorithm
+ */
+struct FontFaceRequest {
+  int weight = 400;                           //!< CSS `font-weight`, 100-900 (700 = bold).
+  FontStyle style = FontStyle::Normal;        //!< CSS `font-style`.
+  FontStretch stretch = FontStretch::Normal;  //!< CSS `font-stretch`.
+
+  /// Equality comparison.
+  bool operator==(const FontFaceRequest& other) const = default;
+};
+
+/// Ostream output operator, so test failures print the requested face instead of an opaque struct.
+inline std::ostream& operator<<(std::ostream& os, const FontFaceRequest& request) {
+  return os << "FontFaceRequest(weight=" << request.weight << ", style=" << request.style
+            << ", stretch=" << request.stretch << ")";
+}
 
 /**
  * Interface implemented by each font source (embedded, system) and by the aggregate \ref
@@ -64,11 +92,19 @@ public:
   virtual bool hasFamily(std::string_view family) const = 0;
 
   /**
-   * Load the raw sfnt (TTF/OTF) bytes for \p family, or an empty vector if unavailable.
+   * Load the raw sfnt (TTF/OTF) bytes for the face of \p family that best matches \p request, or
+   * an empty vector if the family is unavailable.
+   *
+   * Providers that only hold a single file per family return it for every request, which means
+   * bold and italic render as regular for those families - see \ref EmbeddedFontProvider.
    *
    * The returned bytes are suitable for `FontManager::loadFontData()`.
+   *
+   * @param family Family name to load (case-insensitive).
+   * @param request Face within the family to prefer.
    */
-  virtual std::vector<uint8_t> loadFamilyData(std::string_view family) const = 0;
+  virtual std::vector<uint8_t> loadFamilyData(std::string_view family,
+                                              const FontFaceRequest& request) const = 0;
 };
 
 }  // namespace donner::svg

--- a/donner/svg/resources/FontManager.cc
+++ b/donner/svg/resources/FontManager.cc
@@ -363,7 +363,10 @@ FontHandle FontManager::findFont(std::string_view family, int weight, int style,
   // No document @font-face matched. Consult the external provider (embedded/system catalog) before
   // falling back to Public Sans. The provider itself orders Embedded before System.
   if (provider_ != nullptr && provider_->hasFamily(family)) {
-    std::vector<uint8_t> data = provider_->loadFamilyData(family);
+    const FontFaceRequest request{.weight = weight,
+                                  .style = static_cast<FontStyle>(style),
+                                  .stretch = static_cast<FontStretch>(stretch)};
+    std::vector<uint8_t> data = provider_->loadFamilyData(family, request);
     if (!data.empty()) {
       const Entity entity = registry_.create();
       if (loadFontDataIntoEntity(entity, data, FontDataTrust::Trusted)) {

--- a/donner/svg/resources/SystemFontProvider.cc
+++ b/donner/svg/resources/SystemFontProvider.cc
@@ -9,8 +9,11 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <CoreText/CoreText.h>
 
+#include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <iterator>
+#include <limits>
 
 namespace donner::svg {
 
@@ -66,8 +69,7 @@ void writeBE16(uint8_t* p, uint16_t v) {
 /// `.ttc`/`.dfont` collections, where reading the file bytes directly would not yield a single
 /// usable font. Returns empty on failure.
 std::vector<uint8_t> buildSfntFromCTFont(CTFontRef font) {
-  CFRef<CFArrayRef> tags(
-      CTFontCopyAvailableTables(font, kCTFontTableOptionNoOptions));
+  CFRef<CFArrayRef> tags(CTFontCopyAvailableTables(font, kCTFontTableOptionNoOptions));
   if (!tags) {
     return {};
   }
@@ -86,8 +88,8 @@ std::vector<uint8_t> buildSfntFromCTFont(CTFontRef font) {
 
   bool hasCff = false;
   for (CFIndex i = 0; i < numTablesSigned; ++i) {
-    const auto tag = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(
-        CFArrayGetValueAtIndex(tags.get(), i)));
+    const auto tag =
+        static_cast<uint32_t>(reinterpret_cast<uintptr_t>(CFArrayGetValueAtIndex(tags.get(), i)));
     CFRef<CFDataRef> tableData(
         CTFontCopyTable(font, static_cast<CTFontTableTag>(tag), kCTFontTableOptionNoOptions));
     if (!tableData) {
@@ -160,6 +162,117 @@ std::vector<uint8_t> buildSfntFromCTFont(CTFontRef font) {
   return sfnt;
 }
 
+/**
+ * Map a CSS `font-weight` (100-900) onto CoreText's normalized `kCTFontWeightTrait` scale, where
+ * -1 is thinnest, 0 is regular and 1 is heaviest. The anchors are the ones Apple documents for the
+ * `NSFontWeight*` constants.
+ */
+double NormalizedWeight(int cssWeight) {
+  struct Anchor {
+    int css;
+    double normalized;
+  };
+  static constexpr Anchor kAnchors[] = {{100, -0.80}, {200, -0.60}, {300, -0.40},
+                                        {400, 0.00},  {500, 0.23},  {600, 0.30},
+                                        {700, 0.40},  {800, 0.56},  {900, 0.62}};
+
+  if (cssWeight <= kAnchors[0].css) {
+    return kAnchors[0].normalized;
+  }
+  for (size_t i = 1; i < std::size(kAnchors); ++i) {
+    if (cssWeight <= kAnchors[i].css) {
+      const Anchor& low = kAnchors[i - 1];
+      const Anchor& high = kAnchors[i];
+      const double t = static_cast<double>(cssWeight - low.css) / (high.css - low.css);
+      return low.normalized + t * (high.normalized - low.normalized);
+    }
+  }
+  return kAnchors[std::size(kAnchors) - 1].normalized;
+}
+
+/// Map \ref FontStretch (1-9, 5 = normal) onto CoreText's normalized `kCTFontWidthTrait` scale.
+double NormalizedWidth(FontStretch stretch) {
+  return (static_cast<double>(static_cast<uint8_t>(stretch)) - 5.0) / 4.0;
+}
+
+/// Read a numeric entry out of a CoreText traits dictionary, or \p fallback when absent.
+double TraitNumber(CFDictionaryRef traits, CFStringRef key, double fallback) {
+  const auto number = static_cast<CFNumberRef>(CFDictionaryGetValue(traits, key));
+  if (number == nullptr) {
+    return fallback;
+  }
+  double value = fallback;
+  if (!CFNumberGetValue(number, kCFNumberDoubleType, &value)) {
+    return fallback;
+  }
+  return value;
+}
+
+/**
+ * Pick the face within \p familyDescriptor that best matches \p request.
+ *
+ * Scoring follows the CSS font-matching priority (style, then stretch, then weight) with the same
+ * penalty scale as the `@font-face` matcher in \ref FontManager, so document-provided and
+ * system-provided families rank their faces the same way.
+ *
+ * @param familyDescriptor Descriptor carrying only the family name.
+ * @param request Face to prefer.
+ * @return A retained descriptor for the best face, or nullptr when the family cannot be expanded
+ *   (the caller then falls back to the family default).
+ * @see https://www.w3.org/TR/css-fonts-4/#font-style-matching
+ */
+CTFontDescriptorRef BestFaceInFamily(CTFontDescriptorRef familyDescriptor,
+                                     const FontFaceRequest& request) {
+  CFRef<CFSetRef> mandatory([] {
+    const void* keys[] = {kCTFontFamilyNameAttribute};
+    return CFSetCreate(kCFAllocatorDefault, keys, 1, &kCFTypeSetCallBacks);
+  }());
+  if (!mandatory) {
+    return nullptr;
+  }
+
+  CFRef<CFArrayRef> faces(
+      CTFontDescriptorCreateMatchingFontDescriptors(familyDescriptor, mandatory.get()));
+  if (!faces) {
+    return nullptr;
+  }
+
+  const double wantWeight = NormalizedWeight(request.weight);
+  const double wantWidth = NormalizedWidth(request.stretch);
+  const bool wantSlanted = request.style != FontStyle::Normal;
+
+  CTFontDescriptorRef best = nullptr;
+  double bestScore = std::numeric_limits<double>::max();
+
+  const CFIndex count = CFArrayGetCount(faces.get());
+  for (CFIndex i = 0; i < count; ++i) {
+    const auto face = static_cast<CTFontDescriptorRef>(CFArrayGetValueAtIndex(faces.get(), i));
+    CFRef<CFDictionaryRef> traits(
+        static_cast<CFDictionaryRef>(CTFontDescriptorCopyAttribute(face, kCTFontTraitsAttribute)));
+    if (!traits) {
+      continue;
+    }
+
+    const auto symbolic =
+        static_cast<uint32_t>(TraitNumber(traits.get(), kCTFontSymbolicTrait, 0.0));
+    const bool isSlanted = (symbolic & kCTFontTraitItalic) != 0;
+
+    double score = 0.0;
+    if (isSlanted != wantSlanted) {
+      score += 10000.0;
+    }
+    score += std::abs(TraitNumber(traits.get(), kCTFontWidthTrait, 0.0) - wantWidth) * 1000.0;
+    score += std::abs(TraitNumber(traits.get(), kCTFontWeightTrait, 0.0) - wantWeight) * 100.0;
+
+    if (score < bestScore) {
+      bestScore = score;
+      best = face;
+    }
+  }
+
+  return best != nullptr ? static_cast<CTFontDescriptorRef>(CFRetain(best)) : nullptr;
+}
+
 }  // namespace
 
 bool SystemFontProvider::isSupported() {
@@ -205,15 +318,16 @@ bool SystemFontProvider::hasFamily(std::string_view family) const {
   return false;
 }
 
-std::vector<uint8_t> SystemFontProvider::loadFamilyData(std::string_view family) const {
+std::vector<uint8_t> SystemFontProvider::loadFamilyData(std::string_view family,
+                                                        const FontFaceRequest& request) const {
   // Guard against CoreText silently substituting a fallback font for an unknown family name.
   if (!hasFamily(family)) {
     return {};
   }
 
   const std::string familyStr(family);
-  CFRef<CFStringRef> cfFamily(CFStringCreateWithCString(kCFAllocatorDefault, familyStr.c_str(),
-                                                        kCFStringEncodingUTF8));
+  CFRef<CFStringRef> cfFamily(
+      CFStringCreateWithCString(kCFAllocatorDefault, familyStr.c_str(), kCFStringEncodingUTF8));
   if (!cfFamily) {
     return {};
   }
@@ -230,7 +344,13 @@ std::vector<uint8_t> SystemFontProvider::loadFamilyData(std::string_view family)
   if (!desc) {
     return {};
   }
-  CFRef<CTFontRef> font(CTFontCreateWithFontDescriptor(desc.get(), 0.0, nullptr));
+
+  // Expand the family into its individual faces and pick the one matching `request`. Building a
+  // font straight from the family-only descriptor always yields the family's default (regular
+  // upright) face, which is what makes bold and italic render as regular.
+  CFRef<CTFontDescriptorRef> best(BestFaceInFamily(desc.get(), request));
+  CFRef<CTFontRef> font(
+      CTFontCreateWithFontDescriptor(best ? best.get() : desc.get(), 0.0, nullptr));
   if (!font) {
     return {};
   }
@@ -262,7 +382,8 @@ bool SystemFontProvider::hasFamily(std::string_view /*family*/) const {
   return false;
 }
 
-std::vector<uint8_t> SystemFontProvider::loadFamilyData(std::string_view /*family*/) const {
+std::vector<uint8_t> SystemFontProvider::loadFamilyData(std::string_view /*family*/,
+                                                        const FontFaceRequest& /*request*/) const {
   return {};
 }
 

--- a/donner/svg/resources/SystemFontProvider.h
+++ b/donner/svg/resources/SystemFontProvider.h
@@ -13,8 +13,9 @@ namespace donner::svg {
  *
  * On macOS this enumerates families via CoreText (`CTFontManagerCopyAvailableFontFamilyNames`) and
  * materializes a flat sfnt byte stream on demand by reconstructing the font's tables through
- * CoreText (which works even for `.ttc`/`.dfont` members). All families report \ref
- * FontSource::System.
+ * CoreText (which works even for `.ttc`/`.dfont` members). Faces within a family are scored against
+ * the requested weight/style/stretch, so bold and italic resolve to the real designed face. All
+ * families report \ref FontSource::System.
  *
  * On non-Apple platforms this is a stub: it enumerates nothing and loads nothing, so the catalog
  * still compiles and behaves (embedded fonts only).
@@ -25,7 +26,8 @@ public:
 
   std::vector<FontFamilyInfo> families() const override;
   bool hasFamily(std::string_view family) const override;
-  std::vector<uint8_t> loadFamilyData(std::string_view family) const override;
+  std::vector<uint8_t> loadFamilyData(std::string_view family,
+                                      const FontFaceRequest& request) const override;
 
   /// Returns true if this build enumerates real system fonts (i.e. macOS), false for the stub.
   static bool isSupported();

--- a/donner/svg/resources/tests/FontCatalog_tests.cc
+++ b/donner/svg/resources/tests/FontCatalog_tests.cc
@@ -5,8 +5,11 @@
 
 #include <algorithm>
 #include <memory>
+#include <ranges>
 
+#include "donner/svg/core/FontStyle.h"
 #include "donner/svg/resources/EmbeddedFontProvider.h"
+#include "donner/svg/resources/FontManager.h"
 #include "donner/svg/resources/SystemFontProvider.h"
 
 namespace donner::svg {
@@ -15,6 +18,8 @@ namespace {
 
 using ::testing::Contains;
 using ::testing::ElementsAre;
+using ::testing::IsEmpty;
+using ::testing::Not;
 
 /// A provider that reports a fixed family list and returns a single sentinel byte per family so
 /// tests can tell which provider served a given family.
@@ -36,7 +41,8 @@ public:
                        [&](const std::string& name) { return name == family; });
   }
 
-  std::vector<uint8_t> loadFamilyData(std::string_view family) const override {
+  std::vector<uint8_t> loadFamilyData(std::string_view family,
+                                      const FontFaceRequest& /*request*/) const override {
     if (!hasFamily(family)) {
       return {};
     }
@@ -93,7 +99,7 @@ TEST(EmbeddedFontProviderTest, SetSpansMultipleCategories) {
 TEST(EmbeddedFontProviderTest, EveryAdvertisedFamilyLoadsValidSfntBytes) {
   EmbeddedFontProvider provider;
   for (const FontFamilyInfo& info : provider.families()) {
-    const std::vector<uint8_t> data = provider.loadFamilyData(info.family);
+    const std::vector<uint8_t> data = provider.loadFamilyData(info.family, FontFaceRequest{});
     ASSERT_GE(data.size(), 4u) << info.family;
     // Every curated source is a TrueType sfnt with magic 0x00010000.
     EXPECT_EQ(data[0], 0x00) << info.family;
@@ -108,16 +114,15 @@ TEST(EmbeddedFontProviderTest, LookupIsCaseInsensitive) {
   EXPECT_TRUE(provider.hasFamily("inter"));
   EXPECT_TRUE(provider.hasFamily("JETBRAINS MONO"));
   EXPECT_FALSE(provider.hasFamily("Definitely Not A Font"));
-  EXPECT_TRUE(provider.loadFamilyData("Definitely Not A Font").empty());
+  EXPECT_TRUE(provider.loadFamilyData("Definitely Not A Font", FontFaceRequest{}).empty());
 }
 
 // --- FontCatalog aggregation + precedence -----------------------------------------------------
 
 TEST(FontCatalogTest, GroupsEmbeddedBeforeSystem) {
   std::vector<std::unique_ptr<FontFamilyProvider>> providers;
-  providers.push_back(
-      std::make_unique<MarkerProvider>(std::vector<std::string>{"EmbeddedOnly"},
-                                       FontSource::Embedded, 0x11));
+  providers.push_back(std::make_unique<MarkerProvider>(std::vector<std::string>{"EmbeddedOnly"},
+                                                       FontSource::Embedded, 0x11));
   providers.push_back(std::make_unique<MarkerProvider>(std::vector<std::string>{"SystemOnly"},
                                                        FontSource::System, 0x22));
   FontCatalog catalog(std::move(providers));
@@ -152,10 +157,10 @@ TEST(FontCatalogTest, EmbeddedShadowsSystemForDuplicateFamily) {
 
 TEST(FontCatalogTest, FamiliesBySourceFilters) {
   std::vector<std::unique_ptr<FontFamilyProvider>> providers;
-  providers.push_back(std::make_unique<MarkerProvider>(
-      std::vector<std::string>{"E1", "E2"}, FontSource::Embedded, 0x01));
-  providers.push_back(std::make_unique<MarkerProvider>(std::vector<std::string>{"S1"},
-                                                       FontSource::System, 0x02));
+  providers.push_back(std::make_unique<MarkerProvider>(std::vector<std::string>{"E1", "E2"},
+                                                       FontSource::Embedded, 0x01));
+  providers.push_back(
+      std::make_unique<MarkerProvider>(std::vector<std::string>{"S1"}, FontSource::System, 0x02));
   FontCatalog catalog(std::move(providers));
 
   EXPECT_THAT(familyNames(catalog.familiesBySource(FontSource::Embedded)),
@@ -194,18 +199,64 @@ TEST(SystemFontProviderTest, LoadsSfntForKnownSystemFamily) {
   if (!provider.hasFamily("Helvetica")) {
     GTEST_SKIP() << "Helvetica not available on this host";
   }
-  const std::vector<uint8_t> data = provider.loadFamilyData("Helvetica");
+  const std::vector<uint8_t> data = provider.loadFamilyData("Helvetica", FontFaceRequest{});
   ASSERT_GE(data.size(), 4u);
   const uint32_t magic = (uint32_t(data[0]) << 24) | (uint32_t(data[1]) << 16) |
                          (uint32_t(data[2]) << 8) | uint32_t(data[3]);
-  EXPECT_TRUE(magic == 0x00010000u || magic == 0x4F54544Fu /*OTTO*/ || magic == 0x74727565u /*true*/)
+  EXPECT_TRUE(magic == 0x00010000u || magic == 0x4F54544Fu /*OTTO*/ ||
+              magic == 0x74727565u /*true*/)
       << "unexpected sfnt magic: " << std::hex << magic;
 }
 
 TEST(SystemFontProviderTest, UnknownFamilyReturnsEmpty) {
   SystemFontProvider provider;
   EXPECT_FALSE(provider.hasFamily("Definitely Not Installed Font XYZ"));
-  EXPECT_TRUE(provider.loadFamilyData("Definitely Not Installed Font XYZ").empty());
+  EXPECT_TRUE(
+      provider.loadFamilyData("Definitely Not Installed Font XYZ", FontFaceRequest{}).empty());
+}
+
+// Regression: a catalog family is a *set* of faces, and `font-weight`/`font-style` pick which one.
+// Resolving them all to the family's default face is what makes bold and italic render as regular.
+TEST(FontManagerCatalogFaceTest, BoldResolvesToADistinctFaceFromRegular) {
+  SystemFontProvider probe;
+  if (!probe.hasFamily("Helvetica")) {
+    GTEST_SKIP() << "Helvetica not available on this host";
+  }
+
+  FontCatalog catalog;
+  Registry registry;
+  FontManager manager(registry);
+  manager.setFontProvider(&catalog);
+
+  const std::span<const uint8_t> regular = manager.fontData(manager.findFont("Helvetica", 400));
+  const std::span<const uint8_t> bold = manager.fontData(manager.findFont("Helvetica", 700));
+
+  ASSERT_THAT(regular, Not(IsEmpty()));
+  ASSERT_THAT(bold, Not(IsEmpty()));
+  EXPECT_FALSE(std::ranges::equal(regular, bold))
+      << "font-weight:700 resolved to the same face bytes as font-weight:400";
+}
+
+TEST(FontManagerCatalogFaceTest, ItalicResolvesToADistinctFaceFromUpright) {
+  SystemFontProvider probe;
+  if (!probe.hasFamily("Helvetica")) {
+    GTEST_SKIP() << "Helvetica not available on this host";
+  }
+
+  FontCatalog catalog;
+  Registry registry;
+  FontManager manager(registry);
+  manager.setFontProvider(&catalog);
+
+  const std::span<const uint8_t> upright =
+      manager.fontData(manager.findFont("Helvetica", 400, static_cast<int>(FontStyle::Normal), 5));
+  const std::span<const uint8_t> italic =
+      manager.fontData(manager.findFont("Helvetica", 400, static_cast<int>(FontStyle::Italic), 5));
+
+  ASSERT_THAT(upright, Not(IsEmpty()));
+  ASSERT_THAT(italic, Not(IsEmpty()));
+  EXPECT_FALSE(std::ranges::equal(upright, italic))
+      << "font-style:italic resolved to the same face bytes as font-style:normal";
 }
 #else
 TEST(SystemFontProviderTest, StubEnumeratesNothing) {

--- a/donner/svg/resources/tests/FontManager_tests.cc
+++ b/donner/svg/resources/tests/FontManager_tests.cc
@@ -10,7 +10,11 @@
 #include <vector>
 
 #include "donner/base/fonts/SfntUtils.h"
+#include "donner/svg/core/FontStretch.h"
+#include "donner/svg/core/FontStyle.h"
 #include "embed_resources/PublicSansFont.h"
+
+using testing::Eq;
 
 namespace donner::svg {
 
@@ -62,8 +66,10 @@ public:
     return false;
   }
 
-  std::vector<uint8_t> loadFamilyData(std::string_view family) const override {
+  std::vector<uint8_t> loadFamilyData(std::string_view family,
+                                      const FontFaceRequest& request) const override {
     ++loadCalls;
+    lastRequest = request;
     if (!hasFamily(family)) {
       return {};
     }
@@ -72,6 +78,7 @@ public:
   }
 
   mutable int loadCalls = 0;
+  mutable FontFaceRequest lastRequest;
 
 private:
   std::vector<std::string> families_;
@@ -533,6 +540,40 @@ TEST(FontManagerTest, FallsBackToPublicSansWhenProviderLacksFamily) {
   EXPECT_TRUE(static_cast<bool>(handle));
   EXPECT_EQ(handle, mgr.fallbackFont());
   EXPECT_EQ(provider.loadCalls, 0);
+}
+
+// Regression: a family is a set of faces, so the provider needs the requested weight/style/stretch
+// to pick one. Dropping them here is what makes `font-weight: bold` render as regular for every
+// catalog-resolved family.
+TEST(FontManagerTest, ProviderReceivesTheRequestedFace) {
+  Registry registry;
+  FontManager mgr(registry);
+  FakeFontProvider provider({"ProviderFamily"});
+  mgr.setFontProvider(&provider);
+
+  (void)mgr.findFont("ProviderFamily", 700, static_cast<int>(FontStyle::Italic),
+                     static_cast<int>(FontStretch::Condensed));
+
+  EXPECT_THAT(provider.lastRequest,
+              Eq(FontFaceRequest{
+                  .weight = 700, .style = FontStyle::Italic, .stretch = FontStretch::Condensed}));
+}
+
+// Faces are cached per requested face, not per family, so a later bold lookup is not served the
+// regular face out of the cache.
+TEST(FontManagerTest, ProviderIsConsultedOncePerRequestedFace) {
+  Registry registry;
+  FontManager mgr(registry);
+  FakeFontProvider provider({"ProviderFamily"});
+  mgr.setFontProvider(&provider);
+
+  (void)mgr.findFont("ProviderFamily", 400);
+  (void)mgr.findFont("ProviderFamily", 400);
+  EXPECT_EQ(provider.loadCalls, 1);
+
+  (void)mgr.findFont("ProviderFamily", 700);
+  EXPECT_EQ(provider.loadCalls, 2);
+  EXPECT_THAT(provider.lastRequest.weight, Eq(700));
 }
 
 TEST(FontManagerTest, DefaultProviderAdoptedByNewInstances) {

--- a/donner/svg/tests/SVGTextElement_tests.cc
+++ b/donner/svg/tests/SVGTextElement_tests.cc
@@ -462,6 +462,116 @@ TEST(SVGTextElementCacheTests, SetPositionInvalidatesCache) {
   EXPECT_NEAR(startAfter.x, 50.0, 0.5);
 }
 
+// Regression: the editor's font controls write presentation attributes onto the selected `<text>`
+// element (`font-size`, `font-family`, `font-weight`, ...). Those are style inputs to text layout,
+// so a write must drop the memoized `ComputedTextGeometryComponent` - both renderers draw straight
+// out of that cache, and a stale entry makes every font control look like a no-op.
+TEST(SVGTextElementCacheTests, FontSizeAttributeChangeInvalidatesCache) {
+  SVGDocument doc = instantiateSubtree(R"-(
+    <svg viewBox="0 0 200 40">
+      <text id="t" x="10" y="20" font-family="fallback-font" font-size="12px">ABCDEF</text>
+    </svg>
+  )-",
+                                       kExperimentalOptions);
+
+  auto textElement = doc.querySelector("#t")->cast<SVGTextElement>();
+
+  // Prime the cache, the way the editor does when it measures the selection bounds.
+  const double lengthBefore = textElement.getComputedTextLength();
+  ASSERT_GT(lengthBefore, 0.0);
+
+  textElement.setAttribute("font-size", "24px");
+
+  // Doubling the font size doubles the advance width.
+  EXPECT_THAT(textElement.getComputedTextLength(),
+              testing::DoubleNear(lengthBefore * 2.0, lengthBefore * 0.05));
+}
+
+TEST(SVGTextElementCacheTests, TextAnchorAttributeChangeInvalidatesCache) {
+  SVGDocument doc = instantiateSubtree(R"-(
+    <svg viewBox="0 0 200 40">
+      <text id="t" x="100" y="20" font-family="fallback-font" font-size="12px">ABCDEF</text>
+    </svg>
+  )-",
+                                       kExperimentalOptions);
+
+  auto textElement = doc.querySelector("#t")->cast<SVGTextElement>();
+
+  const double length = textElement.getComputedTextLength();
+  ASSERT_GT(length, 0.0);
+  ASSERT_THAT(textElement.getStartPositionOfChar(0).x, testing::DoubleNear(100.0, 0.5));
+
+  textElement.setAttribute("text-anchor", "end");
+
+  // `text-anchor: end` puts the *end* of the run on the anchor point.
+  EXPECT_THAT(textElement.getStartPositionOfChar(0).x, testing::DoubleNear(100.0 - length, 0.5));
+}
+
+TEST(SVGTextElementCacheTests, StyleAttributeChangeInvalidatesCache) {
+  SVGDocument doc = instantiateSubtree(R"-(
+    <svg viewBox="0 0 200 40">
+      <text id="t" x="10" y="20" font-family="fallback-font" font-size="12px">ABCDEF</text>
+    </svg>
+  )-",
+                                       kExperimentalOptions);
+
+  auto textElement = doc.querySelector("#t")->cast<SVGTextElement>();
+
+  const double lengthBefore = textElement.getComputedTextLength();
+  ASSERT_GT(lengthBefore, 0.0);
+
+  textElement.setStyle("font-size: 24px");
+
+  EXPECT_THAT(textElement.getComputedTextLength(),
+              testing::DoubleNear(lengthBefore * 2.0, lengthBefore * 0.05));
+}
+
+// `font-size` inherits, so a write on an ancestor group must invalidate the text roots beneath it.
+TEST(SVGTextElementCacheTests, InheritedFontChangeOnAncestorInvalidatesCache) {
+  SVGDocument doc = instantiateSubtree(R"-(
+    <svg viewBox="0 0 200 40">
+      <g id="g">
+        <text id="t" x="10" y="20" font-family="fallback-font">ABCDEF</text>
+      </g>
+    </svg>
+  )-",
+                                       kExperimentalOptions);
+
+  auto group = doc.querySelector("#g").value();
+  auto textElement = doc.querySelector("#t")->cast<SVGTextElement>();
+
+  group.setAttribute("font-size", "12px");
+  const double lengthBefore = textElement.getComputedTextLength();
+  ASSERT_GT(lengthBefore, 0.0);
+
+  group.setAttribute("font-size", "24px");
+
+  EXPECT_THAT(textElement.getComputedTextLength(),
+              testing::DoubleNear(lengthBefore * 2.0, lengthBefore * 0.05));
+}
+
+// A write on a `<tspan>` must invalidate the enclosing `<text>` root's layout, not just its own.
+TEST(SVGTextElementCacheTests, TSpanFontSizeAttributeChangeInvalidatesParent) {
+  SVGDocument doc = instantiateSubtree(R"-(
+    <svg viewBox="0 0 200 40">
+      <text id="root" x="10" y="20" font-family="fallback-font" font-size="12px"
+        ><tspan id="span">ABC</tspan></text>
+    </svg>
+  )-",
+                                       kExperimentalOptions);
+
+  auto root = doc.querySelector("#root")->cast<SVGTextElement>();
+  auto span = doc.querySelector("#span")->cast<SVGTSpanElement>();
+
+  const double lengthBefore = root.getComputedTextLength();
+  ASSERT_GT(lengthBefore, 0.0);
+
+  span.setAttribute("font-size", "24px");
+
+  EXPECT_THAT(root.getComputedTextLength(),
+              testing::DoubleNear(lengthBefore * 2.0, lengthBefore * 0.05));
+}
+
 TEST(SVGTextElementCacheTests, TSpanPositionChangeInvalidatesParent) {
   SVGDocument doc = instantiateSubtree(R"-(
     <svg viewBox="0 0 200 40">

--- a/tools/gpu_inventory/manifests/gpu_operations.json
+++ b/tools/gpu_inventory/manifests/gpu_operations.json
@@ -987,12 +987,14 @@
         "poll",
         "submit",
         "unmap",
+        "writeBuffer",
         "writeTexture"
       ],
       "wgpuCFunctions": [
         "wgpuLabel"
       ],
       "wgpuCTypes": [
+        "WGPUBuffer",
         "WGPUMapAsyncStatus",
         "WGPUMapAsyncStatus_Success",
         "WGPUStringView"

--- a/tools/mcp-servers/editor-control/BUILD.bazel
+++ b/tools/mcp-servers/editor-control/BUILD.bazel
@@ -56,6 +56,8 @@ cc_library(
         "//donner/svg/compositor",
         "//donner/svg/renderer",
         "//donner/svg/renderer:renderer_image_io",
+        "//donner/svg/resources:font_catalog",
+        "//donner/svg/resources:font_manager",
         "@nlohmann_json//:json",
         "@pixelmatch-cpp17",
     ] + select({

--- a/tools/mcp-servers/editor-control/EditorControlSession.h
+++ b/tools/mcp-servers/editor-control/EditorControlSession.h
@@ -19,6 +19,7 @@
 #include "donner/editor/ViewportState.h"
 #include "donner/editor/repro/ReproFile.h"
 #include "donner/svg/renderer/Renderer.h"
+#include "donner/svg/resources/FontCatalog.h"
 #include "nlohmann/json.hpp"
 
 namespace donner::editor::mcp {
@@ -141,6 +142,7 @@ private:
   [[nodiscard]] bool loadCurrentSourceText(const LoadOptions& options, std::string_view sourcePath,
                                            bool resetRenderVersion, nlohmann::json* loadInfo,
                                            std::string* error);
+  void installFontCatalogOnDocument();
   [[nodiscard]] nlohmann::json sourceStateJson() const;
 
   class HeadlessTextureCache {
@@ -196,6 +198,9 @@ private:
   [[nodiscard]] bool ensureDocumentLoaded(std::string* error) const;
   [[nodiscard]] bool waitUntilIdle(std::string* error);
 
+  /// Same catalog used by EditorShell, declared first so render workers cannot
+  /// outlive the provider they resolve family changes through.
+  svg::FontCatalog fontCatalog_;
   EditorApp app_;
   std::unique_ptr<SelectTool> selectTool_;
   PenTool penTool_;

--- a/tools/mcp-servers/editor-control/EditorControlSessionDocument.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSessionDocument.cc
@@ -16,6 +16,7 @@
 #include "donner/editor/TextPatch.h"
 #include "donner/editor/ViewportState.h"
 #include "donner/svg/SVGDocument.h"
+#include "donner/svg/resources/FontManager.h"
 #include "nlohmann/json.hpp"
 #include "tools/mcp-servers/editor-control/EditorControlSessionInternal.h"
 
@@ -26,6 +27,17 @@ namespace {
 using nlohmann::json;
 
 }  // namespace
+
+void EditorControlSession::installFontCatalogOnDocument() {
+  svg::SVGDocument& document = app_.document().document();
+  document.withWriteAccess([this](svg::DocumentWriteAccess& access) {
+    Registry& registry = access.registry();
+    svg::FontManager& fontManager = registry.ctx().contains<svg::FontManager>()
+                                        ? registry.ctx().get<svg::FontManager>()
+                                        : registry.ctx().emplace<svg::FontManager>(registry);
+    fontManager.setFontProvider(&fontCatalog_);
+  });
+}
 
 ToolCallResult EditorControlSession::loadDocument(const json& arguments) {
   std::string error;
@@ -87,6 +99,7 @@ bool EditorControlSession::loadCurrentSourceText(const LoadOptions& options,
     *error = "failed to parse SVG source";
     return false;
   }
+  installFontCatalogOnDocument();
 
   currentSourcePath_ = std::string(sourcePath);
   app_.setCurrentFilePath(std::string(sourcePath));

--- a/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
@@ -351,6 +351,56 @@ TEST(EditorControlSessionTest, ToolListExposesSelectorDragAndRenderTools) {
   EXPECT_TRUE((*replayTool)["inputSchema"]["properties"].contains("gl_drive_document_input"));
 }
 
+TEST(EditorControlSessionTest, CatalogFontFamilyMutationChangesRenderedGlyphs) {
+  constexpr std::string_view kScene = R"svg(
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 100">
+  <text id="label" x="10" y="60" font-size="48">Font selection</text>
+</svg>)svg";
+
+  EditorControlSession session;
+  const ToolCallResult load =
+      session.handleToolCall("load_svg", json{{"svg_source", std::string(kScene)},
+                                              {"canvas_width", 300},
+                                              {"canvas_height", 100},
+                                              {"render_after_load", false}});
+  ASSERT_TRUE(load.body.value("ok", false)) << load.body.dump(2);
+
+  const ToolCallResult selected =
+      session.handleToolCall("select_by_selector", json{{"selector", "#label"}, {"render", true}});
+  ASSERT_TRUE(selected.body.value("ok", false)) << selected.body.dump(2);
+  const ToolCallResult changed = session.handleToolCall(
+      "set_style_property",
+      json{{"property", "font-family"}, {"value", "Bebas Neue"}, {"render_after_set", true}});
+  ASSERT_TRUE(changed.body.value("ok", false)) << changed.body.dump(2);
+
+  ASSERT_FALSE(selected.body["render_stages"].empty());
+  ASSERT_FALSE(changed.body["render_stages"].empty());
+  const json& selectedTiles = selected.body["render_stages"].back()["display_preview"]["tiles"];
+  const json& changedTiles = changed.body["render_stages"].back()["display_preview"]["tiles"];
+  ASSERT_TRUE(selectedTiles.is_array()) << selected.body.dump(2);
+  ASSERT_TRUE(changedTiles.is_array()) << changed.body.dump(2);
+  ASSERT_FALSE(selectedTiles.empty()) << selected.body.dump(2);
+  ASSERT_FALSE(changedTiles.empty()) << changed.body.dump(2);
+
+  std::vector<std::string> selectedHashes;
+  for (const json& tile : selectedTiles) {
+    ASSERT_TRUE(tile["content_hash"].is_string()) << tile.dump(2);
+    selectedHashes.push_back(tile["content_hash"].get<std::string>());
+  }
+  std::vector<std::string> changedHashes;
+  for (const json& tile : changedTiles) {
+    ASSERT_TRUE(tile["content_hash"].is_string()) << tile.dump(2);
+    changedHashes.push_back(tile["content_hash"].get<std::string>());
+  }
+  EXPECT_NE(selectedHashes, changedHashes);
+  EXPECT_TRUE(changed.body.value("queued_selection_mutation", false));
+  EXPECT_TRUE(changed.body.value("flushed_mutation", false));
+
+  const ToolCallResult source = session.handleToolCall("get_svg_source", json::object());
+  ASSERT_TRUE(source.body.value("ok", false));
+  EXPECT_NE(source.body.value("text", "").find("font-family: Bebas Neue"), std::string::npos);
+}
+
 TEST(EditorControlSessionTest, ClickLayerVisibilityButtonCapturesImmediateAndSettledFrames) {
   constexpr std::string_view kScene =
       R"svg(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 20">


### PR DESCRIPTION
The welcome screen, File menu, and keyboard shortcut now share one safe New Document flow.

- Add a New Document button to the splash page.
- Add File -> New and the platform New Document shortcut.
- Route every entry point through the existing dirty-document confirmation path.
- Replace the current file with a clean untitled canvas only after confirmation.

## Verification

- Cumulative UX stack: `bazel test //donner/editor/tests:menu_bar_presenter_tests //donner/editor/tests:sample_picker_presenter_tests //donner/editor/tests:editor_shell_tests //tools/mcp-servers/editor-control:editor_control_session_tests --test_output=errors`
- Cumulative UX stack: `bazel build --config=editor-wasm //donner/editor/wasm:wasm_web_package`
- Cumulative UX stack on PR #1000: `bazel test //... --test_output=errors`
