### PR TITLE
ci: Exclude vendored code from CodeFactor analysis

### DIFF
--- a/.codefactor.yml
+++ b/.codefactor.yml
@@ -1,0 +1,5 @@
+# CodeFactor analysis configuration.
+# Vendored code is analyzed upstream, not held to this repository's style
+# rules; findings there are noise the maintainers cannot act on.
+exclude:
+  - "third_party/**"


### PR DESCRIPTION
CodeFactor was flagging findings inside third_party (the vendored stb header's CWE-120s and complexity, blank-line style in vendored sources), none of which are actionable here: vendored code follows its upstream conventions and changes by import, not local style fixes. A repo-root .codefactor.yml excludes third_party/** from analysis so PR annotations only cover code this repository owns.