### PR TITLE
ci: Share a capacity-4 turnstile pool across the self-hosted lanes

### DIFF
--- a/.github/actions/re-turnstile/action.yml
+++ b/.github/actions/re-turnstile/action.yml
@@ -4,16 +4,61 @@ description: >-
   runs. This action must run in a separate hosted prerequisite job: running the
   wait on the constrained self-hosted pool can let newer runs occupy every
   runner while the oldest lane job remains queued, deadlocking the FIFO. Waits
-  (oldest run first) until the requested lane is free, then returns so the
+  (oldest run first) until the pool has a free slot, then returns so the
   dependent self-hosted job can be scheduled. Read-only: it lists this
   repository's own workflow runs via the Actions API and mutates nothing.
+
+
+  Several lanes may share one pool. The runner fleet has four machines, so the
+  pool is sized four and the lanes mix and match: any combination of Linux CI
+  and coverage jobs may hold the four slots, instead of one slot per lane which
+  capped the whole fleet at two. The accepted tradeoff is that up to four
+  concurrent CI jobs share the remote-execution backend; interactive
+  development use of that backend still outranks CI, which is why the pool is
+  capped well below what the fleet could otherwise submit.
+
+
+  Admission counts a run as holding a slot from the moment its pool job exists,
+  not from the moment it starts executing. A run whose turnstile has passed but
+  whose self-hosted job has not been picked up yet is still committed to a
+  slot; if it were counted only once executing, a burst of runs would all
+  observe free capacity within one poll interval and over-admit. The window
+  before a freshly created run's job list materializes is covered by treating
+  an older run with no pool job yet as holding a slot.
+
+
+  The admission rules live in admission.py, which reads fabricated Actions API
+  payloads just as well as real ones and is unit-tested by
+  tools/turnstile_admission_tests.py. This file only fetches pages and applies
+  the answer.
 
 inputs:
   lane:
     description: >-
-      Job name to serialize on. All runs whose job of this name is active
-      form one FIFO queue; only the oldest proceeds at a time.
+      This run's own pool job name. Used to describe the wait, and as the
+      whole pool when `pool` is not given.
     required: true
+  pool:
+    description: >-
+      Whitespace-separated job names that share one pool. Any run holding any
+      of these jobs consumes a slot. Defaults to `lane` alone, which with the
+      default capacity of 1 reproduces the original single-lane FIFO.
+    required: false
+    default: ""
+  pool-workflows:
+    description: >-
+      Whitespace-separated workflow file names (for example "main.yml
+      coverage.yml") whose runs can hold pool slots. Only these workflows are
+      enumerated, so a run of an unrelated workflow is never mistaken for a
+      pool run that is still initializing. Defaults to this run's own workflow.
+    required: false
+    default: ""
+  capacity:
+    description: >-
+      How many pool jobs may be admitted at once. Default 1 preserves the
+      original strictly serialized behavior for any single-lane caller.
+    required: false
+    default: "1"
   token:
     description: Token with actions:read on this repository (github.token).
     required: true
@@ -37,9 +82,13 @@ runs:
       shell: bash
       env:
         TURNSTILE_LANE: ${{ inputs.lane }}
+        TURNSTILE_POOL: ${{ inputs.pool }}
+        TURNSTILE_POOL_WORKFLOWS: ${{ inputs.pool-workflows }}
+        TURNSTILE_CAPACITY: ${{ inputs.capacity }}
         TURNSTILE_TOKEN: ${{ inputs.token }}
         TURNSTILE_TIMEOUT_MINUTES: ${{ inputs.timeout-minutes }}
         TURNSTILE_POLL_SECONDS: ${{ inputs.poll-seconds }}
+        TURNSTILE_ACTION_PATH: ${{ github.action_path }}
       run: |
         set -uo pipefail
 
@@ -48,7 +97,16 @@ runs:
         run_id="${GITHUB_RUN_ID}"
         lane="${TURNSTILE_LANE}"
         poll="${TURNSTILE_POLL_SECONDS}"
+        capacity="${TURNSTILE_CAPACITY}"
+        admission="${TURNSTILE_ACTION_PATH}/admission.py"
         deadline=$(( $(date +%s) + TURNSTILE_TIMEOUT_MINUTES * 60 ))
+
+        pool_names="${TURNSTILE_POOL}"
+        if [[ -z "${pool_names// /}" ]]; then
+          pool_names="${lane}"
+        fi
+        # shellcheck disable=SC2086 # deliberate word splitting into a JSON array
+        pool_json=$(printf '%s\n' ${pool_names} | jq -Rsc 'split("\n") | map(select(length > 0))')
 
         # GET one Actions API page. Callers that enumerate collections own the
         # pagination so admission does not depend on a burst fitting one page.
@@ -61,20 +119,28 @@ runs:
             "$1" 2>/dev/null
         }
 
-        # Identify this run: its ordering key (run_number) and workflow id.
-        # API availability is part of admission correctness. Retry off-pool
-        # until the common safety deadline instead of releasing all waiters on
-        # one transient 5xx response.
-        me_json=""
-        my_number=""
-        workflow_id=""
+        # Identify this run's workflow, then resolve every workflow whose runs
+        # can hold a pool slot. API availability is part of admission
+        # correctness, so retry off-pool until the common safety deadline
+        # instead of releasing all waiters on one transient 5xx response.
+        workflow_ids=""
         while true; do
+          workflow_ids=""
           if me_json=$(gh_get "${api}/repos/${repo}/actions/runs/${run_id}"); then
-            my_number=$(printf '%s' "${me_json}" | jq -er '.run_number | numbers' 2>/dev/null) || my_number=""
-            workflow_id=$(printf '%s' "${me_json}" | jq -er '.workflow_id | numbers' 2>/dev/null) || workflow_id=""
-            if [[ "${my_number}" =~ ^[0-9]+$ && "${workflow_id}" =~ ^[0-9]+$ ]]; then
-              break
+            my_workflow=$(printf '%s' "${me_json}" | jq -er '.workflow_id | numbers' 2>/dev/null) || my_workflow=""
+            if [[ "${my_workflow}" =~ ^[0-9]+$ ]]; then
+              if [[ -z "${TURNSTILE_POOL_WORKFLOWS// /}" ]]; then
+                workflow_ids="${my_workflow}"
+              elif all_workflows=$(gh_get "${api}/repos/${repo}/actions/workflows?per_page=100"); then
+                # shellcheck disable=SC2086 # deliberate word splitting into a JSON array
+                wanted=$(printf '%s\n' ${TURNSTILE_POOL_WORKFLOWS} | jq -Rsc 'split("\n") | map(select(length > 0))')
+                workflow_ids=$(printf '%s' "${all_workflows}" | jq -r --argjson wanted "${wanted}" \
+                  '.workflows[]? | . as $w | select([$wanted[] | select($w.path | endswith("/" + .))] | length > 0) | .id' 2>/dev/null)
+              fi
             fi
+          fi
+          if [[ -n "${workflow_ids}" ]]; then
+            break
           fi
           now=$(date +%s)
           if (( now >= deadline )); then
@@ -85,108 +151,98 @@ runs:
           echo "turnstile: Actions API metadata unavailable; re-checking in $(( poll + jitter ))s"
           sleep $(( poll + jitter ))
         done
-        echo "turnstile: lane='${lane}' this run #${my_number} (workflow ${workflow_id})"
+        echo "turnstile: lane='${lane}' pool=${pool_json} capacity=${capacity} run ${run_id}"
 
-        # A run is "ahead" of us if it is older (smaller run_number) and its
-        # lane job is not yet in a terminal state. A still-initializing older
-        # run whose lane job has not appeared yet also counts as ahead so we
-        # never jump its place (strict FIFO, no two-at-once race). Because the
-        # order is a strict total order on run_number, the oldest run is never
-        # ahead of anyone: no cycles, no deadlock, no starvation.
-        last_ahead_desc=""
+        last_blockers=""
         clear_observations=0
         while true; do
-          ahead_desc=""
           list_failed=0
-          # Enumerate older, still-active runs of this workflow, oldest first,
-          # and break on the first one still holding the lane (that alone is
-          # enough to keep waiting). Filter every nonterminal status server-side
-          # so an old active run is never missed behind >100 newer runs; active
-          # runs are not hidden behind a page of newer runs.
-          older_active=$(
-            for status in queued in_progress requested waiting pending; do
-              page=1
-              while true; do
-                if ! p=$(gh_get "${api}/repos/${repo}/actions/workflows/${workflow_id}/runs?status=${status}&per_page=100&page=${page}"); then
-                  echo "LIST_FAILED"
-                  break
-                fi
-                if ! printf '%s' "${p}" | jq -e '.workflow_runs | arrays' >/dev/null 2>&1; then
-                  echo "LIST_FAILED"
-                  break
-                fi
-                printf '%s' "${p}" | jq -r --argjson mine "${my_number}" \
-                  '.workflow_runs[] | select(.run_number < $mine) | "\(.id)\t\(.run_number)"'
-                page_size=$(printf '%s' "${p}" | jq -r '.workflow_runs | length')
-                (( page_size < 100 )) && break
-                page=$(( page + 1 ))
+          # Enumerate still-active runs of every pool workflow. Filter each
+          # nonterminal status server-side so an old active run is never hidden
+          # behind a page of newer runs.
+          candidates=$(
+            for workflow_id in ${workflow_ids}; do
+              for status in queued in_progress requested waiting pending; do
+                page=1
+                while true; do
+                  if ! p=$(gh_get "${api}/repos/${repo}/actions/workflows/${workflow_id}/runs?status=${status}&per_page=100&page=${page}"); then
+                    echo "LIST_FAILED"
+                    break
+                  fi
+                  if ! printf '%s' "${p}" | jq -e '.workflow_runs | arrays' >/dev/null 2>&1; then
+                    echo "LIST_FAILED"
+                    break
+                  fi
+                  printf '%s' "${p}" | jq -r '.workflow_runs[].id'
+                  page_size=$(printf '%s' "${p}" | jq -r '.workflow_runs | length')
+                  if (( page_size < 100 )); then
+                    break
+                  fi
+                  page=$(( page + 1 ))
+                done
               done
             done
           )
-          if printf '%s\n' "${older_active}" | grep -q '^LIST_FAILED$'; then
+          if printf '%s\n' "${candidates}" | grep -q '^LIST_FAILED$'; then
             list_failed=1
           fi
-          while IFS=$'\t' read -r other_id other_number; do
-            [[ -z "${other_id}" || "${other_id}" == "LIST_FAILED" ]] && continue
-            [[ "${other_id}" == "${run_id}" ]] && continue
-            if ! jobs=$(gh_get "${api}/repos/${repo}/actions/runs/${other_id}/jobs?per_page=100"); then
-              # Cannot inspect this older active run; be conservative and treat
-              # it as ahead so we do not race past it.
-              ahead_desc="#${other_number} (jobs unavailable)"
-              break
-            fi
-            lane_state=$(printf '%s' "${jobs}" \
-              | jq -r --arg lane "${lane}" \
-                  'first(.jobs[]? | select(.name == $lane) | .status) // "absent"' \
-                  2>/dev/null) || lane_state="unavailable"
-            case "${lane_state}" in
-              queued|in_progress|requested|waiting|pending|absent)
-                # Any nonterminal state holds the lane. Absent means the older
-                # run is still initializing and has not yet created (or skipped)
-                # its lane job.
-                ahead_desc="#${other_number} (lane ${lane_state})"
-                break
-                ;;
-              unavailable)
-                ahead_desc="#${other_number} (jobs unavailable)"
-                break
-                ;;
-              *)
-                # terminal (completed/skipped/cancelled): not blocking
-                ;;
-            esac
-          done < <(printf '%s\n' "${older_active}" | grep -v '^LIST_FAILED$' | sort -t$'\t' -k2 -n)
 
-          if [[ -n "${ahead_desc}" ]]; then
-            clear_observations=0
-            last_ahead_desc="${ahead_desc}"
-          elif [[ "${list_failed}" -eq 1 ]]; then
-            clear_observations=0
-            ahead_desc="${last_ahead_desc:-Actions API unavailable}"
-          else
+          # Collect each candidate run's job list. A run whose jobs cannot be
+          # read is passed through as null, which admission.py counts as
+          # executing, so an API hiccup narrows the pool instead of opening it.
+          request=$(jq -nc --argjson capacity "${capacity}" --argjson me "${run_id}" \
+            --argjson pool "${pool_json}" \
+            '{capacity: $capacity, me: $me, pool: $pool, runs: []}')
+          while read -r other_id; do
+            if ! [[ "${other_id}" =~ ^[0-9]+$ ]] || [[ "${other_id}" == "${run_id}" ]]; then
+              continue
+            fi
+            if ! jobs=$(gh_get "${api}/repos/${repo}/actions/runs/${other_id}/jobs?per_page=100"); then
+              jobs="null"
+            fi
+            if ! printf '%s' "${jobs}" | jq -e '.' >/dev/null 2>&1; then
+              jobs="null"
+            fi
+            request=$(printf '%s' "${request}" | jq -c --argjson id "${other_id}" \
+              --argjson jobs "${jobs}" '.runs += [{id: $id, jobs: $jobs}]')
+          done < <(printf '%s\n' "${candidates}" | grep -v '^LIST_FAILED$' | sort -n -u)
+
+          decision=$(printf '%s' "${request}" | python3 "${admission}")
+          admit=$(printf '%s' "${decision}" | jq -r '.admit')
+          occupancy=$(printf '%s' "${decision}" | jq -r '.occupancy')
+          blockers=$(printf '%s' "${decision}" | jq -r '.blockers | join(", ")')
+
+          if [[ "${admit}" == "true" && "${list_failed}" -eq 0 ]]; then
             # Status-filtered run lists converge asynchronously after dispatch.
-            # Confirm a clear lane across a poll interval before releasing it.
+            # Confirm free capacity across a poll interval before taking a slot.
             clear_observations=$(( clear_observations + 1 ))
             if (( clear_observations >= 2 )); then
-              echo "turnstile: clear, proceeding"
+              echo "turnstile: ${occupancy}/${capacity} pool slots held, proceeding"
               exit 0
             fi
             jitter=$(( RANDOM % 5 ))
-            echo "turnstile: candidate clear; confirming in $(( poll + jitter ))s"
+            echo "turnstile: ${occupancy}/${capacity} pool slots held; confirming in $(( poll + jitter ))s"
             sleep $(( poll + jitter ))
             continue
           fi
 
+          clear_observations=0
+          if [[ "${list_failed}" -eq 1 ]]; then
+            blockers="${blockers:-${last_blockers:-Actions API unavailable}}"
+          else
+            last_blockers="${blockers}"
+          fi
+
           now=$(date +%s)
           if (( now >= deadline )); then
-            echo "turnstile: safety timeout reached while waiting behind ${ahead_desc}; proceeding (fail-open)"
+            echo "turnstile: safety timeout reached while waiting behind ${blockers}; proceeding (fail-open)"
             exit 0
           fi
           jitter=$(( RANDOM % 5 ))
           if [[ "${list_failed}" -eq 1 ]]; then
-            echo "turnstile: Actions API list unavailable; retaining gate behind ${ahead_desc}; re-checking in $(( poll + jitter ))s"
+            echo "turnstile: Actions API list unavailable; retaining gate behind ${blockers}; re-checking in $(( poll + jitter ))s"
           else
-            echo "turnstile: waiting behind run ${ahead_desc}; re-checking in $(( poll + jitter ))s"
+            echo "turnstile: ${occupancy}/${capacity} pool slots held by ${blockers}; re-checking in $(( poll + jitter ))s"
           fi
           sleep $(( poll + jitter ))
         done

--- a/.github/actions/re-turnstile/admission.py
+++ b/.github/actions/re-turnstile/admission.py
@@ -1,0 +1,135 @@
+"""Admission decision for the shared self-hosted remote-execution pool.
+
+Reads one JSON document on stdin and writes one JSON document on stdout, so
+the wait loop in action.yml only has to fetch pages from the Actions API and
+this file owns every rule about who may take a slot. That split is deliberate:
+the rules are the part that can be wrong in a way no workflow run would make
+obvious, so they live in a unit that tools/turnstile_admission_tests.py drives
+directly with fabricated API payloads.
+
+Input:
+
+    {
+      "capacity": 4,
+      "me": 42,
+      "pool": ["linux-self-hosted", "coverage-self-hosted"],
+      "runs": [
+        {"id": 41, "jobs": {"jobs": [{"name": "...", "status": "..."}]}},
+        {"id": 40, "jobs": null}
+      ]
+    }
+
+`jobs` is the body of `/actions/runs/{id}/jobs`, or null when that call
+failed. Output:
+
+    {"admit": false, "occupancy": 4, "blockers": ["41 (active)", ...]}
+"""
+
+import json
+import sys
+
+# A pool job in any of these states has not finished, so the run still holds
+# its slot. Anything else (completed, skipped, cancelled) has released it.
+_PENDING_STATES = frozenset({"queued", "requested", "waiting", "pending"})
+
+# How a run occupies the pool.
+#
+# ACTIVE   a pool job is executing, so it holds a machine right now.
+# PENDING  a pool job exists but has not started: it is queued behind its
+#          `needs`, which covers both a run still waiting at its own turnstile
+#          and a run whose turnstile passed but whose self-hosted job has not
+#          been picked up yet. Both must count, otherwise a burst of runs all
+#          observe free capacity inside one poll interval and over-admit.
+# ABSENT   the run has created no pool job yet, so it may still create one.
+#          Callers treat an older run in this state as holding a slot; this is
+#          the only state that covers the window between a run being created
+#          and its job list materializing.
+# CLEAR    every pool job reached a terminal state, so the run holds nothing.
+ACTIVE = "active"
+PENDING = "pending"
+ABSENT = "absent"
+CLEAR = "clear"
+
+
+def pool_state(jobs_payload, pool):
+    """Reduce one run's jobs payload to how it occupies the pool.
+
+    A payload of None means the Actions API could not be read for that run.
+    That is reported as ACTIVE on purpose: an API hiccup should narrow the
+    pool rather than open it.
+    """
+    if jobs_payload is None:
+        return ACTIVE
+
+    pool_names = set(pool)
+    states = [
+        job.get("status")
+        for job in jobs_payload.get("jobs") or []
+        if job.get("name") in pool_names
+    ]
+    if not states:
+        return ABSENT
+    if "in_progress" in states:
+        return ACTIVE
+    if any(state in _PENDING_STATES for state in states):
+        return PENDING
+    return CLEAR
+
+
+def decide(request):
+    """Decide whether the requesting run may take a pool slot.
+
+    A run occupies a slot when either:
+
+      * it is OLDER than us and holds the pool in any non-clear state, whether
+        it is executing, admitted but not yet scheduled, or still
+        initializing; or
+      * it is NEWER than us and is already executing.
+
+    Newer runs that are only waiting are deliberately not counted. They must
+    yield to us, and because they see us in a non-clear state they already
+    count us, so no newer run can be admitted without leaving room for us.
+    Counting newer runs that are already executing keeps the total honest if
+    one slipped past under API skew, and cannot deadlock because an executing
+    run finishes. Waiting runs are never ACTIVE, so no two waiting runs block
+    each other and the oldest waiter is blocked by nobody: strict
+    first in, first out, no cycles, no starvation.
+
+    Runs are ordered by workflow run id. A pool spans several workflows and
+    run_number only counts within one workflow, so run_number cannot order two
+    runs from different workflows. Run ids increase across the whole
+    repository and give the strict total order the queue needs.
+    """
+    capacity = int(request["capacity"])
+    me = int(request["me"])
+    pool = list(request["pool"])
+
+    blockers = []
+    for run in request.get("runs") or []:
+        run_id = int(run["id"])
+        if run_id == me:
+            continue
+        state = pool_state(run.get("jobs"), pool)
+        if run_id < me:
+            holds = state != CLEAR
+        else:
+            holds = state == ACTIVE
+        if holds:
+            blockers.append((run_id, state))
+
+    blockers.sort()
+    return {
+        "occupancy": len(blockers),
+        "admit": len(blockers) < capacity,
+        "blockers": ["{0} ({1})".format(run_id, state) for run_id, state in blockers],
+    }
+
+
+def main():
+    json.dump(decide(json.load(sys.stdin)), sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -763,10 +763,15 @@ jobs:
           fail_ci_if_error: true
           verbose: false
 
-  # Wait for the coverage lane on a hosted runner so queued older work can
+  # Wait for a self-hosted pool slot on a hosted runner so queued older work can
   # still acquire the constrained self-hosted runner pool. Waiting inside the
   # heavy job can deadlock when newer runs occupy every runner while the oldest
   # lane remains queued.
+  #
+  # Coverage shares one pool with CI's Linux lane, sized to the runner fleet,
+  # instead of holding a private slot. A per-lane slot made coverage a 1-wide
+  # FIFO: a burst of coverage runs serialized into a multi-hour backlog while
+  # the rest of the fleet sat idle because no Linux work was queued.
   coverage-self-hosted-turnstile:
     runs-on: ubuntu-24.04
     needs: determine-targets
@@ -782,6 +787,9 @@ jobs:
         uses: ./.github/actions/re-turnstile
         with:
           lane: coverage-self-hosted
+          pool: linux-self-hosted coverage-self-hosted
+          pool-workflows: main.yml coverage.yml
+          capacity: "4"
           token: ${{ github.token }}
           timeout-minutes: "150"
 
@@ -800,22 +808,24 @@ jobs:
     # still fails in about a minute regardless of this backstop; the CPU-capped
     # 2-3 h local re-run cannot recur because local fallback is disabled.
     timeout-minutes: 210
-    # Admission control on the shared remote-execution backend. Two concurrent
-    # instrumented coverage builds were the measured failure that hit the
-    # timeout: both self-hosted lanes execute on a shared remote-execution
-    # backend that an interactive development host also uses with priority, so
-    # two-plus concurrent instrumented builds oversubscribe it and crawl into
-    # the timeout (measured). Serialization is enforced by the hosted
-    # re-turnstile prerequisite above, NOT by a GitHub concurrency group.
-    # A concurrency group caps the queue at one pending run and cancels any
-    # older pending run when a third concurrent run arrives, so a parallel-PR
-    # burst (and every post-merge main coverage run competing for the same
-    # group) drops pending runs and self-clogs. The turnstile instead holds
-    # each run until its turn, FIFO, so N concurrent runs all execute in
-    # submission order and none are cancelled, while still keeping at most one
-    # instrumented coverage build on the backend at a time. The sibling CI
-    # linux-self-hosted lane serializes on its own turnstile lane, so a Linux
-    # build and a coverage build may overlap but two coverage builds never do.
+    # Admission control on the shared remote-execution backend. Both
+    # self-hosted lanes execute on a backend that an interactive development
+    # host also uses with priority, so unbounded concurrent instrumented builds
+    # oversubscribe it and crawl into the timeout (measured). Admission is
+    # enforced by the hosted re-turnstile prerequisite above, NOT by a GitHub
+    # concurrency group. A concurrency group caps the queue at one pending run
+    # and cancels any older pending run when a third concurrent run arrives, so
+    # a parallel-PR burst (and every post-merge main coverage run competing for
+    # the same group) drops pending runs and self-clogs. The turnstile instead
+    # holds each run until its turn, FIFO, so N concurrent runs all execute in
+    # submission order and none are cancelled.
+    #
+    # The bound is a POOL shared with CI's linux-self-hosted lane, sized to the
+    # runner fleet, not one slot per lane. Per-lane slots capped the fleet at
+    # two jobs and made a coverage burst serialize behind itself while Linux
+    # capacity sat idle. Any mix of Linux and coverage jobs may hold the pool's
+    # slots; the ceiling on backend demand is the pool size, which is what the
+    # oversubscription measurement actually constrains.
     env:
       # RE-availability SLA: do NOT fall back to local execution when remote
       # execution is unavailable or degraded. A CPU-capped self-hosted runner

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -628,7 +628,12 @@ jobs:
   # cannot run on the constrained self-hosted pool itself: newer runs could
   # occupy every runner while the oldest lane job remains queued, creating a
   # head-of-line deadlock. This lightweight prerequisite waits off-pool and
-  # releases exactly one dependent self-hosted job at a time.
+  # releases dependent self-hosted jobs in submission order.
+  #
+  # The Linux and coverage lanes share ONE pool sized to the runner fleet
+  # rather than holding one slot each. Per-lane serialization capped the whole
+  # fleet at two concurrent jobs no matter which lane the queued work was in,
+  # so a burst of coverage runs left Linux capacity idle and vice versa.
   linux-self-hosted-turnstile:
     runs-on: ubuntu-24.04
     needs: [gatekeeper, determine-targets]
@@ -644,6 +649,9 @@ jobs:
         uses: ./.github/actions/re-turnstile
         with:
           lane: linux-self-hosted
+          pool: linux-self-hosted coverage-self-hosted
+          pool-workflows: main.yml coverage.yml
+          capacity: "4"
           token: ${{ github.token }}
           timeout-minutes: "150"
 
@@ -670,20 +678,23 @@ jobs:
     # backstop.
     timeout-minutes: 210
     # Admission control on the shared remote-execution backend. Both self-hosted
-    # lanes execute on a shared remote-execution backend that an interactive
-    # development host also uses with priority; two-plus concurrent operator PRs
-    # oversubscribe it and crawl into the 60 min timeout (measured).
-    # Serialization is enforced by the hosted re-turnstile prerequisite above,
-    # NOT by a GitHub concurrency group. A concurrency group caps the queue at
-    # one pending run and cancels any older pending run when a third concurrent
-    # run arrives, so a parallel-PR burst (and every post-merge main run
-    # competing for the same group) drops pending runs. The turnstile instead
-    # holds each run until its turn, FIFO, so N concurrent runs all execute in
-    # submission order and none are cancelled, while keeping at most one Linux
-    # build on the backend at a time. Bounding CI's demand on the backend also
-    # protects the interactive host's latency. The sibling coverage-self-hosted
-    # lane serializes on its own turnstile lane, so a Linux build and a coverage
-    # build may overlap but two of the same heavy lane never do.
+    # lanes execute on a backend that an interactive development host also uses
+    # with priority; unbounded concurrent operator PRs oversubscribe it and
+    # crawl into the 60 min timeout (measured). Admission is enforced by the
+    # hosted re-turnstile prerequisite above, NOT by a GitHub concurrency group.
+    # A concurrency group caps the queue at one pending run and cancels any
+    # older pending run when a third concurrent run arrives, so a parallel-PR
+    # burst (and every post-merge main run competing for the same group) drops
+    # pending runs. The turnstile instead holds each run until its turn, FIFO,
+    # so N concurrent runs all execute in submission order and none are
+    # cancelled. Bounding CI's demand on the backend also protects the
+    # interactive host's latency.
+    #
+    # The bound is a POOL shared with the coverage lane, sized to the runner
+    # fleet, not one slot per lane. Per-lane slots capped the fleet at two jobs
+    # and let a burst in one lane serialize behind itself while the other
+    # lane's capacity sat idle. Any mix of Linux and coverage jobs may hold the
+    # pool's slots.
     env:
       # The runner host may add the LAN Bazel cache from its home rc. Use that
       # acceleration when healthy, but do NOT fall back to local execution when

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -61,6 +61,8 @@ exports_files(
         "donner_splash.svg",
         "BUILD.bazel",
         "MODULE.bazel",
+        ".github/actions/re-turnstile/action.yml",
+        ".github/actions/re-turnstile/admission.py",
         ".github/workflows/cmake.yml",
         ".github/workflows/codeql.yml",
         ".github/workflows/coverage.yml",

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -168,6 +168,19 @@ py_test(
 )
 
 py_test(
+    name = "turnstile_admission_tests",
+    size = "small",
+    srcs = ["turnstile_admission_tests.py"],
+    data = [
+        "//:.github/actions/re-turnstile/action.yml",
+        "//:.github/actions/re-turnstile/admission.py",
+        "//:.github/workflows/coverage.yml",
+        "//:.github/workflows/main.yml",
+    ],
+    deps = ["@rules_python//python/runfiles"],
+)
+
+py_test(
     name = "remote_cache_config_tests",
     size = "small",
     srcs = ["remote_cache_config_tests.py"],

--- a/tools/turnstile_admission_tests.py
+++ b/tools/turnstile_admission_tests.py
@@ -1,0 +1,273 @@
+"""Pins the shared self-hosted pool's admission rules.
+
+The turnstile is the only thing standing between a burst of CI runs and an
+oversubscribed remote-execution backend, and it is invisible when it is wrong:
+over-admitting looks like a slow backend, and under-admitting looks like a
+queue. So the rules live in a pure unit that these tests drive with fabricated
+Actions API payloads, and the workflow wiring that feeds it is pinned here too.
+"""
+
+import importlib.util
+import re
+import unittest
+
+from python.runfiles import runfiles
+
+_LINUX_LANE = "linux-self-hosted"
+_COVERAGE_LANE = "coverage-self-hosted"
+_POOL = [_LINUX_LANE, _COVERAGE_LANE]
+
+# Four runner machines, so four concurrent pool jobs in any lane mix.
+_EXPECTED_CAPACITY = "4"
+
+
+def _runfile(path):
+    resolver = runfiles.Create()
+    located = resolver.Rlocation(path)
+    assert located is not None, path
+    return located
+
+
+def _read(path):
+    with open(_runfile(path), encoding="utf-8") as handle:
+        return handle.read()
+
+
+def _load_admission():
+    path = _runfile("donner/.github/actions/re-turnstile/admission.py")
+    spec = importlib.util.spec_from_file_location("turnstile_admission", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+admission = _load_admission()
+
+
+def _jobs(*named_states):
+    """Build an Actions API jobs payload from (name, status) pairs."""
+    return {"jobs": [{"name": name, "status": status} for name, status in named_states]}
+
+
+def _run(run_id, jobs):
+    return {"id": run_id, "jobs": jobs}
+
+
+def _decide(me, runs, capacity=4, pool=None):
+    return admission.decide(
+        {
+            "capacity": capacity,
+            "me": me,
+            "pool": list(pool if pool is not None else _POOL),
+            "runs": runs,
+        }
+    )
+
+
+class PoolStateTests(unittest.TestCase):
+    def test_executing_pool_job_is_active(self):
+        payload = _jobs(("determine-targets", "completed"), (_LINUX_LANE, "in_progress"))
+        self.assertEqual(admission.pool_state(payload, _POOL), admission.ACTIVE)
+
+    def test_queued_pool_job_is_pending(self):
+        payload = _jobs((_COVERAGE_LANE, "queued"))
+        self.assertEqual(admission.pool_state(payload, _POOL), admission.PENDING)
+
+    def test_run_without_a_pool_job_yet_is_absent(self):
+        payload = _jobs(("determine-targets", "in_progress"))
+        self.assertEqual(admission.pool_state(payload, _POOL), admission.ABSENT)
+
+    def test_finished_and_skipped_pool_jobs_are_clear(self):
+        payload = _jobs((_LINUX_LANE, "completed"), (_COVERAGE_LANE, "completed"))
+        self.assertEqual(admission.pool_state(payload, _POOL), admission.CLEAR)
+
+    def test_executing_outranks_queued_within_one_run(self):
+        payload = _jobs((_LINUX_LANE, "queued"), (_COVERAGE_LANE, "in_progress"))
+        self.assertEqual(admission.pool_state(payload, _POOL), admission.ACTIVE)
+
+    def test_unreadable_jobs_payload_counts_as_active(self):
+        # An API hiccup must narrow the pool, never open it.
+        self.assertEqual(admission.pool_state(None, _POOL), admission.ACTIVE)
+
+    def test_only_pool_names_count(self):
+        payload = _jobs(("some-hosted-job", "in_progress"))
+        self.assertEqual(admission.pool_state(payload, _POOL), admission.ABSENT)
+
+
+class AdmissionTests(unittest.TestCase):
+    def test_empty_pool_admits(self):
+        self.assertTrue(_decide(100, [])["admit"])
+
+    def test_lanes_mix_and_match_up_to_capacity(self):
+        # Three older runs executing, one from each lane plus a repeat: the
+        # pool is shared, so a fourth job of either lane still fits.
+        runs = [
+            _run(10, _jobs((_LINUX_LANE, "in_progress"))),
+            _run(11, _jobs((_COVERAGE_LANE, "in_progress"))),
+            _run(12, _jobs((_LINUX_LANE, "in_progress"))),
+        ]
+        decision = _decide(100, runs)
+        self.assertEqual(decision["occupancy"], 3)
+        self.assertTrue(decision["admit"])
+
+    def test_capacity_is_the_hard_stop(self):
+        runs = [
+            _run(10 + index, _jobs((_LINUX_LANE, "in_progress"))) for index in range(4)
+        ]
+        decision = _decide(100, runs)
+        self.assertEqual(decision["occupancy"], 4)
+        self.assertFalse(decision["admit"])
+
+    def test_admitted_but_unscheduled_older_run_still_holds_its_slot(self):
+        # The counting edge: run 13's turnstile has passed but its self-hosted
+        # job has not been picked up. Counting only executing jobs would let a
+        # burst admit a fifth run inside one poll interval.
+        runs = [
+            _run(10, _jobs((_LINUX_LANE, "in_progress"))),
+            _run(11, _jobs((_COVERAGE_LANE, "in_progress"))),
+            _run(12, _jobs((_LINUX_LANE, "in_progress"))),
+            _run(13, _jobs((_COVERAGE_LANE, "queued"))),
+        ]
+        decision = _decide(100, runs)
+        self.assertEqual(decision["occupancy"], 4)
+        self.assertFalse(decision["admit"])
+
+    def test_older_run_still_initializing_holds_a_slot(self):
+        # Covers the window between a run being created and its job list
+        # materializing, which is the only way a genuinely committed run can
+        # be invisible.
+        runs = [
+            _run(10 + index, _jobs((_LINUX_LANE, "in_progress"))) for index in range(3)
+        ]
+        runs.append(_run(13, _jobs(("determine-targets", "in_progress"))))
+        self.assertFalse(_decide(100, runs)["admit"])
+
+    def test_finished_older_runs_release_their_slots(self):
+        runs = [
+            _run(10, _jobs((_LINUX_LANE, "completed"))),
+            _run(11, _jobs((_COVERAGE_LANE, "completed"))),
+            _run(12, _jobs((_LINUX_LANE, "in_progress"))),
+        ]
+        decision = _decide(100, runs)
+        self.assertEqual(decision["occupancy"], 1)
+        self.assertTrue(decision["admit"])
+
+    def test_newer_waiting_runs_do_not_block_us(self):
+        # Strict first in, first out: a newer run that is only queued must
+        # yield. Counting it would let two waiters block each other forever.
+        runs = [_run(200 + index, _jobs((_LINUX_LANE, "queued"))) for index in range(6)]
+        decision = _decide(100, runs)
+        self.assertEqual(decision["occupancy"], 0)
+        self.assertTrue(decision["admit"])
+
+    def test_newer_executing_run_is_still_counted(self):
+        runs = [
+            _run(10 + index, _jobs((_LINUX_LANE, "in_progress"))) for index in range(3)
+        ]
+        runs.append(_run(200, _jobs((_COVERAGE_LANE, "in_progress"))))
+        self.assertFalse(_decide(100, runs)["admit"])
+
+    def test_own_run_is_never_its_own_blocker(self):
+        runs = [_run(100, _jobs((_COVERAGE_LANE, "queued")))]
+        self.assertEqual(_decide(100, runs)["occupancy"], 0)
+
+    def test_queue_admits_exactly_capacity_and_drains_in_order(self):
+        # Six runs arrive at once. Each evaluates itself against the same
+        # world, and exactly the four oldest are admitted.
+        waiting = [10, 11, 12, 13, 14, 15]
+        world = [_run(run_id, _jobs((_COVERAGE_LANE, "queued"))) for run_id in waiting]
+        admitted = [run_id for run_id in waiting if _decide(run_id, world)["admit"]]
+        self.assertEqual(admitted, [10, 11, 12, 13])
+
+        # The oldest finishes; the next waiter, and only it, moves up.
+        world[0] = _run(10, _jobs((_COVERAGE_LANE, "completed")))
+        admitted = [
+            run_id for run_id in waiting[1:] if _decide(run_id, world)["admit"]
+        ]
+        self.assertEqual(admitted, [11, 12, 13, 14])
+
+    def test_capacity_one_reproduces_the_single_lane_fifo(self):
+        runs = [_run(10, _jobs((_LINUX_LANE, "queued")))]
+        self.assertFalse(_decide(100, runs, capacity=1, pool=[_LINUX_LANE])["admit"])
+        self.assertTrue(_decide(5, runs, capacity=1, pool=[_LINUX_LANE])["admit"])
+
+    def test_blockers_are_reported_oldest_first(self):
+        runs = [
+            _run(12, _jobs((_LINUX_LANE, "in_progress"))),
+            _run(10, _jobs((_COVERAGE_LANE, "queued"))),
+        ]
+        decision = _decide(100, runs, capacity=1)
+        self.assertEqual(decision["blockers"], ["10 (pending)", "12 (active)"])
+
+
+class TurnstileWiringTests(unittest.TestCase):
+    """The rules only help if both lanes actually share one pool."""
+
+    def setUp(self):
+        self.action = _read("donner/.github/actions/re-turnstile/action.yml")
+        self.workflows = {
+            "main.yml": _read("donner/.github/workflows/main.yml"),
+            "coverage.yml": _read("donner/.github/workflows/coverage.yml"),
+        }
+
+    def _turnstile_usages(self, text):
+        """Every `uses: ./.github/actions/re-turnstile` block's `with:` body."""
+        pattern = re.compile(
+            r"uses:\s*\./\.github/actions/re-turnstile\s*\n"
+            r"(?P<with>(?:[ \t]*\n|[ \t]+\S.*\n)+)"
+        )
+        return [match.group("with") for match in pattern.finditer(text)]
+
+    def test_every_usage_shares_the_same_pool_and_capacity(self):
+        usages = [
+            usage
+            for text in self.workflows.values()
+            for usage in self._turnstile_usages(text)
+        ]
+        self.assertEqual(len(usages), 2, "expected one turnstile per self-hosted lane")
+        for usage in usages:
+            for lane in _POOL:
+                self.assertIn(lane, usage)
+            self.assertRegex(usage, r"capacity:\s*\"?" + _EXPECTED_CAPACITY)
+            self.assertIn("main.yml", usage)
+            self.assertIn("coverage.yml", usage)
+
+    def test_each_workflow_gates_its_own_lane(self):
+        self.assertIn("lane: " + _LINUX_LANE, self.workflows["main.yml"])
+        self.assertIn("lane: " + _COVERAGE_LANE, self.workflows["coverage.yml"])
+
+    def _job_body(self, text, job):
+        match = re.search(
+            r"^  " + re.escape(job) + r":\n(.*?)(?=^  \S)", text, re.S | re.M
+        )
+        self.assertIsNotNone(match, job)
+        return match.group(1)
+
+    def test_wait_runs_on_a_hosted_prerequisite_job(self):
+        # Waiting on the constrained pool itself deadlocks the queue. Both
+        # turnstile jobs must stay on hosted runners.
+        for name, text in self.workflows.items():
+            for match in re.finditer(
+                r"^  ([a-z0-9-]+turnstile):\n(.*?)(?=^  \S)", text, re.S | re.M
+            ):
+                self.assertIn("runs-on: ubuntu-", match.group(2), name)
+
+    def test_no_concurrency_group_gates_the_self_hosted_lanes(self):
+        # A job-level concurrency group cancels older pending runs, which is
+        # the self-clogging behavior the turnstile exists to avoid. The
+        # workflow-level group that dedupes superseded PR pushes is a different
+        # mechanism and stays.
+        for job, name in ((_LINUX_LANE, "main.yml"), (_COVERAGE_LANE, "coverage.yml")):
+            body = self._job_body(self.workflows[name], job)
+            self.assertNotIn("concurrency:", body, job)
+
+    def test_fail_open_and_api_retry_properties_are_kept(self):
+        self.assertIn("proceeding (fail-open)", self.action)
+        self.assertIn("retaining gate behind", self.action)
+
+    def test_action_defaults_preserve_single_lane_behavior(self):
+        self.assertRegex(self.action, r"capacity:\n(?:.*\n)*?\s+default: \"1\"")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The self-hosted turnstile serialized each lane independently at concurrency 1 (only the oldest run's job proceeds), so with two lanes the four-VM runner fleet was capped at two concurrent jobs and the coverage lane formed a multi-hour FIFO under merge traffic. The turnstile action now supports a shared pool: both lanes pass the same pool of job names with capacity 4, so linux and coverage runs mix and match across the fleet.

Admission is strict FIFO with capacity, ordered by workflow run id (a pool spans workflows, and run_number only orders within one workflow). A run holds a slot when an older run's pool job is executing, admitted-but-unscheduled, or still initializing (a fresh run whose job list has not materialized yet counts, closing the burst over-admission window); newer runs count only when already executing, so waiters never block each other and the oldest waiter is blocked by nobody. An unreadable jobs payload counts as active, so an API hiccup narrows the pool rather than opening it. Two deliberate conservatisms: an older run that never creates a pool job (a docs-only run) holds a slot until it completes rather than the action evaluating job conditions, and the jobs listing is read unpaginated, which is sound at this repository's job counts.

The rules live in a pure stdin/stdout module driven by a new 25-case unit battery (mix-and-match up to capacity, hard stop at capacity, both initializing-run windows, API-hiccup narrowing, six simultaneous waiters admitting exactly the four oldest in order, and capacity 1 reproducing the original single-lane FIFO exactly). The load-bearing properties the original design documented are preserved and asserted: the wait runs on a hosted prerequisite job, fail-open at the safety cap, transient API failures keep the gate, and no GitHub concurrency groups. Both workflow files and the action parse cleanly; the routing and policy test suites pass; the accepted tradeoff (up to four CI jobs sharing the remote-execution backend, with interactive use still outranking CI) is recorded in the workflow comments.