### PR TITLE
ci: Restrict the Bazel wasm smoke test to macOS

### DIFF
--- a/donner/editor/wasm/tests/BUILD.bazel
+++ b/donner/editor/wasm/tests/BUILD.bazel
@@ -37,11 +37,20 @@ playwright_bin.playwright_test(
         "NODE_OPTIONS": "",
         "PLAYWRIGHT_BROWSERS_PATH": "$(rootpath @playwright//:chromium)/../",
     },
+    # macOS-only: the selected smoke test asserts on presented WebGPU canvas
+    # pixels, and headless Chromium on Linux cannot present a WebGPU
+    # OffscreenCanvas swapchain with the SwiftShader WebGPU adapter. The GPU
+    # service finds no SharedImageBackingFactory for the swapchain allocation
+    # (usage WebgpuSwapChainTexture|DisplayRead|...), fails the first present,
+    # and destroys the device, after which every WebGPU call rejects with "A
+    # valid external Instance reference no longer exists". A browser-only
+    # probe (worker + transferred OffscreenCanvas + clear + present) fails the
+    # same way with no Donner code involved, on both Chromium 147 and 151 and
+    # with ANGLE/SwiftShader GL, Vulkan, and Graphite flag configurations, so
+    # this is an environment capability boundary, not a flag or timing gap.
+    # macOS headless Chromium presents through the real GPU and passes.
     target_compatible_with = [
         "@platforms//cpu:aarch64",
-    ] + select({
-        "@platforms//os:macos": [],
-        "@platforms//os:linux": [],
-        "//conditions:default": ["@platforms//:incompatible"],
-    }),
+        "@platforms//os:macos",
+    ],
 )

--- a/donner/editor/wasm/tests/browser-matrix.spec.mjs
+++ b/donner/editor/wasm/tests/browser-matrix.spec.mjs
@@ -116,8 +116,18 @@ test("Bazel owns a hermetic no-window Chromium browser lane", () => {
   );
   assert.match(
     buildFile,
-    /target_compatible_with = \[[\s\S]*?"@platforms\/\/cpu:aarch64"[\s\S]*?\] \+ select\(\{[\s\S]*?"@platforms\/\/os:macos": \[\][\s\S]*?"@platforms\/\/os:linux": \[\][\s\S]*?"\/\/conditions:default": \["@platforms\/\/:incompatible"\]/,
-    "the headless browser test must allow only macOS and Linux ARM64 execution",
+    /target_compatible_with = \[[\s\S]*?"@platforms\/\/cpu:aarch64"[\s\S]*?"@platforms\/\/os:macos"[\s\S]*?\]/,
+    "the headless browser test must allow only macOS ARM64 execution",
+  );
+  // Linux is excluded deliberately, not by omission: headless Chromium there
+  // cannot present a WebGPU OffscreenCanvas swapchain on the SwiftShader
+  // adapter, so the presented-pixel assertions can never pass. Restoring the
+  // platform needs a GPU-backed runner or upstream swapchain support, not just
+  // a constraint edit, so re-adding it here should fail this contract first.
+  assert.doesNotMatch(
+    buildFile,
+    /"@platforms\/\/os:linux"/,
+    "the headless browser test cannot run on Linux until WebGPU swapchain presentation exists there",
   );
 
   const chromiumConfig = readFileSync(path.join(testDirectory, "playwright.config.js"), "utf8");


### PR DESCRIPTION
## Problem

`//donner/editor/wasm/tests:chromium_remote_smoke` fails deterministically on
Linux arm64. The test asserts on presented WebGPU canvas pixels, and headless
Chromium there cannot present a WebGPU OffscreenCanvas swapchain on the
SwiftShader WebGPU adapter: the GPU service finds no `SharedImageBackingFactory`
for the swapchain allocation, the first present fails, the device is destroyed,
and every later WebGPU call rejects with "A valid external Instance reference no
longer exists". The editor never completes a document render, so the test times
out waiting for readback pixels.

This target was introduced recently and has not yet run on a Linux lane that
executes it, so the failure is latent rather than observed in CI history.

## Evidence this is an environment capability boundary

- A browser-only probe (worker plus transferred `OffscreenCanvas`, clear,
  present) fails identically with no project code involved.
- Reproduces on Playwright 1.59.1 (Chromium 147) and 1.62.1 (Chromium 151),
  with and without the Bazel wrapper, and with ANGLE/SwiftShader GL, Vulkan,
  and Graphite flag variants.
- Pure buffer `mapAsync` (no canvas) succeeds in the same browser session and
  WebGL renders fine, so only the WebGPU swapchain presentation path is absent.
- The wasm package built at the last green revision of the browser workflow
  fails the same way, ruling out a product regression.
- The 20s deadline is not the cause: captures fail immediately and roughly 180
  requests are attempted inside the window.

## Change

Replace the `select()` that admitted both Linux and macOS with a plain
`target_compatible_with` of `aarch64 + macos`, and document the reason inline.
CI runs Bazel with `--skip_incompatible_explicit_targets`, so the target is
skipped cleanly on Linux lanes and continues to run on macOS arm64, where
headless Chromium presents through a real GPU.

## Verification

Red before the change and skipped-clean after, including two runs with
`--nocache_test_results` and a pattern-based invocation. Buildifier clean.

## Known limitation

WebGPU browser smoke coverage now runs only on macOS arm64. Restoring the Linux
lane requires either GPU-backed Linux runners or upstream Chromium/SwiftShader
support for WebGPU swapchain interop; worth revisiting when either lands.
