### PR TITLE
Compose native GL document tiles through one texture

### DIFF
--- a/docs/design_docs/0044-2-editor_fluid_canvas_rendering.md
+++ b/docs/design_docs/0044-2-editor_fluid_canvas_rendering.md
@@ -425,11 +425,15 @@ Selection chrome is UI, not document content. It should not use a full-document 
 Cached document tiles have one backend-specific presentation boundary. Geode/WGPU builds sample
 them directly into the window framebuffer. The non-WGPU GL path samples the same tile textures,
 with their full affine placement and paint order, into one pane-sized explicit intermediate and
-presents that texture with one axis-aligned ImGui image. It must cache an unchanged composition,
-retain no CPU copy of tile pixels, and account for both intermediate RGBA8 textures in presentation
-resource diagnostics. Per-tile `AddImageQuad` commands are not a supported document-composition
-path on GL. The WGPU presenter retains a compatibility-only per-tile fallback for a frame whose
+presents that texture with one axis-aligned ImGui image. The intermediate reuses unchanged
+compositions, retains no CPU copy of tile pixels, and reports both RGBA8 textures in presentation
+resource diagnostics. `//donner/editor/tests:render_pane_presenter_visual_repro_tests` pins affine
+placement and cache reuse, while `//donner/editor/tests:gl_texture_cache_tests` pins resource
+accounting. The WGPU presenter retains a compatibility-only per-tile fallback for a frame whose
 payload cannot enter the direct Geode underlay.
+`//donner/editor/tests:render_pane_presenter_visual_repro_tests` under `--config=geode` covers that
+fallback, while `//donner/editor/tests:gl_rnr_replay_tests` covers direct Geode and native GL
+presentation.
 
 Replace the current full-canvas overlay texture with:
 

--- a/docs/design_docs/0044-2-editor_fluid_canvas_rendering.md
+++ b/docs/design_docs/0044-2-editor_fluid_canvas_rendering.md
@@ -1,7 +1,7 @@
 # Design: Editor Fluid Canvas Rendering
 
 **Status:** Implementation in progress
-**Author:** Codex
+**Author:** Unknown (model-authored; exact identifier not recorded)
 **Created:** 2026-05-27
 
 ## Summary
@@ -422,6 +422,15 @@ thing now and cull it" instead of "allocate a texture and upload it forever."
 
 Selection chrome is UI, not document content. It should not use a full-document raster target.
 
+Cached document tiles have one backend-specific presentation boundary. Geode/WGPU builds sample
+them directly into the window framebuffer. The non-WGPU GL path samples the same tile textures,
+with their full affine placement and paint order, into one pane-sized explicit intermediate and
+presents that texture with one axis-aligned ImGui image. It must cache an unchanged composition,
+retain no CPU copy of tile pixels, and account for both intermediate RGBA8 textures in presentation
+resource diagnostics. Per-tile `AddImageQuad` commands are not a supported document-composition
+path on GL. The WGPU presenter retains a compatibility-only per-tile fallback for a frame whose
+payload cannot enter the direct Geode underlay.
+
 Replace the current full-canvas overlay texture with:
 
 - immediate Geode drawing for handles, AABBs, marquee, and path outlines directly into the
@@ -432,8 +441,7 @@ Replace the current full-canvas overlay texture with:
 - culling against the visible document rect before path transformation/draw.
 
 In Geode editor builds, the immediate chrome path must use Donner renderer calls, not ImGui path
-commands. The render-pane presenter still uses ImGui to present cached canvas tiles, then
-`EditorWindow` invokes a post-ImGui direct-render callback before surface presentation/readback.
+commands. `EditorWindow` invokes a direct-render callback before surface presentation/readback.
 That callback points `RendererGeode` at the current swapchain texture, preserves existing
 framebuffer contents, pushes a framebuffer-space clip rect for the artboard, and calls
 `OverlayRenderer::drawChromeFromSnapshot`.
@@ -467,6 +475,10 @@ The retained snapshot above does not weaken that rule, because the rule is about
 chrome is re-pointed at the presented transform at draw time, so it never puts a newer transform
 over older pixels. Only geometry, which no reprojection can reconcile, is allowed to lead, and only
 by the single render it takes the gate to release.
+
+During an active move, resize, or rotate gesture, the immediate chrome uses gesture-owned oriented
+bounds and handles only. It does not traverse selected geometry or text layout on each pointer
+frame. Detailed path outlines and text baselines return after the interaction settles.
 
 Large selections use LOD:
 

--- a/donner/editor/AsyncRenderer.h
+++ b/donner/editor/AsyncRenderer.h
@@ -275,9 +275,10 @@ struct RenderResult {
   };
 
   /// One composite tile from the worker's `CompositorController::
-  /// snapshotCompositorTiles()` snapshot. The editor uploads one GL texture
-  /// per tile (keyed on `id`) and
-  /// blits each tile at its canvas offset. Immediate tiles intentionally use
+  /// snapshotCompositorTiles()` snapshot. The editor uploads one GL texture per tile (keyed on
+  /// `id`). The GL presenter composes those cached textures into one pane-sized presentation
+  /// texture; the WebGPU presenter composites them directly into the framebuffer. Immediate tiles
+  /// intentionally use
   /// transient ids and always carry a fresh payload. Geometry fields are
   /// doc-unit quantities so the editor can scale them by the current
   /// `pixelsPerDocUnit` during canvas-resize debouncing.
@@ -332,10 +333,9 @@ struct RenderResult {
   };
 
   struct CompositedPreview {
-    /// Paint-order tile list. Blit in `tiles` order: each tile gets
-    /// one `AddImage` call at `(canvasOffsetDoc + dragTranslationDoc)
-    /// * pixelsPerDocUnit` with size `bitmapDimsDoc *
-    /// pixelsPerDocUnit`.
+    /// Paint-order tile list. Presentation samples the tiles in this order at
+    /// `(canvasOffsetDoc + dragTranslationDoc) * pixelsPerDocUnit`, with size
+    /// `bitmapDimsDoc * pixelsPerDocUnit`.
     std::vector<CompositedTile> tiles;
     /// Active drag-target entity (for selection chrome routing). May
     /// be `entt::null` if no entity is currently being dragged.
@@ -687,8 +687,8 @@ public:
     return lastSegmentInspectorRows_;
   }
 
-  /// Unified in-paint-order snapshot of every tile the compositor
-  /// blits to produce the final composite.
+  /// Unified in-paint-order snapshot of every tile the compositor samples to produce the final
+  /// composite.
   /// The editor's layer-inspector panel renders this list with
   /// thumbnails for every tile so the operator can see the
   /// comprehensive composite at a glance.

--- a/donner/editor/BUILD.bazel
+++ b/donner/editor/BUILD.bazel
@@ -852,10 +852,20 @@ donner_cc_library(
 )
 
 donner_cc_library(
+    name = "document_composite_texture",
+    hdrs = ["DocumentCompositeTexture.h"],
+    deps = [
+        ":imgui_headers",
+        "//donner/base",
+    ],
+)
+
+donner_cc_library(
     name = "render_pane_presenter",
     srcs = ["RenderPanePresenter.cc"],
     hdrs = ["RenderPanePresenter.h"],
     deps = [
+        ":document_composite_texture",
         ":gl_texture_cache",
         ":imgui_headers",
         ":menu_bar_presenter",
@@ -890,6 +900,65 @@ donner_cc_library(
         ":whole_app_worker_config",
         "//donner/base",
     ],
+)
+
+donner_cc_library(
+    name = "editor_shell_presentation",
+    srcs = ["EditorShellPresentation.cc"],
+    hdrs = ["EditorShellPresentation.h"],
+    defines = select({
+        ":wasm_geode_enabled": ["DONNER_EDITOR_WGPU"],
+        "//donner/svg/renderer:renderer_backend_geode": ["DONNER_EDITOR_WGPU"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        ":frame_cost_breakdown",
+        ":gl_texture_cache",
+        ":overlay_renderer",
+        ":presented_frame_composer",
+        ":render_pane_presenter",
+        ":select_tool",
+        ":tracy_wrapper",
+        ":viewport_state",
+        "//donner/base",
+        "//donner/editor/gui:editor_window",
+        "//donner/svg/renderer:renderer_interface",
+    ] + select({
+        ":wasm_geode_enabled": [
+            "//donner/svg/renderer:renderer_geode",
+        ],
+        "//donner/svg/renderer:renderer_backend_geode": [
+            "//donner/svg/renderer:renderer_geode",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+donner_cc_library(
+    name = "document_presentation_compositor",
+    srcs = ["DocumentPresentationCompositor.cc"],
+    hdrs = ["DocumentPresentationCompositor.h"],
+    defines = select({
+        ":wasm_geode_enabled": ["DONNER_EDITOR_WGPU"],
+        "//donner/svg/renderer:renderer_backend_geode": ["DONNER_EDITOR_WGPU"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        ":document_composite_texture",
+        ":editor_shell_presentation",
+        ":gl_texture_cache",
+        ":presented_frame_composer",
+        ":render_pane_presenter",
+        ":select_tool",
+        ":viewport_state",
+        "//donner/base",
+    ] + select({
+        ":wasm_geode_enabled": [],
+        "//donner/svg/renderer:renderer_backend_geode": [],
+        "//conditions:default": [
+            "//third_party/glad",
+        ],
+    }),
 )
 
 donner_cc_library(
@@ -947,8 +1016,6 @@ donner_cc_library(
     name = "editor_shell",
     srcs = [
         "EditorShell.cc",
-        "EditorShellPresentation.cc",
-        "EditorShellPresentation.h",
         "FillStrokeWidget.cc",
     ],
     hdrs = [
@@ -968,6 +1035,7 @@ donner_cc_library(
         ":compositor_debug_panel",
         ":dialog_presenter",
         ":disclosure_chevron",
+        ":document_presentation_compositor",
         ":document_presenter",
         ":document_save",
         ":document_sync_controller",
@@ -977,6 +1045,7 @@ donner_cc_library(
         ":editor_input_bridge",
         ":editor_sample_catalog",
         ":editor_shell_layout",
+        ":editor_shell_presentation",
         ":editor_symbol_glyphs",
         ":editor_theme",
         ":embedded_svg_icon",

--- a/donner/editor/DocumentCompositeTexture.h
+++ b/donner/editor/DocumentCompositeTexture.h
@@ -1,0 +1,17 @@
+#pragma once
+/// @file
+
+#include "donner/base/Box.h"
+#include "donner/base/Vector2.h"
+#include "donner/editor/ImGuiIncludes.h"
+
+namespace donner::editor {
+
+/// One axis-aligned document composite suitable for a single ImGui image draw.
+struct DocumentCompositeTextureView {
+  ImTextureID texture = 0;
+  Vector2i dimensions = Vector2i::Zero();
+  Box2d screenRect;
+};
+
+}  // namespace donner::editor

--- a/donner/editor/DocumentPresentationCompositor.cc
+++ b/donner/editor/DocumentPresentationCompositor.cc
@@ -348,11 +348,7 @@ struct DocumentPresentationCompositor::Impl {
     if (tileProgram != 0 && resolveProgram != 0 && vertexArray != 0 && vertexBuffer != 0) {
       return true;
     }
-#ifdef __EMSCRIPTEN__
-    constexpr const char* kVersion = "#version 300 es\nprecision highp float;\n";
-#else
     constexpr const char* kVersion = "#version 330 core\n";
-#endif
     const std::string vertexSource = std::string(kVersion) +
                                      R"glsl(layout(location = 0) in vec2 positionPx;
 layout(location = 1) in vec2 textureUv;

--- a/donner/editor/DocumentPresentationCompositor.cc
+++ b/donner/editor/DocumentPresentationCompositor.cc
@@ -1,0 +1,660 @@
+#include "donner/editor/DocumentPresentationCompositor.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <iterator>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "donner/editor/EditorShellPresentation.h"
+#include "donner/editor/PresentedFrameComposer.h"
+#include "donner/editor/RenderPanePresenter.h"
+
+namespace donner::editor {
+
+#ifndef DONNER_EDITOR_WGPU
+namespace {
+
+struct TileKey {
+  ImTextureID texture = 0;
+  std::string id;
+  Entity layerEntity = entt::null;
+  std::uint64_t generation = 0;
+  Vector2i bitmapDimsPx = Vector2i::Zero();
+  Vector2d canvasOffsetDoc = Vector2d::Zero();
+  Vector2d bitmapDimsDoc = Vector2d::Zero();
+  Vector2d dragTranslationDoc = Vector2d::Zero();
+  Vector2d uvBottomRight = Vector2d(1.0, 1.0);
+  Transform2d documentFromCachedDocument = Transform2d();
+  bool metadataOnly = false;
+  bool isDragTarget = false;
+};
+
+TileKey MakeTileKey(const GlTextureCache::TileView& tile) {
+  return TileKey{
+      .texture = tile.texture,
+      .id = tile.id,
+      .layerEntity = tile.layerEntity,
+      .generation = tile.generation,
+      .bitmapDimsPx = tile.bitmapDimsPx,
+      .canvasOffsetDoc = tile.canvasOffsetDoc,
+      .bitmapDimsDoc = tile.bitmapDimsDoc,
+      .dragTranslationDoc = tile.dragTranslationDoc,
+      .uvBottomRight = tile.uvBottomRight,
+      .documentFromCachedDocument = tile.documentFromCachedDocument,
+      .metadataOnly = tile.metadataOnly,
+      .isDragTarget = tile.isDragTarget,
+  };
+}
+
+bool EqualTransform(const Transform2d& lhs, const Transform2d& rhs) {
+  return std::equal(std::begin(lhs.data), std::end(lhs.data), std::begin(rhs.data));
+}
+
+bool EqualTileKey(const TileKey& lhs, const TileKey& rhs) {
+  return lhs.texture == rhs.texture && lhs.id == rhs.id && lhs.layerEntity == rhs.layerEntity &&
+         lhs.generation == rhs.generation && lhs.bitmapDimsPx == rhs.bitmapDimsPx &&
+         lhs.canvasOffsetDoc == rhs.canvasOffsetDoc && lhs.bitmapDimsDoc == rhs.bitmapDimsDoc &&
+         lhs.dragTranslationDoc == rhs.dragTranslationDoc &&
+         lhs.uvBottomRight == rhs.uvBottomRight &&
+         EqualTransform(lhs.documentFromCachedDocument, rhs.documentFromCachedDocument) &&
+         lhs.metadataOnly == rhs.metadataOnly && lhs.isDragTarget == rhs.isDragTarget;
+}
+
+struct DragKey {
+  Entity entity = entt::null;
+  std::vector<Entity> extraEntities;
+  Vector2d translation = Vector2d::Zero();
+  Transform2d documentFromCachedDocument = Transform2d();
+  std::uint64_t dragGeneration = 0;
+};
+
+std::optional<DragKey> MakeDragKey(const std::optional<SelectTool::ActiveDragPreview>& preview) {
+  if (!preview.has_value()) {
+    return std::nullopt;
+  }
+  return DragKey{
+      .entity = preview->entity,
+      .extraEntities = preview->extraEntities,
+      .translation = preview->translation,
+      .documentFromCachedDocument = preview->documentFromCachedDocument,
+      .dragGeneration = preview->dragGeneration,
+  };
+}
+
+bool EqualDragKey(const std::optional<DragKey>& lhs, const std::optional<DragKey>& rhs) {
+  if (lhs.has_value() != rhs.has_value()) {
+    return false;
+  }
+  if (!lhs.has_value()) {
+    return true;
+  }
+  return lhs->entity == rhs->entity && lhs->extraEntities == rhs->extraEntities &&
+         lhs->translation == rhs->translation &&
+         EqualTransform(lhs->documentFromCachedDocument, rhs->documentFromCachedDocument) &&
+         lhs->dragGeneration == rhs->dragGeneration;
+}
+
+struct RequestKey {
+  ViewportState viewport;
+  Box2d imageClipRect;
+  std::vector<TileKey> overviewTiles;
+  std::vector<TileKey> tiles;
+  std::optional<DragKey> activeDrag;
+  std::optional<DragKey> displayedDrag;
+  Entity suppressedLayerEntity = entt::null;
+  bool suppressDragTargetTiles = false;
+};
+
+bool EqualViewport(const ViewportState& lhs, const ViewportState& rhs) {
+  return lhs.paneOrigin == rhs.paneOrigin && lhs.paneSize == rhs.paneSize &&
+         lhs.documentViewBox == rhs.documentViewBox &&
+         lhs.devicePixelRatio == rhs.devicePixelRatio && lhs.zoom == rhs.zoom &&
+         lhs.panDocPoint == rhs.panDocPoint && lhs.panScreenPoint == rhs.panScreenPoint;
+}
+
+bool EqualTileKeys(const std::vector<TileKey>& lhs, const std::vector<TileKey>& rhs) {
+  return lhs.size() == rhs.size() &&
+         std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end(), EqualTileKey);
+}
+
+bool EqualRequest(const RequestKey& lhs, const RequestKey& rhs) {
+  return EqualViewport(lhs.viewport, rhs.viewport) && lhs.imageClipRect == rhs.imageClipRect &&
+         EqualTileKeys(lhs.overviewTiles, rhs.overviewTiles) &&
+         EqualTileKeys(lhs.tiles, rhs.tiles) && EqualDragKey(lhs.activeDrag, rhs.activeDrag) &&
+         EqualDragKey(lhs.displayedDrag, rhs.displayedDrag) &&
+         lhs.suppressedLayerEntity == rhs.suppressedLayerEntity &&
+         lhs.suppressDragTargetTiles == rhs.suppressDragTargetTiles;
+}
+
+RequestKey MakeRequestKey(const ViewportState& viewport, const Box2d& imageClipRect,
+                          std::span<const GlTextureCache::TileView> overviewTiles,
+                          std::span<const GlTextureCache::TileView> tiles,
+                          const std::optional<SelectTool::ActiveDragPreview>& activeDragPreview,
+                          const std::optional<SelectTool::ActiveDragPreview>& displayedDragPreview,
+                          Entity suppressedLayerEntity, bool suppressDragTargetTiles) {
+  RequestKey key{
+      .viewport = viewport,
+      .imageClipRect = imageClipRect,
+      .activeDrag = MakeDragKey(activeDragPreview),
+      .displayedDrag = MakeDragKey(displayedDragPreview),
+      .suppressedLayerEntity = suppressedLayerEntity,
+      .suppressDragTargetTiles = suppressDragTargetTiles,
+  };
+  key.overviewTiles.reserve(overviewTiles.size());
+  for (const GlTextureCache::TileView& tile : overviewTiles) {
+    key.overviewTiles.push_back(MakeTileKey(tile));
+  }
+  key.tiles.reserve(tiles.size());
+  for (const GlTextureCache::TileView& tile : tiles) {
+    key.tiles.push_back(MakeTileKey(tile));
+  }
+  return key;
+}
+
+GLuint CompileShader(GLenum type, const char* source) {
+  const GLuint shader = glCreateShader(type);
+  if (shader == 0) {
+    return 0;
+  }
+  glShaderSource(shader, 1, &source, nullptr);
+  glCompileShader(shader);
+  GLint compiled = GL_FALSE;
+  glGetShaderiv(shader, GL_COMPILE_STATUS, &compiled);
+  if (compiled == GL_TRUE) {
+    return shader;
+  }
+  std::array<char, 1024> log{};
+  GLsizei length = 0;
+  glGetShaderInfoLog(shader, static_cast<GLsizei>(log.size()), &length, log.data());
+  std::fprintf(stderr, "DocumentPresentationCompositor shader compile failed: %.*s\n",
+               static_cast<int>(length), log.data());
+  glDeleteShader(shader);
+  return 0;
+}
+
+GLuint LinkProgram(const char* vertexSource, const char* fragmentSource) {
+  const GLuint vertex = CompileShader(GL_VERTEX_SHADER, vertexSource);
+  const GLuint fragment = CompileShader(GL_FRAGMENT_SHADER, fragmentSource);
+  if (vertex == 0 || fragment == 0) {
+    if (vertex != 0) {
+      glDeleteShader(vertex);
+    }
+    if (fragment != 0) {
+      glDeleteShader(fragment);
+    }
+    return 0;
+  }
+  const GLuint program = glCreateProgram();
+  glAttachShader(program, vertex);
+  glAttachShader(program, fragment);
+  glLinkProgram(program);
+  glDeleteShader(vertex);
+  glDeleteShader(fragment);
+  GLint linked = GL_FALSE;
+  glGetProgramiv(program, GL_LINK_STATUS, &linked);
+  if (linked == GL_TRUE) {
+    return program;
+  }
+  std::array<char, 1024> log{};
+  GLsizei length = 0;
+  glGetProgramInfoLog(program, static_cast<GLsizei>(log.size()), &length, log.data());
+  std::fprintf(stderr, "DocumentPresentationCompositor program link failed: %.*s\n",
+               static_cast<int>(length), log.data());
+  glDeleteProgram(program);
+  return 0;
+}
+
+struct SavedGlState {
+  GLint framebuffer = 0;
+  GLint program = 0;
+  GLint activeTexture = 0;
+  GLint texture0 = 0;
+  GLint arrayBuffer = 0;
+  GLint vertexArray = 0;
+  std::array<GLint, 4> viewport{};
+  std::array<GLint, 4> scissorBox{};
+  std::array<GLfloat, 4> clearColor{};
+  GLint blendSrcRgb = 0;
+  GLint blendDstRgb = 0;
+  GLint blendSrcAlpha = 0;
+  GLint blendDstAlpha = 0;
+  GLint blendEquationRgb = 0;
+  GLint blendEquationAlpha = 0;
+  GLboolean blend = GL_FALSE;
+  GLboolean scissor = GL_FALSE;
+  GLboolean depth = GL_FALSE;
+  GLboolean cull = GL_FALSE;
+  GLboolean stencil = GL_FALSE;
+
+  SavedGlState() {
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, &framebuffer);
+    glGetIntegerv(GL_CURRENT_PROGRAM, &program);
+    glGetIntegerv(GL_ACTIVE_TEXTURE, &activeTexture);
+    glActiveTexture(GL_TEXTURE0);
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &texture0);
+    glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &arrayBuffer);
+    glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &vertexArray);
+    glGetIntegerv(GL_VIEWPORT, viewport.data());
+    glGetIntegerv(GL_SCISSOR_BOX, scissorBox.data());
+    glGetFloatv(GL_COLOR_CLEAR_VALUE, clearColor.data());
+    glGetIntegerv(GL_BLEND_SRC_RGB, &blendSrcRgb);
+    glGetIntegerv(GL_BLEND_DST_RGB, &blendDstRgb);
+    glGetIntegerv(GL_BLEND_SRC_ALPHA, &blendSrcAlpha);
+    glGetIntegerv(GL_BLEND_DST_ALPHA, &blendDstAlpha);
+    glGetIntegerv(GL_BLEND_EQUATION_RGB, &blendEquationRgb);
+    glGetIntegerv(GL_BLEND_EQUATION_ALPHA, &blendEquationAlpha);
+    blend = glIsEnabled(GL_BLEND);
+    scissor = glIsEnabled(GL_SCISSOR_TEST);
+    depth = glIsEnabled(GL_DEPTH_TEST);
+    cull = glIsEnabled(GL_CULL_FACE);
+    stencil = glIsEnabled(GL_STENCIL_TEST);
+  }
+
+  ~SavedGlState() {
+    glBindFramebuffer(GL_FRAMEBUFFER, static_cast<GLuint>(framebuffer));
+    glUseProgram(static_cast<GLuint>(program));
+    glBindBuffer(GL_ARRAY_BUFFER, static_cast<GLuint>(arrayBuffer));
+    glBindVertexArray(static_cast<GLuint>(vertexArray));
+    glViewport(viewport[0], viewport[1], viewport[2], viewport[3]);
+    glScissor(scissorBox[0], scissorBox[1], scissorBox[2], scissorBox[3]);
+    glClearColor(clearColor[0], clearColor[1], clearColor[2], clearColor[3]);
+    glBlendFuncSeparate(static_cast<GLenum>(blendSrcRgb), static_cast<GLenum>(blendDstRgb),
+                        static_cast<GLenum>(blendSrcAlpha), static_cast<GLenum>(blendDstAlpha));
+    glBlendEquationSeparate(static_cast<GLenum>(blendEquationRgb),
+                            static_cast<GLenum>(blendEquationAlpha));
+    const auto restoreEnable = [](GLenum capability, GLboolean enabled) {
+      if (enabled == GL_TRUE) {
+        glEnable(capability);
+      } else {
+        glDisable(capability);
+      }
+    };
+    restoreEnable(GL_BLEND, blend);
+    restoreEnable(GL_SCISSOR_TEST, scissor);
+    restoreEnable(GL_DEPTH_TEST, depth);
+    restoreEnable(GL_CULL_FACE, cull);
+    restoreEnable(GL_STENCIL_TEST, stencil);
+    glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(texture0));
+    glActiveTexture(static_cast<GLenum>(activeTexture));
+  }
+};
+
+struct Vertex {
+  float x = 0.0f;
+  float y = 0.0f;
+  float u = 0.0f;
+  float v = 0.0f;
+};
+
+Box2d QuadBounds(const PresentedTileQuad& quad) {
+  Box2d bounds = Box2d::CreateEmpty(quad.topLeft);
+  bounds.addPoint(quad.topRight);
+  bounds.addPoint(quad.bottomRight);
+  bounds.addPoint(quad.bottomLeft);
+  return bounds;
+}
+
+bool IsValidSize(const Vector2i& size) {
+  return size.x > 0 && size.y > 0 && size.x <= ViewportState::kMaxCanvasDim &&
+         size.y <= ViewportState::kMaxCanvasDim;
+}
+
+}  // namespace
+#endif
+
+struct DocumentPresentationCompositor::Impl {
+#ifndef DONNER_EDITOR_WGPU
+  GLuint framebuffer = 0;
+  GLuint premultipliedTexture = 0;
+  GLuint resolvedTexture = 0;
+  GLuint vertexArray = 0;
+  GLuint vertexBuffer = 0;
+  GLuint tileProgram = 0;
+  GLuint resolveProgram = 0;
+  Vector2i allocationSize = Vector2i::Zero();
+  std::optional<RequestKey> lastRequest;
+  DocumentCompositeTextureView view;
+  std::uint64_t compositionCount = 0;
+
+  ~Impl() {
+    if (tileProgram != 0) {
+      glDeleteProgram(tileProgram);
+    }
+    if (resolveProgram != 0) {
+      glDeleteProgram(resolveProgram);
+    }
+    if (vertexBuffer != 0) {
+      glDeleteBuffers(1, &vertexBuffer);
+    }
+    if (vertexArray != 0) {
+      glDeleteVertexArrays(1, &vertexArray);
+    }
+    if (premultipliedTexture != 0) {
+      glDeleteTextures(1, &premultipliedTexture);
+    }
+    if (resolvedTexture != 0) {
+      glDeleteTextures(1, &resolvedTexture);
+    }
+    if (framebuffer != 0) {
+      glDeleteFramebuffers(1, &framebuffer);
+    }
+  }
+
+  bool ensurePrograms() {
+    if (tileProgram != 0 && resolveProgram != 0 && vertexArray != 0 && vertexBuffer != 0) {
+      return true;
+    }
+#ifdef __EMSCRIPTEN__
+    constexpr const char* kVersion = "#version 300 es\nprecision highp float;\n";
+#else
+    constexpr const char* kVersion = "#version 330 core\n";
+#endif
+    const std::string vertexSource = std::string(kVersion) +
+                                     R"glsl(layout(location = 0) in vec2 positionPx;
+layout(location = 1) in vec2 textureUv;
+uniform vec2 outputSizePx;
+out vec2 uv;
+void main() {
+  vec2 ndc = positionPx / outputSizePx * 2.0 - 1.0;
+  gl_Position = vec4(ndc, 0.0, 1.0);
+  uv = textureUv;
+}
+)glsl";
+    const std::string tileFragmentSource = std::string(kVersion) +
+                                           R"glsl(in vec2 uv;
+uniform sampler2D sourceTexture;
+out vec4 outputColor;
+void main() {
+  vec4 color = texture(sourceTexture, uv);
+  outputColor = vec4(color.rgb * color.a, color.a);
+}
+)glsl";
+    const std::string resolveFragmentSource = std::string(kVersion) +
+                                              R"glsl(in vec2 uv;
+uniform sampler2D sourceTexture;
+out vec4 outputColor;
+void main() {
+  vec4 color = texture(sourceTexture, uv);
+  outputColor = color.a > 0.0 ? vec4(color.rgb / color.a, color.a) : vec4(0.0);
+}
+)glsl";
+    tileProgram = LinkProgram(vertexSource.c_str(), tileFragmentSource.c_str());
+    resolveProgram = LinkProgram(vertexSource.c_str(), resolveFragmentSource.c_str());
+    if (tileProgram == 0 || resolveProgram == 0) {
+      return false;
+    }
+    glGenVertexArrays(1, &vertexArray);
+    glGenBuffers(1, &vertexBuffer);
+    if (vertexArray == 0 || vertexBuffer == 0) {
+      return false;
+    }
+    glBindVertexArray(vertexArray);
+    glBindBuffer(GL_ARRAY_BUFFER, vertexBuffer);
+    glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(sizeof(Vertex) * 6u), nullptr,
+                 GL_STREAM_DRAW);
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex),
+                          reinterpret_cast<void*>(offsetof(Vertex, x)));
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex),
+                          reinterpret_cast<void*>(offsetof(Vertex, u)));
+    return true;
+  }
+
+  bool ensureTextures(const Vector2i& size) {
+    if (!IsValidSize(size)) {
+      return false;
+    }
+    if (framebuffer == 0) {
+      glGenFramebuffers(1, &framebuffer);
+    }
+    if (premultipliedTexture == 0) {
+      glGenTextures(1, &premultipliedTexture);
+    }
+    if (resolvedTexture == 0) {
+      glGenTextures(1, &resolvedTexture);
+    }
+    if (framebuffer == 0 || premultipliedTexture == 0 || resolvedTexture == 0) {
+      return false;
+    }
+    if (allocationSize == size) {
+      return true;
+    }
+    const auto allocate = [&](GLuint texture) {
+      glBindTexture(GL_TEXTURE_2D, texture);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, size.x, size.y, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                   nullptr);
+    };
+    allocate(premultipliedTexture);
+    allocate(resolvedTexture);
+    allocationSize = size;
+    lastRequest.reset();
+    return true;
+  }
+
+  bool attach(GLuint texture) const {
+    glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture, 0);
+    return glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE;
+  }
+
+  void setClip(const Box2d& clip, const Vector2i& size) const {
+    const int left = std::clamp(static_cast<int>(std::floor(clip.topLeft.x)), 0, size.x);
+    const int top = std::clamp(static_cast<int>(std::floor(clip.topLeft.y)), 0, size.y);
+    const int right = std::clamp(static_cast<int>(std::ceil(clip.bottomRight.x)), 0, size.x);
+    const int bottom = std::clamp(static_cast<int>(std::ceil(clip.bottomRight.y)), 0, size.y);
+    glScissor(left, top, std::max(0, right - left), std::max(0, bottom - top));
+  }
+
+  void drawQuad(GLuint texture, const PresentedTileQuad& quad, const Vector2d& uvBottomRight,
+                GLuint program, const Vector2i& outputSize) const {
+    const float u = static_cast<float>(uvBottomRight.x);
+    const float v = static_cast<float>(uvBottomRight.y);
+    const std::array<Vertex, 6> vertices = {
+        Vertex{static_cast<float>(quad.topLeft.x), static_cast<float>(quad.topLeft.y), 0.0f, 0.0f},
+        Vertex{static_cast<float>(quad.topRight.x), static_cast<float>(quad.topRight.y), u, 0.0f},
+        Vertex{static_cast<float>(quad.bottomRight.x), static_cast<float>(quad.bottomRight.y), u,
+               v},
+        Vertex{static_cast<float>(quad.topLeft.x), static_cast<float>(quad.topLeft.y), 0.0f, 0.0f},
+        Vertex{static_cast<float>(quad.bottomRight.x), static_cast<float>(quad.bottomRight.y), u,
+               v},
+        Vertex{static_cast<float>(quad.bottomLeft.x), static_cast<float>(quad.bottomLeft.y), 0.0f,
+               v},
+    };
+    glUseProgram(program);
+    glUniform2f(glGetUniformLocation(program, "outputSizePx"), static_cast<float>(outputSize.x),
+                static_cast<float>(outputSize.y));
+    glUniform1i(glGetUniformLocation(program, "sourceTexture"), 0);
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, texture);
+    glBindVertexArray(vertexArray);
+    glBindBuffer(GL_ARRAY_BUFFER, vertexBuffer);
+    glBufferSubData(GL_ARRAY_BUFFER, 0, static_cast<GLsizeiptr>(sizeof(vertices)), vertices.data());
+    glDrawArrays(GL_TRIANGLES, 0, 6);
+  }
+#endif
+};
+
+DocumentPresentationCompositor::DocumentPresentationCompositor()
+    : impl_(std::make_unique<Impl>()) {}
+
+DocumentPresentationCompositor::~DocumentPresentationCompositor() = default;
+
+DocumentCompositeTextureView DocumentPresentationCompositor::compose(
+    const ViewportState& viewport, const Box2d& imageClipRect,
+    std::span<const GlTextureCache::TileView> overviewTiles,
+    std::span<const GlTextureCache::TileView> tiles,
+    const std::optional<SelectTool::ActiveDragPreview>& activeDragPreview,
+    const std::optional<SelectTool::ActiveDragPreview>& displayedDragPreview,
+    Entity suppressedLayerEntity, bool suppressDragTargetTiles) {
+#ifdef DONNER_EDITOR_WGPU
+  (void)viewport;
+  (void)imageClipRect;
+  (void)overviewTiles;
+  (void)tiles;
+  (void)activeDragPreview;
+  (void)displayedDragPreview;
+  (void)suppressedLayerEntity;
+  (void)suppressDragTargetTiles;
+  return {};
+#else
+  const double dpr = viewport.devicePixelRatio;
+  if (!std::isfinite(dpr) || dpr <= 0.0) {
+    reset();
+    return {};
+  }
+  const Vector2i outputSize(std::max(1, static_cast<int>(std::ceil(viewport.paneSize.x * dpr))),
+                            std::max(1, static_cast<int>(std::ceil(viewport.paneSize.y * dpr))));
+  RequestKey request =
+      MakeRequestKey(viewport, imageClipRect, overviewTiles, tiles, activeDragPreview,
+                     displayedDragPreview, suppressedLayerEntity, suppressDragTargetTiles);
+  if (impl_->lastRequest.has_value() && EqualRequest(*impl_->lastRequest, request) &&
+      impl_->view.texture != 0) {
+    return impl_->view;
+  }
+
+  SavedGlState savedState;
+  if (!impl_->ensurePrograms() || !impl_->ensureTextures(outputSize) ||
+      !impl_->attach(impl_->premultipliedTexture)) {
+    std::fprintf(stderr, "DocumentPresentationCompositor failed to initialize GL resources\n");
+    reset();
+    return {};
+  }
+
+  glViewport(0, 0, outputSize.x, outputSize.y);
+  glDisable(GL_DEPTH_TEST);
+  glDisable(GL_CULL_FACE);
+  glDisable(GL_STENCIL_TEST);
+  glDisable(GL_SCISSOR_TEST);
+  glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+  glClear(GL_COLOR_BUFFER_BIT);
+  glEnable(GL_BLEND);
+  glBlendEquationSeparate(GL_FUNC_ADD, GL_FUNC_ADD);
+  glBlendFuncSeparate(GL_ONE, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+
+  const Vector2d paneOriginPx = viewport.paneOrigin * dpr;
+  Transform2d outputFromCanvas(Transform2d::uninitialized);
+  const double devicePixelsPerDocUnit = viewport.devicePixelsPerDocUnit();
+  outputFromCanvas.data[0] = devicePixelsPerDocUnit;
+  outputFromCanvas.data[1] = 0.0;
+  outputFromCanvas.data[2] = 0.0;
+  outputFromCanvas.data[3] = devicePixelsPerDocUnit;
+  outputFromCanvas.data[4] = viewport.panScreenPoint.x * dpr -
+                             viewport.panDocPoint.x * devicePixelsPerDocUnit - paneOriginPx.x;
+  outputFromCanvas.data[5] = viewport.panScreenPoint.y * dpr -
+                             viewport.panDocPoint.y * devicePixelsPerDocUnit - paneOriginPx.y;
+  const Box2d outputClipRect(imageClipRect.topLeft * dpr - paneOriginPx,
+                             imageClipRect.bottomRight * dpr - paneOriginPx);
+  const std::optional<PresentedDragBaseline> dragBaseline =
+      PresentedBaselineFromDragPreviews(activeDragPreview, displayedDragPreview);
+
+  const auto computeTileQuad = [&](const GlTextureCache::TileView& tile) {
+    if (!ShouldPresentCompositedTile(tile, suppressedLayerEntity, suppressDragTargetTiles) ||
+        (suppressDragTargetTiles && TileMatchesActiveDragPreview(tile, activeDragPreview))) {
+      return std::optional<PresentedTileQuad>();
+    }
+    return ComputePresentedTileQuad(PresentedGeometryFromTileView(tile, activeDragPreview),
+                                    outputFromCanvas, dragBaseline);
+  };
+  const auto drawTile = [&](const GlTextureCache::TileView& tile) {
+    const std::optional<PresentedTileQuad> quad = computeTileQuad(tile);
+    if (!quad.has_value()) {
+      return;
+    }
+    impl_->drawQuad(static_cast<GLuint>(tile.texture), *quad, tile.uvBottomRight,
+                    impl_->tileProgram, outputSize);
+  };
+
+  glEnable(GL_SCISSOR_TEST);
+  if (!overviewTiles.empty()) {
+    std::vector<Box2d> activeTileBounds;
+    activeTileBounds.reserve(tiles.size() * 2u);
+    for (const GlTextureCache::TileView& tile : tiles) {
+      if (const std::optional<PresentedTileQuad> quad = computeTileQuad(tile)) {
+        activeTileBounds.push_back(QuadBounds(*quad));
+      }
+      if (TileMatchesActiveDragPreview(tile, activeDragPreview)) {
+        const std::optional<PresentedTileQuad> cachedQuad = ComputePresentedTileQuad(
+            PresentedGeometryFromTileView(tile, std::nullopt), outputFromCanvas, std::nullopt);
+        if (cachedQuad.has_value()) {
+          activeTileBounds.push_back(QuadBounds(*cachedQuad));
+        }
+      }
+    }
+    for (const Box2d& overviewClipRect :
+         SubtractPresentedTileBoundsFromClip(outputClipRect, activeTileBounds)) {
+      impl_->setClip(overviewClipRect, outputSize);
+      for (const GlTextureCache::TileView& tile : overviewTiles) {
+        drawTile(tile);
+      }
+    }
+  }
+  impl_->setClip(outputClipRect, outputSize);
+  for (const GlTextureCache::TileView& tile : tiles) {
+    drawTile(tile);
+  }
+
+  if (!impl_->attach(impl_->resolvedTexture)) {
+    std::fprintf(stderr, "DocumentPresentationCompositor resolve framebuffer is incomplete\n");
+    reset();
+    return {};
+  }
+  glDisable(GL_SCISSOR_TEST);
+  glDisable(GL_BLEND);
+  glClear(GL_COLOR_BUFFER_BIT);
+  const PresentedTileQuad fullQuad{
+      .topLeft = Vector2d::Zero(),
+      .topRight = Vector2d(outputSize.x, 0.0),
+      .bottomRight = Vector2d(outputSize.x, outputSize.y),
+      .bottomLeft = Vector2d(0.0, outputSize.y),
+  };
+  impl_->drawQuad(impl_->premultipliedTexture, fullQuad, Vector2d(1.0, 1.0), impl_->resolveProgram,
+                  outputSize);
+
+  impl_->lastRequest = std::move(request);
+  ++impl_->compositionCount;
+  impl_->view = DocumentCompositeTextureView{
+      .texture = static_cast<ImTextureID>(impl_->resolvedTexture),
+      .dimensions = outputSize,
+      .screenRect = Box2d(viewport.paneOrigin, viewport.paneOrigin + viewport.paneSize),
+  };
+  return impl_->view;
+#endif
+}
+
+void DocumentPresentationCompositor::reset() {
+#ifndef DONNER_EDITOR_WGPU
+  impl_->lastRequest.reset();
+  impl_->view = {};
+#endif
+}
+
+std::uint64_t DocumentPresentationCompositor::retainedBytes() const {
+#ifdef DONNER_EDITOR_WGPU
+  return 0;
+#else
+  if (impl_->allocationSize.x <= 0 || impl_->allocationSize.y <= 0) {
+    return 0;
+  }
+  return static_cast<std::uint64_t>(impl_->allocationSize.x) *
+         static_cast<std::uint64_t>(impl_->allocationSize.y) * 4u * 2u;
+#endif
+}
+
+std::uint64_t DocumentPresentationCompositor::compositionCountForTesting() const {
+#ifdef DONNER_EDITOR_WGPU
+  return 0;
+#else
+  return impl_->compositionCount;
+#endif
+}
+
+}  // namespace donner::editor

--- a/donner/editor/DocumentPresentationCompositor.h
+++ b/donner/editor/DocumentPresentationCompositor.h
@@ -31,6 +31,19 @@ public:
   DocumentPresentationCompositor(const DocumentPresentationCompositor&) = delete;
   DocumentPresentationCompositor& operator=(const DocumentPresentationCompositor&) = delete;
 
+  /**
+   * Compose the current document presentation into one pane-sized texture.
+   *
+   * @param viewport Presented document-to-screen mapping.
+   * @param imageClipRect Visible document region clipped to the render pane.
+   * @param overviewTiles Low-resolution infill tiles drawn below active coverage.
+   * @param tiles Active paint-order tile views.
+   * @param activeDragPreview Live drag transform to advance eligible tiles.
+   * @param displayedDragPreview Drag transform already represented by cached tiles.
+   * @param suppressedLayerEntity Layer omitted from this presentation frame.
+   * @param suppressDragTargetTiles Whether active drag-target tiles are omitted.
+   * @return Cached or newly composed texture view, or an empty view when composition is invalid.
+   */
   [[nodiscard]] DocumentCompositeTextureView compose(
       const ViewportState& viewport, const Box2d& imageClipRect,
       std::span<const GlTextureCache::TileView> overviewTiles,
@@ -39,7 +52,7 @@ public:
       const std::optional<SelectTool::ActiveDragPreview>& displayedDragPreview,
       Entity suppressedLayerEntity, bool suppressDragTargetTiles);
 
-  /// Release cached output and invalidate the request cache.
+  /// Invalidate the cached request and clear its presented view while retaining allocations.
   void reset();
 
   /// Bytes retained by the two RGBA8 intermediate textures.

--- a/donner/editor/DocumentPresentationCompositor.h
+++ b/donner/editor/DocumentPresentationCompositor.h
@@ -1,0 +1,56 @@
+#pragma once
+/// @file
+/// Explicit intermediate-texture composition for non-WGPU document tiles.
+
+#include <memory>
+#include <optional>
+#include <span>
+
+#include "donner/base/Box.h"
+#include "donner/base/EcsRegistry.h"
+#include "donner/base/Vector2.h"
+#include "donner/editor/DocumentCompositeTexture.h"
+#include "donner/editor/GlTextureCache.h"
+#include "donner/editor/SelectTool.h"
+#include "donner/editor/ViewportState.h"
+
+namespace donner::editor {
+
+/**
+ * Composes cached non-WGPU document tiles into one transparent GL texture.
+ *
+ * The compositor preserves each tile's full affine presentation quad, including live drag and
+ * transform previews. It performs the tile blend in premultiplied form, resolves back to straight
+ * alpha for ImGui, and caches the result while all presentation inputs remain unchanged.
+ */
+class DocumentPresentationCompositor {
+public:
+  DocumentPresentationCompositor();
+  ~DocumentPresentationCompositor();
+
+  DocumentPresentationCompositor(const DocumentPresentationCompositor&) = delete;
+  DocumentPresentationCompositor& operator=(const DocumentPresentationCompositor&) = delete;
+
+  [[nodiscard]] DocumentCompositeTextureView compose(
+      const ViewportState& viewport, const Box2d& imageClipRect,
+      std::span<const GlTextureCache::TileView> overviewTiles,
+      std::span<const GlTextureCache::TileView> tiles,
+      const std::optional<SelectTool::ActiveDragPreview>& activeDragPreview,
+      const std::optional<SelectTool::ActiveDragPreview>& displayedDragPreview,
+      Entity suppressedLayerEntity, bool suppressDragTargetTiles);
+
+  /// Release cached output and invalidate the request cache.
+  void reset();
+
+  /// Bytes retained by the two RGBA8 intermediate textures.
+  [[nodiscard]] std::uint64_t retainedBytes() const;
+
+  /// Number of cache-miss compositions, exposed for deterministic performance tests.
+  [[nodiscard]] std::uint64_t compositionCountForTesting() const;
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace donner::editor

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -36,6 +36,7 @@
 #include "donner/editor/AttributeWriteback.h"
 #include "donner/editor/DisclosureChevron.h"
 #include "donner/editor/DocumentSave.h"
+#include "donner/editor/DocumentPresentationCompositor.h"
 #include "donner/editor/DragCoalesce.h"
 #include "donner/editor/EditorDockLayout.h"
 #include "donner/editor/EditorSampleCatalog.h"
@@ -304,30 +305,31 @@ void AccumulateFrameLoopPhaseCost(double layoutMs, double menusDialogsMs, double
 }
 
 void PublishPresentationResourceStats(double totalTrackedBytes, double peakTrackedBytes,
-                                      double pendingRetiredBytes, double agedRetiredBytes,
-                                      double activeTileTextures, double overviewTileTextures,
-                                      double pendingRetiredTextures, double agedRetiredTextures,
-                                      double retiredFrameCount, double lifetimeTextureCreates,
-                                      double lifetimeBufferCreates) {
+                                      double documentCompositeBytes, double pendingRetiredBytes,
+                                      double agedRetiredBytes, double activeTileTextures,
+                                      double overviewTileTextures, double pendingRetiredTextures,
+                                      double agedRetiredTextures, double retiredFrameCount,
+                                      double lifetimeTextureCreates, double lifetimeBufferCreates) {
   MAIN_THREAD_ASYNC_EM_ASM(
       {
         window['__donnerPresentationResourceStats'] = ({
           'totalTrackedBytes' : $0,
           'peakTrackedBytes' : $1,
-          'pendingRetiredBytes' : $2,
-          'agedRetiredBytes' : $3,
-          'activeTileTextures' : $4,
-          'overviewTileTextures' : $5,
-          'pendingRetiredTextures' : $6,
-          'agedRetiredTextures' : $7,
-          'retiredFrameCount' : $8,
-          'lifetimeTextureCreates' : $9,
-          'lifetimeBufferCreates' : $10,
+          'documentCompositeBytes' : $2,
+          'pendingRetiredBytes' : $3,
+          'agedRetiredBytes' : $4,
+          'activeTileTextures' : $5,
+          'overviewTileTextures' : $6,
+          'pendingRetiredTextures' : $7,
+          'agedRetiredTextures' : $8,
+          'retiredFrameCount' : $9,
+          'lifetimeTextureCreates' : $10,
+          'lifetimeBufferCreates' : $11,
         });
       },
-      totalTrackedBytes, peakTrackedBytes, pendingRetiredBytes, agedRetiredBytes,
-      activeTileTextures, overviewTileTextures, pendingRetiredTextures, agedRetiredTextures,
-      retiredFrameCount, lifetimeTextureCreates, lifetimeBufferCreates);
+      totalTrackedBytes, peakTrackedBytes, documentCompositeBytes, pendingRetiredBytes,
+      agedRetiredBytes, activeTileTextures, overviewTileTextures, pendingRetiredTextures,
+      agedRetiredTextures, retiredFrameCount, lifetimeTextureCreates, lifetimeBufferCreates);
 }
 
 #endif
@@ -1229,6 +1231,8 @@ EditorShell::EditorShell(gui::EditorWindow& window, EditorShellOptions options)
     // unique_ptr is released.
     ConfigureEmbeddedSvgIconRenderer(*directOverlayRenderer_);
   }
+#else
+  documentPresentationCompositor_ = std::make_unique<DocumentPresentationCompositor>();
 #endif
   PrewarmEditorIcons();
   if (!rotateCursorSet_.initialize(window_.rawHandle(), window_.geodeDevice())) {
@@ -1716,6 +1720,8 @@ void EditorShell::maybeLogResourceDiagnostics(const FrameCostBreakdown& frameCos
   std::cerr << "[DonnerResource] frame=" << resourceDiagnosticsFrame_
             << " tracked_mib=" << MegabytesRoundedUp(resources.totalTrackedBytes)
             << " peak_mib=" << MegabytesRoundedUp(resources.peakTrackedBytes)
+            << " document_composite_mib="
+            << MegabytesRoundedUp(resources.documentCompositeBytes)
             << " active_tile_mib=" << MegabytesRoundedUp(resources.activeTileBytes)
             << " overview_tile_mib=" << MegabytesRoundedUp(resources.overviewTileBytes)
             << " retired_mib="
@@ -4101,8 +4107,6 @@ void EditorShell::renderRenderPanePresentation(
   }
   const Entity presentSuppressedLayerEntity =
       penPreviewSuppressedEntity != entt::null ? penPreviewSuppressedEntity : suppressedLayerEntity;
-  interactionController_.frameHistory().setLatestMemorySample(
-      MemorySampleFromPresentationResources(textures_.presentationResourceStats()));
   // Document tiles use the direct framebuffer path where possible. The
   // framebuffer pass also owns the transparency checkerboard unconditionally:
   // there is no draw-list checkerboard to fall back to, because every pixel the
@@ -4136,12 +4140,9 @@ void EditorShell::renderRenderPanePresentation(
   };
   const bool drawOverviewTiles =
       ShouldPresentOverviewTiles(textures_.activeTilesViewportBounded(), textures_.overviewTiles());
-  if (!contentOnlyCaptureThisFrame_ && directDocumentRenderer_ != nullptr &&
-      directDocumentClipRect.has_value()) {
+  if (directDocumentRenderer_ != nullptr && directDocumentClipRect.has_value()) {
     // Tiles ride the framebuffer pass only when every one of them is a Geode
-    // texture. The remaining case is the browser bitmap bridge, whose CPU tiles
-    // are still blitted as images by the render pane - an image blit, never
-    // path geometry.
+    // texture. A non-Geode compatibility payload falls back through the render pane.
     underlayPresentsTiles =
         ((drawOverviewTiles && hasDirectlyPresentableTile(textures_.overviewTiles())) ||
          hasDirectlyPresentableTile(textures_.tiles())) &&
@@ -4195,6 +4196,32 @@ void EditorShell::renderRenderPanePresentation(
     };
   }
   installImmediateChromePlan(std::move(chromePlan));
+#ifndef DONNER_EDITOR_WGPU
+  const std::optional<Box2d> intermediateDocumentClipRect =
+      PresentedImageClipRect(paneRect, presentedDocumentViewport.imageScreenRect());
+  DocumentCompositeTextureView documentComposite;
+  if (documentPresentationCompositor_ != nullptr && intermediateDocumentClipRect.has_value() &&
+      (!textures_.tiles().empty() || !textures_.overviewTiles().empty())) {
+    const bool drawOverviewTiles = ShouldPresentOverviewTiles(
+        textures_.activeTilesViewportBounded(), textures_.overviewTiles());
+    const std::vector<GlTextureCache::TileView> noOverviewTiles;
+    documentComposite = documentPresentationCompositor_->compose(
+        presentedDocumentViewport, *intermediateDocumentClipRect,
+        drawOverviewTiles ? textures_.overviewTiles() : noOverviewTiles, textures_.tiles(),
+        activeDragPreview, displayedDragPreview, presentSuppressedLayerEntity,
+        suppressDragTargetTiles);
+  } else if (documentPresentationCompositor_ != nullptr) {
+    documentPresentationCompositor_->reset();
+  }
+  textures_.setDocumentCompositeBytes(documentPresentationCompositor_ != nullptr
+                                          ? documentPresentationCompositor_->retainedBytes()
+                                          : 0u);
+#else
+  const DocumentCompositeTextureView documentComposite;
+  textures_.setDocumentCompositeBytes(0u);
+#endif
+  interactionController_.frameHistory().setLatestMemorySample(
+      MemorySampleFromPresentationResources(textures_.presentationResourceStats()));
   RenderPanePresenterState paneState{
       .viewport = interactionController_.viewport(),
       .presentedDocumentViewport = &presentedDocumentViewport,
@@ -4207,6 +4234,7 @@ void EditorShell::renderRenderPanePresentation(
       .suppressedLayerEntity = presentSuppressedLayerEntity,
       .suppressDragTargetTiles = suppressDragTargetTiles,
       .documentPresentedDirectly = documentPresentedDirectly,
+      .documentComposite = documentComposite,
       .compositorTileOverlay = !contentOnlyCaptureThisFrame_ && compositorTileOverlay_,
       .perfOverlayMode = contentOnlyCaptureThisFrame_ ? PerfOverlayMode::Off : perfOverlayMode_,
   };
@@ -6570,7 +6598,9 @@ void EditorShell::recordFrameTelemetry(
   // `donner/base/MemoryAttribution.h`); the render thread publishes the
   // compositor's half from `AsyncRenderer::workerLoop`. The frame publisher
   // reads both and is the only writer of the page-visible stats object.
-  SetRetainedBytes(MemoryCategory::PresentationTiles, presentationResources.activeTileBytes);
+  SetRetainedBytes(MemoryCategory::PresentationTiles,
+                   presentationResources.activeTileBytes +
+                       presentationResources.documentCompositeBytes);
   SetEntryCount(MemoryCategory::PresentationTiles,
                 static_cast<std::uint64_t>(presentationResources.activeTileTextures));
   SetRetainedBytes(MemoryCategory::PresentationOverviewTiles,
@@ -6622,6 +6652,7 @@ void EditorShell::recordFrameTelemetry(
   PublishPresentationResourceStats(
       static_cast<double>(presentationResources.totalTrackedBytes),
       static_cast<double>(presentationResources.peakTrackedBytes),
+      static_cast<double>(presentationResources.documentCompositeBytes),
       static_cast<double>(presentationResources.pendingRetiredBytes),
       static_cast<double>(presentationResources.agedRetiredBytes),
       static_cast<double>(presentationResources.activeTileTextures),

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -35,8 +35,8 @@
 #include "donner/css/parser/ColorParser.h"
 #include "donner/editor/AttributeWriteback.h"
 #include "donner/editor/DisclosureChevron.h"
-#include "donner/editor/DocumentSave.h"
 #include "donner/editor/DocumentPresentationCompositor.h"
+#include "donner/editor/DocumentSave.h"
 #include "donner/editor/DragCoalesce.h"
 #include "donner/editor/EditorDockLayout.h"
 #include "donner/editor/EditorSampleCatalog.h"
@@ -1720,8 +1720,7 @@ void EditorShell::maybeLogResourceDiagnostics(const FrameCostBreakdown& frameCos
   std::cerr << "[DonnerResource] frame=" << resourceDiagnosticsFrame_
             << " tracked_mib=" << MegabytesRoundedUp(resources.totalTrackedBytes)
             << " peak_mib=" << MegabytesRoundedUp(resources.peakTrackedBytes)
-            << " document_composite_mib="
-            << MegabytesRoundedUp(resources.documentCompositeBytes)
+            << " document_composite_mib=" << MegabytesRoundedUp(resources.documentCompositeBytes)
             << " active_tile_mib=" << MegabytesRoundedUp(resources.activeTileBytes)
             << " overview_tile_mib=" << MegabytesRoundedUp(resources.overviewTileBytes)
             << " retired_mib="
@@ -6598,9 +6597,9 @@ void EditorShell::recordFrameTelemetry(
   // `donner/base/MemoryAttribution.h`); the render thread publishes the
   // compositor's half from `AsyncRenderer::workerLoop`. The frame publisher
   // reads both and is the only writer of the page-visible stats object.
-  SetRetainedBytes(MemoryCategory::PresentationTiles,
-                   presentationResources.activeTileBytes +
-                       presentationResources.documentCompositeBytes);
+  SetRetainedBytes(
+      MemoryCategory::PresentationTiles,
+      presentationResources.activeTileBytes + presentationResources.documentCompositeBytes);
   SetEntryCount(MemoryCategory::PresentationTiles,
                 static_cast<std::uint64_t>(presentationResources.activeTileTextures));
   SetRetainedBytes(MemoryCategory::PresentationOverviewTiles,

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -65,6 +65,8 @@ struct ReproAction;
 
 namespace donner::editor {
 
+class DocumentPresentationCompositor;
+
 namespace internal {
 struct ToolbarPaintState;
 }
@@ -649,6 +651,8 @@ private:
   std::unique_ptr<FramebufferCheckerboardRenderer> directCheckerboardRenderer_;
   std::unique_ptr<svg::RendererGeode> directDocumentRenderer_;
   std::unique_ptr<svg::RendererGeode> directOverlayRenderer_;
+#else
+  std::unique_ptr<DocumentPresentationCompositor> documentPresentationCompositor_;
 #endif
 
   std::string lastWindowTitle_;

--- a/donner/editor/GlTextureCache.cc
+++ b/donner/editor/GlTextureCache.cc
@@ -939,8 +939,8 @@ PresentationResourceStats GlTextureCache::presentationResourceStats() const {
 #endif
 
   stats.totalTrackedBytes = stats.documentCompositeBytes + stats.activeTileBytes +
-                            stats.overviewTileBytes +
-                            stats.pendingRetiredBytes + stats.agedRetiredBytes;
+                            stats.overviewTileBytes + stats.pendingRetiredBytes +
+                            stats.agedRetiredBytes;
   peakTrackedResourceBytes_ = std::max(peakTrackedResourceBytes_, stats.totalTrackedBytes);
   stats.peakTrackedBytes = peakTrackedResourceBytes_;
   return stats;

--- a/donner/editor/GlTextureCache.cc
+++ b/donner/editor/GlTextureCache.cc
@@ -889,6 +889,7 @@ PresentationResourceStats GlTextureCache::presentationResourceStats() const {
     return allocationBytes(Vector2i(entry.width, entry.height));
   };
 
+  stats.documentCompositeBytes = documentCompositeBytes_;
   stats.activeTileTextures = static_cast<int>(tileTextures_.size());
   for (const auto& [_, entry] : tileTextures_) {
     if (entry.texture != 0) {
@@ -937,7 +938,8 @@ PresentationResourceStats GlTextureCache::presentationResourceStats() const {
   }
 #endif
 
-  stats.totalTrackedBytes = stats.activeTileBytes + stats.overviewTileBytes +
+  stats.totalTrackedBytes = stats.documentCompositeBytes + stats.activeTileBytes +
+                            stats.overviewTileBytes +
                             stats.pendingRetiredBytes + stats.agedRetiredBytes;
   peakTrackedResourceBytes_ = std::max(peakTrackedResourceBytes_, stats.totalTrackedBytes);
   stats.peakTrackedBytes = peakTrackedResourceBytes_;

--- a/donner/editor/GlTextureCache.h
+++ b/donner/editor/GlTextureCache.h
@@ -48,6 +48,8 @@ struct CompositedTileTextureIdentity {
 
 /// Approximate resource footprint retained by the editor presentation texture cache.
 struct PresentationResourceStats {
+  /// Bytes retained by an external explicit document-composite target.
+  std::uint64_t documentCompositeBytes = 0;
   /// Bytes retained by active composited tile textures.
   std::uint64_t activeTileBytes = 0;
   /// Bytes retained by the zoom-out overview tile textures.
@@ -157,9 +159,9 @@ struct PresentationCoverageDiagnostics {
  *
  * Composited preview rendering is per-tile: instead of three named bg/promoted/fg
  * textures, the cache owns one GL texture per `CompositedTile` (keyed on the tile id), allocated
- * lazily on first upload and freed when the tile leaves the snapshot. The editor's
- * `RenderPanePresenter` iterates `tiles()` in paint order and blits each tile at its
- * `(canvasOffsetDoc + dragTranslationDoc) * pixelsPerDocUnit` origin.
+ * lazily on first upload and freed when the tile leaves the snapshot. The GL presentation
+ * compositor samples `tiles()` in paint order into one pane-sized texture. WebGPU builds retain
+ * the direct-framebuffer presentation path.
  */
 class GlTextureCache {
 public:
@@ -210,6 +212,8 @@ public:
   ThumbnailTextureView retainThumbnailTextureSnapshot(
       std::uint64_t key, std::shared_ptr<const svg::RendererTextureSnapshot> textureSnapshot);
 
+  /// Report bytes retained by the non-WGPU explicit document compositor.
+  void setDocumentCompositeBytes(std::uint64_t bytes) { documentCompositeBytes_ = bytes; }
   /// Evict every cached thumbnail texture whose key is not in @p liveKeys,
   /// freeing the backing GL/WGPU texture. Called after each Layers-panel render
   /// so thumbnails for removed rows do not leak across refreshes.
@@ -220,9 +224,8 @@ public:
   /// Number of thumbnail textures currently retained (testing/diagnostics).
   [[nodiscard]] std::size_t thumbnailTextureCount() const { return thumbnailTextures_.size(); }
 
-  /// One composite-tile entry as the presenter sees it: the GL
-  /// texture handle (resolved from the upload cache) plus the
-  /// geometry fields the presenter needs to blit in paint order.
+  /// One composite-tile entry as presentation sees it: the GL texture handle
+  /// (resolved from the upload cache) plus its paint-order geometry.
   struct TileView {
     ImTextureID texture = 0;
     std::string id;
@@ -353,6 +356,7 @@ private:
   int metadataOnlyMissCount_ = 0;
   int duplicateLiveTextureCount_ = 0;
   FrameCostBreakdown::CompositedUpload lastCompositedUploadCost_;
+  std::uint64_t documentCompositeBytes_ = 0;
   mutable std::uint64_t peakTrackedResourceBytes_ = 0;
 
 #ifdef DONNER_EDITOR_WGPU

--- a/donner/editor/OverlayRenderer.cc
+++ b/donner/editor/OverlayRenderer.cc
@@ -801,23 +801,11 @@ SelectionChromeSnapshot OverlayRenderer::captureChromeSnapshot(
   const bool includePathPointChrome = pathOutlinesOnly;
 
   // A live select gesture carries immutable start bounds and the exact current
-  // document transform. Keep its path outline sampled from the live DOM so it
-  // scales and rotates with the presented object, while retaining the
-  // lightweight oriented-bounds path for handles and omitting per-element
-  // AABBs and path-point chrome.
+  // document transform. Build its lightweight bounds chrome directly from
+  // that state instead of traversing selected geometry while the async
+  // renderer may hold the document. Detailed path and text-baseline chrome
+  // refine after the interaction settles.
   if (combinedBoundsOnly && activeBoundsPreview.has_value()) {
-    AppendChromeItems(
-        selection, cullRectDoc, &snapshot.paths, &snapshot.aabbsDoc,
-        /*outPathAnchorPoints=*/nullptr, /*outPathControlLines=*/nullptr,
-        /*outPathControlPoints=*/nullptr, &snapshot.textBaselinesDoc,
-        AppendChromeItemsOptions{
-            .includePaths = true,
-            .includePerElementAabbs = false,
-            .includePathPointChrome = false,
-            .canvasScale = scale,
-            .devicePixelRatio = devicePixelRatio,
-            .representedDocumentFromLiveDocument = representedDocumentFromLiveDocument,
-        });
     const auto corners = TransformedBoxCorners(activeBoundsPreview->startBoundsDoc,
                                                activeBoundsPreview->documentFromStartDocument);
     std::array<Vector2d, 4> representedCorners;

--- a/donner/editor/OverlayRenderer.h
+++ b/donner/editor/OverlayRenderer.h
@@ -356,10 +356,10 @@ public:
   /// otherwise not mutating these components on the same registry.
   /// When `cullRectDoc` is present, path outlines, AABBs, and handles
   /// fully outside that document-space rect are skipped before draw.
-  /// `CombinedBoundsOnly` normally skips selected path extraction and stores
-  /// one combined bounds box for low-latency large-selection feedback. During
-  /// an active scale/rotate preview it also captures path outlines so they
-  /// remain visible and aligned with the gesture.
+  /// `CombinedBoundsOnly` skips selected path extraction and stores one
+  /// combined bounds box for low-latency interaction feedback. An active
+  /// scale/rotate preview derives oriented bounds and handles directly from
+  /// gesture-owned geometry without traversing the selection.
   /// @param devicePixelRatio Viewport framebuffer scale used to convert
   ///   logical UI stroke widths into device pixels.
   ///

--- a/donner/editor/RenderPanePresenter.cc
+++ b/donner/editor/RenderPanePresenter.cc
@@ -668,6 +668,7 @@ void RenderPanePresenter::render(const RenderPanePresenterState& state) const {
     }
     return tileQuad;
   };
+#ifdef DONNER_EDITOR_WGPU
   const auto computeTileQuad = [&](const GlTextureCache::TileView& tile) {
     if (!ShouldPresentCompositedTile(tile, state.suppressedLayerEntity,
                                      state.suppressDragTargetTiles)) {
@@ -682,10 +683,8 @@ void RenderPanePresenter::render(const RenderPanePresenterState& state) const {
     }
     const float uvRight = static_cast<float>(tile.uvBottomRight.x);
     const float uvBottom = static_cast<float>(tile.uvBottomRight.y);
-    // Draw-list fallback for frames with no directly presentable Geode tile and
-    // for non-WGPU builds; the quads carry the affine drag-preview transform
-    // that AddImage cannot express. Retired by the presentation-path
-    // unification.
+    // A non-Geode payload cannot enter the direct framebuffer underlay. Keep the compatibility
+    // fallback so device-loss or bitmap-bridge frames remain visible.
     paneDrawList->AddImageQuad(  // NOLINT(banned_patterns: sanctioned fallback presentation)
         tile.texture, ToImVec2(tileQuad->topLeft), ToImVec2(tileQuad->topRight),
         ToImVec2(tileQuad->bottomRight), ToImVec2(tileQuad->bottomLeft), ImVec2(0.0f, 0.0f),
@@ -698,9 +697,8 @@ void RenderPanePresenter::render(const RenderPanePresenterState& state) const {
     if (drawOverviewTiles) {
       std::vector<Box2d> activeTileBounds;
       activeTileBounds.reserve(state.textures.tiles().size());
-      for (const auto& tile : state.textures.tiles()) {
-        const std::optional<PresentedTileQuad> tileQuad = computeTileQuad(tile);
-        if (tileQuad.has_value()) {
+      for (const GlTextureCache::TileView& tile : state.textures.tiles()) {
+        if (const std::optional<PresentedTileQuad> tileQuad = computeTileQuad(tile)) {
           activeTileBounds.push_back(PresentedTileQuadBounds(*tileQuad));
         }
         if (TileMatchesActiveDragPreview(tile, state.activeDragPreview)) {
@@ -713,23 +711,30 @@ void RenderPanePresenter::render(const RenderPanePresenterState& state) const {
         }
       }
 
-      const std::vector<Box2d> overviewClipRects =
-          SubtractPresentedTileBoundsFromClip(*imageClipRect, activeTileBounds);
-      for (const Box2d& overviewClipRect : overviewClipRects) {
+      for (const Box2d& overviewClipRect :
+           SubtractPresentedTileBoundsFromClip(*imageClipRect, activeTileBounds)) {
         paneDrawList->PushClipRect(ToImVec2(overviewClipRect.topLeft),
                                    ToImVec2(overviewClipRect.bottomRight),
                                    /*intersect_with_current_clip_rect=*/true);
-        for (const auto& tile : state.textures.overviewTiles()) {
+        for (const GlTextureCache::TileView& tile : state.textures.overviewTiles()) {
           drawTile(tile);
         }
         paneDrawList->PopClipRect();
       }
     }
-    for (const auto& tile : state.textures.tiles()) {
+    for (const GlTextureCache::TileView& tile : state.textures.tiles()) {
       drawTile(tile);
     }
     paneDrawList->PopClipRect();
   }
+#else
+  const DocumentCompositeTextureView& documentComposite = state.documentComposite;
+  if (documentComposite.texture != 0 && !state.documentPresentedDirectly) {
+    paneDrawList->AddImage(
+        documentComposite.texture, ToImVec2(documentComposite.screenRect.topLeft),
+        ToImVec2(documentComposite.screenRect.bottomRight), ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f));
+  }
+#endif
   if (state.compositorTileOverlay && imageClipRect.has_value()) {
     paneDrawList->PushClipRect(ToImVec2(imageClipRect->topLeft),
                                ToImVec2(imageClipRect->bottomRight),

--- a/donner/editor/RenderPanePresenter.h
+++ b/donner/editor/RenderPanePresenter.h
@@ -9,6 +9,7 @@
 #include "donner/base/Box.h"
 #include "donner/base/Path.h"
 #include "donner/base/Vector2.h"
+#include "donner/editor/DocumentCompositeTexture.h"
 #include "donner/editor/GlTextureCache.h"
 #include "donner/editor/MenuBarPresenter.h"
 #include "donner/editor/OverlayRenderer.h"
@@ -46,6 +47,7 @@ struct RenderPanePresenterState {
   Entity suppressedLayerEntity = entt::null;
   bool suppressDragTargetTiles = false;
   bool documentPresentedDirectly = false;
+  DocumentCompositeTextureView documentComposite;
   bool compositorTileOverlay = false;
   PerfOverlayMode perfOverlayMode = PerfOverlayMode::Off;
 };

--- a/donner/editor/tests/BUILD.bazel
+++ b/donner/editor/tests/BUILD.bazel
@@ -368,6 +368,7 @@ donner_cc_test(
     deps = [
         "//donner/base",
         "//donner/base:base_test_utils",
+        "//donner/editor:document_presentation_compositor",
         "//donner/editor:gl_texture_cache",
         "//donner/editor:imgui_headers",
         "//donner/editor:menu_bar_presenter",

--- a/donner/editor/tests/EditorRnrGlReplay.cc
+++ b/donner/editor/tests/EditorRnrGlReplay.cc
@@ -428,7 +428,8 @@ void PrintFrameCost(const FrameCostBreakdown& cost) {
 }
 
 void PrintPresentationResources(const PresentationResourceStats& resources) {
-  std::cout << "{\"active_tile_bytes\":" << resources.activeTileBytes
+  std::cout << "{\"document_composite_bytes\":" << resources.documentCompositeBytes
+            << ",\"active_tile_bytes\":" << resources.activeTileBytes
             << ",\"overview_tile_bytes\":" << resources.overviewTileBytes
             << ",\"pending_retired_bytes\":" << resources.pendingRetiredBytes
             << ",\"aged_retired_bytes\":" << resources.agedRetiredBytes

--- a/donner/editor/tests/GlRnrReplay_tests.cc
+++ b/donner/editor/tests/GlRnrReplay_tests.cc
@@ -10,6 +10,7 @@
 #include <cstring>
 #include <filesystem>
 #include <iostream>
+#include <iterator>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -3239,21 +3240,21 @@ TEST(GlRnrReplayTest, HoldFramesBehindRecordsWithheldReplayDiagnostics) {
   repro::GlRnrReplayResult result;
   std::string error;
   ASSERT_GL_REPLAY_OR_SKIP(options, result, error);
+  SCOPED_TRACE(CanonicalReplayDiagnostics(result));
 
-  // The first result is ready on `kFirstPresentedReplayFrame`; `holdFramesBehind = 1` withholds it
-  // for exactly that one poll and releases it on the next frame.
-  const repro::GlRnrReplayFrameDiagnostics* withheld =
-      FindFrameDiagnostics(result, kFirstPresentedReplayFrame);
-  ASSERT_NE(withheld, nullptr);
+  // Viewport initialization decides which replay frame first posts work. Assert the deterministic
+  // hold relative to the completed result instead of pinning that initialization to a frame index.
+  const auto withheld = std::find_if(
+      result.frameDiagnostics.begin(), result.frameDiagnostics.end(),
+      [](const repro::GlRnrReplayFrameDiagnostics& frame) { return frame.replayResultWithheld; });
+  ASSERT_NE(withheld, result.frameDiagnostics.end());
   EXPECT_EQ(withheld->replayWorkerScheduling, repro::GlRnrReplayWorkerScheduling::HoldFramesBehind);
   EXPECT_EQ(withheld->replayWorkerRenderDelayMsForTesting, 1);
   EXPECT_EQ(withheld->replayHoldFramesBehind, 1);
   EXPECT_EQ(withheld->replayResultHoldPollsThisFrame, 1u);
-  EXPECT_TRUE(withheld->replayResultWithheld);
 
-  const repro::GlRnrReplayFrameDiagnostics* released =
-      FindFrameDiagnostics(result, kFirstPresentedReplayFrame + 1);
-  ASSERT_NE(released, nullptr);
+  const auto released = std::next(withheld);
+  ASSERT_NE(released, result.frameDiagnostics.end());
   EXPECT_EQ(released->replayResultHoldPollsThisFrame, 0u);
   EXPECT_FALSE(released->replayResultWithheld);
   EXPECT_NE(FindCapture(result, kFirstPresentedReplayFrame + 1), nullptr);
@@ -3584,13 +3585,10 @@ TEST(GlRnrReplayTest, GeodeDragZoomRebuildsDonnerDGestureBoundsEveryPresentedFra
         << "Selection overlay was not rebuilt for presented zoom frame " << frame;
     EXPECT_TRUE(diagnostics->frameCost.overlay.selectionBoundsOnly)
         << "Active drag should use gesture-owned bounds chrome on presented zoom frame " << frame;
-    // Gesture-owned bounds chrome keeps exactly one selection outline per selected element so the
-    // outline scales and rotates with the presented object; it drops per-element AABBs and
-    // path-point chrome. Pinned by
-    // `OverlayRendererTest.ActiveCombinedBoundsPreviewKeepsScaledSelectionPath`.
-    EXPECT_EQ(diagnostics->frameCost.overlay.pathCount, 1)
-        << "Active drag lost the gesture-scaled selection outline on presented zoom frame "
-        << frame;
+    // Gesture-owned bounds chrome skips live path and text traversal while the worker may hold the
+    // document. The oriented bounds and handles still advance with the presented object.
+    EXPECT_EQ(diagnostics->frameCost.overlay.pathCount, 0)
+        << "Active drag traversed selection paths on presented zoom frame " << frame;
     EXPECT_EQ(diagnostics->frameCost.overlay.handleCount, 4)
         << "Selection transform handles were not rebuilt for presented zoom frame " << frame;
     EXPECT_GT(diagnostics->frameCost.overlay.payloadBytes, 0u)

--- a/donner/editor/tests/GlRnrReplay_tests.cc
+++ b/donner/editor/tests/GlRnrReplay_tests.cc
@@ -283,6 +283,22 @@ std::optional<std::filesystem::path> WriteStaticContentReplay(
   file.metadata.windowHeight = 480;
   file.metadata.displayScale = 1.0;
 
+  repro::ReproViewport viewport;
+  viewport.paneOriginX = 220.0;
+  viewport.paneOriginY = 180.0;
+  viewport.paneSizeW = 200.0;
+  viewport.paneSizeH = 120.0;
+  viewport.devicePixelRatio = 1.0;
+  viewport.zoom = 1.0;
+  viewport.panDocX = 100.0;
+  viewport.panDocY = 60.0;
+  viewport.panScreenX = 320.0;
+  viewport.panScreenY = 240.0;
+  viewport.viewBoxX = 0.0;
+  viewport.viewBoxY = 0.0;
+  viewport.viewBoxW = 200.0;
+  viewport.viewBoxH = 120.0;
+
   for (std::uint64_t frameIndex = 0; frameIndex <= lastFrame; ++frameIndex) {
     repro::ReproFrame frame;
     frame.index = frameIndex;
@@ -290,6 +306,7 @@ std::optional<std::filesystem::path> WriteStaticContentReplay(
     frame.deltaMs = 1000.0 / 60.0;
     frame.mouseX = 320.0;
     frame.mouseY = 240.0;
+    frame.viewport = viewport;
     file.frames.push_back(frame);
   }
 
@@ -2156,6 +2173,7 @@ TEST(GlRnrReplayTest, ContentOnlyDocumentCanvasCaptureMatchesRendererGroundTruth
   repro::GlRnrReplayResult result;
   std::string error;
   ASSERT_GL_REPLAY_OR_SKIP(options, result, error);
+  SCOPED_TRACE(CanonicalReplayDiagnostics(result));
 
   std::optional<svg::RendererBitmap> actual = LoadCaptureBitmap(result, kFirstPresentedReplayFrame);
   ASSERT_TRUE(actual.has_value());
@@ -2190,6 +2208,7 @@ TEST(GlRnrReplayTest, DirectDocumentCanvasCaptureIsNotDimmedByRenderPaneBackgrou
   repro::GlRnrReplayResult result;
   std::string error;
   ASSERT_GL_REPLAY_OR_SKIP(options, result, error);
+  SCOPED_TRACE(CanonicalReplayDiagnostics(result));
 
   std::optional<svg::RendererBitmap> actual = LoadCaptureBitmap(result, kFirstPresentedReplayFrame);
   ASSERT_TRUE(actual.has_value());

--- a/donner/editor/tests/GlTextureCache_tests.cc
+++ b/donner/editor/tests/GlTextureCache_tests.cc
@@ -260,6 +260,16 @@ TEST(GlTextureCacheTest, ResetCompositedClearsMetadataBookkeepingAndCost) {
   EXPECT_EQ(coverage.overviewOutputSizePx, Vector2i::Zero());
 }
 
+TEST(GlTextureCacheTest, DocumentCompositeBytesParticipateInTrackedResourceTotal) {
+  GlTextureCache cache;
+  cache.setDocumentCompositeBytes(8192u);
+
+  const PresentationResourceStats stats = cache.presentationResourceStats();
+  EXPECT_EQ(stats.documentCompositeBytes, 8192u);
+  EXPECT_EQ(stats.totalTrackedBytes, 8192u);
+  EXPECT_EQ(stats.peakTrackedBytes, 8192u);
+}
+
 TEST(GlTextureCacheTest, EmptyThumbnailAndRetainOnEmptyDoNotAllocate) {
   GlTextureCache cache;
   svg::RendererBitmap bitmap;

--- a/donner/editor/tests/OverlayRenderer_tests.cc
+++ b/donner/editor/tests/OverlayRenderer_tests.cc
@@ -250,7 +250,7 @@ TEST(OverlayRendererTest, EditingChromeOnlySkipsSelectionGeometry) {
   EXPECT_TRUE(snapshot.handleAnchorsDoc.empty());
 }
 
-TEST(OverlayRendererTest, ActiveCombinedBoundsPreviewKeepsTextBaseline) {
+TEST(OverlayRendererTest, ActiveCombinedBoundsPreviewSkipsTextBaselineTraversal) {
   constexpr std::string_view kTextSvg =
       R"(<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
            <text id="t" x="50" y="80" font-size="20" font-family="sans-serif">Hello</text>
@@ -273,11 +273,10 @@ TEST(OverlayRendererTest, ActiveCombinedBoundsPreviewKeepsTextBaseline) {
       boundsPreview, std::span<const svg::SVGElement>(), std::nullopt,
       SelectionChromeDetail::CombinedBoundsOnly);
 
-  ASSERT_EQ(snapshot.textBaselinesDoc.size(), 1u);
-  EXPECT_NEAR(snapshot.textBaselinesDoc.front().startDoc.y, 96.0, 1.0);
+  EXPECT_TRUE(snapshot.textBaselinesDoc.empty());
 }
 
-TEST(OverlayRendererTest, ActiveCombinedBoundsPreviewKeepsScaledSelectionPath) {
+TEST(OverlayRendererTest, ActiveCombinedBoundsPreviewAvoidsSelectionPathCapture) {
   EditorApp app;
   ASSERT_TRUE(app.loadFromString(kTrivialSvg));
   auto rect = app.document().document().querySelector("#r1");
@@ -296,9 +295,7 @@ TEST(OverlayRendererTest, ActiveCombinedBoundsPreviewKeepsScaledSelectionPath) {
       boundsPreview, std::span<const svg::SVGElement>(), std::nullopt,
       SelectionChromeDetail::CombinedBoundsOnly);
 
-  ASSERT_EQ(snapshot.paths.size(), 1u);
-  EXPECT_EQ(snapshot.paths.front().pathDoc.bounds(),
-            scale.transformBox(boundsPreview.startBoundsDoc));
+  EXPECT_TRUE(snapshot.paths.empty());
   EXPECT_TRUE(snapshot.aabbsDoc.empty());
   ASSERT_TRUE(snapshot.orientedBoundsDoc.has_value());
   EXPECT_EQ(snapshot.orientedBoundsDoc->cornersDoc[0], Vector2d(30.0, 36.0));

--- a/donner/editor/tests/RenderPanePresenterVisualRepro_tests.cc
+++ b/donner/editor/tests/RenderPanePresenterVisualRepro_tests.cc
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <filesystem>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -13,6 +14,7 @@
 
 #include "donner/base/MathUtils.h"
 #include "donner/base/tests/TestTempDir.h"
+#include "donner/editor/DocumentPresentationCompositor.h"
 #include "donner/editor/ImGuiIncludes.h"
 #include "donner/editor/MenuBarPresenter.h"
 #include "donner/editor/RenderPanePresenter.h"
@@ -159,6 +161,24 @@ svg::RendererBitmap CapturePresenterFrame(
   // the presenter; the presenter no longer consumes a chrome snapshot.
   const std::optional<SelectionChromeSnapshot> noOverlaySnapshot;
   RenderPanePresenter presenter;
+  DocumentCompositeTextureView documentComposite;
+#ifndef DONNER_EDITOR_WGPU
+  std::unique_ptr<DocumentPresentationCompositor> compositor;
+#endif
+
+#ifndef DONNER_EDITOR_WGPU
+  if (!documentPresentedDirectly) {
+    compositor = std::make_unique<DocumentPresentationCompositor>();
+    const bool drawOverviewTiles = ShouldPresentOverviewTiles(
+        textures->activeTilesViewportBounded(), textures->overviewTiles());
+    const std::vector<GlTextureCache::TileView> noOverviewTiles;
+    documentComposite = compositor->compose(
+        viewport, viewport.imageScreenRect(),
+        drawOverviewTiles ? textures->overviewTiles() : noOverviewTiles, textures->tiles(),
+        activePreview, displayedPreview, suppressedLayerEntity,
+        /*suppressDragTargetTiles=*/false);
+  }
+#endif
 
   window->beginFrame();
   ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
@@ -191,6 +211,7 @@ svg::RendererBitmap CapturePresenterFrame(
       .contentRegion = Vector2d(kLogicalWidth, kLogicalHeight),
       .suppressedLayerEntity = suppressedLayerEntity,
       .documentPresentedDirectly = documentPresentedDirectly,
+      .documentComposite = documentComposite,
       .compositorTileOverlay = compositorTileOverlay,
   });
   ImGui::End();
@@ -282,6 +303,53 @@ TEST(RenderPanePresenterVisualReproTest, WritesDisplayNoneSuppressionScreenshots
   EXPECT_GT(expectedVisiblePixels, 2500)
       << "The expected screenshot should keep the selected drag target visible while the "
          "display:none layer is suppressed.";
+}
+
+TEST(RenderPanePresenterVisualReproTest, IntermediateCompositeReusesUnchangedPresentation) {
+  gui::EditorWindow window(gui::EditorWindowOptions{
+      .title = "Document Composite Cache Repro",
+      .initialWidth = kLogicalWidth,
+      .initialHeight = kLogicalHeight,
+      .visible = false,
+      .offscreen = true,
+      .offscreenContentScale = 1.0,
+      .enableFramebufferReadback = true,
+  });
+  if (!window.valid()) {
+    GTEST_SKIP() << "Hidden editor window is unavailable on this host";
+  }
+
+  GlTextureCache textures(window.geodeDevice());
+  textures.initialize();
+  textures.uploadComposited(MakePreview(/*includeHiddenLayer=*/true));
+
+  ViewportState viewport;
+  viewport.paneSize = Vector2d(kLogicalWidth, kLogicalHeight);
+  viewport.documentViewBox = Box2d::FromXYWH(0.0, 0.0, static_cast<double>(kLogicalWidth),
+                                             static_cast<double>(kLogicalHeight));
+  viewport.panScreenPoint = Vector2d::Zero();
+  viewport.panDocPoint = Vector2d::Zero();
+
+  DocumentPresentationCompositor compositor;
+  const DocumentCompositeTextureView first =
+      compositor.compose(viewport, viewport.imageScreenRect(), {}, textures.tiles(), std::nullopt,
+                         std::nullopt, entt::null, /*suppressDragTargetTiles=*/false);
+  const DocumentCompositeTextureView second =
+      compositor.compose(viewport, viewport.imageScreenRect(), {}, textures.tiles(), std::nullopt,
+                         std::nullopt, entt::null, /*suppressDragTargetTiles=*/false);
+
+  ASSERT_NE(first.texture, 0u);
+  EXPECT_EQ(second.texture, first.texture);
+  EXPECT_EQ(compositor.compositionCountForTesting(), 1u)
+      << "An unchanged UI frame must reuse the explicit document composite.";
+  EXPECT_EQ(compositor.retainedBytes(),
+            static_cast<std::uint64_t>(kLogicalWidth) * kLogicalHeight * 4u * 2u);
+
+  viewport.panScreenPoint.x = 1.0;
+  (void)compositor.compose(viewport, viewport.imageScreenRect(), {}, textures.tiles(), std::nullopt,
+                           std::nullopt, entt::null, /*suppressDragTargetTiles=*/false);
+  EXPECT_EQ(compositor.compositionCountForTesting(), 2u)
+      << "A viewport change must invalidate the document composite.";
 }
 
 TEST(RenderPanePresenterVisualReproTest,

--- a/donner/editor/tests/RenderPanePresenterVisualRepro_tests.cc
+++ b/donner/editor/tests/RenderPanePresenterVisualRepro_tests.cc
@@ -338,6 +338,12 @@ TEST(RenderPanePresenterVisualReproTest, IntermediateCompositeReusesUnchangedPre
       compositor.compose(viewport, viewport.imageScreenRect(), {}, textures.tiles(), std::nullopt,
                          std::nullopt, entt::null, /*suppressDragTargetTiles=*/false);
 
+#ifdef DONNER_EDITOR_WGPU
+  EXPECT_EQ(first.texture, 0u);
+  EXPECT_EQ(second.texture, 0u);
+  EXPECT_EQ(compositor.compositionCountForTesting(), 0u);
+  EXPECT_EQ(compositor.retainedBytes(), 0u);
+#else
   ASSERT_NE(first.texture, 0u);
   EXPECT_EQ(second.texture, first.texture);
   EXPECT_EQ(compositor.compositionCountForTesting(), 1u)
@@ -350,6 +356,7 @@ TEST(RenderPanePresenterVisualReproTest, IntermediateCompositeReusesUnchangedPre
                            std::nullopt, entt::null, /*suppressDragTargetTiles=*/false);
   EXPECT_EQ(compositor.compositionCountForTesting(), 2u)
       << "A viewport change must invalidate the document composite.";
+#endif
 }
 
 TEST(RenderPanePresenterVisualReproTest,
@@ -442,26 +449,26 @@ TEST(RenderPanePresenterVisualReproTest,
   // 2x. Document-space chrome drawn with the live transform lands at twice the
   // offset and twice the size, floating off the pixels it is annotating.
   constexpr double kLiveZoomAheadOfPresentation = 2.0;
-  const svg::RendererBitmap withoutOverlay = CapturePresenterFrame(
-      &window, &textures, entt::null, std::nullopt, std::nullopt,
-      /*documentPresentedDirectly=*/true, /*compositorTileOverlay=*/false,
-      kLiveZoomAheadOfPresentation);
-  const svg::RendererBitmap withOverlay = CapturePresenterFrame(
-      &window, &textures, entt::null, std::nullopt, std::nullopt,
-      /*documentPresentedDirectly=*/true, /*compositorTileOverlay=*/true,
-      kLiveZoomAheadOfPresentation);
+  const svg::RendererBitmap withoutOverlay =
+      CapturePresenterFrame(&window, &textures, entt::null, std::nullopt, std::nullopt,
+                            /*documentPresentedDirectly=*/true, /*compositorTileOverlay=*/false,
+                            kLiveZoomAheadOfPresentation);
+  const svg::RendererBitmap withOverlay =
+      CapturePresenterFrame(&window, &textures, entt::null, std::nullopt, std::nullopt,
+                            /*documentPresentedDirectly=*/true, /*compositorTileOverlay=*/true,
+                            kLiveZoomAheadOfPresentation);
   // Aligned baseline: the same overlay with the live viewport matching the
   // presented one. Its extent is this host's presented-tile far corner plus
   // whatever label overhang this host's text rendering produces, which makes
   // the divergence assertion below host-independent.
-  const svg::RendererBitmap alignedWithoutOverlay = CapturePresenterFrame(
-      &window, &textures, entt::null, std::nullopt, std::nullopt,
-      /*documentPresentedDirectly=*/true, /*compositorTileOverlay=*/false,
-      /*liveZoomAheadOfPresentation=*/1.0);
-  const svg::RendererBitmap alignedWithOverlay = CapturePresenterFrame(
-      &window, &textures, entt::null, std::nullopt, std::nullopt,
-      /*documentPresentedDirectly=*/true, /*compositorTileOverlay=*/true,
-      /*liveZoomAheadOfPresentation=*/1.0);
+  const svg::RendererBitmap alignedWithoutOverlay =
+      CapturePresenterFrame(&window, &textures, entt::null, std::nullopt, std::nullopt,
+                            /*documentPresentedDirectly=*/true, /*compositorTileOverlay=*/false,
+                            /*liveZoomAheadOfPresentation=*/1.0);
+  const svg::RendererBitmap alignedWithOverlay =
+      CapturePresenterFrame(&window, &textures, entt::null, std::nullopt, std::nullopt,
+                            /*documentPresentedDirectly=*/true, /*compositorTileOverlay=*/true,
+                            /*liveZoomAheadOfPresentation=*/1.0);
   ASSERT_FALSE(alignedWithoutOverlay.empty());
   ASSERT_FALSE(alignedWithOverlay.empty());
   ASSERT_EQ(alignedWithOverlay.pixels.size(), alignedWithoutOverlay.pixels.size());
@@ -525,8 +532,7 @@ TEST(RenderPanePresenterVisualReproTest,
           std::max(alignedMaxLogicalY, static_cast<double>(y) / readbackFromLogicalY);
     }
   }
-  ASSERT_GT(alignedChangedPixels, 0)
-      << "The aligned baseline overlay must draw something at all.";
+  ASSERT_GT(alignedChangedPixels, 0) << "The aligned baseline overlay must draw something at all.";
 
   // The tile covers document (54,44)-(132,122); drawn against the 2x live
   // viewport its annotations would land at roughly twice the offset and size.

--- a/tools/gpu_inventory/manifests/editor_integration.json
+++ b/tools/gpu_inventory/manifests/editor_integration.json
@@ -35,6 +35,9 @@
     "donner/editor/CompositorDebugPanel.h": {
       "usesEditorWgpuDefine": true
     },
+    "donner/editor/DocumentPresentationCompositor.cc": {
+      "usesEditorWgpuDefine": true
+    },
     "donner/editor/EditorShell.cc": {
       "usesEditorWgpuDefine": true,
       "wgpuCFunctions": [
@@ -103,6 +106,9 @@
       ]
     },
     "donner/editor/ImGuiBackendIncludes.h": {
+      "usesEditorWgpuDefine": true
+    },
+    "donner/editor/RenderPanePresenter.cc": {
       "usesEditorWgpuDefine": true
     },
     "donner/editor/ViewportInteractionController.h": {
@@ -312,6 +318,9 @@
       ]
     },
     "donner/editor/tests/LayersPanel_tests.cc": {
+      "usesEditorWgpuDefine": true
+    },
+    "donner/editor/tests/RenderPanePresenterVisualRepro_tests.cc": {
       "usesEditorWgpuDefine": true
     },
     "donner/editor/tests/ViewportInteractionController_tests.cc": {


### PR DESCRIPTION
Native GL document tiles now compose through one explicit pane-sized texture before ImGui presentation.

- Preserve affine tile placement, paint order, overview infill, drag transforms, and layer suppression.
- Cache unchanged compositions and account for both RGBA8 intermediate textures.
- Keep Geode/WGPU direct framebuffer presentation and its compatibility fallback intact.
- Avoid live path and text traversal while active gestures use oriented bounds and handles.
- Refresh deterministic GPU inventory and presentation diagnostics.

## Verification

- `bazel test //donner/editor/tests:render_pane_presenter_visual_repro_tests //donner/editor/tests:render_pane_presenter_tests //donner/editor/tests:editor_shell_tests //donner/editor/tests:gl_rnr_replay_tests //donner/editor/tests:overlay_renderer_tests //donner/editor/tests:gl_texture_cache_tests --test_output=errors`
- `bazel test --config=geode //donner/editor/tests:render_pane_presenter_visual_repro_tests --test_output=errors`
- `bazel test //tools/gpu_inventory:manifest_freshness_tests --test_output=errors`
- `bazel build --config=editor-wasm //donner/editor/wasm:wasm_web_package`
- `bazel test //... --test_output=errors`
- `python3 tools/cmake/gen_cmakelists.py --check`
