### PR TITLE
feat: Add a composited rendering mode setting to the editor

### DIFF
--- a/donner/editor/AsyncRenderer.cc
+++ b/donner/editor/AsyncRenderer.cc
@@ -9,6 +9,7 @@
 
 #include "donner/base/MemoryAttribution.h"
 #include "donner/base/Utils.h"
+#include "donner/base/xml/components/TreeComponent.h"
 #include "donner/editor/OverlayRenderer.h"
 #include "donner/editor/TracyWrapper.h"
 #include "donner/svg/SVGDocument.h"
@@ -186,9 +187,20 @@ bool SameEntityList(const std::vector<Entity>& lhs, const std::vector<Entity>& r
   return lhs == rhs;
 }
 
-bool ContainsAllEntities(const std::vector<Entity>& haystack, const std::vector<Entity>& needles) {
-  return std::ranges::all_of(needles,
-                             [&](Entity entity) { return ContainsEntity(haystack, entity); });
+bool ContainsAllEntitiesOrOwningAncestors(Registry& registry,
+                                          const std::vector<Entity>& promotedEntities,
+                                          const std::vector<Entity>& desiredEntities) {
+  return std::ranges::all_of(desiredEntities, [&](Entity desiredEntity) {
+    Entity cursor = desiredEntity;
+    while (cursor != entt::null && registry.valid(cursor)) {
+      if (ContainsEntity(promotedEntities, cursor)) {
+        return true;
+      }
+      const auto* tree = registry.try_get<donner::components::TreeComponent>(cursor);
+      cursor = tree != nullptr ? tree->parent() : entt::null;
+    }
+    return false;
+  });
 }
 
 bool WaitForSampleThumbnailDelay(const svg::compositor::CancellationToken& cancellation,
@@ -927,22 +939,19 @@ void AsyncRenderer::workerLoop() {
       if (renderMode == CompositedRenderingMode::FilterOnly) {
         // Filter-only: cached isolated layers for SVG filters (the expensive
         // re-render case) and nothing else. Opacity groups, blend modes, and
-        // masks render inline; selection/drag and animation subtrees are not
-        // promoted; the document is not pre-split into bucket layers.
+        // masks render inline; animation subtrees are not promoted and the
+        // document is not pre-split into bucket layers. Selection/drag layers
+        // remain active because they are structural editor presentation, not
+        // optional retained-content caching.
         compositorConfig.mandatoryHintScope = svg::compositor::MandatoryHintScope::FilterOnly;
-        compositorConfig.autoPromoteInteractions = false;
         compositorConfig.autoPromoteAnimations = false;
         compositorConfig.complexityBucketing = false;
       }
-      // The editor retains compositor textures across frames, so even a geometrically cheap span
-      // is less expensive to upload once than to rerasterize during every pointer update. Browser
-      // WebGPU makes the difference especially pronounced, but the same policy removes the native
-      // renderer's dominant steady-drag CPU cost as well.
-      compositorConfig.immediateStaticSpans = false;
-      compositorConfig.dynamicImmediateStaticSpans = false;
-      // The first full-document draw is already correct. Publish it first, then warm retained
-      // caches from the worker's independent low-priority lane after the result is accepted.
-      compositorConfig.deferFirstFrameWarmup = true;
+      // Every non-Off editor frame is presented from the compositor's paint-order tile set.
+      // Preserve the normal immediate-span policy so cheap background/selection/foreground spans
+      // remain layers without retaining needless textures, and finish the first-frame warmup before
+      // publishing so a cold frame cannot fall back to a monolithic full-canvas payload.
+      compositorConfig.deferFirstFrameWarmup = false;
       // CompositorController stores its SVGDocument by reference. Bind that reference to the
       // AsyncRenderer-owned value before constructing the controller: RenderLease is destroyed
       // after this request, while deferred warmup and later frames intentionally outlive it.
@@ -1046,11 +1055,10 @@ void AsyncRenderer::workerLoop() {
     // document-space transform to every drag-target tile, keeping the path
     // overlay and cached content in lockstep while avoiding a full DOM render
     // on each pointer frame.
-    // Selection/drag promotion is a full-compositing feature: Off has no
-    // controller to promote into, and FilterOnly composits filters only, so
-    // both present drags through full-document renders.
-    const bool editorPromotionEnabled =
-        compositor_ != nullptr && renderMode == CompositedRenderingMode::On;
+    // Selection/drag promotion is structural editor presentation in both non-Off modes. FilterOnly
+    // narrows automatic retained-content layers; it does not collapse selected content back into a
+    // root render.
+    const bool editorPromotionEnabled = compositor_ != nullptr;
     const std::vector<Entity> desiredEntities = (geometryDebugOverlay || !editorPromotionEnabled)
                                                     ? std::vector<Entity>()
                                                     : DesiredCompositorEntities(request);
@@ -1098,9 +1106,9 @@ void AsyncRenderer::workerLoop() {
             compositorEntity_ = entity;
           }
           compositorInteractionKind_ = desiredKind;
-        } else if (promoteResult.fullCanvasPreviewRequired()) {
-          // Valid renderable content under a filter, clip-path, or mask is presented through the
-          // full-canvas composited tile built from the final snapshot below.
+        } else if (promoteResult.owningTilesRequired()) {
+          // The requested entity remains inside the paint-order tiles that own its ancestor
+          // compositing context. Only the interaction split is unavailable.
         }
       }
       if (compositorEntities_.empty()) {
@@ -1114,7 +1122,9 @@ void AsyncRenderer::workerLoop() {
       }
     }
     const bool desiredPromotionIncomplete =
-        !desiredEntities.empty() && !ContainsAllEntities(compositorEntities_, desiredEntities);
+        !desiredEntities.empty() &&
+        !ContainsAllEntitiesOrOwningAncestors(requestDocument.registry(), compositorEntities_,
+                                              desiredEntities);
 
     // The DOM is the sole source of truth for the dragged entity's
     // position - `SelectTool` mutates the `transform` attribute every
@@ -1153,10 +1163,9 @@ void AsyncRenderer::workerLoop() {
         request.dragPreview->interactionKind == svg::compositor::InteractionHint::ActiveDrag;
     const bool splitPreviewSafe = !desiredPromotionIncomplete;
     if (compositor_ != nullptr) {
-      // `!desiredEntities.empty()` matters when editor promotion is disabled
-      // (FilterOnly): with nothing promoted, `desiredPromotionIncomplete` is
-      // vacuously false during a drag, and skipping the main compose would
-      // present a full-canvas snapshot of a frame that was never composed.
+      // `!desiredEntities.empty()` protects requests without editor selection/drag promotion:
+      // `desiredPromotionIncomplete` is vacuously false when nothing is requested, but skipping the
+      // main compose would leave diagnostic snapshots stale.
       compositor_->setSkipMainComposeDuringSplit(activeDragRequest && splitPreviewSafe &&
                                                  !desiredEntities.empty() &&
                                                  !request.captureCpuSnapshot);
@@ -1167,15 +1176,22 @@ void AsyncRenderer::workerLoop() {
     // Tiles whose id/generation/dimensions were already published carry
     // metadata only; the GL cache keeps the existing texture and applies
     // updated presentation geometry.
+    bool desiredPromotionCoverageCompleteAfterRender = false;
     const auto buildCompositedPreview = [&]() -> std::optional<RenderResult::CompositedPreview> {
       if (request.overviewInfillOnly) {
         return std::nullopt;
       }
-      if (compositor_ == nullptr || !splitPreviewSafe || !request.dragPreview.has_value() ||
-          compositorEntity_ == entt::null || compositor_->layerCount() == 0u) {
+      if (compositor_ == nullptr) {
         return std::nullopt;
       }
-      const std::vector<Entity> dragPreviewEntities = DragPreviewEntities(*request.dragPreview);
+      const std::vector<Entity> dragPreviewEntities =
+          request.dragPreview.has_value() ? DragPreviewEntities(*request.dragPreview)
+                                          : std::vector<Entity>();
+      const Entity previewEntity =
+          desiredPromotionCoverageCompleteAfterRender ? compositorEntity_ : entt::null;
+      const svg::compositor::InteractionHint previewInteractionKind =
+          request.dragPreview.has_value() ? request.dragPreview->interactionKind
+                                          : svg::compositor::InteractionHint::Selection;
       const Transform2d documentFromOutput = rasterViewport.outputFromDocument.inverse();
       const auto outputPointToPresentedDoc = [&](const Vector2d& outputPoint) {
         return documentFromOutput.transformPosition(outputPoint) - documentViewBox.topLeft;
@@ -1318,8 +1334,8 @@ void AsyncRenderer::workerLoop() {
       }
       return RenderResult::CompositedPreview{
           .tiles = std::move(previewTiles),
-          .entity = compositorEntity_,
-          .interactionKind = request.dragPreview->interactionKind,
+          .entity = previewEntity,
+          .interactionKind = previewInteractionKind,
           .representedDragPreview = request.dragPreview,
       };
     };
@@ -1350,7 +1366,40 @@ void AsyncRenderer::workerLoop() {
       {
         const ScopedHeapDelta renderFrameHeapDelta(MemoryStage::WorkerRenderFrame);
         if (compositor_ != nullptr) {
+          const auto syncWorkerPromotions = [&]() {
+            std::erase_if(compositorEntities_,
+                          [this](Entity entity) { return !compositor_->isPromoted(entity); });
+            compositorEntity_ =
+                compositorEntities_.empty() ? entt::null : compositorEntities_.front();
+            if (compositorEntity_ == entt::null) {
+              compositorInteractionKind_ = svg::compositor::InteractionHint::Selection;
+            }
+          };
           renderCompleted = compositor_->renderFrame(viewport, cancelRender_, surfaceFromCanvas);
+          if (renderCompleted) {
+            syncWorkerPromotions();
+            bool promotionAddedAfterPrepare = false;
+            for (Entity entity : desiredEntities) {
+              if (compositor_->isPromoted(entity)) {
+                continue;
+              }
+              const svg::compositor::CompositorController::PromoteResult promoteResult =
+                  compositor_->promoteEntity(entity, desiredKind);
+              if (promoteResult.promotedLayer()) {
+                AppendUniqueEntity(&compositorEntities_, entity);
+                promotionAddedAfterPrepare = true;
+              }
+            }
+            if (promotionAddedAfterPrepare) {
+              compositorEntity_ = compositorEntities_.front();
+              compositorInteractionKind_ = desiredKind;
+              renderCompleted =
+                  compositor_->renderFrame(viewport, cancelRender_, surfaceFromCanvas);
+              if (renderCompleted) {
+                syncWorkerPromotions();
+              }
+            }
+          }
         } else {
           // Composited rendering Off: flat full-document render with no
           // retained state, presented through the full-canvas snapshot path
@@ -1364,6 +1413,10 @@ void AsyncRenderer::workerLoop() {
         }
       }
       workerTiming.renderFrameMs = elapsedSince(renderFrameStart);
+    }
+    if (renderCompleted && compositor_ != nullptr && !desiredEntities.empty()) {
+      desiredPromotionCoverageCompleteAfterRender = ContainsAllEntitiesOrOwningAncestors(
+          requestDocument.registry(), compositorEntities_, desiredEntities);
     }
 
     // A superseding request can arrive after the compositor's final internal cancellation point.
@@ -1413,17 +1466,15 @@ void AsyncRenderer::workerLoop() {
       continue;
     }
 
-    // Build a CompositedPreview from the compositor tile set when available.
-    // If the splitter cannot provide tiles for this frame, the final snapshot
-    // below is wrapped as a single full-canvas tile so presentation still goes
-    // through the compositor path.
+    // Every non-Off editor frame publishes the compositor's paint-order tile set. Promotion
+    // refusal only disables the drag skip-compose optimization; the remaining mandatory layers
+    // and static segments are still the correct presentation topology.
     {
       const auto buildPreviewStart = std::chrono::steady_clock::now();
       const ScopedHeapDelta buildPreviewHeapDelta(MemoryStage::WorkerBuildPreview);
       compositedPreview = buildCompositedPreview();
       workerTiming.buildPreviewMs = elapsedSince(buildPreviewStart);
     }
-
     // Selection chrome is no longer baked into the bitmap - main.cc
     // draws it via the ImGui draw list every frame so clicks don't
     // pay the SVG re-rasterize cost. The `request.selection` field
@@ -1464,9 +1515,14 @@ void AsyncRenderer::workerLoop() {
     workerTiming.timedOutWaitSite = readbackStats.timedOutWaitSite;
     workerTiming.timedOutWaitMs = readbackStats.timedOutWaitMs;
     noteGpuWaitOutcome(readbackStats);
+    // Only the explicit Off mode, overview infill, and the geometry-debug diagnostic use a flat
+    // payload. Normal On and FilterOnly presentation must have produced compositor tiles above.
     if (!compositedPreview.has_value() && (!bitmap.empty() || fullCanvasTexture != nullptr)) {
-      const Entity previewEntity =
-          request.dragPreview.has_value() ? request.dragPreview->entity : request.selectedEntity;
+      UTILS_RELEASE_ASSERT_MSG(
+          compositor_ == nullptr || request.overviewInfillOnly || geometryDebugOverlay,
+          "A non-Off editor render produced no compositor tiles. Refusing monolithic full-canvas "
+          "presentation.");
+      const Entity previewEntity = compositor_ != nullptr ? compositorEntity_ : entt::null;
       const svg::compositor::InteractionHint interactionKind =
           request.dragPreview.has_value() ? request.dragPreview->interactionKind
                                           : svg::compositor::InteractionHint::Selection;
@@ -1476,7 +1532,16 @@ void AsyncRenderer::workerLoop() {
       compositedPreview = BuildFullCanvasCompositedPreview(
           documentViewBox, bitmap, std::move(fullCanvasTexture), ++fullCanvasPayloadGeneration_,
           previewEntity, interactionKind, rasterViewport, request.dragPreview);
+      if (geometryDebugOverlay) {
+        compositedPreview->tiles.front().kind = RenderResult::CompositedTile::Kind::Immediate;
+        compositedPreview->tiles.front().id = "geometry-debug-flat";
+      }
     }
+    UTILS_RELEASE_ASSERT_MSG(
+        compositor_ == nullptr || request.overviewInfillOnly || geometryDebugOverlay ||
+            compositedPreview.has_value(),
+        "A non-Off editor render produced no compositor tiles. Refusing monolithic full-canvas "
+        "presentation.");
 
     // Attribute what this render iteration is holding, before the result leaves
     // the worker. The compositor caches are a level (they persist across

--- a/donner/editor/AsyncRenderer.cc
+++ b/donner/editor/AsyncRenderer.cc
@@ -909,6 +909,15 @@ void AsyncRenderer::workerLoop() {
       compositorEntities_.clear();
       compositorInteractionKind_ = svg::compositor::InteractionHint::Selection;
       publishedCompositedTiles_.clear();
+      // The per-generation remap history exists only to preserve compositor
+      // caches across structural replaces; with no compositor the erase sites
+      // in the swap path are unreachable, so drop the history here or a long
+      // Off session accumulates one map per structural replace. Leaving Off
+      // always reconstructs and needs no remap history.
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        retainedStructuralRemaps_.clear();
+      }
     }
     const bool needsFreshCompositor =
         renderMode != CompositedRenderingMode::Off &&

--- a/donner/editor/AsyncRenderer.cc
+++ b/donner/editor/AsyncRenderer.cc
@@ -889,9 +889,42 @@ void AsyncRenderer::workerLoop() {
     // GL textures still showed the dragged element at its rasterize-
     // time position. Pinned by
     // `RnrReplayTest::FilterSnapbackReproPreservesCompositorAcrossWriteback`.
-    const bool needsFreshCompositor = !compositor_ || compositorRenderer_ != &requestRenderer;
+    // A third lifecycle input joins the two above: the UI-selected composited
+    // rendering mode. `Off` runs with no controller at all (every
+    // `compositor_` consumer below is null-guarded); the other modes bake
+    // their policy into `CompositorConfig` at construction, so any mode
+    // change reconstructs.
+    const CompositedRenderingMode renderMode =
+        compositedRenderingMode_.load(std::memory_order_acquire);
+    const bool renderModeChanged = renderMode != appliedCompositedRenderingMode_;
+    appliedCompositedRenderingMode_ = renderMode;
+    if (renderMode == CompositedRenderingMode::Off && compositor_ != nullptr) {
+      // Entering Off: destroy the controller and every retained cache with it.
+      // `compositorDocument_` exists only to give the controller a stable
+      // SVGDocument reference, so it is released too.
+      compositor_.reset();
+      compositorDocument_.reset();
+      compositorRenderer_ = nullptr;
+      compositorEntity_ = entt::null;
+      compositorEntities_.clear();
+      compositorInteractionKind_ = svg::compositor::InteractionHint::Selection;
+      publishedCompositedTiles_.clear();
+    }
+    const bool needsFreshCompositor =
+        renderMode != CompositedRenderingMode::Off &&
+        (!compositor_ || compositorRenderer_ != &requestRenderer || renderModeChanged);
     if (needsFreshCompositor) {
       svg::compositor::CompositorConfig compositorConfig;
+      if (renderMode == CompositedRenderingMode::FilterOnly) {
+        // Filter-only: cached isolated layers for SVG filters (the expensive
+        // re-render case) and nothing else. Opacity groups, blend modes, and
+        // masks render inline; selection/drag and animation subtrees are not
+        // promoted; the document is not pre-split into bucket layers.
+        compositorConfig.mandatoryHintScope = svg::compositor::MandatoryHintScope::FilterOnly;
+        compositorConfig.autoPromoteInteractions = false;
+        compositorConfig.autoPromoteAnimations = false;
+        compositorConfig.complexityBucketing = false;
+      }
       // The editor retains compositor textures across frames, so even a geometrically cheap span
       // is less expensive to upload once than to rerasterize during every pointer update. Browser
       // WebGPU makes the difference especially pronounced, but the same policy removes the native
@@ -922,7 +955,7 @@ void AsyncRenderer::workerLoop() {
     }
 
     const bool documentSwapDetected =
-        !needsFreshCompositor &&
+        compositor_ != nullptr && !needsFreshCompositor &&
         (request.documentGeneration != compositorDocumentGeneration_ ||
          (compositorDocument_.has_value() &&
           compositorDocument_->handle().get() != requestDocument.handle().get()));
@@ -986,8 +1019,10 @@ void AsyncRenderer::workerLoop() {
     const bool geometryDebugOverlayChanged = geometryDebugOverlay != appliedGeometryDebugOverlay_;
     if (geometryDebugOverlayChanged) {
       appliedGeometryDebugOverlay_ = geometryDebugOverlay;
-      compositor_->resetAllLayers();
-      compositorResetCount_.fetch_add(1, std::memory_order_release);
+      if (compositor_ != nullptr) {
+        compositor_->resetAllLayers();
+        compositorResetCount_.fetch_add(1, std::memory_order_release);
+      }
       compositorEntity_ = entt::null;
       compositorEntities_.clear();
       compositorInteractionKind_ = svg::compositor::InteractionHint::Selection;
@@ -1002,8 +1037,14 @@ void AsyncRenderer::workerLoop() {
     // document-space transform to every drag-target tile, keeping the path
     // overlay and cached content in lockstep while avoiding a full DOM render
     // on each pointer frame.
-    const std::vector<Entity> desiredEntities =
-        geometryDebugOverlay ? std::vector<Entity>() : DesiredCompositorEntities(request);
+    // Selection/drag promotion is a full-compositing feature: Off has no
+    // controller to promote into, and FilterOnly composits filters only, so
+    // both present drags through full-document renders.
+    const bool editorPromotionEnabled =
+        compositor_ != nullptr && renderMode == CompositedRenderingMode::On;
+    const std::vector<Entity> desiredEntities = (geometryDebugOverlay || !editorPromotionEnabled)
+                                                    ? std::vector<Entity>()
+                                                    : DesiredCompositorEntities(request);
     const Entity desiredEntity = desiredEntities.empty() ? entt::null : desiredEntities.front();
     const svg::compositor::InteractionHint desiredKind =
         request.dragPreview.has_value() ? request.dragPreview->interactionKind
@@ -1057,7 +1098,8 @@ void AsyncRenderer::workerLoop() {
         compositorEntity_ = entt::null;
       }
     }
-    if (request.dragPreview.has_value() && request.dragPreview->forceLayerRasterization) {
+    if (editorPromotionEnabled && request.dragPreview.has_value() &&
+        request.dragPreview->forceLayerRasterization) {
       for (Entity entity : DragPreviewEntities(*request.dragPreview)) {
         compositor_->markPromotedLayerDirty(entity);
       }
@@ -1086,8 +1128,10 @@ void AsyncRenderer::workerLoop() {
     // Push the current UI-thread setting for tight-bounded segments
     // into the compositor. Setter is a no-op when unchanged; otherwise
     // it marks all segments dirty so the flip takes effect this frame.
-    compositor_->setTightBoundedSegmentsEnabled(
-        tightBoundedSegments_.load(std::memory_order_acquire));
+    if (compositor_ != nullptr) {
+      compositor_->setTightBoundedSegmentsEnabled(
+          tightBoundedSegments_.load(std::memory_order_acquire));
+    }
 
     // Keep the compositor hint in ActiveDrag across mouse-up so the
     // layer/segment caches survive quick release->drag-again cycles, but
@@ -1099,8 +1143,15 @@ void AsyncRenderer::workerLoop() {
         request.dragPreview.has_value() &&
         request.dragPreview->interactionKind == svg::compositor::InteractionHint::ActiveDrag;
     const bool splitPreviewSafe = !desiredPromotionIncomplete;
-    compositor_->setSkipMainComposeDuringSplit(activeDragRequest && splitPreviewSafe &&
-                                               !request.captureCpuSnapshot);
+    if (compositor_ != nullptr) {
+      // `!desiredEntities.empty()` matters when editor promotion is disabled
+      // (FilterOnly): with nothing promoted, `desiredPromotionIncomplete` is
+      // vacuously false during a drag, and skipping the main compose would
+      // present a full-canvas snapshot of a frame that was never composed.
+      compositor_->setSkipMainComposeDuringSplit(activeDragRequest && splitPreviewSafe &&
+                                                 !desiredEntities.empty() &&
+                                                 !request.captureCpuSnapshot);
+    }
     workerTiming.setupMs = elapsedSince(workerStart);
 
     // Build a CompositedPreview from the compositor's current tile state.
@@ -1111,7 +1162,7 @@ void AsyncRenderer::workerLoop() {
       if (request.overviewInfillOnly) {
         return std::nullopt;
       }
-      if (!splitPreviewSafe || !request.dragPreview.has_value() ||
+      if (compositor_ == nullptr || !splitPreviewSafe || !request.dragPreview.has_value() ||
           compositorEntity_ == entt::null || compositor_->layerCount() == 0u) {
         return std::nullopt;
       }
@@ -1289,7 +1340,19 @@ void AsyncRenderer::workerLoop() {
       const auto renderFrameStart = std::chrono::steady_clock::now();
       {
         const ScopedHeapDelta renderFrameHeapDelta(MemoryStage::WorkerRenderFrame);
-        renderCompleted = compositor_->renderFrame(viewport, cancelRender_, surfaceFromCanvas);
+        if (compositor_ != nullptr) {
+          renderCompleted = compositor_->renderFrame(viewport, cancelRender_, surfaceFromCanvas);
+        } else {
+          // Composited rendering Off: flat full-document render with no
+          // retained state, presented through the full-canvas snapshot path
+          // below. This is the same direct path the compositor's
+          // `verifyPixelIdentity` reference render uses, so pixels match the
+          // composited modes by construction.
+          svg::RendererDriver directDriver(requestRenderer);
+          renderCompleted = directDriver.drawInterruptibly(
+              requestDocument, viewport, surfaceFromCanvas,
+              [this]() { return cancelRender_.isCancelled(); });
+        }
       }
       workerTiming.renderFrameMs = elapsedSince(renderFrameStart);
     }
@@ -1413,7 +1476,11 @@ void AsyncRenderer::workerLoop() {
     // memory in different ways, so they are published as different counter
     // kinds. See `donner/base/MemoryAttribution.h`.
     {
-      const auto breakdown = compositor_->bitmapMemoryBreakdown();
+      // With composited rendering Off there is no controller; publish zeroed
+      // compositor categories so the memory panel reflects the freed caches.
+      const auto breakdown = compositor_ != nullptr
+                                 ? compositor_->bitmapMemoryBreakdown()
+                                 : svg::compositor::CompositorController::BitmapMemoryBreakdown{};
       SetRetainedBytes(MemoryCategory::CompositorSegmentBitmaps, breakdown.segmentBitmapBytes);
       SetRetainedBytes(MemoryCategory::CompositorSegmentTextures, breakdown.segmentTextureBytes);
       SetRetainedBytes(MemoryCategory::CompositorLayerBitmaps, breakdown.layerBitmapBytes);
@@ -1470,18 +1537,31 @@ void AsyncRenderer::workerLoop() {
           done.result.version = request.version;
           done.result.documentGeneration = request.documentGeneration;
           done.presentationHoldPollsRemaining = replayResultHoldFramesForTesting_;
-          lastFastPathCounters_ = compositor_->fastPathCountersForTesting();
-          lastCompositorRenderFrameStats_ = compositor_->lastRenderFrameStats();
+          lastFastPathCounters_ =
+              compositor_ != nullptr ? compositor_->fastPathCountersForTesting()
+                                     : svg::compositor::CompositorController::FastPathCounters{};
+          lastCompositorRenderFrameStats_ =
+              compositor_ != nullptr ? compositor_->lastRenderFrameStats()
+                                     : svg::compositor::CompositorController::RenderFrameStats{};
           if (compositorDiagnosticsEnabled_.load(std::memory_order_acquire)) {
             const auto diagnosticsStart = std::chrono::steady_clock::now();
-            const auto thumbnailMode =
-                activeDragRequest
-                    ? svg::compositor::CompositorController::SnapshotThumbnails::Omit
-                    : svg::compositor::CompositorController::SnapshotThumbnails::Include;
-            lastLayerInspectorRows_ = compositor_->snapshotLayerInspectorRows(thumbnailMode);
-            lastSegmentInspectorRows_ = compositor_->snapshotSegmentInspectorRows();
-            lastCompositeTiles_ = compositor_->snapshotCompositeTiles(thumbnailMode);
-            lastStateSnapshot_ = compositor_->snapshotState();
+            if (compositor_ != nullptr) {
+              const auto thumbnailMode =
+                  activeDragRequest
+                      ? svg::compositor::CompositorController::SnapshotThumbnails::Omit
+                      : svg::compositor::CompositorController::SnapshotThumbnails::Include;
+              lastLayerInspectorRows_ = compositor_->snapshotLayerInspectorRows(thumbnailMode);
+              lastSegmentInspectorRows_ = compositor_->snapshotSegmentInspectorRows();
+              lastCompositeTiles_ = compositor_->snapshotCompositeTiles(thumbnailMode);
+              lastStateSnapshot_ = compositor_->snapshotState();
+            } else {
+              // Composited rendering Off: clear the inspector surfaces so the
+              // debug panel shows the compositor as absent, not stale.
+              lastLayerInspectorRows_.clear();
+              lastSegmentInspectorRows_.clear();
+              lastCompositeTiles_.clear();
+              lastStateSnapshot_ = {};
+            }
             workerTiming.diagnosticsMs = elapsedSince(diagnosticsStart);
           }
           lastWorkerCompositorEntity_ = compositorEntity_;

--- a/donner/editor/AsyncRenderer.cc
+++ b/donner/editor/AsyncRenderer.cc
@@ -9,7 +9,6 @@
 
 #include "donner/base/MemoryAttribution.h"
 #include "donner/base/Utils.h"
-#include "donner/base/xml/components/TreeComponent.h"
 #include "donner/editor/OverlayRenderer.h"
 #include "donner/editor/TracyWrapper.h"
 #include "donner/svg/SVGDocument.h"
@@ -185,22 +184,6 @@ std::vector<Entity> DesiredCompositorEntities(const RenderRequest& request) {
 
 bool SameEntityList(const std::vector<Entity>& lhs, const std::vector<Entity>& rhs) {
   return lhs == rhs;
-}
-
-bool ContainsAllEntitiesOrOwningAncestors(Registry& registry,
-                                          const std::vector<Entity>& promotedEntities,
-                                          const std::vector<Entity>& desiredEntities) {
-  return std::ranges::all_of(desiredEntities, [&](Entity desiredEntity) {
-    Entity cursor = desiredEntity;
-    while (cursor != entt::null && registry.valid(cursor)) {
-      if (ContainsEntity(promotedEntities, cursor)) {
-        return true;
-      }
-      const auto* tree = registry.try_get<donner::components::TreeComponent>(cursor);
-      cursor = tree != nullptr ? tree->parent() : entt::null;
-    }
-    return false;
-  });
 }
 
 bool WaitForSampleThumbnailDelay(const svg::compositor::CancellationToken& cancellation,
@@ -1123,8 +1106,7 @@ void AsyncRenderer::workerLoop() {
     }
     const bool desiredPromotionIncomplete =
         !desiredEntities.empty() &&
-        !ContainsAllEntitiesOrOwningAncestors(requestDocument.registry(), compositorEntities_,
-                                              desiredEntities);
+        !compositor_->interactionLayersCover(compositorEntities_, desiredEntities);
 
     // The DOM is the sole source of truth for the dragged entity's
     // position - `SelectTool` mutates the `transform` attribute every
@@ -1415,8 +1397,8 @@ void AsyncRenderer::workerLoop() {
       workerTiming.renderFrameMs = elapsedSince(renderFrameStart);
     }
     if (renderCompleted && compositor_ != nullptr && !desiredEntities.empty()) {
-      desiredPromotionCoverageCompleteAfterRender = ContainsAllEntitiesOrOwningAncestors(
-          requestDocument.registry(), compositorEntities_, desiredEntities);
+      desiredPromotionCoverageCompleteAfterRender =
+          compositor_->interactionLayersCover(compositorEntities_, desiredEntities);
     }
 
     // A superseding request can arrive after the compositor's final internal cancellation point.

--- a/donner/editor/AsyncRenderer.h
+++ b/donner/editor/AsyncRenderer.h
@@ -51,6 +51,7 @@
 #include "donner/base/EcsRegistry.h"
 #include "donner/base/Transform.h"
 #include "donner/base/Vector2.h"
+#include "donner/editor/CompositedRenderingMode.h"
 #include "donner/editor/OverlayRenderer.h"
 #include "donner/editor/ViewportState.h"
 #include "donner/svg/SVGDocument.h"
@@ -620,6 +621,26 @@ public:
     return tightBoundedSegments_.load(std::memory_order_acquire);
   }
 
+  /// Select how the worker uses the compositor: full compositing, cached
+  /// layers for filters only, or no compositor at all (direct full-document
+  /// renders). See \ref CompositedRenderingMode. The change applies at the
+  /// start of the next worker iteration: entering `Off` destroys the live
+  /// `CompositorController`; leaving `Off` or changing between the other
+  /// modes reconstructs it with the matching `CompositorConfig`. Every mode
+  /// produces identical pixels.
+  ///
+  /// Same threading contract as \ref setTightBoundedSegmentsEnabled:
+  /// safe to call from the UI thread while a render is in flight.
+  void setCompositedRenderingMode(CompositedRenderingMode mode) {
+    compositedRenderingMode_.store(mode, std::memory_order_release);
+  }
+
+  /// Mirror of the current mode. UI reads this to render the correct radio
+  /// state in the View menu without racing the worker.
+  [[nodiscard]] CompositedRenderingMode compositedRenderingMode() const {
+    return compositedRenderingMode_.load(std::memory_order_acquire);
+  }
+
   /// Toggle the Geode geometry debug overlay
   /// (`RendererInterface::setDebugGeometryOverlay`) on the root document
   /// renderer. The change applies at the start of the next worker iteration.
@@ -974,6 +995,16 @@ private:
   /// Default-true matches `CompositorConfig::tightBoundedSegments`. See
   /// `setTightBoundedSegmentsEnabled`.
   std::atomic<bool> tightBoundedSegments_{true};
+
+  /// Composited rendering mode requested by the UI thread. See
+  /// `setCompositedRenderingMode`. Default `On` preserves the pre-setting
+  /// behavior: full compositing.
+  std::atomic<CompositedRenderingMode> compositedRenderingMode_{CompositedRenderingMode::On};
+
+  /// Worker-thread-only: the mode the live compositor (or its absence) was
+  /// built for. A mismatch against `compositedRenderingMode_` tears down or
+  /// reconstructs the compositor at the start of the iteration.
+  CompositedRenderingMode appliedCompositedRenderingMode_ = CompositedRenderingMode::On;
 
   /// Geode geometry debug overlay request from the UI thread. See
   /// `setGeometryDebugOverlayEnabled`. Default-off matches the

--- a/donner/editor/AsyncRenderer.h
+++ b/donner/editor/AsyncRenderer.h
@@ -345,8 +345,8 @@ struct RenderResult {
     /// * pixelsPerDocUnit` with size `bitmapDimsDoc *
     /// pixelsPerDocUnit`.
     std::vector<CompositedTile> tiles;
-    /// Active drag-target entity (for selection chrome routing). May
-    /// be `entt::null` if no entity is currently being dragged.
+    /// Primary editor-promoted entity represented by a movable layer tile. Null when Off or when
+    /// the requested selection must remain inside its owning compositor tiles.
     Entity entity = entt::null;
     /// Interaction phase that produced this composited preview.
     svg::compositor::InteractionHint interactionKind = svg::compositor::InteractionHint::Selection;

--- a/donner/editor/BUILD.bazel
+++ b/donner/editor/BUILD.bazel
@@ -507,6 +507,7 @@ donner_cc_library(
     srcs = ["AsyncRenderer.cc"],
     hdrs = ["AsyncRenderer.h"],
     deps = [
+        ":composited_rendering_mode",
         ":overlay_renderer",
         ":tracy_wrapper",
         ":viewport_state",
@@ -685,10 +686,16 @@ donner_cc_library(
     srcs = ["MenuBarPresenter.cc"],
     hdrs = ["MenuBarPresenter.h"],
     deps = [
+        ":composited_rendering_mode",
         ":editor_theme",
         ":imgui_headers",
         "@imgui",
     ],
+)
+
+donner_cc_library(
+    name = "composited_rendering_mode",
+    hdrs = ["CompositedRenderingMode.h"],
 )
 
 donner_cc_library(

--- a/donner/editor/CompositedRenderingMode.h
+++ b/donner/editor/CompositedRenderingMode.h
@@ -16,8 +16,8 @@ enum class CompositedRenderingMode : std::uint8_t {
   Off,
   /// Compositor runs, but only SVG filters (the expensive re-render case) get
   /// cached isolated layers. Opacity groups, blend modes, and masks render
-  /// inline, and selection/drag promotion, animation promotion, and complexity
-  /// bucketing are disabled.
+  /// inline. Editor-required selection/drag layers remain active; animation
+  /// promotion and complexity bucketing are disabled.
   FilterOnly,
   /// Full compositing: mandatory hints for all isolation signals plus
   /// selection/drag promotion, animation promotion, and complexity bucketing.

--- a/donner/editor/CompositedRenderingMode.h
+++ b/donner/editor/CompositedRenderingMode.h
@@ -1,0 +1,27 @@
+#pragma once
+/// @file
+
+#include <cstdint>
+
+namespace donner::editor {
+
+/// How the editor's background renderer uses the compositor, selected via the
+/// View menu's "Composited Rendering" submenu. Every mode produces identical
+/// pixels; the modes trade retained caching (memory, cache-management cost)
+/// against per-frame re-render cost.
+enum class CompositedRenderingMode : std::uint8_t {
+  /// No `CompositorController` is constructed. Every frame renders the full
+  /// document directly through `RendererDriver::draw`. The baseline for
+  /// measuring what compositing buys on a given document.
+  Off,
+  /// Compositor runs, but only SVG filters (the expensive re-render case) get
+  /// cached isolated layers. Opacity groups, blend modes, and masks render
+  /// inline, and selection/drag promotion, animation promotion, and complexity
+  /// bucketing are disabled.
+  FilterOnly,
+  /// Full compositing: mandatory hints for all isolation signals plus
+  /// selection/drag promotion, animation promotion, and complexity bucketing.
+  On,
+};
+
+}  // namespace donner::editor

--- a/donner/editor/CompositedRenderingMode.h
+++ b/donner/editor/CompositedRenderingMode.h
@@ -11,8 +11,8 @@ namespace donner::editor {
 /// against per-frame re-render cost.
 enum class CompositedRenderingMode : std::uint8_t {
   /// No `CompositorController` is constructed. Every frame renders the full
-  /// document directly through `RendererDriver::draw`. The baseline for
-  /// measuring what compositing buys on a given document.
+  /// document directly through `RendererDriver::drawInterruptibly`. The
+  /// baseline for measuring what compositing buys on a given document.
   Off,
   /// Compositor runs, but only SVG filters (the expensive re-render case) get
   /// cached isolated layers. Opacity groups, blend modes, and masks render

--- a/donner/editor/EditorShell.cc
+++ b/donner/editor/EditorShell.cc
@@ -2331,8 +2331,22 @@ void EditorShell::applyMenuActions(const MenuBarActions& menuActions) {
   const bool compositorTileOverlayBeforeMenu = compositorTileOverlay_;
   const PerfOverlayMode perfOverlayModeBeforeMenu = perfOverlayMode_;
   const bool geometryDebugOverlayBeforeMenu = geometryDebugOverlay_;
+  const CompositedRenderingMode compositedRenderingModeBeforeMenu = compositedRenderingMode_;
   ApplyViewMenuToggleActions(menuActions, &showCompositorDebugPanel_, &perfOverlayMode_,
-                             &geometryDebugOverlay_, &compositorTileOverlay_);
+                             &geometryDebugOverlay_, &compositorTileOverlay_,
+                             &compositedRenderingMode_);
+  if (compositedRenderingMode_ != compositedRenderingModeBeforeMenu) {
+    // Push the new mode to the worker and post a render; the worker tears
+    // down or reconstructs the compositor at the start of that iteration.
+    renderCoordinator_.asyncRenderer().setCompositedRenderingMode(compositedRenderingMode_);
+    // Reconstruction restarts compositor tile generations, so a refreshed
+    // tile can arrive carrying an id+generation the texture cache has already
+    // seen with different pixels. Drop uploaded textures the same way a
+    // document load does.
+    textures_.resetComposited();
+    renderCoordinator_.requestPresentationRefresh();
+    requestRenderAtEndOfFrame_ = true;
+  }
   if (geometryDebugOverlay_ != geometryDebugOverlayBeforeMenu) {
     // Push the new overlay state to the worker and post a render. Geometry
     // debug uses a flat full-document pass while enabled; disabling it resets
@@ -6583,6 +6597,7 @@ void EditorShell::renderMenuBarAndDialogs(bool compactUi) {
       .compositorTileOverlay = compositorTileOverlay_,
       .geometryDebugOverlay = geometryDebugOverlay_,
       .perfOverlayMode = perfOverlayMode_,
+      .compositedRenderingMode = compositedRenderingMode_,
       .panelLayoutLocked = dockLayoutLocked_,
   };
   MenuBarActions menuActions;

--- a/donner/editor/EditorShell.h
+++ b/donner/editor/EditorShell.h
@@ -783,6 +783,11 @@ private:
   /// Render-pane frame-timing/perf overlay mode. Off by default; set via the
   /// View menu's Performance Overlay submenu.
   PerfOverlayMode perfOverlayMode_ = PerfOverlayMode::Off;
+  /// How the render worker uses the compositor (full / filters only / not at
+  /// all). Full compositing by default; set via the View menu's Composited
+  /// Rendering submenu and applied to the render worker through
+  /// `AsyncRenderer::setCompositedRenderingMode`.
+  CompositedRenderingMode compositedRenderingMode_ = CompositedRenderingMode::On;
   /// Whether the Geode geometry debug overlay is enabled on the document
   /// renderer. It shows the dynamically-dilated post-vertex Slug quad
   /// triangles in one frame-final root-target pass. While enabled, the editor

--- a/donner/editor/MenuBarPresenter.cc
+++ b/donner/editor/MenuBarPresenter.cc
@@ -73,6 +73,18 @@ void ApplyMenuBarCommand(bool activated, MenuBarCommand command, const MenuBarSt
       actions->setPerfOverlayMode = true;
       actions->perfOverlayMode = PerfOverlayMode::FullGraph;
       return;
+    case MenuBarCommand::SetCompositedRenderingOff:
+      actions->setCompositedRenderingMode = true;
+      actions->compositedRenderingMode = CompositedRenderingMode::Off;
+      return;
+    case MenuBarCommand::SetCompositedRenderingFilterOnly:
+      actions->setCompositedRenderingMode = true;
+      actions->compositedRenderingMode = CompositedRenderingMode::FilterOnly;
+      return;
+    case MenuBarCommand::SetCompositedRenderingOn:
+      actions->setCompositedRenderingMode = true;
+      actions->compositedRenderingMode = CompositedRenderingMode::On;
+      return;
     case MenuBarCommand::ToggleLayoutLock: actions->toggleLayoutLock = true; return;
     case MenuBarCommand::ResetLayout: actions->resetLayout = true; return;
   }
@@ -80,7 +92,8 @@ void ApplyMenuBarCommand(bool activated, MenuBarCommand command, const MenuBarSt
 
 void ApplyViewMenuToggleActions(const MenuBarActions& actions, bool* showCompositorDebugPanel,
                                 PerfOverlayMode* perfOverlayMode, bool* geometryDebugOverlay,
-                                bool* compositorTileOverlay) {
+                                bool* compositorTileOverlay,
+                                CompositedRenderingMode* compositedRenderingMode) {
   if (actions.toggleCompositorDebugPanel && showCompositorDebugPanel != nullptr) {
     *showCompositorDebugPanel = !*showCompositorDebugPanel;
   }
@@ -92,6 +105,9 @@ void ApplyViewMenuToggleActions(const MenuBarActions& actions, bool* showComposi
   }
   if (actions.toggleCompositorTileOverlay && compositorTileOverlay != nullptr) {
     *compositorTileOverlay = !*compositorTileOverlay;
+  }
+  if (actions.setCompositedRenderingMode && compositedRenderingMode != nullptr) {
+    *compositedRenderingMode = actions.compositedRenderingMode;
   }
 }
 
@@ -221,6 +237,21 @@ MenuBarActions MenuBarPresenter::render(const MenuBarState& state, ImFont* boldM
                         MenuBarCommand::ToggleLayoutLock, state, &actions);
     ApplyMenuBarCommand(ImGui::MenuItem("Reset Layout"), MenuBarCommand::ResetLayout, state,
                         &actions);
+    if (ImGui::BeginMenu("Composited Rendering")) {
+      ApplyMenuBarCommand(ImGui::MenuItem("On", nullptr,
+                                          state.compositedRenderingMode ==
+                                              CompositedRenderingMode::On),
+                          MenuBarCommand::SetCompositedRenderingOn, state, &actions);
+      ApplyMenuBarCommand(ImGui::MenuItem("Filters Only", nullptr,
+                                          state.compositedRenderingMode ==
+                                              CompositedRenderingMode::FilterOnly),
+                          MenuBarCommand::SetCompositedRenderingFilterOnly, state, &actions);
+      ApplyMenuBarCommand(ImGui::MenuItem("Off", nullptr,
+                                          state.compositedRenderingMode ==
+                                              CompositedRenderingMode::Off),
+                          MenuBarCommand::SetCompositedRenderingOff, state, &actions);
+      ImGui::EndMenu();
+    }
     if (ImGui::BeginMenu("Performance Overlay")) {
       ApplyMenuBarCommand(
           ImGui::MenuItem("Off", nullptr, state.perfOverlayMode == PerfOverlayMode::Off),

--- a/donner/editor/MenuBarPresenter.h
+++ b/donner/editor/MenuBarPresenter.h
@@ -3,6 +3,8 @@
 
 #include <cstdint>
 
+#include "donner/editor/CompositedRenderingMode.h"
+
 struct ImFont;
 
 namespace donner::editor {
@@ -51,6 +53,9 @@ struct MenuBarState {
   /// Current render-pane performance overlay mode (drives the View-menu
   /// checkmarks). Off by default.
   PerfOverlayMode perfOverlayMode = PerfOverlayMode::Off;
+  /// Current composited rendering mode (drives the View-menu radio marks).
+  /// Full compositing by default.
+  CompositedRenderingMode compositedRenderingMode = CompositedRenderingMode::On;
   /// Whether the dockable panel layout is locked (drives the View-menu "Lock
   /// Panel Layout" checkmark). Locked by default.
   bool panelLayoutLocked = true;
@@ -101,6 +106,11 @@ struct MenuBarActions {
   /// Requested performance overlay mode; meaningful only while
   /// `setPerfOverlayMode` is true.
   PerfOverlayMode perfOverlayMode = PerfOverlayMode::Off;
+  /// Set when the user picks a composited rendering mode via the View menu.
+  bool setCompositedRenderingMode = false;
+  /// Requested composited rendering mode; meaningful only while
+  /// `setCompositedRenderingMode` is true.
+  CompositedRenderingMode compositedRenderingMode = CompositedRenderingMode::On;
   /// Set when the user toggles the panel-layout lock via the View menu.
   bool toggleLayoutLock = false;
   /// Set when the user picks "Reset Layout" to restore the default dock layout.
@@ -139,6 +149,9 @@ enum class MenuBarCommand {
   SetPerfOverlayOff,
   SetPerfOverlayFpsPill,
   SetPerfOverlayFullGraph,
+  SetCompositedRenderingOff,
+  SetCompositedRenderingFilterOnly,
+  SetCompositedRenderingOn,
   ToggleLayoutLock,
   ResetLayout,
 };
@@ -162,7 +175,8 @@ void ApplyMenuBarCommand(bool activated, MenuBarCommand command, const MenuBarSt
 void ApplyViewMenuToggleActions(const MenuBarActions& actions, bool* showCompositorDebugPanel,
                                 PerfOverlayMode* perfOverlayMode,
                                 bool* geometryDebugOverlay = nullptr,
-                                bool* compositorTileOverlay = nullptr);
+                                bool* compositorTileOverlay = nullptr,
+                                CompositedRenderingMode* compositedRenderingMode = nullptr);
 
 /// Renders the app's top menu bar and reports semantic actions back to the shell.
 class MenuBarPresenter {

--- a/donner/editor/PresentationRenderScheduler.cc
+++ b/donner/editor/PresentationRenderScheduler.cc
@@ -88,8 +88,8 @@ PresentationRenderScheduleDecision PresentationRenderScheduler::evaluate(
                                                      input.selectedEntity != entt::null &&
                                                      input.forceSelectedLayerRasterization;
   // A selected element needs a selection-hint render whenever the raster window changes. Otherwise
-  // a high-zoom pan/zoom regular render can publish a full-canvas fallback and evict the promoted
-  // drag-target tile just before the next drag starts.
+  // a high-zoom pan/zoom regular render can omit the promoted drag-target tile just before the next
+  // drag starts.
   const bool selectedViewportRenderNeedsPrewarm = input.selectedEntity != entt::null &&
                                                   !input.activeDragPreview.has_value() &&
                                                   (canvasSizeChanged || rasterViewportChanged);

--- a/donner/editor/tests/AsyncRenderer_tests.cc
+++ b/donner/editor/tests/AsyncRenderer_tests.cc
@@ -427,11 +427,17 @@ TEST(AsyncRendererTest, CompositedRenderingModesProduceIdenticalPixels) {
       <rect x="4" y="4" width="20" height="20" fill="red" filter="url(#blur)"/>
       <g opacity="0.5">
         <rect x="30" y="8" width="16" height="16" fill="green"/>
+        <rect x="34" y="12" width="10" height="10" fill="purple" filter="url(#blur)"/>
         <rect x="38" y="16" width="16" height="16" fill="blue"/>
       </g>
       <rect x="10" y="44" width="12" height="12" fill="black"/>
     </svg>
   )svg");
+  // The filter NESTED inside the opacity group, with in-group siblings before
+  // and after it, is the sharp case: FilterOnly must not extract it (the
+  // inline group's isolation would be split - trailing siblings re-enter at
+  // full alpha and the tile blit resets paint), so it renders inline and the
+  // pixels stay identical across all three modes.
   document.setCanvasSize(64, 64);
 
   svg::Renderer renderer;

--- a/donner/editor/tests/AsyncRenderer_tests.cc
+++ b/donner/editor/tests/AsyncRenderer_tests.cc
@@ -321,7 +321,8 @@ TEST(AsyncRendererTest, GeometryOverlayForcesFlatFrameThenRepromotesSelectionWhe
   ASSERT_GT(asyncRenderer.compositorState().activeHintsCount, 0u);
 
   asyncRenderer.setGeometryDebugOverlayEnabled(true);
-  ASSERT_TRUE(renderSelected(2).has_value());
+  const std::optional<RenderResult> firstDebugResult = renderSelected(2);
+  ASSERT_TRUE(firstDebugResult.has_value());
 
   if (!geometryOverlaySupported) {
     EXPECT_EQ(asyncRenderer.workerCompositorEntity(), entity);
@@ -330,6 +331,11 @@ TEST(AsyncRendererTest, GeometryOverlayForcesFlatFrameThenRepromotesSelectionWhe
     EXPECT_EQ(asyncRenderer.compositorResetCountForTesting(), 0u);
     return;
   }
+
+  ASSERT_TRUE(firstDebugResult->compositedPreview.has_value());
+  ASSERT_EQ(firstDebugResult->compositedPreview->tiles.size(), 1u);
+  EXPECT_EQ(firstDebugResult->compositedPreview->tiles.front().id, "geometry-debug-flat");
+  EXPECT_NE(firstDebugResult->compositedPreview->tiles.front().id, "full-canvas");
 
   const auto state = asyncRenderer.compositorState();
   EXPECT_TRUE(asyncRenderer.workerCompositorEntity() == entt::null);
@@ -340,7 +346,12 @@ TEST(AsyncRendererTest, GeometryOverlayForcesFlatFrameThenRepromotesSelectionWhe
   const std::uint64_t resetCountAfterEnable = asyncRenderer.compositorResetCountForTesting();
   EXPECT_EQ(resetCountAfterEnable, 1u);
 
-  ASSERT_TRUE(renderSelected(3).has_value());
+  const std::optional<RenderResult> consecutiveDebugResult = renderSelected(3);
+  ASSERT_TRUE(consecutiveDebugResult.has_value());
+  ASSERT_TRUE(consecutiveDebugResult->compositedPreview.has_value());
+  ASSERT_EQ(consecutiveDebugResult->compositedPreview->tiles.size(), 1u);
+  EXPECT_EQ(consecutiveDebugResult->compositedPreview->tiles.front().id, "geometry-debug-flat");
+  EXPECT_NE(consecutiveDebugResult->compositedPreview->tiles.front().id, "full-canvas");
   const auto consecutiveDebugState = asyncRenderer.compositorState();
   EXPECT_TRUE(asyncRenderer.workerCompositorEntity() == entt::null);
   EXPECT_EQ(consecutiveDebugState.activeHintsCount, 0u);
@@ -400,10 +411,8 @@ TEST(AsyncRendererGpuWaitFailureTest, RepeatedIdenticalLossBumpsTheGenerationOnc
 
 namespace {
 
-/// Returns the presented full-canvas pixels for a render result, whichever
-/// presentation path produced them: the CPU snapshot when the backend honors
-/// `captureCpuSnapshot`, otherwise the single full-canvas composited tile's
-/// texture snapshot (Geode presentation ignores the CPU snapshot request).
+/// Returns materialized full-frame pixels for a render result: the explicit CPU snapshot when
+/// available, otherwise the payload of a single compositor tile that covers the frame.
 svg::RendererBitmap FullCanvasPixels(const RenderResult& result) {
   if (!result.bitmap.empty()) {
     return result.bitmap;
@@ -412,6 +421,24 @@ svg::RendererBitmap FullCanvasPixels(const RenderResult& result) {
     return MaterializeTileBitmap(result.compositedPreview->tiles.front());
   }
   return {};
+}
+
+bool ContainsFullCanvasTile(const RenderResult& result) {
+  return result.compositedPreview.has_value() &&
+         std::ranges::any_of(
+             result.compositedPreview->tiles,
+             [](const RenderResult::CompositedTile& tile) { return tile.id == "full-canvas"; });
+}
+
+const RenderResult::CompositedTile* FindLayerTile(const RenderResult& result, Entity entity) {
+  if (!result.compositedPreview.has_value()) {
+    return nullptr;
+  }
+  const auto it = std::ranges::find_if(
+      result.compositedPreview->tiles, [entity](const RenderResult::CompositedTile& tile) {
+        return tile.kind == RenderResult::CompositedTile::Kind::Layer && tile.layerEntity == entity;
+      });
+  return it == result.compositedPreview->tiles.end() ? nullptr : &*it;
 }
 
 }  // namespace
@@ -443,25 +470,29 @@ TEST(AsyncRendererTest, CompositedRenderingModesProduceIdenticalPixels) {
   svg::Renderer renderer;
   AsyncRenderer asyncRenderer;
   std::uint64_t version = 0;
-  const auto renderAndCapture = [&]() -> svg::RendererBitmap {
+  const auto renderAndCapture = [&]() -> std::optional<RenderResult> {
     RenderRequest request(renderer, document);
     request.version = ++version;
     request.documentGeneration = 1;
     request.captureCpuSnapshot = true;
     asyncRenderer.requestRender(request);
-    const std::optional<RenderResult> result = WaitForRenderResult(asyncRenderer);
-    if (!result.has_value()) {
-      return {};
-    }
-    return FullCanvasPixels(*result);
+    return WaitForRenderResult(asyncRenderer);
   };
 
-  const svg::RendererBitmap onPixels = renderAndCapture();
+  const std::optional<RenderResult> onResult = renderAndCapture();
+  ASSERT_TRUE(onResult.has_value());
+  ASSERT_TRUE(onResult->compositedPreview.has_value());
+  EXPECT_FALSE(ContainsFullCanvasTile(*onResult));
+  const svg::RendererBitmap onPixels = FullCanvasPixels(*onResult);
   ASSERT_FALSE(onPixels.empty());
   EXPECT_EQ(asyncRenderer.compositorReconstructCountForTesting(), 1u);
 
   asyncRenderer.setCompositedRenderingMode(CompositedRenderingMode::FilterOnly);
-  const svg::RendererBitmap filterOnlyPixels = renderAndCapture();
+  const std::optional<RenderResult> filterOnlyResult = renderAndCapture();
+  ASSERT_TRUE(filterOnlyResult.has_value());
+  ASSERT_TRUE(filterOnlyResult->compositedPreview.has_value());
+  EXPECT_FALSE(ContainsFullCanvasTile(*filterOnlyResult));
+  const svg::RendererBitmap filterOnlyPixels = FullCanvasPixels(*filterOnlyResult);
   ASSERT_FALSE(filterOnlyPixels.empty());
   EXPECT_EQ(asyncRenderer.compositorReconstructCountForTesting(), 2u)
       << "A mode change between composited modes must reconstruct the controller";
@@ -470,7 +501,10 @@ TEST(AsyncRendererTest, CompositedRenderingModesProduceIdenticalPixels) {
       << "FilterOnly must render pixel-identically to full compositing";
 
   asyncRenderer.setCompositedRenderingMode(CompositedRenderingMode::Off);
-  const svg::RendererBitmap offPixels = renderAndCapture();
+  const std::optional<RenderResult> offResult = renderAndCapture();
+  ASSERT_TRUE(offResult.has_value());
+  EXPECT_TRUE(ContainsFullCanvasTile(*offResult));
+  const svg::RendererBitmap offPixels = FullCanvasPixels(*offResult);
   ASSERT_FALSE(offPixels.empty());
   const auto offState = asyncRenderer.compositorState();
   EXPECT_EQ(offState.activeHintsCount, 0u);
@@ -480,7 +514,11 @@ TEST(AsyncRendererTest, CompositedRenderingModesProduceIdenticalPixels) {
       << "The direct (no compositor) path must render pixel-identically to full compositing";
 
   asyncRenderer.setCompositedRenderingMode(CompositedRenderingMode::On);
-  const svg::RendererBitmap restoredPixels = renderAndCapture();
+  const std::optional<RenderResult> restoredResult = renderAndCapture();
+  ASSERT_TRUE(restoredResult.has_value());
+  ASSERT_TRUE(restoredResult->compositedPreview.has_value());
+  EXPECT_FALSE(ContainsFullCanvasTile(*restoredResult));
+  const svg::RendererBitmap restoredPixels = FullCanvasPixels(*restoredResult);
   ASSERT_FALSE(restoredPixels.empty());
   EXPECT_EQ(asyncRenderer.compositorReconstructCountForTesting(), 3u)
       << "Leaving Off must reconstruct the controller";
@@ -489,13 +527,14 @@ TEST(AsyncRendererTest, CompositedRenderingModesProduceIdenticalPixels) {
       << "Returning to full compositing must restore the original output";
 }
 
-TEST(AsyncRendererTest, FilterOnlyModeRestrictsHintsAndDisablesSelectionPromotion) {
+TEST(AsyncRendererTest, FilterOnlyRestrictsMandatoryHintsButKeepsSelectionLayer) {
   svg::SVGDocument document = svg::instantiateSubtree(R"svg(
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
       <defs>
         <filter id="blur"><feGaussianBlur stdDeviation="1.5"/></filter>
       </defs>
-      <rect x="4" y="4" width="20" height="20" fill="red" filter="url(#blur)"/>
+      <rect id="filtered" x="4" y="4" width="20" height="20" fill="red"
+            filter="url(#blur)"/>
       <g opacity="0.5">
         <rect x="30" y="8" width="16" height="16" fill="green"/>
         <rect x="38" y="16" width="16" height="16" fill="blue"/>
@@ -507,6 +546,9 @@ TEST(AsyncRendererTest, FilterOnlyModeRestrictsHintsAndDisablesSelectionPromotio
   auto target = document.querySelector("#target");
   ASSERT_TRUE(target.has_value());
   const Entity entity = target->unsafeEntityHandle().entity();
+  auto filtered = document.querySelector("#filtered");
+  ASSERT_TRUE(filtered.has_value());
+  const Entity filteredEntity = filtered->unsafeEntityHandle().entity();
 
   svg::Renderer renderer;
   AsyncRenderer asyncRenderer;
@@ -530,15 +572,23 @@ TEST(AsyncRendererTest, FilterOnlyModeRestrictsHintsAndDisablesSelectionPromotio
       << "Full compositing promotes at least the filter subtree and the selection";
 
   asyncRenderer.setCompositedRenderingMode(CompositedRenderingMode::FilterOnly);
-  ASSERT_TRUE(renderSelected().has_value());
-  EXPECT_TRUE(asyncRenderer.workerCompositorEntity() == entt::null)
-      << "FilterOnly must not promote the selection";
+  const std::optional<RenderResult> filterOnlyResult = renderSelected();
+  ASSERT_TRUE(filterOnlyResult.has_value());
+  EXPECT_EQ(asyncRenderer.workerCompositorEntity(), entity)
+      << "FilterOnly must preserve the editor's structural selection layer";
   const auto filterOnlyState = asyncRenderer.compositorState();
-  EXPECT_EQ(filterOnlyState.activeHintsCount, 0u)
-      << "FilterOnly publishes no editor promotion hints";
-  EXPECT_EQ(filterOnlyState.layerCount, 1u)
-      << "FilterOnly keeps exactly the filter subtree composited (no opacity layer, no selection "
-         "layer, no complexity buckets)";
+  EXPECT_EQ(filterOnlyState.activeHintsCount, 1u)
+      << "FilterOnly keeps the selected entity explicitly promoted";
+  EXPECT_EQ(filterOnlyState.layerCount, 2u)
+      << "FilterOnly keeps the filter subtree and selection separate, without opacity or "
+         "complexity-bucket layers";
+  ASSERT_TRUE(filterOnlyResult->compositedPreview.has_value());
+  EXPECT_FALSE(ContainsFullCanvasTile(*filterOnlyResult));
+  EXPECT_NE(FindLayerTile(*filterOnlyResult, filteredEntity), nullptr)
+      << "FilterOnly must publish the isolated filter layer, not hide it behind a full-canvas "
+         "presentation";
+  EXPECT_NE(FindLayerTile(*filterOnlyResult, entity), nullptr)
+      << "FilterOnly must publish the selected entity as its own editor layer";
 
   asyncRenderer.setCompositedRenderingMode(CompositedRenderingMode::Off);
   ASSERT_TRUE(renderSelected().has_value());
@@ -546,6 +596,266 @@ TEST(AsyncRendererTest, FilterOnlyModeRestrictsHintsAndDisablesSelectionPromotio
   const auto offState = asyncRenderer.compositorState();
   EXPECT_EQ(offState.activeHintsCount, 0u);
   EXPECT_EQ(offState.layerCount, 0u);
+}
+
+TEST(AsyncRendererE2ETest, FilterOnlyPublishesSplashBlurGroupsAsSeparateLayers) {
+  std::ifstream splashStream("donner_splash.svg");
+  if (!splashStream.is_open()) {
+    GTEST_SKIP() << "donner_splash.svg not found in runfiles";
+  }
+  std::ostringstream splashBuffer;
+  splashBuffer << splashStream.rdbuf();
+
+  svg::SVGDocument document = svg::instantiateSubtree(splashBuffer.str());
+  document.setCanvasSize(892, 512);
+  const std::array<std::string_view, 3> filterSelectors = {
+      "#Lightning_glow_dark",
+      "#Lightning_glow_bright",
+      "#Big_lightning_glow",
+  };
+  std::array<Entity, 3> filterEntities;
+  for (std::size_t i = 0; i < filterSelectors.size(); ++i) {
+    auto element = document.querySelector(filterSelectors[i]);
+    ASSERT_TRUE(element.has_value()) << filterSelectors[i];
+    filterEntities[i] = element->unsafeEntityHandle().entity();
+  }
+
+  svg::Renderer renderer;
+  AsyncRenderer asyncRenderer;
+  asyncRenderer.setCompositedRenderingMode(CompositedRenderingMode::FilterOnly);
+
+  RenderRequest request(renderer, document);
+  request.version = 1;
+  request.documentGeneration = 1;
+  asyncRenderer.requestRender(request);
+  const std::optional<RenderResult> result = WaitForRenderResult(asyncRenderer);
+
+  ASSERT_TRUE(result.has_value());
+  ASSERT_TRUE(result->compositedPreview.has_value());
+  EXPECT_FALSE(ContainsFullCanvasTile(*result));
+  for (std::size_t i = 0; i < filterSelectors.size(); ++i) {
+    EXPECT_NE(FindLayerTile(*result, filterEntities[i]), nullptr)
+        << filterSelectors[i] << " must remain an isolated presented layer in FilterOnly mode";
+  }
+}
+
+TEST(AsyncRendererTest, FilterOnlyPublishesNewFilterLayerOnFirstFilteredFrame) {
+  svg::SVGDocument document = svg::instantiateSubtree(R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+      <defs><filter id="blur"><feGaussianBlur stdDeviation="2"/></filter></defs>
+      <rect id="target" x="8" y="8" width="24" height="24" fill="red"/>
+    </svg>
+  )svg");
+  document.setCanvasSize(64, 64);
+  auto target = document.querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  const Entity targetEntity = target->unsafeEntityHandle().entity();
+
+  svg::Renderer renderer;
+  AsyncRenderer asyncRenderer;
+  asyncRenderer.setCompositedRenderingMode(CompositedRenderingMode::FilterOnly);
+  const auto render = [&](std::uint64_t version) {
+    RenderRequest request(renderer, document);
+    request.version = version;
+    request.documentGeneration = 1;
+    asyncRenderer.requestRender(request);
+    return WaitForRenderResult(asyncRenderer);
+  };
+
+  const std::optional<RenderResult> before = render(1);
+  ASSERT_TRUE(before.has_value());
+  EXPECT_FALSE(ContainsFullCanvasTile(*before));
+  EXPECT_EQ(FindLayerTile(*before, targetEntity), nullptr);
+
+  AsGraphicsElement(*target).setStyle("filter:url(#blur)");
+  const std::optional<RenderResult> after = render(2);
+  ASSERT_TRUE(after.has_value());
+  EXPECT_FALSE(ContainsFullCanvasTile(*after));
+  EXPECT_NE(FindLayerTile(*after, targetEntity), nullptr)
+      << "The first frame after adding a filter must reconcile against the prepared render tree "
+         "and publish the new filter layer";
+}
+
+TEST(AsyncRendererTest, FilterOnlyColdSelectionDoesNotSplitInlineOpacityAncestor) {
+  svg::SVGDocument document = svg::instantiateSubtree(R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+      <g opacity="0.5">
+        <rect x="4" y="4" width="20" height="20" fill="red"/>
+        <rect id="target" x="12" y="12" width="20" height="20" fill="green"/>
+        <rect x="20" y="20" width="20" height="20" fill="blue"/>
+      </g>
+    </svg>
+  )svg");
+  document.setCanvasSize(64, 64);
+  auto target = document.querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  const Entity targetEntity = target->unsafeEntityHandle().entity();
+
+  svg::Renderer renderer;
+  AsyncRenderer asyncRenderer;
+  const auto renderAndCapture = [&](std::uint64_t version) {
+    RenderRequest request(renderer, document);
+    request.version = version;
+    request.documentGeneration = 1;
+    request.selectedEntity = targetEntity;
+    request.captureCpuSnapshot = true;
+    asyncRenderer.requestRender(request);
+    return WaitForRenderResult(asyncRenderer);
+  };
+
+  asyncRenderer.setCompositedRenderingMode(CompositedRenderingMode::FilterOnly);
+  const std::optional<RenderResult> filterOnly = renderAndCapture(1);
+  ASSERT_TRUE(filterOnly.has_value());
+  EXPECT_FALSE(ContainsFullCanvasTile(*filterOnly));
+  EXPECT_EQ(FindLayerTile(*filterOnly, targetEntity), nullptr)
+      << "A selected descendant cannot be extracted from an opacity group that FilterOnly keeps "
+         "inline";
+  const svg::RendererBitmap filterOnlyPixels = FullCanvasPixels(*filterOnly);
+  ASSERT_FALSE(filterOnlyPixels.empty());
+
+  asyncRenderer.setCompositedRenderingMode(CompositedRenderingMode::Off);
+  const std::optional<RenderResult> off = renderAndCapture(2);
+  ASSERT_TRUE(off.has_value());
+  const svg::RendererBitmap offPixels = FullCanvasPixels(*off);
+  ASSERT_EQ(filterOnlyPixels.dimensions, offPixels.dimensions);
+  EXPECT_EQ(filterOnlyPixels.pixels, offPixels.pixels)
+      << "Refusing the unsafe selection split must preserve the inline opacity group's pixels";
+}
+
+TEST(AsyncRendererTest, FilterOnlyDropsSelectionLayerWhenAncestorBecomesInlineOpacityGroup) {
+  svg::SVGDocument document = svg::instantiateSubtree(R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+      <g id="group">
+        <rect x="4" y="4" width="20" height="20" fill="red"/>
+        <rect id="target" x="12" y="12" width="20" height="20" fill="green"/>
+        <rect x="20" y="20" width="20" height="20" fill="blue"/>
+      </g>
+    </svg>
+  )svg");
+  document.setCanvasSize(64, 64);
+  auto group = document.querySelector("#group");
+  auto target = document.querySelector("#target");
+  ASSERT_TRUE(group.has_value());
+  ASSERT_TRUE(target.has_value());
+  const Entity targetEntity = target->unsafeEntityHandle().entity();
+
+  svg::Renderer renderer;
+  AsyncRenderer asyncRenderer;
+  asyncRenderer.setCompositedRenderingMode(CompositedRenderingMode::FilterOnly);
+  const auto renderSelected = [&](std::uint64_t version) {
+    RenderRequest request(renderer, document);
+    request.version = version;
+    request.documentGeneration = 1;
+    request.selectedEntity = targetEntity;
+    asyncRenderer.requestRender(request);
+    return WaitForRenderResult(asyncRenderer);
+  };
+
+  const std::optional<RenderResult> before = renderSelected(1);
+  ASSERT_TRUE(before.has_value());
+  EXPECT_NE(FindLayerTile(*before, targetEntity), nullptr);
+
+  AsGraphicsElement(*group).setStyle("opacity:0.5");
+  const std::optional<RenderResult> after = renderSelected(2);
+  ASSERT_TRUE(after.has_value());
+  EXPECT_FALSE(ContainsFullCanvasTile(*after));
+  EXPECT_EQ(FindLayerTile(*after, targetEntity), nullptr)
+      << "The first prepared frame after adding ancestor opacity must fold the selection back "
+         "into that inline compositing context";
+  EXPECT_TRUE(asyncRenderer.workerCompositorEntity() == entt::null)
+      << "Worker promotion bookkeeping must follow compositor safety demotion";
+
+  AsGraphicsElement(*group).setStyle("");
+  const std::optional<RenderResult> restored = renderSelected(3);
+  ASSERT_TRUE(restored.has_value());
+  EXPECT_NE(FindLayerTile(*restored, targetEntity), nullptr)
+      << "Removing the inline ancestor context must restore the still-selected entity layer";
+  EXPECT_EQ(asyncRenderer.workerCompositorEntity(), targetEntity);
+}
+
+TEST(AsyncRendererTest, FilterOnlyDropsSelectedParentWhenChildBecomesFilterLayer) {
+  svg::SVGDocument document = svg::instantiateSubtree(R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+      <defs><filter id="blur"><feGaussianBlur stdDeviation="2"/></filter></defs>
+      <g id="target">
+        <rect x="4" y="4" width="20" height="20" fill="red"/>
+        <rect id="child" x="20" y="20" width="20" height="20" fill="blue"/>
+      </g>
+    </svg>
+  )svg");
+  document.setCanvasSize(64, 64);
+  auto target = document.querySelector("#target");
+  auto child = document.querySelector("#child");
+  ASSERT_TRUE(target.has_value());
+  ASSERT_TRUE(child.has_value());
+  const Entity targetEntity = target->unsafeEntityHandle().entity();
+  const Entity childEntity = child->unsafeEntityHandle().entity();
+
+  svg::Renderer renderer;
+  AsyncRenderer asyncRenderer;
+  asyncRenderer.setCompositedRenderingMode(CompositedRenderingMode::FilterOnly);
+  const auto renderSelected = [&](std::uint64_t version) {
+    RenderRequest request(renderer, document);
+    request.version = version;
+    request.documentGeneration = 1;
+    request.selectedEntity = targetEntity;
+    asyncRenderer.requestRender(request);
+    return WaitForRenderResult(asyncRenderer);
+  };
+
+  const std::optional<RenderResult> before = renderSelected(1);
+  ASSERT_TRUE(before.has_value());
+  EXPECT_NE(FindLayerTile(*before, targetEntity), nullptr);
+
+  AsGraphicsElement(*child).setStyle("filter:url(#blur)");
+  const std::optional<RenderResult> after = renderSelected(2);
+  ASSERT_TRUE(after.has_value());
+  EXPECT_FALSE(ContainsFullCanvasTile(*after));
+  EXPECT_EQ(FindLayerTile(*after, targetEntity), nullptr)
+      << "A selected parent must not overlap a newly mandatory descendant layer";
+  EXPECT_NE(FindLayerTile(*after, childEntity), nullptr)
+      << "The new filter descendant must own its isolated layer on the first changed frame";
+  EXPECT_TRUE(asyncRenderer.workerCompositorEntity() == entt::null);
+}
+
+TEST(AsyncRendererTest, OnDropsSelectionLayerWhenAncestorBecomesCompositingGroup) {
+  svg::SVGDocument document = svg::instantiateSubtree(R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+      <g id="group">
+        <rect x="4" y="4" width="20" height="20" fill="red"/>
+        <rect id="target" x="20" y="20" width="20" height="20" fill="blue"/>
+      </g>
+    </svg>
+  )svg");
+  document.setCanvasSize(64, 64);
+  auto group = document.querySelector("#group");
+  auto target = document.querySelector("#target");
+  ASSERT_TRUE(group.has_value());
+  ASSERT_TRUE(target.has_value());
+  const Entity targetEntity = target->unsafeEntityHandle().entity();
+
+  svg::Renderer renderer;
+  AsyncRenderer asyncRenderer;
+  const auto renderSelected = [&](std::uint64_t version) {
+    RenderRequest request(renderer, document);
+    request.version = version;
+    request.documentGeneration = 1;
+    request.selectedEntity = targetEntity;
+    asyncRenderer.requestRender(request);
+    return WaitForRenderResult(asyncRenderer);
+  };
+
+  const std::optional<RenderResult> before = renderSelected(1);
+  ASSERT_TRUE(before.has_value());
+  EXPECT_NE(FindLayerTile(*before, targetEntity), nullptr);
+
+  AsGraphicsElement(*group).setStyle("isolation:isolate");
+  const std::optional<RenderResult> after = renderSelected(2);
+  ASSERT_TRUE(after.has_value());
+  EXPECT_FALSE(ContainsFullCanvasTile(*after));
+  EXPECT_EQ(FindLayerTile(*after, targetEntity), nullptr)
+      << "On must not keep an interaction layer extracted from a newly isolated ancestor";
+  EXPECT_TRUE(asyncRenderer.workerCompositorEntity() == entt::null);
 }
 
 TEST(AsyncRendererTest, DeferredStartQueuesWorkAndStartsExactlyOnce) {
@@ -637,12 +947,12 @@ TEST(AsyncRendererTest, CancellingDeferredCompositorWarmupCannotLoseDocumentWait
          "busy immediately before the worker released the gate.";
 }
 
-TEST(AsyncRendererTest, FirstDocumentResultPublishesBeforeRetainedCacheWarmup) {
+TEST(AsyncRendererTest, FirstDocumentResultWarmsLayerTilesBeforePublishing) {
   svg::SVGDocument document = svg::instantiateSubtree(R"svg(
     <defs>
       <filter id="f"><feGaussianBlur stdDeviation="2"/></filter>
     </defs>
-    <g filter="url(#f)">
+    <g id="filtered" filter="url(#f)">
       <rect x="1" y="1" width="12" height="12" fill="blue" />
     </g>
   )svg");
@@ -654,13 +964,18 @@ TEST(AsyncRendererTest, FirstDocumentResultPublishesBeforeRetainedCacheWarmup) {
   request.version = 1;
   request.documentGeneration = 1;
   asyncRenderer.requestRender(request);
-  ASSERT_TRUE(WaitForRenderResult(asyncRenderer).has_value());
+  const std::optional<RenderResult> result = WaitForRenderResult(asyncRenderer);
+  ASSERT_TRUE(result.has_value());
 
   const auto stats = asyncRenderer.compositorRenderFrameStats();
   EXPECT_GT(stats.firstFrameDrawMs, 0.0);
-  EXPECT_EQ(stats.firstFrameWarmupMs, 0.0)
-      << "The accepted result must describe the already-correct main draw, not later speculative "
-         "cache preparation.";
+  EXPECT_GT(stats.firstFrameWarmupMs, 0.0)
+      << "The first accepted non-Off result must finish its compositor tile warmup";
+  EXPECT_FALSE(asyncRenderer.compositorState().firstFrameWarmupPending);
+  EXPECT_FALSE(ContainsFullCanvasTile(*result));
+  auto filtered = document.querySelector("#filtered");
+  ASSERT_TRUE(filtered.has_value());
+  EXPECT_NE(FindLayerTile(*result, filtered->unsafeEntityHandle().entity()), nullptr);
 }
 
 TEST(AsyncRendererTest, MultiSelectActiveDragMarksEverySelectedLayerAsDragTarget) {
@@ -709,6 +1024,100 @@ TEST(AsyncRendererTest, MultiSelectActiveDragMarksEverySelectedLayerAsDragTarget
   };
   EXPECT_NE(dragTileFor(r1Entity), result->compositedPreview->tiles.end());
   EXPECT_NE(dragTileFor(r2Entity), result->compositedPreview->tiles.end());
+}
+
+TEST(AsyncRendererTest, NestedMultiSelectionNeverPublishesOverlappingLayers) {
+  constexpr std::string_view kNestedSelectionSvg = R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+      <rect x="0" y="0" width="64" height="64" fill="white"/>
+      <g id="parent">
+        <rect id="child" x="12" y="12" width="24" height="24" fill="red"/>
+      </g>
+    </svg>
+  )svg";
+  svg::SVGDocument document = svg::instantiateSubtree(std::string(kNestedSelectionSvg));
+  document.setCanvasSize(64, 64);
+  auto parent = document.querySelector("#parent");
+  auto child = document.querySelector("#child");
+  ASSERT_TRUE(parent.has_value());
+  ASSERT_TRUE(child.has_value());
+  const Entity parentEntity = parent->unsafeEntityHandle().entity();
+  const Entity childEntity = child->unsafeEntityHandle().entity();
+
+  svg::Renderer renderer;
+  AsyncRenderer asyncRenderer;
+  RenderRequest request(renderer, document);
+  request.version = 1;
+  request.documentGeneration = 1;
+  request.captureCpuSnapshot = true;
+  request.selectedEntity = parentEntity;
+  request.dragPreview = RenderRequest::DragPreview{
+      .entity = parentEntity,
+      .extraEntities = {childEntity},
+      .interactionKind = svg::compositor::InteractionHint::ActiveDrag,
+  };
+  asyncRenderer.requestRender(request);
+  const std::optional<RenderResult> layered = WaitForRenderResult(asyncRenderer);
+
+  ASSERT_TRUE(layered.has_value());
+  ASSERT_TRUE(layered->compositedPreview.has_value());
+  EXPECT_FALSE(ContainsFullCanvasTile(*layered));
+  EXPECT_NE(FindLayerTile(*layered, parentEntity), nullptr);
+  EXPECT_EQ(FindLayerTile(*layered, childEntity), nullptr)
+      << "A nested child selection must stay inside its already-promoted parent tile";
+  EXPECT_EQ(layered->compositedPreview->entity, parentEntity);
+
+  svg::SVGDocument reversedDocument = svg::instantiateSubtree(std::string(kNestedSelectionSvg));
+  reversedDocument.setCanvasSize(64, 64);
+  auto reversedParent = reversedDocument.querySelector("#parent");
+  auto reversedChild = reversedDocument.querySelector("#child");
+  ASSERT_TRUE(reversedParent.has_value());
+  ASSERT_TRUE(reversedChild.has_value());
+  const Entity reversedParentEntity = reversedParent->unsafeEntityHandle().entity();
+  const Entity reversedChildEntity = reversedChild->unsafeEntityHandle().entity();
+  svg::Renderer reversedRenderer;
+  AsyncRenderer reversedAsyncRenderer;
+  RenderRequest reversedRequest(reversedRenderer, reversedDocument);
+  reversedRequest.version = 1;
+  reversedRequest.documentGeneration = 1;
+  reversedRequest.captureCpuSnapshot = true;
+  reversedRequest.selectedEntity = reversedChildEntity;
+  reversedRequest.dragPreview = RenderRequest::DragPreview{
+      .entity = reversedChildEntity,
+      .extraEntities = {reversedParentEntity},
+      .interactionKind = svg::compositor::InteractionHint::ActiveDrag,
+  };
+  reversedAsyncRenderer.requestRender(reversedRequest);
+  const std::optional<RenderResult> reversed = WaitForRenderResult(reversedAsyncRenderer);
+  ASSERT_TRUE(reversed.has_value());
+  ASSERT_TRUE(reversed->compositedPreview.has_value());
+  EXPECT_NE(FindLayerTile(*reversed, reversedChildEntity), nullptr);
+  EXPECT_EQ(FindLayerTile(*reversed, reversedParentEntity), nullptr);
+  EXPECT_TRUE(reversed->compositedPreview->entity == entt::null)
+      << "A partially promoted nested selection must require rendered drag frames";
+
+  svg::SVGDocument referenceDocument = svg::instantiateSubtree(std::string(kNestedSelectionSvg));
+  referenceDocument.setCanvasSize(64, 64);
+  svg::Renderer referenceRenderer;
+  AsyncRenderer directRenderer;
+  directRenderer.setCompositedRenderingMode(CompositedRenderingMode::Off);
+  RenderRequest referenceRequest(referenceRenderer, referenceDocument);
+  referenceRequest.version = 1;
+  referenceRequest.documentGeneration = 1;
+  referenceRequest.captureCpuSnapshot = true;
+  directRenderer.requestRender(referenceRequest);
+  const std::optional<RenderResult> reference = WaitForRenderResult(directRenderer);
+  ASSERT_TRUE(reference.has_value());
+
+  const svg::RendererBitmap layeredPixels = FullCanvasPixels(*layered);
+  const svg::RendererBitmap reversedPixels = FullCanvasPixels(*reversed);
+  const svg::RendererBitmap referencePixels = FullCanvasPixels(*reference);
+  ASSERT_EQ(layeredPixels.dimensions, referencePixels.dimensions);
+  EXPECT_EQ(layeredPixels.pixels, referencePixels.pixels)
+      << "Nested multi-selection must not double-render the child's pixels";
+  ASSERT_EQ(reversedPixels.dimensions, referencePixels.dimensions);
+  EXPECT_EQ(reversedPixels.pixels, referencePixels.pixels)
+      << "Reversing nested selection order must not change pixels";
 }
 
 TEST(AsyncRendererE2ETest, UnbundledDonnerDDragMarksEveryComponentAsDragTarget) {
@@ -774,7 +1183,7 @@ TEST(AsyncRendererE2ETest, UnbundledDonnerDDragMarksEveryComponentAsDragTarget) 
   EXPECT_NE(dragTileFor(secondEntity), result->compositedPreview->tiles.end());
 }
 
-TEST(AsyncRendererTest, FullCanvasFallbackCarriesBoundedRasterViewportGeometry) {
+TEST(AsyncRendererTest, OffModeFullCanvasCarriesBoundedRasterViewportGeometry) {
   svg::SVGDocument document = svg::instantiateSubtree(R"svg(
     <rect x="150" y="250" width="20" height="20" fill="red" />
   )svg");
@@ -783,6 +1192,7 @@ TEST(AsyncRendererTest, FullCanvasFallbackCarriesBoundedRasterViewportGeometry) 
 
   svg::Renderer renderer;
   AsyncRenderer asyncRenderer;
+  asyncRenderer.setCompositedRenderingMode(CompositedRenderingMode::Off);
 
   RenderRequest request(renderer, document);
   request.version = 1;
@@ -807,7 +1217,7 @@ TEST(AsyncRendererTest, FullCanvasFallbackCarriesBoundedRasterViewportGeometry) 
   EXPECT_EQ(tile.bitmapDimsDoc, Vector2d(100.0, 80.0));
 }
 
-TEST(AsyncRendererTest, FreshFullCanvasFallbacksHaveDistinctTextureIdentity) {
+TEST(AsyncRendererTest, FreshOffModeFullCanvasFramesHaveDistinctTextureIdentity) {
   svg::SVGDocument document = svg::instantiateSubtree(R"svg(
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100">
       <rect x="0" y="0" width="100" height="100" fill="red"/>
@@ -818,6 +1228,7 @@ TEST(AsyncRendererTest, FreshFullCanvasFallbacksHaveDistinctTextureIdentity) {
 
   svg::Renderer renderer;
   AsyncRenderer asyncRenderer;
+  asyncRenderer.setCompositedRenderingMode(CompositedRenderingMode::Off);
   RenderRequest request(renderer, document);
   request.version = 7;
   request.documentGeneration = 1;
@@ -871,10 +1282,11 @@ TEST(AsyncRendererTest, FreshFullCanvasFallbacksHaveDistinctTextureIdentity) {
               Rgba(::testing::Lt(80), ::testing::Lt(80), Gt(200), Gt(200)));
 }
 
-TEST(AsyncRendererTest, ProductionRendererCachesStaticSpansAcrossPublishedFrames) {
+TEST(AsyncRendererTest, SimpleIdleSelectionPublishesThreeImmediateLayers) {
   svg::SVGDocument document = svg::instantiateSubtree(R"svg(
-    <rect id="target" x="40" y="0" width="10" height="10" fill="red" />
-    <rect id="cheap" x="2" y="2" width="8" height="8" fill="blue" />
+    <rect id="under" x="2" y="2" width="8" height="8" fill="blue" />
+    <rect id="target" x="24" y="2" width="8" height="8" fill="red" />
+    <rect id="over" x="46" y="2" width="8" height="8" fill="green" />
   )svg");
   document.setCanvasSize(64, 64);
 
@@ -895,34 +1307,34 @@ TEST(AsyncRendererTest, ProductionRendererCachesStaticSpansAcrossPublishedFrames
     request.version = version;
     request.documentGeneration = 1;
     request.selectedEntity = targetEntity;
-    request.dragPreview = RenderRequest::DragPreview{
-        .entity = targetEntity,
-        .interactionKind = svg::compositor::InteractionHint::Selection,
-    };
     asyncRenderer.requestRender(request);
     return waitForResult();
   };
-  const auto expectNoImmediateTiles = [](const RenderResult& result) {
-    ASSERT_TRUE(result.compositedPreview.has_value());
-    for (const RenderResult::CompositedTile& tile : result.compositedPreview->tiles) {
-      EXPECT_NE(tile.kind, RenderResult::CompositedTile::Kind::Immediate)
-          << "Production editor frames must cache static spans instead of rerasterizing them";
-    }
+
+  const auto expectThreeImmediateLayers = [&](const std::optional<RenderResult>& result) {
+    ASSERT_TRUE(result.has_value());
+    ASSERT_TRUE(result->compositedPreview.has_value());
+    EXPECT_FALSE(ContainsFullCanvasTile(*result));
+    ASSERT_EQ(result->compositedPreview->tiles.size(), 3u);
+    EXPECT_EQ(result->compositedPreview->tiles[0].kind,
+              RenderResult::CompositedTile::Kind::Immediate);
+    EXPECT_EQ(result->compositedPreview->tiles[1].kind, RenderResult::CompositedTile::Kind::Layer);
+    EXPECT_EQ(result->compositedPreview->tiles[1].layerEntity, targetEntity);
+    EXPECT_EQ(result->compositedPreview->tiles[2].kind,
+              RenderResult::CompositedTile::Kind::Immediate);
+
+    const auto compositeTiles = asyncRenderer.compositorCompositeTiles();
+    ASSERT_EQ(compositeTiles.size(), 3u) << DescribeCompositeSegments(compositeTiles);
+    EXPECT_TRUE(
+        std::ranges::all_of(compositeTiles, [](const auto& tile) { return tile.immediate; }))
+        << "A simple selected scene should keep bg/selection/fg as explicit paint-order layers "
+           "while rendering each one immediately.\n"
+        << DescribeCompositeSegments(compositeTiles);
   };
 
-  const std::optional<RenderResult> first = postSelection(1);
-  ASSERT_TRUE(first.has_value());
-  expectNoImmediateTiles(*first);
-  const auto firstStats = asyncRenderer.compositorRenderFrameStats();
-  EXPECT_GT(firstStats.cachedTileCount, 0);
-
-  const std::optional<RenderResult> second = postSelection(2);
-  ASSERT_TRUE(second.has_value());
-  expectNoImmediateTiles(*second);
-  const auto secondStats = asyncRenderer.compositorRenderFrameStats();
-  EXPECT_EQ(secondStats.immediateTileCount, 0);
-  EXPECT_EQ(secondStats.cachedTileCount, 0)
-      << "An unchanged follow-up frame must reuse the cached segment payloads";
+  expectThreeImmediateLayers(postSelection(1));
+  asyncRenderer.setCompositedRenderingMode(CompositedRenderingMode::FilterOnly);
+  expectThreeImmediateLayers(postSelection(2));
 }
 
 TEST(AsyncRendererE2ETest, SplashDonnerSelectionExposesEligibleStaticSpansForLayerPanel) {
@@ -1933,12 +2345,14 @@ TEST(AsyncRendererTest, CompositorResetOnDocumentVersionChange) {
   }
 }
 
-// A request with `selectedEntity` set and no `dragPreview` must still produce
-// a valid composited preview. If the compositor cannot split the selection yet,
-// the final CPU snapshot is wrapped as one full-canvas tile.
+// A request with `selectedEntity` set and no `dragPreview` must publish the same
+// paint-order layer topology used during a drag. Idle presentation must not
+// collapse back to a monolithic full-canvas render.
 TEST(AsyncRendererTest, SelectedEntityWithoutDragPreviewProducesCompositedPreview) {
   svg::SVGDocument document = svg::instantiateSubtree(R"svg(
-    <rect id="target" x="0" y="0" width="16" height="16" fill="red" />
+    <rect id="under" x="0" y="0" width="16" height="16" fill="blue" />
+    <rect id="target" x="20" y="0" width="16" height="16" fill="red" />
+    <rect id="over" x="40" y="0" width="16" height="16" fill="green" />
   )svg");
   document.setCanvasSize(64, 64);
 
@@ -1962,13 +2376,23 @@ TEST(AsyncRendererTest, SelectedEntityWithoutDragPreviewProducesCompositedPrevie
   }
 
   ASSERT_TRUE(result.has_value());
-  EXPECT_EQ(result->bitmap.empty(), renderer.requiresTextureSnapshotPresentation());
+  EXPECT_TRUE(result->bitmap.empty())
+      << "Layer tiles already carry the idle presentation; a redundant full-canvas CPU snapshot "
+         "would collapse the topology the editor must preserve";
   ASSERT_TRUE(result->compositedPreview.has_value());
   EXPECT_TRUE(result->compositedPreview->valid());
+  EXPECT_FALSE(ContainsFullCanvasTile(*result));
+  ASSERT_EQ(result->compositedPreview->tiles.size(), 3u);
+  EXPECT_EQ(result->compositedPreview->tiles[0].kind,
+            RenderResult::CompositedTile::Kind::Immediate);
+  EXPECT_EQ(result->compositedPreview->tiles[1].kind, RenderResult::CompositedTile::Kind::Layer);
+  EXPECT_EQ(result->compositedPreview->tiles[1].layerEntity, target->unsafeEntityHandle().entity());
+  EXPECT_EQ(result->compositedPreview->tiles[2].kind,
+            RenderResult::CompositedTile::Kind::Immediate);
   EXPECT_TRUE(std::ranges::any_of(result->compositedPreview->tiles, HasPresentationPayload));
 }
 
-TEST(AsyncRendererTest, ColdRenderWithoutSelectionProducesFullCanvasCompositedTile) {
+TEST(AsyncRendererTest, ColdRenderWithoutSelectionProducesCompositorSegment) {
   svg::SVGDocument document = svg::instantiateSubtree(R"svg(
     <rect x="0" y="0" width="64" height="64" fill="red" />
   )svg");
@@ -1991,8 +2415,8 @@ TEST(AsyncRendererTest, ColdRenderWithoutSelectionProducesFullCanvasCompositedTi
   ASSERT_TRUE(result->compositedPreview.has_value());
   ASSERT_EQ(result->compositedPreview->tiles.size(), 1u);
   const RenderResult::CompositedTile& tile = result->compositedPreview->tiles.front();
-  EXPECT_EQ(tile.kind, RenderResult::CompositedTile::Kind::Segment);
-  EXPECT_EQ(tile.id, "full-canvas");
+  EXPECT_EQ(tile.kind, RenderResult::CompositedTile::Kind::Immediate);
+  EXPECT_NE(tile.id, "full-canvas");
   EXPECT_TRUE(HasPresentationPayload(tile));
   if (renderer.requiresTextureSnapshotPresentation()) {
     ASSERT_NE(tile.textureSnapshot, nullptr);
@@ -2007,6 +2431,34 @@ TEST(AsyncRendererTest, ColdRenderWithoutSelectionProducesFullCanvasCompositedTi
   EXPECT_EQ(tile.canvasOffsetDoc, Vector2d::Zero());
   EXPECT_EQ(tile.bitmapDimsDoc, Vector2d(64.0, 64.0));
   EXPECT_TRUE(result->compositedPreview->entity == entt::null);
+}
+
+TEST(AsyncRendererTest, EmptyDocumentProducesTransparentCompositorSegment) {
+  svg::SVGDocument document = svg::instantiateSubtree(
+      R"svg(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" display="none"/>)svg");
+  document.setCanvasSize(64, 64);
+
+  svg::Renderer renderer;
+  AsyncRenderer asyncRenderer;
+  RenderRequest request(renderer, document);
+  request.version = 1;
+  request.documentGeneration = 1;
+  asyncRenderer.requestRender(request);
+
+  const std::optional<RenderResult> result = WaitForRenderResult(asyncRenderer);
+  ASSERT_TRUE(result.has_value());
+  ASSERT_TRUE(result->compositedPreview.has_value());
+  ASSERT_EQ(result->compositedPreview->tiles.size(), 1u);
+  const RenderResult::CompositedTile& tile = result->compositedPreview->tiles.front();
+  EXPECT_NE(tile.id, "full-canvas");
+  EXPECT_TRUE(tile.kind == RenderResult::CompositedTile::Kind::Segment ||
+              tile.kind == RenderResult::CompositedTile::Kind::Immediate);
+  EXPECT_EQ(tile.bitmapDimsDoc, Vector2d(64.0, 64.0));
+  const svg::RendererBitmap pixels = MaterializeTileBitmap(tile);
+  ASSERT_FALSE(pixels.pixels.empty());
+  EXPECT_TRUE(
+      std::ranges::all_of(pixels.pixels, [](std::uint8_t channel) { return channel == 0u; }));
+  EXPECT_FALSE(ContainsFullCanvasTile(*result));
 }
 
 TEST(AsyncRendererTest, CompositedTilesCarryRasterCanvasSizeForCacheIdentity) {
@@ -2045,7 +2497,7 @@ TEST(AsyncRendererTest, CompositedTilesCarryRasterCanvasSizeForCacheIdentity) {
   }
 }
 
-TEST(AsyncRendererTest, CompositingContextDescendantsProduceFullCanvasCompositedPreview) {
+TEST(AsyncRendererTest, CompositingContextDescendantsStillProduceLayeredPreview) {
   const std::array<std::string_view, 3> cases = {
       R"svg(
         <defs><filter id="blur"><feGaussianBlur stdDeviation="4"/></filter></defs>
@@ -2094,18 +2546,12 @@ TEST(AsyncRendererTest, CompositingContextDescendantsProduceFullCanvasComposited
 
     ASSERT_TRUE(result.has_value());
     ASSERT_TRUE(result->compositedPreview.has_value()) << svgBody;
-    ASSERT_EQ(result->compositedPreview->tiles.size(), 1u) << svgBody;
-    const RenderResult::CompositedTile& tile = result->compositedPreview->tiles.front();
-    EXPECT_EQ(tile.id, "full-canvas") << svgBody;
-    EXPECT_TRUE(HasPresentationPayload(tile)) << svgBody;
-    if (!tile.bitmap.empty()) {
-      EXPECT_EQ(tile.bitmap.dimensions, result->bitmap.dimensions) << svgBody;
-      EXPECT_EQ(tile.bitmap.pixels, result->bitmap.pixels) << svgBody;
-    }
-    if (tile.textureSnapshot != nullptr) {
-      EXPECT_EQ(tile.textureSnapshot->dimensions(), tile.bitmapDimsPx) << svgBody;
-    }
-    EXPECT_EQ(result->compositedPreview->entity, target->unsafeEntityHandle().entity()) << svgBody;
+    EXPECT_FALSE(ContainsFullCanvasTile(*result)) << svgBody;
+    EXPECT_TRUE(std::ranges::any_of(result->compositedPreview->tiles, HasPresentationPayload))
+        << svgBody;
+    EXPECT_TRUE(result->compositedPreview->entity == entt::null)
+        << "A refused interaction split must not advertise a movable cached entity\n"
+        << svgBody;
     ASSERT_TRUE(result->compositedPreview->representedDragPreview.has_value()) << svgBody;
     EXPECT_EQ(result->compositedPreview->representedDragPreview->entity,
               target->unsafeEntityHandle().entity())
@@ -2191,8 +2637,9 @@ TEST(AsyncRendererTest, CompositorStaysAliveAcrossDragRelease) {
   auto held = waitForResult();
   ASSERT_TRUE(held.has_value());
   ASSERT_TRUE(held->compositedPreview.has_value());
-  ASSERT_EQ(held->compositedPreview->tiles.size(), 1u);
-  EXPECT_EQ(held->compositedPreview->tiles.front().id, "full-canvas");
+  EXPECT_FALSE(ContainsFullCanvasTile(*held));
+  EXPECT_NE(FindLayerTile(*held, target->unsafeEntityHandle().entity()), nullptr)
+      << "Idle selection must keep its promoted layer between drag gestures";
 
   // Drag frame 2: same entity, same DOM transform (4, 0). If the compositor
   // were torn down between the release and this drag, it would re-rasterize
@@ -2210,13 +2657,11 @@ TEST(AsyncRendererTest, CompositorStaysAliveAcrossDragRelease) {
   auto drag2 = waitForResult();
   ASSERT_TRUE(drag2.has_value());
   ASSERT_TRUE(drag2->compositedPreview.has_value());
-  if (!renderer.requiresTextureSnapshotPresentation()) {
-    EXPECT_EQ(findDragTileBitmap(*drag2->compositedPreview), promotedPixelsDrag1)
-        << "drag-target tile bitmap should be identical after release -> drag-again";
-  } else {
-    EXPECT_EQ(findDragTileSignature(*drag2->compositedPreview), promotedSignatureDrag1)
-        << "drag-target tile signature should be stable after release -> drag-again";
-  }
+  const auto promotedSignatureDrag2 = findDragTileSignature(*drag2->compositedPreview);
+  EXPECT_EQ(std::get<1>(promotedSignatureDrag2), std::get<1>(promotedSignatureDrag1));
+  EXPECT_EQ(std::get<2>(promotedSignatureDrag2), std::get<2>(promotedSignatureDrag1))
+      << "drag-target tile generation and dimensions should remain stable after release -> "
+         "drag-again; a metadata-only second result reuses the payload published before release";
 }
 
 TEST(AsyncRendererTest, ActiveDragCanvasResizePublishesFreshFinalOnly) {
@@ -3346,11 +3791,9 @@ TEST(AsyncRendererTest, DragFrameVersionBumpDoesNotResetCompositor) {
 //
 //   Frame 0 (page load): RenderRequest with no selectedEntity and no
 //     dragPreview. Compositor takes the cold-render path, draws the
-//     correct full document, and publishes it before retained-cache
-//     warmup. After acceptance the worker warms mandatory filter layers
-//     and static segments on its cancellable low-priority lane. If the
-//     next gesture arrives first, it cancels that lane and the foreground
-//     render completes only the payloads still missing.
+//     correct full document, then warms mandatory filter layers and static
+//     segments before publishing the first paint-order tile set. This avoids
+//     ever presenting a monolithic full-canvas fallback in On mode.
 //
 //   Frame 1 (click-then-drag, one UI frame): user clicks a letter →
 //     SelectTool sets selection + dragState in the same event. By the

--- a/donner/editor/tests/AsyncRenderer_tests.cc
+++ b/donner/editor/tests/AsyncRenderer_tests.cc
@@ -1120,6 +1120,52 @@ TEST(AsyncRendererTest, NestedMultiSelectionNeverPublishesOverlappingLayers) {
       << "Reversing nested selection order must not change pixels";
 }
 
+TEST(AsyncRendererTest, PendingParentDemotionDoesNotClaimMovableChildCoverage) {
+  svg::SVGDocument document = svg::instantiateSubtree(R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+      <g id="parent">
+        <rect id="child" x="12" y="12" width="24" height="24" fill="red"/>
+      </g>
+    </svg>
+  )svg");
+  document.setCanvasSize(64, 64);
+  auto parent = document.querySelector("#parent");
+  auto child = document.querySelector("#child");
+  ASSERT_TRUE(parent.has_value());
+  ASSERT_TRUE(child.has_value());
+  const Entity parentEntity = parent->unsafeEntityHandle().entity();
+  const Entity childEntity = child->unsafeEntityHandle().entity();
+
+  svg::Renderer renderer;
+  AsyncRenderer asyncRenderer;
+  const auto renderSelected = [&](std::uint64_t version, Entity selectedEntity) {
+    RenderRequest request(renderer, document);
+    request.version = version;
+    request.documentGeneration = 1;
+    request.selectedEntity = selectedEntity;
+    request.dragPreview = RenderRequest::DragPreview{
+        .entity = selectedEntity,
+        .interactionKind = svg::compositor::InteractionHint::ActiveDrag,
+    };
+    asyncRenderer.requestRender(request);
+    return WaitForRenderResult(asyncRenderer);
+  };
+
+  const std::optional<RenderResult> parentResult = renderSelected(1, parentEntity);
+  ASSERT_TRUE(parentResult.has_value());
+  ASSERT_TRUE(parentResult->compositedPreview.has_value());
+  EXPECT_EQ(parentResult->compositedPreview->entity, parentEntity);
+
+  const std::optional<RenderResult> childResult = renderSelected(2, childEntity);
+  ASSERT_TRUE(childResult.has_value());
+  ASSERT_TRUE(childResult->compositedPreview.has_value());
+  EXPECT_NE(FindLayerTile(*childResult, parentEntity), nullptr)
+      << "The previous parent layer may remain cached during demotion hysteresis";
+  EXPECT_EQ(FindLayerTile(*childResult, childEntity), nullptr);
+  EXPECT_TRUE(childResult->compositedPreview->entity == entt::null)
+      << "A pending previous-selection parent is not a movable layer for the child request";
+}
+
 TEST(AsyncRendererE2ETest, UnbundledDonnerDDragMarksEveryComponentAsDragTarget) {
   std::ifstream splashStream("donner_splash.svg");
   if (!splashStream.is_open()) {

--- a/donner/editor/tests/AsyncRenderer_tests.cc
+++ b/donner/editor/tests/AsyncRenderer_tests.cc
@@ -408,6 +408,7 @@ TEST(AsyncRendererGpuWaitFailureTest, RepeatedIdenticalLossBumpsTheGenerationOnc
   asyncRenderer.noteGpuWaitOutcomeForTesting(escalated);
   EXPECT_EQ(asyncRenderer.gpuWaitFailure().generation, 2u);
   EXPECT_EQ(asyncRenderer.gpuWaitFailure().timedOutWaitSite, svg::GpuWaitTimeoutSite::QueueIdle);
+}
 
 namespace {
 

--- a/donner/editor/tests/AsyncRenderer_tests.cc
+++ b/donner/editor/tests/AsyncRenderer_tests.cc
@@ -492,6 +492,7 @@ TEST(AsyncRendererTest, FilterOnlyModeRestrictsHintsAndDisablesSelectionPromotio
       <rect x="4" y="4" width="20" height="20" fill="red" filter="url(#blur)"/>
       <g opacity="0.5">
         <rect x="30" y="8" width="16" height="16" fill="green"/>
+        <rect x="38" y="16" width="16" height="16" fill="blue"/>
       </g>
       <rect id="target" x="10" y="44" width="12" height="12" fill="black"/>
     </svg>
@@ -513,25 +514,32 @@ TEST(AsyncRendererTest, FilterOnlyModeRestrictsHintsAndDisablesSelectionPromotio
     return WaitForRenderResult(asyncRenderer);
   };
 
+  // `activeHintsCount` counts editor-explicit `promoteEntity` hints only;
+  // mandatory (detector) promotions are observed through `layerCount`.
   ASSERT_TRUE(renderSelected().has_value());
   EXPECT_EQ(asyncRenderer.workerCompositorEntity(), entity);
   const auto onState = asyncRenderer.compositorState();
-  EXPECT_GE(onState.activeHintsCount, 2u)
-      << "Full compositing publishes mandatory hints for the filter AND the opacity group, plus "
-         "the selection hint";
+  EXPECT_EQ(onState.activeHintsCount, 1u) << "The selection promotion must take";
+  EXPECT_GE(onState.layerCount, 2u)
+      << "Full compositing promotes at least the filter subtree and the selection";
 
   asyncRenderer.setCompositedRenderingMode(CompositedRenderingMode::FilterOnly);
   ASSERT_TRUE(renderSelected().has_value());
   EXPECT_TRUE(asyncRenderer.workerCompositorEntity() == entt::null)
       << "FilterOnly must not promote the selection";
   const auto filterOnlyState = asyncRenderer.compositorState();
-  EXPECT_EQ(filterOnlyState.activeHintsCount, 1u)
-      << "FilterOnly publishes a mandatory hint for the filter only";
+  EXPECT_EQ(filterOnlyState.activeHintsCount, 0u)
+      << "FilterOnly publishes no editor promotion hints";
+  EXPECT_EQ(filterOnlyState.layerCount, 1u)
+      << "FilterOnly keeps exactly the filter subtree composited (no opacity layer, no selection "
+         "layer, no complexity buckets)";
 
   asyncRenderer.setCompositedRenderingMode(CompositedRenderingMode::Off);
   ASSERT_TRUE(renderSelected().has_value());
   EXPECT_TRUE(asyncRenderer.workerCompositorEntity() == entt::null);
-  EXPECT_EQ(asyncRenderer.compositorState().activeHintsCount, 0u);
+  const auto offState = asyncRenderer.compositorState();
+  EXPECT_EQ(offState.activeHintsCount, 0u);
+  EXPECT_EQ(offState.layerCount, 0u);
 }
 
 TEST(AsyncRendererTest, DeferredStartQueuesWorkAndStartsExactlyOnce) {

--- a/donner/editor/tests/AsyncRenderer_tests.cc
+++ b/donner/editor/tests/AsyncRenderer_tests.cc
@@ -397,6 +397,141 @@ TEST(AsyncRendererGpuWaitFailureTest, RepeatedIdenticalLossBumpsTheGenerationOnc
   asyncRenderer.noteGpuWaitOutcomeForTesting(escalated);
   EXPECT_EQ(asyncRenderer.gpuWaitFailure().generation, 2u);
   EXPECT_EQ(asyncRenderer.gpuWaitFailure().timedOutWaitSite, svg::GpuWaitTimeoutSite::QueueIdle);
+
+namespace {
+
+/// Returns the presented full-canvas pixels for a render result, whichever
+/// presentation path produced them: the CPU snapshot when the backend honors
+/// `captureCpuSnapshot`, otherwise the single full-canvas composited tile's
+/// texture snapshot (Geode presentation ignores the CPU snapshot request).
+svg::RendererBitmap FullCanvasPixels(const RenderResult& result) {
+  if (!result.bitmap.empty()) {
+    return result.bitmap;
+  }
+  if (result.compositedPreview.has_value() && result.compositedPreview->tiles.size() == 1) {
+    return MaterializeTileBitmap(result.compositedPreview->tiles.front());
+  }
+  return {};
+}
+
+}  // namespace
+
+TEST(AsyncRendererTest, CompositedRenderingModesProduceIdenticalPixels) {
+  // One entity per isolation signal class: a filter (stays composited in
+  // FilterOnly), an opacity group (inline in FilterOnly), and a plain rect.
+  svg::SVGDocument document = svg::instantiateSubtree(R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+      <defs>
+        <filter id="blur"><feGaussianBlur stdDeviation="1.5"/></filter>
+      </defs>
+      <rect x="4" y="4" width="20" height="20" fill="red" filter="url(#blur)"/>
+      <g opacity="0.5">
+        <rect x="30" y="8" width="16" height="16" fill="green"/>
+        <rect x="38" y="16" width="16" height="16" fill="blue"/>
+      </g>
+      <rect x="10" y="44" width="12" height="12" fill="black"/>
+    </svg>
+  )svg");
+  document.setCanvasSize(64, 64);
+
+  svg::Renderer renderer;
+  AsyncRenderer asyncRenderer;
+  std::uint64_t version = 0;
+  const auto renderAndCapture = [&]() -> svg::RendererBitmap {
+    RenderRequest request(renderer, document);
+    request.version = ++version;
+    request.documentGeneration = 1;
+    request.captureCpuSnapshot = true;
+    asyncRenderer.requestRender(request);
+    const std::optional<RenderResult> result = WaitForRenderResult(asyncRenderer);
+    if (!result.has_value()) {
+      return {};
+    }
+    return FullCanvasPixels(*result);
+  };
+
+  const svg::RendererBitmap onPixels = renderAndCapture();
+  ASSERT_FALSE(onPixels.empty());
+  EXPECT_EQ(asyncRenderer.compositorReconstructCountForTesting(), 1u);
+
+  asyncRenderer.setCompositedRenderingMode(CompositedRenderingMode::FilterOnly);
+  const svg::RendererBitmap filterOnlyPixels = renderAndCapture();
+  ASSERT_FALSE(filterOnlyPixels.empty());
+  EXPECT_EQ(asyncRenderer.compositorReconstructCountForTesting(), 2u)
+      << "A mode change between composited modes must reconstruct the controller";
+  ASSERT_EQ(filterOnlyPixels.dimensions, onPixels.dimensions);
+  EXPECT_TRUE(filterOnlyPixels.pixels == onPixels.pixels)
+      << "FilterOnly must render pixel-identically to full compositing";
+
+  asyncRenderer.setCompositedRenderingMode(CompositedRenderingMode::Off);
+  const svg::RendererBitmap offPixels = renderAndCapture();
+  ASSERT_FALSE(offPixels.empty());
+  const auto offState = asyncRenderer.compositorState();
+  EXPECT_EQ(offState.activeHintsCount, 0u);
+  EXPECT_EQ(offState.layerCount, 0u);
+  ASSERT_EQ(offPixels.dimensions, onPixels.dimensions);
+  EXPECT_TRUE(offPixels.pixels == onPixels.pixels)
+      << "The direct (no compositor) path must render pixel-identically to full compositing";
+
+  asyncRenderer.setCompositedRenderingMode(CompositedRenderingMode::On);
+  const svg::RendererBitmap restoredPixels = renderAndCapture();
+  ASSERT_FALSE(restoredPixels.empty());
+  EXPECT_EQ(asyncRenderer.compositorReconstructCountForTesting(), 3u)
+      << "Leaving Off must reconstruct the controller";
+  ASSERT_EQ(restoredPixels.dimensions, onPixels.dimensions);
+  EXPECT_TRUE(restoredPixels.pixels == onPixels.pixels)
+      << "Returning to full compositing must restore the original output";
+}
+
+TEST(AsyncRendererTest, FilterOnlyModeRestrictsHintsAndDisablesSelectionPromotion) {
+  svg::SVGDocument document = svg::instantiateSubtree(R"svg(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+      <defs>
+        <filter id="blur"><feGaussianBlur stdDeviation="1.5"/></filter>
+      </defs>
+      <rect x="4" y="4" width="20" height="20" fill="red" filter="url(#blur)"/>
+      <g opacity="0.5">
+        <rect x="30" y="8" width="16" height="16" fill="green"/>
+      </g>
+      <rect id="target" x="10" y="44" width="12" height="12" fill="black"/>
+    </svg>
+  )svg");
+  document.setCanvasSize(64, 64);
+  auto target = document.querySelector("#target");
+  ASSERT_TRUE(target.has_value());
+  const Entity entity = target->unsafeEntityHandle().entity();
+
+  svg::Renderer renderer;
+  AsyncRenderer asyncRenderer;
+  std::uint64_t version = 0;
+  const auto renderSelected = [&]() {
+    RenderRequest request(renderer, document);
+    request.version = ++version;
+    request.documentGeneration = 1;
+    request.selectedEntity = entity;
+    asyncRenderer.requestRender(request);
+    return WaitForRenderResult(asyncRenderer);
+  };
+
+  ASSERT_TRUE(renderSelected().has_value());
+  EXPECT_EQ(asyncRenderer.workerCompositorEntity(), entity);
+  const auto onState = asyncRenderer.compositorState();
+  EXPECT_GE(onState.activeHintsCount, 2u)
+      << "Full compositing publishes mandatory hints for the filter AND the opacity group, plus "
+         "the selection hint";
+
+  asyncRenderer.setCompositedRenderingMode(CompositedRenderingMode::FilterOnly);
+  ASSERT_TRUE(renderSelected().has_value());
+  EXPECT_TRUE(asyncRenderer.workerCompositorEntity() == entt::null)
+      << "FilterOnly must not promote the selection";
+  const auto filterOnlyState = asyncRenderer.compositorState();
+  EXPECT_EQ(filterOnlyState.activeHintsCount, 1u)
+      << "FilterOnly publishes a mandatory hint for the filter only";
+
+  asyncRenderer.setCompositedRenderingMode(CompositedRenderingMode::Off);
+  ASSERT_TRUE(renderSelected().has_value());
+  EXPECT_TRUE(asyncRenderer.workerCompositorEntity() == entt::null);
+  EXPECT_EQ(asyncRenderer.compositorState().activeHintsCount, 0u);
 }
 
 TEST(AsyncRendererTest, DeferredStartQueuesWorkAndStartsExactlyOnce) {

--- a/donner/editor/tests/MenuBarPresenter_tests.cc
+++ b/donner/editor/tests/MenuBarPresenter_tests.cc
@@ -183,6 +183,17 @@ TEST(MenuBarPresenterActionsTest, ApplyViewMenuToggleActionsHandlesNullAndIndepe
   ApplyViewMenuToggleActions(actions, &showCompositorDebugPanel, &perfOverlayMode);
   EXPECT_FALSE(showCompositorDebugPanel);
   EXPECT_EQ(perfOverlayMode, PerfOverlayMode::FullGraph);
+
+  CompositedRenderingMode compositedRenderingMode = CompositedRenderingMode::On;
+  actions = MenuBarActions{};
+  actions.setCompositedRenderingMode = true;
+  actions.compositedRenderingMode = CompositedRenderingMode::FilterOnly;
+  ApplyViewMenuToggleActions(actions, nullptr, nullptr);
+  EXPECT_EQ(compositedRenderingMode, CompositedRenderingMode::On)
+      << "null out-param must leave the caller's mode untouched";
+  ApplyViewMenuToggleActions(actions, nullptr, nullptr, nullptr, nullptr,
+                             &compositedRenderingMode);
+  EXPECT_EQ(compositedRenderingMode, CompositedRenderingMode::FilterOnly);
 }
 
 TEST(MenuBarPresenterActionsTest, ApplyMenuBarCommandIgnoresInactiveAndNullActions) {
@@ -309,6 +320,21 @@ TEST(MenuBarPresenterActionsTest, ApplyMenuBarCommandMapsSimpleCommandsToActions
   ApplyMenuBarCommand(true, MenuBarCommand::SetPerfOverlayFullGraph, state, &actions);
   EXPECT_TRUE(actions.setPerfOverlayMode);
   EXPECT_EQ(actions.perfOverlayMode, PerfOverlayMode::FullGraph);
+
+  actions = MenuBarActions{};
+  ApplyMenuBarCommand(true, MenuBarCommand::SetCompositedRenderingOff, state, &actions);
+  EXPECT_TRUE(actions.setCompositedRenderingMode);
+  EXPECT_EQ(actions.compositedRenderingMode, CompositedRenderingMode::Off);
+
+  actions = MenuBarActions{};
+  ApplyMenuBarCommand(true, MenuBarCommand::SetCompositedRenderingFilterOnly, state, &actions);
+  EXPECT_TRUE(actions.setCompositedRenderingMode);
+  EXPECT_EQ(actions.compositedRenderingMode, CompositedRenderingMode::FilterOnly);
+
+  actions = MenuBarActions{};
+  ApplyMenuBarCommand(true, MenuBarCommand::SetCompositedRenderingOn, state, &actions);
+  EXPECT_TRUE(actions.setCompositedRenderingMode);
+  EXPECT_EQ(actions.compositedRenderingMode, CompositedRenderingMode::On);
 }
 
 TEST(MenuBarPresenterActionsTest, ApplyMenuBarCommandRoutesSelectCommandsBySourceFocus) {

--- a/donner/editor/tests/PresentationRenderScheduler_tests.cc
+++ b/donner/editor/tests/PresentationRenderScheduler_tests.cc
@@ -108,6 +108,29 @@ TEST(PresentationRenderSchedulerTest, RepeatedUpToDateSelectionDoesNotRequestRen
   EXPECT_FALSE(second.dragPreview.has_value());
 }
 
+TEST(PresentationRenderSchedulerTest, UnownedTileCacheDoesNotSuppressActiveDragRender) {
+  PresentationRenderScheduler scheduler;
+  CompositedPresentation presentation;
+  scheduler.noteRenderCompleted(/*completedVersion=*/1, kCanvasSize, RasterViewport());
+  presentation.noteCachedTextures(entt::null, /*version=*/1, kCanvasSize);
+
+  SelectTool::ActiveDragPreview activeDrag{
+      .entity = Entity(7),
+      .translation = Vector2d(4.0, 2.0),
+      .documentFromCachedDocument = Transform2d::Translate(Vector2d(4.0, 2.0)),
+      .dragGeneration = 1,
+  };
+  const PresentationRenderScheduleDecision decision =
+      scheduler.evaluate(presentation, Input(Entity(7), /*version=*/1, activeDrag));
+
+  EXPECT_TRUE(decision.shouldRequestRender());
+  EXPECT_TRUE(decision.needsCompositedLayerCapture)
+      << "Off mode and OwningTilesRequired results have no movable entity tile; every changed drag "
+         "transform must request rendered pixels";
+  ASSERT_TRUE(decision.dragPreview.has_value());
+  EXPECT_EQ(decision.dragPreview->entity, Entity(7));
+}
+
 TEST(PresentationRenderSchedulerTest, PresentationSettingChangeForcesCurrentDocumentRender) {
   PresentationRenderScheduler scheduler;
   CompositedPresentation presentation;

--- a/donner/editor/tests/ViewMenuVisibility_tests.cc
+++ b/donner/editor/tests/ViewMenuVisibility_tests.cc
@@ -19,6 +19,8 @@ TEST(ViewMenuVisibility, MenuBarStateDefaultsMatchVisibilityContract) {
       << "Performance overlay must default to off";
   EXPECT_FALSE(state.geometryDebugOverlay)
       << "Geode geometry debug overlay must default to off (zero impact on normal rendering)";
+  EXPECT_EQ(state.compositedRenderingMode, CompositedRenderingMode::On)
+      << "Composited rendering must default to full compositing (pre-setting behavior)";
 }
 
 // The toggle actions are edge-triggered requests, so they must default to false
@@ -28,6 +30,7 @@ TEST(ViewMenuVisibility, MenuBarActionsToggleRequestsDefaultFalse) {
   EXPECT_FALSE(actions.toggleCompositorDebugPanel);
   EXPECT_FALSE(actions.setPerfOverlayMode);
   EXPECT_FALSE(actions.toggleGeometryDebugOverlay);
+  EXPECT_FALSE(actions.setCompositedRenderingMode);
 }
 
 TEST(ViewMenuVisibility, ToggleActionsFlipCompositorDebugPanel) {

--- a/donner/editor/wasm/tests/smoke.spec.ts
+++ b/donner/editor/wasm/tests/smoke.spec.ts
@@ -1492,11 +1492,20 @@ test("Geode WASM selects through the overlay with one prewarm render and no recu
   );
   const workerStats = await page.evaluate(() => window.__donnerWorkerStats);
   expect(workerStats).toBeDefined();
-  // Presentation costs no CPU readback: Geode draws the document straight into
-  // the canvas frame, so the readback counters stay at zero and the wait
-  // strategy is only ever one of the two GPU-fence strategies.
-  expect(workerStats?.readbackCount).toBe(0);
-  expect(workerStats?.readbackPollIterations).toBe(0);
+  console.log(`wasm-worker-stats=${JSON.stringify(workerStats)}`);
+  // Browser WebGPU textures cannot cross the worker/UI device boundary, so the
+  // two immediate owning spans around the preserved selected layer each need
+  // one CPU readback for upload. Tie that cost to the tiles rasterized in this
+  // settle frame: an extra readback would expose duplicate tile work or a
+  // forbidden flat full-canvas snapshot.
+  expect(workerStats?.immediateTileCount).toBe(2);
+  expect(workerStats?.cachedTileCount).toBe(0);
+  expect(workerStats?.readbackCount).toBe(
+    (workerStats?.immediateTileCount || 0) + (workerStats?.cachedTileCount || 0),
+  );
+  expect(workerStats?.readbackPollIterations || 0).toBeGreaterThanOrEqual(
+    workerStats?.readbackCount || 0,
+  );
   expect(["timed-wait-any", "device-poll"]).toContain(workerStats?.readbackWaitStrategy);
   // A run that presented frames must say so explicitly rather than by the
   // absence of a failure field. A hung GPU wait publishes the same object with
@@ -1509,7 +1518,6 @@ test("Geode WASM selects through the overlay with one prewarm render and no recu
   expect(workerStats?.gpuWaitTimeoutSite).toBe("none");
   expect(workerStats?.gpuWaitTimeoutMs).toBe(0);
   expect(workerStats?.publishReason).toBe("render-result");
-  console.log(`wasm-worker-stats=${JSON.stringify(workerStats)}`);
   expect(fatalMessages).toEqual([]);
 });
 

--- a/donner/svg/compositor/CompositorController.cc
+++ b/donner/svg/compositor/CompositorController.cc
@@ -405,6 +405,22 @@ bool CompositorController::isPromoted(Entity entity) const {
   return activeHints_.contains(entity);
 }
 
+bool CompositorController::interactionLayersCover(const std::vector<Entity>& interactionLayerRoots,
+                                                  const std::vector<Entity>& entities) const {
+  Registry& registry = document().registry();
+  return std::ranges::all_of(entities, [&](Entity entity) {
+    Entity cursor = entity;
+    while (cursor != entt::null && registry.valid(cursor)) {
+      if (std::ranges::find(interactionLayerRoots, cursor) != interactionLayerRoots.end()) {
+        return true;
+      }
+      const auto* tree = registry.try_get<donner::components::TreeComponent>(cursor);
+      cursor = tree != nullptr ? tree->parent() : entt::null;
+    }
+    return false;
+  });
+}
+
 void CompositorController::markPromotedLayerDirty(Entity entity) {
   CompositorLayer* layer = findLayer(entity);
   if (layer != nullptr) {

--- a/donner/svg/compositor/CompositorController.cc
+++ b/donner/svg/compositor/CompositorController.cc
@@ -48,6 +48,7 @@ CompositorController::CompositorController(SVGDocument& document, RendererInterf
     : document_(document),
       renderer_(renderer),
       config_(config),
+      mandatoryDetector_(config.mandatoryHintScope),
       // Only carve subtrees into bucket layers when they're actually
       // expensive to re-rasterize. `filterPenalty = 16` (default) plus the
       // subtree's own entity cost puts any filter group well above this

--- a/donner/svg/compositor/CompositorController.cc
+++ b/donner/svg/compositor/CompositorController.cc
@@ -41,7 +41,49 @@
 
 namespace donner::svg::compositor {
 
-namespace {}  // namespace
+namespace {
+
+bool HasAssignedDescendant(Registry& registry, Entity entity) {
+  using TreeComponent = donner::components::TreeComponent;
+  std::vector<Entity> stack;
+  if (const auto* tree = registry.try_get<TreeComponent>(entity)) {
+    for (Entity child = tree->firstChild(); child != entt::null;
+         child = registry.get<TreeComponent>(child).nextSibling()) {
+      stack.push_back(child);
+    }
+  }
+  while (!stack.empty()) {
+    const Entity descendant = stack.back();
+    stack.pop_back();
+    const auto* assignment = registry.try_get<ComputedLayerAssignmentComponent>(descendant);
+    if (assignment != nullptr && assignment->layerId != 0) {
+      return true;
+    }
+    if (const auto* tree = registry.try_get<TreeComponent>(descendant)) {
+      for (Entity child = tree->firstChild(); child != entt::null;
+           child = registry.get<TreeComponent>(child).nextSibling()) {
+        stack.push_back(child);
+      }
+    }
+  }
+  return false;
+}
+
+bool HasAssignedAncestor(Registry& registry, Entity entity) {
+  const auto* tree = registry.try_get<donner::components::TreeComponent>(entity);
+  Entity cursor = tree != nullptr ? tree->parent() : entt::null;
+  while (cursor != entt::null && registry.valid(cursor)) {
+    const auto* assignment = registry.try_get<ComputedLayerAssignmentComponent>(cursor);
+    if (assignment != nullptr && assignment->layerId != 0) {
+      return true;
+    }
+    const auto* ancestorTree = registry.try_get<donner::components::TreeComponent>(cursor);
+    cursor = ancestorTree != nullptr ? ancestorTree->parent() : entt::null;
+  }
+  return false;
+}
+
+}  // namespace
 
 CompositorController::CompositorController(SVGDocument& document, RendererInterface& renderer,
                                            CompositorConfig config)
@@ -77,23 +119,51 @@ CompositorController::PromoteResult CompositorController::promoteEntity(
       case PromoteRefusalReason::MemoryLimit: return PromoteResult{PromoteResult::MemoryLimit};
       case PromoteRefusalReason::DescendantPromoted:
         return PromoteResult{PromoteResult::DescendantPromoted};
-      case PromoteRefusalReason::None:
-        return PromoteResult{PromoteResult::FullCanvasPreviewRequired};
+      case PromoteRefusalReason::None: return PromoteResult{PromoteResult::OwningTilesRequired};
     }
-    return PromoteResult{PromoteResult::FullCanvasPreviewRequired};
+    return PromoteResult{PromoteResult::OwningTilesRequired};
   };
 
   if (!registry.valid(entity)) {
     return refuse(PromoteRefusalReason::InvalidEntity);
   }
 
-  // Descendants under an ancestor filter / mask / clip-path cannot be extracted into their own
-  // layer without losing the ancestor compositing context. They are still presentable through the
-  // compositor as a full-canvas tile.
-  if (HasCompositingBreakingAncestor(registry, entity)) {
+  // FilterOnly leaves opacity, blend-mode, and isolation ancestors inline. Promotion safety in
+  // that scope therefore depends on their resolved isolation state, including CSS-authored
+  // values. A cold editor request can promote a selection before the first renderFrame call; raw
+  // XML attributes are not enough to classify those cases. Prepare and reconcile first so the
+  // narrowed scope never extracts a selection from an inline compositing context. Full scope
+  // defers the equivalent validation to render preparation so its cold path stays unchanged.
+  if (!documentPrepared_ && config_.mandatoryHintScope == MandatoryHintScope::FilterOnly) {
+    ParseWarningSink warningSink;
+    RendererUtils::prepareDocumentForRendering(document(), /*verbose=*/false, warningSink);
+    documentPrepared_ = true;
+    if (registry.ctx().contains<components::RenderTreeState>()) {
+      registry.ctx().get<components::RenderTreeState>().needsFullRebuild = false;
+    }
+    mandatoryDetector_.reconcile(registry);
+    if (config_.complexityBucketing) {
+      complexityBucketer_.reconcile(registry);
+    }
+    hintsScanned_ = true;
+    const ResolveOptions resolveOptions{
+        .enableInteractionHints = config_.autoPromoteInteractions,
+        .enableAnimationHints = config_.autoPromoteAnimations,
+        .enableComplexityBucketHints = config_.complexityBucketing,
+    };
+    resolver_.resolve(registry, kMaxCompositorLayers, resolveOptions);
+    reconcileLayers(registry);
+    refreshLayerMetadata();
+  }
+
+  // Descendants under an ancestor filter / mask / clip-path or an already assigned layer cannot be
+  // extracted into their own layer without losing or duplicating the owning context. The editor
+  // still presents the compositor's remaining paint-order tiles; only the requested interaction
+  // split is refused.
+  if (HasCompositingBreakingAncestor(registry, entity) || HasAssignedAncestor(registry, entity)) {
     lastPromoteRefusalReason_ = PromoteRefusalReason::None;
     lastPromoteRefusalEntity_ = entt::null;
-    return PromoteResult{PromoteResult::FullCanvasPreviewRequired};
+    return PromoteResult{PromoteResult::OwningTilesRequired};
   }
 
   // Layer-set hysteresis. If `entity` is in the
@@ -142,33 +212,12 @@ CompositorController::PromoteResult CompositorController::promoteEntity(
   // edges when dragging `#Clouds_with_gradients` on the splash, which
   // contains cls-90 / cls-93 clip-path sublayers.
   //
-  // Falling back to non-composited rendering for this specific drag
-  // target costs compositor optimization but preserves correctness.
+  // Leaving this specific drag target inside its owning compositor tiles costs the interaction
+  // fast path but preserves correctness.
   // Typical interactive targets (single shapes, text letters, filter
   // groups themselves) are unaffected.
-  {
-    using TreeComponent = donner::components::TreeComponent;
-    std::vector<Entity> stack;
-    if (const auto* tree = registry.try_get<TreeComponent>(entity)) {
-      for (Entity child = tree->firstChild(); child != entt::null;
-           child = registry.get<TreeComponent>(child).nextSibling()) {
-        stack.push_back(child);
-      }
-    }
-    while (!stack.empty()) {
-      const Entity descendant = stack.back();
-      stack.pop_back();
-      const auto* assignment = registry.try_get<ComputedLayerAssignmentComponent>(descendant);
-      if (assignment != nullptr && assignment->layerId != 0) {
-        return refuse(PromoteRefusalReason::DescendantPromoted);
-      }
-      if (const auto* descTree = registry.try_get<TreeComponent>(descendant)) {
-        for (Entity grandchild = descTree->firstChild(); grandchild != entt::null;
-             grandchild = registry.get<TreeComponent>(grandchild).nextSibling()) {
-          stack.push_back(grandchild);
-        }
-      }
-    }
+  if (HasAssignedDescendant(registry, entity)) {
+    return refuse(PromoteRefusalReason::DescendantPromoted);
   }
 
   // Under `autoPromoteInteractions`, the editor-driven
@@ -308,13 +357,20 @@ void CompositorController::processPendingDemotions(Registry& registry) {
   reconcileLayers(registry);
 }
 
-bool CompositorController::dropNonRenderableInteractionHints(Registry& registry) {
+bool CompositorController::dropUnsafeInteractionHints(Registry& registry) {
   std::vector<Entity> droppedEntities;
   droppedEntities.reserve(activeHints_.size());
   for (const auto& [entity, hint] : activeHints_) {
     (void)hint;
-    if (!registry.valid(entity) ||
-        !registry.all_of<components::RenderingInstanceComponent>(entity)) {
+    const bool hasNoRenderInstance =
+        !registry.valid(entity) || !registry.all_of<components::RenderingInstanceComponent>(entity);
+    const bool hasCompositingAncestor =
+        !hasNoRenderInstance && HasCompositingBreakingAncestor(registry, entity);
+    const bool hasPromotedAncestor = !hasNoRenderInstance && HasAssignedAncestor(registry, entity);
+    const bool hasPromotedDescendant =
+        !hasNoRenderInstance && HasAssignedDescendant(registry, entity);
+    if (hasNoRenderInstance || hasCompositingAncestor || hasPromotedAncestor ||
+        hasPromotedDescendant) {
       droppedEntities.push_back(entity);
     }
   }
@@ -784,7 +840,6 @@ bool CompositorController::remapAfterStructuralReplace(
     complexityBucketer_.rebuildForReplacedDocument(registry);
   }
   hintsScanned_ = true;
-  const bool droppedNonRenderableHints = dropNonRenderableInteractionHints(registry);
 
   // Step 3: remap layer entity ids. Cached `bitmap_`, `canvasFromBitmap_`,
   // `bitmapEntityFromWorldTransform_`, and `fallbackReasons_` survive
@@ -828,7 +883,10 @@ bool CompositorController::remapAfterStructuralReplace(
   };
   resolver_.resolve(registry, kMaxCompositorLayers, resolveOptions);
   reconcileLayers(registry);
-  if (droppedNonRenderableHints) {
+  const bool droppedUnsafeHints = dropUnsafeInteractionHints(registry);
+  if (droppedUnsafeHints) {
+    resolver_.resolve(registry, kMaxCompositorLayers, resolveOptions);
+    reconcileLayers(registry);
     markAllSegmentsDirty();
   }
 
@@ -1453,34 +1511,16 @@ void CompositorController::renderFrameImpl(const RenderViewport& viewport,
   // bucket detectors can't score anything useful. Defer them to the first
   // post-prepare frame by also rescanning whenever `hintsScanned_` is false.
   //
-  // The same condition applies when `needsFullRebuild` is true:
+  // The same condition applies whenever the document is dirty:
   // `RenderingContext::invalidateRenderTree()` (called by
   // `SVGDocument::setCanvasSize` etc.) wipes every RIC. Running the
-  // detector against the empty view here would mark every existing
-  // mandatory hint as stale (the qualifying set is empty, see
-  // `MandatoryHintDetector::reconcile`) and silently demote every
-  // filter / mask / isolated-layer subtree until the user mutates the
-  // document again. Skip the pre-prepare scan in that case and let the
-  // post-prepare branch below pick the hints back up against the
-  // freshly-rebuilt RIC view. Pinned by `MandatoryFilterLayerSurvives
-  // CanvasResize`.
-  const bool deferDetectorsToPostPrepare = needsFullRebuild;
-  const bool needsHintRescan = !hintsScanned_ || documentDirty;
-  if ((!documentPrepared_ || documentDirty) && documentPrepared_ && !deferDetectorsToPostPrepare) {
-    // Document is already prepared and became dirty - rescan now.
-    {
-      ZoneScopedN("Compositor::mandatoryDetector.reconcile");
-      mandatoryDetector_.reconcile(registry);
-    }
-    if (config_.complexityBucketing) {
-      ZoneScopedN("Compositor::complexityBucketer.reconcile");
-      complexityBucketer_.reconcile(registry);
-    }
-    hintsScanned_ = true;
-  } else if (!documentPrepared_ && needsHintRescan) {
-    // First frame, RICs don't exist yet. Skip the detectors - we'll run them
-    // immediately after the first prepare below.
-  }
+  // detector against either that empty view or the stale pre-mutation view
+  // can incorrectly drop a still-live mandatory layer or retain one whose
+  // entity just became `display:none`. Skip the pre-prepare scan in that
+  // case and let the post-prepare branch below reconcile against the freshly
+  // rebuilt RIC view. Pinned by `MandatoryFilterLayerSurvivesCanvasResize`
+  // and the editor's same-frame display:none layer suppression test.
+  const bool deferDetectorsToPostPrepare = documentDirty;
   const ResolveOptions resolveOptions{
       .enableInteractionHints = config_.autoPromoteInteractions,
       .enableAnimationHints = config_.autoPromoteAnimations,
@@ -1551,7 +1591,8 @@ void CompositorController::renderFrameImpl(const RenderViewport& viewport,
     // discovered mandatory filter/mask/isolated-layer promotes the affected
     // subtree immediately.
     const auto firstFramePlanningStart = std::chrono::steady_clock::now();
-    if (!hintsScanned_) {
+    const bool needsLayerPlanning = !hintsScanned_ || deferDetectorsToPostPrepare;
+    if (needsLayerPlanning) {
       ZoneScopedN("Compositor::firstFrameDetectorsAndWarmup");
       {
         ZoneScopedN("Compositor::mandatoryDetector.reconcile (first)");
@@ -1572,16 +1613,18 @@ void CompositorController::renderFrameImpl(const RenderViewport& viewport,
       }
       refreshLayerMetadata();
       lastRenderFrameStats_.firstFramePlanningMs = elapsedMsSince(firstFramePlanningStart);
+    }
 
-      // The flat output above is already the correct frame. Interactive owners may publish it now
-      // and perform this offscreen-only cache preparation in a later cancellable worker turn.
-      if (config_.deferFirstFrameWarmup) {
-        firstFrameWarmupPending_ = true;
-      } else {
-        const auto firstFrameWarmupStart = std::chrono::steady_clock::now();
-        warmFirstFrameCaches(viewport, surfaceFromCanvas);
-        lastRenderFrameStats_.firstFrameWarmupMs = elapsedMsSince(firstFrameWarmupStart);
-      }
+    // The flat output above is already the correct frame. Owners that allow flat first-frame
+    // presentation may defer the initial cache fill. Tile-only owners warm eagerly on every
+    // transition to an empty layer set, including a later selection demotion, so the root static
+    // segment remains publishable instead of disappearing until another promotion.
+    if (config_.deferFirstFrameWarmup && needsLayerPlanning) {
+      firstFrameWarmupPending_ = true;
+    } else if (!config_.deferFirstFrameWarmup) {
+      const auto firstFrameWarmupStart = std::chrono::steady_clock::now();
+      warmFirstFrameCaches(viewport, surfaceFromCanvas);
+      lastRenderFrameStats_.firstFrameWarmupMs = elapsedMsSince(firstFrameWarmupStart);
     }
     return;
   }
@@ -1607,12 +1650,6 @@ void CompositorController::renderFrameImpl(const RenderViewport& viewport,
     documentPrepared_ = true;
     refreshLayerMetadata();
 
-    if (dropNonRenderableInteractionHints(registry)) {
-      resolver_.resolve(registry, kMaxCompositorLayers, resolveOptions);
-      reconcileLayers(registry);
-      markAllSegmentsDirty();
-    }
-
     // After preparation, keep the global rebuild signal consumed. RenderingContext clears this
     // after a successful render-tree instantiation; this write is a defensive no-op for callers
     // that still reach this path with the flag set.
@@ -1632,6 +1669,11 @@ void CompositorController::renderFrameImpl(const RenderViewport& viewport,
       hintsScanned_ = true;
       resolver_.resolve(registry, kMaxCompositorLayers, resolveOptions);
       reconcileLayers(registry);
+    }
+    if (dropUnsafeInteractionHints(registry)) {
+      resolver_.resolve(registry, kMaxCompositorLayers, resolveOptions);
+      reconcileLayers(registry);
+      markAllSegmentsDirty();
     }
   }
 
@@ -1653,6 +1695,11 @@ void CompositorController::renderFrameImpl(const RenderViewport& viewport,
     splitStaticLayersViewport_ = Vector2i::Zero();
     rootDirty_ = false;
     mainRendererHasCachedFrame_ = true;
+    if (!config_.deferFirstFrameWarmup) {
+      const auto emptyLayerWarmupStart = std::chrono::steady_clock::now();
+      warmFirstFrameCaches(viewport, surfaceFromCanvas);
+      lastRenderFrameStats_.firstFrameWarmupMs = elapsedMsSince(emptyLayerWarmupStart);
+    }
     return;
   }
 

--- a/donner/svg/compositor/CompositorController.h
+++ b/donner/svg/compositor/CompositorController.h
@@ -413,6 +413,11 @@ public:
    */
   [[nodiscard]] bool isPromoted(Entity entity) const;
 
+  /// True when every requested entity is represented by one of the current request's interaction
+  /// layer roots, directly or through a DOM ancestor.
+  [[nodiscard]] bool interactionLayersCover(const std::vector<Entity>& interactionLayerRoots,
+                                            const std::vector<Entity>& entities) const;
+
   /**
    * Mark an already-promoted layer dirty so the next \ref renderFrame re-rasterizes it.
    *

--- a/donner/svg/compositor/CompositorController.h
+++ b/donner/svg/compositor/CompositorController.h
@@ -198,9 +198,12 @@ inline constexpr size_t kMaxCompositorMemoryBytes = 1024ull * 1024ull * 1024ull;
  * inside a live compositor.
  *
  * Default-constructed config has all features enabled. Mandatory hints
- * (opacity < 1, filter, mask, blend-mode, isolation) are always active - they
- * implement SVG semantics, not an optional optimization, and cannot be
- * disabled through config.
+ * (opacity < 1, filter, mask, blend-mode, isolation) are always detected and
+ * cannot be turned off entirely - but `mandatoryHintScope` can narrow which
+ * signals publish hints. Narrowing never changes pixels: an unhinted signal
+ * renders through the driver's inline isolation path (the same path entities
+ * under compositing-breaking ancestors already take); it only trades retained
+ * layer caching for per-frame re-render cost.
  */
 struct CompositorConfig {
   /// Editor-published `InteractionHint` hints promote the selected / dragged
@@ -212,6 +215,14 @@ struct CompositorConfig {
   /// cost stays O(animated subtree). When false, animations re-render the
   /// whole document per tick; selection / drag compositing is unaffected.
   bool autoPromoteAnimations = true;
+
+  /// Which mandatory-compositing signals `MandatoryHintDetector` publishes
+  /// hints for. `FilterOnly` is the editor's "filter-only" composited
+  /// rendering mode: filters (the expensive re-render case) keep their cached
+  /// isolated layers while opacity groups, blend modes, and masks render
+  /// inline every frame. Fixed at construction - changing it means
+  /// reconstructing the controller.
+  MandatoryHintScope mandatoryHintScope = MandatoryHintScope::All;
 
   /// `ComplexityBucketer` pre-splits the document into a small number of
   /// layers at load / structural rebuild to reduce click-to-first-drag-update

--- a/donner/svg/compositor/CompositorController.h
+++ b/donner/svg/compositor/CompositorController.h
@@ -321,8 +321,8 @@ public:
     enum class Code : uint8_t {
       /// The requested entity owns a promoted compositor layer.
       PromotedLayer,
-      /// The request is valid but must be presented as a full-canvas preview.
-      FullCanvasPreviewRequired,
+      /// The request is valid but cannot be extracted from its owning compositor tiles.
+      OwningTilesRequired,
       /// The requested entity is not valid in the document registry.
       InvalidEntity,
       /// The compositor cannot add another layer without exceeding the layer limit.
@@ -334,7 +334,7 @@ public:
     };
 
     static constexpr Code PromotedLayer = Code::PromotedLayer;
-    static constexpr Code FullCanvasPreviewRequired = Code::FullCanvasPreviewRequired;
+    static constexpr Code OwningTilesRequired = Code::OwningTilesRequired;
     static constexpr Code InvalidEntity = Code::InvalidEntity;
     static constexpr Code LayerLimit = Code::LayerLimit;
     static constexpr Code MemoryLimit = Code::MemoryLimit;
@@ -344,9 +344,7 @@ public:
     Code code = Code::PromotedLayer;
 
     [[nodiscard]] bool promotedLayer() const { return code == Code::PromotedLayer; }
-    [[nodiscard]] bool fullCanvasPreviewRequired() const {
-      return code == Code::FullCanvasPreviewRequired;
-    }
+    [[nodiscard]] bool owningTilesRequired() const { return code == Code::OwningTilesRequired; }
     [[nodiscard]] operator bool() const { return promotedLayer(); }
 
     friend bool operator==(PromoteResult result, Code code) { return result.code == code; }
@@ -390,9 +388,9 @@ public:
    * @param interactionKind Semantic kind for the Interaction hint. Use `Selection` for
    *   selection-driven pre-warm (no drag in progress) and `ActiveDrag` for an active
    *   user drag. Defaults to `ActiveDrag` for callers that only use this API during drag.
-   * @return Promotion result. Valid renderable descendants under a filter, clip-path, or mask
-   *   return \ref PromoteResult::FullCanvasPreviewRequired so callers can present a full-canvas
-   *   composited tile instead of treating the request as a hard failure.
+   * @return Promotion result. Valid renderable descendants under a compositing ancestor return
+   *   \ref PromoteResult::OwningTilesRequired so callers keep them inside the compositor's
+   *   existing paint-order tiles instead of treating the request as a hard failure.
    */
   PromoteResult promoteEntity(Entity entity,
                               InteractionHint interactionKind = InteractionHint::ActiveDrag);
@@ -1164,14 +1162,15 @@ private:
   /// `pendingDemotions_` and reuses the cached bitmap.
   void processPendingDemotions(Registry& registry);
 
-  /// Drop interaction hints for entities that no longer have a render instance.
+  /// Drop interaction hints for entities that can no longer own a safe independent layer.
   ///
-  /// Demotion hysteresis deliberately keeps released drag layers alive for a short
-  /// window, but an entity that just became `display:none` has left paint order.
-  /// Keeping its interaction layer as a static-segment boundary lets preserved
-  /// segment caches describe the wrong paint range. Returns true when the layer
-  /// assignment must be re-resolved and every static segment should be rebuilt.
-  bool dropNonRenderableInteractionHints(Registry& registry);
+  /// Demotion hysteresis deliberately keeps released drag layers alive for a short window, but an
+  /// entity that just became `display:none` has left paint order. A selected entity whose ancestor
+  /// just became an opacity/blend/filter/mask/isolation context must likewise rejoin that context
+  /// instead of remaining extracted. An interaction layer also cannot overlap a newly assigned
+  /// ancestor or descendant layer. Returns true when the layer assignment must be re-resolved and
+  /// every static segment should be rebuilt.
+  bool dropUnsafeInteractionHints(Registry& registry);
 
   /// Returns true when @p entity has a non-pending ActiveDrag interaction hint.
   bool isActiveDragTarget(Entity entity) const;

--- a/donner/svg/compositor/CompositorController_tests.cc
+++ b/donner/svg/compositor/CompositorController_tests.cc
@@ -241,7 +241,7 @@ TEST_F(CompositorControllerTest, PromoteInvalidEntityFails) {
   const auto result = compositor.promoteEntity(entt::null);
   EXPECT_EQ(result, CompositorController::PromoteResult::InvalidEntity);
   EXPECT_FALSE(result.promotedLayer());
-  EXPECT_FALSE(result.fullCanvasPreviewRequired());
+  EXPECT_FALSE(result.owningTilesRequired());
   EXPECT_EQ(compositor.layerCount(), 0u);
   EXPECT_FALSE(compositor.isPromoted(entt::null));
   EXPECT_TRUE(compositor.layerComposeOffset(entt::null).isIdentity());
@@ -920,9 +920,8 @@ TEST_F(CompositorControllerTest, FallbackReasonsOfUnpromotedEntity) {
   EXPECT_EQ(compositor.fallbackReasonsOf(entity), FallbackReason::None);
 }
 
-TEST_F(CompositorControllerTest,
-       PromoteDescendantUnderRawCompositingAncestorUsesFullCanvasPreview) {
-  const auto expectFullCanvasPreview = [this](std::string_view svg) {
+TEST_F(CompositorControllerTest, PromoteDescendantUnderRawCompositingAncestorUsesOwningTiles) {
+  const auto expectOwningTiles = [this](std::string_view svg) {
     SVGDocument document = makeDocument(svg);
     auto target = document.querySelector("#target");
     ASSERT_TRUE(target.has_value());
@@ -931,8 +930,8 @@ TEST_F(CompositorControllerTest,
     CompositorController compositor(document, renderer_);
     const auto result = compositor.promoteEntity(entity);
 
-    EXPECT_EQ(result, CompositorController::PromoteResult::FullCanvasPreviewRequired);
-    EXPECT_TRUE(result.fullCanvasPreviewRequired());
+    EXPECT_EQ(result, CompositorController::PromoteResult::OwningTilesRequired);
+    EXPECT_TRUE(result.owningTilesRequired());
     EXPECT_FALSE(result.promotedLayer());
     EXPECT_FALSE(compositor.isPromoted(entity));
     EXPECT_EQ(compositor.layerCount(), 0u);
@@ -940,7 +939,7 @@ TEST_F(CompositorControllerTest,
               CompositorController::PromoteRefusalReason::None);
   };
 
-  expectFullCanvasPreview(R"svg(
+  expectOwningTiles(R"svg(
     <defs>
       <filter id="blur"><feGaussianBlur stdDeviation="2" /></filter>
     </defs>
@@ -948,7 +947,7 @@ TEST_F(CompositorControllerTest,
       <rect id="target" width="10" height="10" fill="red" />
     </g>
   )svg");
-  expectFullCanvasPreview(R"svg(
+  expectOwningTiles(R"svg(
     <defs>
       <clipPath id="cp"><rect width="5" height="5" /></clipPath>
     </defs>
@@ -956,7 +955,7 @@ TEST_F(CompositorControllerTest,
       <rect id="target" width="10" height="10" fill="red" />
     </g>
   )svg");
-  expectFullCanvasPreview(R"svg(
+  expectOwningTiles(R"svg(
     <defs>
       <mask id="m"><rect width="10" height="10" fill="white" /></mask>
     </defs>
@@ -966,8 +965,7 @@ TEST_F(CompositorControllerTest,
   )svg");
 }
 
-TEST_F(CompositorControllerTest,
-       PromoteDescendantUnderPreparedIsolatedAncestorUsesFullCanvasPreview) {
+TEST_F(CompositorControllerTest, PromoteDescendantUnderPreparedIsolatedAncestorUsesOwningTiles) {
   SVGDocument document = makeDocument(R"svg(
     <g id="ancestor" opacity="0.5">
       <rect id="target" width="10" height="10" fill="red" />
@@ -984,8 +982,8 @@ TEST_F(CompositorControllerTest,
   CompositorController compositor(document, renderer_);
   const auto result = compositor.promoteEntity(entity);
 
-  EXPECT_EQ(result, CompositorController::PromoteResult::FullCanvasPreviewRequired);
-  EXPECT_TRUE(result.fullCanvasPreviewRequired());
+  EXPECT_EQ(result, CompositorController::PromoteResult::OwningTilesRequired);
+  EXPECT_TRUE(result.owningTilesRequired());
   EXPECT_FALSE(compositor.isPromoted(entity));
   EXPECT_EQ(compositor.layerCount(), 0u);
 }
@@ -1253,7 +1251,7 @@ TEST_F(CompositorControllerTest, TextureBackedStaticSegmentsExposeDimensionsWith
   EXPECT_EQ(inspectorSegmentIt->bitmapDims, Vector2i(32, 32));
 }
 
-TEST_F(CompositorControllerTest, PromotedGroupWithMandatoryChildDragReusesTextureFastPath) {
+TEST_F(CompositorControllerTest, MandatoryChildDisplacesOverlappingParentInteractionLayer) {
   SVGDocument document = makeDocument(R"svg(
     <g id="Blue_center_burst">
       <ellipse id="burst_child" cx="45" cy="30" rx="18" ry="21" fill="blue" opacity="0.75" />
@@ -1273,54 +1271,34 @@ TEST_F(CompositorControllerTest, PromotedGroupWithMandatoryChildDragReusesTextur
 
   compositor.renderFrame(RenderViewport{kTestSvgDefaultSize});
   const auto rowsAfterFirst = compositor.snapshotLayerInspectorRows();
-  ASSERT_GT(rowsAfterFirst.size(), 1u)
-      << "The opacity child should remain a mandatory promoted descendant layer.";
+  ASSERT_EQ(rowsAfterFirst.size(), 1u)
+      << "The mandatory child and selected parent must not remain as overlapping layers";
   const auto rowAfterFirst =
       std::find_if(rowsAfterFirst.begin(), rowsAfterFirst.end(),
                    [entity](const auto& row) { return row.entity == entity; });
   const auto childRowAfterFirst =
       std::find_if(rowsAfterFirst.begin(), rowsAfterFirst.end(),
                    [childEntity](const auto& row) { return row.entity == childEntity; });
-  ASSERT_NE(rowAfterFirst, rowsAfterFirst.end());
+  EXPECT_EQ(rowAfterFirst, rowsAfterFirst.end());
   ASSERT_NE(childRowAfterFirst, rowsAfterFirst.end());
-  ASSERT_TRUE(rowAfterFirst->hasValidBitmap);
   ASSERT_TRUE(childRowAfterFirst->hasValidBitmap);
-  const uint64_t generationAfterFirst = rowAfterFirst->generation;
-  const uint32_t rasterizeCountAfterFirst = rowAfterFirst->rasterizeCount;
   const uint64_t childGenerationAfterFirst = childRowAfterFirst->generation;
   const uint32_t childRasterizeCountAfterFirst = childRowAfterFirst->rasterizeCount;
+  EXPECT_FALSE(compositor.isPromoted(entity));
+  EXPECT_NE(compositor.findLayerForTest(childEntity), nullptr);
 
-  const auto countersBeforeDrag = compositor.fastPathCountersForTesting();
   target->cast<SVGGraphicsElement>().setTransform(Transform2d::Translate(7.0, 11.0));
   compositor.renderFrame(RenderViewport{kTestSvgDefaultSize});
 
   const auto rowsAfterDrag = compositor.snapshotLayerInspectorRows();
-  const auto rowAfterDrag =
-      std::find_if(rowsAfterDrag.begin(), rowsAfterDrag.end(),
-                   [entity](const auto& row) { return row.entity == entity; });
   const auto childRowAfterDrag =
       std::find_if(rowsAfterDrag.begin(), rowsAfterDrag.end(),
                    [childEntity](const auto& row) { return row.entity == childEntity; });
-  ASSERT_NE(rowAfterDrag, rowsAfterDrag.end());
   ASSERT_NE(childRowAfterDrag, rowsAfterDrag.end());
-  EXPECT_EQ(rowAfterDrag->generation, generationAfterFirst)
-      << "A translation-only drag of a promoted group with a mandatory child layer must reuse the "
-         "cached texture.";
-  EXPECT_EQ(rowAfterDrag->rasterizeCount, rasterizeCountAfterFirst)
-      << "Re-rasterizing this subtree on every drag frame is the #Blue_center_burst lag.";
-  EXPECT_EQ(childRowAfterDrag->generation, childGenerationAfterFirst);
+  EXPECT_EQ(childRowAfterDrag->generation, childGenerationAfterFirst)
+      << "Dropping the overlapping parent layer must not throw away the mandatory child's cached "
+         "texture during a parent translation";
   EXPECT_EQ(childRowAfterDrag->rasterizeCount, childRasterizeCountAfterFirst);
-
-  const auto countersAfterDrag = compositor.fastPathCountersForTesting();
-  EXPECT_EQ(countersAfterDrag.fastPathFrames, countersBeforeDrag.fastPathFrames + 1u);
-  EXPECT_EQ(countersAfterDrag.slowPathFramesWithDirty, countersBeforeDrag.slowPathFramesWithDirty);
-
-  const auto* layer = compositor.findLayerForTest(entity);
-  ASSERT_NE(layer, nullptr);
-  ASSERT_TRUE(layer->canvasFromBitmap().isTranslation());
-  EXPECT_NEAR(layer->canvasFromBitmap().translation().x, 7.0, 1e-10);
-  EXPECT_NEAR(layer->canvasFromBitmap().translation().y, 11.0, 1e-10);
-
   const auto* childLayer = compositor.findLayerForTest(childEntity);
   ASSERT_NE(childLayer, nullptr);
   ASSERT_TRUE(childLayer->canvasFromBitmap().isTranslation());

--- a/donner/svg/compositor/CompositorGolden_tests.cc
+++ b/donner/svg/compositor/CompositorGolden_tests.cc
@@ -3715,7 +3715,7 @@ TEST_F(CompositorGoldenTest, FilteredGroupWithChildrenRasterizesIncludingChildre
   EXPECT_LE(result.mismatchCount, result.totalPixels / 20u) << result;  // 5% AA tolerance
 }
 
-TEST_F(CompositorGoldenTest, ChildOfFilteredGroupRequiresFullCanvasPreview) {
+TEST_F(CompositorGoldenTest, ChildOfFilteredGroupRequiresOwningTiles) {
   SVGDocument document = parseDocument(R"svg(
     <svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
       <defs>
@@ -3735,12 +3735,12 @@ TEST_F(CompositorGoldenTest, ChildOfFilteredGroupRequiresFullCanvasPreview) {
 
   CompositorController compositor(document, renderer_);
   EXPECT_EQ(compositor.promoteEntity(target->unsafeEntityHandle().entity()),
-            CompositorController::PromoteResult::FullCanvasPreviewRequired);
+            CompositorController::PromoteResult::OwningTilesRequired);
   EXPECT_FALSE(compositor.isPromoted(target->unsafeEntityHandle().entity()));
   EXPECT_EQ(compositor.layerCount(), 0u);
 }
 
-TEST_F(CompositorGoldenTest, ChildOfClippedGroupRequiresFullCanvasPreview) {
+TEST_F(CompositorGoldenTest, ChildOfClippedGroupRequiresOwningTiles) {
   SVGDocument document = parseDocument(R"svg(
     <svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
       <defs>
@@ -3760,10 +3760,10 @@ TEST_F(CompositorGoldenTest, ChildOfClippedGroupRequiresFullCanvasPreview) {
 
   CompositorController compositor(document, renderer_);
   EXPECT_EQ(compositor.promoteEntity(target->unsafeEntityHandle().entity()),
-            CompositorController::PromoteResult::FullCanvasPreviewRequired);
+            CompositorController::PromoteResult::OwningTilesRequired);
 }
 
-TEST_F(CompositorGoldenTest, ChildOfMaskedGroupRequiresFullCanvasPreview) {
+TEST_F(CompositorGoldenTest, ChildOfMaskedGroupRequiresOwningTiles) {
   SVGDocument document = parseDocument(R"svg(
     <svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
       <defs>
@@ -3783,7 +3783,7 @@ TEST_F(CompositorGoldenTest, ChildOfMaskedGroupRequiresFullCanvasPreview) {
 
   CompositorController compositor(document, renderer_);
   EXPECT_EQ(compositor.promoteEntity(target->unsafeEntityHandle().entity()),
-            CompositorController::PromoteResult::FullCanvasPreviewRequired);
+            CompositorController::PromoteResult::OwningTilesRequired);
 }
 
 // Positive: a plain descendant (no compositing ancestor) still promotes.

--- a/donner/svg/compositor/LayerResolver.cc
+++ b/donner/svg/compositor/LayerResolver.cc
@@ -30,7 +30,8 @@ void LayerResolver::resolve(Registry& registry, uint32_t maxLayers, const Resolv
     std::vector<Entity> stale;
     auto assignmentView = registry.view<ComputedLayerAssignmentComponent>();
     for (auto entity : assignmentView) {
-      if (!registry.all_of<CompositorHintComponent>(entity)) {
+      const auto* hints = registry.try_get<CompositorHintComponent>(entity);
+      if (hints == nullptr || hints->empty()) {
         stale.push_back(entity);
       }
     }

--- a/donner/svg/compositor/LayerResolver_tests.cc
+++ b/donner/svg/compositor/LayerResolver_tests.cc
@@ -214,6 +214,19 @@ TEST_F(LayerResolverTest, ReResolveAfterHintDropClearsAssignment) {
   EXPECT_EQ(resolver_.stats().layersAssigned, 1u);
 }
 
+TEST_F(LayerResolverTest, EmptyHintComponentClearsStaleAssignment) {
+  const Entity entity = registry_.create();
+  registry_.emplace<CompositorHintComponent>(entity);
+  registry_.emplace<ComputedLayerAssignmentComponent>(entity, ComputedLayerAssignmentComponent{1u});
+
+  resolver_.resolve(registry_, kDefaultBudget);
+
+  EXPECT_FALSE(hasAssignment(entity))
+      << "An empty retained hint component must not keep a stale promoted layer alive";
+  EXPECT_EQ(resolver_.stats().candidatesEvaluated, 0u);
+  EXPECT_EQ(resolver_.stats().layersAssigned, 0u);
+}
+
 TEST_F(LayerResolverTest, WriteOnlyOnDiffAvoidsChurn) {
   const Entity e = registry_.create();
   ScopedCompositorHint hint = ScopedCompositorHint::Explicit(registry_, e, 0x4000);

--- a/donner/svg/compositor/MandatoryHintDetector.cc
+++ b/donner/svg/compositor/MandatoryHintDetector.cc
@@ -24,13 +24,21 @@ bool MandatoryHintDetector::qualifies(const components::RenderingInstanceCompone
 
 namespace {
 
-/// Returns true if any ancestor of @p entity carries a clip-path, mask, or
-/// filter on its `RenderingInstanceComponent`. Such an ancestor wraps a
-/// compositing context that would be broken if a descendant were extracted
-/// into its own cached layer - the clip/mask/filter context is applied by the
-/// main tree walk, not replayed when the extracted layer bitmap is composited
-/// back. Returning true is a signal to NOT auto-promote.
-bool HasCompositingBreakingAncestor(Registry& registry, Entity entity) {
+/// Returns true if any ancestor of @p entity carries a compositing context
+/// that would be broken if the descendant were extracted into its own cached
+/// layer - the ancestor's context is applied by the main tree walk, not
+/// replayed when the extracted layer bitmap is composited back. Returning
+/// true is a signal to NOT auto-promote.
+///
+/// Under `All`, clip-path / mask / filter ancestors qualify; an isolation
+/// ancestor (opacity < 1, blend mode) does not need to, because it is itself
+/// promoted. Under `FilterOnly`, isolation ancestors stay INLINE (their
+/// signal is out of scope), so extracting a descendant filter would split
+/// the group: trailing in-group content would land in a segment slice that
+/// re-enters the group at full alpha, and the tile blit resets paint before
+/// composing. Treat unhinted isolation ancestors as breaking too; the nested
+/// filter then renders fully inline - pixel-correct, merely uncached.
+bool HasCompositingBreakingAncestor(Registry& registry, Entity entity, MandatoryHintScope scope) {
   const auto* tree = registry.try_get<donner::components::TreeComponent>(entity);
   if (tree == nullptr) {
     return false;
@@ -41,6 +49,9 @@ bool HasCompositingBreakingAncestor(Registry& registry, Entity entity) {
             registry.try_get<components::RenderingInstanceComponent>(cursor)) {
       if (ancestorInstance->clipPath.has_value() || ancestorInstance->mask.has_value() ||
           ancestorInstance->resolvedFilter.has_value()) {
+        return true;
+      }
+      if (scope == MandatoryHintScope::FilterOnly && ancestorInstance->isolatedLayer) {
         return true;
       }
     }
@@ -71,7 +82,7 @@ void MandatoryHintDetector::reconcile(Registry& registry) {
     // lost by extracting the subtree into its own cached layer. Such entities
     // fall through to the driver's inline `pushClip` / `pushMask` /
     // `pushFilterLayer` path, which handles the context correctly.
-    if (HasCompositingBreakingAncestor(registry, entity)) {
+    if (HasCompositingBreakingAncestor(registry, entity, scope_)) {
       continue;
     }
     qualifying.insert(entity);

--- a/donner/svg/compositor/MandatoryHintDetector.cc
+++ b/donner/svg/compositor/MandatoryHintDetector.cc
@@ -8,11 +8,17 @@
 
 namespace donner::svg::compositor {
 
-bool MandatoryHintDetector::qualifies(const components::RenderingInstanceComponent& instance) {
+bool MandatoryHintDetector::qualifies(const components::RenderingInstanceComponent& instance,
+                                      MandatoryHintScope scope) {
   // Three signals force isolated compositing:
   //   - isolatedLayer: subsumes opacity < 1, mix-blend-mode != normal, isolation: isolate
   //   - resolvedFilter.has_value(): `filter` applied
   //   - mask.has_value(): `mask` applied
+  // FilterOnly narrows to the filter signal; the others render through the
+  // driver's inline isolation path instead of a retained layer.
+  if (scope == MandatoryHintScope::FilterOnly) {
+    return instance.resolvedFilter.has_value();
+  }
   return instance.isolatedLayer || instance.resolvedFilter.has_value() || instance.mask.has_value();
 }
 
@@ -58,7 +64,7 @@ void MandatoryHintDetector::reconcile(Registry& registry) {
   for (auto entity : view) {
     ++stats_.candidatesEvaluated;
     const auto& instance = view.get<components::RenderingInstanceComponent>(entity);
-    if (!qualifies(instance)) {
+    if (!qualifies(instance, scope_)) {
       continue;
     }
     // Don't auto-promote if an ancestor's clip-path / mask / filter would be

--- a/donner/svg/compositor/MandatoryHintDetector.h
+++ b/donner/svg/compositor/MandatoryHintDetector.h
@@ -28,6 +28,9 @@ enum class MandatoryHintScope : uint8_t {
   All,
   /// Publish hints only for `resolvedFilter.has_value()`. Filters dominate
   /// re-render cost; opacity groups, blend modes, and masks render inline.
+  /// A filter nested under an inline isolation ancestor is NOT promoted
+  /// either (extracting it would split the ancestor's isolation group); it
+  /// renders fully inline instead.
   FilterOnly,
 };
 

--- a/donner/svg/compositor/MandatoryHintDetector.h
+++ b/donner/svg/compositor/MandatoryHintDetector.h
@@ -14,6 +14,24 @@ struct RenderingInstanceComponent;
 namespace donner::svg::compositor {
 
 /**
+ * Which mandatory-compositing signals `MandatoryHintDetector` acts on.
+ *
+ * Every signal is handled correctly by the renderer driver's inline
+ * `pushClip` / `pushMask` / `pushFilterLayer` path when no hint is published
+ * (that inline path is what entities under compositing-breaking ancestors
+ * already use), so narrowing the scope trades retained-layer caching for
+ * per-frame re-render cost without changing pixels.
+ */
+enum class MandatoryHintScope : uint8_t {
+  /// Publish hints for every signal: `isolatedLayer` (opacity < 1,
+  /// mix-blend-mode, isolation: isolate), filter, and mask.
+  All,
+  /// Publish hints only for `resolvedFilter.has_value()`. Filters dominate
+  /// re-render cost; opacity groups, blend modes, and masks render inline.
+  FilterOnly,
+};
+
+/**
  * Stats produced by `MandatoryHintDetector::reconcile()`. Tests inspect these to
  * verify that the detector published / dropped the right number of hints on a
  * given pass.
@@ -36,12 +54,15 @@ struct MandatoryHintDetectorStats {
  * Subsystem that publishes `Mandatory` `CompositorHint` entries for SVG
  * features that force isolated compositing.
  *
- * A `RenderingInstanceComponent` qualifies for a mandatory hint when any of the
- * following is true:
+ * Under `MandatoryHintScope::All` (the default), a `RenderingInstanceComponent`
+ * qualifies for a mandatory hint when any of the following is true:
  *   - `isolatedLayer == true` (covers `opacity < 1`, `mix-blend-mode`,
  *     `isolation: isolate`).
  *   - `resolvedFilter.has_value()` (SVG `filter`).
  *   - `mask.has_value()` (SVG `mask`).
+ *
+ * Under `MandatoryHintScope::FilterOnly`, only the filter signal qualifies;
+ * the other signals render through the driver's inline isolation path.
  *
  * Other fallback-inducing features (`clipPath`, markers, external paint
  * servers) intentionally do NOT force a mandatory promotion - that's the
@@ -57,8 +78,11 @@ struct MandatoryHintDetectorStats {
  */
 class MandatoryHintDetector {
 public:
-  /// Default constructor.
+  /// Default constructor. Acts on every mandatory signal (`MandatoryHintScope::All`).
   MandatoryHintDetector() = default;
+
+  /// Construct with an explicit signal scope. See `MandatoryHintScope`.
+  explicit MandatoryHintDetector(MandatoryHintScope scope) : scope_(scope) {}
 
   /// Destructor. Drops all outstanding hints via `ScopedCompositorHint` RAII.
   ~MandatoryHintDetector() = default;
@@ -122,9 +146,14 @@ public:
   [[nodiscard]] const MandatoryHintDetectorStats& stats() const { return stats_; }
 
 private:
-  /// Returns true if the given rendering instance exhibits any of the three
-  /// mandatory-compositing signals.
-  [[nodiscard]] static bool qualifies(const components::RenderingInstanceComponent& instance);
+  /// Returns true if the given rendering instance exhibits a
+  /// mandatory-compositing signal covered by @p scope.
+  [[nodiscard]] static bool qualifies(const components::RenderingInstanceComponent& instance,
+                                      MandatoryHintScope scope);
+
+  /// Which signals publish hints. Fixed at construction; a consumer that
+  /// changes scope reconstructs its compositor.
+  MandatoryHintScope scope_ = MandatoryHintScope::All;
 
   /// One scoped `Mandatory` hint per currently-qualifying entity.
   std::unordered_map<Entity, ScopedCompositorHint> hints_;

--- a/donner/svg/compositor/MandatoryHintDetector_tests.cc
+++ b/donner/svg/compositor/MandatoryHintDetector_tests.cc
@@ -177,6 +177,45 @@ TEST(MandatoryHintDetectorTest, MaskQualifies) {
               testing::ElementsAre(HintEntryIs(HintSource::Mandatory, 0xFFFF)));
 }
 
+TEST(MandatoryHintDetectorTest, FilterOnlyScopePublishesForFilterSignal) {
+  Registry registry;
+  MandatoryHintDetector detector(MandatoryHintScope::FilterOnly);
+
+  const Entity entity = registry.create();
+  auto& instance = registry.emplace<RenderingInstanceComponent>(entity);
+  instance.resolvedFilter.emplace(std::vector<FilterEffect>{});
+
+  detector.reconcile(registry);
+
+  EXPECT_EQ(detector.stats().hintsPublished, 1u);
+  EXPECT_EQ(detector.stats().hintsActive, 1u);
+  ASSERT_TRUE(registry.all_of<CompositorHintComponent>(entity));
+  EXPECT_THAT(registry.get<CompositorHintComponent>(entity).entries,
+              testing::ElementsAre(HintEntryIs(HintSource::Mandatory, 0xFFFF)));
+}
+
+TEST(MandatoryHintDetectorTest, FilterOnlyScopeIgnoresIsolationAndMaskSignals) {
+  Registry registry;
+  MandatoryHintDetector detector(MandatoryHintScope::FilterOnly);
+
+  const Entity isolated = registry.create();
+  registry.emplace<RenderingInstanceComponent>(isolated).isolatedLayer = true;
+
+  const Entity masked = registry.create();
+  registry.emplace<RenderingInstanceComponent>(masked).mask = components::ResolvedMask{
+      ResolvedReference{EntityHandle()}, std::nullopt, MaskContentUnits::Default};
+
+  detector.reconcile(registry);
+
+  EXPECT_EQ(detector.stats().candidatesEvaluated, 2u);
+  EXPECT_EQ(detector.stats().hintsPublished, 0u)
+      << "FilterOnly scope must leave opacity/blend isolation and masks to the driver's inline "
+         "isolation path";
+  EXPECT_EQ(detector.stats().hintsActive, 0u);
+  EXPECT_FALSE(registry.all_of<CompositorHintComponent>(isolated));
+  EXPECT_FALSE(registry.all_of<CompositorHintComponent>(masked));
+}
+
 TEST(MandatoryHintDetectorTest, ReconcileIsIdempotent) {
   Registry registry;
   MandatoryHintDetector detector;

--- a/donner/svg/compositor/MandatoryHintDetector_tests.cc
+++ b/donner/svg/compositor/MandatoryHintDetector_tests.cc
@@ -216,6 +216,35 @@ TEST(MandatoryHintDetectorTest, FilterOnlyScopeIgnoresIsolationAndMaskSignals) {
   EXPECT_FALSE(registry.all_of<CompositorHintComponent>(masked));
 }
 
+TEST(MandatoryHintDetectorTest, FilterOnlyScopeSkipsFilterUnderInlineIsolationAncestor) {
+  // `<g opacity="0.5"> <rect filter="..."/> </g>` under FilterOnly: the group
+  // stays inline (isolation is out of scope), so promoting the child filter
+  // would split the group's isolation - trailing in-group content re-enters
+  // at full alpha and the tile blit resets paint. The child must render
+  // inline instead.
+  Registry registry;
+  MandatoryHintDetector detector(MandatoryHintScope::FilterOnly);
+
+  const Entity group = makeTreeEntity(registry, entt::null);
+  registry.emplace<RenderingInstanceComponent>(group).isolatedLayer = true;
+
+  const Entity filtered = makeTreeEntity(registry, group);
+  registry.emplace<RenderingInstanceComponent>(filtered).resolvedFilter.emplace(
+      std::vector<FilterEffect>{});
+
+  detector.reconcile(registry);
+
+  EXPECT_EQ(detector.stats().hintsPublished, 0u)
+      << "A filter under an inline isolation ancestor must not be extracted in FilterOnly scope";
+  EXPECT_FALSE(registry.all_of<CompositorHintComponent>(filtered));
+
+  // The same topology under the default All scope promotes (the ancestor is
+  // itself promoted, so the group's isolation is not broken by extraction).
+  MandatoryHintDetector allScopeDetector;
+  allScopeDetector.reconcile(registry);
+  EXPECT_TRUE(registry.all_of<CompositorHintComponent>(filtered));
+}
+
 TEST(MandatoryHintDetectorTest, ReconcileIsIdempotent) {
   Registry registry;
   MandatoryHintDetector detector;

--- a/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
+++ b/tools/mcp-servers/editor-control/EditorControlSession_tests.cc
@@ -1,5 +1,6 @@
 #include "tools/mcp-servers/editor-control/EditorControlSession.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <cstdlib>
 #include <filesystem>
@@ -637,7 +638,7 @@ TEST(EditorControlSessionTest, InvalidSvgSourceEditKeepsDraftAndStalePreview) {
   EXPECT_FALSE(fixed.body["source"].value("preview_stale", true));
 }
 
-TEST(EditorControlSessionTest, PreDragRenderUsesFullCanvasCompositedTile) {
+TEST(EditorControlSessionTest, PreDragRenderUsesLayeredCompositedTiles) {
   EditorControlSession session;
 
   ToolCallResult load =
@@ -651,17 +652,21 @@ TEST(EditorControlSessionTest, PreDragRenderUsesFullCanvasCompositedTile) {
 
   const json& stage = load.body["render_stages"].back();
   ASSERT_FALSE(stage["composited_preview"].is_null());
-  EXPECT_EQ(stage["composited_preview"].value("tile_count", 0), 1);
-  ASSERT_EQ(stage["composited_preview"]["tiles"].size(), 1u);
-  EXPECT_EQ(stage["composited_preview"]["tiles"][0].value("kind", ""), "segment");
-  EXPECT_EQ(stage["composited_preview"]["tiles"][0].value("id", ""), "full-canvas");
+  EXPECT_EQ(stage["composited_preview"].value("tile_count", 0), 3);
+  ASSERT_EQ(stage["composited_preview"]["tiles"].size(), 3u);
+  EXPECT_TRUE(std::ranges::any_of(stage["composited_preview"]["tiles"], [](const json& tile) {
+    return tile.value("kind", "") == "layer";
+  }));
+  EXPECT_FALSE(std::ranges::any_of(stage["composited_preview"]["tiles"], [](const json& tile) {
+    return tile.value("id", "") == "full-canvas";
+  }));
 
   const json& display = stage["display_preview"];
   EXPECT_EQ(display.value("path", ""), "tiles");
-  EXPECT_EQ(display.value("tile_count", 0), 1);
-  ASSERT_EQ(display["tiles"].size(), 1u);
-  EXPECT_EQ(display["tiles"][0].value("kind", ""), "segment");
-  EXPECT_EQ(display["tiles"][0].value("id", ""), "full-canvas");
+  EXPECT_EQ(display.value("tile_count", 0), 3);
+  ASSERT_EQ(display["tiles"].size(), 3u);
+  EXPECT_FALSE(std::ranges::any_of(
+      display["tiles"], [](const json& tile) { return tile.value("id", "") == "full-canvas"; }));
 }
 
 TEST(EditorControlSessionTest, SelectsBySelectorAndDragsThroughCompositedPreview) {


### PR DESCRIPTION
Adds a View menu "Composited Rendering" setting with three runtime modes, while preserving the editor's paint-order layer presentation in every non-Off mode.

## Modes

| Mode | Behavior |
| --- | --- |
| On (default) | Full compositing. Mandatory isolation, editor selection/drag layers, animation promotion, and complexity bucketing are enabled. |
| Filters Only | Only SVG filters retain automatic content-isolation layers. Opacity groups, blend modes, and masks render inline; editor selection/drag layers remain active; animation promotion and complexity bucketing are disabled. |
| Off | No `CompositorController` is constructed. Each frame renders directly and is presented as the explicit `full-canvas` diagnostic path. |

All three modes produce identical final pixels. They trade retained caching and layer maintenance against per-frame rendering work.

## Active presentation contract

Normal active presentation in On and Filters Only always publishes the compositor's paint-order tiles. It never falls through to `full-canvas` because the editor is idle, a selection is not being dragged, the first-frame cache is cold, or an interaction split is unsafe.

- A cheap selected scene presents background, selected, and foreground as three immediate-classified layers.
- Filters Only publishes the splash's three blurred glow groups as separate filter layers.
- Selection and drag layers remain structural editor behavior in both non-Off modes.
- Overview infill is an out-of-band low-resolution coverage cache. Geometry debug is a separate explicit flat diagnostic named `geometry-debug-flat`.

## Promotion safety

`PromoteResult::OwningTilesRequired` replaces the old full-canvas fallback contract. If extracting a requested selection would split an ancestor compositing context or overlap an assigned ancestor or descendant, the entity remains inside the paint-order tiles that own it.

Detector and interaction reconciliation now run against the prepared render tree. This covers cold requests, filter additions, `display:none`, opacity/isolation changes, structural remaps, and stale empty hint components in the same accepted frame.

`CompositedPreview::entity` names a genuinely movable promoted tile only. Off, owning-tile refusal, and partially covered nested multi-selection publish a null movable entity, so the scheduler requests rendered drag frames instead of moving chrome over stationary pixels. Nested parent/child selection is overlap-safe in both ordering directions.

## Verification

- Full repository gate: 342 passed, 117 intentional skips, 0 failures.
- Uncached native and Geode async-renderer/compositor suites.
- Editor presentation scheduler and editor-control MCP session suites.
- Editor Wasm transition and package-size gates.
- Hermetic Chromium remote smoke test.
- Repository lint, changed-line clang-format, and diff checks.
- Independent code review and public privacy review passed on the final candidate.
