### PR TITLE
Preserve WebGPU map cleanup across handle reuse

### DIFF
--- a/donner/editor/wasm/tests/wgpu-readback-contract.spec.mjs
+++ b/donner/editor/wasm/tests/wgpu-readback-contract.spec.mjs
@@ -31,6 +31,52 @@ const geodeDeviceHeader = await readFile(
   new URL("../../../svg/renderer/geode/GeodeDevice.h", import.meta.url),
   "utf8",
 );
+const emdawnWebgpuSource = await readFile(
+  new URL("../../../../third_party/emdawnwebgpu/webgpu/src/library_webgpu.js", import.meta.url),
+  "utf8",
+);
+
+test("late map rejection cannot clear a reused buffer handle's cleanup state", () => {
+  const mapAsyncStart = emdawnWebgpuSource.search(/\bemwgpuBufferMapAsync\s*:/);
+  assert.ok(mapAsyncStart >= 0, "expected the asynchronous buffer-map bridge");
+  const mapAsyncEndOffset = emdawnWebgpuSource.slice(mapAsyncStart).search(
+    /\bemwgpuBufferUnmap\s*:/,
+  );
+  assert.ok(mapAsyncEndOffset > 0, "expected the buffer-unmap bridge after mapAsync");
+  const mapAsyncEnd = mapAsyncStart + mapAsyncEndOffset;
+  const mapAsync = emdawnWebgpuSource.slice(mapAsyncStart, mapAsyncEnd);
+  const cleanupListDeclaration = mapAsync.match(
+    /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*\[\]/,
+  );
+  assert.ok(
+    cleanupListDeclaration,
+    "each map generation must own a distinct cleanup list",
+  );
+  const cleanupList = cleanupListDeclaration[1];
+  assert.match(
+    mapAsync,
+    new RegExp(`bufferOnUnmaps\\[bufferPtr\\]\\s*=\\s*${cleanupList}\\b`),
+    "the current buffer handle must publish that generation's cleanup list",
+  );
+  const cleanupDeletes = [
+    ...mapAsync.matchAll(/delete\s+WebGPU\.Internals\.bufferOnUnmaps\[bufferPtr\]/g),
+  ];
+  assert.equal(cleanupDeletes.length, 1, "the rejection path must have one cleanup deletion");
+  const guardedCleanup = mapAsync.match(
+    new RegExp(
+      `if\\s*\\(WebGPU\\.Internals\\.bufferOnUnmaps\\[bufferPtr\\]\\s*===\\s*${cleanupList}\\)\\s*\\{([\\s\\S]*?)\\}`,
+    ),
+  );
+  assert.ok(
+    guardedCleanup,
+    "a late rejection must not delete cleanup state installed by a reused handle",
+  );
+  assert.match(
+    guardedCleanup[1],
+    /delete\s+WebGPU\.Internals\.bufferOnUnmaps\[bufferPtr\]/,
+    "only the current map generation may delete its cleanup state",
+  );
+});
 
 test("diagnostic readback requests remain pending until a capture completes", () => {
   const peek = source.match(

--- a/third_party/emdawnwebgpu/webgpu/src/library_webgpu.js
+++ b/third_party/emdawnwebgpu/webgpu/src/library_webgpu.js
@@ -1066,7 +1066,8 @@ var LibraryWebGPU = {
   emwgpuBufferMapAsync__sig: 'vpjjpp',
   emwgpuBufferMapAsync: (bufferPtr, futureId, mode, offset, size) => {
     var buffer = WebGPU.getJsObject(bufferPtr);
-    WebGPU.Internals.bufferOnUnmaps[bufferPtr] = [];
+    var onUnmap = [];
+    WebGPU.Internals.bufferOnUnmaps[bufferPtr] = onUnmap;
 
     {{{ gpu.convertSentinelToUndefined('size', true) }}}
 
@@ -1088,7 +1089,10 @@ var LibraryWebGPU = {
           0;
         {{{ gpu.makeCheck('status') }}}
         _emwgpuOnMapAsyncCompleted(futureId, status, {{{ gpu.passAsPointer('messagePtr') }}});
-        delete WebGPU.Internals.bufferOnUnmaps[bufferPtr];
+        // An aborted C++ map can release and reuse bufferPtr before this Promise settles.
+        if (WebGPU.Internals.bufferOnUnmaps[bufferPtr] === onUnmap) {
+          delete WebGPU.Internals.bufferOnUnmaps[bufferPtr];
+        }
       });
     }));
   },


### PR DESCRIPTION
This fixes a browser WebGPU buffer-map cleanup race that can terminate the renderer worker after a cancelled snapshot is followed by a new readback.

- give each asynchronous Emdawn buffer map a distinct cleanup-list identity
- delete rejection cleanup state only when that map generation is still current
- add a source contract that fails if cleanup returns to raw handle-only deletion
- preserve prompt cancellation without retries, longer timeouts, or weakened browser assertions

## Root cause

Cancelling a pending readback completes the C++ map future synchronously, so the released buffer object's address can be reused before the original JavaScript Promise rejects. The old rejection used that address as an unguarded table key and could delete the new map's cleanup list. The next readback then mapped successfully but crashed while registering its cleanup callback.

The fix captures the list installed by each map and removes the table entry only when it still points to that exact list. Late rejection can no longer mutate a newer generation at the same handle address.

## Validation

- regression contract: red on the old bridge, green after the generation guard
- `npm --prefix donner/editor/wasm/tests run test:selector` (28 passed)
- both Emdawn Wasm link consumers and the editor package-size test
- hermetic Bazel Chromium smoke test
- formerly failing Text and Style browser case, 20 of 20 headed Chromium runs
- full browser matrix: 26 Chromium default, 5 Firefox resize, 2 WebKit carousel, 9 Firefox composited, and 13 Chromium composited tests passed
- `bazel test //... --test_output=errors` (458 targets: 341 passed, 117 intentional skips)
- repository lint, CMake validation, dprint, and diff checks
