### PR TITLE
Stabilize fill and stroke controls during drags

### DIFF
--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -2997,8 +2997,19 @@ void EditorShell::renderFillStrokeToolbarWidget() {
   const bool canvasInteractionActive = selectTool_.isDragging() || selectTool_.isMarqueeing() ||
                                        penTool_.isDraggingAnchor() || textTool_.isDraggingBox() ||
                                        textTool_.isAdjustingFrame();
+  svg::SVGDocumentHandle currentPaintDocument;
+  std::optional<Entity> currentPaintSelection;
+  if (app_.hasDocument()) {
+    currentPaintDocument = app_.document().document().handle();
+    if (!app_.selectedElements().empty()) {
+      currentPaintSelection = app_.selectedElements().front().unsafeEntityHandle().entity();
+    }
+  }
+  const bool paintSnapshotMatchesSelection =
+      toolbarPaintSnapshot_ != nullptr && toolbarPaintSnapshotDocument_ == currentPaintDocument &&
+      toolbarPaintSnapshotSelection_ == currentPaintSelection;
   const FillStrokeWidgetInteractionState interactionState = ResolveFillStrokeWidgetInteractionState(
-      app_.hasDocument(), rendererBusy, canvasInteractionActive, toolbarPaintSnapshot_ != nullptr);
+      app_.hasDocument(), rendererBusy, canvasInteractionActive, paintSnapshotMatchesSelection);
   const bool canEditPaint = interactionState.canEdit;
   std::string editorSource;
   std::string documentSource;
@@ -3018,7 +3029,9 @@ void EditorShell::renderFillStrokeToolbarWidget() {
   if (interactionState.refreshPaintSnapshot) {
     paintState = ToolbarPaintStateForApp(app_, sourceForRanges);
     toolbarPaintSnapshot_ = std::make_unique<ToolbarPaintState>(paintState);
-  } else if (toolbarPaintSnapshot_ != nullptr) {
+    toolbarPaintSnapshotDocument_ = std::move(currentPaintDocument);
+    toolbarPaintSnapshotSelection_ = currentPaintSelection;
+  } else if (paintSnapshotMatchesSelection) {
     paintState = *toolbarPaintSnapshot_;
   } else {
     paintState = ToolbarPaintStateForActivePaint(app_.activePaintStyle());

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -2994,7 +2994,12 @@ Box2d EditorShell::canvasZoomControlScreenRect() const {
 
 void EditorShell::renderFillStrokeToolbarWidget() {
   const bool rendererBusy = renderCoordinator_.asyncRenderer().isBusy();
-  const bool canEditPaint = app_.hasDocument() && !rendererBusy;
+  const bool canvasInteractionActive = selectTool_.isDragging() || selectTool_.isMarqueeing() ||
+                                       penTool_.isDraggingAnchor() || textTool_.isDraggingBox() ||
+                                       textTool_.isAdjustingFrame();
+  const FillStrokeWidgetInteractionState interactionState = ResolveFillStrokeWidgetInteractionState(
+      app_.hasDocument(), rendererBusy, canvasInteractionActive, toolbarPaintSnapshot_ != nullptr);
+  const bool canEditPaint = interactionState.canEdit;
   std::string editorSource;
   std::string documentSource;
   std::optional<std::string_view> sourceForRanges;
@@ -3005,11 +3010,12 @@ void EditorShell::renderFillStrokeToolbarWidget() {
       sourceForRanges = std::string_view(editorSource);
     }
   }
-  // The worker owns the selected element while busy. Preserve the last idle
-  // presentation instead of replacing the selected paint with the unrelated
-  // authoring default for every render update.
+  // The worker owns the selected element while busy, and drag-frame handoffs
+  // alternate between busy and idle as previews land. Preserve one paint and
+  // enabled-state presentation for the entire canvas interaction instead of
+  // letting the swap arrow and selected swatches oscillate with worker state.
   ToolbarPaintState paintState;
-  if (!rendererBusy) {
+  if (interactionState.refreshPaintSnapshot) {
     paintState = ToolbarPaintStateForApp(app_, sourceForRanges);
     toolbarPaintSnapshot_ = std::make_unique<ToolbarPaintState>(paintState);
   } else if (toolbarPaintSnapshot_ != nullptr) {

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -650,8 +650,12 @@ private:
   bool sidebarSnapshotRefreshPending_ = false;
   /// Last paint presentation read while the document was idle. The renderer
   /// owns the document registry while busy, so worker frames replay this
-  /// value instead of substituting the unrelated authoring paint.
+  /// value instead of substituting the unrelated authoring paint. The owner
+  /// fields prevent a drag that changes selection from replaying the previous
+  /// element's paint.
   std::unique_ptr<internal::ToolbarPaintState> toolbarPaintSnapshot_;
+  svg::SVGDocumentHandle toolbarPaintSnapshotDocument_;
+  std::optional<Entity> toolbarPaintSnapshotSelection_;
   /// Document-derived menu/shortcut state from the last idle UI epoch. Busy frames must replay
   /// these values instead of traversing the live registry behind the worker's write guard.
   bool cachedCanvasHasSelectableElements_ = false;

--- a/donner/editor/FillStrokeWidget.cc
+++ b/donner/editor/FillStrokeWidget.cc
@@ -49,10 +49,12 @@ constexpr float kFillChipBottom = 29.0f;
 }  // namespace
 
 FillStrokeWidgetInteractionState ResolveFillStrokeWidgetInteractionState(
-    bool hasDocument, bool rendererBusy, bool canvasInteractionActive, bool hasPaintSnapshot) {
+    bool hasDocument, bool rendererBusy, bool canvasInteractionActive,
+    bool paintSnapshotMatchesSelection) {
   return FillStrokeWidgetInteractionState{
       .canEdit = hasDocument && !rendererBusy && !canvasInteractionActive,
-      .refreshPaintSnapshot = !rendererBusy && (!canvasInteractionActive || !hasPaintSnapshot),
+      .refreshPaintSnapshot =
+          !rendererBusy && (!canvasInteractionActive || !paintSnapshotMatchesSelection),
   };
 }
 

--- a/donner/editor/FillStrokeWidget.cc
+++ b/donner/editor/FillStrokeWidget.cc
@@ -48,6 +48,14 @@ constexpr float kFillChipBottom = 29.0f;
 
 }  // namespace
 
+FillStrokeWidgetInteractionState ResolveFillStrokeWidgetInteractionState(
+    bool hasDocument, bool rendererBusy, bool canvasInteractionActive, bool hasPaintSnapshot) {
+  return FillStrokeWidgetInteractionState{
+      .canEdit = hasDocument && !rendererBusy && !canvasInteractionActive,
+      .refreshPaintSnapshot = !rendererBusy && (!canvasInteractionActive || !hasPaintSnapshot),
+  };
+}
+
 FillStrokeWidgetLayout ComputeFillStrokeWidgetLayout(const ImVec2& widgetMin,
                                                      const ImVec2& widgetMax) {
   const float x = widgetMin.x;

--- a/donner/editor/FillStrokeWidget.h
+++ b/donner/editor/FillStrokeWidget.h
@@ -17,8 +17,8 @@ namespace donner::editor::internal {
 
 /// Interactive regions of the Fill/Stroke widget, in hit-test priority order.
 enum class FillStrokeWidgetRegion {
-  None,         ///< No interactive region under the point.
-  FillSwatch,   ///< Front (fill) swatch: opens the fill color picker.
+  None,          ///< No interactive region under the point.
+  FillSwatch,    ///< Front (fill) swatch: opens the fill color picker.
   StrokeSwatch,  ///< Back (stroke) swatch: opens the stroke color picker.
   Swap,          ///< Double-arrow affordance: swaps fill and stroke paints.
   FillNone,      ///< Fill "set none" affordance.
@@ -30,24 +30,34 @@ enum class FillStrokeWidgetRegion {
 /// Screen-space rectangles for every drawable/interactive part of the widget.
 struct FillStrokeWidgetLayout {
   ImVec2 fillMin, fillMax;              ///< Front (fill) swatch.
-  ImVec2 strokeMin, strokeMax;         ///< Back (stroke) swatch.
-  ImVec2 swapMin, swapMax;             ///< Swap double-arrow affordance.
-  ImVec2 fillNoneMin, fillNoneMax;     ///< Fill "set none" affordance.
+  ImVec2 strokeMin, strokeMax;          ///< Back (stroke) swatch.
+  ImVec2 swapMin, swapMax;              ///< Swap double-arrow affordance.
+  ImVec2 fillNoneMin, fillNoneMax;      ///< Fill "set none" affordance.
   ImVec2 strokeNoneMin, strokeNoneMax;  ///< Stroke "set none" affordance.
-  ImVec2 fillChipMin, fillChipMax;     ///< Fill custom-paint label chip.
+  ImVec2 fillChipMin, fillChipMax;      ///< Fill custom-paint label chip.
   ImVec2 strokeChipMin, strokeChipMax;  ///< Stroke custom-paint label chip.
 };
 
 /// Stable interaction policy for one fill/stroke toolbar frame.
 struct FillStrokeWidgetInteractionState {
+  /// Whether widget actions may mutate the active paint.
   bool canEdit = false;
+  /// Whether the shell should replace its cached paint snapshot this frame.
   bool refreshPaintSnapshot = false;
 };
 
-/// Resolve editability and snapshot refresh without keying drag chrome to a
-/// renderer busy bit that can alternate between adjacent preview frames. The
-/// caller must report whether its snapshot belongs to the current document
-/// and first selected element, not merely whether any snapshot exists.
+/**
+ * Resolve editability and snapshot refresh without keying drag chrome to a renderer busy bit.
+ *
+ * The caller reports whether its snapshot belongs to the current document and first selected
+ * element, not merely whether any snapshot exists.
+ *
+ * @param hasDocument Whether the editor currently owns a document.
+ * @param rendererBusy Whether the async renderer currently owns document access.
+ * @param canvasInteractionActive Whether a canvas gesture is in progress.
+ * @param paintSnapshotMatchesSelection Whether the cached paint belongs to the current selection.
+ * @return Editability and snapshot-refresh policy for the current toolbar frame.
+ */
 [[nodiscard]] FillStrokeWidgetInteractionState ResolveFillStrokeWidgetInteractionState(
     bool hasDocument, bool rendererBusy, bool canvasInteractionActive,
     bool paintSnapshotMatchesSelection);
@@ -81,7 +91,7 @@ void DrawSwapAffordance(ImDrawList* drawList, const ImVec2& min, const ImVec2& m
 /// Draw a "set none" affordance. @p fillVariant selects the solid (fill) motif
 /// versus the hollow (stroke) motif; @p active brightens it when the slot is
 /// already none.
-void DrawNoneAffordance(ImDrawList* drawList, const ImVec2& min, const ImVec2& max, bool fillVariant,
-                        bool active);
+void DrawNoneAffordance(ImDrawList* drawList, const ImVec2& min, const ImVec2& max,
+                        bool fillVariant, bool active);
 
 }  // namespace donner::editor::internal

--- a/donner/editor/FillStrokeWidget.h
+++ b/donner/editor/FillStrokeWidget.h
@@ -38,6 +38,17 @@ struct FillStrokeWidgetLayout {
   ImVec2 strokeChipMin, strokeChipMax;  ///< Stroke custom-paint label chip.
 };
 
+/// Stable interaction policy for one fill/stroke toolbar frame.
+struct FillStrokeWidgetInteractionState {
+  bool canEdit = false;
+  bool refreshPaintSnapshot = false;
+};
+
+/// Resolve editability and snapshot refresh without keying drag chrome to a
+/// renderer busy bit that can alternate between adjacent preview frames.
+[[nodiscard]] FillStrokeWidgetInteractionState ResolveFillStrokeWidgetInteractionState(
+    bool hasDocument, bool rendererBusy, bool canvasInteractionActive, bool hasPaintSnapshot);
+
 /// Compute widget sub-rectangles from the widget's outer bounds.
 [[nodiscard]] FillStrokeWidgetLayout ComputeFillStrokeWidgetLayout(const ImVec2& widgetMin,
                                                                    const ImVec2& widgetMax);

--- a/donner/editor/FillStrokeWidget.h
+++ b/donner/editor/FillStrokeWidget.h
@@ -45,9 +45,12 @@ struct FillStrokeWidgetInteractionState {
 };
 
 /// Resolve editability and snapshot refresh without keying drag chrome to a
-/// renderer busy bit that can alternate between adjacent preview frames.
+/// renderer busy bit that can alternate between adjacent preview frames. The
+/// caller must report whether its snapshot belongs to the current document
+/// and first selected element, not merely whether any snapshot exists.
 [[nodiscard]] FillStrokeWidgetInteractionState ResolveFillStrokeWidgetInteractionState(
-    bool hasDocument, bool rendererBusy, bool canvasInteractionActive, bool hasPaintSnapshot);
+    bool hasDocument, bool rendererBusy, bool canvasInteractionActive,
+    bool paintSnapshotMatchesSelection);
 
 /// Compute widget sub-rectangles from the widget's outer bounds.
 [[nodiscard]] FillStrokeWidgetLayout ComputeFillStrokeWidgetLayout(const ImVec2& widgetMin,

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -55,6 +55,13 @@ constexpr std::string_view kStyledSvg = R"svg(
 </svg>
 )svg";
 
+constexpr std::string_view kPaintSnapshotSelectionChangeSvg = R"svg(
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="80" viewBox="0 0 120 80">
+  <rect id="first" x="10" y="12" width="40" height="24" fill="#ff0000"/>
+  <rect id="second" x="65" y="12" width="40" height="24" fill="#0000ff"/>
+</svg>
+)svg";
+
 constexpr std::string_view kReferencedSvg = R"svg(
 <svg xmlns="http://www.w3.org/2000/svg" width="120" height="80" viewBox="0 0 120 80">
   <defs>
@@ -3531,6 +3538,38 @@ TEST(EditorShellTest, FillStrokeToolbarStaysVisuallyStableDuringShapeDrag) {
 
   RenderToolbarFrame(window, shell, kCursor, ImVec2(-100.0f, -100.0f), /*mouseDown=*/false);
   expectStableDragChrome();
+}
+
+TEST(EditorShellTest, FillStrokeToolbarCapturesNewSelectionBeforeFreezingShapeDrag) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window,
+                    OptionsWithSource(kPaintSnapshotSelectionChangeSvg, "paint_selection.svg"));
+  ASSERT_TRUE(shell.valid());
+  EditorShellTestAccess::ConfigureViewport(shell, Box2d::FromXYWH(0.0, 0.0, 120.0, 80.0));
+  svg::SVGDocument& document = EditorShellTestAccess::App(shell).document().document();
+  std::optional<svg::SVGElement> first = document.querySelector("#first");
+  std::optional<svg::SVGElement> second = document.querySelector("#second");
+  ASSERT_TRUE(first.has_value());
+  ASSERT_TRUE(second.has_value());
+
+  constexpr ImVec2 kCursor(20.0f, 40.0f);
+  EditorShellTestAccess::App(shell).setSelection(*first);
+  RenderToolbarFrame(window, shell, kCursor, ImVec2(-100.0f, -100.0f), /*mouseDown=*/false);
+  ASSERT_TRUE(DrawDataContainsColor(IM_COL32(255, 0, 0, 255)));
+
+  EditorShellTestAccess::App(shell).setSelection(*second);
+  ASSERT_TRUE(EditorShellTestAccess::BeginSelectedShapeDrag(
+      shell, Vector2d(75.0, 20.0), Box2d::FromXYWH(65.0, 12.0, 40.0, 24.0)));
+  RenderToolbarFrame(window, shell, kCursor, ImVec2(-100.0f, -100.0f), /*mouseDown=*/false);
+
+  EXPECT_TRUE(DrawDataContainsColor(IM_COL32(0, 0, 255, 255)))
+      << "The drag must freeze the newly selected element's fill";
+  EXPECT_FALSE(DrawDataContainsColor(IM_COL32(255, 0, 0, 255)))
+      << "The drag must not replay the previous selection's fill";
 }
 
 TEST(EditorShellTest, ToolPaletteSelectCommitsOpenPenPath) {

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -647,11 +647,11 @@ TEST(EditorShellInternalTest, FillStrokeWidgetInteractionStateIgnoresBusyHandoff
   const internal::FillStrokeWidgetInteractionState idleDrag =
       internal::ResolveFillStrokeWidgetInteractionState(
           /*hasDocument=*/true, /*rendererBusy=*/false, /*canvasInteractionActive=*/true,
-          /*hasPaintSnapshot=*/true);
+          /*paintSnapshotMatchesSelection=*/true);
   const internal::FillStrokeWidgetInteractionState busyDrag =
       internal::ResolveFillStrokeWidgetInteractionState(
           /*hasDocument=*/true, /*rendererBusy=*/true, /*canvasInteractionActive=*/true,
-          /*hasPaintSnapshot=*/true);
+          /*paintSnapshotMatchesSelection=*/true);
   EXPECT_EQ(idleDrag.canEdit, busyDrag.canEdit);
   EXPECT_EQ(idleDrag.refreshPaintSnapshot, busyDrag.refreshPaintSnapshot);
   EXPECT_FALSE(idleDrag.canEdit);
@@ -660,14 +660,14 @@ TEST(EditorShellInternalTest, FillStrokeWidgetInteractionStateIgnoresBusyHandoff
   const internal::FillStrokeWidgetInteractionState firstDragFrame =
       internal::ResolveFillStrokeWidgetInteractionState(
           /*hasDocument=*/true, /*rendererBusy=*/false, /*canvasInteractionActive=*/true,
-          /*hasPaintSnapshot=*/false);
+          /*paintSnapshotMatchesSelection=*/false);
   EXPECT_FALSE(firstDragFrame.canEdit);
   EXPECT_TRUE(firstDragFrame.refreshPaintSnapshot);
 
   const internal::FillStrokeWidgetInteractionState settled =
       internal::ResolveFillStrokeWidgetInteractionState(
           /*hasDocument=*/true, /*rendererBusy=*/false, /*canvasInteractionActive=*/false,
-          /*hasPaintSnapshot=*/true);
+          /*paintSnapshotMatchesSelection=*/true);
   EXPECT_TRUE(settled.canEdit);
   EXPECT_TRUE(settled.refreshPaintSnapshot);
 }

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -636,6 +636,35 @@ TEST(EditorShellInternalTest, FillStrokeWidgetLayoutAndHitTestClassifyRegions) {
   EXPECT_EQ(hit(strokeChip, false, true), internal::FillStrokeWidgetRegion::StrokeChip);
 }
 
+TEST(EditorShellInternalTest, FillStrokeWidgetInteractionStateIgnoresBusyHandoffsDuringDrag) {
+  const internal::FillStrokeWidgetInteractionState idleDrag =
+      internal::ResolveFillStrokeWidgetInteractionState(
+          /*hasDocument=*/true, /*rendererBusy=*/false, /*canvasInteractionActive=*/true,
+          /*hasPaintSnapshot=*/true);
+  const internal::FillStrokeWidgetInteractionState busyDrag =
+      internal::ResolveFillStrokeWidgetInteractionState(
+          /*hasDocument=*/true, /*rendererBusy=*/true, /*canvasInteractionActive=*/true,
+          /*hasPaintSnapshot=*/true);
+  EXPECT_EQ(idleDrag.canEdit, busyDrag.canEdit);
+  EXPECT_EQ(idleDrag.refreshPaintSnapshot, busyDrag.refreshPaintSnapshot);
+  EXPECT_FALSE(idleDrag.canEdit);
+  EXPECT_FALSE(idleDrag.refreshPaintSnapshot);
+
+  const internal::FillStrokeWidgetInteractionState firstDragFrame =
+      internal::ResolveFillStrokeWidgetInteractionState(
+          /*hasDocument=*/true, /*rendererBusy=*/false, /*canvasInteractionActive=*/true,
+          /*hasPaintSnapshot=*/false);
+  EXPECT_FALSE(firstDragFrame.canEdit);
+  EXPECT_TRUE(firstDragFrame.refreshPaintSnapshot);
+
+  const internal::FillStrokeWidgetInteractionState settled =
+      internal::ResolveFillStrokeWidgetInteractionState(
+          /*hasDocument=*/true, /*rendererBusy=*/false, /*canvasInteractionActive=*/false,
+          /*hasPaintSnapshot=*/true);
+  EXPECT_TRUE(settled.canEdit);
+  EXPECT_TRUE(settled.refreshPaintSnapshot);
+}
+
 TEST(EditorShellInternalTest, SourceHelpersPreferInitialSourceAndCanonicalizeTrailingNewline) {
   const std::filesystem::path path = TempPathForTest("initial.svg");
   WriteTextFile(path, "<svg id=\"from-file\"/>\n");
@@ -3474,7 +3503,7 @@ TEST(EditorShellTest, FillStrokeToolbarKeepsChosenPaintVisibleWhileRendererIsBus
   renderer.setReplayRenderDelayForTesting(std::chrono::milliseconds(0));
 }
 
-TEST(EditorShellTest, FillStrokeToolbarStaysVisuallyStableAcrossDragRenderHandoffs) {
+TEST(EditorShellTest, FillStrokeToolbarStaysVisuallyStableDuringShapeDrag) {
   gui::EditorWindow window = MakeHiddenWindow();
   if (!window.valid()) {
     GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
@@ -3502,18 +3531,6 @@ TEST(EditorShellTest, FillStrokeToolbarStaysVisuallyStableAcrossDragRenderHandof
 
   RenderToolbarFrame(window, shell, kCursor, ImVec2(-100.0f, -100.0f), /*mouseDown=*/false);
   expectStableDragChrome();
-
-  AsyncRenderer& renderer =
-      EditorShellTestAccess::BeginDelayedRender(shell, std::chrono::milliseconds(500));
-  ASSERT_TRUE(renderer.isBusy());
-  RenderToolbarFrame(window, shell, kCursor, ImVec2(-100.0f, -100.0f), /*mouseDown=*/false);
-  expectStableDragChrome();
-
-  renderer.cancelInFlight();
-  EXPECT_TRUE(renderer.waitUntilNoRenderInFlightForTesting(std::chrono::steady_clock::now() +
-                                                           std::chrono::seconds(2)));
-  std::ignore = renderer.pollResult();
-  renderer.setReplayRenderDelayForTesting(std::chrono::milliseconds(0));
 }
 
 TEST(EditorShellTest, ToolPaletteSelectCommitsOpenPenPath) {

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -1283,6 +1283,13 @@ public:
     return shell.selectTool_.isMarqueeing();
   }
 
+  static bool BeginSelectedShapeDrag(EditorShell& shell, const Vector2d& documentPoint,
+                                     const Box2d& selectionBounds) {
+    const std::array<Box2d, 1> bounds = {selectionBounds};
+    return shell.selectTool_.tryStartRedragOnSelected(shell.app_, documentPoint, MouseModifiers{},
+                                                      bounds);
+  }
+
   static void BufferPendingClick(EditorShell& shell, const Vector2d& documentPoint,
                                  MouseModifiers modifiers = MouseModifiers{}) {
     shell.interactionController_.bufferPendingClick(documentPoint, modifiers);
@@ -3459,6 +3466,48 @@ TEST(EditorShellTest, FillStrokeToolbarKeepsChosenPaintVisibleWhileRendererIsBus
       << "The selected element's fill swatch must not change while its render is in flight";
   EXPECT_FALSE(DrawDataContainsColor(IM_COL32(0xff, 0x00, 0xaa, 0xff)))
       << "A busy frame must not replace the selected fill with the authoring fill";
+
+  renderer.cancelInFlight();
+  EXPECT_TRUE(renderer.waitUntilNoRenderInFlightForTesting(std::chrono::steady_clock::now() +
+                                                           std::chrono::seconds(2)));
+  std::ignore = renderer.pollResult();
+  renderer.setReplayRenderDelayForTesting(std::chrono::milliseconds(0));
+}
+
+TEST(EditorShellTest, FillStrokeToolbarStaysVisuallyStableAcrossDragRenderHandoffs) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(kStyledSvg, "styled.svg"));
+  ASSERT_TRUE(shell.valid());
+  EditorShellTestAccess::ConfigureViewport(shell, Box2d::FromXYWH(0.0, 0.0, 120.0, 80.0));
+  std::optional<svg::SVGElement> target =
+      EditorShellTestAccess::App(shell).document().document().querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  EditorShellTestAccess::App(shell).setSelection(*target);
+  ASSERT_TRUE(EditorShellTestAccess::BeginSelectedShapeDrag(
+      shell, Vector2d(20.0, 20.0), Box2d::FromXYWH(10.0, 12.0, 40.0, 24.0)));
+
+  constexpr ImVec2 kCursor(20.0f, 40.0f);
+  constexpr ImU32 kEnabledSwap = IM_COL32(215, 222, 232, 255);
+  constexpr ImU32 kDisabledSwap = IM_COL32(120, 126, 134, 255);
+  const auto expectStableDragChrome = [&]() {
+    EXPECT_TRUE(DrawDataContainsColor(kDisabledSwap));
+    EXPECT_FALSE(DrawDataContainsColor(kEnabledSwap));
+    EXPECT_TRUE(DrawDataContainsColor(IM_COL32(255, 0, 0, 255))) << "Fill swatch changed";
+    EXPECT_TRUE(DrawDataContainsColor(IM_COL32(0, 0, 255, 255))) << "Stroke swatch changed";
+  };
+
+  RenderToolbarFrame(window, shell, kCursor, ImVec2(-100.0f, -100.0f), /*mouseDown=*/false);
+  expectStableDragChrome();
+
+  AsyncRenderer& renderer =
+      EditorShellTestAccess::BeginDelayedRender(shell, std::chrono::milliseconds(500));
+  ASSERT_TRUE(renderer.isBusy());
+  RenderToolbarFrame(window, shell, kCursor, ImVec2(-100.0f, -100.0f), /*mouseDown=*/false);
+  expectStableDragChrome();
 
   renderer.cancelInFlight();
   EXPECT_TRUE(renderer.waitUntilNoRenderInFlightForTesting(std::chrono::steady_clock::now() +


### PR DESCRIPTION
Fill and stroke controls now stay visually stable throughout canvas drags.

- Freeze the last valid paint presentation while the renderer owns document access.
- Bind cached paint to the current document and first selected element before replaying it.
- Refresh the snapshot on idle frames without coupling toolbar chrome to busy-bit transitions.
- Cover selection changes during a drag so paint from the previous element cannot leak forward.

## Verification

- `bazel test //donner/editor/tests:editor_shell_tests --test_output=errors`
- Cumulative UX stack: `bazel test //donner/editor/tests:editor_shell_tests //donner/editor/tests:menu_bar_presenter_tests //donner/editor/tests:sample_picker_presenter_tests //donner/editor/tests:text_format_bar_presenter_tests //donner/svg/resources:font_catalog_tests //donner/svg/resources:font_manager_tests //donner/svg/tests:svg_tests //tools/mcp-servers/editor-control:editor_control_session_tests --test_output=errors`
- Cumulative UX stack: `bazel build --config=editor-wasm //donner/editor/wasm:wasm_web_package`
- Cumulative UX stack on PR #1000: `bazel test //... --test_output=errors`
