### PR TITLE
Make font selection and previews reflect available families

### DIFF
--- a/donner/editor/AsyncRenderer.cc
+++ b/donner/editor/AsyncRenderer.cc
@@ -209,6 +209,7 @@ SampleThumbnailRenderResult RenderSampleThumbnail(
     SampleThumbnailRenderRequest request, svg::RendererInterface& renderer,
     const svg::compositor::CancellationToken& cancellation, std::chrono::milliseconds delay) {
   SampleThumbnailRenderResult result{
+      .kind = request.kind,
       .key = request.key,
       .outcome = SampleThumbnailRenderOutcome::RenderError,
   };
@@ -736,6 +737,7 @@ void AsyncRenderer::workerLoop() {
 
       SampleThumbnailRenderResult result;
       if (offscreenRenderer == nullptr) {
+        result.kind = sampleThumbnailStorage->kind;
         result.key = sampleThumbnailStorage->key;
         result.outcome = SampleThumbnailRenderOutcome::RendererUnavailable;
       } else {

--- a/donner/editor/AsyncRenderer.h
+++ b/donner/editor/AsyncRenderer.h
@@ -379,8 +379,15 @@ enum class SampleThumbnailRenderOutcome : std::uint8_t {
   RendererUnavailable,
 };
 
+/// Consumer of one bounded low-priority SVG preview render.
+enum class AuxiliaryPreviewKind : std::uint8_t {
+  Sample,
+  FontFamily,
+};
+
 /// One SVG source queued for bounded, low-priority rendering on the existing render worker.
 struct SampleThumbnailRenderRequest {
+  AuxiliaryPreviewKind kind = AuxiliaryPreviewKind::Sample;
   /// Caller-defined key copied into the result (the sample-catalog index in `EditorShell`).
   std::uint64_t key = 0;
   /// Complete SVG source. The request owns its copy until the worker finishes parsing it.
@@ -396,6 +403,7 @@ struct SampleThumbnailRenderRequest {
 
 /// CPU bitmap returned by one asynchronous sample-thumbnail attempt.
 struct SampleThumbnailRenderResult {
+  AuxiliaryPreviewKind kind = AuxiliaryPreviewKind::Sample;
   std::uint64_t key = 0;
   SampleThumbnailRenderOutcome outcome = SampleThumbnailRenderOutcome::RenderError;
   svg::RendererBitmap bitmap;

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -415,6 +415,8 @@ constexpr std::string_view kEditorUiRegularFontName = "Donner UI Regular";
 constexpr std::string_view kEditorUiBoldFontName = "Donner UI Bold";
 constexpr std::string_view kEditorCodeFontName = "Donner Code";
 constexpr std::string_view kEditorCodeSymbolFontName = "Donner Code Symbols";
+constexpr int kFontPreviewWidth = 196;
+constexpr int kFontPreviewHeight = 24;
 
 void SetImGuiFontConfigName(ImFontConfig& config, std::string_view name) {
   const std::size_t size = std::min(name.size(), sizeof(config.Name) - 1u);
@@ -435,6 +437,38 @@ ImFont* FindImGuiFontByConfigName(const ImFontAtlas& atlas, std::string_view nam
     }
   }
   return nullptr;
+}
+
+std::string EscapeXmlText(std::string_view text) {
+  std::string escaped;
+  escaped.reserve(text.size());
+  for (char c : text) {
+    switch (c) {
+      case '&': escaped += "&amp;"; break;
+      case '<': escaped += "&lt;"; break;
+      case '>': escaped += "&gt;"; break;
+      case '"': escaped += "&quot;"; break;
+      case '\'': escaped += "&apos;"; break;
+      default: escaped.push_back(c); break;
+    }
+  }
+  return escaped;
+}
+
+std::string FontPreviewSvg(std::string_view family) {
+  const std::string escaped = EscapeXmlText(family);
+  return "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 196 24\">"
+         "<text x=\"1\" y=\"18\" font-family=\"" +
+         escaped + "\" font-size=\"16\" fill=\"#fff\">" + escaped + "</text></svg>";
+}
+
+std::uint64_t FontPreviewKey(std::string_view family) {
+  std::uint64_t hash = 14695981039346656037ULL;
+  for (unsigned char c : family) {
+    hash ^= static_cast<unsigned char>(std::tolower(c));
+    hash *= 1099511628211ULL;
+  }
+  return hash;
 }
 
 bool ResourceDiagnosticsEnabled() {
@@ -1093,6 +1127,7 @@ EditorShell::EditorShell(gui::EditorWindow& window, EditorShellOptions options)
       textures_(window.geodeDevice()),
       thumbnailTextures_(window.geodeDevice()),
       sampleThumbnailTextures_(window.geodeDevice()),
+      fontPreviewTextures_(window.geodeDevice()),
       toolbarIconTextures_(window.geodeDevice()),
       layerThumbnailRenderer_(window.geodeDevice()),
       fontCatalog_(),
@@ -2716,30 +2751,13 @@ FormatBarState EditorShell::computeFormatBarState() {
     ReadTextFormatState(selection.front(), &state);
   }
 
-  // The family picker lists the real font catalog (embedded curated Google
-  // Fonts, then macOS system fonts), grouped Embedded-then-System as
-  // `FontCatalog::families()` orders them. A menu entry previews in its own
-  // face only where the editor already has that face loaded as an ImGui font:
-  // the default UI face (Roboto) and the code face (Fira Code). Other families
-  // render their label in the default UI font, and the free-text box still
-  // round-trips any family the catalog lacks. Building preview faces for
-  // arbitrary catalog entries from `fontCatalog().loadFace()` bytes would need
-  // a mid-session ImGui atlas rebuild, out of scope for this bar.
-  ImFont* const regularFace =
-      ImGui::GetIO().Fonts->Fonts.empty() ? nullptr : ImGui::GetIO().Fonts->Fonts[0];
+  // Preview bitmaps are generated lazily by the existing low-priority render
+  // worker. This keeps the 180-plus desktop System group out of startup and
+  // avoids mutating ImGui's atlas after its backend texture has been uploaded.
   state.boldToggleFont = uiFontBold_;
-  state.families = BuildFormatBarFamilies(fontCatalog().families(),
-                                          [&](const svg::FontFamilyInfo& info) -> ImFont* {
-                                            if (StringUtils::Equals<StringComparison::IgnoreCase>(
-                                                    info.family, std::string_view("Roboto"))) {
-                                              return regularFace;
-                                            }
-                                            if (StringUtils::Equals<StringComparison::IgnoreCase>(
-                                                    info.family, std::string_view("Fira Code"))) {
-                                              return codeFont_;
-                                            }
-                                            return nullptr;
-                                          });
+  state.families = BuildFormatBarFamilies(
+      fontCatalog().families(),
+      [&](const svg::FontFamilyInfo& info) { return fontPreviewForFamily(info.family); });
   return state;
 }
 
@@ -4229,6 +4247,7 @@ void EditorShell::renderRenderPanePresentation(
                                                 static_cast<float>(formatBarRect->topLeft.y)),
                                          static_cast<float>(formatBarRect->width()));
       applyFormatBarActions(formatBarState, actions);
+      requestFontPreviews(actions.requestFontPreviews);
     }
     renderCanvasZoomControl();
     if (adaptiveUiLayout_.showCanvasScrollbars) {
@@ -4272,18 +4291,28 @@ void EditorShell::ensureSampleThumbnails() {
 
   if (std::optional<SampleThumbnailRenderResult> result =
           asyncRenderer.pollSampleThumbnailResult()) {
-    const std::size_t index = static_cast<std::size_t>(result->key);
-    if (index < samples.size()) {
+    if (result->kind == AuxiliaryPreviewKind::FontFamily && fontPreviewInFlight_.has_value() &&
+        result->key == FontPreviewKey(*fontPreviewInFlight_)) {
       if (result->outcome == SampleThumbnailRenderOutcome::Rendered && !result->bitmap.empty()) {
-        sampleThumbnailBitmaps_[index] = std::move(result->bitmap);
+        fontPreviewBitmaps_.insert_or_assign(*fontPreviewInFlight_, std::move(result->bitmap));
+      } else if (result->outcome != SampleThumbnailRenderOutcome::Cancelled) {
+        fontPreviewBitmaps_.insert_or_assign(*fontPreviewInFlight_, std::nullopt);
       }
-      if (result->outcome != SampleThumbnailRenderOutcome::Cancelled &&
-          index == sampleThumbnailGenerationCursor_) {
-        ++sampleThumbnailGenerationCursor_;
+      fontPreviewInFlight_.reset();
+    } else if (result->kind == AuxiliaryPreviewKind::Sample) {
+      const std::size_t index = static_cast<std::size_t>(result->key);
+      if (index < samples.size()) {
+        if (result->outcome == SampleThumbnailRenderOutcome::Rendered && !result->bitmap.empty()) {
+          sampleThumbnailBitmaps_[index] = std::move(result->bitmap);
+        }
+        if (result->outcome != SampleThumbnailRenderOutcome::Cancelled &&
+            index == sampleThumbnailGenerationCursor_) {
+          ++sampleThumbnailGenerationCursor_;
+        }
       }
-    }
-    if (sampleThumbnailInFlightIndex_ == index) {
-      sampleThumbnailInFlightIndex_.reset();
+      if (sampleThumbnailInFlightIndex_ == index) {
+        sampleThumbnailInFlightIndex_.reset();
+      }
     }
   }
 
@@ -4327,6 +4356,84 @@ void EditorShell::cancelSampleThumbnailGeneration() {
   renderCoordinator_.asyncRenderer().cancelSampleThumbnailWork();
   sampleThumbnailInFlightIndex_.reset();
   sampleThumbnailRetryPending_ = false;
+  if (fontPreviewInFlight_.has_value()) {
+    pendingFontPreviews_.push_front(std::move(*fontPreviewInFlight_));
+    fontPreviewInFlight_.reset();
+  }
+}
+
+void EditorShell::requestFontPreviews(const std::vector<std::string>& families) {
+  bool queued = false;
+  for (const std::string& family : families) {
+    if (!fontCatalog_.hasFamily(family) || fontPreviewBitmaps_.contains(family) ||
+        fontPreviewInFlight_ == family ||
+        std::ranges::find(pendingFontPreviews_, family) != pendingFontPreviews_.end()) {
+      continue;
+    }
+    pendingFontPreviews_.push_back(family);
+    queued = true;
+  }
+  if (queued) {
+    window_.wakeEventLoop();
+  }
+}
+
+void EditorShell::advanceFontPreviewGeneration() {
+  AsyncRenderer& asyncRenderer = renderCoordinator_.asyncRenderer();
+  if (std::optional<SampleThumbnailRenderResult> result =
+          asyncRenderer.pollSampleThumbnailResult()) {
+    if (result->kind == AuxiliaryPreviewKind::FontFamily && fontPreviewInFlight_.has_value() &&
+        result->key == FontPreviewKey(*fontPreviewInFlight_)) {
+      if (result->outcome == SampleThumbnailRenderOutcome::Rendered && !result->bitmap.empty()) {
+        fontPreviewBitmaps_.insert_or_assign(*fontPreviewInFlight_, std::move(result->bitmap));
+      } else if (result->outcome != SampleThumbnailRenderOutcome::Cancelled) {
+        // Remember terminal failures so an unsupported face does not spin the
+        // event loop every time its row becomes visible.
+        fontPreviewBitmaps_.insert_or_assign(*fontPreviewInFlight_, std::nullopt);
+      }
+    }
+    fontPreviewInFlight_.reset();
+  }
+
+  if (fontPreviewInFlight_.has_value() || pendingFontPreviews_.empty() || asyncRenderer.isBusy()) {
+    return;
+  }
+
+  std::string family = std::move(pendingFontPreviews_.front());
+  pendingFontPreviews_.pop_front();
+  const double displayScale = window_.displayScale();
+  SampleThumbnailRenderRequest request{
+      .kind = AuxiliaryPreviewKind::FontFamily,
+      .key = FontPreviewKey(family),
+      .source = FontPreviewSvg(family),
+      .dimensions =
+          Vector2i(std::max(1, static_cast<int>(std::ceil(kFontPreviewWidth * displayScale))),
+                   std::max(1, static_cast<int>(std::ceil(kFontPreviewHeight * displayScale)))),
+  };
+#ifndef __EMSCRIPTEN__
+  request.nativeRenderer = &renderCoordinator_.renderer();
+#endif
+  if (asyncRenderer.requestSampleThumbnail(std::move(request))) {
+    fontPreviewInFlight_ = std::move(family);
+  } else {
+    pendingFontPreviews_.push_front(std::move(family));
+  }
+}
+
+FormatBarFontPreview EditorShell::fontPreviewForFamily(std::string_view family) {
+  const auto it = fontPreviewBitmaps_.find(std::string(family));
+  if (it == fontPreviewBitmaps_.end() || !it->second.has_value()) {
+    return {};
+  }
+  const GlTextureCache::ThumbnailTextureView uploaded =
+      fontPreviewTextures_.uploadThumbnail(FontPreviewKey(family), *it->second);
+  return FormatBarFontPreview{
+      .texture = static_cast<std::uint64_t>(uploaded.texture),
+      .uvMaxX = static_cast<float>(uploaded.uvBottomRight.x),
+      .uvMaxY = static_cast<float>(uploaded.uvBottomRight.y),
+      .width = static_cast<float>(kFontPreviewWidth),
+      .height = static_cast<float>(kFontPreviewHeight),
+  };
 }
 
 void EditorShell::renderSamplePicker(const ImVec2& paneOrigin, const ImVec2& contentRegion) {
@@ -6687,6 +6794,9 @@ void EditorShell::runFrame() {
   contentOnlyCaptureForNextFrame_ = false;
   textures_.advancePresentationFrame();
   compositorDebugPanel_.advancePresentationFrame();
+  if (!showSamplePicker_) {
+    advanceFontPreviewGeneration();
+  }
   snapshotReproFrame();
   const float frameDeltaMs = ImGui::GetIO().DeltaTime * 1000.0f;
   interactionController_.noteFrameDelta(frameDeltaMs);

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -9,6 +9,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 #include "donner/editor/CanvasScrollbars.h"
@@ -442,6 +443,9 @@ private:
   void renderSidebars();
   void ensureSampleThumbnails();
   void cancelSampleThumbnailGeneration();
+  void requestFontPreviews(const std::vector<std::string>& families);
+  void advanceFontPreviewGeneration();
+  [[nodiscard]] FormatBarFontPreview fontPreviewForFamily(std::string_view family);
   void renderSamplePicker(const ImVec2& paneOrigin, const ImVec2& contentRegion);
   void renderSourcePaneSplitter(float windowWidth, float paneOriginY, float paneHeight,
                                 float sourcePaneWidth);
@@ -560,6 +564,9 @@ private:
   /// Dedicated cache for the bounded welcome catalog. It is intentionally
   /// separate from row thumbnails, whose retention sweep follows live layers.
   GlTextureCache sampleThumbnailTextures_;
+  /// Lazily rendered family-name previews. Only visible dropdown rows enter
+  /// this dedicated cache, so desktop system-font enumeration stays cheap.
+  GlTextureCache fontPreviewTextures_;
   /// Toolbar tool-icon texture cache. Holds the Donner-rendered white-mask
   /// bitmaps for the palette icons, keyed by a stable per-icon id. Never
   /// retention-swept (unlike `thumbnailTextures_`), so the four icons upload
@@ -579,6 +586,9 @@ private:
   /// still initializing. Nothing else wakes the on-demand loop for that, so the
   /// picker arms its own short idle retry. @see nextIdleWakeSeconds
   bool sampleThumbnailRetryPending_ = false;
+  std::unordered_map<std::string, std::optional<svg::RendererBitmap>> fontPreviewBitmaps_;
+  std::deque<std::string> pendingFontPreviews_;
+  std::optional<std::string> fontPreviewInFlight_;
   /// Embedded + system font catalog. It is declared before the render coordinator so it outlives
   /// every worker-side FontManager and offscreen renderer during reverse-order destruction.
   svg::FontCatalog fontCatalog_;

--- a/donner/editor/TextFormatBarPresenter.cc
+++ b/donner/editor/TextFormatBarPresenter.cc
@@ -130,7 +130,7 @@ bool ApplyFormatBarActionsToSelection(const FormatBarActions& actions, const For
 
 std::vector<FormatBarFontFamily> BuildFormatBarFamilies(
     const std::vector<svg::FontFamilyInfo>& catalogFamilies,
-    const std::function<ImFont*(const svg::FontFamilyInfo&)>& previewForFamily) {
+    const std::function<FormatBarFontPreview(const svg::FontFamilyInfo&)>& previewForFamily) {
   std::vector<FormatBarFontFamily> families;
   families.reserve(catalogFamilies.size());
   // Preserve the catalog's ordering (Embedded group first, then System, sorted
@@ -139,7 +139,7 @@ std::vector<FormatBarFontFamily> BuildFormatBarFamilies(
   for (const svg::FontFamilyInfo& info : catalogFamilies) {
     families.push_back(FormatBarFontFamily{
         .name = info.family,
-        .previewFont = previewForFamily ? previewForFamily(info) : nullptr,
+        .preview = previewForFamily ? previewForFamily(info) : FormatBarFontPreview{},
         .source = info.source,
     });
   }
@@ -222,14 +222,32 @@ FormatBarActions TextFormatBarPresenter::render(const FormatBarState& state, con
           shownGroup = family.source;
         }
         const bool selected = family.name == state.fontFamily;
-        // Preview each family in its own face where the editor has one loaded.
-        if (family.previewFont != nullptr) {
-          ImGui::PushFont(family.previewFont);
+        ImGui::PushID(family.name.c_str());
+        const float rowHeight = std::max(ImGui::GetTextLineHeight(), family.preview.height);
+        const bool chosen = ImGui::Selectable("##font_family", selected, ImGuiSelectableFlags_None,
+                                              ImVec2(0.0f, rowHeight));
+        const ImVec2 rowMin = ImGui::GetItemRectMin();
+        const ImVec2 rowMax = ImGui::GetItemRectMax();
+        if (family.preview.available()) {
+          const float renderedWidth = std::min(family.preview.width, rowMax.x - rowMin.x);
+          const float renderedHeight = std::min(family.preview.height, rowMax.y - rowMin.y);
+          const ImVec2 previewMin(rowMin.x,
+                                  rowMin.y + (rowMax.y - rowMin.y - renderedHeight) * 0.5f);
+          const ImVec2 previewMax(previewMin.x + renderedWidth, previewMin.y + renderedHeight);
+          ImGui::GetWindowDrawList()->AddImage(static_cast<ImTextureID>(family.preview.texture),
+                                               previewMin, previewMax, ImVec2(0.0f, 0.0f),
+                                               ImVec2(family.preview.uvMaxX, family.preview.uvMaxY),
+                                               ImGui::GetColorU32(ImGuiCol_Text));
+        } else {
+          ImGui::GetWindowDrawList()->AddText(
+              ImVec2(rowMin.x,
+                     rowMin.y + (rowMax.y - rowMin.y - ImGui::GetTextLineHeight()) * 0.5f),
+              ImGui::GetColorU32(ImGuiCol_Text), family.name.c_str());
+          if (ImGui::IsItemVisible()) {
+            actions.requestFontPreviews.push_back(family.name);
+          }
         }
-        const bool chosen = ImGui::Selectable(family.name.c_str(), selected);
-        if (family.previewFont != nullptr) {
-          ImGui::PopFont();
-        }
+        ImGui::PopID();
         if (chosen) {
           actions.setFontFamily = true;
           actions.fontFamily = family.name;

--- a/donner/editor/TextFormatBarPresenter.h
+++ b/donner/editor/TextFormatBarPresenter.h
@@ -18,6 +18,7 @@
 /// bar is a second surface over those commands, not a new styling pipeline.
 
 #include <array>
+#include <cstdint>
 #include <functional>
 #include <string>
 #include <vector>
@@ -32,14 +33,27 @@ namespace donner::editor {
 
 class EditorApp;
 
+/// Donner-rendered family-name preview uploaded for one dropdown row.
+struct FormatBarFontPreview {
+  /// Backend texture handle represented without importing ImGui into this header.
+  std::uint64_t texture = 0;
+  /// Bottom-right UV for texture allocations larger than the preview payload.
+  float uvMaxX = 1.0f;
+  float uvMaxY = 1.0f;
+  /// Logical row size used when the raster payload was produced.
+  float width = 0.0f;
+  float height = 0.0f;
+
+  [[nodiscard]] bool available() const { return texture != 0 && width > 0.0f && height > 0.0f; }
+};
+
 /// One selectable font family in the format bar's family picker.
 struct FormatBarFontFamily {
   /// CSS family name written to the document (e.g. "Roboto", "sans-serif").
   std::string name;
-  /// Face used to preview this family's menu entry, or null to fall back to the
-  /// default UI font. Lets each family render in its own face when the editor
-  /// has it loaded (the embedded Roboto and Fira Code faces today).
-  ImFont* previewFont = nullptr;
+  /// Donner-rendered label in this family's own face. An unavailable preview
+  /// falls back to UI text while the bounded worker request is in flight.
+  FormatBarFontPreview preview;
   /// Origin of this family in the catalog. The picker lists the Embedded group
   /// before the System group and shows a header at each group boundary.
   svg::FontSource source = svg::FontSource::Embedded;
@@ -48,13 +62,13 @@ struct FormatBarFontFamily {
 /// Build the picker's family list from a catalog listing (see
 /// `FontCatalog::families()`, which already orders Embedded before System and
 /// sorts within each group). Each entry keeps its CSS family name and source;
-/// `previewFont` is filled from @p previewForFamily for families the editor has
-/// a loaded face for, and left null otherwise (the entry then renders in the
-/// default UI font). Families the catalog lacks are still reachable through the
-/// bar's free-text box, so this list is additive, not a whitelist.
+/// `preview` is filled from @p previewForFamily for families already rendered
+/// by the bounded preview worker. Families the catalog lacks are still
+/// reachable through the bar's free-text box, so this list is additive, not a
+/// whitelist.
 [[nodiscard]] std::vector<FormatBarFontFamily> BuildFormatBarFamilies(
     const std::vector<svg::FontFamilyInfo>& catalogFamilies,
-    const std::function<ImFont*(const svg::FontFamilyInfo&)>& previewForFamily);
+    const std::function<FormatBarFontPreview(const svg::FontFamilyInfo&)>& previewForFamily);
 
 /// Snapshot of the current text formatting context, driving the bar's controls.
 ///
@@ -96,6 +110,8 @@ struct FormatBarActions {
   bool toggleBold = false;
   bool toggleItalic = false;
   bool toggleUnderline = false;
+  /// Visible dropdown rows whose family-name previews are not cached yet.
+  std::vector<std::string> requestFontPreviews;
 };
 
 /// Common font-size presets offered by the size combo (document units).

--- a/donner/editor/TextFormatBarPresenter.h
+++ b/donner/editor/TextFormatBarPresenter.h
@@ -59,13 +59,18 @@ struct FormatBarFontFamily {
   svg::FontSource source = svg::FontSource::Embedded;
 };
 
-/// Build the picker's family list from a catalog listing (see
-/// `FontCatalog::families()`, which already orders Embedded before System and
-/// sorts within each group). Each entry keeps its CSS family name and source;
-/// `preview` is filled from @p previewForFamily for families already rendered
-/// by the bounded preview worker. Families the catalog lacks are still
-/// reachable through the bar's free-text box, so this list is additive, not a
-/// whitelist.
+/**
+ * Build the picker's family list from a catalog listing.
+ *
+ * `FontCatalog::families()` already orders Embedded before System and sorts within each group.
+ * Each entry keeps its CSS family name and source; `preview` is filled for families already
+ * rendered by the bounded preview worker. Families the catalog lacks remain reachable through the
+ * free-text box, so this list is additive rather than a whitelist.
+ *
+ * @param catalogFamilies Ordered font families available to the picker.
+ * @param previewForFamily Returns a rendered preview when one is ready for a family.
+ * @return Picker entries preserving catalog order, source, and available previews.
+ */
 [[nodiscard]] std::vector<FormatBarFontFamily> BuildFormatBarFamilies(
     const std::vector<svg::FontFamilyInfo>& catalogFamilies,
     const std::function<FormatBarFontPreview(const svg::FontFamilyInfo&)>& previewForFamily);

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -812,8 +812,20 @@ public:
   static TextEditor& Source(EditorShell& shell) { return shell.textEditor_; }
   static const TextEditor& Source(const EditorShell& shell) { return shell.textEditor_; }
 
-  static FormatBarState ComputeFormatBarState(EditorShell& shell) {
-    return shell.computeFormatBarState();
+  static void RequestFontPreviews(EditorShell& shell, std::vector<std::string> families) {
+    shell.requestFontPreviews(families);
+  }
+
+  static void AdvanceFontPreviewGeneration(EditorShell& shell) {
+    shell.advanceFontPreviewGeneration();
+  }
+
+  static FormatBarFontPreview FontPreviewForFamily(EditorShell& shell, std::string_view family) {
+    return shell.fontPreviewForFamily(family);
+  }
+
+  static std::size_t CachedFontPreviewCount(const EditorShell& shell) {
+    return shell.fontPreviewBitmaps_.size();
   }
 
   static bool TryOpenPath(EditorShell& shell, std::string_view path, std::string* error) {
@@ -3189,26 +3201,30 @@ TEST(EditorShellTest, ShellGeometryHelpersClampToViewportAndSelectionCache) {
   EXPECT_FLOAT_EQ(compactPalette.width(), 156.0f);
 }
 
-TEST(EditorShellTest, TextFormatBarPreviewsEveryCatalogFamilyInItsOwnFace) {
+TEST(EditorShellTest, TextFormatBarLazilyRendersCatalogFamilyInItsOwnFace) {
   gui::EditorWindow window = MakeHiddenWindow();
   if (!window.valid()) {
     GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
   }
 
-  EditorShell shell(window, OptionsWithSource(R"(<svg xmlns="http://www.w3.org/2000/svg">
-    <text id="target" x="10" y="30">Preview</text>
-  </svg>)"));
+  EditorShell shell(window, OptionsWithSource(R"(<svg xmlns="http://www.w3.org/2000/svg"/>)"));
   ASSERT_TRUE(shell.valid());
-  auto target = EditorShellTestAccess::App(shell).document().document().querySelector("#target");
-  ASSERT_TRUE(target.has_value());
-  EditorShellTestAccess::App(shell).setSelection(*target);
+  EXPECT_EQ(EditorShellTestAccess::CachedFontPreviewCount(shell), 0u)
+      << "Constructing the editor must not eagerly materialize the desktop font catalog";
 
-  const FormatBarState state = EditorShellTestAccess::ComputeFormatBarState(shell);
-  ASSERT_TRUE(state.visible);
-  ASSERT_EQ(state.families.size(), shell.fontCatalog().families().size());
-  for (const FormatBarFontFamily& family : state.families) {
-    EXPECT_NE(family.previewFont, nullptr) << family.name;
+  EditorShellTestAccess::RequestFontPreviews(shell, {"Bebas Neue"});
+  FormatBarFontPreview preview;
+  for (int attempt = 0; attempt < 500 && !preview.available(); ++attempt) {
+    EditorShellTestAccess::AdvanceFontPreviewGeneration(shell);
+    preview = EditorShellTestAccess::FontPreviewForFamily(shell, "Bebas Neue");
+    if (!preview.available()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
   }
+  EXPECT_TRUE(preview.available());
+  EXPECT_EQ(EditorShellTestAccess::CachedFontPreviewCount(shell), 1u);
+  EXPECT_EQ(preview.width, 196.0f);
+  EXPECT_EQ(preview.height, 24.0f);
 }
 
 TEST(EditorShellTest, PrivateUiRenderHelpersCoverPaneToolbarAndPanelStates) {

--- a/donner/editor/tests/EditorShell_tests.cc
+++ b/donner/editor/tests/EditorShell_tests.cc
@@ -812,6 +812,10 @@ public:
   static TextEditor& Source(EditorShell& shell) { return shell.textEditor_; }
   static const TextEditor& Source(const EditorShell& shell) { return shell.textEditor_; }
 
+  static FormatBarState ComputeFormatBarState(EditorShell& shell) {
+    return shell.computeFormatBarState();
+  }
+
   static bool TryOpenPath(EditorShell& shell, std::string_view path, std::string* error) {
     return shell.tryOpenPath(path, error);
   }
@@ -3183,6 +3187,28 @@ TEST(EditorShellTest, ShellGeometryHelpersClampToViewportAndSelectionCache) {
       ImVec2(844.0f, 390.0f - compactLandscape.topBarHeight));
   EXPECT_LE(compactPalette.bottomRight.x, compactLandscape.panelX);
   EXPECT_FLOAT_EQ(compactPalette.width(), 156.0f);
+}
+
+TEST(EditorShellTest, TextFormatBarPreviewsEveryCatalogFamilyInItsOwnFace) {
+  gui::EditorWindow window = MakeHiddenWindow();
+  if (!window.valid()) {
+    GTEST_SKIP() << "GL-backed hidden editor window is unavailable on this host";
+  }
+
+  EditorShell shell(window, OptionsWithSource(R"(<svg xmlns="http://www.w3.org/2000/svg">
+    <text id="target" x="10" y="30">Preview</text>
+  </svg>)"));
+  ASSERT_TRUE(shell.valid());
+  auto target = EditorShellTestAccess::App(shell).document().document().querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  EditorShellTestAccess::App(shell).setSelection(*target);
+
+  const FormatBarState state = EditorShellTestAccess::ComputeFormatBarState(shell);
+  ASSERT_TRUE(state.visible);
+  ASSERT_EQ(state.families.size(), shell.fontCatalog().families().size());
+  for (const FormatBarFontFamily& family : state.families) {
+    EXPECT_NE(family.previewFont, nullptr) << family.name;
+  }
 }
 
 TEST(EditorShellTest, PrivateUiRenderHelpersCoverPaneToolbarAndPanelStates) {

--- a/donner/editor/tests/TextFormatBarPresenter_tests.cc
+++ b/donner/editor/tests/TextFormatBarPresenter_tests.cc
@@ -288,10 +288,16 @@ TEST(TextFormatBarPresenterActionsTest, NoActionsQueueNoMutation) {
 // ---------------------------------------------------------------------------
 
 TEST(TextFormatBarPresenterActionsTest, BuildFormatBarFamiliesGroupsEmbeddedThenSystem) {
-  // Distinct sentinel pointers stand in for loaded ImGui faces; the builder only
-  // stores them, never dereferences them.
-  ImFont* const robotoFace = reinterpret_cast<ImFont*>(0x10);
-  ImFont* const codeFace = reinterpret_cast<ImFont*>(0x20);
+  const FormatBarFontPreview robotoPreview{
+      .texture = 0x10,
+      .width = 100.0f,
+      .height = 20.0f,
+  };
+  const FormatBarFontPreview codePreview{
+      .texture = 0x20,
+      .width = 100.0f,
+      .height = 20.0f,
+  };
 
   // Mirror FontCatalog::families(): the Embedded group first, then System, each
   // already sorted within its group.
@@ -302,14 +308,14 @@ TEST(TextFormatBarPresenterActionsTest, BuildFormatBarFamiliesGroupsEmbeddedThen
   };
 
   const std::vector<FormatBarFontFamily> built =
-      BuildFormatBarFamilies(catalog, [&](const svg::FontFamilyInfo& info) -> ImFont* {
+      BuildFormatBarFamilies(catalog, [&](const svg::FontFamilyInfo& info) {
         if (info.family == "Roboto") {
-          return robotoFace;
+          return robotoPreview;
         }
         if (info.family == "Fira Code") {
-          return codeFace;
+          return codePreview;
         }
-        return nullptr;
+        return FormatBarFontPreview{};
       });
 
   ASSERT_EQ(built.size(), 3u);
@@ -317,14 +323,14 @@ TEST(TextFormatBarPresenterActionsTest, BuildFormatBarFamiliesGroupsEmbeddedThen
   // the right rows.
   EXPECT_EQ(built[0].name, "Fira Code");
   EXPECT_EQ(built[0].source, svg::FontSource::Embedded);
-  EXPECT_EQ(built[0].previewFont, codeFace);
+  EXPECT_EQ(built[0].preview.texture, codePreview.texture);
   EXPECT_EQ(built[1].name, "Roboto");
   EXPECT_EQ(built[1].source, svg::FontSource::Embedded);
-  EXPECT_EQ(built[1].previewFont, robotoFace);
+  EXPECT_EQ(built[1].preview.texture, robotoPreview.texture);
   EXPECT_EQ(built[2].name, "Helvetica");
   EXPECT_EQ(built[2].source, svg::FontSource::System);
   // A System family with no loaded face previews in the default UI font (null).
-  EXPECT_EQ(built[2].previewFont, nullptr);
+  EXPECT_FALSE(built[2].preview.available());
 }
 
 TEST(TextFormatBarPresenterActionsTest, BuildFormatBarFamiliesToleratesNullPreviewResolver) {
@@ -334,7 +340,7 @@ TEST(TextFormatBarPresenterActionsTest, BuildFormatBarFamiliesToleratesNullPrevi
   const std::vector<FormatBarFontFamily> built = BuildFormatBarFamilies(catalog, {});
   ASSERT_EQ(built.size(), 1u);
   EXPECT_EQ(built[0].name, "Roboto");
-  EXPECT_EQ(built[0].previewFont, nullptr);
+  EXPECT_FALSE(built[0].preview.available());
 }
 
 // ---------------------------------------------------------------------------
@@ -399,7 +405,10 @@ TEST_F(TextFormatBarPresenterTest, VisibleBarRendersControlsWithoutImplicitActio
   state.hasFontSize = true;
   state.bold = true;
   state.boldToggleFont = face;
-  state.families = {FormatBarFontFamily{"Roboto", face}, FormatBarFontFamily{"serif", nullptr}};
+  state.families = {
+      FormatBarFontFamily{.name = "Roboto"},
+      FormatBarFontFamily{.name = "serif"},
+  };
 
   // Two frames: the first seeds internal buffers, the second exercises the
   // steady state. Neither involves user input, so no actions should fire.
@@ -429,6 +438,9 @@ void MergeActions(FormatBarActions& merged, const FormatBarActions& frame) {
   merged.toggleBold = merged.toggleBold || frame.toggleBold;
   merged.toggleItalic = merged.toggleItalic || frame.toggleItalic;
   merged.toggleUnderline = merged.toggleUnderline || frame.toggleUnderline;
+  merged.requestFontPreviews.insert(merged.requestFontPreviews.end(),
+                                    frame.requestFontPreviews.begin(),
+                                    frame.requestFontPreviews.end());
 }
 
 class TextFormatBarPresenterInputTest : public ::testing::Test {
@@ -469,9 +481,9 @@ protected:
     // Two Embedded families followed by one System family: the picker prints
     // one header per group and no header between same-group rows.
     state.families = {
-        FormatBarFontFamily{"Roboto", face, svg::FontSource::Embedded},
-        FormatBarFontFamily{"Fira Code", face, svg::FontSource::Embedded},
-        FormatBarFontFamily{"Zilla Slab", nullptr, svg::FontSource::System},
+        FormatBarFontFamily{.name = "Roboto", .source = svg::FontSource::Embedded},
+        FormatBarFontFamily{.name = "Fira Code", .source = svg::FontSource::Embedded},
+        FormatBarFontFamily{.name = "Zilla Slab", .source = svg::FontSource::System},
     };
     return state;
   }
@@ -614,6 +626,16 @@ TEST_F(TextFormatBarPresenterInputTest, ControlsRemainClickableAfterCanvasTakesF
 
   const FormatBarActions actions = ClickOverCanvas(state, ToggleCenter(BoldLeft()));
   EXPECT_TRUE(actions.toggleBold);
+}
+
+TEST_F(TextFormatBarPresenterInputTest, OpenFamilyMenuRequestsVisibleMissingPreviews) {
+  const FormatBarState state = MakeState();
+  Frame(state);
+  OpenComboPopup(state, ToggleCenter(FamilyArrowLeft()));
+
+  const FormatBarActions actions = Frame(state);
+  EXPECT_EQ(actions.requestFontPreviews,
+            (std::vector<std::string>{"Roboto", "Fira Code", "Zilla Slab"}));
 }
 
 TEST_F(TextFormatBarPresenterInputTest, DraggingSizeControlCommitsNewFontSize) {

--- a/donner/svg/BUILD.bazel
+++ b/donner/svg/BUILD.bazel
@@ -176,6 +176,7 @@ donner_cc_library(
         ":svg_document_handle",
         "//donner/svg/components",
         "//donner/svg/components/animation:components",
+        "//donner/svg/components/text:text_invalidation",
         "//donner/svg/core",
         "//donner/svg/parser:parser_core",
         "//donner/svg/properties",

--- a/donner/svg/SVGDocument.cc
+++ b/donner/svg/SVGDocument.cc
@@ -26,8 +26,8 @@
 #include "donner/svg/components/paint/ClipPathComponent.h"
 #include "donner/svg/components/resources/ResourceManagerContext.h"
 #include "donner/svg/components/style/ComputedStyleComponent.h"
-#include "donner/svg/components/text/ComputedTextGeometryComponent.h"
 #include "donner/svg/components/text/TextComponent.h"
+#include "donner/svg/components/text/TextInvalidation.h"
 #include "donner/svg/components/text/TextPositioningComponent.h"
 #include "donner/svg/components/text/TextRootComponent.h"
 #include "donner/svg/renderer/RenderingContext.h"
@@ -50,27 +50,6 @@ SourceRange MutationRange(std::string_view source, const xml::XMLMutation& mutat
 
   return mutation.node.getNodeLocation().value_or(
       SourceRange{FileOffset::Offset(0), FileOffset::Offset(0)});
-}
-
-void InvalidateTextGeometry(EntityHandle handle) {
-  Registry& registry = *handle.registry();
-  Entity current = handle.entity();
-  while (current != entt::null) {
-    if (registry.any_of<components::TextRootComponent>(current)) {
-      registry.remove<components::ComputedTextGeometryComponent>(current);
-      registry.get_or_emplace<components::DirtyFlagsComponent>(current).mark(
-          components::DirtyFlagsComponent::TextGeometry |
-          components::DirtyFlagsComponent::RenderInstance);
-      return;
-    }
-
-    const auto* tree = registry.try_get<donner::components::TreeComponent>(current);
-    if (tree == nullptr) {
-      return;
-    }
-
-    current = tree->parent();
-  }
 }
 
 std::optional<EntityHandle> TextElementHandleForNodeValueMutation(
@@ -116,7 +95,7 @@ std::optional<ParseDiagnostic> ApplyNodeValueChanged(std::string_view source,
     text.text = *mutation.value;
     text.textChunks.clear();
     text.textChunks.emplace_back(*mutation.value);
-    InvalidateTextGeometry(*targetHandle);
+    (void)components::InvalidateTextLayout(*targetHandle);
     return std::nullopt;
   }
 

--- a/donner/svg/SVGElement.cc
+++ b/donner/svg/SVGElement.cc
@@ -24,6 +24,8 @@
 #include "donner/svg/components/style/ComputedStyleComponent.h"
 #include "donner/svg/components/style/StyleComponent.h"
 #include "donner/svg/components/style/StyleSystem.h"
+#include "donner/svg/components/text/TextInvalidation.h"
+#include "donner/svg/components/text/TextRootComponent.h"
 #include "donner/svg/properties/PresentationAttributeParsing.h"
 
 namespace donner::svg {
@@ -33,6 +35,19 @@ namespace {
 /// Mark an entity with dirty flags for incremental invalidation.
 void markDirty(EntityHandle handle, uint16_t flags) {
   handle.get_or_emplace<components::DirtyFlagsComponent>().mark(flags);
+}
+
+/**
+ * Mark a style-cascade change on \p handle, plus any \p extraFlags.
+ *
+ * Text layout is memoized per text root in \ref components::ComputedTextGeometryComponent and both
+ * renderers draw straight out of it, so a style change inside a text subtree has to drop it. The
+ * font properties (`font-family`, `font-size`, `font-weight`, `letter-spacing`, ...) are exactly
+ * the ones an editor writes, and without this every one of them is a silent no-op.
+ */
+void markStyleCascadeDirty(EntityHandle handle, uint16_t extraFlags = 0) {
+  markDirty(handle, components::DirtyFlagsComponent::StyleCascade | extraFlags);
+  (void)components::InvalidateTextLayout(handle);
 }
 
 void invalidateComputedStyle(EntityHandle handle) {
@@ -53,7 +68,7 @@ void markNeedsFullStyleRecompute(EntityHandle handle) {
 
 void markConditionalProcessingChanged(EntityHandle handle) {
   markNeedsFullStyleRecompute(handle);
-  markDirty(handle, components::DirtyFlagsComponent::StyleCascade);
+  markStyleCascadeDirty(handle);
 }
 
 void invalidateComputedStyleForDescendants(EntityHandle handle) {
@@ -77,6 +92,11 @@ void propagateStyleDirtyToDescendants(EntityHandle handle) {
           markDirty(desc, components::DirtyFlagsComponent::Style |
                               components::DirtyFlagsComponent::Paint |
                               components::DirtyFlagsComponent::RenderInstance);
+          // The font properties inherit, so a style change on an ancestor restyles every text
+          // root beneath it. Match on the root itself to keep this O(1) per descendant.
+          if (desc.all_of<components::TextRootComponent>()) {
+            (void)components::InvalidateTextLayout(desc);
+          }
         });
   }
 }
@@ -402,7 +422,7 @@ void SVGElement::setClassName(std::string_view name) {
   markNeedsFullStyleRecompute(handle_);
   invalidateComputedStyle(handle_);
   invalidateComputedStyleForDescendants(handle_);
-  markDirty(handle_, components::DirtyFlagsComponent::StyleCascade);
+  markStyleCascadeDirty(handle_);
   propagateStyleDirtyToDescendants(handle_);
 }
 
@@ -418,7 +438,7 @@ void SVGElement::setStyle(std::string_view style) {
   markNeedsFullStyleRecompute(handle_);
   invalidateComputedStyleForDescendants(handle_);
 
-  markDirty(handle_, components::DirtyFlagsComponent::StyleCascade);
+  markStyleCascadeDirty(handle_);
   propagateStyleDirtyToDescendants(handle_);
 }
 
@@ -434,7 +454,7 @@ void SVGElement::updateStyle(std::string_view style) {
   invalidateComputedStyle(handle_);
   invalidateComputedStyleForDescendants(handle_);
 
-  markDirty(handle_, components::DirtyFlagsComponent::StyleCascade);
+  markStyleCascadeDirty(handle_);
   propagateStyleDirtyToDescendants(handle_);
 }
 
@@ -499,8 +519,7 @@ ParseResult<bool> SVGElement::trySetPresentationAttribute(std::string_view name,
       // (cx, cy, r, d, etc.), mark style cascade + shape dirty.
       markNeedsFullStyleRecompute(handle_);
       invalidateComputedStyle(handle_);
-      markDirty(handle_, components::DirtyFlagsComponent::StyleCascade |
-                             components::DirtyFlagsComponent::Shape);
+      markStyleCascadeDirty(handle_, components::DirtyFlagsComponent::Shape);
       if (PropertyRegistry::isPresentationAttributeInherited(actualName)) {
         invalidateComputedStyleForDescendants(handle_);
         propagateStyleDirtyToDescendants(handle_);

--- a/donner/svg/SVGTextContentElement.cc
+++ b/donner/svg/SVGTextContentElement.cc
@@ -2,11 +2,8 @@
 
 #include "donner/base/ParseWarningSink.h"
 #include "donner/base/Vector2.h"
-#include "donner/base/xml/components/TreeComponent.h"
-#include "donner/svg/components/DirtyFlagsComponent.h"
-#include "donner/svg/components/text/ComputedTextGeometryComponent.h"
 #include "donner/svg/components/text/TextComponent.h"
-#include "donner/svg/components/text/TextRootComponent.h"
+#include "donner/svg/components/text/TextInvalidation.h"
 #include "donner/svg/text/TextEngine.h"
 
 namespace donner::svg {
@@ -36,23 +33,7 @@ SVGTextContentElement::SVGTextContentElement(EntityHandle handle) : SVGGraphicsE
 
 void SVGTextContentElement::invalidateTextGeometry() {
   [[maybe_unused]] DocumentWriteAccess access = handle_.writeAccess();
-  // Walk up to the text root and remove cached text layout.
-  Registry& registry = *handle_.registry();
-  Entity current = handle_.entity();
-  while (current != entt::null) {
-    if (registry.any_of<components::TextRootComponent>(current)) {
-      registry.remove<components::ComputedTextGeometryComponent>(current);
-      registry.get_or_emplace<components::DirtyFlagsComponent>(current).mark(
-          components::DirtyFlagsComponent::TextGeometry |
-          components::DirtyFlagsComponent::RenderInstance);
-      return;
-    }
-    const auto* tree = registry.try_get<donner::components::TreeComponent>(current);
-    if (!tree) {
-      break;
-    }
-    current = tree->parent();
-  }
+  (void)components::InvalidateTextLayout(handle_);
 }
 
 std::vector<Path> SVGTextContentElement::computedGlyphPaths() const {

--- a/donner/svg/components/text/BUILD.bazel
+++ b/donner/svg/components/text/BUILD.bazel
@@ -23,6 +23,25 @@ cc_library(
 )
 
 cc_library(
+    name = "text_invalidation",
+    srcs = [
+        "TextInvalidation.cc",
+    ],
+    hdrs = [
+        "TextInvalidation.h",
+    ],
+    visibility = [
+        "//donner/svg:__subpackages__",
+    ],
+    deps = [
+        ":components",
+        "//donner/base",
+        "//donner/base/xml/components",
+        "//donner/svg/components:components_core",
+    ],
+)
+
+cc_library(
     name = "text_positioning_presentation",
     srcs = [
         "TextPositioningPresentation.cc",
@@ -35,6 +54,7 @@ cc_library(
     ],
     deps = [
         ":components",
+        ":text_invalidation",
         "//donner/base",
         "//donner/base/xml/components",
         "//donner/svg/components:components_core",

--- a/donner/svg/components/text/TextInvalidation.cc
+++ b/donner/svg/components/text/TextInvalidation.cc
@@ -1,0 +1,37 @@
+#include "donner/svg/components/text/TextInvalidation.h"
+
+#include "donner/base/xml/components/TreeComponent.h"
+#include "donner/svg/components/DirtyFlagsComponent.h"
+#include "donner/svg/components/text/ComputedTextGeometryComponent.h"
+#include "donner/svg/components/text/TextRootComponent.h"
+
+namespace donner::svg::components {
+
+Entity InvalidateTextLayout(EntityHandle handle) {
+  Registry& registry = *handle.registry();
+  // Documents without any text at all are the common case; skip the ancestor walk entirely.
+  if (registry.storage<TextRootComponent>().empty()) {
+    return entt::null;
+  }
+
+  Entity current = handle.entity();
+  while (current != entt::null) {
+    if (registry.all_of<TextRootComponent>(current)) {
+      registry.remove<ComputedTextGeometryComponent>(current);
+      registry.get_or_emplace<DirtyFlagsComponent>(current).mark(
+          DirtyFlagsComponent::TextGeometry | DirtyFlagsComponent::RenderInstance);
+      return current;
+    }
+
+    const auto* tree = registry.try_get<donner::components::TreeComponent>(current);
+    if (!tree) {
+      break;
+    }
+
+    current = tree->parent();
+  }
+
+  return entt::null;
+}
+
+}  // namespace donner::svg::components

--- a/donner/svg/components/text/TextInvalidation.h
+++ b/donner/svg/components/text/TextInvalidation.h
@@ -1,0 +1,25 @@
+#pragma once
+/// @file
+
+#include "donner/base/EcsRegistry.h"
+
+namespace donner::svg::components {
+
+/**
+ * Drop the cached text layout of the text root enclosing \p handle.
+ *
+ * \ref ComputedTextGeometryComponent is a memoized layout derived from the text root's computed
+ * style, text content, and positioning attributes. Both renderers draw straight out of it, so any
+ * mutation that can change one of those inputs must drop it or the old glyphs keep rendering.
+ *
+ * Walks up from \p handle until it finds the \ref TextRootComponent, so it is safe to call with a
+ * `<tspan>`, `<textPath>`, or the `<text>` root itself. Calling it on an entity outside any text
+ * subtree is a no-op.
+ *
+ * @param handle Element whose enclosing text root should be invalidated.
+ * @return The text root entity that was invalidated, or `entt::null` if \p handle is not inside a
+ *   text subtree.
+ */
+Entity InvalidateTextLayout(EntityHandle handle);
+
+}  // namespace donner::svg::components

--- a/donner/svg/components/text/TextPositioningPresentation.cc
+++ b/donner/svg/components/text/TextPositioningPresentation.cc
@@ -4,12 +4,9 @@
 
 #include "donner/base/parser/LengthParser.h"
 #include "donner/base/parser/NumberParser.h"
-#include "donner/base/xml/components/TreeComponent.h"
-#include "donner/svg/components/DirtyFlagsComponent.h"
 #include "donner/svg/components/text/ComputedTextComponent.h"
-#include "donner/svg/components/text/ComputedTextGeometryComponent.h"
+#include "donner/svg/components/text/TextInvalidation.h"
 #include "donner/svg/components/text/TextPositioningComponent.h"
-#include "donner/svg/components/text/TextRootComponent.h"
 #include "donner/svg/parser/ListParser.h"
 
 namespace donner::svg::components {
@@ -63,24 +60,12 @@ std::optional<SmallVector<double, 1>> ParseRotateList(std::string_view value) {
   return list;
 }
 
-/// Invalidate the enclosing text root's cached layout, mirroring
-/// `SVGTextContentElement::invalidateTextGeometry()`.
+/// Invalidate the enclosing text root's cached layout. Positioning attributes also feed
+/// \ref ComputedTextComponent (per-character x/y/dx/dy/rotate lists), so that is dropped too.
 void InvalidateTextRootLayout(EntityHandle handle) {
-  Registry& registry = *handle.registry();
-  Entity current = handle.entity();
-  while (current != entt::null) {
-    if (registry.any_of<TextRootComponent>(current)) {
-      registry.remove<ComputedTextGeometryComponent>(current);
-      registry.remove<ComputedTextComponent>(current);
-      registry.get_or_emplace<DirtyFlagsComponent>(current).mark(
-          DirtyFlagsComponent::TextGeometry | DirtyFlagsComponent::RenderInstance);
-      return;
-    }
-    const auto* tree = registry.try_get<donner::components::TreeComponent>(current);
-    if (!tree) {
-      break;
-    }
-    current = tree->parent();
+  const Entity textRoot = InvalidateTextLayout(handle);
+  if (textRoot != entt::null) {
+    handle.registry()->remove<ComputedTextComponent>(textRoot);
   }
 }
 

--- a/donner/svg/resources/BUILD.bazel
+++ b/donner/svg/resources/BUILD.bazel
@@ -221,6 +221,8 @@ donner_cc_test(
     deps = [
         ":font_catalog",
         ":font_catalog_types",
+        ":font_manager",
+        "//donner/svg/core",
         "@com_google_gtest//:gtest_main",
     ],
 )

--- a/donner/svg/resources/BUILD.bazel
+++ b/donner/svg/resources/BUILD.bazel
@@ -110,6 +110,7 @@ donner_cc_library(
         "//donner/editor:__subpackages__",
         "//donner/svg:__subpackages__",
     ],
+    deps = ["//donner/svg/core"],
 )
 
 donner_cc_library(
@@ -202,6 +203,7 @@ donner_cc_test(
         ":font_catalog_types",
         ":font_manager",
         "//donner/base/fonts:sfnt_utils",
+        "//donner/svg/core",
         "//third_party/public-sans",
         "@com_google_gtest//:gtest_main",
         "@stb//:truetype",

--- a/donner/svg/resources/BUILD.bazel
+++ b/donner/svg/resources/BUILD.bazel
@@ -124,6 +124,7 @@ donner_cc_library(
     visibility = [
         "//donner/editor:__subpackages__",
         "//donner/svg:__subpackages__",
+        "//tools/mcp-servers/editor-control:__pkg__",
     ],
     deps = [
         ":font_catalog_types",
@@ -172,6 +173,7 @@ donner_cc_library(
     visibility = [
         "//donner/editor:__subpackages__",
         "//donner/svg:__subpackages__",
+        "//tools/mcp-servers/editor-control:__pkg__",
     ],
     deps = [
         ":font_catalog_types",

--- a/donner/svg/resources/EmbeddedFontProvider.cc
+++ b/donner/svg/resources/EmbeddedFontProvider.cc
@@ -35,7 +35,8 @@ std::vector<FontFamilyInfo> EmbeddedFontProvider::families() const {
   std::vector<FontFamilyInfo> result;
   result.reserve(entries().size());
   for (const EmbeddedEntry& entry : entries()) {
-    result.push_back(FontFamilyInfo{std::string(entry.family), FontSource::Embedded, entry.category});
+    result.push_back(
+        FontFamilyInfo{std::string(entry.family), FontSource::Embedded, entry.category});
   }
   std::sort(result.begin(), result.end(),
             [](const FontFamilyInfo& a, const FontFamilyInfo& b) { return a.family < b.family; });
@@ -51,7 +52,8 @@ bool EmbeddedFontProvider::hasFamily(std::string_view family) const {
   return false;
 }
 
-std::vector<uint8_t> EmbeddedFontProvider::loadFamilyData(std::string_view family) const {
+std::vector<uint8_t> EmbeddedFontProvider::loadFamilyData(
+    std::string_view family, const FontFaceRequest& /*request*/) const {
   for (const EmbeddedEntry& entry : entries()) {
     if (StringUtils::Equals<StringComparison::IgnoreCase>(entry.family, family)) {
       return std::vector<uint8_t>(entry.data.begin(), entry.data.end());

--- a/donner/svg/resources/EmbeddedFontProvider.h
+++ b/donner/svg/resources/EmbeddedFontProvider.h
@@ -11,6 +11,11 @@ namespace donner::svg {
  * The family table is generated from `third_party/google_fonts/fonts.bzl` (see the
  * `DONNER_GF_ENTRY` x-macro include), so it always matches the fetched-and-embedded bytes. All
  * families report \ref FontSource::Embedded.
+ *
+ * Each family is a single file, so \ref loadFamilyData ignores the requested face: ten of the
+ * twelve curated families are variable fonts whose `wght` axis neither text backend instances, and
+ * the other two ship only a regular face. Bold and italic therefore render upright and regular for
+ * embedded families.
  */
 class EmbeddedFontProvider : public FontFamilyProvider {
 public:
@@ -18,7 +23,8 @@ public:
 
   std::vector<FontFamilyInfo> families() const override;
   bool hasFamily(std::string_view family) const override;
-  std::vector<uint8_t> loadFamilyData(std::string_view family) const override;
+  std::vector<uint8_t> loadFamilyData(std::string_view family,
+                                      const FontFaceRequest& request) const override;
 };
 
 }  // namespace donner::svg

--- a/donner/svg/resources/FontCatalog.cc
+++ b/donner/svg/resources/FontCatalog.cc
@@ -57,10 +57,11 @@ bool FontCatalog::hasFamily(std::string_view family) const {
   return false;
 }
 
-std::vector<uint8_t> FontCatalog::loadFamilyData(std::string_view family) const {
+std::vector<uint8_t> FontCatalog::loadFamilyData(std::string_view family,
+                                                 const FontFaceRequest& request) const {
   for (const auto& provider : providers_) {
     if (provider->hasFamily(family)) {
-      std::vector<uint8_t> data = provider->loadFamilyData(family);
+      std::vector<uint8_t> data = provider->loadFamilyData(family, request);
       if (!data.empty()) {
         return data;
       }

--- a/donner/svg/resources/FontCatalog.h
+++ b/donner/svg/resources/FontCatalog.h
@@ -14,8 +14,8 @@ namespace donner::svg {
  *
  * A default-constructed catalog contains an embedded provider (curated Google Fonts) followed by a
  * system provider (CoreText on macOS; a no-op stub elsewhere). Providers are consulted in order, so
- * resolution and `loadFace()` prefer **Embedded** families over **System** families, and `families()`
- * lists the Embedded group before the System group.
+ * resolution and `loadFace()` prefer **Embedded** families over **System** families, and
+ * `families()` lists the Embedded group before the System group.
  *
  * The catalog implements \ref FontFamilyProvider, so it can be installed directly on a \ref
  * FontManager (via `setFontProvider()` or `SetDefaultFontProvider()`).
@@ -61,15 +61,19 @@ public:
   std::optional<FontFamilyInfo> find(std::string_view family) const;
 
   /// Raw sfnt bytes for \p family from the first provider that has it (Embedded before System).
-  std::vector<uint8_t> loadFamilyData(std::string_view family) const override;
+  std::vector<uint8_t> loadFamilyData(std::string_view family,
+                                      const FontFaceRequest& request) const override;
 
   // Picker conveniences:
 
   /// Families from a single source (Embedded or System), sorted by name.
   std::vector<FontFamilyInfo> familiesBySource(FontSource source) const;
 
-  /// Alias for `loadFamilyData()`, named for the picker's preview use.
-  std::vector<uint8_t> loadFace(std::string_view family) const { return loadFamilyData(family); }
+  /// Alias for `loadFamilyData()`, named for the picker's preview use. Previews show the family's
+  /// default face, so this asks for the regular upright one.
+  std::vector<uint8_t> loadFace(std::string_view family) const {
+    return loadFamilyData(family, FontFaceRequest{});
+  }
 
 private:
   std::vector<std::unique_ptr<FontFamilyProvider>> providers_;

--- a/donner/svg/resources/FontCatalogTypes.h
+++ b/donner/svg/resources/FontCatalogTypes.h
@@ -2,9 +2,13 @@
 /// @file
 
 #include <cstdint>
+#include <ostream>
 #include <string>
 #include <string_view>
 #include <vector>
+
+#include "donner/svg/core/FontStretch.h"
+#include "donner/svg/core/FontStyle.h"
 
 namespace donner::svg {
 
@@ -35,8 +39,8 @@ enum class FontCategory {
 
 /// One entry in the font catalog: a family name plus how it was discovered and classified.
 struct FontFamilyInfo {
-  std::string family;                          //!< Display name and CSS `font-family` match key.
-  FontSource source = FontSource::Embedded;    //!< Origin (embedded vs system).
+  std::string family;                             //!< Display name and CSS `font-family` match key.
+  FontSource source = FontSource::Embedded;       //!< Origin (embedded vs system).
   FontCategory category = FontCategory::Unknown;  //!< Best-effort style bucket.
 
   /// Equality (used by tests).
@@ -44,6 +48,30 @@ struct FontFamilyInfo {
     return family == other.family && source == other.source && category == other.category;
   }
 };
+
+/**
+ * Which face inside a family a `font-family` lookup wants, taken from the element's computed CSS
+ * font properties.
+ *
+ * A family is a *set* of faces, not one file: "Helvetica" covers Regular, Bold, Oblique, and Bold
+ * Oblique. Providers must honour this or `font-weight: bold` silently renders as regular.
+ *
+ * @see https://www.w3.org/TR/css-fonts-4/#font-matching-algorithm
+ */
+struct FontFaceRequest {
+  int weight = 400;                           //!< CSS `font-weight`, 100-900 (700 = bold).
+  FontStyle style = FontStyle::Normal;        //!< CSS `font-style`.
+  FontStretch stretch = FontStretch::Normal;  //!< CSS `font-stretch`.
+
+  /// Equality comparison.
+  bool operator==(const FontFaceRequest& other) const = default;
+};
+
+/// Ostream output operator, so test failures print the requested face instead of an opaque struct.
+inline std::ostream& operator<<(std::ostream& os, const FontFaceRequest& request) {
+  return os << "FontFaceRequest(weight=" << request.weight << ", style=" << request.style
+            << ", stretch=" << request.stretch << ")";
+}
 
 /**
  * Interface implemented by each font source (embedded, system) and by the aggregate \ref
@@ -64,11 +92,19 @@ public:
   virtual bool hasFamily(std::string_view family) const = 0;
 
   /**
-   * Load the raw sfnt (TTF/OTF) bytes for \p family, or an empty vector if unavailable.
+   * Load the raw sfnt (TTF/OTF) bytes for the face of \p family that best matches \p request, or
+   * an empty vector if the family is unavailable.
+   *
+   * Providers that only hold a single file per family return it for every request, which means
+   * bold and italic render as regular for those families - see \ref EmbeddedFontProvider.
    *
    * The returned bytes are suitable for `FontManager::loadFontData()`.
+   *
+   * @param family Family name to load (case-insensitive).
+   * @param request Face within the family to prefer.
    */
-  virtual std::vector<uint8_t> loadFamilyData(std::string_view family) const = 0;
+  virtual std::vector<uint8_t> loadFamilyData(std::string_view family,
+                                              const FontFaceRequest& request) const = 0;
 };
 
 }  // namespace donner::svg

--- a/donner/svg/resources/FontManager.cc
+++ b/donner/svg/resources/FontManager.cc
@@ -363,7 +363,10 @@ FontHandle FontManager::findFont(std::string_view family, int weight, int style,
   // No document @font-face matched. Consult the external provider (embedded/system catalog) before
   // falling back to Public Sans. The provider itself orders Embedded before System.
   if (provider_ != nullptr && provider_->hasFamily(family)) {
-    std::vector<uint8_t> data = provider_->loadFamilyData(family);
+    const FontFaceRequest request{.weight = weight,
+                                  .style = static_cast<FontStyle>(style),
+                                  .stretch = static_cast<FontStretch>(stretch)};
+    std::vector<uint8_t> data = provider_->loadFamilyData(family, request);
     if (!data.empty()) {
       const Entity entity = registry_.create();
       if (loadFontDataIntoEntity(entity, data, FontDataTrust::Trusted)) {

--- a/donner/svg/resources/SystemFontProvider.cc
+++ b/donner/svg/resources/SystemFontProvider.cc
@@ -9,8 +9,11 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <CoreText/CoreText.h>
 
+#include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <iterator>
+#include <limits>
 
 namespace donner::svg {
 
@@ -66,8 +69,7 @@ void writeBE16(uint8_t* p, uint16_t v) {
 /// `.ttc`/`.dfont` collections, where reading the file bytes directly would not yield a single
 /// usable font. Returns empty on failure.
 std::vector<uint8_t> buildSfntFromCTFont(CTFontRef font) {
-  CFRef<CFArrayRef> tags(
-      CTFontCopyAvailableTables(font, kCTFontTableOptionNoOptions));
+  CFRef<CFArrayRef> tags(CTFontCopyAvailableTables(font, kCTFontTableOptionNoOptions));
   if (!tags) {
     return {};
   }
@@ -86,8 +88,8 @@ std::vector<uint8_t> buildSfntFromCTFont(CTFontRef font) {
 
   bool hasCff = false;
   for (CFIndex i = 0; i < numTablesSigned; ++i) {
-    const auto tag = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(
-        CFArrayGetValueAtIndex(tags.get(), i)));
+    const auto tag =
+        static_cast<uint32_t>(reinterpret_cast<uintptr_t>(CFArrayGetValueAtIndex(tags.get(), i)));
     CFRef<CFDataRef> tableData(
         CTFontCopyTable(font, static_cast<CTFontTableTag>(tag), kCTFontTableOptionNoOptions));
     if (!tableData) {
@@ -160,6 +162,117 @@ std::vector<uint8_t> buildSfntFromCTFont(CTFontRef font) {
   return sfnt;
 }
 
+/**
+ * Map a CSS `font-weight` (100-900) onto CoreText's normalized `kCTFontWeightTrait` scale, where
+ * -1 is thinnest, 0 is regular and 1 is heaviest. The anchors are the ones Apple documents for the
+ * `NSFontWeight*` constants.
+ */
+double NormalizedWeight(int cssWeight) {
+  struct Anchor {
+    int css;
+    double normalized;
+  };
+  static constexpr Anchor kAnchors[] = {{100, -0.80}, {200, -0.60}, {300, -0.40},
+                                        {400, 0.00},  {500, 0.23},  {600, 0.30},
+                                        {700, 0.40},  {800, 0.56},  {900, 0.62}};
+
+  if (cssWeight <= kAnchors[0].css) {
+    return kAnchors[0].normalized;
+  }
+  for (size_t i = 1; i < std::size(kAnchors); ++i) {
+    if (cssWeight <= kAnchors[i].css) {
+      const Anchor& low = kAnchors[i - 1];
+      const Anchor& high = kAnchors[i];
+      const double t = static_cast<double>(cssWeight - low.css) / (high.css - low.css);
+      return low.normalized + t * (high.normalized - low.normalized);
+    }
+  }
+  return kAnchors[std::size(kAnchors) - 1].normalized;
+}
+
+/// Map \ref FontStretch (1-9, 5 = normal) onto CoreText's normalized `kCTFontWidthTrait` scale.
+double NormalizedWidth(FontStretch stretch) {
+  return (static_cast<double>(static_cast<uint8_t>(stretch)) - 5.0) / 4.0;
+}
+
+/// Read a numeric entry out of a CoreText traits dictionary, or \p fallback when absent.
+double TraitNumber(CFDictionaryRef traits, CFStringRef key, double fallback) {
+  const auto number = static_cast<CFNumberRef>(CFDictionaryGetValue(traits, key));
+  if (number == nullptr) {
+    return fallback;
+  }
+  double value = fallback;
+  if (!CFNumberGetValue(number, kCFNumberDoubleType, &value)) {
+    return fallback;
+  }
+  return value;
+}
+
+/**
+ * Pick the face within \p familyDescriptor that best matches \p request.
+ *
+ * Scoring follows the CSS font-matching priority (style, then stretch, then weight) with the same
+ * penalty scale as the `@font-face` matcher in \ref FontManager, so document-provided and
+ * system-provided families rank their faces the same way.
+ *
+ * @param familyDescriptor Descriptor carrying only the family name.
+ * @param request Face to prefer.
+ * @return A retained descriptor for the best face, or nullptr when the family cannot be expanded
+ *   (the caller then falls back to the family default).
+ * @see https://www.w3.org/TR/css-fonts-4/#font-style-matching
+ */
+CTFontDescriptorRef BestFaceInFamily(CTFontDescriptorRef familyDescriptor,
+                                     const FontFaceRequest& request) {
+  CFRef<CFSetRef> mandatory([] {
+    const void* keys[] = {kCTFontFamilyNameAttribute};
+    return CFSetCreate(kCFAllocatorDefault, keys, 1, &kCFTypeSetCallBacks);
+  }());
+  if (!mandatory) {
+    return nullptr;
+  }
+
+  CFRef<CFArrayRef> faces(
+      CTFontDescriptorCreateMatchingFontDescriptors(familyDescriptor, mandatory.get()));
+  if (!faces) {
+    return nullptr;
+  }
+
+  const double wantWeight = NormalizedWeight(request.weight);
+  const double wantWidth = NormalizedWidth(request.stretch);
+  const bool wantSlanted = request.style != FontStyle::Normal;
+
+  CTFontDescriptorRef best = nullptr;
+  double bestScore = std::numeric_limits<double>::max();
+
+  const CFIndex count = CFArrayGetCount(faces.get());
+  for (CFIndex i = 0; i < count; ++i) {
+    const auto face = static_cast<CTFontDescriptorRef>(CFArrayGetValueAtIndex(faces.get(), i));
+    CFRef<CFDictionaryRef> traits(
+        static_cast<CFDictionaryRef>(CTFontDescriptorCopyAttribute(face, kCTFontTraitsAttribute)));
+    if (!traits) {
+      continue;
+    }
+
+    const auto symbolic =
+        static_cast<uint32_t>(TraitNumber(traits.get(), kCTFontSymbolicTrait, 0.0));
+    const bool isSlanted = (symbolic & kCTFontTraitItalic) != 0;
+
+    double score = 0.0;
+    if (isSlanted != wantSlanted) {
+      score += 10000.0;
+    }
+    score += std::abs(TraitNumber(traits.get(), kCTFontWidthTrait, 0.0) - wantWidth) * 1000.0;
+    score += std::abs(TraitNumber(traits.get(), kCTFontWeightTrait, 0.0) - wantWeight) * 100.0;
+
+    if (score < bestScore) {
+      bestScore = score;
+      best = face;
+    }
+  }
+
+  return best != nullptr ? static_cast<CTFontDescriptorRef>(CFRetain(best)) : nullptr;
+}
+
 }  // namespace
 
 bool SystemFontProvider::isSupported() {
@@ -205,15 +318,16 @@ bool SystemFontProvider::hasFamily(std::string_view family) const {
   return false;
 }
 
-std::vector<uint8_t> SystemFontProvider::loadFamilyData(std::string_view family) const {
+std::vector<uint8_t> SystemFontProvider::loadFamilyData(std::string_view family,
+                                                        const FontFaceRequest& request) const {
   // Guard against CoreText silently substituting a fallback font for an unknown family name.
   if (!hasFamily(family)) {
     return {};
   }
 
   const std::string familyStr(family);
-  CFRef<CFStringRef> cfFamily(CFStringCreateWithCString(kCFAllocatorDefault, familyStr.c_str(),
-                                                        kCFStringEncodingUTF8));
+  CFRef<CFStringRef> cfFamily(
+      CFStringCreateWithCString(kCFAllocatorDefault, familyStr.c_str(), kCFStringEncodingUTF8));
   if (!cfFamily) {
     return {};
   }
@@ -230,7 +344,13 @@ std::vector<uint8_t> SystemFontProvider::loadFamilyData(std::string_view family)
   if (!desc) {
     return {};
   }
-  CFRef<CTFontRef> font(CTFontCreateWithFontDescriptor(desc.get(), 0.0, nullptr));
+
+  // Expand the family into its individual faces and pick the one matching `request`. Building a
+  // font straight from the family-only descriptor always yields the family's default (regular
+  // upright) face, which is what makes bold and italic render as regular.
+  CFRef<CTFontDescriptorRef> best(BestFaceInFamily(desc.get(), request));
+  CFRef<CTFontRef> font(
+      CTFontCreateWithFontDescriptor(best ? best.get() : desc.get(), 0.0, nullptr));
   if (!font) {
     return {};
   }
@@ -262,7 +382,8 @@ bool SystemFontProvider::hasFamily(std::string_view /*family*/) const {
   return false;
 }
 
-std::vector<uint8_t> SystemFontProvider::loadFamilyData(std::string_view /*family*/) const {
+std::vector<uint8_t> SystemFontProvider::loadFamilyData(std::string_view /*family*/,
+                                                        const FontFaceRequest& /*request*/) const {
   return {};
 }
 

--- a/donner/svg/resources/SystemFontProvider.h
+++ b/donner/svg/resources/SystemFontProvider.h
@@ -13,8 +13,9 @@ namespace donner::svg {
  *
  * On macOS this enumerates families via CoreText (`CTFontManagerCopyAvailableFontFamilyNames`) and
  * materializes a flat sfnt byte stream on demand by reconstructing the font's tables through
- * CoreText (which works even for `.ttc`/`.dfont` members). All families report \ref
- * FontSource::System.
+ * CoreText (which works even for `.ttc`/`.dfont` members). Faces within a family are scored against
+ * the requested weight/style/stretch, so bold and italic resolve to the real designed face. All
+ * families report \ref FontSource::System.
  *
  * On non-Apple platforms this is a stub: it enumerates nothing and loads nothing, so the catalog
  * still compiles and behaves (embedded fonts only).
@@ -25,7 +26,8 @@ public:
 
   std::vector<FontFamilyInfo> families() const override;
   bool hasFamily(std::string_view family) const override;
-  std::vector<uint8_t> loadFamilyData(std::string_view family) const override;
+  std::vector<uint8_t> loadFamilyData(std::string_view family,
+                                      const FontFaceRequest& request) const override;
 
   /// Returns true if this build enumerates real system fonts (i.e. macOS), false for the stub.
   static bool isSupported();

--- a/donner/svg/resources/tests/FontCatalog_tests.cc
+++ b/donner/svg/resources/tests/FontCatalog_tests.cc
@@ -41,7 +41,8 @@ public:
                        [&](const std::string& name) { return name == family; });
   }
 
-  std::vector<uint8_t> loadFamilyData(std::string_view family) const override {
+  std::vector<uint8_t> loadFamilyData(std::string_view family,
+                                      const FontFaceRequest& /*request*/) const override {
     if (!hasFamily(family)) {
       return {};
     }
@@ -98,7 +99,7 @@ TEST(EmbeddedFontProviderTest, SetSpansMultipleCategories) {
 TEST(EmbeddedFontProviderTest, EveryAdvertisedFamilyLoadsValidSfntBytes) {
   EmbeddedFontProvider provider;
   for (const FontFamilyInfo& info : provider.families()) {
-    const std::vector<uint8_t> data = provider.loadFamilyData(info.family);
+    const std::vector<uint8_t> data = provider.loadFamilyData(info.family, FontFaceRequest{});
     ASSERT_GE(data.size(), 4u) << info.family;
     // Every curated source is a TrueType sfnt with magic 0x00010000.
     EXPECT_EQ(data[0], 0x00) << info.family;
@@ -113,7 +114,7 @@ TEST(EmbeddedFontProviderTest, LookupIsCaseInsensitive) {
   EXPECT_TRUE(provider.hasFamily("inter"));
   EXPECT_TRUE(provider.hasFamily("JETBRAINS MONO"));
   EXPECT_FALSE(provider.hasFamily("Definitely Not A Font"));
-  EXPECT_TRUE(provider.loadFamilyData("Definitely Not A Font").empty());
+  EXPECT_TRUE(provider.loadFamilyData("Definitely Not A Font", FontFaceRequest{}).empty());
 }
 
 // --- FontCatalog aggregation + precedence -----------------------------------------------------
@@ -198,7 +199,7 @@ TEST(SystemFontProviderTest, LoadsSfntForKnownSystemFamily) {
   if (!provider.hasFamily("Helvetica")) {
     GTEST_SKIP() << "Helvetica not available on this host";
   }
-  const std::vector<uint8_t> data = provider.loadFamilyData("Helvetica");
+  const std::vector<uint8_t> data = provider.loadFamilyData("Helvetica", FontFaceRequest{});
   ASSERT_GE(data.size(), 4u);
   const uint32_t magic = (uint32_t(data[0]) << 24) | (uint32_t(data[1]) << 16) |
                          (uint32_t(data[2]) << 8) | uint32_t(data[3]);
@@ -210,7 +211,8 @@ TEST(SystemFontProviderTest, LoadsSfntForKnownSystemFamily) {
 TEST(SystemFontProviderTest, UnknownFamilyReturnsEmpty) {
   SystemFontProvider provider;
   EXPECT_FALSE(provider.hasFamily("Definitely Not Installed Font XYZ"));
-  EXPECT_TRUE(provider.loadFamilyData("Definitely Not Installed Font XYZ").empty());
+  EXPECT_TRUE(
+      provider.loadFamilyData("Definitely Not Installed Font XYZ", FontFaceRequest{}).empty());
 }
 
 // Regression: a catalog family is a *set* of faces, and `font-weight`/`font-style` pick which one.

--- a/donner/svg/resources/tests/FontCatalog_tests.cc
+++ b/donner/svg/resources/tests/FontCatalog_tests.cc
@@ -5,8 +5,11 @@
 
 #include <algorithm>
 #include <memory>
+#include <ranges>
 
+#include "donner/svg/core/FontStyle.h"
 #include "donner/svg/resources/EmbeddedFontProvider.h"
+#include "donner/svg/resources/FontManager.h"
 #include "donner/svg/resources/SystemFontProvider.h"
 
 namespace donner::svg {
@@ -15,6 +18,8 @@ namespace {
 
 using ::testing::Contains;
 using ::testing::ElementsAre;
+using ::testing::IsEmpty;
+using ::testing::Not;
 
 /// A provider that reports a fixed family list and returns a single sentinel byte per family so
 /// tests can tell which provider served a given family.
@@ -115,9 +120,8 @@ TEST(EmbeddedFontProviderTest, LookupIsCaseInsensitive) {
 
 TEST(FontCatalogTest, GroupsEmbeddedBeforeSystem) {
   std::vector<std::unique_ptr<FontFamilyProvider>> providers;
-  providers.push_back(
-      std::make_unique<MarkerProvider>(std::vector<std::string>{"EmbeddedOnly"},
-                                       FontSource::Embedded, 0x11));
+  providers.push_back(std::make_unique<MarkerProvider>(std::vector<std::string>{"EmbeddedOnly"},
+                                                       FontSource::Embedded, 0x11));
   providers.push_back(std::make_unique<MarkerProvider>(std::vector<std::string>{"SystemOnly"},
                                                        FontSource::System, 0x22));
   FontCatalog catalog(std::move(providers));
@@ -152,10 +156,10 @@ TEST(FontCatalogTest, EmbeddedShadowsSystemForDuplicateFamily) {
 
 TEST(FontCatalogTest, FamiliesBySourceFilters) {
   std::vector<std::unique_ptr<FontFamilyProvider>> providers;
-  providers.push_back(std::make_unique<MarkerProvider>(
-      std::vector<std::string>{"E1", "E2"}, FontSource::Embedded, 0x01));
-  providers.push_back(std::make_unique<MarkerProvider>(std::vector<std::string>{"S1"},
-                                                       FontSource::System, 0x02));
+  providers.push_back(std::make_unique<MarkerProvider>(std::vector<std::string>{"E1", "E2"},
+                                                       FontSource::Embedded, 0x01));
+  providers.push_back(
+      std::make_unique<MarkerProvider>(std::vector<std::string>{"S1"}, FontSource::System, 0x02));
   FontCatalog catalog(std::move(providers));
 
   EXPECT_THAT(familyNames(catalog.familiesBySource(FontSource::Embedded)),
@@ -198,7 +202,8 @@ TEST(SystemFontProviderTest, LoadsSfntForKnownSystemFamily) {
   ASSERT_GE(data.size(), 4u);
   const uint32_t magic = (uint32_t(data[0]) << 24) | (uint32_t(data[1]) << 16) |
                          (uint32_t(data[2]) << 8) | uint32_t(data[3]);
-  EXPECT_TRUE(magic == 0x00010000u || magic == 0x4F54544Fu /*OTTO*/ || magic == 0x74727565u /*true*/)
+  EXPECT_TRUE(magic == 0x00010000u || magic == 0x4F54544Fu /*OTTO*/ ||
+              magic == 0x74727565u /*true*/)
       << "unexpected sfnt magic: " << std::hex << magic;
 }
 
@@ -206,6 +211,50 @@ TEST(SystemFontProviderTest, UnknownFamilyReturnsEmpty) {
   SystemFontProvider provider;
   EXPECT_FALSE(provider.hasFamily("Definitely Not Installed Font XYZ"));
   EXPECT_TRUE(provider.loadFamilyData("Definitely Not Installed Font XYZ").empty());
+}
+
+// Regression: a catalog family is a *set* of faces, and `font-weight`/`font-style` pick which one.
+// Resolving them all to the family's default face is what makes bold and italic render as regular.
+TEST(FontManagerCatalogFaceTest, BoldResolvesToADistinctFaceFromRegular) {
+  SystemFontProvider probe;
+  if (!probe.hasFamily("Helvetica")) {
+    GTEST_SKIP() << "Helvetica not available on this host";
+  }
+
+  FontCatalog catalog;
+  Registry registry;
+  FontManager manager(registry);
+  manager.setFontProvider(&catalog);
+
+  const std::span<const uint8_t> regular = manager.fontData(manager.findFont("Helvetica", 400));
+  const std::span<const uint8_t> bold = manager.fontData(manager.findFont("Helvetica", 700));
+
+  ASSERT_THAT(regular, Not(IsEmpty()));
+  ASSERT_THAT(bold, Not(IsEmpty()));
+  EXPECT_FALSE(std::ranges::equal(regular, bold))
+      << "font-weight:700 resolved to the same face bytes as font-weight:400";
+}
+
+TEST(FontManagerCatalogFaceTest, ItalicResolvesToADistinctFaceFromUpright) {
+  SystemFontProvider probe;
+  if (!probe.hasFamily("Helvetica")) {
+    GTEST_SKIP() << "Helvetica not available on this host";
+  }
+
+  FontCatalog catalog;
+  Registry registry;
+  FontManager manager(registry);
+  manager.setFontProvider(&catalog);
+
+  const std::span<const uint8_t> upright =
+      manager.fontData(manager.findFont("Helvetica", 400, static_cast<int>(FontStyle::Normal), 5));
+  const std::span<const uint8_t> italic =
+      manager.fontData(manager.findFont("Helvetica", 400, static_cast<int>(FontStyle::Italic), 5));
+
+  ASSERT_THAT(upright, Not(IsEmpty()));
+  ASSERT_THAT(italic, Not(IsEmpty()));
+  EXPECT_FALSE(std::ranges::equal(upright, italic))
+      << "font-style:italic resolved to the same face bytes as font-style:normal";
 }
 #else
 TEST(SystemFontProviderTest, StubEnumeratesNothing) {

--- a/donner/svg/resources/tests/FontManager_tests.cc
+++ b/donner/svg/resources/tests/FontManager_tests.cc
@@ -10,7 +10,11 @@
 #include <vector>
 
 #include "donner/base/fonts/SfntUtils.h"
+#include "donner/svg/core/FontStretch.h"
+#include "donner/svg/core/FontStyle.h"
 #include "embed_resources/PublicSansFont.h"
+
+using testing::Eq;
 
 namespace donner::svg {
 
@@ -62,8 +66,10 @@ public:
     return false;
   }
 
-  std::vector<uint8_t> loadFamilyData(std::string_view family) const override {
+  std::vector<uint8_t> loadFamilyData(std::string_view family,
+                                      const FontFaceRequest& request) const override {
     ++loadCalls;
+    lastRequest = request;
     if (!hasFamily(family)) {
       return {};
     }
@@ -72,6 +78,7 @@ public:
   }
 
   mutable int loadCalls = 0;
+  mutable FontFaceRequest lastRequest;
 
 private:
   std::vector<std::string> families_;
@@ -533,6 +540,40 @@ TEST(FontManagerTest, FallsBackToPublicSansWhenProviderLacksFamily) {
   EXPECT_TRUE(static_cast<bool>(handle));
   EXPECT_EQ(handle, mgr.fallbackFont());
   EXPECT_EQ(provider.loadCalls, 0);
+}
+
+// Regression: a family is a set of faces, so the provider needs the requested weight/style/stretch
+// to pick one. Dropping them here is what makes `font-weight: bold` render as regular for every
+// catalog-resolved family.
+TEST(FontManagerTest, ProviderReceivesTheRequestedFace) {
+  Registry registry;
+  FontManager mgr(registry);
+  FakeFontProvider provider({"ProviderFamily"});
+  mgr.setFontProvider(&provider);
+
+  (void)mgr.findFont("ProviderFamily", 700, static_cast<int>(FontStyle::Italic),
+                     static_cast<int>(FontStretch::Condensed));
+
+  EXPECT_THAT(provider.lastRequest,
+              Eq(FontFaceRequest{
+                  .weight = 700, .style = FontStyle::Italic, .stretch = FontStretch::Condensed}));
+}
+
+// Faces are cached per requested face, not per family, so a later bold lookup is not served the
+// regular face out of the cache.
+TEST(FontManagerTest, ProviderIsConsultedOncePerRequestedFace) {
+  Registry registry;
+  FontManager mgr(registry);
+  FakeFontProvider provider({"ProviderFamily"});
+  mgr.setFontProvider(&provider);
+
+  (void)mgr.findFont("ProviderFamily", 400);
+  (void)mgr.findFont("ProviderFamily", 400);
+  EXPECT_EQ(provider.loadCalls, 1);
+
+  (void)mgr.findFont("ProviderFamily", 700);
+  EXPECT_EQ(provider.loadCalls, 2);
+  EXPECT_THAT(provider.lastRequest.weight, Eq(700));
 }
 
 TEST(FontManagerTest, DefaultProviderAdoptedByNewInstances) {

--- a/donner/svg/tests/SVGTextElement_tests.cc
+++ b/donner/svg/tests/SVGTextElement_tests.cc
@@ -487,23 +487,24 @@ TEST(SVGTextElementCacheTests, FontSizeAttributeChangeInvalidatesCache) {
               testing::DoubleNear(lengthBefore * 2.0, lengthBefore * 0.05));
 }
 
-TEST(SVGTextElementCacheTests, LetterSpacingAttributeChangeInvalidatesCache) {
+TEST(SVGTextElementCacheTests, TextAnchorAttributeChangeInvalidatesCache) {
   SVGDocument doc = instantiateSubtree(R"-(
     <svg viewBox="0 0 200 40">
-      <text id="t" x="10" y="20" font-family="fallback-font" font-size="12px">ABCDEF</text>
+      <text id="t" x="100" y="20" font-family="fallback-font" font-size="12px">ABCDEF</text>
     </svg>
   )-",
                                        kExperimentalOptions);
 
   auto textElement = doc.querySelector("#t")->cast<SVGTextElement>();
 
-  const double lengthBefore = textElement.getComputedTextLength();
-  ASSERT_GT(lengthBefore, 0.0);
+  const double length = textElement.getComputedTextLength();
+  ASSERT_GT(length, 0.0);
+  ASSERT_THAT(textElement.getStartPositionOfChar(0).x, testing::DoubleNear(100.0, 0.5));
 
-  textElement.setAttribute("letter-spacing", "10px");
+  textElement.setAttribute("text-anchor", "end");
 
-  // Five inter-character gaps across "ABCDEF" grow by 10px each.
-  EXPECT_THAT(textElement.getComputedTextLength(), testing::DoubleNear(lengthBefore + 50.0, 1.0));
+  // `text-anchor: end` puts the *end* of the run on the anchor point.
+  EXPECT_THAT(textElement.getStartPositionOfChar(0).x, testing::DoubleNear(100.0 - length, 0.5));
 }
 
 TEST(SVGTextElementCacheTests, StyleAttributeChangeInvalidatesCache) {

--- a/donner/svg/tests/SVGTextElement_tests.cc
+++ b/donner/svg/tests/SVGTextElement_tests.cc
@@ -462,6 +462,115 @@ TEST(SVGTextElementCacheTests, SetPositionInvalidatesCache) {
   EXPECT_NEAR(startAfter.x, 50.0, 0.5);
 }
 
+// Regression: the editor's font controls write presentation attributes onto the selected `<text>`
+// element (`font-size`, `font-family`, `font-weight`, ...). Those are style inputs to text layout,
+// so a write must drop the memoized `ComputedTextGeometryComponent` - both renderers draw straight
+// out of that cache, and a stale entry makes every font control look like a no-op.
+TEST(SVGTextElementCacheTests, FontSizeAttributeChangeInvalidatesCache) {
+  SVGDocument doc = instantiateSubtree(R"-(
+    <svg viewBox="0 0 200 40">
+      <text id="t" x="10" y="20" font-family="fallback-font" font-size="12px">ABCDEF</text>
+    </svg>
+  )-",
+                                       kExperimentalOptions);
+
+  auto textElement = doc.querySelector("#t")->cast<SVGTextElement>();
+
+  // Prime the cache, the way the editor does when it measures the selection bounds.
+  const double lengthBefore = textElement.getComputedTextLength();
+  ASSERT_GT(lengthBefore, 0.0);
+
+  textElement.setAttribute("font-size", "24px");
+
+  // Doubling the font size doubles the advance width.
+  EXPECT_THAT(textElement.getComputedTextLength(),
+              testing::DoubleNear(lengthBefore * 2.0, lengthBefore * 0.05));
+}
+
+TEST(SVGTextElementCacheTests, LetterSpacingAttributeChangeInvalidatesCache) {
+  SVGDocument doc = instantiateSubtree(R"-(
+    <svg viewBox="0 0 200 40">
+      <text id="t" x="10" y="20" font-family="fallback-font" font-size="12px">ABCDEF</text>
+    </svg>
+  )-",
+                                       kExperimentalOptions);
+
+  auto textElement = doc.querySelector("#t")->cast<SVGTextElement>();
+
+  const double lengthBefore = textElement.getComputedTextLength();
+  ASSERT_GT(lengthBefore, 0.0);
+
+  textElement.setAttribute("letter-spacing", "10px");
+
+  // Five inter-character gaps across "ABCDEF" grow by 10px each.
+  EXPECT_THAT(textElement.getComputedTextLength(), testing::DoubleNear(lengthBefore + 50.0, 1.0));
+}
+
+TEST(SVGTextElementCacheTests, StyleAttributeChangeInvalidatesCache) {
+  SVGDocument doc = instantiateSubtree(R"-(
+    <svg viewBox="0 0 200 40">
+      <text id="t" x="10" y="20" font-family="fallback-font" font-size="12px">ABCDEF</text>
+    </svg>
+  )-",
+                                       kExperimentalOptions);
+
+  auto textElement = doc.querySelector("#t")->cast<SVGTextElement>();
+
+  const double lengthBefore = textElement.getComputedTextLength();
+  ASSERT_GT(lengthBefore, 0.0);
+
+  textElement.setStyle("font-size: 24px");
+
+  EXPECT_THAT(textElement.getComputedTextLength(),
+              testing::DoubleNear(lengthBefore * 2.0, lengthBefore * 0.05));
+}
+
+// `font-size` inherits, so a write on an ancestor group must invalidate the text roots beneath it.
+TEST(SVGTextElementCacheTests, InheritedFontChangeOnAncestorInvalidatesCache) {
+  SVGDocument doc = instantiateSubtree(R"-(
+    <svg viewBox="0 0 200 40">
+      <g id="g">
+        <text id="t" x="10" y="20" font-family="fallback-font">ABCDEF</text>
+      </g>
+    </svg>
+  )-",
+                                       kExperimentalOptions);
+
+  auto group = doc.querySelector("#g").value();
+  auto textElement = doc.querySelector("#t")->cast<SVGTextElement>();
+
+  group.setAttribute("font-size", "12px");
+  const double lengthBefore = textElement.getComputedTextLength();
+  ASSERT_GT(lengthBefore, 0.0);
+
+  group.setAttribute("font-size", "24px");
+
+  EXPECT_THAT(textElement.getComputedTextLength(),
+              testing::DoubleNear(lengthBefore * 2.0, lengthBefore * 0.05));
+}
+
+// A write on a `<tspan>` must invalidate the enclosing `<text>` root's layout, not just its own.
+TEST(SVGTextElementCacheTests, TSpanFontSizeAttributeChangeInvalidatesParent) {
+  SVGDocument doc = instantiateSubtree(R"-(
+    <svg viewBox="0 0 200 40">
+      <text id="root" x="10" y="20" font-family="fallback-font" font-size="12px"
+        ><tspan id="span">ABC</tspan></text>
+    </svg>
+  )-",
+                                       kExperimentalOptions);
+
+  auto root = doc.querySelector("#root")->cast<SVGTextElement>();
+  auto span = doc.querySelector("#span")->cast<SVGTSpanElement>();
+
+  const double lengthBefore = root.getComputedTextLength();
+  ASSERT_GT(lengthBefore, 0.0);
+
+  span.setAttribute("font-size", "24px");
+
+  EXPECT_THAT(root.getComputedTextLength(),
+              testing::DoubleNear(lengthBefore * 2.0, lengthBefore * 0.05));
+}
+
 TEST(SVGTextElementCacheTests, TSpanPositionChangeInvalidatesParent) {
   SVGDocument doc = instantiateSubtree(R"-(
     <svg viewBox="0 0 200 40">

--- a/tools/mcp-servers/editor-control/BUILD.bazel
+++ b/tools/mcp-servers/editor-control/BUILD.bazel
@@ -56,6 +56,8 @@ cc_library(
         "//donner/svg/compositor",
         "//donner/svg/renderer",
         "//donner/svg/renderer:renderer_image_io",
+        "//donner/svg/resources:font_catalog",
+        "//donner/svg/resources:font_manager",
         "@nlohmann_json//:json",
         "@pixelmatch-cpp17",
     ] + select({

--- a/tools/mcp-servers/editor-control/EditorControlSession.h
+++ b/tools/mcp-servers/editor-control/EditorControlSession.h
@@ -19,6 +19,7 @@
 #include "donner/editor/ViewportState.h"
 #include "donner/editor/repro/ReproFile.h"
 #include "donner/svg/renderer/Renderer.h"
+#include "donner/svg/resources/FontCatalog.h"
 #include "nlohmann/json.hpp"
 
 namespace donner::editor::mcp {
@@ -141,6 +142,7 @@ private:
   [[nodiscard]] bool loadCurrentSourceText(const LoadOptions& options, std::string_view sourcePath,
                                            bool resetRenderVersion, nlohmann::json* loadInfo,
                                            std::string* error);
+  void installFontCatalogOnDocument();
   [[nodiscard]] nlohmann::json sourceStateJson() const;
 
   class HeadlessTextureCache {
@@ -196,6 +198,9 @@ private:
   [[nodiscard]] bool ensureDocumentLoaded(std::string* error) const;
   [[nodiscard]] bool waitUntilIdle(std::string* error);
 
+  /// Same catalog used by EditorShell, declared first so render workers cannot
+  /// outlive the provider they resolve family changes through.
+  svg::FontCatalog fontCatalog_;
   EditorApp app_;
   std::unique_ptr<SelectTool> selectTool_;
   PenTool penTool_;

--- a/tools/mcp-servers/editor-control/EditorControlSessionDocument.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSessionDocument.cc
@@ -16,6 +16,7 @@
 #include "donner/editor/TextPatch.h"
 #include "donner/editor/ViewportState.h"
 #include "donner/svg/SVGDocument.h"
+#include "donner/svg/resources/FontManager.h"
 #include "nlohmann/json.hpp"
 #include "tools/mcp-servers/editor-control/EditorControlSessionInternal.h"
 
@@ -26,6 +27,17 @@ namespace {
 using nlohmann::json;
 
 }  // namespace
+
+void EditorControlSession::installFontCatalogOnDocument() {
+  svg::SVGDocument& document = app_.document().document();
+  document.withWriteAccess([this](svg::DocumentWriteAccess& access) {
+    Registry& registry = access.registry();
+    svg::FontManager& fontManager = registry.ctx().contains<svg::FontManager>()
+                                        ? registry.ctx().get<svg::FontManager>()
+                                        : registry.ctx().emplace<svg::FontManager>(registry);
+    fontManager.setFontProvider(&fontCatalog_);
+  });
+}
 
 ToolCallResult EditorControlSession::loadDocument(const json& arguments) {
   std::string error;
@@ -87,6 +99,7 @@ bool EditorControlSession::loadCurrentSourceText(const LoadOptions& options,
     *error = "failed to parse SVG source";
     return false;
   }
+  installFontCatalogOnDocument();
 
   currentSourcePath_ = std::string(sourcePath);
   app_.setCurrentFilePath(std::string(sourcePath));

--- a/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
@@ -351,6 +351,56 @@ TEST(EditorControlSessionTest, ToolListExposesSelectorDragAndRenderTools) {
   EXPECT_TRUE((*replayTool)["inputSchema"]["properties"].contains("gl_drive_document_input"));
 }
 
+TEST(EditorControlSessionTest, CatalogFontFamilyMutationChangesRenderedGlyphs) {
+  constexpr std::string_view kScene = R"svg(
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 100">
+  <text id="label" x="10" y="60" font-size="48">Font selection</text>
+</svg>)svg";
+
+  EditorControlSession session;
+  const ToolCallResult load =
+      session.handleToolCall("load_svg", json{{"svg_source", std::string(kScene)},
+                                              {"canvas_width", 300},
+                                              {"canvas_height", 100},
+                                              {"render_after_load", false}});
+  ASSERT_TRUE(load.body.value("ok", false)) << load.body.dump(2);
+
+  const ToolCallResult selected =
+      session.handleToolCall("select_by_selector", json{{"selector", "#label"}, {"render", true}});
+  ASSERT_TRUE(selected.body.value("ok", false)) << selected.body.dump(2);
+  const ToolCallResult changed = session.handleToolCall(
+      "set_style_property",
+      json{{"property", "font-family"}, {"value", "Bebas Neue"}, {"render_after_set", true}});
+  ASSERT_TRUE(changed.body.value("ok", false)) << changed.body.dump(2);
+
+  ASSERT_FALSE(selected.body["render_stages"].empty());
+  ASSERT_FALSE(changed.body["render_stages"].empty());
+  const json& selectedTiles = selected.body["render_stages"].back()["display_preview"]["tiles"];
+  const json& changedTiles = changed.body["render_stages"].back()["display_preview"]["tiles"];
+  ASSERT_TRUE(selectedTiles.is_array()) << selected.body.dump(2);
+  ASSERT_TRUE(changedTiles.is_array()) << changed.body.dump(2);
+  ASSERT_FALSE(selectedTiles.empty()) << selected.body.dump(2);
+  ASSERT_FALSE(changedTiles.empty()) << changed.body.dump(2);
+
+  std::vector<std::string> selectedHashes;
+  for (const json& tile : selectedTiles) {
+    ASSERT_TRUE(tile["content_hash"].is_string()) << tile.dump(2);
+    selectedHashes.push_back(tile["content_hash"].get<std::string>());
+  }
+  std::vector<std::string> changedHashes;
+  for (const json& tile : changedTiles) {
+    ASSERT_TRUE(tile["content_hash"].is_string()) << tile.dump(2);
+    changedHashes.push_back(tile["content_hash"].get<std::string>());
+  }
+  EXPECT_NE(selectedHashes, changedHashes);
+  EXPECT_TRUE(changed.body.value("queued_selection_mutation", false));
+  EXPECT_TRUE(changed.body.value("flushed_mutation", false));
+
+  const ToolCallResult source = session.handleToolCall("get_svg_source", json::object());
+  ASSERT_TRUE(source.body.value("ok", false));
+  EXPECT_NE(source.body.value("text", "").find("font-family: Bebas Neue"), std::string::npos);
+}
+
 TEST(EditorControlSessionTest, ClickLayerVisibilityButtonCapturesImmediateAndSettledFrames) {
   constexpr std::string_view kScene =
       R"svg(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 20">


### PR DESCRIPTION
Font family changes now reach rendered glyphs, and the picker lazily previews each available family in its own default face.

- Carry requested weight, style, and stretch into catalog face selection while retaining family source metadata.
- Invalidate text layout and composited presentation when font attributes change.
- Generate bounded previews through the existing asynchronous auxiliary-render worker.
- Preserve current font ingestion limits, trust classification, and fallback behavior.

## Verification

- Cumulative UX stack: `bazel test //donner/editor/tests:text_format_bar_presenter_tests //donner/editor/tests:editor_shell_tests //donner/svg/resources:font_catalog_tests //donner/svg/resources:font_manager_tests //donner/svg/tests:svg_tests //tools/mcp-servers/editor-control:editor_control_session_tests --test_output=errors`
- Cumulative UX stack: `bazel build --config=editor-wasm //donner/editor/wasm:wasm_web_package`
- Cumulative UX stack on PR #1000: `bazel test //... --test_output=errors`
- Cumulative UX stack: `python3 tools/cmake/gen_cmakelists.py --check`
