### PR TITLE
Run Wasm Playwright smoke tests through Bazel

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,6 +1,7 @@
 .git
 examples/bazel-examples
 tools/python
+donner/editor/wasm/tests/node_modules
 
 # Ignore subtree repos with their own Bazel workspace
 third_party/tiny-skia-cpp

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,6 +23,8 @@ new_local_repository = use_repo_rule("//third_party:bazel/local.bzl", "new_local
 
 git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
+http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
 # Build dependencies
 bazel_dep(name = "apple_support", version = "2.8.0", repo_name = "build_bazel_apple_support")  # Must be before rules_cc
 bazel_dep(name = "rules_cc", version = "0.2.22")
@@ -150,6 +152,53 @@ bazel_dep(name = "nlohmann_json", version = "3.12.0.bcr.1", dev_dependency = Tru
 bazel_dep(name = "google_benchmark", version = "1.9.5", dev_dependency = True)
 bazel_dep(name = "rules_shell", version = "0.8.0", dev_dependency = True)
 bazel_dep(name = "pixelmatch-cpp17", version = "1.0.3", dev_dependency = True)
+bazel_dep(name = "aspect_rules_js", version = "2.1.2", dev_dependency = True)
+bazel_dep(name = "rules_playwright", version = "0.5.3", dev_dependency = True)
+
+playwright = use_extension(
+    "@rules_playwright//playwright:extensions.bzl",
+    "playwright",
+    dev_dependency = True,
+)
+playwright.repo(
+    name = "playwright",
+    browsers_json = "//donner/editor/wasm/tests:browsers.1.62.1.json",
+    integrity_path_map = {
+        "builds/chromium/1234/chromium-linux-arm64.zip": "sha256-ta19j+cPIws0GY3bVibXF8AW2y9ifLRLkiurvK80ebk=",
+    },
+)
+
+# rules_playwright 0.5.3 still generates the retired legacy macOS Chromium
+# archive path. Playwright 1.62.1 uses Chrome for Testing for supported macOS
+# releases, so provide that exact pinned archive to the generated repositories.
+http_file(
+    name = "playwright_chromium_mac_arm64",
+    dev_dependency = True,
+    integrity = "sha256-AaI++VAbJ0XgwpRMLlgyB+b2Ey2NkcOof/ZbUHnkOO8=",
+    urls = ["https://cdn.playwright.dev/builds/cft/151.0.7922.34/mac-arm64/chrome-mac-arm64.zip"],
+)
+
+override_repo(
+    playwright,
+    **{
+        "playwright-chromium-mac14-arm64": "playwright_chromium_mac_arm64",
+        "playwright-chromium-mac15-arm64": "playwright_chromium_mac_arm64",
+    }
+)
+
+use_repo(playwright, "playwright")
+
+npm = use_extension(
+    "@aspect_rules_js//npm:extensions.bzl",
+    "npm",
+    dev_dependency = True,
+)
+npm.npm_translate_lock(
+    name = "npm",
+    pnpm_lock = "//donner/editor/wasm/tests:pnpm-lock.yaml",
+    verify_node_modules_ignored = "//:.bazelignore",
+)
+use_repo(npm, "npm")
 
 new_local_repository(
     name = "css-parsing-tests",

--- a/donner/editor/wasm/BUILD.bazel
+++ b/donner/editor/wasm/BUILD.bazel
@@ -246,7 +246,7 @@ editor_wasm_geode_transitioned_target(
         "manual",
         "wasm",
     ],
-    visibility = ["//visibility:private"],
+    visibility = ["//donner/editor/wasm/tests:__pkg__"],
 )
 
 serve_http(

--- a/donner/editor/wasm/tests/BUILD.bazel
+++ b/donner/editor/wasm/tests/BUILD.bazel
@@ -1,0 +1,42 @@
+load("@npm//donner/editor/wasm/tests:@playwright/test/package_json.bzl", playwright_bin = "bin")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+
+package(default_visibility = ["//visibility:public"])
+
+npm_link_all_packages(name = "node_modules")
+
+playwright_bin.playwright_test(
+    name = "chromium_remote_smoke",
+    size = "large",
+    args = [
+        "test",
+        "$(rootpath :smoke.spec.ts)",
+        "--config=$(rootpath :playwright.bazel.config.js)",
+        "--grep=production Geode wasm presents visible editor pixels",
+    ],
+    copy_data_to_bin = False,
+    data = [
+        "canvas-color-stats.ts",
+        "package.json",
+        "playwright.bazel.config.js",
+        "playwright.config.js",
+        "remote-webserver.mjs",
+        "smoke.spec.ts",
+        ":node_modules/@playwright/test",
+        "//donner/editor/wasm:wasm_web_package",
+        "@playwright//:chromium",
+    ],
+    env = {
+        "CI": "1",
+        "DONNER_WASM_PACKAGE_DIR": "$(rootpath //donner/editor/wasm:wasm_web_package)",
+        "DONNER_WASM_REQUIRE_WEBGPU": "1",
+        "DONNER_WASM_TEST_SERVER": "$(rootpath :remote-webserver.mjs)",
+        # The repo-wide remote Emscripten workaround disables Node's WebAssembly
+        # runtime, but Playwright's HTTP client uses its bundled llhttp Wasm.
+        "NODE_OPTIONS": "",
+        "PLAYWRIGHT_BROWSERS_PATH": "$(rootpath @playwright//:chromium)/../",
+    },
+    target_compatible_with = [
+        "@platforms//cpu:aarch64",
+    ],
+)

--- a/donner/editor/wasm/tests/BUILD.bazel
+++ b/donner/editor/wasm/tests/BUILD.bazel
@@ -38,5 +38,9 @@ playwright_bin.playwright_test(
     },
     target_compatible_with = [
         "@platforms//cpu:aarch64",
-    ],
+    ] + select({
+        "@platforms//os:macos": [],
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )

--- a/donner/editor/wasm/tests/BUILD.bazel
+++ b/donner/editor/wasm/tests/BUILD.bazel
@@ -23,12 +23,12 @@ playwright_bin.playwright_test(
         "remote-webserver.mjs",
         "smoke.spec.ts",
         ":node_modules/@playwright/test",
-        "//donner/editor/wasm:wasm_web_package",
+        "//donner/editor/wasm:_wasm_web_package_for_serve",
         "@playwright//:chromium",
     ],
     env = {
         "CI": "1",
-        "DONNER_WASM_PACKAGE_DIR": "$(rootpath //donner/editor/wasm:wasm_web_package)",
+        "DONNER_WASM_PACKAGE_DIR": "$(rootpath //donner/editor/wasm:_wasm_web_package_for_serve)",
         "DONNER_WASM_REQUIRE_WEBGPU": "1",
         "DONNER_WASM_TEST_SERVER": "$(rootpath :remote-webserver.mjs)",
         # The repo-wide remote Emscripten workaround disables Node's WebAssembly

--- a/donner/editor/wasm/tests/BUILD.bazel
+++ b/donner/editor/wasm/tests/BUILD.bazel
@@ -17,6 +17,7 @@ playwright_bin.playwright_test(
     copy_data_to_bin = False,
     data = [
         "canvas-color-stats.ts",
+        "gesture-streams.ts",
         "package.json",
         "playwright.bazel.config.js",
         "playwright.config.js",

--- a/donner/editor/wasm/tests/browser-matrix.spec.mjs
+++ b/donner/editor/wasm/tests/browser-matrix.spec.mjs
@@ -21,6 +21,21 @@ test("Bazel owns a hermetic no-window Chromium browser lane", () => {
     /browsers_json = "\/\/donner\/editor\/wasm\/tests:browsers\.1\.62\.1\.json"/,
     "the browser revisions must come from the Playwright version in package-lock.json",
   );
+  assert.match(
+    moduleFile,
+    /builds\/cft\/151\.0\.7922\.34\/mac-arm64\/chrome-mac-arm64\.zip/,
+    "macOS remote tests must use Playwright's Chrome-for-Testing artifact path",
+  );
+  assert.match(
+    moduleFile,
+    /"playwright-chromium-mac14-arm64": "playwright_chromium_mac_arm64"/,
+    "the default rules_playwright macOS archive must be replaced hermetically",
+  );
+  assert.match(
+    moduleFile,
+    /"playwright-chromium-mac15-arm64": "playwright_chromium_mac_arm64"/,
+    "the latest supported rules_playwright macOS archive must be replaced hermetically",
+  );
 
   const buildFilePath = path.join(testDirectory, "BUILD.bazel");
   assert.ok(existsSync(buildFilePath), "Wasm browser tests need a Bazel package");
@@ -32,6 +47,11 @@ test("Bazel owns a hermetic no-window Chromium browser lane", () => {
   assert.match(
     buildFile,
     /"PLAYWRIGHT_BROWSERS_PATH": "\$\(rootpath @playwright\/\/:chromium\)\/\.\.\/"/,
+  );
+  assert.doesNotMatch(
+    buildFile,
+    /"@platforms\/\/os:linux"/,
+    "the headless browser test must remain runnable on macOS remote execution",
   );
 
   const chromiumConfig = readFileSync(path.join(testDirectory, "playwright.config.js"), "utf8");

--- a/donner/editor/wasm/tests/browser-matrix.spec.mjs
+++ b/donner/editor/wasm/tests/browser-matrix.spec.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import test from "node:test";
@@ -8,6 +8,39 @@ import { fileURLToPath } from "node:url";
 const require = createRequire(import.meta.url);
 const testDirectory = path.dirname(fileURLToPath(import.meta.url));
 const repositoryRoot = path.resolve(testDirectory, "../../../..");
+
+test("Bazel owns a hermetic no-window Chromium browser lane", () => {
+  const moduleFile = readFileSync(path.join(repositoryRoot, "MODULE.bazel"), "utf8");
+  assert.match(
+    moduleFile,
+    /bazel_dep\(name = "rules_playwright", version = "0\.5\.3"/,
+    "MODULE.bazel must pin the browser repository rule",
+  );
+  assert.match(
+    moduleFile,
+    /browsers_json = "\/\/donner\/editor\/wasm\/tests:browsers\.1\.62\.1\.json"/,
+    "the browser revisions must come from the Playwright version in package-lock.json",
+  );
+
+  const buildFilePath = path.join(testDirectory, "BUILD.bazel");
+  assert.ok(existsSync(buildFilePath), "Wasm browser tests need a Bazel package");
+  const buildFile = readFileSync(buildFilePath, "utf8");
+  assert.match(buildFile, /playwright_bin\.playwright_test\(/);
+  assert.match(buildFile, /name = "chromium_remote_smoke"/);
+  assert.match(buildFile, /"@playwright\/\/:chromium"/);
+  assert.match(buildFile, /"\/\/donner\/editor\/wasm:wasm_web_package"/);
+  assert.match(
+    buildFile,
+    /"PLAYWRIGHT_BROWSERS_PATH": "\$\(rootpath @playwright\/\/:chromium\)\/\.\.\/"/,
+  );
+
+  const chromiumConfig = readFileSync(path.join(testDirectory, "playwright.config.js"), "utf8");
+  assert.match(
+    chromiumConfig,
+    /channel:\s*"chromium"/,
+    "the regular Chromium build preserves WebGPU presentation without opening a window",
+  );
+});
 
 test("CI discovers Firefox, WebKit, and real Safari compatibility regressions", () => {
   const config = require("./playwright.compatibility.config.js");

--- a/donner/editor/wasm/tests/browser-matrix.spec.mjs
+++ b/donner/editor/wasm/tests/browser-matrix.spec.mjs
@@ -9,6 +9,48 @@ const require = createRequire(import.meta.url);
 const testDirectory = path.dirname(fileURLToPath(import.meta.url));
 const repositoryRoot = path.resolve(testDirectory, "../../../..");
 
+test("Playwright version stays synchronized across package locks and browser metadata", () => {
+  const packageJson = JSON.parse(readFileSync(path.join(testDirectory, "package.json"), "utf8"));
+  const packageLock = JSON.parse(
+    readFileSync(path.join(testDirectory, "package-lock.json"), "utf8"),
+  );
+  const playwrightVersion = packageJson.devDependencies["@playwright/test"];
+  assert.match(playwrightVersion, /^\d+\.\d+\.\d+$/);
+  assert.equal(packageLock.packages[""].devDependencies["@playwright/test"], playwrightVersion);
+  for (const packageName of ["@playwright/test", "playwright", "playwright-core"]) {
+    assert.equal(
+      packageLock.packages[`node_modules/${packageName}`].version,
+      playwrightVersion,
+      `${packageName} in package-lock.json must match package.json`,
+    );
+  }
+
+  const pnpmLock = readFileSync(path.join(testDirectory, "pnpm-lock.yaml"), "utf8");
+  for (
+    const lockEntry of [
+      `specifier: ${playwrightVersion}`,
+      `version: ${playwrightVersion}`,
+      `'@playwright/test@${playwrightVersion}':`,
+      `playwright@${playwrightVersion}:`,
+      `playwright-core@${playwrightVersion}:`,
+    ]
+  ) {
+    assert.ok(pnpmLock.includes(lockEntry), `pnpm-lock.yaml is missing ${lockEntry}`);
+  }
+
+  const browserMetadataPath = path.join(
+    testDirectory,
+    `browsers.${playwrightVersion}.json`,
+  );
+  assert.ok(existsSync(browserMetadataPath), "browser metadata filename must match Playwright");
+  const browserMetadata = JSON.parse(readFileSync(browserMetadataPath, "utf8"));
+  assert.equal(browserMetadata.playwrightVersion, playwrightVersion);
+  assert.equal(
+    browserMetadata.comment,
+    `Pinned from playwright-core ${playwrightVersion}; update with the npm lock.`,
+  );
+});
+
 test("Bazel owns a hermetic no-window Chromium browser lane", () => {
   const moduleFile = readFileSync(path.join(repositoryRoot, "MODULE.bazel"), "utf8");
   assert.match(
@@ -188,17 +230,17 @@ test("CI discovers Firefox, WebKit, and real Safari compatibility regressions", 
     .replace(/\\\s*\n\s*/g, " ")
     .replace(/\s+/g, " ");
   const laneCommands = [
-    'run_lane "chromium-default" bash donner/editor/wasm/tests/run_tests.sh --headed',
-    'run_lane "firefox-geode-resize" npm --prefix donner/editor/wasm/tests' +
-      " run test:compatibility -- --project=firefox-geode-resize --headed",
-    'run_lane "webkit-geode-carousel" npm --prefix donner/editor/wasm/tests' +
-      " run test:compatibility -- --project=webkit-geode-carousel --headed",
-    'run_lane "firefox-composited-invariants" bash' +
-      " donner/editor/wasm/tests/run_tests.sh --headed" +
-      " --config=playwright.composited-firefox.config.js",
-    'run_lane "composited-chromium" bash' +
-      " donner/editor/wasm/tests/run_tests.sh --headed" +
-      " --config=playwright.composited-chromium.config.js",
+    "run_lane \"chromium-default\" bash donner/editor/wasm/tests/run_tests.sh --headed",
+    "run_lane \"firefox-geode-resize\" npm --prefix donner/editor/wasm/tests"
+    + " run test:compatibility -- --project=firefox-geode-resize --headed",
+    "run_lane \"webkit-geode-carousel\" npm --prefix donner/editor/wasm/tests"
+    + " run test:compatibility -- --project=webkit-geode-carousel --headed",
+    "run_lane \"firefox-composited-invariants\" bash"
+    + " donner/editor/wasm/tests/run_tests.sh --headed"
+    + " --config=playwright.composited-firefox.config.js",
+    "run_lane \"composited-chromium\" bash"
+    + " donner/editor/wasm/tests/run_tests.sh --headed"
+    + " --config=playwright.composited-chromium.config.js",
   ];
   let searchFrom = 0;
   for (const laneCommand of laneCommands) {

--- a/donner/editor/wasm/tests/browser-matrix.spec.mjs
+++ b/donner/editor/wasm/tests/browser-matrix.spec.mjs
@@ -30,13 +30,17 @@ test("Playwright version stays synchronized across package locks and browser met
     const lockEntry of [
       `specifier: ${playwrightVersion}`,
       `version: ${playwrightVersion}`,
-      `'@playwright/test@${playwrightVersion}':`,
       `playwright@${playwrightVersion}:`,
       `playwright-core@${playwrightVersion}:`,
     ]
   ) {
     assert.ok(pnpmLock.includes(lockEntry), `pnpm-lock.yaml is missing ${lockEntry}`);
   }
+  const scopedPackageKey = `@playwright/test@${playwrightVersion}`;
+  assert.ok(
+    pnpmLock.includes(`'${scopedPackageKey}':`) || pnpmLock.includes(`"${scopedPackageKey}":`),
+    `pnpm-lock.yaml is missing the exact ${scopedPackageKey} key`,
+  );
 
   const browserMetadataPath = path.join(
     testDirectory,

--- a/donner/editor/wasm/tests/browser-matrix.spec.mjs
+++ b/donner/editor/wasm/tests/browser-matrix.spec.mjs
@@ -43,7 +43,17 @@ test("Bazel owns a hermetic no-window Chromium browser lane", () => {
   assert.match(buildFile, /playwright_bin\.playwright_test\(/);
   assert.match(buildFile, /name = "chromium_remote_smoke"/);
   assert.match(buildFile, /"@playwright\/\/:chromium"/);
-  assert.match(buildFile, /"\/\/donner\/editor\/wasm:wasm_web_package"/);
+  assert.match(
+    buildFile,
+    /"\/\/donner\/editor\/wasm:_wasm_web_package_for_serve"/,
+    "the browser lane must own the editor-Wasm transition instead of requiring caller flags",
+  );
+  const editorBuildFile = readFileSync(path.join(testDirectory, "..", "BUILD.bazel"), "utf8");
+  assert.match(
+    editorBuildFile,
+    /editor_wasm_geode_transitioned_target\([\s\S]*?name = "_wasm_web_package_for_serve"[\s\S]*?visibility = \["\/\/donner\/editor\/wasm\/tests:__pkg__"\]/,
+    "only the browser-test package should be able to consume the transitioned web package",
+  );
   assert.match(
     buildFile,
     /"PLAYWRIGHT_BROWSERS_PATH": "\$\(rootpath @playwright\/\/:chromium\)\/\.\.\/"/,

--- a/donner/editor/wasm/tests/browser-matrix.spec.mjs
+++ b/donner/editor/wasm/tests/browser-matrix.spec.mjs
@@ -58,10 +58,10 @@ test("Bazel owns a hermetic no-window Chromium browser lane", () => {
     buildFile,
     /"PLAYWRIGHT_BROWSERS_PATH": "\$\(rootpath @playwright\/\/:chromium\)\/\.\.\/"/,
   );
-  assert.doesNotMatch(
+  assert.match(
     buildFile,
-    /"@platforms\/\/os:linux"/,
-    "the headless browser test must remain runnable on macOS remote execution",
+    /target_compatible_with = \[[\s\S]*?"@platforms\/\/cpu:aarch64"[\s\S]*?\] \+ select\(\{[\s\S]*?"@platforms\/\/os:macos": \[\][\s\S]*?"@platforms\/\/os:linux": \[\][\s\S]*?"\/\/conditions:default": \["@platforms\/\/:incompatible"\]/,
+    "the headless browser test must allow only macOS and Linux ARM64 execution",
   );
 
   const chromiumConfig = readFileSync(path.join(testDirectory, "playwright.config.js"), "utf8");
@@ -78,6 +78,35 @@ test("browser diagnostics do not manufacture fatal adapter failures", () => {
     smokeTest,
     /requestAdapter\(\{ forceFallbackAdapter: true \}\)/,
     "an optional fallback-adapter probe must not emit a fatal-class browser warning",
+  );
+  assert.match(
+    smokeTest,
+    /const recordFatalMessage[\s\S]*?fatalMessages\.push[\s\S]*?console\.error[\s\S]*?page\.on\("console"[\s\S]*?recordFatalMessage[\s\S]*?page\.on\("pageerror"[\s\S]*?recordFatalMessage/,
+    "startup failures must be emitted while they are captured, before openEditor can time out",
+  );
+});
+
+test("remote browser server preserves bounded request failures", () => {
+  const server = readFileSync(path.join(testDirectory, "remote-webserver.mjs"), "utf8");
+  assert.match(
+    server,
+    /function describeServerError[\s\S]*?replaceAll\(root, "<package>"\)[\s\S]*?if \(error\?\.code !== "ENOENT"\) \{[\s\S]*?console\.error/,
+    "the remote webserver must preserve bounded package and request failures in test.log",
+  );
+  assert.match(
+    server,
+    /\.replace\(\/\(\?:\\\/\[\^\\s\/:\]\+\)\{2,\}\/g, "<path>"\)/,
+    "server diagnostics must scrub absolute paths outside the package root",
+  );
+  assert.match(
+    server,
+    /\.slice\(0, 512\)/,
+    "server diagnostics must stay bounded in remote test logs",
+  );
+  assert.match(
+    server,
+    /console\.error\(`remote-webserver request failed: \$\{describeServerError\(error\)\}`\)/,
+    "non-ENOENT failures must emit the sanitized diagnostic",
   );
 });
 

--- a/donner/editor/wasm/tests/browser-matrix.spec.mjs
+++ b/donner/editor/wasm/tests/browser-matrix.spec.mjs
@@ -84,6 +84,16 @@ test("Bazel owns a hermetic no-window Chromium browser lane", () => {
   const buildFile = readFileSync(buildFilePath, "utf8");
   assert.match(buildFile, /playwright_bin\.playwright_test\(/);
   assert.match(buildFile, /name = "chromium_remote_smoke"/);
+  const smokeTest = readFileSync(path.join(testDirectory, "smoke.spec.ts"), "utf8");
+  const localSmokeImports = [...smokeTest.matchAll(/from "\.\/([^"]+)"/g)].map(
+    ([, importedModule]) => `${importedModule}.ts`,
+  );
+  for (const importedFile of localSmokeImports) {
+    assert.ok(
+      buildFile.includes(`"${importedFile}"`),
+      `the Bazel browser lane is missing smoke.spec.ts dependency ${importedFile}`,
+    );
+  }
   assert.match(buildFile, /"@playwright\/\/:chromium"/);
   assert.match(
     buildFile,

--- a/donner/editor/wasm/tests/browser-matrix.spec.mjs
+++ b/donner/editor/wasm/tests/browser-matrix.spec.mjs
@@ -42,6 +42,15 @@ test("Bazel owns a hermetic no-window Chromium browser lane", () => {
   );
 });
 
+test("browser diagnostics do not manufacture fatal adapter failures", () => {
+  const smokeTest = readFileSync(path.join(testDirectory, "smoke.spec.ts"), "utf8");
+  assert.doesNotMatch(
+    smokeTest,
+    /requestAdapter\(\{ forceFallbackAdapter: true \}\)/,
+    "an optional fallback-adapter probe must not emit a fatal-class browser warning",
+  );
+});
+
 test("CI discovers Firefox, WebKit, and real Safari compatibility regressions", () => {
   const config = require("./playwright.compatibility.config.js");
   const projects = new Map(config.projects.map((project) => [project.name, project]));

--- a/donner/editor/wasm/tests/browsers.1.62.1.json
+++ b/donner/editor/wasm/tests/browsers.1.62.1.json
@@ -1,4 +1,5 @@
 {
+  "playwrightVersion": "1.62.1",
   "comment": "Pinned from playwright-core 1.62.1; update with the npm lock.",
   "browsers": [
     {

--- a/donner/editor/wasm/tests/browsers.1.62.1.json
+++ b/donner/editor/wasm/tests/browsers.1.62.1.json
@@ -1,0 +1,75 @@
+{
+  "comment": "Pinned from playwright-core 1.62.1; update with the npm lock.",
+  "browsers": [
+    {
+      "name": "chromium",
+      "revision": "1234",
+      "installByDefault": true,
+      "browserVersion": "151.0.7922.34",
+      "title": "Chrome for Testing"
+    },
+    {
+      "name": "chromium-headless-shell",
+      "revision": "1234",
+      "installByDefault": true,
+      "browserVersion": "151.0.7922.34",
+      "title": "Chrome Headless Shell"
+    },
+    {
+      "name": "chromium-tip-of-tree",
+      "revision": "1433",
+      "installByDefault": false,
+      "browserVersion": "151.0.7893.0",
+      "title": "Chrome Canary for Testing"
+    },
+    {
+      "name": "chromium-tip-of-tree-headless-shell",
+      "revision": "1433",
+      "installByDefault": false,
+      "browserVersion": "151.0.7893.0",
+      "title": "Chrome Canary Headless Shell"
+    },
+    {
+      "name": "firefox",
+      "revision": "1538",
+      "installByDefault": true,
+      "browserVersion": "153.0",
+      "title": "Firefox"
+    },
+    {
+      "name": "firefox-beta",
+      "revision": "1526",
+      "installByDefault": false,
+      "browserVersion": "152.0b1",
+      "title": "Firefox Beta"
+    },
+    {
+      "name": "webkit",
+      "revision": "2336",
+      "installByDefault": true,
+      "revisionOverrides": {
+        "mac14": "2251",
+        "mac14-arm64": "2251",
+        "ubuntu20.04-x64": "2092",
+        "ubuntu20.04-arm64": "2092"
+      },
+      "browserVersion": "26.5",
+      "title": "WebKit"
+    },
+    {
+      "name": "ffmpeg",
+      "revision": "1011",
+      "installByDefault": true
+    },
+    {
+      "name": "winldd",
+      "revision": "1007",
+      "installByDefault": false
+    },
+    {
+      "name": "android",
+      "revision": "1001",
+      "installByDefault": false
+    }
+  ]
+}

--- a/donner/editor/wasm/tests/package-lock.json
+++ b/donner/editor/wasm/tests/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "donner-editor-wasm-tests",
       "devDependencies": {
-        "@playwright/test": "^1.59.1"
+        "@playwright/test": "1.62.1"
       }
     },
     "node_modules/@playwright/test": {

--- a/donner/editor/wasm/tests/package.json
+++ b/donner/editor/wasm/tests/package.json
@@ -9,6 +9,9 @@
     "test:selector": "node --test backend-selector.spec.mjs browser-matrix.spec.mjs isolation-fallback.spec.mjs loading-page.spec.mjs wgpu-readback-contract.spec.mjs"
   },
   "devDependencies": {
-    "@playwright/test": "^1.59.1"
+    "@playwright/test": "1.62.1"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": []
   }
 }

--- a/donner/editor/wasm/tests/playwright.bazel.config.js
+++ b/donner/editor/wasm/tests/playwright.bazel.config.js
@@ -1,0 +1,45 @@
+const { createHash } = require("node:crypto");
+const path = require("node:path");
+const baseConfig = require("./playwright.config.js");
+
+function requireEnvironment(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} must be supplied by the Bazel test target`);
+  }
+  return value;
+}
+
+function shellQuote(value) {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+const testIdentity = process.env.TEST_TMPDIR || process.cwd();
+const portSeed = createHash("sha256").update(testIdentity).digest().readUInt16BE(0);
+const port = 20000 + (portSeed % 20000);
+const baseUrl = `http://127.0.0.1:${port}`;
+const server = path.resolve(requireEnvironment("DONNER_WASM_TEST_SERVER"));
+const packageDirectory = path.resolve(requireEnvironment("DONNER_WASM_PACKAGE_DIR"));
+const outputRoot = process.env.TEST_UNDECLARED_OUTPUTS_DIR || requireEnvironment("TEST_TMPDIR");
+
+process.env.DONNER_WASM_BASE_URL = baseUrl;
+
+module.exports = {
+  ...baseConfig,
+  forbidOnly: true,
+  outputDir: path.join(outputRoot, "playwright"),
+  reporter: "list",
+  retries: 0,
+  workers: 1,
+  webServer: {
+    command: [
+      shellQuote(process.execPath),
+      shellQuote(server),
+      `--port ${port}`,
+      `--dir ${shellQuote(packageDirectory)}`,
+    ].join(" "),
+    reuseExistingServer: false,
+    timeout: 30000,
+    url: `${baseUrl}/index.html`,
+  },
+};

--- a/donner/editor/wasm/tests/playwright.config.js
+++ b/donner/editor/wasm/tests/playwright.config.js
@@ -27,6 +27,11 @@ module.exports = defineConfig({
   timeout: 30000,
   use: {
     ...devices["Desktop Chrome"],
+    // Playwright normally swaps in Chromium's legacy headless shell when
+    // headless. The regular Chromium channel uses the new headless path, which
+    // presents the transferred WebGPU canvas while still opening no window.
+    channel: "chromium",
+    headless: true,
     ignoreHTTPSErrors: true,
     launchOptions: {
       args: [

--- a/donner/editor/wasm/tests/pnpm-lock.yaml
+++ b/donner/editor/wasm/tests/pnpm-lock.yaml
@@ -1,0 +1,52 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@playwright/test':
+        specifier: 1.62.1
+        version: 1.62.1
+
+packages:
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+snapshots:
+
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
+  fsevents@2.3.2:
+    optional: true
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2

--- a/donner/editor/wasm/tests/pnpm-lock.yaml
+++ b/donner/editor/wasm/tests/pnpm-lock.yaml
@@ -1,42 +1,51 @@
-lockfileVersion: '9.0'
+lockfileVersion: "9.0"
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 importers:
-
   .:
     devDependencies:
-      '@playwright/test':
+      "@playwright/test":
         specifier: 1.62.1
         version: 1.62.1
 
 packages:
-
-  '@playwright/test@1.62.1':
-    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
-    engines: {node: '>=20'}
+  "@playwright/test@1.62.1":
+    resolution:
+      {
+        integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==,
+      }
+    engines: { node: ">=20" }
     hasBin: true
 
   fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    resolution:
+      {
+        integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==,
+      }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
     os: [darwin]
 
   playwright-core@1.62.1:
-    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==,
+      }
+    engines: { node: ">=20" }
     hasBin: true
 
   playwright@1.62.1:
-    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==,
+      }
+    engines: { node: ">=20" }
     hasBin: true
 
 snapshots:
-
-  '@playwright/test@1.62.1':
+  "@playwright/test@1.62.1":
     dependencies:
       playwright: 1.62.1
 

--- a/donner/editor/wasm/tests/remote-webserver.mjs
+++ b/donner/editor/wasm/tests/remote-webserver.mjs
@@ -37,6 +37,16 @@ function resolveRequestPath(requestUrl) {
   return candidate;
 }
 
+function describeServerError(error) {
+  const code = typeof error?.code === "string" ? error.code : "UNKNOWN";
+  const message = (error instanceof Error ? error.message : String(error))
+    .replaceAll(root, "<package>")
+    .replace(/(?:\/[^\s/:]+){2,}/g, "<path>")
+    .replace(/\s+/g, " ")
+    .slice(0, 512);
+  return `${code}: ${message}`;
+}
+
 const server = createServer(async (request, response) => {
   response.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
   response.setHeader("Cross-Origin-Opener-Policy", "same-origin");
@@ -65,6 +75,9 @@ const server = createServer(async (request, response) => {
     }
     await pipeline(createReadStream(filePath), response);
   } catch (error) {
+    if (error?.code !== "ENOENT") {
+      console.error(`remote-webserver request failed: ${describeServerError(error)}`);
+    }
     if (!response.headersSent) {
       response.writeHead(error?.code === "ENOENT" ? 404 : 500);
     }

--- a/donner/editor/wasm/tests/remote-webserver.mjs
+++ b/donner/editor/wasm/tests/remote-webserver.mjs
@@ -1,0 +1,75 @@
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import { createServer } from "node:http";
+import path from "node:path";
+import { pipeline } from "node:stream/promises";
+
+function argument(name) {
+  const index = process.argv.indexOf(name);
+  if (index < 0 || index + 1 >= process.argv.length) {
+    throw new Error(`${name} is required`);
+  }
+  return process.argv[index + 1];
+}
+
+const port = Number.parseInt(argument("--port"), 10);
+const root = path.resolve(argument("--dir"));
+if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+  throw new Error("--port must be an integer from 1 through 65535");
+}
+
+const contentTypes = new Map([
+  [".css", "text/css; charset=utf-8"],
+  [".html", "text/html; charset=utf-8"],
+  [".js", "text/javascript; charset=utf-8"],
+  [".json", "application/json; charset=utf-8"],
+  [".svg", "image/svg+xml"],
+  [".wasm", "application/wasm"],
+]);
+
+function resolveRequestPath(requestUrl) {
+  const pathname = decodeURIComponent(new URL(requestUrl, "http://127.0.0.1").pathname);
+  const relativePath = pathname === "/" ? "index.html" : pathname.slice(1);
+  const candidate = path.resolve(root, relativePath);
+  if (candidate !== root && !candidate.startsWith(`${root}${path.sep}`)) {
+    return null;
+  }
+  return candidate;
+}
+
+const server = createServer(async (request, response) => {
+  response.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+  response.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+  response.setHeader("Cache-Control", "no-store");
+
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    response.writeHead(405, { Allow: "GET, HEAD" });
+    response.end();
+    return;
+  }
+
+  try {
+    const filePath = resolveRequestPath(request.url || "/");
+    if (!filePath || !(await stat(filePath)).isFile()) {
+      response.writeHead(404);
+      response.end("Not found\n");
+      return;
+    }
+
+    response.writeHead(200, {
+      "Content-Type": contentTypes.get(path.extname(filePath)) || "application/octet-stream",
+    });
+    if (request.method === "HEAD") {
+      response.end();
+      return;
+    }
+    await pipeline(createReadStream(filePath), response);
+  } catch (error) {
+    if (!response.headersSent) {
+      response.writeHead(error?.code === "ENOENT" ? 404 : 500);
+    }
+    response.end(error?.code === "ENOENT" ? "Not found\n" : "Server error\n");
+  }
+});
+
+server.listen(port, "127.0.0.1");

--- a/donner/editor/wasm/tests/smoke.spec.ts
+++ b/donner/editor/wasm/tests/smoke.spec.ts
@@ -207,26 +207,14 @@ test.use({
 });
 
 async function readWebGpuDiagnostics(page: Page) {
-  const browser = await page.evaluate(async () => {
+  const browser = await page.evaluate(() => {
     const gpu = navigator.gpu;
-    let fallbackAdapterAvailable = false;
-    let adapterRequestError: string | null = null;
-    if (gpu) {
-      try {
-        fallbackAdapterAvailable =
-          (await gpu.requestAdapter({ forceFallbackAdapter: true })) !== null;
-      } catch (error) {
-        adapterRequestError = String(error);
-      }
-    }
 
     return {
       isSecureContext,
       crossOriginIsolated,
       hasSharedArrayBuffer: typeof SharedArrayBuffer !== "undefined",
       hasNavigatorGpu: Boolean(gpu),
-      fallbackAdapterAvailable,
-      adapterRequestError,
       selectedBackend: window.__donnerBackend,
       userAgent: navigator.userAgent,
     };

--- a/donner/editor/wasm/tests/smoke.spec.ts
+++ b/donner/editor/wasm/tests/smoke.spec.ts
@@ -281,15 +281,20 @@ async function openEditor(page: Page, options: OpenEditorOptions = {}): Promise<
     url.searchParams.set("wgpuReadbackStats", "1");
   }
   const fatalMessages: string[] = [];
+  const recordFatalMessage = (message: string) => {
+    const boundedMessage = message.replace(/\s+/g, " ").slice(0, 2000);
+    fatalMessages.push(boundedMessage);
+    console.error(`browser fatal: ${boundedMessage}`);
+  };
 
   page.on("console", (message) => {
     const text = message.text();
     if (kFatalRuntimePattern.test(text)) {
-      fatalMessages.push(`[console:${message.type()}] ${text}`);
+      recordFatalMessage(`[console:${message.type()}] ${text}`);
     }
   });
   page.on("pageerror", (error) => {
-    fatalMessages.push(`[pageerror] ${error.stack || error.message}`);
+    recordFatalMessage(`[pageerror] ${error.stack || error.message}`);
   });
 
   await page.goto(url.toString(), { waitUntil: "domcontentloaded" });

--- a/donner/svg/renderer/RendererGeode.cc
+++ b/donner/svg/renderer/RendererGeode.cc
@@ -1985,6 +1985,12 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
     std::vector<SceneInstance> sceneInstances;
     wgpu::Buffer sceneChunkBuffer;
     wgpu::Buffer sceneRecordBuffer;
+    /// Stable identities of the two buffers above (see
+    /// `GeodeDevice::AllocateBufferId`). The encoder's bind-group cache
+    /// outlives the document, so it keys on these rather than on the handle
+    /// addresses, which are recycled once the document is destroyed.
+    uint64_t sceneChunkBufferId = 0;
+    uint64_t sceneRecordBufferId = 0;
     uint32_t sceneFirstInstance = 0;
     /// Byte offset of the first instance's record inside sceneRecordBuffer
     /// (indices are global across slab chunks; offsets are per-buffer).
@@ -2331,6 +2337,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       geode::GeoEncoder::SceneBatchBinding binding = {};
       binding.chunkBuffer = batch.sceneChunkBuffer;
       binding.recordBuffer = batch.sceneRecordBuffer;
+      binding.chunkBufferId = batch.sceneChunkBufferId;
+      binding.recordBufferId = batch.sceneRecordBufferId;
       binding.firstRecordOffset = batch.sceneFirstRecordOffset;
       binding.instanceCount = static_cast<uint32_t>(batch.sceneInstances.size());
       binding.vertexCount = batch.sceneVertexCount;
@@ -2497,6 +2505,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
           recordSlotPtr != nullptr ? *recordSlotPtr : residentFillSlot->recordSlot;
       const wgpu::Buffer chunk = residentFillSlot->buffer;
       const wgpu::Buffer recordBuf = effectiveRecordSlot.buffer;
+      const uint64_t chunkId = residentFillSlot->bufferId;
+      const uint64_t recordBufId = effectiveRecordSlot.bufferId;
       const uint32_t recordIndex = effectiveRecordSlot.index;
       const uint32_t vertexCount = encoded->boundingDrawVertexCount();
 
@@ -2511,8 +2521,11 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       };
 
       if (pendingBatch.has_value() && pendingBatch->mode == PendingBatch::Mode::Scene) {
-        if (pendingBatch->sceneChunkBuffer == chunk &&
-            pendingBatch->sceneRecordBuffer == recordBuf &&
+        // Buffer identities, not handles: the two are interchangeable inside
+        // one frame, but comparing ids keeps every "is this the same buffer?"
+        // question in this file answered the same way.
+        if (pendingBatch->sceneChunkBufferId == chunkId &&
+            pendingBatch->sceneRecordBufferId == recordBufId &&
             pendingBatch->sceneClipVersion == clipVersion &&
             pendingBatch->sceneFirstInstance + pendingBatch->sceneInstances.size() ==
                 recordIndex) {
@@ -2526,6 +2539,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
           pendingBatch->mode = PendingBatch::Mode::Scene;
           pendingBatch->sceneChunkBuffer = chunk;
           pendingBatch->sceneRecordBuffer = recordBuf;
+          pendingBatch->sceneChunkBufferId = chunkId;
+          pendingBatch->sceneRecordBufferId = recordBufId;
           pendingBatch->sceneFirstInstance = recordIndex;
           pendingBatch->sceneFirstRecordOffset = effectiveRecordSlot.offset;
           pendingBatch->sceneClipVersion = clipVersion;
@@ -2571,17 +2586,22 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
               firstRecordSlotPtr != nullptr ? *firstRecordSlotPtr : first.slot->recordSlot;
           const wgpu::Buffer firstChunk = first.slot->buffer;
           const wgpu::Buffer firstRecordBuf = effectiveFirstRecordSlot.buffer;
+          const uint64_t firstChunkId = first.slot->bufferId;
+          const uint64_t firstRecordBufId = effectiveFirstRecordSlot.bufferId;
           const uint32_t firstIndex = effectiveFirstRecordSlot.index;
           pendingBatch = PendingBatch{};
           pendingBatch->mode = PendingBatch::Mode::Scene;
           pendingBatch->sceneChunkBuffer = firstChunk;
           pendingBatch->sceneRecordBuffer = firstRecordBuf;
+          pendingBatch->sceneChunkBufferId = firstChunkId;
+          pendingBatch->sceneRecordBufferId = firstRecordBufId;
           pendingBatch->sceneFirstInstance = firstIndex;
           pendingBatch->sceneFirstRecordOffset = effectiveFirstRecordSlot.offset;
           pendingBatch->sceneClipVersion = clipVersion;
           pendingBatch->sceneVertexCount = first.vertexCount;
           pendingBatch->sceneInstances.push_back(first);
-          if (firstChunk == chunk && firstRecordBuf == recordBuf && firstIndex + 1 == recordIndex) {
+          if (firstChunkId == chunkId && firstRecordBufId == recordBufId &&
+              firstIndex + 1 == recordIndex) {
             appendSceneInstance(*pendingBatch,
                                 PendingBatch::SceneInstance{residentFillSlot, encoded, &path,
                                                             color, rule,
@@ -2593,6 +2613,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
             pendingBatch->mode = PendingBatch::Mode::Scene;
             pendingBatch->sceneChunkBuffer = chunk;
             pendingBatch->sceneRecordBuffer = recordBuf;
+            pendingBatch->sceneChunkBufferId = chunkId;
+            pendingBatch->sceneRecordBufferId = recordBufId;
             pendingBatch->sceneFirstInstance = recordIndex;
             pendingBatch->sceneFirstRecordOffset = effectiveRecordSlot.offset;
             pendingBatch->sceneClipVersion = clipVersion;
@@ -2631,6 +2653,8 @@ struct RendererGeode::Impl : public geode::GeometryDebugSink, public geode::Filt
       pendingBatch->mode = PendingBatch::Mode::Scene;
       pendingBatch->sceneChunkBuffer = chunk;
       pendingBatch->sceneRecordBuffer = recordBuf;
+      pendingBatch->sceneChunkBufferId = chunkId;
+      pendingBatch->sceneRecordBufferId = recordBufId;
       pendingBatch->sceneFirstInstance = recordIndex;
       pendingBatch->sceneFirstRecordOffset = effectiveRecordSlot.offset;
       pendingBatch->sceneClipVersion = clipVersion;

--- a/donner/svg/renderer/geode/BUILD.bazel
+++ b/donner/svg/renderer/geode/BUILD.bazel
@@ -131,6 +131,10 @@ donner_cc_library(
     target_compatible_with = _GEODE_ONLY,
     visibility = ["//donner/svg/renderer:__subpackages__"],
     deps = [
+        # The slabs stamp every buffer they create with
+        # `GeodeDevice::AllocateBufferId`, which is defined out of line, so
+        # this is a link dependency and not just an include.
+        ":geode_device",
         ":geode_wgpu_util",
         "//third_party/webgpu-cpp:webgpu_cpp",
     ],

--- a/donner/svg/renderer/geode/GeoEncoder.cc
+++ b/donner/svg/renderer/geode/GeoEncoder.cc
@@ -389,6 +389,12 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
     ScopedWgpuHandle<wgpu::Buffer> buffer;
     uint64_t capacity = 0;
     uint64_t offset = 0;  // Next unused byte within `buffer`.
+    /// Stable identity of `buffer` (see `GeodeDevice::AllocateBufferId`),
+    /// re-stamped on every growth. Arena buffers are recycled through the
+    /// device's buffer pool, so two arenas at different times can hold the
+    /// same handle address with completely different contents; anything
+    /// that caches across frames must compare this id instead.
+    uint64_t bufferId = 0;
     std::vector<ScopedWgpuHandle<wgpu::Buffer>> retired;
     wgpu::BufferUsage usage = wgpu::BufferUsage::CopyDst;
     const char* label = "GeodeArena";
@@ -459,6 +465,8 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
     wgpu::Buffer buffer;
     uint64_t offset;
     uint64_t size;
+    /// Stable identity of `buffer`; see `Arena::bufferId`.
+    uint64_t bufferId = 0;
   };
   /// One shared uniform allocation for every scene-batch draw this encoder
   /// records while the uniform bytes stay unchanged (identity mvp plus
@@ -514,6 +522,10 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
         device->countBuffer();
         arena.capacity = newCap;
       }
+      // Fresh identity for the new backing buffer, pooled or not: the
+      // contents restart at offset 0 and share nothing with the retired
+      // buffer, even when the pool hands back the same handle address.
+      arena.bufferId = GeodeDevice::AllocateBufferId();
       arena.offset = 0;
     }
   }
@@ -584,7 +596,7 @@ struct GeoEncoder::Impl : public GeodeTextureEncoder::UniformScratch {
     device->queue().writeBuffer(arena.buffer.get(), alignedOffset, data, size);
     device->countBufferWrite(size);
     arena.offset = alignedOffset + size;
-    return {arena.buffer.get(), alignedOffset, size};
+    return {arena.buffer.get(), alignedOffset, size, arena.bufferId};
   }
 
   /// Allocate a read-only storage binding for `byteCount` bytes of `data`,
@@ -1755,6 +1767,7 @@ void GeoEncoder::Impl::uploadResidentGeometry(GeodeResidentSlot& slot, const Enc
     return;
   }
   slot.buffer = alloc.buffer;
+  slot.bufferId = alloc.bufferId;
   slot.allocationOffset = alloc.offset;
   slot.allocationSize = alloc.size;
 
@@ -2164,7 +2177,10 @@ void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,
   impl_->populateBatchUniform(u, args, Transform2d(), /*identityMvp=*/true);
   Impl::Allocation uniAlloc = {};
   if (binding.recordSlab != nullptr) {
-    uniAlloc.buffer = binding.recordSlab->acquireBatchUniform(*impl_->device, &u, sizeof(Uniforms));
+    const GeodeRecordSlab::BatchUniformHandle uniform =
+        binding.recordSlab->acquireBatchUniform(*impl_->device, &u, sizeof(Uniforms));
+    uniAlloc.buffer = uniform.buffer;
+    uniAlloc.bufferId = uniform.bufferId;
     uniAlloc.offset = 0;
     uniAlloc.size = sizeof(Uniforms);
   }
@@ -2210,17 +2226,28 @@ void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,
   chunkEntry(9, 9);
   chunkEntry(10, 10);
 
+  // Buffer IDENTITIES, never handle addresses: the cache lives on the
+  // device, which outlives the documents drawn on it, and a destroyed
+  // document's handle addresses are handed straight back out to the next
+  // one. See `GeodeDevice::SceneBatchBindGroupKey`.
   GeodeDevice::SceneBatchBindGroupKey cacheKey = {};
-  cacheKey.uniformBuffer = uniAlloc.buffer;
+  cacheKey.uniformBufferId = uniAlloc.bufferId;
   cacheKey.uniformOffset = uniAlloc.offset;
   cacheKey.uniformSize = uniAlloc.size;
-  cacheKey.chunkBuffer = binding.chunkBuffer;
+  cacheKey.chunkBufferId = binding.chunkBufferId;
   cacheKey.chunkBytes = chunkBytes;
-  cacheKey.recordBuffer = binding.recordBuffer;
+  cacheKey.recordBufferId = binding.recordBufferId;
   cacheKey.recordOffset = recordSpanStart;
   cacheKey.recordBytes = recordSpanBytes;
 
-  wgpu::BindGroup bindGroup = impl_->device->findSceneBatchBindGroup(cacheKey);
+  // A zero id means some buffer in this binding has no stable identity, so
+  // no key can distinguish it from a later buffer; skip the cache entirely
+  // rather than store an entry that a future batch could match by accident.
+  const bool cacheable =
+      cacheKey.uniformBufferId != 0 && cacheKey.chunkBufferId != 0 && cacheKey.recordBufferId != 0;
+
+  wgpu::BindGroup bindGroup =
+      cacheable ? impl_->device->findSceneBatchBindGroup(cacheKey) : wgpu::BindGroup{};
   if (!bindGroup) {
     wgpu::BindGroupDescriptor bgDesc = {};
     bgDesc.label = wgpuLabel("GeodeSceneBatchBindGroup");
@@ -2230,9 +2257,16 @@ void GeoEncoder::fillPathSceneBatch(const css::RGBA& color, FillRule rule,
     wgpu::BindGroup created = impl_->device->device().createBindGroup(bgDesc);
     impl_->device->countBindGroup();
     bindGroup = created;
-    // The cache takes ownership of the +1 handle and keeps the bound
-    // buffers alive for the entry's lifetime.
-    impl_->device->storeSceneBatchBindGroup(cacheKey, std::move(created));
+    if (cacheable) {
+      // The cache takes ownership of the +1 handle.
+      impl_->device->storeSceneBatchBindGroup(cacheKey, std::move(created));
+    } else {
+      // Defensive only: every buffer that can reach this call is stamped at
+      // creation, so no live path produces a zero id today. Hand the +1 to
+      // the encoder's per-frame arena so that if one ever does, the bind
+      // group is released at the frame boundary instead of leaking.
+      bindGroup = impl_->transientResources.retain(created);
+    }
   }
 
   // The binding covers the span of consecutive record slots starting at
@@ -2600,6 +2634,7 @@ void GeoEncoder::Impl::uploadResidentGradientGeometry(GeodeResidentGradientSlot&
     return;
   }
   slot.buffer = alloc.buffer;
+  slot.bufferId = alloc.bufferId;
   slot.allocationOffset = alloc.offset;
   slot.allocationSize = alloc.size;
 

--- a/donner/svg/renderer/geode/GeoEncoder.h
+++ b/donner/svg/renderer/geode/GeoEncoder.h
@@ -586,6 +586,12 @@ public:
   struct SceneBatchBinding {
     wgpu::Buffer chunkBuffer;   ///< Slab chunk holding every instance's geometry.
     wgpu::Buffer recordBuffer;  ///< Record-slab buffer holding the records.
+    /// Stable identities of `chunkBuffer` / `recordBuffer` (see
+    /// `GeodeDevice::AllocateBufferId`). The bind-group cache outlives the
+    /// document that owns these buffers, so it keys on these ids; the raw
+    /// handle addresses are recycled once that document is destroyed.
+    uint64_t chunkBufferId = 0;
+    uint64_t recordBufferId = 0;
     /// BYTE offset of the first instance's record inside recordBuffer.
     /// Record-slot indices are global across slab chunks, so an index is
     /// not a byte offset once the slab has grown; the caller passes the

--- a/donner/svg/renderer/geode/GeodeDevice.cc
+++ b/donner/svg/renderer/geode/GeodeDevice.cc
@@ -240,7 +240,15 @@ namespace {
 /// Monotonic source for `GeodeDevice::deviceId()`. Never reused, starts at 1
 /// (0 is the "no device" sentinel on a `GeodeResidentSlot`).
 std::atomic<uint64_t> g_nextDeviceId{0};
+
+/// Monotonic source for `GeodeDevice::AllocateBufferId()`. Never reused,
+/// starts at 1 (0 is the "no buffer" sentinel).
+std::atomic<uint64_t> g_nextBufferId{0};
 }  // namespace
+
+uint64_t GeodeDevice::AllocateBufferId() {
+  return g_nextBufferId.fetch_add(1, std::memory_order_relaxed) + 1;
+}
 
 GeodeDevice::GeodeDevice()
     : impl_(std::make_unique<Impl>()),

--- a/donner/svg/renderer/geode/GeodeDevice.h
+++ b/donner/svg/renderer/geode/GeodeDevice.h
@@ -325,28 +325,57 @@ public:
    * Scene batches bind pooled arena and slab buffers whose identities and
    * offsets are stable across steady-state frames, so a cached bind group
    * keyed this way is reusable frame over frame (keeping the per-frame
-   * bind-group create count flat; the GeodePerf ceilings pin this). A
-   * cached entry holds a reference to its bind group, which in turn keeps
-   * every bound buffer alive, so a raw handle in a live key can never be
-   * recycled for a different buffer.
+   * bind-group create count flat; the GeodePerf ceilings pin this).
+   *
+   * Buffers are identified by the process-unique ids handed out by
+   * `AllocateBufferId()`, NOT by their `WGPUBuffer` handle addresses. A
+   * cached bind group keeps the buffer's GPU-side resource alive inside
+   * WebGPU, but it does NOT keep the caller's handle object alive: when the
+   * document that owned a slab chunk is destroyed, its handles are released
+   * and their addresses become available to the allocator again. A device
+   * outlives the documents drawn on it (renderers lease devices from a
+   * small idle pool), so a later document's freshly created buffer can land
+   * on a recycled address and - with identical chunk sizes and record
+   * offsets, the norm for small documents - compare EQUAL to an entry left
+   * behind by the dead one. The lookup would then hand back the previous
+   * document's bind group and the batch would draw that document's records
+   * and geometry, which shows up as whole shapes rendered at another
+   * document's transform.
    */
   struct SceneBatchBindGroupKey {
-    WGPUBuffer uniformBuffer = nullptr;
+    uint64_t uniformBufferId = 0;
     uint64_t uniformOffset = 0;
     uint64_t uniformSize = 0;
-    WGPUBuffer chunkBuffer = nullptr;
+    uint64_t chunkBufferId = 0;
     uint64_t chunkBytes = 0;
-    WGPUBuffer recordBuffer = nullptr;
+    uint64_t recordBufferId = 0;
     uint64_t recordOffset = 0;
     uint64_t recordBytes = 0;
 
     friend bool operator<(const SceneBatchBindGroupKey& a, const SceneBatchBindGroupKey& b) {
-      return std::tie(a.uniformBuffer, a.uniformOffset, a.uniformSize, a.chunkBuffer, a.chunkBytes,
-                      a.recordBuffer, a.recordOffset, a.recordBytes) <
-             std::tie(b.uniformBuffer, b.uniformOffset, b.uniformSize, b.chunkBuffer, b.chunkBytes,
-                      b.recordBuffer, b.recordOffset, b.recordBytes);
+      return std::tie(a.uniformBufferId, a.uniformOffset, a.uniformSize, a.chunkBufferId,
+                      a.chunkBytes, a.recordBufferId, a.recordOffset, a.recordBytes) <
+             std::tie(b.uniformBufferId, b.uniformOffset, b.uniformSize, b.chunkBufferId,
+                      b.chunkBytes, b.recordBufferId, b.recordOffset, b.recordBytes);
     }
   };
+
+  /**
+   * Allocate a process-unique identity for a GPU buffer handle, from a
+   * monotonic counter that starts at 1 and is never reused.
+   *
+   * Anything that outlives a buffer and still has to answer "is this the
+   * same buffer I saw before?" must compare these ids rather than
+   * `WGPUBuffer` handle addresses. Releasing the last handle reference frees
+   * the handle object even while WebGPU keeps the underlying resource alive
+   * for bind groups and recorded commands that already reference it, so a
+   * later allocation can reuse the address and make two unrelated buffers
+   * indistinguishable. `deviceId()` exists for the same reason one level up.
+   *
+   * `0` is reserved for "no buffer", so a default-constructed id never
+   * matches a real one.
+   */
+  [[nodiscard]] static uint64_t AllocateBufferId();
 
   /// Look up a cached scene-batch bind group. Returns a borrowed handle
   /// (valid while the cache entry lives), or an empty handle on miss.

--- a/donner/svg/renderer/geode/GeodeResidentPathComponent.h
+++ b/donner/svg/renderer/geode/GeodeResidentPathComponent.h
@@ -104,6 +104,10 @@ public:
     wgpu::Buffer buffer;
     uint64_t offset = 0;
     uint32_t index = 0;
+    /// Stable identity of `buffer` (see `GeodeDevice::AllocateBufferId`).
+    /// Anything that caches keyed on this slot must compare the id: the
+    /// handle address is recycled once the owning slab is destroyed.
+    uint64_t bufferId = 0;
   };
 
   explicit GeodeRecordSlab(uint64_t deviceId) : owningDeviceId_(deviceId) {}
@@ -159,10 +163,11 @@ public:
         return false;
       }
       device.countBuffer();
-      chunks_.push_back(Chunk{std::move(buffer), newSize});
+      chunks_.push_back(Chunk{std::move(buffer), newSize, GeodeDevice::AllocateBufferId()});
       usedBytes_ = 0;
     }
     out.buffer = chunks_.back().buffer.get();
+    out.bufferId = chunks_.back().bufferId;
     out.offset = usedBytes_;
     // Indices are GLOBAL across chunks (slotAt walks cumulative chunk
     // capacities): a per-chunk index would collide with the previous
@@ -182,6 +187,13 @@ public:
   /// recorded batch draws still read.
   void freeSlot(const Slot& slot) { pendingFrees_.push_back(slot.index); }
 
+  /// A batch-uniform buffer plus its stable identity; `buffer` is null when
+  /// the slab declined (uniform cache full, or buffer creation failed).
+  struct BatchUniformHandle {
+    wgpu::Buffer buffer;
+    uint64_t bufferId = 0;
+  };
+
   /**
    * Persistent buffer holding one distinct scene-batch uniform value.
    *
@@ -197,15 +209,15 @@ public:
    * distinct values are live, and the caller falls back to its per-frame
    * arena.
    */
-  wgpu::Buffer acquireBatchUniform(GeodeDevice& device, const void* bytes, uint64_t size) {
+  BatchUniformHandle acquireBatchUniform(GeodeDevice& device, const void* bytes, uint64_t size) {
     const auto* first = static_cast<const uint8_t*>(bytes);
     for (const BatchUniform& entry : batchUniforms_) {
       if (entry.bytes.size() == size && std::memcmp(entry.bytes.data(), first, size) == 0) {
-        return entry.buffer.get();
+        return BatchUniformHandle{entry.buffer.get(), entry.bufferId};
       }
     }
     if (batchUniforms_.size() >= kMaxBatchUniforms) {
-      return wgpu::Buffer();
+      return BatchUniformHandle{};
     }
     wgpu::BufferDescriptor desc = {};
     desc.label = wgpuLabel("GeodeSceneBatchUniform");
@@ -213,14 +225,15 @@ public:
     desc.usage = wgpu::BufferUsage::Uniform | wgpu::BufferUsage::CopyDst;
     ScopedWgpuHandle<wgpu::Buffer> buffer(device.device().createBuffer(desc));
     if (!buffer) {
-      return wgpu::Buffer();
+      return BatchUniformHandle{};
     }
     device.countBuffer();
     device.queue().writeBuffer(buffer.get(), 0, first, size);
     device.countBufferWrite(size);
-    batchUniforms_.push_back(
-        BatchUniform{std::move(buffer), std::vector<uint8_t>(first, first + size)});
-    return batchUniforms_.back().buffer.get();
+    batchUniforms_.push_back(BatchUniform{std::move(buffer),
+                                          std::vector<uint8_t>(first, first + size),
+                                          GeodeDevice::AllocateBufferId()});
+    return BatchUniformHandle{batchUniforms_.back().buffer.get(), batchUniforms_.back().bufferId};
   }
 
   /// Borrowed handle of the newest buffer (batches bind sub-ranges of it).
@@ -244,11 +257,13 @@ private:
   struct Chunk {
     ScopedWgpuHandle<wgpu::Buffer> buffer;
     uint64_t size = 0;
+    uint64_t bufferId = 0;
   };
 
   struct BatchUniform {
     ScopedWgpuHandle<wgpu::Buffer> buffer;
     std::vector<uint8_t> bytes;
+    uint64_t bufferId = 0;
   };
 
   static constexpr uint64_t kInitialRecordSlabBytes = 262144u;
@@ -263,11 +278,11 @@ private:
     uint64_t offset = static_cast<uint64_t>(index) * sizeof(InstanceRecord);
     for (const Chunk& chunk : chunks_) {
       if (offset < chunk.size) {
-        return Slot{chunk.buffer.get(), offset, index};
+        return Slot{chunk.buffer.get(), offset, index, chunk.bufferId};
       }
       offset -= chunk.size;
     }
-    return Slot{wgpu::Buffer(), 0, index};
+    return Slot{wgpu::Buffer(), 0, index, 0};
   }
 
   uint64_t owningDeviceId_;
@@ -316,6 +331,10 @@ public:
     wgpu::Buffer buffer;  // Borrowed handle; owned by the slab chunk.
     uint64_t offset = 0;
     uint64_t size = 0;
+    /// Stable identity of `buffer` (see `GeodeDevice::AllocateBufferId`).
+    /// Only allocation results carry it; `free` matches on the handle,
+    /// which is unambiguous while the slab that owns the chunk is alive.
+    uint64_t bufferId = 0;
   };
 
   /// Create an empty slab bound to `deviceId` (usually the current
@@ -403,6 +422,7 @@ public:
       const uint64_t start = alignUp(it->offset, alignment);
       if (start + size <= it->offset + it->size) {
         out.buffer = chunks_[it->chunk].buffer.get();
+        out.bufferId = chunks_[it->chunk].bufferId;
         out.offset = start;
         out.size = size;
         if (start == it->offset) {
@@ -440,6 +460,7 @@ public:
       }
       device.countBuffer();
       chunk.size = newSize;
+      chunk.bufferId = GeodeDevice::AllocateBufferId();
       chunks_.push_back(std::move(chunk));
       if (!gauge_) {
         gauge_ = device.residentBytesGauge();
@@ -450,6 +471,7 @@ public:
 
     Chunk& chunk = chunks_.back();
     out.buffer = chunk.buffer.get();
+    out.bufferId = chunk.bufferId;
     out.offset = alignUp(chunk.cursor, alignment);
     out.size = size;
     chunk.cursor = out.offset + size;
@@ -462,10 +484,13 @@ public:
     if (alloc.size == 0) {
       return;
     }
-    // Locate the owning chunk.
+    // Locate the owning chunk by identity rather than by handle address, so
+    // the match means "the chunk this range was carved out of" and cannot be
+    // confused by a recycled handle. A default-constructed allocation carries
+    // id 0 and matches nothing, since ids start at 1.
     size_t chunkIndex = 0;
     for (; chunkIndex < chunks_.size(); ++chunkIndex) {
-      if (chunks_[chunkIndex].buffer.get() == alloc.buffer) {
+      if (chunks_[chunkIndex].bufferId == alloc.bufferId) {
         break;
       }
     }
@@ -486,6 +511,7 @@ private:
     ScopedWgpuHandle<wgpu::Buffer> buffer;
     uint64_t size = 0;
     uint64_t cursor = 0;
+    uint64_t bufferId = 0;
   };
 
   struct FreeRange {
@@ -526,6 +552,12 @@ struct GeodeResidentSlot {
   /// slab's allocation alignment so consecutive slots leave no unwritten
   /// bytes between them.
   wgpu::Buffer buffer;
+  /// Stable identity of `buffer` (see `GeodeDevice::AllocateBufferId`).
+  /// A cross-entity batch binds the whole chunk and caches the resulting
+  /// bind group past the lifetime of the document that owns it, so the
+  /// cache key has to name the chunk by this id rather than by the handle
+  /// address, which the allocator recycles once the slab is destroyed.
+  uint64_t bufferId = 0;
   /// Slab that owns `buffer`; null until residence is established. Held
   /// by shared_ptr so a device change (which swaps the registry's slab)
   /// cannot leave a slot referencing a destroyed slab: old slots keep the
@@ -643,7 +675,9 @@ struct GeodeResidentSlot {
     if (this != &other) {
       reset();
       buffer = other.buffer;
+      bufferId = other.bufferId;
       other.buffer = wgpu::Buffer();
+      other.bufferId = 0;
       slab = std::move(other.slab);
       allocationOffset = other.allocationOffset;
       allocationSize = other.allocationSize;
@@ -693,7 +727,7 @@ struct GeodeResidentSlot {
   /// done.
   void reset() {
     if (slab && allocationSize != 0) {
-      GeodeResidentSlab::Allocation alloc{buffer, allocationOffset, allocationSize};
+      GeodeResidentSlab::Allocation alloc{buffer, allocationOffset, allocationSize, bufferId};
       slab->free(alloc);
     }
     // The record slot survives geometry re-uploads: its painter-ordered
@@ -708,6 +742,7 @@ struct GeodeResidentSlot {
     allocationOffset = 0;
     allocationSize = 0;
     buffer = wgpu::Buffer();
+    bufferId = 0;
     bindGroup.reset();
     resident = false;
     encodedKey = nullptr;
@@ -734,6 +769,10 @@ struct GeodeResidentGradientSlot {
   /// offsets. Region layout matches \ref GeodeResidentSlot, with the
   /// uniform region sized for `GradientUniforms` (672 bytes).
   wgpu::Buffer buffer;
+  /// Stable identity of `buffer` (see `GeodeDevice::AllocateBufferId`), so
+  /// returning the allocation matches the owning chunk by identity rather
+  /// than by a handle address the allocator can recycle.
+  uint64_t bufferId = 0;
   /// Slab that owns `buffer`; null until residence is established. Held
   /// by shared_ptr so a device change (which swaps the registry's slab)
   /// cannot leave a slot referencing a destroyed slab: old slots keep the
@@ -795,7 +834,9 @@ struct GeodeResidentGradientSlot {
     if (this != &other) {
       reset();
       buffer = other.buffer;
+      bufferId = other.bufferId;
       other.buffer = wgpu::Buffer();
+      other.bufferId = 0;
       slab = std::move(other.slab);
       allocationOffset = other.allocationOffset;
       allocationSize = other.allocationSize;
@@ -829,7 +870,7 @@ struct GeodeResidentGradientSlot {
   /// Never calls `Buffer::destroy()`; see GeodeResidentSlot::reset.
   void reset() {
     if (slab && allocationSize != 0) {
-      GeodeResidentSlab::Allocation alloc{buffer, allocationOffset, allocationSize};
+      GeodeResidentSlab::Allocation alloc{buffer, allocationOffset, allocationSize, bufferId};
       slab->free(alloc);
     }
     // The slab pointers themselves are intentionally kept: they outlive
@@ -839,6 +880,7 @@ struct GeodeResidentGradientSlot {
     allocationOffset = 0;
     allocationSize = 0;
     buffer = wgpu::Buffer();
+    bufferId = 0;
     bindGroup.reset();
     resident = false;
     encodedKey = nullptr;

--- a/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
+++ b/donner/svg/renderer/geode/tests/GeoEncoder_tests.cc
@@ -6,6 +6,7 @@
 #include <array>
 #include <atomic>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <vector>
 
@@ -13,6 +14,7 @@
 #include "donner/base/Path.h"
 #include "donner/base/Transform.h"
 #include "donner/css/Color.h"
+#include "donner/svg/renderer/geode/GeodeBufferPool.h"
 #include "donner/svg/renderer/geode/GeodeCallbackState.h"
 #include "donner/svg/renderer/geode/GeodeDevice.h"
 #include "donner/svg/renderer/geode/GeodeGpuWait.h"
@@ -332,6 +334,308 @@ TEST_F(GeoEncoderTest, RecordSlabFreeListSurvivesChunkGrowth) {
     EXPECT_FALSE(live.buffer == reusedA.buffer && live.offset == reusedA.offset);
     EXPECT_FALSE(live.buffer == reusedB.buffer && live.offset == reusedB.offset);
   }
+}
+
+/// The scene-batch bind-group cache lives on the device, which outlives the
+/// documents drawn through it (renderers lease devices from an idle pool).
+/// A destroyed document's slabs release their buffer handles, and those
+/// addresses go straight back to the allocator, so a later document's
+/// buffers can land on them. Small documents make that collision easy -
+/// same chunk size, record offset 0, same record-span byte count - so a key
+/// built from handle addresses could compare EQUAL across two unrelated
+/// documents and the lookup would return the dead document's bind group,
+/// drawing its records and geometry instead. Buffer ids must therefore never
+/// repeat, no matter what the allocator does with the handles.
+TEST_F(GeoEncoderTest, BufferIdsAreNeverReusedAcrossSlabGenerations) {
+  struct SlabGeneration {
+    WGPUBuffer chunkHandle = nullptr;
+    WGPUBuffer recordHandle = nullptr;
+    WGPUBuffer uniformHandle = nullptr;
+    uint64_t chunkId = 0;
+    uint64_t recordId = 0;
+    uint64_t uniformId = 0;
+  };
+
+  // One document's worth of slabs, destroyed before returning: exactly the
+  // lifetime a rendered-and-closed document has.
+  const auto renderOneDocument = [this]() {
+    geode::GeodeResidentSlab geometry(device_->deviceId());
+    geode::GeodeRecordSlab records(device_->deviceId());
+
+    geode::GeodeResidentSlab::Allocation geometryAlloc;
+    EXPECT_TRUE(geometry.allocate(*device_, 4096, 256, geometryAlloc));
+    geode::GeodeRecordSlab::Slot recordSlot;
+    EXPECT_TRUE(records.allocateSlot(*device_, recordSlot));
+    const uint32_t uniformBytes[4] = {1u, 2u, 3u, 4u};
+    const geode::GeodeRecordSlab::BatchUniformHandle uniform =
+        records.acquireBatchUniform(*device_, uniformBytes, sizeof(uniformBytes));
+
+    SlabGeneration out;
+    out.chunkHandle = geometryAlloc.buffer;
+    out.recordHandle = recordSlot.buffer;
+    out.uniformHandle = uniform.buffer;
+    out.chunkId = geometryAlloc.bufferId;
+    out.recordId = recordSlot.bufferId;
+    out.uniformId = uniform.bufferId;
+    return out;
+  };
+
+  const SlabGeneration first = renderOneDocument();
+  const SlabGeneration second = renderOneDocument();
+
+  // 0 is the "no buffer" sentinel and must never be handed out.
+  EXPECT_NE(first.chunkId, 0u);
+  EXPECT_NE(first.recordId, 0u);
+  EXPECT_NE(first.uniformId, 0u);
+
+  EXPECT_NE(first.chunkId, second.chunkId);
+  EXPECT_NE(first.recordId, second.recordId);
+  EXPECT_NE(first.uniformId, second.uniformId);
+
+  // Two keys that agree on every size and offset - the shape two small
+  // documents rendered back to back produce - must stay distinct. Under the
+  // map's ordering, "distinct" means one sorts before the other.
+  const auto makeKey = [](const SlabGeneration& generation) {
+    geode::GeodeDevice::SceneBatchBindGroupKey key;
+    key.uniformBufferId = generation.uniformId;
+    key.uniformOffset = 0;
+    key.uniformSize = sizeof(geode::InstanceRecord);
+    key.chunkBufferId = generation.chunkId;
+    key.chunkBytes = 1u << 20;
+    key.recordBufferId = generation.recordId;
+    key.recordOffset = 0;
+    key.recordBytes = 2 * sizeof(geode::InstanceRecord);
+    return key;
+  };
+  const geode::GeodeDevice::SceneBatchBindGroupKey firstKey = makeKey(first);
+  const geode::GeodeDevice::SceneBatchBindGroupKey secondKey = makeKey(second);
+  EXPECT_TRUE(firstKey < secondKey || secondKey < firstKey)
+      << "Two documents' scene-batch keys collided; the second document would "
+         "draw the first's records and geometry";
+
+  // Within one slab generation the ids DO have to be stable, or the cache
+  // would miss every frame and the batched draw would rebuild its bind group
+  // each time.
+  geode::GeodeRecordSlab records(device_->deviceId());
+  geode::GeodeRecordSlab::Slot slotA;
+  geode::GeodeRecordSlab::Slot slotB;
+  ASSERT_TRUE(records.allocateSlot(*device_, slotA));
+  ASSERT_TRUE(records.allocateSlot(*device_, slotB));
+  ASSERT_EQ(slotA.buffer, slotB.buffer) << "Fixture must keep both slots in one chunk";
+  EXPECT_EQ(slotA.bufferId, slotB.bufferId);
+}
+
+/// End-to-end guard on the scene-batch bind-group cache lookup itself.
+///
+/// `BufferIdsAreNeverReusedAcrossSlabGenerations` pins the ids, but nothing
+/// forces `fillPathSceneBatch` to actually build its key out of them: keying
+/// on the `WGPUBuffer` handle addresses instead still passes every other test
+/// in this suite, every golden, and the whole resvg suite on any machine
+/// whose allocator happens not to recycle the handles. That is precisely the
+/// hole the original defect lived in, so the cache lookup gets its own
+/// assertion.
+///
+/// Two slab generations model two documents rendered through one pooled
+/// device, shaped so their bindings agree on everything the key can see -
+/// same chunk size, record offset 0, same record-span byte count, same
+/// uniform bytes. The first generation is fully destroyed before the second
+/// allocates, which is what frees the handle addresses for reuse. Every
+/// generation's first batch must MISS (one `createBindGroup`), because it
+/// binds different buffers; an immediate repeat within a generation must HIT
+/// (zero), because it binds the same ones.
+TEST_F(GeoEncoderTest, SceneBatchBindGroupCacheDistinguishesSlabGenerations) {
+  // One document's slabs, plus the two record slots its batch draws.
+  struct Generation {
+    std::shared_ptr<geode::GeodeResidentSlab> geometry;
+    std::shared_ptr<geode::GeodeRecordSlab> records;
+    geode::GeodeResidentSlab::Allocation chunk;
+    geode::GeodeRecordSlab::Slot recordSlots[2];
+  };
+
+  constexpr uint32_t kInstanceCount = 2;
+
+  const auto makeGeneration = [this]() {
+    Generation generation;
+    generation.geometry = std::make_shared<geode::GeodeResidentSlab>(device_->deviceId());
+    generation.records = std::make_shared<geode::GeodeRecordSlab>(device_->deviceId());
+    // 4 KiB of geometry is enough to own a chunk; the chunk's SIZE is what
+    // the key sees, and the slab's initial chunk is the same for every
+    // generation.
+    EXPECT_TRUE(generation.geometry->allocate(*device_, 4096, 256, generation.chunk));
+    for (uint32_t i = 0; i < kInstanceCount; ++i) {
+      EXPECT_TRUE(generation.records->allocateSlot(*device_, generation.recordSlots[i]));
+    }
+
+    // Populate the records so the batch is a real draw rather than a draw
+    // over uninitialized storage. Identity transform, a small quad bounding
+    // polygon, and zero band counts, so the shader's band-count gates stop
+    // before dereferencing the (empty) geometry chunk.
+    for (uint32_t i = 0; i < kInstanceCount; ++i) {
+      geode::InstanceRecord record = {};
+      record.transformRow0[0] = 1.0f;
+      record.transformRow1[1] = 1.0f;
+      record.color[1] = 0.5f;
+      record.color[3] = 1.0f;
+      record.boundingVertexCount = 4;
+      const float quad[8] = {8.0f, 8.0f, 24.0f, 8.0f, 24.0f, 24.0f, 8.0f, 24.0f};
+      std::memcpy(record.boundingVertices, quad, sizeof(quad));
+      device_->queue().writeBuffer(generation.recordSlots[i].buffer,
+                                   generation.recordSlots[i].offset, &record,
+                                   sizeof(record));
+    }
+    return generation;
+  };
+
+  const auto bindingFor = [](const Generation& generation) {
+    GeoEncoder::SceneBatchBinding binding = {};
+    binding.chunkBuffer = generation.chunk.buffer;
+    binding.recordBuffer = generation.recordSlots[0].buffer;
+    binding.chunkBufferId = generation.chunk.bufferId;
+    binding.recordBufferId = generation.recordSlots[0].bufferId;
+    binding.firstRecordOffset = generation.recordSlots[0].offset;
+    binding.instanceCount = kInstanceCount;
+    binding.vertexCount = 6;
+    binding.recordSlab = generation.records.get();
+    return binding;
+  };
+
+  geode::GeodeCounters counters;
+  device_->setCounters(&counters);
+  // The device is shared process-wide by this fixture, so the counters must
+  // come back off however this test exits.
+  struct CounterScope {
+    geode::GeodeDevice* device;
+    ~CounterScope() { device->setCounters(nullptr); }
+  } counterScope{device_.get()};
+
+  // Draw one generation's batch twice through a fresh encoder, and report the
+  // `createBindGroup` calls each of the two batches caused.
+  const auto drawGeneration = [&](const Generation& generation, uint64_t& firstBatchCreates,
+                                  uint64_t& repeatBatchCreates) {
+    GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+    encoder.clear(css::RGBA(0, 0, 0, 0));
+
+    const GeoEncoder::SceneBatchBinding binding = bindingFor(generation);
+    const uint64_t beforeFirst = counters.bindgroupCreates;
+    encoder.fillPathSceneBatch(css::RGBA(0, 128, 0, 255), FillRule::NonZero, binding);
+    firstBatchCreates = counters.bindgroupCreates - beforeFirst;
+
+    const uint64_t beforeRepeat = counters.bindgroupCreates;
+    encoder.fillPathSceneBatch(css::RGBA(0, 128, 0, 255), FillRule::NonZero, binding);
+    repeatBatchCreates = counters.bindgroupCreates - beforeRepeat;
+
+    encoder.finish();
+  };
+
+  // Several generations, because a handle address only becomes reusable once
+  // its owner is gone: one round is a single roll of the allocator's dice,
+  // and a key built from addresses has to survive every one of them.
+  constexpr int kGenerations = 8;
+  for (int round = 0; round < kGenerations; ++round) {
+    uint64_t firstBatchCreates = 0;
+    uint64_t repeatBatchCreates = 0;
+    {
+      const Generation generation = makeGeneration();
+      drawGeneration(generation, firstBatchCreates, repeatBatchCreates);
+    }
+    // The generation (and its buffers) are released here, before the next
+    // round allocates.
+
+    EXPECT_EQ(firstBatchCreates, 1u)
+        << "Round " << round
+        << ": this generation's batch binds buffers no earlier generation owned, so its "
+           "bind-group lookup must miss. A hit means the cache matched a dead generation's "
+           "entry and this batch drew the previous generation's records and geometry.";
+    EXPECT_EQ(repeatBatchCreates, 0u)
+        << "Round " << round
+        << ": repeating the identical batch must reuse the cached bind group.";
+  }
+}
+
+/// Companion to the slab-generation test above, and the half of the guard
+/// that does not depend on the allocator at all.
+///
+/// The encoder's bump arenas hand their buffers back to a `GeodeBufferPool`
+/// when they are destroyed, and the next encoder reacquires the very same
+/// buffer. So two batches drawn through two encoders over ONE generation of
+/// slabs agree on every byte a bind-group key can see - same chunk, same
+/// record span, same arena buffer at the same offset and size - and differ
+/// only in the arena's identity, which is re-stamped on every growth because
+/// the recycled buffer's contents start over. The second batch must still
+/// miss. `bufferCreates == 0` on the second batch is what proves the pool
+/// really did hand back the same buffer, so this test cannot quietly stop
+/// testing anything.
+TEST_F(GeoEncoderTest, SceneBatchBindGroupCacheDistinguishesRecycledArenaUniforms) {
+  auto geometry = std::make_shared<geode::GeodeResidentSlab>(device_->deviceId());
+  auto records = std::make_shared<geode::GeodeRecordSlab>(device_->deviceId());
+
+  geode::GeodeResidentSlab::Allocation chunk;
+  ASSERT_TRUE(geometry->allocate(*device_, 4096, 256, chunk));
+  geode::GeodeRecordSlab::Slot recordSlot;
+  ASSERT_TRUE(records->allocateSlot(*device_, recordSlot));
+
+  geode::InstanceRecord record = {};
+  record.transformRow0[0] = 1.0f;
+  record.transformRow1[1] = 1.0f;
+  record.color[1] = 0.5f;
+  record.color[3] = 1.0f;
+  record.boundingVertexCount = 4;
+  const float quad[8] = {8.0f, 8.0f, 24.0f, 8.0f, 24.0f, 24.0f, 8.0f, 24.0f};
+  std::memcpy(record.boundingVertices, quad, sizeof(quad));
+  device_->queue().writeBuffer(recordSlot.buffer, recordSlot.offset, &record, sizeof(record));
+
+  // A null `recordSlab` routes the batch uniform through the encoder's
+  // per-frame arena instead of the slab's persistent table, which is the
+  // allocation the buffer pool recycles.
+  GeoEncoder::SceneBatchBinding binding = {};
+  binding.chunkBuffer = chunk.buffer;
+  binding.recordBuffer = recordSlot.buffer;
+  binding.chunkBufferId = chunk.bufferId;
+  binding.recordBufferId = recordSlot.bufferId;
+  binding.firstRecordOffset = recordSlot.offset;
+  binding.instanceCount = 1;
+  binding.vertexCount = 6;
+  binding.recordSlab = nullptr;
+
+  geode::GeodeCounters counters;
+  device_->setCounters(&counters);
+  struct CounterScope {
+    geode::GeodeDevice* device;
+    ~CounterScope() { device->setCounters(nullptr); }
+  } counterScope{device_.get()};
+
+  GeodeBufferPool pool;
+  const auto drawOneEncoder = [&](uint64_t& bindGroupCreates, uint64_t& bufferCreates) {
+    GeoEncoder encoder(*device_, *pipeline_, *gradientPipeline_, *imagePipeline_, target_);
+    encoder.setBufferPool(&pool);
+    encoder.clear(css::RGBA(0, 0, 0, 0));
+
+    const uint64_t bindGroupsBefore = counters.bindgroupCreates;
+    const uint64_t buffersBefore = counters.bufferCreates;
+    encoder.fillPathSceneBatch(css::RGBA(0, 128, 0, 255), FillRule::NonZero, binding);
+    bindGroupCreates = counters.bindgroupCreates - bindGroupsBefore;
+    bufferCreates = counters.bufferCreates - buffersBefore;
+
+    encoder.finish();
+    // The encoder is destroyed here, releasing its arena buffer into `pool`.
+  };
+
+  uint64_t firstBindGroups = 0;
+  uint64_t firstBuffers = 0;
+  drawOneEncoder(firstBindGroups, firstBuffers);
+  EXPECT_EQ(firstBindGroups, 1u);
+  ASSERT_GE(firstBuffers, 1u) << "The first batch must grow the uniform arena";
+
+  uint64_t secondBindGroups = 0;
+  uint64_t secondBuffers = 0;
+  drawOneEncoder(secondBindGroups, secondBuffers);
+  ASSERT_EQ(secondBuffers, 0u)
+      << "Fixture precondition: the second encoder must reacquire the first encoder's arena "
+         "buffer from the pool, otherwise this test is not exercising a recycled buffer";
+  EXPECT_EQ(secondBindGroups, 1u)
+      << "The recycled arena buffer holds a different uniform allocation than the one the "
+         "cached bind group was built over, so the lookup must miss. A hit means the key is "
+         "built from the buffer's handle rather than its identity.";
 }
 
 TEST_F(GeoEncoderTest, ArenaGrowthKeepsEarlierGridBinding) {

--- a/tools/gpu_inventory/manifests/gpu_operations.json
+++ b/tools/gpu_inventory/manifests/gpu_operations.json
@@ -987,12 +987,14 @@
         "poll",
         "submit",
         "unmap",
+        "writeBuffer",
         "writeTexture"
       ],
       "wgpuCFunctions": [
         "wgpuLabel"
       ],
       "wgpuCTypes": [
+        "WGPUBuffer",
         "WGPUMapAsyncStatus",
         "WGPUMapAsyncStatus_Success",
         "WGPUStringView"


### PR DESCRIPTION
Wasm browser smoke coverage now runs as a hermetic, headless Bazel test on remote execution.

- Pin Playwright browser artifacts and package metadata to one exact version across npm and pnpm locks.
- Build the served editor package through the package-local Wasm transition.
- Restrict the browser action to macOS and Linux ARM64 platforms.
- Declare every local smoke-test import as a Bazel runfile.
- Emit bounded, path-sanitized server failures and bounded browser fatal messages before startup polling can hide them.

## Verification

- `npm --prefix donner/editor/wasm/tests run test:selector`
- `bazel test //donner/editor/wasm/tests:chromium_remote_smoke --test_output=errors --remote_download_outputs=all`
- `bazel test //... --test_output=errors`
- `python3 tools/cmake/gen_cmakelists.py --check`
